### PR TITLE
fix: fix default number of testruns from 2 to 25.

### DIFF
--- a/pkg/platform/mgo/rdb.go
+++ b/pkg/platform/mgo/rdb.go
@@ -86,14 +86,7 @@ func (r *RunDB) PutTest(ctx context.Context, t run.Test) error {
 	return nil
 }
 
-func (r *RunDB) Read(ctx context.Context, cid string, user, app, id *string, from, to *time.Time, offset *int, limit *int) ([]*run.TestRun, error) {
-	off, lim := 0, 2
-	if offset != nil {
-		off = *offset
-	}
-	if limit != nil {
-		lim = *limit
-	}
+func (r *RunDB) Read(ctx context.Context, cid string, user, app, id *string, from, to *time.Time, offset int, limit int) ([]*run.TestRun, error) {
 	filter := bson.M{
 		"cid": cid,
 	}
@@ -119,13 +112,9 @@ func (r *RunDB) Read(ctx context.Context, cid string, user, app, id *string, fro
 	var tcs []*run.TestRun
 	opt := options.Find()
 
-	if off < 0 {
-		off = 0
-	}
-
 	opt.SetSort(bson.M{"created": -1}) //for descending order
-	opt.SetSkip(int64(off))
-	opt.SetLimit(int64(lim))
+	opt.SetSkip(int64(offset))
+	opt.SetLimit(int64(limit))
 
 	cur, err := r.c.Find(ctx, filter, opt)
 	if err != nil {

--- a/pkg/service/run/run.go
+++ b/pkg/service/run/run.go
@@ -44,7 +44,14 @@ func (r *Run) Normalize(ctx context.Context, cid, id string) error {
 }
 
 func (r *Run) Get(ctx context.Context, summary bool, cid string, user, app, id *string, from, to *time.Time, offset *int, limit *int) ([]*TestRun, error) {
-	res, err := r.rdb.Read(ctx, cid, user, app, id, from, to, offset, limit)
+	off, lim := 0, 25
+	if offset != nil {
+		off = *offset
+	}
+	if limit != nil {
+		lim = *limit
+	}
+	res, err := r.rdb.Read(ctx, cid, user, app, id, from, to, off, lim)
 	if err != nil {
 		r.log.Error("failed to read test runs from DB", zap.String("cid", cid), zap.Any("user", user), zap.Any("app", app), zap.Any("id", id), zap.Any("from", from), zap.Any("to", to), zap.Error(err))
 		return nil, errors.New("failed getting test runs")

--- a/pkg/service/run/service.go
+++ b/pkg/service/run/service.go
@@ -14,7 +14,7 @@ type Service interface {
 }
 
 type DB interface {
-	Read(ctx context.Context, cid string, user, app, id *string, from, to *time.Time, offset *int, limit *int) ([]*TestRun, error)
+	Read(ctx context.Context, cid string, user, app, id *string, from, to *time.Time, offset int, limit int) ([]*TestRun, error)
 	Upsert(ctx context.Context, run TestRun) error
 	ReadTest(ctx context.Context, id string) (Test, error)
 	ReadTests(ctx context.Context, runID string) ([]Test, error)


### PR DESCRIPTION
Also move the default checking code to service controller

fixes #9