### PR TITLE
build(docker-compose): use prebuilt docker images for keploy

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   web:
-    build: .
+    image: ghcr.io/keploy/keploy
     ports:
       - "8081:8081"
     environment:


### PR DESCRIPTION
building images for regular users can be time consuming and also requires atleast 12GB+ memory to build. Prebuilt docker images makes the experience faster and more approachable.