### PR TITLE
build(ci): enable secret actions for fork PRs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,8 +3,10 @@ name: Go
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
+#   pull_request:
+#     branches: [ main ]
+  pull_request_target:
+    types: [assigned, opened, synchronize, reopened]
 
 jobs:
 


### PR DESCRIPTION
replaced `pull_request` with `pull_request_target` to ensure that github actions secret can be accessed for PRs. This is important to run keploy for testing during CI.