### PR TITLE
docs(readme): add command to get the latest keploy image

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The UI can be accessed at http://localhost:8081
 
 ### Keeping keploy up-to-date
 ```shell
-docker pull ghcr.io/keploy/keploy:latest
+docker-compose pull
 ```
 
 ### Integrate the SDK

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ docker-compose up
 ```
 The UI can be accessed at http://localhost:8081
 
+### Keeping keploy up-to-date
+```shell
+docker pull ghcr.io/keploy/keploy:latest
+```
+
 ### Integrate the SDK
 Install the [Go SDK](https://github.com/keploy/go-sdk) with
 ```shell


### PR DESCRIPTION
- Fixes #57 
- Added docker pull command to get the latest keploy image