### PR TITLE
ci: add commit linting and automatic release

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,0 +1,5 @@
+[tool]
+[tool.commitizen]
+name = "cz_conventional_commits"
+version = "0.2.4"
+tag_format = "v$version"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,8 @@
 name: Go
 
 on:
-#  push:
-#    branches: [ main ]
-  pull_request:
+  push:
     branches: [ main ]
-#   pull_request_target:
-#     types: [assigned, opened, synchronize, reopened]
 
 jobs:
 
@@ -36,9 +32,9 @@ jobs:
           KEPLOY_API_KEY: 81f83aeeedddf453966347dc136c66
           KEPLOY_ENABLE_DEDUP: true
 
-#       - uses: codecov/codecov-action@v2
-#         with:
-#           files: ./coverage.txt
+      #       - uses: codecov/codecov-action@v2
+      #         with:
+      #           files: ./coverage.txt
       - name: Install goveralls
         run: go install github.com/mattn/goveralls@latest
       - name: Send coverage
@@ -46,3 +42,6 @@ jobs:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: goveralls -coverprofile=coverage.txt -service=github
 
+      - uses: codfish/semantic-release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+- hooks:
+  - id: commitizen
+    stages:
+    - commit-msg
+  repo: https://github.com/commitizen-tools/commitizen
+  rev: v2.21.2

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,13 @@
+{
+  "branches": ["main"],
+  "repositoryUrl": "git@github.com:keploy/keploy.git",
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/github",
+    ["@semantic-release/exec", {
+      "prepareCmd" : "set-version ${nextRelease.version}",
+      "publishCmd" : "publish-package"
+    }]
+  ]
+}


### PR DESCRIPTION
Although we are using conventional commits, there are situations when the commit messages can have unwanted spaces. These spaces can be problematic for automatic releaser like `semantic releaser` - which is also added in this commit.
