### PR TITLE
ci: fix failure in the automatic releaser

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,11 +45,13 @@ jobs:
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: goveralls -coverprofile=coverage.txt -service=github
+
+      - name: Install extra dependencies
+        run: npm install -g @semantic-release/exec
+
       - uses: codfish/semantic-release-action@v1
         with:
           dry_run: true
-          additional_packages: |
-            ['@semantic-release/exec']
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,12 +46,14 @@ jobs:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: goveralls -coverprofile=coverage.txt -service=github
 
-      - name: Install extra dependencies
-        run: npm install -g @semantic-release/exec
+#      - name: Install extra dependencies
+#        run: npm install -g @semantic-release/exec
 
-      - uses: codfish/semantic-release-action@v1
+      - uses: codfish/semantic-release-action@additional-packages
         with:
           dry_run: true
+          additional_packages: |
+            ['@semantic-release/exec']
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,4 +45,11 @@ jobs:
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: goveralls -coverprofile=coverage.txt -service=github
+      - uses: codfish/semantic-release-action@v1
+        with:
+          dry_run: true
+          additional_packages: |
+            ['@semantic-release/exec']
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,5 +43,8 @@ jobs:
         run: goveralls -coverprofile=coverage.txt -service=github
 
       - uses: codfish/semantic-release-action@v1
+        with:
+          additional_packages: |
+              ['@semantic-release/exec']
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,11 @@ jobs:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: goveralls -coverprofile=coverage.txt -service=github
 
-      - name: Install extra dependencies
-        run: npm install -g @semantic-release/exec
-      - uses: codfish/semantic-release-action@v1
+#      - name: Install extra dependencies
+#        run: npm install -g @semantic-release/exec
+      - uses: codfish/semantic-release-action@additional-packages
+        with:
+          additional_packages: |
+            ['@semantic-release/exec']
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,9 +42,8 @@ jobs:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: goveralls -coverprofile=coverage.txt -service=github
 
+      - name: Install extra dependencies
+        run: npm install -g @semantic-release/exec
       - uses: codfish/semantic-release-action@v1
-        with:
-          additional_packages: |
-              ['@semantic-release/exec']
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
the `codfish/semantic-release-action` was failing because the `semantic-release/exec` wasn't
installed. So we are fixing this by adding the `additional_packages` in the actions to install it.
