### PR TITLE
fix(logging): Escape logged user input for security

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <td align="center"><a href="https://github.com/namantaneja167"><img src="https://avatars.githubusercontent.com/u/42579074?v=4" width="100px;" alt=""/><br /><sub><b>Naman Taneja</b></sub></a><br /><a href="#contributer-namantaneja167" title="Contributer">🚧</a></td>
 <td align="center"><a href="https://github.com/rajatsharma"><img src="https://avatars.githubusercontent.com/u/13231434?v=4" width="100px;" alt=""/><br /><sub><b>Rajat Sharma</b></sub></a><br /><a href="#contributer-rajatsharma" title="Contributer">🚧</a></td>
 <td align="center"><a href="https://github.com/Akshit42-hue"><img src="https://avatars.githubusercontent.com/u/59443454?v=4" width="100px;" alt=""/><br /><sub><b>Axit Patel</b></sub></a><br /><a href="#contributer-Akshit42-hue" title="Contributer">🚧</a></td>
+<td align="center"><a href="https://github.com/ditsuke"><img src="https://avatars.githubusercontent.com/u/72784348?v=4" width="100px;" alt=""/><br /><sub><b>Tushar Malik</b></sub></a><br /><a href="#contributer-ditsuke" title="Contributer">🚧</a></td>
 
 </tr>
 </table>

--- a/pkg/service/regression/regression.go
+++ b/pkg/service/regression/regression.go
@@ -83,6 +83,9 @@ func (r *Regression) GetApps(ctx context.Context, cid string) ([]string, error) 
 	return r.tdb.GetApps(ctx, cid)
 }
 
+// sanitiseInput sanitises user input strings before logging them for safety, removing newlines
+// and escaping HTML tags. This is to prevent log injection, including forgery of log records.
+// Reference: https://www.owasp.org/index.php/Log_Injection
 func sanitiseInput(s string) string {
 	re := regexp.MustCompile(`(\n|\n\r|\r\n|\r)`)
 	return html.EscapeString(string(re.ReplaceAll([]byte(s), []byte(""))))

--- a/pkg/service/regression/regression.go
+++ b/pkg/service/regression/regression.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"net/http"
 	"reflect"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -81,11 +83,16 @@ func (r *Regression) GetApps(ctx context.Context, cid string) ([]string, error) 
 	return r.tdb.GetApps(ctx, cid)
 }
 
-func (r *Regression) Get(ctx context.Context, cid, appID, id string) (models.TestCase, error) {
+func sanitiseInput(s string) string {
+	re := regexp.MustCompile(`(\n|\n\r|\r\n|\r)`)
+	return html.EscapeString(string(re.ReplaceAll([]byte(s), []byte(" "))))
+}
 
+func (r *Regression) Get(ctx context.Context, cid, appID, id string) (models.TestCase, error) {
 	tcs, err := r.tdb.Get(ctx, cid, id)
 	if err != nil {
-		r.log.Error("failed to get testcases from the DB", zap.String("cid", cid), zap.String("appID", appID), zap.Error(err))
+		sanitizedAppID := sanitiseInput(appID)
+		r.log.Error("failed to get testcases from the DB", zap.String("cid", cid), zap.String("appID", sanitizedAppID), zap.Error(err))
 		return models.TestCase{}, errors.New("internal failure")
 	}
 	return tcs, nil
@@ -103,7 +110,8 @@ func (r *Regression) GetAll(ctx context.Context, cid, appID string, offset *int,
 	tcs, err := r.tdb.GetAll(ctx, cid, appID, false, off, lim)
 
 	if err != nil {
-		r.log.Error("failed to get testcases from the DB", zap.String("cid", cid), zap.String("appID", appID), zap.Error(err))
+		sanitizedAppID := sanitiseInput(appID)
+		r.log.Error("failed to get testcases from the DB", zap.String("cid", cid), zap.String("appID", sanitizedAppID), zap.Error(err))
 		return nil, errors.New("internal failure")
 	}
 	return tcs, nil

--- a/pkg/service/regression/regression.go
+++ b/pkg/service/regression/regression.go
@@ -85,7 +85,7 @@ func (r *Regression) GetApps(ctx context.Context, cid string) ([]string, error) 
 
 func sanitiseInput(s string) string {
 	re := regexp.MustCompile(`(\n|\n\r|\r\n|\r)`)
-	return html.EscapeString(string(re.ReplaceAll([]byte(s), []byte(" "))))
+	return html.EscapeString(string(re.ReplaceAll([]byte(s), []byte(""))))
 }
 
 func (r *Regression) Get(ctx context.Context, cid, appID, id string) (models.TestCase, error) {


### PR DESCRIPTION
## Related Issue
Closes: #107
Closes: #106

#### Describe the changes you've made
This commit adds safe escaping for logged user input in the `service/regression` package, replacing newlines with spaces and escaping HTML.

## Type of change
Logging, security.
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added
None, but I could work on it if we need any.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
N/A

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)
None.
