### PR TITLE
ci(publish-docker): Remove QEMU setup

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,10 +62,6 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      # We need QEMU to emulate the ARM architecture
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@dd6dfe41c1ffde2e8c4ba7de0bcf4e163ec8b84d
-
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apk add -U --no-cache ca-certificates && apk add build-base
 ENV GO111MODULE=on
 
 # Build Delve
-RUN GOOS=linux GOARCH=${BUILDPLATFORM} go install github.com/go-delve/delve/cmd/dlv@latest
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 WORKDIR /app
 
@@ -35,7 +35,7 @@ COPY . .
 COPY --from=ui-builder /ui/public /app/web/public
 
 #RUN CGO_ENABLED=0 GOOS=linux go build -o health cmd/health/main.go
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${BUILDPLATFORM} go build -o keploy cmd/server/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -o keploy cmd/server/main.go
 
 # final stage
 FROM --platform=${BUILDPLATFORM} alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apk add -U --no-cache ca-certificates && apk add build-base
 ENV GO111MODULE=on
 
 # Build Delve
-RUN go install github.com/go-delve/delve/cmd/dlv@latest
+RUN GOOS=linux GOARCH=${BUILDPLATFORM} go install github.com/go-delve/delve/cmd/dlv@latest
 
 WORKDIR /app
 
@@ -35,7 +35,7 @@ COPY . .
 COPY --from=ui-builder /ui/public /app/web/public
 
 #RUN CGO_ENABLED=0 GOOS=linux go build -o health cmd/health/main.go
-RUN CGO_ENABLED=0 GOOS=linux go build -o keploy cmd/server/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${BUILDPLATFORM} go build -o keploy cmd/server/main.go
 
 # final stage
 FROM --platform=${BUILDPLATFORM} alpine


### PR DESCRIPTION
## Related Issue
  - Info about Issue or bug

Closes: #118

#### Describe the changes you've made
After some investigation, @slayerjain and I concluded that QEMU is not required by our multiarch build. This PR removes the setup-qemu step from the docker-publish workflow.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added
None.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
NA

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)
N/A
