### PR TITLE
docs(readme): add reference for java and ts sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ All of these can be visualised here - http://localhost:8081/testlist
 
 ## Language Support
 - [x] [Go SDK](https://github.com/keploy/go-sdk)
-- [ ] Java SDK - WIP [#51](https://github.com/keploy/keploy/issues/51)
-- [ ] Typescript/Javascript SDK - WIP [#61](https://github.com/keploy/keploy/issues/61)
+- [x] [Java SDK](https://github.com/keploy/java-sdk)
+- [x] [Typescript/Javascript SDK](https://github.com/keploy/typescript-sdk)
 - [ ] Python SDK - WIP [#58](https://github.com/keploy/keploy/issues/58)
 
 Need another language support? Please raise an [issue](https://github.com/keploy/keploy/issues/new?assignees=&labels=&template=feature_request.md&title=) or discuss on our [slack channel](https://join.slack.com/t/keploy/shared_invite/zt-12rfbvc01-o54cOG0X1G6eVJTuI_orSA)


### PR DESCRIPTION
Update the documentation to have the ts/js and java sdk. 