### PR TITLE
fix: skips the unusual tele call on disabling telemetry

### DIFF
--- a/pkg/platform/telemetry/telemetry.go
+++ b/pkg/platform/telemetry/telemetry.go
@@ -34,7 +34,10 @@ func NewTelemetry(col DB, enabled, offMode bool, logger *zap.Logger) *Telemetry 
 func (ac *Telemetry) Ping(isTestMode bool) {
 
 	check := false
-	if !ac.Enabled || isTestMode {
+	if !ac.Enabled {
+		return
+	}
+	if isTestMode {
 		check = true
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -51,7 +51,9 @@ func Server() *chi.Mux {
 
 	rand.Seed(time.Now().UTC().UnixNano())
 
-	logger, err := zap.NewDevelopment()
+	logConf := zap.NewDevelopmentConfig()
+	logConf.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
+	logger, err := logConf.Build()
 	if err != nil {
 		panic(err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -45,6 +45,7 @@ type config struct {
 	APIKey          string `envconfig:"API_KEY"`
 	EnableDeDup     bool   `envconfig:"ENABLE_DEDUP" default:"false"`
 	EnableTelemetry bool   `envconfig:"ENABLE_TELEMETRY" default:"true"`
+	EnableDebugger  bool   `envconfig:"ENABLE_DEBUG" default:"false"`
 }
 
 func Server() *chi.Mux {
@@ -63,6 +64,10 @@ func Server() *chi.Mux {
 	err = envconfig.Process("keploy", &conf)
 	if err != nil {
 		logger.Error("failed to read/process configuration", zap.Error(err))
+	}
+
+	if conf.EnableDebugger {
+		logConf.Level.SetLevel(zap.DebugLevel)
 	}
 
 	cl, err := mgo.New(conf.MongoURI)


### PR DESCRIPTION
Signed-off-by: re-Tick <jain.ritik.1001@gmail.com>

## Related Issue
  - After disabling telemetry in keploy, unwanted telemetry ping call was occurring.

#### Describe the changes you've made
  - Add a return statement when telemetry is disabled in the ping method of telemetry package.
  - Set the logger level to info so that debug logs are avoided in console.
  - But setting ENABLE_DEBUG env variable to true changes the logger level to "debug".

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |