### PR TITLE
feat: generate mock name if empty and logs yaml file path

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -150,7 +150,7 @@ func Server() *chi.Mux {
 
 	httpListener := m.Match(cmux.HTTP1Fast())
 
-	log.Println("connect to http://localhost:8081/ for GraphQL playground")
+	log.Println("connect to http://localhost:8081/ for GraphQL playground\n ")
 
 	g := new(errgroup.Group)
 	g.Go(func() error { return grpcserver.New(logger, regSrv, runSrv, mockSrv, grpcListener) })


### PR DESCRIPTION

Signed-off-by: re-Tick <jain.ritik.1001@gmail.com>

## Related Issue
  - keploy should generate a random name for mocks with no name tag.
Closes: #[issue number that will be closed through this PR]

#### Describe the changes you've made
 - Uses uuid to generate name for mocks and write them to yaml file at the provided path directory.
 - logs the auto generated mock name along with changes for unit tests configuration with keploy.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |