### PR TITLE
fix: updates the http-spec for comma delimiter

### DIFF
--- a/grpc/grpcserver/server.go
+++ b/grpc/grpcserver/server.go
@@ -281,19 +281,19 @@ func (srv *Server) PostTC(ctx context.Context, request *proto.TestCaseReq) (*pro
 		tc[0].Spec.Encode(&models.HttpSpec{
 			// Metadata: , TODO: What should be here
 			Created: request.Captured,
-			Request: models.HttpReq{
+			Request: models.MockHttpReq{
 				Method:     models.Method(request.HttpReq.Method),
 				ProtoMajor: int(request.HttpReq.ProtoMajor),
 				ProtoMinor: int(request.HttpReq.ProtoMinor),
 				URL:        request.HttpReq.URL,
 				URLParams:  request.HttpReq.URLParams,
 				Body:       request.HttpReq.Body,
-				Header:     utils.GetHttpHeader(request.HttpReq.Header),
+				Header:     mock2.ToMockHeader(utils.GetHttpHeader(request.HttpReq.Header)),
 			},
-			Response: models.HttpResp{
+			Response: models.MockHttpResp{
 				StatusCode: int(request.HttpResp.StatusCode),
 				Body:       request.HttpResp.Body,
-				Header:     utils.GetHttpHeader(request.HttpResp.Header),
+				Header:     mock2.ToMockHeader(utils.GetHttpHeader(request.HttpResp.Header)),
 			},
 			Objects: mock2.ToModelObjects([]*proto.Mock_Object{{ // TODO: remove this. after making range check in go-sdk http interceptor logic check cause there 0th index is picked up directly. ELse it will panic
 				Type: "error",

--- a/grpc/mock/mock.go
+++ b/grpc/mock/mock.go
@@ -3,6 +3,8 @@ package mock
 import (
 	"encoding/base64"
 	"fmt"
+	"net/http"
+	"strings"
 
 	proto "go.keploy.io/server/grpc/regression"
 	"go.keploy.io/server/grpc/utils"
@@ -20,17 +22,17 @@ func Encode(doc *proto.Mock, log *zap.Logger) models.Mock {
 	case string(models.HTTP_EXPORT):
 		spec := models.HttpSpec{
 			Metadata: doc.Spec.Metadata,
-			Request: models.HttpReq{
+			Request: models.MockHttpReq{
 				Method:     models.Method(doc.Spec.Req.Method),
 				ProtoMajor: int(doc.Spec.Req.ProtoMajor),
 				ProtoMinor: int(doc.Spec.Req.ProtoMinor),
 				URL:        doc.Spec.Req.URL,
-				Header:     utils.GetHttpHeader(doc.Spec.Req.Header),
+				Header:     ToMockHeader(utils.GetHttpHeader(doc.Spec.Req.Header)),
 				Body:       doc.Spec.Req.Body,
 			},
-			Response: models.HttpResp{
+			Response: models.MockHttpResp{
 				StatusCode: int(doc.Spec.Res.StatusCode),
-				Header:     utils.GetHttpHeader(doc.Spec.Res.Header),
+				Header:     ToMockHeader(utils.GetHttpHeader(doc.Spec.Res.Header)),
 				Body:       doc.Spec.Res.Body,
 			},
 			Objects: []models.Object{{
@@ -108,7 +110,7 @@ func Decode(doc []models.Mock, log *zap.Logger) []*proto.Mock {
 					ProtoMajor: int64(spec.Request.ProtoMajor),
 					ProtoMinor: int64(spec.Request.ProtoMinor),
 					URL:        spec.Request.URL,
-					Header:     utils.GetProtoMap(spec.Request.Header),
+					Header:     utils.GetProtoMap(ToHttpHeader(spec.Request.Header)),
 					Body:       spec.Request.Body,
 				},
 				Objects: []*proto.Mock_Object{{
@@ -117,7 +119,7 @@ func Decode(doc []models.Mock, log *zap.Logger) []*proto.Mock {
 				}},
 				Res: &proto.HttpResp{
 					StatusCode: int64(spec.Response.StatusCode),
-					Header:     utils.GetProtoMap(spec.Response.Header),
+					Header:     utils.GetProtoMap(ToHttpHeader(spec.Response.Header)),
 					Body:       spec.Response.Body,
 				},
 				Mocks:      spec.Mocks,
@@ -140,4 +142,20 @@ func Decode(doc []models.Mock, log *zap.Logger) []*proto.Mock {
 		res = append(res, mock)
 	}
 	return res
+}
+
+func ToHttpHeader(mockHeader map[string]string) http.Header {
+	header := http.Header{}
+	for i, j := range mockHeader {
+		header[i] = strings.Split(j, ",")
+	}
+	return header
+}
+
+func ToMockHeader(httpHeader http.Header) map[string]string {
+	header := map[string]string{}
+	for i, j := range httpHeader {
+		header[i] = strings.Join(j, ", ")
+	}
+	return header
 }

--- a/http/regression/regression.go
+++ b/http/regression/regression.go
@@ -205,19 +205,19 @@ func (rg *regression) PostTC(w http.ResponseWriter, r *http.Request) {
 		}
 		tc[0].Spec.Encode(&models.HttpSpec{
 			// Metadata: , TODO: What should be here
-			Request: models.HttpReq{
+			Request: models.MockHttpReq{
 				Method:     models.Method(data.HttpReq.Method),
 				ProtoMajor: int(data.HttpReq.ProtoMajor),
 				ProtoMinor: int(data.HttpReq.ProtoMinor),
 				URL:        data.HttpReq.URL,
 				URLParams:  data.HttpReq.URLParams,
 				Body:       data.HttpReq.Body,
-				Header:     data.HttpReq.Header,
+				Header:     mock.ToMockHeader(data.HttpReq.Header),
 			},
-			Response: models.HttpResp{
+			Response: models.MockHttpResp{
 				StatusCode: int(data.HttpResp.StatusCode),
 				Body:       data.HttpResp.Body,
-				Header:     data.HttpResp.Header,
+				Header:     mock.ToMockHeader(data.HttpResp.Header),
 			},
 			Objects: []models.Object{{
 				Type: "error",

--- a/pkg/models/mock.go
+++ b/pkg/models/mock.go
@@ -34,10 +34,26 @@ type Object struct {
 
 type HttpSpec struct {
 	Metadata   map[string]string   `json:"metadata" yaml:"metadata"`
-	Request    HttpReq             `json:"req" yaml:"req"`
-	Response   HttpResp            `json:"resp" yaml:"resp"`
+	Request    MockHttpReq         `json:"req" yaml:"req"`
+	Response   MockHttpResp        `json:"resp" yaml:"resp"`
 	Objects    []Object            `json:"objects" yaml:"objects"`
 	Mocks      []string            `json:"mocks" yaml:"mocks,omitempty"`
 	Assertions map[string][]string `json:"assertions" yaml:"assertions,omitempty"`
 	Created    int64               `json:"created" yaml:"created,omitempty"`
+}
+
+type MockHttpReq struct {
+	Method     Method            `json:"method" yaml:"method"`
+	ProtoMajor int               `json:"proto_major" yaml:"proto_major"` // e.g. 1
+	ProtoMinor int               `json:"proto_minor" yaml:"proto_minor"` // e.g. 0
+	URL        string            `json:"url" yaml:"url"`
+	URLParams  map[string]string `json:"url_params" yaml:"url_params,omitempty"`
+	Header     map[string]string `json:"header" yaml:"header"`
+	Body       string            `json:"body" yaml:"body"`
+}
+
+type MockHttpResp struct {
+	StatusCode int               `json:"status_code" yaml:"status_code"` // e.g. 200
+	Header     map[string]string `json:"header" yaml:"header"`
+	Body       string            `json:"body" yaml:"body"`
 }

--- a/pkg/service/regression/regression.go
+++ b/pkg/service/regression/regression.go
@@ -174,9 +174,21 @@ func (r *Regression) toTestCase(tcs []models.Mock, mockPath string) ([]models.Te
 			noise = []string{}
 		}
 		res = append(res, models.TestCase{
-			ID:       j.Name,
-			HttpReq:  spec.Request,
-			HttpResp: spec.Response,
+			ID: j.Name,
+			HttpReq: models.HttpReq{
+				Method:     spec.Request.Method,
+				ProtoMajor: spec.Request.ProtoMajor,
+				ProtoMinor: spec.Request.ProtoMinor,
+				URL:        spec.Request.URL,
+				URLParams:  spec.Request.URLParams,
+				Body:       spec.Request.Body,
+				Header:     mock2.ToHttpHeader(spec.Request.Header),
+			},
+			HttpResp: models.HttpResp{
+				StatusCode: spec.Response.StatusCode,
+				Body:       spec.Response.Body,
+				Header:     mock2.ToHttpHeader(spec.Response.Header),
+			},
 			Noise:    noise,
 			Mocks:    mock2.Decode(mocks, r.log),
 			Captured: spec.Created,


### PR DESCRIPTION
the header's field-values are delimited to string seperated by comma

Signed-off-by: re-Tick <jain.ritik.1001@gmail.com>

## Related Issue
  - The yaml file's headers field-value should be comma seperated string instead of a string array.

#### Describe the changes you've made
Create a new request and response field type of http-spec to update the header type to map[string]string.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |