### PR TITLE
docs(readme): remove mongo from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,7 @@ Keploy is added as a middleware to your application that captures and replays al
 
 
 ## Quickstart
-### Start MongoDB
-Spin up MongoDB to store the test-runs results
-
-```shell
-docker container run -it -p27017:27017 mongo
-```
-
 > Note that Testcases are exported as files in the repo by default
-
 
 ### MacOS 
 ```shell
@@ -113,7 +105,7 @@ docker-compose up -d
 
 #### Run the application
 ```shell
-go run handler.go main.go
+export KEPLOY_MODE=record && go run handler.go main.go
 ```
 
 ### Generate testcases


### PR DESCRIPTION
The latest version of keploy no longer needs mongo to be running for saving test results/runs or test cases. 