### PR TITLE
Add default version to server

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,7 +7,7 @@ import (
 // version is the version of the server and will be injected during build by ldflags
 // see https://goreleaser.com/customization/build/
 
-var version = "0.1.0-dev"
+var version = server.DefaultVersion
 
 func main() {
 	// main method to start Keploy server

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -6,9 +6,8 @@ import (
 
 // version is the version of the server and will be injected during build by ldflags
 // see https://goreleaser.com/customization/build/
-var version = "0.1.0-dev"
 
 func main() {
 	// main method to start Keploy server
-	server.Server(version)
+	server.Server(server.DefaultVersion)
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,7 +7,9 @@ import (
 // version is the version of the server and will be injected during build by ldflags
 // see https://goreleaser.com/customization/build/
 
+var version = "0.1.0-dev"
+
 func main() {
 	// main method to start Keploy server
-	server.Server(server.DefaultVersion)
+	server.Server(version)
 }

--- a/server/const.go
+++ b/server/const.go
@@ -1,0 +1,5 @@
+package server
+
+const(
+	DefaultVersion = "0.1.0-dev"
+)

--- a/server/server.go
+++ b/server/server.go
@@ -38,6 +38,8 @@ import (
 
 // const defaultPort = "8080"
 
+const DefaultVersion string = "0.1.0-dev" //DefaultVersion is the default version of the server
+
 const logo string = `
        ▓██▓▄
     ▓▓▓▓██▓█▓▄

--- a/server/server.go
+++ b/server/server.go
@@ -38,7 +38,6 @@ import (
 
 // const defaultPort = "8080"
 
-const DefaultVersion string = "0.1.0-dev" //DefaultVersion is the default version of the server
 
 const logo string = `
        ▓██▓▄


### PR DESCRIPTION
## Related Issue
  Keploy server did not use a global default version for starting the server. This PR adds a variable to the server file so that whenever the user does not pass a version to start the server, the server can start using the default version.
Closes: #[issue number that will be closed through this PR]

#### Describe the changes you've made
A clear and concise description of what you have done to successfully close your assigned issue. Any new files? or anything you feel to let us know!

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
NA
## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |