### PR TITLE
fix: add length check condition for mocks array

### DIFF
--- a/pkg/platform/fs/mock.go
+++ b/pkg/platform/fs/mock.go
@@ -158,9 +158,14 @@ func toTestCase(tcs []models.Mock, fileName, mockPath string) ([]models.TestCase
 		if err != nil {
 			return nil, fmt.Errorf("failed to decode the yaml spec field of testcase. file: %s  error: %s", pkg.SanitiseInput(fileName), err.Error())
 		}
-		nameCheck := strings.Split(spec.Mocks[0], "-")[0]
-		var mockName string;
-		if(nameCheck == "mock"){
+
+		var nameCheck string
+		if len(spec.Mocks) > 0 {
+			nameCheck = strings.Split(spec.Mocks[0], "-")[0]
+		}
+
+		var mockName string
+		if nameCheck == "mock" {
 			mockName = "mock-" + strings.Split(fileName, "-")[1]
 		} else {
 			mockName = fileName


### PR DESCRIPTION
- If a test doesn't have mocks then the keploy server gets crashes, for eg: 500 and 404 error codes.

Signed-off-by: gouravkrosx <gouravgreatkr@gmail.com>

#### Describe the changes you've made
- I have added a check for array length, if it's greater than 0 then do anything.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
`NA`

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |