### PR TITLE
Added telemetry events at service level

### DIFF
--- a/grpc/grpcserver/server.go
+++ b/grpc/grpcserver/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -17,6 +18,7 @@ import (
 	"go.keploy.io/server/grpc/utils"
 	"go.keploy.io/server/pkg"
 	"go.keploy.io/server/pkg/models"
+	"go.keploy.io/server/pkg/platform/telemetry"
 	"go.keploy.io/server/pkg/service/mock"
 	regression2 "go.keploy.io/server/pkg/service/regression"
 	tcSvc "go.keploy.io/server/pkg/service/testCase"
@@ -32,10 +34,12 @@ type Server struct {
 	svc            regression2.Service
 	tcSvc          tcSvc.Service
 	mock           mock.Service
+	tele           telemetry.Service
+	client         http.Client
 	proto.UnimplementedRegressionServiceServer
 }
 
-func New(k *keploy.Keploy, logger *zap.Logger, svc regression2.Service, m mock.Service, tc tcSvc.Service, listener net.Listener, testExport bool, testReportPath string) error {
+func New(k *keploy.Keploy, logger *zap.Logger, svc regression2.Service, m mock.Service, tc tcSvc.Service, listener net.Listener, testExport bool, testReportPath string, telemetry telemetry.Service, cl http.Client) error {
 
 	// create an instance for grpc server
 	srv := grpc.NewServer(kgrpcserver.UnaryInterceptor(k))
@@ -46,6 +50,8 @@ func New(k *keploy.Keploy, logger *zap.Logger, svc regression2.Service, m mock.S
 		testExport:     testExport,
 		testReportPath: testReportPath,
 		tcSvc:          tc,
+		tele:           telemetry,
+		client:         cl,
 	})
 	reflection.Register(srv)
 	err := srv.Serve(listener)
@@ -87,6 +93,10 @@ func (srv *Server) GetMocks(ctx context.Context, request *proto.GetMockReq) (*pr
 	response := &proto.GetMockResp{
 		Mocks: res,
 	}
+
+	//sending RecordedMocks Telemetry event to Telemetry service.
+	srv.tele.RecordedMocks(len(mocks), srv.client, ctx)
+
 	return response, nil
 }
 

--- a/pkg/platform/telemetry/service.go
+++ b/pkg/platform/telemetry/service.go
@@ -27,6 +27,8 @@ type Service interface {
 	Normalize(http.Client, context.Context)
 	EditTc(http.Client, context.Context)
 	Testrun(int, int, http.Client, context.Context)
+	RecordedTests(int, int, http.Client, context.Context)
+	RecordedMocks(int, http.Client, context.Context)
 	DeleteTc(http.Client, context.Context)
 	GetApps(int, http.Client, context.Context)
 }

--- a/pkg/platform/telemetry/telemetry.go
+++ b/pkg/platform/telemetry/telemetry.go
@@ -113,6 +113,16 @@ func (ac *Telemetry) Testrun(success int, failure int, client http.Client, ctx c
 	ac.SendTelemetry("TestRun", client, ctx, map[string]interface{}{"Passed-Tests": success, "Failed-Tests": failure})
 }
 
+// Telemetry event for the tests and mocks that are recorded
+func (ac *Telemetry) RecordedTests(testCaseCount int, mockCount int, client http.Client, ctx context.Context) {
+	ac.SendTelemetry("RecordedTestsAndMocks", client, ctx, map[string]interface{}{"Test-Case-Count": testCaseCount, "Mock-Count": mockCount})
+}
+
+// Telemetry event for the mocks that are recorded in the mocking feature
+func (ac *Telemetry) RecordedMocks(mockCount int, client http.Client, ctx context.Context) {
+	ac.SendTelemetry("RecordedMocks", client, ctx, map[string]interface{}{"Mock-Count": mockCount})
+}
+
 func (ac *Telemetry) GetApps(apps int, client http.Client, ctx context.Context) {
 	ac.SendTelemetry("GetApps", client, ctx, map[string]interface{}{"Apps": apps})
 }

--- a/pkg/service/regression/regression.go
+++ b/pkg/service/regression/regression.go
@@ -920,6 +920,10 @@ func (r *Regression) PutTest(ctx context.Context, run models.TestRun, testExport
 		} else {
 			pp.SetColorScheme(models.PassingColorScheme)
 		}
+
+		// sending Testrun Telemetry event to Telemetry service.
+		r.tele.Testrun(success, failure, r.client, ctx)
+
 		pp.Printf("\n <=========================================> \n  TESTRUN SUMMARY. For testrun with id: %s\n"+"\tTotal tests: %s\n"+"\tTotal test passed: %s\n"+"\tTotal test failed: %s\n <=========================================> \n\n", run.ID, total, success, failure)
 	}
 	if !testExport {

--- a/pkg/service/testCase/testCase.go
+++ b/pkg/service/testCase/testCase.go
@@ -128,6 +128,18 @@ func (r *TestCase) readTCS(ctx context.Context, testCasePath, mockPath string) (
 		r.log.Info(fmt.Sprintf("no testcases found in %s directory.", pkg.SanitiseInput(testCasePath)))
 		return nil, err
 	}
+
+	// go routine got sending telemetry event
+	go func ()  {
+		testCaseCount := len(res)
+		mockCount := 0
+		for _,testCase := range res {
+			mockCount += len(testCase.Mocks)
+		}
+		// sending RecordedTest Telemetry event to Telemetry service.
+		r.tele.RecordedTests(testCaseCount, mockCount, r.client, ctx)
+	}()
+	
 	return res, err
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -201,7 +201,7 @@ func Server(ver string) *chi.Mux {
 
 	g := new(errgroup.Group)
 	g.Go(func() error {
-		return grpcserver.New(k, logger, regSrv, mockSrv, tcSvc, grpcListener, conf.EnableTestExport, conf.ReportPath)
+		return grpcserver.New(k, logger, regSrv, mockSrv, tcSvc, grpcListener, conf.EnableTestExport, conf.ReportPath, analyticsConfig, client)
 	})
 
 	g.Go(func() error {


### PR DESCRIPTION
## Related Issue
  - Currently Telemetry events only get triggered from UI which is deprecated . This doesn't give us any analytic metric . The Telemetry events needs to be fired form service layer .

Closes: #[314](https://github.com/keploy/keploy/issues/314)

#### Describe the changes you've made
Introduced few new events for giving analytics regarding number of tests and mocks that are recorded and triggered them from service layer .

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |