### PR TITLE
adding host header in catching

### DIFF
--- a/pkg/hooks/launch.go
+++ b/pkg/hooks/launch.go
@@ -93,6 +93,7 @@ func (h *Hook) LaunchUserApplication(appCmd, appContainer, appNetwork string, De
 									continue
 								}
 								if inspect.State.Pid != 0 {
+									h.ipAddress = inspect.NetworkSettings.Networks[appDockerNetwork].IPAddress
 									containerPid = inspect.State.Pid
 									break
 								}

--- a/pkg/hooks/loader.go
+++ b/pkg/hooks/loader.go
@@ -69,6 +69,7 @@ type Hook struct {
 	close      link.Link
 	closeRet   link.Link
 	objects    bpfObjects
+	ipAddress  string
 }
 
 func NewHook(db platform.TestCaseDB, logger *zap.Logger) *Hook {
@@ -563,6 +564,11 @@ func (h *Hook) LoadHooks(appCmd, appContainer string) error {
 	h.logger.Debug(Emoji + "Keploy Pid sent successfully...")
 
 	return nil
+}
+
+// to access the IP address of the hook
+func (h *Hook) GetIP() string {
+	return h.ipAddress
 }
 
 // detectCgroupPath returns the first-found mount point of type cgroup2

--- a/pkg/service/test/test.go
+++ b/pkg/service/test/test.go
@@ -110,7 +110,7 @@ func (t *tester) Test(tcsPath, mockPath, testReportPath string, appCmd, appConta
 	var userIp string
 	ok, _ := loadedHooks.IsDockerRelatedCmd(appCmd)
 	if ok {
-		userIp = loadedHooks.GetUserIp(appContainer, appNetwork)
+		userIp = loadedHooks.GetIP()
 		t.logger.Debug(Emoji, zap.Any("User Ip", userIp))
 	}
 
@@ -443,11 +443,8 @@ func replaceHostToIP(currentURL string, ipAddress string) string {
 		return currentURL
 	}
 
-	// Check if the URL host is "localhost"
-	if parsedURL.Hostname() == "localhost" {
-		// Replace "localhost" with the IP address
-		parsedURL.Host = strings.Replace(parsedURL.Host, "localhost", ipAddress, 1)
-	}
+	// Replace hostname with the IP address
+	parsedURL.Host = strings.Replace(parsedURL.Host, parsedURL.Hostname(), ipAddress, 1)
 
 	// Return the modified URL
 	return parsedURL.String()

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -107,6 +107,7 @@ func SimulateHttp(tc models.TestCase, logger *zap.Logger, getResp func() *models
 func ParseHTTPRequest(requestBytes []byte) (*http.Request, error) {
 	// Parse the request using the http.ReadRequest function
 	request, err := http.ReadRequest(bufio.NewReader(bytes.NewReader(requestBytes)))
+	request.Header.Set("Host", request.Host)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Related Issue
  * Host header not captured during record

Closes: #628

#### Describe the changes you've made
* Since host in header isn't captured(due to internal dependency of http package removing it) had to manually store the host in header.
* Replaced the hardcoded search and replace of "localhost" term with generic hostname of request. 
* Stored the IP address in hooks that can be accessed while testing for calls via docker related commands.  

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

