### PR TITLE
fix:add timeout when Connection:keep-alive is enabled in request 

### DIFF
--- a/pkg/hooks/connection/tracker.go
+++ b/pkg/hooks/connection/tracker.go
@@ -66,6 +66,9 @@ func (conn *Tracker) IsComplete() bool {
 	// Calculate the time elapsed since the last activity in nanoseconds.
 	elapsedTime := currentTimestamp - conn.lastActivityTimestamp
 
+	//Caveat: Added a timeout of 2 seconds, after this duration we assume that all the data events would have come.
+	// This will ensure that we capture the requests responses where Connection:keep-alive is enabled.
+
 	// Check if 1 second has passed since the last activity.
 	if elapsedTime >= uint64(time.Second*2) {
 		conn.logger.Debug("Either connection is alive or request is a mutlipart/file-upload")

--- a/pkg/hooks/connection/tracker.go
+++ b/pkg/hooks/connection/tracker.go
@@ -59,6 +59,20 @@ func (conn *Tracker) IsComplete() bool {
 	conn.mutex.RLock()
 	defer conn.mutex.RUnlock()
 	// log.Printf("IsComplete() called: Successfully reading the data...")
+
+	// Get the current timestamp in nanoseconds.
+	currentTimestamp := uint64(time.Now().UnixNano())
+
+	// Calculate the time elapsed since the last activity in nanoseconds.
+	elapsedTime := currentTimestamp - conn.lastActivityTimestamp
+
+	// Check if 1 second has passed since the last activity.
+	if elapsedTime >= uint64(time.Second*2) {
+		conn.logger.Debug("Either connection is alive or request is a mutlipart/file-upload")
+		return true
+	}
+
+	// Check if other conditions for completeness are met.
 	return conn.closeTimestamp != 0 &&
 		conn.totalReadBytes == conn.recvBytes &&
 		conn.totalWrittenBytes == conn.sentBytes

--- a/pkg/hooks/loader.go
+++ b/pkg/hooks/loader.go
@@ -334,7 +334,7 @@ func (h *Hook) LoadHooks(appCmd, appContainer string) error {
 	go func() {
 		for {
 			connectionFactory.HandleReadyConnections(h.db, h.GetDeps, h.ResetDeps)
-			time.Sleep(1 * time.Second)
+			time.Sleep(2 * time.Second)
 		}
 	}()
 	// ------------ For Egress -------------

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -619,7 +619,7 @@ func (ps *ProxySet) handleConnection(conn net.Conn, port uint32) {
 	if destInfo.IpVersion == 4 {
 		actualAddress = fmt.Sprintf("%v:%v", util.ToIP4AddressStr(destInfo.DestIp4), destInfo.DestPort)
 	} else if destInfo.IpVersion == 6 {
-		actualAddress = fmt.Sprintf("%v:%v", util.ToIPv6AddressStr(destInfo.DestIp6), destInfo.DestPort)
+		actualAddress = fmt.Sprintf("[%v]:%v", util.ToIPv6AddressStr(destInfo.DestIp6), destInfo.DestPort)
 	}
 
 	//Dialing for tls connection


### PR DESCRIPTION


Closes:  #632 

#### Describe the changes you've made
- Added a timeout of 2 seconds, after this duration we assume that all the data events would have come.
- Also fixed format of ipv6 address in proxy server. for eg: replace `::1:some_dest_port `->` [::1]:some_dest_port` 

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
`NA`

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |