### PR TITLE
fix: fails to create mongo db mocks

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -621,12 +621,12 @@ func (ps *ProxySet) handleConnection(conn net.Conn, port uint32) {
 	}
 	isTLS := isTLSHandshake(testBuffer)
 	multiReader := io.MultiReader(reader, conn)
-	customConn := &CustomConn{
+	conn = &CustomConn{
 		Conn: conn,
 		r:    multiReader,
 	}
 	if isTLS {
-		conn, err = handleTLSConnection(customConn)
+		conn, err = handleTLSConnection(conn)
 		if err != nil {
 			ps.logger.Error(Emoji+"failed to handle TLS connection", zap.Error(err))
 			return


### PR DESCRIPTION
## Related Issue
  - Keploy fails to record mocks for mongo db. 

Closes: #[issue number that will be closed through this PR]

#### Describe the changes you've made
- Instead of using customConn, used the same conn object in case of tls connection.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
`NA`

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x ] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |