### PR TITLE
[fix]:removing resp channel

### DIFF
--- a/pkg/hooks/connection/factory.go
+++ b/pkg/hooks/connection/factory.go
@@ -70,7 +70,7 @@ func (factory *Factory) HandleReadyConnections(path string, db platform.TestCase
 				// resetDeps()
 				// fmt.Println("after reseting the deps array: ", getDeps(), "\n ")
 			default:
-				factory.logger.Warn(Emoji+"Keploy mode is not set to record/test. Tracker is being skipped.",
+				factory.logger.Warn(Emoji+"Keploy mode is not set to record. Tracker is being skipped.",
 					zap.Any("current mode", models.GetMode()))
 			}
 

--- a/pkg/hooks/connection/factory.go
+++ b/pkg/hooks/connection/factory.go
@@ -22,17 +22,15 @@ type Factory struct {
 	connections         map[structs.ConnID]*Tracker
 	inactivityThreshold time.Duration
 	mutex               *sync.RWMutex
-	respChannel         chan *models.HttpResp
 	logger              *zap.Logger
 }
 
 // NewFactory creates a new instance of the factory.
-func NewFactory(inactivityThreshold time.Duration, respChannel chan *models.HttpResp, logger *zap.Logger) *Factory {
+func NewFactory(inactivityThreshold time.Duration, logger *zap.Logger) *Factory {
 	return &Factory{
 		connections:         make(map[structs.ConnID]*Tracker),
 		mutex:               &sync.RWMutex{},
 		inactivityThreshold: inactivityThreshold,
-		respChannel:         respChannel,
 		logger:              logger,
 	}
 }
@@ -71,20 +69,6 @@ func (factory *Factory) HandleReadyConnections(path string, db platform.TestCase
 
 				// resetDeps()
 				// fmt.Println("after reseting the deps array: ", getDeps(), "\n ")
-			case models.MODE_TEST:
-				respBody, err := io.ReadAll(parsedHttpRes.Body)
-				parsedHttpRes.Body.Close()
-				if err != nil {
-					factory.logger.Error(Emoji+"failed to read the http response body", zap.Error(err),
-						zap.Any("mode", models.MODE_TEST))
-					return
-				}
-				// resetDeps()
-				factory.respChannel <- &models.HttpResp{
-					StatusCode: parsedHttpRes.StatusCode,
-					Header:     pkg.ToYamlHttpHeader(parsedHttpRes.Header),
-					Body:       string(respBody),
-				}
 			default:
 				factory.logger.Warn(Emoji+"Keploy mode is not set to record/test. Tracker is being skipped.",
 					zap.Any("current mode", models.GetMode()))

--- a/pkg/service/test/test.go
+++ b/pkg/service/test/test.go
@@ -190,13 +190,12 @@ func (t *tester) Test(path, testReportPath string, appCmd, appContainer, appNetw
 				if ok || dIDE {
 					//changing Ip address only in case of docker
 					tc.HttpReq.URL = replaceHostToIP(tc.HttpReq.URL, userIp)
-					t.logger.Debug(Emoji,zap.Any("replaced URL in case of docker env",tc.HttpReq.URL))
+					t.logger.Debug(Emoji, zap.Any("replaced URL in case of docker env", tc.HttpReq.URL))
 				}
 				t.logger.Debug(fmt.Sprintf("the url of the testcase: %v", tc.HttpReq.URL))
 				// time.Sleep(10 * time.Second)
-				resp, err := pkg.SimulateHttp(*tc, t.logger, loadedHooks.GetResp)
+				resp, err := pkg.SimulateHttp(*tc, t.logger)
 				t.logger.Debug(Emoji+"After simulating the request", zap.Any("test case id", tc.Name))
-				resp = loadedHooks.GetResp()
 				t.logger.Debug(Emoji+"After GetResp of the request", zap.Any("test case id", tc.Name))
 
 				if err != nil {


### PR DESCRIPTION
## Related Issue
  - Removing resp channel from test and record flow.

Solves: #672

#### Describe the changes you've made
Removed resp channel from hooks and set the response for call in simulatehttp.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [X] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

# How were the updates tested?

Ran the updated code with new as well as pre-existing samples to insure smooth functioning, along with projects that were breaking earlier due to this bug
