### PR TITLE
ci: update dockefile and gha for keploy v2

### DIFF
--- a/.github/workflows/go-self-hosted.yml
+++ b/.github/workflows/go-self-hosted.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/main-self-hosted.yml
+++ b/.github/workflows/main-self-hosted.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - name: Build
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - name: Build
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
 #      - name: Checkout UI
 #        uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,8 @@ jobs:
 #          rm -rf $GITHUB_WORKSPACE/ui
 
   build-go:
-    runs-on: macos-latest
+    # runs-on: macos-latest
+    runs-on: ubuntu-latest
 #    needs: build-ui
     steps:
       - uses: actions/checkout@v2
@@ -72,17 +73,17 @@ jobs:
 #        with:
 #          path: web
 #          key: ${{ hashFiles('ui/src') }}
-      - name: Import Code-Signing Certificates
-        uses: Apple-Actions/import-codesign-certs@v1
-        with:
-          # The certificates in a PKCS12 file encoded as a base64 string created with "openssl base64 -in cert.p12 -out cert-base64.txt"
-          p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
-          # The password used to import the PKCS12 file.
-          p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}  
-      - name: Install gon via HomeBrew for code signing and app notarization
-        run: |
-          brew tap mitchellh/gon
-          brew install mitchellh/gon/gon
+      # - name: Import Code-Signing Certificates
+      #   uses: Apple-Actions/import-codesign-certs@v1
+      #   with:
+      #     # The certificates in a PKCS12 file encoded as a base64 string created with "openssl base64 -in cert.p12 -out cert-base64.txt"
+      #     p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
+      #     # The password used to import the PKCS12 file.
+      #     p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}  
+      # - name: Install gon via HomeBrew for code signing and app notarization
+      #   run: |
+      #     brew tap mitchellh/gon
+      #     brew install mitchellh/gon/gon
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
@@ -90,5 +91,5 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          APPLE_ACCOUNT_PASSWORD: ${{ secrets.APPLE_ACCOUNT_PASSWORD }}
+          # APPLE_ACCOUNT_PASSWORD: ${{ secrets.APPLE_ACCOUNT_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -6,42 +6,42 @@ archives:
 builds:
   - binary: keploy
     id: keploy
-    main: ./cmd/server/main.go
+    main: ./main.go
     # ldflags:
     #   - -s -w -X main.build={{.Version}}
     env:
       - CGO_ENABLED=0
     goos:
       - linux
-      - windows
+      # - windows
     goarch:
       - amd64
-      - 386
+      # - 386
       - arm64
-  - binary: keploy
-    id: keploy-macos
-    main: ./cmd/server/main.go
-    env:
-      - CGO_ENABLED=0
-    goos:
-      - darwin
-    goarch:
-      - amd64
-      - arm64
+  # - binary: keploy
+  #   id: keploy-macos
+  #   main: ./cmd/server/main.go
+  #   env:
+  #     - CGO_ENABLED=0
+  #   goos:
+  #     - darwin
+  #   goarch:
+  #     - amd64
+  #     - arm64
 
-universal_binaries:
--
-  # ID of resulting universal binary.
-  #
-  # Defaults to the project name.
-  id: keploy-mac-universal
+# universal_binaries:
+# -
+#   # ID of resulting universal binary.
+#   #
+#   # Defaults to the project name.
+#   id: keploy-mac-universal
 
-  # IDs to use to filter the built binaries.
-  #
-  # Defaults to the `id` field.
-  # Since: v1.3.
-  ids:
-  - keploy-macos
+#   # IDs to use to filter the built binaries.
+#   #
+#   # Defaults to the `id` field.
+#   # Since: v1.3.
+#   ids:
+#   - keploy-macos
 
   # Whether to remove the previous single-arch binaries from the artifact list.
   # If left as false, your end release might have both several macOS archives:


### PR DESCRIPTION
This makes the CI computable with Keploy V2. Keploy V2 binary is no longer compatible with windows and macOS. Instead keploy would run via docker on windows and macOS. 