### PR TITLE
fix: unable to use docker compose file to record/test via keploy

### DIFF
--- a/pkg/hooks/launch.go
+++ b/pkg/hooks/launch.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
+	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 	"go.keploy.io/server/pkg/models"
 	"go.uber.org/zap"
@@ -55,7 +56,7 @@ func (h *Hook) LaunchUserApplication(appCmd, appContainer, appNetwork string, De
 	ok, cmd := h.IsDockerRelatedCmd(appCmd)
 	if ok {
 
-		h.logger.Debug(Emoji + "Running user application on Docker")
+		h.logger.Debug(Emoji+"Running user application on Docker", zap.Any("Docker env", cmd))
 
 		if cmd == "docker-compose" {
 			if len(appContainer) == 0 {
@@ -67,29 +68,30 @@ func (h *Hook) LaunchUserApplication(appCmd, appContainer, appNetwork string, De
 				h.logger.Error(Emoji+"please provide docker network name in case of docker-compose file", zap.Any("AppCmd", appCmd))
 				return fmt.Errorf(Emoji + "docker network name not found")
 			}
+			h.logger.Debug(Emoji, zap.Any("appContainer", appContainer), zap.Any("appNetwork", appNetwork))
+		} else if cmd == "docker" {
+			var err error
+			appContainerName, appDockerNetwork, err = parseDockerCommand(appCmd)
+			h.logger.Debug(Emoji, zap.String("Parsed container name", appContainerName))
+			h.logger.Debug(Emoji, zap.String("Parsed docker network", appDockerNetwork))
+
+			if err != nil {
+				h.logger.Error(Emoji+"failed to parse container or network name from given docker command", zap.Error(err), zap.Any("AppCmd", appCmd))
+				return err
+			}
+
+			if len(appContainer) == 0 {
+
+				appContainer = appContainerName
+			}
+
+			if len(appNetwork) == 0 {
+
+				appNetwork = appDockerNetwork
+			}
 		}
 
-		var err error
-		appContainerName, appDockerNetwork, err = parseDockerCommand(appCmd)
-		h.logger.Debug(Emoji, zap.String("Parsed container name", appContainerName))
-		h.logger.Debug(Emoji, zap.String("Parsed docker network", appDockerNetwork))
-
-		if err != nil {
-			h.logger.Error(Emoji+"failed to parse container or network name from given docker command", zap.Error(err), zap.Any("AppCmd", appCmd))
-			return err
-		}
-
-		if len(appContainer) == 0 {
-
-			appContainer = appContainerName
-		}
-
-		if len(appNetwork) == 0 {
-
-			appNetwork = appDockerNetwork
-		}
-
-		err = h.processDockerEnv(appCmd, appContainer, appNetwork)
+		err := h.processDockerEnv(appCmd, appContainer, appNetwork)
 		if err != nil {
 			return err
 		}
@@ -172,7 +174,14 @@ func (h *Hook) processDockerEnv(appCmd, appContainer, appNetwork string) error {
 		logTicker := time.NewTicker(1 * time.Second)
 		defer logTicker.Stop()
 
-		messages, errs := dockerClient.Events(context.Background(), types.EventsOptions{})
+		eventFilter := filters.NewArgs()
+		eventFilter.Add("type", "container")
+		eventFilter.Add("event", "create")
+
+		messages, errs := dockerClient.Events(context.Background(), types.EventsOptions{
+			// Filters: eventFilter,
+		})
+
 		for {
 			if time.Now().After(endTime) {
 				dockerErrCh <- fmt.Errorf("no container found for :%v", appContainer)
@@ -189,10 +198,24 @@ func (h *Hook) processDockerEnv(appCmd, appContainer, appNetwork string) error {
 				dockerErrCh <- fmt.Errorf("found sudden interrupt")
 				return
 			case <-logTicker.C:
-				h.logger.Info(Emoji+"Still waiting for the container to start.", zap.String("containerName", appContainer))
+				h.logger.Info(Emoji+"still waiting for the container to start.", zap.String("containerName", appContainer))
 			case e := <-messages:
 				if e.Type == events.ContainerEventType && e.Action == "create" {
-					fmt.Println(Emoji+"Container created: ", e.ID)
+					// Fetch container details
+					containerDetails, err := dockerClient.ContainerInspect(context.Background(), e.ID)
+					if err != nil {
+						h.logger.Debug(Emoji+"failed to inspect container", zap.Error(err))
+						continue
+					}
+
+					// Check if the container's name matches the desired name
+					if containerDetails.Name != "/"+appContainer {
+						h.logger.Debug(Emoji+"ignoring container creation for unrelated container", zap.String("containerName", containerDetails.Name))
+						continue
+					}
+
+					h.logger.Debug(Emoji+"container created for desired app", zap.Any("ID", e.ID))
+
 					containerPid := 0
 					containerIp := ""
 					containerFound := false
@@ -218,7 +241,7 @@ func (h *Hook) processDockerEnv(appCmd, appContainer, appNetwork string) error {
 									if models.GetMode() == models.MODE_TEST {
 										h.logger.Debug(Emoji + "setting container ip address")
 										containerIp = networkDetails.IPAddress
-										h.logger.Debug(Emoji + "receiver channel received the ip address")
+										h.logger.Debug(Emoji+"receiver channel received the ip address", zap.Any("containerIp found", containerIp))
 									}
 								} else {
 									h.logger.Debug(Emoji+"Network details for given network not found", zap.Any("network", appNetwork))
@@ -228,7 +251,7 @@ func (h *Hook) processDockerEnv(appCmd, appContainer, appNetwork string) error {
 							}
 							containerPid = inspect.State.Pid
 							containerFound = true
-							h.logger.Debug(Emoji + "container and ip found...")
+							h.logger.Debug(Emoji + "container found...")
 							break
 						}
 					}
@@ -278,6 +301,8 @@ func (h *Hook) runApp(appCmd string, isDocker bool) error {
 	cmd.Stderr = os.Stderr
 	h.userAppCmd = cmd
 
+	h.logger.Debug(Emoji, zap.Any("executing cmd", cmd.String()))
+
 	// Run the command, this handles non-zero exit code get from application.
 	err := cmd.Run()
 	if err != nil {
@@ -291,9 +316,20 @@ func (h *Hook) runApp(appCmd string, isDocker bool) error {
 // It checks if the cmd is related to docker or not, it also returns if its a docker compose file
 func (h *Hook) IsDockerRelatedCmd(cmd string) (bool, string) {
 	// Check for Docker command patterns
-	dockerCommandPatterns := []string{"docker ", "docker-compose ", "sudo docker ", "sudo docker-compose "}
+	dockerCommandPatterns := []string{
+		"docker-compose ",
+		"sudo docker-compose ",
+		"docker compose ",
+		"sudo docker compose ",
+		"docker ",
+		"sudo docker ",
+	}
+
 	for _, pattern := range dockerCommandPatterns {
 		if strings.HasPrefix(strings.ToLower(cmd), pattern) {
+			if strings.Contains(pattern, "compose") {
+				return true, "docker-compose"
+			}
 			return true, "docker"
 		}
 	}

--- a/pkg/hooks/launch.go
+++ b/pkg/hooks/launch.go
@@ -179,7 +179,7 @@ func (h *Hook) processDockerEnv(appCmd, appContainer, appNetwork string) error {
 		eventFilter.Add("event", "create")
 
 		messages, errs := dockerClient.Events(context.Background(), types.EventsOptions{
-			// Filters: eventFilter,
+			Filters: eventFilter,
 		})
 
 		for {

--- a/pkg/proxy/util/util.go
+++ b/pkg/proxy/util/util.go
@@ -178,11 +178,23 @@ func IPToDotDecimal(ip net.IP) string {
 	return ipStr
 }
 
+// It checks if the cmd is related to docker or not, it also returns if its a docker compose file
 func IsDockerRelatedCommand(cmd string) (bool, string) {
 	// Check for Docker command patterns
-	dockerCommandPatterns := []string{"docker ", "docker-compose ", "sudo docker ", "sudo docker-compose "}
+	dockerCommandPatterns := []string{
+		"docker-compose ",
+		"sudo docker-compose ",
+		"docker compose ",
+		"sudo docker compose ",
+		"docker ",
+		"sudo docker ",
+	}
+
 	for _, pattern := range dockerCommandPatterns {
 		if strings.HasPrefix(strings.ToLower(cmd), pattern) {
+			if strings.Contains(pattern, "compose") {
+				return true, "docker-compose"
+			}
 			return true, "docker"
 		}
 	}


### PR DESCRIPTION
## Related Issue
  - #689 

#### Describe the changes you've made
- Now, docker event listener will only listen for contianer-create events and handle that only for given application container name
- Disabled follow redirects for APIs with redirections to maintain response consistency.

Current Limitation: The docker compose file of user should be in the directory/subdirectory where keploy binary is running.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
`NA`

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |