### PR TITLE
feat: revamp cli user experience and add examples

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN go build -o keploy .
 # === Runtime Stage ===
 FROM debian:bookworm-slim
 
+ENV IS_DOCKER_CMD=true 
+
 # Update the package lists and install required packages
 RUN apt-get update && \
     apt-get install -y ca-certificates curl sudo && \

--- a/cmd/examples.go
+++ b/cmd/examples.go
@@ -48,10 +48,10 @@ Java
 
 Docker
 	Record:
-	keployV2 record -c "docker run -p 8080:8080 --name <containerName> --network <networkName> --rm <applicationImage>"
+	keployV2 record -c "docker run -p 8080:8080 --name myContainerName --network myNetworkName --rm myApplicationImage"
 
 	Test:
-	keployV2 test -c "docker run -p 8080:8080  --name <containerName> --network <networkName> --rm <applicationImage>" --delay 1
+	keployV2 test -c "docker run -p 8080:8080  --name myContainerName --network myNetworkName --rm myApplicationImage" --delay 1
 `
 
 type Example struct {

--- a/cmd/examples.go
+++ b/cmd/examples.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+func NewCmdExample(logger *zap.Logger) *Example {
+	return &Example{
+		logger: logger,
+	}
+}
+
+var customHelpTemplate = `
+{{if .Example}}Examples:
+{{.Example}}
+{{end}}
+{{if .HasAvailableSubCommands}}Guided Commands:{{range .Commands}}{{if .IsAvailableCommand}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}
+{{end}}
+{{if .HasAvailableFlags}}Flags:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}
+{{end}}
+Use "{{.CommandPath}} [command] --help" for more information about a command.
+`
+
+var examples = `
+Golang Application
+	Record:
+	sudo -E keploy record -c "/path/to/user/app"
+	
+	Test:
+	sudo -E keploy test -c "/path/to/user/app" --delay 2
+
+Node Application
+	Record:
+	go run -exec "sudo -E"  <pathToKeployBinary> record -c “npm start --prefix /path/to/node/app"
+	
+	Test:
+	go run -exec "sudo -E"  <pathToKeployBinary> test -c “npm start --prefix /path/to/node/app" --delay 2
+
+Java 
+	Record:
+	sudo -E keploy <pathToKeployBinary> record -c "java -jar /path/to/java/jar"
+
+	Test:
+	sudo -E keploy <pathToKeployBinary> test -c "java -jar /path/to/java/jar" --delay 2
+
+Docker
+	Record:
+	keployV2 record -c "docker run -p 8080:8080 --name <containerName> --network <networkName> --rm <applicationImage>"
+
+	Test:
+	keployV2 test -c "docker run -p 8080:8080  --name <containerName> --network <networkName> --rm <applicationImage>" --delay 1
+`
+
+type Example struct {
+	logger *zap.Logger
+}
+
+func (r *Example) GetCmd() *cobra.Command {
+	var recordCmd = &cobra.Command{
+		Use:     "example",
+		Short:   "Example to record and test via keploy",
+		Example: examples,
+	}
+	recordCmd.SetHelpTemplate(customHelpTemplate)
+	return recordCmd
+}

--- a/cmd/examples.go
+++ b/cmd/examples.go
@@ -27,10 +27,10 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.
 var examples = `
 Golang Application
 	Record:
-	sudo -E keploy record -c "/path/to/user/app"
+	sudo -E keploy record -c "/path/to/user/app/binary"
 	
 	Test:
-	sudo -E keploy test -c "/path/to/user/app" --delay 2
+	sudo -E keploy test -c "/path/to/user/app/binary" --delay 2
 
 Node Application
 	Record:
@@ -41,10 +41,10 @@ Node Application
 
 Java 
 	Record:
-	sudo -E keploy <pathToKeployBinary> record -c "java -jar /path/to/java/jar"
+	sudo -E keploy <pathToKeployBinary> record -c "java -jar /path/to/java-project/target/jar"
 
 	Test:
-	sudo -E keploy <pathToKeployBinary> test -c "java -jar /path/to/java/jar" --delay 2
+	sudo -E keploy <pathToKeployBinary> test -c "java -jar  /path/to/java-project/target/jar" --delay 2
 
 Docker
 	Record:

--- a/cmd/examples.go
+++ b/cmd/examples.go
@@ -34,24 +34,28 @@ Golang Application
 
 Node Application
 	Record:
-	go run -exec "sudo -E"  <pathToKeployBinary> record -c “npm start --prefix /path/to/node/app"
+	sudo -E keploy record -c “npm start --prefix /path/to/node/app"
 	
 	Test:
-	go run -exec "sudo -E"  <pathToKeployBinary> test -c “npm start --prefix /path/to/node/app" --delay 2
+	sudo -E keploy test -c “npm start --prefix /path/to/node/app" --delay 2
 
 Java 
 	Record:
-	sudo -E keploy <pathToKeployBinary> record -c "java -jar /path/to/java-project/target/jar"
+	sudo -E keploy record -c "java -jar /path/to/java-project/target/jar"
 
 	Test:
-	sudo -E keploy <pathToKeployBinary> test -c "java -jar  /path/to/java-project/target/jar" --delay 2
+	sudo -E keploy test -c "java -jar /path/to/java-project/target/jar" --delay 2
 
 Docker
+	Alias:
+	alias keploy='sudo docker run --name keploy-ebpf -p 16789:16789 --network keploy-network --privileged --pid=host -it -v "$(pwd)":/files -v /sys/fs/cgroup:/sys/fs/cgroup
+	-v /sys/kernel/debug:/sys/kernel/debug -v /sys/fs/bpf:/sys/fs/bpf -v /var/run/docker.sock:/var/run/docker.sock --rm ghcr.io/keploy/keploy'
+
 	Record:
-	keployV2 record -c "docker run -p 8080:8080 --name myContainerName --network myNetworkName --rm myApplicationImage"
+	keploy record -c "docker run -p 8080:8080 --name myContainerName --network myNetworkName --rm myApplicationImage"
 
 	Test:
-	keployV2 test -c "docker run -p 8080:8080  --name myContainerName --network myNetworkName --rm myApplicationImage" --delay 1
+	keploy test -c "docker run -p 8080:8080  --name myContainerName --network myNetworkName --rm myApplicationImage" --delay 1
 `
 
 type Example struct {

--- a/cmd/record.go
+++ b/cmd/record.go
@@ -70,7 +70,7 @@ func (r *Record) GetCmd() *cobra.Command {
 			if appCmd == "" {
 				fmt.Println("Error: missing required -c flag\n")
 				if isDockerCmd {
-					fmt.Println("Example usage:\n", `keployV2 record -c "docker run -p 8080:808 --network myNetworkName --rm myApplicationImageName" --delay 6\n`)
+					fmt.Println("Example usage:\n", `keploy record -c "docker run -p 8080:808 --network myNetworkName --rm myApplicationImageName" --delay 6\n`)
 				}
 				fmt.Println("Example usage:\n", cmd.Example, "\n")
 
@@ -92,7 +92,7 @@ func (r *Record) GetCmd() *cobra.Command {
 				if !hasContainerName && appContainer == "" {
 					fmt.Println("Error: missing required --containerName flag")
 					if isDockerCmd {
-						fmt.Println("\nExample usage:\n", `keployV2 record -c "docker run -p 8080:808 --network myNetworkName --rm myApplicationImageName" --delay 6`)
+						fmt.Println("\nExample usage:\n", `keploy record -c "docker run -p 8080:808 --network myNetworkName --rm myApplicationImageName" --delay 6`)
 					} else {
 						fmt.Println("Example usage:\n", cmd.Example, "\n")
 					}

--- a/cmd/record.go
+++ b/cmd/record.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"go.keploy.io/server/pkg/service/record"
@@ -25,14 +28,16 @@ type Record struct {
 func (r *Record) GetCmd() *cobra.Command {
 	// record the keploy testcases/mocks for the user application
 	var recordCmd = &cobra.Command{
-		Use:   "record",
-		Short: "record the keploy testcases from the API calls",
-		Run: func(cmd *cobra.Command, args []string) {
+		Use:     "record",
+		Short:   "record the keploy testcases from the API calls",
+		Example: `sudo -E keploy record -c "/path/to/user/app"`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			isDockerCmd := len(os.Getenv("IS_DOCKER_CMD")) > 0
 
 			path, err := cmd.Flags().GetString("path")
 			if err != nil {
 				r.logger.Error(Emoji + "failed to read the testcase path input")
-				return
+				return err
 			}
 
 			//if user provides relative path
@@ -54,7 +59,6 @@ func (r *Record) GetCmd() *cobra.Command {
 
 			path += "/keploy"
 
-			r.logger.Info(Emoji, zap.Any("keploy test and mock path", path))
 			// tcsPath := path + "/tests"
 			// mockPath := path + "/mocks"
 
@@ -63,13 +67,38 @@ func (r *Record) GetCmd() *cobra.Command {
 			if err != nil {
 				r.logger.Error(Emoji+"Failed to get the command to run the user application", zap.Error((err)))
 			}
+			if appCmd == "" {
+				fmt.Println("Error: missing required -c flag\n")
+				if isDockerCmd {
+					fmt.Println("Example usage:\n", `keployV2 record -c "docker run -p 8080:808 --network myNetworkName --rm myApplicationImageName" --delay 6\n`)
+				}
+				fmt.Println("Example usage:\n", cmd.Example, "\n")
 
+				return errors.New("missing required -c flag")
+			}
 			appContainer, err := cmd.Flags().GetString("containerName")
 
 			if err != nil {
 				r.logger.Error(Emoji+"Failed to get the application's docker container name", zap.Error((err)))
 			}
-
+			var hasContainerName bool
+			if isDockerCmd {
+				for _, arg := range os.Args {
+					if strings.Contains(arg, "--name") {
+						hasContainerName = true
+						break
+					}
+				}
+				if !hasContainerName && appContainer == "" {
+					fmt.Println("Error: missing required --containerName flag")
+					if isDockerCmd {
+						fmt.Println("\nExample usage:\n", `keployV2 record -c "docker run -p 8080:808 --network myNetworkName --rm myApplicationImageName" --delay 6`)
+					} else {
+						fmt.Println("Example usage:\n", cmd.Example, "\n")
+					}
+					return errors.New("missing required --containerName flag")
+				}
+			}
 			networkName, err := cmd.Flags().GetString("networkName")
 
 			if err != nil {
@@ -82,9 +111,11 @@ func (r *Record) GetCmd() *cobra.Command {
 				r.logger.Error(Emoji+"Failed to get the delay flag", zap.Error((err)))
 			}
 
+			r.logger.Info(Emoji, zap.Any("keploy test and mock path", path))
+
 			// r.recorder.CaptureTraffic(tcsPath, mockPath, appCmd, appContainer, networkName, delay)
 			r.recorder.CaptureTraffic(path, appCmd, appContainer, networkName, delay)
-
+			return nil
 			// server.Server(version, kServices, conf, logger)
 			// server.Server(version)
 		},
@@ -107,6 +138,8 @@ func (r *Record) GetCmd() *cobra.Command {
 
 	recordCmd.Flags().Uint64P("delay", "d", 5, "User provided time to run its application")
 	// recordCmd.MarkFlagRequired("delay")
+	recordCmd.SilenceUsage = true
+	recordCmd.SilenceErrors = true
 
 	return recordCmd
 }

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -69,7 +69,7 @@ func (t *Test) GetCmd() *cobra.Command {
 			if appCmd == "" {
 				fmt.Println("Error: missing required -c flag\n")
 				if isDockerCmd {
-					fmt.Println("Example usage:\n", `keployV2 test -c "docker run -p 8080:808 --network myNetworkName --rm myApplicationImageName" --delay 6\n`)
+					fmt.Println("Example usage:\n", `keploy test -c "docker run -p 8080:808 --network myNetworkName --rm myApplicationImageName" --delay 6\n`)
 				}
 				fmt.Println("Example usage:\n", cmd.Example, "\n")
 
@@ -91,7 +91,7 @@ func (t *Test) GetCmd() *cobra.Command {
 				if !hasContainerName && appContainer == "" {
 					fmt.Println("Error: missing required --containerName flag")
 					if isDockerCmd {
-						fmt.Println("\nExample usage:\n", `keployV2 test -c "docker run -p 8080:808 --network myNetworkName --rm myApplicationImageName" --delay 6`)
+						fmt.Println("\nExample usage:\n", `keploy test -c "docker run -p 8080:808 --network myNetworkName --rm myApplicationImageName" --delay 6`)
 					} else {
 						fmt.Println("Example usage:\n", cmd.Example, "\n")
 					}
@@ -108,7 +108,7 @@ func (t *Test) GetCmd() *cobra.Command {
 			if delay <= 5 {
 				fmt.Printf("Warning: delay is set to %d seconds, incase your app takes more time to start udse --delay to set custom delay\n", delay)
 				if isDockerCmd {
-					fmt.Println("Example usage:\n", `keployV2 test -c "docker run -p 8080:808 --network myNetworkName --rm myApplicationImageName" --delay 6\n`)
+					fmt.Println("Example usage:\n", `keploy test -c "docker run -p 8080:808 --network myNetworkName --rm myApplicationImageName" --delay 6\n`)
 				} else {
 					fmt.Println("Example usage:\n", cmd.Example, "\n")
 				}


### PR DESCRIPTION
## Related Issue
  - Enhancing user experience by adding sample cases and updating logs

Closes: #694

#### Describe the changes you've made
Guiding when user enters wrong command, showing sample, adding support for debug mode.
## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **<img width="1362" alt="image" src="https://github.com/keploy/keploy/assets/60891544/6f4852f1-c7f9-4de9-a2cd-5904f1739fd0">** | <img width="1372" alt="image" src="https://github.com/keploy/keploy/assets/60891544/8a912e6c-52bd-4321-a33b-9f386f7834f2"> |
| **<img width="1376" alt="image" src="https://github.com/keploy/keploy/assets/60891544/314384da-4e83-4f0c-8dbe-b9190c5f1543">** | <img width="1292" alt="image" src="https://github.com/keploy/keploy/assets/60891544/152e2c9d-f673-4601-830c-e038cd337f06"> |
| **<img width="1368" alt="image" src="https://github.com/keploy/keploy/assets/60891544/540a510b-0676-424d-be73-e6d29959e20b">** | <img width="1222" alt="image" src="https://github.com/keploy/keploy/assets/60891544/94a45b30-22c0-438d-b7cb-4ba98194d6de"> |
|<img width="915" alt="image" src="https://github.com/keploy/keploy/assets/60891544/ab32db78-9dc5-455f-8417-24ffd0c7eafe">|<img width="1136" alt="image" src="https://github.com/keploy/keploy/assets/60891544/cc16c013-abfc-4694-bf89-459a24a9620e">|
|<img width="1155" alt="image" src="https://github.com/keploy/keploy/assets/60891544/b69273c5-7298-4720-8aff-f1255a28cf56">|<img width="980" alt="image" src="https://github.com/keploy/keploy/assets/60891544/6723f96b-c71e-4dab-ab36-67da23ef6a99">|
|<img width="1142" alt="image" src="https://github.com/keploy/keploy/assets/60891544/5214c3af-0200-4e4a-9c49-92b585c86c5c">|<img width="1150" alt="image" src="https://github.com/keploy/keploy/assets/60891544/e5d8f313-0de8-445b-b3c2-763bb36ac8ad">|