### PR TITLE
refactor: debug flag anywhere in cmd

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,6 +80,15 @@ Test:
 keployV2 test --c "docker run -p 8080:8080  --name <containerName> --network keploy-network --rm <applicationImage>" --delay 1
 `
 
+func checkForDebugFlag(args []string) bool {
+	for _, arg := range args {
+		if arg == "--debug" {
+			return true
+		}
+	}
+	return false
+}
+
 func (r *Root) execute() {
 
 	// Root command
@@ -95,10 +104,8 @@ func (r *Root) execute() {
 	rootCmd.PersistentFlags().BoolVar(&debugMode, "debug", false, "Run in debug mode")
 
 	// Manually parse flags to determine debug mode early
-	args := os.Args[1:]
-	rootCmd.ParseFlags(args)
-
-	// Now that flags are parsed, set up the logger
+	debugMode = checkForDebugFlag(os.Args[1:])
+	// Now that flags are parsed, set up the l722ogger
 	r.logger = setupLogger()
 
 	r.subCommands = append(r.subCommands, NewCmdExample(r.logger), NewCmdTest(r.logger), NewCmdRecord(r.logger))


### PR DESCRIPTION
## Related Issue
  - Debug flag can be used anywhere in cmd.

Closes: #722
#### Describe the changes you've made
This would enable the debug flag to be passed after as well as before the subcommands.
## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
