### PR TITLE
Add support for recording stubs in unit tests

### DIFF
--- a/cmd/mockrecord.go
+++ b/cmd/mockrecord.go
@@ -51,13 +51,7 @@ func (mr *MockRecord) GetCmd() *cobra.Command {
 				mr.logger.Debug(Emoji, zap.Any("testPath", path))
 			}
 
-			path += "/keploy"
-
-			delay, err := cmd.Flags().GetUint64("delay")
-
-			if err != nil {
-				mr.logger.Error(Emoji+"Failed to get the delay flag", zap.Error((err)))
-			}
+			path += "/stubs"
 
 			pid, err := cmd.Flags().GetUint32("pid")
 
@@ -65,13 +59,13 @@ func (mr *MockRecord) GetCmd() *cobra.Command {
 				mr.logger.Error(Emoji+"Failed to get the pid of the application", zap.Error((err)))
 			}
 
-			dir, err := cmd.Flags().GetString("testSuite")
+			dir, err := cmd.Flags().GetString("mockName")
 			if err != nil {
-				mr.logger.Error(Emoji + "failed to read the testSuite name")
+				mr.logger.Error(Emoji + "failed to read the mockName name")
 				return
 			}
 
-			mr.mockRecorder.MockRecord(path, delay, pid, dir)
+			mr.mockRecorder.MockRecord(path, pid, dir)
 		},
 	}
 
@@ -81,11 +75,8 @@ func (mr *MockRecord) GetCmd() *cobra.Command {
 	serveCmd.Flags().StringP("path", "p", "", "Path to local directory where generated testcases/mocks are stored")
 	serveCmd.MarkFlagRequired("path")
 
-	serveCmd.Flags().Uint64P("delay", "d", 5, "User provided time to run its application")
-	serveCmd.MarkFlagRequired("delay")
-
-	serveCmd.Flags().StringP("testSuite", "t", "", "User provided test suite")
-	serveCmd.MarkFlagRequired("testSuite")
+	serveCmd.Flags().StringP("mockName", "m", "", "User provided test suite")
+	serveCmd.MarkFlagRequired("mockName")
 
 	return serveCmd
 }

--- a/cmd/mockrecord.go
+++ b/cmd/mockrecord.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"go.keploy.io/server/pkg/service/mockrecord"
+	"go.uber.org/zap"
+)
+
+func NewCmdMockRecord(logger *zap.Logger) *MockRecord {
+	mockRecorder := mockrecord.NewMockRecorder(logger)
+	return &MockRecord{
+		mockRecorder: mockRecorder,
+		logger:       logger,
+	}
+}
+
+type MockRecord struct {
+	mockRecorder mockrecord.MockRecorder
+	logger       *zap.Logger
+}
+
+func (mr *MockRecord) GetCmd() *cobra.Command {
+	var serveCmd = &cobra.Command{
+		Use:   "mockRecord",
+		Short: "run the keploy server to record Mocks",
+		Run: func(cmd *cobra.Command, args []string) {
+
+			path, err := cmd.Flags().GetString("path")
+			if err != nil {
+				mr.logger.Error(Emoji + "failed to read the testset path input")
+				return
+			}
+
+			//if user provides relative path
+			if len(path) > 0 && path[0] != '/' {
+				absPath, err := filepath.Abs(path)
+				if err != nil {
+					mr.logger.Error(Emoji+"failed to get the absolute path from relative path", zap.Error(err))
+					return
+				}
+				path = absPath
+			} else if len(path) == 0 { // if user doesn't provide any path
+				err := fmt.Errorf("could not find the test case path, please provide a valid one")
+				mr.logger.Error(Emoji, zap.Any("testPath", path), zap.Error(err))
+				return
+			} else {
+				// user provided the absolute path
+				mr.logger.Debug(Emoji, zap.Any("testPath", path))
+			}
+
+			path += "/keploy"
+
+			delay, err := cmd.Flags().GetUint64("delay")
+
+			if err != nil {
+				mr.logger.Error(Emoji+"Failed to get the delay flag", zap.Error((err)))
+			}
+
+			pid, err := cmd.Flags().GetUint32("pid")
+
+			if err != nil {
+				mr.logger.Error(Emoji+"Failed to get the pid of the application", zap.Error((err)))
+			}
+
+			dir, err := cmd.Flags().GetString("testSuite")
+			if err != nil {
+				mr.logger.Error(Emoji + "failed to read the testSuite name")
+				return
+			}
+
+			mr.mockRecorder.MockRecord(path, delay, pid, dir)
+		},
+	}
+
+	serveCmd.Flags().Uint32("pid", 0, "Process id of your application.")
+	serveCmd.MarkFlagRequired("pid")
+
+	serveCmd.Flags().StringP("path", "p", "", "Path to local directory where generated testcases/mocks are stored")
+	serveCmd.MarkFlagRequired("path")
+
+	serveCmd.Flags().Uint64P("delay", "d", 5, "User provided time to run its application")
+	serveCmd.MarkFlagRequired("delay")
+
+	serveCmd.Flags().StringP("testSuite", "t", "", "User provided test suite")
+	serveCmd.MarkFlagRequired("testSuite")
+
+	return serveCmd
+}

--- a/cmd/mocktest.go
+++ b/cmd/mocktest.go
@@ -51,13 +51,7 @@ func (s *MockTest) GetCmd() *cobra.Command {
 				s.logger.Debug(Emoji, zap.Any("testPath", path))
 			}
 
-			path += "/keploy"
-
-			delay, err := cmd.Flags().GetUint64("delay")
-
-			if err != nil {
-				s.logger.Error(Emoji+"Failed to get the delay flag", zap.Error((err)))
-			}
+			path += "/stubs"
 
 			pid, err := cmd.Flags().GetUint32("pid")
 
@@ -65,13 +59,13 @@ func (s *MockTest) GetCmd() *cobra.Command {
 				s.logger.Error(Emoji+"Failed to get the pid of the application", zap.Error((err)))
 			}
 
-			dir, err := cmd.Flags().GetString("testSuite")
+			dir, err := cmd.Flags().GetString("mockName")
 			if err != nil {
-				s.logger.Error(Emoji + "failed to read the testSuite name")
+				s.logger.Error(Emoji + "failed to read the mockName name")
 				return
 			}
 
-			s.mockTester.MockTest(path, delay, pid, dir)
+			s.mockTester.MockTest(path, pid, dir)
 		},
 	}
 
@@ -81,11 +75,8 @@ func (s *MockTest) GetCmd() *cobra.Command {
 	serveCmd.Flags().StringP("path", "p", "", "Path to local directory where generated testcases/mocks are stored")
 	serveCmd.MarkFlagRequired("path")
 
-	serveCmd.Flags().Uint64P("delay", "d", 5, "User provided time to run its application")
-	serveCmd.MarkFlagRequired("delay")
-
-	serveCmd.Flags().StringP("testSuite", "t", "", "User provided test suite")
-	serveCmd.MarkFlagRequired("testSuite")
+	serveCmd.Flags().StringP("mockName", "m", "", "User provided test suite")
+	serveCmd.MarkFlagRequired("mockName")
 
 	return serveCmd
 }

--- a/cmd/mocktest.go
+++ b/cmd/mocktest.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"go.keploy.io/server/pkg/service/mocktest"
+	"go.uber.org/zap"
+)
+
+func NewCmdMockTest(logger *zap.Logger) *MockTest {
+	mockTester := mocktest.NewMockTester(logger)
+	return &MockTest{
+		mockTester: mockTester,
+		logger:     logger,
+	}
+}
+
+type MockTest struct {
+	mockTester mocktest.MockTester
+	logger     *zap.Logger
+}
+
+func (s *MockTest) GetCmd() *cobra.Command {
+	var serveCmd = &cobra.Command{
+		Use:   "mockTest",
+		Short: "run the keploy server to test Mocks",
+		Run: func(cmd *cobra.Command, args []string) {
+
+			path, err := cmd.Flags().GetString("path")
+			if err != nil {
+				s.logger.Error(Emoji + "failed to read the testset path input")
+				return
+			}
+
+			//if user provides relative path
+			if len(path) > 0 && path[0] != '/' {
+				absPath, err := filepath.Abs(path)
+				if err != nil {
+					s.logger.Error(Emoji+"failed to get the absolute path from relative path", zap.Error(err))
+					return
+				}
+				path = absPath
+			} else if len(path) == 0 { // if user doesn't provide any path
+				err := fmt.Errorf("could not find the test case path, please provide a valid one")
+				s.logger.Error(Emoji, zap.Any("testPath", path), zap.Error(err))
+				return
+			} else {
+				// user provided the absolute path
+				s.logger.Debug(Emoji, zap.Any("testPath", path))
+			}
+
+			path += "/keploy"
+
+			delay, err := cmd.Flags().GetUint64("delay")
+
+			if err != nil {
+				s.logger.Error(Emoji+"Failed to get the delay flag", zap.Error((err)))
+			}
+
+			pid, err := cmd.Flags().GetUint32("pid")
+
+			if err != nil {
+				s.logger.Error(Emoji+"Failed to get the pid of the application", zap.Error((err)))
+			}
+
+			dir, err := cmd.Flags().GetString("testSuite")
+			if err != nil {
+				s.logger.Error(Emoji + "failed to read the testSuite name")
+				return
+			}
+
+			s.mockTester.MockTest(path, delay, pid, dir)
+		},
+	}
+
+	serveCmd.Flags().Uint32("pid", 0, "Process id of your application.")
+	serveCmd.MarkFlagRequired("pid")
+
+	serveCmd.Flags().StringP("path", "p", "", "Path to local directory where generated testcases/mocks are stored")
+	serveCmd.MarkFlagRequired("path")
+
+	serveCmd.Flags().Uint64P("delay", "d", 5, "User provided time to run its application")
+	serveCmd.MarkFlagRequired("delay")
+
+	serveCmd.Flags().StringP("testSuite", "t", "", "User provided test suite")
+	serveCmd.MarkFlagRequired("testSuite")
+
+	return serveCmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -124,7 +124,7 @@ func (r *Root) execute() {
 	// Now that flags are parsed, set up the l722ogger
 	r.logger = setupLogger()
 
-	r.subCommands = append(r.subCommands, NewCmdRecord(r.logger), NewCmdTest(r.logger), NewCmdServe(r.logger), NewCmdExample(r.logger))
+	r.subCommands = append(r.subCommands, NewCmdRecord(r.logger), NewCmdTest(r.logger), NewCmdServe(r.logger), NewCmdExample(r.logger), NewCmdMockRecord(r.logger), NewCmdMockTest(r.logger))
 
 	// add the registered keploy plugins as subcommands to the rootCmd
 	for _, sc := range r.subCommands {

--- a/pkg/hooks/connection/factory.go
+++ b/pkg/hooks/connection/factory.go
@@ -37,7 +37,7 @@ func NewFactory(inactivityThreshold time.Duration, logger *zap.Logger) *Factory 
 
 // func (factory *Factory) HandleReadyConnections(k *keploy.Keploy) {
 // func (factory *Factory) HandleReadyConnections(path string, db platform.TestCaseDB, getDeps func() []*models.Mock, resetDeps func() int) {
-func (factory *Factory) HandleReadyConnections(path string, db platform.TestCaseDB) {
+func (factory *Factory) HandleReadyConnections(db platform.TestCaseDB) {
 
 	factory.mutex.Lock()
 	defer factory.mutex.Unlock()
@@ -63,7 +63,7 @@ func (factory *Factory) HandleReadyConnections(path string, db platform.TestCase
 			case models.MODE_RECORD:
 				// capture the ingress call for record cmd
 				factory.logger.Debug("capturing ingress call from tracker in record mode")
-				capture(path, db, parsedHttpReq, parsedHttpRes, factory.logger)
+				capture(db, parsedHttpReq, parsedHttpRes, factory.logger)
 			case models.MODE_TEST:
 				factory.logger.Debug("skipping tracker in test mode")
 			default:
@@ -95,7 +95,7 @@ func (factory *Factory) GetOrCreate(connectionID structs.ConnID) *Tracker {
 	return tracker
 }
 
-func capture(path string, db platform.TestCaseDB, req *http.Request, resp *http.Response, logger *zap.Logger) {
+func capture(db platform.TestCaseDB, req *http.Request, resp *http.Response, logger *zap.Logger) {
 	// meta := map[string]string{
 	// 	"method": req.Method,
 	// }
@@ -128,7 +128,7 @@ func capture(path string, db platform.TestCaseDB, req *http.Request, resp *http.
 	// }
 
 	// err = db.Insert(httpMock, getDeps())
-	err = db.WriteTestcase(path, &models.TestCase{
+	err = db.WriteTestcase(&models.TestCase{
 		Version: models.V1Beta2,
 		Name:    "",
 		Kind:    models.HTTP,

--- a/pkg/platform/interface.go
+++ b/pkg/platform/interface.go
@@ -3,11 +3,8 @@ package platform
 import "go.keploy.io/server/pkg/models"
 
 type TestCaseDB interface {
-	WriteTestcase(path string, tc *models.TestCase) error
-	WriteMock(path string, tc *models.Mock) error
-
-	NewSessionIndex(path string) (string, error)
-	ReadSessionIndices(path string) ([]string, error)
+	WriteTestcase(tc *models.TestCase) error
+	WriteMock(tc *models.Mock) error
 
 	ReadTestcase(path string, options interface{}) ([]*models.TestCase, error)
 	ReadMocks(path string) ([]*models.Mock, []*models.Mock, error)

--- a/pkg/platform/yaml/utils.go
+++ b/pkg/platform/yaml/utils.go
@@ -329,9 +329,6 @@ func ValidatePath(path string) (string, error) {
 	if strings.Contains(path, "..") {
 		return "", errors.New("invalid path: contains '..' indicating directory traversal")
 	}
-	if strings.ContainsAny(path, "/\\") {
-		return "", errors.New("invalid path: contains directory separators")
-	}
 	if strings.Count(path, ".") > 1 {
 		return "", errors.New("invalid path: contains more than one '.' character")
 	}

--- a/pkg/platform/yaml/utils.go
+++ b/pkg/platform/yaml/utils.go
@@ -2,6 +2,7 @@ package yaml
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"net/http"
@@ -282,7 +283,7 @@ func NewSessionIndex(path string, Logger *zap.Logger) (string, error) {
 				Logger.Debug("failed to convert the index string to integer", zap.Error(err))
 				continue
 			}
-			if indx < fileIndx + 1 {
+			if indx < fileIndx+1 {
 				indx = fileIndx + 1
 			}
 		}
@@ -321,4 +322,18 @@ func ReadSessionIndices(path string, Logger *zap.Logger) ([]string, error) {
 		}
 	}
 	return indices, nil
+}
+
+func ValidatePath(path string) error {
+	// Validate the input to prevent directory traversal attack
+	if strings.Contains(path, "..") {
+		return errors.New("invalid path: contains '..' indicating directory traversal")
+	}
+	if strings.ContainsAny(path, "/\\") {
+		return errors.New("invalid path: contains directory separators")
+	}
+	if strings.Count(path, ".") > 1 {
+		return errors.New("invalid path: contains more than one '.' character")
+	}
+	return nil
 }

--- a/pkg/platform/yaml/utils.go
+++ b/pkg/platform/yaml/utils.go
@@ -324,16 +324,16 @@ func ReadSessionIndices(path string, Logger *zap.Logger) ([]string, error) {
 	return indices, nil
 }
 
-func ValidatePath(path string) error {
+func ValidatePath(path string) (string, error) {
 	// Validate the input to prevent directory traversal attack
 	if strings.Contains(path, "..") {
-		return errors.New("invalid path: contains '..' indicating directory traversal")
+		return "", errors.New("invalid path: contains '..' indicating directory traversal")
 	}
 	if strings.ContainsAny(path, "/\\") {
-		return errors.New("invalid path: contains directory separators")
+		return "", errors.New("invalid path: contains directory separators")
 	}
 	if strings.Count(path, ".") > 1 {
-		return errors.New("invalid path: contains more than one '.' character")
+		return "", errors.New("invalid path: contains more than one '.' character")
 	}
-	return nil
+	return path, nil
 }

--- a/pkg/platform/yaml/yaml.go
+++ b/pkg/platform/yaml/yaml.go
@@ -7,7 +7,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -21,18 +20,21 @@ import (
 var Emoji = "\U0001F430" + " Keploy:"
 
 type Yaml struct {
-	// tcsPath  string
-	// mockPath string
-	// path string
-	Logger *zap.Logger
+	TcsPath  string
+	MockPath string
+	MockName string
+	TcsName  string
+	Logger   *zap.Logger
 }
 
 // func NewYamlStore(tcsPath, mockPath string, Logger *zap.Logger) platform.TestCaseDB {
-func NewYamlStore(Logger *zap.Logger) platform.TestCaseDB {
+func NewYamlStore(tcsPath string, mockPath string, tcsName string, mockName string, Logger *zap.Logger) platform.TestCaseDB {
 	return &Yaml{
-		// tcsPath:  tcsPath,
-		// mockPath: mockPath,
-		Logger: Logger,
+		TcsPath:  tcsPath,
+		MockPath: mockPath,
+		MockName: mockName,
+		TcsName:  tcsName,
+		Logger:   Logger,
 	}
 }
 
@@ -151,15 +153,18 @@ func (ys *Yaml) Write(path, fileName string, doc NetworkTrafficDoc) error {
 }
 
 // func (ys *yaml) Insert(tc *models.Mock, mocks []*models.Mock) error {
-func (ys *Yaml) WriteTestcase(path string, tc *models.TestCase) error {
+func (ys *Yaml) WriteTestcase(tc *models.TestCase) error {
 
-	// testcases are stored in one directory for a session
-	path += "/tests"
-
-	// finds the recently generated testcase to derive the sequence number for the current testcase
-	lastIndx, err := findLastIndex(path, ys.Logger)
-	if err != nil {
-		return err
+	var tcsName string
+	if ys.TcsName == "" {
+		// finds the recently generated testcase to derive the sequence number for the current testcase
+		lastIndx, err := findLastIndex(ys.TcsPath, ys.Logger)
+		if err != nil {
+			return err
+		}
+		tcsName = fmt.Sprintf("test-%v", lastIndx)
+	} else {
+		tcsName = ys.TcsName
 	}
 
 	// encode the testcase and its mocks into yaml docs
@@ -170,14 +175,13 @@ func (ys *Yaml) WriteTestcase(path string, tc *models.TestCase) error {
 	}
 
 	// write testcase yaml
-	tcName := fmt.Sprintf("test-%v", lastIndx)
-	yamlTc.Name = tcName
-	err = ys.Write(path, tcName, *yamlTc)
+	yamlTc.Name = tcsName
+	err = ys.Write(ys.TcsPath, tcsName, *yamlTc)
 	if err != nil {
 		ys.Logger.Error("failed to write testcase yaml file", zap.Error(err))
 		return err
 	}
-	ys.Logger.Info("🟠 Keploy has captured test cases for the user's application.", zap.String("path", path), zap.String("testcase name", tcName))
+	ys.Logger.Info("🟠 Keploy has captured test cases for the user's application.", zap.String("path", ys.TcsPath), zap.String("testcase name", ys.TcsName))
 
 	// write the mock yamls
 	// mockName := fmt.Sprintf("mock-%v", lastIndx)
@@ -192,14 +196,17 @@ func (ys *Yaml) WriteTestcase(path string, tc *models.TestCase) error {
 	// if len(yamlMocks) > 0 {
 	// 	ys.Logger.Info("🟠 Keploy has recorded mocks for the external calls of user's application", zap.String("path", ys.mockPath), zap.String("mock name", mockName))
 	// }
-
 	return nil
 }
 
 // func (ys *yaml) Read (options interface{}) ([]models.Mock,  map[string][]models.Mock, error) {
 func (ys *Yaml) ReadTestcase(path string, options interface{}) ([]*models.TestCase, error) {
-	tcs := []*models.TestCase{}
 
+	if path == "" {
+		path = ys.TcsPath
+	}
+
+	tcs := []*models.TestCase{}
 	// tcsPath := filepath.Join(path, "tests")
 
 	_, err := os.Stat(path)
@@ -297,83 +304,31 @@ func read(path, name string) ([]*NetworkTrafficDoc, error) {
 	return yamlDocs, nil
 }
 
-func (ys *Yaml) WriteMock(path string, mock *models.Mock) error {
+func (ys *Yaml) WriteMock(mock *models.Mock) error {
+
+	if ys.MockName != "" {
+		if mock.Name != "" {
+			mock.Name = ys.MockName + "-" + mock.Name
+		} else {
+			mock.Name = ys.MockName
+		}
+	}
+
 	mockYaml, err := EncodeMock(mock, ys.Logger)
 	if err != nil {
 		return err
 	}
+
 	if mock.Name == "" {
 		mock.Name = "mocks"
 	}
-	err = ys.Write(path, mock.Name, *mockYaml)
+
+	err = ys.Write(ys.MockPath, mock.Name, *mockYaml)
 	if err != nil {
 		return err
 	}
+
 	return nil
-}
-
-func (ys *Yaml) NewSessionIndex(path string) (string, error) {
-	indx := 0
-	dir, err := os.OpenFile(path, os.O_RDONLY, fs.FileMode(os.O_RDONLY))
-	if err != nil {
-		ys.Logger.Debug("creating a folder for the keploy generated testcases", zap.Error(err))
-		return fmt.Sprintf("test-set-%v", indx), nil
-	}
-
-	files, err := dir.ReadDir(0)
-	if err != nil {
-		return "", err
-	}
-
-	for _, v := range files {
-		// fmt.Println("name for the file", v.Name())
-		fileName := filepath.Base(v.Name())
-		fileNamePackets := strings.Split(fileName, "-")
-		if len(fileNamePackets) == 3 {
-			fileIndx, err := strconv.Atoi(fileNamePackets[2])
-			if err != nil {
-				ys.Logger.Debug("failed to convert the index string to integer", zap.Error(err))
-				continue
-			}
-			if indx < fileIndx+1 {
-				indx = fileIndx + 1
-			}
-		}
-	}
-	return fmt.Sprintf("test-set-%v", indx), nil
-}
-
-func (ys *Yaml) ReadSessionIndices(path string) ([]string, error) {
-	indices := []string{}
-	dir, err := os.OpenFile(path, os.O_RDONLY, fs.FileMode(os.O_RDONLY))
-	if err != nil {
-		ys.Logger.Debug("creating a folder for the keploy generated testcases", zap.Error(err))
-		return indices, nil
-	}
-
-	files, err := dir.ReadDir(0)
-	if err != nil {
-		return indices, err
-	}
-
-	for _, v := range files {
-		// Define the regular expression pattern
-		pattern := `^test-set-\d{1,}$`
-
-		// Compile the regular expression
-		regex, err := regexp.Compile(pattern)
-		if err != nil {
-			return indices, err
-		}
-
-		// Check if the string matches the pattern
-		if regex.MatchString(v.Name()) {
-			// fmt.Println("name for the file", v.Name())
-
-			indices = append(indices, v.Name())
-		}
-	}
-	return indices, nil
 }
 
 func (ys *Yaml) ReadMocks(path string) ([]*models.Mock, []*models.Mock, error) {
@@ -382,13 +337,22 @@ func (ys *Yaml) ReadMocks(path string) ([]*models.Mock, []*models.Mock, error) {
 		tcsMocks    = []*models.Mock{}
 	)
 
-	if _, err := os.Stat(filepath.Join(path, "config.yaml")); err == nil {
+	if path == "" {
+		path = ys.MockPath
+	}
+
+	configMockName := "config"
+	if ys.MockName != "" {
+		configMockName = ys.MockName + "-config"
+	}
+
+	if _, err := os.Stat(filepath.Join(path, configMockName+".yaml")); err == nil {
 		// _, err := os.Stat(filepath.Join(path, "config.yaml"))
 		// if err != nil {
 		// 	ys.Logger.Error("failed to find the config yaml", zap.Error(err))
 		// 	return nil, nil, err
 		// }
-		configYamls, err := read(path, "config")
+		configYamls, err := read(path, configMockName)
 		if err != nil {
 			ys.Logger.Error("failed to read the mocks from config yaml", zap.Error(err), zap.Any("session", filepath.Base(path)))
 			return nil, nil, err
@@ -400,13 +364,18 @@ func (ys *Yaml) ReadMocks(path string) ([]*models.Mock, []*models.Mock, error) {
 		}
 	}
 
-	if _, err := os.Stat(filepath.Join(path, "mocks.yaml")); err == nil {
+	mockName := "mocks"
+	if ys.MockName != "" {
+		mockName = ys.MockName + "-mocks"
+	}
+
+	if _, err := os.Stat(filepath.Join(path, mockName+".yaml")); err == nil {
 		// _, err = os.Stat(filepath.Join(path, "mocks.yaml"))
 		// if err != nil {
 		// 	ys.Logger.Error("failed to find the mock yaml", zap.Error(err))
 		// 	return nil, nil, err
 		// }
-		mockYamls, err := read(path, "mocks")
+		mockYamls, err := read(path, mockName)
 		if err != nil {
 			ys.Logger.Error("failed to read the mocks from yaml for testcases", zap.Error(err), zap.Any("session", filepath.Base(path)))
 			return nil, nil, err

--- a/pkg/platform/yaml/yaml.go
+++ b/pkg/platform/yaml/yaml.go
@@ -346,6 +346,20 @@ func (ys *Yaml) ReadMocks(path string) ([]*models.Mock, []*models.Mock, error) {
 		configMockName = ys.MockName + "-config"
 	}
 
+	mockName := "mocks"
+	if ys.MockName != "" {
+		mockName = ys.MockName + "-mocks"
+	}
+
+	err := ValidatePath(path + "/" + configMockName + ".yaml")
+	if err != nil {
+		return nil, nil, err
+	}
+	err = ValidatePath(path + "/" + mockName + ".yaml")
+	if err != nil {
+		return nil, nil, err
+	}
+
 	if _, err := os.Stat(path + "/" + configMockName + ".yaml"); err == nil {
 		// _, err := os.Stat(filepath.Join(path, "config.yaml"))
 		// if err != nil {
@@ -362,11 +376,6 @@ func (ys *Yaml) ReadMocks(path string) ([]*models.Mock, []*models.Mock, error) {
 			ys.Logger.Error("failed to decode the config mocks from yaml docs", zap.Error(err), zap.Any("session", filepath.Base(path)))
 			return nil, nil, err
 		}
-	}
-
-	mockName := "mocks"
-	if ys.MockName != "" {
-		mockName = ys.MockName + "-mocks"
 	}
 
 	if _, err := os.Stat(path + "/" + mockName + ".yaml"); err == nil {

--- a/pkg/platform/yaml/yaml.go
+++ b/pkg/platform/yaml/yaml.go
@@ -351,16 +351,16 @@ func (ys *Yaml) ReadMocks(path string) ([]*models.Mock, []*models.Mock, error) {
 		mockName = ys.MockName + "-mocks"
 	}
 
-	err := ValidatePath(path + "/" + configMockName + ".yaml")
+	configMockPath, err := ValidatePath(path + "/" + configMockName + ".yaml")
 	if err != nil {
 		return nil, nil, err
 	}
-	err = ValidatePath(path + "/" + mockName + ".yaml")
+	mockPath, err := ValidatePath(path + "/" + mockName + ".yaml")
 	if err != nil {
 		return nil, nil, err
 	}
 
-	if _, err := os.Stat(path + "/" + configMockName + ".yaml"); err == nil {
+	if _, err := os.Stat(configMockPath); err == nil {
 		// _, err := os.Stat(filepath.Join(path, "config.yaml"))
 		// if err != nil {
 		// 	ys.Logger.Error("failed to find the config yaml", zap.Error(err))
@@ -378,7 +378,7 @@ func (ys *Yaml) ReadMocks(path string) ([]*models.Mock, []*models.Mock, error) {
 		}
 	}
 
-	if _, err := os.Stat(path + "/" + mockName + ".yaml"); err == nil {
+	if _, err := os.Stat(mockPath); err == nil {
 		// _, err = os.Stat(filepath.Join(path, "mocks.yaml"))
 		// if err != nil {
 		// 	ys.Logger.Error("failed to find the mock yaml", zap.Error(err))

--- a/pkg/platform/yaml/yaml.go
+++ b/pkg/platform/yaml/yaml.go
@@ -346,7 +346,7 @@ func (ys *Yaml) ReadMocks(path string) ([]*models.Mock, []*models.Mock, error) {
 		configMockName = ys.MockName + "-config"
 	}
 
-	if _, err := os.Stat(filepath.Join(path, configMockName+".yaml")); err == nil {
+	if _, err := os.Stat(path + "/" + configMockName + ".yaml"); err == nil {
 		// _, err := os.Stat(filepath.Join(path, "config.yaml"))
 		// if err != nil {
 		// 	ys.Logger.Error("failed to find the config yaml", zap.Error(err))
@@ -369,7 +369,7 @@ func (ys *Yaml) ReadMocks(path string) ([]*models.Mock, []*models.Mock, error) {
 		mockName = ys.MockName + "-mocks"
 	}
 
-	if _, err := os.Stat(filepath.Join(path, mockName+".yaml")); err == nil {
+	if _, err := os.Stat(path + "/" + mockName + ".yaml"); err == nil {
 		// _, err = os.Stat(filepath.Join(path, "mocks.yaml"))
 		// if err != nil {
 		// 	ys.Logger.Error("failed to find the mock yaml", zap.Error(err))

--- a/pkg/proxy/integrations/mongoparser/mongoparser.go
+++ b/pkg/proxy/integrations/mongoparser/mongoparser.go
@@ -547,12 +547,15 @@ func recordMessage(h *hooks.Hook, requestBuffer, responseBuffer []byte, logStr s
 
 	shouldRecordCalls := true
 	name := "mocks"
+	meta1 := map[string]string{
+		"operation": opReq.String(),
+	}
 
 	// Skip heartbeat from capturing in the global set of mocks. Since, the heartbeat packet always contain the "hello" boolean.
 	// See: https://github.com/mongodb/mongo-go-driver/blob/8489898c64a2d8c2e2160006eb851a11a9db9e9d/x/mongo/driver/operation/hello.go#L503
 	// if strings.Contains(opReq.String(), "helloOk") || strings.Contains(opReq.String(), "hello") {
 	if isHeartBeat(opReq, *mongoRequests[0].Header, mongoRequests[0].Message) {
-		name = "config"
+		meta1["type"] = "config"
 		// isHeartbeatRecorded := false
 		for _, v := range configRequests {
 			// requestHeader.
@@ -583,9 +586,6 @@ func recordMessage(h *hooks.Hook, requestBuffer, responseBuffer []byte, logStr s
 		}
 	}
 	if shouldRecordCalls {
-		meta1 := map[string]string{
-			"operation": opReq.String(),
-		}
 		mongoMock := &models.Mock{
 			Version: models.V1Beta2,
 			Kind:    models.Mongo,

--- a/pkg/proxy/integrations/postgresParser/utils.go
+++ b/pkg/proxy/integrations/postgresParser/utils.go
@@ -11,7 +11,6 @@ import (
 	"unicode"
 
 	"github.com/agnivade/levenshtein"
-	"github.com/cloudflare/cfssl/log"
 	"go.keploy.io/server/pkg/hooks"
 	"go.keploy.io/server/pkg/models"
 	"go.uber.org/zap"
@@ -88,59 +87,59 @@ func IdentifyPacket(data []byte) (models.Packet, error) {
 	return nil, errors.New("unknown packet type or data too short for declared length")
 }
 
-// improve the matching by the headers , and the body of the request. Use pgproto3 library to encode and decode
-func tempMatching(configMocks, tcsMocks []*models.Mock, reqBuff []byte, h *hooks.Hook) (bool, string) {
-	//first check if the request is a startup packet
-	com := PostgresEncoder(reqBuff)
+// // improve the matching by the headers , and the body of the request. Use pgproto3 library to encode and decode
+// func tempMatching(configMocks, tcsMocks []*models.Mock, reqBuff []byte, h *hooks.Hook) (bool, string) {
+// 	//first check if the request is a startup packet
+// 	com := PostgresEncoder(reqBuff)
 
-	for idx, mock := range configMocks {
-		encoded, _ := PostgresDecoder(mock.Spec.PostgresReq.Payload)
-		// if _, ok := maps[mock.Spec.PostgresResp.Payload]; ok {
-		// 	continue
-		// }
-		if string(encoded) == string(reqBuff) || mock.Spec.PostgresReq.Payload == com {
-			log.Debug(Emoji,"matched in first loop")
+// 	for idx, mock := range configMocks {
+// 		encoded, _ := PostgresDecoder(mock.Spec.PostgresReq.Payload)
+// 		// if _, ok := maps[mock.Spec.PostgresResp.Payload]; ok {
+// 		// 	continue
+// 		// }
+// 		if string(encoded) == string(reqBuff) || mock.Spec.PostgresReq.Payload == com {
+// 			log.Debug(Emoji,"matched in first loop")
 
-			configMocks = append(configMocks[:idx], configMocks[idx+1:]...)
-			h.SetConfigMocks(configMocks)
-			return true, mock.Spec.PostgresResp.Payload
-		}
-		i := 0
-		// instead of this match with actual data
-		for i = 0; i < len(com); i++ {
-			if com[i] != mock.Spec.PostgresReq.Payload[i] {
-				break
-			}
-		}
-		if i >= 8 {
-			log.Debug(Emoji,"matched in second loop")
+// 			configMocks = append(configMocks[:idx], configMocks[idx+1:]...)
+// 			h.SetConfigMocks(configMocks)
+// 			return true, mock.Spec.PostgresResp.Payload
+// 		}
+// 		i := 0
+// 		// instead of this match with actual data
+// 		for i = 0; i < len(com); i++ {
+// 			if com[i] != mock.Spec.PostgresReq.Payload[i] {
+// 				break
+// 			}
+// 		}
+// 		if i >= 8 {
+// 			log.Debug(Emoji,"matched in second loop")
 
-			configMocks = append(configMocks[:idx], configMocks[idx+1:]...)
-			h.SetConfigMocks(configMocks)
-			return true, mock.Spec.PostgresResp.Payload
-		}
-	}
+// 			configMocks = append(configMocks[:idx], configMocks[idx+1:]...)
+// 			h.SetConfigMocks(configMocks)
+// 			return true, mock.Spec.PostgresResp.Payload
+// 		}
+// 	}
 
-	// fmt.Println("encoded request is :",com)
-	// from mocks
-	for _, mock := range tcsMocks {
-		encoded, _ := PostgresDecoder(mock.Spec.PostgresReq.Payload)
-		if string(encoded) == string(reqBuff) {
-			return true, mock.Spec.PostgresResp.Payload
-		}
-		i := 0
-		for i = 0; i < len(com); i++ {
-			if com[i] == mock.Spec.PostgresReq.Payload[i] {
-				log.Debug(Emoji,"matched in second loop")
-			}
-		}
-		if i >= len(com)/2 {
-			return true, mock.Spec.PostgresResp.Payload
-		}
-	}
+// 	// fmt.Println("encoded request is :",com)
+// 	// from mocks
+// 	for _, mock := range tcsMocks {
+// 		encoded, _ := PostgresDecoder(mock.Spec.PostgresReq.Payload)
+// 		if string(encoded) == string(reqBuff) {
+// 			return true, mock.Spec.PostgresResp.Payload
+// 		}
+// 		i := 0
+// 		for i = 0; i < len(com); i++ {
+// 			if com[i] == mock.Spec.PostgresReq.Payload[i] {
+// 				log.Debug(Emoji,"matched in second loop")
+// 			}
+// 		}
+// 		if i >= len(com)/2 {
+// 			return true, mock.Spec.PostgresResp.Payload
+// 		}
+// 	}
 
-	return false, ""
-}
+// 	return false, ""
+// }
 
 type Request struct {
 	Data     []byte
@@ -348,7 +347,7 @@ func ChangeAuthToMD5(tcsMocks []*models.Mock, h *hooks.Hook, log *zap.Logger) {
 			// bufStr := base64.StdEncoding.EncodeToString(reqBuff)
 			// }
 			encode, _ := PostgresDecoder(reqBuff.Message[0].Data)
-			if isStartupPacket(encode) && checkScram(mock.Spec.GenericResponses[requestIndex].Message[0].Data,log) { //||reqBuff.Message[0].Data == "AAAAeAADAAB1c2VyAGtlcGxveS11c2VyAGRhdGFiYXNlAGtlcGxveS10ZXN0AGNsaWVudF9lbmNvZGluZwBVVEY4AERhdGVTdHlsZQBJU08AVGltZVpvbmUARXRjL1VUQwBleHRyYV9mbG9hdF9kaWdpdHMAMgAA" {
+			if isStartupPacket(encode) && checkScram(mock.Spec.GenericResponses[requestIndex].Message[0].Data, log) { //||reqBuff.Message[0].Data == "AAAAeAADAAB1c2VyAGtlcGxveS11c2VyAGRhdGFiYXNlAGtlcGxveS10ZXN0AGNsaWVudF9lbmNvZGluZwBVVEY4AERhdGVTdHlsZQBJU08AVGltZVpvbmUARXRjL1VUQwBleHRyYV9mbG9hdF9kaWdpdHMAMgAA" {
 				log.Debug("CHANGING TO MD5 for Response")
 				mock.Spec.GenericResponses[requestIndex].Message[0].Data = "UgAAAAwAAAAF4I8BHg=="
 			}

--- a/pkg/service/mockrecord/mockrecord.go
+++ b/pkg/service/mockrecord/mockrecord.go
@@ -3,6 +3,7 @@ package mockrecord
 import (
 	"sync"
 
+	"go.keploy.io/server/pkg"
 	"go.keploy.io/server/pkg/hooks"
 	"go.keploy.io/server/pkg/models"
 	"go.keploy.io/server/pkg/platform/yaml"
@@ -29,17 +30,19 @@ func (s *mockRecorder) MockRecord(path string, pid uint32, mockName string) {
 	models.SetMode(models.MODE_RECORD)
 	ys := yaml.NewYamlStore(path, path, "", mockName, s.logger)
 
+	routineId := pkg.GenerateRandomID()
+
 	// Initiate the hooks
-	loadedHooks := hooks.NewHook(ys, s.logger)
+	loadedHooks := hooks.NewHook(ys, routineId, s.logger)
 	if err := loadedHooks.LoadHooks("", "", pid); err != nil {
 		return
 	}
 
 	// start the proxy
-	ps := proxy.BootProxy(s.logger, proxy.Option{}, "", "", pid, "", []uint{})
+	ps := proxy.BootProxy(s.logger, proxy.Option{}, "", "", pid, "", []uint{}, loadedHooks)
 
 	// proxy update its state in the ProxyPorts map
-	ps.SetHook(loadedHooks)
+	// ps.SetHook(loadedHooks)
 
 	// Sending Proxy Ip & Port to the ebpf program
 	if err := loadedHooks.SendProxyInfo(ps.IP4, ps.Port, ps.IP6); err != nil {

--- a/pkg/service/mockrecord/mockrecord.go
+++ b/pkg/service/mockrecord/mockrecord.go
@@ -28,7 +28,7 @@ func (s *mockRecorder) MockRecord(path string, Delay uint64, pid uint32, dirName
 
 	models.SetMode(models.MODE_RECORD)
 	ys := yaml.NewYamlStore(s.logger)
-	
+
 	path += "/" + dirName
 
 	// Initiate the hooks
@@ -38,7 +38,7 @@ func (s *mockRecorder) MockRecord(path string, Delay uint64, pid uint32, dirName
 	}
 
 	// start the proxy
-	ps := proxy.BootProxies(s.logger, proxy.Option{}, "", "")
+	ps := proxy.BootProxy(s.logger, proxy.Option{}, "", "", pid, "")
 
 	// proxy update its state in the ProxyPorts map
 	ps.SetHook(loadedHooks)

--- a/pkg/service/mockrecord/mockrecord.go
+++ b/pkg/service/mockrecord/mockrecord.go
@@ -24,21 +24,19 @@ func NewMockRecorder(logger *zap.Logger) MockRecorder {
 	}
 }
 
-func (s *mockRecorder) MockRecord(path string, Delay uint64, pid uint32, dirName string) {
+func (s *mockRecorder) MockRecord(path string, pid uint32, mockName string) {
 
 	models.SetMode(models.MODE_RECORD)
-	ys := yaml.NewYamlStore(s.logger)
-
-	path += "/" + dirName
+	ys := yaml.NewYamlStore(path, path, "", mockName, s.logger)
 
 	// Initiate the hooks
-	loadedHooks := hooks.NewHook(path, ys, s.logger)
+	loadedHooks := hooks.NewHook(ys, s.logger)
 	if err := loadedHooks.LoadHooks("", "", pid); err != nil {
 		return
 	}
 
 	// start the proxy
-	ps := proxy.BootProxy(s.logger, proxy.Option{}, "", "", pid, "")
+	ps := proxy.BootProxy(s.logger, proxy.Option{}, "", "", pid, "", []uint{})
 
 	// proxy update its state in the ProxyPorts map
 	ps.SetHook(loadedHooks)

--- a/pkg/service/mockrecord/mockrecord.go
+++ b/pkg/service/mockrecord/mockrecord.go
@@ -1,0 +1,54 @@
+package mockrecord
+
+import (
+	"sync"
+
+	"go.keploy.io/server/pkg/hooks"
+	"go.keploy.io/server/pkg/models"
+	"go.keploy.io/server/pkg/platform/yaml"
+	"go.keploy.io/server/pkg/proxy"
+	"go.uber.org/zap"
+)
+
+var Emoji = "\U0001F430" + " Keploy:"
+
+type mockRecorder struct {
+	logger *zap.Logger
+	mutex  sync.Mutex
+}
+
+func NewMockRecorder(logger *zap.Logger) MockRecorder {
+	return &mockRecorder{
+		logger: logger,
+		mutex:  sync.Mutex{},
+	}
+}
+
+func (s *mockRecorder) MockRecord(path string, Delay uint64, pid uint32, dirName string) {
+
+	models.SetMode(models.MODE_RECORD)
+	ys := yaml.NewYamlStore(s.logger)
+	
+	path += "/" + dirName
+
+	// Initiate the hooks
+	loadedHooks := hooks.NewHook(path, ys, s.logger)
+	if err := loadedHooks.LoadHooks("", "", pid); err != nil {
+		return
+	}
+
+	// start the proxy
+	ps := proxy.BootProxies(s.logger, proxy.Option{}, "", "")
+
+	// proxy update its state in the ProxyPorts map
+	ps.SetHook(loadedHooks)
+
+	// Sending Proxy Ip & Port to the ebpf program
+	if err := loadedHooks.SendProxyInfo(ps.IP4, ps.Port, ps.IP6); err != nil {
+		return
+	}
+
+	// Shutdown other resources
+	loadedHooks.Stop(false)
+	ps.StopProxyServer()
+}

--- a/pkg/service/mockrecord/service.go
+++ b/pkg/service/mockrecord/service.go
@@ -1,0 +1,5 @@
+package mockrecord
+
+type MockRecorder interface {
+	MockRecord(path string, Delay uint64, pid uint32, dir string)
+}

--- a/pkg/service/mockrecord/service.go
+++ b/pkg/service/mockrecord/service.go
@@ -1,5 +1,5 @@
 package mockrecord
 
 type MockRecorder interface {
-	MockRecord(path string, Delay uint64, pid uint32, dir string)
+	MockRecord(path string, pid uint32, dir string)
 }

--- a/pkg/service/mocktest/mocktest.go
+++ b/pkg/service/mocktest/mocktest.go
@@ -1,7 +1,6 @@
 package mocktest
 
 import (
-	"fmt"
 	"sync"
 
 	"go.keploy.io/server/pkg"
@@ -27,8 +26,6 @@ func NewMockTester(logger *zap.Logger) MockTester {
 }
 
 func (s *mockTester) MockTest(path string, pid uint32, mockName string) {
-
-	fmt.Println("hi")
 
 	models.SetMode(models.MODE_TEST)
 	ys := yaml.NewYamlStore(path, path, "", mockName, s.logger)

--- a/pkg/service/mocktest/mocktest.go
+++ b/pkg/service/mocktest/mocktest.go
@@ -40,7 +40,7 @@ func (s *mockTester) MockTest(path string, Delay uint64, pid uint32, dirName str
 	}
 
 	// start the proxy
-	ps := proxy.BootProxies(s.logger, proxy.Option{}, "", "")
+	ps := proxy.BootProxy(s.logger, proxy.Option{}, "", "", pid, "")
 
 	// proxy update its state in the ProxyPorts map
 	ps.SetHook(loadedHooks)

--- a/pkg/service/mocktest/mocktest.go
+++ b/pkg/service/mocktest/mocktest.go
@@ -1,0 +1,67 @@
+package mocktest
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync"
+
+	"go.keploy.io/server/pkg/hooks"
+	"go.keploy.io/server/pkg/models"
+	"go.keploy.io/server/pkg/platform/yaml"
+	"go.keploy.io/server/pkg/proxy"
+	"go.uber.org/zap"
+)
+
+var Emoji = "\U0001F430" + " Keploy:"
+
+type mockTester struct {
+	logger *zap.Logger
+	mutex  sync.Mutex
+}
+
+func NewMockTester(logger *zap.Logger) MockTester {
+	return &mockTester{
+		logger: logger,
+		mutex:  sync.Mutex{},
+	}
+}
+
+func (s *mockTester) MockTest(path string, Delay uint64, pid uint32, dirName string) {
+
+	models.SetMode(models.MODE_TEST)
+	ys := yaml.NewYamlStore(s.logger)
+
+	s.logger.Debug("path of mocks : " + path)
+
+	// Initiate the hooks
+	loadedHooks := hooks.NewHook(path, ys, s.logger)
+	if err := loadedHooks.LoadHooks("", "", pid); err != nil {
+		return
+	}
+
+	// start the proxy
+	ps := proxy.BootProxies(s.logger, proxy.Option{}, "", "")
+
+	// proxy update its state in the ProxyPorts map
+	ps.SetHook(loadedHooks)
+
+	// Sending Proxy Ip & Port to the ebpf program
+	if err := loadedHooks.SendProxyInfo(ps.IP4, ps.Port, ps.IP6); err != nil {
+		return
+	}
+
+	configMocks, tcsMocks, err := ys.ReadMocks(filepath.Join(path, dirName))
+	if err != nil {
+		loadedHooks.Stop(true)
+		ps.StopProxyServer()
+		return
+	}
+
+	s.logger.Debug(fmt.Sprintf("the config mocks for %s are: %v\nthe testcase mocks are: %v", dirName, configMocks, tcsMocks))
+	loadedHooks.SetConfigMocks(configMocks)
+	loadedHooks.SetTcsMocks(tcsMocks)
+
+	// Shutdown other resources
+	loadedHooks.Stop(false)
+	ps.StopProxyServer()
+}

--- a/pkg/service/mocktest/service.go
+++ b/pkg/service/mocktest/service.go
@@ -1,0 +1,5 @@
+package mocktest
+
+type MockTester interface {
+	MockTest(path string, Delay uint64, pid uint32, dir string)
+}

--- a/pkg/service/mocktest/service.go
+++ b/pkg/service/mocktest/service.go
@@ -1,5 +1,5 @@
 package mocktest
 
 type MockTester interface {
-	MockTest(path string, Delay uint64, pid uint32, dir string)
+	MockTest(path string, pid uint32, dir string)
 }

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -25,17 +25,16 @@ func NewRecorder(logger *zap.Logger) Recorder {
 func (r *recorder) CaptureTraffic(path string, appCmd, appContainer, appNetwork string, Delay uint64, ports []uint) {
 	models.SetMode(models.MODE_RECORD)
 
-	ys := yaml.NewYamlStore(r.logger)
-
-	dirName, err := ys.NewSessionIndex(path)
+	dirName, err := yaml.NewSessionIndex(path, r.logger)
 	if err != nil {
-		r.logger.Error("failed to find the directroy name for the session", zap.Error(err))
 		return
 	}
-	path += "/" + dirName
+
+	ys := yaml.NewYamlStore(path+"/"+dirName+"/tests", path+"/"+dirName, "", "", r.logger)
+
 	routineId := pkg.GenerateRandomID()
 	// Initiate the hooks and update the vaccant ProxyPorts map
-	loadedHooks := hooks.NewHook(path, ys, routineId, r.logger)
+	loadedHooks := hooks.NewHook(ys, routineId, r.logger)
 
 	// Recover from panic and gracfully shutdown
 	defer loadedHooks.Recover(routineId)

--- a/pkg/service/serve/graph/schema.resolvers.go
+++ b/pkg/service/serve/graph/schema.resolvers.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 
+	"go.keploy.io/server/pkg/platform/yaml"
 	"go.keploy.io/server/pkg/service/serve/graph/model"
 	"go.uber.org/zap"
 )
@@ -79,7 +80,7 @@ func (r *queryResolver) TestSets(ctx context.Context) ([]string, error) {
 	}
 	testPath := r.Resolver.Path
 
-	testSets, err := r.Resolver.YS.ReadSessionIndices(testPath)
+	testSets, err := yaml.ReadSessionIndices(testPath, r.Logger)
 	if err != nil {
 		r.Resolver.Logger.Error("failed to fetch test sets", zap.Any("testPath", testPath), zap.Error(err))
 		return nil, err

--- a/pkg/service/serve/serve.go
+++ b/pkg/service/serve/serve.go
@@ -51,11 +51,11 @@ func (s *server) Serve(path, testReportPath string, Delay uint64, pid, port uint
 
 	tester := test.NewTester(s.logger)
 	testReportFS := yaml.NewTestReportFS(s.logger)
-	ys := yaml.NewYamlStore(s.logger)
+	ys := yaml.NewYamlStore("", "", "", "", s.logger)
 
 	routineId := pkg.GenerateRandomID()
 	// Initiate the hooks
-	loadedHooks := hooks.NewHook(path, ys, routineId, s.logger)
+	loadedHooks := hooks.NewHook(ys, routineId, s.logger)
 
 	// Recover from panic and gracfully shutdown
 	defer loadedHooks.Recover(routineId)

--- a/pkg/service/test/test.go
+++ b/pkg/service/test/test.go
@@ -44,11 +44,11 @@ func (t *tester) Test(path, testReportPath string, appCmd, appContainer, appNetw
 	testReportFS := yaml.NewTestReportFS(t.logger)
 	// fetch the recorded testcases with their mocks
 	// ys := yaml.NewYamlStore(tcsPath, mockPath, t.logger)
-	ys := yaml.NewYamlStore(t.logger)
+	ys := yaml.NewYamlStore(path+"/tests", path, "", "", t.logger)
 
 	routineId := pkg.GenerateRandomID()
 	// Initiate the hooks
-	loadedHooks := hooks.NewHook(path, ys, routineId, t.logger)
+	loadedHooks := hooks.NewHook(ys, routineId, t.logger)
 
 	// Recover from panic and gracfully shutdown
 	defer loadedHooks.Recover(routineId)
@@ -69,7 +69,7 @@ func (t *tester) Test(path, testReportPath string, appCmd, appContainer, appNetw
 		return false
 	}
 
-	sessions, err := ys.ReadSessionIndices(path)
+	sessions, err := yaml.ReadSessionIndices(path, t.logger)
 	if err != nil {
 		t.logger.Debug("failed to read the recorded sessions", zap.Error(err))
 		return false
@@ -79,7 +79,6 @@ func (t *tester) Test(path, testReportPath string, appCmd, appContainer, appNetw
 	result := true
 
 	for _, sessionIndex := range sessions {
-
 		testRes := t.RunTestSet(sessionIndex, path, testReportPath, appCmd, appContainer, appNetwork, Delay, 0, ys, loadedHooks, testReportFS, nil, apiTimeout)
 		result = result && testRes
 	}
@@ -100,7 +99,6 @@ func (t *tester) RunTestSet(testSet, path, testReportPath, appCmd, appContainer,
 	defer loadedHooks.Recover(pkg.GenerateRandomID())
 
 	result := true
-
 	tcs, err := ys.ReadTestcase(filepath.Join(path, testSet, "tests"), nil)
 	if err != nil {
 		return true


### PR DESCRIPTION
## Related Issue
 Add support for recording stubs using keploy v2 for using in unit tests

Closes: #726 

#### Describe the changes you've made
1. decoupled path from hooks and attached into yaml .
2. Remove config.yaml and added them in mocks.yaml.
3. create two commands :
   sub cmd : mockRecord  flags : path, mockName, pid
   sub cmd : mockTest  flags : path, mockName, pid

In both the commands pid of the running unit test is given and accordingly other flag are given by the user . In mockRecord we take in mockName name, rather than randomly creating one session and we store only mocks over there. tests will not be created as unit tests don't hit handlers they hit the handler functions. Similarly, for mockTest mockName name is taken and only those mocks are loaded.

In this way we can support recording stubs in unit tests

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Tested using gin-mongo app details are provided in go-samples [PR](https://github.com/keploy/go-sdk/pull/194) 
#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |