### PR TITLE
fix: fix the content-length header of http response

### DIFF
--- a/pkg/hooks/loader.go
+++ b/pkg/hooks/loader.go
@@ -138,6 +138,13 @@ func (h *Hook) PopFront() {
 	h.tcsMocks = h.tcsMocks[1:]
 	h.mu.Unlock()
 }
+
+func (h *Hook) PopIndex(index int) {
+	h.mu.Lock()
+	h.tcsMocks = append(h.tcsMocks[:index], h.tcsMocks[index+1:]...)
+	h.mu.Unlock()
+}
+
 func (h *Hook) FetchDep(indx int) *models.Mock {
 	h.mu.Lock()
 	dep := h.tcsMocks[indx]

--- a/pkg/proxy/integrations/httpparser/httpparser.go
+++ b/pkg/proxy/integrations/httpparser/httpparser.go
@@ -94,7 +94,10 @@ func decodeOutgoingHttp(requestBuffer []byte, clienConn, destConn net.Conn, h *h
 	}
 
 	//parse request url
-	reqURL, _ := url.Parse(req.URL.String())
+	reqURL, err := url.Parse(req.URL.String())
+	if err != nil {
+		logger.Error(Emoji+"failed to parse request url", zap.Error(err))
+	}
 
 	//check if req body is a json
 	isReqBodyJSON := isJSON(reqbody)
@@ -142,7 +145,7 @@ func decodeOutgoingHttp(requestBuffer []byte, clienConn, destConn net.Conn, h *h
 	}
 
 	if len(eligibleMock) == 0 {
-		logger.Error(Emoji + "Didn't match any mock")
+		logger.Error(Emoji + "Didn't match any prexisting http mock")
 		return
 	}
 

--- a/pkg/proxy/integrations/httpparser/httpparser.go
+++ b/pkg/proxy/integrations/httpparser/httpparser.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -283,7 +284,7 @@ func decodeOutgoingHttp(requestBuffer []byte, clienConn, destConn net.Conn, h *h
 	//Matching algorithmm
 	//Get the mocks
 	tcsMocks := h.GetTcsMocks()
-	var bestMatch string
+	var bestMatch *models.Mock
 	//Parse the request buffer
 	req, err := http.ReadRequest(bufio.NewReader(bytes.NewReader(requestBuffer)))
 	if err != nil {
@@ -357,8 +358,9 @@ func decodeOutgoingHttp(requestBuffer []byte, clienConn, destConn net.Conn, h *h
 
 	var bestMatchIndex int
 	for idx, mock := range tcsMocks {
-		if mock.Spec.HttpReq.Body == bestMatch {
+		if reflect.DeepEqual(mock, bestMatch) {
 			bestMatchIndex = idx
+			break
 		}
 	}
 	if h.GetDepsSize() == 0 {
@@ -416,6 +418,7 @@ func decodeOutgoingHttp(requestBuffer []byte, clienConn, destConn net.Conn, h *h
 	// pop the mocked output from the dependency queue
 	// deps = deps[1:]
 	h.PopIndex(bestMatchIndex)
+	return
 }
 
 // encodeOutgoingHttp function parses the HTTP request and response text messages to capture outgoing network calls as mocks.

--- a/pkg/proxy/integrations/httpparser/httpparser.go
+++ b/pkg/proxy/integrations/httpparser/httpparser.go
@@ -62,14 +62,14 @@ func mapsHaveSameKeys(map1 map[string]string, map2 map[string][]string) bool {
 	return true
 }
 
-func ProcessOutgoingHttp(requestBuffer []byte, clientConn, destConn net.Conn, h *hooks.Hook, logger *zap.Logger) {
+func ProcessOutgoingHttp(request []byte, clientConn, destConn net.Conn, h *hooks.Hook, logger *zap.Logger) {
 	switch models.GetMode() {
 	case models.MODE_RECORD:
 		// *deps = append(*deps, encodeOutgoingHttp(request,  clientConn,  destConn, logger))
-		h.AppendMocks(encodeOutgoingHttp(requestBuffer, clientConn, destConn, logger))
+		h.AppendMocks(encodeOutgoingHttp(request, clientConn, destConn, logger))
 		// h.TestCaseDB.WriteMock(encodeOutgoingHttp(request, clientConn, destConn, logger))
 	case models.MODE_TEST:
-		decodeOutgoingHttp(requestBuffer, clientConn, destConn, h, logger)
+		decodeOutgoingHttp(request, clientConn, destConn, h, logger)
 	default:
 		logger.Info(Emoji+"Invalid mode detected while intercepting outgoing http call", zap.Any("mode", models.GetMode()))
 	}
@@ -278,7 +278,7 @@ func checkIfGzipped(check io.ReadCloser) (bool, *bufio.Reader) {
 	}
 }
 
-// decodeOutgoingHttp
+//Decodes the mocks in test mode so that they can be sent to the user application.
 func decodeOutgoingHttp(requestBuffer []byte, clienConn, destConn net.Conn, h *hooks.Hook, logger *zap.Logger) {
 	//Matching algorithmm
 	//Get the mocks

--- a/pkg/proxy/util/util.go
+++ b/pkg/proxy/util/util.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"strconv"
 	"strings"
-	"time"
 	"unicode"
 
 	"github.com/agnivade/levenshtein"

--- a/pkg/proxy/util/util.go
+++ b/pkg/proxy/util/util.go
@@ -11,6 +11,12 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
+	"unicode"
+
+	"github.com/agnivade/levenshtein"
+	"go.keploy.io/server/pkg/hooks"
+	"go.keploy.io/server/pkg/models"
 )
 
 // ToIP4AddressStr converts the integer IP4 Address to the octet format
@@ -235,5 +241,134 @@ func IsDockerRelatedCommand(cmd string) (bool, string) {
 		}
 	}
 
+	return false, ""
+}
+
+func findStringMatch(req string, mockString []string) int {
+	minDist := int(^uint(0) >> 1) // Initialize with max int value
+	bestMatch := -1
+	for idx, req := range mockString {
+		if !IsAsciiPrintable(mockString[idx]) {
+			continue
+		}
+
+		dist := levenshtein.ComputeDistance(req, mockString[idx])
+		if dist == 0 {
+			return 0
+		}
+
+		if dist < minDist {
+			minDist = dist
+			bestMatch = idx
+		}
+	}
+	return bestMatch
+}
+
+func HttpDecoder(encoded string) ([]byte, error) {
+	// decode the string to a buffer.
+
+	data := []byte(encoded)
+	return data, nil
+}
+
+func AdaptiveK(length, kMin, kMax, N int) int {
+	k := length / N
+	if k < kMin {
+		return kMin
+	} else if k > kMax {
+		return kMax
+	}
+	return k
+}
+
+func CreateShingles(data []byte, k int) map[string]struct{} {
+	shingles := make(map[string]struct{})
+	for i := 0; i < len(data)-k+1; i++ {
+		shingle := string(data[i : i+k])
+		shingles[shingle] = struct{}{}
+	}
+	return shingles
+}
+
+// JaccardSimilarity computes the Jaccard similarity between two sets of shingles.
+func JaccardSimilarity(setA, setB map[string]struct{}) float64 {
+	intersectionSize := 0
+	for k := range setA {
+		if _, exists := setB[k]; exists {
+			intersectionSize++
+		}
+	}
+
+	unionSize := len(setA) + len(setB) - intersectionSize
+
+	if unionSize == 0 {
+		return 0.0
+	}
+	return float64(intersectionSize) / float64(unionSize)
+}
+
+func findBinaryMatch(configMocks []*models.Mock, reqBuff []byte, h *hooks.Hook) int {
+
+	mxSim := -1.0
+	mxIdx := -1
+	// find the fuzzy hash of the mocks
+	for idx, mock := range configMocks {
+		encoded, _ := HttpDecoder(mock.Spec.HttpReq.Body)
+		k := AdaptiveK(len(reqBuff), 3, 8, 5)
+		shingles1 := CreateShingles(encoded, k)
+		shingles2 := CreateShingles(reqBuff, k)
+		similarity := JaccardSimilarity(shingles1, shingles2)
+		fmt.Printf("Jaccard Similarity: %f\n", similarity)
+		if mxSim < similarity {
+			mxSim = similarity
+			mxIdx = idx
+		}
+	}
+	return mxIdx
+}
+
+func IsAsciiPrintable(s string) bool {
+	for _, r := range s {
+		if r > unicode.MaxASCII || !unicode.IsPrint(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func HttpEncoder(buffer []byte) string {
+	//Encode the buffer to string
+	encoded := string(buffer)
+	return encoded
+}
+func Fuzzymatch(tcsMocks []*models.Mock, reqBuff []byte, h *hooks.Hook) (bool, string) {
+	com := HttpEncoder(reqBuff)
+	for _, mock := range tcsMocks {
+		encoded, _ := HttpDecoder(mock.Spec.HttpReq.Body)
+		if string(encoded) == string(reqBuff) || mock.Spec.HttpReq.Body == com {
+			fmt.Println("matched in first loop")
+			return true, mock.Spec.HttpReq.Body
+		}
+	}
+	// convert all the configmocks to string array
+	mockString := make([]string, len(tcsMocks))
+	for i := 0; i < len(tcsMocks); i++ {
+		mockString[i] = string(tcsMocks[i].Spec.HttpReq.Body)
+	}
+	// find the closest match
+	if IsAsciiPrintable(string(reqBuff)) {
+		idx := findStringMatch(string(reqBuff), mockString)
+		if idx != -1 {
+			nMatch := tcsMocks[idx].Spec.HttpReq.Body
+			fmt.Println("Returning mock from String Match !!")
+			return true, nMatch
+		}
+	}
+	idx := findBinaryMatch(tcsMocks, reqBuff, h)
+	if idx != -1 {
+		nMatch := tcsMocks[idx].Spec.HttpReq.Body
+		return true, nMatch
+	}
 	return false, ""
 }

--- a/pkg/proxy/util/util.go
+++ b/pkg/proxy/util/util.go
@@ -341,13 +341,13 @@ func HttpEncoder(buffer []byte) string {
 	encoded := string(buffer)
 	return encoded
 }
-func Fuzzymatch(tcsMocks []*models.Mock, reqBuff []byte, h *hooks.Hook) (bool, string) {
+func Fuzzymatch(tcsMocks []*models.Mock, reqBuff []byte, h *hooks.Hook) (bool, *models.Mock) {
 	com := HttpEncoder(reqBuff)
 	for _, mock := range tcsMocks {
 		encoded, _ := HttpDecoder(mock.Spec.HttpReq.Body)
 		if string(encoded) == string(reqBuff) || mock.Spec.HttpReq.Body == com {
 			fmt.Println("matched in first loop")
-			return true, mock.Spec.HttpReq.Body
+			return true, mock
 		}
 	}
 	// convert all the configmocks to string array
@@ -359,15 +359,13 @@ func Fuzzymatch(tcsMocks []*models.Mock, reqBuff []byte, h *hooks.Hook) (bool, s
 	if IsAsciiPrintable(string(reqBuff)) {
 		idx := findStringMatch(string(reqBuff), mockString)
 		if idx != -1 {
-			nMatch := tcsMocks[idx].Spec.HttpReq.Body
 			fmt.Println("Returning mock from String Match !!")
-			return true, nMatch
+			return true, tcsMocks[idx]
 		}
 	}
 	idx := findBinaryMatch(tcsMocks, reqBuff, h)
 	if idx != -1 {
-		nMatch := tcsMocks[idx].Spec.HttpReq.Body
-		return true, nMatch
+		return true, tcsMocks[idx]
 	}
-	return false, ""
+	return false, &models.Mock{}
 }

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/araddon/dateparse"
-	"github.com/gorilla/mux"
 	"go.keploy.io/server/pkg/models"
 	"go.uber.org/zap"
 )
@@ -18,24 +17,13 @@ var Emoji = "\U0001F430" + " Keploy:"
 
 // UrlParams returns the Url and Query parameters from the request url.
 func UrlParams(r *http.Request) map[string]string {
-	params := mux.Vars(r)
-
-	result := params
 	qp := r.URL.Query()
-	for i, j := range qp {
-		var s string
-		if _, ok := result[i]; ok {
-			s = result[i]
-		}
-		for _, e := range j {
-			if s != "" {
-				s += ", " + e
-			} else {
-				s = e
-			}
-		}
-		result[i] = s
+	result := make(map[string]string)
+
+	for key, values := range qp {
+		result[key] = strings.Join(values, ", ")
 	}
+
 	return result
 }
 
@@ -113,7 +101,6 @@ func SimulateHttp(tc models.TestCase, logger *zap.Logger) (*models.HttpResp, err
 
 	return resp, nil
 }
-
 
 func ParseHTTPRequest(requestBytes []byte) (*http.Request, error) {
 	// Parse the request using the http.ReadRequest function


### PR DESCRIPTION
## Related Issue
  - The recorded content length is different for the gzipped response.

#### Describe the changes you've made
Updates the content-length header of response in test mode.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
