### PR TITLE
Add support for invoking commands via docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,13 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Docker CLI (docker-compose)
+# Install Docker engine
 RUN curl -fsSL https://get.docker.com -o get-docker.sh && \
     sh get-docker.sh && \
     rm get-docker.sh
+
+# Install docker-compose to PATH
+RUN apt install docker-compose -y
 
 # Copy the keploy binary and the entrypoint script from the build container
 COPY --from=build /app/keploy /app/keploy


### PR DESCRIPTION
docker-compose is an independent binary, and is not shipped with Docker Engine. Hence, just like you cannot run non-statically C++ applications without their dependency inside docker containers, you also cannot run docker-compose commands unless you've installed it inside the environment. This PR adds suppport to install the plugin.

Closes: #702 ]

#### Describe the changes you've made
A clear and concise description of what you have done to successfully close your assigned issue. Any new files? or anything you feel to let us know!

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
