### PR TITLE
fix: added support for the expect header in Keploy

### DIFF
--- a/pkg/proxy/integrations/httpparser/httpparser.go
+++ b/pkg/proxy/integrations/httpparser/httpparser.go
@@ -476,6 +476,7 @@ func encodeOutgoingHttp(request []byte, clientConn, destConn net.Conn, logger *z
 			return nil
 		}
 		handleChunkedRequests(&finalReq, clientConn, destConn, logger, request)
+	}
 
 	// read the response from the actual server
 	resp, err = util.ReadBytes(destConn)

--- a/pkg/proxy/integrations/httpparser/httpparser.go
+++ b/pkg/proxy/integrations/httpparser/httpparser.go
@@ -448,10 +448,34 @@ func encodeOutgoingHttp(request []byte, clientConn, destConn net.Conn, logger *z
 		logger.Error("failed to write request message to the destination server", zap.Error(err))
 		return nil
 	}
-	finalReq = append(finalReq, request...)
-
-	//Handle chunked requests
-	handleChunkedRequests(&finalReq, clientConn, destConn, logger, request)
+		finalReq = append(finalReq, request...)
+	//check if the expect : 100-continue header is present
+	lines := strings.Split(string(request), "\n")
+	var expectHeader string
+	for _, line := range lines {
+		if strings.HasPrefix(line, "Expect:") {
+			expectHeader = strings.TrimSpace(strings.TrimPrefix(line, "Expect:"))
+			break
+		}
+	}
+	if expectHeader == "100-continue" {
+		//Read if the response from the client is 100-continue
+		resp, err = util.ReadBytes(destConn)
+		if err != nil {
+			logger.Error("failed to read the response message from the user client", zap.Error(err))
+			return nil
+		}
+		// write the response message to the client
+		_, err = clientConn.Write(resp)
+		if err != nil {
+			logger.Error("failed to write response message to the user client", zap.Error(err))
+			return nil
+		}
+		if string(resp) != "HTTP/1.1 100 Continue\r\n\r\n" {
+			logger.Error("failed to get the 100 continue response from the user client")
+			return nil
+		}
+		handleChunkedRequests(&finalReq, clientConn, destConn, logger, request)
 
 	// read the response from the actual server
 	resp, err = util.ReadBytes(destConn)
@@ -470,7 +494,7 @@ func encodeOutgoingHttp(request []byte, clientConn, destConn net.Conn, logger *z
 	var req *http.Request
 	// converts the request message buffer to http request
 	req, err = http.ReadRequest(bufio.NewReader(bytes.NewReader(finalReq)))
-	if err != nil {
+		if err != nil {
 		logger.Error("failed to parse the http request message", zap.Error(err))
 		return nil
 	}
@@ -490,7 +514,7 @@ func encodeOutgoingHttp(request []byte, clientConn, destConn net.Conn, logger *z
 		logger.Error("failed to parse the http response message", zap.Error(err))
 		return nil
 	}
-	var respBody []byte
+		var respBody []byte
 	if respParsed.Body != nil { // Read
 		if respParsed.Header.Get("Content-Encoding") == "gzip" {
 			check := respParsed.Body

--- a/pkg/proxy/integrations/httpparser/httpparser.go
+++ b/pkg/proxy/integrations/httpparser/httpparser.go
@@ -494,7 +494,7 @@ func encodeOutgoingHttp(request []byte, clientConn, destConn net.Conn, logger *z
 	var req *http.Request
 	// converts the request message buffer to http request
 	req, err = http.ReadRequest(bufio.NewReader(bytes.NewReader(finalReq)))
-		if err != nil {
+	if err != nil {
 		logger.Error("failed to parse the http request message", zap.Error(err))
 		return nil
 	}
@@ -514,7 +514,7 @@ func encodeOutgoingHttp(request []byte, clientConn, destConn net.Conn, logger *z
 		logger.Error("failed to parse the http response message", zap.Error(err))
 		return nil
 	}
-		var respBody []byte
+	var respBody []byte
 	if respParsed.Body != nil { // Read
 		if respParsed.Header.Get("Content-Encoding") == "gzip" {
 			check := respParsed.Body


### PR DESCRIPTION
## Related Issue
Keploy fails to record testcases when the application is using the expect header.

Closes: #746 

#### Describe the changes you've made
I have added support for the expect header in Keploy. Now if the server encounters this header, it writes it to the destination connection first before reading the entire request, and only if the destination connection sends a 100-continue response, we read the entire request and then send it to the destination.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |