### PR TITLE
fix: import ca in case of different java version

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -137,11 +137,12 @@ func isJavaInstalled() bool {
 	return err == nil
 }
 
-// JavaCAExists checks if the CA is already installed in the Java keystore
-func JavaCAExists(alias string) bool {
-	cmd := exec.Command("keytool", "-list", "-alias", alias, "-cacerts", "-storepass", "changeit")
+// JavaCAExists checks if the CA is already installed in the specified Java keystore
+func JavaCAExists(alias, storepass, cacertsPath string) bool {
+	cmd := exec.Command("keytool", "-list", "-keystore", cacertsPath, "-storepass", storepass, "-alias", alias)
 
 	err := cmd.Run()
+
 	return err == nil
 }
 
@@ -181,12 +182,12 @@ func InstallJavaCA(logger *zap.Logger, caPath string) {
 		// You can modify these as per your requirements
 		storePass := "changeit"
 		alias := "keployCA"
-		if JavaCAExists(alias) {
+		if JavaCAExists(alias, storePass, cacertsPath) {
 			logger.Info("Java detected and CA already exists", zap.String("path", cacertsPath))
 			return
 		}
 
-		cmd := exec.Command("keytool", "-import", "-trustcacerts", "-cacerts", "-storepass", storePass, "-noprompt", "-alias", alias, "-file", caPath)
+		cmd := exec.Command("keytool", "-import", "-trustcacerts", "-keystore", cacertsPath, "-storepass", storePass, "-noprompt", "-alias", alias, "-file", caPath)
 
 		cmdOutput, err := cmd.CombinedOutput()
 		if err != nil {


### PR DESCRIPTION
## Related Issue
  - #748 

Closes: #[issue number that will be closed through this PR]

#### Describe the changes you've made
- Add caCertPath and storepass flags to find for the right ca certificate in different java versions. 

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
`NA`

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |