### PR TITLE
fix: fetch java_home from proc file system

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -75,7 +75,13 @@ func (s *Serve) GetCmd() *cobra.Command {
 				s.logger.Error("Failed to get the port of keploy server", zap.Error((err)))
 			}
 
-			s.server.Serve(path, testReportPath, delay, pid, port)
+			language, err := cmd.Flags().GetString("language")
+			if err != nil {
+				s.logger.Error("failed to read the programming language")
+				return
+			}
+
+			s.server.Serve(path, testReportPath, delay, pid, port, language)
 		},
 	}
 
@@ -89,6 +95,9 @@ func (s *Serve) GetCmd() *cobra.Command {
 
 	serveCmd.Flags().Uint64P("delay", "d", 5, "User provided time to run its application")
 	serveCmd.MarkFlagRequired("delay")
+
+	serveCmd.Flags().StringP("language", "l", "", "application programming language")
+	serveCmd.MarkFlagRequired("language")
 
 	return serveCmd
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -61,18 +61,21 @@ func (s *Serve) GetCmd() *cobra.Command {
 
 			if err != nil {
 				s.logger.Error("Failed to get the delay flag", zap.Error((err)))
+				return
 			}
 
 			pid, err := cmd.Flags().GetUint32("pid")
 
 			if err != nil {
 				s.logger.Error("Failed to get the pid of the application", zap.Error((err)))
+				return
 			}
 
 			port, err := cmd.Flags().GetUint32("port")
 
 			if err != nil {
 				s.logger.Error("Failed to get the port of keploy server", zap.Error((err)))
+				return
 			}
 
 			language, err := cmd.Flags().GetString("language")

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -9,7 +9,6 @@ import (
 	"crypto/x509"
 	"embed"
 	"fmt"
-	"go.keploy.io/server/pkg/proxy/integrations/grpcparser"
 	"io"
 	"io/ioutil"
 	"log"
@@ -21,6 +20,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+
+	"go.keploy.io/server/pkg/proxy/integrations/grpcparser"
 
 	"github.com/cloudflare/cfssl/csr"
 	"github.com/cloudflare/cfssl/helpers"
@@ -173,7 +174,6 @@ func getJavaHomeFromPID(pid string) (string, error) {
 
 		}
 	}
-	fmt.Println("Not sending error because there is none")
 	return "", fmt.Errorf("failed to find JAVA_HOME from PID")
 }
 
@@ -200,12 +200,13 @@ func getJavaHome() (string, error) {
 }
 
 // InstallJavaCA installs the CA in the Java keystore
-func InstallJavaCA(logger *zap.Logger, caPath string, pid uint32) {
+func InstallJavaCA(logger *zap.Logger, caPath string, pid uint32, isJavaServe bool) {
 	// check if java is installed
 	if isJavaInstalled() {
 		var javaHome string
 		var err error
-		if pid != 0 { // in case of unit tests, we know the pid beforehand
+		logger.Debug("", zap.Any("isJavaServe", isJavaServe))
+		if pid != 0 && isJavaServe { // in case of unit tests, we know the pid beforehand
 			logger.Debug("checking java path from proc file system", zap.Any("pid", pid))
 			javaHome, err = getJavaHomeFromPID(strconv.Itoa(int(pid)))
 		} else {
@@ -245,8 +246,18 @@ func InstallJavaCA(logger *zap.Logger, caPath string, pid uint32) {
 	}
 }
 
+func containsJava(input string) bool {
+	// Convert the input string and the search term "java" to lowercase for a case-insensitive comparison.
+	inputLower := strings.ToLower(input)
+	searchTerm := "java"
+	searchTermLower := strings.ToLower(searchTerm)
+
+	// Use strings.Contains to check if the lowercase input contains the lowercase search term.
+	return strings.Contains(inputLower, searchTermLower)
+}
+
 // BootProxy starts proxy server on the idle local port, Default:16789
-func BootProxy(logger *zap.Logger, opt Option, appCmd, appContainer string, pid uint32) *ProxySet {
+func BootProxy(logger *zap.Logger, opt Option, appCmd, appContainer string, pid uint32, lang string) *ProxySet {
 
 	// assign default values if not provided
 	distro := getDistroInfo()
@@ -265,8 +276,11 @@ func BootProxy(logger *zap.Logger, opt Option, appCmd, appContainer string, pid 
 		return nil
 	}
 
+	//check if serve command is used by java application
+	isJavaServe := containsJava(lang)
+
 	// install CA in the java keystore if java is installed
-	InstallJavaCA(logger, caPath, pid)
+	InstallJavaCA(logger, caPath, pid, isJavaServe)
 
 	// Update the trusted CAs store
 	cmd := exec.Command("/usr/bin/sudo", caStoreUpdateCmd[distro])

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -39,7 +39,7 @@ func (r *recorder) CaptureTraffic(path string, appCmd, appContainer, appNetwork 
 	}
 
 	// start the BootProxy
-	ps := proxy.BootProxy(r.logger, proxy.Option{}, appCmd, appContainer, 0)
+	ps := proxy.BootProxy(r.logger, proxy.Option{}, appCmd, appContainer, 0, "")
 
 	//proxy fetches the destIp and destPort from the redirect proxy map
 	ps.SetHook(loadedHooks)

--- a/pkg/service/serve/serve.go
+++ b/pkg/service/serve/serve.go
@@ -39,8 +39,8 @@ func NewServer(logger *zap.Logger) Server {
 
 const defaultPort = 6789
 
-//Serve is called by the serve command and is used to run a graphql server, to run tests separately via apis.
-func (s *server) Serve(path, testReportPath string, Delay uint64, pid, port uint32) {
+// Serve is called by the serve command and is used to run a graphql server, to run tests separately via apis.
+func (s *server) Serve(path, testReportPath string, Delay uint64, pid, port uint32, lang string) {
 
 	if port == 0 {
 		port = defaultPort
@@ -64,7 +64,7 @@ func (s *server) Serve(path, testReportPath string, Delay uint64, pid, port uint
 	}
 
 	// start the proxy
-	ps := proxy.BootProxy(s.logger, proxy.Option{}, "", "",pid)
+	ps := proxy.BootProxy(s.logger, proxy.Option{}, "", "", pid, lang)
 
 	// proxy update its state in the ProxyPorts map
 	ps.SetHook(loadedHooks)

--- a/pkg/service/serve/service.go
+++ b/pkg/service/serve/service.go
@@ -1,5 +1,5 @@
 package serve
 
 type Server interface {
-	Serve(path, testReportPath string, Delay uint64, pid, port uint32)
+	Serve(path, testReportPath string, Delay uint64, pid, port uint32, lang string)
 }

--- a/pkg/service/test/test.go
+++ b/pkg/service/test/test.go
@@ -53,7 +53,7 @@ func (t *tester) Test(path, testReportPath string, appCmd, appContainer, appNetw
 	}
 
 	// start the proxy
-	ps := proxy.BootProxy(t.logger, proxy.Option{}, appCmd, appContainer, 0)
+	ps := proxy.BootProxy(t.logger, proxy.Option{}, appCmd, appContainer, 0, "")
 
 	// proxy update its state in the ProxyPorts map
 	ps.SetHook(loadedHooks)


### PR DESCRIPTION
## Related Issue
  - #774 

#### Describe the changes you've made
- Add language flag in keploy serve command to identify when to search for java home in proc file system.
- Now if the language is java and keploy is running via serve command, then only proc file system would be searched to find the exact java home related to the process id.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
`NA`

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |