### PR TITLE
refactor: Improved error handling for parsed response body

### DIFF
--- a/pkg/proxy/integrations/httpparser/httpparser.go
+++ b/pkg/proxy/integrations/httpparser/httpparser.go
@@ -594,8 +594,17 @@ func encodeOutgoingHttp(request []byte, clientConn, destConn net.Conn, logger *z
 		logger.Error("failed to parse the http response message", zap.Error(err))
 		return nil
 	}
+
+	//Checking if the body of the response is empty or does not exist.
+	bufReader := bufio.NewReader(respParsed.Body)
+	_, err = bufReader.Peek(2)
+	canRead := true
+	if err != nil && err != io.EOF {
+		logger.Debug("The body of the final response is empty", zap.Error(err))
+		canRead = false
+	}
 	var respBody []byte
-	if respParsed.Body != nil { // Read
+	if canRead { // Read
 		if respParsed.Header.Get("Content-Encoding") == "gzip" {
 			check := respParsed.Body
 			ok, reader := checkIfGzipped(check)


### PR DESCRIPTION
## Related Issue
Whenever the server is not able to send the response body, Keploy throws a segmentation fault error. Instead it should handle the error in advance and not try to read the body if it is empty or doesn't exist.

Closes: #796 

#### Describe the changes you've made
We peek the parsed response body before reading it to make sure it is not empty. If it is, then we do not read the body and continue with the rest of the function.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
