### PR TITLE
fix: cleanup all the child processes started by app

### DIFF
--- a/pkg/hooks/loader.go
+++ b/pkg/hooks/loader.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -284,16 +285,50 @@ func (h *Hook) SetKeployModeInKernel(mode uint32) {
 		h.logger.Error("failed to set keploy mode in the epbf program", zap.Any("error thrown by ebpf map", err.Error()))
 	}
 }
+func (h *Hook) getProcessesByPGID(parentPID int) {
+
+	pids := []int{}
+
+	h.findChildProcesses(fmt.Sprintf("%d", parentPID), &pids)
+
+	for _, childPID := range pids {
+		err := syscall.Kill(childPID, syscall.SIGKILL)
+		if err != nil {
+			h.logger.Error("failed to set kill child pid", zap.Any("error killing child process", err.Error()))
+		}
+	}
+}
+
+func (h *Hook) findChildProcesses(parentPID string, pids *[]int) {
+
+	cmd := exec.Command("pgrep", "-P", parentPID)
+	parentIDint, err := strconv.Atoi(parentPID)
+	if err != nil {
+		h.logger.Error("failed to convert parent PID to int", zap.Any("error converting parent PID to int", err.Error()))
+	}
+
+	*pids = append(*pids, parentIDint)
+
+	output, err := cmd.Output()
+	if err != nil {
+		return
+	}
+
+	outputStr := string(output)
+	childPIDs := strings.Split(outputStr, "\n")
+	childPIDs = childPIDs[:len(childPIDs)-1]
+
+	for _, childPID := range childPIDs {
+		if childPID != "" {
+			h.findChildProcesses(childPID, pids)
+		}
+	}
+}
 
 // StopUserApplication stops the user application
 func (h *Hook) StopUserApplication() {
 	if h.userAppCmd != nil && h.userAppCmd.Process != nil {
-		err := h.userAppCmd.Process.Kill()
-		if err != nil {
-			h.logger.Error("failed to stop user application", zap.Error(err))
-		} else {
-			h.logger.Info("User application stopped successfully...")
-		}
+		h.getProcessesByPGID(h.userAppCmd.Process.Pid)
 	}
 }
 


### PR DESCRIPTION
## Related Issue
  -Recursively kills the child process started by the application.

Closes: #799

#### Describe the changes you've made
Instead of just killing the PID of the application we kill the child processes started by the application as well.

# How to Kill the child processes?
* Approach 1: PGID-Based Termination
This method involves identifying and terminating all processes sharing the same Process Group ID (PGID) as the user application. While this approach can efficiently kill all processes within the same group simultaneously, it presents a significant risk: it may inadvertently terminate unrelated processes—possibly even the parent processes—since they share the same PGID as the target application. Consequently, this approach is not recommended as it does not guarantee the isolation of the user application's processes and may lead to unintended system disruptions.


* Approach 2: Recursive PID Fetching and Termination
This approach adopts a more refined strategy to terminate processes initiated by the user application. It starts by identifying the child processes directly spawned by the user application using its Process ID (PID), and then recursively identifying and storing the PIDs of all subsequent child processes. Once all relevant PIDs are accumulated, the method proceeds to terminate these processes in a parent-first sequence. This sequence is critical as it prevents the triggering of any potential cleanup mechanisms that might activate if a child process is terminated before its parent. This strategy ensures a safer and more controlled termination of processes directly associated with the user application, without affecting unrelated processes sharing the same PGID.



Conclusion Approach 2 is the most suitable approach.

StopUserApplication is being called twice while stopping loaded hooks in case of force stop and RunTestSet. 

By monitoring the ProcessState of the userAppCmd, we can ensure that the child process of an already killed process isn't called recursively as it would cause.

Findings for userAppCmd:
* Since wait is already being used we can't use wait for the process to finish in order to see the final process state to avoid going on the pre-killed child process.
* Move StopUserApplication inside the force-stop method, as during the test phase user application is already stopped while stopping loaded hooks.
 
## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [X] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

