### PR TITLE
fix: adding timeout to handle http timeout

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -71,6 +71,11 @@ func (s *Serve) GetCmd() *cobra.Command {
 				return
 			}
 
+			apiTimeout, err := cmd.Flags().GetUint64("apiTimeout")
+			if err != nil {
+				s.logger.Error("Failed to get the apiTimeout flag", zap.Error((err)))
+			}
+
 			port, err := cmd.Flags().GetUint32("port")
 
 			if err != nil {
@@ -87,7 +92,7 @@ func (s *Serve) GetCmd() *cobra.Command {
 			ports, err := cmd.Flags().GetUintSlice("passThroughPorts")
 			if err != nil {
 				s.logger.Error("failed to read the ports of outgoing calls to be ignored")
-				return 
+				return
 			}
 			// for _, v := range ports {
 
@@ -95,7 +100,7 @@ func (s *Serve) GetCmd() *cobra.Command {
 
 			s.logger.Debug("the ports are", zap.Any("ports", ports))
 
-			s.server.Serve(path, testReportPath, delay, pid, port, language, ports)
+			s.server.Serve(path, testReportPath, delay, pid, port, language, ports, apiTimeout)
 		},
 	}
 
@@ -109,6 +114,8 @@ func (s *Serve) GetCmd() *cobra.Command {
 
 	serveCmd.Flags().Uint64P("delay", "d", 5, "User provided time to run its application")
 	serveCmd.MarkFlagRequired("delay")
+
+	serveCmd.Flags().Uint64P("apiTimeout", "", 5, "User provided timeout for calling its application")
 
 	serveCmd.Flags().UintSlice("passThroughPorts", []uint{}, "Ports of Outgoing dependency calls to be ignored as mocks")
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -115,7 +115,7 @@ func (s *Serve) GetCmd() *cobra.Command {
 	serveCmd.Flags().Uint64P("delay", "d", 5, "User provided time to run its application")
 	serveCmd.MarkFlagRequired("delay")
 
-	serveCmd.Flags().Uint64P("apiTimeout", "", 5, "User provided timeout for calling its application")
+	serveCmd.Flags().Uint64("apiTimeout", 5, "User provided timeout for calling its application")
 
 	serveCmd.Flags().UintSlice("passThroughPorts", []uint{}, "Ports of Outgoing dependency calls to be ignored as mocks")
 

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -150,7 +150,7 @@ func (t *Test) GetCmd() *cobra.Command {
 	// recordCmd.MarkFlagRequired("networkName")
 	testCmd.Flags().Uint64P("delay", "d", 5, "User provided time to run its application")
 
-	testCmd.Flags().Uint64P("apiTimeout", "", 5, "User provided timeout for calling its application")
+	testCmd.Flags().Uint64("apiTimeout", 5, "User provided timeout for calling its application")
 
 	testCmd.Flags().UintSlice("passThroughPorts", []uint{}, "Ports of Outgoing dependency calls to be ignored as mocks")
 

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -101,6 +101,10 @@ func (t *Test) GetCmd() *cobra.Command {
 			}
 
 			delay, err := cmd.Flags().GetUint64("delay")
+			if err != nil {
+				t.logger.Error("Failed to get the delay flag", zap.Error((err)))
+			}
+
 			if delay <= 5 {
 				fmt.Printf("Warning: delay is set to %d seconds, incase your app takes more time to start use --delay to set custom delay\n", delay)
 				if isDockerCmd {
@@ -109,9 +113,12 @@ func (t *Test) GetCmd() *cobra.Command {
 					fmt.Println("Example usage:\n", cmd.Example, "\n")
 				}
 			}
+
+			apiTimeout, err := cmd.Flags().GetUint64("apiTimeout")
 			if err != nil {
-				t.logger.Error("Failed to get the delay flag", zap.Error((err)))
+				t.logger.Error("Failed to get the apiTimeout flag", zap.Error((err)))
 			}
+
 			t.logger.Info("", zap.Any("keploy test and mock path", path), zap.Any("keploy testReport path", testReportPath))
 
 			ports, err := cmd.Flags().GetUintSlice("passThroughPorts")
@@ -125,7 +132,7 @@ func (t *Test) GetCmd() *cobra.Command {
 
 			t.logger.Debug("the ports are", zap.Any("ports", ports))
 
-			t.tester.Test(path, testReportPath, appCmd, appContainer, networkName, delay, ports)
+			t.tester.Test(path, testReportPath, appCmd, appContainer, networkName, delay, ports, apiTimeout)
 			return nil
 		},
 	}
@@ -142,6 +149,8 @@ func (t *Test) GetCmd() *cobra.Command {
 	testCmd.Flags().StringP("networkName", "n", "", "Name of the application's docker network")
 	// recordCmd.MarkFlagRequired("networkName")
 	testCmd.Flags().Uint64P("delay", "d", 5, "User provided time to run its application")
+
+	testCmd.Flags().Uint64P("apiTimeout", "", 5, "User provided timeout for calling its application")
 
 	testCmd.Flags().UintSlice("passThroughPorts", []uint{}, "Ports of Outgoing dependency calls to be ignored as mocks")
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -780,12 +780,12 @@ func (ps *ProxySet) handleTLSConnection(conn net.Conn) (net.Conn, error) {
 	caPrivKey, err = helpers.ParsePrivateKeyPEM(caPKey)
 	if err != nil {
 		ps.logger.Error(Emoji+"Failed to parse CA private key: ", zap.Error(err))
-		return &dns.Transfer{}, err
+		return nil, err
 	}
 	caCertParsed, err = helpers.ParseCertificatePEM(caCrt)
 	if err != nil {
 		ps.logger.Error(Emoji+"Failed to parse CA certificate: ", zap.Error(err))
-		return &dns.Transfer{}, err
+		return nil, err
 	}
 
 	// Create a TLS configuration
@@ -806,7 +806,7 @@ func (ps *ProxySet) handleTLSConnection(conn net.Conn) (net.Conn, error) {
 
 	if err != nil {
 		ps.logger.Error(Emoji+"failed to complete TLS handshake with the client with error: ", zap.Error(err))
-		return &dns.Transfer{}, err
+		return nil, err
 	}
 	// fmt.Println("after the parsed req: ", string(req))
 	// Perform the TLS handshake

--- a/pkg/service/serve/graph/resolver.go
+++ b/pkg/service/serve/graph/resolver.go
@@ -24,4 +24,5 @@ type Resolver struct {
 	Delay            uint64
 	AppPid           uint32
 	firstRequestDone bool
+	ApiTimeout       uint64
 }

--- a/pkg/service/serve/graph/schema.resolvers.go
+++ b/pkg/service/serve/graph/schema.resolvers.go
@@ -18,7 +18,7 @@ func (r *mutationResolver) RunTestSet(ctx context.Context, testSet string) (*mod
 		err := fmt.Errorf(Emoji + "failed to get Resolver")
 		return nil, err
 	}
-	
+
 	tester := r.Resolver.Tester
 
 	if tester == nil {
@@ -44,25 +44,25 @@ func (r *mutationResolver) RunTestSet(ctx context.Context, testSet string) (*mod
 
 	testReportFS := r.Resolver.TestReportFS
 	if tester == nil {
-		r.Logger.Error( "failed to get testReportFS from resolver")
+		r.Logger.Error("failed to get testReportFS from resolver")
 		return nil, fmt.Errorf(Emoji+"failed to run testSet:%v", testSet)
 	}
 
 	ys := r.Resolver.YS
 	if ys == nil {
-		r.Logger.Error( "failed to get ys from resolver")
+		r.Logger.Error("failed to get ys from resolver")
 		return nil, fmt.Errorf(Emoji+"failed to run testSet:%v", testSet)
 	}
 
 	loadedHooks := r.LoadedHooks
 	if loadedHooks == nil {
-		r.Logger.Error( "failed to get loadedHooks from resolver")
+		r.Logger.Error("failed to get loadedHooks from resolver")
 		return nil, fmt.Errorf(Emoji+"failed to run testSet:%v", testSet)
 	}
 
 	go func() {
 		r.Logger.Debug("starting testrun...", zap.Any("testSet", testSet))
-		tester.RunTestSet(testSet, testCasePath, testReportPath, "", "", "", delay, pid, ys, loadedHooks, testReportFS, testRunChan)
+		tester.RunTestSet(testSet, testCasePath, testReportPath, "", "", "", delay, pid, ys, loadedHooks, testReportFS, testRunChan, r.ApiTimeout)
 	}()
 
 	testRunID := <-testRunChan
@@ -104,7 +104,7 @@ func (r *queryResolver) TestSetStatus(ctx context.Context, testRunID string) (*m
 	testReportFs := r.Resolver.TestReportFS
 
 	if testReportFs == nil {
-		r.Logger.Error( "failed to get testReportFS from resolver")
+		r.Logger.Error("failed to get testReportFS from resolver")
 		return nil, fmt.Errorf(Emoji+"failed to get the status for testRunID:%v", testRunID)
 	}
 	testReport, err := testReportFs.Read(ctx, r.Resolver.TestReportPath, testRunID)

--- a/pkg/service/serve/serve.go
+++ b/pkg/service/serve/serve.go
@@ -41,7 +41,7 @@ func NewServer(logger *zap.Logger) Server {
 const defaultPort = 6789
 
 // Serve is called by the serve command and is used to run a graphql server, to run tests separately via apis.
-func (s *server) Serve(path, testReportPath string, Delay uint64, pid, port uint32, lang string, passThorughPorts []uint) {
+func (s *server) Serve(path, testReportPath string, Delay uint64, pid, port uint32, lang string, passThorughPorts []uint, apiTimeout uint64) {
 
 	if port == 0 {
 		port = defaultPort
@@ -92,6 +92,7 @@ func (s *server) Serve(path, testReportPath string, Delay uint64, pid, port uint
 			TestReportPath: testReportPath,
 			Delay:          Delay,
 			AppPid:         pid,
+			ApiTimeout:     apiTimeout,
 		},
 	}))
 

--- a/pkg/service/serve/service.go
+++ b/pkg/service/serve/service.go
@@ -1,5 +1,5 @@
 package serve
 
 type Server interface {
-	Serve(path, testReportPath string, Delay uint64, pid, port uint32, lang string, passThorughPorts []uint)
+	Serve(path, testReportPath string, Delay uint64, pid, port uint32, lang string, passThorughPorts []uint, apiTimeout uint64)
 }

--- a/pkg/service/test/service.go
+++ b/pkg/service/test/service.go
@@ -8,6 +8,6 @@ import (
 
 type Tester interface {
 	// Test(tcsPath, mockPath, testReportPath string, appCmd, appContainer, networkName string, Delay uint64) bool
-	Test(path, testReportPath string, appCmd, appContainer, networkName string, Delay uint64, passThorughPorts []uint) bool
-	RunTestSet(testSet, path, testReportPath, appCmd, appContainer, appNetwork string, delay uint64, pid uint32, ys platform.TestCaseDB, loadedHook *hooks.Hook, testReportfs yaml.TestReportFS, testRunChan chan string) bool
+	Test(path, testReportPath string, appCmd, appContainer, networkName string, Delay uint64, passThorughPorts []uint, apiTimeout uint64) bool
+	RunTestSet(testSet, path, testReportPath, appCmd, appContainer, appNetwork string, delay uint64, pid uint32, ys platform.TestCaseDB, loadedHook *hooks.Hook, testReportfs yaml.TestReportFS, testRunChan chan string, apiTimeout uint64) bool
 }

--- a/pkg/service/test/test.go
+++ b/pkg/service/test/test.go
@@ -38,7 +38,7 @@ func NewTester(logger *zap.Logger) Tester {
 
 // func (t *tester) Test(tcsPath, mockPath, testReportPath string, pid uint32) bool {
 // func (t *tester) Test(tcsPath, mockPath, testReportPath string, appCmd, appContainer, appNetwork string, Delay uint64) bool {
-func (t *tester) Test(path, testReportPath string, appCmd, appContainer, appNetwork string, Delay uint64, passThorughPorts []uint) bool {
+func (t *tester) Test(path, testReportPath string, appCmd, appContainer, appNetwork string, Delay uint64, passThorughPorts []uint, apiTimeout uint64) bool {
 	models.SetMode(models.MODE_TEST)
 
 	testReportFS := yaml.NewTestReportFS(t.logger)
@@ -80,7 +80,7 @@ func (t *tester) Test(path, testReportPath string, appCmd, appContainer, appNetw
 
 	for _, sessionIndex := range sessions {
 
-		testRes := t.RunTestSet(sessionIndex, path, testReportPath, appCmd, appContainer, appNetwork, Delay, 0, ys, loadedHooks, testReportFS, nil)
+		testRes := t.RunTestSet(sessionIndex, path, testReportPath, appCmd, appContainer, appNetwork, Delay, 0, ys, loadedHooks, testReportFS, nil, apiTimeout)
 		result = result && testRes
 	}
 	t.logger.Info("test run completed", zap.Bool("passed overall", result))
@@ -94,7 +94,7 @@ func (t *tester) Test(path, testReportPath string, appCmd, appContainer, appNetw
 	return true
 }
 
-func (t *tester) RunTestSet(testSet, path, testReportPath, appCmd, appContainer, appNetwork string, delay uint64, pid uint32, ys platform.TestCaseDB, loadedHooks *hooks.Hook, testReportFS yaml.TestReportFS, testRunChan chan string) bool {
+func (t *tester) RunTestSet(testSet, path, testReportPath, appCmd, appContainer, appNetwork string, delay uint64, pid uint32, ys platform.TestCaseDB, loadedHooks *hooks.Hook, testReportFS yaml.TestReportFS, testRunChan chan string, apiTimeout uint64) bool {
 
 	// Recover from panic and gracfully shutdown
 	defer loadedHooks.Recover(pkg.GenerateRandomID())
@@ -217,7 +217,7 @@ func (t *tester) RunTestSet(testSet, path, testReportPath, appCmd, appContainer,
 			}
 			t.logger.Debug(fmt.Sprintf("the url of the testcase: %v", tc.HttpReq.URL))
 			// time.Sleep(10 * time.Second)
-			resp, err := pkg.SimulateHttp(*tc, t.logger)
+			resp, err := pkg.SimulateHttp(*tc, t.logger, apiTimeout)
 			t.logger.Debug("After simulating the request", zap.Any("test case id", tc.Name))
 			t.logger.Debug("After GetResp of the request", zap.Any("test case id", tc.Name))
 

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -78,6 +78,7 @@ func SimulateHttp(tc models.TestCase, logger *zap.Logger) (*models.HttpResp, err
 
 	// Creating the client and disabling redirects
 	client := &http.Client{
+		Timeout: time.Second * 5,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -59,7 +59,7 @@ func IsTime(stringDate string) bool {
 	return err == nil
 }
 
-func SimulateHttp(tc models.TestCase, logger *zap.Logger) (*models.HttpResp, error) {
+func SimulateHttp(tc models.TestCase, logger *zap.Logger, apiTimeout uint64) (*models.HttpResp, error) {
 	resp := &models.HttpResp{}
 
 	logger.Info("making a http request", zap.Any("test case id", tc.Name))
@@ -78,7 +78,7 @@ func SimulateHttp(tc models.TestCase, logger *zap.Logger) (*models.HttpResp, err
 
 	// Creating the client and disabling redirects
 	client := &http.Client{
-		Timeout: time.Second * 5,
+		Timeout: time.Second * time.Duration(apiTimeout),
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},


### PR DESCRIPTION
## Related Issue
  - Test run gets blocked in case of failed outgoing call from user application

<img width="918" alt="image" src="https://github.com/keploy/keploy/assets/60891544/5f3b814b-6d4e-4e2e-8fc5-5ea8a11211eb">

Closes: #815

#### Describe the changes you've made
Put a timeout on client do which makes call to user application, in case the call fails we would proceed further and other tests are performed successfully
## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
