### PR TITLE
[bug]: Fixed retry and body parsing issues

### DIFF
--- a/pkg/proxy/integrations/httpparser/httpparser.go
+++ b/pkg/proxy/integrations/httpparser/httpparser.go
@@ -203,11 +203,9 @@ func chunkedResponse(finalResp *[]byte, clientConn, destConn net.Conn, logger *z
 			//Set deadline of 5 seconds
 			destConn.SetReadDeadline(time.Now().Add(5 * time.Second))
 			resp, err := util.ReadBytes(destConn)
-			if err != nil {
+			if err != nil && err != io.EOF {
 				//Check if the connection closed.
-				if err == io.EOF {
-					continue
-				} else if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+				if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
 					//Check if the deadline is reached.
 					logger.Info(Emoji + "Stopped getting buffer from the destination server")
 					break
@@ -400,7 +398,7 @@ func decodeOutgoingHttp(requestBuffer []byte, clienConn, destConn net.Conn, h *h
 	}
 
 	if len(eligibleMock) == 0 {
-		logger.Error( "Didn't match any prexisting http mock")
+		logger.Error("Didn't match any prexisting http mock")
 		util.Passthrough(clienConn, destConn, [][]byte{requestBuffer}, h.Recover, logger)
 		return
 	}
@@ -694,7 +692,7 @@ func encodeOutgoingHttp(request []byte, clientConn, destConn net.Conn, logger *z
 		if err != nil {
 			if err == io.EOF {
 				break
-			}else{
+			} else {
 				logger.Info("failed to write request message to the destination server", zap.Error(err))
 				return nil, err
 			}


### PR DESCRIPTION
## Related Issue
When a client tries to make another request on the same connection, it is not able to do so because Keploy's http parser closes the client connection after one the request gets completed or there is an error.
When the server a 503 response, it also sends a small body along with it, but Keploy is currently not able to record that.

Closes: #824 #825 #836

#### Describe the changes you've made
Added a for loop for connection pooling in the http parser and also handled EOF in the chunked requests and chunked responses.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
