### PR TITLE
fix: wrong new proxy port sent to kernel

### DIFF
--- a/pkg/hooks/launch.go
+++ b/pkg/hooks/launch.go
@@ -296,7 +296,7 @@ func (h *Hook) processDockerEnv(appCmd, appContainer, appNetwork string) error {
 								return
 							}
 
-							h.logger.Debug(fmt.Sprintf("New proxy ip sent to kernel:%v", proxyIp))
+							h.logger.Debug(fmt.Sprintf("New proxy ip:%v & proxy port:%v sent to kernel", proxyIp, proxyPort))
 						} else {
 							dockerErrCh <- fmt.Errorf("NetworkSettings not found for the %v container", appContainer)
 							return

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -374,6 +374,9 @@ func BootProxy(logger *zap.Logger, opt Option, appCmd, appContainer string, pid 
 		hook:             h,
 	}
 
+	//setting the proxy port field in hook
+	proxySet.hook.SetProxyPort(opt.Port)
+
 	if isPortAvailable(opt.Port) {
 		go func() {
 			defer h.Recover(pkg.GenerateRandomID())


### PR DESCRIPTION
## Related Issue
  - Keploy not able to generate test cases in docker environment.

Closes: https://github.com/keploy/keploy/issues/833

#### Describe the changes you've made
- Set proxy port field of hook in boot proxy function.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
`NA`

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |