### PR TITLE
fix: update the exit loggs to ignore unwanted errors

### DIFF
--- a/pkg/hooks/loader.go
+++ b/pkg/hooks/loader.go
@@ -299,9 +299,11 @@ func (h *Hook) killProcessesAndTheirChildren(parentPID int) {
 	h.findAndCollectChildProcesses(fmt.Sprintf("%d", parentPID), &pids)
 
 	for _, childPID := range pids {
-		err := syscall.Kill(childPID, syscall.SIGKILL)
-		if err != nil {
-			h.logger.Error("failed to set kill child pid", zap.Any("error killing child process", err.Error()))
+		if h.userAppCmd.ProcessState == nil {
+			err := syscall.Kill(childPID, syscall.SIGKILL)
+			if err != nil {
+				h.logger.Error("failed to set kill child pid", zap.Any("error killing child process", err.Error()))
+			}
 		}
 	}
 }
@@ -335,6 +337,7 @@ func (h *Hook) findAndCollectChildProcesses(parentPID string, pids *[]int) {
 // StopUserApplication stops the user application
 func (h *Hook) StopUserApplication() {
 	if h.userAppCmd != nil && h.userAppCmd.Process != nil {
+		h.logger.Debug("the process state for the user process", zap.String("state", h.userAppCmd.ProcessState.String()), zap.Any("processState", h.userAppCmd.ProcessState))
 		if h.userAppCmd.ProcessState != nil && h.userAppCmd.ProcessState.Exited() {
 			return
 		}
@@ -357,9 +360,9 @@ func (h *Hook) Recover(id int) {
 func (h *Hook) Stop(forceStop bool) {
 	if !forceStop {
 		<-h.stopper
+		h.logger.Info("Received signal, exiting program..")
 		// stop the user application cmd
 		h.StopUserApplication()
-		h.logger.Info("Received signal, exiting program..")
 
 	} else {
 		h.logger.Info("Exiting keploy program gracefully.")

--- a/pkg/hooks/ringBufReader.go
+++ b/pkg/hooks/ringBufReader.go
@@ -100,7 +100,7 @@ func socketDataEventCallback(reader *ringbuf.Reader, connectionFactory *connecti
 
 		record, err := reader.Read()
 		if err != nil {
-			if errors.Is(err, ringbuf.ErrClosed) {
+			if !errors.Is(err, ringbuf.ErrClosed) {
 				logger.Error("failed to receive signal from ringbuf socketDataEvent reader", zap.Error(err))
 				return
 			}

--- a/pkg/platform/yaml/yaml.go
+++ b/pkg/platform/yaml/yaml.go
@@ -350,9 +350,6 @@ func (ys *Yaml) ReadMocks(path string) ([]*models.Mock, []*models.Mock, error) {
 		// 	ys.Logger.Error("failed to find the config yaml", zap.Error(err))
 		// 	return nil, nil, err
 		// }
-		fmt.Println("mockPath")
-		fmt.Println(path)
-		fmt.Println(mockName)
 
 		yamls, err := read(path, mockName)
 		if err != nil {
@@ -365,8 +362,6 @@ func (ys *Yaml) ReadMocks(path string) ([]*models.Mock, []*models.Mock, error) {
 			return nil, nil, err
 		}
 
-		fmt.Println("mockLen")
-		fmt.Println(len(mocks))
 
 		for _, mock := range mocks {
 			if mock.Spec.Metadata["type"] == "config" {

--- a/pkg/proxy/integrations/mongoparser/mongoparser.go
+++ b/pkg/proxy/integrations/mongoparser/mongoparser.go
@@ -3,6 +3,7 @@ package mongoparser
 import (
 	"encoding/binary"
 	"fmt"
+	"io"
 	"math/rand"
 	"net"
 	"reflect"
@@ -60,6 +61,10 @@ func decodeOutgoingMongo(clientConnId, destConnId int64, requestBuffer []byte, c
 			started := time.Now()
 			requestBuffer, err = util.ReadBytes(clientConn)
 			if err != nil {
+				if err == io.EOF {
+					logger.Debug("recieved request buffer is empty in test mode for mongo calls")
+					return
+				}
 				logger.Error("failed to read request from the mongo client", zap.Error(err), zap.Any("clientConnId", clientConnId))
 				return
 			}
@@ -87,6 +92,10 @@ func decodeOutgoingMongo(clientConnId, destConnId int64, requestBuffer []byte, c
 				logger.Debug("into the for loop for request stream")
 				requestBuffer1, err := util.ReadBytes(clientConn)
 				if err != nil {
+					if err == io.EOF {
+						logger.Debug("recieved request buffer is empty for streaming mongo request call")
+						return
+					}
 					logger.Error("failed to read reply from the mongo server", zap.Error(err), zap.String("mongo server address", destConn.RemoteAddr().String()))
 					return
 				}
@@ -335,9 +344,13 @@ func encodeOutgoingMongo(clientConnId, destConnId int64, requestBuffer []byte, c
 		if string(requestBuffer) == "read form client connection" {
 			lstr := ""
 			started := time.Now()
-			requestBuffer, lstr, err = util.ReadBytes1(clientConn)
+			requestBuffer, err = util.ReadBytes(clientConn)
 			logger.Debug("reading from the mongo connection", zap.Any("", string(requestBuffer)))
 			if err != nil {
+				if err == io.EOF {
+					logger.Debug("recieved request buffer is empty in record mode for mongo call")
+					return
+				}
 				logger.Error("failed to read request from the mongo client", zap.Error(err), zap.String("mongo client address", clientConn.RemoteAddr().String()), zap.Any("client conn id", clientConnId), zap.Any("dest conn id", destConnId))
 				return
 			}
@@ -377,9 +390,13 @@ func encodeOutgoingMongo(clientConnId, destConnId int64, requestBuffer []byte, c
 				// fmt.Println("into the more_to_come", logStr)
 				tmpStr := ""
 				started = time.Now()
-				requestBuffer1, tmpStr, err := util.ReadBytes1(clientConn)
+				requestBuffer1, err := util.ReadBytes(clientConn)
 				logStr += tmpStr
 				if err != nil {
+					if err == io.EOF {
+						logger.Debug("recieved request buffer is empty in record mode for mongo request")
+						return
+					}
 					logger.Error("failed to read reply from the mongo server", zap.Error(err), zap.String("mongo server address", destConn.RemoteAddr().String()), zap.Any("client conn id", clientConnId), zap.Any("dest conn id", destConnId))
 					return
 				}
@@ -428,10 +445,15 @@ func encodeOutgoingMongo(clientConnId, destConnId int64, requestBuffer []byte, c
 		// read reply message from the mongo server
 		tmpStr := ""
 		started = time.Now()
-		responseBuffer, tmpStr, err := util.ReadBytes1(destConn)
+		responseBuffer, err := util.ReadBytes(destConn)
 		logger.Debug("reading from the destination mongo server", zap.Any("", string(responseBuffer)))
 		logStr += tmpStr
 		if err != nil {
+			if err == io.EOF {
+				logger.Debug("recieved response buffer is empty in record mode for mongo call")
+				destConn.Close()
+				return
+			}
 			logger.Error("failed to read reply from the mongo server", zap.Error(err), zap.String("mongo server address", destConn.RemoteAddr().String()), zap.Any("client conn id", clientConnId), zap.Any("dest conn id", destConnId))
 			return
 		}
@@ -477,6 +499,11 @@ func encodeOutgoingMongo(clientConnId, destConnId int64, requestBuffer []byte, c
 				responseBuffer, err = util.ReadBytes(destConn)
 				logStr += tmpStr
 				if err != nil {
+					if err == io.EOF {
+						logger.Debug("recieved response buffer is empty in record mode for mongo call")
+						destConn.Close()
+						return
+					}
 					logger.Error("failed to read reply from the mongo server", zap.Error(err), zap.String("mongo server address", destConn.RemoteAddr().String()), zap.Any("client conn id", clientConnId), zap.Any("dest conn id", destConnId))
 					return
 				}

--- a/pkg/proxy/integrations/mongoparser/mongoparser.go
+++ b/pkg/proxy/integrations/mongoparser/mongoparser.go
@@ -163,8 +163,10 @@ func decodeOutgoingMongo(clientConnId, destConnId int64, requestBuffer []byte, c
 								continue
 							}
 							for sectionIndx, section := range req.Message.(*models.MongoOpMessage).Sections {
-								score := compareOpMsgSection(section, mongoRequests[i].Message.(*models.MongoOpMessage).Sections[sectionIndx], logger)
-								scoreSum += score
+								if len(req.Message.(*models.MongoOpMessage).Sections) == len(mongoRequests[i].Message.(*models.MongoOpMessage).Sections) {
+									score := compareOpMsgSection(section, mongoRequests[i].Message.(*models.MongoOpMessage).Sections[sectionIndx], logger)
+									scoreSum += score
+								}
 							}
 							currentScore := scoreSum / float64(len(mongoRequests))
 							if currentScore > maxMatchScore {
@@ -256,15 +258,17 @@ func decodeOutgoingMongo(clientConnId, destConnId int64, requestBuffer []byte, c
 							if req.Message.(*models.MongoOpMessage).FlagBits != mongoRequests[i].Message.(*models.MongoOpMessage).FlagBits {
 								continue
 							}
-							if len(req.Message.(*models.MongoOpMessage).Sections) != len(mongoRequests[i].Message.(*models.MongoOpMessage).Sections) {
-								continue
-							}
+							scoreSum := 0.0
 							for sectionIndx, section := range req.Message.(*models.MongoOpMessage).Sections {
-								score := compareOpMsgSection(section, mongoRequests[i].Message.(*models.MongoOpMessage).Sections[sectionIndx], logger)
-								if score > maxMatchScore {
-									maxMatchScore = score
-									bestMatchIndex = tcsIndx
+								if len(req.Message.(*models.MongoOpMessage).Sections) == len(mongoRequests[i].Message.(*models.MongoOpMessage).Sections) {
+									score := compareOpMsgSection(section, mongoRequests[i].Message.(*models.MongoOpMessage).Sections[sectionIndx], logger)
+									scoreSum += score
 								}
+							}
+							currentScore := scoreSum / float64(len(mongoRequests))
+							if currentScore > maxMatchScore {
+								maxMatchScore = currentScore
+								bestMatchIndex = tcsIndx
 							}
 						default:
 							logger.Error("the OpCode of the mongo wiremessage is invalid.")

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -24,6 +24,7 @@ import (
 
 	"go.keploy.io/server/pkg"
 	"go.keploy.io/server/pkg/proxy/integrations/grpcparser"
+	postgresparser "go.keploy.io/server/pkg/proxy/integrations/postgresParser"
 
 	"github.com/cloudflare/cfssl/csr"
 	cfsslLog "github.com/cloudflare/cfssl/log"
@@ -38,7 +39,6 @@ import (
 	genericparser "go.keploy.io/server/pkg/proxy/integrations/genericParser"
 	"go.keploy.io/server/pkg/proxy/integrations/httpparser"
 	"go.keploy.io/server/pkg/proxy/integrations/mongoparser"
-	postgresparser "go.keploy.io/server/pkg/proxy/integrations/postgresParser"
 	"go.keploy.io/server/pkg/proxy/util"
 	"go.uber.org/zap"
 
@@ -117,7 +117,6 @@ func (c *Conn) Read(b []byte) (n int, err error) {
 
 	// return n, nil
 }
-
 
 // func (ps *ProxySet) SetHook(hook *hooks.Hook) {
 // 	ps.hook = hook

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
-	"math/rand"
 	"net"
 	"os"
 	"os/exec"
@@ -55,17 +54,19 @@ func getNextID() int64 {
 }
 
 type ProxySet struct {
-	IP4              uint32
-	IP6              [4]uint32
-	Port             uint32
-	hook             *hooks.Hook
-	logger           *zap.Logger
-	FilterPid        bool
-	Listener         net.Listener
-	DnsServer        *dns.Server
-	DnsServerTimeout time.Duration
-	dockerAppCmd     bool
-	PassThroughPorts []uint
+	IP4               uint32
+	IP6               [4]uint32
+	Port              uint32
+	hook              *hooks.Hook
+	logger            *zap.Logger
+	FilterPid         bool
+	clientConnections []net.Conn
+	connMutex         *sync.Mutex
+	Listener          net.Listener
+	DnsServer         *dns.Server
+	DnsServerTimeout  time.Duration
+	dockerAppCmd      bool
+	PassThroughPorts  []uint
 }
 
 type CustomConn struct {
@@ -365,13 +366,15 @@ func BootProxy(logger *zap.Logger, opt Option, appCmd, appContainer string, pid 
 	dIDE := (appCmd == "" && len(appContainer) != 0)
 
 	var proxySet = ProxySet{
-		Port:             opt.Port,
-		IP4:              proxyAddr4,
-		IP6:              proxyAddr6,
-		logger:           logger,
-		dockerAppCmd:     (dCmd || dIDE),
-		PassThroughPorts: passThroughPorts,
-		hook:             h,
+		Port:              opt.Port,
+		IP4:               proxyAddr4,
+		IP6:               proxyAddr6,
+		logger:            logger,
+		clientConnections: []net.Conn{},
+		connMutex:         &sync.Mutex{},
+		dockerAppCmd:      (dCmd || dIDE),
+		PassThroughPorts:  passThroughPorts,
+		hook:              h,
 	}
 
 	//setting the proxy port field in hook
@@ -593,6 +596,10 @@ func (ps *ProxySet) startProxy() {
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
+			if strings.Contains(err.Error(), "use of closed network connection") {
+				break
+			}
+
 			ps.logger.Error("failed to accept connection to the proxy", zap.Error(err))
 			// retry++
 			// if retry < 5 {
@@ -600,7 +607,9 @@ func (ps *ProxySet) startProxy() {
 			// }
 			break
 		}
-
+		ps.connMutex.Lock()
+		ps.clientConnections = append(ps.clientConnections, conn)
+		ps.connMutex.Unlock()
 		go func() {
 			defer ps.hook.Recover(pkg.GenerateRandomID())
 
@@ -863,11 +872,17 @@ func (ps *ProxySet) handleConnection(conn net.Conn, port uint32) {
 
 	// releases the occupied source port when done fetching the destination info
 	ps.hook.CleanProxyEntry(uint16(sourcePort))
-
+	
+	clientConnId := getNextID()
 	reader := bufio.NewReader(conn)
 	initialData := make([]byte, 5)
 	testBuffer, err := reader.Peek(len(initialData))
 	if err != nil {
+		if err == io.EOF && len(testBuffer) == 0 {
+			ps.logger.Debug("received EOF, closing connection", zap.Error(err), zap.Any("connectionID", clientConnId))
+			conn.Close()
+			return
+		}
 		ps.logger.Error("failed to peek the request message in proxy", zap.Error(err), zap.Any("proxy port", port))
 		return
 	}
@@ -886,8 +901,6 @@ func (ps *ProxySet) handleConnection(conn net.Conn, port uint32) {
 		}
 	}
 	connEstablishedAt := time.Now()
-	rand.Seed(time.Now().UnixNano())
-	clientConnId := getNextID()
 
 	// attempt to read the conn until buffer is either filled or connection is closed
 	var buffer []byte
@@ -1065,6 +1078,12 @@ func (ps *ProxySet) callNext(requestBuffer []byte, clientConn, destConn net.Conn
 }
 
 func (ps *ProxySet) StopProxyServer() {
+	ps.connMutex.Lock()
+	for _, clientConn := range ps.clientConnections {
+		clientConn.Close()
+	}
+	ps.connMutex.Unlock()
+
 	err := ps.Listener.Close()
 	if err != nil {
 		ps.logger.Error("failed to stop proxy server", zap.Error(err))

--- a/pkg/proxy/util/util.go
+++ b/pkg/proxy/util/util.go
@@ -200,35 +200,6 @@ func ReadBytes(reader io.Reader) ([]byte, error) {
 	return buffer, nil
 }
 
-func ReadBytes1(reader io.Reader) ([]byte, string, error) {
-	logStr := ""
-	var buffer []byte
-
-	for {
-		// Create a temporary buffer to hold the incoming bytes
-		buf := make([]byte, 1024)
-
-		// Read bytes from the Reader
-		n, err := reader.Read(buf)
-		// fmt.Println("read bytes: ", n , ", err: ", err)
-		logStr += fmt.Sprintln("read bytes: ", n, ", err: ", err)
-		if err != nil && err != io.EOF {
-			return nil, logStr, err
-		}
-
-		// Append the bytes to the buffer
-		buffer = append(buffer, buf[:n]...)
-
-		// If we've reached the end of the input stream, break out of the loop
-		// if err == io.EOF || n != 1024 {
-		if n != 1024 {
-			break
-		}
-	}
-
-	return buffer, logStr, nil
-}
-
 func GetLocalIPv4() (net.IP, error) {
 	ifaces, err := net.Interfaces()
 	if err != nil {


### PR DESCRIPTION
## Related Issue
  - Clean the exit loggs of Keploy CLI cmds.
 
Closes: #846 
#### Describe the changes you've made
Ignores the already closed error for the ringbuffer of eBPF during exit of Keploy CLI commands. And closes the existing client connections of proxy server when server is stopped during exit. Adds check before trying to kill the process with pid to filter unwanted error.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.