### PR TITLE
fix: log errors and stop user app

### DIFF
--- a/cmd/mockrecord.go
+++ b/cmd/mockrecord.go
@@ -78,5 +78,7 @@ func (mr *MockRecord) GetCmd() *cobra.Command {
 	serveCmd.Flags().StringP("mockName", "m", "", "User provided test suite")
 	serveCmd.MarkFlagRequired("mockName")
 
+	serveCmd.Hidden = true
+
 	return serveCmd
 }

--- a/cmd/mocktest.go
+++ b/cmd/mocktest.go
@@ -78,5 +78,7 @@ func (s *MockTest) GetCmd() *cobra.Command {
 	serveCmd.Flags().StringP("mockName", "m", "", "User provided test suite")
 	serveCmd.MarkFlagRequired("mockName")
 
+	serveCmd.Hidden = true
+
 	return serveCmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,7 +86,7 @@ Available Commands:{{range .Commands}}{{if .IsAvailableCommand}}
 Flags:
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableLocalFlags}}
 
-Guided Commands:{{range .Commands}}{{if not .IsAvailableCommand}}
+Guided Commands:{{range .Commands}}{{if and (not .IsAvailableCommand) (not .Hidden)}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}
 
 Examples:

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -122,5 +122,7 @@ func (s *Serve) GetCmd() *cobra.Command {
 	serveCmd.Flags().StringP("language", "l", "", "application programming language")
 	serveCmd.MarkFlagRequired("language")
 
+	serveCmd.Hidden = true
+
 	return serveCmd
 }

--- a/pkg/hooks/loader.go
+++ b/pkg/hooks/loader.go
@@ -349,7 +349,7 @@ func (h *Hook) Recover(id int) {
 
 	if r := recover(); r != nil {
 		h.logger.Debug("Recover from panic in go routine", zap.Any("current routine id", id), zap.Any("main routine id", h.mainRoutineId))
-		h.Stop(true)
+		h.Stop(true, nil)
 		// stop the user application cmd
 		h.StopUserApplication()
 		if id != h.mainRoutineId {
@@ -359,13 +359,20 @@ func (h *Hook) Recover(id int) {
 	}
 }
 
-func (h *Hook) Stop(forceStop bool) {
-	if !forceStop {
-		<-h.stopper
-		h.logger.Info("Received signal, exiting program..")
-		// stop the user application cmd
-		h.StopUserApplication()
+func (h *Hook) Stop(forceStop bool, close chan bool) {
 
+	if close == nil {
+		close = make(chan bool)
+	}
+
+	if !forceStop {
+		select {
+		case <-close:
+			return
+		case <-h.stopper:
+			h.logger.Info("Received signal to exit keploy program..")
+			h.StopUserApplication()
+		}
 	} else {
 		h.logger.Info("Exiting keploy program gracefully.")
 	}

--- a/pkg/models/testrun.go
+++ b/pkg/models/testrun.go
@@ -8,30 +8,34 @@ type TestReport struct {
 	Failure int          `json:"failure" yaml:"failure"`
 	Total   int          `json:"total" yaml:"total"`
 	Tests   []TestResult `json:"tests" yaml:"tests,omitempty"`
+	TestSet string       `json:"testSet" yaml:"test_set"`
 }
 
 type TestResult struct {
-	Kind         Kind         `json:"kind" yaml:"kind"`
-	Name         string       `json:"name" yaml:"name"`
-	Status       TestStatus   `json:"status" yaml:"status"`
-	Started      int64        `json:"started" yaml:"started"`
-	Completed    int64        `json:"completed" yaml:"completed"`
-	TestCasePath string       `json:"testCasePath" yaml:"test_case_path"`
-	MockPath     string       `json:"mockPath" yaml:"mock_path"`
-	TestCaseID   string       `json:"testCaseID" yaml:"test_case_id"`
-	Req          HttpReq  `json:"req" yaml:"req,omitempty"`
+	Kind         Kind       `json:"kind" yaml:"kind"`
+	Name         string     `json:"name" yaml:"name"`
+	Status       TestStatus `json:"status" yaml:"status"`
+	Started      int64      `json:"started" yaml:"started"`
+	Completed    int64      `json:"completed" yaml:"completed"`
+	TestCasePath string     `json:"testCasePath" yaml:"test_case_path"`
+	MockPath     string     `json:"mockPath" yaml:"mock_path"`
+	TestCaseID   string     `json:"testCaseID" yaml:"test_case_id"`
+	Req          HttpReq    `json:"req" yaml:"req,omitempty"`
 	// Mocks        []string     `json:"mocks" yaml:"mocks"`
-	Res          HttpResp `json:"resp" yaml:"resp,omitempty"`
-	Noise        []string     `json:"noise" yaml:"noise,omitempty"`
-	Result       Result       `json:"result" yaml:"result"`
+	Res    HttpResp `json:"resp" yaml:"resp,omitempty"`
+	Noise  []string `json:"noise" yaml:"noise,omitempty"`
+	Result Result   `json:"result" yaml:"result"`
 }
 
 type TestRunStatus string
 
 const (
-	TestRunStatusRunning TestRunStatus = "RUNNING"
-	TestRunStatusFailed  TestRunStatus = "FAILED"
-	TestRunStatusPassed  TestRunStatus = "PASSED"
+	TestRunStatusRunning      TestRunStatus = "RUNNING"
+	TestRunStatusFailed       TestRunStatus = "FAILED"
+	TestRunStatusPassed       TestRunStatus = "PASSED"
+	TestRunStatusAppHalted    TestRunStatus = "APP_HALTED"
+	TestRunStatusUserAbort    TestRunStatus = "USER_ABORT"
+	TestRunStatusFaultUserApp TestRunStatus = "APP_FAULT"
 )
 
 type Result struct {
@@ -43,7 +47,7 @@ type Result struct {
 
 type DepResult struct {
 	Name string          `json:"name" bson:"name" yaml:"name"`
-	Type string  `json:"type" bson:"type" yaml:"type"`
+	Type string          `json:"type" bson:"type" yaml:"type"`
 	Meta []DepMetaResult `json:"meta" bson:"meta" yaml:"meta"`
 }
 

--- a/pkg/service/mockrecord/mockrecord.go
+++ b/pkg/service/mockrecord/mockrecord.go
@@ -62,6 +62,6 @@ func (s *mockRecorder) MockRecord(path string, pid uint32, mockName string) {
 	s.logger.Info("Received signal, initiating graceful shutdown...")
 
 	// Shutdown other resources
-	loadedHooks.Stop(true)
+	loadedHooks.Stop(true, nil)
 	ps.StopProxyServer()
 }

--- a/pkg/service/mocktest/mocktest.go
+++ b/pkg/service/mocktest/mocktest.go
@@ -75,6 +75,6 @@ func (s *mockTester) MockTest(path string, pid uint32, mockName string) {
 	s.logger.Info("Received signal, initiating graceful shutdown...")
 
 	// Shutdown other resources
-	loadedHooks.Stop(true)
+	loadedHooks.Stop(true, nil)
 	ps.StopProxyServer()
 }

--- a/pkg/service/mocktest/mocktest.go
+++ b/pkg/service/mocktest/mocktest.go
@@ -58,7 +58,7 @@ func (s *mockTester) MockTest(path string, pid uint32, mockName string) {
 	configMocks, tcsMocks, err := ys.ReadMocks("")
 
 	if err != nil {
-		loadedHooks.Stop(true)
+		loadedHooks.Stop(true, nil)
 		ps.StopProxyServer()
 		return
 	}

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -68,7 +68,7 @@ func (r *recorder) CaptureTraffic(path string, appCmd, appContainer, appNetwork 
 			case hooks.ErrCommandError:
 				r.logger.Error("failed to run user application hence stopping keploy", zap.Error(err))
 			case hooks.ErrUnExpected:
-				r.logger.Error("user application terminated unexpectedly")
+				r.logger.Warn("user application terminated unexpectedly, please check application logs if this behaviour is expected")
 			default:
 				r.logger.Error("unknown error recieved from application")
 			}

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -54,23 +54,35 @@ func (r *recorder) CaptureTraffic(path string, appCmd, appContainer, appNetwork 
 	if err := loadedHooks.SendProxyInfo(ps.IP4, ps.Port, ps.IP6); err != nil {
 		return
 	}
-	// time.
+
+	stopHooksAbort := make(chan bool)
+	stoppedProxy := false
 
 	// start user application
-	if err := loadedHooks.LaunchUserApplication(appCmd, appContainer, appNetwork, Delay); err != nil {
-		r.logger.Error("failed to process user application hence stopping keploy", zap.Error(err))
-		loadedHooks.Stop(true)
+	go func() {
+		if err := loadedHooks.LaunchUserApplication(appCmd, appContainer, appNetwork, Delay); err != nil {
+			switch err {
+			case hooks.ErrInterrupted:
+				r.logger.Info("keploy terminated user application")
+				return
+			case hooks.ErrCommandError:
+				r.logger.Error("failed to run user application hence stopping keploy", zap.Error(err))
+			case hooks.ErrUnExpected:
+				r.logger.Error("user application terminated unexpectedly")
+			default:
+				r.logger.Error("unknown error recieved from application")
+			}
+		}
+		// stop listening for the eBPF events
+		loadedHooks.Stop(true, nil)
+		//stop listening for proxy server
 		ps.StopProxyServer()
-		return
+		stopHooksAbort <- true
+		stoppedProxy = true
+	}()
+
+	loadedHooks.Stop(false, stopHooksAbort)
+	if !stoppedProxy {
+		ps.StopProxyServer()
 	}
-
-	// Enable Pid Filtering
-	// loadedHooks.EnablePidFilter()
-	// ps.FilterPid = true
-
-	// stop listening for the eBPF events
-	loadedHooks.Stop(false)
-
-	//stop listening for proxy server
-	ps.StopProxyServer()
 }

--- a/pkg/service/serve/serve.go
+++ b/pkg/service/serve/serve.go
@@ -138,7 +138,7 @@ func (s *server) Serve(path, testReportPath string, Delay uint64, pid, port uint
 	}
 
 	// Shutdown other resources
-	loadedHooks.Stop(true)
+	loadedHooks.Stop(true, nil)
 	ps.StopProxyServer()
 
 	close(shutdown) // If you have other goroutines that should listen for this, you can use this channel to notify them.

--- a/pkg/service/test/service.go
+++ b/pkg/service/test/service.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"go.keploy.io/server/pkg/hooks"
+	"go.keploy.io/server/pkg/models"
 	"go.keploy.io/server/pkg/platform"
 	"go.keploy.io/server/pkg/platform/yaml"
 )
@@ -9,5 +10,5 @@ import (
 type Tester interface {
 	// Test(tcsPath, mockPath, testReportPath string, appCmd, appContainer, networkName string, Delay uint64) bool
 	Test(path, testReportPath string, appCmd, appContainer, networkName string, Delay uint64, passThorughPorts []uint, apiTimeout uint64) bool
-	RunTestSet(testSet, path, testReportPath, appCmd, appContainer, appNetwork string, delay uint64, pid uint32, ys platform.TestCaseDB, loadedHook *hooks.Hook, testReportfs yaml.TestReportFS, testRunChan chan string, apiTimeout uint64) bool
+	RunTestSet(testSet, path, testReportPath, appCmd, appContainer, appNetwork string, delay uint64, pid uint32, ys platform.TestCaseDB, loadedHook *hooks.Hook, testReportfs yaml.TestReportFS, testRunChan chan string, apiTimeout uint64) models.TestRunStatus
 }

--- a/pkg/service/test/test.go
+++ b/pkg/service/test/test.go
@@ -181,7 +181,7 @@ func (t *tester) RunTestSet(testSet, path, testReportPath, appCmd, appContainer,
 				case hooks.ErrCommandError:
 					t.logger.Error("failed to run user application hence stopping keploy", zap.Error(err))
 				case hooks.ErrUnExpected:
-					t.logger.Error("user application terminated unexpectedly")
+					t.logger.Warn("user application terminated unexpectedly, please check application logs if this behaviour is expected")
 				default:
 					t.logger.Error("unknown error recieved from application")
 				}
@@ -259,6 +259,10 @@ func (t *tester) RunTestSet(testSet, path, testReportPath, appCmd, appContainer,
 			case hooks.ErrCommandError:
 				exitLoop = true
 				status = models.TestRunStatusFaultUserApp
+			case hooks.ErrUnExpected:
+				exitLoop = true
+				status = models.TestRunStatusAppHalted
+				t.logger.Warn("stopping testrun for the test set:", zap.Any("test-set", testSet))
 			default:
 				exitLoop = true
 				status = models.TestRunStatusAppHalted

--- a/pkg/service/test/test.go
+++ b/pkg/service/test/test.go
@@ -158,6 +158,16 @@ func (t *tester) RunTestSet(testSet, path, testReportPath, appCmd, appContainer,
 
 	errChan := make(chan error)
 	t.logger.Debug("", zap.Any("app pid", pid))
+
+	defer func() {
+		if len(appCmd) == 0 && pid != 0 {
+			t.logger.Debug("no need to stop the user application when running keploy tests along with unit tests")
+		} else {
+			// stop the user application
+			loadedHooks.StopUserApplication()
+		}
+	}()
+
 	if len(appCmd) == 0 && pid != 0 {
 		t.logger.Debug("running keploy tests along with other unit tests")
 	} else {
@@ -388,13 +398,6 @@ func (t *tester) RunTestSet(testSet, path, testReportPath, appCmd, appContainer,
 
 	t.logger.Debug("the result before", zap.Any("", testReport.Status), zap.Any("testreport name", testReport.Name))
 	t.logger.Debug("the result after", zap.Any("", testReport.Status), zap.Any("testreport name", testReport.Name))
-
-	if len(appCmd) == 0 && pid != 0 {
-		t.logger.Debug("no need to stop the user application when running keploy tests along with unit tests")
-	} else {
-		// stop the user application
-		loadedHooks.StopUserApplication()
-	}
 
 	return status
 }


### PR DESCRIPTION
## Related Issue
  - Info about Issue or bug
  1. Occasionally when userApp don't run properly or when user command is not proper , that error is not logged and Keploy also doesn't stop.
  2. Few commands like serve and mockerRecord should be shown to user when user uses --help command.
  3. Test report doesn't contain parameter test-set which it belongs to , So this may cause a problem if user want to backtrack from test report to test.

Closes: [#855](https://github.com/keploy/keploy/issues/855)

#### Describe the changes you've made
A clear and concise description of what you have done to successfully close your assigned issue. Any new files? or anything you feel to let us know!

1. To fix userApp error problem following changes are made - 
    There can be three type of errors from userApp 
     i) UserInterrupt (Keploy will be killed by user and following Keploy will kill application)
     ii) CommandError (command give by user to run the app is fault)
    iii) UserAppError (User app has some problem and stopped suddenly)
    I have created all the errors and propagated into parent functions and logged the errors and made sure that both  keploy and userApp is closed when there is an error.
2. To not show commands like serve and mockRecord I have added the tag hidden and changed the template so that it doesn't even show in guided commands
3. To show test-set in test-report I have added test-set field in report




## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added
1. Just run Keploy without any subcommand to see whether the serve and mockRecord commands are anywhere to see.
2. Run keploy in record and test mode with any user App do the following 
    i) interrupt by pressing control-c and observer the logs
    ii) Give a wrong userApp cmd and observer the logs
   iii) Run the userApp separately and also try to run it via Keploy and observer the logs
4. Check the test-reports for test-set parameter


Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |