### PR TITLE
fix: catch signal and exit gracefully

### DIFF
--- a/pkg/service/mockrecord/mockrecord.go
+++ b/pkg/service/mockrecord/mockrecord.go
@@ -1,7 +1,11 @@
 package mockrecord
 
 import (
+	"fmt"
+	"os"
+	"os/signal"
 	"sync"
+	"syscall"
 
 	"go.keploy.io/server/pkg"
 	"go.keploy.io/server/pkg/hooks"
@@ -49,7 +53,15 @@ func (s *mockRecorder) MockRecord(path string, pid uint32, mockName string) {
 		return
 	}
 
+	// Listen for the interrupt signal
+	stopper := make(chan os.Signal, 1)
+	signal.Notify(stopper, syscall.SIGINT, syscall.SIGTERM)
+
+	fmt.Printf(Emoji+"Received signal:%v\n", <-stopper)
+
+	s.logger.Info("Received signal, initiating graceful shutdown...")
+
 	// Shutdown other resources
-	loadedHooks.Stop(false)
+	loadedHooks.Stop(true)
 	ps.StopProxyServer()
 }

--- a/pkg/service/mocktest/mocktest.go
+++ b/pkg/service/mocktest/mocktest.go
@@ -1,7 +1,11 @@
 package mocktest
 
 import (
+	"fmt"
+	"os"
+	"os/signal"
 	"sync"
+	"syscall"
 
 	"go.keploy.io/server/pkg"
 	"go.keploy.io/server/pkg/hooks"
@@ -62,7 +66,15 @@ func (s *mockTester) MockTest(path string, pid uint32, mockName string) {
 	loadedHooks.SetConfigMocks(configMocks)
 	loadedHooks.SetTcsMocks(tcsMocks)
 
+	// Listen for the interrupt signal
+	stopper := make(chan os.Signal, 1)
+	signal.Notify(stopper, syscall.SIGINT, syscall.SIGTERM)
+
+	fmt.Printf(Emoji+"Received signal:%v\n", <-stopper)
+
+	s.logger.Info("Received signal, initiating graceful shutdown...")
+
 	// Shutdown other resources
-	loadedHooks.Stop(false)
+	loadedHooks.Stop(true)
 	ps.StopProxyServer()
 }


### PR DESCRIPTION
## Related Issue

Previously go-sdk in killing mockRecord and mockTest process using os.Kill but it should be changed to SIGTERM as os.Kill cannot be catched by keploy .

Closes: [#878 ](https://github.com/keploy/keploy/issues/878)

#### Describe the changes you've made

Catched SIGTERM signal and close keploy gracefuly

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |