### PR TITLE
fix: empty testname when capturing the testcase

### DIFF
--- a/pkg/platform/yaml/yaml.go
+++ b/pkg/platform/yaml/yaml.go
@@ -178,7 +178,7 @@ func (ys *Yaml) WriteTestcase(tc *models.TestCase) error {
 		ys.Logger.Error("failed to write testcase yaml file", zap.Error(err))
 		return err
 	}
-	ys.Logger.Info("🟠 Keploy has captured test cases for the user's application.", zap.String("path", ys.TcsPath), zap.String("testcase name", ys.TcsName))
+	ys.Logger.Info("🟠 Keploy has captured test cases for the user's application.", zap.String("path", ys.TcsPath), zap.String("testcase name", tcsName))
 
 	// write the mock yamls
 	// mockName := fmt.Sprintf("mock-%v", lastIndx)


### PR DESCRIPTION
## Related Issue
  - Info about Issue or bug

Closes: #873

#### Describe the changes you've made
The name of test case is inside `tcsName` variable. I have updated the arguments of Logger.info function to pass `tcsName`. 

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

N/A

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| ![image](https://github.com/keploy/keploy/assets/91385321/83a2a81c-37c8-4b93-8c5d-8a8936abae21) | <b>![image](https://github.com/keploy/keploy/assets/91385321/84b9c874-902b-4f0f-a9c3-696d7fa479d2)</b> |