### PR TITLE
update:header set for outoging http call

### DIFF
--- a/pkg/util.go
+++ b/pkg/util.go
@@ -69,7 +69,7 @@ func SimulateHttp(tc models.TestCase, logger *zap.Logger, apiTimeout uint64) (*m
 		return nil, err
 	}
 	req.Header = ToHttpHeader(tc.HttpReq.Header)
-	req.Header.Set("KEPLOY_TEST_ID", tc.Name)
+	req.Header.Set("KEPLOY-TEST-ID", tc.Name)
 	req.ProtoMajor = tc.HttpReq.ProtoMajor
 	req.ProtoMinor = tc.HttpReq.ProtoMinor
 	req.Close = true


### PR DESCRIPTION
## Related Issue
  - Updating header for outgoing HTTP calls

Closes: #901 

#### Describe the changes you've made
Using _ (underscore) or . (dot) in HTTP header fields is technically possible, but it's not a common or recommended practice. The naming conventions for HTTP header fields are generally to use hyphens (-) to separate words, like Content-Type or User-Agent.
# Considerations:
## Standards Compliance:
According to the [HTTP/1.1 specification (RFC 2616)](https://tools.ietf.org/html/rfc2616#section-4.2), header field names are case-insensitive and can contain any printable ASCII character except colon (:). However, the convention is to use hyphen-separated words in Camel-Case format.
## Compatibility:
Some web servers, proxies, and libraries may expect header field names to follow the common convention and may not handle underscores or dots well. For example, Nginx by default does not allow underscores in HTTP header field names.
Readability and Maintenance:
Using uncommon characters can lead to confusion and make maintenance more difficult, as developers might not expect to see them in header field names.
## Client Behavior:
 Some HTTP clients may have unexpected behavior when encountering uncommon characters in header field names.
# Conclusion:
It's best to stick to the commonly used naming convention for HTTP header fields, which is hyphen-separated words, like X-Request-ID, to ensure the broadest compatibility and readability.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.