### PR TITLE
feat: option to name test cases

### DIFF
--- a/pkg/hooks/connection/factory.go
+++ b/pkg/hooks/connection/factory.go
@@ -133,7 +133,7 @@ func capture(db platform.TestCaseDB, req *http.Request, resp *http.Response, log
 	// err = db.Insert(httpMock, getDeps())
 	err = db.WriteTestcase(&models.TestCase{
 		Version: models.V1Beta2,
-		Name:    pkg.ToYamlHttpHeader(req.Header)["Keploy_test_name"],
+		Name:    pkg.ToYamlHttpHeader(req.Header)["Keploy-Test-Name"],
 		Kind:    models.HTTP,
 		Created: time.Now().Unix(),
 		HttpReq: models.HttpReq{

--- a/pkg/hooks/connection/factory.go
+++ b/pkg/hooks/connection/factory.go
@@ -133,7 +133,7 @@ func capture(db platform.TestCaseDB, req *http.Request, resp *http.Response, log
 	// err = db.Insert(httpMock, getDeps())
 	err = db.WriteTestcase(&models.TestCase{
 		Version: models.V1Beta2,
-		Name:    "",
+		Name:    pkg.ToYamlHttpHeader(req.Header)["Keploy_test_name"],
 		Kind:    models.HTTP,
 		Created: time.Now().Unix(),
 		HttpReq: models.HttpReq{

--- a/pkg/platform/yaml/yaml.go
+++ b/pkg/platform/yaml/yaml.go
@@ -42,18 +42,22 @@ func NewYamlStore(tcsPath string, mockPath string, tcsName string, mockName stri
 // createYamlFile is used to create the yaml file along with the path directory (if does not exists)
 func createYamlFile(path string, fileName string, Logger *zap.Logger) (bool, error) {
 	// checks id the yaml exists
-	if _, err := os.Stat(filepath.Join(path, fileName+".yaml")); err != nil {
+	yamlPath, err := ValidatePath(filepath.Join(path, fileName + ".yaml"))
+	if err != nil {
+		return false, err
+	}
+	if _, err := os.Stat(yamlPath); err != nil {
 		// creates the path director if does not exists
 		err = os.MkdirAll(filepath.Join(path), fs.ModePerm)
 		if err != nil {
-			Logger.Error("failed to create a directory for the yaml file", zap.Error(err), zap.Any("path directory", path), zap.Any("yaml", fileName))
+			Logger.Error("failed to create a directory for the yaml file", zap.Error(err), zap.Any("path directory", path), zap.Any("yaml", fileName)) // lgtm [go/clear-text-logging]
 			return false, err
 		}
 
 		// create the yaml file
-		_, err := os.Create(filepath.Join(path, fileName+".yaml"))
+		_, err := os.Create(yamlPath)
 		if err != nil {
-			Logger.Error("failed to create a yaml file", zap.Error(err), zap.Any("path directory", path), zap.Any("yaml", fileName))
+			Logger.Error("failed to create a yaml file", zap.Error(err), zap.Any("path directory", path), zap.Any("yaml", fileName)) // lgtm [go/clear-text-logging]
 			return false, err
 		}
 
@@ -122,9 +126,15 @@ func (ys *Yaml) Write(path, fileName string, doc NetworkTrafficDoc) error {
 	if err != nil {
 		return err
 	}
-	file, err := os.OpenFile(filepath.Join(path, fileName+".yaml"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, os.ModePerm)
+
+	yamlPath, err := ValidatePath(filepath.Join(path, fileName+".yaml"))
 	if err != nil {
-		ys.Logger.Error("failed to open the created yaml file", zap.Error(err), zap.Any("yaml file name", fileName))
+		return err 
+	}
+
+	file, err := os.OpenFile(yamlPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, os.ModePerm)
+	if err != nil {
+		ys.Logger.Error("failed to open the created yaml file", zap.Error(err), zap.Any("yaml file name", fileName)) // lgtm [go/clear-text-logging]
 		return err
 	}
 
@@ -134,14 +144,14 @@ func (ys *Yaml) Write(path, fileName string, doc NetworkTrafficDoc) error {
 	}
 	d, err := yamlLib.Marshal(&doc)
 	if err != nil {
-		ys.Logger.Error("failed to marshal the recorded calls into yaml", zap.Error(err), zap.Any("yaml file name", fileName))
+		ys.Logger.Error("failed to marshal the recorded calls into yaml", zap.Error(err), zap.Any("yaml file name", fileName)) // lgtm [go/clear-text-logging]
 		return err
 	}
 	data = append(data, d...)
 
 	_, err = file.Write(data)
 	if err != nil {
-		ys.Logger.Error("failed to write the yaml document", zap.Error(err), zap.Any("yaml file name", fileName))
+		ys.Logger.Error("failed to write the yaml document", zap.Error(err), zap.Any("yaml file name", fileName)) // lgtm [go/clear-text-logging]
 		return err
 	}
 	defer file.Close()
@@ -182,7 +192,7 @@ func (ys *Yaml) WriteTestcase(tc *models.TestCase) error {
 		ys.Logger.Error("failed to write testcase yaml file", zap.Error(err))
 		return err
 	}
-	ys.Logger.Info("🟠 Keploy has captured test cases for the user's application.", zap.String("path", ys.TcsPath), zap.String("testcase name", tcsName))
+	ys.Logger.Info("🟠 Keploy has captured test cases for the user's application.", zap.String("path", ys.TcsPath), zap.String("testcase name", tcsName)) // lgtm [go/clear-text-logging]
 
 	// write the mock yamls
 	// mockName := fmt.Sprintf("mock-%v", lastIndx)

--- a/pkg/platform/yaml/yaml.go
+++ b/pkg/platform/yaml/yaml.go
@@ -159,7 +159,11 @@ func (ys *Yaml) WriteTestcase(tc *models.TestCase) error {
 		if err != nil {
 			return err
 		}
-		tcsName = fmt.Sprintf("test-%v", lastIndx)
+		if tc.Name == "" {
+			tcsName = fmt.Sprintf("test-%v", lastIndx)
+		} else {
+			tcsName = tc.Name
+		}
 	} else {
 		tcsName = ys.TcsName
 	}

--- a/pkg/platform/yaml/yaml.go
+++ b/pkg/platform/yaml/yaml.go
@@ -50,14 +50,14 @@ func createYamlFile(path string, fileName string, Logger *zap.Logger) (bool, err
 		// creates the path director if does not exists
 		err = os.MkdirAll(filepath.Join(path), fs.ModePerm)
 		if err != nil {
-			Logger.Error("failed to create a directory for the yaml file", zap.Error(err), zap.Any("path directory", path), zap.Any("yaml", fileName)) // lgtm [go/clear-text-logging]
+			Logger.Error("failed to create a directory for the yaml file", zap.Error(err), zap.Any("path directory", path), zap.Any("yaml", fileName))
 			return false, err
 		}
 
 		// create the yaml file
 		_, err := os.Create(yamlPath)
 		if err != nil {
-			Logger.Error("failed to create a yaml file", zap.Error(err), zap.Any("path directory", path), zap.Any("yaml", fileName)) // lgtm [go/clear-text-logging]
+			Logger.Error("failed to create a yaml file", zap.Error(err), zap.Any("path directory", path), zap.Any("yaml", fileName))
 			return false, err
 		}
 
@@ -134,7 +134,7 @@ func (ys *Yaml) Write(path, fileName string, doc NetworkTrafficDoc) error {
 
 	file, err := os.OpenFile(yamlPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, os.ModePerm)
 	if err != nil {
-		ys.Logger.Error("failed to open the created yaml file", zap.Error(err), zap.Any("yaml file name", fileName)) // lgtm [go/clear-text-logging]
+		ys.Logger.Error("failed to open the created yaml file", zap.Error(err), zap.Any("yaml file name", fileName)) 
 		return err
 	}
 
@@ -144,14 +144,14 @@ func (ys *Yaml) Write(path, fileName string, doc NetworkTrafficDoc) error {
 	}
 	d, err := yamlLib.Marshal(&doc)
 	if err != nil {
-		ys.Logger.Error("failed to marshal the recorded calls into yaml", zap.Error(err), zap.Any("yaml file name", fileName)) // lgtm [go/clear-text-logging]
+		ys.Logger.Error("failed to marshal the recorded calls into yaml", zap.Error(err), zap.Any("yaml file name", fileName)) 
 		return err
 	}
 	data = append(data, d...)
 
 	_, err = file.Write(data)
 	if err != nil {
-		ys.Logger.Error("failed to write the yaml document", zap.Error(err), zap.Any("yaml file name", fileName)) // lgtm [go/clear-text-logging]
+		ys.Logger.Error("failed to write the yaml document", zap.Error(err), zap.Any("yaml file name", fileName)) 
 		return err
 	}
 	defer file.Close()
@@ -192,7 +192,7 @@ func (ys *Yaml) WriteTestcase(tc *models.TestCase) error {
 		ys.Logger.Error("failed to write testcase yaml file", zap.Error(err))
 		return err
 	}
-	ys.Logger.Info("🟠 Keploy has captured test cases for the user's application.", zap.String("path", ys.TcsPath), zap.String("testcase name", tcsName)) // lgtm [go/clear-text-logging]
+	ys.Logger.Info("🟠 Keploy has captured test cases for the user's application.", zap.String("path", ys.TcsPath), zap.String("testcase name", tcsName))
 
 	// write the mock yamls
 	// mockName := fmt.Sprintf("mock-%v", lastIndx)


### PR DESCRIPTION
## Related Issue
  - Info about Issue or bug

Closes: #880

#### Describe the changes you've made
Added the code to fetch the value from key: Keploy_Test_Name passed in the header of the request, and changed the value of `tcsName` with the value of our key since the variable is passed to the write .

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
N/A

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)
![image](https://github.com/keploy/keploy/assets/91385321/35619d7c-927c-4961-b229-45c6c54d1634)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **![image](https://github.com/keploy/keploy/assets/91385321/31510761-896d-4a31-a946-c559ad7679ab)** | <b>![image](https://github.com/keploy/keploy/assets/91385321/b9bd09f6-73b3-42ea-b7eb-644707d3df19)</b> |