### PR TITLE
Implement stopper in service layer

### DIFF
--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -1,6 +1,10 @@
 package record
 
 import (
+	"os"
+	"os/signal"
+	"syscall"
+
 	"go.keploy.io/server/pkg"
 	"go.keploy.io/server/pkg/hooks"
 	"go.keploy.io/server/pkg/models"
@@ -23,6 +27,12 @@ func NewRecorder(logger *zap.Logger) Recorder {
 
 // func (r *recorder) CaptureTraffic(tcsPath, mockPath string, appCmd, appContainer, appNetwork string, Delay uint64) {
 func (r *recorder) CaptureTraffic(path string, appCmd, appContainer, appNetwork string, Delay uint64, ports []uint) {
+
+	var ps *proxy.ProxySet
+
+	stopper := make(chan os.Signal, 1)
+	signal.Notify(stopper, os.Interrupt, os.Kill, syscall.SIGHUP, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGKILL)
+
 	models.SetMode(models.MODE_RECORD)
 
 	dirName, err := yaml.NewSessionIndex(path, r.logger)
@@ -39,13 +49,24 @@ func (r *recorder) CaptureTraffic(path string, appCmd, appContainer, appNetwork 
 	// Recover from panic and gracfully shutdown
 	defer loadedHooks.Recover(routineId)
 
-	// load the ebpf hooks into the kernel
-	if err := loadedHooks.LoadHooks(appCmd, appContainer, 0); err != nil {
+	select {
+	case <-stopper:
 		return
+	default:
+		// load the ebpf hooks into the kernel
+		if err := loadedHooks.LoadHooks(appCmd, appContainer, 0); err != nil {
+			return
+		}
 	}
 
-	// start the BootProxy
-	ps := proxy.BootProxy(r.logger, proxy.Option{}, appCmd, appContainer, 0, "", ports, loadedHooks)
+	select {
+	case <-stopper:
+		loadedHooks.Stop(true, nil)
+		return
+	default:
+		// start the BootProxy
+		ps = proxy.BootProxy(r.logger, proxy.Option{}, appCmd, appContainer, 0, "", ports, loadedHooks)
+	}
 
 	//proxy fetches the destIp and destPort from the redirect proxy map
 	// ps.SetHook(loadedHooks)
@@ -58,28 +79,35 @@ func (r *recorder) CaptureTraffic(path string, appCmd, appContainer, appNetwork 
 	stopHooksAbort := make(chan bool)
 	stoppedProxy := false
 
-	// start user application
-	go func() {
-		if err := loadedHooks.LaunchUserApplication(appCmd, appContainer, appNetwork, Delay); err != nil {
-			switch err {
-			case hooks.ErrInterrupted:
-				r.logger.Info("keploy terminated user application")
-				return
-			case hooks.ErrCommandError:
-				r.logger.Error("failed to run user application hence stopping keploy", zap.Error(err))
-			case hooks.ErrUnExpected:
-				r.logger.Warn("user application terminated unexpectedly, please check application logs if this behaviour is expected")
-			default:
-				r.logger.Error("unknown error recieved from application")
-			}
-		}
-		// stop listening for the eBPF events
+	select {
+	case <-stopper:
 		loadedHooks.Stop(true, nil)
-		//stop listening for proxy server
 		ps.StopProxyServer()
-		stopHooksAbort <- true
-		stoppedProxy = true
-	}()
+		return
+	default:
+		// start user application
+		go func() {
+			if err := loadedHooks.LaunchUserApplication(appCmd, appContainer, appNetwork, Delay); err != nil {
+				switch err {
+				case hooks.ErrInterrupted:
+					r.logger.Info("keploy terminated user application")
+					return
+				case hooks.ErrCommandError:
+					r.logger.Error("failed to run user application hence stopping keploy", zap.Error(err))
+				case hooks.ErrUnExpected:
+					r.logger.Warn("user application terminated unexpectedly, please check application logs if this behaviour is expected")
+				default:
+					r.logger.Error("unknown error recieved from application")
+				}
+			}
+			// stop listening for the eBPF events
+			loadedHooks.Stop(true, nil)
+			//stop listening for proxy server
+			ps.StopProxyServer()
+			stopHooksAbort <- true
+			stoppedProxy = true
+		}()
+	}
 
 	loadedHooks.Stop(false, stopHooksAbort)
 	if !stoppedProxy {

--- a/pkg/service/test/test.go
+++ b/pkg/service/test/test.go
@@ -117,14 +117,14 @@ func (t *tester) Test(path, testReportPath string, appCmd, appContainer, appNetw
 	}
 	t.logger.Info("test run completed", zap.Bool("passed overall", result))
 
+	stopHooksAbort <- true
+	stopProxyServerAbort <- true
+
 	// stop listening for the eBPF events
 	loadedHooks.Stop(true, nil)
 
 	//stop listening for proxy server
 	ps.StopProxyServer()
-
-	stopHooksAbort <- true
-	stopProxyServerAbort <- true
 
 	return true
 }

--- a/pkg/service/test/test.go
+++ b/pkg/service/test/test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"net/url"
@@ -39,6 +42,12 @@ func NewTester(logger *zap.Logger) Tester {
 // func (t *tester) Test(tcsPath, mockPath, testReportPath string, pid uint32) bool {
 // func (t *tester) Test(tcsPath, mockPath, testReportPath string, appCmd, appContainer, appNetwork string, Delay uint64) bool {
 func (t *tester) Test(path, testReportPath string, appCmd, appContainer, appNetwork string, Delay uint64, passThorughPorts []uint, apiTimeout uint64) bool {
+
+	var ps *proxy.ProxySet
+
+	stopper := make(chan os.Signal, 1)
+	signal.Notify(stopper, os.Interrupt, os.Kill, syscall.SIGHUP, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGKILL)
+
 	models.SetMode(models.MODE_TEST)
 
 	testReportFS := yaml.NewTestReportFS(t.logger)
@@ -53,13 +62,24 @@ func (t *tester) Test(path, testReportPath string, appCmd, appContainer, appNetw
 	// Recover from panic and gracfully shutdown
 	defer loadedHooks.Recover(routineId)
 
-	// load the ebpf hooks into the kernel
-	if err := loadedHooks.LoadHooks(appCmd, appContainer, 0); err != nil {
+	select {
+	case <-stopper:
 		return false
+	default:
+		// load the ebpf hooks into the kernel
+		if err := loadedHooks.LoadHooks(appCmd, appContainer, 0); err != nil {
+			return false
+		}
 	}
 
-	// start the proxy
-	ps := proxy.BootProxy(t.logger, proxy.Option{}, appCmd, appContainer, 0, "", passThorughPorts, loadedHooks)
+	select {
+	case <-stopper:
+		loadedHooks.Stop(true, nil)
+		return false
+	default:
+		// start the proxy
+		ps = proxy.BootProxy(t.logger, proxy.Option{}, appCmd, appContainer, 0, "", passThorughPorts, loadedHooks)
+	}
 
 	// proxy update its state in the ProxyPorts map
 	// ps.SetHook(loadedHooks)


### PR DESCRIPTION


## Related Issue
  - Info about Issue or bug

Closes: #906 

#### Describe the changes you've made
A clear and concise description of what you have done to successfully close your assigned issue. Any new files? or anything you feel to let us know!

Added stopper in record and test service

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| <img width="1105" alt="Screenshot 2023-09-28 at 10 16 56 AM" src="https://github.com/keploy/keploy/assets/72094895/7f1036c5-47fc-4b58-b577-8b779493b698"> | <img width="1110" alt="Screenshot 2023-09-28 at 10 23 23 AM" src="https://github.com/keploy/keploy/assets/72094895/07048177-b51e-4820-82ec-0dd6c6da9db5"> |