### PR TITLE
fix: adds delay for the second test-set in serve cmd

### DIFF
--- a/pkg/proxy/integrations/postgresParser/postgres_parser.go
+++ b/pkg/proxy/integrations/postgresParser/postgres_parser.go
@@ -224,6 +224,7 @@ func decodePostgresOutgoing(requestBuffer []byte, clientConn, destConn net.Conn,
 	ChangeAuthToMD5(tcsMocks, h, logger)
 
 	for {
+		tcsMocks := h.GetTcsMocks()
 		// Since protocol packets have to be parsed for checking stream end,
 		// clientConnection have deadline for read to determine the end of stream.
 		err := clientConn.SetReadDeadline(time.Now().Add(10 * time.Millisecond))
@@ -264,7 +265,7 @@ func decodePostgresOutgoing(requestBuffer []byte, clientConn, destConn net.Conn,
 		matched, pgResponses := matchingPg(tcsMocks, pgRequests, h)
 
 		if !matched {
-			logger.Error("failed to match the dependency call from user application", zap.Any("request packets", len(pgRequests)))
+			logger.Error("failed to match the dependency call from user application", zap.Any("the number of mocks", len(tcsMocks)), zap.Any("request packets", len(pgRequests)), zap.Any("requestBuffer", pgRequests[0]))
 			return errors.New("failed to match the dependency call from user application")
 			// continue
 		}

--- a/pkg/service/serve/graph/resolver.go
+++ b/pkg/service/serve/graph/resolver.go
@@ -23,6 +23,5 @@ type Resolver struct {
 	TestReportPath   string
 	Delay            uint64
 	AppPid           uint32
-	firstRequestDone bool
 	ApiTimeout       uint64
 }

--- a/pkg/service/serve/graph/schema.resolvers.go
+++ b/pkg/service/serve/graph/schema.resolvers.go
@@ -33,16 +33,6 @@ func (r *mutationResolver) RunTestSet(ctx context.Context, testSet string) (*mod
 	testReportPath := r.Resolver.TestReportPath
 	delay := r.Resolver.Delay
 
-	// since we are not restarting the application again and again,
-	// so we don't want for the test to wait for the delay time everytime a new test runs.
-	if r.firstRequestDone {
-		delay = 1
-	}
-
-	if !r.Resolver.firstRequestDone {
-		r.firstRequestDone = true
-	}
-
 	testReportFS := r.Resolver.TestReportFS
 	if tester == nil {
 		r.Logger.Error("failed to get testReportFS from resolver")


### PR DESCRIPTION
## Related Issue
  - When I run multiple test-sets in test with the unit test integration, then the http requests are triggered before the user application is restarted.

Closes: #918 

#### Describe the changes you've made
There is a `firstRequestDone` variable which is used to assign the delay to 1 for the simulation of requests. This PR removes that boolean so that the requests are triggered after the user application has been restarted in the unit-test integration. Also fixes the postgres issue to get the updated mocks each time before reading the next requests from postgres client.


## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added
Tested changes with the go-test library.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
NA

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
