### PR TITLE
fix: docker installation for macos in installation script

### DIFF
--- a/keploy.sh
+++ b/keploy.sh
@@ -80,7 +80,7 @@ installKeploy (){
         if [ "$OS_NAME" = "Darwin" ]; then
         #!/bin/bash
             if ! which docker &> /dev/null; then
-                echo echo -e "\e]8;;https://www.docker.com\Docker not found on device, install docker? (y/n)\e]8;;\a"
+                echo -n "Docker not found on device, install docker? (y/n):"
                 read user_input
                 if [ "$user_input" = "y" ]; then
                     echo "Installing docker via brew"


### PR DESCRIPTION
## Related Issue
  - In docker installation, echo was there 2 times and also there was no need to add link in that.


#### Describe the changes you've made
- Remove links in the echo output (where docker is not installed and takes input to install)
## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
`NA`

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |