### PR TITLE
Add version in binary and docker 

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,6 +62,11 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
+      - name: Set version
+        shell: bash
+        run: |
+          echo "VERSION=$(echo ${GITHUB_REF#refs/tags/v})" >> $GITHUB_ENV
+
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
@@ -73,7 +78,9 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: SENTRY_DSN_DOCKER=${{secrets.SENTRY_DSN_DOCKER}}
+          build-args: |
+            SENTRY_DSN_DOCKER=${{secrets.SENTRY_DSN_DOCKER}}
+            VERSION=${{ env.VERSION }}
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ FROM golang:1.21 AS build
 # Set the working directory
 WORKDIR /app
 
+# Define build arguments for ldflags
+ARG SENTRY_DSN_DOCKER
+ARG VERSION
+
 # Copy the Go module files and download dependencies
 COPY go.mod go.sum /app/
 RUN go mod download
@@ -12,14 +16,10 @@ RUN go mod download
 COPY . /app
 
 # Build the keploy binary
-RUN go build -o keploy .
+RUN go build -ldflags="-X main.Dsn=$SENTRY_DSN_DOCKER -X main.version=$VERSION" -o keploy .
 
 # === Runtime Stage ===
 FROM debian:bookworm-slim
-
-ARG SENTRY_DSN_DOCKER
-ENV IS_DOCKER_CMD=true
-ENV Dsn=$SENTRY_DSN_DOCKER
 
 # Update the package lists and install required packages
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ RUN go build -ldflags="-X main.Dsn=$SENTRY_DSN_DOCKER -X main.version=$VERSION" 
 # === Runtime Stage ===
 FROM debian:bookworm-slim
 
+ENV IS_DOCKER_CMD=true 
+
 # Update the package lists and install required packages
 RUN apt-get update && \
     apt-get install -y ca-certificates curl sudo && \

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -9,6 +9,7 @@ builds:
     main: ./main.go
     ldflags:
       - -s -w -X main.Dsn={{.Env.SENTRY_DSN_BINARY}}
+      - -s -w -X main.version={{.Version}}
     env:
       - CGO_ENABLED=0
     goos:

--- a/main.go
+++ b/main.go
@@ -3,14 +3,10 @@ package main
 import (
 	"fmt"
 	_ "net/http/pprof"
-	"os"
 	"time"
 
-	sentry "github.com/getsentry/sentry-go"
-	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/cloudflare/cfssl/log"
-	v "github.com/hashicorp/go-version"
+	sentry "github.com/getsentry/sentry-go"
 	"go.keploy.io/server/cmd"
 	"go.keploy.io/server/utils"
 )
@@ -19,7 +15,7 @@ import (
 // see https://goreleaser.com/customization/build/
 
 var version string
-var Dsn string
+var dsn string
 
 const logo string = `
        ▓██▓▄
@@ -33,54 +29,15 @@ const logo string = `
         ▓
 `
 
-func getKeployVersion() string {
-
-	repo, err := git.PlainOpen(".")
-	if err != nil {
-		return "v0.1.0-dev"
-	}
-
-	tagIter, err := repo.Tags()
-	if err != nil {
-		return "v0.1.0-dev"
-	}
-	var latestTag string
-	var latestTagVersion *v.Version
-
-	err = tagIter.ForEach(func(tagRef *plumbing.Reference) error {
-		tagName := tagRef.Name().Short()
-		tagVersion, err := v.NewVersion(tagName)
-		if err == nil {
-			if latestTagVersion == nil || latestTagVersion.LessThan(tagVersion) {
-				latestTagVersion = tagVersion
-				latestTag = tagName
-			}
-		}
-		return nil
-	})
-
-	if err != nil {
-		return "v0.1.0-dev"
-	}
-
-	return latestTag + "-dev"
-}
-
-
 func main() {
 	if version == "" {
-		version = getKeployVersion()
+		version = "2-dev"
 	}
 	fmt.Println(logo, " ")
 	fmt.Printf("version: %v\n\n", version)
-	fmt.Printf("dsn: %v\n\n", Dsn)
-	isDocker := os.Getenv("IS_DOCKER_CMD")
-	if isDocker != "" {
-		Dsn = os.Getenv("Dsn")
-	}
 	//Initialise sentry.
 	err := sentry.Init(sentry.ClientOptions{
-		Dsn:              Dsn,
+		Dsn:              dsn,
 		TracesSampleRate: 1.0,
 	})
 	log.Level = 0

--- a/main.go
+++ b/main.go
@@ -72,7 +72,8 @@ func main() {
 		version = getKeployVersion()
 	}
 	fmt.Println(logo, " ")
-	fmt.Printf("%v\n\n", version)
+	fmt.Printf("version: %v\n\n", version)
+	fmt.Printf("dsn: %v\n\n", Dsn)
 	isDocker := os.Getenv("IS_DOCKER_CMD")
 	if isDocker != "" {
 		Dsn = os.Getenv("Dsn")


### PR DESCRIPTION
## Related Issue
  - Info about Issue or bug

Closes: #1029

#### Describe the changes you've made

There are 3 different scenarios where the version should be appeared in CLI output
1. When user runs released binary of keploy
2. When user runs released docker of keploy
3. When developer runs keploy in local by cloning keploy (docker as well as binary)

i) The 3rd scenario is nearly impossible because, when a developer forks keploy repository the release tags aren't pulled into the fork by default. So it is not possible to get the tags/version. I have tried multiple ways like 
--Pulling tags through code in main.go and using them but I found that we can't just pull tags but commit will also be pulled with the tags which will mess developer repo.
--Doing a request to keploy repo with each commit in dev repo and seeing if there is a tag associated with it or not . But this is taking lot of time like 4-5 sec which is not preferable for just getting version.
I have referred other project and they were not printing the version in the output but they were printing the major version and a suffix like "dev". So I have also decided to do the same by printing "2-dev" in case of developer running keploy.

ii) Regarding 1st scenario previously version used to be appeared in the release binary but it stopped appearing after adding this line in goreleaser
` - -s -w -X main.Dsn={{.Env.SENTRY_DSN_BINARY}}`
I have did a bit of research and found out that by default these ldflags will be added
`-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser.`
So when we add a custom ldflag like SENTRY_DSN_BINARY the default will be erased and only custom will be taken up. Confirmed from go releaser maintainer - https://github.com/goreleaser/goreleaser/issues/4377
So I have added the version ldflag into the custom

iii) For 2nd scenario I have added the version from tag into the docker-publish and into Dockerfile to show the version.

I have also changed how dsn in being populated

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

Ignore the values in the version those were test numbers.
Developer:

<img width="1440" alt="Screenshot 2023-10-19 at 11 49 01 AM" src="https://github.com/keploy/keploy/assets/72094895/8c0f4559-cd99-4e67-b56e-25400105d74a">

Binary:

<img width="1440" alt="Screenshot 2023-10-19 at 11 49 12 AM" src="https://github.com/keploy/keploy/assets/72094895/1a125182-5072-480d-9b4a-a19d7e3f54b1">

Docker:

<img width="1440" alt="Screenshot 2023-10-19 at 11 49 45 AM" src="https://github.com/keploy/keploy/assets/72094895/6aa550bc-4544-44ce-8876-de3dfa809d25">



