### PR TITLE
fix: updates the decode function for OpMsg section

### DIFF
--- a/pkg/proxy/integrations/mongoparser/mongoparser.go
+++ b/pkg/proxy/integrations/mongoparser/mongoparser.go
@@ -689,7 +689,7 @@ func compareOpMsgSection(expectedSection, actualSection string, logger *zap.Logg
 		return score
 	case strings.HasPrefix(expectedSection, "{ SectionSingle msg:"):
 		var expectedMsgsStr string
-		expectedMsgsStr, err := decodeOpMsgSectionSingle(actualSection)
+		expectedMsgsStr, err := extractSectionSingle(actualSection)
 		if err != nil {
 			logger.Error("failed to fetch the msgs from the single section of recorded OpMsg", zap.Error(err))
 			return 0
@@ -699,7 +699,7 @@ func compareOpMsgSection(expectedSection, actualSection string, logger *zap.Logg
 		// // Find submatches using the regular expression
 
 		var actualMsgsStr string
-		actualMsgsStr, err = decodeOpMsgSectionSingle(actualSection)
+		actualMsgsStr, err = extractSectionSingle(actualSection)
 		if err != nil {
 			logger.Error("failed to fetch the msgs from the single section of incoming OpMsg", zap.Error(err))
 			return 0


### PR DESCRIPTION

## Related Issue
  - Test fails for the mongo call which have have a substring containing ` }` in the sectionSingle of OpMsg like:
  ``` "errmsg":"Error in specification { background: true, name: \"merchant_id_text_url_text_hash_hashed\", key: { merchant_id: \"text\", url: \"text\", hash: \"hashed\" } } :: caused by :: Can''t use more than one index plugin for a single index." ```.
  Due to which keploy is not able to extract and encode into the message back to the binary Mongo wire message.
Closes: #[issue number that will be closed through this PR]

#### Describe the changes you've made
The decode function is not able to distinguish the closing braces of the string json and sectionSingle, so used the prefix and suffix in place of regex to extract the document correctly

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Tested the changes with gin-mongo API. And the problamatic example of OpMsg in isolation

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
