### PR TITLE
fix: i/o timeout while reading http response

### DIFF
--- a/pkg/proxy/integrations/httpparser/httpparser.go
+++ b/pkg/proxy/integrations/httpparser/httpparser.go
@@ -128,7 +128,9 @@ func chunkedRequest(finalReq *[]byte, clientConn, destConn net.Conn, logger *zap
 				logger.Error("failed to write request message to the destination server", zap.Error(err))
 				return
 			}
-			if string(requestChunked) == "0\r\n\r\n" {
+
+			//check if the intial request is completed
+			if strings.HasSuffix(string(requestChunked), "0\r\n\r\n") {
 				break
 			}
 		}
@@ -237,6 +239,10 @@ func handleChunkedRequests(finalReq *[]byte, clientConn, destConn net.Conn, logg
 			contentLengthRequest(finalReq, clientConn, destConn, logger, contentLength)
 		}
 	} else if transferEncodingHeader != "" {
+		// check if the intial request is the complete request.
+		if strings.HasSuffix(string(*finalReq), "0\r\n\r\n") {
+			return
+		}
 		chunkedRequest(finalReq, clientConn, destConn, logger, transferEncodingHeader)
 	}
 }
@@ -267,6 +273,10 @@ func handleChunkedResponses(finalResp *[]byte, clientConn, destConn net.Conn, lo
 			contentLengthResponse(finalResp, clientConn, destConn, logger, contentLength)
 		}
 	} else if transferEncodingHeader != "" {
+		//check if the intial response is the complete response.
+		if strings.HasSuffix(string(*finalResp), "0\r\n\r\n") {
+			return
+		}
 		chunkedResponse(finalResp, clientConn, destConn, logger, transferEncodingHeader)
 	}
 }
@@ -517,11 +527,11 @@ func encodeOutgoingHttp(request []byte, clientConn, destConn net.Conn, logger *z
 			}
 			finalReq = append(finalReq, request...)
 		}
-		
+
 		// Capture the request timestamp
 		reqTimestampMock := time.Now()
 
-		handleChunkedRequests(&finalReq, clientConn, destConn, logger)		
+		handleChunkedRequests(&finalReq, clientConn, destConn, logger)
 		// read the response from the actual server
 		resp, err = util.ReadBytes(destConn)
 		if err != nil {
@@ -574,7 +584,6 @@ func encodeOutgoingHttp(request []byte, clientConn, destConn net.Conn, logger *z
 		var respBody []byte
 		//Checking if the body of the response is empty or does not exist.
 
-
 		if respParsed.Body != nil { // Read
 			if respParsed.Header.Get("Content-Encoding") == "gzip" {
 				check := respParsed.Body
@@ -626,7 +635,7 @@ func encodeOutgoingHttp(request []byte, clientConn, destConn net.Conn, logger *z
 					Header:     pkg.ToYamlHttpHeader(respParsed.Header),
 					Body:       string(respBody),
 				},
-				Created: time.Now().Unix(),
+				Created:          time.Now().Unix(),
 				ReqTimestampMock: reqTimestampMock,
 				ResTimestampMock: resTimestampcMock,
 			},


### PR DESCRIPTION
## Related Issue
  - Keploy throws i/o timeout while reading http response for the 2nd and subsequent mocks.

Closes: #1062 

#### Describe the changes you've made
- Added a return statement when there is `Transfer-Encoding:chunked` request/response but the complete request/response (including body) comes in the initial packet only.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
`NA`

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |