### PR TITLE
fix: updates the auth calls to config for mongo

### DIFF
--- a/pkg/service/test/test.go
+++ b/pkg/service/test/test.go
@@ -34,15 +34,15 @@ type tester struct {
 	mutex  sync.Mutex
 }
 type TestOptions struct {
-	MongoPassword string
-	Delay uint64
+	MongoPassword    string
+	Delay            uint64
 	PassThorughPorts []uint
-	ApiTimeout uint64
-	Testsets []string
-	AppContainer string
-	AppNetwork string
-	ProxyPort uint32
-	NoiseConfig map[string]interface{}
+	ApiTimeout       uint64
+	Testsets         []string
+	AppContainer     string
+	AppNetwork       string
+	ProxyPort        uint32
+	NoiseConfig      map[string]interface{}
 }
 
 func NewTester(logger *zap.Logger) Tester {
@@ -219,7 +219,6 @@ func (t *tester) RunTestSet(testSet, path, testReportPath, appCmd, appContainer,
 	loadedHooks.SetConfigMocks(configMocks)
 	loadedHooks.SetTcsMocks(tcsMocks)
 
-
 	errChan := make(chan error, 1)
 	t.logger.Debug("", zap.Any("app pid", pid))
 
@@ -353,15 +352,15 @@ func (t *tester) RunTestSet(testSet, path, testReportPath, appCmd, appContainer,
 				t.logger.Info("result", zap.Any("testcase id", models.HighlightFailingString(tc.Name)), zap.Any("testset id", models.HighlightFailingString(testSet)), zap.Any("passed", models.HighlightFailingString("false")))
 				continue
 			}
-      
+
 			testPass, testResult := t.testHttp(*tc, resp, noiseConfig)
-			
+
 			if !testPass {
 				t.logger.Info("result", zap.Any("testcase id", models.HighlightFailingString(tc.Name)), zap.Any("testset id", models.HighlightFailingString(testSet)), zap.Any("passed", models.HighlightFailingString(testPass)))
 			} else {
 				t.logger.Info("result", zap.Any("testcase id", models.HighlightPassingString(tc.Name)), zap.Any("testset id", models.HighlightPassingString(testSet)), zap.Any("passed", models.HighlightPassingString(testPass)))
 			}
-			
+
 			testStatus := models.TestStatusPending
 			if testPass {
 				testStatus = models.TestStatusPassed
@@ -433,14 +432,14 @@ func (t *tester) RunTestSet(testSet, path, testReportPath, appCmd, appContainer,
 
 	err = testReportFS.Write(context.Background(), testReportPath, testReport)
 
-	t.logger.Info("test report for " + testSet + ": " , zap.Any("name: ", testReport.Name), zap.Any("path: ", path + "/" + testReport.Name))
+	t.logger.Info("test report for "+testSet+": ", zap.Any("name: ", testReport.Name), zap.Any("path: ", path+"/"+testReport.Name))
 
 	if status == models.TestRunStatusFailed {
 		pp.SetColorScheme(models.FailingColorScheme)
 	} else {
 		pp.SetColorScheme(models.PassingColorScheme)
 	}
-	
+
 	pp.Printf("\n <=========================================> \n  TESTRUN SUMMARY. For testrun with id: %s\n"+"\tTotal tests: %s\n"+"\tTotal test passed: %s\n"+"\tTotal test failed: %s\n <=========================================> \n\n", testReport.TestSet, testReport.Total, testReport.Success, testReport.Failure)
 
 	if err != nil {


### PR DESCRIPTION
## Related Issue
  - The authentication mocks for mongo are captured once and filtered on the basis of captured time before simulation, due to which the testrun fails for multiple testcases in the test-set. 
  - The mocks are fetched and stored locally before the read blocking call due to which the matching of requests fails since there are no mock requests to match with. This results in test run failure

Closes: #1103 

#### Describe the changes you've made
  - Updates the authentication calls in mongo protocol to config calls for the database connection.
  -  Fixes the issue of accessing an empty array after simulation by fetching tcs mocks after connection.read call

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Tested the changes with the gin-mongo sample which connects to documentDB database.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
