### PR TITLE
fix: tls connection in python

### DIFF
--- a/pkg/proxy/asset/setup_ca.sh
+++ b/pkg/proxy/asset/setup_ca.sh
@@ -95,6 +95,12 @@ handle_tls_setup() {
 # Log the NODE_EXTRA_CA_CERTS environment variable
   echo "NODE_EXTRA_CA_CERTS is set to: $NODE_EXTRA_CA_CERTS"
 
+  # Set the REQUESTS_CA_BUNDLE to the same value as NODE_EXTRA_CA_CERTS for python
+  export REQUESTS_CA_BUNDLE=$NODE_EXTRA_CA_CERTS
+
+  # Log the REQUESTS_CA_BUNDLE environment variable
+  echo "REQUESTS_CA_BUNDLE is set to: $REQUESTS_CA_BUNDLE"
+
   echo "Setup successful"
 }
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -340,9 +340,16 @@ func BootProxy(logger *zap.Logger, opt Option, appCmd, appContainer string, pid 
 		logger.Error(Emoji+"Failed to extract certificate to tmp folder: %v", zap.Any("failed to extract certificate", err))
 	}
 
+	// for node
 	err = os.Setenv("NODE_EXTRA_CA_CERTS", tempCertPath)
 	if err != nil {
 		logger.Error(Emoji+"Failed to set environment variable NODE_EXTRA_CA_CERTS: %v", zap.Any("failed to certificate path in environment", err))
+	}
+
+	// for python
+	err = os.Setenv("REQUESTS_CA_BUNDLE", tempCertPath)
+	if err != nil {
+		logger.Error(Emoji+"Failed to set environment variable REQUESTS_CA_BUNDLE: %v", zap.Any("failed to certificate path in environment", err))
 	}
 
 	if opt.Port == 0 {


### PR DESCRIPTION
## Related Issue
  - Unable to handle TLS connection in case of Python virtual env, in the regular environment it's working.

Closes: #1107 

#### Describe the changes you've made
- Set an environment variable `REQUESTS_CA_BUNDLE` in the case of Python to use our custom CA for TLS connections.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
`NA`

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |