### PR TITLE
fix: sets the auth password for mongo to handle scram authentication

### DIFF
--- a/pkg/proxy/integrations/mongoparser/mongoparser.go
+++ b/pkg/proxy/integrations/mongoparser/mongoparser.go
@@ -26,16 +26,13 @@ var Emoji = "\U0001F430" + " Keploy:"
 var configRequests = []string{""}
 var password string
 
-func SetAuthPassword(p string) {
-	password = p
-}
-
 type MongoParser struct {
 	logger *zap.Logger
 	hooks  *hooks.Hook
 }
 
-func NewMongoParser(logger *zap.Logger, h *hooks.Hook) *MongoParser {
+func NewMongoParser(logger *zap.Logger, h *hooks.Hook, authPassword string) *MongoParser {
+	password = authPassword
 	return &MongoParser{
 		logger: logger,
 		hooks:  h,

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -313,7 +313,7 @@ func BootProxy(logger *zap.Logger, opt Option, appCmd, appContainer string, pid 
 	//Register all the parsers in the map.
 	Register("grpc", grpcparser.NewGrpcParser(logger, h))
 	Register("postgres", postgresparser.NewPostgresParser(logger, h))
-	Register("mongo", mongoparser.NewMongoParser(logger, h))
+	Register("mongo", mongoparser.NewMongoParser(logger, h, opt.MongoPassword))
 	Register("http", httpparser.NewHttpParser(logger, h))
 	Register("mysql", mysqlparser.NewMySqlParser(logger, h))
 	// assign default values if not provided

--- a/pkg/service/test/test.go
+++ b/pkg/service/test/test.go
@@ -89,7 +89,7 @@ func (t *tester) InitialiseTest(cfg *TestConfig) (InitialiseTestReturn, error) {
 		return returnVal, errors.New("Keploy was interupted by stopper")
 	default:
 		// start the proxy
-		returnVal.ProxySet = proxy.BootProxy(t.logger, proxy.Option{Port: cfg.Proxyport}, cfg.AppCmd, cfg.AppContainer, 0, "", cfg.PassThorughPorts, returnVal.LoadedHooks, context.Background())
+		returnVal.ProxySet = proxy.BootProxy(t.logger, proxy.Option{Port: cfg.Proxyport, MongoPassword: cfg.MongoPassword}, cfg.AppCmd, cfg.AppContainer, 0, "", cfg.PassThorughPorts, returnVal.LoadedHooks, context.Background())
 	}
 
 	// proxy update its state in the ProxyPorts map
@@ -162,6 +162,7 @@ func (t *tester) Test(path string, testReportPath string, appCmd string, options
 		Delay:            options.Delay,
 		PassThorughPorts: options.PassThorughPorts,
 		ApiTimeout:       options.ApiTimeout,
+		MongoPassword:    options.MongoPassword,
 	}
 	initialisedValues, err := t.InitialiseTest(cfg)
 	// Recover from panic and gracfully shutdown

--- a/pkg/service/test/util.go
+++ b/pkg/service/test/util.go
@@ -46,6 +46,7 @@ type TestConfig struct {
 	Proxyport        uint32
 	TestReportPath   string
 	AppCmd           string
+	MongoPassword    string
 	Testsets         *[]string
 	AppContainer     string
 	AppNetwork       string


### PR DESCRIPTION
## Related Issue
  - Fails in test mode for a documentDB application.

Closes: #1129 

#### Describe the changes you've made
Assigns the value of the mongoPassword configured via the test cmd flags to the mongoParser in order to handle the scram authentication.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

I have recorded and tested some APIs of a go and java application which make external calls to DocumentDB.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
