### PR TITLE
fix: remove timeout from chunking

### DIFF
--- a/pkg/proxy/integrations/httpparser/httpparser.go
+++ b/pkg/proxy/integrations/httpparser/httpparser.go
@@ -202,18 +202,13 @@ func contentLengthResponse(finalResp *[]byte, clientConn, destConn net.Conn, log
 func chunkedResponse(finalResp *[]byte, clientConn, destConn net.Conn, logger *zap.Logger, transferEncodingHeader string) {
 	if transferEncodingHeader == "chunked" {
 		for {
-			//Set deadline of 5 seconds
-			destConn.SetReadDeadline(time.Now().Add(5 * time.Second))
 			resp, err := util.ReadBytes(destConn)
-			if err != nil && err != io.EOF {
-				//Check if the connection closed.
-				if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-					//Check if the deadline is reached.
-					logger.Debug("Stopped getting buffer from the destination server")
-					break
-				} else {
+			if err != nil {
+				if err != io.EOF {
 					logger.Debug("failed to read the response message from the destination server", zap.Error(err))
 					return
+				} else {
+					break
 				}
 			}
 			*finalResp = append(*finalResp, resp...)

--- a/pkg/proxy/integrations/httpparser/httpparser.go
+++ b/pkg/proxy/integrations/httpparser/httpparser.go
@@ -208,6 +208,7 @@ func chunkedResponse(finalResp *[]byte, clientConn, destConn net.Conn, logger *z
 					logger.Debug("failed to read the response message from the destination server", zap.Error(err))
 					return
 				} else {
+					logger.Debug("recieved EOF, exiting loop as response is complete", zap.Error(err))
 					break
 				}
 			}


### PR DESCRIPTION
## Related Issue
  Chunked http integration is failed because of the timeout implemented at the httpparser .

Closes: #1127

#### Describe the changes you've made
The server can take its own time to send the chuck response . There is no time limit in it. But we have introduced a time limit of 5 seconds in our proxy which cause the issue mentioned above. Removed the time out implementation to resolve this issue.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

I have tested the sample apps provided in the issue and everything worked out fine after implementing changes.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
NA

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |