### PR TITLE
refactor: error handling when running keploy serve

### DIFF
--- a/pkg/hooks/launch.go
+++ b/pkg/hooks/launch.go
@@ -37,7 +37,7 @@ var (
 	ErrCommandError   = errors.New("exited due to command error")
 	ErrUnExpected     = errors.New("an unexpected error occurred")
 	ErrDockerError    = errors.New("an error occurred while using docker client")
-	ErrFailedUnitTest = errors.New("any test failure occured when running keploy tests along with unit tests")
+	ErrFailedUnitTest = errors.New("test failure occured when running keploy tests along with unit tests")
 )
 
 func (h *Hook) LaunchUserApplication(appCmd, appContainer, appNetwork string, Delay uint64, isUnitTestIntegration bool) error {
@@ -524,9 +524,9 @@ func (h *Hook) runApp(appCmd string, isUnitTestIntegration bool) error {
 			h.logger.Warn("userApplication might not have shut down correctly. Please verify if it has been closed", zap.Error(err))
 			return ErrInterrupted
 		}
-		
+
 		// This is done for non-server running commands like "mvn test", "npm test", "go test" etc
-		if isUnitTestIntegration{
+		if isUnitTestIntegration {
 			return ErrFailedUnitTest
 		}
 		h.logger.Error("userApplication failed to run with the following error. Please check application logs", zap.Error(err))

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -98,7 +98,7 @@ func (r *recorder) CaptureTraffic(path string, proxyPort uint32, appCmd, appCont
 		// start user application
 		go func() {
 			stopApplication := false
-			if err := loadedHooks.LaunchUserApplication(appCmd, appContainer, appNetwork, Delay); err != nil {
+			if err := loadedHooks.LaunchUserApplication(appCmd, appContainer, appNetwork, Delay, false); err != nil {
 				switch err {
 				case hooks.ErrInterrupted:
 					r.Logger.Info("keploy terminated user application")

--- a/pkg/service/test/test.go
+++ b/pkg/service/test/test.go
@@ -258,7 +258,7 @@ func (t *tester) InitialiseRunTestSet(cfg *RunTestSetConfig) InitialiseRunTestSe
 		// start user application
 		if !cfg.ServeTest {
 			go func() {
-				if err := cfg.LoadedHooks.LaunchUserApplication(cfg.AppCmd, cfg.AppContainer, cfg.AppNetwork, cfg.Delay); err != nil {
+				if err := cfg.LoadedHooks.LaunchUserApplication(cfg.AppCmd, cfg.AppContainer, cfg.AppNetwork, cfg.Delay, false); err != nil {
 					switch err {
 					case hooks.ErrInterrupted:
 						t.logger.Info("keploy terminated user application")
@@ -460,7 +460,7 @@ func (t *tester) RunTestSet(testSet, path, testReportPath, appCmd, appContainer,
 	if initialisedValues.InitialStatus != "" {
 		return initialisedValues.InitialStatus
 	}
-	
+
 	isApplicationStopped := false
 	// Recover from panic and gracfully shutdown
 	defer loadedHooks.Recover(pkg.GenerateRandomID())
@@ -485,7 +485,7 @@ func (t *tester) RunTestSet(testSet, path, testReportPath, appCmd, appContainer,
 	var userIp string
 	userIp = initialisedValues.UserIP
 	t.logger.Debug("the userip of the user docker container", zap.Any("", userIp))
-	
+
 	var entTcs, nonKeployTcs []string
 	for _, tc := range initialisedValues.Tcs {
 		// Filter the TCS Mocks based on the test case's request and response timestamp such that mock's timestamps lies between the test's timestamp and then, set the TCS Mocks.
@@ -717,7 +717,7 @@ func (t *tester) testHttp(tc models.TestCase, actualResponse *models.HttpResp, n
 func replaceHostToIP(currentURL string, ipAddress string) (string, error) {
 	// Parse the current URL
 	parsedURL, err := url.Parse(currentURL)
-	
+
 	if err != nil {
 		// Return the original URL if parsing fails
 		return currentURL, err


### PR DESCRIPTION
## Related Issue
  -  Refactoring of error handling in keploy serve.

Closes: `NA`

#### Describe the changes you've made
- Made a new error type to distinguish errors between server-running & non-server-running commands (For eg: `mvn test`, `npm test`, `go test` etc.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
`NA`

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |