### PR TITLE
fix: modified return of nil response for HTTP Connection Error

### DIFF
--- a/pkg/service/test/test.go
+++ b/pkg/service/test/test.go
@@ -333,7 +333,7 @@ func (t *tester) SimulateRequest(cfg *SimulateRequestConfig) {
 		t.logger.Debug("After simulating the request", zap.Any("test case id", cfg.Tc.Name))
 		t.logger.Debug("After GetResp of the request", zap.Any("test case id", cfg.Tc.Name))
 
-		if err != nil {
+		if err != nil && resp == nil {
 			t.logger.Info("result", zap.Any("testcase id", models.HighlightFailingString(cfg.Tc.Name)), zap.Any("testset id", models.HighlightFailingString(cfg.TestSet)), zap.Any("passed", models.HighlightFailingString("false")))
 			return
 		}


### PR DESCRIPTION
## Related Issue
When port is changed in the test case after `keploy record` is run, the `keploy test` produces a report which shows that the status is `Running` instead of `Failed`.  

Closes: #1169

#### Describe the changes you've made
- A small code change in `pkg/util.go` to handle cases where the returned HTTP response is null, to return a valid `models.HttpResp` to make sure that this case can be accurately classified as Failed in `pkg/service/test/test.go` when compared with the actual response that needed to be returned. 
- A condition addition in an if block in `pkg/service/test/test.go` to check if response is nil before doing an early return without running `testHttp`.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added
`NA`

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
`NA`

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)
`NA`