### PR TITLE
feat(pg-parser): ignore deletion of startup request mocks during match

### DIFF
--- a/pkg/proxy/integrations/postgresParser/postgres_parser.go
+++ b/pkg/proxy/integrations/postgresParser/postgres_parser.go
@@ -63,7 +63,8 @@ func (p *PostgresParser) ProcessOutgoing(requestBuffer []byte, clientConn, destC
 	case models.MODE_RECORD:
 		encodePostgresOutgoing(requestBuffer, clientConn, destConn, p.hooks, p.logger, ctx)
 	case models.MODE_TEST:
-		decodePostgresOutgoing(requestBuffer, clientConn, destConn, p.hooks, p.logger, ctx)
+		logger := p.logger.With(zap.Any("Client IP Address", clientConn.RemoteAddr().String()), zap.Any("Client ConnectionID", util.GetNextID()), zap.Any("Destination ConnectionID", util.GetNextID()))
+		decodePostgresOutgoing(requestBuffer, clientConn, destConn, p.hooks, logger, ctx)
 	default:
 		p.logger.Info("Invalid mode detected while intercepting outgoing http call", zap.Any("mode", models.GetMode()))
 	}


### PR DESCRIPTION
## Related Issue
  - Info about Issue or bug

Closes: #[issue number that will be closed through this PR]

#### Describe the changes you've made
Some applications are making more connections with Postgres during test mode than it did during record mode. So there are also more auth requests from the application during test mode, but we didn't have sufficient auth packets - which leads to auth failures in some requests.

 **Why did this happen?**

Since the application is able to execute much faster during testmode, it tries to increase the connection pool to handle higher request throughput. This seems to be normal application behaviour for psycog3
Fix: We are making database connection related properties like authentication re-useable to handle cases where more connections are created during test mode.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |