### PR TITLE
fix: add support for v1beta2 and old postgres mocks

### DIFF
--- a/pkg/platform/yaml/yaml.go
+++ b/pkg/platform/yaml/yaml.go
@@ -397,7 +397,7 @@ func (ys *Yaml) ReadTcsMocks(tcRead platform.KindSpecifier, path string) ([]plat
 		mock := readMock.(*models.Mock)
 		if mock.Version == "api.keploy-enterprise.io/v1beta1" {
 			entMocks = append(entMocks, mock.Name)
-		} else if mock.Version != "api.keploy.io/v1beta1" {
+		} else if mock.Version != "api.keploy.io/v1beta1" && mock.Version != "api.keploy.io/v1beta2" {
 			nonKeployMocks = append(nonKeployMocks, mock.Name)
 		}
 		if (mock.Spec.ReqTimestampMock == (time.Time{}) || mock.Spec.ResTimestampMock == (time.Time{})) && mock.Kind != "SQL" {
@@ -456,7 +456,7 @@ func (ys *Yaml) ReadConfigMocks(path string) ([]platform.KindSpecifier, error) {
 		}
 
 		for _, mock := range mocks {
-			if mock.Spec.Metadata["type"] == "config" {
+			if mock.Spec.Metadata["type"] == "config" || mock.Kind == "Postgres" {
 				configMocks = append(configMocks, mock)
 			}
 		}


### PR DESCRIPTION
## Related Issue
- #1356

Closes: #1356

#### Describe the changes you've made
Add support for v1beta2 used in some older keploy releases and also older Postgres mocks. 

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

