### PR TITLE
[feature]: Make generating testReports files optional

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,7 +32,6 @@ type Root struct {
 }
 
 var debugMode bool
-var generateTestReport bool
 
 type colorConsoleEncoder struct {
 	*zapcore.EncoderConfig
@@ -235,24 +234,6 @@ func deleteLogs(logger *zap.Logger) {
 	}
 }
 
-func deleteTestReport(logger *zap.Logger) {
-	if generateTestReport {
-		return
-	}
-
-	//Remove testReports folder if it exists and generateTestReport flag is not set
-	_, err := os.Stat("keploy/testReports")
-	if os.IsNotExist(err) {
-		return
-	}
-	err = os.RemoveAll("keploy/testReports")
-	if err != nil {
-		logger.Error("Error removing testReports folder: %v\n", zap.String("error", err.Error()))
-		return
-	}
-
-}
-
 func (r *Root) execute() {
 	// Root command
 	var rootCmd = &cobra.Command{
@@ -264,7 +245,6 @@ func (r *Root) execute() {
 	rootCmd.SetHelpTemplate(rootCustomHelpTemplate)
 
 	rootCmd.PersistentFlags().BoolVar(&debugMode, "debug", false, "Run in debug mode")
-	rootCmd.PersistentFlags().BoolVar(&generateTestReport, "generateTestReport", false, "Generate test reports")
 
 	// Manually parse flags to determine debug mode early
 	debugMode = checkForDebugFlag(os.Args[1:])
@@ -278,8 +258,6 @@ func (r *Root) execute() {
 	for _, sc := range r.subCommands {
 		rootCmd.AddCommand(sc.GetCmd())
 	}
-
-	defer deleteTestReport(r.logger)
 
 	if err := rootCmd.Execute(); err != nil {
 		r.logger.Error("failed to start the CLI.", zap.Any("error", err.Error()))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,7 @@ type Root struct {
 }
 
 var debugMode bool
+var generateTestReport bool
 
 type colorConsoleEncoder struct {
 	*zapcore.EncoderConfig
@@ -234,6 +235,24 @@ func deleteLogs(logger *zap.Logger) {
 	}
 }
 
+func deleteTestReport(logger *zap.Logger) {
+	if generateTestReport {
+		return
+	}
+
+	//Remove testReports folder if it exists and generateTestReport flag is not set
+	_, err := os.Stat("keploy/testReports")
+	if os.IsNotExist(err) {
+		return
+	}
+	err = os.RemoveAll("keploy/testReports")
+	if err != nil {
+		logger.Error("Error removing testReports folder: %v\n", zap.String("error", err.Error()))
+		return
+	}
+
+}
+
 func (r *Root) execute() {
 	// Root command
 	var rootCmd = &cobra.Command{
@@ -245,6 +264,7 @@ func (r *Root) execute() {
 	rootCmd.SetHelpTemplate(rootCustomHelpTemplate)
 
 	rootCmd.PersistentFlags().BoolVar(&debugMode, "debug", false, "Run in debug mode")
+	rootCmd.PersistentFlags().BoolVar(&generateTestReport, "generateTestReport", false, "Generate test reports")
 
 	// Manually parse flags to determine debug mode early
 	debugMode = checkForDebugFlag(os.Args[1:])
@@ -258,6 +278,8 @@ func (r *Root) execute() {
 	for _, sc := range r.subCommands {
 		rootCmd.AddCommand(sc.GetCmd())
 	}
+
+	defer deleteTestReport(r.logger)
 
 	if err := rootCmd.Execute(); err != nil {
 		r.logger.Error("failed to start the CLI.", zap.Any("error", err.Error()))

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -57,6 +57,13 @@ func (s *Serve) GetCmd() *cobra.Command {
 
 			testReportPath := path + "/testReports"
 
+			generateTestReport, err := cmd.Flags().GetBool("generateTestReport")
+
+			if err != nil {
+				s.logger.Error("Failed to get the generateTestReport flag", zap.Error((err)))
+				return
+			}
+
 			s.logger.Info("", zap.Any("keploy test and mock path", path), zap.Any("keploy testReport path", testReportPath))
 
 			delay, err := cmd.Flags().GetUint64("delay")
@@ -113,7 +120,7 @@ func (s *Serve) GetCmd() *cobra.Command {
 			}
 			s.logger.Debug("the ports are", zap.Any("ports", ports))
 
-			s.server.Serve(path, proxyPort, testReportPath, delay, pid, port, language, ports, apiTimeout, appCmd, enableTele)
+			s.server.Serve(path, proxyPort, testReportPath, delay, pid, port, language, ports, apiTimeout, appCmd, enableTele, generateTestReport)
 		},
 	}
 
@@ -129,6 +136,8 @@ func (s *Serve) GetCmd() *cobra.Command {
 	serveCmd.MarkFlagRequired("delay")
 
 	serveCmd.Flags().Uint64("apiTimeout", 5, "User provided timeout for calling its application")
+
+	serveCmd.Flags().Bool("generateTestReport", false, "Generate test report")
 
 	serveCmd.Flags().UintSlice("passThroughPorts", []uint{}, "Ports of Outgoing dependency calls to be ignored as mocks")
 	serveCmd.Flags().Bool("enableTele", true, "Switch for telemetry")

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -99,24 +99,6 @@ type Test struct {
 
 var generateTestReport bool
 
-func deleteTestReport(logger *zap.Logger) {
-	if generateTestReport {
-		return
-	}
-
-	//Remove testReports folder if it exists and generateTestReport flag is not set
-	_, err := os.Stat("keploy/testReports")
-	if os.IsNotExist(err) {
-		return
-	}
-	err = os.RemoveAll("keploy/testReports")
-	if err != nil {
-		logger.Error("Error removing testReports folder: %v\n", zap.String("error", err.Error()))
-		return
-	}
-
-}
-
 func (t *Test) GetCmd() *cobra.Command {
 
 	var testCmd = &cobra.Command{
@@ -308,6 +290,7 @@ func (t *Test) GetCmd() *cobra.Command {
 				TestsetNoise:       testsetNoise,
 				WithCoverage:       withCoverage,
 				CoverageReportPath: coverageReportPath,
+				GenerateTestReport: generateTestReport,
 			}, enableTele)
 
 			return nil
@@ -348,8 +331,6 @@ func (t *Test) GetCmd() *cobra.Command {
 	testCmd.SilenceErrors = true
 
 	testCmd.Flags().BoolVar(&generateTestReport, "generateTestReport", false, "Generate test reports")
-
-	defer deleteTestReport(t.logger)
 
 	return testCmd
 }

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -97,7 +97,28 @@ type Test struct {
 	logger *zap.Logger
 }
 
+var generateTestReport bool
+
+func deleteTestReport(logger *zap.Logger) {
+	if generateTestReport {
+		return
+	}
+
+	//Remove testReports folder if it exists and generateTestReport flag is not set
+	_, err := os.Stat("keploy/testReports")
+	if os.IsNotExist(err) {
+		return
+	}
+	err = os.RemoveAll("keploy/testReports")
+	if err != nil {
+		logger.Error("Error removing testReports folder: %v\n", zap.String("error", err.Error()))
+		return
+	}
+
+}
+
 func (t *Test) GetCmd() *cobra.Command {
+
 	var testCmd = &cobra.Command{
 		Use:     "test",
 		Short:   "run the recorded testcases and execute assertions",
@@ -325,6 +346,10 @@ func (t *Test) GetCmd() *cobra.Command {
 	testCmd.Flags().Lookup("withCoverage").NoOptDefVal = "true"
 	testCmd.SilenceUsage = true
 	testCmd.SilenceErrors = true
+
+	testCmd.Flags().BoolVar(&generateTestReport, "generateTestReport", false, "Generate test reports")
+
+	defer deleteTestReport(t.logger)
 
 	return testCmd
 }

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -42,6 +42,7 @@ type Test struct {
 	PassThroughPorts   []uint              `json:"passThroughPorts" yaml:"passThroughPorts"`
 	WithCoverage       bool                `json:"withCoverage" yaml:"withCoverage"`             // boolean to capture the coverage in test
 	CoverageReportPath string              `json:"coverageReportPath" yaml:"coverageReportPath"` // directory path to store the coverage files
+	GenerateTestReport bool                `json:"generateTestReport" yaml:"generateTestReport"` // boolean to generate test report
 }
 
 type Globalnoise struct {

--- a/pkg/service/generateConfig/generateConfig.go
+++ b/pkg/service/generateConfig/generateConfig.go
@@ -5,9 +5,9 @@ import (
 	"os/exec"
 	"sync"
 
+	"go.keploy.io/server/utils"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
-  "go.keploy.io/server/utils"
 )
 
 var Emoji = "\U0001F430" + " Keploy:"
@@ -58,6 +58,7 @@ test:
   passThroughPorts: []
   withCoverage: false
   coverageReportPath: ""
+  generateTestReport: false
   `
 
 func (g *generatorConfig) GenerateConfig(filePath string) {
@@ -71,7 +72,7 @@ func (g *generatorConfig) GenerateConfig(filePath string) {
 		g.logger.Fatal("Failed to marshal the config", zap.Error(err))
 	}
 
-  finalOutput := append(results, []byte(utils.ConfigGuide)...)
+	finalOutput := append(results, []byte(utils.ConfigGuide)...)
 
 	err = os.WriteFile(filePath, finalOutput, os.ModePerm)
 	if err != nil {

--- a/pkg/service/serve/serve.go
+++ b/pkg/service/serve/serve.go
@@ -43,7 +43,7 @@ func NewServer(logger *zap.Logger) Server {
 const defaultPort = 6789
 
 // Serve is called by the serve command and is used to run a graphql server, to run tests separately via apis.
-func (s *server) Serve(path string, proxyPort uint32, testReportPath string, Delay uint64, pid, port uint32, lang string, passThroughPorts []uint, apiTimeout uint64, appCmd string, enableTele bool) {
+func (s *server) Serve(path string, proxyPort uint32, testReportPath string, Delay uint64, pid, port uint32, lang string, passThroughPorts []uint, apiTimeout uint64, appCmd string, enableTele bool, generateTestReport bool) {
 	var ps *proxy.ProxySet
 
 	if port == 0 {
@@ -58,6 +58,10 @@ func (s *server) Serve(path string, proxyPort uint32, testReportPath string, Del
 	tester := test.NewTester(s.logger)
 	testReportFS := yaml.NewTestReportFS(s.logger)
 	teleFS := fs.NewTeleFS(s.logger)
+
+	// Delete the generated test report if flag is not set
+	defer utils.DeleteTestReport(s.logger, generateTestReport)
+
 	tele := telemetry.NewTelemetry(enableTele, false, teleFS, s.logger, "", nil)
 	tele.Ping(false)
 	ys := yaml.NewYamlStore("", "", "", "", s.logger, tele)

--- a/pkg/service/serve/service.go
+++ b/pkg/service/serve/service.go
@@ -1,5 +1,5 @@
 package serve
 
 type Server interface {
-	Serve(path string, proxyPort uint32, testReportPath string, Delay uint64, pid, port uint32, lang string, passThroughPorts []uint, apiTimeout uint64, appCmd string, enableTele bool)
+	Serve(path string, proxyPort uint32, testReportPath string, Delay uint64, pid, port uint32, lang string, passThroughPorts []uint, apiTimeout uint64, appCmd string, enableTele bool, generateTestReport bool)
 }

--- a/pkg/service/test/test.go
+++ b/pkg/service/test/test.go
@@ -259,6 +259,7 @@ func (t *tester) Test(path string, testReportPath string, appCmd string, options
 	}
 	t.logger.Info("test run completed", zap.Bool("passed overall", result))
 
+	//pass the generateTestReport flag
 	defer deleteTestReport(t.logger, options.GenerateTestReport)
 	// log the overall code coverage for the test run of go binaries
 	if options.WithCoverage {

--- a/pkg/service/test/test.go
+++ b/pkg/service/test/test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -14,8 +15,6 @@ import (
 	"sync"
 	"syscall"
 	"time"
-
-	"net/url"
 
 	"github.com/k0kubun/pp/v3"
 	"github.com/wI2L/jsondiff"
@@ -27,6 +26,7 @@ import (
 	"go.keploy.io/server/pkg/platform/telemetry"
 	"go.keploy.io/server/pkg/platform/yaml"
 	"go.keploy.io/server/pkg/proxy"
+
 	"go.uber.org/zap"
 )
 
@@ -50,6 +50,7 @@ type TestOptions struct {
 	TestsetNoise       models.TestsetNoise
 	WithCoverage       bool
 	CoverageReportPath string
+	GenerateTestReport bool
 }
 
 func NewTester(logger *zap.Logger) Tester {
@@ -257,6 +258,8 @@ func (t *tester) Test(path string, testReportPath string, appCmd string, options
 		}
 	}
 	t.logger.Info("test run completed", zap.Bool("passed overall", result))
+
+	defer deleteTestReport(t.logger, options.GenerateTestReport)
 	// log the overall code coverage for the test run of go binaries
 	if options.WithCoverage {
 		t.logger.Info("there is a opportunity to get the coverage here")

--- a/pkg/service/test/test.go
+++ b/pkg/service/test/test.go
@@ -26,7 +26,7 @@ import (
 	"go.keploy.io/server/pkg/platform/telemetry"
 	"go.keploy.io/server/pkg/platform/yaml"
 	"go.keploy.io/server/pkg/proxy"
-
+	"go.keploy.io/server/utils"
 	"go.uber.org/zap"
 )
 
@@ -260,7 +260,7 @@ func (t *tester) Test(path string, testReportPath string, appCmd string, options
 	t.logger.Info("test run completed", zap.Bool("passed overall", result))
 
 	//pass the generateTestReport flag
-	defer deleteTestReport(t.logger, options.GenerateTestReport)
+	defer utils.DeleteTestReport(t.logger, options.GenerateTestReport)
 	// log the overall code coverage for the test run of go binaries
 	if options.WithCoverage {
 		t.logger.Info("there is a opportunity to get the coverage here")

--- a/pkg/service/test/util.go
+++ b/pkg/service/test/util.go
@@ -458,3 +458,23 @@ func makeDirectory(path string) error {
 	syscall.Umask(oldUmask)
 	return nil
 }
+
+func deleteTestReport(logger *zap.Logger, generateTestReport bool) {
+	logger.Info("generateTestReport is ", zap.Bool("generateTestReport", generateTestReport))
+	fmt.Println("generateTestReport is ", generateTestReport)
+	if generateTestReport {
+		return
+	}
+
+	//Remove testReports folder if it exists and generateTestReport flag is not set
+	_, err := os.Stat("keploy/testReports")
+	if os.IsNotExist(err) {
+		return
+	}
+	err = os.RemoveAll("keploy/testReports")
+	if err != nil {
+		logger.Error("Error removing testReports folder: %v\n", zap.String("error", err.Error()))
+		return
+	}
+
+}

--- a/pkg/service/test/util.go
+++ b/pkg/service/test/util.go
@@ -459,22 +459,4 @@ func makeDirectory(path string) error {
 	return nil
 }
 
-func deleteTestReport(logger *zap.Logger, generateTestReport bool) {
-	logger.Info("generateTestReport is ", zap.Bool("generateTestReport", generateTestReport))
-	fmt.Println("generateTestReport is ", generateTestReport)
-	if generateTestReport {
-		return
-	}
 
-	//Remove testReports folder if it exists and generateTestReport flag is not set
-	_, err := os.Stat("keploy/testReports")
-	if os.IsNotExist(err) {
-		return
-	}
-	err = os.RemoveAll("keploy/testReports")
-	if err != nil {
-		logger.Error("Error removing testReports folder: %v\n", zap.String("error", err.Error()))
-		return
-	}
-
-}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cloudflare/cfssl/log"
 	sentry "github.com/getsentry/sentry-go"
+	"go.uber.org/zap"
 )
 
 var Emoji = "\U0001F430" + " Keploy:"
@@ -103,4 +104,22 @@ func HandlePanic() {
 		log.Error(Emoji+"Recovered from:", r, "\nstack trace:\n", string(stackTrace))
 		sentry.Flush(time.Second * 2)
 	}
+}
+
+func DeleteTestReport(logger *zap.Logger, generateTestReport bool) {
+	if generateTestReport {
+		return
+	}
+
+	//Remove testReports folder if it exists and generateTestReport flag is not set
+	_, err := os.Stat("keploy/testReports")
+	if os.IsNotExist(err) {
+		return
+	}
+	err = os.RemoveAll("keploy/testReports")
+	if err != nil {
+		logger.Error("Error removing testReports folder: %v\n", zap.String("error", err.Error()))
+		return
+	}
+
 }


### PR DESCRIPTION
## Related Issue
  - Info about Issue or bug

Closes: #1393 

#### Describe the changes you've made
Added a Flag ```--generateTestReport``` to ```keploy test``` ```keploy serve``` and config file  that will allow the user to choose if they want to generate the testReports or not. If the flag is not present, the folder will be deleted at the end of the CLI execution.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added
NA

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
NA

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)
![image](https://github.com/keploy/keploy/assets/114267538/889ea290-c8e6-4318-8a2c-9341fd5c6802)

