### PR TITLE
refactor:setting time stamp for response only after verified response

### DIFF
--- a/pkg/hooks/connection/tracker.go
+++ b/pkg/hooks/connection/tracker.go
@@ -66,9 +66,8 @@ type Tracker struct {
 	mutex  sync.RWMutex
 	logger *zap.Logger
 
-	reqTimestamps  []time.Time
-	respTimestamps []time.Time
-	isNewRequest   bool
+	reqTimestamps []time.Time
+	isNewRequest  bool
 }
 
 func NewTracker(connID structs2.ConnID, logger *zap.Logger) *Tracker {
@@ -128,6 +127,8 @@ func (conn *Tracker) IsComplete() (bool, []byte, []byte, time.Time, time.Time) {
 
 	requestBuf, responseBuf := []byte{}, []byte{}
 
+	var reqTimestamps, respTimestamp time.Time
+
 	//if recTestCounter > 0, it means that we have num(recTestCounter) of request and response present in the queues to record.
 	if conn.recTestCounter > 0 {
 		if (len(conn.userReqSizes) > 0 && len(conn.kernelReqSizes) > 0) &&
@@ -161,6 +162,7 @@ func (conn *Tracker) IsComplete() (bool, []byte, []byte, time.Time, time.Time) {
 
 			if conn.verifyResponseData(expectedSentBytes, actualSentBytes) {
 				validRes = true
+				respTimestamp = time.Now()
 			} else {
 				conn.logger.Debug("Malformed response", zap.Any("ExpectedSentBytes", expectedSentBytes), zap.Any("ActualSentBytes", actualSentBytes))
 				recordTraffic = false
@@ -218,6 +220,7 @@ func (conn *Tracker) IsComplete() (bool, []byte, []byte, time.Time, time.Time) {
 				conn.userReqs = conn.userReqs[1:]
 
 				responseBuf = conn.resp
+				respTimestamp = time.Now()
 			} else {
 				conn.logger.Debug("no data buffer for request", zap.Any("Length of RecvBufQueue", len(conn.userReqs)))
 				recordTraffic = false
@@ -236,8 +239,6 @@ func (conn *Tracker) IsComplete() (bool, []byte, []byte, time.Time, time.Time) {
 		conn.logger.Debug("unverified recording", zap.Any("recordTraffic", recordTraffic))
 	}
 
-	var reqTimestamps time.Time
-	var respTimestamps time.Time
 	// Checking if record traffic is recorded and request & response timestamp is captured or not.
 	if recordTraffic {
 		if len(conn.reqTimestamps) > 0 {
@@ -256,25 +257,10 @@ func (conn *Tracker) IsComplete() (bool, []byte, []byte, time.Time, time.Time) {
 			recordTraffic = false
 		}
 
-		if len(conn.respTimestamps) > 0 {
-			// Get the timestamp of current request
-			respTimestamps = conn.respTimestamps[0]
-			// Pop the timestamp of current request
-			conn.respTimestamps = conn.respTimestamps[1:]
-		} else {
-			conn.logger.Debug("no response timestamp found")
-			if len(requestBuf) > 0 {
-				reqLine := strings.Split(string(requestBuf), "\n")
-				if models.GetMode() == models.MODE_RECORD && len(reqLine) > 0 && reqLine[0] != "" {
-					conn.logger.Warn(fmt.Sprintf("failed to capture response timestamp for a request. Please record it again if important:%v", reqLine[0]))
-				}
-			}
-			recordTraffic = false
-		}
-		conn.logger.Debug(fmt.Sprintf("TestRequestTimestamp:%v || TestResponseTimestamp:%v", reqTimestamps, respTimestamps))
+		conn.logger.Debug(fmt.Sprintf("TestRequestTimestamp:%v || TestResponseTimestamp:%v", reqTimestamps, respTimestamp))
 	}
 
-	return recordTraffic, requestBuf, responseBuf, reqTimestamps, respTimestamps
+	return recordTraffic, requestBuf, responseBuf, reqTimestamps, respTimestamp
 }
 
 // reset resets the connection's request and response data buffers.
@@ -320,7 +306,6 @@ func (conn *Tracker) AddDataEvent(event structs2.SocketDataEvent) {
 		// Capturing the timestamp of response as the response just started to come.
 		// This is to ensure that we capture the response timestamp for the first chunk of the response.
 		if !conn.isNewRequest {
-			conn.respTimestamps = append(conn.respTimestamps, time.Now())
 			conn.isNewRequest = true
 		}
 

--- a/pkg/service/test/test.go
+++ b/pkg/service/test/test.go
@@ -157,7 +157,6 @@ func (t *tester) InitialiseTest(cfg *TestConfig) (InitialiseTestReturn, error) {
 	}
 
 	sessions, err := yaml.ReadSessionIndices(cfg.Path, t.logger)
-	fmt.Println(sessions)
 	if err != nil {
 		t.logger.Debug("failed to read the recorded sessions", zap.Error(err))
 		return returnVal, err
@@ -638,8 +637,6 @@ func (t *tester) RunTestSet(testSet, path, testReportPath, appCmd, appContainer,
 		}
 		sortedConfigMocks := SortMocks(tc, configMocks, t.logger)
 		loadedHooks.SetConfigMocks(sortedConfigMocks)
-		fmt.Println(tc.Name)
-		fmt.Println((*&readTcsMocks[0].Name))
 		if tc.Version == "api.keploy-enterprise.io/v1beta1" {
 			entTcs = append(entTcs, tc.Name)
 		} else if tc.Version != "api.keploy.io/v1beta1" && tc.Version != "api.keploy.io/v1beta2" {

--- a/pkg/service/test/test.go
+++ b/pkg/service/test/test.go
@@ -638,6 +638,8 @@ func (t *tester) RunTestSet(testSet, path, testReportPath, appCmd, appContainer,
 		}
 		sortedConfigMocks := SortMocks(tc, configMocks, t.logger)
 		loadedHooks.SetConfigMocks(sortedConfigMocks)
+		fmt.Println(tc.Name)
+		fmt.Println((*&readTcsMocks[0].Name))
 		if tc.Version == "api.keploy-enterprise.io/v1beta1" {
 			entTcs = append(entTcs, tc.Name)
 		} else if tc.Version != "api.keploy.io/v1beta1" && tc.Version != "api.keploy.io/v1beta2" {


### PR DESCRIPTION
## Related Issue
  - Instead of using an array to save the response time reverted to set the response time of response only after the data is verified.
Closes: #1418

#### Describe the changes you've made
Because of maintaining an array of mock and picking the first element of the array we were unable to get certain mock files as a result of which  connection would end and test cases would fail.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

<img width="476" alt="image" src="https://github.com/keploy/keploy/assets/60891544/e3b74ff8-b1ba-41a1-9db4-778bcae74571">