### PR TITLE
[Feature]: Make generating TestReports files optional

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -107,6 +107,8 @@ type Test struct {
 	logger *zap.Logger
 }
 
+var generateTestReport bool
+
 func (t *Test) GetCmd() *cobra.Command {
 	var testCmd = &cobra.Command{
 		Use:     "test",
@@ -381,7 +383,7 @@ func (t *Test) GetCmd() *cobra.Command {
 
 			if coverage {
 				g := graph.NewGraph(t.logger)
-				g.Serve(path, proxyPort, testReportPath, delay, pid, port, lang, ports, apiTimeout, appCmd, enableTele)
+				g.Serve(path, proxyPort, testReportPath, delay, pid, port, lang, ports, apiTimeout, appCmd, enableTele, generateTestReport)
 			} else {
 				t.tester.Test(path, testReportPath, appCmd, test.TestOptions{
 					Tests:              tests,
@@ -399,6 +401,7 @@ func (t *Test) GetCmd() *cobra.Command {
 					CoverageReportPath: coverageReportPath,
 					IgnoreOrdering:     ignoreOrdering,
 					PassthroughHosts:   passThroughHosts,
+					GenerateTestReport: generateTestReport,
 				}, enableTele)
 			}
 
@@ -449,6 +452,9 @@ func (t *Test) GetCmd() *cobra.Command {
 
 	testCmd.Flags().Bool("coverage", false, "Capture the code coverage of the go binary in the command flag.")
 	testCmd.Flags().Lookup("coverage").NoOptDefVal = "true"
+
+	testCmd.Flags().BoolVar(&generateTestReport, "generateTestReport", false, "Generate test reports")
+
 	testCmd.SilenceUsage = true
 	testCmd.SilenceErrors = true
 

--- a/pkg/graph/serve.go
+++ b/pkg/graph/serve.go
@@ -40,7 +40,7 @@ func NewGraph(logger *zap.Logger) graphInterface {
 const defaultPort = 6789
 
 // Serve is called by the serve command and is used to run a graphql server, to run tests separately via apis.
-func (g *graph) Serve(path string, proxyPort uint32, testReportPath string, Delay uint64, pid, port uint32, lang string, passThroughPorts []uint, apiTimeout uint64, appCmd string, enableTele bool) {
+func (g *graph) Serve(path string, proxyPort uint32, testReportPath string, Delay uint64, pid, port uint32, lang string, passThroughPorts []uint, apiTimeout uint64, appCmd string, enableTele bool, generateTestReport bool) {
 	var ps *proxy.ProxySet
 
 	if port == 0 {
@@ -55,6 +55,10 @@ func (g *graph) Serve(path string, proxyPort uint32, testReportPath string, Dela
 	tester := test.NewTester(g.logger)
 	testReportFS := yaml.NewTestReportFS(g.logger)
 	teleFS := fs.NewTeleFS(g.logger)
+
+	// Delete the generated test report if flag is not set
+	defer utils.DeleteTestReport(g.logger, generateTestReport)
+
 	tele := telemetry.NewTelemetry(enableTele, false, teleFS, g.logger, "", nil)
 	tele.Ping(false)
 	ys := yaml.NewYamlStore("", "", "", "", g.logger, tele)

--- a/pkg/graph/service.go
+++ b/pkg/graph/service.go
@@ -5,6 +5,6 @@ import (
 )
 
 type graphInterface interface {
-	Serve(path string, proxyPort uint32, testReportPath string, Delay uint64, pid, port uint32, lang string, passThroughPorts []uint, apiTimeout uint64, appCmd string, enableTele bool)
-    stopGraphqlServer(http *http.Server)
+	Serve(path string, proxyPort uint32, testReportPath string, Delay uint64, pid, port uint32, lang string, passThroughPorts []uint, apiTimeout uint64, appCmd string, enableTele bool, generateTestReport bool)
+	stopGraphqlServer(http *http.Server)
 }

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -55,6 +55,7 @@ type Test struct {
 	CoverageReportPath      string              `json:"coverageReportPath" yaml:"coverageReportPath"` // directory path to store the coverage files
 	IgnoreOrdering          bool                `json:"ignoreOrdering" yaml:"ignoreOrdering"`
 	Stubs                   Stubs               `json:"stubs" yaml:"stubs"`
+	GenTestReport           bool                `json:"generateTestReport" yaml:"generateTestReport"`
 }
 
 type Globalnoise struct {

--- a/pkg/service/generateConfig/generateConfig.go
+++ b/pkg/service/generateConfig/generateConfig.go
@@ -70,6 +70,7 @@ test:
         ports: 0
   withCoverage: false
   coverageReportPath: ""
+  generateTestReport: false
 `
 
 func (g *generatorConfig) GenerateConfig(filePath string) {

--- a/pkg/service/test/test.go
+++ b/pkg/service/test/test.go
@@ -53,6 +53,7 @@ type TestOptions struct {
 	CoverageReportPath string
 	IgnoreOrdering     bool
 	PassthroughHosts   []models.Filters
+	GenerateTestReport bool
 }
 
 func NewTester(logger *zap.Logger) Tester {
@@ -261,6 +262,9 @@ func (t *tester) Test(path string, testReportPath string, appCmd string, options
 		}
 	}
 	t.logger.Info("test run completed", zap.Bool("passed overall", result))
+
+	defer utils.DeleteTestReport(t.logger, options.GenerateTestReport)
+
 	// log the overall code coverage for the test run of go binaries
 	if options.WithCoverage {
 		t.logger.Info("there is a opportunity to get the coverage here")

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cloudflare/cfssl/log"
 	sentry "github.com/getsentry/sentry-go"
+	"go.uber.org/zap"
 )
 
 var Emoji = "\U0001F430" + " Keploy:"
@@ -123,6 +124,24 @@ func HandlePanic() {
 		log.Error(Emoji+"Recovered from:", r, "\nstack trace:\n", string(stackTrace))
 		sentry.Flush(time.Second * 2)
 	}
+}
+
+func DeleteTestReport(logger *zap.Logger, generateTestReport bool) {
+	if generateTestReport {
+		return
+	}
+
+	//Remove testReports folder if it exists and generateTestReport flag is not set
+	_, err := os.Stat("keploy/testReports")
+	if os.IsNotExist(err) {
+		return
+	}
+	err = os.RemoveAll("keploy/testReports")
+	if err != nil {
+		logger.Error("Error removing testReports folder: %v\n", zap.String("error", err.Error()))
+		return
+	}
+
 }
 
 var WarningSign = "\U000026A0"


### PR DESCRIPTION
## Related Issue
  - Info about Issue or bug

Closes: #1393 

#### Describe the changes you've made
Added a Flag ```--generateTestReport``` to ```keploy test``` ```keploy serve``` and config file  that will allow the user to choose if they want to generate the testReports or not. If the flag is not present, the folder will be deleted at the end of the CLI execution.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added
NA

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
NA

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)
![image](https://github.com/keploy/keploy/assets/114267538/889ea290-c8e6-4318-8a2c-9341fd5c6802)

