### PR TITLE
Removed unknown command  error logger since deep inside rootCmd.Execute() there is already printErr statement

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -291,7 +291,6 @@ func (r *Root) execute() {
 	}
 
 	if err := rootCmd.Execute(); err != nil {
-		// r.logger.Error("failed to start the CLI.", zap.Any("error", err.Error()))
 		os.Exit(1)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -291,7 +291,7 @@ func (r *Root) execute() {
 	}
 
 	if err := rootCmd.Execute(); err != nil {
-		r.logger.Error("failed to start the CLI.", zap.Any("error", err.Error()))
+		// r.logger.Error("failed to start the CLI.", zap.Any("error", err.Error()))
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION


## Related Issue
  - keploy CLI logs error message when command is unknown

Closes: #1328 

#### Describe the changes you've made
Removed logger inside  rootCmd.Execute() in root.go file since there are already PrintErrln statements deep inside Execute()

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| ![Screenshot from 2024-02-10 08-19-23](https://github.com/keploy/keploy/assets/85030597/3ee3a60b-5c4e-42ed-b6bd-3dcb4adf7217) | ![Screenshot from 2024-02-10 08-18-39](https://github.com/keploy/keploy/assets/85030597/53c2539f-9900-4aec-8d52-1ae6a5e2c740) |