### PR TITLE
#1558-bug: added path validation check in write fn in testreport file

### DIFF
--- a/pkg/platform/yaml/testReport.go
+++ b/pkg/platform/yaml/testReport.go
@@ -77,6 +77,10 @@ func (fe *TestReport) Write(ctx context.Context, path string, doc platform.KindS
 	if !ok {
 		return fmt.Errorf("%s failed to read test report in yaml file", Emoji)
 	}
+	_, path_err := util.ValidatePath(path)
+	if path_err != nil {
+		return path_err
+	}
 	if readDock.Name == "" {
 		lastIndex, err := findLastIndex(path, fe.Logger)
 		if err != nil {


### PR DESCRIPTION
## Related Issue
  - Issue #1558 path validation was missing from `Write` func in testReport file

Closes: #1558 

#### Describe the changes you've made
Added `util.ValidatePath` func call to validate the path before using it.

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ x] My code follows the style guidelines of this project.
- [ x] I have performed a self-review of my own code.
- [ x] My changes generate no new warnings.
- [ x] New and existing unit tests pass locally with my changes.