### PR TITLE
fix: adds test filter to the serve to generate code coverage

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -42,7 +42,7 @@ func ReadTestConfig(configPath string) (*models.Test, error) {
 	return &doc.Test, nil
 }
 
-func (t *Test) getTestConfig(path *string, proxyPort *uint32, appCmd *string, tests *map[string][]string, appContainer, networkName *string, Delay *uint64, buildDelay *time.Duration, passThroughPorts *[]uint, apiTimeout *uint64, globalNoise *models.GlobalNoise, testSetNoise *models.TestsetNoise, coverageReportPath *string, withCoverage *bool, generateTestReport *bool, configPath string, ignoreOrdering *bool, passThroughHosts *[]models.Filters) error {
+func (t *Test) getTestConfig(path *string, proxyPort *uint32, appCmd *string, testFilters *map[string][]string, appContainer, networkName *string, Delay *uint64, buildDelay *time.Duration, passThroughPorts *[]uint, apiTimeout *uint64, globalNoise *models.GlobalNoise, testSetNoise *models.TestsetNoise, coverageReportPath *string, withCoverage *bool, generateTestReport *bool, configPath string, ignoreOrdering *bool, passThroughHosts *[]models.Filters) error {
 	configFilePath := filepath.Join(configPath, "keploy-config.yaml")
 	if isExist := utils.CheckFileExists(configFilePath); !isExist {
 		return errFileNotFound
@@ -61,8 +61,8 @@ func (t *Test) getTestConfig(path *string, proxyPort *uint32, appCmd *string, te
 		*appCmd = confTest.Command
 	}
 	for testset, testcases := range confTest.SelectedTests {
-		if _, ok := (*tests)[testset]; !ok {
-			(*tests)[testset] = testcases
+		if _, ok := (*testFilters)[testset]; !ok {
+			(*testFilters)[testset] = testcases
 		}
 	}
 	if *appContainer == "" {
@@ -246,7 +246,7 @@ func (t *Test) GetCmd() *cobra.Command {
 				return err
 			}
 
-			tests := map[string][]string{}
+			testFilters := map[string][]string{}
 
 			testsets, err := cmd.Flags().GetStringSlice("testsets")
 			if err != nil {
@@ -255,14 +255,14 @@ func (t *Test) GetCmd() *cobra.Command {
 			}
 
 			for _, testset := range testsets {
-				tests[testset] = []string{}
+				testFilters[testset] = []string{}
 			}
 
 			globalNoise := make(models.GlobalNoise)
 			testsetNoise := make(models.TestsetNoise)
 
 			passThroughHosts := []models.Filters{}
-			err = t.getTestConfig(&path, &proxyPort, &appCmd, &tests, &appContainer, &networkName, &delay, &buildDelay, &ports, &apiTimeout, &globalNoise, &testsetNoise, &coverageReportPath, &withCoverage, &generateTestReport, configPath, &ignoreOrdering, &passThroughHosts)
+			err = t.getTestConfig(&path, &proxyPort, &appCmd, &testFilters, &appContainer, &networkName, &delay, &buildDelay, &ports, &apiTimeout, &globalNoise, &testsetNoise, &coverageReportPath, &withCoverage, &generateTestReport, configPath, &ignoreOrdering, &passThroughHosts)
 			if err != nil {
 				if err == errFileNotFound {
 					t.logger.Info("Keploy config not found, continuing without configuration")
@@ -433,11 +433,11 @@ func (t *Test) GetCmd() *cobra.Command {
 			t.logger.Debug("the configuration for mocking mongo connection", zap.Any("password", mongoPassword))
 			if coverage {
 				g := graph.NewGraph(t.logger)
-				g.Serve(path, proxyPort, mongoPassword, testReportPath, generateTestReport, delay, pid, port, lang, ports, apiTimeout, appCmd, enableTele)
+				g.Serve(path, proxyPort, mongoPassword, testReportPath, generateTestReport, delay, pid, port, lang, ports, apiTimeout, appCmd, enableTele, testFilters)
 			} else {
 
 				t.tester.StartTest(path, testReportPath, appCmd, test.TestOptions{
-					Tests:              tests,
+					Tests:              testFilters,
 					AppContainer:       appContainer,
 					AppNetwork:         networkName,
 					MongoPassword:      mongoPassword,

--- a/pkg/graph/resolver.go
+++ b/pkg/graph/resolver.go
@@ -15,6 +15,7 @@ var Emoji = "\U0001F430" + " Keploy:"
 
 type Resolver struct {
 	Tester             test.Tester
+	TestFilter 		   map[string][]string
 	TestReportFS       platform.TestReportDB
 	Storage            platform.TestCaseDB
 	LoadedHooks        *hooks.Hook

--- a/pkg/graph/resolver.go
+++ b/pkg/graph/resolver.go
@@ -15,7 +15,7 @@ var Emoji = "\U0001F430" + " Keploy:"
 
 type Resolver struct {
 	Tester             test.Tester
-	TestFilter 		   map[string][]string
+	TestFilter         map[string][]string
 	TestReportFS       platform.TestReportDB
 	Storage            platform.TestCaseDB
 	LoadedHooks        *hooks.Hook

--- a/pkg/graph/serve.go
+++ b/pkg/graph/serve.go
@@ -40,7 +40,7 @@ func NewGraph(logger *zap.Logger) graphInterface {
 const defaultPort = 6789
 
 // Serve is called by the serve command and is used to run a graphql server, to run tests separately via apis.
-func (g *graph) Serve(path string, proxyPort uint32, mongopassword, testReportPath string, generateTestReport bool, Delay uint64, pid, port uint32, lang string, passThroughPorts []uint, apiTimeout uint64, appCmd string, enableTele bool) {
+func (g *graph) Serve(path string, proxyPort uint32, mongopassword, testReportPath string, generateTestReport bool, Delay uint64, pid, port uint32, lang string, passThroughPorts []uint, apiTimeout uint64, appCmd string, enableTele bool, testFilters map[string][]string) {
 	var ps *proxy.ProxySet
 
 	defer pkg.DeleteTestReports(g.logger, generateTestReport)
@@ -73,6 +73,7 @@ func (g *graph) Serve(path string, proxyPort uint32, mongopassword, testReportPa
 
 	srv := handler.NewDefaultServer(NewExecutableSchema(Config{
 		Resolvers: &Resolver{
+			TestFilter:         testFilters,
 			Tester:             tester,
 			TestReportFS:       testReportFS,
 			Storage:            ys,

--- a/pkg/graph/service.go
+++ b/pkg/graph/service.go
@@ -5,6 +5,6 @@ import (
 )
 
 type graphInterface interface {
-	Serve(path string, proxyPort uint32, mongoPassword, testReportPath string, generateTestReport bool, Delay uint64, pid, port uint32, lang string, passThroughPorts []uint, apiTimeout uint64, appCmd string, enableTele bool)
+	Serve(path string, proxyPort uint32, mongoPassword, testReportPath string, generateTestReport bool, Delay uint64, pid, port uint32, lang string, passThroughPorts []uint, apiTimeout uint64, appCmd string, enableTele bool, testFilters map[string][]string)
 	stopGraphqlServer(http *http.Server)
 }

--- a/pkg/service/test/match.go
+++ b/pkg/service/test/match.go
@@ -20,13 +20,6 @@ func UnmarshallJson(s string, log *zap.Logger) (interface{}, error) {
 	}
 }
 
-func ArrayToMap(arr []string) map[string]bool {
-	res := map[string]bool{}
-	for i := range arr {
-		res[arr[i]] = true
-	}
-	return res
-}
 
 func InterfaceToString(val interface{}) string {
 	switch v := val.(type) {

--- a/pkg/service/test/match.go
+++ b/pkg/service/test/match.go
@@ -20,7 +20,6 @@ func UnmarshallJson(s string, log *zap.Logger) (interface{}, error) {
 	}
 }
 
-
 func InterfaceToString(val interface{}) string {
 	switch v := val.(type) {
 	case int:

--- a/pkg/service/test/test.go
+++ b/pkg/service/test/test.go
@@ -245,7 +245,7 @@ func (t *tester) Test(path string, testReportPath string, appCmd string, options
 	}
 	for _, sessionIndex := range sessions {
 		// checking whether the provided testset match with a recorded testset.
-		testcases := ArrayToMap(options.Tests[sessionIndex])
+		testcases := utils.ArrayToMap(options.Tests[sessionIndex])
 		if _, ok := options.Tests[sessionIndex]; !ok && len(options.Tests) != 0 {
 			continue
 		}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -357,3 +357,12 @@ func UpdateKeployToDocker(cmdName string, isDockerCompose bool, flags interface{
 }
 
 var WarningSign = "\U000026A0"
+
+// ArrayToMap converts an array of strings to a map[string]bool.
+func ArrayToMap(arr []string) map[string]bool {
+	res := map[string]bool{}
+	for i := range arr {
+		res[arr[i]] = true
+	}
+	return res
+}


### PR DESCRIPTION
## Related Issue
  - filter to run specific test-set/testcases do not work for code coverages

Closes: #1611

#### Describe the changes you've made
Returns filtered test sets to the unit test frameworks and passes filtered testcases to the RunTestSets of test service

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Tested the changes with junit test to capture code coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
NA

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

