### PR TITLE
fix: adds a nil check before stopping the ebpf hooks

### DIFF
--- a/pkg/hooks/loader.go
+++ b/pkg/hooks/loader.go
@@ -62,7 +62,7 @@ type Hook struct {
 	mutex                    sync.RWMutex
 	userAppCmd               *exec.Cmd
 	userAppShutdownInitiated bool
-	isHooksLoaded 		 bool
+	isHooksLoaded            bool
 	mainRoutineId            int
 
 	// ebpf objects and events
@@ -585,9 +585,9 @@ func deleteFileIfExists(filename string, logger *zap.Logger) error {
 
 func (h *Hook) Stop(forceStop bool) {
 	if !h.isHooksLoaded || h.socket == nil {
-		return	
+		return
 	}
-	
+
 	if !forceStop && !h.IsUserAppTerminateInitiated() {
 		h.logger.Info("Received signal to exit keploy program..")
 		h.StopUserApplication()
@@ -610,7 +610,6 @@ func (h *Hook) Stop(forceStop bool) {
 		}
 	}
 
-	
 	// closing all events
 	//other
 	h.socket.Close()

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -356,8 +356,6 @@ func SetupCA(logger *zap.Logger, pid uint32, lang string) error {
 		return err
 	}
 
-	fmt.Println("set the certificate path in environment", os.Getenv("NODE_EXTRA_CA_CERTS"))
-
 	// for python
 	err = os.Setenv("REQUESTS_CA_BUNDLE", tempCertPath)
 	if err != nil {


### PR DESCRIPTION
## Related Issue
  - Nil pointer exception when the code coverage fails to run user test cmd

Closes: #

#### Describe the changes you've made
Adds a nil check to avoid nil pointer referrence before closing the ebpf hooks

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
