### PR TITLE
fix: cmd failure if user is not sudoer

### DIFF
--- a/pkg/hooks/launch.go
+++ b/pkg/hooks/launch.go
@@ -1,7 +1,6 @@
 package hooks
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -476,12 +475,12 @@ func (h *Hook) processDockerEnv(appCmd, appContainer, appNetwork string, buildDe
 func (h *Hook) runApp(appCmd string, isUnitTestIntegration bool) error {
 	// Create a new command with your appCmd'
 	username := os.Getenv("SUDO_USER")
-	var cmd *exec.Cmd
+	cmd := exec.Command("sh", "-c", appCmd)
 	if username != "" {
+		// print all environment variables
+		h.logger.Debug("env inherited from the cmd", zap.Any("env", os.Environ()))
 		// Run the command as the user who invoked sudo to preserve the user environment variables and PATH
 		cmd = exec.Command("sudo", "-E", "-u", os.Getenv("SUDO_USER"), "env", "PATH="+os.Getenv("PATH"), "sh", "-c", appCmd)
-	} else {
-		cmd = exec.Command("sh", "-c", appCmd)
 	}
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setpgid: true,
@@ -491,42 +490,6 @@ func (h *Hook) runApp(appCmd string, isUnitTestIntegration bool) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	h.userAppCmd = cmd
-
-	// Run the app as the user who invoked sudo
-	if username != "" {
-		uidCmd := exec.Command("id", "-u", username)
-		gidCmd := exec.Command("id", "-g", username)
-
-		var uidOut, gidOut bytes.Buffer
-		uidCmd.Stdout = &uidOut
-		gidCmd.Stdout = &gidOut
-
-		err := uidCmd.Run()
-		if err != nil {
-			return err
-		}
-
-		err = gidCmd.Run()
-		if err != nil {
-			return err
-		}
-
-		uidStr := strings.TrimSpace(uidOut.String())
-		gidStr := strings.TrimSpace(gidOut.String())
-
-		uid, err := strconv.ParseUint(uidStr, 10, 32)
-		if err != nil {
-			return err
-		}
-
-		gid, err := strconv.ParseUint(gidStr, 10, 32)
-		if err != nil {
-			return err
-		}
-
-		// Switch the user
-		cmd.SysProcAttr.Credential = &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid)}
-	}
 
 	h.logger.Debug("", zap.Any("executing cmd", cmd.String()))
 


### PR DESCRIPTION
#### Describe the changes you've made
Removed redundant user and group id set on the app cmd which lead to failures if the user is not a sudoer. 