### PR TITLE
chore: remove unnecessary binding of root cmd flags

### DIFF
--- a/cli/provider/service.go
+++ b/cli/provider/service.go
@@ -41,7 +41,7 @@ func NewServiceProvider(logger *zap.Logger, configDb *configdb.ConfigDb) *Servic
 }
 
 func (n *ServiceProvider) GetTelemetryService(ctx context.Context, config config.Config) (*telemetry.Telemetry, error) {
-	installtionID, err := n.configDb.GetInstallationID(ctx)
+	installationID, err := n.configDb.GetInstallationID(ctx)
 	if err != nil {
 		return nil, errors.New("failed to get installation id")
 	}
@@ -49,7 +49,7 @@ func (n *ServiceProvider) GetTelemetryService(ctx context.Context, config config
 		Enabled:        !config.DisableTele,
 		Version:        utils.Version,
 		GlobalMap:      map[string]interface{}{},
-		InstallationID: installtionID,
+		InstallationID: installationID,
 	},
 	), nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -28,7 +28,8 @@ import (
 
 var WarningSign = "\U000026A0"
 
-func BindFlagsToViper(logger *zap.Logger, cmd *cobra.Command, viperKeyPrefix string) {
+func BindFlagsToViper(logger *zap.Logger, cmd *cobra.Command, viperKeyPrefix string) error {
+	var bindErr error
 	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 		// Construct the Viper key and the env variable name
 		if viperKeyPrefix == "" {
@@ -43,14 +44,17 @@ func BindFlagsToViper(logger *zap.Logger, cmd *cobra.Command, viperKeyPrefix str
 		err := viper.BindPFlag(viperKey, flag)
 		if err != nil {
 			LogError(logger, err, "failed to bind flag to config")
+			bindErr = err
 		}
 
 		// Tell Viper to also read this flag's value from the corresponding env variable
 		err = viper.BindEnv(viperKey, envVarName)
 		if err != nil {
 			LogError(logger, err, "failed to bind environment variables to config")
+			bindErr = err
 		}
 	})
+	return bindErr
 }
 
 //func ModifyToSentryLogger(ctx context.Context, logger *zap.Logger, client *sentry.Client, configDb *configdb.ConfigDb) *zap.Logger {


### PR DESCRIPTION
## Related Issue
  - No need to validate root cmd flags.

Closes: #[issue number that will be closed through this PR]

#### Describe the changes you've made
- Removed unnecessary viper binding of root command flags because subcommand contains the persistent flags of root.
- Since each subcommand is validated, the persistent flags of root are also binded.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
`NA`

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |