### PR TITLE
fix: go test coverage

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -199,6 +199,7 @@ func (c *CmdConfigurator) AddFlags(cmd *cobra.Command) error {
 			cmd.Flags().Bool("ignoreOrdering", c.cfg.Test.IgnoreOrdering, "Ignore ordering of array in response")
 			cmd.Flags().Bool("coverage", c.cfg.Test.Coverage, "Enable coverage reporting for the testcases. for golang please set language flag to golang, ref https://keploy.io/docs/server/sdk-installation/go/")
 			cmd.Flags().Bool("removeUnusedMocks", false, "Clear the unused mocks for the passed test-sets")
+			cmd.Flags().Bool("goCoverage", c.cfg.Test.GoCoverage, "Enable go coverage reporting for the testcases")
 		} else {
 			cmd.Flags().Uint64("recordTimer", 0, "User provided time to record its application")
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -47,6 +47,7 @@ type Test struct {
 	APITimeout         uint64              `json:"apiTimeout" yaml:"apiTimeout" mapstructure:"apiTimeout"`
 	Coverage           bool                `json:"coverage" yaml:"coverage" mapstructure:"coverage"`                                // boolean to capture the coverage in test
 	CoverageReportPath string              `json:"coverageReportPath" yaml:"coverageReportPath " mapstructure:"coverageReportPath"` // directory path to store the coverage files
+	GoCoverage         bool                `json:"goCoverage" yaml:"goCoverage" mapstructure:"goCoverage"`                          // boolean to capture the coverage in test
 	IgnoreOrdering     bool                `json:"ignoreOrdering" yaml:"ignoreOrdering" mapstructure:"ignoreOrdering"`
 	MongoPassword      string              `json:"mongoPassword" yaml:"mongoPassword" mapstructure:"mongoPassword"`
 	Language           string              `json:"language" yaml:"language" mapstructure:"language"`

--- a/config/default.go
+++ b/config/default.go
@@ -28,6 +28,7 @@ test:
   delay: 5
   apiTimeout: 5
   coverage: false
+  goCoverage: false
   coverageReportPath: ""
   ignoreOrdering: true
   mongoPassword: "default@123"

--- a/pkg/core/proxy/integrations/generic/match.go
+++ b/pkg/core/proxy/integrations/generic/match.go
@@ -62,7 +62,7 @@ func fuzzyMatch(ctx context.Context, reqBuff [][]byte, mockDb integrations.MockM
 			}
 
 			totalMocks := append(filteredMocks, unfilteredMocks...)
-			index = findBinaryMatch(totalMocks, reqBuff, 0.5)
+			index = findBinaryMatch(totalMocks, reqBuff, 0.4)
 
 			if index != -1 {
 				responseMock := make([]models.GenericPayload, len(totalMocks[index].Spec.GenericResponses))

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -624,7 +624,7 @@ func (r *replayer) printSummary(ctx context.Context, testRunResult bool) {
 			return
 		}
 		r.logger.Info("test run completed", zap.Bool("passed overall", testRunResult))
-		if r.config.Test.Coverage {
+		if r.config.Test.GoCoverage {
 			r.logger.Info("there is a opportunity to get the coverage here")
 			coverCmd := exec.CommandContext(ctx, "go", "tool", "covdata", "percent", "-i="+os.Getenv("GOCOVERDIR"))
 			output, err := coverCmd.Output()

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -74,7 +74,6 @@ func SimulateHTTP(ctx context.Context, tc models.TestCase, testSet string, logge
 		return nil, err
 	}
 	req.Header = ToHTTPHeader(tc.HTTPReq.Header)
-	req.Header.Set("KEPLOY-TEST-ID", tc.Name)
 	req.ProtoMajor = tc.HTTPReq.ProtoMajor
 	req.ProtoMinor = tc.HTTPReq.ProtoMinor
 


### PR DESCRIPTION
## Related Issue
 
**ISSUE** :

1. go coverage is not working because --coverage flag is now used for spinning graphQl server
2. Tried a go-app, generic mocks are not matching because of high similarity constant.
3. keploy test header which is added via test is causing diff in the test response because in a go-app headers in request getting repeated in the test response. 

**Changes**:
1. added new goCoverage flag
2. decreased similarity constant 
3. remove keploy test header as their is no use case as of now.

#### Describe the changes you've made
A clear and concise description of what you have done to successfully close your assigned issue. Any new files? or anything you feel to let us know!

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |