### PR TITLE
fix: make exact match work for chunked pg req

### DIFF
--- a/pkg/core/proxy/integrations/postgres/v1/decode.go
+++ b/pkg/core/proxy/integrations/postgres/v1/decode.go
@@ -64,6 +64,7 @@ func decodePostgres(ctx context.Context, logger *zap.Logger, reqBuf []byte, clie
 			}
 
 			if !matched {
+				logger.Debug("MISMATCHED REQ is" + string(pgRequests[0]))
 				_, err = pUtil.PassThrough(ctx, logger, clientConn, dstCfg, pgRequests)
 				if err != nil {
 					utils.LogError(logger, err, "failed to pass the request", zap.Any("request packets", len(pgRequests)))

--- a/pkg/core/proxy/integrations/postgres/v1/match.go
+++ b/pkg/core/proxy/integrations/postgres/v1/match.go
@@ -45,7 +45,7 @@ func getTestPS(reqBuff [][]byte, logger *zap.Logger, ConnectionID string) {
 	// also append the query data for the prepared statement
 	if len(querydata) > 0 {
 		testmap2[ConnectionID] = append(testmap2[ConnectionID], querydata...)
-		// fmt.Println("Test Prepared statement Map", testmap2)
+		// logger.Debug("Test Prepared statement Map", testmap2)
 		testmap = testmap2
 	}
 
@@ -84,9 +84,12 @@ func matchingReadablePG(ctx context.Context, logger *zap.Logger, requestBuffers 
 				logger.Debug("ConnectionId-", zap.String("ConnectionId", ConnectionID))
 				logger.Debug("TestMap*****", zap.Any("TestMap", testmap))
 			}
-			// if recordedPrep != nil {
-			// 	fmt.Println("PREPARED STATEMENT", recordedPrep)
-			// }
+
+			// merge all the streaming requests into 1 for matching
+			newRq := mergePgRequests(requestBuffers, logger)
+			if len(newRq) > 0 {
+				requestBuffers = newRq
+			}
 
 			var sortFlag = true
 			var sortedTcsMocks []*models.Mock
@@ -217,13 +220,11 @@ func matchingReadablePG(ctx context.Context, logger *zap.Logger, requestBuffers 
 					if newMock != nil {
 						matchedMock = newMock
 					}
-					// fmt.Println("Matched In Absolute Custom Matching for sorted!!!", matchedMock.Name)
 				}
 				idx = findBinaryStreamMatch(logger, sortedTcsMocks, requestBuffers, sorted)
 				if idx != -1 && !matched {
 					matched = true
 					matchedMock = tcsMocks[idx]
-					// fmt.Println("Matched In Binary Matching for Sorted", matchedMock.Name)
 				}
 			}
 
@@ -236,7 +237,6 @@ func matchingReadablePG(ctx context.Context, logger *zap.Logger, requestBuffers 
 					if newMock != nil {
 						matchedMock = newMock
 					}
-					// fmt.Println("Matched In Absolute Custom Matching for Unsorted", matchedMock.Name)
 				}
 				idx = findBinaryStreamMatch(logger, tcsMocks, requestBuffers, sorted)
 				// check if the validate the query with the matched mock
@@ -277,14 +277,13 @@ func matchingReadablePG(ctx context.Context, logger *zap.Logger, requestBuffers 
 				}
 				return true, matchedMock.Spec.PostgresResponses, nil
 			}
-
 			return false, nil, nil
 		}
 	}
 }
 
 func findBinaryStreamMatch(logger *zap.Logger, tcsMocks []*models.Mock, requestBuffers [][]byte, sorted bool) int {
-
+	logger.Debug("INSIDE BINARY MATCH!!")
 	mxSim := -1.0
 	mxIdx := -1
 
@@ -355,13 +354,15 @@ func findPGStreamMatch(tcsMocks []*models.Mock, requestBuffers [][]byte, logger 
 	match := false
 	// loop for the exact match of the request
 	for idx, mock := range tcsMocks {
-		if len(mock.Spec.PostgresRequests) == len(requestBuffers) {
+		// this is sync packet problem in pg req ..
+		mmocks := mergeMocks(mock.Spec.PostgresRequests, logger)
+		mock.Spec.PostgresRequests = mmocks
+		if len(mock.Spec.PostgresRequests) == len(requestBuffers) { //|| (isSorted && (len(mock.Spec.PostgresRequests)+1) == len(requestBuffers))
 			for _, reqBuff := range requestBuffers {
 				actualPgReq := decodePgRequest(reqBuff, logger)
 				if actualPgReq == nil {
 					return -1, nil
 				}
-
 				// here handle cases of prepared statement very carefully
 				match, err := compareExactMatch(mock, actualPgReq, logger)
 				if err != nil {
@@ -457,10 +458,10 @@ func changeResToPS(mock *models.Mock, actualPgReq *models.Backend, logger *zap.L
 	// [B E P D B E]
 	// [P, B, E, P, B, D, E] -> [B, E, P, B, D, E]
 	if (reflect.DeepEqual(actualpackets, []string{"B", "E", "P", "D", "B", "E"}) || reflect.DeepEqual(actualpackets, []string{"B", "E", "P", "B", "D", "E"})) && reflect.DeepEqual(mockPackets, []string{"P", "B", "E", "P", "B", "D", "E"}) {
-		// fmt.Println("Handling Case 1 for mock", mock.Name)
+		// logger.Debug("Handling Case 1 for mock", mock.Name)
 		// handleCase1(packets, mockPackets)
 		// also check if the second query is same or not
-		// fmt.Println("ActualPgReq", actualPgReq.Parses[0].Query, "MOCK REQ 1", mock.Spec.PostgresRequests[0].Parses[0].Query, "MOCK REQ 2", mock.Spec.PostgresRequests[0].Parses[1].Query)
+		// logger.Debug("ActualPgReq", actualPgReq.Parses[0].Query, "MOCK REQ 1", mock.Spec.PostgresRequests[0].Parses[0].Query, "MOCK REQ 2", mock.Spec.PostgresRequests[0].Parses[1].Query)
 		if actualPgReq.Parses[0].Query != mock.Spec.PostgresRequests[0].Parses[1].Query {
 			return false, nil
 		}
@@ -471,7 +472,7 @@ func changeResToPS(mock *models.Mock, actualPgReq *models.Backend, logger *zap.L
 	// case 2
 	var ps string
 	if reflect.DeepEqual(actualpackets, []string{"B", "E"}) && reflect.DeepEqual(mockPackets, []string{"P", "B", "D", "E"}) {
-		// fmt.Println("Handling Case 2 for mock", mock.Name)
+		// logger.Debug("Handling Case 2 for mock", mock.Name)
 		ps = actualPgReq.Binds[0].PreparedStatement
 		for _, v := range testmap[connectionID] {
 			if v.Query == mock.Spec.PostgresRequests[0].Parses[0].Query && v.PrepIdentifier == ps {
@@ -483,7 +484,7 @@ func changeResToPS(mock *models.Mock, actualPgReq *models.Backend, logger *zap.L
 
 	if ischanged {
 		// if strings.Contains(ps, "S_") {
-		// fmt.Println("Inside Prepared Statement")
+		// logger.Debug("Inside Prepared Statement")
 		newMock = sliceCommandTag(mock, logger, testmap[connectionID], actualPgReq, 2)
 		// }
 		return true, newMock
@@ -494,7 +495,7 @@ func changeResToPS(mock *models.Mock, actualPgReq *models.Backend, logger *zap.L
 
 	// Case 3
 	if reflect.DeepEqual(actualpackets, []string{"B", "E", "B", "E"}) && reflect.DeepEqual(mockPackets, []string{"P", "B", "E", "P", "B", "D", "E"}) {
-		// fmt.Println("Handling Case 3 for mock", mock.Name)
+		// logger.Debug("Handling Case 3 for mock", mock.Name)
 		ischanged1 := false
 		ps1 := actualPgReq.Binds[0].PreparedStatement
 		for _, v := range testmap[connectionID] {
@@ -520,7 +521,7 @@ func changeResToPS(mock *models.Mock, actualPgReq *models.Backend, logger *zap.L
 
 	// Case 4
 	if reflect.DeepEqual(actualpackets, []string{"B", "E", "B", "E"}) && reflect.DeepEqual(mockPackets, []string{"B", "E", "P", "B", "D", "E"}) {
-		// fmt.Println("Handling Case 4 for mock", mock.Name)
+		// logger.Debug("Handling Case 4 for mock", mock.Name)
 		// get the query for the prepared statement of test mode
 		ischanged := false
 		ps := actualPgReq.Binds[1].PreparedStatement
@@ -542,7 +543,7 @@ func changeResToPS(mock *models.Mock, actualPgReq *models.Backend, logger *zap.L
 }
 
 func PreparedStatementMatch(mock *models.Mock, actualPgReq *models.Backend, logger *zap.Logger, ConnectionID string, recordedPrep PrepMap) (bool, []string, error) {
-	// fmt.Println("Inside PreparedStatementMatch")
+	// logger.Debug("Inside PreparedStatementMatch")
 	// check the current Query associated with the connection id and Identifier
 	ifps := checkIfps(actualPgReq.PacketTypes)
 	if !ifps {
@@ -572,7 +573,7 @@ func PreparedStatementMatch(mock *models.Mock, actualPgReq *models.Backend, logg
 		// then will check what is the recorded prepared statement for this query
 		for _, v := range currentQuerydata {
 			if v.PrepIdentifier == currentPs {
-				// fmt.Println("Current query for this identifier is ", v.Query)
+				// logger.Debug("Current query for this identifier is ", v.Query)
 				currentQuery = v.Query
 				break
 			}
@@ -621,7 +622,7 @@ func compareExactMatch(mock *models.Mock, actualPgReq *models.Backend, logger *z
 	for i := 0; i < len(actualPgReq.PacketTypes); i++ {
 		switch actualPgReq.PacketTypes[i] {
 		case "P":
-			// fmt.Println("Inside P")
+			// logger.Debug("Inside P")
 			p++
 			if actualPgReq.Parses[p-1].Query != mock.Spec.PostgresRequests[0].Parses[p-1].Query {
 				return false, nil
@@ -641,7 +642,7 @@ func compareExactMatch(mock *models.Mock, actualPgReq *models.Backend, logger *z
 			}
 
 		case "B":
-			// fmt.Println("Inside B")
+			// logger.Debug("Inside B")
 			b++
 			if actualPgReq.Binds[b-1].DestinationPortal != mock.Spec.PostgresRequests[0].Binds[b-1].DestinationPortal {
 				return false, nil
@@ -679,7 +680,7 @@ func compareExactMatch(mock *models.Mock, actualPgReq *models.Backend, logger *z
 			}
 
 		case "E":
-			// fmt.Println("Inside E")
+			// logger.Debug("Inside E")
 			e++
 			if actualPgReq.Executes[e-1].Portal != mock.Spec.PostgresRequests[0].Executes[e-1].Portal {
 				return false, nil
@@ -722,18 +723,18 @@ func validateMock(tcsMocks []*models.Mock, idx int, requestBuffers [][]byte, log
 			}
 		}
 		if reflect.DeepEqual(mock.PacketTypes, []string{"B", "E", "B", "E"}) {
-			// fmt.Println("Inside Validate Mock for B, E, B, E")
+			// logger.Debug("Inside Validate Mock for B, E, B, E")
 			return true, nil
 		}
 		if reflect.DeepEqual(mock.PacketTypes, []string{"B", "E"}) {
-			// fmt.Println("Inside Validate Mock for B, E")
+			// logger.Debug("Inside Validate Mock for B, E")
 			copyMock := *tcsMocks[idx]
 			copyMock.Spec.PostgresResponses[0].PacketTypes = []string{"2", "C", "Z"}
 			copyMock.Spec.PostgresResponses[0].Payload = ""
 			return false, &copyMock
 		}
 		if reflect.DeepEqual(mock.PacketTypes, []string{"P", "B", "D", "E"}) {
-			// fmt.Println("Inside Validate Mock for P, B, D, E")
+			// logger.Debug("Inside Validate Mock for P, B, D, E")
 			copyMock := *tcsMocks[idx]
 			copyMock.Spec.PostgresResponses[0].PacketTypes = []string{"1", "2", "T", "C", "Z"}
 			copyMock.Spec.PostgresResponses[0].Payload = ""
@@ -742,15 +743,15 @@ func validateMock(tcsMocks []*models.Mock, idx int, requestBuffers [][]byte, log
 	} else {
 		// [B, E, P, B, D, E] => [ P, B, D, E]
 		if reflect.DeepEqual(mock.PacketTypes, []string{"B", "E", "P", "B", "D", "E"}) && reflect.DeepEqual(actualPgReq.PacketTypes, []string{"P", "B", "D", "E"}) {
-			// fmt.Println("Inside Validate Mock for B, E, B, E")
+			// logger.Debug("Inside Validate Mock for B, E, B, E")
 			if mock.Parses[0].Query == actualPgReq.Parses[0].Query {
 				// no need to do anything
-				// fmt.Println("Matched with the query AHHAHAHAHAH", mock.Parses[0].Query)
+				// logger.Debug("Matched with the query AHHAHAHAHAH", mock.Parses[0].Query)
 				copyMock := *tcsMocks[idx]
 				copyMock.Spec.PostgresResponses[0].PacketTypes = []string{"1", "2", "T", "C", "Z"}
 				copyMock.Spec.PostgresResponses[0].Payload = ""
 				copyMock.Spec.PostgresResponses[0].CommandCompletes = copyMock.Spec.PostgresResponses[0].CommandCompletes[1:]
-				// fmt.Println("Matched with the query AHHAHAHAHAH", copyMock)
+				// logger.Debug("Matched with the query AHHAHAHAHAH", copyMock)
 				return false, &copyMock
 			}
 		}

--- a/pkg/core/proxy/integrations/postgres/v1/util.go
+++ b/pkg/core/proxy/integrations/postgres/v1/util.go
@@ -455,3 +455,42 @@ func decodePgRequest(buffer []byte, logger *zap.Logger) *models.Backend {
 
 	return nil
 }
+
+func mergePgRequests(requestBuffers [][]byte, logger *zap.Logger) [][]byte {
+	logger.Debug("MERGING REQUESTS")
+	// Check for PBDE first
+	var mergeBuff []byte
+	for _, v := range requestBuffers {
+		backend := decodePgRequest(v, logger)
+
+		if backend == nil {
+			logger.Debug("Rerurning nil while merging ")
+			break
+		}
+		buf, _ := postgresDecoderBackend(*backend)
+		mergeBuff = append(mergeBuff, buf...)
+	}
+	if len(mergeBuff) > 0 {
+		return [][]byte{mergeBuff}
+	}
+
+	return requestBuffers
+}
+
+func mergeMocks(pgmocks []models.Backend, logger *zap.Logger) []models.Backend {
+	logger.Debug("MERGING Mocks")
+	// Check for PBDE first
+	if len(pgmocks[0].PacketTypes) == 0 || pgmocks[0].PacketTypes[0] != "P" {
+		return pgmocks
+	}
+	var mergeBuff []byte
+	for _, v := range pgmocks {
+		buf, _ := postgresDecoderBackend(v)
+		mergeBuff = append(mergeBuff, buf...)
+	}
+	if len(mergeBuff) > 0 {
+		return []models.Backend{*decodePgRequest(mergeBuff, logger)}
+	}
+
+	return pgmocks
+}


### PR DESCRIPTION
## Related Issue
  - So I observed, that breaking it’s happening in case of streaming postgres requests by client in case of pooling .
const { Pool } = require('pg');
 So currently keploy matches the request coming at the time test mode with the requests saved in the mock files . So what happening is pg client is streaming in a random order which is causing mismatch in the matching algorithm. 
 for eg - in record it can give me requests in 4 chunks [P],[B],[D],[E] but in case it might give me in a single buffer or breaking in any other fashion.
So I solved it by merging all the requests in a single buffer both for the actual requests and the saved in the mocks for uniformity and matching. 
So any pattern will at last be compared as [P,B,D,E].
 
Closes: #1788 

#### Describe the changes you've made
A clear and concise description of what you have done to successfully close your assigned issue. Any new files? or anything you feel to let us know!

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |