### PR TITLE
fix: blocking of keploy after interrupt while using http deps

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,8 @@ import (
 	"go.keploy.io/server/v2/pkg/platform/yaml/configdb"
 	"go.keploy.io/server/v2/utils"
 	"go.keploy.io/server/v2/utils/log"
+	//pprof for debugging
+	// _ "net/http/pprof"
 )
 
 // version is the version of the server and will be injected during build by ldflags, same with dsn
@@ -33,6 +35,12 @@ const logo string = `
 `
 
 func main() {
+
+	// Uncomment the following code to enable pprof for debugging
+	// go func() {
+	// 	fmt.Println("Starting pprof server for debugging...")
+	// 	http.ListenAndServe("localhost:6060", nil)
+	// }()
 	printLogo()
 	ctx := utils.NewCtx()
 	start(ctx)

--- a/pkg/core/proxy/integrations/http/encode.go
+++ b/pkg/core/proxy/integrations/http/encode.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"golang.org/x/sync/errgroup"
 	"io"
 	"net"
 	"strings"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"go.keploy.io/server/v2/pkg/core/proxy/util"
 	"go.keploy.io/server/v2/pkg/models"
@@ -226,6 +227,7 @@ func encodeHTTP(ctx context.Context, logger *zap.Logger, reqBuf []byte, clientCo
 					logger.Debug("failed to read the request message from the user client", zap.Error(err))
 					logger.Debug("This was the last response from the server: " + string(resp))
 					errCh <- nil
+					return nil
 				}
 				errCh <- err
 				return nil


### PR DESCRIPTION
## Related Issue
  - Fixed blocking of keploy after interrupt

Closes: #1802 

#### Describe the changes you've made
- Was not returning from the go routine when an error occurred while reading from the client connection.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
`NA`

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |