### PR TITLE
fix: go coverage in native

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -189,6 +189,7 @@ func (c *CmdConfigurator) AddFlags(cmd *cobra.Command) error {
 		cmd.Flags().Uint32("proxyPort", c.cfg.ProxyPort, "Port used by the Keploy proxy server to intercept the outgoing dependency calls")
 		cmd.Flags().Uint32("dnsPort", c.cfg.DNSPort, "Port used by the Keploy DNS server to intercept the DNS queries")
 		cmd.Flags().StringP("command", "c", c.cfg.Command, "Command to start the user application")
+		cmd.Flags().String("cmdType", c.cfg.CommandType, "Type of command to start the user application (native/docker/docker-compose)")
 		cmd.Flags().DurationP("buildDelay", "b", c.cfg.BuildDelay, "User provided time to wait docker container build")
 		cmd.Flags().String("containerName", c.cfg.ContainerName, "Name of the application's docker container")
 		cmd.Flags().StringP("networkName", "n", c.cfg.NetworkName, "Name of the application's docker network")
@@ -323,6 +324,10 @@ func (c CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command) 
 			}
 			return errors.New("missing required -c flag or appCmd in config file")
 		}
+
+		// set the command type
+		c.cfg.CommandType = string(utils.FindDockerCmd(c.cfg.Command))
+
 		if c.cfg.GenerateGithubActions {
 			defer utils.GenerateGithubActions(c.logger, c.cfg.Command)
 		}
@@ -336,12 +341,12 @@ func (c CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command) 
 					return errors.New(errMsg)
 				}
 				if strings.Contains(c.cfg.Path, "..") {
-					c.cfg.Path, err = filepath.Abs(filepath.Clean(c.cfg.Path))
+
+					c.cfg.Path, err = utils.GetAbsPath(filepath.Clean(c.cfg.Path))
 					if err != nil {
-						errMsg := "failed to get the absolute path from relative path"
-						utils.LogError(c.logger, err, errMsg)
-						return errors.New(errMsg)
+						return fmt.Errorf("failed to get the absolute path from relative path: %w", err)
 					}
+
 					relativePath, err := filepath.Rel(curDir, c.cfg.Path)
 					if err != nil {
 						errMsg := "failed to get the relative path from absolute path"
@@ -374,12 +379,12 @@ func (c CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command) 
 			return err
 		}
 
-		absPath, err := filepath.Abs(c.cfg.Path)
+		absPath, err := utils.GetAbsPath(c.cfg.Path)
 		if err != nil {
-			errMsg := "failed to get the absolute path from relative path"
-			utils.LogError(c.logger, err, errMsg)
-			return errors.New(errMsg)
+			utils.LogError(c.logger, err, "error while getting absolute path")
+			return errors.New("failed to get the absolute path")
 		}
+
 		c.cfg.Path = absPath + "/keploy"
 		if cmd.Name() == "test" {
 			testSets, err := cmd.Flags().GetStringSlice("testsets")
@@ -389,6 +394,16 @@ func (c CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command) 
 				return errors.New(errMsg)
 			}
 			config.SetSelectedTests(c.cfg, testSets)
+
+			if utils.CmdType(c.cfg.CommandType) == utils.Native && c.cfg.Test.GoCoverage {
+				goCovPath, err := utils.SetCoveragePath(c.logger, c.cfg.Test.CoverageReportPath)
+				if err != nil {
+					utils.LogError(c.logger, err, "failed to set go coverage path")
+					return errors.New("failed to set go coverage path")
+				}
+				c.cfg.Test.CoverageReportPath = goCovPath
+			}
+
 			if c.cfg.Test.Delay <= 5 {
 				c.logger.Warn(fmt.Sprintf("Delay is set to %d seconds, incase your app takes more time to start use --delay to set custom delay", c.cfg.Test.Delay))
 				if c.cfg.InDocker {

--- a/cli/test.go
+++ b/cli/test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"os"
 
 	"go.keploy.io/server/v2/pkg/graph"
 	"go.keploy.io/server/v2/utils"
@@ -41,6 +42,15 @@ func Test(ctx context.Context, logger *zap.Logger, cfg *config.Config, serviceFa
 				err := g.Serve(ctx)
 				if err != nil {
 					utils.LogError(logger, err, "failed to start graph service")
+					return nil
+				}
+			}
+
+			cmdType := utils.FindDockerCmd(cfg.Command)
+			if cmdType == utils.Native && cfg.Test.GoCoverage {
+				err := os.Setenv("GOCOVERDIR", cfg.Test.CoverageReportPath)
+				if err != nil {
+					utils.LogError(logger, err, "failed to set GOCOVERDIR")
 					return nil
 				}
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,9 @@
 // Package config provides configuration structures for the application.
 package config
 
-import "time"
+import (
+	"time"
+)
 
 type Config struct {
 	Path                  string        `json:"path" yaml:"path" mapstructure:"path" `
@@ -23,6 +25,7 @@ type Config struct {
 	GenerateGithubActions bool          `json:"generateGithubActions" yaml:"generateGithubActions" mapstructure:"generateGithubActions"`
 	KeployContainer       string        `json:"keployContainer" yaml:"keployContainer" mapstructure:"keployContainer"`
 	KeployNetwork         string        `json:"keployNetwork" yaml:"keployNetwork" mapstructure:"keployNetwork"`
+	CommandType           string        `json:"cmdType" yaml:"cmdType" mapstructure:"cmdType"`
 }
 
 type Record struct {

--- a/config/default.go
+++ b/config/default.go
@@ -55,6 +55,7 @@ enableTesting: false
 keployContainer: "keploy-v2"
 keployNetwork: "keploy-network"
 inDocker: false
+cmdType: "native"
 `
 
 var config = &Config{}

--- a/pkg/core/proxy/integrations/http/decode.go
+++ b/pkg/core/proxy/integrations/http/decode.go
@@ -109,6 +109,7 @@ func decodeHTTP(ctx context.Context, logger *zap.Logger, reqBuf []byte, clientCo
 					errCh <- err
 					return
 				}
+				continue
 			}
 
 			statusLine := fmt.Sprintf("HTTP/%d.%d %d %s\r\n", stub.Spec.HTTPReq.ProtoMajor, stub.Spec.HTTPReq.ProtoMinor, stub.Spec.HTTPResp.StatusCode, http.StatusText(stub.Spec.HTTPResp.StatusCode))

--- a/pkg/core/proxy/integrations/http/decode.go
+++ b/pkg/core/proxy/integrations/http/decode.go
@@ -109,7 +109,8 @@ func decodeHTTP(ctx context.Context, logger *zap.Logger, reqBuf []byte, clientCo
 					errCh <- err
 					return
 				}
-				continue
+				errCh <- nil
+				return
 			}
 
 			statusLine := fmt.Sprintf("HTTP/%d.%d %d %s\r\n", stub.Spec.HTTPReq.ProtoMajor, stub.Spec.HTTPReq.ProtoMinor, stub.Spec.HTTPResp.StatusCode, http.StatusText(stub.Spec.HTTPResp.StatusCode))

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -633,8 +633,10 @@ func (r *Replayer) printSummary(ctx context.Context, testRunResult bool) {
 			return
 		}
 		r.logger.Info("test run completed", zap.Bool("passed overall", testRunResult))
-		if r.config.Test.GoCoverage {
-			r.logger.Info("there is a opportunity to get the coverage here")
+
+		if utils.CmdType(r.config.CommandType) == utils.Native && r.config.Test.GoCoverage {
+			r.logger.Info("there is an opportunity to get the coverage here")
+
 			coverCmd := exec.CommandContext(ctx, "go", "tool", "covdata", "percent", "-i="+os.Getenv("GOCOVERDIR"))
 			output, err := coverCmd.Output()
 			if err != nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -513,11 +513,12 @@ func GetAbsPath(path string) (string, error) {
 // makeDirectory creates a directory if not exists with all user access
 func makeDirectory(path string) error {
 	oldUmask := syscall.Umask(0)
+	defer syscall.Umask(oldUmask)
 	err := os.MkdirAll(path, 0777)
 	if err != nil {
 		return err
 	}
-	syscall.Umask(oldUmask)
+
 	return nil
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -518,7 +518,6 @@ func makeDirectory(path string) error {
 	if err != nil {
 		return err
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
## Related Issue
  - go coverage not working without setting `GOCOVERDIR` explicitly.

Closes: https://github.com/keploy/keploy/issues/1813

#### Describe the changes you've made
- Set `GOCOVERDIR` implicitly if `goCoverage` is enabled.
- Handle custom path for coverage reports

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
`NA`

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |