### PR TITLE
fix: closing of keploy due to panic in any parser

### DIFF
--- a/pkg/core/proxy/integrations/generic/decode.go
+++ b/pkg/core/proxy/integrations/generic/decode.go
@@ -20,7 +20,7 @@ func decodeGeneric(ctx context.Context, logger *zap.Logger, reqBuf []byte, clien
 	logger.Debug("Into the generic parser in test mode")
 	errCh := make(chan error, 1)
 	go func(errCh chan error, genericRequests [][]byte) {
-		defer utils.RecoverFromParser(logger, clientConn, nil)
+		defer pUtil.Recover(logger, clientConn, nil)
 		defer close(errCh)
 		for {
 			// Since protocol packets have to be parsed for checking stream end,

--- a/pkg/core/proxy/integrations/generic/decode.go
+++ b/pkg/core/proxy/integrations/generic/decode.go
@@ -20,7 +20,7 @@ func decodeGeneric(ctx context.Context, logger *zap.Logger, reqBuf []byte, clien
 	logger.Debug("Into the generic parser in test mode")
 	errCh := make(chan error, 1)
 	go func(errCh chan error, genericRequests [][]byte) {
-		defer utils.Recover(logger)
+		defer utils.RecoverFromParser(logger, clientConn, nil)
 		defer close(errCh)
 		for {
 			// Since protocol packets have to be parsed for checking stream end,

--- a/pkg/core/proxy/integrations/generic/encode.go
+++ b/pkg/core/proxy/integrations/generic/encode.go
@@ -61,14 +61,14 @@ func encodeGeneric(ctx context.Context, logger *zap.Logger, reqBuf []byte, clien
 
 	// read requests from client
 	g.Go(func() error {
-		defer utils.Recover(logger)
+		defer utils.RecoverFromParser(logger, clientConn, nil)
 		defer close(clientBuffChan)
 		pUtil.ReadBuffConn(ctx, logger, clientConn, clientBuffChan, errChan)
 		return nil
 	})
 	// read responses from destination
 	g.Go(func() error {
-		defer utils.Recover(logger)
+		defer utils.RecoverFromParser(logger, nil, destConn)
 		defer close(destBuffChan)
 		pUtil.ReadBuffConn(ctx, logger, destConn, destBuffChan, errChan)
 		return nil

--- a/pkg/core/proxy/integrations/generic/encode.go
+++ b/pkg/core/proxy/integrations/generic/encode.go
@@ -61,14 +61,14 @@ func encodeGeneric(ctx context.Context, logger *zap.Logger, reqBuf []byte, clien
 
 	// read requests from client
 	g.Go(func() error {
-		defer utils.RecoverFromParser(logger, clientConn, nil)
+		defer pUtil.Recover(logger, clientConn, nil)
 		defer close(clientBuffChan)
 		pUtil.ReadBuffConn(ctx, logger, clientConn, clientBuffChan, errChan)
 		return nil
 	})
 	// read responses from destination
 	g.Go(func() error {
-		defer utils.RecoverFromParser(logger, nil, destConn)
+		defer pUtil.Recover(logger, nil, destConn)
 		defer close(destBuffChan)
 		pUtil.ReadBuffConn(ctx, logger, destConn, destBuffChan, errChan)
 		return nil

--- a/pkg/core/proxy/integrations/grpc/encode.go
+++ b/pkg/core/proxy/integrations/grpc/encode.go
@@ -2,12 +2,13 @@ package grpc
 
 import (
 	"context"
+	"io"
+	"net"
+
 	"go.keploy.io/server/v2/pkg/models"
 	"go.keploy.io/server/v2/utils"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
-	"io"
-	"net"
 )
 
 func encodeGrpc(ctx context.Context, logger *zap.Logger, reqBuf []byte, clientConn, destConn net.Conn, mocks chan<- *models.Mock, _ models.OutgoingOptions) error {
@@ -35,7 +36,7 @@ func encodeGrpc(ctx context.Context, logger *zap.Logger, reqBuf []byte, clientCo
 
 	// Route requests from the client to the server.
 	g.Go(func() error {
-		defer utils.Recover(logger)
+		defer utils.RecoverFromParser(logger, clientConn, destConn)
 		err := transferFrame(ctx, destConn, clientConn, streamInfoCollection, reqFromClient, serverSideDecoder, mocks)
 		if err != nil {
 			// check for EOF error
@@ -55,7 +56,7 @@ func encodeGrpc(ctx context.Context, logger *zap.Logger, reqBuf []byte, clientCo
 	// Route response from the server to the client.
 	clientSideDecoder := NewDecoder()
 	g.Go(func() error {
-		defer utils.Recover(logger)
+		defer utils.RecoverFromParser(logger, clientConn, destConn)
 		err := transferFrame(ctx, clientConn, destConn, streamInfoCollection, !reqFromClient, clientSideDecoder, mocks)
 		if err != nil {
 			utils.LogError(logger, err, "failed to transfer frame from server to client")

--- a/pkg/core/proxy/integrations/grpc/encode.go
+++ b/pkg/core/proxy/integrations/grpc/encode.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 
+	pUtil "go.keploy.io/server/v2/pkg/core/proxy/util"
 	"go.keploy.io/server/v2/pkg/models"
 	"go.keploy.io/server/v2/utils"
 	"go.uber.org/zap"
@@ -36,7 +37,7 @@ func encodeGrpc(ctx context.Context, logger *zap.Logger, reqBuf []byte, clientCo
 
 	// Route requests from the client to the server.
 	g.Go(func() error {
-		defer utils.RecoverFromParser(logger, clientConn, destConn)
+		defer pUtil.Recover(logger, clientConn, destConn)
 		err := transferFrame(ctx, destConn, clientConn, streamInfoCollection, reqFromClient, serverSideDecoder, mocks)
 		if err != nil {
 			// check for EOF error
@@ -56,7 +57,7 @@ func encodeGrpc(ctx context.Context, logger *zap.Logger, reqBuf []byte, clientCo
 	// Route response from the server to the client.
 	clientSideDecoder := NewDecoder()
 	g.Go(func() error {
-		defer utils.RecoverFromParser(logger, clientConn, destConn)
+		defer pUtil.Recover(logger, clientConn, destConn)
 		err := transferFrame(ctx, clientConn, destConn, streamInfoCollection, !reqFromClient, clientSideDecoder, mocks)
 		if err != nil {
 			utils.LogError(logger, err, "failed to transfer frame from server to client")

--- a/pkg/core/proxy/integrations/http/decode.go
+++ b/pkg/core/proxy/integrations/http/decode.go
@@ -31,6 +31,7 @@ func decodeHTTP(ctx context.Context, logger *zap.Logger, reqBuf []byte, clientCo
 	errCh := make(chan error, 1)
 
 	go func(errCh chan error, reqBuf []byte, opts models.OutgoingOptions) {
+		defer utils.RecoverFromParser(logger, clientConn, nil)
 		defer close(errCh)
 		for {
 			//Check if the expected header is present
@@ -109,6 +110,8 @@ func decodeHTTP(ctx context.Context, logger *zap.Logger, reqBuf []byte, clientCo
 					errCh <- err
 					return
 				}
+				errCh <- nil
+				return
 			}
 
 			statusLine := fmt.Sprintf("HTTP/%d.%d %d %s\r\n", stub.Spec.HTTPReq.ProtoMajor, stub.Spec.HTTPReq.ProtoMinor, stub.Spec.HTTPResp.StatusCode, http.StatusText(stub.Spec.HTTPResp.StatusCode))

--- a/pkg/core/proxy/integrations/http/decode.go
+++ b/pkg/core/proxy/integrations/http/decode.go
@@ -14,7 +14,7 @@ import (
 
 	"go.keploy.io/server/v2/pkg"
 	"go.keploy.io/server/v2/pkg/core/proxy/integrations"
-	"go.keploy.io/server/v2/pkg/core/proxy/util"
+	pUtil "go.keploy.io/server/v2/pkg/core/proxy/util"
 	"go.keploy.io/server/v2/pkg/models"
 	"go.keploy.io/server/v2/utils"
 	"go.uber.org/zap"
@@ -31,7 +31,7 @@ func decodeHTTP(ctx context.Context, logger *zap.Logger, reqBuf []byte, clientCo
 	errCh := make(chan error, 1)
 
 	go func(errCh chan error, reqBuf []byte, opts models.OutgoingOptions) {
-		defer utils.RecoverFromParser(logger, clientConn, nil)
+		defer pUtil.Recover(logger, clientConn, nil)
 		defer close(errCh)
 		for {
 			//Check if the expected header is present
@@ -49,7 +49,7 @@ func decodeHTTP(ctx context.Context, logger *zap.Logger, reqBuf []byte, clientCo
 				}
 				logger.Debug("The 100 continue response has been sent to the user application")
 				//Read the request buffer again
-				newRequest, err := util.ReadBytes(ctx, logger, clientConn)
+				newRequest, err := pUtil.ReadBytes(ctx, logger, clientConn)
 				if err != nil {
 					utils.LogError(logger, err, "failed to read the request buffer from the user application")
 					errCh <- err
@@ -104,7 +104,7 @@ func decodeHTTP(ctx context.Context, logger *zap.Logger, reqBuf []byte, clientCo
 					utils.LogError(logger, nil, "Didn't match any preExisting http mock", zap.Any("metadata", getReqMeta(request)))
 				}
 
-				_, err = util.PassThrough(ctx, logger, clientConn, dstCfg, [][]byte{reqBuf})
+				_, err = pUtil.PassThrough(ctx, logger, clientConn, dstCfg, [][]byte{reqBuf})
 				if err != nil {
 					utils.LogError(logger, err, "failed to passThrough http request", zap.Any("metadata", getReqMeta(request)))
 					errCh <- err
@@ -171,7 +171,7 @@ func decodeHTTP(ctx context.Context, logger *zap.Logger, reqBuf []byte, clientCo
 				return
 			}
 
-			reqBuf, err = util.ReadBytes(ctx, logger, clientConn)
+			reqBuf, err = pUtil.ReadBytes(ctx, logger, clientConn)
 			if err != nil {
 				logger.Debug("failed to read the request buffer from the client", zap.Error(err))
 				logger.Debug("This was the last response from the server:\n" + string(responseString))

--- a/pkg/core/proxy/integrations/http/encode.go
+++ b/pkg/core/proxy/integrations/http/encode.go
@@ -48,7 +48,7 @@ func encodeHTTP(ctx context.Context, logger *zap.Logger, reqBuf []byte, clientCo
 
 	//for keeping conn alive
 	g.Go(func() error {
-		defer utils.Recover(logger)
+		defer utils.RecoverFromParser(logger, clientConn, destConn)
 		defer close(errCh)
 		for {
 			//check if expect : 100-continue header is present

--- a/pkg/core/proxy/integrations/http/encode.go
+++ b/pkg/core/proxy/integrations/http/encode.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"go.keploy.io/server/v2/pkg/core/proxy/util"
+	pUtil "go.keploy.io/server/v2/pkg/core/proxy/util"
 	"go.keploy.io/server/v2/pkg/models"
 	"go.keploy.io/server/v2/utils"
 	"go.uber.org/zap"
@@ -48,7 +49,7 @@ func encodeHTTP(ctx context.Context, logger *zap.Logger, reqBuf []byte, clientCo
 
 	//for keeping conn alive
 	g.Go(func() error {
-		defer utils.RecoverFromParser(logger, clientConn, destConn)
+		defer pUtil.Recover(logger, clientConn, destConn)
 		defer close(errCh)
 		for {
 			//check if expect : 100-continue header is present

--- a/pkg/core/proxy/integrations/mongo/decode.go
+++ b/pkg/core/proxy/integrations/mongo/decode.go
@@ -25,7 +25,7 @@ func decodeMongo(ctx context.Context, logger *zap.Logger, reqBuf []byte, clientC
 	errCh := make(chan error, 1)
 
 	go func(errCh chan error, reqBuf []byte, startedDecoding time.Time, requestBuffers [][]byte) {
-		defer utils.Recover(logger)
+		defer utils.RecoverFromParser(logger, clientConn, nil)
 		defer close(errCh)
 		var readRequestDelay time.Duration
 		for {

--- a/pkg/core/proxy/integrations/mongo/decode.go
+++ b/pkg/core/proxy/integrations/mongo/decode.go
@@ -25,7 +25,7 @@ func decodeMongo(ctx context.Context, logger *zap.Logger, reqBuf []byte, clientC
 	errCh := make(chan error, 1)
 
 	go func(errCh chan error, reqBuf []byte, startedDecoding time.Time, requestBuffers [][]byte) {
-		defer utils.RecoverFromParser(logger, clientConn, nil)
+		defer util.Recover(logger, clientConn, nil)
 		defer close(errCh)
 		var readRequestDelay time.Duration
 		for {

--- a/pkg/core/proxy/integrations/mongo/encode.go
+++ b/pkg/core/proxy/integrations/mongo/encode.go
@@ -10,7 +10,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	"go.keploy.io/server/v2/pkg/core/proxy/util"
+	pUtil "go.keploy.io/server/v2/pkg/core/proxy/util"
 	"go.keploy.io/server/v2/pkg/models"
 	"go.keploy.io/server/v2/utils"
 	"go.uber.org/zap"
@@ -27,7 +27,7 @@ func (m *Mongo) encodeMongo(ctx context.Context, logger *zap.Logger, reqBuf []by
 	}
 
 	g.Go(func() error {
-		defer utils.RecoverFromParser(logger, clientConn, destConn)
+		defer pUtil.Recover(logger, clientConn, destConn)
 		defer close(errCh)
 		for {
 			var err error
@@ -38,7 +38,7 @@ func (m *Mongo) encodeMongo(ctx context.Context, logger *zap.Logger, reqBuf []by
 			if string(reqBuf) == "read form client conn" {
 				// lstr := ""
 				started := time.Now()
-				reqBuf, err = util.ReadBytes(ctx, logger, clientConn)
+				reqBuf, err = pUtil.ReadBytes(ctx, logger, clientConn)
 				logger.Debug("reading from the mongo conn", zap.Any("", string(reqBuf)))
 				if err != nil {
 					if err == io.EOF {
@@ -85,7 +85,7 @@ func (m *Mongo) encodeMongo(ctx context.Context, logger *zap.Logger, reqBuf []by
 			// logStr += fmt.Sprintln("after writing the request to the destination: ", time.Since(started))
 			if val, ok := mongoRequest.(*models.MongoOpMessage); ok && hasSecondSetBit(val.FlagBits) {
 				for {
-					requestBuffer1, err := util.ReadBytes(ctx, logger, clientConn)
+					requestBuffer1, err := pUtil.ReadBytes(ctx, logger, clientConn)
 
 					// logStr += tmpStr
 					if err != nil {
@@ -138,7 +138,7 @@ func (m *Mongo) encodeMongo(ctx context.Context, logger *zap.Logger, reqBuf []by
 			// tmpStr := ""
 			reqTimestampMock := time.Now()
 			started := time.Now()
-			responsePckLengthBuffer, err := util.ReadRequiredBytes(ctx, logger, destConn, 4)
+			responsePckLengthBuffer, err := pUtil.ReadRequiredBytes(ctx, logger, destConn, 4)
 			if err != nil {
 				if err == io.EOF {
 					logger.Debug("recieved response buffer is empty in record mode for mongo call")
@@ -155,7 +155,7 @@ func (m *Mongo) encodeMongo(ctx context.Context, logger *zap.Logger, reqBuf []by
 			pckLength := getPacketLength(responsePckLengthBuffer)
 			logger.Debug("received pck length ", zap.Any("packet length", pckLength))
 
-			responsePckDataBuffer, err := util.ReadRequiredBytes(ctx, logger, destConn, int(pckLength)-4)
+			responsePckDataBuffer, err := pUtil.ReadRequiredBytes(ctx, logger, destConn, int(pckLength)-4)
 
 			logger.Debug("recieved these packets", zap.Any("packets", responsePckDataBuffer))
 
@@ -204,7 +204,7 @@ func (m *Mongo) encodeMongo(ctx context.Context, logger *zap.Logger, reqBuf []by
 						m.recordMessage(ctx, logger, mongoRequests, mongoResponses, opReq, reqTimestampMock, mocks)
 					}
 					started = time.Now()
-					responseBuffer, err = util.ReadBytes(ctx, logger, destConn)
+					responseBuffer, err = pUtil.ReadBytes(ctx, logger, destConn)
 					// logStr += tmpStr
 					if err != nil {
 						if err == io.EOF {

--- a/pkg/core/proxy/integrations/mongo/encode.go
+++ b/pkg/core/proxy/integrations/mongo/encode.go
@@ -27,7 +27,7 @@ func (m *Mongo) encodeMongo(ctx context.Context, logger *zap.Logger, reqBuf []by
 	}
 
 	g.Go(func() error {
-		defer utils.Recover(logger)
+		defer utils.RecoverFromParser(logger, clientConn, destConn)
 		defer close(errCh)
 		for {
 			var err error

--- a/pkg/core/proxy/integrations/mysql/decode.go
+++ b/pkg/core/proxy/integrations/mysql/decode.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"go.keploy.io/server/v2/pkg/core/proxy/integrations"
-	"go.keploy.io/server/v2/pkg/core/proxy/util"
+	pUtil "go.keploy.io/server/v2/pkg/core/proxy/util"
 	"go.keploy.io/server/v2/pkg/models"
 	"go.keploy.io/server/v2/utils"
 	"go.uber.org/zap"
@@ -33,7 +33,7 @@ func decodeMySQL(ctx context.Context, logger *zap.Logger, clientConn net.Conn, d
 	errCh := make(chan error, 1)
 
 	go func(errCh chan error, configMocks []*models.Mock, tcsMocks []*models.Mock, prevRequest string, requestBuffers [][]byte) {
-		defer utils.RecoverFromParser(logger, clientConn, nil)
+		defer pUtil.Recover(logger, clientConn, nil)
 		defer close(errCh)
 		for {
 			//log.Debug("Config and TCS Mocks", zap.Any("configMocks", configMocks), zap.Any("tcsMocks", tcsMocks))
@@ -98,7 +98,7 @@ func decodeMySQL(ctx context.Context, logger *zap.Logger, clientConn net.Conn, d
 				}
 
 				// Attempt to read from the client
-				requestBuffer, err := util.ReadBytes(ctx, logger, clientConn)
+				requestBuffer, err := pUtil.ReadBytes(ctx, logger, clientConn)
 				if err != nil {
 					if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
 						// Timeout occurred, no data received from client
@@ -178,7 +178,7 @@ func decodeMySQL(ctx context.Context, logger *zap.Logger, clientConn net.Conn, d
 				if matchedIndex == -1 {
 					logger.Debug("No matching mock found")
 
-					responseBuffer, err := util.PassThrough(ctx, logger, clientConn, dstCfg, requestBuffers)
+					responseBuffer, err := pUtil.PassThrough(ctx, logger, clientConn, dstCfg, requestBuffers)
 					if err != nil {
 						utils.LogError(logger, err, "Failed to passthrough the mysql request to the actual database server")
 						errCh <- err

--- a/pkg/core/proxy/integrations/mysql/decode.go
+++ b/pkg/core/proxy/integrations/mysql/decode.go
@@ -33,7 +33,7 @@ func decodeMySQL(ctx context.Context, logger *zap.Logger, clientConn net.Conn, d
 	errCh := make(chan error, 1)
 
 	go func(errCh chan error, configMocks []*models.Mock, tcsMocks []*models.Mock, prevRequest string, requestBuffers [][]byte) {
-		defer utils.Recover(logger)
+		defer utils.RecoverFromParser(logger, clientConn, nil)
 		defer close(errCh)
 		for {
 			//log.Debug("Config and TCS Mocks", zap.Any("configMocks", configMocks), zap.Any("tcsMocks", tcsMocks))

--- a/pkg/core/proxy/integrations/mysql/encode.go
+++ b/pkg/core/proxy/integrations/mysql/encode.go
@@ -3,9 +3,10 @@ package mysql
 import (
 	"context"
 	"errors"
-	"golang.org/x/sync/errgroup"
 	"net"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"go.keploy.io/server/v2/pkg/core/proxy/util"
 	"go.keploy.io/server/v2/pkg/models"
@@ -30,7 +31,7 @@ func encodeMySQL(ctx context.Context, logger *zap.Logger, clientConn, destConn n
 
 	//for keeping conn alive
 	g.Go(func() error {
-		defer utils.Recover(logger)
+		defer utils.RecoverFromParser(logger, clientConn, destConn)
 		defer close(errCh)
 		for {
 			lastCommand = 0x00 //resetting last command for new loop

--- a/pkg/core/proxy/integrations/mysql/encode.go
+++ b/pkg/core/proxy/integrations/mysql/encode.go
@@ -8,7 +8,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	"go.keploy.io/server/v2/pkg/core/proxy/util"
+	pUtil "go.keploy.io/server/v2/pkg/core/proxy/util"
 	"go.keploy.io/server/v2/pkg/models"
 	"go.keploy.io/server/v2/utils"
 	"go.uber.org/zap"
@@ -31,7 +31,7 @@ func encodeMySQL(ctx context.Context, logger *zap.Logger, clientConn, destConn n
 
 	//for keeping conn alive
 	g.Go(func() error {
-		defer utils.RecoverFromParser(logger, clientConn, destConn)
+		defer pUtil.Recover(logger, clientConn, destConn)
 		defer close(errCh)
 		for {
 			lastCommand = 0x00 //resetting last command for new loop
@@ -55,7 +55,7 @@ func encodeMySQL(ctx context.Context, logger *zap.Logger, clientConn, destConn n
 					errCh <- err
 					return nil
 				}
-				handshakeResponseFromClient, err := util.ReadBytes(ctx, logger, clientConn)
+				handshakeResponseFromClient, err := pUtil.ReadBytes(ctx, logger, clientConn)
 				if err != nil {
 					utils.LogError(logger, err, "failed to read handshake response from client")
 					errCh <- err
@@ -72,7 +72,7 @@ func encodeMySQL(ctx context.Context, logger *zap.Logger, clientConn, destConn n
 				}
 				//TODO: why is this sleep here?
 				time.Sleep(100 * time.Millisecond)
-				okPacket1, err := util.ReadBytes(ctx, logger, destConn)
+				okPacket1, err := pUtil.ReadBytes(ctx, logger, destConn)
 				if err != nil {
 					utils.LogError(logger, err, "failed to read packet from server after handshake")
 					errCh <- err
@@ -133,7 +133,7 @@ func encodeMySQL(ctx context.Context, logger *zap.Logger, clientConn, destConn n
 				})
 				if oprResponse2 == "AUTH_SWITCH_REQUEST" {
 
-					authSwitchResponse, err := util.ReadBytes(ctx, logger, clientConn)
+					authSwitchResponse, err := pUtil.ReadBytes(ctx, logger, clientConn)
 					if err != nil {
 						utils.LogError(logger, err, "failed to read AuthSwitchResponse from client")
 						errCh <- err
@@ -148,7 +148,7 @@ func encodeMySQL(ctx context.Context, logger *zap.Logger, clientConn, destConn n
 						errCh <- err
 						return nil
 					}
-					serverResponse, err := util.ReadBytes(ctx, logger, destConn)
+					serverResponse, err := pUtil.ReadBytes(ctx, logger, destConn)
 					if err != nil {
 						utils.LogError(logger, err, "failed to read response from server")
 						errCh <- err
@@ -204,7 +204,7 @@ func encodeMySQL(ctx context.Context, logger *zap.Logger, clientConn, destConn n
 					}
 					if pluginType == "cachingSha2PasswordPerformFullAuthentication" {
 
-						clientResponse, err := util.ReadBytes(ctx, logger, clientConn)
+						clientResponse, err := pUtil.ReadBytes(ctx, logger, clientConn)
 						if err != nil {
 							utils.LogError(logger, err, "failed to read response from client")
 							errCh <- err
@@ -219,7 +219,7 @@ func encodeMySQL(ctx context.Context, logger *zap.Logger, clientConn, destConn n
 							errCh <- err
 							return nil
 						}
-						finalServerResponse, err := util.ReadBytes(ctx, logger, destConn)
+						finalServerResponse, err := pUtil.ReadBytes(ctx, logger, destConn)
 						if err != nil {
 							utils.LogError(logger, err, "failed to read final response from server")
 							errCh <- err
@@ -264,7 +264,7 @@ func encodeMySQL(ctx context.Context, logger *zap.Logger, clientConn, destConn n
 							},
 							Message: mysqlRespFinal,
 						})
-						clientResponse1, err := util.ReadBytes(ctx, logger, clientConn)
+						clientResponse1, err := pUtil.ReadBytes(ctx, logger, clientConn)
 						if err != nil {
 							utils.LogError(logger, err, "failed to read response from client")
 							errCh <- err
@@ -279,7 +279,7 @@ func encodeMySQL(ctx context.Context, logger *zap.Logger, clientConn, destConn n
 							errCh <- err
 							return nil
 						}
-						finalServerResponse1, err := util.ReadBytes(ctx, logger, destConn)
+						finalServerResponse1, err := pUtil.ReadBytes(ctx, logger, destConn)
 						if err != nil {
 							utils.LogError(logger, err, "failed to read final response from server")
 							errCh <- err
@@ -329,7 +329,7 @@ func encodeMySQL(ctx context.Context, logger *zap.Logger, clientConn, destConn n
 						})
 					} else {
 						// time.Sleep(10 * time.Millisecond)
-						finalServerResponse, err := util.ReadBytes(ctx, logger, destConn)
+						finalServerResponse, err := pUtil.ReadBytes(ctx, logger, destConn)
 						if err != nil {
 							utils.LogError(logger, err, "failed to read final response from server")
 							errCh <- err
@@ -370,7 +370,7 @@ func encodeMySQL(ctx context.Context, logger *zap.Logger, clientConn, destConn n
 				}
 				if pluginType == "cachingSha2PasswordPerformFullAuthentication" {
 
-					clientResponse, err := util.ReadBytes(ctx, logger, clientConn)
+					clientResponse, err := pUtil.ReadBytes(ctx, logger, clientConn)
 					if err != nil {
 						utils.LogError(logger, err, "failed to read response from client")
 						errCh <- err
@@ -385,7 +385,7 @@ func encodeMySQL(ctx context.Context, logger *zap.Logger, clientConn, destConn n
 						errCh <- err
 						return nil
 					}
-					finalServerResponse, err := util.ReadBytes(ctx, logger, destConn)
+					finalServerResponse, err := pUtil.ReadBytes(ctx, logger, destConn)
 					if err != nil {
 						utils.LogError(logger, err, "failed to read final response from server")
 						errCh <- err
@@ -430,7 +430,7 @@ func encodeMySQL(ctx context.Context, logger *zap.Logger, clientConn, destConn n
 						},
 						Message: mysqlRespFinal,
 					})
-					clientResponse1, err := util.ReadBytes(ctx, logger, clientConn)
+					clientResponse1, err := pUtil.ReadBytes(ctx, logger, clientConn)
 					if err != nil {
 						utils.LogError(logger, err, "failed to read response from client")
 						errCh <- err
@@ -445,7 +445,7 @@ func encodeMySQL(ctx context.Context, logger *zap.Logger, clientConn, destConn n
 						errCh <- err
 						return nil
 					}
-					finalServerResponse1, err := util.ReadBytes(ctx, logger, destConn)
+					finalServerResponse1, err := pUtil.ReadBytes(ctx, logger, destConn)
 					if err != nil {
 						utils.LogError(logger, err, "failed to read final response from server")
 						errCh <- err
@@ -542,7 +542,7 @@ func handleClientQueries(ctx context.Context, logger *zap.Logger, initialBuffer 
 				queryBuffer = initialBuffer
 				firstIteration = false
 			} else {
-				queryBuffer, err = util.ReadBytes(ctx, logger, clientConn)
+				queryBuffer, err = pUtil.ReadBytes(ctx, logger, clientConn)
 				if err != nil {
 					utils.LogError(logger, err, "failed to read query from the mysql client")
 					return err
@@ -575,7 +575,7 @@ func handleClientQueries(ctx context.Context, logger *zap.Logger, initialBuffer 
 			if res == 9 {
 				return nil
 			}
-			queryResponse, err := util.ReadBytes(ctx, logger, destConn)
+			queryResponse, err := pUtil.ReadBytes(ctx, logger, destConn)
 			if err != nil {
 				utils.LogError(logger, err, "failed to read query response from mysql server")
 				return err

--- a/pkg/core/proxy/integrations/postgres/v1/decode.go
+++ b/pkg/core/proxy/integrations/postgres/v1/decode.go
@@ -22,6 +22,7 @@ func decodePostgres(ctx context.Context, logger *zap.Logger, reqBuf []byte, clie
 	errCh := make(chan error, 1)
 
 	go func(errCh chan error, pgRequests [][]byte) {
+		defer utils.RecoverFromParser(logger, clientConn, nil)
 		// close should be called from the producer of the channel
 		defer close(errCh)
 		for {

--- a/pkg/core/proxy/integrations/postgres/v1/decode.go
+++ b/pkg/core/proxy/integrations/postgres/v1/decode.go
@@ -22,7 +22,7 @@ func decodePostgres(ctx context.Context, logger *zap.Logger, reqBuf []byte, clie
 	errCh := make(chan error, 1)
 
 	go func(errCh chan error, pgRequests [][]byte) {
-		defer utils.RecoverFromParser(logger, clientConn, nil)
+		defer pUtil.Recover(logger, clientConn, nil)
 		// close should be called from the producer of the channel
 		defer close(errCh)
 		for {

--- a/pkg/core/proxy/integrations/postgres/v1/encode.go
+++ b/pkg/core/proxy/integrations/postgres/v1/encode.go
@@ -81,7 +81,7 @@ func encodePostgres(ctx context.Context, logger *zap.Logger, reqBuf []byte, clie
 
 	// read requests from client
 	g.Go(func() error {
-		defer utils.Recover(logger)
+		defer utils.RecoverFromParser(logger, clientConn, destConn)
 		defer close(clientBuffChan)
 		pUtil.ReadBuffConn(ctx, logger, clientConn, clientBuffChan, errChan)
 		return nil
@@ -89,13 +89,14 @@ func encodePostgres(ctx context.Context, logger *zap.Logger, reqBuf []byte, clie
 
 	// read responses from destination
 	g.Go(func() error {
-		defer utils.Recover(logger)
+		defer utils.RecoverFromParser(logger, clientConn, destConn)
 		defer close(destBuffChan)
 		pUtil.ReadBuffConn(ctx, logger, destConn, destBuffChan, errChan)
 		return nil
 	})
 
 	go func() {
+		defer utils.RecoverFromParser(logger, clientConn, destConn)
 		err := g.Wait()
 		if err != nil {
 			logger.Info("error group is returning an error", zap.Error(err))

--- a/pkg/core/proxy/integrations/postgres/v1/encode.go
+++ b/pkg/core/proxy/integrations/postgres/v1/encode.go
@@ -81,7 +81,7 @@ func encodePostgres(ctx context.Context, logger *zap.Logger, reqBuf []byte, clie
 
 	// read requests from client
 	g.Go(func() error {
-		defer utils.RecoverFromParser(logger, clientConn, destConn)
+		defer pUtil.Recover(logger, clientConn, destConn)
 		defer close(clientBuffChan)
 		pUtil.ReadBuffConn(ctx, logger, clientConn, clientBuffChan, errChan)
 		return nil
@@ -89,14 +89,14 @@ func encodePostgres(ctx context.Context, logger *zap.Logger, reqBuf []byte, clie
 
 	// read responses from destination
 	g.Go(func() error {
-		defer utils.RecoverFromParser(logger, clientConn, destConn)
+		defer pUtil.Recover(logger, clientConn, destConn)
 		defer close(destBuffChan)
 		pUtil.ReadBuffConn(ctx, logger, destConn, destBuffChan, errChan)
 		return nil
 	})
 
 	go func() {
-		defer utils.RecoverFromParser(logger, clientConn, destConn)
+		defer pUtil.Recover(logger, clientConn, destConn)
 		err := g.Wait()
 		if err != nil {
 			logger.Info("error group is returning an error", zap.Error(err))

--- a/pkg/core/proxy/proxy.go
+++ b/pkg/core/proxy/proxy.go
@@ -246,7 +246,7 @@ func (p *Proxy) start(ctx context.Context) error {
 		// handle the client connection
 		case clientConn := <-clientConnCh:
 			clientConnErrGrp.Go(func() error {
-				defer utils.RecoverFromParser(p.logger, clientConn, nil)
+				defer util.Recover(p.logger, clientConn, nil)
 				err := p.handleConnection(clientConnCtx, clientConn)
 				if err != nil && err != io.EOF {
 					utils.LogError(p.logger, err, "failed to handle the client connection")

--- a/pkg/core/proxy/proxy.go
+++ b/pkg/core/proxy/proxy.go
@@ -101,7 +101,7 @@ func (p *Proxy) StartProxy(ctx context.Context, opts core.ProxyOptions) error {
 
 	// start the proxy server
 	g.Go(func() error {
-		utils.Recover(p.logger)
+		defer utils.Recover(p.logger)
 		err := p.start(ctx)
 		if err != nil {
 			utils.LogError(p.logger, err, "error while running the proxy server")
@@ -122,9 +122,10 @@ func (p *Proxy) StartProxy(ctx context.Context, opts core.ProxyOptions) error {
 	// start the TCP DNS server
 	p.logger.Debug("Starting Tcp Dns Server for handling Dns queries over TCP")
 	g.Go(func() error {
-		utils.Recover(p.logger)
+		defer utils.Recover(p.logger)
 		errCh := make(chan error, 1)
 		go func(errCh chan error) {
+			defer utils.Recover(p.logger)
 			err := p.startTCPDNSServer(ctx)
 			if err != nil {
 				errCh <- err
@@ -147,9 +148,10 @@ func (p *Proxy) StartProxy(ctx context.Context, opts core.ProxyOptions) error {
 	// start the UDP DNS server
 	p.logger.Debug("Starting Udp Dns Server for handling Dns queries over UDP")
 	g.Go(func() error {
-		utils.Recover(p.logger)
+		defer utils.Recover(p.logger)
 		errCh := make(chan error, 1)
 		go func(errCh chan error) {
+			defer utils.Recover(p.logger)
 			err := p.startUDPDNSServer(ctx)
 			if err != nil {
 				errCh <- err
@@ -223,6 +225,7 @@ func (p *Proxy) start(ctx context.Context) error {
 		clientConnCh := make(chan net.Conn, 1)
 		errCh := make(chan error, 1)
 		go func() {
+			defer utils.Recover(p.logger)
 			conn, err := listener.Accept()
 			if err != nil {
 				if strings.Contains(err.Error(), "use of closed network connection") {
@@ -243,7 +246,7 @@ func (p *Proxy) start(ctx context.Context) error {
 		// handle the client connection
 		case clientConn := <-clientConnCh:
 			clientConnErrGrp.Go(func() error {
-				defer utils.Recover(p.logger)
+				defer utils.RecoverFromParser(p.logger, clientConn, nil)
 				err := p.handleConnection(clientConnCtx, clientConn)
 				if err != nil && err != io.EOF {
 					utils.LogError(p.logger, err, "failed to handle the client connection")
@@ -318,7 +321,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 
 		err := srcConn.Close()
 		if err != nil {
-			utils.LogError(p.logger, err, "failed to close the source connection")
+			utils.LogError(p.logger, err, "failed to close the source connection", zap.Any("clientConnID", clientConnID))
 			return
 		}
 

--- a/pkg/core/proxy/util/util.go
+++ b/pkg/core/proxy/util/util.go
@@ -113,7 +113,7 @@ func ReadBytes(ctx context.Context, logger *zap.Logger, reader io.Reader) ([]byt
 	for {
 		// Start a goroutine to perform the read operation
 		g.Go(func() error {
-			defer utils.Recover(logger)
+			defer utils.RecoverFromParser(logger, nil, nil)
 			buf := make([]byte, 1024)
 			n, err := reader.Read(buf)
 			if ctx.Err() != nil {
@@ -182,7 +182,7 @@ func ReadRequiredBytes(ctx context.Context, logger *zap.Logger, reader io.Reader
 	for numBytes > 0 {
 		// Start a goroutine to perform the read operation
 		g.Go(func() error {
-			defer utils.Recover(logger)
+			defer utils.RecoverFromParser(logger, nil, nil)
 			buf := make([]byte, numBytes)
 			n, err := reader.Read(buf)
 			if ctx.Err() != nil {
@@ -249,12 +249,10 @@ func PassThrough(ctx context.Context, logger *zap.Logger, clientConn net.Conn, d
 
 	// channels for writing messages from proxy to destination or client
 	destBufferChannel := make(chan []byte)
-	errChannel := make(chan error)
-	//TODO:Should I even close this error channel here?
-	defer close(errChannel)
+	errChannel := make(chan error, 1)
 
 	go func() {
-		defer utils.Recover(logger)
+		defer utils.RecoverFromParser(logger, clientConn, nil)
 		defer close(destBufferChannel)
 		defer close(errChannel)
 		defer func(destConn net.Conn) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -239,8 +239,8 @@ func attachLogFileToSentry(logger *zap.Logger, logFilePath string) error {
 	return nil
 }
 
-// handleRecovery handles the common logic for recovering from a panic.
-func handleRecovery(logger *zap.Logger, r interface{}, errMsg string) {
+// HandleRecovery handles the common logic for recovering from a panic.
+func HandleRecovery(logger *zap.Logger, r interface{}, errMsg string) {
 	err := attachLogFileToSentry(logger, "./keploy-logs.txt")
 	if err != nil {
 		LogError(logger, err, "failed to attach log file to sentry")
@@ -260,49 +260,12 @@ func Recover(logger *zap.Logger) {
 	}
 	sentry.Flush(2 * time.Second)
 	if r := recover(); r != nil {
-		handleRecovery(logger, r, "Recovered from panic")
+		HandleRecovery(logger, r, "Recovered from panic")
 		err := Stop(logger, fmt.Sprintf("Recovered from: %s", r))
 		if err != nil {
 			LogError(logger, err, "failed to stop the global context")
 		}
 		sentry.Flush(2 * time.Second)
-	}
-}
-
-// RecoverFromParser recovers from a panic and logs the stack trace to Sentry.
-// It also closes the client and destination connection.
-func RecoverFromParser(logger *zap.Logger, client, dest net.Conn) {
-	if logger == nil {
-		fmt.Println(Emoji + "Failed to recover from panic. Logger is nil.")
-		return
-	}
-
-	sentry.Flush(2 * time.Second)
-	if r := recover(); r != nil {
-		logger.Error("Recovered from panic in parser, closing active connections")
-		if client != nil {
-			err := client.Close()
-			if err != nil {
-				// Use string matching as a last resort to check for the specific error
-				if !strings.Contains(err.Error(), "use of closed network connection") {
-					// Log other errors
-					LogError(logger, err, "failed to close the client connection")
-				}
-			}
-		}
-
-		if dest != nil {
-			err := dest.Close()
-			if err != nil {
-				// Use string matching as a last resort to check for the specific error
-				if !strings.Contains(err.Error(), "use of closed network connection") {
-					// Log other errors
-					LogError(logger, err, "failed to close the destination connection")
-				}
-			}
-		}
-		handleRecovery(logger, r, "Recovered from panic")
-		sentry.Flush(time.Second * 2)
 	}
 }
 


### PR DESCRIPTION
## Related Issue
  - Closing of keploy due to panic in parser

Closes: #1815 

#### Describe the changes you've made
- Added another Recover function to recover from parser and only close the active client and dest connection and return without canceling the global context.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
`NA`

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |