### PR TITLE
feat: add support for async http matching

### DIFF
--- a/pkg/core/proxy/integrations/http/decode.go
+++ b/pkg/core/proxy/integrations/http/decode.go
@@ -21,10 +21,9 @@ import (
 )
 
 type matchParams struct {
-	req           *http.Request
-	reqBodyIsJSON bool
-	reqBody       []byte
-	reqBuf        []byte
+	req     *http.Request
+	reqBody []byte
+	reqBuf  []byte
 }
 
 // Decodes the mocks in test mode so that they can be sent to the user application.
@@ -88,10 +87,9 @@ func decodeHTTP(ctx context.Context, logger *zap.Logger, reqBuf []byte, clientCo
 			//check if reqBuf body is a json
 
 			param := &matchParams{
-				req:           request,
-				reqBodyIsJSON: isJSON(reqBody),
-				reqBody:       reqBody,
-				reqBuf:        reqBuf,
+				req:     request,
+				reqBody: reqBody,
+				reqBuf:  reqBuf,
 			}
 			ok, stub, err := match(ctx, logger, param, mockDb)
 			if err != nil {

--- a/pkg/core/proxy/integrations/http/decode.go
+++ b/pkg/core/proxy/integrations/http/decode.go
@@ -20,12 +20,6 @@ import (
 	"go.uber.org/zap"
 )
 
-type matchParams struct {
-	req     *http.Request
-	reqBody []byte
-	reqBuf  []byte
-}
-
 // Decodes the mocks in test mode so that they can be sent to the user application.
 func decodeHTTP(ctx context.Context, logger *zap.Logger, reqBuf []byte, clientConn net.Conn, dstCfg *integrations.ConditionalDstCfg, mockDb integrations.MockMemDb, opts models.OutgoingOptions) error {
 	errCh := make(chan error, 1)
@@ -84,14 +78,14 @@ func decodeHTTP(ctx context.Context, logger *zap.Logger, reqBuf []byte, clientCo
 				return
 			}
 
-			//check if reqBuf body is a json
-
-			param := &matchParams{
-				req:     request,
-				reqBody: reqBody,
-				reqBuf:  reqBuf,
+			input := &req{
+				method: request.Method,
+				url:    request.URL,
+				header: request.Header,
+				body:   reqBody,
+				raw:    reqBuf,
 			}
-			ok, stub, err := match(ctx, logger, param, mockDb)
+			ok, stub, err := match(ctx, logger, input, mockDb)
 			if err != nil {
 				utils.LogError(logger, err, "error while matching http mocks", zap.Any("metadata", getReqMeta(request)))
 				errCh <- err

--- a/pkg/core/proxy/integrations/http/match.go
+++ b/pkg/core/proxy/integrations/http/match.go
@@ -32,12 +32,7 @@ func match(ctx context.Context, logger *zap.Logger, matchParams *matchParams, mo
 				return false, nil, errors.New("error while matching the request with the mocks")
 			}
 
-			logger.Info(fmt.Sprintf("Length of unfilteredMocks:%v", len(unfilteredMocks)))
-			for i, mock := range unfilteredMocks {
-				if mock.Kind == models.HTTP {
-					fmt.Printf("unfilteredMocks-%v:%v\n", i, mock.Spec.HTTPReq)
-				}
-			}
+			logger.Debug(fmt.Sprintf("Length of unfilteredMocks:%v", len(unfilteredMocks)))
 
 			var eligibleMocks []*models.Mock
 

--- a/pkg/core/proxy/integrations/http/match.go
+++ b/pkg/core/proxy/integrations/http/match.go
@@ -19,164 +19,168 @@ import (
 	"go.uber.org/zap"
 )
 
-func match(ctx context.Context, logger *zap.Logger, matchParams *matchParams, mockDb integrations.MockMemDb) (bool, *models.Mock, error) {
-	for {
-		select {
-		case <-ctx.Done():
-			return false, nil, ctx.Err()
-		default:
-			unfilteredMocks, err := mockDb.GetUnFilteredMocks()
+type req struct {
+	method string
+	url    *url.URL
+	header http.Header
+	body   []byte
+	raw    []byte
+}
 
-			if err != nil {
-				utils.LogError(logger, err, "failed to get unfilteredMocks mocks")
-				return false, nil, errors.New("error while matching the request with the mocks")
+func match(ctx context.Context, logger *zap.Logger, input *req, mockDb integrations.MockMemDb) (bool, *models.Mock, error) {
+	for {
+		if ctx.Err() != nil {
+			return false, nil, ctx.Err()
+		}
+
+		mocks, err := mockDb.GetUnFilteredMocks()
+
+		if err != nil {
+			utils.LogError(logger, err, "failed to get unfilteredMocks mocks")
+			return false, nil, errors.New("error while matching the request with the mocks")
+		}
+
+		logger.Debug(fmt.Sprintf("Length of unfilteredMocks:%v", len(mocks)))
+
+		var schemaMatched []*models.Mock
+
+		for _, mock := range mocks {
+			if ctx.Err() != nil {
+				return false, nil, ctx.Err()
+			}
+			if mock.Kind != models.HTTP {
+				continue
 			}
 
-			logger.Debug(fmt.Sprintf("Length of unfilteredMocks:%v", len(unfilteredMocks)))
+			//if the content type is present in http request then we need to check for the same type in the mock
+			if input.header.Get("Content-Type") != "" {
+				if input.header.Get("Content-Type") != mock.Spec.HTTPReq.Header["Content-Type"] {
+					logger.Debug("The content type of mock and request aren't the same")
+					continue
+				}
+			}
 
-			var eligibleMocks []*models.Mock
+			// check the type of the body if content type is not present
+			if !matchBodyType(mock.Spec.HTTPReq.Body, input.body) {
+				logger.Debug("The body of mock and request aren't of same type")
+				continue
+			}
 
-			for _, mock := range unfilteredMocks {
+			//parse request body url
+			parsedURL, err := url.Parse(mock.Spec.HTTPReq.URL)
+			if err != nil {
+				utils.LogError(logger, err, "failed to parse mock url")
+				continue
+			}
+
+			//Check if the path matches
+			if parsedURL.Path != input.url.Path {
+				//If it is not the same, continue
+				logger.Debug("The url path of mock and request aren't the same")
+				continue
+			}
+
+			//Check if the method matches
+			if mock.Spec.HTTPReq.Method != models.Method(input.method) {
+				//If it is not the same, continue
+				logger.Debug("The method of mock and request aren't the same")
+				continue
+			}
+
+			// Check if the header keys match
+			if !mapsHaveSameKeys(mock.Spec.HTTPReq.Header, input.header) {
+				// Different headers, so not a match
+				logger.Debug("The header keys of mock and request aren't the same")
+				continue
+			}
+
+			if !mapsHaveSameKeys(mock.Spec.HTTPReq.URLParams, input.url.Query()) {
+				// Different query params, so not a match
+				logger.Debug("The query params of mock and request aren't the same")
+				continue
+			}
+			schemaMatched = append(schemaMatched, mock)
+		}
+
+		if len(schemaMatched) == 0 {
+			// basic schema is not matched with any mock hence returning false
+			return false, nil, nil
+		}
+
+		// do exact body match
+		ok, bestMatch := exactBodyMatch(input.body, schemaMatched)
+		if ok {
+			if !updateMock(ctx, logger, bestMatch, mockDb) {
+				continue
+			}
+			return true, bestMatch, nil
+		}
+
+		shortlisted := schemaMatched
+		// If the body is JSON we do a schema match. we can add more custom type matching
+		if isJSON(input.body) {
+			var bodyMatched []*models.Mock
+
+			logger.Debug("Performing schema match for body")
+			for _, mock := range schemaMatched {
 				if ctx.Err() != nil {
 					return false, nil, ctx.Err()
 				}
-				if mock.Kind == models.HTTP {
 
-					//if the content type is present in http request then we need to check for the same type in the mock
-					if matchParams.req.Header.Get("Content-Type") != "" {
-						if matchParams.req.Header.Get("Content-Type") != mock.Spec.HTTPReq.Header["Content-Type"] {
-							logger.Debug("The content type of mock and request aren't the same")
-							continue
-						}
-					}
-
-					// check the type of the body if content type is not present
-					if !matchBodyType(mock.Spec.HTTPReq.Body, matchParams.reqBody) {
-						logger.Debug("The body of mock and request aren't of same type")
-						continue
-					}
-
-					//parse request body url
-					parsedURL, err := url.Parse(mock.Spec.HTTPReq.URL)
-					if err != nil {
-						utils.LogError(logger, err, "failed to parse mock url")
-						continue
-					}
-
-					//Check if the path matches
-					if parsedURL.Path != matchParams.req.URL.Path {
-						//If it is not the same, continue
-						logger.Debug("The url path of mock and request aren't the same")
-						continue
-					}
-
-					//Check if the method matches
-					if mock.Spec.HTTPReq.Method != models.Method(matchParams.req.Method) {
-						//If it is not the same, continue
-						logger.Debug("The method of mock and request aren't the same")
-						continue
-					}
-
-					// Check if the header keys match
-					if !mapsHaveSameKeys(mock.Spec.HTTPReq.Header, matchParams.req.Header) {
-						// Different headers, so not a match
-						logger.Debug("The header keys of mock and request aren't the same")
-						continue
-					}
-
-					if !mapsHaveSameKeys(mock.Spec.HTTPReq.URLParams, matchParams.req.URL.Query()) {
-						// Different query params, so not a match
-						logger.Debug("The query params of mock and request aren't the same")
-						continue
-					}
-					eligibleMocks = append(eligibleMocks, mock)
+				ok, err := bodyMatch(logger, []byte(mock.Spec.HTTPReq.Body), input.body)
+				if err != nil {
+					logger.Error("failed to do schema matching on request body", zap.Error(err))
+					break
 				}
-			}
 
-			if len(eligibleMocks) == 0 {
-				// basic schema is not matched with any mock hence returning false
-				return false, nil, nil
-			}
-
-			// If the request body is empty, we can return the first eligible mock
-			if string(matchParams.reqBody) == "" {
-				ok, bestMatch := getEmptyBodyMock(eligibleMocks)
 				if ok {
-					if !handleMatch(ctx, logger, bestMatch, mockDb) {
-						continue
-					}
-					return true, bestMatch, nil
+					bodyMatched = append(bodyMatched, mock)
+					logger.Debug("found a mock with body schema match")
 				}
+			}
 
-				logger.Debug("couldn't find any mock with empty body")
+			if len(bodyMatched) == 0 {
+				logger.Debug("couldn't find any mock with body schema match")
 				return false, nil, nil
 			}
 
-			// If the body is JSON we do a schema match. we can add more custom type matching
-			if isJSON(matchParams.reqBody) {
-				var homogeneousMocks []*models.Mock
-
-				logger.Debug("Performing schema match for body")
-				for _, mock := range eligibleMocks {
-					if ctx.Err() != nil {
-						return false, nil, ctx.Err()
-					}
-
-					ok, err := schemaMatch(logger, []byte(mock.Spec.HTTPReq.Body), matchParams.reqBody)
-					if err != nil {
-						logger.Error("failed to do schema matching on request body", zap.Error(err))
-						break
-					}
-
-					if ok {
-						homogeneousMocks = append(homogeneousMocks, mock)
-						logger.Debug("found a mock with body schema match")
-					}
-				}
-
-				if len(homogeneousMocks) == 0 {
-					logger.Debug("couldn't find any mock with body schema match")
-					return false, nil, nil
-				}
-
-				//if we have only one schema matched mock, we return it
-				if len(homogeneousMocks) == 1 {
-					if !handleMatch(ctx, logger, homogeneousMocks[0], mockDb) {
-						continue
-					}
-					return true, homogeneousMocks[0], nil
-				}
-
-				//if more than one schema matched mocks are present, we perform fuzzy match on rest of the mocks
-				eligibleMocks = homogeneousMocks
-			}
-
-			// we should perform fuzzy match if body type is not JSON
-			// or if we have more than one json schema matched mocks. (useful in case of async http requests)
-			logger.Debug("Performing fuzzy match for req buffer")
-			isMatched, bestMatch := fuzzyMatch(eligibleMocks, matchParams.reqBuf)
-			if isMatched {
-				if !handleMatch(ctx, logger, bestMatch, mockDb) {
+			//if we have only one schema matched mock, we return it
+			if len(bodyMatched) == 1 {
+				if !updateMock(ctx, logger, bodyMatched[0], mockDb) {
 					continue
 				}
-				return true, bestMatch, nil
+				return true, bodyMatched[0], nil
 			}
-			return false, nil, nil
+
+			//if more than one schema matched mocks are present, we perform fuzzy match on rest of the mocks
+			shortlisted = bodyMatched
 		}
+
+		// we should perform fuzzy match if body type is not JSON
+		// or if we have more than one json schema matched mocks. (useful in case of async http requests)
+		logger.Debug("Performing fuzzy match for req buffer")
+		isMatched, bestMatch := fuzzyMatch(shortlisted, input.raw)
+		if isMatched {
+			if !updateMock(ctx, logger, bestMatch, mockDb) {
+				continue
+			}
+			return true, bestMatch, nil
+		}
+		return false, nil, nil
 	}
 
 }
 
-func getEmptyBodyMock(eligibleMocks []*models.Mock) (bool, *models.Mock) {
-	for _, mock := range eligibleMocks {
-		if mock.Spec.HTTPReq.Body == "" {
+func exactBodyMatch(body []byte, schemaMatched []*models.Mock) (bool, *models.Mock) {
+	for _, mock := range schemaMatched {
+		if mock.Spec.HTTPReq.Body == string(body) {
 			return true, mock
 		}
 	}
 	return false, nil
 }
 
-func schemaMatch(logger *zap.Logger, mockBody, reqBody []byte) (bool, error) {
+func bodyMatch(logger *zap.Logger, mockBody, reqBody []byte) (bool, error) {
 
 	var mockData map[string]interface{}
 	var reqData map[string]interface{}
@@ -364,8 +368,8 @@ func isCSV(data []byte) bool {
 	return false
 }
 
-// handleMatch processes the matched mock based on its filtered status.
-func handleMatch(_ context.Context, logger *zap.Logger, matchedMock *models.Mock, mockDb integrations.MockMemDb) bool {
+// updateMock processes the matched mock based on its filtered status.
+func updateMock(_ context.Context, logger *zap.Logger, matchedMock *models.Mock, mockDb integrations.MockMemDb) bool {
 	if matchedMock.TestModeInfo.IsFiltered {
 		originalMatchedMock := *matchedMock
 		matchedMock.TestModeInfo.IsFiltered = false

--- a/pkg/core/proxy/integrations/postgres/v1/match.go
+++ b/pkg/core/proxy/integrations/postgres/v1/match.go
@@ -262,6 +262,7 @@ func matchingReadablePG(ctx context.Context, logger *zap.Logger, requestBuffers 
 					originalMatchedMock := *matchedMock
 					matchedMock.TestModeInfo.IsFiltered = false
 					matchedMock.TestModeInfo.SortOrder = math.MaxInt
+					//UpdateUnFilteredMock also marks the mock as used
 					updated := mockDb.UpdateUnFilteredMock(&originalMatchedMock, matchedMock)
 					if !updated {
 						continue

--- a/pkg/platform/yaml/mockdb/db.go
+++ b/pkg/platform/yaml/mockdb/db.go
@@ -182,7 +182,16 @@ func (ys *MockYaml) GetFilteredMocks(ctx context.Context, testSetID string, afte
 		}
 
 		for _, mock := range mocks {
-			if mock.Spec.Metadata["type"] != "config" && mock.Kind != "Generic" && mock.Kind != "Postgres" {
+			isFilteredMock := true
+			switch mock.Kind {
+			case "Generic":
+				isFilteredMock = false
+			case "Postgres":
+				isFilteredMock = false
+			case "Http":
+				isFilteredMock = false
+			}
+			if mock.Spec.Metadata["type"] != "config" && isFilteredMock {
 				tcsMocks = append(tcsMocks, mock)
 			}
 		}
@@ -238,7 +247,16 @@ func (ys *MockYaml) GetUnFilteredMocks(ctx context.Context, testSetID string, af
 			return nil, err
 		}
 		for _, mock := range mocks {
-			if mock.Spec.Metadata["type"] == "config" || mock.Kind == "Postgres" || mock.Kind == "Generic" {
+			isUnFilteredMock := false
+			switch mock.Kind {
+			case "Generic":
+				isUnFilteredMock = true
+			case "Postgres":
+				isUnFilteredMock = true
+			case "Http":
+				isUnFilteredMock = true
+			}
+			if mock.Spec.Metadata["type"] == "config" || isUnFilteredMock {
 				configMocks = append(configMocks, mock)
 			}
 		}


### PR DESCRIPTION
## Related Issue
  - Async matching was not supported in http.

Closes: #1831 

#### Describe the changes you've made
- Made all the HTTP mocks unfiltered mocks and also changed the implementation of current HTTP matching which was not robust earlier.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
`NA`

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |