### PR TITLE
fix: add keploy-test-id header to noisy field in abs match

### DIFF
--- a/pkg/service/replay/absmatch.go
+++ b/pkg/service/replay/absmatch.go
@@ -157,6 +157,7 @@ func CompareHTTPReq(tcs1, tcs2 *models.TestCase, _ models.GlobalNoise, ignoreOrd
 	}
 
 	reqHeaderNoise := map[string][]string{}
+	reqHeaderNoise["Keploy-Test-Id"] = []string{}
 
 	// compare http req headers
 	ok := CompareHeaders(pkg.ToHTTPHeader(tcs1.HTTPReq.Header), pkg.ToHTTPHeader(tcs2.HTTPReq.Header), &reqCompare.HeaderResult, reqHeaderNoise)
@@ -422,6 +423,7 @@ func CompareCurl(curl1, curl2 string, logger *zap.Logger) bool {
 	}
 
 	curlHeaderNoise := map[string][]string{}
+	curlHeaderNoise["Keploy-Test-Id"] = []string{}
 
 	hres := []models.HeaderResult{}
 	ok := CompareHeaders(pkg.ToHTTPHeader(headers1), pkg.ToHTTPHeader(headers2), &hres, curlHeaderNoise)

--- a/pkg/service/replay/absmatch.go
+++ b/pkg/service/replay/absmatch.go
@@ -47,11 +47,10 @@ func AbsMatch(tcs1, tcs2 *models.TestCase, noiseConfig map[string]map[string][]s
 		pass = false
 	}
 
-	//compare name
+	//compare name (just for debugging)
 	if tcs1.Name != tcs2.Name {
 		nameResult.Normal = false
 		logger.Debug("test case name is not equal", zap.Any("tcs1Name", tcs1.Name), zap.Any("tcs2Name", tcs2.Name))
-		pass = false
 	}
 
 	//compare curl
@@ -76,6 +75,7 @@ func AbsMatch(tcs1, tcs2 *models.TestCase, noiseConfig map[string]map[string][]s
 		pass = false
 	}
 
+	absResult.Name = nameResult
 	absResult.Kind = kindResult
 	absResult.Req = reqCompare
 	absResult.Resp = respCompare


### PR DESCRIPTION
## Related Issue
  - The test bench broke due to this parameter.

Closes: #[issue number that will be closed through this PR]

#### Describe the changes you've made
- Add `Keploy-Test-Id` to header noisy in abs match.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
`NA`

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |