### PR TITLE
fix: fix typo in cli/mock.go

### DIFF
--- a/cli/mock.go
+++ b/cli/mock.go
@@ -19,7 +19,7 @@ func init() {
 func Mock(ctx context.Context, logger *zap.Logger, _ *config.Config, serviceFactory ServiceFactory, cmdConfigurator CmdConfigurator) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:     "mock",
-		Short:   "Record and replay ougoung network traffic for the user application",
+		Short:   "Record and replay outgoing network traffic for the user application",
 		Example: `keploy mock -c "/path/to/user/app" --delay 10`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			record, err := cmd.Flags().GetBool("record")


### PR DESCRIPTION
## Related Issue
NA

Closes: NA

#### Describe the changes you've made
Fixed a typo (ougoung -> outgoing) in the one-liner of the `mock` command which is displayed on keploy cli's help message.

## Type of change
Typo

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added
NA

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
NA

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |
![image](https://github.com/keploy/keploy/assets/27297702/bc21e82b-43b2-4f28-a1b9-f2bbae31e7ee)
