### PR TITLE
Globalnoise

### DIFF
--- a/pkg/platform/yaml/testdb/util.go
+++ b/pkg/platform/yaml/testdb/util.go
@@ -246,9 +246,10 @@ func Decode(yamlTestcase *yaml.NetworkTrafficDoc, logger *zap.Logger) (*models.T
 		switch reflect.ValueOf(httpSpec.Assertions["noise"]).Kind() {
 		case reflect.Map:
 			for k, v := range httpSpec.Assertions["noise"].(map[string]interface{}) {
-				tc.Noise[k] = []string{}
+				l := strings.ToLower(k)
+				tc.Noise[l] = []string{}
 				for _, val := range v.([]interface{}) {
-					tc.Noise[k] = append(tc.Noise[k], val.(string))
+					tc.Noise[l] = append(tc.Noise[l], val.(string))
 				}
 			}
 		case reflect.Slice:

--- a/pkg/service/replay/match.go
+++ b/pkg/service/replay/match.go
@@ -336,7 +336,7 @@ func matchJSONWithNoiseHandling(key string, expected, actual interface{}, noiseM
 			if !ok {
 				return matchJSONComparisonResult, nil
 			}
-			if valueMatchJSONComparisonResult, er := matchJSONWithNoiseHandling(prefix+k, v, val, noiseMap, ignoreOrdering); !valueMatchJSONComparisonResult.matches || er != nil {
+			if valueMatchJSONComparisonResult, er := matchJSONWithNoiseHandling(strings.ToLower(prefix+k), v, val, noiseMap, ignoreOrdering); !valueMatchJSONComparisonResult.matches || er != nil {
 				return valueMatchJSONComparisonResult, nil
 			} else if !valueMatchJSONComparisonResult.isExact {
 				isExact = false
@@ -344,7 +344,8 @@ func matchJSONWithNoiseHandling(key string, expected, actual interface{}, noiseM
 				differences = append(differences, valueMatchJSONComparisonResult.differences...)
 			}
 			// remove the noisy key from both expected and actual JSON.
-			if _, ok := CheckStringExist(prefix+k, noiseMap); ok {
+			// Viper bindings are case insensitive, so we need convert the key to lowercase.
+			if _, ok := CheckStringExist(strings.ToLower(prefix+k), noiseMap); ok {
 				delete(copiedExpMap, prefix+k)
 				delete(copiedActMap, k)
 				continue
@@ -778,7 +779,7 @@ func CompareHeaders(h1 http.Header, h2 http.Header, res *[]models.HeaderResult, 
 	match := true
 	_, isHeaderNoisy := noise["header"]
 	for k, v := range h1 {
-		regexArr, isNoisy := CheckStringExist(k, noise)
+		regexArr, isNoisy := CheckStringExist(strings.ToLower(k), noise)
 		if isNoisy && len(regexArr) != 0 {
 			isNoisy, _ = MatchesAnyRegex(v[0], regexArr)
 		}
@@ -855,7 +856,7 @@ func CompareHeaders(h1 http.Header, h2 http.Header, res *[]models.HeaderResult, 
 		}
 	}
 	for k, v := range h2 {
-		regexArr, isNoisy := CheckStringExist(k, noise)
+		regexArr, isNoisy := CheckStringExist(strings.ToLower(k), noise)
 		if isNoisy && len(regexArr) != 0 {
 			isNoisy, _ = MatchesAnyRegex(v[0], regexArr)
 		}

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -21,12 +21,25 @@ type TestReportVerdict struct {
 
 func LeftJoinNoise(globalNoise config.GlobalNoise, tsNoise config.GlobalNoise) config.GlobalNoise {
 	noise := globalNoise
-	for field, regexArr := range tsNoise["body"] {
-		noise["body"][field] = regexArr
+
+	if _, ok := noise["body"]; !ok {
+		noise["body"] = make(map[string][]string)
 	}
-	for field, regexArr := range tsNoise["header"] {
-		noise["header"][field] = regexArr
+	if tsNoiseBody, ok := tsNoise["body"]; ok {
+		for field, regexArr := range tsNoiseBody {
+			noise["body"][field] = regexArr
+		}
 	}
+
+	if _, ok := noise["header"]; !ok {
+		noise["header"] = make(map[string][]string)
+	}
+	if tsNoiseHeader, ok := tsNoise["header"]; ok {
+		for field, regexArr := range tsNoiseHeader {
+			noise["header"][field] = regexArr
+		}
+	}
+
 	return noise
 }
 


### PR DESCRIPTION
## Related Issue
  - [Global Noise failing due to case insensitive viper bindings](https://github.com/keploy/keploy/issues/1724)

Closes: #[1724](https://github.com/keploy/keploy/issues/1724)

#### Describe the changes you've made
Used lower case during comparison for body and header keys

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
NA

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **![Screenshot_20240508_110651](https://github.com/keploy/keploy/assets/73810056/bc94a581-4de1-4556-a740-dcb0b985aa10)** | <b>
![Screenshot_20240508_110531](https://github.com/keploy/keploy/assets/73810056/6401db33-1d46-4248-9fa9-bf0b1fe2cdf3)
 </b> |

![image](https://github.com/keploy/keploy/assets/73810056/9868530d-f644-4abc-84e9-7d93f6727429)
