### PR TITLE
fix: log warning in case of ca failures

### DIFF
--- a/pkg/core/proxy/proxy.go
+++ b/pkg/core/proxy/proxy.go
@@ -91,8 +91,8 @@ func (p *Proxy) StartProxy(ctx context.Context, opts core.ProxyOptions) error {
 	// set up the CA for tls connections
 	err = SetupCA(ctx, p.logger)
 	if err != nil {
-		utils.LogError(p.logger, err, "failed to setup CA")
-		return err
+		// log the error and continue
+		p.logger.Warn("failed to setup CA", zap.Error(err))
 	}
 	g, ok := ctx.Value(models.ErrGroupKey).(*errgroup.Group)
 	if !ok {


### PR DESCRIPTION
Log warning in case of error if the CA injection fails so that rest of the code could work. 

eg: 

```
keploy test                             

       ▓██▓▄
    ▓▓▓▓██▓█▓▄
     ████████▓▒
          ▀▓▓███▄      ▄▄   ▄               ▌
         ▄▌▌▓▓████▄    ██ ▓█▀  ▄▌▀▄  ▓▓▌▄   ▓█  ▄▌▓▓▌▄ ▌▌   ▓
       ▓█████████▌▓▓   ██▓█▄  ▓█▄▓▓ ▐█▌  ██ ▓█  █▌  ██  █▌ █▓
      ▓▓▓▓▀▀▀▀▓▓▓▓▓▓▌  ██  █▓  ▓▌▄▄ ▐█▓▄▓█▀ █▓█ ▀█▄▄█▀   █▓█
       ▓▌                           ▐█▌                   █▌
        ▓
  
version: 2.1.0-alpha18

🐰 Keploy: 2024-05-26T12:05:10+05:30    WARN    Delay is set to 5 seconds, incase your app takes more time to start use --delay to set custom delay
🐰 Keploy: 2024-05-26T12:05:10+05:30    INFO    Example usage: keploy test -c "/path/to/user/app" --delay 6
🐰 Keploy: 2024-05-26T12:05:10+05:30    INFO    GitHub Actions workflow file generated successfully     {"path": "/githubactions/keploy.yml"}
🐰 Keploy: 2024-05-26T12:05:11+05:30    INFO    keploy initialized and probes added to the kernel.
🐰 Keploy: 2024-05-26T12:05:12+05:30    ERROR   Java detected but failed to import CA   {"output": "Warning: use -cacerts option to access cacerts keystore\nkeytool error: java.io.EOFException\n", "error": "exit status 1"}
🐰 Keploy: 2024-05-26T12:05:12+05:30    ERROR   Failed to install CA in the java keystore       {"error": "exit status 1"}
🐰 Keploy: 2024-05-26T12:05:12+05:30    ERROR   failed to setup CA      {"error": "exit status 1"}
🐰 Keploy: 2024-05-26T12:05:12+05:30    ERROR   failed to start proxy   {"error": "exit status 1"}
🐰 Keploy: 2024-05-26T12:05:12+05:30    ERROR   failed to boot replay: failed to start the hooks and proxy: failed to hook into the app      {"error": "failed to start the hooks and proxy: failed to hook into the app"}
🐰 Keploy: 2024-05-26T12:05:12+05:30    INFO    stopping Keploy {"reason": "failed to boot replay: failed to start the hooks and proxy: failed to hook into the app"}
🐰 Keploy: 2024-05-26T12:05:13+05:30    INFO    eBPF resources released successfully...
🐰 Keploy: 2024-05-26T12:05:13+05:30    ERROR   failed to replay        {"error": "failed to boot replay: failed to start the hooks and proxy: failed to hook into the app"} 
```