### PR TITLE
Fix/race cond

### DIFF
--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -72,7 +72,6 @@ func (r *Recorder) Start(ctx context.Context) error {
 	defer func() {
 		select {
 		case <-ctx.Done():
-			r.telemetry.RecordedTestSuite(newTestSetID, testCount, mockCountMap)
 		default:
 			err := utils.Stop(r.logger, stopReason)
 			if err != nil {
@@ -93,6 +92,7 @@ func (r *Recorder) Start(ctx context.Context) error {
 		if err != nil {
 			utils.LogError(r.logger, err, "failed to stop recording")
 		}
+		r.telemetry.RecordedTestSuite(newTestSetID, testCount, mockCountMap)
 	}()
 
 	defer close(appErrChan)


### PR DESCRIPTION
## Related Issue
  - Race condition with testCount while exiting keploy record

Closes: #1851

#### Describe the changes you've made
Moved `r.telemetry.RecordTestSuite(newTestSetID, testCount, mockCountMap)` so that every context is done and testSuite is recorded. As a result, the race condition is prevented. Thanks @gouravkrosx and @slayerjain for their support on #1867.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

No additional tests. Only the build procedure at #1851

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)

NA

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |