### PR TITLE
chore: check for file type for finding indices

### DIFF
--- a/pkg/platform/yaml/yaml.go
+++ b/pkg/platform/yaml/yaml.go
@@ -172,7 +172,7 @@ func ReadSessionIndices(_ context.Context, path string, Logger *zap.Logger) ([]s
 	}
 
 	for _, v := range files {
-		if v.Name() != "reports" && v.Name() != "testReports" {
+		if v.Name() != "reports" && v.Name() != "testReports" && v.IsDir() {
 			indices = append(indices, v.Name())
 		}
 	}


### PR DESCRIPTION
## Related Issue
  - Read only dirs while calculating indices.

Closes: https://github.com/keploy/keploy/issues/1917

#### Describe the changes you've made
While calculating indices we must just check for the folder types.