### PR TITLE
feat: add support for global passthrough in test mode

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -190,7 +190,6 @@ func (c *CmdConfigurator) AddFlags(cmd *cobra.Command) error {
 		}
 	case "record", "test":
 		cmd.Flags().String("configPath", ".", "Path to the local directory where keploy configuration file is stored")
-		cmd.Flags().StringP("rerecord", "r", c.cfg.ReRecord, "Rerecord the testcases/mocks for the given testset(s)")
 		cmd.Flags().StringP("path", "p", ".", "Path to local directory where generated testcases/mocks are stored")
 		cmd.Flags().Uint32("port", c.cfg.Port, "GraphQL server port used for executing testcases in unit test library integration")
 		cmd.Flags().Uint32("proxyPort", c.cfg.ProxyPort, "Port used by the Keploy proxy server to intercept the outgoing dependency calls")
@@ -221,8 +220,10 @@ func (c *CmdConfigurator) AddFlags(cmd *cobra.Command) error {
 			cmd.Flags().Bool("removeUnusedMocks", c.cfg.Test.RemoveUnusedMocks, "Clear the unused mocks for the passed test-sets")
 			cmd.Flags().Bool("goCoverage", c.cfg.Test.GoCoverage, "Enable go coverage reporting for the testcases")
 			cmd.Flags().Bool("fallBackOnMiss", c.cfg.Test.FallBackOnMiss, "Enable connecting to actual service if mock not found during test mode")
+			cmd.Flags().Bool("globalPassthrough", c.cfg.Test.GlobalPassthrough, "Enable global passthrough for all the outgoing calls")
 		} else {
 			cmd.Flags().Uint64("recordTimer", 0, "User provided time to record its application")
+			cmd.Flags().StringP("rerecord", "r", c.cfg.Record.ReRecord, "Rerecord the testcases/mocks for the given testset(s)")
 		}
 	case "keploy":
 		cmd.PersistentFlags().Bool("debug", c.cfg.Debug, "Run in debug mode")

--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -220,7 +220,7 @@ func (c *CmdConfigurator) AddFlags(cmd *cobra.Command) error {
 			cmd.Flags().Bool("removeUnusedMocks", c.cfg.Test.RemoveUnusedMocks, "Clear the unused mocks for the passed test-sets")
 			cmd.Flags().Bool("goCoverage", c.cfg.Test.GoCoverage, "Enable go coverage reporting for the testcases")
 			cmd.Flags().Bool("fallBackOnMiss", c.cfg.Test.FallBackOnMiss, "Enable connecting to actual service if mock not found during test mode")
-			cmd.Flags().Bool("globalPassthrough", c.cfg.Test.GlobalPassthrough, "Enable global passthrough for all the outgoing calls")
+			cmd.Flags().Bool("mocking", true, "enable/disable mocking for the testcases")
 		} else {
 			cmd.Flags().Uint64("recordTimer", 0, "User provided time to record its application")
 			cmd.Flags().StringP("rerecord", "r", c.cfg.Record.ReRecord, "Rerecord the testcases/mocks for the given testset(s)")

--- a/config/config.go
+++ b/config/config.go
@@ -69,7 +69,7 @@ type Test struct {
 	Language           string              `json:"language" yaml:"language" mapstructure:"language"`
 	RemoveUnusedMocks  bool                `json:"removeUnusedMocks" yaml:"removeUnusedMocks" mapstructure:"removeUnusedMocks"`
 	FallBackOnMiss     bool                `json:"fallBackOnMiss" yaml:"fallBackOnMiss" mapstructure:"fallBackOnMiss"`
-	GlobalPassthrough  bool                `json:"globalPassthrough" yaml:"globalPassthrough" mapstructure:"globalPassthrough"`
+	Mocking            bool                `json:"mocking" yaml:"mocking" mapstructure:"mocking"`
 }
 
 type Globalnoise struct {

--- a/config/config.go
+++ b/config/config.go
@@ -10,7 +10,6 @@ import (
 type Config struct {
 	Path                  string       `json:"path" yaml:"path" mapstructure:"path" `
 	AppID                 string       `json:"appId" yaml:"appId" mapstructure:"appId"`
-	ReRecord              string       `json:"rerecord" yaml:"rerecord" mapstructure:"rerecord"`
 	Command               string       `json:"command" yaml:"command" mapstructure:"command"`
 	Port                  uint32       `json:"port" yaml:"port" mapstructure:"port"`
 	DNSPort               uint32       `json:"dnsPort" yaml:"dnsPort" mapstructure:"dnsPort"`
@@ -37,6 +36,7 @@ type Config struct {
 type Record struct {
 	Filters     []Filter      `json:"filters" yaml:"filters" mapstructure:"filters"`
 	RecordTimer time.Duration `json:"recordTimer" yaml:"recordTimer" mapstructure:"recordTimer"`
+	ReRecord    string        `json:"rerecord" yaml:"rerecord" mapstructure:"rerecord"`
 }
 
 type Normalize struct {
@@ -69,6 +69,7 @@ type Test struct {
 	Language           string              `json:"language" yaml:"language" mapstructure:"language"`
 	RemoveUnusedMocks  bool                `json:"removeUnusedMocks" yaml:"removeUnusedMocks" mapstructure:"removeUnusedMocks"`
 	FallBackOnMiss     bool                `json:"fallBackOnMiss" yaml:"fallBackOnMiss" mapstructure:"fallBackOnMiss"`
+	GlobalPassthrough  bool                `json:"globalPassthrough" yaml:"globalPassthrough" mapstructure:"globalPassthrough"`
 }
 
 type Globalnoise struct {

--- a/config/default.go
+++ b/config/default.go
@@ -37,7 +37,7 @@ test:
   mongoPassword: "default@123"
   language: ""
   removeUnusedMocks: false
-  globalPassthrough: false
+  mocking: true
 record:
   recordTimer: 0s
   filters: []

--- a/config/default.go
+++ b/config/default.go
@@ -37,6 +37,7 @@ test:
   mongoPassword: "default@123"
   language: ""
   removeUnusedMocks: false
+  globalPassthrough: false
 record:
   recordTimer: 0s
   filters: []

--- a/main.go
+++ b/main.go
@@ -41,7 +41,11 @@ func main() {
 	// Uncomment the following code to enable pprof for debugging
 	// go func() {
 	// 	fmt.Println("Starting pprof server for debugging...")
-	// 	http.ListenAndServe("localhost:6060", nil)
+	// 	err := http.ListenAndServe("localhost:6060", nil)
+	// 	if err != nil {
+	// 		fmt.Println("Failed to start the pprof server for debugging", err)
+	// 		return
+	// 	}
 	// }()
 	printLogo()
 	ctx := utils.NewCtx()

--- a/pkg/core/proxy/options.go
+++ b/pkg/core/proxy/options.go
@@ -1,5 +1,7 @@
 package proxy
 
+// TODO: what is the need of this? currently it is not being used anywhere.
+
 // Option provides a means to initiate the proxy based on user input.
 type Option struct {
 	Port          uint32

--- a/pkg/core/proxy/proxy.go
+++ b/pkg/core/proxy/proxy.go
@@ -344,7 +344,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 	}()
 
 	//check for global passthrough in test mode
-	if rule.OutgoingOptions.GlobalPassthrough && rule.Mode == models.MODE_TEST {
+	if !rule.OutgoingOptions.Mocking && rule.Mode == models.MODE_TEST {
 
 		dstConn, err = net.Dial("tcp", dstAddr)
 		if err != nil {
@@ -579,8 +579,8 @@ func (p *Proxy) Mock(_ context.Context, id uint64, opts models.OutgoingOptions) 
 	})
 	p.MockManagers.Store(id, NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), p.logger))
 
-	if opts.GlobalPassthrough {
-		p.logger.Info("🔀 Global pass through is enabled, the response will not be mocked")
+	if !opts.Mocking {
+		p.logger.Info("🔀 Mocking is disabled, the response will be fetched from the actual service")
 	}
 
 	if string(p.nsswitchData) == "" {

--- a/pkg/core/proxy/proxy.go
+++ b/pkg/core/proxy/proxy.go
@@ -343,6 +343,23 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 		}
 	}()
 
+	//check for global passthrough in test mode
+	if rule.OutgoingOptions.GlobalPassthrough && rule.Mode == models.MODE_TEST {
+
+		dstConn, err = net.Dial("tcp", dstAddr)
+		if err != nil {
+			utils.LogError(p.logger, err, "failed to dial the conn to destination server", zap.Any("proxy port", p.Port), zap.Any("server address", dstAddr))
+			return err
+		}
+
+		err = p.globalPassThrough(parserCtx, srcConn, dstConn)
+		if err != nil {
+			utils.LogError(p.logger, err, "failed to handle the global pass through")
+			return err
+		}
+		return nil
+	}
+
 	//checking for the destination port of "mysql"
 	if destInfo.Port == 3306 {
 		var dstConn net.Conn
@@ -561,6 +578,10 @@ func (p *Proxy) Mock(_ context.Context, id uint64, opts models.OutgoingOptions) 
 		OutgoingOptions: opts,
 	})
 	p.MockManagers.Store(id, NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), p.logger))
+
+	if opts.GlobalPassthrough {
+		p.logger.Info("🔀 Global pass through is enabled, the response will not be mocked")
+	}
 
 	if string(p.nsswitchData) == "" {
 		// setup the nsswitch config to redirect the DNS queries to the proxy

--- a/pkg/core/proxy/util.go
+++ b/pkg/core/proxy/util.go
@@ -1,9 +1,18 @@
 package proxy
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
 	"os"
 
+	pUtil "go.keploy.io/server/v2/pkg/core/proxy/util"
+	"go.keploy.io/server/v2/pkg/models"
+	"go.keploy.io/server/v2/utils"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 )
 
 // writeNsswitchConfig writes the content to nsswitch.conf file
@@ -15,4 +24,61 @@ func writeNsswitchConfig(logger *zap.Logger, nsSwitchConfig string, data []byte,
 		return err
 	}
 	return nil
+}
+
+func (p *Proxy) globalPassThrough(ctx context.Context, client, dest net.Conn) error {
+
+	logger := p.logger.With(zap.Any("Client IP Address", client.RemoteAddr().String()), zap.Any("Client ConnectionID", ctx.Value(models.ClientConnectionIDKey).(string)), zap.Any("Destination ConnectionID", ctx.Value(models.DestConnectionIDKey).(string)))
+
+	//get the error group from the context
+	g, ok := ctx.Value(models.ErrGroupKey).(*errgroup.Group)
+	if !ok {
+		return errors.New("failed to get the error group from the context")
+	}
+
+	clientBuffChan := make(chan []byte)
+	destBuffChan := make(chan []byte)
+	errChan := make(chan error, 2)
+
+	// read requests from client
+	g.Go(func() error {
+		defer pUtil.Recover(logger, client, nil)
+		defer close(clientBuffChan)
+		pUtil.ReadBuffConn(ctx, logger, client, clientBuffChan, errChan)
+		return nil
+	})
+	// read responses from destination
+	g.Go(func() error {
+		defer pUtil.Recover(logger, nil, dest)
+		defer close(destBuffChan)
+		pUtil.ReadBuffConn(ctx, logger, dest, destBuffChan, errChan)
+		return nil
+	})
+
+	//write the request or response buffer to the respective destination
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case buffer := <-clientBuffChan:
+			// Write the request message to the destination
+			_, err := dest.Write(buffer)
+			if err != nil {
+				utils.LogError(logger, err, "failed to write request message to the destination server")
+				return fmt.Errorf("error writing to destination")
+			}
+		case buffer := <-destBuffChan:
+			// Write the response message to the client
+			_, err := client.Write(buffer)
+			if err != nil {
+				utils.LogError(logger, err, "failed to write response message to the client")
+				return fmt.Errorf("error writing to client")
+			}
+		case err := <-errChan:
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+	}
 }

--- a/pkg/core/proxy/util/util.go
+++ b/pkg/core/proxy/util/util.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	"go.keploy.io/server/v2/pkg/core/proxy/integrations"
+	"go.keploy.io/server/v2/pkg/models"
 	"golang.org/x/sync/errgroup"
 
 	"go.keploy.io/server/v2/utils"
@@ -36,6 +37,14 @@ var idCounter int64 = -1
 func GetNextID() int64 {
 	return atomic.AddInt64(&idCounter, 1)
 }
+
+type Peer string
+
+// Peer constants
+const (
+	Client      Peer = "client"
+	Destination Peer = "destination"
+)
 
 // ReadBuffConn is used to read the buffer from the connection
 func ReadBuffConn(ctx context.Context, logger *zap.Logger, conn net.Conn, bufferChannel chan []byte, errChannel chan error) {
@@ -230,6 +239,32 @@ func ReadRequiredBytes(ctx context.Context, logger *zap.Logger, reader io.Reader
 	}
 
 	return buffer, nil
+}
+
+// ReadFromPeer function is used to read the buffer from the peer connection. The peer can be either the client or the destination.
+func ReadFromPeer(ctx context.Context, logger *zap.Logger, conn net.Conn, buffChan chan []byte, errChan chan error, peer Peer) error {
+	//get the error group from the context
+	g, ok := ctx.Value(models.ErrGroupKey).(*errgroup.Group)
+	if !ok {
+		return errors.New("failed to get the error group from the context while reading from peer")
+	}
+
+	var client, dest net.Conn
+
+	if peer == Client {
+		client = conn
+	} else {
+		dest = conn
+	}
+
+	g.Go(func() error {
+		defer Recover(logger, client, dest)
+		defer close(buffChan)
+		ReadBuffConn(ctx, logger, conn, buffChan, errChan)
+		return nil
+	})
+
+	return nil
 }
 
 // PassThrough function is used to pass the network traffic to the destination connection.

--- a/pkg/core/proxy/util/util.go
+++ b/pkg/core/proxy/util/util.go
@@ -39,7 +39,7 @@ func GetNextID() int64 {
 
 // ReadBuffConn is used to read the buffer from the connection
 func ReadBuffConn(ctx context.Context, logger *zap.Logger, conn net.Conn, bufferChannel chan []byte, errChannel chan error) {
-	//TODO: where to close the bufferChannel and errChannel
+	//TODO: where to close the errChannel
 	for {
 		select {
 		case <-ctx.Done():

--- a/pkg/models/instrument.go
+++ b/pkg/models/instrument.go
@@ -15,8 +15,9 @@ type OutgoingOptions struct {
 	Rules         []config.BypassRule
 	MongoPassword string
 	// TODO: role of SQLDelay should be mentioned in the comments.
-	SQLDelay       time.Duration // This is the same as Application delay.
-	FallBackOnMiss bool          // this enables to pass the request to the actual server if no mock is found during test mode.
+	SQLDelay          time.Duration // This is the same as Application delay.
+	FallBackOnMiss    bool          // this enables to pass the request to the actual server if no mock is found during test mode.
+	GlobalPassthrough bool
 }
 
 type IncomingOptions struct {

--- a/pkg/models/instrument.go
+++ b/pkg/models/instrument.go
@@ -15,9 +15,9 @@ type OutgoingOptions struct {
 	Rules         []config.BypassRule
 	MongoPassword string
 	// TODO: role of SQLDelay should be mentioned in the comments.
-	SQLDelay          time.Duration // This is the same as Application delay.
-	FallBackOnMiss    bool          // this enables to pass the request to the actual server if no mock is found during test mode.
-	GlobalPassthrough bool
+	SQLDelay       time.Duration // This is the same as Application delay.
+	FallBackOnMiss bool          // this enables to pass the request to the actual server if no mock is found during test mode.
+	Mocking        bool          // used to enable/disable mocking
 }
 
 type IncomingOptions struct {

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -206,7 +206,7 @@ func (r *Recorder) Start(ctx context.Context) error {
 		return nil
 	})
 	go func() {
-		if len(r.config.ReRecord) != 0 {
+		if len(r.config.Record.ReRecord) != 0 {
 			err = r.ReRecord(reRecordCtx, appID)
 			reRecordCancel()
 
@@ -337,7 +337,7 @@ func (r *Recorder) StartMock(ctx context.Context) error {
 
 func (r *Recorder) ReRecord(ctx context.Context, appID uint64) error {
 
-	tcs, err := r.testDB.GetTestCases(ctx, r.config.ReRecord)
+	tcs, err := r.testDB.GetTestCases(ctx, r.config.Record.ReRecord)
 	if err != nil {
 		r.logger.Error("Failed to get testcases", zap.Error(err))
 		return nil
@@ -376,7 +376,7 @@ func (r *Recorder) ReRecord(ctx context.Context, appID uint64) error {
 			r.logger.Debug("", zap.Any("replaced URL in case of docker env", tc.HTTPReq.URL))
 		}
 
-		resp, err := pkg.SimulateHTTP(ctx, *tc, r.config.ReRecord, r.logger, r.config.Test.APITimeout)
+		resp, err := pkg.SimulateHTTP(ctx, *tc, r.config.Record.ReRecord, r.logger, r.config.Test.APITimeout)
 		if err != nil {
 			r.logger.Error("Failed to simulate HTTP request", zap.Error(err))
 			allTestCasesRecorded = false

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -271,11 +271,11 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 	}
 
 	err = r.instrumentation.MockOutgoing(runTestSetCtx, appID, models.OutgoingOptions{
-		Rules:             r.config.BypassRules,
-		MongoPassword:     r.config.Test.MongoPassword,
-		SQLDelay:          time.Duration(r.config.Test.Delay),
-		FallBackOnMiss:    r.config.Test.FallBackOnMiss,
-		GlobalPassthrough: r.config.Test.GlobalPassthrough,
+		Rules:          r.config.BypassRules,
+		MongoPassword:  r.config.Test.MongoPassword,
+		SQLDelay:       time.Duration(r.config.Test.Delay),
+		FallBackOnMiss: r.config.Test.FallBackOnMiss,
+		Mocking:        r.config.Test.Mocking,
 	})
 	if err != nil {
 		utils.LogError(r.logger, err, "failed to mock outgoing")

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -271,10 +271,11 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 	}
 
 	err = r.instrumentation.MockOutgoing(runTestSetCtx, appID, models.OutgoingOptions{
-		Rules:          r.config.BypassRules,
-		MongoPassword:  r.config.Test.MongoPassword,
-		SQLDelay:       time.Duration(r.config.Test.Delay),
-		FallBackOnMiss: r.config.Test.FallBackOnMiss,
+		Rules:             r.config.BypassRules,
+		MongoPassword:     r.config.Test.MongoPassword,
+		SQLDelay:          time.Duration(r.config.Test.Delay),
+		FallBackOnMiss:    r.config.Test.FallBackOnMiss,
+		GlobalPassthrough: r.config.Test.GlobalPassthrough,
 	})
 	if err != nil {
 		utils.LogError(r.logger, err, "failed to mock outgoing")


### PR DESCRIPTION
## Related Issue
  - Support for global passthrough of external calls

Closes: https://github.com/keploy/keploy/issues/1919

#### Describe the changes you've made
- Add a flag to disable mocking in test mode. You can use it like, `keploy test -c "<appCMD>" --mocking=false`
- Move the Rerecord flag to only test in the cmd package.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
`NA`

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |