### PR TITLE
chore: kill docker container 

### DIFF
--- a/pkg/core/app/app.go
+++ b/pkg/core/app/app.go
@@ -427,7 +427,7 @@ func (a *App) waitTillExit() {
 			// Inspect the container status
 			containerJSON, err := a.docker.ContainerInspect(context.Background(), containerID)
 			if err != nil {
-				a.logger.Error("failed to inspect container", zap.String("containerID", containerID), zap.Error(err))
+				a.logger.Debug("failed to inspect container", zap.String("containerID", containerID), zap.Error(err))
 				return
 			}
 

--- a/pkg/core/app/app.go
+++ b/pkg/core/app/app.go
@@ -427,7 +427,7 @@ func (a *App) waitTillExit() {
 			// Inspect the container status
 			containerJSON, err := a.docker.ContainerInspect(context.Background(), containerID)
 			if err != nil {
-				a.logger.Debug("failed to inspect container", zap.String("containerID", containerID), zap.Error(err))
+				a.logger.Info("failed to inspect container", zap.String("containerID", containerID), zap.Error(err))
 				return
 			}
 

--- a/pkg/core/app/app.go
+++ b/pkg/core/app/app.go
@@ -490,11 +490,12 @@ func (a *App) run(ctx context.Context) models.AppError {
 
 	err = cmd.Wait()
 
+	if utils.IsDockerKind(a.kind) {
+		a.waitTillExit()
+	}
+
 	select {
 	case <-ctx.Done():
-		if utils.IsDockerKind(a.kind) {
-			a.waitTillExit()
-		}
 		a.logger.Debug("context cancelled, error while waiting for the app to exit", zap.Error(ctx.Err()))
 		return models.AppError{AppErrorType: models.ErrCtxCanceled, Err: ctx.Err()}
 	default:

--- a/pkg/core/app/app.go
+++ b/pkg/core/app/app.go
@@ -427,7 +427,7 @@ func (a *App) waitTillExit() {
 			// Inspect the container status
 			containerJSON, err := a.docker.ContainerInspect(context.Background(), containerID)
 			if err != nil {
-				a.logger.Info("failed to inspect container", zap.String("containerID", containerID), zap.Error(err))
+				a.logger.Debug("failed to inspect container", zap.String("containerID", containerID), zap.Error(err))
 				return
 			}
 

--- a/pkg/core/app/app.go
+++ b/pkg/core/app/app.go
@@ -490,12 +490,11 @@ func (a *App) run(ctx context.Context) models.AppError {
 
 	err = cmd.Wait()
 
-	if utils.IsDockerKind(a.kind) {
-		a.waitTillExit()
-	}
-
 	select {
 	case <-ctx.Done():
+		if utils.IsDockerKind(a.kind) {
+			a.waitTillExit()
+		}
 		a.logger.Debug("context cancelled, error while waiting for the app to exit", zap.Error(ctx.Err()))
 		return models.AppError{AppErrorType: models.ErrCtxCanceled, Err: ctx.Err()}
 	default:

--- a/pkg/core/app/app.go
+++ b/pkg/core/app/app.go
@@ -473,9 +473,9 @@ func (a *App) run(ctx context.Context) models.AppError {
 			}
 
 			return nil
-		} else {
-			return utils.InterruptProcessTree(a.logger, cmd.Process.Pid, syscall.SIGINT)
 		}
+		return utils.InterruptProcessTree(a.logger, cmd.Process.Pid, syscall.SIGINT)
+
 	}
 	// wait after sending the interrupt signal, before sending the kill signal
 	cmd.WaitDelay = 25 * time.Second

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -586,13 +586,17 @@ func InterruptProcessTree(logger *zap.Logger, ppid int, sig syscall.Signal) erro
 	}
 
 	for _, pid := range uniqueProcess {
-		err := syscall.Kill(-pid, sig)
-		// ignore the ESRCH error as it means the process is already dead
-		if errno, ok := err.(syscall.Errno); ok && err != nil && errno != syscall.ESRCH {
-			logger.Error("failed to send signal to process", zap.Int("pid", pid), zap.Error(err))
-		}
+		SendSignal(logger, -pid, sig)
 	}
 	return nil
+}
+
+func SendSignal(logger *zap.Logger, pid int, sig syscall.Signal) {
+	err := syscall.Kill(pid, sig)
+	// ignore the ESRCH error as it means the process is already dead
+	if errno, ok := err.(syscall.Errno); ok && err != nil && errno != syscall.ESRCH {
+		logger.Error("failed to send signal to process", zap.Int("pid", pid), zap.Error(err))
+	}
 }
 
 func uniqueProcessGroups(pids []int) ([]int, error) {


### PR DESCRIPTION
##  Solution
  - Instead of killing children kill the container directly
  - Wait for 25 second before sending sigkill
  - Listen to docker events for 30seconds, if not killed log that application isn't killed

Closes: https://github.com/keploy/keploy/issues/1904
