### PR TITLE
chore: fix compilation errors on macos

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/fatih/color"
-	"github.com/moby/moby/pkg/parsers/kernel"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.keploy.io/server/v2/config"
@@ -167,6 +166,7 @@ func (c *CmdConfigurator) AddFlags(cmd *cobra.Command) error {
 	//add flags
 	var err error
 	switch cmd.Name() {
+
 	case "update":
 		return nil
 	case "normalize":
@@ -248,14 +248,19 @@ func (c *CmdConfigurator) AddFlags(cmd *cobra.Command) error {
 }
 
 func (c *CmdConfigurator) Validate(ctx context.Context, cmd *cobra.Command) error {
-	//check if the version of the kernel is above 5.15 for eBPF support
-	isValid := kernel.CheckKernelVersion(5, 15, 0)
-	if !isValid {
-		errMsg := "Kernel version is below 5.15. Keploy requires kernel version 5.15 or above"
-		utils.LogError(c.logger, nil, errMsg)
-		return errors.New(errMsg)
+	err := isCompatible(c.logger)
+	if err != nil {
+		return err
 	}
-
+	//if runtime.GOOS == "linux" {
+	//	//check if the version of the kernel is above 5.15 for eBPF support
+	//	isValid := kernel.CheckKernelVersion(5, 15, 0)
+	//	if !isValid {
+	//		errMsg := "Kernel version is below 5.15. Keploy requires kernel version 5.15 or above"
+	//		utils.LogError(c.logger, nil, errMsg)
+	//		return errors.New(errMsg)
+	//	}
+	//}
 	return c.ValidateFlags(ctx, cmd)
 }
 

--- a/cli/provider/compat_linux.go
+++ b/cli/provider/compat_linux.go
@@ -1,0 +1,26 @@
+//go:build linux
+
+package provider
+
+import (
+	"errors"
+
+	"github.com/moby/moby/pkg/parsers/kernel"
+	"go.uber.org/zap"
+)
+
+func isCompatible(logger *zap.Logger) error {
+	//check if the version of the kernel is above 5.15 for eBPF support
+	isValid := kernel.CheckKernelVersion(5, 15, 0)
+	if !isValid {
+		c, err := kernel.GetKernelVersion()
+		if err != nil {
+			logger.Error("Error getting kernel version", zap.Error(err))
+			return err
+		}
+		errMsg := "detected linux kernel version" + c.String() + ". Keploy requires linux kernel version 5.15 or above. Please upgrade your kernel or docker version.\n"
+		logger.Error(errMsg)
+		return errors.New(errMsg)
+	}
+	return nil
+}

--- a/cli/provider/compat_others.go
+++ b/cli/provider/compat_others.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+// This is a placeholder file for other OSes.
+
+package provider
+
+import "go.uber.org/zap"
+
+func isCompatible(logger *zap.Logger) error {
+	return nil
+}


### PR DESCRIPTION
Currently due to the Linux kernel version check, keploy could no longer be compiled on macOS. 