### PR TITLE
ci: use macos github action for goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,8 @@ jobs:
 #          rm -rf $GITHUB_WORKSPACE/ui
 
   build-go:
-    # runs-on: macos-latest
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
+    # runs-on: ubuntu-latest
 #    needs: build-ui
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
change the runner from ubuntu to macos to ensure macOS bianries can be signed. we use `gon` for signing macos binaries and it requries macOS 