### PR TITLE
ci: change the version of gon used

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.21"
+          go-version: "1.22"
 
 #      - name: Checkout UI
 #        uses: actions/checkout@v2
@@ -80,10 +80,10 @@ jobs:
           p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
           # The password used to import the PKCS12 file.
           p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
-      - name: Install gon via HomeBrew for code signing and app notarization
+      - name:  Install gon for code signing and app notarization
         run: |
-          brew tap mitchellh/gon
-          brew install mitchellh/gon/gon
+          wget -q https://github.com/Bearer/gon/releases/download/v0.0.37/gon_macos.zip
+          unzip gon_macos.zip -d /usr/local/bin
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:


### PR DESCRIPTION
We need to change the version of gon because apple has stopped accepting `altool` and now uses a new tool which current version of gon doesn't support. 

ref: https://github.com/mitchellh/gon/pull/72