### PR TITLE
feat: add support for running pre/post scripts of test-set

### DIFF
--- a/pkg/core/app/app.go
+++ b/pkg/core/app/app.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
 	"syscall"
 	"time"
@@ -444,53 +443,35 @@ func (a *App) waitTillExit() {
 }
 
 func (a *App) run(ctx context.Context) models.AppError {
-	// Run the app as the user who invoked sudo
+
 	userCmd := a.cmd
-	username := os.Getenv("SUDO_USER")
 
 	if utils.FindDockerCmd(a.cmd) == utils.DockerRun {
 		userCmd = utils.EnsureRmBeforeName(userCmd)
 	}
 
-	cmd := exec.CommandContext(ctx, "sh", "-c", userCmd)
-	if username != "" {
-		// print all environment variables
-		a.logger.Debug("env inherited from the cmd", zap.Any("env", os.Environ()))
-		// Run the command as the user who invoked sudo to preserve the user environment variables and PATH
-		cmd = exec.CommandContext(ctx, "sudo", "-E", "-u", os.Getenv("SUDO_USER"), "env", "PATH="+os.Getenv("PATH"), "sh", "-c", userCmd)
-	}
-
-	// Set the cancel function for the command
-	cmd.Cancel = func() error {
-
-		if utils.IsDockerKind(a.kind) {
-			a.logger.Debug("sending SIGINT to the container", zap.Any("cmd.Process.Pid", cmd.Process.Pid))
-			err := utils.SendSignal(a.logger, -cmd.Process.Pid, syscall.SIGINT)
-
-			return err
+	// Define the function to cancel the command
+	cmdCancel := func(cmd *exec.Cmd) func() error {
+		return func() error {
+			if utils.IsDockerKind(a.kind) {
+				a.logger.Debug("sending SIGINT to the container", zap.Any("cmd.Process.Pid", cmd.Process.Pid))
+				err := utils.SendSignal(a.logger, -cmd.Process.Pid, syscall.SIGINT)
+				return err
+			}
+			return utils.InterruptProcessTree(a.logger, cmd.Process.Pid, syscall.SIGINT)
 		}
-		return utils.InterruptProcessTree(a.logger, cmd.Process.Pid, syscall.SIGINT)
-
-	}
-	// wait after sending the interrupt signal, before sending the kill signal
-	cmd.WaitDelay = 25 * time.Second
-
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setpgid: true,
 	}
 
-	// Set the output of the command
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	a.logger.Debug("", zap.Any("executing cli", cmd.String()))
-
-	err := cmd.Start()
-	if err != nil {
-		return models.AppError{AppErrorType: models.ErrCommandError, Err: err}
+	var err error
+	cmdErr := utils.ExecuteCommand(ctx, a.logger, userCmd, cmdCancel, 25*time.Second)
+	if cmdErr.Err != nil {
+		switch cmdErr.Source {
+		case utils.Start:
+			return models.AppError{AppErrorType: models.ErrCommandError, Err: cmdErr.Err}
+		case utils.Wait:
+			err = cmdErr.Err
+		}
 	}
-
-	err = cmd.Wait()
 
 	if utils.IsDockerKind(a.kind) {
 		a.waitTillExit()

--- a/pkg/core/app/app.go
+++ b/pkg/core/app/app.go
@@ -465,10 +465,10 @@ func (a *App) run(ctx context.Context) models.AppError {
 	var err error
 	cmdErr := utils.ExecuteCommand(ctx, a.logger, userCmd, cmdCancel, 25*time.Second)
 	if cmdErr.Err != nil {
-		switch cmdErr.Source {
-		case utils.Start:
+		switch cmdErr.Type {
+		case utils.Init:
 			return models.AppError{AppErrorType: models.ErrCommandError, Err: cmdErr.Err}
-		case utils.Wait:
+		case utils.Runtime:
 			err = cmdErr.Err
 		}
 	}

--- a/pkg/models/testrun.go
+++ b/pkg/models/testrun.go
@@ -49,6 +49,7 @@ const (
 	TestSetStatusUserAbort    TestSetStatus = "USER_ABORT"
 	TestSetStatusFaultUserApp TestSetStatus = "APP_FAULT"
 	TestSetStatusInternalErr  TestSetStatus = "INTERNAL_ERR"
+	TestSetStatusFaultScript  TestSetStatus = "SCRIPT_FAULT"
 )
 
 func StringToTestSetStatus(s string) (TestSetStatus, error) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -572,17 +572,17 @@ func SetCoveragePath(logger *zap.Logger, goCovPath string) (string, error) {
 	return goCovPath, nil
 }
 
-type CmdErrorSource string
+type ErrType string
 
-// CmdErrorSource constants to get the source from which the error occurred, i.e., start or wait
+// ErrType constants to get the type of error, during init or runtime
 const (
-	Start CmdErrorSource = "start"
-	Wait  CmdErrorSource = "wait"
+	Init    ErrType = "init"
+	Runtime ErrType = "runtime"
 )
 
 type CmdError struct {
-	Source CmdErrorSource
-	Err    error
+	Type ErrType
+	Err  error
 }
 
 func ExecuteCommand(ctx context.Context, logger *zap.Logger, userCmd string, cancel func(cmd *exec.Cmd) func() error, waitDelay time.Duration) CmdError {
@@ -615,12 +615,12 @@ func ExecuteCommand(ctx context.Context, logger *zap.Logger, userCmd string, can
 
 	err := cmd.Start()
 	if err != nil {
-		return CmdError{Source: Start, Err: err}
+		return CmdError{Type: Init, Err: err}
 	}
 
 	err = cmd.Wait()
 	if err != nil {
-		return CmdError{Source: Wait, Err: err}
+		return CmdError{Type: Runtime, Err: err}
 	}
 
 	return CmdError{}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -572,6 +572,60 @@ func SetCoveragePath(logger *zap.Logger, goCovPath string) (string, error) {
 	return goCovPath, nil
 }
 
+type CmdErrorSource string
+
+// CmdErrorSource constants to get the source from which the error occurred, i.e., start or wait
+const (
+	Start CmdErrorSource = "start"
+	Wait  CmdErrorSource = "wait"
+)
+
+type CmdError struct {
+	Source CmdErrorSource
+	Err    error
+}
+
+func ExecuteCommand(ctx context.Context, logger *zap.Logger, userCmd string, cancel func(cmd *exec.Cmd) func() error, waitDelay time.Duration) CmdError {
+	// Run the app as the user who invoked sudo
+	username := os.Getenv("SUDO_USER")
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", userCmd)
+	if username != "" {
+		// print all environment variables
+		logger.Debug("env inherited from the cmd", zap.Any("env", os.Environ()))
+		// Run the command as the user who invoked sudo to preserve the user environment variables and PATH
+		cmd = exec.CommandContext(ctx, "sudo", "-E", "-u", os.Getenv("SUDO_USER"), "env", "PATH="+os.Getenv("PATH"), "sh", "-c", userCmd)
+	}
+
+	// Set the cancel function for the command
+	cmd.Cancel = cancel(cmd)
+
+	// wait after sending the interrupt signal, before sending the kill signal
+	cmd.WaitDelay = waitDelay
+
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+
+	// Set the output of the command
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	logger.Debug("", zap.Any("executing cli", cmd.String()))
+
+	err := cmd.Start()
+	if err != nil {
+		return CmdError{Source: Start, Err: err}
+	}
+
+	err = cmd.Wait()
+	if err != nil {
+		return CmdError{Source: Wait, Err: err}
+	}
+
+	return CmdError{}
+}
+
 // InterruptProcessTree interrupts an entire process tree using the given signal
 func InterruptProcessTree(logger *zap.Logger, ppid int, sig syscall.Signal) error {
 	// Find all descendant PIDs of the given PID & then signal them.


### PR DESCRIPTION
## Related Issue
  - Allow user to run pre/post script for each test-set.
  
Closes: https://github.com/keploy/keploy/issues/1953

#### Describe the changes you've made
- Refactored the cmd execution logic 
- Add support for pre/post scripts to run before/after each test-set.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
`NA`

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |