### PR TITLE
fix: added check for prisma prepare statement matching

### DIFF
--- a/pkg/core/proxy/integrations/postgres/v1/decode.go
+++ b/pkg/core/proxy/integrations/postgres/v1/decode.go
@@ -128,7 +128,7 @@ func getRecordPrepStatement(allMocks []*models.Mock) PrepMap {
 				p := 0
 				for _, header := range req.PacketTypes {
 					if header == "P" {
-						if strings.Contains(req.Parses[p].Name, "S_") {
+						if strings.Contains(req.Parses[p].Name, "S_") || strings.Contains(req.Parses[p].Name, "s") {
 							psMap[req.Parses[p].Query] = req.Parses[p].Name
 							querydata = append(querydata, QueryData{PrepIdentifier: req.Parses[p].Name,
 								Query: req.Parses[p].Query,

--- a/pkg/core/proxy/integrations/postgres/v1/match.go
+++ b/pkg/core/proxy/integrations/postgres/v1/match.go
@@ -38,7 +38,7 @@ func getTestPS(reqBuff [][]byte, logger *zap.Logger, ConnectionID string) {
 		p := 0
 		for _, header := range actualPgReq.PacketTypes {
 			if header == "P" {
-				if strings.Contains(actualPgReq.Parses[p].Name, "S_") && !IsValuePresent(ConnectionID, actualPgReq.Parses[p].Name) {
+				if (strings.Contains(actualPgReq.Parses[p].Name, "S_") || strings.Contains(actualPgReq.Parses[p].Name, "s")) && !IsValuePresent(ConnectionID, actualPgReq.Parses[p].Name) {
 					querydata = append(querydata, QueryData{PrepIdentifier: actualPgReq.Parses[p].Name, Query: actualPgReq.Parses[p].Query})
 				}
 				p++


### PR DESCRIPTION
## Related Issue
Prisma was failing in test mode because of incorrect prepare statement matching


#### Describe the changes you've made
Added check for prepare statments of type 's*' along with 'S_*' as well.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |