### PR TITLE
fix: denoise bugs

### DIFF
--- a/pkg/platform/yaml/testdb/util.go
+++ b/pkg/platform/yaml/testdb/util.go
@@ -248,10 +248,9 @@ func Decode(yamlTestcase *yaml.NetworkTrafficDoc, logger *zap.Logger) (*models.T
 		switch reflect.ValueOf(httpSpec.Assertions["noise"]).Kind() {
 		case reflect.Map:
 			for k, v := range httpSpec.Assertions["noise"].(map[string]interface{}) {
-				l := strings.ToLower(k)
-				tc.Noise[l] = []string{}
+				tc.Noise[k] = []string{}
 				for _, val := range v.([]interface{}) {
-					tc.Noise[l] = append(tc.Noise[l], val.(string))
+					tc.Noise[k] = append(tc.Noise[k], val.(string))
 				}
 			}
 		case reflect.Slice:

--- a/pkg/platform/yaml/testdb/util.go
+++ b/pkg/platform/yaml/testdb/util.go
@@ -38,20 +38,22 @@ func EncodeTestcase(tc models.TestCase, logger *zap.Logger) (*yaml.NetworkTraffi
 	}
 	noise := tc.Noise
 
-	noiseFieldsFound := FindNoisyFields(m, func(_ string, vals []string) bool {
-		// check if k is date
-		for _, v := range vals {
-			if pkg.IsTime(v) {
-				return true
+	if tc.Name == "" {
+		noiseFieldsFound := FindNoisyFields(m, func(_ string, vals []string) bool {
+			// check if k is date
+			for _, v := range vals {
+				if pkg.IsTime(v) {
+					return true
+				}
 			}
+
+			// maybe we need to concatenate the values
+			return pkg.IsTime(strings.Join(vals, ", "))
+		})
+
+		for _, v := range noiseFieldsFound {
+			noise[v] = []string{}
 		}
-
-		// maybe we need to concatenate the values
-		return pkg.IsTime(strings.Join(vals, ", "))
-	})
-
-	for _, v := range noiseFieldsFound {
-		noise[v] = []string{}
 	}
 
 	switch tc.Kind {

--- a/pkg/service/replay/match.go
+++ b/pkg/service/replay/match.go
@@ -80,9 +80,9 @@ func match(tc *models.TestCase, actualResponse *models.HTTPResp, noiseConfig map
 		a := strings.Split(field, ".")
 		if len(a) > 1 && a[0] == "body" {
 			x := strings.Join(a[1:], ".")
-			bodyNoise[x] = regexArr
+			bodyNoise[strings.ToLower(x)] = regexArr
 		} else if a[0] == "header" {
-			headerNoise[a[len(a)-1]] = regexArr
+			headerNoise[strings.ToLower(a[len(a)-1])] = regexArr
 		}
 	}
 


### PR DESCRIPTION
1. Noise in the reports was wrong because we are explicitly converting noise into lower case. Removed this.
2. Remove auto-detection of noise while updating test case because when we remove noise, still the noise is getting appended.