### PR TITLE
Fix keploy gives error for gin mongo when recorded with docker compose

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -60,6 +60,7 @@ const InternalConfig = `
 enableTesting: false
 keployContainer: "keploy-v2"
 keployNetwork: "keploy-network"
+inDocker: false
 cmdType: "native"
 `
 

--- a/config/default.go
+++ b/config/default.go
@@ -19,7 +19,6 @@ dnsPort: 26789
 debug: false
 disableANSI: false
 disableTele: false
-inDocker: false
 generateGithubActions: true
 containerName: ""
 networkName: ""
@@ -61,7 +60,6 @@ const InternalConfig = `
 enableTesting: false
 keployContainer: "keploy-v2"
 keployNetwork: "keploy-network"
-inDocker: false
 cmdType: "native"
 `
 


### PR DESCRIPTION
Closes: #2038 

#### Describe the changes you've made
Remove the indocker flag 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

#### Describe if there is any unusual behaviour of your code
NA

