### PR TITLE
fix: postgres parser bug

### DIFF
--- a/pkg/core/proxy/integrations/postgres/v1/match.go
+++ b/pkg/core/proxy/integrations/postgres/v1/match.go
@@ -772,7 +772,6 @@ func validateMock(tcsMocks []*models.Mock, idx int, requestBuffers [][]byte, log
 		if reflect.DeepEqual(mock.PacketTypes, []string{"B", "E"}) {
 			// logger.Debug("Inside Validate Mock for B, E")
 			copyMock := *tcsMocks[idx]
-			copyMock.Spec.PostgresResponses[0].PacketTypes = []string{"2", "D", "C", "Z"}
 			copyMock.Spec.PostgresResponses[0].Payload = ""
 			return false, &copyMock
 		}

--- a/pkg/core/proxy/integrations/postgres/v1/match.go
+++ b/pkg/core/proxy/integrations/postgres/v1/match.go
@@ -695,7 +695,11 @@ func compareExactMatch(mock *models.Mock, actualPgReq *models.Backend, logger *z
 			for j := 0; j < len(actualPgReq.Binds[b-1].Parameters); j++ {
 				// parameter represents a timestamp value do not compare it just continue
 				if isTimestamp(actualPgReq.Binds[b-1].Parameters[j]) {
-					fmt.Println("Timestamp value")
+					logger.Debug("found a timestamp value")
+					continue
+				}
+				if isBcryptHash(actualPgReq.Binds[b-1].Parameters[j]) {
+					logger.Debug("found a bcrypt hash")
 					continue
 				}
 				for i, v := range actualPgReq.Binds[b-1].Parameters[j] {
@@ -814,4 +818,13 @@ func isTimestamp(byteArray []byte) bool {
 	// Define a regex for ISO 8601 timestamps
 	timestampRegex := regexp.MustCompile(`\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(.\d+)?(Z)?`)
 	return timestampRegex.MatchString(s)
+}
+
+func isBcryptHash(byteArray []byte) bool {
+	// Convert byte array to string
+	s := string(byteArray)
+
+	// Define a regex for bcrypt hashes
+	bcryptRegex := regexp.MustCompile(`^\$2[aby]\$\d{2}\$[./A-Za-z0-9]{53}$`)
+	return bcryptRegex.MatchString(s)
 }

--- a/pkg/core/proxy/integrations/postgres/v1/match.go
+++ b/pkg/core/proxy/integrations/postgres/v1/match.go
@@ -772,7 +772,7 @@ func validateMock(tcsMocks []*models.Mock, idx int, requestBuffers [][]byte, log
 		if reflect.DeepEqual(mock.PacketTypes, []string{"B", "E"}) {
 			// logger.Debug("Inside Validate Mock for B, E")
 			copyMock := *tcsMocks[idx]
-			copyMock.Spec.PostgresResponses[0].PacketTypes = []string{"2", "C", "Z"}
+			copyMock.Spec.PostgresResponses[0].PacketTypes = []string{"2", "D", "C", "Z"}
 			copyMock.Spec.PostgresResponses[0].Payload = ""
 			return false, &copyMock
 		}


### PR DESCRIPTION
## Related Issue

Closes: #2134

#### Describe the changes you've made

RCA:
1. The API broke due to incorrect mocking in Postgres parser.
2. The timestamp fields in the request buffer was different and it wasn't matched in exact match.

Changes:
1. Added logic to ignore timestamp field matching.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

<img width="1440" alt="Screenshot 2024-07-26 at 1 37 18 AM" src="https://github.com/user-attachments/assets/3397fd57-0c26-47ad-b0ca-412c71ee7486">
