### PR TITLE
feat: introduce flag to replace http host

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -258,6 +258,7 @@ func (c *CmdConfigurator) AddUncommonFlags(cmd *cobra.Command) {
 		cmd.Flags().Uint64("record-timer", 0, "User provided time to record its application")
 	case "test", "rerecord":
 		cmd.Flags().StringSliceP("test-sets", "t", utils.Keys(c.cfg.Test.SelectedTests), "Testsets to run e.g. --testsets \"test-set-1, test-set-2\"")
+		cmd.Flags().String("host", c.cfg.Test.Host, "Custom host to replace the actual host in the testcases")
 		if cmd.Name() == "test" {
 			cmd.Flags().Uint64P("delay", "d", 5, "User provided time to run its application")
 			cmd.Flags().Uint64("api-timeout", c.cfg.Test.APITimeout, "User provided timeout for calling its application")
@@ -548,6 +549,13 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 
 			if cmd.Name() == "rerecord" {
 				c.cfg.Test.SkipCoverage = true
+				host, err := cmd.Flags().GetString("host")
+				if err != nil {
+					errMsg := "failed to get the provided host"
+					utils.LogError(c.logger, err, errMsg)
+					return errors.New(errMsg)
+				}
+				c.cfg.ReRecord.Host = host
 				return nil
 			}
 

--- a/config/config.go
+++ b/config/config.go
@@ -60,6 +60,7 @@ type Record struct {
 type ReRecord struct {
 	SelectedTests []string `json:"selectedTests" yaml:"selectedTests" mapstructure:"selectedTests"`
 	Filters       []Filter `json:"filters" yaml:"filters" mapstructure:"filters"`
+	Host          string   `json:"host" yaml:"host" mapstructure:"host"`
 }
 
 type Normalize struct {
@@ -83,6 +84,7 @@ type Test struct {
 	SelectedTests      map[string][]string `json:"selectedTests" yaml:"selectedTests" mapstructure:"selectedTests"`
 	GlobalNoise        Globalnoise         `json:"globalNoise" yaml:"globalNoise" mapstructure:"globalNoise"`
 	Delay              uint64              `json:"delay" yaml:"delay" mapstructure:"delay"`
+	Host               string              `json:"host" yaml:"host" mapstructure:"host"`
 	APITimeout         uint64              `json:"apiTimeout" yaml:"apiTimeout" mapstructure:"apiTimeout"`
 	SkipCoverage       bool                `json:"skipCoverage" yaml:"skipCoverage" mapstructure:"skipCoverage"`                   // boolean to capture the coverage in test
 	CoverageReportPath string              `json:"coverageReportPath" yaml:"coverageReportPath" mapstructure:"coverageReportPath"` // directory path to store the coverage files

--- a/pkg/service/orchestrator/rerecord.go
+++ b/pkg/service/orchestrator/rerecord.go
@@ -234,7 +234,7 @@ func (o *Orchestrator) replayTests(ctx context.Context, testSet string) (bool, e
 			}
 			o.logger.Debug("", zap.Any("replaced URL in case of docker env", tc.HTTPReq.URL))
 		}
-		
+
 		if o.config.ReRecord.Host != "" {
 			tc.HTTPReq.URL, err = utils.ReplaceHost(tc.HTTPReq.URL, o.config.ReRecord.Host)
 			if err != nil {

--- a/pkg/service/orchestrator/rerecord.go
+++ b/pkg/service/orchestrator/rerecord.go
@@ -227,12 +227,20 @@ func (o *Orchestrator) replayTests(ctx context.Context, testSet string) (bool, e
 			return false, ctx.Err()
 		}
 		if utils.IsDockerCmd(cmdType) {
-			tc.HTTPReq.URL, err = utils.ReplaceHostToIP(tc.HTTPReq.URL, userIP)
+			tc.HTTPReq.URL, err = utils.ReplaceHost(tc.HTTPReq.URL, userIP)
 			if err != nil {
 				utils.LogError(o.logger, err, "failed to replace host to docker container's IP")
 				break
 			}
 			o.logger.Debug("", zap.Any("replaced URL in case of docker env", tc.HTTPReq.URL))
+		}
+		
+		if o.config.ReRecord.Host != "" {
+			tc.HTTPReq.URL, err = utils.ReplaceHost(tc.HTTPReq.URL, o.config.ReRecord.Host)
+			if err != nil {
+				utils.LogError(o.logger, err, "failed to replace host to provided host by the user")
+				break
+			}
 		}
 
 		resp, err := pkg.SimulateHTTP(ctx, *tc, testSet, o.logger, o.config.Test.APITimeout)

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -601,13 +601,21 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		}
 
 		if utils.IsDockerCmd(cmdType) {
-
-			testCase.HTTPReq.URL, err = utils.ReplaceHostToIP(testCase.HTTPReq.URL, userIP)
+			testCase.HTTPReq.URL, err = utils.ReplaceHost(testCase.HTTPReq.URL, userIP)
 			if err != nil {
 				utils.LogError(r.logger, err, "failed to replace host to docker container's IP")
 				break
 			}
 			r.logger.Debug("", zap.Any("replaced URL in case of docker env", testCase.HTTPReq.URL))
+		}
+
+		// send the flag replace-host instead of sending the IP
+		if r.config.Test.Host != "" {
+			testCase.HTTPReq.URL, err = utils.ReplaceHost(testCase.HTTPReq.URL, r.config.Test.Host)
+			if err != nil {
+				utils.LogError(r.logger, err, "failed to replace host to provided host by the user")
+				break
+			}
 		}
 
 		started := time.Now().UTC()

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -37,7 +37,7 @@ var WarningSign = "\U000026A0"
 
 var ErrCode = 0
 
-func ReplaceHostToIP(currentURL string, ipAddress string) (string, error) {
+func ReplaceHost(currentURL string, ipAddress string) (string, error) {
 	// Parse the current URL
 	parsedURL, err := url.Parse(currentURL)
 


### PR DESCRIPTION
## Related Issue
  - #2184 

Closes: #[2184]

#### Describe the changes you've made

  - Added a host flag in test as well re-record for replacing the url host before simulating the tests.
  - Now user can replace the request host by using `--host` flag of keploy

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |