### PR TITLE
fix: missed reading eof packet leads to blocked client conn

### DIFF
--- a/pkg/core/proxy/integrations/mysql/recorder/query.go
+++ b/pkg/core/proxy/integrations/mysql/recorder/query.go
@@ -338,7 +338,7 @@ func handleTextResultSet(ctx context.Context, logger *zap.Logger, clientConn, de
 		textResultSet.Columns = append(textResultSet.Columns, column)
 	}
 
-	if sg.CapabilityFlags == 0&mysql.CLIENT_DEPRECATE_EOF {
+	if sg.CapabilityFlags&mysql.CLIENT_DEPRECATE_EOF > 0 {
 
 		// Read the EOF packet for column definition
 		eofData, err := mysqlUtils.ReadPacketBuffer(ctx, logger, destConn)

--- a/pkg/core/proxy/integrations/mysql/wire/decode.go
+++ b/pkg/core/proxy/integrations/mysql/wire/decode.go
@@ -176,6 +176,9 @@ func decodePacket(ctx context.Context, logger *zap.Logger, packet mysql.Packet, 
 
 		setPacketInfo(ctx, parsedPacket, pkt, mysql.HandshakeResponse41, clientConn, payloadType, decodeCtx)
 
+		// Store the client capabilities to use it later
+		decodeCtx.ClientCapabilities = pkt.CapabilityFlags
+
 		logger.Debug("HandshakeResponse41 decoded", zap.Any("parsed packet", parsedPacket))
 
 		return parsedPacket, nil

--- a/pkg/core/proxy/integrations/mysql/wire/util.go
+++ b/pkg/core/proxy/integrations/mysql/wire/util.go
@@ -19,6 +19,7 @@ type DecodeContext struct {
 	LastOp             *LastOperation
 	PreparedStatements map[uint32]*mysql.StmtPrepareOkPacket
 	ServerGreetings    *ServerGreetings
+	ClientCapabilities uint32
 	PluginName         string
 }
 


### PR DESCRIPTION
## What does this PR do?

- This PR fixed the condition where we read the `EOF` packet after the column definition packet in TextResultSet.

## Related PRs and Issues

- https://github.com/keploy/keploy/issues/2023

Closes: https://github.com/keploy/keploy/issues/2214

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know test plan followed

Please describe the tests(if any). Provide instructions how its affecting the coverage.

## Checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] New and existing unit tests pass locally with my changes.
