### PR TITLE
fix: ignore machine id if not present

### DIFF
--- a/pkg/platform/yaml/configdb/user/db.go
+++ b/pkg/platform/yaml/configdb/user/db.go
@@ -43,12 +43,12 @@ func (db *Db) GetInstallationID(_ context.Context) (string, error) {
 	} else {
 		id, err = machineid.ID()
 		if err != nil {
-			db.logger.Warn("failed to get machine id", zap.Error(err))
+			db.logger.Debug("failed to get machine id", zap.Error(err))
 			return "", nil
 		}
 	}
 	if id == "" {
-		db.logger.Warn("got empty machine id")
+		db.logger.Debug("got empty machine id")
 		return "", nil
 	}
 	return id, nil

--- a/pkg/platform/yaml/configdb/user/db.go
+++ b/pkg/platform/yaml/configdb/user/db.go
@@ -3,7 +3,6 @@ package user
 
 import (
 	"context"
-	"errors"
 	"os"
 	"runtime"
 
@@ -44,12 +43,13 @@ func (db *Db) GetInstallationID(_ context.Context) (string, error) {
 	} else {
 		id, err = machineid.ID()
 		if err != nil {
-			return "", errors.New("failed to get machine id")
+			db.logger.Warn("failed to get machine id", zap.Error(err))
+			return "", nil
 		}
 	}
 	if id == "" {
-		db.logger.Error("got empty machine id")
-		return "", errors.New("empty machine id")
+		db.logger.Warn("got empty machine id")
+		return "", nil
 	}
 	return id, nil
 }


### PR DESCRIPTION
Issue :  If machineId is not present in machine(docker containers/ Kubernetes) currently keploy stops execution
solution: Ignore machineId if not present.

