### PR TITLE
fix: added nil check for template

### DIFF
--- a/pkg/util.go
+++ b/pkg/util.go
@@ -102,12 +102,14 @@ func SimulateHTTP(ctx context.Context, tc *models.TestCase, testSet string, logg
 	if err != nil {
 		utils.LogError(logger, err, "failed to parse the template")
 	}
-	var output bytes.Buffer
-	err = tmpl.Execute(&output, utils.TemplatizedValues)
-	if err != nil {
-		utils.LogError(logger, err, "failed to execute the template")
+	if tmpl != nil {
+		var output bytes.Buffer
+		err = tmpl.Execute(&output, utils.TemplatizedValues)
+		if err != nil {
+			utils.LogError(logger, err, "failed to execute the template")
+		}
+		testCaseStr = output.Bytes()
 	}
-	testCaseStr = output.Bytes()
 	err = json.Unmarshal([]byte(testCaseStr), &tc)
 	if err != nil {
 		utils.LogError(logger, err, "failed to unmarshal the testcase")


### PR DESCRIPTION
## What does this PR do?
There was a nil pointer exception taking place at the point where the template is being rendered. Added a nil check for the template variable to prevent that.

## Related PRs and Issues

- (Info about Related PR or issue)

Closes: #[issue number that will be closed through this PR]

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] New and existing unit tests pass locally with my changes.
