### PR TITLE
fix: version problem in tele

### DIFF
--- a/cli/provider/service.go
+++ b/cli/provider/service.go
@@ -7,6 +7,7 @@ import (
 	"go.keploy.io/server/v2/config"
 	"go.keploy.io/server/v2/pkg/platform/telemetry"
 	"go.keploy.io/server/v2/pkg/service"
+	"go.keploy.io/server/v2/utils"
 
 	"go.keploy.io/server/v2/pkg/service/tools"
 	"go.keploy.io/server/v2/pkg/service/utgen"
@@ -33,7 +34,7 @@ func (n *ServiceProvider) GetService(ctx context.Context, cmd string) (interface
 
 	tel := telemetry.NewTelemetry(n.logger, telemetry.Options{
 		Enabled:        !n.cfg.DisableTele,
-		Version:        n.cfg.Version,
+		Version:        utils.Version,
 		GlobalMap:      TeleGlobalMap,
 		InstallationID: n.cfg.InstallationID,
 	})


### PR DESCRIPTION
## What does this PR do?
Taking the version from the utils package instead of the config

## Related PRs and Issues
Currently the version was coming empty because it was being taken from the config. Now taking it directly from utils so it will never be empty.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:
- [ ] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] New and existing unit tests pass locally with my changes.
