### PR TITLE
fix: handle eof in case of COM_QUIT

### DIFF
--- a/pkg/core/proxy/integrations/mysql/recorder/query.go
+++ b/pkg/core/proxy/integrations/mysql/recorder/query.go
@@ -71,6 +71,10 @@ func handleClientQueries(ctx context.Context, logger *zap.Logger, clientConn, de
 
 			commandRespPkt, err := handleQueryResponse(ctx, logger, clientConn, destConn, decodeCtx)
 			if err != nil {
+				if err == io.EOF && commandPkt.Header.Type == mysql.CommandStatusToString(mysql.COM_QUIT) {
+					logger.Debug("server closed the connection without any response")
+					return err
+				}
 				utils.LogError(logger, err, "failed to handle the query response")
 				return err
 			}

--- a/pkg/core/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/core/proxy/integrations/mysql/replayer/match.go
@@ -186,7 +186,10 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 					matchCount := matchQuitPacket(ctx, logger, mockReq.PacketBundle, req.PacketBundle)
 					if matchCount > maxMatchedCount {
 						maxMatchedCount = matchCount
-						matchedResp = &mock.Spec.MySQLResponses[0]
+						matchedResp = &mysql.Response{} // in case if server closed the connection without sending any response
+						if len(mock.Spec.MySQLResponses) > 0 {
+							matchedResp = &mock.Spec.MySQLResponses[0] // if server responded with "error" packet
+						}
 						matchedMock = mock
 					}
 				case mysql.CommandStatusToString(mysql.COM_INIT_DB):

--- a/pkg/core/proxy/integrations/mysql/wire/util.go
+++ b/pkg/core/proxy/integrations/mysql/wire/util.go
@@ -102,7 +102,8 @@ func GetCachingSha2PasswordMechanism(data byte) (string, error) {
 	case byte(mysql.FastAuthSuccess):
 		return mysql.CachingSha2PasswordToString(mysql.FastAuthSuccess), nil
 	default:
-		return "", fmt.Errorf("invalid caching_sha2_password mechanism")
+		einval := fmt.Sprintf("invalid caching_sha2_password mechanism, found:%02x ", data)
+		return "", fmt.Errorf(einval)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

- This PR fixes the issue when during record mode, in response to `COM_QUIT` packet server doesn't send a response and closes the connection.

## Related PRs and Issues

- (Info about Related PR or issue)

Closes: #[issue number that will be closed through this PR]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know test plan followed

Please describe the tests(if any). Provide instructions how its affecting the coverage.

## Checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] New and existing unit tests pass locally with my changes.
