### PR TITLE
fix: handling of authSwitchReq during auth mechanism switch

### DIFF
--- a/pkg/core/proxy/integrations/mysql/replayer/conn.go
+++ b/pkg/core/proxy/integrations/mysql/replayer/conn.go
@@ -16,6 +16,11 @@ import (
 	"go.uber.org/zap"
 )
 
+type reqResp struct {
+	req  []mysql.Request
+	resp []mysql.Response
+}
+
 // Replay mode
 func simulateInitialHandshake(ctx context.Context, logger *zap.Logger, clientConn net.Conn, mocks []*models.Mock, mockDb integrations.MockMemDb, decodeCtx *wire.DecodeContext) error {
 	// Get the mock for initial handshake
@@ -101,23 +106,120 @@ func simulateInitialHandshake(ctx context.Context, logger *zap.Logger, clientCon
 		return nil
 	}
 
+	// Get the next packet to decide the auth mechanism or auth switching
 	// For Native password: next packet is Ok/Err
-	// For CachingSha2 password: next packet is AuthSwitchRequest/AuthMoreData
+	// For CachingSha2 password: next packet is AuthMoreData
 
 	authDecider := resp[1].PacketBundle.Header.Type
 
+	var authSwitched bool
+
+	// Check if the next packet is AuthSwitchRequest
+	// Server sends AuthSwitchRequest when it wants to switch the auth mechanism
+	if authDecider == mysql.AuthStatusToString(mysql.AuthSwitchRequest) {
+		logger.Debug("Auth switch request found, switching the auth mechanism")
+		authSwitched = true
+
+		// Get the AuthSwitchRequest packet
+		authSwithReqPkt, ok := resp[1].Message.(*mysql.AuthSwitchRequestPacket)
+		if !ok {
+			utils.LogError(logger, nil, "failed to assert auth switch request packet")
+			return nil
+		}
+
+		// Change the auth plugin name
+		decodeCtx.PluginName = authSwithReqPkt.PluginName
+
+		// Encode the AuthSwitchRequest packet
+		buf, err = wire.EncodeToBinary(ctx, logger, &resp[1].PacketBundle, clientConn, decodeCtx)
+		if err != nil {
+			utils.LogError(logger, err, "failed to encode auth switch request packet")
+			return err
+		}
+
+		// Write the AuthSwitchRequest packet to the client
+		_, err = clientConn.Write(buf)
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			utils.LogError(logger, err, "failed to write auth switch request to the client")
+			return err
+		}
+
+		// Read the auth switch response from the client
+		authSwitchRespBuf, err := mysqlUtils.ReadPacketBuffer(ctx, logger, clientConn)
+		if err != nil {
+			utils.LogError(logger, err, "failed to read auth switch response from the client")
+			return err
+		}
+
+		// Get the packet from the buffer
+		authSwitchRespPkt, err := mysqlUtils.BytesToMySQLPacket(authSwitchRespBuf)
+		if err != nil {
+			utils.LogError(logger, err, "failed to convert auth switch response to packet")
+			return err
+		}
+
+		if len(req) < 2 {
+			utils.LogError(logger, nil, "no mysql mocks found for auth switch response")
+			return fmt.Errorf("no mysql mocks found for auth switch response")
+		}
+
+		// Get the auth switch response from the mock
+		authSwitchRespMock := req[1].PacketBundle
+
+		if authSwitchRespMock.Header.Type != mysql.AuthSwithResponse {
+			utils.LogError(logger, nil, "expected auth switch response mock not found", zap.Any("found", authSwitchRespMock.Header.Type))
+			return fmt.Errorf("expected %s but found %s", mysql.AuthSwithResponse, authSwitchRespMock.Header.Type)
+		}
+
+		// Since auth switch response data can be different, we should just check the sequence number
+		if authSwitchRespMock.Header.Header.SequenceID != authSwitchRespPkt.Header.SequenceID {
+			utils.LogError(logger, nil, "sequence number mismatch for auth switch response", zap.Any("expected", authSwitchRespMock.Header.Header.SequenceID), zap.Any("actual", authSwitchRespPkt.Header.SequenceID))
+			return fmt.Errorf("sequence number mismatch for auth switch response")
+		}
+
+		logger.Debug("auth mechanism switched successfully")
+
+		// Get the next packet to decide the auth mechanism
+		if len(resp) < 3 {
+			utils.LogError(logger, nil, "no mysql mocks found for auth mechanism after auth switch request")
+			return nil
+		}
+
+		authDecider = resp[2].PacketBundle.Header.Type
+	}
+
 	switch authDecider {
 	case mysql.StatusToString(mysql.OK):
+		var nativePassMocks reqResp
+		if authSwitched {
+			nativePassMocks.resp = resp[2:]
+		} else {
+			nativePassMocks.resp = resp[1:]
+		}
+
 		// It means we need to simulate the native password
-		err := simulateNativePassword(ctx, logger, clientConn, initialHandshakeMock, mockDb, decodeCtx)
+		err := simulateNativePassword(ctx, logger, clientConn, nativePassMocks, initialHandshakeMock, mockDb, decodeCtx)
 		if err != nil {
 			utils.LogError(logger, err, "failed to simulate native password")
 			return err
 		}
 
-	case mysql.AuthStatusToString(mysql.AuthSwitchRequest), mysql.AuthStatusToString(mysql.AuthMoreData):
+	case mysql.AuthStatusToString(mysql.AuthMoreData):
+
+		var cacheSha2PassMock reqResp
+		if authSwitched {
+			cacheSha2PassMock.req = req[2:]
+			cacheSha2PassMock.resp = resp[2:]
+		} else {
+			cacheSha2PassMock.req = req[1:]
+			cacheSha2PassMock.resp = resp[1:]
+		}
+
 		// It means we need to simulate the caching_sha2_password
-		err := simulateCacheSha2Password(ctx, logger, clientConn, initialHandshakeMock, mockDb, decodeCtx)
+		err := simulateCacheSha2Password(ctx, logger, clientConn, cacheSha2PassMock, initialHandshakeMock, mockDb, decodeCtx)
 		if err != nil {
 			utils.LogError(logger, err, "failed to simulate caching_sha2_password")
 			return err
@@ -127,13 +229,12 @@ func simulateInitialHandshake(ctx context.Context, logger *zap.Logger, clientCon
 	return nil
 }
 
-func simulateNativePassword(ctx context.Context, logger *zap.Logger, clientConn net.Conn, initialHandshakeMock *models.Mock, mockDb integrations.MockMemDb, decodeCtx *wire.DecodeContext) error {
-	resp := initialHandshakeMock.Spec.MySQLResponses
+func simulateNativePassword(ctx context.Context, logger *zap.Logger, clientConn net.Conn, nativePassMocks reqResp, initialHandshakeMock *models.Mock, mockDb integrations.MockMemDb, decodeCtx *wire.DecodeContext) error {
 
-	logger.Debug("final response for native password", zap.Any("response", resp[1].PacketBundle.Header.Type))
+	logger.Debug("final response for native password", zap.Any("response", nativePassMocks.resp[0].PacketBundle.Header.Type))
 
 	// Send the final response (OK/Err) to the client
-	buf, err := wire.EncodeToBinary(ctx, logger, &resp[1].PacketBundle, clientConn, decodeCtx)
+	buf, err := wire.EncodeToBinary(ctx, logger, &nativePassMocks.resp[0].PacketBundle, clientConn, decodeCtx)
 	if err != nil {
 		utils.LogError(logger, err, "failed to encode final response packet for native password")
 		return err
@@ -159,53 +260,36 @@ func simulateNativePassword(ctx context.Context, logger *zap.Logger, clientConn 
 	return nil
 }
 
-func simulateCacheSha2Password(ctx context.Context, logger *zap.Logger, clientConn net.Conn, initialHandshakeMock *models.Mock, mockDb integrations.MockMemDb, decodeCtx *wire.DecodeContext) error {
-	resp := initialHandshakeMock.Spec.MySQLResponses
+func simulateCacheSha2Password(ctx context.Context, logger *zap.Logger, clientConn net.Conn, cacheSha2PassMock reqResp, initialHandshakeMock *models.Mock, mockDb integrations.MockMemDb, decodeCtx *wire.DecodeContext) error {
+	resp := cacheSha2PassMock.resp
 
-	// Get the AuthMoreData or AuthSwitchRequest packet
-	if len(resp) < 2 {
-		utils.LogError(logger, nil, "no mysql mocks found for auth more data or auth switch request")
+	// Get the AuthMoreData
+	if len(resp) < 1 {
+		utils.LogError(logger, nil, "no mysql mocks found for auth more data")
 	}
 
-	// Get the AuthMore or AuthSwitchRequest packet
-	var authBuf []byte
-	var err error
-	var CachingSha2PasswordMechanism string
-
-	switch resp[1].Message.(type) {
-	case *mysql.AuthSwitchRequestPacket:
-		// Get the auth switch request packet
-		pkt, ok := resp[1].Message.(*mysql.AuthSwitchRequestPacket)
-		if !ok {
-			utils.LogError(logger, nil, "failed to assert auth switch request packet")
-			return nil
-		}
-
-		CachingSha2PasswordMechanism = pkt.PluginData
-
-		authBuf, err = wire.EncodeToBinary(ctx, logger, &resp[1].PacketBundle, clientConn, decodeCtx)
-		if err != nil {
-			utils.LogError(logger, err, "failed to encode auth switch request packet")
-			return err
-		}
-	case *mysql.AuthMoreDataPacket:
-		// Get the auth more data packet
-		pkt, ok := resp[1].Message.(*mysql.AuthMoreDataPacket)
-		if !ok {
-			utils.LogError(logger, nil, "failed to assert auth more data packet")
-			return nil
-		}
-
-		CachingSha2PasswordMechanism = pkt.Data
-
-		authBuf, err = wire.EncodeToBinary(ctx, logger, &resp[1].PacketBundle, clientConn, decodeCtx)
-		if err != nil {
-			utils.LogError(logger, err, "failed to encode auth more data packet")
-			return err
-		}
+	//check if the response is of type AuthMoreData
+	if _, ok := resp[0].Message.(*mysql.AuthMoreDataPacket); !ok {
+		utils.LogError(logger, nil, "failed to assert auth more data packet")
+		return fmt.Errorf("failed to get auth more data packet, expected %T but got %T", mysql.AuthMoreDataPacket{}, resp[0].Message)
 	}
 
-	// Write the AuthMoreData or AuthSwitchRequest packet to the client
+	// Get the auth more data packet
+	pkt, ok := resp[0].Message.(*mysql.AuthMoreDataPacket)
+	if !ok {
+		utils.LogError(logger, nil, "failed to assert auth more data packet")
+		return nil
+	}
+
+	CachingSha2PasswordMechanism := pkt.Data
+
+	authBuf, err := wire.EncodeToBinary(ctx, logger, &resp[0].PacketBundle, clientConn, decodeCtx)
+	if err != nil {
+		utils.LogError(logger, err, "failed to encode auth more data packet")
+		return err
+	}
+
+	// Write the AuthMoreData packet to the client
 	_, err = clientConn.Write(authBuf)
 	if err != nil {
 		if ctx.Err() != nil {
@@ -215,16 +299,24 @@ func simulateCacheSha2Password(ctx context.Context, logger *zap.Logger, clientCo
 		return err
 	}
 
+	if len(cacheSha2PassMock.resp) < 2 {
+		utils.LogError(logger, nil, "response mock not found for caching_sha2_password after auth more data")
+		return fmt.Errorf("response mock not found for caching_sha2_password after auth more data")
+	}
+
+	//update the cacheSha2PassMock resp
+	cacheSha2PassMock.resp = cacheSha2PassMock.resp[1:]
+
 	//simulate the caching_sha2_password auth mechanism
 	switch CachingSha2PasswordMechanism {
 	case mysql.CachingSha2PasswordToString(mysql.PerformFullAuthentication):
-		err := simulateFullAuth(ctx, logger, clientConn, initialHandshakeMock, mockDb, decodeCtx)
+		err := simulateFullAuth(ctx, logger, clientConn, cacheSha2PassMock, initialHandshakeMock, mockDb, decodeCtx)
 		if err != nil {
 			utils.LogError(logger, err, "failed to simulate full auth")
 			return err
 		}
 	case mysql.CachingSha2PasswordToString(mysql.FastAuthSuccess):
-		err := simulateFastAuthSuccess(ctx, logger, clientConn, initialHandshakeMock, mockDb, decodeCtx)
+		err := simulateFastAuthSuccess(ctx, logger, clientConn, cacheSha2PassMock, initialHandshakeMock, mockDb, decodeCtx)
 		if err != nil {
 			utils.LogError(logger, err, "failed to simulate fast auth success")
 			return err
@@ -233,18 +325,18 @@ func simulateCacheSha2Password(ctx context.Context, logger *zap.Logger, clientCo
 	return nil
 }
 
-func simulateFastAuthSuccess(ctx context.Context, logger *zap.Logger, clientConn net.Conn, initialHandshakeMock *models.Mock, mockDb integrations.MockMemDb, decodeCtx *wire.DecodeContext) error {
-	resp := initialHandshakeMock.Spec.MySQLResponses
+func simulateFastAuthSuccess(ctx context.Context, logger *zap.Logger, clientConn net.Conn, fastAuthMocks reqResp, initialHandshakeMock *models.Mock, mockDb integrations.MockMemDb, decodeCtx *wire.DecodeContext) error {
+	resp := fastAuthMocks.resp
 
-	if len(resp) < 3 {
+	if len(resp) < 1 {
 		utils.LogError(logger, nil, "final response mock not found for fast auth success")
 		return fmt.Errorf("final response mock not found for fast auth success")
 	}
 
-	logger.Debug("final response for fast auth success", zap.Any("response", resp[2].PacketBundle.Header.Type))
+	logger.Debug("final response for fast auth success", zap.Any("response", resp[0].PacketBundle.Header.Type))
 
 	// Send the final response (OK/Err) to the client
-	buf, err := wire.EncodeToBinary(ctx, logger, &resp[2].PacketBundle, clientConn, decodeCtx)
+	buf, err := wire.EncodeToBinary(ctx, logger, &resp[0].PacketBundle, clientConn, decodeCtx)
 	if err != nil {
 		utils.LogError(logger, err, "failed to encode final response packet for fast auth success")
 		return err
@@ -271,10 +363,10 @@ func simulateFastAuthSuccess(ctx context.Context, logger *zap.Logger, clientConn
 	return nil
 }
 
-func simulateFullAuth(ctx context.Context, logger *zap.Logger, clientConn net.Conn, initialHandshakeMock *models.Mock, mockDb integrations.MockMemDb, decodeCtx *wire.DecodeContext) error {
+func simulateFullAuth(ctx context.Context, logger *zap.Logger, clientConn net.Conn, fullAuthMocks reqResp, initialHandshakeMock *models.Mock, mockDb integrations.MockMemDb, decodeCtx *wire.DecodeContext) error {
 
-	resp := initialHandshakeMock.Spec.MySQLResponses
-	req := initialHandshakeMock.Spec.MySQLRequests
+	resp := fullAuthMocks.resp
+	req := fullAuthMocks.req
 
 	// read the public key request from the client
 	publicKeyRequestBuf, err := mysqlUtils.ReadPacketBuffer(ctx, logger, clientConn)
@@ -297,21 +389,21 @@ func simulateFullAuth(ctx context.Context, logger *zap.Logger, clientConn net.Co
 	}
 
 	// Get the public key response from the mock
-	if len(req) < 2 {
+	if len(req) < 1 {
 		utils.LogError(logger, nil, "no mysql mocks found for public key response")
 		return fmt.Errorf("no mysql mocks found for public key response")
 	}
 
-	publicKeyMock, ok := req[1].Message.(string)
+	publicKeyMock, ok := req[0].Message.(string)
 	if !ok {
 		utils.LogError(logger, nil, "failed to assert public key response packet")
 		return nil
 	}
 
 	// Match the header of the public key request
-	ok = matchHeader(*req[1].PacketBundle.Header.Header, *pkt.Header.Header)
+	ok = matchHeader(*req[0].PacketBundle.Header.Header, *pkt.Header.Header)
 	if !ok {
-		utils.LogError(logger, nil, "header mismatch for public key request", zap.Any("expected", req[1].PacketBundle.Header.Header), zap.Any("actual", pkt.Header.Header))
+		utils.LogError(logger, nil, "header mismatch for public key request", zap.Any("expected", req[0].PacketBundle.Header.Header), zap.Any("actual", pkt.Header.Header))
 		return nil
 	}
 
@@ -322,20 +414,20 @@ func simulateFullAuth(ctx context.Context, logger *zap.Logger, clientConn net.Co
 	}
 
 	// Get the AuthMoreData for sending the public key
-	if len(resp) < 3 {
+	if len(resp) < 1 {
 		utils.LogError(logger, nil, "no mysql mocks found for auth more data (public key)")
 		return fmt.Errorf("no mysql mocks found for auth more data (public key)")
 	}
 
 	// Get the AuthMoreData packet
-	_, ok = resp[2].PacketBundle.Message.(*mysql.AuthMoreDataPacket)
+	_, ok = resp[0].PacketBundle.Message.(*mysql.AuthMoreDataPacket)
 	if !ok {
 		utils.LogError(logger, nil, "failed to assert auth more data packet (public key)")
 		return nil
 	}
 
 	// encode the public key response
-	buf, err := wire.EncodeToBinary(ctx, logger, &resp[2].PacketBundle, clientConn, decodeCtx)
+	buf, err := wire.EncodeToBinary(ctx, logger, &resp[0].PacketBundle, clientConn, decodeCtx)
 	if err != nil {
 		utils.LogError(logger, err, "failed to encode public key response packet")
 		return err
@@ -366,13 +458,13 @@ func simulateFullAuth(ctx context.Context, logger *zap.Logger, clientConn net.Co
 		return err
 	}
 
-	if len(req) < 3 {
+	if len(req) < 2 {
 		utils.LogError(logger, nil, "no mysql mocks found for encrypted password during full auth")
 		return fmt.Errorf("no mysql mocks found for encrypted password during full auth")
 	}
 
 	// Get the encrypted password from the mock
-	encryptedPassMock := req[2].PacketBundle
+	encryptedPassMock := req[1].PacketBundle
 
 	if encryptedPassMock.Header.Type != mysql.EncryptedPassword {
 		utils.LogError(logger, nil, "expected encrypted password mock not found", zap.Any("found", encryptedPassMock.Header.Type))
@@ -386,16 +478,16 @@ func simulateFullAuth(ctx context.Context, logger *zap.Logger, clientConn net.Co
 	}
 
 	//Now send the final response (OK/Err) to the client
-	if len(resp) < 4 {
+	if len(resp) < 2 {
 		utils.LogError(logger, nil, "final response mock not found for full auth")
 		return fmt.Errorf("final response mock not found for full auth")
 	}
 
-	logger.Debug("final response for full auth", zap.Any("response", resp[3].PacketBundle.Header.Type))
+	logger.Debug("final response for full auth", zap.Any("response", resp[1].PacketBundle.Header.Type))
 
 	// Get the final response (OK/Err) from the mock
 	// Send the final response (OK/Err) to the client
-	buf, err = wire.EncodeToBinary(ctx, logger, &resp[3].PacketBundle, clientConn, decodeCtx)
+	buf, err = wire.EncodeToBinary(ctx, logger, &resp[1].PacketBundle, clientConn, decodeCtx)
 	if err != nil {
 		utils.LogError(logger, err, "failed to encode final response packet for full auth")
 		return err

--- a/pkg/core/proxy/integrations/mysql/wire/phase/conn/authSwitchResponsePacket.go
+++ b/pkg/core/proxy/integrations/mysql/wire/phase/conn/authSwitchResponsePacket.go
@@ -5,6 +5,7 @@ package conn
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"errors"
 
 	"go.keploy.io/server/v2/pkg/models/mysql"
@@ -14,7 +15,7 @@ import (
 
 func DecodeAuthSwitchResponse(_ context.Context, data []byte) (*mysql.AuthSwitchResponsePacket, error) {
 	return &mysql.AuthSwitchResponsePacket{
-		Data: string(data),
+		Data: base64.StdEncoding.EncodeToString(data),
 	}, nil
 }
 

--- a/pkg/core/proxy/integrations/mysql/wire/util.go
+++ b/pkg/core/proxy/integrations/mysql/wire/util.go
@@ -114,7 +114,8 @@ func StringToCachingSha2PasswordMechanism(data string) (mysql.CachingSha2Passwor
 	case "FastAuthSuccess":
 		return mysql.FastAuthSuccess, nil
 	default:
-		return 0, fmt.Errorf("invalid caching_sha2_password mechanism")
+		einval := fmt.Sprintf("invalid caching_sha2_password mechanism, found:%s ", data)
+		return 0, fmt.Errorf(einval)
 	}
 }
 

--- a/pkg/models/mysql/const.go
+++ b/pkg/models/mysql/const.go
@@ -40,6 +40,7 @@ const (
 // Some constants for MySQL
 const (
 	EncryptedPassword = "encrypted_password"
+	AuthSwithResponse = "AuthSwitchResponse"
 )
 
 // CachingSha2Password constants


### PR DESCRIPTION
## What does this PR do?
- This PR adds a fix for handling `AuthSwitchRequest` in the MySQL parser when server wants to switch the auth mechanism after a disagreement with the client default mechanism. 

## Related PRs and Issues

- https://github.com/keploy/keploy/issues/2268

Closes: #[issue number that will be closed through this PR]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know test plan followed

Please describe the tests(if any). Provide instructions how its affecting the coverage.

## Checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] New and existing unit tests pass locally with my changes.
