### PR TITLE
fix: matching of handshakeResponse in mysql

### DIFF
--- a/pkg/core/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/core/proxy/integrations/mysql/replayer/match.go
@@ -49,10 +49,10 @@ func matchHanshakeResponse41(_ context.Context, _ *zap.Logger, expected, actual 
 	exp := expected.Message.(*mysql.HandshakeResponse41Packet)
 	act := actual.Message.(*mysql.HandshakeResponse41Packet)
 
-	// Match the CapabilityFlags
-	if exp.CapabilityFlags != act.CapabilityFlags {
-		return fmt.Errorf("capability flags mismatch for handshake response, expected: %d, actual: %d", exp.CapabilityFlags, act.CapabilityFlags)
-	}
+	// // Match the CapabilityFlags
+	// if exp.CapabilityFlags != act.CapabilityFlags {
+	// 	return fmt.Errorf("capability flags mismatch for handshake response, expected: %d, actual: %d", exp.CapabilityFlags, act.CapabilityFlags)
+	// }
 
 	// Match the MaxPacketSize
 	if exp.MaxPacketSize != act.MaxPacketSize {
@@ -89,16 +89,16 @@ func matchHanshakeResponse41(_ context.Context, _ *zap.Logger, expected, actual 
 		return fmt.Errorf("auth plugin name mismatch for handshake response, expected: %s, actual: %s", exp.AuthPluginName, act.AuthPluginName)
 	}
 
-	// Match the ConnectionAttributes
-	if len(exp.ConnectionAttributes) != len(act.ConnectionAttributes) {
-		return fmt.Errorf("connection attributes length mismatch for handshake response, expected: %d, actual: %d", len(exp.ConnectionAttributes), len(act.ConnectionAttributes))
-	}
+	// // Match the ConnectionAttributes
+	// if len(exp.ConnectionAttributes) != len(act.ConnectionAttributes) {
+	// 	return fmt.Errorf("connection attributes length mismatch for handshake response, expected: %d, actual: %d", len(exp.ConnectionAttributes), len(act.ConnectionAttributes))
+	// }
 
-	for key, value := range exp.ConnectionAttributes {
-		if act.ConnectionAttributes[key] != value && key != "_pid" {
-			return fmt.Errorf("connection attributes mismatch for handshake response, expected: %s, actual: %s", value, act.ConnectionAttributes[key])
-		}
-	}
+	// for key, value := range exp.ConnectionAttributes {
+	// 	if act.ConnectionAttributes[key] != value && key != "_pid" {
+	// 		return fmt.Errorf("connection attributes mismatch for handshake response, expected: %s, actual: %s", value, act.ConnectionAttributes[key])
+	// 	}
+	// }
 
 	// Match the ZstdCompressionLevel
 	if exp.ZstdCompressionLevel != act.ZstdCompressionLevel {


### PR DESCRIPTION
## What does this PR do?

- This PR fixes the matching logic of `HandshakeResponse41` packet in MySQL parser

## Related PRs and Issues

- (Info about Related PR or issue)

Closes: #[issue number that will be closed through this PR]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know test plan followed

Please describe the tests(if any). Provide instructions how its affecting the coverage.

## Checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] New and existing unit tests pass locally with my changes.
