### PR TITLE
feat: add support for legacy mongo protocol

### DIFF
--- a/pkg/core/proxy/integrations/mongo/decode.go
+++ b/pkg/core/proxy/integrations/mongo/decode.go
@@ -202,11 +202,14 @@ func decodeMongo(ctx context.Context, logger *zap.Logger, reqBuf []byte, clientC
 							}
 						}
 					}
-					matchedMock := *configMocks[bestMatchIndex]
-					matchedMock.TestModeInfo.SortOrder = math.MaxInt
-					isUpdated := mockDb.UpdateUnFilteredMock(configMocks[bestMatchIndex], &matchedMock)
-					if !isUpdated {
-						continue
+
+					if bestMatchIndex != -1 && maxMatchScore != 0.0 {
+						matchedMock := *configMocks[bestMatchIndex]
+						matchedMock.TestModeInfo.SortOrder = math.MaxInt
+						isUpdated := mockDb.UpdateUnFilteredMock(configMocks[bestMatchIndex], &matchedMock)
+						if !isUpdated {
+							continue
+						}
 					}
 					break
 				}

--- a/pkg/core/proxy/integrations/mongo/decode.go
+++ b/pkg/core/proxy/integrations/mongo/decode.go
@@ -207,9 +207,8 @@ func decodeMongo(ctx context.Context, logger *zap.Logger, reqBuf []byte, clientC
 					isUpdated := mockDb.UpdateUnFilteredMock(configMocks[bestMatchIndex], &matchedMock)
 					if !isUpdated {
 						continue
-					} else {
-						break
 					}
+					break
 				}
 
 				responseTo := mongoRequests[0].Header.RequestID

--- a/pkg/core/proxy/integrations/mongo/operation.go
+++ b/pkg/core/proxy/integrations/mongo/operation.go
@@ -478,7 +478,7 @@ func extractSectionSingle(data string) (string, error) {
 	return content, nil
 }
 
-func processOpReply(expectedRequest, actualRequest models.MongoRequest, expectedResponse *models.MongoOpReply, logger *zap.Logger) (string, bool) {
+func processOpReply(expectedRequest, actualRequest models.MongoRequest, expectedResponse *models.MongoOpReply, mongoPassword string, logger *zap.Logger) (string, bool) {
 	if len(expectedResponse.Documents) == 0 {
 		return "", false
 	}
@@ -489,30 +489,21 @@ func processOpReply(expectedRequest, actualRequest models.MongoRequest, expected
 			logger.Error("Failed to unmarshal JSON document of OpReply", zap.Error(err))
 			return "", false
 		}
+
 		// Extract and decode the payload from the actual MongoDB request
 		responseMsgData, ok := responseMsg["speculativeAuthenticate"].(map[string]interface{})
 		if !ok {
-			logger.Debug("failed to extract payload from response data", zap.Any("responseMsgData", responseMsg))
-			continue
+			_, ok = responseMsg["payload"].(map[string]interface{})
+			if !ok {
+				logger.Debug("failed to extract payload from response data", zap.Any("responseMsg", responseMsg))
+				continue
+			}
+			responseMsgData = responseMsg
 		}
-		resPayload, err := extractAuthPayload(responseMsgData)
-		if err != nil {
-			logger.Debug("Failed to fetch the payload from the received MongoDB response", zap.Error(err))
-			continue
-		}
-		logger.Debug(fmt.Sprintf("Payload of the received response: %s", resPayload))
-
-		decodedResPayload, err := decodeBase64Str(resPayload)
-		if err != nil {
-			logger.Error("Error decoding the received payload base64 string", zap.Error(err))
-			return "", false
-		}
-		logger.Debug(fmt.Sprintf("Decoded payload of the actual for the SASLStart: %s", string(decodedResPayload)))
 
 		// Extract and decode the expected MongoDB request payload
 		expectedrequestPayload := expectedRequest.Message.(*models.MongoOpQuery).Query // Assuming the query is the payload
 		var expectedrequestPayloadMap map[string]interface{}
-
 		err = json.Unmarshal([]byte(expectedrequestPayload), &expectedrequestPayloadMap)
 		if err != nil {
 			utils.LogError(logger, err, "failed to unmarshal request payload into map")
@@ -520,22 +511,13 @@ func processOpReply(expectedRequest, actualRequest models.MongoRequest, expected
 		}
 		expectedRequest, ok := expectedrequestPayloadMap["speculativeAuthenticate"].(map[string]interface{})
 		if !ok {
-			logger.Debug("failed to extract payload from expected request data", zap.Any("expectedRequest", expectedRequest))
-			continue
+			_, ok = expectedrequestPayloadMap["payload"].(map[string]interface{})
+			if !ok {
+				logger.Debug("failed to extract payload from response data", zap.Any("responseMsg", responseMsg))
+				continue
+			}
+			expectedRequest = expectedrequestPayloadMap
 		}
-		expectedPayload, err := extractAuthPayload(expectedRequest)
-		if err != nil {
-			logger.Debug("Failed to fetch the payload from the expected MongoDB request", zap.Error(err))
-			continue
-		}
-		logger.Debug(fmt.Sprintf("Payload of the expected request: %s", expectedPayload))
-
-		decodedExpPayload, err := decodeBase64Str(expectedPayload)
-		if err != nil {
-			logger.Error("Error decoding the expected request payload base64 string", zap.Error(err))
-			return "", false
-		}
-		logger.Debug(fmt.Sprintf("Decoded payload of the expected for the SASLStart: %s", string(decodedExpPayload)))
 
 		actualRequestPayload := actualRequest.Message.(*models.MongoOpQuery).Query // Assuming the query is the payload
 		var actualRequestPayloadMap map[string]interface{}
@@ -547,58 +529,185 @@ func processOpReply(expectedRequest, actualRequest models.MongoRequest, expected
 
 		actualRequest, ok := actualRequestPayloadMap["speculativeAuthenticate"].(map[string]interface{})
 		if !ok {
-			logger.Debug("failed to extract payload from actual request data", zap.Any("expectedRequest", expectedRequest))
-			continue
+			_, ok = actualRequestPayloadMap["payload"].(map[string]interface{})
+			if !ok {
+				logger.Debug("failed to extract payload from response data", zap.Any("responseMsg", responseMsg))
+				continue
+			}
+			actualRequest = actualRequestPayloadMap
 		}
 
-		actualReqPayload, err := extractAuthPayload(actualRequest)
-		if err != nil {
-			logger.Debug("Failed to extract the payload from the actual MongoDB request", zap.Error(err))
-			continue
-		}
-		// Extract and decode the payload from the actual MongoDB request
-		decodedReqPayload, err := decodeBase64Str(actualReqPayload)
-		if err != nil {
-			logger.Error("Failed to fetch the payload from the actual MongoDB request", zap.Error(err))
-			return "", false
-		}
-		logger.Debug(fmt.Sprintf("Payload of the actual request: %s", decodedReqPayload))
-
-		newFirstAuthResponse, err := scram.GenerateServerFirstMessage(decodedExpPayload, decodedReqPayload, decodedResPayload, logger)
-		if err != nil {
-			return "", false
-		}
-		logger.Debug("After replacing the new client nonce in auth response", zap.String("first response", newFirstAuthResponse))
-
-		conversationID, err := extractConversationID(responseMsgData)
-		if err != nil {
-			logger.Error("Failed to fetch the conversationId for the SCRAM auth from the recorded first response", zap.Error(err))
-			return "", false
-		}
-
-		// Generate the auth message from the received first request and recorded first response
-		authMessage := scram.GenerateAuthMessage(string(decodedReqPayload), newFirstAuthResponse, logger)
-		if authMessage == "" {
-			err := errors.New("failed to generate auth message")
-			logger.Error("Auth message generation failed", zap.Error(err))
-			return "", false
-		}
-		authMechanism, ok := actualRequest["mechanism"].(string)
+		_, ok = actualRequest["saslStart"]
 		if !ok {
-			logger.Debug("failed to auth mechanism from expected request data", zap.Any("expectedRequest", actualRequest))
-			continue
+			logger.Debug("failed to extract saslStart from response data", zap.Any("responseMsgData", responseMsgData))
+		} else {
+			resPayload, err := extractAuthPayload(responseMsgData)
+			if err != nil {
+				logger.Debug("Failed to fetch the payload from the received MongoDB response", zap.Error(err))
+				continue
+			}
+			logger.Debug(fmt.Sprintf("Payload of the received response: %s", resPayload))
+
+			decodedResPayload, err := decodeBase64Str(resPayload)
+			if err != nil {
+				logger.Error("Error decoding the received payload base64 string", zap.Error(err))
+				return "", false
+			}
+			logger.Debug(fmt.Sprintf("Decoded payload of the actual for the SASLStart: %s", string(decodedResPayload)))
+
+			expectedPayload, err := extractAuthPayload(expectedRequest)
+			if err != nil {
+				logger.Debug("Failed to fetch the payload from the expected MongoDB request", zap.Error(err))
+				continue
+			}
+			logger.Debug(fmt.Sprintf("Payload of the expected request: %s", expectedPayload))
+
+			decodedExpPayload, err := decodeBase64Str(expectedPayload)
+			if err != nil {
+				logger.Error("Error decoding the expected request payload base64 string", zap.Error(err))
+				return "", false
+			}
+			logger.Debug(fmt.Sprintf("Decoded payload of the expected for the SASLStart: %s", string(decodedExpPayload)))
+
+			actualReqPayload, err := extractAuthPayload(actualRequest)
+			if err != nil {
+				logger.Debug("Failed to extract the payload from the actual MongoDB request", zap.Error(err))
+				continue
+			}
+			// Extract and decode the payload from the actual MongoDB request
+			decodedReqPayload, err := decodeBase64Str(actualReqPayload)
+			if err != nil {
+				logger.Error("Failed to fetch the payload from the actual MongoDB request", zap.Error(err))
+				return "", false
+			}
+			logger.Debug(fmt.Sprintf("Payload of the actual request: %s", decodedReqPayload))
+
+			newFirstAuthResponse, err := scram.GenerateServerFirstMessage(decodedExpPayload, decodedReqPayload, decodedResPayload, logger)
+			if err != nil {
+				return "", false
+			}
+			logger.Debug("After replacing the new client nonce in auth response", zap.String("first response", newFirstAuthResponse))
+
+			conversationID, err := extractConversationID(responseMsgData)
+			if err != nil {
+				logger.Error("Failed to fetch the conversationId for the SCRAM auth from the recorded first response", zap.Error(err))
+				return "", false
+			}
+
+			// Generate the auth message from the received first request and recorded first response
+			authMessage := scram.GenerateAuthMessage(string(decodedReqPayload), newFirstAuthResponse, logger)
+			if authMessage == "" {
+				err := errors.New("failed to generate auth message")
+				logger.Error("Auth message generation failed", zap.Error(err))
+				return "", false
+			}
+			authMechanism, ok := actualRequest["mechanism"].(string)
+			if !ok {
+				logger.Debug("failed to auth mechanism from expected request data", zap.Any("expectedRequest", actualRequest))
+				continue
+			}
+			if authMechanism != util.SCRAM_SHA_1 && authMechanism != util.SCRAM_SHA_256 {
+				logger.Error("Invalid authentication mechanism", zap.String("authMechanism", authMechanism))
+				return "", false
+			}
+			authMessage = authMessage + ",auth=" + authMechanism
+			authMessageMap.Store(conversationID, authMessage)
+			// Marshal the new first response for the SCRAM authentication
+			authResponse := base64.StdEncoding.EncodeToString([]byte(newFirstAuthResponse))
+			if authResponse != "" {
+				return authResponse, true
+			}
+
 		}
-		if authMechanism != util.SCRAM_SHA_1 && authMechanism != util.SCRAM_SHA_256 {
-			logger.Error("Invalid authentication mechanism", zap.String("authMechanism", authMechanism))
-			return "", false
+
+		_, ok = actualRequest["saslContinue"]
+		if !ok {
+			logger.Debug("failed to extract saslContinue from response data", zap.Any("responseMsgData", responseMsgData))
+		} else {
+			responsePayload, err := extractAuthPayload(responseMsgData)
+			if err != nil {
+				utils.LogError(logger, err, "failed to fetch the payload from the recorded mongo response")
+				return "", false
+			}
+			logger.Debug(fmt.Sprint("the payload of the recorded second response of SCRAM: ", responsePayload))
+
+			decodedResponsePayload, err := decodeBase64Str(responsePayload)
+			if err != nil {
+				utils.LogError(logger, err, "Error decoding the recorded saslContinue response payload base64 string")
+				return "", false
+			}
+			logger.Debug(fmt.Sprint("the decoded payload of the repsonse for the saslContinue: ", (string)(decodedResponsePayload)))
+
+			fields := strings.Split(string(decodedResponsePayload), ",")
+			verifier, err := parseFieldBase64(fields[0], "v")
+			if err != nil {
+				logger.Debug("failed to parse the verifier of final response message", zap.Any("parsing error", err.Error()))
+				return "", false
+			}
+			logger.Debug("the recorded verifier of the auth request", zap.Any("verifier/server-signature", string(verifier)))
+
+			// fetch the conversation id
+			conversationID, err := extractConversationID(actualRequest)
+			if err != nil {
+				utils.LogError(logger, err, "failed to fetch the conversationId for the SCRAM auth from the recieved final response")
+				return "", false
+			}
+			logger.Debug("fetched conversationId for the SCRAM authentication", zap.String("cid", conversationID))
+
+			salt := ""
+			itr := 0
+			authType := ""
+			// get the authMessage from the saslStart conversation. Since, saslContinue have the same conversationId
+			// authMsg := authMessageMap[conversationID]
+			authMessage, ok := authMessageMap.Load(conversationID)
+			authMessageStr := ""
+			if ok {
+				authMessageStr = authMessage.(string)
+			}
+
+			// get the salt and iteration from the authMessage to generate salted password
+			fields = strings.Split(authMessageStr, ",")
+			filteredFields := []string{}
+			for _, part := range fields {
+				if strings.HasPrefix(part, "s=") {
+					// Split based on "=" and get the value of "s"
+					saltByt, err := decodeBase64Str(strings.TrimPrefix(part, "s="))
+					if err != nil {
+						utils.LogError(logger, err, "failed to decode the base64 string of salt")
+						return "", false
+					}
+					salt = string(saltByt)
+				}
+				if strings.HasPrefix(part, "i=") {
+					// Split based on "=" and get the value of "i"
+					itr, err = strconv.Atoi(strings.Split(part, "=")[1])
+					if err != nil {
+						utils.LogError(logger, err, "failed to convert the string into integer")
+						return "", false
+					}
+				}
+				if strings.HasPrefix(part, "auth=") {
+					// Only add fields that are not prefixed with "auth="
+					authType = strings.Split(part, "=")[1]
+					if err != nil {
+						utils.LogError(logger, err, "failed to convert the string into integer")
+						return "", false
+					}
+				} else {
+					filteredFields = append(filteredFields, part)
+				}
+			}
+			authMessageStr = strings.Join(filteredFields, ",")
+			// Since, the server proof is the signature generated by the authMessage and salted password.
+			// So, need to return the new server proof according to the new authMessage which is different from the recorded.
+			newVerifier, err := scram.GenerateServerFinalMessage(authMessageStr, authType, mongoPassword, salt, itr, logger)
+			if err != nil {
+				utils.LogError(logger, err, "failed to get the new server proof")
+				return "", false
+			}
+			return base64.StdEncoding.EncodeToString([]byte("v=" + newVerifier)), true
 		}
-		authMessage = authMessage + ",auth=" + authMechanism
-		authMessageMap.Store(conversationID, authMessage)
-		// Marshal the new first response for the SCRAM authentication
-		authResponse := base64.StdEncoding.EncodeToString([]byte(newFirstAuthResponse))
-		if authResponse != "" {
-			return authResponse, true
-		}
+
 	}
 
 	return "", false
@@ -863,9 +972,10 @@ func (r *opReply) TransactionDetails() *TransactionDetails {
 	return nil
 }
 
-func encodeOpReply(actualRequest models.MongoRequest, expectedRequest models.MongoRequest, expectedResponse *models.MongoOpReply, logger *zap.Logger) (*opReply, error) {
+func encodeOpReply(actualRequest models.MongoRequest, expectedRequest models.MongoRequest, expectedResponse *models.MongoOpReply, mongoPassword string, logger *zap.Logger) (*opReply, error) {
+
 	replyDocs := []bsoncore.Document{}
-	updatedFirstResponse, isResponseUpdated := processOpReply(expectedRequest, actualRequest, expectedResponse, logger)
+	updatedFirstResponse, isResponseUpdated := processOpReply(expectedRequest, actualRequest, expectedResponse, mongoPassword, logger)
 	for _, v := range expectedResponse.Documents {
 		var unmarshaledDoc bsoncore.Document
 		logger.Debug(fmt.Sprintf("the document string is: %v", string(v)))
@@ -877,16 +987,31 @@ func encodeOpReply(actualRequest models.MongoRequest, expectedRequest models.Mon
 			return nil, err
 		}
 		// set the fields for handshake calls at test mode
-		result["localTime"].(map[string]interface{})["$date"].(map[string]interface{})["$numberLong"] = strconv.FormatInt(time.Now().Unix(), 10)
+		localTime, ok := result["localTime"].(map[string]interface{})
+		if ok {
+			localTime["$date"].(map[string]interface{})["$numberLong"] = strconv.FormatInt(time.Now().Unix(), 10)
+			logger.Debug(fmt.Sprintf("the updated document string is: %v", result["localTime"].(map[string]interface{})["$date"].(map[string]interface{})["$numberLong"]))
+		}
 		if isResponseUpdated {
-			result["speculativeAuthenticate"].(map[string]interface{})["payload"].(map[string]interface{})["$binary"].(map[string]interface{})["base64"] = updatedFirstResponse
+			// add checks
+			query, ok := result["speculativeAuthenticate"].(map[string]interface{})
+			if !ok {
+				logger.Debug("failed to extract payload from response data", zap.Any("responseMsg", result))
+				payload, ok := result["payload"].(map[string]interface{})
+				if !ok {
+					logger.Debug("failed to extract payload from response data", zap.Any("responseMsg", result))
+					continue
+				}
+				payload["$binary"].(map[string]interface{})["base64"] = updatedFirstResponse
+			} else {
+				query["payload"].(map[string]interface{})["$binary"].(map[string]interface{})["base64"] = updatedFirstResponse
+			}
 		}
 		v, err := json.Marshal(result)
 		if err != nil {
 			utils.LogError(logger, err, "failed to marshal the updated string document of OpReply")
 			return nil, err
 		}
-		logger.Debug(fmt.Sprintf("the updated document string is: %v", result["localTime"].(map[string]interface{})["$date"].(map[string]interface{})["$numberLong"]))
 		err = bson.UnmarshalExtJSON([]byte(v), false, &unmarshaledDoc)
 		if err != nil {
 			utils.LogError(logger, err, "failed to unmarshal the updated document string of OpReply")

--- a/pkg/core/proxy/integrations/mongo/util.go
+++ b/pkg/core/proxy/integrations/mongo/util.go
@@ -21,10 +21,7 @@ func isHeartBeat(logger *zap.Logger, opReq Operation, requestHeader models.Mongo
 
 	switch requestHeader.Opcode {
 	case wiremessage.OpQuery:
-		val, ok := mongoRequest.(*models.MongoOpQuery)
-		if ok {
-			return val.FullCollectionName == "admin.$cmd" && opReq.IsIsMaster() && strings.Contains(opReq.String(), "helloOk")
-		}
+		return true
 	case wiremessage.OpMsg:
 		_, ok := mongoRequest.(*models.MongoOpMessage)
 		if ok {


### PR DESCRIPTION
## What does this PR do?

Fix for Mongo Auth failure due to usage of old client driver which led to usage of legacy wire protocol.
## Related PRs and Issues

1. Issue can be reproduced by this branch - https://github.com/keploy/samples-java/tree/mongo_nug/spring-boot-mongo
2. With the latest mongo wire protocol/driver the auth considering `saslStart` and `saslContinue` is done by `OP_MSG` - supported by our parser
3. In a bit lower versions `saslStart` is done by `OP_QUERY` and `saslContinue` by `OP_MSG` - supported by our parser
4. In more lower versions/legacy version `saslStart` and `saslContinue` are done by `OP_QUERY` - not supported by our parser
5. These some times depend on the drivers and specific language drivers also
6. Fixed this by adding `saslContinue` support in `OP_QUERY` in the mongo parser.

sample queries:

` query: '{"saslStart":{"$numberInt":"1"},"mechanism":"SCRAM-SHA-1","payload":{"$binary":{"base64":"biwsbj15b3VyVXNlcm5hbWUscj1HNHw0bVM2ZWRXOzNpZ2sofXguSj9GUy4=","subType":"00"}}}'`


` query: '{"saslContinue":{"$numberInt":"1"},"conversationId":{"$numberInt":"1"},"payload":{"$binary":{"base64":"Yz1iaXdzLHI9RzR8NG1TNmVkVzszaWdrKH14Lko/RlMuNklEZ0FhWGxkOG9XdVJmYjR1c2pIMDlDZUFXRmdmaHIscD0wcWhsaldHQzVWMFU4c2QrN2NLNzErMUxRWEk9","subType":"00"}}}'`

            
            


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know test plan followed

Please describe the tests(if any). Provide instructions how it's affecting the coverage.

## Checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] New and existing unit tests pass locally with my changes.
