### PR TITLE
add: additional prompt for test gen

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -209,6 +209,7 @@ func (c *CmdConfigurator) AddFlags(cmd *cobra.Command) error {
 		cmd.Flags().String("llm-base-url", "", "Base URL for the AI model.")
 		cmd.Flags().String("model", "gpt-4o", "Model to use for the AI.")
 		cmd.Flags().String("llm-api-version", "", "API version of the llm")
+		cmd.Flags().String("additional-prompt", "", "Additional prompt to be used for the AI model.")
 		err := cmd.MarkFlagRequired("test-command")
 		if err != nil {
 			errMsg := "failed to mark testCommand as required flag"

--- a/cli/provider/service.go
+++ b/cli/provider/service.go
@@ -44,7 +44,7 @@ func (n *ServiceProvider) GetService(ctx context.Context, cmd string) (interface
 	case "config", "update", "login":
 		return tools.NewTools(n.logger, tel, n.auth), nil
 	case "gen":
-		return utgen.NewUnitTestGenerator(n.cfg.Gen.SourceFilePath, n.cfg.Gen.TestFilePath, n.cfg.Gen.CoverageReportPath, n.cfg.Gen.TestCommand, n.cfg.Gen.TestDir, n.cfg.Gen.CoverageFormat, n.cfg.Gen.DesiredCoverage, n.cfg.Gen.MaxIterations, n.cfg.Gen.Model, n.cfg.Gen.APIBaseURL, n.cfg.Gen.APIVersion, n.cfg.APIServerURL, n.cfg, tel, n.auth, n.logger)
+		return utgen.NewUnitTestGenerator(n.cfg.Gen.SourceFilePath, n.cfg.Gen.TestFilePath, n.cfg.Gen.CoverageReportPath, n.cfg.Gen.TestCommand, n.cfg.Gen.TestDir, n.cfg.Gen.CoverageFormat, n.cfg.Gen.DesiredCoverage, n.cfg.Gen.MaxIterations, n.cfg.Gen.Model, n.cfg.Gen.APIBaseURL, n.cfg.Gen.APIVersion, n.cfg.APIServerURL, n.cfg.Gen.AdditionalPrompt, n.cfg, tel, n.auth, n.logger)
 	case "record", "test", "mock", "normalize", "templatize", "rerecord", "contract":
 		return Get(ctx, cmd, n.cfg, n.logger, tel, n.auth)
 	default:

--- a/config/config.go
+++ b/config/config.go
@@ -57,6 +57,7 @@ type UtGen struct {
 	APIBaseURL         string  `json:"llmBaseUrl" yaml:"llmBaseUrl" mapstructure:"llmBaseUrl"`
 	Model              string  `json:"model" yaml:"model" mapstructure:"model"`
 	APIVersion         string  `json:"llmApiVersion" yaml:"llmApiVersion" mapstructure:"llmApiVersion"`
+	AdditionalPrompt   string  `json:"additionalPrompt" yaml:"additionalPrompt" mapstructure:"additionalPrompt"`
 }
 type Templatize struct {
 	TestSets []string `json:"testSets" yaml:"testSets" mapstructure:"testSets"`

--- a/pkg/service/utgen/assets/test_generation.toml
+++ b/pkg/service/utgen/assets/test_generation.toml
@@ -12,6 +12,9 @@ Additional guidelines:
 - Brainstorm a list of test cases necessary to fully validate the correctness of the code and achieve 100% code coverage.
 - After adding each test, review all tests to ensure they cover the full range of scenarios, including exception or error handling.
 - If the original test file contains a test suite, assume that each generated test will be part of the same suite. Ensure the new tests are consistent with the existing suite in terms of style, naming conventions, and structure.
+{{- if .additional_command }}
+- {{ .additional_command }}
+{{ end }}
 
 
 ## Source File

--- a/pkg/service/utgen/gen.go
+++ b/pkg/service/utgen/gen.go
@@ -31,24 +31,25 @@ type Cursor struct {
 }
 
 type UnitTestGenerator struct {
-	srcPath       string
-	testPath      string
-	cmd           string
-	dir           string
-	cov           *Coverage
-	lang          string
-	cur           *Cursor
-	failedTests   []*models.FailedUT
-	prompt        *Prompt
-	ai            *AIClient
-	logger        *zap.Logger
-	promptBuilder *PromptBuilder
-	maxIterations int
-	Files         []string
-	tel           Telemetry
+	srcPath          string
+	testPath         string
+	cmd              string
+	dir              string
+	cov              *Coverage
+	lang             string
+	cur              *Cursor
+	failedTests      []*models.FailedUT
+	prompt           *Prompt
+	ai               *AIClient
+	logger           *zap.Logger
+	promptBuilder    *PromptBuilder
+	maxIterations    int
+	Files            []string
+	tel              Telemetry
+	additionalPrompt string
 }
 
-func NewUnitTestGenerator(srcPath, testPath, reportPath, cmd, dir, coverageFormat string, desiredCoverage float64, maxIterations int, model string, apiBaseURL string, apiVersion, apiServerURL string, _ *config.Config, tel Telemetry, auth service.Auth, logger *zap.Logger) (*UnitTestGenerator, error) {
+func NewUnitTestGenerator(srcPath, testPath, reportPath, cmd, dir, coverageFormat string, desiredCoverage float64, maxIterations int, model string, apiBaseURL string, apiVersion, apiServerURL, additionalPrompt string, _ *config.Config, tel Telemetry, auth service.Auth, logger *zap.Logger) (*UnitTestGenerator, error) {
 	generator := &UnitTestGenerator{
 		srcPath:       srcPath,
 		testPath:      testPath,
@@ -63,7 +64,8 @@ func NewUnitTestGenerator(srcPath, testPath, reportPath, cmd, dir, coverageForma
 			Format:  coverageFormat,
 			Desired: desiredCoverage,
 		},
-		cur: &Cursor{},
+		additionalPrompt: additionalPrompt,
+		cur:              &Cursor{},
 	}
 	return generator, nil
 }
@@ -119,7 +121,7 @@ func (g *UnitTestGenerator) Start(ctx context.Context) error {
 		// Run the initial coverage to get the base line
 		iterationCount := 0
 		g.lang = GetCodeLanguage(g.srcPath)
-		g.promptBuilder, err = NewPromptBuilder(g.srcPath, g.testPath, g.cov.Content, "", "", g.lang, g.logger)
+		g.promptBuilder, err = NewPromptBuilder(g.srcPath, g.testPath, g.cov.Content, "", "", g.lang, g.additionalPrompt, g.logger)
 		if err != nil {
 			utils.LogError(g.logger, err, "Error creating prompt builder")
 			return err

--- a/pkg/service/utgen/prompt.go
+++ b/pkg/service/utgen/prompt.go
@@ -57,9 +57,10 @@ type PromptBuilder struct {
 	AdditionalInstructions string
 	Language               string
 	Logger                 *zap.Logger
+	AdditionalPrompt       string
 }
 
-func NewPromptBuilder(srcPath, testPath, covReportContent, includedFiles, additionalInstructions, language string, logger *zap.Logger) (*PromptBuilder, error) {
+func NewPromptBuilder(srcPath, testPath, covReportContent, includedFiles, additionalInstructions, language, additionalPrompt string, logger *zap.Logger) (*PromptBuilder, error) {
 	var err error
 	src := &Source{
 		Name: filepath.Base(srcPath),
@@ -73,6 +74,7 @@ func NewPromptBuilder(srcPath, testPath, covReportContent, includedFiles, additi
 		Language:         language,
 		CovReportContent: covReportContent,
 		Logger:           logger,
+		AdditionalPrompt: additionalPrompt,
 	}
 	promptBuilder.Src.Code, err = readFile(srcPath)
 	if err != nil {
@@ -138,6 +140,7 @@ func (pb *PromptBuilder) BuildPrompt(file, failedTestRuns string) (*Prompt, erro
 		"additional_instructions_text": pb.AdditionalInstructions,
 		"language":                     pb.Language,
 		"max_tests":                    MAX_TESTS_PER_RUN,
+		"additional_command":           pb.AdditionalPrompt,
 	}
 
 	settings := settings.GetSettings()


### PR DESCRIPTION
## What does this PR do?

Adds additional test gen command


Closes: https://github.com/keploy/keploy/issues/2299


## Type of change

- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know test plan followed

```
keploy gen  --source-file-path="/Users/shivamsouravjha/samples-typescript/express-mongoose/src/routes/routes.js"  --test-file-path="/Users/shivamsouravjha/samples-typescript/express-mongoose/test/routes.test.js"   --test-command="npm test"  --coverage-report-path="/Users/shivamsouravjha/samples-typescript/express-mongoose/coverage/cobertura-coverage.xml"  --llmApiVersion "2024-02-01" --llmBaseUrl "http://localhost:8089" --max-iterations "5" --additional-prompt "make sure all the generated testcases are only for student endpoint."
```

## Checklist:
- [X] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [X] My code follows the style guidelines of this project.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] New and existing unit tests pass locally with my changes.
