### PR TITLE
[fix]: keploy hangs if proxy port is already in use

### DIFF
--- a/pkg/core/proxy/proxy.go
+++ b/pkg/core/proxy/proxy.go
@@ -100,11 +100,14 @@ func (p *Proxy) StartProxy(ctx context.Context, opts core.ProxyOptions) error {
 	if !ok {
 		return errors.New("failed to get the error group from the context")
 	}
+	// Create a channel to signal readiness of each server
+	readyChan := make(chan error, 1)
 
 	// start the proxy server
 	g.Go(func() error {
 		defer utils.Recover(p.logger)
-		err := p.start(ctx)
+		err := p.start(ctx, readyChan)
+		readyChan <- err
 		if err != nil {
 			utils.LogError(p.logger, err, "error while running the proxy server")
 			return err
@@ -172,23 +175,32 @@ func (p *Proxy) StartProxy(ctx context.Context, opts core.ProxyOptions) error {
 			return err
 		}
 	})
+	// Wait for the proxy server to be ready or fail
+	err = <-readyChan
+	if err != nil {
+		return err
+	}
 	p.logger.Info("Keploy has taken control of the DNS resolution mechanism, your application may misbehave if you have provided wrong domain name in your application code.")
-
 	p.logger.Info(fmt.Sprintf("Proxy started at port:%v", p.Port))
+
 	return nil
 }
 
 // start function starts the proxy server on the idle local port
-func (p *Proxy) start(ctx context.Context) error {
+func (p *Proxy) start(ctx context.Context, readyChan chan<- error) error {
 
 	// It will listen on all the interfaces
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%v", p.Port))
 	if err != nil {
 		utils.LogError(p.logger, err, fmt.Sprintf("failed to start proxy on port:%v", p.Port))
+		// Notify failure
+		readyChan <- err
 		return err
 	}
 	p.Listener = listener
 	p.logger.Debug(fmt.Sprintf("Proxy server is listening on %s", fmt.Sprintf(":%v", listener.Addr())))
+	// Signal that the server is ready
+	readyChan <- nil
 
 	defer func(listener net.Listener) {
 		err := listener.Close()
@@ -534,7 +546,6 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 
 func (p *Proxy) StopProxyServer(ctx context.Context) {
 	<-ctx.Done()
-
 	p.logger.Info("stopping proxy server...")
 
 	p.connMutex.Lock()


### PR DESCRIPTION
## What does this PR do?

[fix]: keploy hangs if proxy port is already in use

## Related PRs and Issues

Closes: #1705

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know test plan followed

Please describe the tests(if any). Provide instructions how its affecting the coverage.

## Checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] New and existing unit tests pass locally with my changes.
