### PR TITLE
Added instructions for CLA check

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -23,3 +23,20 @@ You accept and agree to the following terms and conditions for Your present and 
 7. Should You wish to submit work that is not Your original creation, You may submit it to "Keploy" separately from any Contribution, identifying the complete details of its source and of any license or other restriction (including, but not limited to, related patents, trademarks, and license agreements) of which you are personally aware, and conspicuously marking the work as "Submitted on behalf of a third-party: [named here]".
 
 8. You agree to notify "Keploy" of any facts or circumstances of which you become aware that would make these representations inaccurate in any respect.
+
+## What to Do If the CLA Check Fails
+
+If you receive notifications that the CLA check has failed for your pull request, please follow these steps:
+
+1. **Review the CLA Document:** Ensure you fully understand the terms and conditions outlined in this document.
+
+2. **Sign the CLA:** Comment on the PR with the following message:
+`I have read the CLA Document and I hereby sign the CLA.`
+
+3. **Recheck the CLA:** If you believe you have already signed the CLA but the check is still failing, try commenting `recheck` to trigger a new CLA verification.
+
+4. **Contact the Maintainers:** If you continue to experience issues, please reach out to the project maintainers for assistance.
+
+5. **Monitor the PR:** After contacting maintainers, keep an eye on the PR for updates or further comments from maintainers regarding the CLA status.
+
+6. **Respond Promptly:** If maintainers request additional information or clarification, respond as soon as possible to keep the process moving forward.


### PR DESCRIPTION
## What does this PR do?

Contributors can read instructions if their PR is failing a CLA check. It is needed because there was no existing instructions for CLA failing check and contributors have to spend more time in finding why their PR is failing a particular check.

## Related PRs and Issues

- It is fixing a bug which is defined in #2125  issue.

Closes: #2125

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Please let us know test plan followed
There are no test plans for this PR.

Please describe the tests(if any). Provide instructions how its affecting the coverage.

## Checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] New and existing unit tests pass locally with my changes.
