### PR TITLE
fix: remove comparison of keploy header in http parser

### DIFF
--- a/pkg/core/proxy/integrations/http/match.go
+++ b/pkg/core/proxy/integrations/http/match.go
@@ -218,12 +218,18 @@ func mapsHaveSameKeys(map1 map[string]string, map2 map[string][]string) bool {
 	}
 
 	for key := range map1 {
+		if key == "KEPLOY-TEST-ID" || key == "KEPLOY-TEST-SET-ID" || key == "keploy-test-id" || key == "keploy-test-set-id" {
+			continue
+		}
 		if _, exists := map2[key]; !exists {
 			return false
 		}
 	}
 
 	for key := range map2 {
+		if key == "KEPLOY-TEST-ID" || key == "KEPLOY-TEST-SET-ID" || key == "keploy-test-id" || key == "keploy-test-set-id" {
+			continue
+		}
 		if _, exists := map1[key]; !exists {
 			return false
 		}


### PR DESCRIPTION
## What does this PR do?

Issue - Few applications which have http calls as outgoing inherit the headers from incoming api call. So in test mode kpeloy adds few headers in the http incoming api call for various reasons like deduplication etc. Due to this these headers are inherited by the outgoing http calls and mock matching is failing.

solution - remove these particular headers from matching.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know test plan followed

Please describe the tests(if any). Provide instructions how its affecting the coverage.

## Checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] New and existing unit tests pass locally with my changes.
