### PR TITLE
Fix code scanning alert no. 149: Incorrect conversion between integer types

### DIFF
--- a/pkg/core/proxy/integrations/postgres/v1/util.go
+++ b/pkg/core/proxy/integrations/postgres/v1/util.go
@@ -365,9 +365,9 @@ func sliceCommandTag(mock *models.Mock, logger *zap.Logger, prep []QueryData, ac
 func getChandedDataRow(input string) (string, error) {
 	// Convert input1 (integer input as string) to integer
 	buffer := make([]byte, 4)
-	if intValue, err := strconv.Atoi(input); err == nil {
+	if uintValue, err := strconv.ParseUint(input, 10, 32); err == nil {
 
-		binary.BigEndian.PutUint32(buffer, uint32(intValue))
+		binary.BigEndian.PutUint32(buffer, uint32(uintValue))
 		return "b64:" + util.EncodeBase64(buffer), nil
 	} else if dateValue, err := time.Parse("2006-01-02", input); err == nil {
 		// Perform additional operations on the date


### PR DESCRIPTION
Fixes [https://github.com/keploy/keploy/security/code-scanning/149](https://github.com/keploy/keploy/security/code-scanning/149)

To fix the problem, we need to ensure that the integer value obtained from `strconv.Atoi` is within the bounds of `uint32` before performing the conversion. This can be done by adding a check to ensure the value is non-negative and does not exceed the maximum value of `uint32`.

1. Use `strconv.ParseUint` instead of `strconv.Atoi` to directly parse the string into a `uint32` value.
2. If using `strconv.Atoi`, add a check to ensure the parsed integer is within the bounds of `uint32` before converting it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
