### PR TITLE
fix: Setup Function with Context-Aware Cancellation for Agent Startup

### DIFF
--- a/pkg/platform/http/agent.go
+++ b/pkg/platform/http/agent.go
@@ -618,7 +618,8 @@ func (a *AgentClient) UnregisterClient(ctx context.Context, clientID uint64) err
 
 func (a *AgentClient) StartInDocker(ctx context.Context, logger *zap.Logger) error {
 	// Start the Keploy agent in a Docker container, directly using the passed context for cancellation
-	err := kdocker.StartInDocker(ctx, logger, &config.Config{
+	agentCtx := context.WithoutCancel(ctx)
+	err := kdocker.StartInDocker(agentCtx, logger, &config.Config{
 		InstallationID: a.conf.InstallationID,
 	})
 	if err != nil {

--- a/pkg/platform/http/agent.go
+++ b/pkg/platform/http/agent.go
@@ -8,17 +8,8 @@ import (
 	"context"
 	_ "embed" // necessary for embedding
 	"encoding/json"
+	"errors"
 	"fmt"
-	"io"
-	"net/http"
-	"os"
-	"os/exec"
-	"runtime"
-	"strconv"
-	"sync"
-	"syscall"
-	"time"
-"errors"
 	"github.com/docker/docker/api/types/events"
 	"go.keploy.io/server/v2/config"
 	"go.keploy.io/server/v2/pkg/agent/hooks"
@@ -28,6 +19,15 @@ import (
 	"go.keploy.io/server/v2/utils"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"sync"
+	"syscall"
+	"time"
 )
 
 type AgentClient struct {
@@ -466,11 +466,11 @@ func (a *AgentClient) Setup(ctx context.Context, cmd string, opts models.SetupOp
 	})
 	a.apps.Store(clientID, usrApp)
 
-		err := usrApp.Setup(ctx)
-		if err != nil {
-			utils.LogError(a.logger, err, "failed to setup app")
-			return 0, err
-		}
+	err := usrApp.Setup(ctx)
+	if err != nil {
+		utils.LogError(a.logger, err, "failed to setup app")
+		return 0, err
+	}
 
 	if isDockerCmd {
 		inode, err := a.Initcontainer(ctx, app.Options{


### PR DESCRIPTION
## What does this PR do?

This PR updates the Setup function to handle context-aware cancellation gracefully. Key improvements include:

Starting the agent only if not already running, with support for context cancellation during startup (e.g., Ctrl+C).

## Related PRs and Issues

- (Info about Related PR or issue)

Closes: #[issue number that will be closed through this PR]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know test plan followed

Please describe the tests(if any). Provide instructions how its affecting the coverage.

## Checklist:
- [ ] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] New and existing unit tests pass locally with my changes.
