### PR TITLE
fix: iteration count in ut-gen events

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ import (
 
 var version string
 var dsn string
-var apiServerURI = "http://localhost:8080"
+var apiServerURI = "http://localhost:8083"
 var gitHubClientID = "Iv23liFBvIVhL29i9BAp"
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ import (
 
 var version string
 var dsn string
-var apiServerURI = "http://localhost:8083"
+var apiServerURI = "http://localhost:8080"
 var gitHubClientID = "Iv23liFBvIVhL29i9BAp"
 
 func main() {


### PR DESCRIPTION
## What does this PR do?

- This fixes the iteration count in ut-gen that is used in the events.
- Earlier coverage update event and test-generation event iterations were out of sync.

## Related PRs and Issues

 `NA`

Closes: #[issue number that will be closed through this PR]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know test plan followed

Please describe the tests(if any). Provide instructions how its affecting the coverage.

## Checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] New and existing unit tests pass locally with my changes.
