### PR TITLE
fix: arch var in installation script

### DIFF
--- a/keploy.sh
+++ b/keploy.sh
@@ -235,6 +235,8 @@ installKeploy (){
         done
     }
 
+    ARCH=$(uname -m)
+    
     OS_NAME="$(uname -s)"
     if [ "$OS_NAME" = "Darwin" ]; then
         NO_ROOT=true


### PR DESCRIPTION
ISSUE - https://github.com/keploy/keploy/issues/2448

Resolution - ARCH variable was accidentally removed from installation script in this PR - https://github.com/keploy/keploy/pull/2441/files , added it again.