### PR TITLE
chore: disable codeql report export and upload

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -72,13 +72,13 @@ jobs:
     - name: Create a folder for security reports
       run: mkdir -p reports
 
-    - name: Generate Security Report
-      uses: peter-murray/github-security-report-action@v2
-      with:
-        token: ${{ secrets.CODEQL_EXPORT_PAT_TOKEN }}
-        outputDir: ./reports
-    - name: Upload artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: security-report
-        path: /home/runner/work/keploy/results
+    # - name: Generate Security Report
+    #   uses: peter-murray/github-security-report-action@v2
+    #   with:
+    #     token: ${{ secrets.CODEQL_EXPORT_PAT_TOKEN }}
+    #     outputDir: ./reports
+    # - name: Upload artifact
+    #   uses: actions/upload-artifact@v3
+    #   with:
+    #     name: security-report
+    #     path: /home/runner/work/keploy/results


### PR DESCRIPTION
## What does this PR do?

Removes codeql report export and upload via third party library. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

