### PR TITLE
fix: incorrect log file reference in golang-docker-compose test script

### DIFF
--- a/.github/workflows/test_workflow_scripts/golang-docker-compose.sh
+++ b/.github/workflows/test_workflow_scripts/golang-docker-compose.sh
@@ -76,9 +76,8 @@ for i in {1..2}; do
 done
 
 # Start keploy in test mode.
-test_container="echoApp"
-test_container_logs="echoTest"
-sudo -E env PATH=$PATH ./../../keployv2 test -c 'docker compose up' --containerName "$test_container" --apiTimeout 60 --delay 20 --generate-github-actions=false &> "${test_container_logs}.txt"
+test_container="echoApp_test"
+sudo -E env PATH=$PATH ./../../keployv2 test -c 'docker compose up' --containerName "$test_container" --apiTimeout 60 --delay 20 --generate-github-actions=false &> "${test_container}.txt"
 
 if grep "ERROR" "${test_container}.txt"; then
     echo "Error found in pipeline..."

--- a/.github/workflows/test_workflow_scripts/golang-docker-compose.sh
+++ b/.github/workflows/test_workflow_scripts/golang-docker-compose.sh
@@ -76,7 +76,7 @@ for i in {1..2}; do
 done
 
 # Start keploy in test mode.
-test_container="echoApp_test"
+test_container="echoApp"
 sudo -E env PATH=$PATH ./../../keployv2 test -c 'docker compose up' --containerName "$test_container" --apiTimeout 60 --delay 20 --generate-github-actions=false &> "${test_container}.txt"
 
 if grep "ERROR" "${test_container}.txt"; then


### PR DESCRIPTION
## What does this PR do?
This PR fixes an issue in the Keploy test script where the log file reference in the grep commands was incorrect. In the original script, the grep commands were checking for errors or warnings in a log file that did not exist (${test_container}.txt), while the actual log file was being saved as ${test_container_logs}.txt.

## Related PRs and Issues
Closes: #2460 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know test plan followed

Please describe the tests(if any). Provide instructions how its affecting the coverage.

## Checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] New and existing unit tests pass locally with my changes.
