### PR TITLE
fix: check `errReadRespBody != nil` but return a nil value error `err`

### DIFF
--- a/pkg/util.go
+++ b/pkg/util.go
@@ -196,7 +196,8 @@ func SimulateHTTP(ctx context.Context, tc *models.TestCase, testSet string, logg
 			if err := httpResp.Body.Close(); err != nil {
 				utils.LogError(logger, err, "failed to close response body")
 			}
-		} }()
+		}
+	}()
 
 	respBody, errReadRespBody := io.ReadAll(httpResp.Body)
 	if errReadRespBody != nil {

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -190,6 +190,7 @@ func SimulateHTTP(ctx context.Context, tc *models.TestCase, testSet string, logg
 		utils.LogError(logger, errHTTPReq, "failed to send testcase request to app")
 		return nil, errHTTPReq
 	}
+	defer httpResp.Body.Close()
 
 	respBody, errReadRespBody := io.ReadAll(httpResp.Body)
 	if errReadRespBody != nil {

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -194,7 +194,7 @@ func SimulateHTTP(ctx context.Context, tc *models.TestCase, testSet string, logg
 	respBody, errReadRespBody := io.ReadAll(httpResp.Body)
 	if errReadRespBody != nil {
 		utils.LogError(logger, errReadRespBody, "failed reading response body")
-		return nil, err
+		return nil, errReadRespBody
 	}
 
 	resp = &models.HTTPResp{

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -190,7 +190,10 @@ func SimulateHTTP(ctx context.Context, tc *models.TestCase, testSet string, logg
 		utils.LogError(logger, errHTTPReq, "failed to send testcase request to app")
 		return nil, errHTTPReq
 	}
-	defer httpResp.Body.Close()
+
+	defer func() {
+		_ = httpResp.Body.Close()
+	}()
 
 	respBody, errReadRespBody := io.ReadAll(httpResp.Body)
 	if errReadRespBody != nil {

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -192,8 +192,11 @@ func SimulateHTTP(ctx context.Context, tc *models.TestCase, testSet string, logg
 	}
 
 	defer func() {
-		_ = httpResp.Body.Close()
-	}()
+		if httpResp != nil && httpResp.Body != nil {
+			if err := httpResp.Body.Close(); err != nil {
+				utils.LogError(logger, err, "failed to close response body")
+			}
+		} }()
 
 	respBody, errReadRespBody := io.ReadAll(httpResp.Body)
 	if errReadRespBody != nil {


### PR DESCRIPTION
## What does this PR do?

fix a bug

btw, there should add a `defer httpResp.Body.Close()` 

## Related PRs and Issues

I create a linter to detect code that returns a non-relevant nilness error bug. I checked the top 1000 GitHub Go repositories and found this, all result listed in https://github.com/alingse/sundrylint/issues/4

Closes: #[issue number that will be closed through this PR]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know test plan followed

Please describe the tests(if any). Provide instructions how its affecting the coverage.

## Checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] New and existing unit tests pass locally with my changes.

