### PR TITLE
refactor: separate templatize from replay service

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -743,7 +743,7 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 
 func (c *CmdConfigurator) CreateConfigFile(ctx context.Context, defaultCfg config.Config) error {
 	defaultCfg = c.UpdateConfigData(defaultCfg)
-	toolSvc := tools.NewTools(c.logger, nil, nil)
+	toolSvc := tools.NewTools(c.logger, nil, nil, nil, nil, nil)
 	configData := defaultCfg
 	configDataBytes, err := yaml.Marshal(configData)
 	if err != nil {

--- a/cli/provider/core_service_linux.go
+++ b/cli/provider/core_service_linux.go
@@ -27,6 +27,7 @@ import (
 	"go.keploy.io/server/v2/pkg/service/orchestrator"
 	"go.keploy.io/server/v2/pkg/service/record"
 	"go.keploy.io/server/v2/pkg/service/replay"
+	"go.keploy.io/server/v2/pkg/service/tools"
 
 	"go.keploy.io/server/v2/utils"
 	"go.uber.org/zap"
@@ -45,14 +46,16 @@ func Get(ctx context.Context, cmd string, cfg *config.Config, logger *zap.Logger
 	contractSvc := contract.New(logger, commonServices.YamlTestDB, commonServices.YamlMockDb, commonServices.YamlOpenAPIDb, cfg)
 	recordSvc := record.New(logger, commonServices.YamlTestDB, commonServices.YamlMockDb, tel, commonServices.Instrumentation, cfg)
 	replaySvc := replay.NewReplayer(logger, commonServices.YamlTestDB, commonServices.YamlMockDb, commonServices.YamlReportDb, commonServices.YamlTestSetDB, tel, commonServices.Instrumentation, auth, commonServices.Storage, cfg)
-
+	toolsSvc := tools.NewTools(logger, commonServices.YamlTestSetDB, commonServices.YamlTestDB, tel, auth, cfg)
 	switch cmd {
 	case "rerecord":
-		return orchestrator.New(logger, recordSvc, replaySvc, cfg), nil
+		return orchestrator.New(logger, recordSvc, toolsSvc, replaySvc, cfg), nil
 	case "record":
 		return recordSvc, nil
-	case "test", "normalize", "templatize":
+	case "test", "normalize":
 		return replaySvc, nil
+	case "templatize", "config", "update", "login", "export", "import":
+		return toolsSvc, nil
 	case "contract":
 		return contractSvc, nil
 	default:

--- a/cli/provider/core_service_others.go
+++ b/cli/provider/core_service_others.go
@@ -19,6 +19,7 @@ import (
 	"go.keploy.io/server/v2/pkg/service"
 	"go.keploy.io/server/v2/pkg/service/contract"
 	"go.keploy.io/server/v2/pkg/service/replay"
+	"go.keploy.io/server/v2/pkg/service/tools"
 	"go.uber.org/zap"
 )
 
@@ -36,8 +37,13 @@ func Get(ctx context.Context, cmd string, c *config.Config, logger *zap.Logger, 
 
 	replaySvc := replay.NewReplayer(logger, commonServices.YamlTestDB, commonServices.YamlMockDb, commonServices.YamlReportDb, commonServices.YamlTestSetDB, tel, commonServices.Instrumentation, auth, commonServices.Storage, c)
 
-	if (cmd == "test" && c.Test.BasePath != "") || cmd == "normalize" || cmd == "templatize" {
+	toolsSvc := tools.NewTools(logger, commonServices.YamlTestSetDB, commonServices.YamlTestDB, tel, auth, c)
+	if (cmd == "test" && c.Test.BasePath != "") || cmd == "normalize" {
 		return replaySvc, nil
+	}
+
+	if cmd == "templatize" || cmd == "config" || cmd == "update" || cmd == "login" || cmd == "export" || cmd == "import" {
+		return toolsSvc, nil
 	}
 
 	if cmd == "contract" {

--- a/cli/provider/service.go
+++ b/cli/provider/service.go
@@ -9,7 +9,6 @@ import (
 	"go.keploy.io/server/v2/pkg/service"
 	"go.keploy.io/server/v2/utils"
 
-	"go.keploy.io/server/v2/pkg/service/tools"
 	"go.keploy.io/server/v2/pkg/service/utgen"
 	"go.uber.org/zap"
 )
@@ -41,11 +40,9 @@ func (n *ServiceProvider) GetService(ctx context.Context, cmd string) (interface
 	tel.Ping()
 
 	switch cmd {
-	case "config", "update", "login", "export", "import":
-		return tools.NewTools(n.logger, tel, n.auth), nil
 	case "gen":
 		return utgen.NewUnitTestGenerator(n.cfg, tel, n.auth, n.logger)
-	case "record", "test", "mock", "normalize", "templatize", "rerecord", "contract":
+	case "record", "test", "mock", "normalize", "rerecord", "contract", "config", "update", "login", "export", "import", "templatize":
 		return Get(ctx, cmd, n.cfg, n.logger, tel, n.auth)
 	default:
 		return nil, errors.New("invalid command")

--- a/cli/templatize.go
+++ b/cli/templatize.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"go.keploy.io/server/v2/config"
-	replaySvc "go.keploy.io/server/v2/pkg/service/replay"
+	toolsSvc "go.keploy.io/server/v2/pkg/service/tools"
 	"go.keploy.io/server/v2/utils"
 	"go.uber.org/zap"
 )
@@ -29,13 +29,13 @@ func Templatize(ctx context.Context, logger *zap.Logger, _ *config.Config, servi
 				utils.LogError(logger, err, "failed to get service")
 				return nil
 			}
-			var replay replaySvc.Service
+			var tools toolsSvc.Service
 			var ok bool
-			if replay, ok = svc.(replaySvc.Service); !ok {
-				utils.LogError(logger, nil, "service doesn't satisfy replay service interface")
+			if tools, ok = svc.(toolsSvc.Service); !ok {
+				utils.LogError(logger, nil, "service doesn't satisfy tools service interface")
 				return nil
 			}
-			if err := replay.Templatize(ctx); err != nil {
+			if err := tools.Templatize(ctx); err != nil {
 				utils.LogError(logger, err, "failed to templatize test cases")
 				return nil
 			}

--- a/pkg/service/orchestrator/orchestrator.go
+++ b/pkg/service/orchestrator/orchestrator.go
@@ -7,6 +7,7 @@ import (
 	"go.keploy.io/server/v2/config"
 	"go.keploy.io/server/v2/pkg/service/record"
 	"go.keploy.io/server/v2/pkg/service/replay"
+	"go.keploy.io/server/v2/pkg/service/tools"
 
 	"go.uber.org/zap"
 )
@@ -15,14 +16,16 @@ type Orchestrator struct {
 	logger *zap.Logger
 	record record.Service
 	replay replay.Service
+	tools  tools.Service
 	config *config.Config
 }
 
-func New(logger *zap.Logger, record record.Service, replay replay.Service, config *config.Config) *Orchestrator {
+func New(logger *zap.Logger, record record.Service, tools tools.Service, replay replay.Service, config *config.Config) *Orchestrator {
 	return &Orchestrator{
 		logger: logger,
 		record: record,
 		replay: replay,
+		tools:  tools,
 		config: config,
 	}
 }

--- a/pkg/service/orchestrator/rerecord.go
+++ b/pkg/service/orchestrator/rerecord.go
@@ -316,7 +316,7 @@ func (o *Orchestrator) checkForTemplates(ctx context.Context, testSets []string)
 	}
 
 	if input == "y\n" || input == "Y\n" {
-		if err := o.replay.Templatize(ctx); err != nil {
+		if err := o.tools.Templatize(ctx); err != nil {
 			utils.LogError(o.logger, err, "failed to templatize test cases, skipping templatization")
 		}
 	}

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -831,7 +831,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 	r.telemetry.TestSetRun(testReport.Success, testReport.Failure, testSetID, string(testSetStatus))
 
 	if r.config.Test.UpdateTemplate || r.config.Test.BasePath != "" {
-		removeDoubleQuotes(utils.TemplatizedValues)
+		utils.RemoveDoubleQuotes(utils.TemplatizedValues)
 		// Write the templatized values to the yaml.
 		if len(utils.TemplatizedValues) > 0 {
 			err = r.testSetConf.Write(ctx, testSetID, &models.TestSet{

--- a/pkg/service/replay/service.go
+++ b/pkg/service/replay/service.go
@@ -35,7 +35,6 @@ type Service interface {
 	GetTestSetConf(ctx context.Context, testSetID string) (*models.TestSet, error)
 	RunApplication(ctx context.Context, appID uint64, opts models.RunOptions) models.AppError
 	Normalize(ctx context.Context) error
-	Templatize(ctx context.Context) error
 	DenoiseTestCases(ctx context.Context, testSetID string, noiseParams []*models.NoiseParams) ([]*models.NoiseParams, error)
 	NormalizeTestCases(ctx context.Context, testRun string, testSetID string, selectedTestCaseIDs []string, testResult []models.TestResult) error
 	DeleteTests(ctx context.Context, testSetID string, testCaseIDs []string) error

--- a/pkg/service/tools/service.go
+++ b/pkg/service/tools/service.go
@@ -12,6 +12,7 @@ type Service interface {
 	Login(ctx context.Context) bool
 	Export(ctx context.Context) error
 	Import(ctx context.Context, path string) error
+	Templatize(ctx context.Context) error
 }
 
 type teleDB interface {

--- a/pkg/service/tools/service.go
+++ b/pkg/service/tools/service.go
@@ -13,7 +13,6 @@ type Service interface {
 	Export(ctx context.Context) error
 	Templatize(ctx context.Context) error
 	Import(ctx context.Context, path, basePath string) error
-
 }
 
 type teleDB interface {

--- a/pkg/service/tools/templatize.go
+++ b/pkg/service/tools/templatize.go
@@ -81,19 +81,6 @@ func (t *Tools) Templatize(ctx context.Context) error {
 			for j := i + 1; j < len(tcs); j++ {
 				addTemplates(t.logger, tcs[j].HTTPReq.Header, &jsonResponse)
 				// check if the tcs[j].HTTPReq.Header is modified that means the template is added log it.
-				if tcs[j].HTTPReq.Header != nil {
-					for key, val := range tcs[j].HTTPReq.Header {
-						if strings.Contains(val, "{{") {
-							// Log the addition of the new template
-							t.logger.Info("New template added for test",
-								zap.String("testcase", tcs[j].Name),
-								zap.String("templateKey", key),
-								zap.String("templateValue", val),
-								zap.String("context", "HTTPReq.Header"),
-							)
-						}
-					}
-				}
 			}
 
 			// Now modify the response body to get templatized body if any.
@@ -108,24 +95,10 @@ func (t *Tools) Templatize(ctx context.Context) error {
 		// CASE:2
 		// Compare the requests headers for the common fields.
 		for i := 0; i < len(tcs)-1; i++ {
-			fmt.Println("Parent: ", tcs[i].Name)
 			// Check for headers first.
 			for j := i + 1; j < len(tcs); j++ {
 				compareReqHeaders(t.logger, tcs[i].HTTPReq.Header, tcs[j].HTTPReq.Header)
 				// check if the tcs[j].HTTPReq.Header is modified that means the template is added log it.
-				if tcs[j].HTTPReq.Header != nil {
-					for key, val := range tcs[j].HTTPReq.Header {
-						if strings.Contains(val, "{{") {
-							// Log the addition of the new template
-							t.logger.Info("New template added for test",
-								zap.String("testcase", tcs[j].Name),
-								zap.String("templateKey", key),
-								zap.String("templateValue", val),
-								zap.String("context", "HTTPReq.Header"),
-							)
-						}
-					}
-				}
 			}
 		}
 
@@ -133,7 +106,6 @@ func (t *Tools) Templatize(ctx context.Context) error {
 		// Check the url of the request for any common fields in the response.
 		// Compare the response of ith testcase with i+1->n reques urls.
 		for i := 0; i < len(tcs)-1; i++ {
-			fmt.Println("Parent: ", tcs[i].Name)
 			jsonResponse, err := parseIntoJSON(tcs[i].HTTPResp.Body)
 			if err != nil {
 				t.logger.Debug("failed to parse response into json.  Not templatizing the response of this test.", zap.Error(err), zap.Any("testcase:", tcs[i].Name))
@@ -148,17 +120,6 @@ func (t *Tools) Templatize(ctx context.Context) error {
 			for j := i + 1; j < len(tcs); j++ {
 				addTemplates(t.logger, &tcs[j].HTTPReq.URL, &jsonResponse)
 				// check if the tcs[j].HTTPReq.URL is modified that means the template is added log it.
-				if tcs[j].HTTPReq.URL != "" {
-					if strings.Contains(tcs[j].HTTPReq.URL, "{{") {
-						// Log the addition of the new template
-						t.logger.Info("New template added for test",
-							zap.String("testcase", tcs[j].Name),
-							zap.String("templateKey", "URL"),
-							zap.String("templateValue", tcs[j].HTTPReq.URL),
-							zap.String("context", "HTTPReq.URL"),
-						)
-					}
-				}
 			}
 
 			// Now modify the response body to get templatized body if any.
@@ -201,17 +162,6 @@ func (t *Tools) Templatize(ctx context.Context) error {
 					continue
 				}
 				// check if the tcs[j].HTTPReq.Body is modified that means the template is added log it.
-				if tcs[j].HTTPReq.Body != "" {
-					if strings.Contains(tcs[j].HTTPReq.Body, "{{") {
-						// Log the addition of the new template
-						t.logger.Info("New template added for test",
-							zap.String("testcase", tcs[j].Name),
-							zap.String("templateKey", "Body"),
-							zap.String("templateValue", tcs[j].HTTPReq.Body),
-							zap.String("context", "HTTPReq.Body"),
-						)
-					}
-				}
 				tcs[j].HTTPReq.Body = string(jsonData)
 			}
 			jsonData, err := json.Marshal(jsonResponse)

--- a/pkg/service/tools/templatize.go
+++ b/pkg/service/tools/templatize.go
@@ -80,7 +80,7 @@ func (t *Tools) Templatize(ctx context.Context) error {
 			// addTemplates where response key is matched to some header key in the next testcases.
 			for j := i + 1; j < len(tcs); j++ {
 				addTemplates(t.logger, tcs[j].HTTPReq.Header, &jsonResponse)
-				// check if the tcs[j].HTTPReq.Header is modified that means the template is added log it.
+				
 			}
 
 			// Now modify the response body to get templatized body if any.
@@ -98,7 +98,6 @@ func (t *Tools) Templatize(ctx context.Context) error {
 			// Check for headers first.
 			for j := i + 1; j < len(tcs); j++ {
 				compareReqHeaders(t.logger, tcs[i].HTTPReq.Header, tcs[j].HTTPReq.Header)
-				// check if the tcs[j].HTTPReq.Header is modified that means the template is added log it.
 			}
 		}
 
@@ -172,7 +171,6 @@ func (t *Tools) Templatize(ctx context.Context) error {
 			tcs[i].HTTPResp.Body = string(jsonData)
 		}
 
-		// TODO: separate the below code into a function.
 		// Updating all the testcases.
 		for _, tc := range tcs {
 			tc.HTTPReq.Body = removeQuotesInTemplates(tc.HTTPReq.Body)
@@ -387,13 +385,6 @@ func addTemplates1(logger *zap.Logger, val1 *string, body *interface{}) bool {
 				b.SetValueByIndex(i, vals[i])
 				*val1 = fmt.Sprintf("{{%s .%v }}", getType(*val1), newKey)
 
-				// Log the addition of the new template
-				// logger.Info("New template added",
-				// 	zap.String("templateKey", newKey),
-				// 	zap.String("templateValue", *val1),
-				// 	zap.String("context", "ObjectItems"),
-				// )
-
 				return true
 			}
 		}
@@ -419,13 +410,6 @@ func addTemplates1(logger *zap.Logger, val1 *string, body *interface{}) bool {
 				// }
 				b[key] = fmt.Sprintf("{{%s .%v }}", getType(val2), newKey)
 				*val1 = fmt.Sprintf("{{%s .%v }}", getType(*val1), newKey)
-
-				// Log the addition of the new template
-				// logger.Info("New template added",
-				// 	zap.String("templateKey", newKey),
-				// 	zap.String("templateValue", *val1),
-				// 	zap.String("context", "map[string]string"),
-				// )
 
 				return true
 			}
@@ -461,12 +445,6 @@ func addTemplates1(logger *zap.Logger, val1 *string, body *interface{}) bool {
 				b[key] = fmt.Sprintf("{{%s .%v}}", getType(b[key]), newKey)
 				*val1 = fmt.Sprintf("{{%s .%v}}", getType(*val1), newKey)
 
-				// Log the addition of the new template
-				// logger.Info("New template added",
-				// 	zap.String("templateKey", newKey),
-				// 	zap.String("templateValue", *val1),
-				// 	zap.String("context", "map[string]interface{}"),
-				// )
 			}
 		}
 	case float64, int64, int, float32:
@@ -631,4 +609,3 @@ func addQuotesInTemplates(jsonStr string) string {
 	})
 	return result
 }
-

--- a/pkg/service/tools/templatize.go
+++ b/pkg/service/tools/templatize.go
@@ -80,7 +80,7 @@ func (t *Tools) Templatize(ctx context.Context) error {
 			// addTemplates where response key is matched to some header key in the next testcases.
 			for j := i + 1; j < len(tcs); j++ {
 				addTemplates(t.logger, tcs[j].HTTPReq.Header, &jsonResponse)
-				
+
 			}
 
 			// Now modify the response body to get templatized body if any.

--- a/pkg/service/tools/tools.go
+++ b/pkg/service/tools/tools.go
@@ -15,29 +15,35 @@ import (
 	"runtime"
 	"strings"
 
-	"go.keploy.io/server/v2/pkg/service/export"
-	postmanimport "go.keploy.io/server/v2/pkg/service/import"
-
 	"github.com/charmbracelet/glamour"
 	"go.keploy.io/server/v2/config"
 	"go.keploy.io/server/v2/pkg/service"
+	"go.keploy.io/server/v2/pkg/service/export"
+	postmanimport "go.keploy.io/server/v2/pkg/service/import"
+	"go.keploy.io/server/v2/pkg/service/replay"
 	"go.keploy.io/server/v2/utils"
 	"go.uber.org/zap"
 	yamlLib "gopkg.in/yaml.v3"
 )
 
-func NewTools(logger *zap.Logger, telemetry teleDB, auth service.Auth) Service {
+func NewTools(logger *zap.Logger, testsetConfig replay.TestSetConfig, testDB replay.TestDB, telemetry teleDB, auth service.Auth, config *config.Config) Service {
 	return &Tools{
-		logger:    logger,
-		telemetry: telemetry,
-		auth:      auth,
+		logger:      logger,
+		telemetry:   telemetry,
+		auth:        auth,
+		testSetConf: testsetConfig,
+		testDB:      testDB,
+		config:      config,
 	}
 }
 
 type Tools struct {
-	logger    *zap.Logger
-	telemetry teleDB
-	auth      service.Auth
+	logger      *zap.Logger
+	telemetry   teleDB
+	testSetConf replay.TestSetConfig
+	testDB      replay.TestDB
+	config      *config.Config
+	auth        service.Auth
 }
 
 var ErrGitHubAPIUnresponsive = errors.New("GitHub API is unresponsive")

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -190,7 +190,6 @@ func RemoveDoubleQuotes(tempMap map[string]interface{}) {
 	}
 }
 
-
 func DeleteFileIfNotExists(logger *zap.Logger, name string) (err error) {
 	//Check if file exists
 	_, err = os.Stat(name)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -177,6 +177,20 @@ func LogError(logger *zap.Logger, err error, msg string, fields ...zap.Field) {
 	}
 }
 
+// TODO: check why without single quotes values are being passed in the template map.
+// This is used to handle the case where the value gets both single quotes and double quotes and the templating engine is not able to handle it.
+// eg: '"Not/A)Brand";v="8", "Chromium";v="126", "Brave";v="126"' can't be handled by the templating engine.
+// Not/A)Brand;v=8, Chromium;v=126, Brave;v=126 can be handled.
+func RemoveDoubleQuotes(tempMap map[string]interface{}) {
+	// Remove double quotes
+	for key, val := range tempMap {
+		if str, ok := val.(string); ok {
+			tempMap[key] = strings.ReplaceAll(str, `"`, "")
+		}
+	}
+}
+
+
 func DeleteFileIfNotExists(logger *zap.Logger, name string) (err error) {
 	//Check if file exists
 	_, err = os.Stat(name)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -177,10 +177,11 @@ func LogError(logger *zap.Logger, err error, msg string, fields ...zap.Field) {
 	}
 }
 
-// TODO: check why without single quotes values are being passed in the template map.
-// This is used to handle the case where the value gets both single quotes and double quotes and the templating engine is not able to handle it.
-// eg: '"Not/A)Brand";v="8", "Chromium";v="126", "Brave";v="126"' can't be handled by the templating engine.
-// Not/A)Brand;v=8, Chromium;v=126, Brave;v=126 can be handled.
+// RemoveDoubleQuotes removes all double quotes from the values in the provided template map.
+// This function handles cases where the templating engine fails to parse values containing both single and double quotes.
+// For example:
+// Input: '"Not/A)Brand";v="8", "Chromium";v="126", "Brave";v="126"'
+// Output: Not/A)Brand;v=8, Chromium;v=126, Brave;v=126
 func RemoveDoubleQuotes(tempMap map[string]interface{}) {
 	// Remove double quotes
 	for key, val := range tempMap {


### PR DESCRIPTION
## What does this PR do?
This pull request introduces significant changes to the codebase, primarily focusing on the migration of the `Templatize` functionality from the `replay` service to the new `tools` service. The changes involve updating various files to reflect this migration, ensuring that the `tools` service now handles the `Templatize` functionality.

Migration of `Templatize` functionality:

* [`pkg/service/tools/templatize.go`](diffhunk://#diff-a13a2ad264c9b7ba4033994fe736455469f67018358fb323e5a5d822e69dc755L1-R1): Renamed from `pkg/service/replay/template.go` and updated the implementation to use the `tools` service instead of the `replay` service. [[1]](diffhunk://#diff-a13a2ad264c9b7ba4033994fe736455469f67018358fb323e5a5d822e69dc755L1-R1) [[2]](diffhunk://#diff-a13a2ad264c9b7ba4033994fe736455469f67018358fb323e5a5d822e69dc755L23-R55) [[3]](diffhunk://#diff-a13a2ad264c9b7ba4033994fe736455469f67018358fb323e5a5d822e69dc755R69-R73) [[4]](diffhunk://#diff-a13a2ad264c9b7ba4033994fe736455469f67018358fb323e5a5d822e69dc755L81-R89) [[5]](diffhunk://#diff-a13a2ad264c9b7ba4033994fe736455469f67018358fb323e5a5d822e69dc755L98-R100) [[6]](diffhunk://#diff-a13a2ad264c9b7ba4033994fe736455469f67018358fb323e5a5d822e69dc755L108-R110) [[7]](diffhunk://#diff-a13a2ad264c9b7ba4033994fe736455469f67018358fb323e5a5d822e69dc755L118-R127) [[8]](diffhunk://#diff-a13a2ad264c9b7ba4033994fe736455469f67018358fb323e5a5d822e69dc755R136-R139) [[9]](diffhunk://#diff-a13a2ad264c9b7ba4033994fe736455469f67018358fb323e5a5d822e69dc755L146-R168) [[10]](diffhunk://#diff-a13a2ad264c9b7ba4033994fe736455469f67018358fb323e5a5d822e69dc755L173-R194) [[11]](diffhunk://#diff-a13a2ad264c9b7ba4033994fe736455469f67018358fb323e5a5d822e69dc755L278-R283) [[12]](diffhunk://#diff-a13a2ad264c9b7ba4033994fe736455469f67018358fb323e5a5d822e69dc755R387)
* [`pkg/service/replay/service.go`](diffhunk://#diff-da4dd6f20c6ac44e7aad6a5830166be2ddf2bd502a56a8274370cbbac0af4367L38): Removed the `Templatize` method from the `Service` interface.
* [`pkg/service/tools/service.go`](diffhunk://#diff-6865dd3905a80c54401313226acf228f4cfbe1ff037f2bac82f2778eb6635dfeR14): Added the `Templatize` method to the `Service` interface.

Updates to service initialization and usage:

* [`cli/provider/core_service_linux.go`](diffhunk://#diff-b2f9bf34466a854b3bb0cf55b4ecaf1503b3c50b386a30f357b8ca25fcc807abR30): Added the `tools` service import and updated the `Get` function to return the `tools` service for relevant commands. [[1]](diffhunk://#diff-b2f9bf34466a854b3bb0cf55b4ecaf1503b3c50b386a30f357b8ca25fcc807abR30) [[2]](diffhunk://#diff-b2f9bf34466a854b3bb0cf55b4ecaf1503b3c50b386a30f357b8ca25fcc807abL48-R58)
* [`cli/provider/core_service_others.go`](diffhunk://#diff-144a8387ca2883db508420665f4a7eecc01007ea99bd6d980e33dcb718ada023R22): Added the `tools` service import and updated the `Get` function to return the `tools` service for relevant commands. [[1]](diffhunk://#diff-144a8387ca2883db508420665f4a7eecc01007ea99bd6d980e33dcb718ada023R22) [[2]](diffhunk://#diff-144a8387ca2883db508420665f4a7eecc01007ea99bd6d980e33dcb718ada023L39-R48)
* [`cli/provider/service.go`](diffhunk://#diff-d4bb4b9e3d057cdf1130621cf7ecdf3a431d4995a7535800d719e02fdac138bdL12): Updated the `GetService` function to remove direct initialization of the `tools` service and instead use the `Get` function. [[1]](diffhunk://#diff-d4bb4b9e3d057cdf1130621cf7ecdf3a431d4995a7535800d719e02fdac138bdL12) [[2]](diffhunk://#diff-d4bb4b9e3d057cdf1130621cf7ecdf3a431d4995a7535800d719e02fdac138bdL44-R45)

Refactoring of orchestrator and templatize command:

* [`pkg/service/orchestrator/orchestrator.go`](diffhunk://#diff-47ed2b8c4c9af7726aa5ae3544cbb436472e408e61c33b737672218eca8c7d2dR10): Updated the `Orchestrator` struct and `New` function to include the `tools` service. [[1]](diffhunk://#diff-47ed2b8c4c9af7726aa5ae3544cbb436472e408e61c33b737672218eca8c7d2dR10) [[2]](diffhunk://#diff-47ed2b8c4c9af7726aa5ae3544cbb436472e408e61c33b737672218eca8c7d2dR19-R28)
* [`cli/templatize.go`](diffhunk://#diff-af7b55fc8288c0f3ecdcefdd6568f4493d9f64b425f261bdf7933c239e6bc081L8-R8): Updated the `Templatize` function to use the `tools` service instead of the `replay` service. [[1]](diffhunk://#diff-af7b55fc8288c0f3ecdcefdd6568f4493d9f64b425f261bdf7933c239e6bc081L8-R8) [[2]](diffhunk://#diff-af7b55fc8288c0f3ecdcefdd6568f4493d9f64b425f261bdf7933c239e6bc081L32-R38)

Additional minor changes:

* [`pkg/service/replay/replay.go`](diffhunk://#diff-e6489c0602898b5fed439b3c4c42885db5890483591af1991adc497ba59e31d9L848-R848): Updated to use `utils.RemoveDoubleQuotes` instead of `removeDoubleQuotes`.
* [`cli/provider/cmd.go`](diffhunk://#diff-a5137720b20dbcb8f3812a18d16b1fc9a65835f982accc5259aac757fface66eL755-R755): Modified the `CreateConfigFile` function to pass additional nil parameters to `tools.NewTools`.

## Related PRs and Issues

- (Info about Related PR or issue)

Closes: #[issue number that will be closed through this PR]

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know test plan followed

Please describe the tests(if any). Provide instructions how its affecting the coverage.

## Checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] New and existing unit tests pass locally with my changes.
