### PR TITLE
refactor: allow write tests afters context cancelled

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -373,6 +373,14 @@ func (c *CmdConfigurator) Validate(ctx context.Context, cmd *cobra.Command) erro
 	}
 	err = c.ValidateFlags(ctx, cmd)
 	if err != nil {
+		if err == c.noCommandError() {
+			utils.LogError(c.logger, nil, "missing required -c flag or appCmd in config file")
+			if c.cfg.InDocker {
+				c.logger.Info(`Example usage: keploy test -c "docker run -p 8080:8080 --network myNetworkName myApplicationImageName" --delay 6`)
+			} else {
+				c.logger.Info(LogExample(RootExamples))
+			}
+		}
 		c.logger.Error("failed to validate flags", zap.Error(err))
 		return err
 	}

--- a/cli/provider/util.go
+++ b/cli/provider/util.go
@@ -10,12 +10,6 @@ import (
 )
 
 func (c *CmdConfigurator) noCommandError() error {
-	utils.LogError(c.logger, nil, "missing required -c flag or appCmd in config file")
-	if c.cfg.InDocker {
-		c.logger.Info(`Example usage: keploy test -c "docker run -p 8080:8080 --network myNetworkName myApplicationImageName" --delay 6`)
-	} else {
-		c.logger.Info(LogExample(RootExamples))
-	}
 	return errors.New("missing required -c flag or appCmd in config file")
 }
 

--- a/pkg/platform/yaml/yaml.go
+++ b/pkg/platform/yaml/yaml.go
@@ -61,6 +61,7 @@ func (cw *ctxWriter) Write(p []byte) (n int, err error) {
 func WriteFile(ctx context.Context, logger *zap.Logger, path, fileName string, docData []byte, isAppend bool) error {
 	isFileEmpty, err := CreateYamlFile(ctx, logger, path, fileName)
 	if err != nil {
+		utils.LogError(logger, err, "failed to create a yaml file", zap.String("path directory", path), zap.String("yaml", fileName))
 		return err
 	}
 	flag := os.O_WRONLY | os.O_TRUNC
@@ -134,8 +135,9 @@ func CreateYamlFile(ctx context.Context, Logger *zap.Logger, path string, fileNa
 		utils.LogError(Logger, err, "failed to validate the yaml file path", zap.String("path directory", path), zap.String("yaml", fileName))
 		return false, err
 	}
+
 	if _, err := os.Stat(yamlPath); err != nil {
-		if ctx.Err() == nil {
+		if ctx.Err() == nil || ctx.Err() == context.Canceled {
 			err = os.MkdirAll(filepath.Join(path), 0777)
 			if err != nil {
 				utils.LogError(Logger, err, "failed to create a directory for the yaml file", zap.String("path directory", path), zap.String("yaml", fileName))


### PR DESCRIPTION
This pull request includes several changes to improve error handling and logging within the codebase. The most important changes include enhancing the validation process for command flags, refining error messages, and improving the creation of YAML files.

Enhancements to error handling and logging:

* [`cli/provider/cmd.go`](diffhunk://#diff-a5137720b20dbcb8f3812a18d16b1fc9a65835f982accc5259aac757fface66eR376-R383): Added detailed logging for missing required flags and provided example usage instructions when the `-c` flag or `appCmd` is missing.
* [`cli/provider/util.go`](diffhunk://#diff-12646fb9c2de3aa23c78a401b55be0a7466c314d84a0b48e1945de8cba228cc4L13-L18): Removed redundant logging in the `noCommandError` method to streamline error handling.
* [`pkg/platform/yaml/yaml.go`](diffhunk://#diff-704bd33e4e54ce7764b1a6a8b1808fe3ee1aecb05bf8695295622043a2346ce1R64): Added logging for errors encountered during YAML file creation to provide more context about the failure.
* [`pkg/platform/yaml/yaml.go`](diffhunk://#diff-704bd33e4e54ce7764b1a6a8b1808fe3ee1aecb05bf8695295622043a2346ce1R138-R140): Improved the directory creation logic to handle `context.Canceled` errors appropriately when validating the YAML file path.