### PR TITLE
fix: validating flag when command is not provided

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -583,13 +583,6 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 			return nil
 		}
 
-		// handle the app command
-		if c.cfg.Command == "" {
-			if !alreadyRunning(cmd.Name(), c.cfg.Test.BasePath) {
-				return c.noCommandError()
-			}
-		}
-
 		// set the command type
 		c.cfg.CommandType = string(utils.FindDockerCmd(c.cfg.Command))
 
@@ -655,6 +648,13 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 			return errors.New("failed to get the absolute path")
 		}
 		c.cfg.Path = absPath + "/keploy"
+
+		// handle the app command
+		if c.cfg.Command == "" {
+			if !alreadyRunning(cmd.Name(), c.cfg.Test.BasePath) {
+				return c.noCommandError()
+			}
+		}
 
 		bypassPorts, err := cmd.Flags().GetUintSlice("passThroughPorts")
 		if err != nil {


### PR DESCRIPTION
This pull request includes changes to the `ValidateFlags` function in the `cli/provider/cmd.go` file. The main modification involves moving the logic that handles the app command to a different location within the function. This change ensures that the command type is set before checking if the app command is already running.

Reorganization of logic in `ValidateFlags`:

* Moved the block of code handling the app command to a different location within the `ValidateFlags` function. This ensures that the command type is set before checking if the app command is already running. [[1]](diffhunk://#diff-a5137720b20dbcb8f3812a18d16b1fc9a65835f982accc5259aac757fface66eL586-L592) [[2]](diffhunk://#diff-a5137720b20dbcb8f3812a18d16b1fc9a65835f982accc5259aac757fface66eR652-R658)

(Provide a description of what this PR does and why it's needed.)

## Related PRs and Issues

- (Info about Related PR or issue)

Closes: #[issue number that will be closed through this PR]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know test plan followed

Please describe the tests(if any). Provide instructions how its affecting the coverage.

## Checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] New and existing unit tests pass locally with my changes.
