### PR TITLE
fix: @semantic-release/exec version to 6.0.3

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,6 +27,6 @@ jobs:
         with:
           dry_run: true
           additional_packages: |
-            ['@semantic-release/exec']
+            ['@semantic-release/exec@6.0.3']
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this PR do?
It defines only a specific version of `@semantic-release/exec`. Because there are breaking changes in version 7

https://github.com/semantic-release/exec/releases/tag/v7.0.0
As you can see in the link above that `@semantic-release/exec` `v7.0.0` has breaking changes and they have converted the plugin to `ES module`. But our system is expecting a `CommonJS module`. 

So this PR fixes version to `6.0.3` until we have  stronger reason to upgrade it further.

Closes: #2544

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know test plan followed
None

## Checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] New and existing unit tests pass locally with my changes.
