### PR TITLE
feat: add reasoning effort type for o1 model

### DIFF
--- a/pkg/service/utgen/ai.go
+++ b/pkg/service/utgen/ai.go
@@ -48,9 +48,9 @@ type CompletionParams struct {
 type ReasoningType string
 
 const (
-	HighReasioning   ReasoningType = "high"
-	LowReasioning    ReasoningType = "low"
-	MediumReasioning ReasoningType = "medium"
+	HighReasioning   ReasoningType = "high"   // HighReasioning represents high reasoning effort.
+	LowReasioning    ReasoningType = "low"    // LowReasioning represents low reasoning effort.
+	MediumReasioning ReasoningType = "medium" // MediumReasioning represents medium reasoning effort.
 )
 
 type Message struct {

--- a/pkg/service/utgen/ai.go
+++ b/pkg/service/utgen/ai.go
@@ -36,13 +36,22 @@ type Prompt struct {
 }
 
 type CompletionParams struct {
-	Model               string    `json:"model"`
-	Messages            []Message `json:"messages"`
-	MaxTokens           int       `json:"max_tokens,omitempty"`
-	MaxCompletionTokens int       `json:"max_completion_tokens,omitempty"`
-	Stream              *bool     `json:"stream,omitempty"`
-	Temperature         float32   `json:"temperature,omitempty"`
+	Model               string        `json:"model"`
+	Messages            []Message     `json:"messages"`
+	MaxTokens           int           `json:"max_tokens,omitempty"`
+	MaxCompletionTokens int           `json:"max_completion_tokens,omitempty"`
+	Stream              *bool         `json:"stream,omitempty"`
+	Temperature         float32       `json:"temperature,omitempty"`
+	ReasoningEffort     ReasoningType `json:"reasoning_effort,omitempty"`
 }
+
+type ReasoningType string
+
+const (
+	HighReasioning   ReasoningType = "high"
+	LowReasioning    ReasoningType = "low"
+	MediumReasioning ReasoningType = "medium"
+)
 
 type Message struct {
 	Role    string `json:"role"`


### PR DESCRIPTION
## What does this PR do?

This pull request introduces a new feature to the `pkg/service/utgen/ai.go` file by adding a `ReasoningEffort` parameter to the `CompletionParams` struct. This change allows for specifying the level of reasoning effort required for AI completions.

Key changes:

* Added `ReasoningEffort` field to the `CompletionParams` struct to allow specifying reasoning effort levels.
* Defined a new `ReasoningType` type and constants for `HighReasoning`, `LowReasoning`, and `MediumReasoning` to represent different levels of reasoning effort.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know test plan followed

Please describe the tests(if any). Provide instructions how its affecting the coverage.

## Checklist:
- [ ] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] New and existing unit tests pass locally with my changes.
