### PR TITLE
fix: missing mongo config mocks

### DIFF
--- a/pkg/core/proxy/integrations/mongo/mongo.go
+++ b/pkg/core/proxy/integrations/mongo/mongo.go
@@ -14,7 +14,6 @@ import (
 
 	"go.keploy.io/server/v2/pkg/core/proxy/util"
 	"go.keploy.io/server/v2/pkg/models"
-	"go.mongodb.org/mongo-driver/x/mongo/driver/wiremessage"
 	"go.uber.org/zap"
 )
 
@@ -103,33 +102,6 @@ func (m *Mongo) recordMessage(_ context.Context, logger *zap.Logger, mongoReques
 	// See: https://github.com/mongodb/mongo-go-driver/blob/8489898c64a2d8c2e2160006eb851a11a9db9e9d/x/mongo/driver/operation/hello.go#L503
 	if isHeartBeat(logger, opReq, *mongoRequests[0].Header, mongoRequests[0].Message) {
 		meta1["type"] = "config"
-
-		for _, req := range mongoRequests {
-
-			switch req.Header.Opcode {
-			case wiremessage.OpQuery:
-				// check the opReq in the recorded config requests. if present then, skip recording
-				if _, ok := m.recordedConfigRequests.Load(req.Message.(*models.MongoOpQuery).Query); ok {
-					shouldRecordCalls = false
-					break
-				}
-				m.recordedConfigRequests.Store(req.Message.(*models.MongoOpQuery).Query, true)
-			case wiremessage.OpMsg:
-				// check the opReq in the recorded config requests. if present then, skip recording
-				if _, ok := m.recordedConfigRequests.Load(req.Message.(*models.MongoOpMessage).Sections[0]); ok {
-					shouldRecordCalls = false
-					break
-				}
-				m.recordedConfigRequests.Store(req.Message.(*models.MongoOpMessage).Sections[0], true)
-			default:
-				// check the opReq in the recorded config requests. if present then, skip recording
-				if _, ok := m.recordedConfigRequests.Load(opReq.String()); ok {
-					shouldRecordCalls = false
-					break
-				}
-				m.recordedConfigRequests.Store(opReq.String(), true)
-			}
-		}
 	}
 	// record the mongo messages
 	if shouldRecordCalls {


### PR DESCRIPTION
## Related PRs and Issues

Closes: #2576

Changes:

1. This is happening as we don't save all the config mocks into the mock file we rule out them as duplicates(not exactly duplicate) but when clustered mongo is used we need them.
2. Removed the code where we discard duplicate mocks(not exactly duplicate)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know test plan followed

Please describe the tests(if any). Provide instructions how its affecting the coverage.

## Checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] New and existing unit tests pass locally with my changes.
