### PR TITLE
Resolves Issue#2242: Adds smoke tests for linux and macOS

### DIFF
--- a/.github/workflows/installation_smoke_test.yaml
+++ b/.github/workflows/installation_smoke_test.yaml
@@ -1,0 +1,77 @@
+name: Installation Smoke Test
+
+on:
+  workflow_run:
+    workflows: ["Docker", "Release"]
+    types: [completed]
+
+jobs:
+  smoke-test:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        environment: [native, docker]
+
+    steps:
+      - name: Get Latest Release from GitHub
+        shell: bash
+        run: |
+          set -e
+          LATEST_RELEASE=$(curl -s https://api.github.com/repos/keploy/keploy/releases/latest | jq -r '.tag_name')
+          echo "Expected Version: $LATEST_RELEASE"
+          echo "LATEST_RELEASE=$LATEST_RELEASE" >> $GITHUB_ENV
+
+      - name: Set up environment
+        run: echo "Running on $(uname -s)-$(uname -m) in ${{ matrix.environment }} mode"
+
+      - name: Install Keploy via One-Click Installer (Native)
+        if: matrix.environment == 'native'
+        shell: bash
+        run: |
+          set -e
+          curl --silent -O -L https://keploy.io/install.sh
+          bash install.sh
+
+      - name: Install Keploy via One-Click Installer (Docker)
+        if: matrix.environment == 'docker'
+        shell: bash
+        run: |
+          set -e
+          docker run --rm ubuntu bash -c "
+            apt-get update && apt-get install -y curl;
+            curl --silent -O -L https://keploy.io/install.sh;
+            bash install.sh
+          "
+
+      - name: Verify Installed Version (Native)
+        if: matrix.environment == 'native'
+        shell: bash
+        run: |
+          set -e
+          INSTALLED_VERSION=$(keploy version | awk '{print $NF}')
+          echo "Installed Version: $INSTALLED_VERSION"
+
+          if [ "$INSTALLED_VERSION" != "$LATEST_RELEASE" ]; then
+            echo "Installed version does not match the latest release!"
+            exit 1
+          else
+            echo "Keploy installed successfully and matches the latest release."
+          fi
+
+      - name: Verify Installed Version (Docker)
+        if: matrix.environment == 'docker'
+        shell: bash
+        run: |
+          set -e
+          INSTALLED_VERSION=$(docker run --rm ubuntu bash -c "keploy version | awk '{print \$NF}'")
+          echo "Installed Version (Docker): $INSTALLED_VERSION"
+
+          if [ "$INSTALLED_VERSION" != "$LATEST_RELEASE" ]; then
+            echo "Installed version does not match the latest release!"
+            exit 1
+          else
+            echo "Keploy installed successfully in Docker and matches the latest release."
+          fi


### PR DESCRIPTION
## What does this PR do?

Adds a basic smoke test for linux and macOS that gets triggered after the completion of release and docker workflows.
This PR introduces a GitHub Actions workflow that fetches the latest Keploy release from GitHub, runs the one-click installation script on Ubuntu and macOS (both natively and inside Docker), and verifies the installation by checking if the installed version matches the latest release. If the versions do not match, the workflow fails.

Closes: #2242  

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] My code follows the style guidelines of this project.
