### PR TITLE
fix: replace fmt.Errorf with errors.New when no format specifiers

### DIFF
--- a/pkg/core/app/app.go
+++ b/pkg/core/app/app.go
@@ -68,7 +68,7 @@ type Options struct {
 func (a *App) Setup(_ context.Context) error {
 
 	if utils.IsDockerCmd(a.kind) && isDetachMode(a.logger, a.cmd, a.kind) {
-		return fmt.Errorf("application could not be started in detached mode")
+		return errors.New("application could not be started in detached mode")
 	}
 
 	switch a.kind {
@@ -107,7 +107,7 @@ func (a *App) SetupDocker() error {
 			return err
 		}
 		if running {
-			return fmt.Errorf("docker container is already in running state")
+			return errors.New("docker container is already in running state")
 		}
 	}
 

--- a/pkg/core/app/util.go
+++ b/pkg/core/app/util.go
@@ -3,6 +3,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -72,7 +73,7 @@ func getInode(pid int) (uint64, error) {
 	// Dev := (f.Sys().(*syscall.Stat_t)).Dev
 	i := (f.Sys().(*syscall.Stat_t)).Ino
 	if i == 0 {
-		return 0, fmt.Errorf("failed to get the inode of the process")
+		return 0, errors.New("failed to get the inode of the process")
 	}
 	return i, nil
 }
@@ -88,13 +89,13 @@ func isDetachMode(logger *zap.Logger, command string, kind utils.CmdType) bool {
 				return false
 			}
 		}
-		utils.LogError(logger, fmt.Errorf("docker start require --attach/-a or --interactive/-i flag"), "failed to start command")
+		utils.LogError(logger, errors.New("docker start require --attach/-a or --interactive/-i flag"), "failed to start command")
 		return true
 	}
 
 	for _, arg := range args {
 		if arg == "-d" || arg == "--detach" {
-			utils.LogError(logger, fmt.Errorf("detach mode is not allowed in Keploy command"), "failed to start command")
+			utils.LogError(logger, errors.New("detach mode is not allowed in Keploy command"), "failed to start command")
 			return true
 		}
 	}

--- a/pkg/core/core_linux.go
+++ b/pkg/core/core_linux.go
@@ -261,7 +261,7 @@ func (c *Core) GetContainerIP(_ context.Context, id uint64) (string, error) {
 	ip := a.ContainerIPv4Addr()
 	c.logger.Debug("ip address of the target app container", zap.Any("ip", ip))
 	if ip == "" {
-		return "", fmt.Errorf("failed to get the IP address of the app container. Try increasing --delay (in seconds)")
+		return "", errors.New("failed to get the IP address of the app container. Try increasing --delay (in seconds)")
 	}
 
 	return ip, nil

--- a/pkg/core/hooks/kernelComm.go
+++ b/pkg/core/hooks/kernelComm.go
@@ -4,7 +4,7 @@ package hooks
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"math/rand"
 
@@ -26,7 +26,7 @@ func (h *Hooks) Get(_ context.Context, srcPort uint16) (*core.NetworkAddress, er
 	// TODO : need to implement eBPF code to differentiate between different apps
 	s, ok := h.sess.Get(0)
 	if !ok {
-		return nil, fmt.Errorf("session not found")
+		return nil, errors.New("session not found")
 	}
 
 	return &core.NetworkAddress{

--- a/pkg/core/proxy/integrations/grpc/transcoder.go
+++ b/pkg/core/proxy/integrations/grpc/transcoder.go
@@ -5,6 +5,7 @@ package grpc
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 
 	"go.keploy.io/server/v2/pkg/core/proxy/integrations"
@@ -85,7 +86,7 @@ func (srv *Transcoder) ProcessDataFrame(ctx context.Context, dataFrame *http2.Da
 		return fmt.Errorf("failed match mocks: %v", err)
 	}
 	if mock == nil {
-		return fmt.Errorf("failed to mock the output for unrecorded outgoing grpc call")
+		return errors.New("failed to mock the output for unrecorded outgoing grpc call")
 	}
 
 	grpcMockResp := mock.Spec.GRPCResp
@@ -250,7 +251,7 @@ func (srv *Transcoder) ProcessContinuationFrame(_ *http2.ContinuationFrame) erro
 	// used by our mock server.
 	// However, if we really need this feature, we can implement it later.
 	utils.LogError(srv.logger, nil, "Continuation Frame received. This is unsupported currently")
-	return fmt.Errorf("continuation frame is unsupported in the current implementation")
+	return errors.New("continuation frame is unsupported in the current implementation")
 }
 
 func (srv *Transcoder) ProcessGenericFrame(ctx context.Context, frame http2.Frame) error {
@@ -277,7 +278,7 @@ func (srv *Transcoder) ProcessGenericFrame(ctx context.Context, frame http2.Fram
 	case *http2.ContinuationFrame:
 		err = srv.ProcessContinuationFrame(frame)
 	default:
-		err = fmt.Errorf("unknown frame received from the client")
+		err = errors.New("unknown frame received from the client")
 	}
 
 	return err

--- a/pkg/core/proxy/integrations/http/chunk.go
+++ b/pkg/core/proxy/integrations/http/chunk.go
@@ -5,7 +5,7 @@ package http
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"io"
 	"net"
 	"strconv"
@@ -63,7 +63,7 @@ func (h *HTTP) HandleChunkedRequests(ctx context.Context, finalReq *[]byte, clie
 		contentLength, err := strconv.Atoi(contentLengthHeader)
 		if err != nil {
 			utils.LogError(h.Logger, err, "failed to get the content-length header")
-			return fmt.Errorf("failed to handle chunked request")
+			return errors.New("failed to handle chunked request")
 		}
 		//Get the length of the body in the request.
 		bodyLength := len(*finalReq) - strings.Index(string(*finalReq), "\r\n\r\n") - 4
@@ -234,7 +234,7 @@ func (h *HTTP) handleChunkedResponses(ctx context.Context, finalResp *[]byte, cl
 		contentLength, err := strconv.Atoi(contentLengthHeader)
 		if err != nil {
 			utils.LogError(h.Logger, err, "failed to get the content-length header")
-			return fmt.Errorf("failed to handle chunked response")
+			return errors.New("failed to handle chunked response")
 		}
 		bodyLength := len(resp) - strings.Index(string(resp), "\r\n\r\n") - 4
 		contentLength -= bodyLength

--- a/pkg/core/proxy/integrations/mongo/operation.go
+++ b/pkg/core/proxy/integrations/mongo/operation.go
@@ -454,7 +454,7 @@ func extractSectionSingle(data string) (string, error) {
 	prefix := "{ SectionSingle msg: "
 	startIndex := strings.Index(data, prefix)
 	if startIndex == -1 {
-		return "", fmt.Errorf("start not found")
+		return "", errors.New("start not found")
 	}
 
 	// Adjust the start index to skip the prefix
@@ -463,7 +463,7 @@ func extractSectionSingle(data string) (string, error) {
 	// We'll assume the content ends with " }" that closes the sectionSingle
 	endIndex := strings.LastIndex(data[startIndex:], " }")
 	if endIndex == -1 {
-		return "", fmt.Errorf("end not found")
+		return "", errors.New("end not found")
 	}
 
 	// Adjust the end index relative to the entire string

--- a/pkg/core/proxy/integrations/mysql/recorder/conn.go
+++ b/pkg/core/proxy/integrations/mysql/recorder/conn.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -201,7 +202,7 @@ func handleInitialHandshake(ctx context.Context, logger *zap.Logger, clientConn,
 		// Store the server greeting packet for the upgraded client connection
 		sg, ok := handshakePkt.Message.(*mysql.HandshakeV10Packet)
 		if !ok {
-			return res, fmt.Errorf("failed to type assert handshake packet")
+			return res, errors.New("failed to type assert handshake packet")
 		}
 		decodeCtx.ServerGreetings.Store(clientConn, sg)
 
@@ -407,7 +408,7 @@ func handleAuth(ctx context.Context, logger *zap.Logger, authPkt *mysql.PacketBu
 		logger.Debug("caching sha2 password authentication is handled successfully")
 		setHandshakeResult(&res, result)
 	case mysql.Sha256:
-		return res, fmt.Errorf("Sha256 Password authentication is not supported")
+		return res, errors.New("Sha256 Password authentication is not supported")
 	default:
 		return res, fmt.Errorf("unsupported authentication plugin: %s", decodeCtx.PluginName)
 	}

--- a/pkg/core/proxy/integrations/mysql/recorder/query.go
+++ b/pkg/core/proxy/integrations/mysql/recorder/query.go
@@ -4,6 +4,7 @@ package recorder
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -127,7 +128,7 @@ func handleQueryResponse(ctx context.Context, logger *zap.Logger, clientConn, de
 	// Get the last operation in order to handle current packet if it is not an error or ok packet
 	lastOp, ok := decodeCtx.LastOp.Load(clientConn)
 	if !ok {
-		return nil, fmt.Errorf("failed to get the last operation from the context while handling the query response")
+		return nil, errors.New("failed to get the last operation from the context while handling the query response")
 	}
 
 	var queryResponsePkt *mysql.PacketBundle

--- a/pkg/core/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/core/proxy/integrations/mysql/replayer/match.go
@@ -5,6 +5,7 @@ package replayer
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -36,7 +37,7 @@ func matchHeader(expected, actual mysql.Header) bool {
 func matchSSLRequest(_ context.Context, _ *zap.Logger, expected, actual mysql.PacketBundle) error {
 	// Match the type
 	if expected.Header.Type != actual.Header.Type {
-		return fmt.Errorf("type mismatch for ssl request")
+		return errors.New("type mismatch for ssl request")
 	}
 
 	//Don't match the header, because the payload length can be different.
@@ -66,7 +67,7 @@ func matchSSLRequest(_ context.Context, _ *zap.Logger, expected, actual mysql.Pa
 func matchHanshakeResponse41(_ context.Context, _ *zap.Logger, expected, actual mysql.PacketBundle) error {
 	// Match the type
 	if expected.Header.Type != actual.Header.Type {
-		return fmt.Errorf("type mismatch for handshake response")
+		return errors.New("type mismatch for handshake response")
 	}
 
 	//Don't match the header, because the payload length can be different.
@@ -132,7 +133,7 @@ func matchHanshakeResponse41(_ context.Context, _ *zap.Logger, expected, actual 
 
 	// Match the ZstdCompressionLevel
 	if exp.ZstdCompressionLevel != act.ZstdCompressionLevel {
-		return fmt.Errorf("zstd compression level mismatch for handshake response")
+		return errors.New("zstd compression level mismatch for handshake response")
 	}
 
 	return nil
@@ -164,7 +165,7 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 				return nil, false, ctx.Err()
 			}
 			utils.LogError(logger, nil, "no mysql mocks found")
-			return nil, false, fmt.Errorf("no mysql mocks found")
+			return nil, false, errors.New("no mysql mocks found")
 		}
 
 		var tcsMocks []*models.Mock
@@ -188,7 +189,7 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 			}
 
 			utils.LogError(logger, nil, "no mysql mocks found for handling command phase")
-			return nil, false, fmt.Errorf("no mysql mocks found for handling command phase")
+			return nil, false, errors.New("no mysql mocks found for handling command phase")
 		}
 
 		var maxMatchedCount int
@@ -311,7 +312,7 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 			prepareOkResp, ok := matchedResp.Message.(*mysql.StmtPrepareOkPacket)
 			if !ok {
 				logger.Error("failed to type assert the StmtPrepareOkPacket")
-				return nil, false, fmt.Errorf("failed to type assert the StmtPrepareOkPacket")
+				return nil, false, errors.New("failed to type assert the StmtPrepareOkPacket")
 			}
 			// This prepared statement will be used in the further execute statement packets
 			decodeCtx.PreparedStatements[prepareOkResp.StatementID] = prepareOkResp

--- a/pkg/core/proxy/integrations/mysql/replayer/query.go
+++ b/pkg/core/proxy/integrations/mysql/replayer/query.go
@@ -4,7 +4,7 @@ package replayer
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"io"
 	"net"
 	"time"
@@ -77,7 +77,7 @@ func simulateCommandPhase(ctx context.Context, logger *zap.Logger, clientConn ne
 
 			if !ok {
 				utils.LogError(logger, nil, "No matching mock found for the command", zap.Any("command", command))
-				return fmt.Errorf("error while simulating the command phase due to no matching mock found")
+				return errors.New("error while simulating the command phase due to no matching mock found")
 			}
 
 			logger.Debug("Matched the command with the mock", zap.Any("mock", resp))

--- a/pkg/core/proxy/integrations/mysql/wire/phase/conn/authNextFactorPacket.go
+++ b/pkg/core/proxy/integrations/mysql/wire/phase/conn/authNextFactorPacket.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 
 	"go.keploy.io/server/v2/pkg/core/proxy/integrations/mysql/utils"
 	"go.keploy.io/server/v2/pkg/models/mysql"
@@ -22,7 +21,7 @@ func DecodeAuthNextFactor(_ context.Context, data []byte) (*mysql.AuthNextFactor
 
 	data, idx, err := utils.ReadNullTerminatedString(data[1:])
 	if err != nil {
-		return nil, fmt.Errorf("malformed handshake response packet: missing null terminator for PluginName")
+		return nil, errors.New("malformed handshake response packet: missing null terminator for PluginName")
 	}
 	packet.PluginName = string(data)
 	packet.PluginData = string(data[idx:])

--- a/pkg/core/proxy/integrations/mysql/wire/phase/generic.go
+++ b/pkg/core/proxy/integrations/mysql/wire/phase/generic.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 
 	"go.keploy.io/server/v2/pkg/core/proxy/integrations/mysql/utils"
@@ -19,7 +20,7 @@ import (
 
 func DecodeEOF(_ context.Context, data []byte, capabilities uint32) (*mysql.EOFPacket, error) {
 	if len(data) > 5 {
-		return nil, fmt.Errorf("EOF packet too long for EOF")
+		return nil, errors.New("EOF packet too long for EOF")
 	}
 
 	packet := &mysql.EOFPacket{
@@ -62,7 +63,7 @@ func EncodeEOF(_ context.Context, packet *mysql.EOFPacket, capabilities uint32) 
 
 func DecodeERR(_ context.Context, data []byte, capabilities uint32) (*mysql.ERRPacket, error) {
 	if len(data) < 9 {
-		return nil, fmt.Errorf("ERR packet too short")
+		return nil, errors.New("ERR packet too short")
 	}
 
 	packet := &mysql.ERRPacket{
@@ -104,7 +105,7 @@ func EncodeErr(_ context.Context, packet *mysql.ERRPacket, capabilities uint32) 
 	// Write the SQL state marker and SQL state if CLIENT_PROTOCOL_41 is set
 	if capabilities&uint32(mysql.CLIENT_PROTOCOL_41) > 0 {
 		if len(packet.SQLStateMarker) != 1 || len(packet.SQLState) != 5 {
-			return nil, fmt.Errorf("invalid SQL state marker or SQL state length")
+			return nil, errors.New("invalid SQL state marker or SQL state length")
 		}
 
 		if err := buf.WriteByte(packet.SQLStateMarker[0]); err != nil {
@@ -128,7 +129,7 @@ func EncodeErr(_ context.Context, packet *mysql.ERRPacket, capabilities uint32) 
 
 func DecodeOk(_ context.Context, data []byte, capabilities uint32) (*mysql.OKPacket, error) {
 	if len(data) < 7 {
-		return nil, fmt.Errorf("OK packet too short")
+		return nil, errors.New("OK packet too short")
 	}
 
 	packet := &mysql.OKPacket{

--- a/pkg/core/proxy/integrations/mysql/wire/phase/query/preparedstmt/stmtExecutePacket.go
+++ b/pkg/core/proxy/integrations/mysql/wire/phase/query/preparedstmt/stmtExecutePacket.go
@@ -5,6 +5,7 @@ package preparedstmt
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 
@@ -17,7 +18,7 @@ import (
 
 func DecodeStmtExecute(_ context.Context, _ *zap.Logger, data []byte, preparedStmts map[uint32]*mysql.StmtPrepareOkPacket) (*mysql.StmtExecutePacket, error) {
 	if len(data) < 10 {
-		return &mysql.StmtExecutePacket{}, fmt.Errorf("packet length too short for COM_STMT_EXECUTE")
+		return &mysql.StmtExecutePacket{}, errors.New("packet length too short for COM_STMT_EXECUTE")
 	}
 
 	pos := 0

--- a/pkg/core/proxy/integrations/mysql/wire/phase/query/preparedstmt/stmtResetPacket.go
+++ b/pkg/core/proxy/integrations/mysql/wire/phase/query/preparedstmt/stmtResetPacket.go
@@ -5,7 +5,7 @@ package preparedstmt
 import (
 	"context"
 	"encoding/binary"
-	"fmt"
+	"errors"
 
 	"go.keploy.io/server/v2/pkg/models/mysql"
 )
@@ -14,7 +14,7 @@ import (
 
 func DecodeStmtReset(_ context.Context, data []byte) (*mysql.StmtResetPacket, error) {
 	if len(data) != 5 {
-		return nil, fmt.Errorf("invalid COM_STMT_RESET packet")
+		return nil, errors.New("invalid COM_STMT_RESET packet")
 	}
 
 	packet := &mysql.StmtResetPacket{

--- a/pkg/core/proxy/integrations/mysql/wire/phase/query/preparedstmt/stmtSendLongDataPacket.go
+++ b/pkg/core/proxy/integrations/mysql/wire/phase/query/preparedstmt/stmtSendLongDataPacket.go
@@ -5,7 +5,7 @@ package preparedstmt
 import (
 	"context"
 	"encoding/binary"
-	"fmt"
+	"errors"
 
 	"go.keploy.io/server/v2/pkg/models/mysql"
 )
@@ -14,7 +14,7 @@ import (
 
 func DecodeStmtSendLongData(_ context.Context, data []byte) (*mysql.StmtSendLongDataPacket, error) {
 	if len(data) < 7 || data[0] != 0x18 {
-		return &mysql.StmtSendLongDataPacket{}, fmt.Errorf("invalid COM_STMT_SEND_LONG_DATA packet")
+		return &mysql.StmtSendLongDataPacket{}, errors.New("invalid COM_STMT_SEND_LONG_DATA packet")
 	}
 
 	packet := &mysql.StmtSendLongDataPacket{

--- a/pkg/core/proxy/integrations/mysql/wire/phase/query/queryPacket.go
+++ b/pkg/core/proxy/integrations/mysql/wire/phase/query/queryPacket.go
@@ -5,7 +5,7 @@ package query
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"go.keploy.io/server/v2/pkg/models/mysql"
 )
@@ -14,7 +14,7 @@ import (
 
 func DecodeQuery(_ context.Context, data []byte) (*mysql.QueryPacket, error) {
 	if len(data) < 2 {
-		return nil, fmt.Errorf("query packet too short")
+		return nil, errors.New("query packet too short")
 	}
 
 	packet := &mysql.QueryPacket{

--- a/pkg/core/proxy/integrations/mysql/wire/phase/query/rowscols/binaryProtocolRowPacket.go
+++ b/pkg/core/proxy/integrations/mysql/wire/phase/query/rowscols/binaryProtocolRowPacket.go
@@ -269,7 +269,7 @@ func EncodeBinaryRow(_ context.Context, logger *zap.Logger, row *mysql.BinaryRow
 		case mysql.FieldTypeString, mysql.FieldTypeVarString, mysql.FieldTypeVarChar, mysql.FieldTypeBLOB, mysql.FieldTypeTinyBLOB, mysql.FieldTypeMediumBLOB, mysql.FieldTypeLongBLOB, mysql.FieldTypeJSON:
 			strValue, ok := columnEntry.Value.(string)
 			if !ok {
-				return nil, fmt.Errorf("invalid value type for string field")
+				return nil, errors.New("invalid value type for string field")
 			}
 			if err := utils.WriteLengthEncodedString(buf, strValue); err != nil {
 				return nil, fmt.Errorf("failed to write length-encoded string: %w", err)
@@ -309,7 +309,7 @@ func EncodeBinaryRow(_ context.Context, logger *zap.Logger, row *mysql.BinaryRow
 		case mysql.FieldTypeFloat:
 			floatValue, ok := columnEntry.Value.(float32)
 			if !ok {
-				return nil, fmt.Errorf("invalid value type for float field")
+				return nil, errors.New("invalid value type for float field")
 			}
 			if err := binary.Write(buf, binary.LittleEndian, floatValue); err != nil {
 				return nil, fmt.Errorf("failed to write float32 value: %w", err)
@@ -317,7 +317,7 @@ func EncodeBinaryRow(_ context.Context, logger *zap.Logger, row *mysql.BinaryRow
 		case mysql.FieldTypeDouble:
 			doubleValue, ok := columnEntry.Value.(float64)
 			if !ok {
-				return nil, fmt.Errorf("invalid value type for double field")
+				return nil, errors.New("invalid value type for double field")
 			}
 			if err := binary.Write(buf, binary.LittleEndian, doubleValue); err != nil {
 				return nil, fmt.Errorf("failed to write float64 value: %w", err)
@@ -357,7 +357,7 @@ func encodeBinaryDateTime(fieldType mysql.FieldType, value interface{}) ([]byte,
 func encodeDate(value interface{}) ([]byte, error) {
 	dateStr, ok := value.(string)
 	if !ok {
-		return nil, fmt.Errorf("invalid value type for date field")
+		return nil, errors.New("invalid value type for date field")
 	}
 	var year, month, day int
 	_, err := fmt.Sscanf(dateStr, "%04d-%02d-%02d", &year, &month, &day)
@@ -387,7 +387,7 @@ func encodeDate(value interface{}) ([]byte, error) {
 func encodeDateTime(value interface{}) ([]byte, error) {
 	dateTimeStr, ok := value.(string)
 	if !ok {
-		return nil, fmt.Errorf("invalid value type for datetime field")
+		return nil, errors.New("invalid value type for datetime field")
 	}
 	var (
 		year, month, day, hour, minute, second, microsecond int
@@ -449,7 +449,7 @@ func encodeDateTime(value interface{}) ([]byte, error) {
 func encodeTime(value interface{}) ([]byte, error) {
 	timeStr, ok := value.(string)
 	if !ok {
-		return nil, fmt.Errorf("invalid value type for time field")
+		return nil, errors.New("invalid value type for time field")
 	}
 	var (
 		isNegative                                  bool

--- a/pkg/core/proxy/integrations/mysql/wire/phase/query/rowscols/columnPacket.go
+++ b/pkg/core/proxy/integrations/mysql/wire/phase/query/rowscols/columnPacket.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 
 	"go.keploy.io/server/v2/pkg/core/proxy/integrations/mysql/utils"
@@ -20,7 +21,7 @@ func DecodeColumn(_ context.Context, _ *zap.Logger, b []byte) (*mysql.ColumnDefi
 		Header: mysql.Header{},
 	}
 	if len(b) < 4 {
-		return nil, 0, fmt.Errorf("invalid column definition packet")
+		return nil, 0, errors.New("invalid column definition packet")
 	}
 	var pos = 0
 

--- a/pkg/core/proxy/integrations/mysql/wire/phase/query/rowscols/textRowPacket.go
+++ b/pkg/core/proxy/integrations/mysql/wire/phase/query/rowscols/textRowPacket.go
@@ -5,6 +5,7 @@ package rowscols
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -42,13 +43,13 @@ func DecodeTextRow(_ context.Context, _ *zap.Logger, data []byte, columns []*mys
 		case mysql.FieldTypeDate:
 			data := data[offset+1:]
 			if dataLength < 10 || len(data) < int(dataLength) {
-				return nil, 0, fmt.Errorf("invalid date data length")
+				return nil, 0, errors.New("invalid date data length")
 			}
 			dateStr := string(data[:dataLength])
 			layout := "2006-01-02"
 			t, err := time.Parse(layout, dateStr)
 			if err != nil {
-				return nil, 0, fmt.Errorf("failed to parse the date string")
+				return nil, 0, errors.New("failed to parse the date string")
 			}
 
 			year, month, day := t.Date()
@@ -63,13 +64,13 @@ func DecodeTextRow(_ context.Context, _ *zap.Logger, data []byte, columns []*mys
 		case mysql.FieldTypeTime:
 			data := data[offset+1:]
 			if dataLength < 8 || len(data) < int(dataLength) {
-				return nil, 0, fmt.Errorf("invalid time data length")
+				return nil, 0, errors.New("invalid time data length")
 			}
 			timeStr := string(data[:dataLength])
 			layout := "15:04:05"
 			t, err := time.Parse(layout, timeStr)
 			if err != nil {
-				return nil, 0, fmt.Errorf("failed to parse the time string")
+				return nil, 0, errors.New("failed to parse the time string")
 			}
 
 			hour, minute, second := t.Clock()
@@ -84,13 +85,13 @@ func DecodeTextRow(_ context.Context, _ *zap.Logger, data []byte, columns []*mys
 		case mysql.FieldTypeDateTime, mysql.FieldTypeTimestamp:
 			data := data[offset+1:]
 			if dataLength < 19 || len(data) < int(dataLength) {
-				return nil, 0, fmt.Errorf("invalid datetime/timestamp data length")
+				return nil, 0, errors.New("invalid datetime/timestamp data length")
 			}
 			dateTimeStr := string(data[:dataLength])
 			layout := "2006-01-02 15:04:05"
 			t, err := time.Parse(layout, dateTimeStr)
 			if err != nil {
-				return nil, 0, fmt.Errorf("failed to parse the datetime/timestamp string")
+				return nil, 0, errors.New("failed to parse the datetime/timestamp string")
 			}
 
 			year, month, day := t.Date()
@@ -145,7 +146,7 @@ func EncodeTextRow(_ context.Context, _ *zap.Logger, row *mysql.TextRow, columns
 		case mysql.FieldTypeDate:
 			dateValue, ok := value.(string)
 			if !ok {
-				return nil, fmt.Errorf("invalid value type for date field")
+				return nil, errors.New("invalid value type for date field")
 			}
 
 			// Write the length of the date value
@@ -161,7 +162,7 @@ func EncodeTextRow(_ context.Context, _ *zap.Logger, row *mysql.TextRow, columns
 		case mysql.FieldTypeTime:
 			timeValue, ok := value.(string)
 			if !ok {
-				return nil, fmt.Errorf("invalid value type for time field")
+				return nil, errors.New("invalid value type for time field")
 			}
 
 			// Write the length of the time value
@@ -177,7 +178,7 @@ func EncodeTextRow(_ context.Context, _ *zap.Logger, row *mysql.TextRow, columns
 		case mysql.FieldTypeDateTime, mysql.FieldTypeTimestamp:
 			dateTimeValue, ok := value.(string)
 			if !ok {
-				return nil, fmt.Errorf("invalid value type for datetime/timestamp field")
+				return nil, errors.New("invalid value type for datetime/timestamp field")
 			}
 
 			// Write the length of the datetime/timestamp value

--- a/pkg/core/proxy/integrations/mysql/wire/phase/query/utility/setOptionPacket.go
+++ b/pkg/core/proxy/integrations/mysql/wire/phase/query/utility/setOptionPacket.go
@@ -5,7 +5,7 @@ package utility
 import (
 	"context"
 	"encoding/binary"
-	"fmt"
+	"errors"
 
 	"go.keploy.io/server/v2/pkg/models/mysql"
 )
@@ -14,7 +14,7 @@ import (
 
 func DecodeSetOption(_ context.Context, data []byte) (*mysql.SetOptionPacket, error) {
 	if len(data) < 3 {
-		return nil, fmt.Errorf("set option packet too short")
+		return nil, errors.New("set option packet too short")
 	}
 
 	packet := &mysql.SetOptionPacket{

--- a/pkg/core/proxy/integrations/mysql/wire/util.go
+++ b/pkg/core/proxy/integrations/mysql/wire/util.go
@@ -4,6 +4,7 @@ package wire
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"sync"
@@ -92,7 +93,7 @@ func GetPluginName(buf interface{}) (string, error) {
 	case *mysql.AuthSwitchRequestPacket:
 		return v.PluginName, nil
 	default:
-		return "", fmt.Errorf("invalid packet type to get plugin name")
+		return "", errors.New("invalid packet type to get plugin name")
 	}
 }
 

--- a/pkg/core/proxy/integrations/scram/util.go
+++ b/pkg/core/proxy/integrations/scram/util.go
@@ -77,7 +77,7 @@ func extractUsername(authMessage string) (string, error) {
 			return nValue, nil
 		}
 	}
-	return "", fmt.Errorf("no username found in the auth message")
+	return "", errors.New("no username found in the auth message")
 }
 
 func extractAuthID(input string) (string, error) {
@@ -86,5 +86,5 @@ func extractAuthID(input string) (string, error) {
 	if len(matches) >= 2 {
 		return "n," + matches[1] + ",", nil
 	}
-	return "", fmt.Errorf("no match found")
+	return "", errors.New("no match found")
 }

--- a/pkg/core/proxy/mockmanager.go
+++ b/pkg/core/proxy/mockmanager.go
@@ -3,6 +3,7 @@
 package proxy
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -90,7 +91,7 @@ func (m *MockManager) UpdateUnFilteredMock(old *models.Mock, new *models.Mock) b
 
 func (m *MockManager) FlagMockAsUsed(mock models.Mock) error {
 	if mock.Name == "" {
-		return fmt.Errorf("mock is empty")
+		return errors.New("mock is empty")
 	}
 	m.consumedMocks.Store(mock.Name, true)
 	return nil

--- a/pkg/core/proxy/proxy.go
+++ b/pkg/core/proxy/proxy.go
@@ -680,7 +680,7 @@ func (p *Proxy) Mock(_ context.Context, id uint64, opts models.OutgoingOptions) 
 func (p *Proxy) SetMocks(_ context.Context, id uint64, filtered []*models.Mock, unFiltered []*models.Mock) error {
 	//session, ok := p.sessions.Get(id)
 	//if !ok {
-	//	return fmt.Errorf("session not found")
+	//	return errors.New("session not found")
 	//}
 	m, ok := p.MockManagers.Load(id)
 	if ok {
@@ -695,7 +695,7 @@ func (p *Proxy) SetMocks(_ context.Context, id uint64, filtered []*models.Mock, 
 func (p *Proxy) GetConsumedMocks(_ context.Context, id uint64) ([]string, error) {
 	m, ok := p.MockManagers.Load(id)
 	if !ok {
-		return nil, fmt.Errorf("mock manager not found to get consumed filtered mocks")
+		return nil, errors.New("mock manager not found to get consumed filtered mocks")
 	}
 	return m.(*MockManager).GetConsumedMocks(), nil
 }

--- a/pkg/core/proxy/tls/ca.go
+++ b/pkg/core/proxy/tls/ca.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"embed"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -74,7 +75,7 @@ func updateCaStore(ctx context.Context) error {
 		}
 	}
 	if !commandRun {
-		return fmt.Errorf("no valid CA store tools command found")
+		return errors.New("no valid CA store tools command found")
 	}
 	return nil
 }
@@ -87,7 +88,7 @@ func getCaPaths() ([]string, error) {
 		}
 	}
 	if len(caPaths) == 0 {
-		return nil, fmt.Errorf("no valid CA store path found")
+		return nil, errors.New("no valid CA store path found")
 	}
 	return caPaths, nil
 }
@@ -299,7 +300,7 @@ func CertForClient(clientHello *tls.ClientHelloInfo, caPrivKey any, caCertParsed
 	}
 	cryptoSigner, ok := caPrivKey.(crypto.Signer)
 	if !ok {
-		return nil, fmt.Errorf("failed to typecast the caPrivKey")
+		return nil, errors.New("failed to typecast the caPrivKey")
 	}
 	signerd, err := local.NewSigner(cryptoSigner, caCertParsed, signer.DefaultSigAlgo(cryptoSigner), nil)
 	if err != nil {

--- a/pkg/core/proxy/util.go
+++ b/pkg/core/proxy/util.go
@@ -4,6 +4,7 @@ package proxy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -56,14 +57,14 @@ func (p *Proxy) globalPassThrough(ctx context.Context, client, dest net.Conn) er
 			_, err := dest.Write(buffer)
 			if err != nil {
 				utils.LogError(logger, err, "failed to write request message to the destination server")
-				return fmt.Errorf("error writing to destination")
+				return errors.New("error writing to destination")
 			}
 		case buffer := <-destBuffChan:
 			// Write the response message to the client
 			_, err := client.Write(buffer)
 			if err != nil {
 				utils.LogError(logger, err, "failed to write response message to the client")
-				return fmt.Errorf("error writing to client")
+				return errors.New("error writing to client")
 			}
 		case err := <-errChan:
 			if err == io.EOF {

--- a/pkg/core/proxy/util/util.go
+++ b/pkg/core/proxy/util/util.go
@@ -416,7 +416,7 @@ func GetLocalIPv4() (net.IP, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("no valid IP address found")
+	return nil, errors.New("no valid IP address found")
 }
 
 func ToIPV4(ip net.IP) (uint32, bool) {
@@ -448,7 +448,7 @@ func GetLocalIPv6() (net.IP, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("no valid IPv6 address found")
+	return nil, errors.New("no valid IPv6 address found")
 }
 
 func IPv6ToUint32Array(ip net.IP) ([4]uint32, error) {
@@ -522,7 +522,7 @@ func GetJavaHome(ctx context.Context) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("java.home not found in command output")
+	return "", errors.New("java.home not found in command output")
 }
 
 // Recover recovers from a panic in any parser and logs the stack trace to Sentry.

--- a/pkg/matcher/http/match.go
+++ b/pkg/matcher/http/match.go
@@ -3,6 +3,7 @@ package http
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -165,7 +166,7 @@ func Match(tc *models.TestCase, actualResponse *models.HTTPResp, noiseConfig map
 					}
 					val, ok := temp.(string)
 					if !ok {
-						utils.LogError(logger, fmt.Errorf("failed to convert the actual header value to string while templatizing"), "")
+						utils.LogError(logger, errors.New("failed to convert the actual header value to string while templatizing"), "")
 						return false, nil
 					}
 					actualValue = append(actualValue, val)
@@ -178,7 +179,7 @@ func Match(tc *models.TestCase, actualResponse *models.HTTPResp, noiseConfig map
 					}
 					val, ok := temp.(string)
 					if !ok {
-						utils.LogError(logger, fmt.Errorf("failed to convert the expected header value to string while templatizing"), "")
+						utils.LogError(logger, errors.New("failed to convert the expected header value to string while templatizing"), "")
 						return false, nil
 					}
 					expectedValue = append(expectedValue, val)

--- a/pkg/platform/auth/auth.go
+++ b/pkg/platform/auth/auth.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -129,7 +130,7 @@ func (a *Auth) GetToken(ctx context.Context) (string, error) {
 		a.logger.Warn("Please follow the instructions to login.")
 		isSuccessful := a.Login(ctx)
 		if !isSuccessful {
-			return "", fmt.Errorf("failed to login")
+			return "", errors.New("failed to login")
 		}
 	}
 

--- a/pkg/platform/coverage/java/utils.go
+++ b/pkg/platform/coverage/java/utils.go
@@ -79,7 +79,7 @@ func downloadAndExtractJaCoCoCli(logger *zap.Logger, version, dir string) error 
 	cliStat, err := os.Stat(cliPath)
 
 	if os.IsNotExist(err) || cliStat != nil {
-		return fmt.Errorf("failed to find JaCoCo binaries in the distribution")
+		return errors.New("failed to find JaCoCo binaries in the distribution")
 	}
 
 	return nil

--- a/pkg/platform/coverage/javascript/javascript.go
+++ b/pkg/platform/coverage/javascript/javascript.go
@@ -4,7 +4,7 @@ package javascript
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -103,7 +103,7 @@ func (j *Javascript) GetCoverage() (models.TestCoverage, error) {
 		return testCov, err
 	}
 	if len(coverageFilePaths) == 0 {
-		return testCov, fmt.Errorf("no coverage files found")
+		return testCov, errors.New("no coverage files found")
 	}
 
 	// coverage is calculated as: (no of statements covered / total no of statements) * 100

--- a/pkg/platform/docker/docker.go
+++ b/pkg/platform/docker/docker.go
@@ -3,6 +3,7 @@ package docker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -75,12 +76,12 @@ func (idc *Impl) ExtractNetworksForContainer(containerName string) (map[string]*
 	// If the network list is empty, the docker daemon is possibly misbehaving,
 	// or the container is in a bad state.
 	utils.LogError(idc.logger, nil, "The network list for the given container is empty. This is unexpected.", zap.String("containerName", containerName))
-	return nil, fmt.Errorf("the container is not attached to any network")
+	return nil, errors.New("the container is not attached to any network")
 }
 
 func (idc *Impl) ConnectContainerToNetworks(containerName string, settings map[string]*network.EndpointSettings) error {
 	if settings == nil {
-		return fmt.Errorf("provided network settings is empty")
+		return errors.New("provided network settings is empty")
 	}
 
 	existingNetworks, err := idc.ExtractNetworksForContainer(containerName)
@@ -109,7 +110,7 @@ func (idc *Impl) ConnectContainerToNetworks(containerName string, settings map[s
 
 func (idc *Impl) AttachNetwork(containerName string, networkNames []string) error {
 	if len(networkNames) == 0 {
-		return fmt.Errorf("provided network names list is empty")
+		return errors.New("provided network names list is empty")
 	}
 
 	existingNetworks, err := idc.ExtractNetworksForContainer(containerName)
@@ -364,7 +365,7 @@ func (idc *Impl) GetHostWorkingDirectory() (string, error) {
 			return mount.Source, nil
 		}
 	}
-	return "", fmt.Errorf(fmt.Sprintf("could not find mount for %s in keploy-v2 container", curDir))
+	return "", fmt.Errorf("could not find mount for %s in keploy-v2 container", curDir)
 }
 
 // ForceAbsolutePath replaces relative paths in bind mounts with absolute paths

--- a/pkg/platform/docker/util.go
+++ b/pkg/platform/docker/util.go
@@ -3,7 +3,7 @@
 package docker
 
 import (
-	"fmt"
+	"errors"
 	"regexp"
 
 	"go.keploy.io/server/v2/utils"
@@ -26,7 +26,7 @@ func ParseDockerCmd(cmd string, kind utils.CmdType, idc Client) (string, string,
 	containerNameRegex := regexp.MustCompile(containerNamePattern)
 	containerNameMatches := containerNameRegex.FindStringSubmatch(cmd)
 	if len(containerNameMatches) < 2 {
-		return "", "", fmt.Errorf("failed to parse container name")
+		return "", "", errors.New("failed to parse container name")
 	}
 	containerName := containerNameMatches[1]
 
@@ -38,14 +38,14 @@ func ParseDockerCmd(cmd string, kind utils.CmdType, idc Client) (string, string,
 		for i := range networks {
 			return containerName, i, nil
 		}
-		return containerName, "", fmt.Errorf("failed to parse network name")
+		return containerName, "", errors.New("failed to parse network name")
 	}
 
 	// Extract network name
 	networkNameRegex := regexp.MustCompile(networkNamePattern)
 	networkNameMatches := networkNameRegex.FindStringSubmatch(cmd)
 	if len(networkNameMatches) < 3 {
-		return containerName, "", fmt.Errorf("failed to parse network name")
+		return containerName, "", errors.New("failed to parse network name")
 	}
 	networkName := networkNameMatches[2]
 

--- a/pkg/service/contract/contract.go
+++ b/pkg/service/contract/contract.go
@@ -4,6 +4,7 @@ package contract
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -105,7 +106,7 @@ func (s *contract) HTTPDocToOpenAPI(logger *zap.Logger, custom models.HTTPDoc) (
 	// Generate Operation ID
 	operationID := generateUniqueID()
 	if operationID == "" {
-		err := fmt.Errorf("failed to generate unique ID")
+		err := errors.New("failed to generate unique ID")
 		utils.LogError(logger, err, "failed to generate unique ID")
 		return models.OpenAPI{}, err
 	}
@@ -291,7 +292,7 @@ func (s *contract) GenerateMocksSchemas(ctx context.Context, services []string, 
 						openapi, err := s.HTTPDocToOpenAPI(s.logger, *mock)
 						if err != nil {
 							utils.LogError(s.logger, err, "failed to convert the yaml file to openapi")
-							return fmt.Errorf("failed to convert the yaml file to openapi")
+							return errors.New("failed to convert the yaml file to openapi")
 						}
 
 						// Validate the generated OpenAPI schema.
@@ -352,7 +353,7 @@ func (s *contract) GenerateTestsSchemas(ctx context.Context, selectedTests []str
 			openapi, err := s.HTTPDocToOpenAPI(s.logger, httpSpec)
 			if err != nil {
 				utils.LogError(s.logger, err, "failed to convert the yaml file to openapi")
-				return fmt.Errorf("failed to convert the yaml file to openapi")
+				return errors.New("failed to convert the yaml file to openapi")
 			}
 			// Validate the OpenAPI document
 			err = validateSchema(openapi)
@@ -375,8 +376,8 @@ func (s *contract) GenerateTestsSchemas(ctx context.Context, selectedTests []str
 
 func (s *contract) Generate(ctx context.Context, checkConfig bool) error {
 	if checkConfig && checkConfigFile(s.config.Contract.Mappings.ServicesMapping) != nil {
-		utils.LogError(s.logger, fmt.Errorf("Unable to find services mappings in the config file"), "Unable to find services mappings in the config file")
-		return fmt.Errorf("Unable to find services mappings in the config file")
+		utils.LogError(s.logger, errors.New("unable to find services mappings in the config file"), "unable to find services mappings in the config file")
+		return errors.New("unable to find services mappings in the config file")
 	}
 
 	mappings := s.config.Contract.Mappings.ServicesMapping
@@ -603,15 +604,15 @@ func (s *contract) DownloadMocks(ctx context.Context, _ string) error {
 func (s *contract) Download(ctx context.Context, checkConfig bool) error {
 
 	if checkConfig && checkConfigFile(s.config.Contract.Mappings.ServicesMapping) != nil {
-		utils.LogError(s.logger, fmt.Errorf("Unable to find services mappings in the config file"), "Unable to find services mappings in the config file")
-		return fmt.Errorf("Unable to find services mappings in the config file")
+		utils.LogError(s.logger, errors.New("unable to find services mappings in the config file"), "Unable to find services mappings in the config file")
+		return errors.New("unable to find services mappings in the config file")
 	}
 	path := s.config.Contract.Path
 	// Validate the path
 	path, err := yaml.ValidatePath(path)
 	if err != nil {
 		utils.LogError(s.logger, err, "failed to validate path")
-		return fmt.Errorf("Error in validating path")
+		return errors.New("error in validating path")
 	}
 	driven := s.config.Contract.Driven
 	if driven == models.ProviderMode.String() {
@@ -635,8 +636,8 @@ func (s *contract) Download(ctx context.Context, checkConfig bool) error {
 
 func (s *contract) Validate(ctx context.Context) error {
 	if s.config.Contract.Mappings.Self == "" {
-		utils.LogError(s.logger, fmt.Errorf("Self service is not defined in the config file"), "Self service is not defined in the config file")
-		return fmt.Errorf("Self service is not defined in the config file")
+		utils.LogError(s.logger, errors.New("self service is not defined in the config file"), "Self service is not defined in the config file")
+		return errors.New("self service is not defined in the config file")
 	}
 
 	if s.config.Contract.Generate {

--- a/pkg/service/contract/utils.go
+++ b/pkg/service/contract/utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -239,7 +240,7 @@ func generateUniqueID() string {
 func checkConfigFile(servicesMapping map[string][]string) error {
 	// Check if the size of servicesMapping is less than 1
 	if len(servicesMapping) < 1 {
-		return fmt.Errorf("services mapping must contain at least 1 services")
+		return errors.New("services mapping must contain at least 1 services")
 	}
 	return nil
 }

--- a/pkg/service/import/import.go
+++ b/pkg/service/import/import.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -79,11 +80,11 @@ func (pi *PostmanImporter) Import(collectionPath, basePath string) error {
 
 func (pi *PostmanImporter) validateCollectionPath(path string) error {
 	if path == "" {
-		return fmt.Errorf("path to Postman collection cannot be empty")
+		return errors.New("path to Postman collection cannot be empty")
 	}
 
 	if !strings.HasSuffix(path, ".json") {
-		return fmt.Errorf("invalid file type: expected .json Postman collection")
+		return errors.New("invalid file type: expected .json Postman collection")
 	}
 
 	return nil
@@ -345,7 +346,7 @@ func (pi *PostmanImporter) processEmptyResponse(testItem *TestData, globalVariab
 		return nil
 	}
 	pi.logger.Error("URL is empty", zap.String("testItem", testItem.Name))
-	return fmt.Errorf("URL is empty")
+	return errors.New("URL is empty")
 }
 
 func (pi *PostmanImporter) writeTestData(testItem TestData, testsPath string, globalVariables map[string]string, testCounter *int) error {

--- a/pkg/service/orchestrator/rerecord.go
+++ b/pkg/service/orchestrator/rerecord.go
@@ -5,7 +5,7 @@ package orchestrator
 import (
 	"bufio"
 	"context"
-	"fmt"
+	"errors"
 	"os"
 	"sort"
 	"strconv"
@@ -143,7 +143,7 @@ func (o *Orchestrator) ReRecord(ctx context.Context) error {
 
 	if stopReason != "" {
 		utils.LogError(o.logger, err, stopReason)
-		return fmt.Errorf(stopReason)
+		return errors.New(stopReason)
 	}
 
 	if ctx.Err() != nil {
@@ -186,7 +186,7 @@ func (o *Orchestrator) replayTests(ctx context.Context, testSet string) (bool, e
 	if err != nil {
 		errMsg := "failed to get all testcases"
 		utils.LogError(o.logger, err, errMsg, zap.String("testset", testSet))
-		return false, fmt.Errorf(errMsg)
+		return false, errors.New(errMsg)
 	}
 
 	if len(tcs) == 0 {
@@ -199,7 +199,7 @@ func (o *Orchestrator) replayTests(ctx context.Context, testSet string) (bool, e
 		errMsg := "failed to extract host and port"
 		utils.LogError(o.logger, err, "")
 		o.logger.Debug("", zap.String("curl", tcs[0].Curl))
-		return false, fmt.Errorf(errMsg)
+		return false, errors.New(errMsg)
 	}
 	cmdType := utils.CmdType(o.config.CommandType)
 
@@ -278,7 +278,7 @@ func (o *Orchestrator) replayTests(ctx context.Context, testSet string) (bool, e
 	}
 
 	if simErr {
-		return allTcRecorded, fmt.Errorf("got error while simulating HTTP request. Please make sure the related services are up and running")
+		return allTcRecorded, errors.New("got error while simulating HTTP request. Please make sure the related services are up and running")
 	}
 
 	return allTcRecorded, nil

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -103,7 +103,7 @@ func (r *Recorder) Start(ctx context.Context, reRecord bool) error {
 	if err != nil {
 		stopReason = "failed to get new test-set id"
 		utils.LogError(r.logger, err, stopReason)
-		return fmt.Errorf(stopReason)
+		return errors.New(stopReason)
 	}
 
 	//checking for context cancellation as we don't want to start the instrumentation if the context is cancelled
@@ -118,7 +118,7 @@ func (r *Recorder) Start(ctx context.Context, reRecord bool) error {
 	if err != nil {
 		stopReason = "failed to instrument the application"
 		utils.LogError(r.logger, err, stopReason)
-		return fmt.Errorf(stopReason)
+		return errors.New(stopReason)
 	}
 
 	r.config.AppID = appID
@@ -131,7 +131,7 @@ func (r *Recorder) Start(ctx context.Context, reRecord bool) error {
 		if ctx.Err() == context.Canceled {
 			return err
 		}
-		return fmt.Errorf(stopReason)
+		return errors.New(stopReason)
 	}
 
 	errGrp.Go(func() error {
@@ -228,7 +228,7 @@ func (r *Recorder) Start(ctx context.Context, reRecord bool) error {
 		return nil
 	}
 	utils.LogError(r.logger, err, stopReason)
-	return fmt.Errorf(stopReason)
+	return errors.New(stopReason)
 }
 
 func (r *Recorder) Instrument(ctx context.Context) (uint64, error) {
@@ -238,7 +238,7 @@ func (r *Recorder) Instrument(ctx context.Context) (uint64, error) {
 	if err != nil {
 		stopReason = "failed setting up the environment"
 		utils.LogError(r.logger, err, stopReason)
-		return 0, fmt.Errorf(stopReason)
+		return 0, errors.New(stopReason)
 	}
 	r.config.AppID = appID
 
@@ -262,7 +262,7 @@ func (r *Recorder) Instrument(ctx context.Context) (uint64, error) {
 			if ctx.Err() == context.Canceled {
 				return appID, err
 			}
-			return appID, fmt.Errorf(stopReason)
+			return appID, errors.New(stopReason)
 		}
 	}
 	return appID, nil

--- a/pkg/service/replay/hooks.go
+++ b/pkg/service/replay/hooks.go
@@ -4,6 +4,7 @@ package replay
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -263,5 +264,5 @@ func extractClaimsWithoutVerification(tokenString string) (jwt.MapClaims, error)
 	if claims, ok := token.Claims.(jwt.MapClaims); ok {
 		return claims, nil
 	}
-	return nil, fmt.Errorf("unable to parse claims")
+	return nil, errors.New("unable to parse claims")
 }

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -107,21 +107,21 @@ func (r *Replayer) Start(ctx context.Context) error {
 	if err != nil {
 		stopReason = fmt.Sprintf("failed to get all test set ids: %v", err)
 		utils.LogError(r.logger, err, stopReason)
-		return fmt.Errorf(stopReason)
+		return errors.New(stopReason)
 	}
 
 	if len(testSetIDs) == 0 {
 		recordCmd := models.HighlightGrayString("keploy record")
 		errMsg := fmt.Sprintf("No test sets found in the keploy folder. Please record testcases using %s command", recordCmd)
 		utils.LogError(r.logger, err, errMsg)
-		return fmt.Errorf(errMsg)
+		return errors.New(errMsg)
 	}
 
 	testRunID, err := r.GetNextTestRunID(ctx)
 	if err != nil {
 		stopReason = fmt.Sprintf("failed to get next test run id: %v", err)
 		utils.LogError(r.logger, err, stopReason)
-		return fmt.Errorf(stopReason)
+		return errors.New(stopReason)
 	}
 
 	var language config.Language
@@ -181,7 +181,7 @@ func (r *Replayer) Start(ctx context.Context) error {
 		if ctx.Err() == context.Canceled {
 			return err
 		}
-		return fmt.Errorf(stopReason)
+		return errors.New(stopReason)
 	}
 
 	hookCancel = inst.HookCancel
@@ -211,7 +211,7 @@ func (r *Replayer) Start(ctx context.Context) error {
 			if ctx.Err() == context.Canceled {
 				return err
 			}
-			return fmt.Errorf(stopReason)
+			return errors.New(stopReason)
 		}
 
 		if !r.config.Test.SkipCoverage {
@@ -235,7 +235,7 @@ func (r *Replayer) Start(ctx context.Context) error {
 			if ctx.Err() == context.Canceled {
 				return err
 			}
-			return fmt.Errorf(stopReason)
+			return errors.New(stopReason)
 		}
 		switch testSetStatus {
 		case models.TestSetStatusAppHalted:
@@ -788,7 +788,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 	err = r.reportDB.InsertReport(reportCtx, testRunID, testSetID, testReport)
 	if err != nil {
 		utils.LogError(r.logger, err, "failed to insert report")
-		return models.TestSetStatusInternalErr, fmt.Errorf("failed to insert report")
+		return models.TestSetStatusInternalErr, errors.New("failed to insert report")
 	}
 
 	err = utils.AddToGitIgnore(r.logger, r.config.Path, "/reports/")

--- a/pkg/service/utgen/gen.go
+++ b/pkg/service/utgen/gen.go
@@ -3,6 +3,7 @@ package utgen
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -94,7 +95,7 @@ func (g *UnitTestGenerator) Start(ctx context.Context) error {
 	// Check for context cancellation before proceeding
 	select {
 	case <-ctx.Done():
-		return fmt.Errorf("process cancelled by user")
+		return errors.New("process cancelled by user")
 	default:
 		// Continue if no cancellation
 	}
@@ -105,7 +106,7 @@ func (g *UnitTestGenerator) Start(ctx context.Context) error {
 			return err
 		}
 		if len(g.Files) == 0 {
-			return fmt.Errorf("couldn't identify the source files. Please mention source file and test file using flags")
+			return errors.New("couldn't identify the source files. Please mention source file and test file using flags")
 		}
 	}
 	const paddingHeight = 1
@@ -119,7 +120,7 @@ func (g *UnitTestGenerator) Start(ctx context.Context) error {
 		// Respect context cancellation in each iteration
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("process cancelled by user")
+			return errors.New("process cancelled by user")
 		default:
 		}
 
@@ -177,7 +178,7 @@ func (g *UnitTestGenerator) Start(ctx context.Context) error {
 			passedTests, noCoverageTest, failedBuild, totalTest := 0, 0, 0, 0
 			select {
 			case <-ctx.Done():
-				return fmt.Errorf("process cancelled by user")
+				return errors.New("process cancelled by user")
 			default:
 			}
 
@@ -259,7 +260,7 @@ func (g *UnitTestGenerator) Start(ctx context.Context) error {
 				}
 				select {
 				case <-ctx.Done():
-					return fmt.Errorf("process cancelled by user")
+					return errors.New("process cancelled by user")
 				default:
 				}
 				coverageInc, err := g.ValidateTest(generatedTest, &passedTests, &noCoverageTest, &failedBuild, installedPackages)
@@ -586,7 +587,7 @@ func (g *UnitTestGenerator) getIndentation(ctx context.Context) (int, error) {
 		counterAttempts++
 	}
 	if indentation == -1 {
-		return 0, fmt.Errorf("failed to analyze the test headers indentation")
+		return 0, errors.New("failed to analyze the test headers indentation")
 	}
 	return indentation, nil
 }
@@ -624,7 +625,7 @@ func (g *UnitTestGenerator) getLine(ctx context.Context) (int, error) {
 		counterAttempts++
 	}
 	if line == -1 {
-		return 0, fmt.Errorf("failed to analyze the relevant line number to insert new tests")
+		return 0, errors.New("failed to analyze the relevant line number to insert new tests")
 	}
 	return line, nil
 }

--- a/pkg/service/utgen/injector.go
+++ b/pkg/service/utgen/injector.go
@@ -3,6 +3,7 @@ package utgen
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"go/ast"
 	"go/parser"
@@ -272,7 +273,7 @@ func (i *Injector) updateGoImports(codeBlock string, newImports []string) (strin
 
 	pkgMatch := packageRegex.FindStringIndex(codeBlock)
 	if pkgMatch == nil {
-		return "", 0, fmt.Errorf("could not find package declaration")
+		return "", 0, errors.New("could not find package declaration")
 	}
 	newImports = i.extractGoImports(newImports, false)
 	importBlock := i.createGoImportBlock(newImports)

--- a/pkg/service/utgen/prompt.go
+++ b/pkg/service/utgen/prompt.go
@@ -103,7 +103,7 @@ func NewPromptBuilder(srcPath, testPath, covReportContent, includedFiles, additi
 func readFile(filePath string) (string, error) {
 	content, err := os.ReadFile(filePath)
 	if err != nil {
-		return "", fmt.Errorf("Error reading %s: %v", filePath, err)
+		return "", fmt.Errorf("error reading %s: %v", filePath, err)
 	}
 	return string(content), nil
 }
@@ -114,7 +114,7 @@ func formatSection(content, templateText string) (string, error) {
 	}
 	tmpl, err := template.New("section").Parse(templateText)
 	if err != nil {
-		return "", fmt.Errorf("Error parsing section template: %v", err)
+		return "", fmt.Errorf("error parsing section template: %v", err)
 	}
 	var buffer bytes.Buffer
 	err = tmpl.Execute(&buffer, map[string]string{
@@ -123,7 +123,7 @@ func formatSection(content, templateText string) (string, error) {
 		"FailedTestRuns":         content,
 	})
 	if err != nil {
-		return "", fmt.Errorf("Error executing section template: %v", err)
+		return "", fmt.Errorf("error executing section template: %v", err)
 	}
 	return buffer.String(), nil
 }
@@ -159,7 +159,7 @@ func (pb *PromptBuilder) BuildPrompt(file, failedTestRuns string) (*Prompt, erro
 	if err != nil {
 		prompt.System = ""
 		prompt.User = ""
-		return prompt, fmt.Errorf("Error rendering system prompt: %v", err)
+		return prompt, fmt.Errorf("error rendering system prompt: %v", err)
 	}
 	prompt.System = systemPrompt
 
@@ -167,7 +167,7 @@ func (pb *PromptBuilder) BuildPrompt(file, failedTestRuns string) (*Prompt, erro
 	if err != nil {
 		prompt.System = ""
 		prompt.User = ""
-		return prompt, fmt.Errorf("Error rendering user prompt: %v", err)
+		return prompt, fmt.Errorf("error rendering user prompt: %v", err)
 	}
 	userPrompt = html.UnescapeString(userPrompt)
 	prompt.User = userPrompt

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -391,7 +392,7 @@ func ExtractHostAndPort(curlCmd string) (string, string, error) {
 			return host, port, nil
 		}
 	}
-	return "", "", fmt.Errorf("no URL found in CURL command")
+	return "", "", errors.New("no URL found in CURL command")
 }
 
 func WaitForPort(ctx context.Context, host string, port string, timeout time.Duration) error {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -52,7 +52,7 @@ func ReplaceHost(currentURL string, ipAddress string) (string, error) {
 	}
 
 	if ipAddress == "" {
-		return currentURL, fmt.Errorf("failed to replace url in case of docker env")
+		return currentURL, errors.New("failed to replace url in case of docker env")
 	}
 
 	// Replace hostname with the IP address
@@ -72,7 +72,7 @@ func ReplaceBaseURL(currentURL string, baseURL string) (string, error) {
 
 	// Check if baseURL is valid
 	if baseURL == "" {
-		return currentURL, fmt.Errorf("failed to replace baseURL: baseURL is empty")
+		return currentURL, errors.New("failed to replace baseURL: baseURL is empty")
 	}
 
 	// Parse the new baseURL
@@ -91,7 +91,7 @@ func ReplaceBaseURL(currentURL string, baseURL string) (string, error) {
 
 func ReplacePort(currentURL string, port string) (string, error) {
 	if port == "" {
-		return currentURL, fmt.Errorf("failed to replace port in case of docker env")
+		return currentURL, errors.New("failed to replace port in case of docker env")
 	}
 
 	parsedURL, err := url.Parse(currentURL)


### PR DESCRIPTION
## What does this PR do?

This PR replaces all occurrences of `fmt.Errorf` without format specifiers with `errors.New` to address static analysis warnings ([SA1006](https://staticcheck.dev/docs/checks#SA1006)) and improve code clarity.

While the performance difference is minimal, using `errors.New` for simple string errors follows Go's idiomatic practices and prevents linter warnings about improper use of printf-style functions.

## Related PRs and Issues

- (Info about Related PR or issue) `NA`

Closes: #[issue number that will be closed through this PR]

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know test plan followed

Please describe the tests(if any). Provide instructions how its affecting the coverage.

## Checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] New and existing unit tests pass locally with my changes.
