### PR TITLE
fix: certificate invalid if application time is before cert issuance time

### DIFF
--- a/.github/workflows/test_workflow_scripts/golang-http-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang-http-linux.sh
@@ -62,7 +62,7 @@ send_request() {
 for i in {1..2}; do
     app_name="http-pokeapi_${i}"
     send_request $i &
-    sudo -E env PATH="$PATH" ./../../keployv2 record -c "./http-pokeapi" --generateGithubActions=false &> "${app_name}.txt"
+    sudo -E env PATH="$PATH" ./../../keployv2 record -c "./http-pokeapi" --generateGithubActions=false --debug &> "${app_name}.txt"
     if grep "ERROR" "${app_name}.txt"; then
         echo "Error found in pipeline..."
         cat "${app_name}.txt"
@@ -79,7 +79,7 @@ for i in {1..2}; do
 done
 
 # Start the go-http app in test mode.
-sudo -E env PATH="$PATH" ./../../keployv2 test -c "./http-pokeapi" --delay 7 --generateGithubActions=false &> test_logs.txt
+sudo -E env PATH="$PATH" ./../../keployv2 test -c "./http-pokeapi" --delay 7 --generateGithubActions=false --debug &> test_logs.txt
 
 if grep "ERROR" "test_logs.txt"; then
     echo "Error found in pipeline..."

--- a/.github/workflows/test_workflow_scripts/golang-http-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang-http-linux.sh
@@ -62,7 +62,7 @@ send_request() {
 for i in {1..2}; do
     app_name="http-pokeapi_${i}"
     send_request $i &
-    sudo -E env PATH="$PATH" ./../../keployv2 record -c "./http-pokeapi" --generateGithubActions=false --debug &> "${app_name}.txt"
+    sudo -E env PATH="$PATH" ./../../keployv2 record -c "./http-pokeapi" --generateGithubActions=false &> "${app_name}.txt"
     if grep "ERROR" "${app_name}.txt"; then
         echo "Error found in pipeline..."
         cat "${app_name}.txt"
@@ -79,7 +79,7 @@ for i in {1..2}; do
 done
 
 # Start the go-http app in test mode.
-sudo -E env PATH="$PATH" ./../../keployv2 test -c "./http-pokeapi" --delay 7 --generateGithubActions=false --debug &> test_logs.txt
+sudo -E env PATH="$PATH" ./../../keployv2 test -c "./http-pokeapi" --delay 7 --generateGithubActions=false &> test_logs.txt
 
 if grep "ERROR" "test_logs.txt"; then
     echo "Error found in pipeline..."

--- a/pkg/core/proxy/integrations/mysql/recorder/conn.go
+++ b/pkg/core/proxy/integrations/mysql/recorder/conn.go
@@ -144,7 +144,7 @@ func handleInitialHandshake(ctx context.Context, logger *zap.Logger, clientConn,
 		// handle the TLS connection and get the upgraded client connection
 		isTLS := pTls.IsTLSHandshake(testBuffer)
 		if isTLS {
-			clientConn, err = pTls.HandleTLSConnection(ctx, logger, clientConn)
+			clientConn, err = pTls.HandleTLSConnection(ctx, logger, clientConn, time.Now())
 			if err != nil {
 				utils.LogError(logger, err, "failed to handle TLS conn")
 				return res, err

--- a/pkg/core/proxy/integrations/mysql/replayer/conn.go
+++ b/pkg/core/proxy/integrations/mysql/replayer/conn.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"time"
 
 	"go.keploy.io/server/v2/pkg/core/proxy/integrations"
 	mysqlUtils "go.keploy.io/server/v2/pkg/core/proxy/integrations/mysql/utils"
@@ -140,7 +141,7 @@ func simulateInitialHandshake(ctx context.Context, logger *zap.Logger, clientCon
 		// handle the TLS connection and get the upgraded client connection
 		isTLS := pTls.IsTLSHandshake(testBuffer)
 		if isTLS {
-			clientConn, err = pTls.HandleTLSConnection(ctx, logger, clientConn)
+			clientConn, err = pTls.HandleTLSConnection(ctx, logger, clientConn, time.Now())
 			if err != nil {
 				utils.LogError(logger, err, "failed to handle TLS conn")
 				return res, err

--- a/pkg/core/proxy/proxy.go
+++ b/pkg/core/proxy/proxy.go
@@ -450,7 +450,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 
 	isTLS := pTls.IsTLSHandshake(testBuffer)
 	if isTLS {
-		srcConn, err = pTls.HandleTLSConnection(ctx, p.logger, srcConn)
+		srcConn, err = pTls.HandleTLSConnection(ctx, p.logger, srcConn, rule.Backdate)
 		if err != nil {
 			utils.LogError(p.logger, err, "failed to handle TLS conn")
 			return err

--- a/pkg/core/proxy/tls/ca.go
+++ b/pkg/core/proxy/tls/ca.go
@@ -307,6 +307,11 @@ func CertForClient(logger *zap.Logger, clientHello *tls.ClientHelloInfo, caPrivK
 		return nil, fmt.Errorf("failed to create signer: %v", err)
 	}
 
+	if backdate.IsZero() {
+		logger.Debug("backdate is zero, using current time")
+		backdate = time.Now()
+	}
+
 	// Case: time freezing (an Ent. feature) is enabled,
 	// If application time is frozen in past, and the certificate is signed today, then the certificate will be invalid.
 	// This results in a certificate error during tls handshake.
@@ -320,7 +325,7 @@ func CertForClient(logger *zap.Logger, clientHello *tls.ClientHelloInfo, caPrivK
 		Request:   string(serverCsr),
 		Profile:   "web",
 		NotBefore: backdate.AddDate(-1, 0, 0),
-		NotAfter:  backdate.AddDate(1, 0, 0),
+		NotAfter:  time.Now().AddDate(1, 0, 0),
 	}
 
 	serverCert, err := signerd.Sign(signReq)

--- a/pkg/core/proxy/tls/ca.go
+++ b/pkg/core/proxy/tls/ca.go
@@ -15,6 +15,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/cloudflare/cfssl/csr"
 	cfsslLog "github.com/cloudflare/cfssl/log"
@@ -254,7 +255,7 @@ var SrcPortToDstURL = sync.Map{}
 
 var setLogLevelOnce sync.Once
 
-func CertForClient(clientHello *tls.ClientHelloInfo, caPrivKey any, caCertParsed *x509.Certificate) (*tls.Certificate, error) {
+func CertForClient(logger *zap.Logger, clientHello *tls.ClientHelloInfo, caPrivKey any, caCertParsed *x509.Certificate, backdate time.Time) (*tls.Certificate, error) {
 
 	// Ensure log level is set only once
 
@@ -306,14 +307,28 @@ func CertForClient(clientHello *tls.ClientHelloInfo, caPrivKey any, caCertParsed
 		return nil, fmt.Errorf("failed to create signer: %v", err)
 	}
 
-	serverCert, err := signerd.Sign(signer.SignRequest{
-		Hosts:   serverReq.Hosts,
-		Request: string(serverCsr),
-		Profile: "web",
-	})
+	// Case: time freezing (an Ent. feature) is enabled,
+	// If application time is frozen in past, and the certificate is signed today, then the certificate will be invalid.
+	// This results in a certificate error during tls handshake.
+	// To avoid this, we set the certificate’s validity period (NotBefore and NotAfter)
+	// by referencing the testcase request time of the application (backdate) instead of the current real time.
+	//
+	// Note: If you have recorded test cases before April 20, 2024 (http://www.sslchecker.com/certdecoder?su=269725513dfeb137f6f29b8488f17ca9)
+	// and are using time freezing, please reach out to us if you get tls handshake error.
+	signReq := signer.SignRequest{
+		Hosts:     serverReq.Hosts,
+		Request:   string(serverCsr),
+		Profile:   "web",
+		NotBefore: backdate.AddDate(-1, 0, 0),
+		NotAfter:  backdate.AddDate(1, 0, 0),
+	}
+
+	serverCert, err := signerd.Sign(signReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign server certificate: %v", err)
 	}
+
+	logger.Debug("signed the certificate for a duration of 2 years", zap.Any("notBefore", signReq.NotBefore.String()), zap.Any("notAfter", signReq.NotAfter.String()))
 
 	// Load the server certificate and private key
 	serverTLSCert, err := tls.X509KeyPair(serverCert, serverKey)

--- a/pkg/core/proxy/tls/tls.go
+++ b/pkg/core/proxy/tls/tls.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/tls"
 	"net"
+	"time"
 
 	"github.com/cloudflare/cfssl/helpers"
 	"go.keploy.io/server/v2/utils"
@@ -19,7 +20,7 @@ func IsTLSHandshake(data []byte) bool {
 	return data[0] == 0x16 && data[1] == 0x03 && (data[2] == 0x00 || data[2] == 0x01 || data[2] == 0x02 || data[2] == 0x03)
 }
 
-func HandleTLSConnection(_ context.Context, logger *zap.Logger, conn net.Conn) (net.Conn, error) {
+func HandleTLSConnection(_ context.Context, logger *zap.Logger, conn net.Conn, backdate time.Time) (net.Conn, error) {
 	//Load the CA certificate and private key
 
 	caPrivKey, err := helpers.ParsePrivateKeyPEM(caPKey)
@@ -36,7 +37,7 @@ func HandleTLSConnection(_ context.Context, logger *zap.Logger, conn net.Conn) (
 	// Create a TLS configuration
 	config := &tls.Config{
 		GetCertificate: func(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
-			return CertForClient(clientHello, caPrivKey, caCertParsed)
+			return CertForClient(logger, clientHello, caPrivKey, caCertParsed, backdate)
 		},
 	}
 

--- a/pkg/models/instrument.go
+++ b/pkg/models/instrument.go
@@ -23,6 +23,7 @@ type OutgoingOptions struct {
 	FallBackOnMiss bool          // this enables to pass the request to the actual server if no mock is found during test mode.
 	Mocking        bool          // used to enable/disable mocking
 	DstCfg         *ConditionalDstCfg
+	Backdate       time.Time // used to set backdate in cacert request
 }
 
 type ConditionalDstCfg struct {

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -282,6 +282,7 @@ func (r *Recorder) GetTestAndMockChans(ctx context.Context, appID uint64) (Frame
 		Rules:          r.config.BypassRules,
 		MongoPassword:  r.config.Test.MongoPassword,
 		FallBackOnMiss: r.config.Test.FallBackOnMiss,
+		Backdate:       time.Now(),
 	}
 
 	outgoingChan, err := r.instrumentation.GetOutgoing(ctx, appID, outgoingOpts)


### PR DESCRIPTION
## What does this PR do?

testcase req time is used for time freezing, so we used first testcase req time as an alias for the application frozen time, we used this time to calculate the NotBefore and NotAfter field in certificate signing request. The duration of the signed certificate is 2 years. (backdate - 1 yr, backdate + 1 yr) 

## Related PRs and Issues


Closes: #2662

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know test plan followed

Please describe the tests(if any). Provide instructions how its affecting the coverage.

## Checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] New and existing unit tests pass locally with my changes.
