### PR TITLE
fix: Improve error handling and resource management in ReadSessionIndices

### DIFF
--- a/pkg/util.go
+++ b/pkg/util.go
@@ -269,7 +269,7 @@ func ReadSessionIndices(path string, Logger *zap.Logger) ([]string, error) {
 
 	dir, err := os.OpenFile(path, os.O_RDONLY, fs.FileMode(os.O_RDONLY))
 	if err != nil {
-		Logger.Debug("creating a folder for the keploy generated testcases", zap.Error(err))
+		Logger.Debug("creating a folder for the keploy  generated testcases", zap.Error(err))
 		return indices, err
 	}
 	defer func() {

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -269,11 +269,13 @@ func ReadSessionIndices(path string, Logger *zap.Logger) ([]string, error) {
 	dir, err := os.OpenFile(path, os.O_RDONLY, fs.FileMode(os.O_RDONLY))
 	if err != nil {
 		Logger.Debug("creating a folder for the keploy generated testcases", zap.Error(err))
-		return indices, nil
+		return indices, err
 	}
+	defer dir.Close()
 
 	files, err := dir.ReadDir(0)
 	if err != nil {
+		Logger.Debug("failed to read directory contents", zap.Error(err))
 		return indices, err
 	}
 

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -266,12 +266,17 @@ func MakeCurlCommand(tc models.HTTPReq) string {
 
 func ReadSessionIndices(path string, Logger *zap.Logger) ([]string, error) {
 	indices := []string{}
+
 	dir, err := os.OpenFile(path, os.O_RDONLY, fs.FileMode(os.O_RDONLY))
 	if err != nil {
 		Logger.Debug("creating a folder for the keploy generated testcases", zap.Error(err))
 		return indices, err
 	}
-	defer dir.Close()
+	defer func() {
+		if closeErr := dir.Close(); closeErr != nil {
+			Logger.Debug("failed to close directory", zap.Error(closeErr))
+		}
+	}()
 
 	files, err := dir.ReadDir(0)
 	if err != nil {
@@ -284,8 +289,10 @@ func ReadSessionIndices(path string, Logger *zap.Logger) ([]string, error) {
 			indices = append(indices, v.Name())
 		}
 	}
+
 	return indices, nil
 }
+
 
 func NextID(IDs []string, identifier string) string {
 	latestIndx := 0

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -293,7 +293,6 @@ func ReadSessionIndices(path string, Logger *zap.Logger) ([]string, error) {
 	return indices, nil
 }
 
-
 func NextID(IDs []string, identifier string) string {
 	latestIndx := 0
 	for _, ID := range IDs {


### PR DESCRIPTION
## Describe the changes that are made
-  Replaced returning `nil` for error handling with returning the actual error in case of an issue while opening the directory.

- Added defer `dir.Close()` to ensure the directory is closed after reading its contents.

- Enhanced logging for errors when reading directory contents.

## What type of PR is this? (check all applicable)
- [x] 🧑‍💻 Code Refactor
- [x] 🔥 Performance Improvements

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [x] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code to test the changes?
- [ ] 👍 yes, mentioned below
- [x] 🙅 no, because it is not needed

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?