### PR TITLE
fix: make redis as generic (#2639)

### DIFF
--- a/pkg/core/proxy/integrations/redis/redis.go
+++ b/pkg/core/proxy/integrations/redis/redis.go
@@ -13,12 +13,12 @@ import (
 	"go.uber.org/zap"
 )
 
-func init() {
-	integrations.Register(integrations.REDIS, &integrations.Parsers{
-		Initializer: New,
-		Priority:    100,
-	})
-}
+// func init() {
+// 	integrations.Register(integrations.REDIS, &integrations.Parsers{
+// 		Initializer: New,
+// 		Priority:    100,
+// 	})
+// }
 
 type Redis struct {
 	logger *zap.Logger


### PR DESCRIPTION
## Describe the changes that are made
- Fixed the header parsing logic in `ToHTTPHeader()` to correctly handle multi-value headers like `Set-Cookie`, which may contain commas in their values.
- Introduced use of `http.CanonicalHeaderKey()` to normalize the header keys (e.g., `Set-Cookie`, `set-cookie`, etc.).
- Added a check to avoid splitting values of headers that legally contain commas.
- Added unit tests in `utils_test.go` to verify the correctness of header parsing.

## Links & References

**Fixes:** #2640

### 🔗 Related PRs
- NA

### 🐞 Related Issues
- https://github.com/keploy/keploy/issues/2640

### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code to test the changes?
- [x] 👍 yes, mentioned in `utils_test.go`
- [ ] 🙅 no, because it is not needed

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
