### PR TITLE
fix: enable >750KB read system call for http/grpc record 

### DIFF
--- a/pkg/core/proxy/integrations/grpc/grpc.go
+++ b/pkg/core/proxy/integrations/grpc/grpc.go
@@ -40,13 +40,14 @@ func (g *Grpc) MatchType(_ context.Context, reqBuf []byte) bool {
 func (g *Grpc) RecordOutgoing(ctx context.Context, src net.Conn, dst net.Conn, mocks chan<- *models.Mock, opts models.OutgoingOptions) error {
 	logger := g.logger.With(zap.Any("Client IP Address", src.RemoteAddr().String()), zap.Any("Client ConnectionID", ctx.Value(models.ClientConnectionIDKey).(string)), zap.Any("Destination ConnectionID", ctx.Value(models.DestConnectionIDKey).(string)))
 
-	reqBuf, err := util.ReadInitialBuf(ctx, logger, src)
+	fullReqBuf, err := util.ReadBytes(ctx, logger, src)
 	if err != nil {
 		utils.LogError(logger, err, "failed to read the initial grpc message")
 		return err
 	}
+	logger.Debug("Complete request received of GRPC", zap.Int("size", len(fullReqBuf)))
 
-	err = encodeGrpc(ctx, logger, reqBuf, src, dst, mocks, opts)
+	err = encodeGrpc(ctx, logger, fullReqBuf, src, dst, mocks, opts)
 	if err != nil {
 		utils.LogError(logger, err, "failed to encode the grpc message into the yaml")
 		return err


### PR DESCRIPTION
## Describe the changes that are made
- `util.go`:

   Added `initialBufferSize` and `maxBufferSize` constants.

  `ReadBytes` now reads in 32KB chunks up to 5MB or EOF.

- `http.go`:

  `RecordOutgoing` now uses the new `ReadBytes` logic to capture full request payloads.

- `grpc.go`

   RecordOutgoing now uses the new `ReadBytes` logic to capture full request payloads.


## Links & References

**Fixes:** #2683   <!-- Replace with actual issue number -->
- NA (if very small change like typo, linting, etc.)

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [x] 🍕 Feature
- [x] 🐞 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [x] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [x] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code to test the changes?
- [ ] 👍 yes, mentioned below
- [x] 🙅 no, because it is not needed

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?