### PR TITLE
chore: telemetry as sync map to avoid race conditions

### DIFF
--- a/cli/provider/service.go
+++ b/cli/provider/service.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 
 	"go.keploy.io/server/v2/config"
@@ -39,7 +38,6 @@ func (n *ServiceProvider) GetService(ctx context.Context, cmd string) (interface
 		GlobalMap:      TeleGlobalMap,
 		InstallationID: n.cfg.InstallationID,
 	})
-	fmt.Println("here is global map", TeleGlobalMap)
 	tel.Ping()
 
 	switch cmd {

--- a/cli/provider/service.go
+++ b/cli/provider/service.go
@@ -3,6 +3,8 @@ package provider
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync"
 
 	"go.keploy.io/server/v2/config"
 	"go.keploy.io/server/v2/pkg/platform/telemetry"
@@ -13,7 +15,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var TeleGlobalMap = make(map[string]interface{})
+var TeleGlobalMap sync.Map
 
 type ServiceProvider struct {
 	logger *zap.Logger
@@ -37,6 +39,7 @@ func (n *ServiceProvider) GetService(ctx context.Context, cmd string) (interface
 		GlobalMap:      TeleGlobalMap,
 		InstallationID: n.cfg.InstallationID,
 	})
+	fmt.Println("here is global map", TeleGlobalMap)
 	tel.Ping()
 
 	switch cmd {

--- a/pkg/models/tele.go
+++ b/pkg/models/tele.go
@@ -1,12 +1,14 @@
 package models
 
+import "sync"
+
 type TeleEvent struct {
-	InstallationID string                 `json:"installationId"`
-	EventType      string                 `json:"eventType"`
-	Meta           map[string]interface{} `json:"meta"`
-	CreatedAt      int64                  `json:"createdAt"`
-	TeleCheck      bool                   `json:"tele_check"`
-	OS             string                 `json:"os"`
-	KeployVersion  string                 `json:"keploy_version"`
-	Arch           string                 `json:"arch"`
+	InstallationID string    `json:"installationId"`
+	EventType      string    `json:"eventType"`
+	Meta           *sync.Map `json:"meta"`
+	CreatedAt      int64     `json:"createdAt"`
+	TeleCheck      bool      `json:"tele_check"`
+	OS             string    `json:"os"`
+	KeployVersion  string    `json:"keploy_version"`
+	Arch           string    `json:"arch"`
 }

--- a/pkg/platform/telemetry/telemetry.go
+++ b/pkg/platform/telemetry/telemetry.go
@@ -97,7 +97,7 @@ func (tel *Telemetry) RecordedTestSuite(testSet string, testsTotal int, mockTota
 func (tel *Telemetry) RecordedTestAndMocks() {
 	dataMap := &sync.Map{}
 	mapcheck := make(map[string]int)
-	dataMap.Store("mocks", mapcheck) // Storing 0 instead of an empty map
+	dataMap.Store("mocks", mapcheck)
 	go tel.SendTelemetry("RecordedTestAndMocks", dataMap)
 }
 
@@ -136,12 +136,12 @@ func (tel *Telemetry) SendTelemetry(eventType string, output ...*sync.Map) {
 		}
 
 		hasGlobalMap := false
-        tel.GlobalMap.Range(func(key, value interface{}) bool {
-            hasGlobalMap = true
-            return false // Stop iteration after finding the first element
-        })
+		tel.GlobalMap.Range(func(key, value interface{}) bool {
+			hasGlobalMap = true
+			return false // Stop iteration after finding the first element
+		})
 
-        if hasGlobalMap {
+		if hasGlobalMap {
 			// event.Meta["global-map"] = syncMapToMap(tel.GlobalMap)
 			// If you want to nest the global map, you can do this (but the telemetry
 			// endpoint needs to support nested sync.Maps):

--- a/pkg/service/tools/service.go
+++ b/pkg/service/tools/service.go
@@ -3,6 +3,7 @@ package tools
 
 import (
 	"context"
+	"sync"
 
 	"go.keploy.io/server/v2/pkg/models"
 )
@@ -10,7 +11,7 @@ import (
 type Service interface {
 	Update(ctx context.Context) error
 	CreateConfig(ctx context.Context, filePath string, config string) error
-	SendTelemetry(event string, output ...map[string]interface{})
+	SendTelemetry(event string, output ...*sync.Map)
 	Login(ctx context.Context) bool
 	Export(ctx context.Context) error
 	Import(ctx context.Context, path, basePath string) error
@@ -18,7 +19,7 @@ type Service interface {
 }
 
 type teleDB interface {
-	SendTelemetry(event string, output ...map[string]interface{})
+	SendTelemetry(event string, output ...*sync.Map)
 }
 
 type TestSetConfig interface {

--- a/pkg/service/tools/tools.go
+++ b/pkg/service/tools/tools.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 
 	"github.com/charmbracelet/glamour"
 	"go.keploy.io/server/v2/config"
@@ -47,7 +48,7 @@ type Tools struct {
 
 var ErrGitHubAPIUnresponsive = errors.New("GitHub API is unresponsive")
 
-func (t *Tools) SendTelemetry(event string, output ...map[string]interface{}) {
+func (t *Tools) SendTelemetry(event string, output ...*sync.Map) {
 	t.telemetry.SendTelemetry(event, output...)
 }
 


### PR DESCRIPTION
## Describe the changes that are made
The current implementation of telemetry map involves creation of a global map of type `map[string]interface{}`, there might be race conditions emerging on accessing the telemetry map at same time on 2 or more places, replacing it with sync.Map prevents race conditions as it inbuilt uses locks 

## Links & References

**Fixes:** #[issue number that will be closed through this PR]
- NA (if very small change like typo, linting, etc.)

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [x] 📦 Chore
- [x] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [x] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [x] 🙅 no, because it is not needed

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help
