### PR TITLE
fix: keploy stuck if docker container already in use

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 
 ## Links & References
 
-**Fixes:** #[issue number that will be closed through this PR]
+**Closes:** #[issue number that will be closed through this PR]
 - NA (if very small change like typo, linting, etc.)
 
 ### 🔗 Related PRs

--- a/pkg/core/app/app.go
+++ b/pkg/core/app/app.go
@@ -263,7 +263,7 @@ func (a *App) extractMeta(ctx context.Context, e events.Message) (bool, error) {
 	var channelsUsed bool
 
 	defer func() {
-		if channelsUsed || ctx.Err() == context.Canceled {
+		if channelsUsed || ctx.Err() != nil {
 			a.logger.Debug("closing the inode and containerIPv4 channels")
 			close(a.inodeChan)
 			close(a.containerIPv4)
@@ -310,7 +310,7 @@ func (a *App) extractMeta(ctx context.Context, e events.Message) (bool, error) {
 		a.logger.Debug("container network not found", zap.Any("containerDetails.NetworkSettings.Networks", info.NetworkSettings.Networks))
 		return false, fmt.Errorf("container network not found: %s", fmt.Sprintf("%+v", info.NetworkSettings.Networks))
 	}
-	
+
 	a.SetContainerIPv4Addr(n.IPAddress)
 
 	channelsUsed = true

--- a/pkg/core/app/app.go
+++ b/pkg/core/app/app.go
@@ -390,8 +390,8 @@ func (a *App) runDocker(ctx context.Context) models.AppError {
 
 	g, ctx := errgroup.WithContext(ctx)
 	ctx = context.WithValue(ctx, models.ErrGroupKey, g)
-	dockerMetaCtx := context.WithoutCancel(ctx)
-	dockerMetaCtx, cancel := context.WithCancel(dockerMetaCtx)
+
+	dockerMetaCtx, cancel := context.WithCancel(ctx)
 
 	defer func() {
 		cancel()

--- a/pkg/core/core_linux.go
+++ b/pkg/core/core_linux.go
@@ -204,7 +204,6 @@ func (c *Core) Run(ctx context.Context, id uint64, _ models.RunOptions) models.A
 	defer func() {
 		err := runAppErrGrp.Wait()
 		defer close(inodeErrCh)
-		defer close(inodeChan)
 		if err != nil {
 			utils.LogError(c.logger, err, "failed to stop the app")
 		}

--- a/pkg/core/core_linux.go
+++ b/pkg/core/core_linux.go
@@ -212,6 +212,7 @@ func (c *Core) Run(ctx context.Context, id uint64, _ models.RunOptions) models.A
 	runAppErrGrp.Go(func() error {
 		defer utils.Recover(c.logger)
 		if a.Kind(ctx) == utils.Native {
+			close(inodeChan) // since we are not using inode in native mode
 			return nil
 		}
 		select {


### PR DESCRIPTION
## Describe the changes that are made

This pull request introduces changes to improve the lifecycle management of channels and context handling in the `pkg/core/app/app.go` file. The changes include adding proper channel closures, introducing a dedicated context for Docker metadata operations, and ensuring graceful cleanup of resources. These updates aim to enhance the stability and maintainability of the application.

### Channel Lifecycle Management:

* Added logic to close the `inodeChan` and `containerIPv4` channels in the `extractMeta` and `getDockerMeta` methods to ensure proper cleanup when the context is canceled or operations are complete. (`pkg/core/app/app.go`, [[1]](diffhunk://#diff-a80f8fc1c17c3284b4e1933765194a11f185ee638e77b09def015a984860b564L263-R272) [[2]](diffhunk://#diff-a80f8fc1c17c3284b4e1933765194a11f185ee638e77b09def015a984860b564R356-R358)

* Initialized the `containerIPv4` channel in the `Run` method to ensure it is properly set up before use. (`pkg/core/app/app.go`, [pkg/core/app/app.goR438](diffhunk://#diff-a80f8fc1c17c3284b4e1933765194a11f185ee638e77b09def015a984860b564R438))

### Context Handling Improvements:

* Introduced a dedicated `dockerMetaCtx` in the `runDocker` method to manage the lifecycle of Docker metadata operations separately from the main context, ensuring better control and cleanup. (`pkg/core/app/app.go`, [pkg/core/app/app.goR393-R407](diffhunk://#diff-a80f8fc1c17c3284b4e1933765194a11f185ee638e77b09def015a984860b564R393-R407))

### Code Cleanup:

* Removed redundant closure of `inodeChan` in the `Run` method of `core_linux.go` to avoid potential double-close issues. (`pkg/core/core_linux.go`, [pkg/core/core_linux.goL207](diffhunk://#diff-493f60ebfbc8d8c25c81b486d0e70419405d116a1a07863e29514550efbfaac0L207))

## Links & References

**Closes:**  https://github.com/keploy/keploy/issues/2723

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [x] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned in the issue
- [ ] 🙅 no, because it is not needed

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?