### PR TITLE
fix: avoid cancel shadowing in NewCtx by renaming local var

### DIFF
--- a/utils/ctx.go
+++ b/utils/ctx.go
@@ -16,9 +16,9 @@ var cancel context.CancelFunc
 
 func NewCtx() context.Context {
 	// Create a context that can be canceled
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, c := context.WithCancel(context.Background())
 
-	SetCancel(cancel)
+	SetCancel(c)
 	// Set up a channel to listen for signals
 	sigs := make(chan os.Signal, 1)
 	// os.Interrupt is more portable than syscall.SIGINT


### PR DESCRIPTION
## Describe the changes that are made
- ✅ Fixed a shadowing bug where the local `cancel` variable in `NewCtx()` was overriding the package-level `cancel` context cancel function.  
- 💡 Renamed local variable to `c` to avoid unintentional shadowing and ensure proper cancellation works across the application lifecycle.

## Links & References

**Closes:** #NA

### 🔗 Related PRs
- NA

### 🐞 Related Issues
- NA

### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore  
- [ ] 🍕 Feature  
- [x] 🐞 Bug Fix  
- [ ] 📝 Documentation Update  
- [ ] 🎨 Style  
- [ ] 🧑‍💻 Code Refactor  
- [ ] 🔥 Performance Improvements  
- [ ] ✅ Test  
- [ ] 🔁 CI  
- [ ] ⏩ Revert  

## Added e2e test pipeline?
- [ ] 👍 yes  
- [x] 🙅 no, because they aren't needed  
- [ ] 🙋 no, because I need help  

## Added comments for hard-to-understand areas?
- [x] 👍 yes  
- [ ] 🙅 no, because the code is self-explanatory  

## Added to documentation?
- [ ] 📜 README.md  
- [ ] 📓 Wiki  
- [x] 🙅 no documentation needed  

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below  
> Run Keploy, interrupt the process (Ctrl+C), and ensure that context cancels cleanly without errors.  

## Self Review done?
- [x] ✅ yes  
- [ ] ❌ no, because I need help  

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

**PR Title**: `fix: avoid cancel function shadowing in utils.NewCtx`  
**Branch Name**: `fix/utils-cancel-shadowing`

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?  
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?  
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?  