### PR TITLE
fix(cli): exit with non-zero status if logger fails to initialize

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,8 +53,8 @@ func setVersion() {
 func start(ctx context.Context) {
 	logger, err := log.New()
 	if err != nil {
-		fmt.Println("Failed to start the logger for the CLI", err)
-		return
+		fmt.Fprintln(os.Stderr, "keploy: failed to start the logger for the CLI:", err)
+		os.Exit(1)
 	}
 	defer func() {
 		if err := utils.DeleteFileIfNotExists(logger, "keploy-logs.txt"); err != nil {


### PR DESCRIPTION
fix(cli): exit with non-zero status if logger fails to initialize

Replaces `return` with `os.Exit(1)` to ensure that the CLI fails gracefully when logger setup fails.
closes #2734 