### PR TITLE
fix: bug keploy config --generate gets stuck on invalid input when keploy.yml exists

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -42,6 +42,7 @@ func Config(ctx context.Context, logger *zap.Logger, cfg *config.Config, service
 						return err
 					}
 					if !override {
+						logger.Info("Skipping config file override")
 						return nil
 					}
 				}

--- a/cli/config.go
+++ b/cli/config.go
@@ -36,7 +36,7 @@ func Config(ctx context.Context, logger *zap.Logger, cfg *config.Config, service
 			if isGenerate {
 				filePath := filepath.Join(cfg.Path, "keploy.yml")
 				if !cfg.InCi && utils.CheckFileExists(filePath) {
-					override, err := utils.AskForConfirmation(ctx, "Config file already exists. Do you want to override it?", )
+					override, err := utils.AskForConfirmation(ctx, "Config file already exists. Do you want to override it?")
 					if err != nil {
 						utils.LogError(logger, err, "failed to ask for confirmation")
 						return err

--- a/cli/config.go
+++ b/cli/config.go
@@ -36,7 +36,7 @@ func Config(ctx context.Context, logger *zap.Logger, cfg *config.Config, service
 			if isGenerate {
 				filePath := filepath.Join(cfg.Path, "keploy.yml")
 				if !cfg.InCi && utils.CheckFileExists(filePath) {
-					override, err := utils.AskForConfirmation("Config file already exists. Do you want to override it?")
+					override, err := utils.AskForConfirmation(ctx, "Config file already exists. Do you want to override it?", )
 					if err != nil {
 						utils.LogError(logger, err, "failed to ask for confirmation")
 						return err

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -286,27 +286,26 @@ var ConfigGuide = `
 
 // AskForConfirmation asks the user for confirmation. A user must type in "yes" or "no" and
 // then press enter. It has fuzzy matching, so "y", "Y", "yes", "YES", and "Yes" all count as
-// confirmations. If the input is not recognized, it will ask again. The function does not return
-// until it gets a valid response from the user.
+// confirmations. If the input is not recognized, exit gracefully as "no".
 func AskForConfirmation(s string) (bool, error) {
 	reader := bufio.NewReader(os.Stdin)
 
-	for {
-		fmt.Printf("%s [y/n]: ", s)
+	fmt.Printf("%s [y/n]: ", s)
 
-		response, err := reader.ReadString('\n')
-		if err != nil {
-			return false, err
-		}
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false, err
+	}
 
-		response = strings.ToLower(strings.TrimSpace(response))
+	response = strings.ToLower(strings.TrimSpace(response))
 
-		switch response {
-		case "y", "yes":
-			return true, nil
-		case "n", "no":
-			return false, nil
-		}
+	switch response {
+	case "y", "yes":
+		return true, nil
+	case "n", "no":
+		return false, nil
+	default:
+		return false, nil
 	}
 }
 


### PR DESCRIPTION
## Describe the changes that are made
I add a default case in AskForConfirmation so that any input other than “y”/“yes” or “n”/“no” (including Ctrl+C) is immediately treated as “no” and returns, allowing the program to exit gracefully.


## Links & References

**Closes:** #2766
- NA (if very small change like typo, linting, etc.)

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- https://github.com/keploy/keploy/issues/2766

### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [x] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

prepare `keploy.yaml` and run the following command.

input `abc`
```sh
$ ./keploy config --generate

       ▓██▓▄
    ▓▓▓▓██▓█▓▄
     ████████▓▒
          ▀▓▓███▄      ▄▄   ▄               ▌
         ▄▌▌▓▓████▄    ██ ▓█▀  ▄▌▀▄  ▓▓▌▄   ▓█  ▄▌▓▓▌▄ ▌▌   ▓
       ▓█████████▌▓▓   ██▓█▄  ▓█▄▓▓ ▐█▌  ██ ▓█  █▌  ██  █▌ █▓
      ▓▓▓▓▀▀▀▀▓▓▓▓▓▓▌  ██  █▓  ▓▌▄▄ ▐█▓▄▓█▀ █▓█ ▀█▄▄█▀   █▓█
       ▓▌                           ▐█▌                   █▌
        ▓

version: 2-dev

Config file already exists. Do you want to override it? [y/n]: abc
$
```

Ctrl + C (SIGINT)
```sh
$ ./keploy config --generate

       ▓██▓▄
    ▓▓▓▓██▓█▓▄
     ████████▓▒
          ▀▓▓███▄      ▄▄   ▄               ▌
         ▄▌▌▓▓████▄    ██ ▓█▀  ▄▌▀▄  ▓▓▌▄   ▓█  ▄▌▓▓▌▄ ▌▌   ▓
       ▓█████████▌▓▓   ██▓█▄  ▓█▄▓▓ ▐█▌  ██ ▓█  █▌  ██  █▌ █▓
      ▓▓▓▓▀▀▀▀▓▓▓▓▓▓▌  ██  █▓  ▓▌▄▄ ▐█▓▄▓█▀ █▓█ ▀█▄▄█▀   █▓█
       ▓▌                           ▐█▌                   █▌
        ▓

version: 2-dev

Config file already exists. Do you want to override it? [y/n]: ^CSignal received: interrupt, canceling context...
$ 
```

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?