### PR TITLE
fix: added overwrite warning for keploy.yml in config --generate (#2766)

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
 
 	"go.keploy.io/server/v2/config"
@@ -36,15 +37,18 @@ func Config(ctx context.Context, logger *zap.Logger, cfg *config.Config, service
 			if isGenerate {
 				filePath := filepath.Join(cfg.Path, "keploy.yml")
 				if !cfg.InCi && utils.CheckFileExists(filePath) {
-					override, err := utils.AskForConfirmation("Config file already exists. Do you want to override it?")
-					if err != nil {
-						utils.LogError(logger, err, "failed to ask for confirmation")
-						return err
-					}
-					if !override {
-						return nil
-					}
-				}
+                  fmt.Println("⚠️  keploy.yml already exists.")
+                  override, err := utils.AskForConfirmation("Do you want to overwrite it? (y/n)")
+                  if err != nil {
+                    utils.LogError(logger, err, "failed to ask for confirmation")
+                    return err
+                 }
+                 if !override {
+                   fmt.Println("❌ Operation cancelled. Config not overwritten.")
+                 return nil
+    }
+}
+
 				svc, err := servicefactory.GetService(ctx, cmd.Name())
 				if err != nil {
 					utils.LogError(logger, err, "failed to get service", zap.String("command", cmd.Name()))


### PR DESCRIPTION
Describe the changes that are made
Added a warning prompt when keploy.yml already exists during keploy config --generate

If the user chooses not to overwrite, the process exits cleanly

Prevents CLI from silently hanging when the config file already exists

Links & References
Closes: #2766

🔗 Related PRs
NA

🐞 Related Issues
#2766

📄 Related Documents
NA

What type of PR is this? (check all applicable)
 🐞 Bug Fix

 🧑‍💻 Code Refactor

 🍕 Feature

 📦 Chore

 📝 Documentation Update

 🎨 Style

 🔥 Performance Improvements

 ✅ Test

 🔁 CI

 ⏩ Revert

Added e2e test pipeline?
 👍 yes

 🙅 no, because they aren't needed

 🙋 no, because I need help

Added comments for hard-to-understand areas?
 👍 yes

 🙅 no, because the code is self-explanatory

Added to documentation?
 📜 README.md

 📓 Wiki

 🙅 no documentation needed

Are there any sample code or steps to test the changes?
 👍 yes, mentioned below

Run keploy config --generate with an existing keploy.yml file
Observe the prompt and exit behavior
Accept or reject the overwrite prompt

Self Review done?
 ✅ yes

 ❌ no, because I need help

Any relevant screenshots, recordings or logs?
NA

🧠 Semantics for PR Title & Branch Name
📌 PR Title: fix: add warning when keploy.yml already exists during config --generate
📌 Branch Name: fix/#2766-config-generate-file-exists

Additional checklist:
 Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?

 Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?

 Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?Describe the changes that are made
Added a warning prompt when keploy.yml already exists during keploy config --generate

If the user chooses not to overwrite, the process exits cleanly

Prevents CLI from silently hanging when the config file already exists

Links & References
Closes: #2766

🔗 Related PRs
NA

🐞 Related Issues
#2766

📄 Related Documents
NA

What type of PR is this? (check all applicable)
 🐞 Bug Fix

 🧑‍💻 Code Refactor

 🍕 Feature

 📦 Chore

 📝 Documentation Update

 🎨 Style

 🔥 Performance Improvements

 ✅ Test

 🔁 CI

 ⏩ Revert

Added e2e test pipeline?
 👍 yes

 🙅 no, because they aren't needed

 🙋 no, because I need help

Added comments for hard-to-understand areas?
 👍 yes

 🙅 no, because the code is self-explanatory

Added to documentation?
 📜 README.md

 📓 Wiki

 🙅 no documentation needed

Are there any sample code or steps to test the changes?
 👍 yes, mentioned below

Run keploy config --generate with an existing keploy.yml file
Observe the prompt and exit behavior
Accept or reject the overwrite prompt

Self Review done?
 ✅ yes

 ❌ no, because I need help

Any relevant screenshots, recordings or logs?
NA

🧠 Semantics for PR Title & Branch Name
📌 PR Title: fix: add warning when keploy.yml already exists during config --generate
📌 Branch Name: fix/#2766-config-generate-file-exists

Additional checklist:
 Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?

 Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?

 Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?