### PR TITLE
fix: handle invalid confirmation input when keploy.yml exists during config --generate

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -291,24 +291,26 @@ var ConfigGuide = `
 func AskForConfirmation(s string) (bool, error) {
 	reader := bufio.NewReader(os.Stdin)
 
-	for {
-		fmt.Printf("%s [y/n]: ", s)
+	fmt.Printf("%s [y/n]: ", s)
 
-		response, err := reader.ReadString('\n')
-		if err != nil {
-			return false, err
-		}
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false, err
+	}
 
-		response = strings.ToLower(strings.TrimSpace(response))
+	response = strings.ToLower(strings.TrimSpace(response))
 
-		switch response {
-		case "y", "yes":
-			return true, nil
-		case "n", "no":
-			return false, nil
-		}
+	switch response {
+	case "y", "yes":
+		return true, nil
+	case "n", "no":
+		return false, nil
+	default:
+		fmt.Println("Invalid input. Expected 'y' or 'n'. Exiting.")
+		return false, errors.New("invalid input")
 	}
 }
+
 
 func CheckFileExists(path string) bool {
 	if _, err := os.Stat(path); os.IsNotExist(err) {


### PR DESCRIPTION
## Describe the changes that are made
- Fixed the behavior of AskForConfirmation to gracefully exit when invalid input is provided.

-Previously, the function would loop indefinitely if input was not y/n. Now it logs a message and exits with an error.

## Links & References

**Closes:** #[#2766]


### 🔗 Related PRs
- NA
### 🐞 Related Issues
- #2766
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [✓] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [✓] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [✓] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [✓] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [✓] 👍 yes, mentioned below:
1. Run keploy config --generate
2. If keploy.yml exists, input invalid confirmation like abc
3. You should see an "Invalid input. Exiting..." message and graceful termination.
- [ ] 🙅 no, because it is not needed

## Self Review done?
- [✓] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:
- PR title: fix: handle invalid confirmation input when keploy.yml exists during config --generate
- Branch Name: fix/#2766-invalid-input-exit
-
📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?