### PR TITLE
feat : Added OPTIONS method in schema generation

### DIFF
--- a/pkg/models/openapi.go
+++ b/pkg/models/openapi.go
@@ -66,11 +66,12 @@ type Info struct {
 }
 
 type PathItem struct {
-	Get    *Operation `json:"get,omitempty" yaml:"get,omitempty"`
-	Post   *Operation `json:"post,omitempty" yaml:"post,omitempty"`
-	Put    *Operation `json:"put,omitempty" yaml:"put,omitempty"`
-	Delete *Operation `json:"delete,omitempty" yaml:"delete,omitempty"`
-	Patch  *Operation `json:"patch,omitempty" yaml:"patch,omitempty"`
+	Get     *Operation `json:"get,omitempty" yaml:"get,omitempty"`
+	Post    *Operation `json:"post,omitempty" yaml:"post,omitempty"`
+	Put     *Operation `json:"put,omitempty" yaml:"put,omitempty"`
+	Delete  *Operation `json:"delete,omitempty" yaml:"delete,omitempty"`
+	Patch   *Operation `json:"patch,omitempty" yaml:"patch,omitempty"`
+	Options *Operation `json:"options,omitempty" yaml:"options,omitempty"`
 }
 
 type Operation struct {


### PR DESCRIPTION
## Describe the changes that are made

1. During generation of schemas with the command `keploy contract generate` `OPTIONS` was not handled and hence if     the test cases had `OPTIONS`  method then it throws error . I have added the fix to handle `OPTIONS` method 

2. During the Marshalling of `json` in when converting `yaml` files into `open ai` schemas , if the the response body contains `html` then it will throw error , I have handled this by bypassing the test cases which involves `html content` 


## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [x] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [x] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [x] 🙅 no, because it is not needed

## Self Review done?
- [ ] ✅ yes
- [x] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA
