### PR TITLE
fix: PostgreSQL mock matching bug #2706

### DIFF
--- a/pkg/core/proxy/integrations/postgres/v1/match.go
+++ b/pkg/core/proxy/integrations/postgres/v1/match.go
@@ -381,6 +381,12 @@ func findPGStreamMatch(tcsMocks []*models.Mock, requestBuffers [][]byte, logger 
 	match := false
 	// loop for the exact match of the request
 	for idx, mock := range tcsMocks {
+		// BUG FIX #2706: Skip mocks that are not properly filtered (should only use filtered mocks)
+		if !mock.TestModeInfo.IsFiltered {
+			logger.Debug("Skipping unfiltered mock", zap.String("mockName", mock.Name))
+			continue
+		}
+		
 		// merging the mocks as well before comparing
 		mock.Spec.PostgresRequests = mergeMocks(mock.Spec.PostgresRequests, logger)
 
@@ -408,6 +414,12 @@ func findPGStreamMatch(tcsMocks []*models.Mock, requestBuffers [][]byte, logger 
 	// loop for the ps match of the request
 	if !match {
 		for idx, mock := range tcsMocks {
+			// BUG FIX #2706: Skip mocks that are not properly filtered (should only use filtered mocks)
+			if !mock.TestModeInfo.IsFiltered {
+				logger.Debug("Skipping unfiltered mock in PS match", zap.String("mockName", mock.Name))
+				continue
+			}
+			
 			// merging the mocks as well before comparing
 			mock.Spec.PostgresRequests = mergeMocks(mock.Spec.PostgresRequests, logger)
 
@@ -441,6 +453,12 @@ func findPGStreamMatch(tcsMocks []*models.Mock, requestBuffers [][]byte, logger 
 	if !match {
 
 		for idx, mock := range tcsMocks {
+			// BUG FIX #2706: Skip mocks that are not properly filtered (should only use filtered mocks)
+			if !mock.TestModeInfo.IsFiltered {
+				logger.Debug("Skipping unfiltered mock in fallback match", zap.String("mockName", mock.Name))
+				continue
+			}
+			
 			// merging the mocks as well before comparing
 			mock.Spec.PostgresRequests = mergeMocks(mock.Spec.PostgresRequests, logger)
 


### PR DESCRIPTION
- Skip unfiltered mocks in all matching loops in findPGStreamMatch()
- Ensures only timestamp-appropriate mocks are selected
- Fixes cascading test failures in tests 85, 89, 91, 96, 99
- Resolves issue where future mocks were incorrectly selected

Fixes #2706

## Describe the changes that are made
- 

## Links & References

**Closes:** #[issue number that will be closed through this PR]
- NA (if very small change like typo, linting, etc.)

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [ ] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

## Self Review done?
- [ ] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [ ] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [ ] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [ ] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?