### PR TITLE
feat: improve support for marking keys as noisy

### DIFF
--- a/pkg/matcher/utils.go
+++ b/pkg/matcher/utils.go
@@ -598,7 +598,7 @@ func CompareHeaders(h1 http.Header, h2 http.Header, res *[]models.HeaderResult, 
 	match := true
 	_, isHeaderNoisy := noise["header"]
 	for k, v := range h1 {
-		regexArr, isNoisy := CheckStringExist(strings.ToLower(k), noise)
+		regexArr, isNoisy := SubstringKeyMatch(strings.ToLower(k), noise)
 		if isNoisy && len(regexArr) != 0 {
 			isNoisy, _ = MatchesAnyRegex(v[0], regexArr)
 		}
@@ -675,7 +675,7 @@ func CompareHeaders(h1 http.Header, h2 http.Header, res *[]models.HeaderResult, 
 		}
 	}
 	for k, v := range h2 {
-		regexArr, isNoisy := CheckStringExist(strings.ToLower(k), noise)
+		regexArr, isNoisy := SubstringKeyMatch(strings.ToLower(k), noise)
 		if isNoisy && len(regexArr) != 0 {
 			isNoisy, _ = MatchesAnyRegex(v[0], regexArr)
 		}
@@ -724,12 +724,21 @@ func MapToArray(mp map[string][]string) []string {
 	return result
 }
 
-func CheckStringExist(s string, mp map[string][]string) ([]string, bool) {
-	if val, ok := mp[s]; ok {
-		return val, ok
+func SubstringKeyMatch(s string, mp map[string][]string) ([]string, bool) {
+	for key, val := range mp {
+		if strings.Contains(s, key) {
+			return val, true
+		}
 	}
 	return []string{}, false
 }
+
+// func CheckStringExist(s string, mp map[string][]string) ([]string, bool) {
+// 	if val, ok := mp[s]; ok {
+// 		return val, ok
+// 	}
+// 	return []string{}, false
+// }
 
 func MatchesAnyRegex(str string, regexArray []string) (bool, string) {
 	for _, pattern := range regexArray {
@@ -843,7 +852,7 @@ func matchJSONWithNoiseHandling(key string, expected, actual interface{}, noiseM
 	}
 	switch x.Kind() {
 	case reflect.Float64, reflect.String, reflect.Bool:
-		regexArr, isNoisy := CheckStringExist(key, noiseMap)
+		regexArr, isNoisy := SubstringKeyMatch(key, noiseMap)
 		if isNoisy && len(regexArr) != 0 {
 			isNoisy, _ = MatchesAnyRegex(InterfaceToString(expected), regexArr)
 		}
@@ -857,7 +866,7 @@ func matchJSONWithNoiseHandling(key string, expected, actual interface{}, noiseM
 		copiedExpMap := make(map[string]interface{})
 		copiedActMap := make(map[string]interface{})
 
-		if regexArr, isNoisy := CheckStringExist(key, noiseMap); isNoisy && len(regexArr) == 0 {
+		if regexArr, isNoisy := SubstringKeyMatch(key, noiseMap); isNoisy && len(regexArr) == 0 {
 			break
 		}
 		// Copy each key-value pair from expMap to copiedExpMap
@@ -885,7 +894,7 @@ func matchJSONWithNoiseHandling(key string, expected, actual interface{}, noiseM
 			}
 			// remove the noisy key from both expected and actual JSON.
 			// Viper bindings are case insensitive, so we need convert the key to lowercase.
-			if _, ok := CheckStringExist(strings.ToLower(prefix+k), noiseMap); ok {
+			if _, ok := SubstringKeyMatch(strings.ToLower(prefix+k), noiseMap); ok {
 				delete(copiedExpMap, prefix+k)
 				delete(copiedActMap, k)
 				continue
@@ -903,7 +912,7 @@ func matchJSONWithNoiseHandling(key string, expected, actual interface{}, noiseM
 		matchJSONComparisonResult.differences = append(matchJSONComparisonResult.differences, differences...)
 		return matchJSONComparisonResult, nil
 	case reflect.Slice:
-		if regexArr, isNoisy := CheckStringExist(key, noiseMap); isNoisy && len(regexArr) == 0 {
+		if regexArr, isNoisy := SubstringKeyMatch(key, noiseMap); isNoisy && len(regexArr) == 0 {
 			break
 		}
 		expSlice := reflect.ValueOf(expected)


### PR DESCRIPTION
## Describe the changes that are made
- Rather than an exact match, we are now checking whether the provided keys in the map are a substring of the key to be compared with. This can improve the UX as the user doesn't have to mark similar fields in different nested bodies as noise, which can be verbose.
- It also applies to the header.

## Links & References

**Closes:** #2844
- NA (if very small change like typo, linting, etc.)

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [x] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [x] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [x] 🙅 no, because it is not needed

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?