### PR TITLE
fix: BeforeTestSetRun hook

### DIFF
--- a/pkg/service/replay/hooks.go
+++ b/pkg/service/replay/hooks.go
@@ -94,6 +94,10 @@ func (h *Hooks) AfterTestSetRun(ctx context.Context, testSetID string, status bo
 
 func (h *Hooks) BeforeTestSetRun(ctx context.Context, testSetID string) error {
 
+	if h.cfg.Test.DisableMockUpload {
+		return nil
+	}
+
 	if h.cfg.Test.BasePath != "" {
 		h.logger.Debug("Mocking is disabled when basePath is given", zap.String("testSetID", testSetID), zap.String("basePath", h.cfg.Test.BasePath))
 		return nil


### PR DESCRIPTION
1. Return early when mock upload is disabled