### PR TITLE
Fix: prevent integer overflow in ExtractHTTP2Frame on 32-bit systems #2835 

### DIFF
--- a/pkg/http2.go
+++ b/pkg/http2.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"strings"
 	"sync"
@@ -43,6 +44,11 @@ func ExtractHTTP2Frame(data []byte) (http2.Frame, int, error) {
 	// Validate length before proceeding
 	if length > MaxFrameSize {
 		return nil, 0, fmt.Errorf("frame length %d exceeds maximum allowed size %d", length, MaxFrameSize)
+	}
+
+	// ✅ Prevent integer overflow on 32-bit systems
+	if length > uint32(math.MaxInt32-9) {
+		return nil, 0, fmt.Errorf("frame length %d would cause integer overflow", length)
 	}
 
 	// Check if we have the complete frame


### PR DESCRIPTION
## Describe the changes that are made 

- Added a check to prevent integer overflow when calculating the total frame size in `ExtractHTTP2Frame`.
- On 32-bit systems, `int(length) + 9` can overflow if `length` is close to `math.MaxInt32`, leading to potential buffer underallocation or memory corruption.
- This fix ensures that `length` does not exceed `math.MaxInt32 - 9` before performing the addition.

## Links & References

**Closes:** #2835 

### 🔗 Related PRs
- NA

### 🐞 Related Issues
- NA

### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore  
- [ ] 🍕 Feature  
- [x] 🐞 Bug Fix  
- [ ] 📝 Documentation Update  
- [ ] 🎨 Style  
- [ ] 🧑‍💻 Code Refactor  
- [ ] 🔥 Performance Improvements  
- [ ] ✅ Test  
- [ ] 🔁 CI  
- [ ] ⏩ Revert  

## Added e2e test pipeline?
- [ ] 👍 yes  
- [x] 🙅 no, because they aren't needed  
- [ ] 🙋 no, because I need help  

## Added comments for hard-to-understand areas?
- [x] 👍 yes  
- [ ] 🙅 no, because the code is self-explanatory  

## Added to documentation?
- [ ] 📜 README.md  
- [ ] 📓 Wiki  
- [x] 🙅 no documentation needed  

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below  
- [ ] 🙅 no, because it is not needed  

### ✅ Sample Test Case

```go
func TestFrameLengthOverflow(t *testing.T) {
	length := uint32(math.MaxInt32 - 8)
	_, _, err := ExtractHTTP2Frame(append(make([]byte, 9+int(length)), 0x0))
	if err != nil {
		t.Errorf("Unexpected error for safe length: %v", err)
	}

	length = uint32(math.MaxInt32 - 5)
	_, _, err = ExtractHTTP2Frame(append(make([]byte, 9+int(length)), 0x0))
	if err == nil {
		t.Error("Expected overflow error but got nil")
	}
}
## Describe the changes that are made
- 

## Links & References

**Closes:** #2835 

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [ ] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

## Self Review done?
- [ ] ✅ yes
- [ ] ❌ no, because I need help

## Additional checklist:
- [ X] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [ X] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [ X] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?