### PR TITLE
fix: increase fd limit of user app

### DIFF
--- a/utils/signal_others.go
+++ b/utils/signal_others.go
@@ -42,6 +42,8 @@ func ExecuteCommand(ctx context.Context, logger *zap.Logger, userCmd string, can
 	// Get the current hard limit value
 	hardLimit := rlimit.Max
 
+	fmt.Println(hardLimit)
+
 	userCmd = fmt.Sprintf("ulimit -S -n %d && %s", hardLimit, userCmd)
 
 	cmd := exec.CommandContext(ctx, "sh", "-c", userCmd)

--- a/utils/signal_others.go
+++ b/utils/signal_others.go
@@ -44,7 +44,7 @@ func ExecuteCommand(ctx context.Context, logger *zap.Logger, userCmd string, can
 
 	fmt.Println(hardLimit)
 
-	userCmd = fmt.Sprintf("ulimit -S -n %d && %s", hardLimit, userCmd)
+	userCmd = fmt.Sprintf("ulimit -S -n %d && %s", hardLimit-1, userCmd)
 
 	cmd := exec.CommandContext(ctx, "sh", "-c", userCmd)
 	if username != "" {

--- a/utils/signal_others.go
+++ b/utils/signal_others.go
@@ -62,8 +62,6 @@ func ExecuteCommand(ctx context.Context, logger *zap.Logger, userCmd string, can
 		}
 	}
 
-	fmt.Println(hardLimit) // Debugging line, can be removed later
-
 	if hardLimit != 0 {
 		userCmd = fmt.Sprintf("ulimit -S -n %d && %s", hardLimit, userCmd)
 	}

--- a/utils/signal_others.go
+++ b/utils/signal_others.go
@@ -40,7 +40,7 @@ func ExecuteCommand(ctx context.Context, logger *zap.Logger, userCmd string, can
 	}
 
 	// Get the current hard limit value
-	hardLimit := rlimit.Max
+	hardLimit := 1024
 
 	fmt.Println(hardLimit)
 

--- a/utils/signal_others.go
+++ b/utils/signal_others.go
@@ -38,7 +38,7 @@ func ExecuteCommand(ctx context.Context, logger *zap.Logger, userCmd string, can
 	hardLimit := 0
 	var err error
 	if username != "" {
-		// get sudoers rlimit
+		// get sudoers rlimit - (reason) https://github.com/keploy/keploy/issues/2899
 		out, err := exec.Command("sudo", "-u", username, "sh", "-c", "ulimit -Hn").Output()
 		if err != nil {
 			logger.Warn("failed to get the hard limit for the number of open file descriptors for the user", zap.String("username", username), zap.Error(err))
@@ -61,6 +61,8 @@ func ExecuteCommand(ctx context.Context, logger *zap.Logger, userCmd string, can
 			hardLimit = int(rlimit.Max)
 		}
 	}
+
+	fmt.Println(hardLimit) // Debugging line, can be removed later
 
 	if hardLimit != 0 {
 		userCmd = fmt.Sprintf("ulimit -S -n %d && %s", hardLimit, userCmd)

--- a/utils/signal_others.go
+++ b/utils/signal_others.go
@@ -44,7 +44,7 @@ func ExecuteCommand(ctx context.Context, logger *zap.Logger, userCmd string, can
 
 	fmt.Println(hardLimit)
 
-	userCmd = fmt.Sprintf("ulimit -S -n %d && %s", hardLimit-1, userCmd)
+	userCmd = fmt.Sprintf("ulimit -S -n %d", hardLimit)
 
 	cmd := exec.CommandContext(ctx, "sh", "-c", userCmd)
 	if username != "" {

--- a/utils/signal_others.go
+++ b/utils/signal_others.go
@@ -40,7 +40,7 @@ func ExecuteCommand(ctx context.Context, logger *zap.Logger, userCmd string, can
 	}
 
 	// Get the current hard limit value
-	hardLimit := 1026
+	hardLimit := rlimit.Cur * 100
 
 	fmt.Println(hardLimit)
 

--- a/utils/signal_others.go
+++ b/utils/signal_others.go
@@ -40,7 +40,7 @@ func ExecuteCommand(ctx context.Context, logger *zap.Logger, userCmd string, can
 	}
 
 	// Get the current hard limit value
-	hardLimit := 1048576
+	hardLimit := rlimit.Max/2 
 
 	fmt.Println(hardLimit)
 

--- a/utils/signal_others.go
+++ b/utils/signal_others.go
@@ -40,7 +40,7 @@ func ExecuteCommand(ctx context.Context, logger *zap.Logger, userCmd string, can
 	}
 
 	// Get the current hard limit value
-	hardLimit := rlimit.Max/2 
+	hardLimit := 1026
 
 	fmt.Println(hardLimit)
 

--- a/utils/signal_others.go
+++ b/utils/signal_others.go
@@ -40,7 +40,7 @@ func ExecuteCommand(ctx context.Context, logger *zap.Logger, userCmd string, can
 	}
 
 	// Get the current hard limit value
-	hardLimit := 1024
+	hardLimit := 1048576
 
 	fmt.Println(hardLimit)
 

--- a/utils/signal_others.go
+++ b/utils/signal_others.go
@@ -40,7 +40,7 @@ func ExecuteCommand(ctx context.Context, logger *zap.Logger, userCmd string, can
 	}
 
 	// Get the current hard limit value
-	hardLimit := rlimit.Cur * 100
+	hardLimit := 102400
 
 	fmt.Println(hardLimit)
 


### PR DESCRIPTION
Issue - #2899

Test execution stops after ~950 test cases. This is because the Keploy is closing the db client connections from the application which in return motivates the application to create more connections with which the no of connections are increasing and exceeding the normal soft limit of file descriptors. This issue of `closing the client connections `is being investigated. Although for big applications with huge mocks and tests normal value of soft limit of file descriptors is less. So we have increased the soft limit of file descriptors in this PR.