### PR TITLE
feat: reload hooks between testset runs for fresh sessions

### DIFF
--- a/pkg/core/core_linux.go
+++ b/pkg/core/core_linux.go
@@ -123,7 +123,7 @@ func (c *Core) Hook(ctx context.Context, id uint64, opts models.HookOptions) err
 
 		//deleting in order to free the memory in case of rerecord. otherwise different app id will be created for the same app.
 		c.apps.Delete(id)
-		c.id = utils.AutoInc{}
+		c.id.Reset()
 
 		return nil
 	})

--- a/pkg/core/hooks/hooks.go
+++ b/pkg/core/hooks/hooks.go
@@ -43,15 +43,15 @@ func NewHooks(logger *zap.Logger, cfg *config.Config) *Hooks {
 }
 
 type Hooks struct {
-	logger    *zap.Logger
-	sess      *core.Sessions
-	proxyIP4  string
-	proxyIP6  [4]uint32
-	proxyPort uint32
-	dnsPort   uint32
-	m         sync.Mutex
-	objectsMutex sync.RWMutex  // Protects eBPF objects during load/unload operations
-	conf      *config.Config
+	logger       *zap.Logger
+	sess         *core.Sessions
+	proxyIP4     string
+	proxyIP6     [4]uint32
+	proxyPort    uint32
+	dnsPort      uint32
+	m            sync.Mutex
+	objectsMutex sync.RWMutex // Protects eBPF objects during load/unload operations
+	conf         *config.Config
 	// eBPF C shared maps
 	clientRegistrationMap    *ebpf.Map
 	agentRegistartionMap     *ebpf.Map
@@ -106,7 +106,7 @@ func (h *Hooks) Load(ctx context.Context, id uint64, opts core.HookCfg) error {
 	h.sess.Set(id, &core.Session{
 		ID: id,
 	})
-	
+
 	// Set the app ID for this session with proper synchronization
 	h.m.Lock()
 	h.appID = id
@@ -569,7 +569,7 @@ func (h *Hooks) unLoad(_ context.Context, opts core.HookCfg) {
 	if err := h.socket.Close(); err != nil {
 		utils.LogError(h.logger, err, "failed to close the socket")
 	}
-	
+
 	// Reset the app ID with proper synchronization
 	h.m.Lock()
 	h.appID = 0
@@ -672,7 +672,7 @@ func (h *Hooks) unLoad(_ context.Context, opts core.HookCfg) {
 	if err := h.recvfromRet.Close(); err != nil {
 		utils.LogError(h.logger, err, "failed to close the recvfromRet")
 	}
-	
+
 	// Close eBPF objects with proper synchronization
 	h.objectsMutex.Lock()
 	if err := h.objects.Close(); err != nil {

--- a/pkg/core/hooks/hooks.go
+++ b/pkg/core/hooks/hooks.go
@@ -104,6 +104,11 @@ func (h *Hooks) Load(ctx context.Context, id uint64, opts core.HookCfg) error {
 	h.sess.Set(id, &core.Session{
 		ID: id,
 	})
+	
+	// Set the app ID for this session with proper synchronization
+	h.m.Lock()
+	h.appID = id
+	h.m.Unlock()
 
 	err := h.load(ctx, opts)
 	if err != nil {
@@ -560,7 +565,11 @@ func (h *Hooks) unLoad(_ context.Context, opts core.HookCfg) {
 	if err := h.socket.Close(); err != nil {
 		utils.LogError(h.logger, err, "failed to close the socket")
 	}
+	
+	// Reset the app ID with proper synchronization
+	h.m.Lock()
 	h.appID = 0
+	h.m.Unlock()
 
 	if !opts.E2E {
 		if err := h.udpp4.Close(); err != nil {

--- a/pkg/core/hooks/kernelComm.go
+++ b/pkg/core/hooks/kernelComm.go
@@ -21,12 +21,12 @@ func (h *Hooks) Get(_ context.Context, srcPort uint16) (*core.NetworkAddress, er
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// Use the current app ID with proper synchronization
 	h.m.Lock()
 	currentAppID := h.appID
 	h.m.Unlock()
-	
+
 	s, ok := h.sess.Get(currentAppID)
 	if !ok {
 		return nil, fmt.Errorf("session not found")
@@ -100,13 +100,13 @@ func (h *Hooks) SendE2EInfo(pid uint32) error {
 func (h *Hooks) SendDockerAppInfo(appID uint64, dockerAppInfo structs.DockerAppInfo) error {
 	h.m.Lock()
 	defer h.m.Unlock()
-	
+
 	// Use the provided app ID or the current app ID, don't generate a random one
 	dockerAppID := appID
 	if dockerAppID == 0 {
 		dockerAppID = h.appID
 	}
-	
+
 	if h.appID != 0 {
 		err := h.dockerAppRegistrationMap.Delete(h.appID)
 		if err != nil {
@@ -114,18 +114,18 @@ func (h *Hooks) SendDockerAppInfo(appID uint64, dockerAppInfo structs.DockerAppI
 			return err
 		}
 	}
-	
+
 	// Don't override the app ID with a random number - use the real app ID
 	err := h.dockerAppRegistrationMap.Update(dockerAppID, dockerAppInfo, ebpf.UpdateAny)
 	if err != nil {
 		utils.LogError(h.logger, err, "failed to send the dockerAppInfo info to the ebpf program")
 		return err
 	}
-	
+
 	// Update the app ID only if we received a valid one
 	if appID != 0 {
 		h.appID = appID
 	}
-	
+
 	return nil
 }

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -234,6 +234,37 @@ func (r *Replayer) Start(ctx context.Context) error {
 
 	for i, testSet := range testSets {
 		testSetResult = false
+		
+		// Reload hooks before each test set if this is not the first test set
+		// This ensures fresh eBPF state and prevents issues between test runs
+		if i > 0 && r.instrument {
+			r.logger.Info("Reloading hooks for test set", zap.String("testSet", testSet), zap.Int("testSetIndex", i+1), zap.Int("totalTestSets", len(testSets)))
+			
+			// Cancel the current hooks and wait for cleanup to complete
+			if hookCancel != nil {
+				hookCancel()
+				// Add a longer delay to allow the cleanup goroutine to complete
+				// This prevents race conditions with eBPF resources during cleanup
+				time.Sleep(500 * time.Millisecond)
+			}
+			
+			// Reload hooks for the new test set with retry mechanism
+			newInst, err := r.reloadHooks(ctx, inst.AppID)
+			if err != nil {
+				stopReason = fmt.Sprintf("failed to reload hooks for test set %s: %v", testSet, err)
+				utils.LogError(r.logger, err, stopReason)
+				if ctx.Err() == context.Canceled {
+					return err
+				}
+				return fmt.Errorf("%s", stopReason)
+			}
+			hookCancel = newInst.HookCancel
+			// Update the inst with the new hook cancel function and app ID
+			inst.HookCancel = newInst.HookCancel
+			inst.AppID = newInst.AppID
+			r.logger.Info("Successfully reloaded hooks for test set", zap.String("testSet", testSet), zap.Uint64("newAppID", newInst.AppID))
+		}
+		
 		err := HookImpl.BeforeTestSetRun(ctx, testSet)
 		if err != nil {
 			stopReason = fmt.Sprintf("failed to run before test hook: %v", err)
@@ -505,6 +536,80 @@ func (r *Replayer) Instrument(ctx context.Context) (*InstrumentState, error) {
 		}
 	}
 	return &InstrumentState{AppID: appID, HookCancel: cancel}, nil
+}
+
+// reloadHooks cancels existing hooks and reloads them for the next test set.
+// This ensures that any stale eBPF state is cleared and fresh hooks are loaded,
+// which can help with reliability and prevent issues between test set runs.
+// This method handles the app context preservation to avoid app deletion during reload.
+func (r *Replayer) reloadHooks(ctx context.Context, appID uint64) (*InstrumentState, error) {
+	if !r.instrument {
+		return &InstrumentState{}, nil
+	}
+
+	r.logger.Debug("Reloading eBPF hooks", zap.Uint64("appID", appID))
+
+	// The challenge is that calling Hook again will set up new cleanup that deletes the app
+	// when the context is canceled. We need to create a fresh setup.
+	
+	// First, set up the app again since it might have been deleted during cleanup
+	newAppID, err := r.instrumentation.Setup(ctx, r.config.Command, models.SetupOptions{
+		Container:     r.config.ContainerName, 
+		DockerNetwork: r.config.NetworkName, 
+		DockerDelay:   r.config.BuildDelay,
+	})
+	if err != nil {
+		return &InstrumentState{}, fmt.Errorf("failed to setup instrumentation during hook reload: %w", err)
+	}
+	
+	// Update the config with the new app ID
+	r.config.AppID = newAppID
+
+	// Create a retry mechanism in case of temporary race conditions
+	var lastErr error
+	maxRetries := 5
+	baseDelay := 100 * time.Millisecond
+	
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		// Check for context cancellation
+		select {
+		case <-ctx.Done():
+			return &InstrumentState{}, context.Canceled
+		default:
+		}
+		
+		// Start fresh hooks with the new app ID
+		hookCtx := context.WithoutCancel(ctx)
+		hookCtx, cancel := context.WithCancel(hookCtx)
+		
+		err := r.instrumentation.Hook(hookCtx, newAppID, models.HookOptions{
+			Mode:          models.MODE_TEST, 
+			EnableTesting: r.config.EnableTesting, 
+			Rules:         r.config.BypassRules,
+		})
+		if err != nil {
+			cancel()
+			lastErr = err
+			if errors.Is(err, context.Canceled) {
+				return &InstrumentState{}, err
+			}
+			// If this failed due to a race condition, wait and retry with exponential backoff
+			if attempt < maxRetries {
+				delay := baseDelay * time.Duration(attempt*attempt) // Quadratic backoff
+				r.logger.Debug("Hook reload failed, retrying", zap.Int("attempt", attempt), zap.Duration("delay", delay), zap.Error(err))
+				time.Sleep(delay)
+				continue
+			}
+			return &InstrumentState{}, fmt.Errorf("failed to reload hooks after %d attempts: %w", maxRetries, lastErr)
+		}
+		
+		// Success - return the new hook state with the new app ID
+		r.logger.Debug("Successfully reloaded eBPF hooks", zap.Uint64("oldAppID", appID), zap.Uint64("newAppID", newAppID), zap.Int("attempt", attempt))
+		return &InstrumentState{AppID: newAppID, HookCancel: cancel}, nil
+	}
+	
+	// This should never be reached, but just in case
+	return &InstrumentState{}, fmt.Errorf("failed to reload hooks after %d attempts: %w", maxRetries, lastErr)
 }
 
 func (r *Replayer) GetNextTestRunID(ctx context.Context) (string, error) {

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -234,12 +234,12 @@ func (r *Replayer) Start(ctx context.Context) error {
 
 	for i, testSet := range testSets {
 		testSetResult = false
-		
+
 		// Reload hooks before each test set if this is not the first test set
 		// This ensures fresh eBPF state and prevents issues between test runs
 		if i > 0 && r.instrument {
 			r.logger.Info("Reloading hooks for test set", zap.String("testSet", testSet), zap.Int("testSetIndex", i+1), zap.Int("totalTestSets", len(testSets)))
-			
+
 			// Cancel the current hooks and wait for cleanup to complete
 			if hookCancel != nil {
 				hookCancel()
@@ -247,7 +247,7 @@ func (r *Replayer) Start(ctx context.Context) error {
 				// The cleanup goroutine needs to finish its operations before we start new setup
 				time.Sleep(2000 * time.Millisecond)
 			}
-			
+
 			// Reload hooks for the new test set with retry mechanism
 			newInst, err := r.reloadHooks(ctx, inst.AppID)
 			if err != nil {
@@ -264,7 +264,7 @@ func (r *Replayer) Start(ctx context.Context) error {
 			inst.AppID = newInst.AppID
 			r.logger.Info("Successfully reloaded hooks for test set", zap.String("testSet", testSet), zap.Uint64("newAppID", newInst.AppID))
 		}
-		
+
 		err := HookImpl.BeforeTestSetRun(ctx, testSet)
 		if err != nil {
 			stopReason = fmt.Sprintf("failed to run before test hook: %v", err)
@@ -551,17 +551,17 @@ func (r *Replayer) reloadHooks(ctx context.Context, appID uint64) (*InstrumentSt
 
 	// The challenge is that calling Hook again will set up new cleanup that deletes the app
 	// when the context is canceled. We need to create a fresh setup.
-	
+
 	// First, set up the app again since it might have been deleted during cleanup
 	newAppID, err := r.instrumentation.Setup(ctx, r.config.Command, models.SetupOptions{
-		Container:     r.config.ContainerName, 
-		DockerNetwork: r.config.NetworkName, 
+		Container:     r.config.ContainerName,
+		DockerNetwork: r.config.NetworkName,
 		DockerDelay:   r.config.BuildDelay,
 	})
 	if err != nil {
 		return &InstrumentState{}, fmt.Errorf("failed to setup instrumentation during hook reload: %w", err)
 	}
-	
+
 	// Update the config with the new app ID
 	r.config.AppID = newAppID
 
@@ -569,7 +569,7 @@ func (r *Replayer) reloadHooks(ctx context.Context, appID uint64) (*InstrumentSt
 	var lastErr error
 	maxRetries := 5
 	baseDelay := 200 * time.Millisecond
-	
+
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		// Check for context cancellation
 		select {
@@ -577,21 +577,21 @@ func (r *Replayer) reloadHooks(ctx context.Context, appID uint64) (*InstrumentSt
 			return &InstrumentState{}, context.Canceled
 		default:
 		}
-		
+
 		// Add a small delay before each attempt to let any remaining cleanup finish
 		if attempt > 1 {
 			delay := baseDelay * time.Duration(attempt) // Linear backoff
 			r.logger.Debug("Retrying hook reload", zap.Int("attempt", attempt), zap.Duration("delay", delay))
 			time.Sleep(delay)
 		}
-		
+
 		// Start fresh hooks with the new app ID
 		hookCtx := context.WithoutCancel(ctx)
 		hookCtx, cancel := context.WithCancel(hookCtx)
-		
+
 		err := r.instrumentation.Hook(hookCtx, newAppID, models.HookOptions{
-			Mode:          models.MODE_TEST, 
-			EnableTesting: r.config.EnableTesting, 
+			Mode:          models.MODE_TEST,
+			EnableTesting: r.config.EnableTesting,
 			Rules:         r.config.BypassRules,
 		})
 		if err != nil {
@@ -609,12 +609,12 @@ func (r *Replayer) reloadHooks(ctx context.Context, appID uint64) (*InstrumentSt
 			}
 			return &InstrumentState{}, fmt.Errorf("failed to reload hooks after %d attempts: %w", maxRetries, lastErr)
 		}
-		
+
 		// Success - return the new hook state with the new app ID
 		r.logger.Debug("Successfully reloaded eBPF hooks", zap.Uint64("oldAppID", appID), zap.Uint64("newAppID", newAppID), zap.Int("attempt", attempt))
 		return &InstrumentState{AppID: newAppID, HookCancel: cancel}, nil
 	}
-	
+
 	// This should never be reached, but just in case
 	return &InstrumentState{}, fmt.Errorf("failed to reload hooks after %d attempts: %w", maxRetries, lastErr)
 }

--- a/utils/inc.go
+++ b/utils/inc.go
@@ -15,3 +15,9 @@ func (a *AutoInc) Next() (id int) {
 	a.id++
 	return
 }
+
+func (a *AutoInc) Reset() {
+	a.Lock()
+	a.id = 0
+	a.Unlock()
+}


### PR DESCRIPTION
This pull request introduces improvements to eBPF hook state management and synchronization, focusing on ensuring reliable hook reloading between test sets and preventing race conditions. The changes add proper locking for shared state, implement a robust hook reload mechanism with retry logic, and update the replay logic to reload hooks between test sets for better isolation and reliability.

**eBPF Hook State Management and Synchronization:**

* Added mutex locking around `appID` updates and accesses in the `Hooks` struct to prevent race conditions when loading, unloading, and interacting with hooks. (`pkg/core/hooks/hooks.go`) [[1]](diffhunk://#diff-30b8a9b622fa625b8a1d1c7e579f0b625e39db86d902577dd71f18605c66bd11R108-R112) [[2]](diffhunk://#diff-30b8a9b622fa625b8a1d1c7e579f0b625e39db86d902577dd71f18605c66bd11R568-R572) [[3]](diffhunk://#diff-60f89d1e8e82d35f7462b3da2e485d3e7bfb363cff7493227594e08d1bf4677aL27-R33) [[4]](diffhunk://#diff-60f89d1e8e82d35f7462b3da2e485d3e7bfb363cff7493227594e08d1bf4677aR104-R106)

**Replay/Test Set Isolation and Reliability:**

* Updated the replay logic in `Replayer.Start` to reload hooks before each test set (except the first), ensuring fresh eBPF state and preventing issues between test runs. This includes waiting for cleanup and updating instrumentation state. (`pkg/service/replay/replay.go`)
* Added a new `Replayer.reloadHooks` method that cancels existing hooks and sets up new ones with a retry mechanism to handle race conditions and ensure hooks are reliably reloaded for each test set. (`pkg/service/replay/replay.go`)