### PR TITLE
fix: mount ssh agent to container incase of running keploy with docker

### DIFF
--- a/cli/provider/docker.go
+++ b/cli/provider/docker.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -181,14 +180,7 @@ func getAlias(ctx context.Context, logger *zap.Logger) (string, error) {
 	sshSock := os.Getenv("SSH_AUTH_SOCK")
 	sshAgentMount := ""
 	if sshSock != "" {
-		switch osName {
-		case "darwin":
-			sshDir := filepath.Dir(sshSock)
-			sshBase := filepath.Base(sshSock)
-			sshAgentMount = fmt.Sprintf("-v %s:/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent/%s ", sshDir, sshBase)
-		default:
-			sshAgentMount = fmt.Sprintf("-v %s:/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent ", sshSock)
-		}
+		sshAgentMount = fmt.Sprintf("-v %s:/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent ", sshSock)
 	}
 
 	switch osName {
@@ -260,6 +252,12 @@ func getAlias(ctx context.Context, logger *zap.Logger) (string, error) {
 				utils.LogError(logger, err, "failed to set DOCKER_HOST environment variable for colima context")
 				return "", errors.New("failed to get alias")
 			}
+
+			sshAgentMount, err = getColimaSSHAuthSock(ctx, logger)
+			if err != nil {
+				logger.Debug("failed to get SSH_AUTH_SOCK from colima, proceeding without it", zap.Error(err))
+			}
+
 			logger.Info("Starting keploy in docker with colima context, as that is the current context.")
 			alias := "docker container run --name keploy-v2 " + envs + sshAgentMount + "-e DOCKER_BUILDKIT=1 -e BINARY_TO_DOCKER=true -p 16789:16789 --privileged --pid=host" + ttyFlag + "-v " + os.Getenv("PWD") + ":" + os.Getenv("PWD") + " -w " + os.Getenv("PWD") + " -v /sys/fs/cgroup:/sys/fs/cgroup -v /sys/kernel/debug:/sys/kernel/debug -v /sys/fs/bpf:/sys/fs/bpf -v /var/run/docker.sock:/var/run/docker.sock -v " + os.Getenv("HOME") + "/.keploy-config:/root/.keploy-config -v " + os.Getenv("HOME") + "/.keploy:/root/.keploy --rm " + img
 			return alias, nil

--- a/cli/provider/docker.go
+++ b/cli/provider/docker.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -180,7 +181,14 @@ func getAlias(ctx context.Context, logger *zap.Logger) (string, error) {
 	sshSock := os.Getenv("SSH_AUTH_SOCK")
 	sshAgentMount := ""
 	if sshSock != "" {
-		sshAgentMount = "-v " + sshSock + ":/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent "
+		switch osName {
+		case "darwin":
+			sshDir := filepath.Dir(sshSock)
+			sshBase := filepath.Base(sshSock)
+			sshAgentMount = fmt.Sprintf("-v %s:/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent/%s ", sshDir, sshBase)
+		default:
+			sshAgentMount = fmt.Sprintf("-v %s:/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent ", sshSock)
+		}
 	}
 
 	switch osName {

--- a/cli/provider/docker.go
+++ b/cli/provider/docker.go
@@ -177,9 +177,15 @@ func getAlias(ctx context.Context, logger *zap.Logger) (string, error) {
 		ttyFlag = " "
 	}
 
+	sshSock := os.Getenv("SSH_AUTH_SOCK")
+	sshAgentMount := ""
+	if sshSock != "" {
+		sshAgentMount = "-v " + sshSock + ":/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent "
+	}
+
 	switch osName {
 	case "linux":
-		alias := "sudo docker container run --name keploy-v2 " + envs + "-v $SSH_AUTH_SOCK:/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent -e DOCKER_BUILDKIT=1 -e BINARY_TO_DOCKER=true -p 16789:16789 --privileged --pid=host" + ttyFlag + " -v " + os.Getenv("PWD") + ":" + os.Getenv("PWD") + " -w " + os.Getenv("PWD") + " -v /sys/fs/cgroup:/sys/fs/cgroup -v /sys/kernel/debug:/sys/kernel/debug -v /sys/fs/bpf:/sys/fs/bpf -v /var/run/docker.sock:/var/run/docker.sock -v " + os.Getenv("HOME") + "/.keploy-config:/root/.keploy-config -v " + os.Getenv("HOME") + "/.keploy:/root/.keploy --rm " + img
+		alias := "sudo docker container run --name keploy-v2 " + envs + sshAgentMount + "-e DOCKER_BUILDKIT=1 -e BINARY_TO_DOCKER=true -p 16789:16789 --privileged --pid=host" + ttyFlag + " -v " + os.Getenv("PWD") + ":" + os.Getenv("PWD") + " -w " + os.Getenv("PWD") + " -v /sys/fs/cgroup:/sys/fs/cgroup -v /sys/kernel/debug:/sys/kernel/debug -v /sys/fs/bpf:/sys/fs/bpf -v /var/run/docker.sock:/var/run/docker.sock -v " + os.Getenv("HOME") + "/.keploy-config:/root/.keploy-config -v " + os.Getenv("HOME") + "/.keploy:/root/.keploy --rm " + img
 		return alias, nil
 	case "windows":
 		// Get the current working directory
@@ -187,7 +193,6 @@ func getAlias(ctx context.Context, logger *zap.Logger) (string, error) {
 		if err != nil {
 			utils.LogError(logger, err, "failed to get the current working directory")
 		}
-		sshSock := os.Getenv("SSH_AUTH_SOCK")
 		dpwd := convertPathToUnixStyle(pwd)
 		cmd := exec.CommandContext(ctx, "docker", "context", "ls", "--format", "{{.Name}}\t{{.Current}}")
 		out, err := cmd.Output()
@@ -203,12 +208,12 @@ func getAlias(ctx context.Context, logger *zap.Logger) (string, error) {
 		dockerContext = strings.Split(dockerContext, "\n")[0]
 		if dockerContext == "colima" {
 			logger.Info("Starting keploy in docker with colima context, as that is the current context.")
-			alias := "docker container run --name keploy-v2 " + envs + "-e BINARY_TO_DOCKER=true -p 16789:16789 --privileged --pid=host" + ttyFlag + "-v " + pwd + ":" + dpwd + " -w " + dpwd + " -v /sys/fs/cgroup:/sys/fs/cgroup -v /sys/kernel/debug:/sys/kernel/debug -v /sys/fs/bpf:/sys/fs/bpf -v /var/run/docker.sock:/var/run/docker.sock -v " + os.Getenv("USERPROFILE") + "\\.keploy-config:/root/.keploy-config -v " + os.Getenv("USERPROFILE") + "\\.keploy:/root/.keploy --rm " + img
+			alias := "docker container run --name keploy-v2 " + envs + sshAgentMount + "-e DOCKER_BUILDKIT=1 -e BINARY_TO_DOCKER=true -p 16789:16789 --privileged --pid=host" + ttyFlag + "-v " + pwd + ":" + dpwd + " -w " + dpwd + " -v /sys/fs/cgroup:/sys/fs/cgroup -v /sys/kernel/debug:/sys/kernel/debug -v /sys/fs/bpf:/sys/fs/bpf -v /var/run/docker.sock:/var/run/docker.sock -v " + os.Getenv("USERPROFILE") + "\\.keploy-config:/root/.keploy-config -v " + os.Getenv("USERPROFILE") + "\\.keploy:/root/.keploy --rm " + img
 			return alias, nil
 		}
 		// if default docker context is used
 		logger.Info("Starting keploy in docker with default context, as that is the current context.")
-		alias := "docker container run --name keploy-v2 " + envs + "-v " + sshSock + ":/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent -e DOCKER_BUILDKIT=1 -e BINARY_TO_DOCKER=true -p 16789:16789 --privileged --pid=host" + ttyFlag + "-v " + pwd + ":" + dpwd + " -w " + dpwd + " -v /sys/fs/cgroup:/sys/fs/cgroup -v debugfs:/sys/kernel/debug:rw -v /sys/fs/bpf:/sys/fs/bpf -v /var/run/docker.sock:/var/run/docker.sock -v " + os.Getenv("USERPROFILE") + "\\.keploy-config:/root/.keploy-config -v " + os.Getenv("USERPROFILE") + "\\.keploy:/root/.keploy --rm " + img
+		alias := "docker container run --name keploy-v2 " + envs + sshAgentMount + "-e DOCKER_BUILDKIT=1 -e BINARY_TO_DOCKER=true -p 16789:16789 --privileged --pid=host" + ttyFlag + "-v " + pwd + ":" + dpwd + " -w " + dpwd + " -v /sys/fs/cgroup:/sys/fs/cgroup -v debugfs:/sys/kernel/debug:rw -v /sys/fs/bpf:/sys/fs/bpf -v /var/run/docker.sock:/var/run/docker.sock -v " + os.Getenv("USERPROFILE") + "\\.keploy-config:/root/.keploy-config -v " + os.Getenv("USERPROFILE") + "\\.keploy:/root/.keploy --rm " + img
 		return alias, nil
 	case "darwin":
 		// Get the context and docker daemon endpoint.
@@ -248,12 +253,12 @@ func getAlias(ctx context.Context, logger *zap.Logger) (string, error) {
 				return "", errors.New("failed to get alias")
 			}
 			logger.Info("Starting keploy in docker with colima context, as that is the current context.")
-			alias := "docker container run --name keploy-v2 " + envs + "-e BINARY_TO_DOCKER=true -p 16789:16789 --privileged --pid=host" + ttyFlag + "-v " + os.Getenv("PWD") + ":" + os.Getenv("PWD") + " -w " + os.Getenv("PWD") + " -v /sys/fs/cgroup:/sys/fs/cgroup -v /sys/kernel/debug:/sys/kernel/debug -v /sys/fs/bpf:/sys/fs/bpf -v /var/run/docker.sock:/var/run/docker.sock -v " + os.Getenv("HOME") + "/.keploy-config:/root/.keploy-config -v " + os.Getenv("HOME") + "/.keploy:/root/.keploy --rm " + img
+			alias := "docker container run --name keploy-v2 " + envs + sshAgentMount + "-e DOCKER_BUILDKIT=1 -e BINARY_TO_DOCKER=true -p 16789:16789 --privileged --pid=host" + ttyFlag + "-v " + os.Getenv("PWD") + ":" + os.Getenv("PWD") + " -w " + os.Getenv("PWD") + " -v /sys/fs/cgroup:/sys/fs/cgroup -v /sys/kernel/debug:/sys/kernel/debug -v /sys/fs/bpf:/sys/fs/bpf -v /var/run/docker.sock:/var/run/docker.sock -v " + os.Getenv("HOME") + "/.keploy-config:/root/.keploy-config -v " + os.Getenv("HOME") + "/.keploy:/root/.keploy --rm " + img
 			return alias, nil
 		}
 		// if default docker context is used
 		logger.Info("Starting keploy in docker with default context, as that is the current context.")
-		alias = "docker container run --name keploy-v2 " + envs + "-v $SSH_AUTH_SOCK:/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent -e DOCKER_BUILDKIT=1 -e BINARY_TO_DOCKER=true -p 16789:16789 --privileged --pid=host" + ttyFlag + "-v " + os.Getenv("PWD") + ":" + os.Getenv("PWD") + " -w " + os.Getenv("PWD") + " -v /sys/fs/cgroup:/sys/fs/cgroup -v debugfs:/sys/kernel/debug:rw -v /sys/fs/bpf:/sys/fs/bpf -v /var/run/docker.sock:/var/run/docker.sock -v " + os.Getenv("HOME") + "/.keploy-config:/root/.keploy-config -v " + os.Getenv("HOME") + "/.keploy:/root/.keploy --rm " + img
+		alias = "docker container run --name keploy-v2 " + envs + sshAgentMount + "-e DOCKER_BUILDKIT=1 -e BINARY_TO_DOCKER=true -p 16789:16789 --privileged --pid=host" + ttyFlag + "-v " + os.Getenv("PWD") + ":" + os.Getenv("PWD") + " -w " + os.Getenv("PWD") + " -v /sys/fs/cgroup:/sys/fs/cgroup -v debugfs:/sys/kernel/debug:rw -v /sys/fs/bpf:/sys/fs/bpf -v /var/run/docker.sock:/var/run/docker.sock -v " + os.Getenv("HOME") + "/.keploy-config:/root/.keploy-config -v " + os.Getenv("HOME") + "/.keploy:/root/.keploy --rm " + img
 		return alias, nil
 	}
 	return "", errors.New("failed to get alias")


### PR DESCRIPTION
## Describe the changes that are made
This pull request updates how the Docker run alias is generated in the `getAlias` function to improve compatibility with SSH agent forwarding and Docker BuildKit across Linux, Windows, and macOS environments. The main changes ensure that the SSH agent socket is correctly mounted inside the container and relevant environment variables are set, which helps with workflows that require SSH authentication (e.g., cloning private repositories) and enables Docker BuildKit for better build performance.

**Docker run alias improvements:**

* Added mounting of the SSH agent socket (`SSH_AUTH_SOCK`) and set `SSH_AUTH_SOCK` environment variable in the Docker run command for Linux, Windows, and macOS to support SSH agent forwarding. [[1]](diffhunk://#diff-005a1ac6747afd3dcc1ae728d6f79aa1178af829814bda78e62c173ae38981ebL182-R190) [[2]](diffhunk://#diff-005a1ac6747afd3dcc1ae728d6f79aa1178af829814bda78e62c173ae38981ebL210-R211) [[3]](diffhunk://#diff-005a1ac6747afd3dcc1ae728d6f79aa1178af829814bda78e62c173ae38981ebL255-R256)
* Set `DOCKER_BUILDKIT=1` environment variable in the Docker run command for all platforms to enable Docker BuildKit features inside the container. [[1]](diffhunk://#diff-005a1ac6747afd3dcc1ae728d6f79aa1178af829814bda78e62c173ae38981ebL182-R190) [[2]](diffhunk://#diff-005a1ac6747afd3dcc1ae728d6f79aa1178af829814bda78e62c173ae38981ebL210-R211) [[3]](diffhunk://#diff-005a1ac6747afd3dcc1ae728d6f79aa1178af829814bda78e62c173ae38981ebL255-R256)
## Links & References

**Closes:** #[issue number that will be closed through this PR]
- NA (if very small change like typo, linting, etc.)

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [ ] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

## Self Review done?
- [ ] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [ ] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [ ] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [ ] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?