### PR TITLE
fix: performance issues in grpc due excessive logging

### DIFF
--- a/pkg/core/proxy/integrations/grpcV2/mock.go
+++ b/pkg/core/proxy/integrations/grpcV2/mock.go
@@ -91,7 +91,7 @@ func (s *grpcMockServer) handler(_ interface{}, stream grpc.ServerStream) error 
 		s.logger.Warn("failed to get metadata from context")
 	}
 
-	s.logger.Info("received gRPC request to mock", zap.String("method", fullMethod), zap.Any("metadata", md))
+	s.logger.Debug("received gRPC request to mock", zap.String("method", fullMethod), zap.Any("metadata", md))
 
 	// Read the request body.
 	var requestBody []byte
@@ -101,7 +101,7 @@ func (s *grpcMockServer) handler(_ interface{}, stream grpc.ServerStream) error 
 		return status.Errorf(codes.Internal, "failed to receive request message: %v", err)
 	}
 	requestBody = reqMsg.data
-	s.logger.Info("fully received request body", zap.Int("size", len(requestBody)))
+	s.logger.Debug("fully received request body", zap.Int("size", len(requestBody)))
 
 	grpcReq := &models.GrpcReq{
 		Headers: s.grpcMetadataToHeaders(md, fullMethod),
@@ -120,7 +120,7 @@ func (s *grpcMockServer) handler(_ interface{}, stream grpc.ServerStream) error 
 		return status.Errorf(codes.NotFound, "no matching keploy mock found for %s", fullMethod)
 	}
 
-	s.logger.Info("found matching mock", zap.String("mock.name", mock.Name), zap.String("mock.kind", string(mock.Kind)))
+	s.logger.Debug("found matching mock", zap.String("mock.name", mock.Name), zap.String("mock.kind", string(mock.Kind)))
 
 	// 3. Send the mocked response
 	grpcResp := mock.Spec.GRPCResp


### PR DESCRIPTION
This pull request focuses on improving the efficiency and clarity of gRPC mock matching and canonicalization logic. The main changes include upgrading logging from `Info` to `Debug` for less noisy output, introducing guards against expensive operations on large or adversarial inputs, and refining the matching logic for gRPC pseudo-headers. These updates make the codebase more robust and easier to troubleshoot, especially at scale.

**Logging improvements:**

* Changed all `logger.Info` calls to `logger.Debug` in `match.go` and `mock.go` to reduce log verbosity and make logs more useful for debugging. [[1]](diffhunk://#diff-57084d3536b26fec534b6724a0100b008a3ae1b65f21f440af0bc95d28a4805fL49-R52) [[2]](diffhunk://#diff-57084d3536b26fec534b6724a0100b008a3ae1b65f21f440af0bc95d28a4805fL65-R75) [[3]](diffhunk://#diff-57084d3536b26fec534b6724a0100b008a3ae1b65f21f440af0bc95d28a4805fL181-R200) [[4]](diffhunk://#diff-e95b4e339b5774f2a96defa0f1a958ab3ed49d010f0e4cda80bccc1e2d19dd0cL94-R94) [[5]](diffhunk://#diff-e95b4e339b5774f2a96defa0f1a958ab3ed49d010f0e4cda80bccc1e2d19dd0cL104-R104) [[6]](diffhunk://#diff-e95b4e339b5774f2a96defa0f1a958ab3ed49d010f0e4cda80bccc1e2d19dd0cL123-R123)

**Efficiency and safety guards:**

* Added hard limits (`maxCanonDepth`, `maxCanonBytes`, `maxBlocks`) to canonicalization in `canonical.go` to prevent excessive computation on large or pathological gRPC bodies. Canonicalization now bails out early for oversized or deeply nested inputs. [[1]](diffhunk://#diff-2a23a7c69b5e8d8083f6cecc7404acd2b7d3966db3998cf48e3bf22d29d908a9R8-R44) [[2]](diffhunk://#diff-2a23a7c69b5e8d8083f6cecc7404acd2b7d3966db3998cf48e3bf22d29d908a9R95-R106) [[3]](diffhunk://#diff-2a23a7c69b5e8d8083f6cecc7404acd2b7d3966db3998cf48e3bf22d29d908a9L100-R121)
* Skips fuzzy body matching for requests with bodies larger than 256 KiB to avoid quadratic work.

**Matching logic refinement:**

* Updated gRPC schema matching to require exact matches for `:method` and `:path` pseudo-headers while tolerating mismatches in `:authority` with a debug log. Introduced `compareMapExcept` to compare maps while skipping specified keys. [[1]](diffhunk://#diff-57084d3536b26fec534b6724a0100b008a3ae1b65f21f440af0bc95d28a4805fL106-L135) [[2]](diffhunk://#diff-57084d3536b26fec534b6724a0100b008a3ae1b65f21f440af0bc95d28a4805fR147-R170)

These changes collectively improve performance, reliability, and maintainability of gRPC mock processing.