### PR TITLE
feat: implement revision tracking in MockManager for better state

### DIFF
--- a/pkg/core/proxy/mockmanager.go
+++ b/pkg/core/proxy/mockmanager.go
@@ -109,8 +109,8 @@ func (m *MockManager) SetUnFilteredMocks(mocks []*models.Mock) {
 		}
 		mock.TestModeInfo.ID = index
 		m.unfiltered.insert(mock.TestModeInfo, mock)
-		m.bumpRevision()
 	}
+	m.bumpRevision()
 }
 
 func (m *MockManager) UpdateUnFilteredMock(old *models.Mock, new *models.Mock) bool {

--- a/pkg/core/proxy/mockmanager.go
+++ b/pkg/core/proxy/mockmanager.go
@@ -94,8 +94,8 @@ func (m *MockManager) SetFilteredMocks(mocks []*models.Mock) {
 		}
 		mock.TestModeInfo.ID = index
 		m.filtered.insert(mock.TestModeInfo, mock)
-		m.bumpRevision()
 	}
+	m.bumpRevision()
 }
 
 func (m *MockManager) SetUnFilteredMocks(mocks []*models.Mock) {


### PR DESCRIPTION
This pull request introduces a revision tracking mechanism to the `MockManager` in `pkg/core/proxy/mockmanager.go`. The main goal is to maintain a monotonically increasing revision number that updates whenever the in-memory set or sort order of mocks changes. This helps external consumers efficiently detect changes to the mocks without scanning the entire set.

**Revision tracking enhancements:**

* Added a `rev` field to `MockManager` and imported `sync/atomic` for thread-safe revision management. [[1]](diffhunk://#diff-9a133c08bbc468a05091b48c725f0228d5a31aaeeda815c2cbc6383ff33ed855R11) [[2]](diffhunk://#diff-9a133c08bbc468a05091b48c725f0228d5a31aaeeda815c2cbc6383ff33ed855R22-R23)
* Implemented `Revision()` and `bumpRevision()` methods to expose and update the revision number atomically.

**Integration with mock mutation methods:**

* Updated `SetFilteredMocks`, `SetUnFilteredMocks`, `UpdateUnFilteredMock`, `DeleteFilteredMock`, and `DeleteUnFilteredMock` to increment the revision number (`bumpRevision()`) whenever mocks are modified. [[1]](diffhunk://#diff-9a133c08bbc468a05091b48c725f0228d5a31aaeeda815c2cbc6383ff33ed855R97) [[2]](diffhunk://#diff-9a133c08bbc468a05091b48c725f0228d5a31aaeeda815c2cbc6383ff33ed855R112) [[3]](diffhunk://#diff-9a133c08bbc468a05091b48c725f0228d5a31aaeeda815c2cbc6383ff33ed855R129) [[4]](diffhunk://#diff-9a133c08bbc468a05091b48c725f0228d5a31aaeeda815c2cbc6383ff33ed855R153) [[5]](diffhunk://#diff-9a133c08bbc468a05091b48c725f0228d5a31aaeeda815c2cbc6383ff33ed855R169)