### PR TITLE
feat: increase grpc request body size limit for fuzzy matching

### DIFF
--- a/pkg/core/proxy/integrations/grpcV2/match.go
+++ b/pkg/core/proxy/integrations/grpcV2/match.go
@@ -83,8 +83,8 @@ func FilterMocksBasedOnGrpcRequest(ctx context.Context, logger *zap.Logger, grpc
 
 			// apply fuzzy match for body with schemaMatched mocks
 			// Guard against quadratic work on very large bodies.
-			if len(expBody) > 256*1024 {
-				logger.Debug("skipping fuzzy match for large body")
+			if len(expBody) > 512*1024 {
+				logger.Debug("skipping fuzzy match for large body", zap.Int("len", len(expBody)))
 				return nil, nil
 			}
 			logger.Debug("performing fuzzy match for decoded data in body")


### PR DESCRIPTION
This pull request makes a minor adjustment to the fuzzy matching logic for gRPC request bodies in the `FilterMocksBasedOnGrpcRequest` function. The threshold for skipping fuzzy matching due to large body size has been increased.

* The threshold for skipping fuzzy matching was raised from 256KB to 512KB, and the debug log now includes the actual body length for better traceability. (`pkg/core/proxy/integrations/grpcV2/match.go`)