### PR TITLE
feat: add support for setting grpc port for grpc tests

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -300,7 +300,8 @@ func (c *CmdConfigurator) AddUncommonFlags(cmd *cobra.Command) {
 	case "test", "rerecord":
 		cmd.Flags().StringSliceP("test-sets", "t", utils.Keys(c.cfg.Test.SelectedTests), "Testsets to run e.g. --testsets \"test-set-1, test-set-2\"")
 		cmd.Flags().String("host", c.cfg.Test.Host, "Custom host to replace the actual host in the testcases")
-		cmd.Flags().Uint32("port", c.cfg.Test.Port, "Custom port to replace the actual port in the testcases")
+		cmd.Flags().Uint32("port", c.cfg.Test.Port, "Custom http port to replace the actual port in the testcases")
+		cmd.Flags().Uint32("grpc-port", c.cfg.Test.GRPCPort, "Custom grpc port to replace the actual port in the testcases")
 		cmd.Flags().Uint64P("delay", "d", 5, "User provided time to run its application")
 		if cmd.Name() == "test" {
 			cmd.Flags().Uint64("api-timeout", c.cfg.Test.APITimeout, "User provided timeout for calling its application")
@@ -357,6 +358,7 @@ func aliasNormalizeFunc(_ *pflag.FlagSet, name string) pflag.NormalizedName {
 		"configPath":            "config-path",
 		"path":                  "path",
 		"port":                  "port",
+		"grpcPort":              "grpc-port",
 		"proxyPort":             "proxy-port",
 		"dnsPort":               "dns-port",
 		"command":               "command",
@@ -869,6 +871,15 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 					return errors.New(errMsg)
 				}
 				c.cfg.ReRecord.Port = port
+
+				grpcPort, err := cmd.Flags().GetUint32("grpc-port")
+				if err != nil {
+					errMsg := "failed to get the provided grpcPort"
+					utils.LogError(c.logger, err, errMsg)
+					return errors.New(errMsg)
+				}
+				c.cfg.ReRecord.GRPCPort = grpcPort
+
 				c.cfg.Test.Delay, err = cmd.Flags().GetUint64("delay")
 				if err != nil {
 					errMsg := "failed to get the provided delay"

--- a/config/config.go
+++ b/config/config.go
@@ -79,6 +79,7 @@ type ReRecord struct {
 	Filters       []Filter `json:"filters" yaml:"filters" mapstructure:"filters"`
 	Host          string   `json:"host" yaml:"host" mapstructure:"host"`
 	Port          uint32   `json:"port" yaml:"port" mapstructure:"port"`
+	GRPCPort      uint32   `json:"grpcPort" yaml:"grpcPort" mapstructure:"grpcPort"`
 }
 type Contract struct {
 	Services []string `json:"services" yaml:"services" mapstructure:"services"`
@@ -123,6 +124,7 @@ type Test struct {
 	Delay               uint64              `json:"delay" yaml:"delay" mapstructure:"delay"`
 	Host                string              `json:"host" yaml:"host" mapstructure:"host"`
 	Port                uint32              `json:"port" yaml:"port" mapstructure:"port"`
+	GRPCPort            uint32              `json:"grpcPort" yaml:"grpcPort" mapstructure:"grpcPort"`
 	APITimeout          uint64              `json:"apiTimeout" yaml:"apiTimeout" mapstructure:"apiTimeout"`
 	SkipCoverage        bool                `json:"skipCoverage" yaml:"skipCoverage" mapstructure:"skipCoverage"`                   // boolean to capture the coverage in test
 	CoverageReportPath  string              `json:"coverageReportPath" yaml:"coverageReportPath" mapstructure:"coverageReportPath"` // directory path to store the coverage files

--- a/config/default.go
+++ b/config/default.go
@@ -34,6 +34,7 @@ test:
   delay: 5
   host: ""
   port: 0
+  grpcPort: 0
   apiTimeout: 5
   skipCoverage: false
   coverageReportPath: ""

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -958,9 +958,17 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			}
 		}
 
-		// Handle user-provided port replacement
-		if r.config.Test.Port != 0 {
+		// Handle user-provided http port replacement
+		if r.config.Test.Port != 0 && testCase.Kind == models.HTTP {
 			err = r.replacePortInTestCase(testCase, strconv.Itoa(int(r.config.Test.Port)))
+			if err != nil {
+				break
+			}
+		}
+
+		// Handle user-provided grpc port replacement
+		if r.config.Test.GRPCPort != 0 && testCase.Kind == models.GRPC_EXPORT {
+			err = r.replacePortInTestCase(testCase, strconv.Itoa(int(r.config.Test.GRPCPort)))
 			if err != nil {
 				break
 			}


### PR DESCRIPTION
## Describe the changes that are made
This pull request adds support for custom gRPC port configuration in both testing and re-recording workflows, alongside improvements to port replacement logic for gRPC authorities (including IPv6 support). It also introduces comprehensive unit tests for these functions. The changes are organized as follows:

**gRPC Port Configuration Support**

* Added `GRPCPort` fields to the `Test` and `ReRecord` structs in `config/config.go`, allowing users to specify custom gRPC ports. [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R82) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R127)
* Updated CLI flag handling to support a new `--grpc-port` flag, including normalization and validation logic in `cli/provider/cmd.go`. [[1]](diffhunk://#diff-a5137720b20dbcb8f3812a18d16b1fc9a65835f982accc5259aac757fface66eL303-R304) [[2]](diffhunk://#diff-a5137720b20dbcb8f3812a18d16b1fc9a65835f982accc5259aac757fface66eR361) [[3]](diffhunk://#diff-a5137720b20dbcb8f3812a18d16b1fc9a65835f982accc5259aac757fface66eR874-R882)
* Set default value for `grpcPort` in `config/default.go`.

**Port Replacement Logic Enhancements**

* Modified replay and re-record logic to correctly replace ports for both HTTP and gRPC test cases, using the new `GRPCPort` configuration and distinguishing between protocols. [[1]](diffhunk://#diff-2dbe9934449644c8aa94b0c0ebd71b6ec7d1ae1cbe403db5d2db0eda51b6ec99L271-R287) [[2]](diffhunk://#diff-e6489c0602898b5fed439b3c4c42885db5890483591af1991adc497ba59e31d9L961-R976)

**Utility Function Improvements**

* Refactored `ReplaceGrpcHost` and `ReplaceGrpcPort` functions in `utils/utils.go` to robustly handle IPv6 addresses and malformed authority strings, using `net.SplitHostPort` for correctness. [[1]](diffhunk://#diff-0df82f8689d3e8d881be0653ab4e9f8221c5835ec95a14930d11669e9c7f07efL74-R81) [[2]](diffhunk://#diff-0df82f8689d3e8d881be0653ab4e9f8221c5835ec95a14930d11669e9c7f07efL90-R98)

**Testing Enhancements**

* Added thorough unit tests for `ReplaceGrpcHost` and `ReplaceGrpcPort`, covering IPv4, IPv6, hostnames, malformed inputs, and edge cases in `utils/utils_test.go`.

**Dependency Update**

* Imported the `models` package in `pkg/service/orchestrator/rerecord.go` to support gRPC test case kind detection.

## Links & References

**Closes:** https://github.com/keploy/keploy/issues/2933
- NA (if very small change like typo, linting, etc.)

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [x] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [x] 👍 yes, added a unit test case for the same
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [x] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [ ] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [x] 🙅 no, because it is not needed

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?