### PR TITLE
fix:remove retprobeMaxActive to avoid using tracefs to load kprobes

### DIFF
--- a/pkg/core/hooks/hooks.go
+++ b/pkg/core/hooks/hooks.go
@@ -30,17 +30,16 @@ import (
 
 func NewHooks(logger *zap.Logger, cfg *config.Config) *Hooks {
 	return &Hooks{
-		logger:            logger,
-		sess:              core.NewSessions(),
-		m:                 sync.Mutex{},
-		objectsMutex:      sync.RWMutex{},
-		proxyIP4:          "127.0.0.1",
-		proxyIP6:          [4]uint32{0000, 0000, 0000, 0001},
-		proxyPort:         cfg.ProxyPort,
-		dnsPort:           cfg.DNSPort,
-		conf:              cfg,
-		retprobeMaxActive: 1024,
-		unloadDone:        make(chan struct{}),
+		logger:       logger,
+		sess:         core.NewSessions(),
+		m:            sync.Mutex{},
+		objectsMutex: sync.RWMutex{},
+		proxyIP4:     "127.0.0.1",
+		proxyIP6:     [4]uint32{0000, 0000, 0000, 0001},
+		proxyPort:    cfg.ProxyPort,
+		dnsPort:      cfg.DNSPort,
+		conf:         cfg,
+		unloadDone:   make(chan struct{}),
 	}
 }
 
@@ -83,31 +82,30 @@ type Hooks struct {
 	connect    link.Link
 	connectRet link.Link
 
-	accept            link.Link
-	acceptRet         link.Link
-	accept4           link.Link
-	accept4Ret        link.Link
-	read              link.Link
-	readRet           link.Link
-	write             link.Link
-	writeRet          link.Link
-	close             link.Link
-	closeRet          link.Link
-	sendto            link.Link
-	sendtoRet         link.Link
-	recvfrom          link.Link
-	recvfromRet       link.Link
-	objects           bpfObjects
-	writev            link.Link
-	writevRet         link.Link
-	readv             link.Link
-	readvRet          link.Link
-	retprobeMaxActive int
-	appID             uint64
-	cgBind4           link.Link
-	cgBind6           link.Link
-	bindEnter         link.Link
-	BindEvents        *ebpf.Map
+	accept      link.Link
+	acceptRet   link.Link
+	accept4     link.Link
+	accept4Ret  link.Link
+	read        link.Link
+	readRet     link.Link
+	write       link.Link
+	writeRet    link.Link
+	close       link.Link
+	closeRet    link.Link
+	sendto      link.Link
+	sendtoRet   link.Link
+	recvfrom    link.Link
+	recvfromRet link.Link
+	objects     bpfObjects
+	writev      link.Link
+	writevRet   link.Link
+	readv       link.Link
+	readvRet    link.Link
+	appID       uint64
+	cgBind4     link.Link
+	cgBind6     link.Link
+	bindEnter   link.Link
+	BindEvents  *ebpf.Map
 }
 
 func (h *Hooks) Load(ctx context.Context, id uint64, opts core.HookCfg) error {
@@ -224,7 +222,7 @@ func (h *Hooks) load(ctx context.Context, opts core.HookCfg) error {
 		}
 		h.tcpv4 = tcpC4
 
-		tcpRC4, err := link.Kretprobe("tcp_v4_connect", objs.SyscallProbeRetTcpV4Connect, &link.KprobeOptions{RetprobeMaxActive: h.retprobeMaxActive})
+		tcpRC4, err := link.Kretprobe("tcp_v4_connect", objs.SyscallProbeRetTcpV4Connect, &link.KprobeOptions{})
 		if err != nil {
 			utils.LogError(h.logger, err, "failed to attach the kretprobe hook on tcp_v4_connect")
 			return err
@@ -333,7 +331,7 @@ func (h *Hooks) load(ctx context.Context, opts core.HookCfg) error {
 		}
 		h.tcpv6 = tcpC6
 
-		tcpRC6, err := link.Kretprobe("tcp_v6_connect", objs.SyscallProbeRetTcpV6Connect, &link.KprobeOptions{RetprobeMaxActive: h.retprobeMaxActive})
+		tcpRC6, err := link.Kretprobe("tcp_v6_connect", objs.SyscallProbeRetTcpV6Connect, &link.KprobeOptions{})
 		if err != nil {
 			utils.LogError(h.logger, err, "failed to attach the kretprobe hook on tcp_v6_connect")
 			return err
@@ -377,7 +375,7 @@ func (h *Hooks) load(ctx context.Context, opts core.HookCfg) error {
 	h.connect = cnt
 
 	//Opening a kretprobe at the exit of connect syscall
-	cntr, err := link.Kretprobe("sys_connect", objs.SyscallProbeRetConnect, &link.KprobeOptions{RetprobeMaxActive: h.retprobeMaxActive})
+	cntr, err := link.Kretprobe("sys_connect", objs.SyscallProbeRetConnect, &link.KprobeOptions{})
 	if err != nil {
 		utils.LogError(h.logger, err, "failed to attach the kretprobe hook on sys_connect")
 		return err
@@ -395,7 +393,7 @@ func (h *Hooks) load(ctx context.Context, opts core.HookCfg) error {
 	h.sendto = snd
 
 	//Opening a kretprobe at the exit of sendto syscall
-	sndr, err := link.Kretprobe("sys_sendto", objs.SyscallProbeRetSendto, &link.KprobeOptions{RetprobeMaxActive: h.retprobeMaxActive})
+	sndr, err := link.Kretprobe("sys_sendto", objs.SyscallProbeRetSendto, &link.KprobeOptions{})
 	if err != nil {
 		utils.LogError(h.logger, err, "failed to attach the kretprobe hook on sys_sendto")
 		return err
@@ -413,7 +411,7 @@ func (h *Hooks) load(ctx context.Context, opts core.HookCfg) error {
 
 	// Open a Kprobe at the exit point of the kernel function and attach the
 	// pre-compiled program.
-	acRet, err := link.Kretprobe("sys_accept", objs.SyscallProbeRetAccept, &link.KprobeOptions{RetprobeMaxActive: h.retprobeMaxActive})
+	acRet, err := link.Kretprobe("sys_accept", objs.SyscallProbeRetAccept, &link.KprobeOptions{})
 	if err != nil {
 		utils.LogError(h.logger, err, "failed to attach the kretprobe hook on sys_accept")
 		return err
@@ -431,7 +429,7 @@ func (h *Hooks) load(ctx context.Context, opts core.HookCfg) error {
 
 	// Open a Kprobe at the exit point of the kernel function and attach the
 	// pre-compiled program.
-	ac4Ret, err := link.Kretprobe("sys_accept4", objs.SyscallProbeRetAccept4, &link.KprobeOptions{RetprobeMaxActive: h.retprobeMaxActive})
+	ac4Ret, err := link.Kretprobe("sys_accept4", objs.SyscallProbeRetAccept4, &link.KprobeOptions{})
 	if err != nil {
 		utils.LogError(h.logger, err, "failed to attach the kretprobe hook on sys_accept4")
 		return err
@@ -449,7 +447,7 @@ func (h *Hooks) load(ctx context.Context, opts core.HookCfg) error {
 
 	// Open a Kprobe at the exit point of the kernel function and attach the
 	// pre-compiled program.
-	rdRet, err := link.Kretprobe("sys_read", objs.SyscallProbeRetRead, &link.KprobeOptions{RetprobeMaxActive: h.retprobeMaxActive})
+	rdRet, err := link.Kretprobe("sys_read", objs.SyscallProbeRetRead, &link.KprobeOptions{})
 	if err != nil {
 		utils.LogError(h.logger, err, "failed to attach the kretprobe hook on sys_read")
 		return err
@@ -467,7 +465,7 @@ func (h *Hooks) load(ctx context.Context, opts core.HookCfg) error {
 
 	// Open a Kprobe at the exit point of the kernel function and attach the
 	// pre-compiled program.
-	wtRet, err := link.Kretprobe("sys_write", objs.SyscallProbeRetWrite, &link.KprobeOptions{RetprobeMaxActive: h.retprobeMaxActive})
+	wtRet, err := link.Kretprobe("sys_write", objs.SyscallProbeRetWrite, &link.KprobeOptions{})
 	if err != nil {
 		utils.LogError(h.logger, err, "failed to attach the kretprobe hook on sys_write")
 		return err
@@ -485,7 +483,7 @@ func (h *Hooks) load(ctx context.Context, opts core.HookCfg) error {
 
 	// Open a Kprobe at the exit point of the kernel function and attach the
 	// pre-compiled program for readv.
-	readvRet, err := link.Kretprobe("sys_readv", objs.SyscallProbeRetReadv, &link.KprobeOptions{RetprobeMaxActive: h.retprobeMaxActive})
+	readvRet, err := link.Kretprobe("sys_readv", objs.SyscallProbeRetReadv, &link.KprobeOptions{})
 	if err != nil {
 		utils.LogError(h.logger, err, "failed to attach the kretprobe hook on sys_readv")
 		return err
@@ -503,7 +501,7 @@ func (h *Hooks) load(ctx context.Context, opts core.HookCfg) error {
 
 	// Open a Kprobe at the exit point of the kernel function and attach the
 	// pre-compiled program for writev.
-	wtvRet, err := link.Kretprobe("sys_writev", objs.SyscallProbeRetWritev, &link.KprobeOptions{RetprobeMaxActive: h.retprobeMaxActive})
+	wtvRet, err := link.Kretprobe("sys_writev", objs.SyscallProbeRetWritev, &link.KprobeOptions{})
 	if err != nil {
 		utils.LogError(h.logger, err, "failed to attach the kretprobe hook on sys_writev")
 		return err
@@ -528,7 +526,7 @@ func (h *Hooks) load(ctx context.Context, opts core.HookCfg) error {
 	h.recvfrom = rcv
 
 	//Attaching a kretprobe at the exit of recvfrom syscall
-	rcvr, err := link.Kretprobe("sys_recvfrom", objs.SyscallProbeRetRecvfrom, &link.KprobeOptions{RetprobeMaxActive: h.retprobeMaxActive})
+	rcvr, err := link.Kretprobe("sys_recvfrom", objs.SyscallProbeRetRecvfrom, &link.KprobeOptions{})
 	if err != nil {
 		utils.LogError(h.logger, err, "failed to attach the kretprobe hook on sys_recvfrom")
 		return err
@@ -537,7 +535,7 @@ func (h *Hooks) load(ctx context.Context, opts core.HookCfg) error {
 
 	// Open a Kprobe at the exit point of the kernel function and attach the
 	// pre-compiled program.
-	clRet, err := link.Kretprobe("sys_close", objs.SyscallProbeRetClose, &link.KprobeOptions{RetprobeMaxActive: h.retprobeMaxActive})
+	clRet, err := link.Kretprobe("sys_close", objs.SyscallProbeRetClose, &link.KprobeOptions{})
 	if err != nil {
 		utils.LogError(h.logger, err, "failed to attach the kretprobe hook on sys_close")
 		return err


### PR DESCRIPTION
## Describe the changes that are made
- Remove using retprobeMaxActive to avoid using tracefs to load kprobes. Loading kprobes with tracefs is leading to a buffer overflow, which is crashing the machine kernel in high-concurrency and load scenarios. 

## Links & References

**Closes:** This kernel panic occurs with high concurrency and load. 

```
/tmp/apport-614/VmCoreDmesg:3156:[ 8661.382348] [T1559791] detected buffer overflow in strcpy
/tmp/apport-614/VmCoreDmesg:3159:[ 8661.382457] [T1559791] invalid opcode: 0000 [#1] PREEMPT SMP NOPTI
/tmp/apport-614/VmCoreDmesg:3162:[ 8661.382665] [T1559791] RIP: 0010:fortify_panic+0x13/0x20
/tmp/apport-614/VmCoreDmesg:3180:[ 8661.384649] [T1559791]  ? fortify_panic+0x13/0x20
/tmp/apport-614/VmCoreDmesg:3182:[ 8661.384804] [T1559791]  ? fortify_panic+0x13/0x20
/tmp/apport-614/VmCoreDmesg:3184:[ 8661.384955] [T1559791]  ? fortify_panic+0x13/0x20
/tmp/apport-614/VmCoreDmesg:3185:[ 8661.385003] [T1559791]  __trace_probe_log_err+0x1b1/0x1c0
/tmp/apport-614/VmCoreDmesg:3186:[ 8661.385053] [T1559791]  __trace_kprobe_create+0x823/0x8d0
/tmp/apport-614/VmCoreDmesg:3187:[ 8661.385110] [T1559791]  ? __pfx___trace_kprobe_create+0x10/0x10
/tmp/apport-614/VmCoreDmesg:3189:[ 8661.385225] [T1559791]  create_or_delete_trace_kprobe+0x15/0x50
/tmp/apport-614/VmCoreDmesg:3191:[ 8661.385360] [T1559791]  ? __pfx_create_or_delete_trace_kprobe+0x10/0x10
/tmp/apport-614/VmCoreDmesg:3192:[ 8661.385423] [T1559791]  probes_write+0x10/0x30
/tmp/apport-614b/VmCoreDmesg:2627:[ 3249.024099] [T1042771] detected buffer overflow in strcpy
/tmp/apport-614b/VmCoreDmesg:2630:[ 3249.024640] [T1042771] invalid opcode: 0000 [#1] PREEMPT SMP NOPTI
/tmp/apport-614b/VmCoreDmesg:2633:[ 3249.025600] [T1042771] RIP: 0010:fortify_panic+0x13/0x20
/tmp/apport-614b/VmCoreDmesg:2651:[ 3249.030617] [T1042771]  ? fortify_panic+0x13/0x20
/tmp/apport-614b/VmCoreDmesg:2653:[ 3249.031162] [T1042771]  ? fortify_panic+0x13/0x20
/tmp/apport-614b/VmCoreDmesg:2655:[ 3249.031780] [T1042771]  ? fortify_panic+0x13/0x20
/tmp/apport-614b/VmCoreDmesg:2656:[ 3249.032047] [T1042771]  ? fortify_panic+0x13/0x20
/tmp/apport-614b/VmCoreDmesg:2657:[ 3249.032313] [T1042771]  __trace_probe_log_err+0x1b1/0x1c0
/tmp/apport-614b/VmCoreDmesg:2658:[ 3249.032520] [T1042771]  __trace_kprobe_create+0x823/0x8d0
/tmp/apport-614b/VmCoreDmesg:2659:[ 3249.032780] [T1042771]  ? __pfx___trace_kprobe_create+0x10/0x10
/tmp/apport-614b/VmCoreDmesg:2661:[ 3249.033330] [T1042771]  create_or_delete_trace_kprobe+0x15/0x50
/tmp/apport-614b/VmCoreDmesg:2663:[ 3249.033826] [T1042771]  ? __pfx_create_or_delete_trace_kprobe+0x10/0x10
/tmp/apport-614b/VmCoreDmesg:2664:[ 3249.034209] [T1042771]  probes_write+0x10/0x30
[ 8661.382348] [T1559791] detected buffer overflow in strcpy
[ 8661.382665] [T1559791] RIP: 0010:fortify_panic+0x13/0x20
[ 8661.384649] [T1559791]  ? fortify_panic+0x13/0x20
[ 8661.384804] [T1559791]  ? fortify_panic+0x13/0x20
[ 8661.384955] [T1559791]  ? fortify_panic+0x13/0x20
[ 8661.385003] [T1559791]  __trace_probe_log_err+0x1b1/0x1c0
[ 8661.385053] [T1559791]  __trace_kprobe_create+0x823/0x8d0
[ 8661.385110] [T1559791]  ? __pfx___trace_kprobe_create+0x10/0x10
[ 8661.385225] [T1559791]  create_or_delete_trace_kprobe+0x15/0x50
[ 8661.385360] [T1559791]  ? __pfx_create_or_delete_trace_kprobe+0x10/0x10
[ 8661.385423] [T1559791]  probes_write+0x10/0x30
[ 3249.024099] [T1042771] detected buffer overflow in strcpy
[ 3249.025600] [T1042771] RIP: 0010:fortify_panic+0x13/0x20
[ 3249.030617] [T1042771]  ? fortify_panic+0x13/0x20
[ 3249.031162] [T1042771]  ? fortify_panic+0x13/0x20
[ 3249.031780] [T1042771]  ? fortify_panic+0x13/0x20
[ 3249.032047] [T1042771]  ? fortify_panic+0x13/0x20
[ 3249.032313] [T1042771]  __trace_probe_log_err+0x1b1/0x1c0
[ 3249.032520] [T1042771]  __trace_kprobe_create+0x823/0x8d0
[ 3249.032780] [T1042771]  ? __pfx___trace_kprobe_create+0x10/0x10
[ 3249.033330] [T1042771]  create_or_delete_trace_kprobe+0x15/0x50
[ 3249.033826] [T1042771]  ? __pfx_create_or_delete_trace_kprobe+0x10/0x10
[ 3249.034209] [T1042771]  probes_write+0x10/0x30
```


### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [x] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [x] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [x] 🙅 no, because it is not needed

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [ ] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [ ] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [ ] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?