### PR TITLE
fix: suppress usage display for Docker Compose validation errors

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -425,6 +425,12 @@ func aliasNormalizeFunc(_ *pflag.FlagSet, name string) pflag.NormalizedName {
 }
 
 func (c *CmdConfigurator) Validate(ctx context.Context, cmd *cobra.Command) error {
+	// Check if this is a Docker Compose command and suppress usage on validation errors
+	commandFlag, _ := cmd.Flags().GetString("command")
+	if utils.FindDockerCmd(commandFlag) == utils.DockerCompose {
+		cmd.SilenceUsage = true
+	}
+
 	err := isCompatible(c.logger)
 	if err != nil {
 		return err

--- a/cli/record.go
+++ b/cli/record.go
@@ -20,12 +20,7 @@ func Record(ctx context.Context, logger *zap.Logger, _ *config.Config, serviceFa
 		Use:     "record",
 		Short:   "record the keploy testcases from the API calls",
 		Example: `keploy record -c "/path/to/user/app"`,
-		PreRunE: func(cmd *cobra.Command, _ []string) error {
-			// Check if this is a Docker Compose command and suppress usage on validation errors
-			commandFlag, _ := cmd.Flags().GetString("command")
-			if utils.FindDockerCmd(commandFlag) == utils.DockerCompose {
-				cmd.SilenceUsage = true
-			}
+	PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return cmdConfigurator.Validate(ctx, cmd)
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/cli/test.go
+++ b/cli/test.go
@@ -20,12 +20,7 @@ func Test(ctx context.Context, logger *zap.Logger, _ *config.Config, serviceFact
 		Use:     "test",
 		Short:   "run the recorded testcases and execute assertions",
 		Example: `keploy test -c "/path/to/user/app" --delay 6`,
-		PreRunE: func(cmd *cobra.Command, _ []string) error {
-			// Check if this is a Docker Compose command and suppress usage on validation errors
-			commandFlag, _ := cmd.Flags().GetString("command")
-			if utils.FindDockerCmd(commandFlag) == utils.DockerCompose {
-				cmd.SilenceUsage = true
-			}
+	PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return cmdConfigurator.Validate(ctx, cmd)
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {


### PR DESCRIPTION
## Describe the changes that are made

- Set SilenceUsage=true for Docker Compose commands in PreRunE
- Preserves all error messages while hiding unwanted usage text
- Maintains Docker Compose functionality
- Affects both 'keploy record' and 'keploy test' commands
- Uses proper Cobra SilenceUsage feature

Resolves #3143



## Links & References

**Closes:** #3147 



- [X] 🍕 Feature



## Added comments for hard-to-understand areas?
- [X] 👍 yes


- [X] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [X] 👍 yes, mentioned below
Stop Docker daemon or ensure Docker is unavailable
Run: keploy record -c "docker-compose up" --container-name "test-app"
Run: keploy test -c "docker-compose up" --container-name "test-app"
Verify: Both commands show error messages but NO usage/help text after errors
Verify: Process exits cleanly with exit code 1

## Self Review done?
- [X] ✅ yes



## Any relevant screenshots, recordings or logs?

SCREEN_RECORDING

https://github.com/user-attachments/assets/43464961-9aa7-4a73-a35e-19b00761a3d1

BEFORE:
<img width="967" height="930" alt="image" src="https://github.com/user-attachments/assets/67c3d949-ba1c-4291-9c0a-9265f53a878a" />
AFTER:
<img width="982" height="448" alt="image" src="https://github.com/user-attachments/assets/3be359f9-11b5-45f5-b394-56a6c460fbf8" />





## Additional checklist:
- [X] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [X] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [X] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?