### PR TITLE
feat: show failure type and categories in report

### DIFF
--- a/pkg/service/report/report.go
+++ b/pkg/service/report/report.go
@@ -275,7 +275,7 @@ func (r *Report) printSummary(reports map[string]*models.TestReport) error {
 
 					// Add risk level if available and not NONE
 					if t.FailureInfo.Risk != "" && t.FailureInfo.Risk != models.None {
-						label += fmt.Sprintf(" [%s]", t.FailureInfo.Risk)
+						label += fmt.Sprintf(" [%s-RISK]", t.FailureInfo.Risk)
 					}
 
 					// Add categories if available
@@ -702,7 +702,7 @@ func (r *Report) renderSingleFailedTest(sb *strings.Builder, test models.TestRes
 
 	// Add risk level if available and not NONE
 	if test.FailureInfo.Risk != "" && test.FailureInfo.Risk != models.None {
-		header += fmt.Sprintf(" [%s]", test.FailureInfo.Risk)
+		header += fmt.Sprintf(" [%s-RISK]", test.FailureInfo.Risk)
 	}
 
 	// Add categories if available
@@ -820,7 +820,7 @@ func (r *Report) generateTestHeader(test models.TestResult, printer *pp.PrettyPr
 
 	// Add risk level if available and not NONE
 	if test.FailureInfo.Risk != "" && test.FailureInfo.Risk != models.None {
-		header += fmt.Sprintf(" [%s]", test.FailureInfo.Risk)
+		header += fmt.Sprintf(" [%s-RISK]", test.FailureInfo.Risk)
 	}
 
 	// Add categories if available


### PR DESCRIPTION
## Describe the changes that are made
- 

## Links & References

**Closes:** #3162 
- NA (if very small change like typo, linting, etc.)

**Please find the screenshots of how the keploy report command would look like with new details (failure type and categorization):**
<details>
  <summary>keploy report</summary>
  
<img width="827" height="666" alt="Screenshot 2025-10-22 at 6 39 37 AM" src="https://github.com/user-attachments/assets/d6403648-b86f-4ee7-9923-799abd61625c" />
<img width="629" height="677" alt="Screenshot 2025-10-22 at 6 39 47 AM" src="https://github.com/user-attachments/assets/02dc8dd2-99e0-4a88-85c1-40773b84b520" />
<img width="854" height="552" alt="Screenshot 2025-10-22 at 6 40 11 AM" src="https://github.com/user-attachments/assets/8aaacffb-2c6f-482d-ada3-16d0fc0c6f40" />

</details>

<details>
  <summary>keploy report --summary</summary>
 
<img width="861" height="605" alt="Screenshot 2025-10-22 at 6 42 48 AM" src="https://github.com/user-attachments/assets/61978956-01d0-4736-8d28-c4803748607c" />

 </details>

<details>
  <summary>keploy report --full</summary>
 
<img width="846" height="535" alt="Screenshot 2025-10-22 at 6 40 26 AM" src="https://github.com/user-attachments/assets/42339524-4004-4132-bd11-ed18363b8c83" />
<img width="725" height="584" alt="Screenshot 2025-10-22 at 6 40 35 AM" src="https://github.com/user-attachments/assets/daed40c3-9c3d-451a-bb99-5e8bad8fe840" />
<img width="879" height="586" alt="Screenshot 2025-10-22 at 6 40 43 AM" src="https://github.com/user-attachments/assets/8e8f631d-4b0f-4d37-879f-3eddb0725b9c" />
<img width="801" height="583" alt="Screenshot 2025-10-22 at 6 40 49 AM" src="https://github.com/user-attachments/assets/56c42470-1d3f-4dda-9b93-78127d896be1" />
<img width="834" height="598" alt="Screenshot 2025-10-22 at 6 40 59 AM" src="https://github.com/user-attachments/assets/f15981ad-9f91-4874-9e69-1706ad87a956" />

 </details>

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [x] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [ ] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

## Self Review done?
- [ ] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [ ] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [ ] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [ ] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?