### PR TITLE
feat: mount config path outside cawd

### DIFF
--- a/cli/provider/util.go
+++ b/cli/provider/util.go
@@ -27,7 +27,8 @@ func alreadyRunning(cmd, basePath string) bool {
 // mountPathIfExternal mounts a path if it's outside the current working directory
 // isFile indicates whether the path points to a file (if true, mount its parent directory)
 // path is expected to be an absolute path
-func mountPathIfExternal(logger *zap.Logger, path string, isFile bool) error {
+// pathType is used for logging (e.g., "proto", "config")
+func mountPathIfExternal(logger *zap.Logger, path string, isFile bool, pathType string) error {
 	if path == "" {
 		return nil
 	}
@@ -56,7 +57,7 @@ func mountPathIfExternal(logger *zap.Logger, path string, isFile bool) error {
 		volumeMount := dirToMount + ":" + dirToMount
 		if !volumeMountExists(volumeMount) {
 			DockerConfig.VolumeMounts = append(DockerConfig.VolumeMounts, volumeMount)
-			logger.Info("Mounting external proto path", zap.String("path", dirToMount))
+			logger.Debug(fmt.Sprintf("Mounting external %s path", pathType), zap.String("path", dirToMount))
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Asish Kumar <officialasishkumar@gmail.com>

## Describe the changes that are made
This PR adds support for mounting external config paths when running Keploy in Docker mode, alongside the existing proto path mounting functionality. The changes enable Docker containers to access configuration files located outside the current working directory.

- Extended `mountPathIfExternal` to accept a `pathType` parameter for improved logging
- Added logic to mount config paths for all Docker commands (record/test/rerecord)
- Changed log level from Info to Debug for mount operations


## Links & References

**Closes:** https://github.com/keploy/keploy/issues/3227


### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [x] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [x] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [x] 🙅 no, because it is not needed

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?