### PR TITLE
fix: prevent nil pointer dereference when actualResponse.Header is nil

### DIFF
--- a/pkg/matcher/http/match.go
+++ b/pkg/matcher/http/match.go
@@ -106,6 +106,9 @@ func Match(tc *models.TestCase, actualResponse *models.HTTPResp, noiseConfig map
 
 	res.BodyResult[0].Normal = pass
 
+	if actualResponse.Header == nil {
+		actualResponse.Header = make(map[string]string)
+	}
 	if !matcherUtils.CompareHeaders(pkg.ToHTTPHeader(tc.HTTPResp.Header), pkg.ToHTTPHeader(actualResponse.Header), hRes, headerNoise) {
 		pass = false
 	}
@@ -391,6 +394,9 @@ var fmtSprintf234 = fmt.Sprintf
 var strconvAtoi234 = strconv.Atoi
 
 func AssertionMatch(tc *models.TestCase, actualResponse *models.HTTPResp, logger *zap.Logger) (bool, *models.Result) {
+	if actualResponse.Header == nil {
+		actualResponse.Header = make(map[string]string)
+	}
 	pass := true
 	res := &models.Result{
 		StatusCode: models.IntResult{


### PR DESCRIPTION
# Overview
This PR addresses issue #3239 by fixing potential nil pointer dereferences in the HTTP matcher. When `actualResponse.Header` was nil, the code would panic during header comparison operations. The fix initializes an empty map for `actualResponse.Header` in both `Match` and `AssertionMatch` functions when it is nil.

# Checklist
- [ ] Code changes are complete
- [ ] Tests pass
- [ ] Documentation updated (if applicable)

# Proof that changes are correct
The changes add nil checks and initializations for `actualResponse.Header` at the beginning of both the `Match` and `AssertionMatch` functions. This ensures that header comparison operations can proceed safely without encountering nil pointer dereferences. The fix is minimal, targeted, and maintains existing functionality while improving robustness.