### PR TITLE
fix: handling of TXT dns record

### DIFF
--- a/pkg/core/proxy/dns.go
+++ b/pkg/core/proxy/dns.go
@@ -156,17 +156,11 @@ func (p *Proxy) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 			}
 			p.logger.Debug(fmt.Sprintf("Answers[when resolution failed for query:%v]:\n%v\n", question.Qtype, answers))
 
-			// Cache the answer only if we actually have answers to cache.
-			// This prevents caching empty slices (e.g., TXT intentionally empty)
-			// and allows future lookups to re-resolve upstream.
-			if len(answers) > 0 {
-				cache.Lock()
-				cache.m[key] = answers
-				cache.Unlock()
-				p.logger.Debug(fmt.Sprintf("Answers[after caching it]:\n%v\n", answers))
-			} else {
-				p.logger.Debug("Nothing to cache for this query (empty answers)")
-			}
+			// Cache the answer
+			cache.Lock()
+			cache.m[key] = answers
+			cache.Unlock()
+			p.logger.Debug(fmt.Sprintf("Answers[after caching it]:\n%v\n", answers))
 		}
 
 		p.logger.Debug(fmt.Sprintf("Answers[before appending to msg]:\n%v\n", answers))


### PR DESCRIPTION
## Describe the changes that are made
- Sending an empty response for the TXT record.
- This avoids the driver trying to parse an invalid TXT. (Here, Mongo driver failed to parse the keploy-proxy as TXT record.)

```
🐰 Keploy: 2025-11-11T09:22:40.793364881Z 	DEBUG	Got some Dns queries
🐰 Keploy: 2025-11-11T09:22:40.793372048Z 	DEBUG		{"Record Type": 16, "Received Query": "common-mongo.keploy-internal-stage.in."}
🐰 Keploy: 2025-11-11T09:22:40.793521131Z 	DEBUG	sending default TXT record response
🐰 Keploy: 2025-11-11T09:22:40.793577464Z 	DEBUG	Answers[when resolution failed for query:16]:
[common-mongo.keploy-internal-stage.in.	3600	IN	TXT	"keploy-proxy"]

🐰 Keploy: 2025-11-11T09:22:40.793636631Z 	DEBUG	Answers[after caching it]:
[common-mongo.keploy-internal-stage.in.	3600	IN	TXT	"keploy-proxy"]

🐰 Keploy: 2025-11-11T09:22:40.793696381Z 	DEBUG	Answers[before appending to msg]:
[common-mongo.keploy-internal-stage.in.	3600	IN	TXT	"keploy-proxy"]

🐰 Keploy: 2025-11-11T09:22:40.793728173Z 	DEBUG	Answers[After appending to msg]:
[common-mongo.keploy-internal-stage.in.	3600	IN	TXT	"keploy-proxy"]

🐰 Keploy: 2025-11-11T09:22:40.794557006Z 	DEBUG	dns msg sending back:
;; opcode: QUERY, status: NOERROR, id: 8765
;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;common-mongo.keploy-internal-stage.in.	IN	 TXT

;; ANSWER SECTION:
common-mongo.keploy-internal-stage.in.	3600	IN	TXT	"keploy-proxy"


🐰 Keploy: 2025-11-11T09:22:40.794566631Z 	DEBUG	dns msg RCODE sending back:
0

DEBUG	Writing dns info back to the client...
{"level":"info","ts":"2025-11-11T09:22:40.792Z","caller":"mongo/data.go:99","service.id":"c6db3c992c3c","service.name":"doubtservice","service.version":"","service.env":"stage","dd.trace_id":"","trace_id":"","span_id":"","request.id":"7bdf7529-15c3-45c3-af20-57e3c6dd1461","dd.span_id":"","session.id":"","user.id":"","msg":"Got the credentials. Setting the options"}
INFO msg=watcher's ctx cancel : context canceled
{"level":"info","ts":"2025-11-11T09:22:40.794Z","caller":"mongo/data.go:157","service.id":"c6db3c992c3c","service.name":"doubtservice","service.version":"","service.env":"stage","dd.trace_id":"","trace_id":"","span_id":"","request.id":"7490b76f-04c2-422d-8b71-b2d5a9e840bd","dd.span_id":"","session.id":"","user.id":"","msg":"Configuring connection pool with MinPoolSize: 5, MaxPoolSize: 20, MaxConnIdleTime: 30 seconds"}
{"level":"error","ts":"2025-11-11T09:22:40.794Z","caller":"mongo/data.go:121","service.id":"c6db3c992c3c","service.name":"doubtservice","service.version":"","service.env":"stage","dd.trace_id":"","trace_id":"","span_id":"","request.id":"ccc4003a-ede7-46d5-bb50-a0de5a5d4b78","dd.span_id":"","session.id":"","user.id":"","msg":"Error connecting to MongoDB: error parsing uri: Invalid TXT record"}
panic: error parsing uri: Invalid TXT record
```

## Links & References

**Closes:** #[issue number that will be closed through this PR]
- NA (if very small change like typo, linting, etc.)

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [ ] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

## Self Review done?
- [ ] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [ ] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [ ] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [ ] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?