### PR TITLE
Expire artifacts after 18h when tests fail

### DIFF
--- a/pkg/platform/yaml/mockdb/db.go
+++ b/pkg/platform/yaml/mockdb/db.go
@@ -9,9 +9,9 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"time"
-    "strings"
 
 	"go.keploy.io/server/v3/pkg"
 	"go.keploy.io/server/v3/pkg/models"
@@ -22,10 +22,10 @@ import (
 )
 
 type MockYaml struct {
-	MockPath  string
-	MockName  string
-	Logger    *zap.Logger
-	idCounter int64
+	MockPath       string
+	MockName       string
+	Logger         *zap.Logger
+	idCounter      int64
 	expiryDuration time.Duration
 }
 

--- a/pkg/platform/yaml/testdb/db.go
+++ b/pkg/platform/yaml/testdb/db.go
@@ -21,8 +21,8 @@ import (
 )
 
 type TestYaml struct {
-	TcsPath string
-	logger  *zap.Logger
+	TcsPath        string
+	logger         *zap.Logger
 	expiryDuration time.Duration
 }
 


### PR DESCRIPTION
Problem
In the current YAML backend implementation, TestYaml.DeleteTestSet and MockYaml.DeleteMocksForSet remove testset folders and mocks immediately when deletion is requested. That can cause accidental data loss—especially while tests are failing or during debugging when artifacts may still be needed.

Solution
This PR changes deletion behaviour to move artifacts to an "expired" area instead of deleting them immediately. A background cleanup goroutine removes expired artifacts after an 18-hour grace period. This preserves artifacts temporarily and makes deletion safer and consistent across the YAML backend.

Key changes
Introduced expiryDuration (set to 18 hours) to control TTL for expired items.

TestYaml.DeleteTestSet now moves a testset directory to an expired/ area and writes an expiry timestamp instead of deleting it immediately.

MockYaml.DeleteMocksForSet now moves mocks to mockpath/expired/ with an expiry timestamp rather than removing them synchronously.

Added periodic cleanup logic to remove expired directories after the TTL.

Files updated: pkg/platform/yaml/testdb/db.go, pkg/platform/yaml/mockdb/db.go.

Testing
Local verification: Deletion requests now move artifacts to expired locations; cleanup logic removes items after the TTL (shorter TTL used while testing).

Backward-compatible: If move fails, code falls back to deleting to avoid leaving duplicate/partial state.

Unit tests: Not yet added; can add tests for move/fallback and cleanup logic on request.

Related Issues
Mitigates accidental data loss in YAML storage; no specific issue is linked in this PR.


