### PR TITLE
chore: cherry-pick transfer-encoding fix to v2

### DIFF
--- a/pkg/core/proxy/integrations/http/chunk.go
+++ b/pkg/core/proxy/integrations/http/chunk.go
@@ -86,13 +86,11 @@ func (h *HTTP) HandleChunkedRequests(ctx context.Context, finalReq *[]byte, clie
 			}
 		}
 	} else if transferEncodingHeader != "" {
-		// check if the initial request is the complete request.
-		if strings.HasSuffix(string(*finalReq), "0\r\n\r\n") {
-			return nil
-		}
-		if transferEncodingHeader == "chunked" {
-			err := h.chunkedRequest(ctx, finalReq, clientConn, destConn, transferEncodingHeader)
-			if err != nil {
+		if strings.Contains(strings.ToLower(transferEncodingHeader), "chunked") {
+			if strings.HasSuffix(string(*finalReq), "0\r\n\r\n") {
+				return nil
+			}
+			if err := h.chunkedRequest(ctx, finalReq, clientConn, destConn, transferEncodingHeader); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
## Describe the changes that are made
The HTTP response decoder was checking for "Transfer-Encoding: chunked" using a case-sensitive substring match on the raw header block.

Some upstream services (e.g. the Java-based config service) emit "Transfer-encoding: chunked", which caused our code to skip the chunked-body handling path entirely and treat the response as if it had no proper body.

As a result, Keploy would:
- only capture the headers in the reconstructed response buffer
- log "failed to read the http response body: unexpected EOF" in Capture
- save testcases with empty or truncated response bodies for those endpoints

The fix normalizes header names before checking for transfer-encoding, so both "Transfer-Encoding" and "Transfer-encoding" (and any other case variants) correctly trigger chunked-response handling.

## Links & References

**Closes:** #3302 
- NA (if very small change like typo, linting, etc.)

### 🔗 Related PRs
- #3303 
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [ ] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

## Self Review done?
- [ ] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [ ] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [ ] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [ ] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?