### PR TITLE
fix: mysql prepare statement id mapping during test mode

### DIFF
--- a/pkg/agent/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match.go
@@ -23,8 +23,9 @@ var querySigCache sync.Map // map[string]string
 
 // recorded PREP registry per recorded connection
 type prepEntry struct { // minimal, enough for lookup
-	StatementID uint32
-	Query       string
+	statementID uint32
+	query       string
+	mockName    string // for debugging purpose
 }
 
 // case-insensitive prefix check without allocation
@@ -184,14 +185,42 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 		return nil, false, fmt.Errorf("no mysql mocks found")
 	}
 
+	// remove this block
+	// get all the mock names that has type com-exec
+	stmtMocks := []string{}
+	for _, mock := range unfiltered {
+		if mock.Kind != models.MySQL {
+			continue
+		}
+		if mock.Spec.Metadata["type"] == "config" {
+			continue // command-phase only wants data mocks
+		}
+		for _, mockReq := range mock.Spec.MySQLRequests {
+			if mockReq.PacketBundle.Header.Type == sCOM_STMT_EXEC {
+				stmtMocks = append(stmtMocks, mock.Name)
+			}
+		}
+	}
+
 	// Build recordedPrepByConn once (map[connID][]prepEntry) from recorded mocks
 	recordedPrepByConn := buildRecordedPrepIndex(unfiltered)
+
+	if req.Header.Type == sCOM_STMT_PREP || req.Header.Type == sCOM_STMT_EXEC {
+		var allEntries []string
+		for connID, prepEntries := range recordedPrepByConn {
+			for _, entry := range prepEntries {
+				allEntries = append(allEntries, fmt.Sprintf("connID=%s stmtID=%d query=%q mock=%s", connID, entry.statementID, entry.query, entry.mockName))
+			}
+		}
+		logger.Debug("recorded prepEntries", zap.String("entries", strings.Join(allEntries, " | ")))
+	}
 
 	var (
 		maxMatchedCount int
 		matchedResp     *mysql.Response
 		matchedMock     *models.Mock
 		queryMatched    bool
+		stmtMatched     bool
 	)
 
 	// Single pass: filter & match on the fly.
@@ -239,8 +268,20 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 
 			case sCOM_STMT_EXEC:
 				// query-aware EXEC matching via recordedPrepByConn + runtime map
-				expMsg, _ := mockReq.PacketBundle.Message.(*mysql.StmtExecutePacket)
-				actMsg, _ := req.PacketBundle.Message.(*mysql.StmtExecutePacket)
+				expMsg, eOk := mockReq.PacketBundle.Message.(*mysql.StmtExecutePacket)
+				actMsg, aOk := req.PacketBundle.Message.(*mysql.StmtExecutePacket)
+
+				if !eOk || !aOk {
+					//  Either mock or actual request is not of type StmtExecutePacket
+					continue
+				}
+
+				logger.Debug("List of com-stmt-execute mocks to match", zap.Strings("mocks", stmtMocks))
+
+				// remove this log and if block
+				if actMsg != nil {
+					logger.Debug("Trying to match the mock with com-stmt-execute request", zap.String("mock_name", mock.Name), zap.Any("Req", actMsg))
+				}
 
 				var expectedQuery, actualQuery string
 				if expMsg != nil {
@@ -250,7 +291,13 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 					actualQuery = strings.TrimSpace(decodeCtx.StmtIDToQuery[actMsg.StatementID])
 				}
 
-				if c := matchStmtExecutePacketQueryAware(mockReq.PacketBundle, req.PacketBundle, expectedQuery, actualQuery); c > maxMatchedCount {
+				logger.Debug("queries comparison", zap.String("expected_query", expectedQuery), zap.String("actual_query", actualQuery), zap.Uint32("mock_statement_id", expMsg.StatementID), zap.Uint32("actual_statment_id", actMsg.StatementID), zap.Any("connID", mock.Spec.Metadata["connID"]), zap.String("mock_name", mock.Name))
+
+				if ok, c := matchStmtExecutePacketQueryAware(logger, mockReq.PacketBundle, req.PacketBundle, expectedQuery, actualQuery, mock.Name); ok {
+					// Query-aware definitive match (exact or structural): pick and stop searching
+					matchedResp, matchedMock, stmtMatched = &mock.Spec.MySQLResponses[0], mock, true
+				} else if c > maxMatchedCount {
+					// fallback score-based candidate (used when no stmt info was available)
 					maxMatchedCount, matchedResp, matchedMock = c, &mock.Spec.MySQLResponses[0], mock
 				}
 
@@ -276,7 +323,7 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 				}
 			}
 		}
-		if queryMatched {
+		if queryMatched || stmtMatched {
 			break
 		}
 	}
@@ -333,29 +380,56 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 		return nil, false, nil
 	}
 
-	// Persist prepared-statement metadata
-	if req.Header.Type == sCOM_STMT_PREP {
-		if prepareOkResp, ok := matchedResp.Message.(*mysql.StmtPrepareOkPacket); ok && prepareOkResp != nil {
-			decodeCtx.PreparedStatements[prepareOkResp.StatementID] = prepareOkResp
-			// also maintain a runtime stmtID -> query map so EXEC/CLOSE can be matched by query.
-			if decodeCtx.StmtIDToQuery == nil {
-				decodeCtx.StmtIDToQuery = make(map[uint32]string)
-			}
-			if sp, ok := req.Message.(*mysql.StmtPreparePacket); ok && sp != nil {
-				decodeCtx.StmtIDToQuery[prepareOkResp.StatementID] = sp.Query
-				logger.Debug("Recorded runtime PREP mapping",
-					zap.Uint32("stmt_id", prepareOkResp.StatementID),
-					zap.String("query", strings.TrimSpace(sp.Query)))
-			}
-		}
-	}
-
+	// Update the mock in the database BEFORE modifying the response
+	// This ensures we update using the original mock state
 	if okk := updateMock(ctx, logger, matchedMock, mockDb); !okk {
 		logger.Debug("failed to update the matched mock")
 		// Re-fetch once to avoid spin
 		return nil, false, fmt.Errorf("failed to update matched mock")
 	}
-	return matchedResp, true, nil
+
+	// Create a copy of the response to avoid modifying the original mock
+	responseCopy := &mysql.Response{
+		PacketBundle: matchedResp.PacketBundle,
+		Payload:      matchedResp.Payload,
+	}
+
+	// Persist prepared-statement metadata
+	if req.Header.Type == sCOM_STMT_PREP {
+		if prepareOkResp, ok := responseCopy.Message.(*mysql.StmtPrepareOkPacket); ok && prepareOkResp != nil {
+			// Store original statement ID for logging
+			originalStmtID := prepareOkResp.StatementID
+
+			// Generate a new unique statement ID for this connection.
+			// During record mode, different connections can produce identical statement IDs
+			// for the same or different queries. However, during test mode, if both queries
+			// execute on the same connection and we reuse those IDs, they would collide.
+			// A single connection cannot have two different queries with the same statement ID.
+			// To avoid this, we assign a new incremental and unique statement ID for each query.
+
+			newStmtID := decodeCtx.NextStmtID
+			decodeCtx.NextStmtID++
+
+			// Create a copy of the StmtPrepareOkPacket and update the statement ID
+			prepareOkRespCopy := *prepareOkResp
+			prepareOkRespCopy.StatementID = newStmtID
+			responseCopy.Message = &prepareOkRespCopy
+
+			if sp, ok := req.Message.(*mysql.StmtPreparePacket); ok && sp != nil {
+				// Store in the prepared statements map so that it can be used during EXEC/CLOSE
+				decodeCtx.PreparedStatements[prepareOkRespCopy.StatementID] = &prepareOkRespCopy
+				// maintain a runtime stmtID -> query map so EXEC/CLOSE can be matched by query.
+				decodeCtx.StmtIDToQuery[prepareOkRespCopy.StatementID] = sp.Query
+				logger.Debug("Recorded runtime PREP mapping with new statement ID",
+					zap.Uint32("original_stmt_id from mock ", originalStmtID),
+					zap.Uint32("new_stmt_id", prepareOkRespCopy.StatementID),
+					zap.String("query", strings.TrimSpace(sp.Query)))
+			}
+		}
+	}
+
+	logger.Debug("matched command with the mock", zap.Any("mock", matchedMock.Name))
+	return responseCopy, true, nil
 }
 
 // func matchClosePacket(_ context.Context, _ *zap.Logger, expected, actual mysql.PacketBundle) int {
@@ -497,15 +571,15 @@ func matchPreparePacket(ctx context.Context, log *zap.Logger, expected, actual m
 // query-aware EXEC scoring.
 //   - Keep the existing header/flags/params scoring.
 //   - Do NOT reward raw StatementID equality.
-//   - Reward query equality (or structural equality) resolved via:
-//     recorded (expected) -> recordedPrepByConn[connID] -> query
-//     runtime  (actual)   -> decodeCtx.StmtIDToQuery(stmtID) set during COM_STMT_PREP
-func matchStmtExecutePacketQueryAware(expected, actual mysql.PacketBundle, expectedQuery, actualQuery string) int {
+//   - If both expectedQuery and actualQuery are present, require them to match (exact or structural).
+//     If they don't match, return (false, 0) immediately.
+//   - If either query is missing, fall back to best-effort scoring (returns (false, score)).
+func matchStmtExecutePacketQueryAware(logger *zap.Logger, expected, actual mysql.PacketBundle, expectedQuery, actualQuery string, mockName string) (bool, int) {
 	matchCount := 0
 
 	// Match the type and return zero if the types are not equal
 	if expected.Header.Type != actual.Header.Type {
-		return 0
+		return false, 0
 	}
 	// Match the header
 	if matchHeader(*expected.Header.Header, *actual.Header.Header) {
@@ -518,6 +592,7 @@ func matchStmtExecutePacketQueryAware(expected, actual mysql.PacketBundle, expec
 	if expectedMessage.Status == actualMessage.Status {
 		matchCount++
 	}
+
 	// DO NOT score StatementID equality (unstable across runs)
 	// if expectedMessage.StatementID == actualMessage.StatementID { matchCount++ }
 
@@ -540,33 +615,60 @@ func matchStmtExecutePacketQueryAware(expected, actual mysql.PacketBundle, expec
 	}
 
 	// Match the parameters
+	var totalMatchedParams int
+	var allParamsMatched bool
 	if len(expectedMessage.Parameters) == len(actualMessage.Parameters) {
 		for i := range expectedMessage.Parameters {
 			ep := expectedMessage.Parameters[i]
 			ap := actualMessage.Parameters[i]
-			if ep.Type == ap.Type &&
-				ep.Name == ap.Name &&
-				ep.Unsigned == ap.Unsigned &&
-				paramValueEqual(ep.Value, ap.Value) {
-				matchCount++
+
+			typeEqual := ep.Type == ap.Type
+			nameEqual := ep.Name == ap.Name
+			unsignedEqual := ep.Unsigned == ap.Unsigned
+			valueEqual := false
+			if unsignedEqual { // initial check to avoid comparing signed vs unsigned values
+				valueEqual = paramValueEqual(ep.Value, ap.Value)
 			}
+			if typeEqual && nameEqual && unsignedEqual && valueEqual {
+				matchCount++
+				totalMatchedParams++
+			}
+		}
+
+		// All parameters matched
+		if len(expectedMessage.Parameters) == totalMatchedParams {
+			allParamsMatched = true
+			logger.Debug("all parameters matched", zap.String("mock-name", mockName))
 		}
 	}
 
-	// Query bonus
+	// Query logic:
+	queryMatched := false
 	eq := strings.TrimSpace(expectedQuery)
 	aq := strings.TrimSpace(actualQuery)
+
+	// If both queries are present, require them to match (exact or structural) for a definitive match.
 	if eq != "" && aq != "" {
+		// If both queries are available, require an exact or structural match to treat this as a definitive match.
 		if strings.EqualFold(eq, aq) {
 			matchCount += 10
+			queryMatched = true
+			logger.Debug("query matched exactly", zap.String("related stmt-exec mock-name", mockName))
 		} else if sigE, errE := getQueryStructureCached(eq); errE == nil {
 			if sigA, errA := getQueryStructureCached(aq); errA == nil && sigE == sigA {
 				matchCount += 6
+				queryMatched = true
+				logger.Debug("query structure matched", zap.String("related stmt-exec mock-name", mockName))
 			}
 		}
 	}
 
-	return matchCount
+	if !queryMatched || !allParamsMatched {
+		return false, matchCount
+	}
+
+	// Both queryMatched and allParamsMatched must be true for a definitive match. Otherwise, return the best-effort score.
+	return (queryMatched && allParamsMatched), matchCount
 }
 
 func paramValueEqual(a, b interface{}) bool {
@@ -578,30 +680,100 @@ func paramValueEqual(a, b interface{}) bool {
 		bv, ok := b.(string)
 		return ok && av == bv
 	case int:
-		bv, ok := b.(int)
-		return ok && av == bv
+		switch bv := b.(type) {
+		case int:
+			return av == bv
+		case int64:
+			return int64(av) == bv
+		case int32:
+			return av == int(bv)
+		case float32:
+			return float32(av) == bv
+		case float64:
+			return float64(av) == bv
+		}
 	case int32:
-		bv, ok := b.(int32)
-		return ok && av == bv
+		switch bv := b.(type) {
+		case int32:
+			return av == bv
+		case int:
+			return int(av) == bv
+		case int64:
+			return int64(av) == bv
+		case float32:
+			return float32(av) == bv
+		case float64:
+			return float64(av) == bv
+		}
 	case int64:
 		switch bv := b.(type) {
 		case int64:
 			return av == bv
 		case int:
 			return av == int64(bv)
+		case int32:
+			return av == int64(bv)
+		case float32:
+			return float32(av) == bv
+		case float64:
+			return float64(av) == bv
 		}
 	case uint32:
-		bv, ok := b.(uint32)
-		return ok && av == bv
+		switch bv := b.(type) {
+		case uint32:
+			return av == bv
+		case uint64:
+			return uint64(av) == bv
+		case float32:
+			return float32(av) == bv
+		case float64:
+			return float64(av) == bv
+		}
 	case uint64:
-		bv, ok := b.(uint64)
-		return ok && av == bv
+		switch bv := b.(type) {
+		case uint64:
+			return av == bv
+		case uint32:
+			return av == uint64(bv)
+		case float32:
+			return float32(av) == bv
+		case float64:
+			return float64(av) == bv
+		}
 	case float32:
-		bv, ok := b.(float32)
-		return ok && av == bv
+		switch bv := b.(type) {
+		case float32:
+			return av == bv
+		case float64:
+			return float64(av) == bv
+		case int:
+			return av == float32(bv)
+		case int32:
+			return av == float32(bv)
+		case int64:
+			return av == float32(bv)
+		case uint32:
+			return av == float32(bv)
+		case uint64:
+			return av == float32(bv)
+		}
 	case float64:
-		bv, ok := b.(float64)
-		return ok && av == bv
+		switch bv := b.(type) {
+		case float64:
+			return av == bv
+		case float32:
+			return av == float64(bv)
+		case int:
+			return av == float64(bv)
+		case int32:
+			return av == float64(bv)
+		case int64:
+			return av == float64(bv)
+		case uint32:
+			return av == float64(bv)
+		case uint64:
+			return av == float64(bv)
+		}
 	case bool:
 		bv, ok := b.(bool)
 		return ok && av == bv
@@ -797,6 +969,7 @@ func pluginEqualCompat(exp, act string) bool {
 // Build recorded PREP index per connection from recorded mocks.
 // We map each connID to the list of (stmtID,query) pairs found by pairing
 // StmtPrepareOkPacket(stmtID) with the nearest COM_STMT_PREPARE query.
+// Assumes each mock has exactly one MySQLRequest and one MySQLResponse.
 func buildRecordedPrepIndex(unfiltered []*models.Mock) map[string][]prepEntry {
 	out := make(map[string][]prepEntry)
 	for _, m := range unfiltered {
@@ -808,46 +981,68 @@ func buildRecordedPrepIndex(unfiltered []*models.Mock) map[string][]prepEntry {
 		}
 		connID := m.Spec.Metadata["connID"]
 
-		// collect all prepare OK stmtIDs in this mock
-		stmtIDs := make(map[uint32]struct{})
-		for _, r := range m.Spec.MySQLResponses {
-			if spok, ok := r.Message.(*mysql.StmtPrepareOkPacket); ok && spok != nil {
-				stmtIDs[spok.StatementID] = struct{}{}
-			}
-		}
-		if len(stmtIDs) == 0 {
+		// Check if we have at least one response
+		if len(m.Spec.MySQLResponses) == 0 {
 			continue
 		}
 
-		// try to find a (nearest) PREP query; fall back to the last PREP in the mock
-		// this is heuristic but robust across our recording layout
-		var lastPrepQuery string
-		for i := len(m.Spec.MySQLRequests) - 1; i >= 0; i-- {
-			if sp, ok := m.Spec.MySQLRequests[i].Message.(*mysql.StmtPreparePacket); ok && sp != nil {
-				lastPrepQuery = strings.TrimSpace(sp.Query)
-				break
-			}
+		// Get the statement ID from the first response (if it's a StmtPrepareOkPacket)
+		spok, ok := m.Spec.MySQLResponses[0].Message.(*mysql.StmtPrepareOkPacket)
+		if !ok || spok == nil {
+			continue
 		}
-		if lastPrepQuery == "" {
+		stmtID := spok.StatementID
+
+		// Check if we have at least one request
+		if len(m.Spec.MySQLRequests) == 0 {
 			continue
 		}
 
-		for stmtID := range stmtIDs {
-			out[connID] = append(out[connID], prepEntry{
-				StatementID: stmtID,
-				Query:       lastPrepQuery,
-			})
+		// Get the query from the first request (if it's a StmtPreparePacket)
+		sp, ok := m.Spec.MySQLRequests[0].Message.(*mysql.StmtPreparePacket)
+		if !ok || sp == nil {
+			continue
 		}
+		prepQuery := strings.TrimSpace(sp.Query)
+		if prepQuery == "" {
+			continue
+		}
+
+		out[connID] = append(out[connID], prepEntry{
+			statementID: stmtID,
+			query:       prepQuery,
+			mockName:    m.Name,
+		})
 	}
 	return out
 }
+
+// Caveat: There can be a condition where for the same connId, for the same query there can be different statementIds,
+// this can happen either when client closes the prepared statement and creates a new one for the same query
+// or if the client prepares the same query multiple times without closing it.
+
+//TODO: Conditions to handle
+
+// 1. On connection conn-1
+// -> preparedStatement with query-1 comes and returns statement-id=1
+// -> closeStmt for stmt-id=1
+// -> preparedStatement with query-1 comes and returns statement-id=2
+// -> closeStmt for stmt-id=2
+// -> preparedStatement with query-1 comes and returns statement-id=3
+// -> stmtExecute on stmt-id=3
+
+// 2. On connection conn-1
+// -> preparedStatement with query-1 comes and returns statement-id=1
+// -> preparedStatement with query-1 comes and returns statement-id=2
+// -> preparedStatement with query-1 comes and returns statement-id=3
+// -> Client will usually use stmt-id-3 but not necessary.
 
 // lookup helper on recordedPrepByConn
 func lookupRecordedQuery(index map[string][]prepEntry, connID string, stmtID uint32) string {
 	list := index[connID]
 	for _, e := range list {
-		if e.StatementID == stmtID {
-			return e.Query
+		if e.statementID == stmtID {
+			return e.query
 		}
 	}
 	return ""

--- a/pkg/agent/proxy/integrations/mysql/replayer/query.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/query.go
@@ -83,6 +83,7 @@ func simulateCommandPhase(ctx context.Context, logger *zap.Logger, clientConn ne
 			commandPkt, err := wire.DecodePayload(ctx, logger, command, clientConn, decodeCtx)
 			if err != nil {
 				utils.LogError(logger, err, "failed to decode the MySQL packet from the client")
+				return err
 			}
 
 			req := mysql.Request{

--- a/pkg/agent/proxy/integrations/mysql/replayer/replay.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/replay.go
@@ -75,6 +75,8 @@ func Replay(ctx context.Context, logger *zap.Logger, clientConn net.Conn, _ *mod
 			PreparedStatements: make(map[uint32]*mysql.StmtPrepareOkPacket),
 			PluginName:         string(mysql.CachingSha2), // usually a default plugin in newer versions of MySQL
 			PreferRecordedCaps: true,
+			StmtIDToQuery:      make(map[uint32]string),
+			NextStmtID:         1,
 		}
 		decodeCtx.LastOp.Store(clientConn, wire.RESET) //resetting last command for new loop
 

--- a/pkg/agent/proxy/integrations/mysql/utils/util.go
+++ b/pkg/agent/proxy/integrations/mysql/utils/util.go
@@ -334,7 +334,7 @@ func ParseBinaryDateTime(b []byte) (interface{}, int, error) {
 		return nil, 0, fmt.Errorf("invalid DATETIME length %d (expected 0|4|7|11) - likely misaligned buffer", l)
 	}
 	if len(b) < 1+l {
-		return nil, 0, io.ErrUnexpectedEOF
+		return nil, 0, fmt.Errorf("unexpected end of buffer while reading DATETIME value , len(b)=%d, expected at least %d", len(b), 1+l)
 	}
 
 	p := b[1:] // start of payload after length

--- a/pkg/agent/proxy/integrations/mysql/wire/phase/query/preparedstmt/stmtExecutePacket.go
+++ b/pkg/agent/proxy/integrations/mysql/wire/phase/query/preparedstmt/stmtExecutePacket.go
@@ -15,25 +15,28 @@ import (
 
 // COM_STMT_EXECUTE: https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_stmt_execute.html
 
-func DecodeStmtExecute(_ context.Context, _ *zap.Logger, data []byte, preparedStmts map[uint32]*mysql.StmtPrepareOkPacket, clientCapabilities uint32) (*mysql.StmtExecutePacket, error) {
+func DecodeStmtExecute(_ context.Context, logger *zap.Logger, data []byte, preparedStmts map[uint32]*mysql.StmtPrepareOkPacket, clientCapabilities uint32) (*mysql.StmtExecutePacket, error) {
 	if len(data) < 10 {
 		return &mysql.StmtExecutePacket{}, fmt.Errorf("packet length too short for COM_STMT_EXECUTE")
 	}
 
 	pos := 0
-
 	packet := &mysql.StmtExecutePacket{}
+
+	logger.Debug("Decoding COM_STMT_EXECUTE packet", zap.Int("packet_length", len(data)), zap.Uint32("client_capabilities", clientCapabilities))
 
 	// Read Status
 	if pos+1 > len(data) {
+		logger.Error("unexpected end of data while reading status", zap.Int("position", pos), zap.Int("data_length", len(data)))
 		return nil, io.ErrUnexpectedEOF
 	}
-	//data[0] is COM_STMT_EXECUTE (0x17)
+	// data[0] is COM_STMT_EXECUTE (0x17)
 	packet.Status = data[pos]
 	pos++
 
 	// Read StatementID
 	if pos+4 > len(data) {
+		logger.Error("unexpected end of data while reading statement ID", zap.Int("position", pos), zap.Int("data_length", len(data)))
 		return nil, io.ErrUnexpectedEOF
 	}
 	packet.StatementID = binary.LittleEndian.Uint32(data[pos : pos+4])
@@ -44,8 +47,11 @@ func DecodeStmtExecute(_ context.Context, _ *zap.Logger, data []byte, preparedSt
 		return nil, fmt.Errorf("prepared statement with ID %d not found", packet.StatementID)
 	}
 
+	logger.Debug("The stmtPrepOk packet", zap.Any("statement_id", packet.StatementID), zap.Any("stmtPrepOk", stmtPrepOk))
+
 	// Read Flags
 	if pos+1 > len(data) {
+		logger.Error("unexpected end of data while reading flags", zap.Int("position", pos), zap.Int("data_length", len(data)))
 		return nil, io.ErrUnexpectedEOF
 	}
 	packet.Flags = data[pos]
@@ -53,6 +59,7 @@ func DecodeStmtExecute(_ context.Context, _ *zap.Logger, data []byte, preparedSt
 
 	// Read IterationCount
 	if pos+4 > len(data) {
+		logger.Error("unexpected end of data while reading iteration count", zap.Int("position", pos), zap.Int("data_length", len(data)))
 		return nil, io.ErrUnexpectedEOF
 	}
 	packet.IterationCount = binary.LittleEndian.Uint32(data[pos : pos+4])
@@ -77,6 +84,7 @@ func DecodeStmtExecute(_ context.Context, _ *zap.Logger, data []byte, preparedSt
 		// Read NULL bitmap
 		nullBitmapLength := (packet.ParameterCount + 7) / 8
 		if pos+nullBitmapLength > len(data) {
+			logger.Error("unexpected end of data while reading NULL bitmap", zap.Int("position", pos), zap.Int("data_length", len(data)), zap.Int("null_bitmap_length", nullBitmapLength))
 			return nil, io.ErrUnexpectedEOF
 		}
 		packet.NullBitmap = data[pos : pos+nullBitmapLength]
@@ -84,6 +92,7 @@ func DecodeStmtExecute(_ context.Context, _ *zap.Logger, data []byte, preparedSt
 
 		// Read NewParamsBindFlag
 		if pos+1 > len(data) {
+			logger.Error("unexpected end of data while reading NewParamsBindFlag", zap.Int("position", pos), zap.Int("data_length", len(data)))
 			return nil, io.ErrUnexpectedEOF
 		}
 		packet.NewParamsBindFlag = data[pos]
@@ -96,6 +105,7 @@ func DecodeStmtExecute(_ context.Context, _ *zap.Logger, data []byte, preparedSt
 		if packet.NewParamsBindFlag == 1 {
 			for i := 0; i < packet.ParameterCount; i++ {
 				if pos+2 > len(data) {
+					logger.Error("unexpected end of data while reading parameter type", zap.Int("position", pos), zap.Int("data_length", len(data)), zap.Int("parameter_index", i))
 					return nil, io.ErrUnexpectedEOF
 				}
 				packet.Parameters[i].Type = binary.LittleEndian.Uint16(data[pos : pos+2])
@@ -123,6 +133,7 @@ func DecodeStmtExecute(_ context.Context, _ *zap.Logger, data []byte, preparedSt
 			}
 
 			if pos >= len(data) {
+				logger.Error("unexpected end of data while reading parameter value", zap.Int("position", pos), zap.Int("data_length", len(data)), zap.Int("parameter_index", i))
 				return nil, io.ErrUnexpectedEOF
 			}
 
@@ -136,6 +147,7 @@ func DecodeStmtExecute(_ context.Context, _ *zap.Logger, data []byte, preparedSt
 				length, _, n := utils.ReadLengthEncodedInteger(data[pos:])
 				pos += n
 				if pos+int(length) > len(data) {
+					logger.Error("unexpected end of data while reading length-encoded parameter value", zap.Int("position", pos), zap.Int("data_length", len(data)), zap.Int("parameter_index", i), zap.Uint64("length", length))
 					return nil, io.ErrUnexpectedEOF
 				}
 

--- a/pkg/agent/proxy/integrations/mysql/wire/util.go
+++ b/pkg/agent/proxy/integrations/mysql/wire/util.go
@@ -28,6 +28,8 @@ type DecodeContext struct {
 
 	//runtime stmt-id → query mapping set when COM_STMT_PREP matches
 	StmtIDToQuery map[uint32]string
+	// Statement ID counter for generating unique statement IDs during replay
+	NextStmtID uint32
 }
 
 const CLIENT_DEPRECATE_EOF = 0x01000000

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1136,10 +1136,11 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			}
 		}
 
+		// log the consumed mocks during the test run of the test case for test set
+		r.logger.Debug("Consumed Mocks", zap.Any("mocks", consumedMocks))
+
 		if !testPass {
-			// log the consumed mocks during the test run of the test case for test set
 			r.logger.Info("result", zap.String("testcase id", models.HighlightFailingString(testCase.Name)), zap.String("testset id", models.HighlightFailingString(testSetID)), zap.String("passed", models.HighlightFailingString(testPass)))
-			r.logger.Debug("Consumed Mocks", zap.Any("mocks", consumedMocks))
 		} else {
 			r.logger.Info("result", zap.String("testcase id", models.HighlightPassingString(testCase.Name)), zap.String("testset id", models.HighlightPassingString(testSetID)), zap.String("passed", models.HighlightPassingString(testPass)))
 		}


### PR DESCRIPTION
Closes: #3306 

This pull request introduces significant improvements to the MySQL replay matching logic, especially around prepared statement handling, query-aware matching, and robustness in type comparisons. The changes enhance both accuracy and maintainability of the replay system, with better logging and safer state management.

### Prepared Statement and Query Matching Improvements

* The matching logic for `COM_STMT_EXEC` packets now requires both the query and all parameters to match for a definitive match, rather than relying on potentially unstable statement ID equality. This makes replay matching more robust across runs and connections. [[1]](diffhunk://#diff-a7cb47d9a83f70361dbf385db2e19d95376817a94b9cd7b87280ca322353a7a9R618-R671) [[2]](diffhunk://#diff-a7cb47d9a83f70361dbf385db2e19d95376817a94b9cd7b87280ca322353a7a9L253-R300)
* Unique statement IDs are now assigned per connection during replay, preventing collisions when the same query is prepared multiple times or after closing and reopening statements. The mapping of statement IDs to queries is maintained and logged for transparency. [[1]](diffhunk://#diff-a7cb47d9a83f70361dbf385db2e19d95376817a94b9cd7b87280ca322353a7a9R383-R432) [[2]](diffhunk://#diff-678766d7cec08eb0a5bebbc3e82b79028ef30ab6c081ba07da2c305e97203bd7R78-R79)
* The `prepEntry` struct and related indexing logic have been refactored to be more minimal and reliable, making it easier to look up queries by statement ID and connection. [[1]](diffhunk://#diff-a7cb47d9a83f70361dbf385db2e19d95376817a94b9cd7b87280ca322353a7a9L26-R28) [[2]](diffhunk://#diff-a7cb47d9a83f70361dbf385db2e19d95376817a94b9cd7b87280ca322353a7a9R972) [[3]](diffhunk://#diff-a7cb47d9a83f70361dbf385db2e19d95376817a94b9cd7b87280ca322353a7a9L811-R1045)

### Logging and Debugging Enhancements

* More detailed debug logs have been added throughout the matching process, including logs for packet decoding, query and parameter matching, and statement ID assignment. This will help with diagnosing replay issues and understanding matching decisions. [[1]](diffhunk://#diff-a7cb47d9a83f70361dbf385db2e19d95376817a94b9cd7b87280ca322353a7a9R188-R223) [[2]](diffhunk://#diff-a7cb47d9a83f70361dbf385db2e19d95376817a94b9cd7b87280ca322353a7a9L242-R284) [[3]](diffhunk://#diff-a7cb47d9a83f70361dbf385db2e19d95376817a94b9cd7b87280ca322353a7a9L253-R300) [[4]](diffhunk://#diff-9f1b9ae529cbc211bce59eeb44986e702363e02fb20fbfc9a38d835cd53bf90fL18-R30) [[5]](diffhunk://#diff-9f1b9ae529cbc211bce59eeb44986e702363e02fb20fbfc9a38d835cd53bf90fR39)

### Type and Value Comparison Robustness

* The parameter value comparison logic now supports cross-type comparisons (e.g., int vs int64, float32 vs float64), making matching more tolerant of type differences between recorded and replayed packets.

### Error Handling Improvements

* Error messages for packet decoding and utility functions have been improved to provide more context, making it easier to debug unexpected buffer or data issues. [[1]](diffhunk://#diff-b9fbdbe127479fae52d42c8999e286c1ed3b23df3895ab831bb9f62968760bddL337-R337) [[2]](diffhunk://#diff-9f1b9ae529cbc211bce59eeb44986e702363e02fb20fbfc9a38d835cd53bf90fL18-R30) [[3]](diffhunk://#diff-9f1b9ae529cbc211bce59eeb44986e702363e02fb20fbfc9a38d835cd53bf90fR39) [[4]](diffhunk://#diff-ecb5dc8f41ccb602b8c73dccafd264d7585d8a430e29feabe05a97f8a424860cR86)

### Replay State Management

* The replay context now initializes all necessary state for prepared statement tracking, ensuring that statement ID and query mapping works correctly from the start of each replay session.

These changes collectively make the replay system more accurate, maintainable, and easier to debug.