### PR TITLE
chore: ignore content-length and message length mismatches when body content is identical

### DIFF
--- a/pkg/matcher/http/match.go
+++ b/pkg/matcher/http/match.go
@@ -107,10 +107,34 @@ func Match(tc *models.TestCase, actualResponse *models.HTTPResp, noiseConfig map
 	res.BodyResult[0].Normal = pass
 
 	if !matcherUtils.CompareHeaders(pkg.ToHTTPHeader(tc.HTTPResp.Header), pkg.ToHTTPHeader(actualResponse.Header), hRes, headerNoise) {
-		pass = false
-	}
+		res.HeadersResult = *hRes
 
-	res.HeadersResult = *hRes
+		// If body matches but content-length differs, ignore the content-length difference
+		if res.BodyResult[0].Normal {
+			for i := range res.HeadersResult {
+				if strings.ToLower(res.HeadersResult[i].Expected.Key) == "content-length" && !res.HeadersResult[i].Normal {
+					logger.Warn("Ignoring Content-Length mismatch since body content is identical",
+						zap.String("expected", strings.Join(res.HeadersResult[i].Expected.Value, ",")),
+						zap.String("actual", strings.Join(res.HeadersResult[i].Actual.Value, ",")))
+					res.HeadersResult[i].Normal = true
+				}
+			}
+		}
+
+		// Check if there are still any header mismatches after ignoring content-length
+		hasHeaderMismatch := false
+		for _, hr := range res.HeadersResult {
+			if !hr.Normal {
+				hasHeaderMismatch = true
+				break
+			}
+		}
+		if hasHeaderMismatch {
+			pass = false
+		}
+	} else {
+		res.HeadersResult = *hRes
+	}
 	if tc.HTTPResp.StatusCode == actualResponse.StatusCode {
 		res.StatusCode.Normal = true
 	} else {


### PR DESCRIPTION
This pull request introduces improvements to how message length and content-length mismatches are handled in gRPC and HTTP response matching logic. The main change is that if the actual and expected message bodies are identical, differences in message length (for gRPC) or content-length (for HTTP) are ignored, reducing false negatives in test case matching.

**gRPC response matching:**

* If the decoded message bodies are identical but the message length differs, the length mismatch is ignored and the result is updated to reflect a successful match for message length. The corresponding difference is also removed from the differences map.

**HTTP response matching:**

* If the body matches but the `Content-Length` header differs, the content-length mismatch is ignored and marked as normal in the header result. Header mismatches are only considered if other headers still differ after this adjustment.