### PR TITLE
chore: ignore content-length and message length mismatches when body content is identical

### DIFF
--- a/pkg/matcher/http/match.go
+++ b/pkg/matcher/http/match.go
@@ -107,10 +107,34 @@ func Match(tc *models.TestCase, actualResponse *models.HTTPResp, noiseConfig map
 	res.BodyResult[0].Normal = pass
 
 	if !matcherUtils.CompareHeaders(pkg.ToHTTPHeader(tc.HTTPResp.Header), pkg.ToHTTPHeader(actualResponse.Header), hRes, headerNoise) {
-		pass = false
-	}
+		res.HeadersResult = *hRes
 
-	res.HeadersResult = *hRes
+		// If body matches but content-length differs, ignore the content-length difference
+		if res.BodyResult[0].Normal {
+			for i := range res.HeadersResult {
+				if strings.ToLower(res.HeadersResult[i].Expected.Key) == "content-length" && !res.HeadersResult[i].Normal {
+					logger.Warn("Ignoring Content-Length mismatch since body content is identical",
+						zap.String("expected", strings.Join(res.HeadersResult[i].Expected.Value, ",")),
+						zap.String("actual", strings.Join(res.HeadersResult[i].Actual.Value, ",")))
+					res.HeadersResult[i].Normal = true
+				}
+			}
+		}
+
+		// Check if there are still any header mismatches after ignoring content-length
+		hasHeaderMismatch := false
+		for _, hr := range res.HeadersResult {
+			if !hr.Normal {
+				hasHeaderMismatch = true
+				break
+			}
+		}
+		if hasHeaderMismatch {
+			pass = false
+		}
+	} else {
+		res.HeadersResult = *hRes
+	}
 	if tc.HTTPResp.StatusCode == actualResponse.StatusCode {
 		res.StatusCode.Normal = true
 	} else {


### PR DESCRIPTION
This pull request introduces improvements to the matching logic for both gRPC and HTTP responses, specifically handling cases where the message or content length differs but the actual content matches. These changes help reduce false negatives during response validation by ignoring length mismatches when the decoded data or body content is identical.

Improvements to response matching logic:

* gRPC matching: If the decoded data matches but the message length differs, the message length mismatch is ignored, and the result is updated to reflect a successful match for message length. This also removes the length difference from the differences map.
* HTTP matching: If the body matches but the `Content-Length` header differs, the mismatch for `Content-Length` is ignored and marked as normal. The code then checks for any remaining header mismatches to determine the final match result.