### PR TITLE
fix: noise filteration for nested fields and report noise detection

### DIFF
--- a/pkg/matcher/grpc/match.go
+++ b/pkg/matcher/grpc/match.go
@@ -219,43 +219,6 @@ func Match(tc *models.TestCase, actualResp *models.GrpcResp, noiseConfig map[str
 	expectedDecodedData := expectedResp.Body.DecodedData
 	actualDecodedData := actualResp.Body.DecodedData
 
-	// If the decoded data is valid JSON, we remove global keys (keys without dots like "timestamp")
-	// recursively from the structure before comparison.
-	if len(bodyNoise) > 0 && json.Valid([]byte(expectedDecodedData)) && json.Valid([]byte(actualDecodedData)) {
-		globalKeys := make(map[string]bool)
-		for k := range bodyNoise {
-			if !strings.Contains(k, ".") {
-				globalKeys[k] = true
-			}
-		}
-
-		if len(globalKeys) > 0 {
-			var expObj, actObj interface{}
-			// Clean Expected Body
-			if err := json.Unmarshal([]byte(expectedDecodedData), &expObj); err == nil {
-				matcher.RemoveGlobalNoise(expObj, globalKeys)
-				if b, err := json.Marshal(expObj); err == nil {
-					expectedDecodedData = string(b)
-				} else {
-					logger.Debug("failed to marshal expected body after noise removal", zap.Error(err))
-				}
-			} else {
-				logger.Debug("failed to unmarshal expected body for noise removal", zap.Error(err))
-			}
-			// Clean Actual Body
-			if err := json.Unmarshal([]byte(actualDecodedData), &actObj); err == nil {
-				matcher.RemoveGlobalNoise(actObj, globalKeys)
-				if b, err := json.Marshal(actObj); err == nil {
-					actualDecodedData = string(b)
-				} else {
-					logger.Debug("failed to marshal actual body after noise removal", zap.Error(err))
-				}
-			} else {
-				logger.Debug("failed to unmarshal actual body for noise removal", zap.Error(err))
-			}
-		}
-	}
-
 	var jsonComparisonResult matcher.JSONComparisonResult
 
 	// Check if both decoded data are valid JSON
@@ -316,8 +279,8 @@ func Match(tc *models.TestCase, actualResp *models.GrpcResp, noiseConfig map[str
 	result.BodyResult = append(result.BodyResult, models.BodyResult{
 		Normal:   decodedDataNormal,
 		Type:     models.GrpcData,
-		Expected: expectedDecodedData, // This now contains the CLEANSED data
-		Actual:   actualDecodedData,   // This now contains the CLEANSED data
+		Expected: expectedDecodedData,
+		Actual:   actualDecodedData,
 	})
 
 	// If decoded data matches but message length differs, ignore the length difference

--- a/pkg/matcher/utils.go
+++ b/pkg/matcher/utils.go
@@ -104,13 +104,29 @@ func (ni noiseIndex) match(keyLower string) (regs []*regexp.Regexp, isNoisy bool
 	return nil, false
 }
 
+// JSONDiffWithNoiseControl compares JSON with support for both Path-based noise (e.g. "body.user.id")
+// and Global noise (e.g. "timestamp") to be ignored everywhere.
 func JSONDiffWithNoiseControl(validatedJSON ValidatedJSON, noise map[string][]string, ignoreOrdering bool) (JSONComparisonResult, error) {
-	idx := buildNoiseIndex(noise)
-	return matchJSONWithNoiseHandlingIndexed("", validatedJSON.expected, validatedJSON.actual, idx, ignoreOrdering)
+	// Split noise into Path-based (contains dots) and Global (no dots)
+	pathNoise := make(map[string][]string)
+	globalKeys := make(map[string]bool)
+
+	for k, v := range noise {
+		// If a key has no dots, treat it as a Global Key to be ignored everywhere.
+		if !strings.Contains(k, ".") {
+			globalKeys[strings.ToLower(k)] = true
+		} else {
+			// Otherwise, it's a path-specific noise (e.g. "body.data.timestamp")
+			pathNoise[k] = v
+		}
+	}
+
+	idx := buildNoiseIndex(pathNoise)
+	return matchJSONWithNoiseHandlingIndexed("", validatedJSON.expected, validatedJSON.actual, idx, globalKeys, ignoreOrdering)
 }
 
-// New optimized implementation.
-func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{}, ni noiseIndex, ignoreOrdering bool) (JSONComparisonResult, error) {
+// matchJSONWithNoiseHandlingIndexed now accepts globalKeys to skip specific keys at any depth.
+func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{}, ni noiseIndex, globalKeys map[string]bool, ignoreOrdering bool) (JSONComparisonResult, error) {
 	var out JSONComparisonResult
 	// Type check fast-path (JSON unmarshal produces these concrete types).
 	switch e := expected.(type) {
@@ -171,8 +187,6 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 			return out, nil
 		}
 
-		// Quick length check — allows early exit if extra/missing keys (ignoring noisy children).
-		// We still need to walk to account for noisy exclusions; so we won't return solely on len.
 		isExact := true
 
 		// Lowercased prefix once.
@@ -184,18 +198,22 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 
 		// 1) All expected keys must be present & match.
 		for k, v := range e {
+			if globalKeys[strings.ToLower(k)] {
+				continue
+			}
+
 			val, ok := a[k]
 			if !ok {
 				return out, nil
 			}
 			childKeyLower := prefixLower + strings.ToLower(k)
 
-			// If child subtree is entirely noisy, skip deep compare.
+			// If child subtree is entirely noisy via path, skip deep compare.
 			if regs, noisy := ni.match(childKeyLower); noisy && len(regs) == 0 {
 				continue
 			}
 
-			res, err := matchJSONWithNoiseHandlingIndexed(prefix+k, v, val, ni, ignoreOrdering)
+			res, err := matchJSONWithNoiseHandlingIndexed(prefix+k, v, val, ni, globalKeys, ignoreOrdering)
 			if err != nil || !res.matches {
 				return out, nil
 			}
@@ -208,6 +226,10 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 
 		// 2) No unexpected non-noisy keys in actual.
 		for k := range a {
+			if globalKeys[strings.ToLower(k)] {
+				continue
+			}
+
 			if _, ok := e[k]; ok {
 				continue
 			}
@@ -240,7 +262,7 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 		if !ignoreOrdering {
 			isExact := true
 			for i := 0; i < len(e); i++ {
-				res, err := matchJSONWithNoiseHandlingIndexed(key, e[i], a[i], ni, ignoreOrdering)
+				res, err := matchJSONWithNoiseHandlingIndexed(key, e[i], a[i], ni, globalKeys, ignoreOrdering)
 				if err != nil || !res.matches {
 					return out, nil
 				}
@@ -269,7 +291,7 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 						continue
 					}
 					childKey := key
-					res, err := matchJSONWithNoiseHandlingIndexed(childKey, e[i], a[j], ni, ignoreOrdering)
+					res, err := matchJSONWithNoiseHandlingIndexed(childKey, e[i], a[j], ni, globalKeys, ignoreOrdering)
 					if err == nil && res.matches {
 						if !res.isExact {
 							isExact = false
@@ -1618,25 +1640,6 @@ func normalizeNestedJSONValue(v interface{}, rootKeys map[string]bool) {
 	case []interface{}:
 		for i := range t {
 			normalizeNestedJSONValue(t[i], rootKeys)
-		}
-	}
-}
-
-// removeGlobalNoise recursively removes keys from a JSON object (map or slice)
-// if the key exists in the keysToIgnore map.
-func RemoveGlobalNoise(data interface{}, keysToIgnore map[string]bool) {
-	switch v := data.(type) {
-	case map[string]interface{}:
-		for k, val := range v {
-			if keysToIgnore[k] {
-				delete(v, k)
-				continue
-			}
-			RemoveGlobalNoise(val, keysToIgnore)
-		}
-	case []interface{}:
-		for _, val := range v {
-			RemoveGlobalNoise(val, keysToIgnore)
 		}
 	}
 }


### PR DESCRIPTION
## Describe the changes that are made

- Updated HTTP and gRPC matchers to detect and recursively ignore keys defined globally in the config (e.g., `timestamp`), regardless of nesting depth.
- Refactored matcher utilities to skip comparisons for global keys efficiently.

## Links & References

**Closes:** https://github.com/keploy/keploy/issues/3311
- NA (if very small change like typo, linting, etc.)

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [x] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [x] 🙅 no, because it is not needed

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?