### PR TITLE
fix: Passthrough for long lived connections (enabled looping)

### DIFF
--- a/pkg/core/proxy/util/util.go
+++ b/pkg/core/proxy/util/util.go
@@ -410,16 +410,15 @@ func PassThrough(ctx context.Context, logger *zap.Logger, clientConn net.Conn, d
 		}
 	}
 
-	// channels for writing messages from proxy to destination or client
 	destBufferChannel := make(chan []byte)
-	errChannel := make(chan error, 1)
+	clientBufferChannel := make(chan []byte)
+	errChannel := make(chan error, 2)
 	passthroughContext, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	go func() {
 		defer Recover(logger, clientConn, nil)
 		defer close(destBufferChannel)
-		defer close(errChannel)
 		defer func(destConn net.Conn) {
 			err := destConn.Close()
 			if err != nil {
@@ -430,32 +429,44 @@ func PassThrough(ctx context.Context, logger *zap.Logger, clientConn net.Conn, d
 		ReadBuffConn(passthroughContext, logger, destConn, destBufferChannel, errChannel)
 	}()
 
-	select {
-	case buffer := <-destBufferChannel:
-		// Write the response message to the client
-		_, err := clientConn.Write(buffer)
-		if err != nil {
-			if ctx.Err() != nil {
-				return nil, ctx.Err()
+	go func() {
+		defer Recover(logger, clientConn, nil)
+		defer close(clientBufferChannel)
+		ReadBuffConn(passthroughContext, logger, clientConn, clientBufferChannel, errChannel)
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+
+		case buffer := <-clientBufferChannel:
+			_, err := destConn.Write(buffer)
+			if err != nil {
+				utils.LogError(logger, err, "failed to write subsequent request to destination")
+				return nil, err
 			}
-			utils.LogError(logger, err, "failed to write response to the client")
-			return nil, err
-		}
 
-		logger.Debug("the iteration for the generic response ends with responses:"+strconv.Itoa(len(buffer)), zap.Any("buffer", buffer))
-	case err := <-errChannel:
-		// Applied this nolint to ignore the staticcheck error here because of readability
-		// nolint:staticcheck
-		if netErr, ok := err.(net.Error); !(ok && netErr.Timeout()) && err != nil {
-			return nil, err
-		}
-		return nil, nil
+		case buffer := <-destBufferChannel:
+			_, err := clientConn.Write(buffer)
+			if err != nil {
+				if ctx.Err() != nil {
+					return nil, ctx.Err()
+				}
+				utils.LogError(logger, err, "failed to write response to the client")
+				return nil, err
+			}
 
-	case <-ctx.Done():
-		return nil, ctx.Err()
+		case err := <-errChannel:
+			// nolint:staticcheck
+			if netErr, ok := err.(net.Error); !(ok && netErr.Timeout()) && err != nil {
+				if err == io.EOF {
+					return nil, nil
+				}
+				return nil, err
+			}
+		}
 	}
-
-	return nil, nil
 }
 
 // ToIP4AddressStr converts the integer IP4 Address to the octet format


### PR DESCRIPTION
## Describe the changes that are made

Fixed the logic of Passthrough function, by enabling looping for long lived connections.
Earlier since there was no looping hence the passthrough only used to write the first chunked it received from the destination connection to the client connection. It resulted into an unexpected premature EOF on the application side. This was observed during the case of --fallBack-on-miss flag.

## Links & References

**Closes:** #3328 
## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [X] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [X] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [X] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [X] 🙅 no, because it is not needed

## Self Review done?
- [X] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [X] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [X] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [X] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?