### PR TITLE
fix(summary): exclude delay from execution time and update summary label

### DIFF
--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1265,8 +1265,11 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 	// Subtract application delay time from total time to show only test execution time
 	if r.instrument {
 		delayDuration := time.Duration(r.config.Test.Delay) * time.Second
-		if timeTaken > delayDuration {
+		if timeTaken >= delayDuration {
 			timeTaken -= delayDuration
+		} else {
+			// If test execution is faster than delay, set to zero to avoid negative values
+			timeTaken = 0
 		}
 	}
 

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1262,6 +1262,13 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 	}
 
 	timeTaken := time.Since(startTime)
+	// Subtract application delay time from total time to show only test execution time
+	if r.instrument {
+		delayDuration := time.Duration(r.config.Test.Delay) * time.Second
+		if timeTaken > delayDuration {
+			timeTaken -= delayDuration
+		}
+	}
 
 	testCaseResults, err := r.reportDB.GetTestCaseResults(runTestSetCtx, testRunID, testSetID)
 	if err != nil {
@@ -1517,12 +1524,12 @@ func (r *Replayer) printSummary(_ context.Context, _ bool) {
 		totalTestTimeTakenStr := timeWithUnits(totalTestTimeTaken)
 
 		if totalTestIgnored > 0 {
-			if _, err := pp.Printf("\n <=========================================> \n  COMPLETE TESTRUN SUMMARY. \n\tTotal tests: %s\n"+"\tTotal test passed: %s\n"+"\tTotal test failed: %s\n"+"\tTotal test ignored: %s\n"+"\tTotal time taken: %s\n", totalTests, totalTestPassed, totalTestFailed, totalTestIgnored, totalTestTimeTakenStr); err != nil {
+			if _, err := pp.Printf("\n <=========================================> \n  COMPLETE TESTRUN SUMMARY. \n\tTotal tests: %s\n"+"\tTotal test passed: %s\n"+"\tTotal test failed: %s\n"+"\tTotal test ignored: %s\n"+"\tTotal test execution time: %s\n", totalTests, totalTestPassed, totalTestFailed, totalTestIgnored, totalTestTimeTakenStr); err != nil {
 				utils.LogError(r.logger, err, "failed to print test run summary")
 				return
 			}
 		} else {
-			if _, err := pp.Printf("\n <=========================================> \n  COMPLETE TESTRUN SUMMARY. \n\tTotal tests: %s\n"+"\tTotal test passed: %s\n"+"\tTotal test failed: %s\n"+"\tTotal time taken: %s\n", totalTests, totalTestPassed, totalTestFailed, totalTestTimeTakenStr); err != nil {
+			if _, err := pp.Printf("\n <=========================================> \n  COMPLETE TESTRUN SUMMARY. \n\tTotal tests: %s\n"+"\tTotal test passed: %s\n"+"\tTotal test failed: %s\n"+"\tTotal test execution time: %s\n", totalTests, totalTestPassed, totalTestFailed, totalTestTimeTakenStr); err != nil {
 				utils.LogError(r.logger, err, "failed to print test run summary")
 				return
 			}

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -559,6 +559,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 	runTestSetCtx, runTestSetCtxCancel := context.WithCancel(runTestSetCtx)
 
 	startTime := time.Now()
+	delayApplied := false
 
 	exitLoopChan := make(chan bool, 2)
 	defer func() {
@@ -781,6 +782,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		}
 
 		// Delay for user application to run
+		delayApplied = true
 		select {
 		case <-time.After(time.Duration(r.config.Test.Delay) * time.Second):
 		case <-runTestSetCtx.Done():
@@ -885,6 +887,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			})
 
 			// Delay for user application to run
+			delayApplied = true
 			select {
 			case <-time.After(time.Duration(r.config.Test.Delay) * time.Second):
 			case <-runTestSetCtx.Done():
@@ -1263,7 +1266,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 
 	timeTaken := time.Since(startTime)
 	// Subtract application delay time from total time to show only test execution time
-	if r.instrument {
+	if delayApplied {
 		delayDuration := time.Duration(r.config.Test.Delay) * time.Second
 		if timeTaken >= delayDuration {
 			timeTaken -= delayDuration

--- a/pkg/service/report/report.go
+++ b/pkg/service/report/report.go
@@ -243,9 +243,9 @@ func (r *Report) printSummary(reports map[string]*models.TestReport) error {
 	}
 
 	if grandDur > 0 {
-		fmt.Fprintf(r.out, "\n\tTotal time taken: %q\n", fmtDuration(grandDur))
+		fmt.Fprintf(r.out, "\n\tTotal test execution time: %q\n", fmtDuration(grandDur))
 	} else {
-		fmt.Fprintf(r.out, "\n\tTotal time taken: %q\n", "N/A")
+		fmt.Fprintf(r.out, "\n\tTotal test execution time: %q\n", "N/A")
 	}
 
 	// Tabwriter over the same buffered writer.

--- a/pkg/service/report/utils.go
+++ b/pkg/service/report/utils.go
@@ -41,9 +41,9 @@ func printSingleSummaryTo(w *bufio.Writer, name string, total, pass, fail int, d
 	fmt.Fprintf(w, "\tTotal test passed: %d\n", pass)
 	fmt.Fprintf(w, "\tTotal test failed: %d\n", fail)
 	if dur > 0 {
-		fmt.Fprintf(w, "\tTotal time taken: %q\n", fmtDuration(dur))
+		fmt.Fprintf(w, "\tTotal test execution time: %q\n", fmtDuration(dur))
 	} else {
-		fmt.Fprintf(w, "\tTotal time taken: %q\n", "N/A")
+		fmt.Fprintf(w, "\tTotal test execution time: %q\n", "N/A")
 	}
 	fmt.Fprintln(w, "\tTest Suite\t\tTotal\tPassed\t\tFailed\t\tTime Taken\t")
 	tt := "N/A"


### PR DESCRIPTION
## Describe the changes that are made
- I’ve completed the fix for Issue #3351. The delay provided by the user is now excluded from the final test execution time. The logic was implemented inside pkg/service/replay/replay.go by subtracting the configured delay from the measured duration. This ensures that the summary reflects only Keploy’s processing time rather than time spent waiting for the application to boot or respond. I also renamed every occurrence of “Total time taken:” to “Total test execution time:” across the replay and report packages to keep the wording consistent.

To verify the fix, I used a simple sample Python HTTP server as the test application. The test shown in the screenshot failed because the sample app was intentionally not serving on the expected port, which is normal. The purpose of this test was not to validate HTTP behavior but to check the summary time output.

The important part is the time displayed in the summary. Even though I used a delay of 10 seconds, the final summary showed “18 ms”. This confirms that the new logic is working correctly. If the delay had not been excluded, the summary would have shown approximately 10 seconds plus execution time. Instead, it displayed only the actual replay time (which in this case was very small), proving that the delay subtraction code is functioning as intended.

The changes compile cleanly, the summary output is correct, and the behavior now matches the expected design.

## Links & References

**Closes:** #[issue number that will be closed through this PR]
- NA (if very small change like typo, linting, etc.)

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [✔️ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [✔️ ] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [ ] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned in the screenshoot.
- [ ] 🙅 no, because it is not needed

## Self Review done?
- [ ✔️] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- 
<img width="2560" height="1600" alt="Screenshot 2025-12-10 044304" src="https://github.com/user-attachments/assets/b2c7a30e-22fd-410c-9371-8ae0facccf14" />
<img width="2560" height="1600" alt="Screenshot 2025-12-10 044239" src="https://github.com/user-attachments/assets/7d9c4654-771e-45f8-839d-76bab2a7cdaf" />
<img width="2560" height="1600" alt="Screenshot 2025-12-10 044217" src="https://github.com/user-attachments/assets/7f65092b-98ec-4a65-b5bc-1f7939edad4d" />
<img width="2560" height="1600" alt="Screenshot 2025-12-10 044204" src="https://github.com/user-attachments/assets/355b8e42-8bc3-4184-9c6c-e507d9c78779" />


## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [ ✔️] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [✔️; ] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [✔️ ] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?