### PR TITLE
fix: close TOCTOU race in MockManager and add race test

### DIFF
--- a/pkg/agent/proxy/mockmanager_race_test.go
+++ b/pkg/agent/proxy/mockmanager_race_test.go
@@ -1,0 +1,57 @@
+// This test is intended to be run with:
+//   go test -race ./pkg/agent/proxy
+//
+// It reproduces a TOCTOU (Time-Of-Check-Time-Of-Use) race condition between
+// GetFilteredMocksByKind/GetUnFilteredMocksByKind (readers) and SetFilteredMocks
+// (writers). The race occurs because tree pointers are read under treesMu.RLock()
+// but used after the lock is released, while writers can replace the entire map.
+// This can lead to stale tree access and data inconsistency.
+package proxy
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+func TestMockManager_GetFilteredMocks_Race(t *testing.T) {
+	manager := NewMockManager(nil, nil, zap.NewNop())
+	var wg sync.WaitGroup
+
+	// Start multiple reader goroutines calling GetFilteredMocksByKind
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 500; j++ {
+				_, _ = manager.GetFilteredMocksByKind(models.REDIS)
+			}
+		}()
+	}
+
+	// Start multiple writer goroutines calling SetFilteredMocks
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(iter int) {
+			defer wg.Done()
+			mocks := []*models.Mock{
+				{
+					Kind: models.REDIS,
+					Name: fmt.Sprintf("mock-%d", iter),
+					TestModeInfo: models.TestModeInfo{
+						ID:         iter,
+						IsFiltered: true,
+						SortOrder:  int64(iter),
+					},
+				},
+			}
+			manager.SetFilteredMocks(mocks)
+		}(i)
+	}
+
+	wg.Wait()
+}
+

--- a/pkg/agent/proxy/mockmanager_race_test.go
+++ b/pkg/agent/proxy/mockmanager_race_test.go
@@ -55,3 +55,41 @@ func TestMockManager_GetFilteredMocks_Race(t *testing.T) {
 	wg.Wait()
 }
 
+func TestMockManager_GetUnFilteredMocks_Race(t *testing.T) {
+	manager := NewMockManager(nil, nil, zap.NewNop())
+	var wg sync.WaitGroup
+
+	// Start multiple reader goroutines calling GetUnFilteredMocksByKind
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 500; j++ {
+				_, _ = manager.GetUnFilteredMocksByKind(models.REDIS)
+			}
+		}()
+	}
+
+	// Start multiple writer goroutines calling SetUnFilteredMocks
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(iter int) {
+			defer wg.Done()
+			mocks := []*models.Mock{
+				{
+					Kind: models.REDIS,
+					Name: fmt.Sprintf("mock-%d", iter),
+					TestModeInfo: models.TestModeInfo{
+						ID:         iter,
+						IsFiltered: false,
+						SortOrder:  int64(iter),
+					},
+				},
+			}
+			manager.SetUnFilteredMocks(mocks)
+		}(i)
+	}
+
+	wg.Wait()
+}
+


### PR DESCRIPTION
## Summary of issue
While working on MockManager, I noticed a TOCTOU (time-of-check-time-of-use) race between the getter and setter paths under concurrent access.

GetFilteredMocksByKind and GetUnFilteredMocksByKind read a tree pointer from the internal map under a read lock, release the lock, and then iterate over the tree. At the same time, SetFilteredMocks / SetUnFilteredMocks can replace the entire map, which allows readers to continue using a stale tree pointer. This leads to data races reported by the Go race detector and can cause inconsistent mock reads under concurrency.
## Fix
Added a re-validation step after ensureKindTrees() so that getters prefer the current tree from the map if it was replaced concurrently.

Protected map length reads in SetFilteredMocks and SetUnFilteredMocks with a read lock to avoid concurrent map access races.

This closes the TOCTOU race window while keeping reader concurrency intact.
## Test

Added a small concurrent test that reproduces the race under the Go race detector.
To verify:
`go test ./pkg/agent/proxy -race -run TestMockManager_GetFilteredMocks_Race
`
screenshot of terminal before fix:
<img width="1386" height="1263" alt="Screenshot 2025-12-20 182722" src="https://github.com/user-attachments/assets/9d7a8e7c-7c04-417c-b253-7842fb19c3bc" />
<img width="1584" height="1281" alt="Screenshot 2025-12-20 182614" src="https://github.com/user-attachments/assets/15c853a2-685c-4a38-a7c8-90a1c5976acd" />
<img width="1339" height="1105" alt="Screenshot 2025-12-20 182629" src="https://github.com/user-attachments/assets/21dbb9cf-7c28-4637-82fe-86e2ea14ac2b" />

screenshot of terminal after fix:
<img width="1016" height="112" alt="Screenshot 2025-12-20 192220" src="https://github.com/user-attachments/assets/a28fe5bc-7453-412d-827f-ab3dcb6f65c6" />

The test consistently triggers race warnings before the fix and passes cleanly after.

