### PR TITLE
fix: redirect docker-compose logs to a file when output is a TTY

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -113,6 +113,7 @@ require (
 	github.com/wI2L/jsondiff v0.5.0
 	github.com/zricethezav/gitleaks/v8 v8.28.0
 	golang.org/x/sync v0.15.0
+	golang.org/x/term v0.32.0
 	google.golang.org/grpc v1.71.0
 	gopkg.in/yaml.v2 v2.4.0
 	helm.sh/helm/v3 v3.18.3

--- a/go.sum
+++ b/go.sum
@@ -603,6 +603,8 @@ golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXR
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
+golang.org/x/term v0.32.0 h1:DR4lr0TjUs3epypdhTOkMmuF5CDFJ/8pOnbzMZPQ7bg=
+golang.org/x/term v0.32.0/go.mod h1:uZG1FhGx848Sqfsq4/DlJr3xGGsYMu/L5GW4abiaEPQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
This pull request enhances how the application handles output from docker-compose commands, especially when running in a terminal (TTY). It introduces logic to redirect docker-compose logs to a temporary file when appropriate, improving log accessibility and user experience. Additionally, it updates dependencies to support this functionality.

**Improvements to docker-compose command output handling:**

* When executing a docker-compose command and the output is a TTY, the output is now redirected to a temporary log file in the OS-specific temp directory, and the user is informed about how to view these logs live.
* If the output is not a TTY, docker-compose output continues to be sent directly to stdout/stderr, with appropriate debug logging.

**Dependency updates:**

* Added `golang.org/x/term v0.32.0` to `go.mod` to enable TTY detection.

**Codebase enhancements:**

* Imported `fmt`, `filepath`, and `golang.org/x/term` in `utils/signal_others.go` to support log file creation and TTY detection.