### PR TITLE
Fix: HTTP proxy stuck in infinite loop on chunked response EOF

### DIFF
--- a/pkg/agent/proxy/integrations/http/chunk.go
+++ b/pkg/agent/proxy/integrations/http/chunk.go
@@ -277,7 +277,7 @@ func (h *HTTP) handleChunkedResponses(ctx context.Context, finalResp *[]byte, cl
 	return nil
 }
 
-// Handled chunked responses when transfer-encoding is given.
+// Handles chunked responses when transfer-encoding is given.
 func (h *HTTP) chunkedResponse(ctx context.Context, finalResp *[]byte, clientConn, destConn net.Conn) error {
 	isEOF := false
 ReadLoop:

--- a/pkg/agent/proxy/integrations/http/chunk_test.go
+++ b/pkg/agent/proxy/integrations/http/chunk_test.go
@@ -21,7 +21,7 @@ const (
 	maxAcceptableReads = 10
 )
 
-// mockConn is a mock net.Conn that simulates a connection returning EOF.
+// mockConn is a mock net.Conn that returns test data on first read, then EOF on subsequent reads.
 type mockConn struct {
 	readCount    int
 	data         []byte


### PR DESCRIPTION
## Describe the changes that are made
Problem:
The HTTP proxy gets stuck in an infinite loop when handling chunked transfer-encoded responses that close the connection. This causes Playwright tests (and other HTTP clients using keep-alive connections) to hang indefinitely during mock recording.

Root Cause:
In chunkedResponse(), the break statements inside the select block only exit the select, not the outer for loop. When the server closes the connection (EOF), the code logs "exiting loop as response is complete" but immediately continues looping, reading EOF repeatedly every ~400ms.

Fix:
Use labeled break (break ReadLoop) to properly exit the for loop when EOF is received with no remaining data.

Testing:
Added unit tests in chunk_test.go that:

Verify the loop exits promptly on EOF (previously would timeout)
Confirm no excessive reads occur after connection close
Reproduce the exact hang behavior seen with Playwright
Before: Tests timeout after 1 second, stuck in EOF read loop
After: Tests complete in ~400ms with proper loop exit

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [x] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [x] 🙅 no, because it is not needed

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA


## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?