### PR TITLE
fix: add nil check before closing udpp4 link

### DIFF
--- a/pkg/agent/hooks/linux/hooks.go
+++ b/pkg/agent/hooks/linux/hooks.go
@@ -54,7 +54,8 @@ type Hooks struct {
 	m         sync.Mutex
 
 	// Linux-specific fields
-	objectsMutex sync.RWMutex // Protects eBPF objects during load/unload operations
+	objectsMutex sync.RWMutex // Protects eBPF objects during load/
+	//  operations
 	// eBPF C shared maps
 	clientRegistrationMap *ebpf.Map
 	agentRegistartionMap  *ebpf.Map
@@ -309,9 +310,11 @@ func (h *Hooks) unLoad(_ context.Context, opts agent.HookCfg) {
 	if err := h.socket.Close(); err != nil {
 		utils.LogError(h.logger, err, "failed to close the socket")
 	}
-
-	if err := h.udpp4.Close(); err != nil {
-		utils.LogError(h.logger, err, "failed to close the udpp4")
+	
+	if h.udpp4!=nil{
+		if err := h.udpp4.Close(); err != nil {
+			utils.LogError(h.logger, err, "failed to close the udpp4")
+		}
 	}
 
 	if err := h.connect4.Close(); err != nil {


### PR DESCRIPTION
## Describe the changes that are made
- udpp4 is declared in the Hooks struct but never initialized in load().
- unLoad() was calling Close() on udpp4 unconditionally, which could cause a nil pointer dereference panic.
- This change adds a nil check before closing udpp4, ensuring safe cleanup and consistency with other optional hooks.

## Links & References

**Closes:** #3465

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [x] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [ ] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [x] 🙅 no, because it is not needed

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA
