### PR TITLE
fix(ci): trigger release workflow only on published non-prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
-name: Release
 on:
-  push:
-    tags:
-    - 'v*.*.*'
+  release:
+    types: [published]
+
 
 permissions:
   contents: write
@@ -49,6 +48,9 @@ jobs:
 #          rm -rf $GITHUB_WORKSPACE/ui
 
   build-go:
+    # Run only for non-prerelease (stable) releases
+    if: github.event.release.prerelease == false
+
     runs-on: macos-latest
     # runs-on: ubuntu-latest
 #    needs: build-ui


### PR DESCRIPTION
### What does this PR do?
This PR modifies the release workflow trigger to enhance release safety.

### Changes
-Replaced tag-based trigger with the `release.published` event.
- Added a guard that prevents prerelease versions from causing a release to the production environment.

### Why?
The trigger on tag push could potentially cause unintended production releases. This ensures that releases are only created when they are intentionally published via GitHub Releases.

Fixes #3198
