### PR TITLE
docs: deprecate utgen package and update contribution

### DIFF
--- a/pkg/service/utgen/README.md
+++ b/pkg/service/utgen/README.md
@@ -17,6 +17,9 @@ Any pull requests targeting this package will likely **not be reviewed or merged
 If you’re interested in contributing to Keploy:
 - Explore other **actively maintained packages**
 - Check open issues labeled **`good first issue`** or **`help wanted`**
+
+  👉 https://github.com/keploy/keploy/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22Good%20First%20Issue%22
+
 - Join discussions and help improve current and future Keploy components
 
 ### Questions?


### PR DESCRIPTION
This PR adds a clear deprecation notice to the `utgen` package.

The package is no longer actively maintained, but its status was not explicitly documented. This update helps set the right expectations for contributors and avoids confusion around future contributions.

---

###  What’s Changed
- Added a deprecation notice to `utgen/README.md`
- Clearly mentioned that new contributions are not accepted
- Guided contributors toward actively maintained areas of the project

---

###  Why This Change?
- Prevents contributors from spending time on deprecated code
- Improves clarity and transparency in the repository
- Keeps contribution efforts focused on maintained components
