### PR TITLE
added a nil check closing udpp4

### DIFF
--- a/pkg/agent/hooks/linux/hooks.go
+++ b/pkg/agent/hooks/linux/hooks.go
@@ -309,9 +309,11 @@ func (h *Hooks) unLoad(_ context.Context, opts agent.HookCfg) {
 	if err := h.socket.Close(); err != nil {
 		utils.LogError(h.logger, err, "failed to close the socket")
 	}
+	if h.udpp4 != nil {
+		if err := h.udpp4.Close(); err != nil {
+			utils.LogError(h.logger, err, "failed to close the udpp4")
+		}
 
-	if err := h.udpp4.Close(); err != nil {
-		utils.LogError(h.logger, err, "failed to close the udpp4")
 	}
 
 	if err := h.connect4.Close(); err != nil {


### PR DESCRIPTION
```unLoad()```  was calling ```udpp4.Close()``` without checking if udpp4 was initialized.
Since udpp4 is declared but never initialized in ```load()```, this could cause a nil pointer panic.

This PR adds a nil check before closing ```udpp4```, making the cleanup logic safe and consistent with other hooks.

Closes: https://github.com/keploy/keploy/issues/3465