### PR TITLE
fix: avoid copying sync.Map in telemetry and CLI provider

### DIFF
--- a/cli/provider/service.go
+++ b/cli/provider/service.go
@@ -14,7 +14,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var TeleGlobalMap sync.Map
+var TeleGlobalMap = &sync.Map{}
 
 type ServiceProvider struct {
 	logger *zap.Logger
@@ -32,7 +32,7 @@ func NewServiceProvider(logger *zap.Logger, cfg *config.Config, auth service.Aut
 
 func (n *ServiceProvider) GetService(ctx context.Context, cmd string) (interface{}, error) {
 
-	tel := telemetry.NewTelemetry(n.logger, telemetry.Options{
+	tel := telemetry.NewTelemetry(n.logger, &telemetry.Options{
 		Enabled:        !n.cfg.DisableTele,
 		Version:        utils.Version,
 		GlobalMap:      TeleGlobalMap,

--- a/pkg/platform/telemetry/telemetry.go
+++ b/pkg/platform/telemetry/telemetry.go
@@ -20,18 +20,18 @@ type Telemetry struct {
 	logger         *zap.Logger
 	InstallationID string
 	KeployVersion  string
-	GlobalMap      sync.Map
+	GlobalMap      *sync.Map
 	client         *http.Client
 }
 
 type Options struct {
 	Enabled        bool
 	Version        string
-	GlobalMap      sync.Map
+	GlobalMap      *sync.Map
 	InstallationID string
 }
 
-func NewTelemetry(logger *zap.Logger, opt Options) *Telemetry {
+func NewTelemetry(logger *zap.Logger, opt *Options) *Telemetry {
 	return &Telemetry{
 		Enabled:        opt.Enabled,
 		logger:         logger,


### PR DESCRIPTION
## Summary

This PR fixes `go vet` copylocks warnings caused by passing `sync.Map` by value
in telemetry and CLI provider code.

`sync.Map` contains an internal mutex (`sync.noCopy`) and must not be copied
after first use. Passing it by value can lead to race conditions, deadlocks,
and undefined behavior under concurrent access.

## Changes

- Updated telemetry `Options` and `Telemetry` structs to use `*sync.Map`
- Updated `NewTelemetry` to accept and assign the pointer
- Passed `&TeleGlobalMap` instead of copying the map in the CLI provider

## Verification

- `go vet ./...` passes successfully
- No functional behavior changes

## Context

This was discovered during routine static analysis using `go vet`, which
reported lock-copying issues in:
- `pkg/platform/telemetry`
- `cli/provider`

Fixing this ensures safe concurrent usage and aligns with Go best practices.

Closes:  https://github.com/keploy/keploy/issues/3509