### PR TITLE
fix: return proper errors instead of uninitialized err variables

### DIFF
--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -345,7 +345,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 	rule, ok := p.sessions.Get(uint64(0))
 	if !ok {
 		utils.LogError(p.logger, nil, "failed to fetch the session rule")
-		return err
+		return fmt.Errorf("failed to fetch the session rule")
 	}
 
 	mgr := syncMock.Get()
@@ -444,7 +444,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 		m, ok := p.MockManagers.Load(uint64(0))
 		if !ok {
 			utils.LogError(p.logger, nil, "failed to fetch the mock manager")
-			return err
+			return fmt.Errorf("failed to fetch the mock manager")
 		}
 
 		//mock the outgoing message
@@ -493,14 +493,14 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 
 	clientID, ok := parserCtx.Value(models.ClientConnectionIDKey).(string)
 	if !ok {
-		utils.LogError(p.logger, err, "failed to fetch the client connection id")
-		return err
+		utils.LogError(p.logger, nil, "failed to fetch the client connection id")
+		return fmt.Errorf("failed to fetch the client connection id")
 	}
 
 	destID, ok := parserCtx.Value(models.DestConnectionIDKey).(string)
 	if !ok {
-		utils.LogError(p.logger, err, "failed to fetch the destination connection id")
-		return err
+		utils.LogError(p.logger, nil, "failed to fetch the destination connection id")
+		return fmt.Errorf("failed to fetch the destination connection id")
 	}
 
 	logger := p.logger.With(zap.String("Client ConnectionID", clientID), zap.String("Destination ConnectionID", destID), zap.String("Destination IP Address", dstAddr), zap.String("Client IP Address", srcConn.RemoteAddr().String()))
@@ -553,14 +553,14 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 		// get the destinationUrl from the map for the tls connection
 		url, ok := pTls.SrcPortToDstURL.Load(sourcePort)
 		if !ok {
-			utils.LogError(logger, err, "failed to fetch the destination url")
-			return err
+			utils.LogError(logger, nil, "failed to fetch the destination url")
+			return fmt.Errorf("failed to fetch the destination url")
 		}
 		//type case the dstUrl to string
 		dstURL, ok := url.(string)
 		if !ok {
-			utils.LogError(logger, err, "failed to type cast the destination url")
-			return err
+			utils.LogError(logger, nil, "failed to type cast the destination url")
+			return fmt.Errorf("failed to type cast the destination url")
 		}
 
 		logger.Debug("the external call is tls-encrypted", zap.Bool("isTLS", isTLS))
@@ -595,8 +595,8 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 	// get the mock manager for the current app
 	m, ok := p.MockManagers.Load(uint64(0))
 	if !ok {
-		utils.LogError(logger, err, "failed to fetch the mock manager")
-		return err
+		utils.LogError(logger, nil, "failed to fetch the mock manager")
+		return fmt.Errorf("failed to fetch the mock manager")
 	}
 
 	generic := true

--- a/pkg/service/replay/mock.go
+++ b/pkg/service/replay/mock.go
@@ -360,7 +360,7 @@ func (m *mock) pushConfigChange(ctx context.Context, testSetID string, tsConfig 
 		m.logger.Error("API server returned an error for config push",
 			zap.Int("statusCode", resp.StatusCode),
 			zap.String("response", string(respBody)))
-		return err
+		return fmt.Errorf("api server returned status %d: %s", resp.StatusCode, string(respBody))
 	}
 
 	var respData MockChangeResp


### PR DESCRIPTION
## Describe the changes that are made
Fixed 8 critical bugs where uninitialized `err` variables were being returned when lookups or type assertions failed Changed all error returns to use `fmt.Errorf()` with descriptive error messages.

### 🔗 Related PRs
- NA

### 🐞 Related Issues
- NA (bug discovered during code review)

### 📄 Related Documents
- Follows existing error handling pattern in codebase (see `pkg/agent/proxy/proxy.go:760`)

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [x] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

### Testing Steps:
1. **Code Compilation**: Verified with `go build ./...` - ✅ Passes
2. **Static Analysis**: Verified with `go vet ./...` - ✅ Passes
3. **Tests**: Verified with `go test ./...` - ✅ All existing tests pass
4. **Code Formatting**: Verified with `go fmt` - ✅ Properly formatted
5. **Linting**: No linting errors found

### Impact:
- **Before**: When lookups/assertions failed, the code would return `nil` (from a previous successful operation), causing silent failures
- **After**: Proper error messages are returned, ensuring errors are propagated correctly and failures are not silently ignored

### Code Quality:
- All fixes follow the existing codebase pattern (see `GetConsumedMocks` at line 760 in `proxy.go`)
- Error messages are descriptive and follow Go best practices
- No breaking changes - only fixes error handling behavior

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

