### PR TITLE
docs: add Docker prerequisite note to Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ This helps expand API Schema, Statement, and Branch Coverage.
 
 ## Quick Start
 
+> **Note:** Make sure Docker is installed and running before starting Keploy.
+
+
+
 ### 1. Install Keploy Agent
 
 ```bash


### PR DESCRIPTION
### Summary
Adds a note to the Quick Start section of the README clarifying that Docker
must be installed and running before using Keploy.

### Motivation
Without this prerequisite, new users may face setup issues. This change
improves clarity and the overall onboarding experience.

### Changes
Added Docker prerequisite note in Quick Start section of README.md

### Related Issue
None
