### PR TITLE
fix: ignore unsupported func type in json marshaling

### DIFF
--- a/pkg/models/instrument.go
+++ b/pkg/models/instrument.go
@@ -59,7 +59,7 @@ type OutgoingOptions struct {
 type ConditionalDstCfg struct {
 	Addr   string // Destination Addr (ip:port)
 	Port   uint
-	TLSCfg *tls.Config
+	TLSCfg *tls.Config `json:"-" yaml:"-"`
 }
 
 type IncomingOptions struct {


### PR DESCRIPTION
Fixes staticcheck SA1026 by adding json/yaml ignore tags to TLSCfg field in ConditionalDstCfg struct. This prevents runtime panic when marshaling the http.Agent configuration.

## Describe the changes that are made

-  Added json:"-" yaml:"-" tags to the TLSCfg field in pkg/models/instrument.go.
- This ensures that the tls.Config object (which contains unsupported func types like Time func() time.Time) is skipped during serialization.
- Resolves the runtime crash flagged by staticcheck (SA1026) when OutgoingReq is marshaled.

## Links & References

**Closes:** #3531 
- NA (if very small change like typo, linting, etc.)

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [x] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

Verification Steps:

1. Created a reproduction test case that populates TLSCfg in OutgoingReq and attempts json.Marshal.
2. Before Fix: The test crashed with json: unsupported type: func() time.Time.
3. After Fix: The test passed successfully (field was ignored).
4. Static Check: Ran staticcheck ./pkg/platform/http/... and confirmed SA1026 is gone.


// Reproduction Code Used
package main
import (
    "crypto/tls"
    "encoding/json"
    "fmt"
    "github.com/keploy/keploy/pkg/models"
)
func main() {
    req := models.OutgoingReq{
        OutgoingOptions: models.OutgoingOptions{
            DstCfg: &models.ConditionalDstCfg{
                Addr: "127.0.0.1:8080",
                TLSCfg: &tls.Config{InsecureSkipVerify: true}, // Contains func()
            },
        },
    }
    _, err := json.Marshal(req)
    if err != nil {
        fmt.Printf("CRASH: %v\n", err)
    }
}


## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- Error Log (Before Fix):

json: unsupported type: func() time.Time

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?