### PR TITLE
fix: mysql port from hard code to config with default

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -264,6 +264,7 @@ func (c *CmdConfigurator) AddFlags(cmd *cobra.Command) error {
 		cmd.Flags().Bool("generate-github-actions", c.cfg.GenerateGithubActions, "Generate Github Actions workflow file")
 		cmd.Flags().String("keploy-container", c.cfg.KeployContainer, "Keploy server container name")
 		cmd.Flags().Bool("in-ci", c.cfg.InCi, "is CI Running or not")
+		cmd.Flags().Uint32("db-port", c.cfg.DBPort, "Database port specific by app")
 
 		//add rest of the uncommon flags for record, test, rerecord commands
 		c.AddUncommonFlags(cmd)

--- a/config/config.go
+++ b/config/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	Contract              Contract            `json:"contract" yaml:"contract" mapstructure:"contract"`
 	Agent                 Agent               `json:"agent" yaml:"agent" mapstructure:"agent"`
 	InCi                  bool                `json:"inCi" yaml:"inCi" mapstructure:"inCi"`
+	DBPort                uint32              `json:"dbPort" yaml:"dbPort" mapstructure:"dbPort"`
 	InstallationID        string              `json:"-" yaml:"-" mapstructure:"-"`
 	ServerPort            uint32              `json:"serverPort" yaml:"serverPort" mapstructure:"serverPort"`
 	Version               string              `json:"-" yaml:"-" mapstructure:"-"`

--- a/config/default.go
+++ b/config/default.go
@@ -18,6 +18,7 @@ templatize:
 port: 0
 proxyPort: 16789
 dnsPort: 26789
+dbPort: 3306
 debug: false
 disableANSI: false
 disableTele: false

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -42,6 +42,7 @@ type Proxy struct {
 	IP6     string
 	Port    uint32
 	DNSPort uint32
+	DBPort  uint32
 
 	DestInfo     agent.DestInfo
 	Integrations map[integrations.IntegrationType]integrations.Integrations
@@ -73,6 +74,7 @@ func New(logger *zap.Logger, info agent.DestInfo, opts *config.Config) *Proxy {
 		logger:            logger,
 		Port:              opts.ProxyPort,
 		DNSPort:           opts.DNSPort, // default: 26789
+		DBPort:            opts.DBPort,  // default: 3306
 		synchronous:       opts.Agent.Synchronous,
 		IP4:               "127.0.0.1", // default: "127.0.0.1" <-> (2130706433)
 		IP6:               "::1",       //default: "::1" <-> ([4]uint32{0000, 0000, 0000, 0001})
@@ -418,7 +420,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 	}
 
 	//checking for the destination port of "mysql"
-	if destInfo.Port == 3306 {
+	if destInfo.Port == p.DBPort {
 		if rule.Mode != models.MODE_TEST {
 			dstConn, err = net.Dial("tcp", dstAddr)
 			if err != nil {


### PR DESCRIPTION
## Describe the changes that are made
the destination port of "mysql" is hard-code in the pkg/agent/proxy/proxy.go.
Since some app might customize the database connection port, I add a config option for this port and set 3306 as the default.

## Links & References

**Closes:** #[issue number that will be closed through this PR]
- NA (if very small change like typo, linting, etc.)

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [x] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [x] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [ ] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [ ] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [ ] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?