### PR TITLE
fix: eliminate staticcheck crash bugs and improve safety

### DIFF
--- a/pkg/http2.go
+++ b/pkg/http2.go
@@ -404,7 +404,7 @@ func (sm *DefaultStreamManager) processCompleteMessage(s *HTTP2StreamState, isOu
 // checkStreamCompletion decides when a stream is complete (request done + response done with trailers)
 func (sm *DefaultStreamManager) checkStreamCompletion(streamID uint32) {
 	s := sm.streams[streamID]
-	if s == nil || s.isComplete == false {
+	if s == nil || !s.isComplete{
 		// Request considered "done" once END_STREAM seen on request side and headers received.
 		reqDone := s.reqHeadersReceived && s.reqEndStreamReceived
 

--- a/pkg/matcher/grpc/match_test.go
+++ b/pkg/matcher/grpc/match_test.go
@@ -26,7 +26,7 @@ func TestMatch_JSONComparison(t *testing.T) {
 			noiseConfig:    map[string]map[string][]string{},
 			ignoreOrdering: false,
 			expectedMatch:  true,
-			description:    "Should match when JSON data is identical",
+			description:    "Should mcaatch when JSON data is identil",
 		},
 		{
 			name:           "Different JSON responses",
@@ -110,18 +110,18 @@ func TestMatch_JSONComparison(t *testing.T) {
 
 			// Check the result
 			if matched != tt.expectedMatch {
-				t.Errorf("Test %q failed: expected match=%v, got match=%v", tt.name, tt.expectedMatch, matched)
-				t.Errorf("Description: %s", tt.description)
+				t.Fatalf("Test %q failed: expected match=%v, got match=%v\nDescription: %s",
+					tt.name, tt.expectedMatch, matched, tt.description)
 			}
 
 			// Ensure result is not nil
 			if result == nil {
-				t.Errorf("Test %q failed: result should not be nil", tt.name)
+				t.Fatalf("Test %q failed: result should not be nil", tt.name)
 			}
 
 			// Check that body result has the correct data
 			if len(result.BodyResult) == 0 {
-				t.Errorf("Test %q failed: expected body result to be present", tt.name)
+				t.Fatalf("Test %q failed: expected body result to be present", tt.name)
 			} else {
 				// Find the decoded data result
 				var decodedDataResult *models.BodyResult
@@ -133,7 +133,7 @@ func TestMatch_JSONComparison(t *testing.T) {
 				}
 
 				if decodedDataResult == nil {
-					t.Errorf("Test %q failed: expected GrpcData body result to be present", tt.name)
+				    t.Fatalf("Test %q failed: expected GrpcData body result to be present", tt.name)
 				} else if decodedDataResult.Normal != tt.expectedMatch {
 					t.Errorf("Test %q failed: expected body result normal=%v, got normal=%v", tt.name, tt.expectedMatch, decodedDataResult.Normal)
 				}

--- a/pkg/matcher/utils.go
+++ b/pkg/matcher/utils.go
@@ -46,7 +46,7 @@ func getCompiled(pattern string) *regexp.Regexp {
 	compiled, err := regexp.Compile(pattern)
 	if err != nil {
 		// Fallback to a regex that never matches to avoid panics / repeated compiles
-		compiled, _ = regexp.Compile(`(?!)`)
+		compiled, _ = regexp.Compile(`($.^)`)
 	}
 
 	regexCacheMu.Lock()

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -111,11 +111,6 @@ func (r *Replayer) Start(ctx context.Context) error {
 	g, ctx := errgroup.WithContext(ctx)
 	ctx, cancel := context.WithCancel(context.WithValue(ctx, models.ErrGroupKey, g))
 
-	setupErrGrp, _ := errgroup.WithContext(ctx)
-	setupCtx := context.WithoutCancel(ctx)
-	setupCtx, setupCtxCancel := context.WithCancel(setupCtx)
-	setupCtx = context.WithValue(setupCtx, models.ErrGroupKey, setupErrGrp)
-
 	var hookCancel context.CancelFunc
 	var stopReason = "replay completed successfully"
 
@@ -132,12 +127,6 @@ func (r *Replayer) Start(ctx context.Context) error {
 		}
 		cancel()
 		err := g.Wait()
-		if err != nil {
-			utils.LogError(r.logger, err, "failed to stop replaying")
-		}
-
-		setupCtxCancel()
-		err = setupErrGrp.Wait()
 		if err != nil {
 			utils.LogError(r.logger, err, "failed to stop replaying")
 		}

--- a/pkg/service/report/report.go
+++ b/pkg/service/report/report.go
@@ -272,8 +272,7 @@ func (r *Report) printSummary(reports map[string]*models.TestReport) error {
 			var failedList []string
 			for _, t := range rep.Tests {
 				if t.Status == models.TestStatusFailed {
-					label := fmt.Sprintf("%s", t.TestCaseID)
-
+					label := t.TestCaseID
 					// Add risk level if available and not NONE
 					if t.FailureInfo.Risk != "" && t.FailureInfo.Risk != models.None {
 						label += fmt.Sprintf(" [%s-RISK]", t.FailureInfo.Risk)

--- a/pkg/service/utgen/prompt.go
+++ b/pkg/service/utgen/prompt.go
@@ -114,7 +114,7 @@ func formatSection(content, templateText string) (string, error) {
 	}
 	tmpl, err := template.New("section").Parse(templateText)
 	if err != nil {
-		return "", fmt.Errorf("Error parsing section template: %v", err)
+		return "", fmt.Errorf("error parsing section template: %v", err)
 	}
 	var buffer bytes.Buffer
 	err = tmpl.Execute(&buffer, map[string]string{
@@ -123,7 +123,7 @@ func formatSection(content, templateText string) (string, error) {
 		"FailedTestRuns":         content,
 	})
 	if err != nil {
-		return "", fmt.Errorf("Error executing section template: %v", err)
+		return "", fmt.Errorf("error executing section template: %v", err)
 	}
 	return buffer.String(), nil
 }
@@ -159,7 +159,7 @@ func (pb *PromptBuilder) BuildPrompt(file, failedTestRuns string) (*Prompt, erro
 	if err != nil {
 		prompt.System = ""
 		prompt.User = ""
-		return prompt, fmt.Errorf("Error rendering system prompt: %v", err)
+		return prompt, fmt.Errorf("error rendering system prompt: %v", err)
 	}
 	prompt.System = systemPrompt
 
@@ -167,7 +167,7 @@ func (pb *PromptBuilder) BuildPrompt(file, failedTestRuns string) (*Prompt, erro
 	if err != nil {
 		prompt.System = ""
 		prompt.User = ""
-		return prompt, fmt.Errorf("Error rendering user prompt: %v", err)
+		return prompt, fmt.Errorf("error rendering user prompt: %v", err)
 	}
 	userPrompt = html.UnescapeString(userPrompt)
 	prompt.User = userPrompt


### PR DESCRIPTION
## Describe the changes that are made
- Fixed a regex fallback that caused runtime panics by replacing unsupported `(?!)` with RE2-safe `$.^`
- Prevented nil pointer dereferences in gRPC matcher tests by switching fatal assertions to `t.Fatalf`
- Removed unused setup context in replay engine that could cause goroutine leaks
- Removed redundant `fmt.Sprintf` calls and fixed boolean comparison patterns
- Fixed error string capitalization to follow Go conventions
- All staticcheck warnings reported in Issue #3515 are now resolved

---

## Links & References

**Closes:** #3515

### 🔗 Related PRs
- NA

### 🐞 Related Issues
- #3515

### 📄 Related Documents
- NA

---

## What type of PR is this? (check all applicable)
- [x] 🐞 Bug Fix
- [x] 🔥 Performance Improvements
- [x] 🧑‍💻 Code Refactor
- [x] ✅ Test

---

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed

---

## Added comments for hard-to-understand areas?
- [x] 🙅 no, because the code is self-explanatory

---

## Added to documentation?
- [x] 🙅 no documentation needed

---

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

### Steps to verify
```bash
go test ./...
