### PR TITLE
ci: release windows exe instead of tar.gz file

### DIFF
--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -9,8 +9,15 @@ release:
   draft: false
 
 archives:
- -
-    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+  - id: default
+    name_template: >-
+      {{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{- if eq .Os "windows" }}.exe{{- end }}
+    builds:
+      - keploy
+      - keploy-windows
+    format_overrides:
+      - goos: windows
+        format: binary
 
 builds:
   - binary: keploy


### PR DESCRIPTION
This pull request updates the `goreleaser.yaml` configuration to improve how release archives are generated, especially for Windows builds. The changes mainly focus on customizing the archive naming, specifying which binaries to include, and ensuring the correct file format for Windows.

Release packaging improvements:

* Added an `id: default` to the archive configuration and updated the `name_template` to append `.exe` for Windows builds, ensuring Windows binaries have the correct extension.
* Specified the `builds` to include both `keploy` and `keploy-windows` binaries in the release archives.
* Introduced a `format_overrides` section to set the archive format to `binary` specifically for Windows (`goos: windows`), ensuring proper packaging for that platform.