### PR TITLE
ci: remove the double exes in the windows binary

### DIFF
--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -10,8 +10,7 @@ release:
 
 archives:
   - id: default
-    name_template: >-
-      {{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{- if eq .Os "windows" }}.exe{{- end }}
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
     builds:
       - keploy
       - keploy-windows


### PR DESCRIPTION
This pull request updates the archive naming convention in the `goreleaser.yaml` configuration file. The change simplifies the `name_template` by removing the conditional logic that previously appended `.exe` to Windows binaries.

Build and release configuration:

* Simplified the `name_template` in the `archives` section of `goreleaser.yaml` by removing the conditional `.exe` extension for Windows builds. Now, all archives follow the format `{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}` regardless of the operating system.