### PR TITLE
resolved 'pip' missing issue while passing the command to the server …

### DIFF
--- a/pkg/service/utgen/utils.go
+++ b/pkg/service/utgen/utils.go
@@ -195,8 +195,11 @@ func RunCommand(command string, cwd string, logger *zap.Logger) (stdout string, 
 	var cmd *exec.Cmd
 
 	if runtime.GOOS == "windows" {
-		cmdArgs := strings.Fields(command)
-		cmd = exec.Command(cmdArgs[0], cmdArgs[1:]...)
+		// Use cmd.exe /C to properly handle shell operators like ||, &&, etc.
+		cmd = exec.Command("cmd", "/C", command)
+		if cwd != "" {
+			cmd.Dir = cwd
+		}
 	} else {
 		// Create the command with the specified working directory
 		cmd = exec.Command("sh", "-c", command)


### PR DESCRIPTION
Signed-Off-by: Chinmay Anand chinmay27anand@gmail.com

## Describe the changes that are made
Fixed Windows command execution issue in unit test generation where shell operators like `||` (logical OR) and `&&` (logical AND) were not being interpreted correctly, causing pytest installation and other dependency management commands to fail.

**Closes:** #3500 

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [✅] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [✅] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [✅] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [✅] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [✅] 🙅 no, because it is not needed

## Self Review done?
- [✅ ] ✅ yes
- [ ] ❌ no, because I need help

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

## Additional checklist:
- [✅] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [✅] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [✅] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?