### PR TITLE
refactor: eliminate redundant templating pass in SimulateHTTP

### DIFF
--- a/pkg/service/orchestrator/rerecord.go
+++ b/pkg/service/orchestrator/rerecord.go
@@ -425,7 +425,7 @@ func (o *Orchestrator) replayTests(ctx context.Context, testSet string, mappingT
 
 		// Create a rendered copy of testcase with current template/secret values
 		// so that comparison uses concrete expected values (not the templatized form)
-		renderedTC, renderErr := pkg.RenderTestCaseWithTemplates(tc)
+		renderedTC, renderErr := pkg.RenderTestCaseWithTemplates(o.logger, tc)
 		if renderErr != nil {
 			utils.LogError(o.logger, renderErr, "failed to render testcase with templates")
 			// fallback to using the original testcase

--- a/pkg/templating_test.go
+++ b/pkg/templating_test.go
@@ -1,0 +1,149 @@
+package pkg
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.keploy.io/server/v3/utils"
+	"go.uber.org/zap"
+)
+
+func TestRenderTestCaseWithTemplates_890(t *testing.T) {
+	logger := zap.NewNop()
+
+	t.Run("BasicTemplating", func(t *testing.T) {
+		utils.TemplatizedValues = map[string]interface{}{
+			"name": "keploy",
+		}
+		utils.SecretValues = map[string]interface{}{}
+		defer func() {
+			utils.TemplatizedValues = map[string]interface{}{}
+		}()
+
+		tc := &models.TestCase{
+			HTTPReq: models.HTTPReq{
+				URL:  "http://example.com/{{.name}}",
+				Body: `{"key":"{{.name}}"}`,
+			},
+		}
+
+		rendered, err := RenderTestCaseWithTemplates(logger, tc)
+		require.NoError(t, err)
+		assert.Equal(t, "http://example.com/keploy", rendered.HTTPReq.URL)
+		assert.Equal(t, `{"key":"keploy"}`, rendered.HTTPReq.Body)
+	})
+
+	t.Run("SecretTemplating", func(t *testing.T) {
+		utils.TemplatizedValues = map[string]interface{}{}
+		utils.SecretValues = map[string]interface{}{
+			"token": "secret-token",
+		}
+		defer func() {
+			utils.SecretValues = map[string]interface{}{}
+		}()
+
+		tc := &models.TestCase{
+			HTTPReq: models.HTTPReq{
+				Header: map[string]string{
+					"Authorization": "Bearer {{.secret.token}}",
+				},
+			},
+		}
+
+		rendered, err := RenderTestCaseWithTemplates(logger, tc)
+		require.NoError(t, err)
+		assert.Equal(t, "Bearer secret-token", rendered.HTTPReq.Header["Authorization"])
+	})
+
+	t.Run("EncodedURLWithBraces", func(t *testing.T) {
+		utils.TemplatizedValues = map[string]interface{}{
+			"id": "123",
+		}
+		defer func() {
+			utils.TemplatizedValues = map[string]interface{}{}
+		}()
+
+		tc := &models.TestCase{
+			HTTPReq: models.HTTPReq{
+				URL: "http://example.com/users/%7B%7B.id%7D%7D",
+			},
+		}
+
+		rendered, err := RenderTestCaseWithTemplates(logger, tc)
+		require.NoError(t, err)
+		assert.Equal(t, "http://example.com/users/123", rendered.HTTPReq.URL)
+	})
+
+	t.Run("IgnoreNonKeployPlaceholders", func(t *testing.T) {
+		tc := &models.TestCase{
+			HTTPReq: models.HTTPReq{
+				Body: `Value: {{\pi}}`,
+			},
+		}
+
+		rendered, err := RenderTestCaseWithTemplates(logger, tc)
+		require.NoError(t, err)
+		assert.Equal(t, `Value: {{\pi}}`, rendered.HTTPReq.Body)
+	})
+
+	t.Run("NoTemplates", func(t *testing.T) {
+		utils.TemplatizedValues = map[string]interface{}{}
+		utils.SecretValues = map[string]interface{}{}
+
+		tc := &models.TestCase{
+			HTTPReq: models.HTTPReq{
+				URL: "http://example.com/test",
+			},
+		}
+
+		rendered, err := RenderTestCaseWithTemplates(logger, tc)
+		require.NoError(t, err)
+		assert.Equal(t, tc.HTTPReq.URL, rendered.HTTPReq.URL)
+		// Ensure it's a copy
+		rendered.HTTPReq.URL = "changed"
+		assert.NotEqual(t, tc.HTTPReq.URL, rendered.HTTPReq.URL)
+	})
+}
+
+func TestSimulateHTTP_WithTemplating_891(t *testing.T) {
+	logger := zap.NewNop()
+	ctx := context.Background()
+
+	// Mock server to respond to requests
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/keploy", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+
+	utils.TemplatizedValues = map[string]interface{}{
+		"name": "keploy",
+	}
+	defer func() {
+		utils.TemplatizedValues = map[string]interface{}{}
+	}()
+
+	tc := &models.TestCase{
+		Name: "test-templating",
+		HTTPReq: models.HTTPReq{
+			Method: "GET",
+			URL:    server.URL + "/{{.name}}",
+			Header: map[string]string{
+				"Content-Type": "application/json",
+			},
+		},
+	}
+
+	resp, err := SimulateHTTP(ctx, tc, "test-set", logger, 10)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, `{"status":"ok"}`, resp.Body)
+}


### PR DESCRIPTION
This PR refactors the [SimulateHTTP](cci:1://file:///c:/Users/97798/Documents/keploy/pkg/util.go:144:0-300:1) function to remove a redundant marshal/render/unmarshal pass. The templating logic has been consolidated into the [RenderTestCaseWithTemplates](cci:1://file:///c:/Users/97798/Documents/keploy/pkg/util.go:414:0-464:1) helper, which now uses the more robust `utils.RenderTemplatesInString` implementation.

### Key Changes:
- **Consolidated Templating**: Migrated inline templating logic from [SimulateHTTP](cci:1://file:///c:/Users/97798/Documents/keploy/pkg/util.go:144:0-300:1) to [RenderTestCaseWithTemplates](cci:1://file:///c:/Users/97798/Documents/keploy/pkg/util.go:414:0-464:1).
- **Improved Robustness**: Updated [RenderTestCaseWithTemplates](cci:1://file:///c:/Users/97798/Documents/keploy/pkg/util.go:414:0-464:1) to use the centralized `utils.RenderTemplatesInString`, which correctly handles Keploy-specific placeholders while ignoring non-target syntax (like LaTeX).
- **URL Handling**: Added logic to unescape URL-encoded braces (`%7B%7B...%7D%7D`) before rendering, ensuring templates in query parameters and paths are correctly processed.
- **Regression Tests**: Added [pkg/templating_test.go](cci:7://file:///c:/Users/97798/Documents/keploy/pkg/templating_test.go:0:0-0:0) to verify templating behavior, secret injection, and edge cases like encoded URLs.
- **Cleanup**: Removed an unused `html/template` import in [pkg/util.go](cci:7://file:///c:/Users/97798/Documents/keploy/pkg/util.go:0:0-0:0).

Fixes: #3555

## Type of Change
- [x] Refactoring
- [x] Bug fix (handling encoded braces)
- [x] New tests

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes