### PR TITLE
fix(mysql): treat query structure match as score-based instead of exact

### DIFF
--- a/pkg/core/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/core/proxy/integrations/mysql/replayer/match.go
@@ -492,6 +492,19 @@ func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.Packe
 	expectedQuery := getQuery(expected)
 	actualQuery := getQuery(actual)
 
+	// Count placeholders in both queries - this is crucial for PREPARE statements
+	// to ensure we match mocks with the same number of parameters
+	expectedPlaceholders := strings.Count(expectedQuery, "?")
+	actualPlaceholders := strings.Count(actualQuery, "?")
+	if expectedPlaceholders != actualPlaceholders {
+		// log.Debug("placeholder count mismatch",
+		// 	zap.String("expected_query", expectedQuery),
+		// 	zap.String("actual_query", actualQuery),
+		// 	zap.Int("expected_placeholders", expectedPlaceholders),
+		// 	zap.Int("actual_placeholders", actualPlaceholders))
+		return false, 0
+	}
+
 	if actual.Header.Header.PayloadLength == expected.Header.Header.PayloadLength {
 		matchCount++
 		if expectedQuery == actualQuery {


### PR DESCRIPTION
This pull request improves the accuracy of MySQL query matching logic in the replayer integration. The most significant changes focus on ensuring that queries with different numbers of parameter placeholders are not considered matches, and on tightening the criteria for query matching in PREPARE/EXECUTE scenarios.

**Query Matching Improvements:**

* Added a check in `matchQuery` to ensure the number of `?` placeholders matches between the expected and actual queries, preventing mismatches in PREPARE statements.
* Updated `matchStmtExecutePacketQueryAware` to require exact query matches when both queries are present, removing structural matching as a valid match condition. [[1]](diffhunk://#diff-786b053b65b89af45898754fc3fd271ea820e8ee27b2089145ec51d8df08b68eL576-R589) [[2]](diffhunk://#diff-786b053b65b89af45898754fc3fd271ea820e8ee27b2089145ec51d8df08b68eL662-R675)