### PR TITLE
feat(record): auto-calculate test delay during record

### DIFF
--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 
 	"time"
 
@@ -28,6 +29,12 @@ type Recorder struct {
 	testSetConf     TestSetConfig
 	config          *config.Config
 	globalMockCh    chan<- *models.Mock
+	// appStartTime records when the agent is ready and recording can begin
+	appStartTime time.Time
+	// firstHitTime records when the first incoming test case is received
+	firstHitTime time.Time
+	// protects access to the timestamp fields
+	mu sync.Mutex
 }
 
 func New(logger *zap.Logger, testDB TestDB, mockDB MockDB, telemetry Telemetry, instrumentation Instrumentation, testSetConf TestSetConfig, config *config.Config) Service {
@@ -112,6 +119,27 @@ func (r *Recorder) Start(ctx context.Context, reRecordCfg models.ReRecordCfg) er
 		if err != nil {
 			utils.LogError(r.logger, err, "failed to stop recording")
 		}
+
+		// After all goroutines have stopped, compute automatic test delay if possible.
+		// This ensures timestamps are final and avoids races with in-flight frames.
+		r.mu.Lock()
+		start := r.appStartTime
+		first := r.firstHitTime
+		r.mu.Unlock()
+
+		if start.IsZero() == false && first.IsZero() == false {
+			dur := first.Sub(start) + 10*time.Second
+			if dur < 0 {
+				dur = 10 * time.Second
+			}
+			secs := uint64(dur.Seconds())
+			// Only set if user hasn't provided a delay
+			if r.config != nil && r.config.Test.Delay == 0 {
+				r.logger.Info("Auto-calculated test delay applied", zap.Uint64("delay_seconds", secs))
+				r.config.Test.Delay = secs
+			}
+		}
+
 		r.telemetry.RecordedTestSuite(newTestSetID, testCount, mockCountMap)
 	}()
 
@@ -198,6 +226,11 @@ func (r *Recorder) Start(ctx context.Context, reRecordCfg models.ReRecordCfg) er
 
 	r.logger.Info("🟢 Keploy agent is ready to record test cases and mocks.")
 
+	// Record the application start time once agent is ready and before traffic begins
+	r.mu.Lock()
+	r.appStartTime = time.Now()
+	r.mu.Unlock()
+
 	// fetching test cases and mocks from the application and inserting them into the database
 	frames, err := r.GetTestAndMockChans(reqCtx)
 	if err != nil {
@@ -224,6 +257,12 @@ func (r *Recorder) Start(ctx context.Context, reRecordCfg models.ReRecordCfg) er
 	r.mockDB.ResetCounterID() // Reset mock ID counter for each recording session
 	errGrp.Go(func() error {
 		for testCase := range frames.Incoming {
+			// Capture first incoming test case arrival time only once
+			r.mu.Lock()
+			if r.firstHitTime.IsZero() {
+				r.firstHitTime = time.Now()
+			}
+			r.mu.Unlock()
 			testCase.Curl = pkg.MakeCurlCommand(testCase.HTTPReq)
 			if reRecordCfg.TestSet == "" {
 				err := r.testDB.InsertTestCase(ctx, testCase, newTestSetID, true)


### PR DESCRIPTION
### What this PR does

This PR automatically calculates `test.delay` during `keploy record` by measuring
the time between application startup and the first incoming request.

### How it works
- Captures app start time after instrumentation is ready
- Captures first incoming test request timestamp
- Computes delay = (first request time - app start time) + buffer
- Applies delay only if user has not explicitly configured one

### Why this is useful
- Removes manual trial-and-error for `test.delay`
- Improves reliability for first-time users
- Preserves backward compatibility

### Testing
- Ran `go fmt ./pkg/service/record/...`
- Ran `go test ./pkg/service/record/...`
- Verified manually using a Go app with delayed startup
