### PR TITLE
Fixed Panic in Misconfigured MySQL

### DIFF
--- a/pkg/agent/proxy/integrations/mysql/utils/util.go
+++ b/pkg/agent/proxy/integrations/mysql/utils/util.go
@@ -369,7 +369,7 @@ func ParseBinaryDateTime(b []byte) (interface{}, int, error) {
 		return fmt.Sprintf("%04d-%02d-%02d %02d:%02d:%02d.%06d",
 			year, month, day, hour, minute, second, us), 1 + l, nil
 	}
-	panic(fmt.Sprintf("unreachable code reached in ParseBinaryDateTime: unexpected length l=%d", l))
+	return nil, 0, fmt.Errorf("unreachable code in ParseBinaryDateTime: unexpected length l=%d", l)
 }
 
 func validYMDHMS(y, m, d, hh, mm, ss int) bool {


### PR DESCRIPTION
● Describe the changes that are made                                                                                                                                      
                                                                                                                                                                          
  - Replace explicit panic() with graceful error return in ParseBinaryDateTime function (pkg/agent/proxy/integrations/mysql/utils/util.go:372)                            
  - The panic was triggered when an unexpected datetime length was encountered while parsing MySQL binary protocol data                                                   
  - Since MySQL protocol input is untrusted, this panic could crash the entire Keploy agent during record or replay sessions                                              
  - The fix returns an error instead of panicking, allowing the caller to handle the failure gracefully                                                                   
  - All 3 callers of this function already properly check and propagate errors, so this change is backwards compatible                                                    
                                                                                                                                                                          
  Before:                                                                                                                                                                 
  panic(fmt.Sprintf("unreachable code reached in ParseBinaryDateTime: unexpected length l=%d", l))                                                                        
                                                                                                                                                                          
  After:                                                                                                                                                                  
  return nil, 0, fmt.Errorf("unreachable code in ParseBinaryDateTime: unexpected length l=%d", l)                                                                         
                                                                                                                                                                          
  Links & References                                                                                                                                                      
                                                                                                                                                                          
  Closes: #3569                                                                                                                                                           
                                                                                                                                                                          
  🔗 Related PRs                                                                                                                                                          
                                                                                                                                                                          
  - NA                                                                                                                                                                    
                                                                                                                                                                          
  🐞 Related Issues                                                                                                                                                       
                                                                                                                                                                          
  - NA                                                                                                                                                                    
                                                                                                                                                                          
  📄 Related Documents                                                                                                                                                    
                                                                                                                                                                          
  - NA                                                                                                                                                                    
                                                                                                                                                                          
  What type of PR is this? (check all applicable)                                                                                                                         
                                                                                                                                                                          
  - 📦 Chore                                                                                                                                                              
  - 🍕 Feature                                                                                                                                                            
  - 🐞 Bug Fix                                                                                                                                                            
  - 📝 Documentation Update                                                                                                                                               
  - 🎨 Style                                                                                                                                                              
  - 🧑‍💻 Code Refactor                                                                                                                                                      
  - 🔥 Performance Improvements                                                                                                                                           
  - ✅ Test                                                                                                                                                               
  - 🔁 CI                                                                                                                                                                 
  - ⏩ Revert                                                                                                                                                             
                                                                                                                                                                          
  Added e2e test pipeline?                                                                                                                                                
                                                                                                                                                                          
  - 👍 yes                                                                                                                                                                
  - 🙅 no, because they aren't needed                                                                                                                                     
                                                                                                                                                                          
  Added comments for hard-to-understand areas?                                                                                                                            
                                                                                                                                                                          
  - 🙅 no, because the code is self-explanatory                                                                                                                           
                                                                                                                                                                          
  Added to documentation?                                                                                                                                                 
                                                                                                                                                                          
  - 🙅 no documentation needed                                                                                                                                            
                                                                                                                                                                          
  Are there any sample code or steps to test the changes?                                                                                                                 
                                                                                                                                                                          
  - 👍 yes, mentioned below                                                                                                                                               
                                                                                                                                                                          
  Run the existing MySQL tests to verify:                                                                                                                                 
  go test ./pkg/agent/proxy/integrations/mysql/... -v                                                                                                                     
                                                                                                                                                                          
  All tests pass including panic resilience tests in panic_fix_test.go.                                                                                                   
                                                                                                                                                                          
  Self Review done?                                                                                                                                                       
                                                                                                                                                                          
  - ✅ yes                                                                                                                                                                
                                                                                                                                                                          
  Any relevant screenshots, recordings or logs?                                                                                                                           
                                                                                                                                                                          
  - NA                                                                                                                                                                    
                                                                                                                                                                          
  🧠 Semantics for PR Title & Branch Name                                                                                                                                 
                                                                                                                                                                          
  Suggested PR Title: fix: replace panic with error return in MySQL ParseBinaryDateTime                                                                                   
                                                                                                                                                                          
  Suggested Branch Name: fix/#3569-mysql-datetime-panic                                                                                                                   
                                                                                                                                                                          
  ---                                                                                                                                                                     
  Additional checklist:                                                                                                                                                   
                                                                                                                                                                          
  - Have you read the https://keploy.io/docs/keploy-explained/contribution-guide/?                                                                                        
  - Have you followed the https://github.com/keploy/keploy/wiki/PR-Semantics for naming this PR?                                                                          
  - Have you followed the https://github.com/keploy/keploy/wiki/Branch-Semantics for naming your branch?