### PR TITLE
fix: move reqTimestamp initialization after ReadRequest in incoming proxy

### DIFF
--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -56,7 +56,6 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 	upstreamReader := bufio.NewReader(upConn)
 
 	for {
-		reqTimestamp := time.Now()
 
 		req, err := http.ReadRequest(clientReader)
 		if err != nil {
@@ -67,6 +66,8 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 			}
 			return
 		}
+		reqTimestamp := time.Now()
+
 		var chunked bool = false
 
 		// SYNCHRONOUS : Disable Keep-Alive for the Upstream


### PR DESCRIPTION
This pull request makes a small change to the request timestamp assignment in the `handleHttp1Connection` function. The timestamp is now set immediately after successfully reading the HTTP request, rather than before. This ensures the timestamp more accurately reflects when the request was received.

* Moved the assignment of `reqTimestamp` to occur after successfully reading the HTTP request in `pkg/agent/proxy/incoming/http.go`, improving accuracy of request timing. [[1]](diffhunk://#diff-d194a5848bf3cb7f6fd624721e635dcc272ba8b4c9022b16631ca8fe3f40c2b0L59) [[2]](diffhunk://#diff-d194a5848bf3cb7f6fd624721e635dcc272ba8b4c9022b16631ca8fe3f40c2b0R69-R70)
 

## Links & References

**Closes:** #[issue number that will be closed through this PR]
- NA (if very small change like typo, linting, etc.)

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [x] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

## Self Review done?
- [ ] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?