### PR TITLE
fix: increase time for agent health

### DIFF
--- a/pkg/platform/docker/docker.go
+++ b/pkg/platform/docker/docker.go
@@ -704,7 +704,7 @@ func (idc *Impl) GenerateKeployAgentService(opts models.SetupOptions) (*yaml.Nod
 
 			// retries
 			{Kind: yaml.ScalarNode, Value: "retries"},
-			{Kind: yaml.ScalarNode, Value: "6"},
+			{Kind: yaml.ScalarNode, Value: "60"},
 
 			// start_period
 			{Kind: yaml.ScalarNode, Value: "start_period"},


### PR DESCRIPTION
This pull request increases the retry count for the Keploy agent service in the Docker setup from 6 to 60. This change will allow the service to make more attempts before failing, potentially improving reliability during startup.

- Docker service configuration:
  * Increased the `retries` value from 6 to 60 in the Keploy agent service configuration within the `GenerateKeployAgentService` function in `docker.go`.