### PR TITLE
fix: correct typos in eBPF hooks code

### DIFF
--- a/pkg/agent/hooks/linux/comm.go
+++ b/pkg/agent/hooks/linux/comm.go
@@ -72,7 +72,7 @@ func (h *Hooks) SendClientInfo(clientInfo structs.ClientInfo) error {
 
 func (h *Hooks) SendAgentInfo(agentInfo structs.AgentInfo) error {
 	key := 0
-	err := h.agentRegistartionMap.Update(uint32(key), agentInfo, ebpf.UpdateAny)
+	err := h.agentRegistrationMap.Update(uint32(key), agentInfo, ebpf.UpdateAny)
 	if err != nil {
 		utils.LogError(h.logger, err, "failed to send the agent info to the ebpf program")
 		return err

--- a/pkg/agent/hooks/linux/hooks.go
+++ b/pkg/agent/hooks/linux/hooks.go
@@ -57,10 +57,10 @@ type Hooks struct {
 	objectsMutex sync.RWMutex // Protects eBPF objects during load/unload operations
 	// eBPF C shared maps
 	clientRegistrationMap *ebpf.Map
-	agentRegistartionMap  *ebpf.Map
+	agentRegistrationMap  *ebpf.Map
 	redirectProxyMap      *ebpf.Map
 
-	// eBPF C shared objectsobjects
+	// eBPF C shared objects
 	// ebpf objects and events
 	socket     link.Link
 	connect4   link.Link
@@ -128,7 +128,7 @@ func (h *Hooks) load(ctx context.Context, opts agent.HookCfg, setupOpts config.A
 	//getting all the ebpf maps with proper synchronization
 	h.objectsMutex.Lock()
 	h.clientRegistrationMap = objs.KeployClientRegistrationMap
-	h.agentRegistartionMap = objs.KeployAgentRegistrationMap
+	h.agentRegistrationMap = objs.KeployAgentRegistrationMap
 	h.objects = objs
 	h.objectsMutex.Unlock()
 	// ---------------


### PR DESCRIPTION
## PR Title: fix: correct typos in eBPF hooks code

## Branch Name: fix/typo-ebpf-hooks

## Describe the changes that are made
- Fixed typo `agentRegistartionMap` → `agentRegistrationMap` in variable name (hooks.go and comm.go)
- Fixed duplicate word in comment `// eBPF C shared objectsobjects` → `// eBPF C shared objects` (hooks.go)

## Links & References

**Closes:** NA (small typo fix)

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [x] 📦 Chore
- [ ] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [x] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed

## Added comments for hard-to-understand areas?
- [x] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 🙅 no, because it is not needed

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA

## Files Changed:
- `pkg/agent/hooks/linux/hooks.go` (lines 60, 63, 131)
- `pkg/agent/hooks/linux/comm.go` (line 75)

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?
