### PR TITLE
feat: improve error messages for network proxy failures with actionab…

### DIFF
--- a/pkg/agent/proxy/dns.go
+++ b/pkg/agent/proxy/dns.go
@@ -31,7 +31,13 @@ func (p *Proxy) startTCPDNSServer(_ context.Context) error {
 	p.logger.Info(fmt.Sprintf("starting TCP DNS server at addr %v", server.Addr))
 	err := server.ListenAndServe()
 	if err != nil {
-		utils.LogError(p.logger, err, "failed to start tcp dns server", zap.String("addr", server.Addr))
+		errMsg := "failed to start TCP DNS server"
+		if strings.Contains(err.Error(), "address already in use") {
+			errMsg = fmt.Sprintf("failed to start TCP DNS server: port %v is already in use. Try: 1) Check if another process is using this port with 'lsof -i :%v' 2) Stop the conflicting process or 3) Use a different DNS port with --dnsPort flag", p.DNSPort, p.DNSPort)
+		} else if strings.Contains(err.Error(), "permission denied") {
+			errMsg = fmt.Sprintf("failed to start TCP DNS server: permission denied on port %v. Try: 1) Run with sudo if using port < 1024 or 2) Use a higher port number with --dnsPort flag", p.DNSPort)
+		}
+		utils.LogError(p.logger, err, errMsg, zap.String("addr", server.Addr))
 	}
 	return nil
 }
@@ -54,7 +60,13 @@ func (p *Proxy) startUDPDNSServer(_ context.Context) error {
 	p.logger.Info(fmt.Sprintf("starting UDP DNS server at addr %v", server.Addr))
 	err := server.ListenAndServe()
 	if err != nil {
-		utils.LogError(p.logger, err, "failed to start udp dns server", zap.String("addr", server.Addr))
+		errMsg := "failed to start UDP DNS server"
+		if strings.Contains(err.Error(), "address already in use") {
+			errMsg = fmt.Sprintf("failed to start UDP DNS server: port %v is already in use. Try: 1) Check if another process is using this port with 'lsof -i :%v' 2) Stop the conflicting process or 3) Use a different DNS port with --dnsPort flag", p.DNSPort, p.DNSPort)
+		} else if strings.Contains(err.Error(), "permission denied") {
+			errMsg = fmt.Sprintf("failed to start UDP DNS server: permission denied on port %v. Try: 1) Run with sudo if using port < 1024 or 2) Use a higher port number with --dnsPort flag", p.DNSPort)
+		}
+		utils.LogError(p.logger, err, errMsg, zap.String("addr", server.Addr))
 		return err
 	}
 	return nil


### PR DESCRIPTION
## PR Title: feat: improve error messages for network proxy failures with actionable solutions

## Branch Name: feat/improve-proxy-error-messages

## Describe the changes that are made
- Improved proxy startup error messages to include actionable troubleshooting steps
- Added specific error handling for "address already in use" errors with commands to diagnose
- Added specific error handling for "permission denied" errors with solutions
- Enhanced TCP/UDP DNS server error messages with clear remediation steps
- Users now receive clear guidance on how to fix common proxy startup issues

## Links & References

**Closes:** #3620

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- https://github.com/keploy/keploy/issues/3620
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [x] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [x] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed

## Added comments for hard-to-understand areas?
- [x] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

### Steps to verify:
1. Run `go build -race -tags=viper_bind_struct -o keploy .` - should compile successfully
2. Run `go test ./pkg/agent/proxy/... -v` - all tests should pass
3. Try starting keploy on a port that's already in use to see the improved error message

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA

## Files Changed:
- `pkg/agent/proxy/proxy.go` (lines 224-231)
- `pkg/agent/proxy/dns.go` (lines 32-42, 61-72)

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?