### PR TITLE
fix: update GoReleaser version and args for release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,8 +96,10 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: v1.26.2
-          args: release --rm-dist --skip-validate
+          # Updated to v2.5.0 as requested
+          version: v2.5.0
+          # Updated args: --rm-dist is deprecated in v2, using --clean instead
+          args: release --clean --skip-validate
         env:
           AC_PROVIDER: ${{ secrets.APPLE_ACCOUNT_TEAM_ID }}
           AC_PASSWORD: ${{ secrets.APPLE_ACCOUNT_PASSWORD }}

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -1,9 +1,11 @@
 # GoReleaser configuration
-release:
-  # Do not mark release as latest automatically
-  # This allows manual control via GitHub UI
-  make_latest: false
+version: 2
 
+release:
+  # FORCE "Not Latest". 
+  # GoReleaser will not mark this release as "Latest" on GitHub.
+  make_latest: false
+  
 archives:
  -
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"


### PR DESCRIPTION
This pull request updates the GoReleaser configuration to use the latest major version (v2) and aligns both the configuration file and GitHub Actions workflow accordingly. The changes ensure compatibility with GoReleaser v2 and update deprecated arguments.

GoReleaser version and configuration updates:

* Updated the GoReleaser GitHub Action in `.github/workflows/release.yml` to use version `v2.5.0` and replaced the deprecated `--rm-dist` argument with `--clean` for compatibility with v2.
* Updated `goreleaser.yaml` to specify `version: 2`, ensuring the configuration is compatible with GoReleaser v2.

Release behavior:

* Clarified and enforced that releases will not be marked as "Latest" on GitHub by setting `make_latest: false` in `goreleaser.yaml`.