### PR TITLE
Fix/windows no shell dependency

### DIFF
--- a/pkg/matcher/utils.go
+++ b/pkg/matcher/utils.go
@@ -48,7 +48,6 @@ func getCompiled(pattern string) *regexp.Regexp {
 		// Fallback to a regex that never matches to avoid panics / repeated compiles
 		compiled, _ = regexp.Compile(`$.^`)
 	}
-
 	regexCacheMu.Lock()
 	// Double-check to avoid races.
 	if old := regexCache[pattern]; old == nil {

--- a/pkg/platform/docker/docker_windows_test.go
+++ b/pkg/platform/docker/docker_windows_test.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package docker
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func TestPrepareDockerCommand_Windows(t *testing.T) {
+	ctx := context.Background()
+	cmd := PrepareDockerCommand(ctx, "docker version")
+
+	bin := filepath.Base(cmd.Path)
+
+	if bin == "cmd.exe" || bin == "powershell.exe" {
+		t.Fatalf("PrepareDockerCommand should not use shell binaries, got: %s", cmd.Path)
+	}
+}


### PR DESCRIPTION
## Describe the changes that are made
- Fixed Windows-native Docker command execution by removing the hard dependency on `cmd.exe` / `powershell.exe`.
- Docker commands are now invoked directly using `exec.CommandContext` instead of relying on a shell.
- Added a Windows-specific unit test to ensure shell executables are not used for Docker commands.

## Links & References

**Closes:** #3571

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- 3571
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [X] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [X] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [X] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [X] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

## Self Review done?
- [X] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name
PR Title: fix(windows): remove hard dependency on cmd.exe and powershell.exe
Branch Name: fix/windows-no-shell-dependency

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [X] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [X] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [X] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?