### PR TITLE
feat: auto re-exec with sudo for Docker commands

### DIFF
--- a/.github/workflows/test_workflow_scripts/fuzzer/grpc/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/fuzzer/grpc/golang-linux.sh
@@ -41,7 +41,7 @@ command -v curl >/dev/null 2>&1 || { echo "curl not found"; exit 1; }
 
 # Generate keploy config and add duration_ms noise to avoid timing diffs
 rm -f ./keploy.yml keploy
-sudo -E env PATH="$PATH" "$RECORD_BIN" config --generate
+"$RECORD_BIN" config --generate
 config_file="./keploy.yml"
 if [ -f "$config_file" ]; then
   sed -i 's/global: {}/global: {"body": {"duration_ms":[]}}/' "$config_file"
@@ -132,9 +132,9 @@ if [ "$MODE" = "incoming" ]; then
 
   # Start server with keploy in record mode
   if [[ "$RECORD_SRC" == "latest" ]]; then
-    sudo -E env PATH="$PATH" "$RECORD_BIN" record -c "$FUZZER_SERVER_BIN" $BIG_PAYLOAD_FLAG 2>&1 | tee record_incoming.txt &
+    "$RECORD_BIN" record -c "$FUZZER_SERVER_BIN" $BIG_PAYLOAD_FLAG 2>&1 | tee record_incoming.txt &
   else
-    sudo -E env PATH="$PATH" "$RECORD_BIN" record -c "$FUZZER_SERVER_BIN" 2>&1 | tee record_incoming.txt &
+    "$RECORD_BIN" record -c "$FUZZER_SERVER_BIN" 2>&1 | tee record_incoming.txt &
   fi
  
  sleep 10
@@ -193,7 +193,7 @@ if [ "$MODE" = "incoming" ]; then
 
 
  # Replay
- sudo -E env PATH="$PATH" "$REPLAY_BIN" test -c "$FUZZER_SERVER_BIN" --api-timeout=200 --skip-coverage=true --disableMockUpload 2>&1 | tee test_incoming.txt
+ "$REPLAY_BIN" test -c "$FUZZER_SERVER_BIN" --api-timeout=200 --skip-coverage=true --disableMockUpload 2>&1 | tee test_incoming.txt
  echo "checking for errors"
  check_for_errors test_incoming.txt
  check_test_report
@@ -242,7 +242,7 @@ elif [ "$MODE" = "outgoing" ]; then
 
 
  # Record the client (it makes outgoing RPCs)
- sudo -E env PATH="$PATH" "$RECORD_BIN" record -c "$FUZZER_CLIENT_BIN --http :18080" 2>&1 | tee record_outgoing.txt &
+ "$RECORD_BIN" record -c "$FUZZER_CLIENT_BIN --http :18080" 2>&1 | tee record_outgoing.txt &
  sleep 10
 
  echo "Waiting for client to listen on 18080..."
@@ -284,7 +284,7 @@ elif [ "$MODE" = "outgoing" ]; then
 
 
  # Replay the client (relying on mocks)
- sudo -E env PATH="$PATH" "$REPLAY_BIN" test -c "$FUZZER_CLIENT_BIN --http :18080" --skip-coverage=true --disableMockUpload 2>&1 | tee test_outgoing.txt
+ "$REPLAY_BIN" test -c "$FUZZER_CLIENT_BIN --http :18080" --skip-coverage=true --disableMockUpload 2>&1 | tee test_outgoing.txt
  echo "checking for errors"
  check_for_errors test_outgoing.txt
  check_test_report

--- a/.github/workflows/test_workflow_scripts/fuzzer/mongo/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/fuzzer/mongo/golang-linux.sh
@@ -214,7 +214,7 @@ endsec
 # --- Recording Phase ---
 section "Start Recording Server"
 # The command includes the fuzzer binary and its specific arguments
-sudo -E env PATH="$PATH" "$RECORD_KEPLOY_BIN" record -c "$MONGO_FUZZER_BIN" 2>&1 | tee record.txt &
+"$RECORD_KEPLOY_BIN" record -c "$MONGO_FUZZER_BIN" 2>&1 | tee record.txt &
 KEPLOY_PID=$!
 echo "Keploy record process started with PID: $KEPLOY_PID"
 endsec
@@ -251,7 +251,7 @@ sleep 5
 section "Replaying Tests"
 cd $GO_FUZZERS_PATH
 # The test command must match the record command
-sudo -E env PATH="$PATH" "$REPLAY_KEPLOY_BIN" test -c "$MONGO_FUZZER_BIN" --mongoPassword "password" --delay 10 --api-timeout=3000 2>&1 | tee test.txt &
+"$REPLAY_KEPLOY_BIN" test -c "$MONGO_FUZZER_BIN" --mongoPassword "password" --delay 10 --api-timeout=3000 2>&1 | tee test.txt &
 TEST_PID=$!
 echo "Keploy test process started with PID: $TEST_PID"
 wait $TEST_PID

--- a/.github/workflows/test_workflow_scripts/fuzzer/mysql/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/fuzzer/mysql/golang-linux.sh
@@ -192,7 +192,7 @@ endsec
 
 # --- Recording Phase ---
 section "Start Recording Server"
-sudo -E env PATH="$PATH" "$RECORD_KEPLOY_BIN" record -c "$MYSQL_FUZZER_BIN" 2>&1 | tee record.txt &
+"$RECORD_KEPLOY_BIN" record -c "$MYSQL_FUZZER_BIN" 2>&1 | tee record.txt &
 KEPLOY_PID=$!
 echo "Keploy record process started with PID: $KEPLOY_PID"
 endsec
@@ -224,7 +224,7 @@ endsec
 
 # --- Replay Phase ---
 section "Replaying Tests"
-sudo -E env PATH="$PATH" "$REPLAY_KEPLOY_BIN" test -c "$MYSQL_FUZZER_BIN" --delay 15 --api-timeout=1000 2>&1 | tee test.txt
+"$REPLAY_KEPLOY_BIN" test -c "$MYSQL_FUZZER_BIN" --delay 15 --api-timeout=1000 2>&1 | tee test.txt
 check_for_errors "test.txt"
 check_test_report
 endsec

--- a/.github/workflows/test_workflow_scripts/fuzzer/postgres/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/fuzzer/postgres/golang-linux.sh
@@ -220,7 +220,7 @@ endsec
 
 # --- Recording Phase ---
 section "Start Recording Server"
-sudo -E env PATH="$PATH" "$RECORD_KEPLOY_BIN" record -c "$POSTGRES_FUZZER_BIN" 2>&1 | tee record.txt &
+"$RECORD_KEPLOY_BIN" record -c "$POSTGRES_FUZZER_BIN" 2>&1 | tee record.txt &
 KEPLOY_PID=$!
 echo "Keploy record process started with PID: $KEPLOY_PID"
 endsec
@@ -267,7 +267,7 @@ endsec
 
 # --- Replay Phase ---
 section "Replaying Tests"
-sudo -E env PATH="$PATH" "$REPLAY_KEPLOY_BIN" test -c "$POSTGRES_FUZZER_BIN" --delay 15 --api-timeout=1000 2>&1 | tee test.txt
+"$REPLAY_KEPLOY_BIN" test -c "$POSTGRES_FUZZER_BIN" --delay 15 --api-timeout=1000 2>&1 | tee test.txt
 check_for_errors "test.txt"
 check_test_report
 endsec

--- a/.github/workflows/test_workflow_scripts/fuzzer/rerecord/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/fuzzer/rerecord/golang-linux.sh
@@ -55,7 +55,7 @@ sudo $RECORD_KEPLOY_BIN config --generate
 # --- 1. Record Phase ---
 section "Start Recording Server"
 # Start keploy record in the background using the RECORD binary
-sudo -E env PATH="$PATH" $RECORD_KEPLOY_BIN record -c $RERECORD_SERVER_BIN > record.log 2>&1 | tee record.log &
+$RECORD_KEPLOY_BIN record -c $RERECORD_SERVER_BIN > record.log 2>&1 | tee record.log &
 KEPLOY_PID=$!
 echo "Keploy record process started with PID: $KEPLOY_PID"
 endsec

--- a/.github/workflows/test_workflow_scripts/golang/echo_mysql/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/echo_mysql/golang-linux.sh
@@ -101,7 +101,7 @@ run_record_iteration() {
   sudo rm -f /tmp/keploy-logs.txt
 
   # Start recording in background so we capture its PID explicitly
-  sudo -E env PATH="$PATH" "$RECORD_BIN" record -c "./urlShort" --generateGithubActions=false \
+  "$RECORD_BIN" record -c "./urlShort" --generateGithubActions=false \
     2>&1 | tee "${app_name}.txt" & 
   local KEPLOY_PID=$!
 
@@ -189,7 +189,7 @@ set +e
 
 sudo rm -f /tmp/keploy-logs.txt
 
-sudo -E env PATH="$PATH" "$REPLAY_BIN" test -c "./urlShort" --delay 7 --generateGithubActions=false \
+"$REPLAY_BIN" test -c "./urlShort" --delay 7 --generateGithubActions=false \
   2>&1 | tee test_logs.txt || true
 REPLAY_RC=$?
 set -e

--- a/.github/workflows/test_workflow_scripts/golang/echo_sql/golang-docker.sh
+++ b/.github/workflows/test_workflow_scripts/golang/echo_sql/golang-docker.sh
@@ -9,7 +9,7 @@ docker compose build
 sudo rm -rf keploy/
 
 # Generate the keploy-config file.
-sudo -E env PATH=$PATH $RECORD_BIN config --generate
+$RECORD_BIN config --generate
 
 # Update the global noise to ts in the config file.
 config_file="./keploy.yml"
@@ -60,7 +60,7 @@ for i in {1..2}; do
     container_name="echoApp"
     send_request &
     # get_container_health &
-    sudo -E env PATH=$PATH $RECORD_BIN record -c "docker compose up" --container-name "$container_name" --generateGithubActions=false |& tee "${container_name}.txt"
+    $RECORD_BIN record -c "docker compose up" --container-name "$container_name" --generateGithubActions=false |& tee "${container_name}.txt"
 
     if grep "WARNING: DATA RACE" "${container_name}.txt"; then
         echo "Race condition detected in recording, stopping pipeline..."
@@ -85,7 +85,7 @@ echo "Services stopped - Keploy should now use mocks for dependency interactions
 
 # Start keploy in test mode.
 test_container="echoApp"
-sudo -E env PATH=$PATH $REPLAY_BIN test -c 'docker compose up' --containerName "$test_container" --apiTimeout 60 --delay 15 --generate-github-actions=false &> "${test_container}.txt"
+$REPLAY_BIN test -c 'docker compose up' --containerName "$test_container" --apiTimeout 60 --delay 15 --generate-github-actions=false &> "${test_container}.txt"
 
 if grep "ERROR" "${test_container}.txt"; then
     echo "Error found in pipeline..."

--- a/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-docker.sh
+++ b/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-docker.sh
@@ -7,7 +7,7 @@ docker network create keploy-network
 docker run --name mongoDb --rm --net keploy-network -p 27017:27017 -d mongo
 
 # Generate the keploy-config file.
-sudo -E env PATH=$PATH $RECORD_BIN config --generate
+$RECORD_BIN config --generate
 
 # Update the global noise to ts.
 config_file="./keploy.yml"
@@ -77,7 +77,7 @@ send_request(){
 for i in {1..2}; do
     container_name="ginApp_${i}"
     send_request &
-    sudo -E env PATH=$PATH $RECORD_BIN record -c "docker run -p 8080:8080 --net keploy-network --rm --name $container_name gin-mongo" --container-name "$container_name"    &> "${container_name}.txt"
+    $RECORD_BIN record -c "docker run -p 8080:8080 --net keploy-network --rm --name $container_name gin-mongo" --container-name "$container_name"    &> "${container_name}.txt"
 
     if grep "WARNING: DATA RACE" "${container_name}.txt"; then
         echo "Race condition detected in recording, stopping pipeline..."
@@ -102,7 +102,7 @@ echo "MongoDB stopped - Keploy should now use mocks for database interactions"
 
 # Start the keploy in test mode.
 test_container="ginApp_test"
-sudo -E env PATH=$PATH $REPLAY_BIN test -c 'docker run -p 8080:8080 --net keploy-network --name ginApp_test gin-mongo' --containerName "$test_container" --apiTimeout 60 --delay 20 --generate-github-actions=false &> "${test_container}.txt"
+$REPLAY_BIN test -c 'docker run -p 8080:8080 --net keploy-network --name ginApp_test gin-mongo' --containerName "$test_container" --apiTimeout 60 --delay 20 --generate-github-actions=false &> "${test_container}.txt"
 
 if grep "ERROR" "${test_container}.txt"; then
     echo "Error found in pipeline..."

--- a/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-linux.sh
@@ -87,7 +87,7 @@ send_request(){
 
 for i in {1..2}; do
     app_name="javaApp_${i}"
-    sudo -E env PATH="$PATH" "$RECORD_BIN" record -c "./ginApp"  \
+    "$RECORD_BIN" record -c "./ginApp"  \
     > "${app_name}.txt" 2>&1 &
     
     KEPLOY_PID=$!
@@ -117,7 +117,7 @@ docker rm mongoDb || true
 echo "MongoDB stopped - Keploy should now use mocks for database interactions"
 
 # Start the gin-mongo app in test mode.
-sudo -E env PATH="$PATH" "$REPLAY_BIN" test -c "./ginApp" --delay 7    &> test_logs.txt
+"$REPLAY_BIN" test -c "./ginApp" --delay 7    &> test_logs.txt
 
 cat test_logs.txt || true
 

--- a/.github/workflows/test_workflow_scripts/golang/go-grpc/grpc-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/go-grpc/grpc-linux.sh
@@ -160,13 +160,13 @@ kill_keploy_process() {
 
 # Reset state before each run
 rm -rf ./keploy*
-sudo -E env PATH="$PATH" "$RECORD_BIN" config --generate
+"$RECORD_BIN" config --generate
 
 if [ "$MODE" = "incoming" ]; then
     echo "🧪 Testing incoming gRPC requests (testing grpc-server)"
     # Record: Keploy wraps the server to capture incoming gRPC calls. The client is just a driver.
     ./grpc-client &> client_incoming.log &
-    sudo -E env PATH="$PATH" "$RECORD_BIN" record -c "./grpc-server" --generateGithubActions=false 2>&1 | tee record_incoming.log &
+    "$RECORD_BIN" record -c "./grpc-server" --generateGithubActions=false 2>&1 | tee record_incoming.log &
     wait_for_port 50051
 
     sleep 5
@@ -181,7 +181,7 @@ if [ "$MODE" = "incoming" ]; then
     check_for_errors record_incoming.log
 
     # Test: Keploy replays the captured gRPC calls against the server.
-    sudo -E env PATH="$PATH" "$REPLAY_BIN" test -c "./grpc-server" --generateGithubActions=false  --disableMockUpload 2>&1 | tee test_incoming.log || true
+    "$REPLAY_BIN" test -c "./grpc-server" --generateGithubActions=false  --disableMockUpload 2>&1 | tee test_incoming.log || true
 
     check_for_errors test_incoming.log
     if ! check_test_report; then
@@ -196,7 +196,7 @@ elif [ "$MODE" = "outgoing" ]; then
     # Record: Keploy wraps the client to capture its outgoing gRPC calls. The server is a dependency.
     ./grpc-server &> server_outgoing.log &
     wait_for_port 50051
-    sudo -E env PATH="$PATH" "$RECORD_BIN" record -c "./grpc-client" --generateGithubActions=false 2>&1 | tee record_outgoing.log &
+    "$RECORD_BIN" record -c "./grpc-client" --generateGithubActions=false 2>&1 | tee record_outgoing.log &
 
     send_requests
     sleep 15 # Allow time for traces to be recorded
@@ -208,7 +208,7 @@ elif [ "$MODE" = "outgoing" ]; then
     check_for_errors record_outgoing.log
 
     # Test: Keploy mocks the server's responses for the client. The real server is NOT run.
-    sudo -E env PATH="$PATH" "$REPLAY_BIN" test -c "./grpc-client" --generateGithubActions=false --disableMockUpload 2>&1 | tee test_outgoing.log || true
+    "$REPLAY_BIN" test -c "./grpc-client" --generateGithubActions=false --disableMockUpload 2>&1 | tee test_outgoing.log || true
 
     check_for_errors test_outgoing.log
     if ! check_test_report; then

--- a/.github/workflows/test_workflow_scripts/golang/grpc-secret/grpc-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/grpc-secret/grpc-linux.sh
@@ -239,7 +239,7 @@ echo "🧪 Starting gRPC Secret Sanitize Testing"
 # Reset state before each run
 cleanup
 rm -rf ./keploy*
-sudo -E env PATH="$PATH" "$RECORD_BIN" config --generate
+"$RECORD_BIN" config --generate
 sleep 3
 
 go build -o grpc-secret .
@@ -255,7 +255,7 @@ for i in 1 2; do
     echo "Recording iteration $i..."
     
     # Start keploy record in background
-    sudo -E env PATH="$PATH" "$RECORD_BIN" record -c "./grpc-secret" --generateGithubActions=false 2>&1 | tee ${app_name}.txt &
+    "$RECORD_BIN" record -c "./grpc-secret" --generateGithubActions=false 2>&1 | tee ${app_name}.txt &
     
     # Send all 4 gRPC requests
     send_grpc_requests &
@@ -275,7 +275,7 @@ done
 
 # --- Run keploy test (before sanitize) ---
 echo "🧪 Phase 2: Running keploy test (before sanitize)..."
-sudo -E env PATH="$PATH" "$REPLAY_BIN" test -c "./grpc-secret" --delay 10 --generateGithubActions=false 2>&1 | tee test_before_sanitize.txt || true
+"$REPLAY_BIN" test -c "./grpc-secret" --delay 10 --generateGithubActions=false 2>&1 | tee test_before_sanitize.txt || true
 
 # Check for errors and race conditions
 check_for_errors test_before_sanitize.txt
@@ -289,7 +289,7 @@ fi
 
 # --- Run keploy sanitize ---
 echo "🧹 Phase 3: Running keploy sanitize..."
-sudo -E env PATH="$PATH" "$RECORD_BIN" sanitize 2>&1 | tee sanitize_logs.txt
+"$RECORD_BIN" sanitize 2>&1 | tee sanitize_logs.txt
 
 # Check for errors and race conditions
 check_for_errors sanitize_logs.txt
@@ -299,7 +299,7 @@ echo "✅ Sanitization complete"
 
 # --- Run keploy test (after sanitize) ---
 echo "🧪 Phase 4: Running keploy test (after sanitize)..."
-sudo -E env PATH="$PATH" "$REPLAY_BIN" test -c "./grpc-secret" --delay 10 --generateGithubActions=false 2>&1 | tee test_after_sanitize.txt || true
+"$REPLAY_BIN" test -c "./grpc-secret" --delay 10 --generateGithubActions=false 2>&1 | tee test_after_sanitize.txt || true
 
 # Check for errors and race conditions
 check_for_errors test_after_sanitize.txt

--- a/.github/workflows/test_workflow_scripts/golang/http_pokeapi/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/http_pokeapi/golang-linux.sh
@@ -71,7 +71,7 @@ send_request() {
 for i in {1..2}; do
     app_name="http-pokeapi_${i}"
     send_request $i &
-    sudo -E env PATH="$PATH" "$RECORD_BIN" record -c "./http-pokeapi" --generateGithubActions=false &> "${app_name}.txt"
+    "$RECORD_BIN" record -c "./http-pokeapi" --generateGithubActions=false &> "${app_name}.txt"
     if grep "ERROR" "${app_name}.txt"; then
         echo "Error found in pipeline..."
         cat "${app_name}.txt"
@@ -88,7 +88,7 @@ for i in {1..2}; do
 done
 
 # Start the go-http app in test mode.
-sudo -E env PATH="$PATH" "$REPLAY_BIN" test -c "./http-pokeapi" --delay 7 --generateGithubActions=false &> test_logs.txt
+"$REPLAY_BIN" test -c "./http-pokeapi" --delay 7 --generateGithubActions=false &> test_logs.txt
 
 
 if grep "ERROR" "test_logs.txt"; then

--- a/.github/workflows/test_workflow_scripts/golang/risk_profile/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/risk_profile/golang-linux.sh
@@ -305,7 +305,7 @@ endsec
 
 section "Record Test Cases"
 echo "Starting Keploy in record mode..."
-sudo -E env PATH="$PATH" $RECORD_BIN record -c "./my-app" 2>&1 | tee record.log &
+$RECORD_BIN record -c "./my-app" 2>&1 | tee record.log &
 KEPLOY_PID=$!
 wait_for_http 8080
 endsec
@@ -328,28 +328,28 @@ section "Run Keploy Tests"
 echo "Running tests with risk profile analysis..."
 git checkout origin/risk-profile-v2
 go build -o my-app
-sudo -E env PATH="$PATH" $REPLAY_BIN test -c "./my-app" --skip-coverage=false --disableMockUpload --useLocalMock 2>&1 | tee test.log || true
+$REPLAY_BIN test -c "./my-app" --skip-coverage=false --disableMockUpload --useLocalMock 2>&1 | tee test.log || true
 check_for_errors "test.log"
 check_report_for_risk_profiles
 endsec
 
 section "Attempt Safe Normalization (Expected to Warn)"
 echo "Running normalize without force flag. Expecting warnings for high-risk failures..."
-sudo -E env PATH="$PATH" $REPLAY_BIN normalize 2>&1 | tee normalize_safe.log || true
+$REPLAY_BIN normalize 2>&1 | tee normalize_safe.log || true
 check_for_errors "normalize_safe.log"
 check_normalize_warnings
 endsec
 
 section "Run Forced Normalization (Expected to Succeed)"
 echo "Running normalize with --allow-high-risk flag..."
-sudo -E env PATH="$PATH" $REPLAY_BIN normalize --allow-high-risk 2>&1 | tee normalize_forced.log || true
+$REPLAY_BIN normalize --allow-high-risk 2>&1 | tee normalize_forced.log || true
 check_for_errors "normalize_forced.log"
 echo "Forced normalization complete. Test cases should now be updated."
 endsec
 
 section "Run Final Validation Test"
 echo "Running final test run to confirm all tests now pass..."
-sudo -E env PATH="$PATH" $REPLAY_BIN test -c "./my-app" --skip-coverage=false --disableMockUpload --useLocalMock 2>&1 | tee final_test.log || true
+$REPLAY_BIN test -c "./my-app" --skip-coverage=false --disableMockUpload --useLocalMock 2>&1 | tee final_test.log || true
 check_for_errors "final_test.log"
 endsec
 

--- a/.github/workflows/test_workflow_scripts/java/spring_petclinic/java-linux.sh
+++ b/.github/workflows/test_workflow_scripts/java/spring_petclinic/java-linux.sh
@@ -175,7 +175,7 @@ for i in 1 2; do
   app_name="javaApp_${i}"
 
   # Start keploy in background, capture PID
-  sudo -E env PATH="$PATH" "$RECORD_BIN" record \
+  "$RECORD_BIN" record \
     -c 'java -jar target/spring-petclinic-rest-3.0.2.jar' \
     > "${app_name}.txt" 2>&1 &
   KEPLOY_PID=$!
@@ -219,7 +219,7 @@ endsec
 
 section "Replay"
 set +e
-sudo -E env PATH="$PATH" "$REPLAY_BIN" test \
+"$REPLAY_BIN" test \
   -c 'java -jar target/spring-petclinic-rest-3.0.2.jar' \
   --delay 20 \
   > test_logs.txt 2>&1

--- a/.github/workflows/test_workflow_scripts/node/express_mongoose/node-docker.sh
+++ b/.github/workflows/test_workflow_scripts/node/express_mongoose/node-docker.sh
@@ -65,7 +65,7 @@ for i in {1..2}; do
     # Start keploy in record mode.
     container_name="nodeApp_${i}"
     send_request &
-    sudo -E env PATH=$PATH $RECORD_BIN record -c "docker run -p 8000:8000 --name "${container_name}" --network keploy-network node-app:1.0" --container-name "${container_name}"    &> "${container_name}.txt"
+    $RECORD_BIN record -c "docker run -p 8000:8000 --name "${container_name}" --network keploy-network node-app:1.0" --container-name "${container_name}"    &> "${container_name}.txt"
     cat "${container_name}.txt"
     if grep "ERROR" "${container_name}.txt"; then
         echo "Error found in pipeline..."
@@ -90,7 +90,7 @@ echo "MongoDB stopped - Keploy should now use mocks for database interactions"
 
 # Start keploy in test mode.
 test_container="nodeApp_test"
-sudo -E env PATH=$PATH $REPLAY_BIN test -c "docker run -p 8000:8000 --rm --name $test_container --network keploy-network node-app:1.0" --containerName "$test_container" --apiTimeout 30 --delay 30 --generate-github-actions=false &> "${test_container}.txt"
+$REPLAY_BIN test -c "docker run -p 8000:8000 --rm --name $test_container --network keploy-network node-app:1.0" --containerName "$test_container" --apiTimeout 30 --delay 30 --generate-github-actions=false &> "${test_container}.txt"
 if grep "ERROR" "${test_container}.txt"; then
     echo "Error found in pipeline..."
     cat "${test_container}.txt"

--- a/.github/workflows/test_workflow_scripts/node/express_mongoose/node-linux.sh
+++ b/.github/workflows/test_workflow_scripts/node/express_mongoose/node-linux.sh
@@ -106,7 +106,7 @@ for i in 1 2; do
   app_name="nodeApp_${i}"
 
   # Start keploy recording in background, capture PID
-  sudo -E env PATH="$PATH" "$RECORD_BIN" record -c 'npm start' \
+  "$RECORD_BIN" record -c 'npm start' \
     > "${app_name}.txt" 2>&1 &
   KEPLOY_PID=$!
 
@@ -176,7 +176,7 @@ run_replay() {
 
   section "Replay #$idx (args: ${extra_args:-<none>})"
   set +e
-  sudo -E env PATH="$PATH" "$REPLAY_BIN" test -c 'npm start' --delay 10 $extra_args \
+  "$REPLAY_BIN" test -c 'npm start' --delay 10 $extra_args \
     > "$logfile" 2>&1
   local rc=$?
   set -e

--- a/.github/workflows/test_workflow_scripts/node/express_mongoose/node-mapping.sh
+++ b/.github/workflows/test_workflow_scripts/node/express_mongoose/node-mapping.sh
@@ -81,7 +81,7 @@ run_templatize() {
 
   section "Templatize #$idx (args: ${extra_args:-<none>})"
   set +e
-  sudo -E env PATH="$PATH" "$RECORD_BIN" templatize $extra_args \
+  "$RECORD_BIN" templatize $extra_args \
     > "$logfile" 2>&1
   local rc=$?
   set -e
@@ -107,7 +107,7 @@ run_rerecord() {
   
   # Start keploy rerecord in background, capture PID
   set +e
-  sudo -E env PATH="$PATH" "$RECORD_BIN" rerecord -c 'npm start' --disable-mapping=false $extra_args \
+  "$RECORD_BIN" rerecord -c 'npm start' --disable-mapping=false $extra_args \
     > "$logfile" 2>&1 &
   local KEPLOY_PID=$!
 
@@ -169,7 +169,7 @@ for i in 1 2; do
   app_name="nodeApp_${i}"
 
   # Start keploy recording in background, capture PID
-  sudo -E env PATH="$PATH" "$RECORD_BIN" record -c 'npm start' --global-passthrough \
+  "$RECORD_BIN" record -c 'npm start' --global-passthrough \
     > "${app_name}.txt" 2>&1 &
   KEPLOY_PID=$!
 
@@ -223,7 +223,7 @@ run_replay() {
 
   section "Replay #$idx (args: ${extra_args:-<none>})"
   set +e
-  sudo -E env PATH="$PATH" "$REPLAY_BIN" test -c 'npm start' --disable-mapping=false --delay 10 $extra_args 
+  "$REPLAY_BIN" test -c 'npm start' --disable-mapping=false --delay 10 $extra_args 
     # > "$logfile" 2>&1
   local rc=$?
   set -e

--- a/.github/workflows/test_workflow_scripts/node/http_br/node-linux.sh
+++ b/.github/workflows/test_workflow_scripts/node/http_br/node-linux.sh
@@ -77,7 +77,7 @@ send_request(){
 for i in {1..2}; do
     app_name="nodeApp_${i}"
     send_request &
-    sudo -E env PATH=$PATH $RECORD_BIN record -c 'node app.js'    &> "${app_name}.txt"
+    $RECORD_BIN record -c 'node app.js'    &> "${app_name}.txt"
     cat "${app_name}.txt"
     if grep "ERROR" "${app_name}.txt"; then
         echo "Error found in pipeline..."
@@ -95,7 +95,7 @@ for i in {1..2}; do
 done
 
 # Test modes and result checking
-sudo -E env PATH=$PATH $REPLAY_BIN test -c 'node app.js' --delay 10    &> test_logs1.txt
+$REPLAY_BIN test -c 'node app.js' --delay 10    &> test_logs1.txt
 cat test_logs1.txt
 if grep "ERROR" "test_logs1.txt"; then
     echo "Error found in pipeline..."
@@ -108,7 +108,7 @@ if grep "WARNING: DATA RACE" "test_logs1.txt"; then
     exit 1
 fi
 
-sudo -E env PATH=$PATH $REPLAY_BIN test -c 'node app.js' --delay 10 --testsets test-set-0    &> test_logs2.txt
+$REPLAY_BIN test -c 'node app.js' --delay 10 --testsets test-set-0    &> test_logs2.txt
 cat test_logs2.txt
 if grep "ERROR" "test_logs2.txt"; then
     echo "Error found in pipeline..."
@@ -121,7 +121,7 @@ if grep "WARNING: DATA RACE" "test_logs2.txt"; then
     exit 1
 fi
 
-sudo -E env PATH=$PATH $REPLAY_BIN test -c 'node app.js' --apiTimeout 30 --delay 10    &> test_logs3.txt
+$REPLAY_BIN test -c 'node app.js' --apiTimeout 30 --delay 10    &> test_logs3.txt
 cat test_logs3.txt
 if grep "ERROR" "test_logs3.txt"; then
     echo "Error found in pipeline..."

--- a/.github/workflows/test_workflow_scripts/python-docker.sh
+++ b/.github/workflows/test_workflow_scripts/python-docker.sh
@@ -55,7 +55,7 @@ send_request(){
 for i in {1..2}; do
     container_name="flaskApp_${i}"
     send_request &
-    sudo -E env PATH=$PATH $RECORD_BIN record -c "docker run -p 6000:6000 --net keploy-network --rm --name $container_name flask-app:1.0" --container-name "$container_name" &> "${container_name}.txt"
+    $RECORD_BIN record -c "docker run -p 6000:6000 --net keploy-network --rm --name $container_name flask-app:1.0" --container-name "$container_name" --generateGithubActions=false  &> "${container_name}.txt"
     if grep "ERROR" "${container_name}.txt"; then
         echo "Error found in pipeline..."
         cat "${container_name}.txt"
@@ -79,7 +79,7 @@ echo "MongoDB stopped - Keploy should now use mocks for database interactions"
 
 # Testing phase
 test_container="flashApp_test"
-sudo -E env PATH=$PATH $REPLAY_BIN test -c "docker run -p 6000:6000 --net keploy-network --name $test_container flask-app:1.0" --containerName "$test_container" --apiTimeout 100 --delay 15 --generate-github-actions=false --debug 
+$REPLAY_BIN test -c "docker run -p 6000:6000 --net keploy-network --name $test_container flask-app:1.0" --containerName "$test_container" --apiTimeout 100 --delay 15 --generate-github-actions=false --debug 
 if grep "ERROR" "${test_container}.txt"; then
     echo "Error found in pipeline..."
     cat "${test_container}.txt"

--- a/.github/workflows/test_workflow_scripts/python/django_postgres/python-linux.sh
+++ b/.github/workflows/test_workflow_scripts/python/django_postgres/python-linux.sh
@@ -64,7 +64,7 @@ send_request(){
 for i in {1..2}; do
     app_name="flaskApp_${i}"
     send_request &
-    sudo -E env PATH="$PATH" $RECORD_BIN record -c "python3 manage.py runserver"   &> "${app_name}.txt"
+    $RECORD_BIN record -c "python3 manage.py runserver"   &> "${app_name}.txt"
     if grep "ERROR" "${app_name}.txt"; then
         echo "Error found in pipeline..."
         cat "${app_name}.txt"
@@ -86,7 +86,7 @@ docker compose down
 echo "Postgres stopped - Keploy should now use mocks for database interactions"
 
 # Testing phase
-sudo -E env PATH="$PATH" $REPLAY_BIN test -c "python3 manage.py runserver" --delay 10    &> test_logs.txt
+$REPLAY_BIN test -c "python3 manage.py runserver" --delay 10    &> test_logs.txt
 
 if grep "ERROR" "test_logs.txt"; then
         echo "Error found in pipeline..."

--- a/.github/workflows/test_workflow_scripts/python/flask-secret/python-linux.sh
+++ b/.github/workflows/test_workflow_scripts/python/flask-secret/python-linux.sh
@@ -99,7 +99,7 @@ send_request(){
 for i in 1 2; do
     app_name="flaskSecret_${i}"
     send_request "secrets" &
-    sudo -E env PATH="$PATH" $RECORD_BIN record -c "python3 main.py" --metadata "suite=secrets,run=$i" 2>&1 | tee ${app_name}.txt
+    $RECORD_BIN record -c "python3 main.py" --metadata "suite=secrets,run=$i" 2>&1 | tee ${app_name}.txt
     if grep "ERROR" "${app_name}.txt"; then exit 1; fi
     if grep "WARNING: DATA RACE" "${app_name}.txt"; then exit 1; fi
     sleep 5
@@ -115,7 +115,7 @@ sleep 5
 # --- Record cycle for the new /astro endpoint (its own test set) ---
 app_name="flaskAstro"
 send_request "astro" &
-sudo -E env PATH="$PATH" $RECORD_BIN record -c "python3 main.py" --metadata "suite=astro,endpoint=/astro" 2>&1 | tee ${app_name}.txt
+$RECORD_BIN record -c "python3 main.py" --metadata "suite=astro,endpoint=/astro" 2>&1 | tee ${app_name}.txt
 if grep "ERROR" "${app_name}.txt"; then exit 1; fi
 if grep "WARNING: DATA RACE" "${app_name}.txt"; then exit 1; fi
 sleep 5
@@ -137,7 +137,7 @@ else
 fi
 
 # Testing phase
-sudo -E env PATH="$PATH" $REPLAY_BIN test -c "python3 main.py" --delay 10 2>&1 | tee test_logs.txt
+$REPLAY_BIN test -c "python3 main.py" --delay 10 2>&1 | tee test_logs.txt
 if grep "ERROR" "test_logs.txt"; then exit 1; fi
 if grep "WARNING: DATA RACE" "test_logs.txt"; then exit 1; fi
 
@@ -177,7 +177,7 @@ fi
 
 # Run test with config path pointing to the new location
 echo "Running test with --config-path $CONFIG_TEST_DIR"
-sudo -E env PATH="$PATH" $REPLAY_BIN test -c "python3 main.py" --delay 10 --config-path "$CONFIG_TEST_DIR" 2>&1 | tee config_path_test_logs.txt
+$REPLAY_BIN test -c "python3 main.py" --delay 10 --config-path "$CONFIG_TEST_DIR" 2>&1 | tee config_path_test_logs.txt
 
 # Check if keploy.yml was created in the original location (should NOT happen)
 if [ -f "keploy.yml" ]; then
@@ -219,14 +219,14 @@ echo "Removing astro test-set-2 to focus normalize on secret sets"
 rm -rf keploy/test-set-2
 
 echo "Running test again, this will fail as expected"
-sudo -E env PATH="$PATH" $REPLAY_BIN test -c "python3 main.py" --delay 10 2>&1 | tee test_logs_fail.txt
+$REPLAY_BIN test -c "python3 main.py" --delay 10 2>&1 | tee test_logs_fail.txt
 
 echo "Running the normalize command"
-sudo -E env PATH="$PATH" $REPLAY_BIN normalize 2>&1 | tee normalize_logs.txt
+$REPLAY_BIN normalize 2>&1 | tee normalize_logs.txt
 if grep "ERROR" "normalize_logs.txt"; then exit 1; fi
 
 echo "Running test again, this time it will pass"
-sudo -E env PATH="$PATH" $REPLAY_BIN test -c "python3 main.py" --delay 10 2>&1 | tee test_logs_pass.txt
+$REPLAY_BIN test -c "python3 main.py" --delay 10 2>&1 | tee test_logs_pass.txt
 if grep "ERROR" "test_logs_pass.txt"; then exit 1; fi
 
 all_passed=true
@@ -260,7 +260,7 @@ rm -rf keploy
 # Record the "misc" endpoints as a new test suite
 app_name="flaskMisc"
 send_request "misc" &
-sudo -E env PATH="$PATH" $RECORD_BIN record -c "python3 main.py" --metadata "suite=misc" 2>&1 | tee ${app_name}.txt
+$RECORD_BIN record -c "python3 main.py" --metadata "suite=misc" 2>&1 | tee ${app_name}.txt
 if grep "ERROR" "${app_name}.txt"; then
     echo "Error found in misc recording..."
     cat "${app_name}.txt"
@@ -276,7 +276,7 @@ wait
 echo "Recorded misc test case and mocks"
 
 # Sanitize the newly created test cases
-sudo -E env PATH="$PATH" $RECORD_BIN sanitize 2>&1 | tee sanitize_logs_misc.txt
+$RECORD_BIN sanitize 2>&1 | tee sanitize_logs_misc.txt
 if grep "ERROR" "sanitize_logs_misc.txt"; then
     echo "Error found in misc sanitize..."
     cat "sanitize_logs_misc.txt"
@@ -285,7 +285,7 @@ fi
 
 # Final testing phase
 echo "Running test on the new 'misc' test suite..."
-sudo -E env PATH="$PATH" $REPLAY_BIN test -c "python3 main.py" --delay 10 2>&1 | tee final_test_logs.txt
+$REPLAY_BIN test -c "python3 main.py" --delay 10 2>&1 | tee final_test_logs.txt
 if grep "ERROR" "final_test_logs.txt"; then
     echo "Error found in final test run..."
     cat "final_test_logs.txt"

--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -50,24 +50,24 @@ Note: If installed keploy without One Click Install, use "keploy example --custo
 var Examples = `
 Golang Application
 	Record:
-	sudo -E env PATH=$PATH keploy record -c "/path/to/user/app/binary"
+	keploy record -c "/path/to/user/app/binary"
 
 	Test:
-	sudo -E env PATH=$PATH keploy test -c "/path/to/user/app/binary" --delay 10
+	keploy test -c "/path/to/user/app/binary" --delay 10
 
 Node Application
 	Record:
-	sudo -E env PATH=$PATH keploy record -c “npm start --prefix /path/to/node/app"
+	keploy record -c “npm start --prefix /path/to/node/app"
 
 	Test:
-	sudo -E env PATH=$PATH keploy test -c “npm start --prefix /path/to/node/app" --delay 10
+	keploy test -c “npm start --prefix /path/to/node/app" --delay 10
 
 Java
 	Record:
-	sudo -E env PATH=$PATH keploy record -c "java -jar /path/to/java-project/target/jar"
+	keploy record -c "java -jar /path/to/java-project/target/jar"
 
 	Test:
-	sudo -E env PATH=$PATH keploy test -c "java -jar /path/to/java-project/target/jar" --delay 10
+	keploy test -c "java -jar /path/to/java-project/target/jar" --delay 10
 
 Docker
 	Alias:
@@ -80,6 +80,7 @@ Docker
 	Test:
 	keploy test -c "docker run -p 8080:8080 --name <containerName> --network <networkName> <applicationImage>" --delay 10 --buildDelay 60
 
+Note: Keploy will automatically prompt for sudo password when elevated privileges are required for eBPF operations.
 `
 
 var ExampleOneClickInstall = `
@@ -573,7 +574,10 @@ func (c *CmdConfigurator) PreProcessFlags(cmd *cobra.Command) error {
 
 func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command) error {
 	disableAnsi, _ := (cmd.Flags().GetBool("disable-ansi"))
-	PrintLogo(os.Stdout, disableAnsi)
+	// Skip printing logo for agent command to avoid duplicate logos in native mode
+	if cmd.Name() != "agent" {
+		PrintLogo(os.Stdout, disableAnsi)
+	}
 	if c.cfg.Debug {
 		logger, err := log.ChangeLogLevel(zap.DebugLevel)
 		*c.logger = *logger
@@ -595,14 +599,27 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 		c.cfg.E2E = true
 	}
 
-	if c.cfg.EnableTesting {
-		// Add mode to logger to debug the keploy during testing
+	// Add mode to logger for agent command to differentiate agent logs from client logs
+	if cmd.Name() == "agent" {
 		logger, err := log.AddMode(cmd.Name())
 		*c.logger = *logger
 		if err != nil {
 			errMsg := "failed to add mode to logger"
 			utils.LogError(c.logger, err, errMsg)
 			return errors.New(errMsg)
+		}
+	}
+
+	if c.cfg.EnableTesting {
+		// Add mode to logger to debug the keploy during testing
+		if cmd.Name() != "agent" { // Skip if already added for agent
+			logger, err := log.AddMode(cmd.Name())
+			*c.logger = *logger
+			if err != nil {
+				errMsg := "failed to add mode to logger"
+				utils.LogError(c.logger, err, errMsg)
+				return errors.New(errMsg)
+			}
 		}
 		c.cfg.DisableTele = true
 	}
@@ -937,6 +954,17 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 			return errors.New("failed to get the absolute path")
 		}
 		c.cfg.Path = absPath + "/keploy"
+
+		// Check and fix keploy folder permissions for native mode only
+		// (handles root-owned files from older sudo-based versions)
+		cmdType := utils.FindDockerCmd(c.cfg.Command)
+		if !utils.IsDockerCmd(cmdType) {
+			// Native mode: fix permissions immediately (this caches sudo credentials)
+			if err := utils.EnsureKeployFolderPermissions(cmd.Context(), c.logger, c.cfg.Path, false); err != nil {
+				utils.LogError(c.logger, err, "failed to ensure keploy folder permissions")
+				return err
+			}
+		}
 
 		// handle the app command
 		if c.cfg.Command == "" {

--- a/keploy.sh
+++ b/keploy.sh
@@ -344,40 +344,40 @@ installKeploy (){
                 update_path "$HOME/.profile"
             fi
         else
-            ALIAS_CMD="alias keploy='sudo -E env PATH=\"\$PATH\" keploy'"
-            # Handle zsh or bash for non-macOS systems
-            if [[ "$current_shell" = "zsh" || "$current_shell" = "-zsh" ]]; then
-                if [ -f "$HOME/.zshrc" ]; then
-                    if grep -q "alias keploy=" "$HOME/.zshrc"; then
-                        sed -i '/alias keploy/d' "$HOME/.zshrc"
+            # Only set alias for v2.x.x versions (including pre-release like -alpha, -beta, -rc, etc.)
+            if [[ "$version" =~ ^v2\.[0-9]+\.[0-9]+ ]]; then
+                ALIAS_CMD="alias keploy='sudo -E env PATH=\"\$PATH\" keploy'"
+                # Handle zsh or bash for non-macOS systems
+                if [[ "$current_shell" = "zsh" || "$current_shell" = "-zsh" ]]; then
+                    if [ -f "$HOME/.zshrc" ]; then
+                        if grep -q "alias keploy=" "$HOME/.zshrc"; then
+                            sed -i '/alias keploy/d' "$HOME/.zshrc"
+                        fi
+                        append_to_rc "$ALIAS_CMD" ~/.zshrc
+                    else
+                        alias keploy="$ALIAS_CMD"
                     fi
-                    append_to_rc "$ALIAS_CMD" ~/.zshrc
-                else
-                    alias keploy="$ALIAS_CMD"
-                fi
-            elif [[ "$current_shell" = "bash" || "$current_shell" = "-bash" ]]; then
-                if [ -f "$HOME/.bashrc" ]; then
-                    if grep -q "alias keploy=" "$HOME/.bashrc"; then
-                        sed -i '/alias keploy/d' "$HOME/.bashrc"
+                elif [[ "$current_shell" = "bash" || "$current_shell" = "-bash" ]]; then
+                    if [ -f "$HOME/.bashrc" ]; then
+                        if grep -q "alias keploy=" "$HOME/.bashrc"; then
+                            sed -i '/alias keploy/d' "$HOME/.bashrc"
+                        fi
+                        append_to_rc "$ALIAS_CMD" ~/.bashrc
+                    else
+                        alias keploy="$ALIAS_CMD"
                     fi
-                    append_to_rc "$ALIAS_CMD" ~/.bashrc
                 else
-                    alias keploy="$ALIAS_CMD"
-                fi
-            else
-                if [ -f "$HOME/.profile" ]; then
-                    if grep -q "alias keploy=" "$HOME/.profile"; then
-                        sed -i '/alias keploy/d' "$HOME/.profile"
+                    if [ -f "$HOME/.profile" ]; then
+                        if grep -q "alias keploy=" "$HOME/.profile"; then
+                            sed -i '/alias keploy/d' "$HOME/.profile"
+                        fi
+                        append_to_rc "$ALIAS_CMD" ~/.profile
+                    else
+                        alias keploy="$ALIAS_CMD"
                     fi
-                    append_to_rc "$ALIAS_CMD" ~/.profile
-                else
-                    alias keploy="$ALIAS_CMD"
                 fi
             fi
-
-
         fi
-    
     }
 
 

--- a/pkg/agent/hooks/linux/comm.go
+++ b/pkg/agent/hooks/linux/comm.go
@@ -81,7 +81,14 @@ func (h *Hooks) SendAgentInfo(agentInfo structs.AgentInfo) error {
 }
 
 func (h *Hooks) WatchBindEvents(ctx context.Context) (<-chan models.IngressEvent, error) {
+	// Acquire read lock to safely access h.BindEvents while it might be closed by unLoad()
+	h.objectsMutex.RLock()
+	if h.BindEvents == nil {
+		h.objectsMutex.RUnlock()
+		return nil, errors.New("BindEvents map is nil")
+	}
 	rb, err := ringbuf.NewReader(h.BindEvents) // Assuming h.BindEvents is the eBPF map
+	h.objectsMutex.RUnlock()
 	if err != nil {
 		return nil, err // Return error if we can't create the reader
 	}
@@ -89,8 +96,13 @@ func (h *Hooks) WatchBindEvents(ctx context.Context) (<-chan models.IngressEvent
 	eventChan := make(chan models.IngressEvent, 100) // A buffered channel can be useful
 
 	go func() {
-		defer rb.Close()
 		defer close(eventChan)
+
+		// Close the ringbuf reader when context is done to unblock rb.Read()
+		go func() {
+			<-ctx.Done()
+			rb.Close()
+		}()
 
 		for {
 			// Read raw data from the ring buffer

--- a/pkg/agent/hooks/linux/hooks.go
+++ b/pkg/agent/hooks/linux/hooks.go
@@ -381,7 +381,7 @@ func (h *Hooks) unLoad(_ context.Context, opts agent.HookCfg) {
 			}
 		}
 	}
-	h.logger.Info("eBPF resources released successfully...")
+	h.logger.Debug("eBPF resources released successfully...")
 }
 
 func (h *Hooks) RegisterClient(ctx context.Context, opts config.Agent, rules []models.BypassRule) error {

--- a/pkg/agent/proxy/incoming/incoming.go
+++ b/pkg/agent/proxy/incoming/incoming.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"strconv"
 	"sync"
@@ -97,7 +98,7 @@ func (pm *IngressProxyManager) ListenForIngressEvents(ctx context.Context) {
 
 		pm.StartIngressProxy(ctx, e.OrigAppPort, e.NewAppPort)
 	}
-	pm.logger.Info("Stopping ingress event listener as the event channel was closed.")
+	pm.logger.Debug("Stopping ingress event listener as the event channel was closed.")
 	pm.StopAll()
 }
 
@@ -163,7 +164,10 @@ func (pm *IngressProxyManager) handleConnection(ctx context.Context, clientConn 
 
 	preface, err := util.ReadInitialBuf(ctx, logger, clientConn)
 	if err != nil {
-		utils.LogError(logger, err, "error reading initial bytes from client connection")
+		//if not EOF then log
+		if err != io.EOF {
+			utils.LogError(logger, err, "error reading initial bytes from client connection")
+		}
 		return
 	}
 	if bytes.HasPrefix(preface, []byte(clientPreface)) {

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -237,7 +237,7 @@ func (p *Proxy) start(ctx context.Context, readyChan chan<- error) error {
 		if err != nil {
 			p.logger.Error("failed to close the listener", zap.Error(err))
 		}
-		p.logger.Info("proxy stopped...")
+		p.logger.Debug("proxy stopped...")
 	}(listener)
 
 	clientConnCtx, clientConnCancel := context.WithCancel(ctx)
@@ -351,6 +351,10 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 		return err
 	}
 
+	// Create a local copy of OutgoingOptions to avoid data race when multiple
+	// goroutines handle connections concurrently and modify DstCfg/Synchronous
+	outgoingOpts := rule.OutgoingOptions
+
 	mgr := syncMock.Get()
 	mgr.SetOutputChannel(rule.MC)
 	var dstAddr string
@@ -417,7 +421,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 		return nil
 	}
 	if p.synchronous {
-		rule.OutgoingOptions.Synchronous = true
+		outgoingOpts.Synchronous = true
 	}
 
 	//checking for the destination port of "mysql"
@@ -432,10 +436,10 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 			dstCfg := &models.ConditionalDstCfg{
 				Port: uint(destInfo.Port),
 			}
-			rule.DstCfg = dstCfg
+			outgoingOpts.DstCfg = dstCfg
 
 			// Record the outgoing message into a mock
-			err := p.Integrations[integrations.MYSQL].RecordOutgoing(parserCtx, srcConn, dstConn, rule.MC, rule.OutgoingOptions)
+			err := p.Integrations[integrations.MYSQL].RecordOutgoing(parserCtx, srcConn, dstConn, rule.MC, outgoingOpts)
 			if err != nil {
 				utils.LogError(p.logger, err, "failed to record the outgoing message")
 				return err
@@ -451,7 +455,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 		}
 
 		//mock the outgoing message
-		err := p.Integrations[integrations.MYSQL].MockOutgoing(parserCtx, srcConn, &models.ConditionalDstCfg{Addr: dstAddr}, m.(*MockManager), rule.OutgoingOptions)
+		err := p.Integrations[integrations.MYSQL].MockOutgoing(parserCtx, srcConn, &models.ConditionalDstCfg{Addr: dstAddr}, m.(*MockManager), outgoingOpts)
 		if err != nil && err != io.EOF && !errors.Is(err, context.Canceled) {
 			utils.LogError(p.logger, err, "failed to mock the outgoing message")
 			// Send specific error type to error channel for external monitoring
@@ -608,7 +612,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 		dstCfg.Addr = dstAddr
 	}
 
-	rule.DstCfg = dstCfg
+	outgoingOpts.DstCfg = dstCfg
 	// get the mock manager for the current app
 	m, ok := p.MockManagers.Load(uint64(0))
 	if !ok {
@@ -641,13 +645,13 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 		p.logger.Debug("The external dependency is supported. Hence using the parser", zap.String("ParserType", string(parserType)))
 		switch rule.Mode {
 		case models.MODE_RECORD:
-			err := matchedParser.RecordOutgoing(parserCtx, srcConn, dstConn, rule.MC, rule.OutgoingOptions)
+			err := matchedParser.RecordOutgoing(parserCtx, srcConn, dstConn, rule.MC, outgoingOpts)
 			if err != nil {
 				utils.LogError(logger, err, "failed to record the outgoing message")
 				return err
 			}
 		case models.MODE_TEST:
-			err := matchedParser.MockOutgoing(parserCtx, srcConn, dstCfg, m.(*MockManager), rule.OutgoingOptions)
+			err := matchedParser.MockOutgoing(parserCtx, srcConn, dstCfg, m.(*MockManager), outgoingOpts)
 			if err != nil && err != io.EOF && !errors.Is(err, context.Canceled) {
 				utils.LogError(logger, err, "failed to mock the outgoing message")
 				// Send specific error type to error channel for external monitoring
@@ -664,13 +668,13 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 	if generic {
 		logger.Debug("The external dependency is not supported. Hence using generic parser")
 		if rule.Mode == models.MODE_RECORD {
-			err := p.Integrations[integrations.GENERIC].RecordOutgoing(parserCtx, srcConn, dstConn, rule.MC, rule.OutgoingOptions)
+			err := p.Integrations[integrations.GENERIC].RecordOutgoing(parserCtx, srcConn, dstConn, rule.MC, outgoingOpts)
 			if err != nil && err != io.EOF && !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), "tls: user canceled") {
 				utils.LogError(logger, err, "failed to record the outgoing message")
 				return err
 			}
 		} else {
-			err := p.Integrations[integrations.GENERIC].MockOutgoing(parserCtx, srcConn, dstCfg, m.(*MockManager), rule.OutgoingOptions)
+			err := p.Integrations[integrations.GENERIC].MockOutgoing(parserCtx, srcConn, dstCfg, m.(*MockManager), outgoingOpts)
 			if err != nil && err != io.EOF && !errors.Is(err, context.Canceled) {
 				utils.LogError(logger, err, "failed to mock the outgoing message")
 				// Send specific error type to error channel for external monitoring
@@ -720,7 +724,7 @@ func (p *Proxy) StopProxyServer(ctx context.Context) {
 		}
 		p.logger.Warn("proxy stopped with cleanup errors", zap.Int("error_count", len(cleanupErrors)))
 	} else {
-		p.logger.Info("proxy stopped cleanly...")
+		p.logger.Debug("proxy stopped cleanly...")
 	}
 }
 

--- a/pkg/agent/proxy/util/util.go
+++ b/pkg/agent/proxy/util/util.go
@@ -190,7 +190,7 @@ func ReadInitialBuf(ctx context.Context, logger *zap.Logger, conn net.Conn) ([]b
 
 	if err == io.EOF && len(initialBuf) == 0 {
 		logger.Debug("received EOF, closing conn", zap.Error(err))
-		return nil, readErr
+		return nil, io.EOF
 	}
 
 	if err != nil && err != io.EOF {

--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -290,7 +290,7 @@ func (a *App) run(ctx context.Context) models.AppError {
 
 				// Force Kill using Docker API
 				// We tell the Docker Daemon explicitly to kill this container.
-				a.logger.Warn("container did not stop gracefully, killing it forecfully", zap.String("containerID", a.container))
+				a.logger.Warn("container did not stop gracefully, killing it forcefully", zap.String("containerID", a.container))
 
 				// "SIGKILL" string is standard for Docker API to force kill
 				err = a.docker.ContainerKill(context.Background(), a.container, "SIGKILL")

--- a/pkg/platform/docker/docker.go
+++ b/pkg/platform/docker/docker.go
@@ -179,12 +179,12 @@ func (idc *Impl) CreateVolume(ctx context.Context, volumeName string, recreate b
 
 		// Compare driver options
 		if idc.volumeOptionsMatch(existingVolume.Options, driverOpts) {
-			idc.logger.Info("volume already exists with the same options", zap.String("volume", volumeName))
+			idc.logger.Debug("volume already exists with the same options", zap.String("volume", volumeName))
 			return nil
 		}
 
 		if !recreate {
-			idc.logger.Info("volume already exists but with different options", zap.String("volume", volumeName))
+			idc.logger.Debug("volume already exists but with different options", zap.String("volume", volumeName))
 			return fmt.Errorf("volume %s exists with different options", volumeName)
 		}
 

--- a/pkg/platform/http/agent.go
+++ b/pkg/platform/http/agent.go
@@ -45,7 +45,8 @@ type AgentClient struct {
 	apps         sync.Map
 	client       http.Client
 	conf         *config.Config
-	agentCmd     *exec.Cmd // Track the agent process
+	agentCmd     *exec.Cmd             // Track the agent process
+	agentPTY     *agentUtils.PTYHandle // Track the PTY handle for interactive commands
 	mu           sync.Mutex
 	agentCancel  context.CancelFunc // Function to cancel the agent context
 }
@@ -118,14 +119,10 @@ func (a *AgentClient) GetIncoming(ctx context.Context, opts models.IncomingOptio
 		for {
 			var testCase models.TestCase
 			if err := decoder.Decode(&testCase); err != nil {
-				if err == io.EOF || err == io.ErrUnexpectedEOF || ctx.Err() != nil {
-					// End of the stream
+				if utils.IsShutdownError(err) {
+					// End of the stream or connection closed during shutdown
 					break
 				}
-				if strings.Contains(err.Error(), "use of closed network connection") {
-					break
-				}
-
 				utils.LogError(a.logger, err, "failed to decode test case from stream")
 				break
 			}
@@ -193,8 +190,8 @@ func (a *AgentClient) GetOutgoing(ctx context.Context, opts models.OutgoingOptio
 		for {
 			var mock models.Mock
 			if err := decoder.Decode(&mock); err != nil {
-				if err == io.EOF || err == io.ErrUnexpectedEOF {
-					// End of the stream
+				if utils.IsShutdownError(err) {
+					// End of the stream or connection closed during shutdown
 					break
 				}
 				utils.LogError(a.logger, err, "failed to decode mock from stream")
@@ -656,24 +653,9 @@ func (a *AgentClient) startNativeAgent(ctx context.Context, opts models.SetupOpt
 		return fmt.Errorf("failed to get errorgroup from the context")
 	}
 
-	// Open the log file (truncate to start fresh)
-	filepath := "keploy_agent.log"
-	logFile, err := os.OpenFile(filepath, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0o644)
-	if err != nil {
-		utils.LogError(a.logger, err, "failed to open log file")
-		return err
-	}
-
 	keployBin, err := utils.GetCurrentBinaryPath()
 	if err != nil {
-		if logFile != nil {
-			logFileCloseErr := logFile.Close()
-			if logFileCloseErr != nil {
-				utils.LogError(a.logger, logFileCloseErr, "failed to close log file")
-			}
-
-			utils.LogError(a.logger, err, "failed to get current keploy binary path")
-		}
+		utils.LogError(a.logger, err, "failed to get current keploy binary path")
 		return err
 	}
 
@@ -715,36 +697,43 @@ func (a *AgentClient) startNativeAgent(ctx context.Context, opts models.SetupOpt
 		// Join them with a comma and add as a single argument
 		args = append(args, "--pass-through-ports", strings.Join(portStrings, ","))
 	}
-	a.logger.Info("Starting native agent with args", zap.Strings("args", args))
+	a.logger.Debug("Starting native agent with args", zap.Strings("args", args))
 
 	if opts.ConfigPath != "" && opts.ConfigPath != "." {
 		args = append(args, "--config-path", opts.ConfigPath)
 	}
 
-	// Create OS-appropriate command (handles sudo/process-group on Unix; plain on Windows)
-	cmd := agentUtils.NewAgentCommand(keployBin, args)
+	// Check if sudo credentials are already cached (e.g., from permission fix)
+	// If cached, we can use sudo -n (non-interactive) and skip PTY
+	sudoCached := utils.AreSudoCredentialsCached()
 
-	cmd.Stdout = logFile
-	cmd.Stderr = logFile
+	// Check if we need PTY for interactive input (e.g., sudo password)
+	// Skip PTY if credentials are already cached - use non-interactive sudo instead
+	if agentUtils.NeedsPTY() && !sudoCached {
+		return a.startNativeAgentWithPTY(ctx, keployBin, args, grp)
+	}
+
+	// Create OS-appropriate command (handles sudo/process-group on Unix; plain on Windows)
+	// If credentials are cached, this will use sudo -n (non-interactive)
+	cmd := agentUtils.NewAgentCommand(keployBin, args, sudoCached)
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 
 	a.mu.Lock()
 	a.agentCmd = cmd // this has been set for proper stopping of the native agent
 	a.mu.Unlock()
 	// Start (OS-specific tweaks happen inside utils.StartCommand)
 	if err := agentUtils.StartCommand(cmd); err != nil {
-		if logFile != nil {
-			_ = logFile.Close()
-			utils.LogError(a.logger, err, "failed to start keploy agent")
-		}
+		utils.LogError(a.logger, err, "failed to start keploy agent")
 		return err
 	}
 
 	pid := cmd.Process.Pid
-	a.logger.Info("keploy agent started", zap.Int("pid", pid))
+	a.logger.Debug("keploy agent started", zap.Int("pid", pid))
 
 	grp.Go(func() error {
 		defer utils.Recover(a.logger)
-		defer logFile.Close()
 
 		err := cmd.Wait()
 		// If ctx wasn't cancelled, bubble up unexpected exits
@@ -755,7 +744,7 @@ func (a *AgentClient) startNativeAgent(ctx context.Context, opts models.SetupOpt
 		a.mu.Lock()
 		a.agentCmd = nil
 		a.mu.Unlock()
-		a.logger.Info("agent process stopped")
+		a.logger.Debug("agent process stopped")
 		return nil
 	})
 
@@ -765,6 +754,8 @@ func (a *AgentClient) startNativeAgent(ctx context.Context, opts models.SetupOpt
 		if a.conf.Agent.AgentURI == "" {
 			return nil
 		}
+		a.logger.Debug("Keploy agent shutdown requested", zap.Int("pid", pid))
+		a.logger.Info("Stopping keploy agent")
 		if err := a.requestAgentStop(); err != nil {
 			a.logger.Warn("failed to request keploy agent shutdown, sending stop signal", zap.Error(err))
 			// Fallback: forcefully stop the agent process
@@ -778,7 +769,74 @@ func (a *AgentClient) startNativeAgent(ctx context.Context, opts models.SetupOpt
 			}
 			return nil
 		}
-		a.logger.Info("Keploy agent shutdown requested", zap.Int("pid", pid))
+		a.logger.Info("Keploy agent stopped.")
+		return nil
+	})
+
+	return nil
+}
+
+// startNativeAgentWithPTY starts the agent with PTY support for interactive input (e.g., sudo password)
+func (a *AgentClient) startNativeAgentWithPTY(ctx context.Context, keployBin string, args []string, grp *errgroup.Group) error {
+	// Create command configured for PTY
+	cmd := agentUtils.NewAgentCommandForPTY(keployBin, args)
+
+	a.logger.Debug("Starting native agent with PTY for interactive input")
+
+	// Start with PTY
+	ptyHandle, err := agentUtils.StartCommandWithPTY(cmd, a.logger)
+	if err != nil {
+		utils.LogError(a.logger, err, "failed to start keploy agent with PTY")
+		return err
+	}
+
+	a.mu.Lock()
+	a.agentCmd = cmd
+	a.agentPTY = ptyHandle
+	a.mu.Unlock()
+
+	pid := cmd.Process.Pid
+	a.logger.Debug("keploy agent started with PTY", zap.Int("pid", pid))
+
+	grp.Go(func() error {
+		defer utils.Recover(a.logger)
+
+		err := ptyHandle.Wait()
+		// If ctx wasn't cancelled, bubble up unexpected exits
+		if err != nil && ctx.Err() == nil {
+			a.logger.Error("agent process exited with error", zap.Error(err))
+			return err
+		}
+		a.mu.Lock()
+		a.agentCmd = nil
+		a.agentPTY = nil
+		a.mu.Unlock()
+		a.logger.Debug("agent process stopped")
+		return nil
+	})
+
+	grp.Go(func() error {
+		defer utils.Recover(a.logger)
+		<-ctx.Done()
+		if a.conf.Agent.AgentURI == "" {
+			return nil
+		}
+		a.logger.Debug("Keploy agent shutdown requested", zap.Int("pid", pid))
+		a.logger.Info("Stopping keploy agent")
+		if err := a.requestAgentStop(); err != nil {
+			a.logger.Warn("failed to request keploy agent shutdown, sending stop signal", zap.Error(err))
+			// Fallback: forcefully stop the agent process
+			a.mu.Lock()
+			ptyHandle := a.agentPTY
+			a.mu.Unlock()
+			if ptyHandle != nil {
+				if stopErr := agentUtils.StopPTYCommand(ptyHandle, a.logger); stopErr != nil {
+					a.logger.Error("failed to forcefully stop agent", zap.Error(stopErr))
+				}
+			}
+			return nil
+		}
+		a.logger.Info("Keploy agent stopped.")
 		return nil
 	})
 
@@ -826,7 +884,7 @@ func (a *AgentClient) stopAgent() {
 
 	if a.agentCmd != nil && a.agentCmd.Process != nil {
 		pid := a.agentCmd.Process.Pid
-		a.logger.Info("Stopping keploy agent", zap.Int("pid", pid))
+		a.logger.Debug("Stopping keploy agent", zap.Int("pid", pid))
 	}
 }
 
@@ -835,7 +893,7 @@ func (a *AgentClient) monitorAgent(clientCtx context.Context, agentCtx context.C
 	select {
 	case <-clientCtx.Done():
 		// Client context cancelled, stop the agent
-		a.logger.Info("Client context cancelled, stopping agent")
+		a.logger.Debug("Client context cancelled, stopping agent")
 		a.stopAgent()
 	case <-agentCtx.Done():
 		// Agent context cancelled or agent stopped
@@ -919,15 +977,18 @@ func (a *AgentClient) Setup(ctx context.Context, cmd string, opts models.SetupOp
 		if err != nil {
 			return fmt.Errorf("failed to start agent: %w", err)
 		}
-		a.logger.Info("Agent is now running, proceeding with setup")
+		a.logger.Debug("Agent is now running, proceeding with setup")
 
-		agentCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		agentCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
 
 		agentReadyCh := make(chan bool, 1)
 		go pkg.AgentHealthTicker(agentCtx, a.logger, a.conf.Agent.AgentURI, agentReadyCh, 1*time.Second)
 
 		select {
+		case <-ctx.Done():
+			// Parent context cancelled (user pressed Ctrl+C)
+			return ctx.Err()
 		case <-agentCtx.Done():
 			return fmt.Errorf("keploy-agent did not become ready in time")
 		case <-agentReadyCh:
@@ -991,27 +1052,33 @@ func (a *AgentClient) startInDocker(ctx context.Context, logger *zap.Logger, opt
 	cmd := kdocker.PrepareDockerCommand(ctx, keployAlias)
 
 	cmd.Cancel = func() error {
-		logger.Info("Context cancelled. Explicitly stopping the 'keploy-v3' Docker container.")
+		logger.Debug("Context cancelled. Explicitly stopping the 'keploy-v3' Docker container.")
 
 		containerName := opts.KeployContainer
 
-		args := []string{"docker", "stop", opts.KeployContainer}
-		var stopCmd *exec.Cmd
-
-		// Conditionally add "sudo" only for Linux
-		if runtime.GOOS == "linux" {
-			stopCmd = exec.Command("sudo", args...)
-		} else {
-			stopCmd = exec.Command(args[0], args[1:]...)
-		}
-
+		// Try stopping the container without sudo first (works if user is in docker group)
+		stopCmd := exec.Command("docker", "stop", containerName)
 		if output, err := stopCmd.CombinedOutput(); err != nil {
-			logger.Warn("Could not stop the docker container. It may have already stopped.",
-				zap.String("container", containerName),
-				zap.Error(err),
-				zap.String("output", string(output)))
+			// If that fails on Linux, try with sudo -n (non-interactive, won't prompt for password)
+			if runtime.GOOS == "linux" {
+				logger.Debug("docker stop without sudo failed, trying with sudo -n", zap.Error(err))
+				stopCmd = exec.Command("sudo", "-n", "docker", "stop", containerName)
+				if output, err := stopCmd.CombinedOutput(); err != nil {
+					logger.Warn("Could not stop the docker container. It may have already stopped.",
+						zap.String("container", containerName),
+						zap.Error(err),
+						zap.String("output", string(output)))
+				} else {
+					logger.Debug("Successfully sent stop command to the container.", zap.String("container", containerName))
+				}
+			} else {
+				logger.Warn("Could not stop the docker container. It may have already stopped.",
+					zap.String("container", containerName),
+					zap.Error(err),
+					zap.String("output", string(output)))
+			}
 		} else {
-			logger.Info("Successfully sent stop command to the container.", zap.String("container", containerName))
+			logger.Debug("Successfully sent stop command to the container.", zap.String("container", containerName))
 		}
 
 		if cmd.Process != nil {
@@ -1020,10 +1087,15 @@ func (a *AgentClient) startInDocker(ctx context.Context, logger *zap.Logger, opt
 		return nil
 	}
 
+	logger.Debug("running the following command to start agent in docker", zap.String("command", cmd.String()))
+
+	// Check if we need PTY for interactive input (e.g., sudo password on Linux)
+	if agentUtils.NeedsPTY() {
+		return a.startInDockerWithPTY(ctx, logger, cmd)
+	}
+
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-
-	logger.Info("running the following command to start agent in docker", zap.String("command", cmd.String()))
 
 	if err := cmd.Run(); err != nil {
 		if ctx.Err() == context.Canceled {
@@ -1032,6 +1104,48 @@ func (a *AgentClient) startInDocker(ctx context.Context, logger *zap.Logger, opt
 			return nil
 		}
 		utils.LogError(logger, err, "failed to run keploy agent in docker")
+		return err
+	}
+
+	return nil
+}
+
+// startInDockerWithPTY starts the docker agent with PTY support for interactive input (e.g., sudo password)
+func (a *AgentClient) startInDockerWithPTY(ctx context.Context, logger *zap.Logger, cmd *exec.Cmd) error {
+	// Configure command for PTY execution (OS-specific)
+	agentUtils.ConfigureCommandForPTY(cmd)
+
+	logger.Debug("Starting docker agent with PTY for interactive input")
+
+	// Start with PTY
+	ptyHandle, err := agentUtils.StartCommandWithPTY(cmd, logger)
+	if err != nil {
+		utils.LogError(logger, err, "failed to start keploy agent in docker with PTY")
+		return err
+	}
+
+	a.mu.Lock()
+	a.agentCmd = cmd
+	a.agentPTY = ptyHandle
+	a.mu.Unlock()
+
+	pid := cmd.Process.Pid
+	logger.Debug("keploy agent in docker started with PTY", zap.Int("pid", pid))
+
+	// Wait for the command to finish
+	err = ptyHandle.Wait()
+
+	a.mu.Lock()
+	a.agentCmd = nil
+	a.agentPTY = nil
+	a.mu.Unlock()
+
+	if err != nil {
+		if ctx.Err() == context.Canceled {
+			logger.Info("Keploy agent in docker stopped gracefully.")
+			return nil
+		}
+		utils.LogError(logger, err, "failed to run keploy agent in docker with PTY")
 		return err
 	}
 
@@ -1064,7 +1178,7 @@ func (a *AgentClient) MakeAgentReadyForDockerCompose(ctx context.Context) error 
 			io.Copy(io.Discard, resp.Body)
 			resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
-				a.logger.Info("Successfully marked agent as ready")
+				a.logger.Debug("Successfully marked agent as ready")
 				return nil
 			}
 			a.logger.Warn("Agent returned non-200 status for ready check", zap.Int("status", resp.StatusCode))

--- a/pkg/platform/http/utils/proc_unix.go
+++ b/pkg/platform/http/utils/proc_unix.go
@@ -4,19 +4,51 @@
 package utils
 
 import (
+	"io"
 	"os"
 	"os/exec"
+	"os/signal"
+	"strings"
+	"sync"
 	"syscall"
 	"time"
 
+	"github.com/creack/pty"
 	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
+	"golang.org/x/term"
 )
 
 // NewAgentCommand returns a command that runs elevated on Unix.
 // - If already root, we run the binary directly.
 // - Otherwise we prefix with "sudo".
+// - If useCachedCreds is true, uses "sudo -n" (non-interactive) which relies on cached credentials.
 // - We put the process in its own group so we can signal the whole group.
-func NewAgentCommand(bin string, args []string) *exec.Cmd {
+func NewAgentCommand(bin string, args []string, useCachedCreds bool) *exec.Cmd {
+	var cmd *exec.Cmd
+	if os.Geteuid() == 0 {
+		cmd = exec.Command(bin, args...)
+	} else {
+		if useCachedCreds {
+			// sudo -n <bin> <args...> - non-interactive, uses cached credentials
+			all := append([]string{"-n", bin}, args...)
+			cmd = exec.Command("sudo", all...)
+		} else {
+			// sudo <bin> <args...> - may prompt for password
+			all := append([]string{bin}, args...)
+			cmd = exec.Command("sudo", all...)
+		}
+	}
+
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true, // new process group: pgid == leader pid
+	}
+	return cmd
+}
+
+// NewAgentCommandForPTY returns a command configured for PTY execution.
+// Uses Setsid instead of Setpgid to allow PTY to become the controlling terminal.
+func NewAgentCommandForPTY(bin string, args []string) *exec.Cmd {
 	var cmd *exec.Cmd
 	if os.Geteuid() == 0 {
 		cmd = exec.Command(bin, args...)
@@ -27,9 +59,15 @@ func NewAgentCommand(bin string, args []string) *exec.Cmd {
 	}
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setpgid: true, // new process group: pgid == leader pid
+		Setsid: true, // create new session for PTY
 	}
 	return cmd
+}
+
+// NeedsPTY returns true if the command needs PTY for interactive input (e.g., sudo password).
+func NeedsPTY() bool {
+	// Need PTY when not root (sudo may prompt for password) and stdin is a TTY
+	return os.Geteuid() != 0 && term.IsTerminal(int(os.Stdin.Fd()))
 }
 
 // StartCommand simply starts the process; group set via SysProcAttr above.
@@ -69,4 +107,205 @@ func StopCommand(cmd *exec.Cmd, logger *zap.Logger) error {
 	}
 
 	return nil
+}
+
+// PTYHandle represents a PTY session for interactive command execution
+type PTYHandle struct {
+	ptmx         *os.File
+	cmd          *exec.Cmd
+	logger       *zap.Logger
+	resizeCh     chan os.Signal
+	wg           sync.WaitGroup
+	oldTermState *term.State // Store original terminal state for restoration
+}
+
+// makeRawInputOnly sets the terminal to a mode suitable for PTY interaction:
+// - Disables local echo (ECHO) - let the PTY slave control echo
+// - Disables canonical mode (ICANON) - send chars immediately without line buffering
+// - Keeps ISIG enabled - so Ctrl+C generates SIGINT properly
+// - Keeps output processing (OPOST) enabled - so \n is converted to \r\n
+// This is different from term.MakeRaw() which disables ALL processing including output.
+func makeRawInputOnly(fd int) (*term.State, error) {
+	oldState, err := term.GetState(fd)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get current termios
+	termios, err := unix.IoctlGetTermios(fd, ioctlReadTermios)
+	if err != nil {
+		return nil, err
+	}
+
+	// Disable echo and canonical mode (input processing)
+	// Keep ISIG enabled so Ctrl+C works for interrupt signals
+	// Keep OPOST (output processing) enabled so \n -> \r\n conversion happens
+	termios.Lflag &^= unix.ECHO | unix.ECHONL | unix.ICANON | unix.IEXTEN
+	termios.Iflag &^= unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON
+	// Note: We do NOT disable OPOST in Oflag, keeping output processing enabled
+	termios.Cflag &^= unix.CSIZE | unix.PARENB
+	termios.Cflag |= unix.CS8
+	termios.Cc[unix.VMIN] = 1
+	termios.Cc[unix.VTIME] = 0
+
+	if err := unix.IoctlSetTermios(fd, ioctlWriteTermios, termios); err != nil {
+		return nil, err
+	}
+
+	return oldState, nil
+}
+
+// StartCommandWithPTY starts a command with a PTY for interactive input (e.g., sudo password).
+// Returns a PTYHandle that must be used to wait for the command and clean up resources.
+func StartCommandWithPTY(cmd *exec.Cmd, logger *zap.Logger) (*PTYHandle, error) {
+	// Start the command with a PTY
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		logger.Error("failed to start command with PTY", zap.Error(err))
+		return nil, err
+	}
+
+	handle := &PTYHandle{
+		ptmx:     ptmx,
+		cmd:      cmd,
+		logger:   logger,
+		resizeCh: make(chan os.Signal, 1),
+	}
+
+	// Set terminal to a mode suitable for PTY interaction:
+	// - Disable local echo (let the PTY slave control echo for password prompts)
+	// - Keep output processing enabled (so \n is converted to \r\n)
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		oldState, err := makeRawInputOnly(int(os.Stdin.Fd()))
+		if err != nil {
+			logger.Debug("failed to set terminal mode", zap.Error(err))
+		} else {
+			handle.oldTermState = oldState
+		}
+	}
+
+	// Handle terminal resize - propagate size changes from real terminal to PTY
+	signal.Notify(handle.resizeCh, syscall.SIGWINCH)
+	handle.wg.Add(1)
+	go func() {
+		defer handle.wg.Done()
+		for range handle.resizeCh {
+			if resizeErr := pty.InheritSize(os.Stdin, ptmx); resizeErr != nil {
+				if !isClosedPTYError(resizeErr) {
+					logger.Debug("failed to resize PTY", zap.Error(resizeErr))
+				}
+			}
+		}
+	}()
+	// Trigger initial resize
+	handle.resizeCh <- syscall.SIGWINCH
+
+	// Copy PTY output to real stdout (for agent logs, prompts, etc.)
+	go func() {
+		_, copyErr := io.Copy(os.Stdout, ptmx)
+		if copyErr != nil && !isClosedPTYError(copyErr) {
+			logger.Debug("error copying PTY output to stdout", zap.Error(copyErr))
+		}
+	}()
+
+	// Copy stdin to PTY (for password input, etc.)
+	go func() {
+		_, copyErr := io.Copy(ptmx, os.Stdin)
+		if copyErr != nil && !isClosedPTYError(copyErr) {
+			logger.Debug("error copying stdin to PTY", zap.Error(copyErr))
+		}
+	}()
+
+	return handle, nil
+}
+
+// Wait waits for the command to finish and cleans up PTY resources.
+func (h *PTYHandle) Wait() error {
+	// Wait for the command to finish
+	cmdErr := h.cmd.Wait()
+
+	// Restore terminal state before any other cleanup
+	if h.oldTermState != nil {
+		if restoreErr := term.Restore(int(os.Stdin.Fd()), h.oldTermState); restoreErr != nil {
+			h.logger.Debug("failed to restore terminal state", zap.Error(restoreErr))
+		}
+	}
+
+	// Stop listening for resize signals
+	signal.Stop(h.resizeCh)
+	// Drain any pending signals
+	select {
+	case <-h.resizeCh:
+	default:
+	}
+	close(h.resizeCh)
+
+	// Wait for the resize goroutine to finish
+	h.wg.Wait()
+
+	// Close PTY
+	if closeErr := h.ptmx.Close(); closeErr != nil {
+		h.logger.Debug("failed to close PTY", zap.Error(closeErr))
+	}
+
+	return cmdErr
+}
+
+// GetProcess returns the underlying process for signal handling
+func (h *PTYHandle) GetProcess() *os.Process {
+	if h.cmd != nil {
+		return h.cmd.Process
+	}
+	return nil
+}
+
+// StopPTYCommand gracefully stops a command running with PTY
+func StopPTYCommand(handle *PTYHandle, logger *zap.Logger) error {
+	if handle == nil || handle.cmd == nil || handle.cmd.Process == nil {
+		return nil
+	}
+
+	// Restore terminal state first
+	if handle.oldTermState != nil {
+		if restoreErr := term.Restore(int(os.Stdin.Fd()), handle.oldTermState); restoreErr != nil {
+			logger.Debug("failed to restore terminal state", zap.Error(restoreErr))
+		}
+		handle.oldTermState = nil // Prevent double restore
+	}
+
+	pid := handle.cmd.Process.Pid
+
+	// Send SIGTERM to the process
+	if err := handle.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		if err.Error() == "os: process already finished" {
+			logger.Debug("process already finished during graceful shutdown", zap.Int("pid", pid))
+			return nil
+		}
+		logger.Warn("failed to send SIGTERM to PTY process", zap.Int("pid", pid), zap.Error(err))
+		// Force kill
+		return handle.cmd.Process.Kill()
+	}
+
+	return nil
+}
+
+// isClosedPTYError checks if the error is due to the PTY being closed,
+// which is expected when the command finishes.
+func isClosedPTYError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	return err == io.EOF ||
+		strings.Contains(errStr, "input/output error") ||
+		strings.Contains(errStr, "file already closed") ||
+		strings.Contains(errStr, "bad file descriptor")
+}
+
+// ConfigureCommandForPTY configures the command's SysProcAttr for PTY execution.
+// On Unix, this sets Setsid to create a new session for the PTY.
+func ConfigureCommandForPTY(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setsid: true, // create new session for PTY
+	}
 }

--- a/pkg/platform/http/utils/termios_darwin.go
+++ b/pkg/platform/http/utils/termios_darwin.go
@@ -1,0 +1,11 @@
+//go:build darwin
+// +build darwin
+
+package utils
+
+import "golang.org/x/sys/unix"
+
+const (
+	ioctlReadTermios  = unix.TIOCGETA
+	ioctlWriteTermios = unix.TIOCSETA
+)

--- a/pkg/platform/http/utils/termios_linux.go
+++ b/pkg/platform/http/utils/termios_linux.go
@@ -1,0 +1,11 @@
+//go:build linux
+// +build linux
+
+package utils
+
+import "golang.org/x/sys/unix"
+
+const (
+	ioctlReadTermios  = unix.TCGETS
+	ioctlWriteTermios = unix.TCSETS
+)

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -87,7 +87,7 @@ func (a *Agent) Setup(ctx context.Context, startCh chan int) error {
 		utils.LogError(a.logger, err, "error during agent setup")
 		return err
 	}
-	a.logger.Info("Context cancelled, stopping the agent")
+	a.logger.Debug("Context cancelled, stopping the agent")
 	return context.Canceled
 
 }

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -183,13 +183,16 @@ func (r *Recorder) Start(ctx context.Context, reRecordCfg models.ReRecordCfg) er
 			return nil
 		})
 
-		agentCtx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		agentCtx, cancel := context.WithTimeout(ctx, 120*time.Second)
 		defer cancel()
 
 		agentReadyCh := make(chan bool, 1)
 		go pkg.AgentHealthTicker(agentCtx, r.logger, r.config.Agent.AgentURI, agentReadyCh, 1*time.Second)
 
 		select {
+		case <-ctx.Done():
+			// Parent context cancelled (user pressed Ctrl+C)
+			return ctx.Err()
 		case <-agentCtx.Done():
 			return fmt.Errorf("keploy-agent did not become ready in time")
 		case <-agentReadyCh:

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -733,13 +733,16 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			return nil
 		})
 
-		agentCtx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		agentCtx, cancel := context.WithTimeout(runTestSetCtx, 120*time.Second)
 		defer cancel()
 
 		agentReadyCh := make(chan bool, 1)
 		go pkg.AgentHealthTicker(agentCtx, r.logger, string(r.config.Agent.AgentURI), agentReadyCh, 1*time.Second)
 
 		select {
+		case <-runTestSetCtx.Done():
+			// Parent context cancelled (user pressed Ctrl+C)
+			return models.TestSetStatusUserAbort, runTestSetCtx.Err()
 		case <-agentCtx.Done():
 			return models.TestSetStatusFailed, fmt.Errorf("keploy-agent did not become ready in time")
 		case <-agentReadyCh:

--- a/utils/permissions_unix.go
+++ b/utils/permissions_unix.go
@@ -1,0 +1,377 @@
+//go:build linux || darwin
+
+package utils
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// CheckKeployFolderPermissions checks if the keploy folder and its contents are readable
+// and writable by the current user. Returns a list of paths with permission issues.
+func CheckKeployFolderPermissions(logger *zap.Logger, keployPath string) ([]PermissionError, error) {
+	var permissionErrors []PermissionError
+	currentUID := uint32(os.Getuid())
+
+	// Check if keploy folder exists
+	info, err := os.Stat(keployPath)
+	if os.IsNotExist(err) {
+		// Folder doesn't exist yet - no permission issues
+		return nil, nil
+	} else if err != nil {
+		// Can't even stat the folder - this is a permission issue
+		return []PermissionError{{Path: keployPath, OwnerUID: 0, IsRead: true}}, nil
+	}
+
+	// Folder exists, check if it's a directory
+	if !info.IsDir() {
+		return nil, fmt.Errorf("keploy path %s exists but is not a directory", keployPath)
+	}
+
+	// Walk the directory tree and check permissions
+	err = filepath.WalkDir(keployPath, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			// Access error - this indicates a permission issue
+			logger.Debug("cannot access path", zap.String("path", path), zap.Error(err))
+			ownerUID := uint32(0)
+			if fileInfo, statErr := os.Lstat(path); statErr == nil {
+				if stat, ok := fileInfo.Sys().(*syscall.Stat_t); ok {
+					ownerUID = stat.Uid
+				}
+			}
+			permissionErrors = append(permissionErrors, PermissionError{Path: path, OwnerUID: ownerUID, IsRead: true})
+			return filepath.SkipDir
+		}
+
+		// Get file info to check ownership
+		fileInfo, infoErr := d.Info()
+		if infoErr != nil {
+			return nil
+		}
+
+		// Check if file is owned by a different user (likely root)
+		if stat, ok := fileInfo.Sys().(*syscall.Stat_t); ok {
+			if stat.Uid != currentUID {
+				// File is owned by someone else - potential permission issue
+				// Verify by actually trying to open for read/write
+				hasIssue := false
+
+				if d.IsDir() {
+					// For directories, check if we can read and write
+					_, readErr := os.ReadDir(path)
+					if readErr != nil {
+						hasIssue = true
+					}
+					// Also check write permission by checking if we can create a temp file
+					// We use access() syscall equivalent - try to open with write flag
+					testFile := filepath.Join(path, ".keploy_perm_test")
+					f, writeErr := os.OpenFile(testFile, os.O_CREATE|os.O_WRONLY, 0644)
+					if writeErr != nil {
+						if os.IsPermission(writeErr) {
+							hasIssue = true
+						}
+					} else {
+						f.Close()
+						os.Remove(testFile)
+					}
+				} else {
+					// For files, try to open for reading and writing
+					f, readErr := os.OpenFile(path, os.O_RDONLY, 0)
+					if readErr != nil {
+						hasIssue = true
+					} else {
+						f.Close()
+					}
+
+					// Check write permission
+					f, writeErr := os.OpenFile(path, os.O_WRONLY, 0)
+					if writeErr != nil {
+						if os.IsPermission(writeErr) {
+							hasIssue = true
+						}
+					} else {
+						f.Close()
+					}
+				}
+
+				if hasIssue {
+					logger.Debug("permission issue detected",
+						zap.String("path", path),
+						zap.Uint32("ownerUID", stat.Uid),
+						zap.Uint32("currentUID", currentUID))
+					permissionErrors = append(permissionErrors, PermissionError{
+						Path:     path,
+						OwnerUID: stat.Uid,
+						IsRead:   false, // Could be read or write
+					})
+				}
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("error walking keploy directory: %w", err)
+	}
+
+	return permissionErrors, nil
+}
+
+// GetPermissionFixCommand returns the sudo command to fix keploy folder permissions.
+// This is used to prepend the fix command to docker commands so they run in the same PTY session.
+// Returns empty string if no fix is needed.
+func GetPermissionFixCommand(keployPath string) string {
+	currentUser, err := user.Current()
+	if err != nil {
+		return ""
+	}
+
+	return fmt.Sprintf("sudo chown -R %s %s", currentUser.Username, keployPath)
+}
+
+// FixKeployFolderPermissions attempts to fix permission issues on the keploy folder
+// by changing ownership to the current user using sudo chown.
+// It shows which files have issues and provides a timeout for the sudo password prompt.
+// If timeout is reached, it continues without fixing (with a warning).
+func FixKeployFolderPermissions(ctx context.Context, logger *zap.Logger, keployPath string, permErrors []PermissionError) error {
+	// Get current user
+	currentUser, err := user.Current()
+	if err != nil {
+		return fmt.Errorf("failed to get current user: %w", err)
+	}
+
+	// Log the files with permission issues
+	fmt.Println()
+	logger.Warn("The keploy folder contains files not accessible by current user (likely from running an older version with sudo).")
+
+	// Show the problematic files (up to 5, then "and X more...")
+	if len(permErrors) > 0 {
+		logger.Info("Files with permission issues:")
+		maxShow := 5
+		for i, pe := range permErrors {
+			if i >= maxShow {
+				logger.Info(fmt.Sprintf("  ... and %d more", len(permErrors)-maxShow))
+				break
+			}
+			logger.Info(fmt.Sprintf("  - %s (owner UID: %d)", pe.Path, pe.OwnerUID))
+		}
+	}
+
+	fmt.Println()
+	logger.Info("To fix this, we need to change ownership of the keploy folder to your user.")
+	fmt.Println()
+
+	// First, cache sudo credentials using sudo -v (this prompts for password)
+	cmd := exec.CommandContext(ctx, "sudo", "-v")
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		// Check if context was cancelled (user pressed Ctrl+C)
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		// Check if the process was killed by a signal (e.g., SIGINT from Ctrl+C)
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			// Exit code -1 or signal termination indicates interrupt
+			if exitErr.ExitCode() == -1 || strings.Contains(err.Error(), "signal") {
+				return context.Canceled
+			}
+		}
+		logger.Warn(fmt.Sprintf("Failed to authenticate sudo: %v", err))
+		logger.Warn(fmt.Sprintf("To fix manually, run: sudo chown -R %s %s", currentUser.Username, keployPath))
+		return fmt.Errorf("sudo authentication failed")
+	}
+
+	// Now run chown with cached credentials (should not prompt again)
+	logger.Info(fmt.Sprintf("Running: sudo chown -R %s %s", currentUser.Username, keployPath))
+	if err := runSudoChownNonInteractive(ctx, currentUser.Username, true, keployPath); err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		logger.Warn(fmt.Sprintf("Failed to fix permissions: %v", err))
+		logger.Warn(fmt.Sprintf("To fix manually, run: sudo chown -R %s %s", currentUser.Username, keployPath))
+		return fmt.Errorf("failed to fix permissions")
+	}
+
+	logger.Info("Successfully fixed keploy folder permissions")
+	return nil
+}
+
+// AreSudoCredentialsCached checks if sudo credentials are currently cached.
+// Returns true if already root or if sudo -n -v succeeds (credentials cached).
+func AreSudoCredentialsCached() bool {
+	// Already root - no sudo needed
+	if os.Geteuid() == 0 {
+		return true
+	}
+
+	// Check if credentials are cached using sudo -n -v
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	checkCmd := exec.CommandContext(ctx, "sudo", "-n", "-v")
+	return checkCmd.Run() == nil
+}
+
+// CacheSudoCredentials prompts for sudo password and caches the credentials.
+// This uses sudo -v which validates and caches credentials without running a command.
+// The cached credentials will be used by subsequent sudo calls (including the agent).
+// If already root or credentials are already cached, this is a no-op.
+func CacheSudoCredentials(ctx context.Context, logger *zap.Logger) error {
+	// No need to cache if already root
+	if os.Geteuid() == 0 {
+		return nil
+	}
+
+	// Check if credentials are already cached using sudo -n -v
+	checkCmd := exec.CommandContext(ctx, "sudo", "-n", "-v")
+	if err := checkCmd.Run(); err == nil {
+		// Credentials already cached
+		logger.Debug("Sudo credentials already cached")
+		return nil
+	}
+
+	logger.Info("Enter sudo password (will be cached for subsequent operations).")
+
+	// Run sudo -v to validate and cache credentials
+	cmd := exec.CommandContext(ctx, "sudo", "-v")
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}
+
+// runSudoChownNonInteractive runs sudo chown using cached credentials (non-interactive).
+func runSudoChownNonInteractive(ctx context.Context, username string, recursive bool, path string) error {
+	args := []string{"-n", "chown"} // -n = non-interactive, fail if password needed
+	if recursive {
+		args = append(args, "-R")
+	}
+	args = append(args, username, path)
+
+	cmd := exec.CommandContext(ctx, "sudo", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}
+
+// runSudoChown runs sudo chown with proper terminal handling.
+// It resets the terminal to sane mode before running sudo to ensure password input works correctly.
+func runSudoChown(ctx context.Context, username string, recursive bool, path string) error {
+	// Open /dev/tty for direct terminal access
+	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	if err != nil {
+		return fmt.Errorf("failed to open /dev/tty: %w", err)
+	}
+	defer tty.Close()
+
+	// Reset terminal to sane mode before running sudo
+	// This ensures the terminal is in canonical mode with echo properly controlled
+	sttyCmd := exec.CommandContext(ctx, "stty", "sane", "-F", "/dev/tty")
+	_ = sttyCmd.Run() // Ignore errors, best effort
+
+	// Build the chown command
+	args := []string{"chown"}
+	if recursive {
+		args = append(args, "-R")
+	}
+	args = append(args, username, path)
+
+	cmd := exec.CommandContext(ctx, "sudo", args...)
+	cmd.Stdin = tty
+	cmd.Stdout = tty
+	cmd.Stderr = tty
+
+	return cmd.Run()
+}
+
+// FixFilePermission attempts to fix permission issues on a specific file by changing ownership.
+// This is called when a file operation (read or write) fails due to permission issues,
+// typically because the file is owned by root from an older sudo-based keploy version.
+func FixFilePermission(ctx context.Context, logger *zap.Logger, filePath string) error {
+	// Get current user
+	currentUser, err := user.Current()
+	if err != nil {
+		return fmt.Errorf("failed to get current user: %w", err)
+	}
+
+	logger.Warn("Cannot access file (likely owned by root from older keploy version)",
+		zap.String("path", filePath))
+	logger.Info(fmt.Sprintf("Running: sudo chown %s %s", currentUser.Username, filePath))
+
+	if err := runSudoChown(ctx, currentUser.Username, false, filePath); err != nil {
+		return fmt.Errorf("failed to change ownership of %s: %w. Please run manually: sudo chown %s %s", filePath, err, currentUser.Username, filePath)
+	}
+
+	logger.Debug("Successfully fixed file permission", zap.String("path", filePath))
+	return nil
+}
+
+// EnsureKeployFolderPermissions checks and fixes permission issues (both read and write) on the keploy folder.
+// This should be called once at startup before any file operations to ensure all files
+// are accessible by the current user. This prevents permission errors during test execution.
+// If deferForDocker is true, it stores the fix info for later use by docker PTY session instead of fixing now.
+func EnsureKeployFolderPermissions(ctx context.Context, logger *zap.Logger, keployPath string, deferForDocker bool) error {
+	// Check if keploy folder exists
+	if _, err := os.Stat(keployPath); os.IsNotExist(err) {
+		// Folder doesn't exist yet - no permission issues to fix
+		return nil
+	}
+
+	permErrors, err := CheckKeployFolderPermissions(logger, keployPath)
+	if err != nil {
+		return fmt.Errorf("failed to check keploy folder permissions: %w", err)
+	}
+
+	if len(permErrors) == 0 {
+		// No permission issues
+		PendingPermissionFix.HasIssues = false
+		return nil
+	}
+
+	// Log the problematic paths at debug level
+	logger.Debug("Found files/directories with permission issues in keploy folder", zap.Int("count", len(permErrors)))
+
+	if deferForDocker {
+		// Store for later - docker PTY will handle this
+		PendingPermissionFix.HasIssues = true
+		PendingPermissionFix.KeployPath = keployPath
+		PendingPermissionFix.PermErrors = permErrors
+
+		// Log the issue info so user knows what's happening
+		fmt.Println()
+		logger.Warn("The keploy folder contains files not accessible by current user (likely from running an older version with sudo).")
+		if len(permErrors) > 0 {
+			logger.Info("Files with permission issues:")
+			maxShow := 5
+			for i, pe := range permErrors {
+				if i >= maxShow {
+					logger.Info(fmt.Sprintf("  ... and %d more", len(permErrors)-maxShow))
+					break
+				}
+				logger.Info(fmt.Sprintf("  - %s (owner UID: %d)", pe.Path, pe.OwnerUID))
+			}
+		}
+		fmt.Println()
+		logger.Info("Permission fix will be included with the docker command (single password prompt).")
+		return nil
+	}
+
+	// Fix permissions on the entire keploy folder
+	// sudo -v will cache credentials, which will be used by subsequent sudo -n commands
+	return FixKeployFolderPermissions(ctx, logger, keployPath, permErrors)
+}

--- a/utils/permissions_windows.go
+++ b/utils/permissions_windows.go
@@ -1,0 +1,51 @@
+//go:build windows
+
+package utils
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+)
+
+// CheckKeployFolderPermissions is a no-op on Windows.
+// Windows doesn't use the Unix permission model, so we don't need to check for permission issues.
+func CheckKeployFolderPermissions(_ *zap.Logger, _ string) ([]PermissionError, error) {
+	return nil, nil
+}
+
+// GetPermissionFixCommand returns empty string on Windows.
+// Permission fixes using sudo/chown are not applicable on Windows.
+func GetPermissionFixCommand(_ string) string {
+	return ""
+}
+
+// FixKeployFolderPermissions is a no-op on Windows.
+// Permission fixes using sudo/chown are not applicable on Windows.
+func FixKeployFolderPermissions(_ context.Context, _ *zap.Logger, _ string, _ []PermissionError) error {
+	return nil
+}
+
+// AreSudoCredentialsCached always returns true on Windows.
+// Sudo is not used on Windows, so we treat it as if credentials are always available.
+func AreSudoCredentialsCached() bool {
+	return true
+}
+
+// CacheSudoCredentials is a no-op on Windows.
+// Sudo is not used on Windows.
+func CacheSudoCredentials(_ context.Context, _ *zap.Logger) error {
+	return nil
+}
+
+// FixFilePermission is a no-op on Windows.
+// Permission fixes using sudo/chown are not applicable on Windows.
+func FixFilePermission(_ context.Context, _ *zap.Logger, _ string) error {
+	return nil
+}
+
+// EnsureKeployFolderPermissions is a no-op on Windows.
+// Permission fixes using sudo/chown are not applicable on Windows.
+func EnsureKeployFolderPermissions(_ context.Context, _ *zap.Logger, _ string, _ bool) error {
+	return nil
+}

--- a/utils/reexec_unix.go
+++ b/utils/reexec_unix.go
@@ -1,0 +1,110 @@
+//go:build linux || darwin
+
+package utils
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"go.uber.org/zap"
+)
+
+// ReexecWithSudo re-executes the current keploy command with sudo.
+// This is used when a Docker/Docker Compose command is detected and keploy is not running as root.
+// Uses syscall.Exec to replace the current process entirely - no parent process remains.
+// This function never returns on success.
+func ReexecWithSudo(logger *zap.Logger) {
+	// Get the current PATH to preserve it
+	currentPath := os.Getenv("PATH")
+
+	// Find sudo binary
+	sudoPath, err := exec.LookPath("sudo")
+	if err != nil {
+		logger.Error("sudo not found in PATH, cannot re-execute with elevated privileges", zap.Error(err))
+		fmt.Println("Error: sudo is required to run Docker commands. Please install sudo or run as root.")
+		os.Exit(1)
+	}
+
+	// Find keploy binary - use the current executable
+	keployPath, err := os.Executable()
+	if err != nil {
+		logger.Error("failed to get current executable path", zap.Error(err))
+		os.Exit(1)
+	}
+
+	// Build the command: sudo -E env PATH="$PATH" keploy <original-args>
+	// -E preserves the environment
+	// env PATH="$PATH" ensures PATH is explicitly set (some sudo configs reset PATH)
+	args := []string{
+		"sudo",
+		"-E",
+		"env",
+		fmt.Sprintf("PATH=%s", currentPath),
+		keployPath,
+	}
+	// Append original arguments (skip the first one which is the program name)
+	args = append(args, os.Args[1:]...)
+
+	logger.Info("Docker command detected, re-executing with sudo for elevated privileges...")
+	logger.Debug("Re-exec command", zap.Strings("args", args))
+	logger.Info("Re-exec command", zap.Strings("args", args))
+
+	// Use syscall.Exec to replace the current process
+	// This means no parent process remains - clean handoff
+	err = syscall.Exec(sudoPath, args, os.Environ())
+	if err != nil {
+		// syscall.Exec only returns on error
+		logger.Error("failed to re-execute with sudo", zap.Error(err))
+		fmt.Printf("Error: failed to re-execute with sudo: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// ShouldReexecWithSudo checks if keploy should re-execute itself with sudo.
+// Returns true if:
+// 1. A Docker/Docker Compose command is detected in the -c/--command flag
+// 2. Keploy is NOT currently running as root
+func ShouldReexecWithSudo() bool {
+	// Already running as root - no need to re-exec
+	if os.Geteuid() == 0 {
+		return false
+	}
+
+	// Extract the command from arguments
+	cmd := ExtractCommandFromArgs(os.Args)
+	if cmd == "" {
+		return false
+	}
+
+	// Check if it's a Docker command
+	cmdType := FindDockerCmd(cmd)
+	return IsDockerCmd(cmdType)
+}
+
+// ExtractCommandFromArgs parses os.Args to find the value of -c or --command flag.
+// Returns empty string if not found.
+func ExtractCommandFromArgs(args []string) string {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+
+		// Check for -c or --command
+		if arg == "-c" || arg == "--command" {
+			// Next argument is the command value
+			if i+1 < len(args) {
+				return args[i+1]
+			}
+			return ""
+		}
+
+		// Check for -c=value or --command=value format
+		if len(arg) > 3 && arg[:3] == "-c=" {
+			return arg[3:]
+		}
+		if len(arg) > 10 && arg[:10] == "--command=" {
+			return arg[10:]
+		}
+	}
+	return ""
+}

--- a/utils/reexec_windows.go
+++ b/utils/reexec_windows.go
@@ -1,0 +1,47 @@
+//go:build windows
+
+package utils
+
+import (
+	"go.uber.org/zap"
+)
+
+// ReexecWithSudo is a no-op on Windows.
+// Docker Desktop on Windows handles permissions differently and doesn't require sudo.
+// If this is called on Windows, it means there's a logic error - we should never
+// try to re-exec with sudo on Windows.
+func ReexecWithSudo(logger *zap.Logger) {
+	logger.Debug("ReexecWithSudo called on Windows - this is a no-op")
+}
+
+// ShouldReexecWithSudo always returns false on Windows.
+// Docker Desktop on Windows handles permissions differently and doesn't require sudo.
+func ShouldReexecWithSudo() bool {
+	return false
+}
+
+// ExtractCommandFromArgs parses os.Args to find the value of -c or --command flag.
+// Returns empty string if not found.
+func ExtractCommandFromArgs(args []string) string {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+
+		// Check for -c or --command
+		if arg == "-c" || arg == "--command" {
+			// Next argument is the command value
+			if i+1 < len(args) {
+				return args[i+1]
+			}
+			return ""
+		}
+
+		// Check for -c=value or --command=value format
+		if len(arg) > 3 && arg[:3] == "-c=" {
+			return arg[3:]
+		}
+		if len(arg) > 10 && arg[:10] == "--command=" {
+			return arg[10:]
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Describe the changes that are made
- When keploy detects a Docker/Docker Compose command in the -c flag and isn't running as root, it automatically re-executes itself with elevated privileges using syscall.Exec().

Key changes:
- Add ReexecWithSudo() using syscall.Exec() for clean process handoff
- Add PTY support for interactive sudo password prompts in native agent
- Restore keploy folder ownership to SUDO_USER after execution
- Remove manual 'sudo -E env PATH=$PATH' from workflow scripts
- Update keploy.sh to only set sudo alias for v2.x.x versions

## Links & References

**Closes:** https://github.com/keploy/keploy/issues/3654
- NA (if very small change like typo, linting, etc.)

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [x] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert