### PR TITLE
fix: use localhost by default as host in test mode

### DIFF
--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1048,12 +1048,17 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			break
 		}
 
-		// Handle user-provided host replacement
-		if r.config.Test.Host != "" {
-			err = r.replaceHostInTestCase(testCase, r.config.Test.Host, "host provided by the user")
-			if err != nil {
-				break
-			}
+		// Handle host replacement - use user-provided host or default to localhost
+		// This is necessary because the agent architecture doesn't intercept the test runner's
+		// network requests (unlike the eBPF approach in v2), so we need to explicitly
+		// replace the recorded hostname with a reachable address.
+		hostToUse := r.config.Test.Host
+		if hostToUse == "" {
+			hostToUse = "localhost"
+		}
+		err = r.replaceHostInTestCase(testCase, hostToUse, "target host")
+		if err != nil {
+			break
 		}
 
 		// Handle user-provided http port replacement


### PR DESCRIPTION
## Describe the changes that are made

This pull request updates the logic for host replacement in the `RunTestSet` method of the `Replayer` service. Now, if the user does not provide a host, the code defaults to using `localhost` instead of skipping host replacement. This ensures that test cases always use a reachable address, which is necessary due to the current agent architecture.

- **Test host replacement logic update:**
  - The host used in test cases is now set to the user-provided host if available, otherwise it defaults to `localhost`. This change ensures network requests are correctly routed in environments where the test runner's network traffic is not intercepted by the agent. (`pkg/service/replay/replay.go`, [pkg/service/replay/replay.goL1051-L1057](diffhunk://#diff-e6489c0602898b5fed439b3c4c42885db5890483591af1991adc497ba59e31d9L1051-L1057))

## Links & References

**Closes:** #[issue number that will be closed through this PR]
- NA (if very small change like typo, linting, etc.)

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [x] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?