### PR TITLE
fix: remove readyChan double-send deadlock in proxy StartProxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,14 @@ Prefer a calendar invite? Mention your availability in the email—we’ll send 
 
 ---
 
+## Known Issues & Bug Fixes
+
+| Status | Severity | Description |
+|--------|----------|-------------|
+| ✅ Fixed | **Critical** | **Proxy `readyChan` double-send deadlock** — The `StartProxy` goroutine wrapper sent to `readyChan` after `start()` returned, but `start()` already sends exactly once internally. On the capacity-1 buffered channel this caused a permanent goroutine deadlock when the proxy port was already in use (e.g., rapid restart, port conflict). Fixed by removing the redundant send in the `g.Go` closure. See [`pkg/agent/proxy/proxy.go`](pkg/agent/proxy/proxy.go). |
+
+---
+
 ## Contribute & Collaborate
 
 Whether you're new or experienced, your input matters. Help us improve Keploy by contributing code, reporting issues, or sharing feedback.

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -169,7 +169,9 @@ func (p *Proxy) StartProxy(ctx context.Context, opts agent.ProxyOptions) error {
 	g.Go(func() error {
 		defer utils.Recover(p.logger)
 		err := p.start(ctx, readyChan)
-		readyChan <- err
+		// Don't send to readyChan here — start() already signals readiness/failure
+		// via readyChan internally. A second send on this capacity-1 channel would
+		// deadlock when the buffer is full (e.g., port already in use).
 		if err != nil {
 			utils.LogError(p.logger, err, "error while running the proxy server")
 			return err


### PR DESCRIPTION
The g.Go wrapper in StartProxy sent to readyChan after start() returned, but start() already sends exactly once to readyChan internally (error on bind failure at L266, nil on success at L272). The redundant send on the capacity-1 buffered channel caused a permanent goroutine deadlock when the port was already in use, because the buffer was full after start()'s send and the second send blocked forever.

Removed the duplicate 'readyChan <- err' in the g.Go closure. start() handles all signaling to readyChan, so the wrapper only needs to log and propagate the error via errgroup.

Impact: fixes goroutine leak and potential hang in StartProxy when the proxy port is occupied (e.g., rapid restart, port conflict).

## Describe the changes that are made
- 

## Links & References

Closes: #[issue number that will be closed through this PR]
- NA (if very small change like typo, linting, etc.)

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [x] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [x] 🔥 Performance Improvements
- [x] ✅ Test
- [x] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

Examples:

- PR Title: `fix: patch MongoDB document update bug`  
- Branch Name: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [ ] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [ ] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [ ] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?