### PR TITLE
fix: changed AAAA fallback to return empty instead of synthetic loopback/proxy IPv6

### DIFF
--- a/pkg/agent/proxy/dns.go
+++ b/pkg/agent/proxy/dns.go
@@ -169,11 +169,11 @@ func (p *Proxy) defaultDNSAnswers(question dns.Question) []dns.RR {
 		}}
 
 	case dns.TypeAAAA:
-		p.logger.Debug("failed to resolve dns query hence sending proxy ip6", zap.Any("proxy Ip", p.IP6))
-		return []dns.RR{&dns.AAAA{
-			Hdr:  dns.RR_Header{Name: question.Name, Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 3600},
-			AAAA: net.ParseIP(p.IP6),
-		}}
+		// Do not synthesize AAAA fallback (::1/proxy IPv6). For environments that are IPv4-only
+		// (for example many docker bridge networks), returning a synthetic IPv6 answer can make
+		// clients prefer an unreachable ::1 destination.
+		p.logger.Debug("no AAAA answer resolved; returning empty AAAA response")
+		return nil
 
 	case dns.TypeSRV:
 		// Special handling for MongoDB SRV queries


### PR DESCRIPTION

## Describe the changes that are made

## Description

This PR fixes a regression introduced after enabling UDP DNS interception via `cgroup/sendmsg4` and `cgroup/sendmsg6`.

## Context

Recent changes made Keploy intercept more unconnected UDP DNS traffic. That exposed an existing DNS fallback behavior for AAAA queries.

## Problem

In Docker-based pipelines (`run_golang_docker` and `python_docker`), DNS misses for AAAA were returning a synthetic IPv6 fallback (`::1` / proxy IPv6). Some clients then preferred IPv6 and attempted connections like `[::1]:5432`, which failed with `connect: connection refused`.

## Root Cause

The fallback itself existed earlier, but it was rarely observed because many UDP DNS queries were not routed through Keploy DNS. After UDP sendmsg interception, those queries were handled by Keploy DNS, so the AAAA fallback started affecting real connection routing.

## What Changed

**File updated:** `dns.go`

- In `defaultDNSAnswers`, `dns.TypeAAAA` no longer returns synthetic proxy IPv6
- On unresolved AAAA queries, Keploy now returns an empty AAAA answer (`nil`), avoiding loopback poisoning
- Existing fallback behavior for A, SRV, MX, and TXT remains unchanged

## Expected Impact

- Prevents incorrect IPv6 loopback resolution in containerized environments
- Keeps IPv4 fallback behavior intact
- Reduces risk of DB/app startup failures caused by `[::1]` dial attempts

## Backward Compatibility

- **Low risk:** only affects unresolved AAAA fallback behavior
- Does not change successful DNS resolution behavior

## Links & References

**Closes:** #[issue number that will be closed through this PR]
- NA (if very small change like typo, linting, etc.)

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [ ] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

## Self Review done?
- [ ] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [ ] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [ ] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [ ] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?