### PR TITLE
fix(utgen): resolve staticcheck linter warnings in utgen package

### DIFF
--- a/pkg/service/utgen/gen.go
+++ b/pkg/service/utgen/gen.go
@@ -238,7 +238,7 @@ func (g *UnitTestGenerator) Start(ctx context.Context) error {
 				}
 
 				// modify the source code for refactoring.
-				if !(strings.Contains(testsDetails.RefactoredSourceCode, "blank output don't refactor code") || strings.Contains(testsDetails.RefactoredSourceCode, "no refactoring")) {
+				if !strings.Contains(testsDetails.RefactoredSourceCode, "blank output don't refactor code") && !strings.Contains(testsDetails.RefactoredSourceCode, "no refactoring") {
 					if err := os.WriteFile(g.srcPath, []byte(testsDetails.RefactoredSourceCode), 0644); err != nil {
 						return fmt.Errorf("failed to refactor source code:%w", err)
 					}
@@ -805,7 +805,7 @@ func (g *UnitTestGenerator) saveFailedTestCasesToFile() error {
 		builder.WriteString(strings.Repeat("-", 49) + "\n")
 	}
 
-	_, err = fileHandle.WriteString(fmt.Sprintf("%s\n", builder.String()))
+	_, err = fmt.Fprintf(fileHandle, "%s\n", builder.String())
 	if err != nil {
 		return fmt.Errorf("error writing to discarded tests file: %w", err)
 	}

--- a/pkg/service/utgen/prompt.go
+++ b/pkg/service/utgen/prompt.go
@@ -114,7 +114,7 @@ func formatSection(content, templateText string) (string, error) {
 	}
 	tmpl, err := template.New("section").Parse(templateText)
 	if err != nil {
-		return "", fmt.Errorf("Error parsing section template: %v", err)
+		return "", fmt.Errorf("error parsing section template: %v", err)
 	}
 	var buffer bytes.Buffer
 	err = tmpl.Execute(&buffer, map[string]string{
@@ -123,7 +123,7 @@ func formatSection(content, templateText string) (string, error) {
 		"FailedTestRuns":         content,
 	})
 	if err != nil {
-		return "", fmt.Errorf("Error executing section template: %v", err)
+		return "", fmt.Errorf("error executing section template: %v", err)
 	}
 	return buffer.String(), nil
 }
@@ -159,7 +159,7 @@ func (pb *PromptBuilder) BuildPrompt(file, failedTestRuns string) (*Prompt, erro
 	if err != nil {
 		prompt.System = ""
 		prompt.User = ""
-		return prompt, fmt.Errorf("Error rendering system prompt: %v", err)
+		return prompt, fmt.Errorf("error rendering system prompt: %v", err)
 	}
 	prompt.System = systemPrompt
 
@@ -167,7 +167,7 @@ func (pb *PromptBuilder) BuildPrompt(file, failedTestRuns string) (*Prompt, erro
 	if err != nil {
 		prompt.System = ""
 		prompt.User = ""
-		return prompt, fmt.Errorf("Error rendering user prompt: %v", err)
+		return prompt, fmt.Errorf("error rendering user prompt: %v", err)
 	}
 	userPrompt = html.UnescapeString(userPrompt)
 	prompt.User = userPrompt

--- a/pkg/service/utgen/utils.go
+++ b/pkg/service/utgen/utils.go
@@ -318,7 +318,7 @@ func createTestFile(testFilePath string, sourceFilePath string) (bool, error) {
 		}()
 
 		// Write initial content to the test file
-		_, err = file.WriteString(fmt.Sprintf("// Unit test for %s\n", filepath.Base(sourceFilePath)))
+		_, err = fmt.Fprintf(file, "// Unit test for %s\n", filepath.Base(sourceFilePath))
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
**Addressed staticcheck issues in the utgen package:**
1-gen.go: Applied De Morgan's law (QF1001) and optimized file writing (QF1012).
2-prompt.go: Fixed capitalized error string (ST1005),.
3-utils.go: Optimized file writing using fmt.Fprintf (QF1012).