### PR TITLE
feat: auto-set test delay based on recording startup time

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,10 +3,14 @@ package config
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
 	"go.keploy.io/server/v3/pkg/models"
+	yaml3 "gopkg.in/yaml.v3"
 )
 
 type MockDownload struct {
@@ -285,4 +289,71 @@ func SetSelectedTestsNormalize(conf *Config, value string) error {
 
 	conf.Normalize.SelectedTests = selected
 	return nil
+}
+
+// UpdateTestDelay reads the existing keploy.yml config file at the given configPath,
+// updates the test.delay field with the measured startup delay, and writes it back.
+//
+// This uses yaml.v3's Node API to walk the YAML tree and update the value in-place,
+// preserving the original field order, comments, and formatting.
+func UpdateTestDelay(configPath string, delay uint64) error {
+	configFilePath := filepath.Join(configPath, "keploy.yml")
+
+	data, err := os.ReadFile(configFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to read config file %s: %w", configFilePath, err)
+	}
+
+	var doc yaml3.Node
+	if err := yaml3.Unmarshal(data, &doc); err != nil {
+		return fmt.Errorf("failed to parse config file: %w", err)
+	}
+
+	// The document node wraps the root mapping node
+	if doc.Kind != yaml3.DocumentNode || len(doc.Content) == 0 {
+		return fmt.Errorf("unexpected YAML structure in config file")
+	}
+	root := doc.Content[0]
+
+	// Find the "test" mapping key in the root
+	if err := setNestedYAMLValue(root, []string{"test", "delay"}, strconv.FormatUint(delay, 10)); err != nil {
+		return fmt.Errorf("failed to update test.delay: %w", err)
+	}
+
+	// Marshal back preserving formatting
+	updatedData, err := yaml3.Marshal(&doc)
+	if err != nil {
+		return fmt.Errorf("failed to marshal updated config: %w", err)
+	}
+
+	if err := os.WriteFile(configFilePath, updatedData, 0644); err != nil {
+		return fmt.Errorf("failed to write updated config file: %w", err)
+	}
+
+	return nil
+}
+
+// setNestedYAMLValue traverses a yaml.Node tree by key path and sets the scalar value.
+func setNestedYAMLValue(node *yaml3.Node, keys []string, value string) error {
+	if node.Kind != yaml3.MappingNode {
+		return fmt.Errorf("expected mapping node, got kind %d", node.Kind)
+	}
+
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		keyNode := node.Content[i]
+		valNode := node.Content[i+1]
+
+		if keyNode.Value == keys[0] {
+			if len(keys) == 1 {
+				// Found the target key — update the scalar value
+				valNode.Value = value
+				valNode.Tag = "!!int"
+				return nil
+			}
+			// Recurse into nested mapping
+			return setNestedYAMLValue(valNode, keys[1:], value)
+		}
+	}
+
+	return fmt.Errorf("key %q not found in YAML", keys[0])
 }

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -88,6 +88,11 @@ func (r *Recorder) Start(ctx context.Context, reRecordCfg models.ReRecordCfg) er
 	domainSet := telemetry.NewDomainSet()
 	var recordingStarted bool
 
+	// Auto-delay measurement: track when recording started and the computed delay
+	var recordStartTime time.Time
+	var measuredAutoDelay uint64
+	var firstTestReceived bool
+
 	// defering the stop function to stop keploy in case of any error in record or in case of context cancellation
 	defer func() {
 		select {
@@ -137,6 +142,16 @@ func (r *Recorder) Start(ctx context.Context, reRecordCfg models.ReRecordCfg) er
 				"host-domains": domainSet.ToSlice(),
 			})
 		}
+
+		// Persist the measured auto-delay to the test.delay field in keploy config
+		if measuredAutoDelay > 0 && r.config.ConfigPath != "" {
+			if updateErr := config.UpdateTestDelay(r.config.ConfigPath, measuredAutoDelay); updateErr != nil {
+				r.logger.Debug("Could not persist auto-delay to config file", zap.Error(updateErr))
+			} else {
+				r.logger.Info(fmt.Sprintf("Saved auto-delay of %ds to test.delay in keploy config. This will be used during 'keploy test'.", measuredAutoDelay))
+			}
+		}
+
 		if s, ok := r.telemetry.(interface{ Shutdown() }); ok {
 			s.Shutdown()
 		}
@@ -185,6 +200,9 @@ func (r *Recorder) Start(ctx context.Context, reRecordCfg models.ReRecordCfg) er
 	for i, port := range passPortsUint {
 		passPortsUint32[i] = uint32(port)
 	}
+
+	// Record the start time for auto-delay measurement
+	recordStartTime = time.Now()
 
 	// Instrument will setup the environment and start the hooks and proxy
 	err := r.instrumentation.Setup(setupCtx, r.config.Command, models.SetupOptions{Container: r.config.ContainerName, DockerDelay: r.config.BuildDelay, Mode: models.MODE_RECORD, CommandType: r.config.CommandType, EnableTesting: false, GlobalPassthrough: r.config.Record.GlobalPassthrough, BuildDelay: r.config.BuildDelay, PassThroughPorts: passPortsUint, ConfigPath: r.config.ConfigPath})
@@ -263,6 +281,16 @@ func (r *Recorder) Start(ctx context.Context, reRecordCfg models.ReRecordCfg) er
 	r.mockDB.ResetCounterID() // Reset mock ID counter for each recording session
 	errGrp.Go(func() error {
 		for testCase := range frames.Incoming {
+			// Measure startup time on first test case arrival
+			if !firstTestReceived && !recordStartTime.IsZero() {
+				firstTestReceived = true
+				startupDuration := time.Since(recordStartTime)
+				bufferSeconds := uint64(10)
+				measuredAutoDelay = uint64(startupDuration.Seconds()) + bufferSeconds
+				r.logger.Info(fmt.Sprintf("Measured application startup time: %v. Auto-setting test delay to %ds (startup + %ds buffer).",
+					startupDuration.Round(time.Second), measuredAutoDelay, bufferSeconds))
+			}
+
 			testCase.Curl = pkg.MakeCurlCommand(testCase.HTTPReq)
 			domainSet.AddAll(telemetry.ExtractDomainsFromTestCase(testCase))
 			if reRecordCfg.TestSet == "" {

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -33,6 +33,7 @@ import (
 	"go.keploy.io/server/v3/utils"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/term"
 )
 
 var (
@@ -872,10 +873,8 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			utils.LogError(r.logger, err, "Failed to make the request to make agent ready for the docker compose")
 		}
 
-		// Delay for user application to run
-		select {
-		case <-time.After(time.Duration(r.config.Test.Delay) * time.Second):
-		case <-runTestSetCtx.Done():
+		// Delay for user application to run (with countdown)
+		if err := r.countdownDelay(runTestSetCtx, r.config.Test.Delay, testSetID); err != nil {
 			return models.TestSetStatusUserAbort, context.Canceled
 		}
 	}
@@ -1011,10 +1010,8 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 				return nil
 			})
 
-			// Delay for user application to run
-			select {
-			case <-time.After(time.Duration(r.config.Test.Delay) * time.Second):
-			case <-runTestSetCtx.Done():
+			// Delay for user application to run (with countdown)
+			if err := r.countdownDelay(runTestSetCtx, r.config.Test.Delay, testSetID); err != nil {
 				return models.TestSetStatusUserAbort, context.Canceled
 			}
 
@@ -2383,4 +2380,56 @@ func (r *Replayer) determineMockingStrategy(ctx context.Context, testSetID strin
 	r.logger.Debug("No meaningful mappings found, using timestamp-based mock filtering strategy (legacy approach)",
 		zap.String("testSetID", testSetID))
 	return false, defaultMappings
+}
+
+// countdownDelay waits for the configured delay before replaying tests.
+// For interactive terminals, it displays a live countdown timer.
+// For non-interactive terminals, it logs a single message.
+func (r *Replayer) countdownDelay(ctx context.Context, delaySec uint64, testSetID string) error {
+	if delaySec == 0 {
+		return nil
+	}
+
+	isInteractive := !r.config.DisableANSI && term.IsTerminal(int(os.Stderr.Fd()))
+
+	if !isInteractive {
+		// Non-interactive: single log message
+		r.logger.Info(fmt.Sprintf("Waiting %ds for application to start before replaying %q...", delaySec, testSetID))
+		select {
+		case <-time.After(time.Duration(delaySec) * time.Second):
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	// Interactive: live countdown timer
+	remaining := delaySec
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	// Format the message template to calculate the clear width dynamically
+	countdownMsg := fmt.Sprintf("\r🕐 Replaying %q in %ds...", testSetID, remaining)
+	// Use the longest possible message length (initial count) + padding for safety
+	clearWidth := len(countdownMsg) + 4
+	clearLine := fmt.Sprintf("\r%s\r\n", strings.Repeat(" ", clearWidth))
+
+	// Print initial countdown
+	fmt.Fprint(os.Stderr, countdownMsg)
+
+	for {
+		select {
+		case <-ticker.C:
+			remaining--
+			if remaining == 0 {
+				// Clear the countdown line and move to a new line
+				fmt.Fprint(os.Stderr, clearLine)
+				return nil
+			}
+			fmt.Fprintf(os.Stderr, "\r🕐 Replaying %q in %ds...  ", testSetID, remaining)
+		case <-ctx.Done():
+			fmt.Fprint(os.Stderr, clearLine)
+			return ctx.Err()
+		}
+	}
 }


### PR DESCRIPTION
## Describe the changes that are made
- During `keploy record`, the time between instrumentation start and the first captured test case is measured as the application startup time.
- This startup duration + a 10-second buffer is automatically written to the `test.delay` field in `keploy.yml`.
- On subsequent `keploy test` runs, the auto-detected delay is used without any user configuration.
- No schema changes — uses the existing `test.delay` config field.
- **Config update uses yaml.v3 Node API** to preserve original field order, comments, and formatting in `keploy.yml`.
- **Countdown timer during replay delay:**
  - **Interactive terminals:** Live countdown display (e.g., `🕐 Replaying "test-set-0" in 10s...9s...1s`) with dynamically calculated clear width
  - **Non-interactive terminals:** Single log message fallback (e.g., `Waiting 10s for application to start before replaying "test-set-0"`)

## Links & References

**Closes:** #3575

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- #3575 — [feature]: automatically set delay based on recording time
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [x] 🍕 Feature
- [ ] �� Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they are not needed

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

### Steps to test:
1. Build keploy: `go build -o keploy .`
2. Check default delay: `cat keploy.yml | grep "delay:"` → should show `delay: 5`
3. Record: `sudo ./keploy record -c "<app-command>" --config-path "."`
4. Hit an API endpoint on your app, then Ctrl+C to stop
5. Check updated delay: `cat keploy.yml | grep "delay:"` → should show `delay: <startup_time + 10>`
6. Test: `sudo ./keploy test -c "<app-command>" --config-path "."` → uses auto-detected delay with countdown timer

### Files changed:
| File | Change |
|------|--------|
| `config/config.go` | `UpdateTestDelay()` + `setNestedYAMLValue()` using yaml.v3 Node API |
| `pkg/service/record/record.go` | Measures startup time on first test case arrival, persists via `UpdateTestDelay()` |
| `pkg/service/replay/replay.go` | Countdown timer with dynamic clear width and newline handling |

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- Tested with `samples-go/gin-mongo` — `test.delay` was automatically updated from `5` to `24` after recording.
- Countdown timer verified in interactive terminal.

https://github.com/user-attachments/assets/798a45ff-5b2c-48c9-be4b-19b74c842021



## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?