### PR TITLE
feat: implement configurable custom matchers for replay comparisons

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -125,6 +125,7 @@ type Normalize struct {
 type Test struct {
 	SelectedTests       map[string][]string `json:"selectedTests" yaml:"selectedTests" mapstructure:"selectedTests"`
 	GlobalNoise         Globalnoise         `json:"globalNoise" yaml:"globalNoise" mapstructure:"globalNoise"`
+	CustomMatchers      CustomMatcherConfig `json:"customMatchers" yaml:"customMatchers" mapstructure:"customMatchers"`
 	Delay               uint64              `json:"delay" yaml:"delay" mapstructure:"delay"`
 	Host                string              `json:"host" yaml:"host" mapstructure:"host"`
 	Port                uint32              `json:"port" yaml:"port" mapstructure:"port"`
@@ -178,6 +179,19 @@ type (
 	GlobalNoise  map[string]map[string][]string
 	TestsetNoise map[string]map[string]map[string][]string
 )
+
+// CustomMatcherConfig holds configurable custom matchers for replay comparisons.
+// Mirrors the Globalnoise pattern: global matchers + per-test-set overrides.
+type CustomMatcherConfig struct {
+	Global   CustomMatcherNoise        `json:"global" yaml:"global" mapstructure:"global"`
+	Testsets CustomMatcherTestsetNoise `json:"test-sets" yaml:"test-sets" mapstructure:"test-sets"`
+}
+
+// CustomMatcherNoise maps: section ("body"/"header") → field path → CustomMatcher.
+type CustomMatcherNoise map[string]map[string]models.CustomMatcher
+
+// CustomMatcherTestsetNoise maps: testset → section → field path → CustomMatcher.
+type CustomMatcherTestsetNoise map[string]map[string]map[string]models.CustomMatcher
 
 func SetByPassPorts(conf *Config, ports []uint) {
 	for _, port := range ports {

--- a/config/default.go
+++ b/config/default.go
@@ -61,6 +61,9 @@ test:
   protoDir: ""
   protoInclude: []
   compareAll: false
+  customMatchers:
+    global: {}
+    test-sets: {}
 record:
   recordTimer: 0s
   filters: []

--- a/pkg/matcher/custom_matcher.go
+++ b/pkg/matcher/custom_matcher.go
@@ -1,0 +1,147 @@
+// Package matcher provides configurable custom matchers for replay comparisons.
+package matcher
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// Custom matcher type constants.
+const (
+	MatcherTypeRegex            = "regex"
+	MatcherTypeNumericTolerance = "numeric_tolerance"
+	MatcherTypePresence         = "presence"
+	MatcherTypeType             = "type"
+)
+
+// ApplyCustomMatcher evaluates the given custom matcher against expected and actual values.
+// Returns true if the matcher passes, false otherwise.
+// An error is returned only for invalid matcher configurations (not for match failures).
+func ApplyCustomMatcher(matcherDef models.CustomMatcher, expected, actual interface{}) (bool, error) {
+	switch strings.ToLower(matcherDef.Type) {
+	case MatcherTypeRegex:
+		return matchRegex(matcherDef.Value, actual), nil
+	case MatcherTypeNumericTolerance:
+		return matchNumericTolerance(matcherDef.Value, expected, actual)
+	case MatcherTypePresence:
+		return matchPresence(actual), nil
+	case MatcherTypeType:
+		return matchTypeCheck(matcherDef.Value, actual), nil
+	default:
+		return false, fmt.Errorf("unsupported custom matcher type: %q", matcherDef.Type)
+	}
+}
+
+// matchRegex checks if the actual value (converted to string) matches the regex pattern.
+func matchRegex(pattern string, actual interface{}) bool {
+	if actual == nil {
+		return false
+	}
+	s := fmt.Sprintf("%v", actual)
+	return getCompiled(pattern).MatchString(s)
+}
+
+// matchNumericTolerance checks if expected and actual numeric values are within ±tolerance.
+func matchNumericTolerance(toleranceStr string, expected, actual interface{}) (bool, error) {
+	tolerance, err := strconv.ParseFloat(toleranceStr, 64)
+	if err != nil {
+		return false, fmt.Errorf("invalid numeric_tolerance value %q: %w", toleranceStr, err)
+	}
+	expFloat, ok := toFloat64(expected)
+	if !ok {
+		return false, nil
+	}
+	actFloat, ok := toFloat64(actual)
+	if !ok {
+		return false, nil
+	}
+	return math.Abs(expFloat-actFloat) <= tolerance, nil
+}
+
+// matchPresence returns true if the actual value is non-nil (i.e. the field exists).
+func matchPresence(actual interface{}) bool {
+	return actual != nil
+}
+
+// matchTypeCheck checks if the actual value's JSON type matches the expected type string.
+// Supported types: "string", "number", "boolean", "array", "object", "null".
+func matchTypeCheck(expectedType string, actual interface{}) bool {
+	actualType := jsonType(actual)
+	return strings.EqualFold(actualType, expectedType)
+}
+
+// jsonType returns the JSON type name for a Go interface value.
+func jsonType(v interface{}) string {
+	if v == nil {
+		return "null"
+	}
+	rv := reflect.TypeOf(v)
+	switch rv.Kind() {
+	case reflect.String:
+		return "string"
+	case reflect.Float64, reflect.Float32, reflect.Int, reflect.Int64, reflect.Int32:
+		return "number"
+	case reflect.Bool:
+		return "boolean"
+	case reflect.Slice:
+		return "array"
+	case reflect.Map:
+		return "object"
+	default:
+		return "unknown"
+	}
+}
+
+// toFloat64 attempts to convert an interface{} value to float64.
+func toFloat64(v interface{}) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int32:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case string:
+		f, err := strconv.ParseFloat(n, 64)
+		return f, err == nil
+	default:
+		return 0, false
+	}
+}
+
+// ResolveCustomMatchers merges global and test-set-specific custom matchers.
+// Test-set matchers override global matchers for the same field path.
+func ResolveCustomMatchers(
+	global map[string]map[string]models.CustomMatcher,
+	testsets map[string]map[string]map[string]models.CustomMatcher,
+	testSetID string,
+) map[string]models.CustomMatcher {
+	result := make(map[string]models.CustomMatcher)
+
+	// Copy global body matchers.
+	if bodyMatchers, ok := global["body"]; ok {
+		for path, m := range bodyMatchers {
+			result[path] = m
+		}
+	}
+
+	// Override with test-set-specific body matchers.
+	if tsMatchers, ok := testsets[testSetID]; ok {
+		if bodyMatchers, ok := tsMatchers["body"]; ok {
+			for path, m := range bodyMatchers {
+				result[path] = m
+			}
+		}
+	}
+
+	return result
+}

--- a/pkg/matcher/custom_matcher_test.go
+++ b/pkg/matcher/custom_matcher_test.go
@@ -1,0 +1,216 @@
+package matcher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// --- Regex Matcher Tests ---
+
+func TestCustomMatcher_Regex_Match(t *testing.T) {
+	m := models.CustomMatcher{Type: "regex", Value: `^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`}
+	ok, err := ApplyCustomMatcher(m, nil, "550e8400-e29b-41d4-a716-446655440000")
+	require.NoError(t, err)
+	assert.True(t, ok, "UUID should match regex")
+}
+
+func TestCustomMatcher_Regex_NoMatch(t *testing.T) {
+	m := models.CustomMatcher{Type: "regex", Value: `^\d+$`}
+	ok, err := ApplyCustomMatcher(m, nil, "not-a-number")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestCustomMatcher_Regex_NilActual(t *testing.T) {
+	m := models.CustomMatcher{Type: "regex", Value: `.*`}
+	ok, err := ApplyCustomMatcher(m, nil, nil)
+	require.NoError(t, err)
+	assert.False(t, ok, "nil actual should not match regex")
+}
+
+func TestCustomMatcher_Regex_NumericActual(t *testing.T) {
+	m := models.CustomMatcher{Type: "regex", Value: `^\d+(\.\d+)?$`}
+	ok, err := ApplyCustomMatcher(m, nil, 42.5)
+	require.NoError(t, err)
+	assert.True(t, ok, "number should be converted to string and matched")
+}
+
+// --- Numeric Tolerance Matcher Tests ---
+
+func TestCustomMatcher_NumericTolerance_WithinRange(t *testing.T) {
+	m := models.CustomMatcher{Type: "numeric_tolerance", Value: "0.5"}
+	ok, err := ApplyCustomMatcher(m, 10.0, 10.3)
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestCustomMatcher_NumericTolerance_ExactBoundary(t *testing.T) {
+	m := models.CustomMatcher{Type: "numeric_tolerance", Value: "1.0"}
+	ok, err := ApplyCustomMatcher(m, 5.0, 6.0)
+	require.NoError(t, err)
+	assert.True(t, ok, "boundary value should pass")
+}
+
+func TestCustomMatcher_NumericTolerance_OutOfRange(t *testing.T) {
+	m := models.CustomMatcher{Type: "numeric_tolerance", Value: "0.01"}
+	ok, err := ApplyCustomMatcher(m, 100.0, 100.5)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestCustomMatcher_NumericTolerance_InvalidTolerance(t *testing.T) {
+	m := models.CustomMatcher{Type: "numeric_tolerance", Value: "not-a-number"}
+	_, err := ApplyCustomMatcher(m, 1.0, 1.0)
+	assert.Error(t, err)
+}
+
+func TestCustomMatcher_NumericTolerance_NonNumericActual(t *testing.T) {
+	m := models.CustomMatcher{Type: "numeric_tolerance", Value: "0.5"}
+	ok, err := ApplyCustomMatcher(m, 1.0, "hello")
+	require.NoError(t, err)
+	assert.False(t, ok, "non-numeric actual should fail")
+}
+
+func TestCustomMatcher_NumericTolerance_StringNumbers(t *testing.T) {
+	m := models.CustomMatcher{Type: "numeric_tolerance", Value: "0.1"}
+	ok, err := ApplyCustomMatcher(m, "5.0", "5.05")
+	require.NoError(t, err)
+	assert.True(t, ok, "string numbers should be parsed and compared")
+}
+
+// --- Presence Matcher Tests ---
+
+func TestCustomMatcher_Presence_NonNil(t *testing.T) {
+	m := models.CustomMatcher{Type: "presence"}
+	ok, err := ApplyCustomMatcher(m, nil, "any-value")
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestCustomMatcher_Presence_Nil(t *testing.T) {
+	m := models.CustomMatcher{Type: "presence"}
+	ok, err := ApplyCustomMatcher(m, nil, nil)
+	require.NoError(t, err)
+	assert.False(t, ok, "nil actual should fail presence check")
+}
+
+func TestCustomMatcher_Presence_EmptyString(t *testing.T) {
+	m := models.CustomMatcher{Type: "presence"}
+	ok, err := ApplyCustomMatcher(m, nil, "")
+	require.NoError(t, err)
+	assert.True(t, ok, "empty string is still present (non-nil)")
+}
+
+func TestCustomMatcher_Presence_ZeroValue(t *testing.T) {
+	m := models.CustomMatcher{Type: "presence"}
+	ok, err := ApplyCustomMatcher(m, nil, 0.0)
+	require.NoError(t, err)
+	assert.True(t, ok, "zero is still present (non-nil)")
+}
+
+// --- Type Matcher Tests ---
+
+func TestCustomMatcher_Type_String(t *testing.T) {
+	m := models.CustomMatcher{Type: "type", Value: "string"}
+	ok, err := ApplyCustomMatcher(m, nil, "hello")
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestCustomMatcher_Type_Number(t *testing.T) {
+	m := models.CustomMatcher{Type: "type", Value: "number"}
+	ok, err := ApplyCustomMatcher(m, nil, 42.0)
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestCustomMatcher_Type_Boolean(t *testing.T) {
+	m := models.CustomMatcher{Type: "type", Value: "boolean"}
+	ok, err := ApplyCustomMatcher(m, nil, true)
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestCustomMatcher_Type_Array(t *testing.T) {
+	m := models.CustomMatcher{Type: "type", Value: "array"}
+	ok, err := ApplyCustomMatcher(m, nil, []interface{}{1, 2, 3})
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestCustomMatcher_Type_Object(t *testing.T) {
+	m := models.CustomMatcher{Type: "type", Value: "object"}
+	ok, err := ApplyCustomMatcher(m, nil, map[string]interface{}{"key": "val"})
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestCustomMatcher_Type_Null(t *testing.T) {
+	m := models.CustomMatcher{Type: "type", Value: "null"}
+	ok, err := ApplyCustomMatcher(m, nil, nil)
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestCustomMatcher_Type_Mismatch(t *testing.T) {
+	m := models.CustomMatcher{Type: "type", Value: "string"}
+	ok, err := ApplyCustomMatcher(m, nil, 42.0)
+	require.NoError(t, err)
+	assert.False(t, ok, "number should not match expected type 'string'")
+}
+
+func TestCustomMatcher_Type_CaseInsensitive(t *testing.T) {
+	m := models.CustomMatcher{Type: "type", Value: "String"}
+	ok, err := ApplyCustomMatcher(m, nil, "hello")
+	require.NoError(t, err)
+	assert.True(t, ok, "type matching should be case-insensitive")
+}
+
+// --- Unsupported Matcher Type ---
+
+func TestCustomMatcher_UnsupportedType(t *testing.T) {
+	m := models.CustomMatcher{Type: "unknown_matcher"}
+	_, err := ApplyCustomMatcher(m, nil, "value")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported custom matcher type")
+}
+
+// --- ResolveCustomMatchers Tests ---
+
+func TestResolveCustomMatchers_GlobalOnly(t *testing.T) {
+	global := map[string]map[string]models.CustomMatcher{
+		"body": {
+			"data.id":        {Type: "regex", Value: `^\d+$`},
+			"data.timestamp": {Type: "presence"},
+		},
+	}
+	result := ResolveCustomMatchers(global, nil, "test-set-1")
+	assert.Len(t, result, 2)
+	assert.Equal(t, "regex", result["data.id"].Type)
+	assert.Equal(t, "presence", result["data.timestamp"].Type)
+}
+
+func TestResolveCustomMatchers_TestsetOverridesGlobal(t *testing.T) {
+	global := map[string]map[string]models.CustomMatcher{
+		"body": {
+			"data.id": {Type: "regex", Value: `^\d+$`},
+		},
+	}
+	testsets := map[string]map[string]map[string]models.CustomMatcher{
+		"test-set-1": {
+			"body": {
+				"data.id": {Type: "presence"}, // overrides global
+			},
+		},
+	}
+	result := ResolveCustomMatchers(global, testsets, "test-set-1")
+	assert.Equal(t, "presence", result["data.id"].Type, "testset matcher should override global")
+}
+
+func TestResolveCustomMatchers_Empty(t *testing.T) {
+	result := ResolveCustomMatchers(nil, nil, "test-set-1")
+	assert.Empty(t, result)
+}

--- a/pkg/matcher/http/match.go
+++ b/pkg/matcher/http/match.go
@@ -27,7 +27,7 @@ var ppNew234 = pp.New
 var jsonMarshal234 = json.Marshal
 var jsonUnmarshal234 = json.Unmarshal
 
-func Match(tc *models.TestCase, actualResponse *models.HTTPResp, noiseConfig map[string]map[string][]string, ignoreOrdering bool, compareAll bool, logger *zap.Logger) (bool, *models.Result) {
+func Match(tc *models.TestCase, actualResponse *models.HTTPResp, noiseConfig map[string]map[string][]string, ignoreOrdering bool, compareAll bool, logger *zap.Logger, customMatchers ...map[string]models.CustomMatcher) (bool, *models.Result) {
 	bodyType := models.Plain
 	if jsonValid234([]byte(actualResponse.Body)) {
 		bodyType = models.JSON
@@ -87,7 +87,7 @@ func Match(tc *models.TestCase, actualResponse *models.HTTPResp, noiseConfig map
 			return false, res
 		}
 		if validatedJSON.IsIdentical() {
-			jsonComparisonResult, err = matcherUtils.JSONDiffWithNoiseControl(validatedJSON, bodyNoise, ignoreOrdering)
+			jsonComparisonResult, err = matcherUtils.JSONDiffWithNoiseControl(validatedJSON, bodyNoise, ignoreOrdering, customMatchers...)
 			pass = jsonComparisonResult.IsExact()
 			if err != nil {
 				return false, res
@@ -283,7 +283,7 @@ func Match(tc *models.TestCase, actualResponse *models.HTTPResp, noiseConfig map
 				}
 				isBodyMismatch = false
 				if validatedJSON.IsIdentical() {
-					jsonComparisonResult, err = matcherUtils.JSONDiffWithNoiseControl(validatedJSON, bodyNoise, ignoreOrdering)
+					jsonComparisonResult, err = matcherUtils.JSONDiffWithNoiseControl(validatedJSON, bodyNoise, ignoreOrdering, customMatchers...)
 					if err != nil {
 						return false, res
 					}

--- a/pkg/matcher/utils.go
+++ b/pkg/matcher/utils.go
@@ -106,7 +106,8 @@ func (ni noiseIndex) match(keyLower string) (regs []*regexp.Regexp, isNoisy bool
 
 // JSONDiffWithNoiseControl compares JSON with support for both Path-based noise (e.g. "body.user.id")
 // and Global noise (e.g. "timestamp") to be ignored everywhere.
-func JSONDiffWithNoiseControl(validatedJSON ValidatedJSON, noise map[string][]string, ignoreOrdering bool) (JSONComparisonResult, error) {
+// customMatchers maps field paths to CustomMatcher definitions for field-level custom matching.
+func JSONDiffWithNoiseControl(validatedJSON ValidatedJSON, noise map[string][]string, ignoreOrdering bool, customMatchers ...map[string]models.CustomMatcher) (JSONComparisonResult, error) {
 	// Split noise into Path-based (contains dots) and Global (no dots)
 	pathNoise := make(map[string][]string)
 	globalKeys := make(map[string]bool)
@@ -121,13 +122,37 @@ func JSONDiffWithNoiseControl(validatedJSON ValidatedJSON, noise map[string][]st
 		}
 	}
 
+	// Merge optional custom matchers into a single map.
+	var cm map[string]models.CustomMatcher
+	if len(customMatchers) > 0 && customMatchers[0] != nil {
+		cm = customMatchers[0]
+	}
+
 	idx := buildNoiseIndex(pathNoise)
-	return matchJSONWithNoiseHandlingIndexed("", validatedJSON.expected, validatedJSON.actual, idx, globalKeys, ignoreOrdering)
+	return matchJSONWithNoiseHandlingIndexed("", validatedJSON.expected, validatedJSON.actual, idx, globalKeys, ignoreOrdering, cm)
 }
 
-// matchJSONWithNoiseHandlingIndexed now accepts globalKeys to skip specific keys at any depth.
-func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{}, ni noiseIndex, globalKeys map[string]bool, ignoreOrdering bool) (JSONComparisonResult, error) {
+// matchJSONWithNoiseHandlingIndexed now accepts globalKeys to skip specific keys at any depth,
+// and customMatchers for field-level custom matching (regex, tolerance, presence, type).
+func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{}, ni noiseIndex, globalKeys map[string]bool, ignoreOrdering bool, customMatchers map[string]models.CustomMatcher) (JSONComparisonResult, error) {
 	var out JSONComparisonResult
+
+	// Check if a custom matcher is defined for this field path.
+	if len(customMatchers) > 0 && key != "" {
+		if cm, ok := customMatchers[strings.ToLower(key)]; ok {
+			matched, err := ApplyCustomMatcher(cm, expected, actual)
+			if err != nil {
+				return out, err
+			}
+			if matched {
+				out.matches, out.isExact = true, true
+				return out, nil
+			}
+			// Custom matcher defined but didn't match — this is a real diff.
+			return out, nil
+		}
+	}
+
 	// Type check fast-path (JSON unmarshal produces these concrete types).
 	switch e := expected.(type) {
 	case nil:
@@ -215,7 +240,7 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 				continue
 			}
 
-			res, err := matchJSONWithNoiseHandlingIndexed(prefix+k, v, val, ni, globalKeys, ignoreOrdering)
+			res, err := matchJSONWithNoiseHandlingIndexed(prefix+k, v, val, ni, globalKeys, ignoreOrdering, customMatchers)
 			if err != nil || !res.matches {
 				return out, nil
 			}
@@ -264,7 +289,7 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 		if !ignoreOrdering {
 			isExact := true
 			for i := 0; i < len(e); i++ {
-				res, err := matchJSONWithNoiseHandlingIndexed(key, e[i], a[i], ni, globalKeys, ignoreOrdering)
+				res, err := matchJSONWithNoiseHandlingIndexed(key, e[i], a[i], ni, globalKeys, ignoreOrdering, customMatchers)
 				if err != nil || !res.matches {
 					return out, nil
 				}
@@ -293,7 +318,7 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 						continue
 					}
 					childKey := key
-					res, err := matchJSONWithNoiseHandlingIndexed(childKey, e[i], a[j], ni, globalKeys, ignoreOrdering)
+					res, err := matchJSONWithNoiseHandlingIndexed(childKey, e[i], a[j], ni, globalKeys, ignoreOrdering, customMatchers)
 					if err == nil && res.matches {
 						if !res.isExact {
 							isExact = false

--- a/pkg/models/testrun.go
+++ b/pkg/models/testrun.go
@@ -134,6 +134,14 @@ type FailureAssessment struct {
 	Reasons       []string          `json:"reasons,omitempty" yaml:"reasons,omitempty"`
 }
 
+// CustomMatcher defines a configurable field-level matcher for replay comparisons.
+// Type can be: "regex", "numeric_tolerance", "presence", "type".
+// Value holds the matcher parameter (regex pattern, tolerance, expected type, etc).
+type CustomMatcher struct {
+	Type  string `json:"type" yaml:"type" mapstructure:"type"`
+	Value string `json:"value,omitempty" yaml:"value,omitempty" mapstructure:"value"`
+}
+
 type Result struct {
 	StatusCode    IntResult      `json:"status_code" bson:"status_code" yaml:"status_code"`
 	FailureInfo   FailureInfo    `json:"-" yaml:"-"`

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1690,7 +1690,15 @@ func (r *Replayer) CompareHTTPResp(tc *models.TestCase, actualResponse *models.H
 	if tsNoise, ok := r.config.Test.GlobalNoise.Testsets[testSetID]; ok {
 		noiseConfig = LeftJoinNoise(r.config.Test.GlobalNoise.Global, tsNoise)
 	}
-	return httpMatcher.Match(tc, actualResponse, noiseConfig, r.config.Test.IgnoreOrdering, r.config.Test.CompareAll, r.logger)
+
+	// Resolve custom matchers from config (global + test-set-specific).
+	customMatchers := matcherUtils.ResolveCustomMatchers(
+		r.config.Test.CustomMatchers.Global,
+		r.config.Test.CustomMatchers.Testsets,
+		testSetID,
+	)
+
+	return httpMatcher.Match(tc, actualResponse, noiseConfig, r.config.Test.IgnoreOrdering, r.config.Test.CompareAll, r.logger, customMatchers)
 }
 
 func (r *Replayer) CompareGRPCResp(tc *models.TestCase, actualResp *models.GrpcResp, testSetID string) (bool, *models.Result) {


### PR DESCRIPTION
## Describe the changes that are made
- Implement configurable custom matchers for field-level comparison during replay, as described in #3738
- Add four matcher types: `regex`, `numeric_tolerance`, `presence`, and `type`
- Users can define matchers in `keploy.yml` under `test.customMatchers` (global + per-test-set)
- Custom matchers provide a middle ground between strict matching and complete field ignoring
- Fully backwards-compatible — existing configs work identically

### Tests Added ([pkg/matcher/custom_matcher_test.go](cci:7://file:///c:/Keploy/pkg/matcher/custom_matcher_test.go:0:0-0:0))

| Test | Matcher Type | What it verifies |
|---|---|---|
| [TestCustomMatcher_Regex_Match](cci:1://file:///c:/Keploy/pkg/matcher/custom_matcher_test.go:12:0-17:1) | regex | UUID matches regex pattern |
| [TestCustomMatcher_Regex_NoMatch](cci:1://file:///c:/Keploy/pkg/matcher/custom_matcher_test.go:19:0-24:1) | regex | Non-matching string fails |
| [TestCustomMatcher_Regex_NilActual](cci:1://file:///c:/Keploy/pkg/matcher/custom_matcher_test.go:26:0-31:1) | regex | nil actual returns false |
| [TestCustomMatcher_Regex_NumericActual](cci:1://file:///c:/Keploy/pkg/matcher/custom_matcher_test.go:33:0-38:1) | regex | Numbers are converted to string for matching |
| [TestCustomMatcher_NumericTolerance_WithinRange](cci:1://file:///c:/Keploy/pkg/matcher/custom_matcher_test.go:42:0-47:1) | numeric_tolerance | Values within ±tolerance pass |
| [TestCustomMatcher_NumericTolerance_ExactBoundary](cci:1://file:///c:/Keploy/pkg/matcher/custom_matcher_test.go:49:0-54:1) | numeric_tolerance | Boundary value passes |
| [TestCustomMatcher_NumericTolerance_OutOfRange](cci:1://file:///c:/Keploy/pkg/matcher/custom_matcher_test.go:56:0-61:1) | numeric_tolerance | Values outside tolerance fail |
| [TestCustomMatcher_NumericTolerance_InvalidTolerance](cci:1://file:///c:/Keploy/pkg/matcher/custom_matcher_test.go:63:0-67:1) | numeric_tolerance | Invalid tolerance string returns error |
| [TestCustomMatcher_NumericTolerance_NonNumericActual](cci:1://file:///c:/Keploy/pkg/matcher/custom_matcher_test.go:69:0-74:1) | numeric_tolerance | Non-numeric actual fails gracefully |
| [TestCustomMatcher_NumericTolerance_StringNumbers](cci:1://file:///c:/Keploy/pkg/matcher/custom_matcher_test.go:76:0-81:1) | numeric_tolerance | String numbers are parsed and compared |
| [TestCustomMatcher_Presence_NonNil](cci:1://file:///c:/Keploy/pkg/matcher/custom_matcher_test.go:85:0-90:1) | presence | Non-nil value passes |
| [TestCustomMatcher_Presence_Nil](cci:1://file:///c:/Keploy/pkg/matcher/custom_matcher_test.go:92:0-97:1) | presence | nil value fails |
| [TestCustomMatcher_Presence_EmptyString](cci:1://file:///c:/Keploy/pkg/matcher/custom_matcher_test.go:99:0-104:1) | presence | Empty string is still present |
| [TestCustomMatcher_Presence_ZeroValue](cci:1://file:///c:/Keploy/pkg/matcher/custom_matcher_test.go:106:0-111:1) | presence | Zero is still present |
| [TestCustomMatcher_Type_String](cci:1://file:///c:/Keploy/pkg/matcher/custom_matcher_test.go:115:0-120:1) | type | String type detected correctly |
| [TestCustomMatcher_Type_Number](cci:1://file:///c:/Keploy/pkg/matcher/custom_matcher_test.go:122:0-127:1) | type | Number type detected correctly |
| [TestCustomMatcher_Type_Boolean](cci:1://file:///c:/Keploy/pkg/matcher/custom_matcher_test.go:129:0-134:1) | type | Boolean type detected correctly |
| [TestCustomMatcher_Type_Array](cci:1://file:///c:/Keploy/pkg/matcher/custom_matcher_test.go:136:0-141:1) | type | Array type detected correctly |
| [TestCustomMatcher_Type_Object](cci:1://file:///c:/Keploy/pkg/matcher/custom_matcher_test.go:143:0-148:1) | type | Object type detected correctly |
| [TestCustomMatcher_Type_Null](cci:1://file:///c:/Keploy/pkg/matcher/custom_matcher_test.go:150:0-155:1) | type | Null type detected correctly |
| [TestCustomMatcher_Type_Mismatch](cci:1://file:///c:/Keploy/pkg/matcher/custom_matcher_test.go:157:0-162:1) | type | Type mismatch fails |
| [TestCustomMatcher_Type_CaseInsensitive](cci:1://file:///c:/Keploy/pkg/matcher/custom_matcher_test.go:164:0-169:1) | type | Type matching is case-insensitive |
| [TestCustomMatcher_UnsupportedType](cci:1://file:///c:/Keploy/pkg/matcher/custom_matcher_test.go:173:0-178:1) | — | Unknown matcher type returns error |
| [TestResolveCustomMatchers_GlobalOnly](cci:1://file:///c:/Keploy/pkg/matcher/custom_matcher_test.go:182:0-193:1) | resolver | Global matchers resolve correctly |
| [TestResolveCustomMatchers_TestsetOverridesGlobal](cci:1://file:///c:/Keploy/pkg/matcher/custom_matcher_test.go:195:0-210:1) | resolver | Test-set matchers override global |
| [TestResolveCustomMatchers_Empty](cci:1://file:///c:/Keploy/pkg/matcher/custom_matcher_test.go:212:0-215:1) | resolver | Empty config returns empty map |

**Results:** 26/26 new tests PASS ✅, 10/10 existing HTTP matcher tests PASS ✅ (zero regressions)

## Links & References

**Closes:** #3738

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- #3738
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [x] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

### Testing Steps
1. Add custom matchers to `keploy.yml`:
   ```yaml
   test:
     customMatchers:
       global:
         body:
           "data.request_id":
             type: "regex"
             value: "^[0-9a-fA-F-]{36}$"
           "data.timestamp":
             type: "presence"
           "data.score":
             type: "numeric_tolerance"
             value: "0.5"