### PR TITLE
feat: add dark mode theme toggle for CLI output

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -285,6 +285,7 @@ func (c *CmdConfigurator) AddFlags(cmd *cobra.Command) error {
 		cmd.PersistentFlags().Bool("debug", c.cfg.Debug, "Run in debug mode")
 		cmd.PersistentFlags().Bool("disable-tele", c.cfg.DisableTele, "Run in telemetry mode")
 		cmd.PersistentFlags().Bool("disable-ansi", c.cfg.DisableANSI, "Disable ANSI color in logs")
+		cmd.PersistentFlags().String("theme", c.cfg.Theme, "Set the color theme for CLI output (light or dark)")
 		err = cmd.PersistentFlags().MarkHidden("disable-tele")
 		if err != nil {
 			errMsg := "failed to mark telemetry as hidden flag"
@@ -416,6 +417,7 @@ func aliasNormalizeFunc(_ *pflag.FlagSet, name string) pflag.NormalizedName {
 		"generateGithubActions": "generate-github-actions",
 		"disableTele":           "disable-tele",
 		"disableANSI":           "disable-ansi",
+		"theme":                 "theme",
 		"selectedTests":         "selected-tests",
 		"testReport":            "test-report",
 		"enableTesting":         "enable-testing",
@@ -649,6 +651,18 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 			return errors.New(errMsg)
 		}
 		c.logger.Info("Color encoding is disabled")
+	}
+
+	// Set the CLI color theme
+	switch models.Theme(c.cfg.Theme) {
+	case models.ThemeDark:
+		models.CurrentTheme = models.ThemeDark
+		c.logger.Info("Dark mode theme is enabled")
+	case models.ThemeLight, "":
+		models.CurrentTheme = models.ThemeLight
+	default:
+		c.logger.Warn("Unknown theme value, falling back to light theme", zap.String("theme", c.cfg.Theme))
+		models.CurrentTheme = models.ThemeLight
 	}
 
 	if cmd.Name() == "test" {
@@ -1346,6 +1360,7 @@ func (c *CmdConfigurator) UpdateConfigData(defaultCfg config.Config) config.Conf
 	defaultCfg.Test.IgnoreOrdering = c.cfg.Test.IgnoreOrdering
 	defaultCfg.Test.Language = c.cfg.Test.Language
 	defaultCfg.DisableANSI = c.cfg.DisableANSI
+	defaultCfg.Theme = c.cfg.Theme
 	defaultCfg.Test.SkipCoverage = c.cfg.Test.SkipCoverage
 	defaultCfg.Test.Mocking = c.cfg.Test.Mocking
 	defaultCfg.Test.DisableLineCoverage = c.cfg.Test.DisableLineCoverage

--- a/cli/provider/util.go
+++ b/cli/provider/util.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"go.keploy.io/server/v3/pkg/models"
 	"go.keploy.io/server/v3/utils"
 )
 
@@ -79,11 +80,42 @@ func FprintWrapper(newLine bool, wr io.Writer, a ...interface{}) {
 
 // Get the color for the logo at position (i, j)
 func getLogoColor(i, j int) string {
+	if models.CurrentTheme == models.ThemeDark {
+		return getDarkLogoColor(i, j)
+	}
+	return getLightLogoColor(i, j)
+}
+
+// getLightLogoColor returns the gradient color for the light theme logo
+func getLightLogoColor(i, j int) string {
 	gradientColors := []string{
 		"\033[38;5;202m", // Dark Orange
 		"\033[38;5;208m",
 		"\033[38;5;214m", // Light Orange
 		"\033[38;5;226m", // Light Yellow
+	}
+
+	switch {
+	case i <= 5:
+		return gradientColors[0]
+	case i == 6 && j <= 42:
+		return gradientColors[1]
+	case i == 7 && j <= 49:
+		return gradientColors[2]
+	case j <= 38:
+		return gradientColors[3]
+	default:
+		return gradientColors[0]
+	}
+}
+
+// getDarkLogoColor returns the gradient color for the dark theme logo
+func getDarkLogoColor(i, j int) string {
+	gradientColors := []string{
+		"\033[38;5;39m",  // Bright Blue
+		"\033[38;5;45m",  // Cyan
+		"\033[38;5;51m",  // Light Cyan
+		"\033[38;5;123m", // Bright Cyan
 	}
 
 	switch {

--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	Debug                 bool                `json:"debug" yaml:"debug" mapstructure:"debug"`
 	DisableTele           bool                `json:"disableTele" yaml:"disableTele" mapstructure:"disableTele"`
 	DisableANSI           bool                `json:"disableANSI" yaml:"disableANSI" mapstructure:"disableANSI"`
+	Theme                 string              `json:"theme" yaml:"theme" mapstructure:"theme"`
 	InDocker              bool                `json:"inDocker" yaml:"-" mapstructure:"inDocker"`
 	ContainerName         string              `json:"containerName" yaml:"containerName" mapstructure:"containerName"`
 	NetworkName           string              `json:"networkName" yaml:"networkName" mapstructure:"networkName"`

--- a/config/default.go
+++ b/config/default.go
@@ -24,6 +24,7 @@ incomingProxyPort: %d
 dnsPort: 26789
 debug: false
 disableANSI: false
+theme: "light"
 disableTele: false
 generateGithubActions: false
 containerName: ""

--- a/pkg/models/const.go
+++ b/pkg/models/const.go
@@ -60,6 +60,17 @@ var (
 	PassThroughHosts = []string{"^dc\\.services\\.visualstudio\\.com$"}
 )
 
+// Theme represents the CLI color theme.
+type Theme string
+
+const (
+	ThemeLight Theme = "light" // default theme, optimized for light terminal backgrounds
+	ThemeDark  Theme = "dark"  // optimized for dark terminal backgrounds
+)
+
+// CurrentTheme holds the active theme for the CLI session.
+var CurrentTheme Theme = ThemeLight
+
 var orangeColorSGR = []color.Attribute{38, 5, 208}
 
 var BaseTime = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -70,12 +81,18 @@ var HighlightString = func(a ...interface{}) string {
 	if IsAnsiDisabled {
 		return fmt.Sprint(a)
 	}
+	if CurrentTheme == ThemeDark {
+		return color.New(color.FgHiCyan).SprintFunc()(a)
+	}
 	return color.New(orangeColorSGR...).SprintFunc()(a)
 }
 
 var HighlightPassingString = func(a ...interface{}) string {
 	if IsAnsiDisabled {
 		return fmt.Sprint(a)
+	}
+	if CurrentTheme == ThemeDark {
+		return color.New(color.FgHiGreen).SprintFunc()(a)
 	}
 	return color.New(color.FgGreen).SprintFunc()(a)
 }
@@ -84,12 +101,18 @@ var HighlightFailingString = func(a ...interface{}) string {
 	if IsAnsiDisabled {
 		return fmt.Sprint(a)
 	}
+	if CurrentTheme == ThemeDark {
+		return color.New(color.FgHiRed).SprintFunc()(a)
+	}
 	return color.New(color.FgRed).SprintFunc()(a)
 }
 
 var HighlightGrayString = func(a ...interface{}) string {
 	if IsAnsiDisabled {
 		return fmt.Sprint(a)
+	}
+	if CurrentTheme == ThemeDark {
+		return color.New(color.FgWhite).SprintFunc()(a)
 	}
 	return color.New(color.FgHiBlack).SprintFunc()(a)
 }
@@ -113,6 +136,22 @@ var GetPassingColorScheme = func() pp.ColorScheme {
 	if IsAnsiDisabled {
 		return defaultColorScheme
 	}
+	if CurrentTheme == ThemeDark {
+		return pp.ColorScheme{
+			String:          pp.Green | pp.Bold,
+			StringQuotation: pp.Green | pp.Bold,
+			FieldName:       pp.Cyan,
+			Integer:         pp.Cyan | pp.Bold,
+			StructName:      pp.White | pp.Bold,
+			Bool:            pp.Yellow | pp.Bold,
+			Float:           pp.Magenta | pp.Bold,
+			EscapedChar:     pp.Magenta | pp.Bold,
+			PointerAdress:   pp.Cyan | pp.Bold,
+			Nil:             pp.Yellow | pp.Bold,
+			Time:            pp.Cyan | pp.Bold,
+			ObjectLength:    pp.Cyan,
+		}
+	}
 	return pp.ColorScheme{
 		String:          pp.Green,
 		StringQuotation: pp.Green | pp.Bold,
@@ -132,6 +171,22 @@ var GetPassingColorScheme = func() pp.ColorScheme {
 var GetFailingColorScheme = func() pp.ColorScheme {
 	if IsAnsiDisabled {
 		return defaultColorScheme
+	}
+	if CurrentTheme == ThemeDark {
+		return pp.ColorScheme{
+			Bool:            pp.Yellow | pp.Bold,
+			Integer:         pp.Cyan | pp.Bold,
+			Float:           pp.Magenta | pp.Bold,
+			String:          pp.Red | pp.Bold,
+			StringQuotation: pp.Red | pp.Bold,
+			EscapedChar:     pp.Magenta | pp.Bold,
+			FieldName:       pp.Yellow | pp.Bold,
+			PointerAdress:   pp.Cyan | pp.Bold,
+			Nil:             pp.Yellow | pp.Bold,
+			Time:            pp.Cyan | pp.Bold,
+			StructName:      pp.White | pp.Bold,
+			ObjectLength:    pp.Cyan,
+		}
 	}
 	return pp.ColorScheme{
 		Bool:            pp.Cyan | pp.Bold,

--- a/pkg/platform/docker/util.go
+++ b/pkg/platform/docker/util.go
@@ -139,6 +139,9 @@ func getAlias(ctx context.Context, logger *zap.Logger, opts models.SetupOptions,
 		if models.IsAnsiDisabled {
 			alias += " --disable-ansi"
 		}
+		if models.CurrentTheme != models.ThemeLight {
+			alias += " --theme " + string(models.CurrentTheme)
+		}
 		if len(opts.PassThroughPorts) > 0 {
 			portStrings := make([]string, len(opts.PassThroughPorts))
 			for i, port := range opts.PassThroughPorts {
@@ -203,6 +206,9 @@ func getAlias(ctx context.Context, logger *zap.Logger, opts models.SetupOptions,
 			if models.IsAnsiDisabled {
 				alias += " --disable-ansi"
 			}
+			if models.CurrentTheme != models.ThemeLight {
+				alias += " --theme " + string(models.CurrentTheme)
+			}
 			if len(opts.PassThroughPorts) > 0 {
 				portStrings := make([]string, len(opts.PassThroughPorts))
 				for i, port := range opts.PassThroughPorts {
@@ -250,6 +256,9 @@ func getAlias(ctx context.Context, logger *zap.Logger, opts models.SetupOptions,
 		}
 		if models.IsAnsiDisabled {
 			alias += " --disable-ansi"
+		}
+		if models.CurrentTheme != models.ThemeLight {
+			alias += " --theme " + string(models.CurrentTheme)
 		}
 		if len(opts.PassThroughPorts) > 0 {
 			portStrings := make([]string, len(opts.PassThroughPorts))
@@ -314,6 +323,9 @@ func getAlias(ctx context.Context, logger *zap.Logger, opts models.SetupOptions,
 			if models.IsAnsiDisabled {
 				alias += " --disable-ansi"
 			}
+			if models.CurrentTheme != models.ThemeLight {
+				alias += " --theme " + string(models.CurrentTheme)
+			}
 			if len(opts.PassThroughPorts) > 0 {
 				portStrings := make([]string, len(opts.PassThroughPorts))
 				for i, port := range opts.PassThroughPorts {
@@ -362,6 +374,9 @@ func getAlias(ctx context.Context, logger *zap.Logger, opts models.SetupOptions,
 		}
 		if models.IsAnsiDisabled {
 			alias += " --disable-ansi"
+		}
+		if models.CurrentTheme != models.ThemeLight {
+			alias += " --theme " + string(models.CurrentTheme)
 		}
 		if len(opts.PassThroughPorts) > 0 {
 			portStrings := make([]string, len(opts.PassThroughPorts))

--- a/pkg/service/report/utils.go
+++ b/pkg/service/report/utils.go
@@ -81,9 +81,15 @@ func printSingleSummaryTo(w *bufio.Writer, name string, total, pass, fail, obsol
 
 	const (
 		reset = "\x1b[0m"
-		blue  = "\x1b[34;1m" // Blue and Bold
-		red   = "\x1b[31;1m" // Red and Bold
 	)
+	var blue, red string
+	if models.CurrentTheme == models.ThemeDark {
+		blue = "\x1b[36;1m" // Bright Cyan for dark backgrounds
+		red = "\x1b[93m"    // Bright Yellow for dark backgrounds
+	} else {
+		blue = "\x1b[34;1m" // Blue and Bold
+		red = "\x1b[31;1m"  // Red and Bold
+	}
 
 	timeStr := "N/A"
 	if dur > 0 {
@@ -143,11 +149,18 @@ func applyCliColorsToDiff(diff string) string {
 
 	// ANSI Constants
 	const (
-		reset  = "\x1b[0m"
-		yellow = "\x1b[33m"
-		red    = "\x1b[31m"
-		green  = "\x1b[32m"
+		reset = "\x1b[0m"
 	)
+	var yellow, red, green string
+	if models.CurrentTheme == models.ThemeDark {
+		yellow = "\x1b[93m"   // Bright Yellow
+		red = "\x1b[91m"      // Bright Red
+		green = "\x1b[92m"    // Bright Green
+	} else {
+		yellow = "\x1b[33m"
+		red = "\x1b[31m"
+		green = "\x1b[32m"
+	}
 
 	var sb strings.Builder
 	sb.Grow(len(diff) + 100)


### PR DESCRIPTION
Implements a configurable theme system for the Keploy CLI, allowing users to switch between light and dark color themes via --theme flag or theme config in keploy.yml.

- Add Theme type (light/dark) and CurrentTheme global
- Add --theme persistent CLI flag
- Add dark-mode-optimized color palettes for:
  - Highlight functions (cyan/bright green/bright red)
  - Pretty-printer color schemes
  - Logo gradient (cyan/blue tones)
  - Report summary and diff ANSI colors
- Propagate theme flag through Docker alias commands
- Add theme field to Config struct and default config
 #2569

Self Review done?
 yes

