### PR TITLE
feat: add constants, language type, and ANSI-aware string highlightin…

### DIFF
--- a/pkg/models/const.go
+++ b/pkg/models/const.go
@@ -68,28 +68,28 @@ var IsAnsiDisabled = false
 
 var HighlightString = func(a ...interface{}) string {
 	if IsAnsiDisabled {
-		return fmt.Sprint(a)
+		return fmt.Sprint(a...)
 	}
 	return color.New(orangeColorSGR...).SprintFunc()(a)
 }
 
 var HighlightPassingString = func(a ...interface{}) string {
 	if IsAnsiDisabled {
-		return fmt.Sprint(a)
+		return fmt.Sprint(a...)
 	}
 	return color.New(color.FgGreen).SprintFunc()(a)
 }
 
 var HighlightFailingString = func(a ...interface{}) string {
 	if IsAnsiDisabled {
-		return fmt.Sprint(a)
+		return fmt.Sprint(a...)
 	}
 	return color.New(color.FgRed).SprintFunc()(a)
 }
 
 var HighlightGrayString = func(a ...interface{}) string {
 	if IsAnsiDisabled {
-		return fmt.Sprint(a)
+		return fmt.Sprint(a...)
 	}
 	return color.New(color.FgHiBlack).SprintFunc()(a)
 }

--- a/pkg/models/const_test.go
+++ b/pkg/models/const_test.go
@@ -1,0 +1,62 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestHighlightFunctions_AnsiDisabled_3829 verifies that all Highlight*
+// functions return clean text (no brackets) when ANSI output is disabled.
+func TestHighlightFunctions_AnsiDisabled_3829(t *testing.T) {
+	// Save original value and restore after tests.
+	origDisabled := IsAnsiDisabled
+	defer func() { IsAnsiDisabled = origDisabled }()
+
+	IsAnsiDisabled = true
+
+	t.Run("HighlightString_SingleArg", func(t *testing.T) {
+		result := HighlightString("test-1")
+		assert.Equal(t, "test-1", result)
+	})
+
+	t.Run("HighlightString_MultipleArgs", func(t *testing.T) {
+		result := HighlightString("hello", " ", "world")
+		assert.Equal(t, "hello world", result)
+	})
+
+	t.Run("HighlightString_NumericArg", func(t *testing.T) {
+		result := HighlightString(85.5)
+		assert.Equal(t, "85.5", result)
+	})
+
+	t.Run("HighlightPassingString_SingleArg", func(t *testing.T) {
+		result := HighlightPassingString("true")
+		assert.Equal(t, "true", result)
+	})
+
+	t.Run("HighlightPassingString_MultipleArgs", func(t *testing.T) {
+		result := HighlightPassingString("test-set-", 0)
+		assert.Equal(t, "test-set-0", result)
+	})
+
+	t.Run("HighlightFailingString_SingleArg", func(t *testing.T) {
+		result := HighlightFailingString("test-1")
+		assert.Equal(t, "test-1", result)
+	})
+
+	t.Run("HighlightFailingString_MultipleArgs", func(t *testing.T) {
+		result := HighlightFailingString("error: ", 404)
+		assert.Equal(t, "error: 404", result)
+	})
+
+	t.Run("HighlightGrayString_SingleArg", func(t *testing.T) {
+		result := HighlightGrayString("test-set-0")
+		assert.Equal(t, "test-set-0", result)
+	})
+
+	t.Run("HighlightGrayString_NumericArg", func(t *testing.T) {
+		result := HighlightGrayString(100)
+		assert.Equal(t, "100", result)
+	})
+}


### PR DESCRIPTION
## Problem

When IsAnsiDisabled = true, all four Highlight* functions passed the variadic slice as a single argument to fmt.Sprint, producing output wrapped in brackets:


## Describe the changes that are made 
const.go
4 lines changed
render_diffs(file:///d:/New%20folder%20(4)/keploy/pkg/models/const.go)

const_test.go
New file
10 test cases covering all four functions with single, multiple, and numeric arguments.

## Links & References

**Closes:** #3829 
- NA (if very small change like typo, linting, etc.)

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [x] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

Run tests
go test ./pkg/models/ -run TestHighlight -v

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

- **PR Title**: `fix: correct variadic handling in Highlight* functions when ANSI is disabled`  
- **Branch Name**: `fix/#3829-highlight-variadic-handling`

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?

I have read the CLA Document and I hereby sign the CLA