### PR TITLE
fix: resolve status_code_class assertion hardcoded literal bug

### DIFF
--- a/pkg/matcher/http/match.go
+++ b/pkg/matcher/http/match.go
@@ -507,7 +507,7 @@ func AssertionMatch(tc *models.TestCase, actualResponse *models.HTTPResp, logger
 			} else {
 				classStr = class
 			}
-			actualClass := fmtSprintf234("%dxx", 200/100)
+			actualClass := fmtSprintf234("%dxx", actualResponse.StatusCode/100)
 			if classStr != actualClass {
 				pass = false
 				logger.Error("status_code_class assertion failed", zap.String("expected", class), zap.String("actual", actualClass))

--- a/pkg/matcher/http/match_test.go
+++ b/pkg/matcher/http/match_test.go
@@ -319,3 +319,94 @@ func TestMatch_CompareAll_JSONStillCompared(t *testing.T) {
 	assert.True(t, result.StatusCode.Normal)
 	assert.False(t, result.BodyResult[0].Normal)
 }
+
+// TestMatch_StatusCodeClassAssertion verifies the behavior of the status_code_class assertion.
+// It ensures that actualClass is dynamically computed from actualResponse.StatusCode.
+func TestMatch_StatusCodeClassAssertion(t *testing.T) {
+	logger := zap.NewNop()
+
+	testCases := []struct {
+		name           string
+		assertClass    string
+		actualStatus   int
+		expectedPass   bool
+	}{
+		{
+			name:         "Assert 2xx against 200 response -> PASS",
+			assertClass:  "2xx",
+			actualStatus: 200,
+			expectedPass: true,
+		},
+		{
+			name:         "Assert 2xx against 500 response -> FAIL",
+			assertClass:  "2xx",
+			actualStatus: 500,
+			expectedPass: false,
+		},
+		{
+			name:         "Assert 5xx against 500 response -> PASS",
+			assertClass:  "5xx",
+			actualStatus: 500,
+			expectedPass: true,
+		},
+		{
+			name:         "Assert 4xx against 404 response -> PASS",
+			assertClass:  "4xx",
+			actualStatus: 404,
+			expectedPass: true,
+		},
+		{
+			name:         "Assert 3xx against 302 response -> PASS",
+			assertClass:  "3xx",
+			actualStatus: 302,
+			expectedPass: true,
+		},
+		{
+			name:         "Assert 5xx against 200 response -> FAIL",
+			assertClass:  "5xx",
+			actualStatus: 200,
+			expectedPass: false,
+		},
+		{
+			name:         "Assert 200 (without xx) against 200 response -> PASS",
+			assertClass:  "200",
+			actualStatus: 200,
+			expectedPass: true,
+		},
+		{
+			name:         "Assert 404 (without xx) against 400 response -> PASS", // 404 becomes 4xx
+			assertClass:  "404",
+			actualStatus: 400,
+			expectedPass: true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+tc := &models.TestCase{
+				Name: tt.name,
+				HTTPResp: models.HTTPResp{
+					StatusCode: 200, // Expected status code recorded
+					Body:       `{"status":"ok"}`,
+				},
+				Assertions: map[models.AssertionType]interface{}{
+					models.StatusCodeClass: tt.assertClass,
+				},
+			}
+
+			actualResponse := &models.HTTPResp{
+				StatusCode: tt.actualStatus,
+				Body:       `{"status":"ok"}`,
+			}
+
+			noiseConfig := map[string]map[string][]string{}
+
+			pass, result := Match(tc, actualResponse, noiseConfig, false, false, logger, false)
+
+			assert.Equal(t, tt.expectedPass, pass, "Expected pass to be %v for %s", tt.expectedPass, tt.name)
+			if tt.expectedPass {
+				assert.True(t, result.StatusCode.Normal, "Expected StatusCode result to be normal on PASS")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Describe the changes that are made
- The `status_code_class` assertion logic was incorrectly computing the actualClass against a hardcoded 200/100 instead of dynamically checking the server's actual response status code. This caused false positives (Assert 2xx against 500 response -> PASS).
- Updated `pkg/matcher/http/match.go` to compute actualClass natively using `actualResponse.StatusCode`.
- Unit tests have been added to `pkg/matcher/http/match_test.go` to verify correctness against 2xx, 3xx, 4xx, and 5xx actual status codes.

## Links & References

**Closes:** #3850

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [x] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
  - Run package tests manually via: `cd pkg/matcher/http && go test -v -run TestMatch_StatusCodeClassAssertion`
- [ ] 🙅 no, because it is not needed

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?
