### PR TITLE
feat(matcher): add semantic HTML response validation with canonicalization pipeline

### DIFF
--- a/pkg/matcher/html_compare.go
+++ b/pkg/matcher/html_compare.go
@@ -1,0 +1,166 @@
+package matcher
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// MaxHTMLBodySize is the upper limit on HTML body size that will be canonicalized.
+// Bodies larger than this are compared as raw strings to avoid OOM in CI.
+const MaxHTMLBodySize = 1 << 20 // 1 MB
+
+type HTMLCompareConfig struct {
+	StripTags      map[string]bool
+	StripAttrRegex []*regexp.Regexp
+}
+
+// CanonicalizeHTML parses, cleans, normalizes, and deterministically serializes HTML content.
+// Returns an error if the input exceeds MaxHTMLBodySize.
+func CanonicalizeHTML(input string, config HTMLCompareConfig) (string, error) {
+	if input == "" {
+		return "", nil
+	}
+
+	// Fix 5: 1MB size guard — avoids OOM on large responses.
+	if len(input) > MaxHTMLBodySize {
+		return "", fmt.Errorf("HTML body exceeds maximum size for canonicalization (%d bytes)", MaxHTMLBodySize)
+	}
+
+	doc, err := html.Parse(strings.NewReader(input))
+	if err != nil {
+		return "", err
+	}
+
+	// Fix 1: No cloneNode — operate directly on the freshly parsed tree.
+	// The tree is not shared, so mutation is safe.
+	filterTree(doc, config)
+	normalizeTree(doc)
+
+	var buf bytes.Buffer
+	if err := html.Render(&buf, doc); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+func filterTree(n *html.Node, config HTMLCompareConfig) {
+	stack := []*html.Node{n}
+	for len(stack) > 0 {
+		node := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+
+		// Collect surviving children in DOM order, then push in reverse
+		// so LIFO stack pops them FirstChild-first.
+		var children []*html.Node
+		var next *html.Node
+		for c := node.FirstChild; c != nil; c = next {
+			next = c.NextSibling // capture before potential RemoveChild
+
+			if c.Type == html.CommentNode {
+				node.RemoveChild(c)
+				continue
+			}
+
+			if c.Type == html.ElementNode && config.StripTags[c.Data] {
+				node.RemoveChild(c)
+				continue
+			}
+
+			if c.Type == html.ElementNode {
+				c.Attr = filterAttributes(c.Attr, config.StripAttrRegex)
+			}
+
+			children = append(children, c)
+		}
+		// Push in reverse so stack pops in DOM order.
+		for i := len(children) - 1; i >= 0; i-- {
+			stack = append(stack, children[i])
+		}
+	}
+}
+
+func filterAttributes(attrs []html.Attribute, regexes []*regexp.Regexp) []html.Attribute {
+	if len(attrs) == 0 {
+		return attrs
+	}
+
+	var filtered []html.Attribute
+	for _, attr := range attrs {
+		skip := false
+		for _, re := range regexes {
+			if re.MatchString(attr.Key) {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			filtered = append(filtered, attr)
+		}
+	}
+	return filtered
+}
+
+type stackItem struct {
+	node     *html.Node
+	preserve bool
+}
+
+func normalizeTree(n *html.Node) {
+	stack := []stackItem{{node: n, preserve: false}}
+	for len(stack) > 0 {
+		item := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		node := item.node
+
+		// Collect surviving children with their preserve state in DOM order,
+		// then push in reverse so LIFO stack pops them FirstChild-first.
+		var children []stackItem
+		var next *html.Node
+		for c := node.FirstChild; c != nil; c = next {
+			next = c.NextSibling // capture before potential RemoveChild
+
+			childPreserve := item.preserve
+			if c.Type == html.ElementNode {
+				// Only <pre> and <textarea> preserve whitespace per the HTML spec.
+				// <code> is an inline element with no whitespace-preservation semantics.
+				switch c.Data {
+				case "pre", "textarea":
+					childPreserve = true
+				}
+
+				sort.Slice(c.Attr, func(i, j int) bool {
+					if c.Attr[i].Namespace != c.Attr[j].Namespace {
+						return c.Attr[i].Namespace < c.Attr[j].Namespace
+					}
+					return c.Attr[i].Key < c.Attr[j].Key
+				})
+			}
+
+			if c.Type == html.TextNode && !item.preserve {
+				c.Data = collapseWhitespace(c.Data)
+				if c.Data == "" {
+					node.RemoveChild(c)
+					continue
+				}
+			}
+
+			children = append(children, stackItem{node: c, preserve: childPreserve})
+		}
+		// Push in reverse so stack pops in DOM order.
+		for i := len(children) - 1; i >= 0; i-- {
+			stack = append(stack, children[i])
+		}
+	}
+}
+
+var whitespaceRegex = regexp.MustCompile(`\s+`)
+
+func collapseWhitespace(s string) string {
+	return strings.TrimSpace(whitespaceRegex.ReplaceAllString(s, " "))
+}

--- a/pkg/matcher/html_compare_test.go
+++ b/pkg/matcher/html_compare_test.go
@@ -1,0 +1,277 @@
+package matcher
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// defaultTestConfig returns an HTMLCompareConfig that strips script and style
+// — the baseline used by the production path.
+func defaultTestConfig() HTMLCompareConfig {
+	return HTMLCompareConfig{
+		StripTags: map[string]bool{
+			"script": true,
+			"style":  true,
+		},
+	}
+}
+
+// ── Level 1: Whitespace Normalization ────────────────────────────────────────
+
+func TestCanonicalizeHTML_Whitespace(t *testing.T) {
+	config := defaultTestConfig()
+
+	a := `<div>Hello   World</div>`
+	b := `<div>Hello World</div>`
+
+	ca, err := CanonicalizeHTML(a, config)
+	require.NoError(t, err)
+	cb, err := CanonicalizeHTML(b, config)
+	require.NoError(t, err)
+
+	assert.Equal(t, ca, cb, "extra whitespace should be collapsed to single space")
+}
+
+func TestCanonicalizeHTML_LeadingTrailingWhitespace(t *testing.T) {
+	config := defaultTestConfig()
+
+	a := `<p>  padded  </p>`
+	b := `<p>padded</p>`
+
+	ca, err := CanonicalizeHTML(a, config)
+	require.NoError(t, err)
+	cb, err := CanonicalizeHTML(b, config)
+	require.NoError(t, err)
+
+	assert.Equal(t, ca, cb, "leading/trailing whitespace in text nodes should be trimmed")
+}
+
+// ── Level 1: Attribute Order ─────────────────────────────────────────────────
+
+func TestCanonicalizeHTML_AttributeOrder(t *testing.T) {
+	config := HTMLCompareConfig{}
+
+	a := `<div id="1" class="a"></div>`
+	b := `<div class="a" id="1"></div>`
+
+	ca, err := CanonicalizeHTML(a, config)
+	require.NoError(t, err)
+	cb, err := CanonicalizeHTML(b, config)
+	require.NoError(t, err)
+
+	assert.Equal(t, ca, cb, "attribute ordering should not affect canonical form")
+}
+
+func TestCanonicalizeHTML_AttributeOrderMultiple(t *testing.T) {
+	config := HTMLCompareConfig{}
+
+	a := `<input type="text" name="q" placeholder="Search" required>`
+	b := `<input placeholder="Search" required name="q" type="text">`
+
+	ca, err := CanonicalizeHTML(a, config)
+	require.NoError(t, err)
+	cb, err := CanonicalizeHTML(b, config)
+	require.NoError(t, err)
+
+	assert.Equal(t, ca, cb, "any permutation of attributes should produce the same canonical form")
+}
+
+// ── Level 1: Dynamic Attribute Stripping ─────────────────────────────────────
+
+func TestCanonicalizeHTML_StripDynamicAttr(t *testing.T) {
+	re := regexp.MustCompile(`^id$`)
+	config := HTMLCompareConfig{
+		StripAttrRegex: []*regexp.Regexp{re},
+	}
+
+	a := `<div id="123">Hello</div>`
+	b := `<div id="456">Hello</div>`
+
+	ca, err := CanonicalizeHTML(a, config)
+	require.NoError(t, err)
+	cb, err := CanonicalizeHTML(b, config)
+	require.NoError(t, err)
+
+	assert.Equal(t, ca, cb, "dynamic id attribute should be stripped before comparison")
+}
+
+func TestCanonicalizeHTML_StripDataStar(t *testing.T) {
+	re := regexp.MustCompile(`^data-.*$`)
+	config := HTMLCompareConfig{
+		StripAttrRegex: []*regexp.Regexp{re},
+	}
+
+	a := `<div data-session="abc" data-ts="1234">Content</div>`
+	b := `<div data-session="xyz" data-ts="9999">Content</div>`
+
+	ca, err := CanonicalizeHTML(a, config)
+	require.NoError(t, err)
+	cb, err := CanonicalizeHTML(b, config)
+	require.NoError(t, err)
+
+	assert.Equal(t, ca, cb, "all data-* attributes should be stripped")
+}
+
+// ── Level 1: Script Stripping ─────────────────────────────────────────────────
+
+func TestCanonicalizeHTML_StripScript(t *testing.T) {
+	config := HTMLCompareConfig{
+		StripTags: map[string]bool{"script": true},
+	}
+
+	a := `<div>Hello<script>alert(1)</script></div>`
+	b := `<div>Hello<script>alert(2)</script></div>`
+
+	ca, err := CanonicalizeHTML(a, config)
+	require.NoError(t, err)
+	cb, err := CanonicalizeHTML(b, config)
+	require.NoError(t, err)
+
+	assert.Equal(t, ca, cb, "script tags should be completely stripped")
+	assert.NotContains(t, ca, "alert", "script content must not appear in canonical form")
+}
+
+func TestCanonicalizeHTML_StripStyle(t *testing.T) {
+	config := HTMLCompareConfig{
+		StripTags: map[string]bool{"style": true},
+	}
+
+	a := `<html><head><style>.foo{color:red}</style></head><body>Hi</body></html>`
+	b := `<html><head><style>.foo{color:blue}</style></head><body>Hi</body></html>`
+
+	ca, err := CanonicalizeHTML(a, config)
+	require.NoError(t, err)
+	cb, err := CanonicalizeHTML(b, config)
+	require.NoError(t, err)
+
+	assert.Equal(t, ca, cb, "style tags should be completely stripped")
+}
+
+// ── Level 1: Comment Stripping ────────────────────────────────────────────────
+
+func TestCanonicalizeHTML_StripComments(t *testing.T) {
+	config := defaultTestConfig()
+
+	a := `<div><!-- this is dynamic: 2024-01-01 -->Hello</div>`
+	b := `<div>Hello</div>`
+
+	ca, err := CanonicalizeHTML(a, config)
+	require.NoError(t, err)
+	cb, err := CanonicalizeHTML(b, config)
+	require.NoError(t, err)
+
+	assert.Equal(t, ca, cb, "HTML comments should be stripped")
+}
+
+// ── Level 1: <pre> Whitespace Preservation ────────────────────────────────────
+
+func TestCanonicalizeHTML_PreservesPreWhitespace(t *testing.T) {
+	config := defaultTestConfig()
+
+	// Whitespace inside <pre> must NOT be collapsed.
+	a := `<pre>line1
+	line2   spaced</pre>`
+	b := `<pre>line1
+line2 spaced</pre>`
+
+	ca, err := CanonicalizeHTML(a, config)
+	require.NoError(t, err)
+	cb, err := CanonicalizeHTML(b, config)
+	require.NoError(t, err)
+
+	// They differ in whitespace inside <pre>, so canonical forms should NOT match.
+	assert.NotEqual(t, ca, cb, "<pre> whitespace must be preserved, not collapsed")
+}
+
+func TestCanonicalizeHTML_CodeDoesNotPreserveWhitespace(t *testing.T) {
+	config := defaultTestConfig()
+
+	// <code> is inline — whitespace IS collapsed (unlike <pre>).
+	a := `<code>hello   world</code>`
+	b := `<code>hello world</code>`
+
+	ca, err := CanonicalizeHTML(a, config)
+	require.NoError(t, err)
+	cb, err := CanonicalizeHTML(b, config)
+	require.NoError(t, err)
+
+	assert.Equal(t, ca, cb, "<code> is inline — whitespace should be collapsed like any other element")
+}
+
+// ── Level 1: 1MB Size Guard ───────────────────────────────────────────────────
+
+func TestCanonicalizeHTML_SizeGuard(t *testing.T) {
+	config := defaultTestConfig()
+
+	// Generate a body clearly above the 1MB threshold.
+	big := strings.Repeat("<div>Hello</div>", 200_000) // ~3.2 MB
+
+	_, err := CanonicalizeHTML(big, config)
+
+	require.Error(t, err, "bodies above 1MB must be rejected with an error")
+	assert.Contains(t, err.Error(), "exceeds maximum size")
+}
+
+func TestCanonicalizeHTML_AtSizeBoundary(t *testing.T) {
+	config := defaultTestConfig()
+
+	// Body exactly at the limit — must succeed.
+	atLimit := strings.Repeat("x", MaxHTMLBodySize)
+	_, err := CanonicalizeHTML(atLimit, config)
+	// html.Parse on binary content may fail but the size guard must NOT fire.
+	// We simply verify the error is not the size-guard error.
+	if err != nil {
+		assert.NotContains(t, err.Error(), "exceeds maximum size",
+			"body exactly at the limit should not trigger the size guard")
+	}
+}
+
+// ── Level 1: Empty Input ──────────────────────────────────────────────────────
+
+func TestCanonicalizeHTML_EmptyInput(t *testing.T) {
+	config := defaultTestConfig()
+
+	result, err := CanonicalizeHTML("", config)
+
+	require.NoError(t, err)
+	assert.Equal(t, "", result, "empty input should return empty string")
+}
+
+// ── Level 1: Malformed HTML ───────────────────────────────────────────────────
+
+func TestCanonicalizeHTML_MalformedHTML(t *testing.T) {
+	config := defaultTestConfig()
+
+	// html.Parse is a spec-compliant error-correcting parser — it never errors
+	// on malformed input. Two "equivalent" malformed documents should normalize
+	// to the same canonical form.
+	a := `<div><p>Unclosed`
+	b := `<div><p>Unclosed</p></div>`
+
+	ca, errA := CanonicalizeHTML(a, config)
+	cb, errB := CanonicalizeHTML(b, config)
+
+	require.NoError(t, errA)
+	require.NoError(t, errB)
+	assert.Equal(t, ca, cb, "error-corrected malformed HTML should produce the same canonical form")
+}
+
+// ── Level 1: Structural Difference ───────────────────────────────────────────
+
+func TestCanonicalizeHTML_ContentDifference(t *testing.T) {
+	config := defaultTestConfig()
+
+	a := `<div>Expected Content</div>`
+	b := `<div>Different Content</div>`
+
+	ca, err := CanonicalizeHTML(a, config)
+	require.NoError(t, err)
+	cb, err := CanonicalizeHTML(b, config)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, ca, cb, "different text content must produce different canonical forms")
+}

--- a/pkg/matcher/http/match.go
+++ b/pkg/matcher/http/match.go
@@ -139,8 +139,40 @@ func Match(tc *models.TestCase, actualResponse *models.HTTPResp, noiseConfig map
 		if !compareAll && bodyType != models.JSON {
 			logger.Debug("Skipping body comparison for non-JSON response", zap.String("bodyType", string(bodyType)))
 			// Mark body as passing when compareAll is false and body is not JSON
-		} else if !matcherUtils.Contains(matcherUtils.MapToArray(noise), "body") && tc.HTTPResp.Body != actualResponse.Body {
-			pass = false
+		} else if !matcherUtils.Contains(matcherUtils.MapToArray(noise), "body") {
+			// Sub-classify the non-JSON body to enable type-specific semantic comparison.
+			subType := pkg.GuessContentType([]byte(actualResponse.Body))
+			switch subType {
+			case models.HTML:
+				// Fix 3: validate that expected body is also HTML before canonicalizing.
+				// Prevents false positives where plain text canonicalizes
+				// to the same html.Parse wrapper as an actual HTML response.
+				expSubType := pkg.GuessContentType([]byte(tc.HTTPResp.Body))
+				if expSubType != models.HTML {
+					logger.Debug("HTML subtype mismatch: expected body is not HTML",
+						zap.String("expected_type", string(expSubType)),
+						zap.String("actual_type", string(subType)))
+					if tc.HTTPResp.Body != actualResponse.Body {
+						pass = false
+					}
+				} else {
+					htmlCfg := buildHTMLConfig(bodyNoise)
+					canExp, errExp := matcherUtils.CanonicalizeHTML(tc.HTTPResp.Body, htmlCfg)
+					canAct, errAct := matcherUtils.CanonicalizeHTML(actualResponse.Body, htmlCfg)
+					if errExp != nil || errAct != nil {
+						logger.Warn("HTML canonicalization failed", zap.NamedError("exp_err", errExp), zap.NamedError("act_err", errAct))
+						if tc.HTTPResp.Body != actualResponse.Body {
+							pass = false
+						}
+					} else if canExp != canAct {
+						pass = false
+					}
+				}
+			default:
+				if tc.HTTPResp.Body != actualResponse.Body {
+					pass = false
+				}
+			}
 		}
 	}
 
@@ -339,6 +371,19 @@ func Match(tc *models.TestCase, actualResponse *models.HTTPResp, noiseConfig map
 						logDiffs.PushFooterDiff(strings.Join(jsonComparisonResult.Differences(), ", "))
 					}
 					logDiffs.PushBodyDiff(fmtSprint234(op.OldValue), fmtSprint234(op.Value), bodyNoise)
+				}
+			case models.HTML:
+				htmlCfg := buildHTMLConfig(bodyNoise)
+				canExp, errExp := matcherUtils.CanonicalizeHTML(tc.HTTPResp.Body, htmlCfg)
+				canAct, errAct := matcherUtils.CanonicalizeHTML(actualResponse.Body, htmlCfg)
+				if errExp != nil || errAct != nil {
+					logger.Warn("HTML canonicalization failed during diff", zap.NamedError("exp_err", errExp), zap.NamedError("act_err", errAct))
+					logDiffs.PushBodyDiff(fmtSprint234(tc.HTTPResp.Body), fmtSprint234(actualResponse.Body), bodyNoise)
+				} else {
+					if canExp != canAct {
+						isBodyMismatch = true
+					}
+					logDiffs.PushBodyDiff(fmtSprint234(canExp), fmtSprint234(canAct), bodyNoise)
 				}
 			default: // right now for every other type we would do a simple comparison, till we don't have dedicated logic for other types.
 				if tc.HTTPResp.Body != actualResponse.Body {
@@ -674,4 +719,27 @@ func FlattenHTTPResponse(h http.Header, body string) (map[string][]string, error
 		return m, err
 	}
 	return m, nil
+}
+
+// buildHTMLConfig translates body noise keys into HTMLCompareConfig attribute-strip patterns.
+// Noise keys such as "id", "data-session", "data-*" become regexp patterns used to strip
+// matching attribute names during HTML canonicalization.
+func buildHTMLConfig(bodyNoise map[string][]string) matcherUtils.HTMLCompareConfig {
+	cfg := matcherUtils.HTMLCompareConfig{
+		StripTags: map[string]bool{
+			"script": true,
+			"style":  true,
+		},
+	}
+	for key := range bodyNoise {
+		// Fix 4: QuoteMeta first so metacharacters in key names are treated as literals,
+		// then replace the escaped glob wildcards with their regex equivalents.
+		escaped := regexp.QuoteMeta(strings.ToLower(key))
+		// QuoteMeta turns * into \* and ? into \? — replace those escaped forms.
+		pattern := "^" + strings.NewReplacer(`\*`, `.*`, `\?`, `.`).Replace(escaped) + "$"
+		if re, err := regexp.Compile(pattern); err == nil {
+			cfg.StripAttrRegex = append(cfg.StripAttrRegex, re)
+		}
+	}
+	return cfg
 }

--- a/pkg/matcher/http/match_test.go
+++ b/pkg/matcher/http/match_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"strings"
 	"testing"
 
 	"errors"
@@ -318,4 +319,166 @@ func TestMatch_CompareAll_JSONStillCompared(t *testing.T) {
 	require.NotNil(t, result)
 	assert.True(t, result.StatusCode.Normal)
 	assert.False(t, result.BodyResult[0].Normal)
+}
+
+// ── Level 2: Match() Integration Tests ───────────────────────────────────────
+
+// TestMatch_HTML_SemanticMatch verifies that two HTML bodies that differ only in
+// whitespace and attribute ordering are treated as equal via CanonicalizeHTML.
+// NOTE: Bodies must begin with an HTML tag AND contain a void element like <br>
+// so that IsXML() returns false and DetectContentType() classifies them as text/html.
+// Pure XHTML like <html><body>text</body></html> is valid XML and would be mis-classified.
+func TestMatch_HTML_SemanticMatch(t *testing.T) {
+	logger := zap.NewNop()
+	tc := &models.TestCase{
+		Name: "test-html-semantic-match",
+		HTTPResp: models.HTTPResp{
+			StatusCode: 200,
+			// <br> is a void element — makes this invalid XML, so IsXML returns false
+			// and GuessContentType correctly returns models.HTML.
+			Body: `<html><body><br><div class="a" id="1">Hello   World</div></body></html>`,
+		},
+	}
+	actualResponse := &models.HTTPResp{
+		StatusCode: 200,
+		// Same document — attributes reordered + whitespace collapsed — semantically identical.
+		Body: `<html><body><br><div id="1" class="a">Hello World</div></body></html>`,
+	}
+	noiseConfig := map[string]map[string][]string{}
+
+	pass, result := Match(tc, actualResponse, noiseConfig, false, true, logger, false)
+
+	assert.True(t, pass, "semantically identical HTML should pass")
+	require.NotNil(t, result)
+	assert.True(t, result.BodyResult[0].Normal)
+}
+
+
+// TestMatch_HTML_DifferentContent verifies that HTML bodies with genuinely different
+// text content fail comparison even with compareAll=true.
+func TestMatch_HTML_DifferentContent(t *testing.T) {
+	logger := zap.NewNop()
+	tc := &models.TestCase{
+		Name: "test-html-different-content",
+		HTTPResp: models.HTTPResp{
+			StatusCode: 200,
+			Body:       `<html><body><br><h1>Expected</h1></body></html>`,
+		},
+	}
+	actualResponse := &models.HTTPResp{
+		StatusCode: 200,
+		Body:       `<html><body><br><h1>Different</h1></body></html>`,
+	}
+	noiseConfig := map[string]map[string][]string{}
+
+	pass, result := Match(tc, actualResponse, noiseConfig, false, true, logger, false)
+
+	assert.False(t, pass, "HTML with different text content must fail")
+	require.NotNil(t, result)
+	assert.False(t, result.BodyResult[0].Normal)
+}
+
+// TestMatch_HTML_TypeMismatch verifies that when the expected body is plain text
+// but the actual body is HTML, the implementation falls back to raw string comparison
+// (no false positive from html.Parse wrapping both in an identical skeleton).
+func TestMatch_HTML_TypeMismatch(t *testing.T) {
+	logger := zap.NewNop()
+	tc := &models.TestCase{
+		Name: "test-html-type-mismatch",
+		HTTPResp: models.HTTPResp{
+			StatusCode: 200,
+			Body:       `Hello World`, // plain text
+		},
+	}
+	actualResponse := &models.HTTPResp{
+		StatusCode: 200,
+		Body:       `<html><body>Hello World</body></html>`, // HTML
+	}
+	noiseConfig := map[string]map[string][]string{}
+
+	pass, result := Match(tc, actualResponse, noiseConfig, false, true, logger, false)
+
+	// Different raw strings → must fail (raw fallback, not HTML canonicalization).
+	assert.False(t, pass, "plain-text expected vs HTML actual must not produce a false positive")
+	require.NotNil(t, result)
+	assert.False(t, result.BodyResult[0].Normal)
+}
+
+// TestMatch_HTML_SizeGuard verifies that when the HTML body exceeds 1MB, the
+// canonicalization error is handled gracefully and raw string comparison takes over.
+func TestMatch_HTML_SizeGuard(t *testing.T) {
+	logger := zap.NewNop()
+
+	// 3 MB of valid-looking HTML — above the 1MB guard in CanonicalizeHTML.
+	bigHTML := `<html><body>` + strings.Repeat(`<div>test</div>`, 200_000) + `</body></html>`
+
+	tc := &models.TestCase{
+		Name: "test-html-size-guard",
+		HTTPResp: models.HTTPResp{
+			StatusCode: 200,
+			Body:       bigHTML,
+		},
+	}
+	actualResponse := &models.HTTPResp{
+		StatusCode: 200,
+		Body:       bigHTML, // identical — raw comparison must still pass
+	}
+	noiseConfig := map[string]map[string][]string{}
+
+	pass, result := Match(tc, actualResponse, noiseConfig, false, true, logger, false)
+
+	// Bodies are identical strings — even with the canonicalization error,
+	// the raw fallback `tc.HTTPResp.Body != actualResponse.Body` is false → pass.
+	assert.True(t, pass, "identical oversized HTML should pass via raw string fallback")
+	require.NotNil(t, result)
+	assert.True(t, result.BodyResult[0].Normal)
+}
+
+// TestMatch_JSON_Regression ensures the JSON comparison path still works exactly
+// as before — HTML integration must not disturb it.
+func TestMatch_JSON_HTMLIntegration_Regression(t *testing.T) {
+	logger := zap.NewNop()
+	tc := &models.TestCase{
+		Name: "test-json-regression",
+		HTTPResp: models.HTTPResp{
+			StatusCode: 200,
+			Body:       `{"status": "ok", "count": 42}`,
+		},
+	}
+
+	t.Run("identical JSON passes", func(t *testing.T) {
+		actual := &models.HTTPResp{
+			StatusCode: 200,
+			Body:       `{"status": "ok", "count": 42}`,
+		}
+		pass, result := Match(tc, actual, map[string]map[string][]string{}, false, false, logger, false)
+		assert.True(t, pass)
+		require.NotNil(t, result)
+		assert.True(t, result.BodyResult[0].Normal)
+	})
+
+	t.Run("different JSON fails", func(t *testing.T) {
+		actual := &models.HTTPResp{
+			StatusCode: 200,
+			Body:       `{"status": "ok", "count": 99}`,
+		}
+		pass, result := Match(tc, actual, map[string]map[string][]string{}, false, false, logger, false)
+		assert.False(t, pass)
+		require.NotNil(t, result)
+		assert.False(t, result.BodyResult[0].Normal)
+	})
+
+	t.Run("noised JSON field passes despite difference", func(t *testing.T) {
+		actual := &models.HTTPResp{
+			StatusCode: 200,
+			Body:       `{"status": "ok", "count": 999}`,
+		}
+		noiseConfig := map[string]map[string][]string{
+			"body": {"count": {".*"}},
+		}
+		pass, result := Match(tc, actual, noiseConfig, false, false, logger, false)
+		assert.True(t, pass, "noised field difference should be ignored")
+		require.NotNil(t, result)
+		assert.True(t, result.BodyResult[0].Normal)
+	})
 }


### PR DESCRIPTION
## Describe the Changes

This PR introduces semantic HTML response validation to Keploy’s matcher engine.

Previously, non-JSON HTTP response bodies were compared using raw string equality. This caused false negatives when two HTML responses were semantically identical but differed in attribute ordering, insignificant whitespace, or dynamically injected content.

This change adds a canonicalization-based HTML comparison pipeline while leaving the existing JSON logic completely untouched.

---

## Summary of Changes

### 1. New: `pkg/matcher/html_compare.go`

Implements `CanonicalizeHTML()` using `golang.org/x/net/html`.

Pipeline:

1. **Size Guard**  
   Bodies larger than 1MB are rejected and fall back to raw string comparison to prevent excessive memory use in CI environments.

2. **Parse**  
   HTML is parsed into a DOM tree using the HTML5-compliant, error-correcting parser.

3. **Filter**  
   - Removes `<script>` and `<style>` elements  
   - Removes HTML comments  
   - Strips noisy attributes via regex patterns derived from `bodyNoise`

4. **Normalize**  
   - Sorts attributes deterministically (namespace-aware)
   - Collapses whitespace except inside `<pre>` and `<textarea>`
   - Removes empty text nodes

5. **Serialize**  
   Uses `html.Render()` to produce deterministic canonical output.

Traversal is fully iterative (explicit stack-based DFS). No recursion is used anywhere in the canonicalization pipeline, eliminating stack overflow risk for deeply nested HTML.

---

### 2. Modified: `pkg/matcher/http/match.go`

- Integrates semantic HTML comparison into the non-JSON branch of `Match()`.
- Uses `GuessContentType()` to sub-classify non-JSON bodies.
- Validates that both expected and actual bodies are HTML before canonicalization.
- Falls back to raw string comparison if:
  - Body types differ
  - Canonicalization fails
  - Size guard triggers
- Adds `case models.HTML` to the diff-logging switch.
- Introduces `buildHTMLConfig()` to translate `bodyNoise` keys into attribute-stripping regex patterns using `regexp.QuoteMeta` for safe glob handling.

JSON comparison logic is completely unchanged.

---

### 3. New: `pkg/matcher/html_compare_test.go`

Adds 16 unit tests covering:

- Whitespace normalization
- Attribute ordering
- Dynamic attribute stripping
- Script/style/comment removal
- Whitespace preservation rules
- Size guard enforcement
- Empty input handling
- Malformed HTML
- Content difference detection

---

### 4. Modified: `pkg/matcher/http/match_test.go`

Adds integration tests validating:

- Semantic HTML matches
- Content mismatches
- Type mismatch fallback
- Size guard fallback
- JSON regression safety

All existing tests pass without modification.

---

## What Is Not Changed

- JSON body detection and comparison
- JSON diff logic
- JSON noise handling
- `BodyResult.Type` behavior
- Non-HTML raw string comparison behavior

Backward compatibility is preserved.

---

## Known Limitations

- `GuessContentType()` prioritizes XML detection before HTML. Well-formed XHTML may be classified as XML and fall back to raw string comparison.
- HTML noise applies only to attribute names. Dot-separated JSON path keys are not applicable and are skipped.
- HTML diff output is whole-body canonical diff (not per-element like JSON).
- `<script>` and `<style>` stripping is unconditional.

Follow-up issues will address detection priority and richer HTML noise semantics.

---

## How to Test

```bash
# Canonicalization unit tests
go test ./pkg/matcher/... -v -run "TestCanonicalizeHTML" -count=1

# Match() HTML integration tests
go test ./pkg/matcher/http/... -v -run "TestMatch_HTML" -count=1

# JSON regression tests
go test ./pkg/matcher/http/... -v -run "TestMatch_JSON_HTMLIntegration_Regression" -count=1

# Full matcher suite
go test ./pkg/matcher/... ./pkg/matcher/http/... -cover -count=1
```