### PR TITLE
fix: status_code_class assertion always returns 2xx (#3843)

### DIFF
--- a/pkg/matcher/http/match.go
+++ b/pkg/matcher/http/match.go
@@ -507,7 +507,7 @@ func AssertionMatch(tc *models.TestCase, actualResponse *models.HTTPResp, logger
 			} else {
 				classStr = class
 			}
-			actualClass := fmtSprintf234("%dxx", 200/100)
+			actualClass := fmtSprintf234("%dxx", actualResponse.StatusCode/100)
 			if classStr != actualClass {
 				pass = false
 				logger.Error("status_code_class assertion failed", zap.String("expected", class), zap.String("actual", actualClass))

--- a/pkg/matcher/http/match_test.go
+++ b/pkg/matcher/http/match_test.go
@@ -319,3 +319,68 @@ func TestMatch_CompareAll_JSONStillCompared(t *testing.T) {
 	assert.True(t, result.StatusCode.Normal)
 	assert.False(t, result.BodyResult[0].Normal)
 }
+
+// TestAssertionMatch_StatusCodeClass_T152 validates the fix for the bug where
+// status_code_class always compared against the hardcoded "2xx" class.
+// It covers all classes (2xx, 3xx, 4xx, 5xx) for both passing and failing cases.
+// See: https://github.com/keploy/keploy/issues/3843 (Team T152)
+func TestAssertionMatch_StatusCodeClass_T152(t *testing.T) {
+	logger := zap.NewNop()
+
+	tests := []struct {
+		name           string
+		assertedClass  string // assertion value set in the test case
+		actualStatus   int    // status code returned by the server
+		expectedToPass bool   // whether the assertion should pass
+	}{
+		// 2xx class
+		{"assert_2xx_server_200_pass", "2xx", 200, true},
+		{"assert_2xx_server_201_pass", "2xx", 201, true},
+		{"assert_2xx_server_500_fail", "2xx", 500, false},
+		{"assert_2xx_server_404_fail", "2xx", 404, false},
+		// 3xx class
+		{"assert_3xx_server_301_pass", "3xx", 301, true},
+		{"assert_3xx_server_302_pass", "3xx", 302, true},
+		{"assert_3xx_server_200_fail", "3xx", 200, false},
+		// 4xx class
+		{"assert_4xx_server_404_pass", "4xx", 404, true},
+		{"assert_4xx_server_400_pass", "4xx", 400, true},
+		{"assert_4xx_server_500_fail", "4xx", 500, false},
+		{"assert_4xx_server_200_fail", "4xx", 200, false},
+		// 5xx class
+		{"assert_5xx_server_500_pass", "5xx", 500, true},
+		{"assert_5xx_server_503_pass", "5xx", 503, true},
+		{"assert_5xx_server_200_fail", "5xx", 200, false},
+		{"assert_5xx_server_404_fail", "5xx", 404, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := &models.TestCase{
+				Name: tt.name,
+				HTTPResp: models.HTTPResp{
+					StatusCode: 200,
+					Body:       `{}`,
+				},
+				Assertions: map[models.AssertionType]interface{}{
+					models.StatusCodeClass: tt.assertedClass,
+				},
+			}
+			actualResponse := &models.HTTPResp{
+				StatusCode: tt.actualStatus,
+				Body:       `{}`,
+			}
+
+			pass, result := AssertionMatch(tc, actualResponse, logger)
+
+			require.NotNil(t, result, "result must not be nil")
+			if tt.expectedToPass {
+				assert.True(t, pass,
+					"expected PASS: assert %q against status %d", tt.assertedClass, tt.actualStatus)
+			} else {
+				assert.False(t, pass,
+					"expected FAIL: assert %q against status %d", tt.assertedClass, tt.actualStatus)
+			}
+		})
+	}
+}

--- a/pkg/platform/docker/util_windows.go
+++ b/pkg/platform/docker/util_windows.go
@@ -4,7 +4,6 @@ package docker
 
 import (
 	"context"
-	"os"
 	"os/exec"
 	"strings"
 )
@@ -12,8 +11,23 @@ import (
 func PrepareDockerCommand(ctx context.Context, keployAlias string) *exec.Cmd {
 	var args []string
 	args = append(args, "/C")
-	args = append(args, strings.Split(keployAlias, " ")...)
-	args = append(args, os.Args[1:]...)
+
+	// Split the alias by spaces, but filter out empty tokens that arise from
+	// double-spaces in the volume-mount string (trailing space in tlsVolumeMount
+	// concatenation). An empty token before "--rm" is treated by Docker as the
+	// image reference and causes "docker: invalid reference format".
+	for _, token := range strings.Split(keployAlias, " ") {
+		if token != "" {
+			args = append(args, token)
+		}
+	}
+
+	// NOTE: Do NOT append os.Args[1:] here.
+	// The non-Windows implementation (util_others.go) uses "sh -c <alias>" and
+	// does not pass the CLI's own arguments to the agent container. Appending
+	// os.Args[1:] (e.g. "record -c docker run ...") to the Docker run command
+	// corrupts the image reference and the agent entrypoint args.
+
 	// Use cmd.exe /C for Windows
 	cmd := exec.CommandContext(
 		ctx,


### PR DESCRIPTION
## Describe the changes that are made
- Fixed `status_code_class` assertion always comparing against hardcoded `"2xx"` regardless of actual HTTP response status code. Changed `200/100` to `actualResponse.StatusCode/100` in `AssertionMatch()`.
- Added 15 table-driven unit tests (`TestAssertionMatch_StatusCodeClass_T152`) covering 2xx, 3xx, 4xx, and 5xx classes for both pass and fail scenarios.
- Fixed `PrepareDockerCommand` on Windows (`util_windows.go`): filter empty tokens from `strings.Split` to prevent `docker: invalid reference format` error, and removed incorrect `os.Args[1:]` append that corrupted the agent container command.

| Endpoint | Status | Assertion        | Before fix | After fix |
|----------|--------|------------------|------------|-----------|
| /not-found | 404  | status_code_class: 4xx | ❌ FAIL (actual: 2xx) | ✅ PASS |
| /error     | 500  | status_code_class: 5xx | ❌ FAIL (actual: 2xx) | ✅ PASS |
| /health    | 200  | status_code_class: 2xx | ✅ PASS               | ✅ PASS | 

## Links & References

**Closes:** #3843

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- #3843 — `status_code_class` assertion always fails for non-2xx responses
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [x] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

**Steps to reproduce the bug:**
1. Record a test case where the server returns a `404` or `500` response.
2. Add `status_code_class: "4xx"` (or `"5xx"`) assertion to the test YAML.
3. Run `keploy test` — assertion always fails with `{"expected":"4xx","actual":"2xx"}`.

**Root cause:** `pkg/matcher/http/match.go` line 509:
```go
// Before (bug): always "2xx"
actualClass := fmt.Sprintf("%dxx", 200/100)

// After (fix): uses actual response status code
actualClass := fmt.Sprintf("%dxx", actualResponse.StatusCode/100)