### PR TITLE
feat(cli): Add structured logging using Zap Logger

### DIFF
--- a/cli/examples.go
+++ b/cli/examples.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"go.keploy.io/server/v3/cli/provider"
@@ -31,11 +30,11 @@ func Example(_ context.Context, logger *zap.Logger, _ *config.Config, _ ServiceF
 				return err
 			}
 			if customSetup {
-				fmt.Println(provider.Examples)
+				logger.Info(provider.Examples)
 				return nil
 			}
-			fmt.Println(provider.ExampleOneClickInstall)
-			fmt.Println(provider.WithoutexampleOneClickInstall)
+			logger.Info(provider.ExampleOneClickInstall)
+			logger.Info(provider.WithoutexampleOneClickInstall)
 			return nil
 		},
 	}

--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -14,7 +14,6 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -168,8 +167,7 @@ func (c *CmdConfigurator) AddFlags(cmd *cobra.Command) error {
 	cmd.SilenceErrors = true
 	cmd.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
 		PrintLogo(os.Stdout, true)
-		color.Red(fmt.Sprintf("❌ error: %v", err))
-		fmt.Println()
+		c.logger.Error("❌ error", zap.Error(err))
 		return err
 	})
 

--- a/pkg/service/export/export.go
+++ b/pkg/service/export/export.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/fs"
 	"net/url"
 	"os"
@@ -263,7 +262,7 @@ func Export(_ context.Context, logger *zap.Logger) error {
 		return err
 	}
 
-	fmt.Println("✅ Curls successfully exported to output.json 🎉")
+	logger.Info("✅ Curls successfully exported to output.json 🎉", zap.String("format", "output.json"))
 
 	return nil
 }

--- a/pkg/service/replay/mock.go
+++ b/pkg/service/replay/mock.go
@@ -89,8 +89,7 @@ func (m *mock) download(ctx context.Context, testSetID string) error {
 			response = "y"
 		} else {
 			m.logger.Warn("Local mock file is different from the one in the Keploy registry.")
-			// Prompt user for confirmation to override the local mock file
-			fmt.Print("The mock file present locally is different from the one in the Keploy registry. Do you want to override the local mock file with the version from the registry? (y/n): ")
+			m.logger.Warn("The mock file present locally is different from the one in the Keploy registry. Do you want to override the local mock file with the version from the registry? (y/n): ")
 		}
 
 		// Create a channel to listen for context cancellation (Ctrl+C)
@@ -463,21 +462,9 @@ func (m *mock) downloadAndSaveMock(downloadFunc func() (io.Reader, error), outpu
 
 	done := make(chan struct{})
 
-	// Spinner goroutine
+	// Spinner logic removed for structured logging compatibility
 	go func() {
-		spinnerChars := []rune{'|', '/', '-', '\\'}
-		i := 0
-		for {
-			select {
-			case <-done:
-				fmt.Print("\r") // Clear spinner line after done
-				return
-			default:
-				fmt.Printf("\rDownloading... %c", spinnerChars[i%len(spinnerChars)])
-				i++
-				timeSleep224(100 * time.Millisecond)
-			}
-		}
+		<-done
 	}()
 
 	_, err = io.Copy(file, cloudFile)

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -14,6 +14,7 @@ import (
 	// "encoding/json"
 	"go.keploy.io/server/v3/config"
 	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
 )
 
 type TestReportVerdict struct {
@@ -281,11 +282,11 @@ func (tfs *TestFailureStore) PrintFailuresTable() {
 	defer tfs.mu.Unlock()
 
 	if len(tfs.failures) == 0 {
-		fmt.Println("No test failures recorded.")
+		zap.L().Info("No test failures recorded.")
 		return
 	}
 
-	fmt.Println("\n======================= MOCKS MISMATCH SUMMARY =======================")
+	zap.L().Info("\n======================= MOCKS MISMATCH SUMMARY =======================")
 
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"TEST SET", "TEST ID", "MOCK DIFFERENCES"})

--- a/pkg/service/tools/templatize.go
+++ b/pkg/service/tools/templatize.go
@@ -141,7 +141,7 @@ func (t *Tools) ProcessTestCasesV2(ctx context.Context, tcs []*models.TestCase, 
 	t.logAPIChains(chains, tcs)
 
 	if fuzzerYamlPath := os.Getenv("ASSERT_CHAINS_WITH"); fuzzerYamlPath != "" {
-		fmt.Println("Asserting chains with fuzzer YAML:", fuzzerYamlPath)
+		t.logger.Info("Asserting chains with fuzzer YAML", zap.String("fuzzerYamlPath", fuzzerYamlPath))
 		t.AssertChains(chains, tcs, fuzzerYamlPath)
 	}
 	return nil
@@ -151,27 +151,30 @@ func (t *Tools) logAPIChains(chains []*TemplateChain, testCases []*models.TestCa
 	if len(chains) == 0 {
 		return
 	}
-	fmt.Println("\n✨ API Chain Analysis ✨")
-	fmt.Println("========================")
+	
+	var sb strings.Builder
+	sb.WriteString("\n✨ API Chain Analysis ✨\n")
+	sb.WriteString("========================\n")
 	for i, chain := range chains {
 		if i > 0 {
-			fmt.Println("--------------------")
+			sb.WriteString("--------------------\n")
 		}
 		truncatedValue := chain.Value
 		if len(truncatedValue) > 50 {
 			truncatedValue = truncatedValue[:47] + "..."
 		}
-		fmt.Printf("🔗 Chain for {{.%s}} (value: \"%s\")\n", chain.TemplateKey, truncatedValue)
-		fmt.Printf("  [PRODUCER] %s\n", formatLocation(chain.Producer, testCases))
+		sb.WriteString(fmt.Sprintf("🔗 Chain for {{.%s}} (value: \"%s\")\n", chain.TemplateKey, truncatedValue))
+		sb.WriteString(fmt.Sprintf("  [PRODUCER] %s\n", formatLocation(chain.Producer, testCases)))
 		for j, consumer := range chain.Consumers {
 			branch := "├─>"
 			if j == len(chain.Consumers)-1 {
 				branch = "    └─>"
 			}
-			fmt.Printf("    %s [CONSUMER] %s\n", branch, formatLocation(consumer, testCases))
+			sb.WriteString(fmt.Sprintf("    %s [CONSUMER] %s\n", branch, formatLocation(consumer, testCases)))
 		}
 	}
-	fmt.Println("========================")
+	sb.WriteString("========================")
+	t.logger.Info(sb.String())
 }
 
 func formatLocation(loc *ValueLocation, testCases []*models.TestCase) string {
@@ -529,48 +532,48 @@ func (t *Tools) applyTemplatesFromIndexV2(ctx context.Context, index map[string]
 var jsonMarshal987 = json.Marshal
 
 func (t *Tools) AssertChains(keployChains []*TemplateChain, testCases []*models.TestCase, fuzzerYamlPath string) {
-	fmt.Println("\n🔎 Chain Assertion against Fuzzer Output")
-	fmt.Println("==========================================")
+	t.logger.Info("\n🔎 Chain Assertion against Fuzzer Output")
+	t.logger.Info("==========================================")
 
 	// 1. Load fuzzer's baseline chains from the YAML file.
 	yamlFile, err := os.ReadFile(fuzzerYamlPath)
 	if err != nil {
-		fmt.Printf("🔴 ERROR: Could not read fuzzer's chain file at %s: %v\n", fuzzerYamlPath, err)
+		t.logger.Error("Could not read fuzzer's chain file", zap.String("path", fuzzerYamlPath), zap.Error(err))
 		return
 	}
 
 	// Use a generic map to bypass struct tag parsing issues.
 	var genericFuzzerData map[string]interface{}
 	if err := yaml.Unmarshal(yamlFile, &genericFuzzerData); err != nil {
-		fmt.Printf("🔴 ERROR: Could not parse fuzzer's YAML file into a generic map: %v\n", err)
+		t.logger.Error("Could not parse fuzzer's YAML file into a generic map", zap.Error(err))
 		return
 	}
 
 	// Manually build the canonical chains from the generic map. This is the FIX.
 	fuzzerChains, err := buildCanonicalChainsFromMap(genericFuzzerData)
 	if err != nil {
-		fmt.Printf("🔴 ERROR: Could not process the parsed fuzzer data: %v\n", err)
+		t.logger.Error("Could not process the parsed fuzzer data", zap.Error(err))
 		return
 	}
-	fmt.Printf("✅ Loaded %d chains from fuzzer baseline file.\n", len(fuzzerChains))
+	t.logger.Info(fmt.Sprintf("✅ Loaded %d chains from fuzzer baseline file.", len(fuzzerChains)))
 
 	// 2. Convert and Normalize Keploy's detected chains.
 	canonicalKeployChains := t.convertToCanonical(keployChains, testCases)
 	normalizeCanonicalChains(canonicalKeployChains)
-	fmt.Printf("✅ Converted and Normalized %d detected Keploy chains for comparison.\n", len(canonicalKeployChains))
+	t.logger.Info(fmt.Sprintf("✅ Converted and Normalized %d detected Keploy chains for comparison.", len(canonicalKeployChains)))
 
 	// 3. Perform the comparison.
 	passed, report := t.compareChainSets(fuzzerChains, canonicalKeployChains)
 
 	// 4. Print the result.
-	fmt.Println("\n--- Comparison Report ---")
-	fmt.Print(report)
+	t.logger.Info("\n--- Comparison Report ---")
+	t.logger.Info(report)
 	if passed {
-		fmt.Println("\n✅ PASSED: Keploy's detected chains match the fuzzer's baseline.")
+		t.logger.Info("\n✅ PASSED: Keploy's detected chains match the fuzzer's baseline.")
 	} else {
-		fmt.Println("\n❌ FAILED: Keploy's detected chains DO NOT match the fuzzer's baseline.")
+		t.logger.Info("\n❌ FAILED: Keploy's detected chains DO NOT match the fuzzer's baseline.")
 	}
-	fmt.Println("==========================================")
+	t.logger.Info("==========================================")
 }
 
 // buildCanonicalChainsFromMap manually constructs the chain structs from a generic map,

--- a/pkg/service/tools/tools.go
+++ b/pkg/service/tools/tools.go
@@ -67,11 +67,11 @@ func (t *Tools) Update(ctx context.Context) error {
 	currentVersion := "v" + utils.Version
 	isKeployInDocker := len(os.Getenv("KEPLOY_INDOCKER")) > 0
 	if isKeployInDocker {
-		fmt.Println("As you are using docker version of keploy, please pull the latest Docker image of keploy to update keploy")
+		t.logger.Info("As you are using docker version of keploy, please pull the latest Docker image of keploy to update keploy")
 		return nil
 	}
 	if strings.HasSuffix(currentVersion, "-dev") {
-		fmt.Println("you are using a development version of Keploy. Skipping update")
+		t.logger.Info("You are using a development version of Keploy. Skipping update.")
 		return nil
 	}
 
@@ -87,7 +87,7 @@ func (t *Tools) Update(ctx context.Context) error {
 	changelog := releaseInfo.Body
 
 	if currentVersion == latestVersion {
-		fmt.Println("✅You are already on the latest version of Keploy: " + latestVersion)
+		t.logger.Info("✅ You are already on the latest version of Keploy", zap.String("version", latestVersion))
 		return nil
 	}
 
@@ -129,7 +129,7 @@ func (t *Tools) Update(ctx context.Context) error {
 		utils.LogError(t.logger, err, "failed to render release notes")
 		return err
 	}
-	fmt.Println(changelog)
+	t.logger.Info("Release Notes:\n" + changelog)
 	return nil
 }
 

--- a/pkg/service/utgen/ai.go
+++ b/pkg/service/utgen/ai.go
@@ -269,11 +269,7 @@ func (ai *AIClient) Call(ctx context.Context, completionParams CompletionParams,
 	var contentBuilder strings.Builder
 	reader := bufio.NewReader(resp.Body)
 
-	if ai.Logger.Level() == zap.DebugLevel {
-		fmt.Println("Streaming results from LLM model...")
-	}
-
-	fmt.Println("Streaming results from LLM model...")
+	ai.Logger.Info("Streaming results from LLM model...")
 	if stream {
 		for {
 			line, err := reader.ReadString('\n')

--- a/pkg/service/utgen/gen.go
+++ b/pkg/service/utgen/gen.go
@@ -300,34 +300,26 @@ func (g *UnitTestGenerator) Start(ctx context.Context) error {
 				}
 			}
 
-			fmt.Printf("\n<=========================================>\n")
-			fmt.Printf(("Tests generated in Session") + "\n")
-			fmt.Printf("+-------------------------------+-------------------------------+-------------------------------+\n")
-			fmt.Printf("| %s | %s | %s |\n",
-				centerAlignText("Total Test Cases", 29),
-				centerAlignText("Test Cases Passed", 29),
-				centerAlignText("Test Cases Failed", 29))
-			fmt.Printf("+-------------------------------+-------------------------------+-------------------------------+\n")
-			fmt.Print(addHeightPadding(paddingHeight, 3, columnWidths3))
-			fmt.Printf("| \033[33m%s\033[0m | \033[32m%s\033[0m | \033[33m%s\033[0m |\n",
-				centerAlignText(fmt.Sprintf("%d", totalTest), 29),
-				centerAlignText(fmt.Sprintf("%d", passedTests), 29),
-				centerAlignText(fmt.Sprintf("%d", failedBuild+noCoverageTest), 29))
-			fmt.Print(addHeightPadding(paddingHeight, 3, columnWidths3))
-			fmt.Printf("+-------------------------------+-------------------------------+-------------------------------+\n")
-			fmt.Printf(("Discarded tests in session") + "\n")
-			fmt.Printf("+------------------------------------------+------------------------------------------+\n")
-			fmt.Printf("| %s | %s |\n",
-				centerAlignText("Build failures", 40),
-				centerAlignText("No Coverage output", 40))
-			fmt.Printf("+------------------------------------------+------------------------------------------+\n")
-			fmt.Print(addHeightPadding(paddingHeight, 2, columnWidths2))
-			fmt.Printf("| \033[35m%s\033[0m | \033[92m%s\033[0m |\n",
-				centerAlignText(fmt.Sprintf("%d", failedBuild), 40),
-				centerAlignText(fmt.Sprintf("%d", noCoverageTest), 40))
-			fmt.Print(addHeightPadding(paddingHeight, 2, columnWidths2))
-			fmt.Printf("+------------------------------------------+------------------------------------------+\n")
-			fmt.Printf("<=========================================>\n")
+			var sb strings.Builder
+			sb.WriteString("\n<=========================================>\n")
+			sb.WriteString("Tests generated in Session\n")
+			sb.WriteString("+-------------------------------+-------------------------------+-------------------------------+\n")
+			sb.WriteString(fmt.Sprintf("| %s | %s | %s |\n", centerAlignText("Total Test Cases", 29), centerAlignText("Test Cases Passed", 29), centerAlignText("Test Cases Failed", 29)))
+			sb.WriteString("+-------------------------------+-------------------------------+-------------------------------+\n")
+			sb.WriteString(addHeightPadding(paddingHeight, 3, columnWidths3))
+			sb.WriteString(fmt.Sprintf("| \033[33m%s\033[0m | \033[32m%s\033[0m | \033[33m%s\033[0m |\n", centerAlignText(fmt.Sprintf("%d", totalTest), 29), centerAlignText(fmt.Sprintf("%d", passedTests), 29), centerAlignText(fmt.Sprintf("%d", failedBuild+noCoverageTest), 29)))
+			sb.WriteString(addHeightPadding(paddingHeight, 3, columnWidths3))
+			sb.WriteString("+-------------------------------+-------------------------------+-------------------------------+\n")
+			sb.WriteString("Discarded tests in session\n")
+			sb.WriteString("+------------------------------------------+------------------------------------------+\n")
+			sb.WriteString(fmt.Sprintf("| %s | %s |\n", centerAlignText("Build failures", 40), centerAlignText("No Coverage output", 40)))
+			sb.WriteString("+------------------------------------------+------------------------------------------+\n")
+			sb.WriteString(addHeightPadding(paddingHeight, 2, columnWidths2))
+			sb.WriteString(fmt.Sprintf("| \033[35m%s\033[0m | \033[92m%s\033[0m |\n", centerAlignText(fmt.Sprintf("%d", failedBuild), 40), centerAlignText(fmt.Sprintf("%d", noCoverageTest), 40)))
+			sb.WriteString(addHeightPadding(paddingHeight, 2, columnWidths2))
+			sb.WriteString("+------------------------------------------+------------------------------------------+\n")
+			sb.WriteString("<=========================================>\n")
+			g.logger.Info(sb.String())
 			err = g.ai.SendCoverageUpdate(ctx, g.ai.SessionID, initialCoverage, g.cov.Current, iterationCount)
 			if err != nil {
 				utils.LogError(g.logger, err, "Error sending coverage update")
@@ -354,40 +346,27 @@ func (g *UnitTestGenerator) Start(ctx context.Context) error {
 			}
 		}
 	}
-	fmt.Printf("\n<=========================================>\n")
-	fmt.Printf(("COMPLETE TEST GENERATE SUMMARY") + "\n")
-	fmt.Printf(("Total Test Summary") + "\n")
-
-	fmt.Printf("+-------------------------------+-------------------------------+-------------------------------+\n")
-	fmt.Printf("| %s | %s | %s |\n",
-		centerAlignText("Total Test Cases", 29),
-		centerAlignText("Test Cases Passed", 29),
-		centerAlignText("Test Cases Failed", 29))
-
-	fmt.Printf("+-------------------------------+-------------------------------+-------------------------------+\n")
-	fmt.Print(addHeightPadding(paddingHeight, 3, columnWidths3))
-	fmt.Printf("| \033[33m%s\033[0m | \033[32m%s\033[0m | \033[33m%s\033[0m |\n",
-		centerAlignText(fmt.Sprintf("%d", g.totalTestCase), 29),
-		centerAlignText(fmt.Sprintf("%d", g.testCasePassed), 29),
-		centerAlignText(fmt.Sprintf("%d", g.testCaseFailed+g.noCoverageTest), 29))
-	fmt.Print(addHeightPadding(paddingHeight, 3, columnWidths3))
-	fmt.Printf("+-------------------------------+-------------------------------+-------------------------------+\n")
-
-	fmt.Printf(("Discarded Cases Summary") + "\n")
-	fmt.Printf("+------------------------------------------+------------------------------------------+\n")
-	fmt.Printf("| %s | %s |\n",
-		centerAlignText("Build failures", 40),
-		centerAlignText("No Coverage output", 40))
-
-	fmt.Printf("+------------------------------------------+------------------------------------------+\n")
-	fmt.Print(addHeightPadding(paddingHeight, 2, columnWidths2))
-	fmt.Printf("| \033[35m%s\033[0m | \033[92m%s\033[0m |\n",
-		centerAlignText(fmt.Sprintf("%d", g.testCaseFailed), 40),
-		centerAlignText(fmt.Sprintf("%d", g.noCoverageTest), 40))
-	fmt.Print(addHeightPadding(paddingHeight, 2, columnWidths2))
-	fmt.Printf("+------------------------------------------+------------------------------------------+\n")
-
-	fmt.Printf("<=========================================>\n")
+	var sb2 strings.Builder
+	sb2.WriteString("\n<=========================================>\n")
+	sb2.WriteString("COMPLETE TEST GENERATE SUMMARY\n")
+	sb2.WriteString("Total Test Summary\n")
+	sb2.WriteString("+-------------------------------+-------------------------------+-------------------------------+\n")
+	sb2.WriteString(fmt.Sprintf("| %s | %s | %s |\n", centerAlignText("Total Test Cases", 29), centerAlignText("Test Cases Passed", 29), centerAlignText("Test Cases Failed", 29)))
+	sb2.WriteString("+-------------------------------+-------------------------------+-------------------------------+\n")
+	sb2.WriteString(addHeightPadding(paddingHeight, 3, columnWidths3))
+	sb2.WriteString(fmt.Sprintf("| \033[33m%s\033[0m | \033[32m%s\033[0m | \033[33m%s\033[0m |\n", centerAlignText(fmt.Sprintf("%d", g.totalTestCase), 29), centerAlignText(fmt.Sprintf("%d", g.testCasePassed), 29), centerAlignText(fmt.Sprintf("%d", g.testCaseFailed+g.noCoverageTest), 29)))
+	sb2.WriteString(addHeightPadding(paddingHeight, 3, columnWidths3))
+	sb2.WriteString("+-------------------------------+-------------------------------+-------------------------------+\n")
+	sb2.WriteString("Discarded Cases Summary\n")
+	sb2.WriteString("+------------------------------------------+------------------------------------------+\n")
+	sb2.WriteString(fmt.Sprintf("| %s | %s |\n", centerAlignText("Build failures", 40), centerAlignText("No Coverage output", 40)))
+	sb2.WriteString("+------------------------------------------+------------------------------------------+\n")
+	sb2.WriteString(addHeightPadding(paddingHeight, 2, columnWidths2))
+	sb2.WriteString(fmt.Sprintf("| \033[35m%s\033[0m | \033[92m%s\033[0m |\n", centerAlignText(fmt.Sprintf("%d", g.testCaseFailed), 40), centerAlignText(fmt.Sprintf("%d", g.noCoverageTest), 40)))
+	sb2.WriteString(addHeightPadding(paddingHeight, 2, columnWidths2))
+	sb2.WriteString("+------------------------------------------+------------------------------------------+\n")
+	sb2.WriteString("<=========================================>\n")
+	g.logger.Info(sb2.String())
 	return nil
 }
 
@@ -430,25 +409,7 @@ func addHeightPadding(rows int, columns int, columnWidths []int) string {
 	return padding
 }
 
-func statusUpdater(stop <-chan bool) {
-	messages := []string{
-		"Running tests... Please wait.",
-		"Still running tests... Hang tight!",
-		"Tests are still executing... Almost there!",
-	}
-	i := 0
-	for {
-		select {
-		case <-stop:
-			fmt.Printf("\r\033[K")
-			return
-		default:
-			fmt.Printf("\r\033[K%s", messages[i%len(messages)])
-			time.Sleep(5 * time.Second)
-			i++
-		}
-	}
-}
+// Removed statusUpdater fmt.Printf based on structured logger constraint
 
 func (g *UnitTestGenerator) runCoverage() error {
 	// Perform an initial build/test command to generate coverage report and get a baseline
@@ -456,14 +417,10 @@ func (g *UnitTestGenerator) runCoverage() error {
 		g.logger.Info(fmt.Sprintf("Running test command to generate coverage report: '%s'", g.cmd))
 	}
 
-	stopStatus := make(chan bool)
-	go statusUpdater(stopStatus)
-
 	startTime := time.Now()
 
 	_, _, exitCode, lastUpdatedTime, err := RunCommand(g.cmd, g.dir, g.logger)
 	duration := time.Since(startTime)
-	stopStatus <- true
 	g.logger.Info(fmt.Sprintf("Test command completed in %v", formatDuration(duration)))
 
 	if err != nil {
@@ -488,7 +445,7 @@ func (g *UnitTestGenerator) runCoverage() error {
 }
 
 func (g *UnitTestGenerator) GenerateTests(ctx context.Context, iterationCount int) (*models.UTDetails, error) {
-	fmt.Println("Generating Tests...")
+	g.logger.Info("Generating Tests...")
 
 	select {
 	case <-ctx.Done():
@@ -538,12 +495,12 @@ func (g *UnitTestGenerator) GenerateTests(ctx context.Context, iterationCount in
 }
 
 func (g *UnitTestGenerator) setCursor(ctx context.Context) error {
-	fmt.Println("Getting indentation for new Tests...")
+	g.logger.Info("Getting indentation for new Tests...")
 	indentation, err := g.getIndentation(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to analyze test headers indentation: %w", err)
 	}
-	fmt.Println("Getting Line number for new Tests...")
+	g.logger.Info("Getting Line number for new Tests...")
 	line, err := g.getLine(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to analyze relevant line number to insert new tests: %w", err)


### PR DESCRIPTION
This commit replaces plain text logging messages consisting of fmt.Println and fmt.Printf with structured zap.Logger statements across the cli and pkg directories.

closes #3837 