### PR TITLE
fix(mysql): handle CLIENT_DEPRECATE_EOF capability flag in recorder

### DIFF
--- a/pkg/agent/proxy/integrations/mysql/recorder/query.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/query.go
@@ -205,30 +205,36 @@ func handlePreparedStmtResponse(ctx context.Context, logger *zap.Logger, clientC
 
 		logger.Debug("ParamsDefs after parsing", zap.Any("ParamDefs", responseOk.ParamDefs))
 
-		// Read the EOF packet for parameter definition
-		eofData, err := mysqlUtils.ReadPacketBuffer(ctx, logger, destConn)
-		if err != nil {
-			if err != io.EOF {
-				utils.LogError(logger, err, "failed to read EOF packet for parameter definition")
+		// When CLIENT_DEPRECATE_EOF is negotiated (MySQL 5.7.5+), the server omits
+		// EOF packets between parameter definitions and column definitions.
+		if decodeCtx.ClientCapabilities&mysql.CLIENT_DEPRECATE_EOF == 0 {
+			// Read the EOF packet for parameter definition
+			eofData, err := mysqlUtils.ReadPacketBuffer(ctx, logger, destConn)
+			if err != nil {
+				if err != io.EOF {
+					utils.LogError(logger, err, "failed to read EOF packet for parameter definition")
+				}
+				return nil, err
 			}
-			return nil, err
+
+			// Write the EOF packet for parameter definition to the client
+			_, err = clientConn.Write(eofData)
+			if err != nil {
+				utils.LogError(logger, err, "failed to write EOF packet for parameter definition to the client")
+				return nil, err
+			}
+
+			// Validate the EOF packet for parameter definition
+			if !mysqlUtils.IsEOFPacket(eofData) {
+				return nil, fmt.Errorf("expected EOF packet for parameter definition, got %v", eofData)
+			}
+
+			responseOk.EOFAfterParamDefs = eofData
+
+			logger.Debug("Eof after param defs", zap.Any("eofData", eofData))
+		} else {
+			logger.Debug("Skipping EOF after param defs (CLIENT_DEPRECATE_EOF is set)")
 		}
-
-		// Write the EOF packet for parameter definition to the client
-		_, err = clientConn.Write(eofData)
-		if err != nil {
-			utils.LogError(logger, err, "failed to write EOF packet for parameter definition to the client")
-			return nil, err
-		}
-
-		// Validate the EOF packet for parameter definition
-		if !mysqlUtils.IsEOFPacket(eofData) {
-			return nil, fmt.Errorf("expected EOF packet for parameter definition, got %v", eofData)
-		}
-
-		responseOk.EOFAfterParamDefs = eofData
-
-		logger.Debug("Eof after param defs", zap.Any("eofData", eofData))
 	}
 
 	//See if there are any columns
@@ -262,30 +268,36 @@ func handlePreparedStmtResponse(ctx context.Context, logger *zap.Logger, clientC
 
 		logger.Debug("ColumnDefs after parsing", zap.Any("ColumnDefs", responseOk.ColumnDefs))
 
-		// Read the EOF packet for column definition
-		eofData, err := mysqlUtils.ReadPacketBuffer(ctx, logger, destConn)
-		if err != nil {
-			if err != io.EOF {
-				utils.LogError(logger, err, "failed to read EOF packet for column definition")
+		// When CLIENT_DEPRECATE_EOF is negotiated (MySQL 5.7.5+), the server omits
+		// EOF packets between parameter definitions and column definitions.
+		if decodeCtx.ClientCapabilities&mysql.CLIENT_DEPRECATE_EOF == 0 {
+			// Read the EOF packet for column definition
+			eofData, err := mysqlUtils.ReadPacketBuffer(ctx, logger, destConn)
+			if err != nil {
+				if err != io.EOF {
+					utils.LogError(logger, err, "failed to read EOF packet for column definition")
+				}
+				return nil, err
 			}
-			return nil, err
+
+			// Write the EOF packet for column definition to the client
+			_, err = clientConn.Write(eofData)
+			if err != nil {
+				utils.LogError(logger, err, "failed to write EOF packet for column definition to the client")
+				return nil, err
+			}
+
+			// Validate the EOF packet for column definition
+			if !mysqlUtils.IsEOFPacket(eofData) {
+				return nil, fmt.Errorf("expected EOF packet for column definition, got %v, while handling prepared statement response", eofData)
+			}
+
+			responseOk.EOFAfterColumnDefs = eofData
+
+			logger.Debug("Eof after column defs", zap.Any("eofData", eofData))
+		} else {
+			logger.Debug("Skipping EOF after column defs (CLIENT_DEPRECATE_EOF is set)")
 		}
-
-		// Write the EOF packet for column definition to the client
-		_, err = clientConn.Write(eofData)
-		if err != nil {
-			utils.LogError(logger, err, "failed to write EOF packet for column definition to the client")
-			return nil, err
-		}
-
-		// Validate the EOF packet for column definition
-		if !mysqlUtils.IsEOFPacket(eofData) {
-			return nil, fmt.Errorf("expected EOF packet for column definition, got %v, while handling prepared statement response", eofData)
-		}
-
-		responseOk.EOFAfterColumnDefs = eofData
-
-		logger.Debug("Eof after column defs", zap.Any("eofData", eofData))
 	}
 
 	//set the lastOp to COM_STMT_PREPARE_OK
@@ -399,12 +411,21 @@ rowLoop:
 			// }
 
 			// Break if the data packet is an EOF packet, But we need to check for generic response
-			// Right now we are just checking for EOF packet as we couldn't differentiate between the generic response and row data packet
+			// Right now we are just checking for EOF/OK packet as we couldn't differentiate between the generic response and row data packet.
+			// When CLIENT_DEPRECATE_EOF is set (MySQL 5.7.5+), the server sends an OK packet instead of EOF at the end of the result set.
 			if mysqlUtils.IsEOFPacket(data) {
 				logger.Debug("Found EOF packet after row data in text resultset")
 				textResultSet.FinalResponse = &mysql.GenericResponse{
 					Data: data,
 					Type: mysql.StatusToString(mysql.EOF),
+				}
+				break rowLoop
+			}
+			if decodeCtx.ClientCapabilities&mysql.CLIENT_DEPRECATE_EOF != 0 && mysqlUtils.IsOKPacket(data) {
+				logger.Debug("Found OK packet after row data in text resultset (CLIENT_DEPRECATE_EOF is set)")
+				textResultSet.FinalResponse = &mysql.GenericResponse{
+					Data: data,
+					Type: mysql.StatusToString(mysql.OK),
 				}
 				break rowLoop
 			}
@@ -469,28 +490,34 @@ func handleBinaryResultSet(ctx context.Context, logger *zap.Logger, clientConn, 
 
 	logger.Debug("Columns: ", zap.Any("Columns", binaryResultSet.Columns))
 
-	// Read the EOF packet for column definition
-	eofData, err := mysqlUtils.ReadPacketBuffer(ctx, logger, destConn)
-	if err != nil {
-		if err != io.EOF {
-			utils.LogError(logger, err, "failed to read EOF packet for column definition")
+	// When CLIENT_DEPRECATE_EOF is negotiated (MySQL 5.7.5+), the server omits the
+	// EOF packet that normally follows column definitions in a binary result set.
+	if decodeCtx.ClientCapabilities&mysql.CLIENT_DEPRECATE_EOF == 0 {
+		// Read the EOF packet for column definition
+		eofData, err := mysqlUtils.ReadPacketBuffer(ctx, logger, destConn)
+		if err != nil {
+			if err != io.EOF {
+				utils.LogError(logger, err, "failed to read EOF packet for column definition")
+			}
+			return nil, err
 		}
-		return nil, err
-	}
 
-	// Write the EOF packet for column definition to the client
-	_, err = clientConn.Write(eofData)
-	if err != nil {
-		utils.LogError(logger, err, "failed to write EOF packet for column definition to the client")
-		return nil, err
-	}
+		// Write the EOF packet for column definition to the client
+		_, err = clientConn.Write(eofData)
+		if err != nil {
+			utils.LogError(logger, err, "failed to write EOF packet for column definition to the client")
+			return nil, err
+		}
 
-	// Validate the EOF packet for column definition
-	if !mysqlUtils.IsEOFPacket(eofData) {
-		return nil, fmt.Errorf("expected EOF packet for column definition, got %v, while handling BinaryProtocolResultSet", eofData)
-	}
+		// Validate the EOF packet for column definition
+		if !mysqlUtils.IsEOFPacket(eofData) {
+			return nil, fmt.Errorf("expected EOF packet for column definition, got %v, while handling BinaryProtocolResultSet", eofData)
+		}
 
-	binaryResultSet.EOFAfterColumns = eofData
+		binaryResultSet.EOFAfterColumns = eofData
+	} else {
+		logger.Debug("Skipping EOF after column defs in binary result set (CLIENT_DEPRECATE_EOF is set)")
+	}
 
 	// Read the row data packets
 rowLoop:
@@ -529,12 +556,21 @@ rowLoop:
 			// }
 
 			// Break if the data packet is an EOF packet, But we need to check for generic response
-			// Right now we are just checking for EOF packet as we couldn't differentiate between the generic response and row data packet
+			// Right now we are just checking for EOF/OK packet as we couldn't differentiate between the generic response and row data packet.
+			// When CLIENT_DEPRECATE_EOF is set (MySQL 5.7.5+), the server sends an OK packet instead of EOF at the end of the result set.
 			if mysqlUtils.IsEOFPacket(data) {
 				logger.Debug("Found EOF packet after row data in binary resultset")
 				binaryResultSet.FinalResponse = &mysql.GenericResponse{
 					Data: data,
 					Type: mysql.StatusToString(mysql.EOF),
+				}
+				break rowLoop
+			}
+			if decodeCtx.ClientCapabilities&mysql.CLIENT_DEPRECATE_EOF != 0 && mysqlUtils.IsOKPacket(data) {
+				logger.Debug("Found OK packet after row data in binary resultset (CLIENT_DEPRECATE_EOF is set)")
+				binaryResultSet.FinalResponse = &mysql.GenericResponse{
+					Data: data,
+					Type: mysql.StatusToString(mysql.OK),
 				}
 				break rowLoop
 			}

--- a/pkg/agent/proxy/integrations/mysql/wire/decode.go
+++ b/pkg/agent/proxy/integrations/mysql/wire/decode.go
@@ -164,12 +164,16 @@ func decodePacket(ctx context.Context, logger *zap.Logger, packet mysql.Packet, 
 		case *mysql.HandshakeResponse41Packet:
 			// Store the client capabilities to use it later
 			decodeCtx.ClientCapabilities = pkt.CapabilityFlags
+			// Also keep ClientCaps in sync so DeprecateEOF() works in record mode
+			decodeCtx.ClientCaps = pkt.CapabilityFlags
 
 			pktType = mysql.HandshakeResponse41
 			lastOp = payloadType
 		case *mysql.SSLRequestPacket:
 			// Store the client capabilities to use it later
 			decodeCtx.ClientCapabilities = pkt.CapabilityFlags
+			// Also keep ClientCaps in sync so DeprecateEOF() works in record mode
+			decodeCtx.ClientCaps = pkt.CapabilityFlags
 
 			pktType = mysql.SSLRequest
 			decodeCtx.UseSSL = true
@@ -296,6 +300,8 @@ func decodePacket(ctx context.Context, logger *zap.Logger, packet mysql.Packet, 
 		}
 		// Store the server greetings to use it later
 		decodeCtx.ServerGreetings.Store(clientConn, pkt)
+		// Also store the server capability flags so DeprecateEOF() works in record mode
+		decodeCtx.ServerCaps = pkt.CapabilityFlags
 		setPacketInfo(ctx, parsedPacket, pkt, mysql.AuthStatusToString(mysql.HandshakeV10), clientConn, mysql.HandshakeV10, decodeCtx)
 
 		logger.Debug("HandshakeV10 decoded", zap.Any("parsed packet", parsedPacket))


### PR DESCRIPTION
GDG CHARUSAT TEAM ID "<TEAM 146">
## fix(mysql): handle CLIENT_DEPRECATE_EOF capability flag in recorder

Closes #3449

---

### Problem

Keploy hangs indefinitely when recording MySQL/TiDB traffic from clients (e.g. Java MySQL Connector, Hibernate/JPA) that negotiate the `CLIENT_DEPRECATE_EOF` capability flag (MySQL 5.7.5+).

The MySQL wire protocol changes significantly when this flag is set:

| Phase | Without `CLIENT_DEPRECATE_EOF` | With `CLIENT_DEPRECATE_EOF` |
|---|---|---|
| COM_STMT_PREPARE response | `params… [EOF] cols… [EOF]` | `params… cols…` (no EOFs) |
| Result set terminator | `rows… [EOF]` | `rows… [OK]` |

Keploy's recorder unconditionally read EOF packets in all of these positions. When the flag was active and no EOF arrived, the recorder consumed the next real data packet, failed validation, and left the connection broken — causing the hang.

**Errors seen:**
🐰 Keploy: ERROR failed to handle the query response
{"Type": "mysql", "error": "failed to handle the prepared statement response: expected EOF packet for parameter definition, got [82 0 0 3 3 100 101 102...]"}
🐰 Keploy: ERROR failed to handle the query response
{"Type": "mysql", "error": "failed to handle the statement execute response: expected EOF packet for column definition, got [11 13 0 14...], while handling BinaryProtocolResultSet"}


---

### Changes

**`pkg/agent/proxy/integrations/mysql/recorder/query.go`**
- `handlePreparedStmtResponse`: guard EOF read after parameter definitions and after column definitions behind `CLIENT_DEPRECATE_EOF == 0`
- `handleTextResultSet` row loop: break on OK packet when `CLIENT_DEPRECATE_EOF` is set (server sends OK instead of EOF as the result-set terminator)
- `handleBinaryResultSet`: guard the post-column-definitions EOF read; also break row loop on OK packet when flag is set

**`pkg/agent/proxy/integrations/mysql/wire/decode.go`**
- `HandshakeV10` decode: sync `decodeCtx.ServerCaps` so `DeprecateEOF()` works in record mode (was only set in replay mode)
- `HandshakeResponse41` / `SSLRequest` decode: sync `decodeCtx.ClientCaps` alongside the existing `ClientCapabilities` field

---
BEFORE :
Server → Keploy recorder

COM_STMT_PREPARE response:
  [param col 1]
  [param col 2]
  ❌ recorder calls ReadPacketBuffer() expecting EOF here
     → server sends COLUMN DATA instead (no EOF with this flag)
     → recorder reads a column packet as "EOF", fails IsEOFPacket()
     → ERROR: "expected EOF packet for parameter definition, got [82 0 0 3 ...]"
     → connection hangs indefinitely
---
AFTER:
Server → Keploy recorder (CLIENT_DEPRECATE_EOF negotiated)

COM_STMT_PREPARE response:
  [param col 1]
  [param col 2]
  ✅ EOF read skipped (flag detected) → moves straight to column defs
  [col def 1]
  [col def 2]
  ✅ EOF read skipped (flag detected) → recording completes normally

COM_STMT_EXECUTE / COM_QUERY response:
  [col def 1] ... [col def N]
  ✅ post-column EOF read skipped
  [row 1] [row 2] ... [row N]
  [OK packet]  ← server sends OK instead of EOF
  ✅ OK packet recognised as result-set terminator → row loop exits cleanly
  → mock recorded successfully ✅
---
### References
- MySQL protocol spec: https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_stmt_prepare.html
- Binary result set spec: https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_binary_resultset.html