### PR TITLE
fix: correct typo 'DEPRICATED' → 'DEPRECATED' in deprecated flag message

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -262,7 +262,7 @@ func (c *CmdConfigurator) AddFlags(cmd *cobra.Command) error {
 		cmd.Flags().StringP("network-name", "n", c.cfg.NetworkName, "Name of the application's docker network")
 		cmd.Flags().UintSlice("pass-through-ports", config.GetByPassPorts(c.cfg), "Ports to bypass the proxy server and ignore the traffic")
 		cmd.Flags().String("app-name", c.cfg.AppName, "Name of the user's application")
-		cmd.Flags().MarkDeprecated("app-id", "DEPRICATED : was used for unique name for the user's application")
+		cmd.Flags().MarkDeprecated("app-id", "DEPRECATED: was used for unique name for the user's application")
 		cmd.Flags().Bool("generate-github-actions", c.cfg.GenerateGithubActions, "Generate Github Actions workflow file")
 		cmd.Flags().String("keploy-container", c.cfg.KeployContainer, "Keploy server container name")
 		cmd.Flags().Bool("in-ci", c.cfg.InCi, "is CI Running or not")


### PR DESCRIPTION
## Description

Fixes a spelling mistake in the deprecation message for the `--app-id` flag in `cli/provider/cmd.go`.

The word `DEPRICATED` was misspelled and has been corrected to `DEPRECATED`. Additionally, the extra space before the colon (` : `) has been removed to follow standard Go flag deprecation message formatting.

## Changes

**File:** `cli/provider/cmd.go` (line 265)

```go
// Before
cmd.Flags().MarkDeprecated("app-id", "DEPRICATED : was used for unique name for the user's application")

// After
cmd.Flags().MarkDeprecated("app-id", "DEPRECATED: was used for unique name for the user's application")
```

## Type of Change

- [x] Bug fix (non-breaking change — corrects a user-facing typo)

## Testing

- Verified no other occurrences of `DEPRICATED` exist anywhere in the codebase
- `go build ./cli/...` passes (pre-existing CGo errors on Windows unrelated to this change)
- `go vet ./cli/...` reports no new issues introduced by this change
- The fix is a single-line, low-risk change with zero functional impact

## Related Issue

Closes #3891

## Checklist

- [x] My commit message follows the [conventional commits](https://www.conventionalcommits.org/) format
- [x] I have signed off my commit (`git commit -s`) as required by the DCO
- [x] The change is minimal and scoped to exactly the reported issue
