### PR TITLE
fix: correct YAML decoding assertion type errors to prevent silent drop

### DIFF
--- a/pkg/platform/yaml/testdb/util.go
+++ b/pkg/platform/yaml/testdb/util.go
@@ -320,14 +320,12 @@ func Decode(yamlTestcase *yaml.NetworkTrafficDoc, logger *zap.Logger) (*models.T
 		for key, raw := range httpSpec.Assertions {
 			tc.Assertions[key] = raw
 			if key == models.NoiseAssertion {
-				noiseMap, ok := raw.(map[models.AssertionType]interface{})
+				noiseMap, ok := raw.(map[string]interface{})
 				if !ok {
 					logger.Warn("noise assertion not in expected map[AssertionType]interface{}", zap.Any("raw", raw))
 					continue
 				}
-				for kt, inner := range noiseMap {
-					field := string(kt)
-					// initialize slice
+				for field, inner := range noiseMap {
 					tc.Noise[field] = []string{}
 					arr, ok := inner.([]interface{})
 					if !ok {
@@ -356,13 +354,12 @@ func Decode(yamlTestcase *yaml.NetworkTrafficDoc, logger *zap.Logger) (*models.T
 		for key, raw := range grpcSpec.Assertions {
 			tc.Assertions[key] = raw
 			if key == models.NoiseAssertion {
-				noiseMap, ok := raw.(map[models.AssertionType]interface{})
+				noiseMap, ok := raw.(map[string]interface{})
 				if !ok {
 					logger.Warn("noise assertion not in expected map[AssertionType]interface{}", zap.Any("raw", raw))
 					continue
 				}
-				for kt, inner := range noiseMap {
-					field := string(kt)
+				for field, inner := range noiseMap {
 					tc.Noise[field] = []string{}
 					arr, ok := inner.([]interface{})
 					if !ok {


### PR DESCRIPTION
**Changes**

- **Location:** `pkg/platform/yaml/testdb/util.go`
- **Fix:** Corrected the type assertion in the `Decode()` function for both HTTP and gRPC branches from `map[models.AssertionType]interface{}` to `map[string]interface{}`.
- **Iteration Update:** Updated the logic to properly iterate over the `map[string]interface{}` to reconstruct the `tc.Noise` map.

```
// --- Before ---
// noiseMap, ok := raw.(map[models.AssertionType]interface{})

// --- After ---
noiseMap, ok := raw.(map[string]interface{})
if !ok {
    logger.Warn("noise assertion not in expected map[string]interface{}", zap.Any("raw", raw))
    continue
}

for field, inner := range noiseMap {
    tc.Noise[field] = []string{}
    arr, ok := inner.([]interface{})
    if !ok {
        continue
    }
    for _, item := range arr {
        if s, ok2 := item.(string); ok2 && s != "" {
            tc.Noise[field] = append(tc.Noise[field], s)
        }
    }
}
```
**Impact**

- Noise assertions are now correctly loaded from YAML files.
- User-defined noise configurations are properly applied during test replays.
- Resolves silent data loss in both HTTP and gRPC testing.

**Evidence**

The bug causes tc.Noise to be empty after decoding, even if the YAML file contains valid noise configurations. This patch ensures the tc.Noise field is populated correctly.
