### PR TITLE
fix(proxy): return error from startTCPDNSServer on failure

### DIFF
--- a/pkg/agent/proxy/dns.go
+++ b/pkg/agent/proxy/dns.go
@@ -37,6 +37,7 @@ func (p *Proxy) startTCPDNSServer(_ context.Context) error {
 	err := server.ListenAndServe()
 	if err != nil {
 		utils.LogError(p.logger, err, "failed to start tcp dns server", zap.String("addr", server.Addr))
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
## Describe the changes that are made

Fixed a bug where the `startTCPDNSServer` function in `pkg/agent/proxy/dns.go` was always returning `nil`, even when the DNS server failed to start. This caused startup errors to be silently swallowed, leaving users without proper error messages when the service failed to initialize.

## Changes

- [dns.go:40](pkg/agent/proxy/dns.go#L40) - Added `return err` after error log in `startTCPDNSServer`
- The fix matches the existing pattern used in `startUDPDNSServer`

## Links & References

**Closes:** https://github.com/keploy/keploy/issues/3827

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

## Added comments for hard-to-understand areas?
- [x] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [x] 🙅 no, because it is not needed

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?