### PR TITLE
fix(agent): close response bodies in MockOutgoing and UpdateMockParams

### DIFF
--- a/pkg/platform/http/agent.go
+++ b/pkg/platform/http/agent.go
@@ -413,7 +413,12 @@ func (a *AgentClient) MockOutgoing(ctx context.Context, opts models.OutgoingOpti
 	if err != nil {
 		return fmt.Errorf("failed to send request for mockOutgoing: %s", err.Error())
 	}
-	defer res.Body.Close()
+	defer func() {
+		io.Copy(io.Discard, res.Body)
+		if err := res.Body.Close(); err != nil {
+			utils.LogError(a.logger, err, "failed to close response body for mockOutgoing")
+		}
+	}()
 
 	var mockResp models.AgentResp
 	err = json.NewDecoder(res.Body).Decode(&mockResp)
@@ -693,7 +698,12 @@ func (a *AgentClient) UpdateMockParams(ctx context.Context, params models.MockFi
 	if err != nil {
 		return fmt.Errorf("failed to send request for updatemockparams: %s", err.Error())
 	}
-	defer res.Body.Close()
+	defer func() {
+		io.Copy(io.Discard, res.Body)
+		if err := res.Body.Close(); err != nil {
+			utils.LogError(a.logger, err, "failed to close response body for updatemockparams")
+		}
+	}()
 
 	var mockResp models.AgentResp
 	err = json.NewDecoder(res.Body).Decode(&mockResp)


### PR DESCRIPTION
## Describe the changes that are made
- Fixed HTTP response body leak in `MockOutgoing` and `UpdateMockParams` methods in `pkg/platform/http/agent.go`
- Added `defer res.Body.Close()` after `client.Do()` calls to prevent resource leaks
- This mirrors the existing pattern used in `StoreMocks`, `BeforeSimulate`, and `GetConsumedMocks` methods

## Links &amp; References

**Closes:** https://github.com/keploy/keploy/issues/3854

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [x] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [x] 🙅 no, because it is not needed

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title &amp; Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?