### PR TITLE
ci: speed up release and Docker publish workflows

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,11 +30,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
 
       - name: Add Private Parsers
         uses: ./.github/actions/setup-private-parsers
@@ -92,6 +87,8 @@ jobs:
           context: .
           ssh: default
           platforms: linux/amd64, linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,10 +56,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
 
       - name: Add Private Parsers
         uses: ./.github/actions/setup-private-parsers


### PR DESCRIPTION
## Describe the changes that are made
- remove duplicate `actions/setup-go` steps from the release and docker publish workflows
- rely on the existing `setup-private-parsers` composite action for Go setup and caching
- add Buildx GitHub Actions cache to the docker publish workflow using `cache-from: type=gha` and `cache-to: type=gha,mode=max`
- improve repeat release build times without changing release artifacts or trigger behavior

## Links & References

**Closes:** `NA`

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [x] 📦 Chore
- [x] 🔥 Performance Improvements
- [x] 🔁 CI

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed

## Added comments for hard-to-understand areas?
- [x] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA

## Sample test steps
- push the branch and confirm both workflows still parse and start correctly
- trigger the docker publish workflow with a tag and verify the build command includes GitHub Actions cache import/export
- compare a first tagged run and a second tagged run to confirm the second docker build reuses cached layers
- confirm release artifacts and docker tags remain unchanged from current behavior

## Additional checklist:
- [ ] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?