### PR TITLE
fix: correct noise assertion type assertion in YAML decode (#3872)

### DIFF
--- a/pkg/platform/yaml/testdb/util.go
+++ b/pkg/platform/yaml/testdb/util.go
@@ -320,13 +320,13 @@ func Decode(yamlTestcase *yaml.NetworkTrafficDoc, logger *zap.Logger) (*models.T
 		for key, raw := range httpSpec.Assertions {
 			tc.Assertions[key] = raw
 			if key == models.NoiseAssertion {
-				noiseMap, ok := raw.(map[models.AssertionType]interface{})
+				noiseMap, ok := raw.(map[string]interface{})
 				if !ok {
-					logger.Warn("noise assertion not in expected map[AssertionType]interface{}", zap.Any("raw", raw))
+					logger.Warn("noise assertion not in expected map[string]interface{}", zap.Any("raw", raw))
 					continue
 				}
 				for kt, inner := range noiseMap {
-					field := string(kt)
+					field := kt
 					// initialize slice
 					tc.Noise[field] = []string{}
 					arr, ok := inner.([]interface{})
@@ -356,13 +356,13 @@ func Decode(yamlTestcase *yaml.NetworkTrafficDoc, logger *zap.Logger) (*models.T
 		for key, raw := range grpcSpec.Assertions {
 			tc.Assertions[key] = raw
 			if key == models.NoiseAssertion {
-				noiseMap, ok := raw.(map[models.AssertionType]interface{})
+				noiseMap, ok := raw.(map[string]interface{})
 				if !ok {
-					logger.Warn("noise assertion not in expected map[AssertionType]interface{}", zap.Any("raw", raw))
+					logger.Warn("noise assertion not in expected map[string]interface{}", zap.Any("raw", raw))
 					continue
 				}
 				for kt, inner := range noiseMap {
-					field := string(kt)
+					field := kt
 					tc.Noise[field] = []string{}
 					arr, ok := inner.([]interface{})
 					if !ok {


### PR DESCRIPTION
### Description:

## Describe the changes
Fixed a silent data loss bug where noise assertions were always dropped when loading test cases from YAML files.

## Root cause: 
YAML deserialization always produces map[string]interface{} for maps. The decode code was asserting [raw.(map[models.AssertionType]interface{})](vscode-file://vscode-app/c:/Users/diino/AppData/Local/Programs/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — even though [models.AssertionType](vscode-file://vscode-app/c:/Users/diino/AppData/Local/Programs/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html) is defined as [type AssertionType string](vscode-file://vscode-app/c:/Users/diino/AppData/Local/Programs/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html), Go treats them as distinct types, so the assertion always failed silently and [tc.Noise](vscode-file://vscode-app/c:/Users/diino/AppData/Local/Programs/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html) was never populated.

## Fix: 
Changed the type assertion to map[string]interface{} (the actual runtime type) in both the HTTP and gRPC decode branches, and removed the now-unnecessary [string(kt)](vscode-file://vscode-app/c:/Users/diino/AppData/Local/Programs/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html) cast.

---

Closes: #3872

---

@gouravkrosx  , @Sarthak160 ,
Please review the changes and let me know if any further modifications are required. Thank you!