### PR TITLE
fix(proxy): prevent stale-key collision in treedb.update() after SetUnFilteredMocks re-indexes

### DIFF
--- a/pkg/agent/proxy/treedb.go
+++ b/pkg/agent/proxy/treedb.go
@@ -72,8 +72,23 @@ func (db *TreeDb) update(oldKey interface{}, newKey interface{}, newObj interfac
 	oldInfo, okOld := oldKey.(models.TestModeInfo)
 	newInfo, okNew := newKey.(models.TestModeInfo)
 
-	// First try exact match
-	_, found := db.rbt.Get(oldKey)
+	// Extract expected name from new object for identity validation.
+	// This prevents accidentally removing a different mock when keys have
+	// shifted after SetUnFilteredMocks re-populates the tree.
+	var expectedName string
+	if newMock, ok := newObj.(*models.Mock); ok && newMock != nil {
+		expectedName = newMock.Name
+	}
+
+	// First try exact key match
+	existingVal, found := db.rbt.Get(oldKey)
+	if found && expectedName != "" {
+		if existingMock, ok := existingVal.(*models.Mock); ok && existingMock != nil {
+			if existingMock.Name != expectedName {
+				found = false // Different mock at this key, skip
+			}
+		}
+	}
 	if found {
 		db.rbt.Remove(oldKey)
 		db.rbt.Put(newKey, newObj)
@@ -88,23 +103,64 @@ func (db *TreeDb) update(oldKey interface{}, newKey interface{}, newObj interfac
 	}
 
 	// If exact match fails, use ID index for O(1) lookup
-	if !okOld {
-		return false
+	if okOld {
+		currentKey, exists := db.idIndex[oldInfo.ID]
+		if exists {
+			// Verify identity before removing
+			if expectedName != "" {
+				idVal, idFound := db.rbt.Get(currentKey)
+				if idFound {
+					if existingMock, ok := idVal.(*models.Mock); ok && existingMock != nil {
+						if existingMock.Name != expectedName {
+							exists = false // Different mock at this ID, skip
+						}
+					}
+				}
+			}
+			if exists {
+				db.rbt.Remove(currentKey)
+				db.rbt.Put(newKey, newObj)
+				delete(db.idIndex, oldInfo.ID)
+				if okNew {
+					db.idIndex[newInfo.ID] = newInfo
+				}
+				return true
+			}
+		}
 	}
 
-	currentKey, exists := db.idIndex[oldInfo.ID]
-	if !exists {
-		return false
+	// Fallback: linear scan by name to find the correct mock.
+	// This handles the case where SetUnFilteredMocks re-populated the tree
+	// with new ID/SortOrder assignments, making key/ID-based lookups stale.
+	if expectedName != "" {
+		var foundKey interface{}
+		it := db.rbt.Iterator()
+		for it.Next() {
+			if existingMock, ok := it.Value().(*models.Mock); ok && existingMock != nil {
+				if existingMock.Name == expectedName {
+					foundKey = it.Key()
+					break
+				}
+			}
+		}
+		if foundKey != nil {
+			foundInfo, foundInfoOk := foundKey.(models.TestModeInfo)
+			db.rbt.Remove(foundKey)
+			// Use the found mock's ID in the new key to keep idIndex consistent
+			adjustedNewKey := newInfo
+			if foundInfoOk {
+				adjustedNewKey.ID = foundInfo.ID
+				delete(db.idIndex, foundInfo.ID)
+			}
+			db.rbt.Put(adjustedNewKey, newObj)
+			if okNew {
+				db.idIndex[adjustedNewKey.ID] = adjustedNewKey
+			}
+			return true
+		}
 	}
 
-	// Found by ID, update it
-	db.rbt.Remove(currentKey)
-	db.rbt.Put(newKey, newObj)
-	delete(db.idIndex, oldInfo.ID)
-	if okNew {
-		db.idIndex[newInfo.ID] = newInfo
-	}
-	return true
+	return false
 }
 
 func (db *TreeDb) deleteAll() {

--- a/pkg/agent/proxy/treedb_test.go
+++ b/pkg/agent/proxy/treedb_test.go
@@ -1,0 +1,150 @@
+package proxy
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// helper to create a mock with the given name, sortOrder, and ID.
+func mockWith(name string, sortOrder int64, id int) *models.Mock {
+	return &models.Mock{
+		Name: name,
+		TestModeInfo: models.TestModeInfo{
+			SortOrder:  sortOrder,
+			ID:         id,
+			IsFiltered: true,
+		},
+	}
+}
+
+func TestUpdateExactMatch(t *testing.T) {
+	db := NewTreeDb(customComparator)
+	m := mockWith("mock-5", 6, 5)
+	db.insert(m.TestModeInfo, m)
+
+	newMock := mockWith("mock-5", 99, 5)
+	newMock.TestModeInfo.IsFiltered = false
+
+	ok := db.update(m.TestModeInfo, newMock.TestModeInfo, newMock)
+	if !ok {
+		t.Fatal("expected update to succeed via exact key match")
+	}
+
+	// Old key should be gone
+	if _, found := db.rbt.Get(m.TestModeInfo); found {
+		t.Error("old key should have been removed")
+	}
+	// New key should exist
+	val, found := db.rbt.Get(newMock.TestModeInfo)
+	if !found {
+		t.Fatal("new key should exist in tree")
+	}
+	if val.(*models.Mock).Name != "mock-5" {
+		t.Errorf("expected mock-5, got %s", val.(*models.Mock).Name)
+	}
+}
+
+func TestUpdateRejectsKeyCollision(t *testing.T) {
+	// Simulate the bug scenario: after SetUnFilteredMocks re-indexes,
+	// a stale mock's old key (SortOrder=8, ID=7) accidentally matches
+	// a DIFFERENT mock that was re-inserted at that key position.
+	db := NewTreeDb(customComparator)
+
+	// "mock-10" now sits at SortOrder=8, ID=7 after re-indexing
+	mock10 := mockWith("mock-10", 8, 7)
+	db.insert(mock10.TestModeInfo, mock10)
+
+	// A stale reference tries to consume "mock-7" using old key (SortOrder=8, ID=7)
+	staleMock7 := mockWith("mock-7", 8, 7)
+	newMock7 := mockWith("mock-7", 99, 7)
+	newMock7.TestModeInfo.IsFiltered = false
+
+	ok := db.update(staleMock7.TestModeInfo, newMock7.TestModeInfo, newMock7)
+
+	// The update should NOT succeed via exact key match since mock-10 != mock-7.
+	// It should fall through to name-based scan, but mock-7 doesn't exist in tree,
+	// so it should return false.
+	if ok {
+		t.Fatal("update should have returned false: mock-7 is not in the tree")
+	}
+
+	// mock-10 should still be intact in the tree
+	val, found := db.rbt.Get(mock10.TestModeInfo)
+	if !found {
+		t.Fatal("mock-10 should NOT have been removed by the stale update")
+	}
+	if val.(*models.Mock).Name != "mock-10" {
+		t.Errorf("expected mock-10 to be intact, got %s", val.(*models.Mock).Name)
+	}
+}
+
+func TestUpdateNameFallbackAfterReindex(t *testing.T) {
+	// After SetUnFilteredMocks re-indexes, mock-7 is at a different key.
+	// A stale reference with old key should still find it via name scan.
+	db := NewTreeDb(customComparator)
+
+	// mock-7 was re-indexed to SortOrder=11, ID=10
+	mock7 := mockWith("mock-7", 11, 10)
+	db.insert(mock7.TestModeInfo, mock7)
+
+	// mock-10 at the old position of mock-7
+	mock10 := mockWith("mock-10", 8, 7)
+	db.insert(mock10.TestModeInfo, mock10)
+
+	// Stale reference uses old key for mock-7
+	staleKey := models.TestModeInfo{SortOrder: 8, ID: 7}
+	newMock7 := mockWith("mock-7", 99, 7)
+	newMock7.TestModeInfo.IsFiltered = false
+
+	ok := db.update(staleKey, newMock7.TestModeInfo, newMock7)
+	if !ok {
+		t.Fatal("expected update to succeed via name-based fallback")
+	}
+
+	// mock-10 should still be intact (not accidentally removed)
+	val, found := db.rbt.Get(mock10.TestModeInfo)
+	if !found {
+		t.Fatal("mock-10 should still be in the tree")
+	}
+	if val.(*models.Mock).Name != "mock-10" {
+		t.Errorf("expected mock-10, got %s", val.(*models.Mock).Name)
+	}
+
+	// mock-7 at old position should be gone
+	_, found = db.rbt.Get(models.TestModeInfo{SortOrder: 11, ID: 10})
+	if found {
+		t.Error("mock-7's old position should have been removed")
+	}
+}
+
+func TestUpdateIDIndexRejectsCollision(t *testing.T) {
+	// Test the ID-index fallback path also validates identity.
+	db := NewTreeDb(customComparator)
+
+	// mock-10 is in the tree with ID=5
+	mock10 := mockWith("mock-10", 6, 5)
+	db.insert(mock10.TestModeInfo, mock10)
+
+	// Stale reference for mock-7 with ID=5 (key doesn't match exactly,
+	// but ID index would find mock-10 at ID=5)
+	staleKey := models.TestModeInfo{SortOrder: 999, ID: 5}
+	newMock7 := mockWith("mock-7", 100, 5)
+	newMock7.TestModeInfo.IsFiltered = false
+
+	ok := db.update(staleKey, newMock7.TestModeInfo, newMock7)
+
+	// Should fail: ID=5 in tree is mock-10, not mock-7. And mock-7 not in tree at all.
+	if ok {
+		t.Fatal("update should have returned false: mock-7 is not in the tree")
+	}
+
+	// mock-10 should still be intact
+	val, found := db.rbt.Get(mock10.TestModeInfo)
+	if !found {
+		t.Fatal("mock-10 should NOT have been removed")
+	}
+	if val.(*models.Mock).Name != "mock-10" {
+		t.Errorf("expected mock-10, got %s", val.(*models.Mock).Name)
+	}
+}


### PR DESCRIPTION
## Describe the changes that are made

During replay, SetUnFilteredMocks is called twice per test-set:

  Phase 1 (wide window, once at test-set start):
    SendMockFilterParamsToAgent(ctx, [], BaseTime, now, ...)
    → FilterTcsMocks marks ALL mocks IsFiltered=true
    → SetUnFilteredMocks: deleteAll() + re-insert; assigns SortOrder/ID 0..N-1

  Phase 2 (narrow window, once per test case):
    SendMockFilterParamsToAgent(ctx, expectedNames, reqTime, respTime, ...)
    → FilterTcsMocks re-evaluates; startup mocks (outside window) become IsFiltered=false
    → SetUnFilteredMocks: deleteAll() + re-insert again; startup mocks move to end,
      remaining mocks shift: what was ID=10 at Phase 1 is now ID=7 at Phase 2

Meanwhile, the integrations-side globalCache (processedMockCache in pkg/postgres/v2/replayer/replayer.go) caches mock pointers together with their Phase-1 TestModeInfo{SortOrder, ID} values. The cache is invalidated only when MockManager.Revision() changes — but in-flight connections that already read the old cache continue to use stale TestModeInfo values.

When such a connection matches a mock and calls UpdateUnFilteredMock → treedb.update(), it supplies the stale Phase-1 key (e.g. SortOrder=11, ID=10). After Phase 2 re-indexed the tree, that key slot now holds a completely different mock (e.g. mock-13). The old update() had no identity check — it trusted the caller's key unconditionally, removed mock-13, and left mock-10 (the actual target) untouched in the tree. Subsequent DB connections that needed mock-10 (e.g. the StartupMessage/auth for connID="2") found nothing and failed with "No matching mock found", causing exit code 1.

This was the root cause of test-set-132 failing while test-set-135 (single connID, no second DB connection) passed — test-set-135 never needed mock-10's equivalent.

Add three-layer identity validation inside treedb.update(), all executed under the existing mutex so the check-and-remove is atomic:

  Layer 1 — Exact key match with name validation:
    Look up oldKey in the RBT. If found, check mock.Name == expectedName before
    proceeding. If the name doesn't match (stale key collision), mark as not-found
    and fall through instead of removing the wrong mock.

  Layer 2 — ID-index fallback with name validation:
    If exact key failed, look up oldInfo.ID in idIndex to get the current key for
    this mock (handles the case where only SortOrder shifted but ID is stable).
    Validate name again before removing.

  Layer 3 — Linear name scan fallback:
    If both key and ID are stale (full re-index after deleteAll), iterate the RBT
    to find the node whose mock.Name == expectedName. Use the found node's ID in
    the new key to keep idIndex consistent.

expectedName is extracted from newObj (*models.Mock).Name. This is always correct because UpdateUnFilteredMock deep-copies the matched mock into updateMock before calling treedb.update(), so newObj.Name always carries the identity of the mock that was actually matched by the integrations layer.

1. Abstraction boundary: treedb is the authoritative store. Store integrity (only remove what was asked for) must be enforced by the store itself, not scattered across every caller.

2. Atomicity: any integrations-side fix would require a read-then-update pattern (re-fetch current key, then call update) across two separate operations, leaving a TOCTOU window where another goroutine could call SetUnFilteredMocks between the read and the update. The treedb fix happens entirely under the mutex — the name check and the removal are a single atomic operation.

pkg/agent/proxy/treedb_test.go (new file, 4 tests):

  TestUpdateExactMatch
    Normal happy path: mock at matching key is found and updated.

  TestUpdateRejectsKeyCollision
    Bug scenario: stale key points to a different mock after re-index.
    update() must reject the operation and leave the innocent mock intact.

  TestUpdateNameFallbackAfterReindex
    Linear scan fallback: target mock exists under a different key after
    SetUnFilteredMocks shifted all IDs. update() must find it by name and
    update it correctly.

  TestUpdateIDIndexRejectsCollision
    ID-index path also validates identity: if idIndex[id] points to a node
    holding a different mock, the operation is rejected.

All 4 tests pass: ok go.keploy.io/server/v3/pkg/agent/proxy 0.008s

  pkg/agent/proxy/treedb.go       — update() method rewritten with 3-layer validation
  pkg/agent/proxy/treedb_test.go  — new unit tests for update() identity semantics

## Links & References

**Closes:** #[issue number that will be closed through this PR]
- NA (if very small change like typo, linting, etc.)

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [x] 👍 yes (added unit test)
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [ ] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

## Self Review done?
- [ ] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [ ] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [ ] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [ ] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?