### PR TITLE
fix: narrow pkill pattern to avoid killing Docker Desktop on macOS CI

### DIFF
--- a/.github/workflows/golang_docker_macos.yml
+++ b/.github/workflows/golang_docker_macos.yml
@@ -135,7 +135,7 @@ jobs:
             docker rm -f "$c" 2>/dev/null || true
           done
           docker network rm keploy-network 2>/dev/null || true
-          pkill -9 -f 'keploy' 2>/dev/null || true
+          pkill -9 -f 'keploy record|keploy test' 2>/dev/null || true
 
       - name: Clean up git config
         if: always()

--- a/.github/workflows/prepare_and_run_macos.yml
+++ b/.github/workflows/prepare_and_run_macos.yml
@@ -240,7 +240,7 @@ jobs:
           docker network rm keploy-network 2>/dev/null || true
 
           # Kill leftover keploy processes
-          pkill -9 -f 'keploy' 2>/dev/null || true
+          pkill -9 -f 'keploy record|keploy test' 2>/dev/null || true
 
           # Prune stopped containers before images — images must never be
           # pruned while stopped containers still reference their layers

--- a/.github/workflows/python_docker_macos.yml
+++ b/.github/workflows/python_docker_macos.yml
@@ -127,7 +127,7 @@ jobs:
             docker rm -f $ids 2>/dev/null || true
           fi
           docker network rm keploy-network 2>/dev/null || true
-          pkill -9 -f 'keploy' 2>/dev/null || true
+          pkill -9 -f 'keploy record|keploy test' 2>/dev/null || true
 
       - name: Clean up git config
         if: always()

--- a/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-docker-macos.sh
+++ b/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-docker-macos.sh
@@ -19,8 +19,8 @@ for c in ginApp ginApp_1 ginApp_2 ginApp_test mongoDb; do
 done
 docker network rm keploy-network 2>/dev/null || true
 
-# Also kill any leftover keploy processes holding ports
-pgrep -f 'keploy' | xargs -r sudo kill -9 2>/dev/null || true
+# Kill leftover keploy CLI processes holding ports (not Docker-managed ones)
+pgrep -f 'keploy record|keploy test' | xargs kill -9 2>/dev/null || true
 
 # Start mongo before starting keploy (retry once if Docker crashes).
 docker network create keploy-network


### PR DESCRIPTION
## Summary
- `pkill -9 -f 'keploy'` in macOS CI cleanup steps matches ANY process with "keploy" in its command line — including Docker Desktop's VM process running keploy container images
- This kills Docker Desktop mid-test on the self-hosted macOS runner, causing all subsequent Docker operations to fail with `exec format error` or `exit status 255`
- Narrowed the pattern to `'keploy record|keploy test'` which only matches the Keploy CLI binary, not Docker-managed container processes
- Applied across all 4 macOS files: `golang_docker_macos.yml`, `python_docker_macos.yml`, `prepare_and_run_macos.yml`, and `gin_mongo/golang-docker-macos.sh`

## Test plan
- [ ] Verify macOS self-hosted CI pipeline passes (gin-mongo, echo-sql, python)
- [ ] Verify Docker Desktop is NOT killed between jobs (no "Terminate orphan process: Docker Desktop" in logs)