### PR TITLE
fix: replace hardcoded GitHub SSH host keys with dynamic fetch in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Prepare Dockerfile for Release Build
         run: |
           cp Dockerfile Dockerfile.release
-          sed -i '/COPY go.mod go.sum \/app\//a RUN git config --global url."ssh:\/\/git@github.com\/".insteadOf "https:\/\/github.com\/" \&\& mkdir -p -m 0700 ~\/.ssh \&\& { echo "github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnxrYX0GvQ3Z8b5vVdBObJ2f9qNpkac8PW3T6g7b"; echo "github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrY\/SGNRIp5HRf7o1qYSMq6h6S4dhp8lN5XdM+sP8lvNabzB6xTnI0="; echo "github.com rsa-sha2-512 AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgLn3a\/+6EVMblT2TImKt+kNWm1U3VFAj7BO\/P3E42EwS\/N+N5gAe3+q8FPVRfnGVjnRz1hb8fgbzJ8cRtKm6EIHzEbLepFW5C8uK0MJbYGm3M5Dz5PjQqL4M+PEuY1VQ3BqFkP8PU2HhGwWIkGpMpI1f6+JpJQ3XnO9GzGqJHPhq7ZJ5MJHbYfCrH4AJzqHB\/S0Kbl2SFVJLABFrqbI8M\/oUGmT+jlJUBEw6SIenU2MXFuVdxCQHWOdMFkFCUj8Rm\/k+LFqelS6XAaEtJXTLv5eSXNjBkqj7r3hMBbYJJNg+wdXq2oUw2M4NiTy7A0FGqYVD9UVzgw=="; } >> ~\/.ssh\/known_hosts' ./Dockerfile.release
+          sed -i '/COPY go.mod go.sum \/app\//a RUN git config --global url."ssh:\/\/git@github.com\/".insteadOf "https:\/\/github.com\/" \&\& mkdir -p -m 0700 ~\/.ssh \&\& ssh-keyscan -t ed25519,ecdsa,rsa github.com >> ~\/.ssh\/known_hosts 2>\/dev\/null' ./Dockerfile.release
           sed -i 's/RUN go mod download/RUN --mount=type=ssh go mod download/' ./Dockerfile.release
           sed -i '/RUN --mount=type=ssh go mod download/i ENV GOPRIVATE=github.com/keploy/*' ./Dockerfile.release
 


### PR DESCRIPTION
## Describe the changes that are made
- Replace hardcoded GitHub SSH host keys in the Docker release build with a dynamic `ssh-keyscan` call so they stay current when GitHub rotates keys.

## Links & References

**Closes:** NA

### 🔗 Related PRs
- #3954 (earlier release pipeline fixes)
### 🐞 Related Issues
- Release pipeline failures on v3.3.54 through v3.3.57
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [x] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed

## Added comments for hard-to-understand areas?
- [x] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 🙅 no, because it is not needed

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
The `build-docker` job fails with:
```
Host key for github.com has changed and you have requested strict checking.
Host key verification failed.
fatal: Could not read from remote repository.
ERROR: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
```

The hardcoded SSH host keys in `release.yml` became stale after GitHub rotated their keys. This PR replaces them with `ssh-keyscan -t ed25519,ecdsa,rsa github.com` so the keys are always fetched fresh at build time.

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?