### PR TITLE
feat: enhance normalization process with last updated tracking

### DIFF
--- a/cli/normalise.go
+++ b/cli/normalise.go
@@ -21,7 +21,7 @@ func Normalize(ctx context.Context, logger *zap.Logger, _ *config.Config, servic
 		Short:   "Normalize Keploy",
 		Example: "keploy normalize  --test-run testrun --tests test-set-1:test-case-1 test-case-2,test-set-2:test-case-1 test-case-2 ",
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
-			return cmdConfigurator.ValidateFlags(ctx, cmd)
+			return cmdConfigurator.Validate(ctx, cmd)
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			svc, err := serviceFactory.GetService(ctx, cmd.Name())

--- a/config/config.go
+++ b/config/config.go
@@ -112,6 +112,7 @@ type Normalize struct {
 	SelectedTests []SelectedTests `json:"selectedTests" yaml:"selectedTests" mapstructure:"selectedTests"`
 	TestRun       string          `json:"testReport" yaml:"testReport" mapstructure:"testReport"`
 	AllowHighRisk bool            `json:"allowHighRisk" yaml:"allowHighRisk" mapstructure:"allowHighRisk"`
+	EditedBy      string          `json:"-" yaml:"-" mapstructure:"-"`
 }
 
 type BypassRule struct {

--- a/pkg/models/testcase.go
+++ b/pkg/models/testcase.go
@@ -1,5 +1,7 @@
 package models
 
+import "time"
+
 type BodyType string
 type Version string
 
@@ -32,6 +34,11 @@ func GetVersion() (V1 Version) {
 	return currentVersion
 }
 
+type LastUpdated struct {
+	Author    string    `json:"author,omitempty" bson:"author,omitempty" yaml:"author,omitempty"`
+	Timestamp time.Time `json:"timestamp,omitempty" bson:"timestamp,omitempty" yaml:"timestamp,omitempty"`
+}
+
 type TestCase struct {
 	Version     Version                       `json:"version" bson:"version"`
 	Kind        Kind                          `json:"kind" bson:"kind"`
@@ -40,6 +47,7 @@ type TestCase struct {
 	Created     int64                         `json:"created" bson:"created"`
 	Updated     int64                         `json:"updated" bson:"updated"`
 	Captured    int64                         `json:"captured" bson:"captured"`
+	LastUpdated *LastUpdated                  `json:"last_updated,omitempty" bson:"last_updated,omitempty" yaml:"last_updated,omitempty"`
 	HTTPReq     HTTPReq                       `json:"http_req" bson:"http_req"`
 	HTTPResp    HTTPResp                      `json:"http_resp" bson:"http_resp"`
 	AllKeys     map[string][]string           `json:"all_keys" bson:"all_keys"`

--- a/pkg/platform/yaml/testdb/util.go
+++ b/pkg/platform/yaml/testdb/util.go
@@ -25,9 +25,10 @@ func EncodeTestcase(tc models.TestCase, logger *zap.Logger) (*yaml.NetworkTraffi
 		zap.String("name", tc.Name))
 
 	doc := &yaml.NetworkTrafficDoc{
-		Version: tc.Version,
-		Kind:    tc.Kind,
-		Name:    tc.Name,
+		Version:     tc.Version,
+		Kind:        tc.Kind,
+		Name:        tc.Name,
+		LastUpdated: tc.LastUpdated,
 	}
 
 	var noise map[string][]string
@@ -294,12 +295,13 @@ func HasBannedHeaders(object map[string]string, bannedHeaders map[string]string)
 
 func Decode(yamlTestcase *yaml.NetworkTrafficDoc, logger *zap.Logger) (*models.TestCase, error) {
 	tc := &models.TestCase{
-		Version:    yamlTestcase.Version,
-		Kind:       yamlTestcase.Kind,
-		Name:       yamlTestcase.Name,
-		Curl:       yamlTestcase.Curl,
-		Noise:      make(map[string][]string),
-		Assertions: make(map[models.AssertionType]interface{}),
+		Version:     yamlTestcase.Version,
+		Kind:        yamlTestcase.Kind,
+		Name:        yamlTestcase.Name,
+		Curl:        yamlTestcase.Curl,
+		LastUpdated: yamlTestcase.LastUpdated,
+		Noise:       make(map[string][]string),
+		Assertions:  make(map[models.AssertionType]interface{}),
 	}
 
 	switch tc.Kind {

--- a/pkg/platform/yaml/yaml.go
+++ b/pkg/platform/yaml/yaml.go
@@ -30,12 +30,13 @@ const (
 
 // NetworkTrafficDoc stores the request-response data of a network call (ingress or egress)
 type NetworkTrafficDoc struct {
-	Version      models.Version `json:"version" yaml:"version"`
-	Kind         models.Kind    `json:"kind" yaml:"kind"`
-	Name         string         `json:"name" yaml:"name"`
-	Spec         yamlLib.Node   `json:"spec" yaml:"spec"`
-	Curl         string         `json:"curl" yaml:"curl,omitempty"`
-	ConnectionID string         `json:"connectionId" yaml:"connectionId,omitempty"`
+	Version      models.Version      `json:"version" yaml:"version"`
+	Kind         models.Kind         `json:"kind" yaml:"kind"`
+	Name         string              `json:"name" yaml:"name"`
+	Spec         yamlLib.Node        `json:"spec" yaml:"spec"`
+	LastUpdated  *models.LastUpdated `json:"last_updated,omitempty" yaml:"last_updated,omitempty"`
+	Curl         string              `json:"curl" yaml:"curl,omitempty"`
+	ConnectionID string              `json:"connectionId" yaml:"connectionId,omitempty"`
 }
 
 // ctxReader wraps an io.Reader with a context for cancellation support

--- a/pkg/service/tools/normalise.go
+++ b/pkg/service/tools/normalise.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"go.keploy.io/server/v2/config"
 	"go.keploy.io/server/v2/pkg"
@@ -13,7 +15,10 @@ import (
 	"go.uber.org/zap"
 )
 
+type lastUpdatedContextKey struct{}
+
 func (t *Tools) Normalize(ctx context.Context) error {
+	ctx = t.addLastUpdatedToContext(ctx)
 
 	var testRun string
 	if t.config.Normalize.TestRun == "" {
@@ -82,7 +87,32 @@ func (t *Tools) Normalize(ctx context.Context) error {
 	return nil
 }
 
+func (t *Tools) addLastUpdatedToContext(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if t == nil || t.config == nil {
+		return ctx
+	}
+
+	editedBy := strings.TrimSpace(t.config.Normalize.EditedBy)
+	if editedBy == "" {
+		return ctx
+	}
+
+	return context.WithValue(ctx, lastUpdatedContextKey{}, models.LastUpdated{
+		Author:    editedBy,
+		Timestamp: time.Now().UTC(),
+	})
+}
+
 func (t *Tools) NormalizeTestCases(ctx context.Context, testRun string, testSetID string, selectedTestCaseIDs []string, testCaseResults []models.TestResult) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	lastUpdated, hasLastUpdated := t.resolveLastUpdated(ctx)
 
 	if len(testCaseResults) == 0 {
 		testReport, err := t.reportDB.GetReport(ctx, testRun, testSetID)
@@ -114,30 +144,37 @@ func (t *Tools) NormalizeTestCases(ctx context.Context, testRun string, testSetI
 	}
 
 	for _, testCase := range selectedTestCases {
-		if _, ok := testCaseResultMap[testCase.Name]; !ok {
+		testCaseResult, ok := testCaseResultMap[testCase.Name]
+		if !ok {
 			t.logger.Info("test case not found in the test report", zap.String("test-case-id", testCase.Name), zap.String("test-set-id", testSetID))
 			continue
 		}
-		if testCaseResultMap[testCase.Name].Status == models.TestStatusPassed {
+		if testCaseResult.Status == models.TestStatusPassed {
 			continue
 		}
-		if testCaseResultMap[testCase.Name].FailureInfo.Risk == models.High && !t.config.Normalize.AllowHighRisk {
+		if testCaseResult.FailureInfo.Risk == models.High && !t.config.Normalize.AllowHighRisk {
 			t.logger.Warn(fmt.Sprintf("failed to normalize test case %s due to a high-risk failure. please confirm the schema compatibility with all consumers and then run with --allow-high-risk", testCase.Name))
 			continue
+		}
+		if hasLastUpdated {
+			testCase.LastUpdated = &models.LastUpdated{
+				Author:    lastUpdated.Author,
+				Timestamp: lastUpdated.Timestamp,
+			}
 		}
 		// Handle normalization based on test case kind
 		switch testCase.Kind {
 		case models.HTTP:
 			// Store the original timestamp to preserve it during normalization
 			originalTimestamp := testCase.HTTPResp.Timestamp
-			testCase.HTTPResp = testCaseResultMap[testCase.Name].Res
+			testCase.HTTPResp = testCaseResult.Res
 			// Restore the original timestamp after normalization
 			testCase.HTTPResp.Timestamp = originalTimestamp
 
 		case models.GRPC_EXPORT:
 			// Store the original timestamp to preserve it during normalization
 			originalTimestamp := testCase.GrpcResp.Timestamp
-			testCase.GrpcResp = testCaseResultMap[testCase.Name].GrpcRes
+			testCase.GrpcResp = testCaseResult.GrpcRes
 			// Restore the original timestamp after normalization
 			testCase.GrpcResp.Timestamp = originalTimestamp
 		}
@@ -147,4 +184,29 @@ func (t *Tools) NormalizeTestCases(ctx context.Context, testRun string, testSetI
 		}
 	}
 	return nil
+}
+
+func (t *Tools) resolveLastUpdated(ctx context.Context) (models.LastUpdated, bool) {
+	lastUpdated, ok := ctx.Value(lastUpdatedContextKey{}).(models.LastUpdated)
+	if ok {
+		lastUpdated.Author = strings.TrimSpace(lastUpdated.Author)
+		if lastUpdated.Author != "" && !lastUpdated.Timestamp.IsZero() {
+			lastUpdated.Timestamp = lastUpdated.Timestamp.UTC()
+			return lastUpdated, true
+		}
+	}
+
+	if t == nil || t.config == nil {
+		return models.LastUpdated{}, false
+	}
+
+	editedBy := strings.TrimSpace(t.config.Normalize.EditedBy)
+	if editedBy == "" {
+		return models.LastUpdated{}, false
+	}
+
+	return models.LastUpdated{
+		Author:    editedBy,
+		Timestamp: time.Now().UTC(),
+	}, true
 }


### PR DESCRIPTION

## Describe the changes that are made

This pull request introduces a new mechanism to track and persist metadata about who last edited a test case and when, as part of the normalization process. It does so by adding a `LastUpdated` field to test case models, updating the normalization logic to set this field, and ensuring the information is properly encoded and decoded in YAML representations. Additionally, it refines flag validation in the CLI and improves context handling in the normalization service.

**Enhancements to test case metadata and normalization:**

* Added a new `LastUpdated` struct and corresponding `LastUpdated` field to the `TestCase` model in `pkg/models/testcase.go` to store the author and timestamp of the last edit. [[1]](diffhunk://#diff-711c8251d6fbdcbd7b5cce2e3d006f4c6a90b095ae07b68ec7835faea2f2285dR37-R41) [[2]](diffhunk://#diff-711c8251d6fbdcbd7b5cce2e3d006f4c6a90b095ae07b68ec7835faea2f2285dR50)
* Updated YAML encoding/decoding logic in `pkg/platform/yaml/testdb/util.go` and `pkg/platform/yaml/yaml.go` to persist and retrieve the `LastUpdated` field for test cases. [[1]](diffhunk://#diff-88490dc42037139450491068ff6032c18fa48a01865335bd4cce2d4dc7e55507R31) [[2]](diffhunk://#diff-88490dc42037139450491068ff6032c18fa48a01865335bd4cce2d4dc7e55507R302) [[3]](diffhunk://#diff-704bd33e4e54ce7764b1a6a8b1808fe3ee1aecb05bf8695295622043a2346ce1R37)

**Normalization service improvements:**

* Modified the normalization process in `pkg/service/tools/normalise.go` to inject and resolve the `LastUpdated` context, setting the field on test cases during normalization if an editor is specified. [[1]](diffhunk://#diff-433f3d0eaff4c919f308bd01f81b5a8a3986e9f4a9dc9aa7377933b0a96fb8fbR18-R21) [[2]](diffhunk://#diff-433f3d0eaff4c919f308bd01f81b5a8a3986e9f4a9dc9aa7377933b0a96fb8fbR90-R115) [[3]](diffhunk://#diff-433f3d0eaff4c919f308bd01f81b5a8a3986e9f4a9dc9aa7377933b0a96fb8fbL117-R177) [[4]](diffhunk://#diff-433f3d0eaff4c919f308bd01f81b5a8a3986e9f4a9dc9aa7377933b0a96fb8fbR188-R212)
* Added the `EditedBy` field to the normalization config in `config/config.go` to specify the user performing normalization.

**CLI and context handling:**

* Changed the CLI flag validation in `cli/normalise.go` to use a more generic `Validate` method, improving maintainability.
* Improved context creation and propagation in the normalization service to ensure robust handling of the `LastUpdated` information. [[1]](diffhunk://#diff-433f3d0eaff4c919f308bd01f81b5a8a3986e9f4a9dc9aa7377933b0a96fb8fbR8-R9) [[2]](diffhunk://#diff-433f3d0eaff4c919f308bd01f81b5a8a3986e9f4a9dc9aa7377933b0a96fb8fbR18-R21) [[3]](diffhunk://#diff-433f3d0eaff4c919f308bd01f81b5a8a3986e9f4a9dc9aa7377933b0a96fb8fbR90-R115)

These changes collectively enable better traceability of test case edits and improve the reliability and maintainability of the normalization workflow.

## Links & References

**Closes:** https://github.com/keploy/enterprise/issues/1768
- NA (if very small change like typo, linting, etc.)

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [x] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?