### PR TITLE
fix: add failure_reason and logs fields to TestReport for APP_HALTED status

### DIFF
--- a/pkg/models/testrun.go
+++ b/pkg/models/testrun.go
@@ -5,22 +5,24 @@ import (
 )
 
 type TestReport struct {
-	Version    Version      `json:"version" yaml:"version"`
-	Name       string       `json:"name" yaml:"name"`
-	Status     string       `json:"status" yaml:"status"`
-	Success    int          `json:"success" yaml:"success"`
-	Failure    int          `json:"failure" yaml:"failure"`
-	Obsolete   int          `json:"obsolete,omitempty" yaml:"obsolete,omitempty"`
-	HighRisk   int          `json:"high_risk,omitempty" yaml:"high-risk,omitempty"`
-	MediumRisk int          `json:"medium_risk,omitempty" yaml:"medium-risk,omitempty"`
-	LowRisk    int          `json:"low_risk,omitempty" yaml:"low-risk,omitempty"`
-	Ignored    int          `json:"ignored" yaml:"ignored"`
-	Total      int          `json:"total" yaml:"total"`
-	Tests      []TestResult `json:"tests" yaml:"tests,omitempty"`
-	TestSet    string       `json:"testSet" yaml:"test_set"`
-	CreatedAt  int64        `json:"created_at" yaml:"created_at"`
-	TimeTaken  string       `json:"time_taken" yaml:"time_taken"`
-	CmdUsed    string       `json:"cmdUsed,omitempty" yaml:"cmdUsed,omitempty"`
+	Version        Version      `json:"version" yaml:"version"`
+	Name           string       `json:"name" yaml:"name"`
+	Status         string       `json:"status" yaml:"status"`
+	Success        int          `json:"success" yaml:"success"`
+	Failure        int          `json:"failure" yaml:"failure"`
+	Obsolete       int          `json:"obsolete,omitempty" yaml:"obsolete,omitempty"`
+	HighRisk       int          `json:"high_risk,omitempty" yaml:"high-risk,omitempty"`
+	MediumRisk     int          `json:"medium_risk,omitempty" yaml:"medium-risk,omitempty"`
+	LowRisk        int          `json:"low_risk,omitempty" yaml:"low-risk,omitempty"`
+	Ignored        int          `json:"ignored" yaml:"ignored"`
+	Total          int          `json:"total" yaml:"total"`
+	Tests          []TestResult `json:"tests" yaml:"tests,omitempty"`
+	TestSet        string       `json:"testSet" yaml:"test_set"`
+	CreatedAt      int64        `json:"created_at" yaml:"created_at"`
+	TimeTaken      string       `json:"time_taken" yaml:"time_taken"`
+	CmdUsed        string       `json:"cmdUsed,omitempty" yaml:"cmdUsed,omitempty"`
+	FailureReason  string       `json:"failure_reason,omitempty" yaml:"failure_reason,omitempty"`
+	Logs           string       `json:"logs,omitempty" yaml:"logs,omitempty"`
 }
 
 type TestCoverage struct {

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -747,6 +747,8 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 
 	testSetStatus := models.TestSetStatusPassed
 	testSetStatusByErrChan := models.TestSetStatusRunning
+	testSetFailureReason string
+	testSetLogs string
 
 	cmdType := utils.CmdType(r.config.CommandType)
 	// Check if mappings are present and decide filtering strategy
@@ -779,16 +781,21 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 				switch err.AppErrorType {
 				case models.ErrCommandError:
 					testSetStatusByErrChan = models.TestSetStatusFaultUserApp
+					testSetFailureReason = err.Error()
 				case models.ErrUnExpected:
 					testSetStatusByErrChan = models.TestSetStatusAppHalted
+					testSetFailureReason = err.Error()
 				case models.ErrAppStopped:
 					testSetStatusByErrChan = models.TestSetStatusAppHalted
+					testSetFailureReason = err.Error()
 				case models.ErrCtxCanceled:
 					return nil
 				case models.ErrInternal:
 					testSetStatusByErrChan = models.TestSetStatusInternalErr
+					testSetFailureReason = err.Error()
 				default:
 					testSetStatusByErrChan = models.TestSetStatusAppHalted
+					testSetFailureReason = err.Error()
 				}
 				utils.LogError(r.logger, err, "application failed to run")
 			case <-runTestSetCtx.Done():
@@ -1037,16 +1044,21 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 					switch err.AppErrorType {
 					case models.ErrCommandError:
 						testSetStatusByErrChan = models.TestSetStatusFaultUserApp
+						testSetFailureReason = err.Error()
 					case models.ErrUnExpected:
 						testSetStatusByErrChan = models.TestSetStatusAppHalted
+						testSetFailureReason = err.Error()
 					case models.ErrAppStopped:
 						testSetStatusByErrChan = models.TestSetStatusAppHalted
+						testSetFailureReason = err.Error()
 					case models.ErrCtxCanceled:
 						return nil
 					case models.ErrInternal:
 						testSetStatusByErrChan = models.TestSetStatusInternalErr
+						testSetFailureReason = err.Error()
 					default:
 						testSetStatusByErrChan = models.TestSetStatusAppHalted
+						testSetFailureReason = err.Error()
 					}
 					utils.LogError(r.logger, err, "application failed to run")
 				case <-runTestSetCtx.Done():
@@ -1609,20 +1621,22 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 	}
 
 	testReport = &models.TestReport{
-		Version:    models.GetVersion(),
-		TestSet:    testSetID,
-		Status:     string(testSetStatus),
-		Total:      testCasesCount,
-		Success:    success,
-		Failure:    failure,
-		Obsolete:   obsolete,
-		Ignored:    ignored,
-		Tests:      testCaseResults,
-		TimeTaken:  timeTaken.String(),
-		HighRisk:   riskHigh,
-		MediumRisk: riskMed,
-		LowRisk:    riskLow,
-		CmdUsed:    r.config.Test.CmdUsed,
+		Version:        models.GetVersion(),
+		TestSet:       testSetID,
+		Status:        string(testSetStatus),
+		Total:        testCasesCount,
+		Success:      success,
+		Failure:      failure,
+		Obsolete:     obsolete,
+		Ignored:      ignored,
+		Tests:        testCaseResults,
+		TimeTaken:    timeTaken.String(),
+		HighRisk:     riskHigh,
+		MediumRisk:   riskMed,
+		LowRisk:      riskLow,
+		CmdUsed:      r.config.Test.CmdUsed,
+		FailureReason: testSetFailureReason,
+		Logs:         testSetLogs,
 	}
 
 	// final report should have reason for sudden stop of the test run so this should get canceled

--- a/pkg/service/report/report.go
+++ b/pkg/service/report/report.go
@@ -277,6 +277,17 @@ func (r *Report) printSummary(reports map[string]*models.TestReport) error {
 	}
 	_ = w.Flush()
 
+	// Show failure reason for test sets that halted or had internal errors
+	for _, rrow := range rows {
+		rep := reports[rrow.name]
+		if rep == nil {
+			continue
+		}
+		if (rep.Status == string(models.TestSetStatusAppHalted) || rep.Status == string(models.TestSetStatusInternalErr)) && rep.FailureReason != "" {
+			fmt.Fprintf(r.out, "\n  WARNING: test set %s halted: %s\n", rrow.name, rep.FailureReason)
+		}
+	}
+
 	fmt.Fprintln(r.out, "\nFAILED TEST CASES:")
 	if failed == 0 {
 		fmt.Fprintln(r.out, "\t(none)")


### PR DESCRIPTION
## Describe the changes that are made
- Added `failure_reason` and `logs` fields to the `TestReport` struct in `pkg/models/testrun.go`
- When a test set halts due to app errors (`APP_HALTED`, `INTERNAL_ERR`, etc.), the error message from `AppError` is now captured and stored in the report instead of being discarded
- Updated `pkg/service/replay/replay.go` to populate `FailureReason` when any non-canceled app error occurs
- Updated `pkg/service/report/report.go` to display a warning line showing the failure reason when a test set halted, before the FAILED TEST CASES section

## Links & References
- **Closes:** #3968

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 🙅 no, because they aren't needed

## Added comments for hard-to-understand areas?
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below

## Self Review done?
- [ ] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA