### PR TITLE
fix: ignore dns in mock mismatch

### DIFF
--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1308,38 +1308,31 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 
 			expectedMocks, hasExpectedMocks := expectedTestMockMappings[testCase.Name]
 
-			// Helper to filter DNS mocks from expected mapping entries (checks both entry kind and mock DB)
-			nonDNSExpectedNames := func(entries []models.MockEntry) []string {
-				names := make([]string, 0, len(entries))
-				for _, m := range entries {
-					isDNS := strings.EqualFold(m.Kind, string(models.DNS))
-					if !isDNS {
-						if kind, ok := mockKindByName[m.Name]; ok && kind == models.DNS {
-							isDNS = true
-						}
-					}
-					if !isDNS {
-						names = append(names, m.Name)
+			// Compute non-DNS expected and consumed name slices once; reused for subset check and mismatch reporting.
+			filteredExpectedNames := make([]string, 0, len(expectedMocks))
+			for _, m := range expectedMocks {
+				isDNS := strings.EqualFold(m.Kind, string(models.DNS))
+				if !isDNS {
+					if kind, ok := mockKindByName[m.Name]; ok && kind == models.DNS {
+						isDNS = true
 					}
 				}
-				return names
+				if !isDNS {
+					filteredExpectedNames = append(filteredExpectedNames, m.Name)
+				}
 			}
 
-			// Helper to filter DNS mocks from consumed mock states
-			nonDNSConsumedNames := func(mocks []models.MockState) []string {
-				names := make([]string, 0, len(mocks))
-				for _, m := range mocks {
-					if m.Kind != models.DNS {
-						names = append(names, m.Name)
-					}
+			filteredMockNames := make([]string, 0, len(consumedMocks))
+			for _, m := range consumedMocks {
+				if m.Kind != models.DNS {
+					filteredMockNames = append(filteredMockNames, m.Name)
 				}
-				return names
 			}
 
 			mockSetMismatch := false
 			if r.instrument && useMappingBased && isMappingEnabled && hasExpectedMocks {
 				// Filter out DNS mocks from comparison since DNS resolution order is non-deterministic
-				mockSetMismatch = !isMockSubset(nonDNSConsumedNames(consumedMocks), nonDNSExpectedNames(expectedMocks))
+				mockSetMismatch = !isMockSubset(filteredMockNames, filteredExpectedNames)
 			}
 
 			emitFailureLogs := !mockSetMismatch
@@ -1457,8 +1450,6 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 				zap.Any("mocks", consumedMocks))
 
 			if mockSetMismatch {
-				filteredExpectedNames := nonDNSExpectedNames(expectedMocks)
-				filteredMockNames := nonDNSConsumedNames(consumedMocks)
 				if testPass {
 					r.logger.Debug("mock mapping mismatch ignored because testcase passed",
 						zap.String("testcase", testCase.Name),


### PR DESCRIPTION
This pull request improves the accuracy and clarity of test mock comparison and reporting in the `RunTestSet` method of `pkg/service/replay/replay.go`. The main focus is to handle DNS mocks separately, since their resolution order is non-deterministic and should not affect test outcomes or reporting. The changes ensure DNS mocks are excluded from mock set comparisons and related logs.

**Mock comparison and reporting improvements:**

* Introduced a `mockKindByName` map to track the `Kind` of each mock by name, enabling efficient filtering of DNS mocks during test execution. [[1]](diffhunk://#diff-e6489c0602898b5fed439b3c4c42885db5890483591af1991adc497ba59e31d9R758-R759) [[2]](diffhunk://#diff-e6489c0602898b5fed439b3c4c42885db5890483591af1991adc497ba59e31d9R883-R889) [[3]](diffhunk://#diff-e6489c0602898b5fed439b3c4c42885db5890483591af1991adc497ba59e31d9R966-R971)
* Modified the mock set comparison logic to exclude DNS mocks from both the expected and actual (consumed) mock lists, ensuring only relevant mocks are compared.
* Updated logging and failure reporting to filter out DNS mocks from the reported expected and actual mock names, making logs more accurate and actionable.