### PR TITLE
docs: fix duplicate heading marker in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -69,7 +69,7 @@ To ensure that each change is relevant and properly peer reviewed, please adhere
 This means that if you are outside the Keploy organization, you must fork the repository and create PRs from branches on your own fork.
 The README in GitHub's [first-contributions repo](https://github.com/firstcontributions/first-contributions) provides an example.
 
-## ## How to set up the docs website locally?
+## How to set up the docs website locally?
 
 1. Fork the repository
 


### PR DESCRIPTION
## What does this PR do?

Fixes a typo in `.github/CONTRIBUTING.md` - removed duplicate heading marker (`## ##` → `##`)

## Why?

The duplicate `##` on line 72 causes incorrect markdown rendering.

## Changes

- Fixed: `## ## How to set up` → `## How to set up`## What does this PR do?

Fixes a typo in `.github/CONTRIBUTING.md` - removed duplicate heading marker (`## ##` → `##`)

## Why?

The duplicate `##` on line 72 causes incorrect markdown rendering.

## Changes

- Fixed: `## ## How to set up` → `## How to set up`