### PR TITLE
Fix: use named debugfs volume and non-fatal rlimit for Docker on Wind…

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,14 +1,7 @@
 #!/bin/sh
 
-# Mount debugfs if not already mounted
-if ! mountpoint -q /sys/kernel/debug 2>/dev/null; then
-  sudo mount -t debugfs debugfs /sys/kernel/debug 2>/dev/null || true
-fi
-
-# Mount tracefs if not already available (fallback for newer kernels
-# where tracefs is separate from debugfs)
-if [ ! -d /sys/kernel/debug/tracing ] && [ ! -d /sys/kernel/tracing ]; then
-  sudo mount -t tracefs tracefs /sys/kernel/tracing 2>/dev/null || true
+if ! mountpoint -q /sys/kernel/debug; then
+  sudo mount -t debugfs debugfs /sys/kernel/debug
 fi
 
 # Use exec to replace the shell process with keploy

--- a/pkg/agent/hooks/linux/hooks.go
+++ b/pkg/agent/hooks/linux/hooks.go
@@ -109,11 +109,8 @@ func (h *Hooks) Load(ctx context.Context, opts agent.HookCfg, setupOpts config.A
 func (h *Hooks) load(ctx context.Context, opts agent.HookCfg, setupOpts config.Agent) error {
 	// Allow the current process to lock memory for eBPF resources.
 	if err := rlimit.RemoveMemlock(); err != nil {
-		// On some environments (e.g., Docker Desktop for Windows with WSL2), the memcg
-		// accounting probe may fail with "function not implemented" even though the kernel
-		// supports eBPF loading. Continue anyway — if eBPF truly can't load,
-		// spec.LoadAndAssign() below will fail with a clear error.
-		h.logger.Warn("failed to remove memlock limit, continuing anyway", zap.Error(err))
+		utils.LogError(h.logger, err, "failed to lock memory for eBPF resources")
+		return err
 	}
 
 	// Load pre-compiled programs and maps into the kernel.

--- a/pkg/platform/docker/docker.go
+++ b/pkg/platform/docker/docker.go
@@ -478,13 +478,9 @@ func (idc *Impl) generateKeployVolumes() []string {
 			dockerContext := strings.Split(strings.TrimSpace(string(out)), "\n")[0]
 			if dockerContext != "colima" {
 				// Default Docker context on Windows
-				// Use the "debugfs" named Docker volume (not a host path) because
-				// the WSL2 VM typically doesn't have debugfs mounted at /sys/kernel/debug.
-				// The named volume is created by CreateVolume with
-				// driver options type=debugfs,device=debugfs.
 				volumes = append(volumes,
 					"/sys/fs/cgroup:/sys/fs/cgroup",
-					"debugfs:/sys/kernel/debug:rw",
+					"/sys/kernel/debug:/sys/kernel/debug:rw",
 					"/sys/fs/bpf:/sys/fs/bpf",
 				)
 			} else {
@@ -969,17 +965,6 @@ func (idc *Impl) modifyAppServiceForKeploy(compose *Compose, appContainerName st
 		}
 	}
 	idc.addTopLevelVolume(compose, KeployTLSVolumeName)
-
-	// On Windows (and macOS with default context), the keploy-agent service
-	// uses a named "debugfs" volume instead of a host path bind mount.
-	// Declare it in the top-level volumes section with driver options so
-	// Docker Compose can create it with the debugfs filesystem type.
-	if runtime.GOOS == "windows" {
-		idc.addTopLevelVolumeWithDriverOpts(compose, "debugfs", map[string]string{
-			"type":   "debugfs",
-			"device": "debugfs",
-		})
-	}
 	return nil
 }
 
@@ -1072,46 +1057,6 @@ func (idc *Impl) addTopLevelVolume(compose *Compose, volumeName string) {
 	compose.Volumes.Content = append(compose.Volumes.Content,
 		&yaml.Node{Kind: yaml.ScalarNode, Value: volumeName},
 		&yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{}}, // {}
-	)
-}
-
-// addTopLevelVolumeWithDriverOpts ensures a named volume is defined at the compose top-level
-// with the specified driver_opts (e.g. type=debugfs, device=debugfs for the debugfs volume).
-func (idc *Impl) addTopLevelVolumeWithDriverOpts(compose *Compose, volumeName string, driverOpts map[string]string) {
-	if compose.Volumes.Kind == 0 {
-		compose.Volumes.Kind = yaml.MappingNode
-		compose.Volumes.Content = []*yaml.Node{}
-	}
-
-	// Check if volume exists; if so, skip
-	for i := 0; i < len(compose.Volumes.Content); i += 2 {
-		if compose.Volumes.Content[i].Value == volumeName {
-			return
-		}
-	}
-
-	// Build driver_opts mapping node
-	driverOptsContent := make([]*yaml.Node, 0, len(driverOpts)*2)
-	for k, v := range driverOpts {
-		driverOptsContent = append(driverOptsContent,
-			&yaml.Node{Kind: yaml.ScalarNode, Value: k},
-			&yaml.Node{Kind: yaml.ScalarNode, Value: v},
-		)
-	}
-
-	volumeConfigNode := &yaml.Node{
-		Kind: yaml.MappingNode,
-		Content: []*yaml.Node{
-			{Kind: yaml.ScalarNode, Value: "driver"},
-			{Kind: yaml.ScalarNode, Value: "local"},
-			{Kind: yaml.ScalarNode, Value: "driver_opts"},
-			{Kind: yaml.MappingNode, Content: driverOptsContent},
-		},
-	}
-
-	compose.Volumes.Content = append(compose.Volumes.Content,
-		&yaml.Node{Kind: yaml.ScalarNode, Value: volumeName},
-		volumeConfigNode,
 	)
 }
 


### PR DESCRIPTION
## Describe the changes that are made
- **`.github/workflows/test_workflow_scripts/update-docker-windows.sh`** (NEW): Created a Windows-specific Docker image build script that targets `linux/amd64` instead of `linux/arm64`. The existing `update-docker-mac.sh` was being used for Windows CI runners, which builds `linux/arm64` images. On `x86_64` Windows runners, this forces the image to run under QEMU emulation, which does not support the `bpf()` syscall — causing `ENOSYS` ("function not implemented") errors when loading eBPF programs.
- **`.github/workflows/prepare_and_run_windows.yml`**: Updated the Windows CI workflow to use the new `update-docker-windows.sh` script instead of `update-docker-mac.sh`, ensuring native `linux/amd64` execution without QEMU emulation.

## Links & References

**Closes:** NA

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- #3970 
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [x] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

## Added comments for hard-to-understand areas?
- [x] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

**Steps to test:**
1. Trigger the Windows CI pipeline on this branch.
2. Verify the Docker image is built for `linux/amd64` (not `linux/arm64`).
3. Confirm the eBPF agent starts without `ENOSYS` / "function not implemented" errors during record/replay.

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: use linux/amd64 Docker image for Windows CI to avoid QEMU eBPF failures`  
- **Branch Name**: `fix/windows-docker-debugfs-mount`

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?