### PR TITLE
feat(config): add env and envFile support for declaring application environment variables

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -267,6 +267,8 @@ func (c *CmdConfigurator) AddFlags(cmd *cobra.Command) error {
 		cmd.Flags().Bool("generate-github-actions", c.cfg.GenerateGithubActions, "Generate Github Actions workflow file")
 		cmd.Flags().String("keploy-container", c.cfg.KeployContainer, "Keploy server container name")
 		cmd.Flags().Bool("in-ci", c.cfg.InCi, "is CI Running or not")
+		cmd.Flags().StringToString("env", c.cfg.Env, "Environment variables to pass to the application (e.g., --env DB_HOST=localhost,DB_PORT=5432)")
+		cmd.Flags().String("env-file", c.cfg.EnvFile, "Path to a .env file with environment variables for the application")
 
 		//add rest of the uncommon flags for record, test, rerecord commands
 		c.AddUncommonFlags(cmd)

--- a/config/config.go
+++ b/config/config.go
@@ -58,7 +58,9 @@ type Config struct {
 	// InMemoryCompose holds docker-compose YAML content in memory to avoid writing
 	// sensitive environment variables (secrets, tokens) to disk. When set, the
 	// compose command uses "-f -" and pipes this content via stdin.
-	InMemoryCompose []byte `json:"-" yaml:"-" mapstructure:"-"`
+	InMemoryCompose []byte            `json:"-" yaml:"-" mapstructure:"-"`
+	Env             map[string]string `json:"env" yaml:"env" mapstructure:"env"`
+	EnvFile         string            `json:"envFile" yaml:"envFile" mapstructure:"envFile"`
 }
 
 type Agent struct {

--- a/config/default.go
+++ b/config/default.go
@@ -93,6 +93,8 @@ contract:
   download: false
   generate: false
 inCi: false
+env: {}
+envFile: ""
 `, models.DefaultIncomingProxyPort)
 
 func GetDefaultConfig() string {

--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -597,7 +597,7 @@ func (a *App) run(ctx context.Context) models.AppError {
 	}
 
 	var err error
-	cmdErr := utils.ExecuteCommand(ctx, a.logger, userCmd, cmdCancel, 25*time.Second, a.composeContent)
+	cmdErr := utils.ExecuteCommand(ctx, a.logger, userCmd, cmdCancel, 25*time.Second, a.composeContent, nil)
 	if cmdErr.Err != nil {
 		switch cmdErr.Type {
 		case utils.Init:

--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -160,7 +160,13 @@ func (a *App) modifyDockerRun(_ context.Context) error {
 		}
 		sort.Strings(envKeys)
 		for _, k := range envKeys {
-			if _, err := fmt.Fprintf(tmpFile, "%s=%s\n", k, a.opts.EnvVars[k]); err != nil {
+			value := a.opts.EnvVars[k]
+			if strings.ContainsAny(value, "\r\n") {
+				tmpFile.Close()
+				os.Remove(tmpFile.Name())
+				return fmt.Errorf("env var %q value contains a newline or carriage return, which is not supported in docker --env-file; provide a single-line value", k)
+			}
+			if _, err := fmt.Fprintf(tmpFile, "%s=%s\n", k, value); err != nil {
 				tmpFile.Close()
 				os.Remove(tmpFile.Name())
 				return fmt.Errorf("failed to write env var %q to temp env file: %w", k, err)
@@ -632,7 +638,11 @@ func (a *App) run(ctx context.Context) models.AppError {
 	}
 
 	var err error
-	cmdErr := utils.ExecuteCommand(ctx, a.logger, userCmd, cmdCancel, 25*time.Second, a.composeContent, a.opts.EnvVars)
+	execEnvVars := a.opts.EnvVars
+	if utils.IsDockerCmd(a.kind) {
+		execEnvVars = nil
+	}
+	cmdErr := utils.ExecuteCommand(ctx, a.logger, userCmd, cmdCancel, 25*time.Second, a.composeContent, execEnvVars)
 	if cmdErr.Err != nil {
 		switch cmdErr.Type {
 		case utils.Init:

--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -147,9 +147,13 @@ func (a *App) modifyDockerRun(_ context.Context) error {
 		return fmt.Errorf("invalid command structure: %s", a.cmd)
 	}
 
-	// Append user-defined environment variables
+	// Append user-defined environment variables.
+	// Values are single-quote-wrapped to prevent shell injection when the
+	// command is later executed via sh -c. Any single quotes inside the value
+	// are escaped using the standard '"'"' technique.
 	for k, v := range a.opts.EnvVars {
-		tlsFlags += fmt.Sprintf("-e %s=%s ", k, v)
+		escapedVal := strings.ReplaceAll(v, "'", "'\\''")
+		tlsFlags += fmt.Sprintf("-e %s='%s' ", k, escapedVal)
 	}
 
 	injection := fmt.Sprintf("%s %s %s", pidMode, networkMode, tlsFlags)

--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -583,7 +583,14 @@ func (a *App) run(ctx context.Context) models.AppError {
 	userCmd := a.cmd
 
 	if a.envTempFile != "" {
-		defer os.Remove(a.envTempFile)
+		defer func(path string) {
+			if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+				a.logger.Debug("failed to remove temporary env file; remove it manually if still present",
+					zap.String("path", path),
+					zap.Error(err),
+				)
+			}
+		}(a.envTempFile)
 	}
 
 	if a.kind == utils.DockerCompose {

--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -147,12 +147,13 @@ func (a *App) modifyDockerRun(_ context.Context) error {
 		return fmt.Errorf("invalid command structure: %s", a.cmd)
 	}
 
-	// Append user-defined environment variables.
-	// Values are single-quote-wrapped to prevent shell injection when the
-	// command is later executed via sh -c. Any single quotes inside the value
-	// are escaped using the standard '"'"' technique.
-	for k, v := range a.opts.EnvVars {
-		escapedVal := strings.ReplaceAll(v, "'", "'\\''")
+	envKeys := make([]string, 0, len(a.opts.EnvVars))
+	for k := range a.opts.EnvVars {
+		envKeys = append(envKeys, k)
+	}
+	sort.Strings(envKeys)
+	for _, k := range envKeys {
+		escapedVal := strings.ReplaceAll(a.opts.EnvVars[k], "'", "'\\''")
 		tlsFlags += fmt.Sprintf("-e %s='%s' ", k, escapedVal)
 	}
 

--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -121,6 +121,10 @@ func (a *App) modifyDockerRun(_ context.Context) error {
 	if a.cmd == "" {
 		return fmt.Errorf("no command provided to modify")
 	}
+	// docker start cannot accept --env-file; env vars can only be set at docker run time.
+	if a.kind == utils.DockerStart && len(a.opts.EnvVars) > 0 {
+		return fmt.Errorf("env var injection is not supported for 'docker start': 'docker start' cannot modify container environment at start time; use 'docker run' instead")
+	}
 	// Attach the keploy agent container's PID namespace and network namespace to the app container
 	// Sharing network namespace so that the docker container IPs of both agent and app remain same
 	// sharing pid namespace so that they share the same process tree (common ancestor) in docker

--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"regexp"
 	"sort"
@@ -52,6 +53,7 @@ type App struct {
 	keployContainer string
 	composeFile     string // path to the temp compose file (set during SetupCompose)
 	composeContent  []byte // in-memory compose YAML; set when InMemoryCompose is used
+	envTempFile     string // path to temp --env-file for docker run; cleaned up after run
 	EnableTesting   bool
 	Mode            models.Mode
 }
@@ -147,14 +149,29 @@ func (a *App) modifyDockerRun(_ context.Context) error {
 		return fmt.Errorf("invalid command structure: %s", a.cmd)
 	}
 
-	envKeys := make([]string, 0, len(a.opts.EnvVars))
-	for k := range a.opts.EnvVars {
-		envKeys = append(envKeys, k)
-	}
-	sort.Strings(envKeys)
-	for _, k := range envKeys {
-		escapedVal := strings.ReplaceAll(a.opts.EnvVars[k], "'", "'\\''")
-		tlsFlags += fmt.Sprintf("-e %s='%s' ", k, escapedVal)
+	if len(a.opts.EnvVars) > 0 {
+		tmpFile, err := os.CreateTemp("", "keploy-env-*.env")
+		if err != nil {
+			return fmt.Errorf("failed to create temp env file for docker run: %w", err)
+		}
+		envKeys := make([]string, 0, len(a.opts.EnvVars))
+		for k := range a.opts.EnvVars {
+			envKeys = append(envKeys, k)
+		}
+		sort.Strings(envKeys)
+		for _, k := range envKeys {
+			fmt.Fprintf(tmpFile, "%s=%s\n", k, a.opts.EnvVars[k])
+		}
+		if err := tmpFile.Close(); err != nil {
+			os.Remove(tmpFile.Name())
+			return fmt.Errorf("failed to write temp env file for docker run: %w", err)
+		}
+		if err := os.Chmod(tmpFile.Name(), 0600); err != nil {
+			os.Remove(tmpFile.Name())
+			return fmt.Errorf("failed to secure temp env file: %w", err)
+		}
+		a.envTempFile = tmpFile.Name()
+		tlsFlags += fmt.Sprintf("--env-file %s ", tmpFile.Name())
 	}
 
 	injection := fmt.Sprintf("%s %s %s", pidMode, networkMode, tlsFlags)
@@ -550,6 +567,10 @@ func extractProjectFlags(cmd string) []string {
 
 func (a *App) run(ctx context.Context) models.AppError {
 	userCmd := a.cmd
+
+	if a.envTempFile != "" {
+		defer os.Remove(a.envTempFile)
+	}
 
 	if a.kind == utils.DockerCompose {
 		defer a.composeDown()

--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -147,6 +147,11 @@ func (a *App) modifyDockerRun(_ context.Context) error {
 		return fmt.Errorf("invalid command structure: %s", a.cmd)
 	}
 
+	// Append user-defined environment variables
+	for k, v := range a.opts.EnvVars {
+		tlsFlags += fmt.Sprintf("-e %s=%s ", k, v)
+	}
+
 	injection := fmt.Sprintf("%s %s %s", pidMode, networkMode, tlsFlags)
 
 	// Modify the command to insert the pidMode and environment variables
@@ -597,7 +602,7 @@ func (a *App) run(ctx context.Context) models.AppError {
 	}
 
 	var err error
-	cmdErr := utils.ExecuteCommand(ctx, a.logger, userCmd, cmdCancel, 25*time.Second, a.composeContent, nil)
+	cmdErr := utils.ExecuteCommand(ctx, a.logger, userCmd, cmdCancel, 25*time.Second, a.composeContent, a.opts.EnvVars)
 	if cmdErr.Err != nil {
 		switch cmdErr.Type {
 		case utils.Init:

--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -160,7 +160,11 @@ func (a *App) modifyDockerRun(_ context.Context) error {
 		}
 		sort.Strings(envKeys)
 		for _, k := range envKeys {
-			fmt.Fprintf(tmpFile, "%s=%s\n", k, a.opts.EnvVars[k])
+			if _, err := fmt.Fprintf(tmpFile, "%s=%s\n", k, a.opts.EnvVars[k]); err != nil {
+				tmpFile.Close()
+				os.Remove(tmpFile.Name())
+				return fmt.Errorf("failed to write env var %q to temp env file: %w", k, err)
+			}
 		}
 		if err := tmpFile.Close(); err != nil {
 			os.Remove(tmpFile.Name())
@@ -171,7 +175,7 @@ func (a *App) modifyDockerRun(_ context.Context) error {
 			return fmt.Errorf("failed to secure temp env file: %w", err)
 		}
 		a.envTempFile = tmpFile.Name()
-		tlsFlags += fmt.Sprintf("--env-file %s ", tmpFile.Name())
+		tlsFlags += fmt.Sprintf("--env-file \"%s\" ", tmpFile.Name())
 	}
 
 	injection := fmt.Sprintf("%s %s %s", pidMode, networkMode, tlsFlags)

--- a/pkg/models/instrument.go
+++ b/pkg/models/instrument.go
@@ -108,6 +108,7 @@ type SetupOptions struct {
 	// environment variables to disk. When non-nil, SetupCompose uses this content
 	// directly instead of reading from a file path extracted from the command.
 	InMemoryCompose []byte
+	EnvVars         map[string]string
 }
 
 type RunOptions struct {

--- a/pkg/platform/docker/docker.go
+++ b/pkg/platform/docker/docker.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -985,9 +986,15 @@ func (idc *Impl) modifyAppServiceForKeploy(compose *Compose, appContainerName st
 			javaOpts := fmt.Sprintf("-Djavax.net.ssl.trustStore=%s -Djavax.net.ssl.trustStorePassword=changeit", trustStorePath)
 			idc.appendServiceEnvVar(serviceContentNode, "JAVA_TOOL_OPTIONS", javaOpts)
 
-			// Inject user-defined environment variables
-			for k, v := range envVars {
-				idc.addServiceEnvVar(serviceContentNode, k, v)
+			// Inject user-defined environment variables.
+			// Sort keys for deterministic YAML output across runs.
+			envKeys := make([]string, 0, len(envVars))
+			for k := range envVars {
+				envKeys = append(envKeys, k)
+			}
+			sort.Strings(envKeys)
+			for _, k := range envKeys {
+				idc.addServiceEnvVar(serviceContentNode, k, envVars[k])
 			}
 
 			// Add PID namespace sharing

--- a/pkg/platform/docker/docker.go
+++ b/pkg/platform/docker/docker.go
@@ -927,7 +927,7 @@ func (idc *Impl) ModifyComposeForAgent(compose *Compose, opts models.SetupOption
 	}
 
 	// Now modify the app container to integrate with keploy-agent
-	err = idc.modifyAppServiceForKeploy(compose, appContainerName)
+	err = idc.modifyAppServiceForKeploy(compose, appContainerName, opts.EnvVars)
 	if err != nil {
 		return fmt.Errorf("failed to modify app service: %w", err)
 	}
@@ -935,7 +935,7 @@ func (idc *Impl) ModifyComposeForAgent(compose *Compose, opts models.SetupOption
 }
 
 // modifyAppServiceForKeploy modifies the app service to depend on keploy-agent and share namespaces
-func (idc *Impl) modifyAppServiceForKeploy(compose *Compose, appContainerName string) error {
+func (idc *Impl) modifyAppServiceForKeploy(compose *Compose, appContainerName string, envVars map[string]string) error {
 	if compose.Services.Content == nil {
 		return fmt.Errorf("no services found in compose file")
 	}
@@ -984,6 +984,12 @@ func (idc *Impl) modifyAppServiceForKeploy(compose *Compose, appContainerName st
 
 			javaOpts := fmt.Sprintf("-Djavax.net.ssl.trustStore=%s -Djavax.net.ssl.trustStorePassword=changeit", trustStorePath)
 			idc.appendServiceEnvVar(serviceContentNode, "JAVA_TOOL_OPTIONS", javaOpts)
+
+			// Inject user-defined environment variables
+			for k, v := range envVars {
+				idc.addServiceEnvVar(serviceContentNode, k, v)
+			}
+
 			// Add PID namespace sharing
 			idc.addServiceProperty(serviceContentNode, "pid", fmt.Sprintf("service:%s", "keploy-agent"))
 

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -214,9 +215,18 @@ func (r *Recorder) Start(ctx context.Context, reRecordCfg models.ReRecordCfg) er
 		memoryLimit = r.config.Record.MemoryLimit
 	}
 
-	envVars, err := utils.ResolveEnvVars(r.config.Env, r.config.EnvFile)
+	envFilePath := r.config.EnvFile
+	if envFilePath != "" && !filepath.IsAbs(envFilePath) && r.config.ConfigPath != "" {
+		basePath := r.config.ConfigPath
+		if info, err := os.Stat(basePath); err == nil && !info.IsDir() {
+			basePath = filepath.Dir(basePath)
+		}
+		envFilePath = filepath.Join(basePath, envFilePath)
+	}
+
+	envVars, err := utils.ResolveEnvVars(r.config.Env, envFilePath)
 	if err != nil {
-		return fmt.Errorf("failed to resolve environment variables: %w", err)
+		return fmt.Errorf("failed to resolve environment variables: %w. Check that envFile path is correct and the file format uses KEY=VALUE pairs", err)
 	}
 
 	// Instrument will setup the environment and start the hooks and proxy

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -215,18 +214,11 @@ func (r *Recorder) Start(ctx context.Context, reRecordCfg models.ReRecordCfg) er
 		memoryLimit = r.config.Record.MemoryLimit
 	}
 
-	envFilePath := r.config.EnvFile
-	if envFilePath != "" && !filepath.IsAbs(envFilePath) && r.config.ConfigPath != "" {
-		basePath := r.config.ConfigPath
-		if info, err := os.Stat(basePath); err == nil && !info.IsDir() {
-			basePath = filepath.Dir(basePath)
-		}
-		envFilePath = filepath.Join(basePath, envFilePath)
-	}
+	envFilePath := utils.ResolveEnvFilePath(r.config.ConfigPath, r.config.EnvFile)
 
 	envVars, err := utils.ResolveEnvVars(r.config.Env, envFilePath)
 	if err != nil {
-		return fmt.Errorf("failed to resolve environment variables: %w. Check that envFile path is correct and the file format uses KEY=VALUE pairs", err)
+		return fmt.Errorf("failed to resolve environment variables: %w. Check env/envFile configuration, ensure variable names are valid and not reserved, and if using envFile confirm it exists and uses KEY=VALUE pairs", err)
 	}
 
 	// Instrument will setup the environment and start the hooks and proxy

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -214,8 +214,13 @@ func (r *Recorder) Start(ctx context.Context, reRecordCfg models.ReRecordCfg) er
 		memoryLimit = r.config.Record.MemoryLimit
 	}
 
+	envVars, err := utils.ResolveEnvVars(r.config.Env, r.config.EnvFile)
+	if err != nil {
+		return fmt.Errorf("failed to resolve environment variables: %w", err)
+	}
+
 	// Instrument will setup the environment and start the hooks and proxy
-	err := r.instrumentation.Setup(setupCtx, r.config.Command, models.SetupOptions{Container: r.config.ContainerName, DockerDelay: r.config.BuildDelay, Mode: models.MODE_RECORD, CommandType: r.config.CommandType, EnableTesting: false, GlobalPassthrough: r.config.Record.GlobalPassthrough, BuildDelay: r.config.BuildDelay, PassThroughPorts: passPortsUint, MemoryLimit: memoryLimit, ConfigPath: r.config.ConfigPath, EnableSampling: r.config.Record.EnableSampling})
+	err = r.instrumentation.Setup(setupCtx, r.config.Command, models.SetupOptions{Container: r.config.ContainerName, DockerDelay: r.config.BuildDelay, Mode: models.MODE_RECORD, CommandType: r.config.CommandType, EnableTesting: false, GlobalPassthrough: r.config.Record.GlobalPassthrough, BuildDelay: r.config.BuildDelay, PassThroughPorts: passPortsUint, MemoryLimit: memoryLimit, ConfigPath: r.config.ConfigPath, EnableSampling: r.config.Record.EnableSampling, EnvVars: envVars})
 
 	if err != nil {
 		// If context was cancelled (user pressed Ctrl+C), return gracefully without error

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -698,7 +698,12 @@ func (r *Replayer) Instrument(ctx context.Context) (*InstrumentState, error) {
 		passPortsUint32[i] = uint32(port)
 	}
 
-	err := r.instrumentation.Setup(ctx, r.config.Command, models.SetupOptions{Container: r.config.ContainerName, CommandType: r.config.CommandType, DockerDelay: r.config.BuildDelay, Mode: models.MODE_TEST, BuildDelay: r.config.BuildDelay, EnableTesting: true, GlobalPassthrough: r.config.Record.GlobalPassthrough, ConfigPath: r.config.ConfigPath, PassThroughPorts: passPortsUint, InMemoryCompose: r.config.InMemoryCompose})
+	envVars, err := utils.ResolveEnvVars(r.config.Env, r.config.EnvFile)
+	if err != nil {
+		return &InstrumentState{}, fmt.Errorf("failed to resolve environment variables: %w", err)
+	}
+
+	err = r.instrumentation.Setup(ctx, r.config.Command, models.SetupOptions{Container: r.config.ContainerName, CommandType: r.config.CommandType, DockerDelay: r.config.BuildDelay, Mode: models.MODE_TEST, BuildDelay: r.config.BuildDelay, EnableTesting: true, GlobalPassthrough: r.config.Record.GlobalPassthrough, ConfigPath: r.config.ConfigPath, PassThroughPorts: passPortsUint, InMemoryCompose: r.config.InMemoryCompose, EnvVars: envVars})
 	if err != nil {
 		stopReason := "failed setting up the environment"
 		utils.LogError(r.logger, err, stopReason)

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -698,21 +698,11 @@ func (r *Replayer) Instrument(ctx context.Context) (*InstrumentState, error) {
 		passPortsUint32[i] = uint32(port)
 	}
 
-	// Resolve relative envFile paths against the config file's directory so that
-	// running keploy with --config-path from a different working directory still
-	// finds the .env file next to keploy.yml.
-	envFilePath := r.config.EnvFile
-	if envFilePath != "" && !filepath.IsAbs(envFilePath) && r.config.ConfigPath != "" {
-		basePath := r.config.ConfigPath
-		if info, err := os.Stat(basePath); err == nil && !info.IsDir() {
-			basePath = filepath.Dir(basePath)
-		}
-		envFilePath = filepath.Join(basePath, envFilePath)
-	}
+	envFilePath := utils.ResolveEnvFilePath(r.config.ConfigPath, r.config.EnvFile)
 
 	envVars, err := utils.ResolveEnvVars(r.config.Env, envFilePath)
 	if err != nil {
-		return &InstrumentState{}, fmt.Errorf("failed to resolve environment variables: %w. Check that envFile path is correct and the file format uses KEY=VALUE pairs", err)
+		return &InstrumentState{}, fmt.Errorf("failed to resolve environment variables: %w. Check env/envFile configuration, ensure variable names are valid and not reserved, and if using envFile confirm it exists and uses KEY=VALUE pairs", err)
 	}
 
 	err = r.instrumentation.Setup(ctx, r.config.Command, models.SetupOptions{Container: r.config.ContainerName, CommandType: r.config.CommandType, DockerDelay: r.config.BuildDelay, Mode: models.MODE_TEST, BuildDelay: r.config.BuildDelay, EnableTesting: true, GlobalPassthrough: r.config.Record.GlobalPassthrough, ConfigPath: r.config.ConfigPath, PassThroughPorts: passPortsUint, InMemoryCompose: r.config.InMemoryCompose, EnvVars: envVars})

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -3007,7 +3007,7 @@ func (r *Replayer) executeScript(ctx context.Context, script string) error {
 		}
 	}
 
-	cmdErr := utils.ExecuteCommand(ctx, r.logger, script, cmdCancel, 25*time.Second, nil)
+	cmdErr := utils.ExecuteCommand(ctx, r.logger, script, cmdCancel, 25*time.Second, nil, nil)
 	if cmdErr.Err != nil {
 		return fmt.Errorf("failed to execute script: %w", cmdErr.Err)
 	}

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -698,9 +698,21 @@ func (r *Replayer) Instrument(ctx context.Context) (*InstrumentState, error) {
 		passPortsUint32[i] = uint32(port)
 	}
 
-	envVars, err := utils.ResolveEnvVars(r.config.Env, r.config.EnvFile)
+	// Resolve relative envFile paths against the config file's directory so that
+	// running keploy with --config-path from a different working directory still
+	// finds the .env file next to keploy.yml.
+	envFilePath := r.config.EnvFile
+	if envFilePath != "" && !filepath.IsAbs(envFilePath) && r.config.ConfigPath != "" {
+		basePath := r.config.ConfigPath
+		if info, err := os.Stat(basePath); err == nil && !info.IsDir() {
+			basePath = filepath.Dir(basePath)
+		}
+		envFilePath = filepath.Join(basePath, envFilePath)
+	}
+
+	envVars, err := utils.ResolveEnvVars(r.config.Env, envFilePath)
 	if err != nil {
-		return &InstrumentState{}, fmt.Errorf("failed to resolve environment variables: %w", err)
+		return &InstrumentState{}, fmt.Errorf("failed to resolve environment variables: %w. Check that envFile path is correct and the file format uses KEY=VALUE pairs", err)
 	}
 
 	err = r.instrumentation.Setup(ctx, r.config.Command, models.SetupOptions{Container: r.config.ContainerName, CommandType: r.config.CommandType, DockerDelay: r.config.BuildDelay, Mode: models.MODE_TEST, BuildDelay: r.config.BuildDelay, EnableTesting: true, GlobalPassthrough: r.config.Record.GlobalPassthrough, ConfigPath: r.config.ConfigPath, PassThroughPorts: passPortsUint, InMemoryCompose: r.config.InMemoryCompose, EnvVars: envVars})

--- a/utils/envfile.go
+++ b/utils/envfile.go
@@ -94,7 +94,7 @@ func ResolveEnvVars(envMap map[string]string, envFilePath string) (map[string]st
 			if !validEnvKeyRe.MatchString(k) {
 				return nil, fmt.Errorf("invalid environment variable name %q in env file %q: must match [a-zA-Z_][a-zA-Z0-9_]*", k, envFilePath)
 			}
-			if _, reserved := reservedKeployEnvKeys[k]; reserved {
+			if _, reserved := reservedKeployEnvKeys[strings.ToUpper(k)]; reserved {
 				return nil, fmt.Errorf("environment variable %q is reserved by Keploy for TLS certificate injection and cannot be overridden via env/envFile", k)
 			}
 			merged[k] = v
@@ -106,7 +106,7 @@ func ResolveEnvVars(envMap map[string]string, envFilePath string) (map[string]st
 		if !validEnvKeyRe.MatchString(k) {
 			return nil, fmt.Errorf("invalid environment variable name %q: must match [a-zA-Z_][a-zA-Z0-9_]*", k)
 		}
-		if _, reserved := reservedKeployEnvKeys[k]; reserved {
+		if _, reserved := reservedKeployEnvKeys[strings.ToUpper(k)]; reserved {
 			return nil, fmt.Errorf("environment variable %q is reserved by Keploy for TLS certificate injection and cannot be overridden via env/envFile", k)
 		}
 		merged[k] = v

--- a/utils/envfile.go
+++ b/utils/envfile.go
@@ -1,0 +1,89 @@
+package utils
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ParseEnvFile reads a .env file and returns its contents as a map.
+// It supports:
+//   - KEY=VALUE pairs
+//   - Lines starting with # are treated as comments and skipped
+//   - Empty lines are skipped
+//   - Values may be wrapped in single or double quotes (quotes are stripped)
+//   - Only the first '=' is used as the delimiter; the rest of the line is the value
+func ParseEnvFile(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open env file %q: %w", path, err)
+	}
+	defer f.Close()
+
+	envMap := make(map[string]string)
+	scanner := bufio.NewScanner(f)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+
+		// skip empty lines and comments
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		idx := strings.Index(line, "=")
+		if idx < 0 {
+			// lines without '=' are skipped silently (bare variable exports)
+			continue
+		}
+
+		key := strings.TrimSpace(line[:idx])
+		if key == "" {
+			continue
+		}
+
+		val := line[idx+1:]
+
+		// strip surrounding quotes (single or double)
+		if len(val) >= 2 {
+			if (val[0] == '"' && val[len(val)-1] == '"') ||
+				(val[0] == '\'' && val[len(val)-1] == '\'') {
+				val = val[1 : len(val)-1]
+			}
+		}
+
+		envMap[key] = val
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading env file %q: %w", path, err)
+	}
+
+	return envMap, nil
+}
+
+// ResolveEnvVars merges an env file and an inline env map into a single map.
+// Inline env values take precedence over values from the env file, matching
+// docker-compose semantics.
+func ResolveEnvVars(envMap map[string]string, envFilePath string) (map[string]string, error) {
+	merged := make(map[string]string)
+
+	if envFilePath != "" {
+		fileVars, err := ParseEnvFile(envFilePath)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range fileVars {
+			merged[k] = v
+		}
+	}
+
+	// inline values override file values
+	for k, v := range envMap {
+		merged[k] = v
+	}
+
+	return merged, nil
+}

--- a/utils/envfile.go
+++ b/utils/envfile.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -112,4 +113,18 @@ func ResolveEnvVars(envMap map[string]string, envFilePath string) (map[string]st
 	}
 
 	return merged, nil
+}
+
+// ResolveEnvFilePath resolves a relative envFile path against the directory
+// that contains the keploy config file. If envFile is already absolute, empty,
+// or configPath is empty, it is returned unchanged.
+func ResolveEnvFilePath(configPath, envFile string) string {
+	if envFile == "" || filepath.IsAbs(envFile) || configPath == "" {
+		return envFile
+	}
+	basePath := configPath
+	if info, err := os.Stat(basePath); err == nil && !info.IsDir() {
+		basePath = filepath.Dir(basePath)
+	}
+	return filepath.Join(basePath, envFile)
 }

--- a/utils/envfile.go
+++ b/utils/envfile.go
@@ -17,12 +17,15 @@ import (
 func ParseEnvFile(path string) (map[string]string, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open env file %q: %w", path, err)
+		return nil, fmt.Errorf("failed to open env file %q: %w. Please verify the file path exists and is readable", path, err)
 	}
 	defer f.Close()
 
 	envMap := make(map[string]string)
 	scanner := bufio.NewScanner(f)
+	// Increase the buffer to support large single-line values (e.g., base64 blobs, certificates).
+	// The default limit (~64KB) causes bufio.ErrTooLong for such values.
+	scanner.Buffer(make([]byte, 64*1024), 10*1024*1024)
 	lineNum := 0
 	for scanner.Scan() {
 		lineNum++
@@ -58,7 +61,7 @@ func ParseEnvFile(path string) (map[string]string, error) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("error reading env file %q: %w", path, err)
+		return nil, fmt.Errorf("error reading env file %q: %w. Check if the file is corrupted or has encoding issues", path, err)
 	}
 
 	return envMap, nil

--- a/utils/envfile.go
+++ b/utils/envfile.go
@@ -10,6 +10,16 @@ import (
 
 var validEnvKeyRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 
+// reservedKeployEnvKeys are env vars Keploy injects for TLS CA interception.
+// Allowing users to override them would silently break certificate injection.
+var reservedKeployEnvKeys = map[string]struct{}{
+	"NODE_EXTRA_CA_CERTS": {},
+	"REQUESTS_CA_BUNDLE":  {},
+	"SSL_CERT_FILE":       {},
+	"CARGO_HTTP_CAINFO":   {},
+	"JAVA_TOOL_OPTIONS":   {},
+}
+
 // ParseEnvFile reads a .env file and returns its contents as a map.
 // It supports:
 //   - KEY=VALUE pairs
@@ -83,6 +93,9 @@ func ResolveEnvVars(envMap map[string]string, envFilePath string) (map[string]st
 			if !validEnvKeyRe.MatchString(k) {
 				return nil, fmt.Errorf("invalid environment variable name %q in env file %q: must match [a-zA-Z_][a-zA-Z0-9_]*", k, envFilePath)
 			}
+			if _, reserved := reservedKeployEnvKeys[k]; reserved {
+				return nil, fmt.Errorf("environment variable %q is reserved by Keploy for TLS certificate injection and cannot be overridden via env/envFile", k)
+			}
 			merged[k] = v
 		}
 	}
@@ -91,6 +104,9 @@ func ResolveEnvVars(envMap map[string]string, envFilePath string) (map[string]st
 	for k, v := range envMap {
 		if !validEnvKeyRe.MatchString(k) {
 			return nil, fmt.Errorf("invalid environment variable name %q: must match [a-zA-Z_][a-zA-Z0-9_]*", k)
+		}
+		if _, reserved := reservedKeployEnvKeys[k]; reserved {
+			return nil, fmt.Errorf("environment variable %q is reserved by Keploy for TLS certificate injection and cannot be overridden via env/envFile", k)
 		}
 		merged[k] = v
 	}

--- a/utils/envfile.go
+++ b/utils/envfile.go
@@ -4,8 +4,11 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 )
+
+var validEnvKeyRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 
 // ParseEnvFile reads a .env file and returns its contents as a map.
 // It supports:
@@ -26,9 +29,7 @@ func ParseEnvFile(path string) (map[string]string, error) {
 	// Increase the buffer to support large single-line values (e.g., base64 blobs, certificates).
 	// The default limit (~64KB) causes bufio.ErrTooLong for such values.
 	scanner.Buffer(make([]byte, 64*1024), 10*1024*1024)
-	lineNum := 0
 	for scanner.Scan() {
-		lineNum++
 		line := strings.TrimSpace(scanner.Text())
 
 		// skip empty lines and comments
@@ -79,12 +80,18 @@ func ResolveEnvVars(envMap map[string]string, envFilePath string) (map[string]st
 			return nil, err
 		}
 		for k, v := range fileVars {
+			if !validEnvKeyRe.MatchString(k) {
+				return nil, fmt.Errorf("invalid environment variable name %q in env file %q: must match [a-zA-Z_][a-zA-Z0-9_]*", k, envFilePath)
+			}
 			merged[k] = v
 		}
 	}
 
 	// inline values override file values
 	for k, v := range envMap {
+		if !validEnvKeyRe.MatchString(k) {
+			return nil, fmt.Errorf("invalid environment variable name %q: must match [a-zA-Z_][a-zA-Z0-9_]*", k)
+		}
 		merged[k] = v
 	}
 

--- a/utils/envfile_test.go
+++ b/utils/envfile_test.go
@@ -186,3 +186,64 @@ func TestResolveEnvVars(t *testing.T) {
 		}
 	})
 }
+
+func TestResolveEnvFilePath(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "keploy.yml")
+	if err := os.WriteFile(cfgFile, []byte(""), 0600); err != nil {
+		t.Fatalf("failed to create temp config file: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		configPath string
+		envFile    string
+		expected   string
+	}{
+		{
+			name:       "envFile empty returns empty",
+			configPath: "/some/dir",
+			envFile:    "",
+			expected:   "",
+		},
+		{
+			name:       "configPath empty returns envFile unchanged",
+			configPath: "",
+			envFile:    ".env",
+			expected:   ".env",
+		},
+		{
+			name:       "absolute envFile returned unchanged",
+			configPath: "/some/dir",
+			envFile:    "/abs/.env",
+			expected:   "/abs/.env",
+		},
+		{
+			name:       "configPath is a file resolves relative to its directory",
+			configPath: cfgFile,
+			envFile:    ".env",
+			expected:   filepath.Join(dir, ".env"),
+		},
+		{
+			name:       "configPath is a directory resolves relative to it directly",
+			configPath: dir,
+			envFile:    ".env",
+			expected:   filepath.Join(dir, ".env"),
+		},
+		{
+			name:       "nonexistent configPath stat fails path used as-is",
+			configPath: "/nonexistent/cfg.yml",
+			envFile:    ".env",
+			expected:   filepath.Join("/nonexistent/cfg.yml", ".env"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolveEnvFilePath(tt.configPath, tt.envFile)
+			if got != tt.expected {
+				t.Errorf("ResolveEnvFilePath(%q, %q) = %q, want %q", tt.configPath, tt.envFile, got, tt.expected)
+			}
+		})
+	}
+}

--- a/utils/envfile_test.go
+++ b/utils/envfile_test.go
@@ -76,7 +76,8 @@ func TestParseEnvFile(t *testing.T) {
 }
 
 func TestParseEnvFile_MissingFile(t *testing.T) {
-	_, err := ParseEnvFile("/nonexistent/.env")
+	path := filepath.Join(t.TempDir(), "does-not-exist.env")
+	_, err := ParseEnvFile(path)
 	if err == nil {
 		t.Fatal("expected error for missing file, got nil")
 	}
@@ -130,6 +131,39 @@ func TestResolveEnvVars(t *testing.T) {
 		}
 		if len(result) != 0 {
 			t.Errorf("expected empty map, got %v", result)
+		}
+	})
+
+	t.Run("rejects invalid inline key with space", func(t *testing.T) {
+		_, err := ResolveEnvVars(map[string]string{"BAD KEY": "val"}, "")
+		if err == nil {
+			t.Fatal("expected error for invalid key, got nil")
+		}
+	})
+
+	t.Run("rejects invalid inline key starting with digit", func(t *testing.T) {
+		_, err := ResolveEnvVars(map[string]string{"1NVALID": "val"}, "")
+		if err == nil {
+			t.Fatal("expected error for key starting with digit, got nil")
+		}
+	})
+
+	t.Run("rejects invalid key with metacharacters", func(t *testing.T) {
+		_, err := ResolveEnvVars(map[string]string{"WITH;META": "val"}, "")
+		if err == nil {
+			t.Fatal("expected error for key with metacharacters, got nil")
+		}
+	})
+
+	t.Run("rejects invalid key from env file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, ".env")
+		if err := os.WriteFile(path, []byte("BAD KEY=value\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := ResolveEnvVars(nil, path)
+		if err == nil {
+			t.Fatal("expected error for invalid key in env file, got nil")
 		}
 	})
 }

--- a/utils/envfile_test.go
+++ b/utils/envfile_test.go
@@ -166,4 +166,23 @@ func TestResolveEnvVars(t *testing.T) {
 			t.Fatal("expected error for invalid key in env file, got nil")
 		}
 	})
+
+	t.Run("rejects reserved key from inline map", func(t *testing.T) {
+		_, err := ResolveEnvVars(map[string]string{"NODE_EXTRA_CA_CERTS": "/my/cert.pem"}, "")
+		if err == nil {
+			t.Fatal("expected error for reserved key NODE_EXTRA_CA_CERTS, got nil")
+		}
+	})
+
+	t.Run("rejects reserved key from env file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, ".env")
+		if err := os.WriteFile(path, []byte("JAVA_TOOL_OPTIONS=-Xmx512m\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := ResolveEnvVars(nil, path)
+		if err == nil {
+			t.Fatal("expected error for reserved key JAVA_TOOL_OPTIONS in env file, got nil")
+		}
+	})
 }

--- a/utils/envfile_test.go
+++ b/utils/envfile_test.go
@@ -1,0 +1,135 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseEnvFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected map[string]string
+		wantErr  bool
+	}{
+		{
+			name:     "basic key-value pairs",
+			content:  "DB_HOST=localhost\nDB_PORT=5432\n",
+			expected: map[string]string{"DB_HOST": "localhost", "DB_PORT": "5432"},
+		},
+		{
+			name:     "comments and empty lines are skipped",
+			content:  "# this is a comment\n\nAPI_KEY=secret\n",
+			expected: map[string]string{"API_KEY": "secret"},
+		},
+		{
+			name:     "double-quoted values are stripped",
+			content:  `DB_URL="postgres://localhost/mydb"`,
+			expected: map[string]string{"DB_URL": "postgres://localhost/mydb"},
+		},
+		{
+			name:     "single-quoted values are stripped",
+			content:  "TOKEN='abc123'",
+			expected: map[string]string{"TOKEN": "abc123"},
+		},
+		{
+			name:     "value containing equals sign",
+			content:  "DSN=host=localhost port=5432",
+			expected: map[string]string{"DSN": "host=localhost port=5432"},
+		},
+		{
+			name:     "lines without equals are skipped",
+			content:  "EXPORT_ME\nKEY=value\n",
+			expected: map[string]string{"KEY": "value"},
+		},
+		{
+			name:     "empty file",
+			content:  "",
+			expected: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, ".env")
+			if err := os.WriteFile(path, []byte(tt.content), 0600); err != nil {
+				t.Fatalf("failed to write temp env file: %v", err)
+			}
+
+			got, err := ParseEnvFile(path)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseEnvFile() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if len(got) != len(tt.expected) {
+				t.Fatalf("ParseEnvFile() returned %d entries, want %d; got=%v", len(got), len(tt.expected), got)
+			}
+			for k, want := range tt.expected {
+				if got[k] != want {
+					t.Errorf("ParseEnvFile()[%q] = %q, want %q", k, got[k], want)
+				}
+			}
+		})
+	}
+}
+
+func TestParseEnvFile_MissingFile(t *testing.T) {
+	_, err := ParseEnvFile("/nonexistent/.env")
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}
+
+func TestResolveEnvVars(t *testing.T) {
+	t.Run("inline only", func(t *testing.T) {
+		result, err := ResolveEnvVars(map[string]string{"KEY": "val"}, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result["KEY"] != "val" {
+			t.Errorf("expected KEY=val, got %q", result["KEY"])
+		}
+	})
+
+	t.Run("env file only", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, ".env")
+		if err := os.WriteFile(path, []byte("FROM_FILE=yes\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		result, err := ResolveEnvVars(nil, path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result["FROM_FILE"] != "yes" {
+			t.Errorf("expected FROM_FILE=yes, got %q", result["FROM_FILE"])
+		}
+	})
+
+	t.Run("inline overrides file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, ".env")
+		if err := os.WriteFile(path, []byte("KEY=from_file\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		result, err := ResolveEnvVars(map[string]string{"KEY": "from_inline"}, path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result["KEY"] != "from_inline" {
+			t.Errorf("expected KEY=from_inline (inline wins), got %q", result["KEY"])
+		}
+	})
+
+	t.Run("empty inputs return empty map", func(t *testing.T) {
+		result, err := ResolveEnvVars(nil, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(result) != 0 {
+			t.Errorf("expected empty map, got %v", result)
+		}
+	})
+}

--- a/utils/signal_others.go
+++ b/utils/signal_others.go
@@ -34,10 +34,19 @@ func SendSignal(logger *zap.Logger, pid int, sig syscall.Signal) error {
 	return nil
 }
 
-func ExecuteCommand(ctx context.Context, logger *zap.Logger, userCmd string, cancel func(cmd *exec.Cmd) func() error, waitDelay time.Duration, stdin []byte) CmdError {
+func ExecuteCommand(ctx context.Context, logger *zap.Logger, userCmd string, cancel func(cmd *exec.Cmd) func() error, waitDelay time.Duration, stdin []byte, envVars map[string]string) CmdError {
 	// Run the app as the user who invoked sudo
 
 	cmd := exec.CommandContext(ctx, "sh", "-c", userCmd)
+
+	// Inject user-defined environment variables on top of the current process environment.
+	// When cmd.Env is nil the child inherits the parent env unchanged (existing behavior).
+	if len(envVars) > 0 {
+		cmd.Env = os.Environ()
+		for k, v := range envVars {
+			cmd.Env = append(cmd.Env, k+"="+v)
+		}
+	}
 
 	// Set the cancel function for the command
 	cmd.Cancel = cancel(cmd)

--- a/utils/signal_windows.go
+++ b/utils/signal_windows.go
@@ -39,10 +39,19 @@ func SendSignal(logger *zap.Logger, pid int, sig syscall.Signal) error {
 //		return CmdError{Type: Init, Err: errors.New("not implemented")}
 //	}
 
-func ExecuteCommand(ctx context.Context, logger *zap.Logger, userCmd string, cancel func(cmd *exec.Cmd) func() error, waitDelay time.Duration, stdin []byte) CmdError {
+func ExecuteCommand(ctx context.Context, logger *zap.Logger, userCmd string, cancel func(cmd *exec.Cmd) func() error, waitDelay time.Duration, stdin []byte, envVars map[string]string) CmdError {
 	// On Windows, commands are typically executed via 'cmd /C' or 'powershell -Command'
 	// to handle complex shell-like logic in 'userCmd'. 'cmd /C' is the most robust default.
 	cmd := exec.CommandContext(ctx, "cmd", "/C", userCmd)
+
+	// Inject user-defined environment variables on top of the current process environment.
+	// When cmd.Env is nil the child inherits the parent env unchanged (existing behavior).
+	if len(envVars) > 0 {
+		cmd.Env = os.Environ()
+		for k, v := range envVars {
+			cmd.Env = append(cmd.Env, k+"="+v)
+		}
+	}
 
 	// Set the custom cancel function for the command
 	cmd.Cancel = cancel(cmd)


### PR DESCRIPTION
## Describe the changes that are made

Adds `env` and `envFile` as top-level fields in `keploy.yml`. Set them and keploy injects those variables into the user application at startup, the same way you'd configure `environment:` in docker-compose. @slayerjain's guidance in the thread was that this should be standalone, not dependent on the per-test-set config work.

- `env` (map) and `envFile` (path) fields added to `Config` struct and the default config template
- `ParseEnvFile` and `ResolveEnvVars` added in `utils/envfile.go`; inline `env` wins over `envFile` when both have the same key
- `EnvVars` added to `models.SetupOptions` to carry the resolved map through the instrumentation chain
- Native: `cmd.Env` built from `os.Environ()` + user vars inside `ExecuteCommand` (Linux/macOS and Windows)
- Docker run: env vars written to a 0600 temp file passed via `--env-file <temppath>` in `modifyDockerRun`; docker reads the file directly (no shell interpolation); temp file removed after the docker process exits
- Docker Compose: `addServiceEnvVar` called per entry inside `modifyAppServiceForKeploy`
- Env vars resolved in both `record` and `replay` paths before `instrumentation.Setup`
- `--env` (StringToString) and `--env-file` (String) CLI flags added to `record`, `test`, and `rerecord`
- Unit tests for `ParseEnvFile` and `ResolveEnvVars` covering basic pairs, comments, empty lines, quoted values, `=` in value, missing file, and merge precedence

**Example `keploy.yml`:**
```yaml
command: "./my-app"
env:
  DB_HOST: localhost
  DB_PORT: "5432"
envFile: ".env"
```

Or via CLI:
```
keploy record -c "./my-app" --env DB_HOST=localhost,DB_PORT=5432 --env-file .env
```

## Links & References

**Closes:** #2046

### 🔗 Related PRs
- NA

### 🐞 Related Issues
- #2046

### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [x] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

## Added comments for hard-to-understand areas?
- [x] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

1. Add `env: { MY_VAR: hello }` to `keploy.yml` in any sample app
2. Run `keploy record -c "./app"` and confirm the app process receives `MY_VAR=hello`
3. Create a `.env` file with `MY_VAR=from_file`, set `envFile: ".env"`, verify the value is picked up
4. Set both `env` and `envFile` with the same key; verify the inline value wins
5. Run `go test ./utils/... -run TestParseEnvFile -run TestResolveEnvVars`

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

- **PR Title**: `feat(config): add env and envFile support for declaring application environment variables`
- **Branch Name**: `feat/env-vars-config`

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?