### PR TITLE
feat: add automatic PII detection during recording

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -329,6 +329,7 @@ func (c *CmdConfigurator) AddUncommonFlags(cmd *cobra.Command) {
 		cmd.Flags().String("base-path", c.cfg.Record.BasePath, "Base URL to hit the server while recording the testcases")
 		cmd.Flags().Int("enable-sampling", c.cfg.Record.EnableSampling, "Enable sampling of testcases")
 		cmd.Flags().Lookup("enable-sampling").NoOptDefVal = "5"
+		cmd.Flags().Bool("detect-pii", c.cfg.Record.DetectPII, "Detect potential PII in captured request/response data during recording")
 		cmd.Flags().String("metadata", c.cfg.Record.Metadata, "Metadata to be stored in config.yaml as key-value pairs (e.g., \"key1=value1,key2=value2\")")
 		cmd.Flags().String("tls-private-key-path", c.cfg.Record.TLSPrivateKeyPath, "Path to the private key for TLS connection")
 	case "test", "rerecord":
@@ -431,6 +432,7 @@ func aliasNormalizeFunc(_ *pflag.FlagSet, name string) pflag.NormalizedName {
 		"keployContainer":       "keploy-container",
 		"keployNetwork":         "keploy-network",
 		"recordTimer":           "record-timer",
+		"detectPII":             "detect-pii",
 		"urlMethods":            "url-methods",
 		"inCi":                  "in-ci",
 		"protoFile":             "proto-file",
@@ -1039,6 +1041,14 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 				return errors.New(errMsg)
 			}
 			c.cfg.Record.Metadata = metadata
+
+			detectPII, err := cmd.Flags().GetBool("detect-pii")
+			if err != nil {
+				errMsg := "failed to get the detect-pii flag"
+				utils.LogError(c.logger, err, errMsg)
+				return errors.New(errMsg)
+			}
+			c.cfg.Record.DetectPII = detectPII
 
 			enableSampling, err := cmd.Flags().GetInt("enable-sampling")
 			if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -88,6 +88,7 @@ type Record struct {
 	RecordTimer       time.Duration   `json:"recordTimer" yaml:"recordTimer" mapstructure:"recordTimer"`
 	Metadata          string          `json:"metadata" yaml:"metadata" mapstructure:"metadata"`
 	Synchronous       bool            `json:"sync" yaml:"sync" mapstructure:"sync"`
+	DetectPII         bool            `json:"detectPII" yaml:"detect_pii" mapstructure:"detectPII"`
 	EnableSampling    int             `json:"enableSampling" yaml:"enableSampling"`
 	GlobalPassthrough bool            `json:"globalPassthrough" yaml:"globalPassthrough" mapstructure:"globalPassthrough"`
 	TLSPrivateKeyPath string          `json:"tlsPrivateKeyPath" yaml:"tlsPrivateKeyPath" mapstructure:"tlsPrivateKeyPath"`

--- a/pkg/service/pii/detect.go
+++ b/pkg/service/pii/detect.go
@@ -1,0 +1,225 @@
+package pii
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const (
+	PatternEmail      = "email"
+	PatternPhone      = "phone"
+	PatternCreditCard = "credit_card"
+	PatternSSN        = "ssn"
+	PatternFieldName  = "field_name"
+)
+
+var (
+	emailRegex = regexp.MustCompile(`(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}\b`)
+	phoneRegex = regexp.MustCompile(`(?:\+?\d{1,3}[\s.\-]?)?(?:\(?\d{2,4}\)?[\s.\-]?)\d{3,4}[\s.\-]?\d{4}`)
+	ccRegex    = regexp.MustCompile(`(?:\d[ -]*?){13,19}`)
+	ssnRegex   = regexp.MustCompile(`\b\d{3}-\d{2}-\d{4}\b`)
+)
+
+var piiFieldNames = map[string]struct{}{
+	"password":        {},
+	"secret":          {},
+	"token":           {},
+	"ssn":             {},
+	"credit_card":     {},
+	"social_security": {},
+	"date_of_birth":   {},
+	"passport":        {},
+}
+
+type Detection struct {
+	Field       string
+	PatternType string
+}
+
+func DetectHeaders(headers map[string]string, source string) []Detection {
+	detections := make([]Detection, 0)
+	for key, value := range headers {
+		field := key
+		if source != "" {
+			field = source + "." + key
+		}
+		detections = append(detections, DetectValue(field, value)...)
+	}
+	return dedupeDetections(detections)
+}
+
+func DetectBody(body string, source string) []Detection {
+	if strings.TrimSpace(body) == "" {
+		return nil
+	}
+
+	var payload interface{}
+	if err := json.Unmarshal([]byte(body), &payload); err != nil {
+		return DetectValue(source, body)
+	}
+
+	detections := make([]Detection, 0)
+	detections = append(detections, detectJSON(payload, source)...)
+	return dedupeDetections(detections)
+}
+
+func DetectValue(field, value string) []Detection {
+	detections := make([]Detection, 0)
+	if isPIIFieldName(field) {
+		detections = append(detections, Detection{Field: field, PatternType: PatternFieldName})
+	}
+
+	if emailRegex.FindString(value) != "" {
+		detections = append(detections, Detection{Field: field, PatternType: PatternEmail})
+	}
+
+	if hasPhone(value) {
+		detections = append(detections, Detection{Field: field, PatternType: PatternPhone})
+	}
+
+	if hasCreditCard(value) {
+		detections = append(detections, Detection{Field: field, PatternType: PatternCreditCard})
+	}
+
+	if ssnRegex.FindString(value) != "" {
+		detections = append(detections, Detection{Field: field, PatternType: PatternSSN})
+	}
+
+	return dedupeDetections(detections)
+}
+
+func detectJSON(value interface{}, path string) []Detection {
+	detections := make([]Detection, 0)
+	switch v := value.(type) {
+	case map[string]interface{}:
+		keys := make([]string, 0, len(v))
+		for key := range v {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			nextPath := key
+			if path != "" {
+				nextPath = path + "." + key
+			}
+			detections = append(detections, detectJSON(v[key], nextPath)...)
+		}
+	case []interface{}:
+		for i, item := range v {
+			nextPath := path + "[" + strconv.Itoa(i) + "]"
+			detections = append(detections, detectJSON(item, nextPath)...)
+		}
+	case string:
+		detections = append(detections, DetectValue(path, v)...)
+	default:
+		// Non-string JSON values are ignored unless field name itself is sensitive.
+		if isPIIFieldName(path) {
+			detections = append(detections, Detection{Field: path, PatternType: PatternFieldName})
+			detections = append(detections, DetectValue(path, fmt.Sprint(v))...)
+		}
+	}
+	return dedupeDetections(detections)
+}
+
+func isPIIFieldName(field string) bool {
+	parts := strings.FieldsFunc(strings.ToLower(field), func(r rune) bool {
+		switch r {
+		case '.', '_', '-', '[', ']':
+			return true
+		default:
+			return false
+		}
+	})
+	for _, part := range parts {
+		if _, ok := piiFieldNames[part]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func hasPhone(value string) bool {
+	matches := phoneRegex.FindAllString(value, -1)
+	for _, match := range matches {
+		digits := onlyDigits(match)
+		if len(digits) < 10 || len(digits) > 15 {
+			continue
+		}
+		// Avoid plain numeric IDs as phone numbers.
+		if !strings.ContainsAny(match, "+-(). ") && len(digits) == 10 {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func hasCreditCard(value string) bool {
+	matches := ccRegex.FindAllString(value, -1)
+	for _, match := range matches {
+		digits := onlyDigits(match)
+		if len(digits) < 13 || len(digits) > 19 {
+			continue
+		}
+		if isLuhnValid(digits) {
+			return true
+		}
+	}
+	return false
+}
+
+func isLuhnValid(number string) bool {
+	sum := 0
+	double := false
+	for i := len(number) - 1; i >= 0; i-- {
+		d := int(number[i] - '0')
+		if d < 0 || d > 9 {
+			return false
+		}
+		if double {
+			d *= 2
+			if d > 9 {
+				d -= 9
+			}
+		}
+		sum += d
+		double = !double
+	}
+	return sum > 0 && sum%10 == 0
+}
+
+func onlyDigits(value string) string {
+	var b strings.Builder
+	b.Grow(len(value))
+	for _, ch := range value {
+		if ch >= '0' && ch <= '9' {
+			b.WriteRune(ch)
+		}
+	}
+	return b.String()
+}
+
+func dedupeDetections(detections []Detection) []Detection {
+	if len(detections) == 0 {
+		return nil
+	}
+	uniq := make(map[string]Detection, len(detections))
+	for _, d := range detections {
+		key := d.Field + "|" + d.PatternType
+		uniq[key] = d
+	}
+	keys := make([]string, 0, len(uniq))
+	for key := range uniq {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([]Detection, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, uniq[key])
+	}
+	return out
+}

--- a/pkg/service/pii/detect_test.go
+++ b/pkg/service/pii/detect_test.go
@@ -1,0 +1,66 @@
+package pii
+
+import "testing"
+
+func TestDetectValueEmail(t *testing.T) {
+	detections := DetectValue("request.body.email", "user@example.com")
+	if !hasPattern(detections, PatternEmail) {
+		t.Fatalf("expected %q detection, got %+v", PatternEmail, detections)
+	}
+}
+
+func TestDetectValueInvalidEmail(t *testing.T) {
+	detections := DetectValue("request.body.message", "user@@example")
+	if hasPattern(detections, PatternEmail) {
+		t.Fatalf("did not expect %q detection, got %+v", PatternEmail, detections)
+	}
+}
+
+func TestDetectValuePhone(t *testing.T) {
+	detections := DetectValue("request.body.phone", "+1 (415) 555-2671")
+	if !hasPattern(detections, PatternPhone) {
+		t.Fatalf("expected %q detection, got %+v", PatternPhone, detections)
+	}
+}
+
+func TestDetectValueCreditCardLuhn(t *testing.T) {
+	valid := DetectValue("request.body.card", "4111 1111 1111 1111")
+	if !hasPattern(valid, PatternCreditCard) {
+		t.Fatalf("expected %q detection for valid card, got %+v", PatternCreditCard, valid)
+	}
+
+	invalid := DetectValue("request.body.card", "4111 1111 1111 1112")
+	if hasPattern(invalid, PatternCreditCard) {
+		t.Fatalf("did not expect %q detection for invalid card, got %+v", PatternCreditCard, invalid)
+	}
+}
+
+func TestDetectValueSSN(t *testing.T) {
+	detections := DetectValue("request.body.identity", "123-45-6789")
+	if !hasPattern(detections, PatternSSN) {
+		t.Fatalf("expected %q detection, got %+v", PatternSSN, detections)
+	}
+}
+
+func TestDetectValueFieldName(t *testing.T) {
+	detections := DetectValue("request.body.password", "not-a-secret")
+	if !hasPattern(detections, PatternFieldName) {
+		t.Fatalf("expected %q detection, got %+v", PatternFieldName, detections)
+	}
+}
+
+func TestDetectNoFalsePositives(t *testing.T) {
+	detections := DetectBody(`{"username":"john_doe_123","note":"hello world","amount":"42"}`, "request.body")
+	if len(detections) != 0 {
+		t.Fatalf("expected no detections, got %+v", detections)
+	}
+}
+
+func hasPattern(detections []Detection, pattern string) bool {
+	for _, d := range detections {
+		if d.PatternType == pattern {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -16,6 +16,7 @@ import (
 	"go.keploy.io/server/v3/pkg"
 	"go.keploy.io/server/v3/pkg/models"
 	"go.keploy.io/server/v3/pkg/platform/telemetry"
+	"go.keploy.io/server/v3/pkg/service/pii"
 
 	"go.keploy.io/server/v3/utils"
 	"go.uber.org/zap"
@@ -263,6 +264,10 @@ func (r *Recorder) Start(ctx context.Context, reRecordCfg models.ReRecordCfg) er
 	r.mockDB.ResetCounterID() // Reset mock ID counter for each recording session
 	errGrp.Go(func() error {
 		for testCase := range frames.Incoming {
+			if r.config.Record.DetectPII {
+				r.warnPIIDetections(testCase)
+			}
+
 			// Skip curl generation for either form data requests or large body (>1MB)
 			if len(testCase.HTTPReq.Body) <= 1*1024*1024 && len(testCase.HTTPReq.Form) == 0 {
 				testCase.Curl = pkg.MakeCurlCommand(testCase.HTTPReq)
@@ -664,6 +669,32 @@ func (r *Recorder) createConfigWithMetadata(ctx context.Context, testSetID strin
 	}
 
 	r.logger.Info("Created test-set config file with metadata")
+}
+
+func (r *Recorder) warnPIIDetections(testCase *models.TestCase) {
+	if testCase == nil {
+		return
+	}
+
+	detections := make([]pii.Detection, 0)
+	detections = append(detections, pii.DetectHeaders(testCase.HTTPReq.Header, "request.header")...)
+	detections = append(detections, pii.DetectBody(testCase.HTTPReq.Body, "request.body")...)
+	detections = append(detections, pii.DetectHeaders(testCase.HTTPResp.Header, "response.header")...)
+	detections = append(detections, pii.DetectBody(testCase.HTTPResp.Body, "response.body")...)
+
+	testCaseName := testCase.Name
+	if strings.TrimSpace(testCaseName) == "" {
+		testCaseName = "unknown-test-case"
+	}
+
+	for _, detection := range detections {
+		r.logger.Warn(fmt.Sprintf(
+			"WARNING: Potential PII detected in %s: %s matches %s",
+			testCaseName,
+			detection.Field,
+			detection.PatternType,
+		))
+	}
 }
 
 // SetGlobalMockChannel sets the global mock channel for sending mocks to correlation manager


### PR DESCRIPTION
## Summary

Adds `--detect-pii` flag to `keploy record` that warns in real-time when captured traffic contains PII patterns.

## Why this matters

The existing `keploy sanitize` command detects secrets after recording as a separate step. Most developers forget to run it, and sensitive data ends up in test YAML files committed to repos. Speedscale automatically removes PII during capture as a core feature.

| Source | Evidence |
|--------|----------|
| [#3400](https://github.com/keploy/keploy/issues/3400) | Requests automatic PII detection and masking |
| Speedscale | Auto-removes PII during traffic capture |

## Changes

- New `pkg/service/pii/` package with pattern-based PII detection
- Detects: emails, phone numbers, credit cards (Luhn check), SSNs, sensitive field names
- `--detect-pii` flag on `keploy record` triggers scanning of each captured request/response
- Warnings printed during recording: `WARNING: Potential PII detected in [test-case]: [field] matches [pattern]`
- Does not modify existing `keploy sanitize` flow

## Testing

- 7 unit tests covering each PII pattern + false positive check
- `go test ./pkg/service/pii/...` passes
- `go build ./...` succeeds

Relates to #3400

This contribution was developed with AI assistance (Codex).