### PR TITLE
feat: add secrets package for automatic secret detection and protection

### DIFF
--- a/pkg/service/secrets/body_form.go
+++ b/pkg/service/secrets/body_form.go
@@ -1,0 +1,117 @@
+package secrets
+
+import (
+	"net/url"
+	"strings"
+
+	ossModels "go.keploy.io/server/v3/pkg/models"
+)
+
+// ProcessFormData detects and replaces secrets in form data entries.
+func ProcessFormData(form []ossModels.FormData, detector *Detector, engine SecretEngine, tracker *FieldTracker) []ossModels.FormData {
+	if len(form) == 0 {
+		return form
+	}
+	for i, entry := range form {
+		fieldPath := "body." + entry.Key
+		if detector.IsAllowed(fieldPath) {
+			continue
+		}
+		isSensitive := detector.IsBodyKeySensitive(entry.Key)
+		// Also check value patterns (Fix #12: form values may contain JWTs etc.)
+		if !isSensitive {
+			for _, val := range entry.Values {
+				if reason := detector.ScanValue(entry.Key, val); reason != "" {
+					isSensitive = true
+					break
+				}
+			}
+		}
+		if !isSensitive {
+			continue
+		}
+		for j, val := range entry.Values {
+			processed, err := engine.Process(val)
+			if err != nil {
+				processed = "[KEPLOY_REDACTED:process_error]"
+			}
+			form[i].Values[j] = processed
+		}
+		tracker.AddBody(entry.Key)
+	}
+	return form
+}
+
+// ProcessURLParams detects and replaces secrets in a URL parameter map.
+func ProcessURLParams(params map[string]string, detector *Detector, engine SecretEngine, tracker *FieldTracker) map[string]string {
+	if len(params) == 0 {
+		return params
+	}
+	results := detector.DetectInURLParams(params)
+	for _, r := range results {
+		processed, err := engine.Process(r.Value)
+		if err != nil {
+			processed = "[KEPLOY_REDACTED:process_error]"
+		}
+		// Extract the bare key from "url_param.key".
+		key := strings.TrimPrefix(r.Field, "url_param.")
+		params[key] = processed
+		tracker.AddURLParam(key)
+	}
+	return params
+}
+
+// ProcessURL parses a raw URL string, detects and replaces secrets in query
+// parameters, and reassembles the URL.
+func ProcessURL(rawURL string, detector *Detector, engine SecretEngine, tracker *FieldTracker) string {
+	if rawURL == "" {
+		return rawURL
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	query := parsed.Query()
+	if len(query) == 0 {
+		return rawURL
+	}
+
+	changed := false
+	for key, values := range query {
+		fieldPath := "url_param." + key
+		if detector.IsAllowed(fieldPath) {
+			continue
+		}
+		isSensitive := false
+		if _, ok := detector.nameURLParams[strings.ToLower(key)]; ok {
+			isSensitive = true
+		}
+		if !isSensitive {
+			// Check value patterns.
+			for _, v := range values {
+				if reason := detector.ScanValue(key, v); reason != "" {
+					isSensitive = true
+					break
+				}
+			}
+		}
+		if !isSensitive {
+			continue
+		}
+		for i, v := range values {
+			processed, err := engine.Process(v)
+			if err != nil {
+				processed = "[KEPLOY_REDACTED:process_error]"
+			}
+			query[key][i] = processed
+			changed = true
+		}
+		tracker.AddURLParam(key)
+	}
+
+	if !changed {
+		return rawURL
+	}
+	parsed.RawQuery = query.Encode()
+	return parsed.String()
+}

--- a/pkg/service/secrets/body_json.go
+++ b/pkg/service/secrets/body_json.go
@@ -1,0 +1,166 @@
+package secrets
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// ProcessJSONBody detects and replaces secrets in a JSON body string using
+// byte-level sjson replacement (no re-serialization, preserves whitespace,
+// key order, number formatting, and unicode escapes for untouched content).
+func ProcessJSONBody(body string, detector *Detector, engine SecretEngine, tracker *FieldTracker) string {
+	if body == "" {
+		return body
+	}
+	trimmed := strings.TrimSpace(body)
+	if len(trimmed) == 0 || (trimmed[0] != '{' && trimmed[0] != '[') {
+		return body
+	}
+	if !gjson.Valid(body) {
+		return body
+	}
+
+	// Collect all leaf paths that need replacement.
+	type replacement struct {
+		path  string
+		value string // the new (processed) value
+	}
+	var replacements []replacement
+
+	walkJSONLeaves(body, "", func(path, key, value string) {
+		fieldPath := "body." + path
+		if detector.IsAllowed(fieldPath) {
+			return
+		}
+
+		// Check field name against sensitive body keys, then value patterns.
+		detected := detector.IsBodyKeySensitive(key)
+		if !detected {
+			detected = detector.ScanValue(key, value) != ""
+		}
+
+		if detected {
+			processed, err := engine.Process(value)
+			if err != nil {
+				// Fail-closed: redact the value rather than leaving the secret in place.
+				processed = "[KEPLOY_REDACTED:process_error]"
+			}
+			replacements = append(replacements, replacement{path: path, value: processed})
+			tracker.AddBody(path)
+		}
+	})
+
+	if len(replacements) == 0 {
+		return body
+	}
+
+	// Sort replacements by path length descending so deeper paths are replaced first.
+	// This prevents sjson from invalidating byte offsets of parent paths.
+	sort.Slice(replacements, func(i, j int) bool {
+		return len(replacements[i].path) > len(replacements[j].path)
+	})
+
+	result := body
+	for _, r := range replacements {
+		// sjson.Set wraps the value with quotes for strings. Use SetRaw with explicit quoting
+		// to ensure we produce a valid JSON string.
+		quotedVal := quoteJSONString(r.value)
+		updated, err := sjson.SetRaw(result, r.path, quotedVal)
+		if err != nil {
+			continue
+		}
+		result = updated
+	}
+	return result
+}
+
+// walkJSONLeaves recursively walks a JSON document and calls fn for each string leaf.
+// path is the dot-separated sjson path, key is the immediate field name.
+func walkJSONLeaves(json string, prefix string, fn func(path, key, value string)) {
+	parsed := gjson.Parse(json)
+	walkResult(parsed, prefix, fn)
+}
+
+func walkResult(result gjson.Result, prefix string, fn func(path, key, value string)) {
+	if result.IsObject() {
+		result.ForEach(func(key, value gjson.Result) bool {
+			keyStr := key.String()
+			// Escape dots in key names for sjson compatibility.
+			escapedKey := escapeKey(keyStr)
+			escapedPath := escapedKey
+			if prefix != "" {
+				escapedPath = prefix + "." + escapedKey
+			}
+
+			if value.IsObject() || value.IsArray() {
+				walkResult(value, escapedPath, fn)
+			} else if value.Type == gjson.String {
+				fn(escapedPath, keyStr, value.Str)
+			}
+			return true
+		})
+	} else if result.IsArray() {
+		result.ForEach(func(key, value gjson.Result) bool {
+			idx := key.String()
+			path := idx
+			if prefix != "" {
+				path = prefix + "." + idx
+			}
+			if value.IsObject() || value.IsArray() {
+				walkResult(value, path, fn)
+			} else if value.Type == gjson.String {
+				fn(path, "", value.Str)
+			}
+			return true
+		})
+	}
+}
+
+// escapeKey escapes sjson special characters in JSON keys for path compatibility.
+func escapeKey(key string) string {
+	if !strings.ContainsAny(key, `.*?#\`) {
+		return key
+	}
+	// Escape backslash first (sjson's escape char), then special chars.
+	r := strings.NewReplacer(
+		`\`, `\\`,
+		".", `\.`,
+		"*", `\*`,
+		"?", `\?`,
+		"#", `\#`,
+	)
+	return r.Replace(key)
+}
+
+// quoteJSONString produces a JSON-encoded string literal (with surrounding quotes).
+func quoteJSONString(s string) string {
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		default:
+			if r < 0x20 {
+				b.WriteString(`\u00`)
+				b.WriteByte("0123456789abcdef"[byte(r)>>4])
+				b.WriteByte("0123456789abcdef"[byte(r)&0xf])
+			} else {
+				b.WriteRune(r)
+			}
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}

--- a/pkg/service/secrets/body_nonhttp.go
+++ b/pkg/service/secrets/body_nonhttp.go
@@ -1,0 +1,183 @@
+package secrets
+
+import (
+	"fmt"
+	"strings"
+
+	ossModels "go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// ProcessNonHTTPMock scans and replaces secrets in non-HTTP mock payloads.
+// Supported: gRPC (headers + JSON body), Redis, Generic (payload data).
+// Postgres, MySQL, and Mongo have complex wire-protocol structures —
+// we scan their string Payload fields for value patterns.
+func ProcessNonHTTPMock(spec *ossModels.MockSpec, kind ossModels.Kind, detector *Detector, engine SecretEngine, tracker *FieldTracker, logger *zap.Logger) {
+	switch kind {
+	case ossModels.GRPC_EXPORT:
+		processGRPCMock(spec, detector, engine, tracker)
+	case ossModels.REDIS:
+		processPayloads(spec.RedisRequests, detector, engine, tracker, "redis_req")
+		processPayloads(spec.RedisResponses, detector, engine, tracker, "redis_resp")
+	case ossModels.Postgres:
+		processPostgresPayloads(spec, detector, engine, tracker)
+	case ossModels.MySQL:
+		processMySQLPayloads(spec, detector, engine, tracker)
+	case ossModels.Mongo:
+		processMongoPayloads(spec, detector, engine, tracker)
+	case ossModels.GENERIC:
+		processPayloads(spec.GenericRequests, detector, engine, tracker, "generic_req")
+		processPayloads(spec.GenericResponses, detector, engine, tracker, "generic_resp")
+	default:
+		if logger != nil {
+			logger.Debug("skipping non-HTTP mock kind for secret protection", zap.String("kind", string(kind)))
+		}
+	}
+}
+
+func processGRPCMock(spec *ossModels.MockSpec, detector *Detector, engine SecretEngine, tracker *FieldTracker) {
+	if spec.GRPCReq != nil {
+		processStringMap(spec.GRPCReq.Headers.OrdinaryHeaders, detector, engine, tracker, "header")
+		processStringMap(spec.GRPCReq.Headers.PseudoHeaders, detector, engine, tracker, "header")
+		// gRPC body may contain JSON data.
+		if spec.GRPCReq.Body.DecodedData != "" {
+			spec.GRPCReq.Body.DecodedData = ProcessJSONBody(
+				spec.GRPCReq.Body.DecodedData, detector, engine, tracker,
+			)
+		}
+	}
+	if spec.GRPCResp != nil {
+		processStringMap(spec.GRPCResp.Headers.OrdinaryHeaders, detector, engine, tracker, "header")
+		processStringMap(spec.GRPCResp.Headers.PseudoHeaders, detector, engine, tracker, "header")
+		if spec.GRPCResp.Body.DecodedData != "" {
+			spec.GRPCResp.Body.DecodedData = ProcessJSONBody(
+				spec.GRPCResp.Body.DecodedData, detector, engine, tracker,
+			)
+		}
+		processStringMap(spec.GRPCResp.Trailers.OrdinaryHeaders, detector, engine, tracker, "header")
+	}
+}
+
+func processPayloads(payloads []ossModels.Payload, detector *Detector, engine SecretEngine, tracker *FieldTracker, prefix string) {
+	for i := range payloads {
+		for j := range payloads[i].Message {
+			data := payloads[i].Message[j].Data
+			if data == "" {
+				continue
+			}
+			// Try JSON first.
+			trimmed := strings.TrimSpace(data)
+			if len(trimmed) > 0 && (trimmed[0] == '{' || trimmed[0] == '[') {
+				payloads[i].Message[j].Data = ProcessJSONBody(data, detector, engine, tracker)
+				continue
+			}
+			// Plain text — scan for value patterns.
+			if reason := detector.ScanValue(prefix, data); reason != "" {
+				processed, err := engine.Process(data)
+				if err != nil {
+					processed = "[KEPLOY_REDACTED:process_error]"
+				}
+				payloads[i].Message[j].Data = processed
+				tracker.AddBody(prefix)
+			}
+		}
+	}
+}
+
+// processPostgresPayloads scans Postgres request/response data for secrets.
+// NOTE: Detection-only — Postgres wire protocol structs have complex binary
+// fields that cannot be safely modified in-place without breaking the protocol.
+// Detected secrets are tracked for noise/audit but not replaced.
+func processPostgresPayloads(spec *ossModels.MockSpec, detector *Detector, engine SecretEngine, tracker *FieldTracker) {
+	for i := range spec.PostgresRequestsV2 {
+		msg := fmt.Sprintf("%v", spec.PostgresRequestsV2[i])
+		if reason := detector.ScanValue("pg_req", msg); reason != "" {
+			tracker.AddBody("pg_req." + reason)
+		}
+	}
+	for i := range spec.PostgresResponsesV2 {
+		msg := fmt.Sprintf("%v", spec.PostgresResponsesV2[i])
+		if reason := detector.ScanValue("pg_resp", msg); reason != "" {
+			tracker.AddBody("pg_resp." + reason)
+		}
+	}
+}
+
+// processMySQLPayloads scans MySQL request/response payload data for secrets.
+// NOTE: Detection-only — MySQL wire protocol messages use complex typed fields
+// that cannot be safely modified without breaking protocol semantics.
+func processMySQLPayloads(spec *ossModels.MockSpec, detector *Detector, engine SecretEngine, tracker *FieldTracker) {
+	for i := range spec.MySQLRequests {
+		msg := fmt.Sprintf("%v", spec.MySQLRequests[i].Message)
+		if reason := detector.ScanValue("mysql_req", msg); reason != "" {
+			// MySQL messages are complex; log detection but can't safely replace in-place
+			tracker.AddBody("mysql_req." + reason)
+		}
+	}
+	for i := range spec.MySQLResponses {
+		msg := fmt.Sprintf("%v", spec.MySQLResponses[i].Message)
+		if reason := detector.ScanValue("mysql_resp", msg); reason != "" {
+			tracker.AddBody("mysql_resp." + reason)
+		}
+	}
+}
+
+// processMongoPayloads scans Mongo request/response data for secrets.
+func processMongoPayloads(spec *ossModels.MockSpec, detector *Detector, engine SecretEngine, tracker *FieldTracker) {
+	for i := range spec.MongoRequests {
+		if spec.MongoRequests[i].Header != nil {
+			// MongoHeader doesn't have a simple string map, but we can scan
+			// the entire header as a string for patterns.
+			headerStr := fmt.Sprintf("%+v", spec.MongoRequests[i].Header)
+			if reason := detector.ScanValue("mongo_header", headerStr); reason != "" {
+				tracker.AddBody("mongo_req_header." + reason)
+			}
+		}
+	}
+	for i := range spec.MongoResponses {
+		if spec.MongoResponses[i].Header != nil {
+			headerStr := fmt.Sprintf("%+v", spec.MongoResponses[i].Header)
+			if reason := detector.ScanValue("mongo_header", headerStr); reason != "" {
+				tracker.AddBody("mongo_resp_header." + reason)
+			}
+		}
+	}
+}
+
+// processStringMap scans a map[string]string for secrets by field name and value pattern.
+func processStringMap(m map[string]string, detector *Detector, engine SecretEngine, tracker *FieldTracker, category string) {
+	if len(m) == 0 {
+		return
+	}
+	for key, val := range m {
+		if detector.IsAllowed(category + "." + key) {
+			continue
+		}
+		detected := false
+		if detector.IsBodyKeySensitive(key) {
+			detected = true
+		}
+		if !detected {
+			if _, ok := detector.nameHeaders[strings.ToLower(key)]; ok {
+				detected = true
+			}
+		}
+		if !detected {
+			if reason := detector.ScanValue(key, val); reason != "" {
+				detected = true
+			}
+		}
+		if detected {
+			processed, err := engine.Process(val)
+			if err != nil {
+				processed = "[KEPLOY_REDACTED:process_error]"
+			}
+			m[key] = processed
+			if category == "header" {
+				tracker.AddHeader(key)
+			} else {
+				tracker.AddBody(category + "." + key)
+			}
+		}
+	}
+}

--- a/pkg/service/secrets/body_xml.go
+++ b/pkg/service/secrets/body_xml.go
@@ -1,0 +1,112 @@
+package secrets
+
+import (
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// xmlRegexCache caches compiled regexes for XML tag/attribute patterns per key.
+var (
+	xmlRegexCache   = make(map[string]*regexp.Regexp)
+	xmlAttrCache    = make(map[string]*regexp.Regexp)
+	xmlRegexCacheMu sync.RWMutex
+)
+
+func getXMLTagRegex(key string) *regexp.Regexp {
+	cacheKey := "tag:" + key
+	xmlRegexCacheMu.RLock()
+	if re, ok := xmlRegexCache[cacheKey]; ok {
+		xmlRegexCacheMu.RUnlock()
+		return re
+	}
+	xmlRegexCacheMu.RUnlock()
+
+	pattern := `(?i)(<` + regexp.QuoteMeta(key) + `[^>]*>)([^<]*)(</` + regexp.QuoteMeta(key) + `>)`
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil
+	}
+	xmlRegexCacheMu.Lock()
+	xmlRegexCache[cacheKey] = re
+	xmlRegexCacheMu.Unlock()
+	return re
+}
+
+func getXMLAttrRegex(key string) *regexp.Regexp {
+	cacheKey := "attr:" + key
+	xmlRegexCacheMu.RLock()
+	if re, ok := xmlAttrCache[cacheKey]; ok {
+		xmlRegexCacheMu.RUnlock()
+		return re
+	}
+	xmlRegexCacheMu.RUnlock()
+
+	pattern := `(?i)(` + regexp.QuoteMeta(key) + `\s*=\s*")([^"]*)`
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil
+	}
+	xmlRegexCacheMu.Lock()
+	xmlAttrCache[cacheKey] = re
+	xmlRegexCacheMu.Unlock()
+	return re
+}
+
+// ProcessXMLBody detects and replaces secrets in an XML body string using
+// regex-based tag content replacement with cached compiled patterns.
+// Note: currently detects by tag/attribute name only (like JSON field-name matching).
+// Value-pattern scanning (JWTs, API keys in arbitrary tags) requires full XML
+// parsing and is not yet implemented — use JSON bodies or custom rules for those.
+func ProcessXMLBody(body string, detector *Detector, engine SecretEngine, tracker *FieldTracker) string {
+	if body == "" {
+		return body
+	}
+	trimmed := strings.TrimSpace(body)
+	if len(trimmed) == 0 || trimmed[0] != '<' {
+		return body
+	}
+
+	result := body
+
+	for key := range detector.nameBody {
+		fieldPath := "body." + key
+		if detector.IsAllowed(fieldPath) {
+			continue
+		}
+
+		// Process element content: <fieldName>value</fieldName>
+		if re := getXMLTagRegex(key); re != nil {
+			result = re.ReplaceAllStringFunc(result, func(match string) string {
+				sub := re.FindStringSubmatch(match)
+				if len(sub) < 4 || sub[2] == "" {
+					return match
+				}
+				processed, err := engine.Process(sub[2])
+				if err != nil {
+					processed = "[KEPLOY_REDACTED:process_error]"
+				}
+				tracker.AddBody(key)
+				return sub[1] + processed + sub[3]
+			})
+		}
+
+		// Process attribute values: fieldName="value"
+		if re := getXMLAttrRegex(key); re != nil {
+			result = re.ReplaceAllStringFunc(result, func(match string) string {
+				sub := re.FindStringSubmatch(match)
+				if len(sub) < 3 || sub[2] == "" {
+					return match
+				}
+				processed, err := engine.Process(sub[2])
+				if err != nil {
+					processed = "[KEPLOY_REDACTED:process_error]"
+				}
+				tracker.AddBody(key)
+				return sub[1] + processed
+			})
+		}
+	}
+
+	return result
+}

--- a/pkg/service/secrets/config.go
+++ b/pkg/service/secrets/config.go
@@ -1,0 +1,95 @@
+package secrets
+
+import (
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ConfigFileRules represents the secret protection rules that can be defined
+// in the existing keploy.yaml config file under record.secretProtection.
+//
+// Example keploy.yaml:
+//
+//	record:
+//	  secretProtection:
+//	    customHeaders:
+//	      - "X-Internal-Token"
+//	    customBodyKeys:
+//	      - "signing_secret"
+//	    customURLParams:
+//	      - "auth_code"
+//	    customPatterns:
+//	      - name: "Internal Token"
+//	        pattern: "itk_[A-Za-z0-9]{32}"
+//	    allowlist:
+//	      - "header.X-Request-ID"
+type ConfigFileRules struct {
+	CustomHeaders   []string      `json:"customHeaders,omitempty" yaml:"customHeaders,omitempty"`
+	CustomBodyKeys  []string      `json:"customBodyKeys,omitempty" yaml:"customBodyKeys,omitempty"`
+	CustomURLParams []string      `json:"customURLParams,omitempty" yaml:"customURLParams,omitempty"`
+	CustomPatterns  []CustomRegex `json:"customPatterns,omitempty" yaml:"customPatterns,omitempty"`
+	Allowlist       []string      `json:"allowlist,omitempty" yaml:"allowlist,omitempty"`
+}
+
+// CustomRegex is a user-defined regex pattern for value-based secret detection.
+type CustomRegex struct {
+	Name    string `json:"name" yaml:"name"`
+	Pattern string `json:"pattern" yaml:"pattern"`
+}
+
+// ParseConfigContent parses inline YAML content for secret protection rules
+// (sent from the UI in K8s environments where the keploy.yaml isn't accessible).
+func ParseConfigContent(content string) (*ConfigFileRules, error) {
+	if content == "" {
+		return nil, nil
+	}
+	var cfg ConfigFileRules
+	if err := yaml.Unmarshal([]byte(content), &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// keployConfig is a minimal representation of keploy.yaml for extracting
+// the secretProtection section. We only unmarshal what we need.
+type keployConfig struct {
+	Record struct {
+		SecretProtection *ConfigFileRules `yaml:"secretProtection,omitempty"`
+	} `yaml:"record"`
+}
+
+// LoadFromKeployConfig loads secret protection rules from the existing keploy.yaml
+// config file. Returns nil if the file doesn't exist or has no secretProtection section.
+func LoadFromKeployConfig(path string) (*ConfigFileRules, error) {
+	if path == "" {
+		path = os.Getenv("KEPLOY_CONFIG_PATH")
+	}
+	if path == "" {
+		// Standard keploy config locations.
+		candidates := []string{"keploy.yaml", "keploy.yml", ".keploy/keploy.yaml", ".keploy/keploy.yml"}
+		for _, c := range candidates {
+			if _, err := os.Stat(c); err == nil {
+				path = c
+				break
+			}
+		}
+	}
+	if path == "" {
+		return nil, nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var cfg keployConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+	return cfg.Record.SecretProtection, nil
+}

--- a/pkg/service/secrets/detect.go
+++ b/pkg/service/secrets/detect.go
@@ -1,0 +1,267 @@
+package secrets
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// DetectionResult describes a detected secret.
+type DetectionResult struct {
+	Field  string // e.g. "header.Authorization", "body.nested.token", "url_param.api_key"
+	Value  string // the original value
+	Reason string // "name_match", "value_pattern:JWT", "config_rule", "ui_rule"
+}
+
+// compiledPattern is a lazy-compiled regex pattern.
+type compiledPattern struct {
+	Name    string
+	Raw     string
+	Regex   *regexp.Regexp
+	OnlyCtx bool // only match when field name also looks secret-ish
+}
+
+// --- Built-in value-pattern regexes ---
+
+var builtinValuePatterns = []struct {
+	Name    string
+	Pattern string
+	OnlyCtx bool // require contextual field name hint
+}{
+	{"JWT", `eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+`, false},
+	{"AWS Access Key", `AKIA[0-9A-Z]{16}`, false},
+	{"GitHub PAT", `gh[ps]_[A-Za-z0-9_]{36,}`, false},
+	{"GitHub Fine-Grained PAT", `github_pat_[A-Za-z0-9_]{22,}`, false},
+	{"Stripe Key", `[sr]k_(test|live)_[0-9a-zA-Z]{24,}`, false},
+	{"Slack Token", `xox[bporas]-[0-9A-Za-z\-]{10,}`, false},
+	{"Google API Key", `AIza[0-9A-Za-z\-_]{35}`, false},
+	{"Private Key Block", `-----BEGIN\s+(RSA\s+|EC\s+|DSA\s+|OPENSSH\s+)?PRIVATE\s+KEY-----`, false},
+	{"Bearer Token", `[Bb]earer\s+[A-Za-z0-9\-._~+/]+=*`, false},
+	{"Basic Auth", `[Bb]asic\s+[A-Za-z0-9+/=]{10,}`, false},
+	// Context-only: only flag when field name also suggests a secret.
+	{"Hex Secret 32+", `[0-9a-fA-F]{32,}`, true},
+}
+
+// --- Built-in sensitive field names (case-insensitive) ---
+
+var defaultSensitiveHeaders = map[string]struct{}{
+	"authorization":            {},
+	"proxy-authorization":      {},
+	"cookie":                   {},
+	"set-cookie":               {},
+	"x-api-key":                {},
+	"x-auth-token":             {},
+	"x-csrf-token":             {},
+	"x-xsrf-token":             {},
+	"x-access-token":           {},
+	"x-secret":                 {},
+	"x-session-id":             {},
+	"x-forwarded-access-token": {},
+	"www-authenticate":         {},
+}
+
+var defaultSensitiveBodyKeys = map[string]struct{}{
+	"password": {}, "passwd": {}, "secret": {}, "token": {},
+	"access_token": {}, "refresh_token": {}, "api_key": {}, "apikey": {},
+	"api_secret": {}, "apisecret": {}, "private_key": {}, "client_secret": {},
+	"auth": {}, "credentials": {}, "session_id": {}, "sessionid": {},
+	"ssn": {}, "credit_card": {}, "card_number": {}, "cvv": {}, "pin": {},
+	"secret_key": {}, "signing_key": {}, "encryption_key": {},
+	"auth_token": {}, "bearer": {},
+}
+
+var defaultSensitiveURLParams = map[string]struct{}{
+	"api_key": {}, "apikey": {}, "token": {}, "access_token": {},
+	"secret": {}, "key": {}, "auth": {}, "password": {}, "passwd": {},
+	"refresh_token": {}, "client_secret": {},
+}
+
+// contextHintKeys are field name substrings that suggest the value might be secret
+// (used by OnlyCtx patterns to reduce false positives on long hex strings etc.)
+var contextHintKeys = []string{
+	"secret", "token", "key", "password", "passwd", "auth", "credential",
+	"api_key", "apikey", "private",
+}
+
+// Detector combines name-based and value-based secret detection.
+type Detector struct {
+	nameHeaders   map[string]struct{}
+	nameBody      map[string]struct{}
+	nameURLParams map[string]struct{}
+	allowlist     map[string]struct{} // "header.X-Foo", "body.field", "url_param.key"
+
+	customPatterns  []CustomRegex // from config file
+	valuePatterns   []compiledPattern
+	compileOnce     sync.Once
+	InvalidPatterns []string // patterns that failed to compile (for diagnostics)
+}
+
+// NewDetector builds a Detector from the protection config and optional config file rules.
+func NewDetector(headers, bodyKeys, urlParams, allowlist []string, fileRules *ConfigFileRules) *Detector {
+	d := &Detector{
+		nameHeaders:   mergeLookup(headers, defaultSensitiveHeaders),
+		nameBody:      mergeLookup(bodyKeys, defaultSensitiveBodyKeys),
+		nameURLParams: mergeLookup(urlParams, defaultSensitiveURLParams),
+		allowlist:     make(map[string]struct{}),
+	}
+
+	// Merge allowlist from all sources.
+	for _, a := range allowlist {
+		d.allowlist[strings.ToLower(strings.TrimSpace(a))] = struct{}{}
+	}
+
+	// Merge config file rules.
+	if fileRules != nil {
+		for _, h := range fileRules.CustomHeaders {
+			d.nameHeaders[strings.ToLower(strings.TrimSpace(h))] = struct{}{}
+		}
+		for _, b := range fileRules.CustomBodyKeys {
+			d.nameBody[strings.ToLower(strings.TrimSpace(b))] = struct{}{}
+		}
+		for _, u := range fileRules.CustomURLParams {
+			d.nameURLParams[strings.ToLower(strings.TrimSpace(u))] = struct{}{}
+		}
+		for _, a := range fileRules.Allowlist {
+			d.allowlist[strings.ToLower(strings.TrimSpace(a))] = struct{}{}
+		}
+		d.customPatterns = fileRules.CustomPatterns
+	}
+
+	return d
+}
+
+func (d *Detector) ensureCompiled() {
+	d.compileOnce.Do(func() {
+		d.valuePatterns = make([]compiledPattern, 0, len(builtinValuePatterns)+len(d.customPatterns))
+		for _, p := range builtinValuePatterns {
+			re, err := regexp.Compile(p.Pattern)
+			if err != nil {
+				continue
+			}
+			d.valuePatterns = append(d.valuePatterns, compiledPattern{
+				Name:    p.Name,
+				Raw:     p.Pattern,
+				Regex:   re,
+				OnlyCtx: p.OnlyCtx,
+			})
+		}
+		// Compile custom patterns from config file.
+		for _, cp := range d.customPatterns {
+			re, err := regexp.Compile(cp.Pattern)
+			if err != nil {
+				d.InvalidPatterns = append(d.InvalidPatterns, fmt.Sprintf("%s: %s (%v)", cp.Name, cp.Pattern, err))
+				continue
+			}
+			d.valuePatterns = append(d.valuePatterns, compiledPattern{
+				Name:  cp.Name,
+				Raw:   cp.Pattern,
+				Regex: re,
+			})
+		}
+	})
+}
+
+// IsAllowed checks whether a given field path is in the allowlist.
+func (d *Detector) IsAllowed(fieldPath string) bool {
+	_, ok := d.allowlist[strings.ToLower(fieldPath)]
+	return ok
+}
+
+// DetectInHeaders scans HTTP headers for secrets.
+func (d *Detector) DetectInHeaders(headers map[string]string) []DetectionResult {
+	d.ensureCompiled()
+	var results []DetectionResult
+	for key, val := range headers {
+		fieldPath := "header." + key
+		if d.IsAllowed(fieldPath) {
+			continue
+		}
+		if _, ok := d.nameHeaders[strings.ToLower(key)]; ok {
+			results = append(results, DetectionResult{Field: fieldPath, Value: val, Reason: "name_match"})
+			continue
+		}
+		if reason := d.scanValue(key, val); reason != "" {
+			results = append(results, DetectionResult{Field: fieldPath, Value: val, Reason: reason})
+		}
+	}
+	return results
+}
+
+// DetectInURLParams scans URL query parameters for secrets.
+func (d *Detector) DetectInURLParams(params map[string]string) []DetectionResult {
+	d.ensureCompiled()
+	var results []DetectionResult
+	for key, val := range params {
+		fieldPath := "url_param." + key
+		if d.IsAllowed(fieldPath) {
+			continue
+		}
+		if _, ok := d.nameURLParams[strings.ToLower(key)]; ok {
+			results = append(results, DetectionResult{Field: fieldPath, Value: val, Reason: "name_match"})
+			continue
+		}
+		if reason := d.scanValue(key, val); reason != "" {
+			results = append(results, DetectionResult{Field: fieldPath, Value: val, Reason: reason})
+		}
+	}
+	return results
+}
+
+// IsBodyKeySensitive checks whether a JSON field name matches the sensitive body key set.
+func (d *Detector) IsBodyKeySensitive(fieldName string) bool {
+	_, ok := d.nameBody[strings.ToLower(fieldName)]
+	return ok
+}
+
+// ScanValue checks a value against regex patterns. Returns the pattern name or "".
+func (d *Detector) ScanValue(fieldName, value string) string {
+	d.ensureCompiled()
+	return d.scanValue(fieldName, value)
+}
+
+func (d *Detector) scanValue(fieldName, value string) string {
+	if len(value) < 8 {
+		return "" // too short to be a meaningful secret
+	}
+	hasCtx := fieldNameLooksSecret(fieldName)
+	for _, p := range d.valuePatterns {
+		if p.OnlyCtx && !hasCtx {
+			continue
+		}
+		if p.Regex.MatchString(value) {
+			return "value_pattern:" + p.Name
+		}
+	}
+	return ""
+}
+
+func fieldNameLooksSecret(name string) bool {
+	lower := strings.ToLower(name)
+	for _, hint := range contextHintKeys {
+		if strings.Contains(lower, hint) {
+			return true
+		}
+	}
+	return false
+}
+
+func mergeLookup(custom []string, defaults map[string]struct{}) map[string]struct{} {
+	if len(custom) > 0 {
+		m := make(map[string]struct{}, len(defaults)+len(custom))
+		// Start with defaults, then add custom.
+		for k := range defaults {
+			m[k] = struct{}{}
+		}
+		for _, k := range custom {
+			m[strings.ToLower(strings.TrimSpace(k))] = struct{}{}
+		}
+		return m
+	}
+	// Clone defaults.
+	m := make(map[string]struct{}, len(defaults))
+	for k := range defaults {
+		m[k] = struct{}{}
+	}
+	return m
+}

--- a/pkg/service/secrets/encrypt.go
+++ b/pkg/service/secrets/encrypt.go
@@ -1,0 +1,405 @@
+package secrets
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+
+	ossModels "go.keploy.io/server/v3/pkg/models"
+)
+
+const (
+	// EncryptedPrefix is the sentinel marker for encrypted values.
+	// During replay, any string starting with this prefix is decrypted.
+	// Uses a UUID-like format to be extremely unlikely in real plaintext data.
+	EncryptedPrefix = "$KEPLOY_ENC_v1_7f3a9b2e$"
+
+	algorithmAES256GCM = "aes-256-gcm"
+)
+
+// EncryptionMetadata is stored alongside the test set so the replay side
+// can recover the data encryption key from OpenBao.
+type EncryptionMetadata struct {
+	WrappedDEK string `json:"wrapped_dek" yaml:"wrapped_dek" bson:"wrapped_dek"`
+	KeyVersion int    `json:"key_version" yaml:"key_version" bson:"key_version"`
+	Algorithm  string `json:"algorithm" yaml:"algorithm" bson:"algorithm"`
+	AppID      string `json:"app_id" yaml:"app_id" bson:"app_id"`
+}
+
+// EncryptionEngine performs AES-256-GCM encryption using a data encryption key (DEK)
+// obtained from OpenBao via envelope encryption.
+type EncryptionEngine struct {
+	gcm        cipher.AEAD
+	wrappedDEK string
+	keyVersion int
+	appID      string
+}
+
+// NewEncryptionEngine creates an engine from a plaintext data encryption key.
+// The wrappedDEK and keyVersion come from OpenBao's GenerateDataKey response.
+func NewEncryptionEngine(plaintextDEK []byte, wrappedDEK string, keyVersion int, appID string) (*EncryptionEngine, error) {
+	if len(plaintextDEK) != 32 {
+		return nil, fmt.Errorf("AES-256 requires a 32-byte key, got %d bytes", len(plaintextDEK))
+	}
+	block, err := aes.NewCipher(plaintextDEK)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AES cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCM: %w", err)
+	}
+	return &EncryptionEngine{
+		gcm:        gcm,
+		wrappedDEK: wrappedDEK,
+		keyVersion: keyVersion,
+		appID:      appID,
+	}, nil
+}
+
+// Process encrypts a plaintext value and returns the sentinel-prefixed ciphertext.
+func (e *EncryptionEngine) Process(plaintext string) (string, error) {
+	nonce := make([]byte, e.gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", fmt.Errorf("failed to generate nonce: %w", err)
+	}
+	ciphertext := e.gcm.Seal(nonce, nonce, []byte(plaintext), nil)
+	encoded := base64.StdEncoding.EncodeToString(ciphertext)
+	return EncryptedPrefix + encoded, nil
+}
+
+// Decrypt restores a sentinel-prefixed encrypted value to its original plaintext.
+func (e *EncryptionEngine) Decrypt(encrypted string) (string, error) {
+	if !strings.HasPrefix(encrypted, EncryptedPrefix) {
+		return encrypted, nil // not encrypted
+	}
+	encoded := strings.TrimPrefix(encrypted, EncryptedPrefix)
+	data, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", fmt.Errorf("failed to decode ciphertext: %w", err)
+	}
+	nonceSize := e.gcm.NonceSize()
+	if len(data) < nonceSize {
+		return "", errors.New("ciphertext too short")
+	}
+	nonce, ciphertext := data[:nonceSize], data[nonceSize:]
+	plaintext, err := e.gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", fmt.Errorf("decryption failed: %w", err)
+	}
+	return string(plaintext), nil
+}
+
+// Metadata returns the encryption metadata for this session.
+func (e *EncryptionEngine) Metadata() *EncryptionMetadata {
+	return &EncryptionMetadata{
+		WrappedDEK: e.wrappedDEK,
+		KeyVersion: e.keyVersion,
+		Algorithm:  algorithmAES256GCM,
+		AppID:      e.appID,
+	}
+}
+
+// IsEncrypted checks whether a string value has the encryption sentinel prefix.
+func IsEncrypted(value string) bool {
+	return strings.HasPrefix(value, EncryptedPrefix)
+}
+
+// Decryptor wraps an EncryptionEngine for replay-side decryption only.
+type Decryptor struct {
+	engine *EncryptionEngine
+}
+
+// NewDecryptor creates a Decryptor from a plaintext DEK (recovered from OpenBao).
+func NewDecryptor(plaintextDEK []byte, meta *EncryptionMetadata) (*Decryptor, error) {
+	eng, err := NewEncryptionEngine(plaintextDEK, meta.WrappedDEK, meta.KeyVersion, meta.AppID)
+	if err != nil {
+		return nil, err
+	}
+	return &Decryptor{engine: eng}, nil
+}
+
+// DecryptValue decrypts a single value if it has the encryption prefix.
+func (d *Decryptor) DecryptValue(value string) (string, error) {
+	return d.engine.Decrypt(value)
+}
+
+func isBase64Char(c byte) bool {
+	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+		(c >= '0' && c <= '9') || c == '+' || c == '/' || c == '='
+}
+
+// DecryptTestCase decrypts all encrypted values in a test case in-place.
+// Returns an error if ANY decryption fails (Fix #3: all-or-nothing).
+func (d *Decryptor) DecryptTestCase(tc *ossModels.TestCase) error {
+	if tc == nil {
+		return nil
+	}
+	var errs []error
+	errs = append(errs, d.decryptHeaders(tc.HTTPReq.Header)...)
+	errs = append(errs, d.decryptHeaders(tc.HTTPResp.Header)...)
+	errs = append(errs, d.decryptStringMap(tc.HTTPReq.URLParams)...)
+
+	// Decrypt form data values.
+	for i := range tc.HTTPReq.Form {
+		for j := range tc.HTTPReq.Form[i].Values {
+			if IsEncrypted(tc.HTTPReq.Form[i].Values[j]) {
+				decrypted, err := d.engine.Decrypt(tc.HTTPReq.Form[i].Values[j])
+				if err != nil {
+					errs = append(errs, fmt.Errorf("form field %q: %w", tc.HTTPReq.Form[i].Key, err))
+				} else {
+					tc.HTTPReq.Form[i].Values[j] = decrypted
+				}
+			}
+		}
+	}
+
+	if body, err := d.decryptBodyStrict(tc.HTTPReq.Body); err != nil {
+		errs = append(errs, err)
+	} else {
+		tc.HTTPReq.Body = body
+	}
+	if body, err := d.decryptBodyStrict(tc.HTTPResp.Body); err != nil {
+		errs = append(errs, err)
+	} else {
+		tc.HTTPResp.Body = body
+	}
+	// URL query params: always attempt parse+decrypt since the sentinel may be
+	// percent-encoded, unescaped, or partially encoded depending on how it was stored.
+	if tc.HTTPReq.URL != "" {
+		if parsed, err := url.Parse(tc.HTTPReq.URL); err == nil {
+			query := parsed.Query()
+			changed := false
+			for key, values := range query {
+				for i, v := range values {
+					// Try raw value first, then URL-unescaped form.
+					val := v
+					if !IsEncrypted(val) {
+						if unescaped, err := url.QueryUnescape(val); err == nil {
+							val = unescaped
+						}
+					}
+					if IsEncrypted(val) {
+						decrypted, err := d.engine.Decrypt(val)
+						if err != nil {
+							errs = append(errs, fmt.Errorf("url param %q: %w", key, err))
+						} else {
+							query[key][i] = decrypted
+							changed = true
+						}
+					}
+				}
+			}
+			if changed {
+				parsed.RawQuery = query.Encode()
+				tc.HTTPReq.URL = parsed.String()
+			}
+		}
+	}
+
+	// gRPC headers + body
+	errs = append(errs, d.decryptStringMap(tc.GrpcReq.Headers.OrdinaryHeaders)...)
+	errs = append(errs, d.decryptStringMap(tc.GrpcReq.Headers.PseudoHeaders)...)
+	errs = append(errs, d.decryptStringMap(tc.GrpcResp.Headers.OrdinaryHeaders)...)
+	errs = append(errs, d.decryptStringMap(tc.GrpcResp.Headers.PseudoHeaders)...)
+	errs = append(errs, d.decryptStringMap(tc.GrpcResp.Trailers.OrdinaryHeaders)...)
+	if tc.GrpcReq.Body.DecodedData != "" {
+		if body, err := d.decryptBodyStrict(tc.GrpcReq.Body.DecodedData); err != nil {
+			errs = append(errs, err)
+		} else {
+			tc.GrpcReq.Body.DecodedData = body
+		}
+	}
+	if tc.GrpcResp.Body.DecodedData != "" {
+		if body, err := d.decryptBodyStrict(tc.GrpcResp.Body.DecodedData); err != nil {
+			errs = append(errs, err)
+		} else {
+			tc.GrpcResp.Body.DecodedData = body
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("decryption failed for %d values in test case %q: first error: %w", len(errs), tc.Name, errs[0])
+	}
+	return nil
+}
+
+// DecryptMock decrypts all encrypted values in a mock in-place.
+// Returns an error if ANY decryption fails (Fix #3: all-or-nothing).
+func (d *Decryptor) DecryptMock(mock *ossModels.Mock) error {
+	if mock == nil {
+		return nil
+	}
+	var errs []error
+
+	if mock.Spec.HTTPReq != nil {
+		errs = append(errs, d.decryptHeaders(mock.Spec.HTTPReq.Header)...)
+		errs = append(errs, d.decryptStringMap(mock.Spec.HTTPReq.URLParams)...)
+		for i := range mock.Spec.HTTPReq.Form {
+			for j := range mock.Spec.HTTPReq.Form[i].Values {
+				if IsEncrypted(mock.Spec.HTTPReq.Form[i].Values[j]) {
+					decrypted, err := d.engine.Decrypt(mock.Spec.HTTPReq.Form[i].Values[j])
+					if err != nil {
+						errs = append(errs, fmt.Errorf("mock form field %q: %w", mock.Spec.HTTPReq.Form[i].Key, err))
+					} else {
+						mock.Spec.HTTPReq.Form[i].Values[j] = decrypted
+					}
+				}
+			}
+		}
+		if body, err := d.decryptBodyStrict(mock.Spec.HTTPReq.Body); err != nil {
+			errs = append(errs, err)
+		} else {
+			mock.Spec.HTTPReq.Body = body
+		}
+		// URL-aware decryption for mock request URLs (same as test case).
+		if mock.Spec.HTTPReq.URL != "" {
+			if parsed, err := url.Parse(mock.Spec.HTTPReq.URL); err == nil {
+				query := parsed.Query()
+				changed := false
+				for key, values := range query {
+					for i, v := range values {
+						val := v
+						if !IsEncrypted(val) {
+							if unescaped, err := url.QueryUnescape(val); err == nil {
+								val = unescaped
+							}
+						}
+						if IsEncrypted(val) {
+							decrypted, err := d.engine.Decrypt(val)
+							if err != nil {
+								errs = append(errs, fmt.Errorf("mock url param %q: %w", key, err))
+							} else {
+								query[key][i] = decrypted
+								changed = true
+							}
+						}
+					}
+				}
+				if changed {
+					parsed.RawQuery = query.Encode()
+					mock.Spec.HTTPReq.URL = parsed.String()
+				}
+			}
+			// Also try body-level decryption for path-embedded sentinels.
+			if body, err := d.decryptBodyStrict(mock.Spec.HTTPReq.URL); err != nil {
+				errs = append(errs, err)
+			} else {
+				mock.Spec.HTTPReq.URL = body
+			}
+		}
+	}
+	if mock.Spec.HTTPResp != nil {
+		errs = append(errs, d.decryptHeaders(mock.Spec.HTTPResp.Header)...)
+		if body, err := d.decryptBodyStrict(mock.Spec.HTTPResp.Body); err != nil {
+			errs = append(errs, err)
+		} else {
+			mock.Spec.HTTPResp.Body = body
+		}
+	}
+	// gRPC
+	if mock.Spec.GRPCReq != nil {
+		errs = append(errs, d.decryptStringMap(mock.Spec.GRPCReq.Headers.OrdinaryHeaders)...)
+		if body, err := d.decryptBodyStrict(mock.Spec.GRPCReq.Body.DecodedData); err != nil {
+			errs = append(errs, err)
+		} else {
+			mock.Spec.GRPCReq.Body.DecodedData = body
+		}
+	}
+	if mock.Spec.GRPCResp != nil {
+		errs = append(errs, d.decryptStringMap(mock.Spec.GRPCResp.Headers.OrdinaryHeaders)...)
+		if body, err := d.decryptBodyStrict(mock.Spec.GRPCResp.Body.DecodedData); err != nil {
+			errs = append(errs, err)
+		} else {
+			mock.Spec.GRPCResp.Body.DecodedData = body
+		}
+	}
+	// Non-HTTP payloads
+	errs = append(errs, decryptPayloadsStrict(d, mock.Spec.RedisRequests)...)
+	errs = append(errs, decryptPayloadsStrict(d, mock.Spec.RedisResponses)...)
+	errs = append(errs, decryptPayloadsStrict(d, mock.Spec.GenericRequests)...)
+	errs = append(errs, decryptPayloadsStrict(d, mock.Spec.GenericResponses)...)
+
+	if len(errs) > 0 {
+		return fmt.Errorf("decryption failed for %d values in mock %q: first error: %w", len(errs), mock.Name, errs[0])
+	}
+	return nil
+}
+
+// decryptHeaders decrypts all encrypted header values, collecting errors.
+func (d *Decryptor) decryptHeaders(headers map[string]string) []error {
+	var errs []error
+	for key, val := range headers {
+		if IsEncrypted(val) {
+			decrypted, err := d.engine.Decrypt(val)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("header %q: %w", key, err))
+			} else {
+				headers[key] = decrypted
+			}
+		}
+	}
+	return errs
+}
+
+// decryptStringMap decrypts all encrypted values in a string map, collecting errors.
+func (d *Decryptor) decryptStringMap(m map[string]string) []error {
+	var errs []error
+	for key, val := range m {
+		if IsEncrypted(val) {
+			decrypted, err := d.engine.Decrypt(val)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("key %q: %w", key, err))
+			} else {
+				m[key] = decrypted
+			}
+		}
+	}
+	return errs
+}
+
+// decryptBodyStrict decrypts sentinels in a body, returning error on any failure.
+func (d *Decryptor) decryptBodyStrict(body string) (string, error) {
+	if !strings.Contains(body, EncryptedPrefix) {
+		return body, nil
+	}
+	result := body
+	for {
+		idx := strings.Index(result, EncryptedPrefix)
+		if idx == -1 {
+			break
+		}
+		start := idx + len(EncryptedPrefix)
+		end := start
+		for end < len(result) && isBase64Char(result[end]) {
+			end++
+		}
+		encrypted := result[idx:end]
+		decrypted, err := d.engine.Decrypt(encrypted)
+		if err != nil {
+			return "", fmt.Errorf("body decrypt at offset %d: %w", idx, err)
+		}
+		result = result[:idx] + decrypted + result[end:]
+	}
+	return result, nil
+}
+
+func decryptPayloadsStrict(d *Decryptor, payloads []ossModels.Payload) []error {
+	var errs []error
+	for i := range payloads {
+		for j := range payloads[i].Message {
+			if body, err := d.decryptBodyStrict(payloads[i].Message[j].Data); err != nil {
+				errs = append(errs, err)
+			} else {
+				payloads[i].Message[j].Data = body
+			}
+		}
+	}
+	return errs
+}

--- a/pkg/service/secrets/obfuscate.go
+++ b/pkg/service/secrets/obfuscate.go
@@ -1,0 +1,72 @@
+package secrets
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"unicode"
+)
+
+// ObfuscationEngine replaces secrets with deterministic junk of the same charset
+// and length. Uses HMAC(seed, value) for determinism — same input produces same
+// output within a recording session, keeping cross-references between test cases
+// and mocks consistent.
+type ObfuscationEngine struct {
+	seed []byte
+}
+
+// NewObfuscationEngine creates an engine with a random per-session seed.
+// Returns an error if the OS entropy pool is unavailable.
+func NewObfuscationEngine() (*ObfuscationEngine, error) {
+	seed := make([]byte, 32)
+	if _, err := rand.Read(seed); err != nil {
+		return nil, fmt.Errorf("crypto/rand.Read failed: OS entropy unavailable: %w", err)
+	}
+	return &ObfuscationEngine{seed: seed}, nil
+}
+
+// Process replaces the value with deterministic junk preserving charset and length.
+func (o *ObfuscationEngine) Process(value string) (string, error) {
+	return o.replacePreservingCharset(value), nil
+}
+
+func (o *ObfuscationEngine) replacePreservingCharset(original string) string {
+	if original == "" {
+		return original
+	}
+
+	mac := hmac.New(sha256.New, o.seed)
+	mac.Write([]byte(original))
+	hash := mac.Sum(nil)
+
+	hashIdx := 0
+	nextByte := func() byte {
+		if hashIdx >= len(hash) {
+			mac.Reset()
+			mac.Write(hash)
+			hash = mac.Sum(nil)
+			hashIdx = 0
+		}
+		b := hash[hashIdx]
+		hashIdx++
+		return b
+	}
+
+	runes := []rune(original)
+	result := make([]rune, len(runes))
+	for i, r := range runes {
+		b := nextByte()
+		switch {
+		case unicode.IsUpper(r):
+			result[i] = rune('A' + int(b)%26)
+		case unicode.IsLower(r):
+			result[i] = rune('a' + int(b)%26)
+		case unicode.IsDigit(r):
+			result[i] = rune('0' + int(b)%10)
+		default:
+			result[i] = r
+		}
+	}
+	return string(result)
+}

--- a/pkg/service/secrets/openbao.go
+++ b/pkg/service/secrets/openbao.go
@@ -1,0 +1,221 @@
+package secrets
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// OpenBaoAPIError is returned when the OpenBao API responds with an error status.
+type OpenBaoAPIError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *OpenBaoAPIError) Error() string {
+	return fmt.Sprintf("OpenBao API error %d: %s", e.StatusCode, e.Body)
+}
+
+// OpenBaoClient communicates with a Keploy-hosted OpenBao instance for
+// transit encryption key management. Uses raw HTTP (no heavy SDK dependency).
+type OpenBaoClient struct {
+	httpClient *http.Client
+	baseURL    string // e.g. "https://openbao.keploy.io"
+	token      string // auth token (derived from API key)
+	logger     *zap.Logger
+}
+
+// NewOpenBaoClient creates a client for the OpenBao transit engine.
+func NewOpenBaoClient(baseURL, token string, logger *zap.Logger) *OpenBaoClient {
+	return &OpenBaoClient{
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		baseURL:    baseURL,
+		token:      token,
+		logger:     logger,
+	}
+}
+
+// transitKeyName returns the transit key path for an app.
+func transitKeyName(appID string) string {
+	return "keploy-apps-" + appID
+}
+
+// EnsureTransitKey creates the transit encryption key if it doesn't exist.
+// Returns nil on success or if the key already exists (HTTP 204/409).
+// Returns an error for genuine failures (permission denied, network errors, etc.).
+func (c *OpenBaoClient) EnsureTransitKey(ctx context.Context, appID string) error {
+	path := fmt.Sprintf("/v1/transit/keys/%s", transitKeyName(appID))
+	body := map[string]interface{}{
+		"type": "aes256-gcm96",
+	}
+	_, err := c.doRequest(ctx, http.MethodPost, path, body)
+	if err != nil {
+		// Key already exists → 409 Conflict. This is expected and not an error.
+		var apiErr *OpenBaoAPIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusConflict {
+			if c.logger != nil {
+				c.logger.Debug("transit key already exists", zap.String("appID", appID))
+			}
+			return nil
+		}
+		return fmt.Errorf("failed to create transit key for app %q: %w", appID, err)
+	}
+	return nil
+}
+
+// GenerateDataKey generates a new data encryption key (DEK) using the transit engine.
+// Returns the plaintext DEK (32 bytes for AES-256) and the OpenBao-wrapped version.
+func (c *OpenBaoClient) GenerateDataKey(ctx context.Context, appID string) (plaintext []byte, wrappedKey string, keyVersion int, err error) {
+	path := fmt.Sprintf("/v1/transit/datakey/plaintext/%s", transitKeyName(appID))
+	body := map[string]interface{}{
+		"bits": 256,
+	}
+	resp, err := c.doRequest(ctx, http.MethodPost, path, body)
+	if err != nil {
+		return nil, "", 0, fmt.Errorf("GenerateDataKey failed: %w", err)
+	}
+	if resp == nil {
+		return nil, "", 0, fmt.Errorf("GenerateDataKey: empty response from OpenBao")
+	}
+
+	data, ok := resp["data"].(map[string]interface{})
+	if !ok {
+		return nil, "", 0, fmt.Errorf("GenerateDataKey: missing 'data' in response")
+	}
+
+	plaintextB64, ok := data["plaintext"].(string)
+	if !ok || plaintextB64 == "" {
+		return nil, "", 0, fmt.Errorf("GenerateDataKey: missing or invalid 'plaintext' in response")
+	}
+	wrappedKey, ok = data["ciphertext"].(string)
+	if !ok || wrappedKey == "" {
+		return nil, "", 0, fmt.Errorf("GenerateDataKey: missing or invalid 'ciphertext' in response")
+	}
+	keyVersionF, ok := data["key_version"].(float64)
+	if !ok {
+		return nil, "", 0, fmt.Errorf("GenerateDataKey: missing or invalid 'key_version' in response")
+	}
+	keyVersion = int(keyVersionF)
+
+	plaintext, err = base64.StdEncoding.DecodeString(plaintextB64)
+	if err != nil {
+		return nil, "", 0, fmt.Errorf("failed to decode plaintext DEK: %w", err)
+	}
+
+	return plaintext, wrappedKey, keyVersion, nil
+}
+
+// DecryptDataKey unwraps a previously wrapped data encryption key.
+func (c *OpenBaoClient) DecryptDataKey(ctx context.Context, appID string, wrappedKey string) ([]byte, error) {
+	path := fmt.Sprintf("/v1/transit/decrypt/%s", transitKeyName(appID))
+	body := map[string]interface{}{
+		"ciphertext": wrappedKey,
+	}
+	resp, err := c.doRequest(ctx, http.MethodPost, path, body)
+	if err != nil {
+		return nil, fmt.Errorf("DecryptDataKey failed: %w", err)
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("DecryptDataKey: empty response from OpenBao")
+	}
+
+	data, ok := resp["data"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("DecryptDataKey: missing 'data' in response")
+	}
+
+	plaintextB64, ok := data["plaintext"].(string)
+	if !ok || plaintextB64 == "" {
+		return nil, fmt.Errorf("DecryptDataKey: missing or invalid 'plaintext' in response")
+	}
+	plaintext, err := base64.StdEncoding.DecodeString(plaintextB64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode plaintext DEK: %w", err)
+	}
+
+	return plaintext, nil
+}
+
+// RotateKey triggers key rotation for the app's transit key.
+// Old key versions are retained for decrypting previously encrypted data.
+func (c *OpenBaoClient) RotateKey(ctx context.Context, appID string) (int, error) {
+	path := fmt.Sprintf("/v1/transit/keys/%s/rotate", transitKeyName(appID))
+	_, err := c.doRequest(ctx, http.MethodPost, path, nil)
+	if err != nil {
+		return 0, fmt.Errorf("RotateKey failed: %w", err)
+	}
+
+	// Read key info to get the new version.
+	infoPath := fmt.Sprintf("/v1/transit/keys/%s", transitKeyName(appID))
+	resp, err := c.doRequest(ctx, http.MethodGet, infoPath, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read key info after rotation: %w", err)
+	}
+	if resp == nil {
+		return 0, fmt.Errorf("RotateKey: empty response when reading key info")
+	}
+
+	data, ok := resp["data"].(map[string]interface{})
+	if !ok {
+		return 0, fmt.Errorf("RotateKey: missing 'data' in key info response")
+	}
+	latestVersion, ok := data["latest_version"].(float64)
+	if !ok {
+		return 0, fmt.Errorf("RotateKey: missing or invalid 'latest_version' in key info response")
+	}
+	return int(latestVersion), nil
+}
+
+func (c *OpenBaoClient) doRequest(ctx context.Context, method, path string, body interface{}) (map[string]interface{}, error) {
+	var reqBody io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		reqBody = bytes.NewReader(data)
+	}
+
+	url := c.baseURL + path
+	req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Vault-Token", c.token)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, &OpenBaoAPIError{StatusCode: resp.StatusCode, Body: string(respBody)}
+	}
+
+	if len(respBody) == 0 {
+		return nil, nil
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result, nil
+}

--- a/pkg/service/secrets/processor.go
+++ b/pkg/service/secrets/processor.go
@@ -1,0 +1,281 @@
+package secrets
+
+import (
+	"strings"
+	"sync"
+
+	ossModels "go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// SecretEngine is the interface for both encryption and obfuscation engines.
+type SecretEngine interface {
+	Process(plaintext string) (string, error)
+}
+
+// FieldTracker records which fields were processed (for noise injection).
+type FieldTracker struct {
+	Headers   map[string]struct{}
+	BodyPaths map[string]struct{}
+	URLParams map[string]struct{}
+}
+
+func NewFieldTracker() *FieldTracker {
+	return &FieldTracker{
+		Headers:   make(map[string]struct{}),
+		BodyPaths: make(map[string]struct{}),
+		URLParams: make(map[string]struct{}),
+	}
+}
+
+func (t *FieldTracker) AddHeader(key string)   { t.Headers[key] = struct{}{} }
+func (t *FieldTracker) AddBody(path string)    { t.BodyPaths[path] = struct{}{} }
+func (t *FieldTracker) AddURLParam(key string) { t.URLParams[key] = struct{}{} }
+
+// DetectionEntry records a single detected secret for the audit trail.
+type DetectionEntry struct {
+	Field  string `json:"field" yaml:"field"`   // e.g. "header.Authorization"
+	Reason string `json:"reason" yaml:"reason"` // e.g. "name_match", "value_pattern:JWT"
+	Action string `json:"action" yaml:"action"` // "encrypted", "obfuscated", "skipped-allowlist"
+}
+
+// DetectionReport is a session-wide audit trail of all detected secrets.
+type DetectionReport struct {
+	mu      sync.Mutex
+	Entries []DetectionEntry `json:"entries" yaml:"entries"`
+}
+
+func (r *DetectionReport) Add(field, reason, action string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.Entries = append(r.Entries, DetectionEntry{Field: field, Reason: reason, Action: action})
+}
+
+// Processor orchestrates secret detection and protection for test cases and mocks.
+type Processor struct {
+	detector *Detector
+	engine   SecretEngine
+	mode     string // "encrypt" or "obfuscate"
+	logger   *zap.Logger
+
+	// Only set in encrypt mode — holds the metadata for the current session.
+	encMeta *EncryptionMetadata
+
+	// Audit trail: all detections across the session (Fix #7).
+	Report *DetectionReport
+}
+
+// NewProcessor creates a Processor based on the given mode.
+// For encrypt mode, pass an initialized EncryptionEngine.
+// For obfuscate mode, pass nil — an ObfuscationEngine is used.
+func NewProcessor(mode string, detector *Detector, encEngine *EncryptionEngine, logger *zap.Logger) *Processor {
+	p := &Processor{
+		detector: detector,
+		mode:     mode,
+		logger:   logger,
+		Report:   &DetectionReport{},
+	}
+
+	if mode == "encrypt" && encEngine != nil {
+		p.engine = encEngine
+		p.encMeta = encEngine.Metadata()
+	} else {
+		obfEng, err := NewObfuscationEngine()
+		if err != nil {
+			if logger != nil {
+				logger.Error("failed to create obfuscation engine — secret protection disabled for this session. This typically indicates an OS entropy issue.", zap.Error(err))
+			}
+			return nil
+		}
+		p.engine = obfEng
+		p.mode = "obfuscate"
+	}
+
+	return p
+}
+
+// Mode returns the active protection mode.
+func (p *Processor) Mode() string { return p.mode }
+
+// EncryptionMeta returns the encryption metadata for the session (nil in obfuscate mode).
+func (p *Processor) EncryptionMeta() *EncryptionMetadata { return p.encMeta }
+
+// ProcessTestCase detects and protects secrets in a test case in-place.
+// In both modes, response-side secret fields are added to noise (Fix #4)
+// because response secrets are often dynamic (e.g. new session tokens per call).
+// In obfuscate mode, ALL processed fields are added to noise.
+func (p *Processor) ProcessTestCase(tc *ossModels.TestCase) {
+	if p == nil || tc == nil {
+		return
+	}
+
+	reqTracker := NewFieldTracker()
+	respTracker := NewFieldTracker()
+
+	// --- HTTP Request ---
+	p.processHeaders(tc.HTTPReq.Header, reqTracker)
+	tc.HTTPReq.URL = ProcessURL(tc.HTTPReq.URL, p.detector, p.engine, reqTracker)
+	tc.HTTPReq.URLParams = ProcessURLParams(tc.HTTPReq.URLParams, p.detector, p.engine, reqTracker)
+	tc.HTTPReq.Body = p.processBody(tc.HTTPReq.Body, reqTracker)
+	tc.HTTPReq.Form = ProcessFormData(tc.HTTPReq.Form, p.detector, p.engine, reqTracker)
+
+	// --- HTTP Response ---
+	p.processHeaders(tc.HTTPResp.Header, respTracker)
+	tc.HTTPResp.Body = p.processBody(tc.HTTPResp.Body, respTracker)
+
+	// --- gRPC Request (Fix #10: process body, not just headers) ---
+	p.processGRPCHeaders(tc.GrpcReq.Headers, reqTracker)
+	if tc.GrpcReq.Body.DecodedData != "" {
+		tc.GrpcReq.Body.DecodedData = p.processBody(tc.GrpcReq.Body.DecodedData, reqTracker)
+	}
+
+	// --- gRPC Response (Fix #10) ---
+	p.processGRPCHeaders(tc.GrpcResp.Headers, respTracker)
+	if tc.GrpcResp.Body.DecodedData != "" {
+		tc.GrpcResp.Body.DecodedData = p.processBody(tc.GrpcResp.Body.DecodedData, respTracker)
+	}
+
+	// Record all detections in the audit trail (headers are recorded in processHeaders;
+	// body/URL/form detections are recorded here from tracker data).
+	action := "encrypted"
+	if p.mode == "obfuscate" {
+		action = "obfuscated"
+	}
+	for path := range reqTracker.BodyPaths {
+		p.Report.Add("body."+path, "auto", action)
+	}
+	for path := range respTracker.BodyPaths {
+		p.Report.Add("resp_body."+path, "auto", action)
+	}
+	for param := range reqTracker.URLParams {
+		p.Report.Add("url_param."+param, "auto", action)
+	}
+
+	// Noise injection:
+	// - Obfuscate mode: ALL fields (request + response) → noise (so replay skips them).
+	// - Encrypt mode: RESPONSE fields → noise (Fix #4: response secrets are dynamic,
+	//   e.g. server returns new tokens each call, so even with decrypt they won't match).
+	//   Request fields are NOT noised in encrypt mode because decrypt restores exact values.
+	if p.mode == "obfuscate" {
+		injectNoise(tc, reqTracker)
+		injectNoise(tc, respTracker)
+	} else {
+		// Encrypt mode: only response-side noise.
+		injectNoise(tc, respTracker)
+	}
+}
+
+// ProcessMock detects and protects secrets in a mock in-place.
+func (p *Processor) ProcessMock(mock *ossModels.Mock) {
+	if p == nil || mock == nil {
+		return
+	}
+
+	tracker := NewFieldTracker()
+
+	if mock.Kind == ossModels.HTTP {
+		if mock.Spec.HTTPReq != nil {
+			p.processHeaders(mock.Spec.HTTPReq.Header, tracker)
+			mock.Spec.HTTPReq.URL = ProcessURL(mock.Spec.HTTPReq.URL, p.detector, p.engine, tracker)
+			mock.Spec.HTTPReq.URLParams = ProcessURLParams(mock.Spec.HTTPReq.URLParams, p.detector, p.engine, tracker)
+			mock.Spec.HTTPReq.Body = p.processBody(mock.Spec.HTTPReq.Body, tracker)
+			mock.Spec.HTTPReq.Form = ProcessFormData(mock.Spec.HTTPReq.Form, p.detector, p.engine, tracker)
+		}
+		if mock.Spec.HTTPResp != nil {
+			p.processHeaders(mock.Spec.HTTPResp.Header, tracker)
+			mock.Spec.HTTPResp.Body = p.processBody(mock.Spec.HTTPResp.Body, tracker)
+		}
+	} else {
+		ProcessNonHTTPMock(&mock.Spec, mock.Kind, p.detector, p.engine, tracker, p.logger)
+	}
+
+	// Record mock detections in session-wide audit trail.
+	action := "encrypted"
+	if p.mode == "obfuscate" {
+		action = "obfuscated"
+	}
+	for path := range tracker.BodyPaths {
+		p.Report.Add("mock.body."+path, "auto", action)
+	}
+	for param := range tracker.URLParams {
+		p.Report.Add("mock.url_param."+param, "auto", action)
+	}
+}
+
+// processHeaders detects and replaces secrets in an HTTP header map.
+func (p *Processor) processHeaders(headers map[string]string, tracker *FieldTracker) {
+	results := p.detector.DetectInHeaders(headers)
+	for _, r := range results {
+		if r.Value == "" {
+			continue // Skip empty values — encrypting "" produces a sentinel that changes semantics
+		}
+		processed, err := p.engine.Process(r.Value)
+		if err != nil {
+			// Fail-closed: redact the value rather than leaving the secret in place.
+			processed = "[KEPLOY_REDACTED:process_error]"
+			p.Report.Add(r.Field, r.Reason, "redacted")
+		} else {
+			action := "encrypted"
+			if p.mode == "obfuscate" {
+				action = "obfuscated"
+			}
+			p.Report.Add(r.Field, r.Reason, action)
+		}
+		key := strings.TrimPrefix(r.Field, "header.")
+		headers[key] = processed
+		tracker.AddHeader(key)
+	}
+}
+
+// processGRPCHeaders processes gRPC metadata using the same header detection
+// and reporting logic as HTTP headers, ensuring consistent allowlist support.
+func (p *Processor) processGRPCHeaders(headers ossModels.GrpcHeaders, tracker *FieldTracker) {
+	p.processHeaders(headers.OrdinaryHeaders, tracker)
+	p.processHeaders(headers.PseudoHeaders, tracker)
+}
+
+// processBody routes to the appropriate body processor based on content.
+func (p *Processor) processBody(body string, tracker *FieldTracker) string {
+	if body == "" {
+		return body
+	}
+	trimmed := strings.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return body
+	}
+
+	switch trimmed[0] {
+	case '{', '[':
+		return ProcessJSONBody(body, p.detector, p.engine, tracker)
+	case '<':
+		return ProcessXMLBody(body, p.detector, p.engine, tracker)
+	default:
+		return body
+	}
+}
+
+// injectNoise adds processed field paths into the test case's Noise map
+// so the replay comparator skips them.
+func injectNoise(tc *ossModels.TestCase, tracker *FieldTracker) {
+	if tc.Noise == nil {
+		tc.Noise = make(map[string][]string)
+	}
+	for hdr := range tracker.Headers {
+		tc.Noise["header"] = appendUnique(tc.Noise["header"], hdr)
+	}
+	for path := range tracker.BodyPaths {
+		tc.Noise["body"] = appendUnique(tc.Noise["body"], path)
+	}
+	for param := range tracker.URLParams {
+		tc.Noise["body"] = appendUnique(tc.Noise["body"], "url_param."+param)
+	}
+}
+
+func appendUnique(slice []string, val string) []string {
+	for _, existing := range slice {
+		if existing == val {
+			return slice
+		}
+	}
+	return append(slice, val)
+}

--- a/pkg/service/secrets/secrets_test.go
+++ b/pkg/service/secrets/secrets_test.go
@@ -1,0 +1,553 @@
+package secrets
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	ossModels "go.keploy.io/server/v3/pkg/models"
+)
+
+// --- Detection Tests ---
+
+func TestDetector_Headers(t *testing.T) {
+	d := NewDetector(nil, nil, nil, nil, nil)
+	results := d.DetectInHeaders(map[string]string{
+		"Authorization": "Bearer xyz",
+		"Content-Type":  "application/json",
+		"X-API-Key":     "secret123",
+		"X-Request-ID":  "abc",
+	})
+	found := map[string]bool{}
+	for _, r := range results {
+		found[r.Field] = true
+	}
+	if !found["header.Authorization"] {
+		t.Error("should detect Authorization")
+	}
+	if !found["header.X-API-Key"] {
+		t.Error("should detect X-API-Key")
+	}
+	if found["header.Content-Type"] {
+		t.Error("should NOT detect Content-Type")
+	}
+	if found["header.X-Request-ID"] {
+		t.Error("should NOT detect X-Request-ID")
+	}
+}
+
+func TestDetector_ValuePatterns(t *testing.T) {
+	d := NewDetector(nil, nil, nil, nil, nil)
+
+	tests := []struct {
+		name     string
+		field    string
+		value    string
+		detected bool
+	}{
+		// Note: test values are crafted to match regex patterns without triggering
+		// GitHub push protection (which blocks real-looking Stripe, Slack, AWS keys).
+		{"JWT", "data", "eyJhbGciOiJIUzI1NiJ9.eyJ0ZXN0IjoiZmFrZSJ9.dGVzdHNpZ25hdHVyZQ", true},
+		{"Bearer", "val", "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9", true},
+		{"Basic Auth", "val", "Basic dXNlcjpwYXNzd29yZDEyMzQ1Njc4OTA=", true},
+		{"Private Key", "val", "-----BEGIN PRIVATE KEY-----\nMIIE...", true},
+		{"Short value", "x", "abc", false},
+		{"Normal value", "user", "alice@example.com", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason := d.ScanValue(tt.field, tt.value)
+			if tt.detected && reason == "" {
+				t.Errorf("expected detection for %q", tt.value)
+			}
+			if !tt.detected && reason != "" {
+				t.Errorf("unexpected detection %q for %q", reason, tt.value)
+			}
+		})
+	}
+}
+
+func TestDetector_Allowlist(t *testing.T) {
+	d := NewDetector(nil, nil, nil, []string{"header.Authorization"}, nil)
+	results := d.DetectInHeaders(map[string]string{
+		"Authorization": "Bearer xyz",
+		"Cookie":        "session=abc",
+	})
+	for _, r := range results {
+		if r.Field == "header.Authorization" {
+			t.Error("Authorization should be allowlisted")
+		}
+	}
+	found := false
+	for _, r := range results {
+		if r.Field == "header.Cookie" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("Cookie should still be detected")
+	}
+}
+
+func TestDetector_URLParams(t *testing.T) {
+	d := NewDetector(nil, nil, nil, nil, nil)
+	results := d.DetectInURLParams(map[string]string{
+		"api_key": "secret123",
+		"page":    "1",
+	})
+	if len(results) != 1 || results[0].Field != "url_param.api_key" {
+		t.Errorf("expected api_key detection, got %v", results)
+	}
+}
+
+func TestDetector_CustomRules(t *testing.T) {
+	d := NewDetector(
+		[]string{"X-Custom-Secret"},
+		[]string{"my_private_field"},
+		[]string{"custom_token"},
+		nil,
+		nil,
+	)
+	// Custom header
+	results := d.DetectInHeaders(map[string]string{"X-Custom-Secret": "val"})
+	if len(results) == 0 {
+		t.Error("should detect custom header")
+	}
+	// Built-in should still work
+	results = d.DetectInHeaders(map[string]string{"Authorization": "Bearer x"})
+	if len(results) == 0 {
+		t.Error("built-in headers should still be detected with custom additions")
+	}
+	// Custom body key
+	if !d.IsBodyKeySensitive("my_private_field") {
+		t.Error("custom body key should be sensitive")
+	}
+	// Built-in body key should still work
+	if !d.IsBodyKeySensitive("password") {
+		t.Error("built-in body key should still work")
+	}
+}
+
+// --- Obfuscation Tests ---
+
+func TestObfuscationEngine_CharsetPreservation(t *testing.T) {
+	eng, _ := NewObfuscationEngine()
+
+	tests := []string{
+		"Bearer eyJhbGciOiJIUzI1NiJ9.abc123",
+		"4111111111111111",
+		"sk-live_A1b2C3d4",
+		"",
+	}
+	for _, input := range tests {
+		result, err := eng.Process(input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		inputRunes := []rune(input)
+		resultRunes := []rune(result)
+		if len(resultRunes) != len(inputRunes) {
+			t.Errorf("rune length mismatch for %q: %d vs %d", input, len(resultRunes), len(inputRunes))
+		}
+		// Verify each rune's charset is preserved.
+		for i, r := range inputRunes {
+			out := resultRunes[i]
+			switch {
+			case r >= 'A' && r <= 'Z' && (out < 'A' || out > 'Z'):
+				t.Errorf("pos %d: expected upper, got %c", i, out)
+			case r >= 'a' && r <= 'z' && (out < 'a' || out > 'z'):
+				t.Errorf("pos %d: expected lower, got %c", i, out)
+			case r >= '0' && r <= '9' && (out < '0' || out > '9'):
+				t.Errorf("pos %d: expected digit, got %c", i, out)
+			}
+		}
+		// Deterministic
+		result2, _ := eng.Process(input)
+		if result != result2 {
+			t.Error("not deterministic")
+		}
+	}
+}
+
+// --- Encryption Tests ---
+
+func TestEncryptionEngine_RoundTrip(t *testing.T) {
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i)
+	}
+	eng, err := NewEncryptionEngine(key, "wrapped-key", 1, "test-app")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	values := []string{
+		"Bearer my-secret-token",
+		"password123",
+		"eyJhbGciOiJIUzI1NiJ9.eyJ0ZXN0IjoxfQ.sig",
+		"",
+		"short",
+	}
+	for _, v := range values {
+		encrypted, err := eng.Process(v)
+		if err != nil {
+			t.Fatalf("encrypt %q: %v", v, err)
+		}
+		if v != "" && !strings.HasPrefix(encrypted, EncryptedPrefix) {
+			t.Errorf("missing sentinel prefix for %q", v)
+		}
+		decrypted, err := eng.Decrypt(encrypted)
+		if err != nil {
+			t.Fatalf("decrypt %q: %v", encrypted, err)
+		}
+		if decrypted != v {
+			t.Errorf("round-trip failed: %q -> %q -> %q", v, encrypted, decrypted)
+		}
+	}
+}
+
+func TestEncryptionEngine_BadKey(t *testing.T) {
+	_, err := NewEncryptionEngine([]byte("too-short"), "", 0, "")
+	if err == nil {
+		t.Error("should reject non-32-byte key")
+	}
+}
+
+func TestDecryptor_AllOrNothing(t *testing.T) {
+	key := make([]byte, 32)
+	eng, _ := NewEncryptionEngine(key, "wrapped", 1, "app")
+
+	tc := &ossModels.TestCase{
+		HTTPReq: ossModels.HTTPReq{
+			Header: map[string]string{
+				"Authorization": mustEncrypt(t, eng, "Bearer token"),
+			},
+			Body: `{"password": "` + mustEncrypt(t, eng, "secret") + `"}`,
+		},
+		HTTPResp: ossModels.HTTPResp{
+			Header: map[string]string{},
+		},
+	}
+
+	dec, _ := NewDecryptor(key, &EncryptionMetadata{WrappedDEK: "w", KeyVersion: 1, AppID: "app"})
+	if err := dec.DecryptTestCase(tc); err != nil {
+		t.Fatalf("decryption should succeed: %v", err)
+	}
+	if tc.HTTPReq.Header["Authorization"] != "Bearer token" {
+		t.Error("header not decrypted")
+	}
+	if !strings.Contains(tc.HTTPReq.Body, "secret") {
+		t.Error("body not decrypted")
+	}
+}
+
+func mustEncrypt(t *testing.T, eng *EncryptionEngine, val string) string {
+	t.Helper()
+	e, err := eng.Process(val)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return e
+}
+
+// --- JSON Body Tests (sjson byte-fidelity) ---
+
+func TestProcessJSONBody_ByteFidelity(t *testing.T) {
+	det := NewDetector(nil, nil, nil, nil, nil)
+	eng, _ := NewObfuscationEngine()
+	tracker := NewFieldTracker()
+
+	// Carefully crafted JSON with specific whitespace and key order.
+	body := `{
+  "username": "alice",
+  "password": "super-secret-123",
+  "count": 42,
+  "nested": {
+    "token": "jwt-value-here",
+    "safe": "not-a-secret"
+  }
+}`
+
+	result := ProcessJSONBody(body, det, eng, tracker)
+
+	// Username should be byte-identical.
+	if !strings.Contains(result, `"username": "alice"`) {
+		t.Error("username should be preserved exactly")
+	}
+	// Count should be byte-identical (number formatting).
+	if !strings.Contains(result, `"count": 42`) {
+		t.Error("count should be preserved exactly (number format)")
+	}
+	// safe should be byte-identical.
+	if !strings.Contains(result, `"safe": "not-a-secret"`) {
+		t.Error("safe should be preserved exactly")
+	}
+	// password should be changed.
+	if strings.Contains(result, "super-secret-123") {
+		t.Error("password should be obfuscated")
+	}
+	// token should be changed.
+	if strings.Contains(result, "jwt-value-here") {
+		t.Error("token should be obfuscated")
+	}
+	// Verify JSON is still valid.
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Errorf("result is not valid JSON: %v", err)
+	}
+	// Tracker should have recorded paths.
+	if _, ok := tracker.BodyPaths["password"]; !ok {
+		t.Error("tracker should record password path")
+	}
+}
+
+func TestProcessJSONBody_NonJSON(t *testing.T) {
+	det := NewDetector(nil, nil, nil, nil, nil)
+	eng, _ := NewObfuscationEngine()
+	tracker := NewFieldTracker()
+
+	body := "plain text body"
+	result := ProcessJSONBody(body, det, eng, tracker)
+	if result != body {
+		t.Error("non-JSON body should be unchanged")
+	}
+}
+
+// --- XML Body Tests ---
+
+func TestProcessXMLBody(t *testing.T) {
+	det := NewDetector(nil, nil, nil, nil, nil)
+	eng, _ := NewObfuscationEngine()
+	tracker := NewFieldTracker()
+
+	body := `<request><password>my-secret</password><name>alice</name></request>`
+	result := ProcessXMLBody(body, det, eng, tracker)
+
+	if strings.Contains(result, "my-secret") {
+		t.Error("password should be obfuscated in XML")
+	}
+	if !strings.Contains(result, "<name>alice</name>") {
+		t.Error("name should be preserved")
+	}
+}
+
+// --- URL Processing Tests ---
+
+func TestProcessURL(t *testing.T) {
+	det := NewDetector(nil, nil, nil, nil, nil)
+	eng, _ := NewObfuscationEngine()
+	tracker := NewFieldTracker()
+
+	url := "https://api.example.com/v1/users?api_key=secret123&page=1"
+	result := ProcessURL(url, det, eng, tracker)
+
+	if strings.Contains(result, "secret123") {
+		t.Error("api_key value should be replaced")
+	}
+	if !strings.Contains(result, "page=1") {
+		t.Error("page param should be unchanged")
+	}
+	if _, ok := tracker.URLParams["api_key"]; !ok {
+		t.Error("tracker should record api_key")
+	}
+}
+
+// --- Processor Integration Tests ---
+
+func TestProcessor_ObfuscateMode_InjectsNoise(t *testing.T) {
+	det := NewDetector(nil, nil, nil, nil, nil)
+	p := NewProcessor("obfuscate", det, nil, nil)
+
+	tc := &ossModels.TestCase{
+		HTTPReq: ossModels.HTTPReq{
+			Header: map[string]string{"Authorization": "Bearer token"},
+			Body:   `{"password": "secret"}`,
+		},
+		HTTPResp: ossModels.HTTPResp{
+			Header: map[string]string{"Set-Cookie": "session=abc"},
+			Body:   `{"ok": true}`,
+		},
+	}
+
+	p.ProcessTestCase(tc)
+
+	// Authorization should be obfuscated.
+	if tc.HTTPReq.Header["Authorization"] == "Bearer token" {
+		t.Error("Authorization not obfuscated")
+	}
+	// Noise should contain header and body entries.
+	if tc.Noise == nil {
+		t.Fatal("noise should be set")
+	}
+	headerNoise := tc.Noise["header"]
+	hasAuth := false
+	for _, h := range headerNoise {
+		if h == "Authorization" {
+			hasAuth = true
+		}
+	}
+	if !hasAuth {
+		t.Error("Authorization should be in header noise")
+	}
+}
+
+func TestProcessor_EncryptMode_ResponseNoise(t *testing.T) {
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i)
+	}
+	encEng, _ := NewEncryptionEngine(key, "wrapped", 1, "app")
+	det := NewDetector(nil, nil, nil, nil, nil)
+	p := NewProcessor("encrypt", det, encEng, nil)
+
+	tc := &ossModels.TestCase{
+		HTTPReq: ossModels.HTTPReq{
+			Header: map[string]string{"Authorization": "Bearer token"},
+		},
+		HTTPResp: ossModels.HTTPResp{
+			Header: map[string]string{"Set-Cookie": "session=abc123def"},
+		},
+	}
+
+	p.ProcessTestCase(tc)
+
+	// Request header should be encrypted (not noised — decrypt restores it).
+	if !IsEncrypted(tc.HTTPReq.Header["Authorization"]) {
+		t.Error("Authorization should be encrypted")
+	}
+	// Response header should be encrypted AND noised (Fix #4: dynamic response secrets).
+	if !IsEncrypted(tc.HTTPResp.Header["Set-Cookie"]) {
+		t.Error("Set-Cookie should be encrypted")
+	}
+	if tc.Noise == nil {
+		t.Fatal("noise should be set for response fields")
+	}
+	hasCookie := false
+	for _, h := range tc.Noise["header"] {
+		if h == "Set-Cookie" {
+			hasCookie = true
+		}
+	}
+	if !hasCookie {
+		t.Error("Set-Cookie should be in noise (response-side, Fix #4)")
+	}
+	// Request-side Authorization should NOT be in noise (encrypt mode restores it).
+	for _, h := range tc.Noise["header"] {
+		if h == "Authorization" {
+			t.Error("Authorization should NOT be in noise in encrypt mode (decrypt restores it)")
+		}
+	}
+}
+
+func TestProcessor_Mock(t *testing.T) {
+	det := NewDetector(nil, nil, nil, nil, nil)
+	p := NewProcessor("obfuscate", det, nil, nil)
+
+	mock := &ossModels.Mock{
+		Kind: ossModels.HTTP,
+		Spec: ossModels.MockSpec{
+			HTTPReq: &ossModels.HTTPReq{
+				Header: map[string]string{"X-API-Key": "secret-key"},
+				Body:   `{"api_key": "my-api-key-123"}`,
+			},
+			HTTPResp: &ossModels.HTTPResp{
+				Header: map[string]string{},
+				Body:   `{"data": "ok"}`,
+			},
+		},
+	}
+
+	p.ProcessMock(mock)
+
+	if mock.Spec.HTTPReq.Header["X-API-Key"] == "secret-key" {
+		t.Error("X-API-Key should be obfuscated")
+	}
+	if strings.Contains(mock.Spec.HTTPReq.Body, "my-api-key-123") {
+		t.Error("api_key in body should be obfuscated")
+	}
+}
+
+func TestProcessor_NonHTTPMock(t *testing.T) {
+	det := NewDetector(nil, nil, nil, nil, nil)
+	p := NewProcessor("obfuscate", det, nil, nil)
+
+	mock := &ossModels.Mock{
+		Kind: ossModels.REDIS,
+		Spec: ossModels.MockSpec{
+			RedisRequests: []ossModels.Payload{
+				{Message: []ossModels.OutputBinary{
+					{Data: `{"token": "redis-secret-token"}`},
+				}},
+			},
+		},
+	}
+
+	p.ProcessMock(mock)
+
+	if strings.Contains(mock.Spec.RedisRequests[0].Message[0].Data, "redis-secret-token") {
+		t.Error("token in Redis payload should be obfuscated")
+	}
+}
+
+// --- Config File Tests ---
+
+func TestParseConfigContent(t *testing.T) {
+	content := `
+customHeaders:
+  - "X-Custom-Auth"
+customBodyKeys:
+  - "signing_secret"
+customURLParams:
+  - "auth_code"
+allowlist:
+  - "header.X-Safe"
+`
+	cfg, err := ParseConfigContent(content)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.CustomHeaders) != 1 || cfg.CustomHeaders[0] != "X-Custom-Auth" {
+		t.Errorf("custom headers not parsed: got %v", cfg.CustomHeaders)
+	}
+	if len(cfg.Allowlist) != 1 || cfg.Allowlist[0] != "header.X-Safe" {
+		t.Errorf("allowlist not parsed: got %v", cfg.Allowlist)
+	}
+}
+
+func TestParseConfigContent_Empty(t *testing.T) {
+	cfg, err := ParseConfigContent("")
+	if err != nil || cfg != nil {
+		t.Error("empty content should return nil")
+	}
+}
+
+// --- Detection Report Test ---
+
+func TestDetectionReport(t *testing.T) {
+	det := NewDetector(nil, nil, nil, nil, nil)
+	p := NewProcessor("obfuscate", det, nil, nil)
+
+	tc := &ossModels.TestCase{
+		HTTPReq: ossModels.HTTPReq{
+			Header: map[string]string{"Authorization": "Bearer token"},
+		},
+		HTTPResp: ossModels.HTTPResp{},
+	}
+	p.ProcessTestCase(tc)
+
+	if len(p.Report.Entries) == 0 {
+		t.Error("detection report should have entries")
+	}
+	found := false
+	for _, e := range p.Report.Entries {
+		if e.Field == "header.Authorization" {
+			found = true
+			if e.Action != "obfuscated" {
+				t.Errorf("expected action 'obfuscated', got %q", e.Action)
+			}
+		}
+	}
+	if !found {
+		t.Error("report should contain Authorization entry")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a reusable `pkg/service/secrets/` package to the shared OSS server module
- Enables k8s-proxy, enterprise, and api-server to import the same secret detection/protection code

Part of https://github.com/keploy/k8s-proxy/issues/248

🤖 Generated with [Claude Code](https://claude.com/claude-code)