### PR TITLE
fix(agent): apply filterOutDeleted to unfiltered mocks

### DIFF
--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -307,6 +307,7 @@ func (a *Agent) UpdateMockParams(ctx context.Context, params models.MockFilterPa
 	// Filter out deleted mocks if totalConsumedMocks is provided
 	if params.TotalConsumedMocks != nil {
 		filteredMocks = a.filterOutDeleted(filteredMocks, params.TotalConsumedMocks)
+		unfilteredMocks = a.filterOutDeleted(unfilteredMocks, params.TotalConsumedMocks)
 	}
 
 	// Set the filtered mocks to the proxy


### PR DESCRIPTION
## Describe the changes that are made
- Apply `filterOutDeleted` to `unfilteredMocks` in `UpdateMockParams`, matching v2's `FilterAndSetMocks` behavior where it was applied to both filtered and unfiltered mock sets.
- Without this, consumed mocks in the unfiltered tree retain their original low `SortOrder` instead of being bumped to a higher value. Since the tree is ordered by `SortOrder` ascending and protocol matchers (e.g. MySQL) read from the unfiltered tree, a previously consumed mock can be matched before the correct one when both share identical request signatures.

## Links & References

**Closes:** #4018

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- #4018
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

## Added comments for hard-to-understand areas?
- [x] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

Run a test set where two or more test cases trigger outgoing calls (e.g. MySQL `COM_STMT_EXECUTE`) with identical request signatures but different expected responses. Without this fix, the earlier mock is matched for both test cases. With this fix, consumed mocks are pushed to the end of the tree and the correct mock is matched.

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?