### PR TITLE
fix: prioritize replay mocks by request timestamp

### DIFF
--- a/pkg/util.go
+++ b/pkg/util.go
@@ -1140,7 +1140,12 @@ func filterByTimeStamp(_ context.Context, logger *zap.Logger, m []*models.Mock, 
 			continue
 		}
 
-		if p.Spec.ReqTimestampMock.After(afterTime) && p.Spec.ResTimestampMock.Before(beforeTime) {
+		// Prefer mocks whose request started during the test-case window.
+		// Response timestamps can trail the captured test-case response by a few
+		// microseconds, especially for the last outgoing dependency call in a test.
+		// Using the request-start time keeps those mocks in the filtered set while
+		// still excluding stale mocks from earlier test cases.
+		if !p.Spec.ReqTimestampMock.Before(afterTime) && !p.Spec.ReqTimestampMock.After(beforeTime) {
 			p.TestModeInfo.IsFiltered = true
 			filteredMocks = append(filteredMocks, p)
 			continue

--- a/pkg/util_test.go
+++ b/pkg/util_test.go
@@ -432,6 +432,51 @@ func TestFilterMocks_678(t *testing.T) {
 	})
 }
 
+func TestFilterConfigMocks_PrioritizesLateMockByRequestTime_3738(t *testing.T) {
+	logger := zap.NewNop()
+	ctx := context.Background()
+
+	testReqTime := time.Date(2026, time.February, 12, 6, 39, 20, 766944656, time.UTC)
+	testRespTime := time.Date(2026, time.February, 12, 6, 39, 20, 820398862, time.UTC)
+
+	staleData := &models.Mock{
+		Name:    "mock-62",
+		Version: "api.keploy.io/v1beta1",
+		Spec: models.MockSpec{
+			ReqTimestampMock: time.Date(2026, time.February, 12, 6, 38, 43, 559270267, time.UTC),
+			ResTimestampMock: time.Date(2026, time.February, 12, 6, 38, 43, 565339949, time.UTC),
+		},
+	}
+	countQuery := &models.Mock{
+		Name:    "mock-137",
+		Version: "api.keploy.io/v1beta1",
+		Spec: models.MockSpec{
+			ReqTimestampMock: time.Date(2026, time.February, 12, 6, 39, 20, 767839595, time.UTC),
+			ResTimestampMock: time.Date(2026, time.February, 12, 6, 39, 20, 809483263, time.UTC),
+		},
+	}
+	trailingData := &models.Mock{
+		Name:    "mock-138",
+		Version: "api.keploy.io/v1beta1",
+		Spec: models.MockSpec{
+			ReqTimestampMock: time.Date(2026, time.February, 12, 6, 39, 20, 809891000, time.UTC),
+			ResTimestampMock: time.Date(2026, time.February, 12, 6, 39, 20, 820711000, time.UTC),
+		},
+	}
+
+	filtered, unfiltered := filterByTimeStamp(ctx, logger, []*models.Mock{trailingData, staleData, countQuery}, testReqTime, testRespTime)
+	require.Len(t, filtered, 2)
+	assert.ElementsMatch(t, []string{"mock-137", "mock-138"}, []string{filtered[0].Name, filtered[1].Name})
+	require.Len(t, unfiltered, 1)
+	assert.Equal(t, "mock-62", unfiltered[0].Name)
+
+	result := FilterConfigMocks(ctx, logger, []*models.Mock{trailingData, staleData, countQuery}, testReqTime, testRespTime)
+	require.Len(t, result, 3)
+	assert.Equal(t, "mock-137", result[0].Name)
+	assert.Equal(t, "mock-138", result[1].Name)
+	assert.Equal(t, "mock-62", result[2].Name)
+}
+
 // TestHasExplicitPort_IPv6_777 validates the hasExplicitPort function with various host strings,
 // including IPv4, IPv6, and hostnames, both with and without ports.
 func TestHasExplicitPort_IPv6_777(t *testing.T) {


### PR DESCRIPTION
## Describe the changes that are made
- Fix replay mock filtering so testcase-specific mocks are prioritized by the outgoing request start time instead of requiring the dependency response to finish before the recorded testcase response timestamp.
- Prevent stale compatible MySQL prepared-statement mocks from being selected when a later dependency call starts inside the testcase window but finishes slightly after it.
- Add a regression test covering the trailing-mock timing pattern that previously caused replay to pick an older mock.

## Links & References

**Closes:** #4021
- NA

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- #4021
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [x] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

Validation:
- `go test ./pkg/...`

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- Validated against a local regression case where a trailing dependency mock starts within the testcase window but its response lands slightly after the recorded testcase response timestamp.
- Before this fix, replay could drop that trailing mock from the prioritized set and choose an older compatible MySQL mock instead.

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [ ] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?
