### PR TITLE
fix: warn when infrastructure service ports are bypassed during recording

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -209,6 +209,25 @@ func IsPassThrough(logger *zap.Logger, req *http.Request, destPort uint, opts mo
 
 		if passThrough {
 			if bypass.Port == 0 || bypass.Port == destPort {
+				// Warn when commonly-needed infrastructure services are being
+				// bypassed so users can identify and fix their config. These
+				// services (Vault, OTel Collector, Consul) are often required
+				// during test replay but their mocks won't exist if recording
+				// skips them.
+				switch destPort {
+				case 8200: // Vault
+					logger.Warn("Bypassing Vault request due to passthrough rule — this request will NOT be recorded as a mock. "+
+						"If Vault is needed during test replay, remove port 8200 from bypass/passthrough config.",
+						zap.Uint("port", destPort), zap.String("url", req.URL.String()))
+				case 4318, 4317: // OpenTelemetry Collector (HTTP/gRPC)
+					logger.Warn("Bypassing OpenTelemetry Collector request due to passthrough rule — this request will NOT be recorded as a mock. "+
+						"If OTel export is needed during test replay, remove port from bypass/passthrough config or disable the exporter in test mode.",
+						zap.Uint("port", destPort), zap.String("url", req.URL.String()))
+				case 8500: // Consul
+					logger.Warn("Bypassing Consul request due to passthrough rule — this request will NOT be recorded as a mock. "+
+						"If Consul KV is needed during test replay, remove port 8500 from bypass/passthrough config.",
+						zap.Uint("port", destPort), zap.String("url", req.URL.String()))
+				}
 				return true
 			}
 			passThrough = false


### PR DESCRIPTION
## Summary

- Adds warning logs in `IsPassThrough()` when requests to well-known infrastructure service ports are being bypassed by passthrough rules during recording

## Problem

During Keploy recording, if Vault (8200), OTel Collector (4317/4318), or Consul (8500) ports are configured as passthrough, outgoing calls to these services are silently discarded and never saved as mocks. During test replay, the proxy has no mocks for these services and returns 502 Bad Gateway, which can cascade into application initialization failures.

In the Agoda `travel-card-api` case, this resulted in:
- 472 mock-miss errors for Vault health checks (`GET /v1/sys/health`)
- 44 mock-miss errors for OTel Collector (`POST /v1/logs`, `POST /v1/metrics`)
- Vault unavailability → HikariCP pool init failure → 14/23 tests failing

## Fix

Added warning logs in `utils/utils.go:IsPassThrough()` for ports 8200, 4317, 4318, and 8500. When a request to these ports is bypassed, the warning includes the port, URL, and a suggestion to remove the port from bypass config or adjust the test setup.

## Test plan

- [ ] Verify warning appears when a Vault/OTel/Consul request is bypassed during recording
- [ ] Verify no functional change to passthrough behavior (still bypasses correctly)
- [ ] Verify no log noise when these ports are NOT in bypass rules

Part of keploy/enterprise#1836

🤖 Generated with [Claude Code](https://claude.com/claude-code)