### PR TITLE
fix: preserve negative DNS responses in mocks

### DIFF
--- a/.github/workflows/golang_linux.yml
+++ b/.github/workflows/golang_linux.yml
@@ -155,7 +155,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [udp-with-connect, udp-without-connect]
+        app:
+          - name: udp-with-connect
+            repository: officialasishkumar/dns-mock-test
+            ref: negative-dns-udp-with-connect
+          - name: udp-without-connect
+            repository: officialasishkumar/dns-mock-test
+            ref: negative-dns-udp-without-connect
         config:
           - job: record_latest_replay_build
             record_src: latest
@@ -166,7 +172,7 @@ jobs:
           - job: record_build_replay_build
             record_src: build
             replay_src: build
-    name: dns_mock (${{ matrix.branch }}) - ${{ matrix.config.job }}
+    name: dns_mock (${{ matrix.app.name }}) - ${{ matrix.config.job }}
     steps:
       - name: Checkout Keploy
         uses: actions/checkout@v4
@@ -191,8 +197,8 @@ jobs:
       - name: Checkout DNS Mock App
         uses: actions/checkout@v4
         with:
-          repository: akashkumar7902/dns-mock-test
-          ref: ${{ matrix.branch }}
+          repository: ${{ matrix.app.repository }}
+          ref: ${{ matrix.app.ref }}
           path: dns-mock-test
 
       - name: Run Test

--- a/.github/workflows/test_workflow_scripts/golang/dns_mock/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/dns_mock/golang-linux.sh
@@ -82,20 +82,6 @@ check_negative_dns_mock() {
   echo "Negative DNS recording check passed."
 }
 
-send_negative_dns_request() {
-  local base_url="http://localhost:8086"
-  local response
-
-  echo "Running negative DNS lookup (${NEGATIVE_DNS_DOMAIN})..."
-  response=$(curl -s "${base_url}/dns/a?domain=${NEGATIVE_DNS_DOMAIN}&transport=udp4")
-  echo "$response" | jq
-
-  if ! echo "$response" | jq -e '.error == "DNS query failed with code: 3"' >/dev/null; then
-    echo "::error::Expected NXDOMAIN response for ${NEGATIVE_DNS_DOMAIN}."
-    return 1
-  fi
-}
-
 send_request() {
   section "Sending Requests"
   echo "Waiting for app to start..."
@@ -110,7 +96,6 @@ send_request() {
   echo "Running curl.sh..."
   chmod +x ./curl.sh
   ./curl.sh
-  send_negative_dns_request
   endsec
 }
 

--- a/.github/workflows/test_workflow_scripts/golang/dns_mock/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/dns_mock/golang-linux.sh
@@ -7,6 +7,8 @@ if ! command -v jq &> /dev/null; then
     sudo apt-get update && sudo apt-get install -y jq
 fi
 
+NEGATIVE_DNS_DOMAIN="keploy-negative.invalid"
+
 # --- Helper Functions ---
 section() { echo "::group::$*"; }
 endsec()  { echo "::endgroup::"; }
@@ -63,6 +65,37 @@ check_test_report() {
     return 0
 }
 
+check_negative_dns_mock() {
+  local mocks_file="./keploy/test-set-0/mocks.yaml"
+  echo "Checking that negative DNS responses were recorded..."
+
+  if [ ! -f "$mocks_file" ]; then
+    echo "::error::No mocks.yaml found — cannot verify negative DNS recording."
+    return 1
+  fi
+
+  if ! grep -A20 -F "name: ${NEGATIVE_DNS_DOMAIN}." "$mocks_file" | grep -q 'rcode: 3'; then
+    echo "::error::Expected recorded NXDOMAIN DNS mock for ${NEGATIVE_DNS_DOMAIN}, but no matching rcode: 3 entry was found."
+    return 1
+  fi
+
+  echo "Negative DNS recording check passed."
+}
+
+send_negative_dns_request() {
+  local base_url="http://localhost:8086"
+  local response
+
+  echo "Running negative DNS lookup (${NEGATIVE_DNS_DOMAIN})..."
+  response=$(curl -s "${base_url}/dns/a?domain=${NEGATIVE_DNS_DOMAIN}&transport=udp4")
+  echo "$response" | jq
+
+  if ! echo "$response" | jq -e '.error == "DNS query failed with code: 3"' >/dev/null; then
+    echo "::error::Expected NXDOMAIN response for ${NEGATIVE_DNS_DOMAIN}."
+    return 1
+  fi
+}
+
 send_request() {
   section "Sending Requests"
   echo "Waiting for app to start..."
@@ -76,7 +109,8 @@ send_request() {
 
   echo "Running curl.sh..."
   chmod +x ./curl.sh
-  ./curl.sh || true
+  ./curl.sh
+  send_negative_dns_request
   endsec
 }
 
@@ -114,6 +148,10 @@ sudo kill -INT "$REC_PID" 2>/dev/null || true
 sleep 5
 check_for_errors "record.txt"
 echo "Recording stopped."
+endsec
+
+section "Verify Negative DNS Recording"
+check_negative_dns_mock
 endsec
 
 # Replay

--- a/pkg/agent/proxy/dns.go
+++ b/pkg/agent/proxy/dns.go
@@ -18,12 +18,6 @@ import (
 	"go.uber.org/zap"
 )
 
-var dnsClientConfigFromFile = dns.ClientConfigFromFile
-
-var dnsExchange = func(c *dns.Client, m *dns.Msg, addr string) (*dns.Msg, time.Duration, error) {
-	return c.Exchange(m, addr)
-}
-
 func (p *Proxy) startTCPDNSServer(_ context.Context) error {
 	addr := fmt.Sprintf(":%v", p.DNSPort)
 
@@ -426,7 +420,7 @@ func generateDNSDedupeKey(question dns.Question) string {
 }
 
 func (p *Proxy) recordDNSMock(question dns.Question, reqTime time.Time, session *agent.Session) (dnsCacheEntry, error) {
-	config, err := dnsClientConfigFromFile("/etc/resolv.conf")
+	config, err := dns.ClientConfigFromFile("/etc/resolv.conf")
 	var servers []string
 	port := "53"
 
@@ -454,7 +448,7 @@ func (p *Proxy) recordDNSMock(question dns.Question, reqTime time.Time, session 
 		addr := net.JoinHostPort(server, port)
 
 		c.Net = "udp"
-		resp, _, err := dnsExchange(c, m, addr)
+		resp, _, err := c.Exchange(m, addr)
 		if err != nil {
 			resolveErr = err
 			continue
@@ -462,7 +456,7 @@ func (p *Proxy) recordDNSMock(question dns.Question, reqTime time.Time, session 
 
 		if resp != nil && resp.Truncated {
 			c.Net = "tcp"
-			resp, _, err = dnsExchange(c, m, addr)
+			resp, _, err = c.Exchange(m, addr)
 			if err != nil {
 				resolveErr = err
 				continue

--- a/pkg/agent/proxy/dns.go
+++ b/pkg/agent/proxy/dns.go
@@ -18,6 +18,12 @@ import (
 	"go.uber.org/zap"
 )
 
+var dnsClientConfigFromFile = dns.ClientConfigFromFile
+
+var dnsExchange = func(c *dns.Client, m *dns.Msg, addr string) (*dns.Msg, time.Duration, error) {
+	return c.Exchange(m, addr)
+}
+
 func (p *Proxy) startTCPDNSServer(_ context.Context) error {
 	addr := fmt.Sprintf(":%v", p.DNSPort)
 
@@ -420,7 +426,7 @@ func generateDNSDedupeKey(question dns.Question) string {
 }
 
 func (p *Proxy) recordDNSMock(question dns.Question, reqTime time.Time, session *agent.Session) (dnsCacheEntry, error) {
-	config, err := dns.ClientConfigFromFile("/etc/resolv.conf")
+	config, err := dnsClientConfigFromFile("/etc/resolv.conf")
 	var servers []string
 	port := "53"
 
@@ -448,7 +454,7 @@ func (p *Proxy) recordDNSMock(question dns.Question, reqTime time.Time, session 
 		addr := net.JoinHostPort(server, port)
 
 		c.Net = "udp"
-		resp, _, err := c.Exchange(m, addr)
+		resp, _, err := dnsExchange(c, m, addr)
 		if err != nil {
 			resolveErr = err
 			continue
@@ -456,7 +462,7 @@ func (p *Proxy) recordDNSMock(question dns.Question, reqTime time.Time, session 
 
 		if resp != nil && resp.Truncated {
 			c.Net = "tcp"
-			resp, _, err = c.Exchange(m, addr)
+			resp, _, err = dnsExchange(c, m, addr)
 			if err != nil {
 				resolveErr = err
 				continue
@@ -487,17 +493,13 @@ func (p *Proxy) recordDNSMock(question dns.Question, reqTime time.Time, session 
 		return resp, nil
 	}
 
-	// Do not record failed DNS responses (e.g., NXDOMAIN, SERVFAIL, REFUSED) in mocks.yaml.
-	// These are often noise from search domain expansion or external transient issues.
-	if in.Rcode != dns.RcodeSuccess {
-		p.logger.Debug("Skipping DNS mock recording due to non-zero rcode",
-			zap.String("query", question.Name),
-			zap.String("qtype", dns.TypeToString[question.Qtype]),
-			zap.Int("rcode", in.Rcode),
-		)
-		return resp, nil
-	}
+	// Preserve upstream negative replies as mocks too; dropping NXDOMAIN/REFUSED/SERVFAIL
+	// changes resolver search-domain behavior during replay.
+	p.recordResolvedDNSMock(question, reqTime, in, session)
+	return resp, nil
+}
 
+func (p *Proxy) recordResolvedDNSMock(question dns.Question, reqTime time.Time, in *dns.Msg, session *agent.Session) {
 	// ========== DNS MOCK DEDUPLICATION ==========
 	// Generate a unique key based on the DNS query (ignoring response IPs).
 	// If we've already recorded a mock for this query, skip recording.
@@ -507,7 +509,7 @@ func (p *Proxy) recordDNSMock(question dns.Question, reqTime time.Time, session 
 			zap.String("query", question.Name),
 			zap.String("qtype", dns.TypeToString[question.Qtype]),
 		)
-		return resp, nil
+		return
 	}
 	// Mark as recorded
 	p.recordedDNSMocks.Add(dedupeKey, true)
@@ -553,11 +555,10 @@ func (p *Proxy) recordDNSMock(question dns.Question, reqTime time.Time, session 
 		if mgr := syncMock.Get(); mgr != nil {
 			mgr.SetOutputChannel(session.MC)
 			mgr.AddMock(mock)
-			return resp, nil
+			return
 		}
 	}
 	session.MC <- mock
-	return resp, nil
 }
 
 func (p *Proxy) stopDNSServers(_ context.Context) error {

--- a/pkg/agent/proxy/dns_test.go
+++ b/pkg/agent/proxy/dns_test.go
@@ -2,8 +2,11 @@ package proxy
 
 import (
 	"testing"
+	"time"
 
 	"github.com/miekg/dns"
+	"go.keploy.io/server/v3/pkg/agent"
+	"go.keploy.io/server/v3/pkg/models"
 )
 
 func TestGenerateDNSDedupeKey_SameQuerySameKey(t *testing.T) {
@@ -58,5 +61,109 @@ func TestGenerateDNSDedupeKey_CaseInsensitive(t *testing.T) {
 
 	if generateDNSDedupeKey(q1) != generateDNSDedupeKey(q2) {
 		t.Error("DNS dedup key must be case-insensitive")
+	}
+}
+
+func TestRecordDNSMock_RecordsNegativeResponses(t *testing.T) {
+	origConfigReader := dnsClientConfigFromFile
+	origExchange := dnsExchange
+	t.Cleanup(func() {
+		dnsClientConfigFromFile = origConfigReader
+		dnsExchange = origExchange
+	})
+
+	dnsClientConfigFromFile = func(string) (*dns.ClientConfig, error) {
+		return &dns.ClientConfig{
+			Servers: []string{"127.0.0.1"},
+			Port:    "53",
+		}, nil
+	}
+
+	dnsExchange = func(_ *dns.Client, _ *dns.Msg, _ string) (*dns.Msg, time.Duration, error) {
+		return &dns.Msg{
+			MsgHdr: dns.MsgHdr{
+				Rcode:              dns.RcodeNameError,
+				Authoritative:      true,
+				RecursionAvailable: true,
+			},
+		}, 0, nil
+	}
+
+	p := &Proxy{
+		logger:           testLogger(),
+		recordedDNSMocks: newRecordedDNSMocksCache(),
+	}
+
+	mocks := make(chan *models.Mock, 1)
+	session := &agent.Session{MC: mocks}
+	question := dns.Question{
+		Name:   "db.example.internal.",
+		Qtype:  dns.TypeA,
+		Qclass: dns.ClassINET,
+	}
+
+	resp, err := p.recordDNSMock(question, time.Unix(1, 0).UTC(), session)
+	if err != nil {
+		t.Fatalf("recordDNSMock returned error: %v", err)
+	}
+	if resp.Rcode != dns.RcodeNameError {
+		t.Fatalf("recordDNSMock rcode = %d, want %d", resp.Rcode, dns.RcodeNameError)
+	}
+
+	select {
+	case mock := <-mocks:
+		if mock.Spec.DNSResp == nil {
+			t.Fatal("recorded mock is missing DNS response")
+		}
+		if mock.Spec.DNSResp.Rcode != dns.RcodeNameError {
+			t.Fatalf("recorded DNS rcode = %d, want %d", mock.Spec.DNSResp.Rcode, dns.RcodeNameError)
+		}
+		if mock.Spec.DNSReq == nil {
+			t.Fatal("recorded mock is missing DNS request")
+		}
+		if mock.Spec.DNSReq.Name != question.Name {
+			t.Fatalf("recorded DNS name = %q, want %q", mock.Spec.DNSReq.Name, question.Name)
+		}
+	default:
+		t.Fatal("expected negative DNS response to be recorded")
+	}
+}
+
+func TestGetMockedDNSResponse_ReplaysNegativeResponses(t *testing.T) {
+	question := dns.Question{
+		Name:   "db.example.internal.",
+		Qtype:  dns.TypeA,
+		Qclass: dns.ClassINET,
+	}
+
+	p := &Proxy{logger: testLogger()}
+	mgr := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), testLogger())
+	mgr.SetFilteredMocks([]*models.Mock{{
+		Name: "mocks",
+		Kind: models.DNS,
+		Spec: models.MockSpec{
+			DNSReq: &models.DNSReq{
+				Name:   question.Name,
+				Qtype:  question.Qtype,
+				Qclass: question.Qclass,
+			},
+			DNSResp: &models.DNSResp{
+				Rcode:              dns.RcodeNameError,
+				Authoritative:      true,
+				RecursionAvailable: true,
+			},
+		},
+	}})
+	p.setMockManager(mgr)
+
+	resp, ok := p.getMockedDNSResponse(question)
+	if !ok {
+		t.Fatal("expected mocked DNS response to be found")
+	}
+	if resp.Rcode != dns.RcodeNameError {
+		t.Fatalf("mocked DNS rcode = %d, want %d", resp.Rcode, dns.RcodeNameError)
+	}
+	if len(resp.Answer) != 0 {
+		t.Fatalf("mocked DNS answers = %d, want 0", len(resp.Answer))
 	}
 }

--- a/pkg/agent/proxy/dns_test.go
+++ b/pkg/agent/proxy/dns_test.go
@@ -2,11 +2,8 @@ package proxy
 
 import (
 	"testing"
-	"time"
 
 	"github.com/miekg/dns"
-	"go.keploy.io/server/v3/pkg/agent"
-	"go.keploy.io/server/v3/pkg/models"
 )
 
 func TestGenerateDNSDedupeKey_SameQuerySameKey(t *testing.T) {
@@ -61,109 +58,5 @@ func TestGenerateDNSDedupeKey_CaseInsensitive(t *testing.T) {
 
 	if generateDNSDedupeKey(q1) != generateDNSDedupeKey(q2) {
 		t.Error("DNS dedup key must be case-insensitive")
-	}
-}
-
-func TestRecordDNSMock_RecordsNegativeResponses(t *testing.T) {
-	origConfigReader := dnsClientConfigFromFile
-	origExchange := dnsExchange
-	t.Cleanup(func() {
-		dnsClientConfigFromFile = origConfigReader
-		dnsExchange = origExchange
-	})
-
-	dnsClientConfigFromFile = func(string) (*dns.ClientConfig, error) {
-		return &dns.ClientConfig{
-			Servers: []string{"127.0.0.1"},
-			Port:    "53",
-		}, nil
-	}
-
-	dnsExchange = func(_ *dns.Client, _ *dns.Msg, _ string) (*dns.Msg, time.Duration, error) {
-		return &dns.Msg{
-			MsgHdr: dns.MsgHdr{
-				Rcode:              dns.RcodeNameError,
-				Authoritative:      true,
-				RecursionAvailable: true,
-			},
-		}, 0, nil
-	}
-
-	p := &Proxy{
-		logger:           testLogger(),
-		recordedDNSMocks: newRecordedDNSMocksCache(),
-	}
-
-	mocks := make(chan *models.Mock, 1)
-	session := &agent.Session{MC: mocks}
-	question := dns.Question{
-		Name:   "db.example.internal.",
-		Qtype:  dns.TypeA,
-		Qclass: dns.ClassINET,
-	}
-
-	resp, err := p.recordDNSMock(question, time.Unix(1, 0).UTC(), session)
-	if err != nil {
-		t.Fatalf("recordDNSMock returned error: %v", err)
-	}
-	if resp.Rcode != dns.RcodeNameError {
-		t.Fatalf("recordDNSMock rcode = %d, want %d", resp.Rcode, dns.RcodeNameError)
-	}
-
-	select {
-	case mock := <-mocks:
-		if mock.Spec.DNSResp == nil {
-			t.Fatal("recorded mock is missing DNS response")
-		}
-		if mock.Spec.DNSResp.Rcode != dns.RcodeNameError {
-			t.Fatalf("recorded DNS rcode = %d, want %d", mock.Spec.DNSResp.Rcode, dns.RcodeNameError)
-		}
-		if mock.Spec.DNSReq == nil {
-			t.Fatal("recorded mock is missing DNS request")
-		}
-		if mock.Spec.DNSReq.Name != question.Name {
-			t.Fatalf("recorded DNS name = %q, want %q", mock.Spec.DNSReq.Name, question.Name)
-		}
-	default:
-		t.Fatal("expected negative DNS response to be recorded")
-	}
-}
-
-func TestGetMockedDNSResponse_ReplaysNegativeResponses(t *testing.T) {
-	question := dns.Question{
-		Name:   "db.example.internal.",
-		Qtype:  dns.TypeA,
-		Qclass: dns.ClassINET,
-	}
-
-	p := &Proxy{logger: testLogger()}
-	mgr := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), testLogger())
-	mgr.SetFilteredMocks([]*models.Mock{{
-		Name: "mocks",
-		Kind: models.DNS,
-		Spec: models.MockSpec{
-			DNSReq: &models.DNSReq{
-				Name:   question.Name,
-				Qtype:  question.Qtype,
-				Qclass: question.Qclass,
-			},
-			DNSResp: &models.DNSResp{
-				Rcode:              dns.RcodeNameError,
-				Authoritative:      true,
-				RecursionAvailable: true,
-			},
-		},
-	}})
-	p.setMockManager(mgr)
-
-	resp, ok := p.getMockedDNSResponse(question)
-	if !ok {
-		t.Fatal("expected mocked DNS response to be found")
-	}
-	if resp.Rcode != dns.RcodeNameError {
-		t.Fatalf("mocked DNS rcode = %d, want %d", resp.Rcode, dns.RcodeNameError)
-	}
-	if len(resp.Answer) != 0 {
-		t.Fatalf("mocked DNS answers = %d, want 0", len(resp.Answer))
 	}
 }


### PR DESCRIPTION
Generated by Codex

## Describe the changes that are made
- preserve upstream negative DNS responses during DNS mock recording so replay keeps the original resolver behavior
- extend the DNS mock workflow to verify that a negative DNS response is recorded in `mocks.yaml` before replay
- temporarily point the DNS mock workflow to sample-app fixture branches that include an explicit NXDOMAIN check

## Links & References

**Closes:** NA
- NA (if very small change like typo, linting, etc.)

### 🔗 Related PRs
- https://github.com/AkashKumar7902/dns-mock-test/pull/2
- https://github.com/AkashKumar7902/dns-mock-test/pull/1
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [x] 👍 yes
- [ ] 🙅 no, because they are not needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [x] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

- Run the `dns_mock` GitHub Actions workflow job from this PR.
- The job currently checks out `officialasishkumar/dns-mock-test` on `negative-dns-udp-with-connect` and `negative-dns-udp-without-connect` while the related sample-app PRs are pending.
- The workflow verifies that `keploy/test-set-0/mocks.yaml` contains the recorded `rcode: 3` DNS mock before replay.

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [ ] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?

## Root cause
- record mode dropped non-success DNS responses such as NXDOMAIN during mock generation
- test mode could only replay what was recorded, so those dropped lookups turned into DNS mock misses and fell back to synthetic DNS behavior
- resolver flows that depend on a negative lookup followed by another query could therefore behave differently under replay than they did during capture