### PR TITLE
feat: async decoding of packets for mysql and http outgoing

### DIFF
--- a/.github/actions/setup-private-parsers/action.yaml
+++ b/.github/actions/setup-private-parsers/action.yaml
@@ -12,7 +12,7 @@ inputs:
   integration-ref:
     description: 'The git ref (branch, tag, or commit) of the integrations repo.'
     required: true
-    default: 'memory-aware-parsers'
+    default: 'async-decoding'
 
 runs:
   using: composite

--- a/.github/actions/setup-private-parsers/action.yaml
+++ b/.github/actions/setup-private-parsers/action.yaml
@@ -12,7 +12,7 @@ inputs:
   integration-ref:
     description: 'The git ref (branch, tag, or commit) of the integrations repo.'
     required: true
-    default: 'async-decoding'
+    default: 'main'
 
 runs:
   using: composite

--- a/.github/workflows/prepare_and_run_integrations.yml
+++ b/.github/workflows/prepare_and_run_integrations.yml
@@ -6,7 +6,7 @@ on:
         description: 'The git ref (branch, tag, or commit) of the integrations repo to use.'
         required: false
         type: string
-        default: 'async-decoding' # Feature branch with memory-aware parser changes
+        default: 'main' # Feature branch with memory-aware parser changes
       runner:
         description: 'The type of runner to use'
         type: string

--- a/.github/workflows/prepare_and_run_integrations.yml
+++ b/.github/workflows/prepare_and_run_integrations.yml
@@ -6,7 +6,7 @@ on:
         description: 'The git ref (branch, tag, or commit) of the integrations repo to use.'
         required: false
         type: string
-        default: 'memory-aware-parsers' # Feature branch with memory-aware parser changes
+        default: 'async-decoding' # Feature branch with memory-aware parser changes
       runner:
         description: 'The type of runner to use'
         type: string

--- a/.github/workflows/test_workflow_scripts/fuzzer/mongo/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/fuzzer/mongo/golang-linux.sh
@@ -138,7 +138,7 @@ send_requests() {
 
   echo "Triggering the fuzzer to generate traffic..."
 
-  curl --max-time 120 -X POST http://localhost:18082/run \
+  curl --max-time 300 -X POST http://localhost:18082/run \
   -H "Content-Type: application/json" \
   -d '{
     "mode": "record",

--- a/.github/workflows/test_workflow_scripts/fuzzer/mongo/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/fuzzer/mongo/golang-linux.sh
@@ -138,7 +138,7 @@ send_requests() {
 
   echo "Triggering the fuzzer to generate traffic..."
 
-  curl -X POST http://localhost:18082/run \
+  curl --max-time 120 -X POST http://localhost:18082/run \
   -H "Content-Type: application/json" \
   -d '{
     "mode": "record",
@@ -167,9 +167,17 @@ send_requests() {
     "connect_timeout_sec": 10,
     "max_conn_idle_time_sec": 30,
     "max_staleness_sec": 90,
-    
+
     "max_diffs": 20
-  }'
+  }' || true
+
+  # If the fuzzer didn't complete in 120s, dump goroutine stacks
+  REC_PID_EARLY="$(pgrep -n -f 'keploy record' || true)"
+  if [ -n "$REC_PID_EARLY" ] && kill -0 "$REC_PID_EARLY" 2>/dev/null; then
+    echo "::warning::Fuzzer timed out during send_requests — dumping goroutine stacks for diagnosis..."
+    sudo kill -QUIT "$REC_PID_EARLY" 2>/dev/null || true
+    sleep 3
+  fi
 }
 
 # --- Main Execution Logic ---
@@ -214,27 +222,81 @@ endsec
 # --- Recording Phase ---
 section "Start Recording Server"
 # The command includes the fuzzer binary and its specific arguments
-"$RECORD_KEPLOY_BIN" record -c "$MONGO_FUZZER_BIN" 2>&1 | tee record.txt &
+GOTRACEBACK=all "$RECORD_KEPLOY_BIN" record -c "$MONGO_FUZZER_BIN" 2>&1 | tee record.txt &
 KEPLOY_PID=$!
 echo "Keploy record process started with PID: $KEPLOY_PID"
 endsec
 
+# Helper: dump goroutine stacks for both keploy CLI and agent subprocess
+dump_goroutine_stacks() {
+  local reason="$1"
+  echo "===== $reason — DUMPING GOROUTINE STACKS ====="
+
+  # Find the keploy agent subprocess (child of the CLI process)
+  AGENT_PID="$(pgrep -f 'keploy' | grep -v "$$" | sort -n | tail -1 || true)"
+  CLI_PID="$(pgrep -n -f 'keploy record' || true)"
+
+  if [ -n "$AGENT_PID" ] && [ "$AGENT_PID" != "$CLI_PID" ]; then
+    echo "===== AGENT (PID=$AGENT_PID) ====="
+    sudo kill -QUIT "$AGENT_PID" 2>/dev/null || true
+    sleep 3
+  fi
+  if [ -n "$CLI_PID" ]; then
+    echo "===== CLI (PID=$CLI_PID) ====="
+    sudo kill -QUIT "$CLI_PID" 2>/dev/null || true
+    sleep 3
+  fi
+}
+
+# Watchdog: if recording hangs for 120s, dump stacks and force kill
+(
+  sleep 120
+  echo "::warning::Recording watchdog triggered after 120s"
+  dump_goroutine_stacks "RECORDING HUNG"
+  sleep 5
+  # Force kill everything to unblock the pipeline
+  pkill -9 -f 'keploy' 2>/dev/null || true
+) &
+WATCHDOG_PID=$!
+
 section "Generate Fuzzer Traffic"
-# Trigger traffic and explicitly kill the Keploy process after a delay
 send_requests "$KEPLOY_PID"
-# Increased sleep time to capture more of the complex, sharded operations
 sleep 7
 endsec
 
+# Kill the watchdog — recording traffic completed normally
+kill "$WATCHDOG_PID" 2>/dev/null || true
+wait "$WATCHDOG_PID" 2>/dev/null || true
+
 section "Stop Recording"
-echo "Stopping Keploy record process (PID: $KEPLOY_PID)..."
+echo "Stopping Keploy record process..."
 
 REC_PID="$(pgrep -n -f 'keploy record' || true)"
 echo "$REC_PID Keploy PID"
-echo "Killing keploy"
+
+echo "Sending SIGINT to keploy..."
 sudo kill -INT "$REC_PID" 2>/dev/null || true
 
-sleep 5
+# Wait up to 15 seconds for graceful shutdown
+SHUTDOWN_TIMEOUT=15
+for i in $(seq 1 $SHUTDOWN_TIMEOUT); do
+  if ! kill -0 "$REC_PID" 2>/dev/null; then
+    echo "Keploy exited after ${i}s"
+    break
+  fi
+  if [ "$i" -eq 10 ]; then
+    dump_goroutine_stacks "SHUTDOWN HUNG"
+  fi
+  sleep 1
+done
+
+# Force kill if still alive
+if kill -0 "$REC_PID" 2>/dev/null; then
+  echo "::error::Keploy did not exit within ${SHUTDOWN_TIMEOUT}s, force killing..."
+  sudo kill -9 "$REC_PID" 2>/dev/null || true
+  sleep 1
+fi
+
 check_for_errors "record.txt"
 echo "Recording stopped."
 endsec

--- a/.github/workflows/test_workflow_scripts/fuzzer/mongo/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/fuzzer/mongo/golang-linux.sh
@@ -171,13 +171,6 @@ send_requests() {
     "max_diffs": 20
   }' || true
 
-  # If the fuzzer didn't complete in 120s, dump goroutine stacks
-  REC_PID_EARLY="$(pgrep -n -f 'keploy record' || true)"
-  if [ -n "$REC_PID_EARLY" ] && kill -0 "$REC_PID_EARLY" 2>/dev/null; then
-    echo "::warning::Fuzzer timed out during send_requests — dumping goroutine stacks for diagnosis..."
-    sudo kill -QUIT "$REC_PID_EARLY" 2>/dev/null || true
-    sleep 3
-  fi
 }
 
 # --- Main Execution Logic ---
@@ -227,46 +220,10 @@ KEPLOY_PID=$!
 echo "Keploy record process started with PID: $KEPLOY_PID"
 endsec
 
-# Helper: dump goroutine stacks for both keploy CLI and agent subprocess
-dump_goroutine_stacks() {
-  local reason="$1"
-  echo "===== $reason — DUMPING GOROUTINE STACKS ====="
-
-  # Find the keploy agent subprocess (child of the CLI process)
-  AGENT_PID="$(pgrep -f 'keploy' | grep -v "$$" | sort -n | tail -1 || true)"
-  CLI_PID="$(pgrep -n -f 'keploy record' || true)"
-
-  if [ -n "$AGENT_PID" ] && [ "$AGENT_PID" != "$CLI_PID" ]; then
-    echo "===== AGENT (PID=$AGENT_PID) ====="
-    sudo kill -QUIT "$AGENT_PID" 2>/dev/null || true
-    sleep 3
-  fi
-  if [ -n "$CLI_PID" ]; then
-    echo "===== CLI (PID=$CLI_PID) ====="
-    sudo kill -QUIT "$CLI_PID" 2>/dev/null || true
-    sleep 3
-  fi
-}
-
-# Watchdog: if recording hangs for 120s, dump stacks and force kill
-(
-  sleep 120
-  echo "::warning::Recording watchdog triggered after 120s"
-  dump_goroutine_stacks "RECORDING HUNG"
-  sleep 5
-  # Force kill everything to unblock the pipeline
-  pkill -9 -f 'keploy' 2>/dev/null || true
-) &
-WATCHDOG_PID=$!
-
 section "Generate Fuzzer Traffic"
 send_requests "$KEPLOY_PID"
 sleep 7
 endsec
-
-# Kill the watchdog — recording traffic completed normally
-kill "$WATCHDOG_PID" 2>/dev/null || true
-wait "$WATCHDOG_PID" 2>/dev/null || true
 
 section "Stop Recording"
 echo "Stopping Keploy record process..."
@@ -283,9 +240,6 @@ for i in $(seq 1 $SHUTDOWN_TIMEOUT); do
   if ! kill -0 "$REC_PID" 2>/dev/null; then
     echo "Keploy exited after ${i}s"
     break
-  fi
-  if [ "$i" -eq 10 ]; then
-    dump_goroutine_stacks "SHUTDOWN HUNG"
   fi
   sleep 1
 done

--- a/.github/workflows/test_workflow_scripts/fuzzer/mongo/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/fuzzer/mongo/golang-linux.sh
@@ -138,7 +138,7 @@ send_requests() {
 
   echo "Triggering the fuzzer to generate traffic..."
 
-  curl --max-time 300 -X POST http://localhost:18082/run \
+  curl --max-time 600 -X POST http://localhost:18082/run \
   -H "Content-Type: application/json" \
   -d '{
     "mode": "record",

--- a/pkg/agent/memoryguard/memoryguard.go
+++ b/pkg/agent/memoryguard/memoryguard.go
@@ -149,7 +149,6 @@ func (g *guard) run(ctx context.Context) {
 			}
 			g.readFailCount = 0
 
-
 			pauseThreshold := thresholdBytes(g.limitBytes, pauseThresholdRatio)
 			resumeThreshold := thresholdBytes(g.limitBytes, resumeThresholdRatio)
 

--- a/pkg/agent/memoryguard/memoryguard.go
+++ b/pkg/agent/memoryguard/memoryguard.go
@@ -3,6 +3,7 @@ package memoryguard
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -148,9 +149,6 @@ func (g *guard) run(ctx context.Context) {
 			}
 			g.readFailCount = 0
 
-			g.logger.Info("Checked keploy-agent memory usage",
-				zap.Int64("memory_usage_bytes", currentBytes),
-				zap.Int64("memory_limit_bytes", g.limitBytes))
 
 			pauseThreshold := thresholdBytes(g.limitBytes, pauseThresholdRatio)
 			resumeThreshold := thresholdBytes(g.limitBytes, resumeThresholdRatio)
@@ -517,9 +515,13 @@ func extractHexIdentifiers(value string) []string {
 //
 // On macOS with Docker Desktop + kind the cgroup namespace is not propagated,
 // so /proc/self/cgroup reports "/" (the root of the entire VM's cgroup tree).
-// Resolving "/" would yield the VM-wide memory.current (~5–8 GiB) instead of
-// this container's actual usage.  We detect that case and return an error so
-// the caller falls through to the identifier-based or PID-based resolution.
+// When cgroupPath is "/" (root), this is valid in containers with proper
+// cgroup namespace isolation where the container sits at the root of its
+// own cgroup namespace. buildMountedCgroupPath handles the "/" case and
+// fileExists validates the resolved path, so we do not reject "/" here.
+// If the resolved path doesn't exist (e.g. macOS Docker Desktop + kind
+// where "/" maps to VM-wide memory), fileExists will fail and the caller
+// falls through to identifier-based or PID-based resolution.
 func resolveFromSelfCgroup(layout cgroupLayout, procSelfCgroupPath string) (string, error) {
 	cgroupPath, err := readSelfCgroupPath(procSelfCgroupPath, layout)
 	if err != nil {
@@ -531,11 +533,6 @@ func resolveFromSelfCgroup(layout cgroupLayout, procSelfCgroupPath string) (stri
 	if cgroupPath == "" {
 		return "", fmt.Errorf("cgroup self-path is empty; skipping to container-specific resolution")
 	}
-
-	// When cgroupPath is "/" (root), this is valid in containers with proper
-	// cgroup namespace isolation where the container sits at the root of its
-	// own cgroup namespace.  buildMountedCgroupPath handles the "/" case and
-	// fileExists validates the resolved path, so we do not reject "/" here.
 
 	candidate, ok := buildMountedCgroupPath(layout.mountPoint, layout.mountRoot, cgroupPath, layout.usageFile)
 	if !ok {
@@ -675,7 +672,7 @@ func findCgroupByOwnPID(layout cgroupLayout) (string, error) {
 
 	var foundPath string
 	// sentinelErr signals a successful early-exit from WalkDir.
-	sentinelErr := fmt.Errorf("found")
+	sentinelErr := errors.New("found")
 
 	walkErr := filepath.WalkDir(layout.mountPoint, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
@@ -707,7 +704,7 @@ func findCgroupByOwnPID(layout cgroupLayout) (string, error) {
 	})
 
 	// WalkDir returns sentinelErr when we found the path — that is success.
-	if walkErr != nil && walkErr.Error() != sentinelErr.Error() {
+	if walkErr != nil && !errors.Is(walkErr, sentinelErr) {
 		return "", walkErr
 	}
 	if foundPath == "" {

--- a/pkg/agent/memoryguard/memoryguard.go
+++ b/pkg/agent/memoryguard/memoryguard.go
@@ -526,12 +526,16 @@ func resolveFromSelfCgroup(layout cgroupLayout, procSelfCgroupPath string) (stri
 		return "", err
 	}
 
-	// Root path ("/") means cgroup namespace isolation is absent; resolving it
-	// would give us the entire VM's memory rather than this container's usage.
-	// Fall through to a more specific resolution strategy.
-	if cgroupPath == "/" || cgroupPath == "" {
-		return "", fmt.Errorf("cgroup self-path is root (%q); skipping to container-specific resolution", cgroupPath)
+	// An empty cgroup path is invalid — fall through to identifier-based
+	// resolution.
+	if cgroupPath == "" {
+		return "", fmt.Errorf("cgroup self-path is empty; skipping to container-specific resolution")
 	}
+
+	// When cgroupPath is "/" (root), this is valid in containers with proper
+	// cgroup namespace isolation where the container sits at the root of its
+	// own cgroup namespace.  buildMountedCgroupPath handles the "/" case and
+	// fileExists validates the resolved path, so we do not reject "/" here.
 
 	candidate, ok := buildMountedCgroupPath(layout.mountPoint, layout.mountRoot, cgroupPath, layout.usageFile)
 	if !ok {

--- a/pkg/agent/memoryguard/memoryguard.go
+++ b/pkg/agent/memoryguard/memoryguard.go
@@ -60,7 +60,6 @@ func LimitBytes(limitMB uint64) (int64, error) {
 	if limitMB > math.MaxInt64/(1024*1024) {
 		return 0, fmt.Errorf("memory limit %dMB is too large", limitMB)
 	}
-
 	return int64(limitMB) * 1024 * 1024, nil
 }
 
@@ -125,7 +124,11 @@ func (g *guard) run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			currentBytes, err := readMemoryCurrent(g.memoryCurrentPath)
+			// readWorkingSetBytes subtracts inactive_file from memory.current so
+			// that page-cache does not count toward the pressure threshold.  This
+			// matches what kubectl top / Kubernetes eviction logic uses and avoids
+			// false-positive pauses caused by reclaimable cache pages.
+			currentBytes, err := readWorkingSetBytes(g.memoryCurrentPath)
 			if err != nil {
 				g.readFailCount++
 				if g.readFailCount == 1 {
@@ -145,8 +148,13 @@ func (g *guard) run(ctx context.Context) {
 			}
 			g.readFailCount = 0
 
+			g.logger.Info("Checked keploy-agent memory usage",
+				zap.Int64("memory_usage_bytes", currentBytes),
+				zap.Int64("memory_limit_bytes", g.limitBytes))
+
 			pauseThreshold := thresholdBytes(g.limitBytes, pauseThresholdRatio)
 			resumeThreshold := thresholdBytes(g.limitBytes, resumeThresholdRatio)
+
 			if pauseThreshold == 0 {
 				pauseThreshold = g.limitBytes
 			}
@@ -174,6 +182,7 @@ func (g *guard) enterPressure(currentBytes, pauseThreshold int64) {
 	alreadyPaused := g.underPressure
 	g.underPressure = true
 	applyPausedState(true)
+
 	now := time.Now()
 	if !alreadyPaused {
 		g.logger.Info("Pausing keploy-agent recording due to memory pressure. "+
@@ -183,7 +192,6 @@ func (g *guard) enterPressure(currentBytes, pauseThreshold int64) {
 			zap.Int64("memory_limit_bytes", g.limitBytes),
 			zap.Uint64("memory_limit_mb", g.memoryLimitMB))
 	}
-
 	if !alreadyPaused || now.Sub(g.lastReclaim) >= reclaimCooldown {
 		g.lastReclaim = now
 		debug.FreeOSMemory()
@@ -206,23 +214,63 @@ func applyPausedState(paused bool) {
 	}
 }
 
+// readMemoryCurrent reads the raw cgroup memory.current value (total bytes
+// including page cache).  Callers that need the working-set should use
+// readWorkingSetBytes instead.
 func readMemoryCurrent(path string) (int64, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return 0, err
 	}
-
 	value := strings.TrimSpace(string(data))
 	if value == "" {
 		return 0, fmt.Errorf("empty cgroup memory usage file: %s", path)
 	}
-
 	currentBytes, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
 		return 0, fmt.Errorf("parse cgroup memory usage file %s: %w", path, err)
 	}
-
 	return currentBytes, nil
+}
+
+// readWorkingSetBytes returns the container's working-set memory:
+//
+//	working_set = memory.current − inactive_file
+//
+// This matches what kubectl top and the Kubernetes eviction manager report,
+// and avoids false-positive pressure events caused by reclaimable page cache.
+// If memory.stat is unavailable the raw memory.current value is returned so
+// the guard still functions (conservatively).
+func readWorkingSetBytes(memCurrentPath string) (int64, error) {
+	currentBytes, err := readMemoryCurrent(memCurrentPath)
+	if err != nil {
+		return 0, err
+	}
+
+	statPath := filepath.Join(filepath.Dir(memCurrentPath), "memory.stat")
+	data, err := os.ReadFile(statPath)
+	if err != nil {
+		// Graceful degradation: memory.stat may not exist on cgroup v1 paths
+		// or in some constrained environments; fall back to raw usage.
+		return currentBytes, nil
+	}
+
+	var inactiveFile int64
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "inactive_file ") {
+			fields := strings.Fields(line)
+			if len(fields) == 2 {
+				inactiveFile, _ = strconv.ParseInt(fields[1], 10, 64)
+			}
+			break
+		}
+	}
+
+	workingSet := currentBytes - inactiveFile
+	if workingSet < 0 {
+		workingSet = 0
+	}
+	return workingSet, nil
 }
 
 func resolveMemoryUsagePath(procMountsPath, procSelfCgroupPath, procMountInfoPath string) (string, cgroupLayout, error) {
@@ -231,6 +279,10 @@ func resolveMemoryUsagePath(procMountsPath, procSelfCgroupPath, procMountInfoPat
 		return "", cgroupLayout{}, err
 	}
 
+	// Primary path: derive the container's cgroup from /proc/self/cgroup.
+	// This works on Linux (including Linux kind clusters) where cgroup namespace
+	// isolation is in effect and /proc/self/cgroup reports the container-relative
+	// path rather than "/".
 	for _, layout := range layouts {
 		candidate, err := resolveFromSelfCgroup(layout, procSelfCgroupPath)
 		if err == nil {
@@ -238,6 +290,9 @@ func resolveMemoryUsagePath(procMountsPath, procSelfCgroupPath, procMountInfoPat
 		}
 	}
 
+	// Secondary path: scan identifiers extracted from the environment, hostname,
+	// /proc/self/cgroup, and /proc/self/mountinfo, then walk the cgroup tree
+	// looking for a scope directory whose name contains one of those identifiers.
 	identifiers, err := collectContainerIdentifiers(procSelfCgroupPath, procMountInfoPath)
 	if err != nil {
 		return "", cgroupLayout{}, err
@@ -250,6 +305,22 @@ func resolveMemoryUsagePath(procMountsPath, procSelfCgroupPath, procMountInfoPat
 			return candidate, layout, nil
 		}
 		resolutionErrs = append(resolutionErrs, err.Error())
+	}
+
+	// Tertiary / macOS-kind fallback: on macOS with Docker Desktop the cgroup
+	// namespace is not propagated into kind node containers, so
+	// /proc/self/cgroup reports "/" and the container ID does not appear in
+	// mountinfo.  Walk every cgroup.procs file under the mount point and find
+	// the scope that actually owns this process (matched by its root-namespace
+	// PID read from NSpid in /proc/self/status).
+	// This path is never reached on a normal Linux setup, so it has zero impact
+	// on the existing Linux flow.
+	for _, layout := range layouts {
+		candidate, err := findCgroupByOwnPID(layout)
+		if err == nil {
+			return candidate, layout, nil
+		}
+		resolutionErrs = append(resolutionErrs, fmt.Sprintf("pid-walk: %v", err))
 	}
 
 	return "", cgroupLayout{}, fmt.Errorf("no container-specific cgroup memory file found (%s)", strings.Join(resolutionErrs, "; "))
@@ -275,7 +346,6 @@ func detectCgroupLayouts(procMountsPath, procMountInfoPath string) ([]cgroupLayo
 		if len(fields) < 4 {
 			continue
 		}
-
 		mountPoint := fields[1]
 		fsType := fields[2]
 		options := strings.Split(fields[3], ",")
@@ -308,11 +378,9 @@ func detectCgroupLayouts(procMountsPath, procMountInfoPath string) ([]cgroupLayo
 			})
 		}
 	}
-
 	if err := scanner.Err(); err != nil {
 		return nil, err
 	}
-
 	if len(layouts) == 0 {
 		return nil, fmt.Errorf("no cgroup v1 memory or cgroup v2 mounts found")
 	}
@@ -323,7 +391,6 @@ func detectCgroupLayouts(procMountsPath, procMountInfoPath string) ([]cgroupLayo
 		}
 		return layouts[i].version < layouts[j].version
 	})
-
 	return layouts, nil
 }
 
@@ -332,18 +399,15 @@ func readSelfCgroupPath(procSelfCgroupPath string, layout cgroupLayout) (string,
 	if err != nil {
 		return "", err
 	}
-
 	for _, line := range strings.Split(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
-
 		parts := strings.SplitN(line, ":", 3)
 		if len(parts) != 3 {
 			continue
 		}
-
 		switch layout.version {
 		case cgroupV2:
 			if parts[1] == "" {
@@ -361,7 +425,6 @@ func readSelfCgroupPath(procSelfCgroupPath string, layout cgroupLayout) (string,
 			}
 		}
 	}
-
 	return "", fmt.Errorf("container cgroup path not found in %s for cgroup v%d", procSelfCgroupPath, layout.version)
 }
 
@@ -370,26 +433,21 @@ func readMountRoots(procMountInfoPath string) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	roots := make(map[string]string)
 	for _, line := range strings.Split(string(data), "\n") {
 		if strings.TrimSpace(line) == "" {
 			continue
 		}
-
 		parts := strings.SplitN(line, " - ", 2)
 		if len(parts) != 2 {
 			continue
 		}
-
 		fields := strings.Fields(parts[0])
 		if len(fields) < 5 {
 			continue
 		}
-
 		roots[fields[4]] = fields[3]
 	}
-
 	return roots, nil
 }
 
@@ -401,13 +459,11 @@ func collectContainerIdentifiers(procSelfCgroupPath, procMountInfoPath string) (
 			candidates[id] = struct{}{}
 		}
 	}
-
 	if hostname, err := os.Hostname(); err == nil {
 		for _, id := range extractHexIdentifiers(hostname) {
 			candidates[id] = struct{}{}
 		}
 	}
-
 	for _, path := range []string{procSelfCgroupPath, procMountInfoPath} {
 		data, err := os.ReadFile(path)
 		if err != nil {
@@ -426,14 +482,12 @@ func collectContainerIdentifiers(procSelfCgroupPath, procMountInfoPath string) (
 	for id := range candidates {
 		identifiers = append(identifiers, id)
 	}
-
 	sort.Slice(identifiers, func(i, j int) bool {
 		if len(identifiers[i]) == len(identifiers[j]) {
 			return identifiers[i] < identifiers[j]
 		}
 		return len(identifiers[i]) > len(identifiers[j])
 	})
-
 	return identifiers, nil
 }
 
@@ -443,7 +497,6 @@ func extractHexIdentifiers(value string) []string {
 	if len(matches) == 0 {
 		return nil
 	}
-
 	seen := make(map[string]struct{}, len(matches))
 	result := make([]string, 0, len(matches))
 	for _, match := range matches {
@@ -453,14 +506,31 @@ func extractHexIdentifiers(value string) []string {
 		seen[match] = struct{}{}
 		result = append(result, match)
 	}
-
 	return result
 }
 
+// resolveFromSelfCgroup derives the container's cgroup memory file path by
+// reading /proc/self/cgroup.  On Linux with proper cgroup namespace isolation
+// this reports the container-relative path (e.g.
+// /kubepods/burstable/pod.../cri-containerd-<id>) and is the fastest,
+// most reliable resolution method.
+//
+// On macOS with Docker Desktop + kind the cgroup namespace is not propagated,
+// so /proc/self/cgroup reports "/" (the root of the entire VM's cgroup tree).
+// Resolving "/" would yield the VM-wide memory.current (~5–8 GiB) instead of
+// this container's actual usage.  We detect that case and return an error so
+// the caller falls through to the identifier-based or PID-based resolution.
 func resolveFromSelfCgroup(layout cgroupLayout, procSelfCgroupPath string) (string, error) {
 	cgroupPath, err := readSelfCgroupPath(procSelfCgroupPath, layout)
 	if err != nil {
 		return "", err
+	}
+
+	// Root path ("/") means cgroup namespace isolation is absent; resolving it
+	// would give us the entire VM's memory rather than this container's usage.
+	// Fall through to a more specific resolution strategy.
+	if cgroupPath == "/" || cgroupPath == "" {
+		return "", fmt.Errorf("cgroup self-path is root (%q); skipping to container-specific resolution", cgroupPath)
 	}
 
 	candidate, ok := buildMountedCgroupPath(layout.mountPoint, layout.mountRoot, cgroupPath, layout.usageFile)
@@ -470,7 +540,6 @@ func resolveFromSelfCgroup(layout cgroupLayout, procSelfCgroupPath string) (stri
 	if !fileExists(candidate) {
 		return "", fmt.Errorf("cgroup memory file %q not found", candidate)
 	}
-
 	return candidate, nil
 }
 
@@ -479,7 +548,6 @@ func buildMountedCgroupPath(mountPoint, mountRoot, cgroupPath, usageFile string)
 	if cleanMountRoot == "." || cleanMountRoot == "" {
 		cleanMountRoot = "/"
 	}
-
 	cleanCgroupPath := filepath.Clean(cgroupPath)
 	if cleanCgroupPath == "." || cleanCgroupPath == "" {
 		cleanCgroupPath = "/"
@@ -502,7 +570,6 @@ func buildMountedCgroupPath(mountPoint, mountRoot, cgroupPath, usageFile string)
 	if relativePath == "" {
 		return filepath.Join(mountPoint, usageFile), true
 	}
-
 	return filepath.Join(mountPoint, relativePath, usageFile), true
 }
 
@@ -516,33 +583,28 @@ func findMemoryUsagePathByIdentifier(layout cgroupLayout, identifiers []string) 
 	}
 
 	mountDepth := strings.Count(filepath.Clean(layout.mountPoint), string(os.PathSeparator))
-
 	best := match{}
+
 	err := filepath.WalkDir(layout.mountPoint, func(path string, d os.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
-
 		currentDepth := strings.Count(path, string(os.PathSeparator)) - mountDepth
 		if d.IsDir() && currentDepth > maxWalkDepth {
 			return filepath.SkipDir
 		}
-
 		if d.IsDir() || d.Name() != layout.usageFile {
 			return nil
 		}
-
 		dir := filepath.Dir(path)
 		if dir == layout.mountPoint {
 			return nil
 		}
-
 		dirLower := strings.ToLower(dir)
 		for _, identifier := range identifiers {
 			if !strings.Contains(dirLower, identifier) {
 				continue
 			}
-
 			depth := strings.Count(dirLower, string(os.PathSeparator))
 			if len(identifier) > best.idLen || (len(identifier) == best.idLen && depth > best.depth) {
 				best = match{
@@ -553,18 +615,101 @@ func findMemoryUsagePathByIdentifier(layout cgroupLayout, identifiers []string) 
 			}
 			break
 		}
-
 		return nil
 	})
 	if err != nil {
 		return "", err
 	}
-
 	if best.path == "" {
 		return "", fmt.Errorf("failed to find container-specific %s under %s", layout.usageFile, layout.mountPoint)
 	}
-
 	return best.path, nil
+}
+
+// getRootNSPID returns this process's PID in the root (initial) PID namespace
+// by reading the NSpid field from /proc/self/status.  NSpid lists namespaces
+// innermost-first, so the last entry is the outermost / host-level PID — the
+// one written into cgroup.procs files by the container runtime.
+func getRootNSPID() (int, error) {
+	data, err := os.ReadFile("/proc/self/status")
+	if err != nil {
+		return 0, err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if !strings.HasPrefix(line, "NSpid:") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			break
+		}
+		// Last field = outermost (root) namespace PID
+		return strconv.Atoi(fields[len(fields)-1])
+	}
+	return 0, fmt.Errorf("NSpid field not found in /proc/self/status")
+}
+
+// findCgroupByOwnPID walks the cgroup tree under layout.mountPoint looking for
+// the leaf scope whose cgroup.procs file contains this process's root-namespace
+// PID.  It is used as a last-resort fallback for environments where
+// /proc/self/cgroup reports "/" and no container identifier can be found in
+// mountinfo — specifically macOS + Docker Desktop + kind clusters where the
+// cgroup namespace is not propagated into kind-node containers.
+//
+// This function is never reached on a standard Linux setup (the primary
+// resolveFromSelfCgroup path succeeds there), so it has zero impact on the
+// existing Linux behaviour.
+func findCgroupByOwnPID(layout cgroupLayout) (string, error) {
+	rootPID, err := getRootNSPID()
+	if err != nil {
+		return "", fmt.Errorf("could not determine root namespace PID: %w", err)
+	}
+	pidStr := strconv.Itoa(rootPID)
+
+	const maxWalkDepth = 8
+	mountDepth := strings.Count(filepath.Clean(layout.mountPoint), string(os.PathSeparator))
+
+	var foundPath string
+	// sentinelErr signals a successful early-exit from WalkDir.
+	sentinelErr := fmt.Errorf("found")
+
+	walkErr := filepath.WalkDir(layout.mountPoint, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil // skip unreadable entries; don't abort the walk
+		}
+		currentDepth := strings.Count(path, string(os.PathSeparator)) - mountDepth
+		if d.IsDir() && currentDepth > maxWalkDepth {
+			return filepath.SkipDir
+		}
+		if d.IsDir() || d.Name() != "cgroup.procs" {
+			return nil
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+			if strings.TrimSpace(line) != pidStr {
+				continue
+			}
+			candidate := filepath.Join(filepath.Dir(path), layout.usageFile)
+			if fileExists(candidate) {
+				foundPath = candidate
+				return sentinelErr // signal early exit
+			}
+		}
+		return nil
+	})
+
+	// WalkDir returns sentinelErr when we found the path — that is success.
+	if walkErr != nil && walkErr.Error() != sentinelErr.Error() {
+		return "", walkErr
+	}
+	if foundPath == "" {
+		return "", fmt.Errorf("no cgroup scope found containing PID %d (root NS) under %s", rootPID, layout.mountPoint)
+	}
+	return foundPath, nil
 }
 
 func hasController(controllers []string, target string) bool {

--- a/pkg/agent/proxy/integrations/http/encode.go
+++ b/pkg/agent/proxy/integrations/http/encode.go
@@ -134,15 +134,14 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 				return err
 			}
 
-			// Non-blocking send to async decode. Check channel capacity
-			// before copying to avoid allocation/GC churn when the decoder
-			// can't keep up (the copy would just be dropped).
-			if !memoryguard.IsRecordingPaused() && len(decodeChan) < cap(decodeChan) {
+			// Send to async decode — blocking with ctx escape so HTTP
+			// mocks are never silently lost due to channel pressure.
+			if !memoryguard.IsRecordingPaused() {
 				buf := make([]byte, len(buffer))
 				copy(buf, buffer)
 				select {
 				case decodeChan <- httpDecodeItem{fromClient: true, data: buf, ts: time.Now()}:
-				default:
+				case <-ctx.Done():
 				}
 			}
 
@@ -163,13 +162,13 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 				return err
 			}
 
-			// Non-blocking send to async decode.
-			if !memoryguard.IsRecordingPaused() && len(decodeChan) < cap(decodeChan) {
+			// Send to async decode — blocking with ctx escape.
+			if !memoryguard.IsRecordingPaused() {
 				buf := make([]byte, len(buffer))
 				copy(buf, buffer)
 				select {
 				case decodeChan <- httpDecodeItem{fromClient: false, data: buf, ts: time.Now()}:
-				default:
+				case <-ctx.Done():
 				}
 			}
 
@@ -193,12 +192,12 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 						continue
 					}
 					_, _ = destConn.Write(buf)
-					if !memoryguard.IsRecordingPaused() && len(decodeChan) < cap(decodeChan) {
+					if !memoryguard.IsRecordingPaused() {
 						cp := make([]byte, len(buf))
 						copy(cp, buf)
 						select {
 						case decodeChan <- httpDecodeItem{fromClient: true, data: cp, ts: time.Now()}:
-						default:
+						case <-ctx.Done():
 						}
 					}
 				case buf, ok := <-destBuffChan:
@@ -210,12 +209,12 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 						continue
 					}
 					_, _ = clientConn.Write(buf)
-					if !memoryguard.IsRecordingPaused() && len(decodeChan) < cap(decodeChan) {
+					if !memoryguard.IsRecordingPaused() {
 						cp := make([]byte, len(buf))
 						copy(cp, buf)
 						select {
 						case decodeChan <- httpDecodeItem{fromClient: false, data: cp, ts: time.Now()}:
-						default:
+						case <-ctx.Done():
 						}
 					}
 				default:

--- a/pkg/agent/proxy/integrations/http/encode.go
+++ b/pkg/agent/proxy/integrations/http/encode.go
@@ -1,12 +1,11 @@
 package http
 
 import (
+	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net"
-	"strings"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -18,12 +17,22 @@ import (
 	"go.uber.org/zap"
 )
 
-// encodeHTTP function parses the HTTP request and response text messages to capture outgoing network calls as mocks.
+// httpDecodeItem carries a forwarded chunk to the async decode goroutine.
+type httpDecodeItem struct {
+	fromClient bool
+	data       []byte
+	ts         time.Time
+}
+
+// encodeHTTP records outgoing HTTP traffic. Forwarding runs in the main
+// select loop at wire speed. All HTTP message reassembly, parsing, and
+// mock creation is offloaded to a background goroutine via a buffered
+// decode channel, so it never slows the data path.
 func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destConn net.Conn, mocks chan<- *models.Mock, opts models.OutgoingOptions) error {
 	remoteAddr := destConn.RemoteAddr().(*net.TCPAddr)
 	destPort := uint(remoteAddr.Port)
 
-	//Writing the request to the server.
+	// Forward initial request to destination immediately — critical path.
 	_, err := destConn.Write(reqBuf)
 	if err != nil {
 		h.Logger.Error("failed to write request message to the destination server", zap.Error(err))
@@ -34,241 +43,258 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 		return ctx.Err()
 	}
 
-	h.Logger.Debug("This is the initial request: " + string(reqBuf))
-	var finalReq []byte
-	errCh := make(chan error, 1)
+	// If recording is already paused, pure passthrough.
+	if memoryguard.IsRecordingPaused() {
+		h.Logger.Debug("memory pressure detected, stopping HTTP recording and falling back to passthrough")
+		return forwardHTTPBidirectional(clientConn, destConn)
+	}
 
-	finalReq = append(finalReq, reqBuf...)
-
-	//get the error group from the context
 	g, ok := ctx.Value(models.ErrGroupKey).(*errgroup.Group)
 	if !ok {
 		return errors.New("failed to get the error group from the context")
 	}
 
-	//for keeping conn alive
+	// Buffered channels let ReadBuffConn read ahead without waiting
+	// for the main loop, preventing TCP flow-control throttling.
+	clientBuffChan := make(chan []byte, 256)
+	destBuffChan := make(chan []byte, 256)
+	errChan := make(chan error, 1)
+
+	// Read from client. stopOnRecordingPause is false: the main loop
+	// skips sending to decodeChan when paused, so recording stops while
+	// forwarding continues through the same goroutines.
 	g.Go(func() error {
 		defer pUtil.Recover(h.Logger, clientConn, destConn)
-		defer close(errCh)
-		for {
-			if memoryguard.IsRecordingPaused() {
-				h.Logger.Debug("memory pressure detected, stopping HTTP recording and falling back to passthrough")
-				done := make(chan struct{}, 2)
-				cp := func(dst, src net.Conn) {
-					_, _ = io.Copy(dst, src)
-					done <- struct{}{}
-				}
-				go cp(destConn, clientConn)
-				go cp(clientConn, destConn)
-				<-done
-				<-done
-				return nil
-			}
-
-			//check if expect : 100-continue header is present
-			lines := strings.Split(string(finalReq), "\n")
-			var expectHeader string
-			for _, line := range lines {
-				if strings.HasPrefix(line, "Expect:") {
-					expectHeader = strings.TrimSpace(strings.TrimPrefix(line, "Expect:"))
-					break
-				}
-			}
-			if expectHeader == "100-continue" {
-				//Read if the response from the server is 100-continue
-				resp, err := pUtil.ReadBytes(ctx, h.Logger, destConn)
-				if err != nil {
-					utils.LogError(h.Logger, err, "failed to read the response message from the server after 100-continue request")
-					errCh <- err
-					return nil
-				}
-
-				// write the response message to the client
-				_, err = clientConn.Write(resp)
-				if err != nil {
-					if ctx.Err() != nil {
-						return ctx.Err()
-					}
-					utils.LogError(h.Logger, err, "failed to write response message to the user client")
-					errCh <- err
-					return nil
-				}
-
-				h.Logger.Debug("This is the response from the server after the expect header" + string(resp))
-
-				if string(resp) != "HTTP/1.1 100 Continue\r\n\r\n" {
-					utils.LogError(h.Logger, nil, "failed to get the 100 continue response from the user client")
-					errCh <- err
-					return nil
-				}
-				//Reading the request buffer again
-				reqBuf, err = pUtil.ReadBytes(ctx, h.Logger, clientConn)
-				if err != nil {
-					utils.LogError(h.Logger, err, "failed to read the request buffer from the user client")
-					errCh <- err
-					return nil
-				}
-				// write the request message to the actual destination server
-				_, err = destConn.Write(reqBuf)
-				if err != nil {
-					if ctx.Err() != nil {
-						return ctx.Err()
-					}
-					utils.LogError(h.Logger, err, "failed to write request message to the destination server")
-					errCh <- err
-					return nil
-				}
-				finalReq = append(finalReq, reqBuf...)
-			}
-
-			// Capture the request timestamp
-			reqTimestampMock := time.Now()
-
-			err := h.HandleChunkedRequests(ctx, &finalReq, clientConn, destConn)
-			if err != nil {
-				utils.LogError(h.Logger, err, "failed to handle chunked requests")
-				errCh <- err
-				return nil
-			}
-
-			h.Logger.Debug(fmt.Sprintf("This is the complete request:\n%v", string(finalReq)))
-			// read the response from the actual server
-			resp, err := pUtil.ReadBytes(ctx, h.Logger, destConn)
-			if err != nil {
-				if err == io.EOF {
-					h.Logger.Debug("Response complete, exiting the loop.")
-					// if there is any buffer left before EOF, we must send it to the client and save this as mock
-					if len(resp) != 0 {
-						// Capturing the response timestamp
-						resTimestampMock := time.Now()
-						// write the response message to the user client
-						_, err = clientConn.Write(resp)
-						if err != nil {
-							if ctx.Err() != nil {
-								return ctx.Err()
-							}
-							utils.LogError(h.Logger, err, "failed to write response message to the user client")
-							errCh <- err
-							return nil
-						}
-
-						// saving last request/response on this conn.
-						m := &FinalHTTP{
-							Req:              finalReq,
-							Resp:             resp,
-							ReqTimestampMock: reqTimestampMock,
-							ResTimestampMock: resTimestampMock,
-						}
-						err := h.parseFinalHTTP(ctx, m, destPort, mocks, opts)
-						if err != nil {
-							utils.LogError(h.Logger, err, "failed to parse the final http request and response")
-							errCh <- err
-							return nil
-						}
-					}
-					break
-				}
-				utils.LogError(h.Logger, err, "failed to read the response message from the destination server")
-				errCh <- err
-				return nil
-			}
-
-			// Capturing the response timestamp
-			resTimestampMock := time.Now()
-
-			// write the response message to the user client
-			_, err = clientConn.Write(resp)
-			if err != nil {
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-				utils.LogError(h.Logger, err, "failed to write response message to the user client")
-				errCh <- err
-				return nil
-			}
-			var finalResp []byte
-			finalResp = append(finalResp, resp...)
-			h.Logger.Debug("This is the initial response: " + string(resp))
-
-			err = h.handleChunkedResponses(ctx, &finalResp, clientConn, destConn, resp)
-			if err != nil {
-				if err == io.EOF {
-					h.Logger.Debug("conn closed by the server", zap.Error(err))
-					//check if before EOF complete response came, and try to parse it.
-					m := &FinalHTTP{
-						Req:              finalReq,
-						Resp:             finalResp,
-						ReqTimestampMock: reqTimestampMock,
-						ResTimestampMock: resTimestampMock,
-					}
-					parseErr := h.parseFinalHTTP(ctx, m, destPort, mocks, opts)
-					if parseErr != nil {
-						utils.LogError(h.Logger, parseErr, "failed to parse the final http request and response")
-						errCh <- parseErr
-					}
-					errCh <- nil
-					return nil
-				}
-				utils.LogError(h.Logger, err, "failed to handle chunk response")
-				errCh <- err
-				return nil
-			}
-
-			h.Logger.Debug("This is the final response: " + string(finalResp))
-
-			m := &FinalHTTP{
-				Req:              finalReq,
-				Resp:             finalResp,
-				ReqTimestampMock: reqTimestampMock,
-				ResTimestampMock: resTimestampMock,
-			}
-
-			err = h.parseFinalHTTP(ctx, m, destPort, mocks, opts)
-			if err != nil {
-				utils.LogError(h.Logger, err, "failed to parse the final http request and response")
-				errCh <- err
-				return nil
-			}
-
-			//resetting for the new request and response.
-			finalReq = []byte("")
-			finalResp = []byte("")
-
-			// read the request from the same connection
-			h.Logger.Debug("Reading the request from the user client again from the same connection")
-
-			finalReq, err = pUtil.ReadBytes(ctx, h.Logger, clientConn)
-			if err != nil {
-				if err != io.EOF {
-					h.Logger.Debug("failed to read the request message from the user client", zap.Error(err))
-					h.Logger.Debug("This was the last response from the server: " + string(resp))
-					errCh <- nil
-					return nil
-				}
-				errCh <- err
-				return nil
-			}
-			// write the request message to the actual destination server
-			_, err = destConn.Write(finalReq)
-			if err != nil {
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-				utils.LogError(h.Logger, err, "failed to write request message to the destination server")
-				errCh <- err
-				return nil
-			}
-		}
+		defer close(clientBuffChan)
+		pUtil.ReadBuffConn(ctx, h.Logger, clientConn, clientBuffChan, errChan, false)
 		return nil
 	})
 
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case err := <-errCh:
-		if err == io.EOF {
-			return nil
+	// Read from destination.
+	g.Go(func() error {
+		defer pUtil.Recover(h.Logger, clientConn, destConn)
+		defer close(destBuffChan)
+		pUtil.ReadBuffConn(ctx, h.Logger, destConn, destBuffChan, errChan, false)
+		return nil
+	})
+
+	go func() {
+		defer pUtil.Recover(h.Logger, clientConn, destConn)
+		err := g.Wait()
+		if err != nil {
+			h.Logger.Debug("error group is returning an error", zap.Error(err))
 		}
-		return err
+		close(errChan)
+	}()
+
+	// Async decode channel and background goroutine.
+	decodeChan := make(chan httpDecodeItem, 512)
+	decodeDone := make(chan struct{})
+	go func() {
+		defer pUtil.Recover(h.Logger, clientConn, destConn)
+		defer close(decodeDone)
+		h.asyncHTTPDecode(ctx, decodeChan, destPort, mocks, opts)
+	}()
+
+	// Seed initial request buffer into decode channel.
+	initialBuf := make([]byte, len(reqBuf))
+	copy(initialBuf, reqBuf)
+	decodeChan <- httpDecodeItem{fromClient: true, data: initialBuf, ts: time.Now()}
+
+	// Main loop: forward only, send copies for async decode.
+	for {
+		select {
+		case <-ctx.Done():
+			close(decodeChan)
+			<-decodeDone
+			return ctx.Err()
+
+		case buffer, ok := <-clientBuffChan:
+			if !ok {
+				clientBuffChan = nil
+				continue
+			}
+			if buffer == nil {
+				continue
+			}
+
+			// Forward to destination immediately — critical path.
+			_, err := destConn.Write(buffer)
+			if err != nil {
+				utils.LogError(h.Logger, err, "failed to write request to destination server")
+				close(decodeChan)
+				<-decodeDone
+				return err
+			}
+
+			// Non-blocking send to async decode.
+			if !memoryguard.IsRecordingPaused() && len(decodeChan) < cap(decodeChan) {
+				buf := make([]byte, len(buffer))
+				copy(buf, buffer)
+				select {
+				case decodeChan <- httpDecodeItem{fromClient: true, data: buf, ts: time.Now()}:
+				default:
+				}
+			}
+
+		case buffer, ok := <-destBuffChan:
+			if !ok {
+				destBuffChan = nil
+				continue
+			}
+			if buffer == nil {
+				continue
+			}
+
+			// Forward to client immediately — critical path.
+			_, err := clientConn.Write(buffer)
+			if err != nil {
+				utils.LogError(h.Logger, err, "failed to write response to client")
+				close(decodeChan)
+				<-decodeDone
+				return err
+			}
+
+			// Non-blocking send to async decode.
+			if !memoryguard.IsRecordingPaused() && len(decodeChan) < cap(decodeChan) {
+				buf := make([]byte, len(buffer))
+				copy(buf, buffer)
+				select {
+				case decodeChan <- httpDecodeItem{fromClient: false, data: buf, ts: time.Now()}:
+				default:
+				}
+			}
+
+		case err, ok := <-errChan:
+			if !ok || err == nil {
+				close(decodeChan)
+				<-decodeDone
+				return nil
+			}
+
+			// Drain buffered data before exiting.
+		drain:
+			for {
+				select {
+				case buf, ok := <-clientBuffChan:
+					if !ok {
+						clientBuffChan = nil
+						continue
+					}
+					if buf == nil {
+						continue
+					}
+					_, _ = destConn.Write(buf)
+				case buf, ok := <-destBuffChan:
+					if !ok {
+						destBuffChan = nil
+						continue
+					}
+					if buf == nil {
+						continue
+					}
+					_, _ = clientConn.Write(buf)
+				default:
+					break drain
+				}
+			}
+
+			close(decodeChan)
+			<-decodeDone
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
 	}
+}
+
+// forwardHTTPBidirectional does raw TCP passthrough without any capture.
+func forwardHTTPBidirectional(clientConn, destConn net.Conn) error {
+	done := make(chan struct{}, 2)
+	cp := func(dst, src net.Conn) {
+		_, _ = io.Copy(dst, src)
+		done <- struct{}{}
+	}
+	go cp(destConn, clientConn)
+	go cp(clientConn, destConn)
+	<-done
+	<-done
+	return nil
+}
+
+// is100Continue returns true if the data starts with an HTTP 100 Continue
+// response, which is an intermediate response before the actual response.
+func is100Continue(data []byte) bool {
+	return bytes.HasPrefix(data, []byte("HTTP/1.1 100")) ||
+		bytes.HasPrefix(data, []byte("HTTP/1.0 100"))
+}
+
+// asyncHTTPDecode runs in a background goroutine and processes forwarded
+// chunks. It uses direction-alternation to detect HTTP message boundaries:
+// all consecutive client chunks form a request, all consecutive dest chunks
+// form a response. When direction changes, the previous exchange is complete
+// and gets parsed/recorded.
+func (h *HTTP) asyncHTTPDecode(ctx context.Context, decodeChan <-chan httpDecodeItem, destPort uint, mocks chan<- *models.Mock, opts models.OutgoingOptions) {
+	var reqBuf []byte
+	var respBuf []byte
+	var reqTimestamp time.Time
+	var resTimestamp time.Time
+	prevWasClient := true // first chunk is always a request (seeded initial reqBuf)
+
+	flushMock := func() {
+		if len(reqBuf) == 0 || len(respBuf) == 0 {
+			return
+		}
+		m := &FinalHTTP{
+			Req:              reqBuf,
+			Resp:             respBuf,
+			ReqTimestampMock: reqTimestamp,
+			ResTimestampMock: resTimestamp,
+		}
+		err := h.parseFinalHTTP(ctx, m, destPort, mocks, opts)
+		if err != nil {
+			h.Logger.Debug("failed to parse HTTP request/response in async decoder", zap.Error(err))
+		}
+		reqBuf = nil
+		respBuf = nil
+	}
+
+	for item := range decodeChan {
+		if item.fromClient {
+			if !prevWasClient && len(reqBuf) > 0 && len(respBuf) > 0 {
+				// Direction changed from dest→client.
+				// Check if the accumulated response is just a 100 Continue.
+				if is100Continue(respBuf) {
+					// 100 Continue is an intermediate response — the actual
+					// response hasn't arrived yet. Append the 100 Continue
+					// to the request buffer as part of the full exchange and
+					// keep accumulating.
+					reqBuf = append(reqBuf, respBuf...)
+					respBuf = nil
+					reqBuf = append(reqBuf, item.data...)
+					prevWasClient = true
+					continue
+				}
+				// Normal case: previous request-response exchange is complete.
+				flushMock()
+				reqTimestamp = item.ts
+			}
+			if len(reqBuf) == 0 {
+				reqTimestamp = item.ts
+			}
+			reqBuf = append(reqBuf, item.data...)
+			prevWasClient = true
+		} else {
+			if prevWasClient && len(respBuf) == 0 {
+				resTimestamp = item.ts
+			}
+			respBuf = append(respBuf, item.data...)
+			resTimestamp = item.ts
+			prevWasClient = false
+		}
+	}
+
+	// Channel closed — flush remaining exchange.
+	flushMock()
 }

--- a/pkg/agent/proxy/integrations/http/encode.go
+++ b/pkg/agent/proxy/integrations/http/encode.go
@@ -8,8 +8,6 @@ import (
 	"net"
 	"time"
 
-	"golang.org/x/sync/errgroup"
-
 	"go.keploy.io/server/v3/pkg/agent/memoryguard"
 	pUtil "go.keploy.io/server/v3/pkg/agent/proxy/util"
 	"go.keploy.io/server/v3/pkg/models"
@@ -49,40 +47,47 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 		return forwardHTTPBidirectional(clientConn, destConn)
 	}
 
-	// Buffered channels let ReadBuffConn read ahead without waiting
-	// for the main loop, preventing TCP flow-control throttling.
+	// Buffered channels for raw byte relay. Each Read() result is sent
+	// immediately — no accumulation, no "wait for short read" like ReadBytes.
 	clientBuffChan := make(chan []byte, 256)
 	destBuffChan := make(chan []byte, 256)
-	errChan := make(chan error, 1)
+	errChan := make(chan error, 2)
 
-	g, ok := ctx.Value(models.ErrGroupKey).(*errgroup.Group)
-	if !ok {
-		return errors.New("failed to get the error group from the context")
+	// readRelay reads from conn in a loop and sends each chunk to ch.
+	// Returns on error, EOF, or context cancellation.
+	readRelay := func(conn net.Conn, ch chan<- []byte) {
+		defer close(ch)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			buf := make([]byte, 32*1024)
+			n, err := conn.Read(buf)
+			if n > 0 {
+				ch <- buf[:n]
+			}
+			if err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				if err != io.EOF {
+					utils.LogError(h.Logger, err, "failed to read from connection")
+				}
+				errChan <- err
+				return
+			}
+		}
 	}
-
-	// Read requests from client.
-	g.Go(func() error {
-		defer pUtil.Recover(h.Logger, clientConn, destConn)
-		defer close(clientBuffChan)
-		pUtil.ReadBuffConn(ctx, h.Logger, clientConn, clientBuffChan, errChan, false)
-		return nil
-	})
-
-	// Read responses from destination.
-	g.Go(func() error {
-		defer pUtil.Recover(h.Logger, clientConn, destConn)
-		defer close(destBuffChan)
-		pUtil.ReadBuffConn(ctx, h.Logger, destConn, destBuffChan, errChan, false)
-		return nil
-	})
 
 	go func() {
 		defer pUtil.Recover(h.Logger, clientConn, destConn)
-		err := g.Wait()
-		if err != nil {
-			h.Logger.Debug("error group is returning an error", zap.Error(err))
-		}
-		close(errChan)
+		readRelay(clientConn, clientBuffChan)
+	}()
+	go func() {
+		defer pUtil.Recover(h.Logger, clientConn, destConn)
+		readRelay(destConn, destBuffChan)
 	}()
 
 	// Async decode channel and background goroutine.

--- a/pkg/agent/proxy/integrations/http/encode.go
+++ b/pkg/agent/proxy/integrations/http/encode.go
@@ -134,7 +134,9 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 				return err
 			}
 
-			// Non-blocking send to async decode.
+			// Non-blocking send to async decode. Check channel capacity
+			// before copying to avoid allocation/GC churn when the decoder
+			// can't keep up (the copy would just be dropped).
 			if !memoryguard.IsRecordingPaused() && len(decodeChan) < cap(decodeChan) {
 				buf := make([]byte, len(buffer))
 				copy(buf, buffer)
@@ -177,7 +179,8 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 				return nil
 			}
 
-			// Drain buffered data before exiting.
+			// Drain buffered data before exiting — forward AND decode
+			// so the last response chunk isn't lost for mock creation.
 		drain:
 			for {
 				select {
@@ -190,6 +193,14 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 						continue
 					}
 					_, _ = destConn.Write(buf)
+					if !memoryguard.IsRecordingPaused() && len(decodeChan) < cap(decodeChan) {
+						cp := make([]byte, len(buf))
+						copy(cp, buf)
+						select {
+						case decodeChan <- httpDecodeItem{fromClient: true, data: cp, ts: time.Now()}:
+						default:
+						}
+					}
 				case buf, ok := <-destBuffChan:
 					if !ok {
 						destBuffChan = nil
@@ -199,6 +210,14 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 						continue
 					}
 					_, _ = clientConn.Write(buf)
+					if !memoryguard.IsRecordingPaused() && len(decodeChan) < cap(decodeChan) {
+						cp := make([]byte, len(buf))
+						copy(cp, buf)
+						select {
+						case decodeChan <- httpDecodeItem{fromClient: false, data: cp, ts: time.Now()}:
+						default:
+						}
+					}
 				default:
 					break drain
 				}

--- a/pkg/agent/proxy/integrations/http/encode.go
+++ b/pkg/agent/proxy/integrations/http/encode.go
@@ -8,8 +8,6 @@ import (
 	"net"
 	"time"
 
-	"golang.org/x/sync/errgroup"
-
 	"go.keploy.io/server/v3/pkg/agent/memoryguard"
 	pUtil "go.keploy.io/server/v3/pkg/agent/proxy/util"
 	"go.keploy.io/server/v3/pkg/models"
@@ -49,42 +47,41 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 		return forwardHTTPBidirectional(clientConn, destConn)
 	}
 
-	g, ok := ctx.Value(models.ErrGroupKey).(*errgroup.Group)
-	if !ok {
-		return errors.New("failed to get the error group from the context")
-	}
-
 	// Buffered channels let ReadBuffConn read ahead without waiting
 	// for the main loop, preventing TCP flow-control throttling.
 	clientBuffChan := make(chan []byte, 256)
 	destBuffChan := make(chan []byte, 256)
-	errChan := make(chan error, 1)
+	// errChan capacity is 2 so both ReadBuffConn goroutines can send
+	// their errors without blocking, even if they error simultaneously.
+	errChan := make(chan error, 2)
 
-	// Read from client. stopOnRecordingPause is false: the main loop
-	// skips sending to decodeChan when paused, so recording stops while
-	// forwarding continues through the same goroutines.
-	g.Go(func() error {
-		defer pUtil.Recover(h.Logger, clientConn, destConn)
-		defer close(clientBuffChan)
-		pUtil.ReadBuffConn(ctx, h.Logger, clientConn, clientBuffChan, errChan, false)
-		return nil
-	})
-
-	// Read from destination.
-	g.Go(func() error {
-		defer pUtil.Recover(h.Logger, clientConn, destConn)
-		defer close(destBuffChan)
-		pUtil.ReadBuffConn(ctx, h.Logger, destConn, destBuffChan, errChan, false)
-		return nil
-	})
-
+	// ReadBuffConn goroutines are standalone (NOT added to the shared
+	// parserErrGrp) to avoid a deadlock: ReadBuffConn's blocking
+	// errChannel send has no ctx.Done() fallback, so if both goroutines
+	// error at the same time, one blocks forever in the shared errgroup.
+	readersDone := make(chan struct{})
 	go func() {
-		defer pUtil.Recover(h.Logger, clientConn, destConn)
-		err := g.Wait()
-		if err != nil {
-			h.Logger.Debug("error group is returning an error", zap.Error(err))
-		}
-		close(errChan)
+		defer close(readersDone)
+
+		clientDone := make(chan struct{})
+		destDone := make(chan struct{})
+
+		go func() {
+			defer pUtil.Recover(h.Logger, clientConn, destConn)
+			defer close(clientBuffChan)
+			defer close(clientDone)
+			pUtil.ReadBuffConn(ctx, h.Logger, clientConn, clientBuffChan, errChan, false)
+		}()
+
+		go func() {
+			defer pUtil.Recover(h.Logger, clientConn, destConn)
+			defer close(destBuffChan)
+			defer close(destDone)
+			pUtil.ReadBuffConn(ctx, h.Logger, destConn, destBuffChan, errChan, false)
+		}()
+
+		<-clientDone
+		<-destDone
 	}()
 
 	// Async decode channel and background goroutine.
@@ -101,12 +98,18 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 	copy(initialBuf, reqBuf)
 	decodeChan <- httpDecodeItem{fromClient: true, data: initialBuf, ts: time.Now()}
 
+	// cleanup ensures all goroutines are stopped before we return.
+	cleanup := func() {
+		close(decodeChan)
+		<-decodeDone
+		<-readersDone
+	}
+
 	// Main loop: forward only, send copies for async decode.
 	for {
 		select {
 		case <-ctx.Done():
-			close(decodeChan)
-			<-decodeDone
+			cleanup()
 			return ctx.Err()
 
 		case buffer, ok := <-clientBuffChan:
@@ -122,8 +125,7 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 			_, err := destConn.Write(buffer)
 			if err != nil {
 				utils.LogError(h.Logger, err, "failed to write request to destination server")
-				close(decodeChan)
-				<-decodeDone
+				cleanup()
 				return err
 			}
 
@@ -150,8 +152,7 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 			_, err := clientConn.Write(buffer)
 			if err != nil {
 				utils.LogError(h.Logger, err, "failed to write response to client")
-				close(decodeChan)
-				<-decodeDone
+				cleanup()
 				return err
 			}
 
@@ -167,8 +168,7 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 
 		case err, ok := <-errChan:
 			if !ok || err == nil {
-				close(decodeChan)
-				<-decodeDone
+				cleanup()
 				return nil
 			}
 
@@ -199,8 +199,7 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 				}
 			}
 
-			close(decodeChan)
-			<-decodeDone
+			cleanup()
 			if errors.Is(err, io.EOF) {
 				return nil
 			}

--- a/pkg/agent/proxy/integrations/http/encode.go
+++ b/pkg/agent/proxy/integrations/http/encode.go
@@ -18,12 +18,16 @@ import (
 	"go.uber.org/zap"
 )
 
-// encodeHTTP function parses the HTTP request and response text messages to capture outgoing network calls as mocks.
+// encodeHTTP records outgoing HTTP traffic. The read/forward/chunked-handling
+// logic is identical to the original synchronous implementation. The only
+// difference is that parseFinalHTTP (HTTP parsing, body decompression, mock
+// creation) is offloaded to a background goroutine so it never blocks the
+// forwarding path.
 func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destConn net.Conn, mocks chan<- *models.Mock, opts models.OutgoingOptions) error {
 	remoteAddr := destConn.RemoteAddr().(*net.TCPAddr)
 	destPort := uint(remoteAddr.Port)
 
-	//Writing the request to the server.
+	// Forward initial request to server.
 	_, err := destConn.Write(reqBuf)
 	if err != nil {
 		h.Logger.Error("failed to write request message to the destination server", zap.Error(err))
@@ -40,16 +44,56 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 
 	finalReq = append(finalReq, reqBuf...)
 
-	//get the error group from the context
+	// Get the error group from the context.
 	g, ok := ctx.Value(models.ErrGroupKey).(*errgroup.Group)
 	if !ok {
 		return errors.New("failed to get the error group from the context")
 	}
 
-	//for keeping conn alive
+	// Async mock recorder: parseFinalHTTP runs here off the forwarding path.
+	// The channel is buffered so the forwarding goroutine never blocks on send.
+	mockDataCh := make(chan *FinalHTTP, 256)
+	recorderDone := make(chan struct{})
+	recordCtx := context.WithoutCancel(ctx)
+	go func() {
+		defer pUtil.Recover(h.Logger, clientConn, destConn)
+		defer close(recorderDone)
+		for m := range mockDataCh {
+			err := h.parseFinalHTTP(recordCtx, m, destPort, mocks, opts)
+			if err != nil {
+				utils.LogError(h.Logger, err, "failed to parse the final http request and response")
+			}
+		}
+	}()
+
+	// enqueueMock sends a paired request/response for async mock creation.
+	// Non-blocking: if the recorder can't keep up, the mock is dropped
+	// (same pattern as postgres/mongo).
+	enqueueMock := func(req, resp []byte, reqTs, resTs time.Time) {
+		m := &FinalHTTP{
+			Req:              req,
+			Resp:             resp,
+			ReqTimestampMock: reqTs,
+			ResTimestampMock: resTs,
+		}
+		select {
+		case mockDataCh <- m:
+		default:
+			h.Logger.Debug("HTTP mock channel full, dropping mock")
+		}
+	}
+
+	// Main forwarding goroutine — logic is identical to the original
+	// synchronous implementation. Only parseFinalHTTP calls are replaced
+	// with enqueueMock sends.
 	g.Go(func() error {
 		defer pUtil.Recover(h.Logger, clientConn, destConn)
 		defer close(errCh)
+		defer func() {
+			close(mockDataCh)
+			<-recorderDone
+		}()
+
 		for {
 			if memoryguard.IsRecordingPaused() {
 				h.Logger.Debug("memory pressure detected, stopping HTTP recording and falling back to passthrough")
@@ -65,7 +109,7 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 				return nil
 			}
 
-			//check if expect : 100-continue header is present
+			// Check if expect: 100-continue header is present.
 			lines := strings.Split(string(finalReq), "\n")
 			var expectHeader string
 			for _, line := range lines {
@@ -75,7 +119,6 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 				}
 			}
 			if expectHeader == "100-continue" {
-				//Read if the response from the server is 100-continue
 				resp, err := pUtil.ReadBytes(ctx, h.Logger, destConn)
 				if err != nil {
 					utils.LogError(h.Logger, err, "failed to read the response message from the server after 100-continue request")
@@ -83,7 +126,6 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 					return nil
 				}
 
-				// write the response message to the client
 				_, err = clientConn.Write(resp)
 				if err != nil {
 					if ctx.Err() != nil {
@@ -101,14 +143,12 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 					errCh <- err
 					return nil
 				}
-				//Reading the request buffer again
 				reqBuf, err = pUtil.ReadBytes(ctx, h.Logger, clientConn)
 				if err != nil {
 					utils.LogError(h.Logger, err, "failed to read the request buffer from the user client")
 					errCh <- err
 					return nil
 				}
-				// write the request message to the actual destination server
 				_, err = destConn.Write(reqBuf)
 				if err != nil {
 					if ctx.Err() != nil {
@@ -121,7 +161,7 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 				finalReq = append(finalReq, reqBuf...)
 			}
 
-			// Capture the request timestamp
+			// Capture the request timestamp.
 			reqTimestampMock := time.Now()
 
 			err := h.HandleChunkedRequests(ctx, &finalReq, clientConn, destConn)
@@ -132,16 +172,14 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 			}
 
 			h.Logger.Debug(fmt.Sprintf("This is the complete request:\n%v", string(finalReq)))
-			// read the response from the actual server
+
+			// Read the response from the actual server.
 			resp, err := pUtil.ReadBytes(ctx, h.Logger, destConn)
 			if err != nil {
 				if err == io.EOF {
 					h.Logger.Debug("Response complete, exiting the loop.")
-					// if there is any buffer left before EOF, we must send it to the client and save this as mock
 					if len(resp) != 0 {
-						// Capturing the response timestamp
 						resTimestampMock := time.Now()
-						// write the response message to the user client
 						_, err = clientConn.Write(resp)
 						if err != nil {
 							if ctx.Err() != nil {
@@ -151,20 +189,7 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 							errCh <- err
 							return nil
 						}
-
-						// saving last request/response on this conn.
-						m := &FinalHTTP{
-							Req:              finalReq,
-							Resp:             resp,
-							ReqTimestampMock: reqTimestampMock,
-							ResTimestampMock: resTimestampMock,
-						}
-						err := h.parseFinalHTTP(ctx, m, destPort, mocks, opts)
-						if err != nil {
-							utils.LogError(h.Logger, err, "failed to parse the final http request and response")
-							errCh <- err
-							return nil
-						}
+						enqueueMock(finalReq, resp, reqTimestampMock, resTimestampMock)
 					}
 					break
 				}
@@ -173,10 +198,9 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 				return nil
 			}
 
-			// Capturing the response timestamp
 			resTimestampMock := time.Now()
 
-			// write the response message to the user client
+			// Forward response to client.
 			_, err = clientConn.Write(resp)
 			if err != nil {
 				if ctx.Err() != nil {
@@ -194,18 +218,7 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 			if err != nil {
 				if err == io.EOF {
 					h.Logger.Debug("conn closed by the server", zap.Error(err))
-					//check if before EOF complete response came, and try to parse it.
-					m := &FinalHTTP{
-						Req:              finalReq,
-						Resp:             finalResp,
-						ReqTimestampMock: reqTimestampMock,
-						ResTimestampMock: resTimestampMock,
-					}
-					parseErr := h.parseFinalHTTP(ctx, m, destPort, mocks, opts)
-					if parseErr != nil {
-						utils.LogError(h.Logger, parseErr, "failed to parse the final http request and response")
-						errCh <- parseErr
-					}
+					enqueueMock(finalReq, finalResp, reqTimestampMock, resTimestampMock)
 					errCh <- nil
 					return nil
 				}
@@ -216,25 +229,13 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 
 			h.Logger.Debug("This is the final response: " + string(finalResp))
 
-			m := &FinalHTTP{
-				Req:              finalReq,
-				Resp:             finalResp,
-				ReqTimestampMock: reqTimestampMock,
-				ResTimestampMock: resTimestampMock,
-			}
+			// Offload mock creation to async recorder.
+			enqueueMock(finalReq, finalResp, reqTimestampMock, resTimestampMock)
 
-			err = h.parseFinalHTTP(ctx, m, destPort, mocks, opts)
-			if err != nil {
-				utils.LogError(h.Logger, err, "failed to parse the final http request and response")
-				errCh <- err
-				return nil
-			}
-
-			//resetting for the new request and response.
+			// Reset for the next request and response.
 			finalReq = []byte("")
-			finalResp = []byte("")
 
-			// read the request from the same connection
+			// Read the next request from the client.
 			h.Logger.Debug("Reading the request from the user client again from the same connection")
 
 			finalReq, err = pUtil.ReadBytes(ctx, h.Logger, clientConn)
@@ -248,7 +249,7 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 				errCh <- err
 				return nil
 			}
-			// write the request message to the actual destination server
+			// Forward the next request to server.
 			_, err = destConn.Write(finalReq)
 			if err != nil {
 				if ctx.Err() != nil {

--- a/pkg/agent/proxy/integrations/http/encode.go
+++ b/pkg/agent/proxy/integrations/http/encode.go
@@ -1,12 +1,15 @@
 package http
 
 import (
-	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net"
+	"strings"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"go.keploy.io/server/v3/pkg/agent/memoryguard"
 	pUtil "go.keploy.io/server/v3/pkg/agent/proxy/util"
@@ -15,22 +18,12 @@ import (
 	"go.uber.org/zap"
 )
 
-// httpDecodeItem carries a forwarded chunk to the async decode goroutine.
-type httpDecodeItem struct {
-	fromClient bool
-	data       []byte
-	ts         time.Time
-}
-
-// encodeHTTP records outgoing HTTP traffic. Forwarding runs in the main
-// select loop at wire speed. All HTTP message reassembly, parsing, and
-// mock creation is offloaded to a background goroutine via a buffered
-// decode channel, so it never slows the data path.
+// encodeHTTP function parses the HTTP request and response text messages to capture outgoing network calls as mocks.
 func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destConn net.Conn, mocks chan<- *models.Mock, opts models.OutgoingOptions) error {
 	remoteAddr := destConn.RemoteAddr().(*net.TCPAddr)
 	destPort := uint(remoteAddr.Port)
 
-	// Forward initial request to destination immediately — critical path.
+	//Writing the request to the server.
 	_, err := destConn.Write(reqBuf)
 	if err != nil {
 		h.Logger.Error("failed to write request message to the destination server", zap.Error(err))
@@ -41,282 +34,241 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 		return ctx.Err()
 	}
 
-	// If recording is already paused, pure passthrough.
-	if memoryguard.IsRecordingPaused() {
-		h.Logger.Debug("memory pressure detected, stopping HTTP recording and falling back to passthrough")
-		return forwardHTTPBidirectional(clientConn, destConn)
+	h.Logger.Debug("This is the initial request: " + string(reqBuf))
+	var finalReq []byte
+	errCh := make(chan error, 1)
+
+	finalReq = append(finalReq, reqBuf...)
+
+	//get the error group from the context
+	g, ok := ctx.Value(models.ErrGroupKey).(*errgroup.Group)
+	if !ok {
+		return errors.New("failed to get the error group from the context")
 	}
 
-	// Buffered channels for raw byte relay. Each Read() result is sent
-	// immediately — no accumulation, no "wait for short read" like ReadBytes.
-	clientBuffChan := make(chan []byte, 256)
-	destBuffChan := make(chan []byte, 256)
-	errChan := make(chan error, 2)
-
-	// readRelay reads from conn in a loop and sends each chunk to ch.
-	// Returns on error, EOF, or context cancellation.
-	readRelay := func(conn net.Conn, ch chan<- []byte) {
-		defer close(ch)
+	//for keeping conn alive
+	g.Go(func() error {
+		defer pUtil.Recover(h.Logger, clientConn, destConn)
+		defer close(errCh)
 		for {
-			select {
-			case <-ctx.Done():
-				return
-			default:
+			if memoryguard.IsRecordingPaused() {
+				h.Logger.Debug("memory pressure detected, stopping HTTP recording and falling back to passthrough")
+				done := make(chan struct{}, 2)
+				cp := func(dst, src net.Conn) {
+					_, _ = io.Copy(dst, src)
+					done <- struct{}{}
+				}
+				go cp(destConn, clientConn)
+				go cp(clientConn, destConn)
+				<-done
+				<-done
+				return nil
 			}
-			buf := make([]byte, 32*1024)
-			n, err := conn.Read(buf)
-			if n > 0 {
-				ch <- buf[:n]
+
+			//check if expect : 100-continue header is present
+			lines := strings.Split(string(finalReq), "\n")
+			var expectHeader string
+			for _, line := range lines {
+				if strings.HasPrefix(line, "Expect:") {
+					expectHeader = strings.TrimSpace(strings.TrimPrefix(line, "Expect:"))
+					break
+				}
 			}
+			if expectHeader == "100-continue" {
+				//Read if the response from the server is 100-continue
+				resp, err := pUtil.ReadBytes(ctx, h.Logger, destConn)
+				if err != nil {
+					utils.LogError(h.Logger, err, "failed to read the response message from the server after 100-continue request")
+					errCh <- err
+					return nil
+				}
+
+				// write the response message to the client
+				_, err = clientConn.Write(resp)
+				if err != nil {
+					if ctx.Err() != nil {
+						return ctx.Err()
+					}
+					utils.LogError(h.Logger, err, "failed to write response message to the user client")
+					errCh <- err
+					return nil
+				}
+
+				h.Logger.Debug("This is the response from the server after the expect header" + string(resp))
+
+				if string(resp) != "HTTP/1.1 100 Continue\r\n\r\n" {
+					utils.LogError(h.Logger, nil, "failed to get the 100 continue response from the user client")
+					errCh <- err
+					return nil
+				}
+				//Reading the request buffer again
+				reqBuf, err = pUtil.ReadBytes(ctx, h.Logger, clientConn)
+				if err != nil {
+					utils.LogError(h.Logger, err, "failed to read the request buffer from the user client")
+					errCh <- err
+					return nil
+				}
+				// write the request message to the actual destination server
+				_, err = destConn.Write(reqBuf)
+				if err != nil {
+					if ctx.Err() != nil {
+						return ctx.Err()
+					}
+					utils.LogError(h.Logger, err, "failed to write request message to the destination server")
+					errCh <- err
+					return nil
+				}
+				finalReq = append(finalReq, reqBuf...)
+			}
+
+			// Capture the request timestamp
+			reqTimestampMock := time.Now()
+
+			err := h.HandleChunkedRequests(ctx, &finalReq, clientConn, destConn)
+			if err != nil {
+				utils.LogError(h.Logger, err, "failed to handle chunked requests")
+				errCh <- err
+				return nil
+			}
+
+			h.Logger.Debug(fmt.Sprintf("This is the complete request:\n%v", string(finalReq)))
+			// read the response from the actual server
+			resp, err := pUtil.ReadBytes(ctx, h.Logger, destConn)
+			if err != nil {
+				if err == io.EOF {
+					h.Logger.Debug("Response complete, exiting the loop.")
+					// if there is any buffer left before EOF, we must send it to the client and save this as mock
+					if len(resp) != 0 {
+						// Capturing the response timestamp
+						resTimestampMock := time.Now()
+						// write the response message to the user client
+						_, err = clientConn.Write(resp)
+						if err != nil {
+							if ctx.Err() != nil {
+								return ctx.Err()
+							}
+							utils.LogError(h.Logger, err, "failed to write response message to the user client")
+							errCh <- err
+							return nil
+						}
+
+						// saving last request/response on this conn.
+						m := &FinalHTTP{
+							Req:              finalReq,
+							Resp:             resp,
+							ReqTimestampMock: reqTimestampMock,
+							ResTimestampMock: resTimestampMock,
+						}
+						err := h.parseFinalHTTP(ctx, m, destPort, mocks, opts)
+						if err != nil {
+							utils.LogError(h.Logger, err, "failed to parse the final http request and response")
+							errCh <- err
+							return nil
+						}
+					}
+					break
+				}
+				utils.LogError(h.Logger, err, "failed to read the response message from the destination server")
+				errCh <- err
+				return nil
+			}
+
+			// Capturing the response timestamp
+			resTimestampMock := time.Now()
+
+			// write the response message to the user client
+			_, err = clientConn.Write(resp)
 			if err != nil {
 				if ctx.Err() != nil {
-					return
+					return ctx.Err()
 				}
+				utils.LogError(h.Logger, err, "failed to write response message to the user client")
+				errCh <- err
+				return nil
+			}
+			var finalResp []byte
+			finalResp = append(finalResp, resp...)
+			h.Logger.Debug("This is the initial response: " + string(resp))
+
+			err = h.handleChunkedResponses(ctx, &finalResp, clientConn, destConn, resp)
+			if err != nil {
+				if err == io.EOF {
+					h.Logger.Debug("conn closed by the server", zap.Error(err))
+					//check if before EOF complete response came, and try to parse it.
+					m := &FinalHTTP{
+						Req:              finalReq,
+						Resp:             finalResp,
+						ReqTimestampMock: reqTimestampMock,
+						ResTimestampMock: resTimestampMock,
+					}
+					parseErr := h.parseFinalHTTP(ctx, m, destPort, mocks, opts)
+					if parseErr != nil {
+						utils.LogError(h.Logger, parseErr, "failed to parse the final http request and response")
+						errCh <- parseErr
+					}
+					errCh <- nil
+					return nil
+				}
+				utils.LogError(h.Logger, err, "failed to handle chunk response")
+				errCh <- err
+				return nil
+			}
+
+			h.Logger.Debug("This is the final response: " + string(finalResp))
+
+			m := &FinalHTTP{
+				Req:              finalReq,
+				Resp:             finalResp,
+				ReqTimestampMock: reqTimestampMock,
+				ResTimestampMock: resTimestampMock,
+			}
+
+			err = h.parseFinalHTTP(ctx, m, destPort, mocks, opts)
+			if err != nil {
+				utils.LogError(h.Logger, err, "failed to parse the final http request and response")
+				errCh <- err
+				return nil
+			}
+
+			//resetting for the new request and response.
+			finalReq = []byte("")
+			finalResp = []byte("")
+
+			// read the request from the same connection
+			h.Logger.Debug("Reading the request from the user client again from the same connection")
+
+			finalReq, err = pUtil.ReadBytes(ctx, h.Logger, clientConn)
+			if err != nil {
 				if err != io.EOF {
-					utils.LogError(h.Logger, err, "failed to read from connection")
+					h.Logger.Debug("failed to read the request message from the user client", zap.Error(err))
+					h.Logger.Debug("This was the last response from the server: " + string(resp))
+					errCh <- nil
+					return nil
 				}
-				errChan <- err
-				return
-			}
-		}
-	}
-
-	go func() {
-		defer pUtil.Recover(h.Logger, clientConn, destConn)
-		readRelay(clientConn, clientBuffChan)
-	}()
-	go func() {
-		defer pUtil.Recover(h.Logger, clientConn, destConn)
-		readRelay(destConn, destBuffChan)
-	}()
-
-	// Async decode channel and background goroutine.
-	decodeChan := make(chan httpDecodeItem, 512)
-	decodeDone := make(chan struct{})
-	go func() {
-		defer pUtil.Recover(h.Logger, clientConn, destConn)
-		defer close(decodeDone)
-		h.asyncHTTPDecode(ctx, decodeChan, destPort, mocks, opts)
-	}()
-
-	// Seed initial request buffer into decode channel.
-	initialBuf := make([]byte, len(reqBuf))
-	copy(initialBuf, reqBuf)
-	decodeChan <- httpDecodeItem{fromClient: true, data: initialBuf, ts: time.Now()}
-
-	// cleanup ensures the decode goroutine is stopped before we return.
-	cleanup := func() {
-		close(decodeChan)
-		<-decodeDone
-	}
-
-	// Main loop: forward only, send copies for async decode.
-	for {
-		select {
-		case <-ctx.Done():
-			cleanup()
-			return ctx.Err()
-
-		case buffer, ok := <-clientBuffChan:
-			if !ok {
-				clientBuffChan = nil
-				continue
-			}
-			if buffer == nil {
-				continue
-			}
-
-			// Forward to destination immediately — critical path.
-			_, err := destConn.Write(buffer)
-			if err != nil {
-				utils.LogError(h.Logger, err, "failed to write request to destination server")
-				cleanup()
-				return err
-			}
-
-			// Send to async decode — blocking with ctx escape so HTTP
-			// mocks are never silently lost due to channel pressure.
-			if !memoryguard.IsRecordingPaused() {
-				buf := make([]byte, len(buffer))
-				copy(buf, buffer)
-				select {
-				case decodeChan <- httpDecodeItem{fromClient: true, data: buf, ts: time.Now()}:
-				case <-ctx.Done():
-				}
-			}
-
-		case buffer, ok := <-destBuffChan:
-			if !ok {
-				destBuffChan = nil
-				continue
-			}
-			if buffer == nil {
-				continue
-			}
-
-			// Forward to client immediately — critical path.
-			_, err := clientConn.Write(buffer)
-			if err != nil {
-				utils.LogError(h.Logger, err, "failed to write response to client")
-				cleanup()
-				return err
-			}
-
-			// Send to async decode — blocking with ctx escape.
-			if !memoryguard.IsRecordingPaused() {
-				buf := make([]byte, len(buffer))
-				copy(buf, buffer)
-				select {
-				case decodeChan <- httpDecodeItem{fromClient: false, data: buf, ts: time.Now()}:
-				case <-ctx.Done():
-				}
-			}
-
-		case err, ok := <-errChan:
-			if !ok || err == nil {
-				cleanup()
+				errCh <- err
 				return nil
 			}
-
-			// Drain buffered data before exiting — forward AND decode
-			// so the last response chunk isn't lost for mock creation.
-		drain:
-			for {
-				select {
-				case buf, ok := <-clientBuffChan:
-					if !ok {
-						clientBuffChan = nil
-						continue
-					}
-					if buf == nil {
-						continue
-					}
-					_, _ = destConn.Write(buf)
-					if !memoryguard.IsRecordingPaused() {
-						cp := make([]byte, len(buf))
-						copy(cp, buf)
-						select {
-						case decodeChan <- httpDecodeItem{fromClient: true, data: cp, ts: time.Now()}:
-						case <-ctx.Done():
-						}
-					}
-				case buf, ok := <-destBuffChan:
-					if !ok {
-						destBuffChan = nil
-						continue
-					}
-					if buf == nil {
-						continue
-					}
-					_, _ = clientConn.Write(buf)
-					if !memoryguard.IsRecordingPaused() {
-						cp := make([]byte, len(buf))
-						copy(cp, buf)
-						select {
-						case decodeChan <- httpDecodeItem{fromClient: false, data: cp, ts: time.Now()}:
-						case <-ctx.Done():
-						}
-					}
-				default:
-					break drain
+			// write the request message to the actual destination server
+			_, err = destConn.Write(finalReq)
+			if err != nil {
+				if ctx.Err() != nil {
+					return ctx.Err()
 				}
-			}
-
-			cleanup()
-			if errors.Is(err, io.EOF) {
+				utils.LogError(h.Logger, err, "failed to write request message to the destination server")
+				errCh <- err
 				return nil
 			}
-			return err
 		}
+		return nil
+	})
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-errCh:
+		if err == io.EOF {
+			return nil
+		}
+		return err
 	}
-}
-
-// forwardHTTPBidirectional does raw TCP passthrough without any capture.
-func forwardHTTPBidirectional(clientConn, destConn net.Conn) error {
-	done := make(chan struct{}, 2)
-	cp := func(dst, src net.Conn) {
-		_, _ = io.Copy(dst, src)
-		done <- struct{}{}
-	}
-	go cp(destConn, clientConn)
-	go cp(clientConn, destConn)
-	<-done
-	<-done
-	return nil
-}
-
-// is100Continue returns true if the data starts with an HTTP 100 Continue
-// response, which is an intermediate response before the actual response.
-func is100Continue(data []byte) bool {
-	return bytes.HasPrefix(data, []byte("HTTP/1.1 100")) ||
-		bytes.HasPrefix(data, []byte("HTTP/1.0 100"))
-}
-
-// asyncHTTPDecode runs in a background goroutine and processes forwarded
-// chunks. It uses direction-alternation to detect HTTP message boundaries:
-// all consecutive client chunks form a request, all consecutive dest chunks
-// form a response. When direction changes, the previous exchange is complete
-// and gets parsed/recorded.
-func (h *HTTP) asyncHTTPDecode(ctx context.Context, decodeChan <-chan httpDecodeItem, destPort uint, mocks chan<- *models.Mock, opts models.OutgoingOptions) {
-	var reqBuf []byte
-	var respBuf []byte
-	var reqTimestamp time.Time
-	var resTimestamp time.Time
-	prevWasClient := true // first chunk is always a request (seeded initial reqBuf)
-
-	flushMock := func() {
-		if len(reqBuf) == 0 || len(respBuf) == 0 {
-			return
-		}
-		m := &FinalHTTP{
-			Req:              reqBuf,
-			Resp:             respBuf,
-			ReqTimestampMock: reqTimestamp,
-			ResTimestampMock: resTimestamp,
-		}
-		err := h.parseFinalHTTP(ctx, m, destPort, mocks, opts)
-		if err != nil {
-			h.Logger.Debug("failed to parse HTTP request/response in async decoder", zap.Error(err))
-		}
-		reqBuf = nil
-		respBuf = nil
-	}
-
-	for item := range decodeChan {
-		if item.fromClient {
-			if !prevWasClient && len(reqBuf) > 0 && len(respBuf) > 0 {
-				// Direction changed from dest→client.
-				// Check if the accumulated response is just a 100 Continue.
-				if is100Continue(respBuf) {
-					// 100 Continue is an intermediate response — the actual
-					// response hasn't arrived yet. Append the 100 Continue
-					// to the request buffer as part of the full exchange and
-					// keep accumulating.
-					reqBuf = append(reqBuf, respBuf...)
-					respBuf = nil
-					reqBuf = append(reqBuf, item.data...)
-					prevWasClient = true
-					continue
-				}
-				// Normal case: previous request-response exchange is complete.
-				flushMock()
-				reqTimestamp = item.ts
-			}
-			if len(reqBuf) == 0 {
-				reqTimestamp = item.ts
-			}
-			reqBuf = append(reqBuf, item.data...)
-			prevWasClient = true
-		} else {
-			if prevWasClient && len(respBuf) == 0 {
-				resTimestamp = item.ts
-			}
-			respBuf = append(respBuf, item.data...)
-			resTimestamp = item.ts
-			prevWasClient = false
-		}
-	}
-
-	// Channel closed — flush remaining exchange.
-	flushMock()
 }

--- a/pkg/agent/proxy/integrations/http/encode.go
+++ b/pkg/agent/proxy/integrations/http/encode.go
@@ -8,6 +8,8 @@ import (
 	"net"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"go.keploy.io/server/v3/pkg/agent/memoryguard"
 	pUtil "go.keploy.io/server/v3/pkg/agent/proxy/util"
 	"go.keploy.io/server/v3/pkg/models"
@@ -51,37 +53,36 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 	// for the main loop, preventing TCP flow-control throttling.
 	clientBuffChan := make(chan []byte, 256)
 	destBuffChan := make(chan []byte, 256)
-	// errChan capacity is 2 so both ReadBuffConn goroutines can send
-	// their errors without blocking, even if they error simultaneously.
-	errChan := make(chan error, 2)
+	errChan := make(chan error, 1)
 
-	// ReadBuffConn goroutines are standalone (NOT added to the shared
-	// parserErrGrp) to avoid a deadlock: ReadBuffConn's blocking
-	// errChannel send has no ctx.Done() fallback, so if both goroutines
-	// error at the same time, one blocks forever in the shared errgroup.
-	readersDone := make(chan struct{})
+	g, ok := ctx.Value(models.ErrGroupKey).(*errgroup.Group)
+	if !ok {
+		return errors.New("failed to get the error group from the context")
+	}
+
+	// Read requests from client.
+	g.Go(func() error {
+		defer pUtil.Recover(h.Logger, clientConn, destConn)
+		defer close(clientBuffChan)
+		pUtil.ReadBuffConn(ctx, h.Logger, clientConn, clientBuffChan, errChan, false)
+		return nil
+	})
+
+	// Read responses from destination.
+	g.Go(func() error {
+		defer pUtil.Recover(h.Logger, clientConn, destConn)
+		defer close(destBuffChan)
+		pUtil.ReadBuffConn(ctx, h.Logger, destConn, destBuffChan, errChan, false)
+		return nil
+	})
+
 	go func() {
-		defer close(readersDone)
-
-		clientDone := make(chan struct{})
-		destDone := make(chan struct{})
-
-		go func() {
-			defer pUtil.Recover(h.Logger, clientConn, destConn)
-			defer close(clientBuffChan)
-			defer close(clientDone)
-			pUtil.ReadBuffConn(ctx, h.Logger, clientConn, clientBuffChan, errChan, false)
-		}()
-
-		go func() {
-			defer pUtil.Recover(h.Logger, clientConn, destConn)
-			defer close(destBuffChan)
-			defer close(destDone)
-			pUtil.ReadBuffConn(ctx, h.Logger, destConn, destBuffChan, errChan, false)
-		}()
-
-		<-clientDone
-		<-destDone
+		defer pUtil.Recover(h.Logger, clientConn, destConn)
+		err := g.Wait()
+		if err != nil {
+			h.Logger.Debug("error group is returning an error", zap.Error(err))
+		}
+		close(errChan)
 	}()
 
 	// Async decode channel and background goroutine.
@@ -98,11 +99,10 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 	copy(initialBuf, reqBuf)
 	decodeChan <- httpDecodeItem{fromClient: true, data: initialBuf, ts: time.Now()}
 
-	// cleanup ensures all goroutines are stopped before we return.
+	// cleanup ensures the decode goroutine is stopped before we return.
 	cleanup := func() {
 		close(decodeChan)
 		<-decodeDone
-		<-readersDone
 	}
 
 	// Main loop: forward only, send copies for async decode.

--- a/pkg/agent/proxy/integrations/http/http.go
+++ b/pkg/agent/proxy/integrations/http/http.go
@@ -259,11 +259,22 @@ func (h *HTTP) parseFinalHTTP(ctx context.Context, mock *FinalHTTP, destPort uin
 	}
 
 	if mgr := syncMock.Get(); mgr != nil {
-		// In synchronous mode, always route HTTP mocks through the sync manager.
-		// The manager uses its internal first-request state to decide whether to
-		// buffer or forward mocks for correct time-window based association.
+		// Route HTTP mocks through the sync manager. The manager uses its
+		// internal first-request state to decide whether to buffer or forward
+		// mocks for correct time-window based association.
 		mgr.AddMock(newMock)
 		return nil
+	}
+
+	// Fallback: syncMock manager unavailable, send to mocks channel directly.
+	// Use select with ctx so we don't block forever during shutdown.
+	select {
+	case <-ctx.Done():
+		select {
+		case mocks <- newMock:
+		default:
+		}
+	case mocks <- newMock:
 	}
 	return nil
 }

--- a/pkg/agent/proxy/integrations/http/http.go
+++ b/pkg/agent/proxy/integrations/http/http.go
@@ -258,19 +258,12 @@ func (h *HTTP) parseFinalHTTP(ctx context.Context, mock *FinalHTTP, destPort uin
 		},
 	}
 
-	if opts.Synchronous {
-		if mgr := syncMock.Get(); mgr != nil {
-			// In synchronous mode, always route HTTP mocks through the sync manager.
-			// The manager uses its internal first-request state to decide whether to
-			// buffer or forward mocks for correct time-window based association.
-			mgr.AddMock(newMock)
-			return nil
-		}
-	}
-	// In non-synchronous mode (k8s-proxy), or if no manager is available,
-	// send directly to the mocks channel so the mock is persisted.
-	if mocks != nil {
-		mocks <- newMock
+	if mgr := syncMock.Get(); mgr != nil {
+		// In synchronous mode, always route HTTP mocks through the sync manager.
+		// The manager uses its internal first-request state to decide whether to
+		// buffer or forward mocks for correct time-window based association.
+		mgr.AddMock(newMock)
+		return nil
 	}
 	return nil
 }

--- a/pkg/agent/proxy/integrations/mysql/recorder/query.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/query.go
@@ -66,7 +66,11 @@ func handleClientQueries(ctx context.Context, logger *zap.Logger, clientConn, de
 			buf := make([]byte, 32*1024)
 			n, err := conn.Read(buf)
 			if n > 0 {
-				ch <- buf[:n]
+				select {
+				case ch <- buf[:n]:
+				case <-ctx.Done():
+					return
+				}
 			}
 			if err != nil {
 				if ctx.Err() != nil {
@@ -75,7 +79,10 @@ func handleClientQueries(ctx context.Context, logger *zap.Logger, clientConn, de
 				if err != io.EOF {
 					utils.LogError(logger, err, "failed to read from connection")
 				}
-				errChan <- err
+				select {
+				case errChan <- err:
+				case <-ctx.Done():
+				}
 				return
 			}
 		}
@@ -369,9 +376,9 @@ func asyncMySQLDecode(ctx context.Context, logger *zap.Logger, decodeChan <-chan
 
 				switch state {
 				case stateExpectResponse:
-					state = processFirstResponse(logger, pkt, decodeCtx, clientConn, lastOp,
+					state = processFirstResponse(ctx, logger, pkt, decodeCtx, clientConn, lastOp,
 						&pendingRespBundle, &textResultSet, &binaryResultSet, &stmtPrepareOk,
-						&remainingCols, &remainingParams, &state)
+						&remainingCols, &remainingParams)
 					if state == stateExpectCommand {
 						resTimestamp = item.ts
 						flushMock()
@@ -538,6 +545,7 @@ func asyncMySQLDecode(ctx context.Context, logger *zap.Logger, decodeChan <-chan
 // processFirstResponse handles the first response packet of a MySQL
 // command-response exchange. It returns the new decoder state.
 func processFirstResponse(
+	ctx context.Context,
 	logger *zap.Logger,
 	pkt []byte,
 	decodeCtx *wire.DecodeContext,
@@ -549,10 +557,9 @@ func processFirstResponse(
 	stmtPrepareOk **mysql.StmtPrepareOkPacket,
 	remainingCols *uint64,
 	remainingParams *uint16,
-	_ *mysqlDecodeState,
 ) mysqlDecodeState {
 	// Try to decode the response packet.
-	commandRespPkt, err := wire.DecodePayload(context.Background(), logger, pkt, clientConn, decodeCtx)
+	commandRespPkt, err := wire.DecodePayload(ctx, logger, pkt, clientConn, decodeCtx)
 	if err != nil {
 		logger.Debug("failed to decode MySQL response in async decoder", zap.Error(err))
 		return stateExpectCommand

--- a/pkg/agent/proxy/integrations/mysql/recorder/query.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/query.go
@@ -403,14 +403,14 @@ func asyncMySQLDecode(ctx context.Context, logger *zap.Logger, decodeChan <-chan
 							textResultSet.FinalResponse = finalResp
 							decodeCtx.LastOp.Store(clientConn, wire.RESET)
 							pendingRespBundle = &mysql.PacketBundle{
-								Header:  &mysql.PacketInfo{Type: respType, Header: origHeader},
+								Header:  &mysql.PacketInfo{Type: string(mysql.Text), Header: origHeader},
 								Message: textResultSet,
 							}
 						} else if binaryResultSet != nil {
 							binaryResultSet.FinalResponse = finalResp
 							decodeCtx.LastOp.Store(clientConn, wire.RESET)
 							pendingRespBundle = &mysql.PacketBundle{
-								Header:  &mysql.PacketInfo{Type: respType, Header: origHeader},
+								Header:  &mysql.PacketInfo{Type: string(mysql.Binary), Header: origHeader},
 								Message: binaryResultSet,
 							}
 						}

--- a/pkg/agent/proxy/integrations/mysql/recorder/query.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/query.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/sync/errgroup"
-
 	"go.keploy.io/server/v3/pkg/agent/memoryguard"
 	mysqlUtils "go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/utils"
 	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/wire"
@@ -49,40 +47,47 @@ func handleClientQueries(ctx context.Context, logger *zap.Logger, clientConn, de
 		return nil
 	}
 
-	// Buffered channels let ReadBuffConn read ahead without waiting
-	// for the main loop, preventing TCP flow-control throttling.
+	// Buffered channels for raw byte relay. Each Read() result is sent
+	// immediately — no accumulation, no "wait for short read" like ReadBytes.
 	clientBuffChan := make(chan []byte, 256)
 	destBuffChan := make(chan []byte, 256)
-	errChan := make(chan error, 1)
+	errChan := make(chan error, 2)
 
-	g, ok := ctx.Value(models.ErrGroupKey).(*errgroup.Group)
-	if !ok {
-		return errors.New("failed to get the error group from the context")
+	// readRelay reads from conn in a loop and sends each chunk to ch.
+	// Returns on error, EOF, or context cancellation.
+	readRelay := func(conn net.Conn, ch chan<- []byte) {
+		defer close(ch)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			buf := make([]byte, 32*1024)
+			n, err := conn.Read(buf)
+			if n > 0 {
+				ch <- buf[:n]
+			}
+			if err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				if err != io.EOF {
+					utils.LogError(logger, err, "failed to read from connection")
+				}
+				errChan <- err
+				return
+			}
+		}
 	}
-
-	// Read requests from client.
-	g.Go(func() error {
-		defer pUtil.Recover(logger, clientConn, destConn)
-		defer close(clientBuffChan)
-		pUtil.ReadBuffConn(ctx, logger, clientConn, clientBuffChan, errChan, false)
-		return nil
-	})
-
-	// Read responses from destination.
-	g.Go(func() error {
-		defer pUtil.Recover(logger, clientConn, destConn)
-		defer close(destBuffChan)
-		pUtil.ReadBuffConn(ctx, logger, destConn, destBuffChan, errChan, false)
-		return nil
-	})
 
 	go func() {
 		defer pUtil.Recover(logger, clientConn, destConn)
-		err := g.Wait()
-		if err != nil {
-			logger.Debug("error group is returning an error", zap.Error(err))
-		}
-		close(errChan)
+		readRelay(clientConn, clientBuffChan)
+	}()
+	go func() {
+		defer pUtil.Recover(logger, clientConn, destConn)
+		readRelay(destConn, destBuffChan)
 	}()
 
 	// Async decode channel and background goroutine.

--- a/pkg/agent/proxy/integrations/mysql/recorder/query.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/query.go
@@ -129,7 +129,9 @@ func handleClientQueries(ctx context.Context, logger *zap.Logger, clientConn, de
 				return err
 			}
 
-			// Non-blocking send to async decode.
+			// Non-blocking send to async decode. Check channel capacity
+			// before copying to avoid allocation/GC churn when the decoder
+			// can't keep up (the copy would just be dropped).
 			if !memoryguard.IsRecordingPaused() && len(decodeChan) < cap(decodeChan) {
 				buf := make([]byte, len(buffer))
 				copy(buf, buffer)
@@ -172,7 +174,8 @@ func handleClientQueries(ctx context.Context, logger *zap.Logger, clientConn, de
 				return nil
 			}
 
-			// Drain buffered data before exiting.
+			// Drain buffered data before exiting — forward AND decode
+			// so the last response chunk isn't lost for mock creation.
 		drain:
 			for {
 				select {
@@ -185,6 +188,14 @@ func handleClientQueries(ctx context.Context, logger *zap.Logger, clientConn, de
 						continue
 					}
 					_, _ = destConn.Write(buf)
+					if !memoryguard.IsRecordingPaused() && len(decodeChan) < cap(decodeChan) {
+						cp := make([]byte, len(buf))
+						copy(cp, buf)
+						select {
+						case decodeChan <- mysqlDecodeItem{fromClient: true, data: cp, ts: time.Now()}:
+						default:
+						}
+					}
 				case buf, ok := <-destBuffChan:
 					if !ok {
 						destBuffChan = nil
@@ -194,6 +205,14 @@ func handleClientQueries(ctx context.Context, logger *zap.Logger, clientConn, de
 						continue
 					}
 					_, _ = clientConn.Write(buf)
+					if !memoryguard.IsRecordingPaused() && len(decodeChan) < cap(decodeChan) {
+						cp := make([]byte, len(buf))
+						copy(cp, buf)
+						select {
+						case decodeChan <- mysqlDecodeItem{fromClient: false, data: cp, ts: time.Now()}:
+						default:
+						}
+					}
 				default:
 					break drain
 				}

--- a/pkg/agent/proxy/integrations/mysql/recorder/query.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/query.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"go.keploy.io/server/v3/pkg/agent/memoryguard"
 	mysqlUtils "go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/utils"
 	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/wire"
@@ -51,37 +53,36 @@ func handleClientQueries(ctx context.Context, logger *zap.Logger, clientConn, de
 	// for the main loop, preventing TCP flow-control throttling.
 	clientBuffChan := make(chan []byte, 256)
 	destBuffChan := make(chan []byte, 256)
-	// errChan capacity is 2 so both ReadBuffConn goroutines can send
-	// their errors without blocking, even if they error simultaneously.
-	errChan := make(chan error, 2)
+	errChan := make(chan error, 1)
 
-	// ReadBuffConn goroutines are standalone (NOT added to the shared
-	// parserErrGrp) to avoid a deadlock: ReadBuffConn's blocking
-	// errChannel send has no ctx.Done() fallback, so if both goroutines
-	// error at the same time, one blocks forever in the shared errgroup.
-	readersDone := make(chan struct{})
+	g, ok := ctx.Value(models.ErrGroupKey).(*errgroup.Group)
+	if !ok {
+		return errors.New("failed to get the error group from the context")
+	}
+
+	// Read requests from client.
+	g.Go(func() error {
+		defer pUtil.Recover(logger, clientConn, destConn)
+		defer close(clientBuffChan)
+		pUtil.ReadBuffConn(ctx, logger, clientConn, clientBuffChan, errChan, false)
+		return nil
+	})
+
+	// Read responses from destination.
+	g.Go(func() error {
+		defer pUtil.Recover(logger, clientConn, destConn)
+		defer close(destBuffChan)
+		pUtil.ReadBuffConn(ctx, logger, destConn, destBuffChan, errChan, false)
+		return nil
+	})
+
 	go func() {
-		defer close(readersDone)
-
-		clientDone := make(chan struct{})
-		destDone := make(chan struct{})
-
-		go func() {
-			defer pUtil.Recover(logger, clientConn, destConn)
-			defer close(clientBuffChan)
-			defer close(clientDone)
-			pUtil.ReadBuffConn(ctx, logger, clientConn, clientBuffChan, errChan, false)
-		}()
-
-		go func() {
-			defer pUtil.Recover(logger, clientConn, destConn)
-			defer close(destBuffChan)
-			defer close(destDone)
-			pUtil.ReadBuffConn(ctx, logger, destConn, destBuffChan, errChan, false)
-		}()
-
-		<-clientDone
-		<-destDone
+		defer pUtil.Recover(logger, clientConn, destConn)
+		err := g.Wait()
+		if err != nil {
+			logger.Debug("error group is returning an error", zap.Error(err))
+		}
+		close(errChan)
 	}()
 
 	// Async decode channel and background goroutine.
@@ -93,11 +94,10 @@ func handleClientQueries(ctx context.Context, logger *zap.Logger, clientConn, de
 		asyncMySQLDecode(ctx, logger, decodeChan, mocks, decodeCtx, clientConn, opts)
 	}()
 
-	// cleanup ensures all goroutines are stopped before we return.
+	// cleanup ensures the decode goroutine is stopped before we return.
 	cleanup := func() {
 		close(decodeChan)
 		<-decodeDone
-		<-readersDone
 	}
 
 	// Main loop: forward only, send copies for async decode.
@@ -291,13 +291,14 @@ func asyncMySQLDecode(ctx context.Context, logger *zap.Logger, decodeChan <-chan
 
 				pendingCommand = commandPkt
 
-				// Handle no-response commands.
+				// Handle no-response commands — record mock with empty
+				// responses, matching the synchronous recorder behavior.
 				if wire.IsNoResponseCommand(commandPkt.Header.Type) {
-					pendingRespBundle = &mysql.PacketBundle{
-						Header:  &mysql.PacketInfo{Type: "NO Response Packet"},
-						Message: nil,
-					}
-					flushMock()
+					requests := []mysql.Request{{PacketBundle: *pendingCommand}}
+					recordMock(ctx, requests, []mysql.Response{}, "mocks", pendingCommand.Header.Type, "NO Response Packet", mocks, reqTimestamp, time.Now(), opts)
+					pendingCommand = nil
+					pendingRespBundle = nil
+					state = stateExpectCommand
 					continue
 				}
 
@@ -305,11 +306,11 @@ func asyncMySQLDecode(ctx context.Context, logger *zap.Logger, decodeChan <-chan
 				if strings.HasPrefix(commandPkt.Header.Type, "0x") {
 					logger.Debug("Skipping unknown command packet to avoid stream desync",
 						zap.String("type", commandPkt.Header.Type))
-					pendingRespBundle = &mysql.PacketBundle{
-						Header:  &mysql.PacketInfo{Type: "NO Response Packet"},
-						Message: nil,
-					}
-					flushMock()
+					requests := []mysql.Request{{PacketBundle: *pendingCommand}}
+					recordMock(ctx, requests, []mysql.Response{}, "mocks", pendingCommand.Header.Type, "NO Response Packet", mocks, reqTimestamp, time.Now(), opts)
+					pendingCommand = nil
+					pendingRespBundle = nil
+					state = stateExpectCommand
 					continue
 				}
 
@@ -391,18 +392,25 @@ func asyncMySQLDecode(ctx context.Context, logger *zap.Logger, decodeChan <-chan
 							respType = mysql.StatusToString(mysql.OK)
 						}
 						finalResp := &mysql.GenericResponse{Data: pkt, Type: respType}
+						// Preserve the wire Header from the initial response
+						// packet (set by processFirstResponse via DecodePayload)
+						// so EncodeToBinary gets correct PayloadLength/SequenceID.
+						var origHeader *mysql.Header
+						if pendingRespBundle != nil && pendingRespBundle.Header != nil {
+							origHeader = pendingRespBundle.Header.Header
+						}
 						if textResultSet != nil {
 							textResultSet.FinalResponse = finalResp
 							decodeCtx.LastOp.Store(clientConn, wire.RESET)
 							pendingRespBundle = &mysql.PacketBundle{
-								Header:  &mysql.PacketInfo{Type: respType},
+								Header:  &mysql.PacketInfo{Type: respType, Header: origHeader},
 								Message: textResultSet,
 							}
 						} else if binaryResultSet != nil {
 							binaryResultSet.FinalResponse = finalResp
 							decodeCtx.LastOp.Store(clientConn, wire.RESET)
 							pendingRespBundle = &mysql.PacketBundle{
-								Header:  &mysql.PacketInfo{Type: respType},
+								Header:  &mysql.PacketInfo{Type: respType, Header: origHeader},
 								Message: binaryResultSet,
 							}
 						}

--- a/pkg/agent/proxy/integrations/mysql/recorder/query.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/query.go
@@ -18,7 +18,6 @@ import (
 	"go.keploy.io/server/v3/pkg/models/mysql"
 	"go.keploy.io/server/v3/utils"
 	"go.uber.org/zap"
-	"golang.org/x/sync/errgroup"
 )
 
 // mysqlDecodeItem carries a forwarded chunk to the async decode goroutine.
@@ -48,42 +47,41 @@ func handleClientQueries(ctx context.Context, logger *zap.Logger, clientConn, de
 		return nil
 	}
 
-	g, ok := ctx.Value(models.ErrGroupKey).(*errgroup.Group)
-	if !ok {
-		return errors.New("failed to get the error group from the context")
-	}
-
 	// Buffered channels let ReadBuffConn read ahead without waiting
 	// for the main loop, preventing TCP flow-control throttling.
 	clientBuffChan := make(chan []byte, 256)
 	destBuffChan := make(chan []byte, 256)
-	errChan := make(chan error, 1)
+	// errChan capacity is 2 so both ReadBuffConn goroutines can send
+	// their errors without blocking, even if they error simultaneously.
+	errChan := make(chan error, 2)
 
-	// Read commands from client. stopOnRecordingPause is false: the main
-	// loop skips sending to decodeChan when paused, so recording stops
-	// while forwarding continues through the same goroutines.
-	g.Go(func() error {
-		defer pUtil.Recover(logger, clientConn, destConn)
-		defer close(clientBuffChan)
-		pUtil.ReadBuffConn(ctx, logger, clientConn, clientBuffChan, errChan, false)
-		return nil
-	})
-
-	// Read responses from destination.
-	g.Go(func() error {
-		defer pUtil.Recover(logger, clientConn, destConn)
-		defer close(destBuffChan)
-		pUtil.ReadBuffConn(ctx, logger, destConn, destBuffChan, errChan, false)
-		return nil
-	})
-
+	// ReadBuffConn goroutines are standalone (NOT added to the shared
+	// parserErrGrp) to avoid a deadlock: ReadBuffConn's blocking
+	// errChannel send has no ctx.Done() fallback, so if both goroutines
+	// error at the same time, one blocks forever in the shared errgroup.
+	readersDone := make(chan struct{})
 	go func() {
-		defer pUtil.Recover(logger, clientConn, destConn)
-		err := g.Wait()
-		if err != nil {
-			logger.Debug("error group is returning an error", zap.Error(err))
-		}
-		close(errChan)
+		defer close(readersDone)
+
+		clientDone := make(chan struct{})
+		destDone := make(chan struct{})
+
+		go func() {
+			defer pUtil.Recover(logger, clientConn, destConn)
+			defer close(clientBuffChan)
+			defer close(clientDone)
+			pUtil.ReadBuffConn(ctx, logger, clientConn, clientBuffChan, errChan, false)
+		}()
+
+		go func() {
+			defer pUtil.Recover(logger, clientConn, destConn)
+			defer close(destBuffChan)
+			defer close(destDone)
+			pUtil.ReadBuffConn(ctx, logger, destConn, destBuffChan, errChan, false)
+		}()
+
+		<-clientDone
+		<-destDone
 	}()
 
 	// Async decode channel and background goroutine.
@@ -95,12 +93,18 @@ func handleClientQueries(ctx context.Context, logger *zap.Logger, clientConn, de
 		asyncMySQLDecode(ctx, logger, decodeChan, mocks, decodeCtx, clientConn, opts)
 	}()
 
+	// cleanup ensures all goroutines are stopped before we return.
+	cleanup := func() {
+		close(decodeChan)
+		<-decodeDone
+		<-readersDone
+	}
+
 	// Main loop: forward only, send copies for async decode.
 	for {
 		select {
 		case <-ctx.Done():
-			close(decodeChan)
-			<-decodeDone
+			cleanup()
 			return ctx.Err()
 
 		case buffer, ok := <-clientBuffChan:
@@ -116,8 +120,7 @@ func handleClientQueries(ctx context.Context, logger *zap.Logger, clientConn, de
 			_, err := destConn.Write(buffer)
 			if err != nil {
 				utils.LogError(logger, err, "failed to write command to the server")
-				close(decodeChan)
-				<-decodeDone
+				cleanup()
 				return err
 			}
 
@@ -144,8 +147,7 @@ func handleClientQueries(ctx context.Context, logger *zap.Logger, clientConn, de
 			_, err := clientConn.Write(buffer)
 			if err != nil {
 				utils.LogError(logger, err, "failed to write response to the client")
-				close(decodeChan)
-				<-decodeDone
+				cleanup()
 				return err
 			}
 
@@ -161,8 +163,7 @@ func handleClientQueries(ctx context.Context, logger *zap.Logger, clientConn, de
 
 		case err, ok := <-errChan:
 			if !ok || err == nil {
-				close(decodeChan)
-				<-decodeDone
+				cleanup()
 				return nil
 			}
 
@@ -193,8 +194,7 @@ func handleClientQueries(ctx context.Context, logger *zap.Logger, clientConn, de
 				}
 			}
 
-			close(decodeChan)
-			<-decodeDone
+			cleanup()
 			if errors.Is(err, io.EOF) {
 				return nil
 			}
@@ -207,15 +207,15 @@ func handleClientQueries(ctx context.Context, logger *zap.Logger, clientConn, de
 type mysqlDecodeState int
 
 const (
-	stateExpectCommand           mysqlDecodeState = iota // waiting for a client command
-	stateExpectResponse                                  // waiting for first response packet
-	stateExpectColumns                                   // reading column definition packets
-	stateExpectEOFAfterColumns                           // expecting EOF after column defs
-	stateExpectRows                                      // reading row data packets
-	stateExpectStmtParams                                // reading param defs for COM_STMT_PREPARE
-	stateExpectEOFAfterParams                            // expecting EOF after param defs
-	stateExpectStmtColumns                               // reading column defs for COM_STMT_PREPARE
-	stateExpectEOFAfterStmtCols                          // expecting EOF after stmt column defs
+	stateExpectCommand          mysqlDecodeState = iota // waiting for a client command
+	stateExpectResponse                                 // waiting for first response packet
+	stateExpectColumns                                  // reading column definition packets
+	stateExpectEOFAfterColumns                          // expecting EOF after column defs
+	stateExpectRows                                     // reading row data packets
+	stateExpectStmtParams                               // reading param defs for COM_STMT_PREPARE
+	stateExpectEOFAfterParams                           // expecting EOF after param defs
+	stateExpectStmtColumns                              // reading column defs for COM_STMT_PREPARE
+	stateExpectEOFAfterStmtCols                         // expecting EOF after stmt column defs
 )
 
 // asyncMySQLDecode runs in a background goroutine and processes forwarded

--- a/pkg/agent/proxy/integrations/mysql/recorder/query.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/query.go
@@ -57,17 +57,19 @@ func handleClientQueries(ctx context.Context, logger *zap.Logger, clientConn, de
 	// Returns on error, EOF, or context cancellation.
 	readRelay := func(conn net.Conn, ch chan<- []byte) {
 		defer close(ch)
+		buf := make([]byte, 32*1024) // reused across reads
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			default:
 			}
-			buf := make([]byte, 32*1024)
 			n, err := conn.Read(buf)
 			if n > 0 {
+				data := make([]byte, n)
+				copy(data, buf[:n])
 				select {
-				case ch <- buf[:n]:
+				case ch <- data:
 				case <-ctx.Done():
 					return
 				}
@@ -98,16 +100,23 @@ func handleClientQueries(ctx context.Context, logger *zap.Logger, clientConn, de
 	}()
 
 	// Async decode channel and background goroutine.
+	// Use a decoder-specific context so cleanup() can unblock recordMock's
+	// channel send (which selects on ctx.Done) without waiting for the
+	// parent context to be canceled.
 	decodeChan := make(chan mysqlDecodeItem, 512)
 	decodeDone := make(chan struct{})
+	decoderCtx, cancelDecoder := context.WithCancel(ctx)
 	go func() {
 		defer pUtil.Recover(logger, clientConn, destConn)
 		defer close(decodeDone)
-		asyncMySQLDecode(ctx, logger, decodeChan, mocks, decodeCtx, clientConn, opts)
+		asyncMySQLDecode(decoderCtx, logger, decodeChan, mocks, decodeCtx, clientConn, opts)
 	}()
 
 	// cleanup ensures the decode goroutine is stopped before we return.
+	// Canceling the decoder context first unblocks any pending channel
+	// sends in recordMock, preventing a deadlock.
 	cleanup := func() {
+		cancelDecoder()
 		close(decodeChan)
 		<-decodeDone
 	}

--- a/pkg/agent/proxy/integrations/mysql/recorder/query.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/query.go
@@ -2,6 +2,7 @@ package recorder
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -12,630 +13,597 @@ import (
 	mysqlUtils "go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/utils"
 	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/wire"
 	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/wire/phase/query/rowscols"
+	pUtil "go.keploy.io/server/v3/pkg/agent/proxy/util"
 	"go.keploy.io/server/v3/pkg/models"
 	"go.keploy.io/server/v3/pkg/models/mysql"
 	"go.keploy.io/server/v3/utils"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 )
 
+// mysqlDecodeItem carries a forwarded chunk to the async decode goroutine.
+type mysqlDecodeItem struct {
+	fromClient bool
+	data       []byte
+	ts         time.Time
+}
+
+// handleClientQueries handles the MySQL command phase with non-blocking
+// forwarding. Raw bytes are relayed at wire speed in the main select loop.
+// All packet reassembly, decoding, and mock creation is offloaded to a
+// background goroutine via a buffered decode channel.
 func handleClientQueries(ctx context.Context, logger *zap.Logger, clientConn, destConn net.Conn, mocks chan<- *models.Mock, decodeCtx *wire.DecodeContext, opts models.OutgoingOptions) error {
-	var (
-		requests  []mysql.Request
-		responses []mysql.Response
-	)
-
-	//for keeping conn alive
-	for {
-		if memoryguard.IsRecordingPaused() {
-			logger.Debug("memory pressure detected, stopping MySQL recording and falling back to passthrough")
-			done := make(chan struct{}, 2)
-			cp := func(dst, src net.Conn) {
-				_, _ = io.Copy(dst, src)
-				done <- struct{}{}
-			}
-			go cp(destConn, clientConn)
-			go cp(clientConn, destConn)
-			<-done
-			<-done
-			return nil
+	// If recording is already paused, pure passthrough.
+	if memoryguard.IsRecordingPaused() {
+		logger.Debug("memory pressure detected, stopping MySQL recording and falling back to passthrough")
+		done := make(chan struct{}, 2)
+		cp := func(dst, src net.Conn) {
+			_, _ = io.Copy(dst, src)
+			done <- struct{}{}
 		}
+		go cp(destConn, clientConn)
+		go cp(clientConn, destConn)
+		<-done
+		<-done
+		return nil
+	}
 
+	g, ok := ctx.Value(models.ErrGroupKey).(*errgroup.Group)
+	if !ok {
+		return errors.New("failed to get the error group from the context")
+	}
+
+	// Buffered channels let ReadBuffConn read ahead without waiting
+	// for the main loop, preventing TCP flow-control throttling.
+	clientBuffChan := make(chan []byte, 256)
+	destBuffChan := make(chan []byte, 256)
+	errChan := make(chan error, 1)
+
+	// Read commands from client. stopOnRecordingPause is false: the main
+	// loop skips sending to decodeChan when paused, so recording stops
+	// while forwarding continues through the same goroutines.
+	g.Go(func() error {
+		defer pUtil.Recover(logger, clientConn, destConn)
+		defer close(clientBuffChan)
+		pUtil.ReadBuffConn(ctx, logger, clientConn, clientBuffChan, errChan, false)
+		return nil
+	})
+
+	// Read responses from destination.
+	g.Go(func() error {
+		defer pUtil.Recover(logger, clientConn, destConn)
+		defer close(destBuffChan)
+		pUtil.ReadBuffConn(ctx, logger, destConn, destBuffChan, errChan, false)
+		return nil
+	})
+
+	go func() {
+		defer pUtil.Recover(logger, clientConn, destConn)
+		err := g.Wait()
+		if err != nil {
+			logger.Debug("error group is returning an error", zap.Error(err))
+		}
+		close(errChan)
+	}()
+
+	// Async decode channel and background goroutine.
+	decodeChan := make(chan mysqlDecodeItem, 512)
+	decodeDone := make(chan struct{})
+	go func() {
+		defer pUtil.Recover(logger, clientConn, destConn)
+		defer close(decodeDone)
+		asyncMySQLDecode(ctx, logger, decodeChan, mocks, decodeCtx, clientConn, opts)
+	}()
+
+	// Main loop: forward only, send copies for async decode.
+	for {
 		select {
 		case <-ctx.Done():
+			close(decodeChan)
+			<-decodeDone
 			return ctx.Err()
-		default:
 
-			// read the command from the client
-			command, err := mysqlUtils.ReadPacketBuffer(ctx, logger, clientConn)
-			if err != nil {
-				if err != io.EOF {
-					utils.LogError(logger, err, "failed to read command packet from client")
-				}
-				return err
+		case buffer, ok := <-clientBuffChan:
+			if !ok {
+				clientBuffChan = nil
+				continue
+			}
+			if buffer == nil {
+				continue
 			}
 
-			// write the command to the destination server
-			_, err = destConn.Write(command)
+			// Forward to destination immediately — critical path.
+			_, err := destConn.Write(buffer)
 			if err != nil {
 				utils.LogError(logger, err, "failed to write command to the server")
+				close(decodeChan)
+				<-decodeDone
 				return err
 			}
 
-			// Getting timestamp for the request
-			reqTimestamp := time.Now()
-
-			commandPkt, err := wire.DecodePayload(ctx, logger, command, clientConn, decodeCtx)
-			if err != nil {
-				utils.LogError(logger, err, "failed to decode the MySQL packet from the client")
-				return err
-			}
-
-			requests = append(requests, mysql.Request{
-				PacketBundle: *commandPkt,
-			})
-
-			// handle no response commands like COM_STMT_CLOSE, COM_STMT_SEND_LONG_DATA, etc
-			if wire.IsNoResponseCommand(commandPkt.Header.Type) {
-				recordMock(ctx, requests, responses, "mocks", commandPkt.Header.Type, "NO Response Packet", mocks, reqTimestamp, time.Now(), opts)
-				// reset the requests and responses
-				requests = []mysql.Request{}
-				responses = []mysql.Response{}
-				logger.Debug("No response command", zap.Any("packet", commandPkt.Header.Type))
-				continue
-			}
-
-			// Unknown/unrecognized packet types (e.g. "0x12") are produced by
-			// decodePacket's default case when the first payload byte doesn't
-			// match any known MySQL command. This typically happens in the
-			// post-TLS uprobe path when the capture starts mid-stream on an
-			// existing connection and the data is misaligned. Treating these
-			// as no-response commands prevents the parser from trying to read
-			// a response that doesn't exist, which would desync the streams
-			// and cascade into errors like "expected TextResultSet, got
-			// *mysql.QueryPacket".
-			if strings.HasPrefix(commandPkt.Header.Type, "0x") {
-				logger.Debug("Skipping unknown command packet to avoid stream desync",
-					zap.String("type", commandPkt.Header.Type))
-				recordMock(ctx, requests, responses, "mocks", commandPkt.Header.Type, "NO Response Packet", mocks, reqTimestamp, time.Now(), opts)
-				requests = []mysql.Request{}
-				responses = []mysql.Response{}
-				continue
-			}
-
-			commandRespPkt, resTimestamp, err := handleQueryResponse(ctx, logger, clientConn, destConn, decodeCtx)
-			if err != nil {
-				if err == io.EOF && commandPkt.Header.Type == mysql.CommandStatusToString(mysql.COM_QUIT) {
-					logger.Debug("server closed the connection without any response")
-					return err
+			// Non-blocking send to async decode.
+			if !memoryguard.IsRecordingPaused() && len(decodeChan) < cap(decodeChan) {
+				buf := make([]byte, len(buffer))
+				copy(buf, buffer)
+				select {
+				case decodeChan <- mysqlDecodeItem{fromClient: true, data: buf, ts: time.Now()}:
+				default:
 				}
-				utils.LogError(logger, err, "failed to handle the query response")
+			}
+
+		case buffer, ok := <-destBuffChan:
+			if !ok {
+				destBuffChan = nil
+				continue
+			}
+			if buffer == nil {
+				continue
+			}
+
+			// Forward to client immediately — critical path.
+			_, err := clientConn.Write(buffer)
+			if err != nil {
+				utils.LogError(logger, err, "failed to write response to the client")
+				close(decodeChan)
+				<-decodeDone
 				return err
 			}
 
-			responses = append(responses, mysql.Response{
-				PacketBundle: *commandRespPkt,
-			})
+			// Non-blocking send to async decode.
+			if !memoryguard.IsRecordingPaused() && len(decodeChan) < cap(decodeChan) {
+				buf := make([]byte, len(buffer))
+				copy(buf, buffer)
+				select {
+				case decodeChan <- mysqlDecodeItem{fromClient: false, data: buf, ts: time.Now()}:
+				default:
+				}
+			}
 
-			// record the mock
-			recordMock(ctx, requests, responses, "mocks", commandPkt.Header.Type, commandRespPkt.Header.Type, mocks, reqTimestamp, resTimestamp, opts)
+		case err, ok := <-errChan:
+			if !ok || err == nil {
+				close(decodeChan)
+				<-decodeDone
+				return nil
+			}
 
-			// reset the requests and responses
-			requests = []mysql.Request{}
-			responses = []mysql.Response{}
+			// Drain buffered data before exiting.
+		drain:
+			for {
+				select {
+				case buf, ok := <-clientBuffChan:
+					if !ok {
+						clientBuffChan = nil
+						continue
+					}
+					if buf == nil {
+						continue
+					}
+					_, _ = destConn.Write(buf)
+				case buf, ok := <-destBuffChan:
+					if !ok {
+						destBuffChan = nil
+						continue
+					}
+					if buf == nil {
+						continue
+					}
+					_, _ = clientConn.Write(buf)
+				default:
+					break drain
+				}
+			}
+
+			close(decodeChan)
+			<-decodeDone
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
 		}
 	}
 }
 
-func handleQueryResponse(ctx context.Context, logger *zap.Logger, clientConn, destConn net.Conn, decodeCtx *wire.DecodeContext) (*mysql.PacketBundle, time.Time, error) {
-	// read the command response from the destination server
-	commandResp, err := mysqlUtils.ReadPacketBuffer(ctx, logger, destConn)
-	if err != nil {
-		if err != io.EOF {
-			utils.LogError(logger, err, "failed to read command response from the server")
+// mysqlDecodeState tracks what the async decoder expects next.
+type mysqlDecodeState int
+
+const (
+	stateExpectCommand           mysqlDecodeState = iota // waiting for a client command
+	stateExpectResponse                                  // waiting for first response packet
+	stateExpectColumns                                   // reading column definition packets
+	stateExpectEOFAfterColumns                           // expecting EOF after column defs
+	stateExpectRows                                      // reading row data packets
+	stateExpectStmtParams                                // reading param defs for COM_STMT_PREPARE
+	stateExpectEOFAfterParams                            // expecting EOF after param defs
+	stateExpectStmtColumns                               // reading column defs for COM_STMT_PREPARE
+	stateExpectEOFAfterStmtCols                          // expecting EOF after stmt column defs
+)
+
+// asyncMySQLDecode runs in a background goroutine and processes forwarded
+// chunks in FIFO order. It reassembles MySQL packets, decodes them, pairs
+// commands with responses, and records mocks — all off the forwarding path.
+func asyncMySQLDecode(ctx context.Context, logger *zap.Logger, decodeChan <-chan mysqlDecodeItem, mocks chan<- *models.Mock, decodeCtx *wire.DecodeContext, clientConn net.Conn, opts models.OutgoingOptions) {
+	var clientReassembly mysqlReassemblyBuffer
+	var destReassembly mysqlReassemblyBuffer
+	var clientOverflowLogged, destOverflowLogged bool
+
+	state := stateExpectCommand
+
+	// Current command being processed.
+	var (
+		pendingCommand    *mysql.PacketBundle
+		reqTimestamp      time.Time
+		resTimestamp      time.Time
+		pendingRespBundle *mysql.PacketBundle // accumulated response
+		lastOp            byte                // the MySQL command type
+		remainingCols     uint64              // columns left to read
+		remainingParams   uint16              // params left to read (stmt prepare)
+	)
+
+	// Temporary storage for result set assembly.
+	var (
+		textResultSet   *mysql.TextResultSet
+		binaryResultSet *mysql.BinaryProtocolResultSet
+		stmtPrepareOk   *mysql.StmtPrepareOkPacket
+	)
+
+	flushMock := func() {
+		if pendingCommand == nil || pendingRespBundle == nil {
+			return
 		}
-		return nil, time.Time{}, err
+		requests := []mysql.Request{{PacketBundle: *pendingCommand}}
+		responses := []mysql.Response{{PacketBundle: *pendingRespBundle}}
+		respOp := pendingRespBundle.Header.Type
+		recordMock(ctx, requests, responses, "mocks", pendingCommand.Header.Type, respOp, mocks, reqTimestamp, resTimestamp, opts)
+		pendingCommand = nil
+		pendingRespBundle = nil
+		state = stateExpectCommand
 	}
 
-	// write the command response to the client
-	_, err = clientConn.Write(commandResp)
+	for item := range decodeChan {
+		if item.fromClient {
+			// --- Client command chunk ---
+			clientReassembly.append(item.data)
+			if clientReassembly.didOverflow() && !clientOverflowLogged {
+				logger.Debug("MySQL client reassembly buffer exceeded limit")
+				clientOverflowLogged = true
+			}
+
+			for {
+				pkt := clientReassembly.extractCompletePacket()
+				if pkt == nil {
+					break
+				}
+
+				// If we had an incomplete exchange, flush it.
+				if state != stateExpectCommand && pendingCommand != nil {
+					flushMock()
+				}
+
+				reqTimestamp = item.ts
+
+				commandPkt, err := wire.DecodePayload(ctx, logger, pkt, clientConn, decodeCtx)
+				if err != nil {
+					logger.Debug("failed to decode MySQL command in async decoder", zap.Error(err))
+					state = stateExpectCommand
+					pendingCommand = nil
+					continue
+				}
+
+				pendingCommand = commandPkt
+
+				// Handle no-response commands.
+				if wire.IsNoResponseCommand(commandPkt.Header.Type) {
+					pendingRespBundle = &mysql.PacketBundle{
+						Header:  &mysql.PacketInfo{Type: "NO Response Packet"},
+						Message: nil,
+					}
+					flushMock()
+					continue
+				}
+
+				// Unknown/unrecognized packet types — treat as no-response.
+				if strings.HasPrefix(commandPkt.Header.Type, "0x") {
+					logger.Debug("Skipping unknown command packet to avoid stream desync",
+						zap.String("type", commandPkt.Header.Type))
+					pendingRespBundle = &mysql.PacketBundle{
+						Header:  &mysql.PacketInfo{Type: "NO Response Packet"},
+						Message: nil,
+					}
+					flushMock()
+					continue
+				}
+
+				// Determine the command type for response handling.
+				op, opOk := decodeCtx.LastOp.Load(clientConn)
+				if opOk {
+					lastOp = op
+				}
+
+				state = stateExpectResponse
+			}
+
+		} else {
+			// --- Server response chunk ---
+			destReassembly.append(item.data)
+			if destReassembly.didOverflow() && !destOverflowLogged {
+				logger.Debug("MySQL dest reassembly buffer exceeded limit")
+				destOverflowLogged = true
+			}
+
+			for {
+				pkt := destReassembly.extractCompletePacket()
+				if pkt == nil {
+					break
+				}
+
+				if state == stateExpectCommand {
+					// Unexpected server data without a pending command.
+					logger.Debug("received MySQL response with no pending command")
+					continue
+				}
+
+				switch state {
+				case stateExpectResponse:
+					state = processFirstResponse(logger, pkt, decodeCtx, clientConn, lastOp,
+						&pendingRespBundle, &textResultSet, &binaryResultSet, &stmtPrepareOk,
+						&remainingCols, &remainingParams, &state)
+					if state == stateExpectCommand {
+						resTimestamp = item.ts
+						flushMock()
+					}
+
+				case stateExpectColumns:
+					col, _, err := rowscols.DecodeColumn(ctx, logger, pkt)
+					if err != nil {
+						logger.Debug("failed to decode column definition in async decoder", zap.Error(err))
+						state = stateExpectCommand
+						continue
+					}
+					if textResultSet != nil {
+						textResultSet.Columns = append(textResultSet.Columns, col)
+					} else if binaryResultSet != nil {
+						binaryResultSet.Columns = append(binaryResultSet.Columns, col)
+					}
+					remainingCols--
+					if remainingCols == 0 {
+						if !decodeCtx.DeprecateEOF() {
+							state = stateExpectEOFAfterColumns
+						} else {
+							state = stateExpectRows
+						}
+					}
+
+				case stateExpectEOFAfterColumns:
+					if !mysqlUtils.IsEOFPacket(pkt) {
+						logger.Debug("expected EOF after columns, got something else")
+					}
+					if textResultSet != nil {
+						textResultSet.EOFAfterColumns = pkt
+					} else if binaryResultSet != nil {
+						binaryResultSet.EOFAfterColumns = pkt
+					}
+					state = stateExpectRows
+
+				case stateExpectRows:
+					if mysqlUtils.IsResultSetTerminator(pkt, decodeCtx.DeprecateEOF()) {
+						respType := mysql.StatusToString(mysql.EOF)
+						if decodeCtx.DeprecateEOF() && mysqlUtils.IsOKReplacingEOF(pkt) {
+							respType = mysql.StatusToString(mysql.OK)
+						}
+						finalResp := &mysql.GenericResponse{Data: pkt, Type: respType}
+						if textResultSet != nil {
+							textResultSet.FinalResponse = finalResp
+							decodeCtx.LastOp.Store(clientConn, wire.RESET)
+							pendingRespBundle = &mysql.PacketBundle{
+								Header:  &mysql.PacketInfo{Type: respType},
+								Message: textResultSet,
+							}
+						} else if binaryResultSet != nil {
+							binaryResultSet.FinalResponse = finalResp
+							decodeCtx.LastOp.Store(clientConn, wire.RESET)
+							pendingRespBundle = &mysql.PacketBundle{
+								Header:  &mysql.PacketInfo{Type: respType},
+								Message: binaryResultSet,
+							}
+						}
+						resTimestamp = item.ts
+						flushMock()
+					} else {
+						// Row data.
+						if textResultSet != nil {
+							row, _, err := rowscols.DecodeTextRow(ctx, logger, pkt, textResultSet.Columns)
+							if err != nil {
+								logger.Debug("failed to decode text row in async decoder", zap.Error(err))
+							} else {
+								textResultSet.Rows = append(textResultSet.Rows, row)
+							}
+						} else if binaryResultSet != nil {
+							row, _, err := rowscols.DecodeBinaryRow(ctx, logger, pkt, binaryResultSet.Columns)
+							if err != nil {
+								logger.Debug("failed to decode binary row in async decoder", zap.Error(err))
+							} else {
+								binaryResultSet.Rows = append(binaryResultSet.Rows, row)
+							}
+						}
+					}
+
+				case stateExpectStmtParams:
+					col, _, err := rowscols.DecodeColumn(ctx, logger, pkt)
+					if err != nil {
+						logger.Debug("failed to decode param definition in async decoder", zap.Error(err))
+						state = stateExpectCommand
+						continue
+					}
+					if stmtPrepareOk != nil {
+						stmtPrepareOk.ParamDefs = append(stmtPrepareOk.ParamDefs, col)
+					}
+					remainingParams--
+					if remainingParams == 0 {
+						if !decodeCtx.DeprecateEOF() {
+							state = stateExpectEOFAfterParams
+						} else {
+							if stmtPrepareOk != nil && stmtPrepareOk.NumColumns > 0 {
+								remainingCols = uint64(stmtPrepareOk.NumColumns)
+								state = stateExpectStmtColumns
+							} else {
+								decodeCtx.LastOp.Store(clientConn, mysql.OK)
+								resTimestamp = item.ts
+								flushMock()
+							}
+						}
+					}
+
+				case stateExpectEOFAfterParams:
+					if mysqlUtils.IsEOFPacket(pkt) && stmtPrepareOk != nil {
+						stmtPrepareOk.EOFAfterParamDefs = pkt
+					}
+					if stmtPrepareOk != nil && stmtPrepareOk.NumColumns > 0 {
+						remainingCols = uint64(stmtPrepareOk.NumColumns)
+						state = stateExpectStmtColumns
+					} else {
+						decodeCtx.LastOp.Store(clientConn, mysql.OK)
+						resTimestamp = item.ts
+						flushMock()
+					}
+
+				case stateExpectStmtColumns:
+					col, _, err := rowscols.DecodeColumn(ctx, logger, pkt)
+					if err != nil {
+						logger.Debug("failed to decode stmt column definition in async decoder", zap.Error(err))
+						state = stateExpectCommand
+						continue
+					}
+					if stmtPrepareOk != nil {
+						stmtPrepareOk.ColumnDefs = append(stmtPrepareOk.ColumnDefs, col)
+					}
+					remainingCols--
+					if remainingCols == 0 {
+						if !decodeCtx.DeprecateEOF() {
+							state = stateExpectEOFAfterStmtCols
+						} else {
+							decodeCtx.LastOp.Store(clientConn, mysql.OK)
+							resTimestamp = item.ts
+							flushMock()
+						}
+					}
+
+				case stateExpectEOFAfterStmtCols:
+					if mysqlUtils.IsEOFPacket(pkt) && stmtPrepareOk != nil {
+						stmtPrepareOk.EOFAfterColumnDefs = pkt
+					}
+					decodeCtx.LastOp.Store(clientConn, mysql.OK)
+					resTimestamp = item.ts
+					flushMock()
+				}
+			}
+		}
+	}
+
+	// Channel closed — flush any remaining exchange.
+	flushMock()
+}
+
+// processFirstResponse handles the first response packet of a MySQL
+// command-response exchange. It returns the new decoder state.
+func processFirstResponse(
+	logger *zap.Logger,
+	pkt []byte,
+	decodeCtx *wire.DecodeContext,
+	clientConn net.Conn,
+	lastOp byte,
+	pendingRespBundle **mysql.PacketBundle,
+	textResultSet **mysql.TextResultSet,
+	binaryResultSet **mysql.BinaryProtocolResultSet,
+	stmtPrepareOk **mysql.StmtPrepareOkPacket,
+	remainingCols *uint64,
+	remainingParams *uint16,
+	_ *mysqlDecodeState,
+) mysqlDecodeState {
+	// Try to decode the response packet.
+	commandRespPkt, err := wire.DecodePayload(context.Background(), logger, pkt, clientConn, decodeCtx)
 	if err != nil {
-		utils.LogError(logger, err, "failed to write command response to the client")
-		return nil, time.Time{}, err
+		logger.Debug("failed to decode MySQL response in async decoder", zap.Error(err))
+		return stateExpectCommand
 	}
 
-	// Snapshot the previous lastOp for diagnostics. If decode sees stale
-	// state and parses a response as a command packet, we include this in
-	// logs to explain the desync path.
-	prevLastOp, _ := decodeCtx.LastOp.Load(clientConn)
-
-	//decode the command response packet
-	commandRespPkt, err := wire.DecodePayload(ctx, logger, commandResp, clientConn, decodeCtx)
-	if err != nil {
-		utils.LogError(logger, err, "failed to decode the command response packet")
-		return nil, time.Time{}, err
+	// Check if response is OK or ERR — simple single-packet response.
+	if commandRespPkt.Header.Type == mysql.StatusToString(mysql.ERR) ||
+		commandRespPkt.Header.Type == mysql.StatusToString(mysql.OK) {
+		*pendingRespBundle = commandRespPkt
+		return stateExpectCommand
 	}
 
-	// check if the command response is an error or ok packet
-	if commandRespPkt.Header.Type == mysql.StatusToString(mysql.ERR) || commandRespPkt.Header.Type == mysql.StatusToString(mysql.OK) {
-		logger.Debug("command response packet", zap.Any("packet", commandRespPkt.Header.Type))
-		resTimestamp := time.Now()
-		return commandRespPkt, resTimestamp, nil
-	}
-
-	// Get the last operation in order to handle current packet if it is not an error or ok packet
-	lastOp, ok := decodeCtx.LastOp.Load(clientConn)
-	if !ok {
-		return nil, time.Time{}, fmt.Errorf("failed to get the last operation from the context while handling the query response")
-	}
-
-	// Guard: if the response was decoded as a command packet (e.g.
-	// *mysql.QueryPacket) instead of a response type, the data streams are
-	// desynchronized — typically because DecodePayload's lastOp was stale and
-	// the response went through decodePacket instead of
-	// handleQueryStmtResponse. Return the raw packet as-is rather than
-	// cascading into handleTextResultSet which would fail with a type
-	// assertion error and kill the parser pipeline.
+	// Guard: if response was decoded as a command packet, streams are desynced.
 	if isCommandPacket(commandRespPkt.Message) {
-		logger.Debug("Response decoded as command packet — stream desync detected, returning raw response",
-			zap.String("responseType", commandRespPkt.Header.Type),
-			zap.String("prevLastOp", fmt.Sprintf("%#x", prevLastOp)),
-			zap.String("lastOp", fmt.Sprintf("%#x", lastOp)))
-		// Reset lastOp so the next iteration starts clean.
+		logger.Debug("Response decoded as command packet — stream desync detected",
+			zap.String("responseType", commandRespPkt.Header.Type))
 		decodeCtx.LastOp.Store(clientConn, wire.RESET)
-		resTimestamp := time.Now()
-		return commandRespPkt, resTimestamp, nil
+		*pendingRespBundle = commandRespPkt
+		return stateExpectCommand
 	}
 
-	var queryResponsePkt *mysql.PacketBundle
-
+	// Multi-packet response — determine type based on lastOp.
 	switch lastOp {
 	case mysql.COM_QUERY:
-		logger.Debug("Handling text result set", zap.Any("lastOp", lastOp))
-		// handle the query response (TextResultSet)
-		queryResponsePkt, err = handleTextResultSet(ctx, logger, clientConn, destConn, commandRespPkt, decodeCtx)
-		if err != nil {
-			return nil, time.Time{}, fmt.Errorf("failed to handle the query response packet: %w", err)
+		ts, ok := commandRespPkt.Message.(*mysql.TextResultSet)
+		if !ok {
+			logger.Debug("expected TextResultSet",
+				zap.String("got", fmt.Sprintf("%T", commandRespPkt.Message)))
+			*pendingRespBundle = commandRespPkt
+			return stateExpectCommand
 		}
+		*textResultSet = ts
+		*binaryResultSet = nil
+		*stmtPrepareOk = nil
+		*remainingCols = ts.ColumnCount
+		*pendingRespBundle = commandRespPkt
+		return stateExpectColumns
 
 	case mysql.COM_STMT_PREPARE:
-		logger.Debug("Handling prepare Statement Response OK", zap.Any("lastOp", lastOp))
-		// handle the prepared statement response (COM_STMT_PREPARE_OK)
-		queryResponsePkt, err = handlePreparedStmtResponse(ctx, logger, clientConn, destConn, commandRespPkt, decodeCtx)
-		if err != nil {
-			return nil, time.Time{}, fmt.Errorf("failed to handle the prepared statement response: %w", err)
+		sp, ok := commandRespPkt.Message.(*mysql.StmtPrepareOkPacket)
+		if !ok {
+			logger.Debug("expected StmtPrepareOkPacket",
+				zap.String("got", fmt.Sprintf("%T", commandRespPkt.Message)))
+			*pendingRespBundle = commandRespPkt
+			return stateExpectCommand
 		}
+		*stmtPrepareOk = sp
+		*textResultSet = nil
+		*binaryResultSet = nil
+		*pendingRespBundle = commandRespPkt
+		if sp.NumParams > 0 {
+			*remainingParams = sp.NumParams
+			return stateExpectStmtParams
+		}
+		if sp.NumColumns > 0 {
+			*remainingCols = uint64(sp.NumColumns)
+			return stateExpectStmtColumns
+		}
+		// No params, no columns — done.
+		decodeCtx.LastOp.Store(clientConn, mysql.OK)
+		return stateExpectCommand
+
 	case mysql.COM_STMT_EXECUTE:
-		logger.Debug("Handling binary protocol result set", zap.Any("lastOp", lastOp))
-		// handle the statment execute response (BinaryProtocolResultSet)
-		queryResponsePkt, err = handleBinaryResultSet(ctx, logger, clientConn, destConn, commandRespPkt, decodeCtx)
-		if err != nil {
-			return nil, time.Time{}, fmt.Errorf("failed to handle the statement execute response: %w", err)
+		bs, ok := commandRespPkt.Message.(*mysql.BinaryProtocolResultSet)
+		if !ok {
+			logger.Debug("expected BinaryProtocolResultSet",
+				zap.String("got", fmt.Sprintf("%T", commandRespPkt.Message)))
+			*pendingRespBundle = commandRespPkt
+			return stateExpectCommand
 		}
+		*binaryResultSet = bs
+		*textResultSet = nil
+		*stmtPrepareOk = nil
+		*remainingCols = bs.ColumnCount
+		*pendingRespBundle = commandRespPkt
+		return stateExpectColumns
 
 	default:
-		return nil, time.Time{}, fmt.Errorf("unsupported operation: %x", lastOp)
+		logger.Debug("unsupported lastOp in async decoder",
+			zap.String("op", fmt.Sprintf("%x", lastOp)))
+		*pendingRespBundle = commandRespPkt
+		return stateExpectCommand
 	}
-	resTimestamp := time.Now()
-	return queryResponsePkt, resTimestamp, nil
-}
-
-func handlePreparedStmtResponse(ctx context.Context, logger *zap.Logger, clientConn, destConn net.Conn, commandRespPkt *mysql.PacketBundle, decodeCtx *wire.DecodeContext) (*mysql.PacketBundle, error) {
-
-	//commandRespPkt is the response to prepare, there are parameters, intermediate EOF, columns, and EOF packets to be handled
-	//ref: https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_stmt_prepare.html#sect_protocol_com_stmt_prepare_response_ok
-
-	responseOk, ok := commandRespPkt.Message.(*mysql.StmtPrepareOkPacket)
-	if !ok {
-		return nil, fmt.Errorf("expected StmtPrepareOkPacket, got %T", commandRespPkt.Message)
-	}
-
-	logger.Debug("Parsing the params and columns in the prepared statement response", zap.Any("responseOk", responseOk))
-
-	//See if there are any parameters
-	if responseOk.NumParams > 0 {
-		for i := uint16(0); i < responseOk.NumParams; i++ {
-
-			// Read the column definition packet
-			colData, err := mysqlUtils.ReadPacketBuffer(ctx, logger, destConn)
-			if err != nil {
-				if err != io.EOF {
-					utils.LogError(logger, err, "failed to read column data for parameter definition")
-				}
-				return nil, err
-			}
-
-			// Write the column definition packet to the client
-			_, err = clientConn.Write(colData)
-			if err != nil {
-				utils.LogError(logger, err, "failed to write column data for parameter definition")
-				return nil, err
-			}
-
-			// Decode the column definition packet
-			column, _, err := rowscols.DecodeColumn(ctx, logger, colData)
-			if err != nil {
-				return nil, fmt.Errorf("failed to decode column definition packet: %w", err)
-			}
-
-			responseOk.ParamDefs = append(responseOk.ParamDefs, column)
-		}
-
-		logger.Debug("ParamsDefs after parsing", zap.Any("ParamDefs", responseOk.ParamDefs))
-
-		if !decodeCtx.DeprecateEOF() {
-			logger.Debug("EOF packet is not deprecated while handling prepared statement param defs")
-
-			// Read the EOF packet for parameter definition
-			eofData, err := mysqlUtils.ReadPacketBuffer(ctx, logger, destConn)
-			if err != nil {
-				if err != io.EOF {
-					utils.LogError(logger, err, "failed to read EOF packet for parameter definition")
-				}
-				return nil, err
-			}
-
-			// Write the EOF packet for parameter definition to the client
-			_, err = clientConn.Write(eofData)
-			if err != nil {
-				utils.LogError(logger, err, "failed to write EOF packet for parameter definition to the client")
-				return nil, err
-			}
-
-			// Validate the EOF packet for parameter definition
-			if !mysqlUtils.IsEOFPacket(eofData) {
-				return nil, fmt.Errorf("expected EOF packet for parameter definition, got %v", eofData)
-			}
-
-			responseOk.EOFAfterParamDefs = eofData
-
-			logger.Debug("Eof after param defs", zap.Any("eofData", eofData))
-		}
-	}
-
-	//See if there are any columns
-	if responseOk.NumColumns > 0 {
-		for i := uint16(0); i < responseOk.NumColumns; i++ {
-
-			// Read the column definition packet
-			colData, err := mysqlUtils.ReadPacketBuffer(ctx, logger, destConn)
-			if err != nil {
-				if err != io.EOF {
-					utils.LogError(logger, err, "failed to read column data for column definition")
-				}
-				return nil, err
-			}
-
-			// Write the column definition packet to the client
-			_, err = clientConn.Write(colData)
-			if err != nil {
-				utils.LogError(logger, err, "failed to write column data for column definition")
-				return nil, err
-			}
-
-			// Decode the column definition packet
-			column, _, err := rowscols.DecodeColumn(ctx, logger, colData)
-			if err != nil {
-				return nil, fmt.Errorf("failed to decode column definition packet: %w", err)
-			}
-
-			responseOk.ColumnDefs = append(responseOk.ColumnDefs, column)
-		}
-
-		logger.Debug("ColumnDefs after parsing", zap.Any("ColumnDefs", responseOk.ColumnDefs))
-
-		if !decodeCtx.DeprecateEOF() {
-			logger.Debug("EOF packet is not deprecated while handling prepared statement column defs")
-
-			// Read the EOF packet for column definition
-			eofData, err := mysqlUtils.ReadPacketBuffer(ctx, logger, destConn)
-			if err != nil {
-				if err != io.EOF {
-					utils.LogError(logger, err, "failed to read EOF packet for column definition")
-				}
-				return nil, err
-			}
-
-			// Write the EOF packet for column definition to the client
-			_, err = clientConn.Write(eofData)
-			if err != nil {
-				utils.LogError(logger, err, "failed to write EOF packet for column definition to the client")
-				return nil, err
-			}
-
-			// Validate the EOF packet for column definition
-			if !mysqlUtils.IsEOFPacket(eofData) {
-				return nil, fmt.Errorf("expected EOF packet for column definition, got %v, while handling prepared statement response", eofData)
-			}
-
-			responseOk.EOFAfterColumnDefs = eofData
-
-			logger.Debug("Eof after column defs", zap.Any("eofData", eofData))
-		}
-	}
-
-	//set the lastOp to COM_STMT_PREPARE_OK
-	decodeCtx.LastOp.Store(clientConn, mysql.OK)
-
-	// commandRespPkt.Message = responseOk // need to check whether this is necessary
-
-	return commandRespPkt, nil
-}
-
-//ref: https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_query_response_text_resultset.html
-
-func handleTextResultSet(ctx context.Context, logger *zap.Logger, clientConn, destConn net.Conn, textResultSetPkt *mysql.PacketBundle, decodeCtx *wire.DecodeContext) (*mysql.PacketBundle, error) {
-
-	// colCountPkt is the first packet of the text result set, it is followed by column definition packets, intermediate eof, row data packets and final eof
-
-	textResultSet, ok := textResultSetPkt.Message.(*mysql.TextResultSet)
-	if !ok {
-		return nil, fmt.Errorf("expected TextResultSet, got %T", textResultSetPkt.Message)
-	}
-
-	// Read the column count packet
-	colCount := textResultSet.ColumnCount
-
-	// Read the column definition packets
-	for i := uint64(0); i < colCount; i++ {
-		// Read the column definition packet
-		colData, err := mysqlUtils.ReadPacketBuffer(ctx, logger, destConn)
-		if err != nil {
-			if err != io.EOF {
-				utils.LogError(logger, err, "failed to read column definition packet")
-			}
-			return nil, err
-		}
-
-		// Write the column definition packet to the client
-		_, err = clientConn.Write(colData)
-		if err != nil {
-			utils.LogError(logger, err, "failed to write column definition packet")
-			return nil, err
-		}
-
-		// Decode the column definition packet
-		column, _, err := rowscols.DecodeColumn(ctx, logger, colData)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode column definition packet: %w", err)
-		}
-
-		textResultSet.Columns = append(textResultSet.Columns, column)
-	}
-
-	if !decodeCtx.DeprecateEOF() {
-		logger.Debug("EOF packet is not deprecated while handling textResultSet")
-
-		// Read the EOF packet for column definition
-		eofData, err := mysqlUtils.ReadPacketBuffer(ctx, logger, destConn)
-		if err != nil {
-			if err != io.EOF {
-				utils.LogError(logger, err, "failed to read EOF packet for column definition")
-			}
-			return nil, err
-		}
-
-		// Write the EOF packet for column definition to the client
-		_, err = clientConn.Write(eofData)
-		if err != nil {
-			utils.LogError(logger, err, "failed to write EOF packet for column definition to the client")
-			return nil, err
-		}
-
-		// Validate the EOF packet for column definition
-		if !mysqlUtils.IsEOFPacket(eofData) {
-			return nil, fmt.Errorf("expected EOF packet for column definition, got %v, while handling textResultSet", eofData)
-		}
-
-		textResultSet.EOFAfterColumns = eofData
-
-	}
-	// Read the row data packets
-rowLoop:
-	for {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
-
-			// Read the packet
-			data, err := mysqlUtils.ReadPacketBuffer(ctx, logger, destConn)
-			if err != nil {
-				if err != io.EOF {
-					utils.LogError(logger, err, "failed to read data packet while reading row data")
-				}
-				return nil, err
-			}
-
-			// Write the packet to the client
-			_, err = clientConn.Write(data)
-			if err != nil {
-				utils.LogError(logger, err, "failed to write data packet while reading row data")
-				return nil, err
-			}
-
-			// // Break if the data packet is a generic response
-			// resp, ok := mysqlUtils.IsGenericResponse(data)
-			// if ok {
-			// 	textResultSet.FinalResponse = &mysql.GenericResponse{
-			// 		Data: data,
-			// 		Type: resp,
-			// 	}
-			// 	break rowLoop
-			// }
-
-			// Check for result set terminator. When CLIENT_DEPRECATE_EOF is
-			// negotiated the server replaces the final EOF with an OK packet
-			// that uses a 0xFE header byte. IsOKReplacingEOF validates the
-			// full OK packet structure to avoid false positives with row data.
-			if mysqlUtils.IsResultSetTerminator(data, decodeCtx.DeprecateEOF()) {
-				respType := mysql.StatusToString(mysql.EOF)
-				if decodeCtx.DeprecateEOF() && mysqlUtils.IsOKReplacingEOF(data) {
-					respType = mysql.StatusToString(mysql.OK)
-				}
-				logger.Debug("Found result set terminator in text resultset", zap.String("type", respType))
-				textResultSet.FinalResponse = &mysql.GenericResponse{
-					Data: data,
-					Type: respType,
-				}
-				break rowLoop
-			}
-
-			// It must be a row data packet
-			row, _, err := rowscols.DecodeTextRow(ctx, logger, data, textResultSet.Columns)
-			if err != nil {
-				return nil, fmt.Errorf("failed to decode row data packet: %w", err)
-			}
-			textResultSet.Rows = append(textResultSet.Rows, row)
-		}
-	}
-
-	// reset the last OP
-	decodeCtx.LastOp.Store(clientConn, wire.RESET)
-
-	return textResultSetPkt, nil
-}
-
-//ref: https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_binary_resultset.html
-// (BinaryProtocolResultset)
-
-func handleBinaryResultSet(ctx context.Context, logger *zap.Logger, clientConn, destConn net.Conn, binaryResultSetPkt *mysql.PacketBundle, decodeCtx *wire.DecodeContext) (*mysql.PacketBundle, error) {
-
-	// colCountPkt is the first packet of the binary result set, it is followed by column definition packets,intermediate eof, row data packets and final eof
-
-	binaryResultSet, ok := binaryResultSetPkt.Message.(*mysql.BinaryProtocolResultSet)
-	if !ok {
-		return nil, fmt.Errorf("expected TextResultSet, got %T", binaryResultSetPkt.Message)
-	}
-
-	// Read the column count packet
-	colCount := binaryResultSet.ColumnCount
-
-	logger.Debug("ColCount in handleBinaryResultSet: ", zap.Any("ColCount", colCount))
-	// Read the column definition packets
-	for i := uint64(0); i < colCount; i++ {
-		// Read the column definition packet
-		colData, err := mysqlUtils.ReadPacketBuffer(ctx, logger, destConn)
-		if err != nil {
-			if err != io.EOF {
-				utils.LogError(logger, err, "failed to read column definition packet")
-			}
-			return nil, err
-		}
-
-		// Write the column definition packet to the client
-		_, err = clientConn.Write(colData)
-		if err != nil {
-			utils.LogError(logger, err, "failed to write column definition packet")
-			return nil, err
-		}
-
-		// Decode the column definition packet
-		column, _, err := rowscols.DecodeColumn(ctx, logger, colData)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode column definition packet: %w", err)
-		}
-
-		binaryResultSet.Columns = append(binaryResultSet.Columns, column)
-	}
-
-	logger.Debug("Columns: ", zap.Any("Columns", binaryResultSet.Columns))
-
-	if !decodeCtx.DeprecateEOF() {
-		logger.Debug("EOF packet is not deprecated while handling BinaryProtocolResultSet")
-
-		// Read the EOF packet for column definition
-		eofData, err := mysqlUtils.ReadPacketBuffer(ctx, logger, destConn)
-		if err != nil {
-			if err != io.EOF {
-				utils.LogError(logger, err, "failed to read EOF packet for column definition")
-			}
-			return nil, err
-		}
-
-		// Write the EOF packet for column definition to the client
-		_, err = clientConn.Write(eofData)
-		if err != nil {
-			utils.LogError(logger, err, "failed to write EOF packet for column definition to the client")
-			return nil, err
-		}
-
-		// Validate the EOF packet for column definition
-		if !mysqlUtils.IsEOFPacket(eofData) {
-			return nil, fmt.Errorf("expected EOF packet for column definition, got %v, while handling BinaryProtocolResultSet", eofData)
-		}
-
-		binaryResultSet.EOFAfterColumns = eofData
-	}
-
-	// Read the row data packets
-rowLoop:
-	for {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
-
-			// Read the packet
-			data, err := mysqlUtils.ReadPacketBuffer(ctx, logger, destConn)
-			if err != nil {
-				if err != io.EOF {
-					utils.LogError(logger, err, "failed to read data packet while reading row data")
-				}
-				return nil, err
-			}
-
-			// Write the packet to the client
-			_, err = clientConn.Write(data)
-			if err != nil {
-				utils.LogError(logger, err, "failed to write data packet while reading row data")
-				return nil, err
-			}
-
-			// Break if the data packet is a generic response
-			// resp, ok := mysqlUtils.IsGenericResponse(data)
-			// if ok {
-			// 	binaryResultSet.FinalResponse = &mysql.GenericResponse{
-			// 		Data: data,
-			// 		Type: resp,
-			// 	}
-			// 	//debug log
-			// 	fmt.Println("Found generic response after row data")
-			// 	break rowLoop
-			// }
-
-			// Check for result set terminator. When CLIENT_DEPRECATE_EOF is
-			// negotiated the server replaces the final EOF with an OK packet
-			// that uses a 0xFE header byte (not 0x00), so there is no
-			// ambiguity with binary row data (binary rows start with 0x00).
-			if mysqlUtils.IsResultSetTerminator(data, decodeCtx.DeprecateEOF()) {
-				respType := mysql.StatusToString(mysql.EOF)
-				if decodeCtx.DeprecateEOF() && mysqlUtils.IsOKReplacingEOF(data) {
-					respType = mysql.StatusToString(mysql.OK)
-				}
-				logger.Debug("Found result set terminator in binary resultset", zap.String("type", respType))
-				binaryResultSet.FinalResponse = &mysql.GenericResponse{
-					Data: data,
-					Type: respType,
-				}
-				break rowLoop
-			}
-
-			// It must be a row data packet
-			row, _, err := rowscols.DecodeBinaryRow(ctx, logger, data, binaryResultSet.Columns)
-			if err != nil {
-				return nil, fmt.Errorf("failed to decode row data packet: %w", err)
-			}
-			binaryResultSet.Rows = append(binaryResultSet.Rows, row)
-		}
-	}
-
-	logger.Debug("Rows: ", zap.Any("Rows", binaryResultSet.Rows))
-
-	// reset the last OP
-	decodeCtx.LastOp.Store(clientConn, wire.RESET)
-
-	return binaryResultSetPkt, nil
-
 }
 
 // isCommandPacket returns true if the decoded message is a client command type

--- a/pkg/agent/proxy/integrations/mysql/recorder/reassemble.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/reassemble.go
@@ -1,0 +1,75 @@
+package recorder
+
+// maxMySQLReassemblyBufferSize is the upper bound on how much data the
+// reassembly buffer will hold before discarding partial messages.
+// 16 MB is MySQL's max_allowed_packet default.
+const maxMySQLReassemblyBufferSize = 16 * 1024 * 1024
+
+// mysqlReassemblyBuffer accumulates raw TCP chunks and yields complete
+// MySQL wire-protocol packets. A MySQL packet has a 4-byte header:
+//
+//	bytes 0-2: payload length (3 bytes, little-endian)
+//	byte 3:    sequence ID
+//
+// Total packet size = payload_length + 4.
+type mysqlReassemblyBuffer struct {
+	buf      []byte
+	overflow bool
+}
+
+// append adds raw bytes from a TCP read to the internal buffer.
+func (r *mysqlReassemblyBuffer) append(data []byte) {
+	if r.overflow {
+		return
+	}
+	r.buf = append(r.buf, data...)
+	if len(r.buf) > maxMySQLReassemblyBufferSize {
+		r.buf = nil
+		r.overflow = true
+	}
+}
+
+// extractCompletePacket returns the first complete MySQL packet, or nil
+// if not enough data has been accumulated yet. Each call removes the
+// returned packet from the buffer.
+func (r *mysqlReassemblyBuffer) extractCompletePacket() []byte {
+	if len(r.buf) < 4 {
+		return nil
+	}
+	// MySQL payload length is the first 3 bytes, little-endian.
+	payloadLen := int(r.buf[0]) | int(r.buf[1])<<8 | int(r.buf[2])<<16
+	totalLen := payloadLen + 4
+	if totalLen > maxMySQLReassemblyBufferSize {
+		// Invalid — skip header to avoid getting stuck.
+		if len(r.buf) > 4 {
+			r.buf = r.buf[4:]
+		} else {
+			r.buf = nil
+		}
+		return nil
+	}
+	if len(r.buf) < totalLen {
+		return nil // partial packet
+	}
+
+	complete := make([]byte, totalLen)
+	copy(complete, r.buf[:totalLen])
+
+	remaining := copy(r.buf, r.buf[totalLen:])
+	if remaining == 0 {
+		r.buf = nil
+	} else {
+		r.buf = r.buf[:remaining]
+	}
+	return complete
+}
+
+// pending returns the number of bytes buffered but not yet extracted.
+func (r *mysqlReassemblyBuffer) pending() int {
+	return len(r.buf)
+}
+
+// didOverflow returns true if the buffer had to discard data.
+func (r *mysqlReassemblyBuffer) didOverflow() bool {
+	return r.overflow
+}

--- a/pkg/agent/proxy/integrations/mysql/replayer/conn.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/conn.go
@@ -361,7 +361,8 @@ func simulateInitialHandshake(ctx context.Context, logger *zap.Logger, clientCon
 		}
 
 		// Since auth switch response data can be different, we should just check the sequence number
-		if authSwitchRespMock.Header.Header.SequenceID != authSwitchRespPkt.Header.SequenceID {
+		if authSwitchRespMock.Header != nil && authSwitchRespMock.Header.Header != nil &&
+			authSwitchRespMock.Header.Header.SequenceID != authSwitchRespPkt.Header.SequenceID {
 			utils.LogError(logger, nil, "sequence number mismatch for auth switch response", zap.Any("expected", authSwitchRespMock.Header.Header.SequenceID), zap.Any("actual", authSwitchRespPkt.Header.SequenceID))
 			return res, fmt.Errorf("sequence number mismatch for auth switch response")
 		}
@@ -681,7 +682,8 @@ func simulateFullAuth(ctx context.Context, logger *zap.Logger, clientConn net.Co
 	}
 
 	// Since encrypted password can be different, we should just check the sequence number
-	if encryptedPassMock.Header.Header.SequenceID != encryptedPassPkt.Header.SequenceID {
+	if encryptedPassMock.Header != nil && encryptedPassMock.Header.Header != nil &&
+		encryptedPassMock.Header.Header.SequenceID != encryptedPassPkt.Header.SequenceID {
 		utils.LogError(logger, nil, "sequence number mismatch for encrypted password", zap.Any("expected", encryptedPassMock.Header.Header.SequenceID), zap.Any("actual", encryptedPassPkt.Header.SequenceID))
 		return fmt.Errorf("sequence number mismatch for encrypted password")
 	}

--- a/pkg/agent/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match.go
@@ -553,7 +553,9 @@ func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.Packe
 		return false, 0
 	}
 
-	if actual.Header.Header.PayloadLength == expected.Header.Header.PayloadLength {
+	if actual.Header != nil && actual.Header.Header != nil &&
+		expected.Header != nil && expected.Header.Header != nil &&
+		actual.Header.Header.PayloadLength == expected.Header.Header.PayloadLength {
 		matchCount++
 		if expectedQuery == actualQuery {
 			matchCount++

--- a/pkg/agent/proxy/integrations/mysql/wire/encode.go
+++ b/pkg/agent/proxy/integrations/mysql/wire/encode.go
@@ -155,7 +155,9 @@ func EncodeToBinary(ctx context.Context, logger *zap.Logger, packet *mysql.Packe
 		payloadLen = int(packet.Header.Header.PayloadLength)
 	}
 	binary.LittleEndian.PutUint32(header, uint32(payloadLen))
-	header[3] = packet.Header.Header.SequenceID
+	if packet.Header != nil && packet.Header.Header != nil {
+		header[3] = packet.Header.Header.SequenceID
+	}
 	data = append(header, data...)
 
 	logger.Debug("Encoded Packet", zap.String("packet", packet.Header.Type), zap.ByteString("data", data))

--- a/pkg/agent/proxy/integrations/mysql/wire/encode.go
+++ b/pkg/agent/proxy/integrations/mysql/wire/encode.go
@@ -16,6 +16,10 @@ import (
 
 func EncodeToBinary(ctx context.Context, logger *zap.Logger, packet *mysql.PacketBundle, clientConn net.Conn, decodeCtx *DecodeContext) ([]byte, error) {
 
+	if packet == nil {
+		return nil, fmt.Errorf("packet is nil")
+	}
+
 	var data []byte
 	var err error
 
@@ -141,6 +145,12 @@ func EncodeToBinary(ctx context.Context, logger *zap.Logger, packet *mysql.Packe
 		if err != nil {
 			return nil, fmt.Errorf("error encoding BinaryProtocolResultSet: %v", err)
 		}
+	default:
+		return nil, fmt.Errorf("unhandled mysql message type %T for encoding", packet.Message)
+	}
+
+	if packet.Header == nil {
+		return nil, fmt.Errorf("packet header is nil for message type %T", packet.Message)
 	}
 
 	// Encode the header for the packet
@@ -151,11 +161,11 @@ func EncodeToBinary(ctx context.Context, logger *zap.Logger, packet *mysql.Packe
 	// PayloadLength corresponds to that first payload only (e.g., column-count = 1).
 	// For single-packet messages, we can safely use len(data).
 	payloadLen := len(data)
-	if isCompositeMessage(packet.Message) && packet.Header != nil && packet.Header.Header != nil {
+	if isCompositeMessage(packet.Message) && packet.Header.Header != nil {
 		payloadLen = int(packet.Header.Header.PayloadLength)
 	}
 	binary.LittleEndian.PutUint32(header, uint32(payloadLen))
-	if packet.Header != nil && packet.Header.Header != nil {
+	if packet.Header.Header != nil {
 		header[3] = packet.Header.Header.SequenceID
 	}
 	data = append(header, data...)

--- a/pkg/agent/proxy/mockmanager.go
+++ b/pkg/agent/proxy/mockmanager.go
@@ -148,8 +148,11 @@ func (m *MockManager) ensureKindTrees(kind models.Kind) (f *TreeDb, u *TreeDb) {
 // ---------- getters ----------
 
 func (m *MockManager) GetFilteredMocks() ([]*models.Mock, error) {
+	m.treesMu.RLock()
+	tree := m.filtered
+	m.treesMu.RUnlock()
 	results := make([]*models.Mock, 0, 64)
-	m.filtered.rangeValues(func(v interface{}) bool {
+	tree.rangeValues(func(v interface{}) bool {
 		if mock, ok := v.(*models.Mock); ok && mock != nil {
 			results = append(results, mock)
 		}
@@ -159,8 +162,11 @@ func (m *MockManager) GetFilteredMocks() ([]*models.Mock, error) {
 }
 
 func (m *MockManager) GetUnFilteredMocks() ([]*models.Mock, error) {
+	m.treesMu.RLock()
+	tree := m.unfiltered
+	m.treesMu.RUnlock()
 	results := make([]*models.Mock, 0, 128)
-	m.unfiltered.rangeValues(func(v interface{}) bool {
+	tree.rangeValues(func(v interface{}) bool {
 		if mock, ok := v.(*models.Mock); ok && mock != nil {
 			results = append(results, mock)
 		}
@@ -300,8 +306,12 @@ func (m *MockManager) SetUnFilteredMocks(mocks []*models.Mock) {
 // ---------- point updates / deletes (keep per-kind in sync) ----------
 
 func (m *MockManager) UpdateUnFilteredMock(old *models.Mock, new *models.Mock) bool {
+	// Snapshot the legacy tree pointer safely
+	m.treesMu.RLock()
+	globalTree := m.unfiltered
+	m.treesMu.RUnlock()
 	// Update legacy/global tree first
-	updatedGlobal := m.unfiltered.update(old.TestModeInfo, new.TestModeInfo, new)
+	updatedGlobal := globalTree.update(old.TestModeInfo, new.TestModeInfo, new)
 
 	oldK, newK := old.Kind, new.Kind
 	var updatedOldKind, updatedNewKind bool
@@ -382,7 +392,10 @@ func (m *MockManager) UpdateUnFilteredMock(old *models.Mock, new *models.Mock) b
 }
 
 func (m *MockManager) DeleteFilteredMock(mock models.Mock) bool {
-	deletedGlobal := m.filtered.delete(mock.TestModeInfo)
+	m.treesMu.RLock()
+	globalTree := m.filtered
+	m.treesMu.RUnlock()
+	deletedGlobal := globalTree.delete(mock.TestModeInfo)
 
 	// per-kind
 	k := mock.Kind
@@ -417,7 +430,10 @@ func (m *MockManager) DeleteFilteredMock(mock models.Mock) bool {
 }
 
 func (m *MockManager) DeleteUnFilteredMock(mock models.Mock) bool {
-	deletedGlobal := m.unfiltered.delete(mock.TestModeInfo)
+	m.treesMu.RLock()
+	globalTree := m.unfiltered
+	m.treesMu.RUnlock()
+	deletedGlobal := globalTree.delete(mock.TestModeInfo)
 
 	// per-kind
 	k := mock.Kind
@@ -537,7 +553,10 @@ func (m *MockManager) GetMySQLCounts() (total, config, data int) {
 	}
 
 	// Fallback: legacy scan of the combined tree
-	m.unfiltered.rangeValues(func(v interface{}) bool {
+	m.treesMu.RLock()
+	legacyTree := m.unfiltered
+	m.treesMu.RUnlock()
+	legacyTree.rangeValues(func(v interface{}) bool {
 		mock, ok := v.(*models.Mock)
 		if !ok || mock == nil || mock.Kind != models.MySQL {
 			return true


### PR DESCRIPTION
This pull request introduces significant improvements to the `memoryguard` package to enhance memory usage detection, particularly in containerized environments, and updates the default integration branch for CI workflows. The most important changes are grouped below.

**Memory usage detection and container compatibility improvements:**

* The memory guard now uses a new `readWorkingSetBytes` function to subtract `inactive_file` from `memory.current`, aligning memory pressure detection with Kubernetes eviction logic and avoiding false positives due to page cache. This function gracefully degrades to raw usage if necessary. [[1]](diffhunk://#diff-b597479dff56c27e654bada78151f778532c3f98f3480063b7809332d3ec5aeaL128-R131) [[2]](diffhunk://#diff-b597479dff56c27e654bada78151f778532c3f98f3480063b7809332d3ec5aeaR217-R295)
* Added comprehensive fallback logic in `resolveMemoryUsagePath` to support macOS with Docker Desktop and kind clusters, including a new `findCgroupByOwnPID` method that walks the cgroup tree to find the correct scope by matching the process's root namespace PID. This ensures accurate memory usage detection in environments lacking cgroup namespace isolation. [[1]](diffhunk://#diff-b597479dff56c27e654bada78151f778532c3f98f3480063b7809332d3ec5aeaR310-R325) [[2]](diffhunk://#diff-b597479dff56c27e654bada78151f778532c3f98f3480063b7809332d3ec5aeaL556-R714)
* Improved code comments and logging throughout the memory guard to clarify logic and provide better observability, including logging memory usage on each check. [[1]](diffhunk://#diff-b597479dff56c27e654bada78151f778532c3f98f3480063b7809332d3ec5aeaR151-R157) [[2]](diffhunk://#diff-b597479dff56c27e654bada78151f778532c3f98f3480063b7809332d3ec5aeaR217-R295)

**Code cleanup and refactoring:**

* Removed unnecessary blank lines and improved code organization in `memoryguard.go` for better readability and maintainability. [[1]](diffhunk://#diff-b597479dff56c27e654bada78151f778532c3f98f3480063b7809332d3ec5aeaL63) [[2]](diffhunk://#diff-b597479dff56c27e654bada78151f778532c3f98f3480063b7809332d3ec5aeaL278) [[3]](diffhunk://#diff-b597479dff56c27e654bada78151f778532c3f98f3480063b7809332d3ec5aeaL311-L315) [[4]](diffhunk://#diff-b597479dff56c27e654bada78151f778532c3f98f3480063b7809332d3ec5aeaL326) [[5]](diffhunk://#diff-b597479dff56c27e654bada78151f778532c3f98f3480063b7809332d3ec5aeaL335-L346) [[6]](diffhunk://#diff-b597479dff56c27e654bada78151f778532c3f98f3480063b7809332d3ec5aeaL364) [[7]](diffhunk://#diff-b597479dff56c27e654bada78151f778532c3f98f3480063b7809332d3ec5aeaL373-L392) [[8]](diffhunk://#diff-b597479dff56c27e654bada78151f778532c3f98f3480063b7809332d3ec5aeaL404-L410) [[9]](diffhunk://#diff-b597479dff56c27e654bada78151f778532c3f98f3480063b7809332d3ec5aeaL429-L436) [[10]](diffhunk://#diff-b597479dff56c27e654bada78151f778532c3f98f3480063b7809332d3ec5aeaL446) [[11]](diffhunk://#diff-b597479dff56c27e654bada78151f778532c3f98f3480063b7809332d3ec5aeaL456-L473) [[12]](diffhunk://#diff-b597479dff56c27e654bada78151f778532c3f98f3480063b7809332d3ec5aeaL482) [[13]](diffhunk://#diff-b597479dff56c27e654bada78151f778532c3f98f3480063b7809332d3ec5aeaL505) [[14]](diffhunk://#diff-b597479dff56c27e654bada78151f778532c3f98f3480063b7809332d3ec5aeaL519-L545)

**Continuous Integration and workflow updates:**

* Changed the default integration branch from `memory-aware-parsers` to `async-decoding` in both the GitHub Actions workflow and the setup action to use the latest feature branch for integration tests. [[1]](diffhunk://#diff-641f4f19c29ac1e9006ab4e913191f7845862a927fc94380f4678eb01645aa79L15-R15) [[2]](diffhunk://#diff-7c30939a72f708f472640a4e3253a7c116ec949d9c33f8c4c78431e15ec84597L9-R9)

**Miscellaneous:**

* Minor import cleanup in `pkg/agent/proxy/integrations/http/encode.go` to remove unused imports and add `bytes`.

## Links & References

**Closes:** https://github.com/keploy/enterprise/issues/1856

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [X] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [X] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [X] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [X] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [X] 🙅 no, because it is not needed

## Self Review done?
- [X] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [X] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [X] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [X] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?