### PR TITLE
ci: add oss_branch selector to manual release workflow

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       oss_branch:
-        description: 'OSS branch to build from (keploy/keploy). Defaults to flipkart.'
-        required: false
-        default: 'flipkart'
+        description: 'OSS branch to build from (keploy/keploy)'
+        required: true
+        default: 'main'
         type: string
 
 permissions:
@@ -25,7 +25,7 @@ jobs:
       - name: Resolve commit
         id: commit
         env:
-          OSS_BRANCH: ${{ inputs.oss_branch || 'flipkart' }}
+          OSS_BRANCH: ${{ inputs.oss_branch }}
         run: |
           set -e
           source_repo="https://github.com/keploy/keploy.git"

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -2,6 +2,12 @@ name: Manual Release Trigger
 
 on:
   workflow_dispatch:
+    inputs:
+      oss_branch:
+        description: 'OSS branch to build from (keploy/keploy). Defaults to flipkart.'
+        required: false
+        default: 'flipkart'
+        type: string
 
 permissions:
   contents: read
@@ -18,10 +24,12 @@ jobs:
     steps:
       - name: Resolve commit
         id: commit
+        env:
+          OSS_BRANCH: ${{ inputs.oss_branch || 'flipkart' }}
         run: |
           set -e
           source_repo="https://github.com/keploy/keploy.git"
-          source_branch="flipkart"
+          source_branch="${OSS_BRANCH}"
           commit_sha="$(git ls-remote "${source_repo}" "refs/heads/${source_branch}" | awk '{print $1}')"
           if [ -z "$commit_sha" ]; then
             echo "Failed to resolve the head commit for branch '${source_branch}' from repository '${source_repo}'."


### PR DESCRIPTION
## Describe the changes that are made
- Added an `oss_branch` input to the `workflow_dispatch` trigger in `.github/workflows/manual-release.yml`
- The input defaults to `flipkart`, preserving existing behaviour when left blank
- The "Resolve commit" step now reads the branch from the `OSS_BRANCH` env var (sourced from the input) instead of a hardcoded string

This lets anyone triggering the workflow from the GitHub Actions UI pick a different OSS branch (e.g. `main`, a feature branch, or a hotfix branch) without editing the workflow file.

## Links & References

**Closes:** NA

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [x] 🔁 CI

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed

## Added comments for hard-to-understand areas?
- [x] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

**To test:**
1. Go to Actions → Manual Release Trigger → Run workflow
2. You will now see an **"OSS branch to build from"** text field pre-filled with `flipkart`
3. Leave it blank / set `flipkart` → pipeline resolves the same commit as before
4. Set a different branch name (e.g. `main`) → pipeline resolves the head of that branch and forwards it to Woodpecker as `OSS_COMMIT_SHA`

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA