### PR TITLE
fix: expected mock ordering

### DIFF
--- a/pkg/service/runner/runner.go
+++ b/pkg/service/runner/runner.go
@@ -221,13 +221,7 @@ func (r *Runner) loadMocks(ctx context.Context, testSetID, testCaseName string, 
 	}
 
 	// Resolve which mocks are needed.
-	mocksThatHaveMappings, mocksWeNeed := r.resolveMockSets(ctx, testSetID, testCaseName)
-
-	// Build the expected mock names list from the mapping.
-	var expected []string
-	for name := range mocksWeNeed {
-		expected = append(expected, name)
-	}
+	mocksThatHaveMappings, mocksWeNeed, expected := r.resolveMockSets(ctx, testSetID, testCaseName)
 
 	// Fetch mocks.
 	afterTime := models.BaseTime
@@ -266,9 +260,10 @@ func (r *Runner) loadMocks(ctx context.Context, testSetID, testCaseName string, 
 	return expected, cleanup, nil
 }
 
-func (r *Runner) resolveMockSets(ctx context.Context, testSetID, testCaseName string) (mocksThatHaveMappings, mocksWeNeed map[string]bool) {
+func (r *Runner) resolveMockSets(ctx context.Context, testSetID, testCaseName string) (mocksThatHaveMappings, mocksWeNeed map[string]bool, expected []string) {
 	mocksThatHaveMappings = make(map[string]bool)
 	mocksWeNeed = make(map[string]bool)
+	expected = make([]string, 0)
 
 	if r.mappingDB == nil {
 		return
@@ -287,9 +282,15 @@ func (r *Runner) resolveMockSets(ctx context.Context, testSetID, testCaseName st
 			for _, m := range mocks {
 				mocksWeNeed[m.Name] = true
 			}
+			for m := range mocksWeNeed {
+				expected = append(expected, m)
+			}
 		}
 	} else {
 		mocksWeNeed = mocksThatHaveMappings
+		for m := range mocksWeNeed {
+			expected = append(expected, m)
+		}
 	}
 	return
 }

--- a/pkg/service/runner/runner.go
+++ b/pkg/service/runner/runner.go
@@ -83,10 +83,8 @@ func (r *Runner) RunTest(ctx context.Context, opts RunTestOpts) *TestResult {
 	}
 
 	// 3. Wait for app.
-	if opts.ServiceURL != "" {
-		if err := waitForApp(ctx, opts.ServiceURL, 2*time.Minute, r.logger); err != nil {
-			return &TestResult{Passed: false, Error: fmt.Sprintf("app not reachable: %v", err), Noise: tc.Noise}
-		}
+	if err := waitForApp(ctx, opts.ServiceURL, 2*time.Minute, r.logger); err != nil {
+		return &TestResult{Passed: false, Error: fmt.Sprintf("app not reachable: %v", err), Noise: tc.Noise}
 	}
 
 	// 4. Global noise.
@@ -135,21 +133,19 @@ func (r *Runner) RunTest(ctx context.Context, opts RunTestOpts) *TestResult {
 func (r *Runner) executeAndCompare(ctx context.Context, tc *models.TestCase, serviceURL string, noise models.GlobalNoise) (bool, models.RespCompare, error) {
 	tcCopy := *tc
 
-	if serviceURL != "" {
-		orig, err := url.Parse(tc.HTTPReq.URL)
-		if err != nil {
-			return false, models.RespCompare{}, fmt.Errorf("invalid original URL: %w", err)
-		}
-		svc, err := url.Parse(serviceURL)
-		if err != nil {
-			return false, models.RespCompare{}, fmt.Errorf("invalid service URL: %w", err)
-		}
-		orig.Scheme = svc.Scheme
-		orig.Host = svc.Host
-		httpReq := tc.HTTPReq
-		httpReq.URL = orig.String()
-		tcCopy.HTTPReq = httpReq
+	orig, err := url.Parse(tc.HTTPReq.URL)
+	if err != nil {
+		return false, models.RespCompare{}, fmt.Errorf("invalid original URL: %w", err)
 	}
+	svc, err := url.Parse(serviceURL)
+	if err != nil {
+		return false, models.RespCompare{}, fmt.Errorf("invalid service URL: %w", err)
+	}
+	orig.Scheme = svc.Scheme
+	orig.Host = svc.Host
+	httpReq := tc.HTTPReq
+	httpReq.URL = orig.String()
+	tcCopy.HTTPReq = httpReq
 
 	actual, err := keployPkg.SimulateHTTP(ctx, &tcCopy, "", r.logger, keployPkg.SimulationConfig{})
 	if err != nil {

--- a/pkg/service/runner/runner.go
+++ b/pkg/service/runner/runner.go
@@ -234,7 +234,10 @@ func (r *Runner) loadMocks(ctx context.Context, testSetID, testCaseName string, 
 	}
 
 	// Resolve which mocks are needed.
-	mocksThatHaveMappings, mocksWeNeed, expected := r.resolveMockSets(ctx, testSetID, testCaseName)
+	mocksThatHaveMappings, mocksWeNeed, expected, err := r.resolveMockSets(ctx, testSetID, testCaseName)
+	if err != nil {
+		return nil, cleanup, fmt.Errorf("failed to resolve mock sets: %w", err)
+	}
 
 	// Fetch mocks.
 	afterTime := models.BaseTime
@@ -273,16 +276,20 @@ func (r *Runner) loadMocks(ctx context.Context, testSetID, testCaseName string, 
 	return expected, cleanup, nil
 }
 
-func (r *Runner) resolveMockSets(ctx context.Context, testSetID, testCaseName string) (mocksThatHaveMappings, mocksWeNeed map[string]bool, expected []string) {
+func (r *Runner) resolveMockSets(ctx context.Context, testSetID, testCaseName string) (mocksThatHaveMappings, mocksWeNeed map[string]bool, expected []string, err error) {
 	mocksThatHaveMappings = make(map[string]bool)
 	mocksWeNeed = make(map[string]bool)
-	expected = make([]string, 0)
 
 	if r.mappingDB == nil {
 		return
 	}
-	testMockMappings, hasMeaningful, err := r.mappingDB.Get(ctx, testSetID)
-	if err != nil || !hasMeaningful {
+	testMockMappings, hasMeaningful, getErr := r.mappingDB.Get(ctx, testSetID)
+	if getErr != nil {
+		err = fmt.Errorf("failed to get mock mappings for test set %q: %w", testSetID, getErr)
+		return
+	}
+	if !hasMeaningful {
+		err = fmt.Errorf("no mock mappings found for test set %q", testSetID)
 		return
 	}
 	for _, mocks := range testMockMappings {
@@ -291,11 +298,14 @@ func (r *Runner) resolveMockSets(ctx context.Context, testSetID, testCaseName st
 		}
 	}
 
-	if mocks, ok := testMockMappings[testCaseName]; ok {
-		for _, m := range mocks {
-			mocksWeNeed[m.Name] = true
-			expected = append(expected, m.Name)
-		}
+	mocks, ok := testMockMappings[testCaseName]
+	if !ok {
+		err = fmt.Errorf("no mock mapping found for test case %q in test set %q", testCaseName, testSetID)
+		return
+	}
+	for _, m := range mocks {
+		mocksWeNeed[m.Name] = true
+		expected = append(expected, m.Name)
 	}
 	return
 }

--- a/pkg/service/runner/runner.go
+++ b/pkg/service/runner/runner.go
@@ -49,6 +49,19 @@ func New(
 }
 
 func (r *Runner) RunTest(ctx context.Context, opts RunTestOpts) *TestResult {
+
+	if opts.TestSetID == "" {
+		return &TestResult{Passed: false, Error: "TestSetID is required"}
+	}
+
+	if opts.TestStepID == "" {
+		return &TestResult{Passed: false, Error: "TestStepID is required"}
+	}
+
+	if opts.ServiceURL == "" {
+		return &TestResult{Passed: false, Error: "ServiceURL is required"}
+	}
+
 	// 1. Fetch the recorded test case.
 	tc, err := r.loadTestCase(ctx, opts.TestSetID, opts.TestStepID)
 	if err != nil {
@@ -277,18 +290,11 @@ func (r *Runner) resolveMockSets(ctx context.Context, testSetID, testCaseName st
 			mocksThatHaveMappings[m.Name] = true
 		}
 	}
-	if testCaseName != "" {
-		if mocks, ok := testMockMappings[testCaseName]; ok {
-			for _, m := range mocks {
-				mocksWeNeed[m.Name] = true
-				expected = append(expected, m.Name)
 
-			}
-		}
-	} else {
-		mocksWeNeed = mocksThatHaveMappings
-		for m := range mocksWeNeed {
-			expected = append(expected, m)
+	if mocks, ok := testMockMappings[testCaseName]; ok {
+		for _, m := range mocks {
+			mocksWeNeed[m.Name] = true
+			expected = append(expected, m.Name)
 		}
 	}
 	return

--- a/pkg/service/runner/runner.go
+++ b/pkg/service/runner/runner.go
@@ -277,6 +277,7 @@ func (r *Runner) resolveMockSets(ctx context.Context, testSetID, testCaseName st
 	mocksWeNeed = make(map[string]bool)
 
 	if r.mappingDB == nil {
+		err = fmt.Errorf("mappingDB not configured; initialize the mapping database dependency to resolve which mocks are needed for test execution")
 		return
 	}
 	testMockMappings, hasMeaningful, getErr := r.mappingDB.Get(ctx, testSetID)

--- a/pkg/service/runner/runner.go
+++ b/pkg/service/runner/runner.go
@@ -281,9 +281,8 @@ func (r *Runner) resolveMockSets(ctx context.Context, testSetID, testCaseName st
 		if mocks, ok := testMockMappings[testCaseName]; ok {
 			for _, m := range mocks {
 				mocksWeNeed[m.Name] = true
-			}
-			for m := range mocksWeNeed {
-				expected = append(expected, m)
+				expected = append(expected, m.Name)
+
 			}
 		}
 	} else {


### PR DESCRIPTION
This pull request refactors how the `expected` mock names list is constructed and returned in the `Runner` service. The main change is to centralize the logic for building the `expected` list within the `resolveMockSets` function, eliminating redundant code and improving maintainability.

Refactoring and code simplification:

* Updated the signature of `resolveMockSets` in `runner.go` to return the `expected` mock names list directly, instead of requiring the caller to build it.
* Moved the logic for constructing the `expected` list from `loadMocks` into `resolveMockSets`, ensuring the list is built in one place. [[1]](diffhunk://#diff-1cf95248bd716268f9ba9a72f940c89a8b600ae015d95849e9bca1e19ec1302eL224-R224) [[2]](diffhunk://#diff-1cf95248bd716268f9ba9a72f940c89a8b600ae015d95849e9bca1e19ec1302eR285-R293)