### PR TITLE
fix: add Logs field to TestReport

### DIFF
--- a/pkg/models/testrun.go
+++ b/pkg/models/testrun.go
@@ -23,6 +23,7 @@ type TestReport struct {
 	TimeTaken     string       `json:"time_taken" yaml:"time_taken"`
 	CmdUsed       string       `json:"cmdUsed,omitempty" yaml:"cmdUsed,omitempty"`
 	AppLogs       string       `json:"appLogs,omitempty" yaml:"app_logs,omitempty"`
+	Logs          string       `json:"logs,omitempty" yaml:"logs,omitempty"`
 }
 
 type TestCoverage struct {


### PR DESCRIPTION
Add Logs field to the TestReport struct. This field is needed for better test failure reporting.

Fixes #3975.