### PR TITLE
fix: preserve comma-separated header values during replay

### DIFF
--- a/pkg/util.go
+++ b/pkg/util.go
@@ -206,13 +206,13 @@ func CompareMultiValueHeaders(mockHeaderValue string, inputHeaderValue []string)
 func ToHTTPHeader(mockHeader map[string]string) http.Header {
 	header := http.Header{}
 	for i, j := range mockHeader {
-		match := IsTime(j)
-		if match {
-			//Values like "Tue, 17 Jan 2023 16:34:58 IST" should be considered as single element
-			header[i] = []string{j}
-			continue
-		}
-		header[i] = strings.Split(j, ",")
+		// Preserve the recorded value as a single header value. Splitting on ","
+		// here corrupts headers whose value legitimately contains commas
+		// (e.g. `compatible_components: CC1,CC2,CC3`) by turning one header
+		// into multiple header lines, which many servers read as just the
+		// first value. Emitting a single line with commas is semantically
+		// equivalent to multiple lines for standard list-valued headers.
+		header[i] = []string{j}
 	}
 	return header
 }

--- a/pkg/util_test.go
+++ b/pkg/util_test.go
@@ -856,16 +856,19 @@ func TestIsTime_VariousFormats_808(t *testing.T) {
 	}
 }
 
-// TestToHTTPHeader_WithTimeValue_909 verifies that the ToHTTPHeader function correctly
-// converts a map of strings to an http.Header object. It specifically checks that
-// header values recognized as timestamps are not split by commas, while other
-// comma-separated values are correctly split into slices.
+// TestToHTTPHeader_WithTimeValue_909 verifies that the ToHTTPHeader function
+// converts a map of strings to an http.Header object, preserving each recorded
+// value as a single header value. Splitting on "," would corrupt values whose
+// content legitimately contains commas (e.g. `compatible_components: CC1,CC2,CC3`),
+// so both timestamp values and comma-separated list values must round-trip
+// untouched.
 func TestToHTTPHeader_WithTimeValue_909(t *testing.T) {
 	// Arrange
 	mockHeader := map[string]string{
-		"Date":            "Tue, 17 Jan 2023 16:34:58 IST",
-		"X-Custom-Header": "value1,value2",
-		"Content-Type":    "application/json",
+		"Date":                  "Tue, 17 Jan 2023 16:34:58 IST",
+		"X-Custom-Header":       "value1,value2",
+		"Content-Type":          "application/json",
+		"Compatible-Components": "CC1,CC2,CC3",
 	}
 
 	// Act
@@ -874,8 +877,9 @@ func TestToHTTPHeader_WithTimeValue_909(t *testing.T) {
 	// Assert
 	require.NotNil(t, httpHeader)
 	assert.Equal(t, []string{"Tue, 17 Jan 2023 16:34:58 IST"}, httpHeader["Date"])
-	assert.Equal(t, []string{"value1", "value2"}, httpHeader["X-Custom-Header"])
+	assert.Equal(t, []string{"value1,value2"}, httpHeader["X-Custom-Header"])
 	assert.Equal(t, []string{"application/json"}, httpHeader["Content-Type"])
+	assert.Equal(t, []string{"CC1,CC2,CC3"}, httpHeader["Compatible-Components"])
 }
 
 // TestParseHTTPRequest_And_Response_111 contains sub-tests for ParseHTTPRequest and


### PR DESCRIPTION
## Describe the changes that are made
- `pkg/util.go` — `ToHTTPHeader` no longer splits recorded header values on `,`. A recorded value like `compatible_components: CC1,CC2,CC3` was being expanded into a 3-element `[]string`, so Go's http client emitted three separate `Compatible-Components:` lines and downstream servers typically picked up only the first value (`CC1`), dropping the rest. The recorded value is now preserved as a single header value, which is semantically equivalent to multiple lines for standard list-valued headers and correctly preserves atomic comma-containing values.
- `pkg/util_test.go` — updated `TestToHTTPHeader_WithTimeValue_909` to reflect the new behavior and added a regression case for `Compatible-Components: CC1,CC2,CC3`.

### Before / After (end-to-end `keploy record` → `keploy test`)

**Before (buggy):**
```
EXPECT HEADER                                 ACTUAL HEADER
Echoed-Compatible-Components: [CC1 CC2 CC3]   Echoed-Compatible-Components: [CC1]

EXPECT BODY                                   ACTUAL BODY
"Compatible-Components": ["CC1,CC2,CC3"]      "Compatible-Components": ["CC1","CC2","CC3"]

Total test passed: 0
Total test failed: 1
```

**After (fixed):**
```
Echoed-Compatible-Components: [CC1,CC2,CC3]   (expected == actual)
"Compatible-Components": ["CC1,CC2,CC3"]      (one slot, full value)

Total test passed: 1
Total test failed: 0
```

## Links & References

**Closes:** NA

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [x] 🐞 Bug Fix

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed (covered by the existing `pkg/util_test.go` unit test, which now includes the `CC1,CC2,CC3` regression case)

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

**Repro / verification steps**

1. Start a tiny HTTP server that echoes request headers back in the response body and as an `Echoed-Compatible-Components` response header.
2. `keploy record -c ./server` — hit the server with `curl -H 'Compatible-Components: CC1,CC2,CC3' http://localhost:8090/echo-headers`. The recorded YAML stores `Compatible-Components: CC1,CC2,CC3` (recording already worked correctly).
3. `keploy test -c ./server`:
   - On `main`: the replayed request sends three separate `Compatible-Components:` lines. The server's `r.Header.Get(...)` returns only `CC1`, which is echoed back in `Echoed-Compatible-Components`. The testcase fails with a header/body mismatch.
   - On this branch: the replayed request sends a single `Compatible-Components: CC1,CC2,CC3` line, the server echoes the full value back, and the testcase passes.

Unit test: `go test ./pkg/ -run TestToHTTPHeader` — green.

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA