### PR TITLE
fix: rejecting root path in macos/kind cluster for calculating memory

### DIFF
--- a/pkg/agent/memoryguard/memoryguard.go
+++ b/pkg/agent/memoryguard/memoryguard.go
@@ -522,25 +522,24 @@ func extractHexIdentifiers(value string) []string {
 // where "/" maps to VM-wide memory), fileExists will fail and the caller
 // falls through to identifier-based or PID-based resolution.
 func resolveFromSelfCgroup(layout cgroupLayout, procSelfCgroupPath string) (string, error) {
-	cgroupPath, err := readSelfCgroupPath(procSelfCgroupPath, layout)
-	if err != nil {
-		return "", err
-	}
+    cgroupPath, err := readSelfCgroupPath(procSelfCgroupPath, layout)
+    if err != nil {
+        return "", err
+    }
 
-	// An empty cgroup path is invalid — fall through to identifier-based
-	// resolution.
-	if cgroupPath == "" {
-		return "", fmt.Errorf("cgroup self-path is empty; skipping to container-specific resolution")
-	}
+    // Reject the root path ("/") so it is forced to use your PID-based fallback on macOS
+    if cgroupPath == "/" || cgroupPath == "" {
+        return "", fmt.Errorf("cgroup self-path is root (%q); skipping to container-specific resolution", cgroupPath)
+    }
 
-	candidate, ok := buildMountedCgroupPath(layout.mountPoint, layout.mountRoot, cgroupPath, layout.usageFile)
-	if !ok {
-		return "", fmt.Errorf("unable to map cgroup path %q to mount %q", cgroupPath, layout.mountPoint)
-	}
-	if !fileExists(candidate) {
-		return "", fmt.Errorf("cgroup memory file %q not found", candidate)
-	}
-	return candidate, nil
+    candidate, ok := buildMountedCgroupPath(layout.mountPoint, layout.mountRoot, cgroupPath, layout.usageFile)
+    if !ok {
+        return "", fmt.Errorf("unable to map cgroup path %q to mount %q", cgroupPath, layout.mountPoint)
+    }
+    if !fileExists(candidate) {
+        return "", fmt.Errorf("cgroup memory file %q not found", candidate)
+    }
+    return candidate, nil
 }
 
 func buildMountedCgroupPath(mountPoint, mountRoot, cgroupPath, usageFile string) (string, bool) {

--- a/pkg/agent/memoryguard/memoryguard.go
+++ b/pkg/agent/memoryguard/memoryguard.go
@@ -239,17 +239,30 @@ func readMemoryCurrent(path string) (int64, error) {
 // If memory.stat is unavailable the raw memory.current value is returned so
 // the guard still functions (conservatively).
 func readWorkingSetBytes(memCurrentPath string) (int64, error) {
-	currentBytes, err := readMemoryCurrent(memCurrentPath)
+	currentBytes, inactiveFile, err := readMemoryStats(memCurrentPath)
 	if err != nil {
 		return 0, err
+	}
+	workingSet := currentBytes - inactiveFile
+	if workingSet < 0 {
+		workingSet = 0
+	}
+	return workingSet, nil
+}
+
+// readMemoryStats returns (memory.current, inactive_file). Exposed for
+// local-testing diagnostics so callers can log both components of the
+// working-set calculation.
+func readMemoryStats(memCurrentPath string) (int64, int64, error) {
+	currentBytes, err := readMemoryCurrent(memCurrentPath)
+	if err != nil {
+		return 0, 0, err
 	}
 
 	statPath := filepath.Join(filepath.Dir(memCurrentPath), "memory.stat")
 	data, err := os.ReadFile(statPath)
 	if err != nil {
-		// Graceful degradation: memory.stat may not exist on cgroup v1 paths
-		// or in some constrained environments; fall back to raw usage.
-		return currentBytes, nil
+		return currentBytes, 0, nil
 	}
 
 	var inactiveFile int64
@@ -262,12 +275,7 @@ func readWorkingSetBytes(memCurrentPath string) (int64, error) {
 			break
 		}
 	}
-
-	workingSet := currentBytes - inactiveFile
-	if workingSet < 0 {
-		workingSet = 0
-	}
-	return workingSet, nil
+	return currentBytes, inactiveFile, nil
 }
 
 func resolveMemoryUsagePath(procMountsPath, procSelfCgroupPath, procMountInfoPath string) (string, cgroupLayout, error) {
@@ -287,37 +295,36 @@ func resolveMemoryUsagePath(procMountsPath, procSelfCgroupPath, procMountInfoPat
 		}
 	}
 
-	// Secondary path: scan identifiers extracted from the environment, hostname,
-	// /proc/self/cgroup, and /proc/self/mountinfo, then walk the cgroup tree
-	// looking for a scope directory whose name contains one of those identifiers.
-	identifiers, err := collectContainerIdentifiers(procSelfCgroupPath, procMountInfoPath)
-	if err != nil {
-		return "", cgroupLayout{}, err
-	}
-
+	// Secondary path: walk every cgroup.procs file under the mount point and
+	// find the scope that actually owns this process (matched by its
+	// root-namespace PID read from NSpid in /proc/self/status). This is
+	// unambiguous — exactly one cgroup contains our PID — so we prefer it
+	// over identifier matching, which can fuzzy-match sibling container
+	// scopes when multiple pod cgroups are visible (kind, nested Docker).
 	var resolutionErrs []string
-	for _, layout := range layouts {
-		candidate, err := findMemoryUsagePathByIdentifier(layout, identifiers)
-		if err == nil {
-			return candidate, layout, nil
-		}
-		resolutionErrs = append(resolutionErrs, err.Error())
-	}
-
-	// Tertiary / macOS-kind fallback: on macOS with Docker Desktop the cgroup
-	// namespace is not propagated into kind node containers, so
-	// /proc/self/cgroup reports "/" and the container ID does not appear in
-	// mountinfo.  Walk every cgroup.procs file under the mount point and find
-	// the scope that actually owns this process (matched by its root-namespace
-	// PID read from NSpid in /proc/self/status).
-	// This path is never reached on a normal Linux setup, so it has zero impact
-	// on the existing Linux flow.
 	for _, layout := range layouts {
 		candidate, err := findCgroupByOwnPID(layout)
 		if err == nil {
 			return candidate, layout, nil
 		}
 		resolutionErrs = append(resolutionErrs, fmt.Sprintf("pid-walk: %v", err))
+	}
+
+	// Tertiary path: scan identifiers extracted from the environment, hostname,
+	// /proc/self/cgroup, and /proc/self/mountinfo, then walk the cgroup tree
+	// looking for a scope directory whose name contains one of those identifiers.
+	// Used only when PID-based resolution fails (e.g. environments where
+	// /proc/self/status NSpid is hidden or cgroup.procs is not readable).
+	identifiers, err := collectContainerIdentifiers(procSelfCgroupPath, procMountInfoPath)
+	if err != nil {
+		return "", cgroupLayout{}, err
+	}
+	for _, layout := range layouts {
+		candidate, err := findMemoryUsagePathByIdentifier(layout, identifiers)
+		if err == nil {
+			return candidate, layout, nil
+		}
+		resolutionErrs = append(resolutionErrs, err.Error())
 	}
 
 	return "", cgroupLayout{}, fmt.Errorf("no container-specific cgroup memory file found (%s)", strings.Join(resolutionErrs, "; "))
@@ -512,34 +519,58 @@ func extractHexIdentifiers(value string) []string {
 // /kubepods/burstable/pod.../cri-containerd-<id>) and is the fastest,
 // most reliable resolution method.
 //
-// On macOS with Docker Desktop + kind the cgroup namespace is not propagated,
-// so /proc/self/cgroup reports "/" (the root of the entire VM's cgroup tree).
-// When cgroupPath is "/" (root), this is valid in containers with proper
-// cgroup namespace isolation where the container sits at the root of its
-// own cgroup namespace. buildMountedCgroupPath handles the "/" case and
-// fileExists validates the resolved path, so we do not reject "/" here.
-// If the resolved path doesn't exist (e.g. macOS Docker Desktop + kind
-// where "/" maps to VM-wide memory), fileExists will fail and the caller
-// falls through to identifier-based or PID-based resolution.
+// When the resolved path is the root ("/"), the mounted candidate may point
+// at an ancestor cgroup rather than the container's own: macOS Docker Desktop
+// exposes the VM's root cgroup, and kind nodes expose the node-level tree.
+// For the root case we therefore require proof that the candidate cgroup
+// actually owns this process (its cgroup.procs contains our PID); otherwise
+// the caller falls through to PID-based or identifier-based resolution.
+// If cgroup.procs cannot be read (e.g. unit tests with a fake tree), the
+// candidate is accepted optimistically to preserve previous behavior.
 func resolveFromSelfCgroup(layout cgroupLayout, procSelfCgroupPath string) (string, error) {
-    cgroupPath, err := readSelfCgroupPath(procSelfCgroupPath, layout)
-    if err != nil {
-        return "", err
-    }
+	cgroupPath, err := readSelfCgroupPath(procSelfCgroupPath, layout)
+	if err != nil {
+		return "", err
+	}
 
-    // Reject the root path ("/") so it is forced to use your PID-based fallback on macOS
-    if cgroupPath == "/" || cgroupPath == "" {
-        return "", fmt.Errorf("cgroup self-path is root (%q); skipping to container-specific resolution", cgroupPath)
-    }
+	candidate, ok := buildMountedCgroupPath(layout.mountPoint, layout.mountRoot, cgroupPath, layout.usageFile)
+	if !ok {
+		return "", fmt.Errorf("unable to map cgroup path %q to mount %q", cgroupPath, layout.mountPoint)
+	}
+	if !fileExists(candidate) {
+		return "", fmt.Errorf("cgroup memory file %q not found", candidate)
+	}
 
-    candidate, ok := buildMountedCgroupPath(layout.mountPoint, layout.mountRoot, cgroupPath, layout.usageFile)
-    if !ok {
-        return "", fmt.Errorf("unable to map cgroup path %q to mount %q", cgroupPath, layout.mountPoint)
-    }
-    if !fileExists(candidate) {
-        return "", fmt.Errorf("cgroup memory file %q not found", candidate)
-    }
-    return candidate, nil
+	if cgroupPath == "/" || cgroupPath == "" {
+		if owns, checked := cgroupOwnsSelf(filepath.Dir(candidate)); checked && !owns {
+			return "", fmt.Errorf("cgroup %q is not container-specific (self not listed in cgroup.procs)", filepath.Dir(candidate))
+		}
+	}
+
+	return candidate, nil
+}
+
+// cgroupOwnsSelf reports whether the cgroup at cgroupDir owns this process.
+// The second return value indicates whether we could actually read
+// cgroup.procs — callers use it to distinguish "verified not ours" from
+// "unable to verify" so missing-file environments (e.g. unit tests) don't
+// incorrectly fail resolution.
+func cgroupOwnsSelf(cgroupDir string) (owns, checked bool) {
+	data, err := os.ReadFile(filepath.Join(cgroupDir, "cgroup.procs"))
+	if err != nil {
+		return false, false
+	}
+	pid, err := getRootNSPID()
+	if err != nil {
+		return false, false
+	}
+	pidStr := strconv.Itoa(pid)
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if strings.TrimSpace(line) == pidStr {
+			return true, true
+		}
+	}
+	return false, true
 }
 
 func buildMountedCgroupPath(mountPoint, mountRoot, cgroupPath, usageFile string) (string, bool) {


### PR DESCRIPTION
 Previously `resolveFromSelfCgroup` trusted whatever path `/proc/self/cgroup` reported and derived `memory.current` from it. Two failure modes had snuck in:                                                                                                                               
                                                                       
  1. **macOS Docker Desktop** — `/proc/self/cgroup` reports `/`, which maps to the entire VM's cgroup (~GB-scale values). The guard thought the agent was always near the limit and paused recording immediately.                                                                           
  2. **kind clusters** — `/proc/self/cgroup` also reports `/`, but `/sys/fs/cgroup` exposes the **kind-node's** whole cgroup tree. The original identifier-based fallback fuzzy-matched a **different pod's** `cri-containerd-<id>.scope` via hex strings in `/proc/self/mountinfo`,
  reporting a constant ~0.2 MB while the real agent used ~90 MB.                                                                                                                                                                                                                            
                                                                       
Initially tried to fix macOS by blanket-rejecting `cgroupPath == "/"`, but that (a) broke a valid unit test, (b) regressed legit root-ns Linux containers, and (c) forced kind into the ambiguous identifier fallback — which is exactly what picked the wrong pod.    
                                                                       
  ## Changes                                                                                                                                                                                                                                                                                
                                                                       
  ### `pkg/agent/memoryguard/memoryguard.go`

  - **Ownership-based validation for root self-cgroup.** `resolveFromSelfCgroup` now builds the mounted candidate, runs `fileExists`, and — only when `cgroupPath == "/"` — verifies the candidate cgroup's `cgroup.procs` actually contains this process's root-namespace PID. If          
  `cgroup.procs` is unreadable (unit tests with fake trees), the candidate is accepted optimistically to preserve previous behavior.
  - **PID-based resolution promoted to secondary (before identifier matching).** A cgroup that contains our PID is unambiguous; hex-identifier matching can fuzzy-match sibling container scopes when multiple pods are visible (kind, nested Docker). PID-walk runs first; identifier scan 
  is kept as last-resort for environments where `NSpid` / `cgroup.procs` aren't exposed.                                                                                                                                                                                                    
  - **Helper `cgroupOwnsSelf`** added; reads `<dir>/cgroup.procs` and reports `(owns, checked)` so callers can distinguish "verified not ours" from "cannot verify."
  - **Helper `readMemoryStats`** extracted so callers can surface both `memory.current` and `inactive_file` for diagnostics.                                                                                                                                                                
  - **Doc comment on `resolveFromSelfCgroup` updated** to describe the new strategy. Error message reworded (dropped second-person / macOS-specific phrasing; covers empty + root uniformly). 
  
## Links & References

**Closes:** https://github.com/keploy/enterprise/issues/1874

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [X] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [X] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [X] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [X] 🙅 no, because it is not needed

## Self Review done?
- [X] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [X] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [X] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [X] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?