### PR TITLE
fix: testcases with no mocks

### DIFF
--- a/pkg/service/runner/runner.go
+++ b/pkg/service/runner/runner.go
@@ -297,7 +297,6 @@ func (r *Runner) resolveMockSets(ctx context.Context, testSetID, testCaseName st
 
 	mocks, ok := testMockMappings[testCaseName]
 	if !ok {
-		mocksWeNeed = mocksThatHaveMappings
 		return
 	}
 	for _, m := range mocks {

--- a/pkg/service/runner/runner.go
+++ b/pkg/service/runner/runner.go
@@ -297,7 +297,7 @@ func (r *Runner) resolveMockSets(ctx context.Context, testSetID, testCaseName st
 
 	mocks, ok := testMockMappings[testCaseName]
 	if !ok {
-		err = fmt.Errorf("no mock mapping found for test case %q in test set %q", testCaseName, testSetID)
+		mocksWeNeed = mocksThatHaveMappings
 		return
 	}
 	for _, m := range mocks {


### PR DESCRIPTION
This pull request makes a targeted change to the `resolveMockSets` function in `runner.go` to improve how missing mock mappings are handled. Instead of returning an error when a mock mapping is not found for a test case, the function now assigns available mocks that have mappings, which may allow tests to proceed with partial data rather than failing outright.

Error handling adjustment:

* Updated `resolveMockSets` in `pkg/service/runner/runner.go` to assign `mocksThatHaveMappings` to `mocksWeNeed` instead of returning an error when no mock mapping is found for a test case, improving robustness in test execution.