### PR TITLE
chore: sanity check — run integration tests against samples-go CI coverage branch

### DIFF
--- a/.github/workflows/golang_docker.yml
+++ b/.github/workflows/golang_docker.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: keploy/samples-go
-          ref: main
+          ref: ci/add-missing-lint-build-coverage
           path: samples-go
       - name: Run ${{ matrix.app.name }} application
         env:

--- a/.github/workflows/golang_docker_macos.yml
+++ b/.github/workflows/golang_docker_macos.yml
@@ -82,6 +82,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: keploy/samples-go
+          ref: ci/add-missing-lint-build-coverage
           path: samples-go
 
       - name: Ensure Docker Compose is available (macOS)

--- a/.github/workflows/golang_docker_windows.yml
+++ b/.github/workflows/golang_docker_windows.yml
@@ -93,6 +93,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: keploy/samples-go
+          ref: ci/add-missing-lint-build-coverage
           path: samples-go
           clean: true
 

--- a/.github/workflows/golang_linux.yml
+++ b/.github/workflows/golang_linux.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           repository: keploy/samples-go
           path: samples-go
-          ref: main
+          ref: ci/add-missing-lint-build-coverage
       - name: Run ${{ matrix.app.name }} application
         env:
           RECORD_BIN: ${{ steps.record.outputs.path }}
@@ -144,6 +144,7 @@ jobs:
         with:
           repository: keploy/samples-go
           path: samples-go
+          ref: ci/add-missing-lint-build-coverage
       - name: Run ${{ matrix.app.name }} application
         env:
           RECORD_BIN: ${{ steps.record.outputs.path }}
@@ -195,6 +196,7 @@ jobs:
         with:
           repository: keploy/samples-go
           path: samples-go
+          ref: ci/add-missing-lint-build-coverage
 
       - name: Run Test
         env:
@@ -248,6 +250,7 @@ jobs:
         with:
           repository: keploy/samples-go
           path: samples-go
+          ref: ci/add-missing-lint-build-coverage
       - name: Run ${{ matrix.app.name }} application
         env:
           REPLAY_BIN: ${{ steps.replay.outputs.path }}

--- a/.github/workflows/golang_native_windows.yml
+++ b/.github/workflows/golang_native_windows.yml
@@ -77,6 +77,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: keploy/samples-go
+          ref: ci/add-missing-lint-build-coverage
           path: samples-go
           clean: true
       - name: Run ${{ matrix.app.name }} application (Windows)

--- a/.github/workflows/golang_wsl.yml
+++ b/.github/workflows/golang_wsl.yml
@@ -50,6 +50,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: keploy/samples-go
+          ref: ci/add-missing-lint-build-coverage
           path: samples-go
 
       - name: Setup WSL (Ubuntu)


### PR DESCRIPTION
## Context

keploy/samples-go#220 adds build and lint CI coverage for 18 sample apps that were previously unchecked. It also:
- upgrades the build and lint workflows to use `go-version: stable` (covering modules that require Go 1.24–1.26)
- fixes pre-existing lint issues in the newly covered apps (package comments, errcheck, unused params, gofmt, deprecated API suppressions, etc.)

None of the changes touch core app logic — only build/lint infrastructure and style fixes.

## What this PR does

Temporarily points every `keploy/samples-go` checkout in the Go integration workflows to the branch `ci/add-missing-lint-build-coverage` instead of `main`, so the Keploy integration tests run against those changes as a sanity check.

Workflows updated:
- \`golang_linux.yml\` (all 4 checkout blocks)
- \`golang_docker.yml\`
- \`golang_docker_macos.yml\`
- \`golang_docker_windows.yml\`
- \`golang_native_windows.yml\`
- \`golang_wsl.yml\`

## After the sanity check passes

1. Merge keploy/samples-go#220 into `main`
2. Close this PR (the ref automatically becomes `main` again once the branch is merged and deleted, or revert these changes and merge)

## What to verify

The integration tests for the following apps (which had lint fixes applied) should all still pass:
- \`connect-tunnel\`, \`dns-mock-test\`, \`dns-dedup\`, \`risk-profile\`, \`sse-preflight\` (golang_linux)
- \`go-memory-load\`, \`proxy-stress-test\` (golang_docker)
- \`http-sse\`, \`simple-grpc\` (golang_linux_replay)