### PR TITLE
fix: remove agent ready file before starting

### DIFF
--- a/pkg/agent/routes/record.go
+++ b/pkg/agent/routes/record.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
 	"go.keploy.io/server/v3/pkg/models"
+	kdocker "go.keploy.io/server/v3/pkg/platform/docker"
 	"go.keploy.io/server/v3/pkg/service/agent"
 	"go.keploy.io/server/v3/utils"
 	"go.uber.org/zap"
@@ -400,17 +401,15 @@ func (a *Agent) HandleMappings(w http.ResponseWriter, r *http.Request) {
 //	healthcheck:
 //	  test: ["CMD", "cat", "/tmp/agent.ready"]
 func (a *Agent) MakeAgentReady(w http.ResponseWriter, r *http.Request) {
-	const readyFile = "/tmp/agent.ready"
-
 	// Create or overwrite the readiness file with a timestamp
 	content := []byte(time.Now().Format(time.RFC3339) + "\n")
-	if err := os.WriteFile(readyFile, content, 0644); err != nil {
-		a.logger.Error("failed to create readiness file", zap.String("file", readyFile), zap.Error(err))
+	if err := os.WriteFile(kdocker.AgentReadyFile, content, 0644); err != nil {
+		a.logger.Error("failed to create readiness file", zap.String("file", kdocker.AgentReadyFile), zap.Error(err))
 		http.Error(w, "failed to mark agent as ready", http.StatusInternalServerError)
 		return
 	}
 
-	a.logger.Debug("Agent marked as ready", zap.String("file", readyFile))
+	a.logger.Debug("Agent marked as ready", zap.String("file", kdocker.AgentReadyFile))
 	w.WriteHeader(http.StatusOK)
 	a.logger.Debug("Keploy Agent is ready from the ...")
 	_, _ = w.Write([]byte("Agent is now ready\n"))

--- a/pkg/platform/docker/docker.go
+++ b/pkg/platform/docker/docker.go
@@ -32,6 +32,11 @@ const (
 	// The path inside the container where certs are mounted
 	KeployTLSMountPath = "/tmp/keploy-tls"
 
+	// AgentReadyFile is the readiness marker file written by the agent once
+	// setup is complete. Used by the Docker Compose healthcheck and cleared
+	// on agent startup to prevent stale state from passing the healthcheck.
+	AgentReadyFile = "/tmp/agent.ready"
+
 	defaultTimeoutForDockerQuery = 1 * time.Minute
 )
 
@@ -743,7 +748,7 @@ func (idc *Impl) GenerateKeployAgentService(opts models.SetupOptions) (*yaml.Nod
 			{Kind: yaml.ScalarNode, Value: "test"},
 			{Kind: yaml.SequenceNode, Content: []*yaml.Node{
 				{Kind: yaml.ScalarNode, Value: "CMD-SHELL"},
-				{Kind: yaml.ScalarNode, Value: "cat /tmp/agent.ready"},
+				{Kind: yaml.ScalarNode, Value: "cat " + AgentReadyFile},
 			}},
 
 			// interval

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sync"
 
 	"go.keploy.io/server/v3/config"
@@ -56,6 +57,14 @@ func New(logger *zap.Logger, hook coreAgent.Hooks, proxy coreAgent.Proxy, client
 
 // Setup will create a new app and store it in the map, all the setup will be done here
 func (a *Agent) Setup(ctx context.Context, startCh chan int) error {
+
+	// Remove stale readiness file from a previous run so the Docker
+	// healthcheck (`cat /tmp/agent.ready`) does not pass before the
+	// CLI has stored mocks on the agent.  The file is re-created by
+	// MakeAgentReadyForDockerCompose once everything is set up.
+	if err := os.Remove("/tmp/agent.ready"); err != nil && !os.IsNotExist(err) {
+		a.logger.Warn("failed to remove stale agent readiness file", zap.Error(err))
+	}
 
 	a.logger.Info("Starting the agent in ", zap.String("mode", string(a.config.Agent.Mode)))
 	errGrp, ctx := errgroup.WithContext(ctx)

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -59,11 +59,12 @@ func New(logger *zap.Logger, hook coreAgent.Hooks, proxy coreAgent.Proxy, client
 func (a *Agent) Setup(ctx context.Context, startCh chan int) error {
 
 	// Remove stale readiness file from a previous run so the Docker
-	// healthcheck (`cat /tmp/agent.ready`) does not pass before the
-	// CLI has stored mocks on the agent.  The file is re-created by
-	// MakeAgentReadyForDockerCompose once everything is set up.
-	if err := os.Remove("/tmp/agent.ready"); err != nil && !os.IsNotExist(err) {
-		a.logger.Warn("failed to remove stale agent readiness file", zap.Error(err))
+	// healthcheck (`cat <AgentReadyFile>`) does not pass before the
+	// CLI has stored mocks on the agent. The file is re-created later
+	// by the MakeAgentReady HTTP handler in pkg/agent/routes/record.go
+	// once setup is complete.
+	if err := os.Remove(kdocker.AgentReadyFile); err != nil && !os.IsNotExist(err) {
+		a.logger.Debug("failed to remove stale agent readiness file", zap.Error(err))
 	}
 
 	a.logger.Info("Starting the agent in ", zap.String("mode", string(a.config.Agent.Mode)))


### PR DESCRIPTION
## Describe the changes that are made

This pull request makes a small but important change to the agent startup process to improve reliability in Docker environments. Specifically, it ensures that any stale readiness file from a previous run is removed before the agent starts, preventing false positives in Docker healthchecks.

- **Docker readiness file management:**
  * On agent startup, the code now removes any existing `/tmp/agent.ready` file to prevent Docker healthchecks from passing prematurely. If removal fails for reasons other than the file not existing, a warning is logged. (`pkg/service/agent/agent.go`) [[1]](diffhunk://#diff-7a81e3b3d3f656498a1b9d59f02f04882725b9a4b4857944d78b6efa9012c141R8) [[2]](diffhunk://#diff-7a81e3b3d3f656498a1b9d59f02f04882725b9a4b4857944d78b6efa9012c141R61-R68)

## Links & References

**Closes:** #[issue number that will be closed through this PR]
- NA (if very small change like typo, linting, etc.)

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [ ] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

## Self Review done?
- [ ] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [ ] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [ ] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [ ] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?