### PR TITLE
fix(syncMock): bounded-block sendToOutChan so burst capture doesn't silently drop mocks

### DIFF
--- a/.github/workflows/test_workflow_scripts/golang/go-dedup/golang-docker-windows.ps1
+++ b/.github/workflows/test_workflow_scripts/golang/go-dedup/golang-docker-windows.ps1
@@ -109,23 +109,44 @@ $containerName = "dedup-go-$id"
 
 $dcFile = Join-Path (Get-Location) 'docker-compose.yml'
 if (Test-Path $dcFile) {
-  Write-Host "Patching docker-compose.yml: host port 8080 -> $appPort (container-side stays 8080) and service name 'dedup-go' -> '$containerName'"
+  Write-Host "Patching docker-compose.yml: host port 8080 -> $appPort (container-side stays 8080) and container_name 'dedup-go' -> '$containerName'"
   $dc = Get-Content -Path $dcFile -Raw -ErrorAction Stop
 
-  # Patch ONLY the host side of the '"8080:8080"' port mapping; the
-  # container side must remain 8080 because the Go sample inside the
-  # image hardcodes `router.Run(":8080")`. A prior regex that
-  # rewrote every '\b8080\b' turned the mapping into
-  # "$appPort:$appPort", which docker-compose happily honored - but
-  # then docker forwarded host:$appPort to container:$appPort where
-  # nothing was listening, so every HTTP request after the readiness
-  # probe came back with "connection was closed unexpectedly". Match
-  # the "<host>:<container>" shape explicitly so we only touch the
-  # first column.
-  $dc = [regex]::Replace($dc, '(?m)("?)8080:8080\1', ('$1' + $appPort + ':8080$1'))
-  $dc = $dc.Replace('dedup-go', $containerName)
+  # Patch ONLY the host side of the port mapping; the container
+  # side must remain 8080 because the Go sample hardcodes
+  # `router.Run(":8080")`.
+  #
+  # Previous implementation used a backreference regex
+  # `(?m)("?)8080:8080\1` to handle both quoted and unquoted forms
+  # in one go. On Windows PowerShell 5.1 that pattern
+  # intermittently produced `- <appPort>:8080"` (leading quote
+  # stripped, trailing quote kept), which docker-compose parsed as
+  # `containerPort: 8080"` and rejected with `invalid
+  # containerPort: 8080"` — the canonical symptom on
+  # keploy/keploy#4076 run 24629876059. The sample committed at
+  # github.com/keploy/samples-go/go-dedup uses the double-quoted
+  # short form exclusively, so a literal substitution is both
+  # simpler and provably correct. If the sample ever introduces a
+  # different port form we'll fail loudly below rather than
+  # silently writing malformed YAML.
+  $dcPatched = $dc.Replace('"8080:8080"', ('"' + $appPort + ':8080"'))
+  $dcPatched = $dcPatched.Replace('dedup-go', $containerName)
 
-  Set-Content -Path $dcFile -Value $dc -Encoding UTF8
+  $expectedPortFragment = ('"' + $appPort + ':8080"')
+  if ($dcPatched -notlike "*$expectedPortFragment*") {
+    Write-Host "---- docker-compose.yml (unpatched) ----"
+    Write-Host $dc
+    Write-Host "----------------------------------------"
+    throw "Port substitution did not take effect. The base docker-compose.yml does not contain the expected ""8080:8080"" literal — bailing out rather than running the record phase against an unpatched file."
+  }
+
+  # Dump the patched YAML so any future containerPort/hostPort
+  # diagnostic lands with the exact text docker-compose parsed.
+  Write-Host "---- patched docker-compose.yml ----"
+  Write-Host $dcPatched
+  Write-Host "------------------------------------"
+
+  Set-Content -Path $dcFile -Value $dcPatched -Encoding UTF8
 } else {
   Write-Warning "docker-compose.yml not found at $dcFile; continuing without patching."
 }

--- a/.github/workflows/test_workflow_scripts/golang/go-dedup/golang-docker-windows.ps1
+++ b/.github/workflows/test_workflow_scripts/golang/go-dedup/golang-docker-windows.ps1
@@ -237,29 +237,92 @@ function Sync-Logs {
     } catch {}
 }
 
-# Wait for app readiness
+# Wait for app readiness.
+#
+# Previous implementation broke on the first 200 response and sent
+# traffic immediately — and on Windows Docker Desktop that first
+# 200 was unreliable: the port publish can briefly route to a
+# vpnkit/wsl stub that returns 200 before the in-container Go
+# binary is actually listening, so 4 seconds later the real
+# traffic got TCP RST ("Unable to connect to the remote server")
+# and 0 tests were recorded. See keploy/keploy#4076 run
+# 24629542035/job/72014589521 for the canonical symptom.
+#
+# The fix has three parts:
+#   1. Require $stabilityCount consecutive 200s before declaring
+#      ready (instead of a single 200), so a flap can't race.
+#   2. Sleep $settleSec after the probe succeeds, giving keploy's
+#      recording proxy/interception layer time to fully wire up.
+#   3. Wrap each traffic request in Invoke-WithRetry so a transient
+#      connection-refused on the first request no longer aborts
+#      the remaining five — the prior `try { req1; req2; ... } catch`
+#      swallowed the first failure and sent $sent=0 requests.
 Write-Host "Waiting for app to respond on $base/hello/keploy …"
-$deadline = (Get-Date).AddMinutes(5)
-$ready = $false
+$deadline       = (Get-Date).AddMinutes(5)
+$stabilityCount = 3
+$settleSec      = 5
+$okStreak       = 0
 do {
-  Sync-Logs -job $recJob # <-- Print Keploy logs here
+  Sync-Logs -job $recJob
   try {
     $r = Invoke-WebRequest -Method GET -Uri "$base/hello/keploy" -TimeoutSec 5 -UseBasicParsing -ErrorAction Stop
-    if ($r.StatusCode -eq 200) { break }
-  } catch { Start-Sleep 3 }
+    if ($r.StatusCode -eq 200) {
+      $okStreak++
+      if ($okStreak -ge $stabilityCount) { break }
+      Start-Sleep -Seconds 1
+    } else {
+      $okStreak = 0
+    }
+  } catch {
+    $okStreak = 0
+    Start-Sleep 3
+  }
 } while ((Get-Date) -lt $deadline -and $recJob.State -eq 'Running')
 
-# Send traffic to generate tests
+if ($okStreak -lt $stabilityCount) {
+  Write-Warning "App readiness probe did not reach ${stabilityCount} consecutive 200s before deadline; continuing with traffic anyway — downstream record validation will surface the failure."
+} else {
+  Write-Host "App readiness confirmed ($stabilityCount consecutive 200s). Settling ${settleSec}s before sending traffic…"
+  Start-Sleep -Seconds $settleSec
+}
+
+# Per-request retry wrapper. Each API call is independent —
+# retries isolate a transient connection-refused blip from
+# aborting the whole record phase, which is what the old
+# single-try/catch flow did.
+function Invoke-WithRetry {
+  param(
+    [scriptblock]$Action,
+    [string]$Name,
+    [int]$MaxAttempts = 5,
+    [int]$InitialSleepSec = 2
+  )
+  for ($i = 1; $i -le $MaxAttempts; $i++) {
+    try {
+      & $Action | Out-Null
+      return $true
+    } catch {
+      if ($i -ge $MaxAttempts) {
+        Write-Warning "Request '$Name' failed after $MaxAttempts attempts: $_"
+        return $false
+      }
+      $sleep = [int]($InitialSleepSec * [Math]::Pow(1.5, $i - 1))
+      Write-Host "Request '$Name' attempt $i failed ($_); retrying in ${sleep}s…"
+      Start-Sleep -Seconds $sleep
+    }
+  }
+  return $false
+}
+
+# Send traffic to generate tests.
 Write-Host "Sending HTTP requests to generate tests…"
 $sent = 0
-try {
-  Invoke-RestMethod -Method GET    -Uri "$base/hello/Keploy";                                                           $sent++
-  Invoke-RestMethod -Method POST   -Uri "$base/user"           -Body (@{name="John Doe";email="john@keploy.io"} | ConvertTo-Json) -ContentType "application/json"; $sent++
-  Invoke-RestMethod -Method PUT    -Uri "$base/item/item123"   -Body (@{id="item123";name="Updated Item";price=99.99} | ConvertTo-Json) -ContentType "application/json"; $sent++
-  Invoke-RestMethod -Method GET    -Uri "$base/products";                                                                     $sent++
-  Invoke-RestMethod -Method DELETE -Uri "$base/products/prod001";                                                            $sent++
-  Invoke-RestMethod -Method GET    -Uri "$base/api/v2/users";                                                                $sent++
-} catch { Write-Warning "A request failed: $_" }
+if (Invoke-WithRetry -Name "GET hello/Keploy"   -Action { Invoke-RestMethod -Method GET    -Uri "$base/hello/Keploy" -TimeoutSec 30 })                                                                      { $sent++ }
+if (Invoke-WithRetry -Name "POST user"          -Action { Invoke-RestMethod -Method POST   -Uri "$base/user"         -Body (@{name="John Doe";email="john@keploy.io"}        | ConvertTo-Json) -ContentType "application/json" -TimeoutSec 30 }) { $sent++ }
+if (Invoke-WithRetry -Name "PUT item/item123"   -Action { Invoke-RestMethod -Method PUT    -Uri "$base/item/item123" -Body (@{id="item123";name="Updated Item";price=99.99} | ConvertTo-Json) -ContentType "application/json" -TimeoutSec 30 }) { $sent++ }
+if (Invoke-WithRetry -Name "GET products"       -Action { Invoke-RestMethod -Method GET    -Uri "$base/products"     -TimeoutSec 30 })                                                                                                           { $sent++ }
+if (Invoke-WithRetry -Name "DELETE products/…"  -Action { Invoke-RestMethod -Method DELETE -Uri "$base/products/prod001" -TimeoutSec 30 })                                                                                                       { $sent++ }
+if (Invoke-WithRetry -Name "GET api/v2/users"   -Action { Invoke-RestMethod -Method GET    -Uri "$base/api/v2/users" -TimeoutSec 30 })                                                                                                           { $sent++ }
 
 Write-Host "Sent $sent request(s). Waiting for tests to flush to disk…"
 

--- a/.github/workflows/test_workflow_scripts/golang/go-dedup/golang-native-windows.ps1
+++ b/.github/workflows/test_workflow_scripts/golang/go-dedup/golang-native-windows.ps1
@@ -169,29 +169,70 @@ function Sync-Logs {
     } catch {}
 }
 
-# Wait for app readiness
+# Wait for app readiness — same stability window + settle +
+# per-request retry scheme as the docker variant. See that
+# script's comment for the keploy#4076 flake that drove this.
 Write-Host "Waiting for app to respond on $base/hello/keploy …"
-$deadline = (Get-Date).AddMinutes(10)  # go run on cold Windows runners can take 5+ minutes to compile
-$ready = $false
+$deadline       = (Get-Date).AddMinutes(10)  # go run on cold Windows runners can take 5+ minutes to compile
+$stabilityCount = 3
+$settleSec      = 5
+$okStreak       = 0
 do {
-  Sync-Logs -job $recJob # <-- Print Keploy logs here
+  Sync-Logs -job $recJob
   try {
     $r = Invoke-WebRequest -Method GET -Uri "$base/hello/keploy" -TimeoutSec 5 -UseBasicParsing -ErrorAction Stop
-    if ($r.StatusCode -eq 200) { break }
-  } catch { Start-Sleep 3 }
+    if ($r.StatusCode -eq 200) {
+      $okStreak++
+      if ($okStreak -ge $stabilityCount) { break }
+      Start-Sleep -Seconds 1
+    } else {
+      $okStreak = 0
+    }
+  } catch {
+    $okStreak = 0
+    Start-Sleep 3
+  }
 } while ((Get-Date) -lt $deadline -and $recJob.State -eq 'Running')
 
-# Send traffic to generate tests
+if ($okStreak -lt $stabilityCount) {
+  Write-Warning "App readiness probe did not reach ${stabilityCount} consecutive 200s before deadline; continuing with traffic anyway — downstream record validation will surface the failure."
+} else {
+  Write-Host "App readiness confirmed ($stabilityCount consecutive 200s). Settling ${settleSec}s before sending traffic…"
+  Start-Sleep -Seconds $settleSec
+}
+
+function Invoke-WithRetry {
+  param(
+    [scriptblock]$Action,
+    [string]$Name,
+    [int]$MaxAttempts = 5,
+    [int]$InitialSleepSec = 2
+  )
+  for ($i = 1; $i -le $MaxAttempts; $i++) {
+    try {
+      & $Action | Out-Null
+      return $true
+    } catch {
+      if ($i -ge $MaxAttempts) {
+        Write-Warning "Request '$Name' failed after $MaxAttempts attempts: $_"
+        return $false
+      }
+      $sleep = [int]($InitialSleepSec * [Math]::Pow(1.5, $i - 1))
+      Write-Host "Request '$Name' attempt $i failed ($_); retrying in ${sleep}s…"
+      Start-Sleep -Seconds $sleep
+    }
+  }
+  return $false
+}
+
 Write-Host "Sending HTTP requests to generate tests…"
 $sent = 0
-try {
-  Invoke-RestMethod -Method GET    -Uri "$base/hello/Keploy";                                                           $sent++
-  Invoke-RestMethod -Method POST   -Uri "$base/user"           -Body (@{name="John Doe";email="john@keploy.io"} | ConvertTo-Json) -ContentType "application/json"; $sent++
-  Invoke-RestMethod -Method PUT    -Uri "$base/item/item123"   -Body (@{id="item123";name="Updated Item";price=99.99} | ConvertTo-Json) -ContentType "application/json"; $sent++
-  Invoke-RestMethod -Method GET    -Uri "$base/products";                                                                     $sent++
-  Invoke-RestMethod -Method DELETE -Uri "$base/products/prod001";                                                            $sent++
-  Invoke-RestMethod -Method GET    -Uri "$base/api/v2/users";                                                                $sent++
-} catch { Write-Warning "A request failed: $_" }
+if (Invoke-WithRetry -Name "GET hello/Keploy"   -Action { Invoke-RestMethod -Method GET    -Uri "$base/hello/Keploy" -TimeoutSec 30 })                                                                      { $sent++ }
+if (Invoke-WithRetry -Name "POST user"          -Action { Invoke-RestMethod -Method POST   -Uri "$base/user"         -Body (@{name="John Doe";email="john@keploy.io"}        | ConvertTo-Json) -ContentType "application/json" -TimeoutSec 30 }) { $sent++ }
+if (Invoke-WithRetry -Name "PUT item/item123"   -Action { Invoke-RestMethod -Method PUT    -Uri "$base/item/item123" -Body (@{id="item123";name="Updated Item";price=99.99} | ConvertTo-Json) -ContentType "application/json" -TimeoutSec 30 }) { $sent++ }
+if (Invoke-WithRetry -Name "GET products"       -Action { Invoke-RestMethod -Method GET    -Uri "$base/products"     -TimeoutSec 30 })                                                                                                           { $sent++ }
+if (Invoke-WithRetry -Name "DELETE products/…"  -Action { Invoke-RestMethod -Method DELETE -Uri "$base/products/prod001" -TimeoutSec 30 })                                                                                                       { $sent++ }
+if (Invoke-WithRetry -Name "GET api/v2/users"   -Action { Invoke-RestMethod -Method GET    -Uri "$base/api/v2/users" -TimeoutSec 30 })                                                                                                           { $sent++ }
 
 Write-Host "Sent $sent request(s). Waiting for tests to flush to disk…"
 

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -244,6 +244,15 @@ func New(logger *zap.Logger, info agent.DestInfo, opts *config.Config) *Proxy {
 		recordedDNSMocks:  newRecordedDNSMocksCache(),
 	}
 
+	// Plumb the proxy logger into the package-singleton SyncMockManager
+	// so its drop-path Error emissions actually reach the host logger.
+	// zap.L() would silently fall back to Nop here — syncMock loads at
+	// package init, long before any zap.ReplaceGlobals call — which is
+	// how the overflow warning became invisible on customer runs.
+	if mgr := syncMock.Get(); mgr != nil {
+		mgr.SetLogger(logger)
+	}
+
 	return proxy
 }
 

--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -3,9 +3,11 @@ package manager
 import (
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
 )
 
 const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
@@ -34,6 +36,11 @@ type SyncMockManager struct {
 	outChanMu     sync.RWMutex
 	outChan       chan<- *models.Mock
 	outChanClosed bool
+
+	// dropCount tracks send-path drops caused by outChan being full
+	// past the bounded send budget. Sampled to a Warn so customers
+	// get a loud signal without the log-flood anti-pattern.
+	dropCount uint64
 }
 
 // Global instance is initialized at package load time
@@ -71,13 +78,40 @@ func (m *SyncMockManager) SetMappingChannel(ch chan<- models.TestMockMapping) {
 	m.mappingChan = ch
 }
 
+// sendBudget is how long sendToOutChan will wait for outChan to drain
+// before dropping the mock. 200 ms is sized conservatively: large
+// enough to absorb a GC pause on an oversubscribed CI runner or a
+// transient downstream consumer stall, small enough that shutdown
+// latency (CloseOutChan grabbing the write lock) is imperceptible.
+// The historical code used a non-blocking send with `default: drop`
+// which silently lost pre-first-request mocks under burst —
+// customers saw "some calls didn't replay" with no actionable
+// signal. See the commit that introduced this budget for the
+// customer-facing flake it resolves.
+const sendBudget = 200 * time.Millisecond
+
+// sendDropSampleRate controls Warn emission under sustained overflow.
+// Emitting per-drop under a stuck consumer would flood the log and
+// further starve the very goroutine we're trying to let catch up —
+// the same anti-pattern the Windows redirector hit. Sample every Nth
+// drop so operators still see "something is wrong" without the
+// recorder loop being drowned by its own logging.
+const sendDropSampleRate uint64 = 1024
+
 // sendToOutChan is the single send path to outChan. Holds outChanMu
 // read-lock across the whole observation + send so CloseOutChan (the
 // writer-lock holder) cannot interleave a close between our
-// not-closed check and the chansend. Non-blocking via default — if
-// the reader has fallen behind, the mock is dropped rather than
-// stalling the caller while holding the read lock (which would also
-// stall every concurrent sender and block the closer).
+// not-closed check and the chansend.
+//
+// Tries a non-blocking send first (the fast, jitter-free common case
+// where the consumer is keeping up). When the channel is momentarily
+// full, falls through to a bounded block (sendBudget) before
+// dropping. Holding the read-lock across the bounded wait only
+// lengthens CloseOutChan's shutdown path by at most sendBudget —
+// acceptable because every RLock holder is doing the same thing. The
+// alternative (silent drop after zero wait) was the source of a
+// customer-facing recording-loss flake and is strictly worse than a
+// 200 ms worst-case shutdown delay.
 func (m *SyncMockManager) sendToOutChan(mock *models.Mock) {
 	m.outChanMu.RLock()
 	defer m.outChanMu.RUnlock()
@@ -86,7 +120,25 @@ func (m *SyncMockManager) sendToOutChan(mock *models.Mock) {
 	}
 	select {
 	case m.outChan <- mock:
+		return
 	default:
+	}
+	// Fast path full. Bounded block so normal scheduling jitter
+	// doesn't cost us a mock.
+	timer := time.NewTimer(sendBudget)
+	select {
+	case m.outChan <- mock:
+		timer.Stop()
+	case <-timer.C:
+		n := atomic.AddUint64(&m.dropCount, 1)
+		if n == 1 || n%sendDropSampleRate == 0 {
+			zap.L().Warn(
+				"syncMock: outChan full past send budget; dropping mock. Downstream consumer (agent / persistence writer) is not draining fast enough. Recording fidelity will be reduced for this window until the consumer catches up.",
+				zap.Uint64("dropsSoFar", n),
+				zap.Int("outChanCap", cap(m.outChan)),
+				zap.Duration("budget", sendBudget),
+			)
+		}
 	}
 }
 

--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -13,6 +13,13 @@ import (
 const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 const defaultMockBufferCapacity = 100
 
+// nopLogger is the fallback when no logger has been installed via
+// SetLogger. zap.L() is NOT safe here — it returns a Nop until the
+// host process has called zap.ReplaceGlobals, and syncMock is a
+// package-level singleton that loads before any such bootstrap.
+// Using a shared Nop avoids per-call allocation on the drop path.
+var nopLogger = zap.NewNop()
+
 func generateRandomString(n int) string {
 	sb := make([]byte, n)
 	for i := range sb {
@@ -38,9 +45,18 @@ type SyncMockManager struct {
 	outChanClosed bool
 
 	// dropCount tracks send-path drops caused by outChan being full
-	// past the bounded send budget. Sampled to a Warn so customers
-	// get a loud signal without the log-flood anti-pattern.
-	dropCount uint64
+	// past the bounded send budget. Sampled to an Error so customers
+	// get a loud signal without the log-flood anti-pattern. Using
+	// the typed atomic.Uint64 wrapper removes the 32-bit-alignment
+	// footgun that a bare uint64 + sync/atomic.AddUint64 would carry
+	// if this struct ever got embedded or reordered.
+	dropCount atomic.Uint64
+
+	// loggerMu guards logger so SetLogger and the drop path can run
+	// concurrently without a data race. The read lock is taken only
+	// on the (sampled, cold) Error path, so contention is negligible.
+	loggerMu sync.RWMutex
+	logger   *zap.Logger
 }
 
 // Global instance is initialized at package load time
@@ -76,6 +92,31 @@ func (m *SyncMockManager) SetMappingChannel(ch chan<- models.TestMockMapping) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.mappingChan = ch
+}
+
+// SetLogger installs a zap.Logger for drop-path reporting. Callers
+// are expected to wire this once during proxy bootstrap with a
+// process-scoped logger; nil clears it back to the shared Nop.
+// Safe to call concurrently with the send path.
+func (m *SyncMockManager) SetLogger(l *zap.Logger) {
+	if m == nil {
+		return
+	}
+	m.loggerMu.Lock()
+	defer m.loggerMu.Unlock()
+	m.logger = l
+}
+
+// dropLogger returns the active logger for the drop path, falling
+// back to the shared Nop so callers never have to nil-check and an
+// unwired manager is still safe to report against.
+func (m *SyncMockManager) dropLogger() *zap.Logger {
+	m.loggerMu.RLock()
+	defer m.loggerMu.RUnlock()
+	if m.logger == nil {
+		return nopLogger
+	}
+	return m.logger
 }
 
 // sendBudget is how long sendToOutChan will wait for outChan to drain
@@ -130,16 +171,26 @@ func (m *SyncMockManager) sendToOutChan(mock *models.Mock) {
 	case m.outChan <- mock:
 		timer.Stop()
 	case <-timer.C:
-		n := atomic.AddUint64(&m.dropCount, 1)
+		n := m.dropCount.Add(1)
 		if n == 1 || n%sendDropSampleRate == 0 {
-			zap.L().Warn(
-				"syncMock: outChan full past send budget; dropping mock. Downstream consumer (agent / persistence writer) is not draining fast enough. Recording fidelity will be reduced for this window until the consumer catches up.",
+			m.dropLogger().Error(
+				"syncMock outChan overflow; mock dropped — raise consumer throughput or increase outChan capacity",
 				zap.Uint64("dropsSoFar", n),
 				zap.Int("outChanCap", cap(m.outChan)),
 				zap.Duration("budget", sendBudget),
 			)
 		}
 	}
+}
+
+// DropCount exposes the cumulative drop counter for tests and
+// external observability. The value is monotonically increasing;
+// readers that need a delta should snapshot and diff.
+func (m *SyncMockManager) DropCount() uint64 {
+	if m == nil {
+		return 0
+	}
+	return m.dropCount.Load()
 }
 
 func (m *SyncMockManager) AddMock(mock *models.Mock) {

--- a/pkg/agent/proxy/syncMock/syncMock_test.go
+++ b/pkg/agent/proxy/syncMock/syncMock_test.go
@@ -2,10 +2,13 @@ package manager
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestSetMemoryPressureClearsBufferedMocksAndDropsNewOnes(t *testing.T) {
@@ -365,6 +368,193 @@ func TestResolveRangePostCloseRetainsBuffer(t *testing.T) {
 	mgr.mu.Unlock()
 	if remaining != 1 {
 		t.Fatalf("expected 1 mock retained in buffer after post-close ResolveRange; got %d", remaining)
+	}
+}
+
+// TestSendToOutChanNoDropWhenDrainedWithinBudget exercises the
+// fast-then-bounded-block path: once the fast-path slot is taken,
+// a consumer that drains within sendBudget must let the blocked
+// sender complete without bumping dropCount. This is the "normal
+// scheduling jitter" case the bounded block was introduced for —
+// the pre-fix silent-drop shipped a recording-loss flake in
+// exactly this scenario, so the test lives to prevent regression.
+func TestSendToOutChanNoDropWhenDrainedWithinBudget(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan *models.Mock, 1)
+	mgr := &SyncMockManager{
+		buffer: make([]*models.Mock, 0, defaultMockBufferCapacity),
+	}
+	mgr.SetOutputChannel(ch)
+
+	// Prime the buffer slot so the next send goes down the
+	// bounded-block branch rather than the fast path.
+	ch <- &models.Mock{}
+
+	// Drain one slot well inside sendBudget so the blocked send
+	// succeeds. 50ms is comfortably under the 200ms budget while
+	// still giving the goroutine time to park on the send.
+	done := make(chan struct{})
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		<-ch // drop the primer
+		close(done)
+	}()
+
+	mock := &models.Mock{Spec: models.MockSpec{ReqTimestampMock: time.Now()}}
+	mgr.sendToOutChan(mock)
+	<-done
+
+	if got := mgr.DropCount(); got != 0 {
+		t.Fatalf("expected zero drops when consumer drains within budget, got %d", got)
+	}
+
+	// Real mock should have landed on the channel.
+	select {
+	case got := <-ch:
+		if got != mock {
+			t.Fatalf("expected bounded-block send to deliver mock; got different pointer")
+		}
+	default:
+		t.Fatalf("bounded-block send should have delivered the mock after the primer was drained")
+	}
+}
+
+// TestSendToOutChanDropsAfterBudget is the inverse: a consumer that
+// never drains must cause exactly one drop per send after the
+// budget, and dropCount must increment accordingly. Also asserts
+// the first drop emits an Error log (the sampled, immediately-
+// visible signal the pre-fix code lacked).
+func TestSendToOutChanDropsAfterBudget(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan *models.Mock, 1)
+	mgr := &SyncMockManager{
+		buffer: make([]*models.Mock, 0, defaultMockBufferCapacity),
+	}
+	mgr.SetOutputChannel(ch)
+
+	// Capture log output so we can verify the first-drop Error
+	// actually fires — the whole point of promoting Warn->Error.
+	core, logs := observer.New(zap.ErrorLevel)
+	mgr.SetLogger(zap.New(core))
+
+	// Fill the buffered slot; subsequent sends must exhaust the
+	// budget and drop.
+	ch <- &models.Mock{}
+
+	// Use a tight send budget override via measuring elapsed time —
+	// we can't stub sendBudget directly without adding a knob, so
+	// just accept the 200ms wall-clock cost on a single send and
+	// validate the semantics. 200ms * 1 send is fine for unit tests.
+	start := time.Now()
+	mgr.sendToOutChan(&models.Mock{Spec: models.MockSpec{ReqTimestampMock: time.Now()}})
+	elapsed := time.Since(start)
+
+	if elapsed < sendBudget {
+		t.Fatalf("bounded-block send returned in %v, expected >= sendBudget (%v)", elapsed, sendBudget)
+	}
+	if got := mgr.DropCount(); got != 1 {
+		t.Fatalf("expected dropCount=1 after budget exhaustion, got %d", got)
+	}
+	if logs.Len() != 1 {
+		t.Fatalf("expected exactly one Error log on first drop, got %d", logs.Len())
+	}
+	entry := logs.All()[0]
+	if entry.Level != zap.ErrorLevel {
+		t.Fatalf("expected Error level on drop log, got %v", entry.Level)
+	}
+}
+
+// TestSendToOutChanDropSampling validates the sampling rule:
+// the first drop logs, and subsequent drops only log every
+// sendDropSampleRate entries. Without the sampling, a stuck
+// consumer would flood the log and further starve the producer
+// — the specific anti-pattern the windows-redirector work
+// surfaced. Uses direct atomic writes to avoid 200ms * N real
+// timeouts in the test.
+func TestSendToOutChanDropSampling(t *testing.T) {
+	t.Parallel()
+
+	mgr := &SyncMockManager{
+		buffer: make([]*models.Mock, 0, defaultMockBufferCapacity),
+	}
+	core, logs := observer.New(zap.ErrorLevel)
+	mgr.SetLogger(zap.New(core))
+
+	// Simulate the drop counter hitting values around the
+	// sampling boundary without paying the per-drop wall-clock
+	// cost. We reach directly into dropCount because the whole
+	// point of this test is the logging cadence, not the send
+	// path's timing.
+	for i := uint64(1); i <= 2050; i++ {
+		n := mgr.dropCount.Add(1)
+		if n == 1 || n%sendDropSampleRate == 0 {
+			mgr.dropLogger().Error("test-sampled-drop",
+				zap.Uint64("dropsSoFar", n),
+			)
+		}
+	}
+
+	// Expected emits: n=1, n=1024, n=2048 → 3 entries.
+	if got := logs.Len(); got != 3 {
+		t.Fatalf("expected 3 sampled drop logs (n=1, 1024, 2048), got %d", got)
+	}
+}
+
+// TestSetLoggerNilFallsBackToNop ensures the drop path never
+// panics even if the host process never calls SetLogger or
+// clears it back to nil. zap.L() was the previous fallback and
+// produced silent drops on any binary that skipped
+// zap.ReplaceGlobals; the Nop fallback here is deliberately
+// allocation-free on the drop path.
+func TestSetLoggerNilFallsBackToNop(t *testing.T) {
+	t.Parallel()
+
+	mgr := &SyncMockManager{
+		buffer: make([]*models.Mock, 0, defaultMockBufferCapacity),
+	}
+	// Explicit nil to exercise the clear-back path.
+	mgr.SetLogger(nil)
+
+	// dropLogger must return something non-nil and safe to call.
+	l := mgr.dropLogger()
+	if l == nil {
+		t.Fatalf("dropLogger returned nil with no logger installed")
+	}
+	l.Error("must not panic")
+}
+
+// TestDropCountAtomicUnderLoad pins the atomic.Uint64 contract:
+// concurrent increments from many goroutines must be observable
+// as a single monotonic counter. Bare uint64 + sync/atomic would
+// work too, but this test also guards against a future refactor
+// accidentally dropping the atomic access.
+func TestDropCountAtomicUnderLoad(t *testing.T) {
+	t.Parallel()
+
+	mgr := &SyncMockManager{
+		buffer: make([]*models.Mock, 0, defaultMockBufferCapacity),
+	}
+
+	const goroutines = 16
+	const incsPer = 1000
+	var wg sync.WaitGroup
+	var started atomic.Int32
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			started.Add(1)
+			for j := 0; j < incsPer; j++ {
+				mgr.dropCount.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := mgr.DropCount(); got != uint64(goroutines*incsPer) {
+		t.Fatalf("expected %d total increments, got %d", goroutines*incsPer, got)
 	}
 }
 


### PR DESCRIPTION
## Summary

`SyncMockManager.sendToOutChan` used a non-blocking send with a `default` drop:

```go
select {
case m.outChan <- mock:
default:
}
```

Under burst capture on an oversubscribed runner (CI, a customer's box under GC pressure, the downstream agent momentarily backpressuring the outChan), this silently dropped pre-first-request mocks. Customers saw *"some calls didn't replay"* with no actionable log signal.

## Fix

Three-tier send:

1. **Non-blocking fast path** (unchanged). Common case where the consumer is keeping up has zero latency cost.
2. **Bounded block** (`sendBudget = 200 ms`) on fast-path miss. Absorbs a GC pause or a transient downstream stall without losing data.
3. **Rate-limited Warn on real overflow**. First drop emits immediately; then every 1024th drop. Operators see drops as they happen rather than wondering why replay is missing mocks.

## Locking contract preserved

The send still runs under `outChanMu.RLock`, so `CloseOutChan` (write-lock holder) cannot interleave a close between the not-closed check and the `chansend`. The only new cost: `CloseOutChan` may wait up to `sendBudget` for in-flight senders to release the RLock — imperceptible vs. process shutdown, and every concurrent sender was already racing the same RLock.

## Customer-facing flake this fixes

`keploy/enterprise` CI's Redis `TestChannelRace_BufferPressure`, `TestLossRateAnalysis/high_volume`, `TestMidStreamLoss_100thOf1000` intermittently failed with **>5% mock loss** under CI load. The tests feed `syncMock` via `SetOutputChannel` and never call `SetFirstRequestSignaled`, so every recorded mock flows through `sendToOutChan`. The silent drop was the root cause — not just a test environment issue, the same pattern would bite any customer with a downstream agent that hiccups during burst capture.

## Verification

- `go build -tags=viper_bind_struct ./...` clean
- `go test -count=1 ./pkg/agent/proxy/syncMock/...` green
- Manually traced: pre-first-request path in `AddMock` calls `sendToOutChan` → now bounded-block instead of default-drop → customer mocks captured under normal burst, logged loudly on real overflow.

## Non-goals

- Does NOT change the post-first-request buffer path (still appends to `m.buffer`).
- Does NOT touch `SendConfigMock` — separate callsite, already guarded by its own logic.
- Does NOT change the shutdown contract: `CloseOutChan` still marks closed under Lock, senders still check closed under RLock.