### PR TITLE
ci(windows/go-dedup): gate readiness probe on keploy PID, neutralize replay stderr

### DIFF
--- a/.github/workflows/test_workflow_scripts/fuzzer/mongo/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/fuzzer/mongo/golang-linux.sh
@@ -228,7 +228,7 @@ endsec
 section "Stop Recording"
 echo "Stopping Keploy record process..."
 
-REC_PID="$(pgrep -n -f 'keploy record' || true)"
+REC_PID="$(pgrep -n -f "$(basename "${RECORD_BIN:-keploy}") record" || true)"
 echo "$REC_PID Keploy PID"
 
 echo "Sending SIGINT to keploy..."

--- a/.github/workflows/test_workflow_scripts/fuzzer/mysql/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/fuzzer/mysql/golang-linux.sh
@@ -206,7 +206,7 @@ endsec
 section "Stop Recording"
 echo "Stopping Keploy record process (PID: $KEPLOY_PID)..."
 
-REC_PID="$(pgrep -n -f 'keploy record' || true)"
+REC_PID="$(pgrep -n -f "$(basename "${RECORD_BIN:-keploy}") record" || true)"
 echo "$REC_PID Keploy PID"
 echo "Killing keploy"
 sudo kill -INT "$REC_PID" 2>/dev/null || true

--- a/.github/workflows/test_workflow_scripts/fuzzer/postgres/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/fuzzer/postgres/golang-linux.sh
@@ -234,7 +234,7 @@ endsec
 section "Stop Recording"
 echo "Stopping Keploy record process (PID: $KEPLOY_PID)..."
 
-REC_PID="$(pgrep -n -f 'keploy record' || true)"
+REC_PID="$(pgrep -n -f "$(basename "${RECORD_BIN:-keploy}") record" || true)"
 echo "$REC_PID Keploy PID"
 echo "Killing keploy"
 if [[ -n "$REC_PID" ]]; then

--- a/.github/workflows/test_workflow_scripts/fuzzer/rerecord/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/fuzzer/rerecord/golang-linux.sh
@@ -72,7 +72,7 @@ sleep 10
 
 # --- 3. Stop Recording ---
 section "Stop Recording"
-REC_PID="$(pgrep -n -f 'keploy record' || true)"
+REC_PID="$(pgrep -n -f "$(basename "${RECORD_BIN:-keploy}") record" || true)"
 echo "$REC_PID Keploy PID"
 echo "Killing keploy"
 if [ -n "$REC_PID" ]; then

--- a/.github/workflows/test_workflow_scripts/golang/dns_mock/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/dns_mock/golang-linux.sh
@@ -107,7 +107,7 @@ send_request
 
 section "Stop Recording"
 echo "Stopping Keploy record process (PID: $KEPLOY_PID)..."
-REC_PID="$(pgrep -n -f 'keploy record' || true)"
+REC_PID="$(pgrep -n -f "$(basename "${RECORD_BIN:-keploy}") record" || true)"
 echo "$REC_PID Keploy PID"
 echo "Killing keploy"
 sudo kill -INT "$REC_PID" 2>/dev/null || true

--- a/.github/workflows/test_workflow_scripts/golang/echo_sql/golang-docker.sh
+++ b/.github/workflows/test_workflow_scripts/golang/echo_sql/golang-docker.sh
@@ -16,7 +16,7 @@ config_file="./keploy.yml"
 sed -i 's/global: {}/global: {"body": {"ts":[]}}/' "$config_file"
 
 container_kill() {
-    REC_PID="$(pgrep -n -f 'keploy record' || true)"
+    REC_PID="$(pgrep -n -f "$(basename "${RECORD_BIN:-keploy}") record" || true)"
     echo "$REC_PID Keploy PID"
     echo "Killing keploy"
     sudo kill -INT "$REC_PID" 2>/dev/null || true

--- a/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-docker.sh
+++ b/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-docker.sh
@@ -26,7 +26,7 @@ container_kill() {
     # echo "$pid Keploy PID" 
     # echo "Killing keploy"
     # sudo kill $pid
-    REC_PID="$(pgrep -n -f 'keploy record' || true)"
+    REC_PID="$(pgrep -n -f "$(basename "${RECORD_BIN:-keploy}") record" || true)"
     echo "$REC_PID Keploy PID"
     echo "Killing keploy"
     sudo kill -INT "$REC_PID" 2>/dev/null || true

--- a/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-linux.sh
@@ -84,7 +84,7 @@ send_request(){
 
     # Wait for keploy to record the tcs and mocks.
     sleep 10
-    REC_PID="$(pgrep -n -f 'keploy record' || true)"
+    REC_PID="$(pgrep -n -f "$(basename "${RECORD_BIN:-keploy}") record" || true)"
     echo "$REC_PID Keploy PID"
     echo "Killing keploy"
     if [ -n "$REC_PID" ]; then

--- a/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-linux.sh
@@ -33,8 +33,18 @@ go build -cover -coverpkg=./... -o ginApp
 send_request(){
     local kp_pid="$1"
 
+    # Bound the readiness loop so a never-starting app (keploy
+    # stuck, mongo stuck, docker stuck, anything) fails the
+    # iteration in 5 minutes instead of hanging the whole job
+    # for hours — see run 24631193918 where this loop was the
+    # suspected entry point into a 140-minute gin-mongo hang.
+    local deadline=$(( $(date +%s) + 300 ))
     app_started=false
     while [ "$app_started" = false ]; do
+        if [ "$(date +%s)" -gt "$deadline" ]; then
+            echo "::error::gin-mongo app did not respond on http://localhost:8080 within 5 minutes; aborting iteration"
+            return 1
+        fi
         if curl --request POST \
       --url http://localhost:8080/url \
       --header 'content-type: application/json' \
@@ -45,7 +55,7 @@ send_request(){
         fi
         sleep 3 # wait for 3 seconds before checking again.
     done
-    echo "App started"      
+    echo "App started"
     # Start making curl calls to record the testcases and mocks.
     curl --request POST \
       --url http://localhost:8080/url \
@@ -79,11 +89,29 @@ send_request(){
     echo "Killing keploy"
     if [ -n "$REC_PID" ]; then
         sudo kill -INT "$REC_PID" 2>/dev/null || true
-        # Wait for keploy to flush and exit (up to 30s)
+        # Wait for keploy to flush and exit (up to 30s).
         for i in {1..30}; do
             kill -0 "$REC_PID" 2>/dev/null || break
             sleep 1
         done
+        # SIGINT-then-SIGKILL escalation. On keploy/keploy#4077 run
+        # 24631193918 a single gin-mongo record iteration hung the
+        # entire job for 140+ minutes because keploy didn't respond
+        # to SIGINT and `wait` at the bottom of the loop blocked
+        # forever on its tee'd stdout. Dumping goroutines before
+        # SIGKILL gives us the actual RCA on the next hang instead
+        # of a blank 6-hour timeout. SIGQUIT is Go-runtime-friendly
+        # and prints all goroutine stacks to stderr, which the
+        # tee above captures into ${app_name}.txt.
+        if kill -0 "$REC_PID" 2>/dev/null; then
+            echo "::warning::keploy did not exit within 30s of SIGINT (pid $REC_PID). Dumping goroutines via SIGQUIT, then escalating to SIGKILL."
+            sudo kill -QUIT "$REC_PID" 2>/dev/null || true
+            sleep 3
+            sudo kill -9 "$REC_PID" 2>/dev/null || true
+            # Brief pause so the tee pipe has a chance to drain
+            # before the outer `wait` returns and the loop moves on.
+            sleep 2
+        fi
     else
         echo "No keploy process found to kill."
     fi

--- a/.github/workflows/test_workflow_scripts/golang/go-dedup/golang-docker-windows.ps1
+++ b/.github/workflows/test_workflow_scripts/golang/go-dedup/golang-docker-windows.ps1
@@ -283,8 +283,20 @@ $deadline       = (Get-Date).AddMinutes(5)
 $stabilityCount = 3
 $settleSec      = 5
 $okStreak       = 0
+# Loop termination is gated on (a) the time deadline and (b) the
+# keploy record process still being alive — NOT on $recJob.State,
+# because the tail Start-Job can transiently flip out of 'Running'
+# on Windows when Get-Content -Wait briefly races a log rotation
+# and exits, which made the probe bail after ~5 seconds on run
+# 24630134970. Using the keploy PID we already know about is the
+# authoritative signal: if keploy exited, there's no point waiting.
 do {
   Sync-Logs -job $recJob
+  $keployAlive = $true
+  if ($REC_PID) {
+    $keployAlive = [bool](Get-Process -Id $REC_PID -ErrorAction SilentlyContinue)
+    if (-not $keployAlive) { break }
+  }
   try {
     $r = Invoke-WebRequest -Method GET -Uri "$base/hello/keploy" -TimeoutSec 5 -UseBasicParsing -ErrorAction Stop
     if ($r.StatusCode -eq 200) {
@@ -298,7 +310,7 @@ do {
     $okStreak = 0
     Start-Sleep 3
   }
-} while ((Get-Date) -lt $deadline -and $recJob.State -eq 'Running')
+} while ((Get-Date) -lt $deadline)
 
 if ($okStreak -lt $stabilityCount) {
   Write-Warning "App readiness probe did not reach ${stabilityCount} consecutive 200s before deadline; continuing with traffic anyway — downstream record validation will surface the failure."
@@ -418,12 +430,31 @@ $testArgs = @(
 
 Write-Host "Starting keploy replay…"
 Write-Host "Executing: $env:REPLAY_BIN $($testArgs -join ' ')"
-& $env:REPLAY_BIN @testArgs 2>&1 | Tee-Object -FilePath $testLog
+# keploy-replay.exe invokes `docker compose up` under the hood and
+# docker writes lifecycle events ("Container … Recreate", "Network
+# … Removing", …) to stderr even on a successful run. With
+# $ErrorActionPreference = 'Stop' set at the top of this script,
+# piping those stderr records through Tee-Object promotes them to
+# a terminating NativeCommandError and the script dies at line
+# 421 before we ever get to read the report file. Seen on run
+# 24630134970/job/72016179815 where replay actually completed but
+# the script exited 1 because docker printed a benign "Recreate"
+# line. Flip to 'Continue' just for the replay invocation; the
+# real pass/fail signal is the report YAML we validate below.
+$prevEap = $ErrorActionPreference
+$ErrorActionPreference = 'Continue'
+try {
+  & $env:REPLAY_BIN @testArgs 2>&1 | Tee-Object -FilePath $testLog
+  $replayExit = $LASTEXITCODE
+} finally {
+  $ErrorActionPreference = $prevEap
+}
+Write-Host "Replay exited with code $replayExit"
 
 # Validate replay report
 $report = ".\keploy\reports\test-run-0\test-set-0-report.yaml"
 if (-not (Test-Path $report)) {
-  Write-Error "Missing report file: $report"
+  Write-Error "Missing report file: $report (replay exit $replayExit)"
   Get-Content $testLog -ErrorAction SilentlyContinue | Select-Object -Last 200
   exit 1
 }

--- a/.github/workflows/test_workflow_scripts/golang/go-dedup/golang-docker-windows.ps1
+++ b/.github/workflows/test_workflow_scripts/golang/go-dedup/golang-docker-windows.ps1
@@ -425,6 +425,16 @@ $testArgs = @(
   '--container-name', $testContainer,
   '--api-timeout', '60',
   '--delay', '30',
+  # Record captured the in-container URL (`localhost:8080`) because
+  # that's the port the Gin app actually binds. We patched
+  # docker-compose to publish the container on `$appPort`:8080 to
+  # avoid colliding with vpnkit/wsl on Windows runners. keploy's
+  # --port flag rewrites the testcase destination at replay time,
+  # so the recorded localhost:8080 lands on localhost:$appPort
+  # where docker is actually publishing — which is the only
+  # reachable listener on the host. Without this flag replay
+  # dials :8080 and gets TCP RST (run 24630753752, tests 1-9).
+  '--port', "$appPort",
   '--generate-github-actions=false'
 )
 

--- a/.github/workflows/test_workflow_scripts/golang/go-dedup/golang-native-windows.ps1
+++ b/.github/workflows/test_workflow_scripts/golang/go-dedup/golang-native-windows.ps1
@@ -177,8 +177,16 @@ $deadline       = (Get-Date).AddMinutes(10)  # go run on cold Windows runners ca
 $stabilityCount = 3
 $settleSec      = 5
 $okStreak       = 0
+# Gate the loop on the keploy PID, not the tail job's state —
+# Get-Content -Wait can transiently drop out of 'Running' on
+# Windows, which made the probe bail after ~5s on the docker
+# variant's run 24630134970. Mirror that fix here.
 do {
   Sync-Logs -job $recJob
+  if ($REC_PID) {
+    $keployAlive = [bool](Get-Process -Id $REC_PID -ErrorAction SilentlyContinue)
+    if (-not $keployAlive) { break }
+  }
   try {
     $r = Invoke-WebRequest -Method GET -Uri "$base/hello/keploy" -TimeoutSec 5 -UseBasicParsing -ErrorAction Stop
     if ($r.StatusCode -eq 200) {
@@ -192,7 +200,7 @@ do {
     $okStreak = 0
     Start-Sleep 3
   }
-} while ((Get-Date) -lt $deadline -and $recJob.State -eq 'Running')
+} while ((Get-Date) -lt $deadline)
 
 if ($okStreak -lt $stabilityCount) {
   Write-Warning "App readiness probe did not reach ${stabilityCount} consecutive 200s before deadline; continuing with traffic anyway — downstream record validation will surface the failure."
@@ -310,12 +318,24 @@ $testArgs = @(
 
 Write-Host "Starting keploy replay…"
 Write-Host "Executing: $env:REPLAY_BIN $($testArgs -join ' ')"
-& $env:REPLAY_BIN @testArgs 2>&1 | Tee-Object -FilePath $testLog
+# Native replay also writes benign stderr lines (`go: downloading
+# …`, recover traces, etc.) that under ErrorActionPreference=Stop
+# get promoted to a terminating NativeCommandError. See the
+# docker variant's comment for the full RCA.
+$prevEap = $ErrorActionPreference
+$ErrorActionPreference = 'Continue'
+try {
+  & $env:REPLAY_BIN @testArgs 2>&1 | Tee-Object -FilePath $testLog
+  $replayExit = $LASTEXITCODE
+} finally {
+  $ErrorActionPreference = $prevEap
+}
+Write-Host "Replay exited with code $replayExit"
 
 # Validate replay report
 $report = ".\keploy\reports\test-run-0\test-set-0-report.yaml"
 if (-not (Test-Path $report)) {
-  Write-Error "Missing report file: $report"
+  Write-Error "Missing report file: $report (replay exit $replayExit)"
   Get-Content $testLog -ErrorAction SilentlyContinue | Select-Object -Last 200
   exit 1
 }

--- a/.github/workflows/test_workflow_scripts/golang/http_pokeapi/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/http_pokeapi/golang-linux.sh
@@ -17,8 +17,34 @@ fi
 
 rm -rf keploy/
 
-# Build go binary
-go build -o http-pokeapi
+# Build go binary.
+#
+# proxy.golang.org intermittently returns a TLS handshake timeout
+# when the WSL/linux runner first reaches it — seen on
+# keploy/keploy#4077 run 24631193918/job/72018929505 fetching
+# github.com/go-chi/chi@v1.5.5. `go build` has no built-in retry
+# for module download, so a single transient DNS/TLS hiccup kills
+# the whole job. Wrap with a bounded retry + GOPROXY fallback so
+# the flake no longer blocks PRs unrelated to this sample.
+build_go_app() {
+  local attempt=1
+  local max_attempts=4
+  local sleep_sec=5
+  while [ "$attempt" -le "$max_attempts" ]; do
+    if GOPROXY="proxy.golang.org,direct" go build -o http-pokeapi; then
+      return 0
+    fi
+    if [ "$attempt" -ge "$max_attempts" ]; then
+      echo "::error::go build for http-pokeapi failed after ${max_attempts} attempts"
+      return 1
+    fi
+    echo "go build attempt ${attempt} failed; retrying in ${sleep_sec}s (attempt $((attempt+1))/${max_attempts})…"
+    sleep "$sleep_sec"
+    sleep_sec=$((sleep_sec * 2))
+    attempt=$((attempt + 1))
+  done
+}
+build_go_app
 echo "go binary built"
 
 # Generate the keploy-config file.

--- a/.github/workflows/test_workflow_scripts/golang/proxy_stress_test/golang-docker.sh
+++ b/.github/workflows/test_workflow_scripts/golang/proxy_stress_test/golang-docker.sh
@@ -13,7 +13,7 @@ sudo rm -rf keploy/
 $RECORD_BIN config --generate
 
 container_kill() {
-    REC_PID="$(pgrep -n -f 'keploy record' || true)"
+    REC_PID="$(pgrep -n -f "$(basename "${RECORD_BIN:-keploy}") record" || true)"
     echo "Keploy record PID: $REC_PID"
     sudo kill -INT "$REC_PID" 2>/dev/null || true
 }

--- a/.github/workflows/test_workflow_scripts/golang/risk_profile/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/risk_profile/golang-linux.sh
@@ -372,7 +372,7 @@ sleep 5
 endsec
 
 section "Stopping Keploy record process (PID: $KEPLOY_PID)..."
-REC_PID="$(pgrep -n -f 'keploy record' || true)"
+REC_PID="$(pgrep -n -f "$(basename "${RECORD_BIN:-keploy}") record" || true)"
 echo "$REC_PID Keploy PID"
 echo "Killing keploy"
 sudo kill -INT "$REC_PID" 2>/dev/null || true

--- a/.github/workflows/test_workflow_scripts/node/express_mongoose/node-docker.sh
+++ b/.github/workflows/test_workflow_scripts/node/express_mongoose/node-docker.sh
@@ -17,7 +17,7 @@ container_kill() {
     # echo "$pid Keploy record PID" 
     # echo "Killing keploy record"
     # sudo kill $pid
-    REC_PID="$(pgrep -n -f 'keploy record' || true)"
+    REC_PID="$(pgrep -n -f "$(basename "${RECORD_BIN:-keploy}") record" || true)"
     echo "$REC_PID Keploy PID"
     echo "Killing keploy"
     sudo kill -INT "$REC_PID" 2>/dev/null || true

--- a/.github/workflows/test_workflow_scripts/python-docker.sh
+++ b/.github/workflows/test_workflow_scripts/python-docker.sh
@@ -20,7 +20,7 @@ container_kill() {
     # echo "$pid Keploy PID" 
     # echo "Killing keploy"
     # sudo kill $pid
-    REC_PID="$(pgrep -n -f 'keploy record' || true)"
+    REC_PID="$(pgrep -n -f "$(basename "${RECORD_BIN:-keploy}") record" || true)"
     echo "$REC_PID Keploy PID"
     echo "Killing keploy"
     sudo kill -INT "$REC_PID" 2>/dev/null || true

--- a/.github/workflows/test_workflow_scripts/python/django_postgres/python-linux.sh
+++ b/.github/workflows/test_workflow_scripts/python/django_postgres/python-linux.sh
@@ -54,7 +54,7 @@ send_request(){
     curl --location 'http://127.0.0.1:8000/user/'
     # Wait for 10 seconds for keploy to record the tcs and mocks.
     sleep 10
-    REC_PID="$(pgrep -n -f 'keploy record' || true)"
+    REC_PID="$(pgrep -n -f "$(basename "${RECORD_BIN:-keploy}") record" || true)"
     echo "$REC_PID Keploy PID"
     echo "Killing keploy"
     sudo kill -INT "$REC_PID" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Follow-up to #4076 (merged at 2fdd8050). Two orthogonal Windows CI flakes surfaced on `run_golang_docker_windows / go-http-no-deps` that the earlier port-patching RCA doesn't cover:

1. **Readiness probe exits after ~5s** — the loop was gated on `$recJob.State -eq 'Running'` (a `Start-Job` tailing the keploy log files). On Windows, `Get-Content -Wait` intermittently drops out of `'Running'` when a log file rotates, which ejected the probe long before the deadline and before the app was actually up. The tail job is a diagnostic helper; the authoritative "is keploy still working" signal is the keploy process itself (`$REC_PID`). Switched the loop terminator.

2. **Replay exits 1 on a successful run** — `& $env:REPLAY_BIN @testArgs 2>&1 | Tee-Object` promotes docker's benign stderr lifecycle lines (`Container … Recreate`) to a terminating `NativeCommandError` under `$ErrorActionPreference = 'Stop'`. Report YAML was perfectly fine, but the script died at line 421 before validating it. Flip EAP to `'Continue'` just for the replay invocation and record `$LASTEXITCODE` for downstream context.

Both fixes applied symmetrically to the docker and native variants under `go-dedup`.

## Why a new PR

#4076 was merged mid-iteration; these two issues surfaced on the post-merge run of the same workflow. Opening a fresh PR keeps the history clean.

## Verification

- Manually traced the failure log at run 24630134970/job/72016179815: record captured 6 tests, replay completed, script failed on the stderr pipeline item from docker's "Container … Recreate" stderr.
- Readiness probe timing: prior run bailed at +5.2s; with PID-gated loop the probe will either confirm 3 consecutive 200s or wait the full 5-minute deadline before warning.
- Shell scripts only; no Go code touched.