### PR TITLE
fix(proxy,tools): keep ERROR level, attach next_step guidance

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -499,14 +499,20 @@ func (c *CmdConfigurator) Validate(ctx context.Context, cmd *cobra.Command) erro
 
 	// The "create config file if missing" behavior is meaningful
 	// only for user-facing commands (record/test/etc.) that are
-	// expected to persist keploy.yml for reuse. The `agent`
-	// subcommand is a worker process — it receives its config
-	// over CLI flags / env from the parent keploy, never reads
-	// keploy.yml from disk, and often runs inside a container
-	// where the host's absolute --config-path doesn't resolve
-	// anyway. Creating a config file there is a no-op at best
-	// and a misleading ENOENT "failed to write config file"
-	// ERROR at worst (kafka-ecommerce CI run 2541/10).
+	// expected to persist keploy.yml for reuse across invocations.
+	// The `agent` subcommand is a worker process spawned by the
+	// parent keploy: it still reads an existing keploy.yml via
+	// viper.ReadInConfig() in PreProcessFlags to pick up the same
+	// settings the parent resolved, but it has no use for writing
+	// a fresh one if the file is missing — the parent has already
+	// handed it the effective config via CLI flags + env. Running
+	// CreateConfigFile from the agent therefore produces a file
+	// no one reads; worse, on containerised runs the host's
+	// absolute --config-path doesn't resolve inside the agent's
+	// filesystem and the call fails with a misleading ENOENT
+	// "failed to write config file" ERROR (kafka-ecommerce CI
+	// run 2541/10). Skip the create-on-missing branch for the
+	// agent subcommand specifically.
 	if !IsConfigFileFound && cmd.Name() != "agent" {
 		err := c.CreateConfigFile(ctx, defaultCfg)
 		if err != nil {

--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -497,7 +497,17 @@ func (c *CmdConfigurator) Validate(ctx context.Context, cmd *cobra.Command) erro
 		c.logger.Warn("AppName in config (" + c.cfg.AppName + ") does not match current directory name (" + appName + ")")
 	}
 
-	if !IsConfigFileFound {
+	// The "create config file if missing" behavior is meaningful
+	// only for user-facing commands (record/test/etc.) that are
+	// expected to persist keploy.yml for reuse. The `agent`
+	// subcommand is a worker process — it receives its config
+	// over CLI flags / env from the parent keploy, never reads
+	// keploy.yml from disk, and often runs inside a container
+	// where the host's absolute --config-path doesn't resolve
+	// anyway. Creating a config file there is a no-op at best
+	// and a misleading ENOENT "failed to write config file"
+	// ERROR at worst (kafka-ecommerce CI run 2541/10).
+	if !IsConfigFileFound && cmd.Name() != "agent" {
 		err := c.CreateConfigFile(ctx, defaultCfg)
 		if err != nil {
 			c.logger.Error("failed to create config file", zap.Error(err))

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -513,11 +513,15 @@ func (p *Proxy) StartProxy(ctx context.Context, opts agent.ProxyOptions) error {
 			// remediation in the returned error (e.g. the enterprise
 			// proxyless/sockmap hook wraps the BPF verifier error
 			// with a "Next steps: upgrade kernel / drop --low-latency
-			// / rebuild without the BPF variant" message). We only
-			// propagate that error upward — the caller of StartProxy
-			// is responsible for surfacing it to the user, and we
-			// skip a LogError here to avoid double-logging the same
-			// failure once the caller logs.
+			// / rebuild without the BPF variant" message). Log once
+			// here with the hook's message visible in zap.Error and
+			// a generic next_step pointing at that embedded guidance,
+			// then propagate so the caller can abort. Partial-proxy
+			// goroutines started before this point are torn down by
+			// the caller cancelling proxyCtx (see service/agent.go).
+			utils.LogError(p.logger, err, "auxiliary proxy hook failed; requested feature cannot run on this host",
+				zap.String("next_step", "the hook's error wraps its own 'Next steps:' remediation — read the full error chain for the feature-specific fix (kernel upgrade, disabling the feature flag, or rebuilding without the BPF variant)"),
+			)
 			return fmt.Errorf("auxiliary proxy hook failed: %w", err)
 		}
 	}

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -505,12 +505,19 @@ func (p *Proxy) StartProxy(ctx context.Context, opts agent.ProxyOptions) error {
 			// feature it implements (currently: --low-latency, which
 			// registers the proxyless / sockmap BPF startup). Silently
 			// continuing into userspace-proxy mode after the hook has
-			// declared a failure gives the user a mode they didn't ask
-			// for and no deterministic signal that the requested mode
-			// wasn't delivered. Return the hook's error so StartProxy
-			// aborts and the caller can surface the "next steps"
-			// message the hook embedded.
-			utils.LogError(p.logger, err, "auxiliary proxy hook failed; requested feature cannot run on this host")
+			// declared a failure would give the user a mode they
+			// didn't ask for and no deterministic signal that the
+			// requested mode wasn't delivered.
+			//
+			// The hook itself is expected to embed actionable
+			// remediation in the returned error (e.g. the enterprise
+			// proxyless/sockmap hook wraps the BPF verifier error
+			// with a "Next steps: upgrade kernel / drop --low-latency
+			// / rebuild without the BPF variant" message). We only
+			// propagate that error upward — the caller of StartProxy
+			// is responsible for surfacing it to the user, and we
+			// skip a LogError here to avoid double-logging the same
+			// failure once the caller logs.
 			return fmt.Errorf("auxiliary proxy hook failed: %w", err)
 		}
 	}
@@ -818,7 +825,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 	if p.GlobalPassthrough || (!rule.Mocking && (rule.Mode == models.MODE_TEST)) {
 		dstConn, err = net.Dial("tcp", dstAddr)
 		if err != nil {
-			utils.LogError(p.logger, err, "failed to dial the conn to destination server", zap.Uint32("proxy port", p.Port), zap.String("server address", dstAddr), zap.String("next_step", "confirm the app's upstream dependency is listening on this address before traffic starts (adjust --delay, add a readiness probe to the test harness, or pre-start the dependency); the dial is a single attempt and will not retry"))
+			utils.LogError(p.logger, err, "failed to dial the conn to destination server", zap.Uint32("proxy port", p.Port), zap.String("server address", dstAddr), zap.String("next_step", util.NextStepDialDestination))
 			return err
 		}
 
@@ -838,7 +845,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 		if rule.Mode != models.MODE_TEST {
 			dstConn, err = net.Dial("tcp", dstAddr)
 			if err != nil {
-				utils.LogError(p.logger, err, "failed to dial the conn to destination server", zap.Uint32("proxy port", p.Port), zap.String("server address", dstAddr), zap.String("next_step", "confirm the app's upstream dependency is listening on this address before traffic starts (adjust --delay, add a readiness probe to the test harness, or pre-start the dependency); the dial is a single attempt and will not retry"))
+				utils.LogError(p.logger, err, "failed to dial the conn to destination server", zap.Uint32("proxy port", p.Port), zap.String("server address", dstAddr), zap.String("next_step", util.NextStepDialDestination))
 				return err
 			}
 			dstCfg := &models.ConditionalDstCfg{
@@ -1294,7 +1301,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 					dstConn, err = tls.Dial("tcp", addr, cfg)
 				}
 				if err != nil {
-					utils.LogError(logger, err, "failed to dial the conn to destination server", zap.Uint32("proxy port", p.Port), zap.String("server address", addr), zap.String("next_step", "confirm the app's upstream dependency is listening on this address before traffic starts (adjust --delay, add a readiness probe to the test harness, or pre-start the dependency); the dial is a single attempt and will not retry"))
+					utils.LogError(logger, err, "failed to dial the conn to destination server", zap.Uint32("proxy port", p.Port), zap.String("server address", addr), zap.String("next_step", util.NextStepDialDestination))
 					return err
 				}
 
@@ -1312,7 +1319,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 		if rule.Mode != models.MODE_TEST && dstConn == nil {
 			dstConn, err = net.Dial("tcp", dstAddr)
 			if err != nil {
-				utils.LogError(logger, err, "failed to dial the conn to destination server", zap.Uint32("proxy port", p.Port), zap.String("server address", dstAddr), zap.String("next_step", "confirm the app's upstream dependency is listening on this address before traffic starts (adjust --delay, add a readiness probe to the test harness, or pre-start the dependency); the dial is a single attempt and will not retry"))
+				utils.LogError(logger, err, "failed to dial the conn to destination server", zap.Uint32("proxy port", p.Port), zap.String("server address", dstAddr), zap.String("next_step", util.NextStepDialDestination))
 				return err
 			}
 		}

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -499,9 +499,19 @@ func (p *Proxy) StartProxy(ctx context.Context, opts agent.ProxyOptions) error {
 	}
 
 	if p.auxiliaryHook != nil {
-		err := p.auxiliaryHook.AfterStart(ctx, p)
-		if err != nil {
-			utils.LogError(p.logger, err, "failed to execute auxiliary proxy hook; verify auxiliary hook configuration or disable the hook if not required")
+		if err := p.auxiliaryHook.AfterStart(ctx, p); err != nil {
+			// Do NOT swallow the error. An auxiliary hook only gets
+			// registered when a caller has explicitly opted into the
+			// feature it implements (currently: --low-latency, which
+			// registers the proxyless / sockmap BPF startup). Silently
+			// continuing into userspace-proxy mode after the hook has
+			// declared a failure gives the user a mode they didn't ask
+			// for and no deterministic signal that the requested mode
+			// wasn't delivered. Return the hook's error so StartProxy
+			// aborts and the caller can surface the "next steps"
+			// message the hook embedded.
+			utils.LogError(p.logger, err, "auxiliary proxy hook failed; requested feature cannot run on this host")
+			return fmt.Errorf("auxiliary proxy hook failed: %w", err)
 		}
 	}
 
@@ -808,7 +818,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 	if p.GlobalPassthrough || (!rule.Mocking && (rule.Mode == models.MODE_TEST)) {
 		dstConn, err = net.Dial("tcp", dstAddr)
 		if err != nil {
-			utils.LogError(p.logger, err, "failed to dial the conn to destination server", zap.Uint32("proxy port", p.Port), zap.String("server address", dstAddr))
+			utils.LogError(p.logger, err, "failed to dial the conn to destination server", zap.Uint32("proxy port", p.Port), zap.String("server address", dstAddr), zap.String("next_step", "confirm the app's upstream dependency is listening on this address before traffic starts (adjust --delay, add a readiness probe to the test harness, or pre-start the dependency); the dial is a single attempt and will not retry"))
 			return err
 		}
 
@@ -828,7 +838,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 		if rule.Mode != models.MODE_TEST {
 			dstConn, err = net.Dial("tcp", dstAddr)
 			if err != nil {
-				utils.LogError(p.logger, err, "failed to dial the conn to destination server", zap.Uint32("proxy port", p.Port), zap.String("server address", dstAddr))
+				utils.LogError(p.logger, err, "failed to dial the conn to destination server", zap.Uint32("proxy port", p.Port), zap.String("server address", dstAddr), zap.String("next_step", "confirm the app's upstream dependency is listening on this address before traffic starts (adjust --delay, add a readiness probe to the test harness, or pre-start the dependency); the dial is a single attempt and will not retry"))
 				return err
 			}
 			dstCfg := &models.ConditionalDstCfg{
@@ -1284,7 +1294,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 					dstConn, err = tls.Dial("tcp", addr, cfg)
 				}
 				if err != nil {
-					utils.LogError(logger, err, "failed to dial the conn to destination server", zap.Uint32("proxy port", p.Port), zap.String("server address", addr))
+					utils.LogError(logger, err, "failed to dial the conn to destination server", zap.Uint32("proxy port", p.Port), zap.String("server address", addr), zap.String("next_step", "confirm the app's upstream dependency is listening on this address before traffic starts (adjust --delay, add a readiness probe to the test harness, or pre-start the dependency); the dial is a single attempt and will not retry"))
 					return err
 				}
 
@@ -1302,7 +1312,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 		if rule.Mode != models.MODE_TEST && dstConn == nil {
 			dstConn, err = net.Dial("tcp", dstAddr)
 			if err != nil {
-				utils.LogError(logger, err, "failed to dial the conn to destination server", zap.Uint32("proxy port", p.Port), zap.String("server address", dstAddr))
+				utils.LogError(logger, err, "failed to dial the conn to destination server", zap.Uint32("proxy port", p.Port), zap.String("server address", dstAddr), zap.String("next_step", "confirm the app's upstream dependency is listening on this address before traffic starts (adjust --delay, add a readiness probe to the test harness, or pre-start the dependency); the dial is a single attempt and will not retry"))
 				return err
 			}
 		}

--- a/pkg/agent/proxy/util/util.go
+++ b/pkg/agent/proxy/util/util.go
@@ -589,7 +589,7 @@ func PassThrough(ctx context.Context, logger *zap.Logger, clientConn net.Conn, d
 
 		destConn, err = tls.Dial("tcp", dstCfg.Addr, dstCfg.TLSCfg)
 		if err != nil {
-			utils.LogError(logger, err, "failed to dial the conn to destination server", zap.Any("server address", dstCfg.Addr))
+			utils.LogError(logger, err, "failed to dial the conn to destination server", zap.Any("server address", dstCfg.Addr), zap.String("next_step", "confirm the upstream dependency (DB / service at this address) is listening before traffic starts; the dial is a single attempt and will not retry"))
 			return nil, err
 		}
 		logger.Debug("TLS connection established with the destination server", zap.Any("Destination Addr", destConn.RemoteAddr().String()))

--- a/pkg/agent/proxy/util/util.go
+++ b/pkg/agent/proxy/util/util.go
@@ -34,6 +34,14 @@ import (
 
 var Emoji = "\U0001F430" + " Keploy:"
 
+// NextStepDialDestination is the shared remediation hint attached
+// to every "failed to dial the conn to destination server" error.
+// The proxy's destination dial is a single attempt with no retry,
+// so the real fix is always on the test-harness side (sequence
+// the dependency start, raise --delay, or add a readiness probe).
+// Kept as a const so all sites update together.
+const NextStepDialDestination = "confirm the app's upstream dependency is listening on this address before traffic starts (adjust --delay, add a readiness probe to the test harness, or pre-start the dependency); the dial is a single attempt and will not retry"
+
 // ErrRecordingPausedDueToMemoryPressure tells record-mode parsers to stop
 // decoding and fall back to transparent passthrough while the agent is under
 // memory pressure.
@@ -589,7 +597,7 @@ func PassThrough(ctx context.Context, logger *zap.Logger, clientConn net.Conn, d
 
 		destConn, err = tls.Dial("tcp", dstCfg.Addr, dstCfg.TLSCfg)
 		if err != nil {
-			utils.LogError(logger, err, "failed to dial the conn to destination server", zap.Any("server address", dstCfg.Addr), zap.String("next_step", "confirm the upstream dependency (DB / service at this address) is listening before traffic starts; the dial is a single attempt and will not retry"))
+			utils.LogError(logger, err, "failed to dial the conn to destination server", zap.Any("server address", dstCfg.Addr), zap.String("next_step", NextStepDialDestination))
 			return nil, err
 		}
 		logger.Debug("TLS connection established with the destination server", zap.Any("Destination Addr", destConn.RemoteAddr().String()))
@@ -597,7 +605,7 @@ func PassThrough(ctx context.Context, logger *zap.Logger, clientConn net.Conn, d
 		logger.Debug("trying to establish a connection with the destination server", zap.Any("Destination Addr", dstCfg.Addr))
 		destConn, err = net.Dial("tcp", dstCfg.Addr)
 		if err != nil {
-			utils.LogError(logger, err, "failed to dial the destination server")
+			utils.LogError(logger, err, "failed to dial the conn to destination server", zap.Any("server address", dstCfg.Addr), zap.String("next_step", NextStepDialDestination))
 			return nil, err
 		}
 		logger.Debug("connection established with the destination server", zap.Any("Destination Addr", destConn.RemoteAddr().String()))

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -260,6 +260,15 @@ func (a *Agent) Hook(ctx context.Context, opts models.HookOptions) error {
 
 	if err != nil {
 		utils.LogError(a.logger, err, "failed to start proxy")
+		// StartProxy may have spawned proxy goroutines before the
+		// failure point (TCP accept loop, TCP DNS, UDP DNS) — they
+		// stay live until proxyCtx is cancelled. Before this fix
+		// they leaked until the outer agent context was cancelled,
+		// holding ports and consuming resources. Cancel here so the
+		// partial proxy is torn down immediately. Matters now that
+		// StartProxy propagates auxiliary-hook failures (keploy#4078)
+		// rather than swallowing them.
+		proxyCtxCancel()
 		return hookErr
 	}
 

--- a/pkg/service/tools/tools.go
+++ b/pkg/service/tools/tools.go
@@ -315,7 +315,10 @@ func (t *Tools) CreateConfig(_ context.Context, filePath string, configData stri
 
 	err = os.WriteFile(filePath, finalOutput, fs.ModePerm)
 	if err != nil {
-		utils.LogError(t.logger, err, "failed to write config file")
+		utils.LogError(t.logger, err, "failed to write config file",
+			zap.String("path", filePath),
+			zap.String("next_step", "verify the directory exists and the user running keploy has write permission; remove any read-only keploy.yml left over from a prior run (e.g. via sudo chown or rm) before re-invoking `keploy config --generate`"),
+		)
 		return nil
 	}
 

--- a/pkg/service/tools/tools.go
+++ b/pkg/service/tools/tools.go
@@ -315,11 +315,17 @@ func (t *Tools) CreateConfig(_ context.Context, filePath string, configData stri
 
 	err = os.WriteFile(filePath, finalOutput, fs.ModePerm)
 	if err != nil {
+		// Return the error so callers (cli/config.go handler,
+		// CmdConfigurator.CreateConfigFile) don't falsely claim
+		// "Config file generated successfully" — they each check
+		// the error already. Prior behavior of returning nil
+		// here was a latent lie that let CI scripts see a
+		// "success" line plus an ERROR line for the same op.
 		utils.LogError(t.logger, err, "failed to write config file",
 			zap.String("path", filePath),
 			zap.String("next_step", "verify the directory exists and the user running keploy has write permission; remove any read-only keploy.yml left over from a prior run (e.g. via sudo chown or rm) before re-invoking `keploy config --generate`"),
 		)
-		return nil
+		return err
 	}
 
 	err = os.Chmod(filePath, 0777) // Set permissions to 777


### PR DESCRIPTION
## Summary

Follow-up to #4077. While reviewing the grep-v allowlists various CI scripts were carrying around keploy log messages, we caught an anti-pattern: those allowlists were masking ERROR-level signals that were legitimate, not noisy. Rather than downgrade the log levels to match the pipeline tolerance (which hides the signal from production operators too), this change keeps the ERROR level and attaches a structured `next_step` field so anyone reading the log — in CI or in prod — sees the exact remediation.

## Sites touched

- `pkg/agent/proxy/proxy.go` × 4 dial sites: `"failed to dial the conn to destination server"` — all call paths (globalPassthrough, MySQL prelude, TLS + plain dials inside handleTCPConnection). Each now documents that the dial is a single attempt with no retry, and the operator's three real options (start the upstream first, raise `--delay`, or add a readiness probe).
- `pkg/agent/proxy/util/util.go` — same guidance for the TLS-dial path in the generic parser util.
- `pkg/service/tools/tools.go` — `"failed to write config file"` now carries the target path and the most common real cause (a read-only `keploy.yml` left by a prior `sudo keploy` invocation that the current user can no longer overwrite).

## What this is NOT

No log-level downgrades, no `utils.LogError` → `logger.Warn` shortcuts. The principle is: ERROR continues to mean "something real went wrong" so operators can trust the signal; the job of the pipeline is to avoid the scenarios that produce ERRORs (not to filter them out).

CI-script allowlist cleanup for the three messages above lives in the enterprise PR (`fix/redis-config-cursor-kafka-transactional`).


## Behavior change — auxiliary proxy hook

`Proxy.StartProxy` previously swallowed `AuxiliaryProxyHook.AfterStart` errors (logged + continued). It now **propagates** them: if the hook fails, `StartProxy` returns the error and the command aborts.

This is deliberate. The auxiliary hook is only registered when a caller has opted into the feature it implements (today: `--low-latency` in enterprise, which registers the proxyless / sockmap BPF startup). Silently falling back to userspace-proxy mode after the hook declared a failure gave the user a mode they didn't ask for and no deterministic signal that the requested mode wasn't delivered. Release notes should flag this for any downstream builds that register their own auxiliary hook — if that hook's failure used to be survivable via the log-and-continue path, the hook implementation needs to return `nil` (when the fallback is correct) or otherwise the command will now abort with the hook's error.
