### PR TITLE
feat(mockdb): per-MockYaml format override (#225 dependency)

### DIFF
--- a/pkg/models/mock.go
+++ b/pkg/models/mock.go
@@ -49,10 +49,15 @@ type Mock struct {
 	// Format is the per-mock on-disk format hint/override. Empty string
 	// means "fall back to the testset-level format" (whatever the caller
 	// / CLI selected via record.mockFormat / KEPLOY_MOCK_FORMAT).
-	// Recognized values are "yaml" or "gob"; anything else is treated as
-	// empty and falls back to the process-wide configured default (see
-	// mockdb.resolveMockFormat). We deliberately do not reject unknown
-	// values so a stale or typo'd format never blocks recording.
+	// Recognized values are "yaml" or "gob". Any other non-empty value
+	// is resolved by mockdb.InsertMock's three-step policy: (1) a
+	// recognized override wins, else (2) if the enclosing testset is
+	// already locked to a format (from an earlier InsertMock or a
+	// rehydrated on-disk file), inherit that lock so typo'd / stale
+	// values do not trip the mixed-format guard, else (3) fall back to
+	// the process-wide configured default. We deliberately do not
+	// reject unknown values so a stale or typo'd format never blocks
+	// recording.
 	//
 	// Writers may propagate this field into the on-disk
 	// NetworkTrafficDoc, and readers may load it back from the same

--- a/pkg/models/mock.go
+++ b/pkg/models/mock.go
@@ -46,6 +46,18 @@ type Mock struct {
 	// list is skipped (treated as noise). Written by the enterprise
 	// secret-protection obfuscator.
 	Noise []string `json:"Noise,omitempty" bson:"noise,omitempty" yaml:"noise,omitempty"`
+	// Format is the per-mock on-disk format override. Empty string means
+	// "fall back to the testset-level format" (whatever the caller / CLI
+	// selected via record.mockFormat / KEPLOY_MOCK_FORMAT). Non-empty
+	// values must be one of "yaml" or "gob"; mockdb readers and writers
+	// honor this field so one session can mix formats inside a single
+	// test-set directory — required by the DaemonSet feature where each
+	// RecordingSession.spec.mockFormat is per-session.
+	//
+	// Writers propagate this field into the on-disk NetworkTrafficDoc.
+	// Readers load it back from the same field. No default: an unset
+	// Format means "use whatever mockdb was configured with at startup".
+	Format string `json:"Format,omitempty" bson:"format,omitempty" yaml:"format,omitempty"`
 }
 
 // TestModeInfo is in-memory-only bookkeeping attached to each Mock once it
@@ -197,6 +209,11 @@ func (m *Mock) DeepCopy() *Mock {
 			LifetimeDerived: lifetimeDerived,
 		},
 		ConnectionID: m.ConnectionID,
+		// Format is a per-mock override; it must survive DeepCopy so the
+		// async gob writer's copied payload preserves the caller's
+		// selected on-disk format. Dropping it here would silently demote
+		// gob-tagged mocks to the default format on the write path.
+		Format: m.Format,
 	}
 
 	// Deep copy the Noise slice so mutations to one copy don't affect the other.

--- a/pkg/models/mock.go
+++ b/pkg/models/mock.go
@@ -46,17 +46,17 @@ type Mock struct {
 	// list is skipped (treated as noise). Written by the enterprise
 	// secret-protection obfuscator.
 	Noise []string `json:"Noise,omitempty" bson:"noise,omitempty" yaml:"noise,omitempty"`
-	// Format is the per-mock on-disk format override. Empty string means
-	// "fall back to the testset-level format" (whatever the caller / CLI
-	// selected via record.mockFormat / KEPLOY_MOCK_FORMAT). Non-empty
-	// values must be one of "yaml" or "gob"; mockdb readers and writers
-	// honor this field so one session can mix formats inside a single
-	// test-set directory — required by the DaemonSet feature where each
-	// RecordingSession.spec.mockFormat is per-session.
+	// Format is the per-mock on-disk format hint/override. Empty string
+	// means "fall back to the testset-level format" (whatever the caller
+	// / CLI selected via record.mockFormat / KEPLOY_MOCK_FORMAT).
+	// Non-empty values must be one of "yaml" or "gob".
 	//
-	// Writers propagate this field into the on-disk NetworkTrafficDoc.
-	// Readers load it back from the same field. No default: an unset
-	// Format means "use whatever mockdb was configured with at startup".
+	// Writers may propagate this field into the on-disk
+	// NetworkTrafficDoc, and readers may load it back from the same
+	// field. However, this metadata alone does not imply that mocks from
+	// both mocks.yaml and mocks.gob are merged when both files exist in a
+	// single test-set directory. No default: an unset Format means "use
+	// whatever mockdb was configured with at startup".
 	Format string `json:"Format,omitempty" bson:"format,omitempty" yaml:"format,omitempty"`
 }
 

--- a/pkg/models/mock.go
+++ b/pkg/models/mock.go
@@ -49,7 +49,10 @@ type Mock struct {
 	// Format is the per-mock on-disk format hint/override. Empty string
 	// means "fall back to the testset-level format" (whatever the caller
 	// / CLI selected via record.mockFormat / KEPLOY_MOCK_FORMAT).
-	// Non-empty values must be one of "yaml" or "gob".
+	// Recognized values are "yaml" or "gob"; anything else is treated as
+	// empty and falls back to the process-wide configured default (see
+	// mockdb.resolveMockFormat). We deliberately do not reject unknown
+	// values so a stale or typo'd format never blocks recording.
 	//
 	// Writers may propagate this field into the on-disk
 	// NetworkTrafficDoc, and readers may load it back from the same

--- a/pkg/platform/yaml/mockdb/db.go
+++ b/pkg/platform/yaml/mockdb/db.go
@@ -79,6 +79,31 @@ func useGobMockFormat() bool {
 	return configuredMockFormat == mockFormatGob
 }
 
+// resolveMockFormat picks the on-disk format for a single mock. Per-mock
+// overrides win over the process-wide default; an empty string falls back
+// to the testset-level format (useGobMockFormat). Callers on the write
+// path use this to route a single mock through the gob or yaml writer
+// independent of what the session's default format is. This is what
+// enables the DaemonSet per-session mockFormat: two concurrent
+// RecordingSessions writing into different test-set directories can
+// each tag their mocks with the desired format even though the mockdb
+// package-level configuredMockFormat is process-global.
+//
+// Valid per-mock formats are "yaml" and "gob". Any other non-empty
+// value falls through to the process-wide default — we prefer to
+// preserve mocks over failing the write when a stale or typo'd format
+// slips in from a user-facing CR.
+func resolveMockFormat(perMock string) bool {
+	switch perMock {
+	case mockFormatGob:
+		return true
+	case "yaml":
+		return false
+	default:
+		return useGobMockFormat()
+	}
+}
+
 type MockYaml struct {
 	MockPath  string
 	MockName  string
@@ -561,7 +586,13 @@ func (ys *MockYaml) InsertMock(ctx context.Context, mock *models.Mock, testSetID
 	// yaml.v3 encoding at 28-30% of record client CPU; gob round-trips
 	// all interface{} Message fields via the gob.Register calls in
 	// pkg/models/*. Sync fallback on queue-full so mocks never drop.
-	if useGobMockFormat() {
+	//
+	// Per-mock override (mock.Format) takes precedence over the
+	// process-wide configured format so the DS agent can thread each
+	// RecordingSession's spec.mockFormat through to individual mocks
+	// without mutating package-level state. Unset / unrecognised =>
+	// fall back to useGobMockFormat (the pre-DS behaviour).
+	if resolveMockFormat(mock.Format) {
 		return ys.insertMockGob(ctx, mock, mockPath, mockFileName)
 	}
 

--- a/pkg/platform/yaml/mockdb/db.go
+++ b/pkg/platform/yaml/mockdb/db.go
@@ -90,13 +90,16 @@ type MockYaml struct {
 	// goroutines never block on disk or gob encoding. Sync fallback
 	// activates when the queue is full so no mock is dropped.
 	//
-	// The writer lifecycle is restartable across Close/InsertMock
-	// cycles so that re-record flows (same Recorder / same mockDB,
-	// multiple Start calls) flush+close between sessions but still
-	// accept mocks for the next session. gobLifecycleMu guards the
-	// transition between "running" and "quiesced"; gobRunning tracks
-	// which state we are in. Do not use sync.Once here — it cannot be
-	// reset, which was the original re-record bug.
+	// gobLifecycleMu guards the transition between "running" and
+	// "quiesced"; gobRunning tracks which state we are in. The
+	// writer can transition from quiesced back to running via
+	// insertMockGob's inline init when a fresh MockYaml receives
+	// its first gob mock — but Close itself is terminal (it sets
+	// ys.closed=true and InsertMock refuses further writes on the
+	// same instance). Re-record / multi-session flows must build a
+	// fresh MockYaml after Close; only updateMocksGob (replay-side
+	// pruning) legitimately calls Close mid-instance, and its own
+	// file rewrite does not go through InsertMock.
 	gobLifecycleMu sync.Mutex
 	gobRunning     bool
 	gobQueue       chan gobWriteJob
@@ -139,6 +142,27 @@ type MockYaml struct {
 	// so the yaml mocks vanish at replay. The sync.Map's
 	// LoadOrStore is the primary guard; true = gob, false = yaml.
 	testSetFormat sync.Map
+
+	// closed is set to true by Close() as its FIRST action, before
+	// any teardown begins. Every public mutating method (InsertMock,
+	// DeleteMocksForSet, UpdateMocks) consults this flag on entry
+	// and refuses to proceed if it is already set. This closes the
+	// Close-vs-concurrent-InsertMock(yaml) race:
+	//
+	// The YAML InsertMock path does not take gobLifecycleMu — only
+	// the gob path does — so without this gate, Close could clear
+	// testSetFormat while a yaml InsertMock is mid-flight, and
+	// another yaml InsertMock that arrives after the clear would
+	// see ENOENT on mocks.gob (the pending gob write may not have
+	// materialised yet) and create mocks.yaml alongside the still-
+	// queued gob write. With closed=true set before any teardown,
+	// any InsertMock that arrives at or after the store sees the
+	// closed flag and returns early, so it can never bypass the
+	// guard during the teardown window.
+	//
+	// atomic.Bool (Go 1.19+) is used because sync/atomic is already
+	// imported for gobOverflows and idCounter; no extra dependency.
+	closed atomic.Bool
 }
 
 type gobWriteJob struct {
@@ -447,8 +471,13 @@ func (ys *MockYaml) updateMocksGob(ctx context.Context, testSetID, gobPath strin
 	// rewrite the gob file. An active writer holds ys.gobFile /
 	// ys.gobBufw / ys.gobEnc; rewriting the file out from under it
 	// would corrupt the next Encode. Close drains the queue and
-	// resets lifecycle state; the next InsertMock restarts a fresh
-	// writer via the inline init in insertMockGob.
+	// flushes the file. Close is terminal (ys.closed is set to true
+	// and InsertMock rejects further writes); this is safe here
+	// because UpdateMocks is a replay-side operation — the replay
+	// MockYaml instance is never subsequently used as a record sink.
+	// Any future prune pass on this same instance still works
+	// because updateMocksGob rewrites mocks.gob via tmp+rename
+	// rather than via InsertMock.
 	if err := ys.Close(); err != nil {
 		utils.LogError(ys.Logger, err, "failed to quiesce async gob writer before pruning; check disk space and writer state", zap.String("path", gobPath))
 		return err
@@ -615,6 +644,19 @@ func (ys *MockYaml) updateMocksGob(ctx context.Context, testSetID, gobPath strin
 // that need to mix formats must route to sibling test-set directories
 // (the DaemonSet per-session flow).
 func (ys *MockYaml) InsertMock(ctx context.Context, mock *models.Mock, testSetID string) error {
+	// Reject any InsertMock that arrives at or after Close() has
+	// started its teardown. Close sets ys.closed as its FIRST action
+	// (before clearing testSetFormat or touching the async gob
+	// writer), so an atomic Load here is sufficient to stop the
+	// yaml-path race: a yaml InsertMock that slipped past the guard
+	// would otherwise observe a cleared testSetFormat + an ENOENT on
+	// mocks.gob (the queued gob write may not have flushed yet) and
+	// create mocks.yaml next to the still-pending mocks.gob. With
+	// this check in place, any caller that sees closed=true bails
+	// before stating or writing anything.
+	if ys.closed.Load() {
+		return fmt.Errorf("mockdb: InsertMock called on closed MockYaml (testSetID=%q)", testSetID)
+	}
 	mock.Name = fmt.Sprint("mock-", ys.getNextID())
 	mockPath := filepath.Join(ys.MockPath, testSetID)
 	mockFileName := ys.MockName
@@ -1053,9 +1095,18 @@ func (ys *MockYaml) gobWriteSync(ctx context.Context, mock *models.Mock, mockPat
 // Range and Delete each key. Invoked from Close to bound memory in
 // long-lived processes (DaemonSet mode, multi-session recorders)
 // where the typical shutdown path never hits DeleteMocksForSet.
-// Callers must hold ys.gobLifecycleMu so a concurrent InsertMock
-// cannot racily repopulate the map between our Range and the caller
-// observing an empty map.
+//
+// Concurrency contract: this helper is only safe to call once Close
+// has (a) stored ys.closed=true so every public mutating path bails
+// before touching testSetFormat, and (b) drained the async gob
+// writer so every queued mocks.gob has materialised on disk. With
+// those preconditions, no concurrent InsertMock can repopulate the
+// map during the Range/Delete walk, and the stat-based rehydrate
+// path on a subsequent fresh MockYaml will still observe the on-disk
+// format correctly. The earlier doc comment claimed that holding
+// gobLifecycleMu was sufficient — that was incorrect because the
+// yaml InsertMock path never takes gobLifecycleMu; the ys.closed
+// gate is what actually makes the map-clear race-safe.
 func (ys *MockYaml) clearTestSetFormats() {
 	ys.testSetFormat.Range(func(key, _ any) bool {
 		ys.testSetFormat.Delete(key)
@@ -1063,25 +1114,55 @@ func (ys *MockYaml) clearTestSetFormats() {
 	})
 }
 
-// Close drains the async gob writer and flushes the file. Safe to
-// call multiple times, and safe to call between record sessions —
-// the writer goroutine exits after flushing, and the next InsertMock
-// starts a fresh goroutine via its own inline init (see
-// insertMockGob). This is what makes re-record cycles (multiple
-// Recorder.Start on the same mockDB instance) work without dropping
-// mocks.
+// Close drains the async gob writer, flushes the file, and marks
+// this MockYaml instance as terminal. Once Close has stored
+// ys.closed=true, any subsequent InsertMock / DeleteMocksForSet on
+// the same instance returns an error instead of racing the teardown.
+// Close itself is idempotent and safe to call multiple times — the
+// second call is a no-op once gobRunning is cleared.
+//
+// Why Close is terminal (R9 fix): the yaml InsertMock path does not
+// take gobLifecycleMu (only the gob path does). Previously Close
+// cleared testSetFormat BEFORE draining the async writer, which left
+// a window where a concurrent InsertMock(yaml) could observe the
+// cleared map plus an ENOENT on the still-queued mocks.gob and
+// create mocks.yaml alongside it — producing a mixed-format on-disk
+// state the readers cannot cope with. The closed gate blocks that
+// second InsertMock cold; the clear is then postponed until AFTER
+// the writer has drained, so every testSetFormat entry whose lock
+// points at a pending gob write has had its file materialise by the
+// time the map is walked.
 //
 // Close also clears the in-memory per-testset format map so long-
 // lived processes (DaemonSet mode, a multi-session Recorder) do not
 // grow the sync.Map unboundedly. Typical record flows terminate a
 // session with Close, not DeleteMocksForSet, so without this clear
 // every test-set ever touched would leak an entry for the full
-// lifetime of the process. The next InsertMock for any testSetID
-// will rehydrate from on-disk state via os.Stat on the first call
-// (see the rehydrate block in InsertMock), so dropping the map is
-// semantically identical to a fresh MockYaml — only the memory
-// footprint changes.
+// lifetime of the process. Multi-session workflows must build a
+// fresh MockYaml per session (via New) — Close cannot be reused as
+// a restart point, because that would re-introduce the race the
+// closed gate was added to close. The rehydrate path in InsertMock
+// (os.Stat on mocks.gob / mocks.yaml) still handles a fresh
+// MockYaml pointed at an existing test-set directory correctly.
 func (ys *MockYaml) Close() error {
+	// Set the closing gate as the VERY FIRST action — before any lock
+	// or teardown. Every public mutating path (InsertMock /
+	// DeleteMocksForSet / UpdateMocks) consults ys.closed on entry and
+	// bails if it is already set. Doing this before we acquire
+	// gobLifecycleMu or touch testSetFormat blocks new inserts from
+	// slipping past the format guard during the teardown window:
+	//
+	//   t0: Close stores closed=true            <-- new inserts rejected here
+	//   t1: Close drains the async gob writer   (mocks.gob fully on disk)
+	//   t2: Close calls clearTestSetFormats     (safe — no new entries can arrive)
+	//
+	// Without the t0 store, step t2 could strip a live yaml testset's
+	// lock while the gob writer's mocks.gob hasn't materialised yet;
+	// a concurrent InsertMock(yaml) path (which does NOT take
+	// gobLifecycleMu) would then stat the missing mocks.gob, pass the
+	// mixed-format guard, and create mocks.yaml alongside the still-
+	// queued gob write.
+	ys.closed.Store(true)
 	// Hold the lifecycle lock for the entire teardown. While we wait
 	// for the writer goroutine to drain, no concurrent InsertMock
 	// can start a new writer — ys.gobRunning stays true and
@@ -1092,14 +1173,14 @@ func (ys *MockYaml) Close() error {
 	// twice.
 	ys.gobLifecycleMu.Lock()
 	defer ys.gobLifecycleMu.Unlock()
-	// Always clear the per-testset format map — even when no gob
-	// writer ran this session (pure-yaml sessions never set
-	// gobRunning=true, but they still populate the map via the
-	// LoadOrStore calls in InsertMock). Doing this before the early-
-	// return is what caps the map's growth across record sessions on
-	// a long-lived MockYaml.
-	ys.clearTestSetFormats()
 	if !ys.gobRunning {
+		// Pure-yaml sessions never set gobRunning=true, but they
+		// still populate testSetFormat via the LoadOrStore calls in
+		// InsertMock. Clear the map before returning so long-lived
+		// processes (DaemonSet mode, multi-session Recorders) do not
+		// grow the sync.Map unboundedly. The closed gate above
+		// already blocked any fresh InsertMock from repopulating it.
+		ys.clearTestSetFormats()
 		return nil
 	}
 	// Signal the writer to exit. Guarded by gobStopClosed so a retry
@@ -1115,11 +1196,22 @@ func (ys *MockYaml) Close() error {
 	case <-time.After(5 * time.Second):
 		// Leave gobRunning=true + gobStopClosed=true so a retry of
 		// Close enters this function, skips the already-closed stop,
-		// and just waits on gobDone again.
+		// and just waits on gobDone again. Do NOT clear
+		// testSetFormat on a timeout: the async writer is still alive
+		// and its eventual mocks.gob creation must stay visible to
+		// the os.Stat rehydrate path on the retry Close.
 		return fmt.Errorf("timed out waiting for gob writer to flush")
 	}
 	ys.gobRunning = false
 	ys.gobStopClosed = false
+	// Drop the per-testset format map only AFTER the async writer
+	// has drained. By this point every queued gob write has
+	// materialised its mocks.gob on disk, so the subsequent
+	// clearTestSetFormats cannot strip a lock whose backing file is
+	// still in-flight. The closed gate set at the top of Close
+	// prevents any new InsertMock from repopulating the map between
+	// here and the caller observing Close has returned.
+	ys.clearTestSetFormats()
 	// Operator visibility: if the async queue filled up during the
 	// session and the sync fallback fired, report the count so disk
 	// stalls / undersized queues are caught at post-run review
@@ -1447,6 +1539,14 @@ func (ys *MockYaml) GetHTTPMocks(ctx context.Context, testSetID string, mockPath
 }
 
 func (ys *MockYaml) DeleteMocksForSet(ctx context.Context, testSetID string) error {
+	// Mirror InsertMock's closing gate: a DeleteMocksForSet that
+	// arrives while Close is draining must not race the cleanup of
+	// testSetFormat or the writer shutdown. Closed MockYaml
+	// instances are terminal — the caller must build a fresh one
+	// (or reset via New) before mutating the on-disk layout.
+	if ys.closed.Load() {
+		return fmt.Errorf("mockdb: DeleteMocksForSet called on closed MockYaml (testSetID=%q)", testSetID)
+	}
 	mockFileName := "mocks"
 	if ys.MockName != "" {
 		mockFileName = ys.MockName

--- a/pkg/platform/yaml/mockdb/db.go
+++ b/pkg/platform/yaml/mockdb/db.go
@@ -1096,8 +1096,8 @@ func (ys *MockYaml) clearTestSetFormats() {
 // pending gob write — a mixed-format on-disk state the readers
 // cannot cope with. This function therefore orders teardown as:
 //
-//   t0: Close drains the async gob writer  (mocks.gob fully on disk)
-//   t1: Close calls clearTestSetFormats    (stat rehydrate sees real mocks.gob)
+//	t0: Close drains the async gob writer  (mocks.gob fully on disk)
+//	t1: Close calls clearTestSetFormats    (stat rehydrate sees real mocks.gob)
 //
 // By the time the map is cleared, every pending gob write has
 // materialised, so any concurrent InsertMock(yaml) racing the clear

--- a/pkg/platform/yaml/mockdb/db.go
+++ b/pkg/platform/yaml/mockdb/db.go
@@ -79,40 +79,6 @@ func useGobMockFormat() bool {
 	return configuredMockFormat == mockFormatGob
 }
 
-// resolveMockFormat picks the on-disk format for a single mock. Per-mock
-// overrides win over the process-wide default; an empty string falls back
-// to the testset-level format (useGobMockFormat). Callers on the write
-// path use this to route a single mock through the gob or yaml writer
-// independent of what the session's default format is. This is what
-// enables the DaemonSet per-session mockFormat: two concurrent
-// RecordingSessions writing into different test-set directories can
-// each tag their mocks with the desired format even though the mockdb
-// package-level configuredMockFormat is process-global.
-//
-// Valid per-mock formats are "yaml" and "gob". Any other non-empty
-// value falls through to the process-wide default — we prefer to
-// preserve mocks over failing the write when a stale or typo'd format
-// slips in from a user-facing CR.
-//
-// Constraint: the read/prune paths (GetFilteredMocks / GetUnFilteredMocks /
-// UpdateMocks) prefer mocks.gob by file presence and do not merge a
-// sibling mocks.yaml when both exist in one test-set directory. A single
-// test-set is therefore required to be uniformly one format; InsertMock
-// enforces that at write time by rejecting a mock whose resolved format
-// disagrees with any already-written file in the test-set directory.
-// Sessions that need to mix formats must route to sibling test-set
-// directories (the DaemonSet per-session flow).
-func resolveMockFormat(perMock string) bool {
-	switch perMock {
-	case mockFormatGob:
-		return true
-	case "yaml":
-		return false
-	default:
-		return useGobMockFormat()
-	}
-}
-
 type MockYaml struct {
 	MockPath  string
 	MockName  string
@@ -650,12 +616,12 @@ func (ys *MockYaml) InsertMock(ctx context.Context, mock *models.Mock, testSetID
 	// without mutating package-level state. Unset / unrecognised =>
 	// fall back to the already-locked testset format when one exists,
 	// else to useGobMockFormat (the pre-DS behaviour). The lock-aware
-	// fallback matters because resolveMockFormat alone would route a
-	// typo like Format="gbo" to the process default even when the
-	// testset is already locked to the opposite format — turning an
-	// unknown value into a mixed-format rejection instead of the
-	// graceful inherit-the-lock behaviour the surrounding docs
-	// promise.
+	// fallback matters because a plain per-mock → process-default
+	// routing would send a typo like Format="gbo" to the process
+	// default even when the testset is already locked to the opposite
+	// format — turning an unknown value into a mixed-format rejection
+	// instead of the graceful inherit-the-lock behaviour the
+	// surrounding docs promise.
 	//
 	// Reject a mock whose resolved format disagrees with whatever is
 	// already claimed for this test-set. Without this check InsertMock
@@ -707,14 +673,12 @@ func (ys *MockYaml) InsertMock(ctx context.Context, mock *models.Mock, testSetID
 		}
 	}
 
-	// Pick writeGob with the three-step lock-aware policy. The legacy
-	// resolveMockFormat is kept for callers that do not have a
-	// testSetID in hand; here we inline the policy so an unrecognised
-	// per-mock value (e.g. a typo'd "gbo") inherits the testset's
-	// already-locked format instead of silently bouncing off the
-	// mixed-format guard. Recognised overrides still win — a caller
-	// that explicitly asks for "gob" on a yaml-locked testset gets
-	// the mixed-format error below, which is the intended guard.
+	// Pick writeGob with the three-step lock-aware policy: an
+	// unrecognised per-mock value (e.g. a typo'd "gbo") inherits the
+	// testset's already-locked format instead of silently bouncing off
+	// the mixed-format guard. Recognised overrides still win — a caller
+	// that explicitly asks for "gob" on a yaml-locked testset gets the
+	// mixed-format error below, which is the intended guard.
 	//
 	// The unknown-format branch is resolved with an atomic
 	// LoadOrStore rather than a read-then-write pair so a racing

--- a/pkg/platform/yaml/mockdb/db.go
+++ b/pkg/platform/yaml/mockdb/db.go
@@ -635,10 +635,14 @@ func (ys *MockYaml) InsertMock(ctx context.Context, mock *models.Mock, testSetID
 	if writeGob {
 		if _, statErr := os.Stat(yamlFile); statErr == nil {
 			return fmt.Errorf("mockdb: cannot write gob-format mock into testset %q that already contains yaml mocks at %s; uniform per-testset format required", testSetID, yamlFile)
+		} else if !os.IsNotExist(statErr) {
+			return fmt.Errorf("mockdb: failed to verify whether yaml mocks already exist for testset %q at %s: %w; check file permissions and filesystem accessibility, then retry", testSetID, yamlFile, statErr)
 		}
 	} else {
 		if _, statErr := os.Stat(gobFile); statErr == nil {
 			return fmt.Errorf("mockdb: cannot write yaml-format mock into testset %q that already contains gob mocks at %s; uniform per-testset format required", testSetID, gobFile)
+		} else if !os.IsNotExist(statErr) {
+			return fmt.Errorf("mockdb: failed to verify whether gob mocks already exist for testset %q at %s: %w; check file permissions and filesystem accessibility, then retry", testSetID, gobFile, statErr)
 		}
 	}
 

--- a/pkg/platform/yaml/mockdb/db.go
+++ b/pkg/platform/yaml/mockdb/db.go
@@ -94,12 +94,13 @@ type MockYaml struct {
 	// "quiesced"; gobRunning tracks which state we are in. The
 	// writer can transition from quiesced back to running via
 	// insertMockGob's inline init when a fresh MockYaml receives
-	// its first gob mock — but Close itself is terminal (it sets
-	// ys.closed=true and InsertMock refuses further writes on the
-	// same instance). Re-record / multi-session flows must build a
-	// fresh MockYaml after Close; only updateMocksGob (replay-side
-	// pruning) legitimately calls Close mid-instance, and its own
-	// file rewrite does not go through InsertMock.
+	// its first gob mock. Close drains the queue and flushes the
+	// file, and is safe to call multiple times on the same
+	// instance — a subsequent InsertMock on a drained MockYaml
+	// simply re-inits the writer on demand. updateMocksGob
+	// (replay-side pruning) calls Close mid-instance to quiesce
+	// the writer before rewriting the file via tmp+rename; its
+	// own file rewrite does not go through InsertMock.
 	gobLifecycleMu sync.Mutex
 	gobRunning     bool
 	gobQueue       chan gobWriteJob
@@ -132,37 +133,15 @@ type MockYaml struct {
 	// — but does not replace — the os.Stat check on mocks.gob /
 	// mocks.yaml further down. The stat check is still needed on a
 	// fresh MockYaml (cross-process restart against an already-
-	// populated test-set directory), but the stat alone cannot close
-	// the intra-process race: the gob writer is async, so an
-	// InsertMock(gob) returns before gobReopenLocked creates the
-	// file, and a tightly-following InsertMock(yaml) for the same
-	// testSetID would see ENOENT on mocks.gob and happily create
-	// mocks.yaml alongside the still-queued gob write. The readers
-	// prefer mocks.gob and silently ignore mocks.yaml in that case,
-	// so the yaml mocks vanish at replay. The sync.Map's
+	// populated test-set directory), and — because Close drains the
+	// async gob writer BEFORE clearing this map (see Close below) —
+	// the stat alone is also sufficient to close the intra-process
+	// race: by the time the map is cleared, every queued gob write
+	// has materialised on disk, so a follow-up InsertMock(yaml)
+	// observing a cleared entry will find the real mocks.gob via
+	// os.Stat and bounce off the mixed-format guard. The sync.Map's
 	// LoadOrStore is the primary guard; true = gob, false = yaml.
 	testSetFormat sync.Map
-
-	// closed is set to true by Close() as its FIRST action, before
-	// any teardown begins. Every public mutating method (InsertMock,
-	// DeleteMocksForSet, UpdateMocks) consults this flag on entry
-	// and refuses to proceed if it is already set. This closes the
-	// Close-vs-concurrent-InsertMock(yaml) race:
-	//
-	// The YAML InsertMock path does not take gobLifecycleMu — only
-	// the gob path does — so without this gate, Close could clear
-	// testSetFormat while a yaml InsertMock is mid-flight, and
-	// another yaml InsertMock that arrives after the clear would
-	// see ENOENT on mocks.gob (the pending gob write may not have
-	// materialised yet) and create mocks.yaml alongside the still-
-	// queued gob write. With closed=true set before any teardown,
-	// any InsertMock that arrives at or after the store sees the
-	// closed flag and returns early, so it can never bypass the
-	// guard during the teardown window.
-	//
-	// atomic.Bool (Go 1.19+) is used because sync/atomic is already
-	// imported for gobOverflows and idCounter; no extra dependency.
-	closed atomic.Bool
 }
 
 type gobWriteJob struct {
@@ -471,13 +450,11 @@ func (ys *MockYaml) updateMocksGob(ctx context.Context, testSetID, gobPath strin
 	// rewrite the gob file. An active writer holds ys.gobFile /
 	// ys.gobBufw / ys.gobEnc; rewriting the file out from under it
 	// would corrupt the next Encode. Close drains the queue and
-	// flushes the file. Close is terminal (ys.closed is set to true
-	// and InsertMock rejects further writes); this is safe here
-	// because UpdateMocks is a replay-side operation — the replay
-	// MockYaml instance is never subsequently used as a record sink.
-	// Any future prune pass on this same instance still works
-	// because updateMocksGob rewrites mocks.gob via tmp+rename
-	// rather than via InsertMock.
+	// flushes the file. Close is re-entrant on this instance: a
+	// future InsertMock would re-init the writer on demand, but
+	// UpdateMocks is a replay-side operation so no InsertMock is
+	// expected to follow. The tmp+rename rewrite below is the only
+	// subsequent write to the gob path.
 	if err := ys.Close(); err != nil {
 		utils.LogError(ys.Logger, err, "failed to quiesce async gob writer before pruning; check disk space and writer state", zap.String("path", gobPath))
 		return err
@@ -644,19 +621,6 @@ func (ys *MockYaml) updateMocksGob(ctx context.Context, testSetID, gobPath strin
 // that need to mix formats must route to sibling test-set directories
 // (the DaemonSet per-session flow).
 func (ys *MockYaml) InsertMock(ctx context.Context, mock *models.Mock, testSetID string) error {
-	// Reject any InsertMock that arrives at or after Close() has
-	// started its teardown. Close sets ys.closed as its FIRST action
-	// (before clearing testSetFormat or touching the async gob
-	// writer), so an atomic Load here is sufficient to stop the
-	// yaml-path race: a yaml InsertMock that slipped past the guard
-	// would otherwise observe a cleared testSetFormat + an ENOENT on
-	// mocks.gob (the queued gob write may not have flushed yet) and
-	// create mocks.yaml next to the still-pending mocks.gob. With
-	// this check in place, any caller that sees closed=true bails
-	// before stating or writing anything.
-	if ys.closed.Load() {
-		return fmt.Errorf("mockdb: InsertMock called on closed MockYaml (testSetID=%q)", testSetID)
-	}
 	mock.Name = fmt.Sprint("mock-", ys.getNextID())
 	mockPath := filepath.Join(ys.MockPath, testSetID)
 	mockFileName := ys.MockName
@@ -1096,17 +1060,17 @@ func (ys *MockYaml) gobWriteSync(ctx context.Context, mock *models.Mock, mockPat
 // long-lived processes (DaemonSet mode, multi-session recorders)
 // where the typical shutdown path never hits DeleteMocksForSet.
 //
-// Concurrency contract: this helper is only safe to call once Close
-// has (a) stored ys.closed=true so every public mutating path bails
-// before touching testSetFormat, and (b) drained the async gob
-// writer so every queued mocks.gob has materialised on disk. With
-// those preconditions, no concurrent InsertMock can repopulate the
-// map during the Range/Delete walk, and the stat-based rehydrate
-// path on a subsequent fresh MockYaml will still observe the on-disk
-// format correctly. The earlier doc comment claimed that holding
-// gobLifecycleMu was sufficient — that was incorrect because the
-// yaml InsertMock path never takes gobLifecycleMu; the ys.closed
-// gate is what actually makes the map-clear race-safe.
+// Concurrency contract ("drain-before-clear"): this helper must be
+// called only AFTER Close has drained the async gob writer so every
+// queued mocks.gob has materialised on disk. With that precondition
+// the on-disk stat rehydrate in a concurrent-or-subsequent
+// InsertMock will observe the real mocks.gob and bounce off the
+// mixed-format guard — even if that InsertMock arrives between the
+// clear and Close returning. Without drain-before-clear, the map
+// could be stripped while a pending gob write was still in the
+// queue, and a concurrent InsertMock(yaml) would see both ENOENT on
+// mocks.gob and a cleared map, then happily create mocks.yaml
+// alongside the still-queued gob write.
 func (ys *MockYaml) clearTestSetFormats() {
 	ys.testSetFormat.Range(func(key, _ any) bool {
 		ys.testSetFormat.Delete(key)
@@ -1114,55 +1078,42 @@ func (ys *MockYaml) clearTestSetFormats() {
 	})
 }
 
-// Close drains the async gob writer, flushes the file, and marks
-// this MockYaml instance as terminal. Once Close has stored
-// ys.closed=true, any subsequent InsertMock / DeleteMocksForSet on
-// the same instance returns an error instead of racing the teardown.
-// Close itself is idempotent and safe to call multiple times — the
-// second call is a no-op once gobRunning is cleared.
+// Close drains the async gob writer, flushes the file, and clears
+// the in-memory per-testset format map. It is idempotent and safe
+// to call multiple times — the second call is a no-op once
+// gobRunning is cleared. Close does NOT block subsequent InsertMock
+// or DeleteMocksForSet calls on the same instance: a re-record flow
+// (--rerecord) legitimately calls DeleteMocksForSet after a Close/
+// reopen cycle, and updateMocksGob calls Close mid-instance to
+// quiesce the writer before rewriting mocks.gob; both must be able
+// to continue operating on the same MockYaml.
 //
-// Why Close is terminal (R9 fix): the yaml InsertMock path does not
-// take gobLifecycleMu (only the gob path does). Previously Close
-// cleared testSetFormat BEFORE draining the async writer, which left
-// a window where a concurrent InsertMock(yaml) could observe the
-// cleared map plus an ENOENT on the still-queued mocks.gob and
-// create mocks.yaml alongside it — producing a mixed-format on-disk
-// state the readers cannot cope with. The closed gate blocks that
-// second InsertMock cold; the clear is then postponed until AFTER
-// the writer has drained, so every testSetFormat entry whose lock
-// points at a pending gob write has had its file materialise by the
-// time the map is walked.
+// Race safety ("drain-before-clear"): the yaml InsertMock path does
+// not take gobLifecycleMu (only the gob path does). If Close cleared
+// testSetFormat BEFORE draining the async writer, a concurrent
+// InsertMock(yaml) could observe the cleared map plus an ENOENT on
+// the still-queued mocks.gob and create mocks.yaml alongside the
+// pending gob write — a mixed-format on-disk state the readers
+// cannot cope with. This function therefore orders teardown as:
+//
+//   t0: Close drains the async gob writer  (mocks.gob fully on disk)
+//   t1: Close calls clearTestSetFormats    (stat rehydrate sees real mocks.gob)
+//
+// By the time the map is cleared, every pending gob write has
+// materialised, so any concurrent InsertMock(yaml) racing the clear
+// will find the real mocks.gob via os.Stat and bounce off the
+// mixed-format guard. No "closed" flag is needed — the ordering
+// alone closes the race.
 //
 // Close also clears the in-memory per-testset format map so long-
 // lived processes (DaemonSet mode, a multi-session Recorder) do not
 // grow the sync.Map unboundedly. Typical record flows terminate a
 // session with Close, not DeleteMocksForSet, so without this clear
 // every test-set ever touched would leak an entry for the full
-// lifetime of the process. Multi-session workflows must build a
-// fresh MockYaml per session (via New) — Close cannot be reused as
-// a restart point, because that would re-introduce the race the
-// closed gate was added to close. The rehydrate path in InsertMock
-// (os.Stat on mocks.gob / mocks.yaml) still handles a fresh
-// MockYaml pointed at an existing test-set directory correctly.
+// lifetime of the process. The rehydrate path in InsertMock (os.Stat
+// on mocks.gob / mocks.yaml) handles the cleared-map case correctly
+// for subsequent inserts on the same or a fresh MockYaml.
 func (ys *MockYaml) Close() error {
-	// Set the closing gate as the VERY FIRST action — before any lock
-	// or teardown. Every public mutating path (InsertMock /
-	// DeleteMocksForSet / UpdateMocks) consults ys.closed on entry and
-	// bails if it is already set. Doing this before we acquire
-	// gobLifecycleMu or touch testSetFormat blocks new inserts from
-	// slipping past the format guard during the teardown window:
-	//
-	//   t0: Close stores closed=true            <-- new inserts rejected here
-	//   t1: Close drains the async gob writer   (mocks.gob fully on disk)
-	//   t2: Close calls clearTestSetFormats     (safe — no new entries can arrive)
-	//
-	// Without the t0 store, step t2 could strip a live yaml testset's
-	// lock while the gob writer's mocks.gob hasn't materialised yet;
-	// a concurrent InsertMock(yaml) path (which does NOT take
-	// gobLifecycleMu) would then stat the missing mocks.gob, pass the
-	// mixed-format guard, and create mocks.yaml alongside the still-
-	// queued gob write.
-	ys.closed.Store(true)
 	// Hold the lifecycle lock for the entire teardown. While we wait
 	// for the writer goroutine to drain, no concurrent InsertMock
 	// can start a new writer — ys.gobRunning stays true and
@@ -1178,8 +1129,9 @@ func (ys *MockYaml) Close() error {
 		// still populate testSetFormat via the LoadOrStore calls in
 		// InsertMock. Clear the map before returning so long-lived
 		// processes (DaemonSet mode, multi-session Recorders) do not
-		// grow the sync.Map unboundedly. The closed gate above
-		// already blocked any fresh InsertMock from repopulating it.
+		// grow the sync.Map unboundedly. Safe to clear unconditionally
+		// here: no async gob write can be in flight (gobRunning=false),
+		// so drain-before-clear holds trivially.
 		ys.clearTestSetFormats()
 		return nil
 	}
@@ -1208,9 +1160,9 @@ func (ys *MockYaml) Close() error {
 	// has drained. By this point every queued gob write has
 	// materialised its mocks.gob on disk, so the subsequent
 	// clearTestSetFormats cannot strip a lock whose backing file is
-	// still in-flight. The closed gate set at the top of Close
-	// prevents any new InsertMock from repopulating the map between
-	// here and the caller observing Close has returned.
+	// still in-flight — any concurrent InsertMock racing this clear
+	// will find the real mocks.gob via os.Stat and re-lock via the
+	// rehydrate branch, or bounce off the mixed-format guard.
 	ys.clearTestSetFormats()
 	// Operator visibility: if the async queue filled up during the
 	// session and the sync fallback fired, report the count so disk
@@ -1539,14 +1491,13 @@ func (ys *MockYaml) GetHTTPMocks(ctx context.Context, testSetID string, mockPath
 }
 
 func (ys *MockYaml) DeleteMocksForSet(ctx context.Context, testSetID string) error {
-	// Mirror InsertMock's closing gate: a DeleteMocksForSet that
-	// arrives while Close is draining must not race the cleanup of
-	// testSetFormat or the writer shutdown. Closed MockYaml
-	// instances are terminal — the caller must build a fresh one
-	// (or reset via New) before mutating the on-disk layout.
-	if ys.closed.Load() {
-		return fmt.Errorf("mockdb: DeleteMocksForSet called on closed MockYaml (testSetID=%q)", testSetID)
-	}
+	// DeleteMocksForSet must remain callable after Close: --rerecord
+	// invokes this method on a MockYaml that has been through a
+	// Close/reopen cycle (or whose Close fired before re-record
+	// started) to clear stale mocks before the next recording pass.
+	// The drain-before-clear ordering in Close already prevents any
+	// mixed-format on-disk state during teardown, so no additional
+	// gate is required here.
 	mockFileName := "mocks"
 	if ys.MockName != "" {
 		mockFileName = ys.MockName

--- a/pkg/platform/yaml/mockdb/db.go
+++ b/pkg/platform/yaml/mockdb/db.go
@@ -93,6 +93,15 @@ func useGobMockFormat() bool {
 // value falls through to the process-wide default — we prefer to
 // preserve mocks over failing the write when a stale or typo'd format
 // slips in from a user-facing CR.
+//
+// Constraint: the read/prune paths (GetFilteredMocks / GetUnFilteredMocks /
+// UpdateMocks) prefer mocks.gob by file presence and do not merge a
+// sibling mocks.yaml when both exist in one test-set directory. A single
+// test-set is therefore required to be uniformly one format; InsertMock
+// enforces that at write time by rejecting a mock whose resolved format
+// disagrees with any already-written file in the test-set directory.
+// Sessions that need to mix formats must route to sibling test-set
+// directories (the DaemonSet per-session flow).
 func resolveMockFormat(perMock string) bool {
 	switch perMock {
 	case mockFormatGob:
@@ -573,6 +582,21 @@ func (ys *MockYaml) updateMocksGob(ctx context.Context, testSetID, gobPath strin
 	return nil
 }
 
+// InsertMock persists one mock under "<MockPath>/<testSetID>/<mockFileName>.(yaml|gob)".
+// The on-disk format is picked by resolveMockFormat: a non-empty
+// mock.Format wins, otherwise the process-wide configured format
+// applies.
+//
+// Mixed-format constraint: read/prune paths (GetFilteredMocks /
+// GetUnFilteredMocks / UpdateMocks) choose mocks.gob over mocks.yaml by
+// file presence and do not merge both when they coexist in one
+// test-set directory. To keep the on-disk state consistent with what
+// those readers will later load, InsertMock rejects a mock whose
+// resolved format disagrees with a file already present in the
+// test-set directory — i.e. a yaml-format mock cannot be written into
+// a test-set that already contains mocks.gob, and vice versa. Sessions
+// that need to mix formats must route to sibling test-set directories
+// (the DaemonSet per-session flow).
 func (ys *MockYaml) InsertMock(ctx context.Context, mock *models.Mock, testSetID string) error {
 	mock.Name = fmt.Sprint("mock-", ys.getNextID())
 	mockPath := filepath.Join(ys.MockPath, testSetID)
@@ -592,7 +616,33 @@ func (ys *MockYaml) InsertMock(ctx context.Context, mock *models.Mock, testSetID
 	// RecordingSession's spec.mockFormat through to individual mocks
 	// without mutating package-level state. Unset / unrecognised =>
 	// fall back to useGobMockFormat (the pre-DS behaviour).
-	if resolveMockFormat(mock.Format) {
+	writeGob := resolveMockFormat(mock.Format)
+
+	// Reject a mock whose resolved format disagrees with whatever is
+	// already on disk for this test-set. Without this check InsertMock
+	// would happily create a second file (mocks.gob next to mocks.yaml,
+	// or vice versa) which the reader/pruner paths then silently ignore
+	// (they pick gob over yaml by file presence and never merge).
+	// Forcing one format per test-set keeps the write-side and read-
+	// side views identical and fails fast at record time instead of at
+	// replay with missing mocks. File existence (not size) is the
+	// correct signal here: the gob writer is async-buffered, so the
+	// file is created by gobReopenLocked before any bytes hit disk —
+	// a size-based check would miss that window and let a yaml
+	// InsertMock slip in before the first gob flush.
+	yamlFile := filepath.Join(mockPath, mockFileName+".yaml")
+	gobFile := filepath.Join(mockPath, mockFileName+".gob")
+	if writeGob {
+		if _, statErr := os.Stat(yamlFile); statErr == nil {
+			return fmt.Errorf("mockdb: cannot write gob-format mock into testset %q that already contains yaml mocks at %s; uniform per-testset format required", testSetID, yamlFile)
+		}
+	} else {
+		if _, statErr := os.Stat(gobFile); statErr == nil {
+			return fmt.Errorf("mockdb: cannot write yaml-format mock into testset %q that already contains gob mocks at %s; uniform per-testset format required", testSetID, gobFile)
+		}
+	}
+
+	if writeGob {
 		return ys.insertMockGob(ctx, mock, mockPath, mockFileName)
 	}
 

--- a/pkg/platform/yaml/mockdb/db.go
+++ b/pkg/platform/yaml/mockdb/db.go
@@ -661,15 +661,34 @@ func (ys *MockYaml) InsertMock(ctx context.Context, mock *models.Mock, testSetID
 	// existence (not size) is the right signal here: the gob writer
 	// creates mocks.gob before the first flush, so a size check
 	// would race the async writer.
+	//
+	// Stat BOTH files up front rather than short-circuiting on the
+	// gob presence: a testset directory that accidentally contains
+	// both mocks.gob and mocks.yaml (prior-version async-writer race,
+	// a manual edit, or a partial Delete) is ambiguous — the readers
+	// prefer gob, so silently locking to gob would orphan the yaml
+	// mocks. Surface the mixed-on-disk state as a hard error and let
+	// the user intervene instead of picking a side.
 	if _, loaded := ys.testSetFormat.Load(testSetID); !loaded {
-		if _, statErr := os.Stat(gobFile); statErr == nil {
+		_, gobStatErr := os.Stat(gobFile)
+		gobExists := gobStatErr == nil
+		if gobStatErr != nil && !os.IsNotExist(gobStatErr) {
+			return fmt.Errorf("mockdb: failed to verify whether gob mocks already exist for testset %q at %s: %w; check file permissions and filesystem accessibility, then retry", testSetID, gobFile, gobStatErr)
+		}
+
+		_, yamlStatErr := os.Stat(yamlFile)
+		yamlExists := yamlStatErr == nil
+		if yamlStatErr != nil && !os.IsNotExist(yamlStatErr) {
+			return fmt.Errorf("mockdb: failed to verify whether yaml mocks already exist for testset %q at %s: %w; check file permissions and filesystem accessibility, then retry", testSetID, yamlFile, yamlStatErr)
+		}
+
+		if gobExists && yamlExists {
+			return fmt.Errorf("mockdb: found both gob and yaml mock files for testset %q in %s; delete or refresh the testset directory so only one of %s or %s remains, then retry", testSetID, filepath.Dir(gobFile), filepath.Base(gobFile), filepath.Base(yamlFile))
+		}
+		if gobExists {
 			ys.testSetFormat.LoadOrStore(testSetID, true)
-		} else if !os.IsNotExist(statErr) {
-			return fmt.Errorf("mockdb: failed to verify whether gob mocks already exist for testset %q at %s: %w; check file permissions and filesystem accessibility, then retry", testSetID, gobFile, statErr)
-		} else if _, statErr := os.Stat(yamlFile); statErr == nil {
+		} else if yamlExists {
 			ys.testSetFormat.LoadOrStore(testSetID, false)
-		} else if !os.IsNotExist(statErr) {
-			return fmt.Errorf("mockdb: failed to verify whether yaml mocks already exist for testset %q at %s: %w; check file permissions and filesystem accessibility, then retry", testSetID, yamlFile, statErr)
 		}
 	}
 

--- a/pkg/platform/yaml/mockdb/db.go
+++ b/pkg/platform/yaml/mockdb/db.go
@@ -154,6 +154,25 @@ type MockYaml struct {
 	// instead of silently losing the tail of mocks.gob on a disk-full
 	// or permission-change shutdown.
 	gobFlushErr error
+
+	// testSetFormat tracks the format chosen by the first InsertMock
+	// call for each testSetID within this MockYaml. Subsequent
+	// InsertMock calls for the same testSetID must agree with the
+	// stored value; a mismatch is rejected synchronously before any
+	// I/O. The map is a race-free in-process guard that complements
+	// — but does not replace — the os.Stat check on mocks.gob /
+	// mocks.yaml further down. The stat check is still needed on a
+	// fresh MockYaml (cross-process restart against an already-
+	// populated test-set directory), but the stat alone cannot close
+	// the intra-process race: the gob writer is async, so an
+	// InsertMock(gob) returns before gobReopenLocked creates the
+	// file, and a tightly-following InsertMock(yaml) for the same
+	// testSetID would see ENOENT on mocks.gob and happily create
+	// mocks.yaml alongside the still-queued gob write. The readers
+	// prefer mocks.gob and silently ignore mocks.yaml in that case,
+	// so the yaml mocks vanish at replay. The sync.Map's
+	// LoadOrStore is the primary guard; true = gob, false = yaml.
+	testSetFormat sync.Map
 }
 
 type gobWriteJob struct {
@@ -619,31 +638,65 @@ func (ys *MockYaml) InsertMock(ctx context.Context, mock *models.Mock, testSetID
 	writeGob := resolveMockFormat(mock.Format)
 
 	// Reject a mock whose resolved format disagrees with whatever is
-	// already on disk for this test-set. Without this check InsertMock
+	// already claimed for this test-set. Without this check InsertMock
 	// would happily create a second file (mocks.gob next to mocks.yaml,
 	// or vice versa) which the reader/pruner paths then silently ignore
 	// (they pick gob over yaml by file presence and never merge).
 	// Forcing one format per test-set keeps the write-side and read-
 	// side views identical and fails fast at record time instead of at
-	// replay with missing mocks. File existence (not size) is the
-	// correct signal here: the gob writer is async-buffered, so the
-	// file is created by gobReopenLocked before any bytes hit disk —
-	// a size-based check would miss that window and let a yaml
-	// InsertMock slip in before the first gob flush.
+	// replay with missing mocks.
+	//
+	// Two guards, layered: (1) an in-memory per-testSetID map
+	// (testSetFormat) that wins the race against the async gob
+	// writer, and (2) an os.Stat of mocks.gob / mocks.yaml that
+	// rehydrates the in-memory map on a fresh MockYaml (cross-
+	// process restart against an already-populated directory).
+	//
+	// Why the stat alone is insufficient: the gob writer is async-
+	// buffered. InsertMock(gob) enqueues a job and returns before
+	// gobReopenLocked creates mocks.gob, so an immediately-following
+	// InsertMock(yaml) for the same testSetID would see ENOENT on
+	// mocks.gob, pass the stat, and create mocks.yaml alongside the
+	// still-queued gob write. Readers prefer mocks.gob, so the yaml
+	// mocks silently disappear at replay. The sync.Map's atomic
+	// LoadOrStore closes that window by synchronously binding the
+	// testSetID to a format on the very first call, regardless of
+	// how slowly the gob writer gets around to the file creation.
 	yamlFile := filepath.Join(mockPath, mockFileName+".yaml")
 	gobFile := filepath.Join(mockPath, mockFileName+".gob")
-	if writeGob {
-		if _, statErr := os.Stat(yamlFile); statErr == nil {
-			return fmt.Errorf("mockdb: cannot write gob-format mock into testset %q that already contains yaml mocks at %s; uniform per-testset format required", testSetID, yamlFile)
+
+	// Rehydrate the in-memory format binding from on-disk state on
+	// the first InsertMock for this testSetID in this process. If a
+	// file already exists from a previous process (or from a prior
+	// Close/re-open cycle on this MockYaml), lock its format in
+	// before we evaluate writeGob. LoadOrStore makes this idempotent
+	// across concurrent callers: only one stat-derived Store wins,
+	// subsequent callers observe the stored value unchanged. File
+	// existence (not size) is the right signal here: the gob writer
+	// creates mocks.gob before the first flush, so a size check
+	// would race the async writer.
+	if _, loaded := ys.testSetFormat.Load(testSetID); !loaded {
+		if _, statErr := os.Stat(gobFile); statErr == nil {
+			ys.testSetFormat.LoadOrStore(testSetID, true)
+		} else if !os.IsNotExist(statErr) {
+			return fmt.Errorf("mockdb: failed to verify whether gob mocks already exist for testset %q at %s: %w; check file permissions and filesystem accessibility, then retry", testSetID, gobFile, statErr)
+		} else if _, statErr := os.Stat(yamlFile); statErr == nil {
+			ys.testSetFormat.LoadOrStore(testSetID, false)
 		} else if !os.IsNotExist(statErr) {
 			return fmt.Errorf("mockdb: failed to verify whether yaml mocks already exist for testset %q at %s: %w; check file permissions and filesystem accessibility, then retry", testSetID, yamlFile, statErr)
 		}
-	} else {
-		if _, statErr := os.Stat(gobFile); statErr == nil {
-			return fmt.Errorf("mockdb: cannot write yaml-format mock into testset %q that already contains gob mocks at %s; uniform per-testset format required", testSetID, gobFile)
-		} else if !os.IsNotExist(statErr) {
-			return fmt.Errorf("mockdb: failed to verify whether gob mocks already exist for testset %q at %s: %w; check file permissions and filesystem accessibility, then retry", testSetID, gobFile, statErr)
+	}
+
+	// Primary guard: atomic claim-or-check on the in-memory map.
+	// This is race-free against a still-in-flight async gob writer
+	// and against another goroutine's concurrent InsertMock for the
+	// same testSetID, because LoadOrStore is documented as atomic.
+	actual, loaded := ys.testSetFormat.LoadOrStore(testSetID, writeGob)
+	if loaded && actual.(bool) != writeGob {
+		if writeGob {
+			return fmt.Errorf("mockdb: cannot write gob-format mock into testset %q that already contains yaml mocks at %s; uniform per-testset format required", testSetID, yamlFile)
 		}
+		return fmt.Errorf("mockdb: cannot write yaml-format mock into testset %q that already contains gob mocks at %s; uniform per-testset format required", testSetID, gobFile)
 	}
 
 	if writeGob {

--- a/pkg/platform/yaml/mockdb/db.go
+++ b/pkg/platform/yaml/mockdb/db.go
@@ -634,9 +634,15 @@ func (ys *MockYaml) InsertMock(ctx context.Context, mock *models.Mock, testSetID
 	// process-wide configured format so the DS agent can thread each
 	// RecordingSession's spec.mockFormat through to individual mocks
 	// without mutating package-level state. Unset / unrecognised =>
-	// fall back to useGobMockFormat (the pre-DS behaviour).
-	writeGob := resolveMockFormat(mock.Format)
-
+	// fall back to the already-locked testset format when one exists,
+	// else to useGobMockFormat (the pre-DS behaviour). The lock-aware
+	// fallback matters because resolveMockFormat alone would route a
+	// typo like Format="gbo" to the process default even when the
+	// testset is already locked to the opposite format — turning an
+	// unknown value into a mixed-format rejection instead of the
+	// graceful inherit-the-lock behaviour the surrounding docs
+	// promise.
+	//
 	// Reject a mock whose resolved format disagrees with whatever is
 	// already claimed for this test-set. Without this check InsertMock
 	// would happily create a second file (mocks.gob next to mocks.yaml,
@@ -684,6 +690,28 @@ func (ys *MockYaml) InsertMock(ctx context.Context, mock *models.Mock, testSetID
 			ys.testSetFormat.LoadOrStore(testSetID, false)
 		} else if !os.IsNotExist(statErr) {
 			return fmt.Errorf("mockdb: failed to verify whether yaml mocks already exist for testset %q at %s: %w; check file permissions and filesystem accessibility, then retry", testSetID, yamlFile, statErr)
+		}
+	}
+
+	// Pick writeGob with the three-step lock-aware policy. The legacy
+	// resolveMockFormat is kept for callers that do not have a
+	// testSetID in hand; here we inline the policy so an unrecognised
+	// per-mock value (e.g. a typo'd "gbo") inherits the testset's
+	// already-locked format instead of silently bouncing off the
+	// mixed-format guard. Recognised overrides still win — a caller
+	// that explicitly asks for "gob" on a yaml-locked testset gets
+	// the mixed-format error below, which is the intended guard.
+	var writeGob bool
+	switch mock.Format {
+	case mockFormatGob:
+		writeGob = true
+	case "yaml":
+		writeGob = false
+	default:
+		if locked, ok := ys.testSetFormat.Load(testSetID); ok {
+			writeGob = locked.(bool)
+		} else {
+			writeGob = useGobMockFormat()
 		}
 	}
 

--- a/pkg/platform/yaml/mockdb/db.go
+++ b/pkg/platform/yaml/mockdb/db.go
@@ -171,6 +171,24 @@ func mockFileLockKey(path, fileName string) string {
 	return fullPath
 }
 
+// testSetLockKey builds the key for the in-memory per-testset format
+// map (ys.testSetFormat). The map is keyed by the full test-set
+// directory path — "<MockPath>/<testSetID>" — rather than the bare
+// testSetID because MockYaml.MockPath is mutable: GetHTTPMocks
+// rewrites it to the caller's mockPath, and any other code path that
+// holds onto the same *MockYaml across different root directories
+// (e.g. a re-configured recorder, a pooled instance in the DS agent)
+// would otherwise let two different directories share one lock
+// bucket. With the bare-testSetID key a second root could observe
+// the first root's format claim, turning a same-name-but-different-
+// path test-set into a mixed-format rejection or — worse — silently
+// inheriting the wrong format without rehydrating from disk.
+// Anchoring on the full path makes each on-disk test-set directory
+// own an independent lock.
+func testSetLockKey(ys *MockYaml, testSetID string) string {
+	return filepath.Join(ys.MockPath, testSetID)
+}
+
 func getMockFileLock(lockKey string) *sync.RWMutex {
 	hasher := fnv.New32a()
 	_, _ = hasher.Write([]byte(lockKey))
@@ -669,7 +687,8 @@ func (ys *MockYaml) InsertMock(ctx context.Context, mock *models.Mock, testSetID
 	// prefer gob, so silently locking to gob would orphan the yaml
 	// mocks. Surface the mixed-on-disk state as a hard error and let
 	// the user intervene instead of picking a side.
-	if _, loaded := ys.testSetFormat.Load(testSetID); !loaded {
+	lockKey := testSetLockKey(ys, testSetID)
+	if _, loaded := ys.testSetFormat.Load(lockKey); !loaded {
 		_, gobStatErr := os.Stat(gobFile)
 		gobExists := gobStatErr == nil
 		if gobStatErr != nil && !os.IsNotExist(gobStatErr) {
@@ -686,9 +705,9 @@ func (ys *MockYaml) InsertMock(ctx context.Context, mock *models.Mock, testSetID
 			return fmt.Errorf("mockdb: found both gob and yaml mock files for testset %q in %s; delete or refresh the testset directory so only one of %s or %s remains, then retry", testSetID, filepath.Dir(gobFile), filepath.Base(gobFile), filepath.Base(yamlFile))
 		}
 		if gobExists {
-			ys.testSetFormat.LoadOrStore(testSetID, true)
+			ys.testSetFormat.LoadOrStore(lockKey, true)
 		} else if yamlExists {
-			ys.testSetFormat.LoadOrStore(testSetID, false)
+			ys.testSetFormat.LoadOrStore(lockKey, false)
 		}
 	}
 
@@ -721,7 +740,7 @@ func (ys *MockYaml) InsertMock(ctx context.Context, mock *models.Mock, testSetID
 		// already locked to. If no lock yet, LoadOrStore claims the
 		// process default; the returned actual is always the value
 		// that will be visible to subsequent callers.
-		actual, _ := ys.testSetFormat.LoadOrStore(testSetID, useGobMockFormat())
+		actual, _ := ys.testSetFormat.LoadOrStore(lockKey, useGobMockFormat())
 		writeGob = actual.(bool)
 		explicitFormat = false
 	}
@@ -734,7 +753,7 @@ func (ys *MockYaml) InsertMock(ctx context.Context, mock *models.Mock, testSetID
 	// branch above already consulted LoadOrStore and cannot fail a
 	// mismatch check (it adopted whatever was stored).
 	if explicitFormat {
-		actual, loaded := ys.testSetFormat.LoadOrStore(testSetID, writeGob)
+		actual, loaded := ys.testSetFormat.LoadOrStore(lockKey, writeGob)
 		if loaded && actual.(bool) != writeGob {
 			if writeGob {
 				return fmt.Errorf("mockdb: cannot write gob-format mock into testset %q that already contains yaml mocks at %s; uniform per-testset format required", testSetID, yamlFile)
@@ -1028,6 +1047,22 @@ func (ys *MockYaml) gobWriteSync(ctx context.Context, mock *models.Mock, mockPat
 	return ys.gobBufw.Flush()
 }
 
+// clearTestSetFormats drops every entry from the in-memory per-
+// testset format map. sync.Map does not expose a bulk Clear in the
+// Go std lib version this project builds against, so we walk it via
+// Range and Delete each key. Invoked from Close to bound memory in
+// long-lived processes (DaemonSet mode, multi-session recorders)
+// where the typical shutdown path never hits DeleteMocksForSet.
+// Callers must hold ys.gobLifecycleMu so a concurrent InsertMock
+// cannot racily repopulate the map between our Range and the caller
+// observing an empty map.
+func (ys *MockYaml) clearTestSetFormats() {
+	ys.testSetFormat.Range(func(key, _ any) bool {
+		ys.testSetFormat.Delete(key)
+		return true
+	})
+}
+
 // Close drains the async gob writer and flushes the file. Safe to
 // call multiple times, and safe to call between record sessions —
 // the writer goroutine exits after flushing, and the next InsertMock
@@ -1035,6 +1070,17 @@ func (ys *MockYaml) gobWriteSync(ctx context.Context, mock *models.Mock, mockPat
 // insertMockGob). This is what makes re-record cycles (multiple
 // Recorder.Start on the same mockDB instance) work without dropping
 // mocks.
+//
+// Close also clears the in-memory per-testset format map so long-
+// lived processes (DaemonSet mode, a multi-session Recorder) do not
+// grow the sync.Map unboundedly. Typical record flows terminate a
+// session with Close, not DeleteMocksForSet, so without this clear
+// every test-set ever touched would leak an entry for the full
+// lifetime of the process. The next InsertMock for any testSetID
+// will rehydrate from on-disk state via os.Stat on the first call
+// (see the rehydrate block in InsertMock), so dropping the map is
+// semantically identical to a fresh MockYaml — only the memory
+// footprint changes.
 func (ys *MockYaml) Close() error {
 	// Hold the lifecycle lock for the entire teardown. While we wait
 	// for the writer goroutine to drain, no concurrent InsertMock
@@ -1046,6 +1092,13 @@ func (ys *MockYaml) Close() error {
 	// twice.
 	ys.gobLifecycleMu.Lock()
 	defer ys.gobLifecycleMu.Unlock()
+	// Always clear the per-testset format map — even when no gob
+	// writer ran this session (pure-yaml sessions never set
+	// gobRunning=true, but they still populate the map via the
+	// LoadOrStore calls in InsertMock). Doing this before the early-
+	// return is what caps the map's growth across record sessions on
+	// a long-lived MockYaml.
+	ys.clearTestSetFormats()
 	if !ys.gobRunning {
 		return nil
 	}
@@ -1455,7 +1508,7 @@ func (ys *MockYaml) DeleteMocksForSet(ctx context.Context, testSetID string) err
 		}
 	}
 
-	// Clear the in-memory per-testSetID format lock now that the on-disk
+	// Clear the in-memory per-testset format lock now that the on-disk
 	// files are gone. Without this drop the lock would survive the
 	// cleanup and reject the next InsertMock whose format differs
 	// from the deleted set's, breaking re-record flows that switch
@@ -1463,7 +1516,10 @@ func (ys *MockYaml) DeleteMocksForSet(ctx context.Context, testSetID string) err
 	// guard remains intact for concurrent sessions that do NOT route
 	// through this explicit cleanup (the in-memory lock in the
 	// InsertMock path still closes the async-writer race window).
-	ys.testSetFormat.Delete(testSetID)
+	// Key matches InsertMock: full test-set directory path so
+	// same-named test-sets under different MockPath roots don't cross-
+	// wipe each other.
+	ys.testSetFormat.Delete(testSetLockKey(ys, testSetID))
 
 	ys.Logger.Info("Successfully cleared old mocks for refresh.", zap.String("testSet", testSetID))
 	return nil

--- a/pkg/platform/yaml/mockdb/db.go
+++ b/pkg/platform/yaml/mockdb/db.go
@@ -602,9 +602,23 @@ func (ys *MockYaml) updateMocksGob(ctx context.Context, testSetID, gobPath strin
 }
 
 // InsertMock persists one mock under "<MockPath>/<testSetID>/<mockFileName>.(yaml|gob)".
-// The on-disk format is picked by resolveMockFormat: a non-empty
-// mock.Format wins, otherwise the process-wide configured format
-// applies.
+// The on-disk format is chosen by a three-step policy, in order of
+// precedence:
+//
+//  1. Recognized per-mock override: mock.Format == "yaml" or "gob"
+//     wins outright, so a caller that explicitly asks for a specific
+//     format gets it (and is subject to the mixed-format guard below
+//     if the testset is already locked to the opposite format).
+//  2. Locked testset: if no recognized override applies and this
+//     testSetID is already bound to a format — either via an earlier
+//     InsertMock in the same process or via the os.Stat rehydrate of
+//     an existing mocks.yaml / mocks.gob — the new mock inherits that
+//     lock. A typo'd or stale value therefore follows the directory
+//     instead of bouncing off the mixed-format guard.
+//  3. Process default: in the remaining case (no override, no lock)
+//     the mock is written in the format chosen by useGobMockFormat
+//     (KEPLOY_MOCK_FORMAT / record.mockFormat), which also becomes the
+//     new testset lock.
 //
 // Mixed-format constraint: read/prune paths (GetFilteredMocks /
 // GetUnFilteredMocks / UpdateMocks) choose mocks.gob over mocks.yaml by
@@ -701,30 +715,49 @@ func (ys *MockYaml) InsertMock(ctx context.Context, mock *models.Mock, testSetID
 	// mixed-format guard. Recognised overrides still win — a caller
 	// that explicitly asks for "gob" on a yaml-locked testset gets
 	// the mixed-format error below, which is the intended guard.
+	//
+	// The unknown-format branch is resolved with an atomic
+	// LoadOrStore rather than a read-then-write pair so a racing
+	// goroutine with an explicit opposite format cannot slip its
+	// claim in between our Load and our writeGob decision. The
+	// returned actual value is authoritative: if we lost the
+	// LoadOrStore race we inherit whatever the winner chose, and
+	// the downstream mixed-format guard is skipped because we've
+	// already atomically resolved to the stored value. A small
+	// explicitFormat flag tracks whether we still need that guard
+	// on the recognised-override path.
 	var writeGob bool
+	explicitFormat := true
 	switch mock.Format {
 	case mockFormatGob:
 		writeGob = true
 	case "yaml":
 		writeGob = false
 	default:
-		if locked, ok := ys.testSetFormat.Load(testSetID); ok {
-			writeGob = locked.(bool)
-		} else {
-			writeGob = useGobMockFormat()
-		}
+		// Unknown value — atomically inherit whatever the testset is
+		// already locked to. If no lock yet, LoadOrStore claims the
+		// process default; the returned actual is always the value
+		// that will be visible to subsequent callers.
+		actual, _ := ys.testSetFormat.LoadOrStore(testSetID, useGobMockFormat())
+		writeGob = actual.(bool)
+		explicitFormat = false
 	}
 
 	// Primary guard: atomic claim-or-check on the in-memory map.
 	// This is race-free against a still-in-flight async gob writer
 	// and against another goroutine's concurrent InsertMock for the
 	// same testSetID, because LoadOrStore is documented as atomic.
-	actual, loaded := ys.testSetFormat.LoadOrStore(testSetID, writeGob)
-	if loaded && actual.(bool) != writeGob {
-		if writeGob {
-			return fmt.Errorf("mockdb: cannot write gob-format mock into testset %q that already contains yaml mocks at %s; uniform per-testset format required", testSetID, yamlFile)
+	// Only runs for recognised-override callers — the unknown-format
+	// branch above already consulted LoadOrStore and cannot fail a
+	// mismatch check (it adopted whatever was stored).
+	if explicitFormat {
+		actual, loaded := ys.testSetFormat.LoadOrStore(testSetID, writeGob)
+		if loaded && actual.(bool) != writeGob {
+			if writeGob {
+				return fmt.Errorf("mockdb: cannot write gob-format mock into testset %q that already contains yaml mocks at %s; uniform per-testset format required", testSetID, yamlFile)
+			}
+			return fmt.Errorf("mockdb: cannot write yaml-format mock into testset %q that already contains gob mocks at %s; uniform per-testset format required", testSetID, gobFile)
 		}
-		return fmt.Errorf("mockdb: cannot write yaml-format mock into testset %q that already contains gob mocks at %s; uniform per-testset format required", testSetID, gobFile)
 	}
 
 	if writeGob {
@@ -1438,6 +1471,16 @@ func (ys *MockYaml) DeleteMocksForSet(ctx context.Context, testSetID string) err
 			return err
 		}
 	}
+
+	// Clear the in-memory per-testSetID format lock now that the on-disk
+	// files are gone. Without this drop the lock would survive the
+	// cleanup and reject the next InsertMock whose format differs
+	// from the deleted set's, breaking re-record flows that switch
+	// between yaml and gob between runs. The race-free mixed-format
+	// guard remains intact for concurrent sessions that do NOT route
+	// through this explicit cleanup (the in-memory lock in the
+	// InsertMock path still closes the async-writer race window).
+	ys.testSetFormat.Delete(testSetID)
 
 	ys.Logger.Info("Successfully cleared old mocks for refresh.", zap.String("testSet", testSetID))
 	return nil

--- a/pkg/platform/yaml/mockdb/per_mock_format_test.go
+++ b/pkg/platform/yaml/mockdb/per_mock_format_test.go
@@ -681,8 +681,196 @@ func TestInsertMock_RehydrateDetectsMixedOnDiskState(t *testing.T) {
 
 	// No in-memory format lock should have been claimed. User
 	// intervention is required; pre-claiming either side would steer
-	// the next InsertMock after cleanup down the wrong path.
-	if _, loaded := ys.testSetFormat.Load("set-0"); loaded {
+	// the next InsertMock after cleanup down the wrong path. Key is
+	// the full test-set directory path (see testSetLockKey) so the
+	// map lookup mirrors what InsertMock does.
+	if _, loaded := ys.testSetFormat.Load(testSetLockKey(ys, "set-0")); loaded {
 		t.Fatalf("testSetFormat should not have an entry after a mixed-on-disk rejection")
+	}
+}
+
+// TestInsertMock_LockKeyIncludesPath is a regression guard for the
+// per-testset format map's collision bug with bare testSetID keys.
+// Two MockYaml instances rooted at different MockPath directories can
+// share a testSetID (e.g. both have "set-0" under their own mocks
+// roots). Keying ys.testSetFormat by just the testSetID would let
+// one instance's format claim bleed into the other's decision path;
+// worse, MockYaml.MockPath is mutable — GetHTTPMocks overwrites it —
+// so a single instance can even collide with itself across different
+// root directories. Anchor the key on the full test-set directory
+// path (MockPath + testSetID) so each on-disk test-set owns an
+// independent lock.
+func TestInsertMock_LockKeyIncludesPath(t *testing.T) {
+	// Isolate from sibling tests' process-wide state.
+	prev := configuredMockFormat
+	t.Cleanup(func() { SetConfiguredMockFormat(prev) })
+	SetConfiguredMockFormat("")
+	t.Setenv("KEPLOY_MOCK_FORMAT", "")
+
+	// Two disjoint root directories. The shared testSetID ("set-0")
+	// is the whole point: with the pre-fix bare-key schema, the
+	// second InsertMock would observe the first instance's format
+	// lock under the same key and the in-memory guards would cross-
+	// contaminate even though the on-disk directories are unrelated.
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	const testSetID = "set-0"
+
+	ysA := New(zap.NewNop(), rootA, "mocks")
+	ysB := New(zap.NewNop(), rootB, "mocks")
+	t.Cleanup(func() {
+		if err := ysA.Close(); err != nil {
+			t.Errorf("deferred Close ysA: %v", err)
+		}
+		if err := ysB.Close(); err != nil {
+			t.Errorf("deferred Close ysB: %v", err)
+		}
+	})
+
+	// Route the two instances to opposite formats on purpose. If the
+	// lock keys collide, the second instance's InsertMock will fail
+	// the mixed-format guard (or silently adopt the other's format)
+	// instead of happily writing its own file.
+	if err := ysA.InsertMock(context.Background(), newHTTPMock("gob"), testSetID); err != nil {
+		t.Fatalf("ysA InsertMock(gob): %v", err)
+	}
+	if err := ysB.InsertMock(context.Background(), newHTTPMock("yaml"), testSetID); err != nil {
+		t.Fatalf("ysB InsertMock(yaml) — lock keys may be colliding across roots: %v", err)
+	}
+
+	// Drain both async gob writers before asserting on-disk state.
+	if err := ysA.Close(); err != nil {
+		t.Fatalf("ysA Close: %v", err)
+	}
+	if err := ysB.Close(); err != nil {
+		t.Fatalf("ysB Close: %v", err)
+	}
+
+	// Post-Close the format map must be empty (see Fix 2), but we
+	// can still inspect the filesystem to prove the two instances'
+	// decisions did not cross-talk.
+	if _, err := os.Stat(filepath.Join(rootA, testSetID, "mocks.gob")); err != nil {
+		t.Fatalf("rootA should have mocks.gob from ysA's gob InsertMock: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(rootA, testSetID, "mocks.yaml")); err == nil {
+		t.Fatalf("rootA must not have mocks.yaml — cross-contamination from ysB")
+	}
+	if _, err := os.Stat(filepath.Join(rootB, testSetID, "mocks.yaml")); err != nil {
+		t.Fatalf("rootB should have mocks.yaml from ysB's yaml InsertMock: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(rootB, testSetID, "mocks.gob")); err == nil {
+		t.Fatalf("rootB must not have mocks.gob — cross-contamination from ysA")
+	}
+
+	// Independence on the in-memory side as well: re-insert after the
+	// Close-triggered clear and inspect the map directly. Each
+	// instance's key must carry only its own MockPath.
+	if err := ysA.InsertMock(context.Background(), newHTTPMock("gob"), testSetID); err != nil {
+		t.Fatalf("ysA second InsertMock: %v", err)
+	}
+	if err := ysB.InsertMock(context.Background(), newHTTPMock("yaml"), testSetID); err != nil {
+		t.Fatalf("ysB second InsertMock: %v", err)
+	}
+	keyA := testSetLockKey(ysA, testSetID)
+	keyB := testSetLockKey(ysB, testSetID)
+	if keyA == keyB {
+		t.Fatalf("lock keys must differ across roots: keyA=%q keyB=%q", keyA, keyB)
+	}
+	vA, okA := ysA.testSetFormat.Load(keyA)
+	vB, okB := ysB.testSetFormat.Load(keyB)
+	if !okA {
+		t.Fatalf("ysA testSetFormat missing entry for %q", keyA)
+	}
+	if !okB {
+		t.Fatalf("ysB testSetFormat missing entry for %q", keyB)
+	}
+	if vA.(bool) != true {
+		t.Fatalf("ysA should be locked to gob (true), got %v", vA)
+	}
+	if vB.(bool) != false {
+		t.Fatalf("ysB should be locked to yaml (false), got %v", vB)
+	}
+	// Cross-lookup must miss: ysA's key must not be present in ysB's
+	// map (same sync.Map instance per MockYaml, but the key check
+	// still guards against any future refactor that shares state).
+	if _, loaded := ysA.testSetFormat.Load(keyB); loaded {
+		t.Fatalf("ysA must not carry ysB's key %q", keyB)
+	}
+	if _, loaded := ysB.testSetFormat.Load(keyA); loaded {
+		t.Fatalf("ysB must not carry ysA's key %q", keyA)
+	}
+}
+
+// TestMockYaml_CloseClearsFormatLocks verifies that Close drops the
+// in-memory per-testset format map. Long-lived processes (DaemonSet
+// agent, a multi-session recorder) call Close at the end of each
+// session but never DeleteMocksForSet; without the clear, the map
+// would accumulate an entry per distinct testset for the lifetime
+// of the MockYaml, leaking memory proportional to session count.
+// After Close the map must be empty, and a subsequent InsertMock
+// must still succeed (the rehydrate path picks the lock back up
+// from on-disk state).
+func TestMockYaml_CloseClearsFormatLocks(t *testing.T) {
+	prev := configuredMockFormat
+	t.Cleanup(func() { SetConfiguredMockFormat(prev) })
+	SetConfiguredMockFormat("")
+	t.Setenv("KEPLOY_MOCK_FORMAT", "")
+
+	dir := t.TempDir()
+	ys := New(zap.NewNop(), dir, "mocks")
+
+	// Seed several testsets with mixed formats so the map populates
+	// across both the rehydrate branch (none, files are fresh) and
+	// the explicit-format branch (LoadOrStore fires).
+	seed := []struct {
+		testSetID string
+		format    string
+	}{
+		{"set-0", "yaml"},
+		{"set-1", "gob"},
+		{"set-2", ""}, // falls through to testset default (yaml)
+	}
+	for _, s := range seed {
+		if err := ys.InsertMock(context.Background(), newHTTPMock(s.format), s.testSetID); err != nil {
+			t.Fatalf("InsertMock(%q, %q): %v", s.testSetID, s.format, err)
+		}
+	}
+
+	// Sanity: all three entries present under the full-path keys.
+	for _, s := range seed {
+		key := testSetLockKey(ys, s.testSetID)
+		if _, loaded := ys.testSetFormat.Load(key); !loaded {
+			t.Fatalf("pre-Close: testSetFormat missing entry for %q", key)
+		}
+	}
+
+	if err := ys.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Post-Close: the map is empty. Walk Range and count; anything >
+	// 0 fails the test.
+	remaining := 0
+	ys.testSetFormat.Range(func(_, _ any) bool {
+		remaining++
+		return true
+	})
+	if remaining != 0 {
+		t.Fatalf("Close should have cleared testSetFormat, still has %d entries", remaining)
+	}
+
+	// Re-insert post-Close: the rehydrate branch repopulates the map
+	// from on-disk state (mocks.yaml / mocks.gob already exist from
+	// the seed phase), so the format is preserved across the Close
+	// boundary and the next InsertMock succeeds for the same format.
+	// For set-1 we re-assert gob; for set-0 yaml.
+	if err := ys.InsertMock(context.Background(), newHTTPMock("gob"), "set-1"); err != nil {
+		t.Fatalf("post-Close InsertMock set-1: %v", err)
+	}
+	if err := ys.InsertMock(context.Background(), newHTTPMock("yaml"), "set-0"); err != nil {
+		t.Fatalf("post-Close InsertMock set-0: %v", err)
+	}
+	if err := ys.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
 	}
 }

--- a/pkg/platform/yaml/mockdb/per_mock_format_test.go
+++ b/pkg/platform/yaml/mockdb/per_mock_format_test.go
@@ -1,38 +1,11 @@
-// Coverage for the per-mock Format override (task #225 / DaemonSet
-// Phase 0 per-session mock format) and its mixed-format guard. Tests:
-//
-//  1. TestPerMockFormat_RouteSelection — table-driven InsertMock
-//     routing: empty Format falls back to the testset-level format
-//     (yaml for the fixture), explicit "yaml" matches the default,
-//     "gob" routes a single mock to mocks.gob, and an unknown value
-//     ("xml") falls through to the testset default rather than
-//     erroring, which is what unblocks multi-session DS flows.
-//
-//  2. TestPerMockFormat_WireRoundTrip — encode/decode preservation
-//     of the Format field through the EncodeMock -> yaml.Marshal ->
-//     yaml.Unmarshal -> DecodeMocks path, including byte-level
-//     omitempty checks on the `format:` line. Pure function test,
-//     no filesystem.
-//
-//  3. TestPerMockFormat_DeepCopyPreserves — regression guard that
-//     models.Mock.DeepCopy carries the Format field through, so the
-//     async gob writer's deep-copy-before-enqueue step cannot drop
-//     the override mid-flight.
-//
-//  4. TestInsertMock_RejectsMixedFormat — both directions (yaml then
-//     gob, gob then yaml) of the single-testset-one-format contract.
-//     Read/prune paths prefer mocks.gob by file presence and never
-//     merge a sibling mocks.yaml, so InsertMock must reject the
-//     second-format write; the assertion covers both the error
-//     message and that no sibling file was created.
-//
-//  5. TestInsertMock_RaceFreeMixedFormatGuard — race-window coverage
-//     for the in-process guard: a gob InsertMock enqueues to the
-//     async writer without waiting for gobReopenLocked to create
-//     mocks.gob on disk, and an immediately-following yaml InsertMock
-//     in the same goroutine must still be rejected by the in-memory
-//     per-testSetID format map rather than racing the async file
-//     creation.
+// per_mock_format_test.go covers the per-mock Format override feature
+// (slice #225 "P0 per-session mock format") and its mixed-format guard:
+// routing policy (recognized / locked-testset / process-default),
+// wire round-trip through YAML encode/decode, deep-copy preservation
+// for async gob writes, mixed-format rejection, race safety against
+// the async gob writer, locked-testset inheritance for unknown formats,
+// concurrent explicit-vs-unknown format ordering, and lock cleanup
+// after DeleteMocksForSet.
 package mockdb
 
 import (
@@ -323,9 +296,9 @@ func TestInsertMock_RejectsMixedFormat(t *testing.T) {
 // Scenario: process default is gob (simulating a run with
 // KEPLOY_MOCK_FORMAT=gob), but the first InsertMock for testSetID
 // "t1" explicitly asks for yaml — locking t1 to yaml. A follow-up
-// InsertMock with Format="gbo" (typo) would, under the old
-// resolveMockFormat-only policy, route to the process default (gob)
-// and be rejected by the mixed-format guard, dropping the mock. The
+// InsertMock with Format="gbo" (typo) would, under a plain per-mock
+// → process-default policy, route to the process default (gob) and
+// be rejected by the mixed-format guard, dropping the mock. The
 // lock-aware policy routes it to the locked format instead and
 // appends cleanly into mocks.yaml, preserving the recording.
 func TestInsertMock_UnknownFormatHonorsLockedTestset(t *testing.T) {

--- a/pkg/platform/yaml/mockdb/per_mock_format_test.go
+++ b/pkg/platform/yaml/mockdb/per_mock_format_test.go
@@ -265,15 +265,26 @@ func TestInsertMock_RejectsMixedFormat(t *testing.T) {
 			t.Fatalf("first InsertMock (gob): %v", err)
 		}
 		// Close() drains the async gob writer so the file is
-		// present on disk for this variant. The race-free
-		// in-memory guard (sync.Map in MockYaml) would catch the
-		// rejection even without this Close — see
-		// TestInsertMock_RaceFreeMixedFormatGuard — but draining
-		// here exercises the on-disk side of the guard too.
+		// present on disk for this variant. Close is terminal
+		// (new in R9: Close stores ys.closed=true so InsertMock
+		// cannot race the teardown — see
+		// TestMockYaml_CloseVsConcurrentInsertMock), so the
+		// follow-up yaml insert exercises the cross-process
+		// rehydrate path via a fresh MockYaml on the same
+		// directory. That path feeds through the os.Stat guard in
+		// InsertMock which picks up the on-disk mocks.gob and
+		// locks the new MockYaml to gob before the mixed-format
+		// check runs.
 		if err := ys.Close(); err != nil {
 			t.Fatalf("Close after gob insert: %v", err)
 		}
-		err := ys.InsertMock(context.Background(), newHTTPMock("yaml"), "set-0")
+		ys2 := New(zap.NewNop(), dir, "mocks")
+		t.Cleanup(func() {
+			if err := ys2.Close(); err != nil {
+				t.Errorf("deferred Close on ys2: %v", err)
+			}
+		})
+		err := ys2.InsertMock(context.Background(), newHTTPMock("yaml"), "set-0")
 		if err == nil {
 			t.Fatalf("expected InsertMock(yaml) to fail after gob file present, got nil")
 		}
@@ -762,42 +773,54 @@ func TestInsertMock_LockKeyIncludesPath(t *testing.T) {
 		t.Fatalf("rootB must not have mocks.gob — cross-contamination from ysA")
 	}
 
-	// Independence on the in-memory side as well: re-insert after the
-	// Close-triggered clear and inspect the map directly. Each
-	// instance's key must carry only its own MockPath.
-	if err := ysA.InsertMock(context.Background(), newHTTPMock("gob"), testSetID); err != nil {
-		t.Fatalf("ysA second InsertMock: %v", err)
+	// Independence on the in-memory side as well: re-insert with
+	// FRESH MockYaml instances (ysA/ysB are terminal after Close —
+	// R9) and inspect each instance's map directly. Each instance's
+	// key must carry only its own MockPath.
+	ysA2 := New(zap.NewNop(), rootA, "mocks")
+	ysB2 := New(zap.NewNop(), rootB, "mocks")
+	t.Cleanup(func() {
+		if err := ysA2.Close(); err != nil {
+			t.Errorf("deferred Close ysA2: %v", err)
+		}
+		if err := ysB2.Close(); err != nil {
+			t.Errorf("deferred Close ysB2: %v", err)
+		}
+	})
+	if err := ysA2.InsertMock(context.Background(), newHTTPMock("gob"), testSetID); err != nil {
+		t.Fatalf("ysA2 InsertMock: %v", err)
 	}
-	if err := ysB.InsertMock(context.Background(), newHTTPMock("yaml"), testSetID); err != nil {
-		t.Fatalf("ysB second InsertMock: %v", err)
+	if err := ysB2.InsertMock(context.Background(), newHTTPMock("yaml"), testSetID); err != nil {
+		t.Fatalf("ysB2 InsertMock: %v", err)
 	}
-	keyA := testSetLockKey(ysA, testSetID)
-	keyB := testSetLockKey(ysB, testSetID)
+	keyA := testSetLockKey(ysA2, testSetID)
+	keyB := testSetLockKey(ysB2, testSetID)
 	if keyA == keyB {
 		t.Fatalf("lock keys must differ across roots: keyA=%q keyB=%q", keyA, keyB)
 	}
-	vA, okA := ysA.testSetFormat.Load(keyA)
-	vB, okB := ysB.testSetFormat.Load(keyB)
+	vA, okA := ysA2.testSetFormat.Load(keyA)
+	vB, okB := ysB2.testSetFormat.Load(keyB)
 	if !okA {
-		t.Fatalf("ysA testSetFormat missing entry for %q", keyA)
+		t.Fatalf("ysA2 testSetFormat missing entry for %q", keyA)
 	}
 	if !okB {
-		t.Fatalf("ysB testSetFormat missing entry for %q", keyB)
+		t.Fatalf("ysB2 testSetFormat missing entry for %q", keyB)
 	}
 	if vA.(bool) != true {
-		t.Fatalf("ysA should be locked to gob (true), got %v", vA)
+		t.Fatalf("ysA2 should be locked to gob (true), got %v", vA)
 	}
 	if vB.(bool) != false {
-		t.Fatalf("ysB should be locked to yaml (false), got %v", vB)
+		t.Fatalf("ysB2 should be locked to yaml (false), got %v", vB)
 	}
-	// Cross-lookup must miss: ysA's key must not be present in ysB's
-	// map (same sync.Map instance per MockYaml, but the key check
-	// still guards against any future refactor that shares state).
-	if _, loaded := ysA.testSetFormat.Load(keyB); loaded {
-		t.Fatalf("ysA must not carry ysB's key %q", keyB)
+	// Cross-lookup must miss: ysA2's key must not be present in
+	// ysB2's map (each MockYaml owns its own sync.Map, but the key
+	// check still guards against any future refactor that shares
+	// state).
+	if _, loaded := ysA2.testSetFormat.Load(keyB); loaded {
+		t.Fatalf("ysA2 must not carry ysB2's key %q", keyB)
 	}
-	if _, loaded := ysB.testSetFormat.Load(keyA); loaded {
-		t.Fatalf("ysB must not carry ysA's key %q", keyA)
+	if _, loaded := ysB2.testSetFormat.Load(keyA); loaded {
+		t.Fatalf("ysB2 must not carry ysA2's key %q", keyA)
 	}
 }
 
@@ -859,18 +882,186 @@ func TestMockYaml_CloseClearsFormatLocks(t *testing.T) {
 		t.Fatalf("Close should have cleared testSetFormat, still has %d entries", remaining)
 	}
 
-	// Re-insert post-Close: the rehydrate branch repopulates the map
-	// from on-disk state (mocks.yaml / mocks.gob already exist from
-	// the seed phase), so the format is preserved across the Close
-	// boundary and the next InsertMock succeeds for the same format.
-	// For set-1 we re-assert gob; for set-0 yaml.
-	if err := ys.InsertMock(context.Background(), newHTTPMock("gob"), "set-1"); err != nil {
-		t.Fatalf("post-Close InsertMock set-1: %v", err)
+	// Close is terminal (R9): InsertMock on the SAME MockYaml after
+	// Close must be rejected, not accepted. This closes the race
+	// where a late InsertMock(yaml) could slip past a cleared
+	// testSetFormat map while a pending gob write had not yet
+	// materialised mocks.gob on disk.
+	if err := ys.InsertMock(context.Background(), newHTTPMock("yaml"), "set-0"); err == nil {
+		t.Fatalf("post-Close InsertMock on same instance should have been rejected, got nil")
+	} else if !strings.Contains(err.Error(), "closed MockYaml") {
+		t.Fatalf("post-Close InsertMock returned unexpected error: %v", err)
 	}
-	if err := ys.InsertMock(context.Background(), newHTTPMock("yaml"), "set-0"); err != nil {
-		t.Fatalf("post-Close InsertMock set-0: %v", err)
+
+	// A fresh MockYaml pointed at the same directory rehydrates the
+	// per-testset format lock from on-disk state (mocks.yaml /
+	// mocks.gob left behind by the seed phase), so the format is
+	// preserved across the MockYaml boundary and the next InsertMock
+	// still enforces the original format. For set-1 we re-assert
+	// gob; for set-0 yaml.
+	ys2 := New(zap.NewNop(), dir, "mocks")
+	t.Cleanup(func() {
+		if err := ys2.Close(); err != nil {
+			t.Errorf("deferred Close on ys2: %v", err)
+		}
+	})
+	if err := ys2.InsertMock(context.Background(), newHTTPMock("gob"), "set-1"); err != nil {
+		t.Fatalf("fresh-MockYaml InsertMock set-1: %v", err)
 	}
-	if err := ys.Close(); err != nil {
-		t.Fatalf("second Close: %v", err)
+	if err := ys2.InsertMock(context.Background(), newHTTPMock("yaml"), "set-0"); err != nil {
+		t.Fatalf("fresh-MockYaml InsertMock set-0: %v", err)
+	}
+}
+
+// TestMockYaml_CloseVsConcurrentInsertMock stresses the
+// Close-vs-concurrent-InsertMock race the R9 fix closes. Without the
+// ys.closed gate and the "drain-then-clear" ordering in Close, a
+// parallel InsertMock(yaml) call could observe a cleared
+// testSetFormat map while the async gob writer still had a pending
+// mocks.gob job in its queue — stat the missing mocks.gob, pass the
+// mixed-format check, and create mocks.yaml alongside the still-
+// queued gob write. With the fix, every InsertMock that arrives at
+// or after Close's closed.Store(true) must return the terminal
+// "closed MockYaml" error; every InsertMock that arrived before the
+// store must have either succeeded (mock is on disk in the locked
+// format) or failed with the normal format-guard error — never
+// "succeeded and wrote the wrong file."
+//
+// On-disk post-condition: the testset directory must never contain
+// BOTH mocks.gob AND mocks.yaml. That is the invariant the readers
+// depend on.
+//
+// Run this under -race to catch any missing synchronization around
+// ys.closed, the testSetFormat map, or the async gob writer's file
+// handle.
+func TestMockYaml_CloseVsConcurrentInsertMock(t *testing.T) {
+	prev := configuredMockFormat
+	t.Cleanup(func() { SetConfiguredMockFormat(prev) })
+	SetConfiguredMockFormat("")
+	// Testset default = yaml. The race we care about is a yaml
+	// InsertMock slipping past the guard while a gob write is still
+	// in-flight — so the process default must be yaml so the
+	// unknown-format fallback also routes to yaml for the
+	// non-overriding goroutines. The closed-gate is format-
+	// independent, so either default would exercise it; yaml is
+	// chosen because the yaml write path is the one that skips
+	// gobLifecycleMu and is therefore the fragile one.
+	t.Setenv("KEPLOY_MOCK_FORMAT", "")
+
+	const (
+		inserters = 10
+		testSetID = "t1"
+	)
+
+	dir := t.TempDir()
+	ys := New(zap.NewNop(), dir, "mocks")
+
+	var startBarrier sync.WaitGroup
+	startBarrier.Add(1)
+	var inserterWG sync.WaitGroup
+	inserterWG.Add(inserters)
+
+	// insertOutcomes records one result per inserter goroutine:
+	// - err is the return value of InsertMock.
+	// - afterClose is true iff the inserter observed ys.closed=true
+	//   at the moment its call entered InsertMock. We can only
+	//   approximate that here by checking Load() after the fact; the
+	//   fix's correctness test is "no inserter returned nil AFTER
+	//   Close completed and the file invariant still holds" — so we
+	//   rely on the on-disk post-condition for the hard assertion
+	//   and use err-class counts for observability.
+	type outcome struct {
+		err error
+	}
+	outcomes := make([]outcome, inserters)
+
+	for i := 0; i < inserters; i++ {
+		i := i
+		go func() {
+			defer inserterWG.Done()
+			startBarrier.Wait()
+			// Explicit Format="yaml" so every inserter takes the
+			// yaml path — the path that does NOT hold
+			// gobLifecycleMu and therefore exposes the race the
+			// closed gate was added to close.
+			outcomes[i] = outcome{err: ys.InsertMock(context.Background(), newHTTPMock("yaml"), testSetID)}
+		}()
+	}
+
+	closerDone := make(chan error, 1)
+	go func() {
+		startBarrier.Wait()
+		closerDone <- ys.Close()
+	}()
+
+	startBarrier.Done()
+	inserterWG.Wait()
+	closeErr := <-closerDone
+	if closeErr != nil {
+		t.Fatalf("Close returned error: %v", closeErr)
+	}
+
+	// Cleanup: a second Close is a no-op and must not error.
+	t.Cleanup(func() {
+		if err := ys.Close(); err != nil {
+			t.Errorf("deferred second Close: %v", err)
+		}
+	})
+
+	// Classify outcomes. Every inserter either succeeded cleanly
+	// (ran before Close's closed.Store(true)) or failed with the
+	// terminal "closed MockYaml" error (ran at or after the store).
+	// Any other error shape is a regression.
+	succeeded := 0
+	rejectedClosed := 0
+	for i, o := range outcomes {
+		if o.err == nil {
+			succeeded++
+			continue
+		}
+		if strings.Contains(o.err.Error(), "closed MockYaml") {
+			rejectedClosed++
+			continue
+		}
+		t.Fatalf("inserter #%d returned unexpected error: %v", i, o.err)
+	}
+	if succeeded+rejectedClosed != inserters {
+		t.Fatalf("outcome accounting mismatch: succeeded=%d rejectedClosed=%d total=%d want=%d",
+			succeeded, rejectedClosed, succeeded+rejectedClosed, inserters)
+	}
+
+	// After Close has returned, ys.closed must be true and any
+	// subsequent InsertMock on the same instance must also be
+	// rejected — confirming the gate is still set, not a transient
+	// window.
+	if !ys.closed.Load() {
+		t.Fatalf("expected ys.closed=true after Close returned")
+	}
+	if err := ys.InsertMock(context.Background(), newHTTPMock("yaml"), testSetID); err == nil {
+		t.Fatalf("post-Close InsertMock should have been rejected")
+	} else if !strings.Contains(err.Error(), "closed MockYaml") {
+		t.Fatalf("post-Close InsertMock returned unexpected error: %v", err)
+	}
+
+	// On-disk invariant: the testset directory must contain at most
+	// one of mocks.gob or mocks.yaml. Mixed state is the bug the
+	// fix prevents.
+	tsDir := filepath.Join(dir, testSetID)
+	_, yamlStatErr := os.Stat(filepath.Join(tsDir, "mocks.yaml"))
+	_, gobStatErr := os.Stat(filepath.Join(tsDir, "mocks.gob"))
+	haveYaml := yamlStatErr == nil
+	haveGob := gobStatErr == nil
+	if haveYaml && haveGob {
+		t.Fatalf("mixed-format on-disk state after Close-vs-InsertMock race: both mocks.yaml and mocks.gob present in %s", tsDir)
+	}
+	// Sanity: if any inserter succeeded, we expect mocks.yaml on
+	// disk (the Format="yaml" was the explicit choice for every
+	// inserter). If all were rejected, the directory may be absent
+	// entirely — accept either.
+	if succeeded > 0 && !haveYaml {
+		t.Fatalf("%d inserters reported success but mocks.yaml is missing from %s", succeeded, tsDir)
+	}
+	if haveGob {
+		t.Fatalf("mocks.gob present despite every inserter choosing Format=\"yaml\"; on-disk path=%s", tsDir)
 	}
 }

--- a/pkg/platform/yaml/mockdb/per_mock_format_test.go
+++ b/pkg/platform/yaml/mockdb/per_mock_format_test.go
@@ -623,3 +623,66 @@ func TestInsertMock_RehydrateAfterDelete(t *testing.T) {
 		t.Fatalf("stale mocks.yaml resurfaced after rehydrated insert")
 	}
 }
+
+// TestInsertMock_RehydrateDetectsMixedOnDiskState covers the mixed-
+// on-disk guard in the rehydrate branch of InsertMock. A testset
+// directory that contains both mocks.gob and mocks.yaml is an
+// ambiguous state — prior-version async-writer races, manual edits,
+// or a partial DeleteMocksForSet could leave both files behind.
+// Readers prefer gob by file presence, so silently locking to gob
+// would orphan the yaml mocks at replay. InsertMock must refuse
+// instead and surface an actionable error, leaving the in-memory
+// format lock untouched so the user can clean up the directory and
+// retry without a pre-claimed format side-effect.
+func TestInsertMock_RehydrateDetectsMixedOnDiskState(t *testing.T) {
+	// Guard against pollution from sibling tests.
+	prev := configuredMockFormat
+	t.Cleanup(func() { SetConfiguredMockFormat(prev) })
+	SetConfiguredMockFormat("")
+	t.Setenv("KEPLOY_MOCK_FORMAT", "")
+
+	dir := t.TempDir()
+	// Seed BOTH mocks.gob and mocks.yaml in the testset directory
+	// directly via os.WriteFile, simulating the stale-directory state
+	// a user might land in. Empty files are enough to trip os.Stat,
+	// which is what the guard keys on.
+	testSetDir := filepath.Join(dir, "set-0")
+	if err := os.MkdirAll(testSetDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	gobPath := filepath.Join(testSetDir, "mocks.gob")
+	yamlPath := filepath.Join(testSetDir, "mocks.yaml")
+	if err := os.WriteFile(gobPath, nil, 0o644); err != nil {
+		t.Fatalf("write mocks.gob: %v", err)
+	}
+	if err := os.WriteFile(yamlPath, nil, 0o644); err != nil {
+		t.Fatalf("write mocks.yaml: %v", err)
+	}
+
+	ys := New(zap.NewNop(), dir, "mocks")
+	t.Cleanup(func() {
+		if err := ys.Close(); err != nil {
+			t.Errorf("deferred Close: %v", err)
+		}
+	})
+
+	// Any format should trigger the rehydrate path on the first
+	// InsertMock for this testSetID and fail loudly. Use "yaml" here
+	// to pin down the schedule — the guard must fire regardless of
+	// the requested format because the rehydrate branch runs before
+	// writeGob is resolved.
+	err := ys.InsertMock(context.Background(), newHTTPMock("yaml"), "set-0")
+	if err == nil {
+		t.Fatalf("expected InsertMock to fail when both mocks.gob and mocks.yaml exist, got nil")
+	}
+	if !strings.Contains(err.Error(), "found both gob and yaml mock files") {
+		t.Fatalf("error message missing mixed-on-disk hint: %v", err)
+	}
+
+	// No in-memory format lock should have been claimed. User
+	// intervention is required; pre-claiming either side would steer
+	// the next InsertMock after cleanup down the wrong path.
+	if _, loaded := ys.testSetFormat.Load("set-0"); loaded {
+		t.Fatalf("testSetFormat should not have an entry after a mixed-on-disk rejection")
+	}
+}

--- a/pkg/platform/yaml/mockdb/per_mock_format_test.go
+++ b/pkg/platform/yaml/mockdb/per_mock_format_test.go
@@ -265,16 +265,12 @@ func TestInsertMock_RejectsMixedFormat(t *testing.T) {
 			t.Fatalf("first InsertMock (gob): %v", err)
 		}
 		// Close() drains the async gob writer so the file is
-		// present on disk for this variant. Close is terminal
-		// (new in R9: Close stores ys.closed=true so InsertMock
-		// cannot race the teardown — see
-		// TestMockYaml_CloseVsConcurrentInsertMock), so the
-		// follow-up yaml insert exercises the cross-process
-		// rehydrate path via a fresh MockYaml on the same
-		// directory. That path feeds through the os.Stat guard in
-		// InsertMock which picks up the on-disk mocks.gob and
-		// locks the new MockYaml to gob before the mixed-format
-		// check runs.
+		// present on disk for this variant. We then use a fresh
+		// MockYaml on the same directory for the follow-up yaml
+		// insert to exercise the cross-process rehydrate path.
+		// That path feeds through the os.Stat guard in InsertMock
+		// which picks up the on-disk mocks.gob and locks the new
+		// MockYaml to gob before the mixed-format check runs.
 		if err := ys.Close(); err != nil {
 			t.Fatalf("Close after gob insert: %v", err)
 		}
@@ -774,9 +770,9 @@ func TestInsertMock_LockKeyIncludesPath(t *testing.T) {
 	}
 
 	// Independence on the in-memory side as well: re-insert with
-	// FRESH MockYaml instances (ysA/ysB are terminal after Close —
-	// R9) and inspect each instance's map directly. Each instance's
-	// key must carry only its own MockPath.
+	// FRESH MockYaml instances so each instance's map is inspected
+	// in isolation from ysA/ysB's cleared state after Close. Each
+	// instance's key must carry only its own MockPath.
 	ysA2 := New(zap.NewNop(), rootA, "mocks")
 	ysB2 := New(zap.NewNop(), rootB, "mocks")
 	t.Cleanup(func() {
@@ -882,15 +878,18 @@ func TestMockYaml_CloseClearsFormatLocks(t *testing.T) {
 		t.Fatalf("Close should have cleared testSetFormat, still has %d entries", remaining)
 	}
 
-	// Close is terminal (R9): InsertMock on the SAME MockYaml after
-	// Close must be rejected, not accepted. This closes the race
-	// where a late InsertMock(yaml) could slip past a cleared
-	// testSetFormat map while a pending gob write had not yet
-	// materialised mocks.gob on disk.
-	if err := ys.InsertMock(context.Background(), newHTTPMock("yaml"), "set-0"); err == nil {
-		t.Fatalf("post-Close InsertMock on same instance should have been rejected, got nil")
-	} else if !strings.Contains(err.Error(), "closed MockYaml") {
-		t.Fatalf("post-Close InsertMock returned unexpected error: %v", err)
+	// Close is re-entrant: a subsequent InsertMock on the SAME
+	// MockYaml must succeed — the re-record / post-Close-reopen
+	// flow depends on this. The cleared map is repopulated from
+	// on-disk state via the os.Stat rehydrate branch in InsertMock,
+	// so the format lock survives the Close boundary. For set-0
+	// (yaml on disk) a follow-up InsertMock with Format="yaml" must
+	// succeed and must not create a sibling mocks.gob.
+	if err := ys.InsertMock(context.Background(), newHTTPMock("yaml"), "set-0"); err != nil {
+		t.Fatalf("post-Close InsertMock on same instance should succeed (re-record flow), got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "set-0", "mocks.gob")); statErr == nil {
+		t.Fatalf("post-Close InsertMock(yaml) must not have created mocks.gob")
 	}
 
 	// A fresh MockYaml pointed at the same directory rehydrates the
@@ -914,26 +913,32 @@ func TestMockYaml_CloseClearsFormatLocks(t *testing.T) {
 }
 
 // TestMockYaml_CloseVsConcurrentInsertMock stresses the
-// Close-vs-concurrent-InsertMock race the R9 fix closes. Without the
-// ys.closed gate and the "drain-then-clear" ordering in Close, a
-// parallel InsertMock(yaml) call could observe a cleared
-// testSetFormat map while the async gob writer still had a pending
-// mocks.gob job in its queue — stat the missing mocks.gob, pass the
-// mixed-format check, and create mocks.yaml alongside the still-
-// queued gob write. With the fix, every InsertMock that arrives at
-// or after Close's closed.Store(true) must return the terminal
-// "closed MockYaml" error; every InsertMock that arrived before the
-// store must have either succeeded (mock is on disk in the locked
-// format) or failed with the normal format-guard error — never
-// "succeeded and wrote the wrong file."
+// Close-vs-concurrent-InsertMock race that the "drain-before-clear"
+// ordering in Close closes. Without that ordering, a parallel
+// InsertMock(yaml) call could observe a cleared testSetFormat map
+// while the async gob writer still had a pending mocks.gob job in
+// its queue — stat the missing mocks.gob, pass the mixed-format
+// check, and create mocks.yaml alongside the still-queued gob write.
+// With Close draining the async writer BEFORE clearing the map,
+// every testSetFormat entry whose lock points at a pending gob
+// write has had its file materialise by the time the map is walked;
+// any concurrent InsertMock(yaml) racing the clear then either
+// arrived before the drain (and its lock was still present when it
+// LoadOrStore'd), or arrived after the clear and re-rehydrates via
+// os.Stat on the now-materialised mocks.gob and bounces off the
+// mixed-format guard.
 //
 // On-disk post-condition: the testset directory must never contain
 // BOTH mocks.gob AND mocks.yaml. That is the invariant the readers
-// depend on.
+// depend on, and the only hard correctness signal this test
+// enforces. Close/InsertMock are both allowed to succeed in any
+// interleaving; inserters that fail with the mixed-format guard
+// error are accepted. No "closed MockYaml" error is expected —
+// Close is no longer terminal, so re-record / late-insert flows
+// continue to work.
 //
 // Run this under -race to catch any missing synchronization around
-// ys.closed, the testSetFormat map, or the async gob writer's file
-// handle.
+// the testSetFormat map or the async gob writer's file handle.
 func TestMockYaml_CloseVsConcurrentInsertMock(t *testing.T) {
 	prev := configuredMockFormat
 	t.Cleanup(func() { SetConfiguredMockFormat(prev) })
@@ -942,10 +947,8 @@ func TestMockYaml_CloseVsConcurrentInsertMock(t *testing.T) {
 	// InsertMock slipping past the guard while a gob write is still
 	// in-flight — so the process default must be yaml so the
 	// unknown-format fallback also routes to yaml for the
-	// non-overriding goroutines. The closed-gate is format-
-	// independent, so either default would exercise it; yaml is
-	// chosen because the yaml write path is the one that skips
-	// gobLifecycleMu and is therefore the fragile one.
+	// non-overriding goroutines. The yaml write path is the one
+	// that skips gobLifecycleMu and is therefore the fragile one.
 	t.Setenv("KEPLOY_MOCK_FORMAT", "")
 
 	const (
@@ -961,19 +964,7 @@ func TestMockYaml_CloseVsConcurrentInsertMock(t *testing.T) {
 	var inserterWG sync.WaitGroup
 	inserterWG.Add(inserters)
 
-	// insertOutcomes records one result per inserter goroutine:
-	// - err is the return value of InsertMock.
-	// - afterClose is true iff the inserter observed ys.closed=true
-	//   at the moment its call entered InsertMock. We can only
-	//   approximate that here by checking Load() after the fact; the
-	//   fix's correctness test is "no inserter returned nil AFTER
-	//   Close completed and the file invariant still holds" — so we
-	//   rely on the on-disk post-condition for the hard assertion
-	//   and use err-class counts for observability.
-	type outcome struct {
-		err error
-	}
-	outcomes := make([]outcome, inserters)
+	outcomes := make([]error, inserters)
 
 	for i := 0; i < inserters; i++ {
 		i := i
@@ -983,8 +974,8 @@ func TestMockYaml_CloseVsConcurrentInsertMock(t *testing.T) {
 			// Explicit Format="yaml" so every inserter takes the
 			// yaml path — the path that does NOT hold
 			// gobLifecycleMu and therefore exposes the race the
-			// closed gate was added to close.
-			outcomes[i] = outcome{err: ys.InsertMock(context.Background(), newHTTPMock("yaml"), testSetID)}
+			// drain-before-clear ordering in Close closes.
+			outcomes[i] = ys.InsertMock(context.Background(), newHTTPMock("yaml"), testSetID)
 		}()
 	}
 
@@ -1008,44 +999,43 @@ func TestMockYaml_CloseVsConcurrentInsertMock(t *testing.T) {
 		}
 	})
 
-	// Classify outcomes. Every inserter either succeeded cleanly
-	// (ran before Close's closed.Store(true)) or failed with the
-	// terminal "closed MockYaml" error (ran at or after the store).
-	// Any other error shape is a regression.
+	// Classify outcomes. Close is no longer terminal, so every
+	// inserter either succeeded cleanly, or failed with the normal
+	// mixed-format guard error if it happened to race a rehydrate
+	// that picked up a foreign lock. Any other error shape is a
+	// regression. In particular we must NOT see a "closed MockYaml"
+	// error — that gate was removed to unblock the --rerecord flow.
 	succeeded := 0
-	rejectedClosed := 0
-	for i, o := range outcomes {
-		if o.err == nil {
+	rejectedMixed := 0
+	for i, err := range outcomes {
+		if err == nil {
 			succeeded++
 			continue
 		}
-		if strings.Contains(o.err.Error(), "closed MockYaml") {
-			rejectedClosed++
+		if strings.Contains(err.Error(), "closed MockYaml") {
+			t.Fatalf("inserter #%d saw a 'closed MockYaml' error; the closed-gate must have been removed: %v", i, err)
+		}
+		if strings.Contains(err.Error(), "uniform per-testset format required") {
+			rejectedMixed++
 			continue
 		}
-		t.Fatalf("inserter #%d returned unexpected error: %v", i, o.err)
+		t.Fatalf("inserter #%d returned unexpected error: %v", i, err)
 	}
-	if succeeded+rejectedClosed != inserters {
-		t.Fatalf("outcome accounting mismatch: succeeded=%d rejectedClosed=%d total=%d want=%d",
-			succeeded, rejectedClosed, succeeded+rejectedClosed, inserters)
+	if succeeded+rejectedMixed != inserters {
+		t.Fatalf("outcome accounting mismatch: succeeded=%d rejectedMixed=%d total=%d want=%d",
+			succeeded, rejectedMixed, succeeded+rejectedMixed, inserters)
 	}
 
-	// After Close has returned, ys.closed must be true and any
-	// subsequent InsertMock on the same instance must also be
-	// rejected — confirming the gate is still set, not a transient
-	// window.
-	if !ys.closed.Load() {
-		t.Fatalf("expected ys.closed=true after Close returned")
-	}
-	if err := ys.InsertMock(context.Background(), newHTTPMock("yaml"), testSetID); err == nil {
-		t.Fatalf("post-Close InsertMock should have been rejected")
-	} else if !strings.Contains(err.Error(), "closed MockYaml") {
-		t.Fatalf("post-Close InsertMock returned unexpected error: %v", err)
+	// Close is re-entrant: a post-Close InsertMock on the same
+	// instance must succeed (the re-record flow relies on this).
+	if err := ys.InsertMock(context.Background(), newHTTPMock("yaml"), testSetID); err != nil {
+		t.Fatalf("post-Close InsertMock must succeed (re-record flow): %v", err)
 	}
 
 	// On-disk invariant: the testset directory must contain at most
 	// one of mocks.gob or mocks.yaml. Mixed state is the bug the
-	// fix prevents.
+	// drain-before-clear ordering prevents, and is the only hard
+	// correctness signal in this test.
 	tsDir := filepath.Join(dir, testSetID)
 	_, yamlStatErr := os.Stat(filepath.Join(tsDir, "mocks.yaml"))
 	_, gobStatErr := os.Stat(filepath.Join(tsDir, "mocks.gob"))

--- a/pkg/platform/yaml/mockdb/per_mock_format_test.go
+++ b/pkg/platform/yaml/mockdb/per_mock_format_test.go
@@ -312,6 +312,81 @@ func TestInsertMock_RejectsMixedFormat(t *testing.T) {
 	})
 }
 
+// TestInsertMock_UnknownFormatHonorsLockedTestset covers the
+// three-step lock-aware fallback in InsertMock: an unrecognised
+// per-mock Format ("gbo" typo, stale value, anything that is not
+// "yaml" or "gob") must inherit the testset's already-locked format
+// rather than bounce off the mixed-format guard via the process
+// default.
+//
+// Scenario: process default is gob (simulating a run with
+// KEPLOY_MOCK_FORMAT=gob), but the first InsertMock for testSetID
+// "t1" explicitly asks for yaml — locking t1 to yaml. A follow-up
+// InsertMock with Format="gbo" (typo) would, under the old
+// resolveMockFormat-only policy, route to the process default (gob)
+// and be rejected by the mixed-format guard, dropping the mock. The
+// lock-aware policy routes it to the locked format instead and
+// appends cleanly into mocks.yaml, preserving the recording.
+func TestInsertMock_UnknownFormatHonorsLockedTestset(t *testing.T) {
+	// Guard against pollution from sibling tests.
+	prev := configuredMockFormat
+	t.Cleanup(func() { SetConfiguredMockFormat(prev) })
+	SetConfiguredMockFormat("")
+	// Process default = gob for the duration of this test. Env var
+	// wins over configuredMockFormat in useGobMockFormat so this is
+	// the most reliable knob.
+	t.Setenv("KEPLOY_MOCK_FORMAT", "gob")
+
+	dir := t.TempDir()
+	ys := New(zap.NewNop(), dir, "mocks")
+	t.Cleanup(func() {
+		if err := ys.Close(); err != nil {
+			t.Errorf("deferred Close: %v", err)
+		}
+	})
+
+	// Mock 1: explicit yaml into t1. Locks t1=yaml in the sync.Map.
+	mock1 := newHTTPMock("yaml")
+	if err := ys.InsertMock(context.Background(), mock1, "t1"); err != nil {
+		t.Fatalf("first InsertMock (yaml): %v", err)
+	}
+
+	// Mock 2: typo'd "gbo". Under the old policy this would resolve
+	// to useGobMockFormat()=true (because env is gob) and the
+	// LoadOrStore-check would reject it as mixed-format. The new
+	// policy sees the unknown value, consults the lock (yaml), and
+	// routes the mock into the yaml file.
+	mock2 := newHTTPMock("gbo")
+	if err := ys.InsertMock(context.Background(), mock2, "t1"); err != nil {
+		t.Fatalf("second InsertMock (gbo typo) should have inherited the yaml lock, got error: %v", err)
+	}
+
+	// mocks.yaml must exist and contain BOTH mock names. mocks.gob
+	// must not have been created.
+	yamlPath := filepath.Join(dir, "t1", "mocks.yaml")
+	gobPath := filepath.Join(dir, "t1", "mocks.gob")
+	if _, err := os.Stat(gobPath); err == nil {
+		t.Fatalf("mocks.gob was created despite the testset being yaml-locked")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("unexpected error statting %s: %v", gobPath, err)
+	}
+	raw, err := os.ReadFile(yamlPath)
+	if err != nil {
+		t.Fatalf("read mocks.yaml: %v", err)
+	}
+	body := string(raw)
+	// Both mocks were auto-assigned sequential names via getNextID
+	// starting at 0. Assert both show up in the wire bytes so a
+	// regression that silently drops mock2 (or routes it elsewhere)
+	// would be caught.
+	if !strings.Contains(body, "mock-0") {
+		t.Fatalf("mocks.yaml missing mock-0:\n%s", body)
+	}
+	if !strings.Contains(body, "mock-1") {
+		t.Fatalf("mocks.yaml missing mock-1 (typo'd Format likely dropped):\n%s", body)
+	}
+}
+
 // TestInsertMock_RaceFreeMixedFormatGuard exercises the race window
 // that the on-disk os.Stat check alone cannot close: the gob writer
 // is asynchronous, so InsertMock(gob) enqueues a job and returns

--- a/pkg/platform/yaml/mockdb/per_mock_format_test.go
+++ b/pkg/platform/yaml/mockdb/per_mock_format_test.go
@@ -40,6 +40,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"go.keploy.io/server/v3/pkg/models"
@@ -452,5 +453,200 @@ func TestInsertMock_RaceFreeMixedFormatGuard(t *testing.T) {
 		t.Fatalf("mocks.yaml was created despite the race-free mixed-format rejection")
 	} else if !os.IsNotExist(statErr) {
 		t.Fatalf("unexpected error statting %s: %v", yamlPath, statErr)
+	}
+}
+
+// TestInsertMock_UnknownFormatRaceWithExplicit covers the concurrency
+// fix in the unknown-format branch of InsertMock: if a goroutine with
+// an unrecognised Format ("gbo" typo) reads the testset lock BEFORE
+// a racing goroutine with an explicit opposite format stores its
+// claim, the unknown-format goroutine must still end up writing into
+// whatever format the winner stored, not the process default. The
+// fix resolves the branch with a single atomic LoadOrStore so the
+// returned value is authoritative regardless of schedule.
+//
+// Scenario: process default = gob. Goroutine A calls
+// InsertMock(Format="yaml", t1); goroutine B calls
+// InsertMock(Format="gbo", t1). Both run concurrently. Whichever
+// goroutine enters the LoadOrStore first claims the lock for the
+// whole testset, and the other goroutine adopts it. With the fix,
+// "gbo" inherits "yaml" (if A won) or A's explicit "yaml" finds the
+// testset already locked to the process default gob (if B won) and
+// fails loudly with the mixed-format guard — but it never silently
+// writes the wrong file.
+//
+// We assert the SCHEDULE-INDEPENDENT invariant: at most one file
+// format is ever created, and at least one mock is present. When A
+// wins, both mocks appear in mocks.yaml. When B wins, A's explicit
+// yaml is rejected and only B's mock lands in mocks.gob. Running
+// this test with `go test -race` verifies the absence of a data
+// race around the unknown-format branch.
+func TestInsertMock_UnknownFormatRaceWithExplicit(t *testing.T) {
+	// Guard against pollution from sibling tests.
+	prev := configuredMockFormat
+	t.Cleanup(func() { SetConfiguredMockFormat(prev) })
+	SetConfiguredMockFormat("")
+	// Process default = gob so a stale read in the unknown-format
+	// branch would resolve to writeGob=true and fall foul of the
+	// mixed-format guard against a yaml-locked testset. That is the
+	// race the fix closes.
+	t.Setenv("KEPLOY_MOCK_FORMAT", "gob")
+
+	dir := t.TempDir()
+	ys := New(zap.NewNop(), dir, "mocks")
+	t.Cleanup(func() {
+		if err := ys.Close(); err != nil {
+			t.Errorf("deferred Close: %v", err)
+		}
+	})
+
+	var start sync.WaitGroup
+	var done sync.WaitGroup
+	start.Add(1)
+	done.Add(2)
+
+	var errA, errB error
+	go func() {
+		defer done.Done()
+		start.Wait()
+		errA = ys.InsertMock(context.Background(), newHTTPMock("yaml"), "t1")
+	}()
+	go func() {
+		defer done.Done()
+		start.Wait()
+		errB = ys.InsertMock(context.Background(), newHTTPMock("gbo"), "t1")
+	}()
+	start.Done()
+	done.Wait()
+
+	// Drain the async gob writer so the on-disk state is final
+	// before we assert. Without this Close a gob-winner outcome
+	// would fail the test because insertMockGob only enqueues — the
+	// file is not yet visible to os.Stat until the writer flushes.
+	if err := ys.Close(); err != nil {
+		t.Fatalf("Close to drain async writer: %v", err)
+	}
+
+	yamlPath := filepath.Join(dir, "t1", "mocks.yaml")
+	gobPath := filepath.Join(dir, "t1", "mocks.gob")
+	_, yamlStatErr := os.Stat(yamlPath)
+	_, gobStatErr := os.Stat(gobPath)
+	haveYaml := yamlStatErr == nil
+	haveGob := gobStatErr == nil
+
+	// Exactly one format file must have been created. The whole
+	// point of the fix is to prevent the two branches from racing
+	// into different files.
+	if haveYaml && haveGob {
+		t.Fatalf("both mocks.yaml and mocks.gob present — race fix regressed (errA=%v errB=%v)", errA, errB)
+	}
+	if !haveYaml && !haveGob {
+		t.Fatalf("no mock file created (errA=%v errB=%v)", errA, errB)
+	}
+
+	// Classify outcomes by which goroutine won the lock:
+	//
+	// - yaml won (A entered LoadOrStore first or B adopted yaml):
+	//   both InsertMock calls should have succeeded, and both
+	//   mock-0/mock-1 names should be in mocks.yaml.
+	// - gob won (B adopted process-default gob before A got there):
+	//   A's explicit yaml must have been rejected by the
+	//   mixed-format guard; only B's mock lands in mocks.gob.
+	switch {
+	case haveYaml:
+		if errA != nil {
+			t.Fatalf("yaml-locked outcome but goroutine A (explicit yaml) failed: %v", errA)
+		}
+		if errB != nil {
+			t.Fatalf("yaml-locked outcome but goroutine B (gbo inherit) failed: %v", errB)
+		}
+		raw, err := os.ReadFile(yamlPath)
+		if err != nil {
+			t.Fatalf("read mocks.yaml: %v", err)
+		}
+		body := string(raw)
+		if !strings.Contains(body, "mock-0") || !strings.Contains(body, "mock-1") {
+			t.Fatalf("both goroutines claim success but mocks.yaml is missing an entry:\n%s", body)
+		}
+	case haveGob:
+		// B's "gbo" inherited the process-default gob via the
+		// atomic LoadOrStore and succeeded. A's explicit yaml
+		// must have hit the mixed-format guard.
+		if errB != nil {
+			t.Fatalf("gob-locked outcome but goroutine B (gbo -> gob) failed: %v", errB)
+		}
+		if errA == nil {
+			t.Fatalf("gob-locked outcome but goroutine A (explicit yaml) unexpectedly succeeded")
+		}
+		if !strings.Contains(errA.Error(), "uniform per-testset format required") {
+			t.Fatalf("goroutine A error did not match mixed-format guard: %v", errA)
+		}
+	}
+}
+
+// TestInsertMock_RehydrateAfterDelete covers the stale-lock drop in
+// DeleteMocksForSet: once an earlier InsertMock has claimed a
+// format lock for a testset and DeleteMocksForSet subsequently
+// clears the on-disk files, the in-memory format lock must be
+// cleared too so a follow-up InsertMock with a different format
+// can pick its own format rather than bouncing off the stale
+// lock with the mixed-format guard. Before the fix the re-record
+// flow would silently reject any format change on the second run
+// even though the directory was empty.
+func TestInsertMock_RehydrateAfterDelete(t *testing.T) {
+	prev := configuredMockFormat
+	t.Cleanup(func() { SetConfiguredMockFormat(prev) })
+	SetConfiguredMockFormat("")
+	t.Setenv("KEPLOY_MOCK_FORMAT", "")
+
+	dir := t.TempDir()
+	ys := New(zap.NewNop(), dir, "mocks")
+	t.Cleanup(func() {
+		if err := ys.Close(); err != nil {
+			t.Errorf("deferred Close: %v", err)
+		}
+	})
+
+	// First insert locks the testset to yaml on disk.
+	if err := ys.InsertMock(context.Background(), newHTTPMock("yaml"), "t1"); err != nil {
+		t.Fatalf("first InsertMock (yaml): %v", err)
+	}
+	yamlPath := filepath.Join(dir, "t1", "mocks.yaml")
+	if _, err := os.Stat(yamlPath); err != nil {
+		t.Fatalf("precondition: mocks.yaml must exist after first InsertMock: %v", err)
+	}
+
+	// DeleteMocksForSet is the ordinary refresh path between
+	// recording runs: it clears both file variants and MUST also
+	// clear the per-testSetID in-memory format lock so the next
+	// InsertMock can freely pick its own format.
+	if err := ys.DeleteMocksForSet(context.Background(), "t1"); err != nil {
+		t.Fatalf("DeleteMocksForSet: %v", err)
+	}
+	if _, err := os.Stat(yamlPath); err == nil {
+		t.Fatalf("mocks.yaml still present after DeleteMocksForSet")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("unexpected error statting %s: %v", yamlPath, err)
+	}
+
+	// Second insert with the opposite format must succeed now that
+	// the stale lock is cleared. Before the fix this call would
+	// bounce off the in-memory lock with the mixed-format error
+	// even though no files remain on disk.
+	if err := ys.InsertMock(context.Background(), newHTTPMock("gob"), "t1"); err != nil {
+		t.Fatalf("InsertMock(gob) after DeleteMocksForSet should have succeeded, got: %v", err)
+	}
+
+	// Drain the async gob writer so the file is on disk before we
+	// assert on its presence.
+	if err := ys.Close(); err != nil {
+		t.Fatalf("Close after rehydrate: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "t1", "mocks.gob")); err != nil {
+		t.Fatalf("mocks.gob must exist after rehydrated insert: %v", err)
+	}
+	if _, err := os.Stat(yamlPath); err == nil {
+		t.Fatalf("stale mocks.yaml resurfaced after rehydrated insert")
 	}
 }

--- a/pkg/platform/yaml/mockdb/per_mock_format_test.go
+++ b/pkg/platform/yaml/mockdb/per_mock_format_test.go
@@ -1,20 +1,38 @@
-// Table-driven coverage for the per-mock Format override (task #225 /
-// DaemonSet Phase 0 per-session mock format). Three cases:
+// Coverage for the per-mock Format override (task #225 / DaemonSet
+// Phase 0 per-session mock format) and its mixed-format guard. Tests:
 //
-//  1. Empty Format field falls back to the testset-level format (yaml
-//     here, exercised with a fresh MockYaml that was not configured
-//     for gob). The mock lands in mocks.yaml and carries no Format
-//     on disk.
+//  1. TestPerMockFormat_RouteSelection — table-driven InsertMock
+//     routing: empty Format falls back to the testset-level format
+//     (yaml for the fixture), explicit "yaml" matches the default,
+//     "gob" routes a single mock to mocks.gob, and an unknown value
+//     ("xml") falls through to the testset default rather than
+//     erroring, which is what unblocks multi-session DS flows.
 //
-//  2. A per-mock Format="gob" override routes one mock to mocks.gob
-//     even though the testset-level format is yaml — this is the case
-//     that unblocks multi-session DS (one session writing gob while
-//     another writes yaml into a sibling test-set directory).
+//  2. TestPerMockFormat_WireRoundTrip — encode/decode preservation
+//     of the Format field through the EncodeMock -> yaml.Marshal ->
+//     yaml.Unmarshal -> DecodeMocks path, including byte-level
+//     omitempty checks on the `format:` line. Pure function test,
+//     no filesystem.
 //
-//  3. Round-trip preserves the field: encode a mock with Format set
-//     through the platform/yaml EncodeMock -> DecodeMocks path and
-//     assert the field survives the wire-format hop. (Pure function
-//     test, no filesystem.)
+//  3. TestPerMockFormat_DeepCopyPreserves — regression guard that
+//     models.Mock.DeepCopy carries the Format field through, so the
+//     async gob writer's deep-copy-before-enqueue step cannot drop
+//     the override mid-flight.
+//
+//  4. TestInsertMock_RejectsMixedFormat — both directions (yaml then
+//     gob, gob then yaml) of the single-testset-one-format contract.
+//     Read/prune paths prefer mocks.gob by file presence and never
+//     merge a sibling mocks.yaml, so InsertMock must reject the
+//     second-format write; the assertion covers both the error
+//     message and that no sibling file was created.
+//
+//  5. TestInsertMock_RaceFreeMixedFormatGuard — race-window coverage
+//     for the in-process guard: a gob InsertMock enqueues to the
+//     async writer without waiting for gobReopenLocked to create
+//     mocks.gob on disk, and an immediately-following yaml InsertMock
+//     in the same goroutine must still be rejected by the in-memory
+//     per-testSetID format map rather than racing the async file
+//     creation.
 package mockdb
 
 import (
@@ -272,11 +290,12 @@ func TestInsertMock_RejectsMixedFormat(t *testing.T) {
 		if err := ys.InsertMock(context.Background(), newHTTPMock("gob"), "set-0"); err != nil {
 			t.Fatalf("first InsertMock (gob): %v", err)
 		}
-		// The gob writer is async: InsertMock returns after enqueue
-		// but before gobReopenLocked has actually created mocks.gob
-		// on disk. Close() drains the queue + flushes the file, so
-		// the subsequent stat-based rejection is deterministic.
-		// Pre-close races were possible without this step.
+		// Close() drains the async gob writer so the file is
+		// present on disk for this variant. The race-free
+		// in-memory guard (sync.Map in MockYaml) would catch the
+		// rejection even without this Close — see
+		// TestInsertMock_RaceFreeMixedFormatGuard — but draining
+		// here exercises the on-disk side of the guard too.
 		if err := ys.Close(); err != nil {
 			t.Fatalf("Close after gob insert: %v", err)
 		}
@@ -291,4 +310,72 @@ func TestInsertMock_RejectsMixedFormat(t *testing.T) {
 			t.Fatalf("mocks.yaml was created despite the mixed-format rejection")
 		}
 	})
+}
+
+// TestInsertMock_RaceFreeMixedFormatGuard exercises the race window
+// that the on-disk os.Stat check alone cannot close: the gob writer
+// is asynchronous, so InsertMock(gob) enqueues a job and returns
+// before gobReopenLocked has created mocks.gob on disk. A
+// tightly-following InsertMock(yaml) for the same testSetID in the
+// same goroutine must still be rejected — otherwise it would stat
+// mocks.gob, get ENOENT, and create mocks.yaml alongside the
+// still-queued gob write, at which point the readers (which prefer
+// mocks.gob by file presence) would silently drop the yaml mocks at
+// replay.
+//
+// The test deliberately does NOT call ys.Close() between the two
+// InsertMock calls. That would drain the gob writer and materialise
+// mocks.gob on disk, which would turn this into a cover of the
+// TestInsertMock_RejectsMixedFormat case. What we want here is the
+// intra-process, pre-flush window — the bug the in-memory sync.Map
+// guard in MockYaml was added for.
+func TestInsertMock_RaceFreeMixedFormatGuard(t *testing.T) {
+	// Guard against pollution from sibling tests.
+	prev := configuredMockFormat
+	t.Cleanup(func() { SetConfiguredMockFormat(prev) })
+	SetConfiguredMockFormat("")
+	t.Setenv("KEPLOY_MOCK_FORMAT", "")
+
+	dir := t.TempDir()
+	ys := New(zap.NewNop(), dir, "mocks")
+	// Drain the writer at the end of the test so the goroutine and
+	// any open file descriptors are released even though the test
+	// itself deliberately does not invoke Close mid-flight.
+	t.Cleanup(func() {
+		if err := ys.Close(); err != nil {
+			t.Errorf("deferred Close: %v", err)
+		}
+	})
+
+	// First insert: gob. The async writer may or may not have run
+	// the creation side by the time InsertMock returns — the point
+	// is that the subsequent yaml insert must be rejected either
+	// way, and crucially in the "writer hasn't flushed yet" slice
+	// of that either-way.
+	if err := ys.InsertMock(context.Background(), newHTTPMock("gob"), "set-0"); err != nil {
+		t.Fatalf("first InsertMock (gob): %v", err)
+	}
+
+	// Second insert: yaml, same testSetID, same goroutine, no
+	// Close() in between. With only the os.Stat guard in place this
+	// call could observe ENOENT on mocks.gob and proceed to create
+	// mocks.yaml. The in-memory sync.Map guard catches it
+	// deterministically.
+	err := ys.InsertMock(context.Background(), newHTTPMock("yaml"), "set-0")
+	if err == nil {
+		t.Fatalf("expected InsertMock(yaml) to fail after same-testset gob insert, got nil")
+	}
+	if !strings.Contains(err.Error(), "uniform per-testset format required") {
+		t.Fatalf("error message missing uniform-format hint: %v", err)
+	}
+
+	// Crucially: mocks.yaml must not have been created by the
+	// rejected call. Check before Close so a late writer flush
+	// cannot mask a buggy write path.
+	yamlPath := filepath.Join(dir, "set-0", "mocks.yaml")
+	if _, statErr := os.Stat(yamlPath); statErr == nil {
+		t.Fatalf("mocks.yaml was created despite the race-free mixed-format rejection")
+	} else if !os.IsNotExist(statErr) {
+		t.Fatalf("unexpected error statting %s: %v", yamlPath, statErr)
+	}
 }

--- a/pkg/platform/yaml/mockdb/per_mock_format_test.go
+++ b/pkg/platform/yaml/mockdb/per_mock_format_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"go.keploy.io/server/v3/pkg/models"
@@ -203,4 +204,69 @@ func TestPerMockFormat_DeepCopyPreserves(t *testing.T) {
 	if out.Format != "gob" {
 		t.Fatalf("DeepCopy dropped Format: got %q", out.Format)
 	}
+}
+
+// TestInsertMock_RejectsMixedFormat guards the read/prune-side
+// contract: GetFilteredMocks / GetUnFilteredMocks / UpdateMocks prefer
+// mocks.gob over mocks.yaml by file presence and never merge the two.
+// InsertMock therefore must refuse to create a second file in a
+// different format once one format's file already exists in the
+// test-set directory — otherwise the yaml mocks would be silently
+// ignored at replay. Both directions are covered: yaml-then-gob and
+// gob-then-yaml.
+func TestInsertMock_RejectsMixedFormat(t *testing.T) {
+	// Guard against pollution from sibling tests.
+	prev := configuredMockFormat
+	t.Cleanup(func() { SetConfiguredMockFormat(prev) })
+	SetConfiguredMockFormat("")
+	t.Setenv("KEPLOY_MOCK_FORMAT", "")
+
+	t.Run("yaml first, then gob is rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		ys := New(zap.NewNop(), dir, "mocks")
+		if err := ys.InsertMock(context.Background(), newHTTPMock("yaml"), "set-0"); err != nil {
+			t.Fatalf("first InsertMock (yaml): %v", err)
+		}
+		err := ys.InsertMock(context.Background(), newHTTPMock("gob"), "set-0")
+		if err == nil {
+			t.Fatalf("expected InsertMock(gob) to fail after yaml file present, got nil")
+		}
+		if !strings.Contains(err.Error(), "uniform per-testset format required") {
+			t.Fatalf("error message missing uniform-format hint: %v", err)
+		}
+		// The rejected write must not have produced a sibling file.
+		if _, statErr := os.Stat(filepath.Join(dir, "set-0", "mocks.gob")); statErr == nil {
+			t.Fatalf("mocks.gob was created despite the mixed-format rejection")
+		}
+		// Clean up any async writer state (no-op for yaml path).
+		if err := ys.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	})
+
+	t.Run("gob first, then yaml is rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		ys := New(zap.NewNop(), dir, "mocks")
+		if err := ys.InsertMock(context.Background(), newHTTPMock("gob"), "set-0"); err != nil {
+			t.Fatalf("first InsertMock (gob): %v", err)
+		}
+		// The gob writer is async: InsertMock returns after enqueue
+		// but before gobReopenLocked has actually created mocks.gob
+		// on disk. Close() drains the queue + flushes the file, so
+		// the subsequent stat-based rejection is deterministic.
+		// Pre-close races were possible without this step.
+		if err := ys.Close(); err != nil {
+			t.Fatalf("Close after gob insert: %v", err)
+		}
+		err := ys.InsertMock(context.Background(), newHTTPMock("yaml"), "set-0")
+		if err == nil {
+			t.Fatalf("expected InsertMock(yaml) to fail after gob file present, got nil")
+		}
+		if !strings.Contains(err.Error(), "uniform per-testset format required") {
+			t.Fatalf("error message missing uniform-format hint: %v", err)
+		}
+		if _, statErr := os.Stat(filepath.Join(dir, "set-0", "mocks.yaml")); statErr == nil {
+			t.Fatalf("mocks.yaml was created despite the mixed-format rejection")
+		}
+	})
 }

--- a/pkg/platform/yaml/mockdb/per_mock_format_test.go
+++ b/pkg/platform/yaml/mockdb/per_mock_format_test.go
@@ -1,0 +1,206 @@
+// Table-driven coverage for the per-mock Format override (task #225 /
+// DaemonSet Phase 0 per-session mock format). Three cases:
+//
+//  1. Empty Format field falls back to the testset-level format (yaml
+//     here, exercised with a fresh MockYaml that was not configured
+//     for gob). The mock lands in mocks.yaml and carries no Format
+//     on disk.
+//
+//  2. A per-mock Format="gob" override routes one mock to mocks.gob
+//     even though the testset-level format is yaml — this is the case
+//     that unblocks multi-session DS (one session writing gob while
+//     another writes yaml into a sibling test-set directory).
+//
+//  3. Round-trip preserves the field: encode a mock with Format set
+//     through the platform/yaml EncodeMock -> DecodeMocks path and
+//     assert the field survives the wire-format hop. (Pure function
+//     test, no filesystem.)
+package mockdb
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.keploy.io/server/v3/pkg/platform/yaml"
+	"go.uber.org/zap"
+	yamlLib "gopkg.in/yaml.v3"
+)
+
+// newHTTPMock builds a minimal valid HTTP mock so the encode path has a
+// non-empty spec to serialise. The specific payload is unimportant for
+// these tests — the only field under inspection is Format.
+func newHTTPMock(format string) *models.Mock {
+	return &models.Mock{
+		Version: "api.keploy.io/v1beta1",
+		Kind:    models.HTTP,
+		Format:  format,
+		Spec: models.MockSpec{
+			Metadata: map[string]string{"src": "per-mock-format-test"},
+			HTTPReq: &models.HTTPReq{
+				Method: "GET", URL: "http://example/x",
+				ProtoMajor: 1, ProtoMinor: 1,
+				Header: map[string]string{},
+			},
+			HTTPResp: &models.HTTPResp{
+				StatusCode: 200,
+				Header:     map[string]string{},
+			},
+		},
+	}
+}
+
+// TestPerMockFormat_RouteSelection covers the InsertMock routing logic:
+// the configured-default path vs a per-mock override. The process-wide
+// toggle (KEPLOY_MOCK_FORMAT / configuredMockFormat) is left unset so
+// "testset-level format" defaults to yaml for the fixture.
+func TestPerMockFormat_RouteSelection(t *testing.T) {
+	// Guard against pollution from other tests in this package that
+	// may have set configuredMockFormat; restore on exit.
+	prev := configuredMockFormat
+	t.Cleanup(func() { SetConfiguredMockFormat(prev) })
+	SetConfiguredMockFormat("")
+	// Also clear any env var inherited from the shell so we really
+	// start with "testset default = yaml".
+	t.Setenv("KEPLOY_MOCK_FORMAT", "")
+
+	type want struct {
+		yamlExists bool
+		gobExists  bool
+	}
+	cases := []struct {
+		name   string
+		format string
+		want   want
+	}{
+		{
+			name:   "empty format falls back to testset default (yaml)",
+			format: "",
+			want:   want{yamlExists: true, gobExists: false},
+		},
+		{
+			name:   "explicit yaml override matches testset default (yaml)",
+			format: "yaml",
+			want:   want{yamlExists: true, gobExists: false},
+		},
+		{
+			name:   "gob override persists to mocks.gob",
+			format: "gob",
+			want:   want{yamlExists: false, gobExists: true},
+		},
+		{
+			name:   "unknown value falls through to testset default (yaml)",
+			format: "xml",
+			want:   want{yamlExists: true, gobExists: false},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			ys := New(zap.NewNop(), dir, "mocks")
+			mock := newHTTPMock(tc.format)
+			if err := ys.InsertMock(context.Background(), mock, "set-0"); err != nil {
+				t.Fatalf("InsertMock: %v", err)
+			}
+			// Close is a no-op for the yaml path, but it drains the
+			// async gob writer when the gob branch fired. Call it
+			// unconditionally so the assertion below sees the fully
+			// flushed filesystem state.
+			if err := ys.Close(); err != nil {
+				t.Fatalf("Close: %v", err)
+			}
+
+			yamlPath := filepath.Join(dir, "set-0", "mocks.yaml")
+			gobPath := filepath.Join(dir, "set-0", "mocks.gob")
+			yamlInfo, yamlErr := os.Stat(yamlPath)
+			gobInfo, gobErr := os.Stat(gobPath)
+			haveYaml := yamlErr == nil && yamlInfo.Size() > 0
+			haveGob := gobErr == nil && gobInfo.Size() > 0
+
+			if haveYaml != tc.want.yamlExists {
+				t.Fatalf("yaml file presence mismatch: got %v want %v (err=%v)",
+					haveYaml, tc.want.yamlExists, yamlErr)
+			}
+			if haveGob != tc.want.gobExists {
+				t.Fatalf("gob file presence mismatch: got %v want %v (err=%v)",
+					haveGob, tc.want.gobExists, gobErr)
+			}
+		})
+	}
+}
+
+// TestPerMockFormat_WireRoundTrip asserts that the Format field round-
+// trips through the wire format unchanged. This is the contract that
+// makes the read-side of the DS multi-session scenario work: mocks
+// written with Format=gob must come back with Format=gob so the
+// writer side can preserve the override on any subsequent re-write
+// (e.g. UpdateMocks' prune-and-rewrite flow).
+func TestPerMockFormat_WireRoundTrip(t *testing.T) {
+	cases := []struct {
+		name   string
+		format string
+	}{
+		{name: "empty", format: ""},
+		{name: "yaml", format: "yaml"},
+		{name: "gob", format: "gob"},
+	}
+
+	logger := zap.NewNop()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := newHTTPMock(tc.format)
+			doc, err := EncodeMock(in, logger)
+			if err != nil {
+				t.Fatalf("EncodeMock: %v", err)
+			}
+			if doc.Format != tc.format {
+				t.Fatalf("EncodeMock did not carry Format: got %q want %q",
+					doc.Format, tc.format)
+			}
+			// Marshal + unmarshal through yaml.v3 so we also cover
+			// the omitempty serialisation behaviour (empty string
+			// must round-trip as empty, not as the literal "format: \"\"").
+			raw, err := yamlLib.Marshal(doc)
+			if err != nil {
+				t.Fatalf("yaml.Marshal doc: %v", err)
+			}
+			var back yaml.NetworkTrafficDoc
+			if err := yamlLib.Unmarshal(raw, &back); err != nil {
+				t.Fatalf("yaml.Unmarshal doc: %v", err)
+			}
+			if back.Format != tc.format {
+				t.Fatalf("wire round-trip Format mismatch: got %q want %q\nraw:\n%s",
+					back.Format, tc.format, string(raw))
+			}
+			// DecodeMocks rehydrates onto models.Mock.Format.
+			mocks, err := DecodeMocks([]*yaml.NetworkTrafficDoc{&back}, logger)
+			if err != nil {
+				t.Fatalf("DecodeMocks: %v", err)
+			}
+			if len(mocks) != 1 {
+				t.Fatalf("DecodeMocks: want 1 mock got %d", len(mocks))
+			}
+			if mocks[0].Format != tc.format {
+				t.Fatalf("DecodeMocks Format mismatch: got %q want %q",
+					mocks[0].Format, tc.format)
+			}
+		})
+	}
+}
+
+// TestPerMockFormat_DeepCopyPreserves is a regression guard for the
+// async gob writer path: insertMockGob deep-copies the mock before
+// enqueueing, and if DeepCopy dropped Format the writer would persist
+// mocks with an empty Format even though the caller set one. Two DS
+// sessions with different formats sharing a single mockdb instance
+// would then silently blend.
+func TestPerMockFormat_DeepCopyPreserves(t *testing.T) {
+	in := newHTTPMock("gob")
+	out := in.DeepCopy()
+	if out.Format != "gob" {
+		t.Fatalf("DeepCopy dropped Format: got %q", out.Format)
+	}
+}

--- a/pkg/platform/yaml/mockdb/per_mock_format_test.go
+++ b/pkg/platform/yaml/mockdb/per_mock_format_test.go
@@ -168,6 +168,28 @@ func TestPerMockFormat_WireRoundTrip(t *testing.T) {
 			if err != nil {
 				t.Fatalf("yaml.Marshal doc: %v", err)
 			}
+			// Byte-level omitempty guard: for an empty Format the
+			// wire bytes must not contain a "format:" line at all.
+			// A pure unmarshal round-trip would still yield back.Format
+			// == "" even if the marshal side emitted `format: ""`, so
+			// assert directly on the serialised bytes to catch a
+			// regression where the yaml tag loses its omitempty
+			// modifier. For non-empty formats the same bytes MUST
+			// carry a `format: <value>` line, which keeps the
+			// bidirectional contract explicit.
+			hasFormatLine := false
+			for _, line := range strings.Split(string(raw), "\n") {
+				if strings.HasPrefix(strings.TrimLeft(line, " \t"), "format:") {
+					hasFormatLine = true
+					break
+				}
+			}
+			if tc.format == "" && hasFormatLine {
+				t.Fatalf("empty Format emitted a format: line on the wire; omitempty regression:\n%s", string(raw))
+			}
+			if tc.format != "" && !hasFormatLine {
+				t.Fatalf("non-empty Format %q did not emit a format: line on the wire:\n%s", tc.format, string(raw))
+			}
 			var back yaml.NetworkTrafficDoc
 			if err := yamlLib.Unmarshal(raw, &back); err != nil {
 				t.Fatalf("yaml.Unmarshal doc: %v", err)

--- a/pkg/platform/yaml/mockdb/util.go
+++ b/pkg/platform/yaml/mockdb/util.go
@@ -22,6 +22,11 @@ func EncodeMock(mock *models.Mock, logger *zap.Logger) (*yaml.NetworkTrafficDoc,
 		Name:         mock.Name,
 		Noise:        mock.Noise,
 		ConnectionID: mock.ConnectionID,
+		// Carry the per-mock format override verbatim to the wire-format
+		// doc. Empty at the in-memory level means "use whatever mockdb
+		// was configured with"; we persist it as empty too via
+		// omitempty, so non-DS recordings remain byte-identical.
+		Format: mock.Format,
 	}
 	switch mock.Kind {
 	case models.Mongo:
@@ -281,6 +286,12 @@ func DecodeMocks(yamlMocks []*yaml.NetworkTrafficDoc, logger *zap.Logger) ([]*mo
 			Kind:         m.Kind,
 			Noise:        m.Noise,
 			ConnectionID: m.ConnectionID,
+			// Propagate the per-mock format back onto the in-memory
+			// Mock so callers can inspect it (e.g. UpdateMocks, which
+			// rewrites the file and must re-emit the same Format to
+			// survive round-trips). Empty here means "fall back to the
+			// testset-level format on re-write".
+			Format: m.Format,
 		}
 		mockCheck := strings.Split(string(m.Kind), "-")
 		if len(mockCheck) > 1 {

--- a/pkg/platform/yaml/yaml.go
+++ b/pkg/platform/yaml/yaml.go
@@ -38,6 +38,14 @@ type NetworkTrafficDoc struct {
 	LastUpdated  *models.LastUpdated `json:"last_updated,omitempty" yaml:"last_updated,omitempty"`
 	Curl         string              `json:"curl" yaml:"curl,omitempty"`
 	ConnectionID string              `json:"connectionId" yaml:"connectionId,omitempty"`
+	// Format is the per-mock on-disk format override carried verbatim
+	// from models.Mock.Format. Empty means "fall back to the testset-level
+	// format"; a non-empty value must be "yaml" or "gob". mockdb readers
+	// populate it back onto models.Mock.Format so one session can mix
+	// formats inside a single test-set directory (required by DaemonSet
+	// per-session mockFormat). Omitempty keeps the wire footprint of
+	// existing (non-DS) recordings unchanged.
+	Format string `json:"format,omitempty" yaml:"format,omitempty"`
 }
 
 // ctxReader wraps an io.Reader with a context for cancellation support

--- a/pkg/platform/yaml/yaml.go
+++ b/pkg/platform/yaml/yaml.go
@@ -41,15 +41,20 @@ type NetworkTrafficDoc struct {
 	// Format is the per-mock on-disk format override carried verbatim
 	// from models.Mock.Format. Empty means "fall back to the testset-level
 	// format"; recognized values are "yaml" or "gob". Any other non-empty
-	// value is treated as unset and falls back to the process-wide
-	// configured format (see mockdb.resolveMockFormat) — we prefer to preserve
-	// mocks over failing the write when a stale or typo'd format slips
-	// in. mockdb readers populate it back onto models.Mock.Format so
-	// formats can vary across mocks recorded in different test-set
-	// directories or sessions (required by DaemonSet per-session
-	// mockFormat), but each individual test-set directory must remain
-	// single-format. Omitempty keeps the wire footprint of existing
-	// (non-DS) recordings unchanged.
+	// value is treated as unset and resolved by InsertMock's three-step
+	// policy: (1) recognized per-mock value wins, else (2) if the
+	// testset is already locked to a format (from an earlier InsertMock
+	// or an on-disk file), inherit that lock, else (3) fall back to the
+	// process-wide configured format. That three-step shape lets a
+	// stale or typo'd value inherit the testset's already-claimed
+	// format instead of bouncing off the mixed-format guard — we
+	// prefer to preserve mocks over failing the write. mockdb readers
+	// populate it back onto models.Mock.Format so formats can vary
+	// across mocks recorded in different test-set directories or
+	// sessions (required by DaemonSet per-session mockFormat), but each
+	// individual test-set directory must remain single-format.
+	// Omitempty keeps the wire footprint of existing (non-DS)
+	// recordings unchanged.
 	Format string `json:"format,omitempty" yaml:"format,omitempty"`
 }
 

--- a/pkg/platform/yaml/yaml.go
+++ b/pkg/platform/yaml/yaml.go
@@ -42,7 +42,7 @@ type NetworkTrafficDoc struct {
 	// from models.Mock.Format. Empty means "fall back to the testset-level
 	// format"; recognized values are "yaml" or "gob". Any other non-empty
 	// value is treated as unset and falls back to the process-wide
-	// configured format (see resolveMockFormat) — we prefer to preserve
+	// configured format (see mockdb.resolveMockFormat) — we prefer to preserve
 	// mocks over failing the write when a stale or typo'd format slips
 	// in. mockdb readers populate it back onto models.Mock.Format so
 	// formats can vary across mocks recorded in different test-set

--- a/pkg/platform/yaml/yaml.go
+++ b/pkg/platform/yaml/yaml.go
@@ -38,23 +38,20 @@ type NetworkTrafficDoc struct {
 	LastUpdated  *models.LastUpdated `json:"last_updated,omitempty" yaml:"last_updated,omitempty"`
 	Curl         string              `json:"curl" yaml:"curl,omitempty"`
 	ConnectionID string              `json:"connectionId" yaml:"connectionId,omitempty"`
-	// Format is the per-mock on-disk format override carried verbatim
-	// from models.Mock.Format. Empty means "fall back to the testset-level
-	// format"; recognized values are "yaml" or "gob". Any other non-empty
-	// value is treated as unset and resolved by InsertMock's three-step
-	// policy: (1) recognized per-mock value wins, else (2) if the
-	// testset is already locked to a format (from an earlier InsertMock
-	// or an on-disk file), inherit that lock, else (3) fall back to the
-	// process-wide configured format. That three-step shape lets a
-	// stale or typo'd value inherit the testset's already-claimed
-	// format instead of bouncing off the mixed-format guard — we
-	// prefer to preserve mocks over failing the write. mockdb readers
-	// populate it back onto models.Mock.Format so formats can vary
-	// across mocks recorded in different test-set directories or
-	// sessions (required by DaemonSet per-session mockFormat), but each
-	// individual test-set directory must remain single-format.
-	// Omitempty keeps the wire footprint of existing (non-DS)
-	// recordings unchanged.
+	// Format, when non-empty, overrides the process-wide configured
+	// on-disk format ("gob" or "yaml") for this specific mock.
+	// Recognized values are "gob" and "yaml"; any other non-empty
+	// value is treated as unset ONLY for InsertMock's three-step
+	// routing decision (recognized value → locked testset format →
+	// process default). The field itself is carried verbatim through
+	// EncodeMock / DecodeMocks, so unknown non-empty values may still
+	// round-trip on disk — they just do not influence the on-disk
+	// format choice. mockdb readers populate it back onto
+	// models.Mock.Format so formats can vary across mocks recorded in
+	// different test-set directories or sessions (required by
+	// DaemonSet per-session mockFormat), but each individual test-set
+	// directory must remain single-format. Omitempty keeps the wire
+	// footprint of existing (non-DS) recordings unchanged.
 	Format string `json:"format,omitempty" yaml:"format,omitempty"`
 }
 

--- a/pkg/platform/yaml/yaml.go
+++ b/pkg/platform/yaml/yaml.go
@@ -40,11 +40,16 @@ type NetworkTrafficDoc struct {
 	ConnectionID string              `json:"connectionId" yaml:"connectionId,omitempty"`
 	// Format is the per-mock on-disk format override carried verbatim
 	// from models.Mock.Format. Empty means "fall back to the testset-level
-	// format"; a non-empty value must be "yaml" or "gob". mockdb readers
-	// populate it back onto models.Mock.Format so one session can mix
-	// formats inside a single test-set directory (required by DaemonSet
-	// per-session mockFormat). Omitempty keeps the wire footprint of
-	// existing (non-DS) recordings unchanged.
+	// format"; recognized values are "yaml" or "gob". Any other non-empty
+	// value is treated as unset and falls back to the process-wide
+	// configured format (see resolveMockFormat) — we prefer to preserve
+	// mocks over failing the write when a stale or typo'd format slips
+	// in. mockdb readers populate it back onto models.Mock.Format so
+	// formats can vary across mocks recorded in different test-set
+	// directories or sessions (required by DaemonSet per-session
+	// mockFormat), but each individual test-set directory must remain
+	// single-format. Omitempty keeps the wire footprint of existing
+	// (non-DS) recordings unchanged.
 	Format string `json:"format,omitempty" yaml:"format,omitempty"`
 }
 


### PR DESCRIPTION
## Summary
Adds a `Format` field to `models.Mock` and `yaml.NetworkTrafficDoc` so individual mocks can override the test-set-level format (`yaml` vs `gob`). Preserves round-trip through encode/decode + DeepCopy. With `omitempty`, existing recordings remain byte-identical on the wire.

This is a dependency for the Keploy DaemonSet per-session mock format slice (#225) — the DS agent needs to write mocks with per-session format semantics rather than the one-format-per-test-set default.

## Slice
Supports DaemonSet rollout at keploy/enterprise#1877 (slice #225).

## Test plan
- [ ] `go test ./pkg/models/... ./pkg/platform/yaml/mockdb/...`
- [ ] New `TestPerMockFormat_RouteSelection`, `TestPerMockFormat_WireRoundTrip`, `TestPerMockFormat_DeepCopyPreserves`
- [ ] Existing mocks on disk (no `format` key) still decode with the test-set default
- [ ] `gob` per-mock + `yaml` default route correctly through `InsertMock`