### PR TITLE
ci: prevent workflows from failing on fork pushes to main

### DIFF
--- a/.github/workflows/golang_docker.yml
+++ b/.github/workflows/golang_docker.yml
@@ -8,7 +8,7 @@ on:
         type: string
 jobs:
   golang_docker:
-    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.repository == 'keploy/keploy' && github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/golang_linux.yml
+++ b/.github/workflows/golang_linux.yml
@@ -98,7 +98,7 @@ jobs:
           source $GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/golang/${{ matrix.app.script_dir }}/golang-linux.sh
 
   golang_linux_private:
-    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.repository == 'keploy/keploy' && github.ref == 'refs/heads/main') }}
     runs-on: ${{ inputs.runner }}
     strategy:
       fail-fast: false

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -38,14 +38,14 @@ jobs:
           fi    
       
       - name: Add Private Parsers
-        if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+        if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.repository == 'keploy/keploy' && github.ref == 'refs/heads/main') }}
         uses: ./.github/actions/setup-private-parsers
         with:
           ssh-private-key: ${{ secrets.INTEGRATIONS_REPO_DEPLOY_KEY_PRIVATE }}
           go-cache: true
 
       - name: Configure Git to use SSH
-        if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+        if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.repository == 'keploy/keploy' && github.ref == 'refs/heads/main') }}
         run: git config --global url."git@github.com:".insteadOf "https://github.com/"
 
       - name: golangci-lint
@@ -64,7 +64,7 @@ jobs:
           fi
 
       - name: Check for Deprecated Dependencies
-        if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+        if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.repository == 'keploy/keploy' && github.ref == 'refs/heads/main') }}
         env:
           GOPRIVATE: github.com/keploy/*
         run: |

--- a/.github/workflows/grpc_linux.yml
+++ b/.github/workflows/grpc_linux.yml
@@ -9,7 +9,7 @@ on:
         default: 'ubuntu-latest'
 jobs:
   grpc_linux:
-    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.repository == 'keploy/keploy' && github.ref == 'refs/heads/main') }}
     runs-on: ${{ inputs.runner }}
     strategy:
       fail-fast: false
@@ -69,7 +69,7 @@ jobs:
           source $GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/golang/${{ matrix.app.script_dir }}/grpc-linux.sh ${{ matrix.mode }}
         
   grpc_linux_protoscope:
-    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.repository == 'keploy/keploy' && github.ref == 'refs/heads/main') }}
     runs-on: ${{ inputs.runner }}
     strategy:
       fail-fast: false

--- a/.github/workflows/java_linux.yml
+++ b/.github/workflows/java_linux.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
 jobs:
   java_linux:
-    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.repository == 'keploy/keploy' && github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -64,7 +64,7 @@ jobs:
           source $GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/java/${{ matrix.app.script_dir }}/java-linux.sh
 
   mysql_dual_conn:
-    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.repository == 'keploy/keploy' && github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/node_docker.yml
+++ b/.github/workflows/node_docker.yml
@@ -8,7 +8,7 @@ on:
         type: string
 jobs:
   node_docker:
-    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.repository == 'keploy/keploy' && github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/node_linux.yml
+++ b/.github/workflows/node_linux.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
 jobs:
   node_linux:
-    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.repository == 'keploy/keploy' && github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/node_mapping.yml
+++ b/.github/workflows/node_mapping.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
 jobs:
   node_mapping:
-    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.repository == 'keploy/keploy' && github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/prepare_and_run.yml
+++ b/.github/workflows/prepare_and_run.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Add Private Parsers
-        if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+        if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.repository == 'keploy/keploy' && github.ref == 'refs/heads/main') }}
         uses: ./.github/actions/setup-private-parsers
         with:
           ssh-private-key: ${{ secrets.INTEGRATIONS_REPO_DEPLOY_KEY_PRIVATE }}
@@ -56,12 +56,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       image_tag: ${{ steps.tag.outputs.image_tag }}
-      image_digest: ${{ steps.digest.outputs.image_digest }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Add Private Parsers
-        if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+        if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.repository == 'keploy/keploy' && github.ref == 'refs/heads/main') }}
         uses: ./.github/actions/setup-private-parsers
         with:
           ssh-private-key: ${{ secrets.INTEGRATIONS_REPO_DEPLOY_KEY_PRIVATE }}
@@ -116,7 +115,7 @@ jobs:
       image_tag: ${{ needs.build-docker-image.outputs.image_tag }}
     uses: ./.github/workflows/golang_docker.yml
   run_fuzzer_linux:
-    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.repository == 'keploy/keploy' && github.ref == 'refs/heads/main') }}
     needs: [build-and-upload, upload-latest]
     uses: ./.github/workflows/fuzzer_linux.yml
     secrets:

--- a/.github/workflows/prepare_and_run_integrations.yml
+++ b/.github/workflows/prepare_and_run_integrations.yml
@@ -27,7 +27,7 @@ jobs:
           sudo apt -y install build-essential gcc libc-dev     
 
       - name: Add Private Parsers
-        if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+        if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.repository == 'keploy/keploy' && github.ref == 'refs/heads/main') }}
         uses: ./.github/actions/setup-private-parsers
         with:
           ssh-private-key: ${{ secrets.INTEGRATIONS_REPO_DEPLOY_KEY_PRIVATE }}
@@ -81,7 +81,7 @@ jobs:
       runner: ${{ inputs.runner }}
       jobs_to_run: 'private_only'
   run_fuzzer_linux:
-    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.repository == 'keploy/keploy' && github.ref == 'refs/heads/main') }}
     needs: [build-and-upload, upload-latest]
     uses: ./.github/workflows/fuzzer_linux.yml
     with:

--- a/.github/workflows/prepare_and_run_macos.yml
+++ b/.github/workflows/prepare_and_run_macos.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   build-and-upload:
     runs-on: ubuntu-latest
-    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.repository == 'keploy/keploy' && github.ref == 'refs/heads/main') }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -30,11 +30,10 @@ jobs:
         with: { name: build, path: keploy }
 
   build-docker-image:
-    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.repository == 'keploy/keploy' && github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-24.04-arm
     outputs:
       image_tag: ${{ steps.tag.outputs.image_tag }}
-      image_digest: ${{ steps.digest.outputs.image_digest }}
     steps:
       - uses: actions/checkout@v4
 
@@ -76,7 +75,7 @@ jobs:
           git config --global --unset-all core.sshCommand 2>/dev/null || true
 
   pull-docker-image:
-    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.repository == 'keploy/keploy' && github.ref == 'refs/heads/main') }}
     runs-on: [self-hosted, macOS, native]
     needs: [build-docker-image]
     timeout-minutes: 10
@@ -126,7 +125,7 @@ jobs:
       MAC_RUNNER_USER_PASSWORD: ${{ secrets.MAC_RUNNER_USER_PASSWORD }}
 
   clean_up_docker_macos:
-    if: ${{ always() && ((github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main')) }}
+    if: ${{ always() && ((github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.repository == 'keploy/keploy' && github.ref == 'refs/heads/main')) }}
     runs-on: [self-hosted, macOS, native]
     needs: [run_python_docker_macos, run_golang_docker_macos]
     timeout-minutes: 10

--- a/.github/workflows/prepare_and_run_windows.yml
+++ b/.github/workflows/prepare_and_run_windows.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build-and-upload:
-    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.repository == 'keploy/keploy' && github.ref == 'refs/heads/main') }}
     runs-on: [self-hosted, Windows, X64]
     # Bound wall-clock so a hung cgo link step (historically: a
     # deadlock inside libwindows_redirector.a's shutdown path) cannot
@@ -378,7 +378,7 @@ jobs:
           & "$env:GITHUB_WORKSPACE\.github\scripts\windows\cleanup-git-isolation.ps1"
 
   docker-image-build:
-    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.repository == 'keploy/keploy' && github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     outputs:
       image_tag: ${{ steps.tag.outputs.image_tag }}
@@ -418,7 +418,7 @@ jobs:
 
   pull-docker-image:
     needs: [docker-image-build]
-    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.repository == 'keploy/keploy' && github.ref == 'refs/heads/main') }}
     runs-on: [self-hosted, Windows, X64]
     # Same rationale as build-and-upload: bound the wall-clock so a
     # hung self-hosted Windows runner cannot stall the whole pipeline.
@@ -500,7 +500,7 @@ jobs:
     uses: ./.github/workflows/golang_native_windows.yml
 
   cleanup:
-    if: ${{ always() && ((github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main')) }}
+    if: ${{ always() && ((github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.repository == 'keploy/keploy' && github.ref == 'refs/heads/main')) }}
     runs-on: [self-hosted, Windows, X64]
     needs: [run_golang_docker_windows, run_golang_native_windows]
     steps:

--- a/.github/workflows/python_docker.yml
+++ b/.github/workflows/python_docker.yml
@@ -8,7 +8,7 @@ on:
         type: string
 jobs:
   python_docker:
-    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.repository == 'keploy/keploy' && github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/python_linux.yml
+++ b/.github/workflows/python_linux.yml
@@ -68,7 +68,7 @@ jobs:
           source $GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/python/${{ matrix.app.script_dir }}/python-linux.sh
 
   python_linux_private:
-    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.repository == 'keploy/keploy' && github.ref == 'refs/heads/main') }}
     runs-on: ${{ inputs.runner }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description
Contributors forking the repository were experiencing workflow failures when pushing to or syncing their own `main` branches. This occurred because forks do not have access to Keploy's internal secrets (such as `INTEGRATIONS_REPO_DEPLOY_KEY_PRIVATE`) or the upstream self-hosted runners, causing immediate job failures on `push` triggers.

This PR addresses the issue by:
1. Updating the `if` condition across all affected `.github/workflows/*.yml` files. The `push` trigger on the `main` branch will now only execute if the repository is explicitly upstream (`keploy/keploy`).
2. Cleaning up a few invalid variable references where a non-existent step (`steps.digest.outputs.image_digest`) was being assigned to a job output.

## Motivation and Context
Prevents false-positive CI failures in contributors' forks, keeping their Actions tab clean while safely preserving all standard PR and upstream CI validations. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Tech debt / CI setup