### PR TITLE
fix: generic mock flush when response complete

### DIFF
--- a/pkg/agent/proxy/integrations/generic/encode.go
+++ b/pkg/agent/proxy/integrations/generic/encode.go
@@ -188,11 +188,12 @@ func createGenericMocksAsync(ctx context.Context, logger *zap.Logger, clientCh, 
 				clientCh = nil
 				continue
 			}
-			// Back-stop for the rare case where an exchange arrived but
-			// was never paired with a response (e.g. the server closed
-			// without replying). The common case is flushed the moment
-			// the first response chunk arrives below, so this branch is
-			// normally a no-op.
+			// Back-stop for the rare case where the previous completed
+			// request/response exchange was not flushed when its first
+			// response chunk arrived. When the next client chunk shows
+			// up, flush that already-paired exchange before starting a
+			// new one. The common case is flushed below on the first
+			// response chunk, so this branch is normally a no-op.
 			if !prevChunkWasReq && len(genericRequests) > 0 && len(genericResponses) > 0 {
 				flushMock()
 			}

--- a/pkg/agent/proxy/integrations/generic/encode.go
+++ b/pkg/agent/proxy/integrations/generic/encode.go
@@ -126,6 +126,23 @@ func forwardBidirectional(clientConn, destConn net.Conn) error {
 // createGenericMocksAsync reads captured data from both channels and creates
 // mock entries based on request-response alternation. Runs in a background
 // goroutine — never blocks the forwarding path.
+//
+// Exchange-boundary detection: a request-response pair is flushed to the
+// syncMock buffer the instant the first response chunk arrives, not when
+// the next request starts. Flushing on "next request" is too late for
+// pooled connections — the next request can be seconds away (mongo driver
+// checkout/heartbeat pools), by which point the enterprise capture has
+// already run ResolveRange for the test and the 7-second buffer cutoff in
+// syncMock.ResolveRange discards the pending mock. The consequence was
+// that in static-dedup mode every test after the first recorded zero
+// mocks.
+//
+// The tradeoff: a server reply split into multiple TCP read chunks lands
+// as a single mock here (only the first chunk), with trailing chunks
+// dropped. For the protocols generic is a fallback for (mongo wire,
+// various binary RPC), responses are almost always a single write and
+// therefore one io.Copy chunk. A future protocol-aware parser should
+// supersede generic where framing matters.
 func createGenericMocksAsync(ctx context.Context, logger *zap.Logger, clientCh, destCh <-chan []byte) {
 	var genericRequests []models.Payload
 	var genericResponses []models.Payload
@@ -171,9 +188,20 @@ func createGenericMocksAsync(ctx context.Context, logger *zap.Logger, clientCh, 
 				clientCh = nil
 				continue
 			}
-			// New request after response — previous exchange complete.
+			// Back-stop for the rare case where an exchange arrived but
+			// was never paired with a response (e.g. the server closed
+			// without replying). The common case is flushed the moment
+			// the first response chunk arrives below, so this branch is
+			// normally a no-op.
 			if !prevChunkWasReq && len(genericRequests) > 0 && len(genericResponses) > 0 {
 				flushMock()
+			}
+			// Starting a brand-new exchange: drop any orphaned response
+			// chunks from a previous multi-chunk server reply whose
+			// head chunk was already flushed, and reset the request
+			// timestamp to this request's arrival time.
+			if len(genericRequests) == 0 {
+				genericResponses = nil
 				reqTimestampMock = time.Now()
 			}
 			genericRequests = append(genericRequests, encodePayload(buf, models.FromClient))
@@ -184,11 +212,21 @@ func createGenericMocksAsync(ctx context.Context, logger *zap.Logger, clientCh, 
 				destCh = nil
 				continue
 			}
-			if prevChunkWasReq {
-				reqTimestampMock = time.Now()
-			}
 			genericResponses = append(genericResponses, encodePayload(buf, models.FromServer))
 			resTimestampMock = time.Now()
+
+			// Flush the moment the first response chunk for an
+			// outstanding request arrives. This makes the mock visible
+			// to the syncMock buffer BEFORE the enterprise capture's
+			// ResolveRange call fires for the current test, which in
+			// static-dedup mode is what associates the mock with the
+			// right test window. Waiting any longer (for the next
+			// client chunk or an idle timer) misses the window on
+			// pooled connections where the next request is seconds
+			// away.
+			if prevChunkWasReq && len(genericRequests) > 0 {
+				flushMock()
+			}
 			prevChunkWasReq = false
 		}
 	}


### PR DESCRIPTION
## Describe the changes that are made
This pull request improves the reliability and correctness of mock exchange detection in the generic protocol integration, specifically for pooled connections and protocols with ambiguous framing. The main changes clarify and adjust when request-response pairs are flushed to the mock buffer, ensuring that mocks are captured in time for enterprise capture logic, even when connections are pooled and requests are infrequent.

**Enhancements to exchange-boundary detection and flushing logic:**

* Added detailed documentation explaining the new exchange-boundary detection approach, which now flushes a request-response pair as soon as the first response chunk arrives, instead of waiting for the next request. This change addresses issues with pooled connections where delayed requests previously caused mocks to be missed.
* Updated the logic to immediately flush the mock when the first response chunk for an outstanding request arrives, ensuring mocks are available to the enterprise capture's `ResolveRange` in time.
* Added a back-stop to flush incomplete exchanges when a new request arrives, handling rare cases where a server closes without replying. Also, resets the response buffer and timestamp when starting a new exchange, preventing orphaned response chunks from being incorrectly paired.

## Links & References

**Closes:** https://github.com/keploy/enterprise/issues/1890

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [X] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [X] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [X] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [X] 🙅 no, because it is not needed

## Self Review done?
- [X] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [X] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [X] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [X] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?