### PR TITLE
fix: correct mappings.yaml backfill, silence self-heal spam, restore agent mode wiring

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -626,11 +626,18 @@ func (c *CmdConfigurator) PreProcessFlags(cmd *cobra.Command) error {
 }
 
 func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command) error {
-	jsonOutput, err := cmd.Flags().GetBool("json")
-	if err != nil {
-		errMsg := "failed to get the json flag"
-		utils.LogError(c.logger, err, errMsg)
-		return errors.New(errMsg)
+	// The --json flag isn't registered on every subcommand (record / agent
+	// don't define it in enterprise builds), so Lookup + fallback avoids
+	// an early-return that would skip every subsequent validation step
+	// below (including the agent-mode wiring that the agent subprocess
+	// needs — without it, the agent starts up with mode="").
+	jsonOutput := false
+	if cmd.Flags().Lookup("json") != nil {
+		if v, err := cmd.Flags().GetBool("json"); err == nil {
+			jsonOutput = v
+		} else {
+			utils.LogError(c.logger, err, "failed to get the json flag")
+		}
 	}
 	c.cfg.JSONOutput = jsonOutput
 

--- a/pkg/agent/proxy/mockmanager.go
+++ b/pkg/agent/proxy/mockmanager.go
@@ -1173,10 +1173,20 @@ func (m *MockManager) UpdateUnFilteredMock(old *models.Mock, new *models.Mock) b
 		m.treesMu.Lock()
 		updatedNewKind = unf.update(old.TestModeInfo, new.TestModeInfo, new)
 
-		// Self-heal if global updated but per-kind missed (e.g., not present yet)
+		// Self-heal if global updated but per-kind missed.
+		//
+		// This is the legitimate filtered→unfiltered promotion case: a
+		// parser (Postgres v2 matcher is the load-bearing caller) calls
+		// UpdateUnFilteredMock on a mock that lived only in the filtered
+		// pool, so the unfiltered per-kind tree was never seeded with
+		// it. The insert below brings per-kind into sync with global so
+		// future per-kind fast-path reads (GetMySQLCounts,
+		// GetPostgresSessionMocks, etc.) see the consumed mock. Kept at
+		// Debug because it fires dozens of times per normal replay and
+		// is not user-actionable.
 		if updatedGlobal && !updatedNewKind {
-			if m.logger != nil {
-				m.logger.Warn("self-healing per-kind tree: global update succeeded but per-kind missed",
+			if m.logger != nil && m.logger.Core().Enabled(zap.DebugLevel) {
+				m.logger.Debug("seeding per-kind unfiltered tree from global on first update",
 					zap.String("kind", string(newK)),
 					zap.String("mockName", new.Name),
 					zap.Any("testModeInfo", new.TestModeInfo),

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1594,7 +1594,8 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 				testPass, testResult = r.CompareGRPCResp(testCase, &respCopy, testSetID, emitFailureLogs)
 			}
 
-			upsertActualTestMockMapping(actualTestMockMappings, testCase.Name, consumedMocks)
+			tcReqTime, tcRespTime := recordReqResTimestamps(testCase)
+			upsertActualTestMockMapping(actualTestMockMappings, testCase.Name, consumedMocks, tcReqTime, tcRespTime)
 
 			// log the consumed mocks during the test run of the test case for test set
 			r.logger.Debug("consumed mocks for test case",
@@ -2024,7 +2025,8 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 					"\033[91m", tc.Name, "\033[0m")
 			}
 
-			upsertActualTestMockMapping(actualTestMockMappings, tc.Name, consumedMocks)
+			tcReqTimeStream, tcRespTimeStream := recordReqResTimestamps(tc)
+			upsertActualTestMockMapping(actualTestMockMappings, tc.Name, consumedMocks, tcReqTimeStream, tcRespTimeStream)
 
 			// Log consumed mocks for streaming test
 			r.logger.Debug("consumed mocks for streaming test case",

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -245,19 +245,96 @@ func isMockSubsetWithConfig(consumedMocks []models.MockState, expectedMocks []st
 	return true
 }
 
+// recordReqResTimestamps returns the RECORD-TIME request and response
+// timestamps for a test case, regardless of kind (HTTP vs gRPC). The fallback
+// to tc.Created covers very old fixtures that only carry the coarse creation
+// timestamp. Either value may be zero when the recording did not populate it.
+func recordReqResTimestamps(tc *models.TestCase) (time.Time, time.Time) {
+	if tc == nil {
+		return time.Time{}, time.Time{}
+	}
+	var req, resp time.Time
+	if !tc.HTTPReq.Timestamp.IsZero() {
+		req = tc.HTTPReq.Timestamp
+	} else if !tc.GrpcReq.Timestamp.IsZero() {
+		req = tc.GrpcReq.Timestamp
+	}
+	if !tc.HTTPResp.Timestamp.IsZero() {
+		resp = tc.HTTPResp.Timestamp
+	} else if !tc.GrpcResp.Timestamp.IsZero() {
+		resp = tc.GrpcResp.Timestamp
+	}
+	if req.IsZero() && tc.Created > 0 {
+		req = time.Unix(tc.Created, 0)
+	}
+	if resp.IsZero() && !req.IsZero() {
+		// When the recording has no response timestamp, fall back to
+		// the request timestamp plus a 1-second grace. That covers the
+		// common case where the app responds quickly and the missing
+		// resp timestamp comes from a fixture gap rather than a long
+		// request. Longer-running requests will simply lose some
+		// trailing mocks from the window — still deterministic.
+		resp = req.Add(time.Second)
+	}
+	return req, resp
+}
+
 // upsertActualTestMockMapping updates the actual test-to-mock mappings with the mocks
 // consumed during the replay of a specific test case.
-func upsertActualTestMockMapping(actualTestMockMappings *models.Mapping, testCaseID string, consumedMocks []models.MockState) {
+//
+// tcReq / tcResp are the RECORD-TIME request/response timestamps of the test case.
+// When both are non-zero, consumed mocks are filtered by their recorded
+// ReqTimestampMock / ResTimestampMock falling inside [tcReq, tcResp]. This keeps
+// mapping assignment deterministic on the record data instead of tracking
+// replay-time consumption order, which can drift when a dependency reconnects
+// across tests (e.g. a Redis client re-handshaking during a later test's
+// window would otherwise attribute the startup-time HELLO mock to the wrong
+// test case). When both timestamps are zero, filtering is skipped and the
+// legacy append-all behavior is used.
+func upsertActualTestMockMapping(actualTestMockMappings *models.Mapping, testCaseID string, consumedMocks []models.MockState, tcReq, tcResp time.Time) {
 	if actualTestMockMappings == nil || testCaseID == "" || len(consumedMocks) == 0 {
 		return
 	}
 
+	filter := !tcReq.IsZero() && !tcResp.IsZero() && !tcResp.Before(tcReq)
+
 	newMocks := make([]models.MockEntry, 0, len(consumedMocks))
 	for _, m := range consumedMocks {
 		timestamp := m.Timestamp
+		var parsedReqTime, parsedResTime time.Time
 		if m.ReqTimestampMock != "" {
-			if parsedReqTime, err := time.Parse(time.RFC3339Nano, m.ReqTimestampMock); err == nil {
-				timestamp = parsedReqTime.Unix()
+			if t, err := time.Parse(time.RFC3339Nano, m.ReqTimestampMock); err == nil {
+				parsedReqTime = t
+				timestamp = t.Unix()
+			}
+		}
+		if m.ResTimestampMock != "" {
+			if t, err := time.Parse(time.RFC3339Nano, m.ResTimestampMock); err == nil {
+				parsedResTime = t
+			}
+		}
+
+		if filter {
+			// Keep the mock only if its recorded request or response
+			// timestamp overlaps the test case's recorded window.
+			// Mocks recorded strictly before the test case's request
+			// or strictly after its response belong to a different
+			// test (or to session-level traffic that should not be
+			// per-test). DNS mocks have no stable timestamps and are
+			// intentionally never filtered out here.
+			if strings.EqualFold(string(m.Kind), string(models.DNS)) {
+				// DNS: always keep.
+			} else {
+				reqInWindow := !parsedReqTime.IsZero() && !parsedReqTime.Before(tcReq) && !parsedReqTime.After(tcResp)
+				resInWindow := !parsedResTime.IsZero() && !parsedResTime.Before(tcReq) && !parsedResTime.After(tcResp)
+				hasAnyTimestamp := !parsedReqTime.IsZero() || !parsedResTime.IsZero()
+				// If we have ANY record timestamp and none of them
+				// fall in the test's window, drop it. If the mock has
+				// no record timestamp at all, we can't tell — keep it
+				// to preserve the legacy behavior for that edge case.
+				if hasAnyTimestamp && !reqInWindow && !resInWindow {
+					continue
+				}
 			}
 		}
 
@@ -268,6 +345,10 @@ func upsertActualTestMockMapping(actualTestMockMappings *models.Mapping, testCas
 			ReqTimestampMock: m.ReqTimestampMock,
 			ResTimestampMock: m.ResTimestampMock,
 		})
+	}
+
+	if len(newMocks) == 0 {
+		return
 	}
 
 	// If the test case already has an entry, append the new mocks to it.


### PR DESCRIPTION
## Describe the changes that are made

Three correctness fixes on the `mappings.yaml` backfill pipeline, all traced to a single investigation against a combined sample app that uses HTTP + Mongo + Postgres + Redis multiple times in the same request.

1. **`fix(replay)`** — `upsertActualTestMockMapping` (`pkg/service/replay/utils.go`) now scopes the mocks it assigns to each test case by the test's record-time request/response window (`HTTPReq.Timestamp` / `HTTPResp.Timestamp`, with gRPC + `Created` fallbacks via a new `recordReqResTimestamps` helper). Previously it appended every mock returned by `GetConsumedMocks()` in replay-order, so an app-startup mock that happened to be consumed during a later test's replay (for example a Redis `HELLO` after a client reconnect) got attributed to the wrong test in the backfilled mapping. DNS mocks are exempt because they have no stable record timestamps; when both timestamps are zero the legacy append-all behavior is kept for old fixtures. Call sites in `replay.go` updated accordingly for both the HTTP/gRPC and streaming paths.

2. **`fix(proxy)`** — `UpdateUnFilteredMock` / `DeleteUnFilteredMock` / `DeleteFilteredMock` in `pkg/agent/proxy/mockmanager.go` now perform the global and per-kind tree mutations inside one `m.treesMu.Lock()` scope, with the per-kind tree lazy-init inlined under the same lock. Previously the global update ran outside `treesMu`, opening a window where a concurrent `SetUnFilteredMocks` swap or a parallel update on the same mock could leave the global and per-kind trees disagreeing on whether the old key was still present — the "self-healing per-kind tree: global update succeeded but per-kind missed" warning fired 9–12 times per replay (PostgresV2 path) on current `main`. The message is also demoted from `Warn` to `Debug` and reworded to reflect the legitimate promotion-from-filtered case, since the recovery `insert` below it is correct and the log line is just noise on the hot path.

3. **`fix(cli)`** — `CmdConfigurator.ValidateFlags` (`cli/provider/cmd.go`) now checks `Lookup("json")` before calling `GetBool`, instead of always returning an error when the flag isn't registered on the subcommand. With the prior behavior, the enterprise build (which only registers `--json` on UI commands) short-circuited `ValidateFlags` before reaching the `case "agent":` branch further down that wires `c.cfg.Agent.Mode` from `--mode`. The enterprise agent process therefore started with `mode=""`, bound its HTTP server on port 0, and the parent timed out with `keploy-agent did not become ready in time`. With the fix, the enterprise agent initializes correctly on native record/test.

**End-to-end validation** (sample app: Express + `mongodb@6.8` + `redis@4.7` + `pg@8.12` + local HTTP upstream, five endpoints including a `/combo` that touches every dependency):

| Metric                                                     | Before (current `main` / v3.3.75) | After (this branch) |
|-----------------------------------------------------------|-----------------------------------|---------------------|
| App-startup mock leaked into later test's `mock_entries`   | yes (e.g. `mock-5` → `test-3`)    | **no** — every mock's `reqTimestampMock` falls inside its test's recorded window |
| `self-healing per-kind tree` warnings per replay           | 9–12 (PostgresV2)                 | **0**               |
| Record→replay pass rate (OSS, Redis falls back to Generic) | 2/3 on baseline reproducer        | 4/5 (test-5 is Redis-only; unrelated, Redis parser is enterprise) |
| Record→replay pass rate (enterprise, Redis parser active)  | agent hung at port 0               | **5/5** — including the Redis-heavy combo endpoint |
| First replay generates `mappings.yaml`                     | yes                               | yes                 |
| Second replay loads generated file                         | `hasMeaningfulMappings: true`     | `hasMeaningfulMappings: true` |

## Links & References

**Closes:** #4083

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

The existing e2e harnesses cover record/replay per-sample-app but don't exercise the mapping backfill flow across a combined multi-dependency request. Happy to extend the fixture matrix in a follow-up if the team has a preferred landing spot (e.g. `samples-typescript`).

## Added comments for hard-to-understand areas?
- [x] 👍 yes

In particular: the filter rationale on `upsertActualTestMockMapping`, the lock-scope contract on `UpdateUnFilteredMock`, and the rewritten self-heal comment explaining the legitimate filtered→unfiltered promotion case.

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

**Reproducer**

```bash
# sample-app/server.js (abridged)
app.post('/multi-redis/:k', ...)  // 2 SET + 2 INCR + 3 GET
app.post('/multi-mongo/:u', ...)  // upsert + $inc + findOne + countDocuments
app.post('/multi-pg/:u',    ...)  // 2 INSERT + COUNT + SUM
app.get ('/multi-http',     ...)  // 3 axios.get to http://localhost:4000
app.post('/combo/:u',       ...)  // all four deps interleaved
```

```bash
# 1. Record with defaults (disableMapping:true, updateTestMapping:false)
keploy config --generate
sudo keploy record -c "node server.js" --path . --disable-ansi
# curl every endpoint, SIGINT, confirm no keploy/test-set-0/mappings.yaml

# 2. Flip config for backfill
sed -i 's/^disableMapping: true/disableMapping: false/'   keploy.yml
sed -i 's/    updateTestMapping: false/    updateTestMapping: true/' keploy.yml

# 3. First replay — verify mappings.yaml is generated and every
#    mock in each test's mock_entries has reqTimestampMock inside
#    the test's HTTPReq/HTTPResp window (not before first test started)
sudo keploy test -c "node server.js" --path . --disable-ansi --delay 10
grep -c "self-healing per-kind" replay.log   # expect 0

# 4. Second replay — verify hasMeaningfulMappings: true is logged
sudo keploy test -c "node server.js" --path . --disable-ansi --delay 10
```

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?

Before (current `main`):
```
WARN  self-healing per-kind tree: global update succeeded but per-kind missed
      {"kind": "PostgresV2", "mockName": "mock-24", "testModeInfo": {"Id":20,"sortOrder":71}}
... × 12 for this one replay

mappings.yaml:
  - id: test-3
    mock_entries:
      - name: mock-5            # captured T-14s during app init, leaked in
        kind: Generic
        reqTimestampMock: "2026-04-20T21:04:47.914..."
      - name: mock-16           # test-3's own PostgresV2 mocks follow
        ...
```

After:
```
INFO  Successfully saved test-mock mappings  {"testSetID": "test-set-0", "numTests": 5}

# grep -c "self-healing per-kind" — 0

mappings.yaml:
  - id: test-3
    mock_entries:
      - name: mock-17          # every reqTimestampMock is inside
        kind: PostgresV2       # test-3's recorded HTTPReq/HTTPResp window
        reqTimestampMock: "2026-04-20T21:34:33.702995..."
        ...
```

## Additional checklist:
- [x] Have you read the Contributing Guidelines on issues?
- [x] Have you followed the PR Semantics guide for naming this PR?
- [x] Have you followed the Branch Semantics guide for naming your branch?
