### PR TITLE
fix(agent): gate /agent/ready on CA bundle being written (closes #4086)

### DIFF
--- a/.github/workflows/e2e-agent-ready-ca-gate.yml
+++ b/.github/workflows/e2e-agent-ready-ca-gate.yml
@@ -1,0 +1,39 @@
+# E2E regression guard for the /agent/ready gate on CA-bundle readiness.
+#
+# NOTE: this repo does not currently carry a Woodpecker pipeline
+# (only .github/workflows/*). The original implementation spec called
+# for a Woodpecker pipeline with a GitHub Actions fallback — this file
+# is that fallback. If Woodpecker is adopted in the future, mirror
+# this job into .woodpecker/e2e-agent-ready-ca-gate.yml.
+name: e2e-agent-ready-ca-gate
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'pkg/agent/routes/**'
+      - 'pkg/agent/proxy/tls/**'
+      - 'tests/e2e/agent-ready-gated-on-ca/**'
+      - '.github/workflows/e2e-agent-ready-ca-gate.yml'
+  pull_request:
+    paths:
+      - 'pkg/agent/routes/**'
+      - 'pkg/agent/proxy/tls/**'
+      - 'tests/e2e/agent-ready-gated-on-ca/**'
+      - '.github/workflows/e2e-agent-ready-ca-gate.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: /agent/ready gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify docker compose available
+        run: docker compose version
+
+      - name: Run e2e regression
+        run: ./tests/e2e/agent-ready-gated-on-ca/run.sh

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -398,11 +398,18 @@ func (p *Proxy) StartProxy(ctx context.Context, opts agent.ProxyOptions) error {
 	// This must happen before any connections are handled.
 	p.StartErrorDrain(ctx)
 
-	// set up the CA for tls connections
+	// set up the CA for tls connections.
+	//
+	// On failure we record the terminal error via MarkCAFailed so the
+	// /agent/ready handler can return a clear "CA setup failed"
+	// diagnostic instead of an indefinite "not yet ready". We still
+	// continue starting the proxy — the proxy can serve non-TLS
+	// traffic and surfacing the error to readiness probes is a better
+	// signal to operators than hard-aborting the agent here.
 	err = pTls.SetupCA(ctx, p.logger, p.IsDocker)
 	if err != nil {
-		// log the error and continue
 		p.logger.Warn("failed to setup CA", zap.Error(err))
+		pTls.MarkCAFailed(err)
 	}
 	g, ok := ctx.Value(models.ErrGroupKey).(*errgroup.Group)
 	if !ok {

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -408,7 +408,24 @@ func (p *Proxy) StartProxy(ctx context.Context, opts agent.ProxyOptions) error {
 	// signal to operators than hard-aborting the agent here.
 	err = pTls.SetupCA(ctx, p.logger, p.IsDocker)
 	if err != nil {
-		p.logger.Warn("failed to setup CA", zap.Error(err))
+		// Terminal: the CA cannot be installed in this process and
+		// Keploy-proxied TLS will fail cert-verify for every workload
+		// that gets routed through the proxy. Log at Error (not Warn)
+		// to match the severity, and include a next_step so operators
+		// see the likely fix without grepping source.
+		p.logger.Error(
+			"SetupCA failed — Keploy-proxied TLS will fail cert-verify. "+
+				"The /agent/ready endpoint will return 503 with this error "+
+				"so dependents don't wait forever for a readiness that "+
+				"will never come.",
+			zap.Error(err),
+			zap.String("next_step",
+				"Verify the agent container has write access to the "+
+					"shared /tmp/keploy-tls volume (docker/k8s mode) or "+
+					"to the host's CA trust store under /usr/local/share/"+
+					"ca-certificates or /etc/pki/ca-trust/source/anchors "+
+					"(native mode). Restart the agent after fixing."),
+		)
 		pTls.MarkCAFailed(err)
 	}
 	g, ok := ctx.Value(models.ErrGroupKey).(*errgroup.Group)

--- a/pkg/agent/proxy/tls/ca.go
+++ b/pkg/agent/proxy/tls/ca.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cloudflare/cfssl/csr"
@@ -58,9 +59,17 @@ var caStoreUpdateCmd = []string{
 // call from multiple goroutines and multiple times during a single agent
 // lifecycle. caReadyCh is closed exactly once, on the first successful
 // SetupCA path, and remains closed for the rest of the process lifetime.
+//
+// caFailure records a terminal SetupCA error so callers (e.g. the
+// /agent/ready handler) can distinguish "CA not yet ready" from "CA
+// setup failed and will never recover without an agent restart". It is
+// written by MarkCAFailed on the error path of SetupCA (via
+// pkg/agent/proxy), and read non-blockingly by CAStatus. It is never
+// reset in production; tests call ResetCAReadyForTest to clear it.
 var (
 	caReadyOnce sync.Once
 	caReadyCh   = make(chan struct{})
+	caFailure   atomic.Pointer[error]
 )
 
 // CAReady returns a channel that is closed once the Keploy CA bundle has
@@ -80,6 +89,54 @@ var (
 // is missing would let app containers boot against a broken TLS trust
 // chain and produce silent failures in HTTPS egress.
 func CAReady() <-chan struct{} { return caReadyCh }
+
+// CAStatus reports the current CA-readiness state in a single
+// non-blocking call. It is the preferred check for HTTP handlers and
+// other consumers that need to distinguish three states:
+//
+//   - ready==true,  err==nil  : the CA bundle has been written to disk
+//     (shared volume in docker/k8s mode, or system CA store in native
+//     mode) and downstream consumers can proceed.
+//   - ready==false, err==nil  : SetupCA has not completed yet — the
+//     caller should back off and retry (typical boot-time race).
+//   - ready==false, err!=nil  : SetupCA completed with a terminal
+//     error. The CA will NOT become ready in this process lifetime;
+//     callers should surface a clear "misconfiguration" signal (e.g.
+//     HTTP 503 with the error message) so operators don't wait
+//     forever for readiness that will never come.
+//
+// CAStatus is safe to call concurrently from any goroutine.
+func CAStatus() (ready bool, err error) {
+	select {
+	case <-caReadyCh:
+		ready = true
+	default:
+	}
+	if p := caFailure.Load(); p != nil && *p != nil {
+		err = *p
+	}
+	return ready, err
+}
+
+// MarkCAFailed records a terminal SetupCA failure so future CAStatus
+// calls can report it. Only the SetupCA caller in pkg/agent/proxy
+// should invoke this — it is exposed (capitalised) because the error
+// is returned to the caller, not handled inside this package. Calling
+// MarkCAFailed with a non-nil err does NOT close caReadyCh: readiness
+// stays unlatched so health checks keep failing, and the error gives
+// operators a clear diagnostic instead of an open-ended timeout.
+//
+// Passing nil is a no-op (so callers can plumb `MarkCAFailed(err)`
+// unconditionally on the SetupCA return). Subsequent non-nil calls
+// overwrite the previous error — SetupCA is not currently retried,
+// but if a future refactor adds retry this keeps the most recent
+// diagnostic visible.
+func MarkCAFailed(err error) {
+	if err == nil {
+		return
+	}
+	caFailure.Store(&err)
+}
 
 // markCAReady closes the CAReady channel exactly once. Safe to call from
 // multiple goroutines and multiple times.

--- a/pkg/agent/proxy/tls/ca.go
+++ b/pkg/agent/proxy/tls/ca.go
@@ -106,16 +106,24 @@ func CAReady() <-chan struct{} { return caReadyCh }
 //     forever for readiness that will never come.
 //
 // CAStatus is safe to call concurrently from any goroutine.
+//
+// Contract: (ready==true, err==nil) is the only "success" shape. If the
+// channel is closed we return nil error unconditionally, even if a
+// previous MarkCAFailed recorded one — a successful markCAReady supersedes
+// any earlier terminal failure (an upstream retry + success for example).
+// That keeps the three documented shapes mutually exclusive so callers
+// can switch on them without chasing a race between the signal fire
+// order and the readiness observation.
 func CAStatus() (ready bool, err error) {
 	select {
 	case <-caReadyCh:
-		ready = true
+		return true, nil
 	default:
 	}
 	if p := caFailure.Load(); p != nil && *p != nil {
 		err = *p
 	}
-	return ready, err
+	return false, err
 }
 
 // MarkCAFailed records a terminal SetupCA failure so future CAStatus
@@ -293,31 +301,25 @@ func setupNative(ctx context.Context, logger *zap.Logger) error {
 
 	// Set Env Vars pointing to the installed cert.
 	//
-	// finalCAPath is empty when getCaPaths() returned NO recognized CA
-	// store paths (can happen on minimal/custom distros). In that case
-	// the loop at the top of this function wrote nothing to disk, so no
-	// env var points anywhere useful. We still mark the agent ready
-	// (blocking /agent/ready forever would just cascade into a
-	// kubelet/compose restart loop without fixing the root cause) but we
-	// must be loud about it: any HTTPS call the app makes that expects
-	// the Keploy MITM CA to be installed will fail silently downstream.
-	if finalCAPath != "" {
-		if err := SetEnvForPath(logger, finalCAPath); err != nil {
-			return err
-		}
-	} else {
-		logger.Warn(
-			"Native-mode SetupCA completed without finding any OS CA store " +
-				"path — /agent/ready will still signal success but NO " +
-				"Keploy CA is installed on this host. Non-Keploy-proxied " +
-				"TLS will work; Keploy-proxied TLS will fail cert " +
-				"verification. Check getCaPaths() for your distro.")
+	// By construction finalCAPath is non-empty here: getCaPaths() returns
+	// an error (caught above) when it can't find any CA store path, so the
+	// per-path loop that assigns finalCAPath always runs at least once on
+	// this code path. Treating the empty case as a programmer error via a
+	// defensive guard keeps this obvious to future readers who might
+	// otherwise re-introduce the "no CA store found but SetupCA succeeded"
+	// inconsistency, which would silently allow /agent/ready to latch
+	// while apps still distrust the Keploy MITM CA.
+	if finalCAPath == "" {
+		return fmt.Errorf("setupNative: finalCAPath is empty after ranging %d CA store paths — this is a programmer error (getCaPaths should have returned an error)", len(caPaths))
+	}
+	if err := SetEnvForPath(logger, finalCAPath); err != nil {
+		return err
 	}
 
 	// Native mode completed successfully — the CA is now installed in
 	// the system store (and the Java keystore if Java is present).
 	// Signal readiness so downstream consumers (e.g. /agent/ready) can
-	// unblock. See the warn block above for the finalCAPath=="" edge.
+	// unblock.
 	markCAReady()
 	return nil
 }

--- a/pkg/agent/proxy/tls/ca.go
+++ b/pkg/agent/proxy/tls/ca.go
@@ -54,6 +54,37 @@ var caStoreUpdateCmd = []string{
 	"certctl rehash",
 }
 
+// caReadyOnce guards the single close of caReadyCh so markCAReady is safe to
+// call from multiple goroutines and multiple times during a single agent
+// lifecycle. caReadyCh is closed exactly once, on the first successful
+// SetupCA path, and remains closed for the rest of the process lifetime.
+var (
+	caReadyOnce sync.Once
+	caReadyCh   = make(chan struct{})
+)
+
+// CAReady returns a channel that is closed once the Keploy CA bundle has
+// been written to disk (either to the shared volume at /tmp/keploy-tls/ca.crt
+// in Docker/k8s mode, or into the system CA store in native mode).
+//
+// Callers that need to guarantee the CA file exists before signalling
+// dependent systems (e.g. Kubernetes pod readiness, docker-compose
+// healthchecks, or the /agent/ready HTTP endpoint) must wait on this
+// channel. A non-blocking select against this channel is the canonical
+// way to refuse readiness until SetupCA has completed.
+//
+// The channel is only closed on the SUCCESS path of SetupCA. If SetupCA
+// fails, the channel stays open and readiness keeps failing; an operator
+// must restart the agent (with fixed config) to recover. This is
+// deliberate — silently writing the readiness marker when the CA bundle
+// is missing would let app containers boot against a broken TLS trust
+// chain and produce silent failures in HTTPS egress.
+func CAReady() <-chan struct{} { return caReadyCh }
+
+// markCAReady closes the CAReady channel exactly once. Safe to call from
+// multiple goroutines and multiple times.
+func markCAReady() { caReadyOnce.Do(func() { close(caReadyCh) }) }
+
 // SetupCA setups custom certificate authority to handle TLS connections
 func SetupCA(ctx context.Context, logger *zap.Logger, isDocker bool) error {
 
@@ -118,6 +149,12 @@ func setupSharedVolume(_ context.Context, logger *zap.Logger, exportPath string)
 	}
 
 	logger.Debug("TLS Certificates successfully exported to shared volume")
+	// Signal CA-bundle readiness to downstream consumers (e.g. the
+	// /agent/ready HTTP handler) only after the ca.crt + truststore
+	// have been written successfully. On the error paths above we
+	// return early without signalling — readiness stays unlatched so
+	// operators can restart the agent with fixed config.
+	markCAReady()
 	return nil
 }
 
@@ -149,7 +186,14 @@ func setupNative(ctx context.Context, logger *zap.Logger) error {
 		}
 
 		// Set environment variables for Node.js and Python to use the custom CA
-		return SetEnvForPath(logger, tempCertPath)
+		if err := SetEnvForPath(logger, tempCertPath); err != nil {
+			return err
+		}
+		// Mirror the shared-volume path: only signal readiness when the
+		// full install chain (cert import + java keystore + env vars)
+		// has succeeded.
+		markCAReady()
+		return nil
 	}
 
 	// Linux/Unix Specific Logic
@@ -192,9 +236,16 @@ func setupNative(ctx context.Context, logger *zap.Logger) error {
 
 	// Set Env Vars pointing to the installed cert
 	if finalCAPath != "" {
-		return SetEnvForPath(logger, finalCAPath)
+		if err := SetEnvForPath(logger, finalCAPath); err != nil {
+			return err
+		}
 	}
 
+	// Native mode completed successfully — the CA is now installed in
+	// the system store (and the Java keystore if Java is present).
+	// Signal readiness so downstream consumers (e.g. /agent/ready) can
+	// unblock.
+	markCAReady()
 	return nil
 }
 

--- a/pkg/agent/proxy/tls/ca.go
+++ b/pkg/agent/proxy/tls/ca.go
@@ -234,17 +234,33 @@ func setupNative(ctx context.Context, logger *zap.Logger) error {
 		return err
 	}
 
-	// Set Env Vars pointing to the installed cert
+	// Set Env Vars pointing to the installed cert.
+	//
+	// finalCAPath is empty when getCaPaths() returned NO recognized CA
+	// store paths (can happen on minimal/custom distros). In that case
+	// the loop at the top of this function wrote nothing to disk, so no
+	// env var points anywhere useful. We still mark the agent ready
+	// (blocking /agent/ready forever would just cascade into a
+	// kubelet/compose restart loop without fixing the root cause) but we
+	// must be loud about it: any HTTPS call the app makes that expects
+	// the Keploy MITM CA to be installed will fail silently downstream.
 	if finalCAPath != "" {
 		if err := SetEnvForPath(logger, finalCAPath); err != nil {
 			return err
 		}
+	} else {
+		logger.Warn(
+			"Native-mode SetupCA completed without finding any OS CA store " +
+				"path — /agent/ready will still signal success but NO " +
+				"Keploy CA is installed on this host. Non-Keploy-proxied " +
+				"TLS will work; Keploy-proxied TLS will fail cert " +
+				"verification. Check getCaPaths() for your distro.")
 	}
 
 	// Native mode completed successfully — the CA is now installed in
 	// the system store (and the Java keystore if Java is present).
 	// Signal readiness so downstream consumers (e.g. /agent/ready) can
-	// unblock.
+	// unblock. See the warn block above for the finalCAPath=="" edge.
 	markCAReady()
 	return nil
 }

--- a/pkg/agent/proxy/tls/ca_readiness_test.go
+++ b/pkg/agent/proxy/tls/ca_readiness_test.go
@@ -1,0 +1,75 @@
+package tls
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestCAStatus_InitialState verifies the baseline after
+// ResetCAReadyForTest: the CA is not ready and no failure is
+// recorded. This is the default operators see during the boot
+// window before SetupCA has completed.
+func TestCAStatus_InitialState(t *testing.T) {
+	ResetCAReadyForTest()
+
+	ready, err := CAStatus()
+	if ready {
+		t.Fatalf("CAStatus.ready: got true, want false")
+	}
+	if err != nil {
+		t.Fatalf("CAStatus.err: got %v, want nil", err)
+	}
+}
+
+// TestCAStatus_AfterReady verifies that closing the channel (the
+// production path via markCAReady) flips ready→true with no error.
+func TestCAStatus_AfterReady(t *testing.T) {
+	ResetCAReadyForTest()
+	CloseCAReadyForTest()
+
+	ready, err := CAStatus()
+	if !ready {
+		t.Fatalf("CAStatus.ready: got false, want true")
+	}
+	if err != nil {
+		t.Fatalf("CAStatus.err: got %v, want nil", err)
+	}
+}
+
+// TestCAStatus_AfterFailure verifies MarkCAFailed is observed by
+// CAStatus without closing the readiness channel — this is the
+// critical invariant that lets the /agent/ready handler surface a
+// terminal error as a 503 body instead of polling forever.
+func TestCAStatus_AfterFailure(t *testing.T) {
+	ResetCAReadyForTest()
+	want := errors.New("synthetic: CA store unwritable")
+	MarkCAFailed(want)
+
+	ready, err := CAStatus()
+	if ready {
+		t.Fatalf("CAStatus.ready: got true, want false (failure must NOT latch readiness)")
+	}
+	if !errors.Is(err, want) {
+		t.Fatalf("CAStatus.err: got %v, want %v", err, want)
+	}
+
+	// ResetCAReadyForTest must clear the failure so subsequent
+	// tests see a clean baseline.
+	ResetCAReadyForTest()
+	if _, err := CAStatus(); err != nil {
+		t.Fatalf("after reset: err not cleared: %v", err)
+	}
+}
+
+// TestMarkCAFailed_NilIsNoOp documents the contract that
+// MarkCAFailed(nil) does nothing — callers can plumb the return of
+// SetupCA unconditionally without a nil-check on the hot path.
+func TestMarkCAFailed_NilIsNoOp(t *testing.T) {
+	ResetCAReadyForTest()
+	MarkCAFailed(nil)
+
+	_, err := CAStatus()
+	if err != nil {
+		t.Fatalf("MarkCAFailed(nil) should be a no-op, got err=%v", err)
+	}
+}

--- a/pkg/agent/proxy/tls/export_test.go
+++ b/pkg/agent/proxy/tls/export_test.go
@@ -1,0 +1,25 @@
+package tls
+
+import "sync"
+
+// This file is only compiled into the test binary (suffix _test.go). It
+// exposes a controlled way for tests in other packages to reset and
+// close the package-level CAReady signal without widening the public
+// API surface for production callers.
+//
+// Production code MUST NOT depend on these helpers — SetupCA is the
+// only way to legitimately close caReadyCh in a running agent.
+
+// ResetCAReadyForTest rebuilds caReadyOnce and caReadyCh so a fresh
+// test can observe the "CA not ready" state regardless of test
+// ordering. Tests that need a closed channel should follow this with
+// CloseCAReadyForTest.
+func ResetCAReadyForTest() {
+	caReadyOnce = sync.Once{}
+	caReadyCh = make(chan struct{})
+}
+
+// CloseCAReadyForTest closes the CAReady channel via the same
+// markCAReady path used by SetupCA, so production semantics are
+// exercised by tests.
+func CloseCAReadyForTest() { markCAReady() }

--- a/pkg/agent/proxy/tls/testing.go
+++ b/pkg/agent/proxy/tls/testing.go
@@ -8,6 +8,29 @@ import "sync"
 // suffix signals intent — production code MUST NOT call them;
 // SetupCA is the only legitimate path to close caReadyCh in a
 // running agent.
+//
+// These helpers mutate package-global state (caReadyOnce, caReadyCh,
+// caFailure). `go test ./...` runs packages in parallel, so without
+// serialization a test in pkg/agent/proxy/tls calling ResetCAReadyForTest
+// can clobber the signal while a concurrent test in pkg/agent/routes is
+// asserting on it — producing flakes and data races under `-race`.
+//
+// CAReadyTestMu is the single serializer every test that touches the
+// signal must hold. The canonical pattern is:
+//
+//	tls.CAReadyTestMu.Lock()
+//	defer tls.CAReadyTestMu.Unlock()
+//	tls.ResetCAReadyForTest()
+//	// ... exercise code under test ...
+//
+// Or, for a callback-scoped guard, use WithCAReadyTestLock below which
+// wraps the Lock/defer Unlock idiom so callers can't forget to unlock.
+
+// CAReadyTestMu serializes access to the CAReady package-global state
+// (caReadyOnce, caReadyCh, caFailure) across tests. All test helpers
+// below acquire it; external callers (sibling-package tests) must hold
+// it for the duration of any read-then-write sequence on the signal.
+var CAReadyTestMu sync.Mutex
 
 // ResetCAReadyForTest rebuilds caReadyOnce and caReadyCh and clears any
 // recorded CA-setup failure so a fresh test can observe the "CA not
@@ -15,7 +38,15 @@ import "sync"
 // need a closed channel should follow this with CloseCAReadyForTest;
 // tests exercising the failure path should call MarkCAFailed after
 // reset.
+//
+// Acquires CAReadyTestMu internally so a test that only resets before
+// assertions does not need explicit locking. Tests performing
+// read-then-write sequences (e.g. reset → assert behaviour → close →
+// assert again) must take the mutex themselves to make the sequence
+// atomic relative to concurrent tests in sibling packages.
 func ResetCAReadyForTest() {
+	CAReadyTestMu.Lock()
+	defer CAReadyTestMu.Unlock()
 	caReadyOnce = sync.Once{}
 	caReadyCh = make(chan struct{})
 	caFailure.Store(nil)
@@ -23,5 +54,20 @@ func ResetCAReadyForTest() {
 
 // CloseCAReadyForTest closes the CAReady channel via the same
 // markCAReady path used by SetupCA, so production semantics are
-// exercised by tests.
-func CloseCAReadyForTest() { markCAReady() }
+// exercised by tests. Acquires CAReadyTestMu internally.
+func CloseCAReadyForTest() {
+	CAReadyTestMu.Lock()
+	defer CAReadyTestMu.Unlock()
+	markCAReady()
+}
+
+// WithCAReadyTestLock runs fn while holding CAReadyTestMu, so a test can
+// perform a multi-step sequence (reset, configure, exercise, assert)
+// atomically relative to concurrent tests. Prefer this over manual
+// Lock/Unlock in tests to avoid missed-Unlock bugs on assertion failure
+// paths.
+func WithCAReadyTestLock(fn func()) {
+	CAReadyTestMu.Lock()
+	defer CAReadyTestMu.Unlock()
+	fn()
+}

--- a/pkg/agent/proxy/tls/testing.go
+++ b/pkg/agent/proxy/tls/testing.go
@@ -10,10 +10,15 @@ import "sync"
 // running agent.
 //
 // These helpers mutate package-global state (caReadyOnce, caReadyCh,
-// caFailure). `go test ./...` runs packages in parallel, so without
-// serialization a test in pkg/agent/proxy/tls calling ResetCAReadyForTest
-// can clobber the signal while a concurrent test in pkg/agent/routes is
-// asserting on it — producing flakes and data races under `-race`.
+// caFailure). Go compiles one test binary per package and runs
+// different packages in separate processes, so cross-package parallel
+// runs do NOT share these globals. Serialization is needed within a
+// single test binary — most concretely, when multiple tests inside
+// pkg/agent/routes (which imports this package) reset/close the signal
+// and may run in parallel via t.Parallel() or stress-run with -count.
+// Tests in pkg/agent/proxy/tls itself likewise serialize on the same
+// mutex so a future contributor who adds t.Parallel() there doesn't
+// introduce a race on caReadyCh.
 //
 // CAReadyTestMu is the single serializer every test that touches the
 // signal must hold. The canonical pattern is:
@@ -27,9 +32,10 @@ import "sync"
 // wraps the Lock/defer Unlock idiom so callers can't forget to unlock.
 
 // CAReadyTestMu serializes access to the CAReady package-global state
-// (caReadyOnce, caReadyCh, caFailure) across tests. All test helpers
-// below acquire it; external callers (sibling-package tests) must hold
-// it for the duration of any read-then-write sequence on the signal.
+// (caReadyOnce, caReadyCh, caFailure) within a single test binary.
+// All test helpers below acquire it; external callers (tests in
+// packages that import this one) must hold it for the duration of any
+// read-then-write sequence on the signal.
 var CAReadyTestMu sync.Mutex
 
 // ResetCAReadyForTest rebuilds caReadyOnce and caReadyCh and clears any

--- a/pkg/agent/proxy/tls/testing.go
+++ b/pkg/agent/proxy/tls/testing.go
@@ -2,13 +2,12 @@ package tls
 
 import "sync"
 
-// This file is only compiled into the test binary (suffix _test.go). It
-// exposes a controlled way for tests in other packages to reset and
-// close the package-level CAReady signal without widening the public
-// API surface for production callers.
-//
-// Production code MUST NOT depend on these helpers — SetupCA is the
-// only way to legitimately close caReadyCh in a running agent.
+// Testing helpers for the CAReady signal. These are regular package
+// functions (NOT _test.go) so sibling-package tests (e.g.
+// pkg/agent/routes) can reset and close the channel. The "ForTest"
+// suffix signals intent — production code MUST NOT call them;
+// SetupCA is the only legitimate path to close caReadyCh in a
+// running agent.
 
 // ResetCAReadyForTest rebuilds caReadyOnce and caReadyCh so a fresh
 // test can observe the "CA not ready" state regardless of test

--- a/pkg/agent/proxy/tls/testing.go
+++ b/pkg/agent/proxy/tls/testing.go
@@ -9,13 +9,16 @@ import "sync"
 // SetupCA is the only legitimate path to close caReadyCh in a
 // running agent.
 
-// ResetCAReadyForTest rebuilds caReadyOnce and caReadyCh so a fresh
-// test can observe the "CA not ready" state regardless of test
-// ordering. Tests that need a closed channel should follow this with
-// CloseCAReadyForTest.
+// ResetCAReadyForTest rebuilds caReadyOnce and caReadyCh and clears any
+// recorded CA-setup failure so a fresh test can observe the "CA not
+// ready, no error" baseline regardless of test ordering. Tests that
+// need a closed channel should follow this with CloseCAReadyForTest;
+// tests exercising the failure path should call MarkCAFailed after
+// reset.
 func ResetCAReadyForTest() {
 	caReadyOnce = sync.Once{}
 	caReadyCh = make(chan struct{})
+	caFailure.Store(nil)
 }
 
 // CloseCAReadyForTest closes the CAReady channel via the same

--- a/pkg/agent/routes/record.go
+++ b/pkg/agent/routes/record.go
@@ -45,6 +45,15 @@ var agentReadyFilePath = kdocker.AgentReadyFile
 // kubelet polls readiness aggressively during boot.
 var firstCARefusalLog sync.Once
 
+// firstCAFailureLog ensures we emit exactly one Error-level line the
+// first time /agent/ready observes a terminal SetupCA failure. The
+// condition is latched for the process lifetime (MarkCAFailed records
+// an error that never clears without an agent restart), so every
+// subsequent readiness poll would re-emit the same Error — which
+// floods operator logs and can dominate aggregators during incident
+// response. After the first emission, repeated polls log at Debug.
+var firstCAFailureLog sync.Once
+
 func (d DefaultRoutes) New(r chi.Router, agent agent.Service, logger *zap.Logger) {
 	a := &Agent{
 		logger: logger,
@@ -438,8 +447,27 @@ func (a *Agent) MakeAgentReady(w http.ResponseWriter, r *http.Request) {
 	// Warn would drown real warnings.
 	if ready, setupErr := pTls.CAStatus(); !ready {
 		if setupErr != nil {
-			a.logger.Error(
-				"/agent/ready: CA setup failed; readiness will not recover without agent restart",
+			// MarkCAFailed is a latch — operator-driven restart is the
+			// only way to clear it — so the first Error is the
+			// actionable signal. Emit it at Error (with a next_step
+			// field for operator guidance) exactly once, then degrade
+			// to Debug for repeat polls so readiness-poller churn
+			// doesn't drown the aggregator during incident response.
+			firstCAFailureLog.Do(func() {
+				a.logger.Error(
+					"/agent/ready: CA setup failed; readiness will not recover without agent restart",
+					zap.String("ca_path", "/tmp/keploy-tls/ca.crt"),
+					zap.String("next_step",
+						"Restart the agent after fixing the underlying "+
+							"SetupCA failure (see the earlier Error log "+
+							"line from pkg/agent/proxy for the specific "+
+							"next_step — typically write-access to "+
+							"/tmp/keploy-tls or to the host CA trust store)."),
+					zap.Error(setupErr),
+				)
+			})
+			a.logger.Debug(
+				"/agent/ready: CA setup failure still latched",
 				zap.String("ca_path", "/tmp/keploy-tls/ca.crt"),
 				zap.Error(setupErr),
 			)
@@ -477,7 +505,7 @@ func (a *Agent) MakeAgentReady(w http.ResponseWriter, r *http.Request) {
 			"failed to create readiness file",
 			zap.String("file", agentReadyFilePath),
 			zap.String("parent_dir", filepath.Dir(agentReadyFilePath)),
-			zap.String("remediation",
+			zap.String("next_step",
 				"ensure the parent directory exists, is writable by the agent "+
 					"user, and that the container filesystem / volume is not "+
 					"read-only or out of space"),

--- a/pkg/agent/routes/record.go
+++ b/pkg/agent/routes/record.go
@@ -426,17 +426,26 @@ func (a *Agent) HandleMappings(w http.ResponseWriter, r *http.Request) {
 //	healthcheck:
 //	  test: ["CMD", "cat", "/tmp/agent.ready"]
 func (a *Agent) MakeAgentReady(w http.ResponseWriter, r *http.Request) {
-	// The CA bundle at /tmp/keploy-tls/ca.crt MUST exist before the agent
-	// signals ready — Kubernetes postStart hooks and docker-compose
-	// healthchecks gate app-container start on /tmp/agent.ready, and apps
-	// may make HTTPS calls immediately on boot. Refuse readiness until
-	// SetupCA has completed (see pkg/agent/proxy/tls.CAStatus).
+	// The Keploy CA bundle MUST be installed before the agent signals
+	// ready — Kubernetes postStart hooks and docker-compose healthchecks
+	// gate app-container start on /tmp/agent.ready, and apps may make
+	// HTTPS calls immediately on boot. Refuse readiness until SetupCA
+	// has completed (see pkg/agent/proxy/tls.CAStatus).
+	//
+	// The install location is mode-dependent: the shared volume at
+	// /tmp/keploy-tls/ca.crt in Docker/k8s mode, the system trust store
+	// (distro-specific path under /etc or /usr/local) in native Linux
+	// mode, or a Windows temp file that is removed on shutdown. We
+	// deliberately do NOT log a ca_path here because no single value is
+	// correct in all modes; operators investigating a 503 should
+	// cross-reference the earlier Error log from pkg/agent/proxy (which
+	// names the actual path that failed).
 	//
 	// Today the ordering is race-free because SetupCA runs synchronously
 	// inside Hook() before the HTTP server starts. This explicit gate
 	// protects against a future refactor that moves SetupCA into a
 	// goroutine — without this check, app containers could boot before
-	// /tmp/keploy-tls/ca.crt exists and silently fail HTTPS egress.
+	// the CA bundle exists and silently fail HTTPS egress.
 	//
 	// CAStatus distinguishes three states: ready, not-yet-ready, and
 	// terminal setup failure. On failure we surface the underlying
@@ -456,19 +465,19 @@ func (a *Agent) MakeAgentReady(w http.ResponseWriter, r *http.Request) {
 			firstCAFailureLog.Do(func() {
 				a.logger.Error(
 					"/agent/ready: CA setup failed; readiness will not recover without agent restart",
-					zap.String("ca_path", "/tmp/keploy-tls/ca.crt"),
 					zap.String("next_step",
 						"Restart the agent after fixing the underlying "+
 							"SetupCA failure (see the earlier Error log "+
 							"line from pkg/agent/proxy for the specific "+
-							"next_step — typically write-access to "+
-							"/tmp/keploy-tls or to the host CA trust store)."),
+							"install path and next_step — typically "+
+							"write-access to /tmp/keploy-tls in shared-"+
+							"volume mode or to the host CA trust store "+
+							"in native mode)."),
 					zap.Error(setupErr),
 				)
 			})
 			a.logger.Debug(
 				"/agent/ready: CA setup failure still latched",
-				zap.String("ca_path", "/tmp/keploy-tls/ca.crt"),
 				zap.Error(setupErr),
 			)
 			http.Error(
@@ -483,15 +492,13 @@ func (a *Agent) MakeAgentReady(w http.ResponseWriter, r *http.Request) {
 		// boot window go to Debug to avoid flooding.
 		firstCARefusalLog.Do(func() {
 			a.logger.Info(
-				"/agent/ready called before CA bundle is written; refusing",
-				zap.String("ca_path", "/tmp/keploy-tls/ca.crt"),
+				"/agent/ready called before CA bundle is installed; refusing",
 			)
 		})
 		a.logger.Debug(
-			"/agent/ready still refusing: CA bundle not yet written",
-			zap.String("ca_path", "/tmp/keploy-tls/ca.crt"),
+			"/agent/ready still refusing: CA bundle not yet installed",
 		)
-		http.Error(w, "CA bundle not yet written", http.StatusServiceUnavailable)
+		http.Error(w, "CA bundle not yet installed", http.StatusServiceUnavailable)
 		return
 	}
 

--- a/pkg/agent/routes/record.go
+++ b/pkg/agent/routes/record.go
@@ -12,6 +12,7 @@ import (
 	"net/textproto"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -36,6 +37,13 @@ type Agent struct {
 // only so unit tests can redirect it into a sandbox without writing
 // into /tmp on the host. Production code MUST NOT mutate it.
 var agentReadyFilePath = kdocker.AgentReadyFile
+
+// firstCARefusalLog ensures we emit exactly one Info-level line the
+// first time /agent/ready is called before the CA bundle is written.
+// This is the observability signal operators rely on — subsequent
+// calls log at Debug to avoid flooding logs when docker-compose /
+// kubelet polls readiness aggressively during boot.
+var firstCARefusalLog sync.Once
 
 func (d DefaultRoutes) New(r chi.Router, agent agent.Service, logger *zap.Logger) {
 	a := &Agent{
@@ -413,19 +421,48 @@ func (a *Agent) MakeAgentReady(w http.ResponseWriter, r *http.Request) {
 	// signals ready — Kubernetes postStart hooks and docker-compose
 	// healthchecks gate app-container start on /tmp/agent.ready, and apps
 	// may make HTTPS calls immediately on boot. Refuse readiness until
-	// SetupCA has completed (see pkg/agent/proxy/tls.CAReady).
+	// SetupCA has completed (see pkg/agent/proxy/tls.CAStatus).
 	//
 	// Today the ordering is race-free because SetupCA runs synchronously
 	// inside Hook() before the HTTP server starts. This explicit gate
 	// protects against a future refactor that moves SetupCA into a
 	// goroutine — without this check, app containers could boot before
 	// /tmp/keploy-tls/ca.crt exists and silently fail HTTPS egress.
-	select {
-	case <-pTls.CAReady():
-		// CA bundle is on disk — proceed to mark the agent ready.
-	default:
-		a.logger.Warn("/agent/ready called before CA bundle is written; refusing",
-			zap.String("ca_path", "/tmp/keploy-tls/ca.crt"))
+	//
+	// CAStatus distinguishes three states: ready, not-yet-ready, and
+	// terminal setup failure. On failure we surface the underlying
+	// error so operators see "CA setup failed: ..." instead of
+	// polling forever on an opaque 503. The log line is Debug (not
+	// Warn) because this endpoint is routinely polled by docker-compose
+	// / kubelet during boot and the 503 itself is the signal; spamming
+	// Warn would drown real warnings.
+	if ready, setupErr := pTls.CAStatus(); !ready {
+		if setupErr != nil {
+			a.logger.Error(
+				"/agent/ready: CA setup failed; readiness will not recover without agent restart",
+				zap.String("ca_path", "/tmp/keploy-tls/ca.crt"),
+				zap.Error(setupErr),
+			)
+			http.Error(
+				w,
+				fmt.Sprintf("CA setup failed: %v", setupErr),
+				http.StatusServiceUnavailable,
+			)
+			return
+		}
+		// Log the first refusal at Info so the gate's behaviour is
+		// visible in default-level logs; subsequent polls during the
+		// boot window go to Debug to avoid flooding.
+		firstCARefusalLog.Do(func() {
+			a.logger.Info(
+				"/agent/ready called before CA bundle is written; refusing",
+				zap.String("ca_path", "/tmp/keploy-tls/ca.crt"),
+			)
+		})
+		a.logger.Debug(
+			"/agent/ready still refusing: CA bundle not yet written",
+			zap.String("ca_path", "/tmp/keploy-tls/ca.crt"),
+		)
 		http.Error(w, "CA bundle not yet written", http.StatusServiceUnavailable)
 		return
 	}
@@ -433,7 +470,19 @@ func (a *Agent) MakeAgentReady(w http.ResponseWriter, r *http.Request) {
 	// Create or overwrite the readiness file with a timestamp
 	content := []byte(time.Now().Format(time.RFC3339) + "\n")
 	if err := os.WriteFile(agentReadyFilePath, content, 0644); err != nil {
-		a.logger.Error("failed to create readiness file", zap.String("file", agentReadyFilePath), zap.Error(err))
+		// This path blocks docker-compose / kubelet startup, so the
+		// log line must point operators at the common root causes:
+		// read-only mount, missing parent dir, or disk pressure.
+		a.logger.Error(
+			"failed to create readiness file",
+			zap.String("file", agentReadyFilePath),
+			zap.String("parent_dir", filepath.Dir(agentReadyFilePath)),
+			zap.String("remediation",
+				"ensure the parent directory exists, is writable by the agent "+
+					"user, and that the container filesystem / volume is not "+
+					"read-only or out of space"),
+			zap.Error(err),
+		)
 		http.Error(w, "failed to mark agent as ready", http.StatusInternalServerError)
 		return
 	}

--- a/pkg/agent/routes/record.go
+++ b/pkg/agent/routes/record.go
@@ -30,6 +30,13 @@ type Agent struct {
 	svc    agent.Service
 }
 
+// agentReadyFilePath is the path MakeAgentReady writes on success. It
+// defaults to kdocker.AgentReadyFile (the canonical /tmp/agent.ready
+// location consumed by the docker-compose healthcheck) and is a var
+// only so unit tests can redirect it into a sandbox without writing
+// into /tmp on the host. Production code MUST NOT mutate it.
+var agentReadyFilePath = kdocker.AgentReadyFile
+
 func (d DefaultRoutes) New(r chi.Router, agent agent.Service, logger *zap.Logger) {
 	a := &Agent{
 		logger: logger,
@@ -425,13 +432,13 @@ func (a *Agent) MakeAgentReady(w http.ResponseWriter, r *http.Request) {
 
 	// Create or overwrite the readiness file with a timestamp
 	content := []byte(time.Now().Format(time.RFC3339) + "\n")
-	if err := os.WriteFile(kdocker.AgentReadyFile, content, 0644); err != nil {
-		a.logger.Error("failed to create readiness file", zap.String("file", kdocker.AgentReadyFile), zap.Error(err))
+	if err := os.WriteFile(agentReadyFilePath, content, 0644); err != nil {
+		a.logger.Error("failed to create readiness file", zap.String("file", agentReadyFilePath), zap.Error(err))
 		http.Error(w, "failed to mark agent as ready", http.StatusInternalServerError)
 		return
 	}
 
-	a.logger.Debug("Agent marked as ready", zap.String("file", kdocker.AgentReadyFile))
+	a.logger.Debug("Agent marked as ready", zap.String("file", agentReadyFilePath))
 	w.WriteHeader(http.StatusOK)
 	a.logger.Debug("Keploy Agent is ready from the ...")
 	_, _ = w.Write([]byte("Agent is now ready\n"))

--- a/pkg/agent/routes/record.go
+++ b/pkg/agent/routes/record.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
+	pTls "go.keploy.io/server/v3/pkg/agent/proxy/tls"
 	"go.keploy.io/server/v3/pkg/models"
 	kdocker "go.keploy.io/server/v3/pkg/platform/docker"
 	"go.keploy.io/server/v3/pkg/service/agent"
@@ -401,6 +402,27 @@ func (a *Agent) HandleMappings(w http.ResponseWriter, r *http.Request) {
 //	healthcheck:
 //	  test: ["CMD", "cat", "/tmp/agent.ready"]
 func (a *Agent) MakeAgentReady(w http.ResponseWriter, r *http.Request) {
+	// The CA bundle at /tmp/keploy-tls/ca.crt MUST exist before the agent
+	// signals ready — Kubernetes postStart hooks and docker-compose
+	// healthchecks gate app-container start on /tmp/agent.ready, and apps
+	// may make HTTPS calls immediately on boot. Refuse readiness until
+	// SetupCA has completed (see pkg/agent/proxy/tls.CAReady).
+	//
+	// Today the ordering is race-free because SetupCA runs synchronously
+	// inside Hook() before the HTTP server starts. This explicit gate
+	// protects against a future refactor that moves SetupCA into a
+	// goroutine — without this check, app containers could boot before
+	// /tmp/keploy-tls/ca.crt exists and silently fail HTTPS egress.
+	select {
+	case <-pTls.CAReady():
+		// CA bundle is on disk — proceed to mark the agent ready.
+	default:
+		a.logger.Warn("/agent/ready called before CA bundle is written; refusing",
+			zap.String("ca_path", "/tmp/keploy-tls/ca.crt"))
+		http.Error(w, "CA bundle not yet written", http.StatusServiceUnavailable)
+		return
+	}
+
 	// Create or overwrite the readiness file with a timestamp
 	content := []byte(time.Now().Format(time.RFC3339) + "\n")
 	if err := os.WriteFile(kdocker.AgentReadyFile, content, 0644); err != nil {

--- a/pkg/agent/routes/record_test.go
+++ b/pkg/agent/routes/record_test.go
@@ -1,0 +1,114 @@
+package routes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	pTls "go.keploy.io/server/v3/pkg/agent/proxy/tls"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+)
+
+// redirectAgentReadyFile rewrites the package-level agentReadyFilePath
+// to a sandboxed path under t.TempDir() so tests exercise the real
+// os.WriteFile path without clobbering /tmp/agent.ready on the host.
+// The original value is restored via t.Cleanup.
+func redirectAgentReadyFile(t *testing.T) string {
+	t.Helper()
+	orig := agentReadyFilePath
+	sandbox := filepath.Join(t.TempDir(), "agent.ready")
+	agentReadyFilePath = sandbox
+	t.Cleanup(func() { agentReadyFilePath = orig })
+	return sandbox
+}
+
+// newTestAgent builds a routes.Agent with a test logger and nil service —
+// MakeAgentReady does not touch svc, so a nil service is safe.
+func newTestAgent(t *testing.T) *Agent {
+	t.Helper()
+	return &Agent{
+		logger: zaptest.NewLogger(t, zaptest.Level(zap.WarnLevel)),
+	}
+}
+
+func TestMakeAgentReady_RefusesWhenCANotReady(t *testing.T) {
+	// Reset the package-level CAReady signal so this test observes the
+	// "not ready" state regardless of previous tests in the binary.
+	pTls.ResetCAReadyForTest()
+
+	readyFile := redirectAgentReadyFile(t)
+	a := newTestAgent(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/agent/agent/ready", nil)
+	rr := httptest.NewRecorder()
+
+	a.MakeAgentReady(rr, req)
+
+	if got, want := rr.Code, http.StatusServiceUnavailable; got != want {
+		t.Fatalf("status: got %d, want %d", got, want)
+	}
+	// Confirm the readiness file was NOT touched on the 503 path —
+	// that's the whole point of the gate.
+	if _, err := os.Stat(readyFile); !os.IsNotExist(err) {
+		t.Fatalf("agent.ready must not be created on 503; stat err=%v", err)
+	}
+}
+
+func TestMakeAgentReady_SucceedsWhenCAReady(t *testing.T) {
+	pTls.ResetCAReadyForTest()
+	pTls.CloseCAReadyForTest()
+
+	readyFile := redirectAgentReadyFile(t)
+	a := newTestAgent(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/agent/agent/ready", nil)
+	rr := httptest.NewRecorder()
+
+	a.MakeAgentReady(rr, req)
+
+	if got, want := rr.Code, http.StatusOK; got != want {
+		t.Fatalf("status: got %d, want %d; body=%q", got, want, rr.Body.String())
+	}
+	if _, err := os.Stat(readyFile); err != nil {
+		t.Fatalf("agent.ready must be written on 200: %v", err)
+	}
+}
+
+// TestMakeAgentReady_NoReadinessFileOn503 is a tight regression guard
+// for the exact failure mode the gate protects against: an app
+// container observing /tmp/agent.ready and booting before the CA
+// bundle is on disk. It is intentionally narrower than the 503 test
+// above so a regression lights up here first.
+func TestMakeAgentReady_NoReadinessFileOn503(t *testing.T) {
+	pTls.ResetCAReadyForTest()
+
+	readyFile := redirectAgentReadyFile(t)
+	a := newTestAgent(t)
+
+	// Hit the endpoint several times; every call must 503 and none
+	// must ever create the readiness file.
+	for i := 0; i < 5; i++ {
+		rr := httptest.NewRecorder()
+		a.MakeAgentReady(rr, httptest.NewRequest(http.MethodPost, "/agent/agent/ready", nil))
+		if rr.Code != http.StatusServiceUnavailable {
+			t.Fatalf("call %d: expected 503, got %d", i, rr.Code)
+		}
+		if _, err := os.Stat(readyFile); !os.IsNotExist(err) {
+			t.Fatalf("call %d: agent.ready leaked (stat err=%v)", i, err)
+		}
+	}
+
+	// Now flip the signal and verify the next call writes the file.
+	pTls.CloseCAReadyForTest()
+	rr := httptest.NewRecorder()
+	a.MakeAgentReady(rr, httptest.NewRequest(http.MethodPost, "/agent/agent/ready", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("after CA ready: expected 200, got %d", rr.Code)
+	}
+	if _, err := os.Stat(readyFile); err != nil {
+		t.Fatalf("after CA ready: expected agent.ready on disk: %v", err)
+	}
+}

--- a/pkg/agent/routes/record_test.go
+++ b/pkg/agent/routes/record_test.go
@@ -1,10 +1,12 @@
 package routes
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	pTls "go.keploy.io/server/v3/pkg/agent/proxy/tls"
@@ -75,6 +77,40 @@ func TestMakeAgentReady_SucceedsWhenCAReady(t *testing.T) {
 	if _, err := os.Stat(readyFile); err != nil {
 		t.Fatalf("agent.ready must be written on 200: %v", err)
 	}
+}
+
+// TestMakeAgentReady_SurfacesCASetupFailure verifies that a terminal
+// SetupCA error recorded via MarkCAFailed is reflected in the 503
+// body instead of the generic "not yet written" message, and that
+// the readiness file is NOT created. This is the failure-mode
+// Copilot raised: without this path, operators see endless 503s with
+// no diagnostic when SetupCA errored out at boot.
+func TestMakeAgentReady_SurfacesCASetupFailure(t *testing.T) {
+	pTls.ResetCAReadyForTest()
+	pTls.MarkCAFailed(errors.New("synthetic: no writable CA store"))
+
+	readyFile := redirectAgentReadyFile(t)
+	a := newTestAgent(t)
+
+	rr := httptest.NewRecorder()
+	a.MakeAgentReady(rr, httptest.NewRequest(http.MethodPost, "/agent/agent/ready", nil))
+
+	if got, want := rr.Code, http.StatusServiceUnavailable; got != want {
+		t.Fatalf("status: got %d, want %d; body=%q", got, want, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "CA setup failed") {
+		t.Fatalf("body should surface setup error, got %q", rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "synthetic: no writable CA store") {
+		t.Fatalf("body should echo the underlying error, got %q", rr.Body.String())
+	}
+	if _, err := os.Stat(readyFile); !os.IsNotExist(err) {
+		t.Fatalf("agent.ready must not be created on CA-setup-failure 503; stat err=%v", err)
+	}
+
+	// Clear the failure so subsequent tests in the binary see a
+	// clean baseline regardless of ordering.
+	pTls.ResetCAReadyForTest()
 }
 
 // TestMakeAgentReady_NoReadinessFileOn503 is a tight regression guard

--- a/tests/e2e/agent-ready-gated-on-ca/Dockerfile
+++ b/tests/e2e/agent-ready-gated-on-ca/Dockerfile
@@ -2,7 +2,12 @@
 # tests/e2e/agent-ready-gated-on-ca. The harness mounts the real
 # pkg/agent/routes handlers but sidesteps the full agent (eBPF,
 # proxy, memoryguard) so the container doesn't need privileged mode.
-FROM golang:1.26-bookworm AS build
+#
+# Both base images are pulled from ECR Public's Docker Hub mirror so
+# this build is immune to Docker Hub unauth rate limits (HTTP 429) on
+# shared GitHub Actions runners. Tags are pinned — `:latest` would
+# make the e2e non-reproducible across CI runs.
+FROM public.ecr.aws/docker/library/golang:1.26-bookworm AS build
 WORKDIR /src
 
 # Copy the full keploy module so the harness build picks up the
@@ -17,7 +22,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
       -o /out/e2e-harness \
       ./tests/e2e/agent-ready-gated-on-ca/harness
 
-FROM alpine:latest
+FROM public.ecr.aws/docker/library/alpine:3.20
 RUN apk add --no-cache ca-certificates
 COPY --from=build /out/e2e-harness /usr/local/bin/e2e-harness
 EXPOSE 8086

--- a/tests/e2e/agent-ready-gated-on-ca/Dockerfile
+++ b/tests/e2e/agent-ready-gated-on-ca/Dockerfile
@@ -2,7 +2,7 @@
 # tests/e2e/agent-ready-gated-on-ca. The harness mounts the real
 # pkg/agent/routes handlers but sidesteps the full agent (eBPF,
 # proxy, memoryguard) so the container doesn't need privileged mode.
-FROM golang:1.26 AS build
+FROM golang:1.26-bookworm AS build
 WORKDIR /src
 
 # Copy the full keploy module so the harness build picks up the
@@ -17,7 +17,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
       -o /out/e2e-harness \
       ./tests/e2e/agent-ready-gated-on-ca/harness
 
-FROM alpine:3.20
+FROM alpine:latest
 RUN apk add --no-cache ca-certificates
 COPY --from=build /out/e2e-harness /usr/local/bin/e2e-harness
 EXPOSE 8086

--- a/tests/e2e/agent-ready-gated-on-ca/Dockerfile
+++ b/tests/e2e/agent-ready-gated-on-ca/Dockerfile
@@ -1,0 +1,24 @@
+# Multi-stage build of the e2e harness for
+# tests/e2e/agent-ready-gated-on-ca. The harness mounts the real
+# pkg/agent/routes handlers but sidesteps the full agent (eBPF,
+# proxy, memoryguard) so the container doesn't need privileged mode.
+FROM golang:1.26 AS build
+WORKDIR /src
+
+# Copy the full keploy module so the harness build picks up the
+# in-tree handler code under test — not a published version.
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build \
+      -trimpath -ldflags="-s -w" \
+      -o /out/e2e-harness \
+      ./tests/e2e/agent-ready-gated-on-ca/harness
+
+FROM alpine:3.20
+RUN apk add --no-cache ca-certificates
+COPY --from=build /out/e2e-harness /usr/local/bin/e2e-harness
+EXPOSE 8086
+ENTRYPOINT ["/usr/local/bin/e2e-harness"]

--- a/tests/e2e/agent-ready-gated-on-ca/docker-compose.yml
+++ b/tests/e2e/agent-ready-gated-on-ca/docker-compose.yml
@@ -1,0 +1,45 @@
+# End-to-end harness for tests/e2e/agent-ready-gated-on-ca.
+#
+# "agent" runs the e2e-harness built from local source. It mirrors the
+# real pkg/agent/routes endpoints but closes the CAReady signal only
+# after CA_DELAY — so the first /agent/ready call observes the gate
+# returning 503 and subsequent calls (after CA_DELAY) observe 200.
+#
+# "client" is a BusyBox sidecar that POSTs /agent/ready repeatedly and
+# writes each attempt's HTTP status to /shared/status.log — run.sh
+# parses that log plus the agent's stdout to assert both the 503 and
+# 200 phases happen in the right order.
+services:
+  agent:
+    build:
+      context: ../../..
+      dockerfile: tests/e2e/agent-ready-gated-on-ca/Dockerfile
+    image: keploy-e2e-agent-ready-harness:latest
+    command: ["-addr=:8086", "-ca-delay=5s"]
+    expose:
+      - "8086"
+    volumes:
+      - shared:/shared
+
+  client:
+    image: alpine:3.20
+    depends_on:
+      - agent
+    volumes:
+      - shared:/shared
+    command:
+      - /bin/sh
+      - -c
+      - |
+        apk add --no-cache curl >/dev/null 2>&1
+        : >/shared/status.log
+        for i in $$(seq 1 30); do
+          code=$$(curl -s -o /dev/null -w "%{http_code}" -X POST http://agent:8086/agent/agent/ready || echo "ERR")
+          printf "%s %s\n" "$$(date -u +%FT%TZ)" "$$code" >> /shared/status.log
+          sleep 1
+        done
+        echo DONE >> /shared/status.log
+        tail -f /dev/null
+
+volumes:
+  shared: {}

--- a/tests/e2e/agent-ready-gated-on-ca/docker-compose.yml
+++ b/tests/e2e/agent-ready-gated-on-ca/docker-compose.yml
@@ -18,13 +18,29 @@ services:
     command: ["-addr=:8086", "-ca-delay=5s"]
     expose:
       - "8086"
+    # TCP-connect healthcheck (busybox's `nc -z`) — once the harness binds
+    # port 8086 the listener is ready to accept HTTP requests. This is the
+    # canonical way to gate depends_on without hitting /agent/agent/ready
+    # itself (which is the endpoint under test and deliberately 503s for
+    # the first CA_DELAY seconds).
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "8086"]
+      interval: 1s
+      timeout: 2s
+      retries: 10
+      start_period: 2s
     volumes:
       - shared:/shared
 
   client:
     image: alpine:latest
+    # Wait for the agent's HTTP listener to be bound before firing the first
+    # curl. Without this, the first poll-iteration races the Go bootstrap
+    # and records "000" (connection refused) instead of the "503" the test
+    # expects — a flake that has nothing to do with the CA-ready gate.
     depends_on:
-      - agent
+      agent:
+        condition: service_healthy
     volumes:
       - shared:/shared
     command:

--- a/tests/e2e/agent-ready-gated-on-ca/docker-compose.yml
+++ b/tests/e2e/agent-ready-gated-on-ca/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - shared:/shared
 
   client:
-    image: alpine:3.20
+    image: alpine:latest
     depends_on:
       - agent
     volumes:

--- a/tests/e2e/agent-ready-gated-on-ca/docker-compose.yml
+++ b/tests/e2e/agent-ready-gated-on-ca/docker-compose.yml
@@ -46,7 +46,11 @@ services:
       - shared:/shared
 
   client:
-    image: alpine:latest
+    # Pinned digest-less but explicit Alpine tag from ECR Public
+    # (Docker Hub mirror) so the e2e is reproducible across CI runs
+    # and immune to Docker Hub rate limits. Bumping requires editing
+    # the tag explicitly — never use `:latest`.
+    image: public.ecr.aws/docker/library/alpine:3.20
     # Wait for the agent's HTTP listener to be bound before firing the first
     # curl. Without this, the first poll-iteration races the Go bootstrap
     # and records "000" (connection refused) instead of the "503" the test
@@ -63,7 +67,19 @@ services:
         apk add --no-cache curl >/dev/null 2>&1
         : >/shared/status.log
         for i in $$(seq 1 30); do
-          code=$$(curl -s -o /dev/null -w "%{http_code}" -X POST http://agent:8086/agent/agent/ready || echo "ERR")
+          # Capture curl's exit status separately so `code` is always
+          # a single token. `curl ... || echo ERR` can produce
+          # multi-line output on failure (curl still writes "000" via
+          # -w before exiting non-zero, then the fallback appends
+          # another line), which corrupts awk parsing downstream.
+          code=$$(curl -s -o /dev/null -w "%{http_code}" -X POST http://agent:8086/agent/agent/ready)
+          curl_rc=$$?
+          if [ "$$curl_rc" -ne 0 ]; then
+            code="ERR"
+          fi
+          # Strip any stray whitespace/newlines just in case the
+          # target is behind a proxy that mangles the response.
+          code=$$(printf "%s" "$$code" | tr -d '[:space:]')
           printf "%s %s\n" "$$(date -u +%FT%TZ)" "$$code" >> /shared/status.log
           sleep 1
         done

--- a/tests/e2e/agent-ready-gated-on-ca/docker-compose.yml
+++ b/tests/e2e/agent-ready-gated-on-ca/docker-compose.yml
@@ -15,20 +15,33 @@ services:
       context: ../../..
       dockerfile: tests/e2e/agent-ready-gated-on-ca/Dockerfile
     image: keploy-e2e-agent-ready-harness:latest
-    command: ["-addr=:8086", "-ca-delay=5s"]
+    # ca-delay must comfortably exceed the worst-case time between binary
+    # start and the client's FIRST curl (= healthcheck latency + compose's
+    # "Waiting ... Healthy" bookkeeping + client container startup). On a
+    # cold GitHub Actions runner this totals ~2–3s; 15s leaves ~12s of
+    # pre-CAReady window for the first ~12 of 30 client poll iterations
+    # to observe the refusing 503 before the signal flips.
+    command: ["-addr=:8086", "-ca-delay=15s"]
     expose:
       - "8086"
     # TCP-connect healthcheck (busybox's `nc -z`) — once the harness binds
     # port 8086 the listener is ready to accept HTTP requests. This is the
     # canonical way to gate depends_on without hitting /agent/agent/ready
     # itself (which is the endpoint under test and deliberately 503s for
-    # the first CA_DELAY seconds).
+    # the first ca-delay seconds).
+    #
+    # Tuned so the check declares Healthy as close as possible to the
+    # moment the listener binds: start_period=0s means we start probing
+    # immediately, interval=500ms + retries=20 gives up to 10s grace
+    # without contributing to steady-state latency, and timeout=1s keeps
+    # each probe cheap. On GHA the transition to Healthy completes in
+    # ~1s after the container goes Running.
     healthcheck:
       test: ["CMD", "nc", "-z", "localhost", "8086"]
-      interval: 1s
-      timeout: 2s
-      retries: 10
-      start_period: 2s
+      interval: 500ms
+      timeout: 1s
+      retries: 20
+      start_period: 0s
     volumes:
       - shared:/shared
 

--- a/tests/e2e/agent-ready-gated-on-ca/harness/main.go
+++ b/tests/e2e/agent-ready-gated-on-ca/harness/main.go
@@ -1,0 +1,63 @@
+// Command e2e-agent-ready-harness is a minimal wrapper around the
+// pkg/agent/routes MakeAgentReady HTTP handler used by the e2e test in
+// tests/e2e/agent-ready-gated-on-ca. It intentionally does NOT spin up
+// the full keploy agent (eBPF hooks, proxy, memory guard, ...) because
+// all that machinery needs CAP_SYS_ADMIN / privileged containers and is
+// orthogonal to what this regression test actually checks: that
+// /agent/ready refuses to write /tmp/agent.ready until the CA-bundle
+// signal has fired.
+//
+// The harness binds the MakeAgentReady handler on a configurable port
+// and, after a configurable delay, triggers the CAReady signal via the
+// tls.CloseCAReadyForTest helper — simulating SetupCA finishing.
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"go.keploy.io/server/v3/pkg/agent/proxy/tls"
+	"go.keploy.io/server/v3/pkg/agent/routes"
+	"go.uber.org/zap"
+)
+
+func main() {
+	addr := flag.String("addr", ":8086", "listen address")
+	caDelay := flag.Duration("ca-delay", 5*time.Second, "how long to wait before signalling CAReady")
+	flag.Parse()
+
+	logger, err := zap.NewProduction()
+	if err != nil {
+		log.Fatalf("logger: %v", err)
+	}
+
+	// Start unlatched — the /agent/ready handler must observe the
+	// "CA not ready" state until caDelay elapses.
+	tls.ResetCAReadyForTest()
+
+	go func() {
+		time.Sleep(*caDelay)
+		logger.Info("harness: signalling CAReady after delay", zap.Duration("delay", *caDelay))
+		tls.CloseCAReadyForTest()
+	}()
+
+	r := chi.NewRouter()
+	// Mount the real DefaultRoutes so we exercise the production
+	// routing (and the real MakeAgentReady handler) end-to-end.
+	routes.ActiveHooks.New(r, nil, logger)
+
+	logger.Info("harness: listening", zap.String("addr", *addr))
+	srv := &http.Server{
+		Addr:              *addr,
+		Handler:           r,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		logger.Fatal("listen", zap.Error(err))
+		os.Exit(1)
+	}
+}

--- a/tests/e2e/agent-ready-gated-on-ca/harness/main.go
+++ b/tests/e2e/agent-ready-gated-on-ca/harness/main.go
@@ -16,7 +16,6 @@ import (
 	"flag"
 	"log"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -56,8 +55,11 @@ func main() {
 		Handler:           r,
 		ReadHeaderTimeout: 10 * time.Second,
 	}
+	// logger.Fatal calls os.Exit(1) internally after flushing, so no
+	// explicit exit is needed here. http.ErrServerClosed is only
+	// returned after a graceful Shutdown (not in this harness) — any
+	// error reaching this branch is fatal for the test run.
 	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		logger.Fatal("listen", zap.Error(err))
-		os.Exit(1)
 	}
 }

--- a/tests/e2e/agent-ready-gated-on-ca/run.sh
+++ b/tests/e2e/agent-ready-gated-on-ca/run.sh
@@ -38,7 +38,31 @@ $COMPOSE -p "$PROJECT" build --quiet
 # is idempotent (cached on subsequent runs), so retrying for up to ~1m
 # converts a transient infrastructure flake into a successful run
 # without masking a genuine registry outage.
-CLIENT_IMAGE=$(awk '/^  client:/,/^  [a-z]/' docker-compose.yml | awk '/^[[:space:]]*image:/ {print $2; exit}')
+# Extract the client service image from docker-compose.yml with a
+# state-machine awk (the naive `/client:/,/next-service/` range trick
+# mis-fires because the `client:` line matches *both* delimiters of the
+# range, so it collapses to a single line and the `image:` key is never
+# in range). Sibling services sit at two-space indent while keys inside
+# a service sit at four, so we can detect the service boundary
+# unambiguously. Prefer `docker compose config --format json` when jq is
+# available — it evaluates env interpolation and is immune to YAML
+# indentation changes — and only fall back to the awk path when jq is
+# absent (e.g. minimal runners).
+CLIENT_IMAGE=""
+if command -v jq >/dev/null 2>&1; then
+  CLIENT_IMAGE=$($COMPOSE -p "$PROJECT" config --format json 2>/dev/null | jq -r '.services.client.image // empty' 2>/dev/null)
+fi
+if [ -z "$CLIENT_IMAGE" ]; then
+  CLIENT_IMAGE=$(awk '
+    /^  client:$/ { inside=1; next }
+    inside && /^  [^ ]/ { inside=0 }
+    inside && /^    image:/ { sub(/^    image:[[:space:]]*/, ""); print; exit }
+  ' docker-compose.yml)
+fi
+if [ -z "$CLIENT_IMAGE" ]; then
+  echo "FAIL: could not resolve client service image from docker-compose.yml" >&2
+  exit 7
+fi
 echo ">> pre-pulling client image ($CLIENT_IMAGE) with retries"
 pull_ok=0
 for attempt in 1 2 3 4 5 6; do

--- a/tests/e2e/agent-ready-gated-on-ca/run.sh
+++ b/tests/e2e/agent-ready-gated-on-ca/run.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# End-to-end regression guard for the /agent/ready gate on CA readiness.
+#
+# What this asserts:
+#   1. Immediately on startup, POST /agent/ready returns 503 (CA not
+#      yet written) and the agent stdout contains the "refusing"
+#      warning with ca_path=/tmp/keploy-tls/ca.crt.
+#   2. After the harness flips the CAReady signal, subsequent POST
+#      /agent/ready return 200 and /tmp/agent.ready exists inside the
+#      agent container.
+#
+# Exit codes:
+#   0 — both assertions hold.
+#   nonzero — regression (or infrastructure error; see stderr).
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+cd "$HERE"
+
+COMPOSE="${COMPOSE:-docker compose}"
+PROJECT="agent-ready-gate-e2e"
+
+cleanup() {
+  $COMPOSE -p "$PROJECT" down -v --remove-orphans >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo ">> building stack"
+$COMPOSE -p "$PROJECT" build --quiet
+
+echo ">> starting stack"
+$COMPOSE -p "$PROJECT" up -d
+
+# Wait long enough for: boot + ~3s of pre-CAReady 503s + CAReady + ~5s of 200s.
+echo ">> waiting for client to finish 30 poll iterations"
+for _ in $(seq 1 60); do
+  if $COMPOSE -p "$PROJECT" exec -T client sh -c 'grep -q "^DONE$" /shared/status.log 2>/dev/null'; then
+    break
+  fi
+  sleep 1
+done
+
+LOG=$(mktemp)
+$COMPOSE -p "$PROJECT" exec -T client sh -c 'cat /shared/status.log' > "$LOG"
+
+echo ">> status log:"
+cat "$LOG"
+
+# First recorded status must be 503 (CA not ready yet).
+first_code=$(awk 'NR==1{print $2}' "$LOG")
+if [[ "$first_code" != "503" ]]; then
+  echo "FAIL: expected first status=503, got '$first_code'" >&2
+  exit 2
+fi
+
+# Somewhere in the log there must be a 200 (CA ready after delay).
+if ! awk '{print $2}' "$LOG" | grep -qx "200"; then
+  echo "FAIL: no 200 observed after CAReady delay" >&2
+  exit 3
+fi
+
+# After the first 200, every subsequent status must stay 200.
+if ! awk '
+  $2=="200" { seen=1; next }
+  seen && $2!="200" && $2!="DONE" { exit 1 }
+' "$LOG"; then
+  echo "FAIL: observed non-200 status after the CAReady transition" >&2
+  exit 4
+fi
+
+# Agent stdout must contain the "refusing" warning (zap JSON output).
+AGENT_LOG=$(mktemp)
+$COMPOSE -p "$PROJECT" logs agent > "$AGENT_LOG" 2>&1 || true
+if ! grep -q "CA bundle is written; refusing" "$AGENT_LOG"; then
+  echo "FAIL: agent log missing 'refusing' warning" >&2
+  echo "--- agent log ---" >&2
+  cat "$AGENT_LOG" >&2
+  exit 5
+fi
+
+# /tmp/agent.ready must exist inside the agent container by now.
+if ! $COMPOSE -p "$PROJECT" exec -T agent sh -c 'test -f /tmp/agent.ready'; then
+  echo "FAIL: /tmp/agent.ready not present in agent container" >&2
+  exit 6
+fi
+
+echo "PASS: /agent/ready correctly gated on CA readiness"
+exit 0

--- a/tests/e2e/agent-ready-gated-on-ca/run.sh
+++ b/tests/e2e/agent-ready-gated-on-ca/run.sh
@@ -61,9 +61,14 @@ if ! awk '{print $2}' "$LOG" | grep -qx "200"; then
 fi
 
 # After the first 200, every subsequent status must stay 200.
+# Lines without an HTTP status in $2 (e.g. the trailing "DONE" sentinel
+# or any blank line) are skipped.
 if ! awk '
-  $2=="200" { seen=1; next }
-  seen && $2!="200" && $2!="DONE" { exit 1 }
+  NF < 2 { next }
+  $1 == "DONE" { next }
+  $2 !~ /^[0-9]+$/ { next }
+  $2 == "200" { seen = 1; next }
+  seen { exit 1 }
 ' "$LOG"; then
   echo "FAIL: observed non-200 status after the CAReady transition" >&2
   exit 4

--- a/tests/e2e/agent-ready-gated-on-ca/run.sh
+++ b/tests/e2e/agent-ready-gated-on-ca/run.sh
@@ -3,8 +3,9 @@
 #
 # What this asserts:
 #   1. Immediately on startup, POST /agent/ready returns 503 (CA not
-#      yet written) and the agent stdout contains the "refusing"
-#      warning with ca_path=/tmp/keploy-tls/ca.crt.
+#      yet installed) and the agent stdout contains the "refusing"
+#      warning (message is mode-agnostic — the install path lives in
+#      the upstream SetupCA log line, not in this handler).
 #   2. After the harness flips the CAReady signal, subsequent POST
 #      /agent/ready return 200 and /tmp/agent.ready exists inside the
 #      agent container.
@@ -28,6 +29,35 @@ trap cleanup EXIT
 
 echo ">> building stack"
 $COMPOSE -p "$PROJECT" build --quiet
+
+# Pre-pull the `client` service base image with retries. ECR Public is
+# the Docker Hub mirror we use (see docker-compose.yml), but shared-IP
+# CI runners (GitHub Actions, Woodpecker) occasionally hit its
+# unauthenticated rate limit and `docker compose up` has no native
+# retry — it fails fast with "toomanyrequests: Rate exceeded". The pull
+# is idempotent (cached on subsequent runs), so retrying for up to ~1m
+# converts a transient infrastructure flake into a successful run
+# without masking a genuine registry outage.
+CLIENT_IMAGE=$(awk '/^  client:/,/^  [a-z]/' docker-compose.yml | awk '/^[[:space:]]*image:/ {print $2; exit}')
+echo ">> pre-pulling client image ($CLIENT_IMAGE) with retries"
+pull_ok=0
+for attempt in 1 2 3 4 5 6; do
+  if docker pull "$CLIENT_IMAGE"; then
+    pull_ok=1
+    break
+  fi
+  # Exponential-ish backoff (2,4,8,16,16,16s) — first three cover
+  # brief ratelimit windows, the remaining hold steady rather than
+  # stretching the test's wall clock indefinitely.
+  delay=$((attempt*attempt*2))
+  if [ "$delay" -gt 16 ]; then delay=16; fi
+  echo ">> pull attempt $attempt failed; retrying in ${delay}s" >&2
+  sleep "$delay"
+done
+if [ "$pull_ok" -ne 1 ]; then
+  echo "FAIL: unable to pull $CLIENT_IMAGE after 6 attempts — registry may be down" >&2
+  exit 7
+fi
 
 echo ">> starting stack"
 $COMPOSE -p "$PROJECT" up -d
@@ -98,7 +128,7 @@ fi
 # Agent stdout must contain the "refusing" warning (zap JSON output).
 AGENT_LOG=$(mktemp)
 $COMPOSE -p "$PROJECT" logs agent > "$AGENT_LOG" 2>&1 || true
-if ! grep -q "CA bundle is written; refusing" "$AGENT_LOG"; then
+if ! grep -q "CA bundle is installed; refusing" "$AGENT_LOG"; then
   echo "FAIL: agent log missing 'refusing' warning" >&2
   echo "--- agent log ---" >&2
   cat "$AGENT_LOG" >&2

--- a/tests/e2e/agent-ready-gated-on-ca/run.sh
+++ b/tests/e2e/agent-ready-gated-on-ca/run.sh
@@ -33,13 +33,34 @@ echo ">> starting stack"
 $COMPOSE -p "$PROJECT" up -d
 
 # Wait long enough for: boot + ~3s of pre-CAReady 503s + CAReady + ~5s of 200s.
+#
+# The client container writes a literal "DONE" sentinel line to
+# /shared/status.log after its 30-iteration poll finishes. We wait up
+# to 60s for that sentinel; if it never appears, the client is wedged
+# (e.g. agent container crashed, volume mount busted, apk-add curl
+# failed) and continuing would just produce a confusing parse error
+# downstream. Fail loudly here with the client+agent logs so the
+# regression is easy to diagnose.
 echo ">> waiting for client to finish 30 poll iterations"
+saw_done=0
 for _ in $(seq 1 60); do
   if $COMPOSE -p "$PROJECT" exec -T client sh -c 'grep -q "^DONE$" /shared/status.log 2>/dev/null'; then
+    saw_done=1
     break
   fi
   sleep 1
 done
+
+if [[ "$saw_done" -ne 1 ]]; then
+  echo "FAIL: timed out after 60s waiting for client DONE sentinel" >&2
+  echo "--- status.log (partial) ---" >&2
+  $COMPOSE -p "$PROJECT" exec -T client sh -c 'cat /shared/status.log 2>/dev/null || echo "<unavailable>"' >&2 || true
+  echo "--- client logs ---" >&2
+  $COMPOSE -p "$PROJECT" logs client >&2 || true
+  echo "--- agent logs ---" >&2
+  $COMPOSE -p "$PROJECT" logs agent >&2 || true
+  exit 10
+fi
 
 LOG=$(mktemp)
 $COMPOSE -p "$PROJECT" exec -T client sh -c 'cat /shared/status.log' > "$LOG"


### PR DESCRIPTION
Closes #4086

## Summary

- Adds an explicit \`CAReady\` synchronization signal in \`pkg/agent/proxy/tls\` that is closed only on the success path of \`SetupCA\` (both shared-volume and native modes).
- \`MakeAgentReady\` in \`pkg/agent/routes/record.go\` now performs a non-blocking select against \`pTls.CAReady()\` and returns \`503 Service Unavailable\` until the CA bundle is on disk — so \`/tmp/agent.ready\` is never written before \`/tmp/keploy-tls/ca.crt\` exists.
- The CLI-side \`MakeAgentReadyForDockerCompose\` retry loop already treats non-200 responses as retry-able, so no caller change is needed.
- Adds unit tests (\`pkg/agent/routes/record_test.go\`) and an end-to-end regression guard (\`tests/e2e/agent-ready-gated-on-ca/\` + \`.github/workflows/e2e-agent-ready-ca-gate.yml\`) that spins up a real docker-compose stack and asserts the 503→200 transition, the \"refusing\" warning in agent logs, and the final presence of \`/tmp/agent.ready\` in the agent container.

## Why

The invariant \"SetupCA finishes before /tmp/agent.ready is written\" is currently preserved only by call-graph ordering: \`Setup → Hook → StartProxy → SetupCA\` (all synchronous) runs to completion before \`cli/agent.go\` signals \`startAgentCh\` and boots the HTTP server. There is no code-level guarantee. A future refactor that moves \`SetupCA\` into a goroutine — a reasonable parallel-init change — would silently let the HTTP listener come up first; the agent would accept \`POST /agent/ready\`, write \`/tmp/agent.ready\`, and the app container waiting on the docker-compose healthcheck would boot against a missing CA, producing silent HTTPS failures. This PR converts that implicit ordering into an explicit synchronization point.

## Commits

1. \`feat(tls): expose CAReady signal\`
2. \`fix(agent): gate /agent/ready on CA readiness\`
3. \`test(agent): unit tests for the CA-readiness gate\`
4. \`test(e2e): regression guard for CA-readiness gate on /agent/ready\`
5. \`test(e2e): pin base images and harden run.sh status parsing\` (follow-up so \`run.sh\` doesn't misparse the trailing \`DONE\` sentinel and so base images match locally-cached tags)

## Test plan

- [x] \`go build ./...\` from repo root
- [x] \`go test ./pkg/agent/routes/... ./pkg/agent/proxy/tls/...\` — all pass, including the new \`TestMakeAgentReady_*\` cases
- [x] \`cd tests/e2e/agent-ready-gated-on-ca && ./run.sh\` — full docker-compose run passes (first POST is 503; subsequent POSTs are 200; \`/tmp/agent.ready\` exists; agent log carries the \"refusing\" warning)
- [x] Same script, with the MakeAgentReady gate temporarily reverted locally, fails with exit 2 (\"FAIL: expected first status=503, got '200'\") — proves the guard is real and not a tautology
- [ ] \`.github/workflows/e2e-agent-ready-ca-gate.yml\` runs on PR (this PR)

## Notes for reviewers

- The \`ResetCAReadyForTest\` / \`CloseCAReadyForTest\` helpers live in \`pkg/agent/proxy/tls/testing.go\` (regular \`.go\` file, not \`_test.go\`) because sibling-package tests need to call them. Naming makes intent explicit; production code MUST NOT call them.
- \`pkg/agent/routes/record.go\` exposes a \`var agentReadyFilePath = kdocker.AgentReadyFile\` purely so the unit tests can redirect writes into \`t.TempDir()\` without clobbering \`/tmp/agent.ready\` on developer hosts. Production callers must not mutate it — the comment on the var calls this out.