### PR TITLE
feat: log pruned mock details during UpdateMocks

### DIFF
--- a/pkg/platform/yaml/mockdb/db.go
+++ b/pkg/platform/yaml/mockdb/db.go
@@ -122,6 +122,16 @@ type MockYaml struct {
 	gobFlushErr error
 }
 
+// prunedMockInfo is the structured per-mock entry logged when
+// UpdateMocks drops a mock. Collected into a single slice and emitted
+// once per prune call so operators can see exactly which mocks were
+// dropped without flooding the log with one line per mock.
+type prunedMockInfo struct {
+	Name     string            `json:"name"`
+	Kind     string            `json:"kind"`
+	Metadata map[string]string `json:"metadata"`
+}
+
 type gobWriteJob struct {
 	mock *models.Mock
 	// testSetPath is the full directory path — "<MockPath>/<testSetID>"
@@ -348,7 +358,7 @@ func (ys *MockYaml) UpdateMocks(ctx context.Context, testSetID string, mockNames
 	}
 
 	newMocks := make([]*models.Mock, 0, len(mocks))
-	prunedCount := 0
+	prunedMocks := make([]prunedMockInfo, 0)
 	for _, mock := range mocks {
 		if mock.Spec.Metadata["type"] == "config" {
 			newMocks = append(newMocks, mock)
@@ -373,7 +383,11 @@ func (ys *MockYaml) UpdateMocks(ctx context.Context, testSetID string, mockNames
 			newMocks = append(newMocks, mock)
 			continue
 		}
-		prunedCount++
+		prunedMocks = append(prunedMocks, prunedMockInfo{
+			Name:     mock.Name,
+			Kind:     string(mock.Kind),
+			Metadata: mock.Spec.Metadata,
+		})
 	}
 
 	if err := ys.writeMocksAtomically(path, mockFileName, newMocks); err != nil {
@@ -384,7 +398,8 @@ func (ys *MockYaml) UpdateMocks(ctx context.Context, testSetID string, mockNames
 		zap.String("testSetID", testSetID),
 		zap.Int("total", len(mocks)),
 		zap.Int("kept", len(newMocks)),
-		zap.Int("pruned", prunedCount),
+		zap.Int("pruned", len(prunedMocks)),
+		zap.Any("prunedMocks", prunedMocks),
 		zap.Time("pruneBefore", pruneBefore))
 
 	return nil
@@ -433,7 +448,7 @@ func (ys *MockYaml) updateMocksGob(ctx context.Context, testSetID, gobPath strin
 	}
 
 	newMocks := make([]*models.Mock, 0, len(mocks))
-	prunedCount := 0
+	prunedMocks := make([]prunedMockInfo, 0)
 	for i, mock := range mocks {
 		// Check ctx every 1024 entries so a very large filter loop
 		// still responds to cancellation without paying the syscall
@@ -460,7 +475,11 @@ func (ys *MockYaml) updateMocksGob(ctx context.Context, testSetID, gobPath strin
 			newMocks = append(newMocks, mock)
 			continue
 		}
-		prunedCount++
+		prunedMocks = append(prunedMocks, prunedMockInfo{
+			Name:     mock.Name,
+			Kind:     string(mock.Kind),
+			Metadata: mock.Spec.Metadata,
+		})
 	}
 
 	// Atomic rewrite: write to a sibling tmp file under the same
@@ -543,7 +562,8 @@ func (ys *MockYaml) updateMocksGob(ctx context.Context, testSetID, gobPath strin
 		zap.String("testSetID", testSetID),
 		zap.Int("total", len(mocks)),
 		zap.Int("kept", len(newMocks)),
-		zap.Int("pruned", prunedCount),
+		zap.Int("pruned", len(prunedMocks)),
+		zap.Any("prunedMocks", prunedMocks),
 		zap.Time("pruneBefore", pruneBefore))
 	return nil
 }

--- a/pkg/platform/yaml/mockdb/db.go
+++ b/pkg/platform/yaml/mockdb/db.go
@@ -132,6 +132,14 @@ type prunedMockInfo struct {
 	Metadata map[string]string `json:"metadata"`
 }
 
+// maxPrunedMocksLogged caps how many per-mock entries get attached to
+// the "pruned mocks successfully" debug log. Replays on large test
+// sets can prune ~10^5 mocks; logging every entry would produce a
+// single multi-MB log line that slows down encoding and overwhelms
+// ingestion. Above the cap we set prunedMocksTruncated=true and rely
+// on the pruned-count total for the overall picture.
+const maxPrunedMocksLogged = 100
+
 type gobWriteJob struct {
 	mock *models.Mock
 	// testSetPath is the full directory path — "<MockPath>/<testSetID>"
@@ -357,8 +365,17 @@ func (ys *MockYaml) UpdateMocks(ctx context.Context, testSetID string, mockNames
 		return err
 	}
 
+	// Only build the per-mock log slice when debug logging is enabled
+	// — on large test sets the allocation and reflection cost of
+	// collecting names/kinds/metadata is a significant overhead if
+	// the emitted log will be dropped by the logger anyway.
+	debugEnabled := ys.Logger.Core().Enabled(zap.DebugLevel)
 	newMocks := make([]*models.Mock, 0, len(mocks))
-	prunedMocks := make([]prunedMockInfo, 0)
+	prunedCount := 0
+	var prunedMocks []prunedMockInfo
+	if debugEnabled {
+		prunedMocks = make([]prunedMockInfo, 0, maxPrunedMocksLogged)
+	}
 	for _, mock := range mocks {
 		if mock.Spec.Metadata["type"] == "config" {
 			newMocks = append(newMocks, mock)
@@ -383,11 +400,14 @@ func (ys *MockYaml) UpdateMocks(ctx context.Context, testSetID string, mockNames
 			newMocks = append(newMocks, mock)
 			continue
 		}
-		prunedMocks = append(prunedMocks, prunedMockInfo{
-			Name:     mock.Name,
-			Kind:     string(mock.Kind),
-			Metadata: mock.Spec.Metadata,
-		})
+		prunedCount++
+		if debugEnabled && len(prunedMocks) < maxPrunedMocksLogged {
+			prunedMocks = append(prunedMocks, prunedMockInfo{
+				Name:     mock.Name,
+				Kind:     string(mock.Kind),
+				Metadata: mock.Spec.Metadata,
+			})
+		}
 	}
 
 	if err := ys.writeMocksAtomically(path, mockFileName, newMocks); err != nil {
@@ -398,8 +418,9 @@ func (ys *MockYaml) UpdateMocks(ctx context.Context, testSetID string, mockNames
 		zap.String("testSetID", testSetID),
 		zap.Int("total", len(mocks)),
 		zap.Int("kept", len(newMocks)),
-		zap.Int("pruned", len(prunedMocks)),
+		zap.Int("pruned", prunedCount),
 		zap.Any("prunedMocks", prunedMocks),
+		zap.Bool("prunedMocksTruncated", prunedCount > len(prunedMocks)),
 		zap.Time("pruneBefore", pruneBefore))
 
 	return nil
@@ -447,8 +468,17 @@ func (ys *MockYaml) updateMocksGob(ctx context.Context, testSetID, gobPath strin
 		return err
 	}
 
+	// See the YAML path above for why per-mock collection is gated on
+	// debug level — the gob path is the one most likely to hit
+	// ~10^5-mock test sets, so skipping the allocation when the log
+	// is a no-op matters more here.
+	debugEnabled := ys.Logger.Core().Enabled(zap.DebugLevel)
 	newMocks := make([]*models.Mock, 0, len(mocks))
-	prunedMocks := make([]prunedMockInfo, 0)
+	prunedCount := 0
+	var prunedMocks []prunedMockInfo
+	if debugEnabled {
+		prunedMocks = make([]prunedMockInfo, 0, maxPrunedMocksLogged)
+	}
 	for i, mock := range mocks {
 		// Check ctx every 1024 entries so a very large filter loop
 		// still responds to cancellation without paying the syscall
@@ -475,11 +505,14 @@ func (ys *MockYaml) updateMocksGob(ctx context.Context, testSetID, gobPath strin
 			newMocks = append(newMocks, mock)
 			continue
 		}
-		prunedMocks = append(prunedMocks, prunedMockInfo{
-			Name:     mock.Name,
-			Kind:     string(mock.Kind),
-			Metadata: mock.Spec.Metadata,
-		})
+		prunedCount++
+		if debugEnabled && len(prunedMocks) < maxPrunedMocksLogged {
+			prunedMocks = append(prunedMocks, prunedMockInfo{
+				Name:     mock.Name,
+				Kind:     string(mock.Kind),
+				Metadata: mock.Spec.Metadata,
+			})
+		}
 	}
 
 	// Atomic rewrite: write to a sibling tmp file under the same
@@ -562,8 +595,9 @@ func (ys *MockYaml) updateMocksGob(ctx context.Context, testSetID, gobPath strin
 		zap.String("testSetID", testSetID),
 		zap.Int("total", len(mocks)),
 		zap.Int("kept", len(newMocks)),
-		zap.Int("pruned", len(prunedMocks)),
+		zap.Int("pruned", prunedCount),
 		zap.Any("prunedMocks", prunedMocks),
+		zap.Bool("prunedMocksTruncated", prunedCount > len(prunedMocks)),
 		zap.Time("pruneBefore", pruneBefore))
 	return nil
 }


### PR DESCRIPTION
## Summary
- Collect each mock dropped by `UpdateMocks` (name, kind, metadata) into a single slice and log it on the existing `pruned mocks successfully` debug line.
- Applied to both the YAML and gob prune paths in `pkg/platform/yaml/mockdb/db.go` so behavior stays consistent across formats.
- Kept as one structured log per prune call (not one per mock) to avoid log pollution on large test sets.

## Test plan
- [x] `go build ./pkg/platform/yaml/mockdb/...`
- [x] `go vet ./pkg/platform/yaml/mockdb/...`
- [ ] Run replay with `--debug` on a test set that triggers pruning and confirm the `prunedMocks` array shows name/kind/metadata for each dropped mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)