### PR TITLE
fix(models): persist HTTPReq/HTTPResp Timestamp as RFC3339Nano in BSON

### DIFF
--- a/pkg/models/http.go
+++ b/pkg/models/http.go
@@ -1,7 +1,10 @@
 package models
 
 import (
+	"fmt"
 	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 type Method string
@@ -58,4 +61,194 @@ type HTTPResp struct {
 	ProtoMinor    int               `json:"proto_minor" yaml:"proto_minor"`
 	Binary        string            `json:"binary" yaml:"binary,omitempty"`
 	Timestamp     time.Time         `json:"timestamp" yaml:"timestamp"`
+}
+
+// MongoDB's BSON DateTime is an int64 count of milliseconds, so the default
+// `time.Time` -> BSON encoding silently drops nanoseconds. HTTPReq.Timestamp
+// and HTTPResp.Timestamp are later used as the edges of the mock-matching
+// time window, and the closing edge often lands in the exact same millisecond
+// as the final MongoDB mock's `reqTimestampMock`. Truncation pushes that mock
+// outside the window by a few microseconds, starving the `find` matcher.
+//
+// The BSON methods below persist both timestamps as RFC3339Nano strings so the
+// round-trip through MongoDB preserves the original precision. MockEntry in
+// mappings.go uses the same strategy (see FormatMockTimestamp).
+//
+// Field names on the shadow structs match the v1/v2 driver default
+// (`strings.ToLower(fieldName)`) so the BSON wire shape is unchanged for every
+// field except `timestamp`, which flips from BSON DateTime to BSON String.
+// UnmarshalBSON transparently accepts either shape, so existing records written
+// before this change continue to decode.
+
+type httpReqBSON struct {
+	Method     Method            `bson:"method"`
+	ProtoMajor int               `bson:"protomajor"`
+	ProtoMinor int               `bson:"protominor"`
+	URL        string            `bson:"url"`
+	URLParams  map[string]string `bson:"urlparams"`
+	Header     map[string]string `bson:"header"`
+	Body       string            `bson:"body"`
+	BodyRef    BodyRef           `bson:"bodyref"`
+	Binary     string            `bson:"binary"`
+	Form       []FormData        `bson:"form"`
+	Timestamp  string            `bson:"timestamp"`
+}
+
+type httpReqBSONReader struct {
+	Method     Method            `bson:"method"`
+	ProtoMajor int               `bson:"protomajor"`
+	ProtoMinor int               `bson:"protominor"`
+	URL        string            `bson:"url"`
+	URLParams  map[string]string `bson:"urlparams"`
+	Header     map[string]string `bson:"header"`
+	Body       string            `bson:"body"`
+	BodyRef    BodyRef           `bson:"bodyref"`
+	Binary     string            `bson:"binary"`
+	Form       []FormData        `bson:"form"`
+	Timestamp  bson.RawValue     `bson:"timestamp"`
+}
+
+// MarshalBSON writes HTTPReq with the Timestamp field serialised as an
+// RFC3339Nano string so BSON DateTime's millisecond resolution cannot truncate
+// it.
+func (h HTTPReq) MarshalBSON() ([]byte, error) {
+	return bson.Marshal(httpReqBSON{
+		Method:     h.Method,
+		ProtoMajor: h.ProtoMajor,
+		ProtoMinor: h.ProtoMinor,
+		URL:        h.URL,
+		URLParams:  h.URLParams,
+		Header:     h.Header,
+		Body:       h.Body,
+		BodyRef:    h.BodyRef,
+		Binary:     h.Binary,
+		Form:       h.Form,
+		Timestamp:  FormatMockTimestamp(h.Timestamp),
+	})
+}
+
+// UnmarshalBSON reads HTTPReq, accepting either the new RFC3339Nano string
+// timestamp or the legacy BSON DateTime (millisecond) shape for backward
+// compatibility with records written before MarshalBSON landed.
+func (h *HTTPReq) UnmarshalBSON(data []byte) error {
+	var raw httpReqBSONReader
+	if err := bson.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	ts, err := decodeBSONTimestamp(raw.Timestamp)
+	if err != nil {
+		return fmt.Errorf("HTTPReq.UnmarshalBSON timestamp: %w", err)
+	}
+
+	*h = HTTPReq{
+		Method:     raw.Method,
+		ProtoMajor: raw.ProtoMajor,
+		ProtoMinor: raw.ProtoMinor,
+		URL:        raw.URL,
+		URLParams:  raw.URLParams,
+		Header:     raw.Header,
+		Body:       raw.Body,
+		BodyRef:    raw.BodyRef,
+		Binary:     raw.Binary,
+		Form:       raw.Form,
+		Timestamp:  ts,
+	}
+	return nil
+}
+
+type httpRespBSON struct {
+	StatusCode    int               `bson:"statuscode"`
+	Header        map[string]string `bson:"header"`
+	Body          string            `bson:"body"`
+	StreamBody    []HTTPStreamChunk `bson:"streambody"`
+	BodySkipped   bool              `bson:"bodyskipped"`
+	BodySize      int64             `bson:"bodysize"`
+	StatusMessage string            `bson:"statusmessage"`
+	ProtoMajor    int               `bson:"protomajor"`
+	ProtoMinor    int               `bson:"protominor"`
+	Binary        string            `bson:"binary"`
+	Timestamp     string            `bson:"timestamp"`
+}
+
+type httpRespBSONReader struct {
+	StatusCode    int               `bson:"statuscode"`
+	Header        map[string]string `bson:"header"`
+	Body          string            `bson:"body"`
+	StreamBody    []HTTPStreamChunk `bson:"streambody"`
+	BodySkipped   bool              `bson:"bodyskipped"`
+	BodySize      int64             `bson:"bodysize"`
+	StatusMessage string            `bson:"statusmessage"`
+	ProtoMajor    int               `bson:"protomajor"`
+	ProtoMinor    int               `bson:"protominor"`
+	Binary        string            `bson:"binary"`
+	Timestamp     bson.RawValue     `bson:"timestamp"`
+}
+
+// MarshalBSON — see the HTTPReq version above. Same rationale.
+func (h HTTPResp) MarshalBSON() ([]byte, error) {
+	return bson.Marshal(httpRespBSON{
+		StatusCode:    h.StatusCode,
+		Header:        h.Header,
+		Body:          h.Body,
+		StreamBody:    h.StreamBody,
+		BodySkipped:   h.BodySkipped,
+		BodySize:      h.BodySize,
+		StatusMessage: h.StatusMessage,
+		ProtoMajor:    h.ProtoMajor,
+		ProtoMinor:    h.ProtoMinor,
+		Binary:        h.Binary,
+		Timestamp:     FormatMockTimestamp(h.Timestamp),
+	})
+}
+
+func (h *HTTPResp) UnmarshalBSON(data []byte) error {
+	var raw httpRespBSONReader
+	if err := bson.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	ts, err := decodeBSONTimestamp(raw.Timestamp)
+	if err != nil {
+		return fmt.Errorf("HTTPResp.UnmarshalBSON timestamp: %w", err)
+	}
+
+	*h = HTTPResp{
+		StatusCode:    raw.StatusCode,
+		Header:        raw.Header,
+		Body:          raw.Body,
+		StreamBody:    raw.StreamBody,
+		BodySkipped:   raw.BodySkipped,
+		BodySize:      raw.BodySize,
+		StatusMessage: raw.StatusMessage,
+		ProtoMajor:    raw.ProtoMajor,
+		ProtoMinor:    raw.ProtoMinor,
+		Binary:        raw.Binary,
+		Timestamp:     ts,
+	}
+	return nil
+}
+
+// decodeBSONTimestamp handles the two on-disk shapes for HTTP timestamps:
+// the new RFC3339Nano string (preserves nanoseconds) and the legacy BSON
+// DateTime (millisecond int64). An absent/null value decodes to the zero time.
+func decodeBSONTimestamp(v bson.RawValue) (time.Time, error) {
+	switch v.Type {
+	case 0, bson.TypeNull, bson.TypeUndefined:
+		return time.Time{}, nil
+	case bson.TypeString:
+		s, ok := v.StringValueOK()
+		if !ok {
+			return time.Time{}, fmt.Errorf("expected string, got malformed value")
+		}
+		return ParseMockTimestamp(s)
+	case bson.TypeDateTime:
+		dt, ok := v.DateTimeOK()
+		if !ok {
+			return time.Time{}, fmt.Errorf("expected DateTime, got malformed value")
+		}
+		return bson.DateTime(dt).Time(), nil
+	default:
+		return time.Time{}, fmt.Errorf("unsupported BSON type %v for timestamp", v.Type)
+	}
 }

--- a/pkg/models/http_bson_test.go
+++ b/pkg/models/http_bson_test.go
@@ -1,0 +1,139 @@
+package models
+
+import (
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// The HTTP-timestamp round-trip through MongoDB must preserve nanoseconds.
+// BSON DateTime is int64 milliseconds, so the default time.Time encoding
+// drops the sub-millisecond tail. MarshalBSON/UnmarshalBSON on HTTPReq and
+// HTTPResp serialise Timestamp as RFC3339Nano strings instead.
+
+func TestHTTPReqBSON_RoundTripPreservesNanoseconds(t *testing.T) {
+	// Matches the failing test-8 / mock-62 case in
+	// FAILURE-ANALYSIS.md: mock landed 7 µs past a millisecond boundary.
+	original := HTTPReq{
+		Method:     "POST",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		URL:        "http://api.staging.keploy.io/cluster/deployment-type/init",
+		URLParams:  map[string]string{"a": "b"},
+		Header:     map[string]string{"Content-Type": "application/json"},
+		Body:       `{"deployment_type":"saas"}`,
+		Binary:     "",
+		Timestamp:  time.Date(2026, 4, 21, 13, 3, 46, 662007331, time.UTC),
+	}
+
+	data, err := bson.Marshal(original)
+	if err != nil {
+		t.Fatalf("MarshalBSON: %v", err)
+	}
+
+	var decoded HTTPReq
+	if err := bson.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("UnmarshalBSON: %v", err)
+	}
+
+	if !decoded.Timestamp.Equal(original.Timestamp) {
+		t.Fatalf("timestamp precision lost: want %s (ns=%d), got %s (ns=%d)",
+			original.Timestamp.Format(time.RFC3339Nano), original.Timestamp.Nanosecond(),
+			decoded.Timestamp.Format(time.RFC3339Nano), decoded.Timestamp.Nanosecond())
+	}
+	if decoded.Method != original.Method || decoded.URL != original.URL || decoded.Body != original.Body {
+		t.Fatalf("non-timestamp field corrupted: %+v", decoded)
+	}
+}
+
+func TestHTTPRespBSON_RoundTripPreservesNanoseconds(t *testing.T) {
+	original := HTTPResp{
+		StatusCode:    200,
+		Header:        map[string]string{"Content-Type": "application/json"},
+		Body:          `{"ok":true}`,
+		StatusMessage: "OK",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Timestamp:     time.Date(2026, 4, 21, 13, 3, 46, 662703152, time.UTC),
+	}
+
+	data, err := bson.Marshal(original)
+	if err != nil {
+		t.Fatalf("MarshalBSON: %v", err)
+	}
+
+	var decoded HTTPResp
+	if err := bson.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("UnmarshalBSON: %v", err)
+	}
+
+	if !decoded.Timestamp.Equal(original.Timestamp) {
+		t.Fatalf("timestamp precision lost: want %s, got %s",
+			original.Timestamp.Format(time.RFC3339Nano),
+			decoded.Timestamp.Format(time.RFC3339Nano))
+	}
+}
+
+// TestHTTPReqBSON_LegacyDateTimeCompat verifies we can still decode records
+// written before MarshalBSON landed — i.e. documents where the timestamp is
+// a BSON DateTime rather than an RFC3339Nano string. Without this, upgrading
+// the api-server would orphan every previously stored test case.
+func TestHTTPReqBSON_LegacyDateTimeCompat(t *testing.T) {
+	legacyTS := time.Date(2026, 4, 21, 13, 3, 46, 662000000, time.UTC)
+
+	// Hand-build a BSON document matching the pre-change wire shape:
+	// every field serialised by the default codec, timestamp as a DateTime.
+	legacyDoc := bson.D{
+		{Key: "method", Value: "POST"},
+		{Key: "protomajor", Value: int32(1)},
+		{Key: "protominor", Value: int32(1)},
+		{Key: "url", Value: "http://example.invalid/"},
+		{Key: "urlparams", Value: bson.M{}},
+		{Key: "header", Value: bson.M{"Content-Type": "application/json"}},
+		{Key: "body", Value: `{}`},
+		{Key: "bodyref", Value: bson.M{"path": "", "size": int64(0)}},
+		{Key: "binary", Value: ""},
+		{Key: "form", Value: bson.A{}},
+		{Key: "timestamp", Value: legacyTS},
+	}
+	data, err := bson.Marshal(legacyDoc)
+	if err != nil {
+		t.Fatalf("build legacy doc: %v", err)
+	}
+
+	var decoded HTTPReq
+	if err := bson.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("UnmarshalBSON (legacy): %v", err)
+	}
+
+	if !decoded.Timestamp.Equal(legacyTS) {
+		t.Fatalf("legacy DateTime decode mismatch: want %s, got %s",
+			legacyTS.Format(time.RFC3339Nano),
+			decoded.Timestamp.Format(time.RFC3339Nano))
+	}
+	if decoded.Method != "POST" || decoded.URL != "http://example.invalid/" {
+		t.Fatalf("legacy non-timestamp fields corrupted: %+v", decoded)
+	}
+}
+
+func TestHTTPReqBSON_ZeroTimestamp(t *testing.T) {
+	original := HTTPReq{Method: "GET", URL: "http://x/"}
+
+	data, err := bson.Marshal(original)
+	if err != nil {
+		t.Fatalf("MarshalBSON: %v", err)
+	}
+
+	var decoded HTTPReq
+	if err := bson.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("UnmarshalBSON: %v", err)
+	}
+
+	if !decoded.Timestamp.IsZero() {
+		t.Fatalf("zero timestamp round-trip changed value: %s", decoded.Timestamp)
+	}
+	if decoded.Method != "GET" || decoded.URL != "http://x/" {
+		t.Fatalf("non-timestamp fields corrupted: %+v", decoded)
+	}
+}

--- a/pkg/models/mappings.go
+++ b/pkg/models/mappings.go
@@ -30,6 +30,20 @@ func FormatMockTimestamp(ts time.Time) string {
 	return ts.Format(time.RFC3339Nano)
 }
 
+// ParseMockTimestamp is the inverse of FormatMockTimestamp. It accepts both
+// RFC3339Nano (the format written by FormatMockTimestamp) and plain RFC3339
+// for compatibility with older fixtures. An empty input returns the zero
+// time without error.
+func ParseMockTimestamp(s string) (time.Time, error) {
+	if s == "" {
+		return time.Time{}, nil
+	}
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return t, nil
+	}
+	return time.Parse(time.RFC3339, s)
+}
+
 type Mapping struct {
 	Version   string           `json:"version" yaml:"version" bson:"version"`
 	Kind      string           `json:"kind" yaml:"kind" bson:"kind"`


### PR DESCRIPTION
## Summary

- `HTTPReq.Timestamp` and `HTTPResp.Timestamp` are bare `time.Time` fields. When a downstream BSON-persists these structs (e.g. api-server storing test cases in MongoDB), the v1/v2 Mongo driver encodes `time.Time` as BSON `DateTime` — an `int64` of **milliseconds**. Nanoseconds are silently dropped.
- For cloud-replay this is load-bearing: these two timestamps become the edges of the mock-matching time window. MongoDB mocks round-trip through blob storage (not Mongo) and keep their original ns precision, so the last mock's `reqTimestampMock` frequently lands a few microseconds past the ms-floored `resp.ts`. The mock then drops out of the filter pool and the `find` matcher starves.
- Fix: add `MarshalBSON` / `UnmarshalBSON` on both structs so the BSON wire shape for `timestamp` is an RFC3339Nano string — same trick `MockEntry` in `mappings.go` already uses for `reqTimestampMock` / `resTimestampMock`. Every other field keeps its existing BSON shape (`strings.ToLower(fieldName)`, matching both v1 and v2 driver defaults).
- `UnmarshalBSON` accepts both the new `String` shape and the legacy `DateTime` shape, so existing Mongo documents written before this lands continue to decode — no data migration required.

## Changes

- `pkg/models/mappings.go` — add `ParseMockTimestamp` as the inverse of `FormatMockTimestamp`. Accepts both RFC3339Nano and RFC3339 for compatibility with older fixtures; empty string → zero time.
- `pkg/models/http.go` — add `MarshalBSON` / `UnmarshalBSON` on `HTTPReq` and `HTTPResp`, plus a `decodeBSONTimestamp` helper that dispatches on BSON type. Shadow structs mirror every existing field with explicit `bson:` tags matching the current default codec output, so the on-disk shape for fields other than `timestamp` is byte-identical.
- `pkg/models/http_bson_test.go` — three regression tests: (1) ns precision round-trips on `HTTPReq`, (2) same on `HTTPResp`, (3) legacy BSON `DateTime` documents still decode correctly (hand-built `bson.D` mirroring the pre-change wire shape), (4) zero timestamp round-trips to zero.

## Test plan

- [x] `go test ./pkg/models/...` — four new tests pass; existing suite still green.
- [x] `go test ./pkg/...` — full package suite still green.
- [x] `go build ./...` — compiles clean.
- [x] Downstream sanity: with a local `replace` in `api-server`, an end-to-end BSON round-trip through the v1 driver preserves the exact nanosecond timestamps from the failing cloud-replay incident (`.661397537Z` / `.662947552Z` / mock at `.662007331Z`). PR in api-server follows.

## Observability / migration notes

- No data migration needed. `UnmarshalBSON` branches on BSON type at read time.
- New writes flip the on-disk `timestamp` field from BSON `DateTime` to BSON `String` for these two structs only. If anyone has an index on `data.http_req.timestamp` / `data.http_resp.timestamp` as a date, it will now be mixed-type. Grep in the downstream Mongo consumers before merging to confirm no such index exists — I did not find any in api-server, but I can't rule out other consumers.