### PR TITLE
fix(replay): write mappings for streaming test cases

### DIFF
--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1864,7 +1864,10 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			streamProxyErrCtx, streamProxyErrCancel := context.WithCancel(runTestSetCtx)
 			go r.monitorProxyErrors(streamProxyErrCtx, testSetID, tc.Name)
 
-			// Execute: Call SimulateRequest synchronously (blocks until stream is done).
+			// Execute: SimulateRequest returns once response headers arrive;
+			// for streaming cases the body reader is drained later by
+			// CompareHTTPStream below, so in-stream mock consumption can
+			// continue after this call returns.
 			started := time.Now().UTC()
 			resp, simErr := r.hookImpl.SimulateRequest(runTestSetCtx, tc, testSetID)
 
@@ -1888,7 +1891,10 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			var hadStreamingMismatch bool              // Track if streaming comparison failed
 			var streamMismatch *pkg.StreamMismatchInfo // Detailed mismatch info for body result
 
-			// Calculate mock mismatch early so we can use emitFailureLogs in streaming comparison
+			// Pre-stream drain + mismatch snapshot: needed to decide whether
+			// CompareHTTPStream below should emit failure logs. The mismatch
+			// is re-evaluated after the post-stream drain so extra mocks
+			// consumed while reading the stream body are counted too.
 			mockNames := make([]string, 0)
 			if r.instrument {
 				consumedMocks, err = r.hookImpl.GetConsumedMocks(runTestSetCtx)
@@ -2000,6 +2006,18 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 					mockNames = append(mockNames, m.Name)
 				}
 				consumedMocks = append(consumedMocks, additionalMocks...)
+			}
+
+			// Re-evaluate mismatch now that consumedMocks covers the full
+			// test case (pre-stream + in-stream). If CompareHTTPStream
+			// already forced emitFailureLogs=false on a streaming body
+			// mismatch, keep it suppressed — don't un-suppress just because
+			// the mock set still looks like a subset.
+			if r.instrument && useMappingBased && isMappingEnabled && hasExpectedMocks {
+				mockSetMismatch = !isMockSubsetWithConfig(consumedMocks, expectedMocks)
+				if !hadStreamingMismatch {
+					emitFailureLogs = !mockSetMismatch
+				}
 			}
 
 			testPass, testResult := r.CompareHTTPResp(tc, httpResp, testSetID, emitFailureLogs)

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1984,17 +1984,6 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 				}
 			}
 
-			// Update consumed mocks map.
-			if r.instrument {
-				consumedMocks, err = r.hookImpl.GetConsumedMocks(runTestSetCtx)
-				if err != nil {
-					utils.LogError(r.logger, err, "failed to get consumed filtered mocks for streaming test")
-				}
-				for _, m := range consumedMocks {
-					totalConsumedMocks[m.Name] = m
-				}
-			}
-
 			testPass, testResult := r.CompareHTTPResp(tc, httpResp, testSetID, emitFailureLogs)
 			// Override testPass if streaming comparison failed
 			// (HTTP matcher skips body comparison for non-JSON bodies by default)

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1984,6 +1984,24 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 				}
 			}
 
+			// Drain mocks consumed during stream body transmission and union
+			// with the pre-stream mocks captured earlier. GetConsumedMocks
+			// drains on read, so if any mocks land between the pre-stream
+			// drain and here (e.g., one backend call per SSE frame, consumed
+			// while CompareHTTPStream was still reading frames above), they
+			// would otherwise be dropped from mappings.yaml.
+			if r.instrument {
+				additionalMocks, drainErr := r.hookImpl.GetConsumedMocks(runTestSetCtx)
+				if drainErr != nil {
+					utils.LogError(r.logger, drainErr, "failed to get consumed filtered mocks for streaming test")
+				}
+				for _, m := range additionalMocks {
+					totalConsumedMocks[m.Name] = m
+					mockNames = append(mockNames, m.Name)
+				}
+				consumedMocks = append(consumedMocks, additionalMocks...)
+			}
+
 			testPass, testResult := r.CompareHTTPResp(tc, httpResp, testSetID, emitFailureLogs)
 			// Override testPass if streaming comparison failed
 			// (HTTP matcher skips body comparison for non-JSON bodies by default)


### PR DESCRIPTION
## Summary

Streaming test cases were missing (or incomplete) in `mappings.yaml` because the Phase-2 streaming loop in `pkg/service/replay/replay.go` handled the two `GetConsumedMocks` calls incorrectly.

`MockManager.GetConsumedMocks` drains the consumed list on read. Two calls are required in the streaming path because:

1. **Pre-stream drain** — needed before `CompareHTTPStream` runs, so the `mockSetMismatch` / `emitFailureLogs` snapshot can gate the body-comparison log output.
2. **Post-stream drain** — `SimulateHTTPStreaming` (`pkg/util.go:602`) returns as soon as response headers arrive and wraps `httpResp.Body` in the returned `StreamingHTTPResponse`. The body is drained later by `CompareHTTPStream`, so any mocks consumed per-frame (e.g., one backend call per SSE event) land *after* the pre-stream drain.

The original buggy code **overwrote** `consumedMocks` on the second call, so `upsertActualTestMockMapping` received whichever subset was smaller — either the first drain's mocks (if the second returned empty) or just the in-stream mocks (if both were non-empty). That's what produced the missing / incomplete entries described in #4098.

## Fix

Keep both drains. On the second call, **union** the results into `consumedMocks` (and `mockNames`) instead of overwriting. After the union, re-evaluate `mockSetMismatch` so extra mocks consumed during stream reading are counted by the subset check; preserve any `emitFailureLogs=false` already forced by a streaming body mismatch.

Closes #4098

## Test plan

- [x] Replay a test set containing streaming (`text/event-stream`) test cases whose backend is called once per frame, and confirm every consumed mock appears under the owning test case in `mappings.yaml` (verified locally with a 3-test SSE repro: all 9 mocks land under the right test).
- [x] Re-run replay for a non-streaming test set to confirm no regression (non-streaming tests run in Phase 1, completely outside the changed code path).
- [x] Verify the `consumed mocks for streaming test case` debug log lists the union of both drains (mockNames now covers all mocks consumed by the test case, not just the pre-stream ones).
