### PR TITLE
fix: base64-encode non-UTF-8 HTTP bodies to stop yaml marshal crash

### DIFF
--- a/.github/workflows/node_binary_body.yml
+++ b/.github/workflows/node_binary_body.yml
@@ -1,0 +1,57 @@
+name: Node Binary Body
+# Exercises keploy's record/replay with HTTP responses that carry non-UTF-8
+# bytes (application/zip, application/octet-stream). Guards against
+# keploy/enterprise#1902 where such bodies used to crash the recorder with
+# "yaml: cannot marshal invalid UTF-8 data as !!str".
+on:
+  workflow_call:
+jobs:
+  node_binary_body:
+    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - job: record_latest_replay_build
+            record_src: latest
+            replay_src: build
+          - job: record_build_replay_latest
+            record_src: build
+            replay_src: latest
+          - job: record_build_replay_build
+            record_src: build
+            replay_src: build
+    name: ${{ matrix.job }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - id: record
+        uses: ./.github/actions/download-binary
+        with:
+          src: ${{ matrix.record_src }}
+
+      - id: replay
+        uses: ./.github/actions/download-binary
+        with:
+          src: ${{ matrix.replay_src }}
+
+      - name: Checkout binary-body sample
+        uses: actions/checkout@v4
+        with:
+          repository: ayush3160/keploy-binary-body-sample
+          path: keploy-binary-body-sample
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Record and replay binary-body sample
+        env:
+          RECORD_BIN: ${{ steps.record.outputs.path }}
+          REPLAY_BIN: ${{ steps.replay.outputs.path }}
+        run: |
+          cd keploy-binary-body-sample
+          source $GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/node/binary_body/node-linux.sh

--- a/.github/workflows/prepare_and_run.yml
+++ b/.github/workflows/prepare_and_run.yml
@@ -568,6 +568,9 @@ jobs:
   run_node_linux:
     needs: [build-and-upload, upload-latest]
     uses: ./.github/workflows/node_linux.yml
+  run_node_binary_body:
+    needs: [build-and-upload, upload-latest]
+    uses: ./.github/workflows/node_binary_body.yml
   run_node_docker:
     needs: [build-and-upload, upload-latest, build-docker-image-amd64]
     uses: ./.github/workflows/node_docker.yml
@@ -894,6 +897,7 @@ jobs:
       - run_golang_wsl
       - run_java_linux
       - run_node_linux
+      - run_node_binary_body
       - run_node_docker
       - run_python_docker
       - run_python_linux
@@ -914,6 +918,7 @@ jobs:
             "${{ needs.run_golang_wsl.result }}" \
             "${{ needs.run_java_linux.result }}" \
             "${{ needs.run_node_linux.result }}" \
+            "${{ needs.run_node_binary_body.result }}" \
             "${{ needs.run_node_docker.result }}" \
             "${{ needs.run_python_docker.result }}" \
             "${{ needs.run_python_linux.result }}" \

--- a/.github/workflows/test_workflow_scripts/node/binary_body/node-linux.sh
+++ b/.github/workflows/test_workflow_scripts/node/binary_body/node-linux.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Record-replay test for a Node.js app that serves HTTP responses with
+# non-UTF-8 bytes (application/zip, application/octet-stream). Before the
+# body_base64 fix, recording this sample failed with
+# "yaml: cannot marshal invalid UTF-8 data as !!str" as reported in
+# keploy/enterprise#1902.
+
+set -Eeuo pipefail
+
+section() { echo "::group::$*"; }
+endsec()  { echo "::endgroup::"; }
+
+die() {
+  rc=$?
+  echo "::error::Pipeline failed (exit=$rc). Dumping context…"
+  echo "== keploy tree =="
+  find ./keploy -maxdepth 4 -type f -print 2>/dev/null | sort || true
+  for f in ./*.txt; do [[ -f "$f" ]] && { echo "--- $f ---"; cat "$f"; }; done
+  exit "$rc"
+}
+trap die ERR
+
+source "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/test-iid.sh"
+
+section "Prepare workspace"
+npm install --silent
+rm -rf keploy/
+rm -f keploy.yml
+echo "Record: $RECORD_BIN"; sudo "$RECORD_BIN" --version
+echo "Replay: $REPLAY_BIN"; sudo "$REPLAY_BIN" --version
+sudo "$RECORD_BIN" config --generate
+# ETag header is content-hash based; Date is a wall-clock — noise both so
+# replay matches even if Express regenerates the headers.
+config_file="./keploy.yml"
+sed -i 's/global: {}/global: {"header": {"Date": [], "ETag": []}}/' "$config_file"
+endsec
+
+send_requests() {
+  # Wait for the app to come up (server.js listens on :3000 by default).
+  local tries=0
+  until curl -sf http://localhost:3000/health >/dev/null; do
+    tries=$((tries + 1))
+    if [[ $tries -ge 30 ]]; then
+      echo "::error::App did not become healthy within 30s"
+      return 1
+    fi
+    sleep 1
+  done
+  echo "App up after ${tries}s"
+
+  # Hit the two endpoints whose payloads contain non-UTF-8 bytes. These are
+  # what used to blow up keploy's yaml encoder.
+  curl -sS -o /tmp/zip.out     -w "zip %{http_code} %{size_download}\n"     http://localhost:3000/zip
+  curl -sS -o /tmp/octets.out  -w "oct %{http_code} %{size_download}\n"     http://localhost:3000/octets
+
+  # Give the recorder a moment to flush testcase + mock YAML.
+  sleep 3
+
+  # Stop keploy gracefully so it finalises the report on disk.
+  pid=$(pgrep -x keploy || true)
+  if [[ -n "$pid" ]]; then
+    echo "Stopping keploy (pid=$pid)"
+    sudo kill "$pid" || true
+  fi
+}
+
+# -------- Record phase --------
+section "Record"
+send_requests &
+# Without the fix this terminates early with
+#   "error while inserting mock into db, hence stopping keploy"
+sudo -E "$RECORD_BIN" record -c 'node server.js' &> record.txt || true
+cat record.txt
+
+if grep -q "cannot marshal invalid UTF-8 data as !!str" record.txt; then
+  echo "::error::Recorder hit the binary-body regression (keploy/enterprise#1902)"
+  exit 1
+fi
+if grep -q "error while inserting mock into db, hence stopping keploy" record.txt; then
+  echo "::error::Recorder stopped on mock insert — binary body not serialised"
+  exit 1
+fi
+if grep -q "WARNING: DATA RACE" record.txt; then
+  echo "::error::Data race detected during record"
+  exit 1
+fi
+
+# Sanity: a test set must have been written.
+if ! ls ./keploy/test-set-*/tests/*.yaml >/dev/null 2>&1; then
+  echo "::error::No test cases were captured"
+  find ./keploy -maxdepth 4 -type f -print 2>/dev/null | sort || true
+  exit 1
+fi
+
+# Sanity: the zip response body must round-trip through YAML. On the fixed
+# code path it lands under `body_base64:` (base64 of the raw zip bytes).
+if ! grep -R "body_base64:" ./keploy/test-set-*/tests/ >/dev/null 2>&1; then
+  echo "::error::Expected body_base64 to be present for the application/zip test case"
+  find ./keploy/test-set-*/tests -maxdepth 2 -type f -print 2>/dev/null | sort || true
+  exit 1
+fi
+endsec
+
+# -------- Replay phase --------
+section "Replay"
+sudo -E "$REPLAY_BIN" test -c 'node server.js' --delay 10 &> replay.txt || true
+cat replay.txt
+
+if grep -q "ERROR" replay.txt; then
+  # Surface offending lines first so the failure is easy to read in CI logs.
+  grep "ERROR" replay.txt | head -20
+  echo "::error::Error in replay output"
+  exit 1
+fi
+if grep -q "WARNING: DATA RACE" replay.txt; then
+  echo "::error::Data race detected during replay"
+  exit 1
+fi
+
+report=$(ls -1 ./keploy/reports/test-run-0/*-report.yaml 2>/dev/null | head -n 1 || true)
+if [[ -z "$report" ]]; then
+  echo "::error::No replay report produced"
+  find ./keploy/reports -maxdepth 3 -type f 2>/dev/null || true
+  exit 1
+fi
+status=$(grep -m1 '^status:' "$report" | awk '{print $2}')
+echo "Replay status: $status"
+if [[ "$status" != "PASSED" ]]; then
+  echo "::error::Replay did not pass"
+  cat "$report"
+  exit 1
+fi
+endsec
+
+echo "Binary body record+replay succeeded."

--- a/pkg/models/http.go
+++ b/pkg/models/http.go
@@ -1,13 +1,116 @@
 package models
 
 import (
+	"encoding/base64"
 	"fmt"
 	"time"
+	"unicode/utf8"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
+	yamlLib "gopkg.in/yaml.v3"
 )
 
 type Method string
+
+// splitBodyForYAML returns the pair that should be written to the yaml
+// document: (body, body_base64). If the body is valid UTF-8 it goes in the
+// first slot and body_base64 is empty. If it contains any non-UTF-8 bytes
+// (e.g. a zip / image / octet-stream response) yaml.v3 rejects it as
+// "yaml: cannot marshal invalid UTF-8 data as !!str", so we base64-encode
+// and leave the plain body empty.
+func splitBodyForYAML(body string) (string, string) {
+	if body == "" || utf8.ValidString(body) {
+		return body, ""
+	}
+	return "", base64.StdEncoding.EncodeToString([]byte(body))
+}
+
+// joinBodyFromYAML is the inverse of splitBodyForYAML. If body_base64 is
+// present it wins and is decoded back into the raw byte-for-byte body.
+func joinBodyFromYAML(body, bodyBase64 string) (string, error) {
+	if bodyBase64 == "" {
+		return body, nil
+	}
+	decoded, err := base64.StdEncoding.DecodeString(bodyBase64)
+	if err != nil {
+		return "", fmt.Errorf("decode body_base64: %w", err)
+	}
+	return string(decoded), nil
+}
+
+// MarshalYAML serialises an HTTPReq. When the body contains non-UTF-8 bytes
+// (which yaml.v3 refuses to emit as a !!str scalar) it is moved to a
+// sibling body_base64 field. See splitBodyForYAML for the rationale.
+func (h HTTPReq) MarshalYAML() (interface{}, error) {
+	body, bodyB64 := splitBodyForYAML(h.Body)
+	type httpReqYAML struct {
+		Method     Method            `yaml:"method"`
+		ProtoMajor int               `yaml:"proto_major"`
+		ProtoMinor int               `yaml:"proto_minor"`
+		URL        string            `yaml:"url"`
+		URLParams  map[string]string `yaml:"url_params,omitempty"`
+		Header     map[string]string `yaml:"header"`
+		Body       string            `yaml:"body"`
+		BodyBase64 string            `yaml:"body_base64,omitempty"`
+		BodyRef    BodyRef           `yaml:"body_ref,omitempty"`
+		Binary     string            `yaml:"binary,omitempty"`
+		Form       []FormData        `yaml:"form,omitempty"`
+		Timestamp  time.Time         `yaml:"timestamp"`
+	}
+	return httpReqYAML{
+		Method:     h.Method,
+		ProtoMajor: h.ProtoMajor,
+		ProtoMinor: h.ProtoMinor,
+		URL:        h.URL,
+		URLParams:  h.URLParams,
+		Header:     h.Header,
+		Body:       body,
+		BodyBase64: bodyB64,
+		BodyRef:    h.BodyRef,
+		Binary:     h.Binary,
+		Form:       h.Form,
+		Timestamp:  h.Timestamp,
+	}, nil
+}
+
+func (h *HTTPReq) UnmarshalYAML(node *yamlLib.Node) error {
+	type httpReqYAML struct {
+		Method     Method            `yaml:"method"`
+		ProtoMajor int               `yaml:"proto_major"`
+		ProtoMinor int               `yaml:"proto_minor"`
+		URL        string            `yaml:"url"`
+		URLParams  map[string]string `yaml:"url_params,omitempty"`
+		Header     map[string]string `yaml:"header"`
+		Body       string            `yaml:"body"`
+		BodyBase64 string            `yaml:"body_base64,omitempty"`
+		BodyRef    BodyRef           `yaml:"body_ref,omitempty"`
+		Binary     string            `yaml:"binary,omitempty"`
+		Form       []FormData        `yaml:"form,omitempty"`
+		Timestamp  time.Time         `yaml:"timestamp"`
+	}
+	var raw httpReqYAML
+	if err := node.Decode(&raw); err != nil {
+		return err
+	}
+	body, err := joinBodyFromYAML(raw.Body, raw.BodyBase64)
+	if err != nil {
+		return err
+	}
+	*h = HTTPReq{
+		Method:     raw.Method,
+		ProtoMajor: raw.ProtoMajor,
+		ProtoMinor: raw.ProtoMinor,
+		URL:        raw.URL,
+		URLParams:  raw.URLParams,
+		Header:     raw.Header,
+		Body:       body,
+		BodyRef:    raw.BodyRef,
+		Binary:     raw.Binary,
+		Form:       raw.Form,
+		Timestamp:  raw.Timestamp,
+	}
+	return nil
+}
 
 // BodyRef stores a reference to a large request body that has been offloaded
 // to the assets directory (bodies > 1MB). When BodyRef is set, Body will be empty.

--- a/pkg/models/http_binary_body_test.go
+++ b/pkg/models/http_binary_body_test.go
@@ -1,0 +1,129 @@
+package models
+
+import (
+	"testing"
+	"time"
+
+	yamlLib "gopkg.in/yaml.v3"
+)
+
+// zipMagic is the leading bytes of a ZIP archive. These bytes are not valid
+// UTF-8 (note 0x03, 0x04 and the high-bit bytes), which is exactly what
+// breaks a naive yaml.Marshal of a string field containing them.
+var zipMagic = []byte{
+	0x50, 0x4b, 0x03, 0x04, 0x14, 0x00, 0x08, 0x00,
+	0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0xff, 0xfe, 0xfd, 0xfc, // high-bit bytes that fail utf8.ValidString
+}
+
+func TestHTTPResp_YAML_RoundTrip_BinaryBody(t *testing.T) {
+	// Reproduces the failure mode from keploy/enterprise#1902:
+	// an application/zip response body contains non-UTF-8 bytes, which
+	// yaml.v3 refuses to marshal as !!str.
+	original := HTTPResp{
+		StatusCode: 200,
+		Header: map[string]string{
+			"Content-Type":        "application/zip",
+			"Content-Disposition": `attachment; filename="mocks.zip"`,
+		},
+		Body:      string(zipMagic),
+		Timestamp: time.Date(2026, 4, 21, 19, 56, 52, 0, time.UTC),
+	}
+
+	out, err := yamlLib.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal non-UTF-8 body failed: %v", err)
+	}
+
+	var decoded HTTPResp
+	if err := yamlLib.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if decoded.Body != original.Body {
+		t.Fatalf("body mismatch after round-trip: want %d bytes, got %d bytes",
+			len(original.Body), len(decoded.Body))
+	}
+}
+
+func TestHTTPResp_YAML_UTF8BodyStaysPlain(t *testing.T) {
+	// Regression guard: valid UTF-8 bodies must continue to serialize as a
+	// plain scalar under `body:` without a body_base64 sibling.
+	original := HTTPResp{
+		StatusCode: 200,
+		Header:     map[string]string{"Content-Type": "application/json"},
+		Body:       `{"hello":"world"}`,
+		Timestamp:  time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC),
+	}
+
+	out, err := yamlLib.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	if got := string(out); containsLine(got, "body_base64:") {
+		t.Fatalf("UTF-8 body should not emit body_base64, got:\n%s", got)
+	}
+
+	var decoded HTTPResp
+	if err := yamlLib.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if decoded.Body != original.Body {
+		t.Fatalf("body mismatch: want %q, got %q", original.Body, decoded.Body)
+	}
+}
+
+func TestHTTPReq_YAML_RoundTrip_BinaryBody(t *testing.T) {
+	// The same failure can happen on the request side when an app uploads
+	// binary content (e.g. a PUT with application/octet-stream).
+	original := HTTPReq{
+		Method:     "PUT",
+		ProtoMajor: 1, ProtoMinor: 1,
+		URL:       "http://example.test/upload",
+		Header:    map[string]string{"Content-Type": "application/octet-stream"},
+		Body:      string(zipMagic),
+		Timestamp: time.Date(2026, 4, 21, 19, 56, 52, 0, time.UTC),
+	}
+
+	out, err := yamlLib.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal non-UTF-8 body failed: %v", err)
+	}
+
+	var decoded HTTPReq
+	if err := yamlLib.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if decoded.Body != original.Body {
+		t.Fatalf("body mismatch after round-trip: want %d bytes, got %d bytes",
+			len(original.Body), len(decoded.Body))
+	}
+}
+
+// containsLine reports whether s contains a line that begins with prefix
+// (ignoring leading whitespace). Used to assert the absence of a YAML key.
+func containsLine(s, prefix string) bool {
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			if lineHasPrefix(s[start:i], prefix) {
+				return true
+			}
+			start = i + 1
+		}
+	}
+	return lineHasPrefix(s[start:], prefix)
+}
+
+func lineHasPrefix(line, prefix string) bool {
+	i := 0
+	for i < len(line) && (line[i] == ' ' || line[i] == '\t') {
+		i++
+	}
+	if i+len(prefix) > len(line) {
+		return false
+	}
+	return line[i:i+len(prefix)] == prefix
+}

--- a/pkg/models/http_stream_body.go
+++ b/pkg/models/http_stream_body.go
@@ -80,14 +80,23 @@ func (c HTTPStreamChunk) ValueByKey(key string) (string, bool) {
 // MarshalYAML serializes an HTTPResp to YAML.
 // If the response has streaming chunks (StreamBody), the body field is written
 // as a YAML sequence of chunks. Otherwise, it is written as a plain scalar string.
+//
+// If the body contains non-UTF-8 bytes (e.g. application/zip, image/*,
+// application/octet-stream payloads) yaml.v3 refuses to emit it as a !!str
+// scalar. The raw bytes are moved into a sibling body_base64 field instead —
+// see splitBodyForYAML.
 func (h HTTPResp) MarshalYAML() (interface{}, error) {
 	bodyNode := &yamlLib.Node{}
+	var bodyB64 string
 	if chunks, ok := streamChunksForYAML(h); ok {
-		// Streaming response — encode as a YAML sequence of chunks
+		// Streaming response — encode as a YAML sequence of chunks.
+		// Streaming formats (SSE / NDJSON / text) are always UTF-8 by
+		// construction, so no base64 fallback is needed here.
 		bodyNode = encodeStreamChunksNode(chunks)
 	} else {
-		// Non-streaming response — encode body as a plain string scalar
-		if err := bodyNode.Encode(h.Body); err != nil {
+		plain, b64 := splitBodyForYAML(h.Body)
+		bodyB64 = b64
+		if err := bodyNode.Encode(plain); err != nil {
 			return nil, err
 		}
 	}
@@ -96,6 +105,7 @@ func (h HTTPResp) MarshalYAML() (interface{}, error) {
 		StatusCode    int               `yaml:"status_code"`
 		Header        map[string]string `yaml:"header"`
 		Body          *yamlLib.Node     `yaml:"body"`
+		BodyBase64    string            `yaml:"body_base64,omitempty"`
 		BodySkipped   bool              `yaml:"body_skipped,omitempty"`
 		BodySize      int64             `yaml:"body_size,omitempty"`
 		StatusMessage string            `yaml:"status_message"`
@@ -109,6 +119,7 @@ func (h HTTPResp) MarshalYAML() (interface{}, error) {
 		StatusCode:    h.StatusCode,
 		Header:        h.Header,
 		Body:          bodyNode,
+		BodyBase64:    bodyB64,
 		BodySkipped:   h.BodySkipped,
 		BodySize:      h.BodySize,
 		StatusMessage: h.StatusMessage,
@@ -122,11 +133,15 @@ func (h HTTPResp) MarshalYAML() (interface{}, error) {
 // UnmarshalYAML deserializes an HTTPResp from YAML.
 // The body field can be either a plain string (non-streaming)
 // or a YAML sequence of chunks (streaming). Both formats are handled.
+//
+// If body_base64 is present on the document, it takes precedence over body
+// and is decoded into the raw byte-for-byte Body — see joinBodyFromYAML.
 func (h *HTTPResp) UnmarshalYAML(node *yamlLib.Node) error {
 	type httpRespYAML struct {
 		StatusCode    int               `yaml:"status_code"`
 		Header        map[string]string `yaml:"header"`
 		Body          yamlLib.Node      `yaml:"body"`
+		BodyBase64    string            `yaml:"body_base64,omitempty"`
 		BodySkipped   bool              `yaml:"body_skipped,omitempty"`
 		BodySize      int64             `yaml:"body_size,omitempty"`
 		StatusMessage string            `yaml:"status_message"`
@@ -156,6 +171,15 @@ func (h *HTTPResp) UnmarshalYAML(node *yamlLib.Node) error {
 	body, streamChunks, err := decodeStreamBody(raw.Body, raw.Header, raw.Timestamp)
 	if err != nil {
 		return err
+	}
+	// body_base64 is only used for non-streaming binary bodies and wins
+	// over an (expected to be empty) plain body.
+	if streamChunks == nil {
+		joined, err := joinBodyFromYAML(body, raw.BodyBase64)
+		if err != nil {
+			return err
+		}
+		body = joined
 	}
 	h.Body = body
 	h.StreamBody = streamChunks


### PR DESCRIPTION
## Describe the changes that are made
- Add `MarshalYAML` / `UnmarshalYAML` on `HTTPReq` and update the existing ones on `HTTPResp` so that bodies containing non-UTF-8 bytes (e.g. `application/zip`, `application/octet-stream`, images, PDFs) are emitted to a sibling `body_base64` field instead of a plain `body:` scalar.
- Rehydrate the raw bytes back into `Body` on decode, so every downstream consumer (replay simulator, matchers, asset offload) keeps reading `http_resp.body` / `http_req.body` unchanged.
- Valid UTF-8 bodies still serialize as a plain `body:` scalar — no `body_base64` key is emitted — so existing yaml fixtures on disk are untouched.
- Add `pkg/models/http_binary_body_test.go` covering the zip-magic round-trip for both `HTTPReq` and `HTTPResp`, plus a regression guard that UTF-8 bodies do not grow a `body_base64` sibling.

## Links & References

**Closes:** keploy/enterprise#1902

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- keploy/enterprise#1902
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

_Unit tests cover the serialization round-trip directly; an e2e with a binary endpoint would be useful as a follow-up._

## Added comments for hard-to-understand areas?
- [x] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

### Repro before this PR
Record any app that returns a binary body. Example from the linked issue: `GET /k8s-proxy/mocks/download` returning a zip. Keploy dies with:

```
ERROR  utils/utils.go:314   failed to marshal the http input-output as yaml
                            {"error": "yaml: cannot marshal invalid UTF-8 data as !!str"}
ERROR  utils/utils.go:314   error while inserting mock into db, hence stopping keploy
INFO   utils/ctx.go:58      stopping Keploy
```

### Verification on this PR
```
go test ./pkg/models/ -run 'TestHTTPResp_YAML|TestHTTPReq_YAML' -v
```
```
=== RUN   TestHTTPResp_YAML_RoundTrip_BinaryBody
--- PASS
=== RUN   TestHTTPResp_YAML_UTF8BodyStaysPlain
--- PASS
=== RUN   TestHTTPReq_YAML_RoundTrip_BinaryBody
--- PASS
```
Full package suites (`go test ./...`) also stay green.

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- See keploy/enterprise#1902 for the original failing log excerpt (test-64, `application/zip` response).

## Notes for reviewers

- **Why `body_base64` instead of reusing the existing `Binary` field?** `Binary` is declared on both `HTTPReq` and `HTTPResp` but no capture path writes to it, and its semantics aren't documented. Added a clearly-named sibling to avoid overloading an ambiguous field.
- **Scope deliberately narrow.** Only the yaml serialization path changes. BSON, JSON (mongo store), replay simulator, asset offload (`BodyRef` / `BodySkipped`), and stream-body (SSE / NDJSON) handling are untouched. If BSON also rejects non-UTF-8 string fields in some driver configurations that should be a separate fix.
- **Streaming bodies are not base64-ified.** SSE / NDJSON are text protocols; the `streamChunksForYAML` branch is preserved as-is.