### PR TITLE
ci: stabilize Java Linux Maven setup

### DIFF
--- a/.github/workflows/java_linux.yml
+++ b/.github/workflows/java_linux.yml
@@ -44,16 +44,13 @@ jobs:
           repository: keploy/samples-java
           path: samples-java
 
-      - name: Installing the necessary dependencies
-        run: |
-          cd samples-java/${{ matrix.app.path }}
-          ./mvnw dependency:resolve
-
-      - name: Compile the project
-        run: |
-          cd samples-java/${{ matrix.app.path }}
-          source $GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/update-java.sh
-          ./mvnw compile
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+          cache-dependency-path: samples-java/${{ matrix.app.path }}/pom.xml
 
       - name: Run the ${{ matrix.app.name }} app
         env:
@@ -99,6 +96,14 @@ jobs:
         with:
           repository: keploy/samples-java
           path: samples-java
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+          cache-dependency-path: samples-java/mysql-dual-conn/pom.xml
 
       - name: Run mysql-dual-conn app
         env:

--- a/.github/workflows/test_workflow_scripts/java/mysql_dual_conn/java-linux.sh
+++ b/.github/workflows/test_workflow_scripts/java/mysql_dual_conn/java-linux.sh
@@ -51,6 +51,27 @@ wait_for_app() {
   endsec; return 1
 }
 
+run_maven_build() {
+  : > mvn_build.log
+
+  for attempt in 1 2 3; do
+    if {
+      echo "===== Maven build attempt ${attempt}/3 ====="
+      mvn -B -U clean package -Dmaven.test.skip=true -q
+    } 2>&1 | tee -a mvn_build.log; then
+      return 0
+    fi
+
+    echo "Maven build failed on attempt ${attempt}/3. The script will retry automatically; if all attempts fail, review mvn_build.log for the root cause."
+    if [[ "$attempt" -lt 3 ]]; then
+      sleep $((attempt * 10))
+    fi
+  done
+
+  echo "::error::Maven build failed after 3 attempts. Review mvn_build.log to inspect the output from all attempts and identify the cause."
+  return 1
+}
+
 send_request() {
   local kp_pid="$1"
 
@@ -90,7 +111,7 @@ endsec
 
 section "Build"
 source "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/update-java.sh"
-mvn clean package -Dmaven.test.skip=true -q | tee mvn_build.log
+run_maven_build
 endsec
 
 JAR_NAME=$(ls target/mysql-dual-conn-*.jar 2>/dev/null | head -n1)

--- a/.github/workflows/test_workflow_scripts/java/spring_petclinic/java-linux.sh
+++ b/.github/workflows/test_workflow_scripts/java/spring_petclinic/java-linux.sh
@@ -88,6 +88,27 @@ detect_api_prefix() {
   return 1
 }
 
+run_maven_build() {
+  : > mvn_build.log
+
+  for attempt in 1 2 3; do
+    if {
+      echo "===== Maven build attempt ${attempt}/3 ====="
+      mvn -B -U clean install -Dmaven.test.skip=true
+    } 2>&1 | tee -a mvn_build.log; then
+      return 0
+    fi
+
+    echo "Maven build failed on attempt ${attempt}/3. Retrying after backoff; if this keeps failing, review mvn_build.log for the underlying error."
+    if [[ "$attempt" -lt 3 ]]; then
+      sleep $((attempt * 10))
+    fi
+  done
+
+  echo "::error::Maven build failed after 3 attempts. Review mvn_build.log for the underlying error, fix the build, and rerun the workflow."
+  return 1
+}
+
 # --- USER PROVIDED HELPERS START ---
 
 # Configuration
@@ -636,7 +657,7 @@ for i in 1; do
   section "Record iteration $i"
 
   # Build app (captured to log)
-  mvn clean install -Dmaven.test.skip=true | tee -a mvn_build.log
+  run_maven_build
 
   app_name="javaApp_${i}"
 

--- a/.github/workflows/test_workflow_scripts/update-java.sh
+++ b/.github/workflows/test_workflow_scripts/update-java.sh
@@ -1,8 +1,40 @@
 #! /bin/bash
 
-# Update the java version
-sudo apt update
-sudo apt install openjdk-17-jre -y
-export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
-export PATH=$JAVA_HOME/bin:$PATH
-source ~/.bashrc
+java_major_version() {
+  "$1" -version 2>&1 | awk -F '[\".]' '/version/ {print ($2 == "1" ? $3 : $2); exit}'
+}
+
+has_java_17_jdk() {
+  [[ -x "$1/bin/java" && -x "$1/bin/javac" ]] && [[ "$(java_major_version "$1/bin/java")" == "17" ]]
+}
+
+java_setup_done=false
+
+if [[ -n "${JAVA_HOME:-}" ]]; then
+  if has_java_17_jdk "$JAVA_HOME"; then
+    export PATH="${JAVA_HOME}/bin:${PATH}"
+    java_setup_done=true
+  fi
+fi
+
+if [[ "$java_setup_done" != "true" ]] && command -v java >/dev/null 2>&1; then
+  java_bin="$(command -v java)"
+  resolved_java_bin="$(readlink -f "$java_bin" 2>/dev/null || true)"
+  if [[ -n "$resolved_java_bin" ]]; then
+    java_bin="$resolved_java_bin"
+  fi
+  java_home="$(dirname "$(dirname "$java_bin")")"
+
+  if has_java_17_jdk "$java_home"; then
+    export JAVA_HOME="$java_home"
+    export PATH="${JAVA_HOME}/bin:${PATH}"
+    java_setup_done=true
+  fi
+fi
+
+if [[ "$java_setup_done" != "true" ]]; then
+  sudo apt-get update
+  sudo apt-get install openjdk-17-jdk-headless -y
+  export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+  export PATH="${JAVA_HOME}/bin:${PATH}"
+fi


### PR DESCRIPTION
## Describe the changes that are made
- Stabilizes the Java Linux sample workflow that failed in `run_java_linux / spring-petclinic-rest (record_build_replay_build)`.
- Removes the duplicate `./mvnw dependency:resolve` and `./mvnw compile` warmup steps from the workflow. The Spring PetClinic script already builds the checked-out sample branch with system `mvn`, so those wrapper calls were extra network work and the direct source of the flaky Maven distribution download.
- Adds `actions/setup-java@v4` with Java 17 and Maven dependency caching for both Java Linux sample jobs.
- Updates `update-java.sh` to reuse an existing Java 17 toolchain, falling back to apt only when Java 17 is not already available.
- Wraps the Java sample Maven builds in bounded retries with batch mode and forced update checks so transient Maven Central failures do not fail the whole CI leg immediately.

## Links & References

**Closes:** NA

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- Failed run: https://github.com/keploy/keploy/actions/runs/24773607797/job/72486510667?pr=4036

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [x] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because this hardens the existing Java Linux e2e pipeline
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [x] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

```bash
bash -n .github/workflows/test_workflow_scripts/update-java.sh \
  .github/workflows/test_workflow_scripts/java/spring_petclinic/java-linux.sh \
  .github/workflows/test_workflow_scripts/java/mysql_dual_conn/java-linux.sh

ruby -e 'require "yaml"; YAML.load_file(".github/workflows/java_linux.yml"); puts "ok"'

git diff --check
```

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- The flaky job failed while `./mvnw dependency:resolve` tried to download Maven 3.6.3 from Maven Central and received HTTP 403: https://github.com/keploy/keploy/actions/runs/24773607797/job/72486510667?pr=4036
- The successful sibling jobs already continued into normal Maven dependency downloads, which points to the wrapper distribution download path as the unstable part.

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?
