### PR TITLE
fix: stabilize Linux integration CI

### DIFF
--- a/.github/workflows/golang_linux.yml
+++ b/.github/workflows/golang_linux.yml
@@ -17,6 +17,7 @@ jobs:
   golang_linux:
     if: ${{ inputs.jobs_to_run == 'all' }}
     runs-on: ${{ inputs.runner }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/golang_linux.yml
+++ b/.github/workflows/golang_linux.yml
@@ -255,6 +255,29 @@ jobs:
           REPLAY_BIN: ${{ steps.replay.outputs.path }}
         run: |
           cd samples-go/${{ matrix.app.path }}
+          download_go_modules() {
+            local attempt=1
+            local max_attempts=4
+            local sleep_sec=5
+            local go_proxy="https://proxy.golang.org,direct"
+            while [ "$attempt" -le "$max_attempts" ]; do
+              if GOPROXY="$go_proxy" go mod download; then
+                return 0
+              fi
+              if [ "$attempt" -ge "$max_attempts" ]; then
+                echo "::error::go mod download failed after ${max_attempts} attempts"
+                return 1
+              fi
+              if [ "$attempt" -eq 2 ]; then
+                go_proxy="direct"
+              fi
+              echo "go mod download attempt ${attempt} failed; retrying in ${sleep_sec}s"
+              sleep "$sleep_sec"
+              sleep_sec=$((sleep_sec * 2))
+              attempt=$((attempt + 1))
+            done
+          }
+          download_go_modules
           $REPLAY_BIN test --port 8000 --sse-port 8047 --api-timeout 200 --delay 30
 
       - name: Test port mapping (http-sse only)

--- a/.github/workflows/golang_linux.yml
+++ b/.github/workflows/golang_linux.yml
@@ -100,6 +100,7 @@ jobs:
   golang_linux_private:
     if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     runs-on: ${{ inputs.runner }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -144,6 +145,7 @@ jobs:
         with:
           repository: keploy/samples-go
           path: samples-go
+          ref: native-linux
       - name: Run ${{ matrix.app.name }} application
         env:
           RECORD_BIN: ${{ steps.record.outputs.path }}

--- a/.github/workflows/grpc_linux.yml
+++ b/.github/workflows/grpc_linux.yml
@@ -11,6 +11,7 @@ jobs:
   grpc_linux:
     if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     runs-on: ${{ inputs.runner }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -35,9 +36,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: keploy/keploy
-
-      - name: Install lsof utility
-        run: sudo apt-get update && sudo apt-get install -y lsof
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -71,6 +69,7 @@ jobs:
   grpc_linux_protoscope:
     if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     runs-on: ${{ inputs.runner }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -94,9 +93,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: keploy/keploy
-
-      - name: Install lsof utility
-        run: sudo apt-get update && sudo apt-get install -y lsof
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -130,6 +126,7 @@ jobs:
 
   grpc_linux_secret:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -153,9 +150,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: keploy/keploy
-
-      - name: Install lsof utility
-        run: sudo apt-get update && sudo apt-get install -y lsof
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/python_linux.yml
+++ b/.github/workflows/python_linux.yml
@@ -34,16 +34,25 @@ jobs:
             record_src: build
             replay_src: build
     name: ${{ matrix.app.name }} (${{ matrix.config.job }})
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           repository: keploy/keploy
 
-      - name: Install Python
-        uses: deadsnakes/action@v3.2.0
+      - name: Checkout the samples-python repository
+        uses: actions/checkout@v4
         with:
-          python-version: "3.11"
+          repository: keploy/samples-python
+          path: samples-python
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: samples-python/${{ matrix.app.path }}/requirements.txt
 
       - id: record
         uses: ./.github/actions/download-binary
@@ -54,11 +63,6 @@ jobs:
         uses: ./.github/actions/download-binary
         with:
           src: ${{ matrix.config.replay_src }}
-      - name: Checkout the samples-python repository
-        uses: actions/checkout@v4
-        with:
-          repository: keploy/samples-python
-          path: samples-python
       - name: Run the ${{ matrix.app.name }} application
         env:
           RECORD_BIN: ${{ steps.record.outputs.path }}
@@ -88,16 +92,26 @@ jobs:
             record_src: build
             replay_src: build
     name: ${{ matrix.app.name }} (${{ matrix.config.job }})
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           repository: keploy/keploy
-      
-      - name: Install Python
-        uses: deadsnakes/action@v3.2.0
+
+      - name: Checkout the samples-python repository
+        uses: actions/checkout@v4
         with:
-          python-version: "3.11"
+          repository: keploy/samples-python
+          path: samples-python
+          ref: native-linux
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: samples-python/${{ matrix.app.path }}/requirements.txt
 
       - name: Setup docker-compose
         run: |
@@ -120,11 +134,6 @@ jobs:
         uses: ./.github/actions/download-binary
         with:
           src: ${{ matrix.config.replay_src }}
-      - name: Checkout the samples-python repository
-        uses: actions/checkout@v4
-        with:
-          repository: keploy/samples-python
-          path: samples-python
       - name: Run the ${{ matrix.app.name }} application
         env:
           RECORD_BIN: ${{ steps.record.outputs.path }}

--- a/.github/workflows/test_workflow_scripts/golang/connect_tunnel/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/connect_tunnel/golang-linux.sh
@@ -16,40 +16,113 @@ echo "REPLAY_BIN=$REPLAY_BIN"
 
 source ./../../.github/workflows/test_workflow_scripts/test-iid.sh
 
+cleanup() {
+    if [ -n "${PROXY_PID:-}" ] && kill -0 "$PROXY_PID" 2>/dev/null; then
+        kill "$PROXY_PID" 2>/dev/null || true
+        wait "$PROXY_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
 # ── Cleanup ──
 if [ -f "./keploy.yml" ]; then
     rm ./keploy.yml
 fi
 rm -rf keploy/
 
-# ── Install tinyproxy ──
-echo "Installing tinyproxy..."
-sudo apt-get update -qq && sudo apt-get install -y -qq tinyproxy > /dev/null 2>&1
-echo "tinyproxy installed."
+# ── Start a local CONNECT proxy ──
+# Avoid apt/tinyproxy in CI. GitHub-hosted apt mirrors can stall, while Go is
+# already provisioned for this workflow.
+cat > /tmp/connect-proxy.go <<'EOF'
+package main
 
-# ── Configure and start tinyproxy ──
-cat > /tmp/tinyproxy.conf <<'PROXYCONF'
-Port 3128
-Listen 0.0.0.0
-Timeout 600
-MaxClients 100
-Allow 0.0.0.0/0
-ConnectPort 443
-ConnectPort 80
-LogLevel Info
-PROXYCONF
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
 
-tinyproxy -c /tmp/tinyproxy.conf &
+func main() {
+	ln, err := net.Listen("tcp", "127.0.0.1:3128")
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Println("connect proxy listening on 127.0.0.1:3128")
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			log.Println(err)
+			continue
+		}
+		go handle(conn)
+	}
+}
+
+func handle(client net.Conn) {
+	defer client.Close()
+
+	reader := bufio.NewReader(client)
+	req, err := http.ReadRequest(reader)
+	if err != nil {
+		return
+	}
+	if req.Method != http.MethodConnect {
+		fmt.Fprint(client, "HTTP/1.1 405 Method Not Allowed\r\n\r\n")
+		return
+	}
+
+	target := req.Host
+	if !strings.Contains(target, ":") {
+		target += ":443"
+	}
+
+	upstream, err := net.DialTimeout("tcp", target, 10*time.Second)
+	if err != nil {
+		fmt.Fprint(client, "HTTP/1.1 502 Bad Gateway\r\n\r\n")
+		return
+	}
+	defer upstream.Close()
+
+	fmt.Fprint(client, "HTTP/1.1 200 Connection Established\r\n\r\n")
+	errc := make(chan error, 2)
+	go func() {
+		_, err := io.Copy(upstream, reader)
+		errc <- err
+	}()
+	go func() {
+		_, err := io.Copy(client, upstream)
+		errc <- err
+	}()
+	<-errc
+}
+EOF
+
+go build -o /tmp/connect-proxy /tmp/connect-proxy.go
+/tmp/connect-proxy &
 PROXY_PID=$!
-echo "tinyproxy started (PID: $PROXY_PID)"
-sleep 2
+echo "CONNECT proxy started (PID: $PROXY_PID)"
 
 # Verify proxy is listening
-if ! nc -z 127.0.0.1 3128 >/dev/null 2>&1; then
-    echo "::error::tinyproxy failed to start on port 3128"
+for attempt in {1..20}; do
+    if (echo > /dev/tcp/127.0.0.1/3128) >/dev/null 2>&1; then
+        echo "CONNECT proxy is ready on :3128"
+        break
+    fi
+    if ! kill -0 "$PROXY_PID" 2>/dev/null; then
+        echo "::error::CONNECT proxy exited before it became ready"
+        exit 1
+    fi
+    sleep 1
+done
+if ! (echo > /dev/tcp/127.0.0.1/3128) >/dev/null 2>&1; then
+    echo "::error::CONNECT proxy failed to start on port 3128"
     exit 1
 fi
-echo "tinyproxy is ready on :3128"
 
 # ── Build the app ──
 go build -o connect-tunnel
@@ -63,13 +136,28 @@ if [ -f "$config_file" ]; then
     sed -i 's/global: {}/global: {"header": {"Date":[], "Content-Length":[]}, "body": {"origin":[], "headers.X-Amzn-Trace-Id":[]}}/' "$config_file"
 fi
 
+stop_recording() {
+    local rec_pid
+    rec_pid="$(pgrep -n -f "$(basename "${RECORD_BIN:-keploy}") record" || true)"
+    if [ -n "$rec_pid" ]; then
+        sudo kill -INT "$rec_pid" 2>/dev/null || true
+        (
+            sleep 15
+            if kill -0 "$rec_pid" 2>/dev/null; then
+                echo "===== FORCE KILLING KEPLOY RECORD PID $rec_pid ====="
+                sudo kill -9 "$rec_pid" 2>/dev/null || true
+            fi
+        ) &
+    fi
+}
+
 # ── Helper: send requests to the app ──
 send_request() {
     sleep 6
     # Wait for app to be ready
     app_ready=false
     for i in {1..30}; do
-        if curl -sf http://localhost:8080/health > /dev/null 2>&1; then
+        if curl -fsS --max-time 5 http://127.0.0.1:8080/health > /dev/null 2>&1; then
             app_ready=true
             break
         fi
@@ -77,22 +165,25 @@ send_request() {
     done
     if [ "$app_ready" = false ]; then
         echo "::error::App failed to become ready on :8080 after 30s"
+        stop_recording
         return 1
     fi
 
     echo "App is ready, sending requests..."
 
     # 1. Health check (no external deps)
-    curl -s http://localhost:8080/health
+    curl -fsS --max-time 10 http://127.0.0.1:8080/health || { stop_recording; return 1; }
     echo ""
 
     # 2. Request via CONNECT tunnel
-    curl -s --max-time 15 http://localhost:8080/via-proxy
+    if ! curl -sS --max-time 15 http://127.0.0.1:8080/via-proxy; then
+        echo "::warning::CONNECT tunnel request failed during record; report validation will decide if this is expected for the selected binary"
+    fi
     echo ""
 
     # Wait for keploy to finish recording
     sleep 7
-    sudo pkill -INT -f "keploy record" 2>/dev/null || true
+    stop_recording
     echo "Sent SIGINT to keploy record process"
 }
 
@@ -101,8 +192,12 @@ for i in 1 2; do
     app_name="connect-tunnel_${i}"
     send_request &
     REQ_PID=$!
-    HTTP_PROXY=http://127.0.0.1:3128 HTTPS_PROXY=http://127.0.0.1:3128 \
-        "$RECORD_BIN" record -c "./connect-tunnel" --generateGithubActions=false 2>&1 | tee "${app_name}.txt"
+    if ! timeout --kill-after=30s 8m env HTTP_PROXY=http://127.0.0.1:3128 HTTPS_PROXY=http://127.0.0.1:3128 \
+        "$RECORD_BIN" record -c "./connect-tunnel" --generateGithubActions=false 2>&1 | tee "${app_name}.txt"; then
+        echo "::error::connect-tunnel recording iteration $i failed or timed out"
+        stop_recording
+        exit 1
+    fi
 
     if grep "ERROR" "${app_name}.txt" | grep "Keploy" | grep -v "tinyproxy\|WARNING\|CONNECT\|connection refused\|no matching.*mock"; then
         echo "::error::Error found in recording iteration $i"
@@ -115,7 +210,10 @@ for i in 1 2; do
         exit 1
     fi
     sleep 5
-    wait "$REQ_PID" 2>/dev/null || true
+    if ! wait "$REQ_PID"; then
+        echo "::error::Request driver failed in recording iteration $i"
+        exit 1
+    fi
     echo "Recorded test cases for iteration $i"
 done
 
@@ -123,17 +221,25 @@ echo "Recording complete. Test sets:"
 ls -la keploy/*/tests/ 2>/dev/null || echo "No test sets found"
 ls -la keploy/*/mocks/ 2>/dev/null || echo "No mocks found"
 
-# ── Stop tinyproxy before replay ──
+# ── Stop CONNECT proxy before replay ──
 # This ensures replay uses mocks, not the real proxy.
-echo "Stopping tinyproxy for replay..."
+echo "Stopping CONNECT proxy for replay..."
 kill "$PROXY_PID" 2>/dev/null || true
+wait "$PROXY_PID" 2>/dev/null || true
 sleep 2
 
 # ── Replay phase ──
 # Allow non-zero exit from replay (some tests may fail with latest binary).
 # We validate results from the report files below.
-HTTP_PROXY=http://127.0.0.1:3128 HTTPS_PROXY=http://127.0.0.1:3128 \
-    "$REPLAY_BIN" test -c "./connect-tunnel" --delay 7 --generateGithubActions=false 2>&1 | tee test_logs.txt || true
+set +e
+timeout --kill-after=30s 8m env HTTP_PROXY=http://127.0.0.1:3128 HTTPS_PROXY=http://127.0.0.1:3128 \
+    "$REPLAY_BIN" test -c "./connect-tunnel" --delay 7 --generateGithubActions=false 2>&1 | tee test_logs.txt
+replay_rc=${PIPESTATUS[0]}
+set -e
+if [ "$replay_rc" -eq 124 ] || [ "$replay_rc" -eq 137 ]; then
+    echo "::error::connect-tunnel replay timed out"
+    exit 1
+fi
 
 if grep "ERROR" "test_logs.txt" | grep "Keploy" | grep -v "tinyproxy\|WARNING\|CONNECT\|connection refused\|no matching.*mock"; then
     echo "::error::Error found in replay"

--- a/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-linux.sh
@@ -1,13 +1,26 @@
 #!/bin/bash
 
-# Checkout a different branch
-git fetch origin
-git checkout native-linux
-
 echo "root ALL=(ALL:ALL) ALL" | sudo tee -a /etc/sudoers
 
 # Start mongo before starting keploy.
+docker rm -f mongoDb >/dev/null 2>&1 || true
 docker run --rm -d -p27017:27017 --name mongoDb mongo
+trap 'docker rm -f mongoDb >/dev/null 2>&1 || true' EXIT
+
+mongo_ready=false
+for mongo_attempt in {1..30}; do
+    if docker exec mongoDb mongosh --quiet --eval 'db.adminCommand({ ping: 1 }).ok' | grep -q '^1$'; then
+        mongo_ready=true
+        break
+    fi
+    sleep 2
+done
+
+if [ "$mongo_ready" != true ]; then
+    echo "::error::MongoDB did not become ready within 60 seconds"
+    docker logs mongoDb || true
+    exit 1
+fi
 
 # Check if there is a keploy-config file, if there is, delete it.
 if [ -f "./keploy.yml" ]; then
@@ -29,6 +42,44 @@ rm -rf keploy/
 # Build the binary.
 go build -cover -coverpkg=./... -o ginApp
 
+stop_recording(){
+    local kp_pid="${1:-}"
+    local rec_pid
+
+    rec_pid="$(pgrep -n -f "$(basename "${RECORD_BIN:-keploy}") record" || true)"
+    echo "$rec_pid Keploy PID"
+    echo "Killing keploy"
+    if [ -n "$rec_pid" ]; then
+        sudo kill -INT "$rec_pid" 2>/dev/null || true
+        # Wait for keploy to flush and exit (up to 30s).
+        for stop_attempt in {1..30}; do
+            kill -0 "$rec_pid" 2>/dev/null || break
+            sleep 1
+        done
+        # SIGINT-then-SIGKILL escalation. On keploy/keploy#4077 run
+        # 24631193918 a single gin-mongo record iteration hung the
+        # entire job for 140+ minutes because keploy didn't respond
+        # to SIGINT and `wait` at the bottom of the loop blocked
+        # forever on its tee'd stdout. Dumping goroutines before
+        # SIGKILL gives us the actual RCA on the next hang instead
+        # of a blank 6-hour timeout. SIGQUIT is Go-runtime-friendly
+        # and prints all goroutine stacks to stderr, which the
+        # tee above captures into ${app_name}.txt.
+        if kill -0 "$rec_pid" 2>/dev/null; then
+            echo "::warning::keploy did not exit within 30s of SIGINT (pid $rec_pid). Dumping goroutines via SIGQUIT, then escalating to SIGKILL."
+            sudo kill -QUIT "$rec_pid" 2>/dev/null || true
+            sleep 3
+            sudo kill -9 "$rec_pid" 2>/dev/null || true
+            # Brief pause so the tee pipe has a chance to drain
+            # before the outer `wait` returns and the loop moves on.
+            sleep 2
+        fi
+    elif [ -n "$kp_pid" ]; then
+        sudo kill -INT "$kp_pid" 2>/dev/null || true
+    else
+        echo "No keploy process found to kill."
+    fi
+}
 
 send_request(){
     local kp_pid="$1"
@@ -43,9 +94,10 @@ send_request(){
     while [ "$app_started" = false ]; do
         if [ "$(date +%s)" -gt "$deadline" ]; then
             echo "::error::gin-mongo app did not respond on http://localhost:8080 within 5 minutes; aborting iteration"
+            stop_recording "$kp_pid"
             return 1
         fi
-        if curl --request POST \
+        if curl --silent --fail --max-time 5 --output /dev/null --request POST \
       --url http://localhost:8080/url \
       --header 'content-type: application/json' \
       --data '{
@@ -57,78 +109,58 @@ send_request(){
     done
     echo "App started"
     # Start making curl calls to record the testcases and mocks.
-    curl --request POST \
+    curl --fail --show-error --max-time 30 --request POST \
       --url http://localhost:8080/url \
       --header 'content-type: application/json' \
       --data '{
       "url": "https://google.com"
-    }'
+    }' || { stop_recording "$kp_pid"; return 1; }
 
-    curl --request POST \
+    curl --fail --show-error --max-time 30 --request POST \
       --url http://localhost:8080/url \
       --header 'content-type: application/json' \
       --data '{
       "url": "https://facebook.com"
-    }'
+    }' || { stop_recording "$kp_pid"; return 1; }
 
-    curl -X GET http://localhost:8080/CJBKJd92
+    curl --fail --show-error --max-time 30 -X GET http://localhost:8080/CJBKJd92 || { stop_recording "$kp_pid"; return 1; }
 
     # Test email verification endpoint
-    curl --request GET \
+    curl --fail --show-error --max-time 30 --request GET \
       --url 'http://localhost:8080/verify-email?email=test@gmail.com' \
-      --header 'Accept: application/json'
+      --header 'Accept: application/json' || { stop_recording "$kp_pid"; return 1; }
 
-    curl --request GET \
+    curl --fail --show-error --max-time 30 --request GET \
       --url 'http://localhost:8080/verify-email?email=admin@yahoo.com' \
-      --header 'Accept: application/json'
+      --header 'Accept: application/json' || { stop_recording "$kp_pid"; return 1; }
 
     # Wait for keploy to record the tcs and mocks.
     sleep 10
-    REC_PID="$(pgrep -n -f "$(basename "${RECORD_BIN:-keploy}") record" || true)"
-    echo "$REC_PID Keploy PID"
-    echo "Killing keploy"
-    if [ -n "$REC_PID" ]; then
-        sudo kill -INT "$REC_PID" 2>/dev/null || true
-        # Wait for keploy to flush and exit (up to 30s).
-        for i in {1..30}; do
-            kill -0 "$REC_PID" 2>/dev/null || break
-            sleep 1
-        done
-        # SIGINT-then-SIGKILL escalation. On keploy/keploy#4077 run
-        # 24631193918 a single gin-mongo record iteration hung the
-        # entire job for 140+ minutes because keploy didn't respond
-        # to SIGINT and `wait` at the bottom of the loop blocked
-        # forever on its tee'd stdout. Dumping goroutines before
-        # SIGKILL gives us the actual RCA on the next hang instead
-        # of a blank 6-hour timeout. SIGQUIT is Go-runtime-friendly
-        # and prints all goroutine stacks to stderr, which the
-        # tee above captures into ${app_name}.txt.
-        if kill -0 "$REC_PID" 2>/dev/null; then
-            echo "::warning::keploy did not exit within 30s of SIGINT (pid $REC_PID). Dumping goroutines via SIGQUIT, then escalating to SIGKILL."
-            sudo kill -QUIT "$REC_PID" 2>/dev/null || true
-            sleep 3
-            sudo kill -9 "$REC_PID" 2>/dev/null || true
-            # Brief pause so the tee pipe has a chance to drain
-            # before the outer `wait` returns and the loop moves on.
-            sleep 2
-        fi
-    else
-        echo "No keploy process found to kill."
-    fi
+    stop_recording "$kp_pid"
+}
+
+has_unexpected_errors() {
+    local log_file="$1"
+    grep "ERROR" "$log_file" | grep -Ev "failed to read from connection.*use of closed network connection"
 }
 
 
-for i in {1..2}; do
-    app_name="javaApp_${i}"
+for record_iteration in {1..2}; do
+    app_name="javaApp_${record_iteration}"
     "$RECORD_BIN" record -c "./ginApp" 2>&1 | tee "${app_name}.txt" &
     
     KEPLOY_PID=$!
 
-    # Drive traffic and stop keploy (will fail the pipeline if health never comes up)
-    send_request "$KEPLOY_PID"
+    # Drive traffic and stop keploy (will fail the pipeline if health never comes up).
+    if ! send_request "$KEPLOY_PID"; then
+        echo "::error::Failed to drive gin-mongo traffic for record iteration ${record_iteration}"
+        cat "${app_name}.txt" || true
+        exit 1
+    fi
 
-    if grep "ERROR" "${app_name}.txt"; then
+    if unexpected_errors="$(has_unexpected_errors "${app_name}.txt")"; then
         echo "Error found in pipeline..."
+        printf '%s\n' "$unexpected_errors"
         cat "${app_name}.txt"
         exit 1
     fi
@@ -139,7 +171,7 @@ for i in {1..2}; do
     fi
     sleep 5
     wait
-    echo "Recorded test case and mocks for iteration ${i}"
+    echo "Recorded test case and mocks for iteration ${record_iteration}"
 done
 
 # Keep MongoDB running during test replay. Keploy will serve mocks for
@@ -149,8 +181,15 @@ done
 
 # Start the gin-mongo app in test mode.
 "$REPLAY_BIN" test -c "./ginApp" --delay 7   2>&1 | tee test_logs.txt
+replay_status=${PIPESTATUS[0]}
 
 cat test_logs.txt || true
+
+if [ "$replay_status" -ne 0 ]; then
+  echo "::error::Keploy replay failed with exit code ${replay_status}"
+  cat test_logs.txt
+  exit "$replay_status"
+fi
 
 # ✅ Extract and validate coverage percentage from log
 coverage_line=$(grep -Eo "Total Coverage Percentage:[[:space:]]+[0-9]+(\.[0-9]+)?%" "test_logs.txt" | tail -n1 || true)
@@ -173,8 +212,9 @@ else
   echo "✅ Coverage meets threshold (>= 50%)"
 fi
 
-if grep "ERROR" "test_logs.txt"; then
+if unexpected_errors="$(has_unexpected_errors "test_logs.txt")"; then
     echo "Error found in pipeline..."
+    printf '%s\n' "$unexpected_errors"
     cat "test_logs.txt"
     exit 1
 fi
@@ -189,21 +229,21 @@ all_passed=true
 
 
 # Get the test results from the testReport file.
-for i in {0..1}
+for test_set in {0..1}
 do
     # Define the report file for each test set
-    report_file="./keploy/reports/test-run-0/test-set-$i-report.yaml"
+    report_file="./keploy/reports/test-run-0/test-set-$test_set-report.yaml"
 
     # Extract the test status
     test_status=$(grep 'status:' "$report_file" | head -n 1 | awk '{print $2}')
 
     # Print the status for debugging
-    echo "Test status for test-set-$i: $test_status"
+    echo "Test status for test-set-$test_set: $test_status"
 
     # Check if any test set did not pass
     if [ "$test_status" != "PASSED" ]; then
         all_passed=false
-        echo "Test-set-$i did not pass."
+        echo "Test-set-$test_set did not pass."
         break # Exit the loop early as all tests need to pass
     fi
 done

--- a/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-linux.sh
@@ -2,6 +2,25 @@
 
 echo "root ALL=(ALL:ALL) ALL" | sudo tee -a /etc/sudoers
 
+dump_gin_mongo_ci_diagnostics() {
+    echo "===== docker ps -a ====="
+    docker ps -a || true
+
+    echo "===== mongoDb logs (last 200 lines) ====="
+    if docker ps -a --format '{{.Names}}' | grep -qx 'mongoDb'; then
+        docker logs --tail 200 mongoDb || true
+    else
+        echo "mongoDb container not found"
+    fi
+
+    echo "===== candidate Keploy/app log files under $(pwd) ====="
+    if find . -type f \( -iname '*keploy*.log' -o -iname '*app*.log' -o -name '*.txt' \) -print | sed 's|^\./||' | grep -q '.'; then
+        find . -type f \( -iname '*keploy*.log' -o -iname '*app*.log' -o -name '*.txt' \) -print | sed 's|^\./||'
+    else
+        echo "No Keploy/app log files matching '*keploy*.log', '*app*.log', or '*.txt' were found in the workspace"
+    fi
+}
+
 # Start mongo before starting keploy.
 docker rm -f mongoDb >/dev/null 2>&1 || true
 docker run --rm -d -p27017:27017 --name mongoDb mongo
@@ -17,8 +36,8 @@ for mongo_attempt in {1..30}; do
 done
 
 if [ "$mongo_ready" != true ]; then
-    echo "::error::MongoDB did not become ready within 60 seconds"
-    docker logs mongoDb || true
+    echo "::error::MongoDB did not become ready within 60 seconds. Next steps: verify the Docker daemon is available, check for image pull or container startup errors, and inspect the mongoDb logs printed below."
+    dump_gin_mongo_ci_diagnostics
     exit 1
 fi
 
@@ -66,13 +85,14 @@ stop_recording(){
         # and prints all goroutine stacks to stderr, which the
         # tee above captures into ${app_name}.txt.
         if kill -0 "$rec_pid" 2>/dev/null; then
-            echo "::warning::keploy did not exit within 30s of SIGINT (pid $rec_pid). Dumping goroutines via SIGQUIT, then escalating to SIGKILL."
+            echo "::error::keploy did not exit within 30s of SIGINT (pid $rec_pid). Dumping goroutines via SIGQUIT, then escalating to SIGKILL."
             sudo kill -QUIT "$rec_pid" 2>/dev/null || true
             sleep 3
             sudo kill -9 "$rec_pid" 2>/dev/null || true
             # Brief pause so the tee pipe has a chance to drain
             # before the outer `wait` returns and the loop moves on.
             sleep 2
+            return 1
         fi
     elif [ -n "$kp_pid" ]; then
         sudo kill -INT "$kp_pid" 2>/dev/null || true
@@ -93,7 +113,8 @@ send_request(){
     app_started=false
     while [ "$app_started" = false ]; do
         if [ "$(date +%s)" -gt "$deadline" ]; then
-            echo "::error::gin-mongo app did not respond on http://localhost:8080 within 5 minutes; aborting iteration"
+            echo "::error::gin-mongo app did not respond on http://localhost:8080 within 5 minutes. Next steps: review 'docker ps -a' and the mongoDb logs printed below, then inspect any Keploy/app log files listed for this workspace."
+            dump_gin_mongo_ci_diagnostics
             stop_recording "$kp_pid"
             return 1
         fi
@@ -136,7 +157,7 @@ send_request(){
 
     # Wait for keploy to record the tcs and mocks.
     sleep 10
-    stop_recording "$kp_pid"
+    stop_recording "$kp_pid" || return 1
 }
 
 has_unexpected_errors() {
@@ -146,7 +167,7 @@ has_unexpected_errors() {
 
 
 for record_iteration in {1..2}; do
-    app_name="javaApp_${record_iteration}"
+    app_name="ginMongo_${record_iteration}"
     "$RECORD_BIN" record -c "./ginApp" 2>&1 | tee "${app_name}.txt" &
     
     KEPLOY_PID=$!

--- a/.github/workflows/test_workflow_scripts/golang/go-grpc/grpc-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/go-grpc/grpc-linux.sh
@@ -134,8 +134,7 @@ wait_for_port() {
     local port=$1
     echo "Waiting for port $port to be open..."
     for i in {1..15}; do
-        # Use lsof to check if ANY process is listening on the port
-        if sudo lsof -i :$port -sTCP:LISTEN >/dev/null 2>&1; then
+        if (echo >"/dev/tcp/127.0.0.1/${port}") >/dev/null 2>&1; then
             echo "Port $port is open."
             return 0
         fi
@@ -143,8 +142,7 @@ wait_for_port() {
         sleep 2
     done
     echo "Timed out waiting for port $port."
-    # List open ports for debugging before failing
-    sudo lsof -i -P -n | grep LISTEN
+    ss -ltnp || true
     exit 1
 }
 

--- a/.github/workflows/test_workflow_scripts/golang/go-grpc/grpc-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/go-grpc/grpc-linux.sh
@@ -25,6 +25,12 @@ echo "root ALL=(ALL:ALL) ALL" | sudo tee -a /etc/sudoers
 
 # --- Build Application ---
 echo "Building gRPC server and client binaries..."
+# Keploy's incoming gRPC proxy binds the original app port on IPv4 in this CI
+# path. GitHub runners can resolve localhost to ::1 first, so keep the sample
+# client on the same loopback family as the readiness check and proxy listener.
+if grep -q '"localhost:50051"' client/client.go; then
+    sed -i 's/"localhost:50051"/"127.0.0.1:50051"/' client/client.go
+fi
 go build -o grpc-server .
 go build -o grpc-client ./client
 chmod +x ./grpc-server ./grpc-client
@@ -110,16 +116,16 @@ check_test_report() {
 send_requests() {
     echo "Waiting for application's HTTP server to start..."
     for i in {1..10}; do
-        if curl -s -o /dev/null -X GET http://localhost:8080/users; then
+        if curl --fail --silent --show-error --max-time 5 -o /dev/null -X GET http://127.0.0.1:8080/health; then
             echo "Application is ready. Sending requests..."
             # 1. POST request
-            curl -s -X POST http://localhost:8080/users -H "Content-Type: application/json" -d '{"name": "test-user", "email": "test@gmail.com", "age": 20}'
+            curl --fail --silent --show-error --max-time 5 -X POST http://127.0.0.1:8080/users -H "Content-Type: application/json" -d '{"name": "test-user", "email": "test@gmail.com", "age": 20}'
             # 2. GET request
-            curl -s -X GET http://localhost:8080/users
+            curl --fail --silent --show-error --max-time 5 -X GET http://127.0.0.1:8080/users
             # 3. PUT request
-            curl -s -X PUT http://localhost:8080/users -H "Content-Type: application/json" -d '{"id": 1, "name": "test-user-updated", "email": "test@gmail.com", "age": 20}'
+            curl --fail --silent --show-error --max-time 5 -X PUT http://127.0.0.1:8080/users -H "Content-Type: application/json" -d '{"id": 1, "name": "test-user-updated", "email": "test@gmail.com", "age": 20}'
             # 4. DELETE request
-            curl -s -X DELETE http://localhost:8080/users -H "Content-Type: application/json" -d '{"id": 1}'
+            curl --fail --silent --show-error --max-time 5 -X DELETE http://127.0.0.1:8080/users -H "Content-Type: application/json" -d '{"id": 1}'
             echo "Requests sent."
             return 0
         fi

--- a/.github/workflows/test_workflow_scripts/golang/grpc-protoscope/grpc-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/grpc-protoscope/grpc-linux.sh
@@ -99,7 +99,7 @@ wait_for_port() {
     local port=$1
     echo "Waiting for port $port to be open..."
     for i in {1..15}; do
-        if sudo lsof -i :$port -sTCP:LISTEN >/dev/null 2>&1; then
+        if (echo >"/dev/tcp/127.0.0.1/${port}") >/dev/null 2>&1; then
             echo "Port $port is open."
             return 0
         fi
@@ -107,7 +107,7 @@ wait_for_port() {
         sleep 2
     done
     echo "Timed out waiting for port $port."
-    sudo lsof -i -P -n | grep LISTEN
+    ss -ltnp || true
     exit 1
 }
 

--- a/.github/workflows/test_workflow_scripts/golang/grpc-secret/grpc-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/grpc-secret/grpc-linux.sh
@@ -66,7 +66,7 @@ wait_for_port_release() {
 
     echo "Waiting for port ${port} to be released..."
     for ((i=0; i<timeout_seconds; i++)); do
-        if ! lsof -tiTCP:"${port}" -sTCP:LISTEN >/dev/null 2>&1; then
+        if ! (echo >"/dev/tcp/127.0.0.1/${port}") >/dev/null 2>&1; then
             echo "Port ${port} is free"
             return 0
         fi
@@ -74,7 +74,7 @@ wait_for_port_release() {
     done
 
     echo "Port ${port} is still in use after ${timeout_seconds}s"
-    lsof -iTCP:"${port}" -sTCP:LISTEN -Pn || true
+    ss -ltnp | grep ":${port} " || true
     return 1
 }
 

--- a/.github/workflows/test_workflow_scripts/python/django_postgres/python-linux.sh
+++ b/.github/workflows/test_workflow_scripts/python/django_postgres/python-linux.sh
@@ -2,17 +2,13 @@
 
 source ./../../../.github/workflows/test_workflow_scripts/test-iid.sh
 
-# Checkout to the specified branch
-git fetch origin
-git checkout native-linux
-
 echo "root ALL=(ALL:ALL) ALL" | sudo tee -a /etc/sudoers
 
 # Start the postgres database
 docker compose up -d
 
 # Install dependencies
-pip3 install -r requirements.txt
+python -m pip install -r requirements.txt
 
 # Setup environment
 export PYTHON_PATH=./venv/lib/python3.10/site-packages/django
@@ -28,44 +24,24 @@ config_file="./keploy.yml"
 sed -i 's/global: {}/global: {"header": {"Allow":[],}}/' "$config_file"
 sleep 5  # Allow time for configuration changes
 
-send_request(){
-    sleep 10
-    app_started=false
-    while [ "$app_started" = false ]; do
-        if curl -X GET http://127.0.0.1:8000/; then
-            app_started=true
-        fi
-        sleep 3 # wait for 3 seconds before checking again.
-    done
-    echo "App started"
-    # Start making curl calls to record the testcases and mocks.
-    curl --location 'http://127.0.0.1:8000/user/' --header 'Content-Type: application/json' --data-raw '{
-        "name": "Jane Smith",
-        "email": "jane.smith@example.com",
-        "password": "smith567",
-        "website": "www.janesmith.com"
-    }'
-    curl --location 'http://127.0.0.1:8000/user/' --header 'Content-Type: application/json' --data-raw '{
-        "name": "John Doe",
-        "email": "john.doe@example.com",
-        "password": "john567",
-        "website": "www.johndoe.com"
-    }'
-    curl --location 'http://127.0.0.1:8000/user/'
-    # Wait for 10 seconds for keploy to record the tcs and mocks.
-    sleep 10
+stop_recording() {
     REC_PID="$(pgrep -n -f "$(basename "${RECORD_BIN:-keploy}") record" || true)"
-    echo "$REC_PID Keploy PID"
-    echo "Killing keploy"
-    sudo kill -INT "$REC_PID" 2>/dev/null || true
+    if [ -n "$REC_PID" ]; then
+        echo "$REC_PID Keploy PID"
+        echo "Killing keploy"
+        sudo kill -INT "$REC_PID" 2>/dev/null || true
+    else
+        echo "No keploy recorder process found"
+    fi
+}
 
-    # DEBUG: if keploy doesn't exit within 15 seconds, dump goroutine stacks
-    # for BOTH the CLI process AND the keploy agent subprocess
+dump_and_force_kill_if_stuck() {
+    local record_pid="$1"
     (
         sleep 15
-        if kill -0 "$REC_PID" 2>/dev/null; then
+        if [ -n "$record_pid" ] && kill -0 "$record_pid" 2>/dev/null; then
             # Find the keploy agent subprocess (child of the CLI)
-            AGENT_PID="$(pgrep -P "$REC_PID" -f 'keploy' 2>/dev/null || true)"
+            AGENT_PID="$(pgrep -P "$record_pid" -f 'keploy' 2>/dev/null || true)"
 
             if [ -n "$AGENT_PID" ]; then
                 echo "===== KEPLOY AGENT SUBPROCESS HUNG (PID=$AGENT_PID) — DUMPING GOROUTINE STACKS ====="
@@ -73,26 +49,66 @@ send_request(){
                 sleep 3
             fi
 
-            echo "===== KEPLOY CLI HUNG (PID=$REC_PID) — DUMPING GOROUTINE STACKS ====="
-            sudo kill -QUIT "$REC_PID" 2>/dev/null || true
+            echo "===== KEPLOY CLI HUNG (PID=$record_pid) — DUMPING GOROUTINE STACKS ====="
+            sudo kill -QUIT "$record_pid" 2>/dev/null || true
             sleep 3
 
             # Force kill both if still alive
             if [ -n "$AGENT_PID" ] && kill -0 "$AGENT_PID" 2>/dev/null; then
                 sudo kill -9 "$AGENT_PID" 2>/dev/null || true
             fi
-            if kill -0 "$REC_PID" 2>/dev/null; then
+            if kill -0 "$record_pid" 2>/dev/null; then
                 echo "===== FORCE KILLING KEPLOY ====="
-                sudo kill -9 "$REC_PID" 2>/dev/null || true
+                sudo kill -9 "$record_pid" 2>/dev/null || true
             fi
         fi
     ) &
+}
+
+wait_for_app() {
+    for attempt in {1..40}; do
+        if curl -fsS --max-time 5 http://127.0.0.1:8000/ >/dev/null; then
+            echo "App started"
+            return 0
+        fi
+        echo "Waiting for app on 127.0.0.1:8000 (attempt $attempt/40)"
+        sleep 3
+    done
+
+    echo "::error::App did not become ready on 127.0.0.1:8000 within 120 seconds"
+    stop_recording
+    dump_and_force_kill_if_stuck "$REC_PID"
+    return 1
+}
+
+send_request(){
+    sleep 10
+    wait_for_app || return 1
+    # Start making curl calls to record the testcases and mocks.
+    curl -fsS --max-time 10 --location 'http://127.0.0.1:8000/user/' --header 'Content-Type: application/json' --data-raw '{
+        "name": "Jane Smith",
+        "email": "jane.smith@example.com",
+        "password": "smith567",
+        "website": "www.janesmith.com"
+    }' || return 1
+    curl -fsS --max-time 10 --location 'http://127.0.0.1:8000/user/' --header 'Content-Type: application/json' --data-raw '{
+        "name": "John Doe",
+        "email": "john.doe@example.com",
+        "password": "john567",
+        "website": "www.johndoe.com"
+    }' || return 1
+    curl -fsS --max-time 10 --location 'http://127.0.0.1:8000/user/' || return 1
+    # Wait for 10 seconds for keploy to record the tcs and mocks.
+    sleep 10
+    stop_recording
+    dump_and_force_kill_if_stuck "$REC_PID"
 }
 
 # Record and Test cycles
 for i in {1..2}; do
     app_name="flaskApp_${i}"
     send_request &
+    request_pid=$!
     $RECORD_BIN record -c "python3 manage.py runserver"   2>&1 | tee "${app_name}.txt"
     if grep "ERROR" "${app_name}.txt"; then
         echo "Error found in pipeline..."
@@ -105,7 +121,10 @@ for i in {1..2}; do
         exit 1
     fi
     sleep 5
-    wait
+    if ! wait "$request_pid"; then
+        echo "::error::Request driver failed while recording iteration ${i}"
+        exit 1
+    fi
     echo "Recorded test case and mocks for iteration ${i}"
 done
 

--- a/.github/workflows/test_workflow_scripts/python/django_postgres/python-linux.sh
+++ b/.github/workflows/test_workflow_scripts/python/django_postgres/python-linux.sh
@@ -24,6 +24,10 @@ config_file="./keploy.yml"
 sed -i 's/global: {}/global: {"header": {"Allow":[],}}/' "$config_file"
 sleep 5  # Allow time for configuration changes
 
+APP_HOST="127.0.0.1"
+APP_PORT="8000"
+APP_URL="http://${APP_HOST}:${APP_PORT}"
+
 stop_recording() {
     REC_PID="$(pgrep -n -f "$(basename "${RECORD_BIN:-keploy}") record" || true)"
     if [ -n "$REC_PID" ]; then
@@ -44,12 +48,12 @@ dump_and_force_kill_if_stuck() {
             AGENT_PID="$(pgrep -P "$record_pid" -f 'keploy' 2>/dev/null || true)"
 
             if [ -n "$AGENT_PID" ]; then
-                echo "===== KEPLOY AGENT SUBPROCESS HUNG (PID=$AGENT_PID) — DUMPING GOROUTINE STACKS ====="
+                echo "===== KEPLOY AGENT SUBPROCESS HUNG (PID=$AGENT_PID) - DUMPING GOROUTINE STACKS ====="
                 sudo kill -QUIT "$AGENT_PID" 2>/dev/null || true
                 sleep 3
             fi
 
-            echo "===== KEPLOY CLI HUNG (PID=$record_pid) — DUMPING GOROUTINE STACKS ====="
+            echo "===== KEPLOY CLI HUNG (PID=$record_pid) - DUMPING GOROUTINE STACKS ====="
             sudo kill -QUIT "$record_pid" 2>/dev/null || true
             sleep 3
 
@@ -67,15 +71,15 @@ dump_and_force_kill_if_stuck() {
 
 wait_for_app() {
     for attempt in {1..40}; do
-        if curl -fsS --max-time 5 http://127.0.0.1:8000/ >/dev/null; then
-            echo "App started"
+        if (exec 3<>"/dev/tcp/${APP_HOST}/${APP_PORT}") 2>/dev/null; then
+            echo "App proxy is accepting connections on ${APP_HOST}:${APP_PORT}"
             return 0
         fi
-        echo "Waiting for app on 127.0.0.1:8000 (attempt $attempt/40)"
+        echo "Waiting for app proxy on ${APP_HOST}:${APP_PORT} (attempt $attempt/40)"
         sleep 3
     done
 
-    echo "::error::App did not become ready on 127.0.0.1:8000 within 120 seconds"
+    echo "::error::App proxy did not become ready on ${APP_HOST}:${APP_PORT} within 120 seconds"
     stop_recording
     dump_and_force_kill_if_stuck "$REC_PID"
     return 1
@@ -85,19 +89,19 @@ send_request(){
     sleep 10
     wait_for_app || return 1
     # Start making curl calls to record the testcases and mocks.
-    curl -fsS --max-time 10 --location 'http://127.0.0.1:8000/user/' --header 'Content-Type: application/json' --data-raw '{
+    curl -fsS --max-time 10 --location "${APP_URL}/user/" --header 'Content-Type: application/json' --data-raw '{
         "name": "Jane Smith",
         "email": "jane.smith@example.com",
         "password": "smith567",
         "website": "www.janesmith.com"
     }' || return 1
-    curl -fsS --max-time 10 --location 'http://127.0.0.1:8000/user/' --header 'Content-Type: application/json' --data-raw '{
+    curl -fsS --max-time 10 --location "${APP_URL}/user/" --header 'Content-Type: application/json' --data-raw '{
         "name": "John Doe",
         "email": "john.doe@example.com",
         "password": "john567",
         "website": "www.johndoe.com"
     }' || return 1
-    curl -fsS --max-time 10 --location 'http://127.0.0.1:8000/user/' || return 1
+    curl -fsS --max-time 10 --location "${APP_URL}/user/" || return 1
     # Wait for 10 seconds for keploy to record the tcs and mocks.
     sleep 10
     stop_recording

--- a/.github/workflows/test_workflow_scripts/python/flask-secret/python-linux.sh
+++ b/.github/workflows/test_workflow_scripts/python/flask-secret/python-linux.sh
@@ -23,11 +23,27 @@ cleanup_keploy() {
 # Set trap to cleanup on script exit
 trap cleanup_keploy EXIT
 
+wait_for_health() {
+    local mode="$1"
+    for attempt in {1..40}; do
+        if curl -fsS --max-time 5 http://127.0.0.1:8000/health >/dev/null; then
+            echo "App started for mode: $mode"
+            return 0
+        fi
+        echo "Waiting for app health for mode $mode (attempt $attempt/40)"
+        sleep 3
+    done
+
+    echo "::error::App health endpoint did not become ready within 120 seconds for mode: $mode"
+    cleanup_keploy
+    return 1
+}
+
 # Add coverage to requirements.txt
 echo "coverage" >> requirements.txt
 
 # Install dependencies
-pip3 install -r requirements.txt
+python -m pip install -r requirements.txt
 
 rm -rf keploy.yml
 
@@ -41,22 +57,19 @@ send_request(){
 
     # wait for app to be ready
     sleep 10
-    until curl -fsS http://127.0.0.1:8000/health >/dev/null; do
-        sleep 3
-    done
-    echo "App started for mode: $mode"
+    wait_for_health "$mode" || return 1
 
     if [ "$mode" = "astro" ]; then
-        curl -sS http://127.0.0.1:8000/astro >/dev/null
+        curl -fsS --max-time 10 http://127.0.0.1:8000/astro >/dev/null || return 1
     elif [ "$mode" = "secrets" ]; then
         for ep in secret1 secret2 secret3; do
             echo "GET /$ep"
-            curl -sS "http://127.0.0.1:8000/$ep" >/dev/null
+            curl -fsS --max-time 10 "http://127.0.0.1:8000/$ep" >/dev/null || return 1
         done
     else # This handles the "misc" case
         for ep in jwtlab curlmix cdn; do
             echo "GET /$ep"
-            curl -sS "http://127.0.0.1:8000/$ep" >/dev/null
+            curl -fsS --max-time 10 "http://127.0.0.1:8000/$ep" >/dev/null || return 1
         done
     fi
 
@@ -99,11 +112,15 @@ send_request(){
 for i in 1 2; do
     app_name="flaskSecret_${i}"
     send_request "secrets" &
+    request_pid=$!
     $RECORD_BIN record -c "python3 main.py" --metadata "suite=secrets,run=$i" 2>&1 | tee ${app_name}.txt
     if grep "ERROR" "${app_name}.txt"; then exit 1; fi
     if grep "WARNING: DATA RACE" "${app_name}.txt"; then exit 1; fi
     sleep 5
-    wait
+    if ! wait "$request_pid"; then
+        echo "::error::Request driver failed while recording secrets iteration ${i}"
+        exit 1
+    fi
     echo "Recorded test case and mocks for iteration ${i}"
 done
 
@@ -115,11 +132,15 @@ sleep 5
 # --- Record cycle for the new /astro endpoint (its own test set) ---
 app_name="flaskAstro"
 send_request "astro" &
+request_pid=$!
 $RECORD_BIN record -c "python3 main.py" --metadata "suite=astro,endpoint=/astro" 2>&1 | tee ${app_name}.txt
 if grep "ERROR" "${app_name}.txt"; then exit 1; fi
 if grep "WARNING: DATA RACE" "${app_name}.txt"; then exit 1; fi
 sleep 5
-wait
+if ! wait "$request_pid"; then
+    echo "::error::Request driver failed while recording astro"
+    exit 1
+fi
 echo "Recorded astro test case and mocks"
 
 echo "Shutting down flask before test mode..."
@@ -260,6 +281,7 @@ rm -rf keploy
 # Record the "misc" endpoints as a new test suite
 app_name="flaskMisc"
 send_request "misc" &
+request_pid=$!
 $RECORD_BIN record -c "python3 main.py" --metadata "suite=misc" 2>&1 | tee ${app_name}.txt
 if grep "ERROR" "${app_name}.txt"; then
     echo "Error found in misc recording..."
@@ -272,7 +294,10 @@ if grep "WARNING: DATA RACE" "${app_name}.txt"; then
     exit 1
 fi
 sleep 5
-wait
+if ! wait "$request_pid"; then
+    echo "::error::Request driver failed while recording misc"
+    exit 1
+fi
 echo "Recorded misc test case and mocks"
 
 # Sanitize the newly created test cases


### PR DESCRIPTION
## Describe the changes that are made
- Filter expected Keploy agent closed-connection logs during intentional gin-mongo recorder shutdown so teardown noise does not fail CI.
- Add bounded MongoDB cleanup/readiness, bounded curl calls, recorder cleanup on failed traffic, and replay exit-status handling through `tee`.
- Run the gin-mongo private Linux workflow from the `samples-go` `native-linux` branch directly and add bounded job timeouts for private matrices.
- Remove the `apt-get install lsof` step from gRPC Linux jobs and replace `lsof` port checks with Bash localhost TCP probes plus `ss` diagnostics.
- Pin the go-grpc sample driver to IPv4 loopback in CI so it reaches Keploy's incoming proxy instead of resolving `localhost` to `::1`.
- Prefetch replay-only sample Go modules before `keploy test`, with bounded retries and direct fallback, so module downloads do not happen inside replay and do not create proxy/mock flakes.
- Add Maven dependency caching and bounded Java sample setup so Java Linux jobs spend less time downloading dependencies and fail faster on setup regressions.
- Replace Python Linux `deadsnakes/action` provisioning with `actions/setup-python` plus pip cache keyed by sample `requirements.txt`, checkout the django sample branch directly, and bound Python Linux job/runtime waits so runner minutes are not lost to apt/PPA or app-start hangs.
- Change django-postgres Linux readiness to a TCP probe of Keploy's app proxy instead of an HTTP GET to `/`, preventing readiness checks from recording repeated 404 test cases when latest Keploy forwards Django to an ephemeral app port.
- Replace the connect-tunnel Linux job's apt-installed `tinyproxy` with a small local Go CONNECT proxy, add a public Go Linux matrix timeout, and wrap connect-tunnel record/replay commands with hard timeouts so missed shutdown signals cannot leave the job stuck.

## Root cause
- Failed run: https://github.com/keploy/keploy/actions/runs/24778344962/job/72503060996?pr=4104
- The referenced `django-postgres` job was cancelled while still in `deadsnakes/action@v3.2.0`. Logs show it added the deadsnakes PPA and then spent about 35 minutes in apt index refresh, repeatedly retrying Ubuntu archive mirrors before GitHub cancelled the operation.
- A second Python Linux job, `flask-secret (record_build_replay_build)`, was cancelled the same way in the same `Install Python` step. Neither job reached the sample script.
- The Python Linux scripts also had unbounded readiness loops, which would have been the next way for these jobs to burn time if app startup regressed.
- Follow-up rerun `24781174816` confirmed setup was fixed but exposed a script-level bug in `django-postgres (record_latest_replay_build)`: latest Keploy forwarded original port `8000` to Django on an ephemeral port (`65023` in that run), while the readiness probe hit `/` through the proxy. Django correctly returned 404, Keploy recorded each probe as a testcase, and the script timed out before driving the intended `/user/` requests.
- The connect-tunnel stuck run was in `Run connect-tunnel application`, inside `.github/workflows/test_workflow_scripts/golang/connect_tunnel/golang-linux.sh`. That script installed `tinyproxy` through apt, then ran foreground `keploy record`/`keploy test` pipelines without hard command timeouts. If app startup, request driving, or recorder shutdown missed its expected path, the job could keep running until the outer workflow stopped it.

## Links & References
**Closes:** NA

### Related PRs
- Investigated while debugging flaky CI on #4103

### Related Issues
- NA

### Related Documents
- gin-mongo failed run: https://github.com/keploy/keploy/actions/runs/24775761058/job/72493927088?pr=4103
- incoming-gRPC stuck run: https://github.com/keploy/keploy/actions/runs/24775761058/job/72493927146?pr=4103
- Python Linux cancellation: https://github.com/keploy/keploy/actions/runs/24778344962/job/72503060996?pr=4104
- connect-tunnel stuck run: https://github.com/keploy/keploy/actions/runs/24778336427/job/72502930735
- django-postgres follow-up readiness failure: https://github.com/keploy/keploy/actions/runs/24781174816/job/72513171212

## What type of PR is this? (check all applicable)
- [ ] Chore
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [x] Performance Improvements
- [x] Test
- [x] CI
- [ ] Revert

## Added e2e test pipeline?
- [ ] yes
- [x] no, because this stabilizes existing e2e CI paths
- [ ] no, because I need help

## Added comments for hard-to-understand areas?
- [x] yes
- [ ] no, because the code is self-explanatory

## Added to documentation?
- [ ] README.md
- [ ] Wiki
- [x] no documentation needed

## Are there any sample code or steps to test the changes?
- [x] yes, mentioned below
- [ ] no, because it is not needed

Validation:
- `bash -n .github/workflows/test_workflow_scripts/golang/gin_mongo/golang-linux.sh`
- `bash -n .github/workflows/test_workflow_scripts/golang/go-grpc/grpc-linux.sh`
- `bash -n .github/workflows/test_workflow_scripts/golang/grpc-protoscope/grpc-linux.sh`
- `bash -n .github/workflows/test_workflow_scripts/golang/grpc-secret/grpc-linux.sh`
- `bash -n .github/workflows/test_workflow_scripts/java/spring_petclinic/java-linux.sh`
- `bash -n .github/workflows/test_workflow_scripts/java/mysql_dual_conn/java-linux.sh`
- `bash -n .github/workflows/test_workflow_scripts/golang/connect_tunnel/golang-linux.sh`
- `bash -n .github/workflows/test_workflow_scripts/python/django_postgres/python-linux.sh`
- `bash -n .github/workflows/test_workflow_scripts/python/flask-secret/python-linux.sh`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/golang_linux.yml'); YAML.load_file('.github/workflows/grpc_linux.yml'); YAML.load_file('.github/workflows/java_linux.yml'); YAML.load_file('.github/workflows/python_linux.yml'); puts 'yaml ok'"`
- `awk '/^cat > \\/tmp\\/connect-proxy.go <<'\"'\"'EOF'\"'\"'/{flag=1;next}/^EOF$/{flag=0}flag' .github/workflows/test_workflow_scripts/golang/connect_tunnel/golang-linux.sh > /private/tmp/connect-proxy-check.go && go build -o /private/tmp/connect-proxy-check /private/tmp/connect-proxy-check.go`
- `git diff --check`
- GitHub Actions run `24777439558`: linked gin-mongo Linux cases passed, incoming-grpc cases passed, simple-grpc replay cases passed after module prefetch.

Local note: I did not run the full Linux e2e jobs locally because this macOS checkout cannot reproduce the Linux runner/eBPF artifact path used by GitHub Actions.

## Any relevant screenshots, recordings or logs?
- gin-mongo recorded requests successfully, then failed because `grep "ERROR"` matched expected shutdown noise: `failed to read from connection ... use of closed network connection`.
- incoming-gRPC was stuck before the sample ran, in `Install lsof utility`; this PR removes that apt dependency instead of adding more runner wait time.
- simple-grpc replay previously downloaded Go modules under Keploy replay, causing `proxy.golang.org` requests to be treated as missing mocks. The workflow now downloads modules before replay starts.
- Python Linux jobs previously depended on deadsnakes/PPA apt setup for Python 3.11. The workflow now uses the hosted toolcache through `actions/setup-python` and restores pip downloads from cache.
- connect-tunnel no longer depends on apt/tinyproxy and now has command-level record/replay timeouts in addition to the job-level timeout.
- django-postgres readiness no longer performs HTTP probe traffic through Keploy during record; it waits for the forwarded proxy port with Bash `/dev/tcp` before sending the intended `/user/` requests.

## Self Review done?
- [x] yes
- [ ] no, because I need help

## Additional checklist:
- [x] Have you read the Contributing Guidelines on issues?
- [x] Have you followed the PR Semantics guide for naming this PR?
- [x] Have you followed the Branch Semantics guide?
