### PR TITLE
feat(record): add DisableProcessStop for multi-session embedders

### DIFF
--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -41,6 +41,17 @@ type Recorder struct {
 	// store interfaces. Register with RegisterCleanup.
 	cleanupMu sync.Mutex
 	cleanups  []func() error
+
+	// disableProcessStop opts out of the global utils.Stop() calls in
+	// Start's defer and in the record-timer goroutine. Intended for
+	// library embedders (e.g. k8s-proxy) that host many concurrent
+	// Recorder instances in one process: one session's failure must
+	// not cancel the shared root context and tear down peer sessions.
+	// Session-local contexts are still cancelled in the defer, so this
+	// session unwinds cleanly; the embedder observes the returned error
+	// from Start() and decides whether to stop anything else. Default
+	// false preserves CLI behaviour where Start() is the sole session.
+	disableProcessStop bool
 }
 
 // RegisterCleanup appends a shutdown callback that Recorder.Start's
@@ -76,6 +87,16 @@ func New(logger *zap.Logger, testDB TestDB, mockDB MockDB, mappingDB MappingDb, 
 		config:          config,
 		hooks:           hooks,
 	}
+}
+
+// SetDisableProcessStop toggles whether Start's defer and the
+// record-timer goroutine call utils.Stop() on exit. Embedders that
+// run multiple Recorders in one process should set this to true so a
+// single session's failure does not cancel the shared root context.
+// When true, Start still cancels its own runApp/req/setup contexts
+// and returns the error so the caller can react per-session.
+func (r *Recorder) SetDisableProcessStop(disabled bool) {
+	r.disableProcessStop = disabled
 }
 
 // SetRecordHooks replaces the current hooks. Mirrors SetTestHooks on the Replayer.
@@ -172,7 +193,10 @@ func (r *Recorder) Start(ctx context.Context, reRecordCfg models.ReRecordCfg) er
 		select {
 		case <-ctx.Done():
 		default:
-			if !reRecordCfg.Rerecord {
+			// Library embedders (r.disableProcessStop) own the root
+			// context and handle per-session failure themselves, so
+			// skipping this global cancel keeps peer sessions alive.
+			if !reRecordCfg.Rerecord && !r.disableProcessStop {
 
 				err := utils.Stop(r.logger, stopReason)
 				if err != nil {
@@ -519,6 +543,11 @@ func (r *Recorder) Start(ctx context.Context, reRecordCfg models.ReRecordCfg) er
 			select {
 			case <-timer:
 				r.logger.Warn("Time up! Stopping keploy")
+				// When embedded, fall back to cancelling only this
+				// session via ctx rather than the global root context.
+				if r.disableProcessStop {
+					return errors.New("record timer expired")
+				}
 				err := utils.Stop(r.logger, "Time up! Stopping keploy")
 				if err != nil {
 					utils.LogError(r.logger, err, "failed to stop recording")

--- a/pkg/service/record/service.go
+++ b/pkg/service/record/service.go
@@ -24,6 +24,12 @@ type Service interface {
 	Start(ctx context.Context, reRecordCfg models.ReRecordCfg) error
 	SetGlobalMockChannel(mockCh chan<- *models.Mock)
 	GetNextTestSetID(ctx context.Context) (string, error)
+	// SetDisableProcessStop opts a single Recorder out of the global
+	// utils.Stop() calls. Embedders that host multiple Recorders in
+	// one process (e.g. k8s-proxy) call this with true so a single
+	// session's failure only unwinds its own context, not the shared
+	// root.
+	SetDisableProcessStop(disabled bool)
 }
 
 type TestDB interface {


### PR DESCRIPTION
## Summary
- Adds `Recorder.SetDisableProcessStop(disabled bool)` (also on the `Service` interface) so library embedders can opt a single `Recorder` out of the global `utils.Stop()` calls in `Start`'s defer and in the `RecordTimer` expiry goroutine.
- Default is `false` — CLI behaviour is untouched. When `true`, session-local contexts (`runAppCtx`, `reqCtx`, `setupCtx`) are still cancelled by the defer and `Start()` returns the error; only the process-wide cancel (registered via `utils.NewCtx()` at CLI startup) is skipped.

## Why
`Recorder.Start` today assumes it is the sole session in the process. Two paths eventually reach `utils.ExecCancel()`:

1. `record.go` defer (mock/testcase insert errors, etc.):
   ```go
   defer func() {
       select {
       case <-ctx.Done():
       default:
           if !reRecordCfg.Rerecord {
               err := utils.Stop(r.logger, stopReason)
               ...
           }
       }
       ...
   }()
   ```
2. `record.go` RecordTimer goroutine:
   ```go
   case <-timer:
       r.logger.Warn("Time up! Stopping keploy")
       err := utils.Stop(r.logger, "Time up! Stopping keploy")
   ```

`utils.Stop()` calls the package-level `cancel` set by `utils.NewCtx()` during CLI startup. That same helper is used by server-style embedders (k8s-proxy) to build their root context, so when OSS invokes `utils.Stop()` inside an embedded session, it cancels the embedder's **root** context — which every other in-process `Recorder` watches. One pod's failure takes every peer pod's recorder with it, even though nothing's wrong with them.

## What the flag changes
- Defer: `if !reRecordCfg.Rerecord && !r.disableProcessStop { utils.Stop(...) }`
- RecordTimer: when embedded, return the timer-expired error instead of invoking `utils.Stop()`; the embedder's `Start` caller decides what to do next.
- Nothing else is skipped — the `Stopping Keploy recording...` log, `NotifyGracefulShutdown`, the three `XxxCtxCancel()` + `Wait()` cleanups, and the LIFO cleanup drain all still run.

## Caller contract
Embedders that set `SetDisableProcessStop(true)` are promising to:
- Own the root context (typically from their own `utils.NewCtx()`).
- Handle the error returned by `Start()` — they now own the decision of whether to tear down anything beyond this session.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./pkg/service/record/...` clean
- [ ] Integration: k8s-proxy sets `SetDisableProcessStop(true)` on its embedded recorders and verifies that an induced mock-insert failure on one pod only aborts that pod's `Run()` goroutine (peer pods keep recording). PR for the k8s-proxy side is out separately.

## Scope / non-goals
- No config-file toggle exposed. This is a programmatic knob for embedders; the CLI path keeps calling `utils.Stop()` as today.
- `utils.NewCtx()` behaviour unchanged. Embedders that don't call `SetDisableProcessStop(true)` see the current semantics.
- No behaviour change for `reRecordCfg.Rerecord == true` (it was already guarded and continues to be).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
