### PR TITLE
fix(http-recorder): exit chunkedResponse on last-chunk suffix, not strict equality

### DIFF
--- a/pkg/agent/proxy/integrations/http/chunk.go
+++ b/pkg/agent/proxy/integrations/http/chunk.go
@@ -2,6 +2,7 @@
 package http
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -14,6 +15,17 @@ import (
 	"go.keploy.io/server/v3/utils"
 	"go.uber.org/zap"
 )
+
+// chunkedTerminator is the last-chunk marker defined by RFC 7230 §4.1.
+// A chunked response ends with `0\r\n\r\n` (size=0 chunk + empty trailer
+// section + CRLF). The proxy loop treats this suffix as end-of-response
+// regardless of how many preceding body bytes share the same TLS record
+// with the terminator — the previous strict-equality check failed on
+// the common case where pUtil.ReadBytes returns ""<body>0\r\n\r\n" and
+// left the loop spinning until the upstream closed the idle HTTP/1.1
+// keep-alive connection (~60 s on SAP sandbox, observed on the
+// sap-demo-java /360 fanout).
+var chunkedTerminator = []byte("0\r\n\r\n")
 
 func (h *HTTP) HandleChunkedRequests(ctx context.Context, finalReq *[]byte, clientConn, destConn net.Conn) error {
 
@@ -351,7 +363,19 @@ ReadLoop:
 				break ReadLoop
 			}
 
-			if string(resp) == "0\r\n\r\n" {
+			// RFC 7230 §4.1 last-chunk: "0\r\n\r\n" terminates a chunked
+			// body. pUtil.ReadBytes returns whatever was in the latest
+			// TLS record (up to 1 KiB of the 16 KiB record), so the
+			// terminator is almost always concatenated with the tail
+			// of the preceding data chunk — e.g. "<...body>0\r\n\r\n".
+			// The old check `string(resp) == "0\r\n\r\n"` only matched
+			// if the terminator arrived in a dedicated Read call, which
+			// an HTTP/1.1 keep-alive upstream almost never does. The
+			// loop would then call ReadBytes again on the now-idle
+			// conn and block until the upstream's keep-alive timeout
+			// (~60 s on SAP sandbox, reproduced on sap-demo-java /360).
+			// HasSuffix correctly detects both packaging shapes.
+			if bytes.HasSuffix(resp, chunkedTerminator) {
 				return nil
 			}
 		}

--- a/pkg/agent/proxy/integrations/http/chunk_test.go
+++ b/pkg/agent/proxy/integrations/http/chunk_test.go
@@ -95,6 +95,58 @@ func TestChunkedResponseExitsOnEOF(t *testing.T) {
 	}
 }
 
+// TestChunkedResponseExitsOnSuffixedTerminator reproduces the SAP /360 bug:
+// pUtil.ReadBytes returns a buffer shaped like "<body>0\r\n\r\n" (last-chunk
+// terminator concatenated with the preceding body bytes in the same TLS
+// record) rather than the terminator in a dedicated read. The old strict
+// equality check `string(resp) == "0\r\n\r\n"` missed this shape, so the
+// loop blocked on a second ReadBytes until the upstream's keep-alive timed
+// out (~60s observed). After the fix uses bytes.HasSuffix, the loop must
+// exit promptly — we assert completion well under the keep-alive idle
+// window by enforcing a tight 100 ms budget (the happy-path return takes
+// microseconds; anything over 100 ms means the suffix check regressed).
+func TestChunkedResponseExitsOnSuffixedTerminator(t *testing.T) {
+	h := newTestHTTP()
+
+	clientConn := &mockConn{}
+	// Buggy shape: body tail + last-chunk marker in one TLS record.
+	destConn := &mockConn{
+		data: []byte("abcdef0\r\n\r\n"),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+	defer cancel()
+
+	var finalResp []byte
+
+	start := time.Now()
+	done := make(chan error, 1)
+	go func() {
+		done <- h.chunkedResponse(ctx, &finalResp, clientConn, destConn)
+	}()
+
+	select {
+	case err := <-done:
+		elapsed := time.Since(start)
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if elapsed > 100*time.Millisecond {
+			t.Fatalf("chunkedResponse took %v (> 100ms) — suggests a second "+
+				"ReadBytes call on an idle conn; the suffix check did not match",
+				elapsed)
+		}
+		if destConn.readCount != 1 {
+			t.Errorf("expected exactly 1 read (exit on suffix match), got %d "+
+				"— a second read means the terminator detection regressed to "+
+				"strict equality", destConn.readCount)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("chunkedResponse stuck past 100ms on buffer \"<body>0\\r\\n\\r\\n\" "+
+			"after %d reads — suffix-terminator check regressed", destConn.readCount)
+	}
+}
+
 // TestChunkedResponseEmptyBody tests the specific case where the server closes
 // the connection immediately (no body). This reproduces the bug seen with Playwright
 // where the proxy gets stuck in a loop. Also verifies we don't do excessive reads.


### PR DESCRIPTION
## Summary

One-line semantic fix in `pkg/agent/proxy/integrations/http/chunk.go`: replace the strict-equality terminator check with `bytes.HasSuffix` against the RFC 7230 last-chunk marker (`0\r\n\r\n`).

## Symptom

Under `keploy record`, every chunked-encoded upstream call against the sap-demo-java `/360` fan-out endpoint stalls for **17-60 seconds**, vs 0.3-0.7 s for the same request hit directly with `curl`. The proxy sits inside `chunkedResponse` after the upstream has already sent its last chunk, until the HTTP/1.1 keep-alive idle timeout (~60 s on the SAP sandbox) closes the TCP connection.

## Root cause

`pUtil.ReadBytes` returns whatever bytes were in the latest TLS record — which in practice packages the tail of the final body chunk together with the last-chunk terminator into a single Read, producing buffers shaped like `"<body>0\r\n\r\n"`.

The old check

```go
if string(resp) == "0\r\n\r\n" {
    return nil
}
```

only matched when the terminator arrived in a dedicated Read call. An HTTP/1.1 keep-alive upstream that has nothing more to say never sends a second TLS record just for `"0\r\n\r\n"`, so the loop calls `pUtil.ReadBytes` again on an idle conn and blocks until the keep-alive timeout.

## Fix

Detect the terminator as a **suffix** of the buffer, which matches both packaging shapes:

```go
if bytes.HasSuffix(resp, chunkedTerminator) {
    return nil
}
```

Extracted `chunkedTerminator = []byte("0\r\n\r\n")` as a package-level `var` with a doc comment explaining the RFC reference and the SAP-observed failure mode.

## Scope

The three sibling HasSuffix checks in the same file already do the right thing — only `chunkedResponse` (previously line 354) carried the strict-equality bug:

- `chunk.go:88` — `HandleChunkedRequests` early-exit on already-complete chunked request
- `chunk.go:210` — `chunkedRequest` loop
- `chunk.go:303` — `handleChunkedResponses` pre-loop check

This PR only touches the fourth site, matching the three already-correct ones.

## Measurements

Before vs after (sap-demo-java `/360`, under `keploy record`, same fan-out endpoints):

| breakpoint | before       | after   | speedup |
|-----------:|-------------:|--------:|--------:|
| bp=11      | 50,628 ms    | 586 ms  | 86x     |
| bp=202     | 17,401 ms    | 291 ms  | 60x     |
| bp=203     | 60,000+ ms   | 618 ms  | 97x+    |

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/agent/proxy/integrations/http/...`
- [x] New regression test `TestChunkedResponseExitsOnSuffixedTerminator`: feeds buffer `"abcdef0\r\n\r\n"` (the buggy shape) through `chunkedResponse` and asserts the loop returns in under 100 ms with exactly one read from the dest conn. Without the fix this test times out / does excessive reads.
- [x] Existing `TestChunkedResponseExitsOnEOF` and `TestChunkedResponseEmptyBody` still pass.
- [x] End-to-end: sap-demo-java `/360` record latency back to single-digit seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)