### PR TITLE
ci(workflows): drop post-#4101 INTEGRATION_REF SHA pin, default to main

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,16 +17,14 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Central pin for the keploy/integrations commit this workflow checks
+  # Central ref for the keploy/integrations commit this workflow checks
   # out via setup-private-parsers. Mirrors the default in
-  # prepare_and_run.yml so all three workflows (prepare_and_run,
-  # release, golangci-lint) track the same integrations SHA. Prefer the
-  # repo-level `vars.INTEGRATION_REF` when set (so operators can
-  # override the pin without editing this file), falling back to the
-  # hard-coded SHA.
-  #
-  # Revert to `main` (drop this key) once keploy/integrations#130 merges.
-  INTEGRATION_REF: ${{ vars.INTEGRATION_REF || '127d5c37875ba2762e3561d17e4e8501fe671afa' }}
+  # prepare_and_run.yml + release.yml so all three workflows track the
+  # same integrations ref. Prefer the repo-level `vars.INTEGRATION_REF`
+  # when set (so operators can override without editing this file),
+  # falling back to `main`. Pin to a specific SHA via the repo var if
+  # a feat branch needs to carry a cross-repo change.
+  INTEGRATION_REF: ${{ vars.INTEGRATION_REF || 'main' }}
 
 jobs:
   golangci:

--- a/.github/workflows/prepare_and_run.yml
+++ b/.github/workflows/prepare_and_run.yml
@@ -23,20 +23,17 @@ concurrency:
 env:
   # Must match the default $IsoRoot in setup-git-isolation.ps1 / cleanup-git-isolation.ps1
   _ISO_ROOT: .git-isolation
-  # Central pin for the keploy/integrations commit that every build
-  # leg in this workflow checks out. Keeping it in one place means the
-  # 4 Add-Private-Parsers steps below (linux/amd64, linux/arm64,
-  # darwin/arm64, windows/amd64) cannot drift apart when the pin is
+  # Central ref for the keploy/integrations commit every build leg in
+  # this workflow checks out. Keeping it in one place means the 4
+  # Add-Private-Parsers steps below (linux/amd64, linux/arm64,
+  # darwin/arm64, windows/amd64) cannot drift apart when the ref is
   # bumped. Prefer the repo-level `vars.INTEGRATION_REF` when set (so
-  # operators can override the pin without editing this file), falling
-  # back to the hard-coded SHA this PR currently needs.
-  #
-  # Kept in sync with release.yml and golangci-lint.yml — all three
-  # workflows now track the same integrations SHA so a bump updates
-  # one place per workflow and the three cannot drift apart.
-  #
-  # Revert to `main` (drop this key) once keploy/integrations#130 merges.
-  INTEGRATION_REF: ${{ vars.INTEGRATION_REF || '127d5c37875ba2762e3561d17e4e8501fe671afa' }}
+  # operators can override without editing this file), falling back to
+  # `main`. Kept in sync with release.yml + golangci-lint.yml so all
+  # three workflows track the same integrations ref. Pin to a specific
+  # SHA via the repo var if a feat branch needs to carry a cross-repo
+  # change.
+  INTEGRATION_REF: ${{ vars.INTEGRATION_REF || 'main' }}
 
 jobs:
   # -------------------------------------------------------------------

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,16 +8,14 @@ permissions:
   contents: write
 
 env:
-  # Central pin for the keploy/integrations commit every build leg in
+  # Central ref for the keploy/integrations commit every build leg in
   # this workflow checks out via setup-private-parsers. Mirrors the
-  # default in prepare_and_run.yml so all three workflows
-  # (prepare_and_run, release, golangci-lint) track the same
-  # integrations SHA. Prefer the repo-level `vars.INTEGRATION_REF` when
-  # set (so operators can override the pin without editing this file),
-  # falling back to the hard-coded SHA.
-  #
-  # Revert to `main` (drop this key) once keploy/integrations#130 merges.
-  INTEGRATION_REF: ${{ vars.INTEGRATION_REF || '127d5c37875ba2762e3561d17e4e8501fe671afa' }}
+  # default in prepare_and_run.yml + golangci-lint.yml so all three
+  # workflows track the same integrations ref. Prefer the repo-level
+  # `vars.INTEGRATION_REF` when set (so operators can override without
+  # editing this file), falling back to `main`. Pin to a specific SHA
+  # via the repo var if a feat branch needs to carry a cross-repo change.
+  INTEGRATION_REF: ${{ vars.INTEGRATION_REF || 'main' }}
 
 # Session 174: release.yml is split across native platform runners to
 # unblock CGO_ENABLED=1 release builds. pg_query_go v6.2.2 (Session P)


### PR DESCRIPTION
## Summary
- keploy/integrations#130 landed at df3b862 on integrations main, so the cross-repo SHA pin that carried #4101 + #130 is no longer needed.
- Reverts the `INTEGRATION_REF` fallback in all three workflows (`golangci-lint.yml`, `release.yml`, `prepare_and_run.yml`) from the pinned SHA `127d5c3` → `main`.
- Preserves the `vars.INTEGRATION_REF` override path so future cross-repo feat branches can still pin to a specific SHA via repo-level var without editing these files.

## Test plan
- [ ] `golangci-lint` workflow runs cleanly on this PR against integrations main.
- [ ] `Prepare Binary and Run Workflows` completes its full fan-out (Linux/Darwin/Windows builds + downstream `run_*` matrix) against integrations main.
- [ ] No `release` workflow regression (not exercised on PR, but will fire on next tag push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)