### PR TITLE
ci(setup-private-parsers): hardcode GitHub host keys, drop ssh-keyscan (fixes v3.5.0 Windows release leg)

### DIFF
--- a/.github/actions/setup-private-parsers/action.yaml
+++ b/.github/actions/setup-private-parsers/action.yaml
@@ -23,15 +23,32 @@ runs:
         go-version-file: go.mod
         cache: ${{ inputs.go-cache }}
 
-    # --- Linux/macOS: Add Known Hosts ---
+    # --- Add Known Hosts (all OSes) ---
+    #
+    # Hard-code GitHub's published SSH host keys instead of running
+    # `ssh-keyscan github.com`. The Windows runner's bundled OpenSSH
+    # can't complete the GitHub-side KEX negotiation since GitHub
+    # started offering `sntrup761x25519-sha512@openssh.com` — the
+    # client aborts with `choose_kex: unsupported KEX method ...`
+    # and the step exits 1. Pinning to GitHub's documented
+    # fingerprints (see https://docs.github.com/en/authentication/
+    # keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints)
+    # is also stronger from a supply-chain standpoint — we never
+    # trust whatever `ssh-keyscan` hands back from the wire.
+    #
+    # If GitHub rotates a key, update the literals here. Keys last
+    # rotated 2023-03-24 (RSA) — others are long-lived.
     - name: Add GitHub to known hosts (non-Windows)
       if: runner.os != 'Windows'
       shell: bash
       run: |
         mkdir -p ~/.ssh
-        ssh-keyscan github.com >> ~/.ssh/known_hosts
+        cat <<'EOF' >> ~/.ssh/known_hosts
+        github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+        github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
+        github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=
+        EOF
 
-    # --- Windows: Add Known Hosts ---
     # Skip when GIT_SSH_COMMAND is already set (per-run isolation handles known_hosts)
     - name: Add GitHub to known hosts (Windows)
       if: runner.os == 'Windows' && !env.GIT_SSH_COMMAND
@@ -41,8 +58,15 @@ runs:
         if (-not (Test-Path -Path $sshDir)) {
             New-Item -ItemType Directory -Path $sshDir -Force | Out-Null
         }
-        # Using ascii ensures no BOM issues with SSH
-        ssh-keyscan github.com | Out-File -FilePath (Join-Path $sshDir "known_hosts") -Encoding ascii -Append
+        $knownHosts = Join-Path $sshDir "known_hosts"
+        # Hard-coded GitHub host keys — see non-Windows step for rationale.
+        # Ascii encoding avoids BOM issues with OpenSSH's parser.
+        $keys = @(
+          "github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl",
+          "github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=",
+          "github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk="
+        )
+        $keys | Out-File -FilePath $knownHosts -Encoding ascii -Append
 
     # --- SSH Agent (Common) ---
     - name: Load Private SSH Key


### PR DESCRIPTION
## Summary
- **v3.5.0 Release** workflow died on Windows at `Add Private Parsers` → `ssh-keyscan github.com`:
  \`\`\`
  choose_kex: unsupported KEX method sntrup761x25519-sha512@openssh.com
  \`\`\`
  Windows-runner OpenSSH can't negotiate GitHub's newer KEX, aborts, leaves \`known_hosts\` empty, and every subsequent SSH git fetch fails. Darwin/Linux happen to ship newer OpenSSH so they didn't trip.
- Replaces \`ssh-keyscan\` on both Linux/macOS and Windows steps with the [documented GitHub host fingerprints](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints) (Ed25519 / ECDSA / RSA).
- Stronger supply-chain posture: we never trust whatever a live \`ssh-keyscan\` returns.
- Rotate the literals if GitHub rotates a key. Last RSA rotation: 2023-03-24; Ed25519/ECDSA long-lived.

## Follow-up
Once merged, the v3.5.0 tag needs re-cutting (or cut v3.5.1) so the release workflow can fire again and upload the missing Windows binary. This PR intentionally only touches the action — not the tag/release itself.

## Test plan
- [ ] Lint + prepare_and_run pass on this PR against integrations main.
- [ ] After merge + next tag: v3.5.1 release workflow build-windows step succeeds past \`Add Private Parsers\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)