### PR TITLE
feat(replay): poll --health-url instead of fixed delay; --delay stays as fallback

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -332,6 +332,8 @@ func (c *CmdConfigurator) AddUncommonFlags(cmd *cobra.Command) {
 		cmd.Flags().Uint32("grpc-port", c.cfg.Test.GRPCPort, "Custom grpc port to replace the actual port in the testcases")
 		cmd.Flags().Uint32("sse-port", c.cfg.Test.SSEPort, "Custom SSE port to replace the actual port in the SSE testcases")
 		cmd.Flags().Uint64P("delay", "d", 5, "User provided time to run its application")
+		cmd.Flags().String("health-url", c.cfg.Test.HealthURL, "HTTP(S) URL polled before the first test is fired; first 2xx response proceeds immediately. Empty (default) preserves the fixed --delay behavior.")
+		cmd.Flags().Duration("health-poll-timeout", c.cfg.Test.HealthPollTimeout, "Ceiling for --health-url polling (e.g. 60s, 2m). If no 2xx is seen within this window, replay logs a warning and falls back to --delay.")
 		cmd.Flags().String("proto-file", c.cfg.Test.ProtoFile, "Path of main proto file")
 		cmd.Flags().String("proto-dir", c.cfg.Test.ProtoDir, "Path of the directory where all protos of a service are located")
 		cmd.Flags().StringArray("proto-include", c.cfg.Test.ProtoInclude, "Path of directories to be included while parsing import statements in proto files")
@@ -419,6 +421,8 @@ func aliasNormalizeFunc(_ *pflag.FlagSet, name string) pflag.NormalizedName {
 		"keployContainer":       "keploy-container",
 		"keployNetwork":         "keploy-network",
 		"recordTimer":           "record-timer",
+		"healthUrl":             "health-url",
+		"healthPollTimeout":     "health-poll-timeout",
 		"urlMethods":            "url-methods",
 		"inCi":                  "in-ci",
 		"protoFile":             "proto-file",

--- a/config/config.go
+++ b/config/config.go
@@ -130,6 +130,8 @@ type Test struct {
 	GlobalNoise                 Globalnoise         `json:"globalNoise" yaml:"globalNoise" mapstructure:"globalNoise"`
 	ReplaceWith                 ReplaceWith         `json:"replaceWith" yaml:"replaceWith" mapstructure:"replaceWith"`
 	Delay                       uint64              `json:"delay" yaml:"delay" mapstructure:"delay"`
+	HealthURL                   string              `json:"healthUrl" yaml:"healthUrl" mapstructure:"healthUrl"`                   // optional HTTP(S) URL polled before firing the first test; empty preserves the fixed --delay behavior
+	HealthPollTimeout           time.Duration       `json:"healthPollTimeout" yaml:"healthPollTimeout" mapstructure:"healthPollTimeout"` // ceiling for the pre-test health poll loop before falling back to --delay
 	Host                        string              `json:"host" yaml:"host" mapstructure:"host"`
 	Port                        uint32              `json:"port" yaml:"port" mapstructure:"port"`
 	GRPCPort                    uint32              `json:"grpcPort" yaml:"grpcPort" mapstructure:"grpcPort"`

--- a/config/default.go
+++ b/config/default.go
@@ -39,6 +39,8 @@ test:
     global: {}
     test-sets: {}
   delay: 5
+  healthUrl: ""
+  healthPollTimeout: 60s
   host: "localhost"
   port: 0
   grpcPort: 0

--- a/pkg/service/replay/health_poll_test.go
+++ b/pkg/service/replay/health_poll_test.go
@@ -1,0 +1,183 @@
+package replay
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"go.keploy.io/server/v3/config"
+)
+
+// newCfg builds a minimal config.Config with the replay/health knobs set.
+// A 1-second --delay fallback keeps the "timeout" test fast.
+func newCfg(healthURL string, pollTimeout time.Duration) *config.Config {
+	cfg := &config.Config{}
+	cfg.Test.Delay = 1
+	cfg.Test.HealthURL = healthURL
+	cfg.Test.HealthPollTimeout = pollTimeout
+	return cfg
+}
+
+// TestWaitForAppReady_200OnFirstTry verifies the happy path: a health endpoint
+// that is up immediately unblocks replay in well under the --delay fallback
+// window (and far under healthPollInterval).
+func TestWaitForAppReady_200OnFirstTry(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := newCfg(srv.URL, 5*time.Second)
+	logger := zap.NewNop()
+
+	start := time.Now()
+	ok := waitForAppReady(context.Background(), logger, cfg)
+	elapsed := time.Since(start)
+
+	if !ok {
+		t.Fatalf("expected waitForAppReady to return true on 200, got false")
+	}
+	if elapsed >= time.Second {
+		t.Fatalf("expected <1s proceed on first-try 200, elapsed=%v", elapsed)
+	}
+}
+
+// TestWaitForAppReady_503ThenOK verifies we honor the poll cadence: after N
+// failing probes the (N+1)th 2xx unblocks replay at roughly N * healthPollInterval
+// wall time (lower bound). This proves the loop is actually retrying rather
+// than short-circuiting.
+func TestWaitForAppReady_503ThenOK(t *testing.T) {
+	const failures int32 = 3
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt32(&hits, 1)
+		if n <= failures {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := newCfg(srv.URL, 10*time.Second)
+	logger := zap.NewNop()
+
+	start := time.Now()
+	ok := waitForAppReady(context.Background(), logger, cfg)
+	elapsed := time.Since(start)
+
+	if !ok {
+		t.Fatalf("expected waitForAppReady to eventually succeed, got false")
+	}
+	// Lower bound: N failing probes are spaced by healthPollInterval each,
+	// so elapsed >= failures * healthPollInterval.
+	minExpected := time.Duration(failures) * healthPollInterval
+	if elapsed < minExpected {
+		t.Fatalf("expected elapsed >= %v (N*500ms) after %d failures, got %v", minExpected, failures, elapsed)
+	}
+	// Upper bound guard: still well below any plausible fallback window.
+	if elapsed > 5*time.Second {
+		t.Fatalf("elapsed %v unexpectedly high; poll loop may be mis-cadenced", elapsed)
+	}
+	if got := atomic.LoadInt32(&hits); got < failures+1 {
+		t.Fatalf("expected at least %d hits, got %d", failures+1, got)
+	}
+}
+
+// TestWaitForAppReady_NeverOK verifies the fallback path: when the health
+// endpoint never returns 2xx we log the WARN and sleep for --delay.
+func TestWaitForAppReady_NeverOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	// Short HealthPollTimeout so the test finishes fast; Delay=1s fallback is the
+	// observable lower bound after the ceiling elapses.
+	cfg := newCfg(srv.URL, 300*time.Millisecond)
+
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	start := time.Now()
+	ok := waitForAppReady(context.Background(), logger, cfg)
+	elapsed := time.Since(start)
+
+	if !ok {
+		t.Fatalf("expected waitForAppReady to proceed via fallback, got false")
+	}
+	// Must have waited at least pollCeiling + fallback Delay.
+	if elapsed < 1200*time.Millisecond {
+		t.Fatalf("expected fallback to wait >=~1.2s (ceiling + delay), got %v", elapsed)
+	}
+
+	found := false
+	for _, entry := range logs.All() {
+		if strings.Contains(entry.Message, "health probe timed out") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected WARN 'health probe timed out' log, entries=%v", logs.All())
+	}
+}
+
+// TestWaitForAppReady_EmptyURLUsesFixedDelay locks in the zero-change default:
+// an empty HealthURL must reproduce the previous time.After(Delay) behavior and
+// never touch the network.
+func TestWaitForAppReady_EmptyURLUsesFixedDelay(t *testing.T) {
+	// Point healthPoller at a stub that would fail the test if called, to
+	// prove the empty-URL branch never invokes the poller.
+	orig := healthPoller
+	healthPoller = func(_ context.Context, _ string) bool {
+		t.Fatalf("healthPoller must not be called when HealthURL is empty")
+		return false
+	}
+	defer func() { healthPoller = orig }()
+
+	cfg := newCfg("", 60*time.Second)
+	cfg.Test.Delay = 0 // keep the test fast; semantics are the same
+	logger := zap.NewNop()
+
+	ok := waitForAppReady(context.Background(), logger, cfg)
+	if !ok {
+		t.Fatalf("expected waitForAppReady to return true in the default path")
+	}
+}
+
+// TestWaitForAppReady_CtxCanceled verifies ctx cancellation is honored during
+// the poll loop — caller should see false so it can return TestSetStatusUserAbort.
+func TestWaitForAppReady_CtxCanceled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	cfg := newCfg(srv.URL, 10*time.Second)
+	logger := zap.NewNop()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	ok := waitForAppReady(ctx, logger, cfg)
+	elapsed := time.Since(start)
+
+	if ok {
+		t.Fatalf("expected waitForAppReady to return false on ctx cancel, got true")
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("ctx cancel should unblock quickly, elapsed=%v", elapsed)
+	}
+}

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1054,10 +1054,9 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			utils.LogError(r.logger, err, "Failed to make the request to make agent ready for the docker compose")
 		}
 
-		// Delay for user application to run
-		select {
-		case <-time.After(time.Duration(r.config.Test.Delay) * time.Second):
-		case <-runTestSetCtx.Done():
+		// Wait for the user application to become ready before firing the first test.
+		// Prefers polling Test.HealthURL when set, otherwise falls back to the fixed --delay sleep.
+		if !waitForAppReady(runTestSetCtx, r.logger, r.config) {
 			return models.TestSetStatusUserAbort, context.Canceled
 		}
 	}
@@ -1199,10 +1198,9 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 				return nil
 			})
 
-			// Delay for user application to run
-			select {
-			case <-time.After(time.Duration(r.config.Test.Delay) * time.Second):
-			case <-runTestSetCtx.Done():
+			// Wait for the user application to become ready before firing the first test.
+			// Prefers polling Test.HealthURL when set, otherwise falls back to the fixed --delay sleep.
+			if !waitForAppReady(runTestSetCtx, r.logger, r.config) {
 				return models.TestSetStatusUserAbort, context.Canceled
 			}
 

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -1,7 +1,9 @@
 package replay
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"path"
@@ -12,12 +14,103 @@ import (
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/olekukonko/tablewriter/tw"
+	"go.uber.org/zap"
 
 	// "encoding/json"
 	"go.keploy.io/server/v3/config"
 	"go.keploy.io/server/v3/pkg"
 	"go.keploy.io/server/v3/pkg/models"
 )
+
+// healthPollInterval is how often the --health-url probe is retried while waiting for 2xx.
+const healthPollInterval = 500 * time.Millisecond
+
+// healthProbeTimeout bounds a single GET attempt to --health-url.
+const healthProbeTimeout = 1 * time.Second
+
+// healthPoller is swapped out in tests; production wires to net/http via httpHealthPoll.
+var healthPoller = httpHealthPoll
+
+// httpHealthPoll issues a single GET to url with a short per-request timeout and reports
+// whether it returned a 2xx status. Non-2xx, transport errors, and timeouts all report false;
+// the caller decides whether to retry.
+func httpHealthPoll(ctx context.Context, url string) bool {
+	reqCtx, cancel := context.WithTimeout(ctx, healthProbeTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, url, nil)
+	if err != nil {
+		return false
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+// waitForAppReady gates the first test on the user-application being up.
+//
+// If Test.HealthURL is empty we keep the historical behavior exactly: sleep for
+// Test.Delay seconds or until ctx is canceled.
+//
+// Otherwise we poll HealthURL every healthPollInterval (with a per-request cap
+// of healthProbeTimeout). The first 2xx unblocks immediately. If HealthPollTimeout
+// elapses with no 2xx, we log a WARN and fall back to the fixed Delay sleep so
+// operators never get stuck worse than today.
+//
+// Returns true when the caller should proceed to run tests, false only when ctx
+// was canceled (caller should treat as user abort).
+func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config) bool {
+	delay := time.Duration(cfg.Test.Delay) * time.Second
+
+	if cfg.Test.HealthURL == "" {
+		select {
+		case <-time.After(delay):
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
+
+	pollCeiling := cfg.Test.HealthPollTimeout
+	if pollCeiling <= 0 {
+		pollCeiling = 60 * time.Second
+	}
+	deadline := time.Now().Add(pollCeiling)
+
+	logger.Info("polling application health endpoint before firing tests",
+		zap.String("healthUrl", cfg.Test.HealthURL),
+		zap.Duration("pollTimeout", pollCeiling),
+	)
+
+	for {
+		if healthPoller(ctx, cfg.Test.HealthURL) {
+			logger.Debug("health endpoint reported 2xx; proceeding",
+				zap.String("healthUrl", cfg.Test.HealthURL),
+			)
+			return true
+		}
+		if time.Now().After(deadline) {
+			logger.Warn("health probe timed out, falling back to fixed delay",
+				zap.String("healthUrl", cfg.Test.HealthURL),
+				zap.Duration("pollTimeout", pollCeiling),
+				zap.Duration("fallbackDelay", delay),
+			)
+			select {
+			case <-time.After(delay):
+				return true
+			case <-ctx.Done():
+				return false
+			}
+		}
+		select {
+		case <-time.After(healthPollInterval):
+		case <-ctx.Done():
+			return false
+		}
+	}
+}
 
 type TestReportVerdict struct {
 	total     int


### PR DESCRIPTION
## Summary
- Replace the unconditional pre-test `time.After(Delay)` sleep in `pkg/service/replay/replay.go` (both sites, ~L1057 and ~L1202) with an active HTTP health poll when the new `Test.HealthURL` is set. First 2xx = app up, proceed immediately.
- Two new flags on `keploy test` / `keploy rerecord`: `--health-url` and `--health-poll-timeout` (default 60s), plumbed via the existing viper/mapstructure config (`Test.HealthURL`, `Test.HealthPollTimeout`).
- Default behavior is byte-for-byte unchanged: empty `HealthURL` keeps the historical fixed-delay path. If polling the configured URL never sees a 2xx within `HealthPollTimeout`, we log WARN `health probe timed out, falling back to fixed delay` and fall through to the existing `time.After(Delay)` sleep - so users are never worse off than today.

## Poll loop shape
500ms ticker, 1s per-request GET timeout, first 2xx wins, ceiling = `--health-poll-timeout`. Ctx cancel unblocks immediately. Timeout = WARN + fall through to `time.After(Delay)`.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./pkg/service/replay/...` (new `health_poll_test.go`, all pass):
  - [x] 200 on first try proceeds <1s
  - [x] 503x3 then 200 proceeds after >=3*500ms (~1.5s)
  - [x] Never-2xx falls back to `--delay` with WARN logged (verified via zap observer)
  - [x] Empty `HealthURL` never hits the network (poller stubbed to fail the test)
  - [x] Ctx cancel during poll returns false (triggers `TestSetStatusUserAbort` in caller)
- [ ] Manual smoke on a real app with a slow-starting container + `--health-url=http://localhost:8080/healthz`

Built on main @ fc849d99.

Generated with [Claude Code](https://claude.com/claude-code)