### PR TITLE
feat: consolidate v3 post-merge suite (#4111 + #4115 + #4117 + #4118)

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -332,6 +332,8 @@ func (c *CmdConfigurator) AddUncommonFlags(cmd *cobra.Command) {
 		cmd.Flags().Uint32("grpc-port", c.cfg.Test.GRPCPort, "Custom grpc port to replace the actual port in the testcases")
 		cmd.Flags().Uint32("sse-port", c.cfg.Test.SSEPort, "Custom SSE port to replace the actual port in the SSE testcases")
 		cmd.Flags().Uint64P("delay", "d", 5, "User provided time to run its application")
+		cmd.Flags().String("health-url", c.cfg.Test.HealthURL, "HTTP(S) URL polled before the first test is fired; first 2xx response proceeds immediately. Empty (default) preserves the fixed --delay behavior.")
+		cmd.Flags().Duration("health-poll-timeout", c.cfg.Test.HealthPollTimeout, "Ceiling for --health-url polling (e.g. 60s, 2m). If no 2xx is seen within this window, replay logs a warning and falls back to --delay.")
 		cmd.Flags().String("proto-file", c.cfg.Test.ProtoFile, "Path of main proto file")
 		cmd.Flags().String("proto-dir", c.cfg.Test.ProtoDir, "Path of the directory where all protos of a service are located")
 		cmd.Flags().StringArray("proto-include", c.cfg.Test.ProtoInclude, "Path of directories to be included while parsing import statements in proto files")
@@ -419,6 +421,8 @@ func aliasNormalizeFunc(_ *pflag.FlagSet, name string) pflag.NormalizedName {
 		"keployContainer":       "keploy-container",
 		"keployNetwork":         "keploy-network",
 		"recordTimer":           "record-timer",
+		"healthUrl":             "health-url",
+		"healthPollTimeout":     "health-poll-timeout",
 		"urlMethods":            "url-methods",
 		"inCi":                  "in-ci",
 		"protoFile":             "proto-file",

--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -333,7 +333,7 @@ func (c *CmdConfigurator) AddUncommonFlags(cmd *cobra.Command) {
 		cmd.Flags().Uint32("sse-port", c.cfg.Test.SSEPort, "Custom SSE port to replace the actual port in the SSE testcases")
 		cmd.Flags().Uint64P("delay", "d", 5, "User provided time to run its application")
 		cmd.Flags().String("health-url", c.cfg.Test.HealthURL, "HTTP(S) URL polled before the first test is fired; first 2xx response proceeds immediately. Empty (default) preserves the fixed --delay behavior.")
-		cmd.Flags().Duration("health-poll-timeout", c.cfg.Test.HealthPollTimeout, "Ceiling for --health-url polling (e.g. 60s, 2m). If no 2xx is seen within this window, replay logs a warning and falls back to --delay.")
+		cmd.Flags().Duration("health-poll-timeout", c.cfg.Test.HealthPollTimeout, "Ceiling for --health-url polling (e.g. 60s, 2m). If no 2xx is seen within this window, replay logs an info message and falls back to --delay.")
 		cmd.Flags().String("proto-file", c.cfg.Test.ProtoFile, "Path of main proto file")
 		cmd.Flags().String("proto-dir", c.cfg.Test.ProtoDir, "Path of the directory where all protos of a service are located")
 		cmd.Flags().StringArray("proto-include", c.cfg.Test.ProtoInclude, "Path of directories to be included while parsing import statements in proto files")

--- a/config/config.go
+++ b/config/config.go
@@ -130,6 +130,8 @@ type Test struct {
 	GlobalNoise                 Globalnoise         `json:"globalNoise" yaml:"globalNoise" mapstructure:"globalNoise"`
 	ReplaceWith                 ReplaceWith         `json:"replaceWith" yaml:"replaceWith" mapstructure:"replaceWith"`
 	Delay                       uint64              `json:"delay" yaml:"delay" mapstructure:"delay"`
+	HealthURL                   string              `json:"healthUrl" yaml:"healthUrl" mapstructure:"healthUrl"`                         // optional HTTP(S) URL polled before firing the first test; empty preserves the fixed --delay behavior
+	HealthPollTimeout           time.Duration       `json:"healthPollTimeout" yaml:"healthPollTimeout" mapstructure:"healthPollTimeout"` // ceiling for the pre-test health poll loop before falling back to --delay
 	Host                        string              `json:"host" yaml:"host" mapstructure:"host"`
 	Port                        uint32              `json:"port" yaml:"port" mapstructure:"port"`
 	GRPCPort                    uint32              `json:"grpcPort" yaml:"grpcPort" mapstructure:"grpcPort"`

--- a/config/default.go
+++ b/config/default.go
@@ -39,6 +39,8 @@ test:
     global: {}
     test-sets: {}
   delay: 5
+  healthUrl: ""
+  healthPollTimeout: 60s
   host: "localhost"
   port: 0
   grpcPort: 0

--- a/pkg/agent/proxy/dns.go
+++ b/pkg/agent/proxy/dns.go
@@ -508,10 +508,13 @@ func (p *Proxy) recordDNSMock(question dns.Question, reqTime time.Time, session 
 	// Prefer the upstream resolver list captured once at proxy
 	// startup (see captureDNSUpstream). This is critical in sidecar
 	// deployments where the app-container resolv.conf has been
-	// rewritten to point at 127.0.0.1:26789 — re-reading the file
-	// here would either (a) discover the loopback entry and forward
-	// queries back at ourselves, or (b) discover nothing at all.
-	// Capturing once at startup pins the REAL cluster resolvers.
+	// rewritten so the `nameserver` entry is 127.0.0.1 and DNS
+	// traffic is redirected to the agent's port 26789 via iptables/
+	// eBPF (resolv.conf entries themselves are IP-only and carry no
+	// port). Re-reading the file here would either (a) discover the
+	// loopback entry and forward queries back at ourselves, or
+	// (b) discover nothing at all. Capturing once at startup pins
+	// the REAL cluster resolvers.
 	//
 	// The public-DNS fallback (8.8.8.8 / 1.1.1.1) is retained for the
 	// rare local-dev case where the proxy runs outside a cluster AND

--- a/pkg/agent/proxy/dns.go
+++ b/pkg/agent/proxy/dns.go
@@ -213,6 +213,36 @@ func (p *Proxy) resolveUncachedDNSResponse(question dns.Question, mode models.Mo
 			if resp, mocked := p.getMockedDNSResponse(question); mocked {
 				return resp
 			}
+			// Mock miss. Before falling back to a synthetic/NXDOMAIN
+			// response, try forwarding to the cluster's real resolver
+			// (typically CoreDNS). This is the fix for the sap-demo /
+			// mysql.svc.cluster.local case: cluster-internal hostnames
+			// are not — and should not be — recorded as mocks, so a
+			// miss in replay mode is the expected shape for in-cluster
+			// DB / cache / queue connections. Faking them with the
+			// proxy's 127.0.0.1 (the legacy default) steers the app at
+			// the wrong IP and crashes the DB driver.
+			//
+			// If the forward succeeds we return the real answer as
+			// FromUpstream so the outer cache layer retains it for the
+			// usual 30 s — subsequent queries don't hit the network.
+			// If the forward fails we fall through to the existing
+			// "mock not found" path: same error, same log line, same
+			// NXDOMAIN / synthetic fallback. Forwarding is strictly
+			// additive.
+			if fwdResp, fwdErr := p.forwardDNSUpstream(question); fwdErr == nil && fwdResp != nil {
+				p.logger.Debug("DNS mock miss resolved via upstream forward",
+					zap.String("query", question.Name),
+					zap.String("qtype", dns.TypeToString[question.Qtype]),
+					zap.Int("rcode", fwdResp.Rcode),
+					zap.Int("answers", len(fwdResp.Answer)))
+				return dnsCacheEntry{Msg: fwdResp, FromUpstream: true}
+			} else if fwdErr != nil {
+				p.logger.Debug("DNS mock miss + upstream forward failed; falling back to synthetic response",
+					zap.String("query", question.Name),
+					zap.String("qtype", dns.TypeToString[question.Qtype]),
+					zap.Error(fwdErr))
+			}
 			// Send mock not found error if we couldn't match any DNS mock.
 			p.logger.Debug("mock miss",
 				zap.String("protocol", "DNS"),
@@ -475,15 +505,24 @@ func generateDNSDedupeKey(question dns.Question) string {
 }
 
 func (p *Proxy) recordDNSMock(question dns.Question, reqTime time.Time, session *agent.Session) (dnsCacheEntry, error) {
-	config, err := dns.ClientConfigFromFile("/etc/resolv.conf")
+	// Prefer the upstream resolver list captured once at proxy
+	// startup (see captureDNSUpstream). This is critical in sidecar
+	// deployments where the app-container resolv.conf has been
+	// rewritten to point at 127.0.0.1:26789 — re-reading the file
+	// here would either (a) discover the loopback entry and forward
+	// queries back at ourselves, or (b) discover nothing at all.
+	// Capturing once at startup pins the REAL cluster resolvers.
+	//
+	// The public-DNS fallback (8.8.8.8 / 1.1.1.1) is retained for the
+	// rare local-dev case where the proxy runs outside a cluster AND
+	// resolv.conf is entirely missing — the forwarder treats this as
+	// "no upstream" and we would otherwise be stuck.
 	var servers []string
 	port := "53"
-
-	if err == nil {
-		servers = config.Servers
-		port = config.Port
+	if p.hasDNSUpstream() {
+		servers = p.dnsUpstreamServers
+		port = p.dnsUpstreamPort
 	} else {
-		// Fallback to public DNS if resolv.conf fails
 		servers = []string{"8.8.8.8", "1.1.1.1"}
 	}
 

--- a/pkg/agent/proxy/dns.go
+++ b/pkg/agent/proxy/dns.go
@@ -213,37 +213,44 @@ func (p *Proxy) resolveUncachedDNSResponse(question dns.Question, mode models.Mo
 			if resp, mocked := p.getMockedDNSResponse(question); mocked {
 				return resp
 			}
-			// Mock miss. Before falling back to a synthetic/NXDOMAIN
-			// response, try forwarding to the cluster's real resolver
-			// (typically CoreDNS). This is the fix for the sap-demo /
-			// mysql.svc.cluster.local case: cluster-internal hostnames
-			// are not — and should not be — recorded as mocks, so a
-			// miss in replay mode is the expected shape for in-cluster
-			// DB / cache / queue connections. Faking them with the
-			// proxy's 127.0.0.1 (the legacy default) steers the app at
-			// the wrong IP and crashes the DB driver.
-			//
-			// If the forward succeeds we return the real answer as
-			// FromUpstream so the outer cache layer retains it for the
-			// usual 30 s — subsequent queries don't hit the network.
-			// If the forward fails we fall through to the existing
-			// "mock not found" path: same error, same log line, same
-			// NXDOMAIN / synthetic fallback. Forwarding is strictly
-			// additive.
-			if fwdResp, fwdErr := p.forwardDNSUpstream(question); fwdErr == nil && fwdResp != nil {
-				p.logger.Debug("DNS mock miss resolved via upstream forward",
-					zap.String("query", question.Name),
-					zap.String("qtype", dns.TypeToString[question.Qtype]),
-					zap.Int("rcode", fwdResp.Rcode),
-					zap.Int("answers", len(fwdResp.Answer)))
-				return dnsCacheEntry{Msg: fwdResp, FromUpstream: true}
-			} else if fwdErr != nil {
-				p.logger.Debug("DNS mock miss + upstream forward failed; falling back to synthetic response",
-					zap.String("query", question.Name),
-					zap.String("qtype", dns.TypeToString[question.Qtype]),
-					zap.Error(fwdErr))
-			}
-			// Send mock not found error if we couldn't match any DNS mock.
+		}
+		// Mock miss (or mocking disabled). Before falling back to a
+		// synthetic/NXDOMAIN response, try forwarding to the cluster's
+		// real resolver (typically CoreDNS). This is the fix for the
+		// sap-demo / mysql.svc.cluster.local case: cluster-internal
+		// hostnames are not — and should not be — recorded as mocks, so
+		// a miss in replay mode is the expected shape for in-cluster
+		// DB / cache / queue connections. Faking them with the proxy's
+		// 127.0.0.1 (the legacy default) steers the app at the wrong
+		// IP and crashes the DB driver.
+		//
+		// When mocking is explicitly disabled the operator's intent is
+		// "use real traffic", so forwarding is even more clearly the
+		// right behaviour than returning a synthetic proxy IP.
+		//
+		// If the forward succeeds we return the real answer as
+		// FromUpstream so the outer cache layer retains it for the
+		// usual 30 s — subsequent queries don't hit the network.
+		// If the forward fails we fall through to the existing
+		// "mock not found" path: same error, same log line, same
+		// NXDOMAIN / synthetic fallback. Forwarding is strictly
+		// additive.
+		if fwdResp, fwdErr := p.forwardDNSUpstream(question); fwdErr == nil && fwdResp != nil {
+			p.logger.Debug("DNS mock miss resolved via upstream forward",
+				zap.String("query", question.Name),
+				zap.String("qtype", dns.TypeToString[question.Qtype]),
+				zap.Int("rcode", fwdResp.Rcode),
+				zap.Int("answers", len(fwdResp.Answer)))
+			return dnsCacheEntry{Msg: fwdResp, FromUpstream: true}
+		} else if fwdErr != nil {
+			p.logger.Debug("DNS mock miss + upstream forward failed; falling back to synthetic response",
+				zap.String("query", question.Name),
+				zap.String("qtype", dns.TypeToString[question.Qtype]),
+				zap.Error(fwdErr))
+		}
+		if mockingEnabled {
+			// Send mock not found error if we couldn't match any DNS
+			// mock and upstream forwarding also failed.
 			p.logger.Debug("mock miss",
 				zap.String("protocol", "DNS"),
 				zap.String("query", question.Name),

--- a/pkg/agent/proxy/dns_forward.go
+++ b/pkg/agent/proxy/dns_forward.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"fmt"
 	"net"
+	"runtime"
 	"strconv"
 	"time"
 
@@ -41,7 +42,19 @@ var resolvConfPath = "/etc/resolv.conf"
 // A nil / empty result is acceptable. The forwarder handles that by
 // returning "no upstream configured" and letting the caller fall back
 // to the legacy synthetic response.
+//
+// Windows has no /etc/resolv.conf and this feature — forward-on-miss
+// to cluster resolvers — is only meaningful in Linux sidecar
+// environments where the k8s injector has rewritten resolv.conf. On
+// Windows we short-circuit to a clean no-op so we neither burn a stat
+// on a path that can never exist nor log a misleading "file not
+// found" at every agent startup. hasDNSUpstream() then returns false
+// and the proxy's DNS handler falls back to the legacy synthetic
+// response, matching pre-feature behavior exactly.
 func (p *Proxy) captureDNSUpstream() {
+	if runtime.GOOS == "windows" {
+		return
+	}
 	config, err := dns.ClientConfigFromFile(resolvConfPath)
 	if err != nil {
 		p.logger.Info("could not read resolv.conf for upstream forwarding; DNS mock misses will fall back to synthetic responses",

--- a/pkg/agent/proxy/dns_forward.go
+++ b/pkg/agent/proxy/dns_forward.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"time"
 
 	"github.com/miekg/dns"
@@ -20,14 +21,17 @@ var resolvConfPath = "/etc/resolv.conf"
 // as the app container's resolver — see the call site in StartProxy
 // for the ordering rationale.
 //
-// Loopback nameservers are filtered out because forwarding to 127.x
-// (or ::1) almost certainly means forwarding back into the very DNS
-// server this forwarder is trying to escape — which would hang the
-// app's query for dnsForwardTimeout on every miss. This filter is
-// defensive: in the current k8s injection model the sidecar
-// container's resolv.conf is untouched, but belts-and-braces against
-// future deployment modes where the injector runs against the whole
-// pod.
+// A loopback nameserver is filtered out ONLY when its port matches
+// the proxy's own DNS listen port (p.DNSPort) — that combination is
+// the unambiguous self-forward case: the k8s injector rewrote
+// resolv.conf to 127.0.0.1 and redirected traffic to our listener, so
+// forwarding there would loop and hang the app's query for
+// dnsForwardTimeout on every miss. Loopback nameservers at OTHER
+// ports (e.g. systemd-resolved on 127.0.0.53:53 or dnsmasq on
+// 127.0.0.1:5353) are legitimate real resolvers and MUST be kept —
+// dropping them in environments where /etc/resolv.conf is entirely
+// loopback would leave dnsUpstreamServers empty and silently disable
+// forward-on-miss.
 //
 // A nil / empty result is acceptable. The forwarder handles that by
 // returning "no upstream configured" and letting the caller fall back
@@ -44,24 +48,35 @@ func (p *Proxy) captureDNSUpstream() {
 		return
 	}
 
+	// resolv.conf has no port syntax per RFC — config.Port is populated
+	// from an "options" line or defaults to "53". We compare by string
+	// to avoid parsing surprises (leading zeros, etc.).
+	nsPort := config.Port
+	if nsPort == "" {
+		nsPort = "53"
+	}
+	selfPort := strconv.FormatUint(uint64(p.DNSPort), 10)
+
 	filtered := make([]string, 0, len(config.Servers))
 	for _, s := range config.Servers {
 		ip := net.ParseIP(s)
 		if ip == nil {
 			continue
 		}
-		if ip.IsLoopback() {
-			p.logger.Debug("dropping loopback upstream resolver from forwarder list",
-				zap.String("server", s))
+		// Only drop loopback when it points at our own listener.
+		// Anything else (systemd-resolved, dnsmasq, etc.) is a real
+		// resolver we can legitimately forward to.
+		if ip.IsLoopback() && nsPort == selfPort {
+			p.logger.Debug("dropping self-referential loopback upstream resolver from forwarder list",
+				zap.String("server", s),
+				zap.String("port", nsPort),
+				zap.String("proxyDNSPort", selfPort))
 			continue
 		}
 		filtered = append(filtered, s)
 	}
 	p.dnsUpstreamServers = filtered
-	p.dnsUpstreamPort = config.Port
-	if p.dnsUpstreamPort == "" {
-		p.dnsUpstreamPort = "53"
-	}
+	p.dnsUpstreamPort = nsPort
 	p.logger.Info("captured upstream DNS resolvers for forward-on-miss",
 		zap.Strings("servers", p.dnsUpstreamServers),
 		zap.String("port", p.dnsUpstreamPort))

--- a/pkg/agent/proxy/dns_forward.go
+++ b/pkg/agent/proxy/dns_forward.go
@@ -1,0 +1,209 @@
+package proxy
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/miekg/dns"
+	"go.uber.org/zap"
+)
+
+// resolvConfPath is the file the forwarder snapshots at startup to
+// discover real upstream resolvers. A package-level var so tests can
+// swap in a temp file without hitting host DNS.
+var resolvConfPath = "/etc/resolv.conf"
+
+// captureDNSUpstream snapshots the cluster resolver list from
+// /etc/resolv.conf into p.dnsUpstreamServers / p.dnsUpstreamPort. Must
+// be called exactly once, at proxy startup, BEFORE p.DNSPort is bound
+// as the app container's resolver — see the call site in StartProxy
+// for the ordering rationale.
+//
+// Loopback nameservers are filtered out because forwarding to 127.x
+// (or ::1) almost certainly means forwarding back into the very DNS
+// server this forwarder is trying to escape — which would hang the
+// app's query for dnsForwardTimeout on every miss. This filter is
+// defensive: in the current k8s injection model the sidecar
+// container's resolv.conf is untouched, but belts-and-braces against
+// future deployment modes where the injector runs against the whole
+// pod.
+//
+// A nil / empty result is acceptable. The forwarder handles that by
+// returning "no upstream configured" and letting the caller fall back
+// to the legacy synthetic response.
+func (p *Proxy) captureDNSUpstream() {
+	config, err := dns.ClientConfigFromFile(resolvConfPath)
+	if err != nil {
+		p.logger.Info("could not read resolv.conf for upstream forwarding; DNS mock misses will fall back to synthetic responses",
+			zap.String("path", resolvConfPath),
+			zap.Error(err))
+		return
+	}
+	if config == nil {
+		return
+	}
+
+	filtered := make([]string, 0, len(config.Servers))
+	for _, s := range config.Servers {
+		ip := net.ParseIP(s)
+		if ip == nil {
+			continue
+		}
+		if ip.IsLoopback() {
+			p.logger.Debug("dropping loopback upstream resolver from forwarder list",
+				zap.String("server", s))
+			continue
+		}
+		filtered = append(filtered, s)
+	}
+	p.dnsUpstreamServers = filtered
+	p.dnsUpstreamPort = config.Port
+	if p.dnsUpstreamPort == "" {
+		p.dnsUpstreamPort = "53"
+	}
+	p.logger.Info("captured upstream DNS resolvers for forward-on-miss",
+		zap.Strings("servers", p.dnsUpstreamServers),
+		zap.String("port", p.dnsUpstreamPort))
+}
+
+// hasDNSUpstream reports whether the forwarder has any real upstream
+// resolver to try. When false, forwardDNSUpstream is a no-op and
+// callers fall back to the legacy synthetic response.
+func (p *Proxy) hasDNSUpstream() bool {
+	return p != nil && len(p.dnsUpstreamServers) > 0
+}
+
+// forwardDNSUpstream performs a single DNS Exchange against each
+// snapshotted upstream server in turn, returning the first Successful
+// response. On timeout or transport error we advance to the next
+// server; if all fail we return an error so the caller can fall
+// through to the legacy default response.
+//
+// Transport rules:
+//   - Start on UDP (cheapest).
+//   - If a UDP response is truncated, retry on TCP against the same
+//     server to pull the full answer.
+//   - All exchanges share a per-call deadline of p.dnsForwardTimeout.
+//
+// No caching is done here — the outer ServeDNS handler already caches
+// "FromUpstream" responses via p.dnsCache, and recording-mode mocks are
+// emitted by the caller. Keeping this function stateless makes it
+// trivially safe to call concurrently from the UDP and TCP DNS servers.
+func (p *Proxy) forwardDNSUpstream(question dns.Question) (*dns.Msg, error) {
+	if !p.hasDNSUpstream() {
+		return nil, fmt.Errorf("no upstream DNS resolver configured")
+	}
+
+	// Only forward types we know how to relay sensibly. Everything
+	// listed here is pass-through for both the query and the answer —
+	// the miekg/dns library serializes whatever RRs the upstream
+	// returns. A / AAAA / SRV / PTR are the task's mandatory set;
+	// TXT / MX / CNAME / NS / SOA / CAA / ANY ride along because
+	// they're free once we're already forwarding and excluding them
+	// would break otherwise-working apps (e.g. SMTP clients chasing
+	// MX, SPF validators reading TXT). Unrecognised QTypes we leave
+	// to the caller's existing default response path so we don't
+	// accidentally start answering DNSSEC queries we can't sign.
+	if !isForwardableQType(question.Qtype) {
+		return nil, fmt.Errorf("qtype %s not forwarded", dns.TypeToString[question.Qtype])
+	}
+
+	// dns.Client.Timeout is the per-exchange wall-clock cap. We also
+	// derive a loop-wide deadline so the worst case across all
+	// servers is still bounded by dnsForwardTimeout, not
+	// N*dnsForwardTimeout. This matters when all upstreams are
+	// black-holed: without the outer deadline, three servers would
+	// each burn 2 s before we fall back.
+	deadline := time.Now().Add(p.dnsForwardTimeout)
+
+	m := new(dns.Msg)
+	m.SetQuestion(dns.Fqdn(question.Name), question.Qtype)
+	m.Question[0].Qclass = nonZeroQclass(question.Qclass)
+	m.RecursionDesired = true
+
+	var lastErr error
+	for _, server := range p.dnsUpstreamServers {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			lastErr = fmt.Errorf("dns forward deadline exceeded before trying %s", server)
+			break
+		}
+		addr := net.JoinHostPort(server, p.dnsUpstreamPort)
+
+		c := &dns.Client{Net: "udp", Timeout: remaining}
+		resp, _, err := c.Exchange(m, addr)
+		if err != nil {
+			p.logger.Debug("upstream DNS forward failed (udp); trying next server",
+				zap.String("server", addr),
+				zap.String("question", question.Name),
+				zap.Error(err))
+			lastErr = err
+			continue
+		}
+
+		if resp != nil && resp.Truncated {
+			// Upstream said "answer too big for UDP" — retry on TCP
+			// against the same server using whatever is left of the
+			// loop-wide deadline.
+			tcpRemaining := time.Until(deadline)
+			if tcpRemaining <= 0 {
+				lastErr = fmt.Errorf("dns forward deadline exceeded before TCP retry to %s", server)
+				break
+			}
+			tc := &dns.Client{Net: "tcp", Timeout: tcpRemaining}
+			tcpResp, _, terr := tc.Exchange(m, addr)
+			if terr != nil {
+				p.logger.Debug("upstream DNS forward failed (tcp); trying next server",
+					zap.String("server", addr),
+					zap.String("question", question.Name),
+					zap.Error(terr))
+				lastErr = terr
+				continue
+			}
+			resp = tcpResp
+		}
+
+		if resp == nil {
+			continue
+		}
+		return resp, nil
+	}
+
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no upstream DNS server returned a response for %s", question.Name)
+	}
+	return nil, lastErr
+}
+
+// isForwardableQType is the allowlist of DNS query types the
+// forwarder will relay. See forwardDNSUpstream for the rationale.
+func isForwardableQType(qtype uint16) bool {
+	switch qtype {
+	case dns.TypeA,
+		dns.TypeAAAA,
+		dns.TypeSRV,
+		dns.TypePTR,
+		dns.TypeCNAME,
+		dns.TypeTXT,
+		dns.TypeMX,
+		dns.TypeNS,
+		dns.TypeSOA,
+		dns.TypeCAA,
+		dns.TypeANY:
+		return true
+	}
+	return false
+}
+
+// nonZeroQclass substitutes dns.ClassINET when the caller did not set
+// a query class. The miekg/dns server layer passes Qclass==0 when the
+// incoming question did not include one (rare but RFC-allowed for
+// some crafted packets); forwarding Qclass=0 upstream is a spec
+// violation and CoreDNS answers with FORMERR.
+func nonZeroQclass(qclass uint16) uint16 {
+	if qclass == 0 {
+		return dns.ClassINET
+	}
+	return qclass
+}

--- a/pkg/agent/proxy/dns_forward.go
+++ b/pkg/agent/proxy/dns_forward.go
@@ -121,7 +121,10 @@ func (p *Proxy) forwardDNSUpstream(question dns.Question) (*dns.Msg, error) {
 	// to the caller's existing default response path so we don't
 	// accidentally start answering DNSSEC queries we can't sign.
 	if !isForwardableQType(question.Qtype) {
-		return nil, fmt.Errorf("qtype %s not forwarded", dns.TypeToString[question.Qtype])
+		if qtypeName, ok := dns.TypeToString[question.Qtype]; ok && qtypeName != "" {
+			return nil, fmt.Errorf("qtype %s not forwarded", qtypeName)
+		}
+		return nil, fmt.Errorf("qtype %d not forwarded", question.Qtype)
 	}
 
 	// dns.Client.Timeout is the per-exchange wall-clock cap. We also

--- a/pkg/agent/proxy/dns_forward.go
+++ b/pkg/agent/proxy/dns_forward.go
@@ -11,10 +11,16 @@ import (
 	"go.uber.org/zap"
 )
 
+// defaultResolvConfPath is the production path captureDNSUpstream
+// reads on non-Windows hosts. Kept as a typed constant so the
+// Windows-short-circuit check below compares against the actual
+// production literal rather than re-spelling it.
+const defaultResolvConfPath = "/etc/resolv.conf"
+
 // resolvConfPath is the file the forwarder snapshots at startup to
 // discover real upstream resolvers. A package-level var so tests can
 // swap in a temp file without hitting host DNS.
-var resolvConfPath = "/etc/resolv.conf"
+var resolvConfPath = defaultResolvConfPath
 
 // captureDNSUpstream snapshots the cluster resolver list from
 // /etc/resolv.conf into p.dnsUpstreamServers / p.dnsUpstreamPort. Must
@@ -46,13 +52,19 @@ var resolvConfPath = "/etc/resolv.conf"
 // Windows has no /etc/resolv.conf and this feature — forward-on-miss
 // to cluster resolvers — is only meaningful in Linux sidecar
 // environments where the k8s injector has rewritten resolv.conf. On
-// Windows we short-circuit to a clean no-op so we neither burn a stat
-// on a path that can never exist nor log a misleading "file not
-// found" at every agent startup. hasDNSUpstream() then returns false
-// and the proxy's DNS handler falls back to the legacy synthetic
-// response, matching pre-feature behavior exactly.
+// Windows with the default path we short-circuit to a clean no-op
+// so we neither burn a stat on a path that can never exist nor log
+// a misleading "file not found" at every agent startup.
+// hasDNSUpstream() then returns false and the proxy's DNS handler
+// falls back to the legacy synthetic response, matching pre-feature
+// behavior exactly.
+//
+// The `resolvConfPath == defaultResolvConfPath` guard means tests
+// that swap in a temp resolv.conf (via the resolvConfPath package
+// var) still exercise the full parsing/filter path on every GOOS,
+// so `go test ./...` on Windows stays green.
 func (p *Proxy) captureDNSUpstream() {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == "windows" && resolvConfPath == defaultResolvConfPath {
 		return
 	}
 	config, err := dns.ClientConfigFromFile(resolvConfPath)

--- a/pkg/agent/proxy/dns_forward.go
+++ b/pkg/agent/proxy/dns_forward.go
@@ -77,7 +77,7 @@ func (p *Proxy) captureDNSUpstream() {
 	}
 	p.dnsUpstreamServers = filtered
 	p.dnsUpstreamPort = nsPort
-	p.logger.Info("captured upstream DNS resolvers for forward-on-miss",
+	p.logger.Debug("captured upstream DNS resolvers for forward-on-miss",
 		zap.Strings("servers", p.dnsUpstreamServers),
 		zap.String("port", p.dnsUpstreamPort))
 }

--- a/pkg/agent/proxy/dns_forward.go
+++ b/pkg/agent/proxy/dns_forward.go
@@ -21,17 +21,22 @@ var resolvConfPath = "/etc/resolv.conf"
 // as the app container's resolver — see the call site in StartProxy
 // for the ordering rationale.
 //
-// A loopback nameserver is filtered out ONLY when its port matches
-// the proxy's own DNS listen port (p.DNSPort) — that combination is
-// the unambiguous self-forward case: the k8s injector rewrote
-// resolv.conf to 127.0.0.1 and redirected traffic to our listener, so
-// forwarding there would loop and hang the app's query for
-// dnsForwardTimeout on every miss. Loopback nameservers at OTHER
-// ports (e.g. systemd-resolved on 127.0.0.53:53 or dnsmasq on
-// 127.0.0.1:5353) are legitimate real resolvers and MUST be kept —
-// dropping them in environments where /etc/resolv.conf is entirely
-// loopback would leave dnsUpstreamServers empty and silently disable
-// forward-on-miss.
+// A loopback nameserver is filtered out ONLY when the effective
+// resolver port in use matches the proxy's own DNS listen port
+// (p.DNSPort) — that combination is the unambiguous self-forward
+// case: the k8s injector rewrote resolv.conf to a loopback address
+// and redirected traffic to our listener, so forwarding there would
+// loop and hang the app's query for dnsForwardTimeout on every miss.
+//
+// Note: resolv.conf `nameserver` lines cannot carry a port; the port
+// comes from an `options` directive (or defaults to 53). A loopback
+// resolver listening on ANY non-proxy port — e.g. systemd-resolved
+// (typically listens on 53 at a loopback address) or a local dnsmasq
+// instance bound to a non-default port — is a legitimate real
+// resolver and MUST be kept. Dropping loopback resolvers
+// unconditionally would leave dnsUpstreamServers empty in
+// environments where resolv.conf is entirely loopback, silently
+// disabling forward-on-miss.
 //
 // A nil / empty result is acceptable. The forwarder handles that by
 // returning "no upstream configured" and letting the caller fall back

--- a/pkg/agent/proxy/dns_forward_test.go
+++ b/pkg/agent/proxy/dns_forward_test.go
@@ -366,11 +366,16 @@ func TestResolveUncachedDNSResponse_TestMode_UpstreamTimeoutFallback(t *testing.
 }
 
 // TestCaptureDNSUpstream_ReadsResolvConf verifies the startup
-// capture reads a resolv.conf file and correctly filters loopback
-// entries. Uses a temp file + the package-level resolvConfPath hook.
+// capture reads a resolv.conf file and correctly filters
+// self-referential loopback entries (loopback at the proxy's own DNS
+// listen port). Uses a temp file + the package-level resolvConfPath
+// hook.
 func TestCaptureDNSUpstream_ReadsResolvConf(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "resolv.conf")
+	// resolv.conf has no port syntax — nameserver lines are IP-only
+	// and the default port is 53. With p.DNSPort == 53, the 127.0.0.1
+	// entry is self-referential and must be dropped.
 	content := "nameserver 10.96.0.10\nnameserver 127.0.0.1\nsearch cluster.local\noptions ndots:5\n"
 	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 		t.Fatalf("write temp resolv.conf: %v", err)
@@ -380,17 +385,84 @@ func TestCaptureDNSUpstream_ReadsResolvConf(t *testing.T) {
 	resolvConfPath = path
 	defer func() { resolvConfPath = orig }()
 
-	p := &Proxy{logger: zap.NewNop()}
+	// Simulate the self-forward condition: proxy is listening on port
+	// 53 (same as default resolv.conf port), so the loopback entry
+	// would loop back into us.
+	p := &Proxy{logger: zap.NewNop(), DNSPort: 53}
 	p.captureDNSUpstream()
 
 	if len(p.dnsUpstreamServers) != 1 {
-		t.Fatalf("dnsUpstreamServers = %v; want exactly [10.96.0.10] after loopback filter", p.dnsUpstreamServers)
+		t.Fatalf("dnsUpstreamServers = %v; want exactly [10.96.0.10] after self-forward filter", p.dnsUpstreamServers)
 	}
 	if p.dnsUpstreamServers[0] != "10.96.0.10" {
 		t.Errorf("dnsUpstreamServers[0] = %q; want 10.96.0.10", p.dnsUpstreamServers[0])
 	}
 	if p.dnsUpstreamPort != "53" {
 		t.Errorf("dnsUpstreamPort = %q; want 53", p.dnsUpstreamPort)
+	}
+}
+
+// TestCaptureDNSUpstream_KeepsNonSelfLoopback is the round-3 fix
+// check: a resolv.conf that lists ONLY a loopback resolver (common in
+// pods behind systemd-resolved at 127.0.0.53 or a local dnsmasq) must
+// leave the upstream list non-empty so forward-on-miss still works.
+// The previous filter dropped every IsLoopback() entry and silently
+// disabled forwarding in those environments.
+func TestCaptureDNSUpstream_KeepsNonSelfLoopback(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "resolv.conf")
+	content := "nameserver 127.0.0.1\nsearch cluster.local\n"
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("write temp resolv.conf: %v", err)
+	}
+
+	orig := resolvConfPath
+	resolvConfPath = path
+	defer func() { resolvConfPath = orig }()
+
+	// Proxy listens on 26789 — resolv.conf's implied port is 53, so
+	// 127.0.0.1:53 is NOT our own listener and must be kept.
+	p := &Proxy{logger: zap.NewNop(), DNSPort: 26789}
+	p.captureDNSUpstream()
+
+	if len(p.dnsUpstreamServers) != 1 {
+		t.Fatalf("dnsUpstreamServers = %v; want [127.0.0.1] (loopback at non-self port must be kept)", p.dnsUpstreamServers)
+	}
+	if p.dnsUpstreamServers[0] != "127.0.0.1" {
+		t.Errorf("dnsUpstreamServers[0] = %q; want 127.0.0.1", p.dnsUpstreamServers[0])
+	}
+	if !p.hasDNSUpstream() {
+		t.Errorf("hasDNSUpstream() = false; expected true so forward-on-miss still fires in loopback-only resolv.conf environments")
+	}
+}
+
+// TestCaptureDNSUpstream_DropsSelfReferentialLoopback is the explicit
+// anti-loop guardrail: when resolv.conf's implied port (53) matches
+// the proxy's own DNS listen port, the loopback entry IS our own
+// listener and forwarding there would loop. Confirm that specific
+// case is still filtered alongside a non-loopback entry.
+func TestCaptureDNSUpstream_DropsSelfReferentialLoopback(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "resolv.conf")
+	content := "nameserver 10.0.0.53\nnameserver ::1\n"
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("write temp resolv.conf: %v", err)
+	}
+
+	orig := resolvConfPath
+	resolvConfPath = path
+	defer func() { resolvConfPath = orig }()
+
+	// Proxy listens on 53 (the default resolv.conf port). ::1:53 is
+	// self-referential and must be dropped; 10.0.0.53 must be kept.
+	p := &Proxy{logger: zap.NewNop(), DNSPort: 53}
+	p.captureDNSUpstream()
+
+	if len(p.dnsUpstreamServers) != 1 {
+		t.Fatalf("dnsUpstreamServers = %v; want [10.0.0.53] only (IPv6 loopback self-ref dropped)", p.dnsUpstreamServers)
+	}
+	if p.dnsUpstreamServers[0] != "10.0.0.53" {
+		t.Errorf("dnsUpstreamServers[0] = %q; want 10.0.0.53", p.dnsUpstreamServers[0])
 	}
 }
 

--- a/pkg/agent/proxy/dns_forward_test.go
+++ b/pkg/agent/proxy/dns_forward_test.go
@@ -1,0 +1,463 @@
+package proxy
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// startFakeUpstream spins up a miekg/dns UDP server on a
+// kernel-assigned port and returns its host:port plus a shutdown func.
+// The handler is supplied by the caller so each test can encode its
+// own answer / delay / error behaviour.
+func startFakeUpstream(t *testing.T, handler dns.HandlerFunc) (string, func()) {
+	t.Helper()
+
+	// Bind on an ephemeral UDP port. We capture the actual assigned
+	// port via net.ListenPacket so we can drive dns.Server with a
+	// pre-bound PacketConn; this is more reliable across CI runners
+	// than relying on dns.Server to discover its own port after
+	// ListenAndServe.
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	mux := dns.NewServeMux()
+	mux.HandleFunc(".", handler)
+	srv := &dns.Server{
+		PacketConn: pc,
+		Handler:    mux,
+	}
+	done := make(chan struct{})
+	go func() {
+		_ = srv.ActivateAndServe()
+		close(done)
+	}()
+
+	// Small startup wait: ActivateAndServe returns only once the
+	// listener is actually ready, but its goroutine completes
+	// asynchronously. Without this, the very first Exchange can race
+	// the server's internal run loop on slow CI boxes. We poll
+	// instead of sleeping a fixed duration to keep the happy path
+	// fast.
+	addr := pc.LocalAddr().String()
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		c := &dns.Client{Net: "udp", Timeout: 50 * time.Millisecond}
+		probe := new(dns.Msg)
+		probe.SetQuestion("probe.test.", dns.TypeA)
+		if _, _, err := c.Exchange(probe, addr); err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	return addr, func() {
+		_ = srv.Shutdown()
+		<-done
+	}
+}
+
+// newProxyWithUpstream builds the minimum Proxy for forwarder tests
+// and points its upstream list at the supplied addr.
+func newProxyWithUpstream(t *testing.T, addr string, timeout time.Duration) *Proxy {
+	t.Helper()
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("split upstream addr: %v", err)
+	}
+	return &Proxy{
+		logger:             zap.NewNop(),
+		IP4:                "127.0.0.1",
+		IP6:                "::1",
+		EnableIPv6Redirect: false,
+		dnsUpstreamServers: []string{host},
+		dnsUpstreamPort:    port,
+		dnsForwardTimeout:  timeout,
+		dnsCache:           newDNSCache(),
+		recordedDNSMocks:   newRecordedDNSMocksCache(),
+	}
+}
+
+// TestForwardDNSUpstream_Success validates the happy path: the
+// forwarder hits the fake upstream, receives an answer, and returns
+// it verbatim.
+func TestForwardDNSUpstream_Success(t *testing.T) {
+	addr, stop := startFakeUpstream(t, func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Authoritative = true
+		if len(r.Question) > 0 && r.Question[0].Qtype == dns.TypeA {
+			m.Answer = append(m.Answer, &dns.A{
+				Hdr: dns.RR_Header{
+					Name:   r.Question[0].Name,
+					Rrtype: dns.TypeA,
+					Class:  dns.ClassINET,
+					Ttl:    60,
+				},
+				A: net.ParseIP("10.0.0.7"),
+			})
+		}
+		_ = w.WriteMsg(m)
+	})
+	defer stop()
+
+	p := newProxyWithUpstream(t, addr, 2*time.Second)
+	q := dns.Question{Name: "mysql.sap-demo.svc.cluster.local.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+
+	resp, err := p.forwardDNSUpstream(q)
+	if err != nil {
+		t.Fatalf("forwardDNSUpstream: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("resp is nil")
+	}
+	if resp.Rcode != dns.RcodeSuccess {
+		t.Errorf("Rcode = %d, want %d", resp.Rcode, dns.RcodeSuccess)
+	}
+	if len(resp.Answer) != 1 {
+		t.Fatalf("Answer len = %d, want 1", len(resp.Answer))
+	}
+	a, ok := resp.Answer[0].(*dns.A)
+	if !ok {
+		t.Fatalf("answer not *dns.A: %T", resp.Answer[0])
+	}
+	if !a.A.Equal(net.ParseIP("10.0.0.7")) {
+		t.Errorf("A = %v, want 10.0.0.7", a.A)
+	}
+}
+
+// TestForwardDNSUpstream_Timeout confirms the forwarder does not hang
+// forever when the upstream is black-holed. With dnsForwardTimeout
+// set to 100 ms the call must return within ~200 ms (generous for CI
+// jitter) with a clear error the caller can fall back on.
+func TestForwardDNSUpstream_Timeout(t *testing.T) {
+	// Stall handler: never responds fast enough. The forwarder's
+	// per-exchange timeout is what has to cut this short. The stall
+	// duration only needs to be longer than the forwarder's timeout
+	// plus a margin — keep it tight so the test exits promptly.
+	addr, stop := startFakeUpstream(t, func(w dns.ResponseWriter, r *dns.Msg) {
+		// Swallow probe queries from startFakeUpstream so the server
+		// looks alive enough for the setup phase to succeed, then
+		// stall on everything else.
+		if len(r.Question) > 0 && strings.HasPrefix(r.Question[0].Name, "probe.test") {
+			m := new(dns.Msg)
+			m.SetReply(r)
+			_ = w.WriteMsg(m)
+			return
+		}
+		// Block briefly. Long enough that the 100 ms forwarder
+		// deadline fires, short enough to not stretch the test.
+		time.Sleep(400 * time.Millisecond)
+	})
+	defer stop()
+
+	p := newProxyWithUpstream(t, addr, 100*time.Millisecond)
+	q := dns.Question{Name: "does-not-exist.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+
+	start := time.Now()
+	resp, err := p.forwardDNSUpstream(q)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("expected timeout error, got resp=%v", resp)
+	}
+	// Give the system some slack — 500ms is a comfortable ceiling that
+	// still catches regression to a multi-second wait.
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("forwardDNSUpstream took %v; expected <500ms with 100ms timeout", elapsed)
+	}
+}
+
+// TestServeDNS_LocalMockHit_NoForward asserts case #1 of the task's
+// test matrix: when a DNS query matches a recorded mock we return the
+// mocked answer and do NOT forward upstream. The fake upstream's
+// handler panics on unexpected traffic — if the forwarder is invoked
+// the test fails loudly.
+func TestServeDNS_LocalMockHit_NoForward(t *testing.T) {
+	addr, stop := startFakeUpstream(t, func(w dns.ResponseWriter, r *dns.Msg) {
+		// Allow only the setup probe (see startFakeUpstream). Any
+		// real traffic here is a bug — the local mock path must
+		// short-circuit the forwarder.
+		if len(r.Question) > 0 && strings.HasPrefix(r.Question[0].Name, "probe.test") {
+			m := new(dns.Msg)
+			m.SetReply(r)
+			_ = w.WriteMsg(m)
+			return
+		}
+		t.Errorf("upstream received query for %q; local-mock path should have answered without forwarding", r.Question[0].Name)
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Rcode = dns.RcodeServerFailure
+		_ = w.WriteMsg(m)
+	})
+	defer stop()
+
+	p := newProxyWithUpstream(t, addr, 2*time.Second)
+
+	// Seed a MockManager with a single DNS mock for example.com. ->
+	// 42.42.42.42. The exact structure mirrors a recorded mock so
+	// getMockedDNSResponse accepts it. We feed the mock through
+	// SetFilteredMocks — that path populates statelessFiltered,
+	// which GetStatelessMocks keys on for DNS lookups.
+	mgr := NewMockManager(nil, nil, zap.NewNop())
+	t.Cleanup(mgr.Close)
+	mgr.SetFilteredMocks([]*models.Mock{{
+		Version: models.GetVersion(),
+		Name:    "dns-mock-test",
+		Kind:    models.DNS,
+		Spec: models.MockSpec{
+			Metadata: map[string]string{"type": "config"},
+			DNSReq: &models.DNSReq{
+				Name:   "example.com.",
+				Qtype:  dns.TypeA,
+				Qclass: dns.ClassINET,
+			},
+			DNSResp: &models.DNSResp{
+				Rcode:              dns.RcodeSuccess,
+				Authoritative:      true,
+				RecursionAvailable: true,
+				Answers:            []string{"example.com. 60 IN A 42.42.42.42"},
+			},
+		},
+	}})
+	p.mockManager = mgr
+
+	q := dns.Question{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	resp, mocked := p.getMockedDNSResponse(q)
+	if !mocked {
+		t.Fatalf("expected local mock hit, got miss")
+	}
+	if len(resp.Answer) != 1 {
+		t.Fatalf("expected 1 answer from mock, got %d", len(resp.Answer))
+	}
+	a, ok := resp.Answer[0].(*dns.A)
+	if !ok {
+		t.Fatalf("answer not *dns.A: %T", resp.Answer[0])
+	}
+	if !a.A.Equal(net.ParseIP("42.42.42.42")) {
+		t.Errorf("A = %v, want 42.42.42.42", a.A)
+	}
+
+	// Belt-and-braces: ensure the surrounding resolveUncachedDNSResponse
+	// path also returns the mock without touching upstream. We run
+	// through it with mockingEnabled=true and mode=MODE_TEST.
+	entry := p.resolveUncachedDNSResponse(q, models.MODE_TEST, true, time.Now(), nil)
+	if entry.Msg == nil || len(entry.Msg.Answer) != 1 {
+		t.Fatalf("resolveUncachedDNSResponse did not return the mocked answer")
+	}
+	if got, _ := entry.Msg.Answer[0].(*dns.A); got == nil || !got.A.Equal(net.ParseIP("42.42.42.42")) {
+		t.Errorf("resolveUncachedDNSResponse returned wrong answer: %+v", entry.Msg.Answer)
+	}
+}
+
+// TestResolveUncachedDNSResponse_TestMode_UpstreamForwardSuccess
+// validates case #2 of the test matrix: in MODE_TEST with a mock
+// miss, the forwarder resolves the query via the fake upstream and
+// the caller returns the real answer (not the 127.0.0.1 synthetic
+// fallback). This is the direct fix for the sap-demo crashloop.
+func TestResolveUncachedDNSResponse_TestMode_UpstreamForwardSuccess(t *testing.T) {
+	addr, stop := startFakeUpstream(t, func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Authoritative = true
+		if len(r.Question) > 0 && r.Question[0].Qtype == dns.TypeA {
+			m.Answer = append(m.Answer, &dns.A{
+				Hdr: dns.RR_Header{
+					Name:   r.Question[0].Name,
+					Rrtype: dns.TypeA,
+					Class:  dns.ClassINET,
+					Ttl:    60,
+				},
+				A: net.ParseIP("10.0.0.7"),
+			})
+		}
+		_ = w.WriteMsg(m)
+	})
+	defer stop()
+
+	p := newProxyWithUpstream(t, addr, 2*time.Second)
+	// Empty mock manager — every query misses locally.
+	emptyMgr := NewMockManager(nil, nil, zap.NewNop())
+	t.Cleanup(emptyMgr.Close)
+	p.mockManager = emptyMgr
+
+	q := dns.Question{Name: "mysql.sap-demo.svc.cluster.local.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	entry := p.resolveUncachedDNSResponse(q, models.MODE_TEST, true, time.Now(), nil)
+
+	if entry.Msg == nil {
+		t.Fatalf("expected forwarded response, got nil Msg")
+	}
+	if !entry.FromUpstream {
+		t.Errorf("entry.FromUpstream = false; expected true for forwarded answer")
+	}
+	if len(entry.Msg.Answer) != 1 {
+		t.Fatalf("expected 1 answer from upstream, got %d", len(entry.Msg.Answer))
+	}
+	a, ok := entry.Msg.Answer[0].(*dns.A)
+	if !ok {
+		t.Fatalf("answer not *dns.A: %T", entry.Msg.Answer[0])
+	}
+	if !a.A.Equal(net.ParseIP("10.0.0.7")) {
+		t.Errorf("A = %v, want 10.0.0.7 (from fake upstream, NOT 127.0.0.1 synthetic)", a.A)
+	}
+}
+
+// TestResolveUncachedDNSResponse_TestMode_UpstreamTimeoutFallback
+// validates case #3: when the upstream is unreachable the forwarder
+// times out and the caller falls back to the legacy default response
+// (which for TypeA is the proxy's 127.0.0.1). The fallback preserves
+// pre-existing behaviour for app DNS mocks that never pointed at an
+// in-cluster resolver in the first place.
+func TestResolveUncachedDNSResponse_TestMode_UpstreamTimeoutFallback(t *testing.T) {
+	// Point upstream at a discard address — UDP to a port nothing
+	// listens on yields "connection refused" on Linux, which the
+	// forwarder treats the same as a timeout for fallback purposes.
+	// To make the test behaviour identical across OSes we use a
+	// stalling real server and squeeze the timeout down.
+	addr, stop := startFakeUpstream(t, func(w dns.ResponseWriter, r *dns.Msg) {
+		if len(r.Question) > 0 && strings.HasPrefix(r.Question[0].Name, "probe.test") {
+			m := new(dns.Msg)
+			m.SetReply(r)
+			_ = w.WriteMsg(m)
+			return
+		}
+		// Stall just long enough to exercise the 80 ms forwarder
+		// deadline; short enough that the test exits quickly.
+		time.Sleep(400 * time.Millisecond)
+	})
+	defer stop()
+
+	p := newProxyWithUpstream(t, addr, 80*time.Millisecond)
+	emptyMgr := NewMockManager(nil, nil, zap.NewNop())
+	t.Cleanup(emptyMgr.Close)
+	p.mockManager = emptyMgr
+
+	q := dns.Question{Name: "unreachable.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	entry := p.resolveUncachedDNSResponse(q, models.MODE_TEST, true, time.Now(), nil)
+
+	// On fallback we expect the synthetic A response pointing at
+	// p.IP4 (127.0.0.1). FromUpstream must be false because this is
+	// the proxy default, not a real answer.
+	if entry.Msg == nil {
+		t.Fatalf("expected fallback response, got nil Msg")
+	}
+	if entry.FromUpstream {
+		t.Errorf("entry.FromUpstream = true; expected false for fallback")
+	}
+	if len(entry.Msg.Answer) != 1 {
+		t.Fatalf("expected 1 fallback A answer, got %d", len(entry.Msg.Answer))
+	}
+	a, ok := entry.Msg.Answer[0].(*dns.A)
+	if !ok {
+		t.Fatalf("fallback answer not *dns.A: %T", entry.Msg.Answer[0])
+	}
+	if !a.A.Equal(net.ParseIP("127.0.0.1")) {
+		t.Errorf("fallback A = %v, want 127.0.0.1 (proxy IP4)", a.A)
+	}
+}
+
+// TestCaptureDNSUpstream_ReadsResolvConf verifies the startup
+// capture reads a resolv.conf file and correctly filters loopback
+// entries. Uses a temp file + the package-level resolvConfPath hook.
+func TestCaptureDNSUpstream_ReadsResolvConf(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "resolv.conf")
+	content := "nameserver 10.96.0.10\nnameserver 127.0.0.1\nsearch cluster.local\noptions ndots:5\n"
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("write temp resolv.conf: %v", err)
+	}
+
+	orig := resolvConfPath
+	resolvConfPath = path
+	defer func() { resolvConfPath = orig }()
+
+	p := &Proxy{logger: zap.NewNop()}
+	p.captureDNSUpstream()
+
+	if len(p.dnsUpstreamServers) != 1 {
+		t.Fatalf("dnsUpstreamServers = %v; want exactly [10.96.0.10] after loopback filter", p.dnsUpstreamServers)
+	}
+	if p.dnsUpstreamServers[0] != "10.96.0.10" {
+		t.Errorf("dnsUpstreamServers[0] = %q; want 10.96.0.10", p.dnsUpstreamServers[0])
+	}
+	if p.dnsUpstreamPort != "53" {
+		t.Errorf("dnsUpstreamPort = %q; want 53", p.dnsUpstreamPort)
+	}
+}
+
+// TestCaptureDNSUpstream_MissingFile asserts that a missing
+// resolv.conf does NOT panic or error out; the agent must keep
+// running with "no upstream" and fall back to synthetic responses.
+func TestCaptureDNSUpstream_MissingFile(t *testing.T) {
+	orig := resolvConfPath
+	resolvConfPath = filepath.Join(t.TempDir(), "does-not-exist")
+	defer func() { resolvConfPath = orig }()
+
+	p := &Proxy{logger: zap.NewNop()}
+	p.captureDNSUpstream()
+
+	if p.hasDNSUpstream() {
+		t.Errorf("hasDNSUpstream() = true; expected false when resolv.conf is missing")
+	}
+}
+
+// TestIsForwardableQType covers the allowlist — ensures new DNS
+// record types aren't silently added to forwarding without human
+// review, and that the mandatory A/AAAA/SRV/PTR are all accepted.
+func TestIsForwardableQType(t *testing.T) {
+	cases := []struct {
+		qtype uint16
+		want  bool
+	}{
+		{dns.TypeA, true},
+		{dns.TypeAAAA, true},
+		{dns.TypeSRV, true},
+		{dns.TypePTR, true},
+		{dns.TypeCNAME, true},
+		{dns.TypeMX, true},
+		{dns.TypeTXT, true},
+		{dns.TypeNS, true},
+		{dns.TypeSOA, true},
+		{dns.TypeCAA, true},
+		{dns.TypeANY, true},
+
+		{dns.TypeRRSIG, false},
+		{dns.TypeDNSKEY, false},
+		{dns.TypeOPT, false},
+		{0, false},
+	}
+	for _, c := range cases {
+		got := isForwardableQType(c.qtype)
+		if got != c.want {
+			t.Errorf("isForwardableQType(%s) = %v; want %v",
+				dns.TypeToString[c.qtype], got, c.want)
+		}
+	}
+}
+
+// TestForwardDNSUpstream_NoUpstreamConfigured makes sure calling the
+// forwarder on a Proxy with no captured upstream returns a clear
+// error rather than dialing nothing.
+func TestForwardDNSUpstream_NoUpstreamConfigured(t *testing.T) {
+	p := &Proxy{
+		logger:            zap.NewNop(),
+		dnsForwardTimeout: 2 * time.Second,
+	}
+	q := dns.Question{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	_, err := p.forwardDNSUpstream(q)
+	if err == nil {
+		t.Fatalf("expected error when no upstream configured, got nil")
+	}
+	if !strings.Contains(err.Error(), "no upstream") {
+		t.Errorf("err = %v; want message containing 'no upstream'", err)
+	}
+}

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -524,8 +524,14 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 			// without chunked TE). Reporting both lets operators tell
 			// "chunked JSON API response" apart from "unknown-length
 			// upload" when triaging capture-budget trips.
+			//
+			// The message deliberately does NOT say "while streaming" — a
+			// large fixed Content-Length body can also trip this branch
+			// (streaming_exchange=false, chunked_transfer=false). The two
+			// booleans report how the body was framed; the message just
+			// reports the budget trip.
 			chunkedTransfer := isChunked(req.TransferEncoding) || isChunked(resp.TransferEncoding)
-			logger.Debug("Skipping HTTP capture because body exceeded capture budget while streaming",
+			logger.Debug("Skipping HTTP capture because body exceeded capture budget",
 				zap.Int("capture_budget_bytes", maxHTTPBodyCaptureBytes),
 				zap.Int64("request_bytes_seen", reqCapture.Total()),
 				zap.Int64("response_bytes_seen", respCapture.Total()),

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -353,8 +353,8 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 				// Release the lock early for streaming exchanges so a
 				// single slow/streaming upload doesn't wedge the sync
 				// semaphore. Capture stays enabled: tee reads the
-				// already-decoded body bytes, and the downstream
-				// capture-budget check (respCapture.Truncated()) handles
+				// already-decoded body bytes, and downstream capture-budget
+				// checks on the request/response capture buffers handle
 				// genuinely oversized streams.
 				releaseLock()
 				chunked = true

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -340,7 +340,15 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 		}
 		reqTimestamp := time.Now()
 
-		var chunked bool = false
+		// streamingExchange tracks whether EITHER side (request or response)
+		// lacked a concrete Content-Length or used Transfer-Encoding:
+		// chunked. This covers the full "no upfront size known" superset
+		// that needs early lock release. At the debug log site below we
+		// also report the narrower 'chunked_transfer' bit separately so
+		// operators can distinguish true chunked encoding from simple
+		// unknown-length streams — the flag name used to be 'chunked',
+		// which conflated the two.
+		var streamingExchange bool = false
 		// pressureCloseMode unifies forceCloseMode with memory pressure.
 		// When true, expected close errors are handled gracefully (DEBUG level),
 		// the sampling lock is released early, and the loop exits after one exchange.
@@ -357,7 +365,7 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 				// checks on the request/response capture buffers handle
 				// genuinely oversized streams.
 				releaseLock()
-				chunked = true
+				streamingExchange = true
 			} else if captureEnabled && pm.synchronous && acquiredLock {
 				mgr := syncMock.Get()
 				if !mgr.GetFirstReqSeen() {
@@ -441,7 +449,7 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 				// body bytes and the capture-budget check handles
 				// genuinely oversized streams.
 				releaseLock()
-				chunked = true
+				streamingExchange = true
 			}
 
 			resp.Close = true
@@ -510,11 +518,19 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 		}
 
 		if shouldCapture && (reqCapture.Truncated() || respCapture.Truncated()) {
+			// chunked_transfer is the narrower bit (actual Transfer-Encoding:
+			// chunked on either side). streaming_exchange is the superset
+			// that also captures unknown-length streams (Content-Length == -1
+			// without chunked TE). Reporting both lets operators tell
+			// "chunked JSON API response" apart from "unknown-length
+			// upload" when triaging capture-budget trips.
+			chunkedTransfer := isChunked(req.TransferEncoding) || isChunked(resp.TransferEncoding)
 			logger.Debug("Skipping HTTP capture because body exceeded capture budget while streaming",
 				zap.Int("capture_budget_bytes", maxHTTPBodyCaptureBytes),
 				zap.Int64("request_bytes_seen", reqCapture.Total()),
 				zap.Int64("response_bytes_seen", respCapture.Total()),
-				zap.Bool("chunked_transfer", chunked),
+				zap.Bool("streaming_exchange", streamingExchange),
+				zap.Bool("chunked_transfer", chunkedTransfer),
 				zap.String("url", req.URL.String()),
 				zap.String("method", req.Method),
 				zap.Int("status_code", resp.StatusCode),

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -350,9 +350,14 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 		// Request modifications for sync/sampling modes.
 		if forceCloseMode {
 			if req.ContentLength == -1 || isChunked(req.TransferEncoding) {
+				// Release the lock early for streaming exchanges so a
+				// single slow/streaming upload doesn't wedge the sync
+				// semaphore. Capture stays enabled: tee reads the
+				// already-decoded body bytes, and the downstream
+				// capture-budget check (respCapture.Truncated()) handles
+				// genuinely oversized streams.
 				releaseLock()
 				chunked = true
-				captureEnabled = false
 			} else if captureEnabled && pm.synchronous && acquiredLock {
 				mgr := syncMock.Get()
 				if !mgr.GetFirstReqSeen() {
@@ -370,8 +375,10 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 		// path returns early via handleHttp1ZeroCopy/forwardRawTCP).
 
 		// Determine whether capture is eligible for this exchange.
-		// Skip tee/buffering to avoid overhead when capture will be skipped anyway.
-		captureEligible := captureEnabled && !(forceCloseMode && chunked) && (!pm.sampling || acquiredLock)
+		// Chunked-encoded exchanges are still captured: the tee reads the
+		// decoded body stream, and oversized bodies are rejected later by
+		// the capture-budget check on reqCapture/respCapture.Truncated().
+		captureEligible := captureEnabled && (!pm.sampling || acquiredLock)
 
 		// Re-check memory pressure right before attaching capture buffers.
 		if captureEligible && isIngressRecordingPaused() {
@@ -428,6 +435,11 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 		// Response modifications for sync/sampling modes.
 		if forceCloseMode {
 			if resp.ContentLength == -1 || isChunked(resp.TransferEncoding) {
+				// Release the sync/sampling lock early on streaming
+				// responses so a slow upstream doesn't wedge the slot,
+				// but keep capture enabled — the tee reads decoded
+				// body bytes and the capture-budget check handles
+				// genuinely oversized streams.
 				releaseLock()
 				chunked = true
 			}
@@ -437,9 +449,9 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 		}
 		respTimestamp := time.Now()
 
-		// Re-evaluate capture eligibility after response headers (chunked may have changed).
+		// Re-evaluate capture eligibility after response headers.
 		// Also re-check memory pressure in case it started mid-exchange.
-		captureEligible = captureEnabled && !(forceCloseMode && chunked) && (!pm.sampling || acquiredLock)
+		captureEligible = captureEnabled && (!pm.sampling || acquiredLock)
 		if captureEligible && isIngressRecordingPaused() {
 			pressureCloseMode = true
 			captureEligible = false
@@ -480,15 +492,15 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 
 		shouldCapture := captureEnabled
 		if forceCloseMode {
-			if chunked {
-				shouldCapture = false
-				logger.Debug("Skipping testcase capture for streaming exchange",
-					zap.Bool("synchronous_mode", pm.synchronous),
-					zap.Bool("sampling_mode", pm.sampling),
-					zap.Int64("request_bytes_seen", reqCapture.Total()),
-					zap.Int64("response_bytes_seen", respCapture.Total()),
-				)
-			} else if pm.sampling && !acquiredLock {
+			// Previously: chunked exchanges were dropped here outright.
+			// That caused legitimate chunked-encoded REST responses
+			// (very common for JSON APIs that omit Content-Length) to
+			// be silently skipped at record time, leading to the
+			// "1-of-25 captures" symptom on stress runs. Chunked
+			// exchanges are now captured normally; the downstream
+			// capture-budget check (reqCapture/respCapture.Truncated())
+			// rejects genuinely oversized streams.
+			if pm.sampling && !acquiredLock {
 				shouldCapture = false
 			}
 		}
@@ -502,6 +514,7 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 				zap.Int("capture_budget_bytes", maxHTTPBodyCaptureBytes),
 				zap.Int64("request_bytes_seen", reqCapture.Total()),
 				zap.Int64("response_bytes_seen", respCapture.Total()),
+				zap.Bool("chunked_transfer", chunked),
 				zap.String("url", req.URL.String()),
 				zap.String("method", req.Method),
 				zap.Int("status_code", resp.StatusCode),

--- a/pkg/agent/proxy/incoming/http_test.go
+++ b/pkg/agent/proxy/incoming/http_test.go
@@ -3,13 +3,21 @@ package proxy
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"go.keploy.io/server/v3/pkg"
+	hooksUtils "go.keploy.io/server/v3/pkg/agent/hooks/conn"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
 )
 
 func stubIngressPaused(t *testing.T, fn func() bool) {
@@ -194,4 +202,309 @@ func TestSerializeCapturedResponseRoundTrip(t *testing.T) {
 	if !bytes.Equal(parsedBody, respBody) {
 		t.Fatalf("expected response body %q, got %q", string(respBody), string(parsedBody))
 	}
+}
+
+// stubCaptureHook replaces the package-level CaptureHook for the duration
+// of a test so the test can observe capture calls without running the
+// full parser + yaml-persist stack.
+func stubCaptureHook(t *testing.T, fn hooksUtils.CaptureFunc) {
+	t.Helper()
+	prev := hooksUtils.CaptureHook
+	hooksUtils.CaptureHook = fn
+	t.Cleanup(func() { hooksUtils.CaptureHook = prev })
+}
+
+// TestHandleHttp1Connection_ChunkedExchangeIsCaptured is a regression test
+// for the record-time "skip chunked capture" bug that dropped 24 of every
+// 25 tests when the upstream returned Transfer-Encoding: chunked (the Go
+// net/http default when no Content-Length is set).
+//
+// The pre-fix handleHttp1Connection logged "Skipping testcase capture for
+// streaming exchange" and never called CaptureHook. After the fix, chunked
+// exchanges under the per-body capture budget are persisted normally.
+func TestHandleHttp1Connection_ChunkedExchangeIsCaptured(t *testing.T) {
+	stubIngressPaused(t, func() bool { return false })
+
+	// Upstream httptest server that returns a chunked response
+	// (no Content-Length => net/http picks Transfer-Encoding: chunked).
+	const upstreamBody = `{"ok":true,"id":42}`
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Explicitly flush before body to force chunked framing in
+		// addition to the missing Content-Length.
+		flusher, _ := w.(http.Flusher)
+		_, _ = w.Write([]byte(upstreamBody[:5]))
+		if flusher != nil {
+			flusher.Flush()
+		}
+		_, _ = w.Write([]byte(upstreamBody[5:]))
+	}))
+	t.Cleanup(upstream.Close)
+	upstreamAddr := strings.TrimPrefix(upstream.URL, "http://")
+
+	// Capture observed test cases (CaptureHook replaces the real
+	// dump+parse+persist pipeline for this unit test).
+	var (
+		captured   []*capturedExchange
+		capturedMu sync.Mutex
+		captureWG  sync.WaitGroup
+	)
+	captureWG.Add(1)
+	stubCaptureHook(t, func(ctx context.Context, logger *zap.Logger, tc chan *models.TestCase,
+		req *http.Request, resp *http.Response, reqTS, respTS time.Time,
+		opts models.IncomingOptions, synchronous bool, appPort uint16) {
+		defer captureWG.Done()
+		// Read request+response bodies here so the test can assert them.
+		reqBody, _ := io.ReadAll(req.Body)
+		respBody, _ := io.ReadAll(resp.Body)
+		capturedMu.Lock()
+		captured = append(captured, &capturedExchange{
+			method:   req.Method,
+			url:      req.URL.String(),
+			reqBody:  string(reqBody),
+			status:   resp.StatusCode,
+			respBody: string(respBody),
+		})
+		capturedMu.Unlock()
+	})
+
+	// Build an IngressProxyManager configured for synchronous record mode.
+	pm := &IngressProxyManager{
+		logger:       zap.NewNop(),
+		tcChan:       make(chan *models.TestCase, 4),
+		synchronous:  true,
+		samplingSem:  make(chan struct{}, 1),
+		incomingOpts: models.IncomingOptions{},
+	}
+
+	// Dial the client side via a TCP pipe. handleHttp1Connection dials
+	// upstream itself (so it needs a real TCP listener), but the client
+	// side is a loopback TCP connection we drive from the test.
+	clientListener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	t.Cleanup(func() { _ = clientListener.Close() })
+
+	connCh := make(chan net.Conn, 1)
+	go func() {
+		c, aerr := clientListener.Accept()
+		if aerr != nil {
+			t.Logf("accept err: %v", aerr)
+			return
+		}
+		connCh <- c
+	}()
+
+	clientConn, err := net.Dial("tcp4", clientListener.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to dial client: %v", err)
+	}
+	t.Cleanup(func() { _ = clientConn.Close() })
+
+	serverConn := <-connCh
+	t.Cleanup(func() { _ = serverConn.Close() })
+
+	// Run handleHttp1Connection in a goroutine — it reads the request off
+	// serverConn, forwards to upstream, writes response back, and fires
+	// the capture goroutine.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	sem := make(chan struct{}, 1)
+	handlerDone := make(chan struct{})
+	go func() {
+		defer close(handlerDone)
+		pm.handleHttp1Connection(ctx, serverConn, upstreamAddr, pm.logger, pm.tcChan, sem, 8080)
+	}()
+
+	// Send a plain HTTP/1.1 GET from the test "client" side. We don't
+	// need a chunked request body for this regression — the response
+	// is chunked, which is the common case. (A chunked request variant
+	// is covered by the second test below.)
+	req := "GET /resource HTTP/1.1\r\nHost: example.local\r\nConnection: close\r\n\r\n"
+	if _, werr := clientConn.Write([]byte(req)); werr != nil {
+		t.Fatalf("failed to write request: %v", werr)
+	}
+
+	// Read the full response back (handleHttp1Connection writes it).
+	respReader := bufio.NewReader(clientConn)
+	respMsg, err := http.ReadResponse(respReader, nil)
+	if err != nil {
+		t.Fatalf("failed to read response from handler: %v", err)
+	}
+	gotBody, _ := io.ReadAll(respMsg.Body)
+	respMsg.Body.Close()
+	if string(gotBody) != upstreamBody {
+		t.Fatalf("forwarded response body mismatch: want %q got %q", upstreamBody, string(gotBody))
+	}
+
+	// Wait for the capture goroutine to run.
+	captureDone := make(chan struct{})
+	go func() {
+		captureWG.Wait()
+		close(captureDone)
+	}()
+	select {
+	case <-captureDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("CaptureHook was never invoked for chunked exchange — the skip bug has regressed")
+	}
+
+	<-handlerDone
+
+	capturedMu.Lock()
+	defer capturedMu.Unlock()
+	if len(captured) != 1 {
+		t.Fatalf("expected 1 captured test case for chunked exchange, got %d", len(captured))
+	}
+	got := captured[0]
+	if got.method != http.MethodGet {
+		t.Fatalf("captured method = %q, want GET", got.method)
+	}
+	if got.status != http.StatusOK {
+		t.Fatalf("captured status = %d, want 200", got.status)
+	}
+	if got.respBody != upstreamBody {
+		t.Fatalf("captured response body = %q, want %q", got.respBody, upstreamBody)
+	}
+}
+
+// TestHandleHttp1Connection_ChunkedRequestIsCaptured covers the
+// Transfer-Encoding: chunked request side (less common than chunked
+// responses, but also dropped by the pre-fix skip branch).
+func TestHandleHttp1Connection_ChunkedRequestIsCaptured(t *testing.T) {
+	stubIngressPaused(t, func() bool { return false })
+
+	const reqBody = "hello-chunked-body"
+	var gotUpstreamBody string
+	var gotUpstreamMu sync.Mutex
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotUpstreamMu.Lock()
+		gotUpstreamBody = string(b)
+		gotUpstreamMu.Unlock()
+		w.Header().Set("Content-Length", "2")
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(upstream.Close)
+	upstreamAddr := strings.TrimPrefix(upstream.URL, "http://")
+
+	var (
+		captured  []*capturedExchange
+		mu        sync.Mutex
+		captureWG sync.WaitGroup
+	)
+	captureWG.Add(1)
+	stubCaptureHook(t, func(ctx context.Context, logger *zap.Logger, tc chan *models.TestCase,
+		req *http.Request, resp *http.Response, reqTS, respTS time.Time,
+		opts models.IncomingOptions, synchronous bool, appPort uint16) {
+		defer captureWG.Done()
+		rb, _ := io.ReadAll(req.Body)
+		rsb, _ := io.ReadAll(resp.Body)
+		mu.Lock()
+		captured = append(captured, &capturedExchange{
+			method:   req.Method,
+			url:      req.URL.String(),
+			reqBody:  string(rb),
+			status:   resp.StatusCode,
+			respBody: string(rsb),
+		})
+		mu.Unlock()
+	})
+
+	pm := &IngressProxyManager{
+		logger:       zap.NewNop(),
+		tcChan:       make(chan *models.TestCase, 4),
+		synchronous:  true,
+		samplingSem:  make(chan struct{}, 1),
+		incomingOpts: models.IncomingOptions{},
+	}
+
+	clientListener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	t.Cleanup(func() { _ = clientListener.Close() })
+
+	connCh := make(chan net.Conn, 1)
+	go func() {
+		c, aerr := clientListener.Accept()
+		if aerr != nil {
+			return
+		}
+		connCh <- c
+	}()
+
+	clientConn, err := net.Dial("tcp4", clientListener.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+	t.Cleanup(func() { _ = clientConn.Close() })
+	serverConn := <-connCh
+	t.Cleanup(func() { _ = serverConn.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	sem := make(chan struct{}, 1)
+	handlerDone := make(chan struct{})
+	go func() {
+		defer close(handlerDone)
+		pm.handleHttp1Connection(ctx, serverConn, upstreamAddr, pm.logger, pm.tcChan, sem, 8080)
+	}()
+
+	// Construct a chunked-encoded POST request manually.
+	chunkHex := fmt.Sprintf("%x", len(reqBody))
+	raw := "POST /upload HTTP/1.1\r\n" +
+		"Host: example.local\r\n" +
+		"Transfer-Encoding: chunked\r\n" +
+		"Connection: close\r\n" +
+		"\r\n" +
+		chunkHex + "\r\n" + reqBody + "\r\n" +
+		"0\r\n\r\n"
+	if _, werr := clientConn.Write([]byte(raw)); werr != nil {
+		t.Fatalf("failed to write chunked request: %v", werr)
+	}
+
+	respReader := bufio.NewReader(clientConn)
+	respMsg, err := http.ReadResponse(respReader, nil)
+	if err != nil {
+		t.Fatalf("failed to read response: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, respMsg.Body)
+	respMsg.Body.Close()
+
+	gotUpstreamMu.Lock()
+	if gotUpstreamBody != reqBody {
+		t.Fatalf("upstream received %q, want %q", gotUpstreamBody, reqBody)
+	}
+	gotUpstreamMu.Unlock()
+
+	captureDone := make(chan struct{})
+	go func() {
+		captureWG.Wait()
+		close(captureDone)
+	}()
+	select {
+	case <-captureDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("CaptureHook was never invoked for chunked-request exchange — the skip bug has regressed")
+	}
+	<-handlerDone
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(captured) != 1 {
+		t.Fatalf("expected 1 captured test case for chunked request, got %d", len(captured))
+	}
+	if captured[0].reqBody != reqBody {
+		t.Fatalf("captured request body = %q, want %q", captured[0].reqBody, reqBody)
+	}
+}
+
+type capturedExchange struct {
+	method, url, reqBody string
+	status               int
+	respBody             string
 }

--- a/pkg/agent/proxy/incoming/http_test.go
+++ b/pkg/agent/proxy/incoming/http_test.go
@@ -302,7 +302,12 @@ func TestHandleHttp1Connection_ChunkedExchangeIsCaptured(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = clientConn.Close() })
 
-	serverConn := <-connCh
+	var serverConn net.Conn
+	select {
+	case serverConn = <-connCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for accept goroutine to deliver serverConn")
+	}
 	t.Cleanup(func() { _ = serverConn.Close() })
 
 	// Run handleHttp1Connection in a goroutine — it reads the request off
@@ -446,7 +451,12 @@ func TestHandleHttp1Connection_ChunkedRequestIsCaptured(t *testing.T) {
 		t.Fatalf("failed to dial: %v", err)
 	}
 	t.Cleanup(func() { _ = clientConn.Close() })
-	serverConn := <-connCh
+	var serverConn net.Conn
+	select {
+	case serverConn = <-connCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for accept goroutine to deliver serverConn")
+	}
 	t.Cleanup(func() { _ = serverConn.Close() })
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/pkg/agent/proxy/incoming/http_test.go
+++ b/pkg/agent/proxy/incoming/http_test.go
@@ -351,7 +351,11 @@ func TestHandleHttp1Connection_ChunkedExchangeIsCaptured(t *testing.T) {
 		t.Fatal("CaptureHook was never invoked for chunked exchange — the skip bug has regressed")
 	}
 
-	<-handlerDone
+	select {
+	case <-handlerDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("handleHttp1Connection did not return within 3s; inspect the handler's ctx/EOF handling")
+	}
 
 	capturedMu.Lock()
 	defer capturedMu.Unlock()
@@ -491,7 +495,11 @@ func TestHandleHttp1Connection_ChunkedRequestIsCaptured(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatal("CaptureHook was never invoked for chunked-request exchange — the skip bug has regressed")
 	}
-	<-handlerDone
+	select {
+	case <-handlerDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("HTTP handler did not finish after the chunked-request exchange; inspect the handler shutdown path")
+	}
 
 	mu.Lock()
 	defer mu.Unlock()

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -474,10 +474,16 @@ func New(logger *zap.Logger, info agent.DestInfo, opts *config.Config) *Proxy {
 		caJavaHome:         opts.Agent.CAJavaHome,
 		dnsCache:           newDNSCache(),
 		recordedDNSMocks:   newRecordedDNSMocksCache(),
-		// 2 s is long enough to absorb a single UDP retransmit against
-		// CoreDNS (~500 ms default) while keeping app-side lookup
-		// latency bounded if the upstream is hard-down. Tuned to match
-		// the task spec ("~2s"); override via exposed helper in tests.
+		// dnsForwardTimeout is the per-forward deadline for upstream DNS
+		// exchanges. 2 s is long enough to absorb a single UDP retransmit
+		// against CoreDNS (~500 ms default) while keeping app-side lookup
+		// latency bounded if the upstream is hard-down. Tuned to match the
+		// task spec ("~2s"). Tests override by assigning to this field
+		// directly on the Proxy struct; see
+		// pkg/agent/proxy/dns_forward_test.go (newProxyWithUpstream). The
+		// field is package-private, so sibling _test.go files have
+		// legitimate direct access and we intentionally do not expose a
+		// setter helper for a one-line test-only override.
 		dnsForwardTimeout: 2 * time.Second,
 	}
 

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -708,12 +708,15 @@ func (p *Proxy) StartProxy(ctx context.Context, opts agent.ProxyOptions) error {
 	// BEFORE binding our own listener on p.DNSPort. This MUST happen
 	// here (not lazily on first query) because in Kubernetes sidecar
 	// deployments the injector rewrites the app container's resolv.conf
-	// to point at 127.0.0.1:26789 — if we ever pick those up as our
-	// "upstream" we forward queries back to ourselves. The sidecar's
-	// own /etc/resolv.conf still points at CoreDNS at this point, so
-	// the snapshot we take here is the correct set of real upstream
-	// resolvers. Errors are non-fatal: on failure the forwarder
-	// simply falls back to the legacy default response.
+	// nameserver entry to 127.0.0.1 and redirects DNS traffic to the
+	// agent's port 26789 via iptables/eBPF (resolv.conf itself has no
+	// port syntax — standard `nameserver` lines are IP-only). If we
+	// ever pick that loopback entry up as our "upstream" we forward
+	// queries back to ourselves. The sidecar's own /etc/resolv.conf
+	// still points at CoreDNS at this point, so the snapshot we take
+	// here is the correct set of real upstream resolvers. Errors are
+	// non-fatal: on failure the forwarder simply falls back to the
+	// legacy default response.
 	p.captureDNSUpstream()
 
 	// start the TCP DNS server

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -163,6 +163,30 @@ type Proxy struct {
 	// Uses bounded LRU with TTL to prevent unbounded memory growth.
 	recordedDNSMocks *expirable.LRU[string, bool]
 
+	// dnsUpstreamServers is the list of upstream DNS resolver IPs
+	// captured from /etc/resolv.conf ONCE at proxy startup, BEFORE the
+	// DNS server begins listening on p.DNSPort. This snapshot preserves
+	// the original (pre-keploy) cluster resolver addresses (typically
+	// CoreDNS in a Kubernetes pod) so that on a mock miss the
+	// userspace DNS handler can forward queries upstream and return a
+	// real answer for cluster-internal names (e.g.
+	// `mysql.svc.cluster.local`) instead of the proxy's 127.0.0.1
+	// fallback — which would cause the app to attempt DB connections
+	// against the wrong IP.
+	//
+	// Captured via dns.ClientConfigFromFile. Empty when the file is
+	// missing or unparseable; the forwarder falls back to the legacy
+	// synthetic response in that case.
+	dnsUpstreamServers []string
+	// dnsUpstreamPort is the port read alongside dnsUpstreamServers.
+	// Defaults to "53" when resolv.conf does not specify one.
+	dnsUpstreamPort string
+	// dnsForwardTimeout caps how long a single upstream Exchange is
+	// allowed to block. Short by design — a flaky resolver must never
+	// stall the app's DNS lookup. On timeout we fall through to the
+	// legacy default/NXDOMAIN behaviour with a clear log line.
+	dnsForwardTimeout time.Duration
+
 	// isGracefulShutdown indicates the application is shutting down gracefully
 	// When set, connection errors should be logged as debug instead of error
 	isGracefulShutdown atomic.Bool
@@ -450,6 +474,11 @@ func New(logger *zap.Logger, info agent.DestInfo, opts *config.Config) *Proxy {
 		caJavaHome:         opts.Agent.CAJavaHome,
 		dnsCache:           newDNSCache(),
 		recordedDNSMocks:   newRecordedDNSMocksCache(),
+		// 2 s is long enough to absorb a single UDP retransmit against
+		// CoreDNS (~500 ms default) while keeping app-side lookup
+		// latency bounded if the upstream is hard-down. Tuned to match
+		// the task spec ("~2s"); override via exposed helper in tests.
+		dnsForwardTimeout: 2 * time.Second,
 	}
 
 	// Plumb the proxy logger into the package-singleton SyncMockManager
@@ -674,6 +703,18 @@ func (p *Proxy) StartProxy(ctx context.Context, opts agent.ProxyOptions) error {
 	if len(opts.DNSIPv6Addr) != 0 {
 		p.IP6 = opts.DNSIPv6Addr
 	}
+
+	// Capture the ORIGINAL cluster resolver list from /etc/resolv.conf
+	// BEFORE binding our own listener on p.DNSPort. This MUST happen
+	// here (not lazily on first query) because in Kubernetes sidecar
+	// deployments the injector rewrites the app container's resolv.conf
+	// to point at 127.0.0.1:26789 — if we ever pick those up as our
+	// "upstream" we forward queries back to ourselves. The sidecar's
+	// own /etc/resolv.conf still points at CoreDNS at this point, so
+	// the snapshot we take here is the correct set of real upstream
+	// resolvers. Errors are non-fatal: on failure the forwarder
+	// simply falls back to the legacy default response.
+	p.captureDNSUpstream()
 
 	// start the TCP DNS server
 	p.logger.Debug("Starting Tcp Dns Server for handling Dns queries over TCP")

--- a/pkg/service/replay/health_poll_test.go
+++ b/pkg/service/replay/health_poll_test.go
@@ -153,6 +153,49 @@ func TestWaitForAppReady_EmptyURLUsesFixedDelay(t *testing.T) {
 	}
 }
 
+// TestWaitForAppReady_CtxCanceledAtCeiling is the round-3 select-race
+// guard. pollCtx is derived from ctx, so when the parent ctx is canceled
+// at (or after) the poll ceiling both ctx.Done() and pollCtx.Done() are
+// ready simultaneously — Go's select may pick either. If the pollCtx
+// branch wins, the old code fell through to the fixed-delay fallback and
+// returned true, incorrectly letting replay proceed after a user abort.
+// The fix is to check ctx.Err() inside the pollCtx branch and return
+// false when the parent context has been canceled. To reliably exercise
+// that branch we set HealthPollTimeout == cancel delay so the two wakeups
+// are tied; the assertion must hold regardless of which branch select
+// picks.
+func TestWaitForAppReady_CtxCanceledAtCeiling(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	// 50ms poll ceiling + 50ms cancel => both ctx.Done() and
+	// pollCtx.Done() become ready at ~the same moment.
+	cfg := newCfg(srv.URL, 50*time.Millisecond)
+	cfg.Test.Delay = 10 // if the bug regresses, fallback sleep returns true after 10s
+
+	logger := zap.NewNop()
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	ok := waitForAppReady(ctx, logger, cfg)
+	elapsed := time.Since(start)
+
+	if ok {
+		t.Fatalf("expected waitForAppReady to return false on user abort at ceiling boundary, got true (fell through to fallback)")
+	}
+	// If the bug regresses, elapsed would be ~10s (poll ceiling + full
+	// Delay fallback). A comfortable ceiling of 2s catches that.
+	if elapsed > 2*time.Second {
+		t.Fatalf("ctx cancel should abort without fallback sleep; elapsed=%v suggests the fixed-delay branch ran", elapsed)
+	}
+}
+
 // TestWaitForAppReady_CtxCanceled verifies ctx cancellation is honored during
 // the poll loop — caller should see false so it can return TestSetStatusUserAbort.
 func TestWaitForAppReady_CtxCanceled(t *testing.T) {

--- a/pkg/service/replay/health_poll_test.go
+++ b/pkg/service/replay/health_poll_test.go
@@ -1,0 +1,183 @@
+package replay
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"go.keploy.io/server/v3/config"
+)
+
+// newCfg builds a minimal config.Config with the replay/health knobs set.
+// A 1-second --delay fallback keeps the "timeout" test fast.
+func newCfg(healthURL string, pollTimeout time.Duration) *config.Config {
+	cfg := &config.Config{}
+	cfg.Test.Delay = 1
+	cfg.Test.HealthURL = healthURL
+	cfg.Test.HealthPollTimeout = pollTimeout
+	return cfg
+}
+
+// TestWaitForAppReady_200OnFirstTry verifies the happy path: a health endpoint
+// that is up immediately unblocks replay in well under the --delay fallback
+// window (and far under healthPollInterval).
+func TestWaitForAppReady_200OnFirstTry(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := newCfg(srv.URL, 5*time.Second)
+	logger := zap.NewNop()
+
+	start := time.Now()
+	ok := waitForAppReady(context.Background(), logger, cfg)
+	elapsed := time.Since(start)
+
+	if !ok {
+		t.Fatalf("expected waitForAppReady to return true on 200, got false")
+	}
+	if elapsed >= time.Second {
+		t.Fatalf("expected <1s proceed on first-try 200, elapsed=%v", elapsed)
+	}
+}
+
+// TestWaitForAppReady_503ThenOK verifies we honor the poll cadence: after N
+// failing probes the (N+1)th 2xx unblocks replay at roughly N * healthPollInterval
+// wall time (lower bound). This proves the loop is actually retrying rather
+// than short-circuiting.
+func TestWaitForAppReady_503ThenOK(t *testing.T) {
+	const failures int32 = 3
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt32(&hits, 1)
+		if n <= failures {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := newCfg(srv.URL, 10*time.Second)
+	logger := zap.NewNop()
+
+	start := time.Now()
+	ok := waitForAppReady(context.Background(), logger, cfg)
+	elapsed := time.Since(start)
+
+	if !ok {
+		t.Fatalf("expected waitForAppReady to eventually succeed, got false")
+	}
+	// Lower bound: N failing probes are spaced by healthPollInterval each,
+	// so elapsed >= failures * healthPollInterval.
+	minExpected := time.Duration(failures) * healthPollInterval
+	if elapsed < minExpected {
+		t.Fatalf("expected elapsed >= %v (N*500ms) after %d failures, got %v", minExpected, failures, elapsed)
+	}
+	// Upper bound guard: still well below any plausible fallback window.
+	if elapsed > 5*time.Second {
+		t.Fatalf("elapsed %v unexpectedly high; poll loop may be mis-cadenced", elapsed)
+	}
+	if got := atomic.LoadInt32(&hits); got < failures+1 {
+		t.Fatalf("expected at least %d hits, got %d", failures+1, got)
+	}
+}
+
+// TestWaitForAppReady_NeverOK verifies the fallback path: when the health
+// endpoint never returns 2xx we log the WARN and sleep for --delay.
+func TestWaitForAppReady_NeverOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	// Short HealthPollTimeout so the test finishes fast; Delay=1s fallback is the
+	// observable lower bound after the ceiling elapses.
+	cfg := newCfg(srv.URL, 300*time.Millisecond)
+
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	start := time.Now()
+	ok := waitForAppReady(context.Background(), logger, cfg)
+	elapsed := time.Since(start)
+
+	if !ok {
+		t.Fatalf("expected waitForAppReady to proceed via fallback, got false")
+	}
+	// Must have waited at least pollCeiling + fallback Delay.
+	if elapsed < 1200*time.Millisecond {
+		t.Fatalf("expected fallback to wait >=~1.2s (ceiling + delay), got %v", elapsed)
+	}
+
+	found := false
+	for _, entry := range logs.All() {
+		if strings.Contains(entry.Message, "health probe timed out") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected WARN 'health probe timed out' log, entries=%v", logs.All())
+	}
+}
+
+// TestWaitForAppReady_EmptyURLUsesFixedDelay locks in the zero-change default:
+// an empty HealthURL must reproduce the previous time.After(Delay) behavior and
+// never touch the network.
+func TestWaitForAppReady_EmptyURLUsesFixedDelay(t *testing.T) {
+	// Point healthPoller at a stub that would fail the test if called, to
+	// prove the empty-URL branch never invokes the poller.
+	orig := healthPoller
+	healthPoller = func(_ context.Context, _ string) bool {
+		t.Fatalf("healthPoller must not be called when HealthURL is empty")
+		return false
+	}
+	defer func() { healthPoller = orig }()
+
+	cfg := newCfg("", 60*time.Second)
+	cfg.Test.Delay = 0 // keep the test fast; semantics are the same
+	logger := zap.NewNop()
+
+	ok := waitForAppReady(context.Background(), logger, cfg)
+	if !ok {
+		t.Fatalf("expected waitForAppReady to return true in the default path")
+	}
+}
+
+// TestWaitForAppReady_CtxCanceled verifies ctx cancellation is honored during
+// the poll loop — caller should see false so it can return TestSetStatusUserAbort.
+func TestWaitForAppReady_CtxCanceled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	cfg := newCfg(srv.URL, 10*time.Second)
+	logger := zap.NewNop()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	ok := waitForAppReady(ctx, logger, cfg)
+	elapsed := time.Since(start)
+
+	if ok {
+		t.Fatalf("expected waitForAppReady to return false on ctx cancel, got true")
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("ctx cancel should unblock quickly, elapsed=%v", elapsed)
+	}
+}

--- a/pkg/service/replay/health_poll_test.go
+++ b/pkg/service/replay/health_poll_test.go
@@ -77,10 +77,14 @@ func TestWaitForAppReady_503ThenOK(t *testing.T) {
 		t.Fatalf("expected waitForAppReady to eventually succeed, got false")
 	}
 	// Lower bound: N failing probes are spaced by healthPollInterval each,
-	// so elapsed >= failures * healthPollInterval.
-	minExpected := time.Duration(failures) * healthPollInterval
+	// so elapsed >= failures * healthPollInterval. Allow a small tolerance
+	// (50ms) to absorb scheduler jitter and ticker drift in CI — without
+	// it this assertion occasionally fires even when the poll cadence is
+	// correct.
+	const jitterTolerance = 50 * time.Millisecond
+	minExpected := time.Duration(failures)*healthPollInterval - jitterTolerance
 	if elapsed < minExpected {
-		t.Fatalf("expected elapsed >= %v (N*500ms) after %d failures, got %v", minExpected, failures, elapsed)
+		t.Fatalf("expected elapsed >= %v (N*500ms - %v tolerance) after %d failures, got %v", minExpected, jitterTolerance, failures, elapsed)
 	}
 	// Upper bound guard: still well below any plausible fallback window.
 	if elapsed > 5*time.Second {

--- a/pkg/service/replay/health_poll_test.go
+++ b/pkg/service/replay/health_poll_test.go
@@ -200,6 +200,111 @@ func TestWaitForAppReady_CtxCanceledAtCeiling(t *testing.T) {
 	}
 }
 
+// TestWaitForAppReady_MalformedURL_FailsFastOnInvalidURL locks in the
+// fast-fail path for malformed --health-url inputs. Without the URL
+// validation at the top of waitForAppReady, http.NewRequestWithContext
+// inside httpHealthPoll would return an error on every probe and we
+// would burn the entire HealthPollTimeout window (default 60s) plus
+// the fixed Delay before returning — with zero actionable feedback to
+// the operator. The fix: validate scheme + host up front and return
+// immediately so a typo surfaces in milliseconds.
+//
+// To prove we never enter the poll loop we also swap out healthPoller
+// with a stub that fails the test if called; if the pre-loop
+// validation regresses this stub catches it even when the time-based
+// bound would pass for other reasons.
+func TestWaitForAppReady_MalformedURL_FailsFastOnInvalidURL(t *testing.T) {
+	orig := healthPoller
+	healthPoller = func(_ context.Context, _ string) bool {
+		t.Fatalf("healthPoller must not be called when HealthURL is malformed — pre-loop validation should short-circuit")
+		return false
+	}
+	defer func() { healthPoller = orig }()
+
+	// HealthPollTimeout is large on purpose: if the validation regresses
+	// and we fall into the poll loop, elapsed balloons and the <100ms
+	// assertion below fires. Delay is also large so the fallback sleep
+	// (if it ever runs) is visible to the assertion.
+	cfg := newCfg("not-a-url", 30*time.Second)
+	cfg.Test.Delay = 10
+
+	core, logs := observer.New(zap.ErrorLevel)
+	logger := zap.New(core)
+
+	start := time.Now()
+	ok := waitForAppReady(context.Background(), logger, cfg)
+	elapsed := time.Since(start)
+
+	if ok {
+		t.Fatalf("expected waitForAppReady to return false on malformed URL, got true")
+	}
+	// The key win: fail fast. 100ms is generous for an in-process
+	// url.Parse + scheme/host check; anything close to the poll
+	// ceiling or fallback delay indicates the pre-loop guard is gone.
+	if elapsed >= 100*time.Millisecond {
+		t.Fatalf("expected <100ms fast-fail on malformed URL, elapsed=%v (did the validation regress?)", elapsed)
+	}
+
+	// Operator-facing log: must mention --health-url so grepping a CI log
+	// actually tells the operator what to fix. Without this, the failure
+	// mode is "keploy just returned false" with no context.
+	var foundLog bool
+	for _, entry := range logs.All() {
+		if strings.Contains(entry.Message, "invalid --health-url") {
+			foundLog = true
+			break
+		}
+	}
+	if !foundLog {
+		t.Fatalf("expected ERROR log mentioning 'invalid --health-url', entries=%v", logs.All())
+	}
+}
+
+// TestWaitForAppReady_MalformedURL_TableDriven covers the set of
+// malformed inputs we explicitly want to reject at the boundary: no
+// scheme, non-http scheme, empty host after scheme, and outright
+// garbage. Each must return false in well under 100ms. If any one of
+// these slips past validation and into the poll loop, the bug surfaces
+// as either a timeout-sized elapsed or a healthPoller call.
+func TestWaitForAppReady_MalformedURL_TableDriven(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"missing scheme", "localhost:8080/health"},
+		{"bare host no scheme", "example.com"},
+		{"scheme but no host", "http://"},
+		{"ftp scheme not supported", "ftp://example.com/health"},
+		{"garbage", "not a url at all"},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			orig := healthPoller
+			healthPoller = func(_ context.Context, _ string) bool {
+				t.Fatalf("healthPoller must not be called for malformed URL %q", c.url)
+				return false
+			}
+			defer func() { healthPoller = orig }()
+
+			cfg := newCfg(c.url, 10*time.Second)
+			cfg.Test.Delay = 5
+			logger := zap.NewNop()
+
+			start := time.Now()
+			ok := waitForAppReady(context.Background(), logger, cfg)
+			elapsed := time.Since(start)
+
+			if ok {
+				t.Fatalf("expected false for malformed URL %q, got true", c.url)
+			}
+			if elapsed >= 100*time.Millisecond {
+				t.Fatalf("expected <100ms fast-fail for %q, elapsed=%v", c.url, elapsed)
+			}
+		})
+	}
+}
+
 // TestWaitForAppReady_CtxCanceled verifies ctx cancellation is honored during
 // the poll loop — caller should see false so it can return TestSetStatusUserAbort.
 func TestWaitForAppReady_CtxCanceled(t *testing.T) {

--- a/pkg/service/replay/health_poll_test.go
+++ b/pkg/service/replay/health_poll_test.go
@@ -200,33 +200,35 @@ func TestWaitForAppReady_CtxCanceledAtCeiling(t *testing.T) {
 	}
 }
 
-// TestWaitForAppReady_MalformedURL_FailsFastOnInvalidURL locks in the
-// fast-fail path for malformed --health-url inputs. Without the URL
-// validation at the top of waitForAppReady, http.NewRequestWithContext
-// inside httpHealthPoll would return an error on every probe and we
-// would burn the entire HealthPollTimeout window (default 60s) plus
-// the fixed Delay before returning — with zero actionable feedback to
-// the operator. The fix: validate scheme + host up front and return
-// immediately so a typo surfaces in milliseconds.
+// TestWaitForAppReady_MalformedURL_FallsBackToDelay locks in the
+// invalid-URL behavior: the poll is skipped, we log at ERROR so
+// operators see the misconfig, and we fall through to the fixed-delay
+// path (same as an empty HealthURL). Crucially we must NOT return
+// false — callers classify false as TestSetStatusUserAbort +
+// context.Canceled, which would misreport a config typo as a user
+// abort. Instead we return true after sleeping Test.Delay, matching
+// the pre-health-url behavior so replay is never worse than before.
 //
 // To prove we never enter the poll loop we also swap out healthPoller
-// with a stub that fails the test if called; if the pre-loop
-// validation regresses this stub catches it even when the time-based
-// bound would pass for other reasons.
-func TestWaitForAppReady_MalformedURL_FailsFastOnInvalidURL(t *testing.T) {
+// with a stub that fails the test if called; that guards against the
+// validation regressing back into the poll path even if the timing
+// bound happens to pass for unrelated reasons.
+func TestWaitForAppReady_MalformedURL_FallsBackToDelay(t *testing.T) {
 	orig := healthPoller
 	healthPoller = func(_ context.Context, _ string) bool {
-		t.Fatalf("healthPoller must not be called when HealthURL is malformed — pre-loop validation should short-circuit")
+		t.Fatalf("healthPoller must not be called when HealthURL is malformed — validation should fall through to the fixed-delay branch")
 		return false
 	}
 	defer func() { healthPoller = orig }()
 
-	// HealthPollTimeout is large on purpose: if the validation regresses
-	// and we fall into the poll loop, elapsed balloons and the <100ms
-	// assertion below fires. Delay is also large so the fallback sleep
-	// (if it ever runs) is visible to the assertion.
+	// Delay is the observable lower bound for the fallback sleep;
+	// keep it small to keep the test quick but large enough that
+	// scheduler jitter cannot make elapsed land above it by accident.
+	// HealthPollTimeout is large on purpose: if the fallback ever
+	// regresses back into the poll loop, the healthPoller stub above
+	// would catch it first.
 	cfg := newCfg("not-a-url", 30*time.Second)
-	cfg.Test.Delay = 10
+	cfg.Test.Delay = 1
 
 	core, logs := observer.New(zap.ErrorLevel)
 	logger := zap.New(core)
@@ -235,19 +237,21 @@ func TestWaitForAppReady_MalformedURL_FailsFastOnInvalidURL(t *testing.T) {
 	ok := waitForAppReady(context.Background(), logger, cfg)
 	elapsed := time.Since(start)
 
-	if ok {
-		t.Fatalf("expected waitForAppReady to return false on malformed URL, got true")
+	if !ok {
+		t.Fatalf("expected waitForAppReady to return true on malformed URL (falls through to fixed-delay path), got false — callers would misclassify this as user abort")
 	}
-	// The key win: fail fast. 100ms is generous for an in-process
-	// url.Parse + scheme/host check; anything close to the poll
-	// ceiling or fallback delay indicates the pre-loop guard is gone.
-	if elapsed >= 100*time.Millisecond {
-		t.Fatalf("expected <100ms fast-fail on malformed URL, elapsed=%v (did the validation regress?)", elapsed)
+	// Lower bound: we must have actually slept Test.Delay seconds.
+	// Allow a small jitter tolerance so ticker/timer drift doesn't
+	// make this flake on loaded CI runners.
+	const jitterTolerance = 50 * time.Millisecond
+	minExpected := time.Duration(cfg.Test.Delay)*time.Second - jitterTolerance
+	if elapsed < minExpected {
+		t.Fatalf("expected elapsed >= %v (Delay fallback), got %v — did we skip the fixed-delay sleep?", minExpected, elapsed)
 	}
 
 	// Operator-facing log: must mention --health-url so grepping a CI log
 	// actually tells the operator what to fix. Without this, the failure
-	// mode is "keploy just returned false" with no context.
+	// mode is "keploy silently ran fixed delay" with no context.
 	var foundLog bool
 	for _, entry := range logs.All() {
 		if strings.Contains(entry.Message, "invalid --health-url") {
@@ -263,9 +267,10 @@ func TestWaitForAppReady_MalformedURL_FailsFastOnInvalidURL(t *testing.T) {
 // TestWaitForAppReady_MalformedURL_TableDriven covers the set of
 // malformed inputs we explicitly want to reject at the boundary: no
 // scheme, non-http scheme, empty host after scheme, and outright
-// garbage. Each must return false in well under 100ms. If any one of
-// these slips past validation and into the poll loop, the bug surfaces
-// as either a timeout-sized elapsed or a healthPoller call.
+// garbage. Each must fall through to the fixed-delay branch (return
+// true, sleep Test.Delay, never invoke the poller) rather than
+// returning false — callers classify false as user abort, so a
+// misconfigured URL must NOT be reported that way.
 func TestWaitForAppReady_MalformedURL_TableDriven(t *testing.T) {
 	cases := []struct {
 		name string
@@ -288,18 +293,20 @@ func TestWaitForAppReady_MalformedURL_TableDriven(t *testing.T) {
 			defer func() { healthPoller = orig }()
 
 			cfg := newCfg(c.url, 10*time.Second)
-			cfg.Test.Delay = 5
+			// Delay=0 keeps the table fast; the empty-URL/fixed-delay
+			// branch still returns true on an immediately-fired
+			// time.After(0), which is exactly what we want to assert
+			// here. The "did we actually sleep Test.Delay" lower-bound
+			// check lives in the dedicated test above; this table's
+			// job is to exhaustively prove every malformed shape
+			// routes to the fixed-delay branch and returns true.
+			cfg.Test.Delay = 0
 			logger := zap.NewNop()
 
-			start := time.Now()
 			ok := waitForAppReady(context.Background(), logger, cfg)
-			elapsed := time.Since(start)
 
-			if ok {
-				t.Fatalf("expected false for malformed URL %q, got true", c.url)
-			}
-			if elapsed >= 100*time.Millisecond {
-				t.Fatalf("expected <100ms fast-fail for %q, elapsed=%v", c.url, elapsed)
+			if !ok {
+				t.Fatalf("expected true (fall through to fixed-delay) for malformed URL %q, got false — callers would misclassify this as user abort", c.url)
 			}
 		})
 	}

--- a/pkg/service/replay/health_poll_test.go
+++ b/pkg/service/replay/health_poll_test.go
@@ -92,7 +92,7 @@ func TestWaitForAppReady_503ThenOK(t *testing.T) {
 }
 
 // TestWaitForAppReady_NeverOK verifies the fallback path: when the health
-// endpoint never returns 2xx we log the WARN and sleep for --delay.
+// endpoint never returns 2xx we log at INFO and sleep for --delay.
 func TestWaitForAppReady_NeverOK(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -103,7 +103,7 @@ func TestWaitForAppReady_NeverOK(t *testing.T) {
 	// observable lower bound after the ceiling elapses.
 	cfg := newCfg(srv.URL, 300*time.Millisecond)
 
-	core, logs := observer.New(zap.WarnLevel)
+	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
 
 	start := time.Now()
@@ -126,7 +126,7 @@ func TestWaitForAppReady_NeverOK(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Fatalf("expected WARN 'health probe timed out' log, entries=%v", logs.All())
+		t.Fatalf("expected INFO 'health probe timed out' log, entries=%v", logs.All())
 	}
 }
 

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1054,10 +1054,9 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			utils.LogError(r.logger, err, "Failed to make the request to make agent ready for the docker compose")
 		}
 
-		// Delay for user application to run
-		select {
-		case <-time.After(time.Duration(r.config.Test.Delay) * time.Second):
-		case <-runTestSetCtx.Done():
+		// Wait for the user application to become ready before firing the first test.
+		// Prefers polling Test.HealthURL when set, otherwise falls back to the fixed --delay sleep.
+		if !waitForAppReady(runTestSetCtx, r.logger, r.config) {
 			return models.TestSetStatusUserAbort, context.Canceled
 		}
 	}
@@ -1199,10 +1198,9 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 				return nil
 			})
 
-			// Delay for user application to run
-			select {
-			case <-time.After(time.Duration(r.config.Test.Delay) * time.Second):
-			case <-runTestSetCtx.Done():
+			// Wait for the user application to become ready before firing the first test.
+			// Prefers polling Test.HealthURL when set, otherwise falls back to the fixed --delay sleep.
+			if !waitForAppReady(runTestSetCtx, r.logger, r.config) {
 				return models.TestSetStatusUserAbort, context.Canceled
 			}
 

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -70,9 +70,10 @@ func httpHealthPoll(ctx context.Context, url string) bool {
 // elapses with no 2xx, we log an INFO telling the operator what to tune and fall
 // back to the fixed Delay sleep so operators never get stuck worse than today.
 //
-// The poll cadence uses a single time.Ticker plus a single time.Timer for the
-// ceiling (pattern: pkg/util.go WaitForPort). This avoids per-iteration timer
-// allocation from time.After and gives deterministic teardown via defer Stop.
+// The poll cadence uses a single time.Ticker, and the overall poll ceiling is
+// enforced by a derived context with timeout observed through Done(). This
+// avoids per-iteration timer allocation from time.After and gives deterministic
+// teardown via defer Stop / defer cancel.
 //
 // Returns true when the caller should proceed to run tests, false only when ctx
 // was canceled (caller should treat as user abort).
@@ -130,11 +131,20 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 			// fallback-to-fixed-delay path.
 			return false
 		case <-pollCtx.Done():
-			// pollCeiling elapsed with no 2xx. If ctx was also canceled we
-			// would have taken the branch above; reaching here means the
-			// deadline fired on its own. Downgraded from Warn per repo
-			// logging guidelines; the message still tells operators exactly
-			// which knobs to turn.
+			// pollCtx is derived from ctx, so a user cancel also fires
+			// this branch. Since select picks a ready case
+			// non-deterministically, we cannot rely on the ctx.Done()
+			// branch above to win the race — explicitly disambiguate
+			// here. If the parent ctx is canceled we treat the wakeup
+			// as a user abort and return false instead of falling
+			// through to the fixed-delay fallback (which would return
+			// true and incorrectly proceed to run tests).
+			if ctx.Err() != nil {
+				return false
+			}
+			// pollCeiling elapsed with no 2xx. Downgraded from Warn per
+			// repo logging guidelines; the message still tells operators
+			// exactly which knobs to turn.
 			logger.Info("health probe timed out, falling back to fixed delay — raise --health-poll-timeout (or test.healthPollTimeout in keploy.yml) or point --health-url at an endpoint that returns 2xx sooner",
 				zap.String("healthUrl", cfg.Test.HealthURL),
 				zap.Duration("pollTimeout", pollCeiling),

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -60,6 +60,29 @@ func httpHealthPoll(ctx context.Context, url string) bool {
 	return resp.StatusCode >= 200 && resp.StatusCode < 300
 }
 
+// sanitizeHealthURL returns a log-safe rendering of a --health-url value.
+// The raw string is operator-supplied and can legitimately carry secrets:
+// basic-auth userinfo (e.g. https://user:pw@host/healthz), API tokens in
+// the query string (...?token=abc), or session fragments. Emitting any of
+// those to zap fields would leak them into structured log sinks, tailing
+// aggregators, and error-reporting backends. We strip userinfo, query,
+// and fragment; scheme + host + path is enough signal to diagnose a
+// misconfigured poll target.
+//
+// On unparseable input we return a fixed placeholder — the operator
+// already gets the raw reason via the separate "reason" field in the
+// invalid-URL Error log, so we don't need to echo the raw string back.
+func sanitizeHealthURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u == nil {
+		return "<unparseable-health-url-redacted>"
+	}
+	u.User = nil
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
+}
+
 // validateHealthURL checks that s is a syntactically usable HTTP(S) URL for
 // http.NewRequestWithContext — i.e. it has a scheme of http or https and a
 // non-empty host. We intentionally keep validation purely syntactic: no DNS
@@ -134,9 +157,9 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 	if healthURL != "" {
 		if reason, ok := validateHealthURL(healthURL); !ok {
 			logger.Error("invalid --health-url; falling back to fixed delay",
-				zap.String("healthUrl", healthURL),
+				zap.String("healthUrl", sanitizeHealthURL(healthURL)),
 				zap.String("reason", reason),
-				zap.String("next_step", "--health-url must be a full URL with scheme (http:// or https://) and host; got "+fmt.Sprintf("%q", healthURL)+" — fix it or omit to use --delay only"),
+				zap.String("next_step", "--health-url must be a full URL with scheme (http:// or https://) and host — fix it or omit to use --delay only"),
 			)
 			healthURL = "" // fall through to the empty-URL / fixed-delay branch below
 		}
@@ -162,7 +185,7 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 	}
 
 	logger.Info("polling application health endpoint before firing tests",
-		zap.String("healthUrl", cfg.Test.HealthURL),
+		zap.String("healthUrl", sanitizeHealthURL(cfg.Test.HealthURL)),
 		zap.Duration("pollTimeout", pollCeiling),
 	)
 
@@ -182,7 +205,7 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 	// first attempt is bounded by the remaining poll ceiling.
 	if healthPoller(pollCtx, cfg.Test.HealthURL) {
 		logger.Debug("health endpoint reported 2xx; proceeding",
-			zap.String("healthUrl", cfg.Test.HealthURL),
+			zap.String("healthUrl", sanitizeHealthURL(cfg.Test.HealthURL)),
 		)
 		return true
 	}
@@ -213,7 +236,7 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 			// repo logging guidelines; the message still tells operators
 			// exactly which knobs to turn.
 			logger.Info("health probe timed out, falling back to fixed delay — raise --health-poll-timeout (or test.healthPollTimeout in keploy.yml) or point --health-url at an endpoint that returns 2xx sooner",
-				zap.String("healthUrl", cfg.Test.HealthURL),
+				zap.String("healthUrl", sanitizeHealthURL(cfg.Test.HealthURL)),
 				zap.Duration("pollTimeout", pollCeiling),
 				zap.Duration("fallbackDelay", delay),
 			)
@@ -228,7 +251,7 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 		case <-ticker.C:
 			if healthPoller(pollCtx, cfg.Test.HealthURL) {
 				logger.Debug("health endpoint reported 2xx; proceeding",
-					zap.String("healthUrl", cfg.Test.HealthURL),
+					zap.String("healthUrl", sanitizeHealthURL(cfg.Test.HealthURL)),
 				)
 				return true
 			}

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -143,8 +143,13 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 	}
 
 	if healthURL == "" {
+		// NewTimer + defer Stop so a ctx cancel releases the timer
+		// immediately instead of leaving it scheduled until `delay`
+		// fires — matters under large --delay and repeated aborts.
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
 		select {
-		case <-time.After(delay):
+		case <-timer.C:
 			return true
 		case <-ctx.Done():
 			return false
@@ -212,8 +217,10 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 				zap.Duration("pollTimeout", pollCeiling),
 				zap.Duration("fallbackDelay", delay),
 			)
+			fallbackTimer := time.NewTimer(delay)
+			defer fallbackTimer.Stop()
 			select {
-			case <-time.After(delay):
+			case <-fallbackTimer.C:
 				return true
 			case <-ctx.Done():
 				return false

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -136,7 +136,7 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 			logger.Error("invalid --health-url; falling back to fixed delay",
 				zap.String("healthUrl", healthURL),
 				zap.String("reason", reason),
-				zap.String("nextStep", "--health-url must be a full URL with scheme (http:// or https://) and host; got "+fmt.Sprintf("%q", healthURL)+" — fix it or omit to use --delay only"),
+				zap.String("next_step", "--health-url must be a full URL with scheme (http:// or https://) and host; got "+fmt.Sprintf("%q", healthURL)+" — fix it or omit to use --delay only"),
 			)
 			healthURL = "" // fall through to the empty-URL / fixed-delay branch below
 		}

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -98,9 +98,21 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 		zap.Duration("pollTimeout", pollCeiling),
 	)
 
+	// Derive a single deadline ctx for the ENTIRE poll window. This is what
+	// makes pollCeiling a true upper bound: every probe — including the
+	// immediate one below and each ticker-driven retry — inherits the
+	// remaining ceiling via context. httpHealthPoll still applies its own
+	// healthProbeTimeout per request, but context.WithTimeout takes whichever
+	// expires first, so a small pollCeiling (e.g. 100ms) cannot be exceeded
+	// by a probe's 1s per-request cap. We keep the caller ctx as the parent
+	// so user-initiated cancel still unblocks instantly.
+	pollCtx, pollCancel := context.WithTimeout(ctx, pollCeiling)
+	defer pollCancel()
+
 	// Probe once immediately so a fast-ready app doesn't pay the first tick's
-	// healthPollInterval of latency.
-	if healthPoller(ctx, cfg.Test.HealthURL) {
+	// healthPollInterval of latency. The probe inherits pollCtx, so even this
+	// first attempt is bounded by the remaining poll ceiling.
+	if healthPoller(pollCtx, cfg.Test.HealthURL) {
 		logger.Debug("health endpoint reported 2xx; proceeding",
 			zap.String("healthUrl", cfg.Test.HealthURL),
 		)
@@ -109,18 +121,21 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 
 	ticker := time.NewTicker(healthPollInterval)
 	defer ticker.Stop()
-	ceiling := time.NewTimer(pollCeiling)
-	defer ceiling.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
+			// Parent ctx canceled by the user — treat as abort, distinct
+			// from the pollCtx deadline branch below which is a normal
+			// fallback-to-fixed-delay path.
 			return false
-		case <-ceiling.C:
-			// Health probe never returned 2xx inside pollCeiling. Downgraded
-			// from Warn per repo logging guidelines; the message still tells
-			// operators exactly which knobs to turn.
-			logger.Info("health probe timed out, falling back to fixed delay — set KEPLOY_HEALTH_URL to an endpoint that returns 2xx sooner, or raise --health-poll-timeout",
+		case <-pollCtx.Done():
+			// pollCeiling elapsed with no 2xx. If ctx was also canceled we
+			// would have taken the branch above; reaching here means the
+			// deadline fired on its own. Downgraded from Warn per repo
+			// logging guidelines; the message still tells operators exactly
+			// which knobs to turn.
+			logger.Info("health probe timed out, falling back to fixed delay — raise --health-poll-timeout (or test.healthPollTimeout in keploy.yml) or point --health-url at an endpoint that returns 2xx sooner",
 				zap.String("healthUrl", cfg.Test.HealthURL),
 				zap.Duration("pollTimeout", pollCeiling),
 				zap.Duration("fallbackDelay", delay),
@@ -132,7 +147,7 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 				return false
 			}
 		case <-ticker.C:
-			if healthPoller(ctx, cfg.Test.HealthURL) {
+			if healthPoller(pollCtx, cfg.Test.HealthURL) {
 				logger.Debug("health endpoint reported 2xx; proceeding",
 					zap.String("healthUrl", cfg.Test.HealthURL),
 				)

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -3,6 +3,7 @@ package replay
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -34,6 +35,12 @@ var healthPoller = httpHealthPoll
 // httpHealthPoll issues a single GET to url with a short per-request timeout and reports
 // whether it returned a 2xx status. Non-2xx, transport errors, and timeouts all report false;
 // the caller decides whether to retry.
+//
+// The response body is fully drained (io.Copy to io.Discard) before Close so the underlying
+// TCP connection can be returned to the DefaultClient's keep-alive pool and reused by the
+// next poll iteration. Without the drain, net/http treats the connection as dirty and opens
+// a new socket every 500ms, which is pure overhead against an endpoint we are going to hit
+// many times in a row.
 func httpHealthPoll(ctx context.Context, url string) bool {
 	reqCtx, cancel := context.WithTimeout(ctx, healthProbeTimeout)
 	defer cancel()
@@ -45,7 +52,11 @@ func httpHealthPoll(ctx context.Context, url string) bool {
 	if err != nil {
 		return false
 	}
-	defer resp.Body.Close()
+	defer func() {
+		// Drain first, then close — enables HTTP keep-alive reuse across poll iterations.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
 	return resp.StatusCode >= 200 && resp.StatusCode < 300
 }
 
@@ -56,8 +67,12 @@ func httpHealthPoll(ctx context.Context, url string) bool {
 //
 // Otherwise we poll HealthURL every healthPollInterval (with a per-request cap
 // of healthProbeTimeout). The first 2xx unblocks immediately. If HealthPollTimeout
-// elapses with no 2xx, we log a WARN and fall back to the fixed Delay sleep so
-// operators never get stuck worse than today.
+// elapses with no 2xx, we log an INFO telling the operator what to tune and fall
+// back to the fixed Delay sleep so operators never get stuck worse than today.
+//
+// The poll cadence uses a single time.Ticker plus a single time.Timer for the
+// ceiling (pattern: pkg/util.go WaitForPort). This avoids per-iteration timer
+// allocation from time.After and gives deterministic teardown via defer Stop.
 //
 // Returns true when the caller should proceed to run tests, false only when ctx
 // was canceled (caller should treat as user abort).
@@ -77,22 +92,35 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 	if pollCeiling <= 0 {
 		pollCeiling = 60 * time.Second
 	}
-	deadline := time.Now().Add(pollCeiling)
 
 	logger.Info("polling application health endpoint before firing tests",
 		zap.String("healthUrl", cfg.Test.HealthURL),
 		zap.Duration("pollTimeout", pollCeiling),
 	)
 
+	// Probe once immediately so a fast-ready app doesn't pay the first tick's
+	// healthPollInterval of latency.
+	if healthPoller(ctx, cfg.Test.HealthURL) {
+		logger.Debug("health endpoint reported 2xx; proceeding",
+			zap.String("healthUrl", cfg.Test.HealthURL),
+		)
+		return true
+	}
+
+	ticker := time.NewTicker(healthPollInterval)
+	defer ticker.Stop()
+	ceiling := time.NewTimer(pollCeiling)
+	defer ceiling.Stop()
+
 	for {
-		if healthPoller(ctx, cfg.Test.HealthURL) {
-			logger.Debug("health endpoint reported 2xx; proceeding",
-				zap.String("healthUrl", cfg.Test.HealthURL),
-			)
-			return true
-		}
-		if time.Now().After(deadline) {
-			logger.Warn("health probe timed out, falling back to fixed delay",
+		select {
+		case <-ctx.Done():
+			return false
+		case <-ceiling.C:
+			// Health probe never returned 2xx inside pollCeiling. Downgraded
+			// from Warn per repo logging guidelines; the message still tells
+			// operators exactly which knobs to turn.
+			logger.Info("health probe timed out, falling back to fixed delay — set KEPLOY_HEALTH_URL to an endpoint that returns 2xx sooner, or raise --health-poll-timeout",
 				zap.String("healthUrl", cfg.Test.HealthURL),
 				zap.Duration("pollTimeout", pollCeiling),
 				zap.Duration("fallbackDelay", delay),
@@ -103,11 +131,13 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 			case <-ctx.Done():
 				return false
 			}
-		}
-		select {
-		case <-time.After(healthPollInterval):
-		case <-ctx.Done():
-			return false
+		case <-ticker.C:
+			if healthPoller(ctx, cfg.Test.HealthURL) {
+				logger.Debug("health endpoint reported 2xx; proceeding",
+					zap.String("healthUrl", cfg.Test.HealthURL),
+				)
+				return true
+			}
 		}
 	}
 }

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -90,8 +90,11 @@ func validateHealthURL(s string) (string, bool) {
 
 // waitForAppReady gates the first test on the user-application being up.
 //
-// If Test.HealthURL is empty we keep the historical behavior exactly: sleep for
-// Test.Delay seconds or until ctx is canceled.
+// If Test.HealthURL is empty (or syntactically invalid) we keep the historical
+// behavior exactly: sleep for Test.Delay seconds or until ctx is canceled. An
+// invalid HealthURL also logs at ERROR so operators see the misconfig, but it
+// is NOT a fatal failure — the fixed-delay path runs so replay never regresses
+// vs the pre-health-url behavior.
 //
 // Otherwise we poll HealthURL every healthPollInterval (with a per-request cap
 // of healthProbeTimeout). The first 2xx unblocks immediately. If HealthPollTimeout
@@ -104,20 +107,15 @@ func validateHealthURL(s string) (string, bool) {
 // teardown via defer Stop / defer cancel.
 //
 // Returns true when the caller should proceed to run tests, false only when ctx
-// was canceled (caller should treat as user abort).
+// was canceled (caller should treat as user abort). Specifically, an invalid
+// HealthURL does NOT cause a false return — callers rely on this contract to
+// disambiguate user abort from misconfiguration (see replay.go classification).
 func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config) bool {
 	delay := time.Duration(cfg.Test.Delay) * time.Second
 
-	if cfg.Test.HealthURL == "" {
-		select {
-		case <-time.After(delay):
-			return true
-		case <-ctx.Done():
-			return false
-		}
-	}
+	healthURL := cfg.Test.HealthURL
 
-	// Fail fast on a malformed --health-url instead of burning the entire
+	// Fail gracefully on a malformed --health-url instead of burning the entire
 	// HealthPollTimeout window on http.NewRequestWithContext errors that
 	// will never succeed. Common mistakes: missing scheme ("localhost:8080"),
 	// stray whitespace, "not-a-url". net/url.Parse is deliberately lenient,
@@ -125,13 +123,32 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 	// what net/http's transport actually needs to dial. No DNS, no dial here:
 	// just syntactic validation so the operator gets actionable feedback now
 	// rather than after 60s of silent retries.
-	if reason, ok := validateHealthURL(cfg.Test.HealthURL); !ok {
-		logger.Error("invalid --health-url; skipping health probe",
-			zap.String("healthUrl", cfg.Test.HealthURL),
-			zap.String("reason", reason),
-			zap.String("nextStep", "--health-url must be a full URL with scheme (http:// or https://) and host; got "+fmt.Sprintf("%q", cfg.Test.HealthURL)),
-		)
-		return false
+	//
+	// On invalid URL we fall back to the fixed-delay path (same as the
+	// empty-URL branch) rather than returning false. Returning false here
+	// would be classified by callers as TestSetStatusUserAbort + context
+	// cancellation, which is a behavior regression vs the pre-health-url
+	// fixed-delay sleep. The ERROR log still fires so operators see the
+	// misconfig, and the contract of "false only on ctx cancel" stays
+	// truthful for callers (see replay.go classification of the return).
+	if healthURL != "" {
+		if reason, ok := validateHealthURL(healthURL); !ok {
+			logger.Error("invalid --health-url; falling back to fixed delay",
+				zap.String("healthUrl", healthURL),
+				zap.String("reason", reason),
+				zap.String("nextStep", "--health-url must be a full URL with scheme (http:// or https://) and host; got "+fmt.Sprintf("%q", healthURL)+" — fix it or omit to use --delay only"),
+			)
+			healthURL = "" // fall through to the empty-URL / fixed-delay branch below
+		}
+	}
+
+	if healthURL == "" {
+		select {
+		case <-time.After(delay):
+			return true
+		case <-ctx.Done():
+			return false
+		}
 	}
 
 	pollCeiling := cfg.Test.HealthPollTimeout

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -60,6 +60,34 @@ func httpHealthPoll(ctx context.Context, url string) bool {
 	return resp.StatusCode >= 200 && resp.StatusCode < 300
 }
 
+// validateHealthURL checks that s is a syntactically usable HTTP(S) URL for
+// http.NewRequestWithContext — i.e. it has a scheme of http or https and a
+// non-empty host. We intentionally keep validation purely syntactic: no DNS
+// resolution, no TCP dial, no HEAD probe. The poll loop is what actually
+// confirms reachability; this function only exists to fail fast on operator
+// typos (missing scheme, "not-a-url", stray whitespace) so we don't burn the
+// whole HealthPollTimeout window on errors that will never succeed.
+//
+// Returns ("", true) when the URL is usable, and (reason, false) otherwise
+// with a short human-readable reason the caller can surface to the operator.
+func validateHealthURL(s string) (string, bool) {
+	u, err := url.Parse(s)
+	if err != nil {
+		return err.Error(), false
+	}
+	switch u.Scheme {
+	case "http", "https":
+	case "":
+		return "missing scheme (expected http:// or https://)", false
+	default:
+		return "unsupported scheme " + fmt.Sprintf("%q", u.Scheme) + " (expected http or https)", false
+	}
+	if u.Host == "" {
+		return "missing host", false
+	}
+	return "", true
+}
+
 // waitForAppReady gates the first test on the user-application being up.
 //
 // If Test.HealthURL is empty we keep the historical behavior exactly: sleep for
@@ -87,6 +115,23 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 		case <-ctx.Done():
 			return false
 		}
+	}
+
+	// Fail fast on a malformed --health-url instead of burning the entire
+	// HealthPollTimeout window on http.NewRequestWithContext errors that
+	// will never succeed. Common mistakes: missing scheme ("localhost:8080"),
+	// stray whitespace, "not-a-url". net/url.Parse is deliberately lenient,
+	// so we also require a non-empty scheme (http/https) and host — matching
+	// what net/http's transport actually needs to dial. No DNS, no dial here:
+	// just syntactic validation so the operator gets actionable feedback now
+	// rather than after 60s of silent retries.
+	if reason, ok := validateHealthURL(cfg.Test.HealthURL); !ok {
+		logger.Error("invalid --health-url; skipping health probe",
+			zap.String("healthUrl", cfg.Test.HealthURL),
+			zap.String("reason", reason),
+			zap.String("nextStep", "--health-url must be a full URL with scheme (http:// or https://) and host; got "+fmt.Sprintf("%q", cfg.Test.HealthURL)),
+		)
+		return false
 	}
 
 	pollCeiling := cfg.Test.HealthPollTimeout

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -1,7 +1,9 @@
 package replay
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"path"
@@ -12,12 +14,103 @@ import (
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/olekukonko/tablewriter/tw"
+	"go.uber.org/zap"
 
 	// "encoding/json"
 	"go.keploy.io/server/v3/config"
 	"go.keploy.io/server/v3/pkg"
 	"go.keploy.io/server/v3/pkg/models"
 )
+
+// healthPollInterval is how often the --health-url probe is retried while waiting for 2xx.
+const healthPollInterval = 500 * time.Millisecond
+
+// healthProbeTimeout bounds a single GET attempt to --health-url.
+const healthProbeTimeout = 1 * time.Second
+
+// healthPoller is swapped out in tests; production wires to net/http via httpHealthPoll.
+var healthPoller = httpHealthPoll
+
+// httpHealthPoll issues a single GET to url with a short per-request timeout and reports
+// whether it returned a 2xx status. Non-2xx, transport errors, and timeouts all report false;
+// the caller decides whether to retry.
+func httpHealthPoll(ctx context.Context, url string) bool {
+	reqCtx, cancel := context.WithTimeout(ctx, healthProbeTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, url, nil)
+	if err != nil {
+		return false
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+// waitForAppReady gates the first test on the user-application being up.
+//
+// If Test.HealthURL is empty we keep the historical behavior exactly: sleep for
+// Test.Delay seconds or until ctx is canceled.
+//
+// Otherwise we poll HealthURL every healthPollInterval (with a per-request cap
+// of healthProbeTimeout). The first 2xx unblocks immediately. If HealthPollTimeout
+// elapses with no 2xx, we log a WARN and fall back to the fixed Delay sleep so
+// operators never get stuck worse than today.
+//
+// Returns true when the caller should proceed to run tests, false only when ctx
+// was canceled (caller should treat as user abort).
+func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config) bool {
+	delay := time.Duration(cfg.Test.Delay) * time.Second
+
+	if cfg.Test.HealthURL == "" {
+		select {
+		case <-time.After(delay):
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
+
+	pollCeiling := cfg.Test.HealthPollTimeout
+	if pollCeiling <= 0 {
+		pollCeiling = 60 * time.Second
+	}
+	deadline := time.Now().Add(pollCeiling)
+
+	logger.Info("polling application health endpoint before firing tests",
+		zap.String("healthUrl", cfg.Test.HealthURL),
+		zap.Duration("pollTimeout", pollCeiling),
+	)
+
+	for {
+		if healthPoller(ctx, cfg.Test.HealthURL) {
+			logger.Debug("health endpoint reported 2xx; proceeding",
+				zap.String("healthUrl", cfg.Test.HealthURL),
+			)
+			return true
+		}
+		if time.Now().After(deadline) {
+			logger.Warn("health probe timed out, falling back to fixed delay",
+				zap.String("healthUrl", cfg.Test.HealthURL),
+				zap.Duration("pollTimeout", pollCeiling),
+				zap.Duration("fallbackDelay", delay),
+			)
+			select {
+			case <-time.After(delay):
+				return true
+			case <-ctx.Done():
+				return false
+			}
+		}
+		select {
+		case <-time.After(healthPollInterval):
+		case <-ctx.Done():
+			return false
+		}
+	}
+}
 
 type TestReportVerdict struct {
 	total     int


### PR DESCRIPTION
## Consolidates
| Original PR | Description |
|---|---|
| #4111 | case-insensitive noise-key match in SubstringKeyMatch |
| #4115 | agent/dns forward on miss to cluster resolver |
| #4117 | persist chunked captures instead of skipping |
| #4118 | replay --health-url poll instead of fixed delay |

All merged via `--no-ff` onto a fresh branch off main. `go build ./...` + `go vet ./...` clean; targeted `go test` on matcher/incoming/replay all green.

Note: #4116 (Windows ssh-keyscan hardcoded keys) and #4119 (release.yml idempotent publish) already landed on main independently. #4111 also landed independently; this PR now carries only #4115 + #4117 + #4118 after a rebase onto post-#4111 main.

## After this merges
Close #4115, #4117, #4118 pointing at this PR.
