### PR TITLE
fix(supervisor): route V2 EmitMock via syncMock for session-window buffer

### DIFF
--- a/pkg/agent/proxy/proxy_v2.go
+++ b/pkg/agent/proxy/proxy_v2.go
@@ -88,6 +88,16 @@ func (p *Proxy) recordViaSupervisor(
 		DestConnID:       fmt.Sprint(destConnID),
 		Opts:             opts,
 		OnPendingCleared: sv.ClearPendingWork,
+		// Route EmitMock through syncMock.AddMock so V2 parsers pick
+		// up the same firstReqSeen session-window buffering, lifetime
+		// derivation, and drop accounting that legacy parsers (http,
+		// mysql, generic) get. Without this, V2-recorded mocks
+		// captured before the first app test request bypass the
+		// session window and are lost at replay — the symptom that
+		// broke postgres e2e record-build-replay-build runs in
+		// integrations#133 (the app's startup DB queries never found
+		// their mocks).
+		RouteMocksViaSyncMock: true,
 		// Legacy fields kept populated so a migrated parser can still
 		// consult them for fields we haven't promoted yet. The parser
 		// must not touch Ingress/Egress net.Conn values on the V2 path.

--- a/pkg/agent/proxy/proxy_v2.go
+++ b/pkg/agent/proxy/proxy_v2.go
@@ -88,8 +88,9 @@ func (p *Proxy) recordViaSupervisor(
 		DestConnID:       fmt.Sprint(destConnID),
 		Opts:             opts,
 		OnPendingCleared: sv.ClearPendingWork,
-		// Route EmitMock through syncMock.AddMock so V2 parsers pick
-		// up the same firstReqSeen session-window buffering, lifetime
+		// Route EmitMock through the SyncMockManager (obtained via
+		// syncMock.Get(), then mgr.AddMock) so V2 parsers pick up the
+		// same firstReqSeen session-window buffering, lifetime
 		// derivation, and drop accounting that legacy parsers (http,
 		// mysql, generic) get. Without this, V2-recorded mocks
 		// captured before the first app test request bypass the

--- a/pkg/agent/proxy/supervisor/session.go
+++ b/pkg/agent/proxy/supervisor/session.go
@@ -9,6 +9,7 @@ import (
 
 	"go.keploy.io/server/v3/pkg/agent/proxy/directive"
 	"go.keploy.io/server/v3/pkg/agent/proxy/fakeconn"
+	syncMock "go.keploy.io/server/v3/pkg/agent/proxy/syncMock"
 	"go.keploy.io/server/v3/pkg/models"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -123,6 +124,24 @@ type Session struct {
 	// Typically wired to supervisor.ClearPendingWork by the dispatcher.
 	// Nil is safe.
 	OnPendingCleared func()
+
+	// RouteMocksViaSyncMock, when true, makes EmitMock deliver the
+	// mock via the package-singleton syncMock.SyncMockManager
+	// (AddMock) instead of directly sending on s.Mocks. Production
+	// recordViaSupervisor sets this to true so the V2 path gets the
+	// same firstReqSeen session-window buffering, lifetime
+	// derivation, and drop accounting that legacy parsers enjoy —
+	// without it, V2-recorded mocks captured before the first app
+	// test request fall outside the session window and are lost at
+	// replay.
+	//
+	// Tests that wire a bare mocks channel and want to observe the
+	// emitted mocks directly should leave this false (default) so
+	// the direct-channel fallback below still fires. The two paths
+	// both run the OnMockRecorded hook chain and the ClientConnID
+	// / monotonic-timestamp normalisation — they only differ on the
+	// final handoff.
+	RouteMocksViaSyncMock bool
 
 	// --- Internal bookkeeping ---
 
@@ -249,6 +268,35 @@ func (s *Session) EmitMock(m *models.Mock) error {
 	s.hookMu.Unlock()
 	if hook != nil {
 		hook(m)
+	}
+
+	// Route through the package-singleton SyncMockManager when the
+	// caller opts in. Legacy parsers (http, mysql, generic, etc.)
+	// call syncMock.AddMock because it does:
+	//
+	//   1. Lifetime derivation from Metadata["type"] (session vs
+	//      per-test), stamped onto TestModeInfo.Lifetime.
+	//   2. firstReqSeen buffering — mocks captured BEFORE the first
+	//      app test request are treated as "session" scope and
+	//      re-delivered on every replay; mocks after belong to the
+	//      currently-active test window. Dispatchers that skip this
+	//      will emit per-test mocks even for startup-phase traffic,
+	//      and replay against a recording loses them because the
+	//      session window is empty.
+	//   3. Memory-pause gating and drop counters.
+	//
+	// Tests that wire a bare s.Mocks channel and want to observe
+	// emitted mocks directly leave RouteMocksViaSyncMock false so
+	// the direct-channel fallback below runs. Production
+	// recordViaSupervisor sets it true.
+	if s.RouteMocksViaSyncMock {
+		if mgr := syncMock.Get(); mgr != nil {
+			mgr.AddMock(m)
+			if s.OnPendingCleared != nil {
+				s.OnPendingCleared()
+			}
+			return nil
+		}
 	}
 
 	if s.Mocks == nil {

--- a/pkg/agent/proxy/supervisor/session.go
+++ b/pkg/agent/proxy/supervisor/session.go
@@ -218,9 +218,29 @@ func (s *Session) IsMockIncomplete() bool {
 // is dropped on the floor and the incomplete flag is cleared, matching
 // the "partial mocks are dropped" invariant).
 //
-// EmitMock honours context cancellation: if Ctx is done before the
-// send succeeds, Ctx.Err() is returned. The caller's post-record hook
-// chain runs synchronously before the send so wrappers can annotate.
+// Context cancellation semantics differ between the two delivery paths:
+//
+//   - Direct-channel path (RouteMocksViaSyncMock=false, s.Mocks bound):
+//     fully honours Ctx — EmitMock's select blocks on `s.Mocks <- m`
+//     vs `<-ctx.Done()` and returns ctx.Err() on cancel. Once the send
+//     wins, delivery is guaranteed; the caller never races backpressure.
+//
+//   - SyncMock path (RouteMocksViaSyncMock=true): ctx is checked ONCE
+//     before calling mgr.AddMock. If ctx was already cancelled,
+//     EmitMock returns ctx.Err() without touching the manager. If ctx
+//     cancels AFTER the AddMock call starts, AddMock runs to completion
+//     (buffers the mock, or blocks in its own bounded sendToOutChan
+//     up to sendBudget) and EmitMock returns nil. AddMock may also
+//     drop the mock under backpressure/memory-pause without signalling
+//     the caller — the drop is recorded on the manager's drop counter
+//     instead. This is a deliberate asymmetry: the syncMock manager
+//     owns its own lifecycle so best-effort delivery with ctx-probe
+//     on entry is the cleanest fit; forcing ctx through would
+//     require threading it into every AddMock call site in the legacy
+//     record path too.
+//
+// Caller's post-record hook chain (OnMockRecorded) runs synchronously
+// before either delivery branch so wrappers can annotate.
 //
 // It is safe to call EmitMock with a nil session (returns nil); this
 // matches the defensive shape of RecordSession call sites. A nil m is
@@ -291,17 +311,18 @@ func (s *Session) EmitMock(m *models.Mock) error {
 	// recordViaSupervisor sets it true.
 	if s.RouteMocksViaSyncMock {
 		if mgr := syncMock.Get(); mgr != nil {
-			// Honour s.Ctx cancellation on this path too.
-			// syncMock.AddMock itself does not observe s.Ctx — it
-			// takes its own mutex, may sit in sendToOutChan up to
-			// the manager's internal sendBudget, and never returns
-			// an error. Without this pre-check the caller would see
-			// EmitMock return nil even after the parser's context
-			// was cancelled, breaking the "EmitMock honours Ctx"
-			// contract documented above. Match the behaviour of the
-			// direct-channel path below (returns ctx.Err() on
-			// cancellation) so both routings look identical to the
-			// parser.
+			// Best-effort ctx probe. syncMock.AddMock doesn't
+			// observe s.Ctx — it takes its own mutex and may sit
+			// in sendToOutChan up to the manager's internal
+			// sendBudget without signalling cancellation back to
+			// us. A pre-check at least catches the "already
+			// cancelled" case so we don't spend AddMock's bounded
+			// wait on work the parser already abandoned. Post-call
+			// cancellation during AddMock's send is documented as
+			// a semantic difference from the direct-channel branch
+			// (see the EmitMock doc comment above); forcing full
+			// ctx-honoring into AddMock would require threading
+			// ctx through every legacy record-path call site too.
 			if ctx := s.Ctx; ctx != nil {
 				if err := ctx.Err(); err != nil {
 					return err

--- a/pkg/agent/proxy/supervisor/session.go
+++ b/pkg/agent/proxy/supervisor/session.go
@@ -225,10 +225,12 @@ func (s *Session) IsMockIncomplete() bool {
 //     the send is not yet ready, cancellation causes EmitMock to return
 //     ctx.Err(). If ctx is ALREADY cancelled AND the send is also ready
 //     (e.g. s.Mocks is buffered with spare capacity), Go's select is
-//     free to pick either case — the mock may still be emitted and
-//     EmitMock may return nil. Once the send case wins, delivery is
-//     guaranteed; callers that want a strict "no emit past cancel"
-//     barrier must probe ctx.Err() themselves before calling EmitMock.
+//     free to pick either case — the outcome is non-deterministic:
+//     EmitMock may emit the mock and return nil, OR it may pick the
+//     ctx.Done() arm and return ctx.Err() without emitting. Once the
+//     send case wins, delivery is guaranteed; callers that want a
+//     strict "no emit past cancel" barrier must probe ctx.Err()
+//     themselves before calling EmitMock.
 //
 //   - SyncMock path (RouteMocksViaSyncMock=true): ctx is checked ONCE
 //     before calling mgr.AddMock. If ctx was already cancelled,

--- a/pkg/agent/proxy/supervisor/session.go
+++ b/pkg/agent/proxy/supervisor/session.go
@@ -297,7 +297,8 @@ func (s *Session) EmitMock(m *models.Mock) error {
 
 	// Route through the package-singleton SyncMockManager when the
 	// caller opts in. Legacy parsers (http, mysql, generic, etc.)
-	// call syncMock.AddMock because it does:
+	// call (*SyncMockManager).AddMock — obtained via syncMock.Get() —
+	// because it does:
 	//
 	//   1. Lifetime derivation from Metadata["type"] (session vs
 	//      per-test), stamped onto TestModeInfo.Lifetime.
@@ -316,18 +317,20 @@ func (s *Session) EmitMock(m *models.Mock) error {
 	// recordViaSupervisor sets it true.
 	if s.RouteMocksViaSyncMock {
 		if mgr := syncMock.Get(); mgr != nil {
-			// Best-effort ctx probe. syncMock.AddMock doesn't
+			// Best-effort ctx probe. mgr.AddMock (the SyncMock
+			// manager method obtained from syncMock.Get()) doesn't
 			// observe s.Ctx — it takes its own mutex and may sit
 			// in sendToOutChan up to the manager's internal
 			// sendBudget without signalling cancellation back to
 			// us. A pre-check at least catches the "already
-			// cancelled" case so we don't spend AddMock's bounded
-			// wait on work the parser already abandoned. Post-call
-			// cancellation during AddMock's send is documented as
-			// a semantic difference from the direct-channel branch
-			// (see the EmitMock doc comment above); forcing full
-			// ctx-honoring into AddMock would require threading
-			// ctx through every legacy record-path call site too.
+			// cancelled" case so we don't spend mgr.AddMock's
+			// bounded wait on work the parser already abandoned.
+			// Post-call cancellation during mgr.AddMock's send is
+			// documented as a semantic difference from the
+			// direct-channel branch (see the EmitMock doc comment
+			// above); forcing full ctx-honoring into AddMock would
+			// require threading ctx through every legacy
+			// record-path call site too.
 			if ctx := s.Ctx; ctx != nil {
 				if err := ctx.Err(); err != nil {
 					return err

--- a/pkg/agent/proxy/supervisor/session.go
+++ b/pkg/agent/proxy/supervisor/session.go
@@ -291,6 +291,22 @@ func (s *Session) EmitMock(m *models.Mock) error {
 	// recordViaSupervisor sets it true.
 	if s.RouteMocksViaSyncMock {
 		if mgr := syncMock.Get(); mgr != nil {
+			// Honour s.Ctx cancellation on this path too.
+			// syncMock.AddMock itself does not observe s.Ctx — it
+			// takes its own mutex, may sit in sendToOutChan up to
+			// the manager's internal sendBudget, and never returns
+			// an error. Without this pre-check the caller would see
+			// EmitMock return nil even after the parser's context
+			// was cancelled, breaking the "EmitMock honours Ctx"
+			// contract documented above. Match the behaviour of the
+			// direct-channel path below (returns ctx.Err() on
+			// cancellation) so both routings look identical to the
+			// parser.
+			if ctx := s.Ctx; ctx != nil {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+			}
 			mgr.AddMock(m)
 			if s.OnPendingCleared != nil {
 				s.OnPendingCleared()

--- a/pkg/agent/proxy/supervisor/session.go
+++ b/pkg/agent/proxy/supervisor/session.go
@@ -221,9 +221,14 @@ func (s *Session) IsMockIncomplete() bool {
 // Context cancellation semantics differ between the two delivery paths:
 //
 //   - Direct-channel path (RouteMocksViaSyncMock=false, s.Mocks bound):
-//     fully honours Ctx — EmitMock's select blocks on `s.Mocks <- m`
-//     vs `<-ctx.Done()` and returns ctx.Err() on cancel. Once the send
-//     wins, delivery is guaranteed; the caller never races backpressure.
+//     EmitMock selects between `s.Mocks <- m` and `<-ctx.Done()`. While
+//     the send is not yet ready, cancellation causes EmitMock to return
+//     ctx.Err(). If ctx is ALREADY cancelled AND the send is also ready
+//     (e.g. s.Mocks is buffered with spare capacity), Go's select is
+//     free to pick either case — the mock may still be emitted and
+//     EmitMock may return nil. Once the send case wins, delivery is
+//     guaranteed; callers that want a strict "no emit past cancel"
+//     barrier must probe ctx.Err() themselves before calling EmitMock.
 //
 //   - SyncMock path (RouteMocksViaSyncMock=true): ctx is checked ONCE
 //     before calling mgr.AddMock. If ctx was already cancelled,

--- a/pkg/agent/proxy/supervisor/supervisor_test.go
+++ b/pkg/agent/proxy/supervisor/supervisor_test.go
@@ -387,11 +387,14 @@ func TestSessionEmitMockRouteViaSyncMock_DirectChannelUntouched(t *testing.T) {
 	}
 
 	// Direct channel must remain empty — the syncMock route should
-	// have returned before touching it.
+	// have returned before touching it. EmitMock is synchronous, so
+	// a non-blocking receive is enough: anything it was going to
+	// send on Mocks would already be buffered by the time EmitMock
+	// returned.
 	select {
 	case got := <-directCh:
 		t.Fatalf("mock leaked to Session.Mocks when RouteMocksViaSyncMock=true: %+v", got)
-	case <-time.After(100 * time.Millisecond):
+	default:
 		// expected: nothing delivered.
 	}
 
@@ -428,10 +431,12 @@ func TestSessionEmitMockRouteViaSyncMock_HonorsCtx(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("err = %v, want context.Canceled", err)
 	}
+	// Non-blocking receive: EmitMock is synchronous, so if it had
+	// written to directCh it would already be readable.
 	select {
 	case got := <-directCh:
 		t.Fatalf("mock leaked to Session.Mocks after ctx cancel: %+v", got)
-	case <-time.After(100 * time.Millisecond):
+	default:
 		// expected: no delivery.
 	}
 }

--- a/pkg/agent/proxy/supervisor/supervisor_test.go
+++ b/pkg/agent/proxy/supervisor/supervisor_test.go
@@ -366,7 +366,10 @@ func TestSessionEmitMockHonorsCtxCancel(t *testing.T) {
 // and produce flaky timeouts. (Cross-package `go test ./...` runs
 // each package in its own binary, so the race was strictly
 // intra-package.) Asserting on the local Session.Mocks channel
-// keeps the test entirely within this Session instance.
+// avoids rebinding that global outChan — the syncMock manager's
+// other state (buffered mocks, firstReqSeen) is still touched
+// because RouteMocksViaSyncMock=true routes through it, but none
+// of that state is read by this test's assertions.
 func TestSessionEmitMockRouteViaSyncMock_DirectChannelUntouched(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/agent/proxy/supervisor/supervisor_test.go
+++ b/pkg/agent/proxy/supervisor/supervisor_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	syncMock "go.keploy.io/server/v3/pkg/agent/proxy/syncMock"
 	"go.keploy.io/server/v3/pkg/models"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
@@ -347,6 +348,93 @@ func TestSessionEmitMockHonorsCtxCancel(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatalf("EmitMock did not return after ctx cancel (deadlock)")
+	}
+}
+
+// TestSessionEmitMockRouteViaSyncMock_Delivery pins the
+// RouteMocksViaSyncMock=true path. Enables the flag, binds a fresh
+// output channel on the package-singleton syncMock manager, and
+// asserts the mock arrives on that channel and OnPendingCleared
+// fired exactly once. This guards the V2 record path's core
+// invariant (mocks flow through syncMock so firstReqSeen buffering
+// + lifetime derivation happen) against regressions that bypass
+// the flag or drop the pending-cleared callback.
+//
+// syncMock is a package singleton — don't t.Parallel this test
+// against other tests that also bind the output channel; they'd
+// race on the shared outChan.
+func TestSessionEmitMockRouteViaSyncMock_Delivery(t *testing.T) {
+	// Not t.Parallel — shares the package-singleton syncMock.
+	mgr := syncMock.Get()
+	ch := make(chan *models.Mock, 1)
+	mgr.SetOutputChannel(ch)
+	t.Cleanup(func() {
+		// Unbind so a later test that doesn't use syncMock still
+		// sees the default nil-outChan shape. Closing the manager's
+		// out channel would be caught by outChanClosed and break
+		// other tests in the package.
+		mgr.SetOutputChannel(nil)
+	})
+
+	var pendingCleared int32
+	sess := &Session{
+		// Intentionally no s.Mocks — prove the syncMock route
+		// is what actually delivers the mock, not the
+		// direct-channel fallback.
+		Logger:                zaptest.NewLogger(t),
+		Ctx:                   context.Background(),
+		RouteMocksViaSyncMock: true,
+		OnPendingCleared: func() {
+			atomic.AddInt32(&pendingCleared, 1)
+		},
+	}
+
+	if err := sess.EmitMock(&models.Mock{Name: "via-syncmock"}); err != nil {
+		t.Fatalf("EmitMock returned err: %v", err)
+	}
+	select {
+	case got := <-ch:
+		if got == nil || got.Name != "via-syncmock" {
+			t.Fatalf("received wrong mock: %+v", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("mock not delivered via syncMock outChan within 1s")
+	}
+	if c := atomic.LoadInt32(&pendingCleared); c != 1 {
+		t.Fatalf("OnPendingCleared calls = %d, want 1", c)
+	}
+}
+
+// TestSessionEmitMockRouteViaSyncMock_HonorsCtx pins the ctx-cancel
+// behaviour on the syncMock routing path. Without the pre-check,
+// EmitMock would call mgr.AddMock (which does not observe s.Ctx)
+// and return nil — silently violating the documented contract
+// that EmitMock returns ctx.Err() when the parser's context has
+// been cancelled.
+func TestSessionEmitMockRouteViaSyncMock_HonorsCtx(t *testing.T) {
+	// Not t.Parallel — shares the package-singleton syncMock.
+	mgr := syncMock.Get()
+	ch := make(chan *models.Mock, 1)
+	mgr.SetOutputChannel(ch)
+	t.Cleanup(func() { mgr.SetOutputChannel(nil) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before EmitMock is called
+
+	sess := &Session{
+		Logger:                zaptest.NewLogger(t),
+		Ctx:                   ctx,
+		RouteMocksViaSyncMock: true,
+	}
+	err := sess.EmitMock(&models.Mock{Name: "should-be-cancelled"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	select {
+	case got := <-ch:
+		t.Fatalf("mock leaked to syncMock outChan after ctx cancel: %+v", got)
+	case <-time.After(100 * time.Millisecond):
+		// expected: no delivery.
 	}
 }
 

--- a/pkg/agent/proxy/supervisor/supervisor_test.go
+++ b/pkg/agent/proxy/supervisor/supervisor_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	syncMock "go.keploy.io/server/v3/pkg/agent/proxy/syncMock"
 	"go.keploy.io/server/v3/pkg/models"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
@@ -351,36 +350,30 @@ func TestSessionEmitMockHonorsCtxCancel(t *testing.T) {
 	}
 }
 
-// TestSessionEmitMockRouteViaSyncMock_Delivery pins the
-// RouteMocksViaSyncMock=true path. Enables the flag, binds a fresh
-// output channel on the package-singleton syncMock manager, and
-// asserts the mock arrives on that channel and OnPendingCleared
-// fired exactly once. This guards the V2 record path's core
-// invariant (mocks flow through syncMock so firstReqSeen buffering
-// + lifetime derivation happen) against regressions that bypass
-// the flag or drop the pending-cleared callback.
+// TestSessionEmitMockRouteViaSyncMock_DirectChannelUntouched pins
+// the RouteMocksViaSyncMock=true path by asserting the negative:
+// when the flag is on, Session.Mocks must NOT receive anything,
+// and OnPendingCleared must still fire. That combination can only
+// be produced by the syncMock branch — the other branches either
+// push to Session.Mocks or only fire OnPendingCleared when Mocks
+// is nil.
 //
-// syncMock is a package singleton — don't t.Parallel this test
-// against other tests that also bind the output channel; they'd
-// race on the shared outChan.
-func TestSessionEmitMockRouteViaSyncMock_Delivery(t *testing.T) {
-	// Not t.Parallel — shares the package-singleton syncMock.
-	mgr := syncMock.Get()
-	ch := make(chan *models.Mock, 1)
-	mgr.SetOutputChannel(ch)
-	t.Cleanup(func() {
-		// Unbind so a later test that doesn't use syncMock still
-		// sees the default nil-outChan shape. Closing the manager's
-		// out channel would be caught by outChanClosed and break
-		// other tests in the package.
-		mgr.SetOutputChannel(nil)
-	})
+// Earlier iterations of this test rebound the package-singleton
+// syncMock's outChan via SetOutputChannel(...). That touched a
+// global visible across every test in the process, and parallel
+// `go test` runs in sibling packages (e.g.
+// pkg/agent/proxy/integrations/http/recordv2_test.go) that also
+// call SetOutputChannel raced on the outChan pointer and produced
+// flaky timeouts. Asserting on the local Session.Mocks channel
+// keeps the test entirely within this Session instance.
+func TestSessionEmitMockRouteViaSyncMock_DirectChannelUntouched(t *testing.T) {
+	t.Parallel()
+
+	directCh := make(chan *models.Mock, 1)
 
 	var pendingCleared int32
 	sess := &Session{
-		// Intentionally no s.Mocks — prove the syncMock route
-		// is what actually delivers the mock, not the
-		// direct-channel fallback.
+		Mocks:                 directCh,
 		Logger:                zaptest.NewLogger(t),
 		Ctx:                   context.Background(),
 		RouteMocksViaSyncMock: true,
@@ -392,16 +385,18 @@ func TestSessionEmitMockRouteViaSyncMock_Delivery(t *testing.T) {
 	if err := sess.EmitMock(&models.Mock{Name: "via-syncmock"}); err != nil {
 		t.Fatalf("EmitMock returned err: %v", err)
 	}
+
+	// Direct channel must remain empty — the syncMock route should
+	// have returned before touching it.
 	select {
-	case got := <-ch:
-		if got == nil || got.Name != "via-syncmock" {
-			t.Fatalf("received wrong mock: %+v", got)
-		}
-	case <-time.After(time.Second):
-		t.Fatalf("mock not delivered via syncMock outChan within 1s")
+	case got := <-directCh:
+		t.Fatalf("mock leaked to Session.Mocks when RouteMocksViaSyncMock=true: %+v", got)
+	case <-time.After(100 * time.Millisecond):
+		// expected: nothing delivered.
 	}
+
 	if c := atomic.LoadInt32(&pendingCleared); c != 1 {
-		t.Fatalf("OnPendingCleared calls = %d, want 1", c)
+		t.Fatalf("OnPendingCleared calls = %d, want 1 (only the syncMock branch fires it without also sending on Mocks)", c)
 	}
 }
 
@@ -411,17 +406,20 @@ func TestSessionEmitMockRouteViaSyncMock_Delivery(t *testing.T) {
 // and return nil — silently violating the documented contract
 // that EmitMock returns ctx.Err() when the parser's context has
 // been cancelled.
+//
+// Uses the local-direct-channel pattern (no singleton rebind) so
+// concurrent test packages that call SetOutputChannel can't
+// interfere.
 func TestSessionEmitMockRouteViaSyncMock_HonorsCtx(t *testing.T) {
-	// Not t.Parallel — shares the package-singleton syncMock.
-	mgr := syncMock.Get()
-	ch := make(chan *models.Mock, 1)
-	mgr.SetOutputChannel(ch)
-	t.Cleanup(func() { mgr.SetOutputChannel(nil) })
+	t.Parallel()
+
+	directCh := make(chan *models.Mock, 1)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel before EmitMock is called
 
 	sess := &Session{
+		Mocks:                 directCh,
 		Logger:                zaptest.NewLogger(t),
 		Ctx:                   ctx,
 		RouteMocksViaSyncMock: true,
@@ -431,8 +429,8 @@ func TestSessionEmitMockRouteViaSyncMock_HonorsCtx(t *testing.T) {
 		t.Fatalf("err = %v, want context.Canceled", err)
 	}
 	select {
-	case got := <-ch:
-		t.Fatalf("mock leaked to syncMock outChan after ctx cancel: %+v", got)
+	case got := <-directCh:
+		t.Fatalf("mock leaked to Session.Mocks after ctx cancel: %+v", got)
 	case <-time.After(100 * time.Millisecond):
 		// expected: no delivery.
 	}

--- a/pkg/agent/proxy/supervisor/supervisor_test.go
+++ b/pkg/agent/proxy/supervisor/supervisor_test.go
@@ -353,10 +353,13 @@ func TestSessionEmitMockHonorsCtxCancel(t *testing.T) {
 // TestSessionEmitMockRouteViaSyncMock_DirectChannelUntouched pins
 // the RouteMocksViaSyncMock=true path by asserting the negative:
 // when the flag is on, Session.Mocks must NOT receive anything,
-// and OnPendingCleared must still fire. That combination can only
-// be produced by the syncMock branch — the other branches either
-// push to Session.Mocks or only fire OnPendingCleared when Mocks
-// is nil.
+// and OnPendingCleared must still fire. Under this test's setup —
+// session not marked incomplete, RouteMocksViaSyncMock=true, Mocks
+// non-nil — that combination identifies the syncMock branch. Note
+// that the incomplete-mock drop path would also produce "Mocks
+// untouched + OnPendingCleared fired" if the session were marked
+// incomplete, so the invariant is conditional on the clean-session
+// precondition this test sets up.
 //
 // Earlier iterations of this test rebound the package-singleton
 // syncMock's outChan via SetOutputChannel(...). That touched a

--- a/pkg/agent/proxy/supervisor/supervisor_test.go
+++ b/pkg/agent/proxy/supervisor/supervisor_test.go
@@ -360,11 +360,12 @@ func TestSessionEmitMockHonorsCtxCancel(t *testing.T) {
 //
 // Earlier iterations of this test rebound the package-singleton
 // syncMock's outChan via SetOutputChannel(...). That touched a
-// global visible across every test in the process, and parallel
-// `go test` runs in sibling packages (e.g.
-// pkg/agent/proxy/integrations/http/recordv2_test.go) that also
-// call SetOutputChannel raced on the outChan pointer and produced
-// flaky timeouts. Asserting on the local Session.Mocks channel
+// global visible across every test in the same test process, so
+// parallel tests or t.Parallel() subtests in this package that
+// also call SetOutputChannel could race on the outChan pointer
+// and produce flaky timeouts. (Cross-package `go test ./...` runs
+// each package in its own binary, so the race was strictly
+// intra-package.) Asserting on the local Session.Mocks channel
 // keeps the test entirely within this Session instance.
 func TestSessionEmitMockRouteViaSyncMock_DirectChannelUntouched(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- `Session.EmitMock` wrote directly to `s.Mocks`, bypassing the package-singleton `syncMock.SyncMockManager`. That skipped lifetime derivation + `firstReqSeen` buffering + drop accounting that legacy parsers (http, mysql, generic) get.
- Under V2, an app's startup-phase DB queries (recorded BEFORE keploy's first test request) need to land in the session-scope buffer so replay's startup sees them. Writing direct to the mocks channel tagged them per-test → lost at replay → app hangs in "Waiting for application startup" during record-build-replay-build runs → every postgres e2e red on keploy/integrations#133.
- Added `Session.RouteMocksViaSyncMock` opt-in flag (true in `proxy_v2.go` recordViaSupervisor, default false for tests that wire bare mocks channels).

## Test plan
- [x] ``go build ./...`` clean.
- [x] ``go test -race -count=1 ./pkg/agent/proxy/...`` green.
- [ ] keploy/integrations#133 e2e postgres suite (asyncpg, http-postgres, listmonk, ps-cache, sap-demo-java) goes green once this lands and the integrations pin is bumped.