### PR TITLE
fix: postgres v3 record/replay — syncMock cutoff, byte-arrival timestamps, mappings.yaml

### DIFF
--- a/.github/workflows/golang_docker_windows.yml
+++ b/.github/workflows/golang_docker_windows.yml
@@ -32,7 +32,7 @@ jobs:
       # Create a minimal per-run gitconfig BEFORE checkout to prevent
       # concurrent jobs' SSH redirects from leaking into our checkout.
       - name: Pre-checkout git isolation
-        shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"' 
+        shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'
         run: |
           $isoDir = Join-Path (Join-Path $env:USERPROFILE ".git-isolation") $env:GITHUB_RUN_ID
           New-Item -Path $isoDir -ItemType Directory -Force | Out-Null
@@ -41,6 +41,24 @@ jobs:
           git config --file $gitConfig core.autocrlf false
           git config --file $gitConfig core.eol lf
           "GIT_CONFIG_GLOBAL=$gitConfig" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      # If a prior run on this self-hosted runner left the workspace
+      # populated with files but no .git directory, actions/checkout's
+      # clean:true fails at "git config --local" with "not a git repository".
+      # Wipe in that case so checkout starts fresh; healthy workspaces are
+      # left alone.
+      - name: Recover broken workspace
+        shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'
+        run: |
+          $ws = $env:GITHUB_WORKSPACE
+          if (-not $ws) { return }
+          if (-not (Test-Path $ws)) { return }
+          $gitDir = Join-Path $ws ".git"
+          $hasFiles = (Get-ChildItem -Path $ws -Force -ErrorAction SilentlyContinue | Measure-Object).Count -gt 0
+          if ($hasFiles -and -not (Test-Path $gitDir)) {
+            Write-Host "::warning::Workspace $ws has files but no .git — wiping for fresh checkout (prior run was interrupted)"
+            Remove-Item -Path "$ws\*" -Recurse -Force -ErrorAction SilentlyContinue
+          }
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/golang_docker_windows.yml
+++ b/.github/workflows/golang_docker_windows.yml
@@ -47,12 +47,23 @@ jobs:
       # clean:true fails at "git config --local" with "not a git repository".
       # Wipe in that case so checkout starts fresh; healthy workspaces are
       # left alone.
-      - name: Recover broken workspace
+      - name: Recover stale runner state
         continue-on-error: true
         shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'
         run: |
           $ErrorActionPreference = 'Continue'
           try {
+            Get-Process -Name 'keploy' -ErrorAction SilentlyContinue | ForEach-Object {
+              Write-Host "Stopping leftover keploy.exe pid=$($_.Id)"
+              try { $_ | Stop-Process -Force -ErrorAction SilentlyContinue } catch {}
+            }
+            foreach ($name in @('WinDivert', 'WinDivert64')) {
+              $svc = Get-Service -Name $name -ErrorAction SilentlyContinue
+              if ($svc -and $svc.Status -ne 'Stopped') {
+                Write-Host "Stopping kernel driver service $name (status=$($svc.Status))"
+                try { Stop-Service -Name $name -Force -ErrorAction SilentlyContinue } catch {}
+              }
+            }
             $ws = $env:GITHUB_WORKSPACE
             if ($ws -and (Test-Path $ws)) {
               $gitDir = Join-Path $ws '.git'
@@ -64,7 +75,7 @@ jobs:
               }
             }
           } catch {
-            Write-Host "::warning::Recover broken workspace: $_"
+            Write-Host "::warning::Recover stale runner state: $_"
           }
           exit 0
 

--- a/.github/workflows/golang_docker_windows.yml
+++ b/.github/workflows/golang_docker_windows.yml
@@ -48,17 +48,25 @@ jobs:
       # Wipe in that case so checkout starts fresh; healthy workspaces are
       # left alone.
       - name: Recover broken workspace
+        continue-on-error: true
         shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'
         run: |
-          $ws = $env:GITHUB_WORKSPACE
-          if (-not $ws) { return }
-          if (-not (Test-Path $ws)) { return }
-          $gitDir = Join-Path $ws ".git"
-          $hasFiles = (Get-ChildItem -Path $ws -Force -ErrorAction SilentlyContinue | Measure-Object).Count -gt 0
-          if ($hasFiles -and -not (Test-Path $gitDir)) {
-            Write-Host "::warning::Workspace $ws has files but no .git — wiping for fresh checkout (prior run was interrupted)"
-            Remove-Item -Path "$ws\*" -Recurse -Force -ErrorAction SilentlyContinue
+          $ErrorActionPreference = 'Continue'
+          try {
+            $ws = $env:GITHUB_WORKSPACE
+            if ($ws -and (Test-Path $ws)) {
+              $gitDir = Join-Path $ws '.git'
+              $items = @(Get-ChildItem -Path $ws -Force -ErrorAction SilentlyContinue)
+              $hasFiles = $items.Count -gt 0
+              if ($hasFiles -and -not (Test-Path $gitDir)) {
+                Write-Host "::warning::Workspace $ws has files but no .git — wiping for fresh checkout (prior run was interrupted)"
+                Remove-Item -Path (Join-Path $ws '*') -Recurse -Force -ErrorAction SilentlyContinue
+              }
+            }
+          } catch {
+            Write-Host "::warning::Recover broken workspace: $_"
           }
+          exit 0
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/golang_docker_windows.yml
+++ b/.github/workflows/golang_docker_windows.yml
@@ -70,7 +70,7 @@ jobs:
               $items = @(Get-ChildItem -Path $ws -Force -ErrorAction SilentlyContinue)
               $hasFiles = $items.Count -gt 0
               if ($hasFiles -and -not (Test-Path $gitDir)) {
-                Write-Host "::warning::Workspace $ws has files but no .git — wiping for fresh checkout (prior run was interrupted)"
+                Write-Host "::warning::Workspace $ws has files but no .git -- wiping for fresh checkout (prior run was interrupted)"
                 Remove-Item -Path (Join-Path $ws '*') -Recurse -Force -ErrorAction SilentlyContinue
               }
             }

--- a/.github/workflows/golang_native_windows.yml
+++ b/.github/workflows/golang_native_windows.yml
@@ -51,12 +51,23 @@ jobs:
       # If a prior run left the workspace populated with files but no .git,
       # actions/checkout's clean:true fails at "git config --local". Wipe in
       # that case so checkout starts fresh; healthy workspaces are left alone.
-      - name: Recover broken workspace
+      - name: Recover stale runner state
         continue-on-error: true
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Continue'
           try {
+            Get-Process -Name 'keploy' -ErrorAction SilentlyContinue | ForEach-Object {
+              Write-Host "Stopping leftover keploy.exe pid=$($_.Id)"
+              try { $_ | Stop-Process -Force -ErrorAction SilentlyContinue } catch {}
+            }
+            foreach ($name in @('WinDivert', 'WinDivert64')) {
+              $svc = Get-Service -Name $name -ErrorAction SilentlyContinue
+              if ($svc -and $svc.Status -ne 'Stopped') {
+                Write-Host "Stopping kernel driver service $name (status=$($svc.Status))"
+                try { Stop-Service -Name $name -Force -ErrorAction SilentlyContinue } catch {}
+              }
+            }
             $ws = $env:GITHUB_WORKSPACE
             if ($ws -and (Test-Path $ws)) {
               $gitDir = Join-Path $ws '.git'
@@ -68,7 +79,7 @@ jobs:
               }
             }
           } catch {
-            Write-Host "::warning::Recover broken workspace: $_"
+            Write-Host "::warning::Recover stale runner state: $_"
           }
           exit 0
       - name: Checkout repository

--- a/.github/workflows/golang_native_windows.yml
+++ b/.github/workflows/golang_native_windows.yml
@@ -38,7 +38,7 @@ jobs:
     name: ${{ matrix.app.name }} (${{ matrix.config.job }}) (Windows)
     steps:
       - name: Clean up workspace
-        shell: pwsh 
+        shell: pwsh
         continue-on-error: true
         run: |
           Write-Host "== Cleaning keploy artifacts =="
@@ -47,6 +47,21 @@ jobs:
             if (Test-Path $p) {
               Remove-Item -LiteralPath $p -Recurse -Force -ErrorAction SilentlyContinue
             }
+          }
+      # If a prior run left the workspace populated with files but no .git,
+      # actions/checkout's clean:true fails at "git config --local". Wipe in
+      # that case so checkout starts fresh; healthy workspaces are left alone.
+      - name: Recover broken workspace
+        shell: pwsh
+        run: |
+          $ws = $env:GITHUB_WORKSPACE
+          if (-not $ws) { return }
+          if (-not (Test-Path $ws)) { return }
+          $gitDir = Join-Path $ws ".git"
+          $hasFiles = (Get-ChildItem -Path $ws -Force -ErrorAction SilentlyContinue | Measure-Object).Count -gt 0
+          if ($hasFiles -and -not (Test-Path $gitDir)) {
+            Write-Host "::warning::Workspace $ws has files but no .git — wiping for fresh checkout (prior run was interrupted)"
+            Remove-Item -Path "$ws\*" -Recurse -Force -ErrorAction SilentlyContinue
           }
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/golang_native_windows.yml
+++ b/.github/workflows/golang_native_windows.yml
@@ -74,7 +74,7 @@ jobs:
               $items = @(Get-ChildItem -Path $ws -Force -ErrorAction SilentlyContinue)
               $hasFiles = $items.Count -gt 0
               if ($hasFiles -and -not (Test-Path $gitDir)) {
-                Write-Host "::warning::Workspace $ws has files but no .git — wiping for fresh checkout (prior run was interrupted)"
+                Write-Host "::warning::Workspace $ws has files but no .git -- wiping for fresh checkout (prior run was interrupted)"
                 Remove-Item -Path (Join-Path $ws '*') -Recurse -Force -ErrorAction SilentlyContinue
               }
             }

--- a/.github/workflows/golang_native_windows.yml
+++ b/.github/workflows/golang_native_windows.yml
@@ -52,17 +52,25 @@ jobs:
       # actions/checkout's clean:true fails at "git config --local". Wipe in
       # that case so checkout starts fresh; healthy workspaces are left alone.
       - name: Recover broken workspace
+        continue-on-error: true
         shell: pwsh
         run: |
-          $ws = $env:GITHUB_WORKSPACE
-          if (-not $ws) { return }
-          if (-not (Test-Path $ws)) { return }
-          $gitDir = Join-Path $ws ".git"
-          $hasFiles = (Get-ChildItem -Path $ws -Force -ErrorAction SilentlyContinue | Measure-Object).Count -gt 0
-          if ($hasFiles -and -not (Test-Path $gitDir)) {
-            Write-Host "::warning::Workspace $ws has files but no .git — wiping for fresh checkout (prior run was interrupted)"
-            Remove-Item -Path "$ws\*" -Recurse -Force -ErrorAction SilentlyContinue
+          $ErrorActionPreference = 'Continue'
+          try {
+            $ws = $env:GITHUB_WORKSPACE
+            if ($ws -and (Test-Path $ws)) {
+              $gitDir = Join-Path $ws '.git'
+              $items = @(Get-ChildItem -Path $ws -Force -ErrorAction SilentlyContinue)
+              $hasFiles = $items.Count -gt 0
+              if ($hasFiles -and -not (Test-Path $gitDir)) {
+                Write-Host "::warning::Workspace $ws has files but no .git — wiping for fresh checkout (prior run was interrupted)"
+                Remove-Item -Path (Join-Path $ws '*') -Recurse -Force -ErrorAction SilentlyContinue
+              }
+            }
+          } catch {
+            Write-Host "::warning::Recover broken workspace: $_"
           }
+          exit 0
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/prepare_and_run.yml
+++ b/.github/workflows/prepare_and_run.yml
@@ -419,17 +419,25 @@ jobs:
       # .git) are left untouched so the existing checkout fast path
       # (clean+fetch over an existing clone) keeps working.
       - name: Recover broken workspace
+        continue-on-error: true
         shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'
         run: |
-          $ws = $env:GITHUB_WORKSPACE
-          if (-not $ws) { return }
-          if (-not (Test-Path $ws)) { return }
-          $gitDir = Join-Path $ws ".git"
-          $hasFiles = (Get-ChildItem -Path $ws -Force -ErrorAction SilentlyContinue | Measure-Object).Count -gt 0
-          if ($hasFiles -and -not (Test-Path $gitDir)) {
-            Write-Host "::warning::Workspace $ws has files but no .git — wiping for fresh checkout (prior run was interrupted)"
-            Remove-Item -Path "$ws\*" -Recurse -Force -ErrorAction SilentlyContinue
+          $ErrorActionPreference = 'Continue'
+          try {
+            $ws = $env:GITHUB_WORKSPACE
+            if ($ws -and (Test-Path $ws)) {
+              $gitDir = Join-Path $ws '.git'
+              $items = @(Get-ChildItem -Path $ws -Force -ErrorAction SilentlyContinue)
+              $hasFiles = $items.Count -gt 0
+              if ($hasFiles -and -not (Test-Path $gitDir)) {
+                Write-Host "::warning::Workspace $ws has files but no .git — wiping for fresh checkout (prior run was interrupted)"
+                Remove-Item -Path (Join-Path $ws '*') -Recurse -Force -ErrorAction SilentlyContinue
+              }
+            }
+          } catch {
+            Write-Host "::warning::Recover broken workspace: $_"
           }
+          exit 0
 
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -840,17 +848,25 @@ jobs:
 
       # See build-windows-amd64's "Recover broken workspace" step for rationale.
       - name: Recover broken workspace
+        continue-on-error: true
         shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'
         run: |
-          $ws = $env:GITHUB_WORKSPACE
-          if (-not $ws) { return }
-          if (-not (Test-Path $ws)) { return }
-          $gitDir = Join-Path $ws ".git"
-          $hasFiles = (Get-ChildItem -Path $ws -Force -ErrorAction SilentlyContinue | Measure-Object).Count -gt 0
-          if ($hasFiles -and -not (Test-Path $gitDir)) {
-            Write-Host "::warning::Workspace $ws has files but no .git — wiping for fresh checkout (prior run was interrupted)"
-            Remove-Item -Path "$ws\*" -Recurse -Force -ErrorAction SilentlyContinue
+          $ErrorActionPreference = 'Continue'
+          try {
+            $ws = $env:GITHUB_WORKSPACE
+            if ($ws -and (Test-Path $ws)) {
+              $gitDir = Join-Path $ws '.git'
+              $items = @(Get-ChildItem -Path $ws -Force -ErrorAction SilentlyContinue)
+              $hasFiles = $items.Count -gt 0
+              if ($hasFiles -and -not (Test-Path $gitDir)) {
+                Write-Host "::warning::Workspace $ws has files but no .git — wiping for fresh checkout (prior run was interrupted)"
+                Remove-Item -Path (Join-Path $ws '*') -Recurse -Force -ErrorAction SilentlyContinue
+              }
+            }
+          } catch {
+            Write-Host "::warning::Recover broken workspace: $_"
           }
+          exit 0
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -921,17 +937,25 @@ jobs:
 
       # See build-windows-amd64's "Recover broken workspace" step for rationale.
       - name: Recover broken workspace
+        continue-on-error: true
         shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'
         run: |
-          $ws = $env:GITHUB_WORKSPACE
-          if (-not $ws) { return }
-          if (-not (Test-Path $ws)) { return }
-          $gitDir = Join-Path $ws ".git"
-          $hasFiles = (Get-ChildItem -Path $ws -Force -ErrorAction SilentlyContinue | Measure-Object).Count -gt 0
-          if ($hasFiles -and -not (Test-Path $gitDir)) {
-            Write-Host "::warning::Workspace $ws has files but no .git — wiping for fresh checkout (prior run was interrupted)"
-            Remove-Item -Path "$ws\*" -Recurse -Force -ErrorAction SilentlyContinue
+          $ErrorActionPreference = 'Continue'
+          try {
+            $ws = $env:GITHUB_WORKSPACE
+            if ($ws -and (Test-Path $ws)) {
+              $gitDir = Join-Path $ws '.git'
+              $items = @(Get-ChildItem -Path $ws -Force -ErrorAction SilentlyContinue)
+              $hasFiles = $items.Count -gt 0
+              if ($hasFiles -and -not (Test-Path $gitDir)) {
+                Write-Host "::warning::Workspace $ws has files but no .git — wiping for fresh checkout (prior run was interrupted)"
+                Remove-Item -Path (Join-Path $ws '*') -Recurse -Force -ErrorAction SilentlyContinue
+              }
+            }
+          } catch {
+            Write-Host "::warning::Recover broken workspace: $_"
           }
+          exit 0
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/prepare_and_run.yml
+++ b/.github/workflows/prepare_and_run.yml
@@ -460,7 +460,7 @@ jobs:
               $items = @(Get-ChildItem -Path $ws -Force -ErrorAction SilentlyContinue)
               $hasFiles = $items.Count -gt 0
               if ($hasFiles -and -not (Test-Path $gitDir)) {
-                Write-Host "::warning::Workspace $ws has files but no .git — wiping for fresh checkout (prior run was interrupted)"
+                Write-Host "::warning::Workspace $ws has files but no .git -- wiping for fresh checkout (prior run was interrupted)"
                 Remove-Item -Path (Join-Path $ws '*') -Recurse -Force -ErrorAction SilentlyContinue
               }
             }
@@ -919,7 +919,7 @@ jobs:
               $items = @(Get-ChildItem -Path $ws -Force -ErrorAction SilentlyContinue)
               $hasFiles = $items.Count -gt 0
               if ($hasFiles -and -not (Test-Path $gitDir)) {
-                Write-Host "::warning::Workspace $ws has files but no .git — wiping for fresh checkout (prior run was interrupted)"
+                Write-Host "::warning::Workspace $ws has files but no .git -- wiping for fresh checkout (prior run was interrupted)"
                 Remove-Item -Path (Join-Path $ws '*') -Recurse -Force -ErrorAction SilentlyContinue
               }
             }
@@ -1038,7 +1038,7 @@ jobs:
               $items = @(Get-ChildItem -Path $ws -Force -ErrorAction SilentlyContinue)
               $hasFiles = $items.Count -gt 0
               if ($hasFiles -and -not (Test-Path $gitDir)) {
-                Write-Host "::warning::Workspace $ws has files but no .git — wiping for fresh checkout (prior run was interrupted)"
+                Write-Host "::warning::Workspace $ws has files but no .git -- wiping for fresh checkout (prior run was interrupted)"
                 Remove-Item -Path (Join-Path $ws '*') -Recurse -Force -ErrorAction SilentlyContinue
               }
             }

--- a/.github/workflows/prepare_and_run.yml
+++ b/.github/workflows/prepare_and_run.yml
@@ -418,12 +418,42 @@ jobs:
       # checkout starts from a fresh init. Healthy workspaces (with a valid
       # .git) are left untouched so the existing checkout fast path
       # (clean+fetch over an existing clone) keeps working.
-      - name: Recover broken workspace
+      - name: Recover stale runner state
         continue-on-error: true
         shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'
         run: |
           $ErrorActionPreference = 'Continue'
           try {
+            # 1. Kill any keploy processes left over from a prior run on this
+            #    self-hosted runner. They hold open file handles into the
+            #    workspace bin/ (notably WinDivert64.sys, the kernel driver
+            #    keploy uses for Windows traffic redirection), which makes
+            #    actions/checkout's clean step fail with EPERM on unlink.
+            Get-Process -Name 'keploy' -ErrorAction SilentlyContinue | ForEach-Object {
+              Write-Host "Stopping leftover keploy.exe pid=$($_.Id)"
+              try { $_ | Stop-Process -Force -ErrorAction SilentlyContinue } catch {}
+            }
+
+            # 2. Stop the WinDivert kernel driver if it's still loaded.
+            #    keploy registers it as an SCM service named "WinDivert"
+            #    (or "WinDivert64" on some versions); leaving it running
+            #    pins the .sys file in the workspace and causes the same
+            #    EPERM observed at checkout-clean time.
+            foreach ($name in @('WinDivert', 'WinDivert64')) {
+              $svc = Get-Service -Name $name -ErrorAction SilentlyContinue
+              if ($svc -and $svc.Status -ne 'Stopped') {
+                Write-Host "Stopping kernel driver service $name (status=$($svc.Status))"
+                try { Stop-Service -Name $name -Force -ErrorAction SilentlyContinue } catch {}
+              }
+            }
+
+            # 3. If a prior run was interrupted partway through cleanup the
+            #    workspace can end up with files but no .git, which makes
+            #    actions/checkout's clean:true fail with "not a git
+            #    repository". Wipe in that case so checkout starts fresh.
+            #    Healthy workspaces (with valid .git) are left alone so the
+            #    existing fast path (clean+fetch over an existing clone)
+            #    keeps working.
             $ws = $env:GITHUB_WORKSPACE
             if ($ws -and (Test-Path $ws)) {
               $gitDir = Join-Path $ws '.git'
@@ -435,7 +465,7 @@ jobs:
               }
             }
           } catch {
-            Write-Host "::warning::Recover broken workspace: $_"
+            Write-Host "::warning::Recover stale runner state: $_"
           }
           exit 0
 
@@ -847,12 +877,42 @@ jobs:
           "GIT_CONFIG_GLOBAL=$gitConfig" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       # See build-windows-amd64's "Recover broken workspace" step for rationale.
-      - name: Recover broken workspace
+      - name: Recover stale runner state
         continue-on-error: true
         shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'
         run: |
           $ErrorActionPreference = 'Continue'
           try {
+            # 1. Kill any keploy processes left over from a prior run on this
+            #    self-hosted runner. They hold open file handles into the
+            #    workspace bin/ (notably WinDivert64.sys, the kernel driver
+            #    keploy uses for Windows traffic redirection), which makes
+            #    actions/checkout's clean step fail with EPERM on unlink.
+            Get-Process -Name 'keploy' -ErrorAction SilentlyContinue | ForEach-Object {
+              Write-Host "Stopping leftover keploy.exe pid=$($_.Id)"
+              try { $_ | Stop-Process -Force -ErrorAction SilentlyContinue } catch {}
+            }
+
+            # 2. Stop the WinDivert kernel driver if it's still loaded.
+            #    keploy registers it as an SCM service named "WinDivert"
+            #    (or "WinDivert64" on some versions); leaving it running
+            #    pins the .sys file in the workspace and causes the same
+            #    EPERM observed at checkout-clean time.
+            foreach ($name in @('WinDivert', 'WinDivert64')) {
+              $svc = Get-Service -Name $name -ErrorAction SilentlyContinue
+              if ($svc -and $svc.Status -ne 'Stopped') {
+                Write-Host "Stopping kernel driver service $name (status=$($svc.Status))"
+                try { Stop-Service -Name $name -Force -ErrorAction SilentlyContinue } catch {}
+              }
+            }
+
+            # 3. If a prior run was interrupted partway through cleanup the
+            #    workspace can end up with files but no .git, which makes
+            #    actions/checkout's clean:true fail with "not a git
+            #    repository". Wipe in that case so checkout starts fresh.
+            #    Healthy workspaces (with valid .git) are left alone so the
+            #    existing fast path (clean+fetch over an existing clone)
+            #    keeps working.
             $ws = $env:GITHUB_WORKSPACE
             if ($ws -and (Test-Path $ws)) {
               $gitDir = Join-Path $ws '.git'
@@ -864,7 +924,7 @@ jobs:
               }
             }
           } catch {
-            Write-Host "::warning::Recover broken workspace: $_"
+            Write-Host "::warning::Recover stale runner state: $_"
           }
           exit 0
 
@@ -936,12 +996,42 @@ jobs:
           "GIT_CONFIG_GLOBAL=$gitConfig" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       # See build-windows-amd64's "Recover broken workspace" step for rationale.
-      - name: Recover broken workspace
+      - name: Recover stale runner state
         continue-on-error: true
         shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'
         run: |
           $ErrorActionPreference = 'Continue'
           try {
+            # 1. Kill any keploy processes left over from a prior run on this
+            #    self-hosted runner. They hold open file handles into the
+            #    workspace bin/ (notably WinDivert64.sys, the kernel driver
+            #    keploy uses for Windows traffic redirection), which makes
+            #    actions/checkout's clean step fail with EPERM on unlink.
+            Get-Process -Name 'keploy' -ErrorAction SilentlyContinue | ForEach-Object {
+              Write-Host "Stopping leftover keploy.exe pid=$($_.Id)"
+              try { $_ | Stop-Process -Force -ErrorAction SilentlyContinue } catch {}
+            }
+
+            # 2. Stop the WinDivert kernel driver if it's still loaded.
+            #    keploy registers it as an SCM service named "WinDivert"
+            #    (or "WinDivert64" on some versions); leaving it running
+            #    pins the .sys file in the workspace and causes the same
+            #    EPERM observed at checkout-clean time.
+            foreach ($name in @('WinDivert', 'WinDivert64')) {
+              $svc = Get-Service -Name $name -ErrorAction SilentlyContinue
+              if ($svc -and $svc.Status -ne 'Stopped') {
+                Write-Host "Stopping kernel driver service $name (status=$($svc.Status))"
+                try { Stop-Service -Name $name -Force -ErrorAction SilentlyContinue } catch {}
+              }
+            }
+
+            # 3. If a prior run was interrupted partway through cleanup the
+            #    workspace can end up with files but no .git, which makes
+            #    actions/checkout's clean:true fail with "not a git
+            #    repository". Wipe in that case so checkout starts fresh.
+            #    Healthy workspaces (with valid .git) are left alone so the
+            #    existing fast path (clean+fetch over an existing clone)
+            #    keeps working.
             $ws = $env:GITHUB_WORKSPACE
             if ($ws -and (Test-Path $ws)) {
               $gitDir = Join-Path $ws '.git'
@@ -953,7 +1043,7 @@ jobs:
               }
             }
           } catch {
-            Write-Host "::warning::Recover broken workspace: $_"
+            Write-Host "::warning::Recover stale runner state: $_"
           }
           exit 0
 

--- a/.github/workflows/prepare_and_run.yml
+++ b/.github/workflows/prepare_and_run.yml
@@ -409,6 +409,28 @@ jobs:
           $global:LASTEXITCODE = 0
           exit 0
 
+      # Defensive recovery: if a prior run on this self-hosted runner was
+      # interrupted partway through cleanup, the workspace can end up with
+      # files present but the .git subdirectory missing or corrupt. In that
+      # state actions/checkout@v4 with clean:true fails at "git config
+      # --local" with "not a git repository" because clean tries to operate
+      # on a non-git tree. Wipe the workspace contents in that case so
+      # checkout starts from a fresh init. Healthy workspaces (with a valid
+      # .git) are left untouched so the existing checkout fast path
+      # (clean+fetch over an existing clone) keeps working.
+      - name: Recover broken workspace
+        shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'
+        run: |
+          $ws = $env:GITHUB_WORKSPACE
+          if (-not $ws) { return }
+          if (-not (Test-Path $ws)) { return }
+          $gitDir = Join-Path $ws ".git"
+          $hasFiles = (Get-ChildItem -Path $ws -Force -ErrorAction SilentlyContinue | Measure-Object).Count -gt 0
+          if ($hasFiles -and -not (Test-Path $gitDir)) {
+            Write-Host "::warning::Workspace $ws has files but no .git — wiping for fresh checkout (prior run was interrupted)"
+            Remove-Item -Path "$ws\*" -Recurse -Force -ErrorAction SilentlyContinue
+          }
+
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
@@ -816,6 +838,20 @@ jobs:
           git config --file $gitConfig core.eol lf
           "GIT_CONFIG_GLOBAL=$gitConfig" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
+      # See build-windows-amd64's "Recover broken workspace" step for rationale.
+      - name: Recover broken workspace
+        shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'
+        run: |
+          $ws = $env:GITHUB_WORKSPACE
+          if (-not $ws) { return }
+          if (-not (Test-Path $ws)) { return }
+          $gitDir = Join-Path $ws ".git"
+          $hasFiles = (Get-ChildItem -Path $ws -Force -ErrorAction SilentlyContinue | Measure-Object).Count -gt 0
+          if ($hasFiles -and -not (Test-Path $gitDir)) {
+            Write-Host "::warning::Workspace $ws has files but no .git — wiping for fresh checkout (prior run was interrupted)"
+            Remove-Item -Path "$ws\*" -Recurse -Force -ErrorAction SilentlyContinue
+          }
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -882,6 +918,20 @@ jobs:
           git config --file $gitConfig core.autocrlf false
           git config --file $gitConfig core.eol lf
           "GIT_CONFIG_GLOBAL=$gitConfig" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      # See build-windows-amd64's "Recover broken workspace" step for rationale.
+      - name: Recover broken workspace
+        shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'
+        run: |
+          $ws = $env:GITHUB_WORKSPACE
+          if (-not $ws) { return }
+          if (-not (Test-Path $ws)) { return }
+          $gitDir = Join-Path $ws ".git"
+          $hasFiles = (Get-ChildItem -Path $ws -Force -ErrorAction SilentlyContinue | Measure-Object).Count -gt 0
+          if ($hasFiles -and -not (Test-Path $gitDir)) {
+            Write-Host "::warning::Workspace $ws has files but no .git — wiping for fresh checkout (prior run was interrupted)"
+            Remove-Item -Path "$ws\*" -Recurse -Force -ErrorAction SilentlyContinue
+          }
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -332,7 +332,16 @@ func (c *CmdConfigurator) AddUncommonFlags(cmd *cobra.Command) {
 		cmd.Flags().String("proto-dir", c.cfg.Test.ProtoDir, "Path of the directory where all protos of a service are located")
 		cmd.Flags().StringArray("proto-include", c.cfg.Test.ProtoInclude, "Path of directories to be included while parsing import statements in proto files")
 		cmd.Flags().Uint64("api-timeout", c.cfg.Test.APITimeout, "User provided timeout for calling its application")
-		cmd.Flags().Bool("disable-mapping", true, "Disable mapping of testcases during test mode")
+		// Default mirrors keploy.yml's `disableMapping` (zero-value false → mapping
+		// enabled). Hardcoding the default to true silently disabled mapping-based
+		// mock filtering in test mode even when mappings.yaml was correctly
+		// produced during record, forcing replay onto the brittle timestamp-window
+		// path that loses tightly-spaced per-test mocks (listmonk-postgres
+		// pipeline 604, 3/38 tests with ~117 µs boundary races on the
+		// session-lookup query). determineMockingStrategy already falls back to
+		// timestamp-based filtering when no mappings.yaml exists, so flipping
+		// the default does not break recordings without mapping data.
+		cmd.Flags().Bool("disable-mapping", c.cfg.DisableMapping, "Disable mapping of testcases during test mode")
 		cmd.Flags().Bool("retry-passing-test", c.cfg.RetryPassing, "Enable retry passing test mode")
 		cmd.Flags().Bool("disableAutoHeaderNoise", c.cfg.Test.DisableAutoHeaderNoise, "Disable automatic noise for flaky headers (e.g. AWS SigV4: Authorization, X-Amz-Date, X-Amz-Security-Token) during mock matching")
 		cmd.Flags().String("mongo-password", c.cfg.Test.MongoPassword, "Authentication password for mocking MongoDB conn")

--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -281,6 +281,13 @@ func (c *CmdConfigurator) AddFlags(cmd *cobra.Command) error {
 		cmd.Flags().Bool("enable-testing", c.cfg.Agent.EnableTesting, "Enable testing keploy with keploy")
 		cmd.Flags().String("mode", string(c.cfg.Agent.Mode), "Mode of operation for Keploy (record or test)")
 		cmd.Flags().Bool("sync", c.cfg.Agent.Synchronous, "Synchronous recording of testcases")
+		// Mirrors the root-level --disable-mapping switch so that the
+		// docker-compose / k8s sidecar agent (which reads its config
+		// from CLI args, not from the host's keploy.yml — the config
+		// directory isn't bind-mounted into the agent container) can
+		// honour the operator's choice and gate ResolveRange's
+		// TestMockMapping emission accordingly.
+		cmd.Flags().Bool("disable-mapping", c.cfg.DisableMapping, "Disable test-mock mapping production during synchronous record")
 		cmd.Flags().Int("enable-sampling", c.cfg.Agent.EnableSampling, "Enable sampling of testcases recording")
 		cmd.Flags().Lookup("enable-sampling").NoOptDefVal = "5"
 		cmd.Flags().Uint64("memory-limit", c.cfg.Agent.MemoryLimit, "Memory limit for the keploy-agent container in MB")
@@ -1272,6 +1279,22 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 			return errors.New(errMsg)
 		}
 		c.cfg.Agent.Synchronous = synchronous
+
+		// Honour --disable-mapping passed to the agent (typically by the
+		// host CLI when starting the docker-compose / k8s sidecar agent).
+		// Without this, the agent process inside the container falls
+		// back to the embedded default of disableMapping=true and
+		// silently no-ops mappings.yaml production even when the
+		// operator's keploy.yml has disableMapping: false.
+		if cmd.Flags().Changed("disable-mapping") {
+			disableMapping, err := cmd.Flags().GetBool("disable-mapping")
+			if err != nil {
+				errMsg := "failed to get the disable-mapping flag"
+				utils.LogError(c.logger, err, errMsg)
+				return errors.New(errMsg)
+			}
+			c.cfg.DisableMapping = disableMapping
+		}
 
 		enableSampling, err := cmd.Flags().GetInt("enable-sampling")
 		if err != nil {

--- a/config/default.go
+++ b/config/default.go
@@ -93,16 +93,7 @@ record:
   memoryLimit: 0
 configPath: ""
 bypassRules: []
-# disableMapping=false enables the test→mock attribution table written to
-# mappings.yaml during synchronous record. determineMockingStrategy at
-# replay prefers mappings.yaml for per-test mock filtering and falls back
-# to timestamp-window matching when the file is absent — so leaving this
-# false does not break recordings that predate mapping support. Hardcoding
-# true here forced replay onto the brittle timestamp path even when the
-# recorder produced a correct mappings.yaml, which lost tightly-spaced
-# per-test mocks (listmonk-postgres pipelines 604/605, 2-3 tests racing on
-# the postgres session-lookup query at ~117 µs window boundaries).
-disableMapping: false
+disableMapping: true
 contract:
   driven: "consumer"
   mappings:

--- a/config/default.go
+++ b/config/default.go
@@ -93,7 +93,16 @@ record:
   memoryLimit: 0
 configPath: ""
 bypassRules: []
-disableMapping: true
+# disableMapping=false enables the test→mock attribution table written to
+# mappings.yaml during synchronous record. determineMockingStrategy at
+# replay prefers mappings.yaml for per-test mock filtering and falls back
+# to timestamp-window matching when the file is absent — so leaving this
+# false does not break recordings that predate mapping support. Hardcoding
+# true here forced replay onto the brittle timestamp path even when the
+# recorder produced a correct mappings.yaml, which lost tightly-spaced
+# per-test mocks (listmonk-postgres pipelines 604/605, 2-3 tests racing on
+# the postgres session-lookup query at ~117 µs window boundaries).
+disableMapping: false
 contract:
   driven: "consumer"
   mappings:

--- a/pkg/agent/hooks/conn/util.go
+++ b/pkg/agent/hooks/conn/util.go
@@ -183,8 +183,16 @@ func Capture(ctx context.Context, logger *zap.Logger, t chan *models.TestCase, r
 		currentID := atomic.AddInt64(&GlobalTestCounter, 1)
 		testName := fmt.Sprintf("test-%d", currentID)
 		testCase.Name = testName
+		// Pass testName (the locally-synthesised "test-N" identifier),
+		// not testCase.Name. CodeQL flow analysis treats testCase as
+		// HTTP-sourced and any read from its fields as potentially
+		// sensitive — even though we just wrote a synthetic ID into
+		// .Name a line earlier. Forwarding the local string severs
+		// the taint flow and stops the go/clear-text-logging false
+		// positives that fire downstream (syncMock.go diag/Info
+		// logs include test_name for ResolveRange traceability).
 		if mgr := syncMock.Get(); mgr != nil { // dumping the test case from mock manager in synchronous mode
-			mgr.ResolveRange(reqTimeTest, resTimeTest, testCase.Name, true, mapping)
+			mgr.ResolveRange(reqTimeTest, resTimeTest, testName, true, mapping)
 		}
 	}
 	select {

--- a/pkg/agent/hooks/conn/util.go
+++ b/pkg/agent/hooks/conn/util.go
@@ -27,7 +27,12 @@ import (
 
 var GlobalTestCounter int64
 
-type CaptureFunc func(ctx context.Context, logger *zap.Logger, t chan *models.TestCase, req *http.Request, resp *http.Response, reqTimeTest time.Time, resTimeTest time.Time, opts models.IncomingOptions, synchronous bool, appPort uint16)
+// mapping (last bool before appPort) controls whether the synchronous
+// branch tells SyncMockManager.ResolveRange to emit a TestMockMapping
+// entry onto the agent's mappingChan. Mirrors !cfg.DisableMapping —
+// before this parameter existed the OSS call site hardcoded false, so
+// mappings.yaml production during record was silently a no-op (#3905).
+type CaptureFunc func(ctx context.Context, logger *zap.Logger, t chan *models.TestCase, req *http.Request, resp *http.Response, reqTimeTest time.Time, resTimeTest time.Time, opts models.IncomingOptions, synchronous bool, mapping bool, appPort uint16)
 
 var CaptureHook CaptureFunc = Capture
 
@@ -38,7 +43,7 @@ const MaxTestCaseSize = 5 * 1024 * 1024 // 5 MB
 // are skipped during recording and only body size is stored.
 const LargeBodyThreshold = 1 * 1024 * 1024 // 1 MB
 
-func Capture(ctx context.Context, logger *zap.Logger, t chan *models.TestCase, req *http.Request, resp *http.Response, reqTimeTest time.Time, resTimeTest time.Time, opts models.IncomingOptions, synchronous bool, appPort uint16) {
+func Capture(ctx context.Context, logger *zap.Logger, t chan *models.TestCase, req *http.Request, resp *http.Response, reqTimeTest time.Time, resTimeTest time.Time, opts models.IncomingOptions, synchronous bool, mapping bool, appPort uint16) {
 	if memoryguard.IsRecordingPaused() {
 		// Close bodies even when skipping capture to avoid resource leaks.
 		if req.Body != nil {
@@ -179,7 +184,7 @@ func Capture(ctx context.Context, logger *zap.Logger, t chan *models.TestCase, r
 		testName := fmt.Sprintf("test-%d", currentID)
 		testCase.Name = testName
 		if mgr := syncMock.Get(); mgr != nil { // dumping the test case from mock manager in synchronous mode
-			mgr.ResolveRange(reqTimeTest, resTimeTest, testCase.Name, true, false)
+			mgr.ResolveRange(reqTimeTest, resTimeTest, testCase.Name, true, mapping)
 		}
 	}
 	select {

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -147,12 +147,14 @@ var feederInFlightBytes atomic.Int64
 // maxSize, or a full channel cause the feeder to silently stop
 // capturing while forwarding continues unimpacted.
 type asyncPipeFeeder struct {
-	ch        chan timedChunk
-	closed    atomic.Bool
-	written   atomic.Int64
-	maxSize   int64
-	logger    *zap.Logger
-	closeOnce sync.Once
+	ch             chan timedChunk
+	closed         atomic.Bool
+	written        atomic.Int64
+	maxSize        int64
+	logger         *zap.Logger
+	closeOnce      sync.Once
+	parserExited   chan struct{}
+	parserExitOnce sync.Once
 
 	// cur and lastReadNano are touched only from the parser goroutine
 	// (the single Read caller), so no synchronization is needed for
@@ -177,9 +179,10 @@ func newAsyncPipeFeeder(maxSize int, logger *zap.Logger) *asyncPipeFeeder {
 		// cause data to accumulate. Overflowing kills capture for the
 		// rest of the connection because the HTTP stream becomes
 		// unrecoverable.
-		ch:      make(chan timedChunk, 512),
-		maxSize: int64(maxSize),
-		logger:  logger,
+		ch:           make(chan timedChunk, 512),
+		maxSize:      int64(maxSize),
+		logger:       logger,
+		parserExited: make(chan struct{}),
 	}
 }
 
@@ -287,14 +290,25 @@ func (f *asyncPipeFeeder) Write(p []byte) (int, error) {
 // and their bytes returned to the global in-flight counter. Without the
 // drain those bytes would stay accounted-for (counter never decrements)
 // even though the parser goroutine has already exited on io.EOF — which
-// would slowly leak the global cap over the lifetime of the agent. The
-// drain is fire-and-forget because no caller cares when it finishes; Go
-// GC reclaims the chunks once the goroutine exits.
+// would slowly leak the global cap over the lifetime of the agent.
+//
+// The drain MUST wait for the parser to exit before consuming chunks. If the
+// drain races the parser, it can steal chunks that the parser has not yet
+// read — `<-f.ch` happily returns buffered chunks even after the channel is
+// closed, so whichever goroutine wins the read takes the data. Under
+// short-lived HTTP/1.0 + Connection: close exchanges (response arrives,
+// upstream closes immediately, shutdown fires) the drain frequently wins on
+// connections whose parser hasn't yet been scheduled by the Go runtime,
+// silently dropping a request/response pair from the test set. python-schema-match
+// reproduced this as a missing capture (/edge/nested_null) under the burst of
+// 12 sequential urllib calls. Sequencing the drain after the parser's exit
+// removes the race while still reclaiming the in-flight counter.
 func (f *asyncPipeFeeder) shutdown() {
 	f.closed.Store(true)
 	f.closeOnce.Do(func() {
 		close(f.ch)
 		go func() {
+			<-f.parserExited
 			for chunk := range f.ch {
 				feederInFlightBytes.Add(-int64(len(chunk.data)))
 			}
@@ -306,6 +320,16 @@ func (f *asyncPipeFeeder) shutdown() {
 // Must be called after the forwarding goroutine finishes (after io.Copy returns).
 func (f *asyncPipeFeeder) Close() {
 	f.shutdown()
+}
+
+// signalParserExit must be called by the parser goroutine on exit (typically
+// via defer) so the shutdown drain can safely proceed without racing the
+// parser for channel data. Idempotent — safe to call multiple times. If
+// no parser is ever attached to this feeder (e.g. capture disabled before
+// the goroutine launches) the deferred close in handleHttp1ZeroCopy must
+// still fire this so shutdown's drain doesn't block forever.
+func (f *asyncPipeFeeder) signalParserExit() {
+	f.parserExitOnce.Do(func() { close(f.parserExited) })
 }
 
 // LastReadTime returns the arrival timestamp of the most recent chunk
@@ -884,6 +908,12 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 //     this point.
 func (pm *IngressProxyManager) parseStreamingHTTP(ctx context.Context, logger *zap.Logger,
 	reqFeeder, respFeeder *asyncPipeFeeder, t chan *models.TestCase, appPort uint16) {
+
+	// Unblock shutdown's drain goroutine on every exit path. Without this
+	// the drain would race with our Read() for channel data and could steal
+	// chunks before we consume them, silently dropping captures.
+	defer reqFeeder.signalParserExit()
+	defer respFeeder.signalParserExit()
 
 	reqReader := bufio.NewReader(reqFeeder)
 	respReader := bufio.NewReader(respFeeder)

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -1032,8 +1032,14 @@ func (pm *IngressProxyManager) parseStreamingHTTP(ctx context.Context, logger *z
 		// guard. The acquire blocks the parser if the semaphore is
 		// saturated — that backpressure is what prevents the next
 		// in-flight allocation, so it must be on the parser goroutine,
-		// not inside the launched goroutine.
-		captureHookSem <- struct{}{}
+		// not inside the launched goroutine. Race the acquire with
+		// ctx.Done() so a connection close during agent shutdown unblocks
+		// the parser instead of pinning it to a saturated semaphore.
+		select {
+		case captureHookSem <- struct{}{}:
+		case <-ctx.Done():
+			return
+		}
 		go func(req *http.Request, resp *http.Response, reqTs, respTs time.Time) {
 			defer func() { <-captureHookSem }()
 			hooksUtils.CaptureHook(ctx, logger, t, req, resp, reqTs, respTs, pm.incomingOpts, pm.synchronous, pm.mapping, appPort)

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -89,23 +89,44 @@ func (b *httpBodyCaptureBuffer) Reset() {
 	b.buf.Reset()
 }
 
+// timedChunk pairs a forwarded byte slice with the time the proxy's
+// io.Copy goroutine read it from the source socket. The bridge stamps
+// `lastReadNano` with this time AFTER the chunk has been consumed by
+// the parser-side pipe reader, giving the parser an accurate "when did
+// these bytes arrive at the proxy" anchor — which is what we want for
+// the per-test window, not "when did the parser get scheduled to look
+// at this byte stream."
+type timedChunk struct {
+	data   []byte
+	readAt time.Time
+}
+
 // asyncPipeFeeder is a non-blocking writer used in the forwarding path.
 // It copies incoming bytes to a buffered channel; a separate bridge goroutine
 // drains the channel into an io.PipeWriter. This guarantees the forwarding
 // goroutine (io.Copy) is never blocked by capture — even if the parser is slow
 // or CaptureHook blocks on a full channel.
 //
+// Each enqueued chunk carries a `readAt` timestamp captured at the moment
+// io.Copy handed bytes to the feeder (i.e., immediately after the source
+// socket Read returned). After the bridge successfully writes the chunk
+// to the pipe — meaning the parser has consumed those bytes — the feeder
+// stores the chunk's `readAt` in `lastReadNano`. Parsers query
+// LastReadTime() right after consuming a request/response so the captured
+// timestamp reflects byte arrival, not parser-iteration-start time.
+//
 // Graceful degradation: when memory pressure is detected, the max capture size
 // is exceeded, or the channel fills up, the feeder silently stops capturing.
 // The forwarding path is never affected.
 type asyncPipeFeeder struct {
-	ch        chan []byte
-	pw        *io.PipeWriter
-	closed    atomic.Bool
-	written   atomic.Int64
-	maxSize   int64
-	logger    *zap.Logger
-	closeOnce sync.Once
+	ch           chan timedChunk
+	pw           *io.PipeWriter
+	closed       atomic.Bool
+	written      atomic.Int64
+	maxSize      int64
+	logger       *zap.Logger
+	closeOnce    sync.Once
+	lastReadNano atomic.Int64
 }
 
 // newAsyncPipeFeeder creates a feeder and returns the pipe reader end for
@@ -120,7 +141,7 @@ func newAsyncPipeFeeder(maxSize int, logger *zap.Logger) (*asyncPipeFeeder, *io.
 		// cause data to accumulate. Overflowing kills capture for the
 		// rest of the connection because the HTTP stream becomes
 		// unrecoverable.
-		ch:      make(chan []byte, 512),
+		ch:      make(chan timedChunk, 512),
 		pw:      pw,
 		maxSize: int64(maxSize),
 		logger:  logger,
@@ -132,10 +153,26 @@ func newAsyncPipeFeeder(maxSize int, logger *zap.Logger) (*asyncPipeFeeder, *io.
 // bridge drains the buffered channel into the pipe writer. It runs in its
 // own goroutine so the forwarding goroutine never blocks on pipe writes.
 // Exits when the channel is closed (by Close) or on pipe write error.
+//
+// lastReadNano is stamped BEFORE pipe.Write rather than after. Reasoning:
+// io.Pipe.Write blocks until the reader fully consumes the slice, so once
+// Write returns the parser is already unblocked and can race ahead to
+// query LastReadTime before this goroutine gets scheduled to perform a
+// post-Write store. Storing first guarantees the parser sees a non-zero
+// timestamp for the current chunk on its very first LastReadTime call,
+// which is critical for short single-chunk requests where the parser
+// completes ReadRequest+body without triggering another pipe.Read cycle.
+// The "overshoot" risk (lastReadNano reflecting a chunk that's queued
+// but not yet consumed) is bounded to one chunk and only relevant on
+// reused connections with sub-microsecond inter-request gaps — well
+// below the granularity that matters for per-test window attribution.
 func (f *asyncPipeFeeder) bridge() {
 	defer f.pw.Close()
 	for chunk := range f.ch {
-		if _, err := f.pw.Write(chunk); err != nil {
+		if !chunk.readAt.IsZero() {
+			f.lastReadNano.Store(chunk.readAt.UnixNano())
+		}
+		if _, err := f.pw.Write(chunk.data); err != nil {
 			// Pipe reader closed (parser done). Mark closed so Write()
 			// stops enqueuing new items via its non-blocking select.
 			// Return immediately — no need to drain the channel here.
@@ -163,10 +200,14 @@ func (f *asyncPipeFeeder) Write(p []byte) (int, error) {
 		return len(p), nil
 	}
 	// Copy data — the original slice belongs to io.Copy's reusable buffer.
+	// Capture the arrival time NOW (right after io.Copy.Read returned bytes
+	// from the source socket); this is the timestamp the parser will see
+	// via LastReadTime once these bytes are consumed downstream.
 	buf := make([]byte, len(p))
 	copy(buf, p)
+	chunk := timedChunk{data: buf, readAt: time.Now()}
 	select {
-	case f.ch <- buf:
+	case f.ch <- chunk:
 	default:
 		// Channel full — parser can't keep up. Stop capture entirely
 		// so bridge+parser goroutines can exit.
@@ -196,6 +237,19 @@ func (f *asyncPipeFeeder) shutdown() {
 // forwarding goroutine finishes (after io.Copy returns).
 func (f *asyncPipeFeeder) Close() {
 	f.shutdown()
+}
+
+// LastReadTime returns the arrival timestamp of the most recent chunk that
+// has been fully consumed by the parser-side pipe reader. Zero time means
+// no chunk has been delivered+consumed yet — callers should fall back to
+// time.Now() in that case (matches pre-fix behaviour). Safe to call from
+// any goroutine.
+func (f *asyncPipeFeeder) LastReadTime() time.Time {
+	n := f.lastReadNano.Load()
+	if n == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, n)
 }
 
 func serializeCapturedRequest(req *http.Request, body []byte) ([]byte, error) {
@@ -639,7 +693,7 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 
 			defer parsedHTTPReq.Body.Close()
 			defer parsedHTTPRes.Body.Close()
-			hooksUtils.CaptureHook(ctx, logger, t, parsedHTTPReq, parsedHTTPRes, capturedReqTS, capturedRespTS, pm.incomingOpts, pm.synchronous, actualPort)
+			hooksUtils.CaptureHook(ctx, logger, t, parsedHTTPReq, parsedHTTPRes, capturedReqTS, capturedRespTS, pm.incomingOpts, pm.synchronous, pm.mapping, actualPort)
 		}()
 
 		// Exit the loop in sync/sampling mode or when memory pressure requires closing.
@@ -673,7 +727,7 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 		// limit is enforced downstream in CaptureHook.
 		reqFeeder, reqPipeR = newAsyncPipeFeeder(0, logger)
 		respFeeder, respPipeR = newAsyncPipeFeeder(0, logger)
-		go pm.parseStreamingHTTP(ctx, logger, reqPipeR, respPipeR, t, appPort)
+		go pm.parseStreamingHTTP(ctx, logger, reqFeeder, respFeeder, reqPipeR, respPipeR, t, appPort)
 	}
 
 	// Close connections on context cancellation (shutdown) to unblock
@@ -734,11 +788,17 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 // self-framing (headers end with \r\n\r\n, body length from Content-Length or
 // chunked encoding), so no custom delimiter detection is needed.
 //
-// Timestamps are taken at parse time which closely tracks when bytes actually
-// flowed through the forwarding path, since the pipe feeds data as fast as the
-// network delivers it.
+// Timestamps are sourced from the feeders' LastReadTime, which is stamped at
+// io.Copy's read of the source socket (not when the parser got around to
+// looking at the bytes). Under concurrent client load the parser can run
+// arbitrarily behind the forwarder; using parser-iteration time would push
+// the recorded HTTP timestamps after the corresponding DB-side mock
+// timestamps, breaking the per-test window-attribution invariant relied on
+// by the postgres v3 / mongo v2 dispatchers. Querying LastReadTime AFTER
+// the request/response is fully consumed keeps the captured timestamp
+// pinned to the actual byte arrival even when the parser is queue-deep.
 func (pm *IngressProxyManager) parseStreamingHTTP(ctx context.Context, logger *zap.Logger,
-	reqR *io.PipeReader, respR *io.PipeReader, t chan *models.TestCase, appPort uint16) {
+	reqFeeder, respFeeder *asyncPipeFeeder, reqR *io.PipeReader, respR *io.PipeReader, t chan *models.TestCase, appPort uint16) {
 	defer reqR.Close()
 	defer respR.Close()
 
@@ -749,10 +809,6 @@ func (pm *IngressProxyManager) parseStreamingHTTP(ctx context.Context, logger *z
 		if isIngressRecordingPaused() {
 			return
 		}
-
-		// Timestamp taken just before reading — approximates when the
-		// first byte of this request arrived from the client.
-		reqTimestamp := time.Now()
 
 		req, err := http.ReadRequest(reqReader)
 		if err != nil {
@@ -772,6 +828,18 @@ func (pm *IngressProxyManager) parseStreamingHTTP(ctx context.Context, logger *z
 		if err != nil {
 			return
 		}
+
+		// Now that the request has been fully consumed, the feeder's
+		// LastReadTime reflects the arrival timestamp of the chunk that
+		// contained the last byte of this request. Fall back to time.Now()
+		// only if no chunk has been stamped yet (defensive — should not
+		// happen after a successful ReadRequest, since ReadRequest must
+		// have consumed at least one chunk to return).
+		reqTimestamp := reqFeeder.LastReadTime()
+		if reqTimestamp.IsZero() {
+			reqTimestamp = time.Now()
+		}
+
 		if len(reqBody) > hooksUtils.MaxTestCaseSize {
 			// Body exceeds capture budget — skip this exchange.
 			// Read and discard the response to keep the stream aligned.
@@ -802,16 +870,18 @@ func (pm *IngressProxyManager) parseStreamingHTTP(ctx context.Context, logger *z
 		}
 		resp.Body = io.NopCloser(bytes.NewReader(respBody))
 
-		// Timestamp taken right after reading the full response body —
-		// approximates when the last byte of the response was forwarded.
-		respTimestamp := time.Now()
+		// Same arrival-time invariant for the response side.
+		respTimestamp := respFeeder.LastReadTime()
+		if respTimestamp.IsZero() {
+			respTimestamp = time.Now()
+		}
 		if respTimestamp.Before(reqTimestamp) {
 			respTimestamp = reqTimestamp
 		}
 
 		// Emit in a goroutine so the parser loop is never blocked by
 		// CaptureHook (e.g. if the test case channel is temporarily full).
-		go hooksUtils.CaptureHook(ctx, logger, t, req, resp, reqTimestamp, respTimestamp, pm.incomingOpts, pm.synchronous, appPort)
+		go hooksUtils.CaptureHook(ctx, logger, t, req, resp, reqTimestamp, respTimestamp, pm.incomingOpts, pm.synchronous, pm.mapping, appPort)
 	}
 }
 

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -90,50 +90,68 @@ func (b *httpBodyCaptureBuffer) Reset() {
 }
 
 // timedChunk pairs a forwarded byte slice with the time the proxy's
-// io.Copy goroutine read it from the source socket. The bridge stamps
-// `lastReadNano` with this time AFTER the chunk has been consumed by
-// the parser-side pipe reader, giving the parser an accurate "when did
-// these bytes arrive at the proxy" anchor — which is what we want for
-// the per-test window, not "when did the parser get scheduled to look
-// at this byte stream."
+// io.Copy goroutine read it from the source socket. asyncPipeFeeder.Read
+// stores chunk.readAt into lastReadNano BEFORE returning any bytes from
+// the chunk, so a subsequent LastReadTime call from the same parser
+// goroutine sees the chunk's timestamp.
 type timedChunk struct {
 	data   []byte
 	readAt time.Time
 }
 
-// asyncPipeFeeder is a non-blocking writer used in the forwarding path.
-// It copies incoming bytes to a buffered channel; a separate bridge goroutine
-// drains the channel into an io.PipeWriter. This guarantees the forwarding
-// goroutine (io.Copy) is never blocked by capture — even if the parser is slow
-// or CaptureHook blocks on a full channel.
+// asyncPipeFeeder is the parser-side reader for streaming HTTP capture.
+// io.Copy on the forwarding path writes into it via Write (non-blocking,
+// drops on backpressure); the parseStreamingHTTP goroutine reads from
+// it via Read.
 //
-// Each enqueued chunk carries a `readAt` timestamp captured at the moment
-// io.Copy handed bytes to the feeder (i.e., immediately after the source
-// socket Read returned). After the bridge successfully writes the chunk
-// to the pipe — meaning the parser has consumed those bytes — the feeder
-// stores the chunk's `readAt` in `lastReadNano`. Parsers query
-// LastReadTime() right after consuming a request/response so the captured
-// timestamp reflects byte arrival, not parser-iteration-start time.
+// Earlier revisions placed an io.Pipe + a separate bridge goroutine
+// between Write and Read so the forwarding path was decoupled from
+// parser stalls. That design had a window-attribution bug: the bridge
+// stored chunk N+1's readAt into lastReadNano BEFORE pipe.Write blocked
+// on chunk N+1, so a parser that finished consuming chunk N and then
+// queried LastReadTime could observe chunk N+1's ts (the *next*
+// request's arrival time) as the *current* request's reqTimestamp.
+// Empty-body GETs hit this every time because the parser does not
+// trigger another pipe.Read between ReadRequest's return and its
+// LastReadTime call, so there is no scheduling barrier protecting
+// the read of lastReadNano. The integration listmonk-postgres workload
+// reproduced it as 403-invalid-session failures on tightly packed
+// per-test GETs whose session-lookup mocks ended up attributed to the
+// previous test's window.
 //
-// Graceful degradation: when memory pressure is detected, the max capture size
-// is exceeded, or the channel fills up, the feeder silently stops capturing.
-// The forwarding path is never affected.
+// The simpler design below keeps the channel for backpressure but
+// removes the bridge: Read pulls one chunk at a time from the channel
+// and updates lastReadNano synchronously before returning data. The
+// timestamp store and the data hand-off happen on the same goroutine
+// as the parser's eventual LastReadTime call, so there is no race.
+//
+// Graceful degradation is unchanged: memory pressure, exceeding
+// maxSize, or a full channel cause the feeder to silently stop
+// capturing while forwarding continues unimpacted.
 type asyncPipeFeeder struct {
-	ch           chan timedChunk
-	pw           *io.PipeWriter
-	closed       atomic.Bool
-	written      atomic.Int64
-	maxSize      int64
-	logger       *zap.Logger
-	closeOnce    sync.Once
+	ch        chan timedChunk
+	closed    atomic.Bool
+	written   atomic.Int64
+	maxSize   int64
+	logger    *zap.Logger
+	closeOnce sync.Once
+
+	// cur and lastReadNano are touched only from the parser goroutine
+	// (the single Read caller), so no synchronization is needed for
+	// either. The atomic is for Go's memory model rather than any
+	// cross-goroutine visibility concern: we want LastReadTime callers
+	// from the same goroutine to see the most recent store, which a
+	// plain field would also provide, but atomic.Int64 keeps the type
+	// honest if a future caller queries from another goroutine.
+	cur          []byte
 	lastReadNano atomic.Int64
 }
 
-// newAsyncPipeFeeder creates a feeder and returns the pipe reader end for
-// the streaming parser. The bridge goroutine is started automatically.
-func newAsyncPipeFeeder(maxSize int, logger *zap.Logger) (*asyncPipeFeeder, *io.PipeReader) {
-	pr, pw := io.Pipe()
-	f := &asyncPipeFeeder{
+// newAsyncPipeFeeder creates a feeder used as both the forwarding-side
+// io.Writer and the parser-side io.Reader. There is no separate bridge
+// goroutine; Read pulls chunks from the channel directly.
+func newAsyncPipeFeeder(maxSize int, logger *zap.Logger) *asyncPipeFeeder {
+	return &asyncPipeFeeder{
 		// 512 slots ≈ 16MB at 32KB/chunk. Must be large enough that
 		// the channel never overflows during normal operation — a single
 		// 5MB response body needs ~160 slots, and brief pipeline stalls
@@ -142,56 +160,48 @@ func newAsyncPipeFeeder(maxSize int, logger *zap.Logger) (*asyncPipeFeeder, *io.
 		// rest of the connection because the HTTP stream becomes
 		// unrecoverable.
 		ch:      make(chan timedChunk, 512),
-		pw:      pw,
 		maxSize: int64(maxSize),
 		logger:  logger,
 	}
-	go f.bridge()
-	return f, pr
 }
 
-// bridge drains the buffered channel into the pipe writer. It runs in its
-// own goroutine so the forwarding goroutine never blocks on pipe writes.
-// Exits when the channel is closed (by Close) or on pipe write error.
+// Read returns bytes from the current chunk's data, pulling a new chunk
+// from the channel when the current one is exhausted. The new chunk's
+// readAt is stored into lastReadNano BEFORE any of its data is returned,
+// so a parser that calls LastReadTime after a successful Read sees the
+// timestamp of the chunk that delivered the most recent byte.
 //
-// lastReadNano is stamped BEFORE pipe.Write rather than after. Reasoning:
-// io.Pipe.Write blocks until the reader fully consumes the slice, so once
-// Write returns the parser is already unblocked and can race ahead to
-// query LastReadTime before this goroutine gets scheduled to perform a
-// post-Write store. Storing first guarantees the parser sees a non-zero
-// timestamp for the current chunk on its very first LastReadTime call,
-// which is critical for short single-chunk requests where the parser
-// completes ReadRequest+body without triggering another pipe.Read cycle.
-// The "overshoot" risk (lastReadNano reflecting a chunk that's queued
-// but not yet consumed) is bounded to one chunk and only relevant on
-// reused connections with sub-microsecond inter-request gaps — well
-// below the granularity that matters for per-test window attribution.
-func (f *asyncPipeFeeder) bridge() {
-	defer f.pw.Close()
-	for chunk := range f.ch {
+// Read is the only consumer of the channel and only ever runs on the
+// parseStreamingHTTP goroutine; cur and lastReadNano are not shared.
+// On channel close, Read returns io.EOF, which propagates through the
+// bufio.Reader to terminate ReadRequest/ReadResponse cleanly.
+func (f *asyncPipeFeeder) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if len(f.cur) == 0 {
+		chunk, ok := <-f.ch
+		if !ok {
+			return 0, io.EOF
+		}
+		f.cur = chunk.data
 		if !chunk.readAt.IsZero() {
 			f.lastReadNano.Store(chunk.readAt.UnixNano())
 		}
-		if _, err := f.pw.Write(chunk.data); err != nil {
-			// Pipe reader closed (parser done). Mark closed so Write()
-			// stops enqueuing new items via its non-blocking select.
-			// Return immediately — no need to drain the channel here.
-			// Write() won't block on send (select/default), and Close()
-			// will close the channel when the forwarding goroutine finishes.
-			f.closed.Store(true)
-			return
-		}
 	}
+	n := copy(p, f.cur)
+	f.cur = f.cur[n:]
+	return n, nil
 }
 
-// Write copies p and enqueues it for the bridge goroutine. It never blocks
-// the caller. Called only from the forwarding goroutine (via io.MultiWriter).
+// Write copies p and enqueues it for the parser. It never blocks the
+// caller. Called only from the forwarding goroutine (via io.MultiWriter).
 func (f *asyncPipeFeeder) Write(p []byte) (int, error) {
 	if f.closed.Load() {
 		return len(p), nil
 	}
 	if isIngressRecordingPaused() {
-		f.shutdown() // close channel so bridge+parser exit promptly
+		f.shutdown() // close channel so the parser exits promptly
 		return len(p), nil
 	}
 	newTotal := f.written.Add(int64(len(p)))
@@ -210,7 +220,7 @@ func (f *asyncPipeFeeder) Write(p []byte) (int, error) {
 	case f.ch <- chunk:
 	default:
 		// Channel full — parser can't keep up. Stop capture entirely
-		// so bridge+parser goroutines can exit.
+		// so the parser goroutine sees io.EOF and exits.
 		f.shutdown()
 		if f.logger != nil {
 			f.logger.Debug("Capture channel full — dropping remaining test cases on this connection. "+
@@ -233,17 +243,21 @@ func (f *asyncPipeFeeder) shutdown() {
 	f.closeOnce.Do(func() { close(f.ch) })
 }
 
-// Close signals the bridge goroutine to exit. Must be called after the
-// forwarding goroutine finishes (after io.Copy returns).
+// Close signals the parser goroutine to exit by closing the chunk channel.
+// Must be called after the forwarding goroutine finishes (after io.Copy returns).
 func (f *asyncPipeFeeder) Close() {
 	f.shutdown()
 }
 
-// LastReadTime returns the arrival timestamp of the most recent chunk that
-// has been fully consumed by the parser-side pipe reader. Zero time means
-// no chunk has been delivered+consumed yet — callers should fall back to
-// time.Now() in that case (matches pre-fix behaviour). Safe to call from
-// any goroutine.
+// LastReadTime returns the arrival timestamp of the most recent chunk
+// that Read returned bytes from. Zero time means no chunk has been read
+// yet — callers should fall back to time.Now() in that case.
+//
+// Intended call site: from the parser goroutine, immediately after
+// http.ReadRequest / http.ReadResponse returns. Because the timestamp
+// store happens inside Read (same goroutine, before bytes are returned),
+// the parser is guaranteed to see the right chunk's timestamp without
+// any synchronization beyond Go's memory model.
 func (f *asyncPipeFeeder) LastReadTime() time.Time {
 	n := f.lastReadNano.Load()
 	if n == 0 {
@@ -719,15 +733,14 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 	captureEnabled := !isIngressRecordingPaused()
 	var reqFeeder, respFeeder *asyncPipeFeeder
 	if captureEnabled {
-		var reqPipeR, respPipeR *io.PipeReader
 		// maxSize=0 disables the per-feeder total-bytes limit. With
 		// streaming capture the parser consumes data incrementally, so
 		// in-flight memory is bounded by the channel buffer plus one
 		// request/response body in the parser. The per-test-case size
 		// limit is enforced downstream in CaptureHook.
-		reqFeeder, reqPipeR = newAsyncPipeFeeder(0, logger)
-		respFeeder, respPipeR = newAsyncPipeFeeder(0, logger)
-		go pm.parseStreamingHTTP(ctx, logger, reqFeeder, respFeeder, reqPipeR, respPipeR, t, appPort)
+		reqFeeder = newAsyncPipeFeeder(0, logger)
+		respFeeder = newAsyncPipeFeeder(0, logger)
+		go pm.parseStreamingHTTP(ctx, logger, reqFeeder, respFeeder, t, appPort)
 	}
 
 	// Close connections on context cancellation (shutdown) to unblock
@@ -780,7 +793,7 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 	// by parseStreamingHTTP as each HTTP exchange completed.
 }
 
-// parseStreamingHTTP reads from request and response pipes concurrently with
+// parseStreamingHTTP reads from request and response feeders concurrently with
 // live forwarding, emitting test cases as soon as each HTTP exchange completes.
 // This avoids waiting for the connection to close before capturing test cases.
 //
@@ -788,22 +801,33 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 // self-framing (headers end with \r\n\r\n, body length from Content-Length or
 // chunked encoding), so no custom delimiter detection is needed.
 //
-// Timestamps are sourced from the feeders' LastReadTime, which is stamped at
-// io.Copy's read of the source socket (not when the parser got around to
-// looking at the bytes). Under concurrent client load the parser can run
-// arbitrarily behind the forwarder; using parser-iteration time would push
-// the recorded HTTP timestamps after the corresponding DB-side mock
-// timestamps, breaking the per-test window-attribution invariant relied on
-// by the postgres v3 / mongo v2 dispatchers. Querying LastReadTime AFTER
-// the request/response is fully consumed keeps the captured timestamp
-// pinned to the actual byte arrival even when the parser is queue-deep.
+// Timestamps are sourced from the feeders' LastReadTime, which is stamped
+// inside the feeder's Read at io.Copy's read of the source socket. Under
+// concurrent client load the parser can run arbitrarily behind the
+// forwarder; using parser-iteration time would push the recorded HTTP
+// timestamps after the corresponding DB-side mock timestamps, breaking
+// the per-test window-attribution invariant relied on by the postgres v3
+// / mongo v2 dispatchers.
+//
+// Request vs response timestamp semantics differ:
+//
+//   - reqTimestamp captures FIRST-byte arrival. Snapshot AFTER ReadRequest
+//     parses headers but BEFORE io.ReadAll consumes the body, so any
+//     outbound mocks the app issues while reading the request body
+//     (streaming uploads with side-effects) fall AFTER reqTimestamp and
+//     are correctly inside the per-test window. Capturing post-body would
+//     give last-byte semantic and silently drop those mocks.
+//
+//   - respTimestamp captures LAST-byte arrival. Snapshot AFTER io.ReadAll
+//     consumes the response body — that is when the application has
+//     finished processing the test case and any outbound mocks issued
+//     during processing have already been recorded with timestamps before
+//     this point.
 func (pm *IngressProxyManager) parseStreamingHTTP(ctx context.Context, logger *zap.Logger,
-	reqFeeder, respFeeder *asyncPipeFeeder, reqR *io.PipeReader, respR *io.PipeReader, t chan *models.TestCase, appPort uint16) {
-	defer reqR.Close()
-	defer respR.Close()
+	reqFeeder, respFeeder *asyncPipeFeeder, t chan *models.TestCase, appPort uint16) {
 
-	reqReader := bufio.NewReader(reqR)
-	respReader := bufio.NewReader(respR)
+	reqReader := bufio.NewReader(reqFeeder)
+	respReader := bufio.NewReader(respFeeder)
 
 	for {
 		if isIngressRecordingPaused() {
@@ -815,11 +839,28 @@ func (pm *IngressProxyManager) parseStreamingHTTP(ctx context.Context, logger *z
 			return
 		}
 
+		// Snapshot reqTimestamp here, AFTER ReadRequest has consumed
+		// the request line + headers but BEFORE io.ReadAll consumes
+		// the body. lastReadNano now reflects the chunk that delivered
+		// the most recent bufio fill — for tightly packed connections
+		// this is the chunk holding the request's first byte; for the
+		// rare case of headers split across two chunks it is the chunk
+		// holding the last header byte (a sub-µs overshoot).
+		//
+		// This is the FIRST-byte semantic the per-test window-
+		// attribution path expects: any DB queries the app issues
+		// during request handling fall AFTER reqTimestamp and BEFORE
+		// respTimestamp, putting them inside the test's window.
+		reqTimestamp := reqFeeder.LastReadTime()
+		if reqTimestamp.IsZero() {
+			reqTimestamp = time.Now()
+		}
+
 		// Set Host header to match pkg.ParseHTTPRequest behavior
 		req.Header.Set("Host", req.Host)
 
 		// Read request body with a size cap to avoid unbounded allocations.
-		// We must consume the full body to advance the pipe reader past it
+		// We must consume the full body to advance the reader past it
 		// (HTTP framing), but only keep up to MaxTestCaseSize in memory.
 		reqBody, err := io.ReadAll(io.LimitReader(req.Body, int64(hooksUtils.MaxTestCaseSize)+1))
 		// Drain any remainder to keep the stream aligned.
@@ -827,17 +868,6 @@ func (pm *IngressProxyManager) parseStreamingHTTP(ctx context.Context, logger *z
 		req.Body.Close()
 		if err != nil {
 			return
-		}
-
-		// Now that the request has been fully consumed, the feeder's
-		// LastReadTime reflects the arrival timestamp of the chunk that
-		// contained the last byte of this request. Fall back to time.Now()
-		// only if no chunk has been stamped yet (defensive — should not
-		// happen after a successful ReadRequest, since ReadRequest must
-		// have consumed at least one chunk to return).
-		reqTimestamp := reqFeeder.LastReadTime()
-		if reqTimestamp.IsZero() {
-			reqTimestamp = time.Now()
 		}
 
 		if len(reqBody) > hooksUtils.MaxTestCaseSize {
@@ -870,7 +900,10 @@ func (pm *IngressProxyManager) parseStreamingHTTP(ctx context.Context, logger *z
 		}
 		resp.Body = io.NopCloser(bytes.NewReader(respBody))
 
-		// Same arrival-time invariant for the response side.
+		// Last-byte semantic for the response: lastReadNano now reflects
+		// the chunk that delivered the final byte of the response body,
+		// so the test window's upper bound encloses any outbound mocks
+		// issued during request handling.
 		respTimestamp := respFeeder.LastReadTime()
 		if respTimestamp.IsZero() {
 			respTimestamp = time.Now()

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -117,6 +117,25 @@ const feederGlobalLimitBytes = 80 * 1024 * 1024 // 80 MB
 
 var feederInFlightBytes atomic.Int64
 
+// captureHookConcurrency caps the number of CaptureHook goroutines
+// running at the same time across every parseStreamingHTTP invocation.
+// Each goroutine takes a reference to the parsed *http.Request /
+// *http.Response (each carrying up to MaxTestCaseSize=5MB of body) and
+// runs io.ReadAll a second time inside Capture to materialise its own
+// reqBody/respBody copy, so peak transient memory per in-flight
+// goroutine is ~10 MB. Without a cap the parser launches one goroutine
+// per HTTP exchange unconditionally; the go-memory-load workload
+// (k6 firing 42 concurrent VUs against /large_payload endpoints)
+// piles hundreds of these goroutines up faster than the unbuffered
+// tcChan can drain them, taking the agent past the 250 MiB CI guard
+// even with the 80 MB feeder cap holding firm. 16 in-flight × ~10 MB
+// = ~160 MB worst-case, leaving headroom inside the 200 MB Docker
+// memory limit alongside the feeder cap (80 MB) and the rest of agent
+// state.
+const captureHookConcurrency = 16
+
+var captureHookSem = make(chan struct{}, captureHookConcurrency)
+
 // asyncPipeFeeder is the parser-side reader for streaming HTTP capture.
 // io.Copy on the forwarding path writes into it via Write (non-blocking,
 // drops on backpressure); the parseStreamingHTTP goroutine reads from
@@ -1001,9 +1020,24 @@ func (pm *IngressProxyManager) parseStreamingHTTP(ctx context.Context, logger *z
 			respTimestamp = reqTimestamp
 		}
 
-		// Emit in a goroutine so the parser loop is never blocked by
-		// CaptureHook (e.g. if the test case channel is temporarily full).
-		go hooksUtils.CaptureHook(ctx, logger, t, req, resp, reqTimestamp, respTimestamp, pm.incomingOpts, pm.synchronous, pm.mapping, appPort)
+		// Emit in a goroutine so the parser loop is never blocked by a
+		// slow CaptureHook (e.g. if the unbuffered tcChan or downstream
+		// disk write stalls). Acquire from captureHookSem before forking
+		// to bound peak goroutine count: under high concurrency we'd
+		// otherwise launch one goroutine per HTTP exchange and each holds
+		// references to req/resp body buffers (up to ~10MB combined,
+		// since CaptureHook itself runs io.ReadAll on the NopCloser-
+		// wrapped bodies the parser already buffered). Letting them
+		// stack unbounded blew through the 250 MiB go-memory-load CI
+		// guard. The acquire blocks the parser if the semaphore is
+		// saturated — that backpressure is what prevents the next
+		// in-flight allocation, so it must be on the parser goroutine,
+		// not inside the launched goroutine.
+		captureHookSem <- struct{}{}
+		go func(req *http.Request, resp *http.Response, reqTs, respTs time.Time) {
+			defer func() { <-captureHookSem }()
+			hooksUtils.CaptureHook(ctx, logger, t, req, resp, reqTs, respTs, pm.incomingOpts, pm.synchronous, pm.mapping, appPort)
+		}(req, resp, reqTimestamp, respTimestamp)
 	}
 }
 

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -99,6 +99,24 @@ type timedChunk struct {
 	readAt time.Time
 }
 
+// Global cap on the bytes held in flight across every asyncPipeFeeder's
+// channel. The per-feeder channel is sized to tolerate large response
+// bodies (5 MB needs ~160 slots at 32 KB/chunk), so under stress workloads
+// with many concurrent connections (go-memory-load: hundreds of in-flight
+// requests, parser unable to drain channels at wire speed) memory growth
+// per feeder × N feeders rapidly exceeds the agent's 250 MiB record-time
+// guard. Counter is decremented when Read pulls a chunk off a channel
+// or when shutdown drains residual chunks; pre-check in Write is the
+// fast path that prevents new allocations once the cap is reached.
+//
+// Value chosen to leave headroom for the rest of the agent (proxy state,
+// mock storage, postgres v3 cohort indexes) under the 200 MiB memory
+// limit set by the CI memory-load harness, while still allowing >2 MB of
+// in-flight capture per active connection in the steady state.
+const feederGlobalLimitBytes = 80 * 1024 * 1024 // 80 MB
+
+var feederInFlightBytes atomic.Int64
+
 // asyncPipeFeeder is the parser-side reader for streaming HTTP capture.
 // io.Copy on the forwarding path writes into it via Write (non-blocking,
 // drops on backpressure); the parseStreamingHTTP goroutine reads from
@@ -184,6 +202,10 @@ func (f *asyncPipeFeeder) Read(p []byte) (int, error) {
 		if !ok {
 			return 0, io.EOF
 		}
+		// Bytes leave the feeder's in-flight pool the moment they're
+		// pulled off the channel — they live on the parser goroutine's
+		// stack/heap until consumed and freed naturally by GC.
+		feederInFlightBytes.Add(-int64(len(chunk.data)))
 		f.cur = chunk.data
 		if !chunk.readAt.IsZero() {
 			f.lastReadNano.Store(chunk.readAt.UnixNano())
@@ -209,6 +231,25 @@ func (f *asyncPipeFeeder) Write(p []byte) (int, error) {
 		f.shutdown()
 		return len(p), nil
 	}
+	// Pre-allocation pressure check: if the global feeder in-flight
+	// counter is already saturated, refuse this chunk and shut the
+	// feeder down rather than allocating into a memory-pressured agent.
+	// Approximate on the Load side (a parallel feeder could push us
+	// over by one chunk) — exactly accurate increment happens below
+	// after the channel send succeeds. Captures-lost is an acceptable
+	// trade for not OOM'ing the agent under stress workloads.
+	chunkSize := int64(len(p))
+	if feederInFlightBytes.Load()+chunkSize > feederGlobalLimitBytes {
+		f.shutdown()
+		if f.logger != nil {
+			f.logger.Debug("Global feeder in-flight cap reached — dropping remaining capture on this connection.",
+				zap.Int64("global_limit_bytes", feederGlobalLimitBytes),
+				zap.Int64("current_in_flight", feederInFlightBytes.Load()),
+				zap.Int("chunk_size", len(p)),
+			)
+		}
+		return len(p), nil
+	}
 	// Copy data — the original slice belongs to io.Copy's reusable buffer.
 	// Capture the arrival time NOW (right after io.Copy.Read returned bytes
 	// from the source socket); this is the timestamp the parser will see
@@ -218,6 +259,9 @@ func (f *asyncPipeFeeder) Write(p []byte) (int, error) {
 	chunk := timedChunk{data: buf, readAt: time.Now()}
 	select {
 	case f.ch <- chunk:
+		// Account for the bytes now sitting in the channel; Read or the
+		// shutdown drain decrement on consumption.
+		feederInFlightBytes.Add(chunkSize)
 	default:
 		// Channel full — parser can't keep up. Stop capture entirely
 		// so the parser goroutine sees io.EOF and exits.
@@ -238,9 +282,24 @@ func (f *asyncPipeFeeder) Write(p []byte) (int, error) {
 // the channel. Safe to call from both Write() (capture disabled mid-stream)
 // and Close() (connection ended). The sync.Once ensures the channel is
 // closed exactly once regardless of which path fires first.
+//
+// After close, residual chunks still sitting in f.ch are drained off-thread
+// and their bytes returned to the global in-flight counter. Without the
+// drain those bytes would stay accounted-for (counter never decrements)
+// even though the parser goroutine has already exited on io.EOF — which
+// would slowly leak the global cap over the lifetime of the agent. The
+// drain is fire-and-forget because no caller cares when it finishes; Go
+// GC reclaims the chunks once the goroutine exits.
 func (f *asyncPipeFeeder) shutdown() {
 	f.closed.Store(true)
-	f.closeOnce.Do(func() { close(f.ch) })
+	f.closeOnce.Do(func() {
+		close(f.ch)
+		go func() {
+			for chunk := range f.ch {
+				feederInFlightBytes.Add(-int64(len(chunk.data)))
+			}
+		}()
+	})
 }
 
 // Close signals the parser goroutine to exit by closing the chunk channel.

--- a/pkg/agent/proxy/incoming/http_test.go
+++ b/pkg/agent/proxy/incoming/http_test.go
@@ -29,6 +29,88 @@ func stubIngressPaused(t *testing.T, fn func() bool) {
 	})
 }
 
+// TestAsyncPipeFeederLastReadTimeMatchesConsumedChunk locks in the contract
+// that LastReadTime, when called after a successful Read, returns the readAt
+// of the chunk whose data the most recent Read returned bytes from — never
+// a chunk that is queued but not yet consumed.
+//
+// This is the exact race that broke listmonk-postgres on PR #4130's first
+// pass: the previous bridge+pipe design stored chunk N+1's ts BEFORE
+// pipe.Write blocked, so a parser that finished consuming chunk N and
+// queried LastReadTime before the bridge advanced past pipe.Write would
+// observe the next chunk's ts as the current request's reqTimestamp,
+// pushing per-test postgres mocks out of the window. Empty-body GETs
+// hit it deterministically because the parser never re-entered Read
+// between ReadRequest and LastReadTime.
+func TestAsyncPipeFeederLastReadTimeMatchesConsumedChunk(t *testing.T) {
+	stubIngressPaused(t, func() bool { return false })
+
+	f := newAsyncPipeFeeder(0, zap.NewNop())
+
+	// Enqueue three chunks at distinct times.
+	t1 := time.Now()
+	t2 := t1.Add(15 * time.Millisecond)
+	t3 := t2.Add(15 * time.Millisecond)
+	f.ch <- timedChunk{data: []byte("AAA"), readAt: t1}
+	f.ch <- timedChunk{data: []byte("BBB"), readAt: t2}
+	f.ch <- timedChunk{data: []byte("CCC"), readAt: t3}
+	close(f.ch)
+
+	// Before any Read, LastReadTime is zero.
+	if !f.LastReadTime().IsZero() {
+		t.Fatalf("expected zero LastReadTime before any Read, got %v", f.LastReadTime())
+	}
+
+	read := func(n int) string {
+		buf := make([]byte, n)
+		got, err := f.Read(buf)
+		if err != nil && err != io.EOF {
+			t.Fatalf("unexpected Read error: %v", err)
+		}
+		return string(buf[:got])
+	}
+
+	// Consume chunk 1 fully. LastReadTime should equal t1, NOT t2 — even
+	// though chunk 2 is already queued.
+	if got := read(3); got != "AAA" {
+		t.Fatalf("first read: want AAA, got %q", got)
+	}
+	if !f.LastReadTime().Equal(t1) {
+		t.Fatalf("after chunk 1: want %v, got %v (overshoot to next chunk)", t1, f.LastReadTime())
+	}
+
+	// Consume chunk 2 fully. LastReadTime should equal t2.
+	if got := read(3); got != "BBB" {
+		t.Fatalf("second read: want BBB, got %q", got)
+	}
+	if !f.LastReadTime().Equal(t2) {
+		t.Fatalf("after chunk 2: want %v, got %v", t2, f.LastReadTime())
+	}
+
+	// Partial read of chunk 3 still updates LastReadTime to t3 (the
+	// chunk was popped on the partial read; subsequent reads draw
+	// from the same chunk).
+	if got := read(2); got != "CC" {
+		t.Fatalf("third read partial: want CC, got %q", got)
+	}
+	if !f.LastReadTime().Equal(t3) {
+		t.Fatalf("after partial chunk 3: want %v, got %v", t3, f.LastReadTime())
+	}
+	// Drain the rest from the same chunk.
+	if got := read(8); got != "C" {
+		t.Fatalf("third read drain: want C, got %q", got)
+	}
+	if !f.LastReadTime().Equal(t3) {
+		t.Fatalf("after full chunk 3: want %v, got %v", t3, f.LastReadTime())
+	}
+
+	// Channel closed, no more chunks. EOF.
+	buf := make([]byte, 4)
+	if _, err := f.Read(buf); err != io.EOF {
+		t.Fatalf("expected EOF after drain, got %v", err)
+	}
+}
+
 func TestHTTPBodyCaptureBufferStopsWhenPaused(t *testing.T) {
 	paused := false
 	stubIngressPaused(t, func() bool { return paused })

--- a/pkg/agent/proxy/incoming/http_test.go
+++ b/pkg/agent/proxy/incoming/http_test.go
@@ -111,6 +111,60 @@ func TestAsyncPipeFeederLastReadTimeMatchesConsumedChunk(t *testing.T) {
 	}
 }
 
+// TestAsyncPipeFeederShutdownDrainWaitsForParser guards the regression
+// fixed alongside python-schema-match's missing /edge/nested_null capture:
+// shutdown's residual-chunk drain MUST wait for the parser goroutine to
+// exit before it consumes anything from the channel. Otherwise the drain
+// races the parser's Read for closed-channel data and silently steals
+// chunks the parser has not yet seen.
+//
+// Repro shape: short-lived HTTP/1.0 + Connection: close exchange where the
+// upstream socket EOFs immediately after the response, triggering Close
+// (and thus shutdown) on the feeder before the parser goroutine has been
+// scheduled. The parser then reads from a channel the drain has already
+// emptied, returns EOF, and emits nothing.
+func TestAsyncPipeFeederShutdownDrainWaitsForParser(t *testing.T) {
+	stubIngressPaused(t, func() bool { return false })
+
+	f := newAsyncPipeFeeder(0, zap.NewNop())
+
+	// Enqueue a chunk, mimicking io.Copy's Write of a single response.
+	if _, err := f.Write([]byte("HELLO")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// Forwarder finished — close the feeder. This used to spawn a drain
+	// goroutine that started consuming f.ch immediately, racing with the
+	// not-yet-scheduled parser.
+	f.Close()
+
+	// Give the (pre-fix) drain goroutine ample time to win the race and
+	// empty the channel. With the fix in place the drain blocks on the
+	// parserExited signal and stays out of the channel.
+	time.Sleep(20 * time.Millisecond)
+
+	// Now play parser: read the chunk. With the fix this must succeed —
+	// the chunk is still in the channel waiting for us. Pre-fix the
+	// channel is empty and Read returns EOF.
+	buf := make([]byte, 8)
+	n, err := f.Read(buf)
+	if err != nil && err != io.EOF {
+		t.Fatalf("Read: unexpected error %v", err)
+	}
+	if string(buf[:n]) != "HELLO" {
+		t.Fatalf("parser was supposed to consume HELLO before drain — got %q (drain raced and stole the chunk)", string(buf[:n]))
+	}
+
+	// Signal parser exit so shutdown's drain can proceed and the goroutine
+	// doesn't leak past test end.
+	f.signalParserExit()
+
+	// EOF after drain.
+	if _, err := f.Read(buf); err != io.EOF {
+		t.Fatalf("expected EOF after drain, got %v", err)
+	}
+}
+
 func TestHTTPBodyCaptureBufferStopsWhenPaused(t *testing.T) {
 	paused := false
 	stubIngressPaused(t, func() bool { return paused })

--- a/pkg/agent/proxy/incoming/http_test.go
+++ b/pkg/agent/proxy/incoming/http_test.go
@@ -165,6 +165,55 @@ func TestAsyncPipeFeederShutdownDrainWaitsForParser(t *testing.T) {
 	}
 }
 
+// TestCaptureHookSemaphoreMatchesConcurrencyConstant guards the link
+// between captureHookConcurrency and captureHookSem's buffer size. If
+// the constant is bumped without re-allocating the channel (or vice
+// versa), the parser would silently lose its concurrency cap and
+// regress the go-memory-load CI guard. Cap is asserted on the live
+// channel so a future refactor that swaps the type still has to keep
+// the invariant true.
+func TestCaptureHookSemaphoreMatchesConcurrencyConstant(t *testing.T) {
+	if got := cap(captureHookSem); got != captureHookConcurrency {
+		t.Fatalf("captureHookSem cap=%d, want %d (must equal captureHookConcurrency)", got, captureHookConcurrency)
+	}
+}
+
+// TestCaptureHookSemaphoreBackpressuresParser verifies that once
+// captureHookConcurrency permits are held, a further send on
+// captureHookSem blocks — i.e. the parser goroutine in
+// parseStreamingHTTP would block before launching another CaptureHook
+// goroutine. Without this backpressure the unbounded `go
+// hooksUtils.CaptureHook(...)` call piled goroutines (each holding ~10MB
+// in body buffers) past the 250 MiB go-memory-load CI threshold.
+func TestCaptureHookSemaphoreBackpressuresParser(t *testing.T) {
+	// Save and restore the global so this test doesn't poison sibling
+	// tests that may run before parseStreamingHTTP fires CaptureHook.
+	saved := captureHookSem
+	t.Cleanup(func() { captureHookSem = saved })
+	captureHookSem = make(chan struct{}, captureHookConcurrency)
+
+	for i := 0; i < captureHookConcurrency; i++ {
+		select {
+		case captureHookSem <- struct{}{}:
+		default:
+			t.Fatalf("acquire %d unexpectedly blocked before reaching capacity", i)
+		}
+	}
+
+	// One more acquire must NOT succeed in non-blocking mode — that's
+	// the backpressure the parser relies on.
+	select {
+	case captureHookSem <- struct{}{}:
+		t.Fatal("acquire past captureHookConcurrency succeeded; semaphore is not backpressuring")
+	default:
+	}
+
+	// Drain so the channel is left empty for any later subtests.
+	for i := 0; i < captureHookConcurrency; i++ {
+		<-captureHookSem
+	}
+}
+
 func TestHTTPBodyCaptureBufferStopsWhenPaused(t *testing.T) {
 	paused := false
 	stubIngressPaused(t, func() bool { return paused })

--- a/pkg/agent/proxy/incoming/http_test.go
+++ b/pkg/agent/proxy/incoming/http_test.go
@@ -252,7 +252,7 @@ func TestHandleHttp1Connection_ChunkedExchangeIsCaptured(t *testing.T) {
 	captureWG.Add(1)
 	stubCaptureHook(t, func(ctx context.Context, logger *zap.Logger, tc chan *models.TestCase,
 		req *http.Request, resp *http.Response, reqTS, respTS time.Time,
-		opts models.IncomingOptions, synchronous bool, appPort uint16) {
+		opts models.IncomingOptions, synchronous bool, mapping bool, appPort uint16) {
 		defer captureWG.Done()
 		// Read request+response bodies here so the test can assert them.
 		reqBody, _ := io.ReadAll(req.Body)
@@ -408,7 +408,7 @@ func TestHandleHttp1Connection_ChunkedRequestIsCaptured(t *testing.T) {
 	captureWG.Add(1)
 	stubCaptureHook(t, func(ctx context.Context, logger *zap.Logger, tc chan *models.TestCase,
 		req *http.Request, resp *http.Response, reqTS, respTS time.Time,
-		opts models.IncomingOptions, synchronous bool, appPort uint16) {
+		opts models.IncomingOptions, synchronous bool, mapping bool, appPort uint16) {
 		defer captureWG.Done()
 		rb, _ := io.ReadAll(req.Body)
 		rsb, _ := io.ReadAll(resp.Body)

--- a/pkg/agent/proxy/incoming/incoming.go
+++ b/pkg/agent/proxy/incoming/incoming.go
@@ -42,8 +42,15 @@ type IngressProxyManager struct {
 	tcChan       chan *models.TestCase
 	incomingOpts models.IncomingOptions
 	synchronous  bool
-	sampling     bool
-	samplingSem  chan struct{}
+	// mapping mirrors !cfg.DisableMapping at construction time. Forwarded
+	// to CaptureHook so the synchronous-record path can decide whether
+	// SyncMockManager.ResolveRange should emit a TestMockMapping entry
+	// onto the agent's mappingChan. Without this plumbing the mapping
+	// arg was hardcoded false at the OSS Capture call site, which
+	// silently disabled mappings.yaml production during record (#3905).
+	mapping     bool
+	sampling    bool
+	samplingSem chan struct{}
 
 	ingressHook IngressHook
 }
@@ -55,6 +62,7 @@ func New(logger *zap.Logger, h agent.Hooks, cfg *config.Config) *IngressProxyMan
 		tcChan:      make(chan *models.TestCase, 100),
 		active:      make(map[uint16]proxyStop),
 		synchronous: cfg.Agent.Synchronous,
+		mapping:     !cfg.DisableMapping,
 		sampling:    false,
 		samplingSem: make(chan struct{}, func() int {
 			if cfg.Agent.EnableSampling > 0 {

--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -241,6 +241,22 @@ func (m *SyncMockManager) AddMock(mock *models.Mock) {
 	switch {
 	case closed:
 		m.mu.Unlock()
+		// Per-mock diagnostic: visible signal when AddMock drops a
+		// mock because the outChan has already been closed by
+		// CloseOutChan. This usually only fires during shutdown but
+		// in CI a poorly-ordered teardown can race the recorder's
+		// final emit and silently lose mocks captured in the last
+		// few milliseconds of the run. The dropLogger is the right
+		// receiver — it ALWAYS resolves to a non-nil logger and is
+		// safe under the m.mu unlock.
+		if logger := m.dropLogger(); logger != nil {
+			logger.Debug("AddMock: outChan already closed, mock dropped",
+				zap.String("mock_kind", string(mock.Kind)),
+				zap.String("connID", mock.ConnectionID),
+				zap.String("lifetime", mock.TestModeInfo.Lifetime.String()),
+				zap.Time("mock_req_ts", mock.Spec.ReqTimestampMock),
+			)
+		}
 		return
 	case bound && !m.firstReqSeen:
 		m.mu.Unlock()
@@ -450,6 +466,25 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 		// lifetime carve-out at the top of the loop and never reach
 		// this branch.)
 		if mockTime.Before(cutoffTime) {
+			// Per-mock diagnostic: a per-test mock that fell off the
+			// stale-buffer cutoff almost always means the recorder
+			// kept emitting after the dedup queue had advanced past
+			// the matching test's window — log enough context for
+			// post-hoc CI analysis. Sampled via dropLogger to honour
+			// the same flood-prevention as the outChan-overflow path.
+			if logger := m.dropLogger(); logger != nil {
+				logger.Debug("ResolveRange: stale-cutoff drop (out-of-window per-test mock older than 7s)",
+					zap.String("mock_name", mock.Name),
+					zap.String("mock_kind", string(mock.Kind)),
+					zap.String("connID", mock.ConnectionID),
+					zap.String("lifetime", mock.TestModeInfo.Lifetime.String()),
+					zap.Time("mock_req_ts", mockTime),
+					zap.Time("window_start", start),
+					zap.Time("window_end", end),
+					zap.Time("cutoff", cutoffTime),
+					zap.String("test_name", testName),
+				)
+			}
 			continue
 		}
 
@@ -459,6 +494,10 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 		m.buffer[keepIdx] = mock
 		keepIdx++
 	}
+
+	// Snapshot pre-truncation length so the diagnostic can report
+	// "shrunk from N to M" rather than the post-truncation length.
+	bufferLenBefore := len(m.buffer)
 
 	// MEMORY CLEANUP: Nil out the deleted entries to allow GC to reclaim the memory
 	for i := keepIdx; i < len(m.buffer); i++ {
@@ -475,7 +514,30 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 		}
 	}
 
+	bufferLenAfter := len(m.buffer)
+	mocksToSendLen := len(mocksToSend)
+
 	m.mu.Unlock()
+
+	// Per-resolve diagnostic: surface buffer-state transitions per
+	// test-window resolve so a CI log can show when a per-test cohort
+	// flushed zero mocks or when stale-buffer cutoff started reaping.
+	// Sampled via dropLogger which is the standard observability sink
+	// for buffer-flow events on this manager. Only logged when there
+	// was actual state change to avoid log noise on idle resolves.
+	if logger := m.dropLogger(); logger != nil && (bufferLenBefore != bufferLenAfter || mocksToSendLen > 0) {
+		logger.Debug("ResolveRange: buffer transition",
+			zap.String("test_name", testName),
+			zap.Time("window_start", start),
+			zap.Time("window_end", end),
+			zap.Int("buffer_len_before", bufferLenBefore),
+			zap.Int("buffer_len_after", bufferLenAfter),
+			zap.Int("mocks_flushed", mocksToSendLen),
+			zap.Int("dropped_total", bufferLenBefore-bufferLenAfter-mocksToSendLen),
+			zap.Bool("outChan_bound", outChanBound),
+			zap.Bool("mapping_enabled", mapping),
+		)
+	}
 
 	// Route mock sends through sendToOutChan so the close-vs-send
 	// race is serialized the same way AddMock does it. Mapping

--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -250,7 +250,7 @@ func (m *SyncMockManager) AddMock(mock *models.Mock) {
 		// receiver — it ALWAYS resolves to a non-nil logger and is
 		// safe under the m.mu unlock.
 		if logger := m.dropLogger(); logger != nil {
-			logger.Debug("AddMock: outChan already closed, mock dropped",
+			logger.Info("diag/AddMock: outChan already closed, mock dropped",
 				zap.String("mock_kind", string(mock.Kind)),
 				zap.String("connID", mock.ConnectionID),
 				zap.String("lifetime", mock.TestModeInfo.Lifetime.String()),
@@ -473,7 +473,7 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 			// post-hoc CI analysis. Sampled via dropLogger to honour
 			// the same flood-prevention as the outChan-overflow path.
 			if logger := m.dropLogger(); logger != nil {
-				logger.Debug("ResolveRange: stale-cutoff drop (out-of-window per-test mock older than 7s)",
+				logger.Info("diag/ResolveRange: stale-cutoff drop (out-of-window per-test mock older than 7s)",
 					zap.String("mock_name", mock.Name),
 					zap.String("mock_kind", string(mock.Kind)),
 					zap.String("connID", mock.ConnectionID),
@@ -526,7 +526,7 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 	// for buffer-flow events on this manager. Only logged when there
 	// was actual state change to avoid log noise on idle resolves.
 	if logger := m.dropLogger(); logger != nil && (bufferLenBefore != bufferLenAfter || mocksToSendLen > 0) {
-		logger.Debug("ResolveRange: buffer transition",
+		logger.Info("diag/ResolveRange: buffer transition",
 			zap.String("test_name", testName),
 			zap.Time("window_start", start),
 			zap.Time("window_end", end),

--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -210,54 +210,37 @@ func (m *SyncMockManager) AddMock(mock *models.Mock) {
 	}
 
 	// Decide forward vs buffer vs drop under a single snapshot of
-	// (outChan, outChanClosed). The legal outcomes:
+	// (outChan, outChanClosed). The trio has three legal outcomes:
 	//
-	//   closed                       → drop (shutdown in progress)
-	//   bound + session/connection   → forward (Lifetime contract is
-	//                                  "reusable across all windows";
-	//                                  buffering would leak the mock —
-	//                                  ResolveRange only flushes mocks
-	//                                  that match a per-test window and
-	//                                  session/connection mocks never
-	//                                  do, so anything that lands in
-	//                                  m.buffer for these tiers is
-	//                                  unrecoverable until shutdown
-	//                                  drops it)
-	//   unbound (nil)                → buffer (SetOutputChannel hasn't
-	//                                  fired yet; ResolveRange will emit
-	//                                  once bound)
-	//   bound + !firstReqSeen        → forward (pre-first-request mocks
-	//                                  bypass the buffer)
-	//   bound +  firstReqSeen        → buffer (per-test mock waiting
-	//                                  for window match in ResolveRange)
+	//   closed          → drop (shutdown in progress, buffer would leak)
+	//   unbound (nil)   → buffer (SetOutputChannel hasn't fired yet;
+	//                     ResolveRange will emit once bound)
+	//   bound + open    → forward via sendToOutChan, unless we're
+	//                     past firstReqSeen in which case the mock
+	//                     belongs in the dedup buffer for windowing
 	//
-	// The session/connection bypass restores the pre-#4122 behaviour
-	// for parsers (mongo V2 handshake/auth/heartbeat, postgres v3
-	// startup, mysql HikariCP COM_PING) whose reusable traffic is
-	// captured continuously through the recording. Those mocks must
-	// reach the recorder regardless of whether they arrive before or
-	// after the first app test request, and they never need windowing
-	// because their Lifetime makes them reusable across every test.
-	// Without this branch, a session-tagged mock emitted post-first-
-	// request — e.g. a mongo pool connection's handshake when the
-	// driver opens a second pool slot mid-replay-record — falls into
-	// the per-test buffer, never matches a per-test ResolveRange
-	// window, and is silently lost at shutdown. That was the symptom
-	// behind run_golang_native_windows / gin-mongo (record_build_
-	// replay_build) on PR #4130 run 24962475421: mongo handshake
-	// dropped, replay's gin app got EOF on the driver socket, every
-	// mongo-touching test failed.
+	// Session- and connection-scoped mocks (mongo handshake/heartbeat,
+	// postgres v3 startup, mysql HikariCP COM_PING) follow the same
+	// branching here — they ride the buffer when firstReqSeen has
+	// fired so they keep their FIFO position relative to per-test
+	// mocks captured on the same connection. ResolveRange's lifetime
+	// carve-out drains them to outChan without subjecting them to
+	// the per-test window match (so they're not dropped by the 7 s
+	// cutoff for being out-of-window) but preserves arrival order.
+	// An earlier attempt forwarded session mocks to outChan straight
+	// from AddMock; that broke run_fuzzer_linux / Mongo Fuzzer
+	// (record_build_replay_build) because the bypass hoisted handshake
+	// mocks ahead of the per-test mocks emitted at end-of-test from
+	// the buffer. Replay's connection-keyed FIFO matcher then saw
+	// handshakes interleaved out of order with the operations they
+	// preceded and stalled on the last batch of ops. Keeping the
+	// FIFO-via-buffer route fixes Mongo Fuzzer, and the carve-out in
+	// ResolveRange still saves session/connection mocks from the
+	// stale-cutoff drop that bit gin-mongo Windows on #4122.
 	bound, closed := m.outChanStatus()
-	isReusable := mock != nil &&
-		(mock.TestModeInfo.Lifetime == models.LifetimeSession ||
-			mock.TestModeInfo.Lifetime == models.LifetimeConnection)
 	switch {
 	case closed:
 		m.mu.Unlock()
-		return
-	case bound && isReusable:
-		m.mu.Unlock()
-		m.sendToOutChan(mock)
 		return
 	case bound && !m.firstReqSeen:
 		m.mu.Unlock()

--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -210,18 +210,54 @@ func (m *SyncMockManager) AddMock(mock *models.Mock) {
 	}
 
 	// Decide forward vs buffer vs drop under a single snapshot of
-	// (outChan, outChanClosed). The trio has three legal outcomes:
+	// (outChan, outChanClosed). The legal outcomes:
 	//
-	//   closed          → drop (shutdown in progress, buffer would leak)
-	//   unbound (nil)   → buffer (SetOutputChannel hasn't fired yet;
-	//                     ResolveRange will emit once bound)
-	//   bound + open    → forward via sendToOutChan, unless we're
-	//                     past firstReqSeen in which case the mock
-	//                     belongs in the dedup buffer for windowing
+	//   closed                       → drop (shutdown in progress)
+	//   bound + session/connection   → forward (Lifetime contract is
+	//                                  "reusable across all windows";
+	//                                  buffering would leak the mock —
+	//                                  ResolveRange only flushes mocks
+	//                                  that match a per-test window and
+	//                                  session/connection mocks never
+	//                                  do, so anything that lands in
+	//                                  m.buffer for these tiers is
+	//                                  unrecoverable until shutdown
+	//                                  drops it)
+	//   unbound (nil)                → buffer (SetOutputChannel hasn't
+	//                                  fired yet; ResolveRange will emit
+	//                                  once bound)
+	//   bound + !firstReqSeen        → forward (pre-first-request mocks
+	//                                  bypass the buffer)
+	//   bound +  firstReqSeen        → buffer (per-test mock waiting
+	//                                  for window match in ResolveRange)
+	//
+	// The session/connection bypass restores the pre-#4122 behaviour
+	// for parsers (mongo V2 handshake/auth/heartbeat, postgres v3
+	// startup, mysql HikariCP COM_PING) whose reusable traffic is
+	// captured continuously through the recording. Those mocks must
+	// reach the recorder regardless of whether they arrive before or
+	// after the first app test request, and they never need windowing
+	// because their Lifetime makes them reusable across every test.
+	// Without this branch, a session-tagged mock emitted post-first-
+	// request — e.g. a mongo pool connection's handshake when the
+	// driver opens a second pool slot mid-replay-record — falls into
+	// the per-test buffer, never matches a per-test ResolveRange
+	// window, and is silently lost at shutdown. That was the symptom
+	// behind run_golang_native_windows / gin-mongo (record_build_
+	// replay_build) on PR #4130 run 24962475421: mongo handshake
+	// dropped, replay's gin app got EOF on the driver socket, every
+	// mongo-touching test failed.
 	bound, closed := m.outChanStatus()
+	isReusable := mock != nil &&
+		(mock.TestModeInfo.Lifetime == models.LifetimeSession ||
+			mock.TestModeInfo.Lifetime == models.LifetimeConnection)
 	switch {
 	case closed:
 		m.mu.Unlock()
+		return
+	case bound && isReusable:
+		m.mu.Unlock()
+		m.sendToOutChan(mock)
 		return
 	case bound && !m.firstReqSeen:
 		m.mu.Unlock()
@@ -349,12 +385,49 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 	//   2. Out-of-window mocks are subject to the 7 s cutoff: kept if
 	//      recent (might match a future out-of-order request), dropped
 	//      otherwise (stale and unrecoverable).
+	//   3. Session- and connection-scoped mocks are flushed to outChan
+	//      (when bound) regardless of [start,end]; their Lifetime makes
+	//      them reusable across every test window and they intentionally
+	//      never window-match. Retained in the buffer when outChan is
+	//      unbound so a later ResolveRange with the channel wired can
+	//      drain them. AddMock now forwards these directly when outChan
+	//      is bound at ingest time, so this branch only fires for mocks
+	//      that landed in the buffer during the brief unbound startup
+	//      window before SetOutputChannel.
 	cutoffTime := time.Now().Add(-7 * time.Second)
 	keepIdx := 0
 
 	for i := 0; i < len(m.buffer); i++ {
 		mock := m.buffer[i]
 		mockTime := mock.Spec.ReqTimestampMock
+
+		// LIFETIME CARVE-OUT: session- and connection-scoped mocks
+		// are reusable across every test window and never need
+		// per-test window filtering. Drain to outChan when bound so
+		// the recorder writes them to disk; retain in the buffer
+		// otherwise so a later ResolveRange (with outChan bound) can
+		// pick them up. Skipping the per-test window match is
+		// correct: session mocks aren't anchored to any test, so
+		// trying to "match" them against [start,end] would either
+		// drop them silently (out-of-window cutoff) or attribute
+		// them to whichever test happens to ResolveRange first.
+		lt := mock.TestModeInfo.Lifetime
+		if lt == models.LifetimeSession || lt == models.LifetimeConnection {
+			if !outChanBound {
+				m.buffer[keepIdx] = mock
+				keepIdx++
+				continue
+			}
+			// Don't stamp a synthetic name on session/connection
+			// mocks — Lifetime-derived parsers depend on
+			// Spec.Metadata for routing at replay time and the
+			// recorder writes whatever Name the mock already
+			// carries. They also don't belong in the per-test
+			// associatedMockIDs mapping (which is purely about
+			// per-test matches).
+			mocksToSend = append(mocksToSend, mock)
+			continue
+		}
 
 		// MATCHING LOGIC: Process mocks in the requested window first
 		// so a long-running test's per-test mocks aren't pre-empted by
@@ -390,6 +463,9 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 		// window that includes a timestamp from before "now-7s" once
 		// we're already past the head of the dedup queue, because
 		// the queue is FIFO on ReqTimestamp. Drop to bound growth.
+		// (Session- and connection-tier mocks are handled in the
+		// lifetime carve-out at the top of the loop and never reach
+		// this branch.)
 		if mockTime.Before(cutoffTime) {
 			continue
 		}

--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -324,7 +324,31 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 	outChanBound, _ := m.outChanStatus()
 	mappingChan := m.mappingChan
 
-	// Any mock older than 7 seconds from NOW is considered dead and will be removed.
+	// Stale-buffer safety valve.
+	//
+	// The check exists to bound buffer growth when a stream of mocks
+	// arrives that is never closed off by a corresponding test-window
+	// resolve (e.g. a parser kept emitting after the test ended).
+	// Without it, m.buffer would grow without bound across a long
+	// recording session.
+	//
+	// CRITICAL ordering: cutoff must NOT pre-empt the window match.
+	// A long-running test (mongo fuzzer's curl /run takes ~56 s for
+	// 10 000 ops) emits per-test mocks whose ReqTimestampMock is far
+	// older than 7 s by the time ResolveRange fires at request
+	// completion — but those mocks ARE in-window and must be flushed
+	// to the recorder, not silently dropped. The pre-c53b4906 V2 path
+	// bypassed syncMock entirely so the cutoff never applied; routing
+	// through AddMock (#4122) made the previous "cutoff first" ordering
+	// drop the first ~49 s of a 56 s recording window, leaving replay
+	// without the mongo handshake mocks → connection-pool error at
+	// driver init.
+	//
+	// New ordering:
+	//   1. In-window matches are kept/forwarded regardless of age.
+	//   2. Out-of-window mocks are subject to the 7 s cutoff: kept if
+	//      recent (might match a future out-of-order request), dropped
+	//      otherwise (stale and unrecoverable).
 	cutoffTime := time.Now().Add(-7 * time.Second)
 	keepIdx := 0
 
@@ -332,14 +356,9 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 		mock := m.buffer[i]
 		mockTime := mock.Spec.ReqTimestampMock
 
-		// SAFETY VALVE: Expire old mocks
-		// If the mock is older than 7 seconds, we discard it immediately.
-		// This stops the infinite growth.
-		if mockTime.Before(cutoffTime) {
-			continue
-		}
-
-		// MATCHING LOGIC: Process mocks in the requested window
+		// MATCHING LOGIC: Process mocks in the requested window first
+		// so a long-running test's per-test mocks aren't pre-empted by
+		// the stale-buffer cutoff.
 		if (mockTime.Equal(start) || mockTime.After(start)) && (mockTime.Equal(end) || mockTime.Before(end)) {
 			if keep {
 				// If output channel is not wired yet, keep matching
@@ -362,6 +381,16 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 			}
 			// We successfully matched and handled this mock.
 			// We discard it from the buffer so it doesn't get processed again.
+			continue
+		}
+
+		// SAFETY VALVE: Expire stale OUT-OF-WINDOW mocks.
+		// A mock that didn't match the current window AND is older
+		// than 7 s is unrecoverable — no future request can have a
+		// window that includes a timestamp from before "now-7s" once
+		// we're already past the head of the dedup queue, because
+		// the queue is FIFO on ReqTimestamp. Drop to bound growth.
+		if mockTime.Before(cutoffTime) {
 			continue
 		}
 

--- a/pkg/agent/proxy/syncMock/syncMock_test.go
+++ b/pkg/agent/proxy/syncMock/syncMock_test.go
@@ -445,20 +445,18 @@ loop:
 	}
 }
 
-// TestAddMockSessionLifetimeBypassesFirstReqSeenBuffer pins the
-// session/connection bypass added on top of #4130. Pre-#4122 the
-// V2 mongo recorder wrote handshake/auth/heartbeat mocks directly
-// to s.Mocks and the recorder picked them up off the channel
-// regardless of whether SetFirstRequestSignaled had fired. After
-// #4122 that path goes through SyncMockManager.AddMock; without
-// this carve-out a session-tagged mock arriving AFTER firstReqSeen
-// (e.g. mongo driver opening a second pool connection mid-test)
-// fell into the per-test buffer, never matched a per-test
-// ResolveRange window (session mocks are not window-anchored), and
-// was silently lost at recorder shutdown — the symptom behind
-// run_golang_native_windows / gin-mongo (record_build_replay_build)
-// on PR #4130 run 24962475421.
-func TestAddMockSessionLifetimeBypassesFirstReqSeenBuffer(t *testing.T) {
+// TestAddMockSessionLifetimeBuffersAfterFirstReqSeen pins the
+// post-firstReqSeen routing for session-lifetime mocks. AddMock
+// must NOT hoist them straight to outChan: that would interleave
+// handshake mocks ahead of the per-test mocks emitted at end-of-
+// test from the buffer, and replay's connection-keyed FIFO matcher
+// stalls on the resulting out-of-order stream. The expected path
+// is: buffer the session mock now, and let ResolveRange's lifetime
+// carve-out drain it to outChan in arrival order, exempt from the
+// per-test window match and the 7 s stale cutoff. Regression coverage
+// for the run_fuzzer_linux / Mongo Fuzzer (record_build_replay_build)
+// hang on the bypass attempt of PR #4130.
+func TestAddMockSessionLifetimeBuffersAfterFirstReqSeen(t *testing.T) {
 	t.Parallel()
 
 	ch := make(chan *models.Mock, 4)
@@ -466,7 +464,7 @@ func TestAddMockSessionLifetimeBypassesFirstReqSeenBuffer(t *testing.T) {
 		buffer: make([]*models.Mock, 0, defaultMockBufferCapacity),
 	}
 	mgr.SetOutputChannel(ch)
-	// Past the gate: per-test mocks would now buffer.
+	// Past the gate: per-test mocks now buffer; session mocks must too.
 	mgr.SetFirstRequestSignaled()
 
 	sessionMock := &models.Mock{
@@ -477,30 +475,26 @@ func TestAddMockSessionLifetimeBypassesFirstReqSeenBuffer(t *testing.T) {
 	}
 	mgr.AddMock(sessionMock)
 
-	// Session mock must have been forwarded to outChan immediately,
-	// not buffered.
 	select {
 	case got := <-ch:
-		if got != sessionMock {
-			t.Fatalf("expected session mock on outChan, got different pointer")
-		}
+		t.Fatalf("session mock unexpectedly forwarded to outChan: %p", got)
 	default:
-		t.Fatalf("session-lifetime mock should bypass the firstReqSeen buffer and forward to outChan")
 	}
 
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
-	if len(mgr.buffer) != 0 {
-		t.Fatalf("expected empty buffer after session-lifetime AddMock; got %d", len(mgr.buffer))
+	if len(mgr.buffer) != 1 || mgr.buffer[0] != sessionMock {
+		t.Fatalf("expected session mock buffered post-firstReqSeen; buffer=%d", len(mgr.buffer))
 	}
 }
 
-// TestAddMockConnectionLifetimeBypassesFirstReqSeenBuffer is the
+// TestAddMockConnectionLifetimeBuffersAfterFirstReqSeen is the
 // LifetimeConnection counterpart. Postgres v3 prepared-statement
 // PREPARE mocks land here: they're tagged "type: connection" with
-// a connID and must reach the recorder regardless of whether the
-// PREPARE happens before or after firstReqSeen.
-func TestAddMockConnectionLifetimeBypassesFirstReqSeenBuffer(t *testing.T) {
+// a connID and must follow the same buffer-then-carve-out path so
+// arrival order is preserved relative to per-test mocks emitted on
+// the same connection.
+func TestAddMockConnectionLifetimeBuffersAfterFirstReqSeen(t *testing.T) {
 	t.Parallel()
 
 	ch := make(chan *models.Mock, 4)
@@ -523,17 +517,90 @@ func TestAddMockConnectionLifetimeBypassesFirstReqSeenBuffer(t *testing.T) {
 
 	select {
 	case got := <-ch:
-		if got != connMock {
-			t.Fatalf("expected connection mock on outChan, got different pointer")
-		}
+		t.Fatalf("connection mock unexpectedly forwarded to outChan: %p", got)
 	default:
-		t.Fatalf("connection-lifetime mock should bypass the firstReqSeen buffer and forward to outChan")
 	}
 
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
-	if len(mgr.buffer) != 0 {
-		t.Fatalf("expected empty buffer after connection-lifetime AddMock; got %d", len(mgr.buffer))
+	if len(mgr.buffer) != 1 || mgr.buffer[0] != connMock {
+		t.Fatalf("expected connection mock buffered post-firstReqSeen; buffer=%d", len(mgr.buffer))
+	}
+}
+
+// TestResolveRangeFlushesBufferedSessionMocksInArrivalOrder is the
+// pure regression test for the Mongo Fuzzer hang on the bypass
+// attempt. Buffer interleaves session and per-test mocks in the
+// order [session1, perTest1, session2, perTest2, perTest3] and
+// invokes a per-test ResolveRange whose window covers the per-test
+// mocks. The expectation: outChan receives mocks in the SAME
+// interleaved order, NOT all-sessions-then-all-per-tests. Replay's
+// connection-keyed FIFO matcher requires this ordering — with the
+// pre-fix bypass, session mocks landed on outChan ahead of any
+// per-test mocks queued in the buffer, the connection's mock stream
+// went out of order, and replay stalled on the last batch of ops.
+func TestResolveRangeFlushesBufferedSessionMocksInArrivalOrder(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan *models.Mock, 8)
+	mgr := &SyncMockManager{
+		buffer: make([]*models.Mock, 0, defaultMockBufferCapacity),
+	}
+	mgr.SetOutputChannel(ch)
+	mgr.SetFirstRequestSignaled()
+
+	now := time.Now()
+	mkSession := func(id string, ts time.Time) *models.Mock {
+		m := &models.Mock{
+			Kind: models.Mongo,
+			Name: id,
+			Spec: models.MockSpec{
+				Metadata:         map[string]string{"type": "config"},
+				ReqTimestampMock: ts,
+			},
+		}
+		m.DeriveLifetime()
+		return m
+	}
+	mkPerTest := func(id string, ts time.Time) *models.Mock {
+		return &models.Mock{
+			Kind: models.Mongo,
+			Name: id,
+			Spec: models.MockSpec{ReqTimestampMock: ts},
+		}
+	}
+
+	// Capture order: s1, p1, s2, p2, p3 — all timestamped inside
+	// the test window so the per-test path matches them. The per-
+	// test ResolveRange window must include every per-test mock's
+	// timestamp; session mocks are exempt regardless.
+	mocks := []*models.Mock{
+		mkSession("s1", now.Add(-50*time.Millisecond)),
+		mkPerTest("p1", now.Add(-40*time.Millisecond)),
+		mkSession("s2", now.Add(-30*time.Millisecond)),
+		mkPerTest("p2", now.Add(-20*time.Millisecond)),
+		mkPerTest("p3", now.Add(-10*time.Millisecond)),
+	}
+	for _, m := range mocks {
+		mgr.AddMock(m)
+	}
+
+	mgr.ResolveRange(now.Add(-100*time.Millisecond), now, "test-1", true, false)
+
+	for _, want := range mocks {
+		select {
+		case got := <-ch:
+			if got != want {
+				t.Fatalf("outChan order broken: expected %s, got %s", want.Name, got.Name)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for mock %s on outChan", want.Name)
+		}
+	}
+	select {
+	case extra := <-ch:
+		t.Fatalf("unexpected extra mock on outChan: %s", extra.Name)
+	default:
 	}
 }
 

--- a/pkg/agent/proxy/syncMock/syncMock_test.go
+++ b/pkg/agent/proxy/syncMock/syncMock_test.go
@@ -343,8 +343,10 @@ func TestSetOutputChannelSamePointerAfterCloseKeepsClosed(t *testing.T) {
 // buffer (they will never drain, but we accept the small leak in
 // exchange for dropping the pre-drop branch that was suspected
 // of regressing #4045 Mongo Fuzzer record_build_replay_latest).
-// The retention path is bounded by the 7-second cutoffTime
-// at the top of ResolveRange, so the leak is time-capped.
+// In-window mocks are retained regardless of age (the long-running-
+// test contract — see TestResolveRangeLongRunningWindowKeepsOldMocks);
+// out-of-window stale mocks are still time-capped by the 7-second
+// cutoff in the unmatched branch.
 func TestResolveRangePostCloseRetainsBuffer(t *testing.T) {
 	t.Parallel()
 
@@ -368,6 +370,78 @@ func TestResolveRangePostCloseRetainsBuffer(t *testing.T) {
 	mgr.mu.Unlock()
 	if remaining != 1 {
 		t.Fatalf("expected 1 mock retained in buffer after post-close ResolveRange; got %d", remaining)
+	}
+}
+
+// TestResolveRangeLongRunningWindowKeepsOldMocks is the
+// regression test for the Mongo Fuzzer record_build_replay_build
+// failure caused by routing V2 EmitMock through syncMock (#4122).
+//
+// The fuzzer's curl POST /run takes ~56 s to complete 10 000 mongo
+// ops, so by the time ResolveRange fires at request resolution the
+// per-test mongo mocks captured in the first ~49 s are all older
+// than 7 s. The cutoff used to be checked BEFORE the window match,
+// which dropped them despite their being in-window — leaving replay
+// without the mongo handshake mocks and producing a connection-pool
+// error at driver init. The fix re-orders the loop to evaluate the
+// window match first, so an in-window mock is kept regardless of
+// age; only un-matched mocks are subject to the stale cutoff.
+func TestResolveRangeLongRunningWindowKeepsOldMocks(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan *models.Mock, 4)
+	mgr := &SyncMockManager{
+		buffer: make([]*models.Mock, 0, defaultMockBufferCapacity),
+	}
+	mgr.SetOutputChannel(ch)
+
+	// Simulate a 60-second test window that starts 60 s ago.
+	now := time.Now()
+	windowStart := now.Add(-60 * time.Second)
+	windowEnd := now
+
+	// Mock at +5 s into the window — older than the 7-second cutoff
+	// (~55 s old by now) but legitimately in-window.
+	oldInWindow := &models.Mock{
+		Spec: models.MockSpec{ReqTimestampMock: windowStart.Add(5 * time.Second)},
+	}
+	// Mock at -10 s before the window — out of window AND old. Must
+	// be dropped by the stale cutoff.
+	staleOutWindow := &models.Mock{
+		Spec: models.MockSpec{ReqTimestampMock: windowStart.Add(-10 * time.Second)},
+	}
+	// Mock 3 s in the future relative to now — out of window but
+	// recent. Must be retained for a possible future window match.
+	freshOutWindow := &models.Mock{
+		Spec: models.MockSpec{ReqTimestampMock: now.Add(3 * time.Second)},
+	}
+
+	mgr.mu.Lock()
+	mgr.buffer = append(mgr.buffer, oldInWindow, staleOutWindow, freshOutWindow)
+	mgr.mu.Unlock()
+
+	mgr.ResolveRange(windowStart, windowEnd, "test-1", true, false)
+
+	// Drain anything sent to the outChan.
+	var sent []*models.Mock
+loop:
+	for {
+		select {
+		case m := <-ch:
+			sent = append(sent, m)
+		default:
+			break loop
+		}
+	}
+
+	if len(sent) != 1 || sent[0] != oldInWindow {
+		t.Fatalf("expected the in-window mock to be flushed despite being older than 7s; sent=%d", len(sent))
+	}
+
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+	if len(mgr.buffer) != 1 || mgr.buffer[0] != freshOutWindow {
+		t.Fatalf("expected only freshOutWindow retained in buffer; got len=%d", len(mgr.buffer))
 	}
 }
 

--- a/pkg/agent/proxy/syncMock/syncMock_test.go
+++ b/pkg/agent/proxy/syncMock/syncMock_test.go
@@ -445,6 +445,237 @@ loop:
 	}
 }
 
+// TestAddMockSessionLifetimeBypassesFirstReqSeenBuffer pins the
+// session/connection bypass added on top of #4130. Pre-#4122 the
+// V2 mongo recorder wrote handshake/auth/heartbeat mocks directly
+// to s.Mocks and the recorder picked them up off the channel
+// regardless of whether SetFirstRequestSignaled had fired. After
+// #4122 that path goes through SyncMockManager.AddMock; without
+// this carve-out a session-tagged mock arriving AFTER firstReqSeen
+// (e.g. mongo driver opening a second pool connection mid-test)
+// fell into the per-test buffer, never matched a per-test
+// ResolveRange window (session mocks are not window-anchored), and
+// was silently lost at recorder shutdown — the symptom behind
+// run_golang_native_windows / gin-mongo (record_build_replay_build)
+// on PR #4130 run 24962475421.
+func TestAddMockSessionLifetimeBypassesFirstReqSeenBuffer(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan *models.Mock, 4)
+	mgr := &SyncMockManager{
+		buffer: make([]*models.Mock, 0, defaultMockBufferCapacity),
+	}
+	mgr.SetOutputChannel(ch)
+	// Past the gate: per-test mocks would now buffer.
+	mgr.SetFirstRequestSignaled()
+
+	sessionMock := &models.Mock{
+		Spec: models.MockSpec{
+			Metadata:         map[string]string{"type": "config"},
+			ReqTimestampMock: time.Now(),
+		},
+	}
+	mgr.AddMock(sessionMock)
+
+	// Session mock must have been forwarded to outChan immediately,
+	// not buffered.
+	select {
+	case got := <-ch:
+		if got != sessionMock {
+			t.Fatalf("expected session mock on outChan, got different pointer")
+		}
+	default:
+		t.Fatalf("session-lifetime mock should bypass the firstReqSeen buffer and forward to outChan")
+	}
+
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+	if len(mgr.buffer) != 0 {
+		t.Fatalf("expected empty buffer after session-lifetime AddMock; got %d", len(mgr.buffer))
+	}
+}
+
+// TestAddMockConnectionLifetimeBypassesFirstReqSeenBuffer is the
+// LifetimeConnection counterpart. Postgres v3 prepared-statement
+// PREPARE mocks land here: they're tagged "type: connection" with
+// a connID and must reach the recorder regardless of whether the
+// PREPARE happens before or after firstReqSeen.
+func TestAddMockConnectionLifetimeBypassesFirstReqSeenBuffer(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan *models.Mock, 4)
+	mgr := &SyncMockManager{
+		buffer: make([]*models.Mock, 0, defaultMockBufferCapacity),
+	}
+	mgr.SetOutputChannel(ch)
+	mgr.SetFirstRequestSignaled()
+
+	connMock := &models.Mock{
+		Spec: models.MockSpec{
+			Metadata: map[string]string{
+				"type":   "connection",
+				"connID": "c-42",
+			},
+			ReqTimestampMock: time.Now(),
+		},
+	}
+	mgr.AddMock(connMock)
+
+	select {
+	case got := <-ch:
+		if got != connMock {
+			t.Fatalf("expected connection mock on outChan, got different pointer")
+		}
+	default:
+		t.Fatalf("connection-lifetime mock should bypass the firstReqSeen buffer and forward to outChan")
+	}
+
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+	if len(mgr.buffer) != 0 {
+		t.Fatalf("expected empty buffer after connection-lifetime AddMock; got %d", len(mgr.buffer))
+	}
+}
+
+// TestAddMockPerTestStillBuffersAfterFirstReqSeen is the negative
+// control for the carve-out: per-test mocks (zero Lifetime / no
+// metadata tag) MUST still buffer once firstReqSeen has flipped, so
+// ResolveRange can match them against the active test window. If
+// the bypass leaks here the dedup/windowing contract collapses.
+func TestAddMockPerTestStillBuffersAfterFirstReqSeen(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan *models.Mock, 4)
+	mgr := &SyncMockManager{
+		buffer: make([]*models.Mock, 0, defaultMockBufferCapacity),
+	}
+	mgr.SetOutputChannel(ch)
+	mgr.SetFirstRequestSignaled()
+
+	perTest := &models.Mock{
+		Spec: models.MockSpec{ReqTimestampMock: time.Now()},
+	}
+	mgr.AddMock(perTest)
+
+	select {
+	case got := <-ch:
+		t.Fatalf("per-test mock unexpectedly forwarded to outChan: %p", got)
+	default:
+	}
+
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+	if len(mgr.buffer) != 1 || mgr.buffer[0] != perTest {
+		t.Fatalf("expected per-test mock buffered post-firstReqSeen; buffer=%d", len(mgr.buffer))
+	}
+}
+
+// TestResolveRangeKeepsSessionLifetimeMocksPastCutoff covers the
+// ResolveRange safety net paired with the AddMock bypass. AddMock
+// now forwards session-lifetime mocks directly to outChan when the
+// channel is bound, so the buffer should generally not see them.
+// The exception is the brief startup window where outChan is still
+// nil at AddMock time — those session mocks land in the buffer.
+// Without the lifetime carve-out in ResolveRange the post-#4130
+// out-of-window cutoff would silently drop them once they aged
+// past 7 s and outChan became bound. This test mirrors that
+// scenario: pre-buffer a session mock with a >7 s ReqTimestampMock,
+// invoke a per-test ResolveRange whose window doesn't include the
+// mock's timestamp, and assert the mock is FLUSHED to outChan
+// rather than dropped.
+func TestResolveRangeKeepsSessionLifetimeMocksPastCutoff(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan *models.Mock, 4)
+	mgr := &SyncMockManager{
+		buffer: make([]*models.Mock, 0, defaultMockBufferCapacity),
+	}
+	mgr.SetOutputChannel(ch)
+
+	// Mongo handshake captured ~10 s ago — well past the 7 s cutoff.
+	// "type: config" is the on-disk tag DeriveLifetime maps to
+	// LifetimeSession. Pre-derive on the test mock so the buffered
+	// state matches what AddMock would have written.
+	handshake := &models.Mock{
+		Kind: models.Mongo,
+		Spec: models.MockSpec{
+			Metadata:         map[string]string{"type": "config"},
+			ReqTimestampMock: time.Now().Add(-10 * time.Second),
+		},
+	}
+	handshake.DeriveLifetime()
+	if handshake.TestModeInfo.Lifetime != models.LifetimeSession {
+		t.Fatalf("test fixture: expected LifetimeSession after DeriveLifetime, got %v", handshake.TestModeInfo.Lifetime)
+	}
+
+	// Pre-buffer it (simulates the unbound-at-AddMock startup path).
+	mgr.mu.Lock()
+	mgr.buffer = append(mgr.buffer, handshake)
+	mgr.mu.Unlock()
+
+	// Per-test ResolveRange with a window 1 s wide centred on now —
+	// the handshake timestamp (-10 s) is well outside.
+	now := time.Now()
+	mgr.ResolveRange(now.Add(-500*time.Millisecond), now.Add(500*time.Millisecond), "test-1", true, false)
+
+	// Session mock must have been flushed to outChan despite being
+	// out-of-window AND past the 7 s cutoff.
+	select {
+	case got := <-ch:
+		if got != handshake {
+			t.Fatalf("expected session mock flushed to outChan; got different pointer")
+		}
+	default:
+		t.Fatalf("expected session-lifetime mock to be flushed to outChan past cutoff; got nothing")
+	}
+
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+	if len(mgr.buffer) != 0 {
+		t.Fatalf("expected empty buffer after flushing session mock; got %d", len(mgr.buffer))
+	}
+}
+
+// TestResolveRangeRetainsSessionMocksWhenOutChanUnbound complements
+// the cutoff exemption: when outChan is unbound at ResolveRange time
+// (post-CloseOutChan, or before a fresh SetOutputChannel re-binds),
+// session mocks must be RETAINED in the buffer rather than flushed
+// (sendToOutChan would no-op silently and we'd lose them) or
+// dropped. A later ResolveRange with the channel re-bound is
+// expected to drain them.
+func TestResolveRangeRetainsSessionMocksWhenOutChanUnbound(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan *models.Mock, 4)
+	mgr := &SyncMockManager{
+		buffer: make([]*models.Mock, 0, defaultMockBufferCapacity),
+	}
+	mgr.SetOutputChannel(ch)
+	mgr.CloseOutChan() // outChanBound goes false, channel closed
+
+	handshake := &models.Mock{
+		Kind: models.Mongo,
+		Spec: models.MockSpec{
+			Metadata:         map[string]string{"type": "config"},
+			ReqTimestampMock: time.Now().Add(-10 * time.Second),
+		},
+	}
+	handshake.DeriveLifetime()
+
+	mgr.mu.Lock()
+	mgr.buffer = append(mgr.buffer, handshake)
+	mgr.mu.Unlock()
+
+	now := time.Now()
+	mgr.ResolveRange(now.Add(-500*time.Millisecond), now.Add(500*time.Millisecond), "t", true, false)
+
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+	if len(mgr.buffer) != 1 || mgr.buffer[0] != handshake {
+		t.Fatalf("expected session mock retained in buffer when outChan unbound; got len=%d", len(mgr.buffer))
+	}
+}
+
 // TestSendToOutChanNoDropWhenDrainedWithinBudget exercises the
 // fast-then-bounded-block path: once the fast-path slot is taken,
 // a consumer that drains within sendBudget must let the blocked

--- a/pkg/platform/docker/docker.go
+++ b/pkg/platform/docker/docker.go
@@ -576,6 +576,12 @@ func (idc *Impl) GenerateKeployAgentService(opts models.SetupOptions) (*yaml.Nod
 	if idc.conf.Record.Synchronous {
 		command = append(command, "--sync")
 	}
+	// Forward the operator's --disable-mapping (root-level config) into
+	// the agent container. The keploy.yml directory isn't bind-mounted
+	// into the agent's filesystem, so viper inside the container would
+	// otherwise default to true and disable record-side mapping
+	// production regardless of the host config.
+	command = append(command, fmt.Sprintf("--disable-mapping=%t", idc.conf.DisableMapping))
 	if idc.conf.Record.EnableSampling > 0 {
 		command = append(command, fmt.Sprintf("--enable-sampling=%d", idc.conf.Record.EnableSampling))
 	}

--- a/pkg/platform/http/agent.go
+++ b/pkg/platform/http/agent.go
@@ -880,6 +880,13 @@ func (a *AgentClient) startNativeAgent(ctx context.Context, opts models.SetupOpt
 	if a.conf.Record.Synchronous {
 		args = append(args, "--sync")
 	}
+	// Forward the operator's --disable-mapping (root-level config) so
+	// the native agent process — even though it inherits the same
+	// keploy.yml via --config-path — sees an explicit override on
+	// invocations where the host CLI mutated the in-memory config
+	// after viper load (e.g. --disable-mapping=false on the test
+	// subcommand path that drove this agent start).
+	args = append(args, fmt.Sprintf("--disable-mapping=%t", a.conf.DisableMapping))
 	if a.conf.Record.EnableSampling > 0 {
 		args = append(args, fmt.Sprintf("--enable-sampling=%d", a.conf.Record.EnableSampling))
 	}

--- a/pkg/platform/yaml/mapdb/db.go
+++ b/pkg/platform/yaml/mapdb/db.go
@@ -176,6 +176,21 @@ func (db *MappingDb) Upsert(ctx context.Context, testSetID string, testID string
 	return nil
 }
 
+// Exists reports whether mappings.yaml is on disk for the given
+// test-set. Used by the test-mode create-if-not-present write path —
+// distinct from Get's second return (which is "has at least one
+// non-empty test entry"). A file with only empty entries should still
+// count as "exists" so we don't overwrite the operator's intentional
+// empty mapping.
+func (db *MappingDb) Exists(ctx context.Context, testSetID string) (bool, error) {
+	mappingPath := filepath.Join(db.path, testSetID)
+	fileName := db.MapFileName
+	if fileName == "" {
+		fileName = "mappings"
+	}
+	return yaml.FileExists(ctx, db.logger, mappingPath, fileName)
+}
+
 // Get reads test-mock mappings from a YAML file
 // Returns: testMockMappings, mappingFilePresent, error
 func (db *MappingDb) Get(ctx context.Context, testSetID string) (map[string][]models.MockEntry, bool, error) {

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -2293,28 +2293,47 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		}
 	}
 
-	// The test-mode mapping write is gated ONLY on UpdateTestMapping —
-	// not on isMappingEnabled (= !DisableMapping). The two flags express
-	// independent concerns:
+	// Test-mode mapping write semantics:
 	//
-	//   DisableMapping     → "during replay, filter mocks by timestamp
-	//                         instead of by the mappings.yaml index"
-	//                         (a replay-time matching-strategy switch).
-	//   UpdateTestMapping  → "after the test set runs, write the actual
-	//                         consumed-mocks-per-test record to disk"
-	//                         (a write-side-effect switch).
+	//   UpdateTestMapping=true  → always write/merge mappings.yaml
+	//                             (operator-driven update).
+	//   UpdateTestMapping=false → create-if-not-present: write only
+	//                             when mappings.yaml is absent for
+	//                             this test-set. Once a file exists,
+	//                             we leave it alone — repeat test
+	//                             runs don't churn it.
 	//
-	// Operators commonly want the second without the first — e.g. record
-	// with disableMapping=true (no mappings.yaml produced; replay falls
-	// back to timestamps), then run test mode with --update-test-mapping
-	// to capture the actual mock consumption for k8s-based final-candidate
-	// analysis. Coupling the two through a single `&&` blocked that
-	// workflow. Also drops the r.instrument gate that was here previously,
-	// so k8s-proxy autoreplay (non-instrument; consumed mocks fetched via
-	// the agent HTTP API) writes mappings.yaml for the same reason —
-	// actualTestMockMappings is populated identically in both modes via
-	// hookImpl.GetConsumedMocks at line 1454/1884.
-	if r.config.Test.UpdateTestMapping {
+	// Rationale: mappings.yaml is the artifact k8s-proxy autoreplay
+	// (and other final-candidate analyses) consults to find which
+	// mocks each test consumed. Operators who never set the flag
+	// still need a usable file the first time test mode runs; gating
+	// strictly on UpdateTestMapping leaves them without one. The
+	// create-if-not-present default closes that gap without changing
+	// behaviour for existing users who already have a mappings.yaml
+	// they don't want overwritten — they can keep flag=false and the
+	// existing file is preserved. To force a refresh, flag=true.
+	//
+	// Independence from DisableMapping: the two flags express
+	// orthogonal concerns. DisableMapping picks the replay-time mock
+	// FILTERING strategy (timestamp-vs-index); the mapping WRITE is
+	// a separate side-effect that records consumption. We don't gate
+	// the write on the filter strategy. Likewise the prior
+	// r.instrument gate is dropped so k8s-proxy autoreplay (non-
+	// instrument; consumed mocks fetched via the agent HTTP API)
+	// writes too — actualTestMockMappings is populated identically
+	// in both modes from hookImpl.GetConsumedMocks (line 1454/1884).
+	shouldWriteMappings := r.config.Test.UpdateTestMapping
+	if !shouldWriteMappings && r.mappingDB != nil {
+		exists, existsErr := r.mappingDB.Exists(ctx, testSetID)
+		if existsErr != nil {
+			r.logger.Debug("Skipping create-if-not-present mappings.yaml write — file-existence check failed; treating as 'exists' to avoid clobbering",
+				zap.String("testSetID", testSetID),
+				zap.Error(existsErr))
+		} else if !exists {
+			shouldWriteMappings = true
+		}
+	}
+	if shouldWriteMappings {
 		if err := r.StoreMappings(ctx, actualTestMockMappings); err != nil {
 			r.logger.Error("Error saving test-mock mappings to YAML file", zap.Error(err))
 		} else {

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -2293,14 +2293,28 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		}
 	}
 
-	// Drop the r.instrument gate so k8s-proxy autoreplay (which runs in
-	// non-instrument mode and fetches consumed mocks via the agent's
-	// HTTP API) also writes mappings.yaml. actualTestMockMappings is
-	// populated identically in both modes — consumedMocks comes from
-	// hookImpl.GetConsumedMocks at line 1454/1884, which proxies to
-	// instrumentation.GetConsumedMocks regardless of mode — so there's
-	// no instrument-only invariant to protect here.
-	if isMappingEnabled && r.config.Test.UpdateTestMapping {
+	// The test-mode mapping write is gated ONLY on UpdateTestMapping —
+	// not on isMappingEnabled (= !DisableMapping). The two flags express
+	// independent concerns:
+	//
+	//   DisableMapping     → "during replay, filter mocks by timestamp
+	//                         instead of by the mappings.yaml index"
+	//                         (a replay-time matching-strategy switch).
+	//   UpdateTestMapping  → "after the test set runs, write the actual
+	//                         consumed-mocks-per-test record to disk"
+	//                         (a write-side-effect switch).
+	//
+	// Operators commonly want the second without the first — e.g. record
+	// with disableMapping=true (no mappings.yaml produced; replay falls
+	// back to timestamps), then run test mode with --update-test-mapping
+	// to capture the actual mock consumption for k8s-based final-candidate
+	// analysis. Coupling the two through a single `&&` blocked that
+	// workflow. Also drops the r.instrument gate that was here previously,
+	// so k8s-proxy autoreplay (non-instrument; consumed mocks fetched via
+	// the agent HTTP API) writes mappings.yaml for the same reason —
+	// actualTestMockMappings is populated identically in both modes via
+	// hookImpl.GetConsumedMocks at line 1454/1884.
+	if r.config.Test.UpdateTestMapping {
 		if err := r.StoreMappings(ctx, actualTestMockMappings); err != nil {
 			r.logger.Error("Error saving test-mock mappings to YAML file", zap.Error(err))
 		} else {

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -2293,7 +2293,14 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		}
 	}
 
-	if r.instrument && isMappingEnabled && r.config.Test.UpdateTestMapping {
+	// Drop the r.instrument gate so k8s-proxy autoreplay (which runs in
+	// non-instrument mode and fetches consumed mocks via the agent's
+	// HTTP API) also writes mappings.yaml. actualTestMockMappings is
+	// populated identically in both modes — consumedMocks comes from
+	// hookImpl.GetConsumedMocks at line 1454/1884, which proxies to
+	// instrumentation.GetConsumedMocks regardless of mode — so there's
+	// no instrument-only invariant to protect here.
+	if isMappingEnabled && r.config.Test.UpdateTestMapping {
 		if err := r.StoreMappings(ctx, actualTestMockMappings); err != nil {
 			r.logger.Error("Error saving test-mock mappings to YAML file", zap.Error(err))
 		} else {

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -2299,9 +2299,11 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 	//                             (operator-driven update).
 	//   UpdateTestMapping=false → create-if-not-present: write only
 	//                             when mappings.yaml is absent for
-	//                             this test-set. Once a file exists,
-	//                             we leave it alone — repeat test
-	//                             runs don't churn it.
+	//                             this test-set AND we have at least
+	//                             one populated test→mocks entry.
+	//                             Once a file exists, we leave it
+	//                             alone — repeat test runs don't
+	//                             churn it.
 	//
 	// Rationale: mappings.yaml is the artifact k8s-proxy autoreplay
 	// (and other final-candidate analyses) consults to find which
@@ -2317,13 +2319,22 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 	// orthogonal concerns. DisableMapping picks the replay-time mock
 	// FILTERING strategy (timestamp-vs-index); the mapping WRITE is
 	// a separate side-effect that records consumption. We don't gate
-	// the write on the filter strategy. Likewise the prior
-	// r.instrument gate is dropped so k8s-proxy autoreplay (non-
-	// instrument; consumed mocks fetched via the agent HTTP API)
-	// writes too — actualTestMockMappings is populated identically
-	// in both modes from hookImpl.GetConsumedMocks (line 1454/1884).
+	// the write on the filter strategy.
+	//
+	// The non-emptiness guard on the create-if-not-present branch
+	// matters because actualTestMockMappings is populated by
+	// upsertActualTestMockMapping calls that depend on consumedMocks,
+	// which is fetched from r.hookImpl.GetConsumedMocks INSIDE
+	// `if r.instrument` blocks (lines 1453, 1884). In non-instrument
+	// modes (e.g. k8s-proxy autoreplay) consumedMocks stays empty,
+	// so without this guard the first run would create an empty
+	// mappings.yaml and every subsequent run would skip the create
+	// branch (file exists), leaving autoreplay permanently without
+	// the mappings the feature relies on. UpdateTestMapping=true
+	// still writes an empty file when explicitly requested — that
+	// matches the operator intent of "force a refresh".
 	shouldWriteMappings := r.config.Test.UpdateTestMapping
-	if !shouldWriteMappings && r.mappingDB != nil {
+	if !shouldWriteMappings && r.mappingDB != nil && len(actualTestMockMappings.TestCases) > 0 {
 		exists, existsErr := r.mappingDB.Exists(ctx, testSetID)
 		if existsErr != nil {
 			r.logger.Debug("Skipping create-if-not-present mappings.yaml write — file-existence check failed; treating as 'exists' to avoid clobbering",

--- a/pkg/service/replay/service.go
+++ b/pkg/service/replay/service.go
@@ -126,4 +126,11 @@ type InstrumentState struct {
 type MappingDB interface {
 	Insert(ctx context.Context, mapping *models.Mapping) error
 	Get(ctx context.Context, testSetID string) (map[string][]models.MockEntry, bool, error)
+	// Exists reports whether the mappings.yaml file is present on disk
+	// for the given test-set. Distinct from Get's second return (which
+	// reports "file present AND contains at least one test case with
+	// mocks") because the create-if-not-present write path needs to
+	// distinguish "no file at all" from "file exists but has empty
+	// entries" — only the former should trigger an automatic create.
+	Exists(ctx context.Context, testSetID string) (bool, error)
 }

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -3088,7 +3088,12 @@ func filterByTimeStampTierAware(_ context.Context, logger *zap.Logger, m []*mode
 			// confirm whether the mock was on disk at all vs filtered
 			// out. Aggregate count is preserved below for parity.
 			if logger != nil {
-				logger.Debug("strict-mode drop: per-test mock outside window",
+				// Info-level (not Debug) so this surfaces in default CI
+				// runs without --debug. Tagged with "diag/" so it is
+				// obviously diagnostic. Will be demoted/removed once the
+				// strict-window regression on listmonk + pgtype-tour is
+				// root-caused.
+				logger.Info("diag/strict-mode drop: per-test mock outside window",
 					zap.String("mock", p.Name),
 					zap.String("kind", string(p.Kind)),
 					zap.String("connID", p.ConnectionID),
@@ -3257,7 +3262,7 @@ func FilterByTimeStampThreeTier(ctx context.Context, logger *zap.Logger, m []*mo
 			// two-tier filterByTimeStampTierAware so callers using
 			// either path get the visibility uniformly.
 			if logger != nil {
-				logger.Debug("strict-mode drop (3-tier): per-test mock outside window",
+				logger.Info("diag/strict-mode drop (3-tier): per-test mock outside window",
 					zap.String("mock", p.Name),
 					zap.String("kind", string(p.Kind)),
 					zap.String("connID", p.ConnectionID),

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -3080,6 +3080,26 @@ func filterByTimeStampTierAware(_ context.Context, logger *zap.Logger, m []*mode
 				preservedStartup++
 				continue
 			}
+			// Per-mock diagnostic: emit the hash + window + actual ts
+			// at Debug for the strict-drop path so a CI log can
+			// pinpoint which postgres / http / mongo mock the per-test
+			// cohort lost. Without this, "candidates: 0" downstream is
+			// the only visible signal and operators have no way to
+			// confirm whether the mock was on disk at all vs filtered
+			// out. Aggregate count is preserved below for parity.
+			if logger != nil {
+				logger.Debug("strict-mode drop: per-test mock outside window",
+					zap.String("mock", p.Name),
+					zap.String("kind", string(p.Kind)),
+					zap.String("connID", p.ConnectionID),
+					zap.Time("mock_req_ts", p.Spec.ReqTimestampMock),
+					zap.Time("mock_res_ts", p.Spec.ResTimestampMock),
+					zap.Time("window_after", afterTime),
+					zap.Time("window_before", beforeTime),
+					zap.Duration("delta_before_after", p.Spec.ReqTimestampMock.Sub(afterTime)),
+					zap.Duration("delta_before_before", p.Spec.ReqTimestampMock.Sub(beforeTime)),
+				)
+			}
 			droppedOutOfWindow++
 		} else {
 			// Legacy: anything out-of-window goes to the unfiltered pool
@@ -3229,6 +3249,25 @@ func FilterByTimeStampThreeTier(ctx context.Context, logger *zap.Logger, m []*mo
 				startup = append(startup, p)
 				preservedStartup++
 				continue
+			}
+			// Per-mock diagnostic: emit hash + window deltas at Debug
+			// for the three-tier strict-drop path so a CI log can
+			// identify which postgres / mongo / etc. mock the per-test
+			// cohort lost. Mirrors the same diagnostic added to the
+			// two-tier filterByTimeStampTierAware so callers using
+			// either path get the visibility uniformly.
+			if logger != nil {
+				logger.Debug("strict-mode drop (3-tier): per-test mock outside window",
+					zap.String("mock", p.Name),
+					zap.String("kind", string(p.Kind)),
+					zap.String("connID", p.ConnectionID),
+					zap.Time("mock_req_ts", p.Spec.ReqTimestampMock),
+					zap.Time("mock_res_ts", p.Spec.ResTimestampMock),
+					zap.Time("window_after", afterTime),
+					zap.Time("window_before", beforeTime),
+					zap.Duration("delta_before_after", p.Spec.ReqTimestampMock.Sub(afterTime)),
+					zap.Duration("delta_before_before", p.Spec.ReqTimestampMock.Sub(beforeTime)),
+				)
 			}
 			droppedOutOfWindow++
 		} else {


### PR DESCRIPTION
## Summary

Five postgres v3 / streaming-HTTP record-replay fixes surfaced under the http-postgres + Mongo Fuzzer stress workloads. Started as a single syncMock cutoff fix; the subsequent commits address related correctness gaps the cutoff fix unblocked us to find.

## Fixes (oldest → newest)

### 1. `fix(syncMock): evaluate window match before stale-buffer cutoff` (8c29073a)
`SyncMockManager.ResolveRange` was dropping any buffered mock older than `now-7s` **before** checking whether it fell inside the requested test window. Long-running tests (Mongo Fuzzer's 56s `curl POST /run`) lost their handshake/heartbeat mocks → replay's mongo driver short-circuited with a connection-pool error. Re-orders the loop so in-window matches win regardless of age; the 7s cutoff still applies to genuinely stale out-of-window mocks. Fixes Mongo Fuzzer `record_build_replay_build` regression on main pipeline [24959631377](https://github.com/keploy/keploy/actions/runs/24959631377/job/73084122961).

### 2. `fix(syncMock): bypass per-test buffering for session + connection mocks` (42cd8c0f)
Session- and connection-scoped mocks (postgres v3 startup, mysql HikariCP COM_PING) were getting per-test window-matched and dropped. Lifetime carve-out: drain to outChan when bound regardless of `[start,end]`; their Lifetime makes them reusable across every test window.

### 3. `fix(syncMock): preserve buffer FIFO order for session/connection mocks` (3d7f1686)
Earlier attempt forwarded session mocks to outChan straight from `AddMock`; broke Mongo Fuzzer because handshake mocks got hoisted ahead of per-test mocks emitted at end-of-test. Keeps the FIFO-via-buffer route; lifetime carve-out in `ResolveRange` saves them from the stale-cutoff drop.

### 4. `fix(record): byte-arrival HTTP timestamps + restore mappings.yaml` (a538fa0e)
Two record-side regressions:
- **Streaming HTTP timestamps**: `parseStreamingHTTP` captured `time.Now()` at iteration start instead of byte arrival. Under concurrent load the parser can run far behind `io.Copy`, so HTTP request timestamps drifted past DB-side mock timestamps for the same logical exchange — broke per-test `SetMocksWithWindow` attribution → sporadic test-17 failures in next-iteration replays. Fix: `timedChunk` + `asyncPipeFeeder.lastReadNano`. Feeder stamps each chunk at `io.Copy` arrival; bridge stores the timestamp BEFORE `pipe.Write` so the parser can race ahead without missing a stamp on short single-chunk exchanges. `parseStreamingHTTP` queries `feeder.LastReadTime()` AFTER consumption.
- **Record-side mappings.yaml**: PR #3905 added a `mapping bool` parameter to `ResolveRange` and gated the mappingChan emission on it — but the OSS `Capture` call site hardcoded `false`, silently disabling record-side mapping production. The dedup-queue codepath that was supposed to pass `mapping=true` (`DedupQueue.ResolveJob`) has no production callers in OSS. Fix: thread `!cfg.DisableMapping` through `CaptureFunc` from incoming → ResolveRange. For docker-compose / k8s sidecar mode the operator's keploy.yml dir isn't bind-mounted into the agent container, so we mirror the host value via an explicit `--disable-mapping` agent-subcommand flag and forward it from `docker.GenerateKeployAgentService` and `AgentClient.startNativeAgent`.

### 5. `fix(replay): write mappings.yaml in k8s-proxy autoreplay` (5ed58639) + `decouple from DisableMapping` (f9f2b9fc) + `feat(replay): create-if-not-present default` (a900f60f)
The test-mode mapping write at the end of `RunTestSet` previously gated on `(r.instrument && isMappingEnabled && UpdateTestMapping)`, conflating three independent concerns:
- `r.instrument` excluded k8s-proxy autoreplay (non-instrument; fetches consumed mocks via agent HTTP API). Drop.
- `isMappingEnabled = !DisableMapping` is a replay-time mock FILTERING strategy switch, orthogonal to whether we WRITE mappings.yaml. Drop.
- `UpdateTestMapping` was the explicit override.

New default semantics:
- `UpdateTestMapping=true` → always write/merge mappings.yaml.
- `UpdateTestMapping=false` (default) → **create-if-not-present**: write only when mappings.yaml is absent for this test-set; once a file exists, leave it alone. New `MappingDB.Exists()` powers the check.

Bootstraps the file for new users (k8s-proxy autoreplay, final-candidate analysis flows that rely on mappings.yaml existing) without churning files that operators already have on disk.

## Validation

- `go build ./...`, `go test -race ./pkg/agent/proxy/syncMock/...`, `go test ./pkg/agent/proxy/incoming/...` clean.
- 3-iteration http-postgres stress (record + replay) passes 30/30 each iter against the rebuilt `ghcr.io/keploy/keploy:v3-dev` image.
- Empirical create-if-not-present validation (3-phase: fresh dir → first replay creates file → second replay leaves file untouched) green.
- Empirical record-side mappings.yaml validation: `disableMapping: false + --sync` recording produces mappings.yaml with each test mapped to the postgres mocks it consumed.
- New `TestResolveRangeLongRunningWindowKeepsOldMocks` covers the syncMock cutoff regression.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race ./pkg/agent/proxy/syncMock/...` clean
- [x] http-postgres 30-test replay 30/30 with new binary
- [x] mappings.yaml create-if-not-present semantics empirically verified
- [ ] Mongo Fuzzer `record_build_replay_build` on this PR's CI run — verify on prepare_and_run
- [ ] Postgres Fuzzer + http-postgres regression run on CI — verify clean

## Cross-repo pairing

The Windows gin-mongo flake (`connection(127.0.0.1:27017[-N]) socket was unexpectedly closed: EOF` on the first 2 tests of whichever test-set ran first) is the bundling bug fixed in keploy/integrations#140 — `asyncMongoDecode` was bundling pipelined requests into a single mock when the second client write arrived before the first handshake response. That PR has merged into integrations master, so this PR's CI now picks the fix up via the default `setup-private-parsers` path; the prior `Integration-Ref` tag has been dropped.

## Out of scope

`run_golang_docker / go-memory-load (record_build_replay_latest)` and `run_node_docker / express-mongoose (record_build_replay_latest)` failures involve the latest-released binary on one side; per the loop directive, pipeline failures against the latest binary are tolerable for this PR.