### PR TITLE
fix(postgres-v3): close TLS-upgrade race via synchronous preamble choreography

### DIFF
--- a/pkg/agent/proxy/directive/directive.go
+++ b/pkg/agent/proxy/directive/directive.go
@@ -75,9 +75,68 @@ func (k Kind) String() string {
 // A nil config for either side means "do not upgrade that side" —
 // useful if the parser knows one peer is already on TLS or does
 // not require symmetric upgrade.
+//
+// PreambleReadFromDest, PreambleForwardToSrc, and ProceedOnPreamble
+// support synchronous protocol-preamble exchanges that race against
+// the relay's pause barrier. The Postgres SSL choreography is the
+// canonical case: client→SSLRequest, server→one of {'S','N'}, client
+// →TLS-ClientHello (immediately after seeing 'S'). The legacy parser-
+// owned path read the SSLResponse byte off the real dest socket and
+// did the TLS handshake atomically; the V2 relay forwarder reads
+// continuously from the real client, so by the time the parser sees
+// 'S' on its FakeConn the client may already have written TLS bytes
+// that the C2D forwarder forwards as plaintext to the server. That
+// in turn corrupts the upstream wire — the server processes part of
+// the client's ClientHello and then keploy's tls.Client.Handshake
+// sends a second ClientHello, which the server rejects ("bad key
+// share" / "tls: illegal parameter"). The race is fundamental to
+// "forwarder reads autonomously" + "parser drives upgrade decisions"
+// without a synchronous handshake op in the directive contract.
+//
+// When PreambleReadFromDest > 0, the relay (under the pause barrier)
+// reads exactly that many bytes from the real dest socket directly
+// (bypassing the C2D/D2C forwarders' tee), forwards them to the real
+// src socket if PreambleForwardToSrc is true, and then decides:
+//
+//   - If ProceedOnPreamble is empty, always proceed with the TLS
+//     handshakes specified by DestTLSConfig / ClientTLSConfig.
+//   - If ProceedOnPreamble is non-empty and the read bytes match it
+//     byte-for-byte, proceed; otherwise return OK=true with no
+//     handshake performed (Ack.PreamblePayload populated, Ack.TLS
+//     Upgraded=false). The caller distinguishes "preamble matched
+//     and TLS is up" from "preamble did not match and TLS was
+//     skipped" via Ack.TLSUpgraded.
+//
+// The Ack also reports Ack.PreamblePayload so the parser can record
+// what the server actually said in its mock. Errors at any stage
+// (Read on dest, Write on src, mismatched length) surface via OK=false
+// just like a handshake failure.
 type UpgradeTLSParams struct {
 	DestTLSConfig   *tls.Config
 	ClientTLSConfig *tls.Config
+
+	// PreambleReadFromDest, when > 0, instructs the relay to read
+	// exactly that many bytes from the real destination socket
+	// before any TLS handshake. Reads use the live socket directly
+	// and bypass the parser's FakeConns; the bytes are returned to
+	// the caller via Ack.PreamblePayload regardless of forwarding.
+	PreambleReadFromDest int
+
+	// PreambleForwardToSrc, when true, asks the relay to write the
+	// preamble bytes back to the real source socket before the TLS
+	// handshakes begin. Used by the Postgres parser to deliver the
+	// SSLResponse byte ('S' / 'N') to the real client without ever
+	// letting the C2D forwarder pick up the client's reply (TLS
+	// ClientHello after 'S') as cleartext.
+	PreambleForwardToSrc bool
+
+	// ProceedOnPreamble, when non-empty, gates the TLS handshakes on
+	// an exact byte-for-byte match against the read preamble. A
+	// mismatch is not an error — the relay returns OK=true with
+	// TLSUpgraded=false so the parser can adapt (e.g. Postgres 'N'
+	// means the server declined SSL and the rest of the session
+	// stays cleartext).
+	ProceedOnPreamble []byte
 }
 
 // Directive is a control message from a parser to the supervisor /
@@ -121,6 +180,21 @@ type Ack struct {
 	Err               error
 	BoundaryReadAt    time.Time
 	BoundaryWrittenAt time.Time
+
+	// PreamblePayload carries the bytes the relay read from the real
+	// destination socket when [UpgradeTLSParams.PreambleReadFromDest]
+	// was > 0. Populated whether or not the TLS handshake actually
+	// ran; an empty slice means no preamble read was requested.
+	PreamblePayload []byte
+
+	// TLSUpgraded reports whether the relay actually performed a TLS
+	// handshake. True when both (or only the requested) sides
+	// completed; false when the preamble gate
+	// [UpgradeTLSParams.ProceedOnPreamble] short-circuited (Postgres
+	// 'N' decline) — the directive still acks OK=true in that case
+	// because the caller's contract was satisfied; the parser uses
+	// PreamblePayload to interpret the outcome.
+	TLSUpgraded bool
 }
 
 // ErrDirectiveClosed is returned from helpers that try to send on a

--- a/pkg/agent/proxy/relay/directive_proc.go
+++ b/pkg/agent/proxy/relay/directive_proc.go
@@ -346,6 +346,23 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, stopping <-chan struct{}, 
 
 	if params.DestTLSConfig != nil {
 		dst := *r.dst.Load()
+		// If the D2C forwarder stashed any cleartext bytes beyond the
+		// preamble window (e.g. a protocol that frames more than the
+		// parser's PreambleReadFromDest tells us about), prepend them
+		// to the dst handshake conn so tls.Client.Handshake reads
+		// them as the first bytes of the ServerHello sequence. The
+		// canonical Postgres SSL flow (1-byte 'S'/'N' preamble, then
+		// pure TLS) leaves nothing past the preamble, so this branch
+		// is defensive — but it keeps the contract that no stashed
+		// bytes are ever silently dropped at the upgrade boundary.
+		if stashed := r.takeStashed(fakeconn.FromDest); len(stashed) > 0 {
+			if log != nil {
+				log.Debug("relay: prepending stashed dst bytes to TLS handshake",
+					zap.Int("bytes", len(stashed)),
+				)
+			}
+			dst = newPrependingConn(dst, stashed)
+		}
 		var err error
 		upgradedDst, err = r.cfg.TLSUpgradeFn(ctx, dst, true, params.DestTLSConfig)
 		if err != nil {
@@ -375,6 +392,35 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, stopping <-chan struct{}, 
 
 	if params.ClientTLSConfig != nil {
 		src := *r.src.Load()
+		// If the C2D forwarder stashed any bytes (canonically the
+		// SUT's TLS ClientHello, which can land in the C2D forwarder's
+		// pre-pause Read when the SUT pipelines its SSLRequest tightly
+		// with its ClientHello — observed intermittently with lib/pq
+		// + libpq under sslmode=require, surfaced as the listmonk +
+		// pgtype-tour `candidates: 0` hash misses on TLS-enabled CI
+		// fixtures), prepend them to the src handshake conn. Without
+		// this, tls.Server.Handshake reads from the bare TCP socket,
+		// MISSES the stashed ClientHello bytes (they were already
+		// consumed by the forwarder's Read), and either hangs forever
+		// or returns "tls: server did not echo the legacy session ID"
+		// on the SUT side / "tls: illegal parameter" on the dst side
+		// once whatever bytes DO arrive are interpreted as a partial
+		// handshake state. The connection then falls through to
+		// passthrough, the recorder sees zero queries on it, and
+		// every test that happened to land on that connection misses
+		// at replay time.
+		//
+		// The takeStashed call also clears r.stashedC2D so endPause
+		// does not silently drop those same bytes after the handshake
+		// returns.
+		if stashed := r.takeStashed(fakeconn.FromClient); len(stashed) > 0 {
+			if log != nil {
+				log.Debug("relay: prepending stashed src bytes to TLS handshake",
+					zap.Int("bytes", len(stashed)),
+				)
+			}
+			src = newPrependingConn(src, stashed)
+		}
 		var err error
 		upgradedSrc, err = r.cfg.TLSUpgradeFn(ctx, src, false, params.ClientTLSConfig)
 		if err != nil {

--- a/pkg/agent/proxy/relay/directive_proc.go
+++ b/pkg/agent/proxy/relay/directive_proc.go
@@ -33,7 +33,7 @@ func (r *Relay) processDirectives(ctx context.Context, stopping <-chan struct{})
 			if !ok {
 				return
 			}
-			ack := r.handleDirective(ctx, d)
+			ack := r.handleDirective(ctx, stopping, d)
 			select {
 			case r.acks <- ack:
 			default:
@@ -49,10 +49,13 @@ func (r *Relay) processDirectives(ctx context.Context, stopping <-chan struct{})
 }
 
 // handleDirective dispatches on Kind. Returns the Ack to emit.
-func (r *Relay) handleDirective(ctx context.Context, d directive.Directive) directive.Ack {
+// stopping is the relay-wide teardown signal; handlers that need to
+// wait for forwarder coordination (currently only KindUpgradeTLS) plumb
+// it through to avoid an indefinite block during shutdown.
+func (r *Relay) handleDirective(ctx context.Context, stopping <-chan struct{}, d directive.Directive) directive.Ack {
 	switch d.Kind {
 	case directive.KindUpgradeTLS:
-		return r.handleUpgradeTLS(ctx, d)
+		return r.handleUpgradeTLS(ctx, stopping, d)
 	case directive.KindPauseDir:
 		return r.handlePauseDir(d)
 	case directive.KindResumeDir:
@@ -75,12 +78,29 @@ func (r *Relay) handleDirective(ctx context.Context, d directive.Directive) dire
 // handleUpgradeTLS runs the TLS upgrade choreography:
 //  1. Install the pause barrier. Forwarders park on their next loop
 //     iteration — i.e. after finishing any Read already in flight.
-//  2. Handshake dest first (keploy = TLS client to real server),
+//  2. (Optional) Read [UpgradeTLSParams.PreambleReadFromDest] bytes
+//     from the real destination socket directly, bypassing the
+//     forwarders' tee, so a synchronous protocol-preamble exchange
+//     (e.g. Postgres SSLResponse byte) is observed before the
+//     forwarders reawaken. If [UpgradeTLSParams.PreambleForwardToSrc]
+//     is true, write those bytes to the real source socket before
+//     touching TLS — closing the race where the C2D forwarder would
+//     otherwise pick up the client's TLS ClientHello bytes (sent in
+//     reaction to the preamble) and deliver them upstream as
+//     cleartext, corrupting the upstream wire before the handshake
+//     even starts.
+//  3. (Optional) Gate handshakes on
+//     [UpgradeTLSParams.ProceedOnPreamble] matching the read preamble.
+//     A mismatch is OK=true with TLSUpgraded=false: it lets a
+//     protocol that allows the server to decline TLS at the preamble
+//     stage (Postgres 'N') return without forcing the whole mock
+//     incomplete.
+//  4. Handshake dest first (keploy = TLS client to real server),
 //     then client (keploy = TLS server, presenting MITM cert).
-//  3. On either failure, release the pause and return OK=false; the
+//  5. On either failure, release the pause and return OK=false; the
 //     relay stays on the original (cleartext) conns. The supervisor
 //     is expected to fall through to raw passthrough.
-//  4. On success, replace the atomic conn pointers with the upgraded
+//  6. On success, replace the atomic conn pointers with the upgraded
 //     versions, release the pause, and return OK=true with boundary
 //     timestamps.
 //
@@ -92,8 +112,13 @@ func (r *Relay) handleDirective(ctx context.Context, d directive.Directive) dire
 // sends next. If the parser sends the directive while a real Read
 // was about to return TLS-handshake bytes, those bytes are forwarded
 // as-is, which is wrong — but the contract puts the responsibility
-// for boundary detection on the parser.
-func (r *Relay) handleUpgradeTLS(ctx context.Context, d directive.Directive) directive.Ack {
+// for boundary detection on the parser. The PreambleReadFromDest /
+// PreambleForwardToSrc fields exist precisely to give the parser a
+// way to satisfy that precondition for protocols (Postgres SSL) where
+// the boundary is "the byte the server is about to send AND the
+// reaction the client is about to write" rather than something the
+// parser can detect from already-forwarded bytes alone.
+func (r *Relay) handleUpgradeTLS(ctx context.Context, stopping <-chan struct{}, d directive.Directive) directive.Ack {
 	log := r.cfg.Logger
 	if r.cfg.TLSUpgradeFn == nil {
 		return directive.Ack{Kind: d.Kind, OK: false, Err: ErrNoTLSUpgrader}
@@ -104,26 +129,216 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, d directive.Directive) dir
 	}
 
 	// Barrier up. Forwarders will park on their next loop iteration.
-	// We don't have a precise "forwarders have parked" signal, but
-	// that is acceptable: any bytes they read just before parking
-	// will still be forwarded on cleartext; the parser will have
-	// already marked the prelude mock complete. The new TLS stream
-	// starts from whatever the real peer sends next.
+	// beginPause also nudges SetReadDeadline on both live sockets so
+	// any forwarder blocked in Read wakes up promptly.
 	r.beginPause()
+
+	// Wait for both forwarders to actually be parked on the pause
+	// channel before proceeding. This is the synchronisation point
+	// that lets takeStashed below observe any bytes a forwarder Read
+	// returned in flight (Postgres SSLResponse 'S' is the canonical
+	// case: D2C's blocked Read wakes from the deadline kick with the
+	// 'S' byte, the post-Read pause check stashes it onto the relay,
+	// then the forwarder calls markForwarderParked). Without this
+	// wait the directive handler races the forwarder, sees an empty
+	// stash, falls through to readFullPreamble on the live socket,
+	// and deadlocks because the byte the parser is asking us to read
+	// has already been consumed by the forwarder Read that just woke
+	// up.
+	r.waitForwardersParked(ctx, stopping)
 
 	boundaryReadAt := time.Now()
 
-	// Atomic two-sided upgrade: run both handshakes FIRST (keeping
-	// the new *tls.Conn values in local vars), only publish the
-	// upgraded conn pointers via r.{dst,src}.Store AFTER both
-	// handshakes succeed. A naive two-step "upgrade dest, publish;
-	// upgrade client, publish" would leave the relay in a mixed state
-	// if the second handshake failed (e.g. dest already TLS-wrapped,
-	// client still cleartext) — the forwarders would then be moving
-	// TLS bytes one way and plaintext the other, corrupting any
-	// traffic in flight before the outer layer torn the sockets
-	// down. The local-then-store pattern keeps the corruption window
-	// at zero.
+	// Step 1 — synchronous preamble exchange. The preamble (e.g.
+	// Postgres SSLResponse byte) may already have been read by the
+	// D2C forwarder before the pause barrier was raised; in that
+	// case the forwarder stashed it via stashInflightFromPause
+	// rather than writing it to the live src socket, and we claim it
+	// here. If the stash is empty we read directly from the live
+	// dest socket — the byte is still in flight from the server and
+	// no forwarder consumed it.
+	//
+	// Either path completes synchronously under the pause, so the
+	// directive handler is the sole owner of the protocol state at
+	// this boundary. Without this two-source design, the obvious
+	// "always read from real_dst" approach would race with D2C: in
+	// the case where D2C already consumed 'S' from the server, the
+	// next byte on real_dst is whatever the server sends after 'S'
+	// (the start of TLS ServerHello, if the C2D forwarder also
+	// already forwarded the client's TLS ClientHello to the server).
+	// We saw 0x16 ('handshake' TLS record type) instead of 'S' /
+	// 0x53 from postgres in exactly that case before this fix.
+	// Clear the past-time deadline beginPause installed on the live
+	// sockets so the synchronous TLS handshakes (and the
+	// preamble-from-real-dst Read on the no-stash branch) aren't
+	// instantly aborted by the same kick. A blocking forwarder Read
+	// has already woken up by now and the post-Read recheck has
+	// already parked it on the pause channel; clearing the deadline
+	// here is safe because the forwarder won't issue another Read
+	// until the pause channel closes (which happens in endPause,
+	// after this function returns). endPause clears the deadline
+	// again — that's a no-op here but keeps the invariant tidy.
+	clearDeadline(r.dst.Load())
+	clearDeadline(r.src.Load())
+
+	var preamblePayload []byte
+	if params.PreambleReadFromDest > 0 {
+		// 1a. Try the D2C stash first.
+		if stashed := r.takeStashed(fakeconn.FromDest); len(stashed) > 0 {
+			if len(stashed) >= params.PreambleReadFromDest {
+				preamblePayload = stashed[:params.PreambleReadFromDest]
+				// If the forwarder stashed more than we needed
+				// (unlikely for a 1-byte preamble but defensive
+				// against future protocols), the surplus is dropped
+				// — the upgraded socket has no clean way to
+				// consume cleartext bytes captured pre-upgrade.
+				if log != nil && len(stashed) > params.PreambleReadFromDest {
+					log.Debug("relay: dropping stashed surplus past preamble window",
+						zap.Int("requested", params.PreambleReadFromDest),
+						zap.Int("stashed", len(stashed)),
+					)
+				}
+			} else {
+				// Stash fell short of what the parser asked for;
+				// top up by reading the remainder directly from
+				// the live socket. This branch is rare in
+				// practice — the Postgres SSL preamble is a
+				// single byte — but keeps the contract strict for
+				// future protocols.
+				preamblePayload = make([]byte, params.PreambleReadFromDest)
+				copy(preamblePayload, stashed)
+				clearDeadline(r.dst.Load())
+				dst := *r.dst.Load()
+				_, err := readFullPreamble(dst, preamblePayload[len(stashed):])
+				if err != nil {
+					if log != nil {
+						log.Debug("relay: TLS upgrade preamble read (post-stash) failed",
+							zap.Error(err),
+							zap.Int("stashed", len(stashed)),
+							zap.Int("requested", params.PreambleReadFromDest),
+							zap.String("directive_reason", d.Reason),
+							zap.String("next_step", "the upstream closed mid-preamble; verify the destination is the protocol the parser was matched to and consider KEPLOY_DISABLE_PARSING=1 to bypass parsing"),
+						)
+					}
+					r.endPause()
+					return directive.Ack{
+						Kind:            d.Kind,
+						OK:              false,
+						Err:             fmt.Errorf("TLS upgrade preamble read: %w", err),
+						PreamblePayload: preamblePayload[:len(stashed)],
+					}
+				}
+			}
+		} else {
+			// 1b. No stash; read straight from the live dest
+			// socket. This path runs when the parser sent the
+			// directive before the D2C forwarder's Read returned
+			// — i.e. before the server replied with the preamble
+			// byte at all. The Read here blocks until the
+			// preamble arrives; ctx-cancel propagates via the
+			// underlying conn's deadline plumbing.
+			//
+			// beginPause set a past-time SetReadDeadline on dst
+			// to wake any blocked forwarder Read; we now need a
+			// clean deadline so this synchronous Read isn't
+			// instantly aborted by the same kick. clearDeadline
+			// drops the deadline; endPause will reapply it later
+			// (no-op since it sets the zero deadline anyway).
+			preamblePayload = make([]byte, params.PreambleReadFromDest)
+			clearDeadline(r.dst.Load())
+			dst := *r.dst.Load()
+			n, err := readFullPreamble(dst, preamblePayload)
+			if err != nil {
+				if log != nil {
+					log.Debug("relay: TLS upgrade preamble read failed",
+						zap.Error(err),
+						zap.Int("requested", params.PreambleReadFromDest),
+						zap.Int("read", n),
+						zap.String("directive_reason", d.Reason),
+						zap.String("next_step", "the upstream closed the connection or returned fewer bytes than the parser expected for its preamble; verify the destination is the protocol the parser was matched to (Postgres on a non-Postgres port, etc.) and consider KEPLOY_DISABLE_PARSING=1 to bypass parsing"),
+					)
+				}
+				r.endPause()
+				return directive.Ack{
+					Kind:            d.Kind,
+					OK:              false,
+					Err:             fmt.Errorf("TLS upgrade preamble read: %w", err),
+					PreamblePayload: preamblePayload[:n],
+				}
+			}
+		}
+
+		// 1c. Drop the stashed C2D payload if any. The forwarder
+		// captured the client's reply to the server's preamble
+		// (e.g. TLS ClientHello after seeing 'S') without writing
+		// it to the live dest socket. The upgraded src conn will
+		// run its own handshake from a fresh ClientHello; the
+		// stashed bytes have no place to go. We log the size at
+		// debug so a future operator can correlate it with a
+		// supervisor warning if the discard ever turns out to drop
+		// genuine application bytes.
+		if c2dStash := r.takeStashed(fakeconn.FromClient); len(c2dStash) > 0 && log != nil {
+			log.Debug("relay: dropping stashed client-side bytes captured during pause",
+				zap.Int("dropped_bytes", len(c2dStash)),
+				zap.String("directive_reason", d.Reason),
+			)
+		}
+
+		if params.PreambleForwardToSrc {
+			// Clear any past-time deadline on src as well; though
+			// SetReadDeadline does not affect Write blocking on
+			// most net.Conn implementations, some wrappers
+			// propagate deadlines to both directions, so the
+			// belt-and-braces clear keeps the Write below clean.
+			clearDeadline(r.src.Load())
+			src := *r.src.Load()
+			if _, werr := src.Write(preamblePayload); werr != nil {
+				if log != nil {
+					log.Debug("relay: TLS upgrade preamble forward failed",
+						zap.Error(werr),
+						zap.String("directive_reason", d.Reason),
+					)
+				}
+				r.endPause()
+				return directive.Ack{
+					Kind:            d.Kind,
+					OK:              false,
+					Err:             fmt.Errorf("TLS upgrade preamble forward: %w", werr),
+					PreamblePayload: preamblePayload,
+				}
+			}
+		}
+		// Optional gate: if the parser said "only proceed when the
+		// preamble matches X", short-circuit on mismatch. This is
+		// OK=true (the directive carried out its protocol-aware job)
+		// with TLSUpgraded=false (no actual handshake happened) so
+		// the parser can record the alternate-path mock without
+		// marking it incomplete.
+		if len(params.ProceedOnPreamble) > 0 && !bytesEqual(params.ProceedOnPreamble, preamblePayload) {
+			boundaryWrittenAt := time.Now()
+			r.endPause()
+			return directive.Ack{
+				Kind:              d.Kind,
+				OK:                true,
+				PreamblePayload:   preamblePayload,
+				TLSUpgraded:       false,
+				BoundaryReadAt:    boundaryReadAt,
+				BoundaryWrittenAt: boundaryWrittenAt,
+			}
+		}
+	}
+
+	// Step 2 — TLS handshakes. Atomic two-sided upgrade: run both
+	// handshakes FIRST (keeping the new *tls.Conn values in local
+	// vars), only publish the upgraded conn pointers via
+	// r.{dst,src}.Store AFTER both handshakes succeed. A naive
+	// two-step "upgrade dest, publish; upgrade client, publish"
+	// would leave the relay in a mixed state if the second handshake
+	// failed (e.g. dest already TLS-wrapped, client still cleartext)
+	// — the forwarders would then be moving TLS bytes one way and
+	// plaintext the other, corrupting any traffic in flight before
+	// the outer layer torn the sockets down. The local-then-store
+	// pattern keeps the corruption window at zero.
 	var (
 		upgradedDst net.Conn
 		upgradedSrc net.Conn
@@ -150,9 +365,10 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, d directive.Directive) dir
 			}
 			r.endPause()
 			return directive.Ack{
-				Kind: d.Kind,
-				OK:   false,
-				Err:  fmt.Errorf("dest TLS upgrade: %w", err),
+				Kind:            d.Kind,
+				OK:              false,
+				Err:             fmt.Errorf("dest TLS upgrade: %w", err),
+				PreamblePayload: preamblePayload,
 			}
 		}
 	}
@@ -181,9 +397,10 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, d directive.Directive) dir
 			}
 			r.endPause()
 			return directive.Ack{
-				Kind: d.Kind,
-				OK:   false,
-				Err:  fmt.Errorf("client TLS upgrade: %w", err),
+				Kind:            d.Kind,
+				OK:              false,
+				Err:             fmt.Errorf("client TLS upgrade: %w", err),
+				PreamblePayload: preamblePayload,
 			}
 		}
 	}
@@ -205,9 +422,52 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, d directive.Directive) dir
 	return directive.Ack{
 		Kind:              d.Kind,
 		OK:                true,
+		PreamblePayload:   preamblePayload,
+		TLSUpgraded:       upgradedDst != nil || upgradedSrc != nil,
 		BoundaryReadAt:    boundaryReadAt,
 		BoundaryWrittenAt: boundaryWrittenAt,
 	}
+}
+
+// readFullPreamble reads exactly len(buf) bytes from conn into buf.
+// Returns the number of bytes read and the first error encountered.
+// io.ErrUnexpectedEOF is returned on a partial read with EOF.
+//
+// We keep this as a thin wrapper rather than calling io.ReadFull
+// directly so the loop is visible in stack traces and so future
+// changes (e.g. a deadline / cancellation hook) have a single place
+// to land.
+func readFullPreamble(conn net.Conn, buf []byte) (int, error) {
+	total := 0
+	for total < len(buf) {
+		n, err := conn.Read(buf[total:])
+		total += n
+		if err != nil {
+			return total, err
+		}
+		if n == 0 {
+			// A zero-byte non-error Read shouldn't happen on a TCP
+			// socket; treat as protocol error to avoid an infinite
+			// busy loop.
+			return total, fmt.Errorf("zero-byte read after %d/%d bytes", total, len(buf))
+		}
+	}
+	return total, nil
+}
+
+// bytesEqual reports whether a and b are byte-for-byte equal.
+// Used to gate ProceedOnPreamble on an exact match. Inlined here so
+// the relay package does not pull in bytes.
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // handlePauseDir pauses tee delivery for d.Dir. Real forwarding is

--- a/pkg/agent/proxy/relay/prepending_conn.go
+++ b/pkg/agent/proxy/relay/prepending_conn.go
@@ -1,0 +1,66 @@
+package relay
+
+import (
+	"net"
+)
+
+// prependingConn wraps a net.Conn and yields a fixed prefix of bytes
+// from Read before falling through to the underlying conn. Writes,
+// deadlines, addresses, and Close pass straight through to the wrapped
+// conn — only the read side is intercepted.
+//
+// This exists so handleUpgradeTLS can hand stashed pre-handshake bytes
+// to tls.Server.Handshake / tls.Client.HandshakeContext without losing
+// them. Background: when the relay raises its pause barrier mid-
+// connection, a forwarder that was already inside src.Read can return
+// with N bytes from the kernel TCP recv buffer that the post-Read
+// pause check then transfers into r.stashedC2D / r.stashedD2C. Those
+// bytes are NOT in the kernel buffer anymore, so a naive
+// tls.Server(src, cfg).Handshake() reading directly from src misses
+// them. With Postgres SSL under sslmode=require and a SUT that
+// pipelines its SSLRequest tightly with its TLS ClientHello (lib/pq +
+// libpq do this under load), the stashed bytes ARE the start of the
+// ClientHello — losing them surfaces as `tls: server did not echo
+// the legacy session ID` (peer-to-keploy) or `tls: illegal parameter`
+// (keploy-to-peer) and the connection falls through to passthrough,
+// taking every query on that connection out of the recording.
+//
+// The implementation is intentionally tiny: a one-shot prefix buffer
+// drained on each Read until empty, then pure pass-through. No
+// concurrency safety beyond what net.Conn already requires from a
+// single Reader (Go's tls package serialises Reads inside the
+// handshake state machine, so a non-locking design is fine here —
+// this type is NOT general-purpose, it is specifically for the
+// "drain stash into TLS handshake" use case).
+type prependingConn struct {
+	net.Conn
+	prefix []byte
+}
+
+// newPrependingConn returns a net.Conn that reads `prefix` first,
+// then falls through to `c`. If prefix is empty, c is returned
+// unchanged so callers don't pay the wrapper cost on the common
+// path where no bytes were stashed.
+func newPrependingConn(c net.Conn, prefix []byte) net.Conn {
+	if len(prefix) == 0 {
+		return c
+	}
+	return &prependingConn{Conn: c, prefix: prefix}
+}
+
+// Read drains the prefix first. Once the prefix is exhausted, future
+// Reads delegate to the wrapped conn. We never mix a partial-prefix
+// + partial-conn Read in a single call: the contract for net.Conn
+// allows a Read to return fewer bytes than the buffer holds, and
+// keeping the two streams separate avoids a class of bugs where a
+// caller sizes its buffer to a protocol frame and expects a single
+// Read to either fully cover the prefix OR fully cover the live
+// stream.
+func (p *prependingConn) Read(b []byte) (int, error) {
+	if len(p.prefix) > 0 {
+		n := copy(b, p.prefix)
+		p.prefix = p.prefix[n:]
+		return n, nil
+	}
+	return p.Conn.Read(b)
+}

--- a/pkg/agent/proxy/relay/prepending_conn_test.go
+++ b/pkg/agent/proxy/relay/prepending_conn_test.go
@@ -1,0 +1,132 @@
+package relay
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// fakeReadConn is a minimal net.Conn whose Read returns a scripted
+// sequence of byte chunks (or io.EOF when exhausted). Other methods
+// are no-ops sufficient to satisfy the interface — Reads are the
+// only thing prependingConn delegates to.
+type fakeReadConn struct {
+	chunks [][]byte
+	closed bool
+}
+
+func (f *fakeReadConn) Read(b []byte) (int, error) {
+	if f.closed {
+		return 0, errors.New("closed")
+	}
+	if len(f.chunks) == 0 {
+		return 0, io.EOF
+	}
+	c := f.chunks[0]
+	n := copy(b, c)
+	if n < len(c) {
+		f.chunks[0] = c[n:]
+	} else {
+		f.chunks = f.chunks[1:]
+	}
+	return n, nil
+}
+
+func (f *fakeReadConn) Write(b []byte) (int, error)        { return len(b), nil }
+func (f *fakeReadConn) Close() error                       { f.closed = true; return nil }
+func (f *fakeReadConn) LocalAddr() net.Addr                { return &net.TCPAddr{} }
+func (f *fakeReadConn) RemoteAddr() net.Addr               { return &net.TCPAddr{} }
+func (f *fakeReadConn) SetDeadline(_ time.Time) error      { return nil }
+func (f *fakeReadConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (f *fakeReadConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+func TestPrependingConn_EmptyPrefix(t *testing.T) {
+	// Empty prefix → wrapper not allocated; raw conn returned. This
+	// keeps the common path (no stash) zero-overhead.
+	raw := &fakeReadConn{chunks: [][]byte{[]byte("hello")}}
+	got := newPrependingConn(raw, nil)
+	if got != raw {
+		t.Fatalf("newPrependingConn(empty) returned wrapper; want raw conn passthrough")
+	}
+}
+
+func TestPrependingConn_PrefixOnly(t *testing.T) {
+	// Prefix shorter than the read buffer; reading once drains the
+	// prefix and returns exactly len(prefix) bytes. Subsequent reads
+	// fall through to the live conn.
+	raw := &fakeReadConn{chunks: [][]byte{[]byte("LIVE")}}
+	c := newPrependingConn(raw, []byte("STASH"))
+
+	buf := make([]byte, 100)
+	n, err := c.Read(buf)
+	if err != nil {
+		t.Fatalf("first Read: %v", err)
+	}
+	if got := string(buf[:n]); got != "STASH" {
+		t.Fatalf("first Read = %q; want %q", got, "STASH")
+	}
+
+	n, err = c.Read(buf)
+	if err != nil {
+		t.Fatalf("second Read: %v", err)
+	}
+	if got := string(buf[:n]); got != "LIVE" {
+		t.Fatalf("second Read = %q; want %q", got, "LIVE")
+	}
+}
+
+func TestPrependingConn_PrefixSpansMultipleReads(t *testing.T) {
+	// Prefix longer than the read buffer; multiple Reads are needed
+	// to drain it. The contract is "never mix prefix + live in one
+	// Read" so each Read returns up to its buffer size from prefix
+	// only, then falls through to live on the next call.
+	prefix := bytes.Repeat([]byte("X"), 32)
+	raw := &fakeReadConn{chunks: [][]byte{[]byte("LIVE")}}
+	c := newPrependingConn(raw, prefix)
+
+	buf := make([]byte, 10)
+	collected := make([]byte, 0, 32)
+	for i := 0; i < 4; i++ {
+		n, err := c.Read(buf)
+		if err != nil {
+			t.Fatalf("Read %d: %v", i, err)
+		}
+		collected = append(collected, buf[:n]...)
+		if i < 3 && n != 10 {
+			t.Fatalf("Read %d = %d bytes; want 10 (still in prefix)", i, n)
+		}
+	}
+
+	if !bytes.Equal(collected[:32], prefix) {
+		t.Fatalf("collected prefix = %q; want %q", collected[:32], prefix)
+	}
+
+	// Next Read should be from live stream.
+	n, err := c.Read(buf)
+	if err != nil {
+		t.Fatalf("post-prefix Read: %v", err)
+	}
+	if got := string(buf[:n]); got != "LIVE" {
+		t.Fatalf("post-prefix Read = %q; want %q", got, "LIVE")
+	}
+}
+
+func TestPrependingConn_PassThroughMethods(t *testing.T) {
+	// Write, Close, addresses, deadlines must delegate to the wrapped
+	// conn — only Read is special.
+	raw := &fakeReadConn{}
+	c := newPrependingConn(raw, []byte("X"))
+
+	if _, err := c.Write([]byte("hello")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !raw.closed {
+		t.Fatal("Close did not propagate to wrapped conn")
+	}
+}

--- a/pkg/agent/proxy/relay/relay.go
+++ b/pkg/agent/proxy/relay/relay.go
@@ -58,8 +58,37 @@ type Relay struct {
 	// are paused (directive processor mid-TLS-upgrade). Forwarders
 	// snapshot pauseCh at the top of each loop iteration and, if
 	// non-nil, block on it until it is closed.
-	pauseMu sync.Mutex
-	pauseCh chan struct{}
+	//
+	// parkedCh is a per-pause-window channel each forwarder closes
+	// (atomically via parkedC2D/parkedD2C) the first time it observes
+	// the pause barrier and parks on pauseCh. The directive handler
+	// uses these to wait for both forwarders to actually be parked
+	// before it claims any stashed bytes — without that wait there is
+	// a TOCTOU race where the directive handler can call takeStashed
+	// before the forwarder's deadline-driven Read returned (which is
+	// what the forwarder needs to do before it can stash anything),
+	// see the empty stash, fall through to readFullPreamble on the
+	// live socket, and then deadlock because the byte was already
+	// consumed by the very Read that woke the forwarder out of its
+	// pre-pause block.
+	pauseMu   sync.Mutex
+	pauseCh   chan struct{}
+	parkedC2D chan struct{}
+	parkedD2C chan struct{}
+
+	// stashedC2D and stashedD2C hold bytes a forwarder Read returned
+	// AFTER the pause barrier was raised but BEFORE the forwarder
+	// could check it. The forwarder transfers in-flight bytes here
+	// (rather than writing them to the live socket and corrupting
+	// the upstream wire across the upgrade boundary) when it
+	// observes the pause set on its post-Read recheck. The directive
+	// handler can claim them via takeStashed; on resume, anything
+	// still stashed is silently discarded — the forwarder no longer
+	// owns those bytes and the upgraded socket has no way to consume
+	// them sensibly.
+	stashMu    sync.Mutex
+	stashedC2D []byte
+	stashedD2C []byte
 
 	// seqC2D and seqD2C are the per-direction monotonic Chunk sequence
 	// numbers, scoped to this connection.
@@ -337,6 +366,7 @@ func (r *Relay) forward(
 		// mid-TLS-upgrade. The barrier is a chan that closes when
 		// resumed.
 		if pc := r.currentPauseCh(); pc != nil {
+			r.markForwarderParked(dir)
 			select {
 			case <-pc:
 			case <-ctx.Done():
@@ -349,6 +379,63 @@ func (r *Relay) forward(
 		src := *srcPtr.Load()
 		n, err := src.Read(buf)
 		readAt := time.Now()
+
+		// Re-check the pause barrier AFTER Read returns and BEFORE
+		// any Write/Tee. Without this, a directive issued while the
+		// forwarder was blocked in Read can land at the top of the
+		// next loop iteration too late: the bytes already read here
+		// would be Written to the live cleartext peer first. For the
+		// Postgres SSL choreography that means a TLS ClientHello
+		// from the real client gets forwarded to the real server
+		// AS IF IT WERE PLAINTEXT, corrupting the upstream TCP
+		// stream — which the directive handler then fights with by
+		// trying to start its own TLS handshake on the same socket.
+		//
+		// The pre-pause Read here may have captured bytes the
+		// directive handler still wants — the Postgres SSLResponse
+		// 'S' byte being the canonical example. Stash them onto the
+		// relay so the directive handler can claim them via
+		// r.takeStashed(dir); whatever it leaves behind is dropped
+		// when the pause lifts (in r.endPause). The forwarder does
+		// NOT write these bytes to the live destination because the
+		// upgraded socket has no protocol context to consume them
+		// (see the upstream-corruption analysis above).
+		if pc := r.currentPauseCh(); pc != nil {
+			if n > 0 {
+				stash := make([]byte, n)
+				copy(stash, buf[:n])
+				r.stashInflightFromPause(dir, stash)
+				if log != nil {
+					log.Debug("relay: stashing in-flight bytes across pause boundary",
+						zap.String("dir", dir.String()),
+						zap.Int("stashed_bytes", n),
+					)
+				}
+				n = 0
+			}
+			// Now that the post-Read stash is committed (or there
+			// were no in-flight bytes to stash), signal the directive
+			// handler that this forwarder is parked. This MUST happen
+			// after stashInflightFromPause so the directive handler's
+			// takeStashed is guaranteed to observe the stash; before
+			// adding markForwarderParked here, the handler could race
+			// past an empty stash and fall into readFullPreamble,
+			// blocking forever on bytes that the forwarder later
+			// stashed (and that the upgraded socket will never re-
+			// deliver).
+			r.markForwarderParked(dir)
+			select {
+			case <-pc:
+			case <-ctx.Done():
+				return nil
+			case <-stopping:
+				return nil
+			}
+			// Pause has lifted. err is preserved so a closed-conn
+			// condition still tears the forwarder down on the next
+			// loop trip.
+		}
+
 		if n > 0 {
 			// Copy into an owned slice so the forwarder can reuse
 			// the scratch buffer on the next iteration without the
@@ -419,6 +506,27 @@ func (r *Relay) forward(
 			if errors.Is(err, io.EOF) {
 				return io.EOF
 			}
+			// A SetReadDeadline-driven timeout fired by beginPause
+			// (and cleared by endPause once the pause lifts) is the
+			// expected wake-up path that lets a forwarder blocked
+			// in Read observe a freshly-installed pause barrier.
+			// Treat it as "loop, re-check pause, then read again"
+			// rather than a terminal error: returning here would
+			// take the relay down at the same moment the upgrade
+			// completed, defeating the point of the pause. The
+			// re-check at the top of the loop will block on the
+			// pause channel; once endPause clears the deadline and
+			// closes the channel, Read returns to its normal
+			// blocking semantics.
+			//
+			// This branch is also tolerant of zero-byte timeouts —
+			// some net.Conn implementations return n=0 with a
+			// timeout-flagged error and the caller is expected to
+			// re-arm. Continuing the loop is the right thing in
+			// either case.
+			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+				continue
+			}
 			return err
 		}
 	}
@@ -439,23 +547,209 @@ func (r *Relay) currentPauseCh() chan struct{} {
 // channel so concurrent directives don't clobber each other; this
 // shouldn't happen in practice because the directive processor is
 // single-threaded.
+//
+// We also nudge SetReadDeadline on both real sockets so any
+// forwarder blocked in Read wakes up promptly and can observe the
+// pause + (in the post-Read recheck path) stash any in-flight
+// payload onto the relay. Without this kick, a forwarder blocked on
+// a quiet socket would never see the pause until the next byte
+// arrived from the peer — which could be a genuine application read
+// the directive handler races against. The deadline is reset to
+// time.Time{} (no deadline) just before endPause completes; until
+// then the deadline-exceeded errors returned by Read are treated as
+// "loop and re-check pause" rather than "tear down the relay".
 func (r *Relay) beginPause() chan struct{} {
 	r.pauseMu.Lock()
 	defer r.pauseMu.Unlock()
 	if r.pauseCh == nil {
 		r.pauseCh = make(chan struct{})
 	}
-	return r.pauseCh
+	if r.parkedC2D == nil {
+		r.parkedC2D = make(chan struct{})
+	}
+	if r.parkedD2C == nil {
+		r.parkedD2C = make(chan struct{})
+	}
+	pc := r.pauseCh
+	// Nudge both sockets out of any blocking Read. A past timestamp
+	// fires immediately; the forwarder Read returns with a deadline
+	// error which the post-Read pause recheck handles (returns to
+	// the top of the loop, blocks on pc). The directive handler is
+	// then the sole reader on the live socket until endPause restores
+	// the no-deadline state.
+	r.nudgeDeadline(r.dst.Load())
+	r.nudgeDeadline(r.src.Load())
+	return pc
+}
+
+// waitForwardersParked blocks until both forwarders have observed the
+// active pause barrier, completed any in-flight Read, stashed any
+// captured bytes, and parked on the pause channel. Returns once both
+// per-direction park signals fire OR ctx cancels OR the relay is
+// stopping. Used by the directive handler to close the TOCTOU race
+// between beginPause and takeStashed: without this wait, the directive
+// handler can claim an empty stash before the forwarder's deadline-
+// driven Read has even returned, then fall through to readFullPreamble
+// on the live socket and deadlock — the forwarder will then read the
+// preamble byte (or part of it) and stash it, but by then the
+// directive handler is committed to a Read that will never see those
+// bytes.
+//
+// Caller must already hold the pause via [beginPause]; this only
+// observes the state, it does not install one.
+func (r *Relay) waitForwardersParked(ctx context.Context, stopping <-chan struct{}) {
+	r.pauseMu.Lock()
+	c2d := r.parkedC2D
+	d2c := r.parkedD2C
+	r.pauseMu.Unlock()
+	if c2d != nil {
+		select {
+		case <-c2d:
+		case <-ctx.Done():
+			return
+		case <-stopping:
+			return
+		}
+	}
+	if d2c != nil {
+		select {
+		case <-d2c:
+		case <-ctx.Done():
+			return
+		case <-stopping:
+			return
+		}
+	}
+}
+
+// markForwarderParked is called by a forwarder the first time it
+// blocks on the pause channel within a given pause window. It closes
+// the per-direction park signal so the directive handler's
+// waitForwardersParked can observe both forwarders are now off the
+// live sockets.
+//
+// Idempotent within a window: subsequent calls are no-ops because the
+// forwarder's local first-park flag is reset only when endPause runs.
+func (r *Relay) markForwarderParked(dir fakeconn.Direction) {
+	r.pauseMu.Lock()
+	defer r.pauseMu.Unlock()
+	switch dir {
+	case fakeconn.FromClient:
+		if r.parkedC2D != nil {
+			select {
+			case <-r.parkedC2D:
+				// already closed
+			default:
+				close(r.parkedC2D)
+			}
+		}
+	case fakeconn.FromDest:
+		if r.parkedD2C != nil {
+			select {
+			case <-r.parkedD2C:
+				// already closed
+			default:
+				close(r.parkedD2C)
+			}
+		}
+	}
 }
 
 // endPause releases the pause barrier. No-op if no pause is active.
+// Any bytes still in the per-direction stash buffers are dropped: the
+// forwarders parked on the pause did not write them to the live
+// peer, and the live peer has now (potentially) been TLS-upgraded so
+// there is no way to deliver them sensibly. The directive handler is
+// expected to have claimed any bytes it cared about via takeStashed
+// while the pause was held.
+//
+// We also clear the SetReadDeadline that beginPause installed so the
+// forwarders' next Read on the (possibly upgraded) sockets blocks
+// normally. The clear happens BEFORE the pause channel is closed so
+// the forwarder cannot observe a "pause lifted but deadline still
+// past" window where its Read would return an immediate deadline
+// error, hit the post-Read pause recheck (now nil), and write to the
+// upgraded socket using stashed bytes that no longer apply.
 func (r *Relay) endPause() {
 	r.pauseMu.Lock()
 	defer r.pauseMu.Unlock()
 	if r.pauseCh != nil {
+		// Restore deadlines on whichever conns are now live (post-
+		// upgrade these may be different *tls.Conn values from the
+		// ones beginPause nudged). SetReadDeadline(time.Time{})
+		// disables the deadline.
+		clearDeadline(r.dst.Load())
+		clearDeadline(r.src.Load())
 		close(r.pauseCh)
 		r.pauseCh = nil
 	}
+	// Reset the park signals to nil so the next pause window starts
+	// with a fresh pair. We don't close any unfired park channels here
+	// — they may have already been closed by markForwarderParked. If
+	// they weren't (a forwarder never parked because it was already in
+	// the post-stop branch), letting them be GC'd is fine; nothing
+	// observes them after the pauseCh is gone.
+	r.parkedC2D = nil
+	r.parkedD2C = nil
+	r.stashMu.Lock()
+	r.stashedC2D = nil
+	r.stashedD2C = nil
+	r.stashMu.Unlock()
+}
+
+// clearDeadline drops any read deadline previously installed on the
+// conn. Mirror of nudgeDeadline; errors are swallowed for the same
+// reason (not every conn honours deadlines, conn may be torn down).
+func clearDeadline(c *net.Conn) {
+	if c == nil || *c == nil {
+		return
+	}
+	_ = (*c).SetReadDeadline(time.Time{})
+}
+
+// stashInflightFromPause is called by the forwarder when its post-Read
+// pause recheck observed the barrier set: the bytes were read from the
+// real source socket but never written to the real destination, so
+// they belong to the directive handler now (it may need them as a
+// protocol preamble it's about to consume — Postgres SSLResponse
+// being the canonical case). The dir argument identifies which
+// direction's stash to populate.
+//
+// Bytes are appended to any existing stash so two consecutive Read+
+// pause-recheck iterations don't lose data; in practice the forwarder
+// only ever reaches this path once per pause window.
+func (r *Relay) stashInflightFromPause(dir fakeconn.Direction, payload []byte) {
+	if len(payload) == 0 {
+		return
+	}
+	r.stashMu.Lock()
+	defer r.stashMu.Unlock()
+	switch dir {
+	case fakeconn.FromClient:
+		r.stashedC2D = append(r.stashedC2D, payload...)
+	case fakeconn.FromDest:
+		r.stashedD2C = append(r.stashedD2C, payload...)
+	}
+}
+
+// takeStashed returns and clears the stash for the given direction.
+// Used by the directive handler under the pause barrier to claim
+// bytes the forwarder captured at the moment the barrier was raised.
+// Returns nil if there is no stash; takeStashed is safe to call
+// before any forwarder Read has fired.
+func (r *Relay) takeStashed(dir fakeconn.Direction) []byte {
+	r.stashMu.Lock()
+	defer r.stashMu.Unlock()
+	var out []byte
+	switch dir {
+	case fakeconn.FromClient:
+		out = r.stashedC2D
+		r.stashedC2D = nil
+	case fakeconn.FromDest:
+		out = r.stashedD2C
+		r.stashedD2C = nil
+	}
+	return out
 }
 
 // nudgeDeadline sets a deadline in the past on the conn if non-nil.

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -148,8 +148,38 @@ func (a *Agent) SetGracefulShutdown(ctx context.Context) error {
 	return a.Proxy.SetGracefulShutdown(ctx)
 }
 
+// outgoingMockChanCap is the buffer depth of the agent → CLI mock
+// stream. The channel pipes typed mocks captured by the recorder
+// goroutines into the gob-encoded HTTP stream the CLI consumes; a
+// deeper buffer absorbs producer bursts at the cost of holding that
+// many in-flight Mocks in memory inside the agent.
+//
+// Sizing tradeoff: each Mock can carry MiB-scale payloads (HTTP
+// request/response body strings, postgres v3 bind values whose raw
+// bytes are now capped per-value via the integrations recorder fix
+// in feat/postgres-v3-ssl-tls-coverage but can still aggregate per
+// mock — multiple Bind parameters, plus DataRow cells on the
+// response side). At 100 entries the worst-case pinned memory for
+// a "fat" mock workload (e.g. the 60-VU × 1 MiB inserts shape that
+// triggered the OOM observed on PR #4135's go-memory-load CI run
+// 24990909605, job 73176710440) is bounded; 1000 was unsafe because
+// the slow CLI consumer (gob-encoded over HTTP, then disk-write per
+// mock) reliably underran the producer and let the channel fill,
+// pinning ~1 GiB of bodies before memoryguard's 500 ms tick could
+// react.
+//
+// 100 was chosen so that it stays well above any normal-traffic
+// micro-burst (typical postgres recordings emit ~10–30 mocks/s) yet
+// the ceiling is reached fast enough that syncMock's existing
+// outChan-overflow drop-with-Error path becomes the dominant
+// backpressure signal long before the cgroup limit is hit. The
+// drop path is intentional: it is far better to lose a mock and
+// keep recording than to OOM-kill the agent and lose every mock
+// captured in the run.
+const outgoingMockChanCap = 100
+
 func (a *Agent) GetOutgoing(ctx context.Context, opts models.OutgoingOptions) (<-chan *models.Mock, error) {
-	m := make(chan *models.Mock, 1000)
+	m := make(chan *models.Mock, outgoingMockChanCap)
 
 	err := a.Proxy.Record(ctx, m, opts)
 	if err != nil {


### PR DESCRIPTION
## Summary

Closes a TLS-upgrade race in the V2 relay that breaks Postgres `SSLRequest` / `SSLResponse` exchange. The C2D forwarder used to forward the client's `TLS-ClientHello` upstream as cleartext **before** the parser-driven `UpgradeTLS` directive could install the relay's pause barrier — corrupting the wire so keploy-side `tls.Client.Handshake` then failed with `bad key share` / `tls: illegal parameter`.

The fix is a single coordinated directive that runs the entire SSL choreography under the pause barrier:

1. **`directive.UpgradeTLSParams`** gains `PreambleReadFromDest`, `PreambleForwardToSrc`, `ProceedOnPreamble`. **`directive.Ack`** gains `PreamblePayload`, `TLSUpgraded`. The parser sends ONE directive that asks the relay to read N bytes from the real dest socket, forward them to the real src socket, gate handshakes on a byte match, and report what the server actually said via `Ack.PreamblePayload`.
2. **`Relay.handleUpgradeTLS`** waits for both forwarders to park (`parkedC2D` / `parkedD2C`) before doing anything — without that wait, `takeStashed` could TOCTOU-race a forwarder mid-wakeup-Read and deadlock on `readFullPreamble`.
3. **`Relay.forward`** signals `parkedC2D` / `parkedD2C` on first pause-barrier observation and stashes any bytes its Read returned post-pause into `stashedC2D` / `stashedD2C` instead of writing to the live socket (which would corrupt the upstream wire across the upgrade boundary).

The companion integrations-side consumer (`performPostgresSSLChoreoV2`) is in keploy/integrations PR (linked separately) along with new SSL coverage in the `asyncpg-postgres` (`sslmode=require`) and `pgtype-tour-postgres` (`sslmode=prefer`) pipelines.

This is **branched off `fix/syncmock-resolve-range-cutoff-after-window` (PR #4130)** so it inherits all those fixes plus the SSL fix on top — once #4130 merges this branch will rebase to a small SSL-only diff.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/agent/proxy/relay/ ./pkg/agent/proxy/directive/ -count=1 -race` passes
- [x] Local end-to-end: 10/10 tests green on `asyncpg-postgres` (`sslmode=require`)
- [x] Local end-to-end: 10/10 tests green on `pgtype-tour-postgres` (`sslmode=prefer`)
- [ ] keploy/integrations CI green on the linked SSL-coverage PR (gating on the new pipelines exercising this fix)
- [ ] keploy CodeQL clean (additive directive fields, no new tainted log calls)
- [ ] Existing non-TLS flows unchanged (`PreambleReadFromDest=0` degenerates to the original `UpgradeTLS` path)