### PR TITLE
Fix gRPC capture timestamps for strict mock windows

### DIFF
--- a/pkg/agent/proxy/incoming/gRPC/record.go
+++ b/pkg/agent/proxy/incoming/gRPC/record.go
@@ -53,8 +53,8 @@ func RecordIncoming(ctx context.Context, logger *zap.Logger, clientConn, destCon
 	// is never blocked by the parser in practice. If the channel fills up, the
 	// forwarder blocks (preserving stream integrity) rather than dropping bytes
 	// which would corrupt the HTTP/2 frame alignment for the parser.
-	clientFrameCh := make(chan []byte, 512)
-	destFrameCh := make(chan []byte, 512)
+	clientFrameCh := make(chan frameChunk, 512)
+	destFrameCh := make(chan frameChunk, 512)
 
 	// Forward client → dest, tee copies to channel
 	go func() {
@@ -118,12 +118,18 @@ func RecordIncoming(ctx context.Context, logger *zap.Logger, clientConn, destCon
 // When memory pressure is detected, the tee stops permanently for this
 // connection (cannot resume without corrupting the parser's frame alignment).
 // Forwarding continues unimpacted.
-func forwardAndTee(src, dst net.Conn, ch chan<- []byte, logger *zap.Logger, direction string) {
+type frameChunk struct {
+	data      []byte
+	timestamp time.Time
+}
+
+func forwardAndTee(src, dst net.Conn, ch chan<- frameChunk, logger *zap.Logger, direction string) {
 	buf := make([]byte, 32*1024)
 	teeActive := !memoryguard.IsRecordingPaused()
 	for {
 		n, err := src.Read(buf)
 		if n > 0 {
+			readAt := time.Now()
 			if _, wErr := dst.Write(buf[:n]); wErr != nil {
 				logger.Debug("forward write error",
 					zap.String("direction", direction), zap.Error(wErr))
@@ -135,7 +141,10 @@ func forwardAndTee(src, dst net.Conn, ch chan<- []byte, logger *zap.Logger, dire
 				} else {
 					data := make([]byte, n)
 					copy(data, buf[:n])
-					ch <- data // blocking send — preserves stream integrity
+					ch <- frameChunk{
+						data:      data,
+						timestamp: readAt,
+					} // blocking send — preserves stream integrity
 				}
 			}
 		}
@@ -149,64 +158,83 @@ func forwardAndTee(src, dst net.Conn, ch chan<- []byte, logger *zap.Logger, dire
 	}
 }
 
-// parseFramesFromChan reconstructs HTTP/2 frames from byte chunks received
-// via channel, then feeds them to the DefaultStreamManager.
-func parseFramesFromChan(ctx context.Context, logger *zap.Logger, ch <-chan []byte, sm *pkg.DefaultStreamManager, isOutgoing bool, triggerEmit func()) {
-	pr, pw := io.Pipe()
-	defer pr.Close()
-
-	go func() {
-		defer pw.Close()
-		var writeErr bool
-		for data := range ch {
-			// Keep draining the channel even after a pipe write error so the
-			// forwarder's blocking ch<-data never hangs. We just stop writing
-			// to the pipe (parser is done), but the channel must be consumed.
-			if !writeErr {
-				if _, err := pw.Write(data); err != nil {
-					writeErr = true
-				}
-			}
-		}
-	}()
-
-	if !isOutgoing {
-		preface := make([]byte, len(http2.ClientPreface))
-		if _, err := io.ReadFull(pr, preface); err != nil {
-			logger.Debug("failed to read HTTP/2 client preface", zap.Error(err))
-			return
-		}
-		if !bytes.Equal(preface, []byte(http2.ClientPreface)) {
-			logger.Debug("unexpected bytes instead of HTTP/2 preface")
-			return
-		}
-	}
-
-	framer := http2.NewFramer(nil, pr)
-	framer.ReadMetaHeaders = nil
-	framer.MaxHeaderListSize = 1 << 20
+// parseFramesFromChan reconstructs HTTP/2 frames from timestamped byte chunks
+// received via channel, then feeds them to the DefaultStreamManager.
+func parseFramesFromChan(ctx context.Context, logger *zap.Logger, ch <-chan frameChunk, sm *pkg.DefaultStreamManager, isOutgoing bool, triggerEmit func()) {
+	var buffer []byte
+	prefaceRead := isOutgoing
 
 	for {
+		var chunk frameChunk
 		select {
 		case <-ctx.Done():
+			drainFrameChunks(ch)
 			return
-		default:
-		}
-
-		frame, err := framer.ReadFrame()
-		if err != nil {
-			if err != io.EOF && !strings.Contains(err.Error(), "use of closed") {
-				logger.Debug("frame parser finished", zap.Bool("isOutgoing", isOutgoing), zap.Error(err))
+		case next, ok := <-ch:
+			if !ok {
+				return
 			}
-			return
+			chunk = next
 		}
 
-		now := time.Now()
-		if err := sm.HandleFrame(frame, isOutgoing, now); err != nil {
-			logger.Debug("stream manager error", zap.Error(err))
+		if len(chunk.data) == 0 {
+			continue
+		}
+		buffer = append(buffer, chunk.data...)
+
+		if !prefaceRead {
+			if len(buffer) < len(http2.ClientPreface) {
+				continue
+			}
+			if !bytes.Equal(buffer[:len(http2.ClientPreface)], []byte(http2.ClientPreface)) {
+				logger.Debug("unexpected bytes instead of HTTP/2 preface")
+				drainFrameChunks(ch)
+				return
+			}
+			buffer = buffer[len(http2.ClientPreface):]
+			prefaceRead = true
 		}
 
-		triggerEmit()
+		for {
+			if len(buffer) < 9 {
+				break
+			}
+			frameLength := (uint32(buffer[0]) << 16) | (uint32(buffer[1]) << 8) | uint32(buffer[2])
+			if frameLength > pkg.MaxFrameSize {
+				logger.Debug("frame parser finished",
+					zap.Bool("isOutgoing", isOutgoing),
+					zap.Uint32("frameLength", frameLength),
+					zap.Uint32("maxFrameSize", pkg.MaxFrameSize))
+				drainFrameChunks(ch)
+				return
+			}
+			frameSize := int(frameLength) + 9
+			if len(buffer) < frameSize {
+				break
+			}
+
+			frame, consumed, err := pkg.ExtractHTTP2Frame(buffer[:frameSize])
+			if err != nil {
+				logger.Debug("frame parser finished", zap.Bool("isOutgoing", isOutgoing), zap.Error(err))
+				drainFrameChunks(ch)
+				return
+			}
+			buffer = buffer[consumed:]
+			if len(buffer) == 0 {
+				buffer = nil
+			}
+
+			if err := sm.HandleFrame(frame, isOutgoing, chunk.timestamp); err != nil {
+				logger.Debug("stream manager error", zap.Error(err))
+			}
+
+			triggerEmit()
+		}
+	}
+}
+
+func drainFrameChunks(ch <-chan frameChunk) {
+	for range ch {
 	}
 }
 

--- a/pkg/agent/proxy/incoming/gRPC/record_test.go
+++ b/pkg/agent/proxy/incoming/gRPC/record_test.go
@@ -1,0 +1,109 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.keploy.io/server/v3/pkg"
+	"go.uber.org/zap"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+)
+
+func TestParseFramesFromChanUsesChunkTimestamps(t *testing.T) {
+	logger := zap.NewNop()
+	sm := pkg.NewStreamManager(logger)
+	requestAt := time.Unix(200, 0).UTC()
+	responseAt := time.Unix(205, 0).UTC()
+
+	clientCh := make(chan frameChunk, 1)
+	clientCh <- frameChunk{
+		data: append([]byte(http2.ClientPreface),
+			append(
+				headersFrameBytes(t, 1, []hpack.HeaderField{
+					{Name: ":method", Value: "POST"},
+					{Name: ":scheme", Value: "http"},
+					{Name: ":path", Value: "/svc.Echo/Ping"},
+					{Name: ":authority", Value: "localhost:50051"},
+					{Name: "content-type", Value: "application/grpc"},
+				}, false),
+				dataFrameBytes(t, 1, true, grpcPayloadBytes([]byte{0x0a, 0x04, 'p', 'i', 'n', 'g'}))...,
+			)...,
+		),
+		timestamp: requestAt,
+	}
+	close(clientCh)
+	parseFramesFromChan(context.Background(), logger, clientCh, sm, false, func() {})
+
+	destCh := make(chan frameChunk, 1)
+	destCh <- frameChunk{
+		data: append(
+			append(
+				headersFrameBytes(t, 1, []hpack.HeaderField{
+					{Name: ":status", Value: "200"},
+					{Name: "content-type", Value: "application/grpc"},
+				}, false),
+				dataFrameBytes(t, 1, false, grpcPayloadBytes([]byte{0x0a, 0x04, 'p', 'o', 'n', 'g'}))...,
+			),
+			headersFrameBytes(t, 1, []hpack.HeaderField{
+				{Name: "grpc-status", Value: "0"},
+				{Name: "grpc-message", Value: ""},
+			}, true)...,
+		),
+		timestamp: responseAt,
+	}
+	close(destCh)
+	parseFramesFromChan(context.Background(), logger, destCh, sm, true, func() {})
+
+	streams := sm.GetCompleteStreams()
+	require.Len(t, streams, 1)
+	assert.Equal(t, requestAt, streams[0].GRPCReq.Timestamp)
+	assert.Equal(t, responseAt, streams[0].GRPCResp.Timestamp)
+}
+
+func headersFrameBytes(t *testing.T, streamID uint32, fields []hpack.HeaderField, endStream bool) []byte {
+	t.Helper()
+
+	var block bytes.Buffer
+	enc := hpack.NewEncoder(&block)
+	for _, field := range fields {
+		require.NoError(t, enc.WriteField(field))
+	}
+
+	return frameBytes(t, func(fr *http2.Framer) error {
+		return fr.WriteHeaders(http2.HeadersFrameParam{
+			StreamID:      streamID,
+			BlockFragment: block.Bytes(),
+			EndHeaders:    true,
+			EndStream:     endStream,
+		})
+	})
+}
+
+func dataFrameBytes(t *testing.T, streamID uint32, endStream bool, data []byte) []byte {
+	t.Helper()
+
+	return frameBytes(t, func(fr *http2.Framer) error {
+		return fr.WriteData(streamID, endStream, data)
+	})
+}
+
+func frameBytes(t *testing.T, write func(*http2.Framer) error) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	require.NoError(t, write(http2.NewFramer(&buf, nil)))
+	return buf.Bytes()
+}
+
+func grpcPayloadBytes(msg []byte) []byte {
+	payload := make([]byte, 5+len(msg))
+	binary.BigEndian.PutUint32(payload[1:5], uint32(len(msg)))
+	copy(payload[5:], msg)
+	return payload
+}

--- a/pkg/http2.go
+++ b/pkg/http2.go
@@ -199,10 +199,12 @@ func (sm *DefaultStreamManager) HandleFrame(frame http2.Frame, isOutgoing bool, 
 		sm.streams[streamID] = &HTTP2StreamState{
 			ID:        streamID,
 			RequestID: requestID,
-			startTime: frameTime,
 		}
 	}
 	s := sm.streams[streamID]
+	if !isOutgoing && s.startTime.IsZero() {
+		s.startTime = frameTime
+	}
 
 	switch f := frame.(type) {
 

--- a/pkg/http2_test.go
+++ b/pkg/http2_test.go
@@ -1,0 +1,89 @@
+package pkg
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+)
+
+func TestStreamManagerUsesIncomingFrameTimeForGRPCRequestTimestamp(t *testing.T) {
+	sm := NewStreamManager(zap.NewNop())
+	requestAt := time.Unix(100, 0).UTC()
+	responseAt := time.Unix(105, 0).UTC()
+
+	// Process response frames first to model the two parser goroutines racing.
+	require.NoError(t, sm.HandleFrame(headersFrame(t, 1, []hpack.HeaderField{
+		{Name: ":status", Value: "200"},
+		{Name: "content-type", Value: "application/grpc"},
+	}, false), true, responseAt))
+	require.NoError(t, sm.HandleFrame(dataFrame(t, 1, false, grpcPayload([]byte{0x0a, 0x04, 'p', 'o', 'n', 'g'})), true, responseAt.Add(time.Millisecond)))
+	require.NoError(t, sm.HandleFrame(headersFrame(t, 1, []hpack.HeaderField{
+		{Name: "grpc-status", Value: "0"},
+		{Name: "grpc-message", Value: ""},
+	}, true), true, responseAt.Add(2*time.Millisecond)))
+
+	require.NoError(t, sm.HandleFrame(headersFrame(t, 1, []hpack.HeaderField{
+		{Name: ":method", Value: "POST"},
+		{Name: ":scheme", Value: "http"},
+		{Name: ":path", Value: "/svc.Echo/Ping"},
+		{Name: ":authority", Value: "localhost:50051"},
+		{Name: "content-type", Value: "application/grpc"},
+	}, false), false, requestAt))
+	require.NoError(t, sm.HandleFrame(dataFrame(t, 1, true, grpcPayload([]byte{0x0a, 0x04, 'p', 'i', 'n', 'g'})), false, requestAt.Add(time.Millisecond)))
+
+	streams := sm.GetCompleteStreams()
+	require.Len(t, streams, 1)
+	assert.Equal(t, requestAt, streams[0].GRPCReq.Timestamp)
+	assert.Equal(t, responseAt.Add(2*time.Millisecond), streams[0].GRPCResp.Timestamp)
+}
+
+func headersFrame(t *testing.T, streamID uint32, fields []hpack.HeaderField, endStream bool) http2.Frame {
+	t.Helper()
+
+	var block bytes.Buffer
+	enc := hpack.NewEncoder(&block)
+	for _, field := range fields {
+		require.NoError(t, enc.WriteField(field))
+	}
+
+	return readFrame(t, func(fr *http2.Framer) error {
+		return fr.WriteHeaders(http2.HeadersFrameParam{
+			StreamID:      streamID,
+			BlockFragment: block.Bytes(),
+			EndHeaders:    true,
+			EndStream:     endStream,
+		})
+	})
+}
+
+func dataFrame(t *testing.T, streamID uint32, endStream bool, data []byte) http2.Frame {
+	t.Helper()
+
+	return readFrame(t, func(fr *http2.Framer) error {
+		return fr.WriteData(streamID, endStream, data)
+	})
+}
+
+func readFrame(t *testing.T, write func(*http2.Framer) error) http2.Frame {
+	t.Helper()
+
+	var buf bytes.Buffer
+	require.NoError(t, write(http2.NewFramer(&buf, nil)))
+	frame, err := http2.NewFramer(nil, &buf).ReadFrame()
+	require.NoError(t, err)
+	return frame
+}
+
+func grpcPayload(msg []byte) []byte {
+	payload := make([]byte, 5+len(msg))
+	binary.BigEndian.PutUint32(payload[1:5], uint32(len(msg)))
+	copy(payload[5:], msg)
+	return payload
+}


### PR DESCRIPTION
## Summary
- Preserve socket-read timestamps while parsing gRPC HTTP/2 frames instead of stamping frames from parser goroutine time.
- Use the first incoming request frame as the gRPC request timestamp even when response parsing wins the goroutine race.
- Add focused tests for strict mock-window timestamp ordering.

## Tests
- `go test ./pkg ./pkg/agent/proxy/incoming/gRPC`