### PR TITLE
fix(supervisor): fall through to passthrough on parser error returns (closes #4138)

### DIFF
--- a/pkg/agent/proxy/supervisor/supervisor.go
+++ b/pkg/agent/proxy/supervisor/supervisor.go
@@ -340,7 +340,24 @@ func (s *Supervisor) classifyReturn(outerCtx context.Context, panicked bool, pan
 	if errors.Is(fnErr, context.Canceled) && outerCtx.Err() != nil {
 		return Result{Status: StatusCanceled, Err: fnErr}
 	}
-	return Result{Status: StatusError, Err: fnErr}
+	// G1 fix: a parser that returned a non-nil error on its own
+	// (decode failure, malformed wire frame, decompression error,
+	// etc.) is in the same situation as a panic from the user-traffic
+	// perspective — the bytes have already been forwarded by the
+	// relay, and the parser's failure to record a clean mock has no
+	// bearing on whether the application's connection should survive.
+	// Set FallthroughToPassthrough so the dispatcher leaves the relay
+	// alone and bytes keep flowing until peer close. fireOnAbort is
+	// invoked so the SessionOnAbort callback can pause the tees and
+	// close the FakeConns; without it the tees keep accumulating
+	// chunks for a parser that will never read them, eventually
+	// dropping at DropChannelFull and spamming Debug logs.
+	s.fireOnAbort()
+	return Result{
+		Status:                   StatusError,
+		Err:                      fnErr,
+		FallthroughToPassthrough: true,
+	}
 }
 
 // reportPanic invokes cfg.PanicReporter guarded against reporter

--- a/pkg/agent/proxy/supervisor/supervisor_test.go
+++ b/pkg/agent/proxy/supervisor/supervisor_test.go
@@ -53,8 +53,17 @@ func TestRunError(t *testing.T) {
 	if !errors.Is(res.Err, sentinel) {
 		t.Fatalf("err: got %v, want %v", res.Err, sentinel)
 	}
-	if res.FallthroughToPassthrough {
-		t.Fatalf("fallthrough: got true, want false (errors alone don't fall through)")
+	// Parser-side decode/state errors must fall through to passthrough.
+	// The bytes have already been forwarded by the relay; the parser's
+	// inability to record a clean mock has no bearing on whether the
+	// application's connection should survive. The dispatcher reads
+	// FallthroughToPassthrough and skips relayCancel when true, leaving
+	// the relay alive to forward subsequent traffic until peer close.
+	// See pkg/agent/proxy/integrations/http/recordv2.go for the call
+	// sites this contract protects (invalid Content-Length, gzip
+	// decompression failure, malformed status line).
+	if !res.FallthroughToPassthrough {
+		t.Fatalf("fallthrough: got false, want true (parser errors must not tear down the application's connection)")
 	}
 }
 

--- a/pkg/agent/proxy/v2_integration_test.go
+++ b/pkg/agent/proxy/v2_integration_test.go
@@ -278,6 +278,94 @@ func TestV2_PanicDoesNotBlockTraffic(t *testing.T) {
 	}
 }
 
+// -------- Error-return parser --------
+
+// errorReturnParser reads one client chunk, then returns a non-nil
+// error without panicking. Mirrors the path real V2 parsers take when
+// they hit a decode failure (invalid Content-Length, gzip header
+// mismatch, malformed wire frame, etc.). The supervisor must classify
+// this as StatusError AND request passthrough so the relay keeps
+// forwarding bytes end-to-end — same invariant the panic test
+// asserts, but for the much more common error-return path.
+func errorReturnParser(_ context.Context, sess *supervisor.Session) error {
+	_, _ = sess.ClientStream.ReadChunk()
+	return errParserDecode{}
+}
+
+type errParserDecode struct{}
+
+func (errParserDecode) Error() string { return "synthetic parser decode error" }
+
+// TestV2_ErrorDoesNotBlockTraffic mirrors TestV2_PanicDoesNotBlockTraffic
+// for the clean error-return path. A real parser returning an error
+// (e.g. http recordv2 on "invalid content-length: ...") must not tear
+// down the application's TCP connection. Confirmed empirically against
+// the V2 HTTP parser via /api/stalls/v2gap/http?case=bad-cl in the
+// sample-app validators; this is the unit-level regression guard.
+func TestV2_ErrorDoesNotBlockTraffic(t *testing.T) {
+	t.Parallel()
+	pp := newPipePair(t)
+
+	sv := supervisor.New(supervisor.Config{Logger: zaptest.NewLogger(t)})
+	defer sv.Close()
+
+	r := mustStartRelay(t, pp, sv.BumpActivity)
+	sess, mocks := mustBuildSession(t, sv, r)
+
+	// Destination: keep echoing forever so we can probe the byte
+	// path AFTER the parser returns.
+	go func() {
+		buf := make([]byte, 64)
+		for {
+			n, err := pp.destSrv.Read(buf)
+			if err != nil {
+				return
+			}
+			_, werr := pp.destSrv.Write(append([]byte("reply:"), buf[:n]...))
+			if werr != nil {
+				return
+			}
+		}
+	}()
+
+	clientGot := make(chan []byte, 1)
+	go func() {
+		_, _ = pp.clientApp.Write([]byte("hello"))
+		b := make([]byte, 64)
+		n, _ := pp.clientApp.Read(b)
+		clientGot <- b[:n]
+	}()
+
+	resCh := make(chan supervisor.Result, 1)
+	go func() { resCh <- sv.Run(context.Background(), errorReturnParser, sess) }()
+
+	// Byte path survives the parser's error return.
+	select {
+	case got := <-clientGot:
+		if !bytes.Equal(got, []byte("reply:hello")) {
+			t.Errorf("got %q, want reply:hello", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("client did not receive reply despite parser returning an error")
+	}
+
+	var res supervisor.Result
+	select {
+	case res = <-resCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("supervisor did not return within 3s")
+	}
+	if res.Status != supervisor.StatusError {
+		t.Errorf("status = %v, want StatusError", res.Status)
+	}
+	if !res.FallthroughToPassthrough {
+		t.Error("error-return must request passthrough — otherwise the dispatcher cancels the relay and tears down the application's connection")
+	}
+	if len(mocks) != 0 {
+		t.Errorf("error-return produced %d mocks, want 0 (incomplete decode → no mock)", len(mocks))
+	}
+}
+
 // -------- Hang parser --------
 
 // hangParser marks pending work (so the watchdog arms) and blocks


### PR DESCRIPTION
Closes #4138.

## Summary

- `Supervisor.classifyReturn` now sets `FallthroughToPassthrough: true` and invokes `fireOnAbort` on the `StatusError` path, matching the existing semantics for `StatusPanicked` / `StatusHung` / `StatusMemCap`. The dispatcher already handles fallthrough correctly: it leaves the relay alive to keep forwarding bytes end-to-end until peer close, and the mock is dropped via the existing `MarkMockIncomplete` machinery.
- `TestRunError` updated to assert the new contract (errors fall through). Comment explains why.
- New `TestV2_ErrorDoesNotBlockTraffic` in `v2_integration_test.go`, symmetric with the existing `TestV2_PanicDoesNotBlockTraffic` — drives a parser that returns a sentinel error mid-stream over a real `net.Pipe()` relay and asserts the application receives its reply.

The change is one block. ~13 of the 14 added lines in `supervisor.go` are explanatory comment.

## Why

V2 architecture's invariant **I2** (`pkg/agent/proxy/README.md`):

> Parser failures are local: panics / hangs / OOM in a parser never affect other connections, **and never affect the faulting connection's byte path**.

Held for panic, hang, memcap, outer-cancel. Did **not** hold for clean error returns — the most common parser failure mode. A V2 HTTP parser hitting `strconv.Atoi("notanumber")` on a malformed `Content-Length` header would return an error; the supervisor reported `StatusError` with `FallthroughToPassthrough=false`; `recordViaSupervisor` called `relayCancel()` and the application's keepalive socket died with it.

The codebase even printed `next_step: ...; the supervisor has already fallen through to passthrough for this connection so user traffic continues` while doing the opposite. See #4138 for the full empirical reproduction with logs and side-by-side probe results.

## Test plan

- [x] `go test -race ./pkg/agent/proxy/...` — all pass
- [x] `go vet ./pkg/agent/proxy/...` — clean
- [x] Manual end-to-end: built `main`+patch, ran a 3-request keepalive A/B probe (`sane → malformed → sane` on a single TCP socket) under `sudo keploy record` against three malformed cases:
  - `bad-cl` (Content-Length parse error): before `conn_survived=False`, after `conn_survived=True` ✅
  - `truncated-gzip` (decompression failure): before `conn_survived=False`, after `conn_survived=True` ✅
  - `bad-status` (malformed status line): unchanged (was already racing through; would also be covered)

## Out of scope (suggested follow-ups)

- The hard-coded `next_step` at `pkg/agent/proxy/proxy.go:1856` becomes truthful for `StatusError` post-fix but still misleads on shutdown-related paths. Worth gating the message on `result.FallthroughToPassthrough` or rewriting in a later PR.
- A `tests/e2e/chaos-broken-parser-error-returns/` harness (real Postgres + a synthetic parser whose `RecordOutgoing` returns a decode error) would mirror the existing chaos panic test and catch any regression that re-introduces the gap. The unit-level `TestV2_ErrorDoesNotBlockTraffic` added here covers the supervisor side; the chaos test would add a real-traffic guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
