### PR TITLE
fix(cli): revert cli/provider.Logo from const to var (restore runtime-override hook)

### DIFF
--- a/cli/provider/util.go
+++ b/cli/provider/util.go
@@ -20,7 +20,7 @@ func alreadyRunning(cmd, basePath string) bool {
 	return (cmd == "test" && basePath != "")
 }
 
-const Logo = `
+var Logo = `
        ▓██▓▄
     ▓▓▓▓██▓█▓▄
      ████████▓▒


### PR DESCRIPTION
## Summary

One-character change: flip `cli/provider.Logo` from `const` back to `var`, restoring the runtime-override hook that downstream wrappers (notably `keploy/enterprise`) rely on for plan-aware banners.

## Why

[#4134](https://github.com/keploy/keploy/pull/4134) (commit 874064ec) changed:

```go
var Logo = `...`
```

to:

```go
const Logo = `...`
```

The change is cosmetic for OSS — the constant carries the same ASCII banner with `OPEN SOURCE` in the trailer. But the `var` form was a documented integration point: any wrapper that builds on the OSS CLI swaps in its own banner once at startup, after authentication identifies the user's plan:

```go
ossCliProvider.Logo = util.LogoForPlan(planType)
```

In v3.5.7 that assignment fails to compile (`cannot assign to ossCliProvider.Logo`). The wrapper has no remaining hook to inject a plan-aware banner, so paying users see `OPEN SOURCE` regardless of their plan tier. Tracked downstream in keploy/enterprise#1932 where the override sites had to be commented out behind `TODO(v3.5.8+)` markers to unblock the bump from v3.5.5 → v3.5.7.

## Why this minimal revert and not a setter

A stricter API surface — e.g. `SetLogo(string)` or `var LogoFn func() string` — is the cleaner long-term shape, but it's a wider design discussion (does it lock during printing, what happens to existing `provider.PrintLogo` call sites in `cli/examples.go`, `cli/export.go`, `cli/import.go`, `cli/root.go`, `cli/provider/cmd.go`, etc.). Reverting `const` → `var` is the smallest change that unblocks the downstream wrapper now and leaves the door open for that larger redesign later. **No OSS user-visible behaviour changes**: the default value and the printer are byte-identical to v3.5.7.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./cli/...` clean
- [x] `go test ./cli/provider/...` — no test files in that package, no test failures introduced

## Next step

Once this lands and OSS tags `v3.5.8`, the downstream PR (keploy/enterprise#1932) updates to bump to `v3.5.8` and uncomments the three `ossCliProvider.Logo = ...` override sites. The cosmetic regression in the enterprise banner goes away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
