### PR TITLE
fix(postgres-v3): preserve TLS relay read timestamps

### DIFF
--- a/pkg/agent/proxy/relay/directive_proc.go
+++ b/pkg/agent/proxy/relay/directive_proc.go
@@ -184,20 +184,9 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, stopping <-chan struct{}, 
 	var preamblePayload []byte
 	if params.PreambleReadFromDest > 0 {
 		// 1a. Try the D2C stash first.
-		if stashed := r.takeStashed(fakeconn.FromDest); len(stashed) > 0 {
-			if len(stashed) >= params.PreambleReadFromDest {
-				preamblePayload = stashed[:params.PreambleReadFromDest]
-				// If the forwarder stashed more than we needed
-				// (unlikely for a 1-byte preamble but defensive
-				// against future protocols), the surplus is dropped
-				// — the upgraded socket has no clean way to
-				// consume cleartext bytes captured pre-upgrade.
-				if log != nil && len(stashed) > params.PreambleReadFromDest {
-					log.Debug("relay: dropping stashed surplus past preamble window",
-						zap.Int("requested", params.PreambleReadFromDest),
-						zap.Int("stashed", len(stashed)),
-					)
-				}
+		if stashed := r.takeStashedPrefix(fakeconn.FromDest, params.PreambleReadFromDest); stashed.len() > 0 {
+			if stashed.len() >= params.PreambleReadFromDest {
+				preamblePayload = stashed.bytes[:params.PreambleReadFromDest]
 			} else {
 				// Stash fell short of what the parser asked for;
 				// top up by reading the remainder directly from
@@ -206,15 +195,15 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, stopping <-chan struct{}, 
 				// single byte — but keeps the contract strict for
 				// future protocols.
 				preamblePayload = make([]byte, params.PreambleReadFromDest)
-				copy(preamblePayload, stashed)
+				copy(preamblePayload, stashed.bytes)
 				clearDeadline(r.dst.Load())
 				dst := *r.dst.Load()
-				_, err := readFullPreamble(dst, preamblePayload[len(stashed):])
+				_, err := readFullPreamble(dst, preamblePayload[stashed.len():])
 				if err != nil {
 					if log != nil {
 						log.Debug("relay: TLS upgrade preamble read (post-stash) failed",
 							zap.Error(err),
-							zap.Int("stashed", len(stashed)),
+							zap.Int("stashed", stashed.len()),
 							zap.Int("requested", params.PreambleReadFromDest),
 							zap.String("directive_reason", d.Reason),
 							zap.String("next_step", "the upstream closed mid-preamble; verify the destination is the protocol the parser was matched to and consider KEPLOY_DISABLE_PARSING=1 to bypass parsing"),
@@ -225,7 +214,7 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, stopping <-chan struct{}, 
 						Kind:            d.Kind,
 						OK:              false,
 						Err:             fmt.Errorf("TLS upgrade preamble read: %w", err),
-						PreamblePayload: preamblePayload[:len(stashed)],
+						PreamblePayload: preamblePayload[:stashed.len()],
 					}
 				}
 			}
@@ -266,22 +255,6 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, stopping <-chan struct{}, 
 					PreamblePayload: preamblePayload[:n],
 				}
 			}
-		}
-
-		// 1c. Drop the stashed C2D payload if any. The forwarder
-		// captured the client's reply to the server's preamble
-		// (e.g. TLS ClientHello after seeing 'S') without writing
-		// it to the live dest socket. The upgraded src conn will
-		// run its own handshake from a fresh ClientHello; the
-		// stashed bytes have no place to go. We log the size at
-		// debug so a future operator can correlate it with a
-		// supervisor warning if the discard ever turns out to drop
-		// genuine application bytes.
-		if c2dStash := r.takeStashed(fakeconn.FromClient); len(c2dStash) > 0 && log != nil {
-			log.Debug("relay: dropping stashed client-side bytes captured during pause",
-				zap.Int("dropped_bytes", len(c2dStash)),
-				zap.String("directive_reason", d.Reason),
-			)
 		}
 
 		if params.PreambleForwardToSrc {
@@ -355,16 +328,17 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, stopping <-chan struct{}, 
 		// pure TLS) leaves nothing past the preamble, so this branch
 		// is defensive — but it keeps the contract that no stashed
 		// bytes are ever silently dropped at the upgrade boundary.
-		if stashed := r.takeStashed(fakeconn.FromDest); len(stashed) > 0 {
+		if stashed := r.takeStashed(fakeconn.FromDest); stashed.len() > 0 {
 			if log != nil {
 				log.Debug("relay: prepending stashed dst bytes to TLS handshake",
-					zap.Int("bytes", len(stashed)),
+					zap.Int("bytes", stashed.len()),
 				)
 			}
-			dst = newPrependingConn(dst, stashed)
+			dst = newPrependingConnWithReadAt(dst, stashed.bytes, stashed.readAt)
 		}
+		trackedDst := newReadTrackingConn(dst)
 		var err error
-		upgradedDst, err = r.cfg.TLSUpgradeFn(ctx, dst, true, params.DestTLSConfig)
+		upgradedDst, err = r.cfg.TLSUpgradeFn(ctx, trackedDst, true, params.DestTLSConfig)
 		if err != nil {
 			if log != nil {
 				// Debug-level: TLS upgrade failures are expected on some
@@ -388,6 +362,7 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, stopping <-chan struct{}, 
 				PreamblePayload: preamblePayload,
 			}
 		}
+		upgradedDst = newReadTimeReportingConn(upgradedDst, trackedDst)
 	}
 
 	if params.ClientTLSConfig != nil {
@@ -413,16 +388,17 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, stopping <-chan struct{}, 
 		// The takeStashed call also clears r.stashedC2D so endPause
 		// does not silently drop those same bytes after the handshake
 		// returns.
-		if stashed := r.takeStashed(fakeconn.FromClient); len(stashed) > 0 {
+		if stashed := r.takeStashed(fakeconn.FromClient); stashed.len() > 0 {
 			if log != nil {
 				log.Debug("relay: prepending stashed src bytes to TLS handshake",
-					zap.Int("bytes", len(stashed)),
+					zap.Int("bytes", stashed.len()),
 				)
 			}
-			src = newPrependingConn(src, stashed)
+			src = newPrependingConnWithReadAt(src, stashed.bytes, stashed.readAt)
 		}
+		trackedSrc := newReadTrackingConn(src)
 		var err error
-		upgradedSrc, err = r.cfg.TLSUpgradeFn(ctx, src, false, params.ClientTLSConfig)
+		upgradedSrc, err = r.cfg.TLSUpgradeFn(ctx, trackedSrc, false, params.ClientTLSConfig)
 		if err != nil {
 			if log != nil {
 				// Debug-level: see dest-side upgrade comment above.
@@ -449,6 +425,7 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, stopping <-chan struct{}, 
 				PreamblePayload: preamblePayload,
 			}
 		}
+		upgradedSrc = newReadTimeReportingConn(upgradedSrc, trackedSrc)
 	}
 
 	// Both handshakes (or only those requested) succeeded. Publish

--- a/pkg/agent/proxy/relay/prepending_conn.go
+++ b/pkg/agent/proxy/relay/prepending_conn.go
@@ -2,6 +2,8 @@ package relay
 
 import (
 	"net"
+	"sync/atomic"
+	"time"
 )
 
 // prependingConn wraps a net.Conn and yields a fixed prefix of bytes
@@ -34,7 +36,9 @@ import (
 // "drain stash into TLS handshake" use case).
 type prependingConn struct {
 	net.Conn
-	prefix []byte
+	prefix       []byte
+	prefixReadAt time.Time
+	lastReadNano atomic.Int64
 }
 
 // newPrependingConn returns a net.Conn that reads `prefix` first,
@@ -42,10 +46,18 @@ type prependingConn struct {
 // unchanged so callers don't pay the wrapper cost on the common
 // path where no bytes were stashed.
 func newPrependingConn(c net.Conn, prefix []byte) net.Conn {
+	return newPrependingConnWithReadAt(c, prefix, time.Time{})
+}
+
+func newPrependingConnWithReadAt(c net.Conn, prefix []byte, readAt time.Time) net.Conn {
 	if len(prefix) == 0 {
 		return c
 	}
-	return &prependingConn{Conn: c, prefix: prefix}
+	return &prependingConn{
+		Conn:         c,
+		prefix:       append([]byte(nil), prefix...),
+		prefixReadAt: readAt,
+	}
 }
 
 // Read drains the prefix first. Once the prefix is exhausted, future
@@ -60,7 +72,22 @@ func (p *prependingConn) Read(b []byte) (int, error) {
 	if len(p.prefix) > 0 {
 		n := copy(b, p.prefix)
 		p.prefix = p.prefix[n:]
+		if !p.prefixReadAt.IsZero() {
+			p.lastReadNano.Store(p.prefixReadAt.UnixNano())
+		}
 		return n, nil
 	}
-	return p.Conn.Read(b)
+	n, err := p.Conn.Read(b)
+	if n > 0 {
+		p.lastReadNano.Store(observedReadAt(p.Conn, time.Now()).UnixNano())
+	}
+	return n, err
+}
+
+func (p *prependingConn) LastReadTime() time.Time {
+	n := p.lastReadNano.Load()
+	if n == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, n)
 }

--- a/pkg/agent/proxy/relay/prepending_conn_test.go
+++ b/pkg/agent/proxy/relay/prepending_conn_test.go
@@ -78,6 +78,29 @@ func TestPrependingConn_PrefixOnly(t *testing.T) {
 	}
 }
 
+func TestPrependingConn_LastReadTimeUsesPrefixReadAt(t *testing.T) {
+	raw := &fakeReadConn{chunks: [][]byte{[]byte("LIVE")}}
+	readAt := time.Unix(1_700_000_000, 42)
+	c := newPrependingConnWithReadAt(raw, []byte("STASH"), readAt)
+
+	buf := make([]byte, 100)
+	n, err := c.Read(buf)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got := string(buf[:n]); got != "STASH" {
+		t.Fatalf("Read = %q; want STASH", got)
+	}
+
+	provider, ok := c.(interface{ LastReadTime() time.Time })
+	if !ok {
+		t.Fatalf("prepending conn does not expose LastReadTime")
+	}
+	if got := provider.LastReadTime(); !got.Equal(readAt) {
+		t.Fatalf("LastReadTime = %v, want prefix readAt %v", got, readAt)
+	}
+}
+
 func TestPrependingConn_PrefixSpansMultipleReads(t *testing.T) {
 	// Prefix longer than the read buffer; multiple Reads are needed
 	// to drain it. The contract is "never mix prefix + live in one

--- a/pkg/agent/proxy/relay/read_time.go
+++ b/pkg/agent/proxy/relay/read_time.go
@@ -1,0 +1,95 @@
+package relay
+
+import (
+	"net"
+	"sync/atomic"
+	"time"
+)
+
+type readTimeProvider interface {
+	LastReadTime() time.Time
+}
+
+type stashedPayload struct {
+	bytes  []byte
+	readAt time.Time
+}
+
+func (s stashedPayload) len() int {
+	return len(s.bytes)
+}
+
+func joinStashed(parts []stashedPayload) stashedPayload {
+	if len(parts) == 0 {
+		return stashedPayload{}
+	}
+	if len(parts) == 1 {
+		return parts[0]
+	}
+	total := 0
+	var firstReadAt time.Time
+	for _, p := range parts {
+		total += len(p.bytes)
+		if firstReadAt.IsZero() && !p.readAt.IsZero() {
+			firstReadAt = p.readAt
+		}
+	}
+	if total == 0 {
+		return stashedPayload{}
+	}
+	out := make([]byte, 0, total)
+	for _, p := range parts {
+		out = append(out, p.bytes...)
+	}
+	return stashedPayload{bytes: out, readAt: firstReadAt}
+}
+
+func observedReadAt(conn net.Conn, fallback time.Time) time.Time {
+	if p, ok := conn.(readTimeProvider); ok {
+		if ts := p.LastReadTime(); !ts.IsZero() {
+			return ts
+		}
+	}
+	return fallback
+}
+
+type readTrackingConn struct {
+	net.Conn
+	lastReadNano atomic.Int64
+}
+
+func newReadTrackingConn(conn net.Conn) *readTrackingConn {
+	return &readTrackingConn{Conn: conn}
+}
+
+func (c *readTrackingConn) Read(p []byte) (int, error) {
+	n, err := c.Conn.Read(p)
+	if n > 0 {
+		c.lastReadNano.Store(observedReadAt(c.Conn, time.Now()).UnixNano())
+	}
+	return n, err
+}
+
+func (c *readTrackingConn) LastReadTime() time.Time {
+	n := c.lastReadNano.Load()
+	if n == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, n)
+}
+
+type readTimeReportingConn struct {
+	net.Conn
+	source readTimeProvider
+}
+
+func newReadTimeReportingConn(conn net.Conn, source readTimeProvider) net.Conn {
+	if conn == nil || source == nil {
+		return conn
+	}
+	return &readTimeReportingConn{Conn: conn, source: source}
+}
+
+func (c *readTimeReportingConn) LastReadTime() time.Time {
+	return c.source.LastReadTime()
+}

--- a/pkg/agent/proxy/relay/relay.go
+++ b/pkg/agent/proxy/relay/relay.go
@@ -87,8 +87,8 @@ type Relay struct {
 	// owns those bytes and the upgraded socket has no way to consume
 	// them sensibly.
 	stashMu    sync.Mutex
-	stashedC2D []byte
-	stashedD2C []byte
+	stashedC2D []stashedPayload
+	stashedD2C []stashedPayload
 
 	// seqC2D and seqD2C are the per-direction monotonic Chunk sequence
 	// numbers, scoped to this connection.
@@ -379,6 +379,9 @@ func (r *Relay) forward(
 		src := *srcPtr.Load()
 		n, err := src.Read(buf)
 		readAt := time.Now()
+		if n > 0 {
+			readAt = observedReadAt(src, readAt)
+		}
 
 		// Re-check the pause barrier AFTER Read returns and BEFORE
 		// any Write/Tee. Without this, a directive issued while the
@@ -404,7 +407,7 @@ func (r *Relay) forward(
 			if n > 0 {
 				stash := make([]byte, n)
 				copy(stash, buf[:n])
-				r.stashInflightFromPause(dir, stash)
+				r.stashInflightFromPause(dir, stash, readAt)
 				if log != nil {
 					log.Debug("relay: stashing in-flight bytes across pause boundary",
 						zap.String("dir", dir.String()),
@@ -718,38 +721,107 @@ func clearDeadline(c *net.Conn) {
 // Bytes are appended to any existing stash so two consecutive Read+
 // pause-recheck iterations don't lose data; in practice the forwarder
 // only ever reaches this path once per pause window.
-func (r *Relay) stashInflightFromPause(dir fakeconn.Direction, payload []byte) {
+func (r *Relay) stashInflightFromPause(dir fakeconn.Direction, payload []byte, readAt time.Time) {
 	if len(payload) == 0 {
 		return
+	}
+	stashed := stashedPayload{
+		bytes:  append([]byte(nil), payload...),
+		readAt: readAt,
 	}
 	r.stashMu.Lock()
 	defer r.stashMu.Unlock()
 	switch dir {
 	case fakeconn.FromClient:
-		r.stashedC2D = append(r.stashedC2D, payload...)
+		r.stashedC2D = append(r.stashedC2D, stashed)
 	case fakeconn.FromDest:
-		r.stashedD2C = append(r.stashedD2C, payload...)
+		r.stashedD2C = append(r.stashedD2C, stashed)
 	}
 }
 
 // takeStashed returns and clears the stash for the given direction.
 // Used by the directive handler under the pause barrier to claim
 // bytes the forwarder captured at the moment the barrier was raised.
-// Returns nil if there is no stash; takeStashed is safe to call
-// before any forwarder Read has fired.
-func (r *Relay) takeStashed(dir fakeconn.Direction) []byte {
+// Returns a zero payload if there is no stash; takeStashed is safe to
+// call before any forwarder Read has fired.
+func (r *Relay) takeStashed(dir fakeconn.Direction) stashedPayload {
 	r.stashMu.Lock()
 	defer r.stashMu.Unlock()
-	var out []byte
+	var parts []stashedPayload
 	switch dir {
 	case fakeconn.FromClient:
-		out = r.stashedC2D
+		parts = r.stashedC2D
 		r.stashedC2D = nil
 	case fakeconn.FromDest:
-		out = r.stashedD2C
+		parts = r.stashedD2C
 		r.stashedD2C = nil
 	}
-	return out
+	return joinStashed(parts)
+}
+
+// takeStashedPrefix returns up to n bytes from the given direction's
+// stash, leaving any surplus bytes queued for a later takeStashed call.
+func (r *Relay) takeStashedPrefix(dir fakeconn.Direction, n int) stashedPayload {
+	if n <= 0 {
+		return stashedPayload{}
+	}
+	r.stashMu.Lock()
+	defer r.stashMu.Unlock()
+
+	switch dir {
+	case fakeconn.FromClient:
+		prefix, rest := splitStashedPrefix(r.stashedC2D, n)
+		r.stashedC2D = rest
+		return prefix
+	case fakeconn.FromDest:
+		prefix, rest := splitStashedPrefix(r.stashedD2C, n)
+		r.stashedD2C = rest
+		return prefix
+	default:
+		return stashedPayload{}
+	}
+}
+
+func splitStashedPrefix(parts []stashedPayload, n int) (stashedPayload, []stashedPayload) {
+	if n <= 0 || len(parts) == 0 {
+		return stashedPayload{}, parts
+	}
+	out := make([]byte, 0, n)
+	var outReadAt time.Time
+	rest := parts
+	for n > 0 && len(rest) > 0 {
+		part := rest[0]
+		if len(part.bytes) == 0 {
+			rest = rest[1:]
+			continue
+		}
+		if outReadAt.IsZero() && !part.readAt.IsZero() {
+			outReadAt = part.readAt
+		}
+		take := len(part.bytes)
+		if take > n {
+			take = n
+		}
+		out = append(out, part.bytes[:take]...)
+		n -= take
+		if take == len(part.bytes) {
+			rest = rest[1:]
+			continue
+		}
+		remainder := stashedPayload{
+			bytes:  append([]byte(nil), part.bytes[take:]...),
+			readAt: part.readAt,
+		}
+		newRest := make([]stashedPayload, 0, len(rest))
+		newRest = append(newRest, remainder)
+		newRest = append(newRest, rest[1:]...)
+		rest = newRest
+		break
+	}
+	if len(out) == 0 {
+		return stashedPayload{}, rest
+	}
+	return stashedPayload{bytes: out, readAt: outReadAt}, rest
 }
 
 // nudgeDeadline sets a deadline in the past on the conn if non-nil.

--- a/pkg/agent/proxy/relay/relay_test.go
+++ b/pkg/agent/proxy/relay/relay_test.go
@@ -440,6 +440,13 @@ type countingConn struct {
 func (c *countingConn) Read(p []byte) (int, error)  { c.reads.Add(1); return c.Conn.Read(p) }
 func (c *countingConn) Write(p []byte) (int, error) { c.writes.Add(1); return c.Conn.Write(p) }
 
+type fixedReadAtConn struct {
+	net.Conn
+	readAt time.Time
+}
+
+func (c fixedReadAtConn) LastReadTime() time.Time { return c.readAt }
+
 func TestDirectiveUpgradeTLS_UsesUpgradedConn(t *testing.T) {
 	t.Parallel()
 	var upgraded countingConn
@@ -473,6 +480,112 @@ func TestDirectiveUpgradeTLS_UsesUpgradedConn(t *testing.T) {
 
 	if upgraded.writes.Load() == 0 {
 		t.Fatalf("upgraded conn never Written; pointer swap did not take effect")
+	}
+}
+
+func TestDirectiveUpgradeTLS_PostUpgradeChunkUsesSocketReadTime(t *testing.T) {
+	t.Parallel()
+
+	clientApp, srcPipe := net.Pipe()
+	dstProxy, destSvc := net.Pipe()
+	t.Cleanup(func() {
+		_ = clientApp.Close()
+		_ = srcPipe.Close()
+		_ = dstProxy.Close()
+		_ = destSvc.Close()
+	})
+
+	readAt := time.Unix(1_700_000_000, 987_654_321)
+	srcProxy := fixedReadAtConn{Conn: srcPipe, readAt: readAt}
+	r := New(Config{
+		TLSUpgradeFn: func(_ context.Context, conn net.Conn, _ bool, _ *tls.Config) (net.Conn, error) {
+			return conn, nil
+		},
+	}, srcProxy, dstProxy)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Errorf("Run did not return")
+		}
+	})
+
+	r.Directives() <- directive.UpgradeTLS(nil, &tls.Config{}, "client-side upgrade")
+	select {
+	case ack := <-r.Acks():
+		if !ack.OK {
+			t.Fatalf("TLS upgrade failed: %+v", ack)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("no ack")
+	}
+
+	go func() {
+		_, _ = clientApp.Write([]byte("post-upgrade"))
+	}()
+	_ = readExact(t, destSvc, len("post-upgrade"))
+
+	chunk, err := r.ClientStream().ReadChunk()
+	if err != nil {
+		t.Fatalf("ReadChunk: %v", err)
+	}
+	if got := string(chunk.Bytes); got != "post-upgrade" {
+		t.Fatalf("chunk bytes = %q, want post-upgrade", got)
+	}
+	if !chunk.ReadAt.Equal(readAt) {
+		t.Fatalf("chunk ReadAt = %v, want socket read time %v", chunk.ReadAt, readAt)
+	}
+}
+
+func TestDirectiveUpgradeTLS_PrependsStashedClientBytesThroughPreamble(t *testing.T) {
+	t.Parallel()
+
+	var gotClientHandshake atomic.Value
+	upgraderFn := func(_ context.Context, conn net.Conn, isClient bool, _ *tls.Config) (net.Conn, error) {
+		if isClient {
+			return conn, nil
+		}
+		if err := conn.SetReadDeadline(time.Now().Add(200 * time.Millisecond)); err != nil {
+			return nil, err
+		}
+		defer func() { _ = conn.SetReadDeadline(time.Time{}) }()
+
+		buf := make([]byte, len("CLIENTHELLO"))
+		n, err := conn.Read(buf)
+		if err != nil {
+			return nil, err
+		}
+		gotClientHandshake.Store(string(buf[:n]))
+		return conn, nil
+	}
+
+	h := newHarness(t, Config{TLSUpgradeFn: upgraderFn})
+	stashAt := time.Unix(1_700_000_001, 123)
+	h.r.stashInflightFromPause(fakeconn.FromDest, []byte("S"), stashAt)
+	h.r.stashInflightFromPause(fakeconn.FromClient, []byte("CLIENTHELLO"), stashAt)
+
+	d := directive.UpgradeTLS(nil, &tls.Config{}, "postgres sslrequest")
+	d.TLS.PreambleReadFromDest = 1
+	d.TLS.ProceedOnPreamble = []byte{'S'}
+	h.r.Directives() <- d
+
+	select {
+	case ack := <-h.r.Acks():
+		if !ack.OK {
+			t.Fatalf("TLS upgrade failed: %+v", ack)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("no ack")
+	}
+
+	if got, _ := gotClientHandshake.Load().(string); got != "CLIENTHELLO" {
+		t.Fatalf("client-side upgrader read %q, want stashed ClientHello", got)
 	}
 }
 


### PR DESCRIPTION
## RCA

Postgres V3 record/replay was losing the byte-arrival timestamp once a connection crossed the Postgres SSLRequest/TLS upgrade path. The recorder stamps query mocks from `sess.ClientStream.LastReadTime()` in `captureQueriesV2`; that stream is fed by the relay's `FakeConn` chunks. On the TLS path, the relay used `time.Now()` after reading from the upgraded connection instead of the original socket read time, so query mocks could land outside the HTTP test window used by syncMock mapping. Replay then looked in the expected test cohort and found `candidates: 0` for SQL hashes that were actually recorded under the wrong time bucket.

There was also a related preamble/stash bug: `handleUpgradeTLS` consumed all D2C stash for the one-byte Postgres preamble and dropped stashed C2D bytes before the client-side TLS handshake. If the SUT's ClientHello was already read by the C2D forwarder while the pause barrier was raised, `tls.Server.Handshake` could no longer see it.

## Fix

- Preserve per-chunk read timestamps through relay stashing.
- Split D2C stash for TLS preamble consumption instead of dropping surplus.
- Preserve C2D stashed ClientHello bytes and prepend them into the client-side TLS handshake.
- Wrap TLS handshake conns with read-time tracking so post-upgrade chunks emitted to `FakeConn` use the underlying socket/prefix read timestamp.

## Tests

- `GOWORK=off go test -count=1 ./pkg/agent/proxy/...`
- Added `TestDirectiveUpgradeTLS_PostUpgradeChunkUsesSocketReadTime`.
- Added `TestDirectiveUpgradeTLS_PrependsStashedClientBytesThroughPreamble`.
- Added `TestPrependingConn_LastReadTimeUsesPrefixReadAt`.

Local pgtype integration replay was also attempted with this binary; the local harness hit a generic-mock mismatch before reaching the target PostgresV3 dispatcher failure, so CI on the integrations branch remains the authoritative end-to-end proof.
