### PR TITLE
fix(grpc): stamp responses after client write

### DIFF
--- a/pkg/agent/proxy/incoming/gRPC/record.go
+++ b/pkg/agent/proxy/incoming/gRPC/record.go
@@ -59,13 +59,13 @@ func RecordIncoming(ctx context.Context, logger *zap.Logger, clientConn, destCon
 	// Forward client → dest, tee copies to channel
 	go func() {
 		defer close(clientFrameCh)
-		forwardAndTee(clientConn, destConn, clientFrameCh, logger, "client→app")
+		forwardAndTee(clientConn, destConn, clientFrameCh, logger, "client→app", false)
 	}()
 
 	// Forward dest → client, tee copies to channel
 	go func() {
 		defer close(destFrameCh)
-		forwardAndTee(destConn, clientConn, destFrameCh, logger, "app→client")
+		forwardAndTee(destConn, clientConn, destFrameCh, logger, "app→client", true)
 	}()
 
 	// Single emitter goroutine to avoid duplicate test case emission.
@@ -123,7 +123,7 @@ type frameChunk struct {
 	timestamp time.Time
 }
 
-func forwardAndTee(src, dst net.Conn, ch chan<- frameChunk, logger *zap.Logger, direction string) {
+func forwardAndTee(src, dst net.Conn, ch chan<- frameChunk, logger *zap.Logger, direction string, stampAfterWrite bool) {
 	buf := make([]byte, 32*1024)
 	teeActive := !memoryguard.IsRecordingPaused()
 	for {
@@ -135,6 +135,10 @@ func forwardAndTee(src, dst net.Conn, ch chan<- frameChunk, logger *zap.Logger, 
 					zap.String("direction", direction), zap.Error(wErr))
 				return
 			}
+			timestamp := readAt
+			if stampAfterWrite {
+				timestamp = time.Now()
+			}
 			if teeActive {
 				if memoryguard.IsRecordingPaused() {
 					teeActive = false
@@ -143,7 +147,7 @@ func forwardAndTee(src, dst net.Conn, ch chan<- frameChunk, logger *zap.Logger, 
 					copy(data, buf[:n])
 					ch <- frameChunk{
 						data:      data,
-						timestamp: readAt,
+						timestamp: timestamp,
 					} // blocking send — preserves stream integrity
 				}
 			}

--- a/pkg/agent/proxy/incoming/gRPC/record_test.go
+++ b/pkg/agent/proxy/incoming/gRPC/record_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"io"
+	"net"
 	"testing"
 	"time"
 
@@ -64,6 +66,50 @@ func TestParseFramesFromChanUsesChunkTimestamps(t *testing.T) {
 	require.Len(t, streams, 1)
 	assert.Equal(t, requestAt, streams[0].GRPCReq.Timestamp)
 	assert.Equal(t, responseAt, streams[0].GRPCResp.Timestamp)
+}
+
+func TestForwardAndTeeStampsResponsesAfterClientWrite(t *testing.T) {
+	logger := zap.NewNop()
+	srcRead, srcWrite := net.Pipe()
+	dstRead, dstWrite := net.Pipe()
+	for _, c := range []net.Conn{srcRead, srcWrite, dstRead, dstWrite} {
+		require.NoError(t, c.SetDeadline(time.Now().Add(5*time.Second)))
+		defer c.Close()
+	}
+
+	ch := make(chan frameChunk, 1)
+	go forwardAndTee(srcRead, dstWrite, ch, logger, "app→client", true)
+
+	payload := []byte("response-frame")
+	writeDone := make(chan error, 1)
+	go func() {
+		_, err := srcWrite.Write(payload)
+		writeDone <- err
+	}()
+
+	select {
+	case err := <-writeDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("source write did not complete")
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	cutoff := time.Now()
+
+	buf := make([]byte, len(payload))
+	_, err := io.ReadFull(dstRead, buf)
+	require.NoError(t, err)
+	assert.Equal(t, payload, buf)
+
+	select {
+	case chunk := <-ch:
+		assert.Equal(t, payload, chunk.data)
+		assert.False(t, chunk.timestamp.Before(cutoff),
+			"response timestamp should be captured after the proxy writes to the client")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for teed frame chunk")
+	}
 }
 
 func headersFrameBytes(t *testing.T, streamID uint32, fields []hpack.HeaderField, endStream bool) []byte {


### PR DESCRIPTION
## Summary
- stamp gRPC response frames after the proxy writes bytes back to the client
- keep request frames stamped at client socket read time
- add a regression test that blocks the client-side write to prove response timestamps are not taken at upstream read time

## Root cause
The earlier strict-window fix moved request timestamps to the socket-read boundary, but response frames still reused the upstream-read timestamp. For strict mock-window containment, a gRPC test case window should start when the proxy receives the request from the client and end after the response bytes are written back to that client.

## Validation
- `go test ./pkg ./pkg/agent/proxy/incoming/gRPC`
