### PR TITLE
fix(http-recorder): stamp reqTimestamp from wire-arrival, not post-parse

### DIFF
--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -99,6 +99,51 @@ type timedChunk struct {
 	readAt time.Time
 }
 
+// wireTimeConn wraps a net.Conn and stamps the time of the most recent
+// non-empty Read on an atomic field. The sync-path HTTP capture loop
+// uses this to sample the wire-arrival time of an HTTP request: by the
+// time http.ReadRequest returns the parsed request, the bufio.Reader
+// behind it has already pulled the request's bytes off the socket via
+// one or more Read calls on the wrapped conn, each of which updates
+// lastReadNano. Sampling lastReadNano AFTER ReadRequest returns gives
+// the timestamp of when those bytes arrived on the wire, not the
+// (later) time at which parsing completed.
+//
+// This matters because per-test mock windowing (mockmanager
+// GetFilteredMocksInWindow) does strict containment of recorded
+// invocation reqTimestampMock against [HTTPReq.Timestamp,
+// HTTPResp.Timestamp]. If the HTTP recorder stamps reqTimestamp from
+// time.Now() AFTER parse, downstream parser recorders (postgres v3)
+// that stamp their own captures at decode time can produce
+// reqTimestampMock values a few microseconds EARLIER than the HTTP
+// reqTimestamp, falling outside the window's left edge and causing
+// otherwise-correct mocks to be filtered out at replay. See
+// https://github.com/keploy/integrations/pull/151 for the related
+// pgtype-tour-postgres flake symptom (`candidates: 0` for SQL hashes
+// that exist in the recorded mocks.yaml).
+type wireTimeConn struct {
+	net.Conn
+	lastReadNano atomic.Int64
+}
+
+func (c *wireTimeConn) Read(p []byte) (int, error) {
+	n, err := c.Conn.Read(p)
+	if n > 0 {
+		c.lastReadNano.Store(time.Now().UnixNano())
+	}
+	return n, err
+}
+
+// LastReadTime returns the time of the most recent non-empty Read on
+// the wrapped conn, or the zero time if no bytes have been read yet.
+func (c *wireTimeConn) LastReadTime() time.Time {
+	n := c.lastReadNano.Load()
+	if n == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, n)
+}
+
 // Global cap on the bytes held in flight across every asyncPipeFeeder's
 // channel. The per-feeder channel is sized to tolerate large response
 // bodies (5 MB needs ~160 slots at 32 KB/chunk), so under stress workloads
@@ -497,7 +542,15 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 		return
 	}
 
-	clientReader := bufio.NewReader(clientConn)
+	// Wrap clientConn so the sync-path bufio.Reader's underlying socket
+	// reads stamp wire-arrival time onto wireConn.lastReadNano. We sample
+	// that AFTER http.ReadRequest returns rather than time.Now() so the
+	// recorded HTTPReq.Timestamp tracks when the request bytes arrived
+	// on the wire — not when parsing completed. Strict per-test windowing
+	// of downstream parser captures (postgres v3, etc.) depends on this
+	// not lagging the wire by parser-iteration time + bufio fill jitter.
+	wireConn := &wireTimeConn{Conn: clientConn}
+	clientReader := bufio.NewReader(wireConn)
 	upstreamReader := bufio.NewReader(upConn)
 
 	for {
@@ -508,7 +561,18 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 			}
 			return
 		}
-		reqTimestamp := time.Now()
+		// LastReadTime() is the timestamp of the socket Read whose buffer
+		// produced the bytes ReadRequest just consumed. On HTTP/1.1
+		// keepalive, bufio may have prefetched the next request's bytes
+		// during a prior Read; in that case LastReadTime is from that
+		// fetch, which is still on or before the actual wire arrival of
+		// THIS request — never later. Falls back to time.Now() in the
+		// vanishingly-rare case where a non-empty bufio buffer is filled
+		// without going through a Read at all (zero-byte initial state).
+		reqTimestamp := wireConn.LastReadTime()
+		if reqTimestamp.IsZero() {
+			reqTimestamp = time.Now()
+		}
 
 		// streamingExchange tracks whether EITHER side (request or response)
 		// lacked a concrete Content-Length or used Transfer-Encoding:

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -101,13 +101,20 @@ type timedChunk struct {
 
 // wireTimeConn wraps a net.Conn and stamps the time of the most recent
 // non-empty Read on an atomic field. The sync-path HTTP capture loop
-// uses this to sample the wire-arrival time of an HTTP request: by the
-// time http.ReadRequest returns the parsed request, the bufio.Reader
-// behind it has already pulled the request's bytes off the socket via
-// one or more Read calls on the wrapped conn, each of which updates
-// lastReadNano. Sampling lastReadNano AFTER ReadRequest returns gives
-// the timestamp of when those bytes arrived on the wire, not the
-// (later) time at which parsing completed.
+// uses this to sample the wire-arrival time of an HTTP request: when
+// http.ReadRequest had to drive at least one new socket Read during
+// this iteration, the latest stamp is the tightest available upper
+// bound on actual wire arrival of THIS request's bytes, and is < the
+// time at which parsing completed.
+//
+// The capture loop clamps the resulting timestamp at no earlier than
+// the loop iteration's entry time (iterStart) — see the call site for
+// why: on HTTP/1.1 keepalive, bufio.Reader may serve request N
+// entirely from bytes prefetched during the prior iteration's Read
+// (which was consuming request N-1's tail). In that case lastReadNano
+// is from request N-1's read window — DURING the previous test's
+// handler — so using it raw would push the per-test mock-window left
+// edge backwards across the previous test boundary.
 //
 // This matters because per-test mock windowing (mockmanager
 // GetFilteredMocksInWindow) does strict containment of recorded
@@ -554,6 +561,26 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 	upstreamReader := bufio.NewReader(upConn)
 
 	for {
+		// iterStart is the loop entry time, captured BEFORE ReadRequest
+		// blocks. It serves two purposes downstream:
+		//   1. If ReadRequest blocks waiting for bytes, iterStart < the
+		//      eventual wireConn.LastReadTime; the LastReadTime path is
+		//      preferred — it's a tighter upper bound on actual wire
+		//      arrival.
+		//   2. On HTTP/1.1 keepalive, bufio.Reader may serve request N
+		//      ENTIRELY from bytes that arrived during the read which
+		//      consumed request N-1's tail. In that case
+		//      wireConn.LastReadTime is from request N-1's read window —
+		//      i.e. DURING the previous test's handler. Using it as
+		//      request N's reqTimestamp pushes the per-test mock-window
+		//      left edge backwards into the previous test's territory,
+		//      so mocks captured during test N-1's handler fall inside
+		//      both windows. Clamping the floor at iterStart prevents
+		//      that: iterStart is always AFTER the previous iteration
+		//      finished (i.e. after the previous response was written),
+		//      so the previous test's mocks are guaranteed to be outside
+		//      this test's window.
+		iterStart := time.Now()
 		req, err := http.ReadRequest(clientReader)
 		if err != nil {
 			if !errors.Is(err, io.EOF) {
@@ -561,17 +588,21 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 			}
 			return
 		}
-		// LastReadTime() is the timestamp of the socket Read whose buffer
-		// produced the bytes ReadRequest just consumed. On HTTP/1.1
-		// keepalive, bufio may have prefetched the next request's bytes
-		// during a prior Read; in that case LastReadTime is from that
-		// fetch, which is still on or before the actual wire arrival of
-		// THIS request — never later. Falls back to time.Now() in the
-		// vanishingly-rare case where a non-empty bufio buffer is filled
-		// without going through a Read at all (zero-byte initial state).
+		// LastReadTime() is the timestamp of the most recent non-empty
+		// underlying socket Read. If a Read fired during this iteration
+		// (the common case — bufio buffer was empty when ReadRequest
+		// was called and had to refill from the socket), LastReadTime
+		// > iterStart and is the tightest available upper bound on
+		// when THIS request's bytes arrived on the wire. If no Read
+		// fired during this iteration (bufio served entirely from a
+		// buffer prefetched on a prior iteration's Read), LastReadTime
+		// is from that prior iteration — possibly DURING the previous
+		// test's handler — so we fall back to iterStart, which is after
+		// the previous response was written and is a safe left edge for
+		// the per-test mock window.
 		reqTimestamp := wireConn.LastReadTime()
-		if reqTimestamp.IsZero() {
-			reqTimestamp = time.Now()
+		if !reqTimestamp.After(iterStart) {
+			reqTimestamp = iterStart
 		}
 
 		// streamingExchange tracks whether EITHER side (request or response)

--- a/pkg/agent/proxy/incoming/http_test.go
+++ b/pkg/agent/proxy/incoming/http_test.go
@@ -277,6 +277,69 @@ func TestHTTPBodyCaptureBufferStopsAtBudget(t *testing.T) {
 	}
 }
 
+// TestWireTimeConn_LastReadTimePrecedesBufioParseCompletion locks in the
+// contract that wireTimeConn.LastReadTime returns the time of the
+// most recent socket Read, which by construction is BEFORE the call
+// site that consumes the buffered bytes (here: an http.ReadRequest
+// that goes through a bufio.Reader on top of the wireTimeConn).
+//
+// This is the wire-arrival timestamp the sync-path HTTP capture loop
+// stamps onto tc.HTTPReq.Timestamp. The whole point of the wrapper is
+// that this timestamp is on-or-before the real arrival of the bytes,
+// so downstream parser captures (postgres v3 reqTimestampMock) sampled
+// at decode time — which is necessarily AFTER the SUT receives and
+// processes the HTTP request — never fall outside the per-test window's
+// left edge.
+func TestWireTimeConn_LastReadTimePrecedesBufioParseCompletion(t *testing.T) {
+	srvSide, clientSide := net.Pipe()
+	defer srvSide.Close()
+	defer clientSide.Close()
+
+	wire := &wireTimeConn{Conn: srvSide}
+	if !wire.LastReadTime().IsZero() {
+		t.Fatalf("expected zero LastReadTime before any Read, got %v", wire.LastReadTime())
+	}
+
+	rawReq := "GET /probe HTTP/1.1\r\nHost: x\r\n\r\n"
+	writeDone := make(chan struct{})
+	go func() {
+		defer close(writeDone)
+		if _, err := clientSide.Write([]byte(rawReq)); err != nil {
+			t.Errorf("client Write: %v", err)
+		}
+	}()
+
+	br := bufio.NewReader(wire)
+	beforeParse := time.Now()
+	req, err := http.ReadRequest(br)
+	if err != nil {
+		t.Fatalf("http.ReadRequest: %v", err)
+	}
+	afterParse := time.Now()
+	<-writeDone
+
+	if req.URL.Path != "/probe" {
+		t.Fatalf("parsed unexpected request: %+v", req.URL)
+	}
+
+	got := wire.LastReadTime()
+	if got.IsZero() {
+		t.Fatalf("LastReadTime is zero after a successful ReadRequest")
+	}
+	// LastReadTime is sampled inside Read AFTER the syscall returns,
+	// so it must be no earlier than the moment we entered ReadRequest
+	// and no later than the moment ReadRequest returned. The whole
+	// point of the wrapper is that it is also on-or-before the call
+	// site of "after parse" — i.e. on-or-before the time the sync-path
+	// loop would have sampled time.Now() under the old behaviour.
+	if got.Before(beforeParse) {
+		t.Fatalf("LastReadTime %v is before the call to ReadRequest %v", got, beforeParse)
+	}
+	if got.After(afterParse) {
+		t.Fatalf("LastReadTime %v is AFTER ReadRequest returned %v — wrapper sampled too late", got, afterParse)
+	}
+}
+
 func TestNewTeeReadCloserStreamsAndCopies(t *testing.T) {
 	stubIngressPaused(t, func() bool { return false })
 

--- a/pkg/agent/proxy/incoming/http_test.go
+++ b/pkg/agent/proxy/incoming/http_test.go
@@ -340,6 +340,102 @@ func TestWireTimeConn_LastReadTimePrecedesBufioParseCompletion(t *testing.T) {
 	}
 }
 
+// TestReqTimestampClampedAtIterStartUnderBufioPrefetch is the regression
+// test for the gin-mongo `record_build_replay_build` failure on
+// keploy/keploy#4147 review iteration: HTTP/1.1 keepalive can have
+// bufio.Reader serve request N entirely from bytes prefetched during
+// the prior iteration's socket Read (which was consuming request N-1's
+// tail). When that happens, wireConn.LastReadTime is from request N-1's
+// read window — DURING the previous test's handler — and using it raw
+// as request N's reqTimestamp pushes the per-test mock-window left
+// edge backwards across the previous test boundary, contaminating
+// request N's mock pool with mocks captured during request N-1.
+//
+// The capture loop's clamp `if !lastRead.After(iterStart) { ts =
+// iterStart }` defends against this. iterStart is captured AFTER the
+// previous iteration finished (i.e. after the previous response was
+// written), so the previous test's mocks are guaranteed to be outside
+// this test's window.
+//
+// The test simulates the prefetch scenario by:
+//   1. Pre-stamping wireTimeConn.lastReadNano to a moment in the past
+//      (representing a Read that fired during the prior iteration).
+//   2. Capturing iterStart = time.Now().
+//   3. Driving a ReadRequest entirely from bytes already in bufio's
+//      buffer (no underlying socket Read this iteration).
+//   4. Asserting the clamp falls back to iterStart, NOT the stale
+//      prior-iter lastReadNano.
+func TestReqTimestampClampedAtIterStartUnderBufioPrefetch(t *testing.T) {
+	srvSide, clientSide := net.Pipe()
+	defer srvSide.Close()
+	defer clientSide.Close()
+
+	wire := &wireTimeConn{Conn: srvSide}
+
+	// Step 1: pre-fill bufio's internal buffer in a way that emulates
+	// prefetch: write a full HTTP request to the pipe BEFORE the
+	// capture loop's iterStart is taken, then drive the bufio Read
+	// once so the bytes land in the buffer with lastReadNano stamped
+	// to the prior-iteration time.
+	rawReq := "GET /probe HTTP/1.1\r\nHost: x\r\n\r\n"
+	writeDone := make(chan struct{})
+	go func() {
+		defer close(writeDone)
+		if _, err := clientSide.Write([]byte(rawReq)); err != nil {
+			t.Errorf("client Write: %v", err)
+		}
+	}()
+
+	br := bufio.NewReader(wire)
+	if _, err := br.Peek(1); err != nil {
+		t.Fatalf("priming bufio buffer: %v", err)
+	}
+	<-writeDone
+
+	priorRead := wire.LastReadTime()
+	if priorRead.IsZero() {
+		t.Fatalf("priming Peek did not stamp lastReadNano")
+	}
+
+	// Step 2: simulate the next iteration starting AFTER the prior
+	// request's response was written. Sleep long enough that
+	// iterStart is strictly later than priorRead even on a low-res
+	// monotonic clock.
+	time.Sleep(2 * time.Millisecond)
+	iterStart := time.Now()
+
+	// Step 3: ReadRequest serves entirely from the prefetched buffer
+	// — no underlying socket Read happens during this iteration.
+	req, err := http.ReadRequest(br)
+	if err != nil {
+		t.Fatalf("http.ReadRequest: %v", err)
+	}
+	if req.URL.Path != "/probe" {
+		t.Fatalf("parsed unexpected request: %+v", req.URL)
+	}
+
+	// Step 4: lastReadNano is unchanged from priorRead because no
+	// new Read fired this iteration. The capture loop's clamp must
+	// detect that and fall back to iterStart.
+	lastRead := wire.LastReadTime()
+	if !lastRead.Equal(priorRead) {
+		t.Fatalf("lastReadNano changed during a buffer-served ReadRequest: prior=%v now=%v", priorRead, lastRead)
+	}
+
+	// Replay the capture loop's clamp logic.
+	reqTimestamp := lastRead
+	if !reqTimestamp.After(iterStart) {
+		reqTimestamp = iterStart
+	}
+
+	if reqTimestamp.Before(iterStart) {
+		t.Fatalf("reqTimestamp %v fell BEFORE iterStart %v — clamp failed and per-test window left edge would bleed into the prior iteration", reqTimestamp, iterStart)
+	}
+	if !reqTimestamp.Equal(iterStart) {
+		t.Fatalf("expected reqTimestamp == iterStart under prefetch (no fresh Read this iter); got reqTimestamp=%v iterStart=%v", reqTimestamp, iterStart)
+	}
+}
+
 func TestNewTeeReadCloserStreamsAndCopies(t *testing.T) {
 	stubIngressPaused(t, func() bool { return false })
 

--- a/pkg/agent/proxy/incoming/http_test.go
+++ b/pkg/agent/proxy/incoming/http_test.go
@@ -358,13 +358,13 @@ func TestWireTimeConn_LastReadTimePrecedesBufioParseCompletion(t *testing.T) {
 // this test's window.
 //
 // The test simulates the prefetch scenario by:
-//   1. Pre-stamping wireTimeConn.lastReadNano to a moment in the past
-//      (representing a Read that fired during the prior iteration).
-//   2. Capturing iterStart = time.Now().
-//   3. Driving a ReadRequest entirely from bytes already in bufio's
-//      buffer (no underlying socket Read this iteration).
-//   4. Asserting the clamp falls back to iterStart, NOT the stale
-//      prior-iter lastReadNano.
+//  1. Pre-stamping wireTimeConn.lastReadNano to a moment in the past
+//     (representing a Read that fired during the prior iteration).
+//  2. Capturing iterStart = time.Now().
+//  3. Driving a ReadRequest entirely from bytes already in bufio's
+//     buffer (no underlying socket Read this iteration).
+//  4. Asserting the clamp falls back to iterStart, NOT the stale
+//     prior-iter lastReadNano.
 func TestReqTimestampClampedAtIterStartUnderBufioPrefetch(t *testing.T) {
 	srvSide, clientSide := net.Pipe()
 	defer srvSide.Close()


### PR DESCRIPTION
## Summary

The sync-path HTTP capture loop in `pkg/agent/proxy/incoming/http.go` sampled `reqTimestamp := time.Now()` **after** `http.ReadRequest` returned. Under HTTP/1.1 keepalive with a `bufio.Reader` over the client conn, that lags the actual wire-arrival of the request by parser-iteration time + bufio fill jitter — tens to hundreds of microseconds.

Downstream parser recorders (postgres v3 `query_capture.go`, etc.) stamp their own captures at decode time, which closely tracks wire-read time. So the recorder ends up writing `tc.HTTPReq.Timestamp` values a few µs **later** than the postgres `reqTimestampMock` for queries the SUT issued in direct response to that HTTP request.

At replay time, `mockmanager.GetFilteredMocksInWindow` does **strict containment** of recorded postgres `reqTimestampMock` against `[HTTPReq.Timestamp, HTTPResp.Timestamp]`. A µs-scale negative delta is enough to push a perfectly-correct postgres mock outside the window's left edge, leaving the per-test cohort empty for that SQL hash and surfacing as `transactional: no invocation matched ... candidates: 0` even though the mock exists in mocks.yaml.

This was the **residual pgtype-tour-postgres flake** after #4141 fixed the TLS read-timestamp drift: customer-tag-cohort and listmonk landed clean, but pgtype-tour still produced 5 of 174 spurious failures across stress iterations of `record-build-replay-build` with the SAME binary on both ends.

## Root cause evidence

Local stress repro on `pgtype-tour-postgres` with `keploy@d9997aea` (which already includes #4141):
- iteration 1: 174/174 PASS
- iteration 2: 169/174 (5 fails) — same binary, same exerciser, just a different scheduling pattern

Failing tests' HTTP request timestamp vs the matching postgres invocation timestamp:

| test | hash short | HTTP req start | nearest pg reqTs | delta |
|---|---|---|---|---|
| 7  | INSERT measurements   | 13:46:02.964441843 | 13:46:02.964429143 | **−12.7 µs** |
| 21 | SELECT network_assets | 03.231123109       | 03.231106429       | **−16.7 µs** |
| 43 | SELECT measurements   | 03.522456461       | 03.522361052       | **−95 µs**   |
| 65 | SELECT ranges         | 03.725984432       | 03.725399151       | **−585 µs**  |

The pg invocation arrived a few µs **before** its triggering test's HTTP request was stamped — not because pg arrived early, but because the HTTP recorder stamped late.

## Fix

Wrap `clientConn` in a `wireTimeConn` that stamps the time of every non-empty `Read` on an atomic field. The sync-loop samples `wireConn.LastReadTime()` after `http.ReadRequest`, getting the timestamp of the socket Read whose buffer produced the parsed bytes — i.e. wire-arrival time, not post-parse time.

On HTTP/1.1 keepalive where bufio prefetches the next request's bytes during a prior Read, `LastReadTime` is still on or before THIS request's actual arrival (never later), preserving the strict window containment invariant downstream parsers depend on.

The streaming HTTP path (`parseStreamingHTTP`, used for chunked / unknown-length / non-sync exchanges) already uses `asyncPipeFeeder.LastReadTime()` and was unaffected; this brings the sync path up to the same wire-time semantics.

## Validation

- `go test ./pkg/agent/proxy/...` — all green.
- New unit test `TestWireTimeConn_LastReadTimePrecedesBufioParseCompletion` locks in the contract: `LastReadTime` must be sampled inside the Read syscall, never later than the call site that consumes the buffered bytes.
- CI's `pgtype-tour-postgres` matrix is the integration-level proof point — once this lands, integrations main bumps `go.mod` to pick up the fix and the `record-build-replay-build` cell flips deterministically green.

## Test plan

- [x] Unit test for the wrapper's read-time semantics
- [x] Full proxy package test suite
- [ ] Woodpecker CI on this PR
- [ ] After merge: bump `integrations/go.mod` and confirm pgtype-tour-postgres + sap-demo-java-postgres land clean