### PR TITLE
fix(proxy): always skip upstream cert verification on dest-side TLS

### DIFF
--- a/pkg/agent/proxy/proxy_test.go
+++ b/pkg/agent/proxy/proxy_test.go
@@ -12,6 +12,8 @@ import (
 	"net"
 	"testing"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 // newTLSTestServer spins up a TLS listener with a self-signed cert. The
@@ -272,5 +274,55 @@ func TestNextProtosSubset(t *testing.T) {
 				t.Fatalf("nextProtosSubset(%v, %v) = %v; want %v", tc.want, tc.offered, got, tc.expected)
 			}
 		})
+	}
+}
+
+// TestNewProxyTLSUpgradeFn_DestSide_AlwaysInsecureSkipVerify locks in the
+// MITM-correct dest-side posture: when the upgrade fn is invoked with
+// isClient=true (keploy dialing the real upstream), it MUST handshake
+// without verifying the upstream cert, regardless of what
+// InsecureSkipVerify the caller-supplied cfg held. The supplied cfg
+// must NOT be mutated — only the per-dial clone gets the flag flipped.
+//
+// This is a regression test for the dest-side passthrough drop reported
+// as `dest TLS handshake failed: x509: certificate is valid for
+// 127.0.0.1, not 10.224.0.152` against in-cluster K8s services whose
+// upstream cert SAN doesn't match the ClusterIP keploy sees.
+func TestNewProxyTLSUpgradeFn_DestSide_AlwaysInsecureSkipVerify(t *testing.T) {
+	// Self-signed cert with CN "test.local"; we'll dial it asking for
+	// a different ServerName to force the strict-verify path to fail
+	// if the fix is missing.
+	ln, _ := newTLSTestServer(t, 0, []string{"h2", "http/1.1"}, nil)
+	defer ln.Close()
+
+	upgrade := newProxyTLSUpgradeFn(zap.NewNop())
+
+	rawConn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial upstream: %v", err)
+	}
+	defer rawConn.Close()
+
+	// Strict cfg: deliberately wrong ServerName, no InsecureSkipVerify.
+	// Without the fix, tls.Client(...).Handshake would fail with an
+	// x509 hostname error.
+	caller := &tls.Config{
+		ServerName: "wrong.example.invalid",
+		NextProtos: []string{"h2", "http/1.1"},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tlsConn, err := upgrade(ctx, rawConn, true, caller)
+	if err != nil {
+		t.Fatalf("dest-side upgrade should ignore upstream cert validity, got: %v", err)
+	}
+	defer tlsConn.Close()
+
+	// The caller's cfg must remain pristine — clone-on-dial, never mutate
+	// what the parser handed us.
+	if caller.InsecureSkipVerify {
+		t.Fatalf("caller cfg.InsecureSkipVerify was mutated to true; expected the upgrade fn to clone before flipping the flag")
 	}
 }

--- a/pkg/agent/proxy/proxy_v2.go
+++ b/pkg/agent/proxy/proxy_v2.go
@@ -243,6 +243,8 @@ func (p *Proxy) recordViaSupervisor(
 //   - For isClient=true (upgrading the destination side — keploy
 //     acts as TLS client to the real server), dials TLS over the
 //     existing conn using tls.Client and performs the handshake.
+//     Upstream cert verification is ALWAYS skipped here — see the
+//     dest-side InsecureSkipVerify rationale on the cfg clone below.
 //   - For isClient=false (upgrading the client side — keploy acts
 //     as TLS server presenting the MITM cert), hands off to
 //     pTls.HandleTLSConnection which already implements the server-
@@ -258,7 +260,41 @@ func newProxyTLSUpgradeFn(logger *zap.Logger) relay.TLSUpgradeFn {
 			return conn, nil
 		}
 		if isClient {
-			tlsConn := tls.Client(conn, cfg)
+			// Upstream identity verification is keploy's responsibility
+			// to NOT do. Keploy is a transparent MITM record/replay
+			// proxy: the real client (pgx, asyncpg, libpq, JDBC, mongo
+			// driver, etc.) already made its trust decision against
+			// keploy's minted cert when it dialed in, and the upstream
+			// it points at in record mode is whatever the application
+			// would have dialed itself — typically a self-signed dev /
+			// CI / staging Postgres or Mongo, or a Kubernetes service
+			// reachable only by ClusterIP. Either way the upstream
+			// cert's SAN/CN often does not match the IP literal keploy
+			// sees in `Destination Address` (e.g. cert valid for
+			// 127.0.0.1, dial target 10.224.0.152), and Go's default
+			// hostname/IP verification would surface that as
+			// `dest TLS handshake failed: x509: certificate is valid
+			// for X, not Y` and trip the parser supervisor's
+			// passthrough fallback — silently dropping all recording
+			// for that connection.
+			//
+			// Parsers that build their DestTLSConfig already set
+			// InsecureSkipVerify on it (see e.g.
+			// integrations/pkg/postgres/v3/recorder.buildDestTLSConfigV2,
+			// keploy/pkg/agent/proxy/integrations/mysql/recorder.buildDestTLSConfigV2)
+			// — but if a parser ever forgets, or if some future call
+			// site lands here with a strict config, we still need the
+			// MITM-correct posture. So clone the parser's cfg, force
+			// InsecureSkipVerify=true on the clone, and dial against
+			// that. ServerName / RootCAs / NextProtos / ClientCert
+			// material on the parser-supplied cfg is preserved
+			// (shallow clone via tls.Config.Clone), so SNI for
+			// vhosted PG-as-a-service providers (RDS, Cloud SQL, Neon)
+			// and any upstream-mTLS material a parser might wire in
+			// still reaches the wire.
+			dialCfg := cfg.Clone()
+			dialCfg.InsecureSkipVerify = true //#nosec G402 -- MITM record-time proxy: keploy intentionally never validates the upstream cert. See the docstring above.
+			tlsConn := tls.Client(conn, dialCfg)
 			if err := tlsConn.HandshakeContext(ctx); err != nil {
 				return nil, fmt.Errorf("dest TLS handshake failed: %w", err)
 			}


### PR DESCRIPTION
## Summary

- Clones the parser-supplied `tls.Config` and forces `InsecureSkipVerify=true` on the clone before dialing the real upstream from `newProxyTLSUpgradeFn` (`pkg/agent/proxy/proxy_v2.go`).
- The caller's cfg is preserved — parsers that already set the flag (e.g. `integrations/pkg/postgres/v3/recorder.buildDestTLSConfigV2`, `keploy/pkg/agent/proxy/integrations/mysql/recorder.buildDestTLSConfigV2`) continue to work; parsers that forget — or any future call site that lands here with a strict cfg — also get the MITM-correct posture.
- `ServerName` / `RootCAs` / `NextProtos` / `ClientCert` material on the parser-supplied cfg is preserved via `Clone`, so SNI for vhosted PG-as-a-service providers (RDS, Cloud SQL, Neon) and any upstream-mTLS material a parser might wire in still reaches the wire.

## Reported error

```
dest TLS handshake failed: x509: certificate is valid for 127.0.0.1, not 10.224.0.152
```

This was hitting in-cluster Kubernetes targets where the upstream cert's SAN does not match the ClusterIP keploy resolves. Go's default verification surfaces the IP/SAN mismatch and trips the parser supervisor's passthrough fallback — silently dropping recording for that connection.

## Why this is the right layer

keploy is a transparent record/replay MITM:

1. The real client (pgx, asyncpg, libpq, JDBC, mongo driver, etc.) already made its trust decision against keploy's minted cert when it dialed *in*.
2. The upstream keploy dials *out* to is whatever the app would have dialed itself — typically a self-signed dev / CI / staging Postgres or Mongo, or a Kubernetes service reachable only by ClusterIP.
3. The upstream cert's SAN/CN routinely does not match the IP literal in `Destination Address`.

Validating identity at this hop adds zero security (we have already replaced the client's trust anchor with our own CA) and reliably breaks recording in real environments. Parsers were already opting out individually; this PR enforces the same posture at the keploy proxy core as defense-in-depth.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/agent/proxy/...` (all green)
- [x] New regression test `TestNewProxyTLSUpgradeFn_DestSide_AlwaysInsecureSkipVerify` locks the contract:
  - Strict caller cfg with deliberately wrong `ServerName` and no `InsecureSkipVerify` must still handshake successfully against a self-signed test server.
  - Caller's `cfg.InsecureSkipVerify` must remain `false` after the dial (clone-on-dial, never mutate the parser's input).
- [ ] CI pipelines on this PR