### PR TITLE
fix(proxy): resolve merge-conflict residue breaking the build

### DIFF
--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -236,25 +236,6 @@ func isNetworkClosedErr(err error) bool {
 // port 3306 through the MySQL integration.
 const defaultMySQLPort uint32 = 3306
 
-func New(logger *zap.Logger, info agent.DestInfo, opts *config.Config) *Proxy {
-	proxy := &Proxy{
-		logger:            logger,
-		Port:              opts.ProxyPort,
-		DNSPort:           opts.DNSPort, // default: 26789
-		synchronous:       opts.Agent.Synchronous,
-		IP4:               "127.0.0.1", // default: "127.0.0.1" <-> (2130706433)
-		IP6:               "::1",       //default: "::1" <-> ([4]uint32{0000, 0000, 0000, 0001})
-		ipMutex:           &sync.Mutex{},
-		connMutex:         &sync.Mutex{},
-		DestInfo:          info,
-		clientClose:       make(chan bool, 1),
-		Integrations:      make(map[integrations.IntegrationType]integrations.Integrations),
-		GlobalPassthrough: opts.Agent.GlobalPassthrough,
-		errChannel:        make(chan error, 100), // buffered channel to prevent blocking
-		IsDocker:          opts.Agent.IsDocker,
-		dnsCache:          newDNSCache(),
-		recordedDNSMocks:  newRecordedDNSMocksCache(),
-		mysqlPorts:        buildMySQLPortSet(opts.MySQLPorts),
 // isPostgresSSLRequest reports whether the first 8 bytes of a connection
 // are a Postgres SSLRequest packet:
 //
@@ -509,6 +490,7 @@ func New(logger *zap.Logger, info agent.DestInfo, opts *config.Config) *Proxy {
 		caJavaHome:         opts.Agent.CAJavaHome,
 		dnsCache:           newDNSCache(),
 		recordedDNSMocks:   newRecordedDNSMocksCache(),
+		mysqlPorts:         buildMySQLPortSet(opts.MySQLPorts),
 		// dnsForwardTimeout is the per-forward deadline for upstream DNS
 		// exchanges. 2 s is long enough to absorb a single UDP retransmit
 		// against CoreDNS (~500 ms default) while keeping app-side lookup


### PR DESCRIPTION
## Summary

The previous \`Merge branch 'main' into port-4000\` merge commit (\`985407ef\`) left a broken merge resolution in \`pkg/agent/proxy/proxy.go\`:

- Two conflicting \`func New\` definitions ended up in the file.
- The first one had its \`Proxy{...}\` composite literal left **unclosed** — the Postgres SSL helpers (\`isPostgresSSLRequest\`, \`isPostgresSSLRequestPrefix\`, \`dialPostgresSSLUpstream\`) were pasted into the middle of the struct literal instead of as top-level functions.
- This produced the syntax errors that broke the Flipkart release build:

\`\`\`
pkg/agent/proxy/proxy.go:267:6: syntax error: unexpected name isPostgresSSLRequest, expected (
pkg/agent/proxy/proxy.go:273:2: syntax error: unexpected newline in composite literal; possibly missing comma or }
pkg/agent/proxy/proxy.go:283:36: syntax error: unexpected ] at end of statement
\`\`\`

(Reference: failing pipeline https://ci.keploy.com/repos/1/pipeline/3290 — \`release-flipkart > release\` step.)

## Fix

- Drop the broken first \`New\` so the Postgres SSL helpers become top-level again.
- Fold \`mysqlPorts: buildMySQLPortSet(opts.MySQLPorts)\` into the surviving \`New\` so the TiDB / configurable-MySQL-ports feature from \`port-4000\` is preserved alongside main's new \`EnableIPv6Redirect\` / \`appPID\` / \`caJavaHome\` / \`dnsForwardTimeout\` fields.

Net diff: **+1 / -19**, no behaviour change beyond fixing the merge.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`gofmt -l pkg/agent/proxy/proxy.go\` clean
- [x] \`go vet ./pkg/agent/proxy/...\` clean
- [ ] Re-run the Flipkart release pipeline against this branch