### PR TITLE
feat(agent): propagate KEPLOY_PG_V3_*, KEPLOY_STRICT_MOCK_WINDOW, KEPLOY_MOCK_FORMAT into agent container

### DIFF
--- a/pkg/platform/docker/docker.go
+++ b/pkg/platform/docker/docker.go
@@ -544,6 +544,22 @@ func (idc *Impl) GenerateKeployAgentService(opts models.SetupOptions) (*yaml.Nod
 		envVars = append(envVars, fmt.Sprintf("INSTALLATION_ID=%s", installationID))
 	}
 
+	// Propagate operator-opt-in env vars (KEPLOY_PG_V3_*, KEPLOY_*_FALLBACK,
+	// etc.) from the host shell into the agent container. The agent reads
+	// these via os.Getenv() inside its own process; without explicit
+	// propagation a host-side `KEPLOY_PG_V3_BINDSHAPE_FALLBACK=1` would
+	// never reach the parser code that gates on it. Whitelist by prefix
+	// rather than full env to avoid leaking unrelated process env into
+	// the container.
+	for _, propagatePrefix := range []string{"KEPLOY_PG_V3_", "KEPLOY_STRICT_MOCK_WINDOW", "KEPLOY_MOCK_FORMAT"} {
+		for _, envEntry := range os.Environ() {
+			if !strings.HasPrefix(envEntry, propagatePrefix) {
+				continue
+			}
+			envVars = append(envVars, envEntry)
+		}
+	}
+
 	// Generate ports
 	var ports []string
 	if opts.AgentPort != 0 {


### PR DESCRIPTION
## Summary

The host CLI (\`keploy record\` / \`keploy test\`) launches the matcher in an agent docker container. Several postgres-v3 (and matcher-tier) feature toggles are read by code that runs inside the agent — \`KEPLOY_PG_V3_*\`, \`KEPLOY_STRICT_MOCK_WINDOW\`, \`KEPLOY_MOCK_FORMAT\` — but the host CLI's compose-template \`environment:\` block did not propagate those env vars from the parent shell. Setting them on the host had no effect on the agent.

This change extends the env-prefix whitelist in \`pkg/platform/docker/docker.go::GenerateKeployAgentService\` so any var matching those prefixes (or names) on the host shell is propagated into the agent service.

## Why

* PG_V3 cohort/bindshape tunables (e.g. \`KEPLOY_PG_V3_BINDSHAPE_FALLBACK\`) are agent-side feature flags. Without propagation they are silently no-ops.
* Same shape for \`KEPLOY_STRICT_MOCK_WINDOW\` and \`KEPLOY_MOCK_FORMAT\`.

## Test plan

- [ ] \`docker compose config\` against the generated compose snippet, with the env set on the host, shows the var on the agent service.
- [ ] Live \`keploy test\` run: confirm agent reads the toggle.
- [ ] Existing agent boot tests still pass.

## Downstream

* [keploy/enterprise PR #1889](https://github.com/keploy/enterprise/pull/1889) pins this commit and depends on it.