### PR TITLE
fix(http-recorder): stamp HTTP req before forward to preserve HTTP→DB causality

### DIFF
--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -956,7 +956,11 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 	go func() {
 		var dst io.Writer = upConn
 		if reqFeeder != nil {
-			dst = io.MultiWriter(upConn, reqFeeder)
+			// Order matters: reqFeeder first samples time.Now() inside its
+			// Write before upConn forwards bytes to the app. This guarantees
+			// HTTP req timestamp ≤ forward instant ≤ any SQL the app fires
+			// in response — preserves causality between HTTP and DB stamps.
+			dst = io.MultiWriter(reqFeeder, upConn)
 		}
 		_, _ = io.Copy(dst, clientConn)
 		if reqFeeder != nil {


### PR DESCRIPTION
## Problem

`handleHttp1ZeroCopy` fans client-side bytes out to two writers via `io.MultiWriter`:

```go
// pkg/agent/proxy/incoming/http.go (before)
dst = io.MultiWriter(upConn, reqFeeder)
io.Copy(dst, clientConn)
```

`io.MultiWriter` invokes its writers **sequentially in declaration order**. Per chunk:
1. `upConn.Write` runs first — bytes leave the proxy and hit the app's socket.
2. *Only then* `reqFeeder.Write` runs — and that's where `chunk.readAt = time.Now()` is stamped (`asyncPipeFeeder.Write`, http.go:295–333).

So the HTTP request's recorded timestamp is taken **after** the upstream app has already received the bytes. The DB-side relay's `wireTimeConn`, in contrast, stamps `time.Now()` synchronously inside `Read` as the bytes arrive on the socket. With a fast app (warm pgx connection, single-row PK select) the dispatched SQL can land at the proxy *before* the HTTP timestamp is sampled:

```
T_arrive    bytes hit clientConn
T_forward   upConn.Write completes (app sees HTTP request)
T_app       app handler dispatches db.Query
T_sql       SQL bytes arrive at proxy  → mock.reqTimestampMock stamped here
T_stamp     reqFeeder.Write runs       → test.req.timestamp stamped here
```

`T_sql < T_stamp` in the worst case → `mock.reqTimestampMock < test.req.timestamp` → the mock falls *outside* its causing test's `[req.ts, resp.ts]` window when per-test mock partitioning is enabled. The matcher then reports `candidates: 0` for SQL hashes that exist verbatim in `mocks.yaml`.

This race only matters once mocks are partitioned per HTTP test window — the legacy "all mocks visible to all tests" matcher didn't care. The MockManager per-test split (and the agent-side `filterByTimeStampTierAware` gate) made the pool windowed, exposing the latent race.

## Empirical evidence (`keploy/integrations#159` `pgtype-tour-postgres` repro)

| | Before |
|---|---|
| PostgresV3 SELECT mocks captured | 157 |
| Mocks falling outside every HTTP test window | **16 (10.2%)** |
| Negative skew range | -19 µs to -635 µs |
| GET tests with empty SELECT cohort | 18/159 (11.3%) |
| Min inter-test gap (prev.resp → nxt.req) | 5.886 ms |
| Replay test report | 174/174 FAIL |

For all 16 affected mocks, the mock fires 5–23 ms after the *previous* test's `resp_ts` (so it is logically the next test's mock) but is stamped 19–635 µs *before* the next test's `req_ts`.

## Fix

Swap the writer order:

```go
// after
dst = io.MultiWriter(reqFeeder, upConn)
io.Copy(dst, clientConn)
```

Now per chunk: `reqFeeder.Write` runs first → `time.Now()` is sampled → only then `upConn.Write` forwards bytes to the app → only then can the app emit SQL. By construction:

```
T_http_stamp  ≤  T_forward  ≤  T_sql_arrival
```

Causality between HTTP and DB timestamps is preserved structurally, by the proxy's own write ordering — no clock-skew tolerance compensation is required.

One file, six lines (with comment).

## Verification

End-to-end against `pgtype-tour-postgres` (TLS-enabled postgres, pgx prepareThreshold=1, single-row PK selects), with the keploy/integrations parser-import fold-in matching CI:

| | Before | After |
|---|---|---|
| Mocks outside every HTTP test window | 16 | **0** |
| GET tests with empty SELECT cohort | 18/159 | 0 (only the 2 `/health` tests, which legitimately do no SQL) |
| `pgtype-tour-postgres` replay | 174/174 FAIL | **174/174 PASS** |

Existing unit tests in `pkg/agent/proxy/...` remain green (38 packages, 0 failures).

## Why no tolerance-compensation patch?

An earlier version of this PR added a 2 ms left-edge tolerance on the window edge as a workaround. That tolerance was a band-aid for *exactly* this race. With the structural fix in place, the workaround is no longer load-bearing for any identified clock-skew source, so it has been dropped to keep the change tight and avoid leaving "defending against unknown" widening rules in the codebase. If a different jitter source surfaces later, a targeted tolerance can be re-added with the specific evidence motivating it.

## Test plan

- [x] `pkg/agent/proxy/...` unit tests green (`go test ./pkg/...`)
- [x] `pgtype-tour-postgres` `record-build-replay-build` lane (TLS+pgx) goes from FAIL → PASS using a binary built from this branch
- [x] `listmonk-postgres` regression remains GREEN (the workload that originally exposed the per-test windowing requirement)
- [ ] CI on `keploy/integrations#162` (paired) shows pgtype-tour + listmonk + customer-tag-cohort + asyncpg + http-postgres/1 + ps-cache + sap-demo-java + postgres-memory + postgres-parser-backpressure all GREEN

Refs: keploy/integrations#159, keploy/integrations#162