### PR TITLE
ci(grpc-secret): probe gRPC reflection so session-pool path is exercised

### DIFF
--- a/.github/workflows/test_workflow_scripts/golang/grpc-secret/grpc-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/grpc-secret/grpc-linux.sh
@@ -149,9 +149,23 @@ kill_keploy_process() {
 send_grpc_requests() {
     echo "Waiting for gRPC server to be ready..."
     sleep 10
-    
+
+    # 0. Reflection probes — exercise the LifetimeSession mock path end-to-end.
+    # The grpc-secret server registers grpc.reflection.v1.ServerReflection in
+    # main.go. These two grpcurl invocations issue ServerReflectionInfo RPCs
+    # that the keploy recorder tags as type=="config" / Lifetime==Session, so
+    # replay must serve them from the session pool (not the per-test pool).
+    # Without this, the matcher's per-test-only path could regress silently
+    # because the regular Jwt/Curl/Cdn/GetSecret RPCs all live in per-test.
+    echo "Probing gRPC reflection (list)..."
+    grpcurl -plaintext -v localhost:50051 list >/dev/null 2>&1 || echo "reflection list completed"
+    sleep 1
+    echo "Probing gRPC reflection (describe SecretService)..."
+    grpcurl -plaintext -v localhost:50051 describe secrets.SecretService >/dev/null 2>&1 || echo "reflection describe completed"
+    sleep 1
+
     echo "Sending all 4 gRPC requests..."
-    
+
     # 1. JwtLab
     echo "Sending JwtLab request..."
     grpcurl -plaintext -v \


### PR DESCRIPTION
## Summary
- Adds two grpcurl reflection probes (`list` + `describe`) to the grpc-secret CI driver before the regular Jwt/Curl/Cdn/GetSecret request set.
- Reflection RPCs are tagged by the recorder as `type=="config"` / `Lifetime==Session`; without these probes the matcher's session-pool fall-through path is **never** exercised end-to-end (every regular RPC in this sample lands in the per-test pool).
- Pairs with [keploy/integrations#153](https://github.com/keploy/integrations/pull/153) which wires the session-pool union into the gRPC matcher (`FilterMocksBasedOnGrpcRequest` now reads `GetPerTestMocksInWindow ∪ GetSessionMocks`, mirroring HTTP).

## Why draft
This PR's CI will fail until integrations#153 merges and `INTEGRATION_REF` (or a go-mod bump) picks up the matcher fix — without the union, replay can't find the reflection mocks and the test report fails. Promote out of draft once integrations is rolled forward.

## Test plan
- [ ] integrations#153 merges to main
- [ ] `INTEGRATION_REF` updated (or go.mod bumped) to include the matcher fix
- [ ] grpc-secret CI passes both `record_build_replay_build` and the cross-version configs
- [ ] Reflection mocks visible in `keploy/test-set-*/mocks.yaml` (sanity: at least one `metadata.type: config` mock per recording)