### PR TITLE
fix(replay): carry mock Lifetime so session/connection mocks reach mappings.yaml

### DIFF
--- a/pkg/agent/proxy/mockmanager.go
+++ b/pkg/agent/proxy/mockmanager.go
@@ -1643,6 +1643,7 @@ func (m *MockManager) UpdateUnFilteredMock(old *models.Mock, new *models.Mock) b
 			IsFiltered:       new.TestModeInfo.IsFiltered,
 			SortOrder:        new.TestModeInfo.SortOrder,
 			Type:             new.Spec.Metadata["type"],
+			Lifetime:         new.TestModeInfo.Lifetime,
 			ReqTimestampMock: models.FormatMockTimestamp(new.Spec.ReqTimestampMock),
 			ResTimestampMock: models.FormatMockTimestamp(new.Spec.ResTimestampMock),
 		}); err != nil {
@@ -1690,6 +1691,7 @@ func (m *MockManager) DeleteFilteredMock(mock models.Mock) bool {
 			IsFiltered:       mock.TestModeInfo.IsFiltered,
 			SortOrder:        mock.TestModeInfo.SortOrder,
 			Type:             mock.Spec.Metadata["type"],
+			Lifetime:         mock.TestModeInfo.Lifetime,
 			ReqTimestampMock: models.FormatMockTimestamp(mock.Spec.ReqTimestampMock),
 			ResTimestampMock: models.FormatMockTimestamp(mock.Spec.ResTimestampMock),
 		}); err != nil {
@@ -1728,6 +1730,7 @@ func (m *MockManager) DeleteUnFilteredMock(mock models.Mock) bool {
 			IsFiltered:       mock.TestModeInfo.IsFiltered,
 			SortOrder:        mock.TestModeInfo.SortOrder,
 			Type:             mock.Spec.Metadata["type"],
+			Lifetime:         mock.TestModeInfo.Lifetime,
 			ReqTimestampMock: models.FormatMockTimestamp(mock.Spec.ReqTimestampMock),
 			ResTimestampMock: models.FormatMockTimestamp(mock.Spec.ResTimestampMock),
 		}); err != nil {
@@ -1830,6 +1833,7 @@ func (m *MockManager) MarkMockAsUsed(mock models.Mock) bool {
 		IsFiltered:       mock.TestModeInfo.IsFiltered,
 		SortOrder:        mock.TestModeInfo.SortOrder,
 		Type:             mock.Spec.Metadata["type"],
+		Lifetime:         mock.TestModeInfo.Lifetime,
 		ReqTimestampMock: models.FormatMockTimestamp(mock.Spec.ReqTimestampMock),
 		ResTimestampMock: models.FormatMockTimestamp(mock.Spec.ResTimestampMock),
 	}); err != nil {

--- a/pkg/models/mock.go
+++ b/pkg/models/mock.go
@@ -653,6 +653,16 @@ type MockState struct {
 	Timestamp        int64     `json:"timestamp"`
 	ReqTimestampMock string    `json:"reqTimestampMock,omitempty"`
 	ResTimestampMock string    `json:"resTimestampMock,omitempty"`
+	// Lifetime carries the recorder-derived mock tier (per-test, session,
+	// connection, …) through GetConsumedMocks so the test-mode mapping
+	// writer can carve out session/connection mocks from its
+	// record-time-window filter — those mocks are recorded during app
+	// boot before any test fires, so their ReqTimestampMock falls
+	// outside every test window even when they're consumed by a test.
+	// Without this, mappings.yaml comes back empty for postgres v3
+	// workloads whose recorder classifies handshake / pool-warmup /
+	// catalog probes as session-tier (#empty-mapping bug).
+	Lifetime Lifetime `json:"lifetime,omitempty"`
 }
 
 func (m *Mock) DeepCopy() *Mock {

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -562,9 +562,27 @@ func upsertActualTestMockMapping(actualTestMockMappings *models.Mapping, testCas
 			// test (or to session-level traffic that should not be
 			// per-test). DNS mocks have no stable timestamps and are
 			// intentionally never filtered out here.
-			if strings.EqualFold(string(m.Kind), string(models.DNS)) {
+			//
+			// Lifetime carve-out: session- and connection-tier mocks
+			// are recorded during app boot or pool warm-up — strictly
+			// before the first HTTP test fires. Their ReqTimestampMock
+			// is therefore *always* outside every test window, even
+			// though the test legitimately consumes them at replay
+			// time (handshake, SET TIME ZONE, prepared-Parse, JDBC
+			// keepalive). The window filter must NOT discard them or
+			// mappings.yaml comes back empty for any test whose mock
+			// budget is dominated by session/connection traffic
+			// (postgres v3 wire-features, listmonk's HikariCP-style
+			// warm-up, mongo's handshake/heartbeat). DNS uses the same
+			// always-keep semantics for an analogous reason: its
+			// timestamps aren't anchored to a test window.
+			switch {
+			case strings.EqualFold(string(m.Kind), string(models.DNS)):
 				// DNS: always keep.
-			} else {
+			case m.Lifetime == models.LifetimeSession || m.Lifetime == models.LifetimeConnection:
+				// Session/connection-tier: always keep — the recorder
+				// stamped them outside every test window by design.
+			default:
 				reqInWindow := !parsedReqTime.IsZero() && !parsedReqTime.Before(tcReq) && !parsedReqTime.After(tcResp)
 				resInWindow := !parsedResTime.IsZero() && !parsedResTime.Before(tcReq) && !parsedResTime.After(tcResp)
 				hasAnyTimestamp := !parsedReqTime.IsZero() || !parsedResTime.IsZero()


### PR DESCRIPTION
## Summary
- The test-mode mapping writer's per-test window filter dropped every session/connection-tier mock because their record-time timestamps fall outside every test window by design (recorded during app boot before any test fires).
- For postgres v3, mongo v2, listmonk-style workloads dominated by session/connection traffic this rendered `mappings.yaml` empty (`tests: []`); partial files then broke replay-time name-based filtering in `determineMockingStrategy`.
- Plumbs `Lifetime` through `MockState` so `upsertActualTestMockMapping` can carve out session/connection-tier mocks alongside the existing DNS always-keep branch.

## Changes
- `pkg/models/mock.go`: add `Lifetime` field to `MockState`.
- `pkg/agent/proxy/mockmanager.go`: propagate `mock.TestModeInfo.Lifetime` into the four `flagMockAsUsed`/`MarkMockAsUsed` call sites that build the `MockState` shipped to `GetConsumedMocks`.
- `pkg/service/replay/utils.go`: window filter switch — DNS keeps existing always-keep; new `LifetimeSession || LifetimeConnection` branch added with the same always-keep semantics; per-test mocks unchanged.

No change to the `DisableMapping` vs `UpdateTestMapping` contract (`replay.go:2318`).

## Empirical verification
postgres-wire-features e2e (real `keploy test --update-test-mapping`):
- Before: `tests: []`, `totalTests: 0`.
- After: 35 mock entries; all 8 unique (sqlAstHash, lifetime) session/connection classes (`DEALLOCATE`, `BEGIN`, `COMMIT`, `CREATE TABLE`, `DROP TABLE`, `CREATE TABLE IF NOT EXISTS`, `SELECT $1`, `TRUNCATE`) present.
- Pass/fail unchanged (3 pass, 2 fail — same legitimate JSON diffs unrelated to mappings).

## Pairs with
The integrations-side traceability hooks (engine-level `ReportSessionUsageForSQL` + canonical-tx short-circuit + check-mappings CI guardrail) ship in keploy/integrations under a separate PR. Either side can land first; the bug is fully resolved only with both.

## Test plan
- [ ] CI go-test passes
- [ ] Reviewer reads the lifetime-tier carve-out in `utils.go` against the existing DNS branch — same shape, parallel rationale
- [ ] Spot-check: a postgres v3 sample with `updateTestMapping: true` lands a non-empty `mappings.yaml` covering session-lifetime SQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)