### PR TITLE
feat: add no app restart replay flag

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -328,6 +328,7 @@ func (c *CmdConfigurator) AddUncommonFlags(cmd *cobra.Command) {
 		cmd.Flags().Uint64P("delay", "d", 5, "User provided time to run its application")
 		cmd.Flags().String("health-url", c.cfg.Test.HealthURL, "HTTP(S) URL polled before the first test is fired; first 2xx response proceeds immediately. Empty (default) preserves the fixed --delay behavior.")
 		cmd.Flags().Duration("health-poll-timeout", c.cfg.Test.HealthPollTimeout, "Ceiling for --health-url polling (e.g. 60s, 2m). If no 2xx is seen within this window, replay logs an info message and falls back to --delay.")
+		cmd.Flags().Bool("no-app-restart", c.cfg.Test.NoAppRestart, "Run all selected test sets against a single application process instead of restarting before each test set")
 		cmd.Flags().String("proto-file", c.cfg.Test.ProtoFile, "Path of main proto file")
 		cmd.Flags().String("proto-dir", c.cfg.Test.ProtoDir, "Path of the directory where all protos of a service are located")
 		cmd.Flags().StringArray("proto-include", c.cfg.Test.ProtoInclude, "Path of directories to be included while parsing import statements in proto files")
@@ -416,6 +417,7 @@ func aliasNormalizeFunc(_ *pflag.FlagSet, name string) pflag.NormalizedName {
 		"recordTimer":           "record-timer",
 		"healthUrl":             "health-url",
 		"healthPollTimeout":     "health-poll-timeout",
+		"noAppRestart":          "no-app-restart",
 		"urlMethods":            "url-methods",
 		"inCi":                  "in-ci",
 		"protoFile":             "proto-file",

--- a/config/config.go
+++ b/config/config.go
@@ -112,6 +112,7 @@ type Test struct {
 	Delay                       uint64              `json:"delay" yaml:"delay" mapstructure:"delay"`
 	HealthURL                   string              `json:"healthUrl" yaml:"healthUrl" mapstructure:"healthUrl"`                         // optional HTTP(S) URL polled before firing the first test; empty preserves the fixed --delay behavior
 	HealthPollTimeout           time.Duration       `json:"healthPollTimeout" yaml:"healthPollTimeout" mapstructure:"healthPollTimeout"` // ceiling for the pre-test health poll loop before falling back to --delay
+	NoAppRestart                bool                `json:"noAppRestart" yaml:"noAppRestart" mapstructure:"noAppRestart"`                // run all selected test sets against one app process instead of restarting between test sets
 	Host                        string              `json:"host" yaml:"host" mapstructure:"host"`
 	Port                        uint32              `json:"port" yaml:"port" mapstructure:"port"`
 	GRPCPort                    uint32              `json:"grpcPort" yaml:"grpcPort" mapstructure:"grpcPort"`

--- a/config/default.go
+++ b/config/default.go
@@ -41,6 +41,7 @@ test:
   delay: 5
   healthUrl: ""
   healthPollTimeout: 60s
+  noAppRestart: false
   host: "localhost"
   port: 0
   grpcPort: 0

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -236,6 +236,7 @@ func (r *Replayer) Start(ctx context.Context) error {
 	setupCtx = context.WithValue(setupCtx, models.ErrGroupKey, setupErrGrp)
 
 	var hookCancel context.CancelFunc
+	var sharedAppCancel context.CancelFunc
 	var stopReason = "replay completed successfully"
 
 	// defering the stop function to stop keploy in case of any error in record or in case of context cancellation
@@ -253,6 +254,9 @@ func (r *Replayer) Start(ctx context.Context) error {
 			r.logger.Debug("failed to notify agent of graceful shutdown", zap.Error(err))
 		}
 
+		if sharedAppCancel != nil {
+			sharedAppCancel()
+		}
 		if hookCancel != nil {
 			hookCancel()
 		}
@@ -393,6 +397,21 @@ func (r *Replayer) Start(ctx context.Context) error {
 	r.testRunTestSets = testSets
 	r.testRunID = testRunID
 	r.firstRun = true
+
+	noAppRestart := r.config.Test.NoAppRestart && r.instrument
+	if r.config.Test.NoAppRestart && !r.instrument {
+		r.logger.Info("ignoring --no-app-restart because replay is running without an app command")
+	}
+	var sharedAppErrCh <-chan models.AppError
+	if noAppRestart {
+		sharedAppCancel, sharedAppErrCh, err = r.startSharedApplication(ctx, g, testSets)
+		if err != nil {
+			stopReason = fmt.Sprintf("failed to start shared application for --no-app-restart: %v", err)
+			utils.LogError(r.logger, err, stopReason)
+			return fmt.Errorf("%s", stopReason)
+		}
+	}
+
 	for i, testSet := range testSets {
 		var backupCreated bool
 		testSetResult = false
@@ -454,7 +473,15 @@ func (r *Replayer) Start(ctx context.Context) error {
 			r.completeTestReportMu.Unlock()
 
 			r.logger.Info("running", zap.String("test-set", models.HighlightString(testSet)), zap.Int("attempt", attempt))
-			testSetStatus, err := r.RunTestSet(ctx, testSet, testRunID, false)
+			if noAppRestart {
+				if appErr, ok := readSharedAppError(sharedAppErrCh); ok {
+					stopReason = fmt.Sprintf("application stopped before test set %s: %s", testSet, appErr.Error())
+					utils.LogError(r.logger, appErr, stopReason)
+					return fmt.Errorf("%s", stopReason)
+				}
+			}
+
+			testSetStatus, err := r.RunTestSet(ctx, testSet, testRunID, noAppRestart)
 			if err != nil {
 				if ctx.Err() == context.Canceled {
 					return err
@@ -462,6 +489,13 @@ func (r *Replayer) Start(ctx context.Context) error {
 				stopReason = fmt.Sprintf("failed to run test set: %v", err)
 				utils.LogError(r.logger, err, stopReason)
 				return fmt.Errorf("%s", stopReason)
+			}
+			if noAppRestart {
+				if appErr, ok := readSharedAppError(sharedAppErrCh); ok {
+					stopReason = fmt.Sprintf("application stopped during test set %s: %s", testSet, appErr.Error())
+					utils.LogError(r.logger, appErr, stopReason)
+					return fmt.Errorf("%s", stopReason)
+				}
 			}
 			switch testSetStatus {
 			case models.TestSetStatusAppHalted:
@@ -669,6 +703,83 @@ func (r *Replayer) Start(ctx context.Context) error {
 	return nil
 }
 
+func readSharedAppError(appErrCh <-chan models.AppError) (models.AppError, bool) {
+	if appErrCh == nil {
+		return models.AppError{}, false
+	}
+	select {
+	case appErr := <-appErrCh:
+		return appErr, true
+	default:
+		return models.AppError{}, false
+	}
+}
+
+func (r *Replayer) startSharedApplication(ctx context.Context, g *errgroup.Group, testSets []string) (context.CancelFunc, <-chan models.AppError, error) {
+	appCommand, err := r.resolveSharedAppCommand(ctx, testSets)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	appCtx, appCancel := context.WithCancel(ctx)
+	appErrCh := make(chan models.AppError, 1)
+	r.logger.Info("running selected test sets without restarting the application", zap.Strings("testSets", testSets))
+
+	g.Go(func() error {
+		defer utils.Recover(r.logger)
+		appErr := r.RunApplication(appCtx, models.RunOptions{AppCommand: appCommand})
+		if appErr.AppErrorType == models.ErrCtxCanceled || appErr == (models.AppError{}) {
+			return nil
+		}
+		select {
+		case appErrCh <- appErr:
+		default:
+		}
+		return nil
+	})
+
+	return appCancel, appErrCh, nil
+}
+
+func (r *Replayer) resolveSharedAppCommand(ctx context.Context, testSets []string) (string, error) {
+	if r.testSetConf == nil {
+		return "", nil
+	}
+
+	var appCommand string
+	for _, testSetID := range testSets {
+		conf, err := r.testSetConf.Read(ctx, testSetID)
+		if err != nil {
+			if isMissingTestSetConfigError(err) {
+				continue
+			}
+			return "", fmt.Errorf("read test-set config for %s: %w", testSetID, err)
+		}
+		if conf == nil || strings.TrimSpace(conf.AppCommand) == "" {
+			continue
+		}
+
+		candidate := strings.TrimSpace(conf.AppCommand)
+		if appCommand == "" {
+			appCommand = candidate
+			continue
+		}
+		if candidate != appCommand {
+			return "", fmt.Errorf("--no-app-restart requires selected test sets to use the same appCommand; %s differs", testSetID)
+		}
+	}
+
+	return appCommand, nil
+}
+
+func isMissingTestSetConfigError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "no such file or directory") ||
+		strings.Contains(err.Error(), "The system cannot find the file specified")
+}
+
 func (r *Replayer) Instrument(ctx context.Context) (*InstrumentState, error) {
 	if !r.instrument {
 		r.logger.Info("Keploy will not mock the outgoing calls when base path is provided", zap.Any("base path", r.config.Test.BasePath))
@@ -809,7 +920,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 	if r.testSetConf != nil {
 		conf, err = r.testSetConf.Read(runTestSetCtx, testSetID)
 		if err != nil {
-			if strings.Contains(err.Error(), "no such file or directory") || strings.Contains(err.Error(), "The system cannot find the file specified") {
+			if isMissingTestSetConfigError(err) {
 				r.logger.Info("test-set config file not found, continuing execution...", zap.String("test-set", testSetID))
 			} else {
 				return models.TestSetStatusFailed, fmt.Errorf("failed to read test set config: %w", err)


### PR DESCRIPTION
## Describe the changes that are made
- Adds `test.noAppRestart` config and the `keploy test --no-app-restart` flag.
- Starts the application once for the selected replay run and executes all selected test sets with the existing `serveTest` path instead of restarting between test sets.
- Validates that selected test-set configs do not request different `appCommand` values before using the shared app lifecycle.

## Links & References

**Closes:** #[issue number that will be closed through this PR]
- NA

### 🔗 Related PRs
- Enterprise Java dedup CI follow-up will pin this commit and use `--no-app-restart`.

### 🐞 Related Issues
- NA

### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [x] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [x] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [x] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

```bash
go test ./config ./cli/provider ./pkg/service/replay
keploy test -c "<app command>" --dedup --no-app-restart
```

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- `go test ./config ./cli/provider ./pkg/service/replay` passed locally.

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?
