### PR TITLE
fix(testdb): correct YAML noise assertion decode type assertion (#3872)

### DIFF
--- a/pkg/platform/yaml/testdb/noise_decode_test.go
+++ b/pkg/platform/yaml/testdb/noise_decode_test.go
@@ -1,0 +1,54 @@
+package testdb
+
+import (
+	"testing"
+)
+
+// TestPopulateNoise_AcceptsYamlV3MapShape regression-tests #3872: the previous
+// implementation type-asserted the noise sub-map as
+// map[models.AssertionType]interface{} which YAML never produces, so noise
+// assertions were silently dropped on load.
+func TestPopulateNoise_AcceptsYamlV3MapShape(t *testing.T) {
+	noise := map[string][]string{}
+	raw := map[string]interface{}{
+		"header.X-Request-ID": []interface{}{"foo", "bar"},
+		"body.timestamp":      []interface{}{},
+	}
+	populateNoise(raw, noise)
+
+	if got, want := len(noise["header.X-Request-ID"]), 2; got != want {
+		t.Errorf("header.X-Request-ID len = %d, want %d", got, want)
+	}
+	if noise["header.X-Request-ID"][0] != "foo" {
+		t.Errorf("header.X-Request-ID[0] = %q, want %q", noise["header.X-Request-ID"][0], "foo")
+	}
+	if _, ok := noise["body.timestamp"]; !ok {
+		t.Error("body.timestamp key should be present (initialised even when empty)")
+	}
+}
+
+// TestPopulateNoise_AcceptsYamlV2MapShape covers the older library output
+// where keys arrive as interface{}.
+func TestPopulateNoise_AcceptsYamlV2MapShape(t *testing.T) {
+	noise := map[string][]string{}
+	raw := map[interface{}]interface{}{
+		"header.X-Request-ID": []interface{}{"foo"},
+	}
+	populateNoise(raw, noise)
+	if got, want := noise["header.X-Request-ID"][0], "foo"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestPopulateNoise_AcceptsConcreteSliceShape covers programmatic
+// constructions where the noise map round-trips without YAML in between.
+func TestPopulateNoise_AcceptsConcreteSliceShape(t *testing.T) {
+	noise := map[string][]string{}
+	raw := map[string][]string{
+		"header.Cookie": {"session", "tracking"},
+	}
+	populateNoise(raw, noise)
+	if got, want := len(noise["header.Cookie"]), 2; got != want {
+		t.Errorf("got %d entries, want %d", got, want)
+	}
+}

--- a/pkg/platform/yaml/testdb/util.go
+++ b/pkg/platform/yaml/testdb/util.go
@@ -322,25 +322,12 @@ func Decode(yamlTestcase *yaml.NetworkTrafficDoc, logger *zap.Logger) (*models.T
 		for key, raw := range httpSpec.Assertions {
 			tc.Assertions[key] = raw
 			if key == models.NoiseAssertion {
-				noiseMap, ok := raw.(map[models.AssertionType]interface{})
-				if !ok {
-					logger.Debug("noise assertion not in expected map[AssertionType]interface{}", zap.Any("raw", raw))
-					continue
-				}
-				for kt, inner := range noiseMap {
-					field := string(kt)
-					// initialize slice
-					tc.Noise[field] = []string{}
-					arr, ok := inner.([]interface{})
-					if !ok {
-						continue
-					}
-					for _, item := range arr {
-						if s, ok2 := item.(string); ok2 && s != "" {
-							tc.Noise[field] = append(tc.Noise[field], s)
-						}
-					}
-				}
+				// On encode the noise map is `map[string][]string`; YAML
+				// decodes it back as map[string]interface{} (yaml.v3) or
+				// map[interface{}]interface{} (yaml.v2). Asserting on
+				// map[AssertionType]interface{} always failed and silently
+				// dropped the noise config (#3872) — accept both shapes.
+				populateNoise(raw, tc.Noise)
 			}
 		}
 
@@ -358,24 +345,7 @@ func Decode(yamlTestcase *yaml.NetworkTrafficDoc, logger *zap.Logger) (*models.T
 		for key, raw := range grpcSpec.Assertions {
 			tc.Assertions[key] = raw
 			if key == models.NoiseAssertion {
-				noiseMap, ok := raw.(map[models.AssertionType]interface{})
-				if !ok {
-					logger.Debug("noise assertion not in expected map[AssertionType]interface{}", zap.Any("raw", raw))
-					continue
-				}
-				for kt, inner := range noiseMap {
-					field := string(kt)
-					tc.Noise[field] = []string{}
-					arr, ok := inner.([]interface{})
-					if !ok {
-						continue
-					}
-					for _, item := range arr {
-						if s, ok2 := item.(string); ok2 && s != "" {
-							tc.Noise[field] = append(tc.Noise[field], s)
-						}
-					}
-				}
+				populateNoise(raw, tc.Noise)
 			}
 		}
 
@@ -385,4 +355,55 @@ func Decode(yamlTestcase *yaml.NetworkTrafficDoc, logger *zap.Logger) (*models.T
 	}
 
 	return tc, nil
+}
+
+// populateNoise normalises a YAML-decoded noise assertion (which may arrive
+// as map[string]interface{} from yaml.v3 or map[interface{}]interface{} from
+// yaml.v2) into the tc.Noise map[string][]string that the rest of keploy
+// expects. The previous code asserted the raw value as
+// map[models.AssertionType]interface{} — that type never matched what the
+// YAML libraries produce, so noise assertions were silently dropped on load.
+func populateNoise(raw interface{}, noise map[string][]string) {
+	if raw == nil {
+		return
+	}
+	visit := func(field string, inner interface{}) {
+		noise[field] = []string{}
+		// yaml.v3 decodes string lists as []interface{}.
+		if arr, ok := inner.([]interface{}); ok {
+			for _, item := range arr {
+				if s, ok2 := item.(string); ok2 && s != "" {
+					noise[field] = append(noise[field], s)
+				}
+			}
+			return
+		}
+		// In tests / programmatic constructions the encoder hands back the
+		// concrete []string, so accept that too.
+		if arr, ok := inner.([]string); ok {
+			for _, s := range arr {
+				if s != "" {
+					noise[field] = append(noise[field], s)
+				}
+			}
+		}
+	}
+	switch m := raw.(type) {
+	case map[string]interface{}:
+		for k, v := range m {
+			visit(k, v)
+		}
+	case map[interface{}]interface{}:
+		for k, v := range m {
+			ks, ok := k.(string)
+			if !ok {
+				continue
+			}
+			visit(ks, v)
+		}
+	case map[string][]string:
+		for k, v := range m {
+			visit(k, v)
+		}
+	}
 }

--- a/pkg/platform/yaml/testdb/util.go
+++ b/pkg/platform/yaml/testdb/util.go
@@ -326,7 +326,7 @@ func Decode(yamlTestcase *yaml.NetworkTrafficDoc, logger *zap.Logger) (*models.T
 				// decodes it back as map[string]interface{} (yaml.v3) or
 				// map[interface{}]interface{} (yaml.v2). Asserting on
 				// map[AssertionType]interface{} always failed and silently
-				// dropped the noise config (#3872) — accept both shapes.
+				// dropped the noise config (#3872), accept both shapes.
 				populateNoise(raw, tc.Noise)
 			}
 		}
@@ -361,7 +361,7 @@ func Decode(yamlTestcase *yaml.NetworkTrafficDoc, logger *zap.Logger) (*models.T
 // as map[string]interface{} from yaml.v3 or map[interface{}]interface{} from
 // yaml.v2) into the tc.Noise map[string][]string that the rest of keploy
 // expects. The previous code asserted the raw value as
-// map[models.AssertionType]interface{} — that type never matched what the
+// map[models.AssertionType]interface{}, that type never matched what the
 // YAML libraries produce, so noise assertions were silently dropped on load.
 func populateNoise(raw interface{}, noise map[string][]string) {
 	if raw == nil {


### PR DESCRIPTION
Fixes #3872. `pkg/platform/yaml/testdb/util.go` decoded the noise assertion sub-map by asserting:

```go
noiseMap, ok := raw.(map[models.AssertionType]interface{})
```

YAML never decodes a sub-map into that custom-typed key, yaml.v3 produces `map[string]interface{}`, yaml.v2 produces `map[interface{}]interface{}`. The assertion always failed, the `Debug` log fired, and `tc.Noise` stayed empty. Users' noise configurations were silently dropped during test replay.

## Change

Extracted a `populateNoise(raw, noise)` helper that:

- Accepts `map[string]interface{}` (yaml.v3), `map[interface{}]interface{}` (yaml.v2), and `map[string][]string` (programmatic round-trips).
- Iterates entries, initialising `noise[field] = []string{}` (preserves the existing 'empty key still present' behaviour) and accepting both `[]interface{}` and `[]string` for the inner values.

Both the HTTP and gRPC branches in `DecodeTestcase` now delegate to this helper, eliminating the duplicate buggy block.

## Test plan

- [x] `go build ./pkg/platform/yaml/testdb/...`, clean
- [x] `go vet ./pkg/platform/yaml/testdb/...`, clean
- [x] `go test ./pkg/platform/yaml/testdb/...`, all existing tests pass
- [x] New `noise_decode_test.go` covers all three input shapes (yaml.v3 map, yaml.v2 map, concrete `map[string][]string`)
- [x] Pre-fix the existing pattern `raw.(map[models.AssertionType]interface{})` returns `ok == false` for every yaml-decoded shape (asserted by tracing the test inputs)

## Customer-data hygiene

No real recordings or customer data introduced. Test inputs use synthetic header names (`X-Request-ID`, `Cookie`) and field paths (`body.timestamp`).