### PR TITLE
fix(record): MSG_PEEK + replay-on-stale for HTTP/1.1 upstream pool reuse

### DIFF
--- a/.github/workflows/http-stale-pool-race-linux.yml
+++ b/.github/workflows/http-stale-pool-race-linux.yml
@@ -71,8 +71,13 @@ jobs:
       - name: Run regression test
         env:
           RECORD_BIN: ${{ steps.record.outputs.path }}
+        # Run via `bash <script>` rather than `source` so the
+        # script's intentional avoidance of `set -e` is not overridden
+        # by the workflow step's default `-eo pipefail`. The script's
+        # `client_status=$?` capture and cleanup-then-fail sequencing
+        # depend on commands not short-circuiting the parent shell.
         run: |
-          source "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/python-linux.sh"
+          bash "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/python-linux.sh"
 
       - name: Upload logs
         if: always()

--- a/.github/workflows/http-stale-pool-race-linux.yml
+++ b/.github/workflows/http-stale-pool-race-linux.yml
@@ -1,0 +1,86 @@
+name: HTTP Stale-Pool Race Regression (Linux)
+# Regression test for issue #4165 — the upstream-pool half-close race
+# in keploy's HTTP/1.1 ingress proxy that surfaced as silent request
+# drops + downstream 503/UC under bursty traffic with idle gaps longer
+# than the backend's keep-alive (gunicorn 2s default).
+#
+# The matrix runs the same bursty-load test against two keploy
+# binaries:
+#   - record_with_build  → uses the PR's binary. MUST pass.
+#   - record_with_latest → uses the published `latest`. Demonstrates
+#                          the bug on releases that pre-date the fix
+#                          (~25-50% drop rate). Marked
+#                          continue-on-error so it documents the bug
+#                          without blocking PR merges; flip to a hard
+#                          gate once a release containing the fix is
+#                          published as `latest`.
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: 'The type of runner to use for this job'
+        type: string
+        required: false
+        default: 'ubuntu-latest'
+      jobs_to_run:
+        description: 'Controls which jobs to run. "all" runs everything.'
+        type: string
+        required: false
+        default: 'all'
+
+jobs:
+  http_stale_pool_race_linux:
+    if: ${{ inputs.jobs_to_run == 'all' }}
+    runs-on: ${{ inputs.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - job: record_with_build
+            record_src: build
+            # The PR's binary MUST keep the test green. If this
+            # leg fails, either the fix regressed or the burst
+            # parameters drift from what reproduces the race.
+            continue_on_error: false
+          - job: record_with_latest
+            record_src: latest
+            # The published `latest` is expected to fail this test
+            # until a release containing the fix ships. Marked
+            # continue-on-error so the failure is visible but does
+            # not block the PR.
+            continue_on_error: true
+    name: stale-pool-race (${{ matrix.config.job }})
+    timeout-minutes: 15
+    continue-on-error: ${{ matrix.config.continue_on_error }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: keploy/keploy
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - id: record
+        uses: ./.github/actions/download-binary
+        with:
+          src: ${{ matrix.config.record_src }}
+
+      - name: Run regression test
+        env:
+          RECORD_BIN: ${{ steps.record.outputs.path }}
+        run: |
+          source "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/python-linux.sh"
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: http-stale-pool-race-${{ matrix.config.job }}-logs
+          path: |
+            .github/workflows/test_workflow_scripts/python/http-stale-pool-race/record_logs.txt
+            .github/workflows/test_workflow_scripts/python/http-stale-pool-race/keploy/
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/prepare_and_run.yml
+++ b/.github/workflows/prepare_and_run.yml
@@ -686,6 +686,13 @@ jobs:
   run_python_linux:
     needs: [build-and-upload, upload-latest]
     uses: ./.github/workflows/python_linux.yml
+  run_http_stale_pool_race_linux:
+    # Regression guard for issue #4165 (upstream-pool half-close race
+    # in handleHttp1ZeroCopy). Bursty client + gunicorn --keep-alive 2
+    # exposes the race; the matrix runs both `build` (must pass) and
+    # `latest` (currently demonstrates the bug, continue-on-error).
+    needs: [build-and-upload, upload-latest]
+    uses: ./.github/workflows/http-stale-pool-race-linux.yml
   run_golang_docker:
     needs: [build-and-upload, upload-latest, build-docker-image-amd64]
     uses: ./.github/workflows/golang_docker.yml

--- a/.github/workflows/prepare_and_run.yml
+++ b/.github/workflows/prepare_and_run.yml
@@ -1126,6 +1126,7 @@ jobs:
       - run_node_docker
       - run_python_docker
       - run_python_linux
+      - run_http_stale_pool_race_linux
       - run_golang_docker
       - run_fuzzer_linux
       - run_grpc_linux
@@ -1145,6 +1146,7 @@ jobs:
             "${{ needs.run_node_docker.result }}" \
             "${{ needs.run_python_docker.result }}" \
             "${{ needs.run_python_linux.result }}" \
+            "${{ needs.run_http_stale_pool_race_linux.result }}" \
             "${{ needs.run_golang_docker.result }}" \
             "${{ needs.run_fuzzer_linux.result }}" \
             "${{ needs.run_grpc_linux.result }}" \

--- a/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/.gitignore
+++ b/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+keploy/
+record_logs.txt

--- a/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/burst_client.py
+++ b/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/burst_client.py
@@ -1,0 +1,97 @@
+"""Bursty HTTP/1.1 keep-alive client that exposes the upstream-pool
+half-close race in keploy's ingress proxy.
+
+Shape: N persistent HTTP/1.1 connections, B bursts of R sequential
+requests per connection, with a fixed idle gap between bursts that is
+strictly longer than gunicorn's `--keep-alive 2`. During each idle
+gap, gunicorn closes its end of every pooled connection. With the bug
+present, keploy's two-goroutine io.Copy byte-pump doesn't notice the
+FIN, and the next burst's first request on each conn vanishes silently
+into a half-dead socket — surfaces here as either a write error
+(BrokenPipeError) or a hung getresponse() that the per-request timeout
+catches.
+
+Threshold gate: the script exits non-zero if the observed drop rate
+exceeds MAX_DROP_PCT (default 5%). Without the fix the drop rate is
+~25-50% (one stale-conn first-req per post-idle-gap burst per pooled
+conn). With the MSG_PEEK + replay-on-stale fix it is 0%.
+
+Deliberately uses http.client (no urllib3 / requests) — those
+libraries auto-retry on stale connections, which masks the bug.
+http.client raises and lets the test see the failure raw.
+"""
+import http.client
+import os
+import sys
+import time
+
+HOST = "127.0.0.1"
+PORT = 8080
+N_CONNS = 5
+BURSTS = 6
+REQS_PER_BURST_PER_CONN = 3
+IDLE_GAP_SEC = 5
+TIMEOUT_SEC = 10
+MAX_DROP_PCT = float(os.environ.get("MAX_DROP_PCT", "5"))
+
+
+def open_conn():
+    return http.client.HTTPConnection(HOST, PORT, timeout=TIMEOUT_SEC)
+
+
+conns = [open_conn() for _ in range(N_CONNS)]
+
+attempts = success = fail = 0
+fail_reasons = {}
+
+for burst in range(BURSTS):
+    if burst > 0:
+        # Idle gap longer than gunicorn --keep-alive 2 → backend
+        # closes its half of every pooled conn during this sleep.
+        # That is the load-bearing precondition for the bug.
+        print(f"  idle gap {IDLE_GAP_SEC}s before burst {burst}")
+        time.sleep(IDLE_GAP_SEC)
+
+    print(f"-- burst {burst}")
+    for r_idx in range(REQS_PER_BURST_PER_CONN):
+        for c_idx, c in enumerate(conns):
+            attempts += 1
+            try:
+                c.request("GET", "/api/echo")
+                resp = c.getresponse()
+                _ = resp.read()
+                if resp.status == 200:
+                    success += 1
+                else:
+                    fail += 1
+                    key = f"http_{resp.status}"
+                    fail_reasons[key] = fail_reasons.get(key, 0) + 1
+                    print(f"  burst={burst} c={c_idx} r={r_idx} {key}")
+            except Exception as exc:
+                fail += 1
+                key = f"err_{type(exc).__name__}"
+                fail_reasons[key] = fail_reasons.get(key, 0) + 1
+                print(f"  burst={burst} c={c_idx} r={r_idx} {key}: {exc}")
+                # Reopen the connection so subsequent reqs in this
+                # burst still have a usable socket. Mirrors what
+                # envoy / nginx / Go's Transport do on stale-detect.
+                try:
+                    c.close()
+                except Exception:
+                    pass
+                conns[c_idx] = open_conn()
+
+drop_pct = 100.0 * fail / attempts if attempts > 0 else 0.0
+print(
+    f"\n=== summary attempts={attempts} success={success} fail={fail} "
+    f"drop_pct={drop_pct:.1f}% reasons={fail_reasons}"
+)
+
+if drop_pct > MAX_DROP_PCT:
+    print(
+        f"::error::drop rate {drop_pct:.1f}% exceeds threshold "
+        f"{MAX_DROP_PCT}% — half-close race regression"
+    )
+    sys.exit(1)
+
+print(f"OK: drop rate {drop_pct:.1f}% within threshold {MAX_DROP_PCT}%")

--- a/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/main.py
+++ b/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/main.py
@@ -1,0 +1,27 @@
+"""Minimal Flask app for the http-stale-pool-race regression test.
+
+Run via gunicorn with the sync worker (default) and `--keep-alive 2`. The
+short keep-alive is the load-bearing config: it lets gunicorn close idle
+connections faster than the bursty client's idle gap, which exercises the
+upstream-pool half-close race in keploy's HTTP/1.1 ingress proxy.
+"""
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+
+@app.get("/api/health")
+def health():
+    return jsonify(status="ok")
+
+
+@app.get("/api/echo")
+def echo():
+    # Body is intentionally tiny — the test cares about per-request
+    # success/fail, not throughput. A small response keeps the kernel
+    # send buffer from masking write-failures on stale conns.
+    return jsonify(value="hello", note="stale-pool-regression")
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8080)

--- a/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/main.py
+++ b/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/main.py
@@ -1,9 +1,12 @@
 """Minimal Flask app for the http-stale-pool-race regression test.
 
-Run via gunicorn with the sync worker (default) and `--keep-alive 2`. The
-short keep-alive is the load-bearing config: it lets gunicorn close idle
-connections faster than the bursty client's idle gap, which exercises the
-upstream-pool half-close race in keploy's HTTP/1.1 ingress proxy.
+Run via gunicorn with `--worker-class gthread --threads 4 --keep-alive 2`.
+gthread is required: gunicorn's default `sync` worker silently disables
+HTTP keep-alive regardless of the `--keep-alive` flag, which means
+connections never persist across the bursty client's idle gap and the
+race we're trying to reproduce can't fire. gthread honors `--keep-alive`
+and closes idle pooled connections after 2s — exactly the asymmetric
+timeout that exposes keploy's upstream-pool half-close race.
 """
 from flask import Flask, jsonify
 

--- a/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/python-linux.sh
+++ b/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/python-linux.sh
@@ -33,8 +33,18 @@ source "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/test-iid.sh"
 
 cleanup() {
     echo "cleanup..."
-    sudo pkill -9 -f keploy 2>/dev/null || true
-    sudo pkill -9 -f gunicorn 2>/dev/null || true
+    # Match by process NAME (default pkill mode), NOT by full command
+    # line (-f). With -f, pkill's regex matches against the full
+    # argv of every process — including its own sudo parent (whose
+    # argv literally contains the pattern arg) and even this script's
+    # bash (whose argv path /home/runner/work/keploy/keploy/... +
+    # something downstream that matches). That self-match was killing
+    # the wrapping bash with SIGKILL after the test PASS, surfacing
+    # as exit 137 even on a successful run. Matching by `comm` (the
+    # bare executable name) hits keploy/gunicorn but never bash/sudo/
+    # pkill themselves.
+    sudo pkill -9 keploy 2>/dev/null || true
+    sudo pkill -9 gunicorn 2>/dev/null || true
     sleep 1
 }
 trap cleanup EXIT
@@ -83,9 +93,18 @@ python burst_client.py
 client_status=$?
 
 echo "=== stop keploy record cleanly ==="
-sudo pkill -INT -f 'keploy.*record' 2>/dev/null || true
+# Match by process NAME (no -f). Same reason as the trap cleanup:
+# `pkill -f 'keploy.*record'` self-matches its own sudo parent
+# because the regex pattern lives in sudo's argv, and Linux pkill -f
+# greedy-matches the regex against the joined cmdline of every
+# process in /proc — which on this CI runner happens to also kill
+# the wrapping bash with SIGKILL after the script's exit, surfacing
+# as a 137 even on a passing test run. `pkill keploy` matches by
+# `comm` (the bare executable name); only the actual keploy process
+# is hit.
+sudo pkill -INT keploy 2>/dev/null || true
 sleep 5
-sudo pkill -9 -f 'keploy.*record' 2>/dev/null || true
+sudo pkill -9 keploy 2>/dev/null || true
 sleep 2
 
 if grep -q 'WARNING: DATA RACE' record_logs.txt; then

--- a/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/python-linux.sh
+++ b/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/python-linux.sh
@@ -17,6 +17,13 @@
 # is ~25-50%; with the fix it is 0%.
 
 set -uo pipefail
+# Explicit set +e: even when this script is sourced from a bash step
+# that has -e enabled by default (GitHub Actions does this for `run:`
+# blocks), we want the burst-client invocation to NOT short-circuit
+# the script — `python burst_client.py` is followed by an explicit
+# `client_status=$?` capture and a cleanup-then-fail sequence that
+# only works without -e.
+set +e
 
 source "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/test-iid.sh"
 

--- a/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/python-linux.sh
+++ b/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/python-linux.sh
@@ -59,7 +59,6 @@ echo "=== start keploy record + gunicorn (gthread worker, --keep-alive 2) ==="
 $RECORD_BIN record \
     -c "gunicorn --bind 0.0.0.0:8080 --workers 2 --threads 4 --worker-class gthread --keep-alive 2 main:app" \
     > record_logs.txt 2>&1 &
-record_pid=$!
 
 echo "=== wait for app readiness ==="
 ready=0

--- a/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/python-linux.sh
+++ b/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/python-linux.sh
@@ -38,12 +38,15 @@ echo "=== generate keploy config ==="
 $RECORD_BIN config --generate
 rm -rf keploy/
 
-echo "=== start keploy record + gunicorn (sync worker, --keep-alive 2) ==="
-# Sync worker (default) so gunicorn's own keep-alive timer is
-# authoritative; UvicornWorker would override it. --keep-alive 2 is
-# the load-bearing setting.
+echo "=== start keploy record + gunicorn (gthread worker, --keep-alive 2) ==="
+# gthread is the load-bearing worker class here — gunicorn's default
+# (sync) silently DISABLES HTTP keep-alive regardless of --keep-alive,
+# so connections never persist across the burst gap and the bug
+# cannot manifest. gthread honors --keep-alive (closes idle conns
+# after 2s), which is exactly the asymmetric timeout that exposes
+# keploy's upstream-pool half-close race.
 $RECORD_BIN record \
-    -c "gunicorn --bind 0.0.0.0:8080 --workers 2 --keep-alive 2 main:app" \
+    -c "gunicorn --bind 0.0.0.0:8080 --workers 2 --threads 4 --worker-class gthread --keep-alive 2 main:app" \
     > record_logs.txt 2>&1 &
 record_pid=$!
 

--- a/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/python-linux.sh
+++ b/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/python-linux.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Regression test for the upstream-pool half-close race in keploy's
+# HTTP/1.1 ingress proxy (issue #4165, fix in handleHttp1ZeroCopy via
+# MSG_PEEK + replay-on-stale).
+#
+# Setup: gunicorn (sync worker, --keep-alive 2) sits behind keploy in
+# record mode. A bursty client (burst_client.py) opens N persistent
+# HTTP/1.1 connections to localhost:8080 and fires bursts with idle
+# gaps longer than gunicorn's keep-alive. Without the fix, keploy
+# silently drops the first request on each post-idle-gap burst because
+# its two-goroutine io.Copy byte-pump never notices the upstream FIN
+# during the gap. With the fix, MSG_PEEK detects the stale conn and
+# redials before forwarding the next request.
+#
+# Pass/fail is driven by burst_client.py's drop-rate gate
+# (MAX_DROP_PCT, default 5%). Without the fix the observed drop rate
+# is ~25-50%; with the fix it is 0%.
+
+set -uo pipefail
+
+source "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/test-iid.sh"
+
+cleanup() {
+    echo "cleanup..."
+    sudo pkill -9 -f keploy 2>/dev/null || true
+    sudo pkill -9 -f gunicorn 2>/dev/null || true
+    sleep 1
+}
+trap cleanup EXIT
+
+cd "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/python/http-stale-pool-race"
+
+echo "=== install python deps ==="
+python -m pip install --upgrade pip >/dev/null
+python -m pip install -r requirements.txt
+
+echo "=== generate keploy config ==="
+$RECORD_BIN config --generate
+rm -rf keploy/
+
+echo "=== start keploy record + gunicorn (sync worker, --keep-alive 2) ==="
+# Sync worker (default) so gunicorn's own keep-alive timer is
+# authoritative; UvicornWorker would override it. --keep-alive 2 is
+# the load-bearing setting.
+$RECORD_BIN record \
+    -c "gunicorn --bind 0.0.0.0:8080 --workers 2 --keep-alive 2 main:app" \
+    > record_logs.txt 2>&1 &
+record_pid=$!
+
+echo "=== wait for app readiness ==="
+ready=0
+for i in $(seq 1 40); do
+    if curl -fsS --max-time 3 http://127.0.0.1:8080/api/health >/dev/null 2>&1; then
+        echo "app up after $((i * 3))s"
+        ready=1
+        break
+    fi
+    sleep 3
+done
+
+if [ "$ready" -ne 1 ]; then
+    echo "::error::app did not become ready within 120s"
+    echo "=== record_logs.txt ==="
+    tail -100 record_logs.txt
+    exit 1
+fi
+
+echo "=== fire bursty load (burst_client.py gates pass/fail on drop rate) ==="
+python burst_client.py
+client_status=$?
+
+echo "=== stop keploy record cleanly ==="
+sudo pkill -INT -f 'keploy.*record' 2>/dev/null || true
+sleep 5
+sudo pkill -9 -f 'keploy.*record' 2>/dev/null || true
+sleep 2
+
+if grep -q 'WARNING: DATA RACE' record_logs.txt; then
+    echo "::error::data race detected in keploy"
+    tail -200 record_logs.txt
+    exit 1
+fi
+
+if [ $client_status -ne 0 ]; then
+    echo "::error::burst client exit=$client_status (drop rate exceeded threshold — bug NOT fixed)"
+    echo "=== last 100 lines of record_logs.txt ==="
+    tail -100 record_logs.txt
+    exit 1
+fi
+
+echo "PASS: bursty load completed within drop threshold under keploy record"

--- a/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/python-linux.sh
+++ b/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/python-linux.sh
@@ -3,14 +3,18 @@
 # HTTP/1.1 ingress proxy (issue #4165, fix in handleHttp1ZeroCopy via
 # MSG_PEEK + replay-on-stale).
 #
-# Setup: gunicorn (sync worker, --keep-alive 2) sits behind keploy in
-# record mode. A bursty client (burst_client.py) opens N persistent
-# HTTP/1.1 connections to localhost:8080 and fires bursts with idle
-# gaps longer than gunicorn's keep-alive. Without the fix, keploy
-# silently drops the first request on each post-idle-gap burst because
-# its two-goroutine io.Copy byte-pump never notices the upstream FIN
-# during the gap. With the fix, MSG_PEEK detects the stale conn and
-# redials before forwarding the next request.
+# Setup: gunicorn (gthread worker, 4 threads, --keep-alive 2) sits
+# behind keploy in record mode. gthread is required because gunicorn's
+# default sync worker silently disables HTTP keep-alive regardless of
+# --keep-alive, so connections never persist across the bursty client's
+# idle gap and the bug can't be reproduced. A bursty client
+# (burst_client.py) opens N persistent HTTP/1.1 connections to
+# localhost:8080 and fires bursts with idle gaps longer than gunicorn's
+# keep-alive. Without the fix, keploy silently drops the first request
+# on each post-idle-gap burst because its two-goroutine io.Copy
+# byte-pump never notices the upstream FIN during the gap. With the
+# fix, MSG_PEEK detects the stale conn and redials before forwarding
+# the next request.
 #
 # Pass/fail is driven by burst_client.py's drop-rate gate
 # (MAX_DROP_PCT, default 5%). Without the fix the observed drop rate

--- a/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/requirements.txt
+++ b/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/requirements.txt
@@ -1,0 +1,2 @@
+flask==3.0.3
+gunicorn==21.2.0

--- a/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/requirements.txt
+++ b/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/requirements.txt
@@ -1,2 +1,8 @@
 flask==3.0.3
-gunicorn==21.2.0
+# Pin to 25.3.0 to match the version mentioned in the PR description /
+# customer environment that originally surfaced the upstream-pool
+# half-close race (#4165). gthread + --keep-alive 2 behavior is the
+# same as 21.x, but keeping the pin aligned with the documented repro
+# version avoids "works on my machine" drift if a future maintainer
+# tries to reproduce the bug from the PR notes alone.
+gunicorn==25.3.0

--- a/pkg/agent/proxy/incoming/capture.go
+++ b/pkg/agent/proxy/incoming/capture.go
@@ -28,6 +28,28 @@ func newCaptureBuffer(limit int) *captureBuffer {
 
 func (b *captureBuffer) Write(p []byte) (int, error) {
 	b.total += int64(len(p))
+
+	// Once the buffer has been marked truncated (size limit hit OR
+	// memoryguard pause), keep accepting writes (so the tee'd reader
+	// keeps draining for forwarding) but don't grow the captured
+	// region further.
+	if b.truncated {
+		return len(p), nil
+	}
+
+	// Memory-pressure pause: if recording is paused, abort capture
+	// IMMEDIATELY and release the captured prefix for GC. Without
+	// this the tee keeps buffering up to maxHTTPBodyCaptureBytes
+	// after the agent has nominally stopped capturing — keeps memory
+	// pressure high during the very window memoryguard is trying to
+	// drain. The caller's Truncated() check then naturally drops the
+	// in-flight test case.
+	if isIngressRecordingPaused() {
+		b.truncated = true
+		b.buf = bytes.Buffer{}
+		return len(p), nil
+	}
+
 	if b.limit <= 0 {
 		b.truncated = true
 		return len(p), nil

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -1058,13 +1058,28 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 	upConnFresh := true
 
 	redial := func() error {
+		// Honor parent ctx — once cancellation has fired, the shutdown
+		// goroutine has closed the conns and any in-flight req.Write /
+		// ReadResponse failed with net.ErrClosed (which isStaleConnError
+		// classifies as stale). Without this short-circuit we'd then
+		// dial a fresh upstream during shutdown, generate one more
+		// pointless round-trip, and delay the connection teardown.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		// Close the previous conn via the holder so a concurrent
 		// shutdown sees a consistent view (either the old conn or the
 		// new one — never a torn pointer).
 		if h := upConnHolder.Load(); h != nil {
 			_ = h.c.Close()
 		}
-		newConn, err := net.DialTimeout("tcp4", upstreamAddr, 3*time.Second)
+		// DialContext (instead of DialTimeout) so an in-flight dial
+		// also gets cancelled when the parent ctx fires. The derived
+		// 3s deadline preserves the original per-dial timeout.
+		dialCtx, cancelDial := context.WithTimeout(ctx, 3*time.Second)
+		defer cancelDial()
+		var d net.Dialer
+		newConn, err := d.DialContext(dialCtx, "tcp4", upstreamAddr)
 		if err != nil {
 			return err
 		}

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"go.keploy.io/server/v3/pkg"
@@ -531,9 +532,12 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 	forceCloseMode := pm.synchronous
 
 	if !forceCloseMode {
-		// Sampling bypass: no lock, no capture — raw TCP passthrough.
+		// Sampling bypass: no capture, but route through the same
+		// request-framed path so we still get MSG_PEEK pool-liveness
+		// protection. Passing nil for the testcase channel suppresses
+		// capture inside handleHttp1ZeroCopy.
 		if pm.sampling && !acquiredLock {
-			forwardRawTCP(ctx, clientConn, upConn)
+			pm.handleHttp1ZeroCopy(ctx, clientConn, upConn, logger, nil, actualPort)
 			return
 		}
 		// Normal mode OR sampling-tracked: zero-copy TCP passthrough with
@@ -914,84 +918,326 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 	}
 }
 
-// handleHttp1ZeroCopy handles HTTP/1.x connections in normal (non-sync,
-// non-sampling) mode. It forwards raw TCP bytes bidirectionally between client
-// and upstream with zero HTTP parsing overhead on the critical path.
+// peekUpstreamLive returns false if the upstream socket has been closed by
+// the peer (FIN/RST already delivered to our kernel) or has unexpected data
+// queued. Implemented as one non-blocking recvfrom(MSG_PEEK|MSG_DONTWAIT) —
+// same liveness probe nginx uses in ngx_http_upstream_keepalive_close_handler.
 //
-// Capture is fully decoupled from forwarding: byte streams are piped through
-// non-blocking asyncPipeFeeders to a streaming parser (parseStreamingHTTP)
-// that emits test cases as soon as each HTTP exchange completes — without
-// waiting for the connection to close. When memory pressure is detected or
-// the capture size limit is reached, the feeders silently stop capturing
-// while forwarding continues unimpacted.
-func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientConn net.Conn, upConn net.Conn, logger *zap.Logger, t chan *models.TestCase, appPort uint16) {
-	logger.Debug("Using zero-copy TCP passthrough with streaming capture")
-
-	captureEnabled := !isIngressRecordingPaused()
-	var reqFeeder, respFeeder *asyncPipeFeeder
-	if captureEnabled {
-		// maxSize=0 disables the per-feeder total-bytes limit. With
-		// streaming capture the parser consumes data incrementally, so
-		// in-flight memory is bounded by the channel buffer plus one
-		// request/response body in the parser. The per-test-case size
-		// limit is enforced downstream in CaptureHook.
-		reqFeeder = newAsyncPipeFeeder(0, logger)
-		respFeeder = newAsyncPipeFeeder(0, logger)
-		go pm.parseStreamingHTTP(ctx, logger, reqFeeder, respFeeder, t, appPort)
+// This catches the "stale pool entry" race where the backend's short
+// keep-alive (gunicorn 2s) fires during an idle gap, our kernel receives
+// the FIN, but no goroutine has read the upstream socket since the last
+// response so we never noticed. Without this probe, the next request's
+// bytes get written into a half-dead pipe and vanish — surfacing
+// downstream as the customer's 503 + outlier ejection.
+func peekUpstreamLive(conn net.Conn) bool {
+	tc, ok := conn.(*net.TCPConn)
+	if !ok {
+		return true
 	}
+	sc, err := tc.SyscallConn()
+	if err != nil {
+		return true
+	}
+	alive := true
+	rcErr := sc.Read(func(fd uintptr) bool {
+		var buf [1]byte
+		n, _, perr := syscall.Recvfrom(int(fd), buf[:], syscall.MSG_PEEK|syscall.MSG_DONTWAIT)
+		switch {
+		case perr == syscall.EAGAIN || perr == syscall.EWOULDBLOCK:
+			alive = true // empty queue, socket healthy
+		case perr != nil:
+			alive = false // ECONNRESET, EPIPE, etc.
+		case n == 0:
+			alive = false // FIN already in our buffer
+		default:
+			alive = false // unexpected data on idle socket — evict
+		}
+		return true // tell SyscallConn we're done; don't block
+	})
+	if rcErr != nil {
+		return true // can't probe — let the actual write decide
+	}
+	return alive
+}
 
-	// Close connections on context cancellation (shutdown) to unblock
-	// the io.Copy goroutines. Without this, the function hangs until
-	// the remote side (e.g., upstream app's keep-alive) closes naturally.
-	// Same pattern used by the gRPC handler.
+func isHTTPUpgrade(req *http.Request) bool {
+	if req.Method == http.MethodConnect {
+		return true
+	}
+	if req.Header.Get("Upgrade") != "" {
+		return true
+	}
+	for _, v := range strings.Split(req.Header.Get("Connection"), ",") {
+		if strings.EqualFold(strings.TrimSpace(v), "upgrade") {
+			return true
+		}
+	}
+	return false
+}
+
+// isIdempotentMethod returns whether RFC 9110 §9.2.2 permits automatic
+// retry of the request after a stale-connection failure.
+func isIdempotentMethod(m string) bool {
+	switch m {
+	case http.MethodGet, http.MethodHead, http.MethodPut,
+		http.MethodDelete, http.MethodOptions, http.MethodTrace:
+		return true
+	}
+	return false
+}
+
+func writeBadGateway(c net.Conn) {
+	_, _ = c.Write([]byte("HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
+}
+
+// handleHttp1ZeroCopy handles HTTP/1.x connections in normal (non-sync,
+// non-sampling) mode.
+//
+// Architecture (Option 3 + MSG_PEEK + replay-on-stale): the function frames
+// HTTP/1.1 requests on the downstream so it can manage upstream connection
+// lifetime per request. Before reusing a pooled upstream conn it does one
+// non-blocking MSG_PEEK to detect already-delivered FIN/RST; on stale
+// detection it dials a fresh upstream. If the actual write to upstream
+// fails (residual race between peek and write), idempotent requests are
+// transparently replayed on a fresh conn — the canonical pattern used by
+// envoy (retry_on: reset-before-request), nginx (proxy_next_upstream), and
+// Go's net/http Transport (errServerClosedIdle).
+//
+// Downstream (envoy↔keploy) keep-alive is preserved across the entire
+// connection lifetime; only upstream conns get redialed on stale detect.
+func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientConn net.Conn, upConn net.Conn, logger *zap.Logger, t chan *models.TestCase, appPort uint16) {
+	logger.Debug("Using request-framed HTTP/1.1 proxy with MSG_PEEK pool liveness")
+
+	upstreamAddr := upConn.RemoteAddr().String()
+
+	// Tear down both conns on agent shutdown.
 	go func() {
 		<-ctx.Done()
-		clientConn.Close()
-		upConn.Close()
+		_ = clientConn.Close()
+		if upConn != nil {
+			_ = upConn.Close()
+		}
 	}()
 
-	done := make(chan struct{}, 2)
+	wireConn := &wireTimeConn{Conn: clientConn}
+	clientReader := bufio.NewReader(wireConn)
+	upstreamReader := bufio.NewReader(upConn)
+	// t == nil → caller (sampling-bypass path) wants MSG_PEEK protection
+	// without capture. Suppress capture for this connection's lifetime.
+	captureEnabled := t != nil && !isIngressRecordingPaused()
 
-	// client → upstream (with optional non-blocking side-copy for capture)
-	go func() {
-		var dst io.Writer = upConn
-		if reqFeeder != nil {
-			// Order matters: reqFeeder first samples time.Now() inside its
-			// Write before upConn forwards bytes to the app. This guarantees
-			// HTTP req timestamp ≤ forward instant ≤ any SQL the app fires
-			// in response — preserves causality between HTTP and DB stamps.
-			dst = io.MultiWriter(reqFeeder, upConn)
-		}
-		_, _ = io.Copy(dst, clientConn)
-		if reqFeeder != nil {
-			reqFeeder.Close()
-		}
-		if tc, ok := upConn.(*net.TCPConn); ok {
-			_ = tc.CloseWrite()
-		}
-		done <- struct{}{}
-	}()
+	// First request rides the pre-dialed upConn — we trust it because
+	// handleHttp1Connection just opened it. Subsequent iterations peek.
+	upConnFresh := true
 
-	// upstream → client (with optional non-blocking side-copy for capture)
-	go func() {
-		var dst io.Writer = clientConn
-		if respFeeder != nil {
-			dst = io.MultiWriter(clientConn, respFeeder)
+	redial := func() error {
+		if upConn != nil {
+			_ = upConn.Close()
 		}
-		_, _ = io.Copy(dst, upConn)
-		if respFeeder != nil {
-			respFeeder.Close()
+		newConn, err := net.DialTimeout("tcp4", upstreamAddr, 3*time.Second)
+		if err != nil {
+			return err
 		}
-		if tc, ok := clientConn.(*net.TCPConn); ok {
-			_ = tc.CloseWrite()
-		}
-		done <- struct{}{}
-	}()
+		upConn = newConn
+		upstreamReader = bufio.NewReader(upConn)
+		return nil
+	}
 
-	<-done
-	<-done
-	// No post-hoc parsing needed — test cases were emitted incrementally
-	// by parseStreamingHTTP as each HTTP exchange completed.
+	for {
+		if isIngressRecordingPaused() {
+			captureEnabled = false
+		}
+
+		iterStart := time.Now()
+		req, err := http.ReadRequest(clientReader)
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				logger.Debug("Client request read ended", zap.Error(err))
+			}
+			return
+		}
+		reqTimestamp := wireConn.LastReadTime()
+		if !reqTimestamp.After(iterStart) {
+			reqTimestamp = iterStart
+		}
+
+		// HTTP Upgrade / CONNECT — bail out to raw byte pump after
+		// forwarding the parsed handshake. Subsequent frames are not
+		// HTTP/1.1, so per-request framing breaks down.
+		if isHTTPUpgrade(req) {
+			if err := req.Write(upConn); err != nil {
+				logger.Debug("Failed to forward upgrade request", zap.Error(err))
+				return
+			}
+			forwardRawTCP(ctx, clientConn, upConn)
+			return
+		}
+
+		// MSG_PEEK before reusing a pooled upstream conn.
+		if !upConnFresh && !peekUpstreamLive(upConn) {
+			logger.Debug("Stale upstream pool entry detected (FIN in queue); redialing",
+				zap.String("upstream", upstreamAddr))
+			if err := redial(); err != nil {
+				logger.Error("Upstream redial after stale-detect failed",
+					zap.String("upstream", upstreamAddr), zap.Error(err))
+				writeBadGateway(clientConn)
+				if req.Body != nil {
+					_ = req.Body.Close()
+				}
+				return
+			}
+		}
+		upConnFresh = false
+
+		// Tee body for capture. Forwarding still works if the buffer
+		// truncates (captureBuffer.Write always reports len(p) bytes
+		// consumed regardless of internal limit).
+		captureEligible := captureEnabled
+		reqCapture := newCaptureBuffer(maxHTTPBodyCaptureBytes)
+		if captureEligible && req.Body != nil && req.Body != http.NoBody {
+			req.Body = newTeeReadCloser(req.Body, reqCapture)
+		}
+
+		// Forward request. On write failure, replay on a fresh upstream
+		// for idempotent methods only. The peek narrows the race; the
+		// replay catches the residual (FIN arrived between peek and
+		// write).
+		if err := req.Write(upConn); err != nil {
+			if req.Body != nil {
+				_ = req.Body.Close()
+			}
+			if isIdempotentMethod(req.Method) && !reqCapture.Truncated() {
+				logger.Debug("Idempotent request write failed; redial+replay",
+					zap.String("method", req.Method), zap.Error(err))
+				if rerr := redial(); rerr != nil {
+					writeBadGateway(clientConn)
+					return
+				}
+				// Replay from buffered body.
+				req.Body = io.NopCloser(bytes.NewReader(reqCapture.Bytes()))
+				if rerr := req.Write(upConn); rerr != nil {
+					logger.Error("Replay of idempotent request failed", zap.Error(rerr))
+					writeBadGateway(clientConn)
+					return
+				}
+				if req.Body != nil {
+					_ = req.Body.Close()
+				}
+			} else {
+				logger.Error("Forward of request to upstream failed",
+					zap.String("method", req.Method), zap.Error(err))
+				writeBadGateway(clientConn)
+				return
+			}
+		} else if req.Body != nil {
+			_ = req.Body.Close()
+		}
+
+		// Read response. Empty-response on idempotent methods is also
+		// classified as stale-conn; replay once.
+		resp, err := http.ReadResponse(upstreamReader, req)
+		if err != nil {
+			if isIdempotentMethod(req.Method) && !reqCapture.Truncated() {
+				logger.Debug("Empty response from upstream; redial+replay",
+					zap.String("method", req.Method), zap.Error(err))
+				if rerr := redial(); rerr != nil {
+					writeBadGateway(clientConn)
+					return
+				}
+				req.Body = io.NopCloser(bytes.NewReader(reqCapture.Bytes()))
+				if rerr := req.Write(upConn); rerr != nil {
+					writeBadGateway(clientConn)
+					return
+				}
+				if req.Body != nil {
+					_ = req.Body.Close()
+				}
+				resp, err = http.ReadResponse(upstreamReader, req)
+				if err != nil {
+					logger.Error("Replay response read failed", zap.Error(err))
+					writeBadGateway(clientConn)
+					return
+				}
+			} else {
+				logger.Error("Failed to read upstream response",
+					zap.Duration("time_since_request", time.Since(reqTimestamp)),
+					zap.Error(err))
+				return
+			}
+		}
+
+		captureEligible = captureEnabled
+		respCapture := newCaptureBuffer(maxHTTPBodyCaptureBytes)
+		if captureEligible && resp.Body != nil && resp.Body != http.NoBody {
+			resp.Body = newTeeReadCloser(resp.Body, respCapture)
+		}
+
+		respTimestamp := time.Now()
+
+		if err := resp.Write(clientConn); err != nil {
+			if resp.Body != nil {
+				_ = resp.Body.Close()
+			}
+			logger.Debug("Failed to forward response to client", zap.Error(err))
+			return
+		}
+		if resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+
+		// Async capture (matches synchronous-mode pattern at the call
+		// site below — keeps the proxy hot-loop free of dump+parse
+		// allocations under load).
+		if captureEnabled && !reqCapture.Truncated() && !respCapture.Truncated() {
+			select {
+			case captureHookSem <- struct{}{}:
+			case <-ctx.Done():
+				return
+			}
+
+			reqBodyBytes := reqCapture.Bytes()
+			respBodyBytes := respCapture.Bytes()
+			capturedReq := req
+			capturedResp := resp
+			capturedReqTS := reqTimestamp
+			capturedRespTS := respTimestamp
+			actualPort := appPort
+
+			go func() {
+				defer func() { <-captureHookSem }()
+
+				exchSize, err := capturedExchangeSize(capturedReq, capturedResp, reqBodyBytes, respBodyBytes)
+				if err != nil || exchSize > maxHTTPCombinedCaptureBytes {
+					return
+				}
+
+				reqData, err := dumpCapturedRequest(capturedReq, reqBodyBytes)
+				if err != nil {
+					return
+				}
+				parsedReq, err := pkg.ParseHTTPRequest(reqData)
+				if err != nil {
+					return
+				}
+				respData, err := dumpCapturedResponse(capturedResp, parsedReq, respBodyBytes)
+				if err != nil {
+					return
+				}
+				parsedResp, err := pkg.ParseHTTPResponse(respData, parsedReq)
+				if err != nil {
+					return
+				}
+				defer parsedReq.Body.Close()
+				defer parsedResp.Body.Close()
+				hooksUtils.CaptureHook(ctx, logger, t, parsedReq, parsedResp, capturedReqTS, capturedRespTS, pm.incomingOpts, pm.synchronous, pm.mapping, actualPort)
+			}()
+		}
+
+		// Honor close signals from either side.
+		if req.Close || resp.Close {
+			return
+		}
+	}
 }
 
 // parseStreamingHTTP reads from request and response feeders concurrently with

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -1032,7 +1032,13 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 		req, err := http.ReadRequest(clientReader)
 		if err != nil {
 			if !errors.Is(err, io.EOF) {
-				logger.Debug("Client request read ended", zap.Error(err))
+				// Malformed / truncated downstream request — surface a
+				// structured 400 so clients/proxies don't see a bare
+				// reset and misattribute it to upstream. EOF is the
+				// normal end-of-keep-alive close path; no response
+				// needed there.
+				logger.Debug("Failed to parse downstream HTTP request", zap.Error(err))
+				writeBadRequest(clientConn)
 			}
 			return
 		}
@@ -1117,11 +1123,16 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 				b, rerr := io.ReadAll(io.LimitReader(req.Body, req.ContentLength+1))
 				_ = req.Body.Close()
 				if rerr != nil {
+					// Failure reading the DOWNSTREAM client body —
+					// usually a client disconnect mid-body or a
+					// truncated request. This is not an upstream
+					// problem, so 400 (writeBadRequest) is the right
+					// status; 502 would misattribute it to the app.
 					logger.Error("Failed to read request body for replay-safe buffering. Possible client disconnect mid-body.",
 						zap.String("method", req.Method),
 						zap.Int64("content_length", req.ContentLength),
 						zap.Error(rerr))
-					writeBadGateway(clientConn)
+					writeBadRequest(clientConn)
 					return
 				}
 				if int64(len(b)) != req.ContentLength {

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -1074,6 +1074,32 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 				writeBadGateway(clientConn)
 				return
 			}
+			// Drain bytes already buffered in our bufio readers before
+			// switching to the raw byte pump. http.ReadRequest may
+			// have buffered post-headers bytes from the same TCP
+			// segment (e.g., a pipelined first WebSocket frame); on
+			// the upstream side, partial response bytes from a
+			// previous keep-alive iteration are theoretically possible
+			// too. forwardRawTCP reads directly from the underlying
+			// net.Conn and would silently drop anything sitting in the
+			// bufio buffers, corrupting upgraded connections.
+			if n := clientReader.Buffered(); n > 0 {
+				chunk, _ := clientReader.Peek(n)
+				if _, werr := upConn.Write(chunk); werr != nil {
+					logger.Debug("Failed to flush bufio-buffered upgrade bytes upstream",
+						zap.String("upstream", upstreamAddr), zap.Error(werr))
+					return
+				}
+				_, _ = clientReader.Discard(n)
+			}
+			if n := upstreamReader.Buffered(); n > 0 {
+				chunk, _ := upstreamReader.Peek(n)
+				if _, werr := clientConn.Write(chunk); werr != nil {
+					logger.Debug("Failed to flush bufio-buffered upgrade bytes downstream", zap.Error(werr))
+					return
+				}
+				_, _ = upstreamReader.Discard(n)
+			}
 			forwardRawTCP(ctx, clientConn, upConn)
 			return
 		}
@@ -1142,7 +1168,8 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 					// Request rather than 502 so downstream
 					// proxies/monitoring don't misattribute the failure
 					// to the app.
-					logger.Error("Request body length did not match Content-Length; treating as malformed client request.",
+					logger.Error("Request body length did not match declared Content-Length; treating as malformed client request. If this fires in production, check the downstream client/proxy for truncated uploads, mid-body disconnects, or an incorrectly computed Content-Length header on the request side.",
+						zap.String("method", req.Method),
 						zap.Int64("content_length", req.ContentLength),
 						zap.Int("bytes_read", len(b)))
 					writeBadRequest(clientConn)

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"go.keploy.io/server/v3/pkg"
@@ -916,48 +915,6 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 			return
 		}
 	}
-}
-
-// peekUpstreamLive returns false if the upstream socket has been closed by
-// the peer (FIN/RST already delivered to our kernel) or has unexpected data
-// queued. Implemented as one non-blocking recvfrom(MSG_PEEK|MSG_DONTWAIT) —
-// same liveness probe nginx uses in ngx_http_upstream_keepalive_close_handler.
-//
-// This catches the "stale pool entry" race where the backend's short
-// keep-alive (gunicorn 2s) fires during an idle gap, our kernel receives
-// the FIN, but no goroutine has read the upstream socket since the last
-// response so we never noticed. Without this probe, the next request's
-// bytes get written into a half-dead pipe and vanish — surfacing
-// downstream as the customer's 503 + outlier ejection.
-func peekUpstreamLive(conn net.Conn) bool {
-	tc, ok := conn.(*net.TCPConn)
-	if !ok {
-		return true
-	}
-	sc, err := tc.SyscallConn()
-	if err != nil {
-		return true
-	}
-	alive := true
-	rcErr := sc.Read(func(fd uintptr) bool {
-		var buf [1]byte
-		n, _, perr := syscall.Recvfrom(int(fd), buf[:], syscall.MSG_PEEK|syscall.MSG_DONTWAIT)
-		switch {
-		case perr == syscall.EAGAIN || perr == syscall.EWOULDBLOCK:
-			alive = true // empty queue, socket healthy
-		case perr != nil:
-			alive = false // ECONNRESET, EPIPE, etc.
-		case n == 0:
-			alive = false // FIN already in our buffer
-		default:
-			alive = false // unexpected data on idle socket — evict
-		}
-		return true // tell SyscallConn we're done; don't block
-	})
-	if rcErr != nil {
-		return true // can't probe — let the actual write decide
-	}
-	return alive
 }
 
 func isHTTPUpgrade(req *http.Request) bool {

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -967,13 +967,15 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 
 	upstreamAddr := upConn.RemoteAddr().String()
 
-	// Tear down both conns on agent shutdown.
+	// On agent shutdown, close ONLY the downstream conn. That unblocks
+	// the http.ReadRequest call in the loop below, which causes the
+	// loop to return, which triggers the function-exit defer (declared
+	// further down) that closes the current upstream conn. Closing
+	// upConn here too would race with redial()'s reassignment — the
+	// race detector flags it on overlapping shutdown+redial.
 	go func() {
 		<-ctx.Done()
 		_ = clientConn.Close()
-		if upConn != nil {
-			_ = upConn.Close()
-		}
 	}()
 
 	wireConn := &wireTimeConn{Conn: clientConn}

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -1131,22 +1131,23 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 			// too. forwardRawTCP reads directly from the underlying
 			// net.Conn and would silently drop anything sitting in the
 			// bufio buffers, corrupting upgraded connections.
+			//
+			// Use io.CopyN — it advances the bufio cursor as it reads
+			// (no separate Discard), and guarantees ALL N bytes are
+			// transferred before returning (handles short writes
+			// internally, unlike a single net.Conn.Write).
 			if n := clientReader.Buffered(); n > 0 {
-				chunk, _ := clientReader.Peek(n)
-				if _, werr := upConn.Write(chunk); werr != nil {
+				if _, werr := io.CopyN(upConn, clientReader, int64(n)); werr != nil {
 					logger.Debug("Failed to flush bufio-buffered upgrade bytes upstream",
 						zap.String("upstream", upstreamAddr), zap.Error(werr))
 					return
 				}
-				_, _ = clientReader.Discard(n)
 			}
 			if n := upstreamReader.Buffered(); n > 0 {
-				chunk, _ := upstreamReader.Peek(n)
-				if _, werr := clientConn.Write(chunk); werr != nil {
+				if _, werr := io.CopyN(clientConn, upstreamReader, int64(n)); werr != nil {
 					logger.Debug("Failed to flush bufio-buffered upgrade bytes downstream", zap.Error(werr))
 					return
 				}
-				_, _ = upstreamReader.Discard(n)
 			}
 			forwardRawTCP(ctx, clientConn, upConn)
 			return

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -947,6 +947,15 @@ func writeBadGateway(c net.Conn) {
 	_, _ = c.Write([]byte("HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
 }
 
+// writeBadRequest is the client-side counterpart to writeBadGateway:
+// 400-class so the failure isn't misattributed to the upstream by
+// downstream proxies / monitoring. Used when we detect a malformed
+// or truncated request from the downstream client (e.g.,
+// Content-Length mismatch during replay-safety pre-buffering).
+func writeBadRequest(c net.Conn) {
+	_, _ = c.Write([]byte("HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
+}
+
 // handleHttp1ZeroCopy handles HTTP/1.x connections in normal (non-sync,
 // non-sampling) mode.
 //
@@ -1116,13 +1125,16 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 					return
 				}
 				if int64(len(b)) != req.ContentLength {
-					// Client lied about Content-Length or hung up
-					// early — surface a 400-class error to be safe;
-					// 502 is the closest existing helper.
-					logger.Error("Request body length did not match Content-Length; not safe to replay.",
+					// Client lied about Content-Length or disconnected
+					// mid-body. This is a downstream-client protocol
+					// issue, not an upstream failure — return 400 Bad
+					// Request rather than 502 so downstream
+					// proxies/monitoring don't misattribute the failure
+					// to the app.
+					logger.Error("Request body length did not match Content-Length; treating as malformed client request.",
 						zap.Int64("content_length", req.ContentLength),
 						zap.Int("bytes_read", len(b)))
-					writeBadGateway(clientConn)
+					writeBadRequest(clientConn)
 					return
 				}
 				preBufferedReqBody = b

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -1009,6 +1009,10 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 	logger.Debug("Using request-framed HTTP/1.1 proxy with MSG_PEEK pool liveness")
 
 	upstreamAddr := upConn.RemoteAddr().String()
+	// Capture the network family of the original conn so redial uses
+	// the same one — hard-coding "tcp4" would break against an IPv6
+	// upstream and could mismatch a "tcp" dual-stack listener.
+	upstreamNetwork := upConn.RemoteAddr().Network()
 
 	// upConnHolder lets the ctx-cancel + function-exit goroutines safely
 	// close whatever the CURRENT upstream conn is, without racing with
@@ -1079,7 +1083,7 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 		dialCtx, cancelDial := context.WithTimeout(ctx, 3*time.Second)
 		defer cancelDial()
 		var d net.Dialer
-		newConn, err := d.DialContext(dialCtx, "tcp4", upstreamAddr)
+		newConn, err := d.DialContext(dialCtx, upstreamNetwork, upstreamAddr)
 		if err != nil {
 			return err
 		}
@@ -1257,10 +1261,13 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 		// we did, the buffer IS the captured body bytes). Forwarding
 		// still works if the buffer truncates (captureBuffer.Write
 		// always reports len(p) bytes consumed regardless of internal
-		// limit).
+		// limit). Allocate the buffer lazily — if capture is disabled
+		// or the body is already pre-buffered or absent, we never
+		// touch reqCapture, so don't pay the per-request alloc.
 		captureEligible := captureEnabled
-		reqCapture := newCaptureBuffer(maxHTTPBodyCaptureBytes)
+		var reqCapture *captureBuffer
 		if captureEligible && preBufferedReqBody == nil && req.Body != nil && req.Body != http.NoBody {
+			reqCapture = newCaptureBuffer(maxHTTPBodyCaptureBytes)
 			req.Body = newTeeReadCloser(req.Body, reqCapture)
 		}
 
@@ -1380,8 +1387,9 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 		}
 
 		captureEligible = captureEnabled
-		respCapture := newCaptureBuffer(maxHTTPBodyCaptureBytes)
+		var respCapture *captureBuffer
 		if captureEligible && resp.Body != nil && resp.Body != http.NoBody {
+			respCapture = newCaptureBuffer(maxHTTPBodyCaptureBytes)
 			resp.Body = newTeeReadCloser(resp.Body, respCapture)
 		}
 
@@ -1410,9 +1418,13 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 		// allocations under load). Body source preference:
 		// preBufferedReqBody (eager-buffered for replay safety; always
 		// the exact bytes the upstream saw) → reqCapture (tee on the
-		// streaming path).
-		reqTeeTruncated := preBufferedReqBody == nil && reqCapture.Truncated()
-		if captureEnabled && !reqTeeTruncated && !respCapture.Truncated() {
+		// streaming path) → nil (no body / capture disabled).
+		// reqCapture / respCapture may be nil when we skipped the
+		// per-request alloc (capture disabled, body absent, or body
+		// pre-buffered).
+		reqTeeTruncated := reqCapture != nil && reqCapture.Truncated()
+		respTeeTruncated := respCapture != nil && respCapture.Truncated()
+		if captureEnabled && !reqTeeTruncated && !respTeeTruncated {
 			select {
 			case captureHookSem <- struct{}{}:
 			case <-ctx.Done():
@@ -1420,12 +1432,16 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 			}
 
 			var reqBodyBytes []byte
-			if preBufferedReqBody != nil {
+			switch {
+			case preBufferedReqBody != nil:
 				reqBodyBytes = preBufferedReqBody
-			} else {
+			case reqCapture != nil:
 				reqBodyBytes = reqCapture.Bytes()
 			}
-			respBodyBytes := respCapture.Bytes()
+			var respBodyBytes []byte
+			if respCapture != nil {
+				respBodyBytes = respCapture.Bytes()
+			}
 			capturedReq := req
 			capturedResp := resp
 			capturedReqTS := reqTimestamp

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -949,9 +949,11 @@ func isIdempotentMethod(m string) bool {
 // opposed to a deterministic protocol/parse failure (where replay
 // would just re-trigger the same bad response). EOF / unexpected EOF
 // / connection reset / broken pipe / "use of closed network
-// connection" all map to "the conn died, try a fresh one"; everything
-// else (e.g., http.ReadResponse rejecting a malformed status line) is
-// not retried.
+// connection" / connection aborted all map to "the conn died, try a
+// fresh one"; everything else — including timeouts (Timeout()=true on
+// the wrapping net.OpError) and protocol-parse errors — is not
+// retried, since those typically indicate a deterministic upstream
+// failure that replay would just re-trigger and double-charge.
 func isStaleConnError(err error) bool {
 	if err == nil {
 		return false
@@ -959,16 +961,17 @@ func isStaleConnError(err error) bool {
 	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 		return true
 	}
-	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) {
+	// Specific syscall errors that propagate via net.OpError's Unwrap
+	// chain (errors.Is recurses through it). Timeouts deliberately
+	// not included — a slow upstream isn't a stale-pool case and
+	// replay would just re-pay the timeout while double-charging the
+	// upstream for the original.
+	if errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, syscall.ECONNABORTED) {
 		return true
 	}
 	if errors.Is(err, net.ErrClosed) {
-		return true
-	}
-	// net.OpError without a recognized syscall cause: treat as
-	// transport-layer failure (e.g., kernel-side connection abort).
-	var opErr *net.OpError
-	if errors.As(err, &opErr) {
 		return true
 	}
 	return false

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -1034,8 +1034,27 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 		// forwarding the parsed handshake. Subsequent frames are not
 		// HTTP/1.1, so per-request framing breaks down.
 		if isHTTPUpgrade(req) {
+			// Pool-liveness probe applies here too: an Upgrade on a
+			// reused-but-stale conn would silently swallow the
+			// handshake and leave the client hanging.
+			if !upConnFresh && !peekUpstreamLive(upConn) {
+				logger.Debug("Stale upstream pool entry detected before upgrade; redialing",
+					zap.String("upstream", upstreamAddr))
+				if rerr := redial(); rerr != nil {
+					logger.Error("Upstream redial before upgrade failed. Verify the application is still listening on the resolved address.",
+						zap.String("upstream", upstreamAddr), zap.Error(rerr))
+					writeBadGateway(clientConn)
+					return
+				}
+			}
+			upConnFresh = false
 			if err := req.Write(upConn); err != nil {
-				logger.Debug("Failed to forward upgrade request", zap.Error(err))
+				logger.Error("Failed to forward upgrade request to upstream. Verify upstream supports the requested upgrade and is listening on the resolved address.",
+					zap.String("method", req.Method),
+					zap.String("upgrade", req.Header.Get("Upgrade")),
+					zap.String("upstream", upstreamAddr),
+					zap.Error(err))
+				writeBadGateway(clientConn)
 				return
 			}
 			forwardRawTCP(ctx, clientConn, upConn)
@@ -1058,12 +1077,71 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 		}
 		upConnFresh = false
 
-		// Tee body for capture. Forwarding still works if the buffer
-		// truncates (captureBuffer.Write always reports len(p) bytes
-		// consumed regardless of internal limit).
+		// Replay-safety pre-buffering. Replaying an idempotent request
+		// is only safe when we can resend the EXACT bytes that were
+		// (or would have been) on the wire — gating on
+		// reqCapture.Truncated() is insufficient because (a) the tee
+		// is not attached on the sampling-bypass path (t == nil), so
+		// reqCapture would be empty and we'd resend an empty body; and
+		// (b) a mid-body write failure would leave reqCapture holding
+		// only a prefix, so replay would resend a partial body.
+		//
+		// For idempotent methods with a known-bounded body, eagerly
+		// drain it into a buffer up-front. The buffer becomes the
+		// single source of truth for both the initial write and any
+		// replay. For unknown-length (chunked) or oversized bodies we
+		// can't safely buffer, so replay is disabled and forwarding
+		// stays streaming.
+		var preBufferedReqBody []byte
+		canReplay := false
+		if isIdempotentMethod(req.Method) {
+			switch {
+			case req.Body == nil || req.Body == http.NoBody || req.ContentLength == 0:
+				// No body — replay is trivially safe.
+				canReplay = true
+			case req.ContentLength > 0 && req.ContentLength <= int64(maxHTTPBodyCaptureBytes):
+				// Known-small body — buffer fully. Use ContentLength+1
+				// as the read cap so an upstream lying about
+				// Content-Length doesn't OOM us.
+				b, rerr := io.ReadAll(io.LimitReader(req.Body, req.ContentLength+1))
+				_ = req.Body.Close()
+				if rerr != nil {
+					logger.Error("Failed to read request body for replay-safe buffering. Possible client disconnect mid-body.",
+						zap.String("method", req.Method),
+						zap.Int64("content_length", req.ContentLength),
+						zap.Error(rerr))
+					writeBadGateway(clientConn)
+					return
+				}
+				if int64(len(b)) != req.ContentLength {
+					// Client lied about Content-Length or hung up
+					// early — surface a 400-class error to be safe;
+					// 502 is the closest existing helper.
+					logger.Error("Request body length did not match Content-Length; not safe to replay.",
+						zap.Int64("content_length", req.ContentLength),
+						zap.Int("bytes_read", len(b)))
+					writeBadGateway(clientConn)
+					return
+				}
+				preBufferedReqBody = b
+				req.Body = io.NopCloser(bytes.NewReader(b))
+				canReplay = true
+			default:
+				// Unknown-length (chunked) or known-too-large body.
+				// Stream-forward but disable replay — partial-body
+				// replay would be worse than a clean 502.
+				canReplay = false
+			}
+		}
+
+		// Tee body for capture (only when we did NOT pre-buffer; if
+		// we did, the buffer IS the captured body bytes). Forwarding
+		// still works if the buffer truncates (captureBuffer.Write
+		// always reports len(p) bytes consumed regardless of internal
+		// limit).
 		captureEligible := captureEnabled
 		reqCapture := newCaptureBuffer(maxHTTPBodyCaptureBytes)
-		if captureEligible && req.Body != nil && req.Body != http.NoBody {
+		if captureEligible && preBufferedReqBody == nil && req.Body != nil && req.Body != http.NoBody {
 			req.Body = newTeeReadCloser(req.Body, reqCapture)
 		}
 
@@ -1075,7 +1153,7 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 			if req.Body != nil {
 				_ = req.Body.Close()
 			}
-			if isIdempotentMethod(req.Method) && !reqCapture.Truncated() {
+			if canReplay {
 				logger.Debug("Idempotent request write failed; redial+replay",
 					zap.String("method", req.Method), zap.Error(err))
 				if rerr := redial(); rerr != nil {
@@ -1084,8 +1162,15 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 					writeBadGateway(clientConn)
 					return
 				}
-				// Replay from buffered body.
-				req.Body = io.NopCloser(bytes.NewReader(reqCapture.Bytes()))
+				// Replay from the pre-buffered body (or no body if
+				// none was sent). Using preBufferedReqBody is what
+				// makes this safe — reqCapture may be partial or
+				// empty depending on capture state and write timing.
+				if preBufferedReqBody != nil {
+					req.Body = io.NopCloser(bytes.NewReader(preBufferedReqBody))
+				} else {
+					req.Body = http.NoBody
+				}
 				if rerr := req.Write(upConn); rerr != nil {
 					logger.Error("Replay of idempotent request failed after redial; upstream may be unhealthy or rejecting writes. Check application status and recent restarts on the resolved address.",
 						zap.String("method", req.Method), zap.String("upstream", upstreamAddr), zap.Error(rerr))
@@ -1096,15 +1181,15 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 					_ = req.Body.Close()
 				}
 			} else {
-				// Non-idempotent or oversized body: cannot safely replay
-				// per RFC 9110 §9.2.2 / capture budget. Surface a 502
-				// to the client and tear down so envoy doesn't reuse
-				// this conn.
-				logger.Error("Forward of request to upstream failed and request is not safely replayable (non-idempotent method or body exceeded capture budget). Verify upstream health on the resolved address.",
+				// Non-idempotent, unknown-length body, or oversized
+				// body: cannot safely replay per RFC 9110 §9.2.2.
+				// Surface a 502 to the client and tear down so envoy
+				// doesn't reuse this conn.
+				logger.Error("Forward of request to upstream failed and request is not safely replayable (non-idempotent method or body cannot be re-sent). Verify upstream health on the resolved address.",
 					zap.String("method", req.Method),
 					zap.String("upstream", upstreamAddr),
 					zap.Bool("idempotent", isIdempotentMethod(req.Method)),
-					zap.Bool("body_truncated", reqCapture.Truncated()),
+					zap.Int64("content_length", req.ContentLength),
 					zap.Error(err))
 				writeBadGateway(clientConn)
 				return
@@ -1114,10 +1199,14 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 		}
 
 		// Read response. Empty-response on idempotent methods is also
-		// classified as stale-conn; replay once.
+		// classified as stale-conn; replay once. canReplay is the
+		// authoritative gate (see preBufferedReqBody comment above) —
+		// don't fall back to reqCapture.Truncated() here because it
+		// can be empty even in safe-to-replay cases (capture disabled
+		// on the sampling-bypass path).
 		resp, err := http.ReadResponse(upstreamReader, req)
 		if err != nil {
-			if isIdempotentMethod(req.Method) && !reqCapture.Truncated() {
+			if canReplay {
 				logger.Debug("Empty response from upstream; redial+replay",
 					zap.String("method", req.Method), zap.Error(err))
 				if rerr := redial(); rerr != nil {
@@ -1126,7 +1215,11 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 					writeBadGateway(clientConn)
 					return
 				}
-				req.Body = io.NopCloser(bytes.NewReader(reqCapture.Bytes()))
+				if preBufferedReqBody != nil {
+					req.Body = io.NopCloser(bytes.NewReader(preBufferedReqBody))
+				} else {
+					req.Body = http.NoBody
+				}
 				if rerr := req.Write(upConn); rerr != nil {
 					logger.Error("Replay request write failed after redial; upstream may be unhealthy. Check application status on the resolved address.",
 						zap.String("method", req.Method), zap.String("upstream", upstreamAddr), zap.Error(rerr))
@@ -1144,15 +1237,15 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 					return
 				}
 			} else {
-				// Non-idempotent or oversized body: surface 502 so the
-				// downstream client doesn't see a silent connection
-				// close (which presents as a confusing reset/hang
-				// rather than a structured 502).
+				// Non-idempotent, unknown-length, or oversized body:
+				// surface 502 so the downstream client doesn't see a
+				// silent connection close (which presents as a
+				// confusing reset/hang rather than a structured 502).
 				logger.Error("Failed to read upstream response and request is not safely replayable. Verify upstream application health on the resolved address.",
 					zap.String("method", req.Method),
 					zap.String("upstream", upstreamAddr),
 					zap.Bool("idempotent", isIdempotentMethod(req.Method)),
-					zap.Bool("body_truncated", reqCapture.Truncated()),
+					zap.Int64("content_length", req.ContentLength),
 					zap.Duration("time_since_request", time.Since(reqTimestamp)),
 					zap.Error(err))
 				writeBadGateway(clientConn)
@@ -1188,15 +1281,24 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 
 		// Async capture (matches synchronous-mode pattern at the call
 		// site below — keeps the proxy hot-loop free of dump+parse
-		// allocations under load).
-		if captureEnabled && !reqCapture.Truncated() && !respCapture.Truncated() {
+		// allocations under load). Body source preference:
+		// preBufferedReqBody (eager-buffered for replay safety; always
+		// the exact bytes the upstream saw) → reqCapture (tee on the
+		// streaming path).
+		reqTeeTruncated := preBufferedReqBody == nil && reqCapture.Truncated()
+		if captureEnabled && !reqTeeTruncated && !respCapture.Truncated() {
 			select {
 			case captureHookSem <- struct{}{}:
 			case <-ctx.Done():
 				return
 			}
 
-			reqBodyBytes := reqCapture.Bytes()
+			var reqBodyBytes []byte
+			if preBufferedReqBody != nil {
+				reqBodyBytes = preBufferedReqBody
+			} else {
+				reqBodyBytes = reqCapture.Bytes()
+			}
 			respBodyBytes := respCapture.Bytes()
 			capturedReq := req
 			capturedResp := resp

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"go.keploy.io/server/v3/pkg"
@@ -943,6 +944,36 @@ func isIdempotentMethod(m string) bool {
 	return false
 }
 
+// isStaleConnError reports whether err looks like an upstream
+// connection-drop (the case replay-on-stale was designed for) as
+// opposed to a deterministic protocol/parse failure (where replay
+// would just re-trigger the same bad response). EOF / unexpected EOF
+// / connection reset / broken pipe / "use of closed network
+// connection" all map to "the conn died, try a fresh one"; everything
+// else (e.g., http.ReadResponse rejecting a malformed status line) is
+// not retried.
+func isStaleConnError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) {
+		return true
+	}
+	if errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	// net.OpError without a recognized syscall cause: treat as
+	// transport-layer failure (e.g., kernel-side connection abort).
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return true
+	}
+	return false
+}
+
 func writeBadGateway(c net.Conn) {
 	_, _ = c.Write([]byte("HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
 }
@@ -976,15 +1007,27 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 
 	upstreamAddr := upConn.RemoteAddr().String()
 
-	// On agent shutdown, close ONLY the downstream conn. That unblocks
-	// the http.ReadRequest call in the loop below, which causes the
-	// loop to return, which triggers the function-exit defer (declared
-	// further down) that closes the current upstream conn. Closing
-	// upConn here too would race with redial()'s reassignment — the
-	// race detector flags it on overlapping shutdown+redial.
+	// upConnHolder lets the ctx-cancel + function-exit goroutines safely
+	// close whatever the CURRENT upstream conn is, without racing with
+	// redial()'s reassignment. The main loop still uses the local upConn
+	// variable for fast access (no atomic load on the hot path); redial
+	// is responsible for keeping the holder in sync.
+	type connHolder struct{ c net.Conn }
+	var upConnHolder atomic.Pointer[connHolder]
+	upConnHolder.Store(&connHolder{c: upConn})
+
+	// On agent shutdown, close BOTH conns: closing the downstream
+	// unblocks http.ReadRequest in the loop's read phase; closing the
+	// upstream unblocks http.ReadResponse / req.Write if the loop is
+	// stuck in upstream I/O on a hung backend. Race-safe via the
+	// atomic — we always close whatever connHolder pointer is current,
+	// even if redial swapped it concurrently.
 	go func() {
 		<-ctx.Done()
 		_ = clientConn.Close()
+		if h := upConnHolder.Load(); h != nil {
+			_ = h.c.Close()
+		}
 	}()
 
 	wireConn := &wireTimeConn{Conn: clientConn}
@@ -998,11 +1041,12 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 	// (handleHttp1Connection) defers Close on its own copy of the original
 	// upConn, but redial() replaces this function's local upConn — so
 	// without this defer, every successful redial leaks the freshly dialed
-	// socket until ctx is cancelled. The closure captures upConn by
-	// reference, so it always closes the latest one.
+	// socket until ctx is cancelled. Reads from the holder so it always
+	// targets the latest conn (the local upConn could be stale if redial
+	// happened mid-iteration).
 	defer func() {
-		if upConn != nil {
-			_ = upConn.Close()
+		if h := upConnHolder.Load(); h != nil {
+			_ = h.c.Close()
 		}
 	}()
 
@@ -1011,8 +1055,11 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 	upConnFresh := true
 
 	redial := func() error {
-		if upConn != nil {
-			_ = upConn.Close()
+		// Close the previous conn via the holder so a concurrent
+		// shutdown sees a consistent view (either the old conn or the
+		// new one — never a torn pointer).
+		if h := upConnHolder.Load(); h != nil {
+			_ = h.c.Close()
 		}
 		newConn, err := net.DialTimeout("tcp4", upstreamAddr, 3*time.Second)
 		if err != nil {
@@ -1020,6 +1067,7 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 		}
 		upConn = newConn
 		upstreamReader = bufio.NewReader(upConn)
+		upConnHolder.Store(&connHolder{c: newConn})
 		return nil
 	}
 
@@ -1256,9 +1304,16 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 		// don't fall back to reqCapture.Truncated() here because it
 		// can be empty even in safe-to-replay cases (capture disabled
 		// on the sampling-bypass path).
+		//
+		// Replay only when the error LOOKS like a connection drop
+		// (isStaleConnError). A protocol/parse error from
+		// http.ReadResponse (malformed status line, bad headers) is
+		// deterministic — replaying just produces the same bad
+		// response and double-charges the upstream for an idempotent
+		// request that's not even getting through.
 		resp, err := http.ReadResponse(upstreamReader, req)
 		if err != nil {
-			if canReplay {
+			if canReplay && isStaleConnError(err) {
 				logger.Debug("Empty response from upstream; redial+replay",
 					zap.String("method", req.Method), zap.Error(err))
 				if rerr := redial(); rerr != nil {

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -983,6 +983,18 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 	// without capture. Suppress capture for this connection's lifetime.
 	captureEnabled := t != nil && !isIngressRecordingPaused()
 
+	// Close the most recent upstream conn on function return. The caller
+	// (handleHttp1Connection) defers Close on its own copy of the original
+	// upConn, but redial() replaces this function's local upConn — so
+	// without this defer, every successful redial leaks the freshly dialed
+	// socket until ctx is cancelled. The closure captures upConn by
+	// reference, so it always closes the latest one.
+	defer func() {
+		if upConn != nil {
+			_ = upConn.Close()
+		}
+	}()
+
 	// First request rides the pre-dialed upConn — we trust it because
 	// handleHttp1Connection just opened it. Subsequent iterations peek.
 	upConnFresh := true
@@ -1035,7 +1047,7 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 			logger.Debug("Stale upstream pool entry detected (FIN in queue); redialing",
 				zap.String("upstream", upstreamAddr))
 			if err := redial(); err != nil {
-				logger.Error("Upstream redial after stale-detect failed",
+				logger.Error("Upstream redial after stale-detect failed. Verify the application is still listening on the resolved address and that the network path between the agent and upstream is healthy.",
 					zap.String("upstream", upstreamAddr), zap.Error(err))
 				writeBadGateway(clientConn)
 				if req.Body != nil {
@@ -1067,13 +1079,16 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 				logger.Debug("Idempotent request write failed; redial+replay",
 					zap.String("method", req.Method), zap.Error(err))
 				if rerr := redial(); rerr != nil {
+					logger.Error("Replay redial after request-write failure failed. Verify the upstream application is still listening on the resolved address.",
+						zap.String("upstream", upstreamAddr), zap.Error(rerr))
 					writeBadGateway(clientConn)
 					return
 				}
 				// Replay from buffered body.
 				req.Body = io.NopCloser(bytes.NewReader(reqCapture.Bytes()))
 				if rerr := req.Write(upConn); rerr != nil {
-					logger.Error("Replay of idempotent request failed", zap.Error(rerr))
+					logger.Error("Replay of idempotent request failed after redial; upstream may be unhealthy or rejecting writes. Check application status and recent restarts on the resolved address.",
+						zap.String("method", req.Method), zap.String("upstream", upstreamAddr), zap.Error(rerr))
 					writeBadGateway(clientConn)
 					return
 				}
@@ -1081,8 +1096,16 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 					_ = req.Body.Close()
 				}
 			} else {
-				logger.Error("Forward of request to upstream failed",
-					zap.String("method", req.Method), zap.Error(err))
+				// Non-idempotent or oversized body: cannot safely replay
+				// per RFC 9110 §9.2.2 / capture budget. Surface a 502
+				// to the client and tear down so envoy doesn't reuse
+				// this conn.
+				logger.Error("Forward of request to upstream failed and request is not safely replayable (non-idempotent method or body exceeded capture budget). Verify upstream health on the resolved address.",
+					zap.String("method", req.Method),
+					zap.String("upstream", upstreamAddr),
+					zap.Bool("idempotent", isIdempotentMethod(req.Method)),
+					zap.Bool("body_truncated", reqCapture.Truncated()),
+					zap.Error(err))
 				writeBadGateway(clientConn)
 				return
 			}
@@ -1098,11 +1121,15 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 				logger.Debug("Empty response from upstream; redial+replay",
 					zap.String("method", req.Method), zap.Error(err))
 				if rerr := redial(); rerr != nil {
+					logger.Error("Replay redial after empty-response failed. Verify the upstream application is still listening on the resolved address.",
+						zap.String("upstream", upstreamAddr), zap.Error(rerr))
 					writeBadGateway(clientConn)
 					return
 				}
 				req.Body = io.NopCloser(bytes.NewReader(reqCapture.Bytes()))
 				if rerr := req.Write(upConn); rerr != nil {
+					logger.Error("Replay request write failed after redial; upstream may be unhealthy. Check application status on the resolved address.",
+						zap.String("method", req.Method), zap.String("upstream", upstreamAddr), zap.Error(rerr))
 					writeBadGateway(clientConn)
 					return
 				}
@@ -1111,14 +1138,24 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 				}
 				resp, err = http.ReadResponse(upstreamReader, req)
 				if err != nil {
-					logger.Error("Replay response read failed", zap.Error(err))
+					logger.Error("Replay response read failed; upstream returned no response on the redialed connection either. Check application logs for crashes/restarts.",
+						zap.String("upstream", upstreamAddr), zap.Error(err))
 					writeBadGateway(clientConn)
 					return
 				}
 			} else {
-				logger.Error("Failed to read upstream response",
+				// Non-idempotent or oversized body: surface 502 so the
+				// downstream client doesn't see a silent connection
+				// close (which presents as a confusing reset/hang
+				// rather than a structured 502).
+				logger.Error("Failed to read upstream response and request is not safely replayable. Verify upstream application health on the resolved address.",
+					zap.String("method", req.Method),
+					zap.String("upstream", upstreamAddr),
+					zap.Bool("idempotent", isIdempotentMethod(req.Method)),
+					zap.Bool("body_truncated", reqCapture.Truncated()),
 					zap.Duration("time_since_request", time.Since(reqTimestamp)),
 					zap.Error(err))
+				writeBadGateway(clientConn)
 				return
 			}
 		}
@@ -1128,8 +1165,6 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 		if captureEligible && resp.Body != nil && resp.Body != http.NoBody {
 			resp.Body = newTeeReadCloser(resp.Body, respCapture)
 		}
-
-		respTimestamp := time.Now()
 
 		if err := resp.Write(clientConn); err != nil {
 			if resp.Body != nil {
@@ -1141,6 +1176,15 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 		if resp.Body != nil {
 			_ = resp.Body.Close()
 		}
+
+		// Last-byte semantics for respTimestamp: capture AFTER resp.Write
+		// has drained the upstream body and forwarded it to the client.
+		// This matches the parseStreamingHTTP doc invariant
+		// (reqTimestamp ≤ outbound-mock-timestamp ≤ respTimestamp): any
+		// DB-side mocks the app fired while streaming the response body
+		// stamp before time.Now() here, so they fall inside the per-test
+		// window and match correctly at replay.
+		respTimestamp := time.Now()
 
 		// Async capture (matches synchronous-mode pattern at the call
 		// site below — keeps the proxy hot-loop free of dump+parse

--- a/pkg/agent/proxy/incoming/peek_unix.go
+++ b/pkg/agent/proxy/incoming/peek_unix.go
@@ -37,18 +37,29 @@ func peekUpstreamLive(conn net.Conn) bool {
 	alive := true
 	rcErr := sc.Read(func(fd uintptr) bool {
 		var buf [1]byte
-		n, _, perr := syscall.Recvfrom(int(fd), buf[:], syscall.MSG_PEEK|syscall.MSG_DONTWAIT)
-		switch {
-		case perr == syscall.EAGAIN || perr == syscall.EWOULDBLOCK:
-			alive = true // empty queue, socket healthy
-		case perr != nil:
-			alive = false // ECONNRESET, EPIPE, etc.
-		case n == 0:
-			alive = false // FIN already in our buffer
-		default:
-			alive = false // unexpected data on idle socket — evict
+		// Loop on EINTR — a signal-interrupted recvfrom doesn't say
+		// anything about the socket's health; treating it as dead
+		// would spuriously evict pooled conns. Returning `false` from
+		// this callback would make SyscallConn block waiting for the
+		// fd to become readable (the wrong semantic for a non-blocking
+		// peek), so we just retry the syscall in place.
+		for {
+			n, _, perr := syscall.Recvfrom(int(fd), buf[:], syscall.MSG_PEEK|syscall.MSG_DONTWAIT)
+			if perr == syscall.EINTR {
+				continue
+			}
+			switch {
+			case perr == syscall.EAGAIN || perr == syscall.EWOULDBLOCK:
+				alive = true // empty queue, socket healthy
+			case perr != nil:
+				alive = false // ECONNRESET, EPIPE, etc.
+			case n == 0:
+				alive = false // FIN already in our buffer
+			default:
+				alive = false // unexpected data on idle socket — evict
+			}
+			return true // tell SyscallConn we're done; don't block
 		}
-		return true // tell SyscallConn we're done; don't block
 	})
 	if rcErr != nil {
 		return true // can't probe — let the actual write decide

--- a/pkg/agent/proxy/incoming/peek_unix.go
+++ b/pkg/agent/proxy/incoming/peek_unix.go
@@ -1,0 +1,50 @@
+//go:build !windows
+
+package proxy
+
+import (
+	"net"
+	"syscall"
+)
+
+// peekUpstreamLive returns false if the upstream socket has been closed by
+// the peer (FIN/RST already delivered to our kernel) or has unexpected data
+// queued. Implemented as one non-blocking recvfrom(MSG_PEEK|MSG_DONTWAIT) —
+// same liveness probe nginx uses in ngx_http_upstream_keepalive_close_handler.
+//
+// This catches the "stale pool entry" race where the backend's short
+// keep-alive (gunicorn 2s) fires during an idle gap, our kernel receives
+// the FIN, but no goroutine has read the upstream socket since the last
+// response so we never noticed. Without this probe, the next request's
+// bytes get written into a half-dead pipe and vanish — surfacing
+// downstream as the customer's 503 + outlier ejection.
+func peekUpstreamLive(conn net.Conn) bool {
+	tc, ok := conn.(*net.TCPConn)
+	if !ok {
+		return true
+	}
+	sc, err := tc.SyscallConn()
+	if err != nil {
+		return true
+	}
+	alive := true
+	rcErr := sc.Read(func(fd uintptr) bool {
+		var buf [1]byte
+		n, _, perr := syscall.Recvfrom(int(fd), buf[:], syscall.MSG_PEEK|syscall.MSG_DONTWAIT)
+		switch {
+		case perr == syscall.EAGAIN || perr == syscall.EWOULDBLOCK:
+			alive = true // empty queue, socket healthy
+		case perr != nil:
+			alive = false // ECONNRESET, EPIPE, etc.
+		case n == 0:
+			alive = false // FIN already in our buffer
+		default:
+			alive = false // unexpected data on idle socket — evict
+		}
+		return true // tell SyscallConn we're done; don't block
+	})
+	if rcErr != nil {
+		return true // can't probe — let the actual write decide
+	}
+	return alive
+}

--- a/pkg/agent/proxy/incoming/peek_unix.go
+++ b/pkg/agent/proxy/incoming/peek_unix.go
@@ -12,6 +12,13 @@ import (
 // queued. Implemented as one non-blocking recvfrom(MSG_PEEK|MSG_DONTWAIT) —
 // same liveness probe nginx uses in ngx_http_upstream_keepalive_close_handler.
 //
+// Build tag is //go:build !windows because MSG_PEEK + MSG_DONTWAIT and the
+// EAGAIN/EWOULDBLOCK/ECONNRESET error codes are POSIX, so this single
+// implementation is correct on every Unix-like target keploy ships to
+// (linux/amd64, linux/arm64, darwin/arm64, *bsd). A separate Windows stub
+// in peek_windows.go returns true unconditionally so non-Unix builds
+// compile cleanly.
+//
 // This catches the "stale pool entry" race where the backend's short
 // keep-alive (gunicorn 2s) fires during an idle gap, our kernel receives
 // the FIN, but no goroutine has read the upstream socket since the last

--- a/pkg/agent/proxy/incoming/peek_windows.go
+++ b/pkg/agent/proxy/incoming/peek_windows.go
@@ -2,54 +2,34 @@
 
 package proxy
 
-import (
-	"net"
+import "net"
 
-	"golang.org/x/sys/windows"
-)
-
-// peekUpstreamLive returns false if the upstream socket has been closed by
-// the peer (FIN/RST already delivered to our kernel) or has unexpected data
-// queued. The unix sibling uses recvfrom(MSG_PEEK|MSG_DONTWAIT); on Windows
-// the equivalent is WSARecv with MSG_PEEK on a socket Go has already put in
-// non-blocking (IOCP) mode, so MSG_DONTWAIT has no analogue and isn't needed
-// — recv on an empty queue returns WSAEWOULDBLOCK immediately.
+// peekUpstreamLive on Windows is a stub that always reports the socket as
+// alive; the caller falls back to write-based stale detection (the
+// idempotent-replay branch in handleHttp1ZeroCopy still catches the race on
+// the next req.Write).
 //
-// See peek_unix.go for why this probe exists (stale upstream pool entries
-// after the backend's short keep-alive fires during an idle gap).
-func peekUpstreamLive(conn net.Conn) bool {
-	tc, ok := conn.(*net.TCPConn)
-	if !ok {
-		return true
-	}
-	sc, err := tc.SyscallConn()
-	if err != nil {
-		return true
-	}
-	alive := true
-	rcErr := sc.Read(func(fd uintptr) bool {
-		var buf [1]byte
-		wsabuf := windows.WSABuf{Len: 1, Buf: &buf[0]}
-		var n uint32
-		flags := uint32(windows.MSG_PEEK)
-		// Synchronous WSARecv (overlapped=nil) on the IOCP-managed socket.
-		// On a non-blocking socket with no queued data this returns
-		// WSAEWOULDBLOCK without blocking the runtime.
-		perr := windows.WSARecv(windows.Handle(fd), &wsabuf, 1, &n, &flags, nil, nil)
-		switch {
-		case perr == windows.WSAEWOULDBLOCK:
-			alive = true // empty queue, socket healthy
-		case perr != nil:
-			alive = false // WSAECONNRESET, WSAECONNABORTED, etc.
-		case n == 0:
-			alive = false // FIN already in our buffer
-		default:
-			alive = false // unexpected data on idle socket — evict
-		}
-		return true // tell SyscallConn we're done; don't block
-	})
-	if rcErr != nil {
-		return true // can't probe — let the actual write decide
-	}
-	return alive
+// Why a stub and not a real probe:
+//
+// The unix sibling uses recvfrom(MSG_PEEK|MSG_DONTWAIT). On Windows the
+// equivalent flags exist in golang.org/x/sys/windows (WSARecv + MSG_PEEK),
+// but Go puts Windows sockets in BLOCKING mode and gets its async behavior
+// from overlapped I/O bound to the runtime's IOCP. A synchronous WSARecv
+// (lpOverlapped == NULL) on such a socket blocks until data arrives, which
+// defeats the purpose of the probe and can stall the goroutine.
+//
+// The alternatives all conflict with Go's IOCP ownership of the socket:
+//
+//  - Overlapped WSARecv + CancelIoEx: the completion still posts to Go's
+//    IOCP, racing with Go's own reads on the same fd.
+//  - ioctlsocket(FIONBIO, 1) + peek + restore: MSDN explicitly warns
+//    against FIONBIO on sockets opened with WSA_FLAG_OVERLAPPED.
+//  - WSAEventSelect: overrides the socket's notification mode that Go
+//    relies on.
+//
+// Since the keploy ingress forwarder is driven by the eBPF bind redirector
+// (Linux-only), Windows is not a real deployment target for this codepath.
+// Keep the stub until/unless that changes.
+func peekUpstreamLive(_ net.Conn) bool {
+	return true
 }

--- a/pkg/agent/proxy/incoming/peek_windows.go
+++ b/pkg/agent/proxy/incoming/peek_windows.go
@@ -1,0 +1,55 @@
+//go:build windows
+
+package proxy
+
+import (
+	"net"
+
+	"golang.org/x/sys/windows"
+)
+
+// peekUpstreamLive returns false if the upstream socket has been closed by
+// the peer (FIN/RST already delivered to our kernel) or has unexpected data
+// queued. The unix sibling uses recvfrom(MSG_PEEK|MSG_DONTWAIT); on Windows
+// the equivalent is WSARecv with MSG_PEEK on a socket Go has already put in
+// non-blocking (IOCP) mode, so MSG_DONTWAIT has no analogue and isn't needed
+// — recv on an empty queue returns WSAEWOULDBLOCK immediately.
+//
+// See peek_unix.go for why this probe exists (stale upstream pool entries
+// after the backend's short keep-alive fires during an idle gap).
+func peekUpstreamLive(conn net.Conn) bool {
+	tc, ok := conn.(*net.TCPConn)
+	if !ok {
+		return true
+	}
+	sc, err := tc.SyscallConn()
+	if err != nil {
+		return true
+	}
+	alive := true
+	rcErr := sc.Read(func(fd uintptr) bool {
+		var buf [1]byte
+		wsabuf := windows.WSABuf{Len: 1, Buf: &buf[0]}
+		var n uint32
+		flags := uint32(windows.MSG_PEEK)
+		// Synchronous WSARecv (overlapped=nil) on the IOCP-managed socket.
+		// On a non-blocking socket with no queued data this returns
+		// WSAEWOULDBLOCK without blocking the runtime.
+		perr := windows.WSARecv(windows.Handle(fd), &wsabuf, 1, &n, &flags, nil, nil)
+		switch {
+		case perr == windows.WSAEWOULDBLOCK:
+			alive = true // empty queue, socket healthy
+		case perr != nil:
+			alive = false // WSAECONNRESET, WSAECONNABORTED, etc.
+		case n == 0:
+			alive = false // FIN already in our buffer
+		default:
+			alive = false // unexpected data on idle socket — evict
+		}
+		return true // tell SyscallConn we're done; don't block
+	})
+	if rcErr != nil {
+		return true // can't probe — let the actual write decide
+	}
+	return alive
+}

--- a/pkg/agent/proxy/incoming/peek_windows.go
+++ b/pkg/agent/proxy/incoming/peek_windows.go
@@ -20,12 +20,12 @@ import "net"
 //
 // The alternatives all conflict with Go's IOCP ownership of the socket:
 //
-//  - Overlapped WSARecv + CancelIoEx: the completion still posts to Go's
-//    IOCP, racing with Go's own reads on the same fd.
-//  - ioctlsocket(FIONBIO, 1) + peek + restore: MSDN explicitly warns
-//    against FIONBIO on sockets opened with WSA_FLAG_OVERLAPPED.
-//  - WSAEventSelect: overrides the socket's notification mode that Go
-//    relies on.
+//   - Overlapped WSARecv + CancelIoEx: the completion still posts to Go's
+//     IOCP, racing with Go's own reads on the same fd.
+//   - ioctlsocket(FIONBIO, 1) + peek + restore: MSDN explicitly warns
+//     against FIONBIO on sockets opened with WSA_FLAG_OVERLAPPED.
+//   - WSAEventSelect: overrides the socket's notification mode that Go
+//     relies on.
 //
 // Since the keploy ingress forwarder is driven by the eBPF bind redirector
 // (Linux-only), Windows is not a real deployment target for this codepath.


### PR DESCRIPTION
## Summary

- Replace the byte-pump `handleHttp1ZeroCopy` with a per-request HTTP/1.1 framing loop that does an `MSG_PEEK | MSG_DONTWAIT` liveness probe before reusing a pooled upstream conn, and replays idempotent requests on stale-conn write/read failures.
- Routes the sampling-bypass path through the same loop with capture suppressed (`t == nil`) so bypass conns also get pool-liveness protection.
- Falls back to `forwardRawTCP` cleanly on `Upgrade` / `CONNECT`.
- Downstream (envoy↔keploy) keep-alive is unchanged on the happy path; only stale upstream conns get redialed.

Closes #4165.

## Why

When the backend has a shorter keep-alive than the downstream proxy's pool idle timeout (e.g. gunicorn `keep-alive 2s` behind istio with `connectionPool.http.idleTimeout: 1h`), the upstream socket gets FIN'd during idle gaps but neither `io.Copy` goroutine notices — both are blocked reading. The downstream pool reuses the stale entry, bytes flow into keploy's downstream socket, the `client→upstream` `io.Copy` write fails, the request vanishes. Customer surfaces this as `503 via_upstream` or hung connections; three in a row trips `consecutive_5xx` outlier ejection. The sampling-bypass path (`forwardRawTCP`) had the same shape and same bug.

This is the canonical race solved by every production HTTP/1.1 proxy. The fix matches the patterns documented in:
- nginx `ngx_http_upstream_keepalive_close_handler` (`MSG_PEEK` before reuse)
- envoy HTTP/1 conn pool `processIdleClient(delay=true)` + `retry_on: reset-before-request`
- Go `net/http` `persistConn.readLoopPeekFailLocked` + `shouldRetryRequest`

Issue #4165 has the full root-cause writeup and reproduction.

## Test plan

Reproduction setup: gunicorn 25.3 (`--keep-alive 2`), behind istio 1.28 with `outlierDetection.consecutive5xxErrors: 3` and `connectionPool.http.idleTimeout: 1h`. keploy enterprise in record mode with `--enable-sampling=5`. Bursty load: 30 concurrent requests, 5s idle gap between bursts.

| Run | Bursty 90s | keploy-proxy drop | Pod restarts |
|---|---|---|---|
| Before fix | 50% timeouts | ~50% | 0 |
| With this PR | **510/510 success (100%)** | **<1%** (timing-window noise) | 0 |

Capture continues to emit test cases through the new path (verified via `agent/capture.go` log lines for both `/api/private/...` and `/api/health` paths during the run).

- [ ] CI build green
- [ ] Existing HTTP/1.1 record/replay e2e suites still pass
- [ ] Manual reproduction in customer-shape setup (gunicorn + istio + bursty load): **done, 100% success**
- [ ] HTTP Upgrade (WebSocket) path falls back to `forwardRawTCP`: **manually verified via code path; needs e2e in CI**
- [ ] Memory pressure path (`isIngressRecordingPaused`): preserved — capture is suppressed mid-stream when paused, forwarding continues

## Notes for reviewers

- The old `parseStreamingHTTP` / `asyncPipeFeeder` path is no longer reached from `handleHttp1ZeroCopy` but I left it in place as it may still be referenced (and removing it is a separate cleanup). Happy to delete in a follow-up if reviewers prefer.
- The MSG_PEEK syscall is Linux-only; on non-Linux `peekUpstreamLive` returns `true` (treats as alive) which is the safe default. Keploy agent runs in Linux containers so this is fine in practice.
- Replay only triggers for idempotent methods AND when the request body is fully buffered (`!reqCapture.Truncated()`) — protects POST/PATCH from being silently retried, and guards against partial-body replays.