### PR TITLE
ci(echo-sql/macos): de-flake by pre-pulling images + retrying on agent timeout

### DIFF
--- a/.github/workflows/test_workflow_scripts/golang/echo_sql/golang-docker-macos.sh
+++ b/.github/workflows/test_workflow_scripts/golang/echo_sql/golang-docker-macos.sh
@@ -78,6 +78,15 @@ done
 # Build Docker Image(s)
 docker compose build
 
+# Pre-pull and warm the compose images so the FIRST record invocation
+# doesn't pay the postgres pull on a cold macOS Docker Desktop. The
+# 60s agent-readiness timeout in keploy is shorter than a cold pull
+# of a multi-hundred-MB image on Docker-on-VM, which is the dominant
+# cause of the "keploy-agent did not become ready in time" flake on
+# this matrix entry.
+echo "Pre-pulling docker compose images..."
+docker compose pull --quiet 2>&1 | tail -5 || true
+
 # Remove any preexisting keploy tests and mocks.
 rm -rf keploy/
 rm ./keploy.yml >/dev/null 2>&1 || true
@@ -104,12 +113,20 @@ send_request(){
     echo "Sending requests to the application..."
     sleep 10
     app_started=false
-    while [ "$app_started" = false ]; do
-        if curl -X GET http://localhost:${APP_PORT}/health; then
+    # Bounded poll (~90s). Unbounded loops keep retrying after the
+    # foreground record has already given up, masking the real failure
+    # in CI logs and inflating job runtime.
+    for attempt in $(seq 1 30); do
+        if curl --fail --silent -X GET http://localhost:${APP_PORT}/health >/dev/null 2>&1; then
             app_started=true
+            break
         fi
         sleep 3
     done
+    if [ "$app_started" = false ]; then
+        echo "send_request: app did not start within 90s; aborting requests"
+        return 1
+    fi
     echo "App started"
     # Make curl calls to record the test cases and mocks.
     curl --request POST \
@@ -133,19 +150,51 @@ send_request(){
     echo "Requests sent successfully."
 }
 
+# Retry wrapper for record: the only flake we see on this job is the
+# transient "keploy-agent did not become ready in time" timeout caused
+# by macOS Docker Desktop cold-starting compose. One retry after a
+# clean compose-down is enough — anything else is a real failure.
+record_once() {
+    local container_name="$1"
+    local log_file="$2"
+    local max_attempts=2
+    for attempt in $(seq 1 "$max_attempts"); do
+        echo "Recording attempt ${attempt}/${max_attempts} for ${container_name}..."
+        $RECORD_BIN record -c "docker compose up" \
+            --container-name "$container_name" \
+            --generateGithubActions=false \
+            --record-timer "40s" \
+            --proxy-port="$PROXY_PORT" \
+            --dns-port="$DNS_PORT" \
+            --keploy-container "$KEPLOY_CONTAINER" \
+            2>&1 | tee "$log_file"
+
+        if grep -q "keploy-agent did not become ready in time" "$log_file" \
+            && [ "$attempt" -lt "$max_attempts" ]; then
+            echo "Agent readiness timeout on attempt ${attempt}; cleaning compose state and retrying..."
+            docker compose down --remove-orphans -v >/dev/null 2>&1 || true
+            sleep 5
+            continue
+        fi
+        return 0
+    done
+}
+
 for i in {1..2}; do
     container_name="${APP_CONTAINER}"
     log_file_name="${APP_CONTAINER}_${i}"
     send_request &
 
-    $RECORD_BIN record -c "docker compose up" --container-name "$container_name" --generateGithubActions=false --record-timer "40s" --proxy-port=$PROXY_PORT --dns-port=$DNS_PORT --keploy-container "$KEPLOY_CONTAINER" 2>&1 | tee "${log_file_name}.txt"
+    record_once "$container_name" "${log_file_name}.txt"
 
     if grep "WARNING: DATA RACE" "${log_file_name}.txt"; then
         echo "Race condition detected in recording, stopping pipeline..."
+        cat "${log_file_name}.txt"
         exit 1
     fi
     if grep "ERROR" "${log_file_name}.txt"; then
         echo "Error found in pipeline..."
+        cat "${log_file_name}.txt"
         exit 1
     fi
     sleep 5
@@ -166,11 +215,13 @@ $REPLAY_BIN test -c 'docker compose up' --containerName "$test_container" --debu
 
 if grep "ERROR" "${test_container}.txt"; then
     echo "Error found in pipeline..."
+    cat "${test_container}.txt"
     exit 1
 fi
 
 if grep "WARNING: DATA RACE" "${test_container}.txt"; then
     echo "Race condition detected in test, stopping pipeline..."
+    cat "${test_container}.txt"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

The `run_golang_docker_macos / echo-sql` job has been failing intermittently on `main` — 3 consecutive failures over 2026-04-29..30 (runs `25100928776`, `25130653239`, `25167910834`) and most recently on PR #4166 (run `25257174468`). Root cause is the same in every failure log:

```
curl: (7) Failed to connect to localhost port <APP_PORT> ...   [repeated]
ERROR  failed stopping keploy   {"error": "cannot stop keploy without a reason"}
ERROR  failed to record         {"error": "keploy-agent did not become ready in time"}
```

The 60s agent-readiness timeout in keploy is shorter than a cold pull of the postgres image on macOS Docker Desktop, which runs Docker in a VM and has cold-start latency. The agent never becomes ready in time, the script's `grep "ERROR"` matches, the job fails.

## Changes

Three targeted changes to `golang-docker-macos.sh`, each independently useful:

1. **Pre-pull compose images** with `docker compose pull --quiet` before the record loop, so the cache is warm when keploy starts polling for agent readiness. No-op when cached; bounded network pull when not.
2. **Retry wrapper around `record`** that triggers ONLY on `keploy-agent did not become ready in time` (max 2 attempts, with a `docker compose down --remove-orphans -v` between). Any other failure falls through to the existing `grep "ERROR"` exit, so this does not mask real bugs.
3. **Bound `send_request`'s health-check loop** at 30 attempts (~90s) and `cat` log files on grep-detected failures. The previous unbounded loop kept the script alive after the foreground `record` had already returned an error, masking the real failure mode in CI logs.

No source-code change. The `gin-mongo` macOS variant in the same matrix already uses bounded loops and retries — this brings echo-sql in line.

## Test plan

- [ ] CI green on this PR (echo-sql macOS passes after merge of the change to the script the job runs).
- [ ] If echo-sql macOS fails on this PR, the log should now show whichever of: a real ERROR (line is `cat`'d), the agent-timeout-twice path (real environment problem, not flake), or the bounded send_request giving up cleanly.
- [ ] Watch echo-sql macOS pass/fail rate on `main` for ~10 runs after merge — expect close to 100% pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)