### PR TITLE
ci(stale-pool-race): asymmetric drop-rate gates instead of continue-on-error

### DIFF
--- a/.github/workflows/http-stale-pool-race-linux.yml
+++ b/.github/workflows/http-stale-pool-race-linux.yml
@@ -5,15 +5,27 @@ name: HTTP Stale-Pool Race Regression (Linux)
 # than the backend's keep-alive (gunicorn 2s default).
 #
 # The matrix runs the same bursty-load test against two keploy
-# binaries:
-#   - record_with_build  → uses the PR's binary. MUST pass.
-#   - record_with_latest → uses the published `latest`. Demonstrates
-#                          the bug on releases that pre-date the fix
-#                          (~25-50% drop rate). Marked
-#                          continue-on-error so it documents the bug
-#                          without blocking PR merges; flip to a hard
-#                          gate once a release containing the fix is
-#                          published as `latest`.
+# binaries, each with its own pass condition. Both legs are now
+# REQUIRED (no continue-on-error) — the asymmetric thresholds make
+# each leg meaningful on its own AND form a tripwire when reality
+# changes:
+#
+#   record_with_build  (uses PR's binary, MAX_DROP_PCT=5)
+#     PASS condition: drop rate <= 5% (the fix is working)
+#     FAIL means:     the fix regressed under the PR being tested
+#
+#   record_with_latest (uses published keploy:latest, MIN_DROP_PCT=10)
+#     PASS condition: drop rate >= 10% (the bug is reproducing in
+#                     a stock release without the fix)
+#     FAIL means:     either (a) the regression test stopped
+#                     reproducing the bug for some other reason
+#                     (burst parameters drifted), OR (b) a release
+#                     containing the fix has shipped as `latest` and
+#                     this matrix entry is now redundant.
+#
+# When (b) eventually fires, follow the cleanup checklist in #4169:
+# remove the record_with_latest matrix entry. The CI failure IS the
+# tripwire that prompts the cleanup — that's intentional.
 on:
   workflow_call:
     inputs:
@@ -38,20 +50,22 @@ jobs:
         config:
           - job: record_with_build
             record_src: build
-            # The PR's binary MUST keep the test green. If this
-            # leg fails, either the fix regressed or the burst
-            # parameters drift from what reproduces the race.
-            continue_on_error: false
+            # The PR's binary must show ~0% drops. PASS gate is
+            # MAX_DROP_PCT=5; no MIN floor.
+            max_drop_pct: "5"
+            min_drop_pct: ""
           - job: record_with_latest
             record_src: latest
-            # The published `latest` is expected to fail this test
-            # until a release containing the fix ships. Marked
-            # continue-on-error so the failure is visible but does
-            # not block the PR.
-            continue_on_error: true
+            # The published `latest` (pre-fix) shows ~25-50% drops.
+            # PASS gate is MIN_DROP_PCT=10 (the bug is still
+            # reproducing). MAX is set to 100 so the gate is purely
+            # the floor. When a release containing the fix ships as
+            # `latest`, drops collapse to ~0 and this leg fails the
+            # MIN check — that's the tripwire from #4169 firing.
+            max_drop_pct: "100"
+            min_drop_pct: "10"
     name: stale-pool-race (${{ matrix.config.job }})
     timeout-minutes: 15
-    continue-on-error: ${{ matrix.config.continue_on_error }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -71,6 +85,8 @@ jobs:
       - name: Run regression test
         env:
           RECORD_BIN: ${{ steps.record.outputs.path }}
+          MAX_DROP_PCT: ${{ matrix.config.max_drop_pct }}
+          MIN_DROP_PCT: ${{ matrix.config.min_drop_pct }}
         # Run via `bash <script>` rather than `source` so the
         # script's intentional avoidance of `set -e` is not overridden
         # by the workflow step's default `-eo pipefail`. The script's

--- a/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/burst_client.py
+++ b/.github/workflows/test_workflow_scripts/python/http-stale-pool-race/burst_client.py
@@ -33,6 +33,16 @@ REQS_PER_BURST_PER_CONN = 3
 IDLE_GAP_SEC = 5
 TIMEOUT_SEC = 10
 MAX_DROP_PCT = float(os.environ.get("MAX_DROP_PCT", "5"))
+# Optional FLOOR — when set, drop_pct must be >= MIN_DROP_PCT for the
+# run to be considered "the bug is reproducing as expected." This is
+# how the record_with_latest matrix leg keeps demonstrating the bug
+# without hiding behind continue-on-error: if a future release of
+# keploy:latest contains the fix, drop_pct collapses to ~0%, the floor
+# assertion fails, and CI loudly tells the operator to clean up the
+# leg (see issue #4169). Empty / unset → no floor (the record_with_build
+# leg uses only MAX_DROP_PCT).
+MIN_DROP_PCT_RAW = os.environ.get("MIN_DROP_PCT", "").strip()
+MIN_DROP_PCT = float(MIN_DROP_PCT_RAW) if MIN_DROP_PCT_RAW else None
 
 
 def open_conn():
@@ -89,9 +99,24 @@ print(
 
 if drop_pct > MAX_DROP_PCT:
     print(
-        f"::error::drop rate {drop_pct:.1f}% exceeds threshold "
-        f"{MAX_DROP_PCT}% — half-close race regression"
+        f"::error::drop rate {drop_pct:.1f}% exceeds MAX threshold "
+        f"{MAX_DROP_PCT}% — half-close race regression (the fix has "
+        f"regressed under the binary being tested)"
     )
     sys.exit(1)
 
-print(f"OK: drop rate {drop_pct:.1f}% within threshold {MAX_DROP_PCT}%")
+if MIN_DROP_PCT is not None and drop_pct < MIN_DROP_PCT:
+    # Tripwire for the record_with_latest leg. The leg is supposed to
+    # demonstrate the bug; when the bug stops reproducing, that means
+    # the fix has shipped in keploy:latest and this matrix entry is
+    # now redundant. See issue #4169 for the cleanup checklist.
+    print(
+        f"::error::drop rate {drop_pct:.1f}% is BELOW the MIN floor "
+        f"{MIN_DROP_PCT}% — the upstream-pool half-close bug is no "
+        f"longer reproducing under this binary. If this fired on the "
+        f"record_with_latest leg, the fix has reached keploy:latest "
+        f"and you should remove this matrix entry per #4169."
+    )
+    sys.exit(1)
+
+print(f"OK: drop rate {drop_pct:.1f}% within thresholds (max={MAX_DROP_PCT}%, min={MIN_DROP_PCT})")


### PR DESCRIPTION
Follow-up to #4166. Closes #4169.

## Why

#4166 added a 2-cell matrix: `record_with_build` (PR's binary, must pass) and `record_with_latest` (published `latest`, demonstrates the bug). The latter was gated behind `continue-on-error: true` so the bug-demo leg wouldn't block PR merges while the fix was still in flight.

That makes the leg purely informational — and worse, **silently breaks the moment a release containing the fix is published as `latest`**: drops collapse from ~28% to ~0%, but the leg still passes (the only assertion was a ceiling, not a floor) and the regression-test value goes to zero with nobody noticing.

## What

Replace `continue-on-error` with asymmetric thresholds on a per-matrix-entry basis. Both legs become required; the assertion polarity differs.

| matrix entry | `MAX_DROP_PCT` | `MIN_DROP_PCT` | PASS condition | FAIL means |
|---|---|---|---|---|
| `record_with_build` | 5 | (none) | drop ≤ 5% | the fix regressed in this PR |
| `record_with_latest` | 100 | 10 | drop ≥ 10% | (a) the regression test stopped reproducing the bug, OR (b) a release containing the fix shipped as `latest` and this matrix entry is now redundant |

The MIN floor on the `latest` leg is the **tripwire**. When (b) eventually fires, CI goes red, the failure message points at #4169, and the operator removes the matrix entry per the checklist there. Intentional design: "let the assertion fail loudly when the time comes" beats building automation that scrapes release metadata.

`burst_client.py` picks up `MIN_DROP_PCT` via env (empty string disables the floor), and the per-leg env is plumbed through the matrix.

## Test plan

- [x] YAML / python both syntax-validate
- [ ] CI: `record_with_build` passes (drop ~0%, MAX=5 satisfied; no MIN)
- [ ] CI: `record_with_latest` passes against today's `keploy:latest` (drop ~28%, MIN=10 satisfied)
- [ ] When a release containing the fix lands as `latest`: `record_with_latest` will fail with a message linking to #4169. That failure is the success of this PR.

## Notes

- Based on `fix/incoming-http1-stale-pool-msg-peek` (#4166). Should be merged after #4166 — it depends on the workflow files added there.
- After #4166 + this PR both merge to `main`, the matrix continues to enforce both invariants until the tripwire fires.