### PR TITLE
fix(relay): close peer conn when one forwarder exits

### DIFF
--- a/.github/workflows/outbound-fin-stall-linux.yml
+++ b/.github/workflows/outbound-fin-stall-linux.yml
@@ -1,0 +1,94 @@
+name: Outbound FIN Stall Regression (Linux)
+# Regression test for issue #4173 — the relay's two-forwarder join
+# stalled on outbound captures whenever the upstream gracefully closed
+# an idle keepalive connection between requests. Fix in PR #4174 wakes
+# the peer forwarder via the existing closeStopping/nudgeDeadline
+# machinery so wgForward.Wait() unblocks promptly.
+#
+# The matrix runs the same urllib3 + silent-upstream test against two
+# keploy binaries:
+#   - record_with_build  → uses the PR's binary. MUST pass.
+#   - record_with_latest → uses the published `latest`. Demonstrates
+#                          the bug on releases that pre-date the fix
+#                          (call-2 fails with ReadTimeoutError after
+#                          60s and only one of two outbound mocks
+#                          gets captured). Marked continue-on-error
+#                          so it documents the bug without blocking
+#                          PR merges; flip to a hard gate once a
+#                          release containing the fix is published
+#                          as `latest`.
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: 'The type of runner to use for this job'
+        type: string
+        required: false
+        default: 'ubuntu-latest'
+      jobs_to_run:
+        description: 'Controls which jobs to run. "all" runs everything.'
+        type: string
+        required: false
+        default: 'all'
+
+jobs:
+  outbound_fin_stall_linux:
+    if: ${{ inputs.jobs_to_run == 'all' }}
+    runs-on: ${{ inputs.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - job: record_with_build
+            record_src: build
+            # The PR's binary MUST keep this test green. If this leg
+            # fails, either the fix regressed or the test parameters
+            # drift from what reproduces the bug.
+            continue_on_error: false
+          - job: record_with_latest
+            record_src: latest
+            # The published `latest` is expected to fail this test
+            # until a release containing the fix ships. Marked
+            # continue-on-error so the failure is visible but does
+            # not block the PR.
+            continue_on_error: true
+    name: outbound-fin-stall (${{ matrix.config.job }})
+    timeout-minutes: 15
+    continue-on-error: ${{ matrix.config.continue_on_error }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: keploy/keploy
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - id: record
+        uses: ./.github/actions/download-binary
+        with:
+          src: ${{ matrix.config.record_src }}
+
+      - name: Run regression test
+        env:
+          RECORD_BIN: ${{ steps.record.outputs.path }}
+        # `bash <script>` rather than `source` so the script's
+        # intentional `set +e` is not overridden by the workflow
+        # step's default `-eo pipefail`. The script captures exit
+        # codes and runs cleanup-then-fail explicitly.
+        run: |
+          bash "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/python/outbound-fin-stall/python-linux.sh"
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: outbound-fin-stall-${{ matrix.config.job }}-logs
+          path: |
+            .github/workflows/test_workflow_scripts/python/outbound-fin-stall/record_logs.txt
+            .github/workflows/test_workflow_scripts/python/outbound-fin-stall/upstream_logs.txt
+            .github/workflows/test_workflow_scripts/python/outbound-fin-stall/keploy/
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/prepare_and_run.yml
+++ b/.github/workflows/prepare_and_run.yml
@@ -693,6 +693,14 @@ jobs:
     # `latest` (currently demonstrates the bug, continue-on-error).
     needs: [build-and-upload, upload-latest]
     uses: ./.github/workflows/http-stale-pool-race-linux.yml
+  run_outbound_fin_stall_linux:
+    # Regression guard for issue #4173 (relay forwarder join stall on
+    # upstream FIN during outbound capture). urllib3 client + fake
+    # upstream that FINs after idle exposes the bug; matrix runs both
+    # `build` (must pass) and `latest` (currently demonstrates the
+    # bug — call-2 hits the 60s read_timeout, continue-on-error).
+    needs: [build-and-upload, upload-latest]
+    uses: ./.github/workflows/outbound-fin-stall-linux.yml
   run_golang_docker:
     needs: [build-and-upload, upload-latest, build-docker-image-amd64]
     uses: ./.github/workflows/golang_docker.yml
@@ -1127,6 +1135,7 @@ jobs:
       - run_python_docker
       - run_python_linux
       - run_http_stale_pool_race_linux
+      - run_outbound_fin_stall_linux
       - run_golang_docker
       - run_fuzzer_linux
       - run_grpc_linux
@@ -1147,6 +1156,7 @@ jobs:
             "${{ needs.run_python_docker.result }}" \
             "${{ needs.run_python_linux.result }}" \
             "${{ needs.run_http_stale_pool_race_linux.result }}" \
+            "${{ needs.run_outbound_fin_stall_linux.result }}" \
             "${{ needs.run_golang_docker.result }}" \
             "${{ needs.run_fuzzer_linux.result }}" \
             "${{ needs.run_grpc_linux.result }}" \

--- a/.github/workflows/test_workflow_scripts/python/outbound-fin-stall/.gitignore
+++ b/.github/workflows/test_workflow_scripts/python/outbound-fin-stall/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+keploy/
+keploy.yml
+record_logs.txt
+upstream_logs.txt

--- a/.github/workflows/test_workflow_scripts/python/outbound-fin-stall/app.py
+++ b/.github/workflows/test_workflow_scripts/python/outbound-fin-stall/app.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Client app for the outbound-fin-stall regression test (#4173).
+
+urllib3 is the same library `botocore` (and therefore boto3) uses to
+talk to AWS services. We open ONE pooled HTTP/1.1 keepalive
+connection (maxsize=1) and fire two POSTs separated by a sleep that
+exceeds the upstream's idle budget. urllib3 calls
+wait_for_read(sock, timeout=0) before reusing the pooled conn — that
+detects the upstream's FIN and reconnects cleanly. The test gates on
+both calls returning 200 within the read_timeout; the call-2 latency
+is the asymmetry the relay fix collapses from ~60s to milliseconds.
+"""
+import os
+import sys
+import time
+
+import urllib3
+
+URL_HOST = sys.argv[1] if len(sys.argv) > 1 else "127.0.0.1"
+URL_PORT = int(sys.argv[2]) if len(sys.argv) > 2 else 9090
+GAP = float(sys.argv[3]) if len(sys.argv) > 3 else 8.0
+
+# Match botocore's defaults — read_timeout=60s is what bounds the
+# regression's tail latency from the application side.
+TIMEOUT = float(os.environ.get("APP_READ_TIMEOUT", "60.0"))
+
+http = urllib3.PoolManager(num_pools=1, maxsize=1)
+url = f"http://{URL_HOST}:{URL_PORT}/publish"
+
+
+def call(label: str, payload: bytes) -> bool:
+    """Returns True iff the call returned 2xx within the read timeout."""
+    t0 = time.time()
+    try:
+        r = http.request(
+            "POST",
+            url,
+            body=payload,
+            headers={"Content-Type": "application/json"},
+            timeout=urllib3.Timeout(connect=3.0, read=TIMEOUT),
+        )
+        elapsed = time.time() - t0
+        ok = 200 <= r.status < 300
+        print(
+            f"[app] {label}: status={r.status} elapsed={elapsed:.3f}s "
+            f"body={r.data!r}",
+            flush=True,
+        )
+        return ok
+    except Exception as e:
+        elapsed = time.time() - t0
+        print(
+            f"[app] {label}: FAILED after {elapsed:.3f}s — "
+            f"{type(e).__name__}: {e}",
+            flush=True,
+        )
+        return False
+
+
+def main() -> int:
+    print(
+        f"[app] target={URL_HOST}:{URL_PORT} gap={GAP}s "
+        f"timeout={TIMEOUT}s (urllib3 PoolManager, maxsize=1)",
+        flush=True,
+    )
+    ok1 = call("call-1", b'{"hello":1}')
+    print(f"[app] sleeping {GAP}s ...", flush=True)
+    time.sleep(GAP)
+    ok2 = call("call-2", b'{"hello":2}')
+    print("[app] done", flush=True)
+    return 0 if (ok1 and ok2) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/test_workflow_scripts/python/outbound-fin-stall/python-linux.sh
+++ b/.github/workflows/test_workflow_scripts/python/outbound-fin-stall/python-linux.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# Regression test for the 60s outbound tail introduced by the relay's
+# missing peer-forwarder wakeup (issue #4173, fix in PR #4174).
+#
+# Setup: a tiny TCP server (silent_upstream.py) acts as an AWS-ALB-style
+# upstream — it answers the first request on a keepalive conn, then
+# sends FIN once the conn has been idle for 5 s. A urllib3 client
+# (app.py) opens ONE pooled HTTP/1.1 connection, fires call-1, sleeps
+# 8 s (longer than the upstream's idle budget), and fires call-2.
+#
+# urllib3's pool calls wait_for_read(sock, timeout=0) before reuse, so
+# without keploy in the path it observes the FIN, throws the dead conn
+# away, and reconnects in milliseconds.
+#
+# With keploy in the path, the relay's two forwarder goroutines are
+# joined via wgForward.Wait(); when the upstream FINs, FromDest reads
+# EOF and exits, but FromClient is still parked in src.Read on the
+# client conn with no event to wake it. Without the fix in #4174, the
+# relay hangs there until the application's own read_timeout fires
+# (60 s for botocore's default), and call-2 fails with a
+# ReadTimeoutError. With the fix, the closeStopping+nudgeDeadline
+# coordinator wakes the peer forwarder; the relay tears down promptly
+# and the client reconnects — call-2 succeeds in milliseconds.
+#
+# Pass criteria:
+#   1. The app exits 0 (both POST calls returned 2xx).
+#   2. keploy/test-set-0/mocks.yaml contains BOTH outbound HTTP
+#      mocks. Without the fix, call-2 never receives a response so
+#      its mock is incomplete and is dropped — only mock-0 (call-1)
+#      lands on disk.
+
+set -uo pipefail
+# Explicit set +e: even when this script is sourced from a workflow
+# step that has -e enabled by default (GitHub Actions does this for
+# `run:` blocks), we want both the upstream-startup loop and the
+# keploy-record invocation to NOT short-circuit the script — we
+# capture exit codes explicitly and run cleanup on every path.
+set +e
+
+source "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/test-iid.sh"
+
+# Match keploy by `comm` (process name) — pkill default mode. Avoid
+# `pkill -f` regex matches against full argv: those self-match the
+# wrapping bash (whose /proc/PID/cmdline includes the script path)
+# and this script's sudo parent, surfacing as a 137 exit even on a
+# passing run. See the cleanup comment in
+# python/http-stale-pool-race/python-linux.sh for the full rationale.
+# The upstream is killed by recorded PID (set after launch) rather
+# than by name, since "python3" matches every Python process on the
+# runner.
+upstream_pid=""
+cleanup() {
+    echo "cleanup..."
+    sudo pkill -9 keploy 2>/dev/null || true
+    if [ -n "$upstream_pid" ]; then
+        kill -9 "$upstream_pid" 2>/dev/null || true
+    fi
+    sleep 1
+}
+trap cleanup EXIT
+
+cd "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/python/outbound-fin-stall"
+
+echo "=== install python deps ==="
+python3 -m pip install --upgrade pip >/dev/null
+python3 -m pip install -r requirements.txt
+
+echo "=== generate keploy config ==="
+$RECORD_BIN config --generate
+rm -rf keploy/
+
+echo "=== start fake upstream (FIN after 5s idle) ==="
+python3 silent_upstream.py 9090 > upstream_logs.txt 2>&1 &
+upstream_pid=$!
+
+# Wait for the upstream's listening socket. Use ss so the readiness
+# check doesn't itself open a TCP conn that would skew the upstream's
+# idle bookkeeping.
+ready=0
+for i in $(seq 1 20); do
+    if ss -tln | awk '{print $4}' | grep -q ":9090$"; then
+        echo "upstream listening after $((i))s"
+        ready=1
+        break
+    fi
+    sleep 1
+done
+if [ "$ready" -ne 1 ]; then
+    echo "::error::upstream did not start within 20s"
+    cat upstream_logs.txt
+    exit 1
+fi
+
+echo "=== run keploy record + app.py (call-1, sleep 8s, call-2) ==="
+sudo -E env PATH="$PATH" "$RECORD_BIN" record \
+    -c "python3 app.py 127.0.0.1 9090 8" \
+    > record_logs.txt 2>&1
+record_status=$?
+
+echo "=== record exit status: $record_status ==="
+
+echo "=== check for data races / hard errors in record_logs.txt ==="
+if grep -q 'WARNING: DATA RACE' record_logs.txt; then
+    echo "::error::data race detected in keploy"
+    tail -200 record_logs.txt
+    exit 1
+fi
+
+echo "=== check app result (both calls must have returned 2xx) ==="
+if ! grep -q 'call-1: status=200' record_logs.txt; then
+    echo "::error::call-1 did not return 200"
+    echo "--- last 100 lines of record_logs.txt ---"
+    tail -100 record_logs.txt
+    exit 1
+fi
+if ! grep -q 'call-2: status=200' record_logs.txt; then
+    echo "::error::call-2 did not return 200 (60s tail regression of #4173)"
+    grep -E '^\[app\]|FAILED|ReadTimeoutError' record_logs.txt | head -20 || true
+    exit 1
+fi
+
+echo "=== check both mocks were captured (call-2 mock is the regression signal) ==="
+mocks_file="keploy/test-set-0/mocks.yaml"
+if [ ! -s "$mocks_file" ]; then
+    echo "::error::mocks file missing or empty: $mocks_file"
+    ls -la keploy/ || true
+    exit 1
+fi
+
+# Each captured outbound mock starts with "name: mock-N" at the spec
+# top level — count those rather than parsing YAML, to keep the
+# script's runtime deps to coreutils.
+mock_count=$(grep -cE '^name:\s+mock-' "$mocks_file" 2>/dev/null || echo 0)
+
+echo "captured mocks: $mock_count"
+if [ "$mock_count" -lt 2 ]; then
+    echo "::error::expected 2 captured mocks (one per HTTP call); got $mock_count"
+    echo "--- mocks.yaml summary ---"
+    grep -E '^(name|kind|        Host:|        body:|    reqTimestampMock:)' "$mocks_file" | head -40
+    echo "--- last 80 lines of record_logs.txt ---"
+    tail -80 record_logs.txt
+    exit 1
+fi
+
+echo "PASS: both outbound calls completed within their read_timeout AND both mocks were captured"

--- a/.github/workflows/test_workflow_scripts/python/outbound-fin-stall/requirements.txt
+++ b/.github/workflows/test_workflow_scripts/python/outbound-fin-stall/requirements.txt
@@ -1,0 +1,6 @@
+# Pinned to the major series customers using boto3 are typically on. The
+# stale-pool detection that drives the test's PASS/FAIL distinction lives
+# in urllib3.util.connection.is_connection_dropped → wait_for_read; that
+# code path is stable across urllib3 1.26.x and 2.x, but pinning here
+# keeps the regression's reference behavior reproducible.
+urllib3==2.3.0

--- a/.github/workflows/test_workflow_scripts/python/outbound-fin-stall/silent_upstream.py
+++ b/.github/workflows/test_workflow_scripts/python/outbound-fin-stall/silent_upstream.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Fake HTTP upstream for the outbound-fin-stall regression test.
+
+Models the production failure mode from issue #4173: an upstream that
+keeps a keepalive TCP connection alive for the first request and then,
+once the connection has been idle for IDLE_BUDGET seconds, **sends
+FIN** (clean close) without warning. This is exactly the shape of an
+AWS ALB hitting its 60s idle timeout — see
+https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-troubleshooting.html
+
+A urllib3 / botocore client that pooled the previous connection will
+detect the FIN before reuse via wait_for_read(sock, timeout=0) and
+reconnect cleanly. Keploy's outbound-capture relay sits between the
+app and the upstream; before the fix in #4174 it would itself reuse
+the dead pool entry and hang on src.Read until the application's own
+read_timeout fired (60s for botocore default), producing a 60s tail
+on every reused-but-dead connection.
+
+Per-request mode is hard-coded to "fin" (graceful close after idle).
+The silent / no-FIN variant exists in the local repro but is not
+covered by this test because it would symmetrically hang both with
+and without the fix — the bug we are gating on is specifically the
+FIN-not-propagated case.
+"""
+import socket
+import sys
+import threading
+import time
+
+PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 9090
+IDLE_BUDGET = 5.0  # seconds
+
+
+def handle(conn: socket.socket, addr) -> None:
+    cid = f"{addr[0]}:{addr[1]}"
+    print(f"[upstream] +conn {cid}", flush=True)
+    request_count = 0
+    buf = b""
+    try:
+        while True:
+            # Wait briefly for the next request bytes; if the budget
+            # elapses with no progress, treat the conn as idle and
+            # send FIN. Real ALB behavior is wall-clock from the last
+            # data byte, which this matches.
+            conn.settimeout(IDLE_BUDGET)
+            try:
+                while b"\r\n\r\n" not in buf:
+                    chunk = conn.recv(4096)
+                    if not chunk:
+                        print(
+                            f"[upstream] {cid} client EOF after "
+                            f"{request_count} reqs",
+                            flush=True,
+                        )
+                        return
+                    buf += chunk
+            except socket.timeout:
+                print(
+                    f"[upstream] {cid} *** IDLE > {IDLE_BUDGET}s "
+                    f"→ sending FIN (close)",
+                    flush=True,
+                )
+                try:
+                    conn.shutdown(socket.SHUT_WR)
+                except OSError:
+                    pass
+                return
+
+            head, _, rest = buf.partition(b"\r\n\r\n")
+            cl = 0
+            for line in head.split(b"\r\n"):
+                if line.lower().startswith(b"content-length:"):
+                    try:
+                        cl = int(line.split(b":", 1)[1].strip())
+                    except ValueError:
+                        cl = 0
+                    break
+            conn.settimeout(5.0)
+            try:
+                while len(rest) < cl:
+                    more = conn.recv(cl - len(rest))
+                    if not more:
+                        break
+                    rest += more
+            except socket.timeout:
+                pass
+            buf = rest[cl:]
+
+            request_count += 1
+            print(
+                f"[upstream] {cid} req#{request_count} "
+                f"({len(rest[:cl])} body bytes) → 200",
+                flush=True,
+            )
+            body = b"OK\n"
+            resp = (
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Length: " + str(len(body)).encode() + b"\r\n"
+                b"Connection: keep-alive\r\n"
+                b"\r\n" + body
+            )
+            conn.sendall(resp)
+    finally:
+        try:
+            conn.close()
+        except OSError:
+            pass
+
+
+def main() -> None:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(("0.0.0.0", PORT))
+    s.listen(16)
+    print(
+        f"[upstream] listening on 0.0.0.0:{PORT}, idle={IDLE_BUDGET}s",
+        flush=True,
+    )
+    while True:
+        conn, addr = s.accept()
+        t = threading.Thread(target=handle, args=(conn, addr), daemon=True)
+        t.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/pkg/agent/proxy/relay/relay.go
+++ b/pkg/agent/proxy/relay/relay.go
@@ -285,16 +285,41 @@ func (r *Relay) run(ctx context.Context) error {
 
 	// Forwarder src → dst (Dir=FromClient).
 	wgForward.Add(1)
+	fwdC2DDone := make(chan struct{})
 	go func() {
 		defer wgForward.Done()
+		defer close(fwdC2DDone)
 		recordErr(r.forward(ctx, stopping, fakeconn.FromClient, &r.src, &r.dst, r.teeC2D, &r.seqC2D))
 	}()
 
 	// Forwarder dst → src (Dir=FromDest).
 	wgForward.Add(1)
+	fwdD2CDone := make(chan struct{})
 	go func() {
 		defer wgForward.Done()
+		defer close(fwdD2CDone)
 		recordErr(r.forward(ctx, stopping, fakeconn.FromDest, &r.dst, &r.src, r.teeD2C, &r.seqD2C))
+	}()
+
+	// FIX: when ONE forwarder exits (e.g. upstream sent FIN → FromDest
+	// got EOF), close the OTHER forwarder's source so its blocked Read
+	// returns immediately. Without this, the relay waits for the still-
+	// blocked forwarder to exit on its own — for outbound captures with
+	// HTTP/1.1 keepalive, that means waiting for the *app's* read_timeout
+	// (60s for botocore) before everything tears down.
+	go func() {
+		select {
+		case <-fwdC2DDone:
+			if dst := r.dst.Load(); dst != nil {
+				_ = (*dst).Close()
+			}
+		case <-fwdD2CDone:
+			if src := r.src.Load(); src != nil {
+				_ = (*src).Close()
+			}
+		case <-stopping:
+			return
+		}
 	}()
 
 	// Block until both forwarders exit.

--- a/pkg/agent/proxy/relay/relay.go
+++ b/pkg/agent/proxy/relay/relay.go
@@ -283,43 +283,39 @@ func (r *Relay) run(ctx context.Context) error {
 		r.processDirectives(ctx, stopping)
 	}()
 
+	// When one forwarder exits, signal the other to exit too via the
+	// existing stopping/nudgeDeadline machinery. Without this signalling,
+	// if e.g. the upstream sends FIN → FromDest reads EOF and exits, the
+	// FromClient forwarder is still parked in src.Read(client) with no
+	// event to wake it; wgForward.Wait() blocks until the application's
+	// HTTP client times out on its own (~60s for botocore default
+	// read_timeout). The recipe used here mirrors what cancelNudge does
+	// for ctx.Done(): close stopping (idempotent via sync.Once so the
+	// late close below stays safe) AND nudge the peer's read deadline so
+	// its in-flight Read returns Timeout(); the forwarder's existing
+	// timeout-loop branch re-checks the top-of-loop select, observes
+	// stopping closed, and exits cleanly. Crucially, the relay still
+	// does NOT close the real sockets — that ownership stays with
+	// proxy.go::handleConnection per the contract in doc.go.
+	var stopOnce sync.Once
+	closeStopping := func() { stopOnce.Do(func() { close(stopping) }) }
+
 	// Forwarder src → dst (Dir=FromClient).
 	wgForward.Add(1)
-	fwdC2DDone := make(chan struct{})
 	go func() {
 		defer wgForward.Done()
-		defer close(fwdC2DDone)
+		defer closeStopping()
+		defer r.nudgeDeadline(r.dst.Load())
 		recordErr(r.forward(ctx, stopping, fakeconn.FromClient, &r.src, &r.dst, r.teeC2D, &r.seqC2D))
 	}()
 
 	// Forwarder dst → src (Dir=FromDest).
 	wgForward.Add(1)
-	fwdD2CDone := make(chan struct{})
 	go func() {
 		defer wgForward.Done()
-		defer close(fwdD2CDone)
+		defer closeStopping()
+		defer r.nudgeDeadline(r.src.Load())
 		recordErr(r.forward(ctx, stopping, fakeconn.FromDest, &r.dst, &r.src, r.teeD2C, &r.seqD2C))
-	}()
-
-	// FIX: when ONE forwarder exits (e.g. upstream sent FIN → FromDest
-	// got EOF), close the OTHER forwarder's source so its blocked Read
-	// returns immediately. Without this, the relay waits for the still-
-	// blocked forwarder to exit on its own — for outbound captures with
-	// HTTP/1.1 keepalive, that means waiting for the *app's* read_timeout
-	// (60s for botocore) before everything tears down.
-	go func() {
-		select {
-		case <-fwdC2DDone:
-			if dst := r.dst.Load(); dst != nil {
-				_ = (*dst).Close()
-			}
-		case <-fwdD2CDone:
-			if src := r.src.Load(); src != nil {
-				_ = (*src).Close()
-			}
-		case <-stopping:
-			return
-		}
 	}()
 
 	// Block until both forwarders exit.
@@ -337,8 +333,11 @@ func (r *Relay) run(ctx context.Context) error {
 	_ = r.clientStream.Close()
 	_ = r.destStream.Close()
 
-	// Signal the directive processor to exit and wait for it.
-	close(stopping)
+	// Signal the directive processor to exit and wait for it. Use the
+	// idempotent closer because either forwarder's defer may have
+	// already closed stopping during its own exit (see closeStopping
+	// above) — closing a closed channel panics.
+	closeStopping()
 	wgDirective.Wait()
 
 	// After the processor has returned, no one else can send on acks:

--- a/pkg/agent/proxy/relay/relay_test.go
+++ b/pkg/agent/proxy/relay/relay_test.go
@@ -704,6 +704,66 @@ func TestCleanShutdownOnCtxCancel(t *testing.T) {
 	}
 }
 
+// TestRunReturnsPromptlyWhenDestClosesWhileClientIdle is a regression
+// guard for the 60s tail introduced by issue #4173. The relay starts
+// two forwarder goroutines and joins them via wgForward.Wait(). When
+// the upstream side closes (e.g. an AWS ALB sending FIN at idle
+// timeout), the FromDest forwarder reads EOF and exits — but the
+// FromClient forwarder is still parked in a blocking Read on the
+// client conn, with no event to wake it. Without the
+// closeStopping+nudgeDeadline coordinator added to run(), Run() then
+// blocks until the application's HTTP client closes the client side
+// itself (typically 60s for botocore's default read_timeout).
+//
+// The test pipes both sides explicitly, lets the relay reach a
+// steady-state where both forwarders are blocked in Read, then closes
+// the dest peer and asserts that Run returns within a short bound.
+// On the regression, this hangs until t.Fatalf fires.
+func TestRunReturnsPromptlyWhenDestClosesWhileClientIdle(t *testing.T) {
+	t.Parallel()
+	clientApp, srcProxy := net.Pipe()
+	dstProxy, destSvc := net.Pipe()
+	t.Cleanup(func() {
+		_ = clientApp.Close()
+		_ = destSvc.Close()
+		_ = srcProxy.Close()
+		_ = dstProxy.Close()
+	})
+
+	r := New(Config{}, srcProxy, dstProxy)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	// Let both forwarder goroutines reach their respective Read calls.
+	time.Sleep(20 * time.Millisecond)
+
+	// Simulate the upstream peer closing the connection (FIN) while the
+	// client side stays idle — the exact production shape from #4173.
+	// The FromDest forwarder will read 0/EOF; the FromClient forwarder
+	// is still parked in Read on srcProxy (clientApp has sent nothing).
+	_ = destSvc.Close()
+
+	// With the fix: FromDest's defer fires closeStopping() and
+	// nudgeDeadline(srcProxy); FromClient's Read returns Timeout(),
+	// loops up, observes stopping closed, exits; wgForward.Wait()
+	// completes; Run returns. All within ~ms.
+	//
+	// Without the fix: Run would block until clientApp.Close() or ctx
+	// cancellation — neither of which we trigger in this test. The
+	// timeout below is the regression guard.
+	select {
+	case err := <-done:
+		if err != nil && !errors.Is(err, io.EOF) {
+			t.Fatalf("Run returned non-nil error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Run did not return within 2s after dest close while client idle (regression of #4173 — relay stuck waiting for FromClient forwarder)")
+	}
+}
+
 func TestFinalizeMockIsNoop(t *testing.T) {
 	t.Parallel()
 	drops := newDropSink()


### PR DESCRIPTION
## Describe the changes that are made
- When one of the relay's two forwarder goroutines exits (typically `FromDest` reading EOF after the upstream sends FIN at idle timeout), close the **other** forwarder's source conn so its blocked `Read` returns immediately. Without this, `wgForward.Wait()` blocks until the application's HTTP client times out on its own — for `botocore`'s default `read_timeout` that is a full 60 seconds per request, every time a pooled-but-already-FIN'd upstream conn is reused.

## Links & References

**Closes:** #4173

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- #4173
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [x] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

The change is in shared transport plumbing (`pkg/agent/proxy/relay/relay.go`) used by every outbound capture path. A targeted e2e test would need a sample app that reuses an HTTP/1.1 keepalive connection across an upstream-side idle timeout. Happy to wire one up under `samples-go` or `samples-python` if reviewers have a preferred shape — see "sample to test the changes" below.

## Added comments for hard-to-understand areas?
- [x] 👍 yes

The new coordinator goroutine has an inline comment explaining the deadlock it resolves and why closing the peer conn is the right wake-up signal.

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

Internal correctness fix — no user-visible API or config change.

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

### Reproduction (~80 lines, no AWS account needed)

A fake upstream that simulates ALB-style "FIN after idle on a keepalive conn" and a tiny `urllib3` client. Full repro is on the linked issue (#4173); the short version:

```bash
# fake upstream — sends FIN after 5s idle on a keepalive TCP
python3 silent_upstream.py &

# Direct (no keploy) — both fast
python3 app.py 127.0.0.1 9090 8
# call-1: status=200 elapsed=0.001s
# call-2: status=200 elapsed=0.001s

# With keploy record (BEFORE this PR)
sudo keploy record -c "python3 app.py 127.0.0.1 9090 8"
# call-1: status=200 elapsed=0.002s
# call-2: FAILED after 60.049s — ReadTimeoutError
# ── mocks.yaml contains only call-1 ──

# With keploy record (AFTER this PR)
sudo keploy record -c "python3 app.py 127.0.0.1 9090 8"
# call-1: status=200 elapsed=0.002s
# call-2: status=200 elapsed=0.001s
# ── mocks.yaml contains BOTH calls ──
```

`urllib3` is the same library `botocore` uses; the asymmetry comes from `urllib3` validating its pooled socket via `wait_for_read(sock, timeout=0)` before reuse, which detects the FIN and reconnects in milliseconds. That validation runs on the socket the application owns — with keploy in the path it sees the (always-alive) localhost socket to keploy, while keploy itself was holding the dead upstream conn without propagating the close fast enough.

### Why "close the peer's source" instead of `nudgeDeadline`

The forwarder loop already treats `SetReadDeadline`-driven `Timeout()` errors as "loop and re-read" (see existing comment in `forward()` around the deadline-handling branch — required so the pause/upgrade choreography keeps working). So nudging the deadline alone wouldn't unblock the goroutine. Closing the underlying conn yields `use of closed network connection` from the next `Read`, which the existing `return err` path handles, and `wgForward.Wait()` completes. Tested locally; the existing pause/upgrade flow is unaffected because the new goroutine only fires when one forwarder has *already* exited.

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?

Side-by-side from the local repro:

| Mode | call-1 | call-2 | mocks captured |
| --- | --- | --- | --- |
| Direct (no keploy) | 1 ms ✅ | 1 ms ✅ | n/a |
| keploy record (unpatched) | 2 ms ✅ | **60.049 s ❌** | 1 (call-2 lost) |
| **keploy record (this PR)** | **2 ms ✅** | **1 ms ✅** | **2 (both captured)** |

In the "before" run the upstream observes only **one** TCP conn — keploy keeps trying to write into the dead one. After the patch, the upstream observes **two** conns — keploy's relay tears down promptly when the upstream FINs, and `urllib3` dials fresh on the retry.

## 🧠 Semantics for PR Title & Branch Name

- PR Title: `fix(relay): close peer conn when one forwarder exits` ✅
- Branch Name: `fix/relay-close-peer-on-forwarder-exit` ✅

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?