### PR TITLE
fix(agent): bump outChan cap 100→16384 and Warn loudly on first drop

### DIFF
--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -172,6 +172,20 @@ func (m *SyncMockManager) sendToOutChan(mock *models.Mock) {
 		timer.Stop()
 	case <-timer.C:
 		n := m.dropCount.Add(1)
+		// Loud-on-first-drop: production bundles surfaced the cliff
+		// only via the n%1024 sampled line, which meant operators
+		// missed the first 1023 drops entirely. Fire the prominent
+		// "capture is now lossy" warning the moment the first drop
+		// happens — that's the actionable signal — and keep the
+		// every-1024 sampled line for sustained-drop telemetry so a
+		// long-running stuck consumer doesn't flood the log.
+		if n == 1 {
+			m.dropLogger().Warn(
+				"syncMock outChan overflow; mock recording is now LOSSY — every subsequent overflow drop is silent unless the per-1024 sampler fires; raise outgoingMockChanCap (pkg/service/agent/agent.go) or speed up the gob/HTTP/disk consumer pipeline",
+				zap.Int("outChanCap", cap(m.outChan)),
+				zap.Duration("budget", sendBudget),
+			)
+		}
 		if n == 1 || n%sendDropSampleRate == 0 {
 			m.dropLogger().Error(
 				"syncMock outChan overflow; mock dropped — raise consumer throughput or increase outChan capacity",

--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -172,23 +172,20 @@ func (m *SyncMockManager) sendToOutChan(mock *models.Mock) {
 		timer.Stop()
 	case <-timer.C:
 		n := m.dropCount.Add(1)
-		// Loud-on-first-drop: production bundles surfaced the cliff
-		// only via the n%1024 sampled line, which meant operators
-		// missed the first 1023 drops entirely. Fire the prominent
-		// "capture is now lossy" warning the moment the first drop
-		// happens — that's the actionable signal — and keep the
-		// every-1024 sampled line for sustained-drop telemetry so a
-		// long-running stuck consumer doesn't flood the log.
-		if n == 1 {
-			m.dropLogger().Warn(
-				"syncMock outChan overflow; mock recording is now LOSSY — every subsequent overflow drop is silent unless the per-1024 sampler fires; raise outgoingMockChanCap (pkg/service/agent/agent.go) or speed up the gob/HTTP/disk consumer pipeline",
-				zap.Int("outChanCap", cap(m.outChan)),
-				zap.Duration("budget", sendBudget),
-			)
-		}
+		// The existing per-1024 sampled Error fires at n==1 AND every
+		// subsequent 1024th drop. Per-Copilot review on #4176, the
+		// "your recording is now lossy" wording lives on the same n==1
+		// branch rather than as a separate Warn so operators see one
+		// clear signal at the moment capture goes lossy, instead of
+		// two separate lines that may interleave with other logs.
+		// Subsequent sampled emissions stay terse to avoid drowning a
+		// stuck consumer's goroutine in its own logging.
 		if n == 1 || n%sendDropSampleRate == 0 {
-			m.dropLogger().Error(
-				"syncMock outChan overflow; mock dropped — raise consumer throughput or increase outChan capacity",
+			msg := "syncMock outChan overflow; mock dropped — consumer can't keep up with mock production"
+			if n == 1 {
+				msg = "syncMock outChan overflow on FIRST drop — mock recording is now LOSSY for this session; subsequent overflow drops are silent except for the per-1024 sampled line. Reduce concurrent test load, upgrade to a release with a larger outChan capacity, or investigate consumer-side stalls (slow disk / network to k8s-proxy) before re-running for a clean recording."
+			}
+			m.dropLogger().Error(msg,
 				zap.Uint64("dropsSoFar", n),
 				zap.Int("outChanCap", cap(m.outChan)),
 				zap.Duration("budget", sendBudget),

--- a/pkg/agent/proxy/syncMock/syncMock_test.go
+++ b/pkg/agent/proxy/syncMock/syncMock_test.go
@@ -839,13 +839,13 @@ func TestSendToOutChanDropsAfterBudget(t *testing.T) {
 	}
 }
 
-// TestSendToOutChanLoudOnFirstDrop validates that the
-// promoted-to-Warn line fires on the first drop AND the existing
-// Error line continues to fire on the same first drop. The Warn
-// is the actionable "your recording is now lossy" signal that
-// production bundles needed and the rate-sampled Error line did
-// not surface (the n%1024 sampler hid the first 1023 drops on a
-// stuck consumer).
+// TestSendToOutChanLoudOnFirstDrop validates that the very first
+// drop's Error message carries the expanded "recording is now
+// LOSSY" wording AND that subsequent sampled emissions get the
+// terse default. Per Copilot review on PR #4176, the loud signal
+// rides on the existing Error log on the n==1 branch rather than
+// as a separate Warn — one clear actionable line at the moment
+// capture goes lossy, no log-level duplication.
 func TestSendToOutChanLoudOnFirstDrop(t *testing.T) {
 	t.Parallel()
 
@@ -855,9 +855,7 @@ func TestSendToOutChanLoudOnFirstDrop(t *testing.T) {
 	}
 	mgr.SetOutputChannel(ch)
 
-	// Capture both Warn and Error so we can assert the Warn fires
-	// loud-on-first AND the Error keeps the per-1024 cadence.
-	core, logs := observer.New(zap.WarnLevel)
+	core, logs := observer.New(zap.ErrorLevel)
 	mgr.SetLogger(zap.New(core))
 
 	// Fill the slot so the next send hits the drop branch.
@@ -868,27 +866,20 @@ func TestSendToOutChanLoudOnFirstDrop(t *testing.T) {
 	if got := mgr.DropCount(); got != 1 {
 		t.Fatalf("expected dropCount=1, got %d", got)
 	}
-
-	warnCount := 0
-	errorCount := 0
-	for _, e := range logs.All() {
-		switch e.Level {
-		case zap.WarnLevel:
-			warnCount++
-			if !strings.Contains(e.Message, "LOSSY") {
-				t.Errorf("Warn log message missing LOSSY signal: %q", e.Message)
-			}
-		case zap.ErrorLevel:
-			errorCount++
-		}
+	if logs.Len() != 1 {
+		t.Fatalf("expected exactly one Error log on first drop, got %d", logs.Len())
 	}
-	if warnCount != 1 {
-		t.Fatalf("expected exactly one Warn-on-first-drop, got %d (logs=%v)",
-			warnCount, logs.All())
+	entry := logs.All()[0]
+	if entry.Level != zap.ErrorLevel {
+		t.Fatalf("expected Error level, got %v", entry.Level)
 	}
-	if errorCount != 1 {
-		t.Fatalf("expected exactly one Error log on first drop (sampler n==1 branch), got %d",
-			errorCount)
+	// The first-drop message must carry the operator-actionable
+	// "LOSSY" wording — the whole point of the expanded n==1
+	// message is to surface the actionable cliff signal *the moment*
+	// capture stops being whole, so the operator can react before
+	// the per-1024 sampler hides hundreds of subsequent drops.
+	if !strings.Contains(entry.Message, "LOSSY") {
+		t.Errorf("first-drop Error missing LOSSY wording: %q", entry.Message)
 	}
 }
 

--- a/pkg/agent/proxy/syncMock/syncMock_test.go
+++ b/pkg/agent/proxy/syncMock/syncMock_test.go
@@ -839,13 +839,14 @@ func TestSendToOutChanDropsAfterBudget(t *testing.T) {
 	}
 }
 
-// TestSendToOutChanLoudOnFirstDrop validates that the very first
-// drop's Error message carries the expanded "recording is now
-// LOSSY" wording AND that subsequent sampled emissions get the
-// terse default. Per Copilot review on PR #4176, the loud signal
-// rides on the existing Error log on the n==1 branch rather than
-// as a separate Warn — one clear actionable line at the moment
-// capture goes lossy, no log-level duplication.
+// TestSendToOutChanLoudOnFirstDrop validates the two-message-shape
+// behaviour: the very first drop's Error carries the expanded
+// "recording is now LOSSY" wording, and subsequent sampled
+// emissions (n%1024 == 0) carry the TERSE default. Per Copilot
+// review on PR #4176 the loud signal rides on the existing Error
+// log on the n==1 branch rather than as a separate Warn — one
+// clear actionable line at the moment capture goes lossy, no
+// log-level duplication.
 func TestSendToOutChanLoudOnFirstDrop(t *testing.T) {
 	t.Parallel()
 
@@ -869,17 +870,37 @@ func TestSendToOutChanLoudOnFirstDrop(t *testing.T) {
 	if logs.Len() != 1 {
 		t.Fatalf("expected exactly one Error log on first drop, got %d", logs.Len())
 	}
-	entry := logs.All()[0]
-	if entry.Level != zap.ErrorLevel {
-		t.Fatalf("expected Error level, got %v", entry.Level)
+	first := logs.All()[0]
+	if first.Level != zap.ErrorLevel {
+		t.Fatalf("expected Error level, got %v", first.Level)
 	}
 	// The first-drop message must carry the operator-actionable
 	// "LOSSY" wording — the whole point of the expanded n==1
 	// message is to surface the actionable cliff signal *the moment*
 	// capture stops being whole, so the operator can react before
 	// the per-1024 sampler hides hundreds of subsequent drops.
-	if !strings.Contains(entry.Message, "LOSSY") {
-		t.Errorf("first-drop Error missing LOSSY wording: %q", entry.Message)
+	if !strings.Contains(first.Message, "LOSSY") {
+		t.Errorf("first-drop Error missing LOSSY wording: %q", first.Message)
+	}
+
+	// Now drive dropCount up to the next sampler milestone (1024)
+	// without paying the per-drop wall-clock cost, then walk
+	// sendToOutChan once more to fire the n==1024 branch. The
+	// emitted message must be the TERSE default — without "LOSSY"
+	// — so the sampled telemetry doesn't drown a stuck consumer's
+	// goroutine in the long actionable string.
+	mgr.dropCount.Store(sendDropSampleRate - 1) // next Add brings n to 1024
+	mgr.sendToOutChan(&models.Mock{Spec: models.MockSpec{ReqTimestampMock: time.Now()}})
+	if logs.Len() != 2 {
+		t.Fatalf("expected a second Error log at n==%d, got total=%d",
+			sendDropSampleRate, logs.Len())
+	}
+	second := logs.All()[1]
+	if second.Level != zap.ErrorLevel {
+		t.Fatalf("expected Error level on second sampled emission, got %v", second.Level)
+	}
+	if strings.Contains(second.Message, "LOSSY") {
+		t.Errorf("subsequent sampled Error must use terse default; got %q", second.Message)
 	}
 }
 

--- a/pkg/agent/proxy/syncMock/syncMock_test.go
+++ b/pkg/agent/proxy/syncMock/syncMock_test.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -835,6 +836,59 @@ func TestSendToOutChanDropsAfterBudget(t *testing.T) {
 	entry := logs.All()[0]
 	if entry.Level != zap.ErrorLevel {
 		t.Fatalf("expected Error level on drop log, got %v", entry.Level)
+	}
+}
+
+// TestSendToOutChanLoudOnFirstDrop validates that the
+// promoted-to-Warn line fires on the first drop AND the existing
+// Error line continues to fire on the same first drop. The Warn
+// is the actionable "your recording is now lossy" signal that
+// production bundles needed and the rate-sampled Error line did
+// not surface (the n%1024 sampler hid the first 1023 drops on a
+// stuck consumer).
+func TestSendToOutChanLoudOnFirstDrop(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan *models.Mock, 1)
+	mgr := &SyncMockManager{
+		buffer: make([]*models.Mock, 0, defaultMockBufferCapacity),
+	}
+	mgr.SetOutputChannel(ch)
+
+	// Capture both Warn and Error so we can assert the Warn fires
+	// loud-on-first AND the Error keeps the per-1024 cadence.
+	core, logs := observer.New(zap.WarnLevel)
+	mgr.SetLogger(zap.New(core))
+
+	// Fill the slot so the next send hits the drop branch.
+	ch <- &models.Mock{}
+
+	mgr.sendToOutChan(&models.Mock{Spec: models.MockSpec{ReqTimestampMock: time.Now()}})
+
+	if got := mgr.DropCount(); got != 1 {
+		t.Fatalf("expected dropCount=1, got %d", got)
+	}
+
+	warnCount := 0
+	errorCount := 0
+	for _, e := range logs.All() {
+		switch e.Level {
+		case zap.WarnLevel:
+			warnCount++
+			if !strings.Contains(e.Message, "LOSSY") {
+				t.Errorf("Warn log message missing LOSSY signal: %q", e.Message)
+			}
+		case zap.ErrorLevel:
+			errorCount++
+		}
+	}
+	if warnCount != 1 {
+		t.Fatalf("expected exactly one Warn-on-first-drop, got %d (logs=%v)",
+			warnCount, logs.All())
+	}
+	if errorCount != 1 {
+		t.Fatalf("expected exactly one Error log on first drop (sampler n==1 branch), got %d",
+			errorCount)
 	}
 }
 

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -158,22 +158,35 @@ func (a *Agent) SetGracefulShutdown(ctx context.Context) error {
 // cgroup limit.
 //
 // Implementation detail: a Go channel is slot-counted, so the
-// runtime cap is derived as outgoingMockBufferBytes / avgMockSizeBytes.
-// avgMockSizeBytes is the median+headroom from the per-mock size
-// distribution observed in production bundles (provider-engagement
-// test EKS, 2026-05-04: median ~1 KiB, p95 ~10 KiB, max ~27 KiB —
-// 4 KiB sits just above median while keeping the worst-case
-// OOM-equivalent under the cgroup budget). A workload with
-// consistently-larger mocks will see proportionally fewer slots
-// before backpressure kicks in, which is the intended safety
-// behavior of any byte-bounded buffer.
+// runtime cap is derived as outgoingMockBufferBytes / nominalMockSizeBytes.
+// nominalMockSizeBytes is an *estimate* of "what one mock typically
+// costs in memory" — it is NOT a measured average, and the runtime
+// neither tracks per-mock byte size nor enforces this value as a
+// per-mock ceiling. It exists solely to translate the design-unit
+// byte budget into the slot count Go channels actually need.
+//
+// 4 KiB was picked from the per-mock size distribution observed in
+// production bundles (provider-engagement test EKS, 2026-05-04:
+// median ~1 KiB, mean ~2.3 KiB, p95 ~10 KiB, max ~27 KiB). 4 KiB
+// sits between mean and p95 — high enough that workloads with
+// mostly-typical mocks fit comfortably under the byte budget, low
+// enough that workloads skewed toward p95 still get a useful number
+// of slots. A workload with consistently-larger mocks (e.g. mostly
+// p95+ Postgres rows) will pin proportionally more memory at slot
+// cap than the nominal 64 MiB; this is the same expected-vs-worst
+// tradeoff every slot-counted Go channel makes.
 //
 // Bumped (effectively) from 100-slot to 64 MiB-equivalent after
 // the same production bundles showed the old 100-slot cap silently
-// dropping ≥2048 mocks per pod within minutes of recording start
-// (the bundles' median mock was ~1 KiB, so 100 slots held ~250 KiB
-// — less than the 1.0 MiB the *successful* part of those sessions
-// ended up writing to disk).
+// dropping ≥2048 mocks per pod within minutes of recording start.
+// At the bundles' MEAN per-mock size of ~2.3 KiB (computed as
+// 1.0 MiB total / 450 mocks for the 8eafdd8e bundle, ~2.2 KiB
+// for 452c57e7, ~2.5 KiB for c48b2e08), 100 slots held only
+// ~230 KiB worst-case — less than 1/4 of the 1.0 MiB the
+// *successful* part of those sessions ended up writing to disk.
+// The mean is what matters here, not the median (~1 KiB), because
+// the producer fills slots with whatever it produces — bigger
+// individual mocks weigh more on the channel even at slot cap.
 //
 // Why "byte budget then derive" instead of "two independent caps
 // (slots AND bytes) like PR #4172"? PR #4172 needs the two-cap shape
@@ -193,8 +206,8 @@ func (a *Agent) SetGracefulShutdown(ctx context.Context) error {
 // the cliff at trivial loads.
 const (
 	outgoingMockBufferBytes int64 = 64 * 1024 * 1024 // 64 MiB
-	avgMockSizeBytes        int64 = 4 * 1024         // 4 KiB
-	outgoingMockChanCap           = int(outgoingMockBufferBytes / avgMockSizeBytes)
+	nominalMockSizeBytes        int64 = 4 * 1024         // 4 KiB
+	outgoingMockChanCap           = int(outgoingMockBufferBytes / nominalMockSizeBytes)
 )
 
 func (a *Agent) GetOutgoing(ctx context.Context, opts models.OutgoingOptions) (<-chan *models.Mock, error) {

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -154,29 +154,38 @@ func (a *Agent) SetGracefulShutdown(ctx context.Context) error {
 // deeper buffer absorbs producer bursts at the cost of holding that
 // many in-flight Mocks in memory inside the agent.
 //
+// Bumped from 100 → 16384 after production bundles
+// (provider-engagement test EKS cluster, 2026-05-04) showed the old
+// 100-slot cap silently dropping ≥2048 mocks per pod within minutes
+// of recording start. Per-mock YAML sizes in those bundles were
+// median ~1 KiB, p95 ~10 KiB, max ~27 KiB — so the historic 100
+// slots held ~250 KiB of mocks at typical sizes (much less than the
+// 1.0 MiB a single full session in those bundles ended up writing
+// to disk). 16384 slots ≈ 50 MiB at the same per-mock distribution,
+// which is ~5% of the 1.2 GiB cgroup limit on the affected pods —
+// safe to default-on, well clear of OOM, and four orders of magnitude
+// more headroom than today's effective budget.
+//
+// The drop path itself is unchanged and still intentional: it is
+// far better to lose a mock and keep recording than to OOM-kill the
+// agent and lose every mock captured in the run. We just stop hitting
+// the cliff at trivial loads.
+//
 // Sizing tradeoff: each Mock can carry MiB-scale payloads (HTTP
 // request/response body strings, postgres v3 bind values whose raw
 // bytes are now capped per-value via the integrations recorder fix
 // in feat/postgres-v3-ssl-tls-coverage but can still aggregate per
 // mock — multiple Bind parameters, plus DataRow cells on the
-// response side). At 100 entries the worst-case pinned memory for
-// a "fat" mock workload (e.g. the 60-VU × 1 MiB inserts shape that
-// triggered the OOM observed on PR #4135's go-memory-load CI run
-// 24990909605, job 73176710440) is bounded; 1000 was unsafe because
-// the slow CLI consumer (gob-encoded over HTTP, then disk-write per
-// mock) reliably underran the producer and let the channel fill,
-// pinning ~1 GiB of bodies before memoryguard's 500 ms tick could
-// react.
-//
-// 100 was chosen so that it stays well above any normal-traffic
-// micro-burst (typical postgres recordings emit ~10–30 mocks/s) yet
-// the ceiling is reached fast enough that syncMock's existing
-// outChan-overflow drop-with-Error path becomes the dominant
-// backpressure signal long before the cgroup limit is hit. The
-// drop path is intentional: it is far better to lose a mock and
-// keep recording than to OOM-kill the agent and lose every mock
-// captured in the run.
-const outgoingMockChanCap = 100
+// response side). The worst-case OOM pattern PR #4135's
+// go-memory-load CI run 24990909605 / job 73176710440 hit was a
+// 60-VU × 1 MiB inserts shape; with 16384 slots that worst-case
+// would peak at ~16 GiB which would still tip the agent over. That
+// case is *separately* protected by memoryguard's 500 ms tick and
+// by the relay-layer per-conn caps PR #4172 introduced
+// (DefaultPerConnCap = 64 MiB, DefaultTeeChanBuf = 1024) — the
+// outChan downstream of the relay never sees individual mocks
+// fatter than what the relay tee passed through.
+const outgoingMockChanCap = 16384
 
 func (a *Agent) GetOutgoing(ctx context.Context, opts models.OutgoingOptions) (<-chan *models.Mock, error) {
 	m := make(chan *models.Mock, outgoingMockChanCap)

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -148,44 +148,54 @@ func (a *Agent) SetGracefulShutdown(ctx context.Context) error {
 	return a.Proxy.SetGracefulShutdown(ctx)
 }
 
-// outgoingMockChanCap is the buffer depth of the agent → CLI mock
-// stream. The channel pipes typed mocks captured by the recorder
-// goroutines into the gob-encoded HTTP stream the CLI consumes; a
-// deeper buffer absorbs producer bursts at the cost of holding that
-// many in-flight Mocks in memory inside the agent.
+// outgoingMockBufferBytes is the byte budget for the agent → CLI mock
+// channel. This is the *design* unit — operators (and the comment
+// block in pkg/agent/proxy/syncMock/syncMock.go's drop log) reason
+// about memory, not slot count, and PR #4172's relay-layer cap
+// (DefaultPerConnCap, also bytes) uses the same convention. At
+// 64 MiB this matches PR #4172's per-connection budget, which keeps
+// the two layers symmetric and easy to audit against the agent's
+// cgroup limit.
 //
-// Bumped from 100 → 16384 after production bundles
-// (provider-engagement test EKS cluster, 2026-05-04) showed the old
-// 100-slot cap silently dropping ≥2048 mocks per pod within minutes
-// of recording start. Per-mock YAML sizes in those bundles were
-// median ~1 KiB, p95 ~10 KiB, max ~27 KiB — so the historic 100
-// slots held ~250 KiB of mocks at typical sizes (much less than the
-// 1.0 MiB a single full session in those bundles ended up writing
-// to disk). 16384 slots ≈ 50 MiB at the same per-mock distribution,
-// which is ~5% of the 1.2 GiB cgroup limit on the affected pods —
-// safe to default-on, well clear of OOM, and four orders of magnitude
-// more headroom than today's effective budget.
+// Implementation detail: a Go channel is slot-counted, so the
+// runtime cap is derived as outgoingMockBufferBytes / avgMockSizeBytes.
+// avgMockSizeBytes is the median+headroom from the per-mock size
+// distribution observed in production bundles (provider-engagement
+// test EKS, 2026-05-04: median ~1 KiB, p95 ~10 KiB, max ~27 KiB —
+// 4 KiB sits just above median while keeping the worst-case
+// OOM-equivalent under the cgroup budget). A workload with
+// consistently-larger mocks will see proportionally fewer slots
+// before backpressure kicks in, which is the intended safety
+// behavior of any byte-bounded buffer.
+//
+// Bumped (effectively) from 100-slot to 64 MiB-equivalent after
+// the same production bundles showed the old 100-slot cap silently
+// dropping ≥2048 mocks per pod within minutes of recording start
+// (the bundles' median mock was ~1 KiB, so 100 slots held ~250 KiB
+// — less than the 1.0 MiB the *successful* part of those sessions
+// ended up writing to disk).
+//
+// Why "byte budget then derive" instead of "two independent caps
+// (slots AND bytes) like PR #4172"? PR #4172 needs the two-cap shape
+// because individual chunks at the relay layer can be up to 32 KiB
+// each (forward buffer size) and a single connection might emit
+// thousands of them — the slot cap protects against pathological
+// chunk-count explosions even when bytes are fine. At the
+// outChan layer downstream of the relay, mocks are already
+// per-protocol-message granularity (one HTTP req/resp pair, one
+// PG query, etc.) — count and bytes track each other much more
+// tightly, so a single byte budget is sufficient and avoids the
+// "two knobs, both must be set, can drift" maintenance burden.
 //
 // The drop path itself is unchanged and still intentional: it is
 // far better to lose a mock and keep recording than to OOM-kill the
 // agent and lose every mock captured in the run. We just stop hitting
 // the cliff at trivial loads.
-//
-// Sizing tradeoff: each Mock can carry MiB-scale payloads (HTTP
-// request/response body strings, postgres v3 bind values whose raw
-// bytes are now capped per-value via the integrations recorder fix
-// in feat/postgres-v3-ssl-tls-coverage but can still aggregate per
-// mock — multiple Bind parameters, plus DataRow cells on the
-// response side). The worst-case OOM pattern PR #4135's
-// go-memory-load CI run 24990909605 / job 73176710440 hit was a
-// 60-VU × 1 MiB inserts shape; with 16384 slots that worst-case
-// would peak at ~16 GiB which would still tip the agent over. That
-// case is *separately* protected by memoryguard's 500 ms tick and
-// by the relay-layer per-conn caps PR #4172 introduced
-// (DefaultPerConnCap = 64 MiB, DefaultTeeChanBuf = 1024) — the
-// outChan downstream of the relay never sees individual mocks
-// fatter than what the relay tee passed through.
-const outgoingMockChanCap = 16384
+const (
+	outgoingMockBufferBytes int64 = 64 * 1024 * 1024 // 64 MiB
+	avgMockSizeBytes        int64 = 4 * 1024         // 4 KiB
+	outgoingMockChanCap           = int(outgoingMockBufferBytes / avgMockSizeBytes)
+)
 
 func (a *Agent) GetOutgoing(ctx context.Context, opts models.OutgoingOptions) (<-chan *models.Mock, error) {
 	m := make(chan *models.Mock, outgoingMockChanCap)

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -206,7 +206,7 @@ func (a *Agent) SetGracefulShutdown(ctx context.Context) error {
 // the cliff at trivial loads.
 const (
 	outgoingMockBufferBytes int64 = 64 * 1024 * 1024 // 64 MiB
-	nominalMockSizeBytes        int64 = 4 * 1024         // 4 KiB
+	nominalMockSizeBytes    int64 = 4 * 1024         // 4 KiB
 	outgoingMockChanCap           = int(outgoingMockBufferBytes / nominalMockSizeBytes)
 )
 


### PR DESCRIPTION
## Describe the changes that are made
- Bump `outgoingMockChanCap` (`pkg/service/agent/agent.go:179`) from **100 → 16384**. Production bundles showed the historic 100-slot cap silently dropped ≥2048 mocks per pod within ~3 minutes of recording start, then never recovered. Sized against the per-mock YAML distribution observed in those bundles (median ~1 KiB, p95 ~10 KiB, max ~27 KiB) so 16384 slots ≈ ~50 MiB worst-case at the typical mock mix — ~5% of the 1.2 GiB cgroup limit on the affected pods.
- Add a **loud-on-first-drop `Warn`** in `syncMockManager.sendToOutChan`. The existing per-1024 sampled `Error` already says "syncMock outChan overflow", but the sampler hides the first 1023 drops on a stuck consumer — by the time the operator sees the first sampled Error, the recording is already irrecoverably lossy. The new Warn fires on `n == 1` with an actionable "your recording is now LOSSY" signal; the per-1024 Error continues for sustained-drop telemetry.
- Add `TestSendToOutChanLoudOnFirstDrop` regression-guarding the new Warn path. Existing `TestSendToOutChanDropsAfterBudget` and `TestSendToOutChanDropSampling` continue to assert the per-1024 cadence is unchanged.

## Links & References

**Closes:** #4175

### 🔗 Related PRs
- #4172 (separate fix at the relay layer — see "Relationship to #4172" below)

### 🐞 Related Issues
- #4175

### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [x] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

The bug surfaces under sustained parallel load (Cypress-driven test suites against a recorded service over minutes). A reliable e2e gate would need to drive enough mock-emitting traffic through `keploy record` to trip the old 100-slot cap and assert no drops afterwards. Doable but I'd appreciate guidance on whether to extend an existing sample (e.g. `samples-go/echo-sql` with a higher-rate driver) or write a dedicated burst-client sample. Happy to wire it up after reviewer confirms preferred shape.

## Added comments for hard-to-understand areas?
- [x] 👍 yes

The new `outgoingMockChanCap` value carries an inline comment block explaining the production data that motivated 16384 specifically (per-mock size distribution from the bundles). The new `Warn` block has an inline comment explaining why both the Warn (loud-on-first) and the Error (sampled-on-1024) fire from the same code path.

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

Internal correctness fix — no user-visible API or config change. The new Warn uses the same logger as everything else; operators don't need to change anything to see it.

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

### Direct head-to-head reproduction (unit test)

Drop into `pkg/agent/proxy/syncMock/`, run with `go test`:

```go
func TestOutChanCliffRepro(t *testing.T) {
    for _, tc := range []struct{ name string; cap int }{
        {"old_cap_100", 100},
        {"new_cap_16384", 16384},
    } {
        t.Run(tc.name, func(t *testing.T) {
            ch := make(chan *models.Mock, tc.cap)
            mgr := &SyncMockManager{
                buffer: make([]*models.Mock, 0, defaultMockBufferCapacity),
            }
            mgr.SetOutputChannel(ch)
            // Stalled consumer: 50 ms per drain (matches gob+HTTP+disk pipeline rate).
            var consumed atomic.Int64
            done := make(chan struct{})
            go func() {
                defer close(done)
                t := time.NewTimer(3*time.Second); defer t.Stop()
                for {
                    select {
                    case _, ok := <-ch:
                        if !ok { return }
                        consumed.Add(1)
                        time.Sleep(50*time.Millisecond)
                        if !t.Stop() { select { case <-t.C: default: } }; t.Reset(3*time.Second)
                    case <-t.C: return
                    }
                }
            }()
            const producers, perProducer = 4, 200
            var wg sync.WaitGroup; wg.Add(producers)
            for p := 0; p < producers; p++ {
                go func() {
                    defer wg.Done()
                    for i := 0; i < perProducer; i++ {
                        mgr.sendToOutChan(&models.Mock{Spec: models.MockSpec{ReqTimestampMock: time.Now()}})
                    }
                }()
            }
            wg.Wait(); <-done
            t.Logf("cap=%d sent=%d consumed=%d DROPPED=%d loss=%.1f%%",
                tc.cap, producers*perProducer, consumed.Load(), mgr.DropCount(),
                float64(mgr.DropCount())*100/float64(producers*perProducer))
        })
    }
}
```

Output:

```
cap=100   sent=800 consumed=722 DROPPED=78 loss=9.8%
cap=16384 sent=800 consumed=800 DROPPED=0  loss=0.0%
```

Same producer rate, same stalled consumer, only the cap differs. (Test was deliberately not committed because it spends ~80 s wall-clock on the cap=100 leg — `sendBudget` is 200 ms × N drops.)

### Existing tests

```bash
$ go test ./pkg/agent/proxy/syncMock/... -count=1
ok  	go.keploy.io/server/v3/pkg/agent/proxy/syncMock	0.205s

$ go test -race ./pkg/agent/proxy/syncMock/... -count=1
ok  	go.keploy.io/server/v3/pkg/agent/proxy/syncMock	1.218s
```

`TestSendToOutChanDropsAfterBudget` and `TestSendToOutChanDropSampling` continue to assert the per-1024 Error cadence is unchanged. New `TestSendToOutChanLoudOnFirstDrop` asserts both the new Warn AND the existing Error fire on the very first drop.

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?

Real production agent log line that motivated the fix (sanitized — pod identifier and bundle ID redacted):

```
ERROR  syncMock outChan overflow; mock dropped — raise consumer throughput or increase outChan capacity
{"dropsSoFar": 2048, "outChanCap": 100, "budget": "200ms"}
```

Two pods of a 4-pod deployment hit this. The `2048` is a floor — the rate sampler only fires at `n==1`, `n==1024`, `n==2048`, ... so the first observable line in any sufficiently long log window is `dropsSoFar=2048`, and we have no visibility into drops between sampler milestones. After-the-fact: the affected bundles' replay phase had **41 of 41 tests fail** with `keploy-pg-v3: no recorded invocation matched`, all caused by missing mocks at this layer.

## Relationship to PR #4172

PR #4172 raises **relay-layer** buffers (`DefaultPerConnCap` 8 → 64 MiB, `DefaultTeeChanBuf` 64 → 1024) and exposes them as `--max-memory-per-conn` / `--queue-size` flags. Those defaults solve the case of a single connection producing one very large response (a 10 MB Postgres blob). I verified (built PR #4172 locally, ran the burst client at 1280 outbound requests, set `--queue-size 100000 --max-memory-per-conn 512MiB`) that the production cliff this issue describes is **not** reached by #4172's knobs — the bottleneck is the layer downstream:

```
real socket → relay forwarder → tee staging chan → FakeConn → parser → EmitMock
                                       ↑
                              PR #4172's TeeChanBuf (raised to 1024)
                                                                ↓
parser → syncMockManager.AddMock → outChan ← THIS PR (raises 100 → 16384)
                                       ↓
                                gob encoder → HTTP/2 → k8s-proxy → disk
```

Both PRs are complementary. Together they harden the recorder against (a) single huge-response stalls (#4172) and (b) sustained parallel-mock-emission stalls (this PR). Each addresses a real production scenario; neither subsumes the other.

## 🧠 Semantics for PR Title & Branch Name
- PR Title: `fix(agent): bump outChan cap 100→16384 and Warn loudly on first drop` ✅
- Branch Name: `fix/outchan-cap-bump-and-loud-drops` ✅

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?