### PR TITLE
fix(pcap): drop redundant handler flush racing with capture goroutine

### DIFF
--- a/.github/workflows/sample_tls_pcap.yml
+++ b/.github/workflows/sample_tls_pcap.yml
@@ -45,6 +45,9 @@ jobs:
           - job: record_build_replay_build
             record_src: build
             replay_src: build
+          - job: record_latest_replay_latest
+            record_src: latest
+            replay_src: latest
         mode:
           - name: capture-only
             flags: "--capture-packets"

--- a/.github/workflows/sample_tls_pcap.yml
+++ b/.github/workflows/sample_tls_pcap.yml
@@ -45,9 +45,6 @@ jobs:
           - job: record_build_replay_build
             record_src: build
             replay_src: build
-          - job: record_latest_replay_latest
-            record_src: latest
-            replay_src: latest
         mode:
           - name: capture-only
             flags: "--capture-packets"

--- a/pkg/agent/proxy/proxy_v2.go
+++ b/pkg/agent/proxy/proxy_v2.go
@@ -141,6 +141,7 @@ func (p *Proxy) recordViaSupervisor(
 	svSess.DestStream = r.DestStream()
 	svSess.Directives = r.Directives()
 	svSess.Acks = r.Acks()
+	svSess.PreClaimPauseBarrier = r.PreClaimPauseBarrier
 
 	// Run the relay in its own goroutine under the supervisor's lifetime.
 	// The supervisor's Close (via sv.SessionOnAbort below) closes the

--- a/pkg/agent/proxy/relay/relay.go
+++ b/pkg/agent/proxy/relay/relay.go
@@ -166,6 +166,31 @@ func New(cfg Config, src, dst net.Conn) *Relay {
 	return r
 }
 
+// PreClaimPauseBarrier installs the relay's pause barrier synchronously
+// from the caller's goroutine, BEFORE the parser sends a directive that
+// also installs one. This closes the goroutine-scheduling race where a
+// directive sent on a buffered channel takes long enough to reach the
+// directive processor that the C2D/D2C forwarders process another peer
+// exchange in the meantime — for the Postgres SSL preamble that means
+// the C2D forwarder forwards the client's TLS ClientHello to the
+// upstream as cleartext, corrupting the upstream wire so the directive
+// handler's later reads see a TLS record (0x16…) instead of the 'S'
+// SSLResponse it expected.
+//
+// Idempotent: subsequent calls reuse the same pause channel. The
+// matching endPause runs from the directive handler's normal path —
+// callers never need to release the barrier themselves.
+//
+// Returns true if this call installed the barrier (the parser is the
+// writer), false if a barrier was already in effect.
+func (r *Relay) PreClaimPauseBarrier() bool {
+	r.pauseMu.Lock()
+	already := r.pauseCh != nil
+	r.pauseMu.Unlock()
+	r.beginPause()
+	return !already
+}
+
 // ClientStream returns the parser-facing FakeConn populated with
 // chunks read from the real client (bytes flowing client → dest).
 // Safe to call before or after Run starts.

--- a/pkg/agent/proxy/supervisor/session.go
+++ b/pkg/agent/proxy/supervisor/session.go
@@ -65,6 +65,17 @@ type Session struct {
 	// Acks is the parser's receive channel for directive acknowledgements.
 	Acks <-chan directive.Ack
 
+	// PreClaimPauseBarrier, when non-nil, lets the parser install the
+	// relay's pause barrier synchronously from its own goroutine BEFORE
+	// sending a directive that also installs one. Used by parsers that
+	// need to defeat the directive-channel scheduling race when the next
+	// real-socket Read is about to deliver bytes that would corrupt the
+	// upstream protocol state (Postgres SSL preamble: C2D forwarding the
+	// client's TLS ClientHello to upstream as cleartext before the
+	// directive handler's beginPause runs). Idempotent — the matching
+	// endPause runs from the directive handler's normal path.
+	PreClaimPauseBarrier func() bool
+
 	// Mocks is the mock-sink channel. Parsers should call EmitMock
 	// rather than sending here directly so the incomplete-mock gate
 	// and the post-record hook chain run consistently.

--- a/pkg/agent/routes/record.go
+++ b/pkg/agent/routes/record.go
@@ -217,8 +217,10 @@ func (a *Agent) HandlePcapStream(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 
 	// Subscribe synchronously BEFORE committing the status code.
-	// SubscribePcap writes the pcap file header into w, which
-	// triggers an implicit 200 in net/http — this is intentional.
+	// SubscribePcap writes the pcap file header into w and flushes it
+	// (triggering an implicit 200 in net/http) before registering the
+	// subscriber, so the client sees a well-formed stream and we don't
+	// race with the capture goroutine on the response's bufio.Writer.
 	// If capture is not active it returns an error without writing
 	// to w, so we can still return 503 cleanly.
 	unsub, err := a.svc.SubscribePcap(w, flusher.Flush)
@@ -227,7 +229,6 @@ func (a *Agent) HandlePcapStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer unsub()
-	flusher.Flush() // push the pcap file header to the client
 	<-r.Context().Done()
 }
 


### PR DESCRIPTION
integration-ref: feat/tls-keylog-postgres

## Summary

Two related fixes for the same `run_sample_tls_pcap (capture-only)` flake:

### 1. `flusher.Flush()` data race on the pcap stream
- `HandlePcapStream` flushed the response a second time after `SubscribePcap` returned, racing with the capture goroutine's own per-subscriber flush on the same `http.ResponseWriter`
- The handler's flush was redundant — `subscribe()` writes the pcap file header and flushes it *before* registering the subscriber, so the header has already reached the client by the time `SubscribePcap` returns
- Drop the second flush; the broadcaster's mutex-serialized flush is the only writer to `w` from registration onward

### 2. Postgres SSL preamble race (paired with `keploy/integrations#<TBD>`)
Removing the data race above unmasked a second flake on the same matrix entry:

```
v3 recorder V2: SSLRequest detected
V2: sending postgres ssl-choreo directive
mock marked incomplete  reason: "unexpected ssl response"
unexpected SSL response byte: 0x16
```

`0x16` is the TLS handshake record type — the directive handler read what postgres sent in response to a TLS ClientHello, not the expected `'S'` SSLResponse byte. Parser sends `UpgradeTLS` on a buffered directives channel; the directive processor needs a goroutine schedule hop before `beginPause` runs. In that gap the C2D forwarder forwards the real client's ClientHello to the upstream as cleartext, postgres slips into TLS-handshake state, and the upstream becomes corrupted from keploy's MITM perspective. pgx's follow-on TLS write on that corrupted upstream stalls — surfaces as `failed to write startup message: timeout` and the app aborts the recording session.

Fix:
- new `Relay.PreClaimPauseBarrier()` — installs the pause barrier synchronously from any goroutine
- exposed via `supervisor.Session.PreClaimPauseBarrier`
- the postgres v3 recorder calls it immediately after detecting `SSLRequest`, before sending the SSL-choreo directive

The barrier is idempotent with the directive handler's own `beginPause`; `endPause` runs from the directive handler's normal path, so the parser doesn't need to release it. The `Session` field is nil-safe — older parsers continue to work.

## Verification
- Reproduced the postgres flake locally: race-enabled keploy with private parsers, sample-tls-app + dockerised mysql/postgres TLS, the failing matrix entry hits the same `0x16` signature ~1/2 runs
- After the fix: 5/5 sequential record sessions complete in ~4 s, postgres ping OK, no `unexpected ssl response`, no `WARNING: DATA RACE`
- `go test -race` clean in both `pkg/agent/proxy/relay/` and `pkg/postgres/v3/recorder/`

## Test plan
- [ ] `run_sample_tls_pcap` matrix passes deterministically with `integration-ref: feat/tls-keylog-postgres` wiring the cross-repo build
- [ ] No data-race traces in any matrix entry's agent log
