### PR TITLE
fix(testdb): propagate auto-assigned name back onto tc.Name

### DIFF
--- a/pkg/platform/yaml/testdb/db.go
+++ b/pkg/platform/yaml/testdb/db.go
@@ -358,6 +358,13 @@ func (ts *TestYaml) upsert(ctx context.Context, testSetID string, tc *models.Tes
 			return tcsInfo{name: "", path: tcsPath}, err
 		}
 		tcsName = claimed
+		// Propagate the auto-assigned name back onto tc so callers can
+		// observe what was actually written to disk. Wrappers around
+		// InsertTestCase (e.g. k8s-proxy's testDBWrapper) key per-session
+		// dedupe and broadcast state on tc.Name; without this propagation
+		// every auto-named capture in a test set looks like the same
+		// nameless event and silently collapses into one entry.
+		tc.Name = claimed
 		reservedPlaceholder = true
 	} else {
 		tcsName = tc.Name

--- a/pkg/platform/yaml/testdb/db.go
+++ b/pkg/platform/yaml/testdb/db.go
@@ -358,13 +358,6 @@ func (ts *TestYaml) upsert(ctx context.Context, testSetID string, tc *models.Tes
 			return tcsInfo{name: "", path: tcsPath}, err
 		}
 		tcsName = claimed
-		// Propagate the auto-assigned name back onto tc so callers can
-		// observe what was actually written to disk. Wrappers around
-		// InsertTestCase (e.g. k8s-proxy's testDBWrapper) key per-session
-		// dedupe and broadcast state on tc.Name; without this propagation
-		// every auto-named capture in a test set looks like the same
-		// nameless event and silently collapses into one entry.
-		tc.Name = claimed
 		reservedPlaceholder = true
 	} else {
 		tcsName = tc.Name
@@ -493,6 +486,18 @@ func (ts *TestYaml) upsert(ctx context.Context, testSetID string, tc *models.Tes
 	}
 
 	writeSucceeded = true
+	// Propagate the auto-assigned name back onto tc so callers can observe
+	// what was actually persisted. Wrappers around InsertTestCase (e.g.
+	// k8s-proxy's testDBWrapper) key per-session dedupe and broadcast state
+	// on tc.Name; without this propagation every auto-named capture in a
+	// test set looks like the same nameless event and silently collapses
+	// into one entry. Done here, after the rename succeeds, so a failure
+	// earlier in upsert (which triggers the deferred placeholder cleanup)
+	// leaves tc.Name unchanged — callers retrying the insert will not
+	// observe a name that no .yaml file backs.
+	if reservedPlaceholder {
+		tc.Name = tcsName
+	}
 	return tcsInfo{name: tcsName, path: tcsPath}, nil
 }
 

--- a/pkg/platform/yaml/testdb/naming_test.go
+++ b/pkg/platform/yaml/testdb/naming_test.go
@@ -429,6 +429,47 @@ func TestInsertTestCase_PropagatesAutoAssignedName(t *testing.T) {
 	}
 }
 
+// TestInsertTestCase_DoesNotPropagateOnFailure guards the second half of
+// the propagation contract: if upsert fails after claimName but before the
+// final rename, tc.Name must be left untouched so the caller does not
+// observe a name that no .yaml file backs. Otherwise a retry would either
+// skip claimName (because tc.Name is now non-empty and treated as
+// caller-supplied) and try to write directly to a name whose placeholder
+// the deferred cleanup just removed, or the wrapper's per-session dedupe
+// would record an event for a capture that was never persisted.
+func TestInsertTestCase_DoesNotPropagateOnFailure(t *testing.T) {
+	parent := t.TempDir()
+	ts := NewWithNaming(zap.NewNop(), parent, NamingDescriptive)
+	testSetID := "no-propagation-on-failure"
+	testSetDir := filepath.Join(parent, testSetID)
+	if err := os.MkdirAll(testSetDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Block saveAssets the same way TestUpsert_PlaceholderCleanedUpOnError
+	// does: a regular file sitting where the assets directory should be
+	// makes saveAssets' MkdirAll fail with ENOTDIR, and a >LargeBodyThreshold
+	// body forces saveAssets to actually try the write.
+	if err := os.WriteFile(filepath.Join(testSetDir, "assets"), []byte("blocked"), 0o644); err != nil {
+		t.Fatalf("seed blocker: %v", err)
+	}
+	bigBody := strings.Repeat("x", LargeBodyThreshold+1)
+	tc := &models.TestCase{
+		Kind: models.HTTP,
+		HTTPReq: models.HTTPReq{
+			Method: "GET",
+			URL:    "http://api.test/users",
+			Body:   bigBody,
+		},
+	}
+
+	if err := ts.InsertTestCase(t.Context(), tc, testSetID, false); err == nil {
+		t.Fatalf("expected InsertTestCase to fail when assets dir is blocked")
+	}
+	if tc.Name != "" {
+		t.Fatalf("tc.Name leaked on failure; got=%q want=\"\" (no yaml was persisted)", tc.Name)
+	}
+}
+
 func TestGenerateName_NewTestsetDir(t *testing.T) {
 	ts := NewWithNaming(zap.NewNop(), "", NamingDescriptive)
 	dir := filepath.Join(t.TempDir(), "fresh-testset", "tests")

--- a/pkg/platform/yaml/testdb/naming_test.go
+++ b/pkg/platform/yaml/testdb/naming_test.go
@@ -386,6 +386,49 @@ func TestUpsert_PlaceholderCleanedUpOnError(t *testing.T) {
 	}
 }
 
+// TestInsertTestCase_PropagatesAutoAssignedName guards the contract that
+// callers of InsertTestCase observe the on-disk name on tc.Name when they
+// did not pre-name the case themselves. Wrappers (e.g. k8s-proxy's
+// testDBWrapper) key per-session dedupe on tc.Name; if the auto-assigned
+// name is not propagated back, every nameless capture in a test set
+// collapses into one entry and the live recording UI loses visibility
+// into the actual capture count until the session stops.
+func TestInsertTestCase_PropagatesAutoAssignedName(t *testing.T) {
+	parent := t.TempDir()
+	ts := NewWithNaming(zap.NewNop(), parent, NamingDescriptive)
+	testSetID := "propagation"
+
+	tc1 := httpTC("GET", "http://api.test/users")
+	if err := ts.InsertTestCase(t.Context(), tc1, testSetID, false); err != nil {
+		t.Fatalf("insert tc1: %v", err)
+	}
+	if tc1.Name != "get-users-1" {
+		t.Fatalf("tc1.Name not propagated; got=%q want=get-users-1", tc1.Name)
+	}
+
+	tc2 := httpTC("GET", "http://api.test/users")
+	if err := ts.InsertTestCase(t.Context(), tc2, testSetID, false); err != nil {
+		t.Fatalf("insert tc2: %v", err)
+	}
+	if tc2.Name != "get-users-2" {
+		t.Fatalf("tc2.Name not propagated; got=%q want=get-users-2", tc2.Name)
+	}
+	if tc1.Name == tc2.Name {
+		t.Fatalf("expected distinct names across two captures, got both %q", tc1.Name)
+	}
+
+	// Pre-named cases (e.g. via the Keploy-Test-Name header path) must
+	// be left unchanged so callers can still drive deterministic naming.
+	tc3 := httpTC("GET", "http://api.test/users")
+	tc3.Name = "custom-name"
+	if err := ts.InsertTestCase(t.Context(), tc3, testSetID, false); err != nil {
+		t.Fatalf("insert tc3: %v", err)
+	}
+	if tc3.Name != "custom-name" {
+		t.Fatalf("explicit tc.Name overwritten; got=%q want=custom-name", tc3.Name)
+	}
+}
+
 func TestGenerateName_NewTestsetDir(t *testing.T) {
 	ts := NewWithNaming(zap.NewNop(), "", NamingDescriptive)
 	dir := filepath.Join(t.TempDir(), "fresh-testset", "tests")


### PR DESCRIPTION
## Describe the changes that are made
- `pkg/platform/yaml/testdb/db.go`: `upsert` now sets `tc.Name = claimed` after a successful auto-name claim, so the caller observes the on-disk filename after `InsertTestCase` returns. Pre-named cases (callers that set `tc.Name` themselves, e.g. via the `Keploy-Test-Name` header path in k8s-proxy) are unchanged.
- `pkg/platform/yaml/testdb/naming_test.go`: adds `TestInsertTestCase_PropagatesAutoAssignedName` covering (1) two consecutive auto-named inserts each leave `tc.Name` populated and distinct, and (2) a pre-named insert is not overwritten.

The change is one line of behavior plus its regression test. It is consistent with how `upsert` already mutates `tc.Curl` before insertion, and strictly improves the existing `AfterTestCaseInsert` hook log site in `pkg/service/record/record.go:393-399`, which currently logs `testCaseName=""` for every auto-named capture.

### Why this matters

`testdb.upsert` writes the auto-assigned filename to disk via a local `tcsName` but never copies the assigned name back onto `tc.Name`. Wrappers that key per-session bookkeeping on `tc.Name` silently misbehave: in particular, `keploy/k8s-proxy`'s `testDBWrapper` forwards every capture onto a session channel where `processTestCase` dedupes by `(testSetID, tc.Name)`. With `tc.Name` empty, every auto-named capture in the same test set collapses into a single entry. The Enterprise UI's active-recording page shows only one testcase during a live session even though the on-disk yaml files (and the post-stop recordings index) carry all of them under their proper descriptive names.

This regression surfaced after `keploy/k8s-proxy#387` removed the wrapper's legacy `"test-N"` override so the OSS naming strategy could take effect — the override had been masking the contract gap. The right long-term fix is at the OSS layer: make `InsertTestCase`'s contract well-defined so any wrapper sees the correct name without reaching into OSS internals. A coordinated wrapper-side regression test using a fake OSS testdb will land separately in `keploy/k8s-proxy`.

## Links & References

**Closes:** #4185

### 🔗 Related PRs
- keploy/k8s-proxy#387 (the change that exposed this latent OSS gap)
- keploy/k8s-proxy companion PR (regression test + comment refresh) — to be linked once filed

### 🐞 Related Issues
- #4185

### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

A unit-level regression test (`TestInsertTestCase_PropagatesAutoAssignedName`) is sufficient to lock in the contract — the bug is a single-line gap in `upsert`. The end-to-end UI symptom is exercised by a coordinated regression test on the wrapper side (`keploy/k8s-proxy` companion PR) so each repo owns its slice of the contract.

## Added comments for hard-to-understand areas?
- [x] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

A short comment on the new line explains *why* propagation is required (so wrappers keying dedupe state on `tc.Name` see the correct value).

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

```bash
# Unit regression test:
go test ./pkg/platform/yaml/testdb/... -run TestInsertTestCase_PropagatesAutoAssignedName -v

# Full testdb suite (no other regressions):
go test ./pkg/platform/yaml/testdb/...

# Build sanity:
go build ./...
```

To verify the fix actually closes the live-recording symptom end-to-end, point a `k8s-proxy` build at this keploy via `replace` directive in `go.mod`, run a recording session against any sandbox app, and confirm the active-recording UI's "Test Cases Recorded" tile increments on every captured request (instead of sticking at 1 until Stop).

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA — symptom and reproduction details are documented on #4185.

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?
