### PR TITLE
fix(replay): continue to next test set when user-app exits in DockerCompose mode

### DIFF
--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -474,6 +474,28 @@ func (r *Replayer) Start(ctx context.Context) error {
 				if ctx.Err() == context.Canceled {
 					return err
 				}
+				// DockerCompose: when the user-app container exits,
+				// compose's --abort-on-container-exit cancels our inner
+				// runTestSetCtx. RunTestSet then returns one of three
+				// statuses depending on which goroutine wins the race —
+				// AppHalted, FaultUserApp, or UserAbort (the last one
+				// happens at line ~964 when the ctx-Done select case
+				// fires before the appErr-status mapping). The outer
+				// ctx is intact (we already early-returned above if it
+				// was), so all three are recoverable: the next test set
+				// builds a fresh compose. Other errors still abort.
+				if cmdType == utils.DockerCompose &&
+					(testSetStatus == models.TestSetStatusAppHalted ||
+						testSetStatus == models.TestSetStatusFaultUserApp ||
+						testSetStatus == models.TestSetStatusUserAbort) {
+					utils.LogError(r.logger, err,
+						"test set failed because the app exited; continuing to next test set",
+						zap.String("test-set", testSet),
+						zap.String("status", string(testSetStatus)))
+					testSetResult = false
+					testRunResult = false
+					break
+				}
 				stopReason = fmt.Sprintf("failed to run test set: %v", err)
 				utils.LogError(r.logger, err, stopReason)
 				return fmt.Errorf("%s", stopReason)


### PR DESCRIPTION
## Summary

In DockerCompose-mode replay, when the user-app container exits non-zero on test set N, `RunTestSet` returns one of `AppHalted` / `FaultUserApp` / `UserAbort` *together with* a `context canceled` error (because `--abort-on-container-exit` cancels our inner `runTestSetCtx`). The outer `Start` loop currently bails out at the `if err != nil` guard *before* reaching the `shouldAbortTestRun` switch, so the entire run aborts on the first failed test set instead of moving on to N+1 with a fresh compose.

This makes `shouldAbortTestRun`'s special-case for DockerCompose effectively dead code:

```go
case models.TestSetStatusAppHalted, models.TestSetStatusFaultUserApp:
    return cmdType != utils.DockerCompose   // intent: don't abort in compose mode
```

## Fix

In the `err != nil` branch of the outer test-set loop, when `cmdType == DockerCompose` and the status indicates a recoverable app exit (`AppHalted` / `FaultUserApp` / `UserAbort`), log and `break` the per-attempt retry loop instead of `return`-ing. Outer ctx is already early-returned above, so we know it's not a real user abort.

The `UserAbort` case looks counter-intuitive but is real: at `RunTestSet` line ~964 a `select { case <-runTestSetCtx.Done(): ... }` can fire before the appErr-status mapping in the watcher goroutine, so an internal cancel masquerades as a user abort. Disambiguated via the outer-ctx check above.

Internal / setup errors (status `InternalErr` or empty status alongside a non-recoverable err) still abort as before.

## Test plan

- [x] Reproduced original bug: 3-test-set cloud replay where the user app fails to boot — run stops after 1st test set with `failed to run test set: context canceled`.
- [x] After fix: same run advances through all 3 test sets, each with a fresh compose, and ends with `stopping Keploy {reason: replay completed successfully}`.

```
13:48:08  running  test-set-...j9ldt   (1st)
13:48:37  ERROR    error while running the app: exit status 3
13:48:37  running  test-set-...mdb8g   (2nd, fresh compose)
13:49:03  ERROR    error while running the app: exit status 3
13:49:03  running  test-set-...qmtfz   (3rd, fresh compose)
13:49:29  ERROR    error while running the app: exit status 3
13:49:29  stopping Keploy  {"reason": "replay completed successfully"}
```

- [ ] CI: existing replay tests pass (no behavior change for non-compose modes; non-app errors still abort).
- [ ] Manual: verify Ctrl+C during a compose replay still aborts cleanly (handled by the unchanged `ctx.Err() == context.Canceled` guard above).