### PR TITLE
fix(log): keep per-test-set agent log non-empty in DockerCompose mode

### DIFF
--- a/utils/log/logger.go
+++ b/utils/log/logger.go
@@ -476,7 +476,18 @@ func AddDebugFileSink(logger *zap.Logger, file *os.File, capBytes int64) (*zap.L
 		capBytes = 100 << 20 // 100 MiB default
 	}
 	capped := newCappedWriteSyncer(zapcore.AddSync(file), capBytes)
-	buffered := &zapcore.BufferedWriteSyncer{WS: capped, Size: 256 << 10}
+	// FlushInterval defaults to 30 s in zap; that's too long for the
+	// agent's per-test-set restart cadence in DockerCompose mode where
+	// short-lived agent processes can shut down before a single auto-flush
+	// fires, leaving the per-test-set scoped file empty. 500 ms is a
+	// pragmatic compromise: records reach disk well before any plausible
+	// SIGTERM grace window expires, with negligible overhead at the
+	// volumes keploy actually emits.
+	buffered := &zapcore.BufferedWriteSyncer{
+		WS:            capped,
+		Size:          256 << 10,
+		FlushInterval: 500 * time.Millisecond,
+	}
 	encoder := NewANSIConsoleEncoder(LogCfg.EncoderConfig)
 	debugCore := newRedactingCore(zapcore.NewCore(
 		encoder,
@@ -582,6 +593,16 @@ func (s *DebugFileSink) RotateForScope(scope string) error {
 	s.originPath = target
 	s.currentScope = scope
 	s.mu.Unlock()
+
+	// Write a synchronous header DIRECTLY to the new file, bypassing the
+	// buffered chain, so the file is guaranteed non-empty even when the
+	// process shuts down before the 500 ms flush interval fires or
+	// before any further records are emitted post-rotation. Doubles as
+	// an audit breadcrumb (operators can grep "rotated to scope" in the
+	// bundle to confirm the rotation actually happened).
+	header := fmt.Sprintf("[keploy log] rotated to scope=%q at %s\n",
+		scope, time.Now().UTC().Format(time.RFC3339Nano))
+	_, _ = newFile.WriteString(header)
 	return nil
 }
 

--- a/utils/log/rotation_stress_test.go
+++ b/utils/log/rotation_stress_test.go
@@ -1,0 +1,232 @@
+package log
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// TestDebugFileSink_ProductionLikeRotation mimics the keploy-agent's
+// real lifecycle: AddDebugFileSink at boot, AddMode swap during
+// Validate, then concurrent goroutines emit records WHILE rotation
+// fires between test sets. Asserts each scoped file ends up non-empty.
+//
+// Repro target: the bundle had per-test-set files of 0 bytes despite
+// the rotation primitive firing.
+func TestDebugFileSink_ProductionLikeRotation(t *testing.T) {
+	SetRedactor(nil)
+	defer SetDebugFileSink(nil)
+
+	dir := t.TempDir()
+	originPath := filepath.Join(dir, "agent-debug.log")
+	originFile, err := os.Create(originPath)
+	if err != nil {
+		t.Fatalf("create origin: %v", err)
+	}
+	defer originFile.Close()
+
+	console := &syncBuffer{}
+	logger := newConsoleLogger(console, zap.InfoLevel)
+
+	// Step 1: AddDebugFileSink at boot.
+	wrapped, sink := AddDebugFileSink(logger, originFile, 0)
+	*logger = *wrapped
+	SetDebugFileSink(sink)
+
+	// Step 2: emit boot-time records (these should land in origin file).
+	for i := 0; i < 50; i++ {
+		logger.Debug("boot-record", zap.Int("i", i))
+	}
+
+	// Step 3: simulate the agent CLI's Validate: AddMode("agent") which
+	// rebuilds the core and (with the fix) re-attaches the file sink.
+	rebuilt, err := AddMode("agent")
+	if err != nil {
+		t.Fatalf("AddMode: %v", err)
+	}
+	*logger = *rebuilt
+
+	// Step 4: Spawn proxy-like goroutines that emit records.
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for g := 0; g < 4; g++ {
+		wg.Add(1)
+		go func(gid int) {
+			defer wg.Done()
+			i := 0
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					logger.Debug("traffic-record",
+						zap.Int("goroutine", gid),
+						zap.Int("seq", i),
+						zap.String("payload", "Handling outgoing connection to destination port"))
+					i++
+					time.Sleep(time.Millisecond) // pace the emissions
+				}
+			}
+		}(g)
+	}
+
+	// Step 5: rotate through three test sets, with brief pauses to let
+	// goroutines emit records into the active scope.
+	scopes := []string{"test-set-a", "test-set-b", "test-set-c"}
+	for _, scope := range scopes {
+		if err := sink.RotateForScope(scope); err != nil {
+			t.Fatalf("RotateForScope(%q): %v", scope, err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	close(stop)
+	wg.Wait()
+
+	if err := sink.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	// Origin file should have boot records + the records emitted between
+	// AddMode and the first rotation (a small window).
+	if info, err := os.Stat(originPath); err != nil {
+		t.Fatalf("stat origin: %v", err)
+	} else if info.Size() == 0 {
+		t.Errorf("origin file empty (expected boot records)")
+	} else {
+		t.Logf("origin file: %d bytes", info.Size())
+	}
+
+	// Each scoped file (except possibly the last, which had no Sync at
+	// next-rotation, only the deferred Flush) should have content.
+	for i, scope := range scopes {
+		scopedPath := filepath.Join(dir, scope, "agent-debug.log")
+		info, err := os.Stat(scopedPath)
+		if err != nil {
+			t.Errorf("[%d] stat %s: %v", i, scopedPath, err)
+			continue
+		}
+		if info.Size() == 0 {
+			t.Errorf("[%d] scope %q file is 0 bytes (the bug)", i, scope)
+		} else {
+			t.Logf("[%d] scope %q file: %d bytes", i, scope, info.Size())
+		}
+	}
+}
+
+// TestDebugFileSink_ScopedFileNonEmptyEvenWithoutPostRotationWrites
+// is the regression test for the empty-per-test-set-file production
+// bug: in DockerCompose mode the agent restarts per test set, so a
+// short-lived agent that fires a single BeforeSimulate (rotation)
+// and then exits before its 500 ms buffer flush leaves the scoped
+// file at 0 bytes. The fix writes a synchronous marker directly to
+// the new file inside RotateForScope so the file is non-empty
+// regardless of what the buffered chain does next.
+func TestDebugFileSink_ScopedFileNonEmptyEvenWithoutPostRotationWrites(t *testing.T) {
+	SetRedactor(nil)
+	defer SetDebugFileSink(nil)
+
+	dir := t.TempDir()
+	originFile, err := os.Create(filepath.Join(dir, "agent-debug.log"))
+	if err != nil {
+		t.Fatalf("create origin: %v", err)
+	}
+	defer originFile.Close()
+
+	console := &syncBuffer{}
+	logger := newConsoleLogger(console, zap.InfoLevel)
+	wrapped, sink := AddDebugFileSink(logger, originFile, 0)
+	*logger = *wrapped
+	SetDebugFileSink(sink)
+
+	// Rotate, then immediately stop. NO records emitted post-rotation.
+	if err := sink.RotateForScope("ts-empty"); err != nil {
+		t.Fatalf("RotateForScope: %v", err)
+	}
+	// Deliberately skip Flush to model the SIGKILL / abrupt-shutdown case.
+
+	scopedPath := filepath.Join(dir, "ts-empty", "agent-debug.log")
+	contents, err := os.ReadFile(scopedPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", scopedPath, err)
+	}
+	if len(contents) == 0 {
+		t.Fatalf("scoped file empty even though rotation fired (the bug)")
+	}
+	if !strings.Contains(string(contents), "rotated to scope=") {
+		t.Errorf("scoped file missing rotation marker: %s", contents)
+	}
+	if !strings.Contains(string(contents), `"ts-empty"`) {
+		t.Errorf("rotation marker missing test-set ID: %s", contents)
+	}
+}
+
+// TestDebugFileSink_RotationAfterFewWrites checks the specific
+// edge case where only a small number of records are emitted between
+// rotations — does the buffer auto-flush, or do those records sit in
+// memory and get lost?
+func TestDebugFileSink_RotationAfterFewWrites(t *testing.T) {
+	SetRedactor(nil)
+	defer SetDebugFileSink(nil)
+
+	dir := t.TempDir()
+	originPath := filepath.Join(dir, "agent-debug.log")
+	originFile, err := os.Create(originPath)
+	if err != nil {
+		t.Fatalf("create origin: %v", err)
+	}
+	defer originFile.Close()
+
+	console := &syncBuffer{}
+	logger := newConsoleLogger(console, zap.InfoLevel)
+
+	wrapped, sink := AddDebugFileSink(logger, originFile, 0)
+	*logger = *wrapped
+	SetDebugFileSink(sink)
+
+	rebuilt, _ := AddMode("agent")
+	*logger = *rebuilt
+
+	// Rotate to scope A; emit a few records; rotate to B.
+	if err := sink.RotateForScope("scope-a"); err != nil {
+		t.Fatalf("rotate to a: %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		logger.Debug("record-in-a", zap.Int("i", i),
+			zap.String("payload", fmt.Sprintf("entry-%d", i)))
+	}
+	if err := sink.RotateForScope("scope-b"); err != nil {
+		t.Fatalf("rotate to b: %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		logger.Debug("record-in-b", zap.Int("i", i))
+	}
+
+	if err := sink.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	scopeAPath := filepath.Join(dir, "scope-a", "agent-debug.log")
+	if info, err := os.Stat(scopeAPath); err != nil {
+		t.Errorf("stat scope-a: %v", err)
+	} else if info.Size() == 0 {
+		t.Errorf("scope-a file is 0 bytes — buffer didn't drain at rotation to scope-b (THIS IS THE PRODUCTION BUG)")
+	} else {
+		t.Logf("scope-a file: %d bytes", info.Size())
+	}
+
+	scopeBPath := filepath.Join(dir, "scope-b", "agent-debug.log")
+	if info, err := os.Stat(scopeBPath); err != nil {
+		t.Errorf("stat scope-b: %v", err)
+	} else if info.Size() == 0 {
+		t.Errorf("scope-b file is 0 bytes")
+	} else {
+		t.Logf("scope-b file: %d bytes", info.Size())
+	}
+}


### PR DESCRIPTION
## Describe the changes that are made

Follow-up to keploy/keploy#4187. Empirically caught: with all of #4187 merged and a fresh agent image, the support bundle from a `keploy cloud replay` run still showed per-test-set `agent-debug.log` files as 0 bytes (with `rotated` directories present, so rotation was firing).

Root cause: in DockerCompose mode the keploy-agent restarts per test set (see `pkg/service/replay/replay.go:974` comment "for every test set the agent and application are restarted"). Each agent process is short-lived. Records emitted between `BeforeSimulate` (which triggers `RotateForScope`) and SIGTERM sit in zap's default 30-second `BufferedWriteSyncer` and never reach disk before shutdown.

Two fixes:

1. **Drop `BufferedWriteSyncer.FlushInterval` from the 30 s zap default to 500 ms.** Records flow to disk well before any plausible SIGTERM grace window can expire. Negligible overhead at keploy's log volume.

2. **Write a synchronous header line directly to the new scoped file inside `RotateForScope`** (bypassing the buffered chain). Guarantees the file is non-empty even if the agent shuts down before any further log records are emitted, and doubles as an audit breadcrumb — operators can grep `rotated to scope=…` in the bundle to confirm rotation fired.

## Links & References

**Closes:** N/A (follow-up; covers gap not caught by #4187's tests)

### 🔗 Related PRs
- keploy/keploy#4187 (parent — debug file sink + per-test-set rotation)
- keploy/enterprise#2003 (umbrella feature request)

### 🐞 Related Issues
- keploy/enterprise#2003

## What type of PR is this? (check all applicable)
- [x] 🐞 Bug Fix

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed

Unit tests cover the exact production scenario that motivated the fix.

## Added comments for hard-to-understand areas?
- [x] 👍 yes

The 500 ms FlushInterval choice and the direct-write rationale are both documented inline.

## Added to documentation?
- [x] 🙅 no documentation needed

Internal mechanic; not a user-visible CLI change.

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

```bash
go test -run "ScopedFileNonEmpty|RotateForScope|RotateAfterFewWrites|ProductionLikeRotation" ./utils/log/...
```

New regression test `TestDebugFileSink_ScopedFileNonEmptyEvenWithoutPostRotationWrites` asserts the scoped file is non-empty and contains the marker even when no records flow post-rotation and `Flush` is never called — the exact production scenario.

Existing rotation tests continue to pass; they now also see the marker line in scoped files (additive content, no invariants broken).

## Self Review done?
- [x] ✅ yes
