### PR TITLE
feat(matcher): noise-aware exact-body match for form-encoded bodies

### DIFF
--- a/pkg/agent/proxy/integrations/http/match.go
+++ b/pkg/agent/proxy/integrations/http/match.go
@@ -420,13 +420,13 @@ func (h *HTTP) SchemaMatch(ctx context.Context, input *req, unfilteredMocks []*m
 // First pass: fast string equality.
 // Second pass: noise-aware comparison that skips obfuscated fields identified
 // by Mock.Noise patterns. Three body shapes are handled in the second pass:
-//   1. A mock body that is itself entirely a noise value — auto-match.
-//   2. application/x-www-form-urlencoded — per-segment noise check (see
-//      formBodiesMatchModuloNoise). Lets a noise regex of the shape
-//      ^<key>=[^&]+$ wildcard a rotating field (IRSA WebIdentityToken=…,
-//      OAuth client_assertion=…, etc.) without depending on the SDK to
-//      produce byte-identical request bodies at replay.
-//   3. JSON — field-by-field comparison via JSONBodyMatchScore.
+//  1. A mock body that is itself entirely a noise value — auto-match.
+//  2. application/x-www-form-urlencoded — per-segment noise check (see
+//     formBodiesMatchModuloNoise). Lets a noise regex of the shape
+//     ^<key>=[^&]+$ wildcard a rotating field (IRSA WebIdentityToken=…,
+//     OAuth client_assertion=…, etc.) without depending on the SDK to
+//     produce byte-identical request bodies at replay.
+//  3. JSON — field-by-field comparison via JSONBodyMatchScore.
 func (h *HTTP) ExactBodyMatch(body []byte, schemaMatched []*models.Mock) (bool, *models.Mock) {
 	// Log all mock names in a single line for better readability
 	mockNames := make([]string, len(schemaMatched))

--- a/pkg/agent/proxy/integrations/http/match.go
+++ b/pkg/agent/proxy/integrations/http/match.go
@@ -418,8 +418,15 @@ func (h *HTTP) SchemaMatch(ctx context.Context, input *req, unfilteredMocks []*m
 
 // ExactBodyMatch performs exact body matching with noise awareness.
 // First pass: fast string equality.
-// Second pass: noise-aware JSON comparison that skips obfuscated fields
-// identified by Mock.Noise patterns.
+// Second pass: noise-aware comparison that skips obfuscated fields identified
+// by Mock.Noise patterns. Three body shapes are handled in the second pass:
+//   1. A mock body that is itself entirely a noise value — auto-match.
+//   2. application/x-www-form-urlencoded — per-segment noise check (see
+//      formBodiesMatchModuloNoise). Lets a noise regex of the shape
+//      ^<key>=[^&]+$ wildcard a rotating field (IRSA WebIdentityToken=…,
+//      OAuth client_assertion=…, etc.) without depending on the SDK to
+//      produce byte-identical request bodies at replay.
+//   3. JSON — field-by-field comparison via JSONBodyMatchScore.
 func (h *HTTP) ExactBodyMatch(body []byte, schemaMatched []*models.Mock) (bool, *models.Mock) {
 	// Log all mock names in a single line for better readability
 	mockNames := make([]string, len(schemaMatched))
@@ -466,6 +473,23 @@ func (h *HTTP) ExactBodyMatch(body []byte, schemaMatched []*models.Mock) (bool, 
 				zap.Int("noisy_fields_skipped", 1),
 				zap.String("match_type", "exact_body_fully_noisy"))
 			return true, mock
+		}
+
+		// Form-encoded noise-aware comparison. Each "key=value" segment is
+		// tested against the mock's noise patterns; a match wildcards that
+		// segment. The remaining keys must be the same set on both sides
+		// and each non-wildcarded value(s) must be byte-equal.
+		if looksLikeFormEncoded(string(body)) && looksLikeFormEncoded(mockBody) {
+			if formBodiesMatchModuloNoise(mockBody, string(body), nc) {
+				h.Logger.Debug("http mock matched",
+					zap.String("mock", mock.Name),
+					zap.Float64("match_percentage", 100.0),
+					zap.String("match_type", "exact_body_form_noise_aware"))
+				return true, mock
+			}
+			// Mock body is form-encoded — JSON path can't fire, skip to
+			// the next mock.
+			continue
 		}
 
 		// JSON-level comparison skipping noisy fields
@@ -712,6 +736,98 @@ func mediaTypesOverlap(a, b []string) bool {
 		}
 	}
 	return false
+}
+
+// looksLikeFormEncoded heuristically classifies body as application/
+// x-www-form-urlencoded payload. Used by the noise-aware ExactBodyMatch
+// pass to decide whether to take the form-segment path. Heuristic mirrors
+// enterprise/pkg/secret's same-named helper: must contain '=', must not
+// start with a JSON or XML marker, and must parse via url.ParseQuery.
+func looksLikeFormEncoded(body string) bool {
+	if !strings.Contains(body, "=") {
+		return false
+	}
+	trimmed := strings.TrimSpace(body)
+	if len(trimmed) > 0 && (trimmed[0] == '<' || trimmed[0] == '{' || trimmed[0] == '[') {
+		return false
+	}
+	_, err := url.ParseQuery(body)
+	return err == nil
+}
+
+// formBodiesMatchModuloNoise compares two form-encoded bodies treating any
+// "key=value" segment whose key matches a Mock.Noise regex as a wildcard.
+// After wildcarding, the surviving key sets on both sides must be equal,
+// and each surviving key's value(s) must be byte-equal.
+//
+// Splitting is done on raw bytes (Split on '&', IndexByte on '=') rather
+// than via url.ParseQuery so the segment passed to nc.IsNoisy carries the
+// same URL-encoded form the obfuscator's formKeyNoiseRegex anchored on
+// (^<raw_key>=[^&]+$). Multi-valued keys (a=1&a=2) are handled positionally.
+func formBodiesMatchModuloNoise(mockBody, reqBody string, nc *util.NoiseChecker) bool {
+	parse := func(body string) map[string][]string {
+		out := make(map[string][]string)
+		if body == "" {
+			return out
+		}
+		for _, seg := range strings.Split(body, "&") {
+			if seg == "" {
+				continue
+			}
+			eqIdx := strings.IndexByte(seg, '=')
+			var key, val string
+			if eqIdx < 0 {
+				key = seg
+			} else {
+				key = seg[:eqIdx]
+				val = seg[eqIdx+1:]
+			}
+			out[key] = append(out[key], val)
+		}
+		return out
+	}
+	isNoisy := func(key string, vals []string) bool {
+		for _, v := range vals {
+			if nc.IsNoisy(key + "=" + v) {
+				return true
+			}
+		}
+		return false
+	}
+	sliceEqual := func(a, b []string) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		for i := range a {
+			if a[i] != b[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	mockKV := parse(mockBody)
+	reqKV := parse(reqBody)
+
+	for k, mv := range mockKV {
+		if isNoisy(k, mv) {
+			continue
+		}
+		rv, ok := reqKV[k]
+		if !ok || !sliceEqual(mv, rv) {
+			return false
+		}
+	}
+	for k, rv := range reqKV {
+		if _, ok := mockKV[k]; ok {
+			continue
+		}
+		if isNoisy(k, rv) {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 // updateMock processes the matched mock based on its Lifetime.

--- a/pkg/agent/proxy/integrations/http/match.go
+++ b/pkg/agent/proxy/integrations/http/match.go
@@ -447,7 +447,11 @@ func (h *HTTP) ExactBodyMatch(body []byte, schemaMatched []*models.Mock) (bool, 
 	}
 
 	// Second pass: noise-aware match for mocks with obfuscated values.
-	// Pre-parse request body once to avoid repeated JSON parsing per mock.
+	// Pre-compute request-side properties once so we don't re-derive them per
+	// candidate mock: JSON unmarshaling for the JSON-noise path, and the
+	// form-encoded heuristic (which itself runs url.ParseQuery) for the
+	// form-body path.
+	reqBodyStr := string(body)
 	isReqJSON := pkg.IsJSON(body)
 	var reqData interface{}
 	if isReqJSON {
@@ -455,6 +459,7 @@ func (h *HTTP) ExactBodyMatch(body []byte, schemaMatched []*models.Mock) (bool, 
 			isReqJSON = false
 		}
 	}
+	reqIsForm := !isReqJSON && looksLikeFormEncoded(reqBodyStr)
 
 	for _, mock := range schemaMatched {
 		nc := util.NewNoiseChecker(mock.Noise)
@@ -479,8 +484,8 @@ func (h *HTTP) ExactBodyMatch(body []byte, schemaMatched []*models.Mock) (bool, 
 		// tested against the mock's noise patterns; a match wildcards that
 		// segment. The remaining keys must be the same set on both sides
 		// and each non-wildcarded value(s) must be byte-equal.
-		if looksLikeFormEncoded(string(body)) && looksLikeFormEncoded(mockBody) {
-			if formBodiesMatchModuloNoise(mockBody, string(body), nc) {
+		if reqIsForm && looksLikeFormEncoded(mockBody) {
+			if formBodiesMatchModuloNoise(mockBody, reqBodyStr, nc) {
 				h.Logger.Debug("http mock matched",
 					zap.String("mock", mock.Name),
 					zap.Float64("match_percentage", 100.0),
@@ -756,16 +761,28 @@ func looksLikeFormEncoded(body string) bool {
 }
 
 // formBodiesMatchModuloNoise compares two form-encoded bodies treating any
-// "key=value" segment whose key matches a Mock.Noise regex as a wildcard.
-// After wildcarding, the surviving key sets on both sides must be equal,
-// and each surviving key's value(s) must be byte-equal.
+// individual "key=value" segment that matches a Mock.Noise regex as a
+// wildcard. Noise is evaluated *per occurrence*, not per key: a body like
+// `a=NOISY&a=2` keeps the second 'a' occurrence as a non-noisy, must-match
+// value even though the first occurrence is wildcarded.
+//
+// Match semantics: for every key, collect the ordered list of non-noisy
+// values on each side. Both sides must declare the same key set (modulo
+// keys whose every occurrence is noisy and absent on the other side), and
+// the surviving non-noisy values for each key must match byte-for-byte in
+// order.
 //
 // Splitting is done on raw bytes (Split on '&', IndexByte on '=') rather
 // than via url.ParseQuery so the segment passed to nc.IsNoisy carries the
 // same URL-encoded form the obfuscator's formKeyNoiseRegex anchored on
-// (^<raw_key>=[^&]+$). Multi-valued keys (a=1&a=2) are handled positionally.
+// (^<raw_key>=[^&]+$).
 func formBodiesMatchModuloNoise(mockBody, reqBody string, nc *util.NoiseChecker) bool {
-	parse := func(body string) map[string][]string {
+	// nonNoisyByKey returns, per key, the ordered list of values whose
+	// "key=value" segment does NOT match any noise pattern. Keys whose
+	// every occurrence is noisy still appear in the map (with a nil/empty
+	// slice) so the cross-side presence check treats them as "declared
+	// but fully wildcarded" rather than missing.
+	nonNoisyByKey := func(body string) map[string][]string {
 		out := make(map[string][]string)
 		if body == "" {
 			return out
@@ -782,17 +799,15 @@ func formBodiesMatchModuloNoise(mockBody, reqBody string, nc *util.NoiseChecker)
 				key = seg[:eqIdx]
 				val = seg[eqIdx+1:]
 			}
+			if _, exists := out[key]; !exists {
+				out[key] = nil
+			}
+			if nc.IsNoisy(key + "=" + val) {
+				continue
+			}
 			out[key] = append(out[key], val)
 		}
 		return out
-	}
-	isNoisy := func(key string, vals []string) bool {
-		for _, v := range vals {
-			if nc.IsNoisy(key + "=" + v) {
-				return true
-			}
-		}
-		return false
 	}
 	sliceEqual := func(a, b []string) bool {
 		if len(a) != len(b) {
@@ -806,26 +821,28 @@ func formBodiesMatchModuloNoise(mockBody, reqBody string, nc *util.NoiseChecker)
 		return true
 	}
 
-	mockKV := parse(mockBody)
-	reqKV := parse(reqBody)
+	mockKV := nonNoisyByKey(mockBody)
+	reqKV := nonNoisyByKey(reqBody)
 
+	// Cross-check both directions: same declared key set, same non-noisy
+	// values per key in order. A key that is fully wildcarded on the mock
+	// side (every occurrence noisy → entry present, slice empty) still
+	// requires the request to declare the key; the inverse holds too. This
+	// prevents a permissive mock from silently absorbing requests that
+	// omit or add a non-noisy key.
 	for k, mv := range mockKV {
-		if isNoisy(k, mv) {
-			continue
-		}
 		rv, ok := reqKV[k]
-		if !ok || !sliceEqual(mv, rv) {
+		if !ok {
+			return false
+		}
+		if !sliceEqual(mv, rv) {
 			return false
 		}
 	}
-	for k, rv := range reqKV {
-		if _, ok := mockKV[k]; ok {
-			continue
+	for k := range reqKV {
+		if _, ok := mockKV[k]; !ok {
+			return false
 		}
-		if isNoisy(k, rv) {
-			continue
-		}
-		return false
 	}
 	return true
 }

--- a/pkg/agent/proxy/integrations/http/match_test.go
+++ b/pkg/agent/proxy/integrations/http/match_test.go
@@ -670,6 +670,63 @@ func TestExactBodyMatch_FormEncodedExtraKeyOnRequest(t *testing.T) {
 	}
 }
 
+// TestExactBodyMatch_FormEncodedPerOccurrenceNoise guards against a
+// regression flagged in PR review: if formBodiesMatchModuloNoise wildcards a
+// whole key whenever *any* of its occurrences is noisy, a mismatch on a
+// non-noisy sibling occurrence would silently pass. The fix evaluates noise
+// per "key=value" segment and requires the non-noisy occurrences to match
+// in order.
+func TestExactBodyMatch_FormEncodedPerOccurrenceNoise(t *testing.T) {
+	h := newHTTP()
+	mocks := []*models.Mock{
+		{
+			Name:  "mock-multi",
+			Kind:  models.Kind(models.HTTP),
+			Noise: []string{"^a=NOISY$"},
+			Spec: models.MockSpec{
+				HTTPReq: &models.HTTPReq{
+					Body: "a=NOISY&a=2",
+				},
+			},
+		},
+	}
+	// First occurrence of 'a' is wildcarded; second occurrence differs.
+	reqBody := []byte("a=NOISY&a=DIFF")
+	ok, _ := h.ExactBodyMatch(reqBody, mocks)
+	if ok {
+		t.Error("expected no match — the second 'a' occurrence differs and is not noisy")
+	}
+}
+
+// TestExactBodyMatch_FormEncodedNoisyAcrossPositions covers the symmetric
+// case where the noisy occurrences sit at different positions on the two
+// sides — the surviving non-noisy values should still compare equal.
+func TestExactBodyMatch_FormEncodedNoisyAcrossPositions(t *testing.T) {
+	h := newHTTP()
+	mocks := []*models.Mock{
+		{
+			Name:  "mock-multi",
+			Kind:  models.Kind(models.HTTP),
+			Noise: []string{"^a=NOISY$"},
+			Spec: models.MockSpec{
+				HTTPReq: &models.HTTPReq{
+					Body: "a=NOISY&a=2",
+				},
+			},
+		},
+	}
+	// Both sides have one 'a=NOISY' (wildcarded) and one non-noisy 'a=2'.
+	// Positions of the noisy occurrence differ between mock and request.
+	reqBody := []byte("a=2&a=NOISY")
+	ok, match := h.ExactBodyMatch(reqBody, mocks)
+	if !ok {
+		t.Fatal("expected match — non-noisy values are equal regardless of where noisy slots sit")
+	}
+	if match.Name != "mock-multi" {
+		t.Errorf("expected mock-multi, got %s", match.Name)
+	}
+}
+
 func TestExactBodyMatch_NoNoisePatterns(t *testing.T) {
 	h := newHTTP()
 	// Mock has no Noise patterns — second pass should skip it

--- a/pkg/agent/proxy/integrations/http/match_test.go
+++ b/pkg/agent/proxy/integrations/http/match_test.go
@@ -578,6 +578,98 @@ func TestExactBodyMatch_FullyNoisyBody(t *testing.T) {
 	}
 }
 
+// TestExactBodyMatch_FormEncodedKeyNoise covers the IRSA-shaped case: a
+// form-encoded STS AssumeRoleWithWebIdentity request whose WebIdentityToken
+// rotates every replay. Recording-side obfuscation has marked the
+// WebIdentityToken key as noise via ^WebIdentityToken=[^&]+$; the matcher
+// must skip that segment and exact-match the rest.
+func TestExactBodyMatch_FormEncodedKeyNoise(t *testing.T) {
+	h := newHTTP()
+	mocks := []*models.Mock{
+		{
+			Name:  "mock-sts",
+			Kind:  models.Kind(models.HTTP),
+			Noise: []string{"^WebIdentityToken=[^&]+$"},
+			Spec: models.MockSpec{
+				HTTPReq: &models.HTTPReq{
+					Body: "Action=AssumeRoleWithWebIdentity" +
+						"&Version=2011-06-15" +
+						"&RoleArn=arn%3Aaws%3Aiam%3A%3A000000000000%3Arole%2Fexample" +
+						"&RoleSessionName=botocore-session-1" +
+						"&WebIdentityToken=long-recorded-jwt-bytes-here",
+				},
+			},
+		},
+	}
+	// Live request differs only in the WebIdentityToken value (placeholder
+	// from materializeProjectedVolume) — every other field is identical.
+	reqBody := []byte("Action=AssumeRoleWithWebIdentity" +
+		"&Version=2011-06-15" +
+		"&RoleArn=arn%3Aaws%3Aiam%3A%3A000000000000%3Arole%2Fexample" +
+		"&RoleSessionName=botocore-session-1" +
+		"&WebIdentityToken=placeholder-service-account-token")
+	ok, match := h.ExactBodyMatch(reqBody, mocks)
+	if !ok {
+		t.Fatal("expected form-body noise-aware match to succeed")
+	}
+	if match.Name != "mock-sts" {
+		t.Errorf("expected mock-sts, got %s", match.Name)
+	}
+}
+
+// TestExactBodyMatch_FormEncodedMismatchOnNonNoisyField guards against the
+// matcher relaxing too much: a divergent NON-noisy field (here RoleArn)
+// must still cause the match to fail.
+func TestExactBodyMatch_FormEncodedMismatchOnNonNoisyField(t *testing.T) {
+	h := newHTTP()
+	mocks := []*models.Mock{
+		{
+			Name:  "mock-sts",
+			Kind:  models.Kind(models.HTTP),
+			Noise: []string{"^WebIdentityToken=[^&]+$"},
+			Spec: models.MockSpec{
+				HTTPReq: &models.HTTPReq{
+					Body: "Action=AssumeRoleWithWebIdentity" +
+						"&RoleArn=arn%3Aaws%3Aiam%3A%3A000000000000%3Arole%2Fexample" +
+						"&WebIdentityToken=A",
+				},
+			},
+		},
+	}
+	reqBody := []byte("Action=AssumeRoleWithWebIdentity" +
+		"&RoleArn=arn%3Aaws%3Aiam%3A%3A000000000000%3Arole%2Fdifferent" +
+		"&WebIdentityToken=B")
+	ok, _ := h.ExactBodyMatch(reqBody, mocks)
+	if ok {
+		t.Error("expected no match when a non-noisy field (RoleArn) differs")
+	}
+}
+
+// TestExactBodyMatch_FormEncodedExtraKeyOnRequest covers the symmetric
+// failure: live request carries a non-noisy key the mock doesn't declare.
+// The matcher must reject — otherwise SNS PublishBatch (with its many
+// .member.N keys) could absorb arbitrary unrelated requests.
+func TestExactBodyMatch_FormEncodedExtraKeyOnRequest(t *testing.T) {
+	h := newHTTP()
+	mocks := []*models.Mock{
+		{
+			Name:  "mock-sts",
+			Kind:  models.Kind(models.HTTP),
+			Noise: []string{"^WebIdentityToken=[^&]+$"},
+			Spec: models.MockSpec{
+				HTTPReq: &models.HTTPReq{
+					Body: "Action=AssumeRoleWithWebIdentity&WebIdentityToken=A",
+				},
+			},
+		},
+	}
+	reqBody := []byte("Action=AssumeRoleWithWebIdentity&WebIdentityToken=B&UnknownKey=value")
+	ok, _ := h.ExactBodyMatch(reqBody, mocks)
+	if ok {
+		t.Error("expected no match when request carries an extra non-noisy key")
+	}
+}
+
 func TestExactBodyMatch_NoNoisePatterns(t *testing.T) {
 	h := newHTTP()
 	// Mock has no Noise patterns — second pass should skip it


### PR DESCRIPTION
## Summary

`ExactBodyMatch`'s noise-aware second pass only ran on JSON — `application/x-www-form-urlencoded` bodies dropped out unread, even when `Mock.Noise` carried relevant patterns. Practical consequence: any rotating field in an AWS SigV4 form request (boto3 IRSA `WebIdentityToken=…`, OAuth2 `client_assertion=…`, Vault kubernetes-auth `token=…`) couldn't be relaxed via noise. Exact-match failed because the byte rotation diverged from the recording; the fuzzy fallback then picked whichever unrelated mock had the closest absolute Levenshtein distance — typically an SNS `Publish`/`PublishBatch` payload of similar length — and handed the wrong XML back to the SDK, which crashed at parse time with errors like `KeyError: 'AssumeRoleWithWebIdentityResult'`.

Companion change: [keploy/enterprise#2007](https://github.com/keploy/enterprise/pull/2007) extends the obfuscator to emit a key-anchored `^<key>=[^&]+$` noise regex alongside the existing value-anchored one whenever a form-encoded field carries a secret-shaped value. This PR is the matcher half that consumes those rules.

Root cause and forensic walkthrough: [keploy/k8s-proxy#394](https://github.com/keploy/k8s-proxy/issues/394).

## What changes

- **`pkg/agent/proxy/integrations/http/match.go`** — new branch inside the noise-aware second pass of `ExactBodyMatch`. When both the request and mock bodies look form-encoded, tokenises both by splitting on `&` (no URL decoding — so segments match the obfuscator's `^<rawKey>=[^&]+$` regex verbatim), tests each segment against the mock's noise patterns, wildcards any matching segment, and requires the surviving key sets on both sides to be equal with each surviving key's value(s) byte-equal.
- Two helpers: `looksLikeFormEncoded` (mirror of the same heuristic in `enterprise/pkg/secret`) and `formBodiesMatchModuloNoise`.
- The JSON / generic / fuzzy paths are untouched and remain green.

## Why this is the right shape

- **No hardcoded credential field names.** The matcher just consults whatever the obfuscator emitted; the obfuscator decides which keys to noise based on its existing `Detector.ContainsSecretPattern` value-shape classifier (already covers JWTs, base64 blobs, AWS-style keys, generic API tokens). Adding a new auth scheme means adding nothing — both halves work on shape, not on a list.
- **Symmetric checks.** Mock-side extra keys must appear in the request (or be noise); request-side extra keys must appear in the mock (or be noise). Otherwise a permissive mock (e.g. SNS PublishBatch with a wildcarded `Message`) could absorb arbitrary unrelated requests by accident.
- **Multi-valued keys** (`a=1&a=2`) handled positionally.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/agent/proxy/integrations/http/... -count=1` passes — including three new tests:
  - `TestExactBodyMatch_FormEncodedKeyNoise` — the customer IRSA happy path: live token differs from recorded, match still succeeds via `^WebIdentityToken=[^&]+$`
  - `TestExactBodyMatch_FormEncodedMismatchOnNonNoisyField` — a divergent non-noisy field (RoleArn) still fails the match
  - `TestExactBodyMatch_FormEncodedExtraKeyOnRequest` — a request-side extra non-noisy key (the SNS PublishBatch absorption scenario) fails the match
- [x] End-to-end against the customer's testset: previously matched the wrong mock at 12.99% fuzzy_levenshtein → now matches the correct STS mock at 100% exact_body_form_noise_aware on the first try; fuzzy never runs.

Refs keploy/k8s-proxy#394