### PR TITLE
fix(matcher): wildcard form segments with embedded unix timestamps

### DIFF
--- a/pkg/agent/proxy/integrations/http/match.go
+++ b/pkg/agent/proxy/integrations/http/match.go
@@ -760,6 +760,51 @@ func looksLikeFormEncoded(body string) bool {
 	return err == nil
 }
 
+// valueHasUnixTimestamp reports whether s contains a decimal run that looks
+// like a modern unix timestamp — 10 digits in [1_500_000_000, 2_500_000_000]
+// (seconds, 2017-07-14 → 2049-03-22) or 13 digits in
+// [1_500_000_000_000, 2_500_000_000_000] (milliseconds, same range). Used
+// by formBodiesMatchModuloNoise to wildcard form segments whose value
+// embeds a record-time timestamp the recorder didn't tag as noise.
+//
+// The 10/13-digit gate is deliberate: 11- and 12-digit runs (e.g. 12-digit
+// AWS account IDs) are not plausible unix timestamps in either unit and
+// must not be wildcarded.
+func valueHasUnixTimestamp(s string) bool {
+	const (
+		secMin uint64 = 1_500_000_000
+		secMax uint64 = 2_500_000_000
+		msMin  uint64 = 1_500_000_000_000
+		msMax  uint64 = 2_500_000_000_000
+	)
+	n := len(s)
+	for i := 0; i < n; {
+		if s[i] < '0' || s[i] > '9' {
+			i++
+			continue
+		}
+		j := i
+		for j < n && s[j] >= '0' && s[j] <= '9' {
+			j++
+		}
+		runLen := j - i
+		if runLen == 10 || runLen == 13 {
+			var v uint64
+			for k := i; k < j; k++ {
+				v = v*10 + uint64(s[k]-'0')
+			}
+			if runLen == 10 && v >= secMin && v <= secMax {
+				return true
+			}
+			if runLen == 13 && v >= msMin && v <= msMax {
+				return true
+			}
+		}
+		i = j
+	}
+	return false
+}
+
 // formBodiesMatchModuloNoise compares two form-encoded bodies treating any
 // individual "key=value" segment that matches a Mock.Noise regex as a
 // wildcard. Noise is evaluated *per occurrence*, not per key: a body like
@@ -803,6 +848,15 @@ func formBodiesMatchModuloNoise(mockBody, reqBody string, nc *util.NoiseChecker)
 				out[key] = nil
 			}
 			if nc.IsNoisy(key + "=" + val) {
+				continue
+			}
+			// Stop-gap until the recorder emits explicit noise patterns
+			// for rotating-timestamp keys (botocore RoleSessionName,
+			// OAuth nonces, …): wildcard any segment whose value
+			// embeds a modern unix timestamp. valueHasUnixTimestamp's
+			// digit-width gate (10 or 13 only) keeps 12-digit AWS
+			// account IDs out of scope.
+			if valueHasUnixTimestamp(val) {
 				continue
 			}
 			out[key] = append(out[key], val)

--- a/pkg/agent/proxy/integrations/http/match_test.go
+++ b/pkg/agent/proxy/integrations/http/match_test.go
@@ -727,6 +727,103 @@ func TestExactBodyMatch_FormEncodedNoisyAcrossPositions(t *testing.T) {
 	}
 }
 
+// TestExactBodyMatch_FormEncodedUnixTimestampAutoWildcard covers the
+// botocore IRSA RoleSessionName case: the recorder marks WebIdentityToken
+// as noise but doesn't tag RoleSessionName=botocore-session-<unix-ts>,
+// which rotates every replay. The form-segment matcher must auto-wildcard
+// any segment whose value embeds a modern unix-second/millisecond
+// timestamp so exact match still wins without a recorder change.
+func TestExactBodyMatch_FormEncodedUnixTimestampAutoWildcard(t *testing.T) {
+	h := newHTTP()
+	mocks := []*models.Mock{
+		{
+			Name:  "mock-sts",
+			Kind:  models.Kind(models.HTTP),
+			Noise: []string{"^WebIdentityToken=[^&]+$"},
+			Spec: models.MockSpec{
+				HTTPReq: &models.HTTPReq{
+					Body: "Action=AssumeRoleWithWebIdentity" +
+						"&RoleArn=arn%3Aaws%3Aiam%3A%3A308798440167%3Arole%2Fexample" +
+						"&RoleSessionName=botocore-session-1778513757" +
+						"&WebIdentityToken=recorded-jwt",
+				},
+			},
+		},
+	}
+	// Replay-time request differs in RoleSessionName's embedded unix-ts
+	// AND the (already-noisy) WebIdentityToken. AWS account ID
+	// (308798440167, 12 digits) is preserved on both sides — must NOT be
+	// wildcarded.
+	reqBody := []byte("Action=AssumeRoleWithWebIdentity" +
+		"&RoleArn=arn%3Aaws%3Aiam%3A%3A308798440167%3Arole%2Fexample" +
+		"&RoleSessionName=botocore-session-1778513766" +
+		"&WebIdentityToken=replay-jwt")
+	ok, match := h.ExactBodyMatch(reqBody, mocks)
+	if !ok {
+		t.Fatal("expected unix-ts-bearing segment to be auto-wildcarded; got no match")
+	}
+	if match.Name != "mock-sts" {
+		t.Errorf("expected mock-sts, got %s", match.Name)
+	}
+}
+
+// TestExactBodyMatch_FormEncodedAccountIDNotWildcarded guards the
+// false-positive direction: a 12-digit AWS account ID is NOT a unix
+// timestamp in either seconds or milliseconds. If the only difference
+// between bodies is the account ID, the matcher must reject — otherwise
+// cross-account mocks could absorb one another.
+func TestExactBodyMatch_FormEncodedAccountIDNotWildcarded(t *testing.T) {
+	h := newHTTP()
+	mocks := []*models.Mock{
+		{
+			Name:  "mock-sts",
+			Kind:  models.Kind(models.HTTP),
+			Noise: []string{"^WebIdentityToken=[^&]+$"},
+			Spec: models.MockSpec{
+				HTTPReq: &models.HTTPReq{
+					Body: "Action=AssumeRoleWithWebIdentity" +
+						"&RoleArn=arn%3Aaws%3Aiam%3A%3A308798440167%3Arole%2Fexample" +
+						"&WebIdentityToken=A",
+				},
+			},
+		},
+	}
+	reqBody := []byte("Action=AssumeRoleWithWebIdentity" +
+		"&RoleArn=arn%3Aaws%3Aiam%3A%3A999999999999%3Arole%2Fexample" +
+		"&WebIdentityToken=B")
+	ok, _ := h.ExactBodyMatch(reqBody, mocks)
+	if ok {
+		t.Error("expected no match: 12-digit account ID must not be treated as a unix timestamp")
+	}
+}
+
+// TestExactBodyMatch_FormEncodedOutOfRangeDigitsNotWildcarded covers the
+// "10 digits but not plausibly a unix ts" branch: the run-length is right
+// but the value is outside [1.5e9, 2.5e9], so it must be preserved as a
+// non-noisy comparison.
+func TestExactBodyMatch_FormEncodedOutOfRangeDigitsNotWildcarded(t *testing.T) {
+	h := newHTTP()
+	mocks := []*models.Mock{
+		{
+			Name:  "mock-form",
+			Kind:  models.Kind(models.HTTP),
+			Noise: []string{"^Token=[^&]+$"},
+			Spec: models.MockSpec{
+				HTTPReq: &models.HTTPReq{
+					// 0123456789 is 10 digits but well below 1.5e9 →
+					// not a unix ts.
+					Body: "UserId=0123456789&Token=A",
+				},
+			},
+		},
+	}
+	reqBody := []byte("UserId=9876543210&Token=B")
+	ok, _ := h.ExactBodyMatch(reqBody, mocks)
+	if ok {
+		t.Error("expected no match: 10-digit value outside modern unix range must not be wildcarded")
+	}
+}
+
 func TestExactBodyMatch_NoNoisePatterns(t *testing.T) {
 	h := newHTTP()
 	// Mock has no Noise patterns — second pass should skip it


### PR DESCRIPTION
## Describe the changes that are made

The noise-aware form-body pass added in #4192 only relaxes a `key=value` segment when the recorder has emitted an explicit `Mock.Noise` regex for it. Botocore's IRSA flow exposes a rotating field the obfuscator doesn't currently tag — `RoleSessionName=botocore-session-<unix-ts>`, regenerated on every cold start.

With only `^WebIdentityToken=[^&]+$` in the noise list (the typical recorded shape), `formBodiesMatchModuloNoise` sees `RoleSessionName=...1778513757` (recorded) vs `...1778513766` (replay) as a non-noisy diff and rejects an otherwise byte-identical `AssumeRoleWithWebIdentity` request. The matcher then falls through to `fuzzy_levenshtein`, which picks an unrelated SNS `Publish` mock at ~12% similarity, serves `<PublishResponse>` XML to boto3's STS parser, and the user app exits 1 during boot.

This PR auto-wildcards form segments whose value embeds a modern unix timestamp:

- `valueHasUnixTimestamp` scans for a 10-digit decimal run in `[1_500_000_000, 2_500_000_000]` (seconds, 2017-07-14 → 2049-03-22) or a 13-digit run in `[1.5e12, 2.5e12]` (milliseconds, same range).
- The 10/13-digit width gate is deliberate: 11- and 12-digit runs are not plausible unix timestamps in either unit, so 12-digit AWS account IDs (e.g. `308798440167` inside a SigV4 `RoleArn`) stay non-noisy and continue to drive a real match decision.
- Hook sits right after the explicit `nc.IsNoisy` check in `formBodiesMatchModuloNoise`'s per-segment loop, so behaviour for mocks that already carry exhaustive noise patterns is unchanged.

Three regression tests cover:
1. The IRSA `RoleSessionName` case end-to-end (account-ID `RoleArn` left identical on both sides to prove the 12-digit gate).
2. False-positive direction — bodies differing only in a 12-digit account ID must NOT match (cross-account isolation guard).
3. A 10-digit value below 1.5e9 (`0123456789`) must NOT be wildcarded — guards the range check on the low end.

### Follow-up (separate PR, recorder side)

This is a stop-gap. The authoritative fix is in the form-key noise emitter (`enterprise/pkg/secret`), which should learn to tag `RoleSessionName` (and the OAuth `client_assertion` / `nonce` family) with `^<key>=[^&]+$` at record time. Once that lands, the heuristic here stays as defence-in-depth for mocks recorded before the obfuscator was updated.

## Links & References

**Closes:** NA

### 🔗 Related PRs
- #4192 (introduced the form-body noise-aware second pass this PR extends)

### 🐞 Related Issues
- NA

### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [x] 🐞 Bug Fix
- [x] ✅ Test

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed

Unit tests in `pkg/agent/proxy/integrations/http/match_test.go` exercise the form-segment matching path directly. The behaviour is internal to the matcher and doesn't need an e2e harness.

## Added comments for hard-to-understand areas?
- [x] 👍 yes

Inline comment on the new branch in `formBodiesMatchModuloNoise` flags this as a stop-gap and points at the digit-width gate's rationale; `valueHasUnixTimestamp`'s doc-comment explains the range choice.

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

```
go test ./pkg/agent/proxy/integrations/http/ -run TestExactBodyMatch_FormEncoded -v
```

All 8 form-encoded subtests pass (5 pre-existing + 3 new).

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?

Sequence observed in the bundle that motivated this fix (`provider-engagement-service`, test-set `7b9c4fdb59-gvfq4`):

```
agent-debug.log:142  mocks under consideration: [mock-2,...,mock-117,...]
agent-debug.log:394  http mock matched   mock: "mock-117"   match_percentage: 11.77   match_type: "fuzzy_levenshtein"
keploy-pes.log:130   provider-engagement-service exited with code 1 (restarting)
keploy-pes.log:131   keploy-v3-a44d exited with code 137
cloud-debug.log:322  failed to get testcase results: found no test results for test set ... gvfq4
```

`mock-117` is an `sns.us-east-1.amazonaws.com` `Action=Publish` recording; the replay request was `sts.us-east-1.amazonaws.com` `Action=AssumeRoleWithWebIdentity`. Only `RoleSessionName`'s embedded unix timestamp distinguished the replay body from the recorded mock-2 — exactly the shape this PR addresses.