### PR TITLE
fix(proxy/relay): add pre-dispatch pause to close postgres SSL preamble race

### DIFF
--- a/pkg/agent/proxy/directive/directive.go
+++ b/pkg/agent/proxy/directive/directive.go
@@ -39,6 +39,27 @@ const (
 	// that batch multi-frame mocks and want an explicit commit
 	// point rather than relying on EmitMock-per-frame.
 	KindFinalizeMock
+
+	// KindResumePreDispatch releases the pre-dispatch pause set up by
+	// [relay.Config.PreDispatchPause]. The relay drains any bytes
+	// stashed during the pause to the real peers (in the order they
+	// were Read), clears its pre-dispatch state, and closes the
+	// pause channel so the forwarders resume normal Read→Write→Tee
+	// operation.
+	//
+	// Parsers send this directive once their inspection of the first
+	// chunk concludes the connection does NOT need a TLS upgrade
+	// (i.e. the protocol's plaintext path is the right one to record).
+	// For TLS, parsers send [KindUpgradeTLS] instead — that handler
+	// consumes the stash directly via PreambleReadFromDest without
+	// needing a separate resume.
+	//
+	// Ack: OK=true on success; OK=false with Err populated if the
+	// drain Write to either real peer fails. On error the relay still
+	// clears the pre-dispatch state and pause channel so the connection
+	// can either continue (via the surviving peer if any) or be torn
+	// down by the supervisor's fallthrough-to-passthrough path.
+	KindResumePreDispatch
 )
 
 // String returns a short label for logging.
@@ -54,6 +75,8 @@ func (k Kind) String() string {
 		return "abort-mock"
 	case KindFinalizeMock:
 		return "finalize-mock"
+	case KindResumePreDispatch:
+		return "resume-pre-dispatch"
 	default:
 		return "unknown"
 	}
@@ -233,4 +256,10 @@ func Pause(d fakeconn.Direction, reason string) Directive {
 // Resume returns a [KindResumeDir] directive for the given direction.
 func Resume(d fakeconn.Direction, reason string) Directive {
 	return Directive{Kind: KindResumeDir, Dir: d, Reason: reason}
+}
+
+// ResumePreDispatch returns a [KindResumePreDispatch] directive. See
+// the kind's docstring for the lifecycle this directive completes.
+func ResumePreDispatch(reason string) Directive {
+	return Directive{Kind: KindResumePreDispatch, Reason: reason}
 }

--- a/pkg/agent/proxy/directive/directive_test.go
+++ b/pkg/agent/proxy/directive/directive_test.go
@@ -10,12 +10,13 @@ import (
 func TestKindString(t *testing.T) {
 	t.Parallel()
 	cases := map[Kind]string{
-		KindUpgradeTLS:   "upgrade-tls",
-		KindPauseDir:     "pause",
-		KindResumeDir:    "resume",
-		KindAbortMock:    "abort-mock",
-		KindFinalizeMock: "finalize-mock",
-		Kind(99):         "unknown",
+		KindUpgradeTLS:        "upgrade-tls",
+		KindPauseDir:          "pause",
+		KindResumeDir:         "resume",
+		KindAbortMock:         "abort-mock",
+		KindFinalizeMock:      "finalize-mock",
+		KindResumePreDispatch: "resume-pre-dispatch",
+		Kind(99):              "unknown",
 	}
 	for k, want := range cases {
 		if got := k.String(); got != want {
@@ -57,5 +58,18 @@ func TestSimpleHelpers(t *testing.T) {
 	r := Resume(fakeconn.FromDest, "resume")
 	if r.Kind != KindResumeDir || r.Dir != fakeconn.FromDest {
 		t.Errorf("Resume = %+v", r)
+	}
+	rpd := ResumePreDispatch("parser-decided-no-tls")
+	if rpd.Kind != KindResumePreDispatch {
+		t.Errorf("ResumePreDispatch kind = %v, want %v", rpd.Kind, KindResumePreDispatch)
+	}
+	if rpd.Reason != "parser-decided-no-tls" {
+		t.Errorf("ResumePreDispatch reason = %q, want %q", rpd.Reason, "parser-decided-no-tls")
+	}
+	// ResumePreDispatch does not target a direction (the relay drains
+	// both directions' stashes regardless), so Dir should be the zero
+	// value.
+	if rpd.Dir != fakeconn.Direction(0) {
+		t.Errorf("ResumePreDispatch Dir = %v, want zero value (directive applies to both directions)", rpd.Dir)
 	}
 }

--- a/pkg/agent/proxy/proxy_v2.go
+++ b/pkg/agent/proxy/proxy_v2.go
@@ -123,6 +123,24 @@ func (p *Proxy) recordViaSupervisor(
 	// connection (no pending requests) from a parser that received
 	// bytes but isn't emitting a mock (hang candidate). EmitMock's
 	// OnPendingCleared clears the flag after each successful emit.
+	// Opt-in pre-dispatch pause: parsers that need to deterministically
+	// observe the first chunk on a connection before any byte reaches
+	// the real peer implement the WantsPreDispatchPause capability.
+	// Today only postgres v3 sets this (to close the SSL preamble
+	// race; see keploy/enterprise#2012). Most parsers don't need it
+	// and would deadlock if their first action wasn't a ResumePreDispatch
+	// directive — so we ONLY engage pre-dispatch when the parser
+	// explicitly asks for it via this opt-in.
+	//
+	// Duck-typed instead of extending the IntegrationsV2 interface so
+	// each parser stays free to add the method independently and we
+	// don't have to touch every IntegrationsV2 implementation in this
+	// change.
+	var preDispatchPause bool
+	if pp, ok := parser.(interface{ WantsPreDispatchPause() bool }); ok {
+		preDispatchPause = pp.WantsPreDispatchPause()
+	}
+
 	r := relay.New(relay.Config{
 		Logger:               logger,
 		TLSUpgradeFn:         newProxyTLSUpgradeFn(logger),
@@ -133,8 +151,9 @@ func (p *Proxy) recordViaSupervisor(
 		// at startup from config.Record.RecordBuffer (yaml/flag/env).
 		// Zero values fall through to relay package defaults via
 		// withDefaults() — preserving the zero-config path.
-		PerConnCap: p.recordBufferCap,
-		TeeChanBuf: p.recordBufferQueueSize,
+		PerConnCap:       p.recordBufferCap,
+		TeeChanBuf:       p.recordBufferQueueSize,
+		PreDispatchPause: preDispatchPause,
 	}, srcConn, dstConn)
 
 	svSess.ClientStream = r.ClientStream()

--- a/pkg/agent/proxy/relay/config.go
+++ b/pkg/agent/proxy/relay/config.go
@@ -117,6 +117,43 @@ type Config struct {
 	// idle between requests) from "parser has a request in flight
 	// but isn't emitting a mock" (hang candidate). Nil is safe.
 	OnClientChunkTeed func()
+
+	// PreDispatchPause, when true, makes [Relay.Run] install a pause
+	// barrier BEFORE spawning the forwarder goroutines and switches
+	// the forwarders into pre-dispatch mode for the duration of the
+	// pause. Pre-dispatch mode differs from the standard pause in two
+	// ways:
+	//
+	//  1. The pre-Read pause check is bypassed so the very first Read
+	//     on each direction proceeds. Without this, the forwarders
+	//     would park immediately at the top of their loop and the
+	//     parser would never see the first chunk on its FakeConn
+	//     (the tee is downstream of the Read), deadlocking on the
+	//     parser's first read.
+	//
+	//  2. The post-Read pause check tees the chunk to the parser's
+	//     FakeConn AND stashes the payload, instead of stashing only.
+	//     The parser sees the bytes while the real-peer Write is
+	//     deferred; the parser can inspect, decide, and release the
+	//     pause via [directive.ResumePreDispatch] (which drains the
+	//     stash to the real peer) or escalate to a full TLS upgrade
+	//     via [directive.UpgradeTLS] (which consumes the stash
+	//     directly).
+	//
+	// The exact use case is the Postgres SSL preamble race documented
+	// in keploy/enterprise#2012: the V2 forwarder reads + writes
+	// continuously, so by the time the parser sees SSLRequest on its
+	// FakeConn the server may already have replied with 'S' and the
+	// client may already have started its TLS ClientHello. Holding
+	// writes on the destination→client direction until the parser has
+	// inspected the first chunk closes the race deterministically.
+	//
+	// Default false preserves today's behaviour for parsers that have
+	// not opted in. Most V2 parsers (http, mysql, mongo) do not need
+	// pre-dispatch pause and would deadlock if they didn't issue a
+	// ResumePreDispatch on entry — recordViaSupervisor only sets
+	// this when the parser implements an opt-in capability method.
+	PreDispatchPause bool
 }
 
 // withDefaults returns a copy of cfg with zero-valued optional fields

--- a/pkg/agent/proxy/relay/directive_proc.go
+++ b/pkg/agent/proxy/relay/directive_proc.go
@@ -2,6 +2,7 @@ package relay
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -66,6 +67,8 @@ func (r *Relay) handleDirective(ctx context.Context, stopping <-chan struct{}, d
 		// The relay is not the mock committer — that is the
 		// supervisor's job. Ack and move on.
 		return directive.Ack{Kind: d.Kind, OK: true}
+	case directive.KindResumePreDispatch:
+		return r.handleResumePreDispatch(d)
 	default:
 		return directive.Ack{
 			Kind: d.Kind,
@@ -535,6 +538,134 @@ func (r *Relay) handleAbortMock(d directive.Directive) directive.Ack {
 			reason = "abort_mock"
 		}
 		r.cfg.OnMarkMockIncomplete(reason)
+	}
+	return directive.Ack{Kind: d.Kind, OK: true}
+}
+
+// handleResumePreDispatch ends the pre-dispatch pause window installed
+// by run() under Config.PreDispatchPause. It:
+//
+//  1. Pulls everything from the per-direction stashes under stashMu.
+//     Those are the bytes the forwarders read + teed during pre-
+//     dispatch but did NOT write to the real peer (because pre-dispatch
+//     is precisely the mode where the parser is in charge of the first
+//     chunk's destiny). Without this drain, the connection would
+//     proceed with the real peers missing the prefix the parser just
+//     decided was fine to forward — the upstream would see byte N+1
+//     of the stream as if it were byte 0, and the protocol would
+//     desynchronize on the very next message.
+//
+//  2. Writes each stashed payload to the corresponding live peer in
+//     read order. C2D stash goes to dst (the real upstream service);
+//     D2C stash goes to src (the real client). A short write or error
+//     on either peer is logged and surfaced via Ack.OK=false, but we
+//     still endPause so the connection's forwarders aren't permanently
+//     stuck — the supervisor will fall through to passthrough.
+//
+//  3. Clears r.preDispatchActive so subsequent forward-loop iterations
+//     take the standard path (pre-Read park works, post-Read recheck
+//     stops teeing during transient pauses).
+//
+//  4. Calls endPause to close the pause channel — forwarders parked on
+//     it wake up and resume normal Read→Write→Tee operation.
+func (r *Relay) handleResumePreDispatch(d directive.Directive) directive.Ack {
+	log := r.cfg.Logger
+
+	// Pull the stashed payloads under the mutex; subsequent forwarder
+	// post-Read rechecks may add new stash entries before endPause
+	// closes the pause channel, but those would still be processed
+	// by the standard pause path (we've cleared preDispatchActive
+	// just below, so no further tee happens; the bytes get stashed-
+	// and-dropped on endPause, which is the right behaviour for any
+	// in-flight read that started before this resume directive
+	// arrived).
+	r.stashMu.Lock()
+	c2dStash := r.stashedC2D
+	d2cStash := r.stashedD2C
+	r.stashedC2D = nil
+	r.stashedD2C = nil
+	r.stashMu.Unlock()
+
+	// Clear the pre-dispatch flag before draining so any concurrent
+	// post-Read recheck (a forwarder that woke from the deadline kick
+	// after stashing) does not double-tee the same bytes we are about
+	// to write.
+	r.preDispatchActive.Store(false)
+
+	var drainErr error
+	if len(c2dStash) > 0 {
+		dst := *r.dst.Load()
+		for _, p := range c2dStash {
+			if dst == nil {
+				break
+			}
+			wn, werr := dst.Write(p.bytes)
+			if werr != nil {
+				if log != nil {
+					log.Debug("relay: ResumePreDispatch C2D drain write error",
+						zap.Error(werr),
+						zap.Int("payload_bytes", len(p.bytes)),
+						zap.Int("written_bytes", wn),
+					)
+				}
+				if r.cfg.OnMarkMockIncomplete != nil {
+					r.cfg.OnMarkMockIncomplete("pre_dispatch_drain_c2d_write_error")
+				}
+				drainErr = fmt.Errorf("resume-pre-dispatch C2D drain: %w", werr)
+				break
+			}
+			if wn != len(p.bytes) {
+				if r.cfg.OnMarkMockIncomplete != nil {
+					r.cfg.OnMarkMockIncomplete("pre_dispatch_drain_c2d_short_write")
+				}
+				drainErr = errors.New("resume-pre-dispatch C2D drain: short write on destination socket")
+				break
+			}
+		}
+	}
+	if drainErr == nil && len(d2cStash) > 0 {
+		src := *r.src.Load()
+		for _, p := range d2cStash {
+			if src == nil {
+				break
+			}
+			wn, werr := src.Write(p.bytes)
+			if werr != nil {
+				if log != nil {
+					log.Debug("relay: ResumePreDispatch D2C drain write error",
+						zap.Error(werr),
+						zap.Int("payload_bytes", len(p.bytes)),
+						zap.Int("written_bytes", wn),
+					)
+				}
+				if r.cfg.OnMarkMockIncomplete != nil {
+					r.cfg.OnMarkMockIncomplete("pre_dispatch_drain_d2c_write_error")
+				}
+				drainErr = fmt.Errorf("resume-pre-dispatch D2C drain: %w", werr)
+				break
+			}
+			if wn != len(p.bytes) {
+				if r.cfg.OnMarkMockIncomplete != nil {
+					r.cfg.OnMarkMockIncomplete("pre_dispatch_drain_d2c_short_write")
+				}
+				drainErr = errors.New("resume-pre-dispatch D2C drain: short write on source socket")
+				break
+			}
+		}
+	}
+
+	// Always endPause, even on a partial drain: the alternative is
+	// to leave the forwarders permanently parked on the pause channel
+	// while the supervisor decides what to do, which deadlocks the
+	// only path that can tear the relay down (parser exits → relayCtx
+	// cancels → forwarders return via ctx.Done in their pause select).
+	// That select IS armed (see the pre-Read park) but we'd rather not
+	// rely on cancellation timing here — making the wake-up
+	// unconditional is cheap and easier to reason about.
+	r.endPause()
+
+	if drainErr != nil {
+		return directive.Ack{Kind: d.Kind, OK: false, Err: drainErr}
 	}
 	return directive.Ack{Kind: d.Kind, OK: true}
 }

--- a/pkg/agent/proxy/relay/directive_proc.go
+++ b/pkg/agent/proxy/relay/directive_proc.go
@@ -580,6 +580,25 @@ func (r *Relay) handleAbortMock(d directive.Directive) directive.Ack {
 func (r *Relay) handleResumePreDispatch(ctx context.Context, stopping <-chan struct{}, d directive.Directive) directive.Ack {
 	log := r.cfg.Logger
 
+	// Defensive precondition: only act on connections that actually
+	// have an active pre-dispatch pause. A duplicate ResumePreDispatch
+	// or a parser bug that fires it after the pause already ended
+	// (e.g. UpgradeTLS already ran) would otherwise nudge deadlines
+	// into the past on the live sockets — and since endPause only
+	// clears deadlines while pauseCh is non-nil, those past deadlines
+	// would persist, putting the forwarders into a tight EAGAIN loop
+	// for the rest of the connection. Reject loudly instead: the
+	// supervisor will surface the error and the connection falls
+	// through to passthrough, which is the right blast radius for a
+	// directive-protocol violation.
+	if !r.preDispatchActive.Load() || r.currentPauseCh() == nil {
+		return directive.Ack{
+			Kind: d.Kind,
+			OK:   false,
+			Err:  errors.New("resume-pre-dispatch: no active pre-dispatch pause to release"),
+		}
+	}
+
 	// Synchronise with the forwarders before touching the stash. The
 	// nudge wakes any forwarder blocked in Read; the wait ensures both
 	// of them have reached the post-Read pause path (either with bytes

--- a/pkg/agent/proxy/relay/directive_proc.go
+++ b/pkg/agent/proxy/relay/directive_proc.go
@@ -68,7 +68,7 @@ func (r *Relay) handleDirective(ctx context.Context, stopping <-chan struct{}, d
 		// supervisor's job. Ack and move on.
 		return directive.Ack{Kind: d.Kind, OK: true}
 	case directive.KindResumePreDispatch:
-		return r.handleResumePreDispatch(d)
+		return r.handleResumePreDispatch(ctx, stopping, d)
 	default:
 		return directive.Ack{
 			Kind: d.Kind,
@@ -545,40 +545,52 @@ func (r *Relay) handleAbortMock(d directive.Directive) directive.Ack {
 // handleResumePreDispatch ends the pre-dispatch pause window installed
 // by run() under Config.PreDispatchPause. It:
 //
-//  1. Pulls everything from the per-direction stashes under stashMu.
-//     Those are the bytes the forwarders read + teed during pre-
-//     dispatch but did NOT write to the real peer (because pre-dispatch
-//     is precisely the mode where the parser is in charge of the first
-//     chunk's destiny). Without this drain, the connection would
-//     proceed with the real peers missing the prefix the parser just
-//     decided was fine to forward — the upstream would see byte N+1
-//     of the stream as if it were byte 0, and the protocol would
-//     desynchronize on the very next message.
+//  1. Nudges both real sockets' read deadlines into the past and waits
+//     for both forwarders to mark themselves parked on the pause
+//     channel. This is the critical synchronisation step. Pre-dispatch
+//     starts WITHOUT a deadline kick (so the forwarders' first Read
+//     proceeds), so by the time this directive arrives a forwarder may
+//     still be blocked in a Read that hasn't returned yet. If we
+//     snapshot the stash and call endPause without first draining the
+//     in-flight Reads through the post-Read pause path, those Reads
+//     would return AFTER our snapshot took the stash, land in the
+//     post-Read recheck still seeing pauseCh != nil, append to the
+//     stash, and then be dropped by endPause's unconditional
+//     stashedC2D/stashedD2C = nil. Bytes lost silently, live stream
+//     desynchronizes.
 //
-//  2. Writes each stashed payload to the corresponding live peer in
+//  2. Pulls everything from the per-direction stashes under stashMu.
+//     With both forwarders parked, no concurrent appends can race
+//     this read. The bytes are the prefix the forwarders teed during
+//     pre-dispatch but did NOT write to the real peer.
+//
+//  3. Writes each stashed payload to the corresponding live peer in
 //     read order. C2D stash goes to dst (the real upstream service);
 //     D2C stash goes to src (the real client). A short write or error
 //     on either peer is logged and surfaced via Ack.OK=false, but we
 //     still endPause so the connection's forwarders aren't permanently
 //     stuck — the supervisor will fall through to passthrough.
 //
-//  3. Clears r.preDispatchActive so subsequent forward-loop iterations
+//  4. Clears r.preDispatchActive so subsequent forward-loop iterations
 //     take the standard path (pre-Read park works, post-Read recheck
 //     stops teeing during transient pauses).
 //
-//  4. Calls endPause to close the pause channel — forwarders parked on
+//  5. Calls endPause to close the pause channel — forwarders parked on
 //     it wake up and resume normal Read→Write→Tee operation.
-func (r *Relay) handleResumePreDispatch(d directive.Directive) directive.Ack {
+func (r *Relay) handleResumePreDispatch(ctx context.Context, stopping <-chan struct{}, d directive.Directive) directive.Ack {
 	log := r.cfg.Logger
 
-	// Pull the stashed payloads under the mutex; subsequent forwarder
-	// post-Read rechecks may add new stash entries before endPause
-	// closes the pause channel, but those would still be processed
-	// by the standard pause path (we've cleared preDispatchActive
-	// just below, so no further tee happens; the bytes get stashed-
-	// and-dropped on endPause, which is the right behaviour for any
-	// in-flight read that started before this resume directive
-	// arrived).
+	// Synchronise with the forwarders before touching the stash. The
+	// nudge wakes any forwarder blocked in Read; the wait ensures both
+	// of them have reached the post-Read pause path (either with bytes
+	// to stash, or with a deadline error producing no stash) and
+	// marked themselves parked. After this returns, both forwarders
+	// are blocked on pauseCh and no concurrent stash appends can race
+	// the snapshot below.
+	r.nudgeDeadline(r.dst.Load())
+	r.nudgeDeadline(r.src.Load())
+	r.waitForwardersParked(ctx, stopping)
+
 	r.stashMu.Lock()
 	c2dStash := r.stashedC2D
 	d2cStash := r.stashedD2C
@@ -586,10 +598,10 @@ func (r *Relay) handleResumePreDispatch(d directive.Directive) directive.Ack {
 	r.stashedD2C = nil
 	r.stashMu.Unlock()
 
-	// Clear the pre-dispatch flag before draining so any concurrent
-	// post-Read recheck (a forwarder that woke from the deadline kick
-	// after stashing) does not double-tee the same bytes we are about
-	// to write.
+	// Clear the pre-dispatch flag before draining so any path that
+	// reads it (currently only the forward loop, which is parked
+	// behind pauseCh until endPause below — the flag clear here is
+	// belt-and-braces) sees the standard pause semantics.
 	r.preDispatchActive.Store(false)
 
 	var drainErr error

--- a/pkg/agent/proxy/relay/relay.go
+++ b/pkg/agent/proxy/relay/relay.go
@@ -103,7 +103,8 @@ type Relay struct {
 	runErr atomic.Pointer[error]
 
 	// preDispatchActive is true between [Relay.Run]'s pre-spawn
-	// [beginPause] (gated on [Config.PreDispatchPause]) and the
+	// [installPreDispatchPause] call (gated on
+	// [Config.PreDispatchPause]) and the
 	// [directive.KindResumePreDispatch] handler. While set, the
 	// forward loop:
 	//
@@ -312,15 +313,15 @@ func (r *Relay) run(ctx context.Context) error {
 	// have replied with 'S' and the client may already have written
 	// TLS bytes that the C2D forwarder forwarded as plaintext.
 	//
-	// installPreDispatchPauseLocked is the no-deadline-kick variant
-	// of beginPause: there are no in-flight Reads yet (forwarders are
+	// installPreDispatchPause is the no-deadline-kick variant of
+	// beginPause: there are no in-flight Reads yet (forwarders are
 	// not running), so the deadline kick beginPause uses to wake a
 	// blocked Read would just leave the read deadlines stuck in the
 	// past — making the forwarder Read return EAGAIN forever in a
 	// tight loop until endPause clears it. The pause channel and the
 	// parker tracking are set up identically.
 	if r.cfg.PreDispatchPause {
-		r.installPreDispatchPauseLocked()
+		r.installPreDispatchPause()
 		r.preDispatchActive.Store(true)
 	}
 
@@ -678,14 +679,14 @@ func (r *Relay) beginPause() chan struct{} {
 	return pc
 }
 
-// installPreDispatchPauseLocked installs the pause channel + parker
+// installPreDispatchPause installs the pause channel + parker
 // tracking WITHOUT touching the live sockets' read deadlines. Use
 // before any forwarder has started reading — the deadline-kick the
 // regular beginPause does would otherwise leave the sockets in a
 // permanent timeout state until endPause cleared it, starving the
-// forwarders out of their pause-aware Read loop. Caller must hold
-// pauseMu.
-func (r *Relay) installPreDispatchPauseLocked() {
+// forwarders out of their pause-aware Read loop. Acquires pauseMu
+// internally; callers must NOT already hold it.
+func (r *Relay) installPreDispatchPause() {
 	r.pauseMu.Lock()
 	defer r.pauseMu.Unlock()
 	r.installPauseChLocked()

--- a/pkg/agent/proxy/relay/relay.go
+++ b/pkg/agent/proxy/relay/relay.go
@@ -693,7 +693,7 @@ func (r *Relay) installPreDispatchPause() {
 }
 
 // installPauseChLocked is the shared body of beginPause and
-// installPreDispatchPauseLocked. Returns the active pause channel and
+// installPreDispatchPause. Returns the active pause channel and
 // guarantees the per-direction park signals are armed. Caller must
 // hold pauseMu.
 func (r *Relay) installPauseChLocked() chan struct{} {
@@ -822,6 +822,17 @@ func (r *Relay) endPause() {
 	r.stashedC2D = nil
 	r.stashedD2C = nil
 	r.stashMu.Unlock()
+	// Always clear the pre-dispatch flag when a pause window ends.
+	// This covers both ResumePreDispatch (the explicit no-TLS resume
+	// path, which also clears it directly before calling endPause as
+	// defence-in-depth) and the TLS-upgrade path (handleUpgradeTLS
+	// transitions from pre-dispatch into its own pause + upgrade and
+	// then calls endPause; without this clear the flag would leak
+	// past the TLS upgrade and corrupt the semantics of any future
+	// pause on the connection — pre-Read park would stay skipped
+	// and post-Read pauses would tee into the parser FakeConn even
+	// when they shouldn't).
+	r.preDispatchActive.Store(false)
 }
 
 // clearDeadline drops any read deadline previously installed on the

--- a/pkg/agent/proxy/relay/relay.go
+++ b/pkg/agent/proxy/relay/relay.go
@@ -101,6 +101,25 @@ type Relay struct {
 	// single-shot; subsequent Run calls return this cached error via
 	// ErrRelayAlreadyRun.
 	runErr atomic.Pointer[error]
+
+	// preDispatchActive is true between [Relay.Run]'s pre-spawn
+	// [beginPause] (gated on [Config.PreDispatchPause]) and the
+	// [directive.KindResumePreDispatch] handler. While set, the
+	// forward loop:
+	//
+	//   - SKIPS the pre-Read park (so the first Read on each direction
+	//     proceeds and produces a chunk for the parser to inspect via
+	//     its FakeConn), and
+	//   - on the post-Read pause check, TEES the chunk in addition to
+	//     stashing — exposing the bytes to the parser even though they
+	//     have not yet been written to the real peer.
+	//
+	// The parser ends the window by sending KindResumePreDispatch
+	// (drain stash to real peer, clear flag, endPause) or by sending
+	// KindUpgradeTLS (the existing TLS upgrade handler consumes the
+	// stash via takeStashedPrefix; it then clears the flag on its own
+	// endPause path).
+	preDispatchActive atomic.Bool
 }
 
 // ErrRelayAlreadyRun is returned from a second [Relay.Run] call.
@@ -283,6 +302,28 @@ func (r *Relay) run(ctx context.Context) error {
 		r.processDirectives(ctx, stopping)
 	}()
 
+	// Pre-dispatch pause: install the pause barrier BEFORE spawning
+	// forwarder goroutines so the very first byte each direction
+	// produces lands in the post-Read pause path (where the
+	// preDispatchActive flag below makes the forwarder tee AND stash
+	// instead of writing). This closes the postgres SSL preamble
+	// race (keploy/enterprise#2012) — without it, by the time the
+	// parser sees SSLRequest on its FakeConn the server may already
+	// have replied with 'S' and the client may already have written
+	// TLS bytes that the C2D forwarder forwarded as plaintext.
+	//
+	// installPreDispatchPauseLocked is the no-deadline-kick variant
+	// of beginPause: there are no in-flight Reads yet (forwarders are
+	// not running), so the deadline kick beginPause uses to wake a
+	// blocked Read would just leave the read deadlines stuck in the
+	// past — making the forwarder Read return EAGAIN forever in a
+	// tight loop until endPause clears it. The pause channel and the
+	// parker tracking are set up identically.
+	if r.cfg.PreDispatchPause {
+		r.installPreDispatchPauseLocked()
+		r.preDispatchActive.Store(true)
+	}
+
 	// When one forwarder exits, signal the other to exit too via the
 	// existing stopping/nudgeDeadline machinery. Without this signalling,
 	// if e.g. the upstream sends FIN → FromDest reads EOF and exits, the
@@ -389,7 +430,18 @@ func (r *Relay) forward(
 		// Respect the pause barrier if the directive processor is
 		// mid-TLS-upgrade. The barrier is a chan that closes when
 		// resumed.
-		if pc := r.currentPauseCh(); pc != nil {
+		//
+		// Pre-dispatch pause is the exception: the pause channel is
+		// already open at first entry (installed by run() before
+		// spawning forwarders), but we must NOT park here — the
+		// parser needs the first Read on each direction to produce a
+		// chunk it can inspect via its FakeConn. The forwarder reads,
+		// hits the post-Read recheck below, and parks there with the
+		// chunk both teed (so the parser sees it) and stashed (so the
+		// real-peer Write is deferred). The flag is cleared by
+		// KindResumePreDispatch (or by the TLS upgrade handler's
+		// endPause), so subsequent iterations behave as today.
+		if pc := r.currentPauseCh(); pc != nil && !r.preDispatchActive.Load() {
 			r.markForwarderParked(dir)
 			select {
 			case <-pc:
@@ -436,7 +488,33 @@ func (r *Relay) forward(
 					log.Debug("relay: stashing in-flight bytes across pause boundary",
 						zap.String("dir", dir.String()),
 						zap.Int("stashed_bytes", n),
+						zap.Bool("pre_dispatch", r.preDispatchActive.Load()),
 					)
+				}
+				// In pre-dispatch mode the parser needs to SEE the
+				// stashed bytes via its FakeConn — that's the whole
+				// point of installing the pause before forwarders
+				// spawn. Tee a chunk with ReadAt set and WrittenAt
+				// left zero (the real Write is deferred to either
+				// the KindResumePreDispatch drain or the TLS upgrade
+				// handler's own write path; in neither case do we
+				// have a meaningful WrittenAt to record at chunk
+				// emission time). The standard pause path (TLS
+				// upgrade after a parser already had its chance to
+				// inspect a prior chunk) does NOT tee — those bytes
+				// are protocol preamble the parser explicitly does
+				// not want to consume via its FakeConn.
+				if r.preDispatchActive.Load() {
+					chunk := fakeconn.Chunk{
+						Dir:    dir,
+						Bytes:  stash,
+						ReadAt: readAt,
+						SeqNo:  seq.Add(1),
+					}
+					teed := t.push(chunk)
+					if teed && dir == fakeconn.FromClient && r.cfg.OnClientChunkTeed != nil {
+						r.cfg.OnClientChunkTeed()
+					}
 				}
 				n = 0
 			}
@@ -587,17 +665,8 @@ func (r *Relay) currentPauseCh() chan struct{} {
 // "loop and re-check pause" rather than "tear down the relay".
 func (r *Relay) beginPause() chan struct{} {
 	r.pauseMu.Lock()
-	defer r.pauseMu.Unlock()
-	if r.pauseCh == nil {
-		r.pauseCh = make(chan struct{})
-	}
-	if r.parkedC2D == nil {
-		r.parkedC2D = make(chan struct{})
-	}
-	if r.parkedD2C == nil {
-		r.parkedD2C = make(chan struct{})
-	}
-	pc := r.pauseCh
+	pc := r.installPauseChLocked()
+	r.pauseMu.Unlock()
 	// Nudge both sockets out of any blocking Read. A past timestamp
 	// fires immediately; the forwarder Read returns with a deadline
 	// error which the post-Read pause recheck handles (returns to
@@ -607,6 +676,36 @@ func (r *Relay) beginPause() chan struct{} {
 	r.nudgeDeadline(r.dst.Load())
 	r.nudgeDeadline(r.src.Load())
 	return pc
+}
+
+// installPreDispatchPauseLocked installs the pause channel + parker
+// tracking WITHOUT touching the live sockets' read deadlines. Use
+// before any forwarder has started reading — the deadline-kick the
+// regular beginPause does would otherwise leave the sockets in a
+// permanent timeout state until endPause cleared it, starving the
+// forwarders out of their pause-aware Read loop. Caller must hold
+// pauseMu.
+func (r *Relay) installPreDispatchPauseLocked() {
+	r.pauseMu.Lock()
+	defer r.pauseMu.Unlock()
+	r.installPauseChLocked()
+}
+
+// installPauseChLocked is the shared body of beginPause and
+// installPreDispatchPauseLocked. Returns the active pause channel and
+// guarantees the per-direction park signals are armed. Caller must
+// hold pauseMu.
+func (r *Relay) installPauseChLocked() chan struct{} {
+	if r.pauseCh == nil {
+		r.pauseCh = make(chan struct{})
+	}
+	if r.parkedC2D == nil {
+		r.parkedC2D = make(chan struct{})
+	}
+	if r.parkedD2C == nil {
+		r.parkedD2C = make(chan struct{})
+	}
+	return r.pauseCh
 }
 
 // waitForwardersParked blocks until both forwarders have observed the

--- a/pkg/agent/proxy/relay/relay_test.go
+++ b/pkg/agent/proxy/relay/relay_test.go
@@ -860,3 +860,140 @@ func (d *dropSink) count(reason string) int {
 	}
 	return n
 }
+
+// TestPreDispatchPause_HoldsC2DUntilResume — the canonical scenario the
+// pre-dispatch pause exists to handle: bytes the client sends DO NOT
+// reach the real destination until the parser explicitly releases the
+// pause. The parser's FakeConn DOES see those bytes (otherwise it
+// couldn't decide whether to release or escalate to a TLS upgrade).
+// Mirrors the Postgres SSL preamble race (keploy/enterprise#2012):
+// without this guarantee, the C2D forwarder would deliver SSLRequest
+// to the server while the parser was still scheduling, the server's
+// 'S' reply would race back through D2C to the client, and the
+// recorder would see whatever byte landed instead of 'S'.
+func TestPreDispatchPause_HoldsC2DUntilResume(t *testing.T) {
+	t.Parallel()
+	h := newHarness(t, Config{PreDispatchPause: true})
+
+	// Client writes the first chunk. Without pre-dispatch this would
+	// land on destSvc within microseconds; with pre-dispatch it must
+	// be held until the parser releases.
+	payload := []byte("first-chunk")
+	go h.writeClient(payload)
+
+	// destSvc must NOT receive the payload while pre-dispatch is active.
+	// Use a short read deadline to assert the bytes are being held.
+	_ = h.destSvc.SetReadDeadline(time.Now().Add(150 * time.Millisecond))
+	buf := make([]byte, len(payload))
+	if n, err := h.destSvc.Read(buf); err == nil {
+		t.Fatalf("destSvc should have timed out while pre-dispatch held the write; got %d bytes %q",
+			n, buf[:n])
+	}
+	_ = h.destSvc.SetReadDeadline(time.Time{})
+
+	// The parser's FakeConn DOES see the chunk — the whole point of
+	// pre-dispatch is that the parser inspects the first message
+	// before any byte hits the real peer.
+	c, err := h.r.ClientStream().ReadChunk()
+	if err != nil {
+		t.Fatalf("ClientStream.ReadChunk during pre-dispatch: %v", err)
+	}
+	if string(c.Bytes) != string(payload) {
+		t.Fatalf("ClientStream chunk bytes=%q, want %q", c.Bytes, payload)
+	}
+	if c.Dir != fakeconn.FromClient {
+		t.Fatalf("ClientStream chunk Dir=%v, want FromClient", c.Dir)
+	}
+	if c.ReadAt.IsZero() {
+		t.Fatalf("ClientStream chunk missing ReadAt: %+v", c)
+	}
+
+	// The handler drains the C2D stash to destSvc synchronously and
+	// destSvc is a net.Pipe — the Write blocks until somebody reads.
+	// Start the reader BEFORE issuing the directive so the handler's
+	// Write can complete (otherwise the ack never lands).
+	gotCh := make(chan []byte, 1)
+	go func() { gotCh <- h.readDest(len(payload)) }()
+
+	h.r.Directives() <- directive.ResumePreDispatch("parser-decided-no-tls")
+	select {
+	case a := <-h.r.Acks():
+		if a.Kind != directive.KindResumePreDispatch || !a.OK {
+			t.Fatalf("bad ResumePreDispatch ack: %+v", a)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("no ack for ResumePreDispatch")
+	}
+
+	got := <-gotCh
+	if string(got) != string(payload) {
+		t.Fatalf("dest got %q after resume, want %q", got, payload)
+	}
+
+	// Subsequent traffic flows normally — pre-dispatch is a one-shot
+	// gate, not a sticky mode. Write a new payload and confirm it
+	// reaches destSvc without another directive round-trip.
+	post := []byte("post-resume")
+	go h.writeClient(post)
+	got = h.readDest(len(post))
+	if string(got) != string(post) {
+		t.Fatalf("post-resume dest got %q, want %q", got, post)
+	}
+}
+
+// TestPreDispatchPause_HoldsD2CUntilResume — symmetric to the C2D test,
+// but exercises the destination→client direction. In the postgres SSL
+// scenario this is the load-bearing one: the server's 'S' reply must
+// NOT reach the client before the parser decides whether to handle the
+// TLS upgrade itself (otherwise the client reacts with TLS ClientHello
+// and the parser-driven handshake collides with the wild one).
+func TestPreDispatchPause_HoldsD2CUntilResume(t *testing.T) {
+	t.Parallel()
+	h := newHarness(t, Config{PreDispatchPause: true})
+
+	// Simulate Postgres replying. The real client must NOT see this
+	// until the parser explicitly resumes.
+	payload := []byte("S") // mimics the SSLResponse byte
+	go h.writeDest(payload)
+
+	// clientApp must NOT receive the payload while pre-dispatch held.
+	_ = h.clientApp.SetReadDeadline(time.Now().Add(150 * time.Millisecond))
+	buf := make([]byte, len(payload))
+	if n, err := h.clientApp.Read(buf); err == nil {
+		t.Fatalf("clientApp should have timed out while pre-dispatch held the write; got %d bytes %q",
+			n, buf[:n])
+	}
+	_ = h.clientApp.SetReadDeadline(time.Time{})
+
+	// The parser's DestStream sees the chunk.
+	d, err := h.r.DestStream().ReadChunk()
+	if err != nil {
+		t.Fatalf("DestStream.ReadChunk during pre-dispatch: %v", err)
+	}
+	if string(d.Bytes) != string(payload) {
+		t.Fatalf("DestStream chunk bytes=%q, want %q", d.Bytes, payload)
+	}
+	if d.Dir != fakeconn.FromDest {
+		t.Fatalf("DestStream chunk Dir=%v, want FromDest", d.Dir)
+	}
+
+	// Same pipe-blocking concern as the C2D test: drain Write blocks
+	// until the test reads. Spawn the reader first.
+	gotCh := make(chan []byte, 1)
+	go func() { gotCh <- h.readClient(len(payload)) }()
+
+	h.r.Directives() <- directive.ResumePreDispatch("parser-decided-no-tls")
+	select {
+	case a := <-h.r.Acks():
+		if a.Kind != directive.KindResumePreDispatch || !a.OK {
+			t.Fatalf("bad ResumePreDispatch ack: %+v", a)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("no ack for ResumePreDispatch")
+	}
+
+	got := <-gotCh
+	if string(got) != string(payload) {
+		t.Fatalf("client got %q after resume, want %q", got, payload)
+	}
+}

--- a/pkg/agent/proxy/relay/relay_test.go
+++ b/pkg/agent/proxy/relay/relay_test.go
@@ -882,12 +882,18 @@ func TestPreDispatchPause_HoldsC2DUntilResume(t *testing.T) {
 	go h.writeClient(payload)
 
 	// destSvc must NOT receive the payload while pre-dispatch is active.
-	// Use a short read deadline to assert the bytes are being held.
+	// Use a short read deadline and assert the Read times out specifically
+	// (not a closed-connection / EOF / unrelated error — those would make
+	// this test pass trivially without proving the pause guarantee).
 	_ = h.destSvc.SetReadDeadline(time.Now().Add(150 * time.Millisecond))
 	buf := make([]byte, len(payload))
-	if n, err := h.destSvc.Read(buf); err == nil {
+	n, err := h.destSvc.Read(buf)
+	if err == nil {
 		t.Fatalf("destSvc should have timed out while pre-dispatch held the write; got %d bytes %q",
 			n, buf[:n])
+	}
+	if ne, ok := err.(net.Error); !ok || !ne.Timeout() {
+		t.Fatalf("destSvc Read should have failed with a timeout (net.Error.Timeout()==true); got %v (n=%d)", err, n)
 	}
 	_ = h.destSvc.SetReadDeadline(time.Time{})
 
@@ -957,11 +963,17 @@ func TestPreDispatchPause_HoldsD2CUntilResume(t *testing.T) {
 	go h.writeDest(payload)
 
 	// clientApp must NOT receive the payload while pre-dispatch held.
+	// Assert specifically on timeout so the test cannot be falsified by
+	// an unrelated read error (e.g. the connection getting torn down).
 	_ = h.clientApp.SetReadDeadline(time.Now().Add(150 * time.Millisecond))
 	buf := make([]byte, len(payload))
-	if n, err := h.clientApp.Read(buf); err == nil {
+	n, err := h.clientApp.Read(buf)
+	if err == nil {
 		t.Fatalf("clientApp should have timed out while pre-dispatch held the write; got %d bytes %q",
 			n, buf[:n])
+	}
+	if ne, ok := err.(net.Error); !ok || !ne.Timeout() {
+		t.Fatalf("clientApp Read should have failed with a timeout (net.Error.Timeout()==true); got %v (n=%d)", err, n)
 	}
 	_ = h.clientApp.SetReadDeadline(time.Time{})
 


### PR DESCRIPTION
## TL;DR

Closes the V2 race that fires the `v3 recorder V2: unexpected SSL response` parser error on postgres CI lanes ([keploy/enterprise#2012](https://github.com/keploy/enterprise/issues/2012)). Adds an opt-in `relay.Config.PreDispatchPause` that installs the pause barrier **before** spawning the forwarder goroutines, plus a new `directive.ResumePreDispatch` for parsers to release it once they've inspected the first chunk. No behaviour change for any parser that doesn't opt in.

Companion PR (postgres opt-in): keploy/integrations [`opt-postgres-into-pre-dispatch-pause`](https://github.com/keploy/integrations/tree/opt-postgres-into-pre-dispatch-pause).

## The race

`pkg/agent/proxy/proxy_v2.go::recordViaSupervisor` today:

```go
go func() { relayDone <- r.Run(relayCtx) }()        // L151 — forwarders launched
...
result := sv.Run(ctx, func(parserCtx, sv2sess *supervisor.Session) error {  // L186 — parser launched
```

The two goroutines race from the start. For postgres on `sslmode=prefer` (the default), within microseconds the C2D forwarder forwards `SSLRequest` to the server, the server replies with `'S'`, the D2C forwarder forwards `'S'` to the client, the client begins its TLS ClientHello, the C2D forwards that on too — all before the parser's first `ReadBytes` on `ClientStream` returns. When the parser finally sends `UpgradeTLS` and the relay reads the preamble byte, the live socket is already mid-TLS handshake and the byte is `0x16` (TLS Handshake ContentType) or `'R'` (postgres AuthenticationOk, depending on which protocol arm won). The recorder treats it as fatal, the record fails, and at replay the app boots into a connection with no recorded session mock.

The race is fundamental to the V2 design — `pkg/agent/proxy/directive/directive.go:79–94` and `pkg/agent/proxy/relay/directive_proc.go:163–170` both name it explicitly. The existing `PreambleReadFromDest` / stash mitigation handles the case where the D2C forwarder *had bytes in flight* when the parser's `beginPause` finally landed; it does **not** cover the case where the D2C forwarder had already *forwarded* `'S'` and moved on. That's the case actually firing in CI.

## The fix

A single relay-side knob, opt-in per-parser.

* `relay.Config.PreDispatchPause bool` — when true, `relay.Run` installs the pause channel + parker tracking via the new `installPreDispatchPauseLocked` helper *before* launching the C2D and D2C forwarder goroutines. The forwarders' first iteration enters their loop already aware of the pause.

* `installPreDispatchPauseLocked` is the no-deadline-kick variant of `beginPause`. The regular `beginPause` nudges read deadlines into the past so an in-flight `Read` wakes up immediately. Doing that here, before forwarders have started reading, would leave the sockets stuck in timeout-error mode forever — every subsequent `Read` would return EAGAIN until `endPause` cleared the deadline, starving the forwarders out of their pause-aware loop. The pre-dispatch path skips the kick.

* `Relay.preDispatchActive atomic.Bool` — a state flag the forwarder reads at two points in its loop:

  - **Pre-Read pause check**: SKIPPED while the flag is set. Without this skip the forwarders park at the top of their loop with no read in flight, the parser's FakeConn stays empty, and the parser deadlocks on its first `ReadBytes`.

  - **Post-Read pause check**: tees the chunk to the parser's FakeConn *in addition to* stashing it (instead of stashing only). The parser sees the bytes via its FakeConn while the real-peer Write stays held in the per-direction stash.

* `directive.KindResumePreDispatch` — a new directive kind. `handleResumePreDispatch` drains the per-direction stashes to their corresponding live peers in read order (`stashedC2D → dst.Write`, `stashedD2C → src.Write`), clears `preDispatchActive`, and calls `endPause`. The connection's forwarders resume Read→Write→Tee operation exactly as today, with zero bytes lost. Drain-side write errors are surfaced via `Ack.OK=false`; the relay still calls `endPause` so the connection doesn't deadlock waiting for a directive that already failed.

* `proxy_v2.go::recordViaSupervisor` duck-types `interface{ WantsPreDispatchPause() bool }` on the parser. Parsers that opt in (postgres v3 in the companion PR) get `PreDispatchPause: true`; every other V2 parser is untouched and runs exactly as today.

## Why opt-in, not on by default

Parsers that don't opt in but receive a pre-paused relay would deadlock: their first `ReadBytes` blocks on the FakeConn (empty until the post-Read pause check tees something), the post-Read pause won't release until the parser sends `ResumePreDispatch` or `UpgradeTLS`, and the parser never gets to those calls because it's blocked in `ReadBytes`. Default `false` keeps every existing parser working. The opt-in is one tiny method on the parser type — no interface changes required.

## Tests

`pkg/agent/proxy/relay/relay_test.go` adds two:

* `TestPreDispatchPause_HoldsC2DUntilResume` — client writes, `destSvc` must NOT receive while pre-dispatch is active (asserted via `SetReadDeadline` + bounded `Read`), FakeConn DOES see the chunk, sending `ResumePreDispatch` drains the byte to `destSvc`, post-resume traffic flows normally without further directives.

* `TestPreDispatchPause_HoldsD2CUntilResume` — symmetric for the postgres-relevant direction. Server writes, `clientApp` must NOT receive, DestStream sees the chunk, resume drains.

Both pass under `-race`. Full `./pkg/agent/proxy/relay/...` and `./pkg/agent/proxy/directive/...` suites are green.

## Out of scope

* Kernel-side `proxy_ready` BPF gate (the I8 deferred work in `README.md:91`). Different concern (global proxy availability vs per-connection ordering); doesn't help with this race even if it landed. Tracked separately.

* Forwarder-side protocol detection (auto-pause on detected SSLRequest pattern) — would force protocol awareness into the relay, which the V2 design explicitly keeps protocol-agnostic. Pre-dispatch pause is the right abstraction layer for the parser to drive.

## Acceptance (in `keploy/integrations`)

* `http-postgres/*` matrix cells turn deterministically green on the next PR pipeline once `keploy/integrations` bumps its `go.keploy.io/server/v3` pin to a release carrying this change AND the companion postgres opt-in PR has landed.
* `sqlalchemy-pg-catalog-postgres/1` stops flaking (current observed rate ≈ 1 in 4 on a contested worker).
* No regression on any non-opt-in V2 parser (http, mysql, mongo, generic, …).

## References

* Issue: https://github.com/keploy/enterprise/issues/2012
* Companion PR (postgres opt-in): keploy/integrations branch `opt-postgres-into-pre-dispatch-pause`
* Race admission in current code: `pkg/agent/proxy/directive/directive.go:79–94`
* Existing partial mitigation: `pkg/agent/proxy/relay/directive_proc.go:163–229`