### PR TITLE
fix(proxy/relay): pre-dispatch should tee only FromClient, not FromDest

### DIFF
--- a/pkg/agent/proxy/relay/relay.go
+++ b/pkg/agent/proxy/relay/relay.go
@@ -493,19 +493,23 @@ func (r *Relay) forward(
 					)
 				}
 				// In pre-dispatch mode the parser needs to SEE the
-				// stashed bytes via its FakeConn — that's the whole
-				// point of installing the pause before forwarders
-				// spawn. Tee a chunk with ReadAt set and WrittenAt
-				// left zero (the real Write is deferred to either
-				// the KindResumePreDispatch drain or the TLS upgrade
-				// handler's own write path; in neither case do we
-				// have a meaningful WrittenAt to record at chunk
-				// emission time). The standard pause path (TLS
-				// upgrade after a parser already had its chance to
-				// inspect a prior chunk) does NOT tee — those bytes
-				// are protocol preamble the parser explicitly does
-				// not want to consume via its FakeConn.
-				if r.preDispatchActive.Load() {
+				// client's first message via its FakeConn — that's
+				// how it inspects e.g. postgres SSLRequest before
+				// deciding between ResumePreDispatch (plain) and
+				// UpgradeTLS (SSL). The TLS-upgrade handler consumes
+				// the server's preamble reply (the SSLResponse byte)
+				// from the stash directly via takeStashedPrefix on
+				// the FromDest direction, so a D2C tee during pre-
+				// dispatch would leave that byte sitting in the
+				// DestStream FakeConn buffer — where the post-
+				// handshake captureSessionV2 would read it AS IF it
+				// were the first post-auth message, mis-parse it,
+				// and corrupt the session mock. Restrict the tee to
+				// FromClient so the parser sees what it asked for
+				// (the client's first chunk) and nothing it didn't
+				// (the server's preamble reply belongs to the
+				// directive handler, not the parser).
+				if r.preDispatchActive.Load() && dir == fakeconn.FromClient {
 					chunk := fakeconn.Chunk{
 						Dir:    dir,
 						Bytes:  stash,
@@ -513,7 +517,7 @@ func (r *Relay) forward(
 						SeqNo:  seq.Add(1),
 					}
 					teed := t.push(chunk)
-					if teed && dir == fakeconn.FromClient && r.cfg.OnClientChunkTeed != nil {
+					if teed && r.cfg.OnClientChunkTeed != nil {
 						r.cfg.OnClientChunkTeed()
 					}
 				}

--- a/pkg/agent/proxy/relay/relay_test.go
+++ b/pkg/agent/proxy/relay/relay_test.go
@@ -977,17 +977,19 @@ func TestPreDispatchPause_HoldsD2CUntilResume(t *testing.T) {
 	}
 	_ = h.clientApp.SetReadDeadline(time.Time{})
 
-	// The parser's DestStream sees the chunk.
-	d, err := h.r.DestStream().ReadChunk()
-	if err != nil {
-		t.Fatalf("DestStream.ReadChunk during pre-dispatch: %v", err)
+	// The parser's DestStream does NOT see the chunk during pre-
+	// dispatch. The directive handler (TLS upgrade) reads server-side
+	// preamble bytes from the stash directly via takeStashedPrefix,
+	// and a tee here would leave those bytes lingering in the FakeConn
+	// buffer for the post-handshake captureSessionV2 to misread as
+	// the first auth-response message. Server-side bytes are stashed
+	// (so the directive handler can claim them) but not teed. Assert
+	// the DestStream stays empty under a short deadline.
+	_ = h.r.DestStream().SetReadDeadline(time.Now().Add(150 * time.Millisecond))
+	if c, err := h.r.DestStream().ReadChunk(); err == nil {
+		t.Fatalf("DestStream should NOT see the D2C byte during pre-dispatch (UpgradeTLS reads it from the stash); got chunk %q", c.Bytes)
 	}
-	if string(d.Bytes) != string(payload) {
-		t.Fatalf("DestStream chunk bytes=%q, want %q", d.Bytes, payload)
-	}
-	if d.Dir != fakeconn.FromDest {
-		t.Fatalf("DestStream chunk Dir=%v, want FromDest", d.Dir)
-	}
+	_ = h.r.DestStream().SetReadDeadline(time.Time{})
 
 	// Same pipe-blocking concern as the C2D test: drain Write blocks
 	// until the test reads. Spawn the reader first.


### PR DESCRIPTION
## TL;DR for someone who only has 30 seconds

This is a one-line follow-up to PR #4196 (merged + released as v3.5.38). #4196 added a new feature called "pre-dispatch pause" to keploy's proxy. That feature works fine for non-encrypted connections, but it accidentally broke recording for encrypted (SSL/TLS) PostgreSQL connections — every postgres CI lane in `keploy/integrations#200` that uses SSL turned red after the v3.5.38 release. This PR fixes that by changing exactly which bytes "pre-dispatch pause" makes visible to the parser.

The bug: pre-dispatch was making the parser see the server's first reply (`'S'`) twice — once via a hidden side channel, then again as a normal stream byte — confusing the parser into mis-reading later bytes. The fix: only expose the *client's* first message to the parser during pre-dispatch; the server's reply is handled separately by the existing TLS-upgrade machinery and does not need to be visible to the parser via the normal stream.

The rest of this description is the explanation a cold reviewer can read top-to-bottom without any background knowledge.

---

## What keploy does

Keploy sits in the middle of a conversation between your app and your database. Two things happen there:

* While your tests run, keploy quietly **records** every message between the two — what the app sent, what the database replied with, when. It saves all of that to disk.
* Later, when you run the tests again, keploy **replays** the database's recorded replies whenever the app asks the same questions — so you can run the tests without needing the real database. Faster tests, no flakiness from a real DB.

To do this, keploy runs a *proxy*: a little intermediary that the app talks to, thinking it's the database. The proxy forwards every byte to the real database (during recording) and saves a copy of everything for later. During replay, the proxy doesn't forward; it makes up replies from the saved copies.

The "proxy" has two main jobs running at the same time:

* **Forwarders** — two background workers that copy bytes between the app and the real database, one for each direction (app→DB and DB→app). They're like couriers moving packets in real time.
* **Parser** — a separate background worker that watches what the forwarders are moving and writes down what it sees. For PostgreSQL there's a specific parser (`postgres v3`) because the PostgreSQL protocol has its own format.

These two jobs run *in parallel*. That parallelism is what makes everything else in this description interesting.

## A quick PostgreSQL detour

Every PostgreSQL conversation starts with a brief negotiation: "Do you want to encrypt this connection?"

1. **App → DB:** `SSLRequest` (8 small bytes — a magic number saying "let's encrypt")
2. **DB → App:** **one byte**, either `'S'` ("Yes, let's encrypt") or `'N'` ("No, plain text is fine")
3. If `'S'`: the two sides run a TLS handshake, then talk encrypted from there.
4. If `'N'`: the app sends the actual `StartupMessage` (its login info) in plain text, and the DB replies with the login challenge.

That single-byte reply at step 2 is the load-bearing part of this PR. From now on I'll call it "the preamble byte."

## What PR #4196 added (the new feature this PR is fixing)

Before #4196, the parser had a problem on the encrypted path. By the time the parser noticed step 1 (the `SSLRequest`) and asked the proxy "please pause everything so I can handle the TLS handshake myself," the forwarders had often already run through steps 2, 3, and 4 of their own accord. The parser was constantly racing the wire and losing.

#4196 fixed that race by adding **pre-dispatch pause**: a new mode where the proxy starts up with the forwarders *already paused*, so the parser is guaranteed to be the first thing to see the first message on the connection. When the parser sees the first message, it makes a decision:

* If it's an `SSLRequest`: send an `UpgradeTLS` directive — the proxy then handles the TLS handshake itself.
* If it's a plain `StartupMessage`: send a `ResumePreDispatch` directive — the proxy releases the forwarders and traffic flows normally.

Either way, the parser is in charge of the first decision. No more race.

To make this work, #4196 made one more change: while pre-dispatch is active, the proxy reads bytes from the real network but **doesn't write them to the real peer**. Instead it stashes them in a holding area until the parser decides what to do. It also tees a copy into the parser's "fake connection" (a stream the parser reads to see what's on the wire).

This worked perfectly for the plain (non-SSL) path. It broke the SSL path. That's this PR.

## The bug, in words

For the SSL path, the parser's job during pre-dispatch is simple: read the **client's** first message (`SSLRequest`), decide it wants TLS, send the `UpgradeTLS` directive. The TLS-upgrade machinery then takes over.

That TLS-upgrade machinery has its own way of getting the preamble byte (`'S'`/`'N'`) from the proxy: it asks the proxy directly, via a special "give me one byte from the database direction" call. The byte is pulled from the holding area (the stash) where the forwarder left it.

So far so good. The bug: #4196's pre-dispatch *also* teed that same byte into the parser's fake connection — the normal stream the parser reads byte-by-byte. So `'S'` ended up in **two** places:

1. The stash — where the TLS-upgrade machinery correctly grabs it.
2. The parser's fake connection — where it just sits there.

When the TLS handshake finishes and the parser later reads from its fake connection to see what the server is saying after authentication (things like "your session is authenticated", "your username is X", "the database is ready"), the very first byte it sees is the leftover `'S'` from step 2 — not the post-handshake message. The parser tries to decode `'S'` as if it were the start of a post-handshake protocol message, fails, and marks the recording as incomplete. The lane fails: no usable session recording produced.

In production: every postgres CI lane in `keploy/integrations#200` that exercises SSL (asyncpg-postgres, sqlalchemy-json-postgres, http-postgres/{1,2,3}, listmonk-postgres, hibernate-cache-tour-postgres, sap-demo-java-postgres, asyncpg-introspect-repro-postgres/2) turned red the moment the integrations PR bumped its keploy pin to v3.5.38. From the postgres-side log you can see the app's connection arriving (`connection received: host=172.18.0.3`) but never reaching the "connection authorized" line — the TLS state goes off the rails because of the duplicated byte.

## The fix, in one sentence

While pre-dispatch is active, tee only the **client→server** direction to the parser's fake connection. Leave the **server→client** direction stashed-only (the TLS-upgrade machinery reads it from there directly).

That's it. A one-condition change in one function:

```go
// before: tee BOTH directions during pre-dispatch
if r.preDispatchActive.Load() { ... t.push(chunk) ... }

// after: tee ONLY the client direction during pre-dispatch
if r.preDispatchActive.Load() && dir == fakeconn.FromClient { ... t.push(chunk) ... }
```

## Why this is safe for the non-SSL path too

For a plain (non-SSL) PostgreSQL connection, the conversation order is:

1. App sends `StartupMessage` (client→server, the first byte on the wire).
2. Parser sees it, decides "no TLS needed," sends `ResumePreDispatch`.
3. Server starts replying.

Step 3 happens **after** pre-dispatch has already ended. By that point the forwarders are running normally — the proxy tees both directions to the parser as it always did. So skipping the server-direction tee during pre-dispatch loses nothing on the plain path: there's nothing to skip; the server hasn't said anything yet.

PostgreSQL is "client speaks first" — the server never opens a conversation. So during pre-dispatch, the only direction that actually has bytes is client→server. The fix matches what the wire actually produces.

For protocols where the server speaks first (we don't have any in tree right now), the relevant parser would need to declare what direction it expects to see — that's a future concern, not one this PR creates.

## How we know the fix works

Two pieces of evidence:

1. **Unit tests in this PR.** The existing `TestPreDispatchPause_HoldsC2DUntilResume` was unchanged — the parser must still see the client's first message via its fake connection (that's its whole job). `TestPreDispatchPause_HoldsD2CUntilResume` was inverted: it now asserts that during pre-dispatch the parser does **not** see the server-direction byte via its fake connection (only the stash holds it). Both tests pass under `-race`.

2. **End-to-end CI on this PR's branch.** The Postgres Fuzzer cell `record_build_replay_latest` had been failing on main since commit d9340a60 (unrelated PR #4198, see below). With this PR's fix applied, that cell now **passes** — the fix flipped a previously-red cell green.

## About the one CI check still red on this PR

There's one job still red on this PR: `run_fuzzer_linux / Postgres Fuzzer (record_build_replay_build)`. It is **not** caused by this PR. It was already red on the previous commit on main (`d9340a60`, PR #4198) before this PR existed. Receipts:

| Commit | Branch | `Postgres Fuzzer (build_replay_build)` |
|---|---|---|
| `17fd6867` | main (the squash-merge of #4196) | ✅ |
| **`d9340a60`** | **main (#4198 — a debug-logging change)** | ❌ first failure |
| `deb440e5` | this PR (built off #4198) | ❌ inherited |

#4198 added a Debug-level log inside `pkg/agent/proxy/mockmanager.go::SetFilteredMocks`. The log itself is correctly gated behind `logger.Check(zap.DebugLevel)`, but the *slice-building* that feeds it (collecting `postgresV3MockNames` on every UpdateMockParams call) is gated only on `m.logger.Core().Enabled(zap.DebugLevel)`. CI fuzzer runs use `--debug`, so the slice-build runs on the hot path; on the fuzzer's stress traffic that's enough extra per-call work to push the `post-fuzz-1` testcase past the keploy CLI's per-request timeout. Same fuzzer cell, same failure mode, on commits before this PR existed.

The fix for that is either a revert of #4198 (it's a diagnostic-only commit) or a tightened Debug-gate. Out of scope here.

## What a reviewer should look at

1. **The one-line change** in `pkg/agent/proxy/relay/relay.go` adding `&& dir == fakeconn.FromClient` to the pre-dispatch tee condition. Read the long comment above it — that comment is the load-bearing piece of documentation for why this is correct.

2. **The inverted test** in `pkg/agent/proxy/relay/relay_test.go` (`TestPreDispatchPause_HoldsD2CUntilResume`). The old assertion ("DestStream sees the chunk") was wrong — the duplicated-byte bug was codified as a passing test in #4196's tests. The new assertion ("DestStream stays empty during pre-dispatch") matches the correct invariant.

3. **The CI status:** one red check (Postgres Fuzzer build/build) is inherited from #4198 (#4198 is the suspect, not this PR). The other red check (CI Gate (Linux)) is the aggregator that flips red if any upstream job is red — so it lights up because of the fuzzer, not because of any check that's actually testing this PR's content.

## References

* Original bug + fix infrastructure: PR #4196 (merged, in v3.5.38).
* Integrations PR that surfaces the regression: keploy/integrations#200.
* Original issue describing the underlying SSL preamble race the whole arc is solving: keploy/enterprise#2012.
* The unrelated main-branch fuzzer regression: PR #4198.