### PR TITLE
chore(proxy/mockmanager): DEBUG_TRACE log on SetFilteredMocks swap

### DIFF
--- a/pkg/agent/proxy/mockmanager.go
+++ b/pkg/agent/proxy/mockmanager.go
@@ -1489,6 +1489,16 @@ func (m *MockManager) SetFilteredMocks(mocks []*models.Mock) {
 	newStateless := make(map[models.Kind]map[string][]*models.Mock)
 	touched := map[models.Kind]struct{}{}
 	var maxSortOrder int64
+	// DEBUG_TRACE: collect PostgresV3 mock names in the main loop only
+	// when Debug logging is enabled, so non-Debug runs don't allocate
+	// the slice or do the per-mock kind check beyond what the swap
+	// already does. The Check() call short-circuits below if the level
+	// is filtered out.
+	debugV3Trace := m.logger != nil && m.logger.Core().Enabled(zap.DebugLevel)
+	var v3Names []string
+	if debugV3Trace {
+		v3Names = make([]string, 0, 8)
+	}
 	for index, mock := range mocks {
 		if mock.TestModeInfo.SortOrder == 0 {
 			mock.TestModeInfo.SortOrder = int64(index) + 1
@@ -1514,6 +1524,9 @@ func (m *MockManager) SetFilteredMocks(mocks []*models.Mock) {
 			key = strings.ToLower(dns.Fqdn(mock.Spec.DNSReq.Name))
 		}
 		newStateless[k][key] = append(newStateless[k][key], mock)
+		if debugV3Trace && mock.Kind == models.PostgresV3 {
+			v3Names = append(v3Names, mock.Name)
+		}
 	}
 	if maxSortOrder > 0 {
 		pkg.UpdateSortCounterIfHigher(maxSortOrder)
@@ -1527,22 +1540,19 @@ func (m *MockManager) SetFilteredMocks(mocks []*models.Mock) {
 	m.bumpRevisionAll()
 	// DEBUG_TRACE: prove what landed in m.filtered after the swap +
 	// bump. Lists every PostgresV3 mock so we can correlate by mock name
-	// against the failing hashes the parser later misses.
-	if m.logger != nil {
-		newRev := m.Revision()
-		v3Names := make([]string, 0, 8)
-		for _, mk := range mocks {
-			if mk == nil || mk.Kind != models.PostgresV3 {
-				continue
-			}
-			v3Names = append(v3Names, mk.Name)
+	// against the failing hashes the parser later misses. Gated behind
+	// logger.Check so non-Debug runs pay nothing for the fmt.Sprintf
+	// + Revision() read.
+	if debugV3Trace {
+		if ce := m.logger.Check(zap.DebugLevel, "DEBUG_TRACE SetFilteredMocks: tree swapped + revision bumped"); ce != nil {
+			ce.Write(
+				zap.String("mockManagerPtr", fmt.Sprintf("%p", m)),
+				zap.Int("inputMocks", len(mocks)),
+				zap.Int("postgresV3Mocks", len(v3Names)),
+				zap.Strings("postgresV3MockNames", v3Names),
+				zap.Uint64("newRevision", m.Revision()),
+			)
 		}
-		m.logger.Debug("DEBUG_TRACE SetFilteredMocks: tree swapped + revision bumped",
-			zap.String("mockManagerPtr", fmt.Sprintf("%p", m)),
-			zap.Int("inputMocks", len(mocks)),
-			zap.Int("postgresV3Mocks", len(v3Names)),
-			zap.Strings("postgresV3MockNames", v3Names),
-			zap.Uint64("newRevision", newRev))
 	}
 }
 

--- a/pkg/agent/proxy/mockmanager.go
+++ b/pkg/agent/proxy/mockmanager.go
@@ -1525,6 +1525,25 @@ func (m *MockManager) SetFilteredMocks(mocks []*models.Mock) {
 		m.bumpRevisionKind(k)
 	}
 	m.bumpRevisionAll()
+	// DEBUG_TRACE: prove what landed in m.filtered after the swap +
+	// bump. Lists every PostgresV3 mock so we can correlate by mock name
+	// against the failing hashes the parser later misses.
+	if m.logger != nil {
+		newRev := m.Revision()
+		v3Names := make([]string, 0, 8)
+		for _, mk := range mocks {
+			if mk == nil || mk.Kind != models.PostgresV3 {
+				continue
+			}
+			v3Names = append(v3Names, mk.Name)
+		}
+		m.logger.Debug("DEBUG_TRACE SetFilteredMocks: tree swapped + revision bumped",
+			zap.String("mockManagerPtr", fmt.Sprintf("%p", m)),
+			zap.Int("inputMocks", len(mocks)),
+			zap.Int("postgresV3Mocks", len(v3Names)),
+			zap.Strings("postgresV3MockNames", v3Names),
+			zap.Uint64("newRevision", newRev))
+	}
 }
 
 func (m *MockManager) SetUnFilteredMocks(mocks []*models.Mock) {


### PR DESCRIPTION
## Summary

Diagnostic-only log emitted once per `UpdateMockParams` call (immediately after the `m.filtered` tree swap + `bumpRevisionAll`) so we can correlate "what the agent thinks it installed" against the v3 parser's `PerTestProvider.Current()` rebuild output during autoreplay.

Context: in the globality autoreplay bundle (`provider-engagem-…-4028052e-8db9fbcf`) every test in `test-set-…74dbc6f666-prtdw` fails with `the server expects 0 arguments for this query, 1 was passed` (asyncpg). Trace points to `emitDescribeResponse` emitting a 0-param `ParameterDescription` because both `s.Tier.FirstBindValueCount(hash)` and `s.Index.FirstBindValueCount(hash)` return `ok=false` for hashes whose perTest mocks ARE in the test window AND were correctly filtered to `filteredMocks: 2` upstream. The breakage sits between this `SetFilteredMocks` call and the `PerTestProvider.Current()` rebuild on the v3 parser side; this log is the agent half of the correlation.

## Log fields

```
DEBUG  DEBUG_TRACE SetFilteredMocks: tree swapped + revision bumped
  mockManagerPtr=0x…          ← pair with mockDbPtr on parser side
  inputMocks=2
  postgresV3Mocks=2
  postgresV3MockNames=[mock-981, mock-982]   ← exact names installed
  newRevision=R               ← pair with publishedRev on parser side
```

Sibling logs land in `keploy/integrations#201` (the v3 parser side); the two correlate by `mockManagerPtr` ↔ `mockDbPtr` and `newRevision` ↔ `publishedRev`.

## Frequency

One line per `UpdateMockParams` call, i.e. once per test case during autoreplay. No hot-path additions.

## Test plan

- [ ] Build clean: `go build ./pkg/agent/proxy/...` ✅
- [ ] Re-run any failing autoreplay bundle and confirm:
  - The `DEBUG_TRACE SetFilteredMocks` line lists the expected mock names for the failing test case
  - `newRevision` strictly increases across consecutive test cases
  - `mockManagerPtr` stays constant within one `Mock()` session (or doesn't — that's part of what we're debugging)

## Notes

- Pure addition; no behavioural change.
- Guarded by `m.logger != nil` so any test path that doesn't wire a logger is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)