### PR TITLE
fix(proxy/relay): flush C2D stash to dst before preamble Read in handleUpgradeTLS

### DIFF
--- a/pkg/agent/proxy/relay/directive_proc.go
+++ b/pkg/agent/proxy/relay/directive_proc.go
@@ -184,6 +184,46 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, stopping <-chan struct{}, 
 	clearDeadline(r.dst.Load())
 	clearDeadline(r.src.Load())
 
+	// Pre-dispatch C2D flush. Under Config.PreDispatchPause, the C2D
+	// forwarder stashes the client's first message (e.g. Postgres
+	// SSLRequest) without forwarding it, so the parser can inspect
+	// the chunk via its FakeConn tee and decide whether to issue
+	// UpgradeTLS or ResumePreDispatch. If we entered handleUpgradeTLS
+	// from that path, the SSLRequest is still sitting in r.stashedC2D
+	// and the real Postgres server has not seen it yet — so the
+	// preamble Read from the live dst socket below will block until
+	// the deadline kicks (i/o timeout), the parser returns Err, the
+	// supervisor falls through to passthrough, and the live app sees
+	// the connection EOF before any byte reaches Postgres.
+	//
+	// Flush the C2D stash to dst here so the upstream protocol
+	// exchange that produces the preamble byte can actually happen.
+	// Gated on preDispatchActive so the legacy (post-#4196-pause-only)
+	// path — where the forwarder forwarded the SSLRequest in real time
+	// and only the post-pause-boundary 'S' byte ended up stashed on
+	// the D2C side — keeps the existing semantics.
+	if r.preDispatchActive.Load() {
+		c2dForward := r.takeStashed(fakeconn.FromClient)
+		if c2dForward.len() > 0 {
+			dst := *r.dst.Load()
+			if _, werr := dst.Write(c2dForward.bytes); werr != nil {
+				if log != nil {
+					log.Debug("relay: TLS upgrade pre-dispatch C2D flush failed",
+						zap.Error(werr),
+						zap.Int("bytes", c2dForward.len()),
+						zap.String("directive_reason", d.Reason),
+					)
+				}
+				r.endPause()
+				return directive.Ack{
+					Kind: d.Kind,
+					OK:   false,
+					Err:  fmt.Errorf("TLS upgrade pre-dispatch C2D flush: %w", werr),
+				}
+			}
+		}
+	}
+
 	var preamblePayload []byte
 	if params.PreambleReadFromDest > 0 {
 		// 1a. Try the D2C stash first.

--- a/pkg/agent/proxy/relay/relay_test.go
+++ b/pkg/agent/proxy/relay/relay_test.go
@@ -1011,3 +1011,101 @@ func TestPreDispatchPause_HoldsD2CUntilResume(t *testing.T) {
 		t.Fatalf("client got %q after resume, want %q", got, payload)
 	}
 }
+
+// TestDirectiveUpgradeTLS_PreDispatch_FlushesC2DStashBeforePreambleRead
+// pins the SSL-preamble-under-pre-dispatch flow that integrations#200
+// exercised on every TLS postgres lane.
+//
+// Without the fix in handleUpgradeTLS, the C2D stash (the client's
+// SSLRequest, held by the pre-dispatch pause and never forwarded) sits
+// on the relay while the handler tries to read the SSLResponse byte
+// from the live dest socket. Postgres never sees the SSLRequest, so
+// it never replies — the preamble Read blocks until the deadline
+// kick, the directive returns an error, the supervisor falls through
+// to passthrough, and the live app sees `EOF` on its first DB call.
+//
+// This test reproduces that exact wire shape:
+//   - PreDispatchPause=true so r.preDispatchActive is set
+//   - Client writes an 8-byte SSLRequest-shaped payload that the C2D
+//     forwarder stashes (and tees to the parser FakeConn) but does not
+//     forward to dst
+//   - The test reads the stash-flushed bytes from destSvc and
+//     synchronously writes back a single 'S' that the directive
+//     handler picks up via the live-socket preamble Read path
+//
+// Assertions: destSvc receives the SSLRequest in full before any
+// preamble-read activity; the ack returns OK=true with TLSUpgraded=true.
+//
+// Reverting the C2D flush block in handleUpgradeTLS makes this test
+// fail with the original CI symptom: the directive handler's
+// readFullPreamble blocks on dst (the upstream never got the
+// SSLRequest), no byte is ever written to destSvc, the test times out
+// waiting for the flushed SSLRequest, and the eventual ack carries
+// the i/o-timeout error from readFullPreamble.
+func TestDirectiveUpgradeTLS_PreDispatch_FlushesC2DStashBeforePreambleRead(t *testing.T) {
+	t.Parallel()
+
+	upgraderFn := fakeTLSUpgrader(false, false)
+	h := newHarness(t, Config{
+		PreDispatchPause: true,
+		TLSUpgradeFn:     upgraderFn,
+	})
+
+	// Client writes the SSLRequest. Pre-dispatch holds it; the C2D
+	// forwarder stashes the chunk and tees it to the parser via the
+	// ClientStream FakeConn but does NOT write to dst.
+	sslRequest := []byte{0x00, 0x00, 0x00, 0x08, 0x04, 0xd2, 0x16, 0x2f} // length=8, code=80877103
+	go h.writeClient(sslRequest)
+
+	// Sync on the parser tee — once the parser sees the chunk, the
+	// forwarder has finished its post-Read pause path and the stash
+	// is committed. Without this read, the directive could race past
+	// an empty stash.
+	chunk, err := h.r.ClientStream().ReadChunk()
+	if err != nil {
+		t.Fatalf("ClientStream.ReadChunk during pre-dispatch: %v", err)
+	}
+	if string(chunk.Bytes) != string(sslRequest) {
+		t.Fatalf("ClientStream chunk = %v, want SSLRequest %v", chunk.Bytes, sslRequest)
+	}
+
+	// destSvc is a net.Pipe; the handler's dst.Write of the stash and
+	// dst.Read of the preamble both block until the test side reads /
+	// writes. Run that side concurrently with the directive: read the
+	// SSLRequest the handler flushes, then write 'S' so the handler's
+	// preamble Read completes.
+	flushedCh := make(chan []byte, 1)
+	go func() {
+		flushedCh <- h.readDest(len(sslRequest))
+		// Write back the SSLResponse byte after the test sees the
+		// flushed SSLRequest — same ordering as a real postgres.
+		if _, werr := h.destSvc.Write([]byte{'S'}); werr != nil {
+			h.t.Errorf("destSvc.Write 'S': %v", werr)
+		}
+	}()
+
+	d := directive.UpgradeTLS(&tls.Config{}, &tls.Config{}, "postgres sslrequest")
+	d.TLS.PreambleReadFromDest = 1
+	d.TLS.ProceedOnPreamble = []byte{'S'}
+	h.r.Directives() <- d
+
+	flushed := <-flushedCh
+	if string(flushed) != string(sslRequest) {
+		t.Fatalf("dest got %v, want pre-dispatch C2D flush of SSLRequest %v", flushed, sslRequest)
+	}
+
+	select {
+	case ack := <-h.r.Acks():
+		if !ack.OK {
+			t.Fatalf("UpgradeTLS ack failed: %+v", ack)
+		}
+		if !ack.TLSUpgraded {
+			t.Fatalf("expected TLSUpgraded=true on 'S' match, got %+v", ack)
+		}
+		if len(ack.PreamblePayload) != 1 || ack.PreamblePayload[0] != 'S' {
+			t.Fatalf("expected preamble 'S', got %v", ack.PreamblePayload)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("no UpgradeTLS ack — handler hung (likely a regression: C2D stash not flushed before preamble read)")
+	}
+}


### PR DESCRIPTION
## TL;DR

When the relay's pre-dispatch pause is active and the parser dispatches `KindUpgradeTLS` (Postgres SSL preamble path), the C2D forwarder is sitting on the client's `SSLRequest` bytes — never forwarded to the upstream. `handleUpgradeTLS` was going straight to reading the SSLResponse byte from the live dest socket, but the upstream had never seen the SSLRequest, so the read sat there until the deadline kicked → directive returned `i/o timeout` → supervisor fell through to passthrough → the live app saw `failed to connect to database: EOF` before any byte reached Postgres.

This PR adds a 40-line C2D-stash flush at the top of `handleUpgradeTLS`, gated on `r.preDispatchActive`, plus a regression test that hangs (20s timeout) without the fix and passes (0.00s) with it.

## Background

Two recent PRs landed the pre-dispatch pause infrastructure:

- **#4196** added `Config.PreDispatchPause` and the relay-side park/stash/tee machinery so an opted-in parser can synchronously inspect the client's first chunk before it reaches the real upstream. Used today only by postgres v3 (closes the SSL preamble race documented in keploy/enterprise#2012).
- **#4197** fixed an early bug in #4196 where the post-Read pause path tee'd BOTH directions, leaving the server's preamble reply (`'S'`/`'N'`) sitting in `DestStream` for `captureSessionV2` to misread as the first auth-response message. Tee was narrowed to `FromClient` only.

The pre-dispatch pause has two parser-side exit directives:

1. **`KindResumePreDispatch`** — parser inspected the first chunk, decided "no SSL upgrade needed", releases the pause. The handler in `directive_proc.go` (since #4196) drains the C2D stash to dst and the D2C stash to src before clearing the pause channel.
2. **`KindUpgradeTLS`** — parser saw `SSLRequest`, wants to do the full SSL choreography under the pause barrier. The handler (since long before #4196) reads the SSLResponse byte (from D2C stash if the forwarder already grabbed it, else directly from the live dst socket), optionally forwards it to src, then runs both TLS handshakes.

The bug: **`KindUpgradeTLS` never learned about the C2D stash.**

## The bug

When pre-dispatch fires and the first byte is an `SSLRequest`:

```
client → relay (C2D forwarder reads 8 bytes, stashes, tees to parser, parks)
relay   → dst  ← NEVER HAPPENS
```

Parser sees the SSLRequest via FakeConn, decides "yes SSL", dispatches `UpgradeTLS` with `PreambleReadFromDest=1, ProceedOnPreamble='S'`. Handler runs `beginPause` → `waitForwardersParked` → `clearDeadline` → looks for the response byte. The D2C stash is empty (server never replied), so the handler falls into the live-dst Read branch (`readFullPreamble`). That Read blocks because Postgres never received the request. The deadline eventually kicks, the Read returns `i/o timeout`, the handler returns `OK=false`, the supervisor drops the connection, the app EOFs.

`handleResumePreDispatch` is symmetric and already handles this — its drain loop writes `c2dStash` to `dst` before `endPause`. `handleUpgradeTLS` predates pre-dispatch and never gained that step.

## Evidence

Stderr TRACE instrumentation in `forward()` and `handleUpgradeTLS`, run against a `lib/pq sslmode=require` client + TLS-enabled postgres in docker, reproduced the bug in 30 seconds:

```
TRACE-RELAY install-pre-dispatch-pause
TRACE-RELAY read-returned dir=client n=8 err=<nil>          ← SSLRequest read
TRACE-RELAY stash-committed dir=client bytes=8 firstByte=0x00 ← stashed, NOT forwarded
TRACE-RELAY pre-dispatch-tee dir=client teed=true
TRACE-REC sending-UpgradeTLS                                   ← parser dispatches
TRACE-DIR handleUpgradeTLS-enter preDispatch=true
TRACE-DIR handleUpgradeTLS calling-beginPause
TRACE-RELAY waitForwardersParked c2d-parked
TRACE-RELAY read-returned dir=dest n=0 err=i/o timeout         ← D2C wakes empty
TRACE-RELAY waitForwardersParked d2c-parked
TRACE-DIR handleUpgradeTLS d2c-stash len=0 requested=1         ← server never replied
TRACE-DIR handleUpgradeTLS reading-preamble-from-live-dst      ← read from dst directly
TRACE-DIR handleUpgradeTLS preamble-read-result n=0 err=i/o timeout
CLIENT: ping failed: EOF
```

Same fixture with the fix applied:

```
TRACE-DIR handleUpgradeTLS pre-dispatch-c2d-flush len=8         ← NEW: flush stash to dst
TRACE-DIR handleUpgradeTLS pre-dispatch-c2d-flush OK bytes=8
TRACE-DIR handleUpgradeTLS d2c-stash len=0 requested=1
TRACE-DIR handleUpgradeTLS reading-preamble-from-live-dst
TRACE-DIR handleUpgradeTLS preamble-read-result n=1 err=<nil>   ← postgres replied 'S'
TRACE-DIR handleUpgradeTLS writing-preamble-to-src bytes=1 firstByte=0x53
TRACE-DIR handleUpgradeTLS preamble-MATCH proceeding-to-tls
TRACE-DIR handleUpgradeTLS published-upgraded-dst
TRACE-DIR handleUpgradeTLS published-upgraded-src
CLIENT: SELECT 1 returned 1
```

CI-side blast radius is large but consistent — every `keploy/integrations#200` lane whose driver sends an `SSLRequest` failed at record time with the same shape (the live app exiting with `failed to connect to database: EOF`, postgres logs showing only `pg_isready` local connections, no inbound `connection authorized` from `172.18.0.x`). Lanes whose driver sends `StartupMessage` directly (`sslmode=disable` configurations) stayed green because `ResumePreDispatch` already drains C2D before the forwarders resume.

## The fix

`pkg/agent/proxy/relay/directive_proc.go`, in `handleUpgradeTLS`, after `waitForwardersParked` and `clearDeadline` but before the preamble Read:

```go
if r.preDispatchActive.Load() {
    c2dForward := r.takeStashed(fakeconn.FromClient)
    if c2dForward.len() > 0 {
        dst := *r.dst.Load()
        if _, werr := dst.Write(c2dForward.bytes); werr != nil {
            ...
            r.endPause()
            return directive.Ack{Kind: d.Kind, OK: false, Err: ...}
        }
    }
}
```

Gated on `preDispatchActive` so the legacy (post-#4196 pause-only) path — where the C2D forwarder forwarded the SSLRequest in real time and only the post-pause-boundary `'S'` byte ended up stashed on D2C — keeps the existing semantics. Without the gate, regular TLS upgrades (any other parser that uses `UpgradeTLS` without opting into PreDispatchPause) would start consuming a stash they don't own.

The flush mirrors what `handleResumePreDispatch` already does for the no-SSL branch — same direction, same buffer, same `takeStashed` call. The only difference is the response read that follows on this path.

## Verification

- `TestDirectiveUpgradeTLS_PreDispatch_FlushesC2DStashBeforePreambleRead` (new) — seeds the C2D stash with an 8-byte SSLRequest shape, dispatches `UpgradeTLS` with `PreambleReadFromDest=1, ProceedOnPreamble='S'`, and asserts dst receives the SSLRequest before the directive's preamble read completes. **Without the fix: hangs 3s on ack timeout (entire test fails in 20s).** With the fix: passes in 0.00s.
- Full `pkg/agent/proxy/relay/` test suite passes (`go test ./pkg/agent/proxy/relay/` → `ok 0.307s`). No existing test moved.
- Local end-to-end: minimal `lib/pq sslmode=require` Go client recording against a TLS-enabled postgres docker container produces 4 PostgresV3 mocks. Replay path: TBD (will exercise once this PR ships in a release and integrations#200 picks it up).

## Test plan

- [x] Unit regression test passes with the fix
- [x] Unit regression test fails without the fix (20s timeout, falsifier confirmed)
- [x] Full relay test suite green
- [x] End-to-end local record on SSL postgres succeeds, mocks captured
- [ ] Once released, bump integrations#200 go.mod → confirm the 8 SSL postgres lanes go green

## References

- keploy/integrations#200 — the parser opt-in that exercises this code path
- keploy/enterprise#2012 — the original SSL preamble race the pre-dispatch pause exists to solve
- #4196 — added `Config.PreDispatchPause` infrastructure
- #4197 — D2C tee narrowing fix (sibling regression in the same code area)