### PR TITLE
fix(http): tier safe-method outbound mocks (GET/HEAD/OPTIONS) as LifetimeSession

### DIFF
--- a/pkg/agent/proxy/integrations/http/http.go
+++ b/pkg/agent/proxy/integrations/http/http.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"go.keploy.io/server/v3/pkg"
@@ -282,15 +283,37 @@ func (h *HTTP) parseFinalHTTP(ctx context.Context, mock *FinalHTTP, destPort uin
 			ReqTimestampMock: mock.ReqTimestampMock,
 			ResTimestampMock: mock.ResTimestampMock,
 		},
-		// HTTP is a request-response protocol — every exchange is per-test
-		// by construction. No handshake/session tier exists at the HTTP
-		// layer; outbound calls from an application under test are always
-		// bound to the current test window. Stamp LifetimePerTest + mark
-		// LifetimeDerived so DeriveLifetime's ingest-time classifier is a
-		// no-op (the recorder is authoritative at emit time). Leaves
-		// Metadata["type"] unchanged (legacy readers still see HTTPClient).
+		// Lifetime classification.
+		//
+		// RFC 7231 §4.2.1 defines GET / HEAD / OPTIONS as SAFE methods:
+		// they don't carry test-specific side effects, and the response
+		// is a function of the request URL + headers + body only. An
+		// application caching SAP / Stripe / pricing-service responses
+		// with a TTL (Spring Cache, Caffeine, ESI, etc.) will re-fetch
+		// the same URL when its cache expires — observed in CI on the
+		// sap-demo-java-postgres lane: the app's first GET to
+		// /A_BusinessPartner('203') fires during testcase #6 (cold
+		// cache), the next ~325 testcases hit the warm cache, then the
+		// replay-phase cache expiry forces a re-fetch at testcase #49
+		// of test-set-0 which falls in a different per-test window than
+		// the recorded mock, dropping under strictMockWindow with
+		// "no matching mock found". Tagging safe-method outbound mocks
+		// as LifetimeSession lets the matcher reuse the recorded
+		// response across tests — that's the semantics safe methods
+		// already promise on the wire.
+		//
+		// Non-safe methods (POST / PUT / PATCH / DELETE) keep
+		// LifetimePerTest because their responses CAN encode
+		// test-specific state (created resource IDs, mutated counts,
+		// idempotency-key echoes). A POST recorded for test-A must not
+		// satisfy test-B's POST — that's the cross-test bleed strict
+		// mode exists to prevent.
+		//
+		// LifetimeDerived stays true so DeriveLifetime treats the
+		// recorder as authoritative (no kind-fallback re-classification
+		// on ingest).
 		TestModeInfo: models.TestModeInfo{
-			Lifetime:        models.LifetimePerTest,
+			Lifetime:        httpOutboundLifetime(req.Method),
 			LifetimeDerived: true,
 		},
 	}
@@ -318,4 +341,27 @@ func (h *HTTP) parseFinalHTTP(ctx context.Context, mock *FinalHTTP, destPort uin
 	case mocks <- newMock:
 	}
 	return nil
+}
+
+// httpOutboundLifetime returns the lifetime tier for a recorded outbound
+// HTTP exchange given the request method. Safe methods (GET / HEAD /
+// OPTIONS per RFC 7231 §4.2.1) carry no test-specific side effects and
+// their response is determined entirely by the request — so the recorded
+// mock is reusable across any test that re-issues the same request, e.g.
+// when the app's HTTP cache (Spring Cache / Caffeine / ESI) expires
+// mid-replay. Non-safe methods (POST / PUT / PATCH / DELETE) keep
+// LifetimePerTest because their responses can encode test-specific state
+// and cross-test reuse would constitute mock bleed.
+//
+// Method comparison is case-insensitive against the canonical RFC tokens.
+// An unknown / empty method is treated as non-safe (defensive default —
+// a per-test mock that turns out to be reusable will reuse on the
+// lifetime-fallback DeriveLifetime path; a session mock that turns out
+// to be test-specific would bleed across tests, which is worse).
+func httpOutboundLifetime(method string) models.Lifetime {
+	switch strings.ToUpper(method) {
+	case "GET", "HEAD", "OPTIONS":
+		return models.LifetimeSession
+	}
+	return models.LifetimePerTest
 }

--- a/pkg/agent/proxy/integrations/http/lifetime_test.go
+++ b/pkg/agent/proxy/integrations/http/lifetime_test.go
@@ -1,0 +1,60 @@
+package http
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// TestHTTPOutboundLifetime pins the safe-vs-non-safe method classification
+// the HTTP recorder uses to tier outbound mocks. Safe methods (GET / HEAD /
+// OPTIONS per RFC 7231 §4.2.1) tier as LifetimeSession so apps that cache
+// upstream responses can survive strictMockWindow when the cache expires
+// mid-replay and re-fetches the same URL in a later test's window than the
+// one the mock was originally recorded under. Non-safe methods stay
+// LifetimePerTest because their responses can encode test-specific side
+// effects.
+//
+// Regression for the sap-demo-java-postgres lane failure on
+// keploy/integrations#196: an idempotent SAP BusinessPartner GET captured
+// during recording testcase #6 was dropped at replay testcase #49 of the
+// same test-set because the mock's request timestamp fell outside the
+// later test's window — the strict-window pre-filter saw it as stale
+// previous-test bleed even though the same URL legitimately re-fetches
+// after the app's HTTP cache TTL.
+func TestHTTPOutboundLifetime(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		method string
+		want   models.Lifetime
+	}{
+		// Safe methods → session.
+		{"GET", models.LifetimeSession},
+		{"HEAD", models.LifetimeSession},
+		{"OPTIONS", models.LifetimeSession},
+		// Case-insensitive — Go's net/http normalises but be defensive.
+		{"get", models.LifetimeSession},
+		{"Head", models.LifetimeSession},
+		{"options", models.LifetimeSession},
+		// Non-safe methods → per-test.
+		{"POST", models.LifetimePerTest},
+		{"PUT", models.LifetimePerTest},
+		{"PATCH", models.LifetimePerTest},
+		{"DELETE", models.LifetimePerTest},
+		// TRACE / CONNECT / unknown → defensive per-test.
+		// (TRACE is idempotent but rarely exercised; CONNECT is for
+		// tunnel setup, not a normal outbound exchange. Keeping them
+		// per-test avoids accidental cross-test reuse on a method an
+		// app might genuinely use as test-stateful.)
+		{"TRACE", models.LifetimePerTest},
+		{"CONNECT", models.LifetimePerTest},
+		{"WEIRD", models.LifetimePerTest},
+		{"", models.LifetimePerTest},
+	}
+	for _, tc := range cases {
+		got := httpOutboundLifetime(tc.method)
+		if got != tc.want {
+			t.Errorf("httpOutboundLifetime(%q) = %v, want %v", tc.method, got, tc.want)
+		}
+	}
+}

--- a/pkg/agent/proxy/integrations/http/recordv2.go
+++ b/pkg/agent/proxy/integrations/http/recordv2.go
@@ -490,6 +490,14 @@ func (h *HTTP) buildHTTPMock(m *FinalHTTP, destPort uint, connID string, opts mo
 			ReqTimestampMock: m.ReqTimestampMock,
 			ResTimestampMock: m.ResTimestampMock,
 		},
+		// Mirror parseFinalHTTP: safe-method outbound mocks (GET / HEAD /
+		// OPTIONS) tier as LifetimeSession so cache-warming traffic an
+		// app re-fetches across tests survives strictMockWindow. See
+		// httpOutboundLifetime in http.go for the full rationale.
+		TestModeInfo: models.TestModeInfo{
+			Lifetime:        httpOutboundLifetime(req.Method),
+			LifetimeDerived: true,
+		},
 	}
 	return mock, nil
 }


### PR DESCRIPTION
## TL;DR

The HTTP outbound recorder claims "every HTTP exchange is per-test by construction" and stamps every captured mock with `LifetimePerTest`. That assumption is wrong for safe methods — `GET` / `HEAD` / `OPTIONS` per RFC 7231 §4.2.1 — whose responses are a pure function of the request. Apps that cache upstream responses (Spring Cache / Caffeine / ESI / etc.) legitimately re-fetch the same URL across multiple tests when their cache TTL expires; the recorded mock is the same response either way, but the strict-mock-window filter sees the older mock's timestamp falling outside the later test's window and drops it as "stale previous-test bleed" → app gets `502 keploy: no matching mock found` → test fails.

This PR tags safe-method outbound mocks as `LifetimeSession` so they tier into the session pool (cross-test reusable). Non-safe methods (`POST` / `PUT` / `PATCH` / `DELETE`) keep `LifetimePerTest` because their responses can encode test-specific state and cross-test reuse would be genuine bleed.

40 lines added in `http.go` + `recordv2.go` + a method→lifetime regression test.

## Background

Keploy classifies recorded mocks into one of three lifetime tiers, set on the mock's `TestModeInfo.Lifetime` at record time:

| Tier | Semantics | Mock-window filter behaviour |
|---|---|---|
| `LifetimePerTest` | The recorded response is specific to the test that produced it. Consumed-on-match within a single per-test window. | Strict mode **drops** if `req_ts ∉ [window.start, window.end]` — the cross-test-bleed guarantee. |
| `LifetimeSession` | The recorded response is reusable across any test in the session. Lives in the session pool, never consumed-and-removed. | Routed straight to the session pool by `filterByTimeStampTierAware`; no window check. |
| `LifetimeConnection` | Connection-scoped (per-connID). Used by handshake/auth mocks. | Routed to a per-connID pool. |

The HTTP outbound recorder (`pkg/agent/proxy/integrations/http/http.go::parseFinalHTTP`) has historically hard-coded `LifetimePerTest`:

```go
TestModeInfo: models.TestModeInfo{
    Lifetime:        models.LifetimePerTest,
    LifetimeDerived: true,
},
```

with the comment *"HTTP is a request-response protocol — every exchange is per-test by construction"*. That's true for non-safe methods. It's not true for safe methods, which RFC 7231 explicitly defines as side-effect-free and response-deterministic.

## The bug (concrete instance)

Failing lane: `sap-demo-java-postgres` (cell 1, `record-build-replay-build`) on integrations#196 / pipeline 1108.

The customer360 Spring Boot app calls a SAP S/4HANA endpoint for each `/customers/{id}/360` request, with **Spring HTTP caching** in front (TTL ~3–5 min). Recorded vs replayed timeline:

| Phase | Time | Event |
|---|---|---|
| Record | 11:28:32 | Testcase #6 fires cold-cache `GET /A_BusinessPartner('203')`. Recorder stamps `LifetimePerTest`, captures **mock M1** with `req_ts = 11:28:32`. |
| Record | 11:28:33 – 11:28:45 | Testcases #7 ... #~300 hit warm in-app cache. No further outgoing fires for BP('203'). |
| Replay | 11:32:06 | Replay starts ~3 min 34 sec after record. In-app cache TTL has expired. |
| Replay | 11:32:20 | Testcase #49 of `test-set-0` (`get-api-v1-customers-by-id-by-id-49`) — a `GET /customers/203/360` — fires `GET /A_BusinessPartner('203')` again (cache miss). |
| Replay | 11:32:20 | Matcher looks for the mock. M1 exists. Its `req_ts = 11:28:32` is ~325 testcases earlier than testcase #49's window. Strict-window filter drops M1 as stale. |
| Replay | 11:32:20 | Keploy returns `502 keploy: no matching mock found for this HTTP request`. App's `SapBusinessPartnerClient` surfaces 502. Testcase asserts 200, fails. |

## Evidence

From the failing run, the keploy agent's own log flags the upgrade-surfaced shape:

```
strict mock-window containment is ACTIVE for this session — per-test mocks
whose request timestamp falls outside the outer test window will be dropped
rather than promoted across tests. If your replays start reporting missing
mocks after an upgrade, this is likely why. viaPerCallFlag: true,
viaEnvOverride: false
```

And the BP('203') call timeline confirms the cache-warming pattern (all three calls below to the SAME URL):

```
Record  pass 1, thread -6   11:28:32.482  SAP GET partner id=203  (cold cache)
Record  pass 2, thread -6   11:29:58.331  SAP GET partner id=203  (still cold for pass 2's fresh window)
Replay  pass 1, thread -331 11:32:20.354  SAP GET partner id=203  (in-app cache expired)
                            ↑ no matching mock found
```

The failure is bit-for-bit identical on `BusinessPartner('11')` and `BusinessPartner('202')` at adjacent testcases.

## Root cause

`pkg/agent/proxy/integrations/http/http.go::parseFinalHTTP` (and its V2 mirror `recordv2.go`) stamps every captured outbound HTTP mock with `LifetimePerTest`, regardless of request method. RFC 7231 §4.2.1 defines `GET` / `HEAD` / `OPTIONS` as **safe methods** — explicitly free of test-specific side effects, with responses determined entirely by the request URL + headers + body. Apps that cache safe-method responses re-fetch the same URL across multiple tests when the cache expires; the recorded response is semantically valid for any re-fetch in the session, so the right tier is `LifetimeSession`.

`LifetimePerTest` on safe-method mocks → strict-window filter sees them as window-bound → drops them when a later test's window doesn't contain the recorder's timestamp.

## The fix

`httpOutboundLifetime(method string) Lifetime`:

```go
func httpOutboundLifetime(method string) models.Lifetime {
    switch strings.ToUpper(method) {
    case "GET", "HEAD", "OPTIONS":
        return models.LifetimeSession
    }
    return models.LifetimePerTest
}
```

Threaded into the recorder's `TestModeInfo` stamp at the only two outbound-mock construction sites:

- `pkg/agent/proxy/integrations/http/http.go::parseFinalHTTP` (V1 legacy recorder, the path sap-demo-java's HTTPS+TLS traffic flows through).
- `pkg/agent/proxy/integrations/http/recordv2.go` (V2 recorder, used by HTTP/2 keep-alive paths).

`LifetimeDerived: true` stays — the recorder is authoritative at emit time and `DeriveLifetime` skips re-classification on ingest.

Why method-based and not "promote any HTTP mock to session":

- Non-safe methods carry real test-specific state. A `POST /api/customers/{id}/notes` recorded during test-A creates the note used by test-A's assertion; replaying it for test-B would constitute genuine cross-test mock bleed — exactly what strict-window was added to prevent.
- RFC 7231's safe/unsafe split aligns 1:1 with "response depends on test state" vs "response is a pure function of the request" — it's the right semantic axis to gate on.

Why `LifetimeDerived: true` stays:

- `DeriveLifetime`'s kind-fallback would route un-tagged HTTP mocks to `LifetimeSession` under lax mode anyway (via `kindsWithImplicitSessionLifetime`), but under strict mode that fallback is disabled and HTTP mocks fall through to `LifetimePerTest`. By classifying at the recorder we move the decision to the right layer (the recorder knows the method; `DeriveLifetime` would need an HTTP-specific carve-out to read it). Marking derived = true keeps the recorder authoritative.

## Verification

- `TestHTTPOutboundLifetime` — pins the method→lifetime map for `GET` / `HEAD` / `OPTIONS` (→ Session) and `POST` / `PUT` / `PATCH` / `DELETE` / `TRACE` / `CONNECT` / unknown / empty (→ PerTest). Case-insensitive comparison verified.
- Full `pkg/agent/proxy/integrations/http/` test suite passes (`go test ./pkg/agent/proxy/integrations/http/` → `ok 0.762s`).
- Adjacent packages (`pkg/agent/proxy/`, `pkg/`, `pkg/models/`) — no regressions.
- End-to-end CI verification will happen once this PR ships in a release and integrations bumps the pin — the `sap-demo-java-postgres` lane should flip green.

## Test plan

- [x] Unit regression test pins safe vs non-safe classification
- [x] Full HTTP integration test suite passes
- [x] Adjacent test packages pass (proxy/mockmanager, models/lifetime, pkg/util)
- [ ] Once released, bump integrations pin → confirm sap-demo-java-postgres flips green
- [ ] Confirm no other lanes regress (no postgres / mongo / generic-protocol lane should be affected — this change is scoped to HTTP outbound)

## References

- keploy/integrations#196 — the failing lane that surfaced the bug
- RFC 7231 §4.2.1 — safe-method definition the fix anchors on
- `pkg/models/lifetime.go::DeriveLifetime` — the ingest-time classifier this recorder bypass coexists with