### PR TITLE
fix(proxy): refuse Postgres SSLRequest when TLS interception is disabled

### DIFF
--- a/pkg/agent/proxy/postgres_sslrequest_test.go
+++ b/pkg/agent/proxy/postgres_sslrequest_test.go
@@ -1,6 +1,16 @@
 package proxy
 
-import "testing"
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/config"
+	"go.keploy.io/server/v3/pkg/agent"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
 
 func TestIsPostgresSSLRequest(t *testing.T) {
 	// The Postgres SSLRequest packet on the wire is exactly 8 bytes:
@@ -32,5 +42,95 @@ func TestIsPostgresSSLRequest(t *testing.T) {
 				t.Fatalf("isPostgresSSLRequest(%v) = %v, want %v", tc.buf, got, tc.want)
 			}
 		})
+	}
+}
+
+type mockDestInfo struct {
+	addr *agent.NetworkAddress
+	err  error
+}
+
+func (m *mockDestInfo) Get(ctx context.Context, srcPort uint16) (*agent.NetworkAddress, error) {
+	return m.addr, m.err
+}
+
+func (m *mockDestInfo) Delete(ctx context.Context, srcPort uint16) error {
+	return nil
+}
+
+func TestPostgresSSLRequest_RefuseSSL(t *testing.T) {
+	// Ensure InterceptPostgresSSLRequest is disabled for this test.
+	agent.InterceptPostgresSSLRequest = false
+
+	logger, _ := zap.NewDevelopment()
+	destInfo := &mockDestInfo{
+		addr: &agent.NetworkAddress{
+			Version:  4,
+			IPv4Addr: 2130706433, // 127.0.0.1
+			Port:     5432,
+		},
+	}
+
+	opts := config.New()
+	p := New(logger, destInfo, opts)
+	p.setSession(&agent.Session{
+		ID:   1,
+		Mode: models.MODE_TEST,
+		OutgoingOptions: models.OutgoingOptions{
+			Mocking: true,
+		},
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer listener.Close()
+
+	errCh := make(chan error, 1)
+	go func() {
+		serverConn, err := listener.Accept()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		defer serverConn.Close()
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		errCh <- p.handleConnection(ctx, serverConn)
+	}()
+
+	clientConn, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+	defer clientConn.Close()
+
+	// Send Postgres SSLRequest
+	canonicalSSLRequest := []byte{0x00, 0x00, 0x00, 0x08, 0x04, 0xd2, 0x16, 0x2f}
+	if _, err := clientConn.Write(canonicalSSLRequest); err != nil {
+		t.Fatalf("failed to write Postgres SSLRequest: %v", err)
+	}
+
+	// Read reply
+	reply := make([]byte, 1)
+	if _, err := clientConn.Read(reply); err != nil {
+		t.Fatalf("failed to read response: %v", err)
+	}
+
+	if reply[0] != 'N' {
+		t.Errorf("expected SSLResponse 'N', got %q", reply[0])
+	}
+
+	// Close the connection so handleConnection finishes with EOF
+	clientConn.Close()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("handleConnection failed: %v", err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Error("handleConnection timed out")
 	}
 }

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -1414,7 +1414,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 	// exactly the one client that's actually speaking SSLRequest.
 	// This keeps the short-greeting deadlock (Redis PING, memcached
 	// 'quit', etc.) off the default code path.
-	if agent.InterceptPostgresSSLRequest && isPostgresSSLRequestPrefix(testBuffer) {
+	if isPostgresSSLRequestPrefix(testBuffer) {
 		sslBuf, perr := reader.Peek(8)
 		if perr != nil {
 			utils.LogError(p.logger, perr, "client started with a Postgres SSLRequest prefix (00 00 00 08 04) but did not deliver the full 8-byte packet; the connection likely dropped mid-handshake — verify the client is a standard libpq/pgx/pq and check for a mismatched sslmode or an intermediary terminating the TCP stream",
@@ -1424,46 +1424,80 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 		}
 		testBuffer = sslBuf
 	}
-	if agent.InterceptPostgresSSLRequest && isPostgresSSLRequest(testBuffer) {
-		p.logger.Debug("Postgres SSLRequest detected, accepting and upgrading to TLS",
-			zap.Int("sourcePort", sourcePort),
-			zap.String("dstAddr", dstAddr),
-		)
-		// Consume the 8-byte SSLRequest from the buffered reader so the
-		// downstream parser never sees it.
-		if _, derr := reader.Discard(8); derr != nil {
-			utils.LogError(p.logger, derr, "failed to discard Postgres SSLRequest bytes; the 8-byte SSLRequest was peeked but the bufio reader could not be advanced. This usually means the underlying TCP connection was reset between peek and discard — retry the client connection, and if it persists capture a packet trace between the client and the proxy listener",
-				zap.Uint32("sourcePort", uint32(sourcePort)),
-				zap.String("dstAddr", dstAddr))
-			return derr
-		}
-		// Reply 'S' (TLS accepted). Write straight to the underlying TCP
-		// connection; writes bypass the buffered reader.
-		if _, werr := srcConn.Write([]byte{'S'}); werr != nil {
-			utils.LogError(p.logger, werr, "failed to write 'S' SSLResponse to Postgres client; the proxy accepted the SSLRequest but could not send the one-byte acknowledgment. Verify the client is still connected (not a half-closed stream), check for client-side read timeouts shorter than the proxy's accept latency, and confirm no firewall is dropping 1-byte segments",
-				zap.Uint32("sourcePort", uint32(sourcePort)),
-				zap.String("dstAddr", dstAddr))
-			return werr
-		}
-		// Re-peek for the TLS ClientHello. The client app sends it as soon
-		// as it gets 'S'. 5 bytes is enough for IsTLSHandshake().
-		testBuffer, err = reader.Peek(5)
-		if err != nil {
-			if err == io.EOF && len(testBuffer) == 0 {
-				p.logger.Debug("Postgres client closed conn after SSLRequest reply")
-				return nil
-			}
-			// Any non-nil error here means we could not read a complete
-			// 5-byte TLS record header — either the client sent fewer
-			// than 5 bytes before closing (EOF with partial buffer) or
-			// the network errored out. Falling through would leave the
-			// downstream TLS detection running against a truncated
-			// prefix and misclassify the stream as plaintext, so bail.
-			utils.LogError(p.logger, err, "failed to read a complete 5-byte TLS record header after replying 'S' to the Postgres SSLRequest; the client did not deliver enough bytes to identify a TLS ClientHello. Check the client's sslmode (require/verify-* should always follow with ClientHello after 'S'), confirm InterceptPostgresSSLRequest is only enabled in pure-proxy builds without a Postgres parser, and capture the bytes sent immediately after 'S' to verify a full TLS record header arrives (starting with 0x16)",
-				zap.Uint32("sourcePort", uint32(sourcePort)),
+	if isPostgresSSLRequest(testBuffer) {
+		if agent.InterceptPostgresSSLRequest {
+			p.logger.Debug("Postgres SSLRequest detected, accepting and upgrading to TLS",
+				zap.Int("sourcePort", sourcePort),
 				zap.String("dstAddr", dstAddr),
-				zap.Int("bytesRead", len(testBuffer)))
-			return err
+			)
+			// Consume the 8-byte SSLRequest from the buffered reader so the
+			// downstream parser never sees it.
+			if _, derr := reader.Discard(8); derr != nil {
+				utils.LogError(p.logger, derr, "failed to discard Postgres SSLRequest bytes; the 8-byte SSLRequest was peeked but the bufio reader could not be advanced. This usually means the underlying TCP connection was reset between peek and discard — retry the client connection, and if it persists capture a packet trace between the client and the proxy listener",
+					zap.Uint32("sourcePort", uint32(sourcePort)),
+					zap.String("dstAddr", dstAddr))
+				return derr
+			}
+			// Reply 'S' (TLS accepted). Write straight to the underlying TCP
+			// connection; writes bypass the buffered reader.
+			if _, werr := srcConn.Write([]byte{'S'}); werr != nil {
+				utils.LogError(p.logger, werr, "failed to write 'S' SSLResponse to Postgres client; the proxy accepted the SSLRequest but could not send the one-byte acknowledgment. Verify the client is still connected (not a half-closed stream), check for client-side read timeouts shorter than the proxy's accept latency, and confirm no firewall is dropping 1-byte segments",
+					zap.Uint32("sourcePort", uint32(sourcePort)),
+					zap.String("dstAddr", dstAddr))
+				return werr
+			}
+			// Re-peek for the TLS ClientHello. The client app sends it as soon
+			// as it gets 'S'. 5 bytes is enough for IsTLSHandshake().
+			testBuffer, err = reader.Peek(5)
+			if err != nil {
+				if err == io.EOF && len(testBuffer) == 0 {
+					p.logger.Debug("Postgres client closed conn after SSLRequest reply")
+					return nil
+				}
+				// Any non-nil error here means we could not read a complete
+				// 5-byte TLS record header — either the client sent fewer
+				// than 5 bytes before closing (EOF with partial buffer) or
+				// the network errored out. Falling through would leave the
+				// downstream TLS detection running against a truncated
+				// prefix and misclassify the stream as plaintext, so bail.
+				utils.LogError(p.logger, err, "failed to read a complete 5-byte TLS record header after replying 'S' to the Postgres SSLRequest; the client did not deliver enough bytes to identify a TLS ClientHello. Check the client's sslmode (require/verify-* should always follow with ClientHello after 'S'), confirm InterceptPostgresSSLRequest is only enabled in pure-proxy builds without a Postgres parser, and capture the bytes sent immediately after 'S' to verify a full TLS record header arrives (starting with 0x16)",
+					zap.Uint32("sourcePort", uint32(sourcePort)),
+					zap.String("dstAddr", dstAddr),
+					zap.Int("bytesRead", len(testBuffer)))
+				return err
+			}
+		} else {
+			p.logger.Debug("Postgres SSLRequest detected but InterceptPostgresSSLRequest is disabled, replying with 'N' to refuse SSL",
+				zap.Int("sourcePort", sourcePort),
+				zap.String("dstAddr", dstAddr),
+			)
+			// Discard the 8-byte SSLRequest from the buffered reader.
+			if _, derr := reader.Discard(8); derr != nil {
+				utils.LogError(p.logger, derr, "failed to discard Postgres SSLRequest bytes; the 8-byte SSLRequest was peeked but the bufio reader could not be advanced.",
+					zap.Uint32("sourcePort", uint32(sourcePort)),
+					zap.String("dstAddr", dstAddr))
+				return derr
+			}
+			// Reply 'N' (TLS refused). Write straight to the underlying TCP connection.
+			if _, werr := srcConn.Write([]byte{'N'}); werr != nil {
+				utils.LogError(p.logger, werr, "failed to write 'N' SSLResponse to Postgres client",
+					zap.Uint32("sourcePort", uint32(sourcePort)),
+					zap.String("dstAddr", dstAddr))
+				return werr
+			}
+			// Re-peek for the client's plaintext startup packet.
+			testBuffer, err = reader.Peek(5)
+			if err != nil {
+				if err == io.EOF && len(testBuffer) == 0 {
+					p.logger.Debug("Postgres client closed conn after SSLRequest reply 'N'")
+					return nil
+				}
+				utils.LogError(p.logger, err, "failed to read client greeting after replying 'N' to the Postgres SSLRequest",
+					zap.Uint32("sourcePort", uint32(sourcePort)),
+					zap.String("dstAddr", dstAddr),
+					zap.Int("bytesRead", len(testBuffer)))
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
## Describe the changes that are made
- In `pkg/agent/proxy/proxy.go`, modified `handleConnection` to inspect the client connection's initial bytes for the PostgreSQL `SSLRequest` header.
- When `agent.InterceptPostgresSSLRequest` is disabled (as it is in public builds that do not have the PostgreSQL parser), the proxy now discards the 8-byte `SSLRequest` header, sends `'N'` to the client (indicating SSL/TLS is refused/not supported), and re-peeks/buffers the subsequent startup bytes from the client.
- This allows clients to gracefully fall back to plaintext connection protocol instead of hanging/timing out.
- Added a unit test `TestPostgresSSLRequest_RefuseSSL` in `pkg/agent/proxy/postgres_sslrequest_test.go` to verify this handshake behaviour.

## Links & References

**Closes:**
- https://github.com/keploy/keploy/issues/3909

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed (covered by the new unit test simulating Postgres SSLRequest handshake on loopback TCP socket)

## Added comments for hard-to-understand areas?
- [x] 👍 yes (added comments explaining the Postgres SSLRequest format and the handshake refusal behavior)

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
- Can be tested locally by running the unit test: `go test -v ./pkg/agent/proxy -run TestPostgresSSLRequest_RefuseSSL`

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA

## Semantics for PR Title & Branch Name

- **PR Title**: `fix(proxy): refuse Postgres SSLRequest when TLS interception is disabled`  
- **Branch Name**: `fix/postgres-ssl-neg`

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?
