### PR TITLE
fix(agent): keep ingress proxy alive across /agent/incoming stream lifetime

### DIFF
--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -924,7 +924,7 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 
 			defer parsedHTTPReq.Body.Close()
 			defer parsedHTTPRes.Body.Close()
-			hooksUtils.CaptureHook(ctx, logger, t, parsedHTTPReq, parsedHTTPRes, capturedReqTS, capturedRespTS, pm.incomingOpts, pm.synchronous, pm.mapping, actualPort)
+			hooksUtils.CaptureHook(ctx, logger, t, parsedHTTPReq, parsedHTTPRes, capturedReqTS, capturedRespTS, pm.loadIncomingOpts(), pm.synchronous, pm.mapping, actualPort)
 		}()
 
 		// Exit the loop in sync/sampling mode or when memory pressure requires closing.
@@ -1581,7 +1581,7 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 				}
 				defer parsedReq.Body.Close()
 				defer parsedResp.Body.Close()
-				hooksUtils.CaptureHook(ctx, logger, t, parsedReq, parsedResp, capturedReqTS, capturedRespTS, pm.incomingOpts, pm.synchronous, pm.mapping, actualPort)
+				hooksUtils.CaptureHook(ctx, logger, t, parsedReq, parsedResp, capturedReqTS, capturedRespTS, pm.loadIncomingOpts(), pm.synchronous, pm.mapping, actualPort)
 			}()
 		}
 
@@ -1739,7 +1739,7 @@ func (pm *IngressProxyManager) parseStreamingHTTP(ctx context.Context, logger *z
 		}
 		go func(req *http.Request, resp *http.Response, reqTs, respTs time.Time) {
 			defer func() { <-captureHookSem }()
-			hooksUtils.CaptureHook(ctx, logger, t, req, resp, reqTs, respTs, pm.incomingOpts, pm.synchronous, pm.mapping, appPort)
+			hooksUtils.CaptureHook(ctx, logger, t, req, resp, reqTs, respTs, pm.loadIncomingOpts(), pm.synchronous, pm.mapping, appPort)
 		}(req, resp, reqTimestamp, respTimestamp)
 	}
 }

--- a/pkg/agent/proxy/incoming/http_test.go
+++ b/pkg/agent/proxy/incoming/http_test.go
@@ -617,8 +617,7 @@ func TestHandleHttp1Connection_ChunkedExchangeIsCaptured(t *testing.T) {
 		logger:       zap.NewNop(),
 		tcChan:       make(chan *models.TestCase, 4),
 		synchronous:  true,
-		samplingSem:  make(chan struct{}, 1),
-		incomingOpts: models.IncomingOptions{},
+		samplingSem: make(chan struct{}, 1),
 	}
 
 	// Dial the client side via a TCP pipe. handleHttp1Connection dials
@@ -771,8 +770,7 @@ func TestHandleHttp1Connection_ChunkedRequestIsCaptured(t *testing.T) {
 		logger:       zap.NewNop(),
 		tcChan:       make(chan *models.TestCase, 4),
 		synchronous:  true,
-		samplingSem:  make(chan struct{}, 1),
-		incomingOpts: models.IncomingOptions{},
+		samplingSem: make(chan struct{}, 1),
 	}
 
 	clientListener, err := net.Listen("tcp4", "127.0.0.1:0")

--- a/pkg/agent/proxy/incoming/http_test.go
+++ b/pkg/agent/proxy/incoming/http_test.go
@@ -614,9 +614,9 @@ func TestHandleHttp1Connection_ChunkedExchangeIsCaptured(t *testing.T) {
 
 	// Build an IngressProxyManager configured for synchronous record mode.
 	pm := &IngressProxyManager{
-		logger:       zap.NewNop(),
-		tcChan:       make(chan *models.TestCase, 4),
-		synchronous:  true,
+		logger:      zap.NewNop(),
+		tcChan:      make(chan *models.TestCase, 4),
+		synchronous: true,
 		samplingSem: make(chan struct{}, 1),
 	}
 
@@ -767,9 +767,9 @@ func TestHandleHttp1Connection_ChunkedRequestIsCaptured(t *testing.T) {
 	})
 
 	pm := &IngressProxyManager{
-		logger:       zap.NewNop(),
-		tcChan:       make(chan *models.TestCase, 4),
-		synchronous:  true,
+		logger:      zap.NewNop(),
+		tcChan:      make(chan *models.TestCase, 4),
+		synchronous: true,
 		samplingSem: make(chan struct{}, 1),
 	}
 

--- a/pkg/agent/proxy/incoming/incoming.go
+++ b/pkg/agent/proxy/incoming/incoming.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.keploy.io/server/v3/config"
@@ -35,12 +36,22 @@ type IngressHook interface {
 }
 
 type IngressProxyManager struct {
-	mu           sync.Mutex
-	active       map[uint16]proxyStop
-	logger       *zap.Logger
-	hooks        agent.Hooks
-	tcChan       chan *models.TestCase
-	incomingOpts models.IncomingOptions
+	mu     sync.Mutex
+	active map[uint16]proxyStop
+	logger *zap.Logger
+	hooks  agent.Hooks
+	tcChan chan *models.TestCase
+	// incomingOpts is read by ingress capture goroutines on every
+	// captured request (CaptureHook call sites in http.go) and written
+	// by IngressProxyManager.Start on every recorder (re)connect. Pre-
+	// atomic this was a plain struct field guarded by nothing on the
+	// read path, which is a real data race the moment a recorder
+	// reconnects with different filter/sampling settings while ingress
+	// traffic is in flight. atomic.Pointer gives a lock-free,
+	// pointer-sized swap that the readers can Load without contending.
+	// Always stored as a heap copy of the caller's value so writes
+	// don't tear the struct in-place.
+	incomingOpts atomic.Pointer[models.IncomingOptions]
 	synchronous  bool
 	// mapping mirrors !cfg.DisableMapping at construction time. Forwarded
 	// to CaptureHook so the synchronous-record path can decide whether
@@ -90,6 +101,17 @@ func New(logger *zap.Logger, h agent.Hooks, cfg *config.Config) *IngressProxyMan
 	return pm
 }
 
+// loadIncomingOpts returns the current IncomingOptions snapshot, or a
+// zero-value struct if Start has never been called. CaptureHook readers
+// in http.go call this on every captured request — the atomic.Pointer
+// Load is wait-free, so this stays cheap on the hot path.
+func (pm *IngressProxyManager) loadIncomingOpts() models.IncomingOptions {
+	if p := pm.incomingOpts.Load(); p != nil {
+		return *p
+	}
+	return models.IncomingOptions{}
+}
+
 // SetIngressHook replaces the default Go TCP forwarder with an external
 // ingress handler (e.g. enterprise sockmap proxy).
 func (pm *IngressProxyManager) SetIngressHook(h IngressHook) {
@@ -101,12 +123,11 @@ func (pm *IngressProxyManager) SetIngressHook(h IngressHook) {
 func (pm *IngressProxyManager) Start(ctx context.Context, opts models.IncomingOptions) chan *models.TestCase {
 	// Always update incomingOpts — a reconnecting recorder may pass
 	// different filtering / sampling settings that should take effect
-	// immediately. Protected by the same mu that gates SetIngressHook
-	// reads/writes, so concurrent calls don't tear the IncomingOptions
-	// struct.
-	pm.mu.Lock()
-	pm.incomingOpts = opts
-	pm.mu.Unlock()
+	// immediately. Atomic swap of a pointer-sized field means the
+	// CaptureHook readers in http.go can Load it on every captured
+	// request without contending on a mutex.
+	optsCopy := opts
+	pm.incomingOpts.Store(&optsCopy)
 
 	// Gate the ListenForIngressEvents goroutine so subsequent Start
 	// invocations don't spawn duplicate watchers. The ctx passed in

--- a/pkg/agent/proxy/incoming/incoming.go
+++ b/pkg/agent/proxy/incoming/incoming.go
@@ -53,6 +53,17 @@ type IngressProxyManager struct {
 	samplingSem chan struct{}
 
 	ingressHook IngressHook
+
+	// startOnce gates the ListenForIngressEvents goroutine so that
+	// repeated Start() calls (a reconnecting recorder opening a new
+	// /agent/incoming stream while the agent process keeps running)
+	// don't leak additional watcher goroutines that all consume from
+	// the same eventChan. The IncomingOptions on subsequent calls
+	// still take effect — incomingOpts is updated unconditionally
+	// under mu — so callers that intentionally reconnect with
+	// different filtering get the new behavior immediately on the
+	// next captured request.
+	startOnce sync.Once
 }
 
 func New(logger *zap.Logger, h agent.Hooks, cfg *config.Config) *IngressProxyManager {
@@ -88,8 +99,23 @@ func (pm *IngressProxyManager) SetIngressHook(h IngressHook) {
 }
 
 func (pm *IngressProxyManager) Start(ctx context.Context, opts models.IncomingOptions) chan *models.TestCase {
+	// Always update incomingOpts — a reconnecting recorder may pass
+	// different filtering / sampling settings that should take effect
+	// immediately. Protected by the same mu that gates SetIngressHook
+	// reads/writes, so concurrent calls don't tear the IncomingOptions
+	// struct.
+	pm.mu.Lock()
 	pm.incomingOpts = opts
-	go pm.ListenForIngressEvents(ctx)
+	pm.mu.Unlock()
+
+	// Gate the ListenForIngressEvents goroutine so subsequent Start
+	// invocations don't spawn duplicate watchers. The ctx passed in
+	// here is now process-lifetime (see pkg/service/agent/agent.go),
+	// so the goroutine survives /agent/incoming stream teardowns;
+	// without the gate, each reconnect would leak another watcher.
+	pm.startOnce.Do(func() {
+		go pm.ListenForIngressEvents(ctx)
+	})
 	return pm.tcChan
 }
 

--- a/pkg/agent/proxy/incoming/incoming.go
+++ b/pkg/agent/proxy/incoming/incoming.go
@@ -70,8 +70,9 @@ type IngressProxyManager struct {
 	// /agent/incoming stream while the agent process keeps running)
 	// don't leak additional watcher goroutines that all consume from
 	// the same eventChan. The IncomingOptions on subsequent calls
-	// still take effect — incomingOpts is updated unconditionally
-	// under mu — so callers that intentionally reconnect with
+	// still take effect — Start always atomic-swaps incomingOpts via
+	// atomic.Pointer.Store regardless of whether the watcher actually
+	// (re)spawns — so callers that intentionally reconnect with
 	// different filtering get the new behavior immediately on the
 	// next captured request.
 	startOnce sync.Once

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -49,15 +49,23 @@ type Agent struct {
 	// test on large suites.
 	strictLogOnce sync.Once
 
-	// setupCtx is the process-lifetime context captured during Setup().
-	// It cancels only when the agent process itself shuts down (SIGTERM),
-	// NOT when an /agent/incoming HTTP stream closes. StartIncomingProxy
-	// uses this — not the request ctx — so the ingress proxy's :8080
-	// listener survives the recorder closing the stream on /record/stop.
-	// Without this, k8s-proxy's stop sequence (HTTP graceful-shutdown
-	// notification + stream close) collapses the listener while the
-	// agent + app are still running, kubelet probes get connection
-	// refused, and the pod enters CrashLoopBackOff.
+	// setupCtx is the Setup-scoped context captured during Setup().
+	// It outlives any single /agent/incoming HTTP stream — which is the
+	// whole point: StartIncomingProxy uses this instead of the request ctx
+	// so the ingress proxy's :8080 listener survives the recorder closing
+	// the stream on /record/stop. Without this, k8s-proxy's stop sequence
+	// (HTTP graceful-shutdown notification + stream close) collapses the
+	// listener while the agent + app are still running, kubelet probes
+	// get connection refused, and the pod enters CrashLoopBackOff.
+	//
+	// Cancellation semantics, exactly: setupCtx is the ctx returned by
+	// `errgroup.WithContext(parentCtx)` inside Setup, so it cancels when
+	// EITHER (a) the parent ctx cancels — the process-shutdown signal
+	// path (SIGTERM via utils/ctx.go), OR (b) any goroutine added to that
+	// errgroup returns a non-nil error. (b) is the intended hook-load
+	// failure path — if hooks fail mid-flight the proxy should also stop;
+	// don't try to decouple this without first auditing what consumes
+	// `models.ErrGroupKey` downstream.
 	setupCtx context.Context
 
 	// tcChan is the test case channel returned by IncomingProxy.Start.
@@ -66,8 +74,8 @@ type Agent struct {
 	// nothing else reads tcChan after that. Without draining, the 100-
 	// slot buffer fills within seconds and subsequent ingress traffic
 	// (including kubelet probes) blocks at the channel send.
-	tcChan      chan *models.TestCase
-	drainOnce   sync.Once
+	tcChan    chan *models.TestCase
+	drainOnce sync.Once
 }
 
 func New(logger *zap.Logger, hook coreAgent.Hooks, proxy coreAgent.Proxy, client kdocker.Client, ip coreAgent.IncomingProxy, config *config.Config) *Agent {
@@ -165,12 +173,24 @@ func (a *Agent) Setup(ctx context.Context, startCh chan int) error {
 func (a *Agent) StartIncomingProxy(_ context.Context, opts models.IncomingOptions) (chan *models.TestCase, error) {
 	// Intentionally ignore the caller's ctx (it's the /agent/incoming HTTP
 	// request's ctx, which dies when the recorder closes the stream on
-	// /record/stop). Use the agent's process-lifetime ctx instead so the
+	// /record/stop). Use the agent's Setup-scoped ctx instead so the
 	// ingress proxy's :8080 listener and the WatchBindEvents goroutine
 	// outlive the recording session — the listener must keep serving
 	// kubelet probes and forwarding application traffic right up until
 	// the agent process itself receives SIGTERM. See incident notes
 	// 2026-05 (CrashLoopBackOff on /record/stop).
+	//
+	// Defensive guard: in the normal CLI boot path, Setup() runs in a
+	// goroutine and assigns a.setupCtx before sending the agent port on
+	// startCh, so the HTTP server (and any /agent/incoming handler) can
+	// only come up after setupCtx is set. But misuse from tests or future
+	// embedders that wire this struct manually could skip Setup; passing
+	// a nil ctx into IncomingProxy.Start would later panic inside
+	// WatchBindEvents on `<-ctx.Done()`. Returning a clear error here
+	// makes the misuse diagnosable instead of crashing the agent process.
+	if a.setupCtx == nil {
+		return nil, errors.New("agent setupCtx is not initialized; ensure Setup() was called before StartIncomingProxy")
+	}
 	tc := a.IncomingProxy.Start(a.setupCtx, opts)
 	a.tcChan = tc
 	a.logger.Debug("Ingress proxy manager started and is listening for bind events.")
@@ -194,6 +214,15 @@ func (a *Agent) SetGracefulShutdown(ctx context.Context) error {
 	a.drainOnce.Do(func() {
 		tc := a.tcChan
 		if tc == nil {
+			return
+		}
+		// Defensive: skip the drainer when setupCtx is nil. Same misuse
+		// case as StartIncomingProxy — a manually-wired Agent that
+		// skipped Setup. Without this guard the goroutine below would
+		// nil-panic on `<-a.setupCtx.Done()` the first time tcChan is
+		// non-readable.
+		if a.setupCtx == nil {
+			a.logger.Warn("setupCtx is nil; skipping tcChan drainer. SetGracefulShutdown was called before Setup() — graceful-shutdown is degenerate in this configuration and the proxy's tcChan may fill up")
 			return
 		}
 		go func() {

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -77,9 +77,24 @@ type Agent struct {
 	//
 	// Reads + writes must hold incomingMu — StartIncomingProxy (HTTP
 	// /agent/incoming handler) writes, SetGracefulShutdown (a different
-	// HTTP handler goroutine) reads via the drainOnce closure.
-	tcChan    chan *models.TestCase
-	drainOnce sync.Once
+	// HTTP handler goroutine) reads when spawning the drainer.
+	tcChan chan *models.TestCase
+
+	// drainCancel cancels the currently-active tcChan drainer (if any).
+	// SetGracefulShutdown stashes the cancel func of the drainer it
+	// spawned; StartIncomingProxy calls it when a new /agent/incoming
+	// stream attaches, so a new recording session takes over the channel
+	// without competing against the previous session's drainer. A new
+	// SetGracefulShutdown after a fresh StartIncomingProxy spawns a
+	// fresh drainer — this gives proper session-aware lifecycle (vs the
+	// original sync.Once design which left a permanent drainer running
+	// after the first /agent/graceful-shutdown and starved any
+	// subsequent reconnect's HandleIncoming of test cases).
+	//
+	// Guarded by drainMu so SetGracefulShutdown and StartIncomingProxy
+	// can'\''t race on the cancel.
+	drainCancel context.CancelFunc
+	drainMu     sync.Mutex
 
 	// streamCtx is the request ctx of the latest /agent/incoming stream
 	// passed into StartIncomingProxy. The drainer in SetGracefulShutdown
@@ -240,6 +255,21 @@ func (a *Agent) StartIncomingProxy(ctx context.Context, opts models.IncomingOpti
 	a.streamCtx = ctx
 	a.tcChan = tc
 	a.incomingMu.Unlock()
+
+	// Cancel any drainer left over from a previous session — without
+	// this, a recorder reconnecting after /agent/graceful-shutdown
+	// would find the previous session's drainer still consuming
+	// tcChan and the new HandleIncoming for-loop would race for /
+	// lose test cases. Cancelling here gives the new session
+	// uncontested ownership of the channel until its own
+	// /agent/graceful-shutdown (which will spawn a fresh drainer).
+	a.drainMu.Lock()
+	if a.drainCancel != nil {
+		a.drainCancel()
+		a.drainCancel = nil
+	}
+	a.drainMu.Unlock()
+
 	a.logger.Debug("Ingress proxy manager started and is listening for bind events.")
 	return tc, nil
 }
@@ -264,22 +294,29 @@ func (a *Agent) SetGracefulShutdown(ctx context.Context) error {
 	// through the proxy — and every captured test case still gets sent
 	// onto tcChan. Without an explicit drainer the 100-slot buffer
 	// fills within a few probe cycles, and subsequent ingress traffic
-	// blocks at the channel send. Spin up a background drainer once,
-	// scoped to the agent process lifetime.
-	a.drainOnce.Do(func() {
-		// Snapshot tcChan and streamCtx under the same mutex
-		// StartIncomingProxy uses to write them — otherwise the read
-		// here races with the write there and the Go race detector
-		// flags it. nil streamCtx is legal here: it means
-		// SetGracefulShutdown was called before any /agent/incoming
-		// stream attached (degenerate setup); we skip the wait below.
-		a.incomingMu.Lock()
-		tc := a.tcChan
-		streamCtx := a.streamCtx
-		a.incomingMu.Unlock()
-		if tc == nil {
-			return
+	// blocks at the channel send.
+	//
+	// Spin up a SESSION-AWARE drainer: it lives only until either the
+	// agent process exits OR the next /agent/incoming stream attaches
+	// (StartIncomingProxy cancels us via drainCancel so the new session
+	// gets uncontested ownership of tcChan).
+	a.incomingMu.Lock()
+	tc := a.tcChan
+	streamCtx := a.streamCtx
+	a.incomingMu.Unlock()
+	if tc != nil {
+		a.drainMu.Lock()
+		// Cancel any drainer left over from a prior graceful-shutdown
+		// before installing the new one. Without this, repeated
+		// /agent/graceful-shutdown calls would leak goroutines (each
+		// waiting on streamCtx then competing on tcChan).
+		if a.drainCancel != nil {
+			a.drainCancel()
 		}
+		drainCtx, cancel := context.WithCancel(a.setupCtx)
+		a.drainCancel = cancel
+		a.drainMu.Unlock()
+
 		go func() {
 			// Wait for the recorder's /agent/incoming stream to close
 			// before consuming. Otherwise this drainer races with the
@@ -302,20 +339,20 @@ func (a *Agent) SetGracefulShutdown(ctx context.Context) error {
 			if streamCtx != nil {
 				select {
 				case <-streamCtx.Done():
-				case <-a.setupCtx.Done():
+				case <-drainCtx.Done():
 					return
 				}
 			}
 			for {
 				select {
-				case <-a.setupCtx.Done():
+				case <-drainCtx.Done():
 					return
 				case <-tc:
 					// discard — recording session is over
 				}
 			}
 		}()
-	})
+	}
 
 	return a.Proxy.SetGracefulShutdown(ctx)
 }

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -92,7 +92,7 @@ type Agent struct {
 	// subsequent reconnect's HandleIncoming of test cases).
 	//
 	// Guarded by drainMu so SetGracefulShutdown and StartIncomingProxy
-	// can'\''t race on the cancel.
+	// can't race on the cancel.
 	drainCancel context.CancelFunc
 	drainMu     sync.Mutex
 

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -76,6 +76,18 @@ type Agent struct {
 	// (including kubelet probes) blocks at the channel send.
 	tcChan    chan *models.TestCase
 	drainOnce sync.Once
+
+	// streamCtx is the request ctx of the latest /agent/incoming stream
+	// passed into StartIncomingProxy. The drainer in SetGracefulShutdown
+	// waits on its cancellation BEFORE consuming from tcChan — otherwise
+	// the drainer races with the still-active HandleIncoming for-loop
+	// over the same channel and steals tail-end test cases that the
+	// recorder hasn't picked up yet. The /agent/graceful-shutdown call
+	// from the recorder precedes its stream close by however long it
+	// takes the recorder to drain its own client-side queue and tear
+	// the connection down; we must not start consuming during that
+	// window.
+	streamCtx context.Context
 }
 
 func New(logger *zap.Logger, hook coreAgent.Hooks, proxy coreAgent.Proxy, client kdocker.Client, ip coreAgent.IncomingProxy, config *config.Config) *Agent {
@@ -170,15 +182,18 @@ func (a *Agent) Setup(ctx context.Context, startCh chan int) error {
 
 }
 
-func (a *Agent) StartIncomingProxy(_ context.Context, opts models.IncomingOptions) (chan *models.TestCase, error) {
-	// Intentionally ignore the caller's ctx (it's the /agent/incoming HTTP
-	// request's ctx, which dies when the recorder closes the stream on
-	// /record/stop). Use the agent's Setup-scoped ctx instead so the
+func (a *Agent) StartIncomingProxy(ctx context.Context, opts models.IncomingOptions) (chan *models.TestCase, error) {
+	// IncomingProxy.Start is given the agent's Setup-scoped ctx so the
 	// ingress proxy's :8080 listener and the WatchBindEvents goroutine
-	// outlive the recording session — the listener must keep serving
-	// kubelet probes and forwarding application traffic right up until
-	// the agent process itself receives SIGTERM. See incident notes
-	// 2026-05 (CrashLoopBackOff on /record/stop).
+	// outlive any single /agent/incoming HTTP stream — the listener must
+	// keep serving kubelet probes and forwarding application traffic
+	// right up until the agent process itself receives SIGTERM. See
+	// incident notes 2026-05 (CrashLoopBackOff on /record/stop).
+	//
+	// The CALLER's ctx (the /agent/incoming request) is captured into
+	// a.streamCtx so SetGracefulShutdown's drainer can wait for it to
+	// cancel — that's the signal the recorder has finished consuming
+	// tcChan and the drainer can safely take over without racing.
 	//
 	// Defensive guard: in the normal CLI boot path, Setup() runs in a
 	// goroutine and assigns a.setupCtx before sending the agent port on
@@ -191,6 +206,7 @@ func (a *Agent) StartIncomingProxy(_ context.Context, opts models.IncomingOption
 	if a.setupCtx == nil {
 		return nil, errors.New("agent setupCtx is not initialized; ensure Setup() was called before StartIncomingProxy")
 	}
+	a.streamCtx = ctx
 	tc := a.IncomingProxy.Start(a.setupCtx, opts)
 	a.tcChan = tc
 	a.logger.Debug("Ingress proxy manager started and is listening for bind events.")
@@ -201,6 +217,14 @@ func (a *Agent) StartIncomingProxy(_ context.Context, opts models.IncomingOption
 // When this flag is set, connection errors will be logged as debug instead of error.
 func (a *Agent) SetGracefulShutdown(ctx context.Context) error {
 	a.logger.Debug("Setting graceful shutdown flag on proxy")
+
+	// Defensive: same misuse case as StartIncomingProxy — a manually-wired
+	// Agent that skipped Setup would crash inside the drainer goroutine on
+	// `<-a.setupCtx.Done()`. Surface as an error so HandleGracefulShutdown
+	// can return 500, matching the no-Warn convention in AGENTS.md.
+	if a.setupCtx == nil {
+		return errors.New("agent setupCtx is not initialized; ensure Setup() was called before SetGracefulShutdown")
+	}
 
 	// The recorder (k8s-proxy / keploy CLI) closes its /agent/incoming
 	// streaming connection right after this call, which means no one
@@ -216,16 +240,28 @@ func (a *Agent) SetGracefulShutdown(ctx context.Context) error {
 		if tc == nil {
 			return
 		}
-		// Defensive: skip the drainer when setupCtx is nil. Same misuse
-		// case as StartIncomingProxy — a manually-wired Agent that
-		// skipped Setup. Without this guard the goroutine below would
-		// nil-panic on `<-a.setupCtx.Done()` the first time tcChan is
-		// non-readable.
-		if a.setupCtx == nil {
-			a.logger.Warn("setupCtx is nil; skipping tcChan drainer. SetGracefulShutdown was called before Setup() — graceful-shutdown is degenerate in this configuration and the proxy's tcChan may fill up")
-			return
-		}
+		// Snapshot streamCtx — nil-safe: nil means SetGracefulShutdown
+		// was called before any /agent/incoming stream attached (legal
+		// in degenerate setups; just skip the wait).
+		streamCtx := a.streamCtx
 		go func() {
+			// Wait for the recorder's /agent/incoming stream to close
+			// before consuming. Otherwise this drainer races with the
+			// HandleIncoming for-loop over the same tc channel and
+			// steals tail-end test cases the recorder hasn't picked
+			// up yet — manifests as test cases silently disappearing
+			// from the last few seconds of a recording. The flag set
+			// on the proxy above already tells the proxy to stop
+			// generating *new* test cases, but anything in-flight on
+			// tcChan when graceful-shutdown fires must still reach the
+			// active stream consumer.
+			if streamCtx != nil {
+				select {
+				case <-streamCtx.Done():
+				case <-a.setupCtx.Done():
+					return
+				}
+			}
 			for {
 				select {
 				case <-a.setupCtx.Done():

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -74,6 +74,10 @@ type Agent struct {
 	// nothing else reads tcChan after that. Without draining, the 100-
 	// slot buffer fills within seconds and subsequent ingress traffic
 	// (including kubelet probes) blocks at the channel send.
+	//
+	// Reads + writes must hold incomingMu — StartIncomingProxy (HTTP
+	// /agent/incoming handler) writes, SetGracefulShutdown (a different
+	// HTTP handler goroutine) reads via the drainOnce closure.
 	tcChan    chan *models.TestCase
 	drainOnce sync.Once
 
@@ -87,7 +91,21 @@ type Agent struct {
 	// takes the recorder to drain its own client-side queue and tear
 	// the connection down; we must not start consuming during that
 	// window.
+	//
+	// Guarded by incomingMu — see tcChan.
 	streamCtx context.Context
+
+	// incomingMu protects streamCtx and tcChan against concurrent access
+	// from StartIncomingProxy and SetGracefulShutdown (different HTTP
+	// handler goroutines). incomingProxyOnce gates the underlying
+	// IncomingProxy.Start so the ListenForIngressEvents goroutine it
+	// spawns runs exactly once per agent process — without this guard a
+	// reconnecting recorder would leak a new watcher goroutine per
+	// /agent/incoming stream (the goroutines all live until SIGTERM
+	// because the ctx is process-scoped now), and we'd accumulate
+	// duplicates that all consume from the same eventChan.
+	incomingMu        sync.Mutex
+	incomingProxyOnce sync.Once
 }
 
 func New(logger *zap.Logger, hook coreAgent.Hooks, proxy coreAgent.Proxy, client kdocker.Client, ip coreAgent.IncomingProxy, config *config.Config) *Agent {
@@ -206,10 +224,31 @@ func (a *Agent) StartIncomingProxy(ctx context.Context, opts models.IncomingOpti
 	if a.setupCtx == nil {
 		return nil, errors.New("agent setupCtx is not initialized; ensure Setup() was called before StartIncomingProxy")
 	}
+
+	// Always refresh streamCtx — a reconnecting recorder gets a new
+	// request ctx each time, and SetGracefulShutdown's drainer must
+	// wait on the LATEST one so it doesn't race with whichever
+	// HandleIncoming for-loop is currently draining the channel.
+	a.incomingMu.Lock()
 	a.streamCtx = ctx
-	tc := a.IncomingProxy.Start(a.setupCtx, opts)
-	a.tcChan = tc
-	a.logger.Debug("Ingress proxy manager started and is listening for bind events.")
+	a.incomingMu.Unlock()
+
+	// IncomingProxy.Start spawns a goroutine (`ListenForIngressEvents`)
+	// whose lifetime is now setupCtx-scoped (i.e. process lifetime).
+	// Gate with sync.Once so subsequent /agent/incoming streams reuse
+	// the existing watcher + tcChan instead of leaking a new goroutine
+	// every time. The published tcChan in `a.tcChan` is read under
+	// the same mutex in SetGracefulShutdown.
+	a.incomingProxyOnce.Do(func() {
+		tc := a.IncomingProxy.Start(a.setupCtx, opts)
+		a.incomingMu.Lock()
+		a.tcChan = tc
+		a.incomingMu.Unlock()
+		a.logger.Debug("Ingress proxy manager started and is listening for bind events.")
+	})
+	a.incomingMu.Lock()
+	tc := a.tcChan
+	a.incomingMu.Unlock()
 	return tc, nil
 }
 
@@ -236,14 +275,19 @@ func (a *Agent) SetGracefulShutdown(ctx context.Context) error {
 	// blocks at the channel send. Spin up a background drainer once,
 	// scoped to the agent process lifetime.
 	a.drainOnce.Do(func() {
+		// Snapshot tcChan and streamCtx under the same mutex
+		// StartIncomingProxy uses to write them — otherwise the read
+		// here races with the write there and the Go race detector
+		// flags it. nil streamCtx is legal here: it means
+		// SetGracefulShutdown was called before any /agent/incoming
+		// stream attached (degenerate setup); we skip the wait below.
+		a.incomingMu.Lock()
 		tc := a.tcChan
+		streamCtx := a.streamCtx
+		a.incomingMu.Unlock()
 		if tc == nil {
 			return
 		}
-		// Snapshot streamCtx — nil-safe: nil means SetGracefulShutdown
-		// was called before any /agent/incoming stream attached (legal
-		// in degenerate setups; just skip the wait).
-		streamCtx := a.streamCtx
 		go func() {
 			// Wait for the recorder's /agent/incoming stream to close
 			// before consuming. Otherwise this drainer races with the

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -48,6 +48,26 @@ type Agent struct {
 	// still find a hit; they just don't get swamped by one line per
 	// test on large suites.
 	strictLogOnce sync.Once
+
+	// setupCtx is the process-lifetime context captured during Setup().
+	// It cancels only when the agent process itself shuts down (SIGTERM),
+	// NOT when an /agent/incoming HTTP stream closes. StartIncomingProxy
+	// uses this — not the request ctx — so the ingress proxy's :8080
+	// listener survives the recorder closing the stream on /record/stop.
+	// Without this, k8s-proxy's stop sequence (HTTP graceful-shutdown
+	// notification + stream close) collapses the listener while the
+	// agent + app are still running, kubelet probes get connection
+	// refused, and the pod enters CrashLoopBackOff.
+	setupCtx context.Context
+
+	// tcChan is the test case channel returned by IncomingProxy.Start.
+	// We hold a reference so SetGracefulShutdown can spawn a drainer:
+	// the recorder closes its consuming HTTP stream on /record/stop and
+	// nothing else reads tcChan after that. Without draining, the 100-
+	// slot buffer fills within seconds and subsequent ingress traffic
+	// (including kubelet probes) blocks at the channel send.
+	tcChan      chan *models.TestCase
+	drainOnce   sync.Once
 }
 
 func New(logger *zap.Logger, hook coreAgent.Hooks, proxy coreAgent.Proxy, client kdocker.Client, ip coreAgent.IncomingProxy, config *config.Config) *Agent {
@@ -93,6 +113,11 @@ func (a *Agent) Setup(ctx context.Context, startCh chan int) error {
 	errGrp, ctx := errgroup.WithContext(ctx)
 	ctx = context.WithValue(ctx, models.ErrGroupKey, errGrp)
 
+	// Capture the process-lifetime ctx (with errgroup attached) so
+	// StartIncomingProxy can keep the ingress listener alive across
+	// /agent/incoming HTTP stream closes.
+	a.setupCtx = ctx
+
 	passPortsUint := a.config.Agent.PassThroughPorts
 
 	rules := make([]models.BypassRule, len(a.config.Agent.PassThroughPorts))
@@ -137,8 +162,17 @@ func (a *Agent) Setup(ctx context.Context, startCh chan int) error {
 
 }
 
-func (a *Agent) StartIncomingProxy(ctx context.Context, opts models.IncomingOptions) (chan *models.TestCase, error) {
-	tc := a.IncomingProxy.Start(ctx, opts)
+func (a *Agent) StartIncomingProxy(_ context.Context, opts models.IncomingOptions) (chan *models.TestCase, error) {
+	// Intentionally ignore the caller's ctx (it's the /agent/incoming HTTP
+	// request's ctx, which dies when the recorder closes the stream on
+	// /record/stop). Use the agent's process-lifetime ctx instead so the
+	// ingress proxy's :8080 listener and the WatchBindEvents goroutine
+	// outlive the recording session — the listener must keep serving
+	// kubelet probes and forwarding application traffic right up until
+	// the agent process itself receives SIGTERM. See incident notes
+	// 2026-05 (CrashLoopBackOff on /record/stop).
+	tc := a.IncomingProxy.Start(a.setupCtx, opts)
+	a.tcChan = tc
 	a.logger.Debug("Ingress proxy manager started and is listening for bind events.")
 	return tc, nil
 }
@@ -147,6 +181,33 @@ func (a *Agent) StartIncomingProxy(ctx context.Context, opts models.IncomingOpti
 // When this flag is set, connection errors will be logged as debug instead of error.
 func (a *Agent) SetGracefulShutdown(ctx context.Context) error {
 	a.logger.Debug("Setting graceful shutdown flag on proxy")
+
+	// The recorder (k8s-proxy / keploy CLI) closes its /agent/incoming
+	// streaming connection right after this call, which means no one
+	// drains tcChan anymore. With the listener now decoupled from the
+	// request ctx (StartIncomingProxy fix above), traffic keeps flowing
+	// through the proxy — and every captured test case still gets sent
+	// onto tcChan. Without an explicit drainer the 100-slot buffer
+	// fills within a few probe cycles, and subsequent ingress traffic
+	// blocks at the channel send. Spin up a background drainer once,
+	// scoped to the agent process lifetime.
+	a.drainOnce.Do(func() {
+		tc := a.tcChan
+		if tc == nil {
+			return
+		}
+		go func() {
+			for {
+				select {
+				case <-a.setupCtx.Done():
+					return
+				case <-tc:
+					// discard — recording session is over
+				}
+			}
+		}()
+	})
+
 	return a.Proxy.SetGracefulShutdown(ctx)
 }
 

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -97,15 +97,13 @@ type Agent struct {
 
 	// incomingMu protects streamCtx and tcChan against concurrent access
 	// from StartIncomingProxy and SetGracefulShutdown (different HTTP
-	// handler goroutines). incomingProxyOnce gates the underlying
-	// IncomingProxy.Start so the ListenForIngressEvents goroutine it
-	// spawns runs exactly once per agent process — without this guard a
-	// reconnecting recorder would leak a new watcher goroutine per
-	// /agent/incoming stream (the goroutines all live until SIGTERM
-	// because the ctx is process-scoped now), and we'd accumulate
-	// duplicates that all consume from the same eventChan.
-	incomingMu        sync.Mutex
-	incomingProxyOnce sync.Once
+	// handler goroutines). The single-watcher guarantee — i.e. that
+	// reconnecting recorders don't leak ListenForIngressEvents goroutines
+	// — is enforced inside IncomingProxy.Start itself (via a sync.Once
+	// on the IngressProxyManager), not here, so subsequent Start calls
+	// with different IncomingOptions still update the proxy's filtering
+	// behavior instead of being silently ignored.
+	incomingMu sync.Mutex
 }
 
 func New(logger *zap.Logger, hook coreAgent.Hooks, proxy coreAgent.Proxy, client kdocker.Client, ip coreAgent.IncomingProxy, config *config.Config) *Agent {
@@ -225,30 +223,24 @@ func (a *Agent) StartIncomingProxy(ctx context.Context, opts models.IncomingOpti
 		return nil, errors.New("agent setupCtx is not initialized; ensure Setup() was called before StartIncomingProxy")
 	}
 
-	// Always refresh streamCtx — a reconnecting recorder gets a new
-	// request ctx each time, and SetGracefulShutdown's drainer must
-	// wait on the LATEST one so it doesn't race with whichever
-	// HandleIncoming for-loop is currently draining the channel.
+	// IncomingProxy.Start is now idempotent (a sync.Once inside
+	// IngressProxyManager.Start gates the ListenForIngressEvents
+	// goroutine) AND it updates the proxy's IncomingOptions every call,
+	// so we can safely invoke it on each /agent/incoming reconnect to
+	// re-apply opts without leaking watchers or stomping in-flight
+	// captures. Returns the same tcChan on repeat calls.
+	tc := a.IncomingProxy.Start(a.setupCtx, opts)
+
+	// Refresh streamCtx + cache tcChan under the same mutex
+	// SetGracefulShutdown reads them under. A reconnecting recorder
+	// gets a new request ctx each time, and the drainer must wait on
+	// the LATEST one so it doesn't race with whichever HandleIncoming
+	// for-loop is currently draining the channel.
 	a.incomingMu.Lock()
 	a.streamCtx = ctx
+	a.tcChan = tc
 	a.incomingMu.Unlock()
-
-	// IncomingProxy.Start spawns a goroutine (`ListenForIngressEvents`)
-	// whose lifetime is now setupCtx-scoped (i.e. process lifetime).
-	// Gate with sync.Once so subsequent /agent/incoming streams reuse
-	// the existing watcher + tcChan instead of leaking a new goroutine
-	// every time. The published tcChan in `a.tcChan` is read under
-	// the same mutex in SetGracefulShutdown.
-	a.incomingProxyOnce.Do(func() {
-		tc := a.IncomingProxy.Start(a.setupCtx, opts)
-		a.incomingMu.Lock()
-		a.tcChan = tc
-		a.incomingMu.Unlock()
-		a.logger.Debug("Ingress proxy manager started and is listening for bind events.")
-	})
-	a.incomingMu.Lock()
-	tc := a.tcChan
-	a.incomingMu.Unlock()
+	a.logger.Debug("Ingress proxy manager started and is listening for bind events.")
 	return tc, nil
 }
 
@@ -294,11 +286,19 @@ func (a *Agent) SetGracefulShutdown(ctx context.Context) error {
 			// HandleIncoming for-loop over the same tc channel and
 			// steals tail-end test cases the recorder hasn't picked
 			// up yet — manifests as test cases silently disappearing
-			// from the last few seconds of a recording. The flag set
-			// on the proxy above already tells the proxy to stop
-			// generating *new* test cases, but anything in-flight on
-			// tcChan when graceful-shutdown fires must still reach the
-			// active stream consumer.
+			// from the last few seconds of a recording.
+			//
+			// Note: `Proxy.SetGracefulShutdown` (called below) does
+			// NOT stop the ingress CaptureHook from producing new
+			// test cases — it only flips an atomic flag that
+			// downgrades connection-error severity in the proxy's
+			// own logs and stops the optional packet-capture
+			// pcap stream. The proxy keeps capturing test traffic
+			// until its ctx is cancelled (process SIGTERM). So
+			// "wait for streamCtx" is the only correct gate: it
+			// guarantees HandleIncoming has stopped reading from
+			// tcChan, and the drainer can take over without
+			// racing.
 			if streamCtx != nil {
 				select {
 				case <-streamCtx.Done():


### PR DESCRIPTION
## Describe the changes that are made

Two coupled bugs in the agent's ingress-proxy lifecycle that together cause a CrashLoopBackOff on `/record/stop` for sidecar-injected pods. Single-file fix in `pkg/service/agent/agent.go` (+63 / -2).

### Bug 1 — proxy lifetime tied to HTTP request ctx

`StartIncomingProxy` used the `/agent/incoming` request's context as the lifetime context for the `IngressProxyManager`. When the recorder closes the stream on `/record/stop`:

1. `r.Context().Done()` fires
2. `WatchBindEvents`' ringbuf reader `rb.Close()` fires
3. `eventChan` closes via `defer close(eventChan)`
4. `ListenForIngressEvents`' `for e := range eventChan` exits
5. `pm.StopAll()` calls `hook.StopIngress()` → `listener.Close()`

`:8080` collapses while the agent process and eBPF `cgBind` hook are still alive. Gunicorn stays bound on the rewritten high port from initial start. Kubelet probes get `connection refused` → liveness fails → app container restarts → new gunicorn rebinds → eBPF rewrites to a NEW high port → agent's stored target is stale → permanent crash loop.

**Fix**: stash the process-lifetime ctx in the `Agent` struct during `Setup()` and use it for `IncomingProxy.Start()`. The request ctx still drives the streaming response loop in `HandleIncoming`, but the proxy and its `WatchBindEvents` goroutine outlive the stream.

### Bug 2 — `/agent/graceful-shutdown` doesn't drain `tcChan`

`SetGracefulShutdown` only flipped `isGracefulShutdown.Store(true)` (a logging flag). With Bug 1 fixed, the listener keeps capturing test cases after the recorder disconnects, but the consumer is gone — `tcChan`'s 100-slot buffer fills within a few probe cycles and every subsequent ingress connection blocks on the channel send, which manifests as probe timeouts.

**Fix**: on `SetGracefulShutdown`, spawn a background drainer (`sync.Once`-gated) scoped to the agent process lifetime that discards anything written to `tcChan`.

## Links & References

**Closes:** NA — internal incident 2026-05 (no public issue filed)

### 🔗 Related PRs
- keploy/k8s-proxy companion PR wires the graceful rolling cleanup on `/record/stop` end of the same flow.

### 🐞 Related Issues
- NA

### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

Manually reproduced in a kind cluster matching the customer's deployment shape (gunicorn + sidecar webhook injection) before and after the fix. Adding the repro as an automated Ginkgo spec under the k8s-proxy e2e suite is filed as a follow-up — the existing suite is DS-mode-focused and would need a sidecar-mode harness extension.

## Added comments for hard-to-understand areas?
- [x] 👍 yes

Both new struct fields (`setupCtx`, `tcChan` + `drainOnce`) carry a multi-paragraph comment explaining the race and the incident that motivated the fix, so future readers don't see the lifetime-decoupling as a refactor opportunity.

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

No public-facing behavior change; the bug only manifested for the k8s-proxy sidecar injection path.