### PR TITLE
fix(mysql): support TiDB on port 4000 and fix replay mock selection

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,10 +36,6 @@ type Config struct {
 	RetryPassing          bool                `json:"retryPassing" yaml:"retryPassing" mapstructure:"retryPassing"`
 	ConfigPath            string              `json:"configPath" yaml:"configPath" mapstructure:"configPath"`
 	BypassRules           []models.BypassRule `json:"bypassRules" yaml:"bypassRules" mapstructure:"bypassRules"`
-	// MysqlPorts lets users tell the proxy which destination ports speak
-	// the MySQL wire protocol (MySQL, TiDB, MariaDB, custom proxies, …).
-	// Empty defaults to [3306, 4000]. Configure when running MySQL on a
-	// non-standard port or against a wire-compatible server elsewhere.
 	MysqlPorts            []uint32            `json:"mysqlPorts" yaml:"mysqlPorts" mapstructure:"mysqlPorts"`
 	EnableTesting         bool                `json:"enableTesting" yaml:"-" mapstructure:"enableTesting"`
 	GenerateGithubActions bool                `json:"generateGithubActions" yaml:"generateGithubActions" mapstructure:"generateGithubActions"`

--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,11 @@ type Config struct {
 	RetryPassing          bool                `json:"retryPassing" yaml:"retryPassing" mapstructure:"retryPassing"`
 	ConfigPath            string              `json:"configPath" yaml:"configPath" mapstructure:"configPath"`
 	BypassRules           []models.BypassRule `json:"bypassRules" yaml:"bypassRules" mapstructure:"bypassRules"`
+	// MysqlPorts lets users tell the proxy which destination ports speak
+	// the MySQL wire protocol (MySQL, TiDB, MariaDB, custom proxies, …).
+	// Empty defaults to [3306, 4000]. Configure when running MySQL on a
+	// non-standard port or against a wire-compatible server elsewhere.
+	MysqlPorts            []uint32            `json:"mysqlPorts" yaml:"mysqlPorts" mapstructure:"mysqlPorts"`
 	EnableTesting         bool                `json:"enableTesting" yaml:"-" mapstructure:"enableTesting"`
 	GenerateGithubActions bool                `json:"generateGithubActions" yaml:"generateGithubActions" mapstructure:"generateGithubActions"`
 	KeployContainer       string              `json:"keployContainer" yaml:"keployContainer" mapstructure:"keployContainer"`

--- a/pkg/agent/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match.go
@@ -730,13 +730,6 @@ func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.Packe
 	}
 
 	if expectedSignature == actualSignature {
-		// AST structural equivalence only — literal values may still
-		// differ (INSERT/DELETE/UPDATE with different bind values share
-		// the same AST shape). Return a high score but NOT a definitive
-		// match, so the outer matcher continues looking for a mock whose
-		// full query text matches byte-for-byte; without that, the first
-		// structurally-equivalent mock would always win and every call
-		// against the same prepared SQL would replay the same response.
 		log.Debug("query structure matched",
 			zap.String("expected signature", expectedSignature),
 			zap.String("actual signature", actualSignature))
@@ -856,15 +849,7 @@ func matchStmtExecutePacketQueryAware(logger *zap.Logger, expected, actual mysql
 			}
 		}
 	}
-
-	// If we couldn't resolve the recorded/actual query (server-assigned
-	// statement IDs differ across runs, so the StmtID->Query lookups
-	// often miss), a full bind-parameter equality is still strong
-	// enough on its own: same statement type, same param count, same
-	// flags/status, and every parameter value byte-equal. Without this,
-	// the matcher falls through to score-based selection where every
-	// candidate INSERT/DELETE mock ties and the first-encountered
-	// one wins for every call.
+	
 	if allParamsMatched && eq == "" && aq == "" {
 		return true, matchCount
 	}

--- a/pkg/agent/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match.go
@@ -730,10 +730,17 @@ func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.Packe
 	}
 
 	if expectedSignature == actualSignature {
+		// AST structural equivalence only — literal values may still
+		// differ (INSERT/DELETE/UPDATE with different bind values share
+		// the same AST shape). Return a high score but NOT a definitive
+		// match, so the outer matcher continues looking for a mock whose
+		// full query text matches byte-for-byte; without that, the first
+		// structurally-equivalent mock would always win and every call
+		// against the same prepared SQL would replay the same response.
 		log.Debug("query structure matched",
 			zap.String("expected signature", expectedSignature),
 			zap.String("actual signature", actualSignature))
-		return true, matchCount
+		return false, matchCount + 6
 	}
 
 	return false, matchCount
@@ -848,6 +855,18 @@ func matchStmtExecutePacketQueryAware(logger *zap.Logger, expected, actual mysql
 				logger.Debug("query structure matched", zap.String("related stmt-exec mock-name", mockName))
 			}
 		}
+	}
+
+	// If we couldn't resolve the recorded/actual query (server-assigned
+	// statement IDs differ across runs, so the StmtID->Query lookups
+	// often miss), a full bind-parameter equality is still strong
+	// enough on its own: same statement type, same param count, same
+	// flags/status, and every parameter value byte-equal. Without this,
+	// the matcher falls through to score-based selection where every
+	// candidate INSERT/DELETE mock ties and the first-encountered
+	// one wins for every call.
+	if allParamsMatched && eq == "" && aq == "" {
+		return true, matchCount
 	}
 
 	if !queryMatched || !allParamsMatched {

--- a/pkg/agent/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match.go
@@ -849,7 +849,7 @@ func matchStmtExecutePacketQueryAware(logger *zap.Logger, expected, actual mysql
 			}
 		}
 	}
-	
+
 	if allParamsMatched && eq == "" && aq == "" {
 		return true, matchCount
 	}

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -1309,8 +1309,8 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 		outgoingOpts.Synchronous = true
 	}
 
-	//checking for the destination port of "mysql"
-	if destInfo.Port == 3306 {
+	//checking for the destination port of "mysql" / TiDB (mysql wire-compatible)
+	if destInfo.Port == 3306 || destInfo.Port == 4000 {
 		if rule.Mode != models.MODE_TEST {
 			dstConn, err = net.Dial("tcp", dstAddr)
 			if err != nil {

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -78,15 +78,8 @@ func probeProxy(logger *zap.Logger, phase string, connID int64, fields ...zap.Fi
 	logger.Info("[PROBE/proxy]", append(base, fields...)...)
 }
 
-// defaultMysqlPorts is the fallback list used by isMysqlPort when the
-// user hasn't set outgoingOpts.MysqlPorts. 3306 is MySQL's default;
-// 4000 is TiDB's default. Configure Config.MysqlPorts to override.
 var defaultMysqlPorts = []uint32{3306, 4000}
 
-// isMysqlPort reports whether the proxy should treat the destination
-// port as MySQL wire protocol — i.e. take the eager-upstream-dial
-// branch in handleConnection. Returns true if port is in configured
-// (when non-empty) or in defaultMysqlPorts (when configured is empty).
 func isMysqlPort(port uint32, configured []uint32) bool {
 	ports := configured
 	if len(ports) == 0 {

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -78,6 +78,28 @@ func probeProxy(logger *zap.Logger, phase string, connID int64, fields ...zap.Fi
 	logger.Info("[PROBE/proxy]", append(base, fields...)...)
 }
 
+// defaultMysqlPorts is the fallback list used by isMysqlPort when the
+// user hasn't set outgoingOpts.MysqlPorts. 3306 is MySQL's default;
+// 4000 is TiDB's default. Configure Config.MysqlPorts to override.
+var defaultMysqlPorts = []uint32{3306, 4000}
+
+// isMysqlPort reports whether the proxy should treat the destination
+// port as MySQL wire protocol — i.e. take the eager-upstream-dial
+// branch in handleConnection. Returns true if port is in configured
+// (when non-empty) or in defaultMysqlPorts (when configured is empty).
+func isMysqlPort(port uint32, configured []uint32) bool {
+	ports := configured
+	if len(ports) == 0 {
+		ports = defaultMysqlPorts
+	}
+	for _, p := range ports {
+		if p == port {
+			return true
+		}
+	}
+	return false
+}
+
 // probeDial emits a [PROBE/dial] log for upstream dial timing.
 func probeDial(logger *zap.Logger, phase string, connID int64, addr string, durNs int64, fields ...zap.Field) {
 	if !probeOn() {
@@ -1309,8 +1331,10 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 		outgoingOpts.Synchronous = true
 	}
 
-	//checking for the destination port of "mysql" / TiDB (mysql wire-compatible)
-	if destInfo.Port == 3306 || destInfo.Port == 4000 {
+	// MySQL wire-protocol ports (MySQL, TiDB, MariaDB, custom proxies).
+	// Configurable via outgoingOpts.MysqlPorts (Config.MysqlPorts in
+	// keploy.yml); defaults to [3306, 4000] when unset.
+	if isMysqlPort(uint32(destInfo.Port), outgoingOpts.MysqlPorts) {
 		if rule.Mode != models.MODE_TEST {
 			dstConn, err = net.Dial("tcp", dstAddr)
 			if err != nil {

--- a/pkg/models/instrument.go
+++ b/pkg/models/instrument.go
@@ -83,6 +83,14 @@ type OutgoingOptions struct {
 	// Surfaced via --opportunistic-tls-intercept so the agent can
 	// pick the right per-connection branch in handleConnection.
 	OpportunisticTLSIntercept bool
+	// MysqlPorts lists destination ports that the proxy should treat as
+	// MySQL (or wire-compatible variants like TiDB) — i.e. dial the
+	// upstream eagerly on connection accept so the server's Initial
+	// Handshake Packet can be relayed. MySQL is a server-speaks-first
+	// protocol; the generic dispatch path waits to peek client bytes
+	// before dialing and deadlocks otherwise. When nil/empty, the
+	// proxy falls back to the built-in defaults [3306, 4000].
+	MysqlPorts []uint32
 }
 
 type ConditionalDstCfg struct {

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -623,6 +623,7 @@ func (r *Recorder) GetTestAndMockChans(ctx context.Context) (FrameChan, error) {
 		TLSPrivateKey:             tlsPrivateKey,
 		CapturePackets:            r.config.Record.CapturePackets,
 		OpportunisticTLSIntercept: r.config.Record.OpportunisticTLSIntercept,
+		MysqlPorts:                r.config.MysqlPorts,
 	})
 	if err != nil {
 

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1089,6 +1089,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			Backdate:               testCases[0].HTTPReq.Timestamp,
 			NoiseConfig:            headerNoiseConfig,
 			DisableAutoHeaderNoise: r.config.Test.DisableAutoHeaderNoise,
+			MysqlPorts:             r.config.MysqlPorts,
 		})
 		if err != nil {
 			if ctx.Err() != context.Canceled {
@@ -1275,6 +1276,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			Backdate:               testCases[0].HTTPReq.Timestamp,
 			NoiseConfig:            headerNoiseConfig,
 			DisableAutoHeaderNoise: r.config.Test.DisableAutoHeaderNoise,
+			MysqlPorts:             r.config.MysqlPorts,
 		})
 		if err != nil {
 			if ctx.Err() != context.Canceled {

--- a/pkg/service/runner/runner.go
+++ b/pkg/service/runner/runner.go
@@ -372,6 +372,7 @@ func (r *Runner) setupTestSet(parentCtx context.Context, testSetID string, backd
 		outOpts.MongoPassword = r.config.Test.MongoPassword
 		outOpts.SQLDelay = time.Duration(r.config.Test.Delay) * time.Second
 		outOpts.DisableAutoHeaderNoise = r.config.Test.DisableAutoHeaderNoise
+		outOpts.MysqlPorts = r.config.MysqlPorts
 	}
 	if headerNoise, ok := r.globalNoise["header"]; ok {
 		outOpts.NoiseConfig = map[string]map[string][]string{"header": headerNoise}


### PR DESCRIPTION
## Summary

Two related fixes uncovered while pointing keploy at a Spring Boot + mysql-connector-j app talking to TiDB on its default port 4000.

1. **Proxy: treat port 4000 as MySQL/TiDB** (`pkg/agent/proxy/proxy.go`)
   The dispatcher peeks the first 5 client bytes to choose a parser, which deadlocks on server-speaks-first protocols. MySQL was special-cased for port 3306 (eager upstream dial); TiDB on 4000 fell through to the peek path and hung until `socketTimeout` fired, producing `Communications link failure ... driver has not received any packets from the server`.

2. **Replay: pick mocks by query text, not just AST shape** (`pkg/agent/proxy/integrations/mysql/replayer/match.go`)
   Two code paths returned definitive matches for *structurally* equivalent SQL, so every `POST /books` with a different title replayed the first INSERT's response (same `last_insert_id`), and `DELETE /books/9999` replayed a successful DELETE-3 mock and reported `deleted: 1` for a not-found row.
   - `matchQuery` (COM_QUERY): demote AST-signature equality from `(true, score)` to `(false, score + 6)` so the matcher keeps searching for an exact text match. Falls back to structural via the existing score path. +6 mirrors the structural-vs-exact weight ladder already in `matchStmtExecutePacketQueryAware` (10 exact / 6 structural).
   - `matchStmtExecutePacketQueryAware` (COM_STMT_EXECUTE): when StmtID→query lookups miss (statement IDs are server-assigned and differ across runs), full bind-parameter equality alone is strong enough — same statement type, same param count, same flags/status, every value byte-equal. Treat that as a definitive match instead of falling through to first-wins score selection.

## Repro

Spring Boot + mysql-connector-j 8.4 against TiDB v7.5.1 on `127.0.0.1:4000`. CRUD endpoints with `POST /books` (different bodies), `DELETE /books/{id}` for both an existing and non-existent id.

Before:
- Record path: every JDBC connection hangs ~5s then errors with `Communications link failure`.
- After making the record path work (port fix only): replay returns 4/14 → 3/13 → 2/13 failing, all on different-bind INSERT/DELETE.

After both fixes: 13/13 passing, deterministically.

## Test plan

- [ ] CI green
- [ ] Existing MySQL e2e suites still pass
- [ ] Manual: re-run TiDB sample (port 4000) — record + replay
- [ ] Manual: re-run an existing MySQL-on-3306 sample to confirm no regression in the structural-match fallback for parameterized SELECTs

🤖 Generated with [Claude Code](https://claude.com/claude-code)