### PR TITLE
ci: concurrent sampling ci test

### DIFF
--- a/.github/workflows/sampling-test.yml
+++ b/.github/workflows/sampling-test.yml
@@ -9,7 +9,7 @@ on:
       samples_go_ref:
         description: 'samples-go ref to check out (branch, tag, or SHA)'
         required: false
-        default: 'go-sampling'
+        default: 'main'
       sampling_limit:
         description: '--enable-sampling slot count (K)'
         required: false
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: keploy/samples-go
-          ref: ${{ github.event.inputs.samples_go_ref || 'go-sampling' }}
+          ref: ${{ github.event.inputs.samples_go_ref || 'main' }}
           path: samples-go
 
       - name: Run sampling end-to-end test

--- a/.github/workflows/sampling-test.yml
+++ b/.github/workflows/sampling-test.yml
@@ -1,0 +1,77 @@
+name: Sampling Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      samples_go_ref:
+        description: 'samples-go ref to check out (branch, tag, or SHA)'
+        required: false
+        default: 'go-sampling'
+      sampling_limit:
+        description: '--enable-sampling slot count (K)'
+        required: false
+        default: '5'
+      total_requests:
+        description: 'Total concurrent curl requests (N)'
+        required: false
+        default: '20'
+
+concurrency:
+  group: sampling-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sampling-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout keploy
+        uses: actions/checkout@v4
+        with:
+          path: keploy
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: keploy/go.mod
+          cache: true
+          cache-dependency-path: keploy/go.sum
+
+      - name: Build keploy
+        working-directory: keploy
+        run: |
+          go build -o keploy main.go
+          chmod +x keploy
+          ls -lh keploy
+
+      - name: Checkout samples-go
+        uses: actions/checkout@v4
+        with:
+          repository: keploy/samples-go
+          ref: ${{ github.event.inputs.samples_go_ref || 'go-sampling' }}
+          path: samples-go
+
+      - name: Run sampling end-to-end test
+        env:
+          KEPLOY_BIN: ${{ github.workspace }}/keploy/keploy
+          SAMPLE_DIR: ${{ github.workspace }}/samples-go/sampling-test
+          SAMPLING_LIMIT: ${{ github.event.inputs.sampling_limit || '5' }}
+          TOTAL_REQUESTS: ${{ github.event.inputs.total_requests || '20' }}
+        run: |
+          chmod +x keploy/.github/workflows/test_workflow_scripts/sampling/run-sampling-test.sh
+          keploy/.github/workflows/test_workflow_scripts/sampling/run-sampling-test.sh
+
+      - name: Upload artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sampling-test-artifacts-${{ github.run_number }}
+          path: |
+            samples-go/sampling-test/record.log
+            samples-go/sampling-test/keploy/
+            samples-go/sampling-test/curl-results/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/test_workflow_scripts/sampling/run-sampling-test.sh
+++ b/.github/workflows/test_workflow_scripts/sampling/run-sampling-test.sh
@@ -136,10 +136,15 @@ if [ ! -d ./keploy/test-set-0/tests ]; then
     ls -la ./keploy 2>/dev/null || true
     exit 1
 fi
-captured=$(find ./keploy/test-set-0/tests -maxdepth 1 -name 'test-*.yaml' -type f | wc -l | tr -d ' ')
-echo "captured test cases: $captured"
+# Keploy names test cases after the HTTP method + path (e.g. get-work-1.yaml).
+# Count only /work captures — the readiness probe on /health may also land in
+# the test-set and would otherwise inflate the count above the sampling budget.
+captured=$(find ./keploy/test-set-0/tests -maxdepth 1 -name 'get-work-*.yaml' -type f | wc -l | tr -d ' ')
+total_files=$(find ./keploy/test-set-0/tests -maxdepth 1 -name '*.yaml' -type f | wc -l | tr -d ' ')
+echo "captured /work test cases: $captured"
+echo "total recorded test cases (incl. /health probe): $total_files"
 echo "sampling limit (K): $SAMPLING_LIMIT"
-echo "total requests (N): $TOTAL_REQUESTS"
+echo "total /work requests (N): $TOTAL_REQUESTS"
 ls ./keploy/test-set-0/tests | sed 's/^/  /'
 endsec
 

--- a/.github/workflows/test_workflow_scripts/sampling/run-sampling-test.sh
+++ b/.github/workflows/test_workflow_scripts/sampling/run-sampling-test.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Drives the --enable-sampling end-to-end test:
+#
+#   1. Build the sample HTTP app (./sampling-test/main.go).
+#   2. Start `keploy record --enable-sampling=$SAMPLING_LIMIT -c ./sampling-test`.
+#   3. Wait for the app to be reachable, then fire $TOTAL_REQUESTS concurrent
+#      curls via curl.sh — the burst overlaps inside the 500ms handler delay,
+#      so the proxy sees far more in-flight connections than sampling slots.
+#   4. Drain, SIGINT keploy, count recorded test cases under ./keploy/test-set-0/tests.
+#   5. Assert:
+#        - every curl saw a 2xx response (clients never broken by bypass)
+#        - SAMPLING_LIMIT <= captured_test_cases < TOTAL_REQUESTS
+#
+# Expects (env): KEPLOY_BIN, SAMPLE_DIR (absolute path to samples-go/sampling-test).
+# Optional   :  SAMPLING_LIMIT (default 5), TOTAL_REQUESTS (default 20),
+#               HANDLER_DELAY_MS (default 500).
+
+set -Eeuo pipefail
+
+SAMPLING_LIMIT="${SAMPLING_LIMIT:-5}"
+TOTAL_REQUESTS="${TOTAL_REQUESTS:-20}"
+HANDLER_DELAY_MS="${HANDLER_DELAY_MS:-500}"
+APP_PORT="${APP_PORT:-8080}"
+
+: "${KEPLOY_BIN:?KEPLOY_BIN must point to the keploy binary}"
+: "${SAMPLE_DIR:?SAMPLE_DIR must point to the sampling-test sample app}"
+
+if [ ! -x "$KEPLOY_BIN" ]; then
+    echo "::error::keploy binary $KEPLOY_BIN is not executable"
+    exit 1
+fi
+if [ ! -d "$SAMPLE_DIR" ]; then
+    echo "::error::sample dir $SAMPLE_DIR does not exist"
+    exit 1
+fi
+
+section() { echo "::group::$*"; }
+endsec()  { echo "::endgroup::"; }
+
+cd "$SAMPLE_DIR"
+
+# Fake installation-id so keploy doesn't try to phone home.
+sudo mkdir -p ~/.keploy
+sudo touch ~/.keploy/installation-id.yaml
+echo "ObjectID('123456789')" | sudo tee ~/.keploy/installation-id.yaml > /dev/null
+
+section "Clean previous recordings"
+rm -rf keploy/ curl-results/ record.log sampling-test
+endsec
+
+section "Build sample app"
+go build -o sampling-test .
+ls -lh sampling-test
+endsec
+
+cleanup() {
+    rc=$?
+    section "Cleanup: stopping keploy & sample app"
+    sudo pkill -INT -f 'keploy record' 2>/dev/null || true
+    sudo pkill -f './sampling-test' 2>/dev/null || true
+    sleep 2
+    sudo pkill -KILL -f 'keploy record' 2>/dev/null || true
+    sudo pkill -KILL -f './sampling-test' 2>/dev/null || true
+    endsec
+    section "record.log tail"
+    tail -n 200 record.log 2>/dev/null || echo "(no record.log)"
+    endsec
+    exit $rc
+}
+trap cleanup EXIT
+
+section "Start keploy record (--enable-sampling=$SAMPLING_LIMIT)"
+HANDLER_DELAY_MS="$HANDLER_DELAY_MS" \
+    sudo -E env PATH="$PATH" HANDLER_DELAY_MS="$HANDLER_DELAY_MS" PORT="$APP_PORT" \
+    "$KEPLOY_BIN" record \
+        -c "./sampling-test" \
+        --enable-sampling="$SAMPLING_LIMIT" \
+        --generate-github-actions=false \
+        2>&1 | tee record.log &
+KEPLOY_TEE_PID=$!
+echo "tee pid: $KEPLOY_TEE_PID"
+endsec
+
+section "Wait for sample app on :$APP_PORT"
+ready=0
+for i in $(seq 1 60); do
+    if curl -sf --max-time 2 "http://localhost:${APP_PORT}/health" >/dev/null 2>&1; then
+        echo "sample app ready after ${i}s"
+        ready=1
+        break
+    fi
+    sleep 1
+done
+if [ "$ready" -ne 1 ]; then
+    echo "::error::sample app failed to come up within 60s"
+    exit 1
+fi
+endsec
+
+section "Fire $TOTAL_REQUESTS concurrent curls"
+TOTAL_REQUESTS="$TOTAL_REQUESTS" \
+    TARGET_URL="http://localhost:${APP_PORT}/work" \
+    RESULTS_DIR="./curl-results" \
+    bash ./curl.sh
+endsec
+
+# Give the proxy a moment to drain pending captures before SIGINT.
+sleep 3
+
+section "Stop keploy (SIGINT)"
+REC_PID="$(pgrep -n -f 'keploy record' || true)"
+if [ -n "$REC_PID" ]; then
+    echo "sending SIGINT to keploy pid $REC_PID"
+    sudo kill -INT "$REC_PID" || true
+fi
+# Wait for the tee'd pipeline to finish so record.log is flushed.
+wait "$KEPLOY_TEE_PID" 2>/dev/null || true
+sleep 2
+endsec
+
+section "Check record.log for errors"
+if grep -E "panic:" record.log >/dev/null 2>&1; then
+    echo "::error::panic detected in record.log"
+    exit 1
+fi
+if grep "WARNING: DATA RACE" record.log >/dev/null 2>&1; then
+    echo "::error::data race detected in record.log"
+    exit 1
+fi
+echo "no critical errors found in record.log"
+endsec
+
+section "Count recorded test cases"
+if [ ! -d ./keploy/test-set-0/tests ]; then
+    echo "::error::./keploy/test-set-0/tests directory missing — nothing recorded"
+    ls -la ./keploy 2>/dev/null || true
+    exit 1
+fi
+captured=$(find ./keploy/test-set-0/tests -maxdepth 1 -name 'test-*.yaml' -type f | wc -l | tr -d ' ')
+echo "captured test cases: $captured"
+echo "sampling limit (K): $SAMPLING_LIMIT"
+echo "total requests (N): $TOTAL_REQUESTS"
+ls ./keploy/test-set-0/tests | sed 's/^/  /'
+endsec
+
+# Tolerance: slot recycling within the burst can occasionally push the
+# captured count one or two above K, so we accept the open interval
+# [K, N). A captured count of N or above means sampling didn't gate
+# anything; a count below K means the slot semaphore is over-limiting.
+if [ "$captured" -lt "$SAMPLING_LIMIT" ]; then
+    echo "::error::captured ($captured) < SAMPLING_LIMIT ($SAMPLING_LIMIT) — sampling under-captured"
+    exit 1
+fi
+if [ "$captured" -ge "$TOTAL_REQUESTS" ]; then
+    echo "::error::captured ($captured) >= TOTAL_REQUESTS ($TOTAL_REQUESTS) — bypass path never triggered"
+    exit 1
+fi
+
+echo "✅ sampling assertion passed: $SAMPLING_LIMIT <= $captured < $TOTAL_REQUESTS"


### PR DESCRIPTION
## Describe the changes that are made

Adds an end-to-end GitHub Actions pipeline that exercises the `--enable-sampling` flag of `keploy record` and asserts the documented bypass behaviour.

**What runs on every PR and every push to `main`:**

1. Build `keploy` from the current branch.
2. Check out the companion `sampling-test` sample app from `keploy/samples-go`.
3. Start `keploy record --enable-sampling=$K -c ./sampling-test`.
4. Wait for the app on `:8080`, then run `curl.sh` to fire `$N` concurrent `GET /work` requests, each on its own TCP connection. The handler sleeps `HANDLER_DELAY_MS` (default 500 ms) so the burst overlaps inside the proxy and the slot semaphore is genuinely contended.
5. Drain captures, send `SIGINT` to keploy.
6. Inspect `./keploy/test-set-0/tests/` and assert:
   - every curl returned 2xx (the bypass path must never break clients — `feedback_no_client_errors`), **and**
   - `$K ≤ captured_test_cases < $N` (sampling actually gated some traffic, but not all of it).

Defaults: `K=5`, `N=20`, handler delay 500 ms. All overridable via `workflow_dispatch` inputs (`sampling_limit`, `total_requests`, `samples_go_ref`).

Files added:

- `.github/workflows/sampling-test.yml` — workflow definition; triggers on `pull_request`, `push` to `main`, and `workflow_dispatch`.
- `.github/workflows/test_workflow_scripts/sampling/run-sampling-test.sh` — driver script (build sample, record, curl burst, SIGINT, assert).

The companion sample app lives in keploy/samples-go#232. The workflow currently pins `samples_go_ref` to `go-sampling` so the two PRs can be merged in either order; flip the default to `main` once the samples-go PR is in.

## Links & References

**Closes:** #4211

### 🔗 Related PRs
- keploy/samples-go#232 — `feat: app for testing concurrent sampling` (the sample app this workflow drives)

### 🐞 Related Issues
- #4211

### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [x] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [x] 👍 yes — *this PR **is** the e2e pipeline*

## Added comments for hard-to-understand areas?
- [x] 👍 yes — the driver script's count-and-assert block explains why we filter to `get-work-*.yaml` only

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed — the sample's `README.md` (in samples-go) explains how to reproduce locally

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

Reproduce locally:

```bash
# In keploy/samples-go (on the go-sampling branch)
cd sampling-test
go build -o sampling-test .

# In another terminal
sudo keploy record --enable-sampling=5 -c ./sampling-test &
TOTAL_REQUESTS=20 bash curl.sh

# Then SIGINT keploy and inspect
ls ./keploy/test-set-0/tests/   # expect 5x get-work-*.yaml + 1x get-health-1.yaml
```

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?

Latest CI run on this branch — successful assertion (post-fix in commit 843d753):

```
captured /work test cases: 5
total recorded test cases (incl. /health probe): 6
sampling limit (K): 5
total /work requests (N): 20
✅ sampling assertion passed: 5 <= 5 < 20
```

curl-side, every client got a 2xx response:

```
curl summary: total=20 ok=20 non2xx=0 wait_failures=0
```

## 🧠 Semantics for PR Title & Branch Name

- **PR Title:** `ci: concurrent sampling ci test`
- **Branch Name:** `ci-sampling`

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?
