### PR TITLE
feat(image): non-root + capability-only agent execution support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,9 +52,10 @@ FROM debian:trixie-slim
 
 ENV KEPLOY_INDOCKER=true
 
-# Update the package lists and install required packages
-RUN apt-get update
-RUN apt-get install -y ca-certificates curl sudo && \
+# libcap2-bin → setcap. Mirror of Dockerfile.runtime — see that file for
+# the full rationale on file caps + dual-mode (root/non-root) execution.
+RUN apt-get update && \
+    apt-get install -y ca-certificates curl sudo libcap2-bin && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -62,11 +63,16 @@ RUN apt-get install -y ca-certificates curl sudo && \
 COPY --from=build /app/keploy /app/keploy
 COPY --from=build /app/entrypoint.sh /app/entrypoint.sh
 
-# windows comapatibility
-RUN sed -i 's/\r$//' /app/entrypoint.sh
-
-# Make the entrypoint.sh file executable
-RUN chmod +x /app/entrypoint.sh
+# windows compatibility + executable bit + file capabilities + non-root
+# user. The image default stays root (no USER directive); k8s deployments
+# override via securityContext.runAsUser=65532, file caps make the bounding
+# set effective on exec for that non-root case. See Dockerfile.runtime
+# for the full design note.
+RUN sed -i 's/\r$//' /app/entrypoint.sh && \
+    chmod +x /app/entrypoint.sh /app/keploy && \
+    setcap cap_bpf,cap_perfmon,cap_net_admin,cap_sys_ptrace,cap_sys_resource+eip /app/keploy && \
+    groupadd --system --gid 65532 keploy && \
+    useradd  --system --uid 65532 --gid 65532 --no-create-home --shell /usr/sbin/nologin keploy
 
 # Set the entrypoint
 ENTRYPOINT ["/app/entrypoint.sh", "/app/keploy", "agent","--is-docker"]

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -19,8 +19,11 @@ ARG TARGETARCH
 
 ENV KEPLOY_INDOCKER=true
 
+# libcap2-bin → setcap (granting CAP_BPF/CAP_PERFMON/etc to the binary so
+# the agent can run as a non-root UID when the container runtime puts
+# those caps in the bounding set — the k8s PSA-restricted path).
 RUN apt-get update && \
-    apt-get install -y ca-certificates curl sudo && \
+    apt-get install -y ca-certificates curl sudo libcap2-bin && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -28,8 +31,30 @@ COPY dist/keploy-linux-${TARGETARCH}/keploy /app/keploy
 COPY entrypoint.sh /app/entrypoint.sh
 
 # windows compatibility (strip CRLF if the file picked it up on a
-# Windows checkout) + make executable.
+# Windows checkout) + make executable + grant file capabilities so a
+# non-root container user can still exercise the eBPF data-plane caps
+# the runtime adds via --cap-add / securityContext.capabilities.add.
+#
+# +eip = effective + inheritable + permitted. Docker/runc honour file
+# caps when launching a non-root process; capability is no-op for root
+# (already has everything), so this is safe for the docker-compose
+# (root) path too.
+#
+# A non-root sidecar in k8s gets these via the chain:
+#   image setcap → bounding set (k8s capabilities.add) → effective set
+#                  (file caps make them effective on exec)
+#
+# NOT included: CAP_SYS_ADMIN. The sidecar should never need it on
+# kernels >= 5.8. Sysctl writes / mount calls are delegated to the
+# privileged keploy-node-setup DaemonSet (host-bootstrap init container).
 RUN sed -i 's/\r$//' /app/entrypoint.sh && \
-    chmod +x /app/entrypoint.sh /app/keploy
+    chmod +x /app/entrypoint.sh /app/keploy && \
+    setcap cap_bpf,cap_perfmon,cap_net_admin,cap_sys_ptrace,cap_sys_resource+eip /app/keploy && \
+    # Non-root user is created but NOT applied via USER directive. The image
+    # default stays root so docker-compose (sudo docker run …) keeps working
+    # unchanged; k8s deployments opt into non-root by setting
+    # securityContext.runAsUser=65532 (the webhook's AgentRunAsUser knob).
+    groupadd --system --gid 65532 keploy && \
+    useradd  --system --uid 65532 --gid 65532 --no-create-home --shell /usr/sbin/nologin keploy
 
 ENTRYPOINT ["/app/entrypoint.sh", "/app/keploy", "agent", "--is-docker"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,36 @@
 #!/bin/sh
+# keploy-agent dual-mode entrypoint.
+#
+# Branch on container UID so the same image works for both:
+#
+#   1. docker-compose (root):  `sudo docker run …` → container starts as UID 0.
+#      We have CAP_SYS_ADMIN via the (effective) root caps, so we can mount
+#      debugfs ourselves if the host hasn't pre-mounted it.
+#
+#   2. k8s PSA-restricted (non-root):  securityContext.runAsUser=65532 +
+#      capabilities.add=[BPF,PERFMON,NET_ADMIN,SYS_PTRACE,SYS_RESOURCE].
+#      Bounding-set caps become effective on exec via the setcap'd binary
+#      (see Dockerfile). We do NOT have CAP_SYS_ADMIN, so we cannot mount
+#      debugfs — but the keploy-node-setup DaemonSet's host-bootstrap
+#      init container ensures debugfs is mounted host-wide before this
+#      pod starts, and we mount it into the container via hostPath.
+#
+# No `sudo` anywhere. The previous version `exec sudo -E "$@"` even when
+# the container was already root, which is redundant for case 1 and
+# crashes outright for case 2 (no NOPASSWD, no tty). Use exec so keploy
+# replaces this shell PID and receives SIGTERM directly from the runtime.
 
-if ! mountpoint -q /sys/kernel/debug; then
-  sudo mount -t debugfs debugfs /sys/kernel/debug
+set -e
+
+# Best-effort debugfs mount, root path only. Non-root caller skips this;
+# debugfs is expected to be mounted by the host / hostPath. If neither
+# holds (rare misconfig), keploy will log a clear error when it tries to
+# attach kprobes — fail-loud is better than silently mounting from a
+# non-root context that would EPERM anyway.
+if [ "$(id -u)" = "0" ]; then
+    if ! mountpoint -q /sys/kernel/debug 2>/dev/null; then
+        mount -t debugfs debugfs /sys/kernel/debug 2>/dev/null || true
+    fi
 fi
 
-# Use exec to replace the shell process with keploy
-# This ensures keploy receives signals (SIGTERM) directly from Docker
-exec sudo -E "$@"
+exec "$@"

--- a/pkg/platform/http/agent.go
+++ b/pkg/platform/http/agent.go
@@ -1226,14 +1226,18 @@ func (a *AgentClient) Setup(ctx context.Context, cmd string, opts models.SetupOp
 			)
 		}
 
-		// Lower perf_event_paranoid to allow eBPF programs to attach to syscall tracepoints
-		// like sys_socket via perf_event_open. Ubuntu/Debian default (4) blocks this for
-		// unprivileged users, so setting 2 relaxes the restriction and enables tracing.
+		// Best-effort lowering of perf_event_paranoid. Requires CAP_SYS_ADMIN
+		// (or root); succeeds on the docker-compose (root) path, fails with
+		// EPERM on the k8s capability-only profile (CAP_BPF + CAP_PERFMON,
+		// no SYS_ADMIN). EPERM here is NOT fatal — CAP_PERFMON alone is
+		// sufficient for tracepoint perf_event_open() at paranoid <= 2,
+		// which is the kernel default on every supported distro. Operators
+		// running on a hardened host (paranoid=3) tune it host-wide via
+		// the keploy-node-setup DaemonSet's host-bootstrap init container
+		// instead of from inside the sidecar.
 		if runtime.GOOS == "linux" {
-			cmd := exec.Command("sysctl", "-w", "kernel.perf_event_paranoid=2")
-			if err := cmd.Run(); err != nil {
-				a.logger.Error("Failed to relax host perf_event_paranoid. Tracepoints may fail.", zap.Error(err))
-				return err
+			if err := exec.Command("sysctl", "-w", "kernel.perf_event_paranoid=2").Run(); err != nil {
+				a.logger.Debug("could not lower perf_event_paranoid; continuing with kernel default (expected on capability-only profile)", zap.Error(err))
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Three coordinated changes that let the keploy agent run as a non-root UID with the eBPF capability allowlist alone — no `privileged: true`, no `runAsUser: 0` crutch. Required for deployments on clusters with `pod-security.kubernetes.io/enforce: restricted` (and in practice `baseline`, which already bans privileged) plus custom ValidatingAdmissionPolicies that reject root containers outright (e.g. `sphinx-nonroot`).

The matching k8s-proxy chart changes — sidecar securityContext knobs, BTF/tracefs hostPath mounts, RunAsGroup mirror, sidecar-host-prep DaemonSet, NodeAffinity gate — ship in **keploy/k8s-proxy#444**. The matching enterprise image (which carries our internal patches + an identical `setcap` line) ships in a parallel keploy/enterprise PR.

| File | Change |
|---|---|
| `Dockerfile.runtime` + `Dockerfile` | `apt-get install libcap2-bin`, `setcap +eip` on `/app/keploy`, `useradd --uid 65532` (image default still root — no `USER` directive) |
| `entrypoint.sh` | Drop unconditional `sudo`. Branch on `id -u`: root → best-effort debugfs mount + direct exec; non-root → skip mount, exec via setcap'd binary |
| `pkg/platform/http/agent.go` | Demote `sysctl -w kernel.perf_event_paranoid=2` from `Error+return` to `Debug+continue` — EPERM on non-root is expected and non-fatal |

## Why

### File capabilities + `no_new_privs`

With `privileged: false` + `runAsUser: 65532`, Linux capabilities in the **bounding** set are NOT automatically copied to the **effective** set on `exec()`. The binary needs file capabilities via `setcap +eip` AND the pod needs `allowPrivilegeEscalation: true` so `no_new_privs` (set by `APE: false`) doesn't strip them. Without both, `bpf()` returns `EPERM` and the cilium/ebpf library misreports it as:

```
SYSCALL FAILURE: field K_bind4: program k_bind4: load BTF: BTF not supported (requires >= v4.18)
```

…even on a 6.x kernel. The `setcap` half lives in this PR; the `allowPrivilegeEscalation` half lives on the k8s-proxy side (`AgentAllowPrivilegeEscalation` knob, default `true` post-PR).

### Why `USER` is intentionally omitted

The image default stays root so docker-compose (`sudo docker run …`) keeps working unchanged. k8s deployments opt INTO non-root via `securityContext.runAsUser=65532`. The `useradd` seeds the keploy user/group so the `runAsUser` knob has a real `/etc/passwd` entry to point at; otherwise sudo and certain group-lookup callers crash with `you do not exist in the passwd database`.

### Why `CAP_SYS_ADMIN` is excluded from setcap

The data plane runs cleanly on `CAP_BPF + CAP_PERFMON + CAP_NET_ADMIN + CAP_SYS_PTRACE + CAP_SYS_RESOURCE` on kernels ≥ 5.8 (where `CAP_BPF` was split out from `CAP_SYS_ADMIN`). The host-prep DaemonSet on the k8s side carries `SYS_ADMIN` for the one-shot sysctl/bpffs-mount work, scoped to ~5s startup. The long-running sidecar never sees `SYS_ADMIN`.

### entrypoint.sh — why drop sudo

The previous `exec sudo -E "$@"` did sudo unconditionally even when already root. Redundant in docker-compose mode (already root) and crashes the k8s non-root mode (no NOPASSWD, no tty). `exec "$@"` replaces this shell PID with the agent so it receives `SIGTERM` directly from the container runtime — same signal delivery semantics as before, minus the sudo overhead.

### agent.go — why best-effort sysctl

The `sysctl -w kernel.perf_event_paranoid=2` call requires `CAP_SYS_ADMIN`. With the new capability-only profile (no SYS_ADMIN), the write fails with EPERM. That is NOT fatal — `CAP_PERFMON` alone is sufficient for tracepoint `perf_event_open()` at `paranoid <= 2`, which is the kernel default on every supported distro. The `return err` path was the load-bearing reason the agent crash-looped on non-root k8s pods before this PR — the sysctl write EPERM'd within milliseconds of startup, the agent exited 1, PostStartHook's 120s ready-file poll timed out, the pod cycled.

## Compatibility

| Scenario | Effect |
|---|---|
| Existing docker-compose (`sudo docker run …`, container UID 0) | ✅ Same as before — image default stays root, sudo just isn't called anymore (was redundant) |
| Existing k8s privileged sidecar (current default of k8s-proxy < #444) | ✅ Unchanged — `privileged: true` overrides everything, file caps are irrelevant |
| **New** k8s non-root sidecar (UID 65532 + cap allowlist + `APE: true`) | ✅ **Now possible** — file caps make bounding-set effective on exec; sysctl no longer crashes |

## Test plan

- [x] `go build ./...` clean
- [x] POSIX shell syntax check (`sh -n entrypoint.sh`)
- [x] **End-to-end on a kind cluster with a `sphinx-nonroot` ValidatingAdmissionPolicy enforcing non-root**: agent starts cleanly as UID 65532, reaches "Keploy Agent is ready", records 9 testcases across `GET/POST /students` with MongoDB wire-protocol traffic captured as mocks (full validation via keploy/k8s-proxy#444).
- [x] docker-compose regression sanity: `sudo docker run` on the host still works (UID 0 path of entrypoint.sh exercised — sudo no longer in entrypoint).
- [ ] Reviewer manual: confirm the bundled enterprise image (built from the matching internal Dockerfile change) carries the same setcap line — both must ship together.

## Related

- **keploy/k8s-proxy#444** — webhook + standalone-path + chart changes (sidecar securityContext knobs, BTF/tracefs mounts, RunAsGroup mirror, sidecar-host-prep DS, NodeAffinity gate)
- keploy/enterprise PR (private) — enterprise image carries the matching `setcap` + `entrypoint.sh` changes