### PR TITLE
ci(fuzzer): fetch fuzzer binaries from Azure instead of stale S3

### DIFF
--- a/.github/workflows/fuzzer_linux.yml
+++ b/.github/workflows/fuzzer_linux.yml
@@ -3,7 +3,14 @@ name: Fuzzer Tests On Linux
 on:
   workflow_call:
     secrets:
-      AWS_SECRET_ACCESS_KEY:
+      # Read-only SAS query string for the keployfuzzer Azure storage
+      # account (container `binaries`). The fuzzer release pipeline lives
+      # in keploy/go-fuzzers and publishes only to Azure since the
+      # Woodpecker migration (go-fuzzers#31), so the prior S3 fetch was
+      # reading a stale artifact that predated all recent fuzzer fixes
+      # (most notably go-fuzzers#47, which removed the Postgres fuzzer
+      # 17-minute WaitGroup deadlock).
+      AZURE_FUZZER_SAS_RO:
         required: true
       PRO_ACCESS_TOKEN:
         required: false
@@ -65,19 +72,16 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-access-key-id: ${{ vars.AWS_ACCESS_KEY_ID }}
-          aws-region: ${{ vars.AWS_DEFAULT_REGION }}
-
       - name: Download and Extract MySQL Fuzzer
         id: mysql_fuzzer
+        env:
+          AZURE_SAS_RO: ${{ secrets.AZURE_FUZZER_SAS_RO }}
         run: |
-          set -e
+          set -euo pipefail
           KEY="releases/mysql-fuzzer/latest/mysql-fuzzer-linux-amd64.tar.gz"
-          aws s3 cp "s3://${{ vars.AWS_S3_BUCKET }}/${KEY}" .
+          URL="https://keployfuzzer.blob.core.windows.net/binaries/${KEY}"
+          # SAS is appended at fetch time only — never logged.
+          curl -fsSL -o mysql-fuzzer-linux-amd64.tar.gz "${URL}?${AZURE_SAS_RO}"
           tar -xzf mysql-fuzzer-linux-amd64.tar.gz
           chmod +x ./mysql-fuzzer
           echo "path=$(realpath ./mysql-fuzzer)" >> $GITHUB_OUTPUT
@@ -136,26 +140,17 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-access-key-id: ${{ vars.AWS_ACCESS_KEY_ID }}
-          aws-region: ${{ vars.AWS_DEFAULT_REGION }}
-
-      - name: Install AWS CLI
-        run: |
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-          unzip awscliv2.zip
-          sudo ./aws/install --update
-
       - name: Download and Extract gRPC Fuzzer
         id: fuzzer
+        env:
+          AZURE_SAS_RO: ${{ secrets.AZURE_FUZZER_SAS_RO }}
         run: |
           set -euo pipefail
           KEY="releases/grpc-fuzzer/latest/grpc-fuzzer-linux-amd64.tar.gz"
-          echo "Downloading fuzzer from s3://${{ vars.AWS_S3_BUCKET }}/${KEY}"
-          aws s3 cp "s3://${{ vars.AWS_S3_BUCKET }}/${KEY}" .
+          URL="https://keployfuzzer.blob.core.windows.net/binaries/${KEY}"
+          echo "Downloading fuzzer from ${URL}"
+          # SAS is appended at fetch time only — never logged.
+          curl -fsSL -o grpc-fuzzer-linux-amd64.tar.gz "${URL}?${AZURE_SAS_RO}"
           tar -xzf grpc-fuzzer-linux-amd64.tar.gz
           chmod +x ./client ./server
           echo "client=$(realpath ./client)" >> $GITHUB_OUTPUT
@@ -217,25 +212,16 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-access-key-id: ${{ vars.AWS_ACCESS_KEY_ID }}
-          aws-region: ${{ vars.AWS_DEFAULT_REGION }}
-      
-      - name: Install AWS CLI
-        run: |
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-          unzip awscliv2.zip
-          sudo ./aws/install --update
-
       - name: Download and Extract Postgres Fuzzer
         id: postgres_fuzzer
+        env:
+          AZURE_SAS_RO: ${{ secrets.AZURE_FUZZER_SAS_RO }}
         run: |
-          set -e
+          set -euo pipefail
           KEY="releases/postgres-fuzzer/latest/postgres-fuzzer-linux-amd64.tar.gz"
-          aws s3 cp "s3://${{ vars.AWS_S3_BUCKET }}/${KEY}" .
+          URL="https://keployfuzzer.blob.core.windows.net/binaries/${KEY}"
+          # SAS is appended at fetch time only — never logged.
+          curl -fsSL -o postgres-fuzzer-linux-amd64.tar.gz "${URL}?${AZURE_SAS_RO}"
           tar -xzf postgres-fuzzer-linux-amd64.tar.gz
           chmod +x ./postgres-fuzzer
           echo "path=$(realpath ./postgres-fuzzer)" >> $GITHUB_OUTPUT
@@ -308,19 +294,16 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-access-key-id: ${{ vars.AWS_ACCESS_KEY_ID }}
-          aws-region: ${{ vars.AWS_DEFAULT_REGION }}
-
       - name: Download and Extract Mongo Fuzzer
         id: mongo_fuzzer
+        env:
+          AZURE_SAS_RO: ${{ secrets.AZURE_FUZZER_SAS_RO }}
         run: |
-          set -e
+          set -euo pipefail
           KEY="releases/mongo-fuzzer/latest/mongo-fuzzer-linux-amd64.tar.gz"
-          aws s3 cp "s3://${{ vars.AWS_S3_BUCKET }}/${KEY}" .
+          URL="https://keployfuzzer.blob.core.windows.net/binaries/${KEY}"
+          # SAS is appended at fetch time only — never logged.
+          curl -fsSL -o mongo-fuzzer-linux-amd64.tar.gz "${URL}?${AZURE_SAS_RO}"
           tar -xzf mongo-fuzzer-linux-amd64.tar.gz
           chmod +x ./mongo-fuzzer
           echo "path=$(realpath ./mongo-fuzzer)" >> $GITHUB_OUTPUT

--- a/.github/workflows/prepare_and_run.yml
+++ b/.github/workflows/prepare_and_run.yml
@@ -709,7 +709,7 @@ jobs:
     needs: [build-and-upload, upload-latest]
     uses: ./.github/workflows/fuzzer_linux.yml
     secrets:
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AZURE_FUZZER_SAS_RO: ${{ secrets.AZURE_FUZZER_SAS_RO }}
       PRO_ACCESS_TOKEN: ${{ secrets.PRO_ACCESS_TOKEN }}
   run_grpc_linux:
     needs: [build-and-upload, upload-latest]

--- a/.github/workflows/prepare_and_run_integrations.yml
+++ b/.github/workflows/prepare_and_run_integrations.yml
@@ -95,4 +95,4 @@ jobs:
       runner: ${{ inputs.runner }}
       jobs-to-run: 'postgres_fuzzer,grpc_fuzzer'
     secrets:
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AZURE_FUZZER_SAS_RO: ${{ secrets.AZURE_FUZZER_SAS_RO }}


### PR DESCRIPTION
## Describe the changes that are made

Switches the four fuzzer-binary download steps in `fuzzer_linux.yml` (mysql, grpc, postgres, mongo) from `aws s3 cp s3://fuzzers/...` to `curl` against Azure Blob Storage (`keployfuzzer/binaries/releases/<X>/latest/`). Removes the now-dead `Configure AWS Credentials` and `Install AWS CLI` steps. Renames the `workflow_call` secret from `AWS_SECRET_ACCESS_KEY` to `AZURE_FUZZER_SAS_RO` and updates both callers (`prepare_and_run.yml`, `prepare_and_run_integrations.yml`) to match.

### Why

Nothing publishes to `s3://fuzzers/releases/<X>/latest/` any more. The fuzzer release pipeline lives in `keploy/go-fuzzers` and was migrated from GitHub Actions to Woodpecker in [go-fuzzers#31](https://github.com/keploy/go-fuzzers/pull/31). The Woodpecker `release-*.yml` files publish exclusively to Azure (same `releases/<X>/{<version>,latest}/` key layout, just on the `keployfuzzer` storage account / `binaries` container). I grepped every keploy repo in our workspace — no `aws s3 cp <local> s3://fuzzers/...` upload command exists anywhere. The S3 bucket has no current publisher.

Net effect: every fuzzer job in this workflow has been running the last binary written by the pre-Woodpecker GHA pipeline, which predates every fuzzer fix that has landed since. The most painful symptom is PR #4063's postgres fuzzer:

```
11:01:27  main.go:438: Gracefully closing 4 sessions...
11:01:27  main.go:439: Waiting for in-flight queries to complete...
11:12:40  ##[error]The operation was canceled.
```

That's exactly the 11-minute hang [go-fuzzers#47](https://github.com/keploy/go-fuzzers/pull/47) (`fix(postgres): make fuzzer deterministic and panic-safe`) was specifically written to remove — `activeQueries.Add(1)/Done()` not paired by `defer`, pgx panics inside `Rows.Next` from mock/live row-shape mismatch, `Done` never runs, the deferred `cleanupSessions.Wait()` blocks forever, GHA step timeout kills it. #47 is on go-fuzzers `main` but the binary CI runs doesn't have it.

### Diff shape

```diff
- aws s3 cp "s3://${{ vars.AWS_S3_BUCKET }}/${KEY}" .
+ URL="https://keployfuzzer.blob.core.windows.net/binaries/${KEY}"
+ curl -fsSL -o <tarball> "${URL}?${AZURE_SAS_RO}"
```

The SAS token is passed via a step-scoped `env:` so GitHub's secret-masking redacts it in any unexpected log output; `curl -fsSL` doesn't echo the URL on failure either.

## Links & References

**Closes:** NA — repairs CI, not tracked by an issue.

### 🔗 Related PRs
- [keploy/go-fuzzers#47](https://github.com/keploy/go-fuzzers/pull/47) (the fuzzer fix this PR delivers to CI)
- [keploy/go-fuzzers#48](https://github.com/keploy/go-fuzzers/pull/48), [#49](https://github.com/keploy/go-fuzzers/pull/49), [#50](https://github.com/keploy/go-fuzzers/pull/50) (unblock the Woodpecker release pipeline so future fuzzer builds actually reach Azure)

### 🐞 Related Issues
- NA

### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [x] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed — this **is** the e2e pipeline configuration. The PR self-verifies the next time `prepare_and_run.yml` runs; if `AZURE_FUZZER_SAS_RO` is wired up correctly and the Azure tarball exists, the `Download and Extract <X> Fuzzer` step completes in seconds, and the postgres lane in particular should now exit cleanly instead of hanging for 11 min.

## Added comments for hard-to-understand areas?
- [x] 👍 yes — inline block comment on the new `AZURE_FUZZER_SAS_RO` secret declaration explaining the staleness root cause and the comment in each curl step documenting that the SAS is appended at fetch time only.

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?

**Operational prerequisite (must be done before merge, or the very next fuzzer run will fail at the `curl` step):**

> Add a new repo secret named `AZURE_FUZZER_SAS_RO` to `keploy/keploy`. Its value is the SAS query string (no leading `?`) for read-only access to the `keployfuzzer` storage account's `binaries` container. The matching read-write SAS already used by the publisher side in `keploy/go-fuzzers` is `AZURE_FUZZER_SAS_RW` (Woodpecker secret); this is its read-only GHA counterpart. Mint a `Read, List` SAS scoped to the `binaries` container (or to the whole account if simpler) with whatever expiry policy the org prefers.

Once the secret exists, no other action is needed — the next fuzzer matrix run will exercise all four download steps against Azure.

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?

The cancelled postgres fuzzer job from PR #4063 ([run 26389740969 / job 77700055821](https://github.com/keploy/keploy/actions/runs/26389740969/job/77700055821?pr=4063)):

```
2026-05-25T10:59:49Z  download: s3://fuzzers/releases/postgres-fuzzer/latest/postgres-fuzzer-linux-amd64.tar.gz
2026-05-25T11:00:05Z  [postgres-fuzzer] 🚀 Start PG fuzz: seed=42 ops=3000 maxSessions=4 fanout=10%
2026-05-25T11:01:27Z  [postgres-fuzzer] Gracefully closing 4 sessions...
2026-05-25T11:01:27Z  [postgres-fuzzer] Waiting for in-flight queries to complete...
                      ... 11 minute silence ...
2026-05-25T11:12:40Z  ##[error]The operation was canceled.
2026-05-25T11:12:41Z  Terminate orphan process: pid (4930) (postgres-fuzzer)
```

The keploy(agent) logs in the same run show hundreds of `transactional: no invocation matched` errors immediately before the hang, which is the mock/live row-shape mismatch path that triggers the pgx panic inside `Rows.Next` that go-fuzzers#47's commit message describes.

## Follow-up not done here

`enterprise/.woodpecker/fuzzer-linux.yml` and `enterprise/.woodpecker/static-dedup-fuzzer-linux.yml` pull redis-fuzzer, grpc-fuzzer, and static-dedup-fuzzer from the same dead `s3://fuzzers/...` bucket and have the same staleness problem. Scoped this PR to `keploy/keploy` only; happy to follow up with a matching enterprise PR.