### PR TITLE
fix(mysql/replay): synthesize OK for unmocked COM_STMT_RESET

### DIFF
--- a/pkg/agent/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match.go
@@ -221,6 +221,7 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 		sCOM_DEBUG      = mysql.CommandStatusToString(mysql.COM_DEBUG)
 		sCOM_PING       = mysql.CommandStatusToString(mysql.COM_PING)
 		sCOM_RESET_CONN = mysql.CommandStatusToString(mysql.COM_RESET_CONNECTION)
+		sCOM_STMT_RESET = mysql.CommandStatusToString(mysql.COM_STMT_RESET)
 	)
 
 	// Fast path: QUIT may have no mock
@@ -523,6 +524,47 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 					return generic, true, "", "", nil
 				}
 			}
+		}
+
+		// COM_STMT_RESET clears the cursor / long-data state of a server
+		// prepared statement and is defined to return an OK packet on
+		// success (ERR only if the statement ID is unknown). Connector/J
+		// emits it opportunistically before re-executing a
+		// ServerPreparedStatement when it suspects lingering state — a
+		// path that the record run often does not exercise because the
+		// recorded driver is single-tenant. Without a mock we used to
+		// drop the connection here, which surfaces to the client as
+		// SQLSTATE 08S01 (CommunicationsException). Since the packet is
+		// stateless from the mock's perspective, synthesizing an OK is
+		// correct protocol behavior.
+		if req.Header.Type == sCOM_STMT_RESET {
+			stmtID := uint32(0)
+			if rp, ok := req.Message.(*mysql.StmtResetPacket); ok {
+				stmtID = rp.StatementID
+			}
+			seq := byte(1)
+			if req.PacketBundle.Header != nil && req.PacketBundle.Header.Header != nil {
+				seq = req.PacketBundle.Header.Header.SequenceID + 1
+			}
+			generic := &mysql.Response{
+				PacketBundle: mysql.PacketBundle{
+					Header: &mysql.PacketInfo{
+						Header: &mysql.Header{PayloadLength: 7, SequenceID: seq},
+						Type:   mysql.StatusToString(mysql.OK),
+					},
+					Message: &mysql.OKPacket{
+						Header:       mysql.OK,
+						AffectedRows: 0,
+						LastInsertID: 0,
+						StatusFlags:  0x0002,
+						Warnings:     0,
+						Info:         "",
+					},
+				},
+			}
+			logger.Debug("Returning synthetic OK for unmocked COM_STMT_RESET",
+				zap.Uint32("statement_id", stmtID))
+			return generic, true, "", "", nil
 		}
 
 		actualQuery := ""


### PR DESCRIPTION
ServerPreparedStatement re-execution under Connector/J 8.x calls ServerPreparedQuery.prepareExecutePacket(), which opportunistically emits COM_STMT_RESET to clear cursor / long-data state before sending the next COM_STMT_EXECUTE. The record run is typically single-tenant and the driver doesn't think a reset is needed, so no recorded mock exists for that packet. On the second+ replay execution of the same prepared statement the driver decides a reset IS needed; the replayer then walked the entire mock pool without finding a match, fell through the COM_QUERY-only synthetic-OK fallback (match.go:478), and tripped query.go:136 ("Connection closing due to no matching mock found"), tearing down the TCP connection.

To the application that surfaces as:

  CJCommunicationsException: Communications link failure
    SQLSTATE 08S01
    Caused by: java.io.IOException: Socket is closed.

HikariCP marks the connection broken; Spring's JpaTransactionManager then tries to rollback on that already-broken connection and fails with "Unable to rollback against JDBC Connection" — which is what the HTTP 500 body shows in the failing replay (the SET autocommit=0/1 lines that appear alongside are just HikariCP opening a fresh connection to replace the broken one, not the cause).

Fix is local to matchCommand: declare sCOM_STMT_RESET, and after the existing COM_QUERY graceful-OK block, add a parallel branch that returns a synthetic mysql.OKPacket for unmocked COM_STMT_RESET. The packet is stateless from the mock's perspective — the server's reply is defined to be OK on success and ERR only for an unknown statement ID — so synthesizing OK is correct protocol behavior and avoids the connection-close cascade. The statement_id is preserved in the debug log for traceability.

Repro path (Spring Boot 3.x + Hibernate 6.x + HikariCP + mysql-connector-j 8.2 against TiDB on port 4000):
  1. Record a flow that executes the same @Query repository method.
  2. Replay; first invocation passes, subsequent invocations of the same prepared statement hit the reset path and fail with 500 "Unable to rollback against JDBC Connection" + agent-log ERROR "Connection closing due to no matching mock found" with request_type=COM_STMT_RESET.

## Describe the changes that are made
- 

## Links & References

**Closes:** #[issue number that will be closed through this PR]
- NA (if very small change like typo, linting, etc.)

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [ ] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

## Self Review done?
- [ ] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [ ] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [ ] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [ ] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?