### PR TITLE
feat(test): fail tests on unmatched outbound mocks (FailOnUnmatchedOutbound)

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -383,6 +383,15 @@ func (c *CmdConfigurator) AddUncommonFlags(cmd *cobra.Command) {
 		cmd.Flags().Bool("mocking", true, "enable/disable mocking for the testcases")
 		cmd.Flags().Bool("disable-line-coverage", c.cfg.Test.DisableLineCoverage, "Disable line coverage generation.")
 		cmd.Flags().Bool("must-pass", c.cfg.Test.MustPass, "enforces that the tests must pass, if it doesn't, remove failing testcases")
+		// fail-on-unmatched-outbound flips a test from PASS to FAIL when
+		// any outbound dependency call could not be matched against a
+		// recorded mock during that test, regardless of whether the
+		// response-oracle comparison succeeded. This catches false
+		// positives where a constant response body (e.g. {"status":"ok"})
+		// hides a broken async downstream interaction (Pulsar/Kafka
+		// publish, fire-and-forget outbox) whose mismatch would otherwise
+		// only surface as a debug log line.
+		cmd.Flags().Bool("fail-on-unmatched-outbound", c.cfg.Test.FailOnUnmatchedOutbound, "Mark a test as FAILED if any outbound dependency call (Pulsar, Kafka, gRPC, generic TCP, etc.) went unmatched during its execution, even if the response oracle would otherwise pass. Default false.")
 		cmd.Flags().Uint32Var(&c.cfg.Test.MaxFailAttempts, "max-fail-attempts", 5, "maximum number of testset failure that can be allowed during must-pass mode")
 		cmd.Flags().Uint32Var(&c.cfg.Test.MaxFlakyChecks, "flaky-check-retry", 1, "maximum number of retries to check for flakiness")
 		cmd.Flags().Bool("compare-all", false, "Compare all response body types including non-JSON (default: false, only JSON bodies are compared)")
@@ -467,6 +476,7 @@ func aliasNormalizeFunc(_ *pflag.FlagSet, name string) pflag.NormalizedName {
 		"capturePackets":            "capture-packets",
 		"opportunisticTlsIntercept": "opportunistic-tls-intercept",
 		"keepAppAlive":              "keep-app-alive",
+		"failOnUnmatchedOutbound":   "fail-on-unmatched-outbound",
 	}
 
 	if newName, ok := flagNameMapping[name]; ok {

--- a/config/config.go
+++ b/config/config.go
@@ -199,6 +199,7 @@ type Test struct {
 	DisableLineCoverage         bool                `json:"disableLineCoverage" yaml:"disableLineCoverage" mapstructure:"disableLineCoverage"`
 	UpdateTemplate              bool                `json:"updateTemplate" yaml:"updateTemplate" mapstructure:"updateTemplate"`
 	MustPass                    bool                `json:"mustPass" yaml:"mustPass" mapstructure:"mustPass"`
+	FailOnUnmatchedOutbound     bool                `json:"failOnUnmatchedOutbound" yaml:"failOnUnmatchedOutbound" mapstructure:"failOnUnmatchedOutbound"` // When true, a test is marked FAILED if any outbound dependency call went unmatched during its execution, even if the response oracle would otherwise pass. Prevents false positives where a constant response body (e.g. {"status":"ok"}) masks broken downstream interactions like async Pulsar/Kafka publishes.
 	MaxFailAttempts             uint32              `json:"maxFailAttempts" yaml:"maxFailAttempts" mapstructure:"maxFailAttempts"`
 	MaxFlakyChecks              uint32              `json:"maxFlakyChecks" yaml:"maxFlakyChecks" mapstructure:"maxFlakyChecks"`
 	ProtoFile                   string              `json:"protoFile" yaml:"protoFile" mapstructure:"protoFile"`

--- a/config/default.go
+++ b/config/default.go
@@ -66,6 +66,15 @@ test:
   disableLineCoverage: false
   updateTemplate: false
   mustPass: false
+  # failOnUnmatchedOutbound flips a test from PASS to FAIL when any
+  # outbound dependency call (Pulsar, Kafka, gRPC, generic TCP, etc.)
+  # could not be matched against a recorded mock during the test,
+  # regardless of the HTTP/response oracle result. Default false to
+  # preserve historical behaviour. Turn on for services where the
+  # response body is a constant ack and the real assertion lives in
+  # what the service published downstream (async outbox patterns,
+  # fire-and-forget messaging).
+  failOnUnmatchedOutbound: false
   maxFailAttempts: 5
   maxFlakyChecks: 1
   protoFile: ""

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -2060,7 +2060,17 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 			}
 			logger.Debug("successfully recorded outgoing message", zap.String("ParserType", string(parserType)))
 		case models.MODE_TEST:
-			err := matchedParser.MockOutgoing(parserCtx, srcConn, dstCfg, m, outgoingOpts)
+			// Inject the proxy's central error channel into the context so
+			// long-lived parsers (Pulsar today; Kafka in the future) that
+			// multiplex many logical streams over a single TCP connection
+			// can publish mid-stream mock-mismatch events via
+			// models.ReportMockMismatchOnChannel without having to return
+			// from MockOutgoing. Returning would tear down every stream
+			// sharing the connection — fine for HTTP, catastrophic for
+			// Pulsar where ~15 partition producers ride the same socket.
+			// Cast to a send-only channel; parsers must not read from it.
+			mockOutgoingCtx := context.WithValue(parserCtx, models.ProxyErrChannelKey, (chan<- error)(p.errChannel))
+			err := matchedParser.MockOutgoing(mockOutgoingCtx, srcConn, dstCfg, m, outgoingOpts)
 			if err != nil && err != io.EOF && !errors.Is(err, context.Canceled) && !isNetworkClosedErr(err) {
 				utils.LogError(logger, err, "failed to mock the outgoing message")
 				// Send specific error type to error channel for external monitoring

--- a/pkg/models/const.go
+++ b/pkg/models/const.go
@@ -185,6 +185,23 @@ type contextKey string
 
 const ErrGroupKey contextKey = "errGroup"
 const ClientConnectionIDKey contextKey = "clientConnectionId"
+
+// ProxyErrChannelKey holds a chan<- error that integration parsers can
+// use to publish mid-stream events (e.g. unmatched-mock mismatches) to
+// the proxy's central error channel without ending the MockOutgoing
+// call. Today, the only way a parser can report a mock mismatch is by
+// returning the error from MockOutgoing — which terminates the
+// connection. That's fine for HTTP (one request/response per
+// connection) but unworkable for long-lived multi-stream protocols
+// like Pulsar where a single connection multiplexes many partition
+// producers; killing the connection on the first miss cascades into
+// dozens of dependent failures and masks the original signal. Parsers
+// pull the channel from this context key and use models.ReportMock-
+// MismatchOnChannel to publish a ParserError{ErrMockNotFound, ...}
+// without disturbing the stream. monitorProxyErrors in
+// pkg/service/replay/replay.go consumes the same channel and attributes
+// each event to the currently-running test case.
+const ProxyErrChannelKey contextKey = "proxyErrChannel"
 const DestConnectionIDKey contextKey = "destConnectionId"
 const PostTLSModeKey contextKey = "postTLSMode"
 const TLSHandshakeStoreKey contextKey = "tlsHandshakeStore"

--- a/pkg/models/errors.go
+++ b/pkg/models/errors.go
@@ -1,6 +1,9 @@
 package models
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 type AppError struct {
 	AppErrorType AppErrorType
@@ -76,4 +79,40 @@ func NewMockMismatchError(err error, report *MockMismatchReport) error {
 		return err
 	}
 	return &mockMismatchError{err: err, report: report}
+}
+
+// ReportMockMismatchOnChannel publishes an ErrMockNotFound ParserError
+// onto the proxy error channel that the caller passed in via context
+// under ProxyErrChannelKey. Used by long-lived parsers (Pulsar today,
+// Kafka tomorrow) that multiplex many logical streams over a single
+// connection and therefore cannot signal a mock miss by returning
+// from MockOutgoing — doing so would tear down every other stream
+// sharing the connection. The function is a no-op when the context
+// carries no channel (e.g. during unit tests that exercise the parser
+// without the proxy harness) so call sites stay branch-free.
+//
+// The returned bool tells the caller whether the event was actually
+// published. A non-blocking send is used; if the buffered channel is
+// full the event is dropped (matches Proxy.SendError behavior — better
+// to lose a single mismatch event than to wedge the parser goroutine
+// when the consumer is slow).
+func ReportMockMismatchOnChannel(ctx context.Context, baseErr error, report *MockMismatchReport) bool {
+	if ctx == nil || report == nil {
+		return false
+	}
+	ch, ok := ctx.Value(ProxyErrChannelKey).(chan<- error)
+	if !ok || ch == nil {
+		return false
+	}
+	parserErr := ParserError{
+		ParserErrorType: ErrMockNotFound,
+		Err:             baseErr,
+		MismatchReport:  report,
+	}
+	select {
+	case ch <- parserErr:
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1793,6 +1793,33 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 				}
 			}
 
+			// failOnUnmatchedOutbound: even when the response oracle would
+			// otherwise pass, flip the verdict to FAILED if any outbound
+			// dependency mock-mismatch was reported during this test.
+			// Catches false positives where a constant response body
+			// (e.g. {"status":"ok"}) masks broken async/fire-and-forget
+			// downstream interactions whose mismatch would otherwise only
+			// surface as a debug log. Only consults the in-process
+			// mock-mismatch failure store; non-instrument (k8s-proxy /
+			// remote agent) routing of mismatches is handled by the
+			// existing GetMockErrors path further down and falls under
+			// follow-up work.
+			if testPass && r.config.Test.FailOnUnmatchedOutbound {
+				unmatchedCount := 0
+				for _, f := range r.mockMismatchFailures.GetFailuresForTestCase(testSetID, testCase.Name) {
+					if f.MismatchReport != nil {
+						unmatchedCount++
+					}
+				}
+				if unmatchedCount > 0 {
+					r.logger.Warn("failOnUnmatchedOutbound: flipping test verdict from PASS to FAIL due to unmatched outbound dependency calls",
+						zap.String("testcase", testCase.Name),
+						zap.String("testset", testSetID),
+						zap.Int("unmatchedOutboundCount", unmatchedCount))
+					testPass = false
+				}
+			}
+
 			if !testPass {
 				r.logger.Info("result", zap.String("testcase id", models.HighlightFailingString(testCase.Name)), zap.String("testset id", models.HighlightFailingString(testSetID)), zap.String("passed", models.HighlightFailingString(testPass)))
 			} else {


### PR DESCRIPTION
## Summary

Adds `test.failOnUnmatchedOutbound` (default false) plus the matching `--fail-on-unmatched-outbound` CLI flag. When enabled, the replay verdict flips from PASS to FAIL if any parser reported a mock-mismatch during the test, regardless of how the response oracle would have ruled.

Closes a false-positive class observed at customer Flipkart on \`POST /shipments/create\`: the HTTP response body is a constant \`\"Shipment created successfully\"\` and the real work (publish to Pulsar via TOSS outbox) happens asynchronously after the response returns. Today the test reliably reports PASS even when the Pulsar publish path is completely broken — the only signal is a debug log line that nothing else reads.

## Why

- Response-oracle-only verdict is insufficient for services that ack synchronously and write asynchronously (outbox patterns, fire-and-forget messaging, partition producers).
- Today, outbound mock mismatches are tracked in \`TestResult.FailureInfo.UnmatchedCalls\` for *failed* tests only — never for *passing* tests, which is the case we're trying to catch.
- This change keeps the default behavior identical (flag is off) so existing recordings don't suddenly flip status; users opt in for stricter assertions.

## What changes

- **\`config/config.go\`** + **\`config/default.go\`** — new \`FailOnUnmatchedOutbound bool\` on the \`Test\` struct.
- **\`cli/provider/cmd.go\`** — \`--fail-on-unmatched-outbound\` flag + camelCase alias.
- **\`pkg/service/replay/replay.go\`** — before the result-log + status cascade, if the flag is on and there are mismatch failures with a \`MismatchReport\` for this test case, flip \`testPass\` to false. Warn log explains the flip.
- **\`pkg/models/const.go\`** — new \`ProxyErrChannelKey contextKey\` for parsers that need to publish mid-stream events.
- **\`pkg/models/errors.go\`** — new \`ReportMockMismatchOnChannel(ctx, baseErr, report)\` helper; non-blocking send onto the proxy error channel injected via context.
- **\`pkg/agent/proxy/proxy.go\`** — at the MockOutgoing dispatch site, inject the proxy's \`errChannel\` into context as a send-only channel under \`ProxyErrChannelKey\`.

## Why a new context-key + helper?

Long-lived multi-stream parsers (Pulsar today; Kafka coming) cannot signal a mock miss by returning from \`MockOutgoing\` — that would tear down every other stream sharing the connection (Pulsar typically multiplexes ~15 partition producers on a single socket). The existing channel mechanism is one error per connection, returned from \`MockOutgoing\`. We need many-events-per-connection without ending the stream. A context-injected write-only channel + helper does this without changing the \`Integrations\` interface.

Existing HTTP/MySQL parsers are unchanged — they still return from \`MockOutgoing\` because that matches their lifecycle (one request per connection).

## Companion enterprise PR

The Pulsar replayer in \`keploy/enterprise\` calls \`ReportMockMismatchOnChannel\` at its synthetic-fallback site, plus a session-end summary. Enterprise PR will be opened separately and depends on this one landing first (with the OSS dependency bump).

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./pkg/models/... ./pkg/service/replay/...\` pass
- [ ] Verify with enterprise PR end-to-end: Pulsar mismatch event → test FAIL when flag is on, PASS when flag is off
- [ ] Verify HTTP/MySQL behavior unchanged (flag off): existing tests still pass; flag on: existing failing tests still fail (no new false positives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)