### PR TITLE
fix: pay --keep-app-alive startup delay when leading test-set is empty

### DIFF
--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -158,13 +158,21 @@ type Replayer struct {
 	instrument      bool
 	isLastTestSet   bool
 	isLastTestCase  bool
-	// isFirstTestSet mirrors isLastTestSet — true while the test-set
-	// about to run is the first one of the current replay run. Read
-	// by the waitForAppReady gate so --delay applies only to the first
-	// test-set when --keep-app-alive is set (subsequent test-sets
-	// inherit a warm app and would otherwise pay --delay seconds of
-	// dead time per boundary).
-	isFirstTestSet     bool
+	// appReadyWaitDone latches true the first time waitForAppReady
+	// actually completes a readiness wait during the current replay
+	// run. Read by the waitForAppReady gate so that, under
+	// --keep-app-alive, --delay (or a HealthURL poll) is paid exactly
+	// once — on the first test-set that reaches the wait — and skipped
+	// thereafter (subsequent test-sets inherit a warm app).
+	//
+	// Keyed on "did the wait actually run" rather than the test-set
+	// loop index: a leading empty/ignored test-set returns before the
+	// wait (see the len(testCases)==0 / ignored early-returns in
+	// RunTestSet), so an index-based "first test-set" flag would let
+	// that empty set consume the first-set status and the next set —
+	// the first one that actually fires requests — would skip the wait
+	// against an app that has not finished booting.
+	appReadyWaitDone   bool
 	runDomainSet       *telemetry.DomainSet // collects host domains across a test run for telemetry
 	testRunTestSets    []string             // all test set IDs for the current run (used by RunTestSet)
 	testRunID          string               // current test run ID (used by RunTestSet)
@@ -472,6 +480,10 @@ func (r *Replayer) Start(ctx context.Context) error {
 	r.testRunTestSets = testSets
 	r.testRunID = testRunID
 	r.firstRun = true
+	// Reset the readiness latch for this run so the first test-set that
+	// reaches waitForAppReady pays --delay (or the HealthURL poll), even
+	// if a prior run on this reused Replayer already set it.
+	r.appReadyWaitDone = false
 	for i, testSet := range testSets {
 		var backupCreated bool
 		testSetResult = false
@@ -499,12 +511,10 @@ func (r *Replayer) Start(ctx context.Context) error {
 		if i == len(testSets)-1 {
 			r.isLastTestSet = true
 		}
-		// Mirror of isLastTestSet but for the first-testset boundary.
-		// Set BEFORE the RunTestSet call so the waitForAppReady call
-		// sites in RunTestSet observe the right value. Reset only at
-		// the top of this iteration (so a flaky-retry attempt within
-		// the SAME iteration still observes the same value).
-		r.isFirstTestSet = (i == 0)
+		// The first-test-set readiness boundary is NOT tracked by loop
+		// index here (a leading empty/ignored test-set would consume it
+		// before the wait ever runs); it is latched in RunTestSet via
+		// r.appReadyWaitDone the first time waitForAppReady completes.
 
 		r.completeTestReportMu.RLock()
 		initTotal := r.totalTests
@@ -1172,25 +1182,31 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		// Prefers polling Test.HealthURL when set, otherwise falls back to the fixed --delay sleep.
 		//
 		// --keep-app-alive: the app was spawned ONCE in Start() and
-		// has already passed its readiness check during the first
-		// test-set; subsequent test-sets inherit the warm app, so
-		// paying --delay seconds (or another HealthURL poll round)
-		// per boundary is dead time. Skip when we're past the first
-		// test-set. The first test-set still runs the wait so the
-		// initial app startup can finish (build/boot/connect) before
-		// the first request fires.
+		// only needs its readiness wait paid once; subsequent test-sets
+		// inherit the warm app, so paying --delay seconds (or another
+		// HealthURL poll round) per boundary is dead time. Skip once the
+		// wait has actually completed. The first test-set that reaches
+		// here still runs the wait so the initial app startup can finish
+		// (build/boot/connect) before the first request fires.
 		//
-		// Gate keyed on `serveTest` (the parameter Start() computes
-		// as `effectiveKeepAlive`) rather than the raw config bool,
-		// so the skip ONLY arms when the one-shot spawn actually
-		// fired. If --keep-app-alive was set on a cmdType where the
-		// one-shot spawn was suppressed (cmdType == Empty / instrument
-		// off), serveTest will be false here and the readiness wait
-		// runs every test-set, matching the historical lifecycle.
-		if serveTest && !r.isFirstTestSet {
-			r.logger.Debug("--keep-app-alive: skipping waitForAppReady on post-first test-set; app already warm")
-		} else if !waitForAppReady(runTestSetCtx, r.logger, r.config) {
-			return models.TestSetStatusUserAbort, context.Canceled
+		// Gate keyed on `serveTest` (the parameter Start() computes as
+		// `effectiveKeepAlive`) AND on r.appReadyWaitDone — the latch set
+		// only after a wait completes — rather than on the test-set loop
+		// index. A leading empty/ignored test-set returns before this
+		// point (see the early-returns in RunTestSet) and so never sets
+		// the latch; the first test-set that actually fires requests
+		// therefore still pays the wait. If --keep-app-alive was set on a
+		// cmdType where the one-shot spawn was suppressed (cmdType ==
+		// Empty / instrument off), serveTest is false here and the
+		// readiness wait runs every test-set, matching the historical
+		// lifecycle.
+		if serveTest && r.appReadyWaitDone {
+			r.logger.Debug("--keep-app-alive: skipping waitForAppReady; app already warm")
+		} else {
+			if !waitForAppReady(runTestSetCtx, r.logger, r.config) {
+				return models.TestSetStatusUserAbort, context.Canceled
+			}
+			r.appReadyWaitDone = true
 		}
 	}
 
@@ -1340,13 +1356,17 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			// spawn in Start() also fires when KeepAppAlive is set
 			// AND cmdType is non-empty AND instrument is enabled.
 			// Gate keyed on `serveTest` (the Start()-computed
-			// effectiveKeepAlive predicate) — identical to the compose
-			// branch above — so the readiness skip arms only when the
-			// one-shot spawn actually fired.
-			if serveTest && !r.isFirstTestSet {
-				r.logger.Debug("--keep-app-alive: skipping waitForAppReady on post-first test-set; app already warm")
-			} else if !waitForAppReady(runTestSetCtx, r.logger, r.config) {
-				return models.TestSetStatusUserAbort, context.Canceled
+			// effectiveKeepAlive predicate) AND r.appReadyWaitDone —
+			// identical to the compose branch above — so the readiness
+			// wait is paid once on the first test-set that reaches it
+			// and skipped thereafter, regardless of leading empty sets.
+			if serveTest && r.appReadyWaitDone {
+				r.logger.Debug("--keep-app-alive: skipping waitForAppReady; app already warm")
+			} else {
+				if !waitForAppReady(runTestSetCtx, r.logger, r.config) {
+					return models.TestSetStatusUserAbort, context.Canceled
+				}
+				r.appReadyWaitDone = true
 			}
 
 		}


### PR DESCRIPTION
## Describe the changes that are made
Under `--keep-app-alive`, the startup readiness wait (`--delay`, or the `--health-url` poll) is supposed to be paid **once** — before the first request — so the user application has time to boot. The skip was gated on the test-set loop index:

```go
r.isFirstTestSet = (i == 0)
...
if serveTest && !r.isFirstTestSet { /* skip waitForAppReady */ }
```

But a test-set with **no test cases** (or one that is fully ignored) returns early from `RunTestSet` *before* `waitForAppReady` ever runs. When such a set sorts first, the next test-set — the first one that actually fires requests — sees `isFirstTestSet == false` and **skips the wait**, hammering an app that hasn't finished starting. Every request then fails with `connection reset by peer` / `EOF` and `ACTUAL STATUS 0`.

**Fix:** replace the index-based flag with an `appReadyWaitDone` latch that is set **only after `waitForAppReady` actually completes**. Empty/ignored leading test-sets return before the wait and never set the latch, so the first test-set that reaches the wait still pays the startup delay; subsequent sets skip it as intended (warm app). The latch is reset at the start of each run. Non `--keep-app-alive` runs (`serveTest == false`) are unchanged and still wait per test-set.

Touched: `pkg/service/replay/replay.go` (struct field + reset + both `waitForAppReady` gate sites — docker-compose and native/docker-run/docker-start).

## Links & References

**Closes:** NA
- NA (no tracking issue)

### 🔗 Related PRs
- Follow-up to #4204 (`feat(test): --keep-app-alive`)
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [x] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

Repro with a multi-test-set cloud replay where the **first (sorted) test-set is empty**:

1. `keploy cloud replay --app <app> --keep-app-alive --delay 40` against an app slow to boot (e.g. Express + Prisma + Postgres), with one empty leading test-set and others that have cases.
2. **Before:** first request fires ~2s after the container starts (the 40s delay is skipped); all tests fail with `connection reset by peer` / `EOF` (status 0).
3. **After:** ~40s elapse between `Starting Application` and the first `starting test for …`; tests run against a booted app.

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
Symptom (status 0 on every test because the app wasn't up yet):

```
INFO  Using stored delay from auto-replay config  {"delay": 40}
...
INFO  Starting Application
INFO  starting test for {"test case": "...", "test set": "...-whst9"}   # ~2s later, not 40s
ERROR failed to send testcase request to app {"error": "... read: connection reset by peer"}
EXPECT STATUS 201  |  ACTUAL STATUS 0
```

## Additional checklist:
- [x] Have you read the Contributing Guidelines on issues?
- [x] Have you followed the PR Semantics guide for naming this PR?
- [x] Have you followed the Branch Semantics guide for naming your branch?
