### PR TITLE
ci(java/mysql-dual-conn): exercise COM_STMT_RESET in record traffic

### DIFF
--- a/.github/workflows/test_workflow_scripts/java/mysql_dual_conn/java-linux.sh
+++ b/.github/workflows/test_workflow_scripts/java/mysql_dual_conn/java-linux.sh
@@ -89,6 +89,12 @@ send_request() {
   echo "=== Query both again (second round) ==="
   curl -sS http://localhost:8080/api/query-both || true
 
+  # Exercises the COM_STMT_RESET synthetic-OK fallback (keploy#4217).
+  # Re-executes a server-prepared statement 5 times on the same JDBC
+  # connection; Connector/J 8.x emits COM_STMT_RESET between executions.
+  echo "=== /api/oms/stmt-reset/5 (trigger COM_STMT_RESET) ==="
+  curl -sS http://localhost:8080/api/oms/stmt-reset/5 || true
+
   # Let keploy persist, then gracefully stop it
   sleep 10
   echo "$kp_pid Keploy PID"


### PR DESCRIPTION
## Describe the changes that are made
- Adds one `curl http://localhost:8080/api/oms/stmt-reset/5` inside the existing `mysql-dual-conn` record loop so the `java_linux` pipeline exercises the `COM_STMT_RESET` synthetic-OK fallback introduced in #4217.
- No other workflow change: the matrix entry, the JAR build, the dual-handshake assertions, and the replay/report check are all unchanged. The new traffic just lands inside `send_request` alongside the existing `/api/query-both`, `/api/oms`, `/api/camunda` calls.
- The sample-app endpoint itself (and the `useServerPrepStmts=true&cachePrepStmts=true&useCursorFetch=true` JDBC flags that make Connector/J 8.x emit `COM_STMT_RESET`) lives in keploy/samples-java#137 and must merge first.

## Links & References

**Closes:** NA

### 🔗 Related PRs
- #4217 — the `match.go` fix this script now exercises end-to-end.
- keploy/samples-java#137 — adds `GET /api/oms/stmt-reset/{n}` to the sample app (must merge before this PR's CI will pass).

### 🐞 Related Issues
- NA

### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [x] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [x] 👍 yes

This PR *is* the e2e wiring. The three existing compat-matrix cells (`record_latest_replay_build`, `record_build_replay_latest`, `record_build_replay_build`) will all now record + replay traffic that includes `COM_STMT_RESET` packets. A regression in the synthetic-OK fallback would surface as either a replay-time `Connection closing due to no matching mock found` error or a failed test report.

## Added comments for hard-to-understand areas?
- [x] 👍 yes — the inline comment in `send_request()` points at #4217 and explains why `useServerPrepStmts` + `useCursorFetch` are required for Connector/J 8.x to emit `COM_STMT_RESET`.

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

```bash
# After keploy/samples-java#137 merges:
RECORD_BIN=/abs/path/to/keploy/out/build/keploy \
REPLAY_BIN=/abs/path/to/keploy/out/build/keploy \
GITHUB_WORKSPACE=/abs/path/to/keploy \
bash -x \$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/java/mysql_dual_conn/java-linux.sh
```

Expected: record log shows the new `=== /api/oms/stmt-reset/5 ===` section; replay produces test reports with `status: PASSED` for every test-set; no `Connection closing due to no matching mock found` lines in `test_logs.txt`.

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA

## Additional checklist:
- [x] Have you read the Contributing Guidelines on issues?
- [x] Have you followed the PR Semantics guide for naming this PR?
- [x] Have you followed the Branch Semantics guide for naming your branch?