### PR TITLE
fix: mock window resolve range race fix

### DIFF
--- a/.github/workflows/test_workflow_scripts/sample-tls-pcap.sh
+++ b/.github/workflows/test_workflow_scripts/sample-tls-pcap.sh
@@ -239,10 +239,25 @@ if ! wait_for_http "http://localhost:8080/" 120; then
   false
 fi
 
-# HTTP routes — outbound TLS to public APIs
-curl -fsS http://localhost:8080/quote >/dev/null
-curl -fsS "http://localhost:8080/echo?msg=ci-${MODE_NAME}-1" >/dev/null
-curl -fsS "http://localhost:8080/echo?msg=ci-${MODE_NAME}-2" >/dev/null
+# HTTP routes — outbound TLS to public APIs.
+#
+# /quote and /echo proxy to live public services (api.github.com and
+# httpbin.org). httpbin in particular is frequently overloaded and
+# returns a transient 5xx, which the sample app forwards verbatim
+# (/echo mirrors the upstream status code) — turning an unrelated
+# upstream blip into a spurious e2e failure that has nothing to do
+# with keploy's TLS capture. Retry the transient codes: `curl --retry`
+# covers timeouts and 408/429/5xx responses, bounded by
+# --retry-max-time. A genuine keploy-side break (the proxy dropping
+# the outbound TLS connection → the app returns 502) still surfaces
+# once the retry budget is exhausted.
+retry_curl() {
+  curl -fsS --retry 5 --retry-delay 3 --retry-max-time 60 --retry-all-errors "$@"
+}
+
+retry_curl http://localhost:8080/quote >/dev/null
+retry_curl "http://localhost:8080/echo?msg=ci-${MODE_NAME}-1" >/dev/null
+retry_curl "http://localhost:8080/echo?msg=ci-${MODE_NAME}-2" >/dev/null
 echo "good! HTTP routes returned"
 
 # MySQL — POST insert then GET read

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -1038,6 +1038,31 @@ func (p *Proxy) start(ctx context.Context, readyChan chan<- error) error {
 
 	clientConnCtx, clientConnCancel := context.WithCancel(ctx)
 	clientConnErrGrp, _ := errgroup.WithContext(clientConnCtx)
+
+	// Periodically drain attributable buffered mocks WHILE recording is
+	// live. The request-driven drains (ResolveRange / DeleteMocksStrictlyBefore)
+	// can't reach a per-test mock that lands after the final request's HTTP
+	// window closed — e.g. a multi-MB Mongo document still decoding when its
+	// response was captured. Without this, such a mock waits in the buffer
+	// until shutdown, where the cancelled recorder ctx makes the relay, the
+	// consumer, and InsertMock all drop it. Ticking here persists it through
+	// the healthy write path. Stops when clientConnCtx is cancelled (the
+	// shutdown defer's clientConnCancel), before CloseOutChan.
+	go func() {
+		ticker := time.NewTicker(1 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-clientConnCtx.Done():
+				return
+			case <-ticker.C:
+				if mgr := syncMock.Get(); mgr != nil {
+					mgr.FlushOwnedWindows()
+				}
+			}
+		}
+	}()
+
 	defer func() {
 		clientConnCancel()
 

--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -545,9 +545,7 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 	if len(m.recentWindows) > 0 {
 		kept := m.recentWindows[:0]
 		for _, w := range m.recentWindows {
-			// if !w.end.Before(cutoffTime) {
 			kept = append(kept, w)
-			// }
 		}
 		m.recentWindows = kept
 	}

--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -13,6 +13,23 @@ import (
 const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 const defaultMockBufferCapacity = 100
 
+// maxRecentWindows bounds the recently-resolved-window ring (see
+// SyncMockManager.recentWindows). The ring is also time-pruned to the
+// 7 s staleness horizon, so this cap only matters under a burst of very
+// short test windows; 256 covers far more than the ~7 s of history the
+// staleness cutoff keeps reachable, while staying O(1) memory.
+const maxRecentWindows = 256
+
+// resolvedWindow is one already-resolved per-test window retained so a
+// late-arriving mock (decoded after the window closed) can still be
+// attributed to the test that actually owns its ReqTimestampMock.
+type resolvedWindow struct {
+	start    time.Time
+	end      time.Time
+	testName string
+	mapping  bool
+}
+
 // nopLogger is the fallback when no logger has been installed via
 // SetLogger. zap.L() is NOT safe here — it returns a Nop until the
 // host process has called zap.ReplaceGlobals, and syncMock is a
@@ -29,12 +46,32 @@ func generateRandomString(n int) string {
 }
 
 type SyncMockManager struct {
-	// mu guards buffer, firstReqSeen, memoryPause, mappingChan.
+	// mu guards buffer, firstReqSeen, memoryPause, mappingChan,
+	// recentWindows.
 	mu           sync.Mutex
 	buffer       []*models.Mock
 	mappingChan  chan<- models.TestMockMapping
 	firstReqSeen bool
 	memoryPause  bool
+
+	// recentWindows is a bounded, time-pruned ring of the most recently
+	// RESOLVED per-test windows. It exists to close the async-emit vs
+	// window-bin race: a parser decodes/emits a mock a few ms after the
+	// real wire event (the presaved ReqTimestampMock is correct, but the
+	// mock lands in the buffer late). If that mock's ReqTimestampMock
+	// falls inside a window whose ResolveRange already fired — the
+	// classic case is a Mongo cursor getMore that the app issued WHILE
+	// producing a response, but whose decode finished after the response
+	// was captured and the window closed — the direct [start,end] match
+	// in ResolveRange misses it, and since every FUTURE window starts
+	// after the previous one ended, it can never match again and is
+	// stale-dropped. By remembering recent windows we retroactively bin
+	// such late arrivals into the window that actually owns them, so the
+	// recorder persists them with their (correct, in-window) timestamps
+	// and replay's timestamp filter picks them up for the right test.
+	// Pruned to the same staleness horizon as the buffer cutoff so it
+	// can't reattach ancient mocks or grow without bound.
+	recentWindows []resolvedWindow
 
 	// outChanMu guards outChan and outChanClosed together. Senders
 	// RLock across the whole read+send; the closer Locks across the
@@ -319,6 +356,96 @@ func (m *SyncMockManager) CloseOutChan() {
 	m.outChanClosed = true
 }
 
+// FlushOwnedWindows forwards every buffered mock that can be attributed
+// right now — session/connection mocks (reusable, never window-bound) and
+// per-test mocks whose ReqTimestampMock falls inside an already-resolved
+// window — leaving only not-yet-attributable per-test mocks in the buffer
+// for a future window match. It is the request-independent twin of
+// ResolveRange's flush branches: the proxy calls it on a ticker for the
+// life of a recording session (see proxy.go) so a mock that lands AFTER
+// its HTTP window resolved (a multi-MB Mongo document still decoding when
+// the response was captured) is persisted WHILE recording is live. The
+// only other drains are request-driven, so after the final request such a
+// mock would otherwise wait until shutdown — by which point the recorder
+// ctx is cancelled and the relay, consumer, and InsertMock all drop it.
+// Order within the buffer is preserved for the mocks left behind.
+func (m *SyncMockManager) FlushOwnedWindows() {
+	if m == nil {
+		return
+	}
+
+	var mocksToSend []*models.Mock
+	var lateMappings map[string][]string
+
+	m.mu.Lock()
+	outChanBound, _ := m.outChanStatus()
+	if !outChanBound {
+		m.mu.Unlock()
+		return
+	}
+	mappingChan := m.mappingChan
+
+	ownerWindow := func(t time.Time) (resolvedWindow, bool) {
+		for _, w := range m.recentWindows {
+			if !t.Before(w.start) && !t.After(w.end) {
+				return w, true
+			}
+		}
+		return resolvedWindow{}, false
+	}
+
+	keepIdx := 0
+	for i := 0; i < len(m.buffer); i++ {
+		mock := m.buffer[i]
+		if mock == nil {
+			continue
+		}
+		if lt := mock.TestModeInfo.Lifetime; lt == models.LifetimeSession || lt == models.LifetimeConnection {
+			// Reusable across tests; flush verbatim (never renamed),
+			// matching ResolveRange's lifetime carve-out.
+			mocksToSend = append(mocksToSend, mock)
+			continue
+		}
+		if w, ok := ownerWindow(mock.Spec.ReqTimestampMock); ok {
+			mock.Name = "mock-" + generateRandomString(8)
+			if w.mapping {
+				if lateMappings == nil {
+					lateMappings = make(map[string][]string)
+				}
+				lateMappings[w.testName] = append(lateMappings[w.testName], mock.Name)
+			}
+			mocksToSend = append(mocksToSend, mock)
+			continue
+		}
+		// Not attributable yet — a future (possibly out-of-order) request
+		// may still claim it. Keep it buffered in place.
+		m.buffer[keepIdx] = mock
+		keepIdx++
+	}
+	for i := keepIdx; i < len(m.buffer); i++ {
+		m.buffer[i] = nil
+	}
+	m.buffer = m.buffer[:keepIdx]
+	m.mu.Unlock()
+
+	// Send AFTER releasing m.mu — sendToOutChan takes outChanMu and may
+	// block up to sendBudget; holding m.mu across it would wedge AddMock.
+	for _, mock := range mocksToSend {
+		m.sendToOutChan(mock)
+	}
+	if mappingChan != nil {
+		for tn, ids := range lateMappings {
+			if len(ids) == 0 {
+				continue
+			}
+			select {
+			case mappingChan <- models.TestMockMapping{TestName: tn, MockIDs: ids}:
+			default:
+			}
+		}
+	}
+}
+
 func (m *SyncMockManager) SetFirstRequestSignaled() {
 	m.mu.Lock()
 	m.firstReqSeen = true
@@ -360,6 +487,11 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 	var mocksToSend []*models.Mock
 	var associatedMockIDs []string
 	var mappingEntry *models.TestMockMapping
+	// lateMappings accumulates mock IDs for mocks retroactively binned
+	// into a PAST (already-resolved) window, keyed by that window's test
+	// name. lateBinned counts them for the buffer-transition diagnostic.
+	var lateMappings map[string][]string
+	lateBinned := 0
 
 	m.mu.Lock()
 	// Snapshot the outChan wiring status under outChanMu (NOT m.mu)
@@ -405,6 +537,33 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 	//      that landed in the buffer during the brief unbound startup
 	//      window before SetOutputChannel.
 	cutoffTime := time.Now().Add(-7 * time.Second)
+
+	// Prune the recently-resolved-window ring to the same staleness
+	// horizon as the buffer cutoff, so retroactive binning below can't
+	// reattach a mock to an ancient window (which would defeat the
+	// stale-cutoff's buffer-bound guarantee).
+	if len(m.recentWindows) > 0 {
+		kept := m.recentWindows[:0]
+		for _, w := range m.recentWindows {
+			// if !w.end.Before(cutoffTime) {
+			kept = append(kept, w)
+			// }
+		}
+		m.recentWindows = kept
+	}
+	// ownerWindow returns the recently-resolved window whose [start,end]
+	// contains t (inclusive, matching the current-window test below).
+	// Windows are non-overlapping FIFO request windows, so at most one
+	// matches.
+	ownerWindow := func(t time.Time) (resolvedWindow, bool) {
+		for _, w := range m.recentWindows {
+			if !t.Before(w.start) && !t.After(w.end) {
+				return w, true
+			}
+		}
+		return resolvedWindow{}, false
+	}
+
 	keepIdx := 0
 
 	for i := 0; i < len(m.buffer); i++ {
@@ -467,6 +626,41 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 			continue
 		}
 
+		// RETROACTIVE BIN: the mock missed the CURRENT window, but a
+		// recently-resolved window may own it. This is the async-emit vs
+		// window-close race — most visibly a Mongo cursor getMore the app
+		// issued WHILE producing a response, whose decode finished only
+		// after that response was captured and its window closed. The
+		// mock's presaved ReqTimestampMock is correct and in that window,
+		// but the direct [start,end] test above already ran for it, and no
+		// FUTURE window can contain an earlier timestamp — so without this
+		// it would fall to the stale-cutoff and be lost. Attribute it to
+		// the owning window's test so it's persisted (and picked up by
+		// replay's timestamp filter) instead of dropped. Placed BEFORE the
+		// stale-cutoff so an in-window-but-old mock (long test window that
+		// straddles the 7 s horizon) is rescued rather than reaped. Mirrors
+		// the in-window branch's keep / outChanBound handling.
+		if ownerW, ok := ownerWindow(mockTime); ok {
+			if keep {
+				if !outChanBound {
+					m.buffer[keepIdx] = mock
+					keepIdx++
+					continue
+				}
+				mock.Name = "mock-" + generateRandomString(8)
+				if ownerW.mapping {
+					if lateMappings == nil {
+						lateMappings = make(map[string][]string)
+					}
+					lateMappings[ownerW.testName] = append(lateMappings[ownerW.testName], mock.Name)
+				}
+				mocksToSend = append(mocksToSend, mock)
+				lateBinned++
+			}
+			// Handled (flushed or retained); drop from the current buffer.
+			continue
+		}
+
 		// SAFETY VALVE: Expire stale OUT-OF-WINDOW mocks.
 		// A mock that didn't match the current window AND is older
 		// than 7 s is unrecoverable — no future request can have a
@@ -525,6 +719,25 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 		}
 	}
 
+	// Record THIS window so a later ResolveRange can retroactively bin a
+	// mock decoded after this window closed (see recentWindows). Appended
+	// AFTER the match loop, so the current window's own mocks went through
+	// the direct [start,end] path above, never the ring. Skipped for the
+	// no-keep / unbound cases is unnecessary — an empty-but-recorded
+	// window is harmless and pruned by age.
+	m.recentWindows = append(m.recentWindows, resolvedWindow{
+		start:    start,
+		end:      end,
+		testName: testName,
+		mapping:  mapping,
+	})
+	if len(m.recentWindows) > maxRecentWindows {
+		// Drop the oldest entries; copy down so the big backing array
+		// isn't retained by the reslice.
+		n := copy(m.recentWindows, m.recentWindows[len(m.recentWindows)-maxRecentWindows:])
+		m.recentWindows = m.recentWindows[:n]
+	}
+
 	bufferLenAfter := len(m.buffer)
 	mocksToSendLen := len(mocksToSend)
 
@@ -544,6 +757,7 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 			zap.Int("buffer_len_before", bufferLenBefore),
 			zap.Int("buffer_len_after", bufferLenAfter),
 			zap.Int("mocks_flushed", mocksToSendLen),
+			zap.Int("late_binned", lateBinned),
 			zap.Int("dropped_total", bufferLenBefore-bufferLenAfter-mocksToSendLen),
 			zap.Bool("outChan_bound", outChanBound),
 			zap.Bool("mapping_enabled", mapping),
@@ -563,35 +777,143 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 		default:
 		}
 	}
+	// Retroactive mapping entries for mocks late-binned into past windows.
+	// The recorder Upserts mappings by test name, so a second entry for an
+	// already-resolved test merges into its existing mapping rather than
+	// replacing it.
+	if mappingChan != nil {
+		for tn, ids := range lateMappings {
+			if len(ids) == 0 {
+				continue
+			}
+			select {
+			case mappingChan <- models.TestMockMapping{TestName: tn, MockIDs: ids}:
+			default:
+			}
+		}
+	}
 }
 
+// DeleteMocksStrictlyBefore is the dedup-queue cleanup invoked when a
+// DUPLICATE request is skipped: it clears buffered mocks captured before
+// the duplicate's request timestamp so the recording doesn't accumulate
+// the skipped duplicate's debris.
+//
+// It must NOT, however, delete a mock that legitimately belongs to an
+// earlier KEPT (non-duplicate) test and merely arrived in the buffer
+// late — the exact failure that lost every per-test Mongo mock in the
+// mongo-bigmock recording: a 6 MB document decodes/emits after its
+// HTTP window already resolved (so ResolveRange never matched it), and
+// then the NEXT cycle's duplicate requests fire DeleteMocksStrictlyBefore
+// and wipe those kept-but-late mocks before any retroactive-bin
+// ResolveRange can rescue them. Duplicate cycles take this path, never
+// ResolveRange, so without the rescue here the kept mocks are gone.
+//
+// Discriminator: a mock belongs to a kept test iff its ReqTimestampMock
+// falls inside a recently-resolved window (recentWindows only ever holds
+// NON-duplicate windows — duplicates resolve through here, not
+// ResolveRange). So a before-the-horizon mock that owns a recent window
+// is a late kept mock → flush it (rescue); one that owns none is the
+// skipped duplicate's own debris → drop it. Session/connection mocks are
+// reusable across tests and are never reaped by a per-test cleanup.
 func (m *SyncMockManager) DeleteMocksStrictlyBefore(timestamp time.Time) {
 	if m == nil {
 		return
 	}
+
+	var mocksToSend []*models.Mock
+	var lateMappings map[string][]string
+
 	m.mu.Lock()
-	defer m.mu.Unlock()
+	outChanBound, _ := m.outChanStatus()
+	mappingChan := m.mappingChan
+
+	ownerWindow := func(t time.Time) (resolvedWindow, bool) {
+		for _, w := range m.recentWindows {
+			if !t.Before(w.start) && !t.After(w.end) {
+				return w, true
+			}
+		}
+		return resolvedWindow{}, false
+	}
 
 	keepIdx := 0
 	for i := 0; i < len(m.buffer); i++ {
 		mock := m.buffer[i]
-
-		if mock.Spec.ReqTimestampMock.Before(timestamp) {
+		if mock == nil {
 			continue
 		}
 
-		// Keep the mock
-		m.buffer[keepIdx] = mock
-		keepIdx++
+		// At/after the cleanup horizon: belongs to the current or a future
+		// request, not the duplicate being skipped — always retain.
+		if !mock.Spec.ReqTimestampMock.Before(timestamp) {
+			m.buffer[keepIdx] = mock
+			keepIdx++
+			continue
+		}
+
+		// Session/connection mocks outlive any single test window and must
+		// survive a per-test cleanup. Flush when we can persist them now,
+		// otherwise retain for a later drain.
+		if lt := mock.TestModeInfo.Lifetime; lt == models.LifetimeSession || lt == models.LifetimeConnection {
+			if outChanBound {
+				mocksToSend = append(mocksToSend, mock)
+				continue
+			}
+			m.buffer[keepIdx] = mock
+			keepIdx++
+			continue
+		}
+
+		// RESCUE: a before-the-horizon per-test mock that owns a recent
+		// KEPT window is a legitimately-kept test's late arrival — flush
+		// it to that test instead of deleting it as duplicate debris.
+		if w, ok := ownerWindow(mock.Spec.ReqTimestampMock); ok {
+			if !outChanBound {
+				// Can't deliver yet; retain so a later flush sends it.
+				m.buffer[keepIdx] = mock
+				keepIdx++
+				continue
+			}
+			mock.Name = "mock-" + generateRandomString(8)
+			if w.mapping {
+				if lateMappings == nil {
+					lateMappings = make(map[string][]string)
+				}
+				lateMappings[w.testName] = append(lateMappings[w.testName], mock.Name)
+			}
+			mocksToSend = append(mocksToSend, mock)
+			continue
+		}
+
+		// Owns no kept window and is before the horizon → the skipped
+		// duplicate's own debris. Drop it (fall through without keeping).
 	}
 
 	// Memory Cleanup: Nil out the deleted entries to allow GC to reclaim the memory
 	for i := keepIdx; i < len(m.buffer); i++ {
 		m.buffer[i] = nil
 	}
-
 	// Reslice the buffer
 	m.buffer = m.buffer[:keepIdx]
+	m.mu.Unlock()
+
+	// Send AFTER releasing m.mu — sendToOutChan takes outChanMu and may
+	// block up to sendBudget; holding m.mu across it would wedge AddMock.
+	for _, mock := range mocksToSend {
+		m.sendToOutChan(mock)
+	}
+	if mappingChan != nil {
+		for tn, ids := range lateMappings {
+			if len(ids) == 0 {
+				continue
+			}
+			select {
+			case mappingChan <- models.TestMockMapping{TestName: tn, MockIDs: ids}:
+			default:
+			}
+		}
+	}
 }
 
 type DedupJob struct {

--- a/pkg/agent/proxy/syncMock/syncMock_test.go
+++ b/pkg/agent/proxy/syncMock/syncMock_test.go
@@ -1019,3 +1019,319 @@ func drainChan(t *testing.T, ch chan *models.Mock, max int) {
 		}
 	}
 }
+
+// TestResolveRangeRetroactivelyBinsLateMock is the regression for the
+// async-emit vs window-close race (the Mongo cursor getMore case): a
+// mock whose presaved ReqTimestampMock falls inside a window whose
+// ResolveRange already fired — because the parser decoded/emitted it a
+// few ms after the response was captured and the window closed — must
+// be retroactively binned into the window that owns it, not stale-
+// dropped. Before the recentWindows ring, the late mock matched no
+// current-or-future window (every future window starts later) and was
+// reaped, so replay's timestamp filter never saw it.
+func TestResolveRangeRetroactivelyBinsLateMock(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan *models.Mock, 8)
+	mgr := &SyncMockManager{}
+	mgr.SetOutputChannel(ch)
+	mgr.SetFirstRequestSignaled() // so AddMock buffers (windowed path)
+
+	// Anchor recently enough that nothing trips the 7 s stale cutoff.
+	base := time.Now().Add(-2 * time.Second)
+
+	// test-1 resolves its window FIRST, while its own getMore mock has
+	// not been decoded/emitted yet — the buffer is empty for it.
+	w1Start, w1End := base, base.Add(5*time.Millisecond)
+	mgr.ResolveRange(w1Start, w1End, "test-1", true, false)
+
+	// The late getMore arrives now, after test-1's window closed. Its
+	// presaved request timestamp sits INSIDE test-1's window. Untagged
+	// Mongo mock => LifetimePerTest, so the session/connection carve-out
+	// does not apply and the retroactive-bin path is what rescues it.
+	lateTs := base.Add(2 * time.Millisecond)
+	mgr.AddMock(&models.Mock{
+		Kind: models.Mongo,
+		Spec: models.MockSpec{ReqTimestampMock: lateTs},
+	})
+	if len(mgr.buffer) != 1 {
+		t.Fatalf("expected the late mock to be buffered, got %d", len(mgr.buffer))
+	}
+
+	// A later request resolves test-2's window. This pass must flush the
+	// late mock by attributing it back to test-1's (still-recent) window.
+	w2Start, w2End := base.Add(100*time.Millisecond), base.Add(105*time.Millisecond)
+	mgr.ResolveRange(w2Start, w2End, "test-2", true, false)
+
+	if len(mgr.buffer) != 0 {
+		t.Fatalf("expected the late mock to be flushed (retroactively binned), buffer=%d", len(mgr.buffer))
+	}
+
+	select {
+	case got := <-ch:
+		if !got.Spec.ReqTimestampMock.Equal(lateTs) {
+			t.Fatalf("flushed mock has wrong timestamp: got %v want %v", got.Spec.ReqTimestampMock, lateTs)
+		}
+		if got.Name == "" {
+			t.Fatalf("retroactively binned mock must be named for replay correlation")
+		}
+	default:
+		t.Fatalf("expected the late mock to be flushed to outChan, got nothing")
+	}
+}
+
+// TestResolveRangeStaleWindowDoesNotResurrectAncientMock guards the
+// bound: a mock that belongs only to a window already pruned past the
+// 7 s staleness horizon must still be dropped, so the ring can't defeat
+// the buffer-growth cap or resurrect unrecoverable mocks.
+func TestResolveRangeStaleWindowDoesNotResurrectAncientMock(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan *models.Mock, 8)
+	mgr := &SyncMockManager{}
+	mgr.SetOutputChannel(ch)
+	mgr.SetFirstRequestSignaled()
+
+	// Ancient window + mock, both well past the 7 s cutoff.
+	old := time.Now().Add(-30 * time.Second)
+	mgr.ResolveRange(old, old.Add(5*time.Millisecond), "old-test", true, false)
+
+	mgr.AddMock(&models.Mock{
+		Kind: models.Mongo,
+		Spec: models.MockSpec{ReqTimestampMock: old.Add(2 * time.Millisecond)},
+	})
+
+	// A fresh resolve prunes the ancient window and reaps the ancient
+	// mock via the stale cutoff.
+	now := time.Now()
+	mgr.ResolveRange(now, now.Add(5*time.Millisecond), "new-test", true, false)
+
+	if len(mgr.buffer) != 0 {
+		t.Fatalf("expected ancient mock to be dropped, buffer=%d", len(mgr.buffer))
+	}
+	select {
+	case got := <-ch:
+		t.Fatalf("ancient mock must not be flushed; got one with ts %v", got.Spec.ReqTimestampMock)
+	default:
+	}
+}
+
+// TestDeleteMocksStrictlyBeforeRescuesLateKeptMock is the regression for
+// the multi-cycle static-dedup data loss seen in mongo-bigmock: cycle 1
+// is kept, but its big-document mocks land in the buffer AFTER their HTTP
+// windows resolved; then cycle 2's DUPLICATE requests fire
+// DeleteMocksStrictlyBefore, which used to wipe those late kept mocks
+// before any retroactive-bin ResolveRange could rescue them. The cleanup
+// must now flush mocks that own a recent KEPT window (and session mocks)
+// while still dropping the duplicate's own debris.
+func TestDeleteMocksStrictlyBeforeRescuesLateKeptMock(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan *models.Mock, 8)
+	mapCh := make(chan models.TestMockMapping, 8)
+	mgr := &SyncMockManager{}
+	mgr.SetOutputChannel(ch)
+	mgr.SetMappingChannel(mapCh)
+	mgr.SetFirstRequestSignaled()
+
+	base := time.Now().Add(-1 * time.Second)
+
+	// Cycle-1 kept (non-duplicate) window for test-1, resolved while its
+	// own mock was still being decoded — buffer empty, nothing matches yet.
+	mgr.ResolveRange(base, base.Add(5*time.Millisecond), "test-1", true, true)
+
+	keptTs := base.Add(2 * time.Millisecond)      // inside test-1's window → rescue
+	debrisTs := base.Add(500 * time.Millisecond)  // owns no window → the duplicate's debris → drop
+	sessionTs := base.Add(300 * time.Millisecond) // session lifetime → never reaped by per-test cleanup
+	dupHorizon := base.Add(1 * time.Second)       // the duplicate request's timestamp
+	futureTs := dupHorizon.Add(5 * time.Millisecond)
+
+	mgr.mu.Lock()
+	mgr.buffer = append(mgr.buffer,
+		&models.Mock{Kind: models.Mongo, Spec: models.MockSpec{ReqTimestampMock: keptTs}},
+		&models.Mock{Kind: models.Mongo, Spec: models.MockSpec{ReqTimestampMock: debrisTs}},
+		&models.Mock{
+			Kind:         models.Mongo,
+			Name:         "sess-keep",
+			TestModeInfo: models.TestModeInfo{Lifetime: models.LifetimeSession},
+			Spec:         models.MockSpec{ReqTimestampMock: sessionTs},
+		},
+		&models.Mock{Kind: models.Mongo, Spec: models.MockSpec{ReqTimestampMock: futureTs}},
+	)
+	mgr.mu.Unlock()
+
+	// A later duplicate request resolves and cleans up before its timestamp.
+	mgr.DeleteMocksStrictlyBefore(dupHorizon)
+
+	// Only the at/after-horizon mock should remain buffered.
+	if len(mgr.buffer) != 1 || !mgr.buffer[0].Spec.ReqTimestampMock.Equal(futureTs) {
+		t.Fatalf("expected only the future mock retained; buffer=%d", len(mgr.buffer))
+	}
+
+	var sent []*models.Mock
+	for drained := false; !drained; {
+		select {
+		case m := <-ch:
+			sent = append(sent, m)
+		default:
+			drained = true
+		}
+	}
+	if len(sent) != 2 {
+		t.Fatalf("expected kept + session mocks rescued (2), got %d", len(sent))
+	}
+
+	var sawKept, sawSession bool
+	for _, m := range sent {
+		switch {
+		case m.Spec.ReqTimestampMock.Equal(keptTs):
+			sawKept = true
+			if m.Name == "" {
+				t.Fatalf("rescued per-test mock must be named for replay correlation")
+			}
+		case m.TestModeInfo.Lifetime == models.LifetimeSession:
+			sawSession = true
+			if m.Name != "sess-keep" {
+				t.Fatalf("session mock must be flushed verbatim, not renamed; got %q", m.Name)
+			}
+		default:
+			t.Fatalf("unexpected mock flushed: ts=%v name=%q (debris must be dropped)", m.Spec.ReqTimestampMock, m.Name)
+		}
+	}
+	if !sawKept || !sawSession {
+		t.Fatalf("expected both kept and session mocks rescued; kept=%v session=%v", sawKept, sawSession)
+	}
+
+	// The rescued kept mock produced a late mapping for test-1; the debris did not.
+	select {
+	case mp := <-mapCh:
+		if mp.TestName != "test-1" || len(mp.MockIDs) != 1 {
+			t.Fatalf("expected one late mapping for test-1, got %+v", mp)
+		}
+	default:
+		t.Fatalf("expected a late TestMockMapping for the rescued kept mock")
+	}
+	select {
+	case mp := <-mapCh:
+		t.Fatalf("debris/session must not produce mapping entries; got %+v", mp)
+	default:
+	}
+}
+
+// TestFlushOwnedWindowsPersistsLateMocksDuringRecording is the regression
+// for the real mongo-bigmock failure: a per-test mock that lands in the
+// buffer AFTER its HTTP window resolved (a 6 MB document still decoding)
+// must be drained WHILE recording is live — at shutdown the recorder ctx
+// is already cancelled and the write path drops everything, so the
+// periodic owned-window flush is what actually persists it. Session mocks
+// flush too; not-yet-attributable per-test mocks stay buffered for a
+// future window.
+func TestFlushOwnedWindowsPersistsLateMocksDuringRecording(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan *models.Mock, 8)
+	mapCh := make(chan models.TestMockMapping, 8)
+	mgr := &SyncMockManager{}
+	mgr.SetOutputChannel(ch)
+	mgr.SetMappingChannel(mapCh)
+	mgr.SetFirstRequestSignaled()
+
+	base := time.Now().Add(-1 * time.Second)
+	// A kept window resolved while its mock was still decoding (buffer empty).
+	mgr.ResolveRange(base, base.Add(5*time.Millisecond), "test-1", true, true)
+
+	ownedTs := base.Add(2 * time.Millisecond)     // inside test-1's window → flush
+	orphanTs := base.Add(500 * time.Millisecond)  // owns no window yet → keep buffered
+	sessionTs := base.Add(300 * time.Millisecond) // session lifetime → flush verbatim
+	mgr.mu.Lock()
+	mgr.buffer = append(mgr.buffer,
+		&models.Mock{Kind: models.Mongo, Spec: models.MockSpec{ReqTimestampMock: ownedTs}},
+		&models.Mock{Kind: models.Mongo, Spec: models.MockSpec{ReqTimestampMock: orphanTs}},
+		&models.Mock{
+			Kind:         models.Mongo,
+			Name:         "sess-keep",
+			TestModeInfo: models.TestModeInfo{Lifetime: models.LifetimeSession},
+			Spec:         models.MockSpec{ReqTimestampMock: sessionTs},
+		},
+	)
+	mgr.mu.Unlock()
+
+	// One periodic tick's worth of work (called directly, no real timer).
+	mgr.FlushOwnedWindows()
+
+	// Owned + session flushed; the orphan stays for a possible future window.
+	if len(mgr.buffer) != 1 || !mgr.buffer[0].Spec.ReqTimestampMock.Equal(orphanTs) {
+		t.Fatalf("expected only the unattributable orphan retained; buffer=%d", len(mgr.buffer))
+	}
+
+	var sent []*models.Mock
+	for drained := false; !drained; {
+		select {
+		case m := <-ch:
+			sent = append(sent, m)
+		default:
+			drained = true
+		}
+	}
+	if len(sent) != 2 {
+		t.Fatalf("expected owned + session flushed (2), got %d", len(sent))
+	}
+	var sawOwned, sawSession bool
+	for _, m := range sent {
+		switch {
+		case m.Spec.ReqTimestampMock.Equal(ownedTs):
+			sawOwned = true
+			if m.Name == "" {
+				t.Fatalf("flushed per-test mock must be named for replay correlation")
+			}
+		case m.TestModeInfo.Lifetime == models.LifetimeSession:
+			sawSession = true
+			if m.Name != "sess-keep" {
+				t.Fatalf("session mock must be flushed verbatim; got %q", m.Name)
+			}
+		default:
+			t.Fatalf("unexpected mock flushed: ts=%v", m.Spec.ReqTimestampMock)
+		}
+	}
+	if !sawOwned || !sawSession {
+		t.Fatalf("expected owned and session flushed; owned=%v session=%v", sawOwned, sawSession)
+	}
+
+	// The owned mock produced a late mapping for test-1.
+	select {
+	case mp := <-mapCh:
+		if mp.TestName != "test-1" || len(mp.MockIDs) != 1 {
+			t.Fatalf("expected one late mapping for test-1, got %+v", mp)
+		}
+	default:
+		t.Fatalf("expected a late TestMockMapping for the owned mock")
+	}
+}
+
+// TestFlushOwnedWindowsLeavesNothingAttributableUnsent is a focused check
+// that a second FlushOwnedWindows after everything attributable is gone
+// is a no-op (no buffer churn, no spurious sends).
+func TestFlushOwnedWindowsNoopWhenNothingOwned(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan *models.Mock, 4)
+	mgr := &SyncMockManager{}
+	mgr.SetOutputChannel(ch)
+	mgr.SetFirstRequestSignaled()
+
+	// A single buffered per-test mock that owns no recorded window.
+	mgr.mu.Lock()
+	mgr.buffer = append(mgr.buffer, &models.Mock{Kind: models.Mongo, Spec: models.MockSpec{ReqTimestampMock: time.Now()}})
+	mgr.mu.Unlock()
+
+	mgr.FlushOwnedWindows()
+
+	if len(mgr.buffer) != 1 {
+		t.Fatalf("unattributable mock must stay buffered; buffer=%d", len(mgr.buffer))
+	}
+	select {
+	case m := <-ch:
+		t.Fatalf("nothing should be flushed; got ts=%v", m.Spec.ReqTimestampMock)
+	default:
+	}
+}

--- a/pkg/agent/proxy/syncMock/syncMock_test.go
+++ b/pkg/agent/proxy/syncMock/syncMock_test.go
@@ -1080,11 +1080,15 @@ func TestResolveRangeRetroactivelyBinsLateMock(t *testing.T) {
 	}
 }
 
-// TestResolveRangeStaleWindowDoesNotResurrectAncientMock guards the
-// bound: a mock that belongs only to a window already pruned past the
-// 7 s staleness horizon must still be dropped, so the ring can't defeat
-// the buffer-growth cap or resurrect unrecoverable mocks.
-func TestResolveRangeStaleWindowDoesNotResurrectAncientMock(t *testing.T) {
+// TestResolveRangeRecordsLateMockInOldWindowButDropsOrphan documents the
+// deliberate design choice: recentWindows is intentionally NOT age-pruned,
+// because a mock whose ReqTimestampMock falls inside a recorded window
+// belongs to that test and must be recorded even if its decode landed
+// late and the window is now old — losing it would be the very data-loss
+// bug this change exists to fix. The buffer-growth bound is preserved
+// instead by (a) the stale-cutoff, which still reaps a mock that falls
+// inside NO recorded window, and (b) the maxRecentWindows cap on the ring.
+func TestResolveRangeRecordsLateMockInOldWindowButDropsOrphan(t *testing.T) {
 	t.Parallel()
 
 	ch := make(chan *models.Mock, 8)
@@ -1092,27 +1096,46 @@ func TestResolveRangeStaleWindowDoesNotResurrectAncientMock(t *testing.T) {
 	mgr.SetOutputChannel(ch)
 	mgr.SetFirstRequestSignaled()
 
-	// Ancient window + mock, both well past the 7 s cutoff.
+	// An old window, well past the 7 s cutoff.
 	old := time.Now().Add(-30 * time.Second)
 	mgr.ResolveRange(old, old.Add(5*time.Millisecond), "old-test", true, false)
 
+	inWindowTs := old.Add(2 * time.Millisecond)   // inside old-test's window → recorded
+	orphanTs := time.Now().Add(-20 * time.Second) // inside no window, ancient → dropped
+
 	mgr.AddMock(&models.Mock{
 		Kind: models.Mongo,
-		Spec: models.MockSpec{ReqTimestampMock: old.Add(2 * time.Millisecond)},
+		Spec: models.MockSpec{ReqTimestampMock: inWindowTs},
+	})
+	mgr.AddMock(&models.Mock{
+		Kind: models.Mongo,
+		Spec: models.MockSpec{ReqTimestampMock: orphanTs},
 	})
 
-	// A fresh resolve prunes the ancient window and reaps the ancient
-	// mock via the stale cutoff.
+	// A fresh resolve drains the buffer: the in-window mock is retroactively
+	// binned to old-test (and flushed) even though old-test is ancient; the
+	// orphan, owning no window, is reaped by the stale cutoff.
 	now := time.Now()
 	mgr.ResolveRange(now, now.Add(5*time.Millisecond), "new-test", true, false)
 
 	if len(mgr.buffer) != 0 {
-		t.Fatalf("expected ancient mock to be dropped, buffer=%d", len(mgr.buffer))
+		t.Fatalf("expected buffer drained, buffer=%d", len(mgr.buffer))
 	}
-	select {
-	case got := <-ch:
-		t.Fatalf("ancient mock must not be flushed; got one with ts %v", got.Spec.ReqTimestampMock)
-	default:
+
+	var sent []*models.Mock
+	for drained := false; !drained; {
+		select {
+		case m := <-ch:
+			sent = append(sent, m)
+		default:
+			drained = true
+		}
+	}
+	if len(sent) != 1 {
+		t.Fatalf("expected exactly the in-window mock flushed, got %d", len(sent))
+	}
+	if !sent[0].Spec.ReqTimestampMock.Equal(inWindowTs) {
+		t.Fatalf("expected the in-window mock flushed; got ts %v (orphan must be dropped)", sent[0].Spec.ReqTimestampMock)
 	}
 }
 


### PR DESCRIPTION
## Describe the changes that are made

Fixes a data-loss race in the sync-mock buffer where a per-test mock that is **decoded/emitted after its HTTP request window has already resolved** was silently dropped instead of being persisted with the test that owns it.

**The race.** A parser emits a mock a few ms after the real wire event — its presaved `ReqTimestampMock` is correct, but the mock lands in the buffer *late*. The clearest cases are a multi-MB Mongo document, or a cursor `getMore` the app issued *while* a response was being produced, whose decode finished only after the response was captured and the HTTP window closed. `ResolveRange`'s direct `[start, end]` match misses such a mock, and because every future window starts after the previous one ended, no future window can ever contain its earlier timestamp — so it falls to the 7s stale-cutoff and is lost. Replay's timestamp filter then never sees it. In `mongo-bigmock` this dropped every per-test Mongo mock from the recording.

The fix closes the race on three fronts in `SyncMockManager`:

1. **Retroactive binning (`recentWindows`).** A bounded (`maxRecentWindows = 256`), age-pruned ring of recently-resolved per-test windows. When a mock misses the current window, `ResolveRange` checks whether it falls inside a recently-resolved window and attributes it back to that window's test — emitting a retroactive `TestMockMapping` (the recorder upserts mappings by test name, so it merges) — instead of dropping it. The retroactive-bin check is placed *before* the stale-cutoff so an in-window-but-old mock is rescued rather than reaped.

2. **Live periodic drain (`FlushOwnedWindows` + proxy ticker).** The request-driven drains can't reach a mock that lands after the *final* request's window closed; it would otherwise sit in the buffer until shutdown, where the cancelled recorder ctx makes the relay, consumer, and `InsertMock` all drop it. The proxy now ticks `FlushOwnedWindows` every 1s for the life of a recording session, forwarding session/connection mocks and per-test mocks that own a resolved window through the healthy write path *while recording is still live*. Not-yet-attributable mocks stay buffered for a future window.

3. **Dedup-cleanup rescue (`DeleteMocksStrictlyBefore`).** The duplicate-request cleanup used to wipe every buffered mock before the duplicate's timestamp, destroying legitimately-kept-but-late mocks before any retroactive-bin pass could rescue them (the multi-cycle `mongo-bigmock` data loss). It now flushes mocks that own a recent *kept* window (and session/connection mocks, which outlive any single window) and drops only the skipped duplicate's own debris.

By design `recentWindows` is **not** age-pruned: a mock whose timestamp falls inside a recorded window belongs to that test and is recorded even if its decode landed late and the window is now old — dropping it is exactly the data loss this change fixes. Buffer growth stays bounded by (a) the stale-cutoff, which still reaps any mock that falls inside **no** recorded window, and (b) the `maxRecentWindows = 256` cap on the ring. Sends happen after `m.mu` is released (they take `outChanMu` and may block up to `sendBudget`), so they can't wedge `AddMock`. A `late_binned` counter is added to the `ResolveRange` diagnostic log.

### Files

- `pkg/agent/proxy/syncMock/syncMock.go` — `recentWindows` ring + `resolvedWindow`; retroactive-bin in `ResolveRange`; new `FlushOwnedWindows`; rescue logic in `DeleteMocksStrictlyBefore`.
- `pkg/agent/proxy/proxy.go` — 1s ticker driving `FlushOwnedWindows` for the recording session's lifetime.
- `pkg/agent/proxy/syncMock/syncMock_test.go` — regression tests for each path.

## Links & References

**Closes:** NA

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

> This is a timing/concurrency fix; it is covered by deterministic unit regression tests (a real e2e would be timing-dependent and flaky). The originating scenario was the `mongo-bigmock` recording.

## Added comments for hard-to-understand areas?
- [x] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

```bash
go test ./pkg/agent/proxy/syncMock/ -run \
  'TestResolveRangeRetroactivelyBinsLateMock|TestResolveRangeRecordsLateMockInOldWindowButDropsOrphan|TestDeleteMocksStrictlyBeforeRescuesLateKeptMock|TestFlushOwnedWindows' -v
```

Covers: retroactive binning of a late mock, recording a late mock in an old window while still dropping an orphan that owns no window (the buffer bound), the dedup-cleanup rescue vs debris-drop, the live periodic drain, and the no-op-when-nothing-owned case.

## Self Review done?
- [ ] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?

`ResolveRange` now logs a `late_binned` count alongside `mocks_flushed` / `dropped_total` so retroactive attribution is observable in agent logs.

## 🧠 Semantics for PR Title & Branch Name

- **PR Title**: `fix: mock window resolve range race fix`
- **Branch Name**: `race-mock-window`

---

## Additional checklist:
- [ ] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [ ] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [ ] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?
