### PR TITLE
fix(record): drain in-flight mocks on graceful stop

### DIFF
--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -338,13 +338,33 @@ func (m *SyncMockManager) SendConfigMock(mock *models.Mock) {
 	m.sendToOutChan(mock)
 }
 
-// CloseOutChan closes the outgoing mock channel under the writer
-// lock so an in-flight sendToOutChan cannot race the close.
-// Idempotent; safe to call with outChan still nil.
+// CloseOutChan flushes any still-attributable buffered mocks and then
+// closes the outgoing mock channel under the writer lock so an in-flight
+// sendToOutChan cannot race the close. Idempotent; safe to call with
+// outChan still nil.
+//
+// The final FlushOwnedWindows is the shutdown twin of the periodic flush
+// ticker the proxy runs while recording is live (see proxy.go): that
+// ticker stops one step earlier in the shutdown sequence (its
+// clientConnCancel), so a mock that finished decoding after the ticker's
+// last tick — the classic teardown-phase late mock, a DB response still
+// being decoded when recording is asked to stop — would otherwise sit in
+// the buffer and be discarded here, orphaning its already-recorded test
+// case at replay. Flushing first persists every mock the buffer can still
+// attribute (session/connection mocks and per-test mocks whose
+// ReqTimestampMock falls inside an already-resolved window).
+//
+// FlushOwnedWindows takes outChanMu.RLock (via sendToOutChan); it runs to
+// completion and releases that lock BEFORE we take the write lock below,
+// so the two never deadlock. The proxy calls CloseOutChan only after all
+// connection handlers have drained, so no new mocks enter the buffer
+// between the flush and the close.
 func (m *SyncMockManager) CloseOutChan() {
 	if m == nil {
 		return
 	}
+	m.FlushOwnedWindows()
+
 	m.outChanMu.Lock()
 	defer m.outChanMu.Unlock()
 	if m.outChanClosed {

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -416,9 +416,23 @@ func (r *Recorder) Start(ctx context.Context) error {
 					zap.String("mockName", mock.Name),
 					zap.String("mockKind", mock.GetKind()))
 			}
-			err := r.mockDB.InsertMock(ctx, mock, newTestSetID)
+			// Persist with a ctx detached from cancellation so a mock that
+			// arrives during graceful shutdown — the late-decoded teardown
+			// tail the agent flushes when recording is asked to stop — is
+			// still written to disk. Inserting with the cancellable ctx made
+			// InsertMock fail the moment the parent ctx was cancelled, and the
+			// mock was then skipped (the continue below), orphaning its
+			// already-recorded test case at replay.
+			insertCtx := context.WithoutCancel(ctx)
+			err := r.mockDB.InsertMock(insertCtx, mock, newTestSetID)
 			if err != nil {
-				if ctx.Err() == context.Canceled {
+				// During shutdown the error channels may already be closed by
+				// the deferred close above, so sending would panic. The insert
+				// used a detached ctx, so an error here is a genuine disk
+				// failure rather than cancellation — log it and keep draining.
+				if ctx.Err() != nil {
+					r.logger.Debug("mock insert failed during shutdown drain; continuing",
+						zap.Error(err), zap.String("mock", mock.Name))
 					continue
 				}
 				insertMockErrChan <- err
@@ -641,26 +655,74 @@ func (r *Recorder) GetTestAndMockChans(ctx context.Context) (FrameChan, error) {
 		defer close(outgoingChan)
 		defer cancel()
 
-		// Also cancel mockCtx when parent ctx is done
-		// This is done inside the goroutine to avoid goroutine leaks
-		go func() {
-			<-ctx.Done()
-			cancel()
+		// Graceful drain on shutdown.
+		//
+		// When the parent ctx is cancelled we do NOT abandon the agent's
+		// mock stream. Abandoning it dropped the late-decoded teardown tail
+		// the agent is still flushing at stop (its CloseOutChan flushes the
+		// buffered mocks the instant recording is told to stop), which
+		// orphaned the already-recorded teardown test cases at replay.
+		// Instead we keep forwarding until the agent closes the stream (EOF),
+		// bounded by drainGrace so a hung agent can never wedge `keploy
+		// record` shutdown. mockCtx is left alive for the drain and torn down
+		// by the deferred cancel() on exit — which also stops the agent
+		// stream when the deadline (not EOF) ended the drain. The deadline
+		// guarantees we always reach that deferred cancel, so dropping the
+		// old <-ctx.Done()->cancel() watchdog goroutine cannot leak mockCtx.
+		const drainGrace = 15 * time.Second
+		var deadlineC <-chan time.Time // nil until the parent ctx cancels
+		var deadline *time.Timer
+		defer func() {
+			if deadline != nil {
+				deadline.Stop()
+			}
 		}()
+		armDrain := func() {
+			if deadline == nil {
+				deadline = time.NewTimer(drainGrace)
+				deadlineC = deadline.C
+			}
+		}
 
 		for {
+			// Watch the parent ctx only until the drain is armed; afterwards
+			// the drain is bounded by stream-EOF or deadlineC instead.
+			var ctxDone <-chan struct{}
+			if deadlineC == nil {
+				ctxDone = ctx.Done()
+			}
 			select {
-			case <-ctx.Done():
+			case <-ctxDone:
+				armDrain()
+			case <-deadlineC:
 				return ctx.Err()
 			case m, ok := <-outgoingStream:
 				if !ok {
+					// Agent closed the stream — every flushed mock forwarded.
 					return nil
 				}
+				if deadlineC != nil {
+					// Draining: bound the forward so a stalled consumer can't
+					// wedge shutdown. The consumer drains frames.Outgoing
+					// until close, so this normally never blocks.
+					select {
+					case outgoingChan <- m:
+					case <-deadlineC:
+						return ctx.Err()
+					}
+					continue
+				}
+				// Steady state: forward, switching to a bounded drain if the
+				// parent ctx cancels mid-send.
 				select {
-				case <-ctx.Done():
-					outgoingChan <- m
-					return ctx.Err()
 				case outgoingChan <- m:
+				case <-ctx.Done():
+					armDrain()
+					select {
+					case outgoingChan <- m:
+					case <-deadlineC:
+						return ctx.Err()
+					}
 				}
 			}
 		}


### PR DESCRIPTION
On stop the async mock-decode pipeline was torn down before it drained, orphaning teardown-phase test cases (DB mock lost, HTTP TC kept -> replay mongo EOF / mysql no-matching-mock). Flush the syncMock buffer before closing the out channel, drain the agent mock stream until EOF (bounded 15s) instead of abandoning it on ctx-cancel, and insert with a cancel-detached ctx so shutdown-tail mocks still reach disk.

## Describe the changes that are made

### The problem
During recording, keploy runs **two pipelines at different speeds**: the HTTP **test case (TC)** is written to disk instantly, but the outgoing **DB mock** is decoded **asynchronously** (mongo `mongo_v2`, mysql `asyncMySQLDecode`) and lands tens of ms–seconds later. When recording is asked to stop (Ctrl+C / `SIGINT` → context cancel), the cancellation cascade tore down the mock pipeline **before it finished draining**. The result: test cases captured in the **teardown phase** (the last requests before stop) keep their HTTP record but lose their late-decoded DB mock.

These become **orphan test cases** — the TC exists on disk, but its mock does not. At replay the app's DB call has no mock to serve, so:
- **mongo** → `socket was unexpectedly closed` (EOF)
- **mysql** → `no matching mock found`

This is why the teardown cluster (`get-orders-1..5`, `get-analytics-top-products-1`, etc.) failed intermittently across the `go-memory-load` lanes.

### Root cause — three drop points at shutdown
1. **Agent — `syncMock.CloseOutChan()`**: buffered late mocks were discarded at close; the periodic `FlushOwnedWindows` ticker had already stopped (`clientConnCancel`), so a mock that finished decoding after the last tick was lost.
2. **CLI — outgoing-mock relay**: on `ctx.Done` it *returned and abandoned* the agent's mock stream, dropping the tail the agent was still flushing.
3. **CLI — mock consumer**: `InsertMock(ctx)` with a cancelled ctx errored and the mock was skipped (never written to disk).

### The fix — bounded graceful drain
- **`syncMock.CloseOutChan` flushes before sealing.** It calls `FlushOwnedWindows` (the existing late-mock rescue from #4229) to forward every still-attributable buffered mock — session/connection mocks and per-test mocks whose `ReqTimestampMock` falls inside an already-resolved window — **before** closing the out channel. The flush fully releases its read-lock before the close takes the write-lock, so there's no deadlock.
- **The CLI relay drains instead of abandoning.** On parent-ctx cancel it keeps forwarding the agent's late-decoded tail until the stream closes (EOF) or a **15s deadline**, then tears down via the deferred cancel. This replaces the old `<-ctx.Done()->cancel()` watchdog goroutine without leaking `mockCtx` (the deadline guarantees we always reach the deferred cancel).
- **The consumer persists with a cancellation-detached context.** `InsertMock` now runs under `context.WithoutCancel(ctx)`, so a mock arriving during the drain is still written to disk; a genuine disk error during shutdown is logged rather than pushed to a possibly-closed error channel (avoids a panic).

**Every shutdown wait is bounded**, so a stuck decode or a hung agent stream can never wedge `keploy record`.

### Why `mappings.yaml` needs no change
A rescued mock reaches `mocks.yaml` with its `ReqTimestampMock` intact. At replay, a mock **not present in `mappings.yaml`** is not skipped (`isMappedToSpecificTest == false` in `mockdb.GetFilteredMocks`) and falls through to the **timestamp-window** match (`pkg.FilterTcsMocks` with the TC's `afterTime`/`beforeTime`). So the rescued teardown mock is matched to its test case purely by timestamp — no mapping entry required.

### Scope / follow-up
This rescues every mock that reaches the **agent's output** (mongo's syncMock buffer + both protocols' decoded tail). If mongo's **external integrations-module decoder** drops a mock *before* it reaches `syncMock`, that needs a matching drain in that repo and is out of scope for this PR.

**Files changed**
- `pkg/agent/proxy/syncMock/syncMock.go` — `CloseOutChan` flush-before-close
- `pkg/service/record/record.go` — bounded relay drain + cancel-detached mock insert

## Links & References

**Closes:** NA (no tracked issue; intermittent teardown-phase replay failures on the `go-memory-load` lanes)

### 🔗 Related PRs
- #4229 (mock window resolve range fix) — this builds on its `FlushOwnedWindows` late-mock rescue
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

> The existing `go-memory-load-mongo` / `go-memory-load-mysql` record→replay matrix lanes already exercise this path (they are exactly where the teardown orphans surfaced); no new lane is needed to validate the fix.

## Added comments for hard-to-understand areas?
- [x] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

> Internal record-shutdown behavior only — no user-facing flag, command, or on-disk format change.

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

**Steps**
1. Build the keploy binary from this branch.
2. Run a `go-memory-load-mongo` / `go-memory-load-mysql` record→replay cycle (the same flow the CI lanes use).
3. After record, confirm the teardown test cases (`get-orders-1..5`, `get-analytics-top-products-1`) now have their mocks present in `keploy/test-set-0/mocks.yaml`.
4. At replay, those test cases should now **pass** instead of failing with `socket was unexpectedly closed` (mongo) / `no matching mock found` (mysql).

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?