### PR TITLE
fix: http mock - test scoped specified

### DIFF
--- a/pkg/agent/proxy/integrations/http/recordv2.go
+++ b/pkg/agent/proxy/integrations/http/recordv2.go
@@ -490,6 +490,10 @@ func (h *HTTP) buildHTTPMock(m *FinalHTTP, destPort uint, connID string, opts mo
 			ReqTimestampMock: m.ReqTimestampMock,
 			ResTimestampMock: m.ResTimestampMock,
 		},
+		TestModeInfo: models.TestModeInfo{
+			Lifetime:        models.LifetimePerTest,
+			LifetimeDerived: true,
+		},
 	}
 	return mock, nil
 }

--- a/pkg/agent/proxy/integrations/http/recordv2_test.go
+++ b/pkg/agent/proxy/integrations/http/recordv2_test.go
@@ -335,6 +335,21 @@ func TestRecordV2_LegacyParity(t *testing.T) {
 		t.Errorf("Metadata mismatch:\n  v2=%+v\n  legacy=%+v",
 			v2Mock.Spec.Metadata, legacyMock.Spec.Metadata)
 	}
+
+	// TestModeInfo parity. Both paths must stamp LifetimePerTest +
+	// LifetimeDerived at build time: an unstamped V2 mock hits
+	// DeriveLifetime's lax-mode kind-fallback at AddMock ingest (its
+	// "HTTP_CLIENT" type tag is non-canonical), gets promoted to
+	// LifetimeSession, and syncMock's lifetime carve-out then persists it
+	// unconditionally — bypassing window resolution and dedup cleanup.
+	if !reflect.DeepEqual(v2Mock.TestModeInfo, legacyMock.TestModeInfo) {
+		t.Errorf("TestModeInfo mismatch:\n  v2=%+v\n  legacy=%+v",
+			v2Mock.TestModeInfo, legacyMock.TestModeInfo)
+	}
+	if v2Mock.TestModeInfo.Lifetime != models.LifetimePerTest || !v2Mock.TestModeInfo.LifetimeDerived {
+		t.Errorf("V2 mock must be stamped LifetimePerTest+LifetimeDerived at build time, got %+v",
+			v2Mock.TestModeInfo)
+	}
 }
 
 // runLegacyParseFinalHTTP invokes the legacy parseFinalHTTP on the given


### PR DESCRIPTION
## Describe the changes that are made
- 
This pull request updates the handling and testing of the `TestModeInfo` field for HTTP mocks in the proxy integration. The main focus is to ensure that all v2 HTTP mocks are stamped with `LifetimePerTest` and `LifetimeDerived` at build time, aligning their behavior with legacy mocks and preventing incorrect lifetime promotion during ingestion.

Key changes:

**HTTP Mock Construction:**
- Ensures that all v2 HTTP mocks are initialized with `TestModeInfo` set to `LifetimePerTest` and `LifetimeDerived: true` in the `buildHTTPMock` function. This prevents mocks from being promoted to `LifetimeSession` and bypassing deduplication logic.

**Testing and Parity Checks:**
- Adds assertions to the `TestRecordV2_LegacyParity` test to verify that both v2 and legacy mocks have matching `TestModeInfo` fields and are correctly stamped at build time. This guards against regressions and ensures consistent mock behavior.

## Links & References

**Closes:** https://github.com/keploy/enterprise/issues/2063
## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [X] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [X] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [X] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [X] 🙅 no, because it is not needed

## Self Review done?
- [X] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [X] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [X] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [X] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?