### PR TITLE
feat(cbshim): forward channelBindingShim to replay + scoped CAP_SYS_ADMIN

### DIFF
--- a/pkg/platform/docker/docker.go
+++ b/pkg/platform/docker/docker.go
@@ -656,6 +656,14 @@ func (idc *Impl) GenerateKeployAgentService(opts models.SetupOptions) (*yaml.Nod
 		{Kind: yaml.ScalarNode, Value: "SYS_PTRACE"},
 		{Kind: yaml.ScalarNode, Value: "SYS_NICE"},
 	}
+	if opts.ChannelBindingShim {
+		// The SCRAM-SHA-256-PLUS channel-binding shim rewrites the client's
+		// tls-server-end-point digest with bpf_probe_write_user, which the
+		// verifier gates behind CAP_SYS_ADMIN — CAP_BPF/CAP_PERFMON alone are
+		// insufficient. Only grant it when the shim is explicitly enabled.
+		capAdd = append(capAdd, &yaml.Node{Kind: yaml.ScalarNode, Value: "SYS_ADMIN",
+			LineComment: "required by the channel-binding shim (bpf_probe_write_user)"})
+	}
 
 	// Create the service YAML node structure
 	serviceNode := &yaml.Node{

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -811,7 +811,7 @@ func (r *Replayer) Instrument(ctx context.Context) (*InstrumentState, error) {
 		passPortsUint32[i] = uint32(port)
 	}
 
-	err := r.instrumentation.Setup(ctx, r.config.Command, models.SetupOptions{Container: r.config.ContainerName, CommandType: r.config.CommandType, DockerDelay: r.config.BuildDelay, Mode: models.MODE_TEST, BuildDelay: r.config.BuildDelay, EnableTesting: true, GlobalPassthrough: r.config.Record.GlobalPassthrough, ConfigPath: r.config.ConfigPath, PassThroughPorts: passPortsUint, InMemoryCompose: r.config.InMemoryCompose})
+	err := r.instrumentation.Setup(ctx, r.config.Command, models.SetupOptions{Container: r.config.ContainerName, CommandType: r.config.CommandType, DockerDelay: r.config.BuildDelay, Mode: models.MODE_TEST, BuildDelay: r.config.BuildDelay, EnableTesting: true, GlobalPassthrough: r.config.Record.GlobalPassthrough, ChannelBindingShim: r.config.Record.ChannelBindingShim, ConfigPath: r.config.ConfigPath, PassThroughPorts: passPortsUint, InMemoryCompose: r.config.InMemoryCompose})
 	if err != nil {
 		stopReason := "failed setting up the environment"
 		utils.LogError(r.logger, err, stopReason)


### PR DESCRIPTION
## Summary

Two small OSS-side gaps that block the SCRAM-SHA-256-PLUS channel-binding shim (the enterprise cbshim — keploy/enterprise#2070 record + #2073 replay) from working end-to-end.

### 1. Forward `channelBindingShim` to the replay path (`pkg/service/replay/replay.go`)
`proxy.New` constructs the cbshim factory only when `opts.Agent.ChannelBindingShim || opts.Record.ChannelBindingShim`. The record path sets it; the **test/replay** `SetupOptions` does not, so on `keploy test` the factory is never built. Result: an app with `channel_binding=require` can be **recorded** (with the shim) but never **replayed** — libpq rejects the mock's trust-mode `AuthenticationOk` with `channel binding required, but server authenticated client without channel binding`.

One line: forward `Record.ChannelBindingShim` into the test `SetupOptions`. The enterprise shim then downgrades `channel_binding=require`→`disable` on libpq during replay so the mocked auth is accepted.

### 2. Grant `CAP_SYS_ADMIN` to the agent container when the shim is on (`pkg/platform/docker/docker.go`)
The shim's `bpf_probe_write_user` is gated behind `CAP_SYS_ADMIN`; `CAP_BPF`+`CAP_PERFMON` are **not** enough — the BPF program fails to load in the agent container (`program ... cannot use helper bpf_probe_write_user`). Add `SYS_ADMIN` to the agent `cap_add`, **only when `ChannelBindingShim` is enabled** (least-privilege; no change for everyone else).

## Why
Without (1), replay of any channel_binding=require recording fails. Without (2), the shim is dead in docker-compose mode (agent-in-container) unless the whole agent is run `privileged`.

## Test plan
- [x] Builds.
- [x] Verified live: with both changes, a psycopg2-binary app on `channel_binding=require` records **and** replays (12/12) through keploy's MITM in docker-compose mode.
- [ ] CI green alongside the enterprise PRs.

Companion: keploy/enterprise#2070 (record), keploy/enterprise#2073 (replay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
