### PR TITLE
fix(postgres): decode timestamps with >4-digit and negative years

### DIFF
--- a/pkg/models/postgres_v3_cell_json.go
+++ b/pkg/models/postgres_v3_cell_json.go
@@ -1034,9 +1034,11 @@ func decodeJSONTimestamp(v any) (time.Time, error) {
 	}
 	// Go's RFC3339 layouts only accept a 4-digit year, but Postgres timestamps
 	// (and our RFC3339Nano encoder, which uses time.Time.Format) can carry years
-	// up to 6 digits — Postgres' max is 294276 — plus negative ("…-…-… BC")
-	// years. Such values fail the layouts above with "cannot parse … as \"-\"".
-	// Re-parse with the year normalized to 4 digits, then restore the real year.
+	// up to 6 digits — Postgres' max is 294276 — plus negative years, which
+	// time.Time.Format renders with a signed leading '-' (e.g.
+	// "-0753-04-21T00:00:00Z"), not a "BC" suffix. Such values fail the layouts
+	// above with "cannot parse … as \"-\"". Re-parse with the year normalized to
+	// 4 digits, then restore the real (possibly negative) year.
 	if t, err := parseWideYearRFC3339(s); err == nil {
 		return t, nil
 	}
@@ -1053,7 +1055,7 @@ func decodeJSONTimestamp(v any) (time.Time, error) {
 func parseWideYearRFC3339(s string) (time.Time, error) {
 	neg := false
 	body := s
-	if strings.HasPrefix(body, "-") { // leading '-' => negative (BC-era) year
+	if strings.HasPrefix(body, "-") { // signed leading '-' => negative year
 		neg = true
 		body = body[1:]
 	}

--- a/pkg/models/postgres_v3_cell_json.go
+++ b/pkg/models/postgres_v3_cell_json.go
@@ -43,6 +43,7 @@ import (
 	"net/netip"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -1028,11 +1029,54 @@ func decodeJSONTimestamp(v any) (time.Time, error) {
 	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
 		return t, nil
 	}
-	t, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("$pgtype timestamp: %w", err)
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, nil
 	}
-	return t, nil
+	// Go's RFC3339 layouts only accept a 4-digit year, but Postgres timestamps
+	// (and our RFC3339Nano encoder, which uses time.Time.Format) can carry years
+	// up to 6 digits — Postgres' max is 294276 — plus negative ("…-…-… BC")
+	// years. Such values fail the layouts above with "cannot parse … as \"-\"".
+	// Re-parse with the year normalized to 4 digits, then restore the real year.
+	if t, err := parseWideYearRFC3339(s); err == nil {
+		return t, nil
+	}
+	// Surface the standard-layout error — it's the most recognizable.
+	_, err = time.Parse(time.RFC3339Nano, s)
+	return time.Time{}, fmt.Errorf("$pgtype timestamp: %w", err)
+}
+
+// parseWideYearRFC3339 parses an RFC3339[Nano] timestamp whose year is not
+// exactly 4 digits (e.g. "149206-12-15T16:39:16.394721Z" or a negative year),
+// which time.Parse's "2006" layout token rejects. It splits off the year,
+// reparses the remainder with a 4-digit placeholder, and rebuilds via time.Date
+// so the fractional seconds and timezone offset are preserved exactly.
+func parseWideYearRFC3339(s string) (time.Time, error) {
+	neg := false
+	body := s
+	if strings.HasPrefix(body, "-") { // leading '-' => negative (BC-era) year
+		neg = true
+		body = body[1:]
+	}
+	dash := strings.IndexByte(body, '-') // first '-' terminates the year field
+	if dash <= 0 {
+		return time.Time{}, fmt.Errorf("no year separator in %q", s)
+	}
+	year, err := strconv.Atoi(body[:dash])
+	if err != nil {
+		return time.Time{}, fmt.Errorf("bad year in %q: %w", s, err)
+	}
+	norm := "0000" + body[dash:] // placeholder 4-digit year for the std layout
+	t, err := time.Parse(time.RFC3339Nano, norm)
+	if err != nil {
+		if t, err = time.Parse(time.RFC3339, norm); err != nil {
+			return time.Time{}, err
+		}
+	}
+	if neg {
+		year = -year
+	}
+	return time.Date(year, t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(),
+		t.Nanosecond(), t.Location()), nil
 }
 
 func decodeJSONPrefix(v any) (netip.Prefix, error) {

--- a/pkg/models/postgres_v3_timestamp_test.go
+++ b/pkg/models/postgres_v3_timestamp_test.go
@@ -34,6 +34,19 @@ func TestDecodeJSONTimestamp_WideAndNormalYears(t *testing.T) {
 			in:   "294276-12-31T23:59:59Z",
 			want: time.Date(294276, time.December, 31, 23, 59, 59, 0, time.UTC),
 		},
+		{
+			// Negative (signed) wide year — time.Time.Format emits a
+			// leading '-', which the std layouts reject. Exercises the
+			// sign-strip + re-apply path in parseWideYearRFC3339.
+			name: "negative wide year UTC",
+			in:   "-12345-06-15T10:11:12.5Z",
+			want: time.Date(-12345, time.June, 15, 10, 11, 12, 500000000, time.UTC),
+		},
+		{
+			name: "negative wide year with offset",
+			in:   "-0753-04-21T00:00:00+01:00",
+			want: time.Date(-753, time.April, 21, 0, 0, 0, 0, time.FixedZone("", 3600)),
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -54,6 +67,11 @@ func TestDecodeJSONTimestamp_WideYearRoundTrip(t *testing.T) {
 	for _, want := range []time.Time{
 		time.Date(149206, time.December, 15, 16, 39, 16, 394721000, time.UTC),
 		time.Date(99999, time.July, 4, 1, 2, 3, 0, time.UTC),
+		// Negative wide year — guards the sign round-trip.
+		time.Date(-12345, time.January, 2, 3, 4, 5, 678900000, time.UTC),
+		// Non-UTC offset + fractional seconds — guards offset/precision
+		// preservation through the wide-year fallback.
+		time.Date(12345, time.January, 2, 3, 4, 5, 678900000, time.FixedZone("", 5*3600+30*60)),
 	} {
 		enc := want.Format(time.RFC3339Nano)
 		got, err := decodeJSONTimestamp(enc)
@@ -62,6 +80,14 @@ func TestDecodeJSONTimestamp_WideYearRoundTrip(t *testing.T) {
 		}
 		if !got.Equal(want) {
 			t.Fatalf("round-trip %q = %v, want %v", enc, got, want)
+		}
+		// Equality only compares the instant; the JSON round-trip must be
+		// lossless at the string level too, so re-encoding the decoded time
+		// with RFC3339Nano must reproduce the exact input — preserving the
+		// timezone offset and fractional-second precision, not just the
+		// represented instant.
+		if reEnc := got.Format(time.RFC3339Nano); reEnc != enc {
+			t.Fatalf("round-trip %q re-encodes to %q (offset/precision not preserved)", enc, reEnc)
 		}
 	}
 }

--- a/pkg/models/postgres_v3_timestamp_test.go
+++ b/pkg/models/postgres_v3_timestamp_test.go
@@ -1,0 +1,77 @@
+package models
+
+import (
+	"testing"
+	"time"
+)
+
+// Regression for the postgres fuzzer failure: a 6-digit-year timestamp
+// ("149206-12-15T16:39:16.394721Z") round-trips through the RFC3339Nano encoder
+// but failed to decode because Go's "2006" layout token only accepts 4 digits.
+func TestDecodeJSONTimestamp_WideAndNormalYears(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want time.Time
+	}{
+		{
+			name: "4-digit year (fast path)",
+			in:   "2024-06-15T10:11:12.345678Z",
+			want: time.Date(2024, time.June, 15, 10, 11, 12, 345678000, time.UTC),
+		},
+		{
+			name: "6-digit year UTC (the fuzzer case)",
+			in:   "149206-12-15T16:39:16.394721Z",
+			want: time.Date(149206, time.December, 15, 16, 39, 16, 394721000, time.UTC),
+		},
+		{
+			name: "5-digit year with offset preserved",
+			in:   "12345-01-02T03:04:05.6789+05:30",
+			want: time.Date(12345, time.January, 2, 3, 4, 5, 678900000, time.FixedZone("", 5*3600+30*60)),
+		},
+		{
+			name: "postgres max year 294276",
+			in:   "294276-12-31T23:59:59Z",
+			want: time.Date(294276, time.December, 31, 23, 59, 59, 0, time.UTC),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := decodeJSONTimestamp(tc.in)
+			if err != nil {
+				t.Fatalf("decodeJSONTimestamp(%q) error: %v", tc.in, err)
+			}
+			if !got.Equal(tc.want) {
+				t.Fatalf("decodeJSONTimestamp(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// Encoding a wide-year time.Time via the same RFC3339Nano layout and decoding it
+// back must be lossless — the round-trip the postgres replay path relies on.
+func TestDecodeJSONTimestamp_WideYearRoundTrip(t *testing.T) {
+	for _, want := range []time.Time{
+		time.Date(149206, time.December, 15, 16, 39, 16, 394721000, time.UTC),
+		time.Date(99999, time.July, 4, 1, 2, 3, 0, time.UTC),
+	} {
+		enc := want.Format(time.RFC3339Nano)
+		got, err := decodeJSONTimestamp(enc)
+		if err != nil {
+			t.Fatalf("round-trip %q: %v", enc, err)
+		}
+		if !got.Equal(want) {
+			t.Fatalf("round-trip %q = %v, want %v", enc, got, want)
+		}
+	}
+}
+
+// Genuinely malformed input must still error (we don't want the wide-year
+// fallback to mask real corruption).
+func TestDecodeJSONTimestamp_Invalid(t *testing.T) {
+	for _, in := range []string{"not-a-time", "2024-13-99T99:99:99Z", ""} {
+		if _, err := decodeJSONTimestamp(in); err == nil {
+			t.Fatalf("decodeJSONTimestamp(%q): expected error, got nil", in)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the intermittent **Postgres Fuzzer** failure (`failed to decode the config mocks from json doc` / `$pgtype timestamp: parsing time …`) that shows up on PRs whose fuzz run happens to generate a timestamp with a year outside 4 digits — e.g. seen on #4247:

```
$pgtype timestamp: parsing time "149206-12-15T16:39:16.394721Z" as
"2006-01-02T15:04:05Z07:00": cannot parse "06-12-15T16:39:16.394721Z" as "-"
```

## Root cause

`PostgresV3` cells encode timestamps with `time.Time.Format(RFC3339Nano)` (`pkg/models/postgres_v3_cell_json.go:106`), which renders **years beyond 4 digits** (Postgres allows up to **294276**) and negative/BC years verbatim. But `decodeJSONTimestamp` only tried `time.RFC3339Nano` / `time.RFC3339`, whose `2006` layout token accepts **exactly 4 digits** — so a wide-year value the encoder happily produced could not be decoded back. Pre-existing; the fuzzer just surfaces it when its random data lands a big year.

## Fix

A wide-year fallback in `decodeJSONTimestamp`: split off the year, reparse the remainder with a 4-digit placeholder, and rebuild via `time.Date` so fractional seconds and the timezone offset are preserved exactly. Normal 4-digit years keep the fast path; genuinely malformed input still errors.

## Tests
`pkg/models` — 6-digit year (the fuzzer case), 5-digit + offset, Postgres max 294276, lossless round-trip, and invalid-still-errors. `go test ./pkg/models/` green; gofmt/vet clean.

## Note
Not a cbshim/channel-binding change — independent core fix. It's the real cause of the Postgres-fuzzer red on #4247 (whose own diff is flag-gated cbshim wiring and doesn't touch Postgres typing). Merging this clears that flake for every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
