### PR TITLE
chore(cbshim): demote per-attach proxy logs to debug

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -77,17 +77,21 @@ type Record struct {
 	Synchronous    bool   `json:"sync" yaml:"sync" mapstructure:"sync"`
 	EnableSampling int    `json:"enableSampling" yaml:"enableSampling"`
 	// ChannelBindingShim enables the SCRAM-SHA-256-PLUS channel-binding shim.
-	// The shim attaches eBPF uprobes to libcrypto's X509_digest and rewrites the
-	// cert-hash libpq folds into the SCRAM proof, so postgres clients running
-	// with channel_binding=require still authenticate through keploy's TLS MITM
-	// against the REAL upstream postgres at record time. Replay does not forward
-	// to the real database — postgres traffic is served from mocks, no SCRAM
-	// handshake actually completes against postgres — so the shim is record-only.
+	// It has two mode-specific behaviors:
+	//   - RECORD: attaches eBPF uprobes to libcrypto's X509_digest and rewrites
+	//     the cert hash libpq folds into the SCRAM proof, so postgres clients
+	//     running with channel_binding=require still authenticate through keploy's
+	//     TLS MITM against the REAL upstream postgres.
+	//   - REPLAY: postgres traffic is served from trust-mode mocks (no real cert,
+	//     so channel binding cannot complete). The shim instead downgrades libpq's
+	//     channel_binding=require to disable so the mocked auth is accepted. This
+	//     intentionally relaxes a security control, but only against keploy's mock.
 	// OSS builds have no implementation registered and ignore this flag entirely;
 	// builds with a registered factory respect it. Defaults to false; flip to
-	// true in keploy.yml under record: to opt in. Requires CAP_BPF + a kernel
-	// that allows bpf_probe_write_user; without those the factory returns an
-	// error and the proxy keeps working for non-PLUS clients.
+	// true in keploy.yml under record: to opt in (the same flag drives both modes;
+	// replay reads it from the record config / the stored auto-replay config).
+	// Requires CAP_BPF + a kernel that allows bpf_probe_write_user; without those
+	// the factory returns an error and the proxy keeps working for non-PLUS clients.
 	ChannelBindingShim bool   `json:"channelBindingShim" yaml:"channelBindingShim" mapstructure:"channelBindingShim"`
 	MemoryLimit        uint64 `json:"memoryLimit" yaml:"memoryLimit" mapstructure:"memoryLimit"`
 	GlobalPassthrough  bool   `json:"globalPassthrough" yaml:"globalPassthrough" mapstructure:"globalPassthrough"`

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -935,14 +935,14 @@ func (p *Proxy) StartProxy(ctx context.Context, opts agent.ProxyOptions) error {
 		// only handles late-loaded libcrypto files (bundled wheel
 		// libs that appear after worker fork-exec) — its job is
 		// per-file uprobe attach, NOT PID tracking.
-		p.logger.Info("cbshim: scanning process tree for libcrypto/libpq mappings",
+		p.logger.Debug("cbshim: scanning process tree for libcrypto/libpq mappings",
 			zap.Uint32("appPID", p.appPID))
 		if err := p.cbshim.AttachToProcessTree(int(p.appPID)); err != nil {
-			p.logger.Info("cbshim: AttachToProcessTree returned error (continuing — library refresh will retry)",
+			p.logger.Debug("cbshim: AttachToProcessTree returned error (continuing — library refresh will retry)",
 				zap.Uint32("appPID", p.appPID), zap.Error(err),
 				zap.String("next_step", "the first-pass scan of /proc/<appPID>/maps + descendants failed to find or attach a uprobe for libcrypto/libpq; the BPF discovery hook (cbshim's security_mmap_file fentry) will catch them on the next library mmap, so this is non-fatal. If SCRAM-PLUS still fails after a few requests, rerun with --debug to see per-process scanProcessMaps results and confirm the agent has CAP_BPF + the kernel allows bpf_probe_write_user."))
 		} else {
-			p.logger.Info("cbshim: AttachToProcessTree completed", zap.Uint32("appPID", p.appPID))
+			p.logger.Debug("cbshim: AttachToProcessTree completed", zap.Uint32("appPID", p.appPID))
 		}
 		// Kick the sched_process_exec ringbuf consumer. The kernel
 		// emits an event every time a process in the agent's PID


### PR DESCRIPTION
## What
The cbshim process-tree scan logs at INFO on every `AttachToProcessTree` call (`cbshim: scanning process tree…`, `cbshim: AttachToProcessTree returned error/completed`). During `cloud replay` this is noisy. This demotes those per-attach lines to **debug**.

Kept at INFO (one-time / actionable):
- `cbshim: BPF-backed channel-binding shim enabled` (activation breadcrumb)
- the factory-error and OSS-build-no-impl notices

## Why
User feedback: too many `INFO cbshim:` lines during local cloud replay. The companion enterprise change demotes the enterprise-side per-event logs (gate lifecycle, scanProcessMaps, downgrade-attached, attached-uprobes) similarly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)