### PR TITLE
fix: mysql parser to use mock manager by default, and mock scoping

### DIFF
--- a/pkg/agent/proxy/integrations/mysql/recorder/race_drain_test.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/race_drain_test.go
@@ -9,10 +9,39 @@ import (
 	"time"
 
 	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/wire"
+	syncMock "go.keploy.io/server/v3/pkg/agent/proxy/syncMock"
 	"go.keploy.io/server/v3/pkg/models"
 	"go.keploy.io/server/v3/pkg/models/mysql"
 	"go.uber.org/zap/zaptest"
 )
+
+// wireSyncMockOutput plugs the process-global syncMock singleton's
+// output channel into the test's mocks channel. recordMock routes every
+// emitted MySQL mock through syncMock.AddMock (mirroring the HTTP legacy
+// recorder), so the only way to observe emitted mocks from a unit test
+// is to bind the manager's outChan: when a channel is bound and
+// firstReqSeen is false (the default singleton state), AddMock forwards
+// synchronously. Cleanup unbinds by pointing the manager at a throwaway
+// channel (SetOutputChannel's same-pointer guard requires a distinct
+// channel to clear the closed flag).
+//
+// Tests using this MUST NOT call t.Parallel(): the syncMock singleton is
+// process-global, so two tests binding their own outChan concurrently
+// would interleave each other's mocks.
+func wireSyncMockOutput(t *testing.T, mocks chan *models.Mock) {
+	t.Helper()
+	mgr := syncMock.Get()
+	if mgr == nil {
+		return
+	}
+	mgr.SetOutputChannel(mocks)
+	t.Cleanup(func() {
+		// Restore the pristine unbound (nil) state so any later test in
+		// this package sees the default buffering behavior rather than a
+		// dangling reader-less channel.
+		mgr.SetOutputChannel(nil)
+	})
+}
 
 // pipeConn is a net.Conn-shaped wrapper around a unidirectional byte
 // pipe. Reads block until bytes are pushed or the conn is closed.
@@ -195,7 +224,8 @@ func prepareOkShort(seq byte, stmtID uint32) []byte {
 //     fast path so a successful Read can never lose its bytes to a
 //     concurrent ctx-cancel.
 func TestHandleClientQueries_DrainOnCtxCancel(t *testing.T) {
-	t.Parallel()
+	// Not parallel: recordMock routes through the process-global syncMock
+	// singleton (see wireSyncMockOutput).
 
 	clientConn := newPipeConn()
 	destConn := newPipeConn()
@@ -204,6 +234,7 @@ func TestHandleClientQueries_DrainOnCtxCancel(t *testing.T) {
 	decodeCtx.LastOp.Store(clientConn, wire.RESET)
 
 	mocks := make(chan *models.Mock, 8)
+	wireSyncMockOutput(t, mocks)
 	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), models.ClientConnectionIDKey, "test-conn-0"))
 
 	done := make(chan struct{})
@@ -291,7 +322,8 @@ collect:
 // column/param defs — that keeps the test focused on the cancel-race
 // boundary rather than the result-set decoder's state machine.
 func TestHandleClientQueries_PreparePlusExecute(t *testing.T) {
-	t.Parallel()
+	// Not parallel: recordMock routes through the process-global syncMock
+	// singleton (see wireSyncMockOutput).
 
 	clientConn := newPipeConn()
 	destConn := newPipeConn()
@@ -300,6 +332,7 @@ func TestHandleClientQueries_PreparePlusExecute(t *testing.T) {
 	decodeCtx.LastOp.Store(clientConn, wire.RESET)
 
 	mocks := make(chan *models.Mock, 8)
+	wireSyncMockOutput(t, mocks)
 	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), models.ClientConnectionIDKey, "test-conn-1"))
 
 	done := make(chan struct{})

--- a/pkg/agent/proxy/integrations/mysql/recorder/record.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record.go
@@ -198,19 +198,17 @@ func recordMock(ctx context.Context, requests []mysql.Request, responses []mysql
 			LifetimeDerived: true,
 		},
 	}
-	// Send to the mocks channel for YAML output. Use either the direct
-	// mocks channel or syncMock.AddMock, but NOT both — AddMock also sends
-	// to outChan (which is the same channel in the sockmap proxy path),
-	// causing every mock to be written to YAML twice.
+
+	if mgr := syncMock.Get(); mgr != nil {
+		mgr.AddMock(mysqlMock)
+		return
+	}
 	if mocks != nil {
 		select {
 		case mocks <- mysqlMock:
 		case <-ctx.Done():
 			return
 		}
-	} else {
-		mgr := syncMock.Get()
-		mgr.AddMock(mysqlMock)
 	}
 	return
 }

--- a/pkg/agent/proxy/integrations/mysql/recorder/record.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record.go
@@ -180,6 +180,10 @@ func recordMock(ctx context.Context, requests []mysql.Request, responses []mysql
 		lifetime = models.LifetimeSession
 	case "connection":
 		lifetime = models.LifetimeConnection
+	default:
+		if models.IsMySQLSessionReusableCommandType(requestOperation) {
+			lifetime = models.LifetimeSession
+		}
 	}
 	mysqlMock := &models.Mock{
 		Version: models.GetVersion(),
@@ -207,8 +211,6 @@ func recordMock(ctx context.Context, requests []mysql.Request, responses []mysql
 		select {
 		case mocks <- mysqlMock:
 		case <-ctx.Done():
-			return
 		}
 	}
-	return
 }

--- a/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
@@ -850,6 +850,14 @@ func emitMockV2(ctx context.Context, sess *supervisor.Session, requests []mysql.
 	if sess.Opts.DstCfg != nil && sess.Opts.DstCfg.Addr != "" {
 		meta["destAddr"] = sess.Opts.DstCfg.Addr
 	}
+
+	lifetime := models.LifetimePerTest
+	switch mockType {
+	case "config":
+		lifetime = models.LifetimeSession
+	case "connection":
+		lifetime = models.LifetimeConnection
+	}
 	m := &models.Mock{
 		Version: models.GetVersion(),
 		Kind:    models.MySQL,
@@ -862,7 +870,12 @@ func emitMockV2(ctx context.Context, sess *supervisor.Session, requests []mysql.
 			ReqTimestampMock: reqTs,
 			ResTimestampMock: resTs,
 		},
+		TestModeInfo: models.TestModeInfo{
+			Lifetime:        lifetime,
+			LifetimeDerived: true,
+		},
 	}
+
 	if err := sess.EmitMock(m); err != nil {
 		if sess.Logger != nil {
 			sess.Logger.Debug("V2: emit mock failed", zap.Error(err))

--- a/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
@@ -857,6 +857,10 @@ func emitMockV2(ctx context.Context, sess *supervisor.Session, requests []mysql.
 		lifetime = models.LifetimeSession
 	case "connection":
 		lifetime = models.LifetimeConnection
+	default:
+		if models.IsMySQLSessionReusableCommandType(reqOp) {
+			lifetime = models.LifetimeSession
+		}
 	}
 	m := &models.Mock{
 		Version: models.GetVersion(),

--- a/pkg/models/lifetime.go
+++ b/pkg/models/lifetime.go
@@ -369,7 +369,25 @@ func mysqlIsSessionReusableCommand(m *Mock) bool {
 	if hdr == nil {
 		return false
 	}
-	switch hdr.Type {
+	return IsMySQLSessionReusableCommandType(hdr.Type)
+}
+
+// IsMySQLSessionReusableCommandType reports whether a MySQL command
+// packet type (the wire Header.Type string, e.g. "COM_PING") is a
+// connection-alive command whose response is input-independent and
+// therefore safe to treat as session-scoped regardless of the on-disk
+// "mocks" tag. It is the single source of truth shared by
+// DeriveLifetime's rule #1 (replay/disk-load ingest) and the MySQL
+// recorders (record.go / record_v2.go), which must stamp
+// LifetimeSession for these at emit time — otherwise, with
+// LifetimeDerived=true pinning the per-test classification, a keepalive
+// fired between test windows is window-filtered and stale-dropped
+// during recording and never makes it to disk.
+//
+// Deliberately narrow — COM_QUERY/COM_INIT_DB/COM_CHANGE_USER/
+// COM_SET_OPTION depend on input and must stay per-test.
+func IsMySQLSessionReusableCommandType(cmdType string) bool {
+	switch cmdType {
 	case "COM_PING", "COM_STATISTICS", "COM_DEBUG", "COM_RESET_CONNECTION":
 		return true
 	}


### PR DESCRIPTION
## Describe the changes that are made
- 
This pull request updates the MySQL mock recording logic to ensure mocks are only sent once and to improve how mock lifetimes are set in version 2 of the recorder. The changes help prevent duplicate mock entries and ensure the correct lifetime is assigned to each mock based on its type.

**Duplicate prevention and channel handling:**

* In `record.go`, updated the logic to check if a `syncMock` manager exists and, if so, use `AddMock` and return immediately, preventing mocks from being sent to the output channel twice.

**Mock lifetime assignment improvements:**

* In `record_v2.go`, added logic to set the mock's `lifetime` based on its type (`config`, `connection`, or default to `per-test`) before creating the mock.
* Added the `TestModeInfo` field to the mock with the chosen `lifetime` and `LifetimeDerived` set to `true` for more accurate test mode metadata.

## Links & References

**Closes:** https://github.com/keploy/enterprise/issues/2089

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [X] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [X] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [X] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [X] 🙅 no, because it is not needed

## Self Review done?
- [X] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [X] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [X] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [X] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?