### PR TITLE
feat(cbshim): multi-factory support so multiple shim impls coexist

### DIFF
--- a/pkg/agent/proxy/cbshim/iface.go
+++ b/pkg/agent/proxy/cbshim/iface.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/x509"
 	"errors"
+	"fmt"
 
 	"go.uber.org/zap"
 )
@@ -67,40 +68,145 @@ type CBShim interface {
 	Close() error
 }
 
-// Factory constructs a CBShim. Registered once at init() time by the
-// implementation package; nil otherwise, in which case NewFromFactory
-// returns (nil, nil).
+// Factory constructs a CBShim. Registered at init() time by each
+// implementation package; the package supports multiple registered
+// factories so distinct shim backends (e.g. eBPF uprobe + LD_PRELOAD)
+// can coexist in a single binary and each handle the cases the other
+// can't — eBPF works regardless of how libcrypto was loaded but needs
+// CAP_BPF + kernel support; LD_PRELOAD works without kernel support
+// but only against binaries that consult ld.so. With both registered,
+// RegisterMITM/RegisterReal etc. fan out to every impl via the
+// composite returned by NewFromFactory.
 type Factory func(logger *zap.Logger) (CBShim, error)
 
-var registeredFactory Factory
+var registeredFactories []Factory
 
-// RegisterFactory installs the concrete cbshim constructor. Intended
-// to be called from init() in the implementation package. Calling
-// twice silently overwrites — the last registration wins. Not safe
-// for concurrent registration, but init() ordering makes that a
-// non-issue in practice.
+// RegisterFactory installs a concrete cbshim constructor. Called from
+// init() in each implementation package; subsequent calls APPEND
+// (they do not overwrite, in contrast to the original single-factory
+// behaviour this replaces) so that blank-importing multiple impl
+// packages from a binary's main wires all of them.
+//
+// Not safe for concurrent registration, but init() ordering makes
+// that a non-issue in practice.
 func RegisterFactory(f Factory) {
-	registeredFactory = f
+	if f == nil {
+		return
+	}
+	registeredFactories = append(registeredFactories, f)
 }
 
-// NewFromFactory invokes the registered factory if one was installed.
-// Returns (nil, nil) when no factory is registered — that signals
-// "no cbshim available" to the caller, which must keep working
-// without it.
+// NewFromFactory invokes every registered factory and returns either
+// the single impl (when one factory is registered) or a composite
+// CBShim that fans out every call to all sub-impls (when more than
+// one is registered). Returns (nil, nil) when no factory is registered
+// — that signals "no cbshim available" to the caller, which must
+// keep working without it.
 //
-// Contract: a REGISTERED factory must return either (impl, nil) on
-// success or (nil, err) on construction failure. (nil, nil) from a
-// registered factory is treated as an error here, so callers don't
-// observe an ambiguous "no factory registered" state that's actually
-// "factory ran but produced nothing", and the proxy.New log branch
-// that points users at OSS-vs-enterprise stays accurate.
+// Contract per factory: each REGISTERED factory must return either
+// (impl, nil) on success or (nil, err) on construction failure.
+// (nil, nil) from a registered factory is treated as an error so
+// callers don't observe an ambiguous "no factory registered" state
+// that's actually "factory ran but produced nothing". A construction
+// error from any one factory aborts the whole NewFromFactory call —
+// the OSS proxy.New log branch that points users at
+// OSS-vs-enterprise stays accurate.
 func NewFromFactory(logger *zap.Logger) (CBShim, error) {
-	if registeredFactory == nil {
+	if len(registeredFactories) == 0 {
 		return nil, nil
 	}
-	cb, err := registeredFactory(logger)
-	if err == nil && cb == nil {
-		return nil, errors.New("cbshim: registered factory returned (nil, nil); a registered factory must produce a non-nil implementation or a non-nil error")
+	if len(registeredFactories) == 1 {
+		// Preserve the original single-factory return path verbatim —
+		// no composite wrapper, callers that pre-date multi-factory
+		// observe the same concrete type / behaviour as before.
+		cb, err := registeredFactories[0](logger)
+		if err == nil && cb == nil {
+			return nil, errors.New("cbshim: registered factory returned (nil, nil); a registered factory must produce a non-nil implementation or a non-nil error")
+		}
+		return cb, err
 	}
-	return cb, err
+	impls := make([]CBShim, 0, len(registeredFactories))
+	for i, f := range registeredFactories {
+		cb, err := f(logger)
+		if err != nil {
+			return nil, fmt.Errorf("cbshim: factory %d construction failed: %w", i, err)
+		}
+		if cb == nil {
+			return nil, fmt.Errorf("cbshim: factory %d returned (nil, nil); each registered factory must produce a non-nil implementation or a non-nil error", i)
+		}
+		impls = append(impls, cb)
+	}
+	return &composite{impls: impls}, nil
+}
+
+// composite fans every CBShim method out to a slice of underlying
+// impls. Used by NewFromFactory when more than one factory is
+// registered. Each impl maintains its own internal state + actuator
+// (eBPF impl publishes into a BPF map; LD_PRELOAD impl publishes
+// into a file/shm read by its .so), so calling RegisterMITM /
+// RegisterReal on all of them is the correct semantics — whichever
+// path the target process exposes is the one that takes effect.
+//
+// AttachToProcessTree and StartProcEventConsumer also fan out, but
+// the LD_PRELOAD impl typically no-ops them (it doesn't attach
+// uprobes; it ships a .so the loader picks up). Each impl is
+// responsible for being a no-op when its mechanism doesn't apply.
+//
+// Close is best-effort: every impl's Close is invoked even when an
+// earlier one returns an error, so a failing impl can't strand
+// another impl's resources. The first error is returned; subsequent
+// errors are dropped (they'd be redundant with the first in
+// practice, since Close failures share a root cause — process
+// shutting down, etc.).
+type composite struct {
+	impls []CBShim
+}
+
+func (c *composite) RegisterMITM(connID string, mitmDER []byte) {
+	for _, i := range c.impls {
+		i.RegisterMITM(connID, mitmDER)
+	}
+}
+
+func (c *composite) RegisterReal(connID string, realDER []byte, sigAlgo x509.SignatureAlgorithm) {
+	for _, i := range c.impls {
+		i.RegisterReal(connID, realDER, sigAlgo)
+	}
+}
+
+func (c *composite) CleanupConnection(connID string) {
+	for _, i := range c.impls {
+		i.CleanupConnection(connID)
+	}
+}
+
+func (c *composite) AttachToProcessTree(rootPID int) error {
+	// Fan out; collect errors. An impl that doesn't attach to
+	// processes (LD_PRELOAD) should return nil — it's not a failure
+	// to have nothing to attach.
+	var firstErr error
+	for i, impl := range c.impls {
+		if err := impl.AttachToProcessTree(rootPID); err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("cbshim: impl %d AttachToProcessTree: %w", i, err)
+			}
+		}
+	}
+	return firstErr
+}
+
+func (c *composite) StartProcEventConsumer(ctx context.Context) {
+	for _, i := range c.impls {
+		i.StartProcEventConsumer(ctx)
+	}
+}
+
+func (c *composite) Close() error {
+	var firstErr error
+	for i, impl := range c.impls {
+		if err := impl.Close(); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("cbshim: impl %d Close: %w", i, err)
+		}
+	}
+	return firstErr
 }

--- a/pkg/agent/proxy/cbshim/iface_test.go
+++ b/pkg/agent/proxy/cbshim/iface_test.go
@@ -1,0 +1,281 @@
+package cbshim
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"sync"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// resetRegistry clears any factories registered by other tests
+// running in this package. cbshim's registration is process-global;
+// without an explicit reset each test would inherit the previous
+// test's state and produce confusing fan-out counts.
+func resetRegistry(t *testing.T) {
+	t.Helper()
+	saved := registeredFactories
+	registeredFactories = nil
+	t.Cleanup(func() { registeredFactories = saved })
+}
+
+// fakeCBShim is a CBShim that records each method invocation in a
+// slice keyed by name. Tests assert on the recorded call counts /
+// connIDs to confirm fan-out semantics.
+type fakeCBShim struct {
+	mu                sync.Mutex
+	registerMITM      []string
+	registerReal      []string
+	cleanupConnection []string
+	attachToProcTree  []int
+	startProcConsumer int
+	closeCalled       int
+	attachErr         error
+	closeErr          error
+}
+
+func (f *fakeCBShim) RegisterMITM(connID string, _ []byte) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.registerMITM = append(f.registerMITM, connID)
+}
+
+func (f *fakeCBShim) RegisterReal(connID string, _ []byte, _ x509.SignatureAlgorithm) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.registerReal = append(f.registerReal, connID)
+}
+
+func (f *fakeCBShim) CleanupConnection(connID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.cleanupConnection = append(f.cleanupConnection, connID)
+}
+
+func (f *fakeCBShim) AttachToProcessTree(rootPID int) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.attachToProcTree = append(f.attachToProcTree, rootPID)
+	return f.attachErr
+}
+
+func (f *fakeCBShim) StartProcEventConsumer(_ context.Context) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.startProcConsumer++
+}
+
+func (f *fakeCBShim) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closeCalled++
+	return f.closeErr
+}
+
+// TestRegisterFactory_AppendsAcrossCalls covers the core change from
+// the original singleton: two RegisterFactory calls must produce two
+// registered factories. Without this, blank-importing both an eBPF
+// shim and an LD_PRELOAD shim would silently drop one — the symptom
+// is that one of the two SCRAM-PLUS paths fails to substitute hashes
+// in production and the diagnosis ("oh, only the second register
+// won") is invisible from a log line.
+func TestRegisterFactory_AppendsAcrossCalls(t *testing.T) {
+	resetRegistry(t)
+
+	RegisterFactory(func(*zap.Logger) (CBShim, error) { return &fakeCBShim{}, nil })
+	RegisterFactory(func(*zap.Logger) (CBShim, error) { return &fakeCBShim{}, nil })
+
+	if got, want := len(registeredFactories), 2; got != want {
+		t.Fatalf("registeredFactories len = %d, want %d (append, not overwrite)", got, want)
+	}
+}
+
+// Defensive: a nil Factory passed to RegisterFactory must not pollute
+// the slice — NewFromFactory would otherwise panic invoking nil.
+func TestRegisterFactory_IgnoresNil(t *testing.T) {
+	resetRegistry(t)
+
+	RegisterFactory(nil)
+
+	if got := len(registeredFactories); got != 0 {
+		t.Fatalf("registeredFactories len = %d, want 0 (nil factory dropped)", got)
+	}
+}
+
+// Single-factory path must be unchanged: NewFromFactory returns the
+// concrete impl directly, not wrapped in a composite. Pre-multi-
+// factory callers (the existing enterprise eBPF cbshim) observe the
+// exact same concrete type.
+func TestNewFromFactory_SingleFactory_ReturnsBareImpl(t *testing.T) {
+	resetRegistry(t)
+	want := &fakeCBShim{}
+
+	RegisterFactory(func(*zap.Logger) (CBShim, error) { return want, nil })
+
+	got, err := NewFromFactory(zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewFromFactory err = %v, want nil", err)
+	}
+	if got != want {
+		t.Errorf("got bare-impl identity %p, want %p (single-factory path must not wrap in composite)", got, want)
+	}
+	if _, isComposite := got.(*composite); isComposite {
+		t.Errorf("single-factory NewFromFactory returned *composite; expected bare impl for backward compat")
+	}
+}
+
+// No registered factories → (nil, nil). OSS-only builds rely on this
+// to detect "no cbshim available" without an error log; if it ever
+// returned an error, the OSS proxy.New code would surface a scary
+// log line on every startup.
+func TestNewFromFactory_NoFactories_ReturnsNilNil(t *testing.T) {
+	resetRegistry(t)
+
+	got, err := NewFromFactory(zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewFromFactory err = %v, want nil for empty registry", err)
+	}
+	if got != nil {
+		t.Errorf("NewFromFactory cb = %v, want nil for empty registry", got)
+	}
+}
+
+// Multi-factory path: NewFromFactory must wrap impls in *composite
+// and fan calls out to each.
+func TestNewFromFactory_TwoFactories_FansOutAllMethods(t *testing.T) {
+	resetRegistry(t)
+	a := &fakeCBShim{}
+	b := &fakeCBShim{}
+
+	RegisterFactory(func(*zap.Logger) (CBShim, error) { return a, nil })
+	RegisterFactory(func(*zap.Logger) (CBShim, error) { return b, nil })
+
+	cb, err := NewFromFactory(zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewFromFactory err = %v, want nil", err)
+	}
+	if _, ok := cb.(*composite); !ok {
+		t.Fatalf("two-factory NewFromFactory returned %T, want *composite", cb)
+	}
+
+	cb.RegisterMITM("conn-1", []byte("mitm-der"))
+	cb.RegisterReal("conn-1", []byte("real-der"), x509.SHA256WithRSA)
+	cb.CleanupConnection("conn-1")
+	if err := cb.AttachToProcessTree(1234); err != nil {
+		t.Errorf("AttachToProcessTree err = %v, want nil", err)
+	}
+	cb.StartProcEventConsumer(context.Background())
+	if err := cb.Close(); err != nil {
+		t.Errorf("Close err = %v, want nil", err)
+	}
+
+	// Each underlying impl saw every call exactly once.
+	for name, impl := range map[string]*fakeCBShim{"a": a, "b": b} {
+		impl.mu.Lock()
+		if got, want := len(impl.registerMITM), 1; got != want {
+			t.Errorf("%s.RegisterMITM count = %d, want %d", name, got, want)
+		}
+		if got, want := len(impl.registerReal), 1; got != want {
+			t.Errorf("%s.RegisterReal count = %d, want %d", name, got, want)
+		}
+		if got, want := len(impl.cleanupConnection), 1; got != want {
+			t.Errorf("%s.CleanupConnection count = %d, want %d", name, got, want)
+		}
+		if got, want := len(impl.attachToProcTree), 1; got != want {
+			t.Errorf("%s.AttachToProcessTree count = %d, want %d", name, got, want)
+		}
+		if got, want := impl.startProcConsumer, 1; got != want {
+			t.Errorf("%s.StartProcEventConsumer count = %d, want %d", name, got, want)
+		}
+		if got, want := impl.closeCalled, 1; got != want {
+			t.Errorf("%s.Close count = %d, want %d", name, got, want)
+		}
+		impl.mu.Unlock()
+	}
+}
+
+// A registered factory that returns (nil, nil) is a contract
+// violation. In the single-factory path this surfaced as an
+// errors.New; the multi-factory path must surface it the same way so
+// a misregistered impl is caught at proxy.New time, not at the first
+// SCRAM-PLUS handshake.
+func TestNewFromFactory_FactoryReturnsNilNil_IsError(t *testing.T) {
+	resetRegistry(t)
+	RegisterFactory(func(*zap.Logger) (CBShim, error) { return nil, nil })
+
+	_, err := NewFromFactory(zap.NewNop())
+	if err == nil {
+		t.Fatalf("NewFromFactory err = nil, want error for (nil, nil) factory")
+	}
+}
+
+// Multi-factory equivalent: one good + one bad factory → whole
+// NewFromFactory aborts. Otherwise a half-constructed composite
+// would silently run with a missing backend and the user would only
+// notice when their statically-bundled libcrypto app fails to
+// SCRAM-PLUS auth.
+func TestNewFromFactory_OneFactoryErrors_AbortsAll(t *testing.T) {
+	resetRegistry(t)
+	bad := errors.New("eBPF unsupported on this kernel")
+
+	RegisterFactory(func(*zap.Logger) (CBShim, error) { return &fakeCBShim{}, nil })
+	RegisterFactory(func(*zap.Logger) (CBShim, error) { return nil, bad })
+
+	cb, err := NewFromFactory(zap.NewNop())
+	if err == nil {
+		t.Fatalf("NewFromFactory err = nil, want %v", bad)
+	}
+	if !errors.Is(err, bad) {
+		t.Errorf("NewFromFactory err = %v, want errors.Is %v (lost the underlying cause)", err, bad)
+	}
+	if cb != nil {
+		t.Errorf("NewFromFactory cb = %v, want nil on factory error", cb)
+	}
+}
+
+// Close must run every impl's Close even if an earlier one errors —
+// otherwise a failing eBPF teardown would strand the LD_PRELOAD
+// impl's staged .so on disk.
+func TestComposite_Close_RunsAllImplsEvenAfterError(t *testing.T) {
+	a := &fakeCBShim{closeErr: errors.New("eBPF detach failed")}
+	b := &fakeCBShim{}
+
+	c := &composite{impls: []CBShim{a, b}}
+	err := c.Close()
+	if err == nil {
+		t.Errorf("Close err = nil, want error from a")
+	}
+	if a.closeCalled != 1 {
+		t.Errorf("a.Close not invoked")
+	}
+	if b.closeCalled != 1 {
+		t.Errorf("b.Close not invoked — first impl's error must not short-circuit subsequent closes")
+	}
+}
+
+// AttachToProcessTree fans out and surfaces the FIRST error;
+// subsequent errors are intentionally dropped to keep the log signal
+// readable (they typically share a root cause — missing CAP_BPF,
+// PID 1 outside our namespace, etc.).
+func TestComposite_AttachToProcessTree_ReturnsFirstError(t *testing.T) {
+	firstErr := errors.New("first impl failed")
+	secondErr := errors.New("second impl failed")
+	a := &fakeCBShim{attachErr: firstErr}
+	b := &fakeCBShim{attachErr: secondErr}
+
+	c := &composite{impls: []CBShim{a, b}}
+	err := c.AttachToProcessTree(1234)
+	if err == nil {
+		t.Fatalf("err = nil, want first-error")
+	}
+	if !errors.Is(err, firstErr) {
+		t.Errorf("err = %v, want errors.Is %v", err, firstErr)
+	}
+	// Both must still have been invoked — fan-out is the whole point.
+	if len(a.attachToProcTree) != 1 || len(b.attachToProcTree) != 1 {
+		t.Errorf("AttachToProcessTree fan-out incomplete: a=%d b=%d, want 1 each",
+			len(a.attachToProcTree), len(b.attachToProcTree))
+	}
+}


### PR DESCRIPTION
## Summary

Lets multiple `cbshim.CBShim` implementations register and run side by side. Concrete motivator: a forthcoming **LD_PRELOAD-based** cbshim variant covers cases the existing **eBPF uprobe** variant can't (e.g. bundled-into-wheel libcrypto under `RTLD_LOCAL` where the symbol isn't reachable for uprobe attach). Each impl has a disjoint failure mode, so the right runtime behaviour is to register both and let the calls fan out — whichever path the target process exposes is the one that takes effect.

The original design used `var registeredFactory Factory` (single slot — `RegisterFactory` overwrites silently). This PR changes that to a slice and adds a fan-out composite when multiple factories are registered.

## Behaviour matrix

| Registered factories | `NewFromFactory` returns | Behaviour |
|---|---|---|
| 0 | `(nil, nil)` | Unchanged — OSS-only builds get "no cbshim available" |
| 1 | bare concrete impl | Unchanged — same identity / type as today; existing enterprise eBPF cbshim is unaffected |
| 2+ | `*composite` wrapping all impls | NEW — each interface method fans out to every sub-impl |

## What's in this PR

`pkg/agent/proxy/cbshim/iface.go`:
- `registeredFactory Factory` → `registeredFactories []Factory`
- `RegisterFactory` appends (nil factories silently dropped)
- `NewFromFactory` builds either a single bare impl (backwards-compat path) or a composite fan-out
- New `*composite` type implementing all six `CBShim` methods:
  - `RegisterMITM` / `RegisterReal` / `CleanupConnection` / `StartProcEventConsumer`: fan out in iteration order
  - `AttachToProcessTree`: fans out; returns first error (later errors typically share a root cause — missing `CAP_BPF`, PID outside namespace, etc.)
  - `Close`: runs every impl's Close even after an earlier error so a failing eBPF teardown can't strand the LD_PRELOAD impl's staged `.so` on disk

`pkg/agent/proxy/cbshim/iface_test.go` — 9 tests:
- Append vs overwrite (the central change)
- Nil-factory dropped defensively
- Single-factory bare-impl identity preserved
- No-factory `(nil, nil)` signal preserved
- Two-factory fan-out across every interface method
- `(nil, nil)` factory remains an error
- One-of-many factory error aborts the whole `NewFromFactory` (errors.Is matches the underlying cause)
- Close runs all impls even after an error
- AttachToProcessTree returns first error but still completes the fan-out

## Why no call-site changes

`proxy.go` / `tls/ca.go` / etc. consume the `CBShim` interface + `NewFromFactory` only — both stay source-compatible. The existing enterprise eBPF cbshim (registered as the sole factory today) continues to be returned as a bare impl with the same observable identity. Follow-up enterprise PR will register a second factory; that's what makes the composite path activate.

## Test plan

- [x] `go build ./pkg/agent/proxy/cbshim/...` clean
- [x] `go test -count=1 ./pkg/agent/proxy/cbshim/...` — 9/9 pass
- [x] `golangci-lint run ./pkg/agent/proxy/cbshim/...` — 0 issues
- [ ] CI on this branch

## Follow-ups (not in this PR)

- Enterprise PR: registers an LD_PRELOAD-based `CBShim` impl as a second factory; uses the composite path. Mirrors the shape of enterprise#2070.
- keploy/keploy#4231 cleanup: rebase that PR's branch onto this; drop the cbmap/cbshim.c bits it adds to OSS (move them to the enterprise PR above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)