### PR TITLE
fix: persist once-per-boot startup mocks dropped from some recorded test sets

### DIFF
--- a/.github/workflows/prepare_and_run.yml
+++ b/.github/workflows/prepare_and_run.yml
@@ -701,6 +701,14 @@ jobs:
     # bug — call-2 hits the 60s read_timeout, continue-on-error).
     needs: [build-and-upload, upload-latest]
     uses: ./.github/workflows/outbound-fin-stall-linux.yml
+  run_startup_mock_capture_linux:
+    # Regression guard for a once-per-boot startup mock (e.g. an AWS
+    # Secret Manager fetch at boot) being dropped from some recorded test
+    # sets. The app fetches a secret at startup before serving; the guard
+    # records two test sets and asserts the mock landed in both. Precise
+    # coverage is in the Go unit tests under pkg/agent/proxy/syncMock.
+    needs: [build-and-upload, upload-latest]
+    uses: ./.github/workflows/startup-mock-capture-linux.yml
   run_golang_docker:
     needs: [build-and-upload, upload-latest, build-docker-image-amd64]
     uses: ./.github/workflows/golang_docker.yml
@@ -1142,6 +1150,7 @@ jobs:
       - run_python_linux
       - run_http_stale_pool_race_linux
       - run_outbound_fin_stall_linux
+      - run_startup_mock_capture_linux
       - run_golang_docker
       - run_fuzzer_linux
       - run_grpc_linux
@@ -1164,6 +1173,7 @@ jobs:
             "${{ needs.run_python_linux.result }}" \
             "${{ needs.run_http_stale_pool_race_linux.result }}" \
             "${{ needs.run_outbound_fin_stall_linux.result }}" \
+            "${{ needs.run_startup_mock_capture_linux.result }}" \
             "${{ needs.run_golang_docker.result }}" \
             "${{ needs.run_fuzzer_linux.result }}" \
             "${{ needs.run_grpc_linux.result }}" \

--- a/.github/workflows/startup-mock-capture-linux.yml
+++ b/.github/workflows/startup-mock-capture-linux.yml
@@ -1,0 +1,69 @@
+name: Startup Mock Capture Regression (Linux)
+# Regression guard: a once-per-boot outbound call (e.g. an AWS Secret
+# Manager fetch performed at application startup, before the app serves
+# any inbound request) must be captured as a mock in EVERY recorded test
+# set. The app fetches a secret at import time from a fake upstream; the
+# guard records two test sets and asserts the startup mock landed in both.
+#
+# Runs only the `build` (PR) binary: in the pure-OSS record path the
+# startup call is direct-sent to disk, so this guards the persistence
+# path end-to-end rather than demonstrating the bug on `latest` (the
+# deterministic trigger is the enterprise --static-dedup path). The
+# precise regression lives in the Go unit tests under
+# pkg/agent/proxy/syncMock.
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: 'The type of runner to use for this job'
+        type: string
+        required: false
+        default: 'ubuntu-latest'
+      jobs_to_run:
+        description: 'Controls which jobs to run. "all" runs everything.'
+        type: string
+        required: false
+        default: 'all'
+
+jobs:
+  startup_mock_capture_linux:
+    if: ${{ inputs.jobs_to_run == 'all' }}
+    runs-on: ${{ inputs.runner }}
+    name: startup-mock-capture (record_with_build)
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: keploy/keploy
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - id: record
+        uses: ./.github/actions/download-binary
+        with:
+          src: build
+
+      - name: Run regression guard
+        env:
+          RECORD_BIN: ${{ steps.record.outputs.path }}
+        # `bash <script>` (not `source`) so the script's intentional
+        # `set +e` is not overridden by the step's default `-eo pipefail`.
+        run: |
+          bash "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/python/startup-mock-capture/python-linux.sh"
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: startup-mock-capture-logs
+          path: |
+            .github/workflows/test_workflow_scripts/python/startup-mock-capture/record_logs_0.txt
+            .github/workflows/test_workflow_scripts/python/startup-mock-capture/record_logs_1.txt
+            .github/workflows/test_workflow_scripts/python/startup-mock-capture/upstream_logs.txt
+            .github/workflows/test_workflow_scripts/python/startup-mock-capture/keploy/
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/test_workflow_scripts/python/startup-mock-capture/.gitignore
+++ b/.github/workflows/test_workflow_scripts/python/startup-mock-capture/.gitignore
@@ -1,0 +1,3 @@
+keploy/
+*_logs.txt
+__pycache__/

--- a/.github/workflows/test_workflow_scripts/python/startup-mock-capture/app.py
+++ b/.github/workflows/test_workflow_scripts/python/startup-mock-capture/app.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""App under test for the startup-mock-capture regression guard.
+
+Models an application that fetches a secret from AWS Secret Manager
+exactly ONCE at process startup — BEFORE it begins serving inbound
+requests — and reuses it for the lifetime of the process. botocore /
+boto3 use urllib3 under the hood, so the urllib3 GET below is the same
+shape as a real Secret Manager init call.
+
+Because the fetch fires at import time (before Flask accepts any inbound
+request), keploy captures it while `firstReqSeen` is still false: it is a
+"startup mock" that owns no test window. The regression this guards is
+that such a once-per-boot mock must be persisted into EVERY recorded test
+set rather than dropped by the syncMock buffer reapers. See the Go unit
+tests in pkg/agent/proxy/syncMock for the deterministic coverage.
+"""
+import sys
+
+import urllib3
+from flask import Flask
+
+HOST = sys.argv[1] if len(sys.argv) > 1 else "127.0.0.1"
+PORT = int(sys.argv[2]) if len(sys.argv) > 2 else 9091
+
+_http = urllib3.PoolManager(num_pools=1, maxsize=1)
+
+
+def _fetch_secret() -> str:
+    r = _http.request(
+        "GET",
+        f"http://{HOST}:{PORT}/secret",
+        timeout=urllib3.Timeout(connect=5.0, read=10.0),
+    )
+    return r.data.decode()
+
+
+# STARTUP: the one-shot "AWS Secret Manager init call", fired at import
+# time before Flask serves anything. This is the outbound call whose mock
+# must survive into every recorded test set.
+SECRET = _fetch_secret()
+print(f"[app] startup secret fetched: {SECRET!r}", flush=True)
+
+app = Flask(__name__)
+
+
+@app.route("/health")
+def health():
+    return "ok", 200
+
+
+@app.route("/value")
+def value():
+    return SECRET, 200
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000, debug=False, use_reloader=False)

--- a/.github/workflows/test_workflow_scripts/python/startup-mock-capture/python-linux.sh
+++ b/.github/workflows/test_workflow_scripts/python/startup-mock-capture/python-linux.sh
@@ -93,7 +93,16 @@ drive_request() {
         sudo pkill -INT keploy 2>/dev/null || true
         return 1
     fi
-    curl -fsS --max-time 10 http://127.0.0.1:8000/value >/dev/null 2>&1
+    # The inbound request is mandatory: it is what makes this record
+    # session produce a test case alongside the startup mock. If it fails
+    # the guard is meaningless (the mocks grep could still pass on the
+    # startup mock alone), so propagate the failure to the caller and stop
+    # keploy.
+    if ! curl -fsS --max-time 10 http://127.0.0.1:8000/value >/dev/null 2>&1; then
+        echo "::error::inbound GET /value failed during record"
+        sudo pkill -INT keploy 2>/dev/null || true
+        return 1
+    fi
     sleep 5
     sudo pkill -INT keploy 2>/dev/null || true
 }
@@ -107,6 +116,11 @@ for i in 0 1; do
     sudo -E env PATH="$PATH" "$RECORD_BIN" record \
         -c "python3 app.py 127.0.0.1 9091" \
         > "record_logs_$i.txt" 2>&1
+    record_status=$?
+    # keploy is stopped via SIGINT by drive_request, so a non-zero status
+    # is expected and not itself a failure; report it for debuggability so
+    # a real record crash isn't misattributed to the later grep checks.
+    echo "=== record test-set-$i exit status: $record_status ==="
     if ! wait "$driver_pid"; then
         echo "::error::request driver failed while recording test-set-$i"
         tail -100 "record_logs_$i.txt"

--- a/.github/workflows/test_workflow_scripts/python/startup-mock-capture/python-linux.sh
+++ b/.github/workflows/test_workflow_scripts/python/startup-mock-capture/python-linux.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+# Regression guard: a once-per-boot outbound call — e.g. an AWS Secret
+# Manager fetch performed at application startup, BEFORE the app serves
+# any inbound request — must be captured as a mock in EVERY recorded test
+# set.
+#
+# Setup: a fake secret-manager upstream (upstream.py) answers a single
+# GET /secret. The app (app.py) fetches that secret ONCE at import time
+# via urllib3 (botocore/boto3's transport), then serves /value. keploy
+# therefore captures the fetch while `firstReqSeen` is still false: it is
+# a "startup mock" owning no test window.
+#
+# Before the fix, syncMock's buffer reapers could drop such a window-less
+# startup mock — the dedup DeleteMocksStrictlyBefore cleanup (when the
+# first inbound request hashes as a duplicate), the 7s stale-cutoff in
+# ResolveRange, and FlushOwnedWindows never flushing window-less mocks.
+# The user-visible symptom was "the startup mock is present in some test
+# sets and missing in others". This guard records TWO test sets and
+# asserts the startup mock landed in BOTH.
+#
+# NOTE: the *deterministic* trigger is the enterprise `--static-dedup`
+# path, which the OSS binary this CI uses does not expose; the precise
+# regression is covered by the Go unit tests in
+# pkg/agent/proxy/syncMock/syncMock_test.go. This guard exercises the OSS
+# record path end-to-end so a future regression in startup-mock
+# persistence is caught against a real application.
+
+set -uo pipefail
+# Explicit `set +e`: even when sourced from a workflow step with `-e`
+# enabled, we capture exit codes explicitly and always run cleanup.
+set +e
+
+source "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/test-iid.sh"
+
+# Match keploy by process name (pkill default) — `pkill -f` would
+# self-match the wrapping bash/sudo argv and surface as a spurious 137.
+# The upstream is killed by recorded PID since "python3" matches every
+# Python process on the runner. See outbound-fin-stall for the rationale.
+upstream_pid=""
+cleanup() {
+    echo "cleanup..."
+    sudo pkill -9 keploy 2>/dev/null || true
+    if [ -n "$upstream_pid" ]; then
+        kill -9 "$upstream_pid" 2>/dev/null || true
+    fi
+    sleep 1
+}
+trap cleanup EXIT
+
+cd "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/python/startup-mock-capture"
+
+echo "=== install python deps ==="
+python3 -m pip install --upgrade pip >/dev/null
+python3 -m pip install -r requirements.txt
+
+echo "=== generate keploy config ==="
+$RECORD_BIN config --generate
+rm -rf keploy/
+
+echo "=== start fake AWS Secret Manager upstream ==="
+python3 upstream.py 9091 > upstream_logs.txt 2>&1 &
+upstream_pid=$!
+
+# Wait for the upstream's listening socket via ss (no extra TCP conn).
+ready=0
+for i in $(seq 1 20); do
+    if ss -tln | awk '{print $4}' | grep -q ":9091$"; then
+        echo "upstream listening after ${i}s"
+        ready=1
+        break
+    fi
+    sleep 1
+done
+if [ "$ready" -ne 1 ]; then
+    echo "::error::upstream did not start within 20s"
+    cat upstream_logs.txt
+    exit 1
+fi
+
+# Drive one inbound request per record session so the test set has a test
+# case alongside the startup mock, then SIGINT keploy to flush the set.
+drive_request() {
+    local up=0
+    for _ in $(seq 1 40); do
+        if curl -fsS --max-time 5 http://127.0.0.1:8000/health >/dev/null 2>&1; then
+            up=1
+            break
+        fi
+        sleep 1
+    done
+    if [ "$up" -ne 1 ]; then
+        echo "::error::app /health did not become ready within 40s"
+        sudo pkill -INT keploy 2>/dev/null || true
+        return 1
+    fi
+    curl -fsS --max-time 10 http://127.0.0.1:8000/value >/dev/null 2>&1
+    sleep 5
+    sudo pkill -INT keploy 2>/dev/null || true
+}
+
+# Record two test sets. Each is a fresh app boot, so each fires the
+# one-shot startup secret fetch — the mock must land in BOTH.
+for i in 0 1; do
+    echo "=== record test-set-$i ==="
+    drive_request &
+    driver_pid=$!
+    sudo -E env PATH="$PATH" "$RECORD_BIN" record \
+        -c "python3 app.py 127.0.0.1 9091" \
+        > "record_logs_$i.txt" 2>&1
+    if ! wait "$driver_pid"; then
+        echo "::error::request driver failed while recording test-set-$i"
+        tail -100 "record_logs_$i.txt"
+        exit 1
+    fi
+
+    if grep -q 'WARNING: DATA RACE' "record_logs_$i.txt"; then
+        echo "::error::data race detected during record of test-set-$i"
+        tail -200 "record_logs_$i.txt"
+        exit 1
+    fi
+    if ! grep -q 'startup secret fetched' "record_logs_$i.txt"; then
+        echo "::error::app did not complete its startup secret fetch in test-set-$i"
+        tail -100 "record_logs_$i.txt"
+        exit 1
+    fi
+    sleep 3
+done
+
+echo "=== verify the startup secret mock landed in BOTH test sets ==="
+missing=0
+for i in 0 1; do
+    mocks_file="keploy/test-set-$i/mocks.yaml"
+    if [ ! -s "$mocks_file" ]; then
+        echo "::error::mocks file missing or empty for test-set-$i: $mocks_file"
+        ls -la "keploy/test-set-$i/" 2>/dev/null || true
+        missing=1
+        continue
+    fi
+    # The fake upstream's response body carries a unique marker; its
+    # presence proves the once-per-boot startup fetch was captured as a
+    # mock for THIS test set.
+    if grep -q 'keploy-startup-secret-v1' "$mocks_file"; then
+        echo "test-set-$i: startup secret mock present"
+    else
+        echo "::error::test-set-$i is MISSING the startup secret-manager mock (the regression)"
+        echo "--- mocks.yaml summary for test-set-$i ---"
+        grep -E '^(name:|kind:)|[Uu]rl|Host' "$mocks_file" | head -40
+        echo "--- last 80 lines of record_logs_$i.txt ---"
+        tail -80 "record_logs_$i.txt"
+        missing=1
+    fi
+done
+
+if [ "$missing" -ne 0 ]; then
+    echo "::error::the once-per-boot startup mock was dropped from at least one test set"
+    exit 1
+fi
+
+echo "PASS: the once-per-boot startup secret mock was captured in every test set"

--- a/.github/workflows/test_workflow_scripts/python/startup-mock-capture/requirements.txt
+++ b/.github/workflows/test_workflow_scripts/python/startup-mock-capture/requirements.txt
@@ -1,0 +1,6 @@
+# Flask serves the inbound endpoint so each record session captures a
+# test case alongside the startup mock. urllib3 is botocore/boto3's HTTP
+# transport, so the startup secret fetch matches a real AWS Secret
+# Manager init call's shape. Pinned for reproducible CI behaviour.
+flask==3.0.3
+urllib3==2.3.0

--- a/.github/workflows/test_workflow_scripts/python/startup-mock-capture/upstream.py
+++ b/.github/workflows/test_workflow_scripts/python/startup-mock-capture/upstream.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Fake AWS Secret Manager upstream for the startup-mock-capture e2e.
+
+Answers any request with a fixed secret JSON and closes the connection
+(Connection: close, so the urllib3 client opens a fresh conn per boot —
+no keepalive bookkeeping needed). Models the one-shot secret fetch an
+application performs at boot before it begins serving traffic.
+"""
+import socket
+import sys
+import threading
+
+PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 9091
+
+# The unique marker below is what the e2e greps for in each recorded
+# test set's mocks.yaml to confirm the startup fetch was captured.
+BODY = b'{"SecretString":"keploy-startup-secret-v1"}'
+
+
+def handle(conn: socket.socket) -> None:
+    try:
+        conn.settimeout(5.0)
+        # Drain the request head; the response is fixed regardless.
+        try:
+            conn.recv(4096)
+        except socket.timeout:
+            pass
+        resp = (
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Type: application/json\r\n"
+            b"Content-Length: " + str(len(BODY)).encode() + b"\r\n"
+            b"Connection: close\r\n"
+            b"\r\n" + BODY
+        )
+        conn.sendall(resp)
+    finally:
+        try:
+            conn.close()
+        except OSError:
+            pass
+
+
+def main() -> None:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(("0.0.0.0", PORT))
+    s.listen(16)
+    print(f"[upstream] fake secret-manager listening on 0.0.0.0:{PORT}", flush=True)
+    while True:
+        conn, _ = s.accept()
+        threading.Thread(target=handle, args=(conn,), daemon=True).start()
+
+
+if __name__ == "__main__":
+    main()

--- a/pkg/agent/proxy/integrations/http/recordv2_test.go
+++ b/pkg/agent/proxy/integrations/http/recordv2_test.go
@@ -342,9 +342,19 @@ func TestRecordV2_LegacyParity(t *testing.T) {
 	// "HTTP_CLIENT" type tag is non-canonical), gets promoted to
 	// LifetimeSession, and syncMock's lifetime carve-out then persists it
 	// unconditionally — bypassing window resolution and dedup cleanup.
-	if !reflect.DeepEqual(v2Mock.TestModeInfo, legacyMock.TestModeInfo) {
+	//
+	// IsStartup is excluded from the comparison: it is NOT a build-time
+	// recorder property. It is a transient routing flag stamped later by
+	// syncMock.AddMock when a mock is captured before the first inbound
+	// request. In this harness the legacy mock is produced via
+	// parseFinalHTTP → AddMock (so it gets tagged), while the V2 builder
+	// returns the mock pre-ingest; in production both paths ingest via
+	// AddMock identically, so the flag is not a recorder divergence.
+	v2TMI, legacyTMI := v2Mock.TestModeInfo, legacyMock.TestModeInfo
+	v2TMI.IsStartup, legacyTMI.IsStartup = false, false
+	if !reflect.DeepEqual(v2TMI, legacyTMI) {
 		t.Errorf("TestModeInfo mismatch:\n  v2=%+v\n  legacy=%+v",
-			v2Mock.TestModeInfo, legacyMock.TestModeInfo)
+			v2TMI, legacyTMI)
 	}
 	if v2Mock.TestModeInfo.Lifetime != models.LifetimePerTest || !v2Mock.TestModeInfo.LifetimeDerived {
 		t.Errorf("V2 mock must be stamped LifetimePerTest+LifetimeDerived at build time, got %+v",

--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -257,6 +257,18 @@ func (m *SyncMockManager) AddMock(mock *models.Mock) {
 		return
 	}
 
+	// Tag app-bootstrap traffic. Any mock captured before the first
+	// inbound request is startup/init traffic (e.g. an AWS Secret Manager
+	// fetch at boot) that ran before any test window exists. It can never
+	// claim a per-test window, so the reapers below (dedup DeleteMocks-
+	// StrictlyBefore, the ResolveRange stale-cutoff, FlushOwnedWindows and
+	// the memory-pressure wipe) would otherwise drop it. firstReqSeen,
+	// flipped on the first inbound request, is the boot-vs-test boundary;
+	// tagging here is the sole signal isStartupMock keys off.
+	if mock != nil && !m.firstReqSeen {
+		mock.TestModeInfo.IsStartup = true
+	}
+
 	// Decide forward vs buffer vs drop under a single snapshot of
 	// (outChan, outChanClosed). The trio has three legal outcomes:
 	//
@@ -417,6 +429,16 @@ func (m *SyncMockManager) FlushOwnedWindows() {
 			mocksToSend = append(mocksToSend, mock)
 			continue
 		}
+		// STARTUP RESCUE: app-bootstrap traffic owns no window (it ran
+		// before any test) so the ownerWindow check above never claims it.
+		// Flush it to disk proactively on the ticker rather than leaving it
+		// parked in the buffer where a dedup cleanup, stale-cutoff, or
+		// memory-pressure wipe could reap it before it is ever persisted.
+		if isStartupMock(mock) {
+			mock.Name = "mock-" + generateRandomString(8)
+			mocksToSend = append(mocksToSend, mock)
+			continue
+		}
 		// Not attributable yet — a future (possibly out-of-order) request
 		// may still claim it. Keep it buffered in place.
 		m.buffer[keepIdx] = mock
@@ -471,10 +493,39 @@ func (m *SyncMockManager) SetMemoryPressure(enabled bool) {
 		return
 	}
 
+	// Drop buffered mocks to relieve memory pressure, but PRESERVE startup
+	// mocks. They were captured before the first inbound request, own no
+	// test window, and the periodic FlushOwnedWindows drain is their only
+	// remaining route to disk — wiping them here would silently lose the
+	// once-per-boot startup mock, the exact data loss the IsStartup tag
+	// exists to prevent (mirrors the rescues in DeleteMocksStrictlyBefore,
+	// ResolveRange and FlushOwnedWindows). They are few (typically one per
+	// boot), so the memory relief is effectively unchanged.
+	var kept []*models.Mock
 	for i := range m.buffer {
+		if isStartupMock(m.buffer[i]) {
+			kept = append(kept, m.buffer[i])
+		}
 		m.buffer[i] = nil
 	}
-	m.buffer = make([]*models.Mock, 0, defaultMockBufferCapacity)
+	// Re-home survivors into a fresh, small backing array so the (possibly
+	// large) old one is released to the GC.
+	m.buffer = append(make([]*models.Mock, 0, defaultMockBufferCapacity), kept...)
+}
+
+// isStartupMock reports whether a buffered per-test mock is app-bootstrap
+// traffic that can never legitimately claim a test window: it was captured
+// before the first inbound request (tagged IsStartup at ingest in AddMock).
+// Such mocks (e.g. an AWS Secret Manager fetch at boot) must be flushed to
+// disk so replay's startup tier can serve them, NOT reaped as duplicate
+// debris or stale-cutoff. The tag — rather than a "request pre-dates the
+// first window" timestamp test — is deliberately the only signal: a mock
+// captured before the FIRST inbound request is unambiguously startup
+// traffic, whereas a per-test mock that merely lands before its window
+// (genuine stale cross-test bleed) must still be reaped to bound buffer
+// growth. Conflating the two would resurrect that bleed.
+func isStartupMock(mk *models.Mock) bool {
+	return mk != nil && mk.TestModeInfo.IsStartup
 }
 
 func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, keep bool, mapping bool) {
@@ -656,6 +707,27 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 				lateBinned++
 			}
 			// Handled (flushed or retained); drop from the current buffer.
+			continue
+		}
+
+		// STARTUP RESCUE: a mock captured before the first inbound request
+		// (IsStartup) is app-bootstrap traffic — an AWS Secret Manager
+		// fetch, DB/driver handshake, config load, etc. fired at boot. It
+		// can never claim a window, so the stale-cutoff below would
+		// silently reap it (the "present in some test sets, missing in
+		// others" bug). Flush it to disk instead so replay's startup tier
+		// can serve it. Placed BEFORE the cutoff so a slow boot (>7 s to
+		// the first request) can't lose it. A per-test mock that merely
+		// lands before the current window (genuine stale cross-test bleed)
+		// is NOT tagged IsStartup and still falls to the cutoff.
+		if isStartupMock(mock) {
+			if !outChanBound {
+				m.buffer[keepIdx] = mock
+				keepIdx++
+				continue
+			}
+			mock.Name = "mock-" + generateRandomString(8)
+			mocksToSend = append(mocksToSend, mock)
 			continue
 		}
 
@@ -880,6 +952,25 @@ func (m *SyncMockManager) DeleteMocksStrictlyBefore(timestamp time.Time) {
 				}
 				lateMappings[w.testName] = append(lateMappings[w.testName], mock.Name)
 			}
+			mocksToSend = append(mocksToSend, mock)
+			continue
+		}
+
+		// STARTUP RESCUE: app-bootstrap traffic (captured before the first
+		// inbound request, or pre-dating the first resolved test window) is
+		// NOT the skipped duplicate's debris — it owns no window because it
+		// ran before any test existed. Without this, a once-per-boot init
+		// call (e.g. AWS Secret Manager) is dropped here whenever the first
+		// inbound request happens to hash as a dedup duplicate (recentWindows
+		// is still empty, so the ownerWindow rescue above can't save it) —
+		// the root of the flaky per-test-set capture. Flush it instead.
+		if isStartupMock(mock) {
+			if !outChanBound {
+				m.buffer[keepIdx] = mock
+				keepIdx++
+				continue
+			}
+			mock.Name = "mock-" + generateRandomString(8)
 			mocksToSend = append(mocksToSend, mock)
 			continue
 		}

--- a/pkg/agent/proxy/syncMock/syncMock_test.go
+++ b/pkg/agent/proxy/syncMock/syncMock_test.go
@@ -1358,3 +1358,173 @@ func TestFlushOwnedWindowsNoopWhenNothingOwned(t *testing.T) {
 	default:
 	}
 }
+
+// startupHTTPMock builds a once-per-boot outbound HTTP mock (e.g. an AWS
+// Secret Manager fetch at process startup): per-test lifetime, as the HTTP
+// recorder stamps it, with a request timestamp at app-boot time.
+func startupHTTPMock(reqTS time.Time) *models.Mock {
+	return &models.Mock{
+		Name: "mocks",
+		Kind: models.HTTP,
+		Spec: models.MockSpec{
+			ReqTimestampMock: reqTS,
+			ResTimestampMock: reqTS.Add(50 * time.Millisecond),
+		},
+		TestModeInfo: models.TestModeInfo{
+			Lifetime:        models.LifetimePerTest,
+			LifetimeDerived: true,
+		},
+	}
+}
+
+// TestStartupMockSurvivesDedupDeleteWhenFirstRequestIsDuplicate reproduces
+// the flaky per-test-set capture bug (Rank 1). A once-per-boot outbound
+// call is captured before the first inbound request while the output
+// channel is not yet bound, so it lands in the buffer tagged IsStartup. If
+// the FIRST inbound request hashes as a dedup duplicate, ResolveJob calls
+// DeleteMocksStrictlyBefore with recentWindows still empty — so the
+// ownerWindow rescue cannot save it and the pre-fix code dropped it as
+// "duplicate debris". It must be flushed to disk instead.
+func TestStartupMockSurvivesDedupDeleteWhenFirstRequestIsDuplicate(t *testing.T) {
+	t.Parallel()
+
+	out := make(chan *models.Mock, 4)
+	mgr := &SyncMockManager{buffer: make([]*models.Mock, 0, defaultMockBufferCapacity)}
+
+	bootTS := time.Now().Add(-2 * time.Second)
+	mgr.AddMock(startupHTTPMock(bootTS)) // outChan nil → buffered, !firstReqSeen → tagged
+	if len(mgr.buffer) != 1 {
+		t.Fatalf("init call should buffer before outChan binds; buffer=%d", len(mgr.buffer))
+	}
+	if !mgr.buffer[0].TestModeInfo.IsStartup {
+		t.Fatalf("a mock captured before firstReqSeen must be tagged IsStartup")
+	}
+
+	// Recorder wires the channel; the first inbound request is a duplicate.
+	mgr.SetOutputChannel(out)
+	mgr.SetFirstRequestSignaled()
+	mgr.DeleteMocksStrictlyBefore(time.Now())
+
+	select {
+	case got := <-out:
+		if !got.Spec.ReqTimestampMock.Equal(bootTS) {
+			t.Fatalf("flushed wrong mock: ts=%v want %v", got.Spec.ReqTimestampMock, bootTS)
+		}
+	default:
+		t.Fatalf("startup init mock was dropped by the dedup cleanup (Rank 1 regression)")
+	}
+}
+
+// TestStartupMockSurvivesStaleCutoffInResolveRange reproduces Rank 2: a
+// slow boot (>7 s between the init call and the first test window) makes
+// the buffered, window-less init mock older than the 7 s stale-cutoff, so
+// the pre-fix ResolveRange reaped it. It must be rescued and flushed.
+func TestStartupMockSurvivesStaleCutoffInResolveRange(t *testing.T) {
+	t.Parallel()
+
+	out := make(chan *models.Mock, 4)
+	mgr := &SyncMockManager{buffer: make([]*models.Mock, 0, defaultMockBufferCapacity)}
+
+	bootTS := time.Now().Add(-10 * time.Second)
+	mgr.AddMock(startupHTTPMock(bootTS)) // buffered (outChan nil), tagged IsStartup
+	mgr.SetOutputChannel(out)
+	mgr.SetFirstRequestSignaled()
+
+	now := time.Now()
+	mgr.ResolveRange(now.Add(-50*time.Millisecond), now, "test-1", true, false)
+
+	select {
+	case got := <-out:
+		if !got.Spec.ReqTimestampMock.Equal(bootTS) {
+			t.Fatalf("flushed wrong mock: ts=%v want %v", got.Spec.ReqTimestampMock, bootTS)
+		}
+	default:
+		t.Fatalf("startup init mock was dropped by the 7s stale-cutoff (Rank 2 regression)")
+	}
+}
+
+// TestSetMemoryPressurePreservesStartupMocks pins the memory-wipe reaper:
+// SetMemoryPressure must drop ordinary buffered mocks to relieve pressure
+// but PRESERVE startup mocks, which own no window and rely on the later
+// FlushOwnedWindows drain to reach disk. Wiping them would reintroduce the
+// once-per-boot loss the IsStartup tag exists to prevent.
+func TestSetMemoryPressurePreservesStartupMocks(t *testing.T) {
+	t.Parallel()
+
+	startup := &models.Mock{Spec: models.MockSpec{ReqTimestampMock: time.Now()}}
+	startup.TestModeInfo.IsStartup = true
+	perTest := &models.Mock{Spec: models.MockSpec{ReqTimestampMock: time.Now()}}
+
+	mgr := &SyncMockManager{buffer: []*models.Mock{perTest, startup}}
+
+	mgr.SetMemoryPressure(true)
+
+	if len(mgr.buffer) != 1 || mgr.buffer[0] != startup {
+		t.Fatalf("expected only the startup mock preserved after memory wipe; buffer=%d", len(mgr.buffer))
+	}
+
+	// New non-startup mocks are still dropped while paused.
+	mgr.AddMock(&models.Mock{Spec: models.MockSpec{ReqTimestampMock: time.Now()}})
+	if len(mgr.buffer) != 1 {
+		t.Fatalf("new mocks must still be dropped under memory pressure; buffer=%d", len(mgr.buffer))
+	}
+}
+
+// TestStartupMockFlushedByFlushOwnedWindows asserts the proactive drain: the
+// per-session ticker flushes startup mocks straight to disk so they cannot
+// linger in the buffer where a later reaper (dedup/stale-cutoff/memory wipe)
+// would destroy them.
+func TestStartupMockFlushedByFlushOwnedWindows(t *testing.T) {
+	t.Parallel()
+
+	out := make(chan *models.Mock, 4)
+	mgr := &SyncMockManager{buffer: make([]*models.Mock, 0, defaultMockBufferCapacity)}
+
+	bootTS := time.Now().Add(-1 * time.Second)
+	mgr.AddMock(startupHTTPMock(bootTS)) // buffered (outChan nil), tagged IsStartup
+	mgr.SetOutputChannel(out)
+
+	mgr.FlushOwnedWindows()
+
+	select {
+	case got := <-out:
+		if !got.Spec.ReqTimestampMock.Equal(bootTS) {
+			t.Fatalf("flushed wrong mock")
+		}
+	default:
+		t.Fatalf("startup mock should be flushed proactively by FlushOwnedWindows")
+	}
+	if len(mgr.buffer) != 0 {
+		t.Fatalf("startup mock should leave the buffer after flush; buffer=%d", len(mgr.buffer))
+	}
+}
+
+// TestDuplicateDebrisStillDroppedAfterFirstReqSeen is the negative control:
+// an outbound mock captured AFTER firstReqSeen that owns no window is the
+// skipped duplicate's own debris — it is NOT a startup mock and the dedup
+// cleanup must still drop it, so the startup rescue does not over-rescue.
+func TestDuplicateDebrisStillDroppedAfterFirstReqSeen(t *testing.T) {
+	t.Parallel()
+
+	out := make(chan *models.Mock, 4)
+	mgr := &SyncMockManager{buffer: make([]*models.Mock, 0, defaultMockBufferCapacity)}
+	mgr.SetOutputChannel(out)
+	mgr.SetFirstRequestSignaled() // request-driven traffic, not startup
+
+	debris := startupHTTPMock(time.Now().Add(-1 * time.Second))
+	mgr.AddMock(debris)
+	if mgr.buffer[0].TestModeInfo.IsStartup {
+		t.Fatalf("a mock captured after firstReqSeen must NOT be tagged IsStartup")
+	}
+
+	mgr.DeleteMocksStrictlyBefore(time.Now())
+
+	select {
+	case got := <-out:
+		t.Fatalf("non-startup debris must be dropped, but it was flushed: ts=%v", got.Spec.ReqTimestampMock)
+	default:
+	}
+	if len(mgr.buffer) != 0 {
+		t.Fatalf("debris must be dropped from the buffer; buffer=%d", len(mgr.buffer))
+	}
+}

--- a/pkg/models/mock.go
+++ b/pkg/models/mock.go
@@ -115,6 +115,25 @@ type TestModeInfo struct {
 	// used?" observability — non-zero helps confirm tagging; zero for
 	// a long-lived mock hints at dead recordings worth re-capturing.
 	HitCount uint64 `json:"-" bson:"-"`
+
+	// IsStartup marks app-bootstrap traffic captured before the first
+	// inbound request (e.g. an AWS Secret Manager fetch at process boot).
+	// Such an outbound call can never claim a per-test window — it ran
+	// before any test — so the record-side syncMock reapers (dedup
+	// cleanup, stale-cutoff, memory-pressure wipe) must rescue it to disk
+	// instead of dropping it as debris.
+	//
+	// This is a RECORD-side cleanup signal only, with no replay-time
+	// meaning, which is why it is NOT modelled as a Lifetime value:
+	// Lifetime is derived from the on-disk Spec.Metadata tag and drives
+	// replay-time pool routing, whereas IsStartup is set live at ingest in
+	// SyncMockManager.AddMock and is only ever read on buffered, live-
+	// captured mocks before they are persisted. Like the sibling
+	// runtime-only fields, the json/bson tags keep it out of the text
+	// formats; gob (which ignores struct tags) does encode it, but a value
+	// carried on a reloaded mock is inert — the reapers run only on the
+	// live record buffer, never on disk-loaded mocks.
+	IsStartup bool `json:"-" bson:"-"`
 }
 
 func (m *Mock) GetKind() string {
@@ -691,6 +710,7 @@ func (m *Mock) DeepCopy() *Mock {
 	sortOrder := m.TestModeInfo.SortOrder
 	lifetime := m.TestModeInfo.Lifetime
 	lifetimeDerived := m.TestModeInfo.LifetimeDerived
+	isStartup := m.TestModeInfo.IsStartup
 	c := Mock{
 		Version: m.Version,
 		Name:    m.Name,
@@ -702,6 +722,7 @@ func (m *Mock) DeepCopy() *Mock {
 			SortOrder:       sortOrder,
 			Lifetime:        lifetime,
 			LifetimeDerived: lifetimeDerived,
+			IsStartup:       isStartup,
 		},
 		ConnectionID: m.ConnectionID,
 	}


### PR DESCRIPTION
## Describe the changes that are made

A once-per-boot **outbound** call — e.g. the AWS Secret Manager fetch an app makes at **startup, before it serves any inbound request** — was being dropped from *some* recorded test sets and kept in others, non-deterministically. With static dedup enabled (the reported scenario, k8s recording against Python pods) it would frequently go missing.

### Root cause
The HTTP recorder stamps every outbound HTTP mock `Lifetime=PerTest`. A call made at boot owns **no test window** (it predates the first request), so it lands in the `syncMock` buffer and is then exposed to every buffer reaper:

1. **`DeleteMocksStrictlyBefore`** (static-dedup cleanup) — when the *first* inbound request hashes as a duplicate, this runs while `recentWindows` is still empty, so the `ownerWindow` rescue can't save the startup mock and it's dropped as "duplicate debris". This is the deterministic trigger behind the reported flakiness.
2. **7s stale-cutoff in `ResolveRange`** — a slow boot (>7s from the startup call to the first request) reaps the window-less mock.
3. **`FlushOwnedWindows`** — never flushed window-less per-test mocks, so a startup mock could sit buffered until it was reaped or lost at shutdown.
4. **`SetMemoryPressure`** — wiped the whole buffer under memory pressure.

Whether each fired depends on dedup outcome, request timing, and memory pressure — all of which vary run to run, hence "present in some test sets, missing in others".

### Fix
- Tag mocks captured while `!firstReqSeen` as `TestModeInfo.IsStartup` at ingest in `AddMock` (runtime-only field; the boot-vs-test boundary is the first inbound request).
- **Rescue** `IsStartup` mocks — flush them to disk — in all four reapers instead of dropping them. This mirrors the **replay-side startup tier**, which already preserves pre-first-window traffic.
- Genuine stale cross-test bleed stays untagged and is still reaped, so buffer growth remains bounded (an earlier timestamp-based heuristic was dropped precisely because it conflated the two).

This is a general HTTP-recording fix, not AWS-specific — it applies to any once-per-boot outbound call (DB/driver handshakes, config fetches, etc.) on both the v1 and v2 record paths (both funnel through `AddMock`).

## Links & References

**Closes:** NA

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [x] 🔁 CI

## Added e2e test pipeline?
- [x] 👍 yes

`startup-mock-capture` (`.github/workflows/test_workflow_scripts/python/startup-mock-capture/`): a self-contained Python app fetches a secret from a fake AWS-Secret-Manager upstream once at startup via urllib3 (botocore's transport) before serving, records **two** test sets, and asserts the startup mock landed in **both**. Wired into `prepare_and_run.yml` as `run_startup_mock_capture_linux`.

> Note: the *deterministic* trigger is the enterprise `--static-dedup` path, which the OSS binary used by CI does not expose, and in the pure-OSS path the startup call is direct-sent to disk — so this e2e is a **behavioral guard** for the record→persist path, not a fail-before/pass-after proof. The deterministic regression lives in the Go unit tests below.

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

Unit tests directly exercising each reaper (all fail without the fix, pass with it; the negative control passes both ways):

```
go test ./pkg/agent/proxy/syncMock/ -run 'Startup|MemoryPressurePreserves|DuplicateDebris' -v
```

- `TestStartupMockSurvivesDedupDeleteWhenFirstRequestIsDuplicate`
- `TestStartupMockSurvivesStaleCutoffInResolveRange`
- `TestStartupMockFlushedByFlushOwnedWindows`
- `TestSetMemoryPressurePreservesStartupMocks`
- `TestDuplicateDebrisStillDroppedAfterFirstReqSeen` (negative control — request-driven debris must still be dropped)

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA
