### PR TITLE
fix(mysql/replay): in-window COM_QUERY stateful reads + graceful SEND_LONG_DATA + TiDB e2e

### DIFF
--- a/.github/workflows/java_linux.yml
+++ b/.github/workflows/java_linux.yml
@@ -131,3 +131,69 @@ jobs:
         run: |
           cd samples-java/mysql-dual-conn
           source $GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/java/mysql_dual_conn/java-linux.sh
+
+  tidb_stmt_cache:
+    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - job: record_latest_replay_build
+            record_src: latest
+            replay_src: build-no-race
+          - job: record_build_replay_latest
+            record_src: build-no-race
+            replay_src: latest
+          - job: record_build_replay_build
+            record_src: build-no-race
+            replay_src: build-no-race
+    name: tidb-stmt-cache (${{ matrix.config.job }})
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - id: record
+        uses: ./.github/actions/download-binary
+        with:
+          src: ${{ matrix.config.record_src }}
+
+      - id: replay
+        uses: ./.github/actions/download-binary
+        with:
+          src: ${{ matrix.config.replay_src }}
+
+      - name: Checkout samples-java repository
+        uses: actions/checkout@v4
+        with:
+          repository: keploy/samples-java
+          path: samples-java
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+          cache-dependency-path: samples-java/tidb-stmt-cache/pom.xml
+
+      - name: Run tidb-stmt-cache app
+        env:
+          RECORD_BIN: ${{ steps.record.outputs.path }}
+          REPLAY_BIN: ${{ steps.replay.outputs.path }}
+        run: |
+          cd samples-java/tidb-stmt-cache
+          source $GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/java/tidb_stmt_cache/java-linux.sh
+
+      - name: Upload tidb-stmt-cache recordings and replay logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tidb-stmt-cache-${{ matrix.config.job }}-recordings
+          path: |
+            samples-java/tidb-stmt-cache/keploy/
+            samples-java/tidb-stmt-cache/test_logs_*.txt
+            samples-java/tidb-stmt-cache/record.txt
+            samples-java/tidb-stmt-cache/mvn_build.log
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/test_workflow_scripts/java/tidb_stmt_cache/java-linux.sh
+++ b/.github/workflows/test_workflow_scripts/java/tidb_stmt_cache/java-linux.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+
+# E2E test for TiDB + MySQL Connector/J prepared-statement replay.
+#
+# Covers the TiDB + MySQL Connector/J prepared-statement replay cluster
+# against single-node TiDB (:4000) with useServerPrepStmts=true&cachePrepStmts=true:
+#
+#   1. cachePrepStmts orphan EXECUTE  (/api/kv)            -> synthetic PREPARE_OK
+#   2. stateful COM_QUERY read-back   (/api/kv/insert-select) -> in-window row
+#   3. orphaned cross-query, same param shape (/api/cross) -> no cross-serving
+#
+# The script records once, then replays TWICE:
+#   (a) baseline               -> exercises (2) and (3) and normal cachePrepStmts
+#   (b) PREPARE-dropped mutant -> deterministically forces the orphan condition
+#       (1) so the synthetic-PREPARE_OK + read-back path is exercised on every
+#       run regardless of HikariCP pool timing.
+#
+# A regression in either path flips the test-set report to FAILED and fails
+# the job loudly.
+
+set -Eeuo pipefail
+
+section() { echo "::group::$*"; }
+endsec()  { echo "::endgroup::"; }
+
+die() {
+  rc=$?
+  echo "::error::Pipeline failed (exit=$rc). Dumping context…"
+  echo "== docker ps =="; docker ps || true
+  echo "== tidb logs (last 200) =="; docker compose logs --tail 200 tidb || true
+  echo "== *.txt logs (last 120) =="; for f in ./*.txt; do [[ -f "$f" ]] && { echo "--- $f ---"; tail -n 120 "$f"; }; done
+  exit "$rc"
+}
+trap die ERR
+
+wait_for_tidb() {
+  section "Wait for TiDB readiness"
+  # The pingcap/tidb image ships no mysql client, so probe the SQL port's
+  # status endpoint (HTTP :10080/status) instead of execing a client.
+  for _ in $(seq 1 120); do
+    if curl -sf http://localhost:10080/status >/dev/null 2>&1; then
+      echo "TiDB is ready."; endsec; return 0
+    fi
+    sleep 1
+  done
+  echo "::error::TiDB did not become ready in time"; endsec; return 1
+}
+
+wait_for_app() {
+  section "Wait for app HTTP port"
+  for _ in $(seq 1 60); do
+    if curl -sS http://localhost:8080/api/health -o /dev/null 2>/dev/null; then
+      echo "App is responding."; endsec; return 0
+    fi
+    sleep 1
+  done
+  echo "::error::App did not start in time"; endsec; return 1
+}
+
+run_maven_build() {
+  : > mvn_build.log
+  for attempt in 1 2 3; do
+    if { echo "== Maven build attempt ${attempt}/3 =="; mvn -B -U clean package -Dmaven.test.skip=true -q; } 2>&1 | tee -a mvn_build.log; then
+      return 0
+    fi
+    echo "Maven build failed on attempt ${attempt}/3; retrying."
+    [[ "$attempt" -lt 3 ]] && sleep $((attempt * 10))
+  done
+  echo "::error::Maven build failed after 3 attempts. See mvn_build.log."; return 1
+}
+
+send_request() {
+  local kp_pid="$1"
+  wait_for_app
+  echo "=== cachePrepStmts orphan traffic (/api/kv) ==="
+  for v in 1 2 3 4 5 6 7 8; do curl -sS "http://localhost:8080/api/kv/$v" || true; echo; done
+  echo "=== stateful COM_QUERY read-back (/api/kv/insert-select) ==="
+  for v in 100 200 300 400 500; do curl -sS "http://localhost:8080/api/kv/insert-select/$v" || true; echo; done
+  echo "=== orphaned cross-query, identical param shape (/api/cross) ==="
+  for v in 7 8 9; do curl -sS "http://localhost:8080/api/cross/$v" || true; echo; done
+  sleep 10
+  echo "Sending SIGINT to keploy ($kp_pid) for graceful shutdown"
+  sudo kill -INT "$kp_pid" 2>/dev/null || true
+}
+
+# Drops the COM_STMT_PREPARE mock for "SELECT ? AS v" from every recorded
+# test-set so replay must synthesize a PREPARE_OK (the orphan path, keploy#4226).
+drop_prepare_mock() {
+  section "Mutate mocks: drop the 'SELECT ? AS v' PREPARE to force the orphan condition"
+  local dropped=0
+  for mf in keploy/test-set-*/mocks.yaml; do
+    [[ -f "$mf" ]] || continue
+    python3 - "$mf" <<'PY'
+import sys
+p = sys.argv[1]
+parts = open(p).read().split("\n---\n")
+keep = [d for d in parts if not (("packet_type: COM_STMT_PREPARE\n" in d) and ("SELECT ? AS v" in d))]
+open(p, "w").write("\n---\n".join(keep))
+print(f"{p}: kept {len(keep)}/{len(parts)} docs")
+PY
+    dropped=1
+  done
+  [[ "$dropped" -eq 1 ]] || { echo "::error::no mocks.yaml found to mutate"; return 1; }
+  endsec
+}
+
+replay_and_check() {
+  local label="$1"
+  section "Replay ($label)"
+  set +e
+  "$REPLAY_BIN" test -c "java -jar $JAR_NAME" --delay 20 --api-timeout 60 2>&1 | tee "test_logs_${label}.txt"
+  local rc=$?
+  set -e
+  echo "Replay ($label) exit code: $rc"
+  endsec
+
+  section "Check reports ($label)"
+  local run_dir
+  run_dir=$(ls -1dt ./keploy/reports/test-run-* 2>/dev/null | head -n1 || true)
+  [[ -n "${run_dir:-}" ]] || { echo "::error::No test-run dir for $label"; return 1; }
+  local all_passed=true found=false
+  for rpt in "$run_dir"/test-set-*-report.yaml; do
+    [[ -f "$rpt" ]] || continue
+    found=true
+    local status; status=$(awk '/^status:/{print $2; exit}' "$rpt")
+    echo "[$label] $(basename "$rpt"): ${status:-<missing>}"
+    [[ "$status" == "PASSED" ]] || all_passed=false
+  done
+  endsec
+  [[ "$found" == true ]] || { echo "::error::No reports for $label"; return 1; }
+  [[ "$all_passed" == true ]] || { echo "::error::[$label] some tests FAILED"; return 1; }
+  echo "[$label] all tests PASSED"
+}
+
+# --- Main ---
+source "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/test-iid.sh"
+
+sudo rm -rf keploy/ keploy.yml
+
+section "Start TiDB"
+docker compose up -d
+wait_for_tidb
+endsec
+
+section "Build"
+source "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/update-java.sh"
+run_maven_build
+endsec
+
+JAR_NAME=$(ls target/tidb-stmt-cache-*.jar 2>/dev/null | head -n1)
+[[ -n "$JAR_NAME" ]] || { echo "::error::JAR not found after build"; exit 1; }
+
+section "Record"
+"$RECORD_BIN" record -c "java -jar $JAR_NAME" > record.txt 2>&1 &
+KEPLOY_PID=$!
+send_request "$KEPLOY_PID"
+set +e; wait "$KEPLOY_PID"; echo "Record exit: $?"; set -e
+if grep -q "WARNING: DATA RACE" record.txt; then echo "::error::Data race during record"; cat record.txt; exit 1; fi
+endsec
+
+section "Shutdown TiDB before test mode"
+docker compose down || true
+echo "TiDB stopped — replay must use recorded mocks"
+endsec
+
+# Snapshot the pristine recording so the mutation phase starts from it.
+cp -r keploy keploy.orig
+
+# (a) baseline: stateful read-back + cross-query must replay correctly.
+replay_and_check "baseline"
+
+# (b) orphan mutant: drop the PREPARE mock, replay again from the snapshot.
+rm -rf keploy && cp -r keploy.orig keploy
+drop_prepare_mock
+replay_and_check "orphan"
+
+echo "All TiDB prepared-statement replay scenarios passed."
+exit 0

--- a/pkg/agent/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match.go
@@ -222,6 +222,7 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 		sCOM_PING       = mysql.CommandStatusToString(mysql.COM_PING)
 		sCOM_RESET_CONN = mysql.CommandStatusToString(mysql.COM_RESET_CONNECTION)
 		sCOM_STMT_RESET = mysql.CommandStatusToString(mysql.COM_STMT_RESET)
+		sCOM_STMT_SLD   = mysql.CommandStatusToString(mysql.COM_STMT_SEND_LONG_DATA)
 	)
 
 	// Fast path: QUIT may have no mock
@@ -403,6 +404,22 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 		// reusable read still resolves while an in-window row always wins.
 		defExecResp *mysql.Response
 		defExecMock *models.Mock
+
+		// COM_QUERY in-window preference (parity with the COM_STMT_EXECUTE
+		// branch from #4235). A parameterless statement (Spring
+		// JdbcTemplate without bind args → COM_QUERY, not a prepared
+		// statement) that issues the SAME SQL text across tests but returns
+		// a DIFFERENT row each time — e.g. an INSERT read-back
+		// "SELECT v FROM kv ORDER BY id DESC LIMIT 1" — records one data
+		// mock per call. The matcher used to take the FIRST exact-text
+		// match in pool order and (because lax-promoted data mocks live in
+		// the reusable session tier and are never consumed by updateMock)
+		// served that same first row to every later test. We instead prefer
+		// the exact-text match recorded INSIDE the current test window, and
+		// keep the first out-of-window exact match only as a fallback for a
+		// genuinely reusable single-recording query.
+		queryExactResp *mysql.Response
+		queryExactMock *models.Mock
 	)
 
 	// Single pass: filter & match on the fly. Iterates the merged pool
@@ -446,7 +463,21 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 
 			case sCOM_QUERY:
 				if ok, c := matchQueryPacket(ctx, logger, mockReq.PacketBundle, req.PacketBundle); ok {
-					matchedResp, matchedMock, queryMatched = &mock.Spec.MySQLResponses[0], mock, true
+					// Exact query-text match. Prefer the candidate recorded
+					// inside the current test window so a repeated stateful
+					// read-back (same SQL, different row per call) resolves to
+					// THIS test's row instead of the first one recorded. An
+					// out-of-window exact match is kept only as a fallback for
+					// a genuinely reusable single-recording query. When no
+					// window is active (windowActive==false) this collapses to
+					// the previous first-exact-match-wins behaviour.
+					if windowActive && !mockInCurrentWindow(mock) {
+						if queryExactMock == nil {
+							queryExactResp, queryExactMock = &mock.Spec.MySQLResponses[0], mock
+						}
+					} else {
+						matchedResp, matchedMock, queryMatched = &mock.Spec.MySQLResponses[0], mock, true
+					}
 				} else if c > maxMatchedCount {
 					maxMatchedCount, matchedResp, matchedMock = c, &mock.Spec.MySQLResponses[0], mock
 					bestPartialMock = mock
@@ -581,6 +612,16 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 		}
 	}
 
+	// COM_QUERY in-window fallback. The scan above takes an in-window
+	// exact-text match eagerly (queryMatched=true, loop broken). If it
+	// found ONLY an out-of-window exact-text match (a reusable
+	// single-recording query, or a stateful read whose matching row was
+	// recorded in a different test's window), serve that recorded
+	// candidate rather than dropping to the score-based partial pick.
+	if req.Header.Type == sCOM_QUERY && !queryMatched && queryExactMock != nil {
+		matchedResp, matchedMock, queryMatched = queryExactResp, queryExactMock, true
+	}
+
 	// COM_STMT_EXECUTE FIFO fallback. If the scan found no definitive
 	// param-exact match (stmtMatched stays false) but did find a per-test
 	// data mock whose prepared query matched exactly, prefer that
@@ -675,6 +716,25 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 					return generic, true, "", "", nil
 				}
 			}
+		}
+
+		// COM_STMT_SEND_LONG_DATA streams a single parameter value to the
+		// server ahead of COM_STMT_EXECUTE and, per the MySQL protocol, has
+		// NO server response. Connector/J emits it for stream-bound
+		// parameters (setBinaryStream / setBlob / setCharacterStream / large
+		// setBytes), so any Java app writing a BLOB/CLOB hits this path. The
+		// matcher has no per-mock comparison for it (the payload is just the
+		// streamed bytes, already reflected in the subsequent EXECUTE's
+		// recorded response), and the record window may legitimately not hold
+		// a mock for it. Without graceful handling matchCommand falls through
+		// to matchedResp==nil and query.go drops the connection with
+		// "no matching mock" BEFORE its IsNoResponseCommand check — surfacing
+		// to the client as SQLSTATE 08S01. Acknowledge it here: query.go sees
+		// ok==true, runs no prepared-stmt cleanup, then its
+		// IsNoResponseCommand branch continues without sending anything.
+		if req.Header.Type == sCOM_STMT_SLD {
+			logger.Debug("Accepting unmocked COM_STMT_SEND_LONG_DATA (no-response command)")
+			return &mysql.Response{}, true, "", "", nil
 		}
 
 		// COM_STMT_RESET clears the cursor / long-data state of a server

--- a/pkg/agent/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match.go
@@ -733,7 +733,43 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 		// ok==true, runs no prepared-stmt cleanup, then its
 		// IsNoResponseCommand branch continues without sending anything.
 		if req.Header.Type == sCOM_STMT_SLD {
-			logger.Debug("Accepting unmocked COM_STMT_SEND_LONG_DATA (no-response command)")
+			// Consume the first recorded SEND_LONG_DATA mock (in-window
+			// preferred, recorded order otherwise) so the recorder's
+			// no-response SLD mocks are marked used instead of being flagged
+			// unused / pruned. Fall back to plain synthetic acceptance when
+			// the record window captured none.
+			var sldMock, sldMockWindow *models.Mock
+			for _, mock := range pool {
+				if mock.Kind != models.MySQL {
+					continue
+				}
+				isSLD := false
+				for _, mr := range mock.Spec.MySQLRequests {
+					if mr.PacketBundle.Header != nil && mr.PacketBundle.Header.Type == sCOM_STMT_SLD {
+						isSLD = true
+						break
+					}
+				}
+				if !isSLD {
+					continue
+				}
+				if windowActive && mockInCurrentWindow(mock) {
+					if sldMockWindow == nil {
+						sldMockWindow = mock
+					}
+				} else if sldMock == nil {
+					sldMock = mock
+				}
+			}
+			chosen := sldMockWindow
+			if chosen == nil {
+				chosen = sldMock
+			}
+			if chosen != nil {
+				updateMock(ctx, logger, chosen, mockDb)
+			}
+			logger.Debug("Accepting COM_STMT_SEND_LONG_DATA (no-response command)",
+				zap.Bool("consumed_recorded_mock", chosen != nil))
 			return &mysql.Response{}, true, "", "", nil
 		}
 

--- a/pkg/agent/proxy/integrations/mysql/replayer/match_comquery_window_test.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match_comquery_window_test.go
@@ -1,0 +1,255 @@
+package replayer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/wire"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.keploy.io/server/v3/pkg/models/mysql"
+	"go.uber.org/zap"
+)
+
+// fakeMockDb is a minimal integrations.MockMemDb for exercising matchCommand
+// directly. Only the accessors matchCommand touches are backed by real state;
+// every other method is a no-op stub. Session-tier mocks are returned from
+// GetSessionMocks (matching how lax-mode promotes per-test MySQL data mocks
+// into the session pool), and UpdateUnFilteredMock is a no-op (session mocks
+// are reusable, never consumed) — which is exactly the condition that made the
+// COM_QUERY matcher serve the first recorded row to every test.
+type fakeMockDb struct {
+	session    []*models.Mock
+	winStart   time.Time
+	winEnd     time.Time
+	deletedFil []string // names passed to DeleteFilteredMock
+}
+
+func (f *fakeMockDb) GetSessionMocks() ([]*models.Mock, error)         { return f.session, nil }
+func (f *fakeMockDb) GetPerTestMocksInWindow() ([]*models.Mock, error) { return nil, nil }
+func (f *fakeMockDb) GetConnectionMocks(string) ([]*models.Mock, error) {
+	return nil, nil
+}
+func (f *fakeMockDb) CurrentTestWindow() (time.Time, time.Time) { return f.winStart, f.winEnd }
+
+// --- remaining MockMemDb surface: inert stubs ---
+func (f *fakeMockDb) GetFilteredMocks() ([]*models.Mock, error)         { return nil, nil }
+func (f *fakeMockDb) GetUnFilteredMocks() ([]*models.Mock, error)       { return nil, nil }
+func (f *fakeMockDb) GetMySQLCounts() (int, int, int)                   { return 0, 0, 0 }
+func (f *fakeMockDb) GetFilteredMocksInWindow() ([]*models.Mock, error) { return nil, nil }
+func (f *fakeMockDb) GetStartupMocks() ([]*models.Mock, error)          { return nil, nil }
+func (f *fakeMockDb) GetStartupMocksByKind(models.Kind) ([]*models.Mock, error) {
+	return nil, nil
+}
+func (f *fakeMockDb) GetSessionScopedMocks() ([]*models.Mock, error) { return nil, nil }
+func (f *fakeMockDb) SessionMockHitCounts() map[string]uint64        { return nil }
+func (f *fakeMockDb) UpdateUnFilteredMock(*models.Mock, *models.Mock) bool {
+	return true // session mocks are reusable: re-stamped, not removed
+}
+func (f *fakeMockDb) DeleteFilteredMock(m models.Mock) bool {
+	f.deletedFil = append(f.deletedFil, m.Name)
+	return false // not a per-test mock; mirrors the real "staged in session" path
+}
+func (f *fakeMockDb) DeleteUnFilteredMock(models.Mock) bool     { return false }
+func (f *fakeMockDb) DeleteStartupMock(models.Mock) bool        { return false }
+func (f *fakeMockDb) MarkMockAsUsed(models.Mock) bool           { return true }
+func (f *fakeMockDb) SetCurrentTestWindow(time.Time, time.Time) {}
+func (f *fakeMockDb) IsTestWindowActive() bool                  { return !f.winStart.IsZero() }
+func (f *fakeMockDb) HasFirstTestFired() bool                   { return true }
+func (f *fakeMockDb) FirstTestWindowStart() time.Time           { return f.winStart }
+func (f *fakeMockDb) WindowSnapshot() models.WindowSnapshot     { return models.WindowSnapshot{} }
+
+// readbackMock builds a session-tier COM_QUERY data mock: same SQL text across
+// all of them, a distinct response payload marker, and a recorded request
+// timestamp so the matcher can window-discriminate.
+func readbackMock(name, sql, marker string, reqTs time.Time) *models.Mock {
+	const payloadLen = 64
+	m := &models.Mock{
+		Name: name,
+		Kind: models.MySQL,
+	}
+	m.TestModeInfo.Lifetime = models.LifetimeSession // lax-promoted data mock
+	m.Spec.Metadata = map[string]string{"type": "mocks"}
+	m.Spec.ReqTimestampMock = reqTs
+	m.Spec.MySQLRequests = []mysql.Request{{
+		PacketBundle: mysql.PacketBundle{
+			Header:  &mysql.PacketInfo{Header: &mysql.Header{PayloadLength: payloadLen, SequenceID: 0}, Type: "COM_QUERY"},
+			Message: &mysql.QueryPacket{Query: sql},
+		},
+	}}
+	m.Spec.MySQLResponses = []mysql.Response{{
+		PacketBundle: mysql.PacketBundle{
+			Header:  &mysql.PacketInfo{Header: &mysql.Header{PayloadLength: payloadLen, SequenceID: 1}, Type: "TextResultSet"},
+			Message: &mysql.TextResultSet{},
+		},
+		Payload: marker, // distinguishes which recorded row was served
+	}}
+	return m
+}
+
+func newDecodeCtx() *wire.DecodeContext {
+	return &wire.DecodeContext{
+		PreparedStatements: map[uint32]*mysql.StmtPrepareOkPacket{},
+		StmtIDToQuery:      map[uint32]string{},
+		NextStmtID:         1,
+	}
+}
+
+func comQueryReq(sql string) mysql.Request {
+	return mysql.Request{
+		PacketBundle: mysql.PacketBundle{
+			Header:  &mysql.PacketInfo{Header: &mysql.Header{PayloadLength: 64, SequenceID: 0}, Type: "COM_QUERY"},
+			Message: &mysql.QueryPacket{Query: sql},
+		},
+	}
+}
+
+func stmtPrepareReq(sql string) mysql.Request {
+	return mysql.Request{
+		PacketBundle: mysql.PacketBundle{
+			Header:  &mysql.PacketInfo{Header: &mysql.Header{PayloadLength: uint32(len(sql) + 1), SequenceID: 0}, Type: "COM_STMT_PREPARE"},
+			Message: &mysql.StmtPreparePacket{Command: 0x16, Query: sql},
+		},
+	}
+}
+
+// TestMatchCommand_OrphanPrepareSynthesizesPrepareOk is the regression guard for
+// the prepared-statement orphan fix (keploy#4226): JDBC cachePrepStmts reuses a
+// server stmtID allocated before the record window, so the recorder captures an
+// EXECUTE with no matching COM_STMT_PREPARE. On replay the cold-cache driver
+// DOES send COM_STMT_PREPARE; with no PREPARE mock to match, matchCommand must
+// synthesize a COM_STMT_PREPARE_OK (and register the stmtID→query mapping so the
+// following EXECUTE resolves) instead of dropping the connection with
+// "no matching mock found".
+func TestMatchCommand_OrphanPrepareSynthesizesPrepareOk(t *testing.T) {
+	logger := zap.NewNop()
+	const sql = "SELECT ? AS v"
+
+	// Pool is non-empty (an unrelated reusable mock) but contains NO PREPARE
+	// mock for this query — the orphaned condition.
+	filler := readbackMock("unrelated", "SELECT 1", "x", time.Time{})
+	db := &fakeMockDb{session: []*models.Mock{filler}}
+	dctx := newDecodeCtx()
+
+	resp, ok, _, _, err := matchCommand(context.Background(), logger, stmtPrepareReq(sql), db, dctx)
+	if err != nil || !ok || resp == nil {
+		t.Fatalf("orphaned PREPARE must synthesize a PREPARE_OK, got ok=%v err=%v resp=%v", ok, err, resp)
+	}
+	prepOk, isPrepOk := resp.Message.(*mysql.StmtPrepareOkPacket)
+	if !isPrepOk {
+		t.Fatalf("expected a *StmtPrepareOkPacket response, got %T", resp.Message)
+	}
+	if prepOk.NumParams != 1 {
+		t.Errorf("synthetic PREPARE_OK NumParams: want 1 (one '?'), got %d", prepOk.NumParams)
+	}
+	if len(prepOk.ParamDefs) != 1 {
+		t.Errorf("synthetic PREPARE_OK must carry one placeholder ColumnDefinition41 per '?', got %d", len(prepOk.ParamDefs))
+	}
+	// The stmtID→query mapping must be wired so the following EXECUTE resolves.
+	if got := dctx.StmtIDToQuery[prepOk.StatementID]; got != sql {
+		t.Errorf("StmtIDToQuery[%d] = %q, want %q", prepOk.StatementID, got, sql)
+	}
+	if _, present := dctx.PreparedStatements[prepOk.StatementID]; !present {
+		t.Errorf("synthetic stmtID %d not registered in PreparedStatements", prepOk.StatementID)
+	}
+}
+
+// TestMatchCommand_SendLongDataAcceptedGracefully is the regression guard for
+// the COM_STMT_SEND_LONG_DATA connection-drop fix. Connector/J streams a
+// setBinaryStream/setBlob parameter as COM_STMT_SEND_LONG_DATA (a no-response
+// command) before COM_STMT_EXECUTE. The matcher has no per-mock comparison for
+// it; without graceful handling matchCommand returns ok=false and query.go
+// drops the connection ("no matching mock") BEFORE its IsNoResponseCommand
+// check — surfacing as SQLSTATE 08S01. matchCommand must instead accept it
+// (ok=true) so the no-response path can continue.
+func TestMatchCommand_SendLongDataAcceptedGracefully(t *testing.T) {
+	logger := zap.NewNop()
+
+	// Pool is non-empty but holds no mock for the long-data packet.
+	db := &fakeMockDb{session: []*models.Mock{readbackMock("unrelated", "SELECT 1", "x", time.Time{})}}
+
+	req := mysql.Request{
+		PacketBundle: mysql.PacketBundle{
+			Header: &mysql.PacketInfo{
+				Header: &mysql.Header{PayloadLength: 12, SequenceID: 0},
+				Type:   "COM_STMT_SEND_LONG_DATA",
+			},
+			Message: &mysql.StmtSendLongDataPacket{StatementID: 3, ParameterID: 0},
+		},
+	}
+	_, ok, _, _, err := matchCommand(context.Background(), logger, req, db, newDecodeCtx())
+	if err != nil {
+		t.Fatalf("unmocked COM_STMT_SEND_LONG_DATA must not error, got %v", err)
+	}
+	if !ok {
+		t.Errorf("unmocked COM_STMT_SEND_LONG_DATA must be accepted (ok=true) to avoid dropping the connection")
+	}
+}
+
+// TestMatchCommand_ComQueryStatefulReadInWindow is the regression guard for the
+// TiDB/Connector-J stateful read-back bug: a
+// parameterless statement that issues the SAME SQL text across tests but
+// returns a DIFFERENT row each time (e.g. an INSERT read-back
+// "SELECT v FROM kv ORDER BY id DESC LIMIT 1"). The data mocks are
+// session-promoted (reusable, never consumed), so the matcher used to serve
+// the FIRST recorded row to every test. matchCommand must instead prefer the
+// exact-text match recorded INSIDE the active test window.
+func TestMatchCommand_ComQueryStatefulReadInWindow(t *testing.T) {
+	logger := zap.NewNop()
+	const sql = "SELECT v FROM kv ORDER BY id DESC LIMIT 1"
+
+	base := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+	t1 := base
+	t2 := base.Add(10 * time.Second)
+	t3 := base.Add(20 * time.Second)
+
+	mocks := []*models.Mock{
+		readbackMock("readback-1", sql, "row=1", t1),
+		readbackMock("readback-2", sql, "row=2", t2),
+		readbackMock("readback-3", sql, "row=3", t3),
+	}
+
+	t.Run("in-window match preferred over first-recorded", func(t *testing.T) {
+		db := &fakeMockDb{
+			session:  mocks,
+			winStart: base.Add(5 * time.Second),  // [t1 < winStart < t2 < winEnd < t3]
+			winEnd:   base.Add(15 * time.Second), // only readback-2 is in-window
+		}
+		resp, ok, _, _, err := matchCommand(context.Background(), logger, comQueryReq(sql), db, newDecodeCtx())
+		if err != nil || !ok || resp == nil {
+			t.Fatalf("expected a match, got ok=%v err=%v resp=%v", ok, err, resp)
+		}
+		if resp.Payload != "row=2" {
+			t.Errorf("expected the in-window row (row=2), got %q — the matcher served a stale/first row", resp.Payload)
+		}
+	})
+
+	t.Run("no active window falls back to first-recorded (no behavior change)", func(t *testing.T) {
+		db := &fakeMockDb{session: mocks} // zero window => windowActive == false
+		resp, ok, _, _, err := matchCommand(context.Background(), logger, comQueryReq(sql), db, newDecodeCtx())
+		if err != nil || !ok || resp == nil {
+			t.Fatalf("expected a match, got ok=%v err=%v resp=%v", ok, err, resp)
+		}
+		if resp.Payload != "row=1" {
+			t.Errorf("with no active window the legacy first-exact-match wins; expected row=1, got %q", resp.Payload)
+		}
+	})
+
+	t.Run("match recorded outside window still resolves via fallback", func(t *testing.T) {
+		// Active window that contains NONE of the recorded read-backs: the
+		// single reusable recording must still be served (out-of-window
+		// fallback), not dropped as a miss.
+		db := &fakeMockDb{
+			session:  []*models.Mock{readbackMock("only", sql, "row=only", t1)},
+			winStart: base.Add(100 * time.Second),
+			winEnd:   base.Add(200 * time.Second),
+		}
+		resp, ok, _, _, err := matchCommand(context.Background(), logger, comQueryReq(sql), db, newDecodeCtx())
+		if err != nil || !ok || resp == nil {
+			t.Fatalf("expected the reusable recording to still match, got ok=%v err=%v", ok, err)
+		}
+		if resp.Payload != "row=only" {
+			t.Errorf("expected out-of-window fallback to serve row=only, got %q", resp.Payload)
+		}
+	})
+}

--- a/pkg/agent/proxy/integrations/mysql/replayer/match_comquery_window_test.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match_comquery_window_test.go
@@ -186,6 +186,51 @@ func TestMatchCommand_SendLongDataAcceptedGracefully(t *testing.T) {
 	}
 }
 
+// sldMock builds a per-test, no-response COM_STMT_SEND_LONG_DATA data mock.
+func sldMock(name string, reqTs time.Time) *models.Mock {
+	m := &models.Mock{Name: name, Kind: models.MySQL}
+	m.TestModeInfo.Lifetime = models.LifetimePerTest
+	m.Spec.Metadata = map[string]string{"type": "mocks"}
+	m.Spec.ReqTimestampMock = reqTs
+	m.Spec.MySQLRequests = []mysql.Request{{
+		PacketBundle: mysql.PacketBundle{
+			Header:  &mysql.PacketInfo{Header: &mysql.Header{PayloadLength: 12, SequenceID: 0}, Type: "COM_STMT_SEND_LONG_DATA"},
+			Message: &mysql.StmtSendLongDataPacket{StatementID: 3, ParameterID: 0},
+		},
+	}}
+	return m
+}
+
+// TestMatchCommand_SendLongDataConsumesRecordedMock verifies the SEND_LONG_DATA
+// fallback consumes a recorded SLD mock when one exists (so it isn't flagged
+// unused / pruned), while still returning the no-response acceptance.
+func TestMatchCommand_SendLongDataConsumesRecordedMock(t *testing.T) {
+	logger := zap.NewNop()
+	base := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+	db := &fakeMockDb{
+		session:  []*models.Mock{sldMock("sld-1", base)},
+		winStart: base.Add(-time.Second),
+		winEnd:   base.Add(time.Second), // sld-1 is in-window
+	}
+	req := mysql.Request{PacketBundle: mysql.PacketBundle{
+		Header:  &mysql.PacketInfo{Header: &mysql.Header{PayloadLength: 12, SequenceID: 0}, Type: "COM_STMT_SEND_LONG_DATA"},
+		Message: &mysql.StmtSendLongDataPacket{StatementID: 3},
+	}}
+	_, ok, _, _, err := matchCommand(context.Background(), logger, req, db, newDecodeCtx())
+	if err != nil || !ok {
+		t.Fatalf("SLD must be accepted, got ok=%v err=%v", ok, err)
+	}
+	consumed := false
+	for _, n := range db.deletedFil {
+		if n == "sld-1" {
+			consumed = true
+		}
+	}
+	if !consumed {
+		t.Errorf("expected the recorded SLD mock to be consumed (DeleteFilteredMock), deletedFil=%v", db.deletedFil)
+	}
+}
+
 // TestMatchCommand_ComQueryStatefulReadInWindow is the regression guard for the
 // TiDB/Connector-J stateful read-back bug: a
 // parameterless statement that issues the SAME SQL text across tests but


### PR DESCRIPTION
## Describe the changes that are made

While rigorously validating keploy's MySQL/TiDB prepared-statement replay
(the `useServerPrepStmts=true&cachePrepStmts=true` + Connector/J 8.x path on
TiDB `:4000`), two real replay bugs surfaced. Both are fixed here in
`pkg/agent/proxy/integrations/mysql/replayer/match.go`, with unit tests and a
new end-to-end CI job.

### 1. COM_QUERY stateful read-backs served the wrong row (bug fix)

A parameterless statement that issues the **same SQL text** across tests but
returns a **different row each call** — e.g. an INSERT read-back
`SELECT v FROM kv ORDER BY id DESC LIMIT 1` — records one data mock per call.
Those data mocks are lax-promoted into the reusable **session** tier and are
never consumed by `updateMock`, so the `COM_QUERY` branch (which took the
first exact-text match and broke) served the **first** recorded row to every
later test → wrong response body (HTTP 200, wrong data).

`COM_STMT_EXECUTE` already handles this via the in-window selection added in
#4235; the `COM_QUERY` branch did not. This gives `COM_QUERY` the same
treatment: prefer the exact-text match recorded **inside the active test
window**, keeping the first out-of-window exact match only as a fallback for a
genuinely reusable single-recording query. When no test window is active it
collapses to the previous first-match-wins behaviour, so non-stateful queries
are unaffected.

**Proof (e2e, real TiDB + Connector/J 8.3):** an `insert-select` workload of 5
read-backs went **13/17 → 17/17**. A unit test reverting just the matcher hunk
fails on the stale row and passes with the fix.

### 2. COM_STMT_SEND_LONG_DATA dropped the connection (bug fix)

Connector/J streams a `setBinaryStream`/`setBlob` parameter as
`COM_STMT_SEND_LONG_DATA` (a no-response command) before `COM_STMT_EXECUTE`.
`matchCommand` had no branch for it, so it returned `ok=false` and `query.go`
tore the connection down with *"no matching mock found"* **before** reaching
its `IsNoResponseCommand` check — surfacing to the app as SQLSTATE `08S01`
(`CommunicationsException`). It is now accepted gracefully in the
`matchedResp==nil` block so the no-response path continues, mirroring the
existing `COM_STMT_RESET` handling (#4217).

> Note: this stops the SLD connection drop. A *full* streamed-BLOB round-trip
> additionally needs recorder work — the pipelined `RESET`+`SLD`+`EXECUTE`
> sequence currently mis-attributes the EXECUTE's response to the RESET mock.
> That recorder fix is out of scope here and tracked as a follow-up.

### 3. e2e CI for the TiDB prepared-statement cluster (test)

New `tidb-stmt-cache` matrix job in `java_linux.yml` (standard 3-cell compat
matrix). It records once, then replays **twice** with TiDB shut down:
**baseline** (stateful read-backs + cross-query) and a **PREPARE-dropped
mutant** that deterministically forces the synthetic-`PREPARE_OK` orphan path
(#4226) regardless of HikariCP timing. Both must report `PASSED`.

## Validated but intentionally NOT changed here

For reviewer transparency, the same investigation triaged three more
candidate issues:

- **Orphaned cross-query param collision** — *not reproducible.* Two orphaned
  queries with an identical param shape in the same window replay correctly;
  the existing in-window + FIFO + consumption logic already disambiguates.
  The new `/api/cross` endpoint is kept as a regression guard.
- **Synthetic `PREPARE_OK` "missing EOF"** — *not a bug.* Connector/J 8.x
  negotiates `CLIENT_DEPRECATE_EOF`, so the empty EOF-after-params is correct
  (confirmed in capability flags + a live cursor-less round-trip).
- **Param-def sequence-id wraparound > 253 params** — *not a bug.* MySQL
  packet sequence ids are mod-256; the wrap is the expected contiguous
  numbering.

## Known follow-ups (separate issues)

- **`COM_STMT_FETCH` / `useCursorFetch=true`** — genuinely unimplemented: the
  recorder skips the FETCH response, so cursor result chunks are never
  captured. Needs recorder + replayer + multi-chunk codec work.
- **Streamed-BLOB recorder sequencing** — the pipelined `RESET`+`SLD`+`EXECUTE`
  response mis-attribution noted above.

## Links & References

**Closes:** NA

### 🔗 Related PRs
- #4226, #4217, #4208, #4235 — the prior MySQL/TiDB prepared-statement fixes this builds on.
- keploy/samples-java#143 — adds `/api/cross` to the sample app; must merge before this job's CI passes.

## What type of PR is this? (check all applicable)
- [x] 🐞 Bug Fix
- [x] ✅ Test
- [x] 🔁 CI

## Added e2e test pipeline?
- [x] 👍 yes

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

Unit: `go test ./pkg/agent/proxy/integrations/mysql/replayer/ -run TestMatchCommand_`
E2E: the new `tidb-stmt-cache` `java_linux` job (record → baseline replay → PREPARE-drop replay), validated locally end-to-end (baseline 17/17, orphan 17/17).

## Self Review done?
- [x] ✅ yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)