### PR TITLE
fix(replay): flow body noise into mock-matching NoiseConfig

### DIFF
--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1072,7 +1072,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			utils.LogError(r.logger, err, stopReason)
 		}
 		r.firstRun = false
-		// Prepare header noise configuration for mock matching
+		// Prepare header + body noise configuration for mock matching
 		mockNoiseConfig := PrepareMockNoiseConfig(r.config.Test.GlobalNoise.Global, r.config.Test.GlobalNoise.Testsets, testSetID)
 
 		if r.config.Test.FallBackOnMiss {
@@ -1261,7 +1261,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 
 		pkg.InitSortCounter(int64(max(len(filteredMocks), len(unfilteredMocks))))
 
-		// Prepare header noise configuration for mock matching
+		// Prepare header + body noise configuration for mock matching
 		mockNoiseConfig := PrepareMockNoiseConfig(r.config.Test.GlobalNoise.Global, r.config.Test.GlobalNoise.Testsets, testSetID)
 
 		if r.config.Test.FallBackOnMiss {

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1073,7 +1073,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		}
 		r.firstRun = false
 		// Prepare header noise configuration for mock matching
-		headerNoiseConfig := PrepareHeaderNoiseConfig(r.config.Test.GlobalNoise.Global, r.config.Test.GlobalNoise.Testsets, testSetID)
+		mockNoiseConfig := PrepareMockNoiseConfig(r.config.Test.GlobalNoise.Global, r.config.Test.GlobalNoise.Testsets, testSetID)
 
 		if r.config.Test.FallBackOnMiss {
 			r.fallbackDeprecateOnce.Do(func() {
@@ -1087,7 +1087,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			SQLDelay:               time.Duration(r.config.Test.Delay) * time.Second,
 			Mocking:                r.config.Test.Mocking,
 			Backdate:               testCases[0].HTTPReq.Timestamp,
-			NoiseConfig:            headerNoiseConfig,
+			NoiseConfig:            mockNoiseConfig,
 			DisableAutoHeaderNoise: r.config.Test.DisableAutoHeaderNoise,
 			SchemaNoiseDetection:   r.config.Test.SchemaNoiseDetection,
 			SchemaNoiseStrict:      r.config.Test.SchemaNoiseStrict,
@@ -1262,7 +1262,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		pkg.InitSortCounter(int64(max(len(filteredMocks), len(unfilteredMocks))))
 
 		// Prepare header noise configuration for mock matching
-		headerNoiseConfig := PrepareHeaderNoiseConfig(r.config.Test.GlobalNoise.Global, r.config.Test.GlobalNoise.Testsets, testSetID)
+		mockNoiseConfig := PrepareMockNoiseConfig(r.config.Test.GlobalNoise.Global, r.config.Test.GlobalNoise.Testsets, testSetID)
 
 		if r.config.Test.FallBackOnMiss {
 			r.fallbackDeprecateOnce.Do(func() {
@@ -1276,7 +1276,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			SQLDelay:               time.Duration(r.config.Test.Delay) * time.Second,
 			Mocking:                r.config.Test.Mocking,
 			Backdate:               testCases[0].HTTPReq.Timestamp,
-			NoiseConfig:            headerNoiseConfig,
+			NoiseConfig:            mockNoiseConfig,
 			DisableAutoHeaderNoise: r.config.Test.DisableAutoHeaderNoise,
 			SchemaNoiseDetection:   r.config.Test.SchemaNoiseDetection,
 			SchemaNoiseStrict:      r.config.Test.SchemaNoiseStrict,

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -308,21 +308,28 @@ func CloneGlobalNoise(src config.GlobalNoise) config.GlobalNoise {
 	return cloned
 }
 
-// PrepareHeaderNoiseConfig prepares the header noise configuration for mock matching.
-// It merges global and test-set specific noise, then extracts only the header noise.
-func PrepareHeaderNoiseConfig(globalNoise config.GlobalNoise, testSetNoise config.TestsetNoise, testSetID string) map[string]map[string][]string {
+// PrepareMockNoiseConfig builds the noise configuration handed to the proxy
+// integrations (OutgoingOptions.NoiseConfig) for mock matching. It carries
+// the "header" noise (HTTP outgoing header matching) AND the "body" noise:
+// parsers that compare outgoing payloads — e.g. the Pulsar SEND payload
+// matcher — strip these body-noise field names so non-deterministic fields
+// (emit timestamps, generated event ids) don't false-reject a replay.
+func PrepareMockNoiseConfig(globalNoise config.GlobalNoise, testSetNoise config.TestsetNoise, testSetID string) map[string]map[string][]string {
 	noiseConfig := CloneGlobalNoise(globalNoise)
 	if tsNoise, ok := testSetNoise[testSetID]; ok {
 		noiseConfig = LeftJoinNoise(noiseConfig, tsNoise)
 	}
 
-	// Extract only header noise for mock matching
-	headerNoiseConfig := map[string]map[string][]string{}
+	// Extract header + body noise for mock matching.
+	mockNoiseConfig := map[string]map[string][]string{}
 	if headerNoise, ok := noiseConfig["header"]; ok {
-		headerNoiseConfig["header"] = headerNoise
+		mockNoiseConfig["header"] = headerNoise
+	}
+	if bodyNoise, ok := noiseConfig["body"]; ok {
+		mockNoiseConfig["body"] = bodyNoise
 	}
 
-	return headerNoiseConfig
+	return mockNoiseConfig
 }
 
 // ReplaceBaseURL replaces the baseUrl of the old URL with the new URL's.

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -332,6 +332,21 @@ func PrepareMockNoiseConfig(globalNoise config.GlobalNoise, testSetNoise config.
 	return mockNoiseConfig
 }
 
+// PrepareHeaderNoiseConfig is retained for backward compatibility with
+// downstream importers of pkg/service/replay. It preserves the original
+// header-only behavior.
+//
+// Deprecated: use PrepareMockNoiseConfig, which also carries body noise for
+// outgoing-payload matchers (e.g. the Pulsar SEND matcher).
+func PrepareHeaderNoiseConfig(globalNoise config.GlobalNoise, testSetNoise config.TestsetNoise, testSetID string) map[string]map[string][]string {
+	mockNoiseConfig := PrepareMockNoiseConfig(globalNoise, testSetNoise, testSetID)
+	headerOnly := map[string]map[string][]string{}
+	if headerNoise, ok := mockNoiseConfig["header"]; ok {
+		headerOnly["header"] = headerNoise
+	}
+	return headerOnly
+}
+
 // ReplaceBaseURL replaces the baseUrl of the old URL with the new URL's.
 func ReplaceBaseURL(newURL, oldURL string) (string, error) {
 	parsedOldURL, err := url.Parse(oldURL)

--- a/pkg/service/replay/utils_test.go
+++ b/pkg/service/replay/utils_test.go
@@ -34,6 +34,26 @@ func TestCloneGlobalNoise_DeepCopy_324(t *testing.T) {
 	assert.False(t, hasNewHeaderField)
 }
 
+// TestPrepareMockNoiseConfig_IncludesBodyNoise guards that the mock-matching
+// noise config handed to the proxy integrations (OutgoingOptions.NoiseConfig)
+// carries BOTH header and body noise. Body noise was previously dropped, which
+// left outgoing-payload matchers (e.g. the Pulsar SEND matcher) with no way to
+// ignore non-deterministic fields and made noise-only differences fail replay.
+func TestPrepareMockNoiseConfig_IncludesBodyNoise(t *testing.T) {
+	global := config.GlobalNoise{
+		"header": {"date": []string{".*"}},
+		"body":   {"eventTs": []string{}, "eventId": []string{}},
+	}
+
+	got := PrepareMockNoiseConfig(global, config.TestsetNoise{}, "test-set-0")
+
+	require.Contains(t, got, "header", "header noise must still flow")
+	require.Contains(t, got, "body", "body noise must now flow (regression guard)")
+	_, hasTs := got["body"]["eventTs"]
+	_, hasID := got["body"]["eventId"]
+	assert.True(t, hasTs && hasID, "expected eventTs and eventId body-noise fields to be carried")
+}
+
 func TestLeftJoinNoise_DoesNotMutateGlobal_325(t *testing.T) {
 	global := config.GlobalNoise{
 		"body": {


### PR DESCRIPTION
## Describe the changes that are made

`OutgoingOptions.NoiseConfig` — the noise configuration handed to the proxy
integrations for **mock matching** — only carried `header` noise.
`PrepareHeaderNoiseConfig` explicitly dropped the `body` category ("Extract
only header noise for mock matching").

That left **outgoing-payload matchers** with no way to ignore non-deterministic
fields. A recorded outgoing message that differs from the live one *only* on
noise (emit timestamps, generated event/message ids) is rejected and the
connection dropped.

This renames the helper to `PrepareMockNoiseConfig` and carries **both**
`header` and `body` noise. The only existing consumer reads
`NoiseConfig["header"]` (`integrations/http/decode.go`), so adding `body` is
purely additive.

This is the **OSS half** of a Pulsar SEND payload-noise fix — the enterprise
Pulsar replayer strips these body-noise fields before its payload-aware
deep-equal so a noise-only SEND no longer fails replay.

Regression test `TestPrepareMockNoiseConfig_IncludesBodyNoise` locks in that
both categories flow.

## Links & References

**Closes:** NA

### 🔗 Related PRs
- keploy/enterprise (private): `fix(pulsar): noise-aware SEND payload matching` — consumes `NoiseConfig["body"]`.

## What type of PR is this?
- [x] 🐞 Bug Fix

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Are there any sample code or steps to test the changes?
- [x] 👍 yes

`go test ./pkg/service/replay/ -run TestPrepareMockNoiseConfig`

## Self Review done?
- [x] ✅ yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)