### PR TITLE
fix(agent): make agent-ready timeout configurable (KEPLOY_AGENT_READY_TIMEOUT), default 60s→120s

### DIFF
--- a/pkg/agent_ready_timeout_test.go
+++ b/pkg/agent_ready_timeout_test.go
@@ -1,0 +1,37 @@
+package pkg
+
+import (
+	"testing"
+	"time"
+)
+
+// TestAgentReadyTimeout pins the parsing of KEPLOY_AGENT_READY_TIMEOUT: a Go
+// duration or a bare integer (seconds) raises the failsafe ceiling; anything
+// empty/invalid/non-positive falls back to the 120s default.
+func TestAgentReadyTimeout(t *testing.T) {
+	const def = 120 * time.Second
+	cases := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{"empty -> default", "", def},
+		{"whitespace -> default", "   ", def},
+		{"go duration seconds", "180s", 180 * time.Second},
+		{"go duration minutes", "3m", 3 * time.Minute},
+		{"bare integer = seconds", "240", 240 * time.Second},
+		{"surrounding whitespace trimmed", "  90s  ", 90 * time.Second},
+		{"invalid string -> default", "abc", def},
+		{"zero -> default", "0", def},
+		{"negative -> default", "-5", def},
+		{"negative duration -> default", "-30s", def},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("KEPLOY_AGENT_READY_TIMEOUT", tc.env)
+			if got := AgentReadyTimeout(nil); got != tc.want {
+				t.Fatalf("AgentReadyTimeout()=%s, want %s (env=%q)", got, tc.want, tc.env)
+			}
+		})
+	}
+}

--- a/pkg/platform/http/agent.go
+++ b/pkg/platform/http/agent.go
@@ -1249,7 +1249,11 @@ func (a *AgentClient) Setup(ctx context.Context, cmd string, opts models.SetupOp
 		}
 		a.logger.Debug("Agent is now running, proceeding with setup")
 
-		agentCtx, cancel := context.WithTimeout(ctx, 60*time.Second) // we will wait for 1 minute for the agent to get ready
+		// Failsafe ceiling only — the ticker below unblocks the instant the
+		// agent reports ready, so a healthy agent never waits near this.
+		// Configurable via KEPLOY_AGENT_READY_TIMEOUT for heavily-loaded hosts.
+		readyTimeout := pkg.AgentReadyTimeout(a.logger)
+		agentCtx, cancel := context.WithTimeout(ctx, readyTimeout)
 		defer cancel()
 
 		agentReadyCh := make(chan bool, 1)
@@ -1260,7 +1264,7 @@ func (a *AgentClient) Setup(ctx context.Context, cmd string, opts models.SetupOp
 			// Parent context cancelled (user pressed Ctrl+C)
 			return ctx.Err()
 		case <-agentCtx.Done():
-			return fmt.Errorf("keploy-agent did not become ready in time")
+			return fmt.Errorf("keploy-agent did not become ready in time (waited %s; if this host is heavily loaded, raise KEPLOY_AGENT_READY_TIMEOUT)", readyTimeout)
 		case <-agentReadyCh:
 		}
 	}

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -294,7 +294,8 @@ func (r *Recorder) Start(ctx context.Context) error {
 			return nil
 		})
 
-		agentCtx, cancel := context.WithTimeout(ctx, 120*time.Second)
+		agentReadyTimeout := pkg.AgentReadyTimeout(r.logger)
+		agentCtx, cancel := context.WithTimeout(ctx, agentReadyTimeout)
 		defer cancel()
 
 		agentReadyCh := make(chan bool, 1)
@@ -305,7 +306,7 @@ func (r *Recorder) Start(ctx context.Context) error {
 			// Parent context cancelled (user pressed Ctrl+C)
 			return ctx.Err()
 		case <-agentCtx.Done():
-			return fmt.Errorf("keploy-agent did not become ready in time")
+			return fmt.Errorf("keploy-agent did not become ready in time (waited %s; if this host is heavily loaded, raise KEPLOY_AGENT_READY_TIMEOUT)", agentReadyTimeout)
 		case <-agentReadyCh:
 		}
 	}

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1049,7 +1049,8 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			return nil
 		})
 
-		agentCtx, cancel := context.WithTimeout(runTestSetCtx, 120*time.Second)
+		agentReadyTimeout := pkg.AgentReadyTimeout(r.logger)
+		agentCtx, cancel := context.WithTimeout(runTestSetCtx, agentReadyTimeout)
 		defer cancel()
 
 		agentReadyCh := make(chan bool, 1)
@@ -1060,7 +1061,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			// Parent context cancelled (user pressed Ctrl+C)
 			return models.TestSetStatusUserAbort, runTestSetCtx.Err()
 		case <-agentCtx.Done():
-			return models.TestSetStatusFailed, fmt.Errorf("keploy-agent did not become ready in time")
+			return models.TestSetStatusFailed, fmt.Errorf("keploy-agent did not become ready in time (waited %s; if this host is heavily loaded, raise KEPLOY_AGENT_READY_TIMEOUT)", agentReadyTimeout)
 		case <-agentReadyCh:
 		}
 

--- a/pkg/service/runner/runner.go
+++ b/pkg/service/runner/runner.go
@@ -348,7 +348,8 @@ func (r *Runner) setupTestSet(parentCtx context.Context, testSetID string, backd
 	// "connect: connection refused" on the agent URL. Mirrors replay's
 	// pre-MockOutgoing AgentHealthTicker gate (replay.go:939-952).
 	if r.config != nil && r.config.Agent.AgentURI != "" {
-		agentCtx, cancel := context.WithTimeout(gCtx, 120*time.Second)
+		agentReadyTimeout := keployPkg.AgentReadyTimeout(r.logger)
+		agentCtx, cancel := context.WithTimeout(gCtx, agentReadyTimeout)
 		agentReadyCh := make(chan bool, 1)
 		go keployPkg.AgentHealthTicker(agentCtx, r.logger, r.config.Agent.AgentURI, agentReadyCh, 1*time.Second)
 		select {
@@ -357,7 +358,7 @@ func (r *Runner) setupTestSet(parentCtx context.Context, testSetID string, backd
 			return nil, gCtx.Err()
 		case <-agentCtx.Done():
 			cancel()
-			return nil, fmt.Errorf("keploy-agent at %s did not become ready within 120s; check the agent container logs and ensure its host port is reachable", r.config.Agent.AgentURI)
+			return nil, fmt.Errorf("keploy-agent at %s did not become ready within %s; check the agent container logs and ensure its host port is reachable (raise KEPLOY_AGENT_READY_TIMEOUT if the host is heavily loaded)", r.config.Agent.AgentURI, agentReadyTimeout)
 		case <-agentReadyCh:
 		}
 		cancel()

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -2678,6 +2678,37 @@ func WaitForPort(ctx context.Context, host string, port string, timeout time.Dur
 	}
 }
 
+// AgentReadyTimeout returns how long the CLI waits for the agent to report
+// ready (via AgentHealthTicker) before giving up. Default 120s; override with
+// KEPLOY_AGENT_READY_TIMEOUT, which accepts either a Go duration ("180s", "3m")
+// or a bare integer number of seconds. Invalid/zero/negative values fall back
+// to the default (with a warning).
+//
+// This bounds only the FAILSAFE ceiling that gates every agent-readiness wait
+// (record, replay, runner, and non-docker-compose setup): AgentHealthTicker
+// polls /agent/ready every second and unblocks the instant the agent is up, so
+// raising this never slows a healthy run — it only grants a slow/heavily-loaded
+// host (e.g. CI arming eBPF for many concurrent pipelines on one box) more
+// grace before the "keploy-agent did not become ready in time" error.
+func AgentReadyTimeout(logger *zap.Logger) time.Duration {
+	const def = 120 * time.Second
+	v := strings.TrimSpace(os.Getenv("KEPLOY_AGENT_READY_TIMEOUT"))
+	if v == "" {
+		return def
+	}
+	if d, err := time.ParseDuration(v); err == nil && d > 0 {
+		return d
+	}
+	if n, err := strconv.Atoi(v); err == nil && n > 0 {
+		return time.Duration(n) * time.Second
+	}
+	if logger != nil {
+		logger.Warn("ignoring invalid KEPLOY_AGENT_READY_TIMEOUT (want a Go duration like \"180s\" or an integer number of seconds)",
+			zap.String("value", v), zap.Duration("using", def))
+	}
+	return def
+}
+
 // AgentHealthTicker continuously monitors the agent health endpoint at specified intervals
 // and signals on the provided channel when the agent becomes available or unavailable.
 // It respects the context timeout and returns when the context is cancelled.


### PR DESCRIPTION
## What

Make the keploy-agent readiness timeout configurable via **`KEPLOY_AGENT_READY_TIMEOUT`**, and bump the default `60s → 120s`.

## Why

`AgentClient.Setup()` waits a **hardcoded 60s** for the agent to report ready (`context.WithTimeout(ctx, 60*time.Second)` in `pkg/platform/http/agent.go`), erroring `keploy-agent did not become ready in time` past that.

The wait is already **event-based** — `AgentHealthTicker` polls `/agent/ready` every 1s and unblocks the instant the agent is up — so the 60s is purely a **failsafe ceiling**, never the happy path. On heavily-loaded hosts (e.g. CI arming eBPF for many concurrent pipelines on a single box), agent bring-up can occasionally exceed 60s, so the ceiling trips and the entire `record`/`test` run fails even though nothing is actually wrong. This is a recurring source of CI flakiness in downstream (enterprise) pipelines across multiple lanes (kafka record + test, atg, etc.) — one fix here cures all of them.

## How

- `resolveAgentReadyTimeout()` reads `KEPLOY_AGENT_READY_TIMEOUT` — accepts a Go duration (`"180s"`, `"3m"`) or a bare integer number of seconds; empty/invalid/non-positive falls back to the default (with a warning).
- Default bumped `60s → 120s`. Raising the ceiling **never slows a healthy run** (the ticker returns immediately on ready) — it only grants a slow host more grace before erroring.
- The error message now reports the actual wait and the override knob.

## Testing
- `go build` / `go vet ./pkg/platform/http/` — clean.
- New unit test `TestResolveAgentReadyTimeout` covers duration / bare-integer / whitespace-trimming / invalid / zero / negative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
