### PR TITLE
fix(compose): build+create the stack before arming the agent-readiness timer

### DIFF
--- a/.github/workflows/golang_docker_windows.yml
+++ b/.github/workflows/golang_docker_windows.yml
@@ -125,6 +125,18 @@ jobs:
           Move-Item -Path ".\replay-bin\keploy.exe" -Destination ".\bin\keploy-replay.exe" -Force
           echo "bin_name=keploy-replay.exe" >> $env:GITHUB_OUTPUT
 
+      # download-image's `docker load` (and the sample app afterwards) need the
+      # Docker Desktop Linux engine up. The self-hosted Windows runner does not
+      # guarantee it is running, so start it and wait for readiness here — same
+      # helper/pattern used by prepare_and_run.yml's "Ensure Docker is running"
+      # step. Without this the job fails on "failed to connect to the docker API
+      # at npipe:////./pipe/dockerDesktopLinuxEngine".
+      - name: Ensure Docker is running
+        shell: 'powershell -ExecutionPolicy Bypass -NoProfile -Command "& ''{0}''"'
+        run: |
+          $script = Join-Path $Env:GITHUB_WORKSPACE '.github/scripts/windows/ensure-docker.ps1'
+          if (Test-Path $script) { & $script } else { Write-Error "Required helper script not found: $script"; exit 1 }
+
       - id: image
         uses: ./.github/actions/download-image
         with:

--- a/.github/workflows/test_workflow_scripts/golang/echo_mysql/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/echo_mysql/golang-linux.sh
@@ -7,6 +7,22 @@ git checkout origin/add-ssl-mysql
 # ----- helpers -----
 section()  { echo "::group::$*"; }
 endsec()   { echo "::endgroup::"; }
+# Retry a command with backoff to ride out transient Docker Hub registry blips
+# (e.g. registry-1.docker.io timeouts pulling mysql:latest), which otherwise
+# fail the whole job on a flake unrelated to the code under test.
+retry() {
+  local max=5 delay=10 attempt=1
+  until "$@"; do
+    if [ "$attempt" -ge "$max" ]; then
+      echo "::error::command failed after ${max} attempts: $*"
+      return 1
+    fi
+    echo "attempt ${attempt}/${max} failed: $* — retrying in ${delay}s..."
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+}
 dump_logs() {
   rc=$?
   echo "Dumping logs and artifacts (exit code: $rc)"
@@ -168,6 +184,7 @@ if ! docker ps --format '{{.Names}}' | grep -q '^mysql-container$'; then
     echo "Starting MySQL with standard Docker run (no SSL)"
     sed -i 's/MYSQL_SSL_MODE=production/MYSQL_SSL_MODE=false/' .env
     cat .env
+    retry docker pull mysql:latest
     docker run --name mysql-container -e MYSQL_ROOT_PASSWORD=password -e MYSQL_DATABASE=uss \
       -p 3306:3306 --rm -d mysql:latest
     wait_for_mysql
@@ -196,6 +213,7 @@ if json_pass_supported; then
     docker compose up -d
     wait_for_mysql
   else
+    retry docker pull mysql:latest
     docker run --name mysql-container -e MYSQL_ROOT_PASSWORD=password -e MYSQL_DATABASE=uss \
       -p 3306:3306 --rm -d mysql:latest
     wait_for_mysql

--- a/.github/workflows/test_workflow_scripts/golang/echo_sql/golang-docker.sh
+++ b/.github/workflows/test_workflow_scripts/golang/echo_sql/golang-docker.sh
@@ -2,8 +2,25 @@
 
 source ./../../.github/workflows/test_workflow_scripts/test-iid.sh
 
+# Retry a command with backoff to ride out transient Docker Hub registry
+# blips (e.g. `i/o timeout` while pulling base images like golang:1.20-bookworm),
+# which otherwise fail the whole job on a flake unrelated to the code under test.
+retry() {
+    local max=5 delay=10 attempt=1
+    until "$@"; do
+        if [ "$attempt" -ge "$max" ]; then
+            echo "::error::command failed after ${max} attempts: $*"
+            return 1
+        fi
+        echo "attempt ${attempt}/${max} failed: $* — retrying in ${delay}s..."
+        sleep "$delay"
+        attempt=$((attempt + 1))
+        delay=$((delay * 2))
+    done
+}
+
 # Build Docker Image
-docker compose build
+retry docker compose build
 
 # Remove any preexisting keploy tests and mocks.
 sudo rm -rf keploy/

--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -74,6 +74,12 @@ func (a *App) Setup(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		// Build, pull, and create the compose stack now — Setup runs BEFORE the
+		// record/replay services arm their fixed agent-readiness timer. Otherwise
+		// `docker compose up` charges that whole build+pull+create phase against the
+		// agent's startup budget (see prepareCompose), which is the root cause of the
+		// "keploy-agent did not become ready in time" flake on large stacks.
+		a.prepareCompose(ctx)
 	default:
 		// setup native binary
 	}
@@ -536,6 +542,95 @@ func extractProjectFlags(cmd string) []string {
 		}
 	}
 	return flags
+}
+
+// prepareCompose builds, pulls, and creates the compose stack WITHOUT starting it,
+// so the subsequent `docker compose up` only has to START already-prepared containers.
+//
+// Why this exists: the record and replay services arm a fixed agent-readiness timer
+// (pkg/service/record/record.go and pkg/service/runner/runner.go) at the moment
+// `docker compose up` is launched. But `up` performs build -> pull -> create for the
+// ENTIRE stack globally before it STARTS any container — including the injected
+// keploy-agent, which every app service shares a network/pid namespace with and
+// depends_on. On a large multi-service stack that pre-start work can exceed the
+// readiness budget, so the agent's host port never opens in time and the run fails
+// with "keploy-agent did not become ready in time" even though the agent is perfectly
+// healthy once it actually starts.
+//
+// prepareCompose runs during Setup — before the readiness timer is armed — so the
+// expensive, variable build/pull/create work is no longer charged against the agent's
+// startup SLA; the timer then measures only the agent's real startup. It is
+// best-effort: any failure is logged and tolerated, in which case `up` simply performs
+// this work on-clock exactly as before, so there is no regression.
+//
+// The build/create commands are DERIVED from the real run command (a.cmd) by swapping
+// only the `up` subcommand for the stage (see composePrepareCmd), and they are executed
+// through the same utils.ExecuteCommand path that runs `up`. That keeps the launcher
+// and every global flag identical — `sudo docker compose ...`, the legacy
+// `docker-compose ...` binary, `--profile`, `--env-file`, `-f -` in-memory content,
+// project-scoping flags, etc. — so prepare always targets the exact same project and
+// configuration the subsequent `up` will start.
+func (a *App) prepareCompose(ctx context.Context) {
+	if a.kind != utils.DockerCompose {
+		return
+	}
+
+	// Cancel handler mirrors the docker branch of run(): interrupt the command's
+	// process group on context cancellation; ExecuteCommand's WaitDelay escalates to
+	// a kill if it does not exit. prepare is best-effort, so a failed signal is fine.
+	prepareCancel := func(cmd *exec.Cmd) func() error {
+		return func() error {
+			if cmd.Process == nil {
+				return nil
+			}
+			return utils.SendSignal(a.logger, -cmd.Process.Pid, syscall.SIGINT)
+		}
+	}
+
+	// `build` covers services with a build: section; `create` pulls image-only
+	// services and materialises every container. Together they are the full pre-start
+	// phase that `up` would otherwise do under the readiness clock.
+	for _, stage := range []string{"build", "create"} {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		stageCmd, ok := composePrepareCmd(a.cmd, stage)
+		if !ok {
+			a.logger.Debug("skipping off-clock compose prepare: no 'up' subcommand found in app command",
+				zap.String("cmd", a.cmd))
+			return
+		}
+		a.logger.Debug("Preparing docker compose stack ahead of the agent-readiness check",
+			zap.String("stage", stage), zap.String("cmd", stageCmd))
+		// a.composeContent is non-nil only for the in-memory path; ExecuteCommand pipes
+		// it via stdin (matching how run() feeds the same content to `up`).
+		if cmdErr := utils.ExecuteCommand(ctx, a.logger, stageCmd, prepareCancel, 10*time.Second, a.composeContent); cmdErr.Err != nil {
+			a.logger.Debug("docker compose prepare stage did not complete; the application run will perform this work on-clock as a fallback",
+				zap.String("stage", stage), zap.Error(cmdErr.Err))
+		}
+	}
+}
+
+// composePrepareCmd derives the command for an off-clock prepare `stage` (build or
+// create) from the actual run command cmd, by replacing the `up` subcommand and
+// everything after it (its flags such as --abort-on-container-exit / --exit-code-from
+// and any positional services) with the stage. Everything BEFORE `up` — the launcher
+// (docker / docker-compose / sudo docker compose ...) and all global flags (-f,
+// --profile, --env-file, -p, --project-directory, ...) — is preserved verbatim, so the
+// prepare step runs against the exact same project and configuration as the subsequent
+// `up`. Returns false when no standalone `up` token is present (then prepare is skipped
+// and `up` performs the work on-clock as before).
+func composePrepareCmd(cmd, stage string) (string, bool) {
+	fields := strings.Fields(cmd)
+	for i, f := range fields {
+		if f == "up" {
+			prefix := strings.Join(fields[:i], " ")
+			return strings.TrimSpace(prefix + " " + stage), true
+		}
+	}
+	return "", false
 }
 
 func (a *App) run(ctx context.Context) models.AppError {


### PR DESCRIPTION
## What this fixes

Docker-compose `record` and `replay`/test runs intermittently fail with:

```
keploy-agent did not become ready in time
```

even though the agent is perfectly healthy. It's a timing bug, not an agent fault.

## Root cause

`record` (`pkg/service/record/record.go`) and `replay`/test (`pkg/service/runner/runner.go`) arm a fixed **120s** agent-readiness timer (`context.WithTimeout` + `AgentHealthTicker` polling `{agentURI}/health`) at the exact moment `docker compose up` is launched.

But `docker compose up` performs **build → pull → create for the entire stack**, globally, before it **starts** any container — including the injected `keploy-agent`, which every app service shares a network/pid namespace with and `depends_on`. On a large multi-service stack that pre-start phase alone can exceed 120s, so the agent's host port never opens in time and the run dies. In a failing CI run, every container (including the agent) was still only `Created`, never `Started`, at the exact 120.0s mark — the build was even cached; pull + create of the full stack ate the budget.

## The fix

Do the pre-start work in `App.Setup` (`App.prepareCompose`), which runs **before** the readiness timer is armed: `docker compose build` then `docker compose create` materialise every image and container off the readiness clock, so the subsequent `up` only has to **start** already-prepared containers.

The `keploy-agent` service is the compose dependency root and is injected without a profile, so it is always pre-created and started first regardless of how the app services are targeted (`up <service>`, profiles, etc.) — which is exactly what the readiness timer waits on.

Best-effort by design: any failure in the prepare step is logged and tolerated, leaving the existing on-clock behaviour as a fallback, so there is **no regression**. Both the record and replay/test flows arm their readiness timer only after `App.Setup` returns, so both benefit.

## Verification

- **Reproduced** the exact failure with a harness mirroring the `record.go` goroutine + `context.WithTimeout` + `AgentHealthTicker` control flow, against a compose whose pre-start work outlasts the timer: without the fix → `keploy-agent did not become ready in time`; with the prepare step off-clock → agent ready in ~1–2s.
- **Measured** the production sequence (`build` + `create`, then a plain `up`): prepare 26s off-clock → `up` start phase **0s** (containers reused, no rebuild/recreate) → agent reachable ~2s, vs. the 120s budget.
- **Edge cases** exercised against docker compose v2: in-memory `-f -` compose, all-`image:` stacks (no `build:`), multi-`-f` merges, `--profile`, and `create`-all then `up <subset>`. In every case the agent (dependency root, no profile) is pre-created, so the readiness timer sees only its real startup.
