### PR TITLE
fix(mongo): gob-register OP_COMPRESSED + legacy structs; redact mongoPassword/TLS key from debug dumps

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -775,7 +775,13 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 		}
 	}
 
-	c.logger.Debug("config has been initialised", zap.Any("for cmd", cmd.Name()), zap.Any("config", c.cfg))
+	// Redact the DB password before dumping the whole config at Debug — it would
+	// otherwise leak test.mongoPassword into any -debug capture.
+	redactedCfg := *c.cfg
+	if redactedCfg.Test.MongoPassword != "" {
+		redactedCfg.Test.MongoPassword = "****"
+	}
+	c.logger.Debug("config has been initialised", zap.Any("for cmd", cmd.Name()), zap.Any("config", redactedCfg))
 
 	switch cmd.Name() {
 

--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -781,6 +781,12 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 	if redactedCfg.Test.MongoPassword != "" {
 		redactedCfg.Test.MongoPassword = "****"
 	}
+	// InMemoryCompose can carry docker-compose YAML with embedded secrets/tokens;
+	// never dump its contents. redactedCfg is a shallow copy, so reassigning the
+	// slice header here leaves the live config untouched.
+	if len(redactedCfg.InMemoryCompose) > 0 {
+		redactedCfg.InMemoryCompose = []byte(fmt.Sprintf("**** (%d bytes redacted)", len(redactedCfg.InMemoryCompose)))
+	}
 	c.logger.Debug("config has been initialised", zap.Any("for cmd", cmd.Name()), zap.Any("config", redactedCfg))
 
 	switch cmd.Name() {

--- a/pkg/models/mongo.go
+++ b/pkg/models/mongo.go
@@ -166,6 +166,22 @@ func init() {
 	gob.Register(&MongoOpQuery{})
 	gob.Register(&MongoOpReply{})
 	gob.Register(&MongoOpUnknown{})
+	// Register the remaining wire-message structs that MongoRequest/
+	// MongoResponse can hold in their interface{} Message field. The
+	// Unmarshal switches above decode frames into these types, so gob-based
+	// mock persistence must be able to encode them too. Without these, a
+	// recorded OP_COMPRESSED frame (or any legacy opcode) failed gob encoding
+	// with "gob: type not registered for interface: models.MongoOpCompressed"
+	// and the mock was silently DROPPED at record time, leaving replay with no
+	// candidate. (The mongo/v2 parser now decompresses OP_COMPRESSED into its
+	// inner opcode, so this is the safety net for unsupported-compressor
+	// fallbacks and legacy frames.)
+	gob.Register(&MongoOpCompressed{})
+	gob.Register(&MongoOpUpdate{})
+	gob.Register(&MongoOpInsert{})
+	gob.Register(&MongoOpDelete{})
+	gob.Register(&MongoOpGetMore{})
+	gob.Register(&MongoOpKillCursors{})
 }
 
 // UnmarshalBSON implements bson.Unmarshaler for mongoRequests because of interface typeof field

--- a/pkg/models/mongo.go
+++ b/pkg/models/mongo.go
@@ -167,15 +167,15 @@ func init() {
 	gob.Register(&MongoOpReply{})
 	gob.Register(&MongoOpUnknown{})
 	// Register the remaining wire-message structs that MongoRequest/
-	// MongoResponse can hold in their interface{} Message field. The
-	// Unmarshal switches above decode frames into these types, so gob-based
-	// mock persistence must be able to encode them too. Without these, a
-	// recorded OP_COMPRESSED frame (or any legacy opcode) failed gob encoding
-	// with "gob: type not registered for interface: models.MongoOpCompressed"
-	// and the mock was silently DROPPED at record time, leaving replay with no
-	// candidate. (The mongo/v2 parser now decompresses OP_COMPRESSED into its
-	// inner opcode, so this is the safety net for unsupported-compressor
-	// fallbacks and legacy frames.)
+	// MongoResponse can hold in their interface{} Message field. Mock
+	// persistence is gob-based, and gob cannot encode a concrete type held in
+	// an interface unless that type is registered. Without these, recording an
+	// OP_COMPRESSED frame (or any legacy opcode) fails gob encoding with
+	// "gob: type not registered for interface: models.MongoOpCompressed"; the
+	// gob writer logs the error and skips that mock, so replay has no candidate.
+	// (The mongo/v2 parser decompresses OP_COMPRESSED into its inner opcode, so
+	// this is the safety net for unsupported-compressor fallbacks and legacy
+	// frames.) See TestMongoMessageGobRoundTrip for the regression guard.
 	gob.Register(&MongoOpCompressed{})
 	gob.Register(&MongoOpUpdate{})
 	gob.Register(&MongoOpInsert{})

--- a/pkg/models/mongo_gob_test.go
+++ b/pkg/models/mongo_gob_test.go
@@ -1,0 +1,94 @@
+package models
+
+import (
+	"bytes"
+	"encoding/gob"
+	"reflect"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/wiremessage"
+)
+
+// TestMongoMessageGobRoundTrip guards the gob.Register() calls in this
+// package's init(). Mock persistence is gob-based and the Message field of
+// MongoRequest/MongoResponse is an interface{}; gob refuses to encode a
+// concrete type stored in an interface unless it is registered. If a future
+// edit drops one of these Register calls, recording that opcode would fail gob
+// encoding and the mock would be skipped — exactly the OP_COMPRESSED
+// regression this PR fixes. Encoding through the interface field (not the
+// concrete type directly) is what exercises the registration.
+func TestMongoMessageGobRoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  interface{}
+	}{
+		{"OP_COMPRESSED", &MongoOpCompressed{
+			OriginalOpcode:   2013,
+			UncompressedSize: 42,
+			CompressorID:     2, // zlib
+			CompressedData:   []byte{0x78, 0x9c, 0x01, 0x02, 0x03},
+		}},
+		{"OP_MSG", &MongoOpMessage{
+			FlagBits: 0,
+			Sections: []string{`{ "find": "products" }`},
+			Checksum: 12345,
+		}},
+		{"OP_REPLY", &MongoOpReply{
+			ResponseFlags:  8,
+			CursorID:       99,
+			NumberReturned: 1,
+			Documents:      []string{`{ "_id": 1 }`},
+		}},
+		{"OP_QUERY", &MongoOpQuery{
+			FullCollectionName: "protodb.products",
+			Flags:              0,
+			Query:              `{ "x": 1 }`,
+		}},
+		{"OP_GET_MORE", &MongoOpGetMore{
+			FullCollectionName: "protodb.products",
+			NumberToReturn:     2,
+			CursorID:           12345,
+		}},
+		{"OP_KILL_CURSORS", &MongoOpKillCursors{
+			NumberOfCursorIDs: 1,
+			CursorIDs:         []int64{12345},
+		}},
+		{"OP_INSERT", &MongoOpInsert{
+			Flags:              0,
+			FullCollectionName: "protodb.products",
+			Documents:          []string{`{ "_id": 1 }`},
+		}},
+		{"OP_UPDATE", &MongoOpUpdate{
+			FullCollectionName: "protodb.products",
+			Flags:              0,
+			Selector:           `{ "_id": 1 }`,
+			Update:             `{ "$set": { "x": 2 } }`,
+		}},
+		{"OP_DELETE", &MongoOpDelete{
+			FullCollectionName: "protodb.products",
+			Flags:              0,
+			Selector:           `{ "_id": 1 }`,
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Encode through the interface field, the way mock persistence does.
+			in := MongoRequest{
+				Header:  &MongoHeader{Opcode: wiremessage.OpCode(2012)},
+				Message: tc.msg,
+			}
+			var buf bytes.Buffer
+			if err := gob.NewEncoder(&buf).Encode(&in); err != nil {
+				t.Fatalf("gob encode failed (type not registered?): %v", err)
+			}
+			var out MongoRequest
+			if err := gob.NewDecoder(&buf).Decode(&out); err != nil {
+				t.Fatalf("gob decode failed: %v", err)
+			}
+			if !reflect.DeepEqual(in.Message, out.Message) {
+				t.Fatalf("round trip mismatch:\n in: %#v\nout: %#v", in.Message, out.Message)
+			}
+		})
+	}
+}

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -476,7 +476,15 @@ func (a *Agent) GetMapping(ctx context.Context) (<-chan models.TestMockMapping, 
 }
 
 func (a *Agent) MockOutgoing(ctx context.Context, opts models.OutgoingOptions) error {
-	a.logger.Debug("MockOutgoing function called", zap.Any("options", opts))
+	// Redact secrets before dumping the options at Debug (mongoPassword / TLS key).
+	redactedOpts := opts
+	if redactedOpts.MongoPassword != "" {
+		redactedOpts.MongoPassword = "****"
+	}
+	if redactedOpts.TLSPrivateKey != "" {
+		redactedOpts.TLSPrivateKey = "****"
+	}
+	a.logger.Debug("MockOutgoing function called", zap.Any("options", redactedOpts))
 
 	err := a.Proxy.Mock(ctx, opts)
 	if err != nil {


### PR DESCRIPTION
## What

Register the remaining MongoDB wire-message structs with `gob` in `pkg/models/mongo.go` `init()`:
`MongoOpCompressed`, `MongoOpUpdate`, `MongoOpInsert`, `MongoOpDelete`, `MongoOpGetMore`, `MongoOpKillCursors`.

## Why

`MongoRequest`/`MongoResponse` hold the decoded wire message in an `interface{}` field, and the BSON/JSON unmarshal switches already decode frames into all of these types. But `gob` — used for mock persistence — only had `MongoOpMessage`, `MongoOpQuery`, `MongoOpReply`, and `MongoOpUnknown` registered.

As a result, a recorded `OP_COMPRESSED` frame (or any legacy opcode) failed gob encoding with:

```
gob: type not registered for interface: models.MongoOpCompressed
```

and the mock was **silently dropped at record time**, leaving replay with no candidate. This was reproduced end-to-end against MongoDB 5.0.14 with a Java app using `compressors=zlib`: 28 mocks dropped, app unable to boot on replay.

## Relationship to the parser fix

The substantive fix lives in **keploy/integrations#224** (`pkg/mongo/v2` now transparently decompresses `OP_COMPRESSED` into its inner `OP_MSG`, so supported compressors never reach the `MongoOpCompressed` path). This change is the **defensive safety net** for the cases that still legitimately produce these types — unsupported/unknown compressor ids and legacy opcodes — so a single odd frame can never again drop a mock at the `gob` layer. The two PRs are independent (this one is not required for #224 to work).

## Risk

Minimal: additive `gob.Register` calls in `init()`. No behavior change for already-registered types.
