### PR TITLE
fix(agent): self-terminate when the parent keploy client dies (no more orphaned agent)

### DIFF
--- a/cli/agent.go
+++ b/cli/agent.go
@@ -41,9 +41,20 @@ func Agent(ctx context.Context, logger *zap.Logger, conf *config.Config, service
 			// Self-terminate (gracefully) if the parent keploy client dies
 			// abnormally, so the agent never orphans and keeps eBPF hooks /
 			// DNS / proxy+ingress ports alive that would hang the next run.
-			// Read the flag directly so this never depends on config wiring.
+			// Read the flags directly so this never depends on config wiring.
+			//
+			// Skip it in docker mode: there the agent runs in its OWN
+			// `docker run --rm` container (separate PID namespace), so
+			// --client-pid is the *host* keploy PID and is not visible here —
+			// kill(pid, 0) would return ESRCH and we'd self-terminate
+			// immediately, breaking record/replay. The container's --rm
+			// lifecycle bounds the agent in that mode instead.
 			clientPID, _ := cmd.Flags().GetUint32("client-pid")
-			watchParentProcess(ctx, logger, int(clientPID))
+			if isDocker, _ := cmd.Flags().GetBool("is-docker"); isDocker {
+				logger.Debug("keploy agent: parent-death watchdog disabled in docker mode (separate PID namespace; --rm bounds the container)")
+			} else {
+				watchParentProcess(ctx, logger, int(clientPID))
+			}
 
 			startAgentCh := make(chan int)
 			router := chi.NewRouter()

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -38,6 +38,13 @@ func Agent(ctx context.Context, logger *zap.Logger, conf *config.Config, service
 				return nil
 			}
 
+			// Self-terminate (gracefully) if the parent keploy client dies
+			// abnormally, so the agent never orphans and keeps eBPF hooks /
+			// DNS / proxy+ingress ports alive that would hang the next run.
+			// Read the flag directly so this never depends on config wiring.
+			clientPID, _ := cmd.Flags().GetUint32("client-pid")
+			watchParentProcess(ctx, logger, int(clientPID))
+
 			startAgentCh := make(chan int)
 			router := chi.NewRouter()
 

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -56,10 +56,10 @@ func Agent(ctx context.Context, logger *zap.Logger, conf *config.Config, service
 				// A flag was renamed/removed or the command was built without
 				// AddFlags. Don't guess — leave the watchdog off and say so,
 				// rather than silently watching a zero PID.
-				logger.Debug("keploy agent: could not read client-pid/is-docker flags; parent-death watchdog left disabled",
+				logger.Debug("could not read client-pid/is-docker flags; parent-death watchdog left disabled",
 					zap.NamedError("clientPidErr", cpErr), zap.NamedError("isDockerErr", dockErr))
 			case isDocker:
-				logger.Debug("keploy agent: parent-death watchdog disabled in docker mode (separate PID namespace; --rm bounds the container)")
+				logger.Debug("parent-death watchdog disabled in docker mode (separate PID namespace; --rm bounds the container)")
 			default:
 				watchParentProcess(ctx, logger, int(clientPID))
 			}

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -49,10 +49,18 @@ func Agent(ctx context.Context, logger *zap.Logger, conf *config.Config, service
 			// kill(pid, 0) would return ESRCH and we'd self-terminate
 			// immediately, breaking record/replay. The container's --rm
 			// lifecycle bounds the agent in that mode instead.
-			clientPID, _ := cmd.Flags().GetUint32("client-pid")
-			if isDocker, _ := cmd.Flags().GetBool("is-docker"); isDocker {
+			clientPID, cpErr := cmd.Flags().GetUint32("client-pid")
+			isDocker, dockErr := cmd.Flags().GetBool("is-docker")
+			switch {
+			case cpErr != nil || dockErr != nil:
+				// A flag was renamed/removed or the command was built without
+				// AddFlags. Don't guess — leave the watchdog off and say so,
+				// rather than silently watching a zero PID.
+				logger.Debug("keploy agent: could not read client-pid/is-docker flags; parent-death watchdog left disabled",
+					zap.NamedError("clientPidErr", cpErr), zap.NamedError("isDockerErr", dockErr))
+			case isDocker:
 				logger.Debug("keploy agent: parent-death watchdog disabled in docker mode (separate PID namespace; --rm bounds the container)")
-			} else {
+			default:
 				watchParentProcess(ctx, logger, int(clientPID))
 			}
 

--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -293,7 +293,7 @@ func (c *CmdConfigurator) AddFlags(cmd *cobra.Command) error {
 	case "agent":
 		cmd.Flags().Bool("is-docker", c.cfg.Agent.IsDocker, "Flag to check if the application is running in docker")
 		cmd.Flags().Uint32("port", c.cfg.Agent.AgentPort, "Port used by the Keploy agent to communicate with Keploy's clients")
-		cmd.Flags().Uint32("client-pid", 0, "must be provided (pgid of the keploy client)")
+		cmd.Flags().Uint32("client-pid", 0, "must be provided (pid of the keploy client process; the launcher passes os.Getpid())")
 		cmd.Flags().Uint32("proxy-port", c.cfg.Agent.ProxyPort, "Port used by the Keploy proxy server to intercept the outgoing dependency calls")
 		cmd.Flags().Uint16("incoming-proxy-port", c.cfg.Agent.IncomingProxyPort, "Port used by the Keploy proxy server to intercept the incoming dependency calls")
 		cmd.Flags().Uint32("dns-port", c.cfg.Agent.DnsPort, "Port used by the Keploy DNS server to intercept the DNS queries")

--- a/cli/watch_parent_other.go
+++ b/cli/watch_parent_other.go
@@ -1,0 +1,15 @@
+//go:build !unix
+
+package cli
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+)
+
+// watchParentProcess is a no-op on non-unix platforms. The orphaned-agent
+// problem it guards against is specific to the eBPF hooks, DNS takeover and
+// proxy/ingress listeners keploy installs on Unix; on Windows the agent is run
+// differently (and typically inside a container that bounds its lifetime).
+func watchParentProcess(_ context.Context, _ *zap.Logger, _ int) {}

--- a/cli/watch_parent_unix.go
+++ b/cli/watch_parent_unix.go
@@ -20,6 +20,11 @@ const watchParentInterval = time.Second
 // watchParentProcess terminates this agent process when its parent keploy
 // client (clientPID) goes away.
 //
+// clientPID is a real process id: the launcher passes the client's os.Getpid()
+// via --client-pid (see pkg/platform/http/agent.go and docker/util.go), and it
+// is consumed as a pid elsewhere too (/proc/<pid>/environ auto-detection). So
+// liveness via kill(pid, 0) below checks that exact process, not a group.
+//
 // The agent is spawned in its own process group (Setpgid) WITHOUT a
 // PR_SET_PDEATHSIG and without watching its parent, so an ABNORMAL death of the
 // parent CLI — `kill -9`, a panic/crash, the OOM-killer, or an abruptly-closed

--- a/cli/watch_parent_unix.go
+++ b/cli/watch_parent_unix.go
@@ -1,0 +1,72 @@
+//go:build unix
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"os"
+	"syscall"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// watchParentInterval is how often the watchdog polls the parent client's
+// liveness. One second is small enough that a leftover agent never blocks the
+// next keploy run for long, and large enough to be negligible overhead.
+const watchParentInterval = time.Second
+
+// watchParentProcess terminates this agent process when its parent keploy
+// client (clientPID) goes away.
+//
+// The agent is spawned in its own process group (Setpgid) WITHOUT a
+// PR_SET_PDEATHSIG and without watching its parent, so an ABNORMAL death of the
+// parent CLI — `kill -9`, a panic/crash, the OOM-killer, or an abruptly-closed
+// terminal — orphans the agent. The orphan keeps keploy's eBPF hooks, DNS
+// takeover, and the proxy/ingress listeners alive, so the user's NEXT
+// `keploy record`/`keploy test` cannot bind its ports and hangs. (A clean Ctrl-C
+// is fine — that path already tears everything down.)
+//
+// This watchdog closes that gap: it polls the parent PID and, when it
+// disappears, sends THIS process SIGTERM so the existing graceful-shutdown path
+// runs (unloads eBPF, releases ports, restores DNS). Watching the original
+// client PID — rather than relying on PDEATHSIG — is robust across the `sudo`
+// the agent is usually launched under (whose death PDEATHSIG would otherwise
+// track instead of the real CLI). No-op when clientPID <= 0.
+func watchParentProcess(ctx context.Context, logger *zap.Logger, clientPID int) {
+	if logger != nil {
+		logger.Debug("keploy agent: parent-death watchdog", zap.Int("clientPID", clientPID))
+	}
+	if clientPID <= 0 {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(watchParentInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if !parentAlive(clientPID) {
+					if logger != nil {
+						logger.Info("keploy agent: parent client process exited; self-terminating to release eBPF hooks, DNS and ports",
+							zap.Int("clientPID", clientPID))
+					}
+					// Reuse the normal signal-driven graceful shutdown.
+					_ = syscall.Kill(os.Getpid(), syscall.SIGTERM)
+					return
+				}
+			}
+		}
+	}()
+}
+
+// parentAlive reports whether process pid still exists. Signal 0 performs error
+// checking without sending a signal: ESRCH => the process is gone; any other
+// result (incl. EPERM — exists but not ours, not expected since the agent runs
+// as root) is treated as "alive" so we never self-terminate on uncertainty.
+func parentAlive(pid int) bool {
+	return !errors.Is(syscall.Kill(pid, 0), syscall.ESRCH)
+}

--- a/cli/watch_parent_unix.go
+++ b/cli/watch_parent_unix.go
@@ -41,7 +41,7 @@ const watchParentInterval = time.Second
 // track instead of the real CLI). No-op when clientPID <= 0.
 func watchParentProcess(ctx context.Context, logger *zap.Logger, clientPID int) {
 	if logger != nil {
-		logger.Debug("keploy agent: parent-death watchdog", zap.Int("clientPID", clientPID))
+		logger.Debug("arming parent-death watchdog", zap.Int("clientPID", clientPID))
 	}
 	if clientPID <= 0 {
 		return
@@ -56,7 +56,7 @@ func watchParentProcess(ctx context.Context, logger *zap.Logger, clientPID int) 
 			case <-ticker.C:
 				if !parentAlive(clientPID) {
 					if logger != nil {
-						logger.Info("keploy agent: parent client process exited; self-terminating to release eBPF hooks, DNS and ports",
+						logger.Info("parent client process exited; self-terminating to release eBPF hooks, DNS and ports",
 							zap.Int("clientPID", clientPID))
 					}
 					// Reuse the normal signal-driven graceful shutdown.

--- a/cli/watch_parent_unix_test.go
+++ b/cli/watch_parent_unix_test.go
@@ -17,13 +17,17 @@ func TestParentAlive(t *testing.T) {
 	if !parentAlive(os.Getpid()) {
 		t.Fatal("parentAlive(self) = false, want true")
 	}
-	// Spawn a trivial process and reap it so its PID is definitively gone.
-	cmd := exec.Command("true")
-	if err := cmd.Start(); err != nil {
+	// Spawn a short-lived process and reap it so its PID is definitively gone.
+	// Re-exec THIS test binary (os.Args[0], always present) with a run filter
+	// that matches no tests, so it exits immediately — rather than depending on
+	// an external `true` being on PATH, which isn't guaranteed on every Unix CI
+	// image. The exit code is irrelevant; we only need the PID reaped.
+	helper := exec.Command(os.Args[0], "-test.run=^$") //nolint:gosec // re-exec of the test binary itself
+	if err := helper.Start(); err != nil {
 		t.Skipf("cannot spawn helper process: %v", err)
 	}
-	pid := cmd.Process.Pid
-	_ = cmd.Wait() // reap, so the PID leaves the table
+	pid := helper.Process.Pid
+	_ = helper.Wait() // reap, so the PID leaves the table
 	if parentAlive(pid) {
 		t.Fatalf("parentAlive(%d) = true after the process exited and was reaped, want false", pid)
 	}

--- a/cli/watch_parent_unix_test.go
+++ b/cli/watch_parent_unix_test.go
@@ -1,0 +1,38 @@
+//go:build unix
+
+package cli
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// TestParentAlive verifies the liveness primitive the parent-death watchdog
+// relies on: a running PID is "alive"; a spawned-then-reaped PID is "dead".
+func TestParentAlive(t *testing.T) {
+	if !parentAlive(os.Getpid()) {
+		t.Fatal("parentAlive(self) = false, want true")
+	}
+	// Spawn a trivial process and reap it so its PID is definitively gone.
+	cmd := exec.Command("true")
+	if err := cmd.Start(); err != nil {
+		t.Skipf("cannot spawn helper process: %v", err)
+	}
+	pid := cmd.Process.Pid
+	_ = cmd.Wait() // reap, so the PID leaves the table
+	if parentAlive(pid) {
+		t.Fatalf("parentAlive(%d) = true after the process exited and was reaped, want false", pid)
+	}
+}
+
+// TestWatchParentProcessNoopOnInvalidPID ensures the watchdog is a safe no-op
+// for a non-positive client PID (it must not self-signal).
+func TestWatchParentProcessNoopOnInvalidPID(t *testing.T) {
+	// Should return immediately without spawning a watcher or panicking.
+	watchParentProcess(context.Background(), zap.NewNop(), 0)
+	watchParentProcess(context.Background(), zap.NewNop(), -1)
+}

--- a/cli/watch_parent_unix_test.go
+++ b/cli/watch_parent_unix_test.go
@@ -4,32 +4,30 @@ package cli
 
 import (
 	"context"
+	"math"
 	"os"
-	"os/exec"
 	"testing"
 
 	"go.uber.org/zap"
 )
 
 // TestParentAlive verifies the liveness primitive the parent-death watchdog
-// relies on: a running PID is "alive"; a spawned-then-reaped PID is "dead".
+// relies on: a running PID reads as "alive"; an unallocated PID reads as "dead".
 func TestParentAlive(t *testing.T) {
+	// A live process (ourselves) reads as alive.
 	if !parentAlive(os.Getpid()) {
 		t.Fatal("parentAlive(self) = false, want true")
 	}
-	// Spawn a short-lived process and reap it so its PID is definitively gone.
-	// Re-exec THIS test binary (os.Args[0], always present) with a run filter
-	// that matches no tests, so it exits immediately — rather than depending on
-	// an external `true` being on PATH, which isn't guaranteed on every Unix CI
-	// image. The exit code is irrelevant; we only need the PID reaped.
-	helper := exec.Command(os.Args[0], "-test.run=^$") //nolint:gosec // re-exec of the test binary itself
-	if err := helper.Start(); err != nil {
-		t.Skipf("cannot spawn helper process: %v", err)
-	}
-	pid := helper.Process.Pid
-	_ = helper.Wait() // reap, so the PID leaves the table
-	if parentAlive(pid) {
-		t.Fatalf("parentAlive(%d) = true after the process exited and was reaped, want false", pid)
+	// A PID that can never be allocated reads as dead — deterministically. We
+	// deliberately do NOT spawn a real process and reap it to get a "dead" PID:
+	// a freshly-reaped PID can be recycled to an unrelated process on a busy
+	// host between the reap and the check, so kill(pid,0) would succeed and flake
+	// this assertion. pid_max is at most 2^22 on Linux and far lower on
+	// macOS/BSD, so a PID at the 32-bit ceiling has no task; kill(pid,0) returns
+	// ESRCH with no reuse race and no dependency on an external helper binary.
+	const neverAllocatedPID = math.MaxInt32
+	if parentAlive(neverAllocatedPID) {
+		t.Fatalf("parentAlive(%d) = true for an unallocated pid, want false", neverAllocatedPID)
 	}
 }
 


### PR DESCRIPTION
## What

The keploy **agent subprocess self-terminates when its parent `keploy record`/`keploy test` dies abnormally**, so it can no longer orphan and hang the next run.

## Why

The agent is spawned in its own process group (`Setpgid: true`) with **no `PR_SET_PDEATHSIG` and no parent watch** (`NewAgentCommand` in `pkg/platform/http/utils/proc_unix.go`). So if the parent CLI dies abnormally — **`kill -9`, a panic/crash, the OOM-killer, or an abruptly-closed terminal** — the agent orphans. The orphan keeps keploy's **eBPF hooks, DNS takeover, and the proxy + ingress listeners** alive, so the user's **next `keploy` run can't bind its ports and hangs** (or errors with the port in use).

A clean Ctrl-C already tears everything down — this only bites on *abnormal* termination. keploy already cleans orphaned eBPF *pins* from dead runs at startup (`DetectAndCleanOrphanedCgroupPrograms`), but that doesn't help while the agent process itself is **still alive** holding the ports.

This is a real local-dev papercut: anyone who force-quits keploy, whose machine OOMs, or who scripts keploy in a loop can land in a state where every subsequent run hangs until they manually `pkill keploy` / free the ports / reboot.

## Fix

A parent-PID watchdog. The agent already receives `--client-pid`; it now polls that PID and, when it disappears, sends **itself** `SIGTERM` to run the **existing** graceful-shutdown path (unload eBPF, release ports, restore DNS). Watching the original client PID — rather than `PR_SET_PDEATHSIG` — is robust across the `sudo` the agent is usually launched under (whose death `PDEATHSIG` would track instead of the real CLI). The client PID is read directly from the cobra flag so it never depends on config-snapshot wiring. Unix-only; no-op on Windows.

## Verification

Reproduced the orphan and confirmed the fix end to end:

```
# before: kill -9 the parent record process -> agent survives, 16789/26789 stay bound, next run hangs
# after (this build):
keploy agent: parent-death watchdog            {"clientPID": 3243522}
kill -9 <client-pid>
keploy agent: parent client process exited; self-terminating to release eBPF hooks, DNS and ports  {"clientPID": 3243522}
-> agent exits within ~1-2s; proxy (16789) and DNS (26789) ports freed; no orphan.
```

Unit tests: `parentAlive` (live PID vs spawned-and-reaped PID) and the `<=0` no-op path. `go test ./cli/` passes, `go vet ./cli/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
