### PR TITLE
fix(ci): wait for the Docker daemon before loading the image (Windows/macOS startup race)

### DIFF
--- a/.github/actions/download-image/action.yml
+++ b/.github/actions/download-image/action.yml
@@ -20,6 +20,49 @@ runs:
         name: ${{ inputs.artifact_name }}
         path: ${{ runner.temp }}/keploy-image
 
+    # The image is loaded into the LOCAL docker daemon below. On Docker Desktop
+    # runners (Windows / macOS) the daemon may still be starting when this action
+    # runs, so `docker load` fails with "failed to connect to the docker API ...
+    # the daemon is running" (a startup race, not a real fault). Wait for the
+    # daemon to answer before loading. Linux runners have systemd Docker already
+    # up, so this returns on the first attempt.
+    - name: Wait for the Docker daemon (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        for i in $(seq 1 30); do
+          if docker info >/dev/null 2>&1; then
+            echo "Docker is ready after $i attempt(s)"
+            exit 0
+          fi
+          echo "Waiting for Docker... attempt $i/30"
+          sleep 2
+        done
+        echo "::error::Docker daemon did not become ready within 60s"
+        docker info 2>&1 | head -20 || true
+        exit 1
+
+    - name: Wait for the Docker daemon (Windows)
+      if: runner.os == 'Windows'
+      shell: powershell
+      run: |
+        $maxAttempts = 30
+        $attempt = 0
+        while ($attempt -lt $maxAttempts) {
+          $attempt++
+          try {
+            docker info *> $null
+            if ($LASTEXITCODE -eq 0) {
+              Write-Host "Docker is ready after $attempt attempt(s)"
+              exit 0
+            }
+          } catch {}
+          Write-Host "Waiting for Docker... attempt $attempt/$maxAttempts"
+          Start-Sleep -Seconds 2
+        }
+        Write-Error "Docker daemon did not become ready within 60s"
+        exit 1
+
     - name: Load image (Unix)
       if: runner.os != 'Windows'
       shell: bash

--- a/.github/actions/download-image/action.yml
+++ b/.github/actions/download-image/action.yml
@@ -60,7 +60,15 @@ runs:
           Write-Host "Waiting for Docker... attempt $attempt/$maxAttempts"
           Start-Sleep -Seconds 2
         }
-        Write-Error "Docker daemon did not become ready within 60s"
+        Write-Host "::error::Docker daemon did not become ready within 60s"
+        # Mirror the Unix path's diagnostics so a genuinely-down daemon or the
+        # wrong (Windows vs Linux) engine context is actionable from the log.
+        # `docker context ls` works without the daemon and reveals whether the
+        # Linux engine the load targets is even selected.
+        Write-Host "docker context ls:"
+        docker context ls 2>&1 | Select-Object -First 20 | ForEach-Object { Write-Host $_ }
+        Write-Host "docker info:"
+        docker info 2>&1 | Select-Object -First 20 | ForEach-Object { Write-Host $_ }
         exit 1
 
     - name: Load image (Unix)


### PR DESCRIPTION
## What

Add a Docker-daemon readiness wait to the shared `download-image` composite action, before it `docker load`s the keploy image.

## Why

On Docker Desktop runners (Windows, and macOS) the daemon can still be starting when the action runs, so `docker load` intermittently fails with:

```
docker : failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine;
check if the path is correct and if the daemon is running:
open //./pipe/dockerDesktopLinuxEngine: The system cannot find the file specified.
```

The image **artifact downloads fine** (SHA verified in the run log) — this is purely a **daemon-startup race**: the job loads the image before the engine is ready, and there was no readiness wait. So the run passes when the daemon happens to be up and fails when it isn't. This is the recurring red on the `run_golang_docker_windows / go-http-no-deps` lane (it passes on `main` and fails intermittently on PRs — the signature of a race, not a real fault).

## Fix

Add a **"Wait for the Docker daemon"** step before the load, mirroring the existing Wait-for-Docker pattern already in `prepare_and_run.yml` (poll `docker info`, 30 × 2s = up to 60s):

- **Unix path** (`bash`): Linux runners have systemd Docker already up, so it returns on the first attempt (no-op); macOS Docker Desktop gets time to come up.
- **Windows path** (`powershell`): waits for Docker Desktop's Linux engine before the `docker load`.

A genuinely-down daemon still fails — now with a clear, bounded message instead of an immediate connect error.

## Scope / risk

- Touches only `.github/actions/download-image/action.yml` (one shared action). No production code.
- No-op on Linux (daemon already ready); strictly additive readiness wait on Windows/macOS.
- This PR's own Windows docker lane exercises the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
