### PR TITLE
feat: unified noise vocabulary and universal mock-mismatch reporting

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -415,6 +415,7 @@ func (c *CmdConfigurator) AddUncommonFlags(cmd *cobra.Command) {
 		cmd.Flags().Bool("compare-all", false, "Compare all response body types including non-JSON (default: false, only JSON bodies are compared)")
 		cmd.Flags().Bool("schema-match", false, "Compare only the schema of the response body")
 		cmd.Flags().Bool("schema-noise-detection", c.cfg.Test.SchemaNoiseDetection, "Detect request-body fields that drift between recording and replay and persist them as field-path noise (req_body_noise) on HTTP mocks during auto-replay matching")
+		cmd.Flags().Bool("schema-noise-strict", c.cfg.Test.SchemaNoiseStrict, "Strictly enforce learned request-body noise during HTTP mock matching: a candidate mock carrying req_body_noise is rejected when any field OUTSIDE its learned/user-configured noise drifted. Same behaviour the in-cluster replay path enforces; previously configurable only via keploy.yml")
 		cmd.Flags().Bool("strict-failure", c.cfg.Test.StrictFailure, "Mark response-failing tests as FAILED even if the consumed mock set also diverged from the recorded mapping (default behaviour demotes such cases to OBSOLETE). The per-test mappingDiff block is still written for diagnostics.")
 		cmd.Flags().Bool("update-test-mapping", c.cfg.Test.UpdateTestMapping, "Update the mapping of testcases")
 		// Start the user app ONCE for the whole replay run instead of
@@ -493,6 +494,7 @@ func aliasNormalizeFunc(_ *pflag.FlagSet, name string) pflag.NormalizedName {
 		"compareAll":                "compare-all",
 		"schemaMatch":               "schema-match",
 		"schemaNoiseDetection":      "schema-noise-detection",
+		"schemaNoiseStrict":         "schema-noise-strict",
 		"updateTestMapping":         "update-test-mapping",
 		"capturePackets":            "capture-packets",
 		"opportunisticTlsIntercept": "opportunistic-tls-intercept",
@@ -1234,6 +1236,13 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 			c.cfg.Test.SchemaNoiseDetection, err = cmd.Flags().GetBool("schema-noise-detection")
 			if err != nil {
 				errMsg := "failed to read the --schema-noise-detection flag; check the flag name with --help and confirm this command supports it"
+				utils.LogError(c.logger, err, errMsg)
+				return errors.New(errMsg)
+			}
+
+			c.cfg.Test.SchemaNoiseStrict, err = cmd.Flags().GetBool("schema-noise-strict")
+			if err != nil {
+				errMsg := "failed to read the --schema-noise-strict flag; check the flag name with --help and confirm this command supports it"
 				utils.LogError(c.logger, err, errMsg)
 				return errors.New(errMsg)
 			}

--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -1240,11 +1240,17 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 				return errors.New(errMsg)
 			}
 
-			c.cfg.Test.SchemaNoiseStrict, err = cmd.Flags().GetBool("schema-noise-strict")
-			if err != nil {
-				errMsg := "failed to read the --schema-noise-strict flag; check the flag name with --help and confirm this command supports it"
-				utils.LogError(c.logger, err, errMsg)
-				return errors.New(errMsg)
+			// Only let the flag override when it was explicitly passed or
+			// the config file doesn't set the key — otherwise the flag's
+			// default would silently clobber a yaml-only configuration
+			// (same guard pattern as disable-mapping above).
+			if cmd.Flags().Changed("schema-noise-strict") || !viper.IsSet("test.schemaNoiseStrict") {
+				c.cfg.Test.SchemaNoiseStrict, err = cmd.Flags().GetBool("schema-noise-strict")
+				if err != nil {
+					errMsg := "failed to read the --schema-noise-strict flag; check the flag name with --help and confirm this command supports it"
+					utils.LogError(c.logger, err, errMsg)
+					return errors.New(errMsg)
+				}
 			}
 
 			// enforce that the test-sets are provided when --must-pass is set to true

--- a/pkg/agent/proxy/integrations/generic/decode.go
+++ b/pkg/agent/proxy/integrations/generic/decode.go
@@ -65,13 +65,21 @@ func decodeGeneric(ctx context.Context, logger *zap.Logger, reqBuf []byte, clien
 				if len(preview) > 64 {
 					preview = preview[:64]
 				}
-				logger.Debug("mock miss",
-					zap.String("protocol", "Generic"),
+				// Build the universal mismatch report so generic misses show
+				// up in the mismatch table / report yaml like HTTP and MySQL
+				// misses do, instead of vanishing as a bare error.
+				report := buildGenericMismatchReport(ctx, genericRequests, mockDb)
+				// Default-visible: this miss is the root cause of the test
+				// failure that follows (the app sees its connection close).
+				logger.Warn("no matching generic mock found for outgoing call",
+					zap.String("protocol", report.Protocol),
 					zap.Int("requestCount", len(genericRequests)),
 					zap.Int("firstRequestBytes", len(genericRequests[0])),
-					zap.String("hint", "Re-record mocks if the wire protocol data has changed"),
+					zap.String("closest", report.ClosestMock),
+					zap.String("diff", report.Diff),
+					zap.String("next_steps", report.NextSteps),
 					zap.Binary("preview", preview))
-				errCh <- fmt.Errorf("no matching generic mock found")
+				errCh <- models.NewMockMismatchError(fmt.Errorf("no matching generic mock found"), report)
 				return
 			}
 			for _, genericResponse := range genericResponses {

--- a/pkg/agent/proxy/integrations/generic/decode.go
+++ b/pkg/agent/proxy/integrations/generic/decode.go
@@ -77,7 +77,7 @@ func decodeGeneric(ctx context.Context, logger *zap.Logger, reqBuf []byte, clien
 					zap.Int("firstRequestBytes", len(genericRequests[0])),
 					zap.String("closest", report.ClosestMock),
 					zap.String("diff", report.Diff),
-					zap.String("next_steps", report.NextSteps),
+					zap.String("next_step", report.NextSteps),
 					zap.Binary("preview", preview))
 				errCh <- models.NewMockMismatchError(fmt.Errorf("generic: %w", models.ErrNoMockMatched), report)
 				return

--- a/pkg/agent/proxy/integrations/generic/decode.go
+++ b/pkg/agent/proxy/integrations/generic/decode.go
@@ -79,7 +79,7 @@ func decodeGeneric(ctx context.Context, logger *zap.Logger, reqBuf []byte, clien
 					zap.String("diff", report.Diff),
 					zap.String("next_steps", report.NextSteps),
 					zap.Binary("preview", preview))
-				errCh <- models.NewMockMismatchError(fmt.Errorf("no matching generic mock found"), report)
+				errCh <- models.NewMockMismatchError(fmt.Errorf("generic: %w", models.ErrNoMockMatched), report)
 				return
 			}
 			for _, genericResponse := range genericResponses {

--- a/pkg/agent/proxy/integrations/generic/match.go
+++ b/pkg/agent/proxy/integrations/generic/match.go
@@ -135,9 +135,28 @@ func buildGenericMismatchReport(ctx context.Context, reqBuffs [][]byte, mockDb i
 			continue
 		}
 		var simSum float64
+		comparable := true
 		for i, reqBuff := range reqBuffs {
-			encoded, _ := util.DecodeBase64(mock.Spec.GenericRequests[i].Message[0].Data)
-			simSum += fuzzyCheck(encoded, reqBuff)
+			msg := mock.Spec.GenericRequests[i].Message[0]
+			// The recorder stores ASCII payloads verbatim (Type String) and
+			// binary payloads base64-encoded — decode per the recorded type,
+			// otherwise the similarity is computed against nil bytes and the
+			// closest-candidate ranking degrades to noise.
+			var recorded []byte
+			if msg.Type == models.String {
+				recorded = []byte(msg.Data)
+			} else {
+				decoded, err := util.DecodeBase64(msg.Data)
+				if err != nil {
+					comparable = false
+					break
+				}
+				recorded = decoded
+			}
+			simSum += fuzzyCheck(recorded, reqBuff)
+		}
+		if !comparable {
+			continue
 		}
 		if avg := simSum / float64(len(reqBuffs)); avg > bestSim {
 			bestSim = avg

--- a/pkg/agent/proxy/integrations/generic/match.go
+++ b/pkg/agent/proxy/integrations/generic/match.go
@@ -8,6 +8,7 @@ import (
 	"go.keploy.io/server/v3/pkg/agent/proxy/integrations"
 	"go.uber.org/zap"
 
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mismatch"
 	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/util"
 	"go.keploy.io/server/v3/pkg/models"
 )
@@ -97,6 +98,62 @@ func fuzzyMatch(ctx context.Context, logger *zap.Logger, reqBuff [][]byte, mockD
 			return false, nil, nil
 		}
 	}
+}
+
+// buildGenericMismatchReport builds the universal mock-miss report for the
+// generic (opaque TCP) parser. Field-level diffs are impossible for unparsed
+// wire bytes, so the report carries the closest candidate by Jaccard
+// similarity with its score — enough for the user to tell "nothing remotely
+// similar was recorded" (re-record) apart from "a near-miss exists"
+// (protocol drift, likely needs re-record of just this dependency).
+func buildGenericMismatchReport(ctx context.Context, reqBuffs [][]byte, mockDb integrations.MockMemDb) *models.MockMismatchReport {
+	summary := fmt.Sprintf("opaque TCP exchange (%d request buffer(s), first %d bytes)", len(reqBuffs), func() int {
+		if len(reqBuffs) == 0 {
+			return 0
+		}
+		return len(reqBuffs[0])
+	}())
+
+	mocks, err := mockDb.GetSessionMocks()
+	if err != nil || ctx.Err() != nil {
+		return mismatch.NewReport(mismatch.ProtocolGeneric, summary).Build()
+	}
+	var genericMocks []*models.Mock
+	for _, m := range mocks {
+		if m.Kind == "Generic" {
+			genericMocks = append(genericMocks, m)
+		}
+	}
+	if len(genericMocks) == 0 {
+		return mismatch.NewReport(mismatch.ProtocolGeneric, summary).
+			WithPhase(models.MatchPhaseNoMocks, 0).Build()
+	}
+
+	bestIdx, bestSim := -1, -1.0
+	for idx, mock := range genericMocks {
+		if len(mock.Spec.GenericRequests) != len(reqBuffs) {
+			continue
+		}
+		var simSum float64
+		for i, reqBuff := range reqBuffs {
+			encoded, _ := util.DecodeBase64(mock.Spec.GenericRequests[i].Message[0].Data)
+			simSum += fuzzyCheck(encoded, reqBuff)
+		}
+		if avg := simSum / float64(len(reqBuffs)); avg > bestSim {
+			bestSim = avg
+			bestIdx = idx
+		}
+	}
+
+	b := mismatch.NewReport(mismatch.ProtocolGeneric, summary).
+		WithPhase(models.MatchPhaseExhausted, len(genericMocks))
+	if bestIdx >= 0 {
+		b = b.WithClosest(genericMocks[bestIdx].Name, nil).
+			WithDiff(fmt.Sprintf("closest recorded exchange %q has Jaccard similarity %.2f (thresholds: 0.9 per-test, 0.4 session)", genericMocks[bestIdx].Name, bestSim))
+	} else {
+		b = b.WithDiff("no recorded exchange has the same number of request buffers")
+	}
+	return b.Build()
 }
 
 // TODO: need to generalize this function for different types of integrations.

--- a/pkg/agent/proxy/integrations/http/decode.go
+++ b/pkg/agent/proxy/integrations/http/decode.go
@@ -210,7 +210,7 @@ func (h *HTTP) decodeHTTP(ctx context.Context, reqBuf []byte, clientConn net.Con
 						zap.Int("candidates", report.CandidateCount),
 						zap.String("closest", report.ClosestMock),
 						zap.String("diff", report.Diff),
-						zap.String("next_steps", report.NextSteps))
+						zap.String("next_step", report.NextSteps))
 				}
 
 				// No mock matched — send a 502 so the application gets a

--- a/pkg/agent/proxy/integrations/http/decode.go
+++ b/pkg/agent/proxy/integrations/http/decode.go
@@ -22,9 +22,10 @@ import (
 )
 
 // ErrMockNotMatched is returned by decodeHTTP when no recorded mock
-// matches the outgoing HTTP request. Callers can check for this with
-// errors.Is to distinguish a mock-miss from a real proxy error.
-var ErrMockNotMatched = errors.New("no matching mock found")
+// matches the outgoing HTTP request. It aliases models.ErrNoMockMatched so
+// callers can errors.Is against either symbol to distinguish a mock-miss
+// from a real proxy error.
+var ErrMockNotMatched = models.ErrNoMockMatched
 
 // Decodes the mocks in test mode so that they can be sent to the user application.
 func (h *HTTP) decodeHTTP(ctx context.Context, reqBuf []byte, clientConn net.Conn, dstCfg *models.ConditionalDstCfg, mockDb integrations.MockMemDb, opts models.OutgoingOptions) error {
@@ -163,17 +164,23 @@ func (h *HTTP) decodeHTTP(ctx context.Context, reqBuf []byte, clientConn net.Con
 			// User body noise from test.globalNoise (root-relative dotted
 			// paths). Lowercased copy for the same reason as headerNoise:
 			// the matcher's noise index matches lowercased paths.
+			// Entries are normalized to presence-only (empty regex list):
+			// request-body mock matching and drift detection are path-based,
+			// so a value-regex cannot gate here the way it can't gate JSON
+			// body leaves in response assertions either. Normalizing (rather
+			// than dropping regex-valued entries) keeps the documented
+			// promise that a path copied from a mismatch report into
+			// test.globalNoise takes effect regardless of value style.
 			var bodyNoise map[string][]string
 			if opts.NoiseConfig != nil {
 				if bn, ok := opts.NoiseConfig["body"]; ok {
 					bodyNoise = make(map[string][]string, len(bn))
 					for k, v := range bn {
-						lk := strings.ToLower(k)
-						if existing, ok := bodyNoise[lk]; ok {
-							bodyNoise[lk] = append(existing, v...)
-						} else {
-							bodyNoise[lk] = v
+						if len(v) > 0 {
+							h.Logger.Debug("body-noise value regexes are ignored for mock matching; the field is skipped by path",
+								zap.String("field", k))
 						}
+						bodyNoise[strings.ToLower(k)] = []string{}
 					}
 				}
 			}

--- a/pkg/agent/proxy/integrations/http/decode.go
+++ b/pkg/agent/proxy/integrations/http/decode.go
@@ -160,9 +160,28 @@ func (h *HTTP) decodeHTTP(ctx context.Context, reqBuf []byte, clientConn net.Con
 				}
 			}
 
-			h.Logger.Debug("header noise", zap.Any("header noise", headerNoise))
+			// User body noise from test.globalNoise (root-relative dotted
+			// paths). Lowercased copy for the same reason as headerNoise:
+			// the matcher's noise index matches lowercased paths.
+			var bodyNoise map[string][]string
+			if opts.NoiseConfig != nil {
+				if bn, ok := opts.NoiseConfig["body"]; ok {
+					bodyNoise = make(map[string][]string, len(bn))
+					for k, v := range bn {
+						lk := strings.ToLower(k)
+						if existing, ok := bodyNoise[lk]; ok {
+							bodyNoise[lk] = append(existing, v...)
+						} else {
+							bodyNoise[lk] = v
+						}
+					}
+				}
+			}
 
-			ok, stub, err := h.match(ctx, input, mockDb, headerNoise, opts.SchemaNoiseDetection, opts.SchemaNoiseStrict) // calling match function to match mocks
+			h.Logger.Debug("header noise", zap.Any("header noise", headerNoise))
+			h.Logger.Debug("body noise", zap.Any("body noise", bodyNoise))
+
+			ok, stub, diag, err := h.match(ctx, input, mockDb, headerNoise, bodyNoise, opts.SchemaNoiseDetection, opts.SchemaNoiseStrict) // calling match function to match mocks
 			if err != nil {
 				utils.LogError(h.Logger, err, "error while matching http mocks", zap.Any("metadata", utils.GetReqMeta(request)))
 				errCh <- err
@@ -171,16 +190,20 @@ func (h *HTTP) decodeHTTP(ctx context.Context, reqBuf []byte, clientConn net.Con
 			h.Logger.Debug("after matching the http request", zap.Any("isMatched", ok), zap.Any("stub", stub), zap.Error(err))
 
 			if !ok {
-				h.Logger.Debug("no matching http mock found", zap.Any("metadata", utils.GetReqMeta(request)))
-
-				// Build mismatch report for the user (surfaced in the mismatch table)
-				report := h.buildHTTPMismatchReport(request, mockDb, nil)
+				// Build mismatch report for the user (surfaced in the mismatch
+				// table, the report yaml and `keploy report`).
+				report := h.buildHTTPMismatchReport(request, input.body, mockDb, nil, headerNoise, bodyNoise, diag)
 				if report != nil {
-					h.Logger.Debug("mock miss",
+					// Default-visible: this is the root cause of the test
+					// failure that follows, so it must not hide at Debug.
+					h.Logger.Warn("no matching http mock found for outgoing request",
 						zap.String("protocol", report.Protocol),
 						zap.String("actual", report.ActualSummary),
+						zap.String("match_phase", report.MatchPhase),
+						zap.Int("candidates", report.CandidateCount),
 						zap.String("closest", report.ClosestMock),
-						zap.String("diff", report.Diff))
+						zap.String("diff", report.Diff),
+						zap.String("next_steps", report.NextSteps))
 				}
 
 				// No mock matched — send a 502 so the application gets a

--- a/pkg/agent/proxy/integrations/http/match.go
+++ b/pkg/agent/proxy/integrations/http/match.go
@@ -1083,10 +1083,11 @@ func (h *HTTP) detectReqBodyNoise(enabled bool, mock *models.Mock, reqBody []byt
 }
 
 // mergeNoiseMaps combines two noise maps into a fresh map; entries in a win
-// on key collision. Either input may be nil.
+// on key collision. Either input may be nil. The result never aliases an
+// input map, so callers may hold or extend it without mutating shared state.
 func mergeNoiseMaps(a, b map[string][]string) map[string][]string {
-	if len(b) == 0 {
-		return a
+	if len(a) == 0 && len(b) == 0 {
+		return nil
 	}
 	out := make(map[string][]string, len(a)+len(b))
 	for k, v := range b {

--- a/pkg/agent/proxy/integrations/http/match.go
+++ b/pkg/agent/proxy/integrations/http/match.go
@@ -13,6 +13,7 @@ import (
 	"github.com/agnivade/levenshtein"
 	"go.keploy.io/server/v3/pkg"
 	"go.keploy.io/server/v3/pkg/agent/proxy/integrations"
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mismatch"
 	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/util"
 	"go.keploy.io/server/v3/pkg/matcher"
 	"go.keploy.io/server/v3/pkg/models"
@@ -115,10 +116,25 @@ type req struct {
 	raw    []byte
 }
 
-func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMemDb, headerNoise map[string][]string, schemaNoiseDetection bool, schemaNoiseStrict bool) (bool, *models.Mock, error) {
+// matchDiag captures where the match cascade stopped when no mock matched, so
+// the mismatch report can tell the user WHICH stage ruled everything out and
+// diff the live request against the candidates that were still alive there —
+// instead of the canned "headers or body differ".
+type matchDiag struct {
+	phase         string         // models.MatchPhase* constant
+	candidates    int            // HTTP mocks considered
+	schemaMatched []*models.Mock // candidates alive after schema match (nil if none)
+}
+
+// match returns (matched, mock, diag, err). diag is non-nil only when
+// matched is false and no error occurred. userBodyNoise carries the user's
+// test.globalNoise body bucket (root-relative dotted paths, lowercased) so
+// manual noise config participates in mock matching with the same vocabulary
+// as response assertions.
+func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMemDb, headerNoise map[string][]string, userBodyNoise map[string][]string, schemaNoiseDetection bool, schemaNoiseStrict bool) (bool, *models.Mock, *matchDiag, error) {
 	for {
 		if ctx.Err() != nil {
-			return false, nil, ctx.Err()
+			return false, nil, nil, ctx.Err()
 		}
 
 		// Fetch HTTP mocks from BOTH pools:
@@ -147,12 +163,12 @@ func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMe
 		perTestMocks, err := mockDb.GetPerTestMocksInWindow()
 		if err != nil {
 			utils.LogError(h.Logger, err, "failed to get per-test mocks")
-			return false, nil, errors.New("error while matching the request with the mocks")
+			return false, nil, nil, errors.New("error while matching the request with the mocks")
 		}
 		sessionMocks, err := mockDb.GetSessionMocks()
 		if err != nil {
 			utils.LogError(h.Logger, err, "failed to get session mocks")
-			return false, nil, errors.New("error while matching the request with the mocks")
+			return false, nil, nil, errors.New("error while matching the request with the mocks")
 		}
 		combined := make([]*models.Mock, 0, len(perTestMocks)+len(sessionMocks))
 		combined = append(combined, perTestMocks...)
@@ -168,14 +184,18 @@ func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMe
 
 		h.Logger.Debug(fmt.Sprintf("Length of unfilteredMocks:%v", len(unfilteredMocks)))
 
+		if len(unfilteredMocks) == 0 {
+			return false, nil, &matchDiag{phase: models.MatchPhaseNoMocks}, nil
+		}
+
 		// Matching process
 		schemaMatched, err := h.SchemaMatch(ctx, input, unfilteredMocks, headerNoise)
 		if err != nil {
-			return false, nil, err
+			return false, nil, nil, err
 		}
 
 		if len(schemaMatched) == 0 {
-			return false, nil, nil
+			return false, nil, &matchDiag{phase: models.MatchPhaseSchema, candidates: len(unfilteredMocks)}, nil
 		}
 
 		h.Logger.Debug("http mock schema match results",
@@ -190,7 +210,7 @@ func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMe
 			if !h.updateMock(ctx, bestMatch, mockDb, nil) {
 				continue
 			}
-			return true, bestMatch, nil
+			return true, bestMatch, nil, nil
 		}
 
 		shortListed := schemaMatched
@@ -198,31 +218,37 @@ func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMe
 		if pkg.IsJSON(input.body) {
 			bodyMatched, err := h.PerformBodyMatch(ctx, schemaMatched, input.body)
 			if err != nil {
-				return false, nil, err
+				return false, nil, nil, err
 			}
 
 			// Strict enforcement (replay path): for any candidate that already
 			// carries learned req_body_noise, every request-body field must
-			// match except those learned-noise paths. A drift on a non-noise
-			// field rejects that candidate, so a changed-but-unmarked field
-			// fails the test instead of being silently served. Candidates with
-			// no learned noise keep the lenient schema/key behaviour.
+			// match except those learned-noise paths and the user's configured
+			// body noise. A drift on a non-noise field rejects that candidate,
+			// so a changed-but-unmarked field fails the test instead of being
+			// silently served. Candidates with no learned noise keep the
+			// lenient schema/key behaviour.
+			beforeStrict := len(bodyMatched)
 			if schemaNoiseStrict {
-				bodyMatched = h.filterStrictNoiseMatches(bodyMatched, input.body)
+				bodyMatched = h.filterStrictNoiseMatches(bodyMatched, input.body, userBodyNoise)
 			}
 
 			if len(bodyMatched) == 0 {
 				h.Logger.Debug("No mock found with body schema match")
-				return false, nil, nil
+				phase := models.MatchPhaseBody
+				if beforeStrict > 0 {
+					phase = models.MatchPhaseStrict
+				}
+				return false, nil, &matchDiag{phase: phase, candidates: len(unfilteredMocks), schemaMatched: schemaMatched}, nil
 			}
 
 			if len(bodyMatched) == 1 {
 				h.Logger.Debug("body match found", zap.String("mock name", bodyMatched[0].Name))
-				detected := h.detectReqBodyNoise(schemaNoiseDetection, bodyMatched[0], input.body)
+				detected := h.detectReqBodyNoise(schemaNoiseDetection, bodyMatched[0], input.body, userBodyNoise)
 				if !h.updateMock(ctx, bodyMatched[0], mockDb, detected) {
 					continue
 				}
-				return true, bodyMatched[0], nil
+				return true, bodyMatched[0], nil, nil
 			}
 
 			// More than one match, perform fuzzy match
@@ -234,13 +260,13 @@ func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMe
 		isMatched, bestMatch := h.PerformFuzzyMatch(shortListed, input.raw)
 		if isMatched {
 			h.Logger.Debug("fuzzy match found a matching mock", zap.String("mock name", bestMatch.Name))
-			detected := h.detectReqBodyNoise(schemaNoiseDetection, bestMatch, input.body)
+			detected := h.detectReqBodyNoise(schemaNoiseDetection, bestMatch, input.body, userBodyNoise)
 			if !h.updateMock(ctx, bestMatch, mockDb, detected) {
 				continue
 			}
-			return true, bestMatch, nil
+			return true, bestMatch, nil, nil
 		}
-		return false, nil, nil
+		return false, nil, &matchDiag{phase: models.MatchPhaseExhausted, candidates: len(unfilteredMocks), schemaMatched: shortListed}, nil
 	}
 }
 
@@ -989,14 +1015,14 @@ func (h *HTTP) updateMock(_ context.Context, matchedMock *models.Mock, mockDb in
 // It reuses detectReqBodyNoise, which returns exactly the drifting field paths
 // that are NOT already known noise (and not obfuscator-covered): a non-empty
 // result means an unmarked field changed, so the candidate cannot match.
-func (h *HTTP) filterStrictNoiseMatches(candidates []*models.Mock, reqBody []byte) []*models.Mock {
+func (h *HTTP) filterStrictNoiseMatches(candidates []*models.Mock, reqBody []byte, userBodyNoise map[string][]string) []*models.Mock {
 	var kept []*models.Mock
 	for _, m := range candidates {
 		if m == nil || m.Spec.HTTPReq == nil || len(m.Spec.HTTPReq.ReqBodyNoise) == 0 {
 			kept = append(kept, m)
 			continue
 		}
-		if drift := h.detectReqBodyNoise(true, m, reqBody); len(drift) > 0 {
+		if drift := h.detectReqBodyNoise(true, m, reqBody, userBodyNoise); len(drift) > 0 {
 			h.Logger.Debug("strict req-body match rejected mock: non-noise field drift",
 				zap.String("mock name", m.Name), zap.Any("drift", drift))
 			continue
@@ -1011,10 +1037,12 @@ func (h *HTTP) filterStrictNoiseMatches(candidates []*models.Mock, reqBody []byt
 // field-path noise (body.<path> -> empty regex list = "ignore this whole
 // field"), gated by the SchemaNoiseDetection flag. Fields already covered by
 // the mock's value-regex Mock.Noise (e.g. enterprise-obfuscated secrets) are
-// excluded so secrets aren't re-flagged as schema noise. Returns nil when the
-// flag is off, when the bodies are byte-identical, or when nothing meaningful
-// changed.
-func (h *HTTP) detectReqBodyNoise(enabled bool, mock *models.Mock, reqBody []byte) map[string][]string {
+// excluded so secrets aren't re-flagged as schema noise, and so are fields
+// the user already declared in test.globalNoise's body bucket (userNoise,
+// root-relative dotted paths) — manual noise config and learned noise share
+// one vocabulary. Returns nil when the flag is off, when the bodies are
+// byte-identical, or when nothing meaningful changed.
+func (h *HTTP) detectReqBodyNoise(enabled bool, mock *models.Mock, reqBody []byte, userNoise map[string][]string) map[string][]string {
 	if !enabled || mock == nil || mock.Spec.HTTPReq == nil {
 		return nil
 	}
@@ -1030,7 +1058,7 @@ func (h *HTTP) detectReqBodyNoise(enabled bool, mock *models.Mock, reqBody []byt
 	case pkg.IsJSON([]byte(mockBody)) && pkg.IsJSON(reqBody):
 		// The matcher matches noise paths root-relative; our stored keys carry
 		// a "body." prefix, so strip it for the already-known exclusion set.
-		known := stripBodyPrefix(mock.Spec.HTTPReq.ReqBodyNoise)
+		known := mergeNoiseMaps(stripBodyPrefix(mock.Spec.HTTPReq.ReqBodyNoise), userNoise)
 		paths := matcher.ChangedJSONFieldPaths(mockBody, string(reqBody), known, isObfuscated)
 		if len(paths) == 0 {
 			return nil
@@ -1042,13 +1070,48 @@ func (h *HTTP) detectReqBodyNoise(enabled bool, mock *models.Mock, reqBody []byt
 		return out
 
 	case isFormURLEncoded(mock.Spec.HTTPReq.Header):
-		return formReqBodyNoise(mockBody, string(reqBody), mock.Spec.HTTPReq.ReqBodyNoise, isObfuscated)
+		// formReqBodyNoise keys its known-set with the "body." prefix, so
+		// user noise (root-relative) is prefixed before merging.
+		known := mergeNoiseMaps(mock.Spec.HTTPReq.ReqBodyNoise, addBodyPrefix(userNoise))
+		return formReqBodyNoise(mockBody, string(reqBody), known, isObfuscated)
 
 	default:
 		// Non-JSON, non-form (binary, plain text) bodies have no meaningful
 		// field paths to diff — leave them to exact/fuzzy matching.
 		return nil
 	}
+}
+
+// mergeNoiseMaps combines two noise maps into a fresh map; entries in a win
+// on key collision. Either input may be nil.
+func mergeNoiseMaps(a, b map[string][]string) map[string][]string {
+	if len(b) == 0 {
+		return a
+	}
+	out := make(map[string][]string, len(a)+len(b))
+	for k, v := range b {
+		out[k] = v
+	}
+	for k, v := range a {
+		out[k] = v
+	}
+	return out
+}
+
+// addBodyPrefix returns a copy of the noise map with "body." prepended to
+// each key that doesn't already carry it.
+func addBodyPrefix(in map[string][]string) map[string][]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(in))
+	for k, v := range in {
+		if !strings.HasPrefix(k, "body.") {
+			k = "body." + k
+		}
+		out[k] = v
+	}
+	return out
 }
 
 // stripBodyPrefix returns a copy of the noise map with the leading "body."
@@ -1170,57 +1233,136 @@ func mergeReqBodyNoise(existing, detected map[string][]string) map[string][]stri
 }
 
 // buildHTTPMismatchReport finds the closest HTTP mock to the given request
-// and returns a human-readable diff report. If httpMocks is nil, it fetches
-// from mockDb; otherwise it uses the pre-fetched slice to avoid a redundant read.
-func (h *HTTP) buildHTTPMismatchReport(request *http.Request, mockDb integrations.MockMemDb, httpMocks []*models.Mock) *models.MockMismatchReport {
-	if httpMocks == nil {
+// and returns a structured field-level diff report. liveBody is the live
+// request body (may be nil for body-less requests); headerNoise/userBodyNoise
+// are the same noise sets the matcher used, so the report never flags a field
+// the matcher would have ignored. diag (from match()) tells the builder how
+// far the cascade got and which candidates were still alive, so the diff is
+// computed against a candidate the matcher actually considered close — not
+// just the lowest-Levenshtein path. If httpMocks is nil, it fetches from
+// mockDb; otherwise it uses the pre-fetched slice to avoid a redundant read.
+func (h *HTTP) buildHTTPMismatchReport(request *http.Request, liveBody []byte, mockDb integrations.MockMemDb, httpMocks []*models.Mock, headerNoise, userBodyNoise map[string][]string, diag *matchDiag) *models.MockMismatchReport {
+	actualKey := request.Method + " " + request.URL.Path
+	if httpMocks == nil && (diag == nil || len(diag.schemaMatched) == 0) {
 		// Mirror match()'s pool-merging + ordering strategy so
 		// mismatch diagnostics see the same candidate set in the
 		// same order the matcher saw. Per-test FIRST, session second.
 		perTestMocks, err := mockDb.GetPerTestMocksInWindow()
 		if err != nil {
-			return &models.MockMismatchReport{
-				Protocol:      "HTTP",
-				ActualSummary: fmt.Sprintf("%s %s", request.Method, request.URL.Path),
-				NextSteps:     "Failed to read mock database. Check logs for errors and retry.",
-			}
+			return mismatch.NewReport(mismatch.ProtocolHTTP, actualKey).
+				WithNextSteps("Failed to read mock database. Check logs for errors and retry.").Build()
 		}
 		sessionMocks, err := mockDb.GetSessionMocks()
 		if err != nil {
-			return &models.MockMismatchReport{
-				Protocol:      "HTTP",
-				ActualSummary: fmt.Sprintf("%s %s", request.Method, request.URL.Path),
-				NextSteps:     "Failed to read mock database. Check logs for errors and retry.",
-			}
+			return mismatch.NewReport(mismatch.ProtocolHTTP, actualKey).
+				WithNextSteps("Failed to read mock database. Check logs for errors and retry.").Build()
 		}
 		mocks := make([]*models.Mock, 0, len(perTestMocks)+len(sessionMocks))
 		mocks = append(mocks, perTestMocks...)
 		mocks = append(mocks, sessionMocks...)
-		if len(mocks) == 0 {
-			return &models.MockMismatchReport{
-				Protocol:      "HTTP",
-				ActualSummary: fmt.Sprintf("%s %s", request.Method, request.URL.Path),
-				NextSteps:     "No HTTP mocks available. Re-record mocks to capture this endpoint.",
-			}
-		}
 		httpMocks = FilterHTTPMocks(mocks)
 	}
-	if len(httpMocks) == 0 {
-		return &models.MockMismatchReport{
-			Protocol:      "HTTP",
-			ActualSummary: fmt.Sprintf("%s %s", request.Method, request.URL.Path),
-			NextSteps:     "No HTTP mocks available. Re-record mocks to capture this endpoint.",
+
+	phase := models.MatchPhaseExhausted
+	candidateCount := len(httpMocks)
+	var schemaSurvivors []*models.Mock
+	if diag != nil {
+		if diag.phase != "" {
+			phase = diag.phase
 		}
+		if diag.candidates > 0 {
+			candidateCount = diag.candidates
+		}
+		schemaSurvivors = diag.schemaMatched
 	}
 
-	// Find closest mock: first try same-method mocks (cheap filter), then fall back to all.
+	if candidateCount == 0 && len(schemaSurvivors) == 0 {
+		return mismatch.NewReport(mismatch.ProtocolHTTP, actualKey).
+			WithPhase(models.MatchPhaseNoMocks, 0).Build()
+	}
+
+	// Pick the candidate to diff against. Preference order:
+	//  1. a schema-match survivor (method+path+keys already matched — the
+	//     interesting drift is in query values, headers, or the body)
+	//  2. the lowest-Levenshtein "METHOD path" mock from the pool.
+	closestMock := pickClosestCandidate(request, schemaSurvivors, httpMocks)
+	if closestMock == nil || closestMock.Spec.HTTPReq == nil {
+		return mismatch.NewReport(mismatch.ProtocolHTTP, actualKey).
+			WithPhase(phase, candidateCount).Build()
+	}
+
+	mockReq := closestMock.Spec.HTTPReq
+	var fieldDiffs []models.MockFieldDiff
+
+	// method / path pseudo-fields
+	if string(mockReq.Method) != request.Method {
+		fieldDiffs = append(fieldDiffs, models.MockFieldDiff{
+			Path: "method", Kind: models.DiffKindValueChanged,
+			Expected: string(mockReq.Method), Actual: request.Method,
+		})
+	}
+	mockPath := mockReq.URL
+	var mockQuery url.Values
+	if parsed, err := url.Parse(mockReq.URL); err == nil {
+		mockPath = parsed.Path
+		mockQuery = parsed.Query()
+	}
+	if mockPath != request.URL.Path {
+		fieldDiffs = append(fieldDiffs, models.MockFieldDiff{
+			Path: "path", Kind: models.DiffKindValueChanged,
+			Expected: mockPath, Actual: request.URL.Path,
+		})
+	}
+
+	// Recorded URLParams take precedence over the parsed URL query (some
+	// recorders store params only there); fall back to the parsed query.
+	recordedQuery := map[string][]string{}
+	if len(mockReq.URLParams) > 0 {
+		for k, v := range mockReq.URLParams {
+			recordedQuery[k] = []string{v}
+		}
+	} else {
+		recordedQuery = mockQuery
+	}
+	fieldDiffs = append(fieldDiffs, mismatch.QueryParamDiffs(recordedQuery, request.URL.Query())...)
+	fieldDiffs = append(fieldDiffs, mismatch.HeaderKeyDiffs(mockReq.Header, request.Header, headerNoise)...)
+
+	// Body diffs: JSON bodies get field-level diffs excluding everything the
+	// matcher itself ignores (learned req_body_noise + user body noise).
+	if len(liveBody) > 0 && pkg.IsJSON([]byte(mockReq.Body)) && pkg.IsJSON(liveBody) {
+		ignore := mergeNoiseMaps(stripBodyPrefix(mockReq.ReqBodyNoise), userBodyNoise)
+		fieldDiffs = append(fieldDiffs, mismatch.JSONBodyDiffs(mockReq.Body, string(liveBody), ignore)...)
+	}
+
+	b := mismatch.NewReport(mismatch.ProtocolHTTP, actualKey).
+		WithPhase(phase, candidateCount).
+		WithClosest(closestMock.Name, fieldDiffs)
+	if len(fieldDiffs) == 0 {
+		// Nothing structurally differs vs the closest candidate, yet the
+		// matcher rejected everything — point the user at the phase instead
+		// of the misleading legacy "headers or body differ".
+		b = b.WithDiff(fmt.Sprintf("closest mock %q has no field-level differences; match stopped at phase %q", closestMock.Name, phase))
+	}
+	return b.Build()
+}
+
+// pickClosestCandidate prefers a schema-match survivor (already same
+// method/path/keys) and falls back to the lowest-Levenshtein "METHOD path"
+// candidate across the pool, same-method candidates first.
+func pickClosestCandidate(request *http.Request, schemaSurvivors, pool []*models.Mock) *models.Mock {
+	if len(schemaSurvivors) > 0 {
+		for _, m := range schemaSurvivors {
+			if m != nil && m.Spec.HTTPReq != nil {
+				return m
+			}
+		}
+	}
 	actualKey := request.Method + " " + request.URL.Path
 	bestDist := -1
-	var closestMock *models.Mock
-	// Two-pass: first same method only, then all if no match found
+	var closest *models.Mock
 	for pass := 0; pass < 2; pass++ {
-		for _, mock := range httpMocks {
-			if mock.Spec.HTTPReq == nil {
+		for _, mock := range pool {
+			if mock == nil || mock.Spec.HTTPReq == nil {
 				continue
 			}
 			if pass == 0 && string(mock.Spec.HTTPReq.Method) != request.Method {
@@ -1235,45 +1377,12 @@ func (h *HTTP) buildHTTPMismatchReport(request *http.Request, mockDb integration
 			dist := levenshtein.ComputeDistance(actualKey, mockKey)
 			if bestDist < 0 || dist < bestDist {
 				bestDist = dist
-				closestMock = mock
+				closest = mock
 			}
 		}
-		if closestMock != nil {
+		if closest != nil {
 			break
 		}
 	}
-	if closestMock == nil || closestMock.Spec.HTTPReq == nil {
-		return &models.MockMismatchReport{
-			Protocol:      "HTTP",
-			ActualSummary: actualKey,
-			NextSteps:     "Re-record mocks if the API endpoint or request format has changed.",
-		}
-	}
-
-	// Build diff details
-	var diffs []string
-	mockReq := closestMock.Spec.HTTPReq
-	if string(mockReq.Method) != request.Method {
-		diffs = append(diffs, fmt.Sprintf("method: %q vs %q", request.Method, mockReq.Method))
-	}
-	mockPath := mockReq.URL
-	if parsed, err := url.Parse(mockReq.URL); err == nil {
-		mockPath = parsed.Path
-	}
-	if mockPath != request.URL.Path {
-		diffs = append(diffs, fmt.Sprintf("path: %q vs %q", request.URL.Path, mockPath))
-	}
-
-	diff := strings.Join(diffs, "; ")
-	if diff == "" {
-		diff = "method and path match but headers or body differ"
-	}
-
-	return &models.MockMismatchReport{
-		Protocol:      "HTTP",
-		ActualSummary: actualKey,
-		ClosestMock:   closestMock.Name,
-		Diff:          diff,
-		NextSteps:     "Re-record mocks if the API endpoint or request format has changed.",
-	}
+	return closest
 }

--- a/pkg/agent/proxy/integrations/http/match_test.go
+++ b/pkg/agent/proxy/integrations/http/match_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -91,7 +92,7 @@ func httpMock(name, method, rawURL string) *models.Mock {
 func TestBuildHTTPMismatchReport_NoMocks(t *testing.T) {
 	h := newHTTP()
 	db := &mockMemDb{mocks: nil}
-	report := h.buildHTTPMismatchReport(makeReq("GET", "/api/users"), db, nil)
+	report := h.buildHTTPMismatchReport(makeReq("GET", "/api/users"), nil, db, nil, nil, nil, nil)
 
 	if report == nil {
 		t.Fatal("expected non-nil report")
@@ -110,7 +111,7 @@ func TestBuildHTTPMismatchReport_NoMocks(t *testing.T) {
 func TestBuildHTTPMismatchReport_DbError(t *testing.T) {
 	h := newHTTP()
 	db := &mockMemDb{err: fmt.Errorf("db error")}
-	report := h.buildHTTPMismatchReport(makeReq("POST", "/api/items"), db, nil)
+	report := h.buildHTTPMismatchReport(makeReq("POST", "/api/items"), nil, db, nil, nil, nil, nil)
 
 	if report == nil {
 		t.Fatal("expected non-nil report")
@@ -129,7 +130,7 @@ func TestBuildHTTPMismatchReport_NoHTTPMocks(t *testing.T) {
 	db := &mockMemDb{mocks: []*models.Mock{
 		{Name: "dns-mock", Kind: "DNS", Spec: models.MockSpec{}},
 	}}
-	report := h.buildHTTPMismatchReport(makeReq("GET", "/api/data"), db, nil)
+	report := h.buildHTTPMismatchReport(makeReq("GET", "/api/data"), nil, db, nil, nil, nil, nil)
 
 	if report == nil {
 		t.Fatal("expected non-nil report")
@@ -146,7 +147,7 @@ func TestBuildHTTPMismatchReport_SameMethodMatch(t *testing.T) {
 		httpMock("mock-get-users", "GET", "http://localhost:8080/api/users"),
 		httpMock("mock-post-users", "POST", "http://localhost:8080/api/users"),
 	}}
-	report := h.buildHTTPMismatchReport(makeReq("GET", "/api/items"), db, nil)
+	report := h.buildHTTPMismatchReport(makeReq("GET", "/api/items"), nil, db, nil, nil, nil, nil)
 
 	if report == nil {
 		t.Fatal("expected non-nil report")
@@ -166,7 +167,7 @@ func TestBuildHTTPMismatchReport_DiffMethodFallback(t *testing.T) {
 	db := &mockMemDb{mocks: []*models.Mock{
 		httpMock("mock-post-items", "POST", "http://localhost:8080/api/items"),
 	}}
-	report := h.buildHTTPMismatchReport(makeReq("GET", "/api/items"), db, nil)
+	report := h.buildHTTPMismatchReport(makeReq("GET", "/api/items"), nil, db, nil, nil, nil, nil)
 
 	if report == nil {
 		t.Fatal("expected non-nil report")
@@ -186,7 +187,7 @@ func TestBuildHTTPMismatchReport_PathDiff(t *testing.T) {
 	db := &mockMemDb{mocks: []*models.Mock{
 		httpMock("mock-get-users", "GET", "http://localhost:8080/api/users"),
 	}}
-	report := h.buildHTTPMismatchReport(makeReq("GET", "/api/orders"), db, nil)
+	report := h.buildHTTPMismatchReport(makeReq("GET", "/api/orders"), nil, db, nil, nil, nil, nil)
 
 	if report == nil {
 		t.Fatal("expected non-nil report")
@@ -206,13 +207,13 @@ func TestBuildHTTPMismatchReport_ExactPathMethodMatch(t *testing.T) {
 		httpMock("mock-get-users", "GET", "http://localhost:8080/api/users"),
 	}}
 	// Same method and path — diff should indicate headers/body differ
-	report := h.buildHTTPMismatchReport(makeReq("GET", "/api/users"), db, nil)
+	report := h.buildHTTPMismatchReport(makeReq("GET", "/api/users"), nil, db, nil, nil, nil, nil)
 
 	if report == nil {
 		t.Fatal("expected non-nil report")
 	}
-	if report.Diff != "method and path match but headers or body differ" {
-		t.Errorf("expected headers/body diff message, got %q", report.Diff)
+	if !strings.Contains(report.Diff, "no field-level differences") {
+		t.Errorf("expected no-field-level-differences diff message, got %q", report.Diff)
 	}
 }
 

--- a/pkg/agent/proxy/integrations/http/mismatch_report_test.go
+++ b/pkg/agent/proxy/integrations/http/mismatch_report_test.go
@@ -1,0 +1,138 @@
+package http
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// httpMockWithReq builds an HTTP mock with full request details for
+// field-diff assertions.
+func httpMockWithReq(name, method, rawURL, body string, header map[string]string, reqBodyNoise map[string][]string) *models.Mock {
+	return &models.Mock{
+		Name: name,
+		Kind: models.Kind(models.HTTP),
+		Spec: models.MockSpec{
+			HTTPReq: &models.HTTPReq{
+				Method:       models.Method(method),
+				URL:          rawURL,
+				Body:         body,
+				Header:       header,
+				ReqBodyNoise: reqBodyNoise,
+			},
+		},
+	}
+}
+
+func makeReqWithQuery(method, path, rawQuery string) *http.Request {
+	return &http.Request{
+		Method: method,
+		URL:    &url.URL{Path: path, RawQuery: rawQuery},
+		Header: http.Header{},
+	}
+}
+
+// A schema-match survivor should be preferred for the diff and its body/query
+// drift reported field-by-field with noise-vocabulary paths.
+func TestBuildHTTPMismatchReport_FieldDiffsAgainstSchemaSurvivor(t *testing.T) {
+	h := newHTTP()
+	mock := httpMockWithReq("mock-1", "POST", "http://localhost:8080/api/orders?page=1",
+		`{"order_id":"o-1","ts":"111"}`, map[string]string{"Content-Type": "application/json"}, nil)
+	db := &mockMemDb{mocks: []*models.Mock{mock}}
+
+	request := makeReqWithQuery("POST", "/api/orders", "page=2")
+	liveBody := []byte(`{"order_id":"o-2","ts":"111"}`)
+	diag := &matchDiag{phase: models.MatchPhaseBody, candidates: 1, schemaMatched: []*models.Mock{mock}}
+
+	report := h.buildHTTPMismatchReport(request, liveBody, db, nil, nil, nil, diag)
+	if report.ClosestMock != "mock-1" {
+		t.Fatalf("expected schema survivor as closest, got %q", report.ClosestMock)
+	}
+	if report.MatchPhase != models.MatchPhaseBody {
+		t.Errorf("expected phase %q, got %q", models.MatchPhaseBody, report.MatchPhase)
+	}
+
+	paths := map[string]models.MockFieldDiff{}
+	for _, d := range report.FieldDiffs {
+		paths[d.Path] = d
+	}
+	if d, ok := paths["body.order_id"]; !ok || d.Expected != "o-1" || d.Actual != "o-2" {
+		t.Errorf("expected body.order_id value diff, got %+v", report.FieldDiffs)
+	}
+	if d, ok := paths["query.page"]; !ok || d.Expected != "1" || d.Actual != "2" {
+		t.Errorf("expected query.page value diff, got %+v", report.FieldDiffs)
+	}
+	if _, ok := paths["body.ts"]; ok {
+		t.Errorf("unchanged body.ts must not be reported: %+v", report.FieldDiffs)
+	}
+}
+
+// Fields covered by learned req_body_noise or user body noise must not be
+// flagged in the report — the report should never tell the user to fix a
+// field the matcher already ignores.
+func TestBuildHTTPMismatchReport_RespectsLearnedAndUserNoise(t *testing.T) {
+	h := newHTTP()
+	mock := httpMockWithReq("mock-1", "POST", "http://localhost:8080/api/orders",
+		`{"request_id":"r-1","ts":"111","real":"x"}`, nil,
+		map[string][]string{"body.request_id": {}})
+	db := &mockMemDb{mocks: []*models.Mock{mock}}
+
+	request := makeReqWithQuery("POST", "/api/orders", "")
+	liveBody := []byte(`{"request_id":"r-2","ts":"222","real":"y"}`)
+	userBodyNoise := map[string][]string{"ts": {}}
+	diag := &matchDiag{phase: models.MatchPhaseStrict, candidates: 1, schemaMatched: []*models.Mock{mock}}
+
+	report := h.buildHTTPMismatchReport(request, liveBody, db, nil, nil, userBodyNoise, diag)
+	var gotPaths []string
+	for _, d := range report.FieldDiffs {
+		gotPaths = append(gotPaths, d.Path)
+	}
+	joined := strings.Join(gotPaths, ",")
+	if strings.Contains(joined, "request_id") {
+		t.Errorf("learned-noise field reported: %v", gotPaths)
+	}
+	if strings.Contains(joined, "body.ts") {
+		t.Errorf("user-noise field reported: %v", gotPaths)
+	}
+	if !strings.Contains(joined, "body.real") {
+		t.Errorf("genuinely drifted field body.real missing: %v", gotPaths)
+	}
+}
+
+// User-configured body noise must thread into detectReqBodyNoise so manual
+// noise config and learned noise share one vocabulary.
+func TestDetectReqBodyNoise_UserNoiseExcluded(t *testing.T) {
+	h := newHTTP()
+	mock := httpMockWithReq("mock-1", "POST", "http://x/y",
+		`{"ts":"111","real":"a"}`, map[string]string{"Content-Type": "application/json"}, nil)
+
+	got := h.detectReqBodyNoise(true, mock, []byte(`{"ts":"222","real":"b"}`), map[string][]string{"ts": {}})
+	if _, ok := got["body.ts"]; ok {
+		t.Errorf("user-noised field must not be re-learned as noise: %+v", got)
+	}
+	if _, ok := got["body.real"]; !ok {
+		t.Errorf("drifting non-noise field should be detected: %+v", got)
+	}
+}
+
+// Strict filtering must treat user-configured body noise as allowed drift.
+func TestFilterStrictNoiseMatches_UserNoiseAllowsDrift(t *testing.T) {
+	h := newHTTP()
+	// Mock carries learned noise (so strict applies) on another field.
+	mock := httpMockWithReq("mock-1", "POST", "http://x/y",
+		`{"request_id":"r-1","ts":"111"}`, map[string]string{"Content-Type": "application/json"},
+		map[string][]string{"body.request_id": {}})
+
+	// ts drifted; without user noise the candidate must be rejected.
+	live := []byte(`{"request_id":"r-9","ts":"222"}`)
+	if kept := h.filterStrictNoiseMatches([]*models.Mock{mock}, live, nil); len(kept) != 0 {
+		t.Fatalf("expected strict rejection without user noise, kept %d", len(kept))
+	}
+	// With user noise on ts the drift is allowed.
+	if kept := h.filterStrictNoiseMatches([]*models.Mock{mock}, live, map[string][]string{"ts": {}}); len(kept) != 1 {
+		t.Fatalf("expected candidate kept with user noise, kept %d", len(kept))
+	}
+}

--- a/pkg/agent/proxy/integrations/http/reqbodynoise_test.go
+++ b/pkg/agent/proxy/integrations/http/reqbodynoise_test.go
@@ -36,21 +36,21 @@ func TestDetectReqBodyNoise(t *testing.T) {
 
 	t.Run("disabled returns nil", func(t *testing.T) {
 		mock := httpMockWithBody(`{"id":"a"}`, jsonHdr, nil)
-		if got := h.detectReqBodyNoise(false, mock, []byte(`{"id":"b"}`)); got != nil {
+		if got := h.detectReqBodyNoise(false, mock, []byte(`{"id":"b"}`), nil); got != nil {
 			t.Fatalf("expected nil when disabled, got %v", got)
 		}
 	})
 
 	t.Run("identical body returns nil", func(t *testing.T) {
 		mock := httpMockWithBody(`{"id":"a"}`, jsonHdr, nil)
-		if got := h.detectReqBodyNoise(true, mock, []byte(`{"id":"a"}`)); got != nil {
+		if got := h.detectReqBodyNoise(true, mock, []byte(`{"id":"a"}`), nil); got != nil {
 			t.Fatalf("expected nil for identical body, got %v", got)
 		}
 	})
 
 	t.Run("json value drift is flagged with body prefix", func(t *testing.T) {
 		mock := httpMockWithBody(`{"id":"a","name":"x"}`, jsonHdr, nil)
-		got := h.detectReqBodyNoise(true, mock, []byte(`{"id":"b","name":"x"}`))
+		got := h.detectReqBodyNoise(true, mock, []byte(`{"id":"b","name":"x"}`), nil)
 		want := []string{"body.id"}
 		if keys := sortedKeys(got); len(keys) != 1 || keys[0] != want[0] {
 			t.Fatalf("got %v, want %v", keys, want)
@@ -61,7 +61,7 @@ func TestDetectReqBodyNoise(t *testing.T) {
 		// Mock.Noise marks the redacted secret value; the recorded body holds
 		// the redacted placeholder while the replayed body holds the real one.
 		mock := httpMockWithBody(`{"id":"a","token":"****"}`, jsonHdr, []string{`^\*\*\*\*$`})
-		got := h.detectReqBodyNoise(true, mock, []byte(`{"id":"b","token":"realsecret"}`))
+		got := h.detectReqBodyNoise(true, mock, []byte(`{"id":"b","token":"realsecret"}`), nil)
 		keys := sortedKeys(got)
 		if len(keys) != 1 || keys[0] != "body.id" {
 			t.Fatalf("expected only body.id (token excluded as obfuscated), got %v", keys)
@@ -70,7 +70,7 @@ func TestDetectReqBodyNoise(t *testing.T) {
 
 	t.Run("form body drift is flagged", func(t *testing.T) {
 		mock := httpMockWithBody(`a=1&b=2`, formHdr, nil)
-		got := h.detectReqBodyNoise(true, mock, []byte(`a=1&b=99`))
+		got := h.detectReqBodyNoise(true, mock, []byte(`a=1&b=99`), nil)
 		keys := sortedKeys(got)
 		if len(keys) != 1 || keys[0] != "body.b" {
 			t.Fatalf("expected body.b, got %v", keys)
@@ -79,7 +79,7 @@ func TestDetectReqBodyNoise(t *testing.T) {
 
 	t.Run("non-json non-form returns nil", func(t *testing.T) {
 		mock := httpMockWithBody(`plain text body`, map[string]string{"Content-Type": "text/plain"}, nil)
-		if got := h.detectReqBodyNoise(true, mock, []byte(`different text`)); got != nil {
+		if got := h.detectReqBodyNoise(true, mock, []byte(`different text`), nil); got != nil {
 			t.Fatalf("expected nil for plain text, got %v", got)
 		}
 	})

--- a/pkg/agent/proxy/integrations/mismatch/mismatch.go
+++ b/pkg/agent/proxy/integrations/mismatch/mismatch.go
@@ -1,0 +1,263 @@
+// Package mismatch is the shared framework protocol parsers use to report a
+// mock miss. It guarantees a uniform vocabulary across protocols so the same
+// failure renders the same way in the CLI mismatch table, `keploy report`,
+// the test-report yaml (FailureInfo.UnmatchedCalls) and the platform UI.
+//
+// Field-diff paths use the SAME grammar as the noise configuration
+// ("body.<dotted.path>", "header.<name>", "query.<name>", "method", "path")
+// so a user can copy a reported path directly into test.globalNoise or a
+// testcase's spec.assertions.noise.
+//
+// A parser that detects a miss should:
+//
+//	report := mismatch.NewReport(mismatch.ProtocolHTTP, "GET /orders/42").
+//	    WithPhase(models.MatchPhaseExhausted, candidateCount).
+//	    WithClosest(closest.Name, fieldDiffs).
+//	    WithNextSteps("...").Build()
+//	errCh <- models.NewMockMismatchError(baseErr, report)
+//
+// proxy.go extracts the report from the error chain and the replayer attaches
+// it to the failing test's FailureInfo.UnmatchedCalls.
+package mismatch
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"go.keploy.io/server/v3/pkg/matcher"
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// Canonical protocol names. Parsers must use these so report consumers can
+// group and filter without normalizing strings.
+const (
+	ProtocolHTTP     = "HTTP"
+	ProtocolHTTP2    = "HTTP/2"
+	ProtocolGRPC     = "gRPC"
+	ProtocolMySQL    = "MySQL"
+	ProtocolPostgres = "PostgreSQL"
+	ProtocolMongo    = "MongoDB"
+	ProtocolRedis    = "Redis"
+	ProtocolGeneric  = "Generic"
+	ProtocolDNS      = "DNS"
+)
+
+// maxFieldDiffValueLen bounds recorded/live values embedded in reports so a
+// large payload can't bloat the report yaml or the CLI table.
+const maxFieldDiffValueLen = 256
+
+// maxFieldDiffs bounds how many per-field diffs a single report carries.
+const maxFieldDiffs = 25
+
+// Builder assembles a models.MockMismatchReport with consistent rendering.
+type Builder struct {
+	report models.MockMismatchReport
+}
+
+// NewReport starts a report for one missed call. actualSummary should be the
+// shortest string that identifies the live call ("POST /orders", "SELECT
+// (prepared stmt 12)", "find users").
+func NewReport(protocol, actualSummary string) *Builder {
+	return &Builder{report: models.MockMismatchReport{
+		Protocol:      protocol,
+		ActualSummary: actualSummary,
+	}}
+}
+
+// WithPhase records how far the match cascade got and how many candidate
+// mocks were considered. Use the models.MatchPhase* constants.
+func (b *Builder) WithPhase(phase string, candidateCount int) *Builder {
+	b.report.MatchPhase = phase
+	b.report.CandidateCount = candidateCount
+	return b
+}
+
+// WithClosest attaches the nearest candidate and its field-level diffs.
+func (b *Builder) WithClosest(mockName string, diffs []models.MockFieldDiff) *Builder {
+	b.report.ClosestMock = mockName
+	if len(diffs) > maxFieldDiffs {
+		diffs = diffs[:maxFieldDiffs]
+	}
+	b.report.FieldDiffs = diffs
+	return b
+}
+
+// WithDiff sets an explicit human-readable diff, overriding the rendered
+// FieldDiffs summary. Prefer WithClosest + field diffs; use this only for
+// protocols where field decomposition is impossible (e.g. opaque binary).
+func (b *Builder) WithDiff(diff string) *Builder {
+	b.report.Diff = diff
+	return b
+}
+
+// WithNextSteps sets the remediation hint shown to the user.
+func (b *Builder) WithNextSteps(steps string) *Builder {
+	b.report.NextSteps = steps
+	return b
+}
+
+// Build renders the Diff string from FieldDiffs (when not explicitly set)
+// and returns the finished report.
+func (b *Builder) Build() *models.MockMismatchReport {
+	r := b.report
+	if r.Diff == "" {
+		r.Diff = RenderFieldDiffs(r.FieldDiffs)
+	}
+	if r.NextSteps == "" {
+		r.NextSteps = defaultNextSteps(&r)
+	}
+	return &r
+}
+
+// RenderFieldDiffs renders field diffs as a compact single-string summary for
+// surfaces that can't show structured data (legacy table cells, logs).
+func RenderFieldDiffs(diffs []models.MockFieldDiff) string {
+	if len(diffs) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(diffs))
+	for _, d := range diffs {
+		switch d.Kind {
+		case models.DiffKindMissingInLive:
+			parts = append(parts, fmt.Sprintf("%s: recorded %q, absent in live call", d.Path, d.Expected))
+		case models.DiffKindMissingInMock:
+			parts = append(parts, fmt.Sprintf("%s: live %q, absent in recording", d.Path, d.Actual))
+		case models.DiffKindTypeChanged:
+			parts = append(parts, fmt.Sprintf("%s: type changed (recorded %s, live %s)", d.Path, d.Expected, d.Actual))
+		default:
+			parts = append(parts, fmt.Sprintf("%s: recorded %q, live %q", d.Path, d.Expected, d.Actual))
+		}
+	}
+	return strings.Join(parts, "; ")
+}
+
+// defaultNextSteps derives an actionable hint from the report shape. The
+// wording deliberately never references commands that don't exist; the two
+// real remedies are noise (for drifting values) and re-recording (for
+// structural change).
+func defaultNextSteps(r *models.MockMismatchReport) string {
+	onlyValueDrift := len(r.FieldDiffs) > 0
+	for _, d := range r.FieldDiffs {
+		if d.Kind != models.DiffKindValueChanged {
+			onlyValueDrift = false
+			break
+		}
+	}
+	switch {
+	case r.MatchPhase == models.MatchPhaseNoMocks:
+		return "No recorded mocks exist for this protocol in the selected test set. Re-record the test set with 'keploy record'."
+	case onlyValueDrift:
+		paths := make([]string, 0, len(r.FieldDiffs))
+		for _, d := range r.FieldDiffs {
+			paths = append(paths, d.Path)
+		}
+		return fmt.Sprintf("Only values drifted (%s). If these are dynamic (timestamps, ids, tokens), add them as noise; otherwise re-record with 'keploy record'.", strings.Join(paths, ", "))
+	default:
+		return "Request structure changed since recording. Re-record the test set with 'keploy record', or refresh mappings with --update-test-mapping if mocks were edited."
+	}
+}
+
+// JSONBodyDiffs computes field-level diffs between a recorded JSON body and
+// the live one, excluding paths in `ignore` (root-relative noise map, e.g.
+// learned req_body_noise plus user-configured body noise). Paths come back
+// prefixed with "body.".
+func JSONBodyDiffs(recordedBody, liveBody string, ignore map[string][]string) []models.MockFieldDiff {
+	return matcher.JSONFieldDiffs(recordedBody, liveBody, ignore, "body.", maxFieldDiffValueLen)
+}
+
+// HeaderKeyDiffs reports header keys present on one side and missing on the
+// other. Values are intentionally not compared — mock matching itself only
+// matches on header keys, so reporting value drift here would tell users to
+// fix something the matcher never looks at. Keys in `ignore` (lowercased,
+// e.g. the auto-noised flaky headers and user header noise) and keploy's own
+// headers are skipped.
+func HeaderKeyDiffs(recorded map[string]string, live map[string][]string, ignore map[string][]string) []models.MockFieldDiff {
+	skip := func(k string) bool {
+		lk := strings.ToLower(k)
+		if strings.HasPrefix(lk, "keploy") {
+			return true
+		}
+		if ignore != nil {
+			if _, ok := ignore[lk]; ok {
+				return true
+			}
+		}
+		return false
+	}
+
+	liveSet := make(map[string]struct{}, len(live))
+	for k := range live {
+		liveSet[strings.ToLower(k)] = struct{}{}
+	}
+	recordedSet := make(map[string]struct{}, len(recorded))
+	for k := range recorded {
+		recordedSet[strings.ToLower(k)] = struct{}{}
+	}
+
+	var out []models.MockFieldDiff
+	for k := range recorded {
+		if skip(k) {
+			continue
+		}
+		if _, ok := liveSet[strings.ToLower(k)]; !ok {
+			out = append(out, models.MockFieldDiff{
+				Path: "header." + k,
+				Kind: models.DiffKindMissingInLive,
+			})
+		}
+	}
+	for k := range live {
+		if skip(k) {
+			continue
+		}
+		if _, ok := recordedSet[strings.ToLower(k)]; !ok {
+			out = append(out, models.MockFieldDiff{
+				Path: "header." + k,
+				Kind: models.DiffKindMissingInMock,
+			})
+		}
+	}
+	sortDiffs(out)
+	return out
+}
+
+// QueryParamDiffs reports query parameters whose keys or values differ.
+// recorded/live map a key to its values (url.Values semantics).
+func QueryParamDiffs(recorded, live map[string][]string) []models.MockFieldDiff {
+	var out []models.MockFieldDiff
+	for k, rv := range recorded {
+		lv, ok := live[k]
+		if !ok {
+			out = append(out, models.MockFieldDiff{
+				Path:     "query." + k,
+				Kind:     models.DiffKindMissingInLive,
+				Expected: strings.Join(rv, ","),
+			})
+			continue
+		}
+		if strings.Join(rv, ",") != strings.Join(lv, ",") {
+			out = append(out, models.MockFieldDiff{
+				Path:     "query." + k,
+				Kind:     models.DiffKindValueChanged,
+				Expected: strings.Join(rv, ","),
+				Actual:   strings.Join(lv, ","),
+			})
+		}
+	}
+	for k, lv := range live {
+		if _, ok := recorded[k]; !ok {
+			out = append(out, models.MockFieldDiff{
+				Path:   "query." + k,
+				Kind:   models.DiffKindMissingInMock,
+				Actual: strings.Join(lv, ","),
+			})
+		}
+	}
+	sortDiffs(out)
+	return out
+}
+
+func sortDiffs(d []models.MockFieldDiff) {
+	sort.Slice(d, func(i, j int) bool { return d[i].Path < d[j].Path })
+}

--- a/pkg/agent/proxy/integrations/mismatch/mismatch_test.go
+++ b/pkg/agent/proxy/integrations/mismatch/mismatch_test.go
@@ -1,0 +1,147 @@
+package mismatch
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+func TestBuilder_RendersFieldDiffsAndDefaults(t *testing.T) {
+	report := NewReport(ProtocolHTTP, "POST /orders").
+		WithPhase(models.MatchPhaseExhausted, 3).
+		WithClosest("mock-7", []models.MockFieldDiff{
+			{Path: "body.created_at", Kind: models.DiffKindValueChanged, Expected: "2026-01-01", Actual: "2026-06-12"},
+		}).Build()
+
+	if report.Protocol != ProtocolHTTP || report.ActualSummary != "POST /orders" {
+		t.Fatalf("identity fields wrong: %+v", report)
+	}
+	if report.MatchPhase != models.MatchPhaseExhausted || report.CandidateCount != 3 {
+		t.Errorf("phase fields wrong: %+v", report)
+	}
+	if report.ClosestMock != "mock-7" {
+		t.Errorf("closest mock wrong: %q", report.ClosestMock)
+	}
+	if !strings.Contains(report.Diff, "body.created_at") {
+		t.Errorf("Diff should render field paths, got %q", report.Diff)
+	}
+	// Pure value drift → next steps must suggest noise, never a nonexistent command.
+	if !strings.Contains(report.NextSteps, "noise") {
+		t.Errorf("value-only drift should suggest noise, got %q", report.NextSteps)
+	}
+	if strings.Contains(report.NextSteps, "keploy rerecord") {
+		t.Errorf("next steps must not reference the nonexistent 'keploy rerecord' command: %q", report.NextSteps)
+	}
+}
+
+func TestBuilder_NoMocksPhase(t *testing.T) {
+	report := NewReport(ProtocolGeneric, "opaque exchange").
+		WithPhase(models.MatchPhaseNoMocks, 0).Build()
+	if !strings.Contains(report.NextSteps, "keploy record") {
+		t.Errorf("no-mocks phase should point at 'keploy record', got %q", report.NextSteps)
+	}
+}
+
+func TestBuilder_StructuralChangeNextSteps(t *testing.T) {
+	report := NewReport(ProtocolHTTP, "GET /a").
+		WithPhase(models.MatchPhaseSchema, 5).
+		WithClosest("mock-1", []models.MockFieldDiff{
+			{Path: "body.new_field", Kind: models.DiffKindMissingInMock, Actual: "1"},
+		}).Build()
+	if !strings.Contains(report.NextSteps, "keploy record") {
+		t.Errorf("structural change should suggest re-record, got %q", report.NextSteps)
+	}
+}
+
+func TestBuilder_FieldDiffCap(t *testing.T) {
+	diffs := make([]models.MockFieldDiff, maxFieldDiffs+10)
+	for i := range diffs {
+		diffs[i] = models.MockFieldDiff{Path: "body.x", Kind: models.DiffKindValueChanged}
+	}
+	report := NewReport(ProtocolHTTP, "GET /a").WithClosest("m", diffs).Build()
+	if len(report.FieldDiffs) != maxFieldDiffs {
+		t.Errorf("expected diff cap %d, got %d", maxFieldDiffs, len(report.FieldDiffs))
+	}
+}
+
+func TestJSONBodyDiffs_RespectsIgnoreAndReportsValues(t *testing.T) {
+	recorded := `{"id":"abc","ts":"111","nested":{"v":1}}`
+	live := `{"id":"abc","ts":"222","nested":{"v":2}}`
+
+	diffs := JSONBodyDiffs(recorded, live, map[string][]string{"ts": {}})
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff (ts ignored), got %d: %+v", len(diffs), diffs)
+	}
+	d := diffs[0]
+	if d.Path != "body.nested.v" || d.Kind != models.DiffKindValueChanged || d.Expected != "1" || d.Actual != "2" {
+		t.Errorf("unexpected diff: %+v", d)
+	}
+}
+
+func TestHeaderKeyDiffs_SkipsNoiseAndKeployHeaders(t *testing.T) {
+	recorded := map[string]string{
+		"Authorization":  "sig",      // in noise → skipped
+		"X-Custom":       "v",        // missing in live → reported
+		"Keploy-Test-Id": "test-1",   // keploy header → skipped
+		"Content-Type":   "app/json", // present both → not reported
+	}
+	live := http.Header{
+		"Content-Type": {"app/json"},
+		"X-New":        {"n"}, // missing in recording → reported
+	}
+	noise := map[string][]string{"authorization": {}}
+
+	diffs := HeaderKeyDiffs(recorded, live, noise)
+	got := map[string]models.MockFieldDiffKind{}
+	for _, d := range diffs {
+		got[d.Path] = d.Kind
+	}
+	if got["header.X-Custom"] != models.DiffKindMissingInLive {
+		t.Errorf("expected header.X-Custom missing_in_live, got %+v", diffs)
+	}
+	if got["header.X-New"] != models.DiffKindMissingInMock {
+		t.Errorf("expected header.X-New missing_in_mock, got %+v", diffs)
+	}
+	if _, ok := got["header.Authorization"]; ok {
+		t.Errorf("noised header must not be reported: %+v", diffs)
+	}
+	if _, ok := got["header.Keploy-Test-Id"]; ok {
+		t.Errorf("keploy header must not be reported: %+v", diffs)
+	}
+}
+
+func TestQueryParamDiffs(t *testing.T) {
+	recorded := map[string][]string{"page": {"1"}, "old": {"x"}}
+	live := map[string][]string{"page": {"2"}, "new": {"y"}}
+
+	diffs := QueryParamDiffs(recorded, live)
+	got := map[string]models.MockFieldDiff{}
+	for _, d := range diffs {
+		got[d.Path] = d
+	}
+	if d := got["query.page"]; d.Kind != models.DiffKindValueChanged || d.Expected != "1" || d.Actual != "2" {
+		t.Errorf("query.page diff wrong: %+v", d)
+	}
+	if d := got["query.old"]; d.Kind != models.DiffKindMissingInLive {
+		t.Errorf("query.old diff wrong: %+v", d)
+	}
+	if d := got["query.new"]; d.Kind != models.DiffKindMissingInMock {
+		t.Errorf("query.new diff wrong: %+v", d)
+	}
+}
+
+func TestRenderFieldDiffs_AllKinds(t *testing.T) {
+	out := RenderFieldDiffs([]models.MockFieldDiff{
+		{Path: "body.a", Kind: models.DiffKindValueChanged, Expected: "1", Actual: "2"},
+		{Path: "header.B", Kind: models.DiffKindMissingInLive, Expected: "x"},
+		{Path: "query.c", Kind: models.DiffKindMissingInMock, Actual: "y"},
+		{Path: "body.d", Kind: models.DiffKindTypeChanged, Expected: "string: s", Actual: "number: 1"},
+	})
+	for _, want := range []string{"body.a", "header.B", "query.c", "body.d", "absent in live", "absent in recording", "type changed"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered diff missing %q: %s", want, out)
+		}
+	}
+}

--- a/pkg/agent/proxy/integrations/mysql/replayer/query.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/query.go
@@ -137,7 +137,7 @@ func simulateCommandPhase(ctx context.Context, logger *zap.Logger, clientConn ne
 					zap.Int("commands_processed", commandCount),
 					zap.String("request_type", req.Header.Type),
 					zap.String("closest_mock", closestMockName))
-				baseErr := fmt.Errorf("error while simulating the command phase due to no matching mock found")
+				baseErr := fmt.Errorf("error while simulating the command phase: %w", models.ErrNoMockMatched)
 				return models.NewMockMismatchError(baseErr, report)
 			}
 

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -2671,11 +2671,28 @@ func (p *Proxy) GetMockErrors(_ context.Context) ([]models.UnmatchedCall, error)
 		if parserErr, ok := err.(models.ParserError); ok && parserErr.ParserErrorType == models.ErrMockNotFound {
 			if parserErr.MismatchReport != nil {
 				errs = append(errs, models.UnmatchedCall{
-					Protocol:      parserErr.MismatchReport.Protocol,
-					ActualSummary: parserErr.MismatchReport.ActualSummary,
-					ClosestMock:   parserErr.MismatchReport.ClosestMock,
-					Diff:          parserErr.MismatchReport.Diff,
-					NextSteps:     parserErr.MismatchReport.NextSteps,
+					Protocol:       parserErr.MismatchReport.Protocol,
+					ActualSummary:  parserErr.MismatchReport.ActualSummary,
+					ClosestMock:    parserErr.MismatchReport.ClosestMock,
+					Diff:           parserErr.MismatchReport.Diff,
+					NextSteps:      parserErr.MismatchReport.NextSteps,
+					MatchPhase:     parserErr.MismatchReport.MatchPhase,
+					CandidateCount: parserErr.MismatchReport.CandidateCount,
+					FieldDiffs:     parserErr.MismatchReport.FieldDiffs,
+				})
+			} else {
+				// A miss without a structured report must still reach the
+				// user's report — silently dropping it here is how whole
+				// protocols' misses used to vanish from
+				// FailureInfo.UnmatchedCalls.
+				summary := ""
+				if parserErr.Err != nil {
+					summary = parserErr.Err.Error()
+				}
+				errs = append(errs, models.UnmatchedCall{
+					Protocol:      "unknown",
+					ActualSummary: summary,
+					NextSteps:     "This protocol's matcher does not emit structured mismatch reports yet; check the agent logs around this test for the mock-miss details.",
 				})
 			}
 		}

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -2680,18 +2680,18 @@ func (p *Proxy) GetMockErrors(_ context.Context) ([]models.UnmatchedCall, error)
 					CandidateCount: parserErr.MismatchReport.CandidateCount,
 					FieldDiffs:     parserErr.MismatchReport.FieldDiffs,
 				})
-			} else {
-				// A miss without a structured report must still reach the
-				// user's report — silently dropping it here is how whole
+			} else if errors.Is(parserErr.Err, models.ErrNoMockMatched) {
+				// A genuine miss without a structured report must still reach
+				// the user's report — silently dropping it here is how whole
 				// protocols' misses used to vanish from
-				// FailureInfo.UnmatchedCalls.
-				summary := ""
-				if parserErr.Err != nil {
-					summary = parserErr.Err.Error()
-				}
+				// FailureInfo.UnmatchedCalls. Errors that are NOT wrapped
+				// around models.ErrNoMockMatched are infrastructure/decode
+				// failures mislabeled by sendMockNotFoundError; reporting
+				// them as unmatched calls would misdirect the user, so they
+				// stay out of the report (they are already logged).
 				errs = append(errs, models.UnmatchedCall{
 					Protocol:      "unknown",
-					ActualSummary: summary,
+					ActualSummary: parserErr.Err.Error(),
 					NextSteps:     "This protocol's matcher does not emit structured mismatch reports yet; check the agent logs around this test for the mock-miss details.",
 				})
 			}

--- a/pkg/matcher/risk.go
+++ b/pkg/matcher/risk.go
@@ -168,6 +168,78 @@ func ChangedJSONFieldPaths(expJSON, actJSON string, known map[string][]string, e
 	return out
 }
 
+// JSONFieldDiffs returns field-level diffs between two JSON documents with
+// recorded/live values attached, for mock-mismatch reporting. It walks both
+// documents with the same traversal as ComputeFailureAssessmentJSON (arrays
+// normalize to a "[]" path suffix) and skips paths covered by `known` noise
+// (path -> regex list, root-relative). `pathPrefix` (e.g. "body.") is
+// prepended to every returned path so the result lines up with the noise
+// config vocabulary. Values are truncated to maxVal runes to keep reports
+// and yaml output bounded. Returns nil when either side isn't valid JSON.
+func JSONFieldDiffs(expJSON, actJSON string, known map[string][]string, pathPrefix string, maxVal int) []models.MockFieldDiff {
+	if !json.Valid([]byte(expJSON)) || !json.Valid([]byte(actJSON)) {
+		return nil
+	}
+
+	var exp, act interface{}
+	if err := json.Unmarshal([]byte(expJSON), &exp); err != nil {
+		return nil
+	}
+	if err := json.Unmarshal([]byte(actJSON), &act); err != nil {
+		return nil
+	}
+
+	idx := buildNoiseIndex(known)
+
+	expMaps := pathMaps{types: map[string]string{}, values: map[string]string{}}
+	actMaps := pathMaps{types: map[string]string{}, values: map[string]string{}}
+
+	collectJSON(exp, "", idx, &expMaps)
+	collectJSON(act, "", idx, &actMaps)
+
+	added, removed, typeChanges, valueChanges := diffMaps(expMaps, actMaps)
+
+	trunc := func(s string) string {
+		if maxVal > 0 && len(s) > maxVal {
+			return s[:maxVal] + "…"
+		}
+		return s
+	}
+
+	var out []models.MockFieldDiff
+	for _, p := range valueChanges {
+		out = append(out, models.MockFieldDiff{
+			Path:     pathPrefix + p,
+			Kind:     models.DiffKindValueChanged,
+			Expected: trunc(expMaps.values[p]),
+			Actual:   trunc(actMaps.values[p]),
+		})
+	}
+	for _, p := range typeChanges {
+		out = append(out, models.MockFieldDiff{
+			Path:     pathPrefix + p,
+			Kind:     models.DiffKindTypeChanged,
+			Expected: trunc(expMaps.types[p] + ": " + expMaps.values[p]),
+			Actual:   trunc(actMaps.types[p] + ": " + actMaps.values[p]),
+		})
+	}
+	for _, p := range removed {
+		out = append(out, models.MockFieldDiff{
+			Path:     pathPrefix + p,
+			Kind:     models.DiffKindMissingInLive,
+			Expected: trunc(expMaps.values[p]),
+		})
+	}
+	for _, p := range added {
+		out = append(out, models.MockFieldDiff{
+			Path:   pathPrefix + p,
+			Kind:   models.DiffKindMissingInMock,
+			Actual: trunc(actMaps.values[p]),
+		})
+	}
+	return out
+}
+
 func collectJSON(v interface{}, path string, ni noiseIndex, out *pathMaps) {
 	keyLower := strings.ToLower(path)
 	if regs, noisy := ni.match(keyLower); noisy && len(regs) == 0 {

--- a/pkg/matcher/risk.go
+++ b/pkg/matcher/risk.go
@@ -3,8 +3,10 @@ package matcher
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"go.keploy.io/server/v3/pkg/models"
 )
@@ -174,8 +176,9 @@ func ChangedJSONFieldPaths(expJSON, actJSON string, known map[string][]string, e
 // normalize to a "[]" path suffix) and skips paths covered by `known` noise
 // (path -> regex list, root-relative). `pathPrefix` (e.g. "body.") is
 // prepended to every returned path so the result lines up with the noise
-// config vocabulary. Values are truncated to maxVal runes to keep reports
-// and yaml output bounded. Returns nil when either side isn't valid JSON.
+// config vocabulary. Values are truncated to at most maxVal bytes (cut at a
+// rune boundary) to keep reports and yaml output bounded. Returns nil when
+// either side isn't valid JSON.
 func JSONFieldDiffs(expJSON, actJSON string, known map[string][]string, pathPrefix string, maxVal int) []models.MockFieldDiff {
 	if !json.Valid([]byte(expJSON)) || !json.Valid([]byte(actJSON)) {
 		return nil
@@ -199,11 +202,26 @@ func JSONFieldDiffs(expJSON, actJSON string, known map[string][]string, pathPref
 
 	added, removed, typeChanges, valueChanges := diffMaps(expMaps, actMaps)
 
+	// diffMaps iterates Go maps, so bucket order is randomized per run; sort
+	// each bucket so reports, yaml output and the capped diff subset are
+	// stable across runs.
+	sort.Strings(added)
+	sort.Strings(removed)
+	sort.Strings(typeChanges)
+	sort.Strings(valueChanges)
+
 	trunc := func(s string) string {
-		if maxVal > 0 && len(s) > maxVal {
-			return s[:maxVal] + "…"
+		if maxVal <= 0 || len(s) <= maxVal {
+			return s
 		}
-		return s
+		// Back the cut off to a rune boundary so a multi-byte UTF-8
+		// character is never split — invalid UTF-8 here would garble the
+		// report yaml/json encoders downstream.
+		cut := maxVal
+		for cut > 0 && !utf8.RuneStart(s[cut]) {
+			cut--
+		}
+		return s[:cut] + "…"
 	}
 
 	var out []models.MockFieldDiff

--- a/pkg/matcher/risk_fielddiffs_test.go
+++ b/pkg/matcher/risk_fielddiffs_test.go
@@ -1,0 +1,56 @@
+package matcher
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+func TestJSONFieldDiffs_KindsValuesAndNoise(t *testing.T) {
+	exp := `{"id":"a","ts":"1","gone":"g","typ":1,"same":"s"}`
+	act := `{"id":"b","ts":"2","typ":"now-string","same":"s","added":true}`
+
+	diffs := JSONFieldDiffs(exp, act, map[string][]string{"ts": {}}, "body.", 0)
+
+	got := map[string]models.MockFieldDiff{}
+	for _, d := range diffs {
+		got[d.Path] = d
+	}
+
+	if d := got["body.id"]; d.Kind != models.DiffKindValueChanged || d.Expected != "a" || d.Actual != "b" {
+		t.Errorf("body.id diff wrong: %+v", d)
+	}
+	if d := got["body.gone"]; d.Kind != models.DiffKindMissingInLive || d.Expected != "g" {
+		t.Errorf("body.gone diff wrong: %+v", d)
+	}
+	if d := got["body.typ"]; d.Kind != models.DiffKindTypeChanged {
+		t.Errorf("body.typ diff wrong: %+v", d)
+	}
+	if d := got["body.added"]; d.Kind != models.DiffKindMissingInMock || d.Actual != "true" {
+		t.Errorf("body.added diff wrong: %+v", d)
+	}
+	if _, ok := got["body.ts"]; ok {
+		t.Errorf("noised path body.ts must not be reported: %+v", diffs)
+	}
+	if _, ok := got["body.same"]; ok {
+		t.Errorf("unchanged path body.same must not be reported: %+v", diffs)
+	}
+}
+
+func TestJSONFieldDiffs_TruncatesValues(t *testing.T) {
+	exp := `{"v":"aaaaaaaaaaaaaaaaaaaa"}`
+	act := `{"v":"bbbbbbbbbbbbbbbbbbbb"}`
+	diffs := JSONFieldDiffs(exp, act, nil, "body.", 5)
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	if len(diffs[0].Expected) > 9 || len(diffs[0].Actual) > 9 { // 5 bytes + ellipsis rune
+		t.Errorf("values not truncated: %+v", diffs[0])
+	}
+}
+
+func TestJSONFieldDiffs_InvalidJSONReturnsNil(t *testing.T) {
+	if d := JSONFieldDiffs("not-json", `{"a":1}`, nil, "body.", 0); d != nil {
+		t.Errorf("expected nil for invalid JSON, got %+v", d)
+	}
+}

--- a/pkg/models/errors.go
+++ b/pkg/models/errors.go
@@ -1,6 +1,9 @@
 package models
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 type AppError struct {
 	AppErrorType AppErrorType
@@ -78,6 +81,12 @@ type MockMismatchReport struct {
 	CandidateCount int             // protocol mocks considered before giving up
 	FieldDiffs     []MockFieldDiff // field-level diffs vs the closest mock, noise-vocabulary paths
 }
+
+// ErrNoMockMatched is the sentinel for a genuine mock miss — an outgoing call
+// for which no recorded mock matched. Protocol parsers wrap it (errors.Is)
+// when they report a miss, so the proxy can distinguish real misses from
+// infrastructure/decode failures when building UnmatchedCalls for reports.
+var ErrNoMockMatched = errors.New("no matching mock found")
 
 type ParserError struct {
 	ParserErrorType ParserErrorType

--- a/pkg/models/errors.go
+++ b/pkg/models/errors.go
@@ -27,15 +27,56 @@ const (
 	ErrTestBinStopped AppErrorType = "test binary stopped"
 )
 
+// MockFieldDiffKind classifies a single field-level divergence between a live
+// outgoing request and the closest recorded mock.
+type MockFieldDiffKind string
+
+const (
+	DiffKindValueChanged  MockFieldDiffKind = "value_changed"   // same field, different value
+	DiffKindTypeChanged   MockFieldDiffKind = "type_changed"    // same field, different JSON type
+	DiffKindMissingInLive MockFieldDiffKind = "missing_in_live" // recorded mock has it, live request doesn't
+	DiffKindMissingInMock MockFieldDiffKind = "missing_in_mock" // live request has it, recorded mock doesn't
+)
+
+// MockFieldDiff is one field-level difference between the live request and the
+// closest candidate mock. Path uses the same vocabulary as the noise
+// configuration (pkg/matcher): "body.<dotted.json.path>", "header.<name>",
+// "query.<name>", plus the pseudo-fields "method" and "path". This shared
+// grammar is deliberate: a user can copy Path straight into
+// test.globalNoise / spec.assertions.noise.
+type MockFieldDiff struct {
+	Path     string            `json:"path" yaml:"path"`
+	Kind     MockFieldDiffKind `json:"kind,omitempty" yaml:"kind,omitempty"`
+	Expected string            `json:"expected,omitempty" yaml:"expected,omitempty"` // recorded (mock) value
+	Actual   string            `json:"actual,omitempty" yaml:"actual,omitempty"`     // live request value
+}
+
+// Match-cascade phases recorded on MockMismatchReport.MatchPhase. They tell
+// the user how far the matcher got before giving up, which determines the
+// right remediation (re-record vs add noise vs fix candidate selection).
+const (
+	MatchPhaseNoMocks    = "no_mocks"             // mock pool for this protocol is empty
+	MatchPhaseSchema     = "no_schema_candidates" // nothing matched method/path/header-keys/query-keys
+	MatchPhaseBody       = "body_mismatch"        // schema candidates existed, request body ruled them all out
+	MatchPhaseStrict     = "strict_noise_reject"  // candidates rejected by strict req-body-noise enforcement
+	MatchPhaseExhausted  = "no_match"             // full cascade ran and nothing matched
+	MatchPhaseProtoError = "protocol_error"       // matching aborted on a protocol/decode error
+)
+
 // MockMismatchReport describes what didn't match when a mock lookup fails.
 // It is populated by protocol-specific matching logic and surfaced to the user
-// in the CLI mismatch table.
+// in the CLI mismatch table, the test-report yaml (FailureInfo.UnmatchedCalls)
+// and the platform/UI APIs. Protocol parsers should build it via
+// pkg/agent/proxy/integrations/mismatch so vocabulary stays uniform.
 type MockMismatchReport struct {
-	Protocol      string // "HTTP", "MySQL", "PostgreSQL", "MongoDB", "gRPC", "HTTP/2", "Generic", "DNS"
-	ActualSummary string // Brief description of the actual request
-	ClosestMock   string // Name of the closest mock (empty if none)
-	Diff          string // Human-readable diff (protocol-specific)
-	NextSteps     string // Actionable suggestion for the user
+	Protocol       string          // "HTTP", "MySQL", "PostgreSQL", "MongoDB", "gRPC", "HTTP/2", "Generic", "DNS"
+	ActualSummary  string          // Brief description of the actual request
+	ClosestMock    string          // Name of the closest mock (empty if none)
+	Diff           string          // Human-readable diff (protocol-specific)
+	NextSteps      string          // Actionable suggestion for the user
+	MatchPhase     string          // how far the match cascade got (MatchPhase* constants)
+	CandidateCount int             // protocol mocks considered before giving up
+	FieldDiffs     []MockFieldDiff // field-level diffs vs the closest mock, noise-vocabulary paths
 }
 
 type ParserError struct {

--- a/pkg/models/testrun.go
+++ b/pkg/models/testrun.go
@@ -132,6 +132,14 @@ type UnmatchedCall struct {
 	ClosestMock   string `json:"closest_mock,omitempty" yaml:"closest_mock,omitempty"`     // internal mock reference for View Closest
 	Diff          string `json:"diff,omitempty" yaml:"diff,omitempty"`
 	NextSteps     string `json:"next_steps,omitempty" yaml:"next_steps,omitempty"` // actionable remediation guidance from the matcher
+	// MatchPhase, CandidateCount and FieldDiffs mirror MockMismatchReport so
+	// report consumers (CLI `keploy report`, report yaml, platform UI) can
+	// render structured field-level drift instead of an opaque string. Paths
+	// in FieldDiffs use the noise-config vocabulary and can be copied
+	// verbatim into test.globalNoise / spec.assertions.noise.
+	MatchPhase     string          `json:"match_phase,omitempty" yaml:"match_phase,omitempty"`
+	CandidateCount int             `json:"candidate_count,omitempty" yaml:"candidate_count,omitempty"`
+	FieldDiffs     []MockFieldDiff `json:"field_diffs,omitempty" yaml:"field_diffs,omitempty"`
 }
 
 // MockSummaryFromSpec builds a protocol-generic summary string from a mock's spec.

--- a/pkg/platform/yaml/mockdb/db.go
+++ b/pkg/platform/yaml/mockdb/db.go
@@ -589,29 +589,43 @@ func (ys *MockYaml) updateMocksGob(ctx context.Context, testSetID, gobPath strin
 		}
 	}
 
-	// Atomic rewrite: write to a sibling tmp file under the same
-	// directory, then rename over gobPath. os.Rename on the same
-	// filesystem is atomic, so a concurrent reader either sees the
-	// full old file or the full new one.
-	//
-	// Preserve the existing file's permissions across the rewrite.
-	// os.CreateTemp creates its file 0600, so without the chmod below
-	// pruning would quietly narrow mocks.gob from whatever mode the
-	// record writer produced (typically 0644 via umask 0022) down to
-	// owner-only, which breaks replay for any other user/process on
-	// the box. Stat before CreateTemp: if the source file is gone,
-	// fall back to the same mode the gob writer uses when it opens
-	// mocks.gob fresh (0644) so we do not introduce a new
-	// mode-inheritance path.
+	if err := writeGobMocksAtomically(ctx, gobPath, newMocks); err != nil {
+		return err
+	}
+
+	ys.Logger.Debug("pruned mocks successfully (gob)",
+		zap.String("testSetID", testSetID),
+		zap.Int("total", len(mocks)),
+		zap.Int("kept", len(newMocks)),
+		zap.Int("pruned", prunedCount),
+		zap.Any("prunedMocks", prunedMocks),
+		zap.Bool("prunedMocksTruncated", prunedCount > len(prunedMocks)),
+		zap.Time("pruneBefore", pruneBefore))
+	return nil
+}
+
+// writeGobMocksAtomically rewrites gobPath with the given mocks via a
+// sibling tmp file + rename. os.Rename on the same filesystem is atomic, so
+// a concurrent reader either sees the full old file or the full new one.
+//
+// Preserve the existing file's permissions across the rewrite.
+// os.CreateTemp creates its file 0600, so without the chmod below the
+// rewrite would quietly narrow mocks.gob from whatever mode the record
+// writer produced (typically 0644 via umask 0022) down to owner-only, which
+// breaks replay for any other user/process on the box. Stat before
+// CreateTemp: if the source file is gone, fall back to the same mode the gob
+// writer uses when it opens mocks.gob fresh (0644) so we do not introduce a
+// new mode-inheritance path.
+func writeGobMocksAtomically(ctx context.Context, gobPath string, mocks []*models.Mock) error {
 	dir := filepath.Dir(gobPath)
 	base := filepath.Base(gobPath)
 	var originalMode os.FileMode = 0644
 	if info, statErr := os.Stat(gobPath); statErr == nil {
 		originalMode = info.Mode().Perm()
 	}
-	tmp, err := os.CreateTemp(dir, base+".prune.*.tmp")
+	tmp, err := os.CreateTemp(dir, base+".rewrite.*.tmp")
 	if err != nil {
-		return fmt.Errorf("create gob prune tmp: %w", err)
+		return fmt.Errorf("create gob rewrite tmp: %w", err)
 	}
 	tmpPath := tmp.Name()
 	cleanup := true
@@ -625,19 +639,19 @@ func (ys *MockYaml) updateMocksGob(ctx context.Context, testSetID, gobPath strin
 	// renamed file.
 	if err := os.Chmod(tmpPath, originalMode); err != nil {
 		_ = tmp.Close()
-		return fmt.Errorf("chmod gob prune tmp to %o: %w", originalMode, err)
+		return fmt.Errorf("chmod gob rewrite tmp to %o: %w", originalMode, err)
 	}
 
 	bw := bufio.NewWriterSize(tmp, 256*1024)
 	if _, err := bw.WriteString(gobMockMagic); err != nil {
 		_ = tmp.Close()
-		return fmt.Errorf("write gob magic to prune tmp: %w", err)
+		return fmt.Errorf("write gob magic to rewrite tmp: %w", err)
 	}
 	enc := gob.NewEncoder(bw)
-	for i, mock := range newMocks {
-		// Same cancellation cadence as the filter loop above — the
-		// encode pass is the expensive one (reflect-heavy) so an
-		// op at cancellation is worth the early exit cost.
+	for i, mock := range mocks {
+		// Check ctx every 1024 entries — the encode pass is the
+		// expensive one (reflect-heavy) so an op at cancellation is
+		// worth the early exit cost.
 		if i&0x3ff == 0 {
 			if err := ctx.Err(); err != nil {
 				_ = tmp.Close()
@@ -646,33 +660,157 @@ func (ys *MockYaml) updateMocksGob(ctx context.Context, testSetID, gobPath strin
 		}
 		if err := enc.Encode(mock); err != nil {
 			_ = tmp.Close()
-			return fmt.Errorf("encode mock during gob prune: %w", err)
+			return fmt.Errorf("encode mock during gob rewrite: %w", err)
 		}
 	}
 	if err := bw.Flush(); err != nil {
 		_ = tmp.Close()
-		return fmt.Errorf("flush gob prune tmp: %w", err)
+		return fmt.Errorf("flush gob rewrite tmp: %w", err)
 	}
 	if err := tmp.Sync(); err != nil {
 		_ = tmp.Close()
-		return fmt.Errorf("sync gob prune tmp: %w", err)
+		return fmt.Errorf("sync gob rewrite tmp: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("close gob prune tmp: %w", err)
+		return fmt.Errorf("close gob rewrite tmp: %w", err)
 	}
 	if err := os.Rename(tmpPath, gobPath); err != nil {
-		return fmt.Errorf("rename gob prune tmp over %s: %w", gobPath, err)
+		return fmt.Errorf("rename gob rewrite tmp over %s: %w", gobPath, err)
 	}
 	cleanup = false
+	return nil
+}
 
-	ys.Logger.Debug("pruned mocks successfully (gob)",
-		zap.String("testSetID", testSetID),
-		zap.Int("total", len(mocks)),
-		zap.Int("kept", len(newMocks)),
-		zap.Int("pruned", prunedCount),
-		zap.Any("prunedMocks", prunedMocks),
-		zap.Bool("prunedMocksTruncated", prunedCount > len(prunedMocks)),
-		zap.Time("pruneBefore", pruneBefore))
+// PersistMockNoise merges learned request-body noise (MockState.ReqBodyNoise,
+// detected under --schema-noise-detection) into the on-disk mocks WITHOUT
+// pruning anything. This is the persistence path when mock pruning
+// (--remove-unused-mocks) is not enabled — previously the learned noise rode
+// only inside UpdateMocks, so running detection without pruning silently
+// discarded everything that was learned at process exit.
+func (ys *MockYaml) PersistMockNoise(ctx context.Context, testSetID string, mockStates map[string]models.MockState) error {
+	// Only mocks that actually carry learned noise matter.
+	withNoise := make(map[string]map[string][]string)
+	for name, st := range mockStates {
+		if len(st.ReqBodyNoise) > 0 {
+			withNoise[name] = st.ReqBodyNoise
+		}
+	}
+	if len(withNoise) == 0 {
+		return nil
+	}
+
+	mockFileName := "mocks"
+	if ys.MockName != "" {
+		mockFileName = ys.MockName
+	}
+	path := filepath.Join(ys.MockPath, testSetID)
+	lock := getMockFileLock(mockFileLockKey(path, mockFileName, ys.Format))
+	lock.Lock()
+	defer lock.Unlock()
+
+	// merge applies the learned noise; returns true when any mock changed
+	// so unchanged files are never rewritten.
+	merge := func(mocks []*models.Mock) bool {
+		changed := false
+		for _, mock := range mocks {
+			noise, ok := withNoise[mock.Name]
+			if !ok || mock.Kind != models.Kind(models.HTTP) || mock.Spec.HTTPReq == nil {
+				continue
+			}
+			merged := mergeReqBodyNoise(mock.Spec.HTTPReq.ReqBodyNoise, noise)
+			if len(merged) != len(mock.Spec.HTTPReq.ReqBodyNoise) {
+				changed = true
+			}
+			mock.Spec.HTTPReq.ReqBodyNoise = merged
+		}
+		return changed
+	}
+
+	logPersisted := func(total int) {
+		ys.Logger.Info("persisted learned request-body noise onto mocks",
+			zap.String("testSetID", testSetID),
+			zap.Int("mocksWithLearnedNoise", len(withNoise)),
+			zap.Int("totalMocks", total))
+	}
+
+	gobPath := filepath.Join(path, mockFileName+".gob")
+	if _, err := os.Stat(gobPath); err == nil {
+		// Quiesce any in-flight async gob writer before the rewrite —
+		// same reasoning as updateMocksGob.
+		if err := ys.Close(); err != nil {
+			utils.LogError(ys.Logger, err, "failed to quiesce async gob writer before noise persistence", zap.String("path", gobPath))
+			return err
+		}
+		mocks, err := readGobMocks(gobPath)
+		if err != nil {
+			return err
+		}
+		if !merge(mocks) {
+			return nil
+		}
+		if err := writeGobMocksAtomically(ctx, gobPath, mocks); err != nil {
+			return err
+		}
+		logPersisted(len(mocks))
+		return nil
+	}
+
+	existsAny, detectedFormat, err := yaml.FileExistsAny(ctx, ys.Logger, path, mockFileName, ys.Format)
+	if err != nil {
+		return err
+	}
+	if !existsAny {
+		return nil
+	}
+
+	reader, err := yaml.NewMockReaderF(ctx, ys.Logger, path, mockFileName, detectedFormat)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	var mocks []*models.Mock
+	if reader.Format() == yaml.FormatJSON {
+		var jsonDocs []*yaml.NetworkTrafficDocJSON
+		for {
+			jd, err := reader.ReadNextDocJSON()
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			if err != nil {
+				return fmt.Errorf("failed to decode the file documents for noise persistence: %w", err)
+			}
+			jsonDocs = append(jsonDocs, jd)
+		}
+		mocks, err = DecodeMocksJSON(jsonDocs, ys.Logger)
+		if err != nil {
+			return err
+		}
+	} else {
+		var docs []*yaml.NetworkTrafficDoc
+		for {
+			doc, err := reader.ReadNextDoc()
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			if err != nil {
+				return fmt.Errorf("failed to decode the file documents for noise persistence: %w", err)
+			}
+			docs = append(docs, doc)
+		}
+		mocks, err = DecodeMocks(docs, ys.Logger)
+		if err != nil {
+			return err
+		}
+	}
+
+	if !merge(mocks) {
+		return nil
+	}
+	if err := ys.writeMocksAtomically(path, mockFileName, mocks, detectedFormat); err != nil {
+		return err
+	}
+	logPersisted(len(mocks))
 	return nil
 }
 

--- a/pkg/platform/yaml/mockdb/persist_noise_test.go
+++ b/pkg/platform/yaml/mockdb/persist_noise_test.go
@@ -1,0 +1,105 @@
+package mockdb
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+func noiseTestMock(body string) *models.Mock {
+	return &models.Mock{
+		Version: "api.keploy.io/v1beta1",
+		Kind:    models.HTTP,
+		Spec: models.MockSpec{
+			Metadata: map[string]string{"src": "noisetest"},
+			HTTPReq: &models.HTTPReq{
+				Method: "POST", URL: "http://x/y", ProtoMajor: 1, ProtoMinor: 1,
+				Header: map[string]string{"Content-Type": "application/json"},
+				Body:   body,
+			},
+			HTTPResp: &models.HTTPResp{StatusCode: 200, StatusMessage: "OK", Body: `{"ok":true}`},
+		},
+	}
+}
+
+// PersistMockNoise must write learned req_body_noise onto the on-disk mock
+// WITHOUT pruning the other mocks — that's the whole point: detection without
+// --remove-unused-mocks used to discard everything learned.
+func TestPersistMockNoise_WritesNoiseWithoutPruning(t *testing.T) {
+	dir := t.TempDir()
+	ys := New(zap.NewNop(), dir, "")
+	ctx := context.Background()
+	testSet := "test-set-1"
+
+	// Two mocks; only mock-0 learns noise. mock-1 must survive untouched.
+	if err := ys.InsertMock(ctx, noiseTestMock(`{"request_id":"r-1"}`), testSet); err != nil {
+		t.Fatal(err)
+	}
+	if err := ys.InsertMock(ctx, noiseTestMock(`{"other":"o"}`), testSet); err != nil {
+		t.Fatal(err)
+	}
+	if err := ys.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ys.PersistMockNoise(ctx, testSet, map[string]models.MockState{
+		"mock-0": {Name: "mock-0", ReqBodyNoise: map[string][]string{"body.request_id": {}}},
+		// A consumed mock with no learned noise must be a no-op entry.
+		"mock-1": {Name: "mock-1"},
+	})
+	if err != nil {
+		t.Fatalf("PersistMockNoise: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, testSet, "mocks.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "req_body_noise") || !strings.Contains(content, "body.request_id") {
+		t.Errorf("learned noise not persisted; file:\n%s", content)
+	}
+	// No pruning: both mocks still present.
+	if !strings.Contains(content, `"other"`) {
+		t.Errorf("unrelated mock was lost during noise persistence; file:\n%s", content)
+	}
+}
+
+// A state map with no learned noise must not rewrite the file at all.
+func TestPersistMockNoise_NoNoiseIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	ys := New(zap.NewNop(), dir, "")
+	ctx := context.Background()
+	testSet := "test-set-1"
+
+	if err := ys.InsertMock(ctx, noiseTestMock(`{"a":"b"}`), testSet); err != nil {
+		t.Fatal(err)
+	}
+	if err := ys.Close(); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, testSet, "mocks.yaml")
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ys.PersistMockNoise(ctx, testSet, map[string]models.MockState{
+		"mock-0": {Name: "mock-0"},
+	}); err != nil {
+		t.Fatalf("PersistMockNoise: %v", err)
+	}
+
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !after.ModTime().Equal(before.ModTime()) {
+		t.Errorf("file rewritten despite no learned noise")
+	}
+}

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -751,7 +751,11 @@ func (r *Replayer) Start(ctx context.Context) error {
 	if !abortTestRun {
 		r.printSummary(ctx, testRunResult)
 
-		if !testRunResult && len(r.mockMismatchFailures.GetFailures()) > 0 && !r.config.DisableMapping {
+		// Print the mismatch table whenever there ARE mock mismatches — not
+		// only when the run as a whole failed. A green run with mock misses
+		// (e.g. tests demoted to OBSOLETE, or a protocol whose misses can't
+		// fail a test) is exactly the case the user must not stay blind to.
+		if len(r.mockMismatchFailures.GetFailures()) > 0 && !r.config.DisableMapping {
 			failuresByTestSet := make(map[string]bool)
 			for _, failure := range r.mockMismatchFailures.GetFailures() {
 				failuresByTestSet[failure.TestSetID] = true
@@ -762,7 +766,15 @@ func (r *Replayer) Start(ctx context.Context) error {
 				testSetIDs = append(testSetIDs, testSetID)
 			}
 			testSets := strings.Join(testSetIDs, ", ")
-			r.logger.Info("Some testsets failed due to mock differences. Please kindly rerecord these testsets to update the mocks.", zap.String("command", fmt.Sprintf("keploy rerecord -c '%s' -t %s", r.config.Command, testSets)))
+			if testRunResult {
+				r.logger.Warn("Tests passed, but some outgoing calls did not match the recorded mocks.",
+					zap.String("test_sets", testSets),
+					zap.String("next_steps", "Review the mismatch summary below. Add drifting dynamic fields as noise (test.globalNoise), or re-record the test-set with 'keploy record' if the request structure changed."))
+			} else {
+				r.logger.Info("Some testsets failed due to mock differences.",
+					zap.String("test_sets", testSets),
+					zap.String("next_steps", "Add drifting dynamic fields as noise (test.globalNoise); if the request structure changed, re-record the test-set with 'keploy record', or refresh mappings with --update-test-mapping."))
+			}
 
 			r.mockMismatchFailures.PrintFailuresTable()
 		}
@@ -2563,6 +2575,24 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		err = r.mockDB.UpdateMocks(runTestSetCtx, testSetID, passingTotalConsumedMocks, pruneBefore, firstTestCaseTime)
 		if err != nil {
 			utils.LogError(r.logger, err, "failed to delete unused mocks")
+		}
+	} else if r.config.Test.SchemaNoiseDetection && r.instrument {
+		// --schema-noise-detection without --remove-unused-mocks: the learned
+		// req_body_noise used to ride only inside UpdateMocks (the pruning
+		// path), so detection alone learned noise and threw it away at exit.
+		// Persist it through the prune-free path instead. We persist noise
+		// from ALL consumed mocks (not just passing tests): the mock matched,
+		// so the request-side drift it learned is valid even when the test
+		// later failed on its response.
+		type mockNoisePersister interface {
+			PersistMockNoise(ctx context.Context, testSetID string, mockStates map[string]models.MockState) error
+		}
+		if p, ok := r.mockDB.(mockNoisePersister); ok {
+			if err := p.PersistMockNoise(runTestSetCtx, testSetID, totalConsumedMocks); err != nil {
+				utils.LogError(r.logger, err, "failed to persist learned request-body noise onto mocks")
+			}
+		} else {
+			r.logger.Debug("mockDB implementation does not support prune-free noise persistence; learned req_body_noise not persisted")
 		}
 	}
 

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -755,9 +755,25 @@ func (r *Replayer) Start(ctx context.Context) error {
 		// only when the run as a whole failed. A green run with mock misses
 		// (e.g. tests demoted to OBSOLETE, or a protocol whose misses can't
 		// fail a test) is exactly the case the user must not stay blind to.
-		if len(r.mockMismatchFailures.GetFailures()) > 0 && !r.config.DisableMapping {
+		//
+		// Exception on green runs: DNS misses are answered with a synthetic
+		// response by design (the app keeps working), so on a fully passing
+		// run they are routine, not actionable — without this filter every
+		// healthy run with app-startup DNS chatter would print the table.
+		mismatchRows := r.mockMismatchFailures.GetFailures()
+		if testRunResult {
+			actionable := make([]TestFailure, 0, len(mismatchRows))
+			for _, f := range mismatchRows {
+				if f.FailureReason == models.ErrMockNotFound && f.MismatchReport != nil && f.MismatchReport.Protocol == "DNS" {
+					continue
+				}
+				actionable = append(actionable, f)
+			}
+			mismatchRows = actionable
+		}
+		if len(mismatchRows) > 0 && !r.config.DisableMapping {
 			failuresByTestSet := make(map[string]bool)
-			for _, failure := range r.mockMismatchFailures.GetFailures() {
+			for _, failure := range mismatchRows {
 				failuresByTestSet[failure.TestSetID] = true
 			}
 

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -785,11 +785,11 @@ func (r *Replayer) Start(ctx context.Context) error {
 			if testRunResult {
 				r.logger.Warn("Tests passed, but some outgoing calls did not match the recorded mocks.",
 					zap.String("test_sets", testSets),
-					zap.String("next_steps", "Review the mismatch summary below. Add drifting dynamic fields as noise (test.globalNoise), or re-record the test-set with 'keploy record' if the request structure changed."))
+					zap.String("next_step", "Review the mismatch summary below. Add drifting dynamic fields as noise (test.globalNoise), or re-record the test-set with 'keploy record' if the request structure changed."))
 			} else {
 				r.logger.Info("Some testsets failed due to mock differences.",
 					zap.String("test_sets", testSets),
-					zap.String("next_steps", "Add drifting dynamic fields as noise (test.globalNoise); if the request structure changed, re-record the test-set with 'keploy record', or refresh mappings with --update-test-mapping."))
+					zap.String("next_step", "Add drifting dynamic fields as noise (test.globalNoise); if the request structure changed, re-record the test-set with 'keploy record', or refresh mappings with --update-test-mapping."))
 			}
 
 			r.mockMismatchFailures.PrintFailuresTable()

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1030,9 +1030,21 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 	selectedTests := matcherUtils.ArrayToMap(r.config.Test.SelectedTests[testSetID])
 	// Map mock name to Kind for DNS filtering (mappings may have empty Kind)
 	mockKindByName := make(map[string]models.Kind)
+	// reusableMockNames marks mocks whose recorder-derived tier is reusable
+	// across tests (session / connection / config) or app-startup traffic —
+	// i.e. NOT per-test. They belong in the mapping (so the pool is complete)
+	// but are excluded from the per-test consumed-vs-expected assertion: only
+	// per-test mocks are deterministically attributed to a single test, so
+	// comparing reusable/startup mocks would falsely demote tests to OBSOLETE
+	// (the same reason DNS mocks are excluded). MockEntry carries no tier, so
+	// we derive it from the loaded mocks (which do, via TestModeInfo.Lifetime).
+	reusableMockNames := make(map[string]bool)
 	addKinds := func(mocks []*models.Mock) {
 		for _, m := range mocks {
 			mockKindByName[m.Name] = m.Kind
+			if isReusableTierMock(m) {
+				reusableMockNames[m.Name] = true
+			}
 		}
 	}
 
@@ -1693,6 +1705,13 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			expectedMocks, hasExpectedMocks := expectedTestMockMappings[testCase.Name]
 
 			// Compute non-DNS expected and consumed name slices once; reused for subset check and mismatch reporting.
+			// Only PER-TEST mocks participate in the consumed-vs-expected
+			// assertion. DNS (non-deterministic resolution order) and
+			// reusable/startup-tier mocks (session / connection / config,
+			// recorded once at app boot and shared across tests) stay in the
+			// mapping but are excluded here: they are not deterministically
+			// attributed to a single test's window, so including them would
+			// falsely demote tests to OBSOLETE.
 			filteredExpectedNames := make([]string, 0, len(expectedMocks))
 			for _, m := range expectedMocks {
 				isDNS := strings.EqualFold(m.Kind, string(models.DNS))
@@ -1701,28 +1720,31 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 						isDNS = true
 					}
 				}
-				if !isDNS {
-					filteredExpectedNames = append(filteredExpectedNames, m.Name)
+				if isDNS || reusableMockNames[m.Name] {
+					continue
 				}
+				filteredExpectedNames = append(filteredExpectedNames, m.Name)
 			}
 
 			filteredMockNames := make([]string, 0, len(consumedMocks))
 			for _, m := range consumedMocks {
-				if m.Kind != models.DNS {
-					filteredMockNames = append(filteredMockNames, m.Name)
+				if m.Kind == models.DNS || isReusableTierState(m) {
+					continue
 				}
+				filteredMockNames = append(filteredMockNames, m.Name)
 			}
 
 			mockSetMismatch := false
 			if r.instrument && useMappingBased && isMappingEnabled && hasExpectedMocks && instrumentConsumedFetchErr == nil {
-				// Filter out DNS mocks from comparison since DNS resolution
-				// order is non-deterministic. Also gate on a successful per-
-				// test GetConsumedMocks — when the fetch failed, consumedMocks
-				// was cleared to nil above, which would deterministically
-				// compute mockSetMismatch=true (empty subset of any non-empty
-				// expected set) and falsely mark the test OBSOLETE due to an
-				// unrelated transport error rather than a real mock-pool
-				// divergence.
+				// Compare only per-test mocks (DNS + reusable/startup tiers
+				// excluded above) since those are the only mocks
+				// deterministically tied to a single test. Also gate on a
+				// successful per-test GetConsumedMocks — when the fetch failed,
+				// consumedMocks was cleared to nil above, which would
+				// deterministically compute mockSetMismatch=true (empty subset
+				// of any non-empty expected set) and falsely mark the test
+				// OBSOLETE due to an unrelated transport error rather than a
+				// real mock-pool divergence.
 				mockSetMismatch = !isMockSubset(filteredMockNames, filteredExpectedNames)
 			}
 
@@ -3767,6 +3789,45 @@ func (r *Replayer) determineMockingStrategy(ctx context.Context, testSetID strin
 }
 
 // isMockSubset checks if all expected mocks are present in the actual mocks list
+// isReusableTierMock reports whether a loaded mock is a reusable, non-per-test
+// tier — session / connection / config — recorded once at app startup and
+// shared across every test rather than consumed by exactly one. Such mocks
+// belong in the per-test mapping (so the replay mock pool is complete) but
+// must be excluded from the per-test consumed-vs-expected assertion: they are
+// not deterministically attributed to a single test's window, so comparing
+// them would falsely demote tests to OBSOLETE. Only per-test mocks are
+// compared. Tier is read from TestModeInfo.Lifetime (derived at ingest) with
+// Spec.Metadata["type"] as a fallback for mocks whose lifetime wasn't derived.
+func isReusableTierMock(m *models.Mock) bool {
+	switch m.TestModeInfo.Lifetime {
+	case models.LifetimeSession, models.LifetimeConnection:
+		return true
+	}
+	if m.Spec.Metadata != nil {
+		switch m.Spec.Metadata["type"] {
+		case "config", "connection":
+			return true
+		}
+	}
+	return false
+}
+
+// isReusableTierState is the MockState (consumed-mock) equivalent of
+// isReusableTierMock. GetConsumedMocks carries the recorder-derived Lifetime
+// and metadata type, so session/connection/config mocks are carved out of the
+// consumed side of the assertion the same way they are on the expected side.
+func isReusableTierState(s models.MockState) bool {
+	switch s.Lifetime {
+	case models.LifetimeSession, models.LifetimeConnection:
+		return true
+	}
+	switch s.Type {
+	case "config", "connection":
+		return true
+	}
+	return false
+}
+
 func isMockSubset(actual []string, expected []string) bool {
 	actualMap := make(map[string]bool)
 	for _, mock := range actual {

--- a/pkg/service/replay/reusable_tier_test.go
+++ b/pkg/service/replay/reusable_tier_test.go
@@ -1,0 +1,151 @@
+package replay
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+func ptMock(name string) *models.Mock {
+	m := &models.Mock{Name: name, Kind: models.HTTP}
+	m.TestModeInfo.Lifetime = models.LifetimePerTest
+	return m
+}
+
+func sessionMock(name string) *models.Mock {
+	m := &models.Mock{Name: name, Kind: models.HTTP}
+	m.TestModeInfo.Lifetime = models.LifetimeSession
+	return m
+}
+
+func connMock(name string) *models.Mock {
+	m := &models.Mock{Name: name, Kind: models.HTTP}
+	m.TestModeInfo.Lifetime = models.LifetimeConnection
+	return m
+}
+
+func configMetaMock(name string) *models.Mock {
+	// Lifetime left at the per-test zero value to prove the metadata fallback
+	// (a mock whose lifetime wasn't derived but whose recorder type is config).
+	return &models.Mock{
+		Name: name, Kind: models.HTTP,
+		Spec: models.MockSpec{Metadata: map[string]string{"type": "config"}},
+	}
+}
+
+func TestIsReusableTierMock(t *testing.T) {
+	cases := []struct {
+		name string
+		m    *models.Mock
+		want bool
+	}{
+		{"per-test is NOT reusable", ptMock("a"), false},
+		{"session is reusable", sessionMock("b"), true},
+		{"connection is reusable", connMock("c"), true},
+		{"config metadata fallback is reusable", configMetaMock("d"), true},
+		{"per-test with no metadata", &models.Mock{Name: "e", Kind: models.HTTP}, false},
+	}
+	for _, tc := range cases {
+		if got := isReusableTierMock(tc.m); got != tc.want {
+			t.Errorf("%s: isReusableTierMock=%v want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestIsReusableTierState(t *testing.T) {
+	cases := []struct {
+		name string
+		s    models.MockState
+		want bool
+	}{
+		{"per-test (zero lifetime, no type)", models.MockState{Name: "a"}, false},
+		{"session lifetime", models.MockState{Name: "b", Lifetime: models.LifetimeSession}, true},
+		{"connection lifetime", models.MockState{Name: "c", Lifetime: models.LifetimeConnection}, true},
+		{"config type fallback", models.MockState{Name: "d", Type: "config"}, true},
+		{"connection type fallback", models.MockState{Name: "e", Type: "connection"}, true},
+	}
+	for _, tc := range cases {
+		if got := isReusableTierState(tc.s); got != tc.want {
+			t.Errorf("%s: isReusableTierState=%v want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// End-to-end of the assertion intent: a test whose mapping lists a per-test
+// mock AND a reusable session mock, but whose replay only re-consumed the
+// per-test mock, must NOT be flagged as a mock-set mismatch — the session
+// mock is excluded from both sides of the subset check.
+func TestSubsetExcludesReusableTier(t *testing.T) {
+	// Loaded mocks tell us the tier of each name (MockEntry carries none).
+	reusable := map[string]bool{}
+	for _, m := range []*models.Mock{ptMock("pt-1"), sessionMock("sess-1")} {
+		if isReusableTierMock(m) {
+			reusable[m.Name] = true
+		}
+	}
+
+	// Mapping (expected) lists both; filter to per-test only.
+	expected := []models.MockEntry{{Name: "pt-1", Kind: "Http"}, {Name: "sess-1", Kind: "Http"}}
+	var filteredExpected []string
+	for _, e := range expected {
+		if reusable[e.Name] {
+			continue
+		}
+		filteredExpected = append(filteredExpected, e.Name)
+	}
+
+	// Consumed during replay: only the per-test mock came back (session reused
+	// elsewhere / not re-reported for this test).
+	consumed := []models.MockState{{Name: "pt-1", Lifetime: models.LifetimePerTest}}
+	var filteredConsumed []string
+	for _, s := range consumed {
+		if isReusableTierState(s) {
+			continue
+		}
+		filteredConsumed = append(filteredConsumed, s.Name)
+	}
+
+	if mismatch := !isMockSubset(filteredConsumed, filteredExpected); mismatch {
+		t.Errorf("expected NO mock-set mismatch once the reusable session mock is excluded; got mismatch (expected=%v consumed=%v)", filteredExpected, filteredConsumed)
+	}
+
+	// Control: a genuinely missing per-test mock must still flag a mismatch.
+	expected2 := []string{"pt-1", "pt-2"} // pt-2 never consumed
+	if mismatch := !isMockSubset(filteredConsumed, expected2); !mismatch {
+		t.Errorf("expected a mismatch when a per-test mock is genuinely missing")
+	}
+}
+
+// isMockSubsetWithConfig (streaming path) must ignore an extra consumed mock
+// of ANY reusable/startup tier (session/connection/config) or DNS — not just
+// config — so a reused mock can't falsely fail the streaming assertion.
+func TestIsMockSubsetWithConfig_ReusableTiers(t *testing.T) {
+	expected := []string{"pt-1"}
+	cases := []struct {
+		name     string
+		consumed []models.MockState
+		want     bool
+	}{
+		{"extra session mock ignored", []models.MockState{
+			{Name: "pt-1", Lifetime: models.LifetimePerTest},
+			{Name: "sess-1", Lifetime: models.LifetimeSession},
+		}, true},
+		{"extra connection mock ignored", []models.MockState{
+			{Name: "pt-1"}, {Name: "conn-1", Lifetime: models.LifetimeConnection},
+		}, true},
+		{"extra config mock ignored (legacy)", []models.MockState{
+			{Name: "pt-1"}, {Name: "cfg-1", Type: "config"},
+		}, true},
+		{"extra DNS mock ignored", []models.MockState{
+			{Name: "pt-1"}, {Name: "dns-1", Kind: models.DNS},
+		}, true},
+		{"extra per-test mock still fails", []models.MockState{
+			{Name: "pt-1"}, {Name: "pt-extra", Lifetime: models.LifetimePerTest},
+		}, false},
+	}
+	for _, tc := range cases {
+		if got := isMockSubsetWithConfig(tc.consumed, expected); got != tc.want {
+			t.Errorf("%s: isMockSubsetWithConfig=%v want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -488,6 +488,14 @@ func retainNoisyTestCaseMocks(noisyTestCaseNames []string, mapping *models.Mappi
 	return added
 }
 
+// isMockSubsetWithConfig reports whether the streaming-path replay consumed a
+// mock set consistent with the test's mapping: a consumed mock that is NOT in
+// the expected set flags a mismatch — UNLESS it is a mock that doesn't
+// participate in the per-test comparison. Only PER-TEST mocks are compared;
+// reusable/startup-tier mocks (session / connection / config, recorded once at
+// app boot and reused) and DNS (non-deterministic resolution order) are
+// ignored, mirroring the non-streaming path's filtering. They belong in the
+// mapping but must not, by their reuse, falsely demote a test to OBSOLETE.
 func isMockSubsetWithConfig(consumedMocks []models.MockState, expectedMocks []string) bool {
 	expectedMap := make(map[string]bool)
 	for _, name := range expectedMocks {
@@ -496,12 +504,13 @@ func isMockSubsetWithConfig(consumedMocks []models.MockState, expectedMocks []st
 
 	for _, m := range consumedMocks {
 		if !expectedMap[m.Name] {
-			// Found an extra mock in the actual run
-			if m.Type != "config" {
-				// This is NOT a config mock, so it IS a mismatch
+			// An extra consumed mock that wasn't in the mapping is a mismatch
+			// ONLY if it's a per-test mock. Reusable/startup-tier mocks
+			// (session/connection/config) and DNS are excluded from the
+			// comparison — they are reused / non-deterministically attributed.
+			if m.Kind != models.DNS && !isReusableTierState(m) {
 				return false
 			}
-			// If Type is "config", we ignore it as an extra mock
 		}
 	}
 	return true

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -849,6 +849,9 @@ func (tfs *TestFailureStore) PrintFailuresTable() {
 					if failure.MismatchReport != nil {
 						r := failure.MismatchReport
 						detail := fmt.Sprintf("[%s] %s", r.Protocol, r.ActualSummary)
+						if r.MatchPhase != "" {
+							detail += fmt.Sprintf(" | phase: %s", r.MatchPhase)
+						}
 						if r.ClosestMock != "" {
 							detail += fmt.Sprintf(" | closest: %s", r.ClosestMock)
 						}

--- a/pkg/service/report/report.go
+++ b/pkg/service/report/report.go
@@ -789,6 +789,11 @@ func (r *Report) renderSingleFailedTest(_ context.Context, sb *strings.Builder, 
 
 	sb.WriteString(header + "\n")
 
+	// Mock-miss diagnostics FIRST: when an outgoing call had no matching
+	// mock, the response diff below is usually a downstream symptom (the app
+	// reacting to keploy's synthetic error), so lead with the root cause.
+	renderUnmatchedCalls(sb, test)
+
 	// Status & header diffs (compact)
 	metaDiff := GenerateStatusAndHeadersTableDiff(test)
 
@@ -851,6 +856,52 @@ func (r *Report) renderSingleFailedTest(_ context.Context, sb *strings.Builder, 
 	}
 	sb.WriteString("\n--------------------------------------------------------------------\n")
 	return nil
+}
+
+// renderUnmatchedCalls writes the structured mock-miss diagnostics
+// (FailureInfo.UnmatchedCalls) for a test. Field-diff paths use the noise
+// vocabulary, so the rendered output doubles as copy-paste material for
+// test.globalNoise / spec.assertions.noise.
+func renderUnmatchedCalls(sb *strings.Builder, test models.TestResult) {
+	if len(test.FailureInfo.UnmatchedCalls) == 0 {
+		return
+	}
+	sb.WriteString("=== OUTGOING CALLS WITH NO MATCHING MOCK (likely root cause) ===\n")
+	for _, uc := range test.FailureInfo.UnmatchedCalls {
+		sb.WriteString(fmt.Sprintf("  [%s] %s", uc.Protocol, uc.ActualSummary))
+		if uc.MatchPhase != "" {
+			sb.WriteString(fmt.Sprintf(" (match stopped at: %s", uc.MatchPhase))
+			if uc.CandidateCount > 0 {
+				sb.WriteString(fmt.Sprintf(", %d candidate mock(s)", uc.CandidateCount))
+			}
+			sb.WriteString(")")
+		}
+		sb.WriteString("\n")
+		if uc.ClosestMock != "" {
+			sb.WriteString(fmt.Sprintf("    closest mock: %s\n", uc.ClosestMock))
+		}
+		if len(uc.FieldDiffs) > 0 {
+			sb.WriteString("    field differences (paths are noise-config compatible):\n")
+			for _, d := range uc.FieldDiffs {
+				switch d.Kind {
+				case models.DiffKindMissingInLive:
+					sb.WriteString(fmt.Sprintf("      %s: recorded %q, absent in live call\n", d.Path, d.Expected))
+				case models.DiffKindMissingInMock:
+					sb.WriteString(fmt.Sprintf("      %s: live %q, absent in recording\n", d.Path, d.Actual))
+				case models.DiffKindTypeChanged:
+					sb.WriteString(fmt.Sprintf("      %s: type changed (recorded %s, live %s)\n", d.Path, d.Expected, d.Actual))
+				default:
+					sb.WriteString(fmt.Sprintf("      %s: recorded %q, live %q\n", d.Path, d.Expected, d.Actual))
+				}
+			}
+		} else if uc.Diff != "" {
+			sb.WriteString(fmt.Sprintf("    diff: %s\n", uc.Diff))
+		}
+		if uc.NextSteps != "" {
+			sb.WriteString(fmt.Sprintf("    next steps: %s\n", uc.NextSteps))
+		}
+	}
+	sb.WriteString("\n")
 }
 
 // writerAdapter lets us reuse a bufio.Writer on top of strings.Builder.

--- a/pkg/service/report/unmatched_calls_test.go
+++ b/pkg/service/report/unmatched_calls_test.go
@@ -1,0 +1,56 @@
+package report
+
+import (
+	"strings"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+func TestRenderUnmatchedCalls_StructuredOutput(t *testing.T) {
+	test := models.TestResult{
+		FailureInfo: models.FailureInfo{
+			UnmatchedCalls: []models.UnmatchedCall{
+				{
+					Protocol:       "HTTP",
+					ActualSummary:  "POST /orders",
+					ClosestMock:    "mock-7",
+					MatchPhase:     models.MatchPhaseBody,
+					CandidateCount: 3,
+					NextSteps:      "add noise or re-record",
+					FieldDiffs: []models.MockFieldDiff{
+						{Path: "body.created_at", Kind: models.DiffKindValueChanged, Expected: "1", Actual: "2"},
+						{Path: "header.X-Old", Kind: models.DiffKindMissingInLive, Expected: "v"},
+					},
+				},
+			},
+		},
+	}
+
+	var sb strings.Builder
+	renderUnmatchedCalls(&sb, test)
+	out := sb.String()
+
+	for _, want := range []string{
+		"OUTGOING CALLS WITH NO MATCHING MOCK",
+		"[HTTP] POST /orders",
+		models.MatchPhaseBody,
+		"3 candidate mock(s)",
+		"closest mock: mock-7",
+		"body.created_at",
+		"header.X-Old",
+		"next steps: add noise or re-record",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderUnmatchedCalls_EmptyIsSilent(t *testing.T) {
+	var sb strings.Builder
+	renderUnmatchedCalls(&sb, models.TestResult{})
+	if sb.Len() != 0 {
+		t.Errorf("expected no output for tests without unmatched calls, got %q", sb.String())
+	}
+}

--- a/pkg/service/runner/runner.go
+++ b/pkg/service/runner/runner.go
@@ -376,8 +376,18 @@ func (r *Runner) setupTestSet(parentCtx context.Context, testSetID string, backd
 		outOpts.SchemaNoiseStrict = r.config.Test.SchemaNoiseStrict
 		outOpts.MysqlPorts = r.config.MysqlPorts
 	}
+	noiseCfg := map[string]map[string][]string{}
 	if headerNoise, ok := r.globalNoise["header"]; ok {
-		outOpts.NoiseConfig = map[string]map[string][]string{"header": headerNoise}
+		noiseCfg["header"] = headerNoise
+	}
+	if bodyNoise, ok := r.globalNoise["body"]; ok {
+		// The body bucket participates in HTTP request-body mock matching
+		// (drift-detection exclusion + strict-noise allowance) — same as the
+		// CLI replay path.
+		noiseCfg["body"] = bodyNoise
+	}
+	if len(noiseCfg) > 0 {
+		outOpts.NoiseConfig = noiseCfg
 	}
 	if err := r.instrumentation.MockOutgoing(gCtx, outOpts); err != nil {
 		return nil, fmt.Errorf("mock-outgoing failed: %w", err)


### PR DESCRIPTION
## Describe the changes that are made
- Introduces a **universal mock-mismatch reporting framework** (`pkg/agent/proxy/integrations/mismatch`) so every protocol parser reports a mock miss with one vocabulary, and the same structured data flows to the CLI mismatch table, the test-report yaml (`failure_info.unmatched_calls`), `keploy report` output, and the platform APIs the UI consumes.
- **Unifies the noise vocabulary and controls** between response assertions and HTTP mock matching:
  - Field-diff paths in mismatch reports use the noise-config grammar (`body.<dotted.path>`, `header.<name>`, `query.<name>`, `method`, `path`) — a reported path can be copied verbatim into `test.globalNoise` or `spec.assertions.noise`.
  - The `body` bucket of `test.globalNoise` (already forwarded to the proxy, previously unconsumed for HTTP) now participates in HTTP mock matching: excluded from req-body-noise detection and allowed as drift under strict enforcement.
  - `--schema-noise-strict` gets a CLI flag (was config-file-only while the in-cluster replay path force-enables it).
  - `req_body_noise` learned by `--schema-noise-detection` is now persisted even when `--remove-unused-mocks` is off, via a new prune-free `mockdb.PersistMockNoise` path (previously it was silently discarded at exit unless pruning ran).
- **Communicates the diff correctly on a miss**:
  - HTTP misses report the match-cascade phase (`no_mocks` / `no_schema_candidates` / `body_mismatch` / `strict_noise_reject` / `no_match`), candidate counts, and per-field diffs with recorded vs live values, computed against a schema-match survivor instead of only Levenshtein over `METHOD path` — replacing the canned "method and path match but headers or body differ".
  - The miss log is default-visible (`Warn`) instead of Debug-only, with phase + next steps.
  - The generic (opaque TCP) parser now emits structured reports (closest candidate by Jaccard + score) instead of a bare error; `proxy.GetMockErrors` no longer drops misses that lack a structured report, so no protocol's misses vanish from the report.
  - The `MOCKS MISMATCH SUMMARY` table prints whenever mismatches exist — including green runs (the false-green case: tests demoted to OBSOLETE, or protocols whose misses can't fail a test).
  - Remediation hints reference real commands (`keploy record`, `--update-test-mapping`); the previous hint referenced `keploy rerecord`, which is not a registered command.
  - `keploy report` renders unmatched outgoing calls *before* the response diff, since the response diff is usually a downstream symptom of the miss.
- **Extensible by design**: protocol parsers build reports via the `mismatch.Builder`; `models.MockFieldDiff`/`MatchPhase`/`CandidateCount` are additive fields on `UnmatchedCall`, so k8s-proxy/UI can render them without breaking changes. MySQL/DNS reports keep working unchanged; migrating them (and postgres/mongo/grpc in the integrations repo) to the builder is follow-up work tracked in the next PR.

## Links & References

**Closes:** NA (gap audit follow-up; happy to link issues if we file them)

### 🔗 Related PRs
- Stacked follow-up: deterministic match policy + fuzzy-match audit (next PR)
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [x] 🍕 Feature
- [x] 🐞 Bug Fix

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed (per-protocol matching reference lands as a keploy/docs PR alongside this)

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

Unit coverage: `pkg/agent/proxy/integrations/mismatch` (builder, diff helpers), `pkg/matcher` (`JSONFieldDiffs`), HTTP matcher (field-diff reports vs schema survivors, learned+user noise exclusion, strict-filter user-noise allowance), `mockdb.PersistMockNoise` (prune-free persistence + no-op safety), `keploy report` unmatched-call rendering.

Manual: replay any HTTP test set with a drifted outgoing request body field. Expect a Warn log naming the call, phase and field diff; the same diff in `MOCKS MISMATCH SUMMARY`; `field_diffs` in `failure_info.unmatched_calls` of the report yaml; and `keploy report` printing the unmatched call above the response diff, with the path copy-pastable into `test.globalNoise`.

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA

🤖 Generated with [Claude Code](https://claude.com/claude-code)
