### PR TITLE
feat: fuzzy-match policy with deterministic replay mode and dedup-loss detection

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -1270,7 +1270,10 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 			case models.FuzzyMatchOn, models.FuzzyMatchWarn, models.FuzzyMatchOff, "":
 			default:
 				errMsg := "invalid --fuzzy-match value " + strconv.Quote(c.cfg.Test.FuzzyMatch) + "; expected one of: on, warn, off"
-				utils.LogError(c.logger, nil, errMsg)
+				// Plain logger.Error, not utils.LogError: there is no underlying
+				// error here (a bad flag value), so utils.LogError's zap.Error(nil)
+				// would log a misleading "error: null".
+				c.logger.Error(errMsg)
 				return errors.New(errMsg)
 			}
 

--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -1255,12 +1255,17 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 				}
 			}
 
-			c.cfg.Test.FuzzyMatch, err = cmd.Flags().GetString("fuzzy-match")
-			if err != nil {
-				errMsg := "failed to read the --fuzzy-match flag; check the flag name with --help and confirm this command supports it"
-				utils.LogError(c.logger, err, errMsg)
-				return errors.New(errMsg)
+			// Same Changed/IsSet guard as schema-noise-strict: the flag
+			// default must not clobber a yaml-only test.fuzzyMatch value.
+			if cmd.Flags().Changed("fuzzy-match") || !viper.IsSet("test.fuzzyMatch") {
+				c.cfg.Test.FuzzyMatch, err = cmd.Flags().GetString("fuzzy-match")
+				if err != nil {
+					errMsg := "failed to read the --fuzzy-match flag; check the flag name with --help and confirm this command supports it"
+					utils.LogError(c.logger, err, errMsg)
+					return errors.New(errMsg)
+				}
 			}
+			// Validate regardless of source (flag or yaml).
 			switch c.cfg.Test.FuzzyMatch {
 			case models.FuzzyMatchOn, models.FuzzyMatchWarn, models.FuzzyMatchOff, "":
 			default:

--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -415,6 +415,7 @@ func (c *CmdConfigurator) AddUncommonFlags(cmd *cobra.Command) {
 		cmd.Flags().Bool("compare-all", false, "Compare all response body types including non-JSON (default: false, only JSON bodies are compared)")
 		cmd.Flags().Bool("schema-match", false, "Compare only the schema of the response body")
 		cmd.Flags().Bool("schema-noise-detection", c.cfg.Test.SchemaNoiseDetection, "Detect request-body fields that drift between recording and replay and persist them as field-path noise (req_body_noise) on HTTP mocks during auto-replay matching")
+		cmd.Flags().String("fuzzy-match", c.cfg.Test.FuzzyMatch, "Policy for similarity-based mock-match fallbacks: 'on' (legacy, silent), 'warn' (fuzzy allowed, each fuzzy-served mock logs a Warn), 'off' (deterministic replay: recorded-order tiebreaks only, otherwise a structured mock miss)")
 		cmd.Flags().Bool("schema-noise-strict", c.cfg.Test.SchemaNoiseStrict, "Strictly enforce learned request-body noise during HTTP mock matching: a candidate mock carrying req_body_noise is rejected when any field OUTSIDE its learned/user-configured noise drifted. Same behaviour the in-cluster replay path enforces; previously configurable only via keploy.yml")
 		cmd.Flags().Bool("strict-failure", c.cfg.Test.StrictFailure, "Mark response-failing tests as FAILED even if the consumed mock set also diverged from the recorded mapping (default behaviour demotes such cases to OBSOLETE). The per-test mappingDiff block is still written for diagnostics.")
 		cmd.Flags().Bool("update-test-mapping", c.cfg.Test.UpdateTestMapping, "Update the mapping of testcases")
@@ -495,6 +496,7 @@ func aliasNormalizeFunc(_ *pflag.FlagSet, name string) pflag.NormalizedName {
 		"schemaMatch":               "schema-match",
 		"schemaNoiseDetection":      "schema-noise-detection",
 		"schemaNoiseStrict":         "schema-noise-strict",
+		"fuzzyMatch":                "fuzzy-match",
 		"updateTestMapping":         "update-test-mapping",
 		"capturePackets":            "capture-packets",
 		"opportunisticTlsIntercept": "opportunistic-tls-intercept",
@@ -1251,6 +1253,20 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 					utils.LogError(c.logger, err, errMsg)
 					return errors.New(errMsg)
 				}
+			}
+
+			c.cfg.Test.FuzzyMatch, err = cmd.Flags().GetString("fuzzy-match")
+			if err != nil {
+				errMsg := "failed to read the --fuzzy-match flag; check the flag name with --help and confirm this command supports it"
+				utils.LogError(c.logger, err, errMsg)
+				return errors.New(errMsg)
+			}
+			switch c.cfg.Test.FuzzyMatch {
+			case models.FuzzyMatchOn, models.FuzzyMatchWarn, models.FuzzyMatchOff, "":
+			default:
+				errMsg := "invalid --fuzzy-match value " + strconv.Quote(c.cfg.Test.FuzzyMatch) + "; expected one of: on, warn, off"
+				utils.LogError(c.logger, nil, errMsg)
+				return errors.New(errMsg)
 			}
 
 			// enforce that the test-sets are provided when --must-pass is set to true

--- a/config/config.go
+++ b/config/config.go
@@ -219,6 +219,7 @@ type Test struct {
 	ProtoDir                    string              `json:"protoDir" yaml:"protoDir" mapstructure:"protoDir"`
 	ProtoInclude                []string            `json:"protoInclude" yaml:"protoInclude" mapstructure:"protoInclude"`
 	CompareAll                  bool                `json:"compareAll" yaml:"compareAll" mapstructure:"compareAll"`
+	FuzzyMatch                  string              `json:"fuzzyMatch" yaml:"fuzzyMatch" mapstructure:"fuzzyMatch"` // on|warn|off — policy for similarity-based mock-match fallbacks (off = deterministic replay)
 	SchemaMatch                 bool                `json:"schemaMatch" yaml:"schemaMatch" mapstructure:"schemaMatch"`
 	UpdateTestMapping           bool                `json:"updateTestMapping" yaml:"updateTestMapping" mapstructure:"updateTestMapping"`
 	DisableAutoHeaderNoise      bool                `json:"disableAutoHeaderNoise" yaml:"disableAutoHeaderNoise" mapstructure:"disableAutoHeaderNoise"`                                    // skip auto-noise for flaky headers (e.g. AWS SigV4)

--- a/config/default.go
+++ b/config/default.go
@@ -73,6 +73,7 @@ test:
   protoDir: ""
   protoInclude: []
   compareAll: false
+  fuzzyMatch: warn
   updateTestMapping: false
   disableAutoHeaderNoise: false
   # strictMockWindow enforces cross-test bleed prevention. Per-test

--- a/pkg/agent/proxy/integrations/generic/decode.go
+++ b/pkg/agent/proxy/integrations/generic/decode.go
@@ -16,7 +16,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func decodeGeneric(ctx context.Context, logger *zap.Logger, reqBuf []byte, clientConn net.Conn, dstCfg *models.ConditionalDstCfg, mockDb integrations.MockMemDb, _ models.OutgoingOptions) error {
+func decodeGeneric(ctx context.Context, logger *zap.Logger, reqBuf []byte, clientConn net.Conn, dstCfg *models.ConditionalDstCfg, mockDb integrations.MockMemDb, opts models.OutgoingOptions) error {
 	genericRequests := [][]byte{reqBuf}
 	logger.Debug("Into the generic parser in test mode")
 	errCh := make(chan error, 1)
@@ -55,7 +55,7 @@ func decodeGeneric(ctx context.Context, logger *zap.Logger, reqBuf []byte, clien
 
 			// bestMatchedIndx := 0
 			// fuzzy match gives the index for the best matched generic mock
-			matched, genericResponses, err := fuzzyMatch(ctx, logger, genericRequests, mockDb)
+			matched, genericResponses, err := fuzzyMatch(ctx, logger, genericRequests, mockDb, opts.FuzzyMatchPolicy)
 			if err != nil {
 				utils.LogError(logger, err, "error while matching generic mocks")
 			}

--- a/pkg/agent/proxy/integrations/generic/decode.go
+++ b/pkg/agent/proxy/integrations/generic/decode.go
@@ -55,7 +55,7 @@ func decodeGeneric(ctx context.Context, logger *zap.Logger, reqBuf []byte, clien
 
 			// bestMatchedIndx := 0
 			// fuzzy match gives the index for the best matched generic mock
-			matched, genericResponses, err := fuzzyMatch(ctx, logger, genericRequests, mockDb, opts.FuzzyMatchPolicy)
+			matched, genericResponses, err := fuzzyMatch(ctx, logger, genericRequests, mockDb, models.NormalizeFuzzyPolicy(opts.FuzzyMatchPolicy))
 			if err != nil {
 				utils.LogError(logger, err, "error while matching generic mocks")
 			}

--- a/pkg/agent/proxy/integrations/generic/fuzzy_policy_test.go
+++ b/pkg/agent/proxy/integrations/generic/fuzzy_policy_test.go
@@ -1,0 +1,103 @@
+package generic
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/util"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+type genericMemDb struct {
+	mocks []*models.Mock
+}
+
+func (m *genericMemDb) GetUnFilteredMocks() ([]*models.Mock, error) { return m.mocks, nil }
+func (m *genericMemDb) GetFilteredMocks() ([]*models.Mock, error)   { return nil, nil }
+func (m *genericMemDb) UpdateUnFilteredMock(_ *models.Mock, _ *models.Mock) bool {
+	return true
+}
+func (m *genericMemDb) DeleteFilteredMock(_ models.Mock) bool             { return false }
+func (m *genericMemDb) DeleteUnFilteredMock(_ models.Mock) bool           { return false }
+func (m *genericMemDb) DeleteStartupMock(_ models.Mock) bool              { return false }
+func (m *genericMemDb) GetMySQLCounts() (total, config, data int)         { return 0, 0, 0 }
+func (m *genericMemDb) MarkMockAsUsed(_ models.Mock) bool                 { return false }
+func (m *genericMemDb) SetCurrentTestWindow(_, _ time.Time)               {}
+func (m *genericMemDb) IsTestWindowActive() bool                          { return false }
+func (m *genericMemDb) GetFilteredMocksInWindow() ([]*models.Mock, error) { return nil, nil }
+func (m *genericMemDb) GetPerTestMocksInWindow() ([]*models.Mock, error)  { return nil, nil }
+func (m *genericMemDb) GetSessionMocks() ([]*models.Mock, error)          { return m.mocks, nil }
+func (m *genericMemDb) GetStartupMocks() ([]*models.Mock, error)          { return nil, nil }
+func (m *genericMemDb) GetStartupMocksByKind(_ models.Kind) ([]*models.Mock, error) {
+	return nil, nil
+}
+func (m *genericMemDb) GetSessionScopedMocks() ([]*models.Mock, error)      { return m.mocks, nil }
+func (m *genericMemDb) HasFirstTestFired() bool                             { return false }
+func (m *genericMemDb) FirstTestWindowStart() time.Time                     { return time.Time{} }
+func (m *genericMemDb) WindowSnapshot() models.WindowSnapshot               { return models.WindowSnapshot{} }
+func (m *genericMemDb) CurrentTestWindow() (time.Time, time.Time)           { return time.Time{}, time.Time{} }
+func (m *genericMemDb) GetConnectionMocks(_ string) ([]*models.Mock, error) { return nil, nil }
+func (m *genericMemDb) SessionMockHitCounts() map[string]uint64             { return nil }
+
+func genericMock(name, reqData string) *models.Mock {
+	return &models.Mock{
+		Name: name,
+		Kind: "Generic",
+		Spec: models.MockSpec{
+			GenericRequests: []models.Payload{
+				{Message: []models.OutputBinary{{Type: "String", Data: reqData}}},
+			},
+			GenericResponses: []models.Payload{
+				{Message: []models.OutputBinary{{Type: "String", Data: "resp"}}},
+			},
+		},
+	}
+}
+
+// A similar-but-not-equal buffer must not be served under fuzzyMatch=off, and
+// must be served (legacy Jaccard fallback) under on/warn.
+//
+// Note: the Jaccard fallback decodes mock data as base64 (binary recordings);
+// the recorded payload is stored encoded, exactly as the recorder does for
+// non-ASCII wire data.
+func TestGenericFuzzyMatch_PolicyGate(t *testing.T) {
+	logger := zap.NewNop()
+	// Long shared prefix → Jaccard similarity above the 0.4 session threshold.
+	recorded := "SELECT id,name,email FROM users WHERE tenant='acme' AND created_at > '2026-01-01'"
+	live := "SELECT id,name,email FROM users WHERE tenant='acme' AND created_at > '2026-06-12'"
+
+	db := &genericMemDb{mocks: []*models.Mock{genericMock("mock-1", util.EncodeBase64([]byte(recorded)))}}
+
+	matched, _, err := fuzzyMatch(context.Background(), logger, [][]byte{[]byte(live)}, db, models.FuzzyMatchOff)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if matched {
+		t.Fatal("fuzzyMatch=off must not serve a similarity guess")
+	}
+
+	matched, _, err = fuzzyMatch(context.Background(), logger, [][]byte{[]byte(live)}, db, models.FuzzyMatchWarn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !matched {
+		t.Fatal("fuzzyMatch=warn should keep the legacy similarity fallback")
+	}
+}
+
+// Exact matches are deterministic and must be served under every policy.
+func TestGenericFuzzyMatch_ExactUnaffectedByPolicy(t *testing.T) {
+	logger := zap.NewNop()
+	data := "PING"
+	db := &genericMemDb{mocks: []*models.Mock{genericMock("mock-1", data)}}
+
+	matched, _, err := fuzzyMatch(context.Background(), logger, [][]byte{[]byte(data)}, db, models.FuzzyMatchOff)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !matched {
+		t.Fatal("exact match must be served even under fuzzyMatch=off")
+	}
+}

--- a/pkg/agent/proxy/integrations/generic/match.go
+++ b/pkg/agent/proxy/integrations/generic/match.go
@@ -19,7 +19,7 @@ import (
 // If a match is found, it returns the corresponding response mock and a boolean value indicating success.
 // If no match is found, it returns false and a nil response.
 // If an error occurs during the matching process, it returns an error.
-func fuzzyMatch(ctx context.Context, logger *zap.Logger, reqBuff [][]byte, mockDb integrations.MockMemDb) (bool, []models.Payload, error) {
+func fuzzyMatch(ctx context.Context, logger *zap.Logger, reqBuff [][]byte, mockDb integrations.MockMemDb, fuzzyPolicy string) (bool, []models.Payload, error) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -54,8 +54,13 @@ func fuzzyMatch(ctx context.Context, logger *zap.Logger, reqBuff [][]byte, mockD
 
 			index := findExactMatch(filteredMocks, reqBuff)
 
-			if index == -1 {
+			if index == -1 && fuzzyPolicy != models.FuzzyMatchOff {
 				index = findBinaryMatch(filteredMocks, reqBuff, 0.9)
+				if index != -1 && fuzzyPolicy != models.FuzzyMatchOn {
+					logger.Warn("generic mock served via similarity (Jaccard) match — verify this is the right mock or set test.fuzzyMatch=off for deterministic replay",
+						zap.String("mock name", filteredMocks[index].Name),
+						zap.Float64("threshold", 0.9))
+				}
 			}
 
 			// Concurrency note for both branches below: see HTTP's
@@ -79,8 +84,13 @@ func fuzzyMatch(ctx context.Context, logger *zap.Logger, reqBuff [][]byte, mockD
 
 			index = findExactMatch(unfilteredMocks, reqBuff)
 
-			if index == -1 {
+			if index == -1 && fuzzyPolicy != models.FuzzyMatchOff {
 				index = findBinaryMatch(unfilteredMocks, reqBuff, 0.4)
+				if index != -1 && fuzzyPolicy != models.FuzzyMatchOn {
+					logger.Warn("generic mock served via similarity (Jaccard) match — verify this is the right mock or set test.fuzzyMatch=off for deterministic replay",
+						zap.String("mock name", unfilteredMocks[index].Name),
+						zap.Float64("threshold", 0.4))
+				}
 			}
 			if index != -1 {
 				responseMock := make([]models.Payload, len(unfilteredMocks[index].Spec.GenericResponses))

--- a/pkg/agent/proxy/integrations/http/decode.go
+++ b/pkg/agent/proxy/integrations/http/decode.go
@@ -193,7 +193,7 @@ func (h *HTTP) decodeHTTP(ctx context.Context, reqBuf []byte, clientConn net.Con
 			h.Logger.Debug("header noise", zap.Any("header noise", headerNoise))
 			h.Logger.Debug("body noise", zap.Any("body noise", bodyNoise))
 
-			ok, stub, diag, err := h.match(ctx, input, mockDb, headerNoise, bodyNoise, opts.SchemaNoiseDetection, opts.SchemaNoiseStrict, opts.FuzzyMatchPolicy) // calling match function to match mocks
+			ok, stub, diag, err := h.match(ctx, input, mockDb, headerNoise, bodyNoise, opts.SchemaNoiseDetection, opts.SchemaNoiseStrict, models.NormalizeFuzzyPolicy(opts.FuzzyMatchPolicy)) // calling match function to match mocks
 			if err != nil {
 				utils.LogError(h.Logger, err, "error while matching http mocks", zap.Any("metadata", utils.GetReqMeta(request)))
 				errCh <- err

--- a/pkg/agent/proxy/integrations/http/decode.go
+++ b/pkg/agent/proxy/integrations/http/decode.go
@@ -193,7 +193,7 @@ func (h *HTTP) decodeHTTP(ctx context.Context, reqBuf []byte, clientConn net.Con
 			h.Logger.Debug("header noise", zap.Any("header noise", headerNoise))
 			h.Logger.Debug("body noise", zap.Any("body noise", bodyNoise))
 
-			ok, stub, diag, err := h.match(ctx, input, mockDb, headerNoise, bodyNoise, opts.SchemaNoiseDetection, opts.SchemaNoiseStrict) // calling match function to match mocks
+			ok, stub, diag, err := h.match(ctx, input, mockDb, headerNoise, bodyNoise, opts.SchemaNoiseDetection, opts.SchemaNoiseStrict, opts.FuzzyMatchPolicy) // calling match function to match mocks
 			if err != nil {
 				utils.LogError(h.Logger, err, "error while matching http mocks", zap.Any("metadata", utils.GetReqMeta(request)))
 				errCh <- err

--- a/pkg/agent/proxy/integrations/http/fuzzy_policy_test.go
+++ b/pkg/agent/proxy/integrations/http/fuzzy_policy_test.go
@@ -1,0 +1,111 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+func jsonBodyMock(name, body string, sortOrder int64) *models.Mock {
+	m := &models.Mock{
+		Name: name,
+		Kind: models.Kind(models.HTTP),
+		Spec: models.MockSpec{
+			HTTPReq: &models.HTTPReq{
+				Method: "POST",
+				URL:    "http://localhost:8080/api/orders",
+				Header: map[string]string{"Content-Type": "application/json"},
+				Body:   body,
+			},
+		},
+	}
+	m.TestModeInfo.SortOrder = sortOrder
+	return m
+}
+
+func orderInput(body string) *req {
+	return &req{
+		method: "POST",
+		url:    &url.URL{Path: "/api/orders"},
+		header: http.Header{"Content-Type": {"application/json"}},
+		body:   []byte(body),
+		raw:    []byte(body),
+	}
+}
+
+// Under test.fuzzyMatch=off, multiple body-key-matched candidates resolve via
+// the recorded-order (lowest SortOrder) tiebreak — never via similarity.
+func TestMatch_FuzzyOff_DeterministicTiebreak(t *testing.T) {
+	h := newHTTP()
+	early := jsonBodyMock("mock-early", `{"order_id":"o-1"}`, 10)
+	late := jsonBodyMock("mock-late", `{"order_id":"o-2"}`, 20)
+	db := &mockMemDb{mocks: []*models.Mock{late, early}, updateUnFilteredReturn: true, deleteFilteredReturn: true}
+
+	// Live body shares the key set with both candidates but matches neither
+	// exactly — under "on" this would go to fuzzy.
+	ok, mock, diag, err := h.match(context.Background(), orderInput(`{"order_id":"o-9"}`), db, nil, nil, false, false, models.FuzzyMatchOff)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || mock == nil {
+		t.Fatalf("expected deterministic tiebreak to serve a mock, got ok=%v diag=%+v", ok, diag)
+	}
+	if mock.Name != "mock-early" {
+		t.Errorf("expected recorded-order pick mock-early, got %s", mock.Name)
+	}
+}
+
+// Under test.fuzzyMatch=off, a request whose body keys match no candidate is
+// a structured miss with the fuzzy_match_disabled phase — not a Jaccard guess.
+func TestMatch_FuzzyOff_MissInsteadOfGuess(t *testing.T) {
+	h := newHTTP()
+	candidate := jsonBodyMock("mock-1", `{"order_id":"o-1"}`, 10)
+	// Non-JSON live body: exact fails, body-key path doesn't apply, fuzzy disabled.
+	input := orderInput(`plain-text-payload`)
+	input.header = http.Header{}
+	candidate.Spec.HTTPReq.Header = map[string]string{}
+	candidate.Spec.HTTPReq.Body = `different-plain-text`
+	db := &mockMemDb{mocks: []*models.Mock{candidate}, updateUnFilteredReturn: true}
+
+	ok, _, diag, err := h.match(context.Background(), input, db, nil, nil, false, false, models.FuzzyMatchOff)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatal("expected a miss with fuzzy disabled")
+	}
+	if diag == nil || diag.phase != models.MatchPhaseFuzzyOff {
+		t.Errorf("expected phase %q, got %+v", models.MatchPhaseFuzzyOff, diag)
+	}
+}
+
+// The default policies (on/warn) keep the legacy fuzzy behaviour: the same
+// request that misses under "off" is served via similarity.
+func TestMatch_FuzzyWarn_StillServesViaSimilarity(t *testing.T) {
+	h := newHTTP()
+	candidate := jsonBodyMock("mock-1", `different-plain-text`, 10)
+	candidate.Spec.HTTPReq.Header = map[string]string{}
+	input := orderInput(`plain-text-payload`)
+	input.header = http.Header{}
+	db := &mockMemDb{mocks: []*models.Mock{candidate}, updateUnFilteredReturn: true}
+
+	ok, mock, _, err := h.match(context.Background(), input, db, nil, nil, false, false, models.FuzzyMatchWarn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || mock == nil || mock.Name != "mock-1" {
+		t.Fatalf("expected fuzzy match under warn policy, got ok=%v", ok)
+	}
+}
+
+func TestLowestSortOrder(t *testing.T) {
+	a := jsonBodyMock("a", `{}`, 5)
+	b := jsonBodyMock("b", `{}`, 2)
+	c := jsonBodyMock("c", `{}`, 9)
+	if got := lowestSortOrder([]*models.Mock{a, b, c}); got.Name != "b" {
+		t.Errorf("expected b, got %s", got.Name)
+	}
+}

--- a/pkg/agent/proxy/integrations/http/fuzzy_policy_test.go
+++ b/pkg/agent/proxy/integrations/http/fuzzy_policy_test.go
@@ -109,3 +109,21 @@ func TestLowestSortOrder(t *testing.T) {
 		t.Errorf("expected b, got %s", got.Name)
 	}
 }
+
+// The deterministic tiebreak must prefer the per-test tier: SortOrder
+// counters are stamped per pool, so a session fixture with a low stamp must
+// not beat the current test's own recorded mock.
+func TestPickDeterministic_PrefersPerTestTier(t *testing.T) {
+	session := jsonBodyMock("session-fixture", `{"order_id":"s"}`, 1)
+	session.TestModeInfo.Lifetime = models.LifetimeSession
+	perTest := jsonBodyMock("per-test-row", `{"order_id":"p"}`, 7)
+	perTest.TestModeInfo.Lifetime = models.LifetimePerTest
+
+	if got := pickDeterministic([]*models.Mock{session, perTest}); got.Name != "per-test-row" {
+		t.Errorf("expected per-test tier preferred, got %s", got.Name)
+	}
+	// With no per-test candidate, fall back to recorded order across the rest.
+	if got := pickDeterministic([]*models.Mock{session}); got.Name != "session-fixture" {
+		t.Errorf("expected session fallback, got %s", got.Name)
+	}
+}

--- a/pkg/agent/proxy/integrations/http/match.go
+++ b/pkg/agent/proxy/integrations/http/match.go
@@ -273,7 +273,7 @@ func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMe
 				return true, exact, nil, nil
 			}
 			if bodyKeyMatched && len(shortListed) > 0 {
-				pick := lowestSortOrder(shortListed)
+				pick := pickDeterministic(shortListed)
 				h.Logger.Info("deterministic tiebreak: serving recorded-order candidate among body-matched mocks",
 					zap.String("mock name", pick.Name),
 					zap.Int("candidates", len(shortListed)))
@@ -316,8 +316,30 @@ func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMe
 	}
 }
 
+// pickDeterministic returns the recorded-order candidate for the
+// deterministic tiebreak, preferring the per-test tier. SortOrder counters
+// are stamped independently per pool (SetFilteredMocks vs SetUnFilteredMocks),
+// so comparing SortOrder across tiers is meaningless — a session fixture
+// stamped 1 would beat the current test's own recorded mock stamped 7,
+// inverting the per-test-first preference the candidate ordering documents.
+func pickDeterministic(mocks []*models.Mock) *models.Mock {
+	var perTest []*models.Mock
+	for _, m := range mocks {
+		isConfig := m.Spec.Metadata != nil && m.Spec.Metadata["type"] == "config"
+		if m.TestModeInfo.Lifetime == models.LifetimePerTest && !isConfig {
+			perTest = append(perTest, m)
+		}
+	}
+	if len(perTest) > 0 {
+		return lowestSortOrder(perTest)
+	}
+	return lowestSortOrder(mocks)
+}
+
 // lowestSortOrder returns the candidate with the smallest recorded SortOrder —
 // i.e. the next mock in recorded order, the deterministic FIFO tiebreak.
+// Callers must only compare candidates from the same pool tier (see
+// pickDeterministic).
 func lowestSortOrder(mocks []*models.Mock) *models.Mock {
 	best := mocks[0]
 	for _, m := range mocks[1:] {

--- a/pkg/agent/proxy/integrations/http/match.go
+++ b/pkg/agent/proxy/integrations/http/match.go
@@ -130,8 +130,9 @@ type matchDiag struct {
 // matched is false and no error occurred. userBodyNoise carries the user's
 // test.globalNoise body bucket (root-relative dotted paths, lowercased) so
 // manual noise config participates in mock matching with the same vocabulary
-// as response assertions.
-func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMemDb, headerNoise map[string][]string, userBodyNoise map[string][]string, schemaNoiseDetection bool, schemaNoiseStrict bool) (bool, *models.Mock, *matchDiag, error) {
+// as response assertions. fuzzyPolicy (models.FuzzyMatch*) governs the
+// similarity fallbacks at the end of the cascade.
+func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMemDb, headerNoise map[string][]string, userBodyNoise map[string][]string, schemaNoiseDetection bool, schemaNoiseStrict bool, fuzzyPolicy string) (bool, *models.Mock, *matchDiag, error) {
 	for {
 		if ctx.Err() != nil {
 			return false, nil, nil, ctx.Err()
@@ -214,6 +215,7 @@ func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMe
 		}
 
 		shortListed := schemaMatched
+		bodyKeyMatched := false
 		// Schema match for JSON bodies
 		if pkg.IsJSON(input.body) {
 			bodyMatched, err := h.PerformBodyMatch(ctx, schemaMatched, input.body)
@@ -253,13 +255,57 @@ func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMe
 
 			// More than one match, perform fuzzy match
 			shortListed = bodyMatched
+			bodyKeyMatched = true
+		}
+
+		// Deterministic mode (test.fuzzyMatch=off): no similarity guessing.
+		// The byte-equality (encoding-normalized) check still runs — it's
+		// deterministic. Among candidates that already matched on body keys
+		// (+ strict noise), the recorded-order (lowest SortOrder) candidate
+		// is served as a deterministic tiebreak. Everything else is a
+		// structured miss instead of a Levenshtein/Jaccard guess.
+		if fuzzyPolicy == models.FuzzyMatchOff {
+			if ok, exact := h.fuzzyExactEncodingMatch(shortListed, input.raw); ok {
+				detected := h.detectReqBodyNoise(schemaNoiseDetection, exact, input.body, userBodyNoise)
+				if !h.updateMock(ctx, exact, mockDb, detected) {
+					continue
+				}
+				return true, exact, nil, nil
+			}
+			if bodyKeyMatched && len(shortListed) > 0 {
+				pick := lowestSortOrder(shortListed)
+				h.Logger.Info("deterministic tiebreak: serving recorded-order candidate among body-matched mocks",
+					zap.String("mock name", pick.Name),
+					zap.Int("candidates", len(shortListed)))
+				detected := h.detectReqBodyNoise(schemaNoiseDetection, pick, input.body, userBodyNoise)
+				if !h.updateMock(ctx, pick, mockDb, detected) {
+					continue
+				}
+				return true, pick, nil, nil
+			}
+			h.Logger.Warn("fuzzy matching disabled (test.fuzzyMatch=off): treating unmatched request as a mock miss",
+				zap.String("method", input.method),
+				zap.String("path", input.url.Path),
+				zap.Int("candidates", len(shortListed)))
+			return false, nil, &matchDiag{phase: models.MatchPhaseFuzzyOff, candidates: len(unfilteredMocks), schemaMatched: shortListed}, nil
 		}
 
 		h.Logger.Debug("Performing fuzzy match for req buffer")
 		// Perform fuzzy match on the request
-		isMatched, bestMatch := h.PerformFuzzyMatch(shortListed, input.raw)
+		isMatched, bestMatch, fz := h.performFuzzyMatchScored(shortListed, input.raw)
 		if isMatched {
 			h.Logger.Debug("fuzzy match found a matching mock", zap.String("mock name", bestMatch.Name))
+			if fz.guessed && fuzzyPolicy != models.FuzzyMatchOn {
+				// Default-visible audit trail for every similarity guess —
+				// the mock may be the wrong one and nothing else will say so.
+				h.Logger.Warn("mock served via similarity (fuzzy) match — verify this is the right mock or set test.fuzzyMatch=off for deterministic replay",
+					zap.String("mock name", bestMatch.Name),
+					zap.String("match_type", fz.matchType),
+					zap.Float64("match_percentage", fz.score),
+					zap.Int("candidates", len(shortListed)),
+					zap.String("method", input.method),
+					zap.String("path", input.url.Path))
+			}
 			detected := h.detectReqBodyNoise(schemaNoiseDetection, bestMatch, input.body, userBodyNoise)
 			if !h.updateMock(ctx, bestMatch, mockDb, detected) {
 				continue
@@ -268,6 +314,18 @@ func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMe
 		}
 		return false, nil, &matchDiag{phase: models.MatchPhaseExhausted, candidates: len(unfilteredMocks), schemaMatched: shortListed}, nil
 	}
+}
+
+// lowestSortOrder returns the candidate with the smallest recorded SortOrder —
+// i.e. the next mock in recorded order, the deterministic FIFO tiebreak.
+func lowestSortOrder(mocks []*models.Mock) *models.Mock {
+	best := mocks[0]
+	for _, m := range mocks[1:] {
+		if m.TestModeInfo.SortOrder < best.TestModeInfo.SortOrder {
+			best = m
+		}
+	}
+	return best
 }
 
 // FilterHTTPMocks Filter mocks to only HTTP mocks
@@ -685,14 +743,25 @@ func (h *HTTP) findBinaryMatch(mocks []*models.Mock, reqBuff []byte) int {
 // PerformFuzzyMatch performs fuzzy matching on the request body.
 // Noisy (obfuscated) values are stripped from mock bodies before computing
 // similarity so that redacted padding doesn't skew the score.
-func (h *HTTP) PerformFuzzyMatch(tcsMocks []*models.Mock, reqBuff []byte) (bool, *models.Mock) {
-	// Log all mock names in a single line for better readability
-	mockNames := make([]string, len(tcsMocks))
-	for i, mock := range tcsMocks {
-		mockNames[i] = mock.Name
-	}
-	h.Logger.Debug("mocks under consideration for performfuzzyMatch function", zap.Strings("mock names", mockNames))
+// fuzzyResult describes how the fuzzy stage picked a mock. guessed is false
+// only for the byte-equality (encoding-normalized) path — Levenshtein and
+// Jaccard picks are similarity guesses and subject to the fuzzy-match policy.
+type fuzzyResult struct {
+	matchType string
+	score     float64 // match percentage 0-100
+	guessed   bool
+}
 
+func (h *HTTP) PerformFuzzyMatch(tcsMocks []*models.Mock, reqBuff []byte) (bool, *models.Mock) {
+	ok, mock, _ := h.performFuzzyMatchScored(tcsMocks, reqBuff)
+	return ok, mock
+}
+
+// fuzzyExactEncodingMatch is the non-guessing part of the fuzzy stage: it
+// matches mocks whose body equals the request after base64
+// encoding/decoding normalization. Safe to run even under
+// test.fuzzyMatch=off, since byte equality is deterministic.
+func (h *HTTP) fuzzyExactEncodingMatch(tcsMocks []*models.Mock, reqBuff []byte) (bool, *models.Mock) {
 	encodedReq := encode(reqBuff)
 	for _, mock := range tcsMocks {
 		encodedMock, _ := decode(mock.Spec.HTTPReq.Body)
@@ -703,6 +772,20 @@ func (h *HTTP) PerformFuzzyMatch(tcsMocks []*models.Mock, reqBuff []byte) (bool,
 				zap.String("match_type", "fuzzy_exact"))
 			return true, mock
 		}
+	}
+	return false, nil
+}
+
+func (h *HTTP) performFuzzyMatchScored(tcsMocks []*models.Mock, reqBuff []byte) (bool, *models.Mock, fuzzyResult) {
+	// Log all mock names in a single line for better readability
+	mockNames := make([]string, len(tcsMocks))
+	for i, mock := range tcsMocks {
+		mockNames[i] = mock.Name
+	}
+	h.Logger.Debug("mocks under consideration for performfuzzyMatch function", zap.Strings("mock names", mockNames))
+
+	if ok, mock := h.fuzzyExactEncodingMatch(tcsMocks, reqBuff); ok {
+		return true, mock, fuzzyResult{matchType: "fuzzy_exact", score: 100.0}
 	}
 
 	// Build mock body strings, stripping noisy values for fair comparison
@@ -729,7 +812,7 @@ func (h *HTTP) PerformFuzzyMatch(tcsMocks []*models.Mock, reqBuff []byte) (bool,
 				zap.String("mock", tcsMocks[idx].Name),
 				zap.Float64("match_percentage", pct),
 				zap.String("match_type", "fuzzy_levenshtein"))
-			return true, tcsMocks[idx]
+			return true, tcsMocks[idx], fuzzyResult{matchType: "fuzzy_levenshtein", score: pct, guessed: true}
 		}
 	}
 
@@ -744,9 +827,9 @@ func (h *HTTP) PerformFuzzyMatch(tcsMocks []*models.Mock, reqBuff []byte) (bool,
 			zap.String("mock", tcsMocks[mxIdx].Name),
 			zap.Float64("match_percentage", mxSim*100),
 			zap.String("match_type", "fuzzy_jaccard"))
-		return true, tcsMocks[mxIdx]
+		return true, tcsMocks[mxIdx], fuzzyResult{matchType: "fuzzy_jaccard", score: mxSim * 100, guessed: true}
 	}
-	return false, nil
+	return false, nil, fuzzyResult{}
 }
 
 // parseMediaTypes splits a (possibly comma-joined) Content-Type header

--- a/pkg/agent/proxy/integrations/http/match.go
+++ b/pkg/agent/proxy/integrations/http/match.go
@@ -274,7 +274,9 @@ func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMe
 			}
 			if bodyKeyMatched && len(shortListed) > 0 {
 				pick := pickDeterministic(shortListed)
-				h.Logger.Info("deterministic tiebreak: serving recorded-order candidate among body-matched mocks",
+				// Debug, not Info: this fires from the per-request matcher hot
+				// path and would flood logs for a large suite.
+				h.Logger.Debug("deterministic tiebreak: serving recorded-order candidate among body-matched mocks",
 					zap.String("mock name", pick.Name),
 					zap.Int("candidates", len(shortListed)))
 				detected := h.detectReqBodyNoise(schemaNoiseDetection, pick, input.body, userBodyNoise)

--- a/pkg/agent/proxy/integrations/mysql/replayer/fuzzy_gate_test.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/fuzzy_gate_test.go
@@ -1,0 +1,90 @@
+package replayer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.keploy.io/server/v3/pkg/models/mysql"
+	"go.uber.org/zap"
+)
+
+func pingMock(name string) *models.Mock {
+	m := &models.Mock{
+		Name: name,
+		Kind: models.MySQL,
+	}
+	m.TestModeInfo.Lifetime = models.LifetimeSession
+	m.Spec.Metadata = map[string]string{"type": "mocks"}
+	m.Spec.MySQLRequests = []mysql.Request{{
+		PacketBundle: mysql.PacketBundle{
+			Header:  &mysql.PacketInfo{Header: &mysql.Header{PayloadLength: 1, SequenceID: 0}, Type: "COM_PING"},
+			Message: &mysql.PingPacket{Command: 0x0e},
+		},
+	}}
+	m.Spec.MySQLResponses = []mysql.Response{{
+		PacketBundle: mysql.PacketBundle{
+			Header:  &mysql.PacketInfo{Header: &mysql.Header{PayloadLength: 7, SequenceID: 1}, Type: "OK"},
+			Message: &mysql.OKPacket{},
+		},
+	}}
+	return m
+}
+
+func pingReq() mysql.Request {
+	return mysql.Request{
+		PacketBundle: mysql.PacketBundle{
+			Header:  &mysql.PacketInfo{Header: &mysql.Header{PayloadLength: 1, SequenceID: 0}, Type: "COM_PING"},
+			Message: &mysql.PingPacket{Command: 0x0e},
+		},
+	}
+}
+
+// Control commands (COM_PING etc.) only ever match via the score path, but
+// their comparators are exact protocol-level matches — the fuzzy-policy gate
+// must NOT classify them as similarity guesses. Under off, a matched ping
+// must still be served; otherwise pooled drivers (keepalive pings) drop their
+// connections the moment deterministic mode is enabled.
+func TestMatchCommand_FuzzyOff_ServesExactControlCommands(t *testing.T) {
+	logger := zap.NewNop()
+	db := &fakeMockDb{session: []*models.Mock{pingMock("ping-1")}}
+	dctx := newDecodeCtx()
+	dctx.FuzzyMatchPolicy = models.FuzzyMatchOff
+
+	resp, ok, _, _, err := matchCommand(context.Background(), logger, pingReq(), db, dctx)
+	if err != nil || !ok || resp == nil {
+		t.Fatalf("exact COM_PING match must be served under fuzzyMatch=off, got ok=%v err=%v", ok, err)
+	}
+}
+
+// A COM_QUERY candidate that survives ONLY via partial-shape scoring (no
+// exact text, no FIFO) is a similarity guess: refused under off, served
+// under on.
+func TestMatchCommand_FuzzyOff_RejectsScoreOnlyQueryPick(t *testing.T) {
+	logger := zap.NewNop()
+	recorded := readbackMock("row-1", "SELECT id, name FROM users WHERE tenant = 'acme'", "m1", time.Time{})
+	liveSQL := "SELECT something_else FROM another_table"
+
+	dctxOff := newDecodeCtx()
+	dctxOff.FuzzyMatchPolicy = models.FuzzyMatchOff
+	dbOff := &fakeMockDb{session: []*models.Mock{recorded}}
+	_, ok, _, _, err := matchCommand(context.Background(), logger, comQueryReq(liveSQL), dbOff, dctxOff)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatal("score-only COM_QUERY pick must be refused under fuzzyMatch=off")
+	}
+
+	dctxOn := newDecodeCtx()
+	dctxOn.FuzzyMatchPolicy = models.FuzzyMatchOn
+	dbOn := &fakeMockDb{session: []*models.Mock{readbackMock("row-1", "SELECT id, name FROM users WHERE tenant = 'acme'", "m1", time.Time{})}}
+	_, ok, _, _, err = matchCommand(context.Background(), logger, comQueryReq(liveSQL), dbOn, dctxOn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("legacy fuzzyMatch=on must keep serving the score-based pick")
+	}
+}

--- a/pkg/agent/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match.go
@@ -375,6 +375,7 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 		matchedMock      *models.Mock
 		queryMatched     bool
 		stmtMatched      bool
+		fifoPicked       bool
 		bestPartialMock  *models.Mock // closest non-exact match for diff reporting
 		bestPartialQuery string       // query of the closest partial match
 
@@ -665,6 +666,28 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 					}()))
 			}
 			matchedResp, matchedMock = chosenResp, chosenMock
+			fifoPicked = true
+		}
+	}
+
+	// Fuzzy-match policy gate for the score-based (partial-shape) pick.
+	// A candidate that survived ONLY via maxMatchedCount scoring — no exact
+	// query text, no definitive query+params match, no recorded-order FIFO —
+	// is a similarity guess and can serve the wrong result set (e.g. a
+	// same-length different SELECT winning at score 1). Under FuzzyMatchOff
+	// the guess is refused so the caller surfaces a structured mock miss;
+	// under FuzzyMatchWarn it is served but logged default-visibly.
+	if matchedMock != nil && !queryMatched && !stmtMatched && !fifoPicked {
+		switch decodeCtx.FuzzyMatchPolicy {
+		case models.FuzzyMatchOff:
+			logger.Warn("deterministic match policy (test.fuzzyMatch=off) rejected a score-based MySQL candidate — treating as a mock miss",
+				zap.String("mock_name", matchedMock.Name),
+				zap.Int("score", maxMatchedCount))
+			matchedResp, matchedMock = nil, nil
+		case models.FuzzyMatchWarn:
+			logger.Warn("MySQL mock served via score-based (partial-shape) match — verify this is the right result set or set test.fuzzyMatch=off for deterministic replay",
+				zap.String("mock_name", matchedMock.Name),
+				zap.Int("score", maxMatchedCount))
 		}
 	}
 

--- a/pkg/agent/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match.go
@@ -677,7 +677,19 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 	// same-length different SELECT winning at score 1). Under FuzzyMatchOff
 	// the guess is refused so the caller surfaces a structured mock miss;
 	// under FuzzyMatchWarn it is served but logged default-visibly.
-	if matchedMock != nil && !queryMatched && !stmtMatched && !fifoPicked {
+	//
+	// The gate applies ONLY to the command types where a partial-shape
+	// similarity pick exists (COM_QUERY, COM_STMT_PREPARE, COM_STMT_EXECUTE).
+	// Control commands (COM_PING, COM_STMT_CLOSE, COM_INIT_DB, COM_STATS,
+	// COM_DEBUG, COM_RESET_CONNECTION) also reach matchedMock through the
+	// score path, but their comparators are exact protocol-level matches on
+	// content-free (or query-exact) packets — refusing or warning on them
+	// would drop connections on routine driver housekeeping (pings,
+	// prepared-statement closes).
+	isFuzzyCapableCmd := req.Header.Type == sCOM_QUERY ||
+		req.Header.Type == sCOM_STMT_PREP ||
+		req.Header.Type == sCOM_STMT_EXEC
+	if matchedMock != nil && isFuzzyCapableCmd && !queryMatched && !stmtMatched && !fifoPicked {
 		switch decodeCtx.FuzzyMatchPolicy {
 		case models.FuzzyMatchOff:
 			logger.Warn("deterministic match policy (test.fuzzyMatch=off) rejected a score-based MySQL candidate — treating as a mock miss",

--- a/pkg/agent/proxy/integrations/mysql/replayer/replay.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/replay.go
@@ -75,7 +75,8 @@ func Replay(ctx context.Context, logger *zap.Logger, clientConn net.Conn, dstCfg
 
 		// Helper struct for decoding packets
 		decodeCtx := &wire.DecodeContext{
-			Mode: models.MODE_TEST,
+			FuzzyMatchPolicy: opts.FuzzyMatchPolicy,
+			Mode:             models.MODE_TEST,
 			// Map for storing last operation per connection
 			LastOp: wire.NewLastOpMap(),
 			// Map for storing server greetings (inc capabilities, auth plugin, etc) per initial handshake (per connection)

--- a/pkg/agent/proxy/integrations/mysql/replayer/replay.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/replay.go
@@ -75,7 +75,7 @@ func Replay(ctx context.Context, logger *zap.Logger, clientConn net.Conn, dstCfg
 
 		// Helper struct for decoding packets
 		decodeCtx := &wire.DecodeContext{
-			FuzzyMatchPolicy: opts.FuzzyMatchPolicy,
+			FuzzyMatchPolicy: models.NormalizeFuzzyPolicy(opts.FuzzyMatchPolicy),
 			Mode:             models.MODE_TEST,
 			// Map for storing last operation per connection
 			LastOp: wire.NewLastOpMap(),

--- a/pkg/agent/proxy/integrations/mysql/wire/util.go
+++ b/pkg/agent/proxy/integrations/mysql/wire/util.go
@@ -32,7 +32,8 @@ type DecodeContext struct {
 	NextStmtID uint32
 	// FuzzyMatchPolicy (models.FuzzyMatch*) governs the score-based
 	// (partial-shape) candidate selection in command-phase matching.
-	// Empty string behaves like models.FuzzyMatchOn (legacy).
+	// Callers normalize via models.NormalizeFuzzyPolicy, so an unset
+	// value behaves like the shipped default (warn).
 	FuzzyMatchPolicy string
 }
 

--- a/pkg/agent/proxy/integrations/mysql/wire/util.go
+++ b/pkg/agent/proxy/integrations/mysql/wire/util.go
@@ -30,6 +30,10 @@ type DecodeContext struct {
 	StmtIDToQuery map[uint32]string
 	// Statement ID counter for generating unique statement IDs during replay
 	NextStmtID uint32
+	// FuzzyMatchPolicy (models.FuzzyMatch*) governs the score-based
+	// (partial-shape) candidate selection in command-phase matching.
+	// Empty string behaves like models.FuzzyMatchOn (legacy).
+	FuzzyMatchPolicy string
 }
 
 const CLIENT_DEPRECATE_EOF = 0x01000000

--- a/pkg/agent/proxy/integrations/util/obfuscate.go
+++ b/pkg/agent/proxy/integrations/util/obfuscate.go
@@ -63,10 +63,10 @@ func NewNoiseChecker(patterns []string) *NoiseChecker {
 	}
 	compiled := make([]*regexp.Regexp, 0, len(patterns))
 	for _, p := range patterns {
+		// getCachedRegexp already logs an invalid pattern once (negative cache
+		// prevents repeats); just skip it here rather than logging it twice.
 		if re := getCachedRegexp(p); re != nil {
 			compiled = append(compiled, re)
-		} else {
-			log.Printf("keploy: ignoring invalid noise regex pattern %q in Mock.Noise — check the pattern syntax", p)
 		}
 	}
 	if len(compiled) == 0 {

--- a/pkg/agent/proxy/integrations/util/obfuscate.go
+++ b/pkg/agent/proxy/integrations/util/obfuscate.go
@@ -35,6 +35,10 @@ func getCachedRegexp(pattern string) *regexp.Regexp {
 	compiled, err := regexp.Compile(pattern)
 	if err != nil {
 		compiled = nil // will be cached as negative result
+		// Mock.Noise is user-editable (mocks.yaml `noise:` regexes). A typo'd
+		// pattern silently never matching is a debugging dead end — say so
+		// once (the negative cache prevents repeats for this pattern).
+		log.Printf("keploy: invalid noise regex %q in mock noise config ignored (it will never match): %v", pattern, err)
 	}
 	noiseCacheMu.Lock()
 	// Evict all entries when cache is full to bound memory usage.

--- a/pkg/models/errors.go
+++ b/pkg/models/errors.go
@@ -63,6 +63,7 @@ const (
 	MatchPhaseBody       = "body_mismatch"        // schema candidates existed, request body ruled them all out
 	MatchPhaseStrict     = "strict_noise_reject"  // candidates rejected by strict req-body-noise enforcement
 	MatchPhaseExhausted  = "no_match"             // full cascade ran and nothing matched
+	MatchPhaseFuzzyOff   = "fuzzy_match_disabled" // candidates existed but similarity fallback is disabled (test.fuzzyMatch=off)
 	MatchPhaseProtoError = "protocol_error"       // matching aborted on a protocol/decode error
 )
 

--- a/pkg/models/instrument.go
+++ b/pkg/models/instrument.go
@@ -51,6 +51,24 @@ type IngressEvent struct {
 	_           uint16 // Padding
 }
 
+// Fuzzy-match policy values for config Test.FuzzyMatch and
+// OutgoingOptions.FuzzyMatchPolicy. They govern the similarity-based
+// fallbacks in mock matching (HTTP Levenshtein/Jaccard, generic Jaccard,
+// MySQL partial-shape scoring):
+//
+//	FuzzyMatchOn   — legacy behaviour: a similarity fallback may serve a mock silently.
+//	FuzzyMatchWarn — similarity fallbacks still run, but every fuzzy-served mock
+//	                 logs a default-visible Warn naming the mock and score.
+//	FuzzyMatchOff  — deterministic replay: similarity guessing is disabled.
+//	                 Recorded-order (FIFO/SortOrder) tiebreaks still apply;
+//	                 anything that would need a similarity guess becomes a
+//	                 structured mock miss instead.
+const (
+	FuzzyMatchOn   = "on"
+	FuzzyMatchWarn = "warn"
+	FuzzyMatchOff  = "off"
+)
+
 type OutgoingOptions struct {
 	Rules         []BypassRule
 	MongoPassword string
@@ -65,6 +83,7 @@ type OutgoingOptions struct {
 	DisableAutoHeaderNoise bool                           // when true, skip injecting default flaky headers (e.g. AWS SigV4) into noise
 	SchemaNoiseDetection   bool                           // when true, detect request-body field drift vs the recorded mock and record it as field-path noise (req_body_noise) on the matched mock
 	SchemaNoiseStrict      bool                           // when true (replay/enforcement path), an HTTP mock that carries learned req_body_noise must match strictly: every request-body field must match except the learned-noise paths, so a non-noise drift rejects the mock
+	FuzzyMatchPolicy       string                         // FuzzyMatchOn/Warn/Off — policy for similarity-based mock-match fallbacks
 	SkipTLSMITM            bool
 	ConnKey                string // connection-level key for TLSHandshakeStore correlation
 	// CapturePackets toggles raw packet capture on the agent's proxy ports

--- a/pkg/models/instrument.go
+++ b/pkg/models/instrument.go
@@ -69,6 +69,19 @@ const (
 	FuzzyMatchOff  = "off"
 )
 
+// NormalizeFuzzyPolicy maps an unset/unknown policy to the shipped default
+// (FuzzyMatchWarn). Call it at every consumption point so an option struct
+// built without the field (older callers, in-cluster paths) behaves exactly
+// like the documented default instead of silently diverging per protocol.
+func NormalizeFuzzyPolicy(p string) string {
+	switch p {
+	case FuzzyMatchOn, FuzzyMatchWarn, FuzzyMatchOff:
+		return p
+	default:
+		return FuzzyMatchWarn
+	}
+}
+
 type OutgoingOptions struct {
 	Rules         []BypassRule
 	MongoPassword string

--- a/pkg/service/replay/missing_mapped_mocks_test.go
+++ b/pkg/service/replay/missing_mapped_mocks_test.go
@@ -1,0 +1,45 @@
+package replay
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// Mocks mapped exclusively to UNSELECTED tests are deliberately not loaded by
+// mockdb; they must not be reported as pruned/missing on selective runs.
+func TestReportMissingMappedMocks_SelectionAware(t *testing.T) {
+	r := &Replayer{logger: zap.NewNop(), mockMismatchFailures: NewTestFailureStore()}
+	mappings := map[string][]models.MockEntry{
+		"test-1": {{Name: "mock-1"}}, // selected, loaded → no row
+		"test-2": {{Name: "mock-2"}}, // selected, missing → row
+		"test-3": {{Name: "mock-3"}}, // NOT selected, not loaded → no row
+	}
+	loaded := []*models.Mock{{Name: "mock-1"}}
+	selected := map[string]bool{"test-1": true, "test-2": true}
+
+	r.reportMissingMappedMocks("ts-1", mappings, selected, loaded, nil)
+
+	fails := r.mockMismatchFailures.GetFailures()
+	if len(fails) != 1 {
+		t.Fatalf("expected exactly one missing-mock row, got %d: %+v", len(fails), fails)
+	}
+	if fails[0].TestID != "test-2" || len(fails[0].ExpectedMocks) != 1 || fails[0].ExpectedMocks[0] != "mock-2" {
+		t.Errorf("unexpected row: %+v", fails[0])
+	}
+}
+
+// With no selection, every mapped test participates.
+func TestReportMissingMappedMocks_FullRun(t *testing.T) {
+	r := &Replayer{logger: zap.NewNop(), mockMismatchFailures: NewTestFailureStore()}
+	mappings := map[string][]models.MockEntry{
+		"test-1": {{Name: "mock-1"}},
+		"test-2": {{Name: "mock-2"}},
+	}
+	r.reportMissingMappedMocks("ts-1", mappings, nil, []*models.Mock{{Name: "mock-1"}}, nil)
+	fails := r.mockMismatchFailures.GetFailures()
+	if len(fails) != 1 || fails[0].TestID != "test-2" {
+		t.Fatalf("expected one row for test-2, got %+v", fails)
+	}
+}

--- a/pkg/service/replay/payload_aware_mismatch_test.go
+++ b/pkg/service/replay/payload_aware_mismatch_test.go
@@ -1,0 +1,42 @@
+package replay
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// TestHasPayloadAwareMismatch pins the rule that decides whether a mock mismatch
+// fails the test: only a MatchPhaseBody mismatch (schema matched, request body
+// diverged — a real payload regression) does. Benign misses (no candidate /
+// schema phase, DNS, unrecorded ops) stay warn-only.
+func TestHasPayloadAwareMismatch(t *testing.T) {
+	r := &Replayer{mockMismatchFailures: NewTestFailureStore()}
+
+	if r.hasPayloadAwareMismatch("ts-0", "tc-1") {
+		t.Fatal("no failures must not be a payload-aware mismatch")
+	}
+
+	// A body-phase mismatch is a real payload regression -> must fail the test.
+	r.mockMismatchFailures.AddUnmatchedCallForTest("ts-0", "tc-1", models.UnmatchedCall{
+		Protocol:   "Pulsar",
+		MatchPhase: models.MatchPhaseBody,
+	})
+	if !r.hasPayloadAwareMismatch("ts-0", "tc-1") {
+		t.Error("a MatchPhaseBody mismatch must be payload-aware (fail the test)")
+	}
+
+	// A schema-phase miss (no candidate / benign) must NOT fail the test.
+	r.mockMismatchFailures.AddUnmatchedCallForTest("ts-0", "tc-2", models.UnmatchedCall{
+		Protocol:   "Pulsar",
+		MatchPhase: models.MatchPhaseSchema,
+	})
+	if r.hasPayloadAwareMismatch("ts-0", "tc-2") {
+		t.Error("a non-body (schema) miss must NOT fail the test (warn-only)")
+	}
+
+	// Scoped per test case: tc-1's body mismatch must not leak to another case.
+	if r.hasPayloadAwareMismatch("ts-0", "tc-99") {
+		t.Error("an unrelated test case must not report a payload-aware mismatch")
+	}
+}

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1175,6 +1175,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			DisableAutoHeaderNoise: r.config.Test.DisableAutoHeaderNoise,
 			SchemaNoiseDetection:   r.config.Test.SchemaNoiseDetection,
 			SchemaNoiseStrict:      r.config.Test.SchemaNoiseStrict,
+			FuzzyMatchPolicy:       r.config.Test.FuzzyMatch,
 			MysqlPorts:             r.config.MysqlPorts,
 		})
 		if err != nil {
@@ -1218,6 +1219,10 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 
 		addKinds(filteredMocks)
 		addKinds(unfilteredMocks)
+
+		if isMappingEnabled {
+			r.reportMissingMappedMocks(testSetID, expectedTestMockMappings, filteredMocks, unfilteredMocks)
+		}
 
 		// Extract host domains from mocks for telemetry (HTTP and gRPC only)
 		if r.runDomainSet != nil {
@@ -1315,6 +1320,9 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		}
 		addKinds(filteredMocks)
 		addKinds(unfilteredMocks)
+		if isMappingEnabled {
+			r.reportMissingMappedMocks(testSetID, expectedTestMockMappings, filteredMocks, unfilteredMocks)
+		}
 		// Extract host domains from mocks for telemetry (HTTP and gRPC only)
 		if r.runDomainSet != nil {
 			for _, m := range filteredMocks {
@@ -1364,6 +1372,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			DisableAutoHeaderNoise: r.config.Test.DisableAutoHeaderNoise,
 			SchemaNoiseDetection:   r.config.Test.SchemaNoiseDetection,
 			SchemaNoiseStrict:      r.config.Test.SchemaNoiseStrict,
+			FuzzyMatchPolicy:       r.config.Test.FuzzyMatch,
 			MysqlPorts:             r.config.MysqlPorts,
 		})
 		if err != nil {
@@ -3224,6 +3233,58 @@ func (r *Replayer) CompareGRPCResp(tc *models.TestCase, actualResp *models.GrpcR
 	}
 
 	return grpcMatcher.Match(tc, actualResp, noiseConfig, r.config.Test.IgnoreOrdering, r.logger, emitFailureLogs)
+}
+
+// reportMissingMappedMocks detects mocks that mappings.yaml says the test set
+// needs but that no longer exist in the mock file — the dedup/evolution case:
+// pruned by --remove-unused-mocks, dropped during a hand-edit, or lost in a
+// partial sync. Without this check the replay silently degrades into misses
+// (or worse, fuzzy substitutions) on calls whose recorded answer was simply
+// deleted. Each affected test gets a row in the MOCKS MISMATCH SUMMARY so the
+// root cause is named BEFORE the first confusing test failure.
+func (r *Replayer) reportMissingMappedMocks(testSetID string, expectedTestMockMappings map[string][]models.MockEntry, filteredMocks, unfilteredMocks []*models.Mock) {
+	if len(expectedTestMockMappings) == 0 {
+		return
+	}
+	loaded := make(map[string]bool, len(filteredMocks)+len(unfilteredMocks))
+	for _, m := range filteredMocks {
+		loaded[m.Name] = true
+	}
+	for _, m := range unfilteredMocks {
+		loaded[m.Name] = true
+	}
+
+	missingByTest := map[string][]string{}
+	missingSet := map[string]bool{}
+	for testID, entries := range expectedTestMockMappings {
+		for _, e := range entries {
+			if !loaded[e.Name] {
+				missingByTest[testID] = append(missingByTest[testID], e.Name)
+				missingSet[e.Name] = true
+			}
+		}
+	}
+	if len(missingByTest) == 0 {
+		return
+	}
+
+	var missing []string
+	for name := range missingSet {
+		missing = append(missing, name)
+	}
+	sort.Strings(missing)
+	r.logger.Warn("mappings.yaml references mocks that are missing from the mock file — they may have been pruned (--remove-unused-mocks), deduplicated, or removed in an edit. Tests that consumed them will miss during replay.",
+		zap.String("testSetID", testSetID),
+		zap.Int("affectedTests", len(missingByTest)),
+		zap.Strings("missingMocks", missing),
+		zap.String("next_steps", "Re-record the test-set with 'keploy record' to regenerate the mocks, or run with --update-test-mapping to refresh mappings against the current mock file."))
+
+	for testID, names := range missingByTest {
+		sort.Strings(names)
+		// ExpectedMocks populated, ActualMocks empty → the summary table
+		// renders these as "Missing mocks: ..." for the affected test.
+		r.mockMismatchFailures.AddFailure(testSetID, testID, names, []string{})
+	}
 }
 
 func (r *Replayer) printSummary(_ context.Context, _ bool) {

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1221,7 +1221,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		addKinds(unfilteredMocks)
 
 		if isMappingEnabled {
-			r.reportMissingMappedMocks(testSetID, expectedTestMockMappings, filteredMocks, unfilteredMocks)
+			r.reportMissingMappedMocks(testSetID, expectedTestMockMappings, selectedTests, filteredMocks, unfilteredMocks)
 		}
 
 		// Extract host domains from mocks for telemetry (HTTP and gRPC only)
@@ -1321,7 +1321,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		addKinds(filteredMocks)
 		addKinds(unfilteredMocks)
 		if isMappingEnabled {
-			r.reportMissingMappedMocks(testSetID, expectedTestMockMappings, filteredMocks, unfilteredMocks)
+			r.reportMissingMappedMocks(testSetID, expectedTestMockMappings, selectedTests, filteredMocks, unfilteredMocks)
 		}
 		// Extract host domains from mocks for telemetry (HTTP and gRPC only)
 		if r.runDomainSet != nil {
@@ -3242,7 +3242,7 @@ func (r *Replayer) CompareGRPCResp(tc *models.TestCase, actualResp *models.GrpcR
 // (or worse, fuzzy substitutions) on calls whose recorded answer was simply
 // deleted. Each affected test gets a row in the MOCKS MISMATCH SUMMARY so the
 // root cause is named BEFORE the first confusing test failure.
-func (r *Replayer) reportMissingMappedMocks(testSetID string, expectedTestMockMappings map[string][]models.MockEntry, filteredMocks, unfilteredMocks []*models.Mock) {
+func (r *Replayer) reportMissingMappedMocks(testSetID string, expectedTestMockMappings map[string][]models.MockEntry, selectedTests map[string]bool, filteredMocks, unfilteredMocks []*models.Mock) {
 	if len(expectedTestMockMappings) == 0 {
 		return
 	}
@@ -3257,6 +3257,15 @@ func (r *Replayer) reportMissingMappedMocks(testSetID string, expectedTestMockMa
 	missingByTest := map[string][]string{}
 	missingSet := map[string]bool{}
 	for testID, entries := range expectedTestMockMappings {
+		// When the user runs a subset of tests, mocks mapped exclusively to
+		// unselected tests are DELIBERATELY not loaded (mockdb skips them via
+		// the mocksWeNeed predicate) — they are not missing from the file and
+		// must not be reported as pruned.
+		if len(selectedTests) > 0 {
+			if _, ok := selectedTests[testID]; !ok {
+				continue
+			}
+		}
 		for _, e := range entries {
 			if !loaded[e.Name] {
 				missingByTest[testID] = append(missingByTest[testID], e.Name)

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -3286,7 +3286,7 @@ func (r *Replayer) reportMissingMappedMocks(testSetID string, expectedTestMockMa
 		zap.String("testSetID", testSetID),
 		zap.Int("affectedTests", len(missingByTest)),
 		zap.Strings("missingMocks", missing),
-		zap.String("next_steps", "Re-record the test-set with 'keploy record' to regenerate the mocks, or run with --update-test-mapping to refresh mappings against the current mock file."))
+		zap.String("next_step", "Re-record the test-set with 'keploy record' to regenerate the mocks, or run with --update-test-mapping to refresh mappings against the current mock file."))
 
 	for testID, names := range missingByTest {
 		sort.Strings(names)

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -235,6 +235,24 @@ func (r *Replayer) GetMockMismatchFailures() []TestFailure {
 	return r.mockMismatchFailures.GetFailures()
 }
 
+// hasPayloadAwareMismatch reports whether the test case hit a mock mismatch where
+// the schema matched a recorded mock but the request body diverged
+// (MatchPhaseBody) — a real payload regression (the Flipkart contactNumber
+// class). Unlike a benign miss (an unrecorded retry/cleanup op, or a DNS lookup
+// answered synthetically), a payload-aware mismatch must FAIL the test even when
+// the application's recorded response is unchanged — e.g. an async Pulsar/Kafka/
+// SQS SEND whose divergence never shows up in the HTTP response — so CI catches
+// the drift instead of staying green. Benign misses keep their warn-only
+// behaviour (they are not MatchPhaseBody).
+func (r *Replayer) hasPayloadAwareMismatch(testSetID, testCaseName string) bool {
+	for _, f := range r.mockMismatchFailures.GetFailuresForTestCase(testSetID, testCaseName) {
+		if f.MismatchReport != nil && f.MismatchReport.MatchPhase == models.MatchPhaseBody {
+			return true
+		}
+	}
+	return false
+}
+
 // GetTestRunID returns the current test run ID.
 func (r *Replayer) GetTestRunID() string {
 	return r.testRunID
@@ -1923,14 +1941,18 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			} else {
 				r.logger.Info("result", zap.String("testcase id", models.HighlightPassingString(testCase.Name)), zap.String("testset id", models.HighlightPassingString(testSetID)), zap.String("passed", models.HighlightPassingString(testPass)))
 			}
-			if testPass {
+			// A payload-aware mock mismatch (schema matched, request body diverged)
+			// is a real regression and must fail the test even when the recorded
+			// response is unchanged, and must not be demoted to OBSOLETE.
+			payloadMismatch := r.hasPayloadAwareMismatch(testSetID, testCase.Name)
+			if testPass && !payloadMismatch {
 				testStatus = models.TestStatusPassed
 				currentSuccess++
 				nextTestsToRun = append(nextTestsToRun, testCase)
 				for _, m := range consumedMocks {
 					passingTotalConsumedMocks[m.Name] = m
 				}
-			} else if mockSetMismatch && !strictMockReject && !r.config.Test.StrictFailure {
+			} else if mockSetMismatch && !strictMockReject && !r.config.Test.StrictFailure && !payloadMismatch {
 				testStatus = models.TestStatusObsolete
 				currentObsolete++
 			} else {
@@ -2470,14 +2492,18 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			}
 
 			//  Record: Update counters and persist result.
+			// A payload-aware mock mismatch (schema matched, request body diverged)
+			// is a real regression and must fail the test even when the recorded
+			// response is unchanged, and must not be demoted to OBSOLETE.
+			payloadMismatch := r.hasPayloadAwareMismatch(testSetID, tc.Name)
 			var testStatus models.TestStatus
-			if testPass {
+			if testPass && !payloadMismatch {
 				testStatus = models.TestStatusPassed
 				success++
 				for _, m := range consumedMocks {
 					passingTotalConsumedMocks[m.Name] = m
 				}
-			} else if mockSetMismatch && !r.config.Test.StrictFailure {
+			} else if mockSetMismatch && !r.config.Test.StrictFailure && !payloadMismatch {
 				testStatus = models.TestStatusObsolete
 				obsolete++
 			} else {

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1941,18 +1941,14 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			} else {
 				r.logger.Info("result", zap.String("testcase id", models.HighlightPassingString(testCase.Name)), zap.String("testset id", models.HighlightPassingString(testSetID)), zap.String("passed", models.HighlightPassingString(testPass)))
 			}
-			// A payload-aware mock mismatch (schema matched, request body diverged)
-			// is a real regression and must fail the test even when the recorded
-			// response is unchanged, and must not be demoted to OBSOLETE.
-			payloadMismatch := r.hasPayloadAwareMismatch(testSetID, testCase.Name)
-			if testPass && !payloadMismatch {
+			if testPass {
 				testStatus = models.TestStatusPassed
 				currentSuccess++
 				nextTestsToRun = append(nextTestsToRun, testCase)
 				for _, m := range consumedMocks {
 					passingTotalConsumedMocks[m.Name] = m
 				}
-			} else if mockSetMismatch && !strictMockReject && !r.config.Test.StrictFailure && !payloadMismatch {
+			} else if mockSetMismatch && !strictMockReject && !r.config.Test.StrictFailure {
 				testStatus = models.TestStatusObsolete
 				currentObsolete++
 			} else {
@@ -2108,6 +2104,26 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 					// so the agent's error channel is consumed only inside the
 					// agent's own drain goroutine, never by the replayer.
 					r.attachMockErrors(runTestSetCtx, testSetID, testCase.Name, testCaseResult)
+					// Re-classify AFTER the drain above (the per-test failure store is only
+					// populated now): a payload-aware mismatch — schema matched, request body
+					// diverged — must FAIL the test even when the recorded response is unchanged
+					// (e.g. an async Pulsar/Kafka/SQS SEND), and must not stay PASSED or be
+					// demoted to OBSOLETE. Benign misses are not MatchPhaseBody (warn-only).
+					if testStatus != models.TestStatusFailed && r.hasPayloadAwareMismatch(testSetID, testCase.Name) {
+						switch testStatus {
+						case models.TestStatusPassed:
+							currentSuccess--
+							if n := len(nextTestsToRun); n > 0 && nextTestsToRun[n-1].Name == testCase.Name {
+								nextTestsToRun = nextTestsToRun[:n-1]
+							}
+						case models.TestStatusObsolete:
+							currentObsolete--
+						}
+						testStatus = models.TestStatusFailed
+						currentFailures++
+						testSetStatus = models.TestSetStatusFailed
+						testCaseResult.Status = models.TestStatusFailed
+					}
 					// Build the {expected, actual} mock set for THIS test case.
 					// See buildExpectedMockInfos / buildActualMockInfos at the
 					// bottom of this file for DNS-filter + perTestConsumed-known
@@ -2492,18 +2508,14 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			}
 
 			//  Record: Update counters and persist result.
-			// A payload-aware mock mismatch (schema matched, request body diverged)
-			// is a real regression and must fail the test even when the recorded
-			// response is unchanged, and must not be demoted to OBSOLETE.
-			payloadMismatch := r.hasPayloadAwareMismatch(testSetID, tc.Name)
 			var testStatus models.TestStatus
-			if testPass && !payloadMismatch {
+			if testPass {
 				testStatus = models.TestStatusPassed
 				success++
 				for _, m := range consumedMocks {
 					passingTotalConsumedMocks[m.Name] = m
 				}
-			} else if mockSetMismatch && !r.config.Test.StrictFailure && !payloadMismatch {
+			} else if mockSetMismatch && !r.config.Test.StrictFailure {
 				testStatus = models.TestStatusObsolete
 				obsolete++
 			} else {
@@ -2549,6 +2561,22 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 				// post-stream consumed-mock drain above, so in-stream mock misses
 				// are included - and attach them to this result.
 				r.attachMockErrors(runTestSetCtx, testSetID, tc.Name, testCaseResult)
+				// Re-classify AFTER the drain above (see the non-streaming path): a
+				// payload-aware mismatch (schema matched, request body diverged) must FAIL
+				// the test even when the recorded response is unchanged; benign misses
+				// (not MatchPhaseBody) stay warn-only.
+				if testStatus != models.TestStatusFailed && r.hasPayloadAwareMismatch(testSetID, tc.Name) {
+					switch testStatus {
+					case models.TestStatusPassed:
+						success--
+					case models.TestStatusObsolete:
+						obsolete--
+					}
+					testStatus = models.TestStatusFailed
+					failure++
+					testSetStatus = models.TestSetStatusFailed
+					testCaseResult.Status = models.TestStatusFailed
+				}
 
 				loopErr = r.reportDB.InsertTestCaseResult(runTestSetCtx, testRunID, testSetID, testCaseResult)
 				if loopErr != nil {

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -745,6 +745,21 @@ func (tfs *TestFailureStore) GetFailures() []TestFailure {
 	return failures
 }
 
+// GetFailuresForTestCase returns the failures recorded for a specific test set +
+// test case.
+func (tfs *TestFailureStore) GetFailuresForTestCase(testSetID, testCaseID string) []TestFailure {
+	tfs.mu.Lock()
+	defer tfs.mu.Unlock()
+
+	var result []TestFailure
+	for _, f := range tfs.failures {
+		if f.TestSetID == testSetID && f.TestID == testCaseID {
+			result = append(result, f)
+		}
+	}
+	return result
+}
+
 type MockDifference struct {
 	Key            string
 	ExpectedValues []string

--- a/pkg/service/runner/runner.go
+++ b/pkg/service/runner/runner.go
@@ -374,6 +374,7 @@ func (r *Runner) setupTestSet(parentCtx context.Context, testSetID string, backd
 		outOpts.DisableAutoHeaderNoise = r.config.Test.DisableAutoHeaderNoise
 		outOpts.SchemaNoiseDetection = r.config.Test.SchemaNoiseDetection
 		outOpts.SchemaNoiseStrict = r.config.Test.SchemaNoiseStrict
+		outOpts.FuzzyMatchPolicy = r.config.Test.FuzzyMatch
 		outOpts.MysqlPorts = r.config.MysqlPorts
 	}
 	noiseCfg := map[string]map[string][]string{}


### PR DESCRIPTION
## Describe the changes that are made
This PR is the **fuzzy-matching audit** follow-up, stacked on #4271 (universal mismatch reporting). It turns every similarity-based mock-match fallback into an explicit, auditable policy and adds a deterministic replay mode.

**Audit of similarity fallbacks covered here (OSS):**
| Site | Today | Risk |
|---|---|---|
| HTTP `PerformFuzzyMatch` | min-Levenshtein / max-Jaccard, **no threshold** — once schema matches, something is always served | wrong mock served silently |
| Generic parser | Jaccard ≥ 0.9 (per-test) / **0.4 (session)** | wrong opaque exchange served |
| MySQL command phase | `maxMatchedCount` partial-shape score as last resort | different query's result set served (same-length COM_QUERY can win at score 1) |

(The postgres/mongo/grpc matchers live in the `integrations` repo — the per-protocol docs PR documents their behavior; migrating them onto this policy is follow-up.)

**New policy — `test.fuzzyMatch` / `--fuzzy-match`:**
- **`warn` (new default)**: matching outcomes unchanged, but every similarity-served mock now logs a default-visible Warn naming the mock, match type, score, and candidate count. This is the audit trail for deciding when a suite can move to `off`.
- **`on`**: legacy silent behaviour.
- **`off` — deterministic replay**:
  - byte-equality (encoding-normalized) matches still serve — they're deterministic;
  - multiple body-key-matched HTTP candidates resolve by **recorded order** (lowest SortOrder) — a FIFO tiebreak, not a similarity guess;
  - anything else is a **structured mock miss** with the new `fuzzy_match_disabled` phase, flowing through the #4271 report pipeline (CLI table, report yaml, `keploy report`, platform);
  - generic parser skips Jaccard entirely; MySQL refuses candidates that survived *only* the score-based pick (exact-text, definitive query+params, and recorded-order FIFO picks — including the existing COM_STMT_EXECUTE FIFO fallback — are untouched).

**Deterministic record/replay when mocks are removed by dedup/pruning/evolution:**
At test-set load, mocks referenced by `mappings.yaml` but missing from the mock file (pruned via `--remove-unused-mocks`, deduplicated, or lost in an edit) are detected up front: a Warn names the missing mocks and likely causes, and each affected test gets a `Missing mocks:` row in the `MOCKS MISMATCH SUMMARY` — instead of the replay failing one unexplained miss at a time.

**Mock.Noise usability:** user-edited `noise:` regexes in mocks.yaml that fail to compile now log a one-time warning instead of silently never matching.

## Links & References

**Closes:** NA

### 🔗 Related PRs
- Stacked on #4271 (must merge first; base branch is `feat/unified-mock-mismatch-reporting`)
### 🐞 Related Issues
- NA
### 📄 Related Documents
- Per-protocol matching reference PR in keploy/docs (companion)

## What type of PR is this? (check all applicable)
- [x] 🍕 Feature

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed (companion keploy/docs PR covers the per-protocol matching + policy reference)

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

Unit coverage: HTTP deterministic tiebreak (recorded-order pick), miss-instead-of-guess with `fuzzy_match_disabled` phase, warn-policy still serving via similarity, `lowestSortOrder`; generic policy gate (off blocks Jaccard, warn keeps it, exact unaffected).

Manual: run `keploy test` (default `warn`) against a test set with a drifting request body — observe the new Warn on each fuzzy-served mock. Re-run with `--fuzzy-match off` — the drifted call becomes a structured miss in the mismatch table/report instead of a silent substitution. Delete a mock named in mappings.yaml and re-run — the missing-mock Warn and summary row appear before any test executes.

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA

🤖 Generated with [Claude Code](https://claude.com/claude-code)
