### PR TITLE
feat(mismatch): unified mock-mismatch reporting + whole-mock side-by-side diff

### DIFF
--- a/.github/workflows/golang_linux.yml
+++ b/.github/workflows/golang_linux.yml
@@ -33,6 +33,9 @@ jobs:
           - name: http-pokeapi
             path: http-pokeapi
             script_dir: http_pokeapi
+          - name: mock-mismatch
+            path: http-pokeapi
+            script_dir: mock_mismatch
           - name: risk-profile
             path: risk-profile
             script_dir: risk_profile

--- a/.github/workflows/golang_linux.yml
+++ b/.github/workflows/golang_linux.yml
@@ -36,6 +36,9 @@ jobs:
           - name: mock-mismatch
             path: http-pokeapi
             script_dir: mock_mismatch
+          - name: mock-mismatch-streaming
+            path: sse-redis
+            script_dir: mock_mismatch_streaming
           - name: risk-profile
             path: risk-profile
             script_dir: risk_profile

--- a/.github/workflows/test_workflow_scripts/golang/mock_mismatch/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/mock_mismatch/golang-linux.sh
@@ -125,17 +125,22 @@ if grep -qE "Mock mismatch: \[HTTP\][^]]*/api/v2/" test_logs.txt; then
     mismatch_reported=true
 fi
 
-# Equivalent specific check on the test-set report yaml: an unmatched_calls
-# entry whose protocol is HTTP and whose actual_summary references /api/v2/.
+# Equivalent specific check on the test-set report yaml: a SINGLE unmatched_calls
+# item whose protocol is HTTP *and* whose actual_summary references /api/v2/.
+# actual_summary appears only inside unmatched_calls items, and each item's
+# protocol line precedes its actual_summary, so tracking the most recent
+# protocol per item binds both fields to the same entry (independent greps
+# could otherwise match different items).
 shopt -s nullglob
 reports=( ./keploy/reports/test-run-*/test-set-*-report.yaml )
 shopt -u nullglob
 for rf in "${reports[@]}"; do
-    # Limit the scan to each report's unmatched_calls block and require both an
-    # HTTP protocol and an /api/v2/ actual_summary within it.
-    if awk '/unmatched_calls:/{f=1} f' "$rf" | grep -qE "protocol: ?\"?HTTP" \
-        && awk '/unmatched_calls:/{f=1} f' "$rf" | grep -qE "actual_summary:.*/api/v2/"; then
-        echo "✓ $(basename "$rf") has an HTTP /api/v2/ unmatched_calls entry"
+    if awk '
+        /protocol:/        { httpItem = ($0 ~ /HTTP/) }
+        /actual_summary:/  { if (httpItem && $0 ~ /\/api\/v2\//) { found = 1 } }
+        END                { exit found ? 0 : 1 }
+    ' "$rf"; then
+        echo "✓ $(basename "$rf") has a single HTTP /api/v2/ unmatched_calls entry"
         mismatch_reported=true
     fi
 done

--- a/.github/workflows/test_workflow_scripts/golang/mock_mismatch/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/mock_mismatch/golang-linux.sh
@@ -114,30 +114,40 @@ if grep "WARNING: DATA RACE" test_logs.txt; then
     exit 1
 fi
 
-# Assert the mismatch surfaced. Primary signal: the console "MOCK MISMATCH"
-# report / per-call "Mock mismatch:" heading printed by the replayer.
+# Assert the SPECIFIC forced mismatch surfaced — an HTTP unmatched outgoing
+# call on the mutated /api/v2/ path. A generic banner (e.g. a routine DNS miss)
+# must NOT satisfy this, otherwise the suite could pass while the HTTP mismatch
+# was actually dropped. The per-call heading is "Mock mismatch: [HTTP] <METHOD>
+# <path>" and the live path is the unmutated /api/v2/... the app requested.
 mismatch_reported=false
-if grep -qiE "MOCK MISMATCH|Mock mismatch:" test_logs.txt; then
-    echo "✓ replay surfaced the MOCK MISMATCH report"
+if grep -qE "Mock mismatch: \[HTTP\][^]]*/api/v2/" test_logs.txt; then
+    echo "✓ replay reported the forced HTTP /api/v2/ mock mismatch"
     mismatch_reported=true
 fi
 
-# Secondary signal: the test-set report YAML carries unmatched_calls / match_phase.
+# Equivalent specific check on the test-set report yaml: an unmatched_calls
+# entry whose protocol is HTTP and whose actual_summary references /api/v2/.
 shopt -s nullglob
 reports=( ./keploy/reports/test-run-*/test-set-*-report.yaml )
 shopt -u nullglob
 for rf in "${reports[@]}"; do
-    if grep -qE "unmatched_calls|match_phase|closest_mock" "$rf"; then
-        echo "✓ report $(basename "$rf") carries the structured mismatch fields"
+    # Limit the scan to each report's unmatched_calls block and require both an
+    # HTTP protocol and an /api/v2/ actual_summary within it.
+    if awk '/unmatched_calls:/{f=1} f' "$rf" | grep -qE "protocol: ?\"?HTTP" \
+        && awk '/unmatched_calls:/{f=1} f' "$rf" | grep -qE "actual_summary:.*/api/v2/"; then
+        echo "✓ $(basename "$rf") has an HTTP /api/v2/ unmatched_calls entry"
         mismatch_reported=true
     fi
 done
 
 if [ "$mismatch_reported" != true ]; then
-    echo "::error::replay did NOT surface the mock mismatch — report regressed"
-    cat test_logs.txt
+    echo "::error::replay did NOT report the forced HTTP /api/v2/ mock mismatch"
+    echo "--- mismatch/unmatched lines in test_logs.txt ---"
+    grep -iE "mismatch|unmatched|no matching" test_logs.txt | head -20
+    echo "--- tail of test_logs.txt ---"
+    tail -40 test_logs.txt
     exit 1
 fi
 
-echo "mock-mismatch e2e passed: the unmatched outgoing call was reported"
+echo "mock-mismatch e2e passed: the forced HTTP /api/v2/ unmatched call was reported"
 exit 0

--- a/.github/workflows/test_workflow_scripts/golang/mock_mismatch/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/mock_mismatch/golang-linux.sh
@@ -78,7 +78,11 @@ send_request() {
     pid=$(pgrep keploy)
     echo "$pid Keploy PID"
     echo "Killing Keploy"
-    sudo kill "$pid"
+    # Unquoted on purpose: pgrep can return BOTH the keploy CLI and the agent
+    # process, so $pid may be multiple newline-separated PIDs. Quoting it passes
+    # one mangled arg to kill ("failed to parse argument"), keploy survives, and
+    # `wait` on the record command hangs to the job timeout. Word-split instead.
+    sudo kill $pid
 }
 
 # Record one iteration of test cases + mocks.

--- a/.github/workflows/test_workflow_scripts/golang/mock_mismatch/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/mock_mismatch/golang-linux.sh
@@ -15,6 +15,22 @@ echo "iid.sh executed"
 
 git fetch origin
 
+# Mock-mismatch reporting (the per-test capture window + unmatched_calls in the
+# report) is new in this PR. On the cross-version matrix the 'latest' replay
+# binary is the published release that predates this feature, so it can never
+# emit the "Mock mismatch: [HTTP]" line / unmatched_calls entry this suite
+# asserts (success is inverted) — skip cleanly there rather than fail
+# deterministically. Local build binaries (*/build/keploy, */build-no-race/
+# keploy) have the feature. Mirrors the streaming sibling + risk_profile /
+# connect_tunnel capability gates.
+case "${REPLAY_BIN:-}" in
+    */build/keploy|*/build-no-race/keploy) ;;
+    *)
+        echo "REPLAY_BIN ($REPLAY_BIN) predates mock-mismatch reporting; skipping suite"
+        exit 0
+        ;;
+esac
+
 if [ -f "./keploy.yml" ]; then
     rm ./keploy.yml
 fi

--- a/.github/workflows/test_workflow_scripts/golang/mock_mismatch/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/mock_mismatch/golang-linux.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+# E2E for the mock-mismatch report. Reuses the http-pokeapi sample (it makes
+# mockable outgoing HTTP calls), records it, then MUTATES the recorded mocks so
+# the live outgoing request no longer matches any mock on replay. Unlike the
+# other suites, success here is INVERTED: we assert that replay SURFACES the
+# mismatch (the "MOCK MISMATCH" report with an unmatched outgoing call), not
+# that every test passed.
+
+echo "$RECORD_BIN"
+echo "$REPLAY_BIN"
+
+source ./../../.github/workflows/test_workflow_scripts/test-iid.sh
+echo "iid.sh executed"
+
+git fetch origin
+
+if [ -f "./keploy.yml" ]; then
+    rm ./keploy.yml
+fi
+rm -rf keploy/
+
+build_go_app() {
+  local attempt=1
+  local max_attempts=4
+  local sleep_sec=5
+  while [ "$attempt" -le "$max_attempts" ]; do
+    if GOPROXY="proxy.golang.org,direct" go build -o http-pokeapi; then
+      return 0
+    fi
+    if [ "$attempt" -ge "$max_attempts" ]; then
+      echo "::error::go build for http-pokeapi failed after ${max_attempts} attempts"
+      return 1
+    fi
+    echo "go build attempt ${attempt} failed; retrying in ${sleep_sec}s…"
+    sleep "$sleep_sec"
+    sleep_sec=$((sleep_sec * 2))
+    attempt=$((attempt + 1))
+  done
+}
+build_go_app
+echo "go binary built"
+
+sudo "$RECORD_BIN" config --generate
+config_file="./keploy.yml"
+sed -i 's/global: {}/global: {"body": {"updated_at":[]}}/' "$config_file"
+
+send_request() {
+    sleep 6
+    app_started=false
+    while [ "$app_started" = false ]; do
+        if curl -X GET http://localhost:8080/api/locations; then
+            app_started=true
+        fi
+        sleep 3
+    done
+    echo "App started"
+    response=$(curl -s -X GET http://localhost:8080/api/locations)
+    location=$(echo "$response" | jq -r ".location[0]")
+    curl -s -X GET "http://localhost:8080/api/locations/$location"
+    sleep 7
+    pid=$(pgrep keploy)
+    echo "$pid Keploy PID"
+    echo "Killing Keploy"
+    sudo kill "$pid"
+}
+
+# Record one iteration of test cases + mocks.
+send_request &
+"$RECORD_BIN" record -c "./http-pokeapi" --generateGithubActions=false 2>&1 | tee record_logs.txt
+if grep "WARNING: DATA RACE" record_logs.txt; then
+    echo "::error::Race condition detected in recording"
+    cat record_logs.txt
+    exit 1
+fi
+wait
+echo "Recorded test cases and mocks"
+
+# Force a mock mismatch: rewrite the recorded request host on the mock side so
+# the live outgoing request (to pokeapi.co) no longer matches any recorded
+# mock. Done on the mocks only — the test cases (inbound) are untouched.
+shopt -s nullglob
+mock_files=( ./keploy/test-set-*/mocks.yaml )
+shopt -u nullglob
+if [ ${#mock_files[@]} -eq 0 ]; then
+    echo "::error::No recorded mocks found to mutate under ./keploy/test-set-*/"
+    cat record_logs.txt
+    exit 1
+fi
+for mf in "${mock_files[@]}"; do
+    sed -i 's#pokeapi\.co#pokeapi-mismatch.invalid#g' "$mf"
+    echo "mutated recorded mocks: $mf"
+done
+
+# Replay. The mutated mocks no longer match → keploy must report the unmatched
+# outgoing call. The replay itself is EXPECTED to not all-pass here.
+"$REPLAY_BIN" test -c "./http-pokeapi" --delay 7 --debug --generateGithubActions=false 2>&1 | tee test_logs.txt
+
+if grep "WARNING: DATA RACE" test_logs.txt; then
+    echo "::error::Race condition detected in test"
+    cat test_logs.txt
+    exit 1
+fi
+
+# Assert the mismatch surfaced. Primary signal: the console "MOCK MISMATCH"
+# report / per-call "Mock mismatch:" heading printed by the replayer.
+mismatch_reported=false
+if grep -qiE "MOCK MISMATCH|Mock mismatch:" test_logs.txt; then
+    echo "✓ replay surfaced the MOCK MISMATCH report"
+    mismatch_reported=true
+fi
+
+# Secondary signal: the test-set report YAML carries unmatched_calls / match_phase.
+shopt -s nullglob
+reports=( ./keploy/reports/test-run-*/test-set-*-report.yaml )
+shopt -u nullglob
+for rf in "${reports[@]}"; do
+    if grep -qE "unmatched_calls|match_phase|closest_mock" "$rf"; then
+        echo "✓ report $(basename "$rf") carries the structured mismatch fields"
+        mismatch_reported=true
+    fi
+done
+
+if [ "$mismatch_reported" != true ]; then
+    echo "::error::replay did NOT surface the mock mismatch — report regressed"
+    cat test_logs.txt
+    exit 1
+fi
+
+echo "mock-mismatch e2e passed: the unmatched outgoing call was reported"
+exit 0

--- a/.github/workflows/test_workflow_scripts/golang/mock_mismatch/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/mock_mismatch/golang-linux.sh
@@ -76,9 +76,12 @@ fi
 wait
 echo "Recorded test cases and mocks"
 
-# Force a mock mismatch: rewrite the recorded request host on the mock side so
-# the live outgoing request (to pokeapi.co) no longer matches any recorded
-# mock. Done on the mocks only — the test cases (inbound) are untouched.
+# Force a mock mismatch: rewrite the recorded request PATH on the mock side.
+# HTTP schema matching compares the request URL path (not host), so changing
+# the recorded "/api/v2/..." path means the live outgoing request to
+# "/api/v2/..." no longer matches any recorded mock -> the matcher reports an
+# unmatched outgoing call. Only the mocks are touched; the test cases (inbound
+# requests) are untouched, so the inbound path still replays normally.
 shopt -s nullglob
 mock_files=( ./keploy/test-set-*/mocks.yaml )
 shopt -u nullglob
@@ -87,10 +90,19 @@ if [ ${#mock_files[@]} -eq 0 ]; then
     cat record_logs.txt
     exit 1
 fi
+mutated_any=false
 for mf in "${mock_files[@]}"; do
-    sed -i 's#pokeapi\.co#pokeapi-mismatch.invalid#g' "$mf"
-    echo "mutated recorded mocks: $mf"
+    sed -i 's#/api/v2/#/api/v0-mismatch/#g' "$mf"
+    if grep -q '/api/v0-mismatch/' "$mf"; then
+        echo "mutated recorded request path in: $mf"
+        mutated_any=true
+    fi
 done
+if [ "$mutated_any" != true ]; then
+    echo "::error::mutation changed no recorded request path — sample/mock layout changed; e2e can't force a mismatch"
+    head -50 "${mock_files[0]}"
+    exit 1
+fi
 
 # Replay. The mutated mocks no longer match → keploy must report the unmatched
 # outgoing call. The replay itself is EXPECTED to not all-pass here.

--- a/.github/workflows/test_workflow_scripts/golang/mock_mismatch_streaming/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/mock_mismatch_streaming/golang-linux.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+
+# E2E for STREAMING mock-mismatch reporting. Uses the sse-redis sample, whose
+# streaming endpoints (SSE / NDJSON / multipart / plain-text) are served from
+# Redis. We record it, then MUTATE the recorded LRANGE read mock — the outgoing
+# Redis call the streaming GETs depend on — to a non-matching key of the SAME
+# byte length (so RESP framing stays valid). On replay the streaming (Phase-2)
+# path must SURFACE the unmatched outgoing Redis (Generic) call on a streaming
+# test case. This is the behavior added by finalizing the per-test capture
+# window AFTER stream consumption; before it, the streaming path opened no
+# window and carried no unmatched_calls. Success here is INVERTED: we assert the
+# streaming mismatch is reported, not that every test passes.
+
+echo "$RECORD_BIN"
+echo "$REPLAY_BIN"
+
+source ./../../.github/workflows/test_workflow_scripts/test-iid.sh
+echo "iid.sh executed"
+
+git fetch origin
+
+# Streaming mock-mismatch reporting only exists in the new (locally built)
+# replay binary. On an older 'latest' artifact the streaming path opens no
+# capture window, so skip cleanly rather than fail a cross-version cell
+# (mirrors the capability gate in risk_profile / connect_tunnel).
+case "${REPLAY_BIN:-}" in
+    */build/keploy|*/build-no-race/keploy) ;;
+    *)
+        echo "REPLAY_BIN ($REPLAY_BIN) predates streaming mock-mismatch reporting; skipping suite"
+        exit 0
+        ;;
+esac
+
+if [ -f "./keploy.yml" ]; then
+    rm ./keploy.yml
+fi
+rm -rf keploy/
+rm -f record_logs.txt test_logs.txt
+
+# Redis backing store for the sample's streaming endpoints.
+docker compose up -d
+echo "waiting for redis..."
+for i in $(seq 1 30); do
+    if docker compose exec -T redis redis-cli ping 2>/dev/null | grep -q PONG; then
+        echo "redis ready"
+        break
+    fi
+    sleep 2
+done
+
+build_go_app() {
+  local attempt=1
+  local max_attempts=4
+  local sleep_sec=5
+  while [ "$attempt" -le "$max_attempts" ]; do
+    if GOPROXY="proxy.golang.org,direct" go build -o sse-redis-app; then
+      return 0
+    fi
+    if [ "$attempt" -ge "$max_attempts" ]; then
+      echo "::error::go build for sse-redis-app failed after ${max_attempts} attempts"
+      return 1
+    fi
+    echo "go build attempt ${attempt} failed; retrying in ${sleep_sec}s…"
+    sleep "$sleep_sec"
+    sleep_sec=$((sleep_sec * 2))
+    attempt=$((attempt + 1))
+  done
+}
+build_go_app
+echo "go binary built"
+
+sudo "$RECORD_BIN" config --generate
+
+send_request() {
+    sleep 6
+    app_started=false
+    while [ "$app_started" = false ]; do
+        if curl -sf http://localhost:8080/health >/dev/null 2>&1; then
+            app_started=true
+        fi
+        sleep 2
+    done
+    echo "App started"
+    # request.sh fires POST /messages (writes) then GETs every streaming
+    # endpoint (SSE/NDJSON/multipart/plain), producing the streaming test cases.
+    BASE_URL=http://localhost:8080 bash ./request.sh || true
+    sleep 7
+    pid=$(pgrep keploy)
+    echo "$pid Keploy PID"
+    echo "Killing Keploy"
+    sudo kill "$pid"
+}
+
+# Record one iteration of test cases + Redis mocks.
+send_request &
+"$RECORD_BIN" record -c "./sse-redis-app" --generateGithubActions=false 2>&1 | tee record_logs.txt
+if grep "WARNING: DATA RACE" record_logs.txt; then
+    echo "::error::Race condition detected in recording"
+    cat record_logs.txt
+    exit 1
+fi
+wait
+echo "Recorded streaming test cases and Redis mocks"
+
+# Force a streaming mock mismatch: rewrite the recorded LRANGE read key only.
+# The streaming GETs read the message list with `lrange sse-demo:messages 0 -1`;
+# rewriting that key (same length, so the RESP $17 prefix stays valid) means the
+# live read no longer matches any recorded mock. The rpush/del writes are left
+# intact, so the mismatch is isolated to the streaming reads.
+shopt -s nullglob
+mock_files=( ./keploy/test-set-*/mocks.yaml )
+shopt -u nullglob
+if [ ${#mock_files[@]} -eq 0 ]; then
+    echo "::error::No recorded mocks found to mutate under ./keploy/test-set-*/"
+    cat record_logs.txt
+    exit 1
+fi
+mutated_any=false
+for mf in "${mock_files[@]}"; do
+    python3 - "$mf" <<'PY'
+import sys
+p = sys.argv[1]
+s = open(p).read()
+old = "lrange\\r\\n$17\\r\\nsse-demo:messages\\r\\n"
+new = "lrange\\r\\n$17\\r\\nsse-demo:MISMATCH\\r\\n"
+n = s.count(old)
+open(p, "w").write(s.replace(old, new))
+print("mutated %d lrange read mock(s) in %s" % (n, p))
+PY
+    if grep -q 'sse-demo:MISMATCH' "$mf"; then
+        echo "mutated LRANGE read key in: $mf"
+        mutated_any=true
+    fi
+done
+if [ "$mutated_any" != true ]; then
+    echo "::error::mutation changed no LRANGE read mock — sample/mock layout changed; e2e can't force a streaming mismatch"
+    head -60 "${mock_files[0]}"
+    exit 1
+fi
+
+# Replay. The mutated reads no longer match → the streaming path must report the
+# unmatched outgoing Redis call on a streaming test. Replay is EXPECTED to not
+# all-pass here.
+"$REPLAY_BIN" test -c "./sse-redis-app" --delay 7 --generateGithubActions=false 2>&1 | tee test_logs.txt
+if grep "WARNING: DATA RACE" test_logs.txt; then
+    echo "::error::Race condition detected in test"
+    cat test_logs.txt
+    exit 1
+fi
+
+# Assert the mismatch surfaced on a STREAMING test case (events-sse / -ndjson /
+# -multipart / -plain) — i.e. a test routed through the Phase-2 streaming path
+# carries an unmatched_calls entry. This is the streaming-specific behavior:
+# before the fix the streaming path opened no capture window, so these tests
+# carried no unmatched_calls regardless of the forced mismatch.
+shopt -s nullglob
+reports=( ./keploy/reports/test-run-*/test-set-*-report.yaml )
+shopt -u nullglob
+if [ ${#reports[@]} -eq 0 ]; then
+    echo "::error::no test-set report produced"
+    tail -40 test_logs.txt
+    exit 1
+fi
+streaming_reported=false
+for rf in "${reports[@]}"; do
+    if python3 - "$rf" <<'PY'
+import sys, re
+txt = open(sys.argv[1]).read()
+# Each per-test block starts with "    - " at the test-results list level.
+blocks = re.split(r'\n    - ', txt)
+ok = False
+for b in blocks:
+    m = re.search(r'test_case_id:\s*(\S+)', b)
+    if not m:
+        continue
+    tid = m.group(1)
+    # streaming test cases are the get-events-* endpoints
+    if 'events-' in tid and 'unmatched_calls:' in b:
+        ok = True
+        print("streaming test reported a mismatch:", tid)
+sys.exit(0 if ok else 1)
+PY
+    then
+        echo "✓ $(basename "$rf") has a streaming test with an unmatched_calls entry"
+        streaming_reported=true
+    fi
+done
+
+if [ "$streaming_reported" != true ]; then
+    echo "::error::replay did NOT report the forced streaming mock mismatch on any streaming test"
+    echo "--- mismatch/unmatched lines in test_logs.txt ---"
+    grep -iE "mismatch|unmatched|no matching" test_logs.txt | head -20
+    echo "--- tail of test_logs.txt ---"
+    tail -40 test_logs.txt
+    docker compose down 2>/dev/null || true
+    exit 1
+fi
+
+echo "streaming mock-mismatch e2e passed: a streaming test reported the forced unmatched Redis read"
+docker compose down 2>/dev/null || true
+exit 0

--- a/.github/workflows/test_workflow_scripts/golang/mock_mismatch_streaming/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/mock_mismatch_streaming/golang-linux.sh
@@ -88,7 +88,11 @@ send_request() {
     pid=$(pgrep keploy)
     echo "$pid Keploy PID"
     echo "Killing Keploy"
-    sudo kill "$pid"
+    # Unquoted on purpose: pgrep can return BOTH the keploy CLI and the agent
+    # process, so $pid may be multiple newline-separated PIDs. Quoting it passes
+    # one mangled arg to kill ("failed to parse argument"), keploy survives, and
+    # `wait` on the record command hangs to the job timeout. Word-split instead.
+    sudo kill $pid
 }
 
 # Record one iteration of test cases + Redis mocks.

--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -415,6 +415,7 @@ func (c *CmdConfigurator) AddUncommonFlags(cmd *cobra.Command) {
 		cmd.Flags().Bool("compare-all", false, "Compare all response body types including non-JSON (default: false, only JSON bodies are compared)")
 		cmd.Flags().Bool("schema-match", false, "Compare only the schema of the response body")
 		cmd.Flags().Bool("schema-noise-detection", c.cfg.Test.SchemaNoiseDetection, "Detect request-body fields that drift between recording and replay and persist them as field-path noise (req_body_noise) on HTTP mocks during auto-replay matching")
+		cmd.Flags().Bool("schema-noise-strict", c.cfg.Test.SchemaNoiseStrict, "Strictly enforce learned request-body noise during HTTP mock matching: a candidate mock carrying req_body_noise is rejected when any field OUTSIDE its learned/user-configured noise drifted. Same behaviour the in-cluster replay path enforces; previously configurable only via keploy.yml")
 		cmd.Flags().Bool("strict-failure", c.cfg.Test.StrictFailure, "Mark response-failing tests as FAILED even if the consumed mock set also diverged from the recorded mapping (default behaviour demotes such cases to OBSOLETE). The per-test mappingDiff block is still written for diagnostics.")
 		cmd.Flags().Bool("update-test-mapping", c.cfg.Test.UpdateTestMapping, "Update the mapping of testcases")
 		// Start the user app ONCE for the whole replay run instead of
@@ -493,6 +494,7 @@ func aliasNormalizeFunc(_ *pflag.FlagSet, name string) pflag.NormalizedName {
 		"compareAll":                "compare-all",
 		"schemaMatch":               "schema-match",
 		"schemaNoiseDetection":      "schema-noise-detection",
+		"schemaNoiseStrict":         "schema-noise-strict",
 		"updateTestMapping":         "update-test-mapping",
 		"capturePackets":            "capture-packets",
 		"opportunisticTlsIntercept": "opportunistic-tls-intercept",
@@ -1234,6 +1236,13 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 			c.cfg.Test.SchemaNoiseDetection, err = cmd.Flags().GetBool("schema-noise-detection")
 			if err != nil {
 				errMsg := "failed to read the --schema-noise-detection flag; check the flag name with --help and confirm this command supports it"
+				utils.LogError(c.logger, err, errMsg)
+				return errors.New(errMsg)
+			}
+
+			c.cfg.Test.SchemaNoiseStrict, err = cmd.Flags().GetBool("schema-noise-strict")
+			if err != nil {
+				errMsg := "failed to read the --schema-noise-strict flag; check the flag name with --help and confirm this command supports it"
 				utils.LogError(c.logger, err, errMsg)
 				return errors.New(errMsg)
 			}

--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -1240,11 +1240,17 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 				return errors.New(errMsg)
 			}
 
-			c.cfg.Test.SchemaNoiseStrict, err = cmd.Flags().GetBool("schema-noise-strict")
-			if err != nil {
-				errMsg := "failed to read the --schema-noise-strict flag; check the flag name with --help and confirm this command supports it"
-				utils.LogError(c.logger, err, errMsg)
-				return errors.New(errMsg)
+			// Only let the flag override when it was explicitly passed or
+			// the config file doesn't set the key — otherwise the flag's
+			// default would silently clobber a yaml-only configuration
+			// (same guard pattern as disable-mapping above).
+			if cmd.Flags().Changed("schema-noise-strict") || !viper.IsSet("test.schemaNoiseStrict") {
+				c.cfg.Test.SchemaNoiseStrict, err = cmd.Flags().GetBool("schema-noise-strict")
+				if err != nil {
+					errMsg := "failed to read the --schema-noise-strict flag; check the flag name with --help and confirm this command supports it"
+					utils.LogError(c.logger, err, errMsg)
+					return errors.New(errMsg)
+				}
 			}
 
 			// enforce that the test-sets are provided when --must-pass is set to true

--- a/pkg/agent/proxy/capture_window_test.go
+++ b/pkg/agent/proxy/capture_window_test.go
@@ -1,0 +1,55 @@
+package proxy
+
+import (
+	"context"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+func mockMiss(summary string) models.ParserError {
+	return models.ParserError{
+		ParserErrorType: models.ErrMockNotFound,
+		MismatchReport:  &models.MockMismatchReport{Protocol: "HTTP", ActualSummary: summary, ClosestMock: "mock-0"},
+	}
+}
+
+// TestCaptureWindow_NoBleedAcrossTests proves the per-test capture contract:
+// a miss surfaces for the test it occurred in, and a consumed miss never
+// carries over to the next test's GetMockErrors (the misattribution bug).
+func TestCaptureWindow_NoBleedAcrossTests(t *testing.T) {
+	p := &Proxy{logger: zap.NewNop(), errChannel: make(chan error, 16)}
+
+	p.BeginTestErrorCapture()
+	p.errChannel <- mockMiss("POST /t1")
+	got, err := p.GetMockErrors(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].ActualSummary != "POST /t1" {
+		t.Fatalf("test1 expected one miss [POST /t1], got %+v", got)
+	}
+
+	// Next test: fresh window, nothing pending — the previous miss must be gone.
+	p.BeginTestErrorCapture()
+	got, _ = p.GetMockErrors(context.Background())
+	if len(got) != 0 {
+		t.Fatalf("test2 must not inherit test1's miss, got %+v", got)
+	}
+}
+
+// TestCaptureWindow_BeginClearsStale proves BeginTestErrorCapture discards
+// misses retained before the window (startup / background traffic) so they
+// don't attach to the first test.
+func TestCaptureWindow_BeginClearsStale(t *testing.T) {
+	p := &Proxy{logger: zap.NewNop(), errChannel: make(chan error, 16)}
+
+	p.pendingMockErrors.addBounded(mockMiss("GET /background"), maxPendingMockErrors)
+	p.BeginTestErrorCapture()
+
+	got, _ := p.GetMockErrors(context.Background())
+	if len(got) != 0 {
+		t.Fatalf("stale pre-window miss should be cleared on Begin, got %+v", got)
+	}
+}

--- a/pkg/agent/proxy/capture_window_test.go
+++ b/pkg/agent/proxy/capture_window_test.go
@@ -39,6 +39,30 @@ func TestCaptureWindow_NoBleedAcrossTests(t *testing.T) {
 	}
 }
 
+// TestCaptureWindow_RendezvousNoLoss runs the real StartErrorDrain goroutine
+// and proves the flush-marker rendezvous keeps a miss that's still in flight:
+// the error is pushed onto errChannel and GetMockErrors is called immediately
+// (the goroutine may not have routed it yet), yet it must still be returned —
+// not lost to the window close.
+func TestCaptureWindow_RendezvousNoLoss(t *testing.T) {
+	p := &Proxy{logger: zap.NewNop(), errChannel: make(chan error, 16)}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	p.StartErrorDrain(ctx)
+
+	for i := 0; i < 25; i++ {
+		p.BeginTestErrorCapture()
+		p.errChannel <- mockMiss("POST /t")
+		got, err := p.GetMockErrors(context.Background())
+		if err != nil {
+			t.Fatalf("iter %d: unexpected error: %v", i, err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("iter %d: rendezvous lost the miss, got %d", i, len(got))
+		}
+	}
+}
+
 // TestCaptureWindow_BeginClearsStale proves BeginTestErrorCapture discards
 // misses retained before the window (startup / background traffic) so they
 // don't attach to the first test.

--- a/pkg/agent/proxy/integrations/generic/decode.go
+++ b/pkg/agent/proxy/integrations/generic/decode.go
@@ -65,13 +65,21 @@ func decodeGeneric(ctx context.Context, logger *zap.Logger, reqBuf []byte, clien
 				if len(preview) > 64 {
 					preview = preview[:64]
 				}
-				logger.Debug("mock miss",
-					zap.String("protocol", "Generic"),
+				// Build the universal mismatch report so generic misses show
+				// up in the mismatch table / report yaml like HTTP and MySQL
+				// misses do, instead of vanishing as a bare error.
+				report := buildGenericMismatchReport(ctx, genericRequests, mockDb)
+				// Default-visible: this miss is the root cause of the test
+				// failure that follows (the app sees its connection close).
+				logger.Warn("no matching generic mock found for outgoing call",
+					zap.String("protocol", report.Protocol),
 					zap.Int("requestCount", len(genericRequests)),
 					zap.Int("firstRequestBytes", len(genericRequests[0])),
-					zap.String("hint", "Re-record mocks if the wire protocol data has changed"),
+					zap.String("closest", report.ClosestMock),
+					zap.String("diff", report.Diff),
+					zap.String("next_steps", report.NextSteps),
 					zap.Binary("preview", preview))
-				errCh <- fmt.Errorf("no matching generic mock found")
+				errCh <- models.NewMockMismatchError(fmt.Errorf("no matching generic mock found"), report)
 				return
 			}
 			for _, genericResponse := range genericResponses {

--- a/pkg/agent/proxy/integrations/generic/decode.go
+++ b/pkg/agent/proxy/integrations/generic/decode.go
@@ -77,7 +77,7 @@ func decodeGeneric(ctx context.Context, logger *zap.Logger, reqBuf []byte, clien
 					zap.Int("firstRequestBytes", len(genericRequests[0])),
 					zap.String("closest", report.ClosestMock),
 					zap.String("diff", report.Diff),
-					zap.String("next_steps", report.NextSteps),
+					zap.String("next_step", report.NextSteps),
 					zap.Binary("preview", preview))
 				errCh <- models.NewMockMismatchError(fmt.Errorf("generic: %w", models.ErrNoMockMatched), report)
 				return

--- a/pkg/agent/proxy/integrations/generic/decode.go
+++ b/pkg/agent/proxy/integrations/generic/decode.go
@@ -79,7 +79,7 @@ func decodeGeneric(ctx context.Context, logger *zap.Logger, reqBuf []byte, clien
 					zap.String("diff", report.Diff),
 					zap.String("next_steps", report.NextSteps),
 					zap.Binary("preview", preview))
-				errCh <- models.NewMockMismatchError(fmt.Errorf("no matching generic mock found"), report)
+				errCh <- models.NewMockMismatchError(fmt.Errorf("generic: %w", models.ErrNoMockMatched), report)
 				return
 			}
 			for _, genericResponse := range genericResponses {

--- a/pkg/agent/proxy/integrations/generic/decode.go
+++ b/pkg/agent/proxy/integrations/generic/decode.go
@@ -69,9 +69,10 @@ func decodeGeneric(ctx context.Context, logger *zap.Logger, reqBuf []byte, clien
 				// up in the mismatch table / report yaml like HTTP and MySQL
 				// misses do, instead of vanishing as a bare error.
 				report := buildGenericMismatchReport(ctx, genericRequests, mockDb)
-				// Default-visible: this miss is the root cause of the test
-				// failure that follows (the app sees its connection close).
-				logger.Warn("no matching generic mock found for outgoing call",
+				// Per-call generic detail at Debug; the canonical mock-mismatch
+				// WARN is emitted once in proxy.sendMockNotFoundError (covers
+				// every parser), so this stays Debug to avoid double-logging.
+				logger.Debug("no matching generic mock found for outgoing call",
 					zap.String("protocol", report.Protocol),
 					zap.Int("requestCount", len(genericRequests)),
 					zap.Int("firstRequestBytes", len(genericRequests[0])),

--- a/pkg/agent/proxy/integrations/generic/match.go
+++ b/pkg/agent/proxy/integrations/generic/match.go
@@ -135,9 +135,28 @@ func buildGenericMismatchReport(ctx context.Context, reqBuffs [][]byte, mockDb i
 			continue
 		}
 		var simSum float64
+		comparable := true
 		for i, reqBuff := range reqBuffs {
-			encoded, _ := util.DecodeBase64(mock.Spec.GenericRequests[i].Message[0].Data)
-			simSum += fuzzyCheck(encoded, reqBuff)
+			msg := mock.Spec.GenericRequests[i].Message[0]
+			// The recorder stores ASCII payloads verbatim (Type String) and
+			// binary payloads base64-encoded — decode per the recorded type,
+			// otherwise the similarity is computed against nil bytes and the
+			// closest-candidate ranking degrades to noise.
+			var recorded []byte
+			if msg.Type == models.String {
+				recorded = []byte(msg.Data)
+			} else {
+				decoded, err := util.DecodeBase64(msg.Data)
+				if err != nil {
+					comparable = false
+					break
+				}
+				recorded = decoded
+			}
+			simSum += fuzzyCheck(recorded, reqBuff)
+		}
+		if !comparable {
+			continue
 		}
 		if avg := simSum / float64(len(reqBuffs)); avg > bestSim {
 			bestSim = avg

--- a/pkg/agent/proxy/integrations/generic/match.go
+++ b/pkg/agent/proxy/integrations/generic/match.go
@@ -8,6 +8,7 @@ import (
 	"go.keploy.io/server/v3/pkg/agent/proxy/integrations"
 	"go.uber.org/zap"
 
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mismatch"
 	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/util"
 	"go.keploy.io/server/v3/pkg/models"
 )
@@ -97,6 +98,62 @@ func fuzzyMatch(ctx context.Context, logger *zap.Logger, reqBuff [][]byte, mockD
 			return false, nil, nil
 		}
 	}
+}
+
+// buildGenericMismatchReport builds the universal mock-miss report for the
+// generic (opaque TCP) parser. Field-level diffs are impossible for unparsed
+// wire bytes, so the report carries the closest candidate by Jaccard
+// similarity with its score — enough for the user to tell "nothing remotely
+// similar was recorded" (re-record) apart from "a near-miss exists"
+// (protocol drift, likely needs re-record of just this dependency).
+func buildGenericMismatchReport(ctx context.Context, reqBuffs [][]byte, mockDb integrations.MockMemDb) *models.MockMismatchReport {
+	summary := fmt.Sprintf("opaque TCP exchange (%d request buffer(s), first %d bytes)", len(reqBuffs), func() int {
+		if len(reqBuffs) == 0 {
+			return 0
+		}
+		return len(reqBuffs[0])
+	}())
+
+	mocks, err := mockDb.GetSessionMocks()
+	if err != nil || ctx.Err() != nil {
+		return mismatch.NewReport(mismatch.ProtocolGeneric, summary).Build()
+	}
+	var genericMocks []*models.Mock
+	for _, m := range mocks {
+		if m.Kind == "Generic" {
+			genericMocks = append(genericMocks, m)
+		}
+	}
+	if len(genericMocks) == 0 {
+		return mismatch.NewReport(mismatch.ProtocolGeneric, summary).
+			WithPhase(models.MatchPhaseNoMocks, 0).Build()
+	}
+
+	bestIdx, bestSim := -1, -1.0
+	for idx, mock := range genericMocks {
+		if len(mock.Spec.GenericRequests) != len(reqBuffs) {
+			continue
+		}
+		var simSum float64
+		for i, reqBuff := range reqBuffs {
+			encoded, _ := util.DecodeBase64(mock.Spec.GenericRequests[i].Message[0].Data)
+			simSum += fuzzyCheck(encoded, reqBuff)
+		}
+		if avg := simSum / float64(len(reqBuffs)); avg > bestSim {
+			bestSim = avg
+			bestIdx = idx
+		}
+	}
+
+	b := mismatch.NewReport(mismatch.ProtocolGeneric, summary).
+		WithPhase(models.MatchPhaseExhausted, len(genericMocks))
+	if bestIdx >= 0 {
+		b = b.WithClosest(genericMocks[bestIdx].Name, nil).
+			WithDiff(fmt.Sprintf("closest recorded exchange %q has Jaccard similarity %.2f (thresholds: 0.9 per-test, 0.4 session)", genericMocks[bestIdx].Name, bestSim))
+	} else {
+		b = b.WithDiff("no recorded exchange has the same number of request buffers")
+	}
+	return b.Build()
 }
 
 // TODO: need to generalize this function for different types of integrations.

--- a/pkg/agent/proxy/integrations/http/decode.go
+++ b/pkg/agent/proxy/integrations/http/decode.go
@@ -206,9 +206,11 @@ func (h *HTTP) decodeHTTP(ctx context.Context, reqBuf []byte, clientConn net.Con
 				// table, the report yaml and `keploy report`).
 				report := h.buildHTTPMismatchReport(request, input.body, mockDb, nil, headerNoise, bodyNoise, diag)
 				if report != nil {
-					// Default-visible: this is the root cause of the test
-					// failure that follows, so it must not hide at Debug.
-					h.Logger.Warn("no matching http mock found for outgoing request",
+					// Per-call HTTP detail at Debug; the canonical, protocol-
+					// agnostic mock-mismatch WARN is emitted once in
+					// proxy.sendMockNotFoundError (where every parser's miss
+					// funnels), so this stays Debug to avoid double-logging.
+					h.Logger.Debug("no matching http mock found for outgoing request",
 						zap.String("protocol", report.Protocol),
 						zap.String("destination", report.Destination),
 						zap.String("actual", report.ActualSummary),

--- a/pkg/agent/proxy/integrations/http/decode.go
+++ b/pkg/agent/proxy/integrations/http/decode.go
@@ -210,7 +210,7 @@ func (h *HTTP) decodeHTTP(ctx context.Context, reqBuf []byte, clientConn net.Con
 						zap.Int("candidates", report.CandidateCount),
 						zap.String("closest", report.ClosestMock),
 						zap.String("diff", report.Diff),
-						zap.String("next_steps", report.NextSteps))
+						zap.String("next_step", report.NextSteps))
 				}
 
 				// No mock matched — send a 502 so the application gets a

--- a/pkg/agent/proxy/integrations/http/decode.go
+++ b/pkg/agent/proxy/integrations/http/decode.go
@@ -22,9 +22,10 @@ import (
 )
 
 // ErrMockNotMatched is returned by decodeHTTP when no recorded mock
-// matches the outgoing HTTP request. Callers can check for this with
-// errors.Is to distinguish a mock-miss from a real proxy error.
-var ErrMockNotMatched = errors.New("no matching mock found")
+// matches the outgoing HTTP request. It aliases models.ErrNoMockMatched so
+// callers can errors.Is against either symbol to distinguish a mock-miss
+// from a real proxy error.
+var ErrMockNotMatched = models.ErrNoMockMatched
 
 // Decodes the mocks in test mode so that they can be sent to the user application.
 func (h *HTTP) decodeHTTP(ctx context.Context, reqBuf []byte, clientConn net.Conn, dstCfg *models.ConditionalDstCfg, mockDb integrations.MockMemDb, opts models.OutgoingOptions) error {
@@ -163,17 +164,23 @@ func (h *HTTP) decodeHTTP(ctx context.Context, reqBuf []byte, clientConn net.Con
 			// User body noise from test.globalNoise (root-relative dotted
 			// paths). Lowercased copy for the same reason as headerNoise:
 			// the matcher's noise index matches lowercased paths.
+			// Entries are normalized to presence-only (empty regex list):
+			// request-body mock matching and drift detection are path-based,
+			// so a value-regex cannot gate here the way it can't gate JSON
+			// body leaves in response assertions either. Normalizing (rather
+			// than dropping regex-valued entries) keeps the documented
+			// promise that a path copied from a mismatch report into
+			// test.globalNoise takes effect regardless of value style.
 			var bodyNoise map[string][]string
 			if opts.NoiseConfig != nil {
 				if bn, ok := opts.NoiseConfig["body"]; ok {
 					bodyNoise = make(map[string][]string, len(bn))
 					for k, v := range bn {
-						lk := strings.ToLower(k)
-						if existing, ok := bodyNoise[lk]; ok {
-							bodyNoise[lk] = append(existing, v...)
-						} else {
-							bodyNoise[lk] = v
+						if len(v) > 0 {
+							h.Logger.Debug("body-noise value regexes are ignored for mock matching; the field is skipped by path",
+								zap.String("field", k))
 						}
+						bodyNoise[strings.ToLower(k)] = []string{}
 					}
 				}
 			}

--- a/pkg/agent/proxy/integrations/http/decode.go
+++ b/pkg/agent/proxy/integrations/http/decode.go
@@ -160,9 +160,28 @@ func (h *HTTP) decodeHTTP(ctx context.Context, reqBuf []byte, clientConn net.Con
 				}
 			}
 
-			h.Logger.Debug("header noise", zap.Any("header noise", headerNoise))
+			// User body noise from test.globalNoise (root-relative dotted
+			// paths). Lowercased copy for the same reason as headerNoise:
+			// the matcher's noise index matches lowercased paths.
+			var bodyNoise map[string][]string
+			if opts.NoiseConfig != nil {
+				if bn, ok := opts.NoiseConfig["body"]; ok {
+					bodyNoise = make(map[string][]string, len(bn))
+					for k, v := range bn {
+						lk := strings.ToLower(k)
+						if existing, ok := bodyNoise[lk]; ok {
+							bodyNoise[lk] = append(existing, v...)
+						} else {
+							bodyNoise[lk] = v
+						}
+					}
+				}
+			}
 
-			ok, stub, err := h.match(ctx, input, mockDb, headerNoise, opts.SchemaNoiseDetection, opts.SchemaNoiseStrict) // calling match function to match mocks
+			h.Logger.Debug("header noise", zap.Any("header noise", headerNoise))
+			h.Logger.Debug("body noise", zap.Any("body noise", bodyNoise))
+
+			ok, stub, diag, err := h.match(ctx, input, mockDb, headerNoise, bodyNoise, opts.SchemaNoiseDetection, opts.SchemaNoiseStrict) // calling match function to match mocks
 			if err != nil {
 				utils.LogError(h.Logger, err, "error while matching http mocks", zap.Any("metadata", utils.GetReqMeta(request)))
 				errCh <- err
@@ -171,16 +190,20 @@ func (h *HTTP) decodeHTTP(ctx context.Context, reqBuf []byte, clientConn net.Con
 			h.Logger.Debug("after matching the http request", zap.Any("isMatched", ok), zap.Any("stub", stub), zap.Error(err))
 
 			if !ok {
-				h.Logger.Debug("no matching http mock found", zap.Any("metadata", utils.GetReqMeta(request)))
-
-				// Build mismatch report for the user (surfaced in the mismatch table)
-				report := h.buildHTTPMismatchReport(request, mockDb, nil)
+				// Build mismatch report for the user (surfaced in the mismatch
+				// table, the report yaml and `keploy report`).
+				report := h.buildHTTPMismatchReport(request, input.body, mockDb, nil, headerNoise, bodyNoise, diag)
 				if report != nil {
-					h.Logger.Debug("mock miss",
+					// Default-visible: this is the root cause of the test
+					// failure that follows, so it must not hide at Debug.
+					h.Logger.Warn("no matching http mock found for outgoing request",
 						zap.String("protocol", report.Protocol),
 						zap.String("actual", report.ActualSummary),
+						zap.String("match_phase", report.MatchPhase),
+						zap.Int("candidates", report.CandidateCount),
 						zap.String("closest", report.ClosestMock),
-						zap.String("diff", report.Diff))
+						zap.String("diff", report.Diff),
+						zap.String("next_steps", report.NextSteps))
 				}
 
 				// No mock matched — send a 502 so the application gets a

--- a/pkg/agent/proxy/integrations/http/decode.go
+++ b/pkg/agent/proxy/integrations/http/decode.go
@@ -161,19 +161,24 @@ func (h *HTTP) decodeHTTP(ctx context.Context, reqBuf []byte, clientConn net.Con
 				}
 			}
 
-			// User body noise from test.globalNoise (root-relative dotted
-			// paths). Lowercased copy for the same reason as headerNoise:
-			// the matcher's noise index matches lowercased paths.
-			// Entries are normalized to presence-only (empty regex list):
-			// request-body mock matching and drift detection are path-based,
-			// so a value-regex cannot gate here the way it can't gate JSON
-			// body leaves in response assertions either. Normalizing (rather
-			// than dropping regex-valued entries) keeps the documented
-			// promise that a path copied from a mismatch report into
-			// test.globalNoise takes effect regardless of value style.
+			// User request-body noise from test.globalNoise.requestBody
+			// (root-relative dotted paths). This is a DEDICATED bucket,
+			// distinct from the "body" bucket that governs RESPONSE
+			// assertions: request-matching noise and response-assertion noise
+			// are separate axes. Reusing the response "body" bucket here would
+			// let a field noised only because it is dynamic in the response
+			// silently soften request matching too (e.g. excusing a wrong
+			// user-id under --schema-noise-strict). Keeping them separate makes
+			// strict matching a real guarantee — a path can only weaken request
+			// matching if the user puts it under requestBody on purpose.
+			//
+			// Lowercased copy for the same reason as headerNoise: the matcher's
+			// noise index matches lowercased paths. Entries are normalized to
+			// presence-only (empty regex list): request-body mock matching and
+			// drift detection are path-based, so a value-regex cannot gate here.
 			var bodyNoise map[string][]string
 			if opts.NoiseConfig != nil {
-				if bn, ok := opts.NoiseConfig["body"]; ok {
+				if bn, ok := opts.NoiseConfig["requestbody"]; ok {
 					bodyNoise = make(map[string][]string, len(bn))
 					for k, v := range bn {
 						if len(v) > 0 {

--- a/pkg/agent/proxy/integrations/http/decode.go
+++ b/pkg/agent/proxy/integrations/http/decode.go
@@ -210,6 +210,7 @@ func (h *HTTP) decodeHTTP(ctx context.Context, reqBuf []byte, clientConn net.Con
 					// failure that follows, so it must not hide at Debug.
 					h.Logger.Warn("no matching http mock found for outgoing request",
 						zap.String("protocol", report.Protocol),
+						zap.String("destination", report.Destination),
 						zap.String("actual", report.ActualSummary),
 						zap.String("match_phase", report.MatchPhase),
 						zap.Int("candidates", report.CandidateCount),

--- a/pkg/agent/proxy/integrations/http/match.go
+++ b/pkg/agent/proxy/integrations/http/match.go
@@ -1244,6 +1244,12 @@ func mergeReqBodyNoise(existing, detected map[string][]string) map[string][]stri
 // mockDb; otherwise it uses the pre-fetched slice to avoid a redundant read.
 func (h *HTTP) buildHTTPMismatchReport(request *http.Request, liveBody []byte, mockDb integrations.MockMemDb, httpMocks []*models.Mock, headerNoise, userBodyNoise map[string][]string, diag *matchDiag) *models.MockMismatchReport {
 	actualKey := request.Method + " " + request.URL.Path
+	// Destination identifies WHICH upstream this missed call targeted; the same
+	// method+path can hit several hosts. Host header first, URL authority next.
+	dest := request.Host
+	if dest == "" && request.URL != nil {
+		dest = request.URL.Host
+	}
 	if httpMocks == nil && (diag == nil || len(diag.schemaMatched) == 0) {
 		// Mirror match()'s pool-merging + ordering strategy so
 		// mismatch diagnostics see the same candidate set in the
@@ -1251,11 +1257,13 @@ func (h *HTTP) buildHTTPMismatchReport(request *http.Request, liveBody []byte, m
 		perTestMocks, err := mockDb.GetPerTestMocksInWindow()
 		if err != nil {
 			return mismatch.NewReport(mismatch.ProtocolHTTP, actualKey).
+				WithDestination(dest).
 				WithNextSteps("Failed to read mock database. Check logs for errors and retry.").Build()
 		}
 		sessionMocks, err := mockDb.GetSessionMocks()
 		if err != nil {
 			return mismatch.NewReport(mismatch.ProtocolHTTP, actualKey).
+				WithDestination(dest).
 				WithNextSteps("Failed to read mock database. Check logs for errors and retry.").Build()
 		}
 		mocks := make([]*models.Mock, 0, len(perTestMocks)+len(sessionMocks))
@@ -1279,6 +1287,7 @@ func (h *HTTP) buildHTTPMismatchReport(request *http.Request, liveBody []byte, m
 
 	if candidateCount == 0 && len(schemaSurvivors) == 0 {
 		return mismatch.NewReport(mismatch.ProtocolHTTP, actualKey).
+			WithDestination(dest).
 			WithPhase(models.MatchPhaseNoMocks, 0).Build()
 	}
 
@@ -1289,6 +1298,7 @@ func (h *HTTP) buildHTTPMismatchReport(request *http.Request, liveBody []byte, m
 	closestMock := pickClosestCandidate(request, schemaSurvivors, httpMocks)
 	if closestMock == nil || closestMock.Spec.HTTPReq == nil {
 		return mismatch.NewReport(mismatch.ProtocolHTTP, actualKey).
+			WithDestination(dest).
 			WithPhase(phase, candidateCount).Build()
 	}
 
@@ -1341,6 +1351,7 @@ func (h *HTTP) buildHTTPMismatchReport(request *http.Request, liveBody []byte, m
 	redactFieldDiffs(fieldDiffs, closestMock.Noise)
 
 	b := mismatch.NewReport(mismatch.ProtocolHTTP, actualKey).
+		WithDestination(dest).
 		WithPhase(phase, candidateCount).
 		WithClosest(closestMock.Name, fieldDiffs).
 		// Whole-request renders for the CLI side-by-side diff. Mock.Noise is

--- a/pkg/agent/proxy/integrations/http/match.go
+++ b/pkg/agent/proxy/integrations/http/match.go
@@ -1337,7 +1337,13 @@ func (h *HTTP) buildHTTPMismatchReport(request *http.Request, liveBody []byte, m
 
 	b := mismatch.NewReport(mismatch.ProtocolHTTP, actualKey).
 		WithPhase(phase, candidateCount).
-		WithClosest(closestMock.Name, fieldDiffs)
+		WithClosest(closestMock.Name, fieldDiffs).
+		// Whole-request renders for the CLI side-by-side diff. Mock.Noise is
+		// passed so obfuscated values stay redacted on both sides.
+		WithRenderedRequests(
+			renderMockRequest(mockReq, closestMock.Noise),
+			renderLiveRequest(request, liveBody, closestMock.Noise),
+		)
 	if len(fieldDiffs) == 0 {
 		// Nothing structurally differs vs the closest candidate, yet the
 		// matcher rejected everything — point the user at the phase instead

--- a/pkg/agent/proxy/integrations/http/match.go
+++ b/pkg/agent/proxy/integrations/http/match.go
@@ -1083,10 +1083,11 @@ func (h *HTTP) detectReqBodyNoise(enabled bool, mock *models.Mock, reqBody []byt
 }
 
 // mergeNoiseMaps combines two noise maps into a fresh map; entries in a win
-// on key collision. Either input may be nil.
+// on key collision. Either input may be nil. The result never aliases an
+// input map, so callers may hold or extend it without mutating shared state.
 func mergeNoiseMaps(a, b map[string][]string) map[string][]string {
-	if len(b) == 0 {
-		return a
+	if len(a) == 0 && len(b) == 0 {
+		return nil
 	}
 	out := make(map[string][]string, len(a)+len(b))
 	for k, v := range b {

--- a/pkg/agent/proxy/integrations/http/match.go
+++ b/pkg/agent/proxy/integrations/http/match.go
@@ -1335,6 +1335,11 @@ func (h *HTTP) buildHTTPMismatchReport(request *http.Request, liveBody []byte, m
 		fieldDiffs = append(fieldDiffs, mismatch.JSONBodyDiffs(mockReq.Body, string(liveBody), ignore)...)
 	}
 
+	// Redact secret / obfuscated values out of the structured diffs before they
+	// are attached — they (and the Diff string derived from them) are persisted
+	// into the report YAML and the platform API.
+	redactFieldDiffs(fieldDiffs, closestMock.Noise)
+
 	b := mismatch.NewReport(mismatch.ProtocolHTTP, actualKey).
 		WithPhase(phase, candidateCount).
 		WithClosest(closestMock.Name, fieldDiffs).

--- a/pkg/agent/proxy/integrations/http/match.go
+++ b/pkg/agent/proxy/integrations/http/match.go
@@ -13,6 +13,7 @@ import (
 	"github.com/agnivade/levenshtein"
 	"go.keploy.io/server/v3/pkg"
 	"go.keploy.io/server/v3/pkg/agent/proxy/integrations"
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mismatch"
 	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/util"
 	"go.keploy.io/server/v3/pkg/matcher"
 	"go.keploy.io/server/v3/pkg/models"
@@ -115,10 +116,25 @@ type req struct {
 	raw    []byte
 }
 
-func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMemDb, headerNoise map[string][]string, schemaNoiseDetection bool, schemaNoiseStrict bool) (bool, *models.Mock, error) {
+// matchDiag captures where the match cascade stopped when no mock matched, so
+// the mismatch report can tell the user WHICH stage ruled everything out and
+// diff the live request against the candidates that were still alive there —
+// instead of the canned "headers or body differ".
+type matchDiag struct {
+	phase         string         // models.MatchPhase* constant
+	candidates    int            // HTTP mocks considered
+	schemaMatched []*models.Mock // candidates alive after schema match (nil if none)
+}
+
+// match returns (matched, mock, diag, err). diag is non-nil only when
+// matched is false and no error occurred. userBodyNoise carries the user's
+// test.globalNoise body bucket (root-relative dotted paths, lowercased) so
+// manual noise config participates in mock matching with the same vocabulary
+// as response assertions.
+func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMemDb, headerNoise map[string][]string, userBodyNoise map[string][]string, schemaNoiseDetection bool, schemaNoiseStrict bool) (bool, *models.Mock, *matchDiag, error) {
 	for {
 		if ctx.Err() != nil {
-			return false, nil, ctx.Err()
+			return false, nil, nil, ctx.Err()
 		}
 
 		// Fetch HTTP mocks from BOTH pools:
@@ -147,12 +163,12 @@ func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMe
 		perTestMocks, err := mockDb.GetPerTestMocksInWindow()
 		if err != nil {
 			utils.LogError(h.Logger, err, "failed to get per-test mocks")
-			return false, nil, errors.New("error while matching the request with the mocks")
+			return false, nil, nil, errors.New("error while matching the request with the mocks")
 		}
 		sessionMocks, err := mockDb.GetSessionMocks()
 		if err != nil {
 			utils.LogError(h.Logger, err, "failed to get session mocks")
-			return false, nil, errors.New("error while matching the request with the mocks")
+			return false, nil, nil, errors.New("error while matching the request with the mocks")
 		}
 		combined := make([]*models.Mock, 0, len(perTestMocks)+len(sessionMocks))
 		combined = append(combined, perTestMocks...)
@@ -168,14 +184,18 @@ func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMe
 
 		h.Logger.Debug(fmt.Sprintf("Length of unfilteredMocks:%v", len(unfilteredMocks)))
 
+		if len(unfilteredMocks) == 0 {
+			return false, nil, &matchDiag{phase: models.MatchPhaseNoMocks}, nil
+		}
+
 		// Matching process
 		schemaMatched, err := h.SchemaMatch(ctx, input, unfilteredMocks, headerNoise)
 		if err != nil {
-			return false, nil, err
+			return false, nil, nil, err
 		}
 
 		if len(schemaMatched) == 0 {
-			return false, nil, nil
+			return false, nil, &matchDiag{phase: models.MatchPhaseSchema, candidates: len(unfilteredMocks)}, nil
 		}
 
 		h.Logger.Debug("http mock schema match results",
@@ -190,7 +210,7 @@ func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMe
 			if !h.updateMock(ctx, bestMatch, mockDb, nil) {
 				continue
 			}
-			return true, bestMatch, nil
+			return true, bestMatch, nil, nil
 		}
 
 		shortListed := schemaMatched
@@ -198,31 +218,37 @@ func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMe
 		if pkg.IsJSON(input.body) {
 			bodyMatched, err := h.PerformBodyMatch(ctx, schemaMatched, input.body)
 			if err != nil {
-				return false, nil, err
+				return false, nil, nil, err
 			}
 
 			// Strict enforcement (replay path): for any candidate that already
 			// carries learned req_body_noise, every request-body field must
-			// match except those learned-noise paths. A drift on a non-noise
-			// field rejects that candidate, so a changed-but-unmarked field
-			// fails the test instead of being silently served. Candidates with
-			// no learned noise keep the lenient schema/key behaviour.
+			// match except those learned-noise paths and the user's configured
+			// body noise. A drift on a non-noise field rejects that candidate,
+			// so a changed-but-unmarked field fails the test instead of being
+			// silently served. Candidates with no learned noise keep the
+			// lenient schema/key behaviour.
+			beforeStrict := len(bodyMatched)
 			if schemaNoiseStrict {
-				bodyMatched = h.filterStrictNoiseMatches(bodyMatched, input.body)
+				bodyMatched = h.filterStrictNoiseMatches(bodyMatched, input.body, userBodyNoise)
 			}
 
 			if len(bodyMatched) == 0 {
 				h.Logger.Debug("No mock found with body schema match")
-				return false, nil, nil
+				phase := models.MatchPhaseBody
+				if beforeStrict > 0 {
+					phase = models.MatchPhaseStrict
+				}
+				return false, nil, &matchDiag{phase: phase, candidates: len(unfilteredMocks), schemaMatched: schemaMatched}, nil
 			}
 
 			if len(bodyMatched) == 1 {
 				h.Logger.Debug("body match found", zap.String("mock name", bodyMatched[0].Name))
-				detected := h.detectReqBodyNoise(schemaNoiseDetection, bodyMatched[0], input.body)
+				detected := h.detectReqBodyNoise(schemaNoiseDetection, bodyMatched[0], input.body, userBodyNoise)
 				if !h.updateMock(ctx, bodyMatched[0], mockDb, detected) {
 					continue
 				}
-				return true, bodyMatched[0], nil
+				return true, bodyMatched[0], nil, nil
 			}
 
 			// More than one match, perform fuzzy match
@@ -234,13 +260,13 @@ func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMe
 		isMatched, bestMatch := h.PerformFuzzyMatch(shortListed, input.raw)
 		if isMatched {
 			h.Logger.Debug("fuzzy match found a matching mock", zap.String("mock name", bestMatch.Name))
-			detected := h.detectReqBodyNoise(schemaNoiseDetection, bestMatch, input.body)
+			detected := h.detectReqBodyNoise(schemaNoiseDetection, bestMatch, input.body, userBodyNoise)
 			if !h.updateMock(ctx, bestMatch, mockDb, detected) {
 				continue
 			}
-			return true, bestMatch, nil
+			return true, bestMatch, nil, nil
 		}
-		return false, nil, nil
+		return false, nil, &matchDiag{phase: models.MatchPhaseExhausted, candidates: len(unfilteredMocks), schemaMatched: shortListed}, nil
 	}
 }
 
@@ -989,14 +1015,14 @@ func (h *HTTP) updateMock(_ context.Context, matchedMock *models.Mock, mockDb in
 // It reuses detectReqBodyNoise, which returns exactly the drifting field paths
 // that are NOT already known noise (and not obfuscator-covered): a non-empty
 // result means an unmarked field changed, so the candidate cannot match.
-func (h *HTTP) filterStrictNoiseMatches(candidates []*models.Mock, reqBody []byte) []*models.Mock {
+func (h *HTTP) filterStrictNoiseMatches(candidates []*models.Mock, reqBody []byte, userBodyNoise map[string][]string) []*models.Mock {
 	var kept []*models.Mock
 	for _, m := range candidates {
 		if m == nil || m.Spec.HTTPReq == nil || len(m.Spec.HTTPReq.ReqBodyNoise) == 0 {
 			kept = append(kept, m)
 			continue
 		}
-		if drift := h.detectReqBodyNoise(true, m, reqBody); len(drift) > 0 {
+		if drift := h.detectReqBodyNoise(true, m, reqBody, userBodyNoise); len(drift) > 0 {
 			h.Logger.Debug("strict req-body match rejected mock: non-noise field drift",
 				zap.String("mock name", m.Name), zap.Any("drift", drift))
 			continue
@@ -1011,10 +1037,12 @@ func (h *HTTP) filterStrictNoiseMatches(candidates []*models.Mock, reqBody []byt
 // field-path noise (body.<path> -> empty regex list = "ignore this whole
 // field"), gated by the SchemaNoiseDetection flag. Fields already covered by
 // the mock's value-regex Mock.Noise (e.g. enterprise-obfuscated secrets) are
-// excluded so secrets aren't re-flagged as schema noise. Returns nil when the
-// flag is off, when the bodies are byte-identical, or when nothing meaningful
-// changed.
-func (h *HTTP) detectReqBodyNoise(enabled bool, mock *models.Mock, reqBody []byte) map[string][]string {
+// excluded so secrets aren't re-flagged as schema noise, and so are fields
+// the user already declared in test.globalNoise's body bucket (userNoise,
+// root-relative dotted paths) — manual noise config and learned noise share
+// one vocabulary. Returns nil when the flag is off, when the bodies are
+// byte-identical, or when nothing meaningful changed.
+func (h *HTTP) detectReqBodyNoise(enabled bool, mock *models.Mock, reqBody []byte, userNoise map[string][]string) map[string][]string {
 	if !enabled || mock == nil || mock.Spec.HTTPReq == nil {
 		return nil
 	}
@@ -1030,7 +1058,7 @@ func (h *HTTP) detectReqBodyNoise(enabled bool, mock *models.Mock, reqBody []byt
 	case pkg.IsJSON([]byte(mockBody)) && pkg.IsJSON(reqBody):
 		// The matcher matches noise paths root-relative; our stored keys carry
 		// a "body." prefix, so strip it for the already-known exclusion set.
-		known := stripBodyPrefix(mock.Spec.HTTPReq.ReqBodyNoise)
+		known := mergeNoiseMaps(stripBodyPrefix(mock.Spec.HTTPReq.ReqBodyNoise), userNoise)
 		paths := matcher.ChangedJSONFieldPaths(mockBody, string(reqBody), known, isObfuscated)
 		if len(paths) == 0 {
 			return nil
@@ -1042,13 +1070,48 @@ func (h *HTTP) detectReqBodyNoise(enabled bool, mock *models.Mock, reqBody []byt
 		return out
 
 	case isFormURLEncoded(mock.Spec.HTTPReq.Header):
-		return formReqBodyNoise(mockBody, string(reqBody), mock.Spec.HTTPReq.ReqBodyNoise, isObfuscated)
+		// formReqBodyNoise keys its known-set with the "body." prefix, so
+		// user noise (root-relative) is prefixed before merging.
+		known := mergeNoiseMaps(mock.Spec.HTTPReq.ReqBodyNoise, addBodyPrefix(userNoise))
+		return formReqBodyNoise(mockBody, string(reqBody), known, isObfuscated)
 
 	default:
 		// Non-JSON, non-form (binary, plain text) bodies have no meaningful
 		// field paths to diff — leave them to exact/fuzzy matching.
 		return nil
 	}
+}
+
+// mergeNoiseMaps combines two noise maps into a fresh map; entries in a win
+// on key collision. Either input may be nil.
+func mergeNoiseMaps(a, b map[string][]string) map[string][]string {
+	if len(b) == 0 {
+		return a
+	}
+	out := make(map[string][]string, len(a)+len(b))
+	for k, v := range b {
+		out[k] = v
+	}
+	for k, v := range a {
+		out[k] = v
+	}
+	return out
+}
+
+// addBodyPrefix returns a copy of the noise map with "body." prepended to
+// each key that doesn't already carry it.
+func addBodyPrefix(in map[string][]string) map[string][]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(in))
+	for k, v := range in {
+		if !strings.HasPrefix(k, "body.") {
+			k = "body." + k
+		}
+		out[k] = v
+	}
+	return out
 }
 
 // stripBodyPrefix returns a copy of the noise map with the leading "body."
@@ -1170,57 +1233,136 @@ func mergeReqBodyNoise(existing, detected map[string][]string) map[string][]stri
 }
 
 // buildHTTPMismatchReport finds the closest HTTP mock to the given request
-// and returns a human-readable diff report. If httpMocks is nil, it fetches
-// from mockDb; otherwise it uses the pre-fetched slice to avoid a redundant read.
-func (h *HTTP) buildHTTPMismatchReport(request *http.Request, mockDb integrations.MockMemDb, httpMocks []*models.Mock) *models.MockMismatchReport {
-	if httpMocks == nil {
+// and returns a structured field-level diff report. liveBody is the live
+// request body (may be nil for body-less requests); headerNoise/userBodyNoise
+// are the same noise sets the matcher used, so the report never flags a field
+// the matcher would have ignored. diag (from match()) tells the builder how
+// far the cascade got and which candidates were still alive, so the diff is
+// computed against a candidate the matcher actually considered close — not
+// just the lowest-Levenshtein path. If httpMocks is nil, it fetches from
+// mockDb; otherwise it uses the pre-fetched slice to avoid a redundant read.
+func (h *HTTP) buildHTTPMismatchReport(request *http.Request, liveBody []byte, mockDb integrations.MockMemDb, httpMocks []*models.Mock, headerNoise, userBodyNoise map[string][]string, diag *matchDiag) *models.MockMismatchReport {
+	actualKey := request.Method + " " + request.URL.Path
+	if httpMocks == nil && (diag == nil || len(diag.schemaMatched) == 0) {
 		// Mirror match()'s pool-merging + ordering strategy so
 		// mismatch diagnostics see the same candidate set in the
 		// same order the matcher saw. Per-test FIRST, session second.
 		perTestMocks, err := mockDb.GetPerTestMocksInWindow()
 		if err != nil {
-			return &models.MockMismatchReport{
-				Protocol:      "HTTP",
-				ActualSummary: fmt.Sprintf("%s %s", request.Method, request.URL.Path),
-				NextSteps:     "Failed to read mock database. Check logs for errors and retry.",
-			}
+			return mismatch.NewReport(mismatch.ProtocolHTTP, actualKey).
+				WithNextSteps("Failed to read mock database. Check logs for errors and retry.").Build()
 		}
 		sessionMocks, err := mockDb.GetSessionMocks()
 		if err != nil {
-			return &models.MockMismatchReport{
-				Protocol:      "HTTP",
-				ActualSummary: fmt.Sprintf("%s %s", request.Method, request.URL.Path),
-				NextSteps:     "Failed to read mock database. Check logs for errors and retry.",
-			}
+			return mismatch.NewReport(mismatch.ProtocolHTTP, actualKey).
+				WithNextSteps("Failed to read mock database. Check logs for errors and retry.").Build()
 		}
 		mocks := make([]*models.Mock, 0, len(perTestMocks)+len(sessionMocks))
 		mocks = append(mocks, perTestMocks...)
 		mocks = append(mocks, sessionMocks...)
-		if len(mocks) == 0 {
-			return &models.MockMismatchReport{
-				Protocol:      "HTTP",
-				ActualSummary: fmt.Sprintf("%s %s", request.Method, request.URL.Path),
-				NextSteps:     "No HTTP mocks available. Re-record mocks to capture this endpoint.",
-			}
-		}
 		httpMocks = FilterHTTPMocks(mocks)
 	}
-	if len(httpMocks) == 0 {
-		return &models.MockMismatchReport{
-			Protocol:      "HTTP",
-			ActualSummary: fmt.Sprintf("%s %s", request.Method, request.URL.Path),
-			NextSteps:     "No HTTP mocks available. Re-record mocks to capture this endpoint.",
+
+	phase := models.MatchPhaseExhausted
+	candidateCount := len(httpMocks)
+	var schemaSurvivors []*models.Mock
+	if diag != nil {
+		if diag.phase != "" {
+			phase = diag.phase
 		}
+		if diag.candidates > 0 {
+			candidateCount = diag.candidates
+		}
+		schemaSurvivors = diag.schemaMatched
 	}
 
-	// Find closest mock: first try same-method mocks (cheap filter), then fall back to all.
+	if candidateCount == 0 && len(schemaSurvivors) == 0 {
+		return mismatch.NewReport(mismatch.ProtocolHTTP, actualKey).
+			WithPhase(models.MatchPhaseNoMocks, 0).Build()
+	}
+
+	// Pick the candidate to diff against. Preference order:
+	//  1. a schema-match survivor (method+path+keys already matched — the
+	//     interesting drift is in query values, headers, or the body)
+	//  2. the lowest-Levenshtein "METHOD path" mock from the pool.
+	closestMock := pickClosestCandidate(request, schemaSurvivors, httpMocks)
+	if closestMock == nil || closestMock.Spec.HTTPReq == nil {
+		return mismatch.NewReport(mismatch.ProtocolHTTP, actualKey).
+			WithPhase(phase, candidateCount).Build()
+	}
+
+	mockReq := closestMock.Spec.HTTPReq
+	var fieldDiffs []models.MockFieldDiff
+
+	// method / path pseudo-fields
+	if string(mockReq.Method) != request.Method {
+		fieldDiffs = append(fieldDiffs, models.MockFieldDiff{
+			Path: "method", Kind: models.DiffKindValueChanged,
+			Expected: string(mockReq.Method), Actual: request.Method,
+		})
+	}
+	mockPath := mockReq.URL
+	var mockQuery url.Values
+	if parsed, err := url.Parse(mockReq.URL); err == nil {
+		mockPath = parsed.Path
+		mockQuery = parsed.Query()
+	}
+	if mockPath != request.URL.Path {
+		fieldDiffs = append(fieldDiffs, models.MockFieldDiff{
+			Path: "path", Kind: models.DiffKindValueChanged,
+			Expected: mockPath, Actual: request.URL.Path,
+		})
+	}
+
+	// Recorded URLParams take precedence over the parsed URL query (some
+	// recorders store params only there); fall back to the parsed query.
+	recordedQuery := map[string][]string{}
+	if len(mockReq.URLParams) > 0 {
+		for k, v := range mockReq.URLParams {
+			recordedQuery[k] = []string{v}
+		}
+	} else {
+		recordedQuery = mockQuery
+	}
+	fieldDiffs = append(fieldDiffs, mismatch.QueryParamDiffs(recordedQuery, request.URL.Query())...)
+	fieldDiffs = append(fieldDiffs, mismatch.HeaderKeyDiffs(mockReq.Header, request.Header, headerNoise)...)
+
+	// Body diffs: JSON bodies get field-level diffs excluding everything the
+	// matcher itself ignores (learned req_body_noise + user body noise).
+	if len(liveBody) > 0 && pkg.IsJSON([]byte(mockReq.Body)) && pkg.IsJSON(liveBody) {
+		ignore := mergeNoiseMaps(stripBodyPrefix(mockReq.ReqBodyNoise), userBodyNoise)
+		fieldDiffs = append(fieldDiffs, mismatch.JSONBodyDiffs(mockReq.Body, string(liveBody), ignore)...)
+	}
+
+	b := mismatch.NewReport(mismatch.ProtocolHTTP, actualKey).
+		WithPhase(phase, candidateCount).
+		WithClosest(closestMock.Name, fieldDiffs)
+	if len(fieldDiffs) == 0 {
+		// Nothing structurally differs vs the closest candidate, yet the
+		// matcher rejected everything — point the user at the phase instead
+		// of the misleading legacy "headers or body differ".
+		b = b.WithDiff(fmt.Sprintf("closest mock %q has no field-level differences; match stopped at phase %q", closestMock.Name, phase))
+	}
+	return b.Build()
+}
+
+// pickClosestCandidate prefers a schema-match survivor (already same
+// method/path/keys) and falls back to the lowest-Levenshtein "METHOD path"
+// candidate across the pool, same-method candidates first.
+func pickClosestCandidate(request *http.Request, schemaSurvivors, pool []*models.Mock) *models.Mock {
+	if len(schemaSurvivors) > 0 {
+		for _, m := range schemaSurvivors {
+			if m != nil && m.Spec.HTTPReq != nil {
+				return m
+			}
+		}
+	}
 	actualKey := request.Method + " " + request.URL.Path
 	bestDist := -1
-	var closestMock *models.Mock
-	// Two-pass: first same method only, then all if no match found
+	var closest *models.Mock
 	for pass := 0; pass < 2; pass++ {
-		for _, mock := range httpMocks {
-			if mock.Spec.HTTPReq == nil {
+		for _, mock := range pool {
+			if mock == nil || mock.Spec.HTTPReq == nil {
 				continue
 			}
 			if pass == 0 && string(mock.Spec.HTTPReq.Method) != request.Method {
@@ -1235,45 +1377,12 @@ func (h *HTTP) buildHTTPMismatchReport(request *http.Request, mockDb integration
 			dist := levenshtein.ComputeDistance(actualKey, mockKey)
 			if bestDist < 0 || dist < bestDist {
 				bestDist = dist
-				closestMock = mock
+				closest = mock
 			}
 		}
-		if closestMock != nil {
+		if closest != nil {
 			break
 		}
 	}
-	if closestMock == nil || closestMock.Spec.HTTPReq == nil {
-		return &models.MockMismatchReport{
-			Protocol:      "HTTP",
-			ActualSummary: actualKey,
-			NextSteps:     "Re-record mocks if the API endpoint or request format has changed.",
-		}
-	}
-
-	// Build diff details
-	var diffs []string
-	mockReq := closestMock.Spec.HTTPReq
-	if string(mockReq.Method) != request.Method {
-		diffs = append(diffs, fmt.Sprintf("method: %q vs %q", request.Method, mockReq.Method))
-	}
-	mockPath := mockReq.URL
-	if parsed, err := url.Parse(mockReq.URL); err == nil {
-		mockPath = parsed.Path
-	}
-	if mockPath != request.URL.Path {
-		diffs = append(diffs, fmt.Sprintf("path: %q vs %q", request.URL.Path, mockPath))
-	}
-
-	diff := strings.Join(diffs, "; ")
-	if diff == "" {
-		diff = "method and path match but headers or body differ"
-	}
-
-	return &models.MockMismatchReport{
-		Protocol:      "HTTP",
-		ActualSummary: actualKey,
-		ClosestMock:   closestMock.Name,
-		Diff:          diff,
-		NextSteps:     "Re-record mocks if the API endpoint or request format has changed.",
-	}
+	return closest
 }

--- a/pkg/agent/proxy/integrations/http/match.go
+++ b/pkg/agent/proxy/integrations/http/match.go
@@ -1243,11 +1243,19 @@ func mergeReqBodyNoise(existing, detected map[string][]string) map[string][]stri
 // just the lowest-Levenshtein path. If httpMocks is nil, it fetches from
 // mockDb; otherwise it uses the pre-fetched slice to avoid a redundant read.
 func (h *HTTP) buildHTTPMismatchReport(request *http.Request, liveBody []byte, mockDb integrations.MockMemDb, httpMocks []*models.Mock, headerNoise, userBodyNoise map[string][]string, diag *matchDiag) *models.MockMismatchReport {
+	// Defensive: this diagnostic builder and its callees (pickClosestCandidate,
+	// renderLiveRequest) — plus decode.go's 502 error line — dereference
+	// request.URL throughout. http.ReadRequest always sets a non-nil URL on the
+	// live path, but normalize here so a hand-built request (tests / future
+	// callers) can never panic the agent on the error path.
+	if request.URL == nil {
+		request.URL = &url.URL{}
+	}
 	actualKey := request.Method + " " + request.URL.Path
 	// Destination identifies WHICH upstream this missed call targeted; the same
 	// method+path can hit several hosts. Host header first, URL authority next.
 	dest := request.Host
-	if dest == "" && request.URL != nil {
+	if dest == "" {
 		dest = request.URL.Host
 	}
 	if httpMocks == nil && (diag == nil || len(diag.schemaMatched) == 0) {

--- a/pkg/agent/proxy/integrations/http/match_test.go
+++ b/pkg/agent/proxy/integrations/http/match_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -91,7 +92,7 @@ func httpMock(name, method, rawURL string) *models.Mock {
 func TestBuildHTTPMismatchReport_NoMocks(t *testing.T) {
 	h := newHTTP()
 	db := &mockMemDb{mocks: nil}
-	report := h.buildHTTPMismatchReport(makeReq("GET", "/api/users"), db, nil)
+	report := h.buildHTTPMismatchReport(makeReq("GET", "/api/users"), nil, db, nil, nil, nil, nil)
 
 	if report == nil {
 		t.Fatal("expected non-nil report")
@@ -110,7 +111,7 @@ func TestBuildHTTPMismatchReport_NoMocks(t *testing.T) {
 func TestBuildHTTPMismatchReport_DbError(t *testing.T) {
 	h := newHTTP()
 	db := &mockMemDb{err: fmt.Errorf("db error")}
-	report := h.buildHTTPMismatchReport(makeReq("POST", "/api/items"), db, nil)
+	report := h.buildHTTPMismatchReport(makeReq("POST", "/api/items"), nil, db, nil, nil, nil, nil)
 
 	if report == nil {
 		t.Fatal("expected non-nil report")
@@ -129,7 +130,7 @@ func TestBuildHTTPMismatchReport_NoHTTPMocks(t *testing.T) {
 	db := &mockMemDb{mocks: []*models.Mock{
 		{Name: "dns-mock", Kind: "DNS", Spec: models.MockSpec{}},
 	}}
-	report := h.buildHTTPMismatchReport(makeReq("GET", "/api/data"), db, nil)
+	report := h.buildHTTPMismatchReport(makeReq("GET", "/api/data"), nil, db, nil, nil, nil, nil)
 
 	if report == nil {
 		t.Fatal("expected non-nil report")
@@ -146,7 +147,7 @@ func TestBuildHTTPMismatchReport_SameMethodMatch(t *testing.T) {
 		httpMock("mock-get-users", "GET", "http://localhost:8080/api/users"),
 		httpMock("mock-post-users", "POST", "http://localhost:8080/api/users"),
 	}}
-	report := h.buildHTTPMismatchReport(makeReq("GET", "/api/items"), db, nil)
+	report := h.buildHTTPMismatchReport(makeReq("GET", "/api/items"), nil, db, nil, nil, nil, nil)
 
 	if report == nil {
 		t.Fatal("expected non-nil report")
@@ -166,7 +167,7 @@ func TestBuildHTTPMismatchReport_DiffMethodFallback(t *testing.T) {
 	db := &mockMemDb{mocks: []*models.Mock{
 		httpMock("mock-post-items", "POST", "http://localhost:8080/api/items"),
 	}}
-	report := h.buildHTTPMismatchReport(makeReq("GET", "/api/items"), db, nil)
+	report := h.buildHTTPMismatchReport(makeReq("GET", "/api/items"), nil, db, nil, nil, nil, nil)
 
 	if report == nil {
 		t.Fatal("expected non-nil report")
@@ -186,7 +187,7 @@ func TestBuildHTTPMismatchReport_PathDiff(t *testing.T) {
 	db := &mockMemDb{mocks: []*models.Mock{
 		httpMock("mock-get-users", "GET", "http://localhost:8080/api/users"),
 	}}
-	report := h.buildHTTPMismatchReport(makeReq("GET", "/api/orders"), db, nil)
+	report := h.buildHTTPMismatchReport(makeReq("GET", "/api/orders"), nil, db, nil, nil, nil, nil)
 
 	if report == nil {
 		t.Fatal("expected non-nil report")
@@ -206,13 +207,13 @@ func TestBuildHTTPMismatchReport_ExactPathMethodMatch(t *testing.T) {
 		httpMock("mock-get-users", "GET", "http://localhost:8080/api/users"),
 	}}
 	// Same method and path — diff should indicate headers/body differ
-	report := h.buildHTTPMismatchReport(makeReq("GET", "/api/users"), db, nil)
+	report := h.buildHTTPMismatchReport(makeReq("GET", "/api/users"), nil, db, nil, nil, nil, nil)
 
 	if report == nil {
 		t.Fatal("expected non-nil report")
 	}
-	if report.Diff != "method and path match but headers or body differ" {
-		t.Errorf("expected headers/body diff message, got %q", report.Diff)
+	if !strings.Contains(report.Diff, "no field-level differences") {
+		t.Errorf("expected no-field-level-differences diff message, got %q", report.Diff)
 	}
 }
 

--- a/pkg/agent/proxy/integrations/http/mismatch_render.go
+++ b/pkg/agent/proxy/integrations/http/mismatch_render.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -18,13 +17,15 @@ import (
 // valueRedacted replaces sensitive/obfuscated values in the rendered requests.
 const valueRedacted = "(redacted)"
 
-// sensitiveHeaderTokens marks header names whose values must never be printed
-// into a report (they commonly carry credentials).
-var sensitiveHeaderTokens = []string{"auth", "key", "token", "secret", "cookie", "signature", "credential"}
+// sensitiveKeyTokens marks header / query / body key names whose values must
+// never be printed into a report (they commonly carry credentials).
+var sensitiveKeyTokens = []string{"auth", "key", "token", "secret", "cookie", "signature", "credential", "password", "passwd", "pwd"}
 
+// isSensitiveHeader reports whether a header, query-param, or JSON body key
+// looks like it carries a credential and should be redacted.
 func isSensitiveHeader(name string) bool {
 	ln := strings.ToLower(name)
-	for _, t := range sensitiveHeaderTokens {
+	for _, t := range sensitiveKeyTokens {
 		if strings.Contains(ln, t) {
 			return true
 		}
@@ -82,7 +83,18 @@ func urlParamsQuery(params map[string]string) string {
 	return vals.Encode()
 }
 
+// Rendering bounds. The rendered requests are persisted into the report and
+// held in the agent's bounded pending-error queue, so a single pathological
+// value or body must not be able to bloat memory unbounded — cap them.
+const (
+	maxRenderValueLen = 256  // a single header / query value
+	maxRenderBodyLen  = 4096 // the rendered body
+)
+
 // renderRequestPreview is the shared renderer behind both sides of the diff.
+// Sensitive header/query/body values (by key name or by the mock's noise
+// patterns) are redacted before they ever land in a report, and every value
+// and the body are length-capped.
 func renderRequestPreview(method, path, rawQuery string, header map[string]string, body string, noise []string) string {
 	nc := util.NewNoiseChecker(noise)
 	isObfuscated := func(v string) bool { return v != "" && nc != nil && nc.IsNoisy(v) }
@@ -91,12 +103,9 @@ func renderRequestPreview(method, path, rawQuery string, header map[string]strin
 	target := path
 	if rawQuery != "" {
 		// Canonicalize so semantically equal queries render identically on
-		// both sides regardless of original parameter order.
-		if vals, err := url.ParseQuery(rawQuery); err == nil {
-			target += "?" + vals.Encode()
-		} else {
-			target += "?" + rawQuery
-		}
+		// both sides, and redact sensitive / obfuscated parameter values so
+		// credentials in the query string never reach the report.
+		target += "?" + redactQuery(rawQuery, nc)
 	}
 	fmt.Fprintf(&b, "%s %s", method, target)
 
@@ -112,31 +121,92 @@ func renderRequestPreview(method, path, rawQuery string, header map[string]strin
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-	// Render ALL headers and the WHOLE body — no count/length cap — so the user
-	// sees the complete recorded mock side-by-side. Sensitive / obfuscated
-	// values are still redacted.
 	for _, k := range keys {
 		v := header[k]
 		if isSensitiveHeader(k) || isObfuscated(v) {
 			v = valueRedacted
+		} else {
+			v = truncateValue(v, maxRenderValueLen)
 		}
 		fmt.Fprintf(&b, "\n%s: %s", textproto.CanonicalMIMEHeaderKey(k), v)
 	}
 	if body != "" {
-		fmt.Fprintf(&b, "\n\n%s", prettyJSONBody(body))
+		fmt.Fprintf(&b, "\n\n%s", truncateValue(redactBody(body, nc), maxRenderBodyLen))
 	}
 	return b.String()
 }
 
-// prettyJSONBody indents a JSON body one field per line so line-level diffs
-// align to fields; non-JSON bodies are returned unchanged.
-func prettyJSONBody(body string) string {
+// truncateValue rune-safely caps s, appending an ellipsis when it cuts.
+func truncateValue(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max]) + "…(truncated)"
+}
+
+// redactQuery canonicalizes a query string and redacts parameter values whose
+// key looks sensitive or whose value matches the mock's noise patterns.
+func redactQuery(rawQuery string, nc *util.NoiseChecker) string {
+	vals, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return rawQuery
+	}
+	for k, vs := range vals {
+		for i, v := range vs {
+			if isSensitiveHeader(k) || (nc != nil && v != "" && nc.IsNoisy(v)) {
+				vs[i] = valueRedacted
+			} else {
+				vs[i] = truncateValue(v, maxRenderValueLen)
+			}
+		}
+	}
+	return vals.Encode()
+}
+
+// redactBody redacts secret / obfuscated fields in a request body before it is
+// rendered into a report. JSON bodies are walked field-by-field — a value is
+// redacted when its key looks sensitive or the value matches the mock's noise
+// patterns — and re-indented one field per line so line diffs align. Non-JSON
+// bodies are redacted wholesale when they match a noise pattern, else returned
+// as-is (the caller length-caps them).
+func redactBody(body string, nc *util.NoiseChecker) string {
 	if !pkg.IsJSON([]byte(body)) {
+		if nc != nil && nc.IsNoisy(body) {
+			return valueRedacted
+		}
 		return body
 	}
-	var buf bytes.Buffer
-	if err := json.Indent(&buf, []byte(body), "", "  "); err != nil {
+	var v interface{}
+	if err := json.Unmarshal([]byte(body), &v); err != nil {
 		return body
 	}
-	return buf.String()
+	redactJSONValue(v, nc)
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return body
+	}
+	return string(out)
+}
+
+func redactJSONValue(v interface{}, nc *util.NoiseChecker) {
+	switch t := v.(type) {
+	case map[string]interface{}:
+		for k, val := range t {
+			if s, ok := val.(string); ok {
+				if isSensitiveHeader(k) || (nc != nil && s != "" && nc.IsNoisy(s)) {
+					t[k] = valueRedacted
+					continue
+				}
+			}
+			redactJSONValue(val, nc)
+		}
+	case []interface{}:
+		for _, val := range t {
+			redactJSONValue(val, nc)
+		}
+	}
 }

--- a/pkg/agent/proxy/integrations/http/mismatch_render.go
+++ b/pkg/agent/proxy/integrations/http/mismatch_render.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/textproto"
 	"net/url"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -33,6 +34,53 @@ func isSensitiveHeader(name string) bool {
 	return false
 }
 
+// secretValuePatterns matches credential-SHAPED values, independent of the key
+// name or the mock's noise config — the value-shape backstop behind the
+// key-name denylist and the noise regexes. They are deliberately
+// prefix/scheme-based (not raw Shannon entropy): a generic "high-entropy"
+// rule would also redact UUIDs, content hashes and idempotency keys, which are
+// frequently the exact field that drifted and caused the mismatch — redacting
+// those would gut the diagnostic value of the diff. Each pattern matches a
+// credential FORM with effectively no legitimate non-secret collision.
+var secretValuePatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]{8,}`),              // Authorization schemes
+	regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}`), // JWT (header.payload.sig)
+	regexp.MustCompile(`-----BEGIN[A-Z ]*PRIVATE KEY-----`),                            // PEM private key
+	regexp.MustCompile(`\b(?:AKIA|ASIA)[A-Z0-9]{16}\b`),                                // AWS access key id
+	regexp.MustCompile(`\bgh[posru]_[A-Za-z0-9]{20,}\b`),                               // GitHub token
+	regexp.MustCompile(`\bkep_[A-Za-z0-9_-]{20,}\b`),                                   // keploy PAT
+	regexp.MustCompile(`\bsk_(?:live|test)_[A-Za-z0-9]{16,}\b`),                        // Stripe secret key
+	regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{10,}\b`),                             // Slack token
+	regexp.MustCompile(`\bglpat-[A-Za-z0-9_-]{20,}\b`),                                 // GitLab PAT
+	regexp.MustCompile(`\bAIza[A-Za-z0-9_-]{35}\b`),                                    // Google API key
+}
+
+// looksLikeSecretValue reports whether a single header / query-param /
+// JSON-scalar value is credential-shaped and must be redacted even when its key
+// isn't on the denylist and the mock's noise config didn't cover it.
+func looksLikeSecretValue(v string) bool {
+	s := strings.TrimSpace(v)
+	if len(s) < 8 {
+		return false
+	}
+	for _, re := range secretValuePatterns {
+		if re.MatchString(s) {
+			return true
+		}
+	}
+	return false
+}
+
+// scrubSecretsInText replaces credential-shaped tokens embedded in free-form
+// (opaque, non-JSON / non-form) body text with the redaction marker, leaving
+// the surrounding structure intact so the diff stays useful.
+func scrubSecretsInText(s string) string {
+	for _, re := range secretValuePatterns {
+		s = re.ReplaceAllString(s, valueRedacted)
+	}
+	return s
+}
+
 // redactFieldDiffs redacts the Expected/Actual values of structured field diffs
 // in place. A value is redacted when its path key looks sensitive or the value
 // matches the mock's noise patterns. These diffs — and the one-line Diff string
@@ -44,10 +92,10 @@ func redactFieldDiffs(diffs []models.MockFieldDiff, mockNoise []string) {
 	isNoisy := func(v string) bool { return v != "" && nc != nil && nc.IsNoisy(v) }
 	for i := range diffs {
 		sensitive := isSensitiveHeader(diffs[i].Path)
-		if sensitive || isNoisy(diffs[i].Expected) {
+		if sensitive || isNoisy(diffs[i].Expected) || looksLikeSecretValue(diffs[i].Expected) {
 			diffs[i].Expected = valueRedacted
 		}
-		if sensitive || isNoisy(diffs[i].Actual) {
+		if sensitive || isNoisy(diffs[i].Actual) || looksLikeSecretValue(diffs[i].Actual) {
 			diffs[i].Actual = valueRedacted
 		}
 	}
@@ -157,7 +205,7 @@ func renderRequestPreview(method, path, rawQuery string, header map[string]strin
 	sort.Strings(keys)
 	for _, k := range keys {
 		v := header[k]
-		if isSensitiveHeader(k) || isObfuscated(v) {
+		if isSensitiveHeader(k) || isObfuscated(v) || looksLikeSecretValue(v) {
 			v = valueRedacted
 		} else {
 			v = truncateValue(v, maxRenderValueLen)
@@ -203,7 +251,7 @@ func redactQuery(rawQuery string, nc *util.NoiseChecker) string {
 	}
 	for k, vs := range vals {
 		for i, v := range vs {
-			if isSensitiveHeader(k) || (nc != nil && v != "" && nc.IsNoisy(v)) {
+			if isSensitiveHeader(k) || (nc != nil && v != "" && nc.IsNoisy(v)) || looksLikeSecretValue(v) {
 				vs[i] = valueRedacted
 			} else {
 				vs[i] = truncateValue(v, maxRenderValueLen)
@@ -239,7 +287,10 @@ func redactBody(body, contentType string, nc *util.NoiseChecker) string {
 	if nc != nil && nc.IsNoisy(body) {
 		return valueRedacted
 	}
-	return body
+	// Opaque body (XML / SOAP / plain-text / proto / GraphQL): there's no field
+	// structure to walk, so scrub credential-shaped tokens in place as a
+	// backstop instead of emitting the body verbatim.
+	return scrubSecretsInText(body)
 }
 
 // redactJSONValue walks a decoded JSON value in place. A sensitive key's value
@@ -255,7 +306,7 @@ func redactJSONValue(v interface{}, nc *util.NoiseChecker) {
 				continue
 			}
 			if s, ok := val.(string); ok {
-				if isNoisy(s) {
+				if isNoisy(s) || looksLikeSecretValue(s) {
 					t[k] = valueRedacted
 				}
 				continue
@@ -265,7 +316,7 @@ func redactJSONValue(v interface{}, nc *util.NoiseChecker) {
 	case []interface{}:
 		for i, val := range t {
 			if s, ok := val.(string); ok {
-				if isNoisy(s) {
+				if isNoisy(s) || looksLikeSecretValue(s) {
 					t[i] = valueRedacted
 				}
 				continue

--- a/pkg/agent/proxy/integrations/http/mismatch_render.go
+++ b/pkg/agent/proxy/integrations/http/mismatch_render.go
@@ -33,6 +33,26 @@ func isSensitiveHeader(name string) bool {
 	return false
 }
 
+// redactFieldDiffs redacts the Expected/Actual values of structured field diffs
+// in place. A value is redacted when its path key looks sensitive or the value
+// matches the mock's noise patterns. These diffs — and the one-line Diff string
+// derived from them — are persisted into the report YAML and the platform API,
+// so raw secrets must never reach them (the whole-request renders are sanitized
+// separately).
+func redactFieldDiffs(diffs []models.MockFieldDiff, mockNoise []string) {
+	nc := util.NewNoiseChecker(mockNoise)
+	isNoisy := func(v string) bool { return v != "" && nc != nil && nc.IsNoisy(v) }
+	for i := range diffs {
+		sensitive := isSensitiveHeader(diffs[i].Path)
+		if sensitive || isNoisy(diffs[i].Expected) {
+			diffs[i].Expected = valueRedacted
+		}
+		if sensitive || isNoisy(diffs[i].Actual) {
+			diffs[i].Actual = valueRedacted
+		}
+	}
+}
+
 // renderMockRequest renders the closest mock's recorded request for the LEFT
 // side of the side-by-side diff: request line, sorted headers (sensitive /
 // obfuscated values redacted), blank line, JSON-pretty body. mockNoise is the
@@ -45,7 +65,21 @@ func renderMockRequest(mockReq *models.HTTPReq, mockNoise []string) string {
 	for k, v := range mockReq.Header {
 		header[k] = v
 	}
-	return renderRequestPreview(string(mockReq.Method), mockURLPath(mockReq.URL), urlParamsQuery(mockReq.URLParams), header, mockReq.Body, mockNoise)
+	return renderRequestPreview(string(mockReq.Method), mockURLPath(mockReq.URL), mockQueryString(mockReq), header, mockReq.Body, mockNoise)
+}
+
+// mockQueryString returns the mock's query string, mirroring the matcher's
+// source-of-truth fallback: recorded URLParams when present, otherwise the
+// query parsed from the full URL. Without the fallback, recordings that store
+// the query only in URL would render a false URL difference vs the live request.
+func mockQueryString(mockReq *models.HTTPReq) string {
+	if len(mockReq.URLParams) > 0 {
+		return urlParamsQuery(mockReq.URLParams)
+	}
+	if parsed, err := url.Parse(mockReq.URL); err == nil {
+		return parsed.RawQuery
+	}
+	return ""
 }
 
 // renderLiveRequest renders the live request for the RIGHT side, in the exact
@@ -131,9 +165,19 @@ func renderRequestPreview(method, path, rawQuery string, header map[string]strin
 		fmt.Fprintf(&b, "\n%s: %s", textproto.CanonicalMIMEHeaderKey(k), v)
 	}
 	if body != "" {
-		fmt.Fprintf(&b, "\n\n%s", truncateValue(redactBody(body, nc), maxRenderBodyLen))
+		fmt.Fprintf(&b, "\n\n%s", truncateValue(redactBody(body, headerValue(header, "content-type"), nc), maxRenderBodyLen))
 	}
 	return b.String()
+}
+
+// headerValue does a case-insensitive lookup in a header map.
+func headerValue(header map[string]string, name string) string {
+	for k, v := range header {
+		if strings.EqualFold(k, name) {
+			return v
+		}
+	}
+	return ""
 }
 
 // truncateValue rune-safely caps s, appending an ellipsis when it cuts.
@@ -149,11 +193,13 @@ func truncateValue(s string, max int) string {
 }
 
 // redactQuery canonicalizes a query string and redacts parameter values whose
-// key looks sensitive or whose value matches the mock's noise patterns.
+// key looks sensitive or whose value matches the mock's noise patterns. On a
+// parse failure it fails closed — the raw query is never emitted, since it
+// could carry credentials.
 func redactQuery(rawQuery string, nc *util.NoiseChecker) string {
 	vals, err := url.ParseQuery(rawQuery)
 	if err != nil {
-		return rawQuery
+		return valueRedacted
 	}
 	for k, vs := range vals {
 		for i, v := range vs {
@@ -169,43 +215,61 @@ func redactQuery(rawQuery string, nc *util.NoiseChecker) string {
 
 // redactBody redacts secret / obfuscated fields in a request body before it is
 // rendered into a report. JSON bodies are walked field-by-field — a value is
-// redacted when its key looks sensitive or the value matches the mock's noise
-// patterns — and re-indented one field per line so line diffs align. Non-JSON
-// bodies are redacted wholesale when they match a noise pattern, else returned
-// as-is (the caller length-caps them).
-func redactBody(body string, nc *util.NoiseChecker) string {
-	if !pkg.IsJSON([]byte(body)) {
-		if nc != nil && nc.IsNoisy(body) {
-			return valueRedacted
+// redacted when its key looks sensitive (regardless of its type) or the value
+// matches the mock's noise patterns — and re-indented one field per line so
+// line diffs align. Form-urlencoded bodies are redacted per parameter. Other
+// non-JSON bodies are redacted wholesale when they match a noise pattern, else
+// returned as-is (the caller length-caps them).
+func redactBody(body, contentType string, nc *util.NoiseChecker) string {
+	if pkg.IsJSON([]byte(body)) {
+		var v interface{}
+		if err := json.Unmarshal([]byte(body), &v); err != nil {
+			return body
 		}
-		return body
+		redactJSONValue(v, nc)
+		out, err := json.MarshalIndent(v, "", "  ")
+		if err != nil {
+			return body
+		}
+		return string(out)
 	}
-	var v interface{}
-	if err := json.Unmarshal([]byte(body), &v); err != nil {
-		return body
+	if strings.Contains(strings.ToLower(contentType), "x-www-form-urlencoded") {
+		return redactQuery(body, nc)
 	}
-	redactJSONValue(v, nc)
-	out, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return body
+	if nc != nil && nc.IsNoisy(body) {
+		return valueRedacted
 	}
-	return string(out)
+	return body
 }
 
+// redactJSONValue walks a decoded JSON value in place. A sensitive key's value
+// is redacted whatever its type (string, number, object, array); string scalars
+// — in objects and arrays — are redacted when they match a noise pattern.
 func redactJSONValue(v interface{}, nc *util.NoiseChecker) {
+	isNoisy := func(s string) bool { return s != "" && nc != nil && nc.IsNoisy(s) }
 	switch t := v.(type) {
 	case map[string]interface{}:
 		for k, val := range t {
+			if isSensitiveHeader(k) {
+				t[k] = valueRedacted
+				continue
+			}
 			if s, ok := val.(string); ok {
-				if isSensitiveHeader(k) || (nc != nil && s != "" && nc.IsNoisy(s)) {
+				if isNoisy(s) {
 					t[k] = valueRedacted
-					continue
 				}
+				continue
 			}
 			redactJSONValue(val, nc)
 		}
 	case []interface{}:
-		for _, val := range t {
+		for i, val := range t {
+			if s, ok := val.(string); ok {
+				if isNoisy(s) {
+					t[i] = valueRedacted
+				}
+				continue
+			}
 			redactJSONValue(val, nc)
 		}
 	}

--- a/pkg/agent/proxy/integrations/http/mismatch_render.go
+++ b/pkg/agent/proxy/integrations/http/mismatch_render.go
@@ -15,15 +15,6 @@ import (
 	"go.keploy.io/server/v3/pkg/models"
 )
 
-// Rendering bounds for the side-by-side whole-mock diff. These cap a single
-// unmatched request so a large payload can't bloat the report yaml or the CLI
-// view.
-const (
-	renderMaxValueLen = 100  // longest rendered header value
-	renderMaxBodyLen  = 2000 // body bytes shown (pretty-printed)
-	renderMaxHeaders  = 12   // headers shown per side
-)
-
 // valueRedacted replaces sensitive/obfuscated values in the rendered requests.
 const valueRedacted = "(redacted)"
 
@@ -121,21 +112,18 @@ func renderRequestPreview(method, path, rawQuery string, header map[string]strin
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-	shown := 0
+	// Render ALL headers and the WHOLE body — no count/length cap — so the user
+	// sees the complete recorded mock side-by-side. Sensitive / obfuscated
+	// values are still redacted.
 	for _, k := range keys {
-		if shown >= renderMaxHeaders {
-			fmt.Fprintf(&b, "\n(+%d more headers)", len(keys)-shown)
-			break
-		}
 		v := header[k]
 		if isSensitiveHeader(k) || isObfuscated(v) {
 			v = valueRedacted
 		}
-		fmt.Fprintf(&b, "\n%s: %s", textproto.CanonicalMIMEHeaderKey(k), truncateForDisplay(v, renderMaxValueLen))
-		shown++
+		fmt.Fprintf(&b, "\n%s: %s", textproto.CanonicalMIMEHeaderKey(k), v)
 	}
 	if body != "" {
-		fmt.Fprintf(&b, "\n\n%s", truncateForDisplay(prettyJSONBody(body), renderMaxBodyLen))
+		fmt.Fprintf(&b, "\n\n%s", prettyJSONBody(body))
 	}
 	return b.String()
 }
@@ -151,17 +139,4 @@ func prettyJSONBody(body string) string {
 		return body
 	}
 	return buf.String()
-}
-
-// truncateForDisplay rune-safely truncates s to at most max characters,
-// appending an ellipsis when something was cut.
-func truncateForDisplay(s string, max int) string {
-	if len(s) <= max {
-		return s
-	}
-	runes := []rune(s)
-	if len(runes) <= max {
-		return s
-	}
-	return string(runes[:max]) + "…"
 }

--- a/pkg/agent/proxy/integrations/http/mismatch_render.go
+++ b/pkg/agent/proxy/integrations/http/mismatch_render.go
@@ -1,0 +1,167 @@
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/textproto"
+	"net/url"
+	"sort"
+	"strings"
+
+	"go.keploy.io/server/v3/pkg"
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/util"
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// Rendering bounds for the side-by-side whole-mock diff. These cap a single
+// unmatched request so a large payload can't bloat the report yaml or the CLI
+// view.
+const (
+	renderMaxValueLen = 100  // longest rendered header value
+	renderMaxBodyLen  = 2000 // body bytes shown (pretty-printed)
+	renderMaxHeaders  = 12   // headers shown per side
+)
+
+// valueRedacted replaces sensitive/obfuscated values in the rendered requests.
+const valueRedacted = "(redacted)"
+
+// sensitiveHeaderTokens marks header names whose values must never be printed
+// into a report (they commonly carry credentials).
+var sensitiveHeaderTokens = []string{"auth", "key", "token", "secret", "cookie", "signature", "credential"}
+
+func isSensitiveHeader(name string) bool {
+	ln := strings.ToLower(name)
+	for _, t := range sensitiveHeaderTokens {
+		if strings.Contains(ln, t) {
+			return true
+		}
+	}
+	return false
+}
+
+// renderMockRequest renders the closest mock's recorded request for the LEFT
+// side of the side-by-side diff: request line, sorted headers (sensitive /
+// obfuscated values redacted), blank line, JSON-pretty body. mockNoise is the
+// mock's Mock.Noise so obfuscated values stay redacted.
+func renderMockRequest(mockReq *models.HTTPReq, mockNoise []string) string {
+	if mockReq == nil {
+		return ""
+	}
+	header := make(map[string]string, len(mockReq.Header))
+	for k, v := range mockReq.Header {
+		header[k] = v
+	}
+	return renderRequestPreview(string(mockReq.Method), mockURLPath(mockReq.URL), urlParamsQuery(mockReq.URLParams), header, mockReq.Body, mockNoise)
+}
+
+// renderLiveRequest renders the live request for the RIGHT side, in the exact
+// same format as renderMockRequest so the two line up in the diff.
+func renderLiveRequest(request *http.Request, body []byte, mockNoise []string) string {
+	if request == nil {
+		return ""
+	}
+	header := make(map[string]string, len(request.Header))
+	for k := range request.Header {
+		header[k] = strings.Join(request.Header.Values(k), ", ")
+	}
+	return renderRequestPreview(request.Method, request.URL.Path, request.URL.RawQuery, header, string(body), mockNoise)
+}
+
+// mockURLPath extracts just the path from a mock's URL (mocks store full URL
+// strings); falls back to the raw string when it doesn't parse.
+func mockURLPath(mockURL string) string {
+	if parsed, err := url.Parse(mockURL); err == nil {
+		return parsed.Path
+	}
+	return mockURL
+}
+
+// urlParamsQuery renders a mock's recorded URLParams in canonical (sorted)
+// query-string form so it lines up against the live request's query.
+func urlParamsQuery(params map[string]string) string {
+	if len(params) == 0 {
+		return ""
+	}
+	vals := url.Values{}
+	for k, v := range params {
+		vals.Set(k, v)
+	}
+	return vals.Encode()
+}
+
+// renderRequestPreview is the shared renderer behind both sides of the diff.
+func renderRequestPreview(method, path, rawQuery string, header map[string]string, body string, noise []string) string {
+	nc := util.NewNoiseChecker(noise)
+	isObfuscated := func(v string) bool { return v != "" && nc != nil && nc.IsNoisy(v) }
+
+	var b strings.Builder
+	target := path
+	if rawQuery != "" {
+		// Canonicalize so semantically equal queries render identically on
+		// both sides regardless of original parameter order.
+		if vals, err := url.ParseQuery(rawQuery); err == nil {
+			target += "?" + vals.Encode()
+		} else {
+			target += "?" + rawQuery
+		}
+	}
+	fmt.Fprintf(&b, "%s %s", method, target)
+
+	var keys []string
+	for k := range header {
+		lk := strings.ToLower(k)
+		// Skip keploy-internal and per-message framing headers — they differ
+		// on every request without ever influencing matching, so showing them
+		// would highlight rows that cannot be the cause of the miss.
+		if strings.HasPrefix(lk, "keploy") || lk == "content-length" {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	shown := 0
+	for _, k := range keys {
+		if shown >= renderMaxHeaders {
+			fmt.Fprintf(&b, "\n(+%d more headers)", len(keys)-shown)
+			break
+		}
+		v := header[k]
+		if isSensitiveHeader(k) || isObfuscated(v) {
+			v = valueRedacted
+		}
+		fmt.Fprintf(&b, "\n%s: %s", textproto.CanonicalMIMEHeaderKey(k), truncateForDisplay(v, renderMaxValueLen))
+		shown++
+	}
+	if body != "" {
+		fmt.Fprintf(&b, "\n\n%s", truncateForDisplay(prettyJSONBody(body), renderMaxBodyLen))
+	}
+	return b.String()
+}
+
+// prettyJSONBody indents a JSON body one field per line so line-level diffs
+// align to fields; non-JSON bodies are returned unchanged.
+func prettyJSONBody(body string) string {
+	if !pkg.IsJSON([]byte(body)) {
+		return body
+	}
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, []byte(body), "", "  "); err != nil {
+		return body
+	}
+	return buf.String()
+}
+
+// truncateForDisplay rune-safely truncates s to at most max characters,
+// appending an ellipsis when something was cut.
+func truncateForDisplay(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	return string(runes[:max]) + "…"
+}

--- a/pkg/agent/proxy/integrations/http/mismatch_render_test.go
+++ b/pkg/agent/proxy/integrations/http/mismatch_render_test.go
@@ -1,0 +1,168 @@
+package http
+
+import (
+	"strings"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/util"
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// These renders are persisted into the report YAML and uploaded to the platform
+// API, so a secret must never survive redaction. The tests below pin every
+// redaction entry point (key-name denylist, mock-noise regexes, and the
+// value-shape backstop) and also assert the backstop does NOT over-redact
+// benign high-entropy values (UUIDs) that users need to read the diff.
+
+const (
+	// A real-shaped JWT (header.payload.signature, base64url, eyJ prefix).
+	jwtSecret = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+	awsKey    = "AKIAIOSFODNN7EXAMPLE"
+	ghToken   = "ghp_1234567890abcdefghijklmnopqrstuvwx"
+	kepToken  = "kep_xyHzkNV34tG9ec9Yii9SardU1JO9udmld8"
+	// A benign high-entropy value that is NOT a credential — must remain visible.
+	benignUUID = "550e8400-e29b-41d4-a716-446655440000"
+)
+
+func mustNotContain(t *testing.T, out, secret, where string) {
+	t.Helper()
+	if secret != "" && strings.Contains(out, secret) {
+		t.Errorf("%s: secret %q leaked into output:\n%s", where, secret, out)
+	}
+}
+
+func mustContain(t *testing.T, out, want, where string) {
+	t.Helper()
+	if !strings.Contains(out, want) {
+		t.Errorf("%s: expected output to contain %q, got:\n%s", where, want, out)
+	}
+}
+
+func TestLooksLikeSecretValue(t *testing.T) {
+	secrets := []string{
+		jwtSecret,
+		"Bearer " + jwtSecret,
+		"bearer abcdef1234567890",
+		"Basic dXNlcjpwYXNzd29yZA==",
+		awsKey,
+		ghToken,
+		kepToken,
+		"sk_live_abcdefghijklmnop1234",
+		"xoxb-123456789012-abcdefXYZ",
+		"glpat-abcdefghijklmnop1234",
+		"-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQ...",
+	}
+	for _, s := range secrets {
+		if !looksLikeSecretValue(s) {
+			t.Errorf("looksLikeSecretValue(%q) = false, want true", s)
+		}
+	}
+
+	// Must NOT be flagged — benign high-entropy / common values the user needs
+	// in the diff. This guards the deliberate decision to NOT use raw entropy.
+	benign := []string{
+		benignUUID,
+		"d41d8cd98f00b204e9800998ecf8427e", // md5 hex digest
+		"deadbeefcafebabe1234567890abcdef", // 32-char hex (e.g. a request id)
+		"warehouse-BLR-42",
+		"a short string",
+		"42",
+		"application/json",
+	}
+	for _, s := range benign {
+		if looksLikeSecretValue(s) {
+			t.Errorf("looksLikeSecretValue(%q) = true, want false (over-redaction)", s)
+		}
+	}
+}
+
+func TestRedactBody_JSON(t *testing.T) {
+	// noise regex covering a per-run token under a NON-keyword key
+	nc := util.NewNoiseChecker([]string{"^sess-[a-z0-9]+$"})
+	body := `{
+	  "password": "hunter2",
+	  "session": "sess-deadbeef",
+	  "assertion": "` + jwtSecret + `",
+	  "nested": {"client_secret": "shh-very-secret"},
+	  "items": ["` + jwtSecret + `", "ok-value"],
+	  "trace_id": "` + benignUUID + `"
+	}`
+	out := redactBody(body, "application/json", nc)
+
+	mustNotContain(t, out, "hunter2", "keyword key (password)")
+	mustNotContain(t, out, "sess-deadbeef", "noise-value on non-keyword key (session)")
+	mustNotContain(t, out, jwtSecret, "value-shape backstop (assertion + array element)")
+	mustNotContain(t, out, "shh-very-secret", "keyword key in nested object (client_secret)")
+	mustContain(t, out, valueRedacted, "redaction marker present")
+	// benign high-entropy value must remain so the user can diff it
+	mustContain(t, out, benignUUID, "benign UUID retained")
+	mustContain(t, out, "ok-value", "benign array element retained")
+}
+
+func TestRedactBody_FormURLEncoded(t *testing.T) {
+	nc := util.NewNoiseChecker(nil)
+	body := "api_key=supersecretvalue123&token=" + ghToken + "&order=42"
+	out := redactBody(body, "application/x-www-form-urlencoded", nc)
+	mustNotContain(t, out, "supersecretvalue123", "form keyword key (api_key)")
+	mustNotContain(t, out, ghToken, "form value-shape backstop (token)")
+	mustContain(t, out, "order=42", "benign form param retained")
+}
+
+func TestRedactBody_OpaqueXML(t *testing.T) {
+	nc := util.NewNoiseChecker(nil)
+	// SOAP / XML: no field structure to walk — the backstop must scrub the
+	// embedded credential while leaving the surrounding structure readable.
+	body := `<soap:Header><wsse:Password>plaintextpw</wsse:Password>` +
+		`<Authorization>Bearer ` + jwtSecret + `</Authorization></soap:Header>`
+	out := redactBody(body, "text/xml", nc)
+	mustNotContain(t, out, jwtSecret, "opaque-body bearer/JWT scrub")
+	mustContain(t, out, "<soap:Header>", "surrounding XML structure retained")
+}
+
+func TestRedactQuery(t *testing.T) {
+	nc := util.NewNoiseChecker(nil)
+	out := redactQuery("access_token="+jwtSecret+"&trace="+benignUUID+"&q=hello", nc)
+	mustNotContain(t, out, jwtSecret, "query keyword key + value-shape")
+	mustContain(t, out, benignUUID, "benign query param retained")
+	mustContain(t, out, "q=hello", "benign query param retained")
+}
+
+func TestRenderRequestPreview_RedactsEverywhere(t *testing.T) {
+	header := map[string]string{
+		"Authorization": "Bearer " + jwtSecret, // keyword key
+		"X-Trace-Token": jwtSecret,             // 'token' keyword key too
+		"X-Correlation": jwtSecret,             // NON-keyword key -> value-shape backstop
+		"Content-Type":  "application/json",
+		"X-Request-Id":  benignUUID, // benign, must remain
+	}
+	body := `{"password":"hunter2","trace_id":"` + benignUUID + `"}`
+	out := renderRequestPreview("POST", "/pay", "api_key="+ghToken+"&id="+benignUUID, header, body, nil)
+
+	mustNotContain(t, out, jwtSecret, "header secret (keyword + non-keyword key)")
+	mustNotContain(t, out, "hunter2", "body keyword key")
+	mustNotContain(t, out, ghToken, "query value-shape")
+	mustContain(t, out, benignUUID, "benign correlation/request id retained")
+}
+
+func TestRedactFieldDiffs(t *testing.T) {
+	nc := []string{"^drift-[0-9]+$"}
+	diffs := []models.MockFieldDiff{
+		{Path: "header.Authorization", Expected: "Bearer old", Actual: "Bearer new"}, // keyword path
+		{Path: "body.note", Expected: "drift-111", Actual: "drift-222"},              // noise value, benign path
+		{Path: "body.assertion", Expected: jwtSecret, Actual: "x"},                   // value-shape backstop
+		{Path: "body.qty", Expected: "2", Actual: "5"},                               // benign -> must remain
+	}
+	redactFieldDiffs(diffs, nc)
+	if diffs[0].Expected != valueRedacted || diffs[0].Actual != valueRedacted {
+		t.Errorf("keyword path not redacted: %+v", diffs[0])
+	}
+	if diffs[1].Expected != valueRedacted || diffs[1].Actual != valueRedacted {
+		t.Errorf("noise value not redacted: %+v", diffs[1])
+	}
+	if diffs[2].Expected != valueRedacted {
+		t.Errorf("value-shape secret not redacted: %+v", diffs[2])
+	}
+	if diffs[3].Expected != "2" || diffs[3].Actual != "5" {
+		t.Errorf("benign qty diff should remain visible: %+v", diffs[3])
+	}
+}

--- a/pkg/agent/proxy/integrations/http/mismatch_report_test.go
+++ b/pkg/agent/proxy/integrations/http/mismatch_report_test.go
@@ -1,0 +1,138 @@
+package http
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// httpMockWithReq builds an HTTP mock with full request details for
+// field-diff assertions.
+func httpMockWithReq(name, method, rawURL, body string, header map[string]string, reqBodyNoise map[string][]string) *models.Mock {
+	return &models.Mock{
+		Name: name,
+		Kind: models.Kind(models.HTTP),
+		Spec: models.MockSpec{
+			HTTPReq: &models.HTTPReq{
+				Method:       models.Method(method),
+				URL:          rawURL,
+				Body:         body,
+				Header:       header,
+				ReqBodyNoise: reqBodyNoise,
+			},
+		},
+	}
+}
+
+func makeReqWithQuery(method, path, rawQuery string) *http.Request {
+	return &http.Request{
+		Method: method,
+		URL:    &url.URL{Path: path, RawQuery: rawQuery},
+		Header: http.Header{},
+	}
+}
+
+// A schema-match survivor should be preferred for the diff and its body/query
+// drift reported field-by-field with noise-vocabulary paths.
+func TestBuildHTTPMismatchReport_FieldDiffsAgainstSchemaSurvivor(t *testing.T) {
+	h := newHTTP()
+	mock := httpMockWithReq("mock-1", "POST", "http://localhost:8080/api/orders?page=1",
+		`{"order_id":"o-1","ts":"111"}`, map[string]string{"Content-Type": "application/json"}, nil)
+	db := &mockMemDb{mocks: []*models.Mock{mock}}
+
+	request := makeReqWithQuery("POST", "/api/orders", "page=2")
+	liveBody := []byte(`{"order_id":"o-2","ts":"111"}`)
+	diag := &matchDiag{phase: models.MatchPhaseBody, candidates: 1, schemaMatched: []*models.Mock{mock}}
+
+	report := h.buildHTTPMismatchReport(request, liveBody, db, nil, nil, nil, diag)
+	if report.ClosestMock != "mock-1" {
+		t.Fatalf("expected schema survivor as closest, got %q", report.ClosestMock)
+	}
+	if report.MatchPhase != models.MatchPhaseBody {
+		t.Errorf("expected phase %q, got %q", models.MatchPhaseBody, report.MatchPhase)
+	}
+
+	paths := map[string]models.MockFieldDiff{}
+	for _, d := range report.FieldDiffs {
+		paths[d.Path] = d
+	}
+	if d, ok := paths["body.order_id"]; !ok || d.Expected != "o-1" || d.Actual != "o-2" {
+		t.Errorf("expected body.order_id value diff, got %+v", report.FieldDiffs)
+	}
+	if d, ok := paths["query.page"]; !ok || d.Expected != "1" || d.Actual != "2" {
+		t.Errorf("expected query.page value diff, got %+v", report.FieldDiffs)
+	}
+	if _, ok := paths["body.ts"]; ok {
+		t.Errorf("unchanged body.ts must not be reported: %+v", report.FieldDiffs)
+	}
+}
+
+// Fields covered by learned req_body_noise or user body noise must not be
+// flagged in the report — the report should never tell the user to fix a
+// field the matcher already ignores.
+func TestBuildHTTPMismatchReport_RespectsLearnedAndUserNoise(t *testing.T) {
+	h := newHTTP()
+	mock := httpMockWithReq("mock-1", "POST", "http://localhost:8080/api/orders",
+		`{"request_id":"r-1","ts":"111","real":"x"}`, nil,
+		map[string][]string{"body.request_id": {}})
+	db := &mockMemDb{mocks: []*models.Mock{mock}}
+
+	request := makeReqWithQuery("POST", "/api/orders", "")
+	liveBody := []byte(`{"request_id":"r-2","ts":"222","real":"y"}`)
+	userBodyNoise := map[string][]string{"ts": {}}
+	diag := &matchDiag{phase: models.MatchPhaseStrict, candidates: 1, schemaMatched: []*models.Mock{mock}}
+
+	report := h.buildHTTPMismatchReport(request, liveBody, db, nil, nil, userBodyNoise, diag)
+	var gotPaths []string
+	for _, d := range report.FieldDiffs {
+		gotPaths = append(gotPaths, d.Path)
+	}
+	joined := strings.Join(gotPaths, ",")
+	if strings.Contains(joined, "request_id") {
+		t.Errorf("learned-noise field reported: %v", gotPaths)
+	}
+	if strings.Contains(joined, "body.ts") {
+		t.Errorf("user-noise field reported: %v", gotPaths)
+	}
+	if !strings.Contains(joined, "body.real") {
+		t.Errorf("genuinely drifted field body.real missing: %v", gotPaths)
+	}
+}
+
+// User-configured body noise must thread into detectReqBodyNoise so manual
+// noise config and learned noise share one vocabulary.
+func TestDetectReqBodyNoise_UserNoiseExcluded(t *testing.T) {
+	h := newHTTP()
+	mock := httpMockWithReq("mock-1", "POST", "http://x/y",
+		`{"ts":"111","real":"a"}`, map[string]string{"Content-Type": "application/json"}, nil)
+
+	got := h.detectReqBodyNoise(true, mock, []byte(`{"ts":"222","real":"b"}`), map[string][]string{"ts": {}})
+	if _, ok := got["body.ts"]; ok {
+		t.Errorf("user-noised field must not be re-learned as noise: %+v", got)
+	}
+	if _, ok := got["body.real"]; !ok {
+		t.Errorf("drifting non-noise field should be detected: %+v", got)
+	}
+}
+
+// Strict filtering must treat user-configured body noise as allowed drift.
+func TestFilterStrictNoiseMatches_UserNoiseAllowsDrift(t *testing.T) {
+	h := newHTTP()
+	// Mock carries learned noise (so strict applies) on another field.
+	mock := httpMockWithReq("mock-1", "POST", "http://x/y",
+		`{"request_id":"r-1","ts":"111"}`, map[string]string{"Content-Type": "application/json"},
+		map[string][]string{"body.request_id": {}})
+
+	// ts drifted; without user noise the candidate must be rejected.
+	live := []byte(`{"request_id":"r-9","ts":"222"}`)
+	if kept := h.filterStrictNoiseMatches([]*models.Mock{mock}, live, nil); len(kept) != 0 {
+		t.Fatalf("expected strict rejection without user noise, kept %d", len(kept))
+	}
+	// With user noise on ts the drift is allowed.
+	if kept := h.filterStrictNoiseMatches([]*models.Mock{mock}, live, map[string][]string{"ts": {}}); len(kept) != 1 {
+		t.Fatalf("expected candidate kept with user noise, kept %d", len(kept))
+	}
+}

--- a/pkg/agent/proxy/integrations/http/mismatch_report_test.go
+++ b/pkg/agent/proxy/integrations/http/mismatch_report_test.go
@@ -92,6 +92,13 @@ func TestBuildHTTPMismatchReport_RecordsDestination(t *testing.T) {
 	if got := h.buildHTTPMismatchReport(req, nil, db, nil, nil, nil, diag).Destination; got != "inventory.internal:9000" {
 		t.Fatalf("expected destination from URL authority fallback, got %q", got)
 	}
+
+	// A nil URL (hand-built request reaching the error path) must not panic; the
+	// destination still comes from the Host header.
+	nilURLReq := &http.Request{Method: "GET", Host: "api.example.com", Header: http.Header{}}
+	if got := h.buildHTTPMismatchReport(nilURLReq, nil, db, nil, nil, nil, diag).Destination; got != "api.example.com" {
+		t.Fatalf("nil-URL request: expected destination from Host, got %q", got)
+	}
 }
 
 // Fields covered by learned req_body_noise or user body noise must not be

--- a/pkg/agent/proxy/integrations/http/mismatch_report_test.go
+++ b/pkg/agent/proxy/integrations/http/mismatch_report_test.go
@@ -70,6 +70,30 @@ func TestBuildHTTPMismatchReport_FieldDiffsAgainstSchemaSurvivor(t *testing.T) {
 	}
 }
 
+// The report must record WHICH upstream the missed call targeted (Host first,
+// URL authority as fallback) so the log and report can disambiguate the same
+// method+path hitting different hosts.
+func TestBuildHTTPMismatchReport_RecordsDestination(t *testing.T) {
+	h := newHTTP()
+	mock := httpMockWithReq("mock-1", "GET", "http://localhost:8080/api/orders", "", nil, nil)
+	db := &mockMemDb{mocks: []*models.Mock{mock}}
+	diag := &matchDiag{phase: models.MatchPhaseBody, candidates: 1, schemaMatched: []*models.Mock{mock}}
+
+	// Host header wins.
+	req := makeReqWithQuery("GET", "/api/orders", "")
+	req.Host = "api.payments.svc:8443"
+	if got := h.buildHTTPMismatchReport(req, nil, db, nil, nil, nil, diag).Destination; got != "api.payments.svc:8443" {
+		t.Fatalf("expected destination from Host header, got %q", got)
+	}
+
+	// Falls back to the URL authority when Host is unset.
+	req = makeReqWithQuery("GET", "/api/orders", "")
+	req.URL.Host = "inventory.internal:9000"
+	if got := h.buildHTTPMismatchReport(req, nil, db, nil, nil, nil, diag).Destination; got != "inventory.internal:9000" {
+		t.Fatalf("expected destination from URL authority fallback, got %q", got)
+	}
+}
+
 // Fields covered by learned req_body_noise or user body noise must not be
 // flagged in the report — the report should never tell the user to fix a
 // field the matcher already ignores.

--- a/pkg/agent/proxy/integrations/http/reqbodynoise_test.go
+++ b/pkg/agent/proxy/integrations/http/reqbodynoise_test.go
@@ -36,21 +36,21 @@ func TestDetectReqBodyNoise(t *testing.T) {
 
 	t.Run("disabled returns nil", func(t *testing.T) {
 		mock := httpMockWithBody(`{"id":"a"}`, jsonHdr, nil)
-		if got := h.detectReqBodyNoise(false, mock, []byte(`{"id":"b"}`)); got != nil {
+		if got := h.detectReqBodyNoise(false, mock, []byte(`{"id":"b"}`), nil); got != nil {
 			t.Fatalf("expected nil when disabled, got %v", got)
 		}
 	})
 
 	t.Run("identical body returns nil", func(t *testing.T) {
 		mock := httpMockWithBody(`{"id":"a"}`, jsonHdr, nil)
-		if got := h.detectReqBodyNoise(true, mock, []byte(`{"id":"a"}`)); got != nil {
+		if got := h.detectReqBodyNoise(true, mock, []byte(`{"id":"a"}`), nil); got != nil {
 			t.Fatalf("expected nil for identical body, got %v", got)
 		}
 	})
 
 	t.Run("json value drift is flagged with body prefix", func(t *testing.T) {
 		mock := httpMockWithBody(`{"id":"a","name":"x"}`, jsonHdr, nil)
-		got := h.detectReqBodyNoise(true, mock, []byte(`{"id":"b","name":"x"}`))
+		got := h.detectReqBodyNoise(true, mock, []byte(`{"id":"b","name":"x"}`), nil)
 		want := []string{"body.id"}
 		if keys := sortedKeys(got); len(keys) != 1 || keys[0] != want[0] {
 			t.Fatalf("got %v, want %v", keys, want)
@@ -61,7 +61,7 @@ func TestDetectReqBodyNoise(t *testing.T) {
 		// Mock.Noise marks the redacted secret value; the recorded body holds
 		// the redacted placeholder while the replayed body holds the real one.
 		mock := httpMockWithBody(`{"id":"a","token":"****"}`, jsonHdr, []string{`^\*\*\*\*$`})
-		got := h.detectReqBodyNoise(true, mock, []byte(`{"id":"b","token":"realsecret"}`))
+		got := h.detectReqBodyNoise(true, mock, []byte(`{"id":"b","token":"realsecret"}`), nil)
 		keys := sortedKeys(got)
 		if len(keys) != 1 || keys[0] != "body.id" {
 			t.Fatalf("expected only body.id (token excluded as obfuscated), got %v", keys)
@@ -70,7 +70,7 @@ func TestDetectReqBodyNoise(t *testing.T) {
 
 	t.Run("form body drift is flagged", func(t *testing.T) {
 		mock := httpMockWithBody(`a=1&b=2`, formHdr, nil)
-		got := h.detectReqBodyNoise(true, mock, []byte(`a=1&b=99`))
+		got := h.detectReqBodyNoise(true, mock, []byte(`a=1&b=99`), nil)
 		keys := sortedKeys(got)
 		if len(keys) != 1 || keys[0] != "body.b" {
 			t.Fatalf("expected body.b, got %v", keys)
@@ -79,7 +79,7 @@ func TestDetectReqBodyNoise(t *testing.T) {
 
 	t.Run("non-json non-form returns nil", func(t *testing.T) {
 		mock := httpMockWithBody(`plain text body`, map[string]string{"Content-Type": "text/plain"}, nil)
-		if got := h.detectReqBodyNoise(true, mock, []byte(`different text`)); got != nil {
+		if got := h.detectReqBodyNoise(true, mock, []byte(`different text`), nil); got != nil {
 			t.Fatalf("expected nil for plain text, got %v", got)
 		}
 	})

--- a/pkg/agent/proxy/integrations/mismatch/mismatch.go
+++ b/pkg/agent/proxy/integrations/mismatch/mismatch.go
@@ -161,10 +161,22 @@ func defaultNextSteps(r *models.MockMismatchReport) string {
 		return "No recorded mocks exist for this protocol in the selected test set. Re-record the test set with 'keploy record'."
 	case onlyValueDrift:
 		paths := make([]string, 0, len(r.FieldDiffs))
+		// Body diffs are reported "body."-prefixed for readability, but HTTP
+		// request matching reads the request-body noise bucket with
+		// root-relative keys — so strip the prefix in the copy-paste hint to
+		// avoid pointing users at the response-noise (body) bucket, which the
+		// request matcher never consults.
+		bodyKeys := make([]string, 0, len(r.FieldDiffs))
 		for _, d := range r.FieldDiffs {
 			paths = append(paths, d.Path)
+			if k := strings.TrimPrefix(d.Path, "body."); k != d.Path {
+				bodyKeys = append(bodyKeys, k)
+			}
 		}
-		return fmt.Sprintf("Only values drifted (%s). If these are dynamic (timestamps, ids, tokens), add them as noise; otherwise re-record with 'keploy record'.", strings.Join(paths, ", "))
+		if len(bodyKeys) > 0 {
+			return fmt.Sprintf("Only values drifted (%s). If these are dynamic (timestamps, ids, tokens), add the request-body fields under test.globalNoise.requestbody with root-relative keys (e.g. requestbody: {%s: []}); otherwise re-record with 'keploy record'.", strings.Join(paths, ", "), strings.Join(bodyKeys, ": [], "))
+		}
+		return fmt.Sprintf("Only values drifted (%s). If these are dynamic (timestamps, ids, tokens), add them to the matching noise (test.globalNoise); otherwise re-record with 'keploy record'.", strings.Join(paths, ", "))
 	default:
 		return "Request structure changed since recording. Re-record the test set with 'keploy record', or refresh mappings with --update-test-mapping if mocks were edited."
 	}

--- a/pkg/agent/proxy/integrations/mismatch/mismatch.go
+++ b/pkg/agent/proxy/integrations/mismatch/mismatch.go
@@ -1,0 +1,263 @@
+// Package mismatch is the shared framework protocol parsers use to report a
+// mock miss. It guarantees a uniform vocabulary across protocols so the same
+// failure renders the same way in the CLI mismatch table, `keploy report`,
+// the test-report yaml (FailureInfo.UnmatchedCalls) and the platform UI.
+//
+// Field-diff paths use the SAME grammar as the noise configuration
+// ("body.<dotted.path>", "header.<name>", "query.<name>", "method", "path")
+// so a user can copy a reported path directly into test.globalNoise or a
+// testcase's spec.assertions.noise.
+//
+// A parser that detects a miss should:
+//
+//	report := mismatch.NewReport(mismatch.ProtocolHTTP, "GET /orders/42").
+//	    WithPhase(models.MatchPhaseExhausted, candidateCount).
+//	    WithClosest(closest.Name, fieldDiffs).
+//	    WithNextSteps("...").Build()
+//	errCh <- models.NewMockMismatchError(baseErr, report)
+//
+// proxy.go extracts the report from the error chain and the replayer attaches
+// it to the failing test's FailureInfo.UnmatchedCalls.
+package mismatch
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"go.keploy.io/server/v3/pkg/matcher"
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// Canonical protocol names. Parsers must use these so report consumers can
+// group and filter without normalizing strings.
+const (
+	ProtocolHTTP     = "HTTP"
+	ProtocolHTTP2    = "HTTP/2"
+	ProtocolGRPC     = "gRPC"
+	ProtocolMySQL    = "MySQL"
+	ProtocolPostgres = "PostgreSQL"
+	ProtocolMongo    = "MongoDB"
+	ProtocolRedis    = "Redis"
+	ProtocolGeneric  = "Generic"
+	ProtocolDNS      = "DNS"
+)
+
+// maxFieldDiffValueLen bounds recorded/live values embedded in reports so a
+// large payload can't bloat the report yaml or the CLI table.
+const maxFieldDiffValueLen = 256
+
+// maxFieldDiffs bounds how many per-field diffs a single report carries.
+const maxFieldDiffs = 25
+
+// Builder assembles a models.MockMismatchReport with consistent rendering.
+type Builder struct {
+	report models.MockMismatchReport
+}
+
+// NewReport starts a report for one missed call. actualSummary should be the
+// shortest string that identifies the live call ("POST /orders", "SELECT
+// (prepared stmt 12)", "find users").
+func NewReport(protocol, actualSummary string) *Builder {
+	return &Builder{report: models.MockMismatchReport{
+		Protocol:      protocol,
+		ActualSummary: actualSummary,
+	}}
+}
+
+// WithPhase records how far the match cascade got and how many candidate
+// mocks were considered. Use the models.MatchPhase* constants.
+func (b *Builder) WithPhase(phase string, candidateCount int) *Builder {
+	b.report.MatchPhase = phase
+	b.report.CandidateCount = candidateCount
+	return b
+}
+
+// WithClosest attaches the nearest candidate and its field-level diffs.
+func (b *Builder) WithClosest(mockName string, diffs []models.MockFieldDiff) *Builder {
+	b.report.ClosestMock = mockName
+	if len(diffs) > maxFieldDiffs {
+		diffs = diffs[:maxFieldDiffs]
+	}
+	b.report.FieldDiffs = diffs
+	return b
+}
+
+// WithDiff sets an explicit human-readable diff, overriding the rendered
+// FieldDiffs summary. Prefer WithClosest + field diffs; use this only for
+// protocols where field decomposition is impossible (e.g. opaque binary).
+func (b *Builder) WithDiff(diff string) *Builder {
+	b.report.Diff = diff
+	return b
+}
+
+// WithNextSteps sets the remediation hint shown to the user.
+func (b *Builder) WithNextSteps(steps string) *Builder {
+	b.report.NextSteps = steps
+	return b
+}
+
+// Build renders the Diff string from FieldDiffs (when not explicitly set)
+// and returns the finished report.
+func (b *Builder) Build() *models.MockMismatchReport {
+	r := b.report
+	if r.Diff == "" {
+		r.Diff = RenderFieldDiffs(r.FieldDiffs)
+	}
+	if r.NextSteps == "" {
+		r.NextSteps = defaultNextSteps(&r)
+	}
+	return &r
+}
+
+// RenderFieldDiffs renders field diffs as a compact single-string summary for
+// surfaces that can't show structured data (legacy table cells, logs).
+func RenderFieldDiffs(diffs []models.MockFieldDiff) string {
+	if len(diffs) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(diffs))
+	for _, d := range diffs {
+		switch d.Kind {
+		case models.DiffKindMissingInLive:
+			parts = append(parts, fmt.Sprintf("%s: recorded %q, absent in live call", d.Path, d.Expected))
+		case models.DiffKindMissingInMock:
+			parts = append(parts, fmt.Sprintf("%s: live %q, absent in recording", d.Path, d.Actual))
+		case models.DiffKindTypeChanged:
+			parts = append(parts, fmt.Sprintf("%s: type changed (recorded %s, live %s)", d.Path, d.Expected, d.Actual))
+		default:
+			parts = append(parts, fmt.Sprintf("%s: recorded %q, live %q", d.Path, d.Expected, d.Actual))
+		}
+	}
+	return strings.Join(parts, "; ")
+}
+
+// defaultNextSteps derives an actionable hint from the report shape. The
+// wording deliberately never references commands that don't exist; the two
+// real remedies are noise (for drifting values) and re-recording (for
+// structural change).
+func defaultNextSteps(r *models.MockMismatchReport) string {
+	onlyValueDrift := len(r.FieldDiffs) > 0
+	for _, d := range r.FieldDiffs {
+		if d.Kind != models.DiffKindValueChanged {
+			onlyValueDrift = false
+			break
+		}
+	}
+	switch {
+	case r.MatchPhase == models.MatchPhaseNoMocks:
+		return "No recorded mocks exist for this protocol in the selected test set. Re-record the test set with 'keploy record'."
+	case onlyValueDrift:
+		paths := make([]string, 0, len(r.FieldDiffs))
+		for _, d := range r.FieldDiffs {
+			paths = append(paths, d.Path)
+		}
+		return fmt.Sprintf("Only values drifted (%s). If these are dynamic (timestamps, ids, tokens), add them as noise; otherwise re-record with 'keploy record'.", strings.Join(paths, ", "))
+	default:
+		return "Request structure changed since recording. Re-record the test set with 'keploy record', or refresh mappings with --update-test-mapping if mocks were edited."
+	}
+}
+
+// JSONBodyDiffs computes field-level diffs between a recorded JSON body and
+// the live one, excluding paths in `ignore` (root-relative noise map, e.g.
+// learned req_body_noise plus user-configured body noise). Paths come back
+// prefixed with "body.".
+func JSONBodyDiffs(recordedBody, liveBody string, ignore map[string][]string) []models.MockFieldDiff {
+	return matcher.JSONFieldDiffs(recordedBody, liveBody, ignore, "body.", maxFieldDiffValueLen)
+}
+
+// HeaderKeyDiffs reports header keys present on one side and missing on the
+// other. Values are intentionally not compared — mock matching itself only
+// matches on header keys, so reporting value drift here would tell users to
+// fix something the matcher never looks at. Keys in `ignore` (lowercased,
+// e.g. the auto-noised flaky headers and user header noise) and keploy's own
+// headers are skipped.
+func HeaderKeyDiffs(recorded map[string]string, live map[string][]string, ignore map[string][]string) []models.MockFieldDiff {
+	skip := func(k string) bool {
+		lk := strings.ToLower(k)
+		if strings.HasPrefix(lk, "keploy") {
+			return true
+		}
+		if ignore != nil {
+			if _, ok := ignore[lk]; ok {
+				return true
+			}
+		}
+		return false
+	}
+
+	liveSet := make(map[string]struct{}, len(live))
+	for k := range live {
+		liveSet[strings.ToLower(k)] = struct{}{}
+	}
+	recordedSet := make(map[string]struct{}, len(recorded))
+	for k := range recorded {
+		recordedSet[strings.ToLower(k)] = struct{}{}
+	}
+
+	var out []models.MockFieldDiff
+	for k := range recorded {
+		if skip(k) {
+			continue
+		}
+		if _, ok := liveSet[strings.ToLower(k)]; !ok {
+			out = append(out, models.MockFieldDiff{
+				Path: "header." + k,
+				Kind: models.DiffKindMissingInLive,
+			})
+		}
+	}
+	for k := range live {
+		if skip(k) {
+			continue
+		}
+		if _, ok := recordedSet[strings.ToLower(k)]; !ok {
+			out = append(out, models.MockFieldDiff{
+				Path: "header." + k,
+				Kind: models.DiffKindMissingInMock,
+			})
+		}
+	}
+	sortDiffs(out)
+	return out
+}
+
+// QueryParamDiffs reports query parameters whose keys or values differ.
+// recorded/live map a key to its values (url.Values semantics).
+func QueryParamDiffs(recorded, live map[string][]string) []models.MockFieldDiff {
+	var out []models.MockFieldDiff
+	for k, rv := range recorded {
+		lv, ok := live[k]
+		if !ok {
+			out = append(out, models.MockFieldDiff{
+				Path:     "query." + k,
+				Kind:     models.DiffKindMissingInLive,
+				Expected: strings.Join(rv, ","),
+			})
+			continue
+		}
+		if strings.Join(rv, ",") != strings.Join(lv, ",") {
+			out = append(out, models.MockFieldDiff{
+				Path:     "query." + k,
+				Kind:     models.DiffKindValueChanged,
+				Expected: strings.Join(rv, ","),
+				Actual:   strings.Join(lv, ","),
+			})
+		}
+	}
+	for k, lv := range live {
+		if _, ok := recorded[k]; !ok {
+			out = append(out, models.MockFieldDiff{
+				Path:   "query." + k,
+				Kind:   models.DiffKindMissingInMock,
+				Actual: strings.Join(lv, ","),
+			})
+		}
+	}
+	sortDiffs(out)
+	return out
+}
+
+func sortDiffs(d []models.MockFieldDiff) {
+	sort.Slice(d, func(i, j int) bool { return d[i].Path < d[j].Path })
+}

--- a/pkg/agent/proxy/integrations/mismatch/mismatch.go
+++ b/pkg/agent/proxy/integrations/mismatch/mismatch.go
@@ -97,6 +97,18 @@ func (b *Builder) WithNextSteps(steps string) *Builder {
 	return b
 }
 
+// WithRenderedRequests attaches the FULL rendered requests for the CLI
+// side-by-side whole-mock diff: mockReq is the closest recorded mock's
+// request, receivedReq is the live request the app sent. Both must already be
+// human-rendered (one field per line, JSON pretty-printed, sensitive values
+// redacted) by the parser. FieldDiffs remain the machine-readable companion;
+// these drive the highlighted whole-request view.
+func (b *Builder) WithRenderedRequests(mockReq, receivedReq string) *Builder {
+	b.report.ClosestMockReq = mockReq
+	b.report.ReceivedReq = receivedReq
+	return b
+}
+
 // Build renders the Diff string from FieldDiffs (when not explicitly set)
 // and returns the finished report.
 func (b *Builder) Build() *models.MockMismatchReport {

--- a/pkg/agent/proxy/integrations/mismatch/mismatch.go
+++ b/pkg/agent/proxy/integrations/mismatch/mismatch.go
@@ -65,6 +65,15 @@ func NewReport(protocol, actualSummary string) *Builder {
 	}}
 }
 
+// WithDestination records the outgoing call's destination/domain (e.g. the
+// HTTP Host authority, or a "host:port") so the report and its log line say
+// WHICH upstream missed — method+path alone collide across hosts when an app
+// calls several services.
+func (b *Builder) WithDestination(dest string) *Builder {
+	b.report.Destination = dest
+	return b
+}
+
 // WithPhase records how far the match cascade got and how many candidate
 // mocks were considered. Use the models.MatchPhase* constants.
 func (b *Builder) WithPhase(phase string, candidateCount int) *Builder {

--- a/pkg/agent/proxy/integrations/mismatch/mismatch_test.go
+++ b/pkg/agent/proxy/integrations/mismatch/mismatch_test.go
@@ -28,8 +28,11 @@ func TestBuilder_RendersFieldDiffsAndDefaults(t *testing.T) {
 		t.Errorf("Diff should render field paths, got %q", report.Diff)
 	}
 	// Pure value drift → next steps must suggest noise, never a nonexistent command.
-	if !strings.Contains(report.NextSteps, "noise") {
-		t.Errorf("value-only drift should suggest noise, got %q", report.NextSteps)
+	// Pure request-body value drift must point users at the request-body noise
+	// bucket (test.globalNoise.requestbody, root-relative keys) — not the
+	// response "body" bucket the request matcher never consults.
+	if !strings.Contains(report.NextSteps, "requestbody") {
+		t.Errorf("value-only request-body drift should point at the requestbody noise bucket, got %q", report.NextSteps)
 	}
 	if strings.Contains(report.NextSteps, "keploy rerecord") {
 		t.Errorf("next steps must not reference the nonexistent 'keploy rerecord' command: %q", report.NextSteps)

--- a/pkg/agent/proxy/integrations/mismatch/mismatch_test.go
+++ b/pkg/agent/proxy/integrations/mismatch/mismatch_test.go
@@ -1,0 +1,147 @@
+package mismatch
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+func TestBuilder_RendersFieldDiffsAndDefaults(t *testing.T) {
+	report := NewReport(ProtocolHTTP, "POST /orders").
+		WithPhase(models.MatchPhaseExhausted, 3).
+		WithClosest("mock-7", []models.MockFieldDiff{
+			{Path: "body.created_at", Kind: models.DiffKindValueChanged, Expected: "2026-01-01", Actual: "2026-06-12"},
+		}).Build()
+
+	if report.Protocol != ProtocolHTTP || report.ActualSummary != "POST /orders" {
+		t.Fatalf("identity fields wrong: %+v", report)
+	}
+	if report.MatchPhase != models.MatchPhaseExhausted || report.CandidateCount != 3 {
+		t.Errorf("phase fields wrong: %+v", report)
+	}
+	if report.ClosestMock != "mock-7" {
+		t.Errorf("closest mock wrong: %q", report.ClosestMock)
+	}
+	if !strings.Contains(report.Diff, "body.created_at") {
+		t.Errorf("Diff should render field paths, got %q", report.Diff)
+	}
+	// Pure value drift → next steps must suggest noise, never a nonexistent command.
+	if !strings.Contains(report.NextSteps, "noise") {
+		t.Errorf("value-only drift should suggest noise, got %q", report.NextSteps)
+	}
+	if strings.Contains(report.NextSteps, "keploy rerecord") {
+		t.Errorf("next steps must not reference the nonexistent 'keploy rerecord' command: %q", report.NextSteps)
+	}
+}
+
+func TestBuilder_NoMocksPhase(t *testing.T) {
+	report := NewReport(ProtocolGeneric, "opaque exchange").
+		WithPhase(models.MatchPhaseNoMocks, 0).Build()
+	if !strings.Contains(report.NextSteps, "keploy record") {
+		t.Errorf("no-mocks phase should point at 'keploy record', got %q", report.NextSteps)
+	}
+}
+
+func TestBuilder_StructuralChangeNextSteps(t *testing.T) {
+	report := NewReport(ProtocolHTTP, "GET /a").
+		WithPhase(models.MatchPhaseSchema, 5).
+		WithClosest("mock-1", []models.MockFieldDiff{
+			{Path: "body.new_field", Kind: models.DiffKindMissingInMock, Actual: "1"},
+		}).Build()
+	if !strings.Contains(report.NextSteps, "keploy record") {
+		t.Errorf("structural change should suggest re-record, got %q", report.NextSteps)
+	}
+}
+
+func TestBuilder_FieldDiffCap(t *testing.T) {
+	diffs := make([]models.MockFieldDiff, maxFieldDiffs+10)
+	for i := range diffs {
+		diffs[i] = models.MockFieldDiff{Path: "body.x", Kind: models.DiffKindValueChanged}
+	}
+	report := NewReport(ProtocolHTTP, "GET /a").WithClosest("m", diffs).Build()
+	if len(report.FieldDiffs) != maxFieldDiffs {
+		t.Errorf("expected diff cap %d, got %d", maxFieldDiffs, len(report.FieldDiffs))
+	}
+}
+
+func TestJSONBodyDiffs_RespectsIgnoreAndReportsValues(t *testing.T) {
+	recorded := `{"id":"abc","ts":"111","nested":{"v":1}}`
+	live := `{"id":"abc","ts":"222","nested":{"v":2}}`
+
+	diffs := JSONBodyDiffs(recorded, live, map[string][]string{"ts": {}})
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff (ts ignored), got %d: %+v", len(diffs), diffs)
+	}
+	d := diffs[0]
+	if d.Path != "body.nested.v" || d.Kind != models.DiffKindValueChanged || d.Expected != "1" || d.Actual != "2" {
+		t.Errorf("unexpected diff: %+v", d)
+	}
+}
+
+func TestHeaderKeyDiffs_SkipsNoiseAndKeployHeaders(t *testing.T) {
+	recorded := map[string]string{
+		"Authorization":  "sig",      // in noise → skipped
+		"X-Custom":       "v",        // missing in live → reported
+		"Keploy-Test-Id": "test-1",   // keploy header → skipped
+		"Content-Type":   "app/json", // present both → not reported
+	}
+	live := http.Header{
+		"Content-Type": {"app/json"},
+		"X-New":        {"n"}, // missing in recording → reported
+	}
+	noise := map[string][]string{"authorization": {}}
+
+	diffs := HeaderKeyDiffs(recorded, live, noise)
+	got := map[string]models.MockFieldDiffKind{}
+	for _, d := range diffs {
+		got[d.Path] = d.Kind
+	}
+	if got["header.X-Custom"] != models.DiffKindMissingInLive {
+		t.Errorf("expected header.X-Custom missing_in_live, got %+v", diffs)
+	}
+	if got["header.X-New"] != models.DiffKindMissingInMock {
+		t.Errorf("expected header.X-New missing_in_mock, got %+v", diffs)
+	}
+	if _, ok := got["header.Authorization"]; ok {
+		t.Errorf("noised header must not be reported: %+v", diffs)
+	}
+	if _, ok := got["header.Keploy-Test-Id"]; ok {
+		t.Errorf("keploy header must not be reported: %+v", diffs)
+	}
+}
+
+func TestQueryParamDiffs(t *testing.T) {
+	recorded := map[string][]string{"page": {"1"}, "old": {"x"}}
+	live := map[string][]string{"page": {"2"}, "new": {"y"}}
+
+	diffs := QueryParamDiffs(recorded, live)
+	got := map[string]models.MockFieldDiff{}
+	for _, d := range diffs {
+		got[d.Path] = d
+	}
+	if d := got["query.page"]; d.Kind != models.DiffKindValueChanged || d.Expected != "1" || d.Actual != "2" {
+		t.Errorf("query.page diff wrong: %+v", d)
+	}
+	if d := got["query.old"]; d.Kind != models.DiffKindMissingInLive {
+		t.Errorf("query.old diff wrong: %+v", d)
+	}
+	if d := got["query.new"]; d.Kind != models.DiffKindMissingInMock {
+		t.Errorf("query.new diff wrong: %+v", d)
+	}
+}
+
+func TestRenderFieldDiffs_AllKinds(t *testing.T) {
+	out := RenderFieldDiffs([]models.MockFieldDiff{
+		{Path: "body.a", Kind: models.DiffKindValueChanged, Expected: "1", Actual: "2"},
+		{Path: "header.B", Kind: models.DiffKindMissingInLive, Expected: "x"},
+		{Path: "query.c", Kind: models.DiffKindMissingInMock, Actual: "y"},
+		{Path: "body.d", Kind: models.DiffKindTypeChanged, Expected: "string: s", Actual: "number: 1"},
+	})
+	for _, want := range []string{"body.a", "header.B", "query.c", "body.d", "absent in live", "absent in recording", "type changed"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered diff missing %q: %s", want, out)
+		}
+	}
+}

--- a/pkg/agent/proxy/integrations/mysql/replayer/query.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/query.go
@@ -137,7 +137,7 @@ func simulateCommandPhase(ctx context.Context, logger *zap.Logger, clientConn ne
 					zap.Int("commands_processed", commandCount),
 					zap.String("request_type", req.Header.Type),
 					zap.String("closest_mock", closestMockName))
-				baseErr := fmt.Errorf("error while simulating the command phase due to no matching mock found")
+				baseErr := fmt.Errorf("error while simulating the command phase: %w", models.ErrNoMockMatched)
 				return models.NewMockMismatchError(baseErr, report)
 			}
 

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -2802,9 +2802,12 @@ func (p *Proxy) GetMockErrors(_ context.Context) ([]models.UnmatchedCall, error)
 		}
 	} else {
 		// Rendezvous could not complete (errChannel full or the drain stalled
-		// past the deadline). Take what the window holds but DON'T close it, so
-		// a miss the goroutine is still routing isn't dropped; the next
-		// BeginTestErrorCapture carries any leftovers forward. Degenerate path.
+		// past the deadline). Take what the window holds now but DON'T close it,
+		// so a miss the goroutine is still routing isn't dropped from THIS fetch.
+		// Any straggler the drain files afterward is discarded by the next
+		// BeginTestErrorCapture (which resets a never-closed window) - preferring
+		// correct per-test attribution over keeping a possibly cross-test miss.
+		// Degenerate path.
 		if acc := p.activeTestErrors.Load(); acc != nil {
 			rawErrs = append(rawErrs, acc.drain()...)
 		}

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -2726,9 +2726,10 @@ func (p *Proxy) EndTestErrorCapture() []error {
 }
 
 // GetErrorChannel returns the error channel for external monitoring.
-// When StartErrorDrain is active, this channel is continuously drained by the
-// background goroutine. Direct consumers (monitorProxyErrors) will compete
-// for reads. Prefer using BeginTestErrorCapture/EndTestErrorCapture instead.
+// Once StartProxy has run, StartErrorDrain continuously drains this channel in a
+// background goroutine, so an external direct consumer would compete with the
+// drain for reads and is not supported. Per-test mock-not-found errors are
+// exposed via BeginTestErrorCapture/GetMockErrors instead.
 func (p *Proxy) GetErrorChannel() <-chan error {
 	return p.errChannel
 }

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -2705,14 +2705,14 @@ func (p *Proxy) StartErrorDrain(ctx context.Context) {
 func (p *Proxy) BeginTestErrorCapture() {
 	p.captureMu.Lock()
 	p.pendingMockErrors.drain()
-	fresh := &testErrorAccumulator{}
-	// If a prior window was left open (its GetMockErrors couldn't finish the
-	// rendezvous — channel full / stalled drain), carry its leftovers into this
-	// window instead of dropping them. Degenerate path; bounded.
-	if old := p.activeTestErrors.Swap(fresh); old != nil {
-		for _, e := range old.drain() {
-			fresh.addBounded(e, maxPendingMockErrors)
-		}
+	// Discard anything left in a prior window that was never closed — e.g. a
+	// GetMockErrors whose HTTP round-trip failed, so the replayer couldn't
+	// finalize it. Carrying those misses into THIS window would misattribute the
+	// previous test's failures to the current test; they belong to a test we can
+	// no longer report for, so drop them (same reasoning as the pre-window
+	// stragglers drained above).
+	if old := p.activeTestErrors.Swap(&testErrorAccumulator{}); old != nil {
+		old.drain()
 	}
 	p.captureMu.Unlock()
 }

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -131,6 +131,14 @@ type Proxy struct {
 	// errChannel from filling up with background noise (OTel, health checks).
 	activeTestErrors atomic.Pointer[testErrorAccumulator]
 	errDrainOnce     sync.Once
+	// pendingMockErrors retains mock-not-found errors that arrive while no
+	// test capture window is active (activeTestErrors is nil). Nothing
+	// currently calls BeginTestErrorCapture, so without this the continuous
+	// drain would discard every mock miss before GetMockErrors (called by the
+	// replayer after the test simulation) can read it. Only mock-not-found
+	// errors are retained here — background noise (OTel, health checks) still
+	// gets discarded, and the buffer is bounded so it can't grow unboundedly.
+	pendingMockErrors testErrorAccumulator
 	// session holds the single active session for this proxy.
 	// Previously this was a sync.Map keyed by appID (always 0), which is
 	// no longer needed since the proxy serves a single client-app.
@@ -2585,6 +2593,34 @@ func (a *testErrorAccumulator) drain() []error {
 	return e
 }
 
+// maxPendingMockErrors bounds the retained mock-not-found errors so a replay
+// session that never drains them can't grow memory unboundedly. The replayer
+// drains per failed test, so the buffer stays small in practice.
+const maxPendingMockErrors = 512
+
+// addBounded appends err unless the accumulator already holds max entries.
+// Returns false when the entry was dropped.
+func (a *testErrorAccumulator) addBounded(err error, max int) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if len(a.errs) >= max {
+		return false
+	}
+	a.errs = append(a.errs, err)
+	return true
+}
+
+// isMockNotFoundErr reports whether err is a parser mock-not-found error —
+// the only error class GetMockErrors surfaces to the replayer, and thus the
+// only class worth retaining in pendingMockErrors.
+func isMockNotFoundErr(err error) bool {
+	parserErr, ok := err.(models.ParserError)
+	if ok && parserErr.ParserErrorType == models.ErrMockNotFound {
+		return true
+	}
+	return errors.Is(err, models.ErrNoMockMatched)
+}
+
 // StartErrorDrain launches a background goroutine that continuously reads from
 // errChannel so it never fills up. Errors are routed to the activeTestErrors
 // accumulator when a test is running, and discarded otherwise.
@@ -2605,6 +2641,10 @@ func (p *Proxy) StartErrorDrain(ctx context.Context) {
 					}
 					if acc := p.activeTestErrors.Load(); acc != nil {
 						acc.add(err)
+					} else if isMockNotFoundErr(err) && p.pendingMockErrors.addBounded(err, maxPendingMockErrors) {
+						// Retained for the replayer's per-test GetMockErrors
+						// fetch — these carry the mismatch report shown to the
+						// user. Non-mock-miss noise still falls to discard below.
 					} else {
 						// Log only the first discard and then every 100th to reduce noise.
 						n := discarded.Add(1)
@@ -2645,11 +2685,14 @@ func (p *Proxy) GetErrorChannel() <-chan error {
 // When StartErrorDrain is active, it reads from the test accumulator instead
 // of the channel (which is drained by the background goroutine).
 func (p *Proxy) GetMockErrors(_ context.Context) ([]models.UnmatchedCall, error) {
-	var rawErrs []error
+	// Errors the drain goroutine retained outside an active capture window
+	// (the usual case today — nothing opens a window) come first, oldest
+	// first.
+	rawErrs := p.pendingMockErrors.drain()
 
 	// Prefer test accumulator if active (StartErrorDrain is running)
 	if acc := p.activeTestErrors.Load(); acc != nil {
-		rawErrs = acc.drain()
+		rawErrs = append(rawErrs, acc.drain()...)
 	} else {
 		// Fallback: drain from channel directly (legacy path)
 	drainLoop:
@@ -2679,6 +2722,8 @@ func (p *Proxy) GetMockErrors(_ context.Context) ([]models.UnmatchedCall, error)
 					MatchPhase:     parserErr.MismatchReport.MatchPhase,
 					CandidateCount: parserErr.MismatchReport.CandidateCount,
 					FieldDiffs:     parserErr.MismatchReport.FieldDiffs,
+					ClosestMockReq: parserErr.MismatchReport.ClosestMockReq,
+					ReceivedReq:    parserErr.MismatchReport.ReceivedReq,
 				})
 			} else if errors.Is(parserErr.Err, models.ErrNoMockMatched) {
 				// A genuine miss without a structured report must still reach

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -130,7 +130,12 @@ type Proxy struct {
 	// and discards errors when nil (no test running). This prevents the
 	// errChannel from filling up with background noise (OTel, health checks).
 	activeTestErrors atomic.Pointer[testErrorAccumulator]
-	errDrainOnce     sync.Once
+	// captureMu serializes the drain goroutine's routing decision (read
+	// activeTestErrors, then add) against BeginTestErrorCapture / GetMockErrors
+	// opening or closing the window. Without it, the goroutine could add a miss
+	// to an accumulator that GetMockErrors has just swapped away, losing it.
+	captureMu    sync.Mutex
+	errDrainOnce sync.Once
 	// pendingMockErrors retains mock-not-found errors that arrive while no
 	// test capture window is active (activeTestErrors is nil). Nothing
 	// currently calls BeginTestErrorCapture, so without this the continuous
@@ -2639,13 +2644,20 @@ func (p *Proxy) StartErrorDrain(ctx context.Context) {
 					if !ok {
 						return
 					}
-					if acc := p.activeTestErrors.Load(); acc != nil {
-						acc.add(err)
-					} else if isMockNotFoundErr(err) && p.pendingMockErrors.addBounded(err, maxPendingMockErrors) {
-						// Retained for the replayer's per-test GetMockErrors
-						// fetch — these carry the mismatch report shown to the
-						// user. Non-mock-miss noise still falls to discard below.
-					} else {
+					// Route under captureMu so the window can't be swapped
+					// between the Load and the add. The accumulator is bounded
+					// too, so even a window left open (e.g. an error path that
+					// skipped GetMockErrors) can't grow without limit.
+					p.captureMu.Lock()
+					acc := p.activeTestErrors.Load()
+					if acc != nil {
+						acc.addBounded(err, maxPendingMockErrors)
+						p.captureMu.Unlock()
+						continue
+					}
+					retained := isMockNotFoundErr(err) && p.pendingMockErrors.addBounded(err, maxPendingMockErrors)
+					p.captureMu.Unlock()
+					if !retained {
 						// Log only the first discard and then every 100th to reduce noise.
 						n := discarded.Add(1)
 						if n == 1 || n%100 == 0 {
@@ -2666,8 +2678,10 @@ func (p *Proxy) StartErrorDrain(ctx context.Context) {
 // background traffic) are discarded so they don't attach to this test.
 // GetMockErrors retrieves and the next BeginTestErrorCapture resets the window.
 func (p *Proxy) BeginTestErrorCapture() {
+	p.captureMu.Lock()
 	p.pendingMockErrors.drain()
 	p.activeTestErrors.Store(&testErrorAccumulator{})
+	p.captureMu.Unlock()
 }
 
 // EndTestErrorCapture stops collecting errors and returns all accumulated errors.
@@ -2690,6 +2704,12 @@ func (p *Proxy) GetErrorChannel() <-chan error {
 // When StartErrorDrain is active, it reads from the test accumulator instead
 // of the channel (which is drained by the background goroutine).
 func (p *Proxy) GetMockErrors(_ context.Context) ([]models.UnmatchedCall, error) {
+	// Everything below runs under captureMu so the drain goroutine can't add to
+	// the window between our sweep and the swap-close. The goroutine only holds
+	// captureMu briefly around its routing decision, never across a channel
+	// receive, so this can't deadlock.
+	p.captureMu.Lock()
+
 	// Pre-window stragglers (retained before the first capture window — e.g.
 	// startup traffic). Oldest first.
 	rawErrs := p.pendingMockErrors.drain()
@@ -2713,12 +2733,13 @@ drainLoop:
 		}
 	}
 
-	// Then the per-test accumulator (errors the drain goroutine already routed
-	// into the active window). Drained AFTER the sweep so an item the goroutine
-	// moved off errChannel concurrently is still captured here.
-	if acc := p.activeTestErrors.Load(); acc != nil {
+	// End the window: Swap to nil so the drain goroutine stops appending to
+	// this test's accumulator (otherwise the last test's window would stay
+	// installed and grow for the rest of the process), and take its errors.
+	if acc := p.activeTestErrors.Swap(nil); acc != nil {
 		rawErrs = append(rawErrs, acc.drain()...)
 	}
+	p.captureMu.Unlock()
 
 	var errs []models.UnmatchedCall
 	for _, err := range rawErrs {

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -125,10 +125,11 @@ type Proxy struct {
 	integrationsPriority []ParserPriority
 	errChannel           chan error
 
-	// activeTestErrors accumulates mock-not-found errors during active test execution.
-	// The continuous error drain goroutine routes errors here when non-nil,
-	// and discards errors when nil (no test running). This prevents the
-	// errChannel from filling up with background noise (OTel, health checks).
+	// activeTestErrors accumulates mock-not-found errors during active test
+	// execution. The continuous drain goroutine routes errors here when non-nil.
+	// When nil (no window), mock-not-found errors fall to pendingMockErrors and
+	// only non-mock noise (OTel, health checks) is discarded — keeping the
+	// errChannel drained either way.
 	activeTestErrors atomic.Pointer[testErrorAccumulator]
 	// captureMu serializes the drain goroutine's routing decision (read
 	// activeTestErrors, then add) against BeginTestErrorCapture / GetMockErrors
@@ -2603,9 +2604,10 @@ func (a *testErrorAccumulator) drain() []error {
 	return e
 }
 
-// maxPendingMockErrors bounds the retained mock-not-found errors so a replay
-// session that never drains them can't grow memory unboundedly. The replayer
-// drains per failed test, so the buffer stays small in practice.
+// maxPendingMockErrors bounds the retained mock-not-found errors (and the
+// per-test capture accumulator) so a replay session can't grow memory
+// unboundedly. The replayer drains after every test, so it stays small in
+// practice.
 const maxPendingMockErrors = 512
 
 // addBounded appends err unless the accumulator already holds max entries.
@@ -2633,7 +2635,8 @@ func isMockNotFoundErr(err error) bool {
 
 // StartErrorDrain launches a background goroutine that continuously reads from
 // errChannel so it never fills up. Errors are routed to the activeTestErrors
-// accumulator when a test is running, and discarded otherwise.
+// accumulator when a test window is open; otherwise mock-not-found errors are
+// retained in pendingMockErrors and only non-mock noise is discarded.
 // This prevents background services (OTel, health checks) from saturating the
 // 100-slot error channel and blocking test coordination.
 // flushMarker is a sentinel GetMockErrors pushes onto errChannel. Because the
@@ -2702,7 +2705,15 @@ func (p *Proxy) StartErrorDrain(ctx context.Context) {
 func (p *Proxy) BeginTestErrorCapture() {
 	p.captureMu.Lock()
 	p.pendingMockErrors.drain()
-	p.activeTestErrors.Store(&testErrorAccumulator{})
+	fresh := &testErrorAccumulator{}
+	// If a prior window was left open (its GetMockErrors couldn't finish the
+	// rendezvous — channel full / stalled drain), carry its leftovers into this
+	// window instead of dropping them. Degenerate path; bounded.
+	if old := p.activeTestErrors.Swap(fresh); old != nil {
+		for _, e := range old.drain() {
+			fresh.addBounded(e, maxPendingMockErrors)
+		}
+	}
 	p.captureMu.Unlock()
 }
 
@@ -2733,17 +2744,21 @@ func (p *Proxy) GetMockErrors(_ context.Context) ([]models.UnmatchedCall, error)
 	// strand an in-flight miss (the remaining race the previous fix left open).
 	// The app has already responded by now, so this test's pushes precede the
 	// marker. A bounded wait keeps a stalled drain from blocking replay.
-	if p.errDrainActive.Load() && p.errChannel != nil {
+	rendezvousOK := false
+	drainActive := p.errDrainActive.Load()
+	if drainActive && p.errChannel != nil {
 		marker := &flushMarker{done: make(chan struct{})}
 		select {
 		case p.errChannel <- marker:
 			select {
 			case <-marker.done:
+				rendezvousOK = true
 			case <-time.After(2 * time.Second):
+				// drain stalled — DON'T close the window below (see end).
 			}
 		default:
-			// errChannel full (drain is behind) — skip; the legacy sweep below
-			// still runs when the drain goroutine isn't the owner.
+			// errChannel full (drain is behind) — marker not enqueued; DON'T
+			// close the window below.
 		}
 	}
 
@@ -2757,7 +2772,7 @@ func (p *Proxy) GetMockErrors(_ context.Context) ([]models.UnmatchedCall, error)
 	// so sweep them here. With the drain goroutine active, the rendezvous above
 	// has already routed everything into the window, so sweeping is unnecessary
 	// and would only risk pulling a NEXT test's stray error into this one.
-	if !p.errDrainActive.Load() {
+	if !drainActive {
 	drainLoop:
 		for {
 			select {
@@ -2776,11 +2791,22 @@ func (p *Proxy) GetMockErrors(_ context.Context) ([]models.UnmatchedCall, error)
 		}
 	}
 
-	// End the window: Swap to nil so the drain goroutine stops appending to
-	// this test's accumulator (otherwise the last test's window would stay
-	// installed and grow for the rest of the process), and take its errors.
-	if acc := p.activeTestErrors.Swap(nil); acc != nil {
-		rawErrs = append(rawErrs, acc.drain()...)
+	if rendezvousOK || !drainActive {
+		// Safe to END the window: the rendezvous confirmed every received error
+		// is routed (or there's no drain goroutine). Swap to nil so the drain
+		// goroutine stops appending — otherwise the last test's window would
+		// stay installed and grow for the rest of the process.
+		if acc := p.activeTestErrors.Swap(nil); acc != nil {
+			rawErrs = append(rawErrs, acc.drain()...)
+		}
+	} else {
+		// Rendezvous could not complete (errChannel full or the drain stalled
+		// past the deadline). Take what the window holds but DON'T close it, so
+		// a miss the goroutine is still routing isn't dropped; the next
+		// BeginTestErrorCapture carries any leftovers forward. Degenerate path.
+		if acc := p.activeTestErrors.Load(); acc != nil {
+			rawErrs = append(rawErrs, acc.drain()...)
+		}
 	}
 	p.captureMu.Unlock()
 

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -2671,11 +2671,28 @@ func (p *Proxy) GetMockErrors(_ context.Context) ([]models.UnmatchedCall, error)
 		if parserErr, ok := err.(models.ParserError); ok && parserErr.ParserErrorType == models.ErrMockNotFound {
 			if parserErr.MismatchReport != nil {
 				errs = append(errs, models.UnmatchedCall{
-					Protocol:      parserErr.MismatchReport.Protocol,
-					ActualSummary: parserErr.MismatchReport.ActualSummary,
-					ClosestMock:   parserErr.MismatchReport.ClosestMock,
-					Diff:          parserErr.MismatchReport.Diff,
-					NextSteps:     parserErr.MismatchReport.NextSteps,
+					Protocol:       parserErr.MismatchReport.Protocol,
+					ActualSummary:  parserErr.MismatchReport.ActualSummary,
+					ClosestMock:    parserErr.MismatchReport.ClosestMock,
+					Diff:           parserErr.MismatchReport.Diff,
+					NextSteps:      parserErr.MismatchReport.NextSteps,
+					MatchPhase:     parserErr.MismatchReport.MatchPhase,
+					CandidateCount: parserErr.MismatchReport.CandidateCount,
+					FieldDiffs:     parserErr.MismatchReport.FieldDiffs,
+				})
+			} else {
+				// A miss without a structured report must still reach the
+				// user's report — silently dropping it here is how whole
+				// protocols' misses used to vanish from
+				// FailureInfo.UnmatchedCalls.
+				summary := ""
+				if parserErr.Err != nil {
+					summary = parserErr.Err.Error()
+				}
+				errs = append(errs, models.UnmatchedCall{
+					Protocol:      "unknown",
+					ActualSummary: summary,
+					NextSteps:     "This protocol's matcher does not emit structured mismatch reports yet; check the agent logs around this test for the mock-miss details.",
 				})
 			}
 		}

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -2680,18 +2680,18 @@ func (p *Proxy) GetMockErrors(_ context.Context) ([]models.UnmatchedCall, error)
 					CandidateCount: parserErr.MismatchReport.CandidateCount,
 					FieldDiffs:     parserErr.MismatchReport.FieldDiffs,
 				})
-			} else {
-				// A miss without a structured report must still reach the
-				// user's report — silently dropping it here is how whole
+			} else if errors.Is(parserErr.Err, models.ErrNoMockMatched) {
+				// A genuine miss without a structured report must still reach
+				// the user's report — silently dropping it here is how whole
 				// protocols' misses used to vanish from
-				// FailureInfo.UnmatchedCalls.
-				summary := ""
-				if parserErr.Err != nil {
-					summary = parserErr.Err.Error()
-				}
+				// FailureInfo.UnmatchedCalls. Errors that are NOT wrapped
+				// around models.ErrNoMockMatched are infrastructure/decode
+				// failures mislabeled by sendMockNotFoundError; reporting
+				// them as unmatched calls would misdirect the user, so they
+				// stay out of the report (they are already logged).
 				errs = append(errs, models.UnmatchedCall{
 					Protocol:      "unknown",
-					ActualSummary: summary,
+					ActualSummary: parserErr.Err.Error(),
 					NextSteps:     "This protocol's matcher does not emit structured mismatch reports yet; check the agent logs around this test for the mock-miss details.",
 				})
 			}

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -134,15 +134,20 @@ type Proxy struct {
 	// activeTestErrors, then add) against BeginTestErrorCapture / GetMockErrors
 	// opening or closing the window. Without it, the goroutine could add a miss
 	// to an accumulator that GetMockErrors has just swapped away, losing it.
-	captureMu    sync.Mutex
-	errDrainOnce sync.Once
-	// pendingMockErrors retains mock-not-found errors that arrive while no
-	// test capture window is active (activeTestErrors is nil). Nothing
-	// currently calls BeginTestErrorCapture, so without this the continuous
-	// drain would discard every mock miss before GetMockErrors (called by the
-	// replayer after the test simulation) can read it. Only mock-not-found
-	// errors are retained here — background noise (OTel, health checks) still
-	// gets discarded, and the buffer is bounded so it can't grow unboundedly.
+	captureMu sync.Mutex
+	// errDrainActive is true while the StartErrorDrain goroutine is running. It
+	// gates the GetMockErrors flush-marker rendezvous (which needs that single
+	// owner to consume the marker); when false we use the legacy direct sweep.
+	errDrainActive atomic.Bool
+	errDrainOnce   sync.Once
+	// pendingMockErrors retains mock-not-found errors that arrive while no test
+	// capture window is active (activeTestErrors is nil) — e.g. between tests,
+	// or when the replayer/agent predates the BeginTestErrorCapture wiring. The
+	// replayer normally opens a window per test (so misses route to
+	// activeTestErrors), but this remains the fallback so a miss is never
+	// silently dropped before GetMockErrors reads it. Only mock-not-found errors
+	// are retained (background noise — OTel, health checks — is still
+	// discarded), and the buffer is bounded so it can't grow unboundedly.
 	pendingMockErrors testErrorAccumulator
 	// session holds the single active session for this proxy.
 	// Previously this was a sync.Map keyed by appID (always 0), which is
@@ -2631,11 +2636,22 @@ func isMockNotFoundErr(err error) bool {
 // accumulator when a test is running, and discarded otherwise.
 // This prevents background services (OTel, health checks) from saturating the
 // 100-slot error channel and blocking test coordination.
+// flushMarker is a sentinel GetMockErrors pushes onto errChannel. Because the
+// single drain goroutine consumes errChannel in FIFO order, once it pulls the
+// marker every error queued before it has already been routed — so closing the
+// capture window at that point cannot strand a miss the goroutine had received
+// but not yet filed. The goroutine closes done to signal it reached the marker.
+type flushMarker struct{ done chan struct{} }
+
+func (*flushMarker) Error() string { return "keploy: capture flush marker" }
+
 func (p *Proxy) StartErrorDrain(ctx context.Context) {
 	p.errDrainOnce.Do(func() {
+		p.errDrainActive.Store(true)
 		var discarded atomic.Int64
 		go func() {
 			defer utils.Recover(p.logger)
+			defer p.errDrainActive.Store(false)
 			for {
 				select {
 				case <-ctx.Done():
@@ -2643,6 +2659,12 @@ func (p *Proxy) StartErrorDrain(ctx context.Context) {
 				case err, ok := <-p.errChannel:
 					if !ok {
 						return
+					}
+					// Flush-marker rendezvous: signal that we've reached it
+					// (all prior errors are already routed) and move on.
+					if m, isMarker := err.(*flushMarker); isMarker {
+						close(m.done)
+						continue
 					}
 					// Route under captureMu so the window can't be swapped
 					// between the Load and the add. The accumulator is bounded
@@ -2704,32 +2726,53 @@ func (p *Proxy) GetErrorChannel() <-chan error {
 // When StartErrorDrain is active, it reads from the test accumulator instead
 // of the channel (which is drained by the background goroutine).
 func (p *Proxy) GetMockErrors(_ context.Context) ([]models.UnmatchedCall, error) {
-	// Everything below runs under captureMu so the drain goroutine can't add to
-	// the window between our sweep and the swap-close. The goroutine only holds
-	// captureMu briefly around its routing decision, never across a channel
-	// receive, so this can't deadlock.
+	// Rendezvous with the drain goroutine BEFORE taking captureMu: push a flush
+	// marker and wait until the goroutine pulls it. FIFO ordering then
+	// guarantees every error the goroutine had already received from errChannel
+	// has been routed into the window — so closing the window below cannot
+	// strand an in-flight miss (the remaining race the previous fix left open).
+	// The app has already responded by now, so this test's pushes precede the
+	// marker. A bounded wait keeps a stalled drain from blocking replay.
+	if p.errDrainActive.Load() && p.errChannel != nil {
+		marker := &flushMarker{done: make(chan struct{})}
+		select {
+		case p.errChannel <- marker:
+			select {
+			case <-marker.done:
+			case <-time.After(2 * time.Second):
+			}
+		default:
+			// errChannel full (drain is behind) — skip; the legacy sweep below
+			// still runs when the drain goroutine isn't the owner.
+		}
+	}
+
 	p.captureMu.Lock()
 
 	// Pre-window stragglers (retained before the first capture window — e.g.
 	// startup traffic). Oldest first.
 	rawErrs := p.pendingMockErrors.drain()
 
-	// Sweep anything still buffered in errChannel that the async drain
-	// goroutine hasn't routed yet. By the time the replayer calls this the app
-	// has already responded, so this test's outgoing-call pushes have happened;
-	// sweeping synchronously here (instead of waiting on the goroutine) keeps a
-	// miss with THIS test rather than leaking it to whichever test drains next.
-	// Non-blocking. Runs in both modes (active window and legacy).
-drainLoop:
-	for {
-		select {
-		case err, ok := <-p.errChannel:
-			if !ok {
+	// Legacy path only (no drain goroutine): errors sit unrouted in errChannel,
+	// so sweep them here. With the drain goroutine active, the rendezvous above
+	// has already routed everything into the window, so sweeping is unnecessary
+	// and would only risk pulling a NEXT test's stray error into this one.
+	if !p.errDrainActive.Load() {
+	drainLoop:
+		for {
+			select {
+			case err, ok := <-p.errChannel:
+				if !ok {
+					break drainLoop
+				}
+				if m, isMarker := err.(*flushMarker); isMarker {
+					close(m.done)
+					continue
+				}
+				rawErrs = append(rawErrs, err)
+			default:
 				break drainLoop
 			}
-			rawErrs = append(rawErrs, err)
-		default:
-			break drainLoop
 		}
 	}
 

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -2876,6 +2876,23 @@ func (p *Proxy) sendMockNotFoundError(err error) {
 	if errors.As(err, &reporter) && reporter != nil {
 		proxyErr.MismatchReport = reporter.MismatchReport()
 	}
+	// Single, protocol-agnostic mock-mismatch log. EVERY parser's MockOutgoing
+	// miss funnels through here, so this one line covers HTTP, generic, MySQL,
+	// gRPC, etc. uniformly — it names WHICH upstream missed and how far matching
+	// got, instead of each parser logging it differently (or not at all). The
+	// per-parser decode loggers stay at Debug to avoid double-logging.
+	if r := proxyErr.MismatchReport; r != nil {
+		p.logger.Warn("mock mismatch: no matching mock for outgoing call",
+			zap.String("protocol", r.Protocol),
+			zap.String("destination", r.Destination),
+			zap.String("actual", r.ActualSummary),
+			zap.String("match_phase", r.MatchPhase),
+			zap.Int("candidates", r.CandidateCount),
+			zap.String("closest", r.ClosestMock),
+			zap.String("next_step", r.NextSteps))
+	} else {
+		p.logger.Warn("mock mismatch: no matching mock for outgoing call (no structured report)", zap.Error(err))
+	}
 	p.SendError(proxyErr)
 }
 

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -2659,9 +2659,14 @@ func (p *Proxy) StartErrorDrain(ctx context.Context) {
 	})
 }
 
-// BeginTestErrorCapture starts collecting errors for the current test case.
-// Call EndTestErrorCapture when the test finishes to retrieve collected errors.
+// BeginTestErrorCapture starts collecting mock-not-found errors for the current
+// test case into a fresh per-test accumulator, so the replayer's GetMockErrors
+// returns only THIS test's misses instead of draining a shared global queue.
+// Stale stragglers retained before any window (startup / between-test
+// background traffic) are discarded so they don't attach to this test.
+// GetMockErrors retrieves and the next BeginTestErrorCapture resets the window.
 func (p *Proxy) BeginTestErrorCapture() {
+	p.pendingMockErrors.drain()
 	p.activeTestErrors.Store(&testErrorAccumulator{})
 }
 
@@ -2685,28 +2690,34 @@ func (p *Proxy) GetErrorChannel() <-chan error {
 // When StartErrorDrain is active, it reads from the test accumulator instead
 // of the channel (which is drained by the background goroutine).
 func (p *Proxy) GetMockErrors(_ context.Context) ([]models.UnmatchedCall, error) {
-	// Errors the drain goroutine retained outside an active capture window
-	// (the usual case today — nothing opens a window) come first, oldest
-	// first.
+	// Pre-window stragglers (retained before the first capture window — e.g.
+	// startup traffic). Oldest first.
 	rawErrs := p.pendingMockErrors.drain()
 
-	// Prefer test accumulator if active (StartErrorDrain is running)
-	if acc := p.activeTestErrors.Load(); acc != nil {
-		rawErrs = append(rawErrs, acc.drain()...)
-	} else {
-		// Fallback: drain from channel directly (legacy path)
-	drainLoop:
-		for {
-			select {
-			case err, ok := <-p.errChannel:
-				if !ok {
-					break drainLoop
-				}
-				rawErrs = append(rawErrs, err)
-			default:
+	// Sweep anything still buffered in errChannel that the async drain
+	// goroutine hasn't routed yet. By the time the replayer calls this the app
+	// has already responded, so this test's outgoing-call pushes have happened;
+	// sweeping synchronously here (instead of waiting on the goroutine) keeps a
+	// miss with THIS test rather than leaking it to whichever test drains next.
+	// Non-blocking. Runs in both modes (active window and legacy).
+drainLoop:
+	for {
+		select {
+		case err, ok := <-p.errChannel:
+			if !ok {
 				break drainLoop
 			}
+			rawErrs = append(rawErrs, err)
+		default:
+			break drainLoop
 		}
+	}
+
+	// Then the per-test accumulator (errors the drain goroutine already routed
+	// into the active window). Drained AFTER the sweep so an item the goroutine
+	// moved off errChannel concurrently is still captured here.
+	if acc := p.activeTestErrors.Load(); acc != nil {
+		rawErrs = append(rawErrs, acc.drain()...)
 	}
 
 	var errs []models.UnmatchedCall

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -2821,6 +2821,7 @@ func (p *Proxy) GetMockErrors(_ context.Context) ([]models.UnmatchedCall, error)
 				errs = append(errs, models.UnmatchedCall{
 					Protocol:       parserErr.MismatchReport.Protocol,
 					ActualSummary:  parserErr.MismatchReport.ActualSummary,
+					Destination:    parserErr.MismatchReport.Destination,
 					ClosestMock:    parserErr.MismatchReport.ClosestMock,
 					Diff:           parserErr.MismatchReport.Diff,
 					NextSteps:      parserErr.MismatchReport.NextSteps,

--- a/pkg/agent/routes/record.go
+++ b/pkg/agent/routes/record.go
@@ -73,6 +73,7 @@ func (d DefaultRoutes) New(r chi.Router, agent agent.Service, logger *zap.Logger
 		// r.Post("/testbench", a.SendKtInfo)
 		r.Get("/consumedmocks", a.GetConsumedMocks)
 		r.Get("/mockerrors", a.GetMockErrors)
+		r.Post("/test-capture/begin", a.BeginTestErrorCapture)
 		r.Post("/agent/ready", a.MakeAgentReady)
 		r.Post("/graceful-shutdown", a.HandleGracefulShutdown)
 		// Long-lived streaming endpoints. /pcap/traffic emits a

--- a/pkg/agent/routes/replay.go
+++ b/pkg/agent/routes/replay.go
@@ -2,6 +2,7 @@
 package routes
 
 import (
+	"context"
 	"encoding/gob"
 	"encoding/json"
 	"net/http"
@@ -88,6 +89,24 @@ func (a *Agent) GetMockErrors(w http.ResponseWriter, r *http.Request) {
 
 	render.Status(r, http.StatusOK)
 	render.JSON(w, r, mockErrors)
+}
+
+// BeginTestErrorCapture opens a per-test mock-error capture window in the proxy
+// so the next GetMockErrors returns only this test's misses. Implemented via a
+// capability type-assertion so the agent.Service interface stays unchanged.
+func (a *Agent) BeginTestErrorCapture(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if b, ok := a.svc.(interface {
+		BeginTestErrorCapture(context.Context) error
+	}); ok {
+		if err := b.BeginTestErrorCapture(r.Context()); err != nil {
+			render.Status(r, http.StatusInternalServerError)
+			render.JSON(w, r, map[string]string{"error": err.Error()})
+			return
+		}
+	}
+	render.Status(r, http.StatusOK)
+	render.JSON(w, r, map[string]string{"status": "ok"})
 }
 
 func (a *Agent) StoreMocks(w http.ResponseWriter, r *http.Request) {

--- a/pkg/matcher/risk.go
+++ b/pkg/matcher/risk.go
@@ -168,6 +168,78 @@ func ChangedJSONFieldPaths(expJSON, actJSON string, known map[string][]string, e
 	return out
 }
 
+// JSONFieldDiffs returns field-level diffs between two JSON documents with
+// recorded/live values attached, for mock-mismatch reporting. It walks both
+// documents with the same traversal as ComputeFailureAssessmentJSON (arrays
+// normalize to a "[]" path suffix) and skips paths covered by `known` noise
+// (path -> regex list, root-relative). `pathPrefix` (e.g. "body.") is
+// prepended to every returned path so the result lines up with the noise
+// config vocabulary. Values are truncated to maxVal runes to keep reports
+// and yaml output bounded. Returns nil when either side isn't valid JSON.
+func JSONFieldDiffs(expJSON, actJSON string, known map[string][]string, pathPrefix string, maxVal int) []models.MockFieldDiff {
+	if !json.Valid([]byte(expJSON)) || !json.Valid([]byte(actJSON)) {
+		return nil
+	}
+
+	var exp, act interface{}
+	if err := json.Unmarshal([]byte(expJSON), &exp); err != nil {
+		return nil
+	}
+	if err := json.Unmarshal([]byte(actJSON), &act); err != nil {
+		return nil
+	}
+
+	idx := buildNoiseIndex(known)
+
+	expMaps := pathMaps{types: map[string]string{}, values: map[string]string{}}
+	actMaps := pathMaps{types: map[string]string{}, values: map[string]string{}}
+
+	collectJSON(exp, "", idx, &expMaps)
+	collectJSON(act, "", idx, &actMaps)
+
+	added, removed, typeChanges, valueChanges := diffMaps(expMaps, actMaps)
+
+	trunc := func(s string) string {
+		if maxVal > 0 && len(s) > maxVal {
+			return s[:maxVal] + "…"
+		}
+		return s
+	}
+
+	var out []models.MockFieldDiff
+	for _, p := range valueChanges {
+		out = append(out, models.MockFieldDiff{
+			Path:     pathPrefix + p,
+			Kind:     models.DiffKindValueChanged,
+			Expected: trunc(expMaps.values[p]),
+			Actual:   trunc(actMaps.values[p]),
+		})
+	}
+	for _, p := range typeChanges {
+		out = append(out, models.MockFieldDiff{
+			Path:     pathPrefix + p,
+			Kind:     models.DiffKindTypeChanged,
+			Expected: trunc(expMaps.types[p] + ": " + expMaps.values[p]),
+			Actual:   trunc(actMaps.types[p] + ": " + actMaps.values[p]),
+		})
+	}
+	for _, p := range removed {
+		out = append(out, models.MockFieldDiff{
+			Path:     pathPrefix + p,
+			Kind:     models.DiffKindMissingInLive,
+			Expected: trunc(expMaps.values[p]),
+		})
+	}
+	for _, p := range added {
+		out = append(out, models.MockFieldDiff{
+			Path:   pathPrefix + p,
+			Kind:   models.DiffKindMissingInMock,
+			Actual: trunc(actMaps.values[p]),
+		})
+	}
+	return out
+}
+
 func collectJSON(v interface{}, path string, ni noiseIndex, out *pathMaps) {
 	keyLower := strings.ToLower(path)
 	if regs, noisy := ni.match(keyLower); noisy && len(regs) == 0 {

--- a/pkg/matcher/risk.go
+++ b/pkg/matcher/risk.go
@@ -3,8 +3,10 @@ package matcher
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"go.keploy.io/server/v3/pkg/models"
 )
@@ -174,8 +176,9 @@ func ChangedJSONFieldPaths(expJSON, actJSON string, known map[string][]string, e
 // normalize to a "[]" path suffix) and skips paths covered by `known` noise
 // (path -> regex list, root-relative). `pathPrefix` (e.g. "body.") is
 // prepended to every returned path so the result lines up with the noise
-// config vocabulary. Values are truncated to maxVal runes to keep reports
-// and yaml output bounded. Returns nil when either side isn't valid JSON.
+// config vocabulary. Values are truncated to at most maxVal bytes (cut at a
+// rune boundary) to keep reports and yaml output bounded. Returns nil when
+// either side isn't valid JSON.
 func JSONFieldDiffs(expJSON, actJSON string, known map[string][]string, pathPrefix string, maxVal int) []models.MockFieldDiff {
 	if !json.Valid([]byte(expJSON)) || !json.Valid([]byte(actJSON)) {
 		return nil
@@ -199,11 +202,26 @@ func JSONFieldDiffs(expJSON, actJSON string, known map[string][]string, pathPref
 
 	added, removed, typeChanges, valueChanges := diffMaps(expMaps, actMaps)
 
+	// diffMaps iterates Go maps, so bucket order is randomized per run; sort
+	// each bucket so reports, yaml output and the capped diff subset are
+	// stable across runs.
+	sort.Strings(added)
+	sort.Strings(removed)
+	sort.Strings(typeChanges)
+	sort.Strings(valueChanges)
+
 	trunc := func(s string) string {
-		if maxVal > 0 && len(s) > maxVal {
-			return s[:maxVal] + "…"
+		if maxVal <= 0 || len(s) <= maxVal {
+			return s
 		}
-		return s
+		// Back the cut off to a rune boundary so a multi-byte UTF-8
+		// character is never split — invalid UTF-8 here would garble the
+		// report yaml/json encoders downstream.
+		cut := maxVal
+		for cut > 0 && !utf8.RuneStart(s[cut]) {
+			cut--
+		}
+		return s[:cut] + "…"
 	}
 
 	var out []models.MockFieldDiff

--- a/pkg/matcher/risk_fielddiffs_test.go
+++ b/pkg/matcher/risk_fielddiffs_test.go
@@ -1,0 +1,56 @@
+package matcher
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+func TestJSONFieldDiffs_KindsValuesAndNoise(t *testing.T) {
+	exp := `{"id":"a","ts":"1","gone":"g","typ":1,"same":"s"}`
+	act := `{"id":"b","ts":"2","typ":"now-string","same":"s","added":true}`
+
+	diffs := JSONFieldDiffs(exp, act, map[string][]string{"ts": {}}, "body.", 0)
+
+	got := map[string]models.MockFieldDiff{}
+	for _, d := range diffs {
+		got[d.Path] = d
+	}
+
+	if d := got["body.id"]; d.Kind != models.DiffKindValueChanged || d.Expected != "a" || d.Actual != "b" {
+		t.Errorf("body.id diff wrong: %+v", d)
+	}
+	if d := got["body.gone"]; d.Kind != models.DiffKindMissingInLive || d.Expected != "g" {
+		t.Errorf("body.gone diff wrong: %+v", d)
+	}
+	if d := got["body.typ"]; d.Kind != models.DiffKindTypeChanged {
+		t.Errorf("body.typ diff wrong: %+v", d)
+	}
+	if d := got["body.added"]; d.Kind != models.DiffKindMissingInMock || d.Actual != "true" {
+		t.Errorf("body.added diff wrong: %+v", d)
+	}
+	if _, ok := got["body.ts"]; ok {
+		t.Errorf("noised path body.ts must not be reported: %+v", diffs)
+	}
+	if _, ok := got["body.same"]; ok {
+		t.Errorf("unchanged path body.same must not be reported: %+v", diffs)
+	}
+}
+
+func TestJSONFieldDiffs_TruncatesValues(t *testing.T) {
+	exp := `{"v":"aaaaaaaaaaaaaaaaaaaa"}`
+	act := `{"v":"bbbbbbbbbbbbbbbbbbbb"}`
+	diffs := JSONFieldDiffs(exp, act, nil, "body.", 5)
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	if len(diffs[0].Expected) > 9 || len(diffs[0].Actual) > 9 { // 5 bytes + ellipsis rune
+		t.Errorf("values not truncated: %+v", diffs[0])
+	}
+}
+
+func TestJSONFieldDiffs_InvalidJSONReturnsNil(t *testing.T) {
+	if d := JSONFieldDiffs("not-json", `{"a":1}`, nil, "body.", 0); d != nil {
+		t.Errorf("expected nil for invalid JSON, got %+v", d)
+	}
+}

--- a/pkg/models/errors.go
+++ b/pkg/models/errors.go
@@ -1,6 +1,9 @@
 package models
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 type AppError struct {
 	AppErrorType AppErrorType
@@ -78,6 +81,12 @@ type MockMismatchReport struct {
 	CandidateCount int             // protocol mocks considered before giving up
 	FieldDiffs     []MockFieldDiff // field-level diffs vs the closest mock, noise-vocabulary paths
 }
+
+// ErrNoMockMatched is the sentinel for a genuine mock miss — an outgoing call
+// for which no recorded mock matched. Protocol parsers wrap it (errors.Is)
+// when they report a miss, so the proxy can distinguish real misses from
+// infrastructure/decode failures when building UnmatchedCalls for reports.
+var ErrNoMockMatched = errors.New("no matching mock found")
 
 type ParserError struct {
 	ParserErrorType ParserErrorType

--- a/pkg/models/errors.go
+++ b/pkg/models/errors.go
@@ -74,6 +74,7 @@ const (
 type MockMismatchReport struct {
 	Protocol       string          // "HTTP", "MySQL", "PostgreSQL", "MongoDB", "gRPC", "HTTP/2", "Generic", "DNS"
 	ActualSummary  string          // Brief description of the actual request
+	Destination    string          // outgoing call's destination/domain (HTTP Host, or host:port) — identifies WHICH upstream missed
 	ClosestMock    string          // Name of the closest mock (empty if none)
 	Diff           string          // Human-readable diff (protocol-specific)
 	NextSteps      string          // Actionable suggestion for the user

--- a/pkg/models/errors.go
+++ b/pkg/models/errors.go
@@ -80,6 +80,15 @@ type MockMismatchReport struct {
 	MatchPhase     string          // how far the match cascade got (MatchPhase* constants)
 	CandidateCount int             // protocol mocks considered before giving up
 	FieldDiffs     []MockFieldDiff // field-level diffs vs the closest mock, noise-vocabulary paths
+	// ClosestMockReq / ReceivedReq are the FULL rendered requests for the CLI
+	// side-by-side diff (left = recorded mock, right = live request). They are
+	// the human-facing complement to FieldDiffs (machine-readable): the
+	// renderer shows the whole mock with differing lines highlighted and falls
+	// back to the FieldDiffs table when these are empty (older agents /
+	// protocols that don't render whole requests). Sensitive/obfuscated values
+	// are redacted by the producing parser before they land here.
+	ClosestMockReq string // rendered request of the closest mock
+	ReceivedReq    string // rendered request the app actually sent
 }
 
 // ErrNoMockMatched is the sentinel for a genuine mock miss — an outgoing call

--- a/pkg/models/errors.go
+++ b/pkg/models/errors.go
@@ -27,15 +27,56 @@ const (
 	ErrTestBinStopped AppErrorType = "test binary stopped"
 )
 
+// MockFieldDiffKind classifies a single field-level divergence between a live
+// outgoing request and the closest recorded mock.
+type MockFieldDiffKind string
+
+const (
+	DiffKindValueChanged  MockFieldDiffKind = "value_changed"   // same field, different value
+	DiffKindTypeChanged   MockFieldDiffKind = "type_changed"    // same field, different JSON type
+	DiffKindMissingInLive MockFieldDiffKind = "missing_in_live" // recorded mock has it, live request doesn't
+	DiffKindMissingInMock MockFieldDiffKind = "missing_in_mock" // live request has it, recorded mock doesn't
+)
+
+// MockFieldDiff is one field-level difference between the live request and the
+// closest candidate mock. Path uses the same vocabulary as the noise
+// configuration (pkg/matcher): "body.<dotted.json.path>", "header.<name>",
+// "query.<name>", plus the pseudo-fields "method" and "path". This shared
+// grammar is deliberate: a user can copy Path straight into
+// test.globalNoise / spec.assertions.noise.
+type MockFieldDiff struct {
+	Path     string            `json:"path" yaml:"path"`
+	Kind     MockFieldDiffKind `json:"kind,omitempty" yaml:"kind,omitempty"`
+	Expected string            `json:"expected,omitempty" yaml:"expected,omitempty"` // recorded (mock) value
+	Actual   string            `json:"actual,omitempty" yaml:"actual,omitempty"`     // live request value
+}
+
+// Match-cascade phases recorded on MockMismatchReport.MatchPhase. They tell
+// the user how far the matcher got before giving up, which determines the
+// right remediation (re-record vs add noise vs fix candidate selection).
+const (
+	MatchPhaseNoMocks    = "no_mocks"             // mock pool for this protocol is empty
+	MatchPhaseSchema     = "no_schema_candidates" // nothing matched method/path/header-keys/query-keys
+	MatchPhaseBody       = "body_mismatch"        // schema candidates existed, request body ruled them all out
+	MatchPhaseStrict     = "strict_noise_reject"  // candidates rejected by strict req-body-noise enforcement
+	MatchPhaseExhausted  = "no_match"             // full cascade ran and nothing matched
+	MatchPhaseProtoError = "protocol_error"       // matching aborted on a protocol/decode error
+)
+
 // MockMismatchReport describes what didn't match when a mock lookup fails.
 // It is populated by protocol-specific matching logic and surfaced to the user
-// in the CLI mismatch table.
+// in the CLI mismatch table, the test-report yaml (FailureInfo.UnmatchedCalls)
+// and the platform/UI APIs. Protocol parsers should build it via
+// pkg/agent/proxy/integrations/mismatch so vocabulary stays uniform.
 type MockMismatchReport struct {
-	Protocol      string // "HTTP", "MySQL", "PostgreSQL", "MongoDB", "gRPC", "HTTP/2", "Generic", "DNS"
-	ActualSummary string // Brief description of the actual request
-	ClosestMock   string // Name of the closest mock (empty if none)
-	Diff          string // Human-readable diff (protocol-specific)
-	NextSteps     string // Actionable suggestion for the user
+	Protocol       string          // "HTTP", "MySQL", "PostgreSQL", "MongoDB", "gRPC", "HTTP/2", "Generic", "DNS"
+	ActualSummary  string          // Brief description of the actual request
+	ClosestMock    string          // Name of the closest mock (empty if none)
+	Diff           string          // Human-readable diff (protocol-specific)
+	NextSteps      string          // Actionable suggestion for the user
+	MatchPhase     string          // how far the match cascade got (MatchPhase* constants)
+	CandidateCount int             // protocol mocks considered before giving up
+	FieldDiffs     []MockFieldDiff // field-level diffs vs the closest mock, noise-vocabulary paths
 }
 
 type ParserError struct {

--- a/pkg/models/testrun.go
+++ b/pkg/models/testrun.go
@@ -132,6 +132,14 @@ type UnmatchedCall struct {
 	ClosestMock   string `json:"closest_mock,omitempty" yaml:"closest_mock,omitempty"`     // internal mock reference for View Closest
 	Diff          string `json:"diff,omitempty" yaml:"diff,omitempty"`
 	NextSteps     string `json:"next_steps,omitempty" yaml:"next_steps,omitempty"` // actionable remediation guidance from the matcher
+	// MatchPhase, CandidateCount and FieldDiffs mirror MockMismatchReport so
+	// report consumers (CLI `keploy report`, report yaml, platform UI) can
+	// render structured field-level drift instead of an opaque string. Paths
+	// in FieldDiffs use the noise-config vocabulary and can be copied
+	// verbatim into test.globalNoise / spec.assertions.noise.
+	MatchPhase     string          `json:"match_phase,omitempty" yaml:"match_phase,omitempty"`
+	CandidateCount int             `json:"candidate_count,omitempty" yaml:"candidate_count,omitempty"`
+	FieldDiffs     []MockFieldDiff `json:"field_diffs,omitempty" yaml:"field_diffs,omitempty"`
 }
 
 // MockSummaryFromSpec builds a protocol-generic summary string from a mock's spec.

--- a/pkg/models/testrun.go
+++ b/pkg/models/testrun.go
@@ -140,6 +140,10 @@ type UnmatchedCall struct {
 	MatchPhase     string          `json:"match_phase,omitempty" yaml:"match_phase,omitempty"`
 	CandidateCount int             `json:"candidate_count,omitempty" yaml:"candidate_count,omitempty"`
 	FieldDiffs     []MockFieldDiff `json:"field_diffs,omitempty" yaml:"field_diffs,omitempty"`
+	// ClosestMockReq / ReceivedReq carry the FULL rendered requests for the CLI
+	// side-by-side whole-mock diff (left = mock, right = live request).
+	ClosestMockReq string `json:"closest_mock_req,omitempty" yaml:"closest_mock_req,omitempty"`
+	ReceivedReq    string `json:"received_req,omitempty" yaml:"received_req,omitempty"`
 }
 
 // MockSummaryFromSpec builds a protocol-generic summary string from a mock's spec.

--- a/pkg/models/testrun.go
+++ b/pkg/models/testrun.go
@@ -129,6 +129,7 @@ type MatchedCall struct {
 type UnmatchedCall struct {
 	Protocol      string `json:"protocol" yaml:"protocol"`
 	ActualSummary string `json:"actual_summary,omitempty" yaml:"actual_summary,omitempty"` // e.g. "POST /comments"
+	Destination   string `json:"destination,omitempty" yaml:"destination,omitempty"`       // outgoing call's destination/domain (HTTP Host, or host:port) — which upstream missed
 	ClosestMock   string `json:"closest_mock,omitempty" yaml:"closest_mock,omitempty"`     // internal mock reference for View Closest
 	Diff          string `json:"diff,omitempty" yaml:"diff,omitempty"`
 	NextSteps     string `json:"next_steps,omitempty" yaml:"next_steps,omitempty"` // actionable remediation guidance from the matcher

--- a/pkg/platform/http/agent.go
+++ b/pkg/platform/http/agent.go
@@ -1458,6 +1458,37 @@ func (a *AgentClient) GetMockErrors(ctx context.Context) ([]models.UnmatchedCall
 	return mockErrors, nil
 }
 
+// BeginTestErrorCapture asks the agent to open a per-test mock-error capture
+// window so the next GetMockErrors returns only this test's misses. A missing
+// endpoint (older agent) returns 404 and is treated as a no-op, preserving the
+// legacy global-queue behaviour.
+func (a *AgentClient) BeginTestErrorCapture(ctx context.Context) error {
+	url := fmt.Sprintf("%s/test-capture/begin", a.conf.Agent.AgentURI)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %s", err.Error())
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := a.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to begin test error capture: %s", err.Error())
+	}
+	defer func() {
+		if closeErr := res.Body.Close(); closeErr != nil {
+			utils.LogError(a.logger, closeErr, "failed to close response body for begin-test-error-capture; safe to ignore once")
+		}
+	}()
+	if res.StatusCode == http.StatusNotFound {
+		return nil // older agent without the endpoint — fall back to legacy behaviour
+	}
+	if res.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(res.Body)
+		return fmt.Errorf("begin test error capture returned status %d: %s", res.StatusCode, string(body))
+	}
+	return nil
+}
+
 // NotifyGracefulShutdown sends a request to the agent to set the graceful shutdown flag.
 // This should be called before cancelling contexts during application shutdown.
 // When the flag is set, connection errors will be logged as debug instead of error.

--- a/pkg/platform/yaml/mockdb/db.go
+++ b/pkg/platform/yaml/mockdb/db.go
@@ -589,29 +589,43 @@ func (ys *MockYaml) updateMocksGob(ctx context.Context, testSetID, gobPath strin
 		}
 	}
 
-	// Atomic rewrite: write to a sibling tmp file under the same
-	// directory, then rename over gobPath. os.Rename on the same
-	// filesystem is atomic, so a concurrent reader either sees the
-	// full old file or the full new one.
-	//
-	// Preserve the existing file's permissions across the rewrite.
-	// os.CreateTemp creates its file 0600, so without the chmod below
-	// pruning would quietly narrow mocks.gob from whatever mode the
-	// record writer produced (typically 0644 via umask 0022) down to
-	// owner-only, which breaks replay for any other user/process on
-	// the box. Stat before CreateTemp: if the source file is gone,
-	// fall back to the same mode the gob writer uses when it opens
-	// mocks.gob fresh (0644) so we do not introduce a new
-	// mode-inheritance path.
+	if err := writeGobMocksAtomically(ctx, gobPath, newMocks); err != nil {
+		return err
+	}
+
+	ys.Logger.Debug("pruned mocks successfully (gob)",
+		zap.String("testSetID", testSetID),
+		zap.Int("total", len(mocks)),
+		zap.Int("kept", len(newMocks)),
+		zap.Int("pruned", prunedCount),
+		zap.Any("prunedMocks", prunedMocks),
+		zap.Bool("prunedMocksTruncated", prunedCount > len(prunedMocks)),
+		zap.Time("pruneBefore", pruneBefore))
+	return nil
+}
+
+// writeGobMocksAtomically rewrites gobPath with the given mocks via a
+// sibling tmp file + rename. os.Rename on the same filesystem is atomic, so
+// a concurrent reader either sees the full old file or the full new one.
+//
+// Preserve the existing file's permissions across the rewrite.
+// os.CreateTemp creates its file 0600, so without the chmod below the
+// rewrite would quietly narrow mocks.gob from whatever mode the record
+// writer produced (typically 0644 via umask 0022) down to owner-only, which
+// breaks replay for any other user/process on the box. Stat before
+// CreateTemp: if the source file is gone, fall back to the same mode the gob
+// writer uses when it opens mocks.gob fresh (0644) so we do not introduce a
+// new mode-inheritance path.
+func writeGobMocksAtomically(ctx context.Context, gobPath string, mocks []*models.Mock) error {
 	dir := filepath.Dir(gobPath)
 	base := filepath.Base(gobPath)
 	var originalMode os.FileMode = 0644
 	if info, statErr := os.Stat(gobPath); statErr == nil {
 		originalMode = info.Mode().Perm()
 	}
-	tmp, err := os.CreateTemp(dir, base+".prune.*.tmp")
+	tmp, err := os.CreateTemp(dir, base+".rewrite.*.tmp")
 	if err != nil {
-		return fmt.Errorf("create gob prune tmp: %w", err)
+		return fmt.Errorf("create gob rewrite tmp: %w", err)
 	}
 	tmpPath := tmp.Name()
 	cleanup := true
@@ -625,19 +639,19 @@ func (ys *MockYaml) updateMocksGob(ctx context.Context, testSetID, gobPath strin
 	// renamed file.
 	if err := os.Chmod(tmpPath, originalMode); err != nil {
 		_ = tmp.Close()
-		return fmt.Errorf("chmod gob prune tmp to %o: %w", originalMode, err)
+		return fmt.Errorf("chmod gob rewrite tmp to %o: %w", originalMode, err)
 	}
 
 	bw := bufio.NewWriterSize(tmp, 256*1024)
 	if _, err := bw.WriteString(gobMockMagic); err != nil {
 		_ = tmp.Close()
-		return fmt.Errorf("write gob magic to prune tmp: %w", err)
+		return fmt.Errorf("write gob magic to rewrite tmp: %w", err)
 	}
 	enc := gob.NewEncoder(bw)
-	for i, mock := range newMocks {
-		// Same cancellation cadence as the filter loop above — the
-		// encode pass is the expensive one (reflect-heavy) so an
-		// op at cancellation is worth the early exit cost.
+	for i, mock := range mocks {
+		// Check ctx every 1024 entries — the encode pass is the
+		// expensive one (reflect-heavy) so an op at cancellation is
+		// worth the early exit cost.
 		if i&0x3ff == 0 {
 			if err := ctx.Err(); err != nil {
 				_ = tmp.Close()
@@ -646,33 +660,157 @@ func (ys *MockYaml) updateMocksGob(ctx context.Context, testSetID, gobPath strin
 		}
 		if err := enc.Encode(mock); err != nil {
 			_ = tmp.Close()
-			return fmt.Errorf("encode mock during gob prune: %w", err)
+			return fmt.Errorf("encode mock during gob rewrite: %w", err)
 		}
 	}
 	if err := bw.Flush(); err != nil {
 		_ = tmp.Close()
-		return fmt.Errorf("flush gob prune tmp: %w", err)
+		return fmt.Errorf("flush gob rewrite tmp: %w", err)
 	}
 	if err := tmp.Sync(); err != nil {
 		_ = tmp.Close()
-		return fmt.Errorf("sync gob prune tmp: %w", err)
+		return fmt.Errorf("sync gob rewrite tmp: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("close gob prune tmp: %w", err)
+		return fmt.Errorf("close gob rewrite tmp: %w", err)
 	}
 	if err := os.Rename(tmpPath, gobPath); err != nil {
-		return fmt.Errorf("rename gob prune tmp over %s: %w", gobPath, err)
+		return fmt.Errorf("rename gob rewrite tmp over %s: %w", gobPath, err)
 	}
 	cleanup = false
+	return nil
+}
 
-	ys.Logger.Debug("pruned mocks successfully (gob)",
-		zap.String("testSetID", testSetID),
-		zap.Int("total", len(mocks)),
-		zap.Int("kept", len(newMocks)),
-		zap.Int("pruned", prunedCount),
-		zap.Any("prunedMocks", prunedMocks),
-		zap.Bool("prunedMocksTruncated", prunedCount > len(prunedMocks)),
-		zap.Time("pruneBefore", pruneBefore))
+// PersistMockNoise merges learned request-body noise (MockState.ReqBodyNoise,
+// detected under --schema-noise-detection) into the on-disk mocks WITHOUT
+// pruning anything. This is the persistence path when mock pruning
+// (--remove-unused-mocks) is not enabled — previously the learned noise rode
+// only inside UpdateMocks, so running detection without pruning silently
+// discarded everything that was learned at process exit.
+func (ys *MockYaml) PersistMockNoise(ctx context.Context, testSetID string, mockStates map[string]models.MockState) error {
+	// Only mocks that actually carry learned noise matter.
+	withNoise := make(map[string]map[string][]string)
+	for name, st := range mockStates {
+		if len(st.ReqBodyNoise) > 0 {
+			withNoise[name] = st.ReqBodyNoise
+		}
+	}
+	if len(withNoise) == 0 {
+		return nil
+	}
+
+	mockFileName := "mocks"
+	if ys.MockName != "" {
+		mockFileName = ys.MockName
+	}
+	path := filepath.Join(ys.MockPath, testSetID)
+	lock := getMockFileLock(mockFileLockKey(path, mockFileName, ys.Format))
+	lock.Lock()
+	defer lock.Unlock()
+
+	// merge applies the learned noise; returns true when any mock changed
+	// so unchanged files are never rewritten.
+	merge := func(mocks []*models.Mock) bool {
+		changed := false
+		for _, mock := range mocks {
+			noise, ok := withNoise[mock.Name]
+			if !ok || mock.Kind != models.Kind(models.HTTP) || mock.Spec.HTTPReq == nil {
+				continue
+			}
+			merged := mergeReqBodyNoise(mock.Spec.HTTPReq.ReqBodyNoise, noise)
+			if len(merged) != len(mock.Spec.HTTPReq.ReqBodyNoise) {
+				changed = true
+			}
+			mock.Spec.HTTPReq.ReqBodyNoise = merged
+		}
+		return changed
+	}
+
+	logPersisted := func(total int) {
+		ys.Logger.Info("persisted learned request-body noise onto mocks",
+			zap.String("testSetID", testSetID),
+			zap.Int("mocksWithLearnedNoise", len(withNoise)),
+			zap.Int("totalMocks", total))
+	}
+
+	gobPath := filepath.Join(path, mockFileName+".gob")
+	if _, err := os.Stat(gobPath); err == nil {
+		// Quiesce any in-flight async gob writer before the rewrite —
+		// same reasoning as updateMocksGob.
+		if err := ys.Close(); err != nil {
+			utils.LogError(ys.Logger, err, "failed to quiesce async gob writer before noise persistence", zap.String("path", gobPath))
+			return err
+		}
+		mocks, err := readGobMocks(gobPath)
+		if err != nil {
+			return err
+		}
+		if !merge(mocks) {
+			return nil
+		}
+		if err := writeGobMocksAtomically(ctx, gobPath, mocks); err != nil {
+			return err
+		}
+		logPersisted(len(mocks))
+		return nil
+	}
+
+	existsAny, detectedFormat, err := yaml.FileExistsAny(ctx, ys.Logger, path, mockFileName, ys.Format)
+	if err != nil {
+		return err
+	}
+	if !existsAny {
+		return nil
+	}
+
+	reader, err := yaml.NewMockReaderF(ctx, ys.Logger, path, mockFileName, detectedFormat)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	var mocks []*models.Mock
+	if reader.Format() == yaml.FormatJSON {
+		var jsonDocs []*yaml.NetworkTrafficDocJSON
+		for {
+			jd, err := reader.ReadNextDocJSON()
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			if err != nil {
+				return fmt.Errorf("failed to decode the file documents for noise persistence: %w", err)
+			}
+			jsonDocs = append(jsonDocs, jd)
+		}
+		mocks, err = DecodeMocksJSON(jsonDocs, ys.Logger)
+		if err != nil {
+			return err
+		}
+	} else {
+		var docs []*yaml.NetworkTrafficDoc
+		for {
+			doc, err := reader.ReadNextDoc()
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			if err != nil {
+				return fmt.Errorf("failed to decode the file documents for noise persistence: %w", err)
+			}
+			docs = append(docs, doc)
+		}
+		mocks, err = DecodeMocks(docs, ys.Logger)
+		if err != nil {
+			return err
+		}
+	}
+
+	if !merge(mocks) {
+		return nil
+	}
+	if err := ys.writeMocksAtomically(path, mockFileName, mocks, detectedFormat); err != nil {
+		return err
+	}
+	logPersisted(len(mocks))
 	return nil
 }
 

--- a/pkg/platform/yaml/mockdb/persist_noise_test.go
+++ b/pkg/platform/yaml/mockdb/persist_noise_test.go
@@ -1,0 +1,105 @@
+package mockdb
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+func noiseTestMock(body string) *models.Mock {
+	return &models.Mock{
+		Version: "api.keploy.io/v1beta1",
+		Kind:    models.HTTP,
+		Spec: models.MockSpec{
+			Metadata: map[string]string{"src": "noisetest"},
+			HTTPReq: &models.HTTPReq{
+				Method: "POST", URL: "http://x/y", ProtoMajor: 1, ProtoMinor: 1,
+				Header: map[string]string{"Content-Type": "application/json"},
+				Body:   body,
+			},
+			HTTPResp: &models.HTTPResp{StatusCode: 200, StatusMessage: "OK", Body: `{"ok":true}`},
+		},
+	}
+}
+
+// PersistMockNoise must write learned req_body_noise onto the on-disk mock
+// WITHOUT pruning the other mocks — that's the whole point: detection without
+// --remove-unused-mocks used to discard everything learned.
+func TestPersistMockNoise_WritesNoiseWithoutPruning(t *testing.T) {
+	dir := t.TempDir()
+	ys := New(zap.NewNop(), dir, "")
+	ctx := context.Background()
+	testSet := "test-set-1"
+
+	// Two mocks; only mock-0 learns noise. mock-1 must survive untouched.
+	if err := ys.InsertMock(ctx, noiseTestMock(`{"request_id":"r-1"}`), testSet); err != nil {
+		t.Fatal(err)
+	}
+	if err := ys.InsertMock(ctx, noiseTestMock(`{"other":"o"}`), testSet); err != nil {
+		t.Fatal(err)
+	}
+	if err := ys.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ys.PersistMockNoise(ctx, testSet, map[string]models.MockState{
+		"mock-0": {Name: "mock-0", ReqBodyNoise: map[string][]string{"body.request_id": {}}},
+		// A consumed mock with no learned noise must be a no-op entry.
+		"mock-1": {Name: "mock-1"},
+	})
+	if err != nil {
+		t.Fatalf("PersistMockNoise: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, testSet, "mocks.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "req_body_noise") || !strings.Contains(content, "body.request_id") {
+		t.Errorf("learned noise not persisted; file:\n%s", content)
+	}
+	// No pruning: both mocks still present.
+	if !strings.Contains(content, `"other"`) {
+		t.Errorf("unrelated mock was lost during noise persistence; file:\n%s", content)
+	}
+}
+
+// A state map with no learned noise must not rewrite the file at all.
+func TestPersistMockNoise_NoNoiseIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	ys := New(zap.NewNop(), dir, "")
+	ctx := context.Background()
+	testSet := "test-set-1"
+
+	if err := ys.InsertMock(ctx, noiseTestMock(`{"a":"b"}`), testSet); err != nil {
+		t.Fatal(err)
+	}
+	if err := ys.Close(); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, testSet, "mocks.yaml")
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ys.PersistMockNoise(ctx, testSet, map[string]models.MockState{
+		"mock-0": {Name: "mock-0"},
+	}); err != nil {
+		t.Fatalf("PersistMockNoise: %v", err)
+	}
+
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !after.ModTime().Equal(before.ModTime()) {
+		t.Errorf("file rewritten despite no learned noise")
+	}
+}

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -602,6 +602,20 @@ func (a *Agent) GetMockErrors(ctx context.Context) ([]models.UnmatchedCall, erro
 	return a.Proxy.GetMockErrors(ctx)
 }
 
+// BeginTestErrorCapture opens a per-test mock-error capture window so the
+// replayer's subsequent GetMockErrors returns only this test's misses instead
+// of draining a process-global queue. The replayer calls it before each test
+// (in-process here, over HTTP via the agent client). Safe no-op return.
+func (a *Agent) BeginTestErrorCapture(_ context.Context) error {
+	// a.Proxy is the agent.Proxy interface; reach the concrete capability via a
+	// type-assertion so the interface stays unchanged. Older proxies without it
+	// simply fall back to the legacy global queue.
+	if b, ok := a.Proxy.(interface{ BeginTestErrorCapture() }); ok {
+		b.BeginTestErrorCapture()
+	}
+	return nil
+}
+
 // StoreMocks stores the filtered and unfiltered mocks for a client ID.
 //
 // Unification (Phase 1): every mock is run through DeriveLifetime on

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -751,7 +751,11 @@ func (r *Replayer) Start(ctx context.Context) error {
 	if !abortTestRun {
 		r.printSummary(ctx, testRunResult)
 
-		if !testRunResult && len(r.mockMismatchFailures.GetFailures()) > 0 && !r.config.DisableMapping {
+		// Print the mismatch table whenever there ARE mock mismatches — not
+		// only when the run as a whole failed. A green run with mock misses
+		// (e.g. tests demoted to OBSOLETE, or a protocol whose misses can't
+		// fail a test) is exactly the case the user must not stay blind to.
+		if len(r.mockMismatchFailures.GetFailures()) > 0 && !r.config.DisableMapping {
 			failuresByTestSet := make(map[string]bool)
 			for _, failure := range r.mockMismatchFailures.GetFailures() {
 				failuresByTestSet[failure.TestSetID] = true
@@ -762,7 +766,15 @@ func (r *Replayer) Start(ctx context.Context) error {
 				testSetIDs = append(testSetIDs, testSetID)
 			}
 			testSets := strings.Join(testSetIDs, ", ")
-			r.logger.Info("Some testsets failed due to mock differences. Please kindly rerecord these testsets to update the mocks.", zap.String("command", fmt.Sprintf("keploy rerecord -c '%s' -t %s", r.config.Command, testSets)))
+			if testRunResult {
+				r.logger.Warn("Tests passed, but some outgoing calls did not match the recorded mocks.",
+					zap.String("test_sets", testSets),
+					zap.String("next_steps", "Review the mismatch summary below. Add drifting dynamic fields as noise (test.globalNoise), or re-record the test-set with 'keploy record' if the request structure changed."))
+			} else {
+				r.logger.Info("Some testsets failed due to mock differences.",
+					zap.String("test_sets", testSets),
+					zap.String("next_steps", "Add drifting dynamic fields as noise (test.globalNoise); if the request structure changed, re-record the test-set with 'keploy record', or refresh mappings with --update-test-mapping."))
+			}
 
 			r.mockMismatchFailures.PrintFailuresTable()
 		}
@@ -2563,6 +2575,24 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		err = r.mockDB.UpdateMocks(runTestSetCtx, testSetID, passingTotalConsumedMocks, pruneBefore, firstTestCaseTime)
 		if err != nil {
 			utils.LogError(r.logger, err, "failed to delete unused mocks")
+		}
+	} else if r.config.Test.SchemaNoiseDetection && r.instrument {
+		// --schema-noise-detection without --remove-unused-mocks: the learned
+		// req_body_noise used to ride only inside UpdateMocks (the pruning
+		// path), so detection alone learned noise and threw it away at exit.
+		// Persist it through the prune-free path instead. We persist noise
+		// from ALL consumed mocks (not just passing tests): the mock matched,
+		// so the request-side drift it learned is valid even when the test
+		// later failed on its response.
+		type mockNoisePersister interface {
+			PersistMockNoise(ctx context.Context, testSetID string, mockStates map[string]models.MockState) error
+		}
+		if p, ok := r.mockDB.(mockNoisePersister); ok {
+			if err := p.PersistMockNoise(runTestSetCtx, testSetID, totalConsumedMocks); err != nil {
+				utils.LogError(r.logger, err, "failed to persist learned request-body noise onto mocks")
+			}
+		} else {
+			r.logger.Debug("mockDB implementation does not support prune-free noise persistence; learned req_body_noise not persisted")
 		}
 	}
 

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -2007,19 +2007,33 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 						for _, f := range r.mockMismatchFailures.GetFailuresForTestCase(testSetID, testCase.Name) {
 							if f.MismatchReport != nil {
 								testCaseResult.FailureInfo.UnmatchedCalls = append(testCaseResult.FailureInfo.UnmatchedCalls, models.UnmatchedCall{
-									Protocol:      f.MismatchReport.Protocol,
-									ActualSummary: f.MismatchReport.ActualSummary,
-									ClosestMock:   f.MismatchReport.ClosestMock,
-									Diff:          f.MismatchReport.Diff,
-									NextSteps:     f.MismatchReport.NextSteps,
+									Protocol:       f.MismatchReport.Protocol,
+									ActualSummary:  f.MismatchReport.ActualSummary,
+									ClosestMock:    f.MismatchReport.ClosestMock,
+									Diff:           f.MismatchReport.Diff,
+									NextSteps:      f.MismatchReport.NextSteps,
+									MatchPhase:     f.MismatchReport.MatchPhase,
+									CandidateCount: f.MismatchReport.CandidateCount,
+									FieldDiffs:     f.MismatchReport.FieldDiffs,
+									ClosestMockReq: f.MismatchReport.ClosestMockReq,
+									ReceivedReq:    f.MismatchReport.ReceivedReq,
 								})
 							}
 						}
-						if !r.instrument {
-							if mockErrors, err := r.instrumentation.GetMockErrors(runTestSetCtx); err == nil {
-								for _, me := range mockErrors {
-									testCaseResult.FailureInfo.UnmatchedCalls = append(testCaseResult.FailureInfo.UnmatchedCalls, me)
-								}
+						// Fetch in EVERY mode, not just non-instrument. The
+						// live HTTP agent transport returns a nil
+						// GetErrorChannel, so the channel-fed store above stays
+						// empty in instrument mode (local `keploy test -c`) —
+						// GetMockErrors is the one source that works on all
+						// transports. Fetched calls are also pushed into
+						// mockMismatchFailures so the end-of-run MOCKS MISMATCH
+						// SUMMARY table shows them; the store was already read
+						// for THIS test above (filtered by test ID), so this
+						// cannot double-count.
+						if mockErrors, err := r.instrumentation.GetMockErrors(runTestSetCtx); err == nil {
+							for _, me := range mockErrors {
+								testCaseResult.FailureInfo.UnmatchedCalls = append(testCaseResult.FailureInfo.UnmatchedCalls, me)
+								r.mockMismatchFailures.AddUnmatchedCallForTest(testSetID, testCase.Name, me)
 							}
 						}
 					}

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -755,9 +755,25 @@ func (r *Replayer) Start(ctx context.Context) error {
 		// only when the run as a whole failed. A green run with mock misses
 		// (e.g. tests demoted to OBSOLETE, or a protocol whose misses can't
 		// fail a test) is exactly the case the user must not stay blind to.
-		if len(r.mockMismatchFailures.GetFailures()) > 0 && !r.config.DisableMapping {
+		//
+		// Exception on green runs: DNS misses are answered with a synthetic
+		// response by design (the app keeps working), so on a fully passing
+		// run they are routine, not actionable — without this filter every
+		// healthy run with app-startup DNS chatter would print the table.
+		mismatchRows := r.mockMismatchFailures.GetFailures()
+		if testRunResult {
+			actionable := make([]TestFailure, 0, len(mismatchRows))
+			for _, f := range mismatchRows {
+				if f.FailureReason == models.ErrMockNotFound && f.MismatchReport != nil && f.MismatchReport.Protocol == "DNS" {
+					continue
+				}
+				actionable = append(actionable, f)
+			}
+			mismatchRows = actionable
+		}
+		if len(mismatchRows) > 0 && !r.config.DisableMapping {
 			failuresByTestSet := make(map[string]bool)
-			for _, failure := range r.mockMismatchFailures.GetFailures() {
+			for _, failure := range mismatchRows {
 				failuresByTestSet[failure.TestSetID] = true
 			}
 

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1627,6 +1627,8 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			testCaseProxyErrCtx, testCaseProxyErrCancel := context.WithCancel(runTestSetCtx)
 			go r.monitorProxyErrors(testCaseProxyErrCtx, testSetID, testCase.Name)
 
+			r.beginTestErrorCapture(runTestSetCtx)
+
 			resp, loopErr := r.hookImpl.SimulateRequest(runTestSetCtx, testCase, testSetID)
 
 			// Stop monitoring for this specific test case
@@ -2161,6 +2163,8 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			// Proxy Monitor: Start a per-test proxy error monitor.
 			streamProxyErrCtx, streamProxyErrCancel := context.WithCancel(runTestSetCtx)
 			go r.monitorProxyErrors(streamProxyErrCtx, testSetID, tc.Name)
+
+			r.beginTestErrorCapture(runTestSetCtx)
 
 			// Execute: SimulateRequest returns once response headers arrive;
 			// for streaming cases the body reader is drained later by
@@ -3693,6 +3697,22 @@ func (r *Replayer) copyDirContents(src, dst string) error {
 		}
 	}
 	return nil
+}
+
+// beginTestErrorCapture opens a per-test mock-error capture window on the agent
+// (via an optional capability — older agents / non-agent instrumentations skip
+// it and fall back to the legacy global queue) so a mock miss during this test
+// attributes to THIS test instead of whichever test drains GetMockErrors next.
+// Called right before each SimulateRequest, on both the normal and streaming
+// paths. Best-effort: a failure only degrades to the old behaviour.
+func (r *Replayer) beginTestErrorCapture(ctx context.Context) {
+	if b, ok := r.instrumentation.(interface {
+		BeginTestErrorCapture(context.Context) error
+	}); ok {
+		if err := b.BeginTestErrorCapture(ctx); err != nil {
+			r.logger.Debug("failed to begin test error capture", zap.Error(err))
+		}
+	}
 }
 
 // monitorProxyErrors monitors the proxy error channel and logs errors

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1997,44 +1997,43 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 								}
 							}
 						}
-						// UnmatchedCalls comes from independent sources
-						// (mockMismatchFailures channel for in-process,
-						// GetMockErrors for remote/k8s-proxy) — neither
-						// depends on the consumed-mock list, so populate
-						// regardless of perTestConsumedKnown so failed/
-						// obsolete tests still surface their mock errors
-						// even when the consumed-mock fetch failed.
-						for _, f := range r.mockMismatchFailures.GetFailuresForTestCase(testSetID, testCase.Name) {
-							if f.MismatchReport != nil {
-								testCaseResult.FailureInfo.UnmatchedCalls = append(testCaseResult.FailureInfo.UnmatchedCalls, models.UnmatchedCall{
-									Protocol:       f.MismatchReport.Protocol,
-									ActualSummary:  f.MismatchReport.ActualSummary,
-									ClosestMock:    f.MismatchReport.ClosestMock,
-									Diff:           f.MismatchReport.Diff,
-									NextSteps:      f.MismatchReport.NextSteps,
-									MatchPhase:     f.MismatchReport.MatchPhase,
-									CandidateCount: f.MismatchReport.CandidateCount,
-									FieldDiffs:     f.MismatchReport.FieldDiffs,
-									ClosestMockReq: f.MismatchReport.ClosestMockReq,
-									ReceivedReq:    f.MismatchReport.ReceivedReq,
-								})
-							}
+					}
+					// UnmatchedCalls is fetched/drained for EVERY test, not just
+					// failed/obsolete ones. Two reasons: (1) a miss during an
+					// otherwise-passing test must still surface; (2) GetMockErrors
+					// drains a process-global queue, so fetching only on
+					// failed/obsolete tests would let a passing test's miss linger
+					// and be misattributed to the next failed test. Draining per
+					// test keeps each test's misses with that test. The channel
+					// source below is already test-tagged.
+					for _, f := range r.mockMismatchFailures.GetFailuresForTestCase(testSetID, testCase.Name) {
+						if f.MismatchReport != nil {
+							testCaseResult.FailureInfo.UnmatchedCalls = append(testCaseResult.FailureInfo.UnmatchedCalls, models.UnmatchedCall{
+								Protocol:       f.MismatchReport.Protocol,
+								ActualSummary:  f.MismatchReport.ActualSummary,
+								ClosestMock:    f.MismatchReport.ClosestMock,
+								Diff:           f.MismatchReport.Diff,
+								NextSteps:      f.MismatchReport.NextSteps,
+								MatchPhase:     f.MismatchReport.MatchPhase,
+								CandidateCount: f.MismatchReport.CandidateCount,
+								FieldDiffs:     f.MismatchReport.FieldDiffs,
+								ClosestMockReq: f.MismatchReport.ClosestMockReq,
+								ReceivedReq:    f.MismatchReport.ReceivedReq,
+							})
 						}
-						// Fetch in EVERY mode, not just non-instrument. The
-						// live HTTP agent transport returns a nil
-						// GetErrorChannel, so the channel-fed store above stays
-						// empty in instrument mode (local `keploy test -c`) —
-						// GetMockErrors is the one source that works on all
-						// transports. Fetched calls are also pushed into
-						// mockMismatchFailures so the end-of-run MOCKS MISMATCH
-						// SUMMARY table shows them; the store was already read
-						// for THIS test above (filtered by test ID), so this
-						// cannot double-count.
-						if mockErrors, err := r.instrumentation.GetMockErrors(runTestSetCtx); err == nil {
-							for _, me := range mockErrors {
-								testCaseResult.FailureInfo.UnmatchedCalls = append(testCaseResult.FailureInfo.UnmatchedCalls, me)
-								r.mockMismatchFailures.AddUnmatchedCallForTest(testSetID, testCase.Name, me)
-							}
+					}
+					// Fetch in EVERY mode, not just non-instrument. The live HTTP
+					// agent transport returns a nil GetErrorChannel, so the
+					// channel-fed store above stays empty in instrument mode
+					// (local `keploy test -c`) — GetMockErrors is the one source
+					// that works on all transports. Fetched calls are also pushed
+					// into mockMismatchFailures so the end-of-run mock mismatch
+					// report shows them; the store was already read for THIS test
+					// above (filtered by test ID), so this cannot double-count.
+					if mockErrors, err := r.instrumentation.GetMockErrors(runTestSetCtx); err == nil {
+						for _, me := range mockErrors {
+							testCaseResult.FailureInfo.UnmatchedCalls = append(testCaseResult.FailureInfo.UnmatchedCalls, me)
+							r.mockMismatchFailures.AddUnmatchedCallForTest(testSetID, testCase.Name, me)
 						}
 					}
 					// Build the {expected, actual} mock set for THIS test case.

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -2164,7 +2164,9 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			streamProxyErrCtx, streamProxyErrCancel := context.WithCancel(runTestSetCtx)
 			go r.monitorProxyErrors(streamProxyErrCtx, testSetID, tc.Name)
 
-			r.beginTestErrorCapture(runTestSetCtx)
+			// NOTE: no BeginTestErrorCapture here — the streaming (Phase 2) path
+			// doesn't fetch GetMockErrors, so opening a window would never be
+			// closed. Streaming mock-mismatch reporting is a separate follow-up.
 
 			// Execute: SimulateRequest returns once response headers arrive;
 			// for streaming cases the body reader is drained later by

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -785,11 +785,11 @@ func (r *Replayer) Start(ctx context.Context) error {
 			if testRunResult {
 				r.logger.Warn("Tests passed, but some outgoing calls did not match the recorded mocks.",
 					zap.String("test_sets", testSets),
-					zap.String("next_steps", "Review the mismatch summary below. Add drifting dynamic fields as noise (test.globalNoise), or re-record the test-set with 'keploy record' if the request structure changed."))
+					zap.String("next_step", "Review the mismatch summary below. Add drifting dynamic fields as noise (test.globalNoise), or re-record the test-set with 'keploy record' if the request structure changed."))
 			} else {
 				r.logger.Info("Some testsets failed due to mock differences.",
 					zap.String("test_sets", testSets),
-					zap.String("next_steps", "Add drifting dynamic fields as noise (test.globalNoise); if the request structure changed, re-record the test-set with 'keploy record', or refresh mappings with --update-test-mapping."))
+					zap.String("next_step", "Add drifting dynamic fields as noise (test.globalNoise); if the request structure changed, re-record the test-set with 'keploy record', or refresh mappings with --update-test-mapping."))
 			}
 
 			r.mockMismatchFailures.PrintFailuresTable()

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -2058,8 +2058,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 					if insErr := r.reportDB.InsertTestCaseResult(runTestSetCtx, testRunID, testSetID, failedResult); insErr != nil {
 						utils.LogError(r.logger, insErr, "failed to insert failed test case result for nil test case result")
 					}
-					currentFailures++
-					testSetStatus = models.TestSetStatusFailed
+					// Outcome was already counted at lines ~1850-1864; don't double-count here.
 					break
 				}
 			} else {
@@ -2072,8 +2071,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 				if insErr := r.reportDB.InsertTestCaseResult(runTestSetCtx, testRunID, testSetID, failedResult); insErr != nil {
 					utils.LogError(r.logger, insErr, "failed to insert failed test case result for nil comparison result")
 				}
-				currentFailures++
-				testSetStatus = models.TestSetStatusFailed
+				// Outcome was already counted at lines ~1850-1864; don't double-count here.
 				break
 			}
 
@@ -2317,6 +2315,21 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			}
 
 			testPass, testResult := r.CompareHTTPResp(tc, httpResp, testSetID, emitFailureLogs)
+			if testResult == nil {
+				// Matcher returned no result (e.g. an internal compare path returning
+				// (false, nil)). Handle it HERE, before the hadStreamingMismatch block
+				// below dereferences testResult.BodyResult. Finalize the window + persist
+				// a failed result so the miss surfaces and can't carry forward.
+				utils.LogError(r.logger, nil, "streaming test result is nil")
+				failedResult := r.CreateFailedTestResult(tc, testSetID, started, "internal error: streaming comparison returned no result")
+				r.attachMockErrors(runTestSetCtx, testSetID, tc.Name, failedResult)
+				failure++
+				testSetStatus = models.TestSetStatusFailed
+				if insErr := r.reportDB.InsertTestCaseResult(runTestSetCtx, testRunID, testSetID, failedResult); insErr != nil {
+					utils.LogError(r.logger, insErr, "failed to insert failed streaming test case result for nil result")
+				}
+				continue
+			}
 			// Override testPass if streaming comparison failed
 			// (HTTP matcher skips body comparison for non-JSON bodies by default)
 			if hadStreamingMismatch {
@@ -2441,17 +2454,9 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 					break
 				}
 			} else {
+				// Unreachable: a nil testResult is finalized right after CompareHTTPResp
+				// above (persists a failed result and continues). Defensive only.
 				utils.LogError(r.logger, nil, "streaming test result is nil")
-				// Finalize the window + persist a failed result (same rationale as
-				// the non-streaming nil-result branch) so a streaming miss surfaces
-				// and can't carry forward.
-				failedResult := r.CreateFailedTestResult(tc, testSetID, started, "internal error: streaming comparison returned no result")
-				r.attachMockErrors(runTestSetCtx, testSetID, tc.Name, failedResult)
-				if insErr := r.reportDB.InsertTestCaseResult(runTestSetCtx, testRunID, testSetID, failedResult); insErr != nil {
-					utils.LogError(r.logger, insErr, "failed to insert failed streaming test case result for nil result")
-				}
-				failure++
-				testSetStatus = models.TestSetStatusFailed
 				break
 			}
 		}
@@ -3712,9 +3717,9 @@ func (r *Replayer) copyDirContents(src, dst string) error {
 // (via an optional capability — older agents / non-agent instrumentations skip
 // it and fall back to the legacy global queue) so a mock miss during this test
 // attributes to THIS test instead of whichever test drains GetMockErrors next.
-// Called right before SimulateRequest on the normal (non-streaming) path; the
-// matching GetMockErrors closes the window. The streaming path does not call it
-// (Phase 2 never fetches GetMockErrors, so the window would never be closed).
+// Called right before SimulateRequest on BOTH the normal and streaming paths;
+// the matching attachMockErrors/GetMockErrors closes the window (the streaming
+// path closes it only after the stream body is fully consumed).
 // Best-effort: a failure only degrades to the old behaviour.
 func (r *Replayer) beginTestErrorCapture(ctx context.Context) {
 	if b, ok := r.instrumentation.(interface {

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -34,7 +34,6 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const UNKNOWN_TEST = "UNKNOWN_TEST"
 const applicationFailedToRunLogMessage = "application failed to run; check the application logs for details or verify the app command is correct"
 
 func shouldAbortTestRun(status models.TestSetStatus, cmdType utils.CmdType) bool {
@@ -1624,15 +1623,9 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 
 			started := time.Now().UTC()
 
-			testCaseProxyErrCtx, testCaseProxyErrCancel := context.WithCancel(runTestSetCtx)
-			go r.monitorProxyErrors(testCaseProxyErrCtx, testSetID, testCase.Name)
-
 			r.beginTestErrorCapture(runTestSetCtx)
 
 			resp, loopErr := r.hookImpl.SimulateRequest(runTestSetCtx, testCase, testSetID)
-
-			// Stop monitoring for this specific test case
-			testCaseProxyErrCancel()
 
 			if loopErr != nil {
 				utils.LogError(r.logger, loopErr, "failed to simulate request")
@@ -2006,38 +1999,16 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 							}
 						}
 					}
-					// UnmatchedCalls is fetched/drained for EVERY test, not just
-					// failed/obsolete ones. Two reasons: (1) a miss during an
-					// otherwise-passing test must still surface; (2) GetMockErrors
-					// drains a process-global queue, so fetching only on
-					// failed/obsolete tests would let a passing test's miss linger
-					// and be misattributed to the next failed test. Draining per
-					// test keeps each test's misses with that test. The channel
-					// source below is already test-tagged.
-					for _, f := range r.mockMismatchFailures.GetFailuresForTestCase(testSetID, testCase.Name) {
-						if f.MismatchReport != nil {
-							testCaseResult.FailureInfo.UnmatchedCalls = append(testCaseResult.FailureInfo.UnmatchedCalls, models.UnmatchedCall{
-								Protocol:       f.MismatchReport.Protocol,
-								ActualSummary:  f.MismatchReport.ActualSummary,
-								ClosestMock:    f.MismatchReport.ClosestMock,
-								Diff:           f.MismatchReport.Diff,
-								NextSteps:      f.MismatchReport.NextSteps,
-								MatchPhase:     f.MismatchReport.MatchPhase,
-								CandidateCount: f.MismatchReport.CandidateCount,
-								FieldDiffs:     f.MismatchReport.FieldDiffs,
-								ClosestMockReq: f.MismatchReport.ClosestMockReq,
-								ReceivedReq:    f.MismatchReport.ReceivedReq,
-							})
-						}
-					}
-					// Finalize the capture window for this test in EVERY mode.
-					// The live HTTP agent transport returns a nil
-					// GetErrorChannel, so the channel-fed store above stays empty
-					// in instrument mode (local `keploy test -c`) — GetMockErrors
-					// is the one source that works on all transports. Also closes
-					// the per-test window (see attachMockErrors); the channel
-					// store was already read for THIS test above (filtered by
-					// test ID), so this cannot double-count.
+					// UnmatchedCalls is finalized for EVERY test, not just
+					// failed/obsolete ones: (1) a miss during an otherwise-passing
+					// test must still surface; (2) the per-test capture window
+					// opened by beginTestErrorCapture must be drained-and-closed
+					// each iteration so a miss can't carry over to the next test.
+					// attachMockErrors (GetMockErrors -> result + summary store) is
+					// the single source of unmatched outgoing calls across all
+					// transports — native and k8s alike reach the agent over HTTP,
+					// so the agent's error channel is consumed only inside the
+					// agent's own drain goroutine, never by the replayer.
 					r.attachMockErrors(runTestSetCtx, testSetID, testCase.Name, testCaseResult)
 					// Build the {expected, actual} mock set for THIS test case.
 					// See buildExpectedMockInfos / buildActualMockInfos at the
@@ -2161,10 +2132,6 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 				break
 			}
 
-			// Proxy Monitor: Start a per-test proxy error monitor.
-			streamProxyErrCtx, streamProxyErrCancel := context.WithCancel(runTestSetCtx)
-			go r.monitorProxyErrors(streamProxyErrCtx, testSetID, tc.Name)
-
 			// NOTE: no BeginTestErrorCapture here — the streaming (Phase 2) path
 			// doesn't fetch GetMockErrors, so opening a window would never be
 			// closed. Streaming mock-mismatch reporting is a separate follow-up.
@@ -2175,9 +2142,6 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			// continue after this call returns.
 			started := time.Now().UTC()
 			resp, simErr := r.hookImpl.SimulateRequest(runTestSetCtx, tc, testSetID)
-
-			// Cleanup: Cancel the proxy error monitor immediately after simulation.
-			streamProxyErrCancel()
 
 			if simErr != nil {
 				utils.LogError(r.logger, simErr, "failed to simulate streaming request")
@@ -3735,53 +3699,6 @@ func (r *Replayer) attachMockErrors(ctx context.Context, testSetID, testCaseName
 			result.FailureInfo.UnmatchedCalls = append(result.FailureInfo.UnmatchedCalls, me)
 		}
 		r.mockMismatchFailures.AddUnmatchedCallForTest(testSetID, testCaseName, me)
-	}
-}
-
-// monitorProxyErrors monitors the proxy error channel and logs errors
-func (r *Replayer) monitorProxyErrors(ctx context.Context, testSetID string, testCaseID string) {
-	defer utils.Recover(r.logger)
-
-	errorChannel := r.instrumentation.GetErrorChannel()
-	if errorChannel == nil {
-		r.logger.Debug("Proxy error channel is nil, skipping error monitoring")
-		return
-	}
-
-	r.logger.Debug("Starting proxy error monitoring",
-		zap.String("testSetID", testSetID),
-		zap.String("testCaseID", testCaseID))
-
-	for {
-		select {
-		case <-ctx.Done():
-			r.logger.Debug("Stopping proxy error monitoring",
-				zap.String("testSetID", testSetID),
-				zap.String("testCaseID", testCaseID))
-			return
-		case proxyErr, ok := <-errorChannel:
-			if !ok {
-				r.logger.Debug("Proxy error channel closed",
-					zap.String("testSetID", testSetID),
-					zap.String("testCaseID", testCaseID))
-				return
-			}
-
-			// Determine effective test case ID
-			effectiveTestCaseID := testCaseID
-			if effectiveTestCaseID == "" {
-				effectiveTestCaseID = UNKNOWN_TEST
-			}
-
-			if parserErr, ok := proxyErr.(models.ParserError); ok {
-				// Handle typed ParserError
-				switch parserErr.ParserErrorType {
-				case models.ErrMockNotFound:
-					r.mockMismatchFailures.AddProxyErrorForTest(testSetID, effectiveTestCaseID, parserErr)
-				}
-			}
-
-		}
 	}
 }
 

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -2050,10 +2050,30 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 					finalTestCaseResults[testCase.Name] = testCaseResult
 				} else {
 					utils.LogError(r.logger, nil, "test case result is nil")
+					// Finalize the capture window and persist a failed result so a
+					// miss during this test attaches here instead of leaking into a
+					// later test (or vanishing) when we bail out on this internal error.
+					failedResult := r.CreateFailedTestResult(testCase, testSetID, started, "internal error: test case result is nil")
+					r.attachMockErrors(runTestSetCtx, testSetID, testCase.Name, failedResult)
+					if insErr := r.reportDB.InsertTestCaseResult(runTestSetCtx, testRunID, testSetID, failedResult); insErr != nil {
+						utils.LogError(r.logger, insErr, "failed to insert failed test case result for nil test case result")
+					}
+					currentFailures++
+					testSetStatus = models.TestSetStatusFailed
 					break
 				}
 			} else {
 				utils.LogError(r.logger, nil, "test result is nil")
+				// Matcher returned no result (e.g. a comparison path returning
+				// (false, nil)). Same as above: finalize the window + persist a
+				// failed result so the miss surfaces and can't carry forward.
+				failedResult := r.CreateFailedTestResult(testCase, testSetID, started, "internal error: comparison returned no result")
+				r.attachMockErrors(runTestSetCtx, testSetID, testCase.Name, failedResult)
+				if insErr := r.reportDB.InsertTestCaseResult(runTestSetCtx, testRunID, testSetID, failedResult); insErr != nil {
+					utils.LogError(r.logger, insErr, "failed to insert failed test case result for nil comparison result")
+				}
+				currentFailures++
+				testSetStatus = models.TestSetStatusFailed
 				break
 			}
 
@@ -2132,9 +2152,13 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 				break
 			}
 
-			// NOTE: no BeginTestErrorCapture here — the streaming (Phase 2) path
-			// doesn't fetch GetMockErrors, so opening a window would never be
-			// closed. Streaming mock-mismatch reporting is a separate follow-up.
+			// Open the per-test capture window before simulation. Unlike the
+			// non-streaming path we must NOT finalize it right after
+			// SimulateRequest (which returns at response headers) — outgoing mock
+			// calls keep happening while CompareHTTPStream consumes the stream
+			// body below. Every exit path therefore calls attachMockErrors only
+			// AFTER stream consumption has finished.
+			r.beginTestErrorCapture(runTestSetCtx)
 
 			// Execute: SimulateRequest returns once response headers arrive;
 			// for streaming cases the body reader is drained later by
@@ -2148,6 +2172,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 				failure++
 				testSetStatus = models.TestSetStatusFailed
 				testCaseResult := r.CreateFailedTestResult(tc, testSetID, started, simErr.Error())
+				r.attachMockErrors(runTestSetCtx, testSetID, tc.Name, testCaseResult)
 				loopErr = r.reportDB.InsertTestCaseResult(runTestSetCtx, testRunID, testSetID, testCaseResult)
 				if loopErr != nil {
 					utils.LogError(r.logger, loopErr, "failed to insert streaming test case result for simulation error")
@@ -2209,6 +2234,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 						failure++
 						testSetStatus = models.TestSetStatusFailed
 						testCaseResult := r.CreateFailedTestResult(tc, testSetID, started, streamErr.Error())
+						r.attachMockErrors(runTestSetCtx, testSetID, tc.Name, testCaseResult)
 						loopErr = r.reportDB.InsertTestCaseResult(runTestSetCtx, testRunID, testSetID, testCaseResult)
 						if loopErr != nil {
 							utils.LogError(r.logger, loopErr, "failed to save streaming test result")
@@ -2250,6 +2276,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 					failure++
 					testSetStatus = models.TestSetStatusFailed
 					testCaseResult := r.CreateFailedTestResult(tc, testSetID, started, errMsg)
+					r.attachMockErrors(runTestSetCtx, testSetID, tc.Name, testCaseResult)
 					loopErr = r.reportDB.InsertTestCaseResult(runTestSetCtx, testRunID, testSetID, testCaseResult)
 					if loopErr != nil {
 						utils.LogError(r.logger, loopErr, "failed to insert streaming test case result for type assertion error")
@@ -2403,6 +2430,11 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 					testCaseResult.FailureInfo.Category = testResult.FailureInfo.Category
 				}
 
+				// Finalize the capture window now - AFTER CompareHTTPStream and the
+				// post-stream consumed-mock drain above, so in-stream mock misses
+				// are included - and attach them to this result.
+				r.attachMockErrors(runTestSetCtx, testSetID, tc.Name, testCaseResult)
+
 				loopErr = r.reportDB.InsertTestCaseResult(runTestSetCtx, testRunID, testSetID, testCaseResult)
 				if loopErr != nil {
 					utils.LogError(r.logger, loopErr, "failed to save streaming test result")
@@ -2410,6 +2442,16 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 				}
 			} else {
 				utils.LogError(r.logger, nil, "streaming test result is nil")
+				// Finalize the window + persist a failed result (same rationale as
+				// the non-streaming nil-result branch) so a streaming miss surfaces
+				// and can't carry forward.
+				failedResult := r.CreateFailedTestResult(tc, testSetID, started, "internal error: streaming comparison returned no result")
+				r.attachMockErrors(runTestSetCtx, testSetID, tc.Name, failedResult)
+				if insErr := r.reportDB.InsertTestCaseResult(runTestSetCtx, testRunID, testSetID, failedResult); insErr != nil {
+					utils.LogError(r.logger, insErr, "failed to insert failed streaming test case result for nil result")
+				}
+				failure++
+				testSetStatus = models.TestSetStatusFailed
 				break
 			}
 		}
@@ -3692,6 +3734,15 @@ func (r *Replayer) beginTestErrorCapture(ctx context.Context) {
 func (r *Replayer) attachMockErrors(ctx context.Context, testSetID, testCaseName string, result *models.TestResult) {
 	mockErrors, err := r.instrumentation.GetMockErrors(ctx)
 	if err != nil {
+		// Don't swallow silently. This test's misses can't be attached, but the
+		// agent-side window is reset by the next BeginTestErrorCapture (which
+		// discards a never-closed window), so the failure can't bleed into the
+		// next test. Log it so a persistent transport problem is visible rather
+		// than reports vanishing without a trace.
+		r.logger.Debug("failed to fetch mock errors for test; skipping unmatched-call attachment",
+			zap.String("testSetID", testSetID),
+			zap.String("testCaseID", testCaseName),
+			zap.Error(err))
 		return
 	}
 	for _, me := range mockErrors {

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -3705,8 +3705,10 @@ func (r *Replayer) copyDirContents(src, dst string) error {
 // (via an optional capability — older agents / non-agent instrumentations skip
 // it and fall back to the legacy global queue) so a mock miss during this test
 // attributes to THIS test instead of whichever test drains GetMockErrors next.
-// Called right before each SimulateRequest, on both the normal and streaming
-// paths. Best-effort: a failure only degrades to the old behaviour.
+// Called right before SimulateRequest on the normal (non-streaming) path; the
+// matching GetMockErrors closes the window. The streaming path does not call it
+// (Phase 2 never fetches GetMockErrors, so the window would never be closed).
+// Best-effort: a failure only degrades to the old behaviour.
 func (r *Replayer) beginTestErrorCapture(ctx context.Context) {
 	if b, ok := r.instrumentation.(interface {
 		BeginTestErrorCapture(context.Context) error

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1029,9 +1029,21 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 	selectedTests := matcherUtils.ArrayToMap(r.config.Test.SelectedTests[testSetID])
 	// Map mock name to Kind for DNS filtering (mappings may have empty Kind)
 	mockKindByName := make(map[string]models.Kind)
+	// reusableMockNames marks mocks whose recorder-derived tier is reusable
+	// across tests (session / connection / config) or app-startup traffic —
+	// i.e. NOT per-test. They belong in the mapping (so the pool is complete)
+	// but are excluded from the per-test consumed-vs-expected assertion: only
+	// per-test mocks are deterministically attributed to a single test, so
+	// comparing reusable/startup mocks would falsely demote tests to OBSOLETE
+	// (the same reason DNS mocks are excluded). MockEntry carries no tier, so
+	// we derive it from the loaded mocks (which do, via TestModeInfo.Lifetime).
+	reusableMockNames := make(map[string]bool)
 	addKinds := func(mocks []*models.Mock) {
 		for _, m := range mocks {
 			mockKindByName[m.Name] = m.Kind
+			if isReusableTierMock(m) {
+				reusableMockNames[m.Name] = true
+			}
 		}
 	}
 
@@ -1692,6 +1704,13 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			expectedMocks, hasExpectedMocks := expectedTestMockMappings[testCase.Name]
 
 			// Compute non-DNS expected and consumed name slices once; reused for subset check and mismatch reporting.
+			// Only PER-TEST mocks participate in the consumed-vs-expected
+			// assertion. DNS (non-deterministic resolution order) and
+			// reusable/startup-tier mocks (session / connection / config,
+			// recorded once at app boot and shared across tests) stay in the
+			// mapping but are excluded here: they are not deterministically
+			// attributed to a single test's window, so including them would
+			// falsely demote tests to OBSOLETE.
 			filteredExpectedNames := make([]string, 0, len(expectedMocks))
 			for _, m := range expectedMocks {
 				isDNS := strings.EqualFold(m.Kind, string(models.DNS))
@@ -1700,28 +1719,31 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 						isDNS = true
 					}
 				}
-				if !isDNS {
-					filteredExpectedNames = append(filteredExpectedNames, m.Name)
+				if isDNS || reusableMockNames[m.Name] {
+					continue
 				}
+				filteredExpectedNames = append(filteredExpectedNames, m.Name)
 			}
 
 			filteredMockNames := make([]string, 0, len(consumedMocks))
 			for _, m := range consumedMocks {
-				if m.Kind != models.DNS {
-					filteredMockNames = append(filteredMockNames, m.Name)
+				if m.Kind == models.DNS || isReusableTierState(m) {
+					continue
 				}
+				filteredMockNames = append(filteredMockNames, m.Name)
 			}
 
 			mockSetMismatch := false
 			if r.instrument && useMappingBased && isMappingEnabled && hasExpectedMocks && instrumentConsumedFetchErr == nil {
-				// Filter out DNS mocks from comparison since DNS resolution
-				// order is non-deterministic. Also gate on a successful per-
-				// test GetConsumedMocks — when the fetch failed, consumedMocks
-				// was cleared to nil above, which would deterministically
-				// compute mockSetMismatch=true (empty subset of any non-empty
-				// expected set) and falsely mark the test OBSOLETE due to an
-				// unrelated transport error rather than a real mock-pool
-				// divergence.
+				// Compare only per-test mocks (DNS + reusable/startup tiers
+				// excluded above) since those are the only mocks
+				// deterministically tied to a single test. Also gate on a
+				// successful per-test GetConsumedMocks — when the fetch failed,
+				// consumedMocks was cleared to nil above, which would
+				// deterministically compute mockSetMismatch=true (empty subset
+				// of any non-empty expected set) and falsely mark the test
+				// OBSOLETE due to an unrelated transport error rather than a
+				// real mock-pool divergence.
 				mockSetMismatch = !isMockSubset(filteredMockNames, filteredExpectedNames)
 			}
 
@@ -3796,6 +3818,45 @@ func (r *Replayer) determineMockingStrategy(ctx context.Context, testSetID strin
 }
 
 // isMockSubset checks if all expected mocks are present in the actual mocks list
+// isReusableTierMock reports whether a loaded mock is a reusable, non-per-test
+// tier — session / connection / config — recorded once at app startup and
+// shared across every test rather than consumed by exactly one. Such mocks
+// belong in the per-test mapping (so the replay mock pool is complete) but
+// must be excluded from the per-test consumed-vs-expected assertion: they are
+// not deterministically attributed to a single test's window, so comparing
+// them would falsely demote tests to OBSOLETE. Only per-test mocks are
+// compared. Tier is read from TestModeInfo.Lifetime (derived at ingest) with
+// Spec.Metadata["type"] as a fallback for mocks whose lifetime wasn't derived.
+func isReusableTierMock(m *models.Mock) bool {
+	switch m.TestModeInfo.Lifetime {
+	case models.LifetimeSession, models.LifetimeConnection:
+		return true
+	}
+	if m.Spec.Metadata != nil {
+		switch m.Spec.Metadata["type"] {
+		case "config", "connection":
+			return true
+		}
+	}
+	return false
+}
+
+// isReusableTierState is the MockState (consumed-mock) equivalent of
+// isReusableTierMock. GetConsumedMocks carries the recorder-derived Lifetime
+// and metadata type, so session/connection/config mocks are carved out of the
+// consumed side of the assertion the same way they are on the expected side.
+func isReusableTierState(s models.MockState) bool {
+	switch s.Lifetime {
+	case models.LifetimeSession, models.LifetimeConnection:
+		return true
+	}
+	switch s.Type {
+	case "config", "connection":
+		return true
+	}
+	return false
+}
+
 func isMockSubset(actual []string, expected []string) bool {
 	actualMap := make(map[string]bool)
 	for _, mock := range actual {

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1639,6 +1639,10 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 				currentFailures++
 				testSetStatus = models.TestSetStatusFailed
 				testCaseResult := r.CreateFailedTestResult(testCase, testSetID, started, loopErr.Error())
+				// Finalize the capture window even on this early exit, so a miss
+				// during this (failed) test attaches here and isn't carried to
+				// the next test or lost.
+				r.attachMockErrors(runTestSetCtx, testSetID, testCase.Name, testCaseResult)
 				loopErr = r.reportDB.InsertTestCaseResult(runTestSetCtx, testRunID, testSetID, testCaseResult)
 				if loopErr != nil {
 					utils.LogError(r.logger, loopErr, "failed to insert test case result for simulation error")
@@ -1738,6 +1742,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 					currentFailures++
 					testSetStatus = models.TestSetStatusFailed
 					testCaseResult := r.CreateFailedTestResult(testCase, testSetID, started, "invalid response type for HTTP test case")
+					r.attachMockErrors(runTestSetCtx, testSetID, testCase.Name, testCaseResult)
 					loopErr = r.reportDB.InsertTestCaseResult(runTestSetCtx, testRunID, testSetID, testCaseResult)
 					if loopErr != nil {
 						utils.LogError(r.logger, loopErr, fmt.Sprintf("failed to insert test case result for type assertion error in %s test case", testCase.Kind))
@@ -1754,6 +1759,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 					currentFailures++
 					testSetStatus = models.TestSetStatusFailed
 					testCaseResult := r.CreateFailedTestResult(testCase, testSetID, started, "invalid response type for gRPC test case")
+					r.attachMockErrors(runTestSetCtx, testSetID, testCase.Name, testCaseResult)
 					loopErr = r.reportDB.InsertTestCaseResult(runTestSetCtx, testRunID, testSetID, testCaseResult)
 					if loopErr != nil {
 						utils.LogError(r.logger, loopErr, "failed to insert test case result for type assertion error")
@@ -2024,20 +2030,15 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 							})
 						}
 					}
-					// Fetch in EVERY mode, not just non-instrument. The live HTTP
-					// agent transport returns a nil GetErrorChannel, so the
-					// channel-fed store above stays empty in instrument mode
-					// (local `keploy test -c`) — GetMockErrors is the one source
-					// that works on all transports. Fetched calls are also pushed
-					// into mockMismatchFailures so the end-of-run mock mismatch
-					// report shows them; the store was already read for THIS test
-					// above (filtered by test ID), so this cannot double-count.
-					if mockErrors, err := r.instrumentation.GetMockErrors(runTestSetCtx); err == nil {
-						for _, me := range mockErrors {
-							testCaseResult.FailureInfo.UnmatchedCalls = append(testCaseResult.FailureInfo.UnmatchedCalls, me)
-							r.mockMismatchFailures.AddUnmatchedCallForTest(testSetID, testCase.Name, me)
-						}
-					}
+					// Finalize the capture window for this test in EVERY mode.
+					// The live HTTP agent transport returns a nil
+					// GetErrorChannel, so the channel-fed store above stays empty
+					// in instrument mode (local `keploy test -c`) — GetMockErrors
+					// is the one source that works on all transports. Also closes
+					// the per-test window (see attachMockErrors); the channel
+					// store was already read for THIS test above (filtered by
+					// test ID), so this cannot double-count.
+					r.attachMockErrors(runTestSetCtx, testSetID, testCase.Name, testCaseResult)
 					// Build the {expected, actual} mock set for THIS test case.
 					// See buildExpectedMockInfos / buildActualMockInfos at the
 					// bottom of this file for DNS-filter + perTestConsumed-known
@@ -3716,6 +3717,24 @@ func (r *Replayer) beginTestErrorCapture(ctx context.Context) {
 		if err := b.BeginTestErrorCapture(ctx); err != nil {
 			r.logger.Debug("failed to begin test error capture", zap.Error(err))
 		}
+	}
+}
+
+// attachMockErrors drains the per-test mock-error capture window (closing it)
+// and records any unmatched outgoing calls onto the result and the end-of-run
+// summary store. It must run on EVERY test-iteration exit — including the early
+// simulation-error / invalid-response returns — so the window is finalized for
+// THIS test and a miss is never carried forward to the next test or lost.
+func (r *Replayer) attachMockErrors(ctx context.Context, testSetID, testCaseName string, result *models.TestResult) {
+	mockErrors, err := r.instrumentation.GetMockErrors(ctx)
+	if err != nil {
+		return
+	}
+	for _, me := range mockErrors {
+		if result != nil {
+			result.FailureInfo.UnmatchedCalls = append(result.FailureInfo.UnmatchedCalls, me)
+		}
+		r.mockMismatchFailures.AddUnmatchedCallForTest(testSetID, testCaseName, me)
 	}
 }
 

--- a/pkg/service/replay/reusable_tier_test.go
+++ b/pkg/service/replay/reusable_tier_test.go
@@ -1,0 +1,151 @@
+package replay
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+func ptMock(name string) *models.Mock {
+	m := &models.Mock{Name: name, Kind: models.HTTP}
+	m.TestModeInfo.Lifetime = models.LifetimePerTest
+	return m
+}
+
+func sessionMock(name string) *models.Mock {
+	m := &models.Mock{Name: name, Kind: models.HTTP}
+	m.TestModeInfo.Lifetime = models.LifetimeSession
+	return m
+}
+
+func connMock(name string) *models.Mock {
+	m := &models.Mock{Name: name, Kind: models.HTTP}
+	m.TestModeInfo.Lifetime = models.LifetimeConnection
+	return m
+}
+
+func configMetaMock(name string) *models.Mock {
+	// Lifetime left at the per-test zero value to prove the metadata fallback
+	// (a mock whose lifetime wasn't derived but whose recorder type is config).
+	return &models.Mock{
+		Name: name, Kind: models.HTTP,
+		Spec: models.MockSpec{Metadata: map[string]string{"type": "config"}},
+	}
+}
+
+func TestIsReusableTierMock(t *testing.T) {
+	cases := []struct {
+		name string
+		m    *models.Mock
+		want bool
+	}{
+		{"per-test is NOT reusable", ptMock("a"), false},
+		{"session is reusable", sessionMock("b"), true},
+		{"connection is reusable", connMock("c"), true},
+		{"config metadata fallback is reusable", configMetaMock("d"), true},
+		{"per-test with no metadata", &models.Mock{Name: "e", Kind: models.HTTP}, false},
+	}
+	for _, tc := range cases {
+		if got := isReusableTierMock(tc.m); got != tc.want {
+			t.Errorf("%s: isReusableTierMock=%v want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestIsReusableTierState(t *testing.T) {
+	cases := []struct {
+		name string
+		s    models.MockState
+		want bool
+	}{
+		{"per-test (zero lifetime, no type)", models.MockState{Name: "a"}, false},
+		{"session lifetime", models.MockState{Name: "b", Lifetime: models.LifetimeSession}, true},
+		{"connection lifetime", models.MockState{Name: "c", Lifetime: models.LifetimeConnection}, true},
+		{"config type fallback", models.MockState{Name: "d", Type: "config"}, true},
+		{"connection type fallback", models.MockState{Name: "e", Type: "connection"}, true},
+	}
+	for _, tc := range cases {
+		if got := isReusableTierState(tc.s); got != tc.want {
+			t.Errorf("%s: isReusableTierState=%v want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// End-to-end of the assertion intent: a test whose mapping lists a per-test
+// mock AND a reusable session mock, but whose replay only re-consumed the
+// per-test mock, must NOT be flagged as a mock-set mismatch — the session
+// mock is excluded from both sides of the subset check.
+func TestSubsetExcludesReusableTier(t *testing.T) {
+	// Loaded mocks tell us the tier of each name (MockEntry carries none).
+	reusable := map[string]bool{}
+	for _, m := range []*models.Mock{ptMock("pt-1"), sessionMock("sess-1")} {
+		if isReusableTierMock(m) {
+			reusable[m.Name] = true
+		}
+	}
+
+	// Mapping (expected) lists both; filter to per-test only.
+	expected := []models.MockEntry{{Name: "pt-1", Kind: "Http"}, {Name: "sess-1", Kind: "Http"}}
+	var filteredExpected []string
+	for _, e := range expected {
+		if reusable[e.Name] {
+			continue
+		}
+		filteredExpected = append(filteredExpected, e.Name)
+	}
+
+	// Consumed during replay: only the per-test mock came back (session reused
+	// elsewhere / not re-reported for this test).
+	consumed := []models.MockState{{Name: "pt-1", Lifetime: models.LifetimePerTest}}
+	var filteredConsumed []string
+	for _, s := range consumed {
+		if isReusableTierState(s) {
+			continue
+		}
+		filteredConsumed = append(filteredConsumed, s.Name)
+	}
+
+	if mismatch := !isMockSubset(filteredConsumed, filteredExpected); mismatch {
+		t.Errorf("expected NO mock-set mismatch once the reusable session mock is excluded; got mismatch (expected=%v consumed=%v)", filteredExpected, filteredConsumed)
+	}
+
+	// Control: a genuinely missing per-test mock must still flag a mismatch.
+	expected2 := []string{"pt-1", "pt-2"} // pt-2 never consumed
+	if mismatch := !isMockSubset(filteredConsumed, expected2); !mismatch {
+		t.Errorf("expected a mismatch when a per-test mock is genuinely missing")
+	}
+}
+
+// isMockSubsetWithConfig (streaming path) must ignore an extra consumed mock
+// of ANY reusable/startup tier (session/connection/config) or DNS — not just
+// config — so a reused mock can't falsely fail the streaming assertion.
+func TestIsMockSubsetWithConfig_ReusableTiers(t *testing.T) {
+	expected := []string{"pt-1"}
+	cases := []struct {
+		name     string
+		consumed []models.MockState
+		want     bool
+	}{
+		{"extra session mock ignored", []models.MockState{
+			{Name: "pt-1", Lifetime: models.LifetimePerTest},
+			{Name: "sess-1", Lifetime: models.LifetimeSession},
+		}, true},
+		{"extra connection mock ignored", []models.MockState{
+			{Name: "pt-1"}, {Name: "conn-1", Lifetime: models.LifetimeConnection},
+		}, true},
+		{"extra config mock ignored (legacy)", []models.MockState{
+			{Name: "pt-1"}, {Name: "cfg-1", Type: "config"},
+		}, true},
+		{"extra DNS mock ignored", []models.MockState{
+			{Name: "pt-1"}, {Name: "dns-1", Kind: models.DNS},
+		}, true},
+		{"extra per-test mock still fails", []models.MockState{
+			{Name: "pt-1"}, {Name: "pt-extra", Lifetime: models.LifetimePerTest},
+		}, false},
+	}
+	for _, tc := range cases {
+		if got := isMockSubsetWithConfig(tc.consumed, expected); got != tc.want {
+			t.Errorf("%s: isMockSubsetWithConfig=%v want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -20,6 +20,7 @@ import (
 	// "encoding/json"
 	"go.keploy.io/server/v3/config"
 	"go.keploy.io/server/v3/pkg"
+	matcherUtils "go.keploy.io/server/v3/pkg/matcher"
 	"go.keploy.io/server/v3/pkg/models"
 )
 
@@ -914,7 +915,7 @@ func printMismatchReport(r *models.MockMismatchReport) {
 
 	switch {
 	case r.ClosestMockReq != "" && r.ReceivedReq != "":
-		printSideBySideDiff(r.ClosestMock, r.ClosestMockReq, r.ReceivedReq)
+		printRequestDiff(r.ClosestMock, r.ClosestMockReq, r.ReceivedReq)
 	case len(r.FieldDiffs) > 0:
 		printFieldDiffTable(r.FieldDiffs)
 	case r.Diff != "":
@@ -926,43 +927,84 @@ func printMismatchReport(r *models.MockMismatchReport) {
 	}
 }
 
-// printSideBySideDiff renders the whole mock request (left) against the whole
-// received request (right). Differing lines are highlighted — red on the mock
-// side, green on the received side. Every line of both requests is shown: no
-// folding and no line cap, so the user sees the complete mock.
-func printSideBySideDiff(mockName, expected, received string) {
-	leftHeader := "EXPECTED MOCK"
-	if mockName != "" {
-		leftHeader = "EXPECTED MOCK: " + mockName
+// printRequestDiff renders the closest mock's recorded request against the live
+// request in the SAME visual style as an HTTP test-case (response) mismatch: a
+// boxed diff whose rows are Expect/Actual sub-tables for the request line,
+// headers and body, produced by the shared matcher.DiffsPrinter. expected and
+// received are the whole rendered requests (request line + headers + body) the
+// parser emitted; the body therefore diffs field-by-field (changed fields
+// only), exactly like a response-body mismatch.
+func printRequestDiff(mockName, expected, received string) {
+	title := mockName
+	if title == "" {
+		title = "closest mock"
 	}
-	colWidths := tw.NewMapper[int, int]().Set(0, 55).Set(1, 55)
-	table := tablewriter.NewTable(os.Stdout,
-		tablewriter.WithRendition(tw.Rendition{
-			Settings: tw.Settings{Separators: tw.Separators{BetweenRows: tw.Off}},
-		}),
-		tablewriter.WithRowAutoWrap(1),
-		tablewriter.WithHeaderAlignment(tw.AlignCenter),
-		tablewriter.WithRowAlignment(tw.AlignLeft),
-		tablewriter.WithMaxWidth(120),
-		tablewriter.WithColumnWidths(colWidths),
-		// Keep the mock name verbatim — autoformat would render "mock-0" as "MOCK - 0".
-		tablewriter.WithHeaderAutoFormat(tw.Off),
-	)
-	table.Header([]string{leftHeader, "RECEIVED REQUEST"})
-	// Show the WHOLE mock side-by-side — every line, no folding and no cap.
-	for _, row := range alignDiffRows(expected, received) {
-		left, right := preserveIndent(row.left), preserveIndent(row.right)
-		if row.changed {
-			if left != "" {
-				left = models.HighlightFailingString(left)
-			}
-			if right != "" {
-				right = models.HighlightPassingString(right)
-			}
+	dp := matcherUtils.NewDiffsPrinter(title)
+
+	mockLine, mockHeaders, mockBody := parseRenderedRequest(expected)
+	liveLine, liveHeaders, liveBody := parseRenderedRequest(received)
+
+	// Request line -> method + target, surfaced as Expect/Actual rows only when
+	// they differ (for a body mismatch the closest mock shares method/path).
+	mockMethod, mockTarget := splitRequestLine(mockLine)
+	liveMethod, liveTarget := splitRequestLine(liveLine)
+	if mockMethod != liveMethod {
+		dp.PushHeaderDiff(mockMethod, liveMethod, "method", nil)
+	}
+	if mockTarget != liveTarget {
+		dp.PushHeaderDiff(mockTarget, liveTarget, "url", nil)
+	}
+
+	// Headers: push only the keys whose values differ, mirroring the response
+	// header diff. Identical (including both-redacted) headers are skipped.
+	seen := map[string]bool{}
+	for k, mv := range mockHeaders {
+		seen[k] = true
+		if lv := liveHeaders[k]; mv != lv {
+			dp.PushHeaderDiff(mv, lv, k, nil)
 		}
-		table.Append([]string{left, right})
 	}
-	table.Render()
+	for k, lv := range liveHeaders {
+		if !seen[k] && lv != "" {
+			dp.PushHeaderDiff("", lv, k, nil)
+		}
+	}
+
+	// Body: JSON bodies diff field-by-field (changed fields only), just like a
+	// response body mismatch; non-JSON falls back to a plain Expect/Actual cell.
+	dp.PushBodyDiff(mockBody, liveBody, nil)
+
+	_ = dp.Render()
+}
+
+// parseRenderedRequest splits a rendered request
+// ("METHOD target\nKey: val\n...\n\n<body>") back into its request line, header
+// map and body so the pieces can feed the shared Expect/Actual diff renderer.
+func parseRenderedRequest(s string) (line string, headers map[string]string, body string) {
+	headers = map[string]string{}
+	headBlock := s
+	if i := strings.Index(s, "\n\n"); i >= 0 {
+		headBlock, body = s[:i], s[i+2:]
+	}
+	lines := strings.Split(headBlock, "\n")
+	if len(lines) == 0 {
+		return line, headers, body
+	}
+	line = lines[0]
+	for _, l := range lines[1:] {
+		if j := strings.Index(l, ": "); j >= 0 {
+			headers[l[:j]] = l[j+2:]
+		}
+	}
+	return line, headers, body
+}
+
+// splitRequestLine splits "METHOD target" into its method and target.
+func splitRequestLine(line string) (method, target string) {
+	if i := strings.Index(line, " "); i >= 0 {
+		return line[:i], line[i+1:]
+	}
+	return line, ""
 }
 
 // printFieldDiffTable renders the compact FIELD | EXPECTED | RECEIVED table —
@@ -994,89 +1036,4 @@ func printFieldDiffTable(fieldDiffs []models.MockFieldDiff) {
 		table.Append([]string{d.Path, exp, rec})
 	}
 	table.Render()
-}
-
-// mockDiffRow is one aligned row of the side-by-side diff.
-type mockDiffRow struct {
-	left    string
-	right   string
-	changed bool
-}
-
-// alignDiffRows line-aligns the two renders via LCS: equal lines pair up
-// unchanged; runs of differing lines zip together as changed rows (one side
-// blank when the other has extra lines).
-func alignDiffRows(expected, received string) []mockDiffRow {
-	expLines := strings.Split(expected, "\n")
-	recLines := strings.Split(received, "\n")
-	n, m := len(expLines), len(recLines)
-	dp := make([][]int, n+1)
-	for i := range dp {
-		dp[i] = make([]int, m+1)
-	}
-	for i := n - 1; i >= 0; i-- {
-		for j := m - 1; j >= 0; j-- {
-			if expLines[i] == recLines[j] {
-				dp[i][j] = dp[i+1][j+1] + 1
-			} else if dp[i+1][j] >= dp[i][j+1] {
-				dp[i][j] = dp[i+1][j]
-			} else {
-				dp[i][j] = dp[i][j+1]
-			}
-		}
-	}
-	var rows []mockDiffRow
-	var dels, inss []string
-	flush := func() {
-		for k := 0; k < len(dels) || k < len(inss); k++ {
-			var l, r string
-			if k < len(dels) {
-				l = dels[k]
-			}
-			if k < len(inss) {
-				r = inss[k]
-			}
-			rows = append(rows, mockDiffRow{left: l, right: r, changed: true})
-		}
-		dels, inss = nil, nil
-	}
-	i, j := 0, 0
-	for i < n && j < m {
-		switch {
-		case expLines[i] == recLines[j]:
-			flush()
-			rows = append(rows, mockDiffRow{left: expLines[i], right: recLines[j]})
-			i++
-			j++
-		case dp[i+1][j] >= dp[i][j+1]:
-			dels = append(dels, expLines[i])
-			i++
-		default:
-			inss = append(inss, recLines[j])
-			j++
-		}
-	}
-	for ; i < n; i++ {
-		dels = append(dels, expLines[i])
-	}
-	for ; j < m; j++ {
-		inss = append(inss, recLines[j])
-	}
-	flush()
-	return rows
-}
-
-// preserveIndent swaps leading spaces for braille-blank (U+2800) so
-// tablewriter's cell trimming doesn't flatten JSON indentation. NBSP doesn't
-// work: unicode.IsSpace counts it as whitespace, so TrimSpace-based cell
-// cleanup strips it; U+2800 renders blank but is not whitespace.
-func preserveIndent(s string) string {
-	i := 0
-	for i < len(s) && s[i] == ' ' {
-		i++
-	}
-	if i == 0 {
-		return s
-	}
-	return strings.Repeat("⠀", i) + s[i:]
 }

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -712,6 +712,7 @@ func (tfs *TestFailureStore) AddUnmatchedCallForTest(testSetID string, testCaseI
 		MismatchReport: &models.MockMismatchReport{
 			Protocol:       call.Protocol,
 			ActualSummary:  call.ActualSummary,
+			Destination:    call.Destination,
 			ClosestMock:    call.ClosestMock,
 			Diff:           call.Diff,
 			NextSteps:      call.NextSteps,
@@ -877,6 +878,9 @@ func printMismatchReport(r *models.MockMismatchReport) {
 		return
 	}
 	heading := fmt.Sprintf("  Mock mismatch: [%s] %s", r.Protocol, r.ActualSummary)
+	if r.Destination != "" {
+		heading += fmt.Sprintf("  →  %s", r.Destination)
+	}
 	if r.ClosestMock != "" {
 		heading += fmt.Sprintf("   (closest mock: %s)", r.ClosestMock)
 	}

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -504,6 +504,14 @@ func retainNoisyTestCaseMocks(noisyTestCaseNames []string, mapping *models.Mappi
 	return added
 }
 
+// isMockSubsetWithConfig reports whether the streaming-path replay consumed a
+// mock set consistent with the test's mapping: a consumed mock that is NOT in
+// the expected set flags a mismatch — UNLESS it is a mock that doesn't
+// participate in the per-test comparison. Only PER-TEST mocks are compared;
+// reusable/startup-tier mocks (session / connection / config, recorded once at
+// app boot and reused) and DNS (non-deterministic resolution order) are
+// ignored, mirroring the non-streaming path's filtering. They belong in the
+// mapping but must not, by their reuse, falsely demote a test to OBSOLETE.
 func isMockSubsetWithConfig(consumedMocks []models.MockState, expectedMocks []string) bool {
 	expectedMap := make(map[string]bool)
 	for _, name := range expectedMocks {
@@ -512,12 +520,13 @@ func isMockSubsetWithConfig(consumedMocks []models.MockState, expectedMocks []st
 
 	for _, m := range consumedMocks {
 		if !expectedMap[m.Name] {
-			// Found an extra mock in the actual run
-			if m.Type != "config" {
-				// This is NOT a config mock, so it IS a mismatch
+			// An extra consumed mock that wasn't in the mapping is a mismatch
+			// ONLY if it's a per-test mock. Reusable/startup-tier mocks
+			// (session/connection/config) and DNS are excluded from the
+			// comparison — they are reused / non-deterministically attributed.
+			if m.Kind != models.DNS && !isReusableTierState(m) {
 				return false
 			}
-			// If Type is "config", we ignore it as an extra mock
 		}
 	}
 	return true

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -689,21 +689,6 @@ func (tfs *TestFailureStore) AddFailure(testSetID, testID string, expectedMocks,
 	tfs.failures = append(tfs.failures, failure)
 }
 
-func (tfs *TestFailureStore) AddProxyErrorForTest(testSetID string, testCaseID string, proxyErr models.ParserError) {
-	tfs.mu.Lock()
-	defer tfs.mu.Unlock()
-
-	failure := TestFailure{
-		TestSetID:      testSetID,
-		TestID:         testCaseID,
-		ExpectedMocks:  []string{},
-		ActualMocks:    []string{},
-		FailureReason:  proxyErr.ParserErrorType,
-		MismatchReport: proxyErr.MismatchReport,
-	}
-	tfs.failures = append(tfs.failures, failure)
-}
-
 // AddUnmatchedCallForTest records a mock-not-found error fetched via the
 // agent's GetMockErrors API (the path used on all transports, notably the
 // HTTP agent transport whose error channel is nil) so it appears in the
@@ -742,20 +727,6 @@ func (tfs *TestFailureStore) GetFailures() []TestFailure {
 	failures := make([]TestFailure, len(tfs.failures))
 	copy(failures, tfs.failures)
 	return failures
-}
-
-// GetFailuresForTestCase returns failures for a specific test set + test case.
-func (tfs *TestFailureStore) GetFailuresForTestCase(testSetID, testCaseID string) []TestFailure {
-	tfs.mu.Lock()
-	defer tfs.mu.Unlock()
-
-	var result []TestFailure
-	for _, f := range tfs.failures {
-		if f.TestSetID == testSetID && f.TestID == testCaseID {
-			result = append(result, f)
-		}
-	}
-	return result
 }
 
 type MockDifference struct {

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -320,13 +320,22 @@ func PrepareMockNoiseConfig(globalNoise config.GlobalNoise, testSetNoise config.
 		noiseConfig = LeftJoinNoise(noiseConfig, tsNoise)
 	}
 
-	// Extract header + body noise for mock matching.
+	// Extract the noise buckets the proxy consumes for mock matching:
+	//   - "header": HTTP outgoing header-key matching.
+	//   - "body":   outgoing-payload matchers (e.g. the Pulsar SEND matcher in
+	//               the integrations repo) strip these field names.
+	//   - "requestbody": DEDICATED HTTP request-body matching noise — kept
+	//               separate from "body" so response-assertion noise can't
+	//               silently soften request matching (see http/decode.go).
 	mockNoiseConfig := map[string]map[string][]string{}
 	if headerNoise, ok := noiseConfig["header"]; ok {
 		mockNoiseConfig["header"] = headerNoise
 	}
 	if bodyNoise, ok := noiseConfig["body"]; ok {
 		mockNoiseConfig["body"] = bodyNoise
+	}
+	if reqBodyNoise, ok := noiseConfig["requestbody"]; ok {
+		mockNoiseConfig["requestbody"] = reqBodyNoise
 	}
 
 	return mockNoiseConfig
@@ -694,6 +703,36 @@ func (tfs *TestFailureStore) AddProxyErrorForTest(testSetID string, testCaseID s
 	tfs.failures = append(tfs.failures, failure)
 }
 
+// AddUnmatchedCallForTest records a mock-not-found error fetched via the
+// agent's GetMockErrors API (the path used on all transports, notably the
+// HTTP agent transport whose error channel is nil) so it appears in the
+// end-of-run MOCKS MISMATCH SUMMARY table alongside channel-sourced failures.
+func (tfs *TestFailureStore) AddUnmatchedCallForTest(testSetID string, testCaseID string, call models.UnmatchedCall) {
+	tfs.mu.Lock()
+	defer tfs.mu.Unlock()
+
+	failure := TestFailure{
+		TestSetID:     testSetID,
+		TestID:        testCaseID,
+		ExpectedMocks: []string{},
+		ActualMocks:   []string{},
+		FailureReason: models.ErrMockNotFound,
+		MismatchReport: &models.MockMismatchReport{
+			Protocol:       call.Protocol,
+			ActualSummary:  call.ActualSummary,
+			ClosestMock:    call.ClosestMock,
+			Diff:           call.Diff,
+			NextSteps:      call.NextSteps,
+			MatchPhase:     call.MatchPhase,
+			CandidateCount: call.CandidateCount,
+			FieldDiffs:     call.FieldDiffs,
+			ClosestMockReq: call.ClosestMockReq,
+			ReceivedReq:    call.ReceivedReq,
+		},
+	}
+	tfs.failures = append(tfs.failures, failure)
+}
+
 func (tfs *TestFailureStore) GetFailures() []TestFailure {
 	tfs.mu.Lock()
 	defer tfs.mu.Unlock()
@@ -780,7 +819,10 @@ func CompareMockSlices(expected, actual []string) []MockDifference {
 	return differences
 }
 
-// PrintFailuresTable prints all failures in a formatted table
+// PrintFailuresTable prints all failures, one block per failed test case: the
+// unmatched outgoing call, a side-by-side EXPECTED MOCK | RECEIVED REQUEST
+// view of the whole request with differing lines highlighted and long
+// unchanged runs folded, and the hint.
 func (tfs *TestFailureStore) PrintFailuresTable() {
 	tfs.mu.Lock()
 	defer tfs.mu.Unlock()
@@ -792,30 +834,10 @@ func (tfs *TestFailureStore) PrintFailuresTable() {
 
 	fmt.Println("\n======================= MOCKS MISMATCH SUMMARY =======================")
 
-	colWidths := tw.NewMapper[int, int]().Set(0, 15).Set(1, 12).Set(2, 50)
-	table := tablewriter.NewTable(os.Stdout,
-		tablewriter.WithRendition(tw.Rendition{
-			Settings: tw.Settings{
-				Separators: tw.Separators{
-					BetweenRows: tw.On,
-				},
-			},
-		}),
-		tablewriter.WithRowAutoWrap(1),
-		tablewriter.WithHeaderAlignment(tw.AlignCenter),
-		tablewriter.WithRowAlignment(tw.AlignCenter),
-		tablewriter.WithMaxWidth(120),
-		tablewriter.WithColumnWidths(colWidths),
-	)
-	table.Header([]string{"TEST SET", "TEST ID", "MOCK DIFFERENCES"})
-
-	// Group failures by test set for better presentation
 	testSetGroups := make(map[string][]TestFailure)
 	for _, failure := range tfs.failures {
 		testSetGroups[failure.TestSetID] = append(testSetGroups[failure.TestSetID], failure)
 	}
-
-	// Sort test set IDs for consistent output
 	var testSetIDs []string
 	for testSetID := range testSetGroups {
 		testSetIDs = append(testSetIDs, testSetID)
@@ -823,16 +845,10 @@ func (tfs *TestFailureStore) PrintFailuresTable() {
 	sort.Strings(testSetIDs)
 
 	for _, testSetID := range testSetIDs {
-		failures := testSetGroups[testSetID]
-		testSetPrinted := false
-
-		// Group failures by test ID to combine mock differences and proxy errors
 		testIDGroups := make(map[string][]TestFailure)
-		for _, failure := range failures {
+		for _, failure := range testSetGroups[testSetID] {
 			testIDGroups[failure.TestID] = append(testIDGroups[failure.TestID], failure)
 		}
-
-		// Sort test IDs for consistent output
 		var testIDs []string
 		for testID := range testIDGroups {
 			testIDs = append(testIDs, testID)
@@ -840,33 +856,13 @@ func (tfs *TestFailureStore) PrintFailuresTable() {
 		sort.Strings(testIDs)
 
 		for _, testID := range testIDs {
-			testFailures := testIDGroups[testID]
-			var combinedDiffText string
-			var allDiffStrings []string
+			fmt.Printf("\nTest: %s / %s\n", testSetID, testID)
 
-			for _, failure := range testFailures {
+			var mappingNotes []string
+			for _, failure := range testIDGroups[testID] {
 				if failure.FailureReason == models.ErrMockNotFound {
-					if failure.MismatchReport != nil {
-						r := failure.MismatchReport
-						detail := fmt.Sprintf("[%s] %s", r.Protocol, r.ActualSummary)
-						if r.MatchPhase != "" {
-							detail += fmt.Sprintf(" | phase: %s", r.MatchPhase)
-						}
-						if r.ClosestMock != "" {
-							detail += fmt.Sprintf(" | closest: %s", r.ClosestMock)
-						}
-						if r.Diff != "" {
-							detail += fmt.Sprintf(" | %s", strings.ReplaceAll(r.Diff, "\n", " "))
-						}
-						if r.NextSteps != "" {
-							detail += fmt.Sprintf(" | hint: %s", strings.ReplaceAll(r.NextSteps, "\n", " "))
-						}
-						allDiffStrings = append(allDiffStrings, detail)
-					} else {
-						allDiffStrings = append(allDiffStrings, "Outgoing call mock was not matched")
-					}
+					printMismatchReport(failure.MismatchReport)
 				}
-
 				if len(failure.ExpectedMocks) > 0 || len(failure.ActualMocks) > 0 {
 					differences := CompareMockSlices(failure.ExpectedMocks, failure.ActualMocks)
 					var missingMocks, extraMocks []string
@@ -879,27 +875,260 @@ func (tfs *TestFailureStore) PrintFailuresTable() {
 						}
 					}
 					if len(missingMocks) > 0 {
-						allDiffStrings = append(allDiffStrings, fmt.Sprintf("Missing mocks: %s", strings.Join(missingMocks, ", ")))
+						mappingNotes = append(mappingNotes, fmt.Sprintf("Expected mocks not consumed: %s", strings.Join(missingMocks, ", ")))
 					}
 					if len(extraMocks) > 0 {
-						allDiffStrings = append(allDiffStrings, fmt.Sprintf("Extra mocks: %s", strings.Join(extraMocks, ", ")))
+						mappingNotes = append(mappingNotes, fmt.Sprintf("Unexpected mocks consumed: %s", strings.Join(extraMocks, ", ")))
 					}
 				}
-				if len(allDiffStrings) > 0 {
-					combinedDiffText = strings.Join(allDiffStrings, " | ")
-				} else {
-					combinedDiffText = "No differences"
-				}
 			}
-
-			if !testSetPrinted {
-				table.Append([]string{testSetID, testID, combinedDiffText})
-				testSetPrinted = true
-			} else {
-				table.Append([]string{"", testID, combinedDiffText})
+			for _, note := range mappingNotes {
+				fmt.Printf("  %s\n", note)
 			}
 		}
 	}
+	fmt.Println()
+}
 
+// printMismatchReport renders one unmatched outgoing call: a heading, then the
+// best available view — a side-by-side whole-request diff when the parser
+// rendered both requests, else the structured FIELD | EXPECTED | RECEIVED
+// table, else the one-line Diff — followed by the hint.
+func printMismatchReport(r *models.MockMismatchReport) {
+	if r == nil {
+		fmt.Println("  Outgoing call mock was not matched")
+		return
+	}
+	heading := fmt.Sprintf("  Unmatched outgoing call: [%s] %s", r.Protocol, r.ActualSummary)
+	if r.ClosestMock != "" {
+		heading += fmt.Sprintf("   (closest mock: %s)", r.ClosestMock)
+	}
+	if r.MatchPhase != "" {
+		heading += fmt.Sprintf("   [match stopped at: %s", r.MatchPhase)
+		if r.CandidateCount > 0 {
+			heading += fmt.Sprintf(", %d candidate mock(s)", r.CandidateCount)
+		}
+		heading += "]"
+	}
+	fmt.Println(heading)
+
+	switch {
+	case r.ClosestMockReq != "" && r.ReceivedReq != "":
+		printSideBySideDiff(r.ClosestMock, r.ClosestMockReq, r.ReceivedReq)
+	case len(r.FieldDiffs) > 0:
+		printFieldDiffTable(r.FieldDiffs)
+	case r.Diff != "":
+		fmt.Printf("  Diff: %s\n", strings.ReplaceAll(r.Diff, "\n", " "))
+	}
+
+	if r.NextSteps != "" {
+		fmt.Printf("  Hint: %s\n", strings.ReplaceAll(r.NextSteps, "\n", " "))
+	}
+}
+
+// printSideBySideDiff renders the whole mock request (left) against the whole
+// received request (right). Differing lines are highlighted — red on the mock
+// side, green on the received side — and runs of unchanged lines longer than
+// foldThreshold collapse into a "… N unchanged lines …" row.
+func printSideBySideDiff(mockName, expected, received string) {
+	leftHeader := "EXPECTED MOCK"
+	if mockName != "" {
+		leftHeader = "EXPECTED MOCK: " + mockName
+	}
+	colWidths := tw.NewMapper[int, int]().Set(0, 55).Set(1, 55)
+	table := tablewriter.NewTable(os.Stdout,
+		tablewriter.WithRendition(tw.Rendition{
+			Settings: tw.Settings{Separators: tw.Separators{BetweenRows: tw.Off}},
+		}),
+		tablewriter.WithRowAutoWrap(1),
+		tablewriter.WithHeaderAlignment(tw.AlignCenter),
+		tablewriter.WithRowAlignment(tw.AlignLeft),
+		tablewriter.WithMaxWidth(120),
+		tablewriter.WithColumnWidths(colWidths),
+		// Keep the mock name verbatim — autoformat would render "mock-0" as "MOCK - 0".
+		tablewriter.WithHeaderAutoFormat(tw.Off),
+	)
+	table.Header([]string{leftHeader, "RECEIVED REQUEST"})
+	for _, row := range foldUnchangedRows(alignDiffRows(expected, received)) {
+		left, right := preserveIndent(row.left), preserveIndent(row.right)
+		if !row.fold && row.changed {
+			if left != "" {
+				left = models.HighlightFailingString(left)
+			}
+			if right != "" {
+				right = models.HighlightPassingString(right)
+			}
+		}
+		table.Append([]string{left, right})
+	}
 	table.Render()
+}
+
+// printFieldDiffTable renders the compact FIELD | EXPECTED | RECEIVED table —
+// the fallback when whole-request renders aren't available. Reads the
+// noise-vocabulary MockFieldDiff (Path/Kind/Expected/Actual).
+func printFieldDiffTable(fieldDiffs []models.MockFieldDiff) {
+	colWidths := tw.NewMapper[int, int]().Set(0, 24).Set(1, 40).Set(2, 40)
+	table := tablewriter.NewTable(os.Stdout,
+		tablewriter.WithRendition(tw.Rendition{
+			Settings: tw.Settings{Separators: tw.Separators{BetweenRows: tw.On}},
+		}),
+		tablewriter.WithRowAutoWrap(1),
+		tablewriter.WithHeaderAlignment(tw.AlignCenter),
+		tablewriter.WithRowAlignment(tw.AlignLeft),
+		tablewriter.WithMaxWidth(120),
+		tablewriter.WithColumnWidths(colWidths),
+	)
+	table.Header([]string{"FIELD", "EXPECTED (MOCK)", "RECEIVED (REQUEST)"})
+	for _, d := range fieldDiffs {
+		exp, rec := d.Expected, d.Actual
+		switch d.Kind {
+		case models.DiffKindMissingInLive:
+			rec = "(missing)"
+		case models.DiffKindMissingInMock:
+			exp = "(not recorded)"
+		case models.DiffKindTypeChanged:
+			exp, rec = "type "+d.Expected, "type "+d.Actual
+		}
+		table.Append([]string{d.Path, exp, rec})
+	}
+	table.Render()
+}
+
+// mockDiffRow is one aligned row of the side-by-side diff.
+type mockDiffRow struct {
+	left    string
+	right   string
+	changed bool
+	fold    bool // "… N unchanged lines …" marker
+}
+
+// maxDiffRenderLines caps lines per side fed to the LCS alignment so a
+// pathological payload can't make rendering quadratic-expensive.
+const maxDiffRenderLines = 400
+
+// alignDiffRows line-aligns the two renders via LCS: equal lines pair up
+// unchanged; runs of differing lines zip together as changed rows (one side
+// blank when the other has extra lines).
+func alignDiffRows(expected, received string) []mockDiffRow {
+	expLines := capLines(strings.Split(expected, "\n"))
+	recLines := capLines(strings.Split(received, "\n"))
+	n, m := len(expLines), len(recLines)
+	dp := make([][]int, n+1)
+	for i := range dp {
+		dp[i] = make([]int, m+1)
+	}
+	for i := n - 1; i >= 0; i-- {
+		for j := m - 1; j >= 0; j-- {
+			if expLines[i] == recLines[j] {
+				dp[i][j] = dp[i+1][j+1] + 1
+			} else if dp[i+1][j] >= dp[i][j+1] {
+				dp[i][j] = dp[i+1][j]
+			} else {
+				dp[i][j] = dp[i][j+1]
+			}
+		}
+	}
+	var rows []mockDiffRow
+	var dels, inss []string
+	flush := func() {
+		for k := 0; k < len(dels) || k < len(inss); k++ {
+			var l, r string
+			if k < len(dels) {
+				l = dels[k]
+			}
+			if k < len(inss) {
+				r = inss[k]
+			}
+			rows = append(rows, mockDiffRow{left: l, right: r, changed: true})
+		}
+		dels, inss = nil, nil
+	}
+	i, j := 0, 0
+	for i < n && j < m {
+		switch {
+		case expLines[i] == recLines[j]:
+			flush()
+			rows = append(rows, mockDiffRow{left: expLines[i], right: recLines[j]})
+			i++
+			j++
+		case dp[i+1][j] >= dp[i][j+1]:
+			dels = append(dels, expLines[i])
+			i++
+		default:
+			inss = append(inss, recLines[j])
+			j++
+		}
+	}
+	for ; i < n; i++ {
+		dels = append(dels, expLines[i])
+	}
+	for ; j < m; j++ {
+		inss = append(inss, recLines[j])
+	}
+	flush()
+	return rows
+}
+
+func capLines(lines []string) []string {
+	if len(lines) <= maxDiffRenderLines {
+		return lines
+	}
+	return append(lines[:maxDiffRenderLines:maxDiffRenderLines], "… (truncated)")
+}
+
+// foldUnchangedRows collapses runs of unchanged rows longer than foldThreshold
+// into a "… N unchanged lines …" marker, keeping foldContext rows on each side
+// of every change — git-diff style context folding.
+func foldUnchangedRows(rows []mockDiffRow) []mockDiffRow {
+	const (
+		foldThreshold = 7
+		foldContext   = 2
+	)
+	var out []mockDiffRow
+	i := 0
+	for i < len(rows) {
+		if rows[i].changed {
+			out = append(out, rows[i])
+			i++
+			continue
+		}
+		runStart := i
+		for i < len(rows) && !rows[i].changed {
+			i++
+		}
+		runLen := i - runStart
+		lead, trail := foldContext, foldContext
+		if runStart == 0 {
+			lead = 0
+		}
+		if i == len(rows) {
+			trail = 0
+		}
+		if runLen <= foldThreshold || runLen <= lead+trail {
+			out = append(out, rows[runStart:i]...)
+			continue
+		}
+		out = append(out, rows[runStart:runStart+lead]...)
+		folded := runLen - lead - trail
+		marker := fmt.Sprintf("… %d unchanged lines …", folded)
+		out = append(out, mockDiffRow{left: marker, right: marker, fold: true})
+		out = append(out, rows[i-trail:i]...)
+	}
+	return out
+}
+
+// preserveIndent swaps leading spaces for braille-blank (U+2800) so
+// tablewriter's cell trimming doesn't flatten JSON indentation. NBSP doesn't
+// work: unicode.IsSpace counts it as whitespace, so TrimSpace-based cell
+// cleanup strips it; U+2800 renders blank but is not whitespace.
+func preserveIndent(s string) string {
+	i := 0
+	for i < len(s) && s[i] == ' ' {
+		i++
+	}
+	if i == 0 {
+		return s
+	}
+	return strings.Repeat("⠀", i) + s[i:]
 }

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -954,17 +954,17 @@ func printRequestDiff(mockName, expected, received string) {
 		dp.PushHeaderDiff(mockTarget, liveTarget, "url", nil)
 	}
 
-	// Headers: push only the keys whose values differ, mirroring the response
-	// header diff. Identical (including both-redacted) headers are skipped.
-	seen := map[string]bool{}
+	// Headers: push a row whenever a key is present on only one side or its
+	// value differs. Two-value lookups distinguish an absent header from one
+	// present with an empty value, so a key-presence mismatch (the exact reason
+	// a mock can be rejected) is never silently dropped.
 	for k, mv := range mockHeaders {
-		seen[k] = true
-		if lv := liveHeaders[k]; mv != lv {
+		if lv, ok := liveHeaders[k]; !ok || mv != lv {
 			dp.PushHeaderDiff(mv, lv, k, nil)
 		}
 	}
 	for k, lv := range liveHeaders {
-		if !seen[k] && lv != "" {
+		if _, ok := mockHeaders[k]; !ok {
 			dp.PushHeaderDiff("", lv, k, nil)
 		}
 	}

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -849,6 +849,9 @@ func (tfs *TestFailureStore) PrintFailuresTable() {
 					if failure.MismatchReport != nil {
 						r := failure.MismatchReport
 						detail := fmt.Sprintf("[%s] %s", r.Protocol, r.ActualSummary)
+						if r.MatchPhase != "" {
+							detail += fmt.Sprintf(" | phase: %s", r.MatchPhase)
+						}
 						if r.ClosestMock != "" {
 							detail += fmt.Sprintf(" | closest: %s", r.ClosestMock)
 						}

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -274,21 +274,27 @@ type TestReportVerdict struct {
 func LeftJoinNoise(globalNoise config.GlobalNoise, tsNoise config.GlobalNoise) config.GlobalNoise {
 	noise := CloneGlobalNoise(globalNoise)
 
+	// Preserve the historical guarantee that the body and header buckets always
+	// exist, since some callers index them directly.
 	if _, ok := noise["body"]; !ok {
 		noise["body"] = make(map[string][]string)
 	}
-	if tsNoiseBody, ok := tsNoise["body"]; ok {
-		for field, regexArr := range tsNoiseBody {
-			noise["body"][field] = regexArr
-		}
-	}
-
 	if _, ok := noise["header"]; !ok {
 		noise["header"] = make(map[string][]string)
 	}
-	if tsNoiseHeader, ok := tsNoise["header"]; ok {
-		for field, regexArr := range tsNoiseHeader {
-			noise["header"][field] = regexArr
+
+	// Merge EVERY section present in the test-set noise — not just body/header.
+	// The previous code hard-coded those two buckets, so test-set-scoped
+	// `requestbody` noise (and any future bucket) was silently dropped while the
+	// global bucket worked, which under --schema-noise-strict could turn a
+	// noised request-body field back into a match-affecting one and falsely
+	// reject the mock.
+	for section, fields := range tsNoise {
+		if _, ok := noise[section]; !ok {
+			noise[section] = make(map[string][]string)
+		}
+		for field, regexArr := range fields {
+			noise[section][field] = regexArr
 		}
 	}
 

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -707,7 +707,7 @@ func (tfs *TestFailureStore) AddProxyErrorForTest(testSetID string, testCaseID s
 // AddUnmatchedCallForTest records a mock-not-found error fetched via the
 // agent's GetMockErrors API (the path used on all transports, notably the
 // HTTP agent transport whose error channel is nil) so it appears in the
-// end-of-run MOCKS MISMATCH SUMMARY table alongside channel-sourced failures.
+// end-of-run mock mismatch report alongside channel-sourced failures.
 func (tfs *TestFailureStore) AddUnmatchedCallForTest(testSetID string, testCaseID string, call models.UnmatchedCall) {
 	tfs.mu.Lock()
 	defer tfs.mu.Unlock()
@@ -820,10 +820,9 @@ func CompareMockSlices(expected, actual []string) []MockDifference {
 	return differences
 }
 
-// PrintFailuresTable prints all failures, one block per failed test case: the
-// unmatched outgoing call, a side-by-side EXPECTED MOCK | RECEIVED REQUEST
-// view of the whole request with differing lines highlighted and long
-// unchanged runs folded, and the hint.
+// PrintFailuresTable prints all failures, one block per failed test case: a
+// "Mock mismatch" heading for each unmatched outgoing call followed by the
+// same Expect/Actual diff used for HTTP test-case mismatches, and the hint.
 func (tfs *TestFailureStore) PrintFailuresTable() {
 	tfs.mu.Lock()
 	defer tfs.mu.Unlock()
@@ -833,7 +832,7 @@ func (tfs *TestFailureStore) PrintFailuresTable() {
 		return
 	}
 
-	fmt.Println("\n======================= MOCKS MISMATCH SUMMARY =======================")
+	fmt.Println("\n=========================== MOCK MISMATCH ===========================")
 
 	testSetGroups := make(map[string][]TestFailure)
 	for _, failure := range tfs.failures {
@@ -900,7 +899,7 @@ func printMismatchReport(r *models.MockMismatchReport) {
 		fmt.Println("  Outgoing call mock was not matched")
 		return
 	}
-	heading := fmt.Sprintf("  Unmatched outgoing call: [%s] %s", r.Protocol, r.ActualSummary)
+	heading := fmt.Sprintf("  Mock mismatch: [%s] %s", r.Protocol, r.ActualSummary)
 	if r.ClosestMock != "" {
 		heading += fmt.Sprintf("   (closest mock: %s)", r.ClosestMock)
 	}

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -928,8 +928,8 @@ func printMismatchReport(r *models.MockMismatchReport) {
 
 // printSideBySideDiff renders the whole mock request (left) against the whole
 // received request (right). Differing lines are highlighted — red on the mock
-// side, green on the received side — and runs of unchanged lines longer than
-// foldThreshold collapse into a "… N unchanged lines …" row.
+// side, green on the received side. Every line of both requests is shown: no
+// folding and no line cap, so the user sees the complete mock.
 func printSideBySideDiff(mockName, expected, received string) {
 	leftHeader := "EXPECTED MOCK"
 	if mockName != "" {
@@ -949,9 +949,10 @@ func printSideBySideDiff(mockName, expected, received string) {
 		tablewriter.WithHeaderAutoFormat(tw.Off),
 	)
 	table.Header([]string{leftHeader, "RECEIVED REQUEST"})
-	for _, row := range foldUnchangedRows(alignDiffRows(expected, received)) {
+	// Show the WHOLE mock side-by-side — every line, no folding and no cap.
+	for _, row := range alignDiffRows(expected, received) {
 		left, right := preserveIndent(row.left), preserveIndent(row.right)
-		if !row.fold && row.changed {
+		if row.changed {
 			if left != "" {
 				left = models.HighlightFailingString(left)
 			}
@@ -1000,19 +1001,14 @@ type mockDiffRow struct {
 	left    string
 	right   string
 	changed bool
-	fold    bool // "… N unchanged lines …" marker
 }
-
-// maxDiffRenderLines caps lines per side fed to the LCS alignment so a
-// pathological payload can't make rendering quadratic-expensive.
-const maxDiffRenderLines = 400
 
 // alignDiffRows line-aligns the two renders via LCS: equal lines pair up
 // unchanged; runs of differing lines zip together as changed rows (one side
 // blank when the other has extra lines).
 func alignDiffRows(expected, received string) []mockDiffRow {
-	expLines := capLines(strings.Split(expected, "\n"))
-	recLines := capLines(strings.Split(received, "\n"))
+	expLines := strings.Split(expected, "\n")
+	recLines := strings.Split(received, "\n")
 	n, m := len(expLines), len(recLines)
 	dp := make([][]int, n+1)
 	for i := range dp {
@@ -1068,54 +1064,6 @@ func alignDiffRows(expected, received string) []mockDiffRow {
 	}
 	flush()
 	return rows
-}
-
-func capLines(lines []string) []string {
-	if len(lines) <= maxDiffRenderLines {
-		return lines
-	}
-	return append(lines[:maxDiffRenderLines:maxDiffRenderLines], "… (truncated)")
-}
-
-// foldUnchangedRows collapses runs of unchanged rows longer than foldThreshold
-// into a "… N unchanged lines …" marker, keeping foldContext rows on each side
-// of every change — git-diff style context folding.
-func foldUnchangedRows(rows []mockDiffRow) []mockDiffRow {
-	const (
-		foldThreshold = 7
-		foldContext   = 2
-	)
-	var out []mockDiffRow
-	i := 0
-	for i < len(rows) {
-		if rows[i].changed {
-			out = append(out, rows[i])
-			i++
-			continue
-		}
-		runStart := i
-		for i < len(rows) && !rows[i].changed {
-			i++
-		}
-		runLen := i - runStart
-		lead, trail := foldContext, foldContext
-		if runStart == 0 {
-			lead = 0
-		}
-		if i == len(rows) {
-			trail = 0
-		}
-		if runLen <= foldThreshold || runLen <= lead+trail {
-			out = append(out, rows[runStart:i]...)
-			continue
-		}
-		out = append(out, rows[runStart:runStart+lead]...)
-		folded := runLen - lead - trail
-		marker := fmt.Sprintf("… %d unchanged lines …", folded)
-		out = append(out, mockDiffRow{left: marker, right: marker, fold: true})
-		out = append(out, rows[i-trail:i]...)
-	}
-	return out
 }
 
 // preserveIndent swaps leading spaces for braille-blank (U+2800) so

--- a/pkg/service/report/report.go
+++ b/pkg/service/report/report.go
@@ -789,6 +789,11 @@ func (r *Report) renderSingleFailedTest(_ context.Context, sb *strings.Builder, 
 
 	sb.WriteString(header + "\n")
 
+	// Mock-miss diagnostics FIRST: when an outgoing call had no matching
+	// mock, the response diff below is usually a downstream symptom (the app
+	// reacting to keploy's synthetic error), so lead with the root cause.
+	renderUnmatchedCalls(sb, test)
+
 	// Status & header diffs (compact)
 	metaDiff := GenerateStatusAndHeadersTableDiff(test)
 
@@ -851,6 +856,52 @@ func (r *Report) renderSingleFailedTest(_ context.Context, sb *strings.Builder, 
 	}
 	sb.WriteString("\n--------------------------------------------------------------------\n")
 	return nil
+}
+
+// renderUnmatchedCalls writes the structured mock-miss diagnostics
+// (FailureInfo.UnmatchedCalls) for a test. Field-diff paths use the noise
+// vocabulary, so the rendered output doubles as copy-paste material for
+// test.globalNoise / spec.assertions.noise.
+func renderUnmatchedCalls(sb *strings.Builder, test models.TestResult) {
+	if len(test.FailureInfo.UnmatchedCalls) == 0 {
+		return
+	}
+	sb.WriteString("=== OUTGOING CALLS WITH NO MATCHING MOCK (likely root cause) ===\n")
+	for _, uc := range test.FailureInfo.UnmatchedCalls {
+		sb.WriteString(fmt.Sprintf("  [%s] %s", uc.Protocol, uc.ActualSummary))
+		if uc.MatchPhase != "" {
+			sb.WriteString(fmt.Sprintf(" (match stopped at: %s", uc.MatchPhase))
+			if uc.CandidateCount > 0 {
+				sb.WriteString(fmt.Sprintf(", %d candidate mock(s)", uc.CandidateCount))
+			}
+			sb.WriteString(")")
+		}
+		sb.WriteString("\n")
+		if uc.ClosestMock != "" {
+			sb.WriteString(fmt.Sprintf("    closest mock: %s\n", uc.ClosestMock))
+		}
+		if len(uc.FieldDiffs) > 0 {
+			sb.WriteString("    field differences (paths are noise-config compatible):\n")
+			for _, d := range uc.FieldDiffs {
+				switch d.Kind {
+				case models.DiffKindMissingInLive:
+					sb.WriteString(fmt.Sprintf("      %s: recorded %q, absent in live call\n", d.Path, d.Expected))
+				case models.DiffKindMissingInMock:
+					sb.WriteString(fmt.Sprintf("      %s: live %q, absent in recording\n", d.Path, d.Actual))
+				case models.DiffKindTypeChanged:
+					sb.WriteString(fmt.Sprintf("      %s: type changed (recorded %s, live %s)\n", d.Path, d.Expected, d.Actual))
+				default:
+					sb.WriteString(fmt.Sprintf("      %s: recorded %q, live %q\n", d.Path, d.Expected, d.Actual))
+				}
+			}
+		} else if uc.Diff != "" {
+			sb.WriteString(fmt.Sprintf("    diff: %s\n", uc.Diff))
+		}
+		if uc.NextSteps != "" {
+			sb.WriteString(fmt.Sprintf("    next steps: %s\n", uc.NextSteps))
+		}
+	}
+	sb.WriteString("\n")
 }
 
 // writerAdapter lets us reuse a bufio.Writer on top of strings.Builder.

--- a/pkg/service/report/unmatched_calls_test.go
+++ b/pkg/service/report/unmatched_calls_test.go
@@ -1,0 +1,56 @@
+package report
+
+import (
+	"strings"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+func TestRenderUnmatchedCalls_StructuredOutput(t *testing.T) {
+	test := models.TestResult{
+		FailureInfo: models.FailureInfo{
+			UnmatchedCalls: []models.UnmatchedCall{
+				{
+					Protocol:       "HTTP",
+					ActualSummary:  "POST /orders",
+					ClosestMock:    "mock-7",
+					MatchPhase:     models.MatchPhaseBody,
+					CandidateCount: 3,
+					NextSteps:      "add noise or re-record",
+					FieldDiffs: []models.MockFieldDiff{
+						{Path: "body.created_at", Kind: models.DiffKindValueChanged, Expected: "1", Actual: "2"},
+						{Path: "header.X-Old", Kind: models.DiffKindMissingInLive, Expected: "v"},
+					},
+				},
+			},
+		},
+	}
+
+	var sb strings.Builder
+	renderUnmatchedCalls(&sb, test)
+	out := sb.String()
+
+	for _, want := range []string{
+		"OUTGOING CALLS WITH NO MATCHING MOCK",
+		"[HTTP] POST /orders",
+		models.MatchPhaseBody,
+		"3 candidate mock(s)",
+		"closest mock: mock-7",
+		"body.created_at",
+		"header.X-Old",
+		"next steps: add noise or re-record",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderUnmatchedCalls_EmptyIsSilent(t *testing.T) {
+	var sb strings.Builder
+	renderUnmatchedCalls(&sb, models.TestResult{})
+	if sb.Len() != 0 {
+		t.Errorf("expected no output for tests without unmatched calls, got %q", sb.String())
+	}
+}

--- a/pkg/service/runner/runner.go
+++ b/pkg/service/runner/runner.go
@@ -376,8 +376,18 @@ func (r *Runner) setupTestSet(parentCtx context.Context, testSetID string, backd
 		outOpts.SchemaNoiseStrict = r.config.Test.SchemaNoiseStrict
 		outOpts.MysqlPorts = r.config.MysqlPorts
 	}
+	noiseCfg := map[string]map[string][]string{}
 	if headerNoise, ok := r.globalNoise["header"]; ok {
-		outOpts.NoiseConfig = map[string]map[string][]string{"header": headerNoise}
+		noiseCfg["header"] = headerNoise
+	}
+	if bodyNoise, ok := r.globalNoise["body"]; ok {
+		// The body bucket participates in HTTP request-body mock matching
+		// (drift-detection exclusion + strict-noise allowance) — same as the
+		// CLI replay path.
+		noiseCfg["body"] = bodyNoise
+	}
+	if len(noiseCfg) > 0 {
+		outOpts.NoiseConfig = noiseCfg
 	}
 	if err := r.instrumentation.MockOutgoing(gCtx, outOpts); err != nil {
 		return nil, fmt.Errorf("mock-outgoing failed: %w", err)

--- a/pkg/service/runner/runner.go
+++ b/pkg/service/runner/runner.go
@@ -381,10 +381,16 @@ func (r *Runner) setupTestSet(parentCtx context.Context, testSetID string, backd
 		noiseCfg["header"] = headerNoise
 	}
 	if bodyNoise, ok := r.globalNoise["body"]; ok {
-		// The body bucket participates in HTTP request-body mock matching
-		// (drift-detection exclusion + strict-noise allowance) — same as the
-		// CLI replay path.
+		// "body" feeds outgoing-payload matchers (e.g. the Pulsar SEND matcher)
+		// and stays the response-assertion bucket — it intentionally does NOT
+		// drive HTTP request-body matching anymore.
 		noiseCfg["body"] = bodyNoise
+	}
+	if reqBodyNoise, ok := r.globalNoise["requestbody"]; ok {
+		// Dedicated HTTP request-body matching noise (drift-detection
+		// exclusion + strict-noise allowance). Separate from "body" so
+		// response-assertion noise can't silently soften request matching.
+		noiseCfg["requestbody"] = reqBodyNoise
 	}
 	if len(noiseCfg) > 0 {
 		outOpts.NoiseConfig = noiseCfg


### PR DESCRIPTION
## Describe the changes that are made

Complete mock-mismatch reporting for the replay flow. This PR targets `main` and is **self-contained**: it carries the unified-reporting foundation (commits from #4271, authorship preserved) because the additions below build directly on it (the `mismatch.Builder`, `MockFieldDiff` model, `JSONFieldDiffs`). If #4271 merges first, this reduces to just the additions.

**Foundation (from #4271):** universal `mismatch.Builder`, noise-vocabulary field diffs, `MatchPhase`/`CandidateCount`, `--schema-noise-strict` flag, `mockdb.PersistMockNoise`, `keploy report` rendering of unmatched calls.

**Added on top:**

**1. Plumbing — the structured report now reaches the user, attributed to the right test, on every exit path.**
Previously `StartErrorDrain` discarded every mock-not-found error (nothing opened a capture window) and the replayer only fetched `GetMockErrors` when `!r.instrument`, so a normal local `keploy test -c …` built the report but never surfaced it.
- `proxy.go`: a **per-test capture window** — `BeginTestErrorCapture` opens a fresh accumulator before each test, the single `StartErrorDrain` goroutine routes each mock-miss into it, and `GetMockErrors` drains-and-closes it. A bounded `pendingMockErrors` FIFO retains pre-window / background misses. A `flushMarker` rendezvous between `GetMockErrors` and the drain guarantees no in-flight miss is lost when the window closes (race-tested under `-race`). `BeginTestErrorCapture` **discards** a never-closed prior window rather than carrying it forward, so a failed fetch can't misattribute one test's misses to the next.
- `service/replay`: `beginTestErrorCapture` before each `SimulateRequest`, and `attachMockErrors` (→ `GetMockErrors`) on **every** test-exit path — the normal result, the early simulation-error / invalid-response returns, the nil-matcher-result / nil-test-case-result branches (which now also persist a failed result), and the **streaming (Phase 2) path** (finalized *after* stream consumption, see below). A miss attaches to the test that caused it and never carries into the next, on all transports.
- **Single owner, single consumer.** The replayer reaches the agent over HTTP in every deployment (native loopback, k8s sidecar, enterprise), so `instrumentation.GetErrorChannel()` is always nil and the legacy `monitorProxyErrors` channel-consumer never fired anywhere. Removed it — and its dead `AddProxyErrorForTest` / `GetFailuresForTestCase` feeders — so the agent's drain goroutine is the **sole** consumer of the error channel and `attachMockErrors` is the **sole** finalizer.

**2. Whole-mock side-by-side diff.**
Render the closest mock vs the live request side-by-side (`EXPECTED MOCK | RECEIVED REQUEST`) with differing lines highlighted and long unchanged runs folded, instead of a one-line cell.
- `models`: `ClosestMockReq`/`ReceivedReq` on `MockMismatchReport` + `UnmatchedCall`.
- `mismatch.Builder.WithRenderedRequests`; HTTP request renderer `http/mismatch_render.go` (JSON pretty-printed, sensitive/obfuscated values redacted).
- `service/replay/utils.go`: `printSideBySideDiff` (LCS align + git-style folding).

**3. Dedicated request-body noise bucket.**
`test.globalNoise.requestbody` for HTTP request-body match noise, decoupled from the response-assertion `body` bucket, so response noise can't silently weaken request matching under `--schema-noise-strict`.

**4. Streaming (SSE / NDJSON / multipart / chunked / binary) mismatch reporting.**
The deferred Phase-2 streaming path now opens the capture window before `SimulateRequest` and finalizes it **after** `CompareHTTPStream` + the post-stream consumed-mock drain — because outgoing mock calls continue while the stream body is consumed, so closing right after headers would drop or misattribute in-stream misses. Streaming-test misses now reach `FailureInfo.UnmatchedCalls` with all fields, same as non-streaming.

Verified end-to-end: local `keploy test` against a sample app, and the **live k8s-proxy flow** (agent builds the report → proxy renders the side-by-side `MOCK MISMATCH` report).

## Links & References

**Closes:** NA

### 🔗 Related PRs
- Supersedes / incorporates #4271 (its commits are included here). Coordinate merge order — if #4271 lands first, rebase drops it to just the additions.
- Cross-repo consumers of the widened report: keploy/api-server#1751 (model), keploy/k8s-proxy#521 (forward to dashboard + `BeginTestErrorCapture` wiring), keploy/enterprise-ui `feat/mock-mismatch-rich-fields` (render).
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [x] 🍕 Feature
- [x] 🐞 Bug Fix
- [x] 🧑‍💻 Code Refactor

## Added e2e test pipeline?
- [x] ✅ yes
- Added a `mock-mismatch` suite (`test_workflow_scripts/golang/mock_mismatch/golang-linux.sh` + a matrix entry in `golang_linux.yml`): records the http-pokeapi sample, mutates the recorded request path so the live request no longer matches any mock on replay, and asserts the **specific** HTTP unmatched-call report surfaces — both the `Mock mismatch: [HTTP] … /api/v2/` console line and a single matching `unmatched_calls` entry in the test-set report YAML.
- Unit coverage also exists for the `mismatch` builder, `JSONFieldDiffs`, the HTTP field-diff/redaction paths, and the capture-window race (`capture_window_test.go`, run under `-race`).

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed
- (`test.globalNoise.requestbody` + the side-by-side output are worth a short docs note as a follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
