### PR TITLE
feat(syncMock): context-keyed per-session mock managers

### DIFF
--- a/pkg/agent/hooks/conn/util.go
+++ b/pkg/agent/hooks/conn/util.go
@@ -191,7 +191,7 @@ func Capture(ctx context.Context, logger *zap.Logger, t chan *models.TestCase, r
 		// the taint flow and stops the go/clear-text-logging false
 		// positives that fire downstream (syncMock.go diag/Info
 		// logs include test_name for ResolveRange traceability).
-		if mgr := syncMock.Get(); mgr != nil { // dumping the test case from mock manager in synchronous mode
+		if mgr := syncMock.GetForContext(ctx); mgr != nil { // dumping the test case from mock manager in synchronous mode
 			mgr.ResolveRange(reqTimeTest, resTimeTest, testName, true, mapping)
 		}
 	}

--- a/pkg/agent/proxy/integrations/generic/encode.go
+++ b/pkg/agent/proxy/integrations/generic/encode.go
@@ -182,7 +182,7 @@ func createGenericMocksAsync(ctx context.Context, logger *zap.Logger, clientCh, 
 				LifetimeDerived: true,
 			},
 		}
-		if mgr := syncMock.Get(); mgr != nil {
+		if mgr := syncMock.GetForContext(ctx); mgr != nil {
 			mgr.AddMock(mock)
 		}
 		genericRequests = nil

--- a/pkg/agent/proxy/integrations/http/http.go
+++ b/pkg/agent/proxy/integrations/http/http.go
@@ -299,10 +299,12 @@ func (h *HTTP) parseFinalHTTP(ctx context.Context, mock *FinalHTTP, destPort uin
 		onMockRecorded(newMock)
 	}
 
-	if mgr := syncMock.Get(); mgr != nil {
+	if mgr := syncMock.GetForContext(ctx); mgr != nil {
 		// Route HTTP mocks through the sync manager. The manager uses its
 		// internal first-request state to decide whether to buffer or forward
-		// mocks for correct time-window based association.
+		// mocks for correct time-window based association. GetForContext picks
+		// the per-session manager when a session key is on ctx (DaemonSet
+		// multi-app), else the global one (sidecar) — unchanged for the latter.
 		mgr.AddMock(newMock)
 		return nil
 	}

--- a/pkg/agent/proxy/integrations/mysql/recorder/record.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record.go
@@ -203,7 +203,7 @@ func recordMock(ctx context.Context, requests []mysql.Request, responses []mysql
 		},
 	}
 
-	if mgr := syncMock.Get(); mgr != nil {
+	if mgr := syncMock.GetForContext(ctx); mgr != nil {
 		mgr.AddMock(mysqlMock)
 		return
 	}

--- a/pkg/agent/proxy/syncMock/context_test.go
+++ b/pkg/agent/proxy/syncMock/context_test.go
@@ -1,0 +1,50 @@
+package manager
+
+import (
+	"context"
+	"testing"
+)
+
+// TestGetForContext_PerSessionIsolation verifies the DaemonSet multi-app path:
+// distinct session keys get distinct managers, the same key is stable, and the
+// no-key path is the global instance (sidecar behaviour unchanged).
+func TestGetForContext_PerSessionIsolation(t *testing.T) {
+	// No key on ctx -> global instance, identical to Get().
+	if GetForContext(context.Background()) != Get() {
+		t.Fatal("no-key GetForContext should return the global instance")
+	}
+	if GetForContext(nil) != Get() { //nolint:staticcheck // explicitly testing nil ctx
+		t.Fatal("nil ctx GetForContext should return the global instance")
+	}
+
+	ctxA := WithSessionKey(context.Background(), "ns-a/app-a/test-set-0")
+	ctxB := WithSessionKey(context.Background(), "ns-b/app-b/test-set-1")
+
+	a1 := GetForContext(ctxA)
+	a2 := GetForContext(ctxA)
+	b1 := GetForContext(ctxB)
+
+	if a1 == nil || b1 == nil {
+		t.Fatal("per-session managers must be non-nil")
+	}
+	if a1 != a2 {
+		t.Error("same session key must return the same manager")
+	}
+	if a1 == b1 {
+		t.Error("different session keys must return different managers")
+	}
+	if a1 == Get() || b1 == Get() {
+		t.Error("per-session managers must not be the global instance")
+	}
+
+	// Teardown removes the per-session manager; a later lookup makes a fresh one.
+	DeleteForContext(ctxA)
+	if GetForContext(ctxA) == a1 {
+		t.Error("after DeleteForContext, a new manager should be created")
+	}
+
+	// WithSessionKey("") is a no-op -> global instance.
+	if GetForContext(WithSessionKey(context.Background(), "")) != Get() {
+		t.Error("empty key must fall back to the global instance")
+	}
+}

--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"context"
 	"math/rand"
 	"sync"
 	"sync/atomic"
@@ -96,15 +97,79 @@ type SyncMockManager struct {
 	logger   *zap.Logger
 }
 
-// Global instance is initialized at package load time
-var instance = &SyncMockManager{
-	buffer:       make([]*models.Mock, 0, defaultMockBufferCapacity),
-	firstReqSeen: false,
+// newManager builds a fresh manager with the default buffer.
+func newManager() *SyncMockManager {
+	return &SyncMockManager{
+		buffer:       make([]*models.Mock, 0, defaultMockBufferCapacity),
+		firstReqSeen: false,
+	}
 }
 
-// Get returns the global manager.
+// Global instance is initialized at package load time. It is the manager
+// returned to callers with no session key — i.e. the sidecar/single-app path,
+// whose behaviour is byte-for-byte unchanged.
+var instance = newManager()
+
+// registry holds per-session managers keyed by an opaque session key. In the
+// DaemonSet (one agent process, many concurrent recordings) each recording
+// session gets its OWN manager — its own buffer, time windows, dedup state and
+// output channel — so two apps recording on one node never share or overwrite
+// each other's mock stream. Callers without a session key keep using the
+// global `instance`, so nothing changes for the sidecar path.
+var registry sync.Map // string -> *SyncMockManager
+
+// sessionKeyCtx is the private context key carrying the per-session manager key.
+type sessionKeyCtxType struct{}
+
+var sessionKeyCtx = sessionKeyCtxType{}
+
+// WithSessionKey returns a ctx that routes syncMock lookups to the per-session
+// manager for key. An empty key is a no-op (callers fall back to the global
+// instance), so this is safe to call unconditionally.
+func WithSessionKey(ctx context.Context, key string) context.Context {
+	if ctx == nil || key == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, sessionKeyCtx, key)
+}
+
+// SessionKeyFromContext extracts the per-session key, or "" when none is set.
+func SessionKeyFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if v, ok := ctx.Value(sessionKeyCtx).(string); ok {
+		return v
+	}
+	return ""
+}
+
+// Get returns the global manager (the no-session-key path).
 func Get() *SyncMockManager {
 	return instance
+}
+
+// GetForContext returns the per-session manager for the session key carried on
+// ctx, lazily creating it. With no key on ctx it returns the global instance,
+// so existing call sites are unchanged unless a key has been threaded in.
+func GetForContext(ctx context.Context) *SyncMockManager {
+	key := SessionKeyFromContext(ctx)
+	if key == "" {
+		return instance
+	}
+	if v, ok := registry.Load(key); ok {
+		return v.(*SyncMockManager)
+	}
+	v, _ := registry.LoadOrStore(key, newManager())
+	return v.(*SyncMockManager)
+}
+
+// DeleteForContext removes a per-session manager (on session teardown) so the
+// registry doesn't accumulate. No-op for the global instance.
+func DeleteForContext(ctx context.Context) {
+	if key := SessionKeyFromContext(ctx); key != "" {
+		registry.Delete(key)
+	}
 }
 
 // SetOutputChannel plugs an outgoing mock channel into the manager.


### PR DESCRIPTION
### What
Make the `syncMock` mock manager **context-keyed** so a single agent process can record multiple apps without their mocks sharing one global manager.

### Why
Every protocol recorder emits mocks through the package-global `syncMock.Get()` — one buffer, one time-window state, one output channel. Correct for the sidecar (one process per app), but it breaks the enterprise **DaemonSet**, where one agent records many apps concurrently: their mocks last-writer-wins onto one manager.

### How
1. `GetForContext(ctx)` returns a per-session `*SyncMockManager` when a session key is on ctx (`WithSessionKey`), else the existing global instance. **Backward-compatible by construction** — callers with no key are byte-for-byte unchanged (the sidecar path).
2. Per-session managers live in a registry keyed by the opaque session key; `DeleteForContext` drops one on teardown.
3. Route the record-emit sites that have a request ctx through `GetForContext`: `http`, `generic` (covers Mongo/Postgres/Redis/…), `mysql`, and the synchronous `ResolveRange` in `conn.Capture`. DNS (`recordDNSMock`) and the V2 supervisor (`emitMockCore`) have no ctx and stay on the global manager.

### Tests
- Existing syncMock + http record tests pass → the global (sidecar) path is unchanged.
- New `TestGetForContext_PerSessionIsolation`: distinct keys → distinct managers; same key stable; no-key → global; teardown.

### Consumer
The enterprise DaemonSet agent threads `namespace/deployment/testSetID` as the session key and binds each session's manager output to its own mock sink. This PR is the **prerequisite** for per-session mock isolation there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)