### PR TITLE
feat(agent): multi-tenant foundation — per-app session key + AppContext/AppRegistry

### DIFF
--- a/pkg/agent/appkey.go
+++ b/pkg/agent/appkey.go
@@ -1,0 +1,57 @@
+package agent
+
+import "context"
+
+// AppKey is the per-application (per-recording-session) identity that keys all
+// per-app state in a multi-tenant agent. One agent process can serve many
+// applications concurrently; every piece of state that used to be a process
+// singleton (proxy session, mock manager, syncMock output, dedup, mode, etc.)
+// is partitioned by this key.
+//
+// It is deliberately an opaque string so the two attribution sources can share
+// one identity type:
+//   - sidecar/native: derived from the app (e.g. app name or a hash of
+//     appName+clientPID).
+//   - daemonset: the per-session key the controller resolves from a target's
+//     {namespace, deployment, testSetID}.
+//
+// The zero value (DefaultAppKey) is the single-tenant / sidecar fallback: when
+// no key is present on the context, callers operate on the default app so the
+// existing one-process-one-app behaviour is preserved byte-for-byte.
+type AppKey string
+
+// DefaultAppKey is the fallback key used when no per-app key is supplied. It
+// preserves the historical single-app behaviour: all state lands under one
+// default AppContext.
+const DefaultAppKey AppKey = ""
+
+type appKeyCtxKey struct{}
+
+// WithAppKey returns a copy of ctx carrying the per-app key. Producers (HTTP
+// route middleware on the control path, the connection router on the data
+// path) stamp the key; consumers deep in the proxy/parsers read it back with
+// AppKeyFromContext without having to thread an extra parameter through every
+// call.
+func WithAppKey(ctx context.Context, key AppKey) context.Context {
+	return context.WithValue(ctx, appKeyCtxKey{}, key)
+}
+
+// AppKeyFromContext returns the per-app key on ctx and whether one was set.
+// When ok is false the caller should use DefaultAppKey (single-tenant path).
+func AppKeyFromContext(ctx context.Context) (AppKey, bool) {
+	if ctx == nil {
+		return DefaultAppKey, false
+	}
+	key, ok := ctx.Value(appKeyCtxKey{}).(AppKey)
+	return key, ok
+}
+
+// AppKeyOrDefault is the convenience accessor: returns the per-app key on ctx
+// or DefaultAppKey when none is present.
+func AppKeyOrDefault(ctx context.Context) AppKey {
+	key, ok := AppKeyFromContext(ctx)
+	if !ok {
+		return DefaultAppKey
+	}
+	return key
+}

--- a/pkg/agent/appkey_test.go
+++ b/pkg/agent/appkey_test.go
@@ -1,0 +1,32 @@
+package agent
+
+import (
+	"context"
+	"testing"
+)
+
+func TestAppKeyContextRoundTrip(t *testing.T) {
+	ctx := WithAppKey(context.Background(), AppKey("ns/dep/ts-1"))
+	got, ok := AppKeyFromContext(ctx)
+	if !ok {
+		t.Fatalf("expected key present on ctx")
+	}
+	if got != AppKey("ns/dep/ts-1") {
+		t.Fatalf("got %q, want %q", got, "ns/dep/ts-1")
+	}
+	if AppKeyOrDefault(ctx) != AppKey("ns/dep/ts-1") {
+		t.Fatalf("AppKeyOrDefault mismatch")
+	}
+}
+
+func TestAppKeyDefaultWhenAbsent(t *testing.T) {
+	if got, ok := AppKeyFromContext(context.Background()); ok || got != DefaultAppKey {
+		t.Fatalf("expected (DefaultAppKey, false), got (%q, %v)", got, ok)
+	}
+	if AppKeyOrDefault(context.Background()) != DefaultAppKey {
+		t.Fatalf("expected DefaultAppKey from empty ctx")
+	}
+	if got, ok := AppKeyFromContext(nil); ok || got != DefaultAppKey { //nolint:staticcheck // nil ctx is a guarded edge
+		t.Fatalf("expected (DefaultAppKey, false) for nil ctx, got (%q, %v)", got, ok)
+	}
+}

--- a/pkg/agent/hooks/linux/comm.go
+++ b/pkg/agent/hooks/linux/comm.go
@@ -31,6 +31,10 @@ func (h *Hooks) Get(_ context.Context, srcPort uint16) (*agent.NetworkAddress, e
 		IPv4Addr: d.DestIP4,
 		IPv6Addr: d.DestIP6,
 		Port:     d.DestPort,
+		// Surface the originating process TGID so the proxy can attribute the
+		// connection to an AppContext (multi-tenancy). The kernel already
+		// records it in the redirect map; it was previously dropped here.
+		Pid: d.KernelPid,
 	}, nil
 }
 

--- a/pkg/agent/proxy/appcontext.go
+++ b/pkg/agent/proxy/appcontext.go
@@ -1,0 +1,284 @@
+package proxy
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+
+	expirable "github.com/hashicorp/golang-lru/v2/expirable"
+	"go.keploy.io/server/v3/pkg/agent"
+	syncMock "go.keploy.io/server/v3/pkg/agent/proxy/syncMock"
+	"go.uber.org/zap"
+)
+
+// AppContext owns every piece of state that, in the single-app proxy, lived as
+// a process singleton on Proxy. One AppContext exists per application
+// (agent.AppKey) so that a single agent process can record/replay many apps
+// concurrently without cross-tenant interference.
+//
+// This is the skeleton (issue #4275, phase 2): the struct + registry + PID
+// attribution. Wiring the proxy hot path onto it lands in a later phase; until
+// then Proxy keeps its own fields and the DefaultAppKey AppContext mirrors the
+// historical single-app behaviour.
+type AppContext struct {
+	logger *zap.Logger
+
+	// Key is the per-app identity; RootPID is the app's process-tree root
+	// used for /proc-ancestry attribution on the native path.
+	Key     agent.AppKey
+	RootPID uint32
+
+	// session + mockManager: the per-app record/replay state. Guarded by
+	// sessionMu, mirroring Proxy.{sessionMu,session,mockManager}.
+	sessionMu   sync.RWMutex
+	session     *agent.Session
+	mockManager *MockManager
+
+	// errChannel + activeTestErrors: per-app mock-not-found error plane.
+	errChannel       chan error
+	activeTestErrors atomic.Pointer[testErrorAccumulator]
+	errDrainOnce     sync.Once
+
+	// dnsCache + recordedDNSMocks ("static-dedup" for DNS): per-app.
+	dnsCache         *expirable.LRU[string, dnsCacheEntry]
+	recordedDNSMocks *expirable.LRU[string, bool]
+
+	// isGracefulShutdown + opportunisticTLSIntercept: per-app flags.
+	isGracefulShutdown        atomic.Bool
+	opportunisticTLSIntercept bool
+
+	// pcap lifecycle, per-app.
+	pcapMu          sync.Mutex
+	pcapCancel      context.CancelFunc
+	pcapDone        chan struct{}
+	pcapBroadcaster *pcapBroadcaster
+
+	// syncMgr is the per-app mock-window manager. Nil here in the skeleton;
+	// wired to syncMock.New() once syncMock is de-globalized (phase 3).
+	syncMgr *syncMock.SyncMockManager
+}
+
+// newAppContext builds an AppContext with its per-app caches/channels
+// initialised the same way Proxy.New initialises the singletons today.
+func newAppContext(logger *zap.Logger, key agent.AppKey) *AppContext {
+	return &AppContext{
+		logger:           logger,
+		Key:              key,
+		errChannel:       make(chan error, 100),
+		dnsCache:         newDNSCache(),
+		recordedDNSMocks: newRecordedDNSMocksCache(),
+	}
+}
+
+func (a *AppContext) getSession() *agent.Session {
+	a.sessionMu.RLock()
+	defer a.sessionMu.RUnlock()
+	return a.session
+}
+
+func (a *AppContext) setSession(s *agent.Session) {
+	a.sessionMu.Lock()
+	defer a.sessionMu.Unlock()
+	a.session = s
+}
+
+func (a *AppContext) getMockManager() *MockManager {
+	a.sessionMu.RLock()
+	defer a.sessionMu.RUnlock()
+	return a.mockManager
+}
+
+// setMockManager swaps in a new manager and Close()s the previous one outside
+// the lock — Close() synchronises with the manager's own workers and must not
+// run under sessionMu (same contract as Proxy.setMockManager).
+func (a *AppContext) setMockManager(m *MockManager) {
+	a.sessionMu.Lock()
+	prev := a.mockManager
+	a.mockManager = m
+	a.sessionMu.Unlock()
+	if prev != nil {
+		prev.Close()
+	}
+}
+
+// resetRecordedDNSMocks clears the per-app DNS dedup tracker for a fresh
+// recording session.
+func (a *AppContext) resetRecordedDNSMocks() {
+	a.recordedDNSMocks = newRecordedDNSMocksCache()
+}
+
+// PIDResolver maps an originating kernel TGID to the owning app key. The
+// attribution source is pluggable: the native path uses /proc ancestry
+// (resolveAppByProcAncestry); the daemonset supplies an authoritative
+// resolver backed by its controller's PID→session map.
+type PIDResolver func(kernelPid uint32) (agent.AppKey, bool)
+
+// AppRegistry holds the live AppContexts keyed by AppKey and resolves an
+// intercepted connection (by its originating kernel PID) to an app.
+type AppRegistry struct {
+	logger *zap.Logger
+
+	apps  sync.Map // agent.AppKey -> *AppContext
+	byPID sync.Map // uint32 (kernelPid) -> agent.AppKey  (attribution cache)
+
+	// resolver turns a kernelPid into an AppKey when it is not yet cached.
+	// When nil, Resolve only consults the cache + DefaultAppKey.
+	resolverMu sync.RWMutex
+	resolver   PIDResolver
+}
+
+func NewAppRegistry(logger *zap.Logger) *AppRegistry {
+	r := &AppRegistry{logger: logger}
+	// Default native attribution: /proc ancestry. The daemonset overrides
+	// this with an authoritative controller-backed resolver via SetResolver.
+	r.resolver = func(kernelPid uint32) (agent.AppKey, bool) {
+		return resolveAppByProcAncestry(r, kernelPid)
+	}
+	return r
+}
+
+// SetResolver installs the pluggable PID→app attribution function.
+func (r *AppRegistry) SetResolver(res PIDResolver) {
+	r.resolverMu.Lock()
+	r.resolver = res
+	r.resolverMu.Unlock()
+}
+
+// Get returns the AppContext for key, if present.
+func (r *AppRegistry) Get(key agent.AppKey) (*AppContext, bool) {
+	v, ok := r.apps.Load(key)
+	if !ok {
+		return nil, false
+	}
+	return v.(*AppContext), true
+}
+
+// GetOrCreate returns the AppContext for key, creating it on first use.
+func (r *AppRegistry) GetOrCreate(key agent.AppKey) *AppContext {
+	if v, ok := r.apps.Load(key); ok {
+		return v.(*AppContext)
+	}
+	ac := newAppContext(r.logger, key)
+	actual, loaded := r.apps.LoadOrStore(key, ac)
+	if loaded {
+		return actual.(*AppContext)
+	}
+	return ac
+}
+
+// RegisterPID seeds the attribution cache so an app's RootPID (and any TGIDs
+// the caller already knows) resolve to its key without a /proc walk.
+func (r *AppRegistry) RegisterPID(kernelPid uint32, key agent.AppKey) {
+	r.byPID.Store(kernelPid, key)
+}
+
+// Delete tears down an app: evicts its cache entries and removes it from the
+// registry. The caller is responsible for closing per-app resources
+// (mockManager, syncMgr, channels) before/after — wired in a later phase.
+func (r *AppRegistry) Delete(key agent.AppKey) {
+	r.apps.Delete(key)
+	r.byPID.Range(func(k, v any) bool {
+		if v.(agent.AppKey) == key {
+			r.byPID.Delete(k)
+		}
+		return true
+	})
+}
+
+// Resolve maps a kernel PID to its owning app key: cache first, then the
+// pluggable resolver (whose result is cached), else DefaultAppKey.
+func (r *AppRegistry) Resolve(kernelPid uint32) agent.AppKey {
+	if v, ok := r.byPID.Load(kernelPid); ok {
+		return v.(agent.AppKey)
+	}
+	r.resolverMu.RLock()
+	res := r.resolver
+	r.resolverMu.RUnlock()
+	if res != nil {
+		if key, ok := res(kernelPid); ok {
+			r.byPID.Store(kernelPid, key)
+			return key
+		}
+	}
+	return agent.DefaultAppKey
+}
+
+// resolveAppByProcAncestry is the default native attribution: walk the /proc
+// parent chain of kernelPid and return the key of the first registered app
+// whose RootPID is an ancestor. Used to build a PIDResolver over an
+// AppRegistry on the sidecar/native path.
+func resolveAppByProcAncestry(reg *AppRegistry, kernelPid uint32) (agent.AppKey, bool) {
+	// Build RootPID -> key once per call (apps are few).
+	roots := map[uint32]agent.AppKey{}
+	reg.apps.Range(func(_, v any) bool {
+		ac := v.(*AppContext)
+		if ac.RootPID != 0 {
+			roots[ac.RootPID] = ac.Key
+		}
+		return true
+	})
+	if len(roots) == 0 {
+		return agent.DefaultAppKey, false
+	}
+	pid := kernelPid
+	for i := 0; i < 64 && pid > 1; i++ {
+		if key, ok := roots[pid]; ok {
+			return key, true
+		}
+		ppid, ok := readParentPID(pid)
+		if !ok {
+			break
+		}
+		pid = ppid
+	}
+	return agent.DefaultAppKey, false
+}
+
+// readParentPID reads PPid from /proc/<pid>/status. Returns false when the
+// process is gone or the field is unreadable.
+func readParentPID(pid uint32) (uint32, bool) {
+	data, err := os.ReadFile("/proc/" + strconv.FormatUint(uint64(pid), 10) + "/status")
+	if err != nil {
+		return 0, false
+	}
+	const key = "PPid:"
+	s := string(data)
+	idx := indexLine(s, key)
+	if idx < 0 {
+		return 0, false
+	}
+	field := s[idx+len(key):]
+	// trim leading spaces/tabs, read digits up to newline
+	j := 0
+	for j < len(field) && (field[j] == ' ' || field[j] == '\t') {
+		j++
+	}
+	start := j
+	for j < len(field) && field[j] >= '0' && field[j] <= '9' {
+		j++
+	}
+	if start == j {
+		return 0, false
+	}
+	ppid, err := strconv.ParseUint(field[start:j], 10, 32)
+	if err != nil {
+		return 0, false
+	}
+	return uint32(ppid), true
+}
+
+// indexLine returns the byte index of prefix at the start of any line in s, or
+// -1. Avoids a regexp/strings.Split allocation on the attribution hot path.
+func indexLine(s, prefix string) int {
+	if len(s) >= len(prefix) && s[:len(prefix)] == prefix {
+		return 0
+	}
+	for i := 0; i+len(prefix) < len(s); i++ {
+		if s[i] == '\n' && s[i+1:i+1+len(prefix)] == prefix {
+			return i + 1
+		}
+	}
+	return -1
+}

--- a/pkg/agent/proxy/appcontext_test.go
+++ b/pkg/agent/proxy/appcontext_test.go
@@ -1,0 +1,68 @@
+package proxy
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/agent"
+	"go.uber.org/zap"
+)
+
+func TestAppRegistryGetOrCreateIsIdempotent(t *testing.T) {
+	r := NewAppRegistry(zap.NewNop())
+	a := r.GetOrCreate(agent.AppKey("app-a"))
+	b := r.GetOrCreate(agent.AppKey("app-a"))
+	if a != b {
+		t.Fatalf("GetOrCreate returned distinct AppContexts for the same key")
+	}
+	if got, ok := r.Get(agent.AppKey("app-a")); !ok || got != a {
+		t.Fatalf("Get did not return the created AppContext")
+	}
+	if a.errChannel == nil || a.dnsCache == nil || a.recordedDNSMocks == nil {
+		t.Fatalf("AppContext caches/channels not initialised")
+	}
+}
+
+func TestAppRegistryResolveUsesCacheThenResolver(t *testing.T) {
+	r := NewAppRegistry(zap.NewNop())
+
+	// No cache entry and the default /proc resolver finds no registered app
+	// → DefaultAppKey.
+	if got := r.Resolve(424242); got != agent.DefaultAppKey {
+		t.Fatalf("expected DefaultAppKey for unknown pid, got %q", got)
+	}
+
+	// A custom resolver is consulted on a miss and its result is cached.
+	calls := 0
+	r.SetResolver(func(pid uint32) (agent.AppKey, bool) {
+		calls++
+		if pid == 100 {
+			return agent.AppKey("app-x"), true
+		}
+		return agent.DefaultAppKey, false
+	})
+	if got := r.Resolve(100); got != agent.AppKey("app-x") {
+		t.Fatalf("resolver result not used, got %q", got)
+	}
+	if got := r.Resolve(100); got != agent.AppKey("app-x") {
+		t.Fatalf("cached result not used, got %q", got)
+	}
+	if calls != 1 {
+		t.Fatalf("resolver should be hit once (then cached), hit %d times", calls)
+	}
+}
+
+func TestAppRegistryRegisterAndDeleteEvictsPIDCache(t *testing.T) {
+	r := NewAppRegistry(zap.NewNop())
+	r.GetOrCreate(agent.AppKey("app-a"))
+	r.RegisterPID(777, agent.AppKey("app-a"))
+	if got := r.Resolve(777); got != agent.AppKey("app-a") {
+		t.Fatalf("RegisterPID not honoured by Resolve, got %q", got)
+	}
+	r.Delete(agent.AppKey("app-a"))
+	if _, ok := r.Get(agent.AppKey("app-a")); ok {
+		t.Fatalf("Delete did not remove the AppContext")
+	}
+	if got := r.Resolve(777); got != agent.DefaultAppKey {
+		t.Fatalf("Delete did not evict the PID cache entry, got %q", got)
+	}
+}

--- a/pkg/agent/service.go
+++ b/pkg/agent/service.go
@@ -136,6 +136,12 @@ type NetworkAddress struct {
 	IPv4Addr uint32
 	IPv6Addr [4]uint32
 	Port     uint32
+	// Pid is the kernel TGID of the process that originated the intercepted
+	// connection, surfaced from the eBPF redirect map's DestInfo.KernelPid.
+	// It is the attribution key for multi-tenancy: the proxy resolves which
+	// AppContext an accepted connection belongs to from this PID. Zero when
+	// the hooks implementation does not populate it (non-Linux, or no entry).
+	Pid uint32
 }
 
 // Sessions provides a thread-safe store for Session objects, keyed by ID.


### PR DESCRIPTION
## What

First slice of the multi-tenant keploy-agent work (#4275): the **user-space foundation** that lets one agent process serve many applications, keyed by an opaque per-app session key. **Skeleton only — behaviour-neutral.** Not yet wired into the proxy hot path; `DefaultAppKey` reproduces today's single-app behaviour exactly.

## Changes

- **`agent.AppKey`** + `WithAppKey` / `AppKeyFromContext` / `AppKeyOrDefault` context helpers (`pkg/agent/appkey.go`). Opaque string key so the native (`/proc`) and daemonset (controller) attribution sources share one identity type. `DefaultAppKey` = single-tenant fallback.
- **Surface the originating kernel TGID** on `agent.NetworkAddress.Pid`, populated from `DestInfo.KernelPid` in `hooks/linux/comm.go` (it was previously dropped). This is the attribution key for routing a connection to an app.
- **`proxy.AppContext`** — owns the per-app state that is a `Proxy` singleton today: session, mockManager, dnsCache, `recordedDNSMocks` (DNS static-dedup), errChannel, activeTestErrors, graceful-shutdown flag, pcap lifecycle, and the per-app syncMock manager slot.
- **`proxy.AppRegistry`** — `AppKey → AppContext` store + a pluggable `PIDResolver` (default `/proc`-ancestry attribution for the native path; the daemonset overrides with an authoritative resolver) backed by a `byPID` cache.

## Tests

- `appkey_test.go` — context round-trip + default-when-absent + nil-ctx guard.
- `appcontext_test.go` — registry `GetOrCreate` idempotency, `Resolve` cache-then-resolver (resolver hit once), `Delete` evicts the PID cache.

## Scope / follow-ups (tracked in #4275)

De-globalize `syncMock`; thread the key through the proxy hot path (`Record/Mock/SetMocks/...` + `handleConnection`); per-app `clientMocks`/`tcChan`/routes middleware in the service; client `X-Keploy-App-Id` + register handshake. Enterprise per-feature isolation and the daemonset bridge are separate.

Draft until the dependent slices land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
