### PR TITLE
feat(syncMock): New() + context-carried per-app managers

### DIFF
--- a/pkg/agent/proxy/syncMock/context.go
+++ b/pkg/agent/proxy/syncMock/context.go
@@ -1,0 +1,44 @@
+package manager
+
+import (
+	"context"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// New constructs a fresh, independent SyncMockManager. In a multi-tenant agent
+// each application owns its own manager (its own mock buffer, output channel,
+// firstReqSeen boundary and resolved-window ring) so one app's recording can
+// never bleed into another's. The process-global singleton (Get) is now just
+// New() called once at package load — the single-tenant / sidecar fallback.
+func New() *SyncMockManager {
+	return &SyncMockManager{
+		buffer:       make([]*models.Mock, 0, defaultMockBufferCapacity),
+		firstReqSeen: false,
+	}
+}
+
+type managerCtxKey struct{}
+
+// NewContext returns a copy of ctx carrying the per-app SyncMockManager. The
+// connection router stamps the owning app's manager onto the context before
+// dispatching to the protocol parsers; the parsers then resolve it back with
+// FromContext when emitting mocks, without threading the manager through every
+// RecordOutgoing signature.
+func NewContext(ctx context.Context, m *SyncMockManager) context.Context {
+	return context.WithValue(ctx, managerCtxKey{}, m)
+}
+
+// FromContext returns the per-app SyncMockManager carried on ctx, or the
+// process-global instance when none is present. The fallback makes the
+// migration safe and behaviour-neutral: an emit site switched from Get() to
+// FromContext(ctx) resolves to exactly the global manager until a per-app
+// manager is actually stamped onto the context (sidecar / no-key path).
+func FromContext(ctx context.Context) *SyncMockManager {
+	if ctx != nil {
+		if m, ok := ctx.Value(managerCtxKey{}).(*SyncMockManager); ok && m != nil {
+			return m
+		}
+	}
+	return instance
+}

--- a/pkg/agent/proxy/syncMock/context_test.go
+++ b/pkg/agent/proxy/syncMock/context_test.go
@@ -1,0 +1,41 @@
+package manager
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewReturnsIndependentManagers(t *testing.T) {
+	a := New()
+	b := New()
+	if a == b {
+		t.Fatalf("New must return distinct managers")
+	}
+	if a == instance || b == instance {
+		t.Fatalf("New must not return the global instance")
+	}
+	if a.buffer == nil {
+		t.Fatalf("New must initialise the buffer")
+	}
+}
+
+func TestFromContextFallsBackToGlobal(t *testing.T) {
+	if FromContext(context.Background()) != instance {
+		t.Fatalf("FromContext with no manager must fall back to the global instance")
+	}
+	var nilCtx context.Context // exercise the guarded nil-ctx edge
+	if FromContext(nilCtx) != instance {
+		t.Fatalf("FromContext(nil) must fall back to the global instance")
+	}
+}
+
+func TestFromContextReturnsStampedManager(t *testing.T) {
+	m := New()
+	ctx := NewContext(context.Background(), m)
+	if FromContext(ctx) != m {
+		t.Fatalf("FromContext must return the manager stamped by NewContext")
+	}
+	if FromContext(ctx) == instance {
+		t.Fatalf("FromContext must not fall back when a manager is present")
+	}
+}

--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -96,13 +96,14 @@ type SyncMockManager struct {
 	logger   *zap.Logger
 }
 
-// Global instance is initialized at package load time
-var instance = &SyncMockManager{
-	buffer:       make([]*models.Mock, 0, defaultMockBufferCapacity),
-	firstReqSeen: false,
-}
+// Global instance is initialized at package load time. It is the
+// single-tenant / sidecar fallback returned by Get() and by FromContext()
+// when no per-app manager is on the context. Built via New() so there is one
+// construction path.
+var instance = New()
 
-// Get returns the global manager.
+// Get returns the global manager (single-tenant fallback). Prefer
+// FromContext(ctx) on the data path so per-app managers are honoured.
 func Get() *SyncMockManager {
 	return instance
 }


### PR DESCRIPTION
## What

Second slice of multi-tenant keploy-agent (#4275). De-globalizes `syncMock` so each application can own an independent mock-window manager instead of sharing the single process singleton. **Mechanism only — behaviour-neutral.**

Stacked on #4276 (base = `feat/multi-tenant-agent-userspace`).

## Changes

- **`New()`** constructs a fresh, independent `SyncMockManager` (own buffer, output channel, `firstReqSeen` boundary, resolved-window ring). The package global is now `New()` called once at load — the single-tenant / sidecar fallback.
- **`NewContext(ctx, m)` / `FromContext(ctx)`** carry the per-app manager on the context. The connection router will stamp the owning app's manager; parsers resolve it back when emitting mocks without threading it through every `RecordOutgoing` signature.
- `FromContext` **falls back to the global `instance`** when no manager is stamped, so migrating an emit site from `Get()` to `FromContext(ctx)` is behaviour-neutral until a per-app manager is actually present.

## Tests

`context_test.go` — `New()` returns distinct managers (not the global); `FromContext` falls back to the global with no/nil ctx and returns the stamped manager when present.

## Follow-up (same epic)

Per-app manager creation in `AppContext` + migrating the emit call sites (`http`, `mysql`, `generic`, `dns`, `supervisor`, `incoming`, `conn`) to `FromContext(ctx)` land with the proxy hot-path wiring slice. Per-app `DedupQueue` moves onto the manager there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
