### PR TITLE
feat(proxy): per-app session + mockManager via request context

### DIFF
--- a/pkg/agent/proxy/dns.go
+++ b/pkg/agent/proxy/dns.go
@@ -166,7 +166,10 @@ func (p *Proxy) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	msg := new(dns.Msg)
 	msg.SetReply(r)
 
-	session := p.getSession()
+	// The DNS server is shared infrastructure (one listener for the whole
+	// node) with no per-connection app key, so resolve the default app.
+	// Per-app DNS attribution is a separate, deferred concern.
+	session := p.getSession(context.Background())
 	mode := models.GetMode()
 	mockingEnabled := true
 	if session != nil {
@@ -429,7 +432,8 @@ func (p *Proxy) defaultDNSResponse(question dns.Question) dnsCacheEntry {
 }
 
 func (p *Proxy) getMockedDNSResponse(question dns.Question) (dnsCacheEntry, bool) {
-	mgr := p.getMockManager()
+	// Shared DNS path → default app (see ServeDNS).
+	mgr := p.getMockManager(context.Background())
 	if mgr == nil {
 		return dnsCacheEntry{}, false
 	}

--- a/pkg/agent/proxy/dns_forward_test.go
+++ b/pkg/agent/proxy/dns_forward_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
+	"go.keploy.io/server/v3/pkg/agent"
 	"go.keploy.io/server/v3/pkg/models"
 	"go.uber.org/zap"
 )
@@ -84,6 +85,7 @@ func newProxyWithUpstream(t *testing.T, addr string, timeout time.Duration) *Pro
 		dnsForwardTimeout:  timeout,
 		dnsCache:           newDNSCache(),
 		recordedDNSMocks:   newRecordedDNSMocksCache(),
+		apps:               NewAppRegistry(zap.NewNop()),
 	}
 }
 
@@ -229,7 +231,7 @@ func TestServeDNS_LocalMockHit_NoForward(t *testing.T) {
 			},
 		},
 	}})
-	p.mockManager = mgr
+	p.apps.GetOrCreate(agent.DefaultAppKey).mockManager = mgr
 
 	q := dns.Question{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
 	resp, mocked := p.getMockedDNSResponse(q)
@@ -288,7 +290,7 @@ func TestResolveUncachedDNSResponse_TestMode_UpstreamForwardSuccess(t *testing.T
 	// Empty mock manager — every query misses locally.
 	emptyMgr := NewMockManager(nil, nil, zap.NewNop())
 	t.Cleanup(emptyMgr.Close)
-	p.mockManager = emptyMgr
+	p.apps.GetOrCreate(agent.DefaultAppKey).mockManager = emptyMgr
 
 	q := dns.Question{Name: "mysql.sap-demo.svc.cluster.local.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
 	entry := p.resolveUncachedDNSResponse(q, models.MODE_TEST, true, time.Now(), nil)
@@ -339,7 +341,7 @@ func TestResolveUncachedDNSResponse_TestMode_UpstreamTimeoutFallback(t *testing.
 	p := newProxyWithUpstream(t, addr, 80*time.Millisecond)
 	emptyMgr := NewMockManager(nil, nil, zap.NewNop())
 	t.Cleanup(emptyMgr.Close)
-	p.mockManager = emptyMgr
+	p.apps.GetOrCreate(agent.DefaultAppKey).mockManager = emptyMgr
 
 	q := dns.Question{Name: "unreachable.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
 	entry := p.resolveUncachedDNSResponse(q, models.MODE_TEST, true, time.Now(), nil)
@@ -397,7 +399,7 @@ func TestResolveUncachedDNSResponse_TestMode_UpstreamNXDOMAIN_FallsBackToProxyIP
 	p := newProxyWithUpstream(t, addr, 2*time.Second)
 	emptyMgr := NewMockManager(nil, nil, zap.NewNop())
 	t.Cleanup(emptyMgr.Close)
-	p.mockManager = emptyMgr
+	p.apps.GetOrCreate(agent.DefaultAppKey).mockManager = emptyMgr
 
 	// "localstack" is the bare service name from the issue — no FQDN,
 	// so Docker DNS returns NXDOMAIN for it.
@@ -459,7 +461,7 @@ func TestResolveUncachedDNSResponse_TestMode_UpstreamSuccessPassesThrough(t *tes
 	p := newProxyWithUpstream(t, addr, 2*time.Second)
 	emptyMgr := NewMockManager(nil, nil, zap.NewNop())
 	t.Cleanup(emptyMgr.Close)
-	p.mockManager = emptyMgr
+	p.apps.GetOrCreate(agent.DefaultAppKey).mockManager = emptyMgr
 
 	q := dns.Question{Name: "mysql.sap-demo.svc.cluster.local.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
 	entry := p.resolveUncachedDNSResponse(q, models.MODE_TEST, true, time.Now(), nil)

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -131,12 +131,15 @@ type Proxy struct {
 	// errChannel from filling up with background noise (OTel, health checks).
 	activeTestErrors atomic.Pointer[testErrorAccumulator]
 	errDrainOnce     sync.Once
-	// session holds the single active session for this proxy.
-	// Previously this was a sync.Map keyed by appID (always 0), which is
-	// no longer needed since the proxy serves a single client-app.
-	sessionMu   sync.RWMutex
-	session     *agent.Session
-	mockManager *MockManager
+	// apps holds the per-application state (session + mockManager today;
+	// more per-app state migrates here incrementally) keyed by agent.AppKey
+	// so one proxy process can record/replay many apps concurrently. The
+	// control plane resolves the app from the request context
+	// (agent.AppKeyFromContext, stamped by the HTTP route middleware); the
+	// data plane (handleConnection) resolves it from the originating kernel
+	// PID via apps.Resolve. The DefaultAppKey AppContext reproduces the
+	// historical single-app behaviour byte-for-byte.
+	apps *AppRegistry
 
 	synchronous bool
 
@@ -632,6 +635,7 @@ func New(logger *zap.Logger, info agent.DestInfo, opts *config.Config) *Proxy {
 		ipMutex:                   &sync.Mutex{},
 		connMutex:                 &sync.Mutex{},
 		DestInfo:                  info,
+		apps:                      NewAppRegistry(logger),
 		clientClose:               make(chan bool, 1),
 		Integrations:              make(map[integrations.IntegrationType]integrations.Integrations),
 		GlobalPassthrough:         opts.Agent.GlobalPassthrough,
@@ -743,23 +747,28 @@ func (p *Proxy) buildRecordSession(
 	}
 }
 
-// getSession returns the current session in a thread-safe manner.
-func (p *Proxy) getSession() *agent.Session {
-	p.sessionMu.RLock()
-	defer p.sessionMu.RUnlock()
-	return p.session
+// appCtx resolves the AppContext for the app identified by ctx (the per-app
+// key stamped on the control path by the route middleware, or on the data
+// path by handleConnection from the originating kernel PID). With no key it
+// resolves the DefaultAppKey AppContext — the single-app path.
+func (p *Proxy) appCtx(ctx context.Context) *AppContext {
+	return p.apps.GetOrCreate(agent.AppKeyOrDefault(ctx))
 }
 
-// setSession replaces the current session in a thread-safe manner.
-func (p *Proxy) setSession(s *agent.Session) {
-	p.sessionMu.Lock()
-	defer p.sessionMu.Unlock()
-	p.session = s
+// getSession returns the current session for ctx's app in a thread-safe manner.
+func (p *Proxy) getSession(ctx context.Context) *agent.Session {
+	return p.appCtx(ctx).getSession()
 }
 
-// GetSession returns the current session in a thread-safe manner (exported for enterprise).
+// setSession replaces the current session for ctx's app in a thread-safe manner.
+func (p *Proxy) setSession(ctx context.Context, s *agent.Session) {
+	p.appCtx(ctx).setSession(s)
+}
+
+// GetSession returns the default app's session (exported for enterprise; the
+// no-context interface method resolves the DefaultAppKey app).
 func (p *Proxy) GetSession() *agent.Session {
-	return p.getSession()
+	return p.apps.GetOrCreate(agent.DefaultAppKey).getSession()
 }
 
 func (p *Proxy) GetDestInfo() agent.DestInfo {
@@ -820,30 +829,15 @@ func (p *Proxy) SetAuxiliaryHook(h agent.AuxiliaryProxyHook) {
 	p.auxiliaryHook = h
 }
 
-// getMockManager returns the current mock manager in a thread-safe manner.
-func (p *Proxy) getMockManager() *MockManager {
-	p.sessionMu.RLock()
-	defer p.sessionMu.RUnlock()
-	return p.mockManager
+// getMockManager returns the current mock manager for ctx's app.
+func (p *Proxy) getMockManager(ctx context.Context) *MockManager {
+	return p.appCtx(ctx).getMockManager()
 }
 
-// setMockManager replaces the current mock manager in a thread-safe manner.
-//
-// Swaps the new manager in while holding sessionMu, then closes the
-// PREVIOUS manager after releasing the lock — Close() must not run under
-// sessionMu because Close() synchronises with its own internal workers.
-// Closing the outgoing manager stops its background idle-sweeper
-// goroutine; without this, every Record / Mock session would leak a
-// goroutine since MockManager owns a per-instance ticker that only
-// stops on Close().
-func (p *Proxy) setMockManager(m *MockManager) {
-	p.sessionMu.Lock()
-	prev := p.mockManager
-	p.mockManager = m
-	p.sessionMu.Unlock()
-	if prev != nil {
-		prev.Close()
-	}
+// setMockManager replaces ctx's app mock manager, closing the previous one
+// outside the lock (see AppContext.setMockManager for the ordering contract).
+func (p *Proxy) setMockManager(ctx context.Context, m *MockManager) {
+	p.appCtx(ctx).setMockManager(m)
 }
 
 func (p *Proxy) InitIntegrations(_ context.Context) error {
@@ -1220,12 +1214,10 @@ func (p *Proxy) start(ctx context.Context, readyChan chan<- error) error {
 		// guaranteeing every send completes before close runs.
 		if mgr := syncMock.Get(); mgr != nil {
 			mgr.CloseOutChan()
-		} else {
-			p.sessionMu.RLock()
-			if p.session != nil && p.session.MC != nil {
-				close(p.session.MC)
+		} else if ac, ok := p.apps.Get(agent.DefaultAppKey); ok {
+			if rule := ac.getSession(); rule != nil && rule.MC != nil {
+				close(rule.MC)
 			}
-			p.sessionMu.RUnlock()
 		}
 
 		p.nsSwitchMutex.Lock()
@@ -1355,8 +1347,16 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 		return err
 	}
 
+	// Attribute this connection to its owning app from the originating
+	// kernel PID (eBPF redirect map → DestInfo.Pid) and stamp the app key
+	// onto ctx so every downstream consumer (session, mock manager, parser
+	// dispatch) operates on that app's state. Unresolved PIDs fall to
+	// DefaultAppKey — the single-app path — so this is behaviour-neutral
+	// until the data plane is actually multi-tenant.
+	ctx = agent.WithAppKey(ctx, p.apps.Resolve(destInfo.Pid))
+
 	//get the session rule
-	rule := p.getSession()
+	rule := p.getSession(ctx)
 	if rule == nil {
 		utils.LogError(p.logger, nil, "failed to fetch the session rule")
 		return err
@@ -1519,7 +1519,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 			return nil
 		}
 
-		m := p.getMockManager()
+		m := p.getMockManager(ctx)
 		if m == nil {
 			utils.LogError(p.logger, nil, "failed to fetch the mock manager")
 			return err
@@ -2129,7 +2129,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 	startConnCloser()
 
 	// get the mock manager for the current app
-	m := p.getMockManager()
+	m := p.getMockManager(ctx)
 	if m == nil {
 		utils.LogError(logger, err, "failed to fetch the mock manager")
 		return err
@@ -2428,12 +2428,12 @@ func (p *Proxy) Record(ctx context.Context, mocks chan<- *models.Mock, opts mode
 	// Lift the per-session opportunistic-TLS toggle onto the proxy
 	// for handleConnection to read. Independent of GlobalPassthrough.
 	p.OpportunisticTLSIntercept = opts.OpportunisticTLSIntercept
-	p.setSession(&agent.Session{
+	p.setSession(ctx, &agent.Session{
 		Mode:            models.MODE_RECORD,
 		MC:              mocks,
 		OutgoingOptions: opts,
 	})
-	p.setMockManager(NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), p.logger))
+	p.setMockManager(ctx, NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), p.logger))
 
 	if opts.CapturePackets {
 		// Agent picks its own scratch dir on its OWN filesystem; the
@@ -2457,13 +2457,13 @@ func (p *Proxy) Record(ctx context.Context, mocks chan<- *models.Mock, opts mode
 	return nil
 }
 
-func (p *Proxy) Mock(_ context.Context, opts models.OutgoingOptions) error {
+func (p *Proxy) Mock(ctx context.Context, opts models.OutgoingOptions) error {
 	// Reset graceful shutdown flag for a new mocking session.
 	p.isGracefulShutdown.Store(false)
 	// Mock is replay; no pcap capture during replay. Tear down any
 	// capture left over from a previous record session.
 	p.stopPacketCapture()
-	p.setSession(&agent.Session{
+	p.setSession(ctx, &agent.Session{
 		Mode:            models.MODE_TEST,
 		OutgoingOptions: opts,
 	})
@@ -2494,8 +2494,8 @@ func (p *Proxy) Mock(_ context.Context, opts models.OutgoingOptions) error {
 	// explicit reset a long-lived connection could match
 	// LifetimeConnection mocks from the prior test-set or merge them
 	// with the current one's.
-	if mm := p.getMockManager(); mm == nil {
-		p.setMockManager(NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), p.logger))
+	if mm := p.getMockManager(ctx); mm == nil {
+		p.setMockManager(ctx, NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), p.logger))
 	} else {
 		mm.ResetForReplaySession()
 	}
@@ -2517,8 +2517,8 @@ func (p *Proxy) Mock(_ context.Context, opts models.OutgoingOptions) error {
 	return nil
 }
 
-func (p *Proxy) SetMocks(_ context.Context, filtered []*models.Mock, unFiltered []*models.Mock) error {
-	if m := p.getMockManager(); m != nil {
+func (p *Proxy) SetMocks(ctx context.Context, filtered []*models.Mock, unFiltered []*models.Mock) error {
+	if m := p.getMockManager(ctx); m != nil {
 		m.SetFilteredMocks(filtered)
 		m.SetUnFilteredMocks(unFiltered)
 		p.dnsCache.Purge()
@@ -2530,8 +2530,8 @@ func (p *Proxy) SetMocks(_ context.Context, filtered []*models.Mock, unFiltered 
 // SetMocksWithWindow atomically updates mocks AND the test window in a
 // single call so concurrent readers cannot observe a torn (newMocks,
 // oldWindow) view. Used to satisfy the WindowedProxy extension interface.
-func (p *Proxy) SetMocksWithWindow(_ context.Context, filtered, unFiltered []*models.Mock, start, end time.Time) error {
-	if m := p.getMockManager(); m != nil {
+func (p *Proxy) SetMocksWithWindow(ctx context.Context, filtered, unFiltered []*models.Mock, start, end time.Time) error {
+	if m := p.getMockManager(ctx); m != nil {
 		m.SetMocksWithWindow(filtered, unFiltered, start, end)
 		p.dnsCache.Purge()
 	}
@@ -2549,15 +2549,19 @@ func (p *Proxy) SetMocksWithWindow(_ context.Context, filtered, unFiltered []*mo
 // Zero-time return means "no cutoff known yet" and callers should fall
 // back to legacy strict-gate semantics.
 func (p *Proxy) FirstTestWindowStart() time.Time {
-	if m := p.getMockManager(); m != nil {
+	// No context on this optional interface method; resolve the default
+	// app. Per-app window reporting (when needed) requires the windowed
+	// extension to carry the app key — tracked with the rest of the
+	// per-app error/window plane.
+	if m := p.apps.GetOrCreate(agent.DefaultAppKey).getMockManager(); m != nil {
 		return m.FirstTestWindowStart()
 	}
 	return time.Time{}
 }
 
-// GetConsumedMocks returns the consumed filtered mocks.
-func (p *Proxy) GetConsumedMocks(_ context.Context) ([]models.MockState, error) {
-	m := p.getMockManager()
+// GetConsumedMocks returns the consumed filtered mocks for ctx's app.
+func (p *Proxy) GetConsumedMocks(ctx context.Context) ([]models.MockState, error) {
+	m := p.getMockManager(ctx)
 	if m == nil {
 		return nil, fmt.Errorf("mock manager not found to get consumed filtered mocks")
 	}


### PR DESCRIPTION
## What

Third slice of multi-tenant keploy-agent (#4275). Moves the proxy's single `session` + `mockManager` into the per-app `AppContext`, keyed by `agent.AppKey` resolved from the request context. **Behaviour-neutral** — with no key on ctx everything resolves to `DefaultAppKey`, reproducing the single-app path.

Stacked on #4277 (base = `feat/mt-syncmock-context`).

## Changes

- `Proxy` holds an `AppRegistry` instead of a scalar `session`/`mockManager`/`sessionMu`.
- `getSession`/`setSession`/`getMockManager`/`setMockManager` now take `ctx` and route to the `AppContext` for `AppKeyOrDefault(ctx)`. `GetSession()` (the no-ctx interface method) resolves the `DefaultAppKey` app.
- **`handleConnection`** attributes each connection to its app from the originating kernel PID (`DestInfo.Pid → apps.Resolve`) and stamps the key on `ctx`, so the per-connection session/mockManager belong to the owning app.
- `Record`/`Mock`/`SetMocks`/`SetMocksWithWindow`/`GetConsumedMocks` operate on `ctx`'s app.
- The shared DNS server resolves the default app (per-app DNS attribution is a separate, deferred concern).

## Deliberately out of this slice (sequencing)

- **`syncMock` stays on the global `Get()`** here. Wiring the per-app manager + migrating the parser emit sites (`http`, `mysql`, `generic`, `dns`, `supervisor`, …) to `FromContext(ctx)` must land **together** — otherwise single-app record breaks (emit sites would write to a manager whose output channel isn't wired). That's the next slice, built on #4277's primitives.
- `dnsCache`, `errChannel`/`activeTestErrors`, `isGracefulShutdown`, `pcap` remain proxy-shared for now (follow-up).

## Tests

Full `pkg/agent/proxy` package tests + `go vet` pass. DNS forward tests updated to seed the default app's mock manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
