### PR TITLE
feat(agent): per-app routing — X-Keploy-App-Id middleware + keyed clientMocks

### DIFF
--- a/pkg/agent/routes/middleware_test.go
+++ b/pkg/agent/routes/middleware_test.go
@@ -1,0 +1,39 @@
+package routes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	coreagent "go.keploy.io/server/v3/pkg/agent"
+)
+
+func TestAppIDMiddlewareStampsKey(t *testing.T) {
+	var got coreagent.AppKey
+	var ok bool
+	h := appIDMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		got, ok = coreagent.AppKeyFromContext(r.Context())
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/agent/health", nil)
+	req.Header.Set(AppIDHeader, "ns/dep/ts-1")
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	if !ok || got != coreagent.AppKey("ns/dep/ts-1") {
+		t.Fatalf("expected key ns/dep/ts-1 on ctx, got (%q, %v)", got, ok)
+	}
+}
+
+func TestAppIDMiddlewareNoHeaderIsDefault(t *testing.T) {
+	var present bool
+	h := appIDMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		_, present = coreagent.AppKeyFromContext(r.Context())
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/agent/health", nil)
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	if present {
+		t.Fatalf("expected no app key on ctx when header absent (DefaultAppKey path)")
+	}
+}

--- a/pkg/agent/routes/record.go
+++ b/pkg/agent/routes/record.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
+	coreagent "go.keploy.io/server/v3/pkg/agent"
 	pTls "go.keploy.io/server/v3/pkg/agent/proxy/tls"
 	"go.keploy.io/server/v3/pkg/models"
 	kdocker "go.keploy.io/server/v3/pkg/platform/docker"
@@ -62,6 +63,12 @@ func (d DefaultRoutes) New(r chi.Router, agent agent.Service, logger *zap.Logger
 	}
 
 	r.Route("/agent", func(r chi.Router) {
+		// Multi-tenancy: lift the per-app key off the X-Keploy-App-Id
+		// header onto the request context so every handler/service/proxy
+		// call operates on that app's state. Absent header → no key →
+		// DefaultAppKey (single-app path), so this is behaviour-neutral
+		// for existing single-tenant clients.
+		r.Use(appIDMiddleware)
 		r.Get("/health", a.Health)
 		r.Post("/incoming", a.HandleIncoming)
 		r.Post("/outgoing", a.HandleOutgoing)
@@ -89,6 +96,23 @@ func (d DefaultRoutes) New(r chi.Router, agent agent.Service, logger *zap.Logger
 		r.Post("/hooks/before-test-run", a.HandleBeforeTestRun)
 		r.Post("/hooks/before-test-set-compose", a.HandleBeforeTestSetCompose)
 		r.Post("/hooks/after-test-run", a.HandleAfterTestRun)
+	})
+}
+
+// AppIDHeader is the HTTP header the client stamps with its per-app key so
+// the multi-tenant agent can route the request to that app's state.
+const AppIDHeader = "X-Keploy-App-Id"
+
+// appIDMiddleware lifts the per-app key from the AppIDHeader onto the request
+// context (via coreagent.WithAppKey). When the header is absent the context
+// is unchanged and downstream code resolves DefaultAppKey — the single-app
+// path — so single-tenant clients are unaffected.
+func appIDMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if v := r.Header.Get(AppIDHeader); v != "" {
+			r = r.WithContext(coreagent.WithAppKey(r.Context(), coreagent.AppKey(v)))
+		}
+		next.ServeHTTP(w, r)
 	})
 }
 

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -39,7 +39,7 @@ type Agent struct {
 	config       *config.Config
 	// activeClients sync.Map
 	// New field for storing client-specific mocks
-	clientMocks sync.Map // map[uint64]*ClientMockStorage
+	clientMocks sync.Map // map[coreAgent.AppKey]*ClientMockStorage
 	Ip          string
 
 	// strictLogOnce de-dupes the "strict mock window enabled" Info log
@@ -658,7 +658,7 @@ func (a *Agent) StoreMocks(ctx context.Context, filtered []*models.Mock, unfilte
 		}
 	}
 
-	a.clientMocks.Store(uint64(0), storage)
+	a.clientMocks.Store(coreAgent.AppKeyOrDefault(ctx), storage)
 
 	// Compute the freeze anchor as the earliest ReqTimestampMock across the
 	// stored mocks and forward it to AgentHooks. The hook implementation
@@ -746,8 +746,9 @@ func (a *Agent) UpdateMockParams(ctx context.Context, params models.MockFilterPa
 			zap.Time("windowEnd", params.BeforeTime))
 	}
 
-	// Get stored mocks for the client
-	storageInterface, exists := a.clientMocks.Load(uint64(0))
+	// Get stored mocks for the app addressed by this request (per-app key
+	// from ctx; DefaultAppKey for single-tenant clients).
+	storageInterface, exists := a.clientMocks.Load(coreAgent.AppKeyOrDefault(ctx))
 	if !exists {
 		return fmt.Errorf("no mocks stored for client ID")
 	}


### PR DESCRIPTION
## What

Fourth slice of multi-tenant keploy-agent (#4275). Activates the per-app proxy for the **control plane**: a route middleware lifts the per-app key off the request and `clientMocks` keys by it. **Behaviour-neutral** for single-tenant clients (no header → `DefaultAppKey`).

Stacked on #4278 (base = `feat/mt-proxy-per-app`).

## Changes

- **`appIDMiddleware`** on the `/agent` router lifts the `X-Keploy-App-Id` header onto the request context (`coreagent.WithAppKey`). Every handler → service → proxy call then operates on that app's state.
- **`Agent.clientMocks`** (`StoreMocks` / `UpdateMockParams`) is now keyed by the per-app key from `ctx` instead of the hardcoded `uint64(0)`.

Together with the ctx-keyed proxy (#4278), this makes `Record`/`Mock`/`SetMocks`/`GetConsumedMocks` and stored-mock lookup per-app **end to end** on the control path.

## Deferred (follow-up)

- Per-app `tcChan`/`IncomingProxy` drainer in `StartIncomingProxy`/`SetGracefulShutdown` (the session-aware drain lifecycle).
- Per-app `SetFreezeAnchor`.

## Tests

`appIDMiddleware` unit tests (header → ctx, absent → default). routes tests + `go vet` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
