### PR TITLE
feat(agent): multi-tenant keploy-agent — OSS user-space foundation

### DIFF
--- a/pkg/agent/appkey.go
+++ b/pkg/agent/appkey.go
@@ -1,0 +1,57 @@
+package agent
+
+import "context"
+
+// AppKey is the per-application (per-recording-session) identity that keys all
+// per-app state in a multi-tenant agent. One agent process can serve many
+// applications concurrently; every piece of state that used to be a process
+// singleton (proxy session, mock manager, syncMock output, dedup, mode, etc.)
+// is partitioned by this key.
+//
+// It is deliberately an opaque string so the two attribution sources can share
+// one identity type:
+//   - sidecar/native: derived from the app (e.g. app name or a hash of
+//     appName+clientPID).
+//   - daemonset: the per-session key the controller resolves from a target's
+//     {namespace, deployment, testSetID}.
+//
+// The zero value (DefaultAppKey) is the single-tenant / sidecar fallback: when
+// no key is present on the context, callers operate on the default app so the
+// existing one-process-one-app behaviour is preserved byte-for-byte.
+type AppKey string
+
+// DefaultAppKey is the fallback key used when no per-app key is supplied. It
+// preserves the historical single-app behaviour: all state lands under one
+// default AppContext.
+const DefaultAppKey AppKey = ""
+
+type appKeyCtxKey struct{}
+
+// WithAppKey returns a copy of ctx carrying the per-app key. Producers (HTTP
+// route middleware on the control path, the connection router on the data
+// path) stamp the key; consumers deep in the proxy/parsers read it back with
+// AppKeyFromContext without having to thread an extra parameter through every
+// call.
+func WithAppKey(ctx context.Context, key AppKey) context.Context {
+	return context.WithValue(ctx, appKeyCtxKey{}, key)
+}
+
+// AppKeyFromContext returns the per-app key on ctx and whether one was set.
+// When ok is false the caller should use DefaultAppKey (single-tenant path).
+func AppKeyFromContext(ctx context.Context) (AppKey, bool) {
+	if ctx == nil {
+		return DefaultAppKey, false
+	}
+	key, ok := ctx.Value(appKeyCtxKey{}).(AppKey)
+	return key, ok
+}
+
+// AppKeyOrDefault is the convenience accessor: returns the per-app key on ctx
+// or DefaultAppKey when none is present.
+func AppKeyOrDefault(ctx context.Context) AppKey {
+	key, ok := AppKeyFromContext(ctx)
+	if !ok {
+		return DefaultAppKey
+	}
+	return key
+}

--- a/pkg/agent/appkey_test.go
+++ b/pkg/agent/appkey_test.go
@@ -1,0 +1,32 @@
+package agent
+
+import (
+	"context"
+	"testing"
+)
+
+func TestAppKeyContextRoundTrip(t *testing.T) {
+	ctx := WithAppKey(context.Background(), AppKey("ns/dep/ts-1"))
+	got, ok := AppKeyFromContext(ctx)
+	if !ok {
+		t.Fatalf("expected key present on ctx")
+	}
+	if got != AppKey("ns/dep/ts-1") {
+		t.Fatalf("got %q, want %q", got, "ns/dep/ts-1")
+	}
+	if AppKeyOrDefault(ctx) != AppKey("ns/dep/ts-1") {
+		t.Fatalf("AppKeyOrDefault mismatch")
+	}
+}
+
+func TestAppKeyDefaultWhenAbsent(t *testing.T) {
+	if got, ok := AppKeyFromContext(context.Background()); ok || got != DefaultAppKey {
+		t.Fatalf("expected (DefaultAppKey, false), got (%q, %v)", got, ok)
+	}
+	if AppKeyOrDefault(context.Background()) != DefaultAppKey {
+		t.Fatalf("expected DefaultAppKey from empty ctx")
+	}
+	if got, ok := AppKeyFromContext(nil); ok || got != DefaultAppKey { //nolint:staticcheck // nil ctx is a guarded edge
+		t.Fatalf("expected (DefaultAppKey, false) for nil ctx, got (%q, %v)", got, ok)
+	}
+}

--- a/pkg/agent/hooks/conn/util.go
+++ b/pkg/agent/hooks/conn/util.go
@@ -191,7 +191,7 @@ func Capture(ctx context.Context, logger *zap.Logger, t chan *models.TestCase, r
 		// the taint flow and stops the go/clear-text-logging false
 		// positives that fire downstream (syncMock.go diag/Info
 		// logs include test_name for ResolveRange traceability).
-		if mgr := syncMock.Get(); mgr != nil { // dumping the test case from mock manager in synchronous mode
+		if mgr := syncMock.FromContext(ctx); mgr != nil { // dumping the test case from mock manager in synchronous mode
 			mgr.ResolveRange(reqTimeTest, resTimeTest, testName, true, mapping)
 		}
 	}

--- a/pkg/agent/hooks/linux/comm.go
+++ b/pkg/agent/hooks/linux/comm.go
@@ -31,6 +31,10 @@ func (h *Hooks) Get(_ context.Context, srcPort uint16) (*agent.NetworkAddress, e
 		IPv4Addr: d.DestIP4,
 		IPv6Addr: d.DestIP6,
 		Port:     d.DestPort,
+		// Surface the originating process TGID so the proxy can attribute the
+		// connection to an AppContext (multi-tenancy). The kernel already
+		// records it in the redirect map; it was previously dropped here.
+		Pid: d.KernelPid,
 	}, nil
 }
 

--- a/pkg/agent/proxy/appcontext.go
+++ b/pkg/agent/proxy/appcontext.go
@@ -1,0 +1,284 @@
+package proxy
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+
+	expirable "github.com/hashicorp/golang-lru/v2/expirable"
+	"go.keploy.io/server/v3/pkg/agent"
+	syncMock "go.keploy.io/server/v3/pkg/agent/proxy/syncMock"
+	"go.uber.org/zap"
+)
+
+// AppContext owns every piece of state that, in the single-app proxy, lived as
+// a process singleton on Proxy. One AppContext exists per application
+// (agent.AppKey) so that a single agent process can record/replay many apps
+// concurrently without cross-tenant interference.
+//
+// This is the skeleton (issue #4275, phase 2): the struct + registry + PID
+// attribution. Wiring the proxy hot path onto it lands in a later phase; until
+// then Proxy keeps its own fields and the DefaultAppKey AppContext mirrors the
+// historical single-app behaviour.
+type AppContext struct {
+	logger *zap.Logger
+
+	// Key is the per-app identity; RootPID is the app's process-tree root
+	// used for /proc-ancestry attribution on the native path.
+	Key     agent.AppKey
+	RootPID uint32
+
+	// session + mockManager: the per-app record/replay state. Guarded by
+	// sessionMu, mirroring Proxy.{sessionMu,session,mockManager}.
+	sessionMu   sync.RWMutex
+	session     *agent.Session
+	mockManager *MockManager
+
+	// errChannel + activeTestErrors: per-app mock-not-found error plane.
+	errChannel       chan error
+	activeTestErrors atomic.Pointer[testErrorAccumulator]
+	errDrainOnce     sync.Once
+
+	// dnsCache + recordedDNSMocks ("static-dedup" for DNS): per-app.
+	dnsCache         *expirable.LRU[string, dnsCacheEntry]
+	recordedDNSMocks *expirable.LRU[string, bool]
+
+	// isGracefulShutdown + opportunisticTLSIntercept: per-app flags.
+	isGracefulShutdown        atomic.Bool
+	opportunisticTLSIntercept bool
+
+	// pcap lifecycle, per-app.
+	pcapMu          sync.Mutex
+	pcapCancel      context.CancelFunc
+	pcapDone        chan struct{}
+	pcapBroadcaster *pcapBroadcaster
+
+	// syncMgr is the per-app mock-window manager. Nil here in the skeleton;
+	// wired to syncMock.New() once syncMock is de-globalized (phase 3).
+	syncMgr *syncMock.SyncMockManager
+}
+
+// newAppContext builds an AppContext with its per-app caches/channels
+// initialised the same way Proxy.New initialises the singletons today.
+func newAppContext(logger *zap.Logger, key agent.AppKey) *AppContext {
+	return &AppContext{
+		logger:           logger,
+		Key:              key,
+		errChannel:       make(chan error, 100),
+		dnsCache:         newDNSCache(),
+		recordedDNSMocks: newRecordedDNSMocksCache(),
+	}
+}
+
+func (a *AppContext) getSession() *agent.Session {
+	a.sessionMu.RLock()
+	defer a.sessionMu.RUnlock()
+	return a.session
+}
+
+func (a *AppContext) setSession(s *agent.Session) {
+	a.sessionMu.Lock()
+	defer a.sessionMu.Unlock()
+	a.session = s
+}
+
+func (a *AppContext) getMockManager() *MockManager {
+	a.sessionMu.RLock()
+	defer a.sessionMu.RUnlock()
+	return a.mockManager
+}
+
+// setMockManager swaps in a new manager and Close()s the previous one outside
+// the lock — Close() synchronises with the manager's own workers and must not
+// run under sessionMu (same contract as Proxy.setMockManager).
+func (a *AppContext) setMockManager(m *MockManager) {
+	a.sessionMu.Lock()
+	prev := a.mockManager
+	a.mockManager = m
+	a.sessionMu.Unlock()
+	if prev != nil {
+		prev.Close()
+	}
+}
+
+// resetRecordedDNSMocks clears the per-app DNS dedup tracker for a fresh
+// recording session.
+func (a *AppContext) resetRecordedDNSMocks() {
+	a.recordedDNSMocks = newRecordedDNSMocksCache()
+}
+
+// PIDResolver maps an originating kernel TGID to the owning app key. The
+// attribution source is pluggable: the native path uses /proc ancestry
+// (resolveAppByProcAncestry); the daemonset supplies an authoritative
+// resolver backed by its controller's PID→session map.
+type PIDResolver func(kernelPid uint32) (agent.AppKey, bool)
+
+// AppRegistry holds the live AppContexts keyed by AppKey and resolves an
+// intercepted connection (by its originating kernel PID) to an app.
+type AppRegistry struct {
+	logger *zap.Logger
+
+	apps  sync.Map // agent.AppKey -> *AppContext
+	byPID sync.Map // uint32 (kernelPid) -> agent.AppKey  (attribution cache)
+
+	// resolver turns a kernelPid into an AppKey when it is not yet cached.
+	// When nil, Resolve only consults the cache + DefaultAppKey.
+	resolverMu sync.RWMutex
+	resolver   PIDResolver
+}
+
+func NewAppRegistry(logger *zap.Logger) *AppRegistry {
+	r := &AppRegistry{logger: logger}
+	// Default native attribution: /proc ancestry. The daemonset overrides
+	// this with an authoritative controller-backed resolver via SetResolver.
+	r.resolver = func(kernelPid uint32) (agent.AppKey, bool) {
+		return resolveAppByProcAncestry(r, kernelPid)
+	}
+	return r
+}
+
+// SetResolver installs the pluggable PID→app attribution function.
+func (r *AppRegistry) SetResolver(res PIDResolver) {
+	r.resolverMu.Lock()
+	r.resolver = res
+	r.resolverMu.Unlock()
+}
+
+// Get returns the AppContext for key, if present.
+func (r *AppRegistry) Get(key agent.AppKey) (*AppContext, bool) {
+	v, ok := r.apps.Load(key)
+	if !ok {
+		return nil, false
+	}
+	return v.(*AppContext), true
+}
+
+// GetOrCreate returns the AppContext for key, creating it on first use.
+func (r *AppRegistry) GetOrCreate(key agent.AppKey) *AppContext {
+	if v, ok := r.apps.Load(key); ok {
+		return v.(*AppContext)
+	}
+	ac := newAppContext(r.logger, key)
+	actual, loaded := r.apps.LoadOrStore(key, ac)
+	if loaded {
+		return actual.(*AppContext)
+	}
+	return ac
+}
+
+// RegisterPID seeds the attribution cache so an app's RootPID (and any TGIDs
+// the caller already knows) resolve to its key without a /proc walk.
+func (r *AppRegistry) RegisterPID(kernelPid uint32, key agent.AppKey) {
+	r.byPID.Store(kernelPid, key)
+}
+
+// Delete tears down an app: evicts its cache entries and removes it from the
+// registry. The caller is responsible for closing per-app resources
+// (mockManager, syncMgr, channels) before/after — wired in a later phase.
+func (r *AppRegistry) Delete(key agent.AppKey) {
+	r.apps.Delete(key)
+	r.byPID.Range(func(k, v any) bool {
+		if v.(agent.AppKey) == key {
+			r.byPID.Delete(k)
+		}
+		return true
+	})
+}
+
+// Resolve maps a kernel PID to its owning app key: cache first, then the
+// pluggable resolver (whose result is cached), else DefaultAppKey.
+func (r *AppRegistry) Resolve(kernelPid uint32) agent.AppKey {
+	if v, ok := r.byPID.Load(kernelPid); ok {
+		return v.(agent.AppKey)
+	}
+	r.resolverMu.RLock()
+	res := r.resolver
+	r.resolverMu.RUnlock()
+	if res != nil {
+		if key, ok := res(kernelPid); ok {
+			r.byPID.Store(kernelPid, key)
+			return key
+		}
+	}
+	return agent.DefaultAppKey
+}
+
+// resolveAppByProcAncestry is the default native attribution: walk the /proc
+// parent chain of kernelPid and return the key of the first registered app
+// whose RootPID is an ancestor. Used to build a PIDResolver over an
+// AppRegistry on the sidecar/native path.
+func resolveAppByProcAncestry(reg *AppRegistry, kernelPid uint32) (agent.AppKey, bool) {
+	// Build RootPID -> key once per call (apps are few).
+	roots := map[uint32]agent.AppKey{}
+	reg.apps.Range(func(_, v any) bool {
+		ac := v.(*AppContext)
+		if ac.RootPID != 0 {
+			roots[ac.RootPID] = ac.Key
+		}
+		return true
+	})
+	if len(roots) == 0 {
+		return agent.DefaultAppKey, false
+	}
+	pid := kernelPid
+	for i := 0; i < 64 && pid > 1; i++ {
+		if key, ok := roots[pid]; ok {
+			return key, true
+		}
+		ppid, ok := readParentPID(pid)
+		if !ok {
+			break
+		}
+		pid = ppid
+	}
+	return agent.DefaultAppKey, false
+}
+
+// readParentPID reads PPid from /proc/<pid>/status. Returns false when the
+// process is gone or the field is unreadable.
+func readParentPID(pid uint32) (uint32, bool) {
+	data, err := os.ReadFile("/proc/" + strconv.FormatUint(uint64(pid), 10) + "/status")
+	if err != nil {
+		return 0, false
+	}
+	const key = "PPid:"
+	s := string(data)
+	idx := indexLine(s, key)
+	if idx < 0 {
+		return 0, false
+	}
+	field := s[idx+len(key):]
+	// trim leading spaces/tabs, read digits up to newline
+	j := 0
+	for j < len(field) && (field[j] == ' ' || field[j] == '\t') {
+		j++
+	}
+	start := j
+	for j < len(field) && field[j] >= '0' && field[j] <= '9' {
+		j++
+	}
+	if start == j {
+		return 0, false
+	}
+	ppid, err := strconv.ParseUint(field[start:j], 10, 32)
+	if err != nil {
+		return 0, false
+	}
+	return uint32(ppid), true
+}
+
+// indexLine returns the byte index of prefix at the start of any line in s, or
+// -1. Avoids a regexp/strings.Split allocation on the attribution hot path.
+func indexLine(s, prefix string) int {
+	if len(s) >= len(prefix) && s[:len(prefix)] == prefix {
+		return 0
+	}
+	for i := 0; i+len(prefix) < len(s); i++ {
+		if s[i] == '\n' && s[i+1:i+1+len(prefix)] == prefix {
+			return i + 1
+		}
+	}
+	return -1
+}

--- a/pkg/agent/proxy/appcontext.go
+++ b/pkg/agent/proxy/appcontext.go
@@ -140,6 +140,14 @@ func (p *Proxy) DeregisterApp(key agent.AppKey) {
 	p.apps.Delete(key)
 }
 
+// ResolveAppKey maps an intercepted connection's originating kernel PID to its
+// owning app key, reporting whether it was attributed. Used by embedders that
+// capture outside handleConnection (the daemonset proxyless reader) to stamp
+// the per-app key on the capture context. Satisfies agent.AppRegistrar.
+func (p *Proxy) ResolveAppKey(kernelPid uint32) (agent.AppKey, bool) {
+	return p.apps.ResolveWithOK(kernelPid)
+}
+
 // PIDResolver maps an originating kernel TGID to the owning app key. The
 // attribution source is pluggable: the native path uses /proc ancestry
 // (resolveAppByProcAncestry); the daemonset supplies an authoritative
@@ -221,8 +229,17 @@ func (r *AppRegistry) Delete(key agent.AppKey) {
 // Resolve maps a kernel PID to its owning app key: cache first, then the
 // pluggable resolver (whose result is cached), else DefaultAppKey.
 func (r *AppRegistry) Resolve(kernelPid uint32) agent.AppKey {
+	key, _ := r.ResolveWithOK(kernelPid)
+	return key
+}
+
+// ResolveWithOK is Resolve but reports whether the PID was actually attributed
+// to a registered app. ok=false (with DefaultAppKey) means unresolved
+// (cold-start / not a target / ambiguous overlap) — callers on the data path
+// use this to drop unattributed captures rather than mis-file them.
+func (r *AppRegistry) ResolveWithOK(kernelPid uint32) (agent.AppKey, bool) {
 	if v, ok := r.byPID.Load(kernelPid); ok {
-		return v.(agent.AppKey)
+		return v.(agent.AppKey), true
 	}
 	r.resolverMu.RLock()
 	res := r.resolver
@@ -230,10 +247,10 @@ func (r *AppRegistry) Resolve(kernelPid uint32) agent.AppKey {
 	if res != nil {
 		if key, ok := res(kernelPid); ok {
 			r.byPID.Store(kernelPid, key)
-			return key
+			return key, true
 		}
 	}
-	return agent.DefaultAppKey
+	return agent.DefaultAppKey, false
 }
 
 // resolveAppByProcAncestry is the default native attribution: walk the /proc

--- a/pkg/agent/proxy/appcontext.go
+++ b/pkg/agent/proxy/appcontext.go
@@ -63,12 +63,42 @@ type AppContext struct {
 // newAppContext builds an AppContext with its per-app caches/channels
 // initialised the same way Proxy.New initialises the singletons today.
 func newAppContext(logger *zap.Logger, key agent.AppKey) *AppContext {
+	// The DefaultAppKey app reuses the process-global syncMock manager so the
+	// single-tenant path — and every existing syncMock.Get() lifecycle site —
+	// is byte-for-byte unchanged; only additional apps get their own manager.
+	mgr := syncMock.New()
+	if key == agent.DefaultAppKey {
+		mgr = syncMock.Get()
+	}
+	mgr.SetLogger(logger)
 	return &AppContext{
 		logger:           logger,
 		Key:              key,
+		syncMgr:          mgr,
 		errChannel:       make(chan error, 100),
 		dnsCache:         newDNSCache(),
 		recordedDNSMocks: newRecordedDNSMocksCache(),
+	}
+}
+
+// SyncMgr returns the app's per-app mock-window manager.
+func (a *AppContext) SyncMgr() *syncMock.SyncMockManager { return a.syncMgr }
+
+// close releases the app's per-app resources: stops the mock manager's
+// idle-sweeper goroutine and closes the syncMock output channel. Never closes
+// the process-global (default-app) manager. Called by AppRegistry.Delete.
+func (a *AppContext) close() {
+	a.sessionMu.Lock()
+	mm := a.mockManager
+	a.mockManager = nil
+	a.sessionMu.Unlock()
+	if mm != nil {
+		mm.Close()
+	}
+	// Non-default apps own a fresh manager; the default app's manager is the
+	// shared global and must outlive any single app's teardown.
+	if a.syncMgr != nil && a.syncMgr != syncMock.Get() {
+		a.syncMgr.CloseOutChan()
 	}
 }
 
@@ -213,16 +243,29 @@ func (r *AppRegistry) RegisterPID(kernelPid uint32, key agent.AppKey) {
 	r.byPID.Store(kernelPid, key)
 }
 
-// Delete tears down an app: evicts its cache entries and removes it from the
-// registry. The caller is responsible for closing per-app resources
-// (mockManager, syncMgr, channels) before/after — wired in a later phase.
+// Delete tears down an app: closes its per-app resources (mock manager
+// idle-sweeper goroutine + syncMock output channel), evicts its PID-attribution
+// cache entries, and removes it from the registry. Mandatory under the
+// long-lived shared daemon — without the close, every session teardown leaks
+// the per-app MockManager's sweeper goroutine.
 func (r *AppRegistry) Delete(key agent.AppKey) {
+	if v, ok := r.apps.Load(key); ok {
+		v.(*AppContext).close()
+	}
 	r.apps.Delete(key)
 	r.byPID.Range(func(k, v any) bool {
 		if v.(agent.AppKey) == key {
 			r.byPID.Delete(k)
 		}
 		return true
+	})
+}
+
+// Range calls f for each live AppContext (stopping if f returns false). Used by
+// the proxy's per-app syncMock flush/close lifecycle.
+func (r *AppRegistry) Range(f func(*AppContext) bool) {
+	r.apps.Range(func(_, v any) bool {
+		return f(v.(*AppContext))
 	})
 }
 

--- a/pkg/agent/proxy/appcontext.go
+++ b/pkg/agent/proxy/appcontext.go
@@ -109,6 +109,37 @@ func (a *AppContext) resetRecordedDNSMocks() {
 	a.recordedDNSMocks = newRecordedDNSMocksCache()
 }
 
+// Proxy implements the multi-tenant AppRegistrar extension.
+var _ agent.AppRegistrar = (*Proxy)(nil)
+
+// SetAppResolver installs the PID→app attribution function on the proxy's
+// registry (satisfies agent.AppRegistrar). Embedders with an authoritative
+// PID→app map (e.g. the daemonset controller) override the default
+// /proc-ancestry resolver here.
+func (p *Proxy) SetAppResolver(resolver func(kernelPid uint32) (agent.AppKey, bool)) {
+	p.apps.SetResolver(resolver)
+}
+
+// RegisterApp creates (if absent) the AppContext for key and seeds the
+// attribution cache with the app's root PID(s), so the data plane
+// (handleConnection → apps.Resolve) resolves the same key the control plane
+// stamps on ctx. Satisfies agent.AppRegistrar.
+func (p *Proxy) RegisterApp(key agent.AppKey, rootPIDs ...uint32) {
+	ac := p.apps.GetOrCreate(key)
+	for _, pid := range rootPIDs {
+		if pid != 0 {
+			ac.RootPID = pid
+			p.apps.RegisterPID(pid, key)
+		}
+	}
+}
+
+// DeregisterApp tears down the app's per-app state. Satisfies
+// agent.AppRegistrar.
+func (p *Proxy) DeregisterApp(key agent.AppKey) {
+	p.apps.Delete(key)
+}
+
 // PIDResolver maps an originating kernel TGID to the owning app key. The
 // attribution source is pluggable: the native path uses /proc ancestry
 // (resolveAppByProcAncestry); the daemonset supplies an authoritative

--- a/pkg/agent/proxy/appcontext_test.go
+++ b/pkg/agent/proxy/appcontext_test.go
@@ -4,8 +4,46 @@ import (
 	"testing"
 
 	"go.keploy.io/server/v3/pkg/agent"
+	syncMock "go.keploy.io/server/v3/pkg/agent/proxy/syncMock"
 	"go.uber.org/zap"
 )
+
+func TestAppContextSyncMgrPerApp(t *testing.T) {
+	r := NewAppRegistry(zap.NewNop())
+	// Default app reuses the process-global manager (single-tenant parity).
+	def := r.GetOrCreate(agent.DefaultAppKey)
+	if def.SyncMgr() != syncMock.Get() {
+		t.Fatalf("default app must reuse the global syncMock manager")
+	}
+	// A named app gets its own, distinct manager.
+	a := r.GetOrCreate(agent.AppKey("app-a"))
+	if a.SyncMgr() == nil || a.SyncMgr() == syncMock.Get() {
+		t.Fatalf("named app must get its own (non-global) syncMock manager")
+	}
+	b := r.GetOrCreate(agent.AppKey("app-b"))
+	if a.SyncMgr() == b.SyncMgr() {
+		t.Fatalf("distinct apps must get distinct syncMock managers")
+	}
+}
+
+func TestAppRegistryDeleteClosesResources(t *testing.T) {
+	r := NewAppRegistry(zap.NewNop())
+	a := r.GetOrCreate(agent.AppKey("app-a"))
+	a.setMockManager(NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop()))
+	// Delete must not panic, must evict, and must clear the manager (closing
+	// its idle-sweeper goroutine) — the daemonset-churn leak fix.
+	r.Delete(agent.AppKey("app-a"))
+	if _, ok := r.Get(agent.AppKey("app-a")); ok {
+		t.Fatalf("Delete did not evict the app")
+	}
+	if a.getMockManager() != nil {
+		t.Fatalf("Delete did not close/clear the mock manager")
+	}
+	// Deleting the default app must NOT close the shared global manager's
+	// output channel (defensive: close() guards against it).
+	_ = r.GetOrCreate(agent.DefaultAppKey)
+	r.Delete(agent.DefaultAppKey) // must not panic / must not close global
+}
 
 func TestAppRegistryGetOrCreateIsIdempotent(t *testing.T) {
 	r := NewAppRegistry(zap.NewNop())

--- a/pkg/agent/proxy/appcontext_test.go
+++ b/pkg/agent/proxy/appcontext_test.go
@@ -1,0 +1,68 @@
+package proxy
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/agent"
+	"go.uber.org/zap"
+)
+
+func TestAppRegistryGetOrCreateIsIdempotent(t *testing.T) {
+	r := NewAppRegistry(zap.NewNop())
+	a := r.GetOrCreate(agent.AppKey("app-a"))
+	b := r.GetOrCreate(agent.AppKey("app-a"))
+	if a != b {
+		t.Fatalf("GetOrCreate returned distinct AppContexts for the same key")
+	}
+	if got, ok := r.Get(agent.AppKey("app-a")); !ok || got != a {
+		t.Fatalf("Get did not return the created AppContext")
+	}
+	if a.errChannel == nil || a.dnsCache == nil || a.recordedDNSMocks == nil {
+		t.Fatalf("AppContext caches/channels not initialised")
+	}
+}
+
+func TestAppRegistryResolveUsesCacheThenResolver(t *testing.T) {
+	r := NewAppRegistry(zap.NewNop())
+
+	// No cache entry and the default /proc resolver finds no registered app
+	// → DefaultAppKey.
+	if got := r.Resolve(424242); got != agent.DefaultAppKey {
+		t.Fatalf("expected DefaultAppKey for unknown pid, got %q", got)
+	}
+
+	// A custom resolver is consulted on a miss and its result is cached.
+	calls := 0
+	r.SetResolver(func(pid uint32) (agent.AppKey, bool) {
+		calls++
+		if pid == 100 {
+			return agent.AppKey("app-x"), true
+		}
+		return agent.DefaultAppKey, false
+	})
+	if got := r.Resolve(100); got != agent.AppKey("app-x") {
+		t.Fatalf("resolver result not used, got %q", got)
+	}
+	if got := r.Resolve(100); got != agent.AppKey("app-x") {
+		t.Fatalf("cached result not used, got %q", got)
+	}
+	if calls != 1 {
+		t.Fatalf("resolver should be hit once (then cached), hit %d times", calls)
+	}
+}
+
+func TestAppRegistryRegisterAndDeleteEvictsPIDCache(t *testing.T) {
+	r := NewAppRegistry(zap.NewNop())
+	r.GetOrCreate(agent.AppKey("app-a"))
+	r.RegisterPID(777, agent.AppKey("app-a"))
+	if got := r.Resolve(777); got != agent.AppKey("app-a") {
+		t.Fatalf("RegisterPID not honoured by Resolve, got %q", got)
+	}
+	r.Delete(agent.AppKey("app-a"))
+	if _, ok := r.Get(agent.AppKey("app-a")); ok {
+		t.Fatalf("Delete did not remove the AppContext")
+	}
+	if got := r.Resolve(777); got != agent.DefaultAppKey {
+		t.Fatalf("Delete did not evict the PID cache entry, got %q", got)
+	}
+}

--- a/pkg/agent/proxy/dns.go
+++ b/pkg/agent/proxy/dns.go
@@ -166,7 +166,10 @@ func (p *Proxy) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	msg := new(dns.Msg)
 	msg.SetReply(r)
 
-	session := p.getSession()
+	// The DNS server is shared infrastructure (one listener for the whole
+	// node) with no per-connection app key, so resolve the default app.
+	// Per-app DNS attribution is a separate, deferred concern.
+	session := p.getSession(context.Background())
 	mode := models.GetMode()
 	mockingEnabled := true
 	if session != nil {
@@ -429,7 +432,8 @@ func (p *Proxy) defaultDNSResponse(question dns.Question) dnsCacheEntry {
 }
 
 func (p *Proxy) getMockedDNSResponse(question dns.Question) (dnsCacheEntry, bool) {
-	mgr := p.getMockManager()
+	// Shared DNS path → default app (see ServeDNS).
+	mgr := p.getMockManager(context.Background())
 	if mgr == nil {
 		return dnsCacheEntry{}, false
 	}

--- a/pkg/agent/proxy/dns_forward_test.go
+++ b/pkg/agent/proxy/dns_forward_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
+	"go.keploy.io/server/v3/pkg/agent"
 	"go.keploy.io/server/v3/pkg/models"
 	"go.uber.org/zap"
 )
@@ -84,6 +85,7 @@ func newProxyWithUpstream(t *testing.T, addr string, timeout time.Duration) *Pro
 		dnsForwardTimeout:  timeout,
 		dnsCache:           newDNSCache(),
 		recordedDNSMocks:   newRecordedDNSMocksCache(),
+		apps:               NewAppRegistry(zap.NewNop()),
 	}
 }
 
@@ -229,7 +231,7 @@ func TestServeDNS_LocalMockHit_NoForward(t *testing.T) {
 			},
 		},
 	}})
-	p.mockManager = mgr
+	p.apps.GetOrCreate(agent.DefaultAppKey).mockManager = mgr
 
 	q := dns.Question{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
 	resp, mocked := p.getMockedDNSResponse(q)
@@ -288,7 +290,7 @@ func TestResolveUncachedDNSResponse_TestMode_UpstreamForwardSuccess(t *testing.T
 	// Empty mock manager — every query misses locally.
 	emptyMgr := NewMockManager(nil, nil, zap.NewNop())
 	t.Cleanup(emptyMgr.Close)
-	p.mockManager = emptyMgr
+	p.apps.GetOrCreate(agent.DefaultAppKey).mockManager = emptyMgr
 
 	q := dns.Question{Name: "mysql.sap-demo.svc.cluster.local.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
 	entry := p.resolveUncachedDNSResponse(q, models.MODE_TEST, true, time.Now(), nil)
@@ -339,7 +341,7 @@ func TestResolveUncachedDNSResponse_TestMode_UpstreamTimeoutFallback(t *testing.
 	p := newProxyWithUpstream(t, addr, 80*time.Millisecond)
 	emptyMgr := NewMockManager(nil, nil, zap.NewNop())
 	t.Cleanup(emptyMgr.Close)
-	p.mockManager = emptyMgr
+	p.apps.GetOrCreate(agent.DefaultAppKey).mockManager = emptyMgr
 
 	q := dns.Question{Name: "unreachable.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
 	entry := p.resolveUncachedDNSResponse(q, models.MODE_TEST, true, time.Now(), nil)
@@ -397,7 +399,7 @@ func TestResolveUncachedDNSResponse_TestMode_UpstreamNXDOMAIN_FallsBackToProxyIP
 	p := newProxyWithUpstream(t, addr, 2*time.Second)
 	emptyMgr := NewMockManager(nil, nil, zap.NewNop())
 	t.Cleanup(emptyMgr.Close)
-	p.mockManager = emptyMgr
+	p.apps.GetOrCreate(agent.DefaultAppKey).mockManager = emptyMgr
 
 	// "localstack" is the bare service name from the issue — no FQDN,
 	// so Docker DNS returns NXDOMAIN for it.
@@ -459,7 +461,7 @@ func TestResolveUncachedDNSResponse_TestMode_UpstreamSuccessPassesThrough(t *tes
 	p := newProxyWithUpstream(t, addr, 2*time.Second)
 	emptyMgr := NewMockManager(nil, nil, zap.NewNop())
 	t.Cleanup(emptyMgr.Close)
-	p.mockManager = emptyMgr
+	p.apps.GetOrCreate(agent.DefaultAppKey).mockManager = emptyMgr
 
 	q := dns.Question{Name: "mysql.sap-demo.svc.cluster.local.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
 	entry := p.resolveUncachedDNSResponse(q, models.MODE_TEST, true, time.Now(), nil)

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -652,7 +652,7 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 				releaseLock()
 				streamingExchange = true
 			} else if captureEnabled && pm.synchronous && acquiredLock {
-				mgr := syncMock.Get()
+				mgr := syncMock.FromContext(ctx)
 				if !mgr.GetFirstReqSeen() {
 					mgr.SetFirstRequestSignaled()
 				}

--- a/pkg/agent/proxy/integrations/generic/encode.go
+++ b/pkg/agent/proxy/integrations/generic/encode.go
@@ -182,7 +182,7 @@ func createGenericMocksAsync(ctx context.Context, logger *zap.Logger, clientCh, 
 				LifetimeDerived: true,
 			},
 		}
-		if mgr := syncMock.Get(); mgr != nil {
+		if mgr := syncMock.FromContext(ctx); mgr != nil {
 			mgr.AddMock(mock)
 		}
 		genericRequests = nil

--- a/pkg/agent/proxy/integrations/http/http.go
+++ b/pkg/agent/proxy/integrations/http/http.go
@@ -299,7 +299,7 @@ func (h *HTTP) parseFinalHTTP(ctx context.Context, mock *FinalHTTP, destPort uin
 		onMockRecorded(newMock)
 	}
 
-	if mgr := syncMock.Get(); mgr != nil {
+	if mgr := syncMock.FromContext(ctx); mgr != nil {
 		// Route HTTP mocks through the sync manager. The manager uses its
 		// internal first-request state to decide whether to buffer or forward
 		// mocks for correct time-window based association.

--- a/pkg/agent/proxy/integrations/mysql/recorder/record.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record.go
@@ -203,7 +203,7 @@ func recordMock(ctx context.Context, requests []mysql.Request, responses []mysql
 		},
 	}
 
-	if mgr := syncMock.Get(); mgr != nil {
+	if mgr := syncMock.FromContext(ctx); mgr != nil {
 		mgr.AddMock(mysqlMock)
 		return
 	}

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -131,12 +131,15 @@ type Proxy struct {
 	// errChannel from filling up with background noise (OTel, health checks).
 	activeTestErrors atomic.Pointer[testErrorAccumulator]
 	errDrainOnce     sync.Once
-	// session holds the single active session for this proxy.
-	// Previously this was a sync.Map keyed by appID (always 0), which is
-	// no longer needed since the proxy serves a single client-app.
-	sessionMu   sync.RWMutex
-	session     *agent.Session
-	mockManager *MockManager
+	// apps holds the per-application state (session + mockManager today;
+	// more per-app state migrates here incrementally) keyed by agent.AppKey
+	// so one proxy process can record/replay many apps concurrently. The
+	// control plane resolves the app from the request context
+	// (agent.AppKeyFromContext, stamped by the HTTP route middleware); the
+	// data plane (handleConnection) resolves it from the originating kernel
+	// PID via apps.Resolve. The DefaultAppKey AppContext reproduces the
+	// historical single-app behaviour byte-for-byte.
+	apps *AppRegistry
 
 	synchronous bool
 
@@ -632,6 +635,7 @@ func New(logger *zap.Logger, info agent.DestInfo, opts *config.Config) *Proxy {
 		ipMutex:                   &sync.Mutex{},
 		connMutex:                 &sync.Mutex{},
 		DestInfo:                  info,
+		apps:                      NewAppRegistry(logger),
 		clientClose:               make(chan bool, 1),
 		Integrations:              make(map[integrations.IntegrationType]integrations.Integrations),
 		GlobalPassthrough:         opts.Agent.GlobalPassthrough,
@@ -743,23 +747,28 @@ func (p *Proxy) buildRecordSession(
 	}
 }
 
-// getSession returns the current session in a thread-safe manner.
-func (p *Proxy) getSession() *agent.Session {
-	p.sessionMu.RLock()
-	defer p.sessionMu.RUnlock()
-	return p.session
+// appCtx resolves the AppContext for the app identified by ctx (the per-app
+// key stamped on the control path by the route middleware, or on the data
+// path by handleConnection from the originating kernel PID). With no key it
+// resolves the DefaultAppKey AppContext — the single-app path.
+func (p *Proxy) appCtx(ctx context.Context) *AppContext {
+	return p.apps.GetOrCreate(agent.AppKeyOrDefault(ctx))
 }
 
-// setSession replaces the current session in a thread-safe manner.
-func (p *Proxy) setSession(s *agent.Session) {
-	p.sessionMu.Lock()
-	defer p.sessionMu.Unlock()
-	p.session = s
+// getSession returns the current session for ctx's app in a thread-safe manner.
+func (p *Proxy) getSession(ctx context.Context) *agent.Session {
+	return p.appCtx(ctx).getSession()
 }
 
-// GetSession returns the current session in a thread-safe manner (exported for enterprise).
+// setSession replaces the current session for ctx's app in a thread-safe manner.
+func (p *Proxy) setSession(ctx context.Context, s *agent.Session) {
+	p.appCtx(ctx).setSession(s)
+}
+
+// GetSession returns the default app's session (exported for enterprise; the
+// no-context interface method resolves the DefaultAppKey app).
 func (p *Proxy) GetSession() *agent.Session {
-	return p.getSession()
+	return p.apps.GetOrCreate(agent.DefaultAppKey).getSession()
 }
 
 func (p *Proxy) GetDestInfo() agent.DestInfo {
@@ -820,30 +829,15 @@ func (p *Proxy) SetAuxiliaryHook(h agent.AuxiliaryProxyHook) {
 	p.auxiliaryHook = h
 }
 
-// getMockManager returns the current mock manager in a thread-safe manner.
-func (p *Proxy) getMockManager() *MockManager {
-	p.sessionMu.RLock()
-	defer p.sessionMu.RUnlock()
-	return p.mockManager
+// getMockManager returns the current mock manager for ctx's app.
+func (p *Proxy) getMockManager(ctx context.Context) *MockManager {
+	return p.appCtx(ctx).getMockManager()
 }
 
-// setMockManager replaces the current mock manager in a thread-safe manner.
-//
-// Swaps the new manager in while holding sessionMu, then closes the
-// PREVIOUS manager after releasing the lock — Close() must not run under
-// sessionMu because Close() synchronises with its own internal workers.
-// Closing the outgoing manager stops its background idle-sweeper
-// goroutine; without this, every Record / Mock session would leak a
-// goroutine since MockManager owns a per-instance ticker that only
-// stops on Close().
-func (p *Proxy) setMockManager(m *MockManager) {
-	p.sessionMu.Lock()
-	prev := p.mockManager
-	p.mockManager = m
-	p.sessionMu.Unlock()
-	if prev != nil {
-		prev.Close()
-	}
+// setMockManager replaces ctx's app mock manager, closing the previous one
+// outside the lock (see AppContext.setMockManager for the ordering contract).
+func (p *Proxy) setMockManager(ctx context.Context, m *MockManager) {
+	p.appCtx(ctx).setMockManager(m)
 }
 
 func (p *Proxy) InitIntegrations(_ context.Context) error {
@@ -1220,12 +1214,10 @@ func (p *Proxy) start(ctx context.Context, readyChan chan<- error) error {
 		// guaranteeing every send completes before close runs.
 		if mgr := syncMock.Get(); mgr != nil {
 			mgr.CloseOutChan()
-		} else {
-			p.sessionMu.RLock()
-			if p.session != nil && p.session.MC != nil {
-				close(p.session.MC)
+		} else if ac, ok := p.apps.Get(agent.DefaultAppKey); ok {
+			if rule := ac.getSession(); rule != nil && rule.MC != nil {
+				close(rule.MC)
 			}
-			p.sessionMu.RUnlock()
 		}
 
 		p.nsSwitchMutex.Lock()
@@ -1355,8 +1347,16 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 		return err
 	}
 
+	// Attribute this connection to its owning app from the originating
+	// kernel PID (eBPF redirect map → DestInfo.Pid) and stamp the app key
+	// onto ctx so every downstream consumer (session, mock manager, parser
+	// dispatch) operates on that app's state. Unresolved PIDs fall to
+	// DefaultAppKey — the single-app path — so this is behaviour-neutral
+	// until the data plane is actually multi-tenant.
+	ctx = agent.WithAppKey(ctx, p.apps.Resolve(destInfo.Pid))
+
 	//get the session rule
-	rule := p.getSession()
+	rule := p.getSession(ctx)
 	if rule == nil {
 		utils.LogError(p.logger, nil, "failed to fetch the session rule")
 		return err
@@ -1519,7 +1519,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 			return nil
 		}
 
-		m := p.getMockManager()
+		m := p.getMockManager(ctx)
 		if m == nil {
 			utils.LogError(p.logger, nil, "failed to fetch the mock manager")
 			return err
@@ -2129,7 +2129,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 	startConnCloser()
 
 	// get the mock manager for the current app
-	m := p.getMockManager()
+	m := p.getMockManager(ctx)
 	if m == nil {
 		utils.LogError(logger, err, "failed to fetch the mock manager")
 		return err
@@ -2428,12 +2428,12 @@ func (p *Proxy) Record(ctx context.Context, mocks chan<- *models.Mock, opts mode
 	// Lift the per-session opportunistic-TLS toggle onto the proxy
 	// for handleConnection to read. Independent of GlobalPassthrough.
 	p.OpportunisticTLSIntercept = opts.OpportunisticTLSIntercept
-	p.setSession(&agent.Session{
+	p.setSession(ctx, &agent.Session{
 		Mode:            models.MODE_RECORD,
 		MC:              mocks,
 		OutgoingOptions: opts,
 	})
-	p.setMockManager(NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), p.logger))
+	p.setMockManager(ctx, NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), p.logger))
 
 	if opts.CapturePackets {
 		// Agent picks its own scratch dir on its OWN filesystem; the
@@ -2457,13 +2457,13 @@ func (p *Proxy) Record(ctx context.Context, mocks chan<- *models.Mock, opts mode
 	return nil
 }
 
-func (p *Proxy) Mock(_ context.Context, opts models.OutgoingOptions) error {
+func (p *Proxy) Mock(ctx context.Context, opts models.OutgoingOptions) error {
 	// Reset graceful shutdown flag for a new mocking session.
 	p.isGracefulShutdown.Store(false)
 	// Mock is replay; no pcap capture during replay. Tear down any
 	// capture left over from a previous record session.
 	p.stopPacketCapture()
-	p.setSession(&agent.Session{
+	p.setSession(ctx, &agent.Session{
 		Mode:            models.MODE_TEST,
 		OutgoingOptions: opts,
 	})
@@ -2494,8 +2494,8 @@ func (p *Proxy) Mock(_ context.Context, opts models.OutgoingOptions) error {
 	// explicit reset a long-lived connection could match
 	// LifetimeConnection mocks from the prior test-set or merge them
 	// with the current one's.
-	if mm := p.getMockManager(); mm == nil {
-		p.setMockManager(NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), p.logger))
+	if mm := p.getMockManager(ctx); mm == nil {
+		p.setMockManager(ctx, NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), p.logger))
 	} else {
 		mm.ResetForReplaySession()
 	}
@@ -2517,8 +2517,8 @@ func (p *Proxy) Mock(_ context.Context, opts models.OutgoingOptions) error {
 	return nil
 }
 
-func (p *Proxy) SetMocks(_ context.Context, filtered []*models.Mock, unFiltered []*models.Mock) error {
-	if m := p.getMockManager(); m != nil {
+func (p *Proxy) SetMocks(ctx context.Context, filtered []*models.Mock, unFiltered []*models.Mock) error {
+	if m := p.getMockManager(ctx); m != nil {
 		m.SetFilteredMocks(filtered)
 		m.SetUnFilteredMocks(unFiltered)
 		p.dnsCache.Purge()
@@ -2530,8 +2530,8 @@ func (p *Proxy) SetMocks(_ context.Context, filtered []*models.Mock, unFiltered 
 // SetMocksWithWindow atomically updates mocks AND the test window in a
 // single call so concurrent readers cannot observe a torn (newMocks,
 // oldWindow) view. Used to satisfy the WindowedProxy extension interface.
-func (p *Proxy) SetMocksWithWindow(_ context.Context, filtered, unFiltered []*models.Mock, start, end time.Time) error {
-	if m := p.getMockManager(); m != nil {
+func (p *Proxy) SetMocksWithWindow(ctx context.Context, filtered, unFiltered []*models.Mock, start, end time.Time) error {
+	if m := p.getMockManager(ctx); m != nil {
 		m.SetMocksWithWindow(filtered, unFiltered, start, end)
 		p.dnsCache.Purge()
 	}
@@ -2549,15 +2549,19 @@ func (p *Proxy) SetMocksWithWindow(_ context.Context, filtered, unFiltered []*mo
 // Zero-time return means "no cutoff known yet" and callers should fall
 // back to legacy strict-gate semantics.
 func (p *Proxy) FirstTestWindowStart() time.Time {
-	if m := p.getMockManager(); m != nil {
+	// No context on this optional interface method; resolve the default
+	// app. Per-app window reporting (when needed) requires the windowed
+	// extension to carry the app key — tracked with the rest of the
+	// per-app error/window plane.
+	if m := p.apps.GetOrCreate(agent.DefaultAppKey).getMockManager(); m != nil {
 		return m.FirstTestWindowStart()
 	}
 	return time.Time{}
 }
 
-// GetConsumedMocks returns the consumed filtered mocks.
-func (p *Proxy) GetConsumedMocks(_ context.Context) ([]models.MockState, error) {
-	m := p.getMockManager()
+// GetConsumedMocks returns the consumed filtered mocks for ctx's app.
+func (p *Proxy) GetConsumedMocks(ctx context.Context) ([]models.MockState, error) {
+	m := p.getMockManager(ctx)
 	if m == nil {
 		return nil, fmt.Errorf("mock manager not found to get consumed filtered mocks")
 	}

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -1178,9 +1178,14 @@ func (p *Proxy) start(ctx context.Context, readyChan chan<- error) error {
 			case <-clientConnCtx.Done():
 				return
 			case <-ticker.C:
-				if mgr := syncMock.Get(); mgr != nil {
-					mgr.FlushOwnedWindows()
-				}
+				// Flush every app's mock-window manager (the default app's is
+				// the global one, so single-tenant is unchanged).
+				p.apps.Range(func(ac *AppContext) bool {
+					if ac.syncMgr != nil {
+						ac.syncMgr.FlushOwnedWindows()
+					}
+					return true
+				})
 			}
 		}
 	}()
@@ -1212,13 +1217,15 @@ func (p *Proxy) start(ctx context.Context, readyChan chan<- error) error {
 		// correlated with a 28-min process hang at runtime.
 		// CloseOutChan takes an RWMutex that AddMock holds for read,
 		// guaranteeing every send completes before close runs.
-		if mgr := syncMock.Get(); mgr != nil {
-			mgr.CloseOutChan()
-		} else if ac, ok := p.apps.Get(agent.DefaultAppKey); ok {
-			if rule := ac.getSession(); rule != nil && rule.MC != nil {
-				close(rule.MC)
+		// Close every app's mock channel via its syncMock manager (the
+		// default app's manager is the global one). CloseOutChan is
+		// idempotent + serialized against in-flight AddMock sends.
+		p.apps.Range(func(ac *AppContext) bool {
+			if ac.syncMgr != nil {
+				ac.syncMgr.CloseOutChan()
 			}
-		}
+			return true
+		})
 
 		p.nsSwitchMutex.Lock()
 		if string(p.nsswitchData) != "" {
@@ -1354,9 +1361,10 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 	// DefaultAppKey — the single-app path — so this is behaviour-neutral
 	// until the data plane is actually multi-tenant.
 	ctx = agent.WithAppKey(ctx, p.apps.Resolve(destInfo.Pid))
+	appCtx := p.appCtx(ctx)
 
 	//get the session rule
-	rule := p.getSession(ctx)
+	rule := appCtx.getSession()
 	if rule == nil {
 		utils.LogError(p.logger, nil, "failed to fetch the session rule")
 		return err
@@ -1366,8 +1374,13 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 	// goroutines handle connections concurrently and modify DstCfg/Synchronous
 	outgoingOpts := rule.OutgoingOptions
 
-	mgr := syncMock.Get()
+	// Bind this app's syncMock manager to its session's mock channel and stamp
+	// it on ctx so the parser emit sites (FromContext) route this app's mocks
+	// into its own manager. For the default app this is the global manager, so
+	// single-tenant behaviour is unchanged.
+	mgr := appCtx.syncMgr
 	mgr.SetOutputChannel(rule.MC)
+	ctx = syncMock.NewContext(ctx, mgr)
 	var dstAddr string
 
 	switch destInfo.Version {

--- a/pkg/agent/proxy/supervisor/session.go
+++ b/pkg/agent/proxy/supervisor/session.go
@@ -368,7 +368,7 @@ func (s *Session) emitMockCore(m *models.Mock, shutdown bool) error {
 	// the direct-channel fallback below runs. Production
 	// recordViaSupervisor sets it true.
 	if s.RouteMocksViaSyncMock {
-		if mgr := syncMock.Get(); mgr != nil {
+		if mgr := syncMock.FromContext(s.Ctx); mgr != nil {
 			// Best-effort ctx probe. mgr.AddMock (the SyncMock
 			// manager method obtained from syncMock.Get()) doesn't
 			// observe s.Ctx — it takes its own mutex and may sit

--- a/pkg/agent/proxy/syncMock/context.go
+++ b/pkg/agent/proxy/syncMock/context.go
@@ -1,0 +1,44 @@
+package manager
+
+import (
+	"context"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// New constructs a fresh, independent SyncMockManager. In a multi-tenant agent
+// each application owns its own manager (its own mock buffer, output channel,
+// firstReqSeen boundary and resolved-window ring) so one app's recording can
+// never bleed into another's. The process-global singleton (Get) is now just
+// New() called once at package load — the single-tenant / sidecar fallback.
+func New() *SyncMockManager {
+	return &SyncMockManager{
+		buffer:       make([]*models.Mock, 0, defaultMockBufferCapacity),
+		firstReqSeen: false,
+	}
+}
+
+type managerCtxKey struct{}
+
+// NewContext returns a copy of ctx carrying the per-app SyncMockManager. The
+// connection router stamps the owning app's manager onto the context before
+// dispatching to the protocol parsers; the parsers then resolve it back with
+// FromContext when emitting mocks, without threading the manager through every
+// RecordOutgoing signature.
+func NewContext(ctx context.Context, m *SyncMockManager) context.Context {
+	return context.WithValue(ctx, managerCtxKey{}, m)
+}
+
+// FromContext returns the per-app SyncMockManager carried on ctx, or the
+// process-global instance when none is present. The fallback makes the
+// migration safe and behaviour-neutral: an emit site switched from Get() to
+// FromContext(ctx) resolves to exactly the global manager until a per-app
+// manager is actually stamped onto the context (sidecar / no-key path).
+func FromContext(ctx context.Context) *SyncMockManager {
+	if ctx != nil {
+		if m, ok := ctx.Value(managerCtxKey{}).(*SyncMockManager); ok && m != nil {
+			return m
+		}
+	}
+	return instance
+}

--- a/pkg/agent/proxy/syncMock/context_test.go
+++ b/pkg/agent/proxy/syncMock/context_test.go
@@ -1,0 +1,41 @@
+package manager
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewReturnsIndependentManagers(t *testing.T) {
+	a := New()
+	b := New()
+	if a == b {
+		t.Fatalf("New must return distinct managers")
+	}
+	if a == instance || b == instance {
+		t.Fatalf("New must not return the global instance")
+	}
+	if a.buffer == nil {
+		t.Fatalf("New must initialise the buffer")
+	}
+}
+
+func TestFromContextFallsBackToGlobal(t *testing.T) {
+	if FromContext(context.Background()) != instance {
+		t.Fatalf("FromContext with no manager must fall back to the global instance")
+	}
+	var nilCtx context.Context // exercise the guarded nil-ctx edge
+	if FromContext(nilCtx) != instance {
+		t.Fatalf("FromContext(nil) must fall back to the global instance")
+	}
+}
+
+func TestFromContextReturnsStampedManager(t *testing.T) {
+	m := New()
+	ctx := NewContext(context.Background(), m)
+	if FromContext(ctx) != m {
+		t.Fatalf("FromContext must return the manager stamped by NewContext")
+	}
+	if FromContext(ctx) == instance {
+		t.Fatalf("FromContext must not fall back when a manager is present")
+	}
+}

--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -96,13 +96,14 @@ type SyncMockManager struct {
 	logger   *zap.Logger
 }
 
-// Global instance is initialized at package load time
-var instance = &SyncMockManager{
-	buffer:       make([]*models.Mock, 0, defaultMockBufferCapacity),
-	firstReqSeen: false,
-}
+// Global instance is initialized at package load time. It is the
+// single-tenant / sidecar fallback returned by Get() and by FromContext()
+// when no per-app manager is on the context. Built via New() so there is one
+// construction path.
+var instance = New()
 
-// Get returns the global manager.
+// Get returns the global manager (single-tenant fallback). Prefer
+// FromContext(ctx) on the data path so per-app managers are honoured.
 func Get() *SyncMockManager {
 	return instance
 }

--- a/pkg/agent/routes/middleware_test.go
+++ b/pkg/agent/routes/middleware_test.go
@@ -1,0 +1,39 @@
+package routes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	coreagent "go.keploy.io/server/v3/pkg/agent"
+)
+
+func TestAppIDMiddlewareStampsKey(t *testing.T) {
+	var got coreagent.AppKey
+	var ok bool
+	h := appIDMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		got, ok = coreagent.AppKeyFromContext(r.Context())
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/agent/health", nil)
+	req.Header.Set(AppIDHeader, "ns/dep/ts-1")
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	if !ok || got != coreagent.AppKey("ns/dep/ts-1") {
+		t.Fatalf("expected key ns/dep/ts-1 on ctx, got (%q, %v)", got, ok)
+	}
+}
+
+func TestAppIDMiddlewareNoHeaderIsDefault(t *testing.T) {
+	var present bool
+	h := appIDMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		_, present = coreagent.AppKeyFromContext(r.Context())
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/agent/health", nil)
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	if present {
+		t.Fatalf("expected no app key on ctx when header absent (DefaultAppKey path)")
+	}
+}

--- a/pkg/agent/routes/record.go
+++ b/pkg/agent/routes/record.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
+	coreagent "go.keploy.io/server/v3/pkg/agent"
 	pTls "go.keploy.io/server/v3/pkg/agent/proxy/tls"
 	"go.keploy.io/server/v3/pkg/models"
 	kdocker "go.keploy.io/server/v3/pkg/platform/docker"
@@ -62,6 +63,12 @@ func (d DefaultRoutes) New(r chi.Router, agent agent.Service, logger *zap.Logger
 	}
 
 	r.Route("/agent", func(r chi.Router) {
+		// Multi-tenancy: lift the per-app key off the X-Keploy-App-Id
+		// header onto the request context so every handler/service/proxy
+		// call operates on that app's state. Absent header → no key →
+		// DefaultAppKey (single-app path), so this is behaviour-neutral
+		// for existing single-tenant clients.
+		r.Use(appIDMiddleware)
 		r.Get("/health", a.Health)
 		r.Post("/incoming", a.HandleIncoming)
 		r.Post("/outgoing", a.HandleOutgoing)
@@ -89,6 +96,23 @@ func (d DefaultRoutes) New(r chi.Router, agent agent.Service, logger *zap.Logger
 		r.Post("/hooks/before-test-run", a.HandleBeforeTestRun)
 		r.Post("/hooks/before-test-set-compose", a.HandleBeforeTestSetCompose)
 		r.Post("/hooks/after-test-run", a.HandleAfterTestRun)
+	})
+}
+
+// AppIDHeader is the HTTP header the client stamps with its per-app key so
+// the multi-tenant agent can route the request to that app's state.
+const AppIDHeader = "X-Keploy-App-Id"
+
+// appIDMiddleware lifts the per-app key from the AppIDHeader onto the request
+// context (via coreagent.WithAppKey). When the header is absent the context
+// is unchanged and downstream code resolves DefaultAppKey — the single-app
+// path — so single-tenant clients are unaffected.
+func appIDMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if v := r.Header.Get(AppIDHeader); v != "" {
+			r = r.WithContext(coreagent.WithAppKey(r.Context(), coreagent.AppKey(v)))
+		}
+		next.ServeHTTP(w, r)
 	})
 }
 

--- a/pkg/agent/service.go
+++ b/pkg/agent/service.go
@@ -136,6 +136,12 @@ type NetworkAddress struct {
 	IPv4Addr uint32
 	IPv6Addr [4]uint32
 	Port     uint32
+	// Pid is the kernel TGID of the process that originated the intercepted
+	// connection, surfaced from the eBPF redirect map's DestInfo.KernelPid.
+	// It is the attribution key for multi-tenancy: the proxy resolves which
+	// AppContext an accepted connection belongs to from this PID. Zero when
+	// the hooks implementation does not populate it (non-Linux, or no entry).
+	Pid uint32
 }
 
 // Sessions provides a thread-safe store for Session objects, keyed by ID.

--- a/pkg/agent/service.go
+++ b/pkg/agent/service.go
@@ -110,6 +110,31 @@ type FirstWindowStartReader interface {
 	FirstTestWindowStart() time.Time
 }
 
+// AppRegistrar is the optional extension implemented by proxies that support
+// multi-tenant per-app routing. Embedders that run one agent for many apps
+// (e.g. the enterprise daemonset) type-assert from Proxy and gracefully fall
+// back when the assertion fails — keeping third-party Proxy implementations
+// compiling without the multi-tenant surface.
+//
+//	if r, ok := p.(AppRegistrar); ok {
+//	    r.SetAppResolver(reconciler.AppForPID) // data-plane attribution
+//	    r.RegisterApp(key, rootPID)            // control-plane setup
+//	}
+type AppRegistrar interface {
+	// SetAppResolver installs the PID→app attribution function used on the
+	// data path to map an intercepted connection's originating kernel PID
+	// (NetworkAddress.Pid) to its AppKey. Overrides the proxy's default
+	// /proc-ancestry resolver.
+	SetAppResolver(resolver func(kernelPid uint32) (AppKey, bool))
+	// RegisterApp creates (if absent) the per-app state for key and seeds
+	// the attribution cache with the app's root PID(s) so the data plane
+	// resolves the same key the control plane uses.
+	RegisterApp(key AppKey, rootPIDs ...uint32)
+	// DeregisterApp tears down the app's per-app state and evicts its PID
+	// cache entries.
+	DeregisterApp(key AppKey)
+}
+
 type IncomingProxy interface {
 	Start(ctx context.Context, opts models.IncomingOptions) chan *models.TestCase
 }

--- a/pkg/agent/service.go
+++ b/pkg/agent/service.go
@@ -133,6 +133,12 @@ type AppRegistrar interface {
 	// DeregisterApp tears down the app's per-app state and evicts its PID
 	// cache entries.
 	DeregisterApp(key AppKey)
+	// ResolveAppKey maps an intercepted connection's originating kernel PID
+	// to its owning app key, reporting whether it was attributed (ok=false
+	// → unattributed: cold-start / not a target / ambiguous). Used by
+	// embedders that capture outside handleConnection (the daemonset
+	// proxyless reader) to stamp the per-app key on the capture context.
+	ResolveAppKey(kernelPid uint32) (AppKey, bool)
 }
 
 type IncomingProxy interface {

--- a/pkg/platform/http/agent.go
+++ b/pkg/platform/http/agent.go
@@ -42,27 +42,86 @@ const (
 )
 
 // TODO: Need to refactor this file
+// appIDHeader is the per-app key header the multi-tenant agent routes on.
+// Kept in sync with routes.AppIDHeader (declared there to avoid an import
+// cycle between the client and the agent route package).
+const appIDHeader = "X-Keploy-App-Id"
+
+// appIDTransport stamps the per-app key (X-Keploy-App-Id) onto every request
+// to the agent so a shared multi-tenant agent can route it to the right app.
+// keyFn is read per-request; an empty key stamps nothing, so single-tenant
+// clients (the default) send no header and the agent falls back to its
+// DefaultAppKey — behaviour-neutral.
+type appIDTransport struct {
+	base  http.RoundTripper
+	keyFn func() string
+}
+
+func (t *appIDTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	if key := t.keyFn(); key != "" && r.Header.Get(appIDHeader) == "" {
+		r = r.Clone(r.Context())
+		r.Header.Set(appIDHeader, key)
+	}
+	return base.RoundTrip(r)
+}
+
 type AgentClient struct {
 	logger       *zap.Logger
 	dockerClient kdocker.Client //embedding the docker client to transfer the docker client methods to the core object
 	apps         sync.Map
 	client       http.Client
-	conf         *config.Config
-	agentCmd     *exec.Cmd             // Track the agent process
-	agentPTY     *agentUtils.PTYHandle // Track the PTY handle for interactive commands
-	mu           sync.Mutex
-	agentCancel  context.CancelFunc // Function to cancel the agent context
+	// appKey is this client's per-app key, stamped on every agent request
+	// via appIDTransport. Empty (default) means single-tenant: no header is
+	// sent and the agent uses its DefaultAppKey. Set by SetAppKey once the
+	// shared-daemon / daemonset register handshake assigns one.
+	appKey      string
+	conf        *config.Config
+	agentCmd    *exec.Cmd             // Track the agent process
+	agentPTY    *agentUtils.PTYHandle // Track the PTY handle for interactive commands
+	mu          sync.Mutex
+	agentCancel context.CancelFunc // Function to cancel the agent context
 }
 
 // var initStopScript []byte
 
 func New(logger *zap.Logger, client kdocker.Client, c *config.Config) *AgentClient {
-
-	return &AgentClient{
+	a := &AgentClient{
 		logger:       logger,
 		dockerClient: client,
-		client:       http.Client{},
 		conf:         c,
+	}
+	// All agent requests flow through a transport that stamps the per-app
+	// key header (no-op while appKey is empty — the single-tenant default).
+	a.client = http.Client{Transport: &appIDTransport{base: http.DefaultTransport, keyFn: a.currentAppKey}}
+	return a
+}
+
+// SetAppKey sets this client's per-app key. Subsequent agent requests carry
+// it as the X-Keploy-App-Id header so a shared multi-tenant agent routes them
+// to this app. Empty restores single-tenant behaviour (no header).
+func (a *AgentClient) SetAppKey(key string) {
+	a.mu.Lock()
+	a.appKey = key
+	a.mu.Unlock()
+}
+
+func (a *AgentClient) currentAppKey() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.appKey
+}
+
+// httpClient returns an http.Client with the given timeout that shares the
+// per-app-key stamping transport, so one-off request clients (e.g. the
+// /hooks/* calls) also carry the X-Keploy-App-Id header when set.
+func (a *AgentClient) httpClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: &appIDTransport{base: http.DefaultTransport, keyFn: a.currentAppKey},
 	}
 }
 
@@ -476,7 +535,7 @@ func (a *AgentClient) BeforeSimulate(ctx context.Context, timestamp *time.Time, 
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	client := &http.Client{Timeout: 50 * time.Second}
+	client := a.httpClient(50 * time.Second)
 	resp, err := client.Do(req)
 	if err != nil {
 		a.logger.Debug("failed to call agent hook", zap.String("endpoint", "/hooks/before-simulate"), zap.Error(err))
@@ -512,7 +571,7 @@ func (a *AgentClient) AfterSimulate(ctx context.Context, tcName string, testSetI
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	client := &http.Client{Timeout: 50 * time.Second}
+	client := a.httpClient(50 * time.Second)
 	resp, err := client.Do(req)
 	if err != nil {
 		a.logger.Debug("failed to call agent hook", zap.String("endpoint", "/hooks/after-simulate"), zap.Error(err))
@@ -547,7 +606,7 @@ func (a *AgentClient) BeforeTestRun(ctx context.Context, testRunID string) error
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	client := &http.Client{Timeout: 50 * time.Second}
+	client := a.httpClient(50 * time.Second)
 	resp, err := client.Do(req)
 	if err != nil {
 		a.logger.Debug("failed to call agent hook", zap.String("endpoint", "/hooks/before-test-run"), zap.Error(err))
@@ -584,7 +643,7 @@ func (a *AgentClient) BeforeTestSetCompose(ctx context.Context, testRunID string
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	client := &http.Client{Timeout: 50 * time.Second}
+	client := a.httpClient(50 * time.Second)
 	resp, err := client.Do(req)
 	if err != nil {
 		a.logger.Debug("failed to call agent hook", zap.String("endpoint", "/hooks/before-test-set-compose"), zap.Error(err))
@@ -622,7 +681,7 @@ func (a *AgentClient) AfterTestRun(ctx context.Context, testRunID string, testSe
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	client := &http.Client{Timeout: 50 * time.Second}
+	client := a.httpClient(50 * time.Second)
 	resp, err := client.Do(req)
 	if err != nil {
 		a.logger.Debug("failed to call agent hook", zap.String("endpoint", "/hooks/after-test-run"), zap.Error(err))

--- a/pkg/platform/http/agent_appkey_test.go
+++ b/pkg/platform/http/agent_appkey_test.go
@@ -1,0 +1,36 @@
+package http
+
+import (
+	"net/http"
+	"testing"
+)
+
+type captureRT struct{ seen string }
+
+func (c *captureRT) RoundTrip(r *http.Request) (*http.Response, error) {
+	c.seen = r.Header.Get(appIDHeader)
+	return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: make(http.Header)}, nil
+}
+
+func doReq(t *testing.T, key string) string {
+	t.Helper()
+	cap := &captureRT{}
+	tr := &appIDTransport{base: cap, keyFn: func() string { return key }}
+	req, _ := http.NewRequest(http.MethodGet, "http://localhost/agent/health", nil)
+	if _, err := tr.RoundTrip(req); err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	return cap.seen
+}
+
+func TestAppIDTransportStampsWhenKeySet(t *testing.T) {
+	if got := doReq(t, "ns/dep/ts-1"); got != "ns/dep/ts-1" {
+		t.Fatalf("header = %q, want ns/dep/ts-1", got)
+	}
+}
+
+func TestAppIDTransportNoHeaderWhenKeyEmpty(t *testing.T) {
+	if got := doReq(t, ""); got != "" {
+		t.Fatalf("expected no %s header for empty key, got %q", appIDHeader, got)
+	}
+}

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -39,7 +39,7 @@ type Agent struct {
 	config       *config.Config
 	// activeClients sync.Map
 	// New field for storing client-specific mocks
-	clientMocks sync.Map // map[uint64]*ClientMockStorage
+	clientMocks sync.Map // map[coreAgent.AppKey]*ClientMockStorage
 	Ip          string
 
 	// strictLogOnce de-dupes the "strict mock window enabled" Info log
@@ -658,7 +658,7 @@ func (a *Agent) StoreMocks(ctx context.Context, filtered []*models.Mock, unfilte
 		}
 	}
 
-	a.clientMocks.Store(uint64(0), storage)
+	a.clientMocks.Store(coreAgent.AppKeyOrDefault(ctx), storage)
 
 	// Compute the freeze anchor as the earliest ReqTimestampMock across the
 	// stored mocks and forward it to AgentHooks. The hook implementation
@@ -746,8 +746,9 @@ func (a *Agent) UpdateMockParams(ctx context.Context, params models.MockFilterPa
 			zap.Time("windowEnd", params.BeforeTime))
 	}
 
-	// Get stored mocks for the client
-	storageInterface, exists := a.clientMocks.Load(uint64(0))
+	// Get stored mocks for the app addressed by this request (per-app key
+	// from ctx; DefaultAppKey for single-tenant clients).
+	storageInterface, exists := a.clientMocks.Load(coreAgent.AppKeyOrDefault(ctx))
 	if !exists {
 		return fmt.Errorf("no mocks stored for client ID")
 	}


### PR DESCRIPTION
## What

Multi-tenant keploy-agent — **OSS user-space foundation** (#4275). Lets one agent process serve many applications concurrently, with per-app state keyed by an opaque app/session key. **Draft.** Every commit is behaviour-neutral: with no key present everything resolves to `DefaultAppKey` (single-app), reproducing today's behaviour. Builds (`go build ./...`), `go vet`, and unit tests pass.

This PR consolidates what were 5 stacked slices into one (closing #4276–#4279); each is a self-contained commit below.

## Commits / slices

1. **Foundation** — `agent.AppKey` + `WithAppKey`/`AppKeyFromContext` context helpers; surface the originating kernel TGID on `agent.NetworkAddress.Pid` (from `DestInfo.KernelPid` in `hooks/linux/comm.go`); `proxy.AppContext` (owns the per-app session/mockManager/dnsCache/recordedDNSMocks/errChannel/pcap/syncMgr) + `proxy.AppRegistry` (key→ctx store + pluggable `/proc`-ancestry PID resolver + cache).
2. **syncMock** — `New()` constructor + `NewContext`/`FromContext` carrier so each app can own an independent mock-window manager; falls back to the global instance when no manager is on ctx (migration-safe).
3. **Proxy per-app** — move `session`/`mockManager` into `AppContext`, keyed via `ctx`; `handleConnection` attributes each connection to its app from `DestInfo.Pid → apps.Resolve` and stamps the key on ctx; `Record`/`Mock`/`SetMocks`/`SetMocksWithWindow`/`GetConsumedMocks` operate on the ctx's app.
4. **Service + routes** — `appIDMiddleware` lifts `X-Keploy-App-Id` onto the request context; `Agent.clientMocks` keyed by the per-app key instead of `uint64(0)`. Makes the control path per-app end to end.
5. **Client** — `appIDTransport` stamps `X-Keploy-App-Id` on every agent request (incl. `/hooks/*`) from the client's app key; `SetAppKey` sets it; empty (default) sends no header → inert.

## Behaviour-neutral & tested

Single-tenant path is unchanged (`DefaultAppKey` / empty key). New unit tests cover the key context helpers, the registry resolve/cache/delete, `syncMock` New/FromContext, the route middleware, and the client transport. Full `pkg/agent/proxy` package tests pass.

## Deliberately out of scope (follow-ups, see #4275)

- Per-app `syncMock` emit-site wiring (`http`/`mysql`/`generic`/`dns`/`supervisor`/`incoming`/`conn` `Get()` → `FromContext(ctx)`) — must land **atomically** with the per-app manager wiring in `handleConnection`, else single-app record breaks.
- Per-app `tcChan`/ingress drainer; per-app `dnsCache`/`errChannel`/`pcap`/`isGracefulShutdown`.
- `/agent/register` handshake (tie the key ↔ client root PID so data-plane PID attribution agrees with the control-plane header) — **activates** the client header; gated on the shared-daemon / daemonset lifecycle.
- Enterprise per-feature isolation (time-freeze, static-dedup, coverage, upload target) and the daemonset `SessionForPID` bridge.

Stays in **draft** until the dependent slices land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
