### PR TITLE
fix(proxy/http): don't log a recovered passthrough fallback at ERROR

### DIFF
--- a/pkg/agent/proxy/integrations/http/recordv2.go
+++ b/pkg/agent/proxy/integrations/http/recordv2.go
@@ -34,6 +34,23 @@ import (
 // incomplete-mock gate) rather than the syncMock / mocks channel shim
 // the legacy path uses.
 //
+// isBenignIncompleteCapture reports whether err means the recorded exchange was
+// cut off by the peer closing before a full HTTP message was captured — EOF /
+// unexpected EOF (a truncated body, e.g. an SQS ReceiveMessage long-poll that
+// the peer closes at shutdown), the teed FakeConn closing, or context
+// cancellation. These are expected, recoverable conditions: the parser
+// supervisor falls back to passthrough and the relay keeps forwarding, so they
+// must not be logged as errors. A non-benign error (a genuine decode/build
+// failure on a complete exchange) means a mock was dropped and is worth a
+// warning. errors.Is unwraps, so a `fmt.Errorf("...: %w", io.ErrUnexpectedEOF)`
+// from buildHTTPMock is correctly classified as benign.
+func isBenignIncompleteCapture(err error) bool {
+	return errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, fakeconn.ErrClosed) ||
+		errors.Is(err, context.Canceled)
+}
+
 // recordV2 loops over request/response pairs for HTTP/1.1 keepalive /
 // pipelining. It exits cleanly on either stream reaching EOF or Close,
 // on ctx cancellation, or on a malformed-HTTP decode error (in which
@@ -149,7 +166,20 @@ func (h *HTTP) recordV2(ctx context.Context, sess *supervisor.Session) error {
 		}, destPort, sess.ClientConnID, sess.Opts)
 		if err != nil {
 			sess.MarkMockIncomplete("http decode error: " + err.Error())
-			utils.LogError(logger, err, "V2 HTTP record: failed to build mock")
+			// A failed build is ALWAYS recovered by the parser supervisor's
+			// passthrough fallback (the relay keeps forwarding raw bytes until
+			// the peer closes), so it is never fatal — logging it at ERROR is
+			// misleading. Classify by cause: an incomplete/truncated capture
+			// from the peer closing before a full message (long-polls,
+			// streaming, client aborts, shutdown races — e.g. an SQS
+			// ReceiveMessage long-poll) is expected and logs at Debug; a genuine
+			// build failure on a complete exchange dropped a mock that replay
+			// may miss, so it logs at Warn (surfaced, not alarming).
+			if isBenignIncompleteCapture(err) {
+				logger.Debug("V2 HTTP record: skipping mock for an incomplete exchange (peer closed before a full message); relaying via passthrough", zap.Error(err))
+			} else {
+				logger.Warn("V2 HTTP record: failed to build mock; relaying via passthrough (mock dropped, replay may miss this interaction)", zap.Error(err))
+			}
 			return err
 		}
 		if mock != nil {

--- a/pkg/agent/proxy/integrations/http/recordv2_loglevel_test.go
+++ b/pkg/agent/proxy/integrations/http/recordv2_loglevel_test.go
@@ -1,0 +1,93 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy/fakeconn"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// TestIsBenignIncompleteCapture pins the classification that decides whether a
+// failed V2-HTTP-record build is logged quietly (Debug) or surfaced (Warn) —
+// never Error, because the parser supervisor always recovers via passthrough.
+func TestIsBenignIncompleteCapture(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain EOF", io.EOF, true},
+		{"wrapped EOF", fmt.Errorf("dest stream: %w", io.EOF), true},
+		{"unexpected EOF", io.ErrUnexpectedEOF, true},
+		// The exact shape buildHTTPMock returns for a truncated body (e.g. an
+		// SQS ReceiveMessage long-poll the peer closes at shutdown).
+		{"read response body: unexpected EOF", fmt.Errorf("read response body: %w", io.ErrUnexpectedEOF), true},
+		{"fakeconn closed", fakeconn.ErrClosed, true},
+		{"wrapped fakeconn closed", fmt.Errorf("relay: %w", fakeconn.ErrClosed), true},
+		{"context canceled", context.Canceled, true},
+		{"genuine decode error", errors.New("malformed chunked encoding"), false},
+		{"unrelated sentinel", io.ErrShortWrite, false},
+	}
+	for _, c := range cases {
+		if got := isBenignIncompleteCapture(c.err); got != c.want {
+			t.Errorf("isBenignIncompleteCapture(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// TestRecordV2_TruncatedResponseNotLoggedAsError is the end-to-end guard for the
+// reported issue: a response whose body is cut short by the peer closing early
+// (the SQS long-poll shape) makes buildHTTPMock fail with io.ErrUnexpectedEOF.
+// keploy recovers via passthrough, so this must NOT be logged at Error — it
+// should leave a quiet Debug breadcrumb instead.
+func TestRecordV2_TruncatedResponseNotLoggedAsError(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	obs := zap.New(core)
+	h := &HTTP{Logger: obs}
+
+	sess, sendReq, closeReq, sendResp, closeResp, _ := newTestSession(t)
+	sess.Logger = obs // recordV2 prefers sess.Logger over h.Logger
+
+	t0 := time.Unix(1_700_000_000, 0)
+	sendReq(canonicalRequest, t0, t0.Add(time.Millisecond))
+	// Declares Content-Length: 100 but only 5 body bytes arrive before close →
+	// buildHTTPMock's body read returns io.ErrUnexpectedEOF.
+	truncated := []byte(
+		"HTTP/1.1 200 OK\r\n" +
+			"Content-Type: text/plain\r\n" +
+			"Content-Length: 100\r\n" +
+			"\r\n" +
+			"hello",
+	)
+	sendResp(truncated, t0.Add(2*time.Millisecond), t0.Add(3*time.Millisecond))
+	closeReq()
+	closeResp()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- h.recordV2(ctx, sess) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("recordV2 did not exit within 2s")
+	}
+
+	for _, e := range logs.All() {
+		if e.Level >= zapcore.ErrorLevel {
+			t.Fatalf("recovered truncated capture logged at %s (want <= Warn): %q", e.Level, e.Message)
+		}
+	}
+	if logs.FilterMessageSnippet("incomplete exchange").Len() == 0 {
+		t.Errorf("expected a Debug breadcrumb for the incomplete exchange; entries=%v", logs.All())
+	}
+}


### PR DESCRIPTION
## Problem

When the V2 HTTP record path fails to build a mock, the parser supervisor **always recovers** by falling back to passthrough (the relay keeps forwarding raw bytes until the peer closes) — so the failure is never fatal. But `recordV2` logged it at **ERROR**:

```
ERROR  V2 HTTP record: failed to build mock {error: "read response body: unexpected EOF"}
```

This is alarming and misleading for anyone recording traffic where the peer closes a connection before a full HTTP message is captured — **SQS `ReceiveMessage` long-polls**, streaming responses, client aborts, and shutdown races all trip it. (It also makes CI lanes that `grep ERROR` the keploy log red on a perfectly-recovered recording.) The supervisor already logs the passthrough fallback itself at `Debug`; only this one site over-reports.

## Fix

Classify the build error by cause (it is never fatal, so it is never `Error`):

| Cause | Level | Why |
|---|---|---|
| `io.EOF` / `io.ErrUnexpectedEOF` / `fakeconn.ErrClosed` / `context.Canceled` | **Debug** | the exchange was cut off mid-message — expected for long-polls / streaming / shutdown; nothing to record |
| any other build error on a complete exchange | **Warn** | a mock was dropped and replay may miss that interaction — surfaced, but not alarming |

The decision is extracted into a small pure helper `isBenignIncompleteCapture` (`errors.Is` unwraps the `fmt.Errorf("read response body: %w", io.ErrUnexpectedEOF)` from `buildHTTPMock`, so the real SQS shape is classified correctly).

## Tests

- `TestIsBenignIncompleteCapture` — table test of the classifier, incl. the exact wrapped `read response body: unexpected EOF`.
- `TestRecordV2_TruncatedResponseNotLoggedAsError` — drives a truncated (`Content-Length: 100`, 5 bytes + close) response through `recordV2` with a zap observer and asserts **nothing is logged at ERROR** and a `Debug` breadcrumb is left.

Full `pkg/agent/proxy/integrations/http` suite passes; `go vet` clean.
