### PR TITLE
fix: startup mocks until first 5 test cases

### DIFF
--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -47,12 +47,24 @@ func generateRandomString(n int) string {
 
 type SyncMockManager struct {
 	// mu guards buffer, firstReqSeen, memoryPause, mappingChan,
-	// recentWindows.
+	// recentWindows, resolvedTestCount.
 	mu           sync.Mutex
 	buffer       []*models.Mock
 	mappingChan  chan<- models.TestMockMapping
 	firstReqSeen bool
 	memoryPause  bool
+
+	// resolvedTestCount is the number of UNIQUE recorded test cases resolved so
+	// far (incremented once per kept ResolveRange — duplicates skipped by static
+	// dedup resolve with keep=false and do NOT advance it). It defines the
+	// startup window: while it is < models.StartupMockTestCaseWindow, every mock
+	// AddMock ingests is tagged TestModeInfo.IsStartup, so the dedup reapers
+	// (DeleteMocksStrictlyBefore, the ResolveRange keep=false / out-of-window
+	// rescues, the memory-pressure wipe) preserve it instead of pruning. The
+	// effect is that static-dedup pruning only begins from the (N+1)-th test
+	// case, keeping the boot-through-Nth-test mock corpus complete. Mirrors
+	// firstReqSeen's lifecycle (set forward-only within a record session).
+	resolvedTestCount int
 
 	// recentWindows is a bounded, time-pruned ring of the most recently
 	// RESOLVED per-test windows. It exists to close the async-emit vs
@@ -257,15 +269,20 @@ func (m *SyncMockManager) AddMock(mock *models.Mock) {
 		return
 	}
 
-	// Tag app-bootstrap traffic. Any mock captured before the first
-	// inbound request is startup/init traffic (e.g. an AWS Secret Manager
-	// fetch at boot) that ran before any test window exists. It can never
-	// claim a per-test window, so the reapers below (dedup DeleteMocks-
-	// StrictlyBefore, the ResolveRange stale-cutoff, FlushOwnedWindows and
-	// the memory-pressure wipe) would otherwise drop it. firstReqSeen,
-	// flipped on the first inbound request, is the boot-vs-test boundary;
-	// tagging here is the sole signal isStartupMock keys off.
-	if mock != nil && !m.firstReqSeen {
+	// Tag startup-window traffic. A mock is "startup" when it is captured
+	// either (a) before the first inbound request — classic app-bootstrap
+	// traffic (e.g. an AWS Secret Manager fetch at boot) that ran before any
+	// test window exists — or (b) while we are still inside the startup window,
+	// i.e. fewer than models.StartupMockTestCaseWindow unique test cases have
+	// been recorded. Case (b) widens the old "before firstReqSeen" rule so the
+	// boot-through-Nth-test mock corpus is preserved wholesale: the IsStartup
+	// tag is the single signal every reaper below keys off (dedup DeleteMocks-
+	// StrictlyBefore, the ResolveRange keep=false / out-of-window / stale-cutoff
+	// rescues, FlushOwnedWindows, and the memory-pressure wipe), so tagging here
+	// makes static-dedup pruning a no-op until the (N+1)-th test case. (firstReqSeen
+	// is subsumed by the count test — count is 0 before the first request — but
+	// is kept explicit so the boot case still holds if the window is ever 0.)
+	if mock != nil && (!m.firstReqSeen || m.resolvedTestCount < models.StartupMockTestCaseWindow) {
 		mock.TestModeInfo.IsStartup = true
 	}
 
@@ -429,11 +446,12 @@ func (m *SyncMockManager) FlushOwnedWindows() {
 			mocksToSend = append(mocksToSend, mock)
 			continue
 		}
-		// STARTUP RESCUE: app-bootstrap traffic owns no window (it ran
-		// before any test) so the ownerWindow check above never claims it.
-		// Flush it to disk proactively on the ticker rather than leaving it
-		// parked in the buffer where a dedup cleanup, stale-cutoff, or
-		// memory-pressure wipe could reap it before it is ever persisted.
+		// STARTUP RESCUE: a startup-window mock the ownerWindow check above
+		// didn't claim (boot traffic owns no window; an early-test mock whose
+		// window hasn't resolved yet on this ticker tick). Flush it to disk
+		// proactively rather than leaving it parked in the buffer where a dedup
+		// cleanup, stale-cutoff, or memory-pressure wipe could reap it before it
+		// is ever persisted.
 		if isStartupMock(mock) {
 			mock.Name = "mock-" + generateRandomString(8)
 			mocksToSend = append(mocksToSend, mock)
@@ -494,13 +512,13 @@ func (m *SyncMockManager) SetMemoryPressure(enabled bool) {
 	}
 
 	// Drop buffered mocks to relieve memory pressure, but PRESERVE startup
-	// mocks. They were captured before the first inbound request, own no
-	// test window, and the periodic FlushOwnedWindows drain is their only
-	// remaining route to disk — wiping them here would silently lose the
-	// once-per-boot startup mock, the exact data loss the IsStartup tag
-	// exists to prevent (mirrors the rescues in DeleteMocksStrictlyBefore,
-	// ResolveRange and FlushOwnedWindows). They are few (typically one per
-	// boot), so the memory relief is effectively unchanged.
+	// mocks (boot traffic and everything captured within the first
+	// StartupMockTestCaseWindow test cases). The periodic FlushOwnedWindows
+	// drain is their route to disk — wiping them here would silently lose
+	// startup mocks, the exact data loss the IsStartup tag exists to prevent
+	// (mirrors the rescues in DeleteMocksStrictlyBefore, ResolveRange and
+	// FlushOwnedWindows). Under memory pressure the startup corpus is bounded
+	// by the window, so the memory relief from dropping the rest is preserved.
 	var kept []*models.Mock
 	for i := range m.buffer {
 		if isStartupMock(m.buffer[i]) {
@@ -513,17 +531,18 @@ func (m *SyncMockManager) SetMemoryPressure(enabled bool) {
 	m.buffer = append(make([]*models.Mock, 0, defaultMockBufferCapacity), kept...)
 }
 
-// isStartupMock reports whether a buffered per-test mock is app-bootstrap
-// traffic that can never legitimately claim a test window: it was captured
-// before the first inbound request (tagged IsStartup at ingest in AddMock).
-// Such mocks (e.g. an AWS Secret Manager fetch at boot) must be flushed to
-// disk so replay's startup tier can serve them, NOT reaped as duplicate
-// debris or stale-cutoff. The tag — rather than a "request pre-dates the
-// first window" timestamp test — is deliberately the only signal: a mock
-// captured before the FIRST inbound request is unambiguously startup
-// traffic, whereas a per-test mock that merely lands before its window
-// (genuine stale cross-test bleed) must still be reaped to bound buffer
-// growth. Conflating the two would resurrect that bleed.
+// isStartupMock reports whether a buffered mock falls in the startup window
+// and must be preserved by every reaper instead of pruned. A mock is tagged
+// IsStartup at ingest in AddMock when it is captured before the first inbound
+// request (classic app-bootstrap, e.g. an AWS Secret Manager fetch) OR while
+// fewer than models.StartupMockTestCaseWindow unique test cases have been
+// recorded. Such mocks must be flushed to disk so replay's startup tier can
+// serve them, NOT reaped as duplicate debris or stale-cutoff. The tag — rather
+// than a timestamp test — is deliberately the only signal: it captures the
+// "recorded inside the startup window" intent precisely (including mocks that
+// land inside a static-dedup duplicate's window), whereas a per-test mock that
+// merely lands before its window once we are PAST the startup window (genuine
+// stale cross-test bleed) is untagged and still reaped to bound buffer growth.
 func isStartupMock(mk *models.Mock) bool {
 	return mk != nil && mk.TestModeInfo.IsStartup
 }
@@ -552,6 +571,17 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 	// send itself when outChanClosed is true.
 	outChanBound, _ := m.outChanStatus()
 	mappingChan := m.mappingChan
+
+	// A kept resolve (keep==true) is one UNIQUE recorded test case; advance the
+	// startup-window counter so AddMock stops tagging mocks IsStartup once we are
+	// past the Nth test. Duplicates resolve with keep==false (static dedup) and
+	// must NOT count — the window is measured in recorded tests, not requests.
+	// Incrementing here only gates FUTURE ingests; the mocks processed in this
+	// call were already tagged (or not) at AddMock time, and the rescues below
+	// key off that per-mock tag, not the live counter.
+	if keep {
+		m.resolvedTestCount++
+	}
 
 	// Stale-buffer safety valve.
 	//
@@ -669,6 +699,25 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 				mock.Name = "mock-" + generateRandomString(8)
 				associatedMockIDs = append(associatedMockIDs, mock.Name)
 				mocksToSend = append(mocksToSend, mock)
+			} else if isStartupMock(mock) {
+				// STARTUP RESCUE (static-dedup duplicate window): keep==false
+				// means the enterprise static-dedup deemed THIS test case a
+				// duplicate, so its in-window mocks are normally pruned (the
+				// drop-via-continue below). But a startup-window mock must
+				// survive — until the Nth unique test is recorded, dedup pruning
+				// is suppressed wholesale (a once-per-boot init call that fires
+				// inside a duplicate's window would otherwise be lost, corrupting
+				// the startup recording). Retain when outChan isn't bound yet,
+				// else flush to disk. No associatedMockIDs entry: a duplicate's
+				// testName is synthetic ("test-0"), so it owns no real mapping —
+				// the same treatment the window-less startup rescue below gives.
+				if !outChanBound {
+					m.buffer[keepIdx] = mock
+					keepIdx++
+					continue
+				}
+				mock.Name = "mock-" + generateRandomString(8)
+				mocksToSend = append(mocksToSend, mock)
 			}
 			// We successfully matched and handled this mock.
 			// We discard it from the buffer so it doesn't get processed again.
@@ -710,16 +759,16 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 			continue
 		}
 
-		// STARTUP RESCUE: a mock captured before the first inbound request
-		// (IsStartup) is app-bootstrap traffic — an AWS Secret Manager
-		// fetch, DB/driver handshake, config load, etc. fired at boot. It
-		// can never claim a window, so the stale-cutoff below would
-		// silently reap it (the "present in some test sets, missing in
-		// others" bug). Flush it to disk instead so replay's startup tier
-		// can serve it. Placed BEFORE the cutoff so a slow boot (>7 s to
-		// the first request) can't lose it. A per-test mock that merely
-		// lands before the current window (genuine stale cross-test bleed)
-		// is NOT tagged IsStartup and still falls to the cutoff.
+		// STARTUP RESCUE (out-of-window): a startup-window mock (IsStartup) that
+		// didn't match the current window — boot traffic like an AWS Secret
+		// Manager fetch / DB handshake / config load, or an early-test mock
+		// whose own window isn't the one resolving now. The stale-cutoff below
+		// would otherwise silently reap it (the "present in some test sets,
+		// missing in others" bug). Flush it to disk instead so replay's startup
+		// tier can serve it. Placed BEFORE the cutoff so a slow boot (>7 s to the
+		// first request) can't lose it. A per-test mock captured PAST the startup
+		// window that merely lands before the current window (genuine stale
+		// cross-test bleed) is NOT tagged IsStartup and still falls to the cutoff.
 		if isStartupMock(mock) {
 			if !outChanBound {
 				m.buffer[keepIdx] = mock
@@ -956,14 +1005,15 @@ func (m *SyncMockManager) DeleteMocksStrictlyBefore(timestamp time.Time) {
 			continue
 		}
 
-		// STARTUP RESCUE: app-bootstrap traffic (captured before the first
-		// inbound request, or pre-dating the first resolved test window) is
-		// NOT the skipped duplicate's debris — it owns no window because it
-		// ran before any test existed. Without this, a once-per-boot init
-		// call (e.g. AWS Secret Manager) is dropped here whenever the first
-		// inbound request happens to hash as a dedup duplicate (recentWindows
-		// is still empty, so the ownerWindow rescue above can't save it) —
-		// the root of the flaky per-test-set capture. Flush it instead.
+		// STARTUP RESCUE: a startup-window mock (boot traffic, or anything
+		// captured within the first StartupMockTestCaseWindow test cases) is NOT
+		// the skipped duplicate's debris and must survive this cleanup. Without
+		// this, a once-per-boot init call (e.g. AWS Secret Manager) is dropped
+		// whenever an early request hashes as a dedup duplicate while
+		// recentWindows can't yet claim it (empty at boot, or the mock landed in
+		// a duplicate's own window) — the root of the flaky per-test-set capture,
+		// and exactly what keeps static dedup from pruning the startup corpus.
+		// Flush it instead.
 		if isStartupMock(mock) {
 			if !outChanBound {
 				m.buffer[keepIdx] = mock

--- a/pkg/agent/proxy/syncMock/syncMock_test.go
+++ b/pkg/agent/proxy/syncMock/syncMock_test.go
@@ -1095,6 +1095,10 @@ func TestResolveRangeRecordsLateMockInOldWindowButDropsOrphan(t *testing.T) {
 	mgr := &SyncMockManager{}
 	mgr.SetOutputChannel(ch)
 	mgr.SetFirstRequestSignaled()
+	// Past the startup window, so the orphan below is a genuine non-startup
+	// orphan and the stale-cutoff drop (this test's invariant) still applies —
+	// inside the window every ingest is tagged IsStartup and rescued.
+	mgr.resolvedTestCount = models.StartupMockTestCaseWindow
 
 	// An old window, well past the 7 s cutoff.
 	old := time.Now().Add(-30 * time.Second)
@@ -1499,22 +1503,25 @@ func TestStartupMockFlushedByFlushOwnedWindows(t *testing.T) {
 	}
 }
 
-// TestDuplicateDebrisStillDroppedAfterFirstReqSeen is the negative control:
-// an outbound mock captured AFTER firstReqSeen that owns no window is the
-// skipped duplicate's own debris — it is NOT a startup mock and the dedup
-// cleanup must still drop it, so the startup rescue does not over-rescue.
-func TestDuplicateDebrisStillDroppedAfterFirstReqSeen(t *testing.T) {
+// TestDuplicateDebrisStillDroppedAfterStartupWindow is the negative control:
+// once we are PAST the startup window (>= N unique recorded test cases), an
+// outbound mock captured after firstReqSeen that owns no window is the skipped
+// duplicate's own debris — it is NOT a startup mock and the dedup cleanup must
+// still drop it, so the widened startup rescue does not over-rescue forever.
+func TestDuplicateDebrisStillDroppedAfterStartupWindow(t *testing.T) {
 	t.Parallel()
 
 	out := make(chan *models.Mock, 4)
 	mgr := &SyncMockManager{buffer: make([]*models.Mock, 0, defaultMockBufferCapacity)}
 	mgr.SetOutputChannel(out)
-	mgr.SetFirstRequestSignaled() // request-driven traffic, not startup
+	mgr.SetFirstRequestSignaled() // request-driven traffic, not boot
+	// Advance past the startup window so new ingests are no longer tagged.
+	mgr.resolvedTestCount = models.StartupMockTestCaseWindow
 
 	debris := startupHTTPMock(time.Now().Add(-1 * time.Second))
 	mgr.AddMock(debris)
 	if mgr.buffer[0].TestModeInfo.IsStartup {
-		t.Fatalf("a mock captured after firstReqSeen must NOT be tagged IsStartup")
+		t.Fatalf("a mock captured past the startup window must NOT be tagged IsStartup")
 	}
 
 	mgr.DeleteMocksStrictlyBefore(time.Now())
@@ -1526,5 +1533,124 @@ func TestDuplicateDebrisStillDroppedAfterFirstReqSeen(t *testing.T) {
 	}
 	if len(mgr.buffer) != 0 {
 		t.Fatalf("debris must be dropped from the buffer; buffer=%d", len(mgr.buffer))
+	}
+}
+
+// TestStartupWindowTagsMocksAfterFirstReqSeen pins the widened tagging: while
+// fewer than N unique test cases have been recorded, AddMock tags ingested
+// mocks IsStartup EVEN after firstReqSeen — that is what makes the first N
+// tests' mocks survive the dedup reapers.
+func TestStartupWindowTagsMocksAfterFirstReqSeen(t *testing.T) {
+	t.Parallel()
+
+	mgr := &SyncMockManager{buffer: make([]*models.Mock, 0, defaultMockBufferCapacity)}
+	mgr.SetFirstRequestSignaled() // past boot, but still inside the startup window
+
+	mgr.AddMock(startupHTTPMock(time.Now()))
+	if !mgr.buffer[0].TestModeInfo.IsStartup {
+		t.Fatalf("a mock captured within the startup window must be tagged IsStartup")
+	}
+}
+
+// TestResolvedTestCountClosesStartupWindowOnKeptResolves verifies the boundary:
+// only kept resolves (keep==true, one per UNIQUE recorded test) advance the
+// counter, and a keep==false (duplicate) resolve does not. After N kept
+// resolves the window closes and new ingests are no longer tagged.
+func TestResolvedTestCountClosesStartupWindowOnKeptResolves(t *testing.T) {
+	t.Parallel()
+
+	out := make(chan *models.Mock, 8)
+	mgr := &SyncMockManager{buffer: make([]*models.Mock, 0, defaultMockBufferCapacity)}
+	mgr.SetOutputChannel(out)
+	mgr.SetFirstRequestSignaled()
+
+	now := time.Now()
+	// A duplicate resolve must NOT advance the counter.
+	mgr.ResolveRange(now.Add(-time.Second), now, "test-0", false, false)
+	if mgr.resolvedTestCount != 0 {
+		t.Fatalf("duplicate (keep=false) resolve must not advance the counter; got %d", mgr.resolvedTestCount)
+	}
+
+	// N kept resolves close the window.
+	for i := range models.StartupMockTestCaseWindow {
+		base := now.Add(time.Duration(i+1) * time.Second)
+		mgr.ResolveRange(base, base.Add(10*time.Millisecond), "test", true, false)
+	}
+	if mgr.resolvedTestCount != models.StartupMockTestCaseWindow {
+		t.Fatalf("expected counter == %d after kept resolves, got %d", models.StartupMockTestCaseWindow, mgr.resolvedTestCount)
+	}
+
+	// Past the window: ingests are no longer startup.
+	mgr.AddMock(startupHTTPMock(now.Add(10 * time.Second)))
+	last := mgr.buffer[len(mgr.buffer)-1]
+	if last.TestModeInfo.IsStartup {
+		t.Fatalf("ingest past the startup window must NOT be tagged IsStartup")
+	}
+}
+
+// TestStartupMockRescuedFromDuplicateWindowResolve is the core static-dedup
+// regression: a startup-window mock captured inside the window of a test case
+// that static-dedup deems a DUPLICATE (ResolveRange keep=false) must be flushed
+// to disk, not pruned with the rest of the duplicate's window. This is the
+// in-window keep=false rescue that the OSS path lacked.
+func TestStartupMockRescuedFromDuplicateWindowResolve(t *testing.T) {
+	t.Parallel()
+
+	out := make(chan *models.Mock, 4)
+	mgr := &SyncMockManager{buffer: make([]*models.Mock, 0, defaultMockBufferCapacity)}
+	mgr.SetOutputChannel(out)
+	mgr.SetFirstRequestSignaled() // inside the startup window (count == 0)
+
+	now := time.Now()
+	inWindowTS := now.Add(-20 * time.Millisecond)
+	mgr.AddMock(startupHTTPMock(inWindowTS))
+	if !mgr.buffer[0].TestModeInfo.IsStartup {
+		t.Fatalf("mock captured inside the startup window must be tagged IsStartup")
+	}
+
+	// Duplicate resolve (keep=false) over the window that contains the mock.
+	mgr.ResolveRange(now.Add(-50*time.Millisecond), now, "test-0", false, false)
+
+	select {
+	case got := <-out:
+		if !got.Spec.ReqTimestampMock.Equal(inWindowTS) {
+			t.Fatalf("rescued wrong mock: ts=%v want %v", got.Spec.ReqTimestampMock, inWindowTS)
+		}
+	default:
+		t.Fatalf("startup mock inside a duplicate window must be rescued, not pruned")
+	}
+	if len(mgr.buffer) != 0 {
+		t.Fatalf("rescued mock should leave the buffer; buffer=%d", len(mgr.buffer))
+	}
+}
+
+// TestNonStartupMockPrunedFromDuplicateWindowResolve is the matching negative
+// control: past the startup window, a non-startup mock inside a duplicate's
+// window (ResolveRange keep=false) is pruned as before — the rescue is scoped to
+// the startup window only.
+func TestNonStartupMockPrunedFromDuplicateWindowResolve(t *testing.T) {
+	t.Parallel()
+
+	out := make(chan *models.Mock, 4)
+	mgr := &SyncMockManager{buffer: make([]*models.Mock, 0, defaultMockBufferCapacity)}
+	mgr.SetOutputChannel(out)
+	mgr.SetFirstRequestSignaled()
+	mgr.resolvedTestCount = models.StartupMockTestCaseWindow // past the window
+
+	now := time.Now()
+	mgr.AddMock(startupHTTPMock(now.Add(-20 * time.Millisecond)))
+	if mgr.buffer[0].TestModeInfo.IsStartup {
+		t.Fatalf("mock past the startup window must NOT be tagged IsStartup")
+	}
+
+	mgr.ResolveRange(now.Add(-50*time.Millisecond), now, "test-0", false, false)
+
+	select {
+	case got := <-out:
+		t.Fatalf("non-startup mock in a duplicate window must be pruned, but it was flushed: ts=%v", got.Spec.ReqTimestampMock)
+	default:
+	}
+	if len(mgr.buffer) != 0 {
+		t.Fatalf("pruned mock should leave the buffer; buffer=%d", len(mgr.buffer))
 	}
 }

--- a/pkg/models/mock.go
+++ b/pkg/models/mock.go
@@ -67,6 +67,18 @@ const (
 	MockNamePostgresV3Session = "PostgresV3Session"
 )
 
+// StartupMockTestCaseWindow is the number of leading UNIQUE recorded test cases
+// whose mocks are treated as "startup mocks". Every mock captured from app boot
+// up to and including the recording of the Nth unique test case is preserved
+// wholesale: it is exempt from the record-side static-dedup pruning (so dedup
+// effectively begins at test N+1) and from replay-side RemoveUnusedMocks
+// pruning. The record side keys off this via SyncMockManager.resolvedTestCount
+// (it tags such mocks TestModeInfo.IsStartup); the replay side derives an
+// equivalent timestamp boundary from the on-disk test cases. Both must agree on
+// N, so it lives here as the single source of truth. Fixed in code rather than
+// exposed as a flag — change here to retune.
+const StartupMockTestCaseWindow = 5
+
 type Mock struct {
 	Version      Version      `json:"Version,omitempty" bson:"Version,omitempty"`
 	Name         string       `json:"Name,omitempty" bson:"Name,omitempty"`
@@ -125,23 +137,28 @@ type TestModeInfo struct {
 	// a long-lived mock hints at dead recordings worth re-capturing.
 	HitCount uint64 `json:"-" bson:"-"`
 
-	// IsStartup marks app-bootstrap traffic captured before the first
-	// inbound request (e.g. an AWS Secret Manager fetch at process boot).
-	// Such an outbound call can never claim a per-test window — it ran
-	// before any test — so the record-side syncMock reapers (dedup
-	// cleanup, stale-cutoff, memory-pressure wipe) must rescue it to disk
-	// instead of dropping it as debris.
+	// IsStartup marks startup-window traffic: a mock captured either before
+	// the first inbound request (classic app-bootstrap, e.g. an AWS Secret
+	// Manager fetch at process boot) OR while fewer than
+	// StartupMockTestCaseWindow unique test cases have been recorded. Such
+	// mocks must survive the record-side syncMock reapers (dedup cleanup,
+	// the ResolveRange keep=false / out-of-window / stale-cutoff rescues, the
+	// memory-pressure wipe) rather than being dropped — that is what keeps
+	// the boot-through-Nth-test mock corpus complete and effectively defers
+	// static-dedup pruning to the (N+1)-th test case.
 	//
 	// This is a RECORD-side cleanup signal only, with no replay-time
 	// meaning, which is why it is NOT modelled as a Lifetime value:
 	// Lifetime is derived from the on-disk Spec.Metadata tag and drives
 	// replay-time pool routing, whereas IsStartup is set live at ingest in
 	// SyncMockManager.AddMock and is only ever read on buffered, live-
-	// captured mocks before they are persisted. Like the sibling
-	// runtime-only fields, the json/bson tags keep it out of the text
-	// formats; gob (which ignores struct tags) does encode it, but a value
-	// carried on a reloaded mock is inert — the reapers run only on the
-	// live record buffer, never on disk-loaded mocks.
+	// captured mocks before they are persisted. (Replay's own startup-mock
+	// preservation is timestamp-based — see replay.startupMockCutoff — not
+	// keyed off this flag.) Like the sibling runtime-only fields, the
+	// json/bson tags keep it out of the text formats; gob (which ignores
+	// struct tags) does encode it, but a value carried on a reloaded mock is
+	// inert — the reapers run only on the live record buffer, never on
+	// disk-loaded mocks.
 	IsStartup bool `json:"-" bson:"-"`
 }
 

--- a/pkg/platform/yaml/mockdb/db.go
+++ b/pkg/platform/yaml/mockdb/db.go
@@ -339,7 +339,13 @@ func mergeReqBodyNoise(existing, detected map[string][]string) map[string][]stri
 // mockNames is a keep-set keyed by mock name (values carry models.MockState details).
 // Mocks present in mockNames are retained; other mocks may still be retained by
 // timestamp-based exemptions (for replay writes and startup/init traffic).
-func (ys *MockYaml) UpdateMocks(ctx context.Context, testSetID string, mockNames map[string]models.MockState, pruneBefore time.Time, firstTestCaseTime time.Time) error {
+//
+// startupCutoffTime is the startup-mock exemption boundary: any mock recorded
+// before it is a "startup mock" (captured from app boot up to and including the
+// first StartupMockTestCaseWindow test cases) and is kept even when no executed
+// test consumes it. The caller (replay) computes it from the per-test-case
+// request timestamps; a zero value disables the exemption.
+func (ys *MockYaml) UpdateMocks(ctx context.Context, testSetID string, mockNames map[string]models.MockState, pruneBefore time.Time, startupCutoffTime time.Time) error {
 	mockFileName := "mocks"
 	if ys.MockName != "" {
 		mockFileName = ys.MockName
@@ -355,7 +361,7 @@ func (ys *MockYaml) UpdateMocks(ctx context.Context, testSetID string, mockNames
 	// to the format-detection logic below for yaml/json.
 	gobPath := filepath.Join(path, mockFileName+".gob")
 	if _, err := os.Stat(gobPath); err == nil {
-		return ys.updateMocksGob(ctx, testSetID, gobPath, mockNames, pruneBefore, firstTestCaseTime)
+		return ys.updateMocksGob(ctx, testSetID, gobPath, mockNames, pruneBefore, startupCutoffTime)
 	}
 
 	// Detect the format the mocks file is actually stored in (may differ
@@ -457,13 +463,14 @@ func (ys *MockYaml) UpdateMocks(ctx context.Context, testSetID string, mockNames
 			newMocks = append(newMocks, mock)
 			continue
 		}
-		// Keep startup/init mocks: mocks recorded before the first test case
-		// are connection-level or app-init traffic (DNS, TLS, DB handshake,
-		// config fetch, etc.) that only fires once at app startup. In multi-
-		// test-set replays without app restart, these won't be consumed in
-		// later test-sets but are still needed for future replays.
-		if !firstTestCaseTime.IsZero() && !mock.Spec.ReqTimestampMock.IsZero() &&
-			mock.Spec.ReqTimestampMock.Before(firstTestCaseTime) {
+		// Keep startup/init mocks: every mock recorded before startupCutoffTime
+		// (app boot up to and including the first StartupMockTestCaseWindow test
+		// cases) is connection-level or app-init traffic (DNS, TLS, DB handshake,
+		// config fetch, etc.) plus the outbound calls of those early tests. In
+		// multi-test-set replays without app restart, these won't be consumed in
+		// later test-sets but are still needed for app startup on future replays.
+		if !startupCutoffTime.IsZero() && !mock.Spec.ReqTimestampMock.IsZero() &&
+			mock.Spec.ReqTimestampMock.Before(startupCutoffTime) {
 			newMocks = append(newMocks, mock)
 			continue
 		}
@@ -496,14 +503,14 @@ func (ys *MockYaml) UpdateMocks(ctx context.Context, testSetID string, mockNames
 
 // updateMocksGob implements RemoveUnusedMocks for mocks.gob. The
 // filter decision matches the YAML path exactly (keep config mocks,
-// mocks named in mockNames, post-replay mocks, and pre-first-test
-// startup mocks — prune everything else). The rewrite rules are
-// different because gob doesn't support append: we read the whole
-// file, filter, and atomically rewrite a fresh single-encoder
-// stream with the magic header. An existing gob writer on this
-// MockYaml must be quiesced before we touch the file so a
+// mocks named in mockNames, post-replay mocks, and startup mocks
+// recorded before startupCutoffTime — prune everything else). The
+// rewrite rules are different because gob doesn't support append: we
+// read the whole file, filter, and atomically rewrite a fresh
+// single-encoder stream with the magic header. An existing gob writer
+// on this MockYaml must be quiesced before we touch the file so a
 // concurrent InsertMock doesn't race the truncate-and-rewrite.
-func (ys *MockYaml) updateMocksGob(ctx context.Context, testSetID, gobPath string, mockNames map[string]models.MockState, pruneBefore, firstTestCaseTime time.Time) error {
+func (ys *MockYaml) updateMocksGob(ctx context.Context, testSetID, gobPath string, mockNames map[string]models.MockState, pruneBefore, startupCutoffTime time.Time) error {
 	ys.Logger.Debug("pruning unused mocks (gob)",
 		zap.Any("consumedMocks", mockNames),
 		zap.String("testSetID", testSetID),
@@ -574,8 +581,11 @@ func (ys *MockYaml) updateMocksGob(ctx context.Context, testSetID, gobPath strin
 			newMocks = append(newMocks, mock)
 			continue
 		}
-		if !firstTestCaseTime.IsZero() && !mock.Spec.ReqTimestampMock.IsZero() &&
-			mock.Spec.ReqTimestampMock.Before(firstTestCaseTime) {
+		// Keep startup mocks (see the YAML path): everything recorded before
+		// startupCutoffTime is app-init traffic plus the early tests' outbound
+		// calls, needed for startup on future replays even when unconsumed here.
+		if !startupCutoffTime.IsZero() && !mock.Spec.ReqTimestampMock.IsZero() &&
+			mock.Spec.ReqTimestampMock.Before(startupCutoffTime) {
 			newMocks = append(newMocks, mock)
 			continue
 		}

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -37,6 +37,51 @@ import (
 const UNKNOWN_TEST = "UNKNOWN_TEST"
 const applicationFailedToRunLogMessage = "application failed to run; check the application logs for details or verify the app command is correct"
 
+// startupMockCutoff returns the startup-mock exemption boundary for a test set:
+// any mock recorded before this time is a startup mock that UpdateMocks must
+// keep even when unconsumed. It is the request timestamp of the
+// (models.StartupMockTestCaseWindow+1)-th test case (ordered by request time),
+// so the startup window covers app boot through the recording of the Nth test
+// case — the replay-side twin of the record-side IsStartup tagging keyed off
+// SyncMockManager.resolvedTestCount.
+//
+// When the set has <= models.StartupMockTestCaseWindow test cases, the entire
+// recording is startup; keepAll (the replay start time, pruneBefore) is
+// returned so every recorded mock is retained — mocks recorded before replay
+// start are kept by this exemption and any written after it are kept by
+// UpdateMocks' post-replay-write rule. Returns the zero time when no test case
+// carries a usable timestamp, which disables the exemption (matching the prior
+// behaviour for timestamp-less sets).
+func startupMockCutoff(testCases []*models.TestCase, keepAll time.Time) time.Time {
+	tcTimes := make([]time.Time, 0, len(testCases))
+	for _, tc := range testCases {
+		var candidate time.Time
+
+		// Prefer high-precision request timestamps when available.
+		if !tc.HTTPReq.Timestamp.IsZero() {
+			candidate = tc.HTTPReq.Timestamp
+		} else if !tc.GrpcReq.Timestamp.IsZero() {
+			candidate = tc.GrpcReq.Timestamp
+		} else if tc.Created > 0 {
+			// Fallback to the coarser Created timestamp.
+			candidate = time.Unix(tc.Created, 0)
+		}
+
+		if !candidate.IsZero() {
+			tcTimes = append(tcTimes, candidate)
+		}
+	}
+	sort.Slice(tcTimes, func(i, j int) bool { return tcTimes[i].Before(tcTimes[j]) })
+
+	if len(tcTimes) > models.StartupMockTestCaseWindow {
+		return tcTimes[models.StartupMockTestCaseWindow]
+	}
+	if len(tcTimes) > 0 {
+		return keepAll
+	}
+	return time.Time{}
+}
+
 func shouldAbortTestRun(status models.TestSetStatus, cmdType utils.CmdType) bool {
 	switch status {
 	case models.TestSetStatusAppHalted, models.TestSetStatusFaultUserApp:
@@ -2539,28 +2584,16 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			}
 		}
 
-		// Find the earliest test-case timestamp so UpdateMocks can exempt
-		// startup/init mocks (recorded before any test case) from deletion.
-		var firstTestCaseTime time.Time
-		for _, tc := range testCases {
-			var candidate time.Time
+		// Compute the startup-mock cutoff so UpdateMocks can exempt startup/init
+		// mocks from deletion. "Startup mocks" are every mock recorded from app
+		// boot up to and including the StartupMockTestCaseWindow-th test case;
+		// mocks recorded before the cutoff survive pruning while still keeping
+		// their per-test mappings for replay matching. With <= window test cases
+		// the whole recording is startup, so pruneBefore is used as the cutoff to
+		// retain everything (see startupMockCutoff).
+		startupCutoffTime := startupMockCutoff(testCases, pruneBefore)
 
-			// Prefer high-precision request timestamps when available.
-			if !tc.HTTPReq.Timestamp.IsZero() {
-				candidate = tc.HTTPReq.Timestamp
-			} else if !tc.GrpcReq.Timestamp.IsZero() {
-				candidate = tc.GrpcReq.Timestamp
-			} else if tc.Created > 0 {
-				// Fallback to the coarser Created timestamp.
-				candidate = time.Unix(tc.Created, 0)
-			}
-
-			if !candidate.IsZero() && (firstTestCaseTime.IsZero() || candidate.Before(firstTestCaseTime)) {
-				firstTestCaseTime = candidate
-			}
-		}
-
-		err = r.mockDB.UpdateMocks(runTestSetCtx, testSetID, passingTotalConsumedMocks, pruneBefore, firstTestCaseTime)
+		err = r.mockDB.UpdateMocks(runTestSetCtx, testSetID, passingTotalConsumedMocks, pruneBefore, startupCutoffTime)
 		if err != nil {
 			utils.LogError(r.logger, err, "failed to delete unused mocks")
 		}

--- a/pkg/service/replay/service.go
+++ b/pkg/service/replay/service.go
@@ -74,7 +74,7 @@ type TestDB interface {
 type MockDB interface {
 	GetFilteredMocks(ctx context.Context, testSetID string, afterTime time.Time, beforeTime time.Time, mocksThatHaveMappings map[string]bool, mocksWeNeed map[string]bool) ([]*models.Mock, error)
 	GetUnFilteredMocks(ctx context.Context, testSetID string, afterTime time.Time, beforeTime time.Time, mocksThatHaveMappings map[string]bool, mocksWeNeed map[string]bool) ([]*models.Mock, error)
-	UpdateMocks(ctx context.Context, testSetID string, mockNames map[string]models.MockState, pruneBefore time.Time, firstTestCaseTime time.Time) error
+	UpdateMocks(ctx context.Context, testSetID string, mockNames map[string]models.MockState, pruneBefore time.Time, startupCutoffTime time.Time) error
 }
 
 type ReportDB interface {

--- a/pkg/service/replay/startupmock_test.go
+++ b/pkg/service/replay/startupmock_test.go
@@ -1,0 +1,98 @@
+package replay
+
+import (
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// tcAt builds a minimal HTTP test case whose request timestamp is `t`.
+func tcAt(t time.Time) *models.TestCase {
+	return &models.TestCase{
+		Kind:    models.HTTP,
+		HTTPReq: models.HTTPReq{Timestamp: t},
+	}
+}
+
+// TestStartupMockCutoff pins the startup-mock exemption boundary used by
+// RemoveUnusedMocks: it must be the (models.StartupMockTestCaseWindow+1)-th test case
+// by request time once a set has more tests than the window, fall back to
+// keepAll when the whole set is startup, and disable cleanly with no usable
+// timestamps.
+func TestStartupMockCutoff(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	keepAll := base.Add(-time.Hour) // stand-in for pruneBefore (replay start)
+
+	// at(i) is the i-th second after base; ordering is intentionally shuffled
+	// in the slices below so we also exercise the internal sort.
+	at := func(i int) time.Time { return base.Add(time.Duration(i) * time.Second) }
+
+	t.Run("more tests than window picks the (window+1)-th by time", func(t *testing.T) {
+		// Window is 5, so with 8 tests the cutoff is the 6th-earliest (index 5),
+		// i.e. at(5). Feed them out of order to prove sorting decides, not arrival.
+		tcs := []*models.TestCase{
+			tcAt(at(3)), tcAt(at(0)), tcAt(at(6)), tcAt(at(1)),
+			tcAt(at(7)), tcAt(at(2)), tcAt(at(5)), tcAt(at(4)),
+		}
+		got := startupMockCutoff(tcs, keepAll)
+		if !got.Equal(at(models.StartupMockTestCaseWindow)) {
+			t.Fatalf("cutoff = %v, want %v (the (window+1)-th test case)", got, at(models.StartupMockTestCaseWindow))
+		}
+	})
+
+	t.Run("exactly window tests keeps everything", func(t *testing.T) {
+		tcs := make([]*models.TestCase, 0, models.StartupMockTestCaseWindow)
+		for i := range models.StartupMockTestCaseWindow {
+			tcs = append(tcs, tcAt(at(i)))
+		}
+		got := startupMockCutoff(tcs, keepAll)
+		if !got.Equal(keepAll) {
+			t.Fatalf("cutoff = %v, want keepAll %v when the whole set is startup", got, keepAll)
+		}
+	})
+
+	t.Run("fewer than window tests keeps everything", func(t *testing.T) {
+		got := startupMockCutoff([]*models.TestCase{tcAt(at(0)), tcAt(at(1))}, keepAll)
+		if !got.Equal(keepAll) {
+			t.Fatalf("cutoff = %v, want keepAll %v", got, keepAll)
+		}
+	})
+
+	t.Run("no test cases disables the exemption", func(t *testing.T) {
+		got := startupMockCutoff(nil, keepAll)
+		if !got.IsZero() {
+			t.Fatalf("cutoff = %v, want zero time", got)
+		}
+	})
+
+	t.Run("timestamp-less tests are ignored and disable the exemption", func(t *testing.T) {
+		// Created==0 and no req timestamps → no usable candidate → zero time.
+		tcs := []*models.TestCase{{Kind: models.HTTP}, {Kind: models.HTTP}}
+		got := startupMockCutoff(tcs, keepAll)
+		if !got.IsZero() {
+			t.Fatalf("cutoff = %v, want zero time for timestamp-less set", got)
+		}
+	})
+
+	t.Run("falls back to grpc and Created timestamps", func(t *testing.T) {
+		// Six tests so the window is exceeded; mix the timestamp sources to
+		// confirm grpc and the coarse Created fallback are honoured. The
+		// 6th-earliest (index 5) is at(5), carried on a Created-only test case.
+		tcs := []*models.TestCase{
+			tcAt(at(0)),
+			{GrpcReq: models.GrpcReq{Timestamp: at(1)}},
+			tcAt(at(2)),
+			{GrpcReq: models.GrpcReq{Timestamp: at(3)}},
+			tcAt(at(4)),
+			{Created: at(5).Unix()},
+		}
+		got := startupMockCutoff(tcs, keepAll)
+		// Created has second precision; compare on unix seconds.
+		if got.Unix() != at(5).Unix() {
+			t.Fatalf("cutoff = %v, want %v from the Created fallback", got, at(5))
+		}
+	})
+}


### PR DESCRIPTION
## Describe the changes that are made

Introduces a **startup-mock window**: every mock recorded from app boot up to and including the recording of the **first 5 unique test cases** (`models.StartupMockTestCaseWindow = 5`) is treated as a "startup mock" and is preserved instead of pruned. This prevents once-per-boot init traffic (DNS/TLS, DB/driver handshakes, secret-manager/config fetches, lazily-initialised calls) from being lost, which previously corrupted the startup-mock recording and caused flaky "present in some test-sets, missing in others" replays.

Startup mocks are protected at **both** ends of the pipeline:

**Record side — `pkg/agent/proxy/syncMock/syncMock.go`**
- New `SyncMockManager.resolvedTestCount`, incremented once per *kept* `ResolveRange` (one unique recorded test case). Duplicates resolve with `keep=false` and do **not** advance it, so the window is measured in recorded tests, not requests.
- `AddMock` now tags a mock `TestModeInfo.IsStartup` when captured before the first request **or** while `resolvedTestCount < StartupMockTestCaseWindow` (widening the old "before first request" rule).
- Added the missing **in-window `keep=false` rescue** in `ResolveRange` — the branch the enterprise `--static-dedup` duplicate path hits. Previously a startup mock landing inside a duplicate's window was pruned before any rescue could fire; it is now flushed to disk.
- Net effect: static-dedup pruning is suppressed wholesale until the 6th test case; all existing reapers (`DeleteMocksStrictlyBefore`, out-of-window/stale-cutoff in `ResolveRange`, `FlushOwnedWindows`, memory-pressure wipe) already key off `IsStartup`.

**Replay side — `pkg/service/replay/replay.go`, `pkg/platform/yaml/mockdb/db.go`**
- New `startupMockCutoff()` computes the exemption boundary as the request timestamp of the 6th test case (was: the 1st). `RemoveUnusedMocks` (`UpdateMocks`, yaml + gob paths) keeps any unconsumed mock recorded before it. Param renamed `firstTestCaseTime → startupCutoffTime`.

`IsStartup` is record-side only (`json:"-" bson:"-"`, not serialised), so the two sides use equivalent mechanisms (tag vs. timestamp) keyed off the single shared constant in `pkg/models/mock.go`.

> ⚠️ **Behavior note:** with `--remove-unused-mocks` enabled, a test-set with ≤ 5 test cases now prunes nothing — by definition the whole recording is startup.

> ℹ️ The enterprise repo (`go.keploy.io/server/v3` consumer) needs no code change — its `--static-dedup` path calls the OSS `ResolveRange`/`ResolveJob` enhanced here and inherits the behavior on a version bump.

## Links & References

**Closes:** https://github.com/keploy/enterprise/issues/2116
## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [x] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

Covered by unit tests on both the record (`syncMock`) and replay (`startupMockCutoff`/`UpdateMocks`) logic.

## Added comments for hard-to-understand areas?
- [x] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

**Unit tests**
```bash
go test ./pkg/agent/proxy/syncMock/... ./pkg/service/replay/... ./pkg/platform/yaml/mockdb/... ./pkg/models/...
```
New/updated coverage:
- `TestStartupWindowTagsMocksAfterFirstReqSeen`, `TestResolvedTestCountClosesStartupWindowOnKeptResolves`
- `TestStartupMockRescuedFromDuplicateWindowResolve`, `TestNonStartupMockPrunedFromDuplicateWindowResolve`
- `TestDuplicateDebrisStillDroppedAfterStartupWindow` (renamed/adjusted negative control)
- `TestStartupMockCutoff` (replay boundary: 6th-test-case cutoff, keep-all for ≤5, timestamp fallbacks)

**Manual (against a public sample app, e.g. `samples-go`)**
1. Record a flow with **more than 6** endpoints, where an init/once-per-boot call fires during one of the first 5 test cases.
2. Confirm that mock is written to disk and remains after recording (record-side: not dropped by static dedup).
3. Run `keploy test --remove-unused-mocks` and confirm the first-5 startup mocks are retained while unused mocks from the 6th test case onward are pruned (replay-side).

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?
