### PR TITLE
feat(mysql): learn drifting COM_QUERY literals as noise and tolerate them under strict matching

### DIFF
--- a/pkg/agent/proxy/integrations/mysql/replayer/conn.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/conn.go
@@ -476,7 +476,7 @@ func simulateNativePassword(ctx context.Context, logger *zap.Logger, clientConn 
 	}
 
 	//update the config mock (since it can be reused in case of more connections compared to record mode)
-	ok := updateMock(ctx, logger, initialHandshakeMock, mockDb)
+	ok := updateMock(ctx, logger, initialHandshakeMock, mockDb, nil)
 	if !ok {
 		utils.LogError(logger, nil, "failed to update the mock unfiltered mock during native password")
 	}
@@ -599,7 +599,7 @@ func simulateFastAuthSuccess(ctx context.Context, logger *zap.Logger, clientConn
 
 	//update the config mock (since it can be reused in case of more connections compared to record mode)
 	//TODO: need to check when updateMock is unsuccessful
-	ok := updateMock(ctx, logger, initialHandshakeMock, mockDb)
+	ok := updateMock(ctx, logger, initialHandshakeMock, mockDb, nil)
 	if !ok {
 		utils.LogError(logger, nil, "failed to update the mock unfiltered mock during fast auth success")
 	}

--- a/pkg/agent/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match.go
@@ -518,7 +518,14 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 					if qp, qok := mockReq.PacketBundle.Message.(*mysql.QueryPacket); qok {
 						bestPartialQuery = qp.Query
 					}
-				} else if c > maxMatchedCount {
+				} else if c > maxMatchedCount && !schemaNoiseStrict {
+					// Under strict, a score-based partial must NEVER be served for
+					// COM_QUERY: only an exact or within-noise match (queryMatched)
+					// or the out-of-window exact fallback may satisfy a strict
+					// query. This stops a same-payload-length, different-skeleton
+					// candidate (e.g. a changed column/operator that the redacted-
+					// skeleton gate already refuses to treat as comparable) from
+					// masking a real query-shape regression via the partial path.
 					maxMatchedCount, matchedResp, matchedMock = c, &mock.Spec.MySQLResponses[0], mock
 					bestPartialMock = mock
 					// On the detection path a structurally-equal-but-value-
@@ -1217,7 +1224,12 @@ func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.Packe
 			log.Debug("strict: same-type-signature candidate is not this query's counterpart (different skeleton)",
 				zap.String("expected query", expectedQuery),
 				zap.String("actual query", actualQuery))
-			return false, matchCount, nil, false
+			// Score 0 so a different-skeleton (different table/column/operator)
+			// candidate can never win the score-based partial fallback under
+			// strict. matchCommand additionally suppresses COM_QUERY partials
+			// under strict, but returning 0 keeps the matchQuery contract honest:
+			// this candidate is not the live query's counterpart.
+			return false, 0, nil, false
 		}
 
 		// DETECTION (lenient): learn which eligible literal positions drifted

--- a/pkg/agent/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match.go
@@ -378,6 +378,14 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 		bestPartialMock  *models.Mock // closest non-exact match for diff reporting
 		bestPartialQuery string       // query of the closest partial match
 
+		// comQueryStrictHardReject is set when a live COM_QUERY's structural
+		// counterpart (same redacted skeleton) was found under strict mode but
+		// drifted in a non-noise / predicate literal — a real regression. It
+		// forces an overall miss so an unrelated score-based partial (e.g. a
+		// different statement that coincidentally scored on payload length) is
+		// NOT served in its place.
+		comQueryStrictHardReject bool
+
 		// COM_STMT_EXECUTE FIFO fallback: when the live bound parameters
 		// match NO recorded mock for the same prepared query (e.g. an
 		// INSERT-then-SELECT read-back of a replay-generated uuid that
@@ -478,7 +486,7 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 				// consume a structurally-equal mock whose only drift is in
 				// learned-noise SET/VALUES positions, and (b) on the detection
 				// path surface newly-detected literal noise for persistence.
-				if ok, c, detected := matchQueryPacket(ctx, logger, mockReq.PacketBundle, req.PacketBundle, schemaNoiseDetection, schemaNoiseStrict, mockReq.QueryNoise); ok {
+				if ok, c, detected, hardReject := matchQueryPacket(ctx, logger, mockReq.PacketBundle, req.PacketBundle, schemaNoiseDetection, schemaNoiseStrict, mockReq.QueryNoise); ok {
 					// Exact query-text match (or a strict within-noise match).
 					// Prefer the candidate recorded inside the current test
 					// window so a repeated stateful read-back (same SQL,
@@ -496,6 +504,19 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 					} else {
 						matchedResp, matchedMock, queryMatched = &mock.Spec.MySQLResponses[0], mock, true
 						queryDetectedNoise = detected
+					}
+				} else if hardReject {
+					// Strict mode: this candidate IS the live query's structural
+					// counterpart (same redacted skeleton) but drifted in a
+					// non-noise / predicate literal — a real regression. Record
+					// it for diff reporting and flag the hard reject, but do NOT
+					// let it (or any other candidate) become a served partial via
+					// the score path. Crucially we do NOT touch maxMatchedCount /
+					// matchedResp / matchedMock here.
+					comQueryStrictHardReject = true
+					bestPartialMock = mock
+					if qp, qok := mockReq.PacketBundle.Message.(*mysql.QueryPacket); qok {
+						bestPartialQuery = qp.Query
 					}
 				} else if c > maxMatchedCount {
 					maxMatchedCount, matchedResp, matchedMock = c, &mock.Spec.MySQLResponses[0], mock
@@ -646,6 +667,13 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 	if req.Header.Type == sCOM_QUERY && !queryMatched && queryExactMock != nil {
 		matchedResp, matchedMock, queryMatched = queryExactResp, queryExactMock, true
 		queryDetectedNoise = queryExactDetectedNoise
+	}
+
+	// Strict hard-reject: the live COM_QUERY's structural counterpart was found
+	// but drifted in a non-noise / predicate literal — a real regression. Force
+	// an overall miss instead of serving an unrelated score-based partial.
+	if req.Header.Type == sCOM_QUERY && schemaNoiseStrict && comQueryStrictHardReject && !queryMatched {
+		matchedResp, matchedMock = nil, nil
 	}
 
 	// COM_STMT_EXECUTE FIFO fallback. If the scan found no definitive
@@ -1063,12 +1091,18 @@ func getQueryStructure(sql string) (string, error) {
 //
 // learnedNoise is the matched mock's existing QueryNoise (the learned set).
 // detected is non-nil only on the detection path when eligible drift was found.
-func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.PacketBundle, getQuery func(packet mysql.PacketBundle) string, schemaNoiseDetection bool, schemaNoiseStrict bool, learnedNoise map[string][]string) (matched bool, score int, detected map[string][]string) {
+//
+// hardReject (4th return) is TRUE only in the strict branch when this candidate
+// is the live query's actual structural counterpart (same redacted skeleton)
+// but its drift is NOT within learned noise — i.e. a real WHERE/predicate
+// regression. The caller (matchCommand) uses it to force an overall miss for
+// that live query rather than serving an unrelated score-based partial.
+func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.PacketBundle, getQuery func(packet mysql.PacketBundle) string, schemaNoiseDetection bool, schemaNoiseStrict bool, learnedNoise map[string][]string) (matched bool, score int, detected map[string][]string, hardReject bool) {
 	matchCount := 0
 
 	// Match the type and return zero if the types are not equal
 	if expected.Header.Type != actual.Header.Type {
-		return false, 0, nil
+		return false, 0, nil, false
 	}
 
 	expectedQuery := getQuery(expected)
@@ -1084,7 +1118,7 @@ func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.Packe
 		// 	zap.String("actual_query", actualQuery),
 		// 	zap.Int("expected_placeholders", expectedPlaceholders),
 		// 	zap.Int("actual_placeholders", actualPlaceholders))
-		return false, 0, nil
+		return false, 0, nil, false
 	}
 
 	if actual.Header != nil && actual.Header.Header != nil &&
@@ -1096,7 +1130,7 @@ func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.Packe
 			log.Debug("Query Exact matched",
 				zap.String("expected query", expectedQuery),
 				zap.String("actual query", actualQuery))
-			return true, matchCount, nil
+			return true, matchCount, nil, false
 		}
 	}
 
@@ -1105,19 +1139,19 @@ func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.Packe
 		log.Debug("expected query is dml but actual is not",
 			zap.String("expected query", expectedQuery),
 			zap.String("actual query", actualQuery))
-		return false, 0, nil
+		return false, 0, nil, false
 	} else if !sqlparser.IsDML(expectedQuery) && sqlparser.IsDML(actualQuery) {
 		log.Debug("actual query is dml but expected is not",
 			zap.String("expected query", expectedQuery),
 			zap.String("actual query", actualQuery))
-		return false, 0, nil
+		return false, 0, nil, false
 	}
 
 	if !(sqlparser.IsDML(expectedQuery) && sqlparser.IsDML(actualQuery)) {
 		log.Debug("No Query is dml",
 			zap.String("expected query", expectedQuery),
 			zap.String("actual query", actualQuery))
-		return false, matchCount, nil
+		return false, matchCount, nil, false
 	}
 
 	// Here we can compare the structure of the queries, as both are DML queries.
@@ -1130,7 +1164,7 @@ func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.Packe
 		log.Debug("failed to get actual query structure",
 			zap.String("actual Query", actualQuery),
 			zap.Error(err))
-		return false, matchCount, nil
+		return false, matchCount, nil, false
 	}
 
 	expectedSignature, err := getQueryStructureCached(expectedQuery)
@@ -1138,7 +1172,7 @@ func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.Packe
 		log.Debug("failed to get expected query structure",
 			zap.String("expected Query", expectedQuery),
 			zap.Error(err))
-		return false, matchCount, nil
+		return false, matchCount, nil, false
 	}
 
 	if expectedSignature == actualSignature {
@@ -1158,18 +1192,32 @@ func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.Packe
 					zap.String("expected query", expectedQuery),
 					zap.String("actual query", actualQuery),
 					zap.Any("learned_noise", learnedNoise))
-				return true, matchCount + 8, nil
+				return true, matchCount + 8, nil, false
 			}
-			// A changed WHERE predicate (non-eligible) or an unlearned eligible
-			// drift must NOT match under strict. Return score 0 so this
-			// structurally-equal candidate is REJECTED outright rather than
-			// served via matchCommand's score-based partial fallback (which
-			// would otherwise treat matchCount+6 as the best partial and serve
-			// it — defeating strict enforcement).
-			log.Debug("strict: structurally-equal query rejected (non-noise literal drift)",
+			// The AST-type structure signature matched, but the drift is NOT
+			// within learned noise. Distinguish two cases via the redacted
+			// skeleton (which preserves tables/columns/operators):
+			//
+			//   - SAME skeleton => this IS the live query's actual counterpart
+			//     and it drifted in a non-noise / predicate (e.g. WHERE) literal:
+			//     a REAL regression. Hard-reject so matchCommand forces an
+			//     overall miss instead of serving an unrelated score-based
+			//     partial.
+			//
+			//   - DIFFERENT skeleton => merely a same-type-signature candidate
+			//     (different table/column/operator). Not this query's
+			//     counterpart; give it a low score and never let it be a
+			//     definitive match or a hard reject.
+			if skeletonsEqual(expectedQuery, actualQuery) {
+				log.Debug("strict: structurally-equal query hard-rejected (non-noise / predicate literal drift)",
+					zap.String("expected query", expectedQuery),
+					zap.String("actual query", actualQuery))
+				return false, 0, nil, true
+			}
+			log.Debug("strict: same-type-signature candidate is not this query's counterpart (different skeleton)",
 				zap.String("expected query", expectedQuery),
 				zap.String("actual query", actualQuery))
-			return false, 0, nil
+			return false, matchCount, nil, false
 		}
 
 		// DETECTION (lenient): learn which eligible literal positions drifted
@@ -1183,21 +1231,21 @@ func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.Packe
 					zap.String("expected query", expectedQuery),
 					zap.String("actual query", actualQuery),
 					zap.Any("detected_noise", learned))
-				return false, matchCount + 6, learned
+				return false, matchCount + 6, learned, false
 			}
 		}
 
-		return false, matchCount + 6, nil
+		return false, matchCount + 6, nil, false
 	}
 
-	return false, matchCount, nil
+	return false, matchCount, nil, false
 }
 
 // matchQueryPacket scores a recorded COM_QUERY against a live one and threads
 // the schema-noise flags + the matched mock's learned QueryNoise through to
 // matchQuery. The third return value carries any literal noise detected on the
 // structurally-equal-but-value-different path so the caller can persist it.
-func matchQueryPacket(ctx context.Context, log *zap.Logger, expected, actual mysql.PacketBundle, schemaNoiseDetection bool, schemaNoiseStrict bool, learnedNoise map[string][]string) (matched bool, score int, detected map[string][]string) {
+func matchQueryPacket(ctx context.Context, log *zap.Logger, expected, actual mysql.PacketBundle, schemaNoiseDetection bool, schemaNoiseStrict bool, learnedNoise map[string][]string) (matched bool, score int, detected map[string][]string, hardReject bool) {
 	getQuery := func(packet mysql.PacketBundle) string {
 		msg, _ := packet.Message.(*mysql.QueryPacket)
 		return msg.Query
@@ -1211,8 +1259,9 @@ func matchPreparePacket(ctx context.Context, log *zap.Logger, expected, actual m
 		return msg.Query
 	}
 	// Prepared statements (COM_STMT_PREPARE/EXECUTE) are out of scope for
-	// request-literal noise — keep schema-noise disabled here.
-	matched, score, _ := matchQuery(ctx, log, expected, actual, getQuery, false, false, nil)
+	// request-literal noise — keep schema-noise disabled here. The hardReject
+	// signal only applies to the strict COM_QUERY path, so it is ignored.
+	matched, score, _, _ := matchQuery(ctx, log, expected, actual, getQuery, false, false, nil)
 	return matched, score
 }
 

--- a/pkg/agent/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match.go
@@ -208,7 +208,7 @@ func isSessionReusableCommandMock(mock *models.Mock) bool {
 	return strings.HasPrefix(hdr.Type, "COM_")
 }
 
-func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mockDb integrations.MockMemDb, decodeCtx *wire.DecodeContext) (*mysql.Response, bool, string, string, error) {
+func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mockDb integrations.MockMemDb, decodeCtx *wire.DecodeContext, schemaNoiseDetection bool, schemaNoiseStrict bool) (*mysql.Response, bool, string, string, error) {
 	// Precompute string constants once (avoid frequent map lookups)
 	var (
 		sCOM_QUIT       = mysql.CommandStatusToString(mysql.COM_QUIT)
@@ -420,6 +420,17 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 		// genuinely reusable single-recording query.
 		queryExactResp *mysql.Response
 		queryExactMock *models.Mock
+
+		// queryDetectedNoise holds the per-position literal noise detected on
+		// the COM_QUERY structurally-equal-but-value-different path for the
+		// mock ultimately served. It is keyed to whichever mock becomes
+		// matchedMock so updateMock can attach it onto a fresh copy and flag it
+		// for persistence. We track per candidate-mock pointer so a later
+		// in-window winner carries ITS own detected noise, not an earlier
+		// candidate's.
+		queryDetectedNoise        map[string][]string
+		queryExactDetectedNoise   map[string][]string
+		partialQueryDetectedNoise map[string][]string
 	)
 
 	// Single pass: filter & match on the fly. Iterates the merged pool
@@ -462,25 +473,39 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 				}
 
 			case sCOM_QUERY:
-				if ok, c := matchQueryPacket(ctx, logger, mockReq.PacketBundle, req.PacketBundle); ok {
-					// Exact query-text match. Prefer the candidate recorded
-					// inside the current test window so a repeated stateful
-					// read-back (same SQL, different row per call) resolves to
-					// THIS test's row instead of the first one recorded. An
-					// out-of-window exact match is kept only as a fallback for
-					// a genuinely reusable single-recording query. When no
-					// window is active (windowActive==false) this collapses to
-					// the previous first-exact-match-wins behaviour.
+				// Thread the matched mock's learned QueryNoise + the schema-
+				// noise flags through so matchQueryPacket can (a) strictly
+				// consume a structurally-equal mock whose only drift is in
+				// learned-noise SET/VALUES positions, and (b) on the detection
+				// path surface newly-detected literal noise for persistence.
+				if ok, c, detected := matchQueryPacket(ctx, logger, mockReq.PacketBundle, req.PacketBundle, schemaNoiseDetection, schemaNoiseStrict, mockReq.QueryNoise); ok {
+					// Exact query-text match (or a strict within-noise match).
+					// Prefer the candidate recorded inside the current test
+					// window so a repeated stateful read-back (same SQL,
+					// different row per call) resolves to THIS test's row
+					// instead of the first one recorded. An out-of-window exact
+					// match is kept only as a fallback for a genuinely reusable
+					// single-recording query. When no window is active
+					// (windowActive==false) this collapses to the previous
+					// first-exact-match-wins behaviour.
 					if windowActive && !mockInCurrentWindow(mock) {
 						if queryExactMock == nil {
 							queryExactResp, queryExactMock = &mock.Spec.MySQLResponses[0], mock
+							queryExactDetectedNoise = detected
 						}
 					} else {
 						matchedResp, matchedMock, queryMatched = &mock.Spec.MySQLResponses[0], mock, true
+						queryDetectedNoise = detected
 					}
 				} else if c > maxMatchedCount {
 					maxMatchedCount, matchedResp, matchedMock = c, &mock.Spec.MySQLResponses[0], mock
 					bestPartialMock = mock
+					// On the detection path a structurally-equal-but-value-
+					// different COM_QUERY returns ok==false with a high score
+					// (matchCount+6) and the detected literal noise. Carry it on
+					// the partial winner so that if this mock is ultimately
+					// served (no exact match anywhere), the noise is persisted.
+					partialQueryDetectedNoise = detected
 					if qp, qok := mockReq.PacketBundle.Message.(*mysql.QueryPacket); qok {
 						bestPartialQuery = qp.Query
 					}
@@ -620,6 +645,7 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 	// candidate rather than dropping to the score-based partial pick.
 	if req.Header.Type == sCOM_QUERY && !queryMatched && queryExactMock != nil {
 		matchedResp, matchedMock, queryMatched = queryExactResp, queryExactMock, true
+		queryDetectedNoise = queryExactDetectedNoise
 	}
 
 	// COM_STMT_EXECUTE FIFO fallback. If the scan found no definitive
@@ -766,7 +792,7 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 				chosen = sldMock
 			}
 			if chosen != nil {
-				updateMock(ctx, logger, chosen, mockDb)
+				updateMock(ctx, logger, chosen, mockDb, nil)
 			}
 			logger.Debug("Accepting COM_STMT_SEND_LONG_DATA (no-response command)",
 				zap.Bool("consumed_recorded_mock", chosen != nil))
@@ -913,9 +939,20 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 		return nil, false, bestPartialQuery, bestPartialMockName, nil
 	}
 
+	// Resolve the literal noise (if any) detected for the COM_QUERY mock we
+	// are about to serve. A structurally-equal-but-value-different COM_QUERY
+	// is served via the score-based partial path (ok==false, score=matchCount+6),
+	// so when no exact/strict match set queryDetectedNoise but the served mock
+	// is that partial winner, carry the partial's detected noise instead.
+	if len(queryDetectedNoise) == 0 && matchedMock != nil && matchedMock == bestPartialMock {
+		queryDetectedNoise = partialQueryDetectedNoise
+	}
+
 	// Update the mock in the database BEFORE modifying the response
-	// This ensures we update using the original mock state
-	if okk := updateMock(ctx, logger, matchedMock, mockDb); !okk {
+	// This ensures we update using the original mock state. When detection
+	// found literal noise on a COM_QUERY mock, updateMock attaches it onto a
+	// fresh copy so flagMockAsUsed carries it out for persistence.
+	if okk := updateMock(ctx, logger, matchedMock, mockDb, queryDetectedNoise); !okk {
 		logger.Debug("failed to update the matched mock")
 		// Re-fetch once to avoid spin
 		return nil, false, "", "", fmt.Errorf("failed to update matched mock")
@@ -1012,12 +1049,26 @@ func getQueryStructure(sql string) (string, error) {
 	return strings.Join(structureParts, "->"), nil
 }
 
-func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.PacketBundle, getQuery func(packet mysql.PacketBundle) string) (bool, int) {
+// matchQuery scores a recorded query packet against a live one. The
+// schemaNoise* flags + learnedNoise enable MySQL request-literal noise for the
+// COM_QUERY path (mirroring HTTP ReqBodyNoise):
+//   - schemaNoiseDetection: when the two queries are STRUCTURALLY identical but
+//     some literal VALUES differ, the detected per-position noise (SET/VALUES
+//     literals only — default-deny everywhere else) is returned as the third
+//     value so the caller can attach it to the matched mock and persist it.
+//     Detection does NOT force a match.
+//   - schemaNoiseStrict: a structurally-identical recorded query MATCHES (is
+//     consumed) iff every differing literal position is in learnedNoise; any
+//     non-learned eligible drift, or any non-eligible (e.g. WHERE) drift, fails.
+//
+// learnedNoise is the matched mock's existing QueryNoise (the learned set).
+// detected is non-nil only on the detection path when eligible drift was found.
+func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.PacketBundle, getQuery func(packet mysql.PacketBundle) string, schemaNoiseDetection bool, schemaNoiseStrict bool, learnedNoise map[string][]string) (matched bool, score int, detected map[string][]string) {
 	matchCount := 0
 
 	// Match the type and return zero if the types are not equal
 	if expected.Header.Type != actual.Header.Type {
-		return false, 0
+		return false, 0, nil
 	}
 
 	expectedQuery := getQuery(expected)
@@ -1033,7 +1084,7 @@ func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.Packe
 		// 	zap.String("actual_query", actualQuery),
 		// 	zap.Int("expected_placeholders", expectedPlaceholders),
 		// 	zap.Int("actual_placeholders", actualPlaceholders))
-		return false, 0
+		return false, 0, nil
 	}
 
 	if actual.Header != nil && actual.Header.Header != nil &&
@@ -1045,7 +1096,7 @@ func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.Packe
 			log.Debug("Query Exact matched",
 				zap.String("expected query", expectedQuery),
 				zap.String("actual query", actualQuery))
-			return true, matchCount
+			return true, matchCount, nil
 		}
 	}
 
@@ -1054,19 +1105,19 @@ func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.Packe
 		log.Debug("expected query is dml but actual is not",
 			zap.String("expected query", expectedQuery),
 			zap.String("actual query", actualQuery))
-		return false, 0
+		return false, 0, nil
 	} else if !sqlparser.IsDML(expectedQuery) && sqlparser.IsDML(actualQuery) {
 		log.Debug("actual query is dml but expected is not",
 			zap.String("expected query", expectedQuery),
 			zap.String("actual query", actualQuery))
-		return false, 0
+		return false, 0, nil
 	}
 
 	if !(sqlparser.IsDML(expectedQuery) && sqlparser.IsDML(actualQuery)) {
 		log.Debug("No Query is dml",
 			zap.String("expected query", expectedQuery),
 			zap.String("actual query", actualQuery))
-		return false, matchCount
+		return false, matchCount, nil
 	}
 
 	// Here we can compare the structure of the queries, as both are DML queries.
@@ -1079,7 +1130,7 @@ func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.Packe
 		log.Debug("failed to get actual query structure",
 			zap.String("actual Query", actualQuery),
 			zap.Error(err))
-		return false, matchCount
+		return false, matchCount, nil
 	}
 
 	expectedSignature, err := getQueryStructureCached(expectedQuery)
@@ -1087,25 +1138,71 @@ func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.Packe
 		log.Debug("failed to get expected query structure",
 			zap.String("expected Query", expectedQuery),
 			zap.Error(err))
-		return false, matchCount
+		return false, matchCount, nil
 	}
 
 	if expectedSignature == actualSignature {
 		log.Debug("query structure matched",
 			zap.String("expected signature", expectedSignature),
 			zap.String("actual signature", actualSignature))
-		return false, matchCount + 6
+
+		// MySQL request-literal noise (COM_QUERY path only — prepared
+		// COM_STMT_EXECUTE is out of scope, see querynoise.go TODO). The two
+		// queries are structurally identical but differ in literal values.
+		//
+		// STRICT enforcement: consume this mock iff every differing literal is
+		// in an eligible position (SET/VALUES) AND already a learned-noise key.
+		if schemaNoiseStrict {
+			if queryMatchesWithinNoise(expectedQuery, actualQuery, learnedNoise) {
+				log.Debug("query matched within learned literal noise (strict)",
+					zap.String("expected query", expectedQuery),
+					zap.String("actual query", actualQuery),
+					zap.Any("learned_noise", learnedNoise))
+				return true, matchCount + 8, nil
+			}
+			// A changed WHERE predicate (non-eligible) or an unlearned eligible
+			// drift must NOT match under strict. Return score 0 so this
+			// structurally-equal candidate is REJECTED outright rather than
+			// served via matchCommand's score-based partial fallback (which
+			// would otherwise treat matchCount+6 as the best partial and serve
+			// it — defeating strict enforcement).
+			log.Debug("strict: structurally-equal query rejected (non-noise literal drift)",
+				zap.String("expected query", expectedQuery),
+				zap.String("actual query", actualQuery))
+			return false, 0, nil
+		}
+
+		// DETECTION (lenient): learn which eligible literal positions drifted
+		// and surface them so the caller can attach them to the matched mock
+		// and persist them. Detection does NOT force a match — it only learns;
+		// the structurally-equal mock is still served by matchCommand's
+		// score/in-window selection, carrying this noise out for persistence.
+		if schemaNoiseDetection {
+			if learned, ok := detectQueryNoise(expectedQuery, actualQuery); ok && len(learned) > 0 {
+				log.Debug("detected literal noise on structurally-equal query",
+					zap.String("expected query", expectedQuery),
+					zap.String("actual query", actualQuery),
+					zap.Any("detected_noise", learned))
+				return false, matchCount + 6, learned
+			}
+		}
+
+		return false, matchCount + 6, nil
 	}
 
-	return false, matchCount
+	return false, matchCount, nil
 }
 
-func matchQueryPacket(ctx context.Context, log *zap.Logger, expected, actual mysql.PacketBundle) (bool, int) {
+// matchQueryPacket scores a recorded COM_QUERY against a live one and threads
+// the schema-noise flags + the matched mock's learned QueryNoise through to
+// matchQuery. The third return value carries any literal noise detected on the
+// structurally-equal-but-value-different path so the caller can persist it.
+func matchQueryPacket(ctx context.Context, log *zap.Logger, expected, actual mysql.PacketBundle, schemaNoiseDetection bool, schemaNoiseStrict bool, learnedNoise map[string][]string) (matched bool, score int, detected map[string][]string) {
 	getQuery := func(packet mysql.PacketBundle) string {
 		msg, _ := packet.Message.(*mysql.QueryPacket)
 		return msg.Query
 	}
-	return matchQuery(ctx, log, expected, actual, getQuery)
+	return matchQuery(ctx, log, expected, actual, getQuery, schemaNoiseDetection, schemaNoiseStrict, learnedNoise)
 }
 
 func matchPreparePacket(ctx context.Context, log *zap.Logger, expected, actual mysql.PacketBundle) (bool, int) {
@@ -1113,7 +1210,10 @@ func matchPreparePacket(ctx context.Context, log *zap.Logger, expected, actual m
 		msg, _ := packet.Message.(*mysql.StmtPreparePacket)
 		return msg.Query
 	}
-	return matchQuery(ctx, log, expected, actual, getQuery)
+	// Prepared statements (COM_STMT_PREPARE/EXECUTE) are out of scope for
+	// request-literal noise — keep schema-noise disabled here.
+	matched, score, _ := matchQuery(ctx, log, expected, actual, getQuery, false, false, nil)
+	return matched, score
 }
 
 // query-aware EXEC scoring.
@@ -1493,10 +1593,30 @@ func matchResetConnectionPacket(_ context.Context, _ *zap.Logger, expected, actu
 // match.go for the rationale — we build a fresh copy and mutate the
 // copy rather than the pool pointer, so concurrent goroutines that
 // match the same session-lifetime mock don't race on TestModeInfo.
-func updateMock(_ context.Context, logger *zap.Logger, matchedMock *models.Mock, mockDb integrations.MockMemDb) bool {
+// updateMock consumes/re-stamps the matched mock. detectedNoise (COM_QUERY
+// request-literal noise learned this match — nil/empty otherwise) is attached
+// onto a FRESH copy of the matched mock's first MySQLRequest, mirroring the
+// HTTP updateMock: flagMockAsUsed reads the copy's QueryNoise to carry it out on
+// the MockState, and mockdb.UpdateMocks/PersistMockNoise persists it. The copy
+// is never the shared pooled mock's map (concurrency: two requests matching the
+// same session mock share the pointer).
+func updateMock(_ context.Context, logger *zap.Logger, matchedMock *models.Mock, mockDb integrations.MockMemDb, detectedNoise map[string][]string) bool {
 	updatedMock := *matchedMock
 	updatedMock.TestModeInfo.IsFiltered = false
 	updatedMock.TestModeInfo.SortOrder = pkg.GetNextSortNum()
+
+	// Attach detected literal noise onto a fresh MySQLRequests copy so the
+	// shared pooled mock's slice/map is never mutated.
+	attachQueryNoise := func(m *models.Mock) {
+		if len(detectedNoise) == 0 || len(m.Spec.MySQLRequests) == 0 {
+			return
+		}
+		reqs := make([]mysql.Request, len(m.Spec.MySQLRequests))
+		copy(reqs, m.Spec.MySQLRequests)
+		reqs[0].QueryNoise = mergeQueryNoise(reqs[0].QueryNoise, detectedNoise)
+		m.Spec.MySQLRequests = reqs
+	}
+	attachQueryNoise(&updatedMock)
 
 	lifetime := updatedMock.TestModeInfo.Lifetime
 	rawConfig := false
@@ -1523,7 +1643,17 @@ func updateMock(_ context.Context, logger *zap.Logger, matchedMock *models.Mock,
 	// SetMocksWithWindow's isInitialStaging branch) — the mock is
 	// still classified as LifetimePerTest but physically lives in
 	// the session tree until the first real test's re-partition.
-	if mockDb.DeleteFilteredMock(*matchedMock) {
+	//
+	// DeleteFilteredMock keys the tree lookup on TestModeInfo, so the
+	// delete-key mock MUST keep the original (unmutated) TestModeInfo — we
+	// pass a copy that retains it but carries the detected noise on a fresh
+	// MySQLRequests slice, so flagMockAsUsed reports the noise on the consumed
+	// per-test mock (it would otherwise be lost: the original matchedMock has
+	// no noise, and updatedMock's mutated TestModeInfo wouldn't match the tree
+	// node). Mirrors the HTTP updateMock deleteMock path.
+	deleteMock := *matchedMock
+	attachQueryNoise(&deleteMock)
+	if mockDb.DeleteFilteredMock(deleteMock) {
 		return true
 	}
 	if mockDb.UpdateUnFilteredMock(matchedMock, &updatedMock) {
@@ -1532,6 +1662,27 @@ func updateMock(_ context.Context, logger *zap.Logger, matchedMock *models.Mock,
 	logger.Debug("failed to delete or update matched per-test mock",
 		zap.String("mock", updatedMock.Name))
 	return false
+}
+
+// mergeQueryNoise returns a fresh map combining existing learned literal noise
+// with newly detected noise; existing entries win on key collision. Never
+// aliases an input map. Mirrors HTTP mergeReqBodyNoise.
+func mergeQueryNoise(existing, detected map[string][]string) map[string][]string {
+	out := make(map[string][]string, len(existing)+len(detected))
+	for k, v := range existing {
+		vc := make([]string, len(v))
+		copy(vc, v)
+		out[k] = vc
+	}
+	for k, v := range detected {
+		if _, ok := out[k]; ok {
+			continue
+		}
+		vc := make([]string, len(v))
+		copy(vc, v)
+		out[k] = vc
+	}
+	return out
 }
 
 // printable strips non-printable bytes (common in legacy mocks)

--- a/pkg/agent/proxy/integrations/mysql/replayer/match_comquery_window_test.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match_comquery_window_test.go
@@ -424,3 +424,34 @@ func TestMatchCommand_ComQueryStrictHardRejectForcesMiss(t *testing.T) {
 		t.Errorf("nothing should be consumed on a hard-reject miss; deletedFil=%v deletedMk=%d", db.deletedFil, len(db.deletedMk))
 	}
 }
+
+// TestMatchCommand_StrictNoPartialForDifferentSkeleton is the regression guard
+// for the follow-up finding: under strict, a candidate whose redacted skeleton
+// differs from the live query (changed column / operator, or a different
+// statement shape) must NOT be served through matchCommand's score-based
+// partial fallback even when payload lengths coincide. Strict serves only an
+// exact or within-noise match; otherwise it must MISS so the real query-shape
+// regression surfaces.
+func TestMatchCommand_StrictNoPartialForDifferentSkeleton(t *testing.T) {
+	logger := zap.NewNop()
+	cases := []struct{ name, recorded, live string }{
+		// same AST node-type signature, different column in WHERE
+		{"column", "update t set a=1 where id=1", "update t set a=1 where ix=1"},
+		// same node-type signature, different operator in WHERE
+		{"operator", "update t set a=1 where id=1", "update t set a=1 where id>1"},
+		// different statement shape (extra SET column) — falls to the score path
+		{"shape", "update t set a=1, b=2 where id=1", "update t set a=1 where id=1"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			db := &fakeMockDb{perTest: []*models.Mock{dmlMock("cand", c.recorded, nil)}}
+			resp, ok, _, _, err := matchCommand(context.Background(), logger, comQueryReq(c.live), db, newDecodeCtx(), false, true)
+			if ok || resp != nil {
+				t.Fatalf("strict: %s drift must MISS, never serve a score partial; got ok=%v resp=%v err=%v", c.name, ok, resp, err)
+			}
+			if len(db.deletedFil) != 0 || len(db.deletedMk) != 0 {
+				t.Errorf("%s: nothing should be consumed on a strict miss; deletedFil=%v", c.name, db.deletedFil)
+			}
+		})
+	}
+}

--- a/pkg/agent/proxy/integrations/mysql/replayer/match_comquery_window_test.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match_comquery_window_test.go
@@ -2,6 +2,7 @@ package replayer
 
 import (
 	"context"
+	"reflect"
 	"testing"
 	"time"
 
@@ -23,7 +24,9 @@ type fakeMockDb struct {
 	session    []*models.Mock
 	winStart   time.Time
 	winEnd     time.Time
-	deletedFil []string // names passed to DeleteFilteredMock
+	deletedFil []string                // names passed to DeleteFilteredMock
+	deletedMk  []models.Mock           // full mocks passed to DeleteFilteredMock
+	updatedNew map[string]*models.Mock // name -> updated copy passed to UpdateUnFilteredMock
 }
 
 func (f *fakeMockDb) GetSessionMocks() ([]*models.Mock, error)         { return f.session, nil }
@@ -44,11 +47,18 @@ func (f *fakeMockDb) GetStartupMocksByKind(models.Kind) ([]*models.Mock, error) 
 }
 func (f *fakeMockDb) GetSessionScopedMocks() ([]*models.Mock, error) { return nil, nil }
 func (f *fakeMockDb) SessionMockHitCounts() map[string]uint64        { return nil }
-func (f *fakeMockDb) UpdateUnFilteredMock(*models.Mock, *models.Mock) bool {
+func (f *fakeMockDb) UpdateUnFilteredMock(_ *models.Mock, n *models.Mock) bool {
+	if n != nil {
+		if f.updatedNew == nil {
+			f.updatedNew = map[string]*models.Mock{}
+		}
+		f.updatedNew[n.Name] = n
+	}
 	return true // session mocks are reusable: re-stamped, not removed
 }
 func (f *fakeMockDb) DeleteFilteredMock(m models.Mock) bool {
 	f.deletedFil = append(f.deletedFil, m.Name)
+	f.deletedMk = append(f.deletedMk, m)
 	// Real semantics: a per-test mock present in the filtered pool is consumed
 	// (removed) and returns true; a per-test mock that has been lax-staged into
 	// the session pool is not in the filtered tree, so DeleteFilteredMock misses
@@ -143,7 +153,7 @@ func TestMatchCommand_OrphanPrepareSynthesizesPrepareOk(t *testing.T) {
 	db := &fakeMockDb{session: []*models.Mock{filler}}
 	dctx := newDecodeCtx()
 
-	resp, ok, _, _, err := matchCommand(context.Background(), logger, stmtPrepareReq(sql), db, dctx)
+	resp, ok, _, _, err := matchCommand(context.Background(), logger, stmtPrepareReq(sql), db, dctx, false, false)
 	if err != nil || !ok || resp == nil {
 		t.Fatalf("orphaned PREPARE must synthesize a PREPARE_OK, got ok=%v err=%v resp=%v", ok, err, resp)
 	}
@@ -189,7 +199,7 @@ func TestMatchCommand_SendLongDataAcceptedGracefully(t *testing.T) {
 			Message: &mysql.StmtSendLongDataPacket{StatementID: 3, ParameterID: 0},
 		},
 	}
-	_, ok, _, _, err := matchCommand(context.Background(), logger, req, db, newDecodeCtx())
+	_, ok, _, _, err := matchCommand(context.Background(), logger, req, db, newDecodeCtx(), false, false)
 	if err != nil {
 		t.Fatalf("unmocked COM_STMT_SEND_LONG_DATA must not error, got %v", err)
 	}
@@ -228,7 +238,7 @@ func TestMatchCommand_SendLongDataConsumesRecordedMock(t *testing.T) {
 		Header:  &mysql.PacketInfo{Header: &mysql.Header{PayloadLength: 12, SequenceID: 0}, Type: "COM_STMT_SEND_LONG_DATA"},
 		Message: &mysql.StmtSendLongDataPacket{StatementID: 3},
 	}}
-	_, ok, _, _, err := matchCommand(context.Background(), logger, req, db, newDecodeCtx())
+	_, ok, _, _, err := matchCommand(context.Background(), logger, req, db, newDecodeCtx(), false, false)
 	if err != nil || !ok {
 		t.Fatalf("SLD must be accepted, got ok=%v err=%v", ok, err)
 	}
@@ -272,7 +282,7 @@ func TestMatchCommand_ComQueryStatefulReadInWindow(t *testing.T) {
 			winStart: base.Add(5 * time.Second),  // [t1 < winStart < t2 < winEnd < t3]
 			winEnd:   base.Add(15 * time.Second), // only readback-2 is in-window
 		}
-		resp, ok, _, _, err := matchCommand(context.Background(), logger, comQueryReq(sql), db, newDecodeCtx())
+		resp, ok, _, _, err := matchCommand(context.Background(), logger, comQueryReq(sql), db, newDecodeCtx(), false, false)
 		if err != nil || !ok || resp == nil {
 			t.Fatalf("expected a match, got ok=%v err=%v resp=%v", ok, err, resp)
 		}
@@ -283,7 +293,7 @@ func TestMatchCommand_ComQueryStatefulReadInWindow(t *testing.T) {
 
 	t.Run("no active window falls back to first-recorded (no behavior change)", func(t *testing.T) {
 		db := &fakeMockDb{session: mocks} // zero window => windowActive == false
-		resp, ok, _, _, err := matchCommand(context.Background(), logger, comQueryReq(sql), db, newDecodeCtx())
+		resp, ok, _, _, err := matchCommand(context.Background(), logger, comQueryReq(sql), db, newDecodeCtx(), false, false)
 		if err != nil || !ok || resp == nil {
 			t.Fatalf("expected a match, got ok=%v err=%v resp=%v", ok, err, resp)
 		}
@@ -301,12 +311,85 @@ func TestMatchCommand_ComQueryStatefulReadInWindow(t *testing.T) {
 			winStart: base.Add(100 * time.Second),
 			winEnd:   base.Add(200 * time.Second),
 		}
-		resp, ok, _, _, err := matchCommand(context.Background(), logger, comQueryReq(sql), db, newDecodeCtx())
+		resp, ok, _, _, err := matchCommand(context.Background(), logger, comQueryReq(sql), db, newDecodeCtx(), false, false)
 		if err != nil || !ok || resp == nil {
 			t.Fatalf("expected the reusable recording to still match, got ok=%v err=%v", ok, err)
 		}
 		if resp.Payload != "row=only" {
 			t.Errorf("expected out-of-window fallback to serve row=only, got %q", resp.Payload)
+		}
+	})
+}
+
+// dmlMock builds a per-test COM_QUERY DML mock (consumable via
+// DeleteFilteredMock) carrying the given recorded SQL and optional learned
+// QueryNoise. Equal payload length to the live request drives the matcher into
+// the structure-equal branch.
+func dmlMock(name, sql string, learned map[string][]string) *models.Mock {
+	m := readbackMock(name, sql, "served", time.Time{})
+	m.TestModeInfo.Lifetime = models.LifetimePerTest
+	m.Spec.Metadata = map[string]string{"type": "mocks"}
+	m.Spec.MySQLRequests[0].QueryNoise = learned
+	return m
+}
+
+// TestMatchCommand_ComQueryLiteralNoise exercises the end-to-end COM_QUERY
+// request-literal noise wiring through matchCommand: detection learns and
+// attaches noise onto the consumed mock; strict enforcement consumes a
+// structurally-identical mock iff every literal drift is in the learned-noise
+// set; and a WHERE-only drift never matches under strict.
+func TestMatchCommand_ComQueryLiteralNoise(t *testing.T) {
+	logger := zap.NewNop()
+	recorded := "update orders set views=5, updated_at='2026-01-01 12:48:36' where region='north'"
+	liveSetDrift := "update orders set views=5, updated_at='2026-06-17 14:00:24' where region='north'"
+	liveWhereDrift := "update orders set views=5, updated_at='2026-01-01 12:48:36' where region='south'"
+
+	t.Run("detection attaches learned noise onto consumed mock", func(t *testing.T) {
+		mock := dmlMock("upd", recorded, nil)
+		db := &fakeMockDb{perTest: []*models.Mock{mock}}
+
+		// Detection ON, strict OFF. The structurally-equal mock is served via
+		// the score-based partial path (ok=true overall because matchedResp is
+		// set), and the detected updated_at noise must be attached to the mock
+		// that DeleteFilteredMock consumed.
+		resp, ok, _, _, err := matchCommand(context.Background(), logger, comQueryReq(liveSetDrift), db, newDecodeCtx(), true, false)
+		if err != nil || !ok || resp == nil {
+			t.Fatalf("expected a served response on detection path, got ok=%v err=%v resp=%v", ok, err, resp)
+		}
+		if len(db.deletedMk) == 0 {
+			t.Fatalf("expected the mock to be consumed via DeleteFilteredMock")
+		}
+		got := db.deletedMk[0].Spec.MySQLRequests[0].QueryNoise
+		want := map[string][]string{"set:updated_at#0": {"2026-01-01 12:48:36"}}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("detected noise attached to consumed mock mismatch:\n want %v\n got  %v", want, got)
+		}
+		// The original pooled mock's map must be untouched (fresh copy).
+		if mock.Spec.MySQLRequests[0].QueryNoise != nil {
+			t.Errorf("detection mutated the shared pooled mock's QueryNoise: %v", mock.Spec.MySQLRequests[0].QueryNoise)
+		}
+	})
+
+	t.Run("strict consumes mock when only learned-noise literal drifts", func(t *testing.T) {
+		learned := map[string][]string{"set:updated_at#0": {"2026-01-01 12:48:36"}}
+		db := &fakeMockDb{perTest: []*models.Mock{dmlMock("upd", recorded, learned)}}
+
+		_, ok, _, _, err := matchCommand(context.Background(), logger, comQueryReq(liveSetDrift), db, newDecodeCtx(), false, true)
+		if err != nil || !ok {
+			t.Fatalf("strict: expected within-noise match to be consumed, got ok=%v err=%v", ok, err)
+		}
+		if len(db.deletedFil) == 0 {
+			t.Errorf("strict within-noise match should consume the mock (DeleteFilteredMock)")
+		}
+	})
+
+	t.Run("strict rejects WHERE-only drift (never learnable)", func(t *testing.T) {
+		learned := map[string][]string{"set:updated_at#0": {"2026-01-01 12:48:36"}}
+		db := &fakeMockDb{perTest: []*models.Mock{dmlMock("upd", recorded, learned)}}
+
+		_, ok, _, _, err := matchCommand(context.Background(), logger, comQueryReq(liveWhereDrift), db, newDecodeCtx(), false, true)
+		if ok {
+			t.Errorf("strict: a changed WHERE predicate must NOT match (err=%v)", err)
 		}
 	})
 }

--- a/pkg/agent/proxy/integrations/mysql/replayer/match_comquery_window_test.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match_comquery_window_test.go
@@ -393,3 +393,34 @@ func TestMatchCommand_ComQueryLiteralNoise(t *testing.T) {
 		}
 	})
 }
+
+// TestMatchCommand_ComQueryStrictHardRejectForcesMiss is the regression guard
+// for Finding 3: when the live query's structural counterpart is found but
+// drifted in a non-noise / predicate literal (a real regression), strict mode
+// must force an OVERALL MISS — it must NOT fall back to serving an unrelated
+// candidate that merely scored a payload-length partial.
+func TestMatchCommand_ComQueryStrictHardRejectForcesMiss(t *testing.T) {
+	logger := zap.NewNop()
+	// Same skeleton as the live query; only the WHERE region literal drifts ->
+	// hard reject under strict (region is non-eligible).
+	counterpart := "update orders set views=5, updated_at='2026-01-01 12:48:36' where region='north'"
+	live := "update orders set views=5, updated_at='2026-01-01 12:48:36' where region='south'"
+	// Unrelated query (different table/columns) that still scores a payload-
+	// length partial (matchCount=1). Without the hard-reject, matchCommand would
+	// serve THIS as the best partial for the live query.
+	unrelated := "update events set code='x' where id=1"
+
+	learned := map[string][]string{"set:updated_at#0": {"2026-01-01 12:48:36"}}
+	db := &fakeMockDb{perTest: []*models.Mock{
+		dmlMock("unrelated", unrelated, nil),
+		dmlMock("counterpart", counterpart, learned),
+	}}
+
+	resp, ok, _, _, err := matchCommand(context.Background(), logger, comQueryReq(live), db, newDecodeCtx(), false, true)
+	if ok || resp != nil {
+		t.Fatalf("strict: WHERE-drift counterpart must force an overall MISS even with a competing partial; got ok=%v resp=%v err=%v", ok, resp, err)
+	}
+	if len(db.deletedFil) != 0 || len(db.deletedMk) != 0 {
+		t.Errorf("nothing should be consumed on a hard-reject miss; deletedFil=%v deletedMk=%d", db.deletedFil, len(db.deletedMk))
+	}
+}

--- a/pkg/agent/proxy/integrations/mysql/replayer/query.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/query.go
@@ -97,8 +97,10 @@ func simulateCommandPhase(ctx context.Context, logger *zap.Logger, clientConn ne
 				PacketBundle: *commandPkt,
 			}
 
-			// Match the request with the mock
-			resp, ok, closestQuery, closestMockName, err := matchCommand(ctx, logger, req, mockDb, decodeCtx)
+			// Match the request with the mock. Thread the schema-noise flags
+			// from OutgoingOptions so the COM_QUERY matcher can learn (detection)
+			// or enforce (strict) MySQL request-literal noise, mirroring HTTP.
+			resp, ok, closestQuery, closestMockName, err := matchCommand(ctx, logger, req, mockDb, decodeCtx, opts.SchemaNoiseDetection, opts.SchemaNoiseStrict)
 			if err != nil {
 				if err == io.EOF {
 					logger.Debug("Connection closing due to EOF from matchCommand",

--- a/pkg/agent/proxy/integrations/mysql/replayer/querynoise.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/querynoise.go
@@ -124,21 +124,71 @@ func extractQueryLiterals(sql string) ([]queryLiteralToken, error) {
 	return tokens, nil
 }
 
-// markLiteralsUnder records every *sqlparser.Literal reachable from expr into
-// the eligible set under key. A SET RHS / VALUES element is usually a bare
-// literal, but it can also be a wrapping expression (e.g. NOW() has no literal,
-// a tuple, an arithmetic expression) — walking the subtree captures whatever
+// markLiteralsUnder records every DIRECT-value *sqlparser.Literal reachable
+// from expr into the eligible set under key. A SET RHS / VALUES element is
+// usually a bare literal, but it can also be a wrapping expression (e.g. a
+// tuple or an arithmetic expression) — walking the subtree captures whatever
 // literals it actually contains while keeping non-literal positions out.
+//
+// Crucially, eligibility must NOT leak into nested query/predicate contexts:
+// a literal inside a subquery, a SELECT/UNION, or a CASE expression under the
+// SET RHS (e.g. `set score=(select max(score) from scores where tenant_id=1)`)
+// lives in a predicate position that is never learnable. We stop descending at
+// those node types so their literals remain default-deny (they are still
+// collected as non-eligible by the main extractor Walk).
 func markLiteralsUnder(expr sqlparser.Expr, key string, eligible map[*sqlparser.Literal]string) {
 	if expr == nil {
 		return
 	}
 	_ = sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
-		if lit, ok := node.(*sqlparser.Literal); ok {
-			eligible[lit] = key
+		switch n := node.(type) {
+		case *sqlparser.Subquery, *sqlparser.Select, *sqlparser.Union, *sqlparser.CaseExpr:
+			// Stop descending: literals under a nested query / CASE predicate
+			// are never directly-set values and must stay non-eligible.
+			return false, nil
+		case *sqlparser.Literal:
+			eligible[n] = key
 		}
 		return true, nil
 	}, expr)
+}
+
+// redactedSkeleton returns sql with every literal replaced by a placeholder
+// while preserving table/column/operator/keyword structure — a canonical
+// skeleton produced by vitess' RedactSQLQuery. The bool is false when the SQL
+// fails to parse/normalize. Two queries whose skeletons are byte-equal share
+// ALL non-literal semantics (same tables, columns, operators, clause shape);
+// only their literal VALUES may differ.
+func redactedSkeleton(sql string) (string, bool) {
+	parser, err := newSQLParser()
+	if err != nil {
+		return "", false
+	}
+	skeleton, err := parser.RedactSQLQuery(sql)
+	if err != nil {
+		return "", false
+	}
+	return skeleton, true
+}
+
+// skeletonsEqual reports whether two queries redact to byte-identical
+// skeletons. This is the authoritative structural gate for request-literal
+// noise: getQueryStructure (the matchQuery structure gate) records only AST
+// node TYPES, so it treats `update users ... where id=1` and
+// `update admins ... where id=1` (or `where id=1` vs `where other_id=1`) as
+// comparable when they are NOT. The redacted skeleton preserves identifiers,
+// operators and clause shape, so requiring it to be equal means per-literal
+// value comparison only decides tolerance — never structural identity.
+func skeletonsEqual(a, b string) bool {
+	sa, oka := redactedSkeleton(a)
+	if !oka {
+		return false
+	}
+	sb, okb := redactedSkeleton(b)
+	if !okb {
+		return false
+	}
+	return sa == sb
 }
 
 // detectQueryNoise diffs a recorded COM_QUERY against a structurally-identical
@@ -153,6 +203,14 @@ func markLiteralsUnder(expr sqlparser.Expr, key string, eligible map[*sqlparser.
 // make the queries "drift" in a place that is never learnable, and the strict
 // enforce step (queryMatchesWithinNoise) rejects the mock on them.
 func detectQueryNoise(recordedSQL, liveSQL string) (map[string][]string, bool) {
+	// Authoritative structural gate: the two queries must redact to the SAME
+	// skeleton (same tables/columns/operators/clause shape). getQueryStructure
+	// only compares AST node TYPES, so without this an UPDATE on `users` and on
+	// `admins`, or `where id=1` vs `where other_id=1`, would be treated as
+	// comparable. Only literal VALUES may differ past this point.
+	if !skeletonsEqual(recordedSQL, liveSQL) {
+		return nil, false
+	}
 	recTokens, err := extractQueryLiterals(recordedSQL)
 	if err != nil {
 		return nil, false
@@ -196,6 +254,12 @@ func detectQueryNoise(recordedSQL, liveSQL string) (map[string][]string, bool) {
 // true. If either side fails to parse, or the token counts differ, it returns
 // false (not structurally identical -> caller must not treat it as a match).
 func queryMatchesWithinNoise(recordedSQL, liveSQL string, learned map[string][]string) bool {
+	// Authoritative structural gate (see detectQueryNoise): a differing
+	// table/column/operator/clause shape is NOT a literal-noise drift and must
+	// reject outright, never be tolerated as "within noise".
+	if !skeletonsEqual(recordedSQL, liveSQL) {
+		return false
+	}
 	recTokens, err := extractQueryLiterals(recordedSQL)
 	if err != nil {
 		return false

--- a/pkg/agent/proxy/integrations/mysql/replayer/querynoise.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/querynoise.go
@@ -1,0 +1,225 @@
+package replayer
+
+import (
+	"fmt"
+
+	"vitess.io/vitess/go/vt/sqlparser"
+)
+
+// queryLiteralToken is one literal value extracted from a SQL statement in a
+// deterministic traversal order. Eligible reports whether this literal lives
+// in a position where request-literal noise may be LEARNED — true only for
+// UPDATE SET expressions and INSERT VALUES tuples. Every other literal
+// (WHERE / ON / HAVING / subquery / CASE / LIMIT / anywhere else) is collected
+// with Eligible=false so the enforce step can default-deny any drift there.
+type queryLiteralToken struct {
+	// Key encodes the eligible literal position so the learned-noise map can
+	// be keyed by clause role rather than by raw traversal index. For
+	// non-eligible literals the Key carries the traversal index only (it is
+	// never written to the learned-noise map, so its exact value is unused by
+	// enforcement — only Eligible and Val matter there).
+	Key string
+	// Val is the literal's raw value as the parser captured it.
+	Val string
+	// Eligible is true only for UPDATE SET / INSERT VALUES literals.
+	Eligible bool
+}
+
+// newSQLParser builds a vitess parser with default options. Mirrors
+// getQueryStructure so behaviour is consistent across the matcher.
+func newSQLParser() (*sqlparser.Parser, error) {
+	parser, err := sqlparser.New(sqlparser.Options{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create MySQL query parser: %w", err)
+	}
+	return parser, nil
+}
+
+// extractQueryLiterals parses sql and returns its literals in a deterministic
+// traversal order. The SAME extractor is run on both the recorded and the live
+// query, so the only invariant that matters for zipping is that two
+// structurally-identical statements yield the same ordered token list — which
+// a single AST Walk guarantees.
+//
+// Eligibility is computed by first collecting the set of *sqlparser.Literal
+// pointers that sit directly under an UPDATE SET expression or an INSERT VALUES
+// tuple, then marking each Walk-visited literal eligible iff its pointer is in
+// that set. This is clause-aware (default-deny): a literal anywhere else —
+// including an UPDATE's WHERE, a SELECT, a DELETE, a subquery, or a CASE — is
+// collected with Eligible=false.
+func extractQueryLiterals(sql string) ([]queryLiteralToken, error) {
+	parser, err := newSQLParser()
+	if err != nil {
+		return nil, err
+	}
+	stmt, err := parser.Parse(sql)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse SQL: %w", err)
+	}
+
+	// eligible maps an eligible *Literal pointer to its clause-role key.
+	eligible := map[*sqlparser.Literal]string{}
+
+	switch s := stmt.(type) {
+	case *sqlparser.Update:
+		// UPDATE ... SET col = <literal>, ... — every literal that appears in
+		// a SET expression's RHS is learnable. We index by the target column
+		// name plus an occurrence counter so two SETs of the same column (rare
+		// but legal) get distinct keys, and key collisions across rows can't
+		// silently merge.
+		colCounts := map[string]int{}
+		for _, ue := range s.Exprs {
+			col := ""
+			if ue.Name != nil {
+				col = ue.Name.Name.String()
+			}
+			n := colCounts[col]
+			colCounts[col] = n + 1
+			key := fmt.Sprintf("set:%s#%d", col, n)
+			markLiteralsUnder(ue.Expr, key, eligible)
+		}
+	case *sqlparser.Insert:
+		// INSERT ... VALUES (<literal>, ...), (...) — every literal in a
+		// VALUES tuple is learnable, keyed by (rowIdx, colIdx).
+		if rows, ok := s.Rows.(sqlparser.Values); ok {
+			for rowIdx, tuple := range rows {
+				for colIdx, expr := range tuple {
+					key := fmt.Sprintf("values:%d:%d", rowIdx, colIdx)
+					markLiteralsUnder(expr, key, eligible)
+				}
+			}
+		}
+		// INSERT ... SELECT (Rows is *Select/*Union) is intentionally not
+		// treated as eligible: those literals live in a SELECT, never learnable.
+
+		// TODO(querynoise): COM_STMT_EXECUTE (prepared statements) is out of
+		// scope. Prepared-statement parameters arrive as bound values rather
+		// than inline literals and would need a separate per-parameter noise
+		// path; this extractor only handles plaintext COM_QUERY SQL.
+	}
+
+	var tokens []queryLiteralToken
+	idx := 0
+	walkErr := sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
+		lit, ok := node.(*sqlparser.Literal)
+		if !ok {
+			return true, nil
+		}
+		key, isEligible := eligible[lit]
+		if !isEligible {
+			key = fmt.Sprintf("lit#%d", idx)
+		}
+		tokens = append(tokens, queryLiteralToken{
+			Key:      key,
+			Val:      lit.Val,
+			Eligible: isEligible,
+		})
+		idx++
+		return true, nil
+	}, stmt)
+	if walkErr != nil {
+		return nil, fmt.Errorf("failed to walk the AST: %w", walkErr)
+	}
+
+	return tokens, nil
+}
+
+// markLiteralsUnder records every *sqlparser.Literal reachable from expr into
+// the eligible set under key. A SET RHS / VALUES element is usually a bare
+// literal, but it can also be a wrapping expression (e.g. NOW() has no literal,
+// a tuple, an arithmetic expression) — walking the subtree captures whatever
+// literals it actually contains while keeping non-literal positions out.
+func markLiteralsUnder(expr sqlparser.Expr, key string, eligible map[*sqlparser.Literal]string) {
+	if expr == nil {
+		return
+	}
+	_ = sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
+		if lit, ok := node.(*sqlparser.Literal); ok {
+			eligible[lit] = key
+		}
+		return true, nil
+	}, expr)
+}
+
+// detectQueryNoise diffs a recorded COM_QUERY against a structurally-identical
+// live COM_QUERY and learns request-literal noise. It parses both; if either
+// fails to parse, or the two produce a different number of literal tokens
+// (i.e. not actually structurally identical at the literal level), it returns
+// (nil, false). Otherwise it zips the token lists by index and, for every index
+// where the values differ AND the token is in an eligible (SET / VALUES)
+// position, records key -> [recordedVal] as noise.
+//
+// Differing literals in NON-eligible positions are deliberately NOT added: they
+// make the queries "drift" in a place that is never learnable, and the strict
+// enforce step (queryMatchesWithinNoise) rejects the mock on them.
+func detectQueryNoise(recordedSQL, liveSQL string) (map[string][]string, bool) {
+	recTokens, err := extractQueryLiterals(recordedSQL)
+	if err != nil {
+		return nil, false
+	}
+	liveTokens, err := extractQueryLiterals(liveSQL)
+	if err != nil {
+		return nil, false
+	}
+	if len(recTokens) != len(liveTokens) {
+		return nil, false
+	}
+
+	noise := map[string][]string{}
+	for i := range recTokens {
+		rt := recTokens[i]
+		lt := liveTokens[i]
+		if rt.Val == lt.Val {
+			continue
+		}
+		if !rt.Eligible {
+			// A non-eligible literal drifted. Detection never learns it; the
+			// enforce path will reject any mock on this drift. Skip it here.
+			continue
+		}
+		noise[rt.Key] = []string{rt.Val}
+	}
+	return noise, true
+}
+
+// queryMatchesWithinNoise reports whether a structurally-identical live
+// COM_QUERY is consumable by a recorded mock under STRICT enforcement, given
+// the mock's learned noise set. It parses both and zips tokens; for every index
+// whose value differs:
+//   - if the token is NOT in an eligible (SET / VALUES) position -> no match
+//     (WHERE / predicate / subquery drift is never tolerated), and
+//   - if the token's clause-role Key is not present in learned -> no match
+//     (the literal drifted at an eligible position that was never learned as
+//     noise — e.g. a column whose value changed but was never flagged).
+//
+// When every differing literal is both eligible AND learned-noise, it returns
+// true. If either side fails to parse, or the token counts differ, it returns
+// false (not structurally identical -> caller must not treat it as a match).
+func queryMatchesWithinNoise(recordedSQL, liveSQL string, learned map[string][]string) bool {
+	recTokens, err := extractQueryLiterals(recordedSQL)
+	if err != nil {
+		return false
+	}
+	liveTokens, err := extractQueryLiterals(liveSQL)
+	if err != nil {
+		return false
+	}
+	if len(recTokens) != len(liveTokens) {
+		return false
+	}
+
+	for i := range recTokens {
+		rt := recTokens[i]
+		lt := liveTokens[i]
+		if rt.Val == lt.Val {
+			continue
+		}
+		if !rt.Eligible {
+			return false
+		}
+		if _, ok := learned[rt.Key]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/agent/proxy/integrations/mysql/replayer/querynoise_test.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/querynoise_test.go
@@ -173,3 +173,62 @@ func TestQueryMatchesWithinNoise_NonComparable(t *testing.T) {
 		t.Errorf("differing literal counts must not match")
 	}
 }
+
+// (Finding 1) A difference in a non-literal part of the query — table, column,
+// or operator — is NOT a literal-noise drift. The redacted skeletons differ, so
+// detection refuses to learn (ok=false) and strict never tolerates it, even if
+// every eligible position were already learned. getQueryStructure alone (AST
+// node types) would wrongly treat these as comparable.
+func TestQueryNoise_NonLiteralDriftRejected(t *testing.T) {
+	cases := []struct{ name, recorded, live string }{
+		{"table", "update users set name='x' where id=1", "update admins set name='x' where id=1"},
+		{"column", "update t set a=1 where id=1", "update t set a=1 where other_id=1"},
+		{"operator", "update t set a=1 where id=1", "update t set a=1 where id>1"},
+	}
+	// Deliberately generous: pretend every eligible position is learned noise.
+	learned := map[string][]string{"set:a#0": {"1"}, "set:name#0": {"x"}}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, ok := detectQueryNoise(c.recorded, c.live); ok {
+				t.Errorf("%s drift must be non-comparable (detectQueryNoise ok=false)", c.name)
+			}
+			if queryMatchesWithinNoise(c.recorded, c.live, learned) {
+				t.Errorf("%s drift must reject under strict (queryMatchesWithinNoise=false)", c.name)
+			}
+		})
+	}
+}
+
+// (Finding 2) A literal inside a subquery/predicate under a SET expression is
+// NOT learnable. The skeleton still matches (only the nested literal differs),
+// but because the literal is non-eligible, detection learns nothing and strict
+// rejects the drift.
+func TestQueryNoise_SubqueryUnderSetNotLearnable(t *testing.T) {
+	recorded := "update t set score=(select max(score) from scores where tenant_id=1) where id=7"
+	live := "update t set score=(select max(score) from scores where tenant_id=2) where id=7"
+
+	// The subquery's tenant_id literal must be collected as NON-eligible.
+	toks, err := extractQueryLiterals(recorded)
+	if err != nil {
+		t.Fatalf("extractQueryLiterals: %v", err)
+	}
+	for _, tk := range toks {
+		if tk.Val == "1" && tk.Eligible {
+			t.Errorf("subquery literal tenant_id=1 must NOT be Eligible; got %+v", tk)
+		}
+	}
+
+	// Skeletons are equal (only the nested literal differs), so detection runs
+	// but learns nothing (the drift is non-eligible).
+	noise, ok := detectQueryNoise(recorded, live)
+	if !ok {
+		t.Fatalf("skeletons should be equal -> detectQueryNoise ok=true")
+	}
+	if len(noise) != 0 {
+		t.Errorf("subquery-predicate drift must not be learned; got %v", noise)
+	}
+	// And strict rejects it even with a generous learned set.
+	if queryMatchesWithinNoise(recorded, live, map[string][]string{"set:score#0": {"whatever"}}) {
+		t.Errorf("subquery-predicate drift must reject under strict")
+	}
+}

--- a/pkg/agent/proxy/integrations/mysql/replayer/querynoise_test.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/querynoise_test.go
@@ -1,0 +1,175 @@
+package replayer
+
+import (
+	"reflect"
+	"testing"
+)
+
+// tokenByKey finds the first token with the given key. Helper for assertions.
+func tokenByKey(toks []queryLiteralToken, key string) (queryLiteralToken, bool) {
+	for _, tk := range toks {
+		if tk.Key == key {
+			return tk, true
+		}
+	}
+	return queryLiteralToken{}, false
+}
+
+// (a) extractor: UPDATE SET literals are eligible, WHERE literal is not.
+func TestExtractQueryLiterals_UpdateSetEligibleWhereNot(t *testing.T) {
+	toks, err := extractQueryLiterals("update t set updated_at='x', n=5 where id=42")
+	if err != nil {
+		t.Fatalf("extractQueryLiterals: %v", err)
+	}
+
+	updatedAt, ok := tokenByKey(toks, "set:updated_at#0")
+	if !ok {
+		t.Fatalf("missing set:updated_at#0 token; got %+v", toks)
+	}
+	if !updatedAt.Eligible {
+		t.Errorf("set:updated_at literal should be Eligible")
+	}
+	if updatedAt.Val != "x" {
+		t.Errorf("set:updated_at val: want %q, got %q", "x", updatedAt.Val)
+	}
+
+	nTok, ok := tokenByKey(toks, "set:n#0")
+	if !ok || !nTok.Eligible {
+		t.Errorf("set:n literal should exist and be Eligible; got %+v", toks)
+	}
+
+	// The WHERE literal (42) must be present but NOT eligible (default-deny).
+	var sawWhere bool
+	for _, tk := range toks {
+		if tk.Val == "42" {
+			sawWhere = true
+			if tk.Eligible {
+				t.Errorf("WHERE literal 42 must NOT be Eligible (never learnable)")
+			}
+		}
+	}
+	if !sawWhere {
+		t.Errorf("WHERE literal 42 not collected at all; got %+v", toks)
+	}
+}
+
+// (b) detectQueryNoise: UPDATE with a drifting updated_at SET literal learns
+// exactly that key and nothing else.
+func TestDetectQueryNoise_UpdateLearnsOnlyDriftingSetLiteral(t *testing.T) {
+	recorded := "update orders set views=5, updated_at='2026-01-01 12:48:36' where region='north'"
+	live := "update orders set views=5, updated_at='2026-06-17 14:00:24' where region='north'"
+
+	noise, ok := detectQueryNoise(recorded, live)
+	if !ok {
+		t.Fatalf("detectQueryNoise returned ok=false for structurally-identical queries")
+	}
+	want := map[string][]string{
+		"set:updated_at#0": {"2026-01-01 12:48:36"},
+	}
+	if !reflect.DeepEqual(noise, want) {
+		t.Fatalf("learned noise mismatch:\n want %v\n got  %v", want, noise)
+	}
+}
+
+// detectQueryNoise must NOT learn a non-eligible (WHERE) drift, and returns the
+// empty (but ok==true) map when only WHERE drifts.
+func TestDetectQueryNoise_DoesNotLearnWhereDrift(t *testing.T) {
+	recorded := "update orders set views=5, updated_at='2026-01-01 12:48:36' where region='north'"
+	live := "update orders set views=5, updated_at='2026-01-01 12:48:36' where region='south'"
+
+	noise, ok := detectQueryNoise(recorded, live)
+	if !ok {
+		t.Fatalf("detectQueryNoise returned ok=false")
+	}
+	if len(noise) != 0 {
+		t.Fatalf("WHERE drift must not be learned; got %v", noise)
+	}
+}
+
+// (c) INSERT VALUES: learns the drifting generated-id position.
+func TestDetectQueryNoise_InsertLearnsValuesPosition(t *testing.T) {
+	recorded := "insert into events (user_id, code) values (101,'code-1001')"
+	live := "insert into events (user_id, code) values (101,'code-2002')"
+
+	noise, ok := detectQueryNoise(recorded, live)
+	if !ok {
+		t.Fatalf("detectQueryNoise returned ok=false")
+	}
+	want := map[string][]string{
+		"values:0:1": {"code-1001"},
+	}
+	if !reflect.DeepEqual(noise, want) {
+		t.Fatalf("learned noise mismatch:\n want %v\n got  %v", want, noise)
+	}
+}
+
+// detectQueryNoise returns (nil,false) when the queries are not structurally
+// comparable (different literal counts) or one fails to parse.
+func TestDetectQueryNoise_NonComparable(t *testing.T) {
+	// Different literal counts (one extra SET column) -> not comparable.
+	if _, ok := detectQueryNoise(
+		"update t set a=1 where id=2",
+		"update t set a=1, b=3 where id=2",
+	); ok {
+		t.Errorf("expected ok=false for differing literal counts")
+	}
+	// Unparseable live query -> ok=false.
+	if _, ok := detectQueryNoise("update t set a=1 where id=2", "this is not sql"); ok {
+		t.Errorf("expected ok=false for unparseable query")
+	}
+}
+
+// (d) ENFORCE: with the learned set from (b), queryMatchesWithinNoise tolerates
+// the updated_at drift.
+func TestQueryMatchesWithinNoise_ToleratesLearnedSetDrift(t *testing.T) {
+	recorded := "update orders set views=5, updated_at='2026-01-01 12:48:36' where region='north'"
+	live := "update orders set views=5, updated_at='2026-06-17 14:00:24' where region='north'"
+	learned := map[string][]string{
+		"set:updated_at#0": {"2026-01-01 12:48:36"},
+	}
+	if !queryMatchesWithinNoise(recorded, live, learned) {
+		t.Fatalf("expected match: only the learned-noise updated_at literal drifted")
+	}
+}
+
+// (e) REGRESSION GUARD: a changed WHERE predicate is never tolerated, and an
+// eligible literal that was not learned (views) also rejects.
+func TestQueryMatchesWithinNoise_RejectsWhereAndUnlearnedDrift(t *testing.T) {
+	recorded := "update orders set views=5, updated_at='2026-01-01 12:48:36' where region='north'"
+	learned := map[string][]string{
+		"set:updated_at#0": {"2026-01-01 12:48:36"},
+	}
+
+	// Changed WHERE predicate (region) — WHERE is never learnable.
+	whereDrift := "update orders set views=5, updated_at='2026-01-01 12:48:36' where region='south'"
+	if queryMatchesWithinNoise(recorded, whereDrift, learned) {
+		t.Errorf("WHERE drift must reject (WHERE never learnable)")
+	}
+
+	// Changed eligible SET literal (views) that is NOT a learned-noise key.
+	viewsDrift := "update orders set views=9, updated_at='2026-01-01 12:48:36' where region='north'"
+	if queryMatchesWithinNoise(recorded, viewsDrift, learned) {
+		t.Errorf("unlearned eligible SET drift (views) must reject")
+	}
+}
+
+// queryMatchesWithinNoise returns true when the queries are byte-identical
+// (no drift at all), regardless of the learned set.
+func TestQueryMatchesWithinNoise_IdenticalQueriesMatch(t *testing.T) {
+	q := "update t set a=1, b='x' where id=2"
+	if !queryMatchesWithinNoise(q, q, nil) {
+		t.Errorf("identical queries must match even with no learned noise")
+	}
+}
+
+// queryMatchesWithinNoise returns false when the queries are not structurally
+// comparable (different literal counts).
+func TestQueryMatchesWithinNoise_NonComparable(t *testing.T) {
+	if queryMatchesWithinNoise(
+		"update t set a=1 where id=2",
+		"update t set a=1, b=3 where id=2",
+		map[string][]string{"set:b#0": {"3"}},
+	) {
+		t.Errorf("differing literal counts must not match")
+	}
+}

--- a/pkg/agent/proxy/mockmanager.go
+++ b/pkg/agent/proxy/mockmanager.go
@@ -1757,6 +1757,7 @@ func (m *MockManager) UpdateUnFilteredMock(old *models.Mock, new *models.Mock) b
 			ReqTimestampMock: models.FormatMockTimestamp(new.Spec.ReqTimestampMock),
 			ResTimestampMock: models.FormatMockTimestamp(new.Spec.ResTimestampMock),
 			ReqBodyNoise:     reqBodyNoiseOf(new.Spec),
+			QueryNoise:       queryNoiseOf(new.Spec),
 		}); err != nil {
 			m.logger.Error("failed to flag mock as used", zap.Error(err))
 		}
@@ -1806,6 +1807,7 @@ func (m *MockManager) DeleteFilteredMock(mock models.Mock) bool {
 			ReqTimestampMock: models.FormatMockTimestamp(mock.Spec.ReqTimestampMock),
 			ResTimestampMock: models.FormatMockTimestamp(mock.Spec.ResTimestampMock),
 			ReqBodyNoise:     reqBodyNoiseOf(mock.Spec),
+			QueryNoise:       queryNoiseOf(mock.Spec),
 		}); err != nil {
 			m.logger.Error("failed to flag mock as used", zap.Error(err))
 		}
@@ -1846,6 +1848,7 @@ func (m *MockManager) DeleteUnFilteredMock(mock models.Mock) bool {
 			ReqTimestampMock: models.FormatMockTimestamp(mock.Spec.ReqTimestampMock),
 			ResTimestampMock: models.FormatMockTimestamp(mock.Spec.ResTimestampMock),
 			ReqBodyNoise:     reqBodyNoiseOf(mock.Spec),
+			QueryNoise:       queryNoiseOf(mock.Spec),
 		}); err != nil {
 			m.logger.Error("failed to flag mock as used", zap.Error(err))
 		}
@@ -2080,6 +2083,17 @@ func reqBodyNoiseOf(spec models.MockSpec) map[string][]string {
 		return nil
 	}
 	return spec.HTTPReq.ReqBodyNoise
+}
+
+// queryNoiseOf returns the per-position COM_QUERY literal noise detected on a
+// MySQL mock's first request (nil when none). Used to carry schema-detected
+// literal noise out on MockState so UpdateMocks / PersistMockNoise can persist
+// it onto the mock's MySQLRequests[0].QueryNoise.
+func queryNoiseOf(spec models.MockSpec) map[string][]string {
+	if len(spec.MySQLRequests) == 0 {
+		return nil
+	}
+	return spec.MySQLRequests[0].QueryNoise
 }
 
 func (m *MockManager) flagMockAsUsed(mock models.MockState) error {

--- a/pkg/models/mock.go
+++ b/pkg/models/mock.go
@@ -718,6 +718,13 @@ type MockState struct {
 	// it onto the mock's HTTPReq.ReqBodyNoise. fieldpath ("body.user.id")
 	// -> regex list; empty list means "ignore the whole field".
 	ReqBodyNoise map[string][]string `json:"reqBodyNoise,omitempty"`
+	// QueryNoise carries per-position literal noise detected during
+	// schema-based auto-replay matching of a COM_QUERY (plaintext SQL) MySQL
+	// mock back from the agent to the replay service so UpdateMocks can
+	// persist it onto the matched mock's MySQLRequests[0].QueryNoise. Key is
+	// the eligible literal position ("set:<col>#<n>" / "values:<row>:<col>");
+	// value is the recorded literal(s) treated as noise.
+	QueryNoise map[string][]string `json:"queryNoise,omitempty"`
 }
 
 func (m *Mock) DeepCopy() *Mock {
@@ -787,6 +794,23 @@ func (m *Mock) DeepCopy() *Mock {
 
 	c.Spec.MySQLRequests = make([]mysql.Request, len(m.Spec.MySQLRequests))
 	copy(c.Spec.MySQLRequests, m.Spec.MySQLRequests)
+	// Deep-copy the per-request QueryNoise map (schema-detected COM_QUERY
+	// literal noise). The shallow copy() above aliases the map header, so a
+	// clone's learned noise would otherwise mutate the shared pooled mock's
+	// map (and vice versa) — same hazard handled for HTTPReq.ReqBodyNoise below.
+	for i := range c.Spec.MySQLRequests {
+		src := m.Spec.MySQLRequests[i].QueryNoise
+		if src == nil {
+			continue
+		}
+		dst := make(map[string][]string, len(src))
+		for k, v := range src {
+			vc := make([]string, len(v))
+			copy(vc, v)
+			dst[k] = vc
+		}
+		c.Spec.MySQLRequests[i].QueryNoise = dst
+	}
 
 	c.Spec.MySQLResponses = make([]mysql.Response, len(m.Spec.MySQLResponses))
 	copy(c.Spec.MySQLResponses, m.Spec.MySQLResponses)

--- a/pkg/models/mock_test.go
+++ b/pkg/models/mock_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"go.keploy.io/server/v3/pkg/models/mysql"
 	yamlLib "gopkg.in/yaml.v3"
 )
 
@@ -41,6 +42,45 @@ func TestDeepCopyPreservesReqBodyNoise(t *testing.T) {
 	}
 	if len(orig.Spec.HTTPReq.ReqBodyNoise["body.ts"]) != 1 {
 		t.Fatal("DeepCopy shared a noise slice with the original")
+	}
+}
+
+// TestDeepCopyPreservesQueryNoise verifies Mock.DeepCopy deep-copies the
+// per-request MySQL QueryNoise map: the clone must carry the same keys/regexes
+// as the original, and mutating either side's map (keys or per-key slices) must
+// not leak across to the other. Without an independent backing map the gob
+// async-writer / pool clones would silently share — and drop — the
+// schema-detected literal noise. Mirrors TestDeepCopyPreservesReqBodyNoise.
+func TestDeepCopyPreservesQueryNoise(t *testing.T) {
+	orig := &Mock{
+		Kind: Kind(MySQL),
+		Spec: MockSpec{
+			MySQLRequests: []mysql.Request{{
+				QueryNoise: map[string][]string{
+					"set:updated_at#0": {"2026-06-16 12:48:36"},
+					"values:0:1":       {},
+				},
+			}},
+		},
+	}
+
+	c := orig.DeepCopy()
+	if len(c.Spec.MySQLRequests) != 1 {
+		t.Fatalf("DeepCopy dropped MySQLRequests: %v", c.Spec.MySQLRequests)
+	}
+	if len(c.Spec.MySQLRequests[0].QueryNoise) != 2 {
+		t.Fatalf("DeepCopy dropped QueryNoise: %v", c.Spec.MySQLRequests[0].QueryNoise)
+	}
+
+	// Mutating the copy must not affect the original (independent backing maps).
+	c.Spec.MySQLRequests[0].QueryNoise["values:0:2"] = []string{}
+	c.Spec.MySQLRequests[0].QueryNoise["set:updated_at#0"] = append(
+		c.Spec.MySQLRequests[0].QueryNoise["set:updated_at#0"], "x")
+	if _, ok := orig.Spec.MySQLRequests[0].QueryNoise["values:0:2"]; ok {
+		t.Fatal("DeepCopy shared the QueryNoise map with the original")
+	}
+	if len(orig.Spec.MySQLRequests[0].QueryNoise["set:updated_at#0"]) != 1 {
+		t.Fatal("DeepCopy shared a QueryNoise slice with the original")
 	}
 }
 

--- a/pkg/models/mysql/mysql.go
+++ b/pkg/models/mysql/mysql.go
@@ -20,6 +20,9 @@ type RequestYaml struct {
 	Header  *PacketInfo       `json:"header,omitempty" yaml:"header"`
 	Meta    map[string]string `json:"meta,omitempty" yaml:"meta,omitempty"`
 	Message yaml.Node         `json:"message,omitempty" yaml:"message"`
+	// QueryNoise mirrors mysql.Request.QueryNoise so schema-detected
+	// COM_QUERY literal noise survives the on-disk YAML round-trip.
+	QueryNoise map[string][]string `json:"queryNoise,omitempty" yaml:"queryNoise,omitempty" bson:"queryNoise,omitempty"`
 }
 
 type ResponseYaml struct {
@@ -35,6 +38,14 @@ type PacketInfo struct {
 
 type Request struct {
 	PacketBundle `json:"packet_bundle" yaml:"packet_bundle"`
+	// QueryNoise carries per-position literal noise learned during
+	// schema-based auto-replay matching (config.Test.SchemaNoiseDetection)
+	// for COM_QUERY (plaintext SQL) requests. The key encodes the eligible
+	// literal position ("set:<col>#<n>" for UPDATE SET, "values:<row>:<col>"
+	// for INSERT VALUES); the value is the recorded literal(s) treated as
+	// noise. Only SET/VALUES literals are ever learnable (default-deny);
+	// WHERE/ON/HAVING/subquery/CASE literals are never recorded here.
+	QueryNoise map[string][]string `json:"queryNoise,omitempty" yaml:"queryNoise,omitempty" bson:"queryNoise,omitempty"`
 }
 
 type Response struct {

--- a/pkg/platform/yaml/mockdb/db.go
+++ b/pkg/platform/yaml/mockdb/db.go
@@ -334,6 +334,21 @@ func mergeReqBodyNoise(existing, detected map[string][]string) map[string][]stri
 	return out
 }
 
+// mergeQueryNoiseOntoMySQLMock merges schema-detected COM_QUERY literal noise
+// (st.QueryNoise) onto a MySQL mock's first request before the mock is
+// re-serialised to disk. No-op for non-MySQL mocks, empty noise, or mocks with
+// no MySQL request. Returns true when the mock's QueryNoise changed (so callers
+// can skip rewriting unchanged files). Mirrors the HTTP ReqBodyNoise merge.
+func mergeQueryNoiseOntoMySQLMock(mock *models.Mock, noise map[string][]string) bool {
+	if len(noise) == 0 || mock.Kind != models.Kind(models.MySQL) || len(mock.Spec.MySQLRequests) == 0 {
+		return false
+	}
+	before := len(mock.Spec.MySQLRequests[0].QueryNoise)
+	merged := mergeReqBodyNoise(mock.Spec.MySQLRequests[0].QueryNoise, noise)
+	mock.Spec.MySQLRequests[0].QueryNoise = merged
+	return len(merged) != before
+}
+
 // UpdateMocks prunes unused mocks from the mock file and keeps required ones.
 //
 // mockNames is a keep-set keyed by mock name (values carry models.MockState details).
@@ -455,6 +470,9 @@ func (ys *MockYaml) UpdateMocks(ctx context.Context, testSetID string, mockNames
 			if len(st.ReqBodyNoise) > 0 && mock.Kind == models.Kind(models.HTTP) && mock.Spec.HTTPReq != nil {
 				mock.Spec.HTTPReq.ReqBodyNoise = mergeReqBodyNoise(mock.Spec.HTTPReq.ReqBodyNoise, st.ReqBodyNoise)
 			}
+			// MySQL request-literal noise (COM_QUERY) detected during
+			// schema-based auto-replay matching.
+			mergeQueryNoiseOntoMySQLMock(mock, st.QueryNoise)
 			newMocks = append(newMocks, mock)
 			continue
 		}
@@ -574,6 +592,9 @@ func (ys *MockYaml) updateMocksGob(ctx context.Context, testSetID, gobPath strin
 			if len(st.ReqBodyNoise) > 0 && mock.Kind == models.Kind(models.HTTP) && mock.Spec.HTTPReq != nil {
 				mock.Spec.HTTPReq.ReqBodyNoise = mergeReqBodyNoise(mock.Spec.HTTPReq.ReqBodyNoise, st.ReqBodyNoise)
 			}
+			// MySQL request-literal noise (COM_QUERY) detected during
+			// schema-based auto-replay matching.
+			mergeQueryNoiseOntoMySQLMock(mock, st.QueryNoise)
 			newMocks = append(newMocks, mock)
 			continue
 		}
@@ -691,21 +712,26 @@ func writeGobMocksAtomically(ctx context.Context, gobPath string, mocks []*model
 	return nil
 }
 
-// PersistMockNoise merges learned request-body noise (MockState.ReqBodyNoise,
-// detected under --schema-noise-detection) into the on-disk mocks WITHOUT
-// pruning anything. This is the persistence path when mock pruning
-// (--remove-unused-mocks) is not enabled — previously the learned noise rode
-// only inside UpdateMocks, so running detection without pruning silently
-// discarded everything that was learned at process exit.
+// PersistMockNoise merges learned noise (MockState.ReqBodyNoise for HTTP and
+// MockState.QueryNoise for MySQL COM_QUERY, detected under
+// --schema-noise-detection) into the on-disk mocks WITHOUT pruning anything.
+// This is the persistence path when mock pruning (--remove-unused-mocks) is not
+// enabled — previously the learned noise rode only inside UpdateMocks, so
+// running detection without pruning silently discarded everything that was
+// learned at process exit.
 func (ys *MockYaml) PersistMockNoise(ctx context.Context, testSetID string, mockStates map[string]models.MockState) error {
 	// Only mocks that actually carry learned noise matter.
-	withNoise := make(map[string]map[string][]string)
+	withNoise := make(map[string]map[string][]string)      // HTTP req-body noise
+	withQueryNoise := make(map[string]map[string][]string) // MySQL COM_QUERY literal noise
 	for name, st := range mockStates {
 		if len(st.ReqBodyNoise) > 0 {
 			withNoise[name] = st.ReqBodyNoise
 		}
+		if len(st.QueryNoise) > 0 {
+			withQueryNoise[name] = st.QueryNoise
+		}
 	}
-	if len(withNoise) == 0 {
+	if len(withNoise) == 0 && len(withQueryNoise) == 0 {
 		return nil
 	}
 
@@ -723,15 +749,18 @@ func (ys *MockYaml) PersistMockNoise(ctx context.Context, testSetID string, mock
 	merge := func(mocks []*models.Mock) bool {
 		changed := false
 		for _, mock := range mocks {
-			noise, ok := withNoise[mock.Name]
-			if !ok || mock.Kind != models.Kind(models.HTTP) || mock.Spec.HTTPReq == nil {
-				continue
+			if noise, ok := withNoise[mock.Name]; ok && mock.Kind == models.Kind(models.HTTP) && mock.Spec.HTTPReq != nil {
+				merged := mergeReqBodyNoise(mock.Spec.HTTPReq.ReqBodyNoise, noise)
+				if len(merged) != len(mock.Spec.HTTPReq.ReqBodyNoise) {
+					changed = true
+				}
+				mock.Spec.HTTPReq.ReqBodyNoise = merged
 			}
-			merged := mergeReqBodyNoise(mock.Spec.HTTPReq.ReqBodyNoise, noise)
-			if len(merged) != len(mock.Spec.HTTPReq.ReqBodyNoise) {
-				changed = true
+			if qnoise, ok := withQueryNoise[mock.Name]; ok {
+				if mergeQueryNoiseOntoMySQLMock(mock, qnoise) {
+					changed = true
+				}
 			}
-			mock.Spec.HTTPReq.ReqBodyNoise = merged
 		}
 		return changed
 	}

--- a/pkg/platform/yaml/mockdb/util.go
+++ b/pkg/platform/yaml/mockdb/util.go
@@ -396,8 +396,9 @@ func EncodeMock(mock *models.Mock, logger *zap.Logger) (*yaml.NetworkTrafficDoc,
 		for _, v := range mock.Spec.MySQLRequests {
 
 			req := mysql.RequestYaml{
-				Header: v.Header,
-				Meta:   v.Meta,
+				Header:     v.Header,
+				Meta:       v.Meta,
+				QueryNoise: v.QueryNoise,
 			}
 			err := req.Message.Encode(v.Message)
 			if err != nil {
@@ -811,6 +812,7 @@ func decodeMySQLMessage(_ context.Context, logger *zap.Logger, yamlSpec *mysql.S
 				Header: v.Header,
 				Meta:   v.Meta,
 			},
+			QueryNoise: v.QueryNoise,
 		}
 
 		switch v.Header.Type {


### PR DESCRIPTION
## Describe the changes that are made
Brings the MySQL `COM_QUERY` matcher up to the same **learn-then-enforce** request-noise model that HTTP already has:

- **Detection (lenient):** when a live `COM_QUERY` is *structurally identical* to a recorded mock but differs in literal **values**, the differing literals in `SET` (UPDATE) / `VALUES` (INSERT) positions are learned as per-mock `QueryNoise` and persisted onto the mock — mirroring the HTTP `ReqBodyNoise` loop (detect → carry on `MockState` → write back via `UpdateMocks`/`PersistMockNoise`).
- **Strict:** a structurally-identical mock is consumed **iff** every differing literal is a learned-noise key. Eligibility is **clause-aware and default-deny** — only `SET`/`VALUES` literals are learnable; `WHERE`/`ON`/`HAVING`/subquery literals are never learnable, so a changed predicate (e.g. `WHERE id=42 → id=99`) still fails.
- **Detection-off / strict-off behaviour is unchanged** (the structure-equal branch still returns the same partial score).

This removes false *"missing mock"* / strict-schema-noise failures during strict replay caused by non-deterministic request-side values written into DML (wall-clock `updated_at`, app-generated ids), while keeping response assertions and real query-shape regressions intact.

Prepared statements (`COM_STMT_EXECUTE`) are **out of scope** here (drift lives in bound parameters, not inline literals) and marked with a `TODO(querynoise)`.

### Key files
- `pkg/agent/proxy/integrations/mysql/replayer/querynoise.go` *(new)* — clause-aware literal extractor + `detectQueryNoise` / `queryMatchesWithinNoise`.
- `.../mysql/replayer/match.go` — wires the structure-equal branch (learn on detection; tolerate/reject on strict) and threads the flags through `matchCommand`.
- `pkg/models/mysql/mysql.go`, `pkg/models/mock.go` — `QueryNoise` field + deep-copy + `MockState` transport.
- `pkg/platform/yaml/mockdb/{db,util}.go`, `pkg/agent/proxy/mockmanager.go` — carry-out + persistence (MySQL branches).

## Links & References

**Closes:** NA

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [x] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed — covered by unit tests + an end-to-end `matchCommand` test; a full record/replay sample is a sensible follow-up.

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed — gated on the existing opt-in `schemaNoiseDetection` / `schemaNoiseStrict` config flags.

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

```
go test ./pkg/agent/proxy/integrations/mysql/replayer/... ./pkg/models/...
```
New tests cover: clause-aware extraction (SET eligible, WHERE not); detection learning only the drifting `SET`/`VALUES` literal; strict tolerating a learned drift; and the regression guard — a changed `WHERE` predicate and an unlearned eligible literal both still reject.

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA

### Reviewer note
Under strict, a structurally-equal candidate whose drift is **not** learned noise now returns score `0` (rejected outright) instead of being served via the score-based partial fallback — intentional, so a partial-serve cannot mask a non-noise drift under strict enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
