### PR TITLE
fix(record,replay): bound teardown drains so a hung goroutine can't swallow SIGINT

### DIFF
--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -178,36 +178,39 @@ func (r *Recorder) Start(ctx context.Context) error {
 		r.logger.Info("Stopping Keploy recording...")
 
 		// Notify the agent that we are shutting down gracefully
-		// This will cause connection errors to be logged as debug instead of error
-		if err := r.instrumentation.NotifyGracefulShutdown(context.Background()); err != nil {
+		// This will cause connection errors to be logged as debug instead of error.
+		// Bound it: an up-but-unresponsive agent (still booting under contention)
+		// must not block teardown — the path SIGINT takes — indefinitely.
+		notifyCtx, notifyCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		if err := r.instrumentation.NotifyGracefulShutdown(notifyCtx); err != nil {
 			r.logger.Debug("failed to notify agent of graceful shutdown", zap.Error(err))
 		}
+		notifyCancel()
 		// Pcap + keylog flow over long-lived HTTP streams started in
 		// Start() right after the agent's broadcaster came up. The
 		// streams unwind on their own when the agent closes the
 		// response or the recorder context is cancelled — there is
 		// no on-disk file on the agent and no fetch step here.
 
+		// Bounded drains: a goroutine wedged under contention that ignores its
+		// cancel() must not hang teardown forever (which would swallow SIGINT and
+		// keep the process alive until an external SIGKILL). See utils.DrainErrGroup.
 		runAppCtxCancel()
-		err := runAppErrGrp.Wait()
-		if err != nil {
+		if err := utils.DrainErrGroup(r.logger, "record-app", runAppErrGrp, 30*time.Second); err != nil {
 			utils.LogError(r.logger, err, "failed to stop application")
 		}
 
 		reqCtxCancel()
-		err = reqErrGrp.Wait()
-		if err != nil {
+		if err := utils.DrainErrGroup(r.logger, "record-req", reqErrGrp, 30*time.Second); err != nil {
 			utils.LogError(r.logger, err, "failed to stop request processing")
 		}
 
 		setupCtxCancel()
-		err = setupErrGrp.Wait()
-		if err != nil {
+		if err := utils.DrainErrGroup(r.logger, "record-setup", setupErrGrp, 30*time.Second); err != nil {
 			utils.LogError(r.logger, err, "failed to stop setup execution, that covers init container")
 		}
 
-		err = errGrp.Wait()
-		if err != nil {
+		if err := utils.DrainErrGroup(r.logger, "record", errGrp, 30*time.Second); err != nil {
 			utils.LogError(r.logger, err, "failed to stop recording")
 		}
 		if recordingStarted {

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -300,23 +300,30 @@ func (r *Replayer) Start(ctx context.Context) error {
 		}
 
 		// Notify the agent that we are shutting down gracefully. It covers early exits before RunTestSet runs
-		// and shutdown paths where the per‑test‑set defer doesn’t execute (or never starts)
-		if err := r.instrumentation.NotifyGracefulShutdown(context.Background()); err != nil {
+		// and shutdown paths where the per‑test‑set defer doesn’t execute (or never starts).
+		// Bound it: context.Background() with no deadline meant an up-but-unresponsive
+		// agent (common while it is still booting under CPU contention) could block this
+		// POST — and therefore the whole teardown, which is the path SIGINT takes — forever.
+		notifyCtx, notifyCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		if err := r.instrumentation.NotifyGracefulShutdown(notifyCtx); err != nil {
 			r.logger.Debug("failed to notify agent of graceful shutdown", zap.Error(err))
 		}
+		notifyCancel()
 
 		if hookCancel != nil {
 			hookCancel()
 		}
 		cancel()
-		err := g.Wait()
-		if err != nil {
+		// Bounded drain: a setup/run goroutine that wedges under contention and does
+		// not observe cancel() must not be able to block this teardown forever, or
+		// SIGINT (which runs through this same defer) is swallowed and the process
+		// hangs until an external SIGKILL. See utils.DrainErrGroup.
+		if err := utils.DrainErrGroup(r.logger, "replay", g, 30*time.Second); err != nil {
 			utils.LogError(r.logger, err, "failed to stop replaying")
 		}
 
 		setupCtxCancel()
-		err = setupErrGrp.Wait()
-		if err != nil {
+		if err := utils.DrainErrGroup(r.logger, "replay-setup", setupErrGrp, 30*time.Second); err != nil {
 			utils.LogError(r.logger, err, "failed to stop replaying")
 		}
 	}()
@@ -925,13 +932,15 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 	defer func() {
 		// Notify the agent before cancelling the app context so proxy logs shutdown errors as debug.
 		if r.instrument && !serveTest {
-			if err := r.instrumentation.NotifyGracefulShutdown(context.Background()); err != nil {
+			notifyCtx, notifyCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			if err := r.instrumentation.NotifyGracefulShutdown(notifyCtx); err != nil {
 				r.logger.Debug("failed to notify agent of graceful shutdown", zap.Error(err))
 			}
+			notifyCancel()
 		}
 		runTestSetCtxCancel()
-		err := runTestSetErrGrp.Wait()
-		if err != nil {
+		// Bounded drain so a wedged per-test-set goroutine can't hang teardown/SIGINT.
+		if err := utils.DrainErrGroup(r.logger, "replay-testset", runTestSetErrGrp, 30*time.Second); err != nil {
 			utils.LogError(r.logger, err, "error in testLoopErrGrp")
 		}
 		close(exitLoopChan)

--- a/utils/drain.go
+++ b/utils/drain.go
@@ -1,0 +1,39 @@
+package utils
+
+import (
+	"time"
+
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+)
+
+// DrainErrGroup waits for g.Wait() to return, but gives up after `timeout`.
+//
+// Why this exists: keploy's record/replay teardown runs in a deferred function
+// that is also the path SIGINT/SIGTERM takes (the signal cancels the root
+// context, which triggers the defer). The teardown calls g.Wait() to drain the
+// run/setup goroutines after cancel(). If any one of those goroutines does not
+// observe context cancellation — e.g. an agent-in-docker bring-up or proxy
+// setup that wedges while the host is under heavy CPU/IO contention — an
+// unbounded g.Wait() blocks the teardown forever. Because that same teardown is
+// what SIGINT triggers, the process then ignores SIGINT entirely and only dies
+// when an outer `timeout`/CI sends SIGKILL minutes later (observed: a CI lane
+// hung ~50 min despite a 15-min `timeout -s INT`).
+//
+// Bounding the drain guarantees the process exits promptly after cancellation.
+// On timeout it logs (so the offending goroutine is discoverable) and returns
+// nil; the leaked goroutine is reaped when the process exits. In the normal
+// case the goroutines drain in well under the timeout, so this is a no-op.
+func DrainErrGroup(logger *zap.Logger, name string, g *errgroup.Group, timeout time.Duration) error {
+	done := make(chan error, 1)
+	go func() { done <- g.Wait() }()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(timeout):
+		logger.Error("teardown drain timed out after cancellation; forcing shutdown so stop/SIGINT isn't swallowed — a goroutine is ignoring context cancellation",
+			zap.String("group", name),
+			zap.Duration("timeout", timeout))
+		return nil
+	}
+}

--- a/utils/drain_test.go
+++ b/utils/drain_test.go
@@ -1,0 +1,53 @@
+package utils
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+)
+
+// TestDrainErrGroupReturnsError verifies the normal path: when the group's
+// goroutines finish before the timeout, DrainErrGroup returns g.Wait()'s error
+// verbatim (and does not wait out the timeout).
+func TestDrainErrGroupReturnsError(t *testing.T) {
+	var g errgroup.Group
+	want := errors.New("boom")
+	g.Go(func() error { return want })
+
+	start := time.Now()
+	got := DrainErrGroup(zap.NewNop(), "test", &g, time.Second)
+	if !errors.Is(got, want) {
+		t.Fatalf("DrainErrGroup err = %v, want %v", got, want)
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("DrainErrGroup blocked for %s on a fast group; should return immediately", elapsed)
+	}
+}
+
+// TestDrainErrGroupTimesOutOnHang is the regression guard for the shutdown
+// deadlock: a goroutine that ignores cancellation (here, blocks forever) must
+// NOT be able to make DrainErrGroup block past its timeout. Without the bound,
+// the teardown that calls this would hang until an external SIGKILL.
+func TestDrainErrGroupTimesOutOnHang(t *testing.T) {
+	var g errgroup.Group
+	block := make(chan struct{})
+	g.Go(func() error {
+		<-block // simulates a goroutine that never observes context cancellation
+		return nil
+	})
+
+	start := time.Now()
+	got := DrainErrGroup(zap.NewNop(), "test", &g, 50*time.Millisecond)
+	elapsed := time.Since(start)
+
+	if got != nil {
+		t.Fatalf("DrainErrGroup err = %v, want nil on timeout", got)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("DrainErrGroup did not return promptly on a hung group: took %s (the deadlock would persist)", elapsed)
+	}
+	close(block) // unblock the leaked goroutine so the test process stays clean
+}


### PR DESCRIPTION
## What

`record.Start` and `replay.Start` install a deferred teardown that drains their run/setup `errgroup`s with **unbounded** `g.Wait()` calls (and notify the agent with `context.Background()`, also unbounded). That deferred teardown is *also* the path SIGINT/SIGTERM takes — the signal cancels the root context, which fires the defer.

If any setup/run goroutine doesn't observe cancellation — e.g. an agent-in-docker bring-up or proxy setup that wedges while the host is under heavy CPU/IO contention — the unbounded `Wait()` blocks teardown forever. Since that teardown is what SIGINT triggers, the process then **ignores SIGINT** and only dies when something external sends SIGKILL.

Observed in CI under heavy parallel load: a lane that wraps `keploy test` in `timeout -s INT 900` still ran ~50 minutes (the agent came up, the run never progressed, and the 15-minute SIGINT was swallowed) until the job was hard-killed.

## Fix

- Add `utils.DrainErrGroup(logger, name, g, timeout)`: waits on `g.Wait()` but gives up after a bound, logging the offending group (so a goroutine that ignores cancellation stays discoverable). On timeout the leaked goroutine is reaped at process exit.
- Use it for every teardown drain in `record.Start` and `replay.Start` (including the per-test-set defer).
- Cap the `NotifyGracefulShutdown` calls with a 10s context instead of `context.Background()`.

Normal shutdowns drain in well under the bound, so this is a **no-op on the happy path** — it only converts an indefinite hang into a prompt, logged exit, guaranteeing `keploy record`/`keploy test` always respond to SIGINT.

## Tests

Deterministic unit tests for `DrainErrGroup`:
- returns the group's error verbatim on fast completion (and doesn't wait out the timeout);
- returns promptly (does not hang) when a goroutine blocks forever — the regression guard for the deadlock.

`go build ./...`, `go vet`, and `go test ./utils/` pass locally.