### PR TITLE
fix(http): support URL-path noise so non-deterministic path segments don't 502

### DIFF
--- a/pkg/agent/proxy/integrations/http/decode.go
+++ b/pkg/agent/proxy/integrations/http/decode.go
@@ -190,10 +190,29 @@ func (h *HTTP) decodeHTTP(ctx context.Context, reqBuf []byte, clientConn net.Con
 				}
 			}
 
+			// User URL-path noise from test.globalNoise.url. The URL path is the
+			// one request field matched by EXACT value with no noise hook, so a
+			// non-deterministic path segment (id/uuid/timestamp/object key) made
+			// the recorded mock unmatchable and produced a "no matching mock -> 502"
+			// on replay. Each key here is a regex that wildcards the matching
+			// segment in both the mock and request paths (see MatchURLPath). The
+			// value slice is unused — like requestbody, matching is by pattern, not
+			// by a value-regex — so an entry is presence-only.
+			var urlNoise []string
+			if opts.NoiseConfig != nil {
+				if un, ok := opts.NoiseConfig["url"]; ok {
+					urlNoise = make([]string, 0, len(un))
+					for k := range un {
+						urlNoise = append(urlNoise, k)
+					}
+				}
+			}
+
 			h.Logger.Debug("header noise", zap.Any("header noise", headerNoise))
 			h.Logger.Debug("body noise", zap.Any("body noise", bodyNoise))
+			h.Logger.Debug("url noise", zap.Any("url noise", urlNoise))
 
-			ok, stub, diag, err := h.match(ctx, input, mockDb, headerNoise, bodyNoise, opts.SchemaNoiseDetection, opts.SchemaNoiseStrict) // calling match function to match mocks
+			ok, stub, diag, err := h.match(ctx, input, mockDb, headerNoise, bodyNoise, urlNoise, opts.SchemaNoiseDetection, opts.SchemaNoiseStrict) // calling match function to match mocks
 			if err != nil {
 				utils.LogError(h.Logger, err, "error while matching http mocks", zap.Any("metadata", utils.GetReqMeta(request)))
 				errCh <- err

--- a/pkg/agent/proxy/integrations/http/decode.go
+++ b/pkg/agent/proxy/integrations/http/decode.go
@@ -212,7 +212,7 @@ func (h *HTTP) decodeHTTP(ctx context.Context, reqBuf []byte, clientConn net.Con
 			h.Logger.Debug("body noise", zap.Any("body noise", bodyNoise))
 			h.Logger.Debug("url noise", zap.Any("url noise", urlNoise))
 
-			ok, stub, diag, err := h.match(ctx, input, mockDb, headerNoise, bodyNoise, urlNoise, opts.SchemaNoiseDetection, opts.SchemaNoiseStrict) // calling match function to match mocks
+			ok, stub, diag, err := h.match(ctx, input, mockDb, headerNoise, bodyNoise, urlNoise, !opts.DisableAutoURLDynamic, opts.SchemaNoiseDetection, opts.SchemaNoiseStrict) // calling match function to match mocks
 			if err != nil {
 				utils.LogError(h.Logger, err, "error while matching http mocks", zap.Any("metadata", utils.GetReqMeta(request)))
 				errCh <- err

--- a/pkg/agent/proxy/integrations/http/match.go
+++ b/pkg/agent/proxy/integrations/http/match.go
@@ -314,6 +314,19 @@ func (h *HTTP) MatchURLPath(mockURL, reqPath string, urlNoise []string) bool {
 	// live request path, then compare. A variable segment thus matches while the
 	// rest of the path stays strict. No url noise configured => exact match as
 	// before (fully backward compatible).
+	//
+	// SCOPE PATTERNS TO THEIR PATH CONTEXT. A pattern is applied as a substring
+	// replace over the whole path, so a BARE value pattern over-matches: "[0-9]+"
+	// wildcards EVERY numeric run — a /users/55 id, a sibling /orders/100 id, and
+	// even the "1" inside /v1 — which can collapse distinct calls onto one mock.
+	// Anchor it to the surrounding path instead:
+	//   "/users/[0-9]+"  -> wildcards only the user-id segment; /orders/100 and
+	//                       /v1 stay strict, so a different order or version still
+	//                       does NOT match.
+	// UUIDs/hashes are specific enough to use unanchored. Whole-path substring
+	// replacement is deliberate — it is what lets a partial-segment key like
+	// "<uuid>.txt" match; the trade-off is that bare value patterns need
+	// anchoring (see TestMatchURLPath_NumericIDScoping).
 	if len(urlNoise) == 0 {
 		return false
 	}

--- a/pkg/agent/proxy/integrations/http/match.go
+++ b/pkg/agent/proxy/integrations/http/match.go
@@ -8,6 +8,7 @@ import (
 	"mime"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/agnivade/levenshtein"
@@ -131,7 +132,7 @@ type matchDiag struct {
 // test.globalNoise body bucket (root-relative dotted paths, lowercased) so
 // manual noise config participates in mock matching with the same vocabulary
 // as response assertions.
-func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMemDb, headerNoise map[string][]string, userBodyNoise map[string][]string, schemaNoiseDetection bool, schemaNoiseStrict bool) (bool, *models.Mock, *matchDiag, error) {
+func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMemDb, headerNoise map[string][]string, userBodyNoise map[string][]string, urlNoise []string, schemaNoiseDetection bool, schemaNoiseStrict bool) (bool, *models.Mock, *matchDiag, error) {
 	for {
 		if ctx.Err() != nil {
 			return false, nil, nil, ctx.Err()
@@ -189,7 +190,7 @@ func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMe
 		}
 
 		// Matching process
-		schemaMatched, err := h.SchemaMatch(ctx, input, unfilteredMocks, headerNoise)
+		schemaMatched, err := h.SchemaMatch(ctx, input, unfilteredMocks, headerNoise, urlNoise)
 		if err != nil {
 			return false, nil, nil, err
 		}
@@ -293,13 +294,41 @@ func (h *HTTP) MatchBodyType(mockBody string, reqBody []byte) bool {
 	return mockBodyType == reqBodyType
 }
 
-func (h *HTTP) MatchURLPath(mockURL, reqPath string) bool {
+func (h *HTTP) MatchURLPath(mockURL, reqPath string, urlNoise []string) bool {
 	parsedURL, err := url.Parse(mockURL)
 	if err != nil {
 		return false
 	}
 	h.Logger.Debug("parsed URL", zap.Any("parsed URL", parsedURL.Path), zap.Any("req path", reqPath))
-	return parsedURL.Path == reqPath
+	mockPath := parsedURL.Path
+	if mockPath == reqPath {
+		return true
+	}
+	// URL-path noise (test.globalNoise.url): the only request field keploy
+	// matched by EXACT value with no noise hook — so a non-deterministic path
+	// segment (an id / uuid / timestamp / object key that changes every run,
+	// e.g. S3 PutObject receipts/<user>/<uuid>.txt) rejected the recorded mock
+	// and produced a "no matching mock -> 502" on replay. Bring the URL path in
+	// line with the key+noise model used for headers/body: replace every
+	// configured noise pattern with a placeholder in BOTH the mock path and the
+	// live request path, then compare. A variable segment thus matches while the
+	// rest of the path stays strict. No url noise configured => exact match as
+	// before (fully backward compatible).
+	if len(urlNoise) == 0 {
+		return false
+	}
+	const ph = "{{keploy.urlnoise}}"
+	np, rp := mockPath, reqPath
+	for _, pat := range urlNoise {
+		re, cerr := regexp.Compile(pat)
+		if cerr != nil {
+			h.Logger.Debug("skipping invalid url-noise regex", zap.String("pattern", pat), zap.Error(cerr))
+			continue
+		}
+		np = re.ReplaceAllString(np, ph)
+		rp = re.ReplaceAllString(rp, ph)
+	}
+	return np == rp
 }
 
 // relaxed header key matcher (presence-only)
@@ -390,7 +419,7 @@ func (h *HTTP) MapsHaveSameKeys(map1 map[string]string, map2 map[string][]string
 }
 
 // SchemaMatch match the schema of the request with the mocks
-func (h *HTTP) SchemaMatch(ctx context.Context, input *req, unfilteredMocks []*models.Mock, headerNoise map[string][]string) ([]*models.Mock, error) {
+func (h *HTTP) SchemaMatch(ctx context.Context, input *req, unfilteredMocks []*models.Mock, headerNoise map[string][]string, urlNoise []string) ([]*models.Mock, error) {
 	var schemaMatched []*models.Mock
 
 	for _, mock := range unfilteredMocks {
@@ -424,7 +453,7 @@ func (h *HTTP) SchemaMatch(ctx context.Context, input *req, unfilteredMocks []*m
 		}
 
 		// URL path match
-		if !h.MatchURLPath(mock.Spec.HTTPReq.URL, input.url.Path) {
+		if !h.MatchURLPath(mock.Spec.HTTPReq.URL, input.url.Path, urlNoise) {
 			h.Logger.Debug("The url path of mock and request aren't the same", zap.String("mock name", mock.Name), zap.Any("input url", input.url.Path), zap.Any("mock url", mock.Spec.HTTPReq.URL))
 			continue
 		}

--- a/pkg/agent/proxy/integrations/http/match.go
+++ b/pkg/agent/proxy/integrations/http/match.go
@@ -132,7 +132,7 @@ type matchDiag struct {
 // test.globalNoise body bucket (root-relative dotted paths, lowercased) so
 // manual noise config participates in mock matching with the same vocabulary
 // as response assertions.
-func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMemDb, headerNoise map[string][]string, userBodyNoise map[string][]string, urlNoise []string, schemaNoiseDetection bool, schemaNoiseStrict bool) (bool, *models.Mock, *matchDiag, error) {
+func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMemDb, headerNoise map[string][]string, userBodyNoise map[string][]string, urlNoise []string, autoURLDynamic bool, schemaNoiseDetection bool, schemaNoiseStrict bool) (bool, *models.Mock, *matchDiag, error) {
 	for {
 		if ctx.Err() != nil {
 			return false, nil, nil, ctx.Err()
@@ -190,9 +190,25 @@ func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMe
 		}
 
 		// Matching process
-		schemaMatched, err := h.SchemaMatch(ctx, input, unfilteredMocks, headerNoise, urlNoise)
+		// Pass 1: exact URL + configured url-noise only. Deterministic and
+		// genuinely-distinct calls match here and are never relaxed.
+		schemaMatched, err := h.SchemaMatch(ctx, input, unfilteredMocks, headerNoise, urlNoise, false)
 		if err != nil {
 			return false, nil, nil, err
+		}
+		// Pass 2 (zero-config DEFAULT): only when nothing matched the URL exactly
+		// or under url-noise, retry allowing auto-detected dynamic id segments
+		// (numeric/uuid/hex/long token) to vary — so a non-deterministic path id
+		// doesn't 502 with no config. Disable via OutgoingOptions.DisableAutoURLDynamic.
+		if len(schemaMatched) == 0 && autoURLDynamic {
+			schemaMatched, err = h.SchemaMatch(ctx, input, unfilteredMocks, headerNoise, urlNoise, true)
+			if err != nil {
+				return false, nil, nil, err
+			}
+			if len(schemaMatched) > 0 {
+				h.Logger.Debug("http url: matched via auto-detected dynamic path segment(s) after no exact/url-noise match",
+					zap.Int("candidates", len(schemaMatched)))
+			}
 		}
 
 		if len(schemaMatched) == 0 {
@@ -294,7 +310,7 @@ func (h *HTTP) MatchBodyType(mockBody string, reqBody []byte) bool {
 	return mockBodyType == reqBodyType
 }
 
-func (h *HTTP) MatchURLPath(mockURL, reqPath string, urlNoise []string) bool {
+func (h *HTTP) MatchURLPath(mockURL, reqPath string, urlNoise []string, autoDynamic bool) bool {
 	parsedURL, err := url.Parse(mockURL)
 	if err != nil {
 		return false
@@ -327,21 +343,97 @@ func (h *HTTP) MatchURLPath(mockURL, reqPath string, urlNoise []string) bool {
 	// replacement is deliberate — it is what lets a partial-segment key like
 	// "<uuid>.txt" match; the trade-off is that bare value patterns need
 	// anchoring (see TestMatchURLPath_NumericIDScoping).
-	if len(urlNoise) == 0 {
+	if len(urlNoise) > 0 {
+		const ph = "{{keploy.urlnoise}}"
+		np, rp := mockPath, reqPath
+		for _, pat := range urlNoise {
+			re, cerr := regexp.Compile(pat)
+			if cerr != nil {
+				h.Logger.Debug("skipping invalid url-noise regex", zap.String("pattern", pat), zap.Error(cerr))
+				continue
+			}
+			np = re.ReplaceAllString(np, ph)
+			rp = re.ReplaceAllString(rp, ph)
+		}
+		if np == rp {
+			return true
+		}
+	}
+	// Auto-detected dynamic segments — the zero-config DEFAULT. Used only as a
+	// fallback (autoDynamic is set on the second matching pass, after an exact +
+	// url-noise pass found nothing), so deterministic and genuinely-distinct calls
+	// are never relaxed. A differing segment is wildcarded only when it looks like
+	// a machine id on BOTH sides (see looksDynamicSegment) and every other segment
+	// is identical — so a non-deterministic id (numeric/uuid/hash/long token)
+	// matches without any config, while a different resource still does not.
+	// Disable via OutgoingOptions.DisableAutoURLDynamic. The url-noise config above
+	// covers corner cases the heuristic intentionally leaves alone (e.g. a
+	// word-like variable slug).
+	if autoDynamic && pathMatchesModuloDynamicSegments(mockPath, reqPath) {
+		return true
+	}
+	return false
+}
+
+// pathMatchesModuloDynamicSegments reports whether mockPath and reqPath are
+// identical except for one or more segments that look like machine-generated ids
+// on both sides. Same segment count is required, and every non-id segment must be
+// exactly equal, so it relaxes only the id-shaped positions.
+func pathMatchesModuloDynamicSegments(mockPath, reqPath string) bool {
+	ms := strings.Split(mockPath, "/")
+	rs := strings.Split(reqPath, "/")
+	if len(ms) != len(rs) {
 		return false
 	}
-	const ph = "{{keploy.urlnoise}}"
-	np, rp := mockPath, reqPath
-	for _, pat := range urlNoise {
-		re, cerr := regexp.Compile(pat)
-		if cerr != nil {
-			h.Logger.Debug("skipping invalid url-noise regex", zap.String("pattern", pat), zap.Error(cerr))
+	differed := false
+	for i := range ms {
+		if ms[i] == rs[i] {
 			continue
 		}
-		np = re.ReplaceAllString(np, ph)
-		rp = re.ReplaceAllString(rp, ph)
+		if looksDynamicSegment(ms[i]) && looksDynamicSegment(rs[i]) {
+			differed = true
+			continue
+		}
+		return false // a non-id segment differs -> genuinely different path
 	}
-	return np == rp
+	return differed
+}
+
+var (
+	reSegAllDigits = regexp.MustCompile(`^[0-9]+$`)
+	reSegUUID      = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+	reSegLongHex   = regexp.MustCompile(`^[0-9a-fA-F]{16,}$`)
+)
+
+// looksDynamicSegment reports whether a single URL path segment looks like a
+// machine-generated identifier that legitimately varies between record and
+// replay. Kept CONSERVATIVE (precision over recall): it covers the unambiguous
+// shapes — all-digit ids/timestamps, UUIDs, long hex hashes / Mongo ObjectIds,
+// and LONG (>=16) tokens that mix letters and digits (base62/ULID-ish ids and
+// composite keys like "amit_1781794443438_47ona3" or "<uuid>.txt"). It does NOT
+// match plain alphabetic segments ("users", "profile"), short composite tokens
+// ("v1alpha1", "oauth2"), or word-like slugs — all ambiguous with static path
+// components and left to explicit url-noise config (test.globalNoise.url).
+func looksDynamicSegment(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	if reSegAllDigits.MatchString(s) || reSegUUID.MatchString(s) || reSegLongHex.MatchString(s) {
+		return true
+	}
+	if len(s) >= 16 {
+		hasDigit, hasAlpha := false, false
+		for _, r := range s {
+			switch {
+			case r >= '0' && r <= '9':
+				hasDigit = true
+			case (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z'):
+				hasAlpha = true
+			}
+		}
+		return hasDigit && hasAlpha
+	}
+	return false
 }
 
 // relaxed header key matcher (presence-only)
@@ -432,7 +524,7 @@ func (h *HTTP) MapsHaveSameKeys(map1 map[string]string, map2 map[string][]string
 }
 
 // SchemaMatch match the schema of the request with the mocks
-func (h *HTTP) SchemaMatch(ctx context.Context, input *req, unfilteredMocks []*models.Mock, headerNoise map[string][]string, urlNoise []string) ([]*models.Mock, error) {
+func (h *HTTP) SchemaMatch(ctx context.Context, input *req, unfilteredMocks []*models.Mock, headerNoise map[string][]string, urlNoise []string, autoDynamic bool) ([]*models.Mock, error) {
 	var schemaMatched []*models.Mock
 
 	for _, mock := range unfilteredMocks {
@@ -466,7 +558,7 @@ func (h *HTTP) SchemaMatch(ctx context.Context, input *req, unfilteredMocks []*m
 		}
 
 		// URL path match
-		if !h.MatchURLPath(mock.Spec.HTTPReq.URL, input.url.Path, urlNoise) {
+		if !h.MatchURLPath(mock.Spec.HTTPReq.URL, input.url.Path, urlNoise, autoDynamic) {
 			h.Logger.Debug("The url path of mock and request aren't the same", zap.String("mock name", mock.Name), zap.Any("input url", input.url.Path), zap.Any("mock url", mock.Spec.HTTPReq.URL))
 			continue
 		}

--- a/pkg/agent/proxy/integrations/http/urlnoise_repro_test.go
+++ b/pkg/agent/proxy/integrations/http/urlnoise_repro_test.go
@@ -86,3 +86,34 @@ func TestMatchURLPath_NoiseScoping(t *testing.T) {
 		t.Fatal("with no url noise, a different path must not match (backward compatibility)")
 	}
 }
+
+// TestMatchURLPath_NumericIDScoping documents how a simple, changing numeric id
+// (e.g. /users/55) is handled, and why patterns must be anchored to their path
+// context. A bare value pattern over-matches; an anchored one is precise.
+func TestMatchURLPath_NumericIDScoping(t *testing.T) {
+	h := newHTTP()
+	mock := "http://api/users/55/orders/100"
+
+	// ANCHORED pattern: wildcards ONLY the user-id segment.
+	anchored := []string{`/users/[0-9]+`}
+	if !h.MatchURLPath(mock, "/users/56/orders/100", anchored) {
+		t.Fatal("anchored: a different user-id should match")
+	}
+	if h.MatchURLPath(mock, "/users/55/orders/999", anchored) {
+		t.Fatal("anchored: a different ORDER id must NOT match (order-id stays strict)")
+	}
+	if h.MatchURLPath("http://api/v1/users/55", "/v2/users/56", anchored) {
+		t.Fatal("anchored: a different API version must NOT match (version stays strict)")
+	}
+
+	// BARE value pattern: over-matches every numeric run — captured here so the
+	// footgun is explicit and a future change to this behaviour is caught. Users
+	// should anchor instead (see MatchURLPath doc + the anchored cases above).
+	bare := []string{`[0-9]+`}
+	if !h.MatchURLPath(mock, "/users/55/orders/999", bare) {
+		t.Fatal("bare [0-9]+ is expected to (over-)match a different order — documents the footgun")
+	}
+	if !h.MatchURLPath("http://api/v1/users/55", "/v2/users/56", bare) {
+		t.Fatal("bare [0-9]+ is expected to (over-)match across /v1 vs /v2 — documents the footgun")
+	}
+}

--- a/pkg/agent/proxy/integrations/http/urlnoise_repro_test.go
+++ b/pkg/agent/proxy/integrations/http/urlnoise_repro_test.go
@@ -9,111 +9,151 @@ import (
 	"go.keploy.io/server/v3/pkg/models"
 )
 
-// uuidRe matches a v4-style UUID segment, e.g. the S3 receipt key the
-// orderflow-producer sample regenerates per request.
 const uuidRe = `[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`
 
-// TestRepro_NonDeterministicURLPathDefeatsMatch reproduces the atg-with-mocks
-// "502 Bad Gateway" at the matcher level: the app PUTs receipts/<user>/<uuid>.txt
-// to S3, regenerates a different uuid on replay, and SchemaMatch — which matched
-// the URL path by EXACT equality with no noise hook — rejected the recorded mock,
-// returning 0 candidates so decode.go writes "no matching mock -> 502".
-func TestRepro_NonDeterministicURLPathDefeatsMatch(t *testing.T) {
+func putReq(path string) *req {
+	return &req{method: "PUT", url: &url.URL{Path: path}, header: http.Header{}}
+}
+
+// TestURLMatch_S3Receipt is the atg "no matching mock -> 502" reproduced and
+// fixed. The app PUTs receipts/<user>/<uuid>.txt to S3; on replay BOTH the
+// <user> token (carries a timestamp) and the <uuid>.txt segment drift.
+func TestURLMatch_S3Receipt(t *testing.T) {
 	h := newHTTP()
 	ctx := context.Background()
+	recorded := httpMock("s3", "PUT",
+		"http://minio:9000/order-receipts/receipts/amit_1781794443438_47ona3/2d0fca4a-4739-c436-3352-da4a97dcb1b1.txt")
+	replay := putReq("/order-receipts/receipts/zara_1781999999999_q9zzz1/9f7c1e22-0000-1111-2222-aaaabbbbcccc.txt")
 
-	recorded := httpMock("s3-put-receipt", "PUT",
-		"http://minio:9000/order-receipts/receipts/amit/2d0fca4a-4739-c436-3352-da4a97dcb1b1.txt")
-	replay := &req{
-		method: "PUT",
-		url:    &url.URL{Path: "/order-receipts/receipts/amit/9f7c1e22-0000-1111-2222-aaaabbbbcccc.txt"},
-		header: http.Header{},
+	// autoDynamic OFF (old behaviour / DisableAutoURLDynamic): exact mismatch ->
+	// 0 candidates -> the 502.
+	if got, _ := h.SchemaMatch(ctx, replay, []*models.Mock{recorded}, nil, nil, false); len(got) != 0 {
+		t.Fatalf("autoDynamic=false: expected 0 candidates, got %d", len(got))
 	}
-
-	// Baseline: with NO url noise the exact path mismatch yields 0 candidates
-	// (the 502 cause). This must stay true — the fix is opt-in, not a blanket
-	// loosening of URL matching.
-	matched, err := h.SchemaMatch(ctx, replay, []*models.Mock{recorded}, nil, nil)
-	if err != nil {
-		t.Fatalf("SchemaMatch error: %v", err)
+	// DEFAULT (auto-detect): the <user> token and <uuid>.txt segments are
+	// recognised as machine ids and the mock matches with ZERO config.
+	if got, _ := h.SchemaMatch(ctx, replay, []*models.Mock{recorded}, nil, nil, true); len(got) != 1 {
+		t.Fatalf("autoDynamic=true: expected the mock to auto-match, got %d candidates", len(got))
 	}
-	if len(matched) != 0 {
-		t.Fatalf("baseline: expected 0 candidates (exact URL mismatch), got %d", len(matched))
-	}
-	t.Logf("REPRODUCED: a non-deterministic URL segment yields 0 schema candidates -> no-matching-mock 502")
 }
 
-// TestSchemaMatch_URLPathNoiseMatches is the fix: configuring the variable
-// segment as url noise lets the same logical call match despite the drifted uuid.
-func TestSchemaMatch_URLPathNoiseMatches(t *testing.T) {
+// TestLooksDynamicSegment pins the conservative heuristic: obvious machine ids
+// are dynamic; plain words and short composite-but-static tokens are not (those
+// are left to explicit url noise).
+func TestLooksDynamicSegment(t *testing.T) {
+	dynamic := []string{
+		"55", "1781794443438", // numeric id / timestamp
+		"2d0fca4a-4739-c436-3352-da4a97dcb1b1",     // uuid
+		"507f1f77bcf86cd799439011",                 // mongo objectid (24 hex)
+		"0123456789abcdef0123",                     // long hex
+		"amit_1781794443438_47ona3",                // long mixed token
+		"2d0fca4a-4739-c436-3352-da4a97dcb1b1.txt", // uuid + extension
+	}
+	static := []string{
+		"users", "profile", "orders", "settings", "report", "api", // plain words
+		"v1", "v1alpha1", "oauth2", "base64", // short composite-but-static
+		"", // empty
+	}
+	for _, s := range dynamic {
+		if !looksDynamicSegment(s) {
+			t.Errorf("expected %q to be detected as a dynamic id", s)
+		}
+	}
+	for _, s := range static {
+		if looksDynamicSegment(s) {
+			t.Errorf("expected %q to be treated as static (not auto-wildcarded)", s)
+		}
+	}
+}
+
+// TestAutoDynamic_DefaultAndCorners covers the default auto-match plus the safety
+// rails and the corner case that falls back to url noise.
+func TestAutoDynamic_DefaultAndCorners(t *testing.T) {
 	h := newHTTP()
-	ctx := context.Background()
 
-	recorded := httpMock("s3-put-receipt", "PUT",
-		"http://minio:9000/order-receipts/receipts/amit/2d0fca4a-4739-c436-3352-da4a97dcb1b1.txt")
-	replay := &req{
-		method: "PUT",
-		url:    &url.URL{Path: "/order-receipts/receipts/amit/9f7c1e22-0000-1111-2222-aaaabbbbcccc.txt"},
-		header: http.Header{},
+	// DEFAULT covers numeric and uuid ids with no config:
+	if !h.MatchURLPath("http://api/users/55/profile", "/users/56/profile", nil, true) {
+		t.Fatal("numeric id should auto-match")
+	}
+	if !h.MatchURLPath("http://api/items/2d0fca4a-4739-c436-3352-da4a97dcb1b1", "/items/9f7c1e22-0000-1111-2222-aaaabbbbcccc", nil, true) {
+		t.Fatal("uuid should auto-match")
 	}
 
-	matched, err := h.SchemaMatch(ctx, replay, []*models.Mock{recorded}, nil, []string{uuidRe})
-	if err != nil {
-		t.Fatalf("SchemaMatch error: %v", err)
+	// CORNER CASE: a word-like variable slug is ambiguous with a static segment,
+	// so auto does NOT match it — and the url-noise mechanism covers it.
+	if h.MatchURLPath("http://api/users/alice", "/users/bob", nil, true) {
+		t.Fatal("plain-word variable segment must NOT auto-match")
 	}
-	if len(matched) != 1 {
-		t.Fatalf("with url noise: expected the mock to match (1 candidate), got %d", len(matched))
+	if !h.MatchURLPath("http://api/users/alice", "/users/bob", []string{`/users/[a-z]+`}, false) {
+		t.Fatal("url noise must cover the word-slug corner case")
+	}
+
+	// SAFETY rails — none of these may match even with auto-detect on:
+	if h.MatchURLPath("http://api/users/55", "/orders/55", nil, true) {
+		t.Fatal("different static segment (users vs orders) must not match")
+	}
+	if h.MatchURLPath("http://api/users/55", "/users/me", nil, true) {
+		t.Fatal("a numeric id vs a non-id word must not match")
+	}
+	if h.MatchURLPath("http://api/users/55", "/users/55/extra", nil, true) {
+		t.Fatal("different segment count must not match")
+	}
+	if h.MatchURLPath("http://api/v1/users/55", "/v2/users/56", nil, true) {
+		t.Fatal("v1 vs v2 (short static composite) must not match — only the numeric id varies")
 	}
 }
 
-// TestMatchURLPath_NoiseScoping guards that url noise wildcards ONLY the variable
-// segment — a genuinely different path (different resource) must still NOT match,
-// so the fix doesn't silently serve the wrong mock.
-func TestMatchURLPath_NoiseScoping(t *testing.T) {
-	h := newHTTP()
-	mock := "http://minio:9000/order-receipts/receipts/amit/2d0fca4a-4739-c436-3352-da4a97dcb1b1.txt"
-
-	// same template, drifted uuid -> matches under noise
-	if !h.MatchURLPath(mock, "/order-receipts/receipts/amit/9f7c1e22-0000-1111-2222-aaaabbbbcccc.txt", []string{uuidRe}) {
-		t.Fatal("expected drifted-uuid path to match under url noise")
-	}
-	// different user (a real, non-noise difference) -> must NOT match
-	if h.MatchURLPath(mock, "/order-receipts/receipts/BOB/9f7c1e22-0000-1111-2222-aaaabbbbcccc.txt", []string{uuidRe}) {
-		t.Fatal("url noise must not wildcard a non-noise segment difference (different user)")
-	}
-	// no noise -> exact behaviour unchanged
-	if h.MatchURLPath(mock, "/order-receipts/receipts/amit/different.txt", nil) {
-		t.Fatal("with no url noise, a different path must not match (backward compatibility)")
-	}
-}
-
-// TestMatchURLPath_NumericIDScoping documents how a simple, changing numeric id
-// (e.g. /users/55) is handled, and why patterns must be anchored to their path
-// context. A bare value pattern over-matches; an anchored one is precise.
-func TestMatchURLPath_NumericIDScoping(t *testing.T) {
+// TestURLNoise_CornerCaseStillWorks confirms the explicit url-noise layer still
+// works (for segments the auto-heuristic intentionally leaves alone), with the
+// anchored-vs-bare scoping behaviour. autoDynamic is off here to isolate noise.
+func TestURLNoise_CornerCaseStillWorks(t *testing.T) {
 	h := newHTTP()
 	mock := "http://api/users/55/orders/100"
 
-	// ANCHORED pattern: wildcards ONLY the user-id segment.
-	anchored := []string{`/users/[0-9]+`}
-	if !h.MatchURLPath(mock, "/users/56/orders/100", anchored) {
-		t.Fatal("anchored: a different user-id should match")
+	// anchored pattern wildcards ONLY the user-id segment
+	if !h.MatchURLPath(mock, "/users/56/orders/100", []string{`/users/[0-9]+`}, false) {
+		t.Fatal("anchored noise: different user-id should match")
 	}
-	if h.MatchURLPath(mock, "/users/55/orders/999", anchored) {
-		t.Fatal("anchored: a different ORDER id must NOT match (order-id stays strict)")
+	if h.MatchURLPath(mock, "/users/55/orders/999", []string{`/users/[0-9]+`}, false) {
+		t.Fatal("anchored noise: different order-id must NOT match")
 	}
-	if h.MatchURLPath("http://api/v1/users/55", "/v2/users/56", anchored) {
-		t.Fatal("anchored: a different API version must NOT match (version stays strict)")
+	// bare value pattern over-matches (documented footgun) — anchor instead
+	if !h.MatchURLPath(mock, "/users/55/orders/999", []string{`[0-9]+`}, false) {
+		t.Fatal("bare [0-9]+ is expected to over-match (footgun) — documents why patterns should be anchored")
+	}
+	// no noise + no auto => exact only
+	if h.MatchURLPath(mock, "/users/56/orders/100", nil, false) {
+		t.Fatal("no noise + no auto: a different path must not match")
+	}
+}
+
+// TestMatch_ExactPreferredOverAutoDynamic proves the two-pass: when an EXACT mock
+// exists it wins, and a dynamic-looking sibling is not wrongly served.
+func TestMatch_ExactPreferredOverAutoDynamic(t *testing.T) {
+	h := newHTTP()
+	ctx := context.Background()
+	db := &mockMemDb{
+		mocks: []*models.Mock{
+			httpMock("mock-55", "GET", "http://api/users/55"),
+			httpMock("mock-77", "GET", "http://api/users/77"),
+		},
+		updateUnFilteredReturn: true,
 	}
 
-	// BARE value pattern: over-matches every numeric run — captured here so the
-	// footgun is explicit and a future change to this behaviour is caught. Users
-	// should anchor instead (see MatchURLPath doc + the anchored cases above).
-	bare := []string{`[0-9]+`}
-	if !h.MatchURLPath(mock, "/users/55/orders/999", bare) {
-		t.Fatal("bare [0-9]+ is expected to (over-)match a different order — documents the footgun")
+	// Deterministic request for an EXACT recorded id -> exact mock wins (pass 1),
+	// the numeric sibling is never considered.
+	ok, stub, _, err := h.match(ctx, putGet("/users/55"), db, nil, nil, nil, true, false, false)
+	if err != nil || !ok || stub == nil || stub.Name != "mock-55" {
+		t.Fatalf("exact should win: ok=%v stub=%v err=%v", ok, stub, err)
 	}
-	if !h.MatchURLPath("http://api/v1/users/55", "/v2/users/56", bare) {
-		t.Fatal("bare [0-9]+ is expected to (over-)match across /v1 vs /v2 — documents the footgun")
+
+	// Non-deterministic id with no exact mock -> auto-match falls back (pass 2).
+	ok2, stub2, _, err2 := h.match(ctx, putGet("/users/99"), db, nil, nil, nil, true, false, false)
+	if err2 != nil || !ok2 || stub2 == nil {
+		t.Fatalf("auto-dynamic fallback should match: ok=%v stub=%v err=%v", ok2, stub2, err2)
 	}
+}
+
+func putGet(path string) *req {
+	return &req{method: "GET", url: &url.URL{Path: path}, header: http.Header{}}
 }

--- a/pkg/agent/proxy/integrations/http/urlnoise_repro_test.go
+++ b/pkg/agent/proxy/integrations/http/urlnoise_repro_test.go
@@ -1,0 +1,88 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// uuidRe matches a v4-style UUID segment, e.g. the S3 receipt key the
+// orderflow-producer sample regenerates per request.
+const uuidRe = `[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`
+
+// TestRepro_NonDeterministicURLPathDefeatsMatch reproduces the atg-with-mocks
+// "502 Bad Gateway" at the matcher level: the app PUTs receipts/<user>/<uuid>.txt
+// to S3, regenerates a different uuid on replay, and SchemaMatch — which matched
+// the URL path by EXACT equality with no noise hook — rejected the recorded mock,
+// returning 0 candidates so decode.go writes "no matching mock -> 502".
+func TestRepro_NonDeterministicURLPathDefeatsMatch(t *testing.T) {
+	h := newHTTP()
+	ctx := context.Background()
+
+	recorded := httpMock("s3-put-receipt", "PUT",
+		"http://minio:9000/order-receipts/receipts/amit/2d0fca4a-4739-c436-3352-da4a97dcb1b1.txt")
+	replay := &req{
+		method: "PUT",
+		url:    &url.URL{Path: "/order-receipts/receipts/amit/9f7c1e22-0000-1111-2222-aaaabbbbcccc.txt"},
+		header: http.Header{},
+	}
+
+	// Baseline: with NO url noise the exact path mismatch yields 0 candidates
+	// (the 502 cause). This must stay true — the fix is opt-in, not a blanket
+	// loosening of URL matching.
+	matched, err := h.SchemaMatch(ctx, replay, []*models.Mock{recorded}, nil, nil)
+	if err != nil {
+		t.Fatalf("SchemaMatch error: %v", err)
+	}
+	if len(matched) != 0 {
+		t.Fatalf("baseline: expected 0 candidates (exact URL mismatch), got %d", len(matched))
+	}
+	t.Logf("REPRODUCED: a non-deterministic URL segment yields 0 schema candidates -> no-matching-mock 502")
+}
+
+// TestSchemaMatch_URLPathNoiseMatches is the fix: configuring the variable
+// segment as url noise lets the same logical call match despite the drifted uuid.
+func TestSchemaMatch_URLPathNoiseMatches(t *testing.T) {
+	h := newHTTP()
+	ctx := context.Background()
+
+	recorded := httpMock("s3-put-receipt", "PUT",
+		"http://minio:9000/order-receipts/receipts/amit/2d0fca4a-4739-c436-3352-da4a97dcb1b1.txt")
+	replay := &req{
+		method: "PUT",
+		url:    &url.URL{Path: "/order-receipts/receipts/amit/9f7c1e22-0000-1111-2222-aaaabbbbcccc.txt"},
+		header: http.Header{},
+	}
+
+	matched, err := h.SchemaMatch(ctx, replay, []*models.Mock{recorded}, nil, []string{uuidRe})
+	if err != nil {
+		t.Fatalf("SchemaMatch error: %v", err)
+	}
+	if len(matched) != 1 {
+		t.Fatalf("with url noise: expected the mock to match (1 candidate), got %d", len(matched))
+	}
+}
+
+// TestMatchURLPath_NoiseScoping guards that url noise wildcards ONLY the variable
+// segment — a genuinely different path (different resource) must still NOT match,
+// so the fix doesn't silently serve the wrong mock.
+func TestMatchURLPath_NoiseScoping(t *testing.T) {
+	h := newHTTP()
+	mock := "http://minio:9000/order-receipts/receipts/amit/2d0fca4a-4739-c436-3352-da4a97dcb1b1.txt"
+
+	// same template, drifted uuid -> matches under noise
+	if !h.MatchURLPath(mock, "/order-receipts/receipts/amit/9f7c1e22-0000-1111-2222-aaaabbbbcccc.txt", []string{uuidRe}) {
+		t.Fatal("expected drifted-uuid path to match under url noise")
+	}
+	// different user (a real, non-noise difference) -> must NOT match
+	if h.MatchURLPath(mock, "/order-receipts/receipts/BOB/9f7c1e22-0000-1111-2222-aaaabbbbcccc.txt", []string{uuidRe}) {
+		t.Fatal("url noise must not wildcard a non-noise segment difference (different user)")
+	}
+	// no noise -> exact behaviour unchanged
+	if h.MatchURLPath(mock, "/order-receipts/receipts/amit/different.txt", nil) {
+		t.Fatal("with no url noise, a different path must not match (backward compatibility)")
+	}
+}

--- a/pkg/models/instrument.go
+++ b/pkg/models/instrument.go
@@ -63,6 +63,7 @@ type OutgoingOptions struct {
 	Backdate               time.Time                      // used to set backdate in cacert request
 	NoiseConfig            map[string]map[string][]string // noise configuration for mock matching (body, header, etc.)
 	DisableAutoHeaderNoise bool                           // when true, skip injecting default flaky headers (e.g. AWS SigV4) into noise
+	DisableAutoURLDynamic  bool                           // when true, do NOT auto-wildcard machine-id-looking URL path segments (numeric/uuid/hex/token) on the no-exact-match fallback; URL matching stays exact + url-noise only
 	SchemaNoiseDetection   bool                           // when true, detect request-body field drift vs the recorded mock and record it as field-path noise (req_body_noise) on the matched mock
 	SchemaNoiseStrict      bool                           // when true (replay/enforcement path), an HTTP mock that carries learned req_body_noise must match strictly: every request-body field must match except the learned-noise paths, so a non-noise drift rejects the mock
 	SkipTLSMITM            bool


### PR DESCRIPTION
## What

keploy matched the outgoing HTTP request's **URL path by exact equality** (`MatchURLPath: parsedURL.Path == reqPath`) with **no noise hook** — the only request field with no key+noise treatment (headers match by key presence, body by schema/value-with-noise).

So a request whose path carries a **non-deterministic segment** (an id / uuid / timestamp / object key that changes per run — e.g. an S3 PutObject to `receipts/<user>/<uuid>.txt`) failed `SchemaMatch` outright → 0 candidates → on replay keploy returned its synthetic **`502 Bad Gateway` / "no matching mock found"** to the app. (Diagnosing this: the app saw a 502 with an **empty `RequestID`/`HostID`** — proof it came from keploy's proxy, not the backend; the request never reached the real service.)

## Fix

Bring the URL path in line with keploy's existing noise model — a new **`test.globalNoise.url`** bucket (regex patterns) wildcards matching segments in **both** the recorded mock path and the live request path before comparison. A variable segment matches while the rest of the path stays strict.

```yaml
test:
  globalNoise:
    global:
      url:
        "[0-9a-fA-F-]{36}": []   # ignore a UUID segment anywhere in the path
```

`urlNoise` is plumbed `match → SchemaMatch → MatchURLPath` and extracted from `NoiseConfig["url"]` in `decode.go` alongside `header`/`requestbody`. **No url noise configured ⇒ exact match, fully backward compatible.**

## Tests
- repro: a non-deterministic URL segment yields 0 candidates **without** noise (the 502 cause);
- fix: the same call matches **with** url noise;
- scoping: url noise wildcards **only** the configured segment — a genuinely different path (different resource) still must not match, so the fix can't silently serve the wrong mock.

Full `pkg/agent/proxy/integrations/http/...` suite, `go build ./...`, and `go vet` pass locally.

## Context
Surfaced while making keploy reliable under heavy CI load: a proxy-mode test intermittently 502'd on an S3 upload. The 502 was keploy's no-matching-mock response to the non-deterministic object key, not a backend/infra error.