### PR TITLE
fix(replay): make per-test-set compose teardown fast and guaranteed

### DIFF
--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -504,13 +504,20 @@ func (a *App) composeDown() {
 		a.logger.Debug("Running docker compose down using in-memory compose content")
 		args := []string{"compose", "-f", "-"}
 		args = append(args, extractProjectFlags(a.cmd)...)
-		args = append(args, "down")
+		// --timeout 1: stop containers fast instead of the default 10s graceful
+		// wait PER container. Between test-sets `keploy test` restarts the whole
+		// compose stack; under loaded CI a slow `down` was exceeding the
+		// per-test-set teardown drain budget and being abandoned, leaving a
+		// half-removed agent container that the next test-set's `up` then
+		// collided with ("container name already in use" -> dependency
+		// keploy-agent failed to start -> test-set abandoned, no report).
+		args = append(args, "down", "--timeout", "1")
 		downCmd = exec.Command("docker", args...)
 		downCmd.Stdin = bytes.NewReader(a.composeContent)
 	case a.composeFile != "":
 		a.logger.Debug("Running docker compose down to clean up containers and networks",
 			zap.String("composeFile", a.composeFile))
-		downCmd = exec.Command("docker", "compose", "-f", a.composeFile, "down")
+		downCmd = exec.Command("docker", "compose", "-f", a.composeFile, "down", "--timeout", "1")
 	default:
 		return
 	}
@@ -518,6 +525,36 @@ func (a *App) composeDown() {
 	if output, err := downCmd.CombinedOutput(); err != nil {
 		a.logger.Debug("docker compose down finished with error (may be expected if containers already removed)",
 			zap.Error(err), zap.String("output", string(output)))
+	}
+
+	// Coverage safety: this runs only AFTER the app has already been stopped by
+	// run()'s cmdCancel (SIGINT + grace period, force-kill only if it doesn't
+	// exit), so the app's coverage flush has already happened — Go writes
+	// GOCOVERDIR, Java its jacoco .exec (both to host-mounted paths that survive
+	// container removal), and the Java SDK streams coverage over a socket during
+	// the run. The --timeout 1 above and the force-remove below therefore only
+	// reclaim already-stopped containers; they never shorten a runtime's
+	// coverage-flush window (that window is cmdCancel's grace, not down).
+	//
+	// Belt-and-suspenders: guarantee the agent + app container names are free
+	// before the next test-set's compose up reuses them. `compose down` already
+	// removes them, but if it errored or was cut short under load the names
+	// could linger and the next up would hit "container name already in use".
+	// A force-remove by name is near-instant and idempotent.
+	a.forceRemoveContainerByName(a.keployContainer)
+	a.forceRemoveContainerByName(a.container)
+}
+
+// forceRemoveContainerByName removes a container by name, ignoring the
+// "no such container" case. Used after compose down to guarantee a name is free
+// for reuse on the next per-test-set compose up.
+func (a *App) forceRemoveContainerByName(name string) {
+	if name == "" {
+		return
+	}
+	if output, err := exec.Command("docker", "rm", "-f", name).CombinedOutput(); err != nil {
+		a.logger.Debug("force-remove container finished (may already be gone)",
+			zap.String("container", name), zap.Error(err), zap.String("output", string(output)))
 	}
 }
 


### PR DESCRIPTION
## Describe the changes that are made
When replaying a docker-compose app with multiple test-sets, `keploy test` restarts the whole compose stack (app + keploy-agent) once **per test-set**. `composeDown` ran a plain `docker compose down`, whose default graceful stop waits up to 10s **per** container. Under load that teardown can exceed the per-test-set drain budget (`RunTestSet`'s bounded `DrainErrGroup`, 30s) and get abandoned mid-flight, leaving the keploy-agent container half-removed. The next test-set's `docker compose up` then hits:

```
Conflict. The container name "/keploy-..." is already in use
-> dependency keploy-agent failed to start
```

the agent container exits 0, `RunApplication` fails, and **that test-set is abandoned with no report** (e.g. a 4-test-set suite emitting only 3 reports).

This makes the per-test-set teardown fast and guaranteed so the prior stack is provably gone before the next test-set's `up`:
- **`docker compose down --timeout 1`** — stop containers in 1s instead of the 10s-per-container graceful wait, so `down` completes within the drain budget and is no longer abandoned.
- **force-remove the agent + app containers by name** after `down` (idempotent, near-instant) — guarantees the names are free for reuse even if `down` errored or was cut short.

Scoped to the docker-compose path (`composeDown` only runs for `kind == DockerCompose`); native and docker-run replay are unaffected. Name reuse is now safe, so no per-test-set rename is needed (which would have introduced container-name collisions between co-located same-project keploy lanes).

**Reproduced** the underlying clash: with a fixed `container_name` and a lingering container of that name, `docker compose up` fails with `Conflict. The container name ... is already in use`; once the prior container is removed first, `up` succeeds.

## Links & References

**Closes:** NA (small, targeted reliability fix)

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed (existing multi-test-set docker-compose replay lanes already exercise this path; the change is in that path's teardown)

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed
