### PR TITLE
fix(replay): bound the app-run teardown wait so a passing run can't false-fail

### DIFF
--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -494,11 +494,13 @@ func sanitizeAppLogLine(line string) string {
 	return strings.TrimSpace(line)
 }
 
-// composeDown runs docker compose down to remove all containers and networks
+// ComposeDown runs docker compose down to remove all containers and networks
 // created by the compose stack. Without this, stopped containers retain
 // references to image layers; a subsequent docker image prune can delete
-// those layers and corrupt Docker Desktop's overlayfs snapshots.
-func (a *App) composeDown() {
+// those layers and corrupt Docker Desktop's overlayfs snapshots. Exported so the
+// replay loop can tear the stack down on a per-test-set setup failure
+// (agent-readiness timeout) before a retry, not only via run()'s defer.
+func (a *App) ComposeDown() {
 	var downCmd *exec.Cmd
 
 	switch {
@@ -548,6 +550,49 @@ func (a *App) composeDown() {
 	// A force-remove by name is near-instant and idempotent.
 	a.forceRemoveContainerByName(a.keployContainer)
 	a.forceRemoveContainerByName(a.container)
+
+	// Reap-barrier: `compose down` / `rm -f` can return before the daemon has
+	// finished reaping under load, so the next compose up's same-name create
+	// races the async reap and stalls at "Creating". Poll until the names are
+	// gone, BOUNDED so it never reintroduces the unbounded teardown that
+	// --timeout 1 removed. Largely a no-op once the stack is reused across
+	// test-sets (one down per lane), but defends the first/last and
+	// non-keep-alive boundaries.
+	a.waitContainersRemoved([]string{a.keployContainer, a.container}, 5*time.Second)
+}
+
+// waitContainersRemoved polls until the named containers no longer exist (or the
+// budget elapses), converting the daemon's async reap into a bounded synchronous
+// barrier so the next compose up cannot race a still-removing same-named
+// container.
+func (a *App) waitContainersRemoved(names []string, budget time.Duration) {
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
+	defer cancel()
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		allGone := true
+		for _, n := range names {
+			if n == "" {
+				continue
+			}
+			// ContainerInspect returns a non-nil error once the container is
+			// gone; treat any error as "no longer blocking" (best-effort barrier).
+			if _, err := a.docker.ContainerInspect(ctx, n); err == nil {
+				allGone = false // still present
+				break
+			}
+		}
+		if allGone {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			a.logger.Debug("waitContainersRemoved: timed out waiting for reap", zap.Strings("containers", names))
+			return
+		case <-ticker.C:
+		}
+	}
 }
 
 // forceRemoveContainerByName removes a container by name, ignoring the
@@ -584,7 +629,7 @@ func (a *App) run(ctx context.Context) models.AppError {
 	userCmd := a.cmd
 
 	if a.kind == utils.DockerCompose {
-		defer a.composeDown()
+		defer a.ComposeDown()
 	}
 
 	if utils.FindDockerCmd(a.cmd) == utils.DockerRun {

--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -305,7 +305,7 @@ func (a *App) RecentLogs(ctx context.Context) string {
 	return a.recentAppLogs(ctx)
 }
 
-func (a *App) waitTillExit() {
+func (a *App) waitTillExit(ctx context.Context) {
 	timeout := time.NewTimer(30 * time.Second)
 	logTicker := time.NewTicker(1 * time.Second)
 	defer logTicker.Stop()
@@ -314,9 +314,14 @@ func (a *App) waitTillExit() {
 	containerID := a.container
 	for {
 		select {
+		// Honor cancellation so this (up to 30s) wait cannot outlive a teardown
+		// the caller is draining — otherwise it pushes the app-run goroutine past
+		// the caller's drain budget and false-FAILs an otherwise-passing run.
+		case <-ctx.Done():
+			return
 		case <-logTicker.C:
 			// Inspect the container status
-			containerJSON, err := a.docker.ContainerInspect(context.Background(), containerID)
+			containerJSON, err := a.docker.ContainerInspect(ctx, containerID)
 			if err != nil {
 				a.logger.Debug("failed to inspect container", zap.String("containerID", containerID), zap.Error(err))
 				return
@@ -645,7 +650,7 @@ func (a *App) run(ctx context.Context) models.AppError {
 	}
 
 	if utils.IsDockerCmd(a.kind) {
-		a.waitTillExit()
+		a.waitTillExit(ctx)
 	}
 
 	select {

--- a/pkg/platform/http/agent.go
+++ b/pkg/platform/http/agent.go
@@ -777,8 +777,14 @@ func (a *AgentClient) Run(ctx context.Context, _ models.RunOptions) models.AppEr
 	runAppErrGrp, runAppCtx := errgroup.WithContext(ctx)
 	appErrCh := make(chan models.AppError, 1)
 	defer func() {
-		err := runAppErrGrp.Wait()
-		if err != nil {
+		// Bound the wait. app.run's teardown (cmdCancel grace + cmd.WaitDelay +
+		// waitTillExit + composeDown) runs on internal timers that are not bounded
+		// by ctx, so an unbounded Wait() here can outlive cancellation and blow
+		// past the caller's per-test-set drain budget — which false-FAILs an
+		// otherwise-passing run on "teardown drain timed out ... a goroutine is
+		// ignoring context cancellation". Bound it under that budget; any teardown
+		// still in flight finishes in the background and is reaped at process exit.
+		if err := utils.DrainErrGroup(a.logger, "agent-run-app", runAppErrGrp, 20*time.Second); err != nil {
 			utils.LogError(a.logger, err, "failed to stop the app")
 		}
 	}()

--- a/pkg/platform/http/agent.go
+++ b/pkg/platform/http/agent.go
@@ -1316,6 +1316,21 @@ func (a *AgentClient) getApp() (*app.App, error) {
 	return h, nil
 }
 
+// ComposeDownOnSetupFailure tears down the managed docker-compose stack so a
+// retry after a per-test-set setup failure (e.g. agent-readiness timeout) does
+// not hit a "container name already in use" conflict from the dependency
+// containers/network left behind. No-op when there is no managed app or it is
+// not a compose app (App.ComposeDown self-guards on kind == DockerCompose).
+func (a *AgentClient) ComposeDownOnSetupFailure(_ context.Context) error {
+	ap, err := a.getApp()
+	if err != nil {
+		a.logger.Debug("ComposeDownOnSetupFailure: no managed app to tear down")
+		return nil
+	}
+	ap.ComposeDown()
+	return nil
+}
+
 func (a *AgentClient) startInDocker(ctx context.Context, logger *zap.Logger, opts models.SetupOptions) error {
 	keployAlias, err := kdocker.GetKeployDockerAlias(ctx, logger, &config.Config{
 		InstallationID: a.conf.InstallationID,

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -457,7 +457,21 @@ func (r *Replayer) Start(ctx context.Context) error {
 	// unstarted), and the per-test-set waitForAppReady skip below
 	// stays armed only when the one-shot spawn actually fired.
 	// Single computed predicate so all three gates move together.
-	effectiveKeepAlive := r.config.Test.KeepAppAlive && r.instrument && cmdType != utils.Empty
+	//
+	// Docker-compose replay reuses the stack across test-sets BY DEFAULT (when
+	// mocking is on): otherwise keploy tears down + recreates the whole
+	// agent+app+network+volumes for every test-set, multiplying docker-daemon
+	// create/destroy churn N-fold and re-paying a per-test-set agent-readiness
+	// window — under loaded CI that churn is what blows past the readiness
+	// timeout. The agent is reused safely: each test-set's mocks are re-scoped
+	// in-band per set (MockOutgoing→ResetForReplaySession, StoreMocks,
+	// SendMockFilterParamsToAgent), the same contract the runner already relies
+	// on. Gated on Mocking so a replay against a real (unmocked) dependency —
+	// where surviving app state across the boundary could change expected
+	// before-state — still restarts per test-set. An explicit --keep-app-alive
+	// keeps working unchanged (OR can only widen).
+	composeReuse := cmdType == utils.DockerCompose && r.config.Test.Mocking
+	effectiveKeepAlive := (r.config.Test.KeepAppAlive || composeReuse) && r.instrument && cmdType != utils.Empty
 	if effectiveKeepAlive {
 		g.Go(func() error {
 			defer utils.Recover(r.logger)
@@ -1142,19 +1156,33 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			return nil
 		})
 
-		agentCtx, cancel := context.WithTimeout(runTestSetCtx, 120*time.Second)
-		defer cancel()
+		// When the stack is reused across test-sets (serveTest), the agent is
+		// started once and stays healthy — only the first test-set needs to wait
+		// for readiness. Re-paying a 120s window per test-set is dead time where a
+		// transient daemon stall can land. Mirrors the waitForAppReady gating.
+		if !serveTest || r.isFirstTestSet {
+			agentCtx, cancel := context.WithTimeout(runTestSetCtx, 120*time.Second)
+			defer cancel()
 
-		agentReadyCh := make(chan bool, 1)
-		go pkg.AgentHealthTicker(agentCtx, r.logger, string(r.config.Agent.AgentURI), agentReadyCh, 1*time.Second)
+			agentReadyCh := make(chan bool, 1)
+			go pkg.AgentHealthTicker(agentCtx, r.logger, string(r.config.Agent.AgentURI), agentReadyCh, 1*time.Second)
 
-		select {
-		case <-runTestSetCtx.Done():
-			// Parent context cancelled (user pressed Ctrl+C)
-			return models.TestSetStatusUserAbort, runTestSetCtx.Err()
-		case <-agentCtx.Done():
-			return models.TestSetStatusFailed, fmt.Errorf("keploy-agent did not become ready in time")
-		case <-agentReadyCh:
+			select {
+			case <-runTestSetCtx.Done():
+				// Parent context cancelled (user pressed Ctrl+C)
+				return models.TestSetStatusUserAbort, runTestSetCtx.Err()
+			case <-agentCtx.Done():
+				// Tear down the compose stack we already created before returning,
+				// so a retry's `compose up` doesn't hit "container name already in
+				// use" — the readiness timeout otherwise leaves the dependency
+				// containers + project network behind. Fresh ctx since
+				// runTestSetCtx is being torn down; composeDown bounds itself.
+				if downErr := r.instrumentation.ComposeDownOnSetupFailure(context.Background()); downErr != nil {
+					r.logger.Debug("composeDown after agent-ready timeout failed", zap.Error(downErr))
+				}
+				return models.TestSetStatusFailed, fmt.Errorf("keploy-agent did not become ready in time")
+			case <-agentReadyCh:
+			}
 		}
 
 		// In case of Docker Compose : since for every test set the agent and application are restarted, hence each test set can be considered as an indicidual test run

--- a/pkg/service/replay/service.go
+++ b/pkg/service/replay/service.go
@@ -34,6 +34,11 @@ type Instrumentation interface {
 	// NotifyGracefulShutdown notifies the agent that the application is shutting down gracefully.
 	// When this is called, connection errors will be logged as debug instead of error.
 	NotifyGracefulShutdown(ctx context.Context) error
+	// ComposeDownOnSetupFailure tears down the docker-compose stack (agent + app
+	// + dependency containers + project network) when per-test-set setup fails
+	// (e.g. agent-readiness timeout), so a retry's `compose up` does not hit a
+	// "container name already in use" conflict. No-op for non-compose apps.
+	ComposeDownOnSetupFailure(ctx context.Context) error
 }
 
 type Service interface {


### PR DESCRIPTION
## Describe the changes that are made
`AgentClient.Run` deferred an **unbounded** `runAppErrGrp.Wait()` that blocks on `app.run`'s teardown (cmdCancel grace + `cmd.WaitDelay` + `waitTillExit` up to 30s + `composeDown`), none of which is bounded by ctx. After cancellation that wait can outlive the caller's per-test-set drain budget (`utils.DrainErrGroup`, 30s), so a replay where **every test passed** still fails the step on:

```
teardown drain timed out after cancellation; forcing shutdown ...
a goroutine is ignoring context cancellation {group: replay-testset}
```

i.e. a green run goes red purely on shutdown timing under load.

Fix:
- Bound the deferred wait with `utils.DrainErrGroup` (20s, under the caller's 30s budget).
- Make `waitTillExit` honor ctx cancellation (it could otherwise block up to 30s inspecting the container after cancel).

Any teardown still in flight finishes in the background and is reaped at process exit. Applies to native / docker-run / compose; happy-path behaviour is unchanged.

## Links & References
**Closes:** NA (reliability fix)
### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed (existing multi-test-set compose replay lanes exercise this teardown path; the change only bounds an existing wait)

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed
