### PR TITLE
fix(replay): reuse the compose stack across test-sets + teardown on timeout

### DIFF
--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -494,11 +494,13 @@ func sanitizeAppLogLine(line string) string {
 	return strings.TrimSpace(line)
 }
 
-// composeDown runs docker compose down to remove all containers and networks
+// ComposeDown runs docker compose down to remove all containers and networks
 // created by the compose stack. Without this, stopped containers retain
 // references to image layers; a subsequent docker image prune can delete
-// those layers and corrupt Docker Desktop's overlayfs snapshots.
-func (a *App) composeDown() {
+// those layers and corrupt Docker Desktop's overlayfs snapshots. Exported so the
+// replay loop can tear the stack down on a per-test-set setup failure
+// (agent-readiness timeout) before a retry, not only via run()'s defer.
+func (a *App) ComposeDown() {
 	var downCmd *exec.Cmd
 
 	switch {
@@ -548,6 +550,49 @@ func (a *App) composeDown() {
 	// A force-remove by name is near-instant and idempotent.
 	a.forceRemoveContainerByName(a.keployContainer)
 	a.forceRemoveContainerByName(a.container)
+
+	// Reap-barrier: `compose down` / `rm -f` can return before the daemon has
+	// finished reaping under load, so the next compose up's same-name create
+	// races the async reap and stalls at "Creating". Poll until the names are
+	// gone, BOUNDED so it never reintroduces the unbounded teardown that
+	// --timeout 1 removed. Largely a no-op once the stack is reused across
+	// test-sets (one down per lane), but defends the first/last and
+	// non-keep-alive boundaries.
+	a.waitContainersRemoved([]string{a.keployContainer, a.container}, 5*time.Second)
+}
+
+// waitContainersRemoved polls until the named containers no longer exist (or the
+// budget elapses), converting the daemon's async reap into a bounded synchronous
+// barrier so the next compose up cannot race a still-removing same-named
+// container.
+func (a *App) waitContainersRemoved(names []string, budget time.Duration) {
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
+	defer cancel()
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		allGone := true
+		for _, n := range names {
+			if n == "" {
+				continue
+			}
+			// ContainerInspect returns a non-nil error once the container is
+			// gone; treat any error as "no longer blocking" (best-effort barrier).
+			if _, err := a.docker.ContainerInspect(ctx, n); err == nil {
+				allGone = false // still present
+				break
+			}
+		}
+		if allGone {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			a.logger.Debug("waitContainersRemoved: timed out waiting for reap", zap.Strings("containers", names))
+			return
+		case <-ticker.C:
+		}
+	}
 }
 
 // forceRemoveContainerByName removes a container by name, ignoring the
@@ -584,7 +629,7 @@ func (a *App) run(ctx context.Context) models.AppError {
 	userCmd := a.cmd
 
 	if a.kind == utils.DockerCompose {
-		defer a.composeDown()
+		defer a.ComposeDown()
 	}
 
 	if utils.FindDockerCmd(a.cmd) == utils.DockerRun {

--- a/pkg/platform/http/agent.go
+++ b/pkg/platform/http/agent.go
@@ -1316,6 +1316,21 @@ func (a *AgentClient) getApp() (*app.App, error) {
 	return h, nil
 }
 
+// ComposeDownOnSetupFailure tears down the managed docker-compose stack so a
+// retry after a per-test-set setup failure (e.g. agent-readiness timeout) does
+// not hit a "container name already in use" conflict from the dependency
+// containers/network left behind. No-op when there is no managed app or it is
+// not a compose app (App.ComposeDown self-guards on kind == DockerCompose).
+func (a *AgentClient) ComposeDownOnSetupFailure(_ context.Context) error {
+	ap, err := a.getApp()
+	if err != nil {
+		a.logger.Debug("ComposeDownOnSetupFailure: no managed app to tear down")
+		return nil
+	}
+	ap.ComposeDown()
+	return nil
+}
+
 func (a *AgentClient) startInDocker(ctx context.Context, logger *zap.Logger, opts models.SetupOptions) error {
 	keployAlias, err := kdocker.GetKeployDockerAlias(ctx, logger, &config.Config{
 		InstallationID: a.conf.InstallationID,

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -457,7 +457,21 @@ func (r *Replayer) Start(ctx context.Context) error {
 	// unstarted), and the per-test-set waitForAppReady skip below
 	// stays armed only when the one-shot spawn actually fired.
 	// Single computed predicate so all three gates move together.
-	effectiveKeepAlive := r.config.Test.KeepAppAlive && r.instrument && cmdType != utils.Empty
+	//
+	// Docker-compose replay reuses the stack across test-sets BY DEFAULT (when
+	// mocking is on): otherwise keploy tears down + recreates the whole
+	// agent+app+network+volumes for every test-set, multiplying docker-daemon
+	// create/destroy churn N-fold and re-paying a per-test-set agent-readiness
+	// window — under loaded CI that churn is what blows past the readiness
+	// timeout. The agent is reused safely: each test-set's mocks are re-scoped
+	// in-band per set (MockOutgoing→ResetForReplaySession, StoreMocks,
+	// SendMockFilterParamsToAgent), the same contract the runner already relies
+	// on. Gated on Mocking so a replay against a real (unmocked) dependency —
+	// where surviving app state across the boundary could change expected
+	// before-state — still restarts per test-set. An explicit --keep-app-alive
+	// keeps working unchanged (OR can only widen).
+	composeReuse := cmdType == utils.DockerCompose && r.config.Test.Mocking
+	effectiveKeepAlive := (r.config.Test.KeepAppAlive || composeReuse) && r.instrument && cmdType != utils.Empty
 	if effectiveKeepAlive {
 		g.Go(func() error {
 			defer utils.Recover(r.logger)
@@ -1142,19 +1156,33 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			return nil
 		})
 
-		agentCtx, cancel := context.WithTimeout(runTestSetCtx, 120*time.Second)
-		defer cancel()
+		// When the stack is reused across test-sets (serveTest), the agent is
+		// started once and stays healthy — only the first test-set needs to wait
+		// for readiness. Re-paying a 120s window per test-set is dead time where a
+		// transient daemon stall can land. Mirrors the waitForAppReady gating.
+		if !serveTest || r.isFirstTestSet {
+			agentCtx, cancel := context.WithTimeout(runTestSetCtx, 120*time.Second)
+			defer cancel()
 
-		agentReadyCh := make(chan bool, 1)
-		go pkg.AgentHealthTicker(agentCtx, r.logger, string(r.config.Agent.AgentURI), agentReadyCh, 1*time.Second)
+			agentReadyCh := make(chan bool, 1)
+			go pkg.AgentHealthTicker(agentCtx, r.logger, string(r.config.Agent.AgentURI), agentReadyCh, 1*time.Second)
 
-		select {
-		case <-runTestSetCtx.Done():
-			// Parent context cancelled (user pressed Ctrl+C)
-			return models.TestSetStatusUserAbort, runTestSetCtx.Err()
-		case <-agentCtx.Done():
-			return models.TestSetStatusFailed, fmt.Errorf("keploy-agent did not become ready in time")
-		case <-agentReadyCh:
+			select {
+			case <-runTestSetCtx.Done():
+				// Parent context cancelled (user pressed Ctrl+C)
+				return models.TestSetStatusUserAbort, runTestSetCtx.Err()
+			case <-agentCtx.Done():
+				// Tear down the compose stack we already created before returning,
+				// so a retry's `compose up` doesn't hit "container name already in
+				// use" — the readiness timeout otherwise leaves the dependency
+				// containers + project network behind. Fresh ctx since
+				// runTestSetCtx is being torn down; composeDown bounds itself.
+				if downErr := r.instrumentation.ComposeDownOnSetupFailure(context.Background()); downErr != nil {
+					r.logger.Debug("composeDown after agent-ready timeout failed", zap.Error(downErr))
+				}
+				return models.TestSetStatusFailed, fmt.Errorf("keploy-agent did not become ready in time")
+			case <-agentReadyCh:
+			}
 		}
 
 		// In case of Docker Compose : since for every test set the agent and application are restarted, hence each test set can be considered as an indicidual test run

--- a/pkg/service/replay/service.go
+++ b/pkg/service/replay/service.go
@@ -34,6 +34,11 @@ type Instrumentation interface {
 	// NotifyGracefulShutdown notifies the agent that the application is shutting down gracefully.
 	// When this is called, connection errors will be logged as debug instead of error.
 	NotifyGracefulShutdown(ctx context.Context) error
+	// ComposeDownOnSetupFailure tears down the docker-compose stack (agent + app
+	// + dependency containers + project network) when per-test-set setup fails
+	// (e.g. agent-readiness timeout), so a retry's `compose up` does not hit a
+	// "container name already in use" conflict. No-op for non-compose apps.
+	ComposeDownOnSetupFailure(ctx context.Context) error
 }
 
 type Service interface {


### PR DESCRIPTION
> Stacked on #4291 (base = `fix/replay-app-run-drain-bound`). #4291 bounds the app-run teardown wait; this PR relocates the app-run goroutine to the outer errgroup, so it depends on that bound. Rebase onto main once #4291 merges.

## Describe the changes that are made
In docker-compose replay, keploy restarts the **whole stack (agent + app + network + volumes) for every test-set**, multiplying docker-daemon create/destroy churn N-fold and re-paying a per-test-set agent-readiness window. Under loaded CI that self-generated churn is what blows past the 120s readiness timeout — the agent container *and its sibling app/db containers* freeze at `Creating` because the daemon can't instantiate them in the window.

This reduces keploy's own contribution to that load and hardens the boundary:

1. **Reuse the stack across test-sets by default in compose mode** (gated on `Mocking`), via the existing keep-app-alive path: **one `compose up`/down per lane** instead of once per test-set. Each test-set's mocks are still re-scoped **in-band per set** (`MockOutgoing` → `ResetForReplaySession`, `StoreMocks`, `SendMockFilterParamsToAgent`) — the same contract the runner already relies on — so isolation holds while the agent survives the boundary. Gated on `Mocking` so a replay against a real (unmocked) dependency still restarts per test-set.
2. **Gate the per-test-set 120s agent-ready wait to the first test-set** when the stack is reused (the agent is already healthy afterwards).
3. **Tear down the stack on an agent-ready timeout** before returning, so a retry's `compose up` doesn't hit `container name already in use` from the dependency containers/network the timeout otherwise left behind.
4. **Bounded poll-until-removed in `ComposeDown`** so the next up can't race the daemon's async reap (defense at the now-rare teardown boundary).

Native / docker-run / non-compose / explicit `--keep-app-alive` paths are unchanged.

**Correctness note (mock isolation across a reused agent):** per test-set the mock pool is fully replaced (`StoreMocks`), the windowing recomputed (`SendMockFilterParamsToAgent`), and per-connID pools reset (`ResetForReplaySession`) — even though the agent process + the app's TCP connections survive. Validated by the multi-test-set compose lanes in CI.

## Links & References
**Closes:** NA
### 🔗 Related PRs
- #4291 (base — bounds the app-run teardown wait)
### 🐞 Related Issues
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 🔥 Performance Improvements
- [ ] 🧑‍💻 Code Refactor

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed (the existing multi-test-set docker-compose lanes — e.g. echo_sql — exercise stack reuse + per-test-set mock isolation)

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed
