### PR TITLE
fix(replay): fast compose teardown on cancel so the drain doesn't time out

### DIFF
--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -641,6 +641,48 @@ func (a *App) run(ctx context.Context) models.AppError {
 					warning := fmt.Sprintf("error sending SIGINT: %s", err)
 					a.logger.Debug(warning)
 				}
+
+				// Docker Compose teardown differs from a single `docker run`: the
+				// stack has several containers (the app, its dependencies, and the
+				// injected keploy-agent). The SIGINT above makes `docker compose up`
+				// stop them gracefully in the foreground, but the app container
+				// usually exits first — e.g. a Go server with no SIGTERM handler
+				// exits immediately on Go's default signal disposition — while the
+				// SLOWER services keep stopping, most notably the eBPF agent.
+				// `docker compose up` does not return until every service has
+				// stopped, and os/exec's WaitDelay then blocks the teardown for ~25s
+				// waiting on it. When the app is kept alive on the outer replay
+				// errgroup (compose + mocking), that teardown runs under
+				// utils.DrainErrGroup's 30s budget, so the overrun trips a spurious
+				// "teardown drain timed out … a goroutine is ignoring context
+				// cancellation" error and fails an otherwise-green run.
+				//
+				// So for compose: give the app a short grace to flush coverage during
+				// the graceful stop, then bring the WHOLE project down fast via
+				// ComposeDown (`docker compose down --timeout 1`) so `docker compose
+				// up` returns promptly instead of blocking on the slow agent. The
+				// run()-deferred ComposeDown then becomes an idempotent no-op.
+				if a.kind == utils.DockerCompose {
+					gracePeriod := 5
+					for i := 0; i < gracePeriod; i++ {
+						time.Sleep(1 * time.Second)
+						// `docker compose up` already returned (all services stopped).
+						if err := cmd.Process.Signal(syscall.Signal(0)); err != nil {
+							a.logger.Debug("docker compose process exited")
+							break
+						}
+						// App container has exited -> its coverage flush is done; no
+						// need to keep waiting on the slower sibling services.
+						if info, err := a.docker.ContainerInspect(context.Background(), a.container); err == nil &&
+							(info.State.Status == "exited" || info.State.Status == "dead") {
+							a.logger.Debug("app container stopped gracefully; tearing down the rest of the compose stack")
+							break
+						}
+					}
+					a.ComposeDown()
+					return utils.SendSignal(a.logger, -cmd.Process.Pid, syscall.SIGKILL)
+				}
+
 				gracePeriod := 5
 				for i := 0; i < gracePeriod; i++ {
 					time.Sleep(1 * time.Second)


### PR DESCRIPTION
## Describe the changes that are made
- In docker-compose mode, `cmdCancel` (the `keploy test/record` teardown hook) used to early-return as soon as the **app container** exited, leaving `docker compose up` to keep gracefully stopping the slower sibling services in the foreground — most notably the injected eBPF **keploy-agent**. `os/exec`'s 25s `WaitDelay` then blocked the teardown.
- Since #4293 the app is kept alive on the **outer** replay errgroup for compose + mocking, so its teardown now runs under `utils.DrainErrGroup`'s **30s** budget. The slow graceful stop overran that budget and emitted a spurious `ERROR teardown drain timed out after cancellation … a goroutine is ignoring context cancellation {"group":"replay"}`, failing **otherwise-green** runs.
- **Fix:** for docker-compose, give the app a short grace to flush coverage during the graceful stop, then bring the **whole project** down fast via `ComposeDown` (`docker compose down --timeout 1`) so `docker compose up` returns promptly instead of blocking on the slow agent. The single `docker run`/`docker start` path is unchanged; the `run()`-deferred `ComposeDown` becomes an idempotent no-op.

### Root cause (evidence)
- Tests pass `32/32` ("verified_green"), then the lane fails on the teardown `ERROR` (caught by the e2e script's `check_for_errors`).
- Regression bisects cleanly to the keep-alive-by-default change: the compose+mocking e2e lanes (memcached `go`/`java`/`node`/`python`) were green on the prior release and went red the moment the app moved onto the outer errgroup.
- Reproduced the mechanism with plain docker: `docker compose up` (foreground) + SIGINT with a slow-to-stop service = **~31s** to return, vs `docker compose down --timeout 1` = **~2s**.

## Links & References
**Closes:** NA (CI regression in the compose + mocking replay teardown)

### 🔗 Related PRs
- #4293, #4290, #4288 (the replay-lifecycle series this builds on)

## What type of PR is this? (check all applicable)
- [x] 🐞 Bug Fix

## Added e2e test pipeline?
- [x] 👍 yes — the existing compose + mocking e2e lanes (e.g. memcached `go`/`java`/`node`/`python`) exercise this teardown path and are the regression guard.

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes — run any docker-compose app under `keploy test -c "docker compose up" --container-name <svc>` with mocking enabled; teardown completes in seconds with no `teardown drain timed out` ERROR.

## Self Review done?
- [x] ✅ yes
