### PR TITLE
fix(replay): make record/replay robust under daemon contention (teardown + agent-readiness)

### DIFF
--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -305,6 +305,23 @@ func (a *App) RecentLogs(ctx context.Context) string {
 	return a.recentAppLogs(ctx)
 }
 
+// containerStopped reports whether the named container has exited/dead, using a
+// SHORT-deadline inspect. Teardown runs under the record/replay
+// utils.DrainErrGroup 30s budget, and under a contended docker daemon a single
+// ContainerInspect on context.Background() could block long enough to overrun
+// that budget — tripping a spurious "teardown drain timed out" error that fails
+// an otherwise-green run. Bounding the inspect keeps every teardown poll fast
+// regardless of daemon load.
+func (a *App) containerStopped(name string) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	info, err := a.docker.ContainerInspect(ctx, name)
+	if err != nil {
+		return false, err
+	}
+	return info.State.Status == "exited" || info.State.Status == "dead", nil
+}
+
 func (a *App) waitTillExit() {
 	timeout := time.NewTimer(30 * time.Second)
 	logTicker := time.NewTicker(1 * time.Second)
@@ -315,16 +332,13 @@ func (a *App) waitTillExit() {
 	for {
 		select {
 		case <-logTicker.C:
-			// Inspect the container status
-			containerJSON, err := a.docker.ContainerInspect(context.Background(), containerID)
+			// Inspect the container status (short-deadline; see containerStopped).
+			stopped, err := a.containerStopped(containerID)
 			if err != nil {
 				a.logger.Debug("failed to inspect container", zap.String("containerID", containerID), zap.Error(err))
 				return
 			}
-
-			a.logger.Debug("container status", zap.String("status", containerJSON.State.Status), zap.String("containerName", a.container))
-			// Check if container is stopped or dead
-			if containerJSON.State.Status == "exited" || containerJSON.State.Status == "dead" {
+			if stopped {
 				return
 			}
 		case <-timeout.C:
@@ -673,8 +687,7 @@ func (a *App) run(ctx context.Context) models.AppError {
 						}
 						// App container has exited -> its coverage flush is done; no
 						// need to keep waiting on the slower sibling services.
-						if info, err := a.docker.ContainerInspect(context.Background(), a.container); err == nil &&
-							(info.State.Status == "exited" || info.State.Status == "dead") {
+						if stopped, err := a.containerStopped(a.container); err == nil && stopped {
 							a.logger.Debug("app container stopped gracefully; tearing down the rest of the compose stack")
 							break
 						}
@@ -695,8 +708,7 @@ func (a *App) run(ctx context.Context) models.AppError {
 
 					// Check the actual container status via Docker API
 					// This handles cases where 'docker run' is dead but container is alive
-					info, err := a.docker.ContainerInspect(context.Background(), a.container)
-					if err == nil && (info.State.Status == "exited" || info.State.Status == "dead") {
+					if stopped, err := a.containerStopped(a.container); err == nil && stopped {
 						a.logger.Debug("container stopped gracefully")
 						return nil
 					}
@@ -706,8 +718,11 @@ func (a *App) run(ctx context.Context) models.AppError {
 				// We tell the Docker Daemon explicitly to kill this container.
 				a.logger.Debug("container did not stop gracefully, killing it forcefully", zap.String("containerID", a.container))
 
-				// "SIGKILL" string is standard for Docker API to force kill
-				err = a.docker.ContainerKill(context.Background(), a.container, "SIGKILL")
+				// "SIGKILL" string is standard for Docker API to force kill. Bound it
+				// so a contended daemon can't block teardown past the drain budget.
+				killCtx, killCancel := context.WithTimeout(context.Background(), 3*time.Second)
+				err = a.docker.ContainerKill(killCtx, a.container, "SIGKILL")
+				killCancel()
 				if err != nil {
 					warning := fmt.Sprintf("error killing container: %s", err)
 					a.logger.Debug(warning)

--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -510,6 +510,12 @@ func sanitizeAppLogLine(line string) string {
 // replay loop can tear the stack down on a per-test-set setup failure
 // (agent-readiness timeout) before a retry, not only via run()'s defer.
 func (a *App) ComposeDown() {
+	// Bound `docker compose down` so a severely contended docker daemon (all CI
+	// lanes up at once) cannot block teardown — which runs under the record/replay
+	// DrainErrGroup budget — indefinitely. Best-effort: if it is cut short, the
+	// force-remove below and the next lane's cleanup reclaim anything left.
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
+	defer cancel()
 	var downCmd *exec.Cmd
 
 	switch {
@@ -528,12 +534,12 @@ func (a *App) ComposeDown() {
 		// collided with ("container name already in use" -> dependency
 		// keploy-agent failed to start -> test-set abandoned, no report).
 		args = append(args, "down", "--timeout", "1")
-		downCmd = exec.Command("docker", args...)
+		downCmd = exec.CommandContext(ctx, "docker", args...)
 		downCmd.Stdin = bytes.NewReader(a.composeContent)
 	case a.composeFile != "":
 		a.logger.Debug("Running docker compose down to clean up containers and networks",
 			zap.String("composeFile", a.composeFile))
-		downCmd = exec.Command("docker", "compose", "-f", a.composeFile, "down", "--timeout", "1")
+		downCmd = exec.CommandContext(ctx, "docker", "compose", "-f", a.composeFile, "down", "--timeout", "1")
 	default:
 		return
 	}
@@ -611,7 +617,10 @@ func (a *App) forceRemoveContainerByName(name string) {
 	if name == "" {
 		return
 	}
-	if output, err := exec.Command("docker", "rm", "-f", name).CombinedOutput(); err != nil {
+	// Bounded so a contended daemon can't block teardown on the force-remove.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if output, err := exec.CommandContext(ctx, "docker", "rm", "-f", name).CombinedOutput(); err != nil {
 		a.logger.Debug("force-remove container finished (may already be gone)",
 			zap.String("container", name), zap.Error(err), zap.String("output", string(output)))
 	}

--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -652,6 +652,16 @@ func (a *App) run(ctx context.Context) models.AppError {
 
 	if utils.FindDockerCmd(a.cmd) == utils.DockerRun {
 		userCmd = utils.EnsureRmBeforeName(userCmd)
+		// Clear any container left over from a prior run with the same --name
+		// before starting. --rm removes the container on exit, but under heavy
+		// docker-daemon contention that reap can lag past the next
+		// `docker run --name`, so a re-run (e.g. dedup record -> replay) hits
+		// "Conflict. The container name is already in use" (docker exit 125).
+		// Force-removing first is bounded + best-effort (a no-op when nothing is
+		// lingering), so the re-run never collides with a still-reaping container.
+		if a.container != "" {
+			a.forceRemoveContainerByName(a.container)
+		}
 	}
 
 	// Define the function to cancel the command

--- a/pkg/platform/http/agent.go
+++ b/pkg/platform/http/agent.go
@@ -1249,7 +1249,13 @@ func (a *AgentClient) Setup(ctx context.Context, cmd string, opts models.SetupOp
 		}
 		a.logger.Debug("Agent is now running, proceeding with setup")
 
-		agentCtx, cancel := context.WithTimeout(ctx, 60*time.Second) // we will wait for 1 minute for the agent to get ready
+		// Wait up to ~the agent's own compose healthcheck readiness budget (retries
+		// 60 x 5s + 10s start_period ≈ 310s). Under heavy CI daemon contention the
+		// agent (eBPF load + container start) can take well over a minute to become
+		// ready; a 60s wait gave up prematurely and tore the stack down with
+		// "keploy-agent did not become ready in time" on an infra-bringup that
+		// would have succeeded.
+		agentCtx, cancel := context.WithTimeout(ctx, 300*time.Second)
 		defer cancel()
 
 		agentReadyCh := make(chan bool, 1)

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -196,7 +196,13 @@ func (r *Recorder) Start(ctx context.Context) error {
 		// cancel() must not hang teardown forever (which would swallow SIGINT and
 		// keep the process alive until an external SIGKILL). See utils.DrainErrGroup.
 		runAppCtxCancel()
-		if err := utils.DrainErrGroup(r.logger, "record-app", runAppErrGrp, 30*time.Second); err != nil {
+		// 120s (not 30s): the app teardown is `docker compose up` returning after a
+		// SIGINT, which under a heavily contended CI daemon completes slowly but DOES
+		// complete (the run already succeeded). A tight budget force-fails those
+		// otherwise-green runs; the teardown's own ops are individually bounded
+		// (ComposeDown, container inspects/kill), so this only adds headroom for the
+		// genuinely-slow-under-load case, not for a truly stuck goroutine.
+		if err := utils.DrainErrGroup(r.logger, "record-app", runAppErrGrp, 120*time.Second); err != nil {
 			utils.LogError(r.logger, err, "failed to stop application")
 		}
 

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -303,7 +303,12 @@ func (r *Recorder) Start(ctx context.Context) error {
 			return nil
 		})
 
-		agentCtx, cancel := context.WithTimeout(ctx, 120*time.Second)
+		// Wait up to ~the agent's compose healthcheck readiness budget (~310s), not
+		// 120s: under heavy CI daemon contention the agent can take longer than two
+		// minutes to become ready, and giving up early tore the stack down with
+		// "keploy-agent did not become ready in time" on an infra-bringup that would
+		// have succeeded.
+		agentCtx, cancel := context.WithTimeout(ctx, 300*time.Second)
 		defer cancel()
 
 		agentReadyCh := make(chan bool, 1)

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1170,7 +1170,12 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		// for readiness. Re-paying a 120s window per test-set is dead time where a
 		// transient daemon stall can land. Mirrors the waitForAppReady gating.
 		if !serveTest || r.isFirstTestSet {
-			agentCtx, cancel := context.WithTimeout(runTestSetCtx, 120*time.Second)
+			// Wait up to ~the agent's compose healthcheck readiness budget (~310s),
+			// not 120s: under heavy CI daemon contention the agent can take longer
+			// than two minutes to become ready; giving up early tore the stack down
+			// with "keploy-agent did not become ready in time" on an infra-bringup
+			// that would have succeeded.
+			agentCtx, cancel := context.WithTimeout(runTestSetCtx, 300*time.Second)
 			defer cancel()
 
 			agentReadyCh := make(chan bool, 1)

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -318,7 +318,13 @@ func (r *Replayer) Start(ctx context.Context) error {
 		// not observe cancel() must not be able to block this teardown forever, or
 		// SIGINT (which runs through this same defer) is swallowed and the process
 		// hangs until an external SIGKILL. See utils.DrainErrGroup.
-		if err := utils.DrainErrGroup(r.logger, "replay", g, 30*time.Second); err != nil {
+		// 120s (not 30s): the app teardown is `docker compose up` returning after a
+		// SIGINT, which under a heavily contended CI daemon completes slowly but DOES
+		// complete (the run already succeeded). A tight budget force-fails those
+		// otherwise-green runs; the teardown's own ops are individually bounded
+		// (ComposeDown, container inspects/kill), so this only adds headroom for the
+		// genuinely-slow-under-load case, not for a truly stuck goroutine.
+		if err := utils.DrainErrGroup(r.logger, "replay", g, 120*time.Second); err != nil {
 			utils.LogError(r.logger, err, "failed to stop replaying")
 		}
 
@@ -954,7 +960,10 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		}
 		runTestSetCtxCancel()
 		// Bounded drain so a wedged per-test-set goroutine can't hang teardown/SIGINT.
-		if err := utils.DrainErrGroup(r.logger, "replay-testset", runTestSetErrGrp, 30*time.Second); err != nil {
+		// 120s: the per-test-set app teardown (compose down) is slow-but-completing
+		// under a contended daemon; its ops are individually bounded, so this is
+		// headroom for load, not for a stuck goroutine.
+		if err := utils.DrainErrGroup(r.logger, "replay-testset", runTestSetErrGrp, 120*time.Second); err != nil {
 			utils.LogError(r.logger, err, "error in testLoopErrGrp")
 		}
 		close(exitLoopChan)

--- a/utils/drain.go
+++ b/utils/drain.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"runtime"
 	"time"
 
 	"go.uber.org/zap"
@@ -21,9 +22,12 @@ import (
 // hung ~50 min despite a 15-min `timeout -s INT`).
 //
 // Bounding the drain guarantees the process exits promptly after cancellation.
-// On timeout it logs (so the offending goroutine is discoverable) and returns
-// nil; the leaked goroutine is reaped when the process exits. In the normal
-// case the goroutines drain in well under the timeout, so this is a no-op.
+// On timeout it dumps every goroutine's stack (so the goroutine that ignored
+// cancellation is actually discoverable: a stack parked in a docker/daemon
+// syscall or socket read points to host IO contention, while one parked on a Go
+// channel/mutex/select with no IO points to a missing-cancel code bug) and
+// returns nil; the leaked goroutine is reaped when the process exits. In the
+// normal case the goroutines drain in well under the timeout, so this is a no-op.
 func DrainErrGroup(logger *zap.Logger, name string, g *errgroup.Group, timeout time.Duration) error {
 	done := make(chan error, 1)
 	go func() { done <- g.Wait() }()
@@ -33,7 +37,22 @@ func DrainErrGroup(logger *zap.Logger, name string, g *errgroup.Group, timeout t
 	case <-time.After(timeout):
 		logger.Error("teardown drain timed out after cancellation; forcing shutdown so stop/SIGINT isn't swallowed — a goroutine is ignoring context cancellation",
 			zap.String("group", name),
-			zap.Duration("timeout", timeout))
+			zap.Duration("timeout", timeout),
+			zap.ByteString("goroutine_dump", allGoroutineStacks()))
 		return nil
 	}
+}
+
+// allGoroutineStacks returns the stack traces of all goroutines, growing the
+// buffer until the dump fits (capped at 16 MiB) so the offending goroutine is
+// never truncated away.
+func allGoroutineStacks() []byte {
+	for size := 1 << 20; size <= 1<<24; size *= 2 {
+		buf := make([]byte, size)
+		if n := runtime.Stack(buf, true); n < size {
+			return buf[:n]
+		}
+	}
+	buf := make([]byte, 1<<24)
+	return buf[:runtime.Stack(buf, true)]
 }


### PR DESCRIPTION
Follow-up to #4294. Under heavy docker-daemon contention (many CI lanes up at once) the record/replay teardown still intermittently overran the 30s `utils.DrainErrGroup` budget and tripped a spurious "teardown drain timed out … goroutine ignoring context cancellation" error that failed otherwise-green runs (tests passed, then the lane failed on teardown). The run always succeeds first, so the teardown is slow-but-completing under load, not stuck.

This makes every teardown op bounded AND gives the slow-under-load case adequate headroom:
- `containerStopped()`: a short-deadline (3s) `ContainerInspect`, used for every teardown status check (`waitTillExit`, the compose + docker-run grace loops) instead of `context.Background()`; also bounds the force `ContainerKill`.
- `ComposeDown`: bound `docker compose down` and `docker rm -f` with context timeouts (25s / 10s) so a contended daemon cannot block teardown.
- Widen the app-teardown drains (`record-app`, `replay`, `replay-testset`) 30s -> 120s. Since each op is individually bounded, this is headroom for genuinely-slow-under-load teardown, not cover for a stuck goroutine; the drain still returns as soon as teardown completes.