### PR TITLE
fix(app): bound docker teardown calls so the drain doesn't time out under load

### DIFF
--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -306,7 +307,11 @@ func (a *App) RecentLogs(ctx context.Context) string {
 }
 
 func (a *App) waitTillExit() {
-	timeout := time.NewTimer(30 * time.Second)
+	// Bounded overall (waitTillExitBudget) AND per-inspect (dockerInspectBudget)
+	// so a saturated daemon can't wedge this on the teardown goroutine — an
+	// unbounded ContainerInspect here would also block the select so even the
+	// overall timeout couldn't fire. Only reached on the non-compose docker path.
+	timeout := time.NewTimer(waitTillExitBudget)
 	logTicker := time.NewTicker(1 * time.Second)
 	defer logTicker.Stop()
 	defer timeout.Stop()
@@ -315,8 +320,10 @@ func (a *App) waitTillExit() {
 	for {
 		select {
 		case <-logTicker.C:
-			// Inspect the container status
-			containerJSON, err := a.docker.ContainerInspect(context.Background(), containerID)
+			// Inspect the container status (bounded; see the note above)
+			ictx, icancel := context.WithTimeout(context.Background(), dockerInspectBudget)
+			containerJSON, err := a.docker.ContainerInspect(ictx, containerID)
+			icancel()
 			if err != nil {
 				a.logger.Debug("failed to inspect container", zap.String("containerID", containerID), zap.Error(err))
 				return
@@ -496,6 +503,21 @@ func sanitizeAppLogLine(line string) string {
 // replay loop can tear the stack down on a per-test-set setup failure
 // (agent-readiness timeout) before a retry, not only via run()'s defer.
 func (a *App) ComposeDown() {
+	// Bound each docker CLI call below on its OWN deadline so a daemon saturated
+	// by a high-stress CI run cannot wedge the teardown. The record/replay
+	// teardown drains the app-runner goroutine under utils.DrainErrGroup's 30s
+	// budget; an UNBOUNDED `docker compose down` / `docker rm -f` blocked that
+	// goroutine well past 30s, tripping a spurious "teardown drain timed out … a
+	// goroutine is ignoring context cancellation" error on an otherwise-green
+	// run. (`--timeout 1` only bounds compose's per-container *stop* grace, not
+	// the `docker compose down` process itself.) Per-call budgets — not one
+	// shared deadline — so the force-remove + reap barrier still free the
+	// agent/app container names even when the down consumes its full budget
+	// (that name-freeing is exactly what avoids "container name already in use"
+	// on the next compose up).
+	downCtx, downCancel := context.WithTimeout(context.Background(), composeDownCmdBudget)
+	defer downCancel()
+
 	var downCmd *exec.Cmd
 
 	switch {
@@ -514,18 +536,18 @@ func (a *App) ComposeDown() {
 		// collided with ("container name already in use" -> dependency
 		// keploy-agent failed to start -> test-set abandoned, no report).
 		args = append(args, "down", "--timeout", "1")
-		downCmd = exec.Command("docker", args...)
+		downCmd = exec.CommandContext(downCtx, "docker", args...)
 		downCmd.Stdin = bytes.NewReader(a.composeContent)
 	case a.composeFile != "":
 		a.logger.Debug("Running docker compose down to clean up containers and networks",
 			zap.String("composeFile", a.composeFile))
-		downCmd = exec.Command("docker", "compose", "-f", a.composeFile, "down", "--timeout", "1")
+		downCmd = exec.CommandContext(downCtx, "docker", "compose", "-f", a.composeFile, "down", "--timeout", "1")
 	default:
 		return
 	}
 
 	if output, err := downCmd.CombinedOutput(); err != nil {
-		a.logger.Debug("docker compose down finished with error (may be expected if containers already removed)",
+		a.logger.Debug("docker compose down finished with error (may be expected if containers already removed, or the bounded teardown deadline elapsed under load)",
 			zap.Error(err), zap.String("output", string(output)))
 	}
 
@@ -553,14 +575,35 @@ func (a *App) ComposeDown() {
 	// --timeout 1 removed. Largely a no-op once the stack is reused across
 	// test-sets (one down per lane), but defends the first/last and
 	// non-keep-alive boundaries.
-	a.waitContainersRemoved([]string{a.keployContainer, a.container}, 5*time.Second)
+	a.waitContainersRemoved([]string{a.keployContainer, a.container}, reapBarrierBudget)
 }
+
+// Teardown budgets. The record/replay teardown drains the app-runner goroutine
+// under utils.DrainErrGroup's 30s budget (pkg/service/record/record.go,
+// pkg/service/replay/replay.go). Every docker CLI call on the teardown path is
+// bounded so the goroutine returns well inside 30s even when the daemon is
+// saturated. Worst-case compose teardown (run()'s cmdCancel): the grace loop
+// (graceBudget + up to one last-iteration overshoot of sleep+inspect ≈ 2.5s,
+// since the deadline is checked at the loop top) + composeDownCmdBudget +
+// 2×forceRemoveBudget + reapBarrierBudget ≈ (5+2.5) + 8 + 2×2 + 3 ≈ 22.5s;
+// waitTillExit is then skipped on the compose path and the ctx-cancelled run
+// returns before recentAppLogs — comfortably under 30s.
+const (
+	composeDownCmdBudget = 8 * time.Second // `docker compose down`
+	forceRemoveBudget    = 2 * time.Second // each `docker rm -f`
+	reapBarrierBudget    = 3 * time.Second // waitContainersRemoved poll
+	graceBudget          = 5 * time.Second // cmdCancel coverage-flush grace
+	waitTillExitBudget   = 8 * time.Second // non-compose post-cancel container wait
+	dockerInspectBudget  = 2 * time.Second // any single teardown ContainerInspect
+)
 
 // waitContainersRemoved polls until the named containers no longer exist (or the
 // budget elapses), converting the daemon's async reap into a bounded synchronous
 // barrier so the next compose up cannot race a still-removing same-named
 // container.
 func (a *App) waitContainersRemoved(names []string, budget time.Duration) {
+	// Bounded on its own deadline so the reap barrier can never push ComposeDown
+	// past the teardown budget.
 	ctx, cancel := context.WithTimeout(context.Background(), budget)
 	defer cancel()
 	ticker := time.NewTicker(100 * time.Millisecond)
@@ -597,8 +640,10 @@ func (a *App) forceRemoveContainerByName(name string) {
 	if name == "" {
 		return
 	}
-	if output, err := exec.Command("docker", "rm", "-f", name).CombinedOutput(); err != nil {
-		a.logger.Debug("force-remove container finished (may already be gone)",
+	ctx, cancel := context.WithTimeout(context.Background(), forceRemoveBudget)
+	defer cancel()
+	if output, err := exec.CommandContext(ctx, "docker", "rm", "-f", name).CombinedOutput(); err != nil {
+		a.logger.Debug("force-remove container finished (may already be gone, or the bounded teardown deadline elapsed)",
 			zap.String("container", name), zap.Error(err), zap.String("output", string(output)))
 	}
 }
@@ -623,8 +668,17 @@ func extractProjectFlags(cmd string) []string {
 func (a *App) run(ctx context.Context) models.AppError {
 	userCmd := a.cmd
 
+	// ComposeDown can fire on two paths within a single run() — cmdCancel below
+	// (SIGINT/teardown) and this deferred call (normal exit / the
+	// --abort-on-container-exit path). Collapse them with a run-local Once so a
+	// bounded ComposeDown never runs twice and risks overrunning the drain
+	// budget; whichever path fires first does the teardown, the other is a
+	// no-op. External callers (the replay per-test-set loop) invoke
+	// a.ComposeDown directly and are unaffected by this run-local guard.
+	var downOnce sync.Once
+	composeDown := func() { downOnce.Do(a.ComposeDown) }
 	if a.kind == utils.DockerCompose {
-		defer a.ComposeDown()
+		defer composeDown()
 	}
 
 	if utils.FindDockerCmd(a.cmd) == utils.DockerRun {
@@ -663,28 +717,35 @@ func (a *App) run(ctx context.Context) models.AppError {
 				// up` returns promptly instead of blocking on the slow agent. The
 				// run()-deferred ComposeDown then becomes an idempotent no-op.
 				if a.kind == utils.DockerCompose {
-					gracePeriod := 5
-					for i := 0; i < gracePeriod; i++ {
-						time.Sleep(1 * time.Second)
+					// Wall-clock-bounded grace (not iteration×inspect): a saturated
+					// daemon must not let the per-tick inspect sum past the teardown
+					// budget. Break as soon as the compose process or the app
+					// container has exited (coverage flush done).
+					graceDeadline := time.Now().Add(graceBudget)
+					for time.Now().Before(graceDeadline) {
+						time.Sleep(500 * time.Millisecond)
 						// `docker compose up` already returned (all services stopped).
 						if err := cmd.Process.Signal(syscall.Signal(0)); err != nil {
 							a.logger.Debug("docker compose process exited")
 							break
 						}
 						// App container has exited -> its coverage flush is done; no
-						// need to keep waiting on the slower sibling services.
-						if info, err := a.docker.ContainerInspect(context.Background(), a.container); err == nil &&
-							(info.State.Status == "exited" || info.State.Status == "dead") {
+						// need to keep waiting on the slower sibling services. Bound the
+						// inspect so a saturated daemon can't stall the grace loop.
+						ictx, icancel := context.WithTimeout(context.Background(), dockerInspectBudget)
+						info, ierr := a.docker.ContainerInspect(ictx, a.container)
+						icancel()
+						if ierr == nil && (info.State.Status == "exited" || info.State.Status == "dead") {
 							a.logger.Debug("app container stopped gracefully; tearing down the rest of the compose stack")
 							break
 						}
 					}
-					a.ComposeDown()
+					composeDown()
 					return utils.SendSignal(a.logger, -cmd.Process.Pid, syscall.SIGKILL)
 				}
 
-				gracePeriod := 5
-				for i := 0; i < gracePeriod; i++ {
+				graceDeadline := time.Now().Add(graceBudget)
+				for time.Now().Before(graceDeadline) {
 					time.Sleep(1 * time.Second)
 
 					// Check if the 'docker run' command has exited
@@ -694,8 +755,11 @@ func (a *App) run(ctx context.Context) models.AppError {
 					}
 
 					// Check the actual container status via Docker API
-					// This handles cases where 'docker run' is dead but container is alive
-					info, err := a.docker.ContainerInspect(context.Background(), a.container)
+					// This handles cases where 'docker run' is dead but container is alive.
+					// Bound the inspect so a saturated daemon can't stall the grace loop.
+					ictx, icancel := context.WithTimeout(context.Background(), dockerInspectBudget)
+					info, err := a.docker.ContainerInspect(ictx, a.container)
+					icancel()
 					if err == nil && (info.State.Status == "exited" || info.State.Status == "dead") {
 						a.logger.Debug("container stopped gracefully")
 						return nil
@@ -706,8 +770,12 @@ func (a *App) run(ctx context.Context) models.AppError {
 				// We tell the Docker Daemon explicitly to kill this container.
 				a.logger.Debug("container did not stop gracefully, killing it forcefully", zap.String("containerID", a.container))
 
-				// "SIGKILL" string is standard for Docker API to force kill
-				err = a.docker.ContainerKill(context.Background(), a.container, "SIGKILL")
+				// "SIGKILL" string is standard for Docker API to force kill.
+				// Bounded so a saturated daemon can't wedge the teardown past the
+				// record/replay drain budget.
+				killCtx, killCancel := context.WithTimeout(context.Background(), 5*time.Second)
+				err = a.docker.ContainerKill(killCtx, a.container, "SIGKILL")
+				killCancel()
 				if err != nil {
 					warning := fmt.Sprintf("error killing container: %s", err)
 					a.logger.Debug(warning)
@@ -731,7 +799,11 @@ func (a *App) run(ctx context.Context) models.AppError {
 		}
 	}
 
-	if utils.IsDockerCmd(a.kind) {
+	// Skip on the compose path: cmdCancel's ComposeDown already brought the
+	// whole stack down and waitContainersRemoved confirmed the app/agent
+	// containers are gone, so waiting again here would only add an inspect loop
+	// to the teardown and risk overrunning the drain budget.
+	if utils.IsDockerCmd(a.kind) && a.kind != utils.DockerCompose {
 		a.waitTillExit()
 	}
 


### PR DESCRIPTION
## Problem

In high-stress CI (a docker daemon saturated by many concurrent lanes), keploy record/replay of a docker-compose app intermittently fails with:

```
ERROR  teardown drain timed out after cancellation; forcing shutdown so stop/SIGINT isn't swallowed — a goroutine is ignoring context cancellation  {"group": "record-app"}
```

The record itself **succeeds** (test cases are captured); the run fails only because this `Error`-level line trips error-scanning CI gates. Root cause: the teardown path makes **unbounded** docker CLI calls. `ComposeDown` runs `docker compose down` and `docker rm -f`, and `run()`'s `cmdCancel` grace loop runs `ContainerInspect`/`ContainerKill`, all against `context.Background()`. `--timeout 1` only bounds compose's per-container *stop* grace — not the `docker compose down` **process** (daemon API calls, network/volume removal). Under daemon contention any of these blocks the `record-app` runner goroutine past `utils.DrainErrGroup`'s 30s budget.

This completes the fast-teardown work from #4294 (which made `docker compose up` return promptly but left `ComposeDown` itself unbounded).

## Fix

- `ComposeDown` bounds all its docker CLI calls under one `composeDownBudget` (20s) deadline (compose down + force-remove + reap barrier). On deadline the down is killed; the force-remove-by-name still frees the agent/app container names for the next compose up.
- `forceRemoveContainerByName` and `waitContainersRemoved` take the bounded `ctx`.
- `cmdCancel` and the deferred `ComposeDown` are collapsed via a run-local `sync.Once`, so a bounded `ComposeDown` never runs twice; the app-runner goroutine returns well inside the 30s drain budget (grace ~5s + down ≤20s).
- The grace-loop `ContainerInspect` and the force-kill `ContainerKill` are bounded too, so a stalled daemon can't stretch the grace window.

No behavior change on an idle daemon (the calls finish well under the budgets); the bounds only engage under contention, where they convert an unbounded hang into a prompt, clean teardown.

## Testing

`go build ./...` + `go vet` clean. Validated end-to-end against the enterprise high-load compose lanes (memcached + Java-TLS) that reproduce the saturated-daemon teardown — those are the conditions that surfaced the spurious drain-timeout error.