### PR TITLE
fix(agent): align agent-ready wait with the agent's healthcheck budget (KEPLOY_AGENT_READY_TIMEOUT)

### DIFF
--- a/pkg/platform/http/agent.go
+++ b/pkg/platform/http/agent.go
@@ -37,7 +37,6 @@ import (
 )
 
 const (
-	agentReadyTimeout       = 2 * time.Minute
 	agentReadyRetryInterval = 2 * time.Second
 )
 
@@ -1249,7 +1248,12 @@ func (a *AgentClient) Setup(ctx context.Context, cmd string, opts models.SetupOp
 		}
 		a.logger.Debug("Agent is now running, proceeding with setup")
 
-		agentCtx, cancel := context.WithTimeout(ctx, 60*time.Second) // we will wait for 1 minute for the agent to get ready
+		// Wait up to the agent's own healthcheck budget for it to become ready.
+		// Under heavy CI docker-daemon contention the agent container can take
+		// well over a minute just to start (observed: a local-image `docker run`
+		// taking 126s), so a 60s wait gave up prematurely and tore down a
+		// bring-up that would have succeeded. Overridable via KEPLOY_AGENT_READY_TIMEOUT.
+		agentCtx, cancel := context.WithTimeout(ctx, pkg.AgentReadyTimeout())
 		defer cancel()
 
 		agentReadyCh := make(chan bool, 1)
@@ -1546,7 +1550,8 @@ func (a *AgentClient) NotifyGracefulShutdown(ctx context.Context) error {
 }
 
 func (a *AgentClient) MakeAgentReadyForDockerCompose(ctx context.Context) error {
-	ctx, cancel := context.WithTimeout(ctx, agentReadyTimeout)
+	// Aligned with the agent's own healthcheck budget; see pkg.AgentReadyTimeout.
+	ctx, cancel := context.WithTimeout(ctx, pkg.AgentReadyTimeout())
 	defer cancel()
 
 	ticker := time.NewTicker(agentReadyRetryInterval)

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -309,7 +309,10 @@ func (r *Recorder) Start(ctx context.Context) error {
 			return nil
 		})
 
-		agentCtx, cancel := context.WithTimeout(ctx, 120*time.Second)
+		// Aligned with the agent's own healthcheck budget; a fixed 120s wait gave
+		// up while the agent container was still starting under CI daemon
+		// contention. See pkg.AgentReadyTimeout (KEPLOY_AGENT_READY_TIMEOUT).
+		agentCtx, cancel := context.WithTimeout(ctx, pkg.AgentReadyTimeout())
 		defer cancel()
 
 		agentReadyCh := make(chan bool, 1)

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1161,7 +1161,10 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		// for readiness. Re-paying a 120s window per test-set is dead time where a
 		// transient daemon stall can land. Mirrors the waitForAppReady gating.
 		if !serveTest || r.isFirstTestSet {
-			agentCtx, cancel := context.WithTimeout(runTestSetCtx, 120*time.Second)
+			// Aligned with the agent's own healthcheck budget; a fixed 120s wait
+			// gave up while the agent container was still starting under CI daemon
+			// contention. See pkg.AgentReadyTimeout (KEPLOY_AGENT_READY_TIMEOUT).
+			agentCtx, cancel := context.WithTimeout(runTestSetCtx, pkg.AgentReadyTimeout())
 			defer cancel()
 
 			agentReadyCh := make(chan bool, 1)

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -2678,6 +2678,30 @@ func WaitForPort(ctx context.Context, host string, port string, timeout time.Dur
 	}
 }
 
+// DefaultAgentReadyTimeout is how long keploy waits for the in-docker
+// keploy-agent to report ready before giving up. It is sized to the agent
+// container's OWN healthcheck budget (start_period 10s + interval 5s × retries
+// 60 ≈ 310s, see pkg/platform/docker): under heavy CI docker-daemon contention
+// the agent container can take ~2 minutes just to start — observed in CI as a
+// `docker run` of an already-local image taking 126s before the agent process
+// ran. A shorter CLI wait gives up while the agent's own healthcheck still
+// considers it starting, tearing down a bring-up that would have succeeded.
+const DefaultAgentReadyTimeout = 330 * time.Second
+
+// AgentReadyTimeout returns how long to wait for the keploy-agent to become
+// ready. It defaults to DefaultAgentReadyTimeout and is overridable via the
+// KEPLOY_AGENT_READY_TIMEOUT env var (whole seconds) for tuning on unusually
+// slow or fast hosts. A non-positive / unparsable value falls back to the
+// default.
+func AgentReadyTimeout() time.Duration {
+	if v := strings.TrimSpace(os.Getenv("KEPLOY_AGENT_READY_TIMEOUT")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return time.Duration(n) * time.Second
+		}
+	}
+	return DefaultAgentReadyTimeout
+}
+
 // AgentHealthTicker continuously monitors the agent health endpoint at specified intervals
 // and signals on the provided channel when the agent becomes available or unavailable.
 // It respects the context timeout and returns when the context is cancelled.

--- a/pkg/util_test.go
+++ b/pkg/util_test.go
@@ -1968,3 +1968,36 @@ func TestFilterByTimeStampThreeTier(t *testing.T) {
 	assert.ElementsMatch(t, []string{"conn", "startup-init", "legacy-conn"}, names(startup),
 		"connection-lifetime + startup-init PerTest + legacy connection-tagged land in startup")
 }
+
+func TestAgentReadyTimeout(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		set  bool
+		want time.Duration
+	}{
+		{name: "default when unset", set: false, want: DefaultAgentReadyTimeout},
+		{name: "valid override", env: "300", set: true, want: 300 * time.Second},
+		{name: "whitespace trimmed", env: "  90 ", set: true, want: 90 * time.Second},
+		{name: "zero falls back to default", env: "0", set: true, want: DefaultAgentReadyTimeout},
+		{name: "negative falls back to default", env: "-5", set: true, want: DefaultAgentReadyTimeout},
+		{name: "garbage falls back to default", env: "soon", set: true, want: DefaultAgentReadyTimeout},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv("KEPLOY_AGENT_READY_TIMEOUT", tc.env)
+			} else {
+				os.Unsetenv("KEPLOY_AGENT_READY_TIMEOUT")
+			}
+			if got := AgentReadyTimeout(); got != tc.want {
+				t.Fatalf("AgentReadyTimeout() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+	// The default must cover the agent container's own healthcheck budget
+	// (~310s), otherwise the CLI gives up while the agent is still starting.
+	if DefaultAgentReadyTimeout < 310*time.Second {
+		t.Fatalf("DefaultAgentReadyTimeout %v is shorter than the agent healthcheck budget (~310s)", DefaultAgentReadyTimeout)
+	}
+}


### PR DESCRIPTION
## Problem

Under heavy CI docker-daemon contention the in-docker `keploy-agent` container can take **~2 minutes just to start**. Observed in CI (enterprise `go-dedup-docker`):

```
14:39:48  Starting keploy in docker with image keploy/enterprise:v3-dev   # image ALREADY local (loaded from cache, no pull)
14:40:48  ERROR keploy-agent did not become ready in time                 # keploy gives up after 60s
14:41:54  Starting Keploy ... inDocker:true                               # the agent process actually starts — 126s after launch
```

A `docker run` of an **already-local** image taking 126s to actually start the container is docker-daemon/host contention (a non-contended daemon does it in <5s). The agent is **not** hanging or crashing — it comes up, just far slower than keploy's wait.

The agent-ready waits were **60s** (`AgentClient` native/docker-run setup) and **120s** (record, replay, `MakeAgentReadyForDockerCompose`) — all **shorter than the agent container's own healthcheck budget**: `start_period 10s + interval 5s × retries 60 ≈ 310s` (see `pkg/platform/docker`). So keploy gives up while the agent's *own* healthcheck still considers it starting, tears the bring-up down, and emits a spurious:

```
ERROR keploy-agent did not become ready in time
```

This intermittently fails otherwise-green compose/docker-run lanes (`go-dedup-docker`, `umami`, `python-postgres-tls-containerized`, …) whenever the host is busy.

## Fix

- Add `pkg.AgentReadyTimeout()` — default **330s** (≥ the agent's ~310s healthcheck budget), overridable via **`KEPLOY_AGENT_READY_TIMEOUT`** (whole seconds) for tuning.
- Use it at **all four** agent-ready sites (`agent.go` setup + `MakeAgentReadyForDockerCompose`, `record.go`, `replay.go`), replacing the hardcoded 60s/120s.

This is **not** widening a timeout to paper over a hang: the agent provably *does* come up (it logged its HTTP server ~126s in) — it was simply slower than the old wait. Aligning the CLI wait to the agent's own declared startup contract fixes an internal inconsistency. Normal runs are unaffected: `AgentHealthTicker` signals the instant the agent is healthy, so the wait returns in milliseconds on an idle host; the larger budget only matters when the daemon is genuinely saturated.

## Testing

- `go build ./pkg/...` + `go vet` clean; `gofmt` clean; `golangci-lint` 0 issues on the touched packages.
- New `TestAgentReadyTimeout` (default / env override / whitespace / zero / negative / garbage fallback, and asserts the default covers the ~310s healthcheck budget) — passes under `-race`.

Relates to #4266 (configurable timeout) and #4267 (build compose stack before arming the timer): this lands the env knob + raises the default to actually cover the observed startup time, across every readiness site.
