### PR TITLE
fix(replay): keep failed-test mocks from auto-replay prune so mappings don't dangle

### DIFF
--- a/pkg/service/replay/missing_mock_prune_test.go
+++ b/pkg/service/replay/missing_mock_prune_test.go
@@ -1,0 +1,55 @@
+package replay
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// Regression for the missing-mock bug: auto-replay's prune (UpdateMocks) keeps
+// only passing-test consumed mocks (+ config/startup), so a FAILED test's mapped
+// mocks were deleted while its mapping was still written (UpdateTestMapping=true)
+// → the mapping dangles → those mocks are missing on every later replay (both
+// the legacy and smart-set cloud-replay paths fail). Confirmed on the real
+// staging recording (test-set ...vhncm: 7 mongo mocks on the first test, mapped
+// but absent from mocks.json).
+//
+// The fix keys mock-preservation on "did the test PASS" instead of "was it
+// EXECUTED". This test shows both behaviours through the same helper:
+//   - skip-set = every EXECUTED test (old)  → a failed test's mocks are DROPPED
+//   - skip-set = PASSED tests only   (fix)  → a failed test's mocks are KEPT
+func TestRetainNonPassingTestMocks_FailedTestMocksSurvivePrune(t *testing.T) {
+	expected := map[string][]models.MockEntry{
+		"test-failed": {{Name: "mock-104", Kind: "Mongo"}, {Name: "mock-105", Kind: "Mongo"}},
+		"test-passed": {{Name: "mock-200", Kind: "Mongo"}},
+		"test-notrun": {{Name: "mock-300", Kind: "Http"}},
+	}
+
+	// OLD behaviour (the bug): preserve only NOT-EXECUTED tests, i.e. skip every
+	// executed test — passed AND failed. The failed test's mocks are not kept,
+	// so the prune deletes them while the mapping still references them.
+	oldSkip := map[string]bool{"test-passed": true, "test-failed": true}
+	keepOld := map[string]models.MockState{"mock-200": {Name: "mock-200"}}
+	retainNonPassingTestMocks(expected, oldSkip, keepOld)
+	if _, ok := keepOld["mock-104"]; ok {
+		t.Fatal("sanity: under the OLD executed-based behaviour, a failed test's mock should NOT be preserved")
+	}
+
+	// NEW behaviour (the fix): preserve every NON-PASSING test, i.e. skip only
+	// PASSED tests. The failed and not-run tests' mapped mocks survive the prune.
+	newSkip := map[string]bool{"test-passed": true}
+	keepNew := map[string]models.MockState{"mock-200": {Name: "mock-200"}}
+	added := retainNonPassingTestMocks(expected, newSkip, keepNew)
+
+	for _, n := range []string{"mock-104", "mock-105", "mock-300"} {
+		if _, ok := keepNew[n]; !ok {
+			t.Errorf("FIX: non-passing test's mapped mock %q must be preserved from pruning so its mapping doesn't dangle, but it was dropped", n)
+		}
+	}
+	if _, ok := keepNew["mock-200"]; !ok {
+		t.Error("a passed test's already-kept mock must remain in the keep-set")
+	}
+	if added != 3 {
+		t.Errorf("expected 3 newly-preserved mocks (mock-104/105/300), got %d", added)
+	}
+}

--- a/pkg/service/replay/missing_mock_prune_test.go
+++ b/pkg/service/replay/missing_mock_prune_test.go
@@ -1,23 +1,29 @@
 package replay
 
 import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"go.keploy.io/server/v3/pkg/models"
+	ossMockdb "go.keploy.io/server/v3/pkg/platform/yaml/mockdb"
+	"go.uber.org/zap"
 )
 
-// Regression for the missing-mock bug: auto-replay's prune (UpdateMocks) keeps
-// only passing-test consumed mocks (+ config/startup), so a FAILED test's mapped
-// mocks were deleted while its mapping was still written (UpdateTestMapping=true)
-// → the mapping dangles → those mocks are missing on every later replay (both
-// the legacy and smart-set cloud-replay paths fail). Confirmed on the real
-// staging recording (test-set ...vhncm: 7 mongo mocks on the first test, mapped
-// but absent from mocks.json).
+// --- Unit: the fix's keep-set helper ---
+//
+// Auto-replay's prune (UpdateMocks) keeps only passing-test consumed mocks
+// (+ config/startup). A test that EXECUTED and FAILED had its mapped mocks
+// deleted from mocks.json while its mapping was still written
+// (UpdateTestMapping=true) — leaving the mapping pointing at deleted mocks. On
+// every later replay that test can't find its mocks (missing-mock -> EOF),
+// breaking both the legacy and smart-set cloud-replay paths.
 //
 // The fix keys mock-preservation on "did the test PASS" instead of "was it
-// EXECUTED". This test shows both behaviours through the same helper:
-//   - skip-set = every EXECUTED test (old)  → a failed test's mocks are DROPPED
-//   - skip-set = PASSED tests only   (fix)  → a failed test's mocks are KEPT
+// EXECUTED". This shows both behaviours through the same helper.
 func TestRetainNonPassingTestMocks_FailedTestMocksSurvivePrune(t *testing.T) {
 	expected := map[string][]models.MockEntry{
 		"test-failed": {{Name: "mock-104", Kind: "Mongo"}, {Name: "mock-105", Kind: "Mongo"}},
@@ -26,8 +32,7 @@ func TestRetainNonPassingTestMocks_FailedTestMocksSurvivePrune(t *testing.T) {
 	}
 
 	// OLD behaviour (the bug): preserve only NOT-EXECUTED tests, i.e. skip every
-	// executed test — passed AND failed. The failed test's mocks are not kept,
-	// so the prune deletes them while the mapping still references them.
+	// executed test — passed AND failed. The failed test's mocks are not kept.
 	oldSkip := map[string]bool{"test-passed": true, "test-failed": true}
 	keepOld := map[string]models.MockState{"mock-200": {Name: "mock-200"}}
 	retainNonPassingTestMocks(expected, oldSkip, keepOld)
@@ -36,20 +41,124 @@ func TestRetainNonPassingTestMocks_FailedTestMocksSurvivePrune(t *testing.T) {
 	}
 
 	// NEW behaviour (the fix): preserve every NON-PASSING test, i.e. skip only
-	// PASSED tests. The failed and not-run tests' mapped mocks survive the prune.
+	// PASSED tests. The failed and not-run tests' mapped mocks survive.
 	newSkip := map[string]bool{"test-passed": true}
 	keepNew := map[string]models.MockState{"mock-200": {Name: "mock-200"}}
 	added := retainNonPassingTestMocks(expected, newSkip, keepNew)
-
 	for _, n := range []string{"mock-104", "mock-105", "mock-300"} {
 		if _, ok := keepNew[n]; !ok {
-			t.Errorf("FIX: non-passing test's mapped mock %q must be preserved from pruning so its mapping doesn't dangle, but it was dropped", n)
+			t.Errorf("FIX: non-passing test's mapped mock %q must be preserved from pruning, but it was dropped", n)
 		}
 	}
 	if _, ok := keepNew["mock-200"]; !ok {
 		t.Error("a passed test's already-kept mock must remain in the keep-set")
 	}
 	if added != 3 {
-		t.Errorf("expected 3 newly-preserved mocks (mock-104/105/300), got %d", added)
+		t.Errorf("expected 3 newly-preserved mocks, got %d", added)
+	}
+}
+
+// pruneFixtureMock builds a minimal, validly-encodable HTTP mock with a given
+// request timestamp. The prune is protocol-agnostic (it keeps/deletes by name,
+// metadata.type, and timestamp), so HTTP stands in for the Mongo mocks the real
+// bug dropped. metadata.type is deliberately NOT "config" so the mock is
+// prune-eligible.
+func pruneFixtureMock(reqTS time.Time) *models.Mock {
+	return &models.Mock{
+		Version: "api.keploy.io/v1beta1",
+		Kind:    models.HTTP,
+		Spec: models.MockSpec{
+			Metadata:         map[string]string{"operation": "GET"},
+			HTTPReq:          &models.HTTPReq{Method: "GET", URL: "http://svc/x", ProtoMajor: 1, ProtoMinor: 1, Header: map[string]string{}},
+			HTTPResp:         &models.HTTPResp{StatusCode: 200, Header: map[string]string{}, Body: "ok"},
+			ReqTimestampMock: reqTS,
+			ResTimestampMock: reqTS.Add(time.Millisecond),
+		},
+	}
+}
+
+func mockNamesOnDisk(t *testing.T, dir, testSetID string) map[string]bool {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(dir, testSetID, "mocks.yaml"))
+	if err != nil {
+		t.Fatalf("read mocks.yaml: %v", err)
+	}
+	names := map[string]bool{}
+	for _, line := range strings.Split(string(b), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "name: ") {
+			names[strings.TrimSpace(strings.TrimPrefix(line, "name:"))] = true
+		}
+	}
+	return names
+}
+
+// Integration: drive the REAL prune (MockYaml.UpdateMocks) and show that a
+// mapped mock which was NOT re-consumed during auto-replay (failed/diverged
+// test) is deleted (the bug), and that augmenting the keep-set via the fix
+// helper preserves it (the fix). This replicates the on-disk dangling-mapping
+// state observed on the real staging recording (vhncm: mapped mongo mocks
+// absent from mocks.json).
+func TestAutoReplayPrune_MappedMockOfNonPassingTestSurvives_Integration(t *testing.T) {
+	ctx := context.Background()
+	const set = "test-set-0"
+
+	base := time.Now().Add(-time.Hour)
+	pruneBefore := time.Now()                // mocks recorded before now -> prune-eligible
+	startupCutoff := base.Add(-time.Minute)  // before all mocks -> none are startup-exempt
+
+	insertThree := func(dir string) (string, string, string) {
+		ys := ossMockdb.New(zap.NewNop(), dir, "mocks")
+		m1 := pruneFixtureMock(base)
+		m2 := pruneFixtureMock(base.Add(time.Second))
+		m3 := pruneFixtureMock(base.Add(2 * time.Second))
+		for _, m := range []*models.Mock{m1, m2, m3} {
+			if err := ys.InsertMock(ctx, m, set); err != nil {
+				t.Fatalf("InsertMock: %v", err)
+			}
+		}
+		ys.Close()
+		return m1.Name, m2.Name, m3.Name // InsertMock renames -> mock-1, mock-2, mock-3
+	}
+
+	// ---- Phase A: BUG ----
+	// test-1 (owns mockA) FAILED/diverged in auto-replay, so mockA is NOT in the
+	// passing-consumed keep-set. mockB/mockC were consumed by passing tests.
+	dirBug := t.TempDir()
+	mockA, mockB, mockC := insertThree(dirBug)
+	passing := map[string]models.MockState{mockB: {Name: mockB}, mockC: {Name: mockC}}
+	ysBug := ossMockdb.New(zap.NewNop(), dirBug, "mocks")
+	if err := ysBug.UpdateMocks(ctx, set, passing, pruneBefore, startupCutoff); err != nil {
+		t.Fatalf("UpdateMocks (bug phase): %v", err)
+	}
+	got := mockNamesOnDisk(t, dirBug, set)
+	if got[mockA] {
+		t.Fatalf("sanity: expected the prune to DELETE the non-re-consumed mapped mock %q (the bug), but it survived", mockA)
+	}
+	if !got[mockB] || !got[mockC] {
+		t.Fatalf("passing-consumed mocks %q/%q must survive the prune", mockB, mockC)
+	}
+	t.Logf("BUG reproduced: prune deleted mapped mock %q; mapping referencing it now dangles", mockA)
+
+	// ---- Phase B: FIX ----
+	// Same setup, but the fix augments the keep-set with the EXPECTED mocks of
+	// the non-passing test (test-1 -> mockA) before pruning.
+	dirFix := t.TempDir()
+	mockA2, mockB2, mockC2 := insertThree(dirFix)
+	passingFix := map[string]models.MockState{mockB2: {Name: mockB2}, mockC2: {Name: mockC2}}
+	expectedMappings := map[string][]models.MockEntry{
+		"test-1": {{Name: mockA2, Kind: "Http"}}, // test-1 did not pass; its mapping references mockA2
+	}
+	retainNonPassingTestMocks(expectedMappings, map[string]bool{ /* test-1 not passed */ }, passingFix)
+	ysFix := ossMockdb.New(zap.NewNop(), dirFix, "mocks")
+	if err := ysFix.UpdateMocks(ctx, set, passingFix, pruneBefore, startupCutoff); err != nil {
+		t.Fatalf("UpdateMocks (fix phase): %v", err)
+	}
+	gotFix := mockNamesOnDisk(t, dirFix, set)
+	if !gotFix[mockA2] {
+		t.Errorf("FIX: a non-passing test's mapped mock %q must survive the prune so its mapping doesn't dangle, but it was deleted", mockA2)
+	}
+	if !gotFix[mockB2] || !gotFix[mockC2] {
+		t.Errorf("passing-consumed mocks must still survive under the fix")
 	}
 }

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -2661,29 +2661,23 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		utils.LogError(r.logger, err, "failed to create .gitignore file")
 	}
 
-	// Preserve mocks and mappings for tests that were expected but not executed in this run
-	if len(expectedTestMockMappings) > 0 {
-		for expectedTestCaseID, expectedMocks := range expectedTestMockMappings {
-			testExecuted := false
-			for _, tc := range activeTestCases {
-				if tc.Name == expectedTestCaseID {
-					testExecuted = true
-					break
-				}
-			}
-
-			if !testExecuted {
-				// Preserve its expected mocks so they aren't deleted by UpdateMocks
-				for _, m := range expectedMocks {
-					if _, exists := passingTotalConsumedMocks[m.Name]; !exists {
-						passingTotalConsumedMocks[m.Name] = models.MockState{
-							Name: m.Name,
-							Kind: models.Kind(m.Kind),
-						}
-					}
-				}
-			}
+	// Preserve the expected mocks of every test that did NOT pass this run
+	// (failed, obsolete, or not executed). Their mappings are still written/
+	// retained (UpdateTestMapping), so the prune (UpdateMocks) must not delete
+	// the mocks those mappings reference — otherwise the mapping dangles and the
+	// test can never find its mocks on replay (the missing-mock failure that hits
+	// both legacy and smart-set cloud-replay). Passed tests are skipped: their
+	// actual consumption is already in passingTotalConsumedMocks. This generalizes
+	// the prior not-executed-only preservation to also cover executed-but-failed.
+	passedTests := make(map[string]bool, len(testCaseResults))
+	for _, tr := range testCaseResults {
+		if tr.Status == models.TestStatusPassed {
+			passedTests[tr.TestCaseID] = true
 		}
+	}
+	if added := retainNonPassingTestMocks(expectedTestMockMappings, passedTests, passingTotalConsumedMocks); added > 0 {
+		r.logger.Debug("preserved expected mocks of non-passing tests from pruning",
+			zap.String("testSetID", testSetID), zap.Int("mocksKept", added))
 	}
 
 	// remove the unused mocks by the test cases of a testset (if the base path is not provided )

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -504,6 +504,43 @@ func retainNoisyTestCaseMocks(noisyTestCaseNames []string, mapping *models.Mappi
 	return added
 }
 
+// retainNonPassingTestMocks preserves the expected mocks of every test that did
+// NOT pass this run (failed, obsolete, or not executed) by adding them to the
+// prune keep-set. Such a test still keeps a written/retained mapping
+// (UpdateTestMapping), so UpdateMocks must not delete the mocks that mapping
+// references — otherwise the mapping is left pointing at deleted mocks and that
+// test can never find its mocks on replay (the missing-mock failure that breaks
+// both the legacy and smart-set cloud-replay paths). Passed tests are skipped:
+// their actual consumption is already in the keep-set. This generalizes the
+// prior not-executed-only preservation to also cover executed-but-failed tests.
+// Returns the number of mocks newly added to keep.
+func retainNonPassingTestMocks(expectedTestMockMappings map[string][]models.MockEntry, passedTests map[string]bool, keep map[string]models.MockState) int {
+	if len(expectedTestMockMappings) == 0 || keep == nil {
+		return 0
+	}
+	added := 0
+	for testID, mocks := range expectedTestMockMappings {
+		if passedTests[testID] {
+			continue
+		}
+		for _, m := range mocks {
+			if m.Name == "" {
+				continue
+			}
+			if _, exists := keep[m.Name]; exists {
+				continue
+			}
+			keep[m.Name] = models.MockState{
+				Name:      m.Name,
+				Kind:      models.Kind(m.Kind),
+				Timestamp: m.Timestamp,
+			}
+			added++
+		}
+	}
+	return added
+}
+
 // isMockSubsetWithConfig reports whether the streaming-path replay consumed a
 // mock set consistent with the test's mapping: a consumed mock that is NOT in
 // the expected set flags a mismatch — UNLESS it is a mock that doesn't


### PR DESCRIPTION
## Problem
Auto-replay runs the prune (`RemoveUnusedMocks` → `UpdateMocks`) keeping only **passing-test** consumed mocks (+ config/startup). With `PreserveFailedMocks=false` (k8s-proxy auto-replay), a test that **executed and failed** has its mapped mocks deleted from `mocks.json`, yet `UpdateTestMapping=true` still writes its mapping — so the mapping **dangles** (references deleted mocks). That test then fails *every* later replay with a missing-mock/EOF, breaking **both** the legacy and smart-set cloud-replay paths. It's self-reinforcing: once pruned, the test can never repopulate.

**Confirmed on a real recording** (`api-server-v2-staging`): the mapping referenced **7 mongo mocks** on the first test that were **absent** from `mocks.json` — their `reqTimestampMock`s appear nowhere in the file, so they were truly dropped (not deduped/renamed).

## Root cause
- #3919 introduced prune-to-passing-consumed (drops failed-test mocks).
- #3941 preserved tests *"expected but not executed"* — but **not** executed-and-failed tests (the gap).
- `MockYaml.UpdateMocks` keeps a mock only if it's `type:config`, in the passing-consumed set, recorded after `pruneBefore`, or startup-window — it never consults the mapping.

## Fix
Generalize #3941's preservation from **"not executed"** to **"not passed"**. New helper `retainNonPassingTestMocks` adds every non-passing test's expected mocks to the prune keep-set before `UpdateMocks`; passed tests are skipped (their actual consumption is already kept). Invariant: **the prune must never delete a mock that a retained mapping still references.**

## Test
`TestRetainNonPassingTestMocks_FailedTestMocksSurvivePrune` runs both behaviours through the helper: the old *executed-based* skip-set drops a failed test's mock; the new *passed-based* skip-set keeps it (plus the not-run case). `go vet` clean; full `pkg/service/replay` suite green.

Related: #3919, #3941, #3996; keploy/k8s-proxy#284, keploy/k8s-proxy#286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)