### PR TITLE
fix(app): force-remove the --name container before a docker-run re-run

### DIFF
--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -683,6 +683,15 @@ func (a *App) run(ctx context.Context) models.AppError {
 
 	if utils.FindDockerCmd(a.cmd) == utils.DockerRun {
 		userCmd = utils.EnsureRmBeforeName(userCmd)
+		// Clear any container left over from a prior run with the same --name
+		// before starting. --rm removes the container on exit, but under heavy
+		// docker-daemon contention that reap can lag past the next
+		// `docker run --name`, so a re-run (e.g. a dedup/timefreeze lane's
+		// record -> replay) hits "Conflict. The container name ... is already in
+		// use" (docker exit 125). Force-removing first is bounded + best-effort
+		// (a no-op when nothing is lingering), so the re-run never collides with a
+		// still-reaping container. Mirrors the compose force-remove in ComposeDown.
+		a.forceRemoveContainerByName(a.container)
 	}
 
 	// Define the function to cancel the command


### PR DESCRIPTION
## Problem

Under heavy CI docker-daemon contention, docker-run lanes intermittently fail on a re-run with:
```
docker: Error response from daemon: Conflict. The container name "/my-app" is already in use ...
ERROR error while running the app {"error": "exit status 125"}
```
`EnsureRmBeforeName` adds `--rm` so the container auto-removes on exit, but under contention that reap can lag past the **next** `docker run --name` on a re-run (e.g. a dedup/timefreeze lane's record → replay), so the name is still taken → exit 125, even though the previous run finished cleanly.

#4297 fixed the **compose** equivalent (ComposeDown's force-remove-by-name to free the name for the next per-test-set `up`). **docker-run mode lacked the same guard.**

## Fix

In `app.run()`'s docker-run branch, force-remove any lingering container with the same `--name` before starting (`forceRemoveContainerByName(a.container)`). It's **bounded** (CommandContext + `forceRemoveBudget`) and **best-effort** (ignores "no such container"), so it's a no-op when nothing is lingering and never collides with a still-reaping container. Mirrors the compose path.

## Testing

`go build ./pkg/client/app/...` + `go vet` clean; `gofmt` clean; `golangci-lint` 0 issues on the touched package. Observed fixing the intermittent `go-docker-timefreeze` / `go-dedup-docker` exit-125 collisions in the enterprise high-load lanes.