### PR TITLE
feat(proxy): context hook to report a mock-mismatch without closing t…

### DIFF
--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -2247,7 +2247,15 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 			}
 			logger.Debug("successfully recorded outgoing message", zap.String("ParserType", string(parserType)))
 		case models.MODE_TEST:
-			err := matchedParser.MockOutgoing(parserCtx, srcConn, dstCfg, m, outgoingOpts)
+			// Hand the parser a reporter so it can record a mock-mismatch
+			// out-of-band — surfacing the miss to the test report without
+			// returning the error that closes this connection. Returning the
+			// error is fine for most protocols, but a Pulsar SEND mismatch must
+			// keep the connection alive (a close makes pulsar-client-go
+			// reconnect the producer and crash on a nil schema); such a parser
+			// reports via this hook, replies normally, and keeps serving.
+			testCtx := models.WithMockMismatchReporter(parserCtx, p.sendMockNotFoundError)
+			err := matchedParser.MockOutgoing(testCtx, srcConn, dstCfg, m, outgoingOpts)
 			if err != nil && err != io.EOF && !errors.Is(err, context.Canceled) && !isNetworkClosedErr(err) {
 				utils.LogError(logger, err, "failed to mock the outgoing message")
 				// Send specific error type to error channel for external monitoring

--- a/pkg/models/mock_mismatch_reporter.go
+++ b/pkg/models/mock_mismatch_reporter.go
@@ -1,0 +1,42 @@
+package models
+
+import "context"
+
+// mockMismatchReporterKey is the unexported context key under which the proxy
+// stashes its mock-mismatch reporter for the duration of a MockOutgoing call.
+type mockMismatchReporterKey struct{}
+
+// WithMockMismatchReporter returns a context carrying report — the callback the
+// proxy uses to record a mock-mismatch (the same sink as a returned
+// ErrMockNotFound). It lets an integration surface a miss to the test report
+// WITHOUT returning the error that ends — and tears down — the client
+// connection.
+//
+// Most parsers don't need this: they return the miss error and the resulting
+// connection close is harmless. It exists for protocols where the close itself
+// is destructive — notably Pulsar, where closing the connection on a SEND
+// mismatch makes pulsar-client-go reconnect the producer and crash on a nil
+// schema (grabCnx -> schemaCache.Put). Such a parser reports the miss via this
+// hook, replies to the client normally, and keeps serving the connection.
+//
+// A nil report is ignored so callers can pass through unconditionally.
+func WithMockMismatchReporter(ctx context.Context, report func(error)) context.Context {
+	if report == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, mockMismatchReporterKey{}, report)
+}
+
+// ReportMockMismatch records err via the reporter installed by
+// WithMockMismatchReporter, returning true when a reporter was present (so the
+// caller may keep the connection alive instead of returning the error). When no
+// reporter is installed — e.g. an older agent, or a non-test path — it is a
+// no-op returning false, and the caller should fall back to returning err.
+func ReportMockMismatch(ctx context.Context, err error) bool {
+	report, ok := ctx.Value(mockMismatchReporterKey{}).(func(error))
+	if !ok || report == nil {
+		return false
+	}
+	report(err)
+	return true
+}


### PR DESCRIPTION
…he conn

Add models.WithMockMismatchReporter / ReportMockMismatch — a context-carried callback the proxy installs (wired to sendMockNotFoundError) for the duration of a MODE_TEST MockOutgoing call. It lets an integration record a mock-mismatch out-of-band — surfacing the miss to the test report via the same ErrMockNotFound sink — WITHOUT returning the error that ends and tears down the client connection.

Most parsers keep returning the miss error (the connection close is harmless). This exists for protocols where the close itself is destructive: a Pulsar SEND mismatch must keep the connection alive, because closing it makes pulsar-client-go reconnect the producer and SIGSEGV on a nil schema (grabCnx -> schemaCache.Put -> SchemaInfo.hash). Such a parser reports via the hook, replies normally, and keeps serving; the enterprise Pulsar replayer is the first consumer.

The hook is additive and backward-compatible: ReportMockMismatch returns false when no reporter is installed, so callers fall back to returning the error.

## Describe the changes that are made
- 

## Links & References

**Closes:** #[issue number that will be closed through this PR]
- NA (if very small change like typo, linting, etc.)

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [ ] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [ ] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

## Self Review done?
- [ ] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [ ] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [ ] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [ ] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?