### PR TITLE
fix(app): make docker-run pre-run container cleanup robust under contention

### DIFF
--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -590,11 +590,17 @@ func (a *App) ComposeDown() {
 // returns before recentAppLogs — comfortably under 30s.
 const (
 	composeDownCmdBudget = 8 * time.Second // `docker compose down`
-	forceRemoveBudget    = 2 * time.Second // each `docker rm -f`
+	forceRemoveBudget    = 2 * time.Second // each `docker rm -f` in the teardown drain path
 	reapBarrierBudget    = 3 * time.Second // waitContainersRemoved poll
 	graceBudget          = 5 * time.Second // cmdCancel coverage-flush grace
 	waitTillExitBudget   = 8 * time.Second // non-compose post-cancel container wait
 	dockerInspectBudget  = 2 * time.Second // any single teardown ContainerInspect
+	// preRunRemoveBudget bounds the startup-time force-remove of a leftover
+	// --name container before a docker-run. Unlike the teardown force-remove it
+	// is NOT in the SIGINT drain path, so it can afford to wait for a still-
+	// running prior container to actually go away under daemon contention; the
+	// 2s teardown cap is too short here and lets "name already in use" through.
+	preRunRemoveBudget = 30 * time.Second
 )
 
 // waitContainersRemoved polls until the named containers no longer exist (or the
@@ -637,13 +643,21 @@ func (a *App) waitContainersRemoved(names []string, budget time.Duration) {
 // "no such container" case. Used after compose down to guarantee a name is free
 // for reuse on the next per-test-set compose up.
 func (a *App) forceRemoveContainerByName(name string) {
+	a.forceRemoveContainerByNameWithin(name, forceRemoveBudget)
+}
+
+// forceRemoveContainerByNameWithin is forceRemoveContainerByName with a caller-
+// chosen deadline. Teardown callers pass the tight forceRemoveBudget (drain
+// path); the startup pre-run cleanup passes preRunRemoveBudget so it can wait
+// out a still-running prior container under contention.
+func (a *App) forceRemoveContainerByNameWithin(name string, budget time.Duration) {
 	if name == "" {
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), forceRemoveBudget)
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
 	defer cancel()
 	if output, err := exec.CommandContext(ctx, "docker", "rm", "-f", name).CombinedOutput(); err != nil {
-		a.logger.Debug("force-remove container finished (may already be gone, or the bounded teardown deadline elapsed)",
+		a.logger.Debug("force-remove container finished (may already be gone, or the bounded deadline elapsed)",
 			zap.String("container", name), zap.Error(err), zap.String("output", string(output)))
 	}
 }
@@ -686,12 +700,19 @@ func (a *App) run(ctx context.Context) models.AppError {
 		// Clear any container left over from a prior run with the same --name
 		// before starting. --rm removes the container on exit, but under heavy
 		// docker-daemon contention that reap can lag past the next
-		// `docker run --name`, so a re-run (e.g. a dedup/timefreeze lane's
-		// record -> replay) hits "Conflict. The container name ... is already in
-		// use" (docker exit 125). Force-removing first is bounded + best-effort
-		// (a no-op when nothing is lingering), so the re-run never collides with a
-		// still-reaping container. Mirrors the compose force-remove in ComposeDown.
-		a.forceRemoveContainerByName(a.container)
+		// `docker run --name`, so a re-run (e.g. a dedup lane re-running the app
+		// per test-set) hits "Conflict. The container name ... is already in use"
+		// (docker exit 125). Resolve the name from --container-name (a.container)
+		// or, when that isn't set, the --name in the command itself, then
+		// force-remove it with preRunRemoveBudget — generous because this is a
+		// startup cleanup, and a still-running prior container can take more than
+		// the 2s teardown cap to remove under contention. Best-effort: a no-op
+		// when nothing is lingering.
+		removeName := a.container
+		if removeName == "" {
+			removeName = utils.ContainerNameFromDockerRun(userCmd)
+		}
+		a.forceRemoveContainerByNameWithin(removeName, preRunRemoveBudget)
 	}
 
 	// Define the function to cancel the command

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1179,6 +1179,23 @@ func EnsureRmBeforeName(cmd string) string {
 	return strings.Join(parts, " ")
 }
 
+// ContainerNameFromDockerRun extracts the value of the --name flag from a
+// `docker run` command, supporting both "--name foo" and "--name=foo". It
+// returns "" when no --name is present. Used to free a leftover container name
+// before a re-run when the --container-name flag wasn't supplied.
+func ContainerNameFromDockerRun(cmd string) string {
+	parts := strings.Fields(cmd)
+	for i, part := range parts {
+		if part == "--name" && i+1 < len(parts) {
+			return parts[i+1]
+		}
+		if name, ok := strings.CutPrefix(part, "--name="); ok {
+			return name
+		}
+	}
+	return ""
+}
+
 func isGoBinary(logger *zap.Logger, filePath string) bool {
 	f, err := elf.Open(filePath)
 	if err != nil {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,24 @@
+package utils
+
+import "testing"
+
+func TestContainerNameFromDockerRun(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{"space form", "docker run --rm --name dedup-go-test dedup-go:latest", "dedup-go-test"},
+		{"equals form", "docker run --name=my-app img", "my-app"},
+		{"name mid-flags", "docker run -d --name x --network y img", "x"},
+		{"no name", "docker run --rm img", ""},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ContainerNameFromDockerRun(tc.cmd); got != tc.want {
+				t.Fatalf("ContainerNameFromDockerRun(%q) = %q, want %q", tc.cmd, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Even after #4301, docker-run lanes that re-run the app (e.g. dedup, which replays multiple test-sets each doing `docker run --name <x>`) still intermittently fail under CI load with:
```
docker: Error response from daemon: Conflict. The container name "/dedup-go-test" is already in use ...
ERROR error while running the app {"error": "exit status 125"}
```
Two gaps in the #4301 pre-run force-remove:
1. It removed only `a.container`, which is **empty when `--container-name` isn't passed**, so it silently no-op'd.
2. It used the **2s** teardown `forceRemoveBudget` — too short to `docker rm -f` a **still-running** prior container under heavy daemon contention, so the remove timed out and the name stayed taken.

## Fix

- Resolve the container name from `--container-name` (`a.container`) **or**, when unset, the `--name` in the command (new `utils.ContainerNameFromDockerRun`).
- Force-remove it with a generous `preRunRemoveBudget` (30s). This runs at **startup**, not in the SIGINT teardown drain path, so waiting for a still-running prior container to actually go away is fine (teardown callers keep the tight 2s budget).

## Testing

- `go build`/`go vet` clean; `gofmt` clean; `golangci-lint` 0 issues on touched packages.
- New `TestContainerNameFromDockerRun` (space form, `--name=` form, mid-flags, absent, empty) passes under `-race`.
- Verified the mechanism against the real collision: a running `--name X` container makes `docker run --name X` fail exit 125; `docker rm -f X` first makes the re-run succeed.

Follows up #4301 (compose got force-remove-by-name in #4297; this hardens the docker-run path).