### PR TITLE
fix(ci-flake): tab-safe PostgresV3 SQLNormalized YAML (CI flake robustness, batch 1)

### DIFF
--- a/pkg/agent/proxy/fakeconn/fakeconn.go
+++ b/pkg/agent/proxy/fakeconn/fakeconn.go
@@ -122,6 +122,28 @@ func newWithLogger(ch <-chan Chunk, localAddr, remoteAddr net.Addr, log logger) 
 // (subject to read deadline and Close).
 func (f *FakeConn) Read(p []byte) (int, error) {
 	if f.closed.Load() {
+		// Close means "no more blocking", NOT "discard bytes already
+		// delivered to me". The relay tee drains its buffered chunks
+		// into f.ch and then Close() fires during teardown; a chunk
+		// that already landed in f.ch (or the stash) is a fully
+		// recorded wire event and must still be readable, otherwise a
+		// response whose body arrived a hair before the connection was
+		// torn down is silently lost (the "server closed before
+		// response" mock-incomplete race on Connection: close traffic
+		// such as the boot-time startup mock). Only return ErrClosed
+		// once nothing buffered remains.
+		if c, ok := f.drainBufferedLocked(); ok {
+			n := copy(p, c.Bytes)
+			if n < len(c.Bytes) {
+				f.mu.Lock()
+				f.buf.Write(c.Bytes[n:])
+				f.bufReadAt = c.ReadAt
+				f.bufWrittenAt = c.WrittenAt
+				f.bufDir = c.Dir
+				f.mu.Unlock()
+			}
+			return n, nil
+		}
 		return 0, ErrClosed
 	}
 	if len(p) == 0 {
@@ -185,9 +207,64 @@ func (f *FakeConn) Read(p []byte) (int, error) {
 // on a single FakeConn to avoid mixing the two.
 func (f *FakeConn) ReadChunk() (Chunk, error) {
 	if f.closed.Load() {
+		// See Read: a chunk already delivered to f.ch (or stashed) is a
+		// recorded wire event and must survive Close. Drain what is
+		// buffered before reporting ErrClosed.
+		if c, ok := f.drainBufferedLocked(); ok {
+			return c, nil
+		}
 		return Chunk{}, ErrClosed
 	}
 	return f.readChunkLocked()
+}
+
+// drainBufferedLocked returns the next chunk that is ALREADY available
+// without blocking: first any residual bytes left in the internal stash
+// by a prior Read, then a single non-blocking receive from f.ch. It is
+// used only on the post-Close read paths so that bytes the relay already
+// handed to this FakeConn are not discarded when Close races the final
+// delivery. Returns ok=false when nothing is immediately available (the
+// caller then returns ErrClosed). It updates the last-read/written
+// timestamps exactly like readChunkLocked so downstream timestamp anchors
+// stay consistent.
+func (f *FakeConn) drainBufferedLocked() (Chunk, bool) {
+	f.mu.Lock()
+	if f.buf.Len() > 0 {
+		out := make([]byte, f.buf.Len())
+		_, _ = f.buf.Read(out)
+		c := Chunk{
+			Dir:       f.bufDir,
+			Bytes:     out,
+			ReadAt:    f.bufReadAt,
+			WrittenAt: f.bufWrittenAt,
+		}
+		f.bufReadAt = time.Time{}
+		f.bufWrittenAt = time.Time{}
+		f.bufDir = 0
+		f.mu.Unlock()
+		if !c.ReadAt.IsZero() {
+			f.lastReadNano.Store(c.ReadAt.UnixNano())
+		}
+		if !c.WrittenAt.IsZero() {
+			f.lastWrittenNano.Store(c.WrittenAt.UnixNano())
+		}
+		return c, true
+	}
+	f.mu.Unlock()
+
+	select {
+	case c, ok := <-f.ch:
+		if !ok {
+			return Chunk{}, false
+		}
+		f.lastReadNano.Store(c.ReadAt.UnixNano())
+		if !c.WrittenAt.IsZero() {
+			f.lastWrittenNano.Store(c.WrittenAt.UnixNano())
+		}
+		return c, true
+	default:
+		return Chunk{}, false
+	}
 }
 
 func (f *FakeConn) readChunkLocked() (Chunk, error) {

--- a/pkg/agent/proxy/fakeconn/fakeconn_test.go
+++ b/pkg/agent/proxy/fakeconn/fakeconn_test.go
@@ -158,6 +158,60 @@ func TestReadAfterCloseReturnsErrClosed(t *testing.T) {
 	}
 }
 
+// TestReadChunkAfterCloseDrainsBuffered is the FakeConn-side regression
+// guard for the startup-mock "server closed before response" drop. The
+// relay tee delivers the final response chunk into f.ch and the relay
+// then calls Close() during teardown. A chunk already sitting in f.ch is
+// a fully recorded wire event: Close means "no more blocking", not
+// "discard bytes already delivered to me". ReadChunk after Close must
+// therefore return the buffered chunk(s) first and only report ErrClosed
+// once nothing buffered remains. Before the fix, the f.closed short
+// circuit returned ErrClosed immediately and the buffered response chunk
+// (carrying the startup mock body) was lost.
+func TestReadChunkAfterCloseDrainsBuffered(t *testing.T) {
+	t.Parallel()
+	ch := make(chan Chunk, 2)
+	ch <- Chunk{Dir: FromDest, Bytes: []byte("startup-secret"), WrittenAt: time.Unix(7, 0)}
+	f := New(ch, nil, nil)
+	_ = f.Close()
+
+	c, err := f.ReadChunk()
+	if err != nil {
+		t.Fatalf("ReadChunk after Close with buffered chunk = %v, want the chunk", err)
+	}
+	if string(c.Bytes) != "startup-secret" {
+		t.Fatalf("got %q, want %q", c.Bytes, "startup-secret")
+	}
+
+	// Nothing buffered now → ErrClosed.
+	if _, err := f.ReadChunk(); !errors.Is(err, ErrClosed) {
+		t.Fatalf("second ReadChunk after Close = %v, want ErrClosed", err)
+	}
+}
+
+// TestReadAfterCloseDrainsBuffered is the byte-oriented counterpart:
+// Read (not ReadChunk) after Close must likewise hand back bytes the
+// relay already delivered before reporting ErrClosed.
+func TestReadAfterCloseDrainsBuffered(t *testing.T) {
+	t.Parallel()
+	ch := make(chan Chunk, 1)
+	ch <- Chunk{Dir: FromDest, Bytes: []byte("body"), WrittenAt: time.Unix(7, 0)}
+	f := New(ch, nil, nil)
+	_ = f.Close()
+
+	p := make([]byte, 8)
+	n, err := f.Read(p)
+	if err != nil {
+		t.Fatalf("Read after Close with buffered chunk = %v, want bytes", err)
+	}
+	if string(p[:n]) != "body" {
+		t.Fatalf("got %q, want %q", p[:n], "body")
+	}
+	if _, err := f.Read(p); !errors.Is(err, ErrClosed) {
+		t.Fatalf("second Read after Close = %v, want ErrClosed", err)
+	}
+}
+
 func TestReadDeadlineExceeded(t *testing.T) {
 	t.Parallel()
 	ch := make(chan Chunk)

--- a/pkg/agent/proxy/mockmanager_consumed_drain_test.go
+++ b/pkg/agent/proxy/mockmanager_consumed_drain_test.go
@@ -1,0 +1,66 @@
+// Package proxy — real per-call DRAINING semantics of MockManager.GetConsumedMocks.
+//
+// The reset-resend safety gate in pkg/service/replay depends on GetConsumedMocks
+// being per-call and draining (it must report ONLY the mocks consumed since the
+// last drain, then clear its list). Earlier replay-side tests stubbed
+// GetConsumedMocks and so never exercised this contract; this test pins it on
+// the REAL MockManager so a regression in the drain can't silently break the
+// gate's "this request consumed >0 mocks" check.
+package proxy
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// TestGetConsumedMocks_PerCallDrains records a consumption into a real
+// MockManager and asserts:
+//   - the first GetConsumedMocks reports exactly that consumption,
+//   - a second GetConsumedMocks returns empty (the list was DRAINED),
+//   - a fresh consumption after the drain is reported on its own (the count is
+//     per-call, not cumulative).
+//
+// This is the exact contract the reset-resend gate relies on: a non-empty
+// per-call result == "this request consumed a mock" == unsafe to re-send.
+func TestGetConsumedMocks_PerCallDrains(t *testing.T) {
+	mm := NewMockManager(nil, nil, zap.NewNop())
+	defer mm.Close()
+
+	// Before any consumption the list is empty.
+	if got := mm.GetConsumedMocks(); len(got) != 0 {
+		t.Fatalf("expected 0 consumed mocks initially, got %d", len(got))
+	}
+
+	// Record one consumption via the public seam (MarkMockAsUsed flags the mock
+	// as used, the same record path DeleteFilteredMock/UpdateMock drive).
+	mock := models.Mock{Name: "mongo-find-1", Kind: models.Mongo}
+	if !mm.MarkMockAsUsed(mock) {
+		t.Fatal("MarkMockAsUsed should record a consumption for a named mock")
+	}
+
+	// First drain reports exactly the one consumed mock.
+	first := mm.GetConsumedMocks()
+	if len(first) != 1 || first[0].Name != "mongo-find-1" {
+		t.Fatalf("expected first drain to report [mongo-find-1], got %#v", first)
+	}
+
+	// Second drain MUST be empty — the previous call drained the list. If this
+	// regresses, the gate's len(consumed) > 0 check would see stale data and
+	// could refuse a safe re-send (or, with a cumulative baseline, wrongly allow
+	// an unsafe one — the original bug).
+	if second := mm.GetConsumedMocks(); len(second) != 0 {
+		t.Fatalf("expected second drain to be empty (drained), got %d: %#v", len(second), second)
+	}
+
+	// A fresh consumption is reported on its own, proving the count is per-call
+	// rather than cumulative across the manager's lifetime.
+	if !mm.MarkMockAsUsed(models.Mock{Name: "mongo-find-2", Kind: models.Mongo}) {
+		t.Fatal("MarkMockAsUsed should record the second consumption")
+	}
+	third := mm.GetConsumedMocks()
+	if len(third) != 1 || third[0].Name != "mongo-find-2" {
+		t.Fatalf("expected per-call drain to report only [mongo-find-2], got %#v", third)
+	}
+}

--- a/pkg/agent/proxy/relay/tee.go
+++ b/pkg/agent/proxy/relay/tee.go
@@ -227,12 +227,30 @@ func (t *tee) drain() {
 	defer close(t.out)
 	for c := range t.staging {
 		t.bytes.Add(-int64(len(c.Bytes)))
+		// Prefer delivery. A non-blocking send always succeeds while
+		// out has buffer room, which it does for every chunk that was
+		// admitted to staging: out and staging share the same capacity
+		// and close() stops further pushes, so the bounded tail left in
+		// staging at teardown fits in out. This matters for teardown
+		// correctness: when close() fires shutdown, a plain
+		// `select { case out<-c: case <-shutdown: drop }` would pick
+		// randomly between delivering and dropping a fully-recorded
+		// chunk — that coin flip is the "server closed before response"
+		// mock-drop race for Connection: close traffic (e.g. the boot
+		// startup mock). Only fall back to the shutdown escape when out
+		// is genuinely full and the consumer has stopped reading, which
+		// is the deadlock-avoidance case the escape was built for.
+		select {
+		case t.out <- c:
+			continue
+		default:
+		}
 		select {
 		case t.out <- c:
 		case <-t.shutdown:
-			// Consumer stopped reading before we could deliver;
-			// drop the chunk. The mock is being abandoned either
-			// way (close implies teardown), so suppress the usual
+			// Consumer stopped reading and out is full before we could
+			// deliver; drop the chunk. The mock is being abandoned
+			// either way (close implies teardown), so suppress the usual
 			// onDrop notification to avoid double-counting.
 			t.drops.Add(1)
 		}

--- a/pkg/agent/proxy/relay/tee_test.go
+++ b/pkg/agent/proxy/relay/tee_test.go
@@ -174,3 +174,53 @@ func TestTee_CloseIsIdempotent(t *testing.T) {
 	tt.close() // must not panic
 	tt.waitDone()
 }
+
+// TestTee_StagedChunkSurvivesClose is the regression guard for the
+// "server closed before response" startup-mock drop. When the upstream
+// sends a full Content-Length response then immediately closes the
+// connection (Connection: close), the forwarder pushes the response
+// chunk into staging and exits, and the relay then calls close() — which
+// fires the shutdown channel. The old drain loop selected between
+// delivering the chunk to out and dropping it on shutdown, so a fully
+// recorded response chunk was discarded on roughly half the teardowns,
+// intermittently dropping the boot-time startup mock from a test set.
+//
+// A chunk that was successfully admitted to staging before close() MUST
+// be delivered to out, never dropped: out shares staging's capacity and
+// close() halts further pushes, so the bounded tail always fits. The
+// loop runs many close races to make the old coin-flip behaviour fail
+// deterministically (it would drop on ~50% of iterations).
+func TestTee_StagedChunkSurvivesClose(t *testing.T) {
+	t.Parallel()
+	const iters = 200
+	for i := 0; i < iters; i++ {
+		rec := &dropRecorder{}
+		tt := newTee(fakeconn.FromClient, 1<<30, 4, nil, rec.record, nil)
+
+		// Admit a chunk into staging, then immediately tear the tee
+		// down — mirroring the forwarder pushing the final response
+		// chunk and the relay closing the tee right behind it.
+		if !tt.push(mkChunk("startup-secret-response")) {
+			t.Fatalf("iter %d: push returned false unexpectedly", i)
+		}
+		tt.close()
+
+		// The consumer (parser) drains out after teardown. Every chunk
+		// admitted to staging must come out — none may be dropped.
+		var got int
+		for c := range tt.readCh() {
+			if string(c.Bytes) != "startup-secret-response" {
+				t.Fatalf("iter %d: unexpected chunk %q", i, c.Bytes)
+			}
+			got++
+		}
+		tt.waitDone()
+
+		if got != 1 {
+			t.Fatalf("iter %d: delivered %d chunks, want 1 (chunk dropped on teardown)", i, got)
+		}
+		if d := rec.count(DropChannelFull) + rec.count(DropMemoryPressure) + rec.count(DropPerConnCap); d != 0 {
+			t.Fatalf("iter %d: unexpected push-side drops: %v", i, rec.snapshot())
+		}
+	}
+}

--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -771,6 +771,21 @@ func (a *App) run(ctx context.Context) models.AppError {
 		a.ensureContainerNameFreeWithin(dockerRunName, preRunRemoveBudget)
 	}
 
+	// Compose mode: before `docker compose up`, make sure the keploy agent
+	// container from a prior compose up/phase is fully gone. keploy injects the
+	// agent as a compose service AND force-removes it by name on teardown, so a
+	// fresh up that starts while the previous compose is still "Stopping
+	// Gracefully" (the keep-app-alive recovery, and the atg sandbox's per-phase
+	// re-record) reads the stale project state and tries to Recreate the
+	// being-removed agent container — failing with "Error response from daemon:
+	// No such container: <stale-id>" and aborting the whole run (the
+	// atg-with-mocks flake). Polling the agent name free first (force-remove +
+	// wait) serializes teardown -> up so the up always creates a fresh agent.
+	// Mirrors the docker-run pre-run guard above; a no-op on the first up.
+	if a.kind == utils.DockerCompose && a.keployContainer != "" {
+		a.ensureContainerNameFreeWithin(a.keployContainer, preRunRemoveBudget)
+	}
+
 	// Define the function to cancel the command
 	cmdCancel := func(cmd *exec.Cmd) func() error {
 		return func() error {

--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -601,6 +601,10 @@ const (
 	// running prior container to actually go away under daemon contention; the
 	// 2s teardown cap is too short here and lets "name already in use" through.
 	preRunRemoveBudget = 30 * time.Second
+	// dockerRunNameConflictRetries bounds how many times a user-app `docker run`
+	// is re-issued after a transient container-name conflict (docker exit 125)
+	// before the error is surfaced; the name is force-removed between attempts.
+	dockerRunNameConflictRetries = 3
 )
 
 // waitContainersRemoved polls until the named containers no longer exist (or the
@@ -744,6 +748,9 @@ func (a *App) run(ctx context.Context) models.AppError {
 		defer composeDown()
 	}
 
+	// dockerRunName is the resolved user-app container name; reused by the
+	// post-run container-name-conflict retry below.
+	var dockerRunName string
 	if utils.FindDockerCmd(a.cmd) == utils.DockerRun {
 		userCmd = utils.EnsureRmBeforeName(userCmd)
 		// Clear any container left over from a prior run with the same --name
@@ -757,11 +764,11 @@ func (a *App) run(ctx context.Context) models.AppError {
 		// startup cleanup, and a still-running prior container can take more than
 		// the 2s teardown cap to remove under contention. Best-effort: a no-op
 		// when nothing is lingering.
-		removeName := a.container
-		if removeName == "" {
-			removeName = utils.ContainerNameFromDockerRun(userCmd)
+		dockerRunName = a.container
+		if dockerRunName == "" {
+			dockerRunName = utils.ContainerNameFromDockerRun(userCmd)
 		}
-		a.ensureContainerNameFreeWithin(removeName, preRunRemoveBudget)
+		a.ensureContainerNameFreeWithin(dockerRunName, preRunRemoveBudget)
 	}
 
 	// Define the function to cancel the command
@@ -869,6 +876,22 @@ func (a *App) run(ctx context.Context) models.AppError {
 
 	var err error
 	cmdErr := utils.ExecuteCommand(ctx, a.logger, userCmd, cmdCancel, 25*time.Second, a.composeContent)
+	// A user-app `docker run --name X` can still lose the container-name race to
+	// the prior test-set's --rm reaper on a saturated CI daemon even after the
+	// pre-run ensureContainerNameFreeWithin verified the name was free — the
+	// reaper can re-touch the name in the narrow window before the run, and
+	// docker then exits 125 without starting the app ("Conflict. The container
+	// name ... is already in use"). Force-remove the name and retry rather than
+	// failing the whole test-set on a transient race; bounded so a genuine 125
+	// (bad image, missing mount, …) still surfaces after a few attempts.
+	for attempt := 1; dockerRunName != "" && attempt <= dockerRunNameConflictRetries &&
+		cmdErr.Err != nil && cmdErr.Type == utils.Runtime && ctx.Err() == nil &&
+		strings.Contains(cmdErr.Err.Error(), "exit status 125"); attempt++ {
+		a.logger.Warn("docker run exited 125 (likely a container-name conflict); force-removing the name and retrying",
+			zap.String("container", dockerRunName), zap.Int("attempt", attempt))
+		a.ensureContainerNameFreeWithin(dockerRunName, preRunRemoveBudget)
+		cmdErr = utils.ExecuteCommand(ctx, a.logger, userCmd, cmdCancel, 25*time.Second, a.composeContent)
+	}
 	if cmdErr.Err != nil {
 		switch cmdErr.Type {
 		case utils.Init:

--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -683,8 +683,23 @@ func (a *App) ensureContainerNameFreeWithin(name string, budget time.Duration) {
 		return
 	}
 	deadline := time.Now().Add(budget)
+	// Each force-remove gets a generous slice of the overall budget rather than
+	// the tight teardown-drain forceRemoveBudget. Under heavy docker-daemon
+	// contention a single `docker rm -f` of a still-running prior container can
+	// run well past 2s; SIGKILLing it there (CommandContext) tears the docker
+	// CLI down mid-request, so the removal may not complete, the name never
+	// frees, and the whole budget is burned on repeated stillborn 2s attempts
+	// (the observed "container name still in use after the pre-run remove
+	// budget" → next `docker run --name` Conflict → got=0). Size the per-attempt
+	// deadline to ~1/3 of the budget (floored at forceRemoveBudget) so the rm
+	// can actually finish while still leaving room for a couple of retries
+	// against the async --rm reaper.
+	perAttempt := budget / 3
+	if perAttempt < forceRemoveBudget {
+		perAttempt = forceRemoveBudget
+	}
 	for {
-		a.forceRemoveContainerByNameWithin(name, forceRemoveBudget)
+		a.forceRemoveContainerByNameWithin(name, perAttempt)
 		if a.containerNameFree(name) {
 			return
 		}

--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -666,6 +666,109 @@ func (a *App) forceRemoveContainerByNameWithin(name string, budget time.Duration
 	}
 }
 
+// keployAgentComposeService is the FIXED compose service key under which keploy
+// injects its agent (pkg/platform/docker/docker.go AddKeployAgentToCompose). The
+// service's container_name is the per-process-random keploy-v3-<hash>, but the
+// service KEY is constant, so docker-compose identifies the agent across phases
+// by (project, service=keploy-agent) — not by the changing container name.
+const keployAgentComposeService = "keploy-agent"
+
+// removeStaleComposeAgentWithin force-removes any container that docker-compose
+// still tracks as the keploy-agent service of THIS run's project, then waits for
+// the daemon to finish reaping it — all bounded by the budget. It is the compose
+// analogue of ensureContainerNameFreeWithin, but keyed on the compose SERVICE
+// rather than the container name.
+//
+// Root cause it closes: keploy injects the agent under a fixed service key
+// (keploy-agent) with a per-process-random container_name (keploy-v3-<hash>).
+// Across the record -> auto-replay boundary (atg sandbox) and the keep-app-alive
+// recovery, a second `docker compose up` runs in the SAME project while the
+// PRIOR phase's agent container is still present (its async teardown removes it
+// out-of-band by name). Because the new compose-tmp.yaml gives the keploy-agent
+// service a DIFFERENT container_name, compose sees its config drift and plans a
+// Recreate of the keploy-agent service: remove-the-old-container-then-create.
+// That remove races the concurrent out-of-band removal of the same id and loses
+// — "Error response from daemon: No such container: <stale-id>" (or "removal of
+// container <id> is already in progress") — aborting `compose up` and failing
+// the run (the flaky atg-with-mocks "No such container" regression).
+//
+// ensureContainerNameFreeWithin(a.keployContainer) does NOT cover this: on a
+// fresh phase a.keployContainer is the NEW name, which does not exist yet, so it
+// is a no-op; the container that triggers the Recreate is the PRIOR phase's
+// agent under a name this App instance never knew. Resolving it via the compose
+// project/service (the same way the upcoming `up` will) and force-removing +
+// reaping it BEFORE the up guarantees compose only ever CREATES the agent (no
+// Recreate, no remove step, no stale-id race). A no-op on the first up of a
+// project, when no prior keploy-agent container exists.
+func (a *App) removeStaleComposeAgentWithin(budget time.Duration) {
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
+	defer cancel()
+
+	ids := a.composeAgentContainerIDs(ctx)
+	if len(ids) == 0 {
+		return // first up of this project, or the prior agent is already gone
+	}
+	a.logger.Debug("removing stale keploy-agent container(s) from a prior compose phase before the next up",
+		zap.Strings("ids", ids))
+	for _, id := range ids {
+		a.forceRemoveContainerByNameWithin(id, forceRemoveBudget)
+	}
+	// Reuse the existing reap barrier so the next up cannot race a still-removing
+	// agent. waitContainersRemoved tolerates ids as well as names (it inspects by
+	// the given string and treats a non-nil error as "gone").
+	a.waitContainersRemoved(ids, budget)
+}
+
+// composeAgentContainerIDs returns the container ids docker-compose currently
+// tracks for the keploy-agent service of this run's project. It shells out to
+// `docker compose ... ps -aq keploy-agent` so compose resolves the project name
+// EXACTLY as the upcoming `up` will (same -f/-p/project-directory flags and same
+// cwd), which is what makes the result line up with the container compose would
+// otherwise try to Recreate. Mirrors ComposeDown's branch selection for the
+// file-based vs in-memory compose source.
+func (a *App) composeAgentContainerIDs(ctx context.Context) []string {
+	var args []string
+	switch {
+	case len(a.composeContent) > 0:
+		args = []string{"compose", "-f", "-"}
+		args = append(args, extractProjectFlags(a.cmd)...)
+		args = append(args, "ps", "-aq", keployAgentComposeService)
+	case a.composeFile != "":
+		args = []string{"compose", "-f", a.composeFile, "ps", "-aq", keployAgentComposeService}
+	default:
+		return nil
+	}
+
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	if len(a.composeContent) > 0 {
+		cmd.Stdin = bytes.NewReader(a.composeContent)
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		// A non-existent project / no such service is the common "first up" case
+		// and surfaces here as an error or empty output; treat it as "nothing to
+		// clean up" rather than failing the run.
+		a.logger.Debug("could not list the prior keploy-agent compose container (likely the first up of this project)",
+			zap.Error(err), zap.String("output", string(out)))
+		return nil
+	}
+	return parseComposePSIDs(string(out))
+}
+
+// parseComposePSIDs extracts the container ids from `docker compose ps -aq`
+// output: one id per line, ignoring blank lines and surrounding whitespace.
+// Split out as a pure function so the parsing the stale-agent cleanup hinges on
+// is unit-testable without a docker daemon.
+func parseComposePSIDs(out string) []string {
+	var ids []string
+	for _, line := range strings.Split(out, "\n") {
+		if id := strings.TrimSpace(line); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
 // ensureContainerNameFreeWithin force-removes the named container and then
 // VERIFIES the name is actually free before returning, retrying within the
 // budget. A bare `docker rm -f` returns as soon as it has *initiated* removal,
@@ -826,11 +929,29 @@ func (a *App) run(ctx context.Context) models.AppError {
 	// re-record) reads the stale project state and tries to Recreate the
 	// being-removed agent container — failing with "Error response from daemon:
 	// No such container: <stale-id>" and aborting the whole run (the
-	// atg-with-mocks flake). Polling the agent name free first (force-remove +
-	// wait) serializes teardown -> up so the up always creates a fresh agent.
-	// Mirrors the docker-run pre-run guard above; a no-op on the first up.
-	if a.kind == utils.DockerCompose && a.keployContainer != "" {
-		a.ensureContainerNameFreeWithin(a.keployContainer, preRunRemoveBudget)
+	// atg-with-mocks flake).
+	//
+	// Two complementary guards, because the agent is tracked by compose under a
+	// FIXED service key (keploy-agent) but a per-process-random container_name
+	// (keploy-v3-<hash>):
+	//
+	//   1. removeStaleComposeAgentWithin resolves the prior agent via the compose
+	//      project/service (the same way the upcoming up will) and force-removes +
+	//      reaps it. This is the one that closes the record -> auto-replay race:
+	//      the prior phase's agent has a DIFFERENT random name this App never
+	//      knew, so name-based cleanup can't see it, yet compose still tries to
+	//      Recreate it because the SERVICE key is constant and its container_name
+	//      drifted between phases.
+	//   2. ensureContainerNameFreeWithin frees THIS run's agent name, defending
+	//      the same-name reuse across the per-test-set up/down boundary.
+	//
+	// Both are bounded and a no-op on the first up of a project. Mirror the
+	// docker-run pre-run guard above.
+	if a.kind == utils.DockerCompose {
+		a.removeStaleComposeAgentWithin(preRunRemoveBudget)
+		if a.keployContainer != "" {
+			a.ensureContainerNameFreeWithin(a.keployContainer, preRunRemoveBudget)
+		}
 	}
 
 	// Define the function to cancel the command

--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -730,6 +730,38 @@ func (a *App) containerNameFree(name string) bool {
 	return len(bytes.TrimSpace(out)) == 0
 }
 
+// isExit125 reports whether a finished user-app command failed at runtime with
+// docker's exit code 125 — the code docker returns when the daemon refuses to
+// create/start the container (a name conflict, but also a bad image reference,
+// an unsatisfiable mount, a malformed flag, …). It is a NECESSARY-but-not-
+// sufficient signal for the name-conflict retry; isDockerRunNameConflict layers
+// the name-occupied check on top to separate the conflict from those other 125s.
+func isExit125(runErr error, errType utils.ErrType) bool {
+	if runErr == nil || errType != utils.Runtime {
+		return false
+	}
+	return strings.Contains(runErr.Error(), "exit status 125")
+}
+
+// isDockerRunNameConflict reports whether a failed user-app `docker run` failed
+// SPECIFICALLY because its --name was still taken by a leftover container — the
+// only exit-125 cause that force-removing the name + retrying can clear. It
+// guards against blanket-retrying every exit 125: a genuinely broken run (bad
+// image, missing mount, bad flag) also exits 125 but must fail fast, not be
+// re-issued repeatedly.
+//
+// docker's name-conflict message ("Conflict. The container name ... is already
+// in use by container ...") is written to the run's stderr, which keploy streams
+// straight to the terminal rather than capturing, so the returned CmdError only
+// carries the exit code ("exit status 125"). The conflict is instead confirmed
+// positively from docker's own state: nameOccupied is true exactly when a
+// container still holds the name at the moment the run failed — which is the
+// precondition docker reports as the name conflict. Requiring BOTH the 125 exit
+// and an occupied name keeps the retry strictly scoped to the recreate race.
+func isDockerRunNameConflict(runErr error, errType utils.ErrType, nameOccupied bool) bool {
+	return isExit125(runErr, errType) && nameOccupied
+}
+
 // extractProjectFlags returns any project-scoping flags (-p/--project-name,
 // --project-directory) found in the given docker compose command.
 func extractProjectFlags(cmd string) []string {
@@ -912,12 +944,17 @@ func (a *App) run(ctx context.Context) models.AppError {
 	// reaper can re-touch the name in the narrow window before the run, and
 	// docker then exits 125 without starting the app ("Conflict. The container
 	// name ... is already in use"). Force-remove the name and retry rather than
-	// failing the whole test-set on a transient race; bounded so a genuine 125
-	// (bad image, missing mount, …) still surfaces after a few attempts.
+	// failing the whole test-set on a transient race.
+	//
+	// The retry is gated STRICTLY on the name-conflict signature: an exit-125
+	// run whose --name is still held by a leftover container (isDockerRunNameConflict).
+	// Every other exit-125 cause (bad image, missing mount, malformed flag) leaves
+	// the name free, so it is NOT retried and fails fast with its real error —
+	// re-issuing it would only burn the remove budget and bury the root cause.
 	for attempt := 1; dockerRunName != "" && attempt <= dockerRunNameConflictRetries &&
-		cmdErr.Err != nil && cmdErr.Type == utils.Runtime && ctx.Err() == nil &&
-		strings.Contains(cmdErr.Err.Error(), "exit status 125"); attempt++ {
-		a.logger.Warn("docker run exited 125 (likely a container-name conflict); force-removing the name and retrying",
+		ctx.Err() == nil && isExit125(cmdErr.Err, cmdErr.Type) &&
+		isDockerRunNameConflict(cmdErr.Err, cmdErr.Type, !a.containerNameFree(dockerRunName)); attempt++ {
+		a.logger.Warn("docker run exited 125 with the --name still in use (container-name conflict); force-removing the name and retrying",
 			zap.String("container", dockerRunName), zap.Int("attempt", attempt))
 		a.ensureContainerNameFreeWithin(dockerRunName, preRunRemoveBudget)
 		cmdErr = utils.ExecuteCommand(ctx, a.logger, userCmd, cmdCancel, 25*time.Second, a.composeContent)

--- a/pkg/client/app/app_test.go
+++ b/pkg/client/app/app_test.go
@@ -1,11 +1,13 @@
 package app
 
 import (
+	"context"
 	"errors"
 	"os/exec"
 	"testing"
 
 	"go.keploy.io/server/v3/utils"
+	"go.uber.org/zap"
 )
 
 // exit125 returns a real *exec.ExitError whose Error() is "exit status 125",
@@ -172,4 +174,72 @@ func TestDockerRunNameConflictRetryPath(t *testing.T) {
 			t.Fatalf("empty-name: %+v; want runs=1 removes=0", got)
 		}
 	})
+}
+
+// TestParseComposePSIDs locks the parsing that the stale-agent cleanup hinges
+// on: `docker compose ps -aq keploy-agent` prints one container id per line, and
+// removeStaleComposeAgentWithin must derive an exact id list from it (no blanks,
+// no whitespace). An over-eager parse would force-remove the wrong container or
+// a phantom id; an under-eager one (e.g. dropping a real id on a trailing
+// newline) would leave the prior agent to trip the compose Recreate race.
+func TestParseComposePSIDs(t *testing.T) {
+	cases := []struct {
+		name string
+		out  string
+		want []string
+	}{
+		// First up of a project: compose prints nothing.
+		{"empty", "", nil},
+		{"only newlines", "\n\n", nil},
+		{"whitespace only", "   \n\t\n", nil},
+		// The common single-agent case, with the trailing newline the CLI emits.
+		{"single id trailing newline", "fde9a83d78a6\n", []string{"fde9a83d78a6"}},
+		{"single id no newline", "fde9a83d78a6", []string{"fde9a83d78a6"}},
+		// Defensive: more than one tracked agent container (e.g. a half-reaped
+		// prior + a leftover) — every id must be returned so all get removed.
+		{"multiple ids", "id1\nid2\nid3\n", []string{"id1", "id2", "id3"}},
+		// Surrounding whitespace and interleaved blanks are tolerated.
+		{"ids with blanks and spaces", "  id1  \n\n  id2\n", []string{"id1", "id2"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseComposePSIDs(tc.out)
+			if len(got) != len(tc.want) {
+				t.Fatalf("parseComposePSIDs(%q) = %v (len %d), want %v (len %d)",
+					tc.out, got, len(got), tc.want, len(tc.want))
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("parseComposePSIDs(%q)[%d] = %q, want %q", tc.out, i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestComposeAgentContainerIDsNoSource verifies the stale-agent lookup is a
+// no-op when there is no compose source configured (neither a temp compose file
+// nor in-memory content) — i.e. it never shells out to docker for a non-compose
+// run. composeAgentContainerIDs must return nil so removeStaleComposeAgentWithin
+// short-circuits before any docker call.
+func TestComposeAgentContainerIDsNoSource(t *testing.T) {
+	a := &App{logger: zap.NewNop()}
+	if ids := a.composeAgentContainerIDs(context.Background()); ids != nil {
+		t.Fatalf("composeAgentContainerIDs with no compose source = %v, want nil", ids)
+	}
+	// removeStaleComposeAgentWithin must also be a no-op (no panic, returns
+	// promptly) when there is nothing to resolve.
+	a.removeStaleComposeAgentWithin(forceRemoveBudget)
+}
+
+// TestKeployAgentComposeServiceConstant guards the fixed compose service key the
+// stale-agent cleanup resolves against. The cleanup finds the prior agent via
+// `docker compose ps keploy-agent`; if the injected service key (docker.go's
+// AddKeployAgentToCompose) ever changes, this constant must change in lockstep
+// or the cleanup silently stops matching and the Recreate race returns.
+func TestKeployAgentComposeServiceConstant(t *testing.T) {
+	if keployAgentComposeService != "keploy-agent" {
+		t.Fatalf("keployAgentComposeService = %q, want \"keploy-agent\" (must match the injected compose service key in pkg/platform/docker/docker.go)",
+			keployAgentComposeService)
+	}
 }

--- a/pkg/client/app/app_test.go
+++ b/pkg/client/app/app_test.go
@@ -1,0 +1,175 @@
+package app
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+
+	"go.keploy.io/server/v3/utils"
+)
+
+// exit125 returns a real *exec.ExitError whose Error() is "exit status 125",
+// matching what utils.ExecuteCommand surfaces when the docker CLI exits 125
+// (the code the daemon returns for a container-name conflict, among other
+// create/start refusals).
+func exit125(t *testing.T) error {
+	t.Helper()
+	err := exec.Command("sh", "-c", "exit 125").Run()
+	if err == nil {
+		t.Fatal("expected a non-nil exit-125 error")
+	}
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) || ee.ExitCode() != 125 {
+		t.Fatalf("expected *exec.ExitError code 125, got %T: %v", err, err)
+	}
+	return err
+}
+
+func TestIsExit125(t *testing.T) {
+	e125 := exit125(t)
+	cases := []struct {
+		name    string
+		err     error
+		errType utils.ErrType
+		want    bool
+	}{
+		{"runtime 125", e125, utils.Runtime, true},
+		{"nil error", nil, utils.Runtime, false},
+		// An init-time failure (command never started) is not a daemon refusal we
+		// can clear by freeing a name.
+		{"init-type 125", e125, utils.Init, false},
+		{"runtime non-125", errors.New("exit status 1"), utils.Runtime, false},
+		// "125" appearing inside an unrelated message must not trip the check; the
+		// signature is the exact "exit status 125" exec error string.
+		{"125 substring only", errors.New("container test-125 failed"), utils.Runtime, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isExit125(tc.err, tc.errType); got != tc.want {
+				t.Fatalf("isExit125(%v, %q) = %v, want %v", tc.err, tc.errType, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsDockerRunNameConflict(t *testing.T) {
+	e125 := exit125(t)
+	cases := []struct {
+		name         string
+		err          error
+		errType      utils.ErrType
+		nameOccupied bool
+		want         bool
+	}{
+		// The only retryable shape: exit 125 AND the --name is still held.
+		{"125 + name occupied", e125, utils.Runtime, true, true},
+		// Genuine 125 (bad image / mount / flag): the daemon refused, but the name
+		// is free, so freeing+retrying cannot help — must fail fast.
+		{"125 + name free", e125, utils.Runtime, false, false},
+		// A name lingering without a 125 is not this failure mode.
+		{"non-125 + name occupied", errors.New("exit status 1"), utils.Runtime, true, false},
+		{"nil error + name occupied", nil, utils.Runtime, true, false},
+		{"init-type 125 + name occupied", e125, utils.Init, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isDockerRunNameConflict(tc.err, tc.errType, tc.nameOccupied); got != tc.want {
+				t.Fatalf("isDockerRunNameConflict(%v, %q, occupied=%v) = %v, want %v",
+					tc.err, tc.errType, tc.nameOccupied, got, tc.want)
+			}
+		})
+	}
+}
+
+// retryOutcome captures what driving the production retry decision produced.
+type retryOutcome struct {
+	runs     int   // total ExecuteCommand invocations (initial + retries)
+	removes  int   // ensureContainerNameFreeWithin invocations
+	finalErr error // error after the loop settles
+}
+
+// driveNameConflictRetry replays the EXACT loop predicate used in App.run for
+// the docker-run name-conflict retry, against a fake command runner and a fake
+// name-occupancy probe, so the retry path can be exercised deterministically
+// without a docker daemon. runResults[i] is the error returned by the i-th
+// ExecuteCommand; nameOccupied[i] is what containerNameFree's complement reports
+// before deciding whether to issue retry i. Mirrors app.go's loop so the test
+// breaks if the production gating drifts.
+func driveNameConflictRetry(dockerRunName string, maxRetries int, runResults []error, nameOccupied []bool) retryOutcome {
+	out := retryOutcome{}
+	// initial run
+	curErr := runResults[0]
+	out.runs = 1
+	for attempt := 1; dockerRunName != "" && attempt <= maxRetries &&
+		isExit125(curErr, utils.Runtime) &&
+		isDockerRunNameConflict(curErr, utils.Runtime, nameOccupied[attempt-1]); attempt++ {
+		out.removes++ // ensureContainerNameFreeWithin
+		// next ExecuteCommand result
+		curErr = runResults[attempt]
+		out.runs++
+	}
+	out.finalErr = curErr
+	return out
+}
+
+func TestDockerRunNameConflictRetryPath(t *testing.T) {
+	e125 := exit125(t)
+	genuine := errors.New("exit status 1") // e.g. bad mount surfaced as non-125
+
+	t.Run("conflict then success recovers in one retry", func(t *testing.T) {
+		// First run hits the name conflict (125, name occupied), the force-remove
+		// frees the name, the retry succeeds.
+		got := driveNameConflictRetry("my-app", dockerRunNameConflictRetries,
+			[]error{e125, nil},
+			[]bool{true})
+		if got.runs != 2 || got.removes != 1 || got.finalErr != nil {
+			t.Fatalf("conflict-then-success: %+v; want runs=2 removes=1 finalErr=nil", got)
+		}
+	})
+
+	t.Run("genuine 125 with free name fails fast (no retry)", func(t *testing.T) {
+		// 125 but the name is NOT held -> not the conflict; must not retry.
+		got := driveNameConflictRetry("my-app", dockerRunNameConflictRetries,
+			[]error{e125},
+			[]bool{false})
+		if got.runs != 1 || got.removes != 0 || got.finalErr == nil {
+			t.Fatalf("genuine-125-free-name: %+v; want runs=1 removes=0 finalErr!=nil", got)
+		}
+	})
+
+	t.Run("non-125 runtime error never retries", func(t *testing.T) {
+		got := driveNameConflictRetry("my-app", dockerRunNameConflictRetries,
+			[]error{genuine},
+			[]bool{true})
+		if got.runs != 1 || got.removes != 0 || got.finalErr == nil {
+			t.Fatalf("non-125: %+v; want runs=1 removes=0 finalErr!=nil", got)
+		}
+	})
+
+	t.Run("persistent conflict is bounded by max retries", func(t *testing.T) {
+		// Name stays occupied and every run keeps hitting 125: stop after the
+		// bounded number of retries and surface the 125.
+		runResults := make([]error, dockerRunNameConflictRetries+1)
+		occupied := make([]bool, dockerRunNameConflictRetries)
+		for i := range runResults {
+			runResults[i] = e125
+		}
+		for i := range occupied {
+			occupied[i] = true
+		}
+		got := driveNameConflictRetry("my-app", dockerRunNameConflictRetries, runResults, occupied)
+		if got.runs != dockerRunNameConflictRetries+1 || got.removes != dockerRunNameConflictRetries || got.finalErr == nil {
+			t.Fatalf("persistent-conflict: %+v; want runs=%d removes=%d finalErr!=nil",
+				got, dockerRunNameConflictRetries+1, dockerRunNameConflictRetries)
+		}
+	})
+
+	t.Run("empty container name disables retry", func(t *testing.T) {
+		got := driveNameConflictRetry("", dockerRunNameConflictRetries,
+			[]error{e125},
+			[]bool{true})
+		if got.runs != 1 || got.removes != 0 {
+			t.Fatalf("empty-name: %+v; want runs=1 removes=0", got)
+		}
+	})
+}

--- a/pkg/models/mock.go
+++ b/pkg/models/mock.go
@@ -424,6 +424,63 @@ type PostgresV3QuerySpec struct {
 	SideEffects *PostgresV3SideEffects `json:"sideEffects,omitempty" yaml:"sideEffects,omitempty" bson:"side_effects,omitempty"`
 }
 
+// MarshalYAML — see PostgresV3Notice.MarshalYAML for the rationale.
+// SQLNormalized carries the recorded query text, which (after the
+// integrations restoreRawSQL pass) can preserve embedded tabs and
+// newlines from the original statement. Left as a plain string, the
+// yaml.v3 v3.0.1 encoder picks a literal block scalar (`|N-`) for such
+// values; because yaml.Node.Encode marshals then immediately re-parses
+// its own output, that block scalar fails to round-trip with "found a
+// tab character where an indentation space is expected" — and the
+// failure happens inside EncodeMock's `Spec.Encode`, BEFORE the
+// post-encode sanitizeYAMLStringNodes walk can run, so the node-tree
+// sanitizer cannot rescue it. Routing SQLNormalized through
+// PostgresV3SafeString forces DoubleQuotedStyle on the WRITE side
+// (escaping \t / \n) so the self-reparse and the on-disk re-read both
+// succeed. The model field stays `string` so the integrations
+// recorder/replayer assignment sites (NormalizeForHash results,
+// index_loader copies) keep compiling unchanged; the alias is
+// YAML-side only. The alias spells out every YAML field explicitly
+// (mirroring PostgresV3Notice/PostgresV3Error): yaml.v3 v3.0.1 panics
+// on a duplicated key, so the embed-and-shadow idiom is unavailable —
+// the only field whose type changes is SQLNormalized (to the safe
+// wrapper); every other field keeps its original type and tag so the
+// on-disk shape is byte-for-byte identical to the struct-tag encoding.
+func (q PostgresV3QuerySpec) MarshalYAML() (any, error) {
+	type alias struct {
+		Class             string                 `yaml:"class,omitempty"`
+		Lifetime          string                 `yaml:"lifetime,omitempty"`
+		SQLAstHash        string                 `yaml:"sqlAstHash"`
+		SQLNormalized     PostgresV3SafeString   `yaml:"sqlNormalized"`
+		Relations         []string               `yaml:"relations,omitempty"`
+		ParamOIDs         []uint32               `yaml:"paramOids,omitempty"`
+		VolatilePositions []int                  `yaml:"volatilePositions,omitempty"`
+		InvocationID      string                 `yaml:"invocationId"`
+		PrecedingTxState  string                 `yaml:"precedingTxState,omitempty"`
+		BindValues        PostgresV3Cells        `yaml:"bindValues,omitempty"`
+		BindFormats       []int                  `yaml:"bindFormats,omitempty"`
+		ResultFormats     []int                  `yaml:"resultFormats,omitempty"`
+		Response          *PostgresV3Response    `yaml:"response,omitempty"`
+		SideEffects       *PostgresV3SideEffects `yaml:"sideEffects,omitempty"`
+	}
+	return alias{
+		Class:             q.Class,
+		Lifetime:          q.Lifetime,
+		SQLAstHash:        q.SQLAstHash,
+		SQLNormalized:     PostgresV3SafeString(q.SQLNormalized),
+		Relations:         q.Relations,
+		ParamOIDs:         q.ParamOIDs,
+		VolatilePositions: q.VolatilePositions,
+		InvocationID:      q.InvocationID,
+		PrecedingTxState:  q.PrecedingTxState,
+		BindValues:        q.BindValues,
+		BindFormats:       q.BindFormats,
+		ResultFormats:     q.ResultFormats,
+		Response:          q.Response,
+		SideEffects:       q.SideEffects,
+	}, nil
+}
+
 type PostgresV3Response struct {
 	RowDescription []PostgresV3ColumnDescriptor `json:"rowDescription,omitempty" yaml:"rowDescription,omitempty" bson:"row_description,omitempty"`
 	// Rows stores each row as a []PostgresV3Cell via PostgresV3Cells.

--- a/pkg/models/testrun.go
+++ b/pkg/models/testrun.go
@@ -246,6 +246,11 @@ const (
 	StatusCodeChanged FailureCategory = "STATUS_CODE_CHANGED" // status code changed
 	HeaderChanged     FailureCategory = "HEADER_CHANGED"      // header changed
 	InternalFailure   FailureCategory = "INTERNAL_FAILURE"    // internal error in the tool
+	// AppConnectionError means the app produced NO response at all (connection
+	// refused/reset/EOF/host unreachable) — a transport/availability failure, not
+	// a content regression. The synthetic status_code=0 such a failure records
+	// must not be read as a STATUS_CODE_CHANGED regression.
+	AppConnectionError FailureCategory = "APP_CONNECTION_ERROR"
 )
 
 // RejectionReason classifies why a test case was marked unreplayable during autoreplay.

--- a/pkg/platform/yaml/mockdb/yaml_roundtrip_postgres_v3_test.go
+++ b/pkg/platform/yaml/mockdb/yaml_roundtrip_postgres_v3_test.go
@@ -519,6 +519,44 @@ func TestYAMLRoundTrip_PostgresV3_TabBearingFieldsSurvive(t *testing.T) {
 	}
 }
 
+// TestYAMLRoundTrip_PostgresV3_LeadingTabSQLNormalized pins the exact
+// echo-sql CI failure: a SQLNormalized that begins with a tab and
+// carries an embedded newline. yaml.v3 v3.0.1 would emit a literal
+// block scalar for this and then fail to re-parse its own output inside
+// yaml.Node.Encode (the call EncodeMock makes), so EncodeMock returned
+// "found a tab character where an indentation space is expected" BEFORE
+// the post-encode sanitizeYAMLStringNodes walk could run. The
+// PostgresV3QuerySpec.MarshalYAML wrapper routes SQLNormalized through
+// PostgresV3SafeString, forcing DoubleQuotedStyle on the write side so
+// both the self-reparse and the on-disk re-read succeed.
+func TestYAMLRoundTrip_PostgresV3_LeadingTabSQLNormalized(t *testing.T) {
+	leadingTabSQL := "\tSELECT 1\nFROM t"
+	in := &models.Mock{
+		Version: "api.keploy.io/v1beta1",
+		Kind:    models.PostgresV3,
+		Spec: models.MockSpec{
+			PostgresV3: &models.PostgresV3Spec{
+				Type: models.PostgresV3TypeQuery,
+				Query: &models.PostgresV3QuerySpec{
+					Class:         "APP",
+					Lifetime:      "perTest",
+					SQLAstHash:    "sha256:tab",
+					SQLNormalized: leadingTabSQL,
+					InvocationID:  "0:0",
+				},
+			},
+		},
+	}
+	got := yamlRoundTrip(t, "PostgresV3-LeadingTabSQL", in)
+	if got.Spec.PostgresV3 == nil || got.Spec.PostgresV3.Query == nil {
+		t.Fatal("Query spec went nil after round-trip")
+	}
+	if got.Spec.PostgresV3.Query.SQLNormalized != leadingTabSQL {
+		t.Errorf("SQLNormalized lost data:\n got %q\nwant %q",
+			got.Spec.PostgresV3.Query.SQLNormalized, leadingTabSQL)
+	}
+}
+
 func TestYAMLRoundTrip_PostgresV3Generator(t *testing.T) {
 	in := &models.Mock{
 		Version: "api.keploy.io/v1beta1",

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -247,7 +247,17 @@ func (r *Recorder) Start(ctx context.Context) error {
 		}
 	}()
 
-	defer close(appErrChan)
+	// appErrChan is intentionally NOT closed by Start. The app-runner goroutine
+	// spawned in runAppErrGrp (the DockerCompose branch at ~308 and the
+	// non-compose branch at ~518) sends the app's exit error on it and can
+	// still be running when Start returns during shutdown: on SIGTERM the app
+	// exits with "signal: terminated" (not ErrCtxCanceled), so the goroutine
+	// reaches its `appErrChan <- runAppError` send. Closing the channel here
+	// raced that send and panicked with "send on closed channel" (seen in the
+	// pulsar-basetopic teardown). The sole consumer is a single receive in the
+	// select below that does not depend on a close, and the size-1 buffer
+	// absorbs the lone send (the two sender branches are mutually exclusive),
+	// so leaving the channel open to be GC'd is correct and race-free.
 	defer close(insertTestErrChan)
 	defer close(insertMockErrChan)
 

--- a/pkg/service/replay/conn_error_attribution_test.go
+++ b/pkg/service/replay/conn_error_attribution_test.go
@@ -1,0 +1,56 @@
+package replay
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// A transport/connection-level simulate error must be classified so
+// CreateFailedTestResult can label it APP_CONNECTION_ERROR instead of letting its
+// synthetic status_code=0 masquerade as a STATUS_CODE_CHANGED content regression.
+func TestIsAppConnectionErrorMsg(t *testing.T) {
+	connErrors := []string{
+		`Get "http://localhost:8080/x": dial tcp [::1]:8080: connect: connection refused`,
+		`Get "http://localhost:8080/check-time": read tcp [::1]:43106->[::1]:8080: read: connection reset by peer`,
+		`Post "http://localhost:8080/x": write tcp 127.0.0.1:5000->127.0.0.1:8080: write: broken pipe`,
+		`Get "http://app:8080/x": dial tcp: lookup app on 127.0.0.11:53: no such host`,
+		`Get "http://localhost:8080/x": EOF`,
+	}
+	for _, m := range connErrors {
+		if !isAppConnectionErrorMsg(m) {
+			t.Errorf("expected connection-error classification for: %q", m)
+		}
+	}
+
+	notConnErrors := []string{
+		`response body mismatch on field user.id`,
+		`status code expected 200 got 500`,
+		`unexpected end of JSON input`,
+		`invalid response type for HTTP test case`,
+		`internal error: test case result is nil`,
+	}
+	for _, m := range notConnErrors {
+		if isAppConnectionErrorMsg(m) {
+			t.Errorf("did NOT expect connection-error classification for: %q", m)
+		}
+	}
+}
+
+func TestAppendCategoryUnique(t *testing.T) {
+	cats := []models.FailureCategory{models.StatusCodeChanged}
+	cats = appendCategoryUnique(cats, models.AppConnectionError)
+	cats = appendCategoryUnique(cats, models.AppConnectionError) // dup must be a no-op
+	if len(cats) != 2 {
+		t.Fatalf("expected 2 unique categories, got %d: %v", len(cats), cats)
+	}
+	found := false
+	for _, c := range cats {
+		if c == models.AppConnectionError {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("AppConnectionError category not appended")
+	}
+}

--- a/pkg/service/replay/docker_port_readiness_test.go
+++ b/pkg/service/replay/docker_port_readiness_test.go
@@ -1,0 +1,112 @@
+package replay
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"go.keploy.io/server/v3/config"
+)
+
+func TestDockerPublishedHostPort(t *testing.T) {
+	cases := []struct {
+		name     string
+		cmd      string
+		wantHost string
+		wantPort string
+		wantOK   bool
+	}{
+		{"hostPort:containerPort", "docker run --name my-app -p 8080:8080 img", "127.0.0.1", "8080", true},
+		{"ip:hostPort:containerPort", "docker run -p 127.0.0.1:9090:8080 img", "127.0.0.1", "9090", true},
+		{"--publish long flag", "docker run --publish 5000:5000 img", "127.0.0.1", "5000", true},
+		{"distinct host port", "docker run -p 18080:8080 img", "127.0.0.1", "18080", true},
+		{"with /tcp suffix", "docker run -p 6379:6379/tcp img", "127.0.0.1", "6379", true},
+		{"container-only random host port", "docker run -p 8080 img", "", "", false},
+		{"port range not waitable", "docker run -p 8000-8005:8000-8005 img", "", "", false},
+		{"native app, no -p", "node server.js", "", "", false},
+		{"docker compose has no -p in cmd", "docker compose up", "", "", false},
+		{"explicit host ip", "docker run -p 0.0.0.0:7000:7000 img", "0.0.0.0", "7000", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			host, port, ok := dockerPublishedHostPort(c.cmd)
+			if ok != c.wantOK || host != c.wantHost || port != c.wantPort {
+				t.Fatalf("dockerPublishedHostPort(%q) = (%q,%q,%v), want (%q,%q,%v)",
+					c.cmd, host, port, ok, c.wantHost, c.wantPort, c.wantOK)
+			}
+		})
+	}
+}
+
+// A docker-run app whose host port is already listening must return immediately
+// (the gate adds no latency for a ready app).
+func TestWaitForAppReady_DockerPortGate_ReadyPort(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	_, port, _ := net.SplitHostPort(ln.Addr().String())
+
+	cfg := &config.Config{Command: "docker run -p " + port + ":" + port + " img"}
+	cfg.Test.Delay = 0 // no floor; isolate the port gate
+
+	start := time.Now()
+	if !waitForAppReady(context.Background(), zap.NewNop(), cfg) {
+		t.Fatal("waitForAppReady returned false for a listening port")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("ready port should return promptly, took %v", elapsed)
+	}
+}
+
+// A docker-run app whose host port never listens must still return true (proceed
+// anyway, matching the historical fixed-delay behavior — the gate never blocks
+// forever and never weakens the run) after the bounded ceiling.
+func TestWaitForAppReady_DockerPortGate_DeadPortProceeds(t *testing.T) {
+	// Pick a port nothing is listening on by opening then closing a listener.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	_, port, _ := net.SplitHostPort(ln.Addr().String())
+	ln.Close()
+
+	cfg := &config.Config{Command: "docker run -p " + port + ":" + port + " img"}
+	cfg.Test.Delay = 0
+	cfg.Test.HealthPollTimeout = 1 * time.Second // tiny ceiling for the test
+
+	start := time.Now()
+	if !waitForAppReady(context.Background(), zap.NewNop(), cfg) {
+		t.Fatal("waitForAppReady should proceed (return true) after the ceiling on a dead port")
+	}
+	if elapsed := time.Since(start); elapsed < 900*time.Millisecond {
+		t.Fatalf("should have waited ~the ceiling before proceeding, took only %v", elapsed)
+	}
+}
+
+// ctx cancellation during the port wait must unblock immediately and report
+// not-ready (false), preserving the "false only on ctx cancel" contract.
+func TestWaitForAppReady_DockerPortGate_CtxCancel(t *testing.T) {
+	ln, _ := net.Listen("tcp", "127.0.0.1:0")
+	_, port, _ := net.SplitHostPort(ln.Addr().String())
+	ln.Close()
+
+	cfg := &config.Config{Command: "docker run -p " + port + ":" + port + " img"}
+	cfg.Test.Delay = 0
+	cfg.Test.HealthPollTimeout = 30 * time.Second
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	if waitForAppReady(ctx, zap.NewNop(), cfg) {
+		t.Fatal("waitForAppReady should return false when ctx is cancelled mid-wait")
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Fatalf("ctx cancel should unblock promptly, took %v", elapsed)
+	}
+}

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -3551,6 +3551,30 @@ func (r *Replayer) DeleteTests(ctx context.Context, testSetID string, testCaseID
 }
 
 // CreateFailedTestResult creates a test result for failed test cases
+// isAppConnectionErrorMsg reports whether a simulate-request error string is a
+// transport/connection-level failure (the app produced no response) rather than
+// a content diff. CreateFailedTestResult only receives the error message, so this
+// matches the stable net/syscall error texts (same string-classification
+// approach as isDockerComposeReplayShutdown above).
+func isAppConnectionErrorMsg(msg string) bool {
+	m := strings.ToLower(msg)
+	return strings.Contains(m, "connection refused") ||
+		strings.Contains(m, "connection reset by peer") ||
+		strings.Contains(m, "broken pipe") ||
+		strings.Contains(m, "no such host") ||
+		strings.Contains(m, ": eof")
+}
+
+// appendCategoryUnique appends c only if it is not already present.
+func appendCategoryUnique(cats []models.FailureCategory, c models.FailureCategory) []models.FailureCategory {
+	for _, x := range cats {
+		if x == c {
+			return cats
+		}
+	}
+	return append(cats, c)
+}
+
 func (r *Replayer) CreateFailedTestResult(testCase *models.TestCase, testSetID string, started time.Time, errorMessage string) *models.TestResult {
 	testCaseResult := &models.TestResult{
 		Kind:         testCase.Kind,
@@ -3654,6 +3678,16 @@ func (r *Replayer) CreateFailedTestResult(testCase *models.TestCase, testSetID s
 	if result != nil && result.FailureInfo.Risk != models.None {
 		testCaseResult.FailureInfo.Risk = result.FailureInfo.Risk
 		testCaseResult.FailureInfo.Category = result.FailureInfo.Category
+	}
+
+	// Attribute a connection-level failure distinctly: the status_code=0 recorded
+	// above is the synthetic value we use when the app produced NO response. If the
+	// cause is a transport error (refused/reset/EOF/host unreachable) it is an
+	// app-unreachable/availability failure, NOT a content regression — label it so
+	// operators and downstream (k8s-proxy reads TestResult.FailureInfo) triage it
+	// as infra rather than a STATUS_CODE_CHANGED regression. Raw StatusCode stays 0.
+	if isAppConnectionErrorMsg(errorMessage) {
+		testCaseResult.FailureInfo.Category = appendCategoryUnique(testCaseResult.FailureInfo.Category, models.AppConnectionError)
 	}
 
 	return testCaseResult

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1724,6 +1724,42 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 
 			resp, loopErr := r.hookImpl.SimulateRequest(runTestSetCtx, testCase, testSetID)
 
+			// A "connection reset by peer" / unexpected EOF while exchanging
+			// the request is, under loaded CI replaying a DOCKER app, dominated
+			// by docker's userland proxy (docker-proxy) resetting a freshly
+			// accepted host-side connection during connection setup — the app
+			// never processed the request, so zero mocks were consumed. That
+			// case is a transient transport failure, not a real regression, and
+			// keploy would otherwise record a false status_code=0.
+			//
+			// We re-send ONLY when it is provably safe: the agent reports that
+			// THIS request consumed no new mocks. MockManager.GetConsumedMocks
+			// is per-call and DRAINING (it returns only what was consumed since
+			// the last drain, which the normal per-test drain already emptied),
+			// so a non-empty result means this request burned a single-use mock
+			// — the gate then refuses to retry, because re-running would
+			// re-exercise non-idempotent logic against exhausted mocks and
+			// fabricate a verdict. This mirrors the ECONNREFUSED re-send
+			// (pkg.SimulateHTTP), just establishing the "nothing irreversible
+			// happened" invariant via mock consumption instead of error type.
+			//
+			// On that refusal path retryResetOnce hands back the mocks its gate
+			// DRAINED for this failed request; we fold them into
+			// totalConsumedMocks so the next SendMockFilterParamsToAgent's
+			// filterOutDeleted still drops those exhausted mocks (the drain only
+			// affects keploy-side reporting, never the agent's own serving
+			// state — see retryResetOnce).
+			if loopErr != nil && pkg.IsTransportConnReset(loopErr) {
+				retryResp, retried, drainedConsumed := r.retryResetOnce(runTestSetCtx, testCase, testSetID, loopErr)
+				if retried {
+					resp, loopErr = retryResp, nil
+				} else {
+					for _, m := range drainedConsumed {
+						totalConsumedMocks[m.Name] = m
+					}
+				}
+			}
+
 			if loopErr != nil {
 				utils.LogError(r.logger, loopErr, "failed to simulate request")
 				currentFailures++
@@ -3840,6 +3876,142 @@ func (r *Replayer) copyDirContents(src, dst string) error {
 		}
 	}
 	return nil
+}
+
+// maxResetResends bounds how many times a transport-reset test request is
+// re-sent. Kept small: the reset is a transient docker-proxy / connection-setup
+// race, so a couple of attempts after a brief readiness re-poll is enough; a
+// genuinely broken app still fails fast.
+const maxResetResends = 2
+
+// resetResendReadyTimeout caps the per-attempt app-port readiness re-poll done
+// before re-sending. It only ever adds latency on the (rare) reset path.
+const resetResendReadyTimeout = 5 * time.Second
+
+// retryResetOnce re-sends a test request that failed with a transport-level
+// connection reset / unexpected EOF (origErr), but ONLY when doing so is
+// provably safe. It returns (resp, true, nil) when a re-send produced a real
+// response, and (nil, false, drained) when the request was not retried or every
+// re-send also failed (the caller then treats origErr as the genuine failure).
+//
+// drained carries the mocks the safety gate observed-and-DRAINED for the
+// just-failed request on the UNSAFE refusal path (see resetResendUnsafe and the
+// drain-accounting note below); it is nil on every other path. The caller must
+// fold it back into totalConsumedMocks so the agent's next-iteration filter
+// (filterOutDeleted) still removes those exhausted single-use mocks.
+//
+// Safety invariant (this is the whole point): a reset is ambiguous about
+// whether the app already consumed a single-use mock. MockManager.GetConsumed-
+// Mocks is per-call and DRAINING — it returns only the mocks consumed SINCE the
+// last drain, then clears its list. In the normal flow the per-test drain at
+// RunTestSet (the `GetConsumedMocks` after a successful request) already emptied
+// that list, so when we get here for a failed request the gate sees EXACTLY this
+// request's consumption. We therefore re-send only while that per-call count is
+// ZERO — i.e. THIS request consumed nothing irreversible. The moment it is >0 we
+// stop and let the original error stand, so a mid-stream reset that already
+// burned a mock is never re-run against exhausted mocks (which would fabricate a
+// verdict). Under the dominant docker-proxy reset the app never saw the request,
+// so the count stays at 0 and the re-send recovers the real response instead of
+// a false status_code=0.
+//
+// Drain side-effect accounting: calling GetConsumedMocks in the gate DRAINS the
+// agent's consumed-reporting list. This does NOT resurrect any exhausted mock —
+// the agent serves from its mock TREES (DeleteFilteredMock removes a single-use
+// mock from them on consume); the drained list is a separate keploy-side
+// REPORTING channel. So a later test can never be re-served a drained-but-
+// consumed mock by the agent's own state. The only risk is keploy-side: those
+// drained mocks would be missing from totalConsumedMocks, so the next
+// SendMockFilterParamsToAgent's filterOutDeleted would fail to filter them and
+// SetMocksWithWindow could re-insert them into the serving pool. We close that
+// by returning the drained mocks (UNSAFE path) for the caller to fold into
+// totalConsumedMocks. On the SAFE path (count==0) the drain is a no-op, and the
+// successful re-send's consumption is still accounted by the subsequent per-test
+// GetConsumedMocks in RunTestSet (loopErr becomes nil, so that block runs).
+func (r *Replayer) retryResetOnce(ctx context.Context, testCase *models.TestCase, testSetID string, origErr error) (interface{}, bool, []models.MockState) {
+	for attempt := 1; attempt <= maxResetResends; attempt++ {
+		if ctx.Err() != nil {
+			return nil, false, nil
+		}
+
+		// Refuse to retry if THIS request consumed a new mock (per-call count
+		// > 0 since the last drain) — that means it was (at least partially)
+		// processed and a re-send would not be idempotent. Hand the drained
+		// mocks back so the caller can keep totalConsumedMocks accurate.
+		if unsafe, drained := r.resetResendUnsafe(ctx); unsafe {
+			r.logger.Debug("transport reset is not safe to re-send (a mock was consumed); leaving the original error",
+				zap.String("testSetID", testSetID),
+				zap.String("testCaseID", testCase.Name))
+			return nil, false, drained
+		}
+
+		// Re-gate on the app's published host port accepting a connection so we
+		// re-send only once the app/proxy is ready again, not blindly. Best
+		// effort: if we can't determine a waitable port (native app, unmapped
+		// publish) we proceed — the bounded attempts still protect us.
+		r.waitForResetResendReady(ctx)
+
+		r.logger.Warn("test request reset by app/proxy before any mock was consumed; re-sending — the request was never processed, so this is not a retry of an assertion",
+			zap.Int("attempt", attempt),
+			zap.Int("maxRetries", maxResetResends),
+			zap.String("testSetID", testSetID),
+			zap.String("testCaseID", testCase.Name),
+			zap.Error(origErr))
+
+		// Re-open the per-test capture window so a mock miss on the re-send
+		// attributes to THIS test (the previous window was for the failed try).
+		r.beginTestErrorCapture(ctx)
+
+		resp, err := r.hookImpl.SimulateRequest(ctx, testCase, testSetID)
+		if err == nil {
+			return resp, true, nil
+		}
+		if !pkg.IsTransportConnReset(err) {
+			// A different failure on the re-send (e.g. the app really is down):
+			// stop and let the caller report the original transport reset.
+			return nil, false, nil
+		}
+		origErr = err
+	}
+	return nil, false, nil
+}
+
+// resetResendUnsafe reports whether re-sending is unsafe because the failed
+// request consumed at least one mock, and returns whatever it drained from the
+// agent's consumed-reporting list so the caller can keep totalConsumedMocks
+// accurate (see the drain side-effect note on retryResetOnce).
+//
+// GetConsumedMocks is per-call and DRAINING: it returns only the mocks consumed
+// since the last drain (which, in the normal flow, is empty by the time we get
+// here for a failed request). So the per-call result IS exactly this request's
+// consumption, and the gate is unsafe iff that count is > 0. On a fetch error it
+// returns unsafe=true with no drained mocks (fail safe): if we cannot prove
+// nothing was consumed, we must not retry.
+func (r *Replayer) resetResendUnsafe(ctx context.Context) (bool, []models.MockState) {
+	consumed, err := r.hookImpl.GetConsumedMocks(ctx)
+	if err != nil {
+		r.logger.Debug("could not fetch consumed mocks to validate reset re-send; not retrying", zap.Error(err))
+		return true, nil
+	}
+	if len(consumed) > 0 {
+		return true, consumed
+	}
+	return false, nil
+}
+
+// waitForResetResendReady best-effort gates a reset re-send on the app's
+// published docker host port accepting a TCP connection again, bounded by
+// resetResendReadyTimeout. It is a no-op for native apps / unmapped publishes.
+func (r *Replayer) waitForResetResendReady(ctx context.Context) {
+	host, port, ok := dockerPublishedHostPort(r.config.Command)
+	if !ok {
+		return
+	}
+	wctx, cancel := context.WithTimeout(ctx, resetResendReadyTimeout)
+	defer cancel()
+	if err := pkg.WaitForPort(wctx, host, port, resetResendReadyTimeout); err != nil {
+		r.logger.Debug("app host port not ready before reset re-send; re-sending anyway",
+			zap.String("host", host), zap.String("port", port), zap.Error(err))
+	}
 }
 
 // beginTestErrorCapture opens a per-test mock-error capture window on the agent

--- a/pkg/service/replay/reset_resend_test.go
+++ b/pkg/service/replay/reset_resend_test.go
@@ -1,0 +1,249 @@
+package replay
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/url"
+	"os"
+	"sync/atomic"
+	"syscall"
+	"testing"
+
+	"go.keploy.io/server/v3/config"
+	"go.keploy.io/server/v3/pkg/agent/proxy"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// connResetURLErr builds the exact error chain net/http returns for a
+// docker-proxy / mid-exchange "connection reset by peer":
+// *url.Error -> *net.OpError(Op:"read") -> *os.SyscallError -> syscall.ECONNRESET.
+func connResetURLErr() error {
+	return &url.Error{Op: "Get", URL: "http://localhost:8080/", Err: &net.OpError{Op: "read", Net: "tcp", Err: os.NewSyscallError("read", syscall.ECONNRESET)}}
+}
+
+// realMockManagerHook delegates GetConsumedMocks to a REAL *proxy.MockManager
+// so the safety gate is exercised against the genuine per-call / DRAINING
+// semantics — not a stub that returns a fixed slice. SimulateRequest fails the
+// first failFirst calls with a transport reset, then returns a 200; simErr,
+// when set, makes every attempt fail with that error.
+type realMockManagerHook struct {
+	TestHooks
+	mm        *proxy.MockManager
+	failFirst int32
+	calls     int32
+	simErr    error
+}
+
+func (h *realMockManagerHook) SimulateRequest(_ context.Context, _ *models.TestCase, _ string) (interface{}, error) {
+	n := atomic.AddInt32(&h.calls, 1)
+	if h.simErr != nil {
+		return nil, h.simErr
+	}
+	if n <= h.failFirst {
+		return nil, connResetURLErr()
+	}
+	return &models.HTTPResp{StatusCode: 200}, nil
+}
+
+// GetConsumedMocks hits the real MockManager, so the gate sees true per-call
+// draining: only what was consumed since the last drain, then the list clears.
+func (h *realMockManagerHook) GetConsumedMocks(_ context.Context) ([]models.MockState, error) {
+	return h.mm.GetConsumedMocks(), nil
+}
+
+// errConsumedHook always fails the consumed-mocks fetch — the safety gate must
+// then refuse to retry (fail safe).
+type errConsumedHook struct {
+	TestHooks
+	calls int32
+}
+
+func (h *errConsumedHook) SimulateRequest(_ context.Context, _ *models.TestCase, _ string) (interface{}, error) {
+	atomic.AddInt32(&h.calls, 1)
+	return nil, connResetURLErr()
+}
+
+func (h *errConsumedHook) GetConsumedMocks(_ context.Context) ([]models.MockState, error) {
+	return nil, errors.New("agent unreachable")
+}
+
+func newTestReplayer(hook TestHooks) *Replayer {
+	// A native command (no -p publish) makes dockerPublishedHostPort return
+	// ok=false, so waitForResetResendReady is a no-op and these unit tests
+	// exercise the safety gate without dialing a real port. The docker
+	// port-readiness re-poll itself is covered by docker_port_readiness_test.go.
+	return &Replayer{
+		logger:   zap.NewNop(),
+		config:   &config.Config{Command: "node app.js"},
+		hookImpl: hook,
+	}
+}
+
+// A reset with NO mock consumed (per-call drain returns empty) is re-sent and
+// recovers the real response. Drives a REAL MockManager that recorded nothing.
+func TestRetryResetOnce_RecoversWhenNoMockConsumed(t *testing.T) {
+	mm := proxy.NewMockManager(nil, nil, zap.NewNop())
+	defer mm.Close()
+	// The caller's original request already reset (docker-proxy); the app saw
+	// nothing, so the manager's consumed list is empty and the very first
+	// re-send recovers the real response.
+	hook := &realMockManagerHook{mm: mm, failFirst: 0}
+	r := newTestReplayer(hook)
+	tc := &models.TestCase{Name: "get-root-1", Kind: models.HTTP}
+
+	resp, retried, drained := r.retryResetOnce(context.Background(), tc, "test-set-0", connResetURLErr())
+	if !retried {
+		t.Fatal("expected the reset to be re-sent and recovered")
+	}
+	if len(drained) != 0 {
+		t.Fatalf("safe path must not carry drained mocks, got %#v", drained)
+	}
+	hr, ok := resp.(*models.HTTPResp)
+	if !ok || hr.StatusCode != 200 {
+		t.Fatalf("expected recovered 200 response, got %#v", resp)
+	}
+	if got := atomic.LoadInt32(&hook.calls); got != 1 {
+		t.Fatalf("expected 1 re-send to recover, got %d", got)
+	}
+}
+
+// A reset AFTER a mock was consumed (per-call drain returns >0) must NOT be
+// retried — re-running would exhaust single-use mocks and fabricate a verdict.
+// The gate must also hand back the mocks it DRAINED so the caller can keep
+// totalConsumedMocks accurate. Driven by a REAL MockManager that recorded a
+// consumption, so the >0 check reflects genuine per-call draining.
+func TestRetryResetOnce_RefusesWhenMockConsumed(t *testing.T) {
+	mm := proxy.NewMockManager(nil, nil, zap.NewNop())
+	defer mm.Close()
+	// The failed request DID burn a single-use mock before the mid-stream reset.
+	if !mm.MarkMockAsUsed(models.Mock{Name: "mongo-1", Kind: models.Mongo}) {
+		t.Fatal("failed to seed a consumed mock into the real MockManager")
+	}
+	hook := &realMockManagerHook{mm: mm, failFirst: 0}
+	r := newTestReplayer(hook)
+	tc := &models.TestCase{Name: "create-user-1", Kind: models.HTTP}
+
+	resp, retried, drained := r.retryResetOnce(context.Background(), tc, "test-set-0", connResetURLErr())
+	if retried {
+		t.Fatalf("must NOT retry a reset that consumed a mock; got resp=%#v", resp)
+	}
+	if got := atomic.LoadInt32(&hook.calls); got != 0 {
+		t.Fatalf("expected 0 re-sends (refused before re-issuing), got %d", got)
+	}
+	// The gate drained the consumed mock; it must be returned for the caller to
+	// fold into totalConsumedMocks (else the agent re-serves it to a later test
+	// via filterOutDeleted).
+	if len(drained) != 1 || drained[0].Name != "mongo-1" {
+		t.Fatalf("expected the drained consumed mock [mongo-1] to be returned, got %#v", drained)
+	}
+	// And the real manager's list is now drained, proving the gate consumed it.
+	if leftover := mm.GetConsumedMocks(); len(leftover) != 0 {
+		t.Fatalf("gate should have drained the consumed list; leftover=%#v", leftover)
+	}
+}
+
+// If the consumed-mock count can't be fetched, fail safe: do not retry.
+func TestRetryResetOnce_FailSafeOnConsumedFetchError(t *testing.T) {
+	hook := &errConsumedHook{}
+	r := newTestReplayer(hook)
+	tc := &models.TestCase{Name: "get-root-1", Kind: models.HTTP}
+
+	_, retried, drained := r.retryResetOnce(context.Background(), tc, "test-set-0", connResetURLErr())
+	if retried {
+		t.Fatal("must not retry when consumed-mock count is unknown")
+	}
+	if len(drained) != 0 {
+		t.Fatalf("fail-safe path must not fabricate drained mocks, got %#v", drained)
+	}
+	if got := atomic.LoadInt32(&hook.calls); got != 0 {
+		t.Fatalf("expected 0 re-sends on fetch error, got %d", got)
+	}
+}
+
+// A persistently reset app stops after maxResetResends and reports not-retried,
+// so the caller surfaces the original transport error (no fabricated success).
+// Driven by a REAL MockManager that records nothing, so every per-call drain is
+// empty and every attempt is deemed safe-to-resend.
+func TestRetryResetOnce_BoundedAndStopsWithoutFabricating(t *testing.T) {
+	mm := proxy.NewMockManager(nil, nil, zap.NewNop())
+	defer mm.Close()
+	hook := &realMockManagerHook{mm: mm, failFirst: 100} // always resets
+	r := newTestReplayer(hook)
+	tc := &models.TestCase{Name: "get-root-1", Kind: models.HTTP}
+
+	resp, retried, drained := r.retryResetOnce(context.Background(), tc, "test-set-0", connResetURLErr())
+	if retried || resp != nil {
+		t.Fatalf("a persistently reset app must not yield a fabricated response; retried=%v resp=%#v", retried, resp)
+	}
+	if len(drained) != 0 {
+		t.Fatalf("no mock was consumed, so nothing should be drained, got %#v", drained)
+	}
+	if got := atomic.LoadInt32(&hook.calls); got != maxResetResends {
+		t.Fatalf("expected exactly %d bounded re-sends, got %d", maxResetResends, got)
+	}
+}
+
+// A non-reset error on a re-send stops immediately (lets the caller report the
+// original reset) instead of looping.
+func TestRetryResetOnce_StopsOnNonResetError(t *testing.T) {
+	mm := proxy.NewMockManager(nil, nil, zap.NewNop())
+	defer mm.Close()
+	hook := &realMockManagerHook{mm: mm, simErr: errors.New("response body mismatch")}
+	r := newTestReplayer(hook)
+	tc := &models.TestCase{Name: "get-root-1", Kind: models.HTTP}
+
+	_, retried, _ := r.retryResetOnce(context.Background(), tc, "test-set-0", connResetURLErr())
+	if retried {
+		t.Fatal("a non-reset failure on re-send must not be treated as a recovery")
+	}
+	if got := atomic.LoadInt32(&hook.calls); got != 1 {
+		t.Fatalf("expected to stop after the first non-reset error, got %d calls", got)
+	}
+}
+
+// Per-call gate semantics across the retry loop: the FIRST attempt's gate sees
+// the failed request's (empty) consumption and proceeds; if a re-send then burns
+// a mock and itself resets, the SECOND attempt's gate sees ONLY that attempt's
+// consumption (>0) and refuses, returning exactly those drained mocks. This pins
+// that each attempt checks only THAT attempt's per-call drain.
+func TestRetryResetOnce_PerAttemptGateUsesPerCallDrain(t *testing.T) {
+	mm := proxy.NewMockManager(nil, nil, zap.NewNop())
+	defer mm.Close()
+	hook := &perAttemptConsumerHook{mm: mm}
+	r := newTestReplayer(hook)
+	tc := &models.TestCase{Name: "get-root-1", Kind: models.HTTP}
+
+	resp, retried, drained := r.retryResetOnce(context.Background(), tc, "test-set-0", connResetURLErr())
+	if retried || resp != nil {
+		t.Fatalf("the second attempt burned a mock then reset; must refuse, got retried=%v resp=%#v", retried, resp)
+	}
+	// Exactly one re-send happened (attempt 1 passed the empty-drain gate and
+	// re-sent; attempt 2's gate saw the >0 drain and refused before re-sending).
+	if got := atomic.LoadInt32(&hook.calls); got != 1 {
+		t.Fatalf("expected exactly 1 re-send before the second gate refused, got %d", got)
+	}
+	if len(drained) != 1 || drained[0].Name != "attempt1-mock" {
+		t.Fatalf("expected the second gate to drain only attempt 1's mock, got %#v", drained)
+	}
+}
+
+// perAttemptConsumerHook makes its (only) re-send both consume a mock into the
+// real MockManager AND reset, so the next gate observes a per-call drain of >0.
+type perAttemptConsumerHook struct {
+	TestHooks
+	mm    *proxy.MockManager
+	calls int32
+}
+
+func (h *perAttemptConsumerHook) SimulateRequest(_ context.Context, _ *models.TestCase, _ string) (interface{}, error) {
+	atomic.AddInt32(&h.calls, 1)
+	// This re-send burns a single-use mock before the connection resets.
+	h.mm.MarkMockAsUsed(models.Mock{Name: "attempt1-mock", Kind: models.Mongo})
+	return nil, connResetURLErr()
+}
+
+func (h *perAttemptConsumerHook) GetConsumedMocks(_ context.Context) ([]models.MockState, error) {
+	return h.mm.GetConsumedMocks(), nil
+}

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -134,6 +134,42 @@ func validateHealthURL(s string) (string, bool) {
 // was canceled (caller should treat as user abort). Specifically, an invalid
 // HealthURL does NOT cause a false return — callers rely on this contract to
 // disambiguate user abort from misconfiguration (see replay.go classification).
+// dockerPublishedHostPort returns the first host (ip, port) that a docker
+// `-p/--publish` mapping in cmd exposes on the host, so a docker-run replay can
+// gate on the app actually listening before firing requests. It handles the
+// common `hostPort:containerPort` and `hostIP:hostPort:containerPort` forms
+// (with an optional `/tcp`|`/udp` suffix). It returns ok=false — keeping the
+// pure --delay behavior — for native apps (no -p), container-only publishes
+// (random host port), port ranges, or anything it cannot parse with
+// confidence, so it never guesses a wrong port to wait on.
+func dockerPublishedHostPort(cmd string) (host, port string, ok bool) {
+	fields := strings.Fields(cmd)
+	for i := 0; i+1 < len(fields); i++ {
+		if fields[i] != "-p" && fields[i] != "--publish" {
+			continue
+		}
+		spec := strings.SplitN(fields[i+1], "/", 2)[0] // drop /tcp,/udp
+		segs := strings.Split(spec, ":")
+		// host port is the second-to-last segment:
+		//   "hp:cp"     -> [hp, cp]
+		//   "ip:hp:cp"  -> [ip, hp, cp]
+		//   "cp"        -> [cp]  (random host port; not waitable -> skip)
+		if len(segs) < 2 {
+			continue
+		}
+		hp := segs[len(segs)-2]
+		h := "127.0.0.1"
+		if len(segs) >= 3 && segs[0] != "" {
+			h = segs[0]
+		}
+		if hp == "" || strings.ContainsAny(hp, "-") { // skip empty / ranges
+			continue
+		}
+		return h, hp, true
+	}
+	return "", "", false
+}
+
 func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config) bool {
 	delay := time.Duration(cfg.Test.Delay) * time.Second
 
@@ -174,10 +210,38 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 		defer timer.Stop()
 		select {
 		case <-timer.C:
-			return true
+			// --delay floor elapsed; fall through to the optional docker
+			// port-readiness gate below.
 		case <-ctx.Done():
 			return false
 		}
+
+		// Docker apps with a published host port: after the --delay floor,
+		// additionally gate on the host port accepting a TCP connection so
+		// replay never fires at a not-yet-listening app (the "status_code
+		// got=0" flake) when the fixed --delay was too short under CI
+		// contention. Best-effort and bounded by a ceiling; native apps and
+		// container-only / unmapped publishes (ok==false) keep the pure
+		// --delay behavior. This can only ever wait LONGER than --delay, never
+		// shorter, and never weakens an assertion — a fast-ready port returns
+		// instantly.
+		if host, port, ok := dockerPublishedHostPort(cfg.Command); ok {
+			ceiling := cfg.Test.HealthPollTimeout
+			if ceiling <= 0 {
+				ceiling = 60 * time.Second
+			}
+			if err := pkg.WaitForPort(ctx, host, port, ceiling); err != nil {
+				if ctx.Err() != nil {
+					return false
+				}
+				logger.Warn("app host port did not become ready within the ceiling; firing tests anyway (replay may see status_code got=0)",
+					zap.String("host", host),
+					zap.String("port", port),
+					zap.Duration("ceiling", ceiling),
+					zap.Error(err))
+			}
+		}
+		return true
 	}
 
 	pollCeiling := cfg.Test.HealthPollTimeout

--- a/pkg/service/runner/runner.go
+++ b/pkg/service/runner/runner.go
@@ -348,7 +348,15 @@ func (r *Runner) setupTestSet(parentCtx context.Context, testSetID string, backd
 	// "connect: connection refused" on the agent URL. Mirrors replay's
 	// pre-MockOutgoing AgentHealthTicker gate (replay.go:939-952).
 	if r.config != nil && r.config.Agent.AgentURI != "" {
-		agentCtx, cancel := context.WithTimeout(gCtx, 120*time.Second)
+		// Use the same contention-tuned budget as the record/replay/agent
+		// readiness gates (pkg.AgentReadyTimeout, default 330s, overridable via
+		// KEPLOY_AGENT_READY_TIMEOUT) rather than a hardcoded 120s. On a
+		// saturated CI daemon the agent container can take well over a minute
+		// just to start, so the 120s ceiling here fired prematurely and failed
+		// an otherwise-healthy sandbox/runner bring-up that the other gates
+		// would have waited out.
+		agentReadyTimeout := keployPkg.AgentReadyTimeout()
+		agentCtx, cancel := context.WithTimeout(gCtx, agentReadyTimeout)
 		agentReadyCh := make(chan bool, 1)
 		go keployPkg.AgentHealthTicker(agentCtx, r.logger, r.config.Agent.AgentURI, agentReadyCh, 1*time.Second)
 		select {
@@ -357,7 +365,7 @@ func (r *Runner) setupTestSet(parentCtx context.Context, testSetID string, backd
 			return nil, gCtx.Err()
 		case <-agentCtx.Done():
 			cancel()
-			return nil, fmt.Errorf("keploy-agent at %s did not become ready within 120s; check the agent container logs and ensure its host port is reachable", r.config.Agent.AgentURI)
+			return nil, fmt.Errorf("keploy-agent at %s did not become ready within %s; check the agent container logs and ensure its host port is reachable", r.config.Agent.AgentURI, agentReadyTimeout)
 		case <-agentReadyCh:
 		}
 		cancel()

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -630,6 +630,45 @@ func isPreResponseConnRefused(err error) bool {
 	return errors.Is(err, syscall.ECONNREFUSED)
 }
 
+// IsTransportConnReset reports whether err is a transport-level connection
+// reset / unexpected close while exchanging the request with the app — i.e.
+// "connection reset by peer" (ECONNRESET), a broken pipe (EPIPE), or a bare
+// io.EOF / io.ErrUnexpectedEOF surfaced by net/http when the peer dropped the
+// connection.
+//
+// This class is dominated, under loaded CI replaying a DOCKER app, by docker's
+// userland proxy (docker-proxy) resetting a freshly-accepted host-side
+// connection during connection setup / before the backend app ever processes
+// the request. The CLI dials the published host port ([::1]:<port>) and sees
+//
+//	read tcp [::1]:<ephem>-><[::1]:<port>: read: connection reset by peer
+//
+// even for a request whose handler makes no downstream calls — proving the
+// reset is in the host<->proxy hop, not the app's response logic.
+//
+// IMPORTANT: a reset is, by the error alone, AMBIGUOUS about whether the app
+// already consumed single-use mocks (a mid-stream reset after the handler ran
+// looks identical). So this predicate only CLASSIFIES the error; the decision
+// to re-send is made by the caller (replay orchestration) and is gated on the
+// app having consumed ZERO new mocks for this request — the same "provably
+// nothing irreversible happened" invariant that makes the ECONNREFUSED re-send
+// safe. Without that gate this must NEVER drive a retry.
+func IsTransportConnReset(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) {
+		return true
+	}
+	// net/http surfaces a peer-side drop during the response read as a bare
+	// io.EOF / io.ErrUnexpectedEOF (no syscall in the chain) — the docker-proxy
+	// reset frequently lands here too (see the "EOF" hits in the reproduction).
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	return false
+}
+
 // doRequestWithConnRefusedRetry executes client.Do, re-sending ONLY on a
 // pre-response connection-refused (bounded, ctx-aware backoff, request body
 // rewound via GetBody). Any other error, or a real response, returns

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -10,6 +10,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"html/template"
 	"io"
@@ -29,6 +30,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 	"unicode/utf8"
 
@@ -605,6 +607,65 @@ func prepareHTTPRequest(ctx context.Context, tc *models.TestCase, testSet string
 	}, nil
 }
 
+// maxConnRefusedRetries bounds how many times a replay test request is re-sent
+// when the connection is REFUSED before the app accepts it. A refused connection
+// proves the app never received the request — zero bytes sent, zero single-use
+// mocks consumed — so re-sending is safe and does NOT fabricate a result: it
+// obtains the real response the suite must assert on instead of a false
+// status_code=0. We deliberately do NOT retry a mid-response reset (ECONNRESET),
+// EOF, or broken pipe: those can occur AFTER the app read the request and
+// consumed mocks, where a retry would re-run non-idempotent logic against
+// exhausted mocks and fabricate a verdict. Under CI contention an app container
+// can briefly refuse while still coming up; this turns that transient transport
+// failure into the real comparison rather than a flaky false regression.
+const (
+	maxConnRefusedRetries   = 3
+	connRefusedRetryBackoff = 150 * time.Millisecond
+)
+
+// isPreResponseConnRefused reports whether err is a pure "connection refused".
+// errors.Is unwraps the *url.Error -> *net.OpError -> *os.SyscallError ->
+// syscall.Errno chain, so no manual unwrapping is needed.
+func isPreResponseConnRefused(err error) bool {
+	return errors.Is(err, syscall.ECONNREFUSED)
+}
+
+// doRequestWithConnRefusedRetry executes client.Do, re-sending ONLY on a
+// pre-response connection-refused (bounded, ctx-aware backoff, request body
+// rewound via GetBody). Any other error, or a real response, returns
+// immediately — so a genuinely crashed/unreachable app still fails fast after
+// the bounded retries, and a mid-response reset is never retried.
+func doRequestWithConnRefusedRetry(ctx context.Context, logger *zap.Logger, client *http.Client, req *http.Request) (*http.Response, error) {
+	for attempt := 0; ; attempt++ {
+		resp, err := client.Do(req)
+		if err == nil {
+			return resp, nil
+		}
+		if attempt >= maxConnRefusedRetries || !isPreResponseConnRefused(err) {
+			return nil, err
+		}
+		// Only retry if we can faithfully re-send the body; otherwise stop so we
+		// never send a truncated/empty body (which would fabricate a result).
+		if req.Body != nil && req.GetBody == nil {
+			return nil, err
+		}
+		if req.GetBody != nil {
+			body, gbErr := req.GetBody()
+			if gbErr != nil {
+				return nil, err
+			}
+			req.Body = body
+		}
+		logger.Warn("test request refused by app (app not yet accepting connections); re-sending — the request was never processed, so this is not a retry of an assertion",
+			zap.Int("attempt", attempt+1), zap.Int("maxRetries", maxConnRefusedRetries), zap.Error(err))
+		select {
+		case <-ctx.Done():
+			return nil, err
+		case <-time.After(connRefusedRetryBackoff * time.Duration(attempt+1)):
+		}
+	}
+}
+
 func SimulateHTTP(ctx context.Context, tc *models.TestCase, testSet string, logger *zap.Logger, cfg SimulationConfig) (*models.HTTPResp, error) {
 	templatedResponse := tc.HTTPResp // keep a copy of the original templatized response
 
@@ -619,8 +680,8 @@ func SimulateHTTP(ctx context.Context, tc *models.TestCase, testSet string, logg
 
 	logger.Debug(fmt.Sprintf("Sending request to user app:%v", prepared.Request))
 
-	// Execute the request
-	httpResp, errHTTPReq := prepared.Client.Do(prepared.Request)
+	// Execute the request (re-sending only on a pre-response connection-refused)
+	httpResp, errHTTPReq := doRequestWithConnRefusedRetry(ctx, logger, prepared.Client, prepared.Request)
 	if errHTTPReq != nil {
 		utils.LogError(logger, errHTTPReq, "failed to send testcase request to app")
 		return nil, errHTTPReq
@@ -696,8 +757,8 @@ func SimulateHTTPStreaming(ctx context.Context, tc *models.TestCase, testSet str
 
 	logger.Debug(fmt.Sprintf("Sending streaming request to user app:%v", prepared.Request))
 
-	// Execute the request
-	httpResp, errHTTPReq := prepared.Client.Do(prepared.Request)
+	// Execute the request (re-sending only on a pre-response connection-refused)
+	httpResp, errHTTPReq := doRequestWithConnRefusedRetry(ctx, logger, prepared.Client, prepared.Request)
 	if errHTTPReq != nil {
 		utils.LogError(logger, errHTTPReq, "failed to send testcase request to app")
 		return nil, errHTTPReq

--- a/pkg/util_connrefused_retry_test.go
+++ b/pkg/util_connrefused_retry_test.go
@@ -2,6 +2,7 @@ package pkg
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -83,6 +84,36 @@ func TestDoRequestWithConnRefusedRetry_StopsAfterMaxWithoutFabricating(t *testin
 	}
 	if got := int(atomic.LoadInt32(&rt.attempts)); got != maxConnRefusedRetries+1 {
 		t.Fatalf("expected %d attempts, got %d", maxConnRefusedRetries+1, got)
+	}
+}
+
+// IsTransportConnReset must classify the docker-proxy / mid-exchange reset
+// family (ECONNRESET, broken pipe, bare EOF/unexpected-EOF) and nothing else,
+// so the replay orchestration can mock-consumption-gate a re-send of exactly
+// this transport class.
+func TestIsTransportConnReset(t *testing.T) {
+	resetLike := []error{
+		connResetErr("http://x/a"),
+		&url.Error{Op: "Post", URL: "http://x/a", Err: &net.OpError{Op: "write", Net: "tcp", Err: os.NewSyscallError("write", syscall.EPIPE)}},
+		&url.Error{Op: "Get", URL: "http://x/a", Err: io.EOF},
+		&url.Error{Op: "Get", URL: "http://x/a", Err: io.ErrUnexpectedEOF},
+	}
+	for _, e := range resetLike {
+		if !IsTransportConnReset(e) {
+			t.Errorf("expected reset classification for: %v", e)
+		}
+	}
+
+	notReset := []error{
+		nil,
+		connRefusedErr("http://x/a"), // refused is handled by its own path, not this one
+		errors.New("response body mismatch"),
+		context.DeadlineExceeded,
+	}
+	for _, e := range notReset {
+		if IsTransportConnReset(e) {
+			t.Errorf("did NOT expect reset classification for: %v", e)
+		}
 	}
 }
 

--- a/pkg/util_connrefused_retry_test.go
+++ b/pkg/util_connrefused_retry_test.go
@@ -1,0 +1,117 @@
+package pkg
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// connRefusedErr builds the exact error chain net/http returns for a dial-time
+// "connection refused": *url.Error -> *net.OpError -> *os.SyscallError ->
+// syscall.ECONNREFUSED, so errors.Is(err, syscall.ECONNREFUSED) is true.
+func connRefusedErr(u string) error {
+	return &url.Error{Op: "Get", URL: u, Err: &net.OpError{Op: "dial", Net: "tcp", Err: os.NewSyscallError("connect", syscall.ECONNREFUSED)}}
+}
+
+// connResetErr is the mid-response "connection reset by peer" chain — ambiguous
+// (the app may already have consumed single-use mocks), so it must NOT be retried.
+func connResetErr(u string) error {
+	return &url.Error{Op: "Get", URL: u, Err: &net.OpError{Op: "read", Net: "tcp", Err: os.NewSyscallError("read", syscall.ECONNRESET)}}
+}
+
+// scriptedRT returns a scripted sequence of errors (attempts 1..len(errs)) then a
+// 200; it records the attempt count and the body bytes seen on the served attempt
+// so a test can assert the request body was rewound between attempts.
+type scriptedRT struct {
+	errs     []error
+	attempts int32
+	lastBody string
+}
+
+func (rt *scriptedRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	n := int(atomic.AddInt32(&rt.attempts, 1))
+	if n <= len(rt.errs) {
+		return nil, rt.errs[n-1]
+	}
+	if req.Body != nil {
+		b, _ := io.ReadAll(req.Body)
+		rt.lastBody = string(b)
+	}
+	return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader("ok")), Header: make(http.Header)}, nil
+}
+
+// A transient pre-response connection-refused must be re-sent so the suite
+// obtains the REAL response instead of a false status_code=0.
+func TestDoRequestWithConnRefusedRetry_RecoversTransientRefusal(t *testing.T) {
+	rt := &scriptedRT{errs: []error{connRefusedErr("http://x/a"), connRefusedErr("http://x/a")}}
+	client := &http.Client{Transport: rt}
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "http://x/a", nil)
+	resp, err := doRequestWithConnRefusedRetry(context.Background(), zap.NewNop(), client, req)
+	if err != nil {
+		t.Fatalf("expected recovery after 2 refusals, got error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if got := atomic.LoadInt32(&rt.attempts); got != 3 {
+		t.Fatalf("expected 3 attempts (2 refused + 1 served), got %d", got)
+	}
+}
+
+// A genuinely unreachable app must fail FAST after the bounded retries — never
+// fabricate a success.
+func TestDoRequestWithConnRefusedRetry_StopsAfterMaxWithoutFabricating(t *testing.T) {
+	errs := make([]error, maxConnRefusedRetries+5)
+	for i := range errs {
+		errs[i] = connRefusedErr("http://x/a")
+	}
+	rt := &scriptedRT{errs: errs}
+	client := &http.Client{Transport: rt}
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "http://x/a", nil)
+	_, err := doRequestWithConnRefusedRetry(context.Background(), zap.NewNop(), client, req)
+	if err == nil {
+		t.Fatal("expected an error after exhausting retries — must not fabricate a result")
+	}
+	if got := int(atomic.LoadInt32(&rt.attempts)); got != maxConnRefusedRetries+1 {
+		t.Fatalf("expected %d attempts, got %d", maxConnRefusedRetries+1, got)
+	}
+}
+
+// A mid-response reset is ambiguous about mock/state consumption — must NOT be
+// retried (else we'd re-run non-idempotent logic against exhausted mocks).
+func TestDoRequestWithConnRefusedRetry_DoesNotRetryReset(t *testing.T) {
+	rt := &scriptedRT{errs: []error{connResetErr("http://x/a")}}
+	client := &http.Client{Transport: rt}
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "http://x/a", nil)
+	_, err := doRequestWithConnRefusedRetry(context.Background(), zap.NewNop(), client, req)
+	if err == nil {
+		t.Fatal("expected the reset error to propagate without retry")
+	}
+	if got := int(atomic.LoadInt32(&rt.attempts)); got != 1 {
+		t.Fatalf("ECONNRESET must not be retried: expected 1 attempt, got %d", got)
+	}
+}
+
+// The retried request must carry the FULL recorded body (rewound via GetBody),
+// never a truncated/empty one — otherwise a retry would fabricate a wrong result.
+func TestDoRequestWithConnRefusedRetry_RewindsBody(t *testing.T) {
+	const body = "the-full-recorded-body"
+	rt := &scriptedRT{errs: []error{connRefusedErr("http://x/a")}}
+	client := &http.Client{Transport: rt}
+	req, _ := http.NewRequestWithContext(context.Background(), "POST", "http://x/a", strings.NewReader(body))
+	if _, err := doRequestWithConnRefusedRetry(context.Background(), zap.NewNop(), client, req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rt.lastBody != body {
+		t.Fatalf("retried request body not rewound: want %q, got %q", body, rt.lastBody)
+	}
+}

--- a/pkg/util_simulate_refuse_integration_test.go
+++ b/pkg/util_simulate_refuse_integration_test.go
@@ -1,0 +1,85 @@
+package pkg
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// startRefuseThenServe reserves a free port, releases it so connects are REFUSED
+// for `refuse`, then re-binds it and serves GET /ping -> 200 {"msg":"pong"}.
+// This reproduces an app container that briefly refuses connections while it is
+// still coming up (the CI contention scenario the retry exists for).
+func startRefuseThenServe(t *testing.T, refuse time.Duration) (baseURL string, stop func()) {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	addr := l.Addr().String()
+	_ = l.Close() // the port now actively refuses until we re-bind below
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ping", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"msg":"pong"}`))
+	})
+	srv := &http.Server{Handler: mux}
+	go func() {
+		time.Sleep(refuse) // connects to addr are refused during this window
+		ln, lerr := net.Listen("tcp", addr)
+		if lerr != nil {
+			return
+		}
+		_ = srv.Serve(ln)
+	}()
+	return "http://" + addr, func() { _ = srv.Close() }
+}
+
+func pingTestCase(baseURL string) *models.TestCase {
+	return &models.TestCase{
+		Name: "ping",
+		Kind: models.HTTP,
+		HTTPReq: models.HTTPReq{
+			Method: "GET",
+			URL:    baseURL + "/ping",
+			Header: map[string]string{},
+		},
+		HTTPResp: models.HTTPResp{StatusCode: http.StatusOK, Body: `{"msg":"pong"}`},
+	}
+}
+
+// SimulateHTTP (the real replay send path) must RECOVER a request to a port that
+// refuses briefly, via the bounded connection-refused retry — proving the retry
+// is wired into the production code path, not just the helper in isolation. If
+// the retry is ever removed, SimulateHTTP returns the refused error and this
+// test fails (red), guarding the fix end-to-end without any CI credential.
+func TestSimulateHTTP_RecoversBriefConnRefused_RefuseInteg(t *testing.T) {
+	baseURL, stop := startRefuseThenServe(t, 300*time.Millisecond)
+	defer stop()
+	resp, err := SimulateHTTP(context.Background(), pingTestCase(baseURL), "test-set", zap.NewNop(), SimulationConfig{APITimeout: 10})
+	if err != nil {
+		t.Fatalf("expected recovery via the connection-refused retry, got error: %v", err)
+	}
+	if resp == nil || resp.StatusCode != http.StatusOK || !strings.Contains(resp.Body, "pong") {
+		t.Fatalf("expected 200 pong, got %+v", resp)
+	}
+}
+
+// A refuse longer than the ~900ms retry budget must FAIL — the retry is bounded
+// and must never fabricate a pass for a genuinely-down app.
+func TestSimulateHTTP_LongConnRefusedFailsBounded_RefuseInteg(t *testing.T) {
+	baseURL, stop := startRefuseThenServe(t, 3*time.Second)
+	defer stop()
+	_, err := SimulateHTTP(context.Background(), pingTestCase(baseURL), "test-set", zap.NewNop(), SimulationConfig{APITimeout: 10})
+	if err == nil {
+		t.Fatal("expected a connection error after the retry budget exhausts (must not fabricate a pass)")
+	}
+}


### PR DESCRIPTION
First in a series of product fixes to make the enterprise CI flake-free.

## This batch — PostgresV3 SQLNormalized tab-in-YAML marshal (CLASS H)

`PostgresV3QuerySpec.SQLNormalized` is a plain `string`. After the integrations `restoreRawSQL` pass it can carry embedded tabs/newlines; `yaml.v3` v3.0.1 emits those as a literal block scalar, and since `yaml.Node.Encode` marshals-then-reparses its own output, the scalar fails to round-trip with `found a tab character where an indentation space is expected` — inside `EncodeMock`'s `Spec.Encode`, before the post-encode `sanitizeYAMLStringNodes` walk can rescue it. The whole PostgresV3 mock is then dropped (observed in enterprise atg-with-mocks: `failed to marshal PostgresV3 mock as yaml {mock_name: mock-15}`).

Fix: add `PostgresV3QuerySpec.MarshalYAML` routing `SQLNormalized` through `PostgresV3SafeString` (double-quotes when needed), mirroring the existing `PostgresV3Notice`/`PostgresV3Error` convention. The model field stays `string` (JSON/BSON + all integrations sites compile unchanged); only the YAML write side gains double-quoting. Regression tests cover leading-tab and tab/newline SQLNormalized round-tripping through `EncodeMock`.

## Follow-ups (separate batches, in progress)
The enterprise CI flake landscape (mapped across pipelines 5062–5122) has these remaining classes, fixed product-side:
- **CLASS A** container-name race on the *user-app* `docker run --name` path (go-docker-timefreeze, go-dedup-docker) — extend the v3.5.77 `ensureContainerNameFreeWithin` guard to the user-app launch.
- **CLASS B** compose-recreate of the keploy-v3 agent sidecar (atg-with-mocks, python-postgres-tls-containerized, kafka) — stop dual-managing the agent (compose service + external force-remove) / per-phase compose project isolation.
- **CLASS C/D** app- and agent-readiness races — gate replay on real readiness (the `--health-url` pattern) + contention-tolerant agent-readiness backoff.
- **CLASS E/F/G/I** grpc deadline (sample per-call ctx), pulsar `send on closed channel` panic, port-reuse on restart, BPF load flake.