### PR TITLE
feat(shutdown): drain in-flight streams in-app on SIGTERM

### DIFF
--- a/utils/ctx.go
+++ b/utils/ctx.go
@@ -76,19 +76,35 @@ func NewCtx() context.Context {
 		// proxy and every parser goroutine are still live (ctx not yet
 		// cancelled), so in-flight streams keep completing for the window —
 		// exactly what a preStop sleep bought — and only then do we tear
-		// down. A second signal cuts the wait short for an impatient
-		// operator (or a kubelet escalating toward SIGKILL). Unset / zero
-		// (the default, and every non-sidecar invocation) skips the wait
+		// down.
+		//
+		// The drain window is RESPECTED: additional SIGTERM/SIGINT signals
+		// that arrive while draining are logged but do NOT cut it short.
+		// The kubelet sends exactly one SIGTERM and never a second one — it
+		// escalates to SIGKILL at terminationGracePeriodSeconds, which is
+		// uncatchable and is the real hard stop (so keep the pod's
+		// terminationGracePeriodSeconds >= this drain; the webhook bumps it
+		// to 45s for a 15s drain). A repeat `kubectl delete` (the usual
+		// source of a second SIGTERM) therefore won't truncate an in-flight
+		// drain; an operator who truly wants an immediate kill uses
+		// `kubectl delete --grace-period=0 --force`. Unset / zero (the
+		// default, and every non-sidecar invocation) skips the wait
 		// entirely, preserving the historical immediate-cancel behaviour.
 		if d := sidecarDrainDuration(); d > 0 {
 			fmt.Printf("Draining in-flight connections for %s before shutdown (KEPLOY_SIDECAR_DRAIN_SECONDS)...\n", d)
-			t := time.NewTimer(d)
-			select {
-			case <-t.C:
-			case sig2 := <-sigs:
-				t.Stop()
-				fmt.Printf("Second signal received: %s, ending drain early...\n", sig2)
+			drainTimer := time.NewTimer(d)
+			for draining := true; draining; {
+				select {
+				case <-drainTimer.C:
+					draining = false
+				case sig2 := <-sigs:
+					fmt.Printf("Signal %s received during shutdown drain; ignoring to honour the %s drain window "+
+						"(SIGKILL at terminationGracePeriodSeconds is the hard stop; use "+
+						"`kubectl delete --grace-period=0 --force` to force an immediate kill).\n", sig2, d)
+				}
 			}
+			drainTimer.Stop()
+			fmt.Printf("Drain window elapsed; proceeding with shutdown.\n")
 		}
 
 		// Run pre-cancel hooks SYNCHRONOUSLY while live state is still

--- a/utils/ctx.go
+++ b/utils/ctx.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strconv"
 	"sync"
 	"syscall"
+	"time"
 
 	"go.uber.org/zap"
 )
@@ -65,6 +67,30 @@ func NewCtx() context.Context {
 		sig := <-sigs // this received signal will be inside keploy docker container if running in docker else on the host.
 		fmt.Printf("Signal received: %s, canceling context...\n", sig)
 
+		// App-managed graceful-shutdown drain (Kubernetes sidecar path).
+		// When the injecting webhook runs in app-managed-drain mode it sets
+		// KEPLOY_SIDECAR_DRAIN_SECONDS on the agent instead of a native
+		// `sleep` lifecycle (SleepAction) preStop hook — that field is GA
+		// only in k8s 1.30 and some older apiservers reject it, which would
+		// fail pod admission. We honour the drain HERE, before cancel(): the
+		// proxy and every parser goroutine are still live (ctx not yet
+		// cancelled), so in-flight streams keep completing for the window —
+		// exactly what a preStop sleep bought — and only then do we tear
+		// down. A second signal cuts the wait short for an impatient
+		// operator (or a kubelet escalating toward SIGKILL). Unset / zero
+		// (the default, and every non-sidecar invocation) skips the wait
+		// entirely, preserving the historical immediate-cancel behaviour.
+		if d := sidecarDrainDuration(); d > 0 {
+			fmt.Printf("Draining in-flight connections for %s before shutdown (KEPLOY_SIDECAR_DRAIN_SECONDS)...\n", d)
+			t := time.NewTimer(d)
+			select {
+			case <-t.C:
+			case sig2 := <-sigs:
+				t.Stop()
+				fmt.Printf("Second signal received: %s, ending drain early...\n", sig2)
+			}
+		}
+
 		// Run pre-cancel hooks SYNCHRONOUSLY while live state is still
 		// readable. fmt.Fprintf to stderr inside hooks is the right
 		// choice — it goes straight to the syscall and survives even
@@ -120,4 +146,25 @@ func ExecCancel() {
 
 func SetCancel(c context.CancelFunc) {
 	cancel = c
+}
+
+// sidecarDrainDuration returns the graceful-shutdown drain window the
+// Kubernetes injecting webhook sets, in app-managed-drain mode, via the
+// KEPLOY_SIDECAR_DRAIN_SECONDS env var. It is the in-process replacement for
+// a native `sleep` lifecycle preStop hook on the keploy-agent sidecar.
+//
+// Returns 0 (no wait) when the var is unset, non-numeric, or non-positive —
+// so only an explicit positive value can delay shutdown, and every
+// non-sidecar / older-deployment invocation keeps the historical
+// cancel-immediately-on-signal behaviour.
+func sidecarDrainDuration() time.Duration {
+	v := os.Getenv("KEPLOY_SIDECAR_DRAIN_SECONDS")
+	if v == "" {
+		return 0
+	}
+	secs, err := strconv.Atoi(v)
+	if err != nil || secs <= 0 {
+		return 0
+	}
+	return time.Duration(secs) * time.Second
 }

--- a/utils/ctx_test.go
+++ b/utils/ctx_test.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	"testing"
+	"time"
+)
+
+// TestSidecarDrainDuration covers the parsing of KEPLOY_SIDECAR_DRAIN_SECONDS,
+// the env var the k8s injecting webhook sets in app-managed-drain mode. Only an
+// explicit positive integer may delay shutdown; everything else (unset,
+// non-numeric, zero, negative) must yield 0 so the historical
+// cancel-immediately-on-signal behaviour is preserved for every other caller.
+func TestSidecarDrainDuration(t *testing.T) {
+	cases := []struct {
+		name string
+		set  bool
+		val  string
+		want time.Duration
+	}{
+		{name: "unset", set: false, want: 0},
+		{name: "empty", set: true, val: "", want: 0},
+		{name: "positive", set: true, val: "15", want: 15 * time.Second},
+		{name: "one", set: true, val: "1", want: time.Second},
+		{name: "zero", set: true, val: "0", want: 0},
+		{name: "negative", set: true, val: "-5", want: 0},
+		{name: "non-numeric", set: true, val: "abc", want: 0},
+		{name: "float-rejected", set: true, val: "1.5", want: 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv("KEPLOY_SIDECAR_DRAIN_SECONDS", tc.val)
+			} else {
+				// t.Setenv can't unset; ensure the loop's prior value can't
+				// leak by explicitly clearing for this subtest.
+				t.Setenv("KEPLOY_SIDECAR_DRAIN_SECONDS", "")
+			}
+			if got := sidecarDrainDuration(); got != tc.want {
+				t.Fatalf("sidecarDrainDuration() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Describe the changes that are made
- Adds an **in-process graceful-shutdown drain** to the root signal handler (`utils.NewCtx`).
- On `SIGTERM`/`SIGINT`, if `KEPLOY_SIDECAR_DRAIN_SECONDS` is a positive integer, the handler keeps the proxy and its parser goroutines **live** for that window *before* cancelling the root context, so in-flight MITM'd streams finish cleanly; then it tears down.
- The drain window is **respected**: additional SIGTERM/SIGINT signals during the window are logged but do **not** truncate it. The kubelet sends exactly one SIGTERM and escalates via SIGKILL at `terminationGracePeriodSeconds` (uncatchable — the real hard stop), so a repeat `kubectl delete` can't cut an in-flight drain short. Immediate kill: `kubectl delete --grace-period=0 --force`.
- Unset / zero / invalid (the default, and every non-sidecar invocation) → **no wait**, preserving the historical cancel-immediately-on-signal behaviour.

### Verified end-to-end (kind, k8s 1.35, app-managed mode)
On `kubectl delete pod`, the keploy-agent sidecar drained for **exactly 15s** before shutdown:
```
+0.00s  Signal received: terminated, canceling context...
+0.00s  Draining in-flight connections for 15s ...
+3.05s  Signal terminated received during shutdown drain; ignoring to honour the 15s drain window ...
+7.05s  ... ignoring ...
+11.05s ... ignoring ...
+15.00s Drain window elapsed; proceeding with shutdown.
```
Three extra SIGTERMs at +3/+7/+11s were each ignored; the full 15s still completed.

### Why
This is the in-app replacement for the native Kubernetes `sleep` lifecycle (`SleepAction`) preStop hook that the **k8s-proxy** webhook injected on the keploy-agent sidecar. `SleepAction` is GA only in **k8s 1.30**; some older apiservers **reject the field outright**, which fails pod admission for every instrumented workload. Performing the drain in-process is portable to any k8s version.

The env var is set by the k8s-proxy webhook in its new opt-in `app-managed-drain` mode (companion PR).

## Links & References

**Closes:** NA

### 🔗 Related PRs
- https://github.com/keploy/k8s-proxy/pull/550 — opt-in app-managed graceful-shutdown drain (sets `KEPLOY_SIDECAR_DRAIN_SECONDS`)
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [x] 🍕 Feature

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

```
# unset -> no delay (default)
go test ./utils/ -run SidecarDrainDuration -v

# behaviourally: with KEPLOY_SIDECAR_DRAIN_SECONDS=15 the agent, on SIGTERM,
# keeps serving in-flight connections for 15s before cancelling its root ctx.
```

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA
