### PR TITLE
fix(replay): scope strict schema-noise mock rejection to HTTP mocks

### DIFF
--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1921,10 +1921,54 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			// non-noise request field drifted. The app's response can still
 			// match (e.g. a deterministic dependency), so the response check
 			// alone won't catch it; treat it as a real test failure.
+			//
+			// SchemaNoiseStrict is an HTTP-only contract: only the HTTP
+			// integration consumes the flag and the shared schema-noise engine
+			// (see pkg/agent/proxy/integrations/http/match.go). The MySQL,
+			// redis and gRPC matchers never receive it. A non-HTTP mock can go
+			// unconsumed for reasons strict schema-noise has no say over — e.g.
+			// a value-driven COM_QUERY structural fallback serving a different
+			// same-shape row, or a redis key drift — so force-failing those
+			// under strict would be a false positive. strictHTTPDrift gates the
+			// strict failure to mismatches that actually involve an HTTP mock;
+			// a mismatch made up only of non-HTTP mocks falls through to the
+			// normal (non-strict) handling, exactly as if strict were off.
+			strictHTTPDrift := false
+			if mockSetMismatch && r.config.Test.SchemaNoiseStrict {
+				consumedSet := make(map[string]bool, len(filteredMockNames))
+				for _, n := range filteredMockNames {
+					consumedSet[n] = true
+				}
+				for _, m := range expectedMocks {
+					// mirror the DNS + reusable/startup-tier exclusion used to
+					// build filteredExpectedNames above.
+					isDNS := strings.EqualFold(m.Kind, string(models.DNS))
+					if !isDNS {
+						if kind, ok := mockKindByName[m.Name]; ok && kind == models.DNS {
+							isDNS = true
+						}
+					}
+					if isDNS || reusableMockNames[m.Name] || consumedSet[m.Name] {
+						continue
+					}
+					// An unconsumed per-test mock. Strict schema-noise only
+					// owns HTTP request-body drift, so only an HTTP mock here
+					// justifies failing the otherwise-passing testcase.
+					kind := models.Kind(m.Kind)
+					if kind == "" {
+						kind = mockKindByName[m.Name]
+					}
+					if kind == models.HTTP {
+						strictHTTPDrift = true
+						break
+					}
+				}
+			}
+
 			strictMockReject := false
 			if mockSetMismatch {
 				switch {
-				case testPass && r.config.Test.SchemaNoiseStrict:
+				case testPass && r.config.Test.SchemaNoiseStrict && strictHTTPDrift:
 					r.logger.Error("strict schema-noise: expected mock was rejected (non-noise request-body drift); failing testcase even though the response matched",
 						zap.String("testcase", testCase.Name),
 						zap.String("testset", testSetID),
@@ -1934,7 +1978,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 					strictMockReject = true
 					r.mockMismatchFailures.AddFailure(testSetID, testCase.Name, filteredExpectedNames, filteredMockNames)
 				case testPass:
-					r.logger.Debug("mock mapping mismatch ignored because testcase passed",
+					r.logger.Debug("mock mapping mismatch ignored because testcase passed (no HTTP mock drifted under strict schema-noise)",
 						zap.String("testcase", testCase.Name),
 						zap.String("testset", testSetID),
 						zap.Strings("expectedMocks", filteredExpectedNames),


### PR DESCRIPTION
## Describe the changes that are made

`SchemaNoiseStrict` is effectively an **HTTP-only contract**: the only matcher that consumes the flag (and the shared `schemanoise.Engine`) is the HTTP integration — see `pkg/agent/proxy/integrations/http/match.go` (`schemanoise.New(...)`, `filterStrictNoiseMatches`). The **MySQL, redis and gRPC matchers never receive the flag at all**.

But the per-test *consumed-vs-expected* mock reconciliation in `RunTestSet` (`pkg/service/replay/replay.go`) failed **any** passing testcase whose mock set diverged, regardless of the kind of the unconsumed mock:

```go
case testPass && r.config.Test.SchemaNoiseStrict:
    // ... testPass = false  (fail the testcase)
```

So a non-HTTP dependency that drifts for reasons strict schema-noise has no say over still force-failed the testcase **even though the recorded response matched**. Concretely:

- a value-driven **COM_QUERY** structural fallback serving a *different same-shape* row (plaintext MySQL has no per-value noise tolerance — only `COM_STMT_EXECUTE` does, via `NoiseChecker`), or
- a **redis** key embedding a generated id (e.g. `GET <orderId>_<token>`),

makes the expected mock go unconsumed → `mockSetMismatch` → strict fail, producing false-positive `strict schema-noise: expected mock was rejected (non-noise request-body drift)` failures.

**Fix:** gate the strict failure on a new `strictHTTPDrift` check — only fail when at least one *unconsumed expected* mock is actually an **HTTP** mock. A mismatch made up solely of non-HTTP mocks now falls through to the normal (non-strict) handling, exactly as if strict were off. HTTP request-body strictness is unchanged.

The mock kind is already available at the call site (`MockEntry.Kind`, resolved via `mockKindByName`), and the new loop mirrors the existing DNS + reusable-tier exclusion used to build `filteredExpectedNames`.

## Links & References

**Closes:** NA

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [x] 🐞 Bug Fix

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙋 no, because I need help

The behavioural change is in the in-cluster replay verdict path; happy to add a `RunTestSet`-level unit test exercising a non-HTTP-only mock-set mismatch under `SchemaNoiseStrict` if maintainers point me at the preferred harness.

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

With `--schema-noise-strict` on, run a test set whose only request-body drift is a non-HTTP dependency (e.g. a Hibernate `UPDATE … SET updated_at='<wall-clock>' …` plaintext `COM_QUERY`, or a redis key containing a generated id) while the HTTP response is deterministic.

- **Before:** testcase fails with `strict schema-noise: expected mock was rejected (non-noise request-body drift)` despite the response matching.
- **After:** the non-HTTP mock-set divergence is ignored (test passes), while genuine HTTP request-body drift still fails strictly.

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA
