### PR TITLE
feat: strict request-body value-match and unified on-disk noise block

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,9 +23,18 @@ jobs:
       - name: Build arm
         run: GOOS=linux GOARCH=arm64 go build -v ./...
 
-      - uses: codfish/semantic-release-action@v3
-        with:
-          dry-run: true
-          additional-packages: '["@semantic-release/exec@7.0.3"]'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # SECURITY: codfish/semantic-release-action was compromised on
+      # 2026-06-24 15:39 UTC — the attacker force-pushed malicious commit
+      # 5792aba (full: 6b9501e1889cc45c91726729610cf69c2442b8c5) and repointed
+      # ALL mutable tags, including v3 and every v3.x, to it. The payload
+      # (Miasma worm) exfiltrates the GITHUB_TOKEN / OIDC token and tries to
+      # backdoor other accessible repos. GitHub took the repo down (TOS block)
+      # on 2026-06-25, so @v3 no longer resolves at all.
+      # Ref: https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action
+      #
+      # Step disabled. To restore a release dry-run safely, do NOT pin to a tag —
+      # pin a third-party action to a verified pre-compromise full commit SHA, or
+      # run semantic-release directly, e.g.:
+      #   - run: npx -p semantic-release@24 -p @semantic-release/exec@7.0.3 semantic-release --dry-run
+      #     env:
+      #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_workflow_scripts/golang/mux_elasticsearch_schema_noise/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/mux_elasticsearch_schema_noise/golang-linux.sh
@@ -7,9 +7,9 @@
 # OUTGOING Elasticsearch request body (POST /documents/_doc) carries a volatile
 # field that drifts between a keploy recording and each replay. Three scenarios:
 #
-#   Phase A — control (flag off): replay writes NO req_body_noise.
+#   Phase A — control (flag off): replay writes NO noise.req.
 #   Phase B — detect+persist (--schema-noise-detection): the body.created_at
-#             drift is detected and persisted as req_body_noise on the ES mock.
+#             drift is detected and persisted under noise.req on the ES mock.
 #   Phase C — strict (test.schemaNoiseStrict): a drift on a NON-noise field
 #             (content, induced by tampering the recorded mock) is rejected.
 #
@@ -109,21 +109,26 @@ checkout_passed() {  # post-documents testcase passed?
   grep -oE '"testcase id": "[^"]*document[^"]*".*"passed": "[^"]+"' "$1" \
     | strip_ansi | grep -q '"passed": "true"'
 }
-mock_has_created_at_noise() { grep -A5 'req_body_noise' "$(mock_file)" 2>/dev/null | grep -q 'body.created_at'; }
-mock_has_any_noise()        { grep -q 'req_body_noise' "$(mock_file)" 2>/dev/null; }
+# Request-body schema noise is written under the unified `noise:` block as a
+# `req:` list of field paths (this replaced the legacy top-level `req_body_noise:`
+# map). A learned path therefore appears as a `- body.<path>` list item, which is
+# unique to noise.req: the HTTP spec's own `req:` is a mapping (no body-path list
+# items) and obfuscator value-regexes live under noise.value.
+mock_has_created_at_noise() { grep -qE '^[[:space:]]*-[[:space:]]+body\.created_at([[:space:]]|$)' "$(mock_file)" 2>/dev/null; }
+mock_has_any_noise()        { grep -qE '^[[:space:]]*-[[:space:]]+body\.' "$(mock_file)" 2>/dev/null; }
 
 # ---------------------------------------------------------------------------
 # Phase A — control
 # ---------------------------------------------------------------------------
 step "Phase A — control (no --schema-noise-detection)"
 record_fresh
-mock_has_any_noise && fail "fresh recording already has req_body_noise" \
-                   || pass "fresh recording has no req_body_noise"
+mock_has_any_noise && fail "fresh recording already has noise.req" \
+                   || pass "fresh recording has no noise.req"
 replay "$APP_DIR/test_control.log" --remove-unused-mocks
 checkout_passed "$APP_DIR/test_control.log" && pass "replay passed with flag off" \
                                             || fail "replay should pass with flag off"
-mock_has_any_noise && fail "flag off must NOT write req_body_noise" \
-                   || pass "flag off wrote no req_body_noise (inert when disabled)"
+mock_has_any_noise && fail "flag off must NOT write noise.req" \
+                   || pass "flag off wrote no noise.req (inert when disabled)"
 
 # ---------------------------------------------------------------------------
 # Phase B — detect + persist
@@ -134,10 +139,10 @@ replay "$APP_DIR/test_detect.log" --schema-noise-detection --remove-unused-mocks
 checkout_passed "$APP_DIR/test_detect.log" && pass "replay passed with detection on" \
                                            || fail "replay should pass with detection on"
 if mock_has_created_at_noise; then
-  pass "ES mock persisted req_body_noise: body.created_at"
-  grep -B1 -A2 'req_body_noise' "$(mock_file)" | sed 's/^/    /'
+  pass "ES mock persisted noise.req: body.created_at"
+  grep -A3 '^noise:' "$(mock_file)" | sed 's/^/    /'
 else
-  fail "expected req_body_noise: body.created_at in the ES mock"
+  fail "expected noise.req: body.created_at in the ES mock"
   echo "  --- mocks.yaml ---"; cat "$(mock_file)" 2>/dev/null | sed 's/^/    /'
 fi
 

--- a/pkg/agent/proxy/integrations/http/match.go
+++ b/pkg/agent/proxy/integrations/http/match.go
@@ -244,13 +244,13 @@ func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMe
 				return false, nil, nil, err
 			}
 
-			// Strict enforcement (replay path): for any candidate that already
-			// carries learned req_body_noise, every request-body field must
-			// match except those learned-noise paths and the user's configured
-			// body noise. A drift on a non-noise field rejects that candidate,
-			// so a changed-but-unmarked field fails the test instead of being
-			// silently served. Candidates with no learned noise keep the
-			// lenient schema/key behaviour.
+			// Strict enforcement (replay path): every candidate's request-body
+			// fields must match the recorded body except the user's configured
+			// body noise and any learned req_body_noise paths. A drift on a
+			// non-noise field rejects that candidate, so a changed-but-unmarked
+			// field fails the test instead of being silently served. This applies
+			// even to candidates with no learned noise — strict mode value-checks
+			// the whole body, not just the lenient key/schema match above.
 			beforeStrict := len(bodyMatched)
 			if schemaNoiseStrict {
 				bodyMatched = h.filterStrictNoiseMatches(noiseEngine, bodyMatched, input.body, userBodyNoise)
@@ -1143,15 +1143,15 @@ func (h *HTTP) updateMock(_ context.Context, matchedMock *models.Mock, mockDb in
 }
 
 // filterStrictNoiseMatches enforces strict request-body matching on the
-// replay path. A candidate mock is dropped only when it already carries
-// learned req_body_noise AND a field OUTSIDE that learned-noise set drifted
-// from the recorded body — i.e. an unmarked field changed. Candidates with no
-// learned noise are kept unchanged (lenient schema/key behaviour), so this
-// never tightens matching for mocks the auto-replay never learned noise for.
+// replay path. Under strict enforcement EVERY candidate is value-compared
+// against its recorded body — not just those carrying learned req_body_noise.
+// A candidate is dropped when a field OUTSIDE the known-noise set (configured
+// global/user body noise ∪ anything the mock already learned) drifted from the
+// recorded body, i.e. an unmarked value or type changed. So a mock with no
+// learned noise no longer passes by default: only fields explicitly marked as
+// noise may differ.
 //
-// It delegates to schemanoise.Engine.StrictReject: a candidate with no learned
-// noise is always kept (lenient), and a candidate WITH learned noise is dropped
-// when a field outside that learned set drifted. The JSON/form comparison and
+// It delegates to schemanoise.Engine.StrictReject. The JSON/form comparison and
 // known-noise merge are owned by the shared engine + httpNoiseAdapter; the
 // returned drift names the offending field path(s) for the rejection log.
 func (h *HTTP) filterStrictNoiseMatches(eng *schemanoise.Engine, candidates []*models.Mock, reqBody []byte, userBodyNoise map[string][]string) []*models.Mock {

--- a/pkg/agent/proxy/integrations/schemanoise/schemanoise.go
+++ b/pkg/agent/proxy/integrations/schemanoise/schemanoise.go
@@ -167,11 +167,17 @@ func (e *Engine) Learn(m *models.Mock, drift map[string][]string) int {
 }
 
 // StrictAllows reports whether mock m may still match the live body under strict
-// enforcement. A mock with no learned noise is always allowed — strict only
-// tightens what was explicitly learned, never mocks the auto-replay never
-// touched. A mock WITH learned noise is rejected when a field OUTSIDE that
-// learned set drifted (an unmarked change), or when the bodies aren't JSON-
-// comparable yet differ byte-for-byte (a non-learnable mismatch).
+// enforcement. Every candidate is value-compared against its recorded request
+// body: it is rejected when a field OUTSIDE the known-noise set (global/user
+// body noise ∪ anything the mock already learned) drifted — an unmarked value or
+// type change — or when the bodies aren't JSON-comparable yet differ
+// byte-for-byte (a non-learnable mismatch). A mock with NO learned noise is no
+// longer waved through: in strict mode only configured/learned noise is
+// tolerated, so a value change on an unmarked field fails the match.
+//
+// This value check only runs when the engine was built with strict enforcement.
+// Without it, StrictReject still tightens only what was explicitly learned and
+// leaves un-learned mocks alone, preserving the lenient schema/key behaviour.
 func (e *Engine) StrictAllows(m *models.Mock, liveBody []byte, userNoise map[string][]string) bool {
 	allowed, _ := e.StrictReject(m, liveBody, userNoise)
 	return allowed
@@ -188,7 +194,13 @@ func (e *Engine) StrictReject(m *models.Mock, liveBody []byte, userNoise map[str
 		return true, nil
 	}
 	stored := e.adapter.StoredNoise(m)
-	if len(stored) == 0 {
+	// Under strict enforcement every candidate is value-compared against its
+	// recorded body, even one with no learned req_body_noise — so a changed value
+	// (or type) on a field not covered by configured/learned noise rejects the
+	// mock. Without strict enforcement we only tighten what was explicitly
+	// learned, so a mock the auto-replay never touched (no stored noise) is left
+	// alone and stays a match.
+	if !e.strict && len(stored) == 0 {
 		return true, nil
 	}
 	recorded, ok := e.adapter.RecordedBody(m)

--- a/pkg/agent/proxy/integrations/schemanoise/schemanoise_test.go
+++ b/pkg/agent/proxy/integrations/schemanoise/schemanoise_test.go
@@ -226,10 +226,29 @@ func TestEngineKnownNoiseMergesStoredAndUser(t *testing.T) {
 
 func TestEngineStrictAllows(t *testing.T) {
 	mock := &models.Mock{}
-	// No learned noise => always allowed (strict never tightens un-learned mocks).
-	none := New(&fakeAdapter{body: []byte(`{"a":1}`), hasBody: true}, false, true)
-	if !none.StrictAllows(mock, []byte(`{"a":2}`), nil) {
-		t.Fatalf("mock with no learned noise must be allowed under strict")
+	// No learned noise, value drift => rejected under strict. Strict now
+	// value-checks every candidate, not just ones carrying learned noise.
+	noneDrift := New(&fakeAdapter{body: []byte(`{"a":1}`), hasBody: true}, false, true)
+	if noneDrift.StrictAllows(mock, []byte(`{"a":2}`), nil) {
+		t.Fatalf("value drift on an un-learned, un-noised field must be rejected under strict")
+	}
+
+	// No learned noise, identical body => allowed (nothing drifted).
+	noneSame := New(&fakeAdapter{body: []byte(`{"a":1}`), hasBody: true}, false, true)
+	if !noneSame.StrictAllows(mock, []byte(`{"a":1}`), nil) {
+		t.Fatalf("identical body must be allowed under strict even with no learned noise")
+	}
+
+	// No learned noise but the drift is on a user-configured noise field => allowed.
+	noneUserNoise := New(&fakeAdapter{body: []byte(`{"a":1}`), hasBody: true}, false, true)
+	if !noneUserNoise.StrictAllows(mock, []byte(`{"a":2}`), map[string][]string{"a": {}}) {
+		t.Fatalf("drift on a user-noised field must be allowed under strict even with no learned noise")
+	}
+
+	// Without strict enforcement an un-learned mock is left alone (lenient).
+	lenient := New(&fakeAdapter{body: []byte(`{"a":1}`), hasBody: true}, false, false)
+	if !lenient.StrictAllows(mock, []byte(`{"a":2}`), nil) {
+		t.Fatalf("non-strict engine must keep lenient behaviour for un-learned mocks")
 	}
 
 	// Learned noise covers the only drifting field => allowed.
@@ -302,5 +321,18 @@ func TestEngineStrictReject(t *testing.T) {
 	allowed, drift = New(binAdapter, false, true).StrictReject(mock, []byte("bin-v2"), nil)
 	if allowed || len(drift) == 0 {
 		t.Fatalf("opaque byte mismatch must be rejected with non-empty drift; got allowed=%v drift=%v", allowed, drift)
+	}
+
+	// No learned noise: strict still value-compares and names the drifted field.
+	noNoiseAdapter := &fakeAdapter{
+		body:    []byte(`{"a":1,"tier_type":"STANDARD_LARGE"}`),
+		hasBody: true,
+	}
+	allowed, drift = New(noNoiseAdapter, false, true).StrictReject(mock, []byte(`{"a":1,"tier_type":"regular"}`), nil)
+	if allowed {
+		t.Fatalf("value drift must be rejected under strict even with no learned noise")
+	}
+	if _, ok := drift["body.tier_type"]; !ok {
+		t.Fatalf("rejection drift must name body.tier_type; got %v", drift)
 	}
 }

--- a/pkg/platform/yaml/codec.go
+++ b/pkg/platform/yaml/codec.go
@@ -55,17 +55,14 @@ type NetworkTrafficDocJSON struct {
 	Kind         models.Kind         `json:"kind"`
 	Name         string              `json:"name"`
 	Spec         json.RawMessage     `json:"spec"`
-	Noise        []string            `json:"noise,omitempty"`
+	Noise        *DocNoise           `json:"noise,omitempty"`
 	LastUpdated  *models.LastUpdated `json:"last_updated,omitempty"`
 	Curl         string              `json:"curl,omitempty"`
 	ConnectionID string              `json:"connectionId,omitempty"`
-	// ReqBodyNoise mirrors NetworkTrafficDoc.ReqBodyNoise: the kind-agnostic
-	// MockSpec.ReqBodyNoise, the single storage location every parser uses (HTTP
-	// included), carried on the shared top-level doc because the per-kind specs
-	// have no field for it. Only populated for a kind whose parser implements the
-	// schema-noise adapter and learned drift (HTTP, plus Pulsar in enterprise);
-	// other kinds (DNS, Mongo, …) leave it empty so omitempty drops it. Restored
-	// to MockSpec on decode.
+	// ReqBodyNoise mirrors NetworkTrafficDoc.ReqBodyNoise: the LEGACY top-level
+	// req_body_noise key, no longer written but still read so older on-disk mocks
+	// keep matching. New mocks carry request-body noise under noise.req (DocNoise);
+	// on decode this legacy map's keys are folded in via ResolveReqBodyNoise.
 	ReqBodyNoise map[string][]string `json:"req_body_noise,omitempty"`
 }
 
@@ -91,6 +88,7 @@ func DocToJSON(doc *NetworkTrafficDoc) (*NetworkTrafficDocJSON, error) {
 		LastUpdated:  doc.LastUpdated,
 		Curl:         doc.Curl,
 		ConnectionID: doc.ConnectionID,
+		ReqBodyNoise: doc.ReqBodyNoise, // legacy read-through (see DocNoise)
 	}, nil
 }
 
@@ -155,6 +153,7 @@ func jsonDocToYamlDoc(jsonDoc *NetworkTrafficDocJSON) (*NetworkTrafficDoc, error
 		LastUpdated:  jsonDoc.LastUpdated,
 		Curl:         jsonDoc.Curl,
 		ConnectionID: jsonDoc.ConnectionID,
+		ReqBodyNoise: jsonDoc.ReqBodyNoise, // legacy read-through (see DocNoise)
 	}
 
 	// Convert json.RawMessage to a generic interface, then encode into yaml.Node

--- a/pkg/platform/yaml/docnoise_test.go
+++ b/pkg/platform/yaml/docnoise_test.go
@@ -1,0 +1,108 @@
+package yaml
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	yamlLib "gopkg.in/yaml.v3"
+)
+
+// TestDocNoise_UnmarshalYAML covers the backward-compatible YAML decoding: the
+// new mapping shape ({req, value}) and the legacy bare string list (-> value).
+func TestDocNoise_UnmarshalYAML(t *testing.T) {
+	t.Run("new mapping shape", func(t *testing.T) {
+		var n DocNoise
+		in := "req:\n  - body.tier_type\n  - body.user.id\nvalue:\n  - \"^tok-.*$\"\n"
+		if err := yamlLib.Unmarshal([]byte(in), &n); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if !reflect.DeepEqual(n.Req, []string{"body.tier_type", "body.user.id"}) {
+			t.Fatalf("req mismatch: %v", n.Req)
+		}
+		if !reflect.DeepEqual(n.Value, []string{"^tok-.*$"}) {
+			t.Fatalf("value mismatch: %v", n.Value)
+		}
+	})
+
+	t.Run("legacy list shape folds into value", func(t *testing.T) {
+		var n DocNoise
+		in := "- \"^tok-.*$\"\n- \"^sess-.*$\"\n"
+		if err := yamlLib.Unmarshal([]byte(in), &n); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if len(n.Req) != 0 {
+			t.Fatalf("legacy list must not populate req: %v", n.Req)
+		}
+		if !reflect.DeepEqual(n.Value, []string{"^tok-.*$", "^sess-.*$"}) {
+			t.Fatalf("legacy list must fold into value: %v", n.Value)
+		}
+	})
+}
+
+// TestDocNoise_UnmarshalJSON mirrors the YAML test for the JSON path.
+func TestDocNoise_UnmarshalJSON(t *testing.T) {
+	t.Run("new object shape", func(t *testing.T) {
+		var n DocNoise
+		if err := json.Unmarshal([]byte(`{"req":["body.a"],"value":["^x.*$"]}`), &n); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if !reflect.DeepEqual(n.Req, []string{"body.a"}) || !reflect.DeepEqual(n.Value, []string{"^x.*$"}) {
+			t.Fatalf("decoded: %#v", n)
+		}
+	})
+
+	t.Run("legacy array shape folds into value", func(t *testing.T) {
+		var n DocNoise
+		if err := json.Unmarshal([]byte(`["^x.*$"]`), &n); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if len(n.Req) != 0 || !reflect.DeepEqual(n.Value, []string{"^x.*$"}) {
+			t.Fatalf("legacy array must fold into value: %#v", n)
+		}
+	})
+}
+
+// TestNewDocNoise_DropsRegexValuesAndSorts verifies the encode helper persists
+// only the field PATHS of the schema-noise map (regex values dropped), sorts them
+// deterministically, and returns nil when there is nothing to write.
+func TestNewDocNoise_DropsRegexValuesAndSorts(t *testing.T) {
+	got := NewDocNoise([]string{"^tok-.*$"}, map[string][]string{
+		"body.z": {"^ignored.*$"}, // regex value must be dropped
+		"body.a": {},
+	})
+	if got == nil {
+		t.Fatal("expected non-nil DocNoise")
+	}
+	if !reflect.DeepEqual(got.Req, []string{"body.a", "body.z"}) {
+		t.Fatalf("req must be sorted paths with no regex values, got %v", got.Req)
+	}
+	if !reflect.DeepEqual(got.Value, []string{"^tok-.*$"}) {
+		t.Fatalf("value mismatch: %v", got.Value)
+	}
+
+	if NewDocNoise(nil, nil) != nil {
+		t.Fatal("empty inputs must yield nil so omitempty drops the noise key")
+	}
+}
+
+// TestResolveReqBodyNoise_PrefersNewFallsBackToLegacy checks decode resolution:
+// noise.req wins, else the legacy req_body_noise map's keys are used (regex
+// values dropped).
+func TestResolveReqBodyNoise_PrefersNewFallsBackToLegacy(t *testing.T) {
+	// New noise.req present -> used directly.
+	got := ResolveReqBodyNoise(&DocNoise{Req: []string{"body.a"}}, map[string][]string{"body.legacy": {}})
+	if _, ok := got["body.a"]; !ok || len(got) != 1 {
+		t.Fatalf("must prefer noise.req, got %v", got)
+	}
+
+	// No noise.req -> fall back to legacy keys, dropping regex values.
+	got = ResolveReqBodyNoise(nil, map[string][]string{"body.legacy": {"^x.*$"}})
+	if v, ok := got["body.legacy"]; !ok || len(v) != 0 {
+		t.Fatalf("legacy fallback must keep key and drop regex, got %v", got)
+	}
+
+	if ResolveReqBodyNoise(nil, nil) != nil {
+		t.Fatal("no noise anywhere must resolve to nil")
+	}
+}

--- a/pkg/platform/yaml/mockdb/noise_nonhttp_test.go
+++ b/pkg/platform/yaml/mockdb/noise_nonhttp_test.go
@@ -42,8 +42,8 @@ func TestNonHTTPNoise_YAMLRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeMock: %v", err)
 	}
-	if len(doc.ReqBodyNoise) != 2 {
-		t.Fatalf("envelope must carry req_body_noise, got %v", doc.ReqBodyNoise)
+	if doc.Noise == nil || len(doc.Noise.Req) != 2 {
+		t.Fatalf("envelope must carry noise.req paths, got %#v", doc.Noise)
 	}
 
 	decoded, err := DecodeMocks([]*yaml.NetworkTrafficDoc{doc}, zap.NewNop())
@@ -72,8 +72,8 @@ func TestNonHTTPNoise_JSONRoundTrip(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("EncodeMockJSON: ok=%v err=%v", ok, err)
 	}
-	if len(doc.ReqBodyNoise) != 1 {
-		t.Fatalf("JSON envelope must carry req_body_noise, got %v", doc.ReqBodyNoise)
+	if doc.Noise == nil || len(doc.Noise.Req) != 1 {
+		t.Fatalf("JSON envelope must carry noise.req paths, got %#v", doc.Noise)
 	}
 
 	decoded, err := DecodeMocksJSON([]*yaml.NetworkTrafficDocJSON{doc}, zap.NewNop())
@@ -100,8 +100,8 @@ func TestNonHTTPNoise_HTTPUsesSameEnvelope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeMock: %v", err)
 	}
-	if _, ok := doc.ReqBodyNoise["body.a"]; !ok {
-		t.Fatalf("HTTP noise must ride the shared envelope, got %v", doc.ReqBodyNoise)
+	if !reqNoiseHas(doc.Noise, "body.a") {
+		t.Fatalf("HTTP noise must ride noise.req, got %#v", doc.Noise)
 	}
 
 	decoded, err := DecodeMocks([]*yaml.NetworkTrafficDoc{doc}, zap.NewNop())
@@ -142,8 +142,11 @@ func TestPersistMockNoise_NonHTTP(t *testing.T) {
 		t.Fatal(err)
 	}
 	content := string(data)
-	if !strings.Contains(content, "req_body_noise") || !strings.Contains(content, "body.eventTs") {
-		t.Fatalf("non-HTTP learned noise not persisted; file:\n%s", content)
+	if !strings.Contains(content, "noise:") || !strings.Contains(content, "req:") || !strings.Contains(content, "body.eventTs") {
+		t.Fatalf("non-HTTP learned noise not persisted under noise.req; file:\n%s", content)
+	}
+	if strings.Contains(content, "req_body_noise") {
+		t.Fatalf("legacy req_body_noise key must no longer be written; file:\n%s", content)
 	}
 
 	// And it must round-trip back into MockSpec.ReqBodyNoise on read.
@@ -169,5 +172,82 @@ func TestPersistMockNoise_NonHTTP(t *testing.T) {
 	}
 	if _, ok := mocks[0].Spec.ReqBodyNoise["body.eventTs"]; !ok {
 		t.Fatalf("persisted non-HTTP noise did not round-trip: %v", mocks[0].Spec.ReqBodyNoise)
+	}
+}
+
+// reqNoiseHas reports whether the unified noise block lists the given request-body
+// field path under noise.req.
+func reqNoiseHas(n *yaml.DocNoise, path string) bool {
+	if n == nil {
+		return false
+	}
+	for _, p := range n.Req {
+		if p == path {
+			return true
+		}
+	}
+	return false
+}
+
+// TestLegacyNoiseFormats_StillDecode is the backward-compatibility guard: a mock
+// written in the OLD on-disk shape — a top-level `noise:` string list (obfuscator
+// value-regexes) plus a separate `req_body_noise:` map (with per-path regex values)
+// — must still decode. The legacy noise list folds into value-noise (Mock.Noise),
+// the req_body_noise keys fold into MockSpec.ReqBodyNoise, and the now-unused regex
+// values are dropped.
+func TestLegacyNoiseFormats_StillDecode(t *testing.T) {
+	raw := []byte(`version: api.keploy.io/v1beta1
+kind: Http
+name: legacy-1
+spec:
+  metadata: {}
+  req:
+    method: POST
+    url: http://x/y
+    header:
+      Content-Type: application/json
+    body: '{"a":"b"}'
+  resp:
+    status_code: 200
+    header: {}
+    body: '{"ok":true}'
+noise:
+  - "^tok-.*$"
+req_body_noise:
+  body.a: ["^x.*$"]
+  body.b: []
+`)
+
+	doc, err := yaml.UnmarshalDoc(yaml.FormatYAML, raw)
+	if err != nil {
+		t.Fatalf("UnmarshalDoc: %v", err)
+	}
+	// Legacy bare `noise:` list must decode into the unified block's value-noise.
+	if got := doc.Noise.ValueNoise(); len(got) != 1 || got[0] != "^tok-.*$" {
+		t.Fatalf("legacy noise list must decode into value noise, got %v", got)
+	}
+
+	mocks, err := DecodeMocks([]*yaml.NetworkTrafficDoc{doc}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("DecodeMocks: %v", err)
+	}
+	if len(mocks) != 1 {
+		t.Fatalf("want 1 decoded mock, got %d", len(mocks))
+	}
+	m := mocks[0]
+
+	if len(m.Noise) != 1 || m.Noise[0] != "^tok-.*$" {
+		t.Fatalf("Mock.Noise must come from the legacy noise list, got %v", m.Noise)
+	}
+	rb := m.Spec.ReqBodyNoise
+	if _, ok := rb["body.a"]; !ok {
+		t.Fatalf("legacy req_body_noise key body.a lost on decode: %v", rb)
+	}
+	if _, ok := rb["body.b"]; !ok {
+		t.Fatalf("legacy req_body_noise key body.b lost on decode: %v", rb)
+	}
+	// The legacy per-path regex value must be dropped (req noise is path-only now).
+	if len(rb["body.a"]) != 0 {
+		t.Fatalf("legacy regex value on body.a must be dropped, got %v", rb["body.a"])
 	}
 }

--- a/pkg/platform/yaml/mockdb/persist_noise_test.go
+++ b/pkg/platform/yaml/mockdb/persist_noise_test.go
@@ -61,8 +61,11 @@ func TestPersistMockNoise_WritesNoiseWithoutPruning(t *testing.T) {
 		t.Fatal(err)
 	}
 	content := string(data)
-	if !strings.Contains(content, "req_body_noise") || !strings.Contains(content, "body.request_id") {
-		t.Errorf("learned noise not persisted; file:\n%s", content)
+	if !strings.Contains(content, "noise:") || !strings.Contains(content, "req:") || !strings.Contains(content, "body.request_id") {
+		t.Errorf("learned noise not persisted under noise.req; file:\n%s", content)
+	}
+	if strings.Contains(content, "req_body_noise") {
+		t.Errorf("legacy req_body_noise key must no longer be written; file:\n%s", content)
 	}
 	// No pruning: both mocks still present.
 	if !strings.Contains(content, `"other"`) {

--- a/pkg/platform/yaml/mockdb/util.go
+++ b/pkg/platform/yaml/mockdb/util.go
@@ -34,15 +34,15 @@ func EncodeMockJSON(mock *models.Mock, logger *zap.Logger) (*yaml.NetworkTraffic
 		Version:      mock.Version,
 		Kind:         mock.Kind,
 		Name:         mock.Name,
-		Noise:        mock.Noise,
 		ConnectionID: mock.ConnectionID,
-		// Generic passthrough of the kind-agnostic MockSpec.ReqBodyNoise (the one
-		// storage location every parser uses, HTTP included). It is only non-empty
-		// for a kind whose parser implements the schema-noise adapter and actually
-		// learned drift (HTTP, plus Pulsar in enterprise); kinds with no such
-		// adapter — DNS, Mongo, MySQL, Postgres, etc. — leave it nil, so omitempty
-		// keeps it out of the doc entirely.
-		ReqBodyNoise: mock.Spec.ReqBodyNoise,
+		// Unified noise block: the obfuscator value-regexes (mock.Noise) plus the
+		// request-body schema-noise field PATHS (mock.Spec.ReqBodyNoise keys; regex
+		// values are dropped). Request-body noise is only non-empty for a kind whose
+		// parser implements the schema-noise adapter and learned drift (HTTP, plus
+		// Pulsar in enterprise). NewDocNoise returns nil when there is nothing to
+		// write, so omitempty keeps the noise key out of the doc entirely. The legacy
+		// top-level req_body_noise key is no longer written (still read on decode).
+		Noise: yaml.NewDocNoise(mock.Noise, mock.Spec.ReqBodyNoise),
 	}
 
 	var spec any
@@ -240,13 +240,14 @@ func EncodeMock(mock *models.Mock, logger *zap.Logger) (*yaml.NetworkTrafficDoc,
 		Version:      mock.Version,
 		Kind:         mock.Kind,
 		Name:         mock.Name,
-		Noise:        mock.Noise,
 		ConnectionID: mock.ConnectionID,
-		// Kind-agnostic schema-noise, carried on the shared top-level doc for
-		// every parser (HTTP included). Set before the mapper/per-kind projection
-		// runs so it survives regardless of the spec envelope. Empty for any kind
-		// whose parser never learned drift, so omitempty drops it.
-		ReqBodyNoise: mock.Spec.ReqBodyNoise,
+		// Unified noise block (see DocNoise): obfuscator value-regexes (mock.Noise)
+		// plus request-body schema-noise field PATHS (mock.Spec.ReqBodyNoise keys;
+		// regex values dropped). Set before the mapper/per-kind projection runs so it
+		// survives regardless of the spec envelope. NewDocNoise returns nil when
+		// empty, so omitempty drops the key. The legacy req_body_noise key is no
+		// longer written (still read on decode).
+		Noise: yaml.NewDocNoise(mock.Noise, mock.Spec.ReqBodyNoise),
 	}
 	mapped, err := encodeWithMapper(mock, &yamlDoc)
 	if err != nil {
@@ -622,7 +623,7 @@ func DecodeMocks(yamlMocks []*yaml.NetworkTrafficDoc, logger *zap.Logger) ([]*mo
 			Version:      m.Version,
 			Name:         m.Name,
 			Kind:         m.Kind,
-			Noise:        m.Noise,
+			Noise:        m.Noise.ValueNoise(),
 			ConnectionID: m.ConnectionID,
 		}
 		mapped, err := decodeWithMapper(m, &mock)
@@ -634,8 +635,9 @@ func DecodeMocks(yamlMocks []*yaml.NetworkTrafficDoc, logger *zap.Logger) ([]*mo
 		if mapped {
 			// Restore kind-agnostic schema-noise carried on the doc envelope
 			// (the per-kind mapper rebuilt mock.Spec and can't know about it).
-			if len(m.ReqBodyNoise) > 0 {
-				mock.Spec.ReqBodyNoise = m.ReqBodyNoise
+			// Prefer the unified noise.req; fall back to the legacy req_body_noise key.
+			if rb := yaml.ResolveReqBodyNoise(m.Noise, m.ReqBodyNoise); len(rb) > 0 {
+				mock.Spec.ReqBodyNoise = rb
 			}
 			mocks = append(mocks, &mock)
 			continue
@@ -806,9 +808,10 @@ func DecodeMocks(yamlMocks []*yaml.NetworkTrafficDoc, logger *zap.Logger) ([]*mo
 		}
 		// Restore kind-agnostic schema-noise carried on the doc envelope onto the
 		// freshly-built spec (the per-kind switch above replaced mock.Spec
-		// wholesale). Uniform across parsers — HTTP included.
-		if len(m.ReqBodyNoise) > 0 {
-			mock.Spec.ReqBodyNoise = m.ReqBodyNoise
+		// wholesale). Uniform across parsers — HTTP included. Prefer the unified
+		// noise.req; fall back to the legacy req_body_noise key.
+		if rb := yaml.ResolveReqBodyNoise(m.Noise, m.ReqBodyNoise); len(rb) > 0 {
+			mock.Spec.ReqBodyNoise = rb
 		}
 		mocks = append(mocks, &mock)
 	}
@@ -1278,7 +1281,7 @@ func DecodeMocksJSON(docs []*yaml.NetworkTrafficDocJSON, logger *zap.Logger) ([]
 			Version:      m.Version,
 			Name:         m.Name,
 			Kind:         m.Kind,
-			Noise:        m.Noise,
+			Noise:        m.Noise.ValueNoise(),
 			ConnectionID: m.ConnectionID,
 		}
 
@@ -1510,9 +1513,10 @@ func DecodeMocksJSON(docs []*yaml.NetworkTrafficDocJSON, logger *zap.Logger) ([]
 		}
 		// Restore kind-agnostic schema-noise carried on the doc envelope (the
 		// per-kind switch above replaced mock.Spec wholesale). Uniform across
-		// parsers — HTTP included.
-		if len(m.ReqBodyNoise) > 0 {
-			mock.Spec.ReqBodyNoise = m.ReqBodyNoise
+		// parsers — HTTP included. Prefer the unified noise.req; fall back to the
+		// legacy req_body_noise key.
+		if rb := yaml.ResolveReqBodyNoise(m.Noise, m.ReqBodyNoise); len(rb) > 0 {
+			mock.Spec.ReqBodyNoise = rb
 		}
 		mocks = append(mocks, &mock)
 	}

--- a/pkg/platform/yaml/yaml.go
+++ b/pkg/platform/yaml/yaml.go
@@ -1,12 +1,15 @@
 package yaml
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"go.keploy.io/server/v3/pkg/models"
 	"go.keploy.io/server/v3/utils"
@@ -39,17 +42,148 @@ type NetworkTrafficDoc struct {
 	Kind         models.Kind         `json:"kind" yaml:"kind"`
 	Name         string              `json:"name" yaml:"name"`
 	Spec         yamlLib.Node        `json:"spec" yaml:"spec"`
-	Noise        []string            `json:"noise,omitempty" yaml:"noise,omitempty"`
+	Noise        *DocNoise           `json:"noise,omitempty" yaml:"noise,omitempty"`
 	LastUpdated  *models.LastUpdated `json:"last_updated,omitempty" yaml:"last_updated,omitempty"`
 	Curl         string              `json:"curl" yaml:"curl,omitempty"`
 	ConnectionID string              `json:"connectionId" yaml:"connectionId,omitempty"`
-	// ReqBodyNoise carries the kind-agnostic MockSpec.ReqBodyNoise on the shared
-	// top-level doc — the single storage location every parser uses (HTTP and
-	// non-HTTP alike), since the per-kind specs (GenericSchema, GrpcSpec, …) have
-	// no field for it. Only populated for a kind whose parser implements the
-	// schema-noise adapter and learned drift (HTTP, plus Pulsar in enterprise);
-	// other kinds (DNS, Mongo, …) leave it empty. Restored to MockSpec on decode.
+	// ReqBodyNoise is the LEGACY top-level schema-noise key (req_body_noise). It is
+	// no longer written — new mocks carry request-body noise under noise.req (see
+	// DocNoise) — but it is still read so older on-disk mocks keep matching. On
+	// decode its keys are folded into the unified noise via ResolveReqBodyNoise
+	// (regex values dropped, since the strict path only ever honoured whole-field
+	// "ignore"). Kept for backward compatibility only.
 	ReqBodyNoise map[string][]string `json:"req_body_noise,omitempty" yaml:"req_body_noise,omitempty"`
+}
+
+// DocNoise is the unified on-disk representation of a mock's noise, written under
+// the single `noise:` key. It supersedes the older layout that split a top-level
+// `noise:` string list (value-regexes) from a separate `req_body_noise:` mapping.
+//
+//   - Req   — request-body field paths to ignore during schema/strict matching
+//     (e.g. "body.tier_type"). A plain list of paths: the strict path only ever
+//     honoured "ignore this whole field", so the legacy per-path regex values are
+//     intentionally dropped.
+//   - Value — exact-match value regexes written by the enterprise obfuscator
+//     (the former top-level `noise:` list, models.Mock.Noise).
+//
+// For backward compatibility the custom unmarshalers also accept the OLD shape
+// where `noise:` was a bare string list — that decodes into Value. The legacy
+// top-level `req_body_noise:` key is still read separately
+// (NetworkTrafficDoc.ReqBodyNoise) and folded into Req on decode. New writes only
+// emit this unified mapping.
+type DocNoise struct {
+	Req   []string `json:"req,omitempty" yaml:"req,omitempty"`
+	Value []string `json:"value,omitempty" yaml:"value,omitempty"`
+}
+
+// NewDocNoise builds the unified noise block for encoding from the in-memory
+// model fields: the obfuscator value-regex list (models.Mock.Noise) and the
+// kind-agnostic schema-noise map (models.MockSpec.ReqBodyNoise). Only the field
+// PATHS of the schema-noise map are persisted — the per-path regex values are
+// intentionally dropped (unused on the strict path). Returns nil when there is
+// nothing to write so `omitempty` drops the `noise:` key entirely. Req paths are
+// sorted for deterministic output.
+func NewDocNoise(value []string, reqBodyNoise map[string][]string) *DocNoise {
+	var req []string
+	if len(reqBodyNoise) > 0 {
+		req = make([]string, 0, len(reqBodyNoise))
+		for path := range reqBodyNoise {
+			req = append(req, path)
+		}
+		sort.Strings(req)
+	}
+	if len(req) == 0 && len(value) == 0 {
+		return nil
+	}
+	return &DocNoise{Req: req, Value: value}
+}
+
+// ValueNoise returns the obfuscator value-regex list (models.Mock.Noise). nil-safe.
+func (n *DocNoise) ValueNoise() []string {
+	if n == nil {
+		return nil
+	}
+	return n.Value
+}
+
+// pathsToNoiseMap turns a list of field paths into the canonical schema-noise map
+// shape (path -> empty regex list), the only form the strict/detection path honours.
+func pathsToNoiseMap(paths []string) map[string][]string {
+	if len(paths) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(paths))
+	for _, p := range paths {
+		out[p] = []string{}
+	}
+	return out
+}
+
+// ResolveReqBodyNoise picks the request-body schema noise for a decoded doc,
+// preferring the new unified noise.req list and falling back to the legacy
+// top-level req_body_noise map (whose keys are kept and regex values dropped, to
+// match the path-only representation). Returns nil when neither is present.
+func ResolveReqBodyNoise(noise *DocNoise, legacy map[string][]string) map[string][]string {
+	if noise != nil && len(noise.Req) > 0 {
+		return pathsToNoiseMap(noise.Req)
+	}
+	if len(legacy) > 0 {
+		paths := make([]string, 0, len(legacy))
+		for k := range legacy {
+			paths = append(paths, k)
+		}
+		return pathsToNoiseMap(paths)
+	}
+	return nil
+}
+
+// UnmarshalYAML accepts both the new mapping shape ({req: [...], value: [...]})
+// and the legacy bare string list (which becomes Value), so old mocks keep
+// decoding.
+func (n *DocNoise) UnmarshalYAML(value *yamlLib.Node) error {
+	if value == nil || value.Tag == "!!null" {
+		return nil
+	}
+	if value.Kind == yamlLib.SequenceNode {
+		var list []string
+		if err := value.Decode(&list); err != nil {
+			return err
+		}
+		n.Value = list
+		return nil
+	}
+	// Alias type to avoid recursing back into this method.
+	type rawDocNoise DocNoise
+	var raw rawDocNoise
+	if err := value.Decode(&raw); err != nil {
+		return err
+	}
+	*n = DocNoise(raw)
+	return nil
+}
+
+// UnmarshalJSON mirrors UnmarshalYAML: it accepts the new object shape and the
+// legacy JSON array (-> Value).
+func (n *DocNoise) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || string(trimmed) == "null" {
+		return nil
+	}
+	if trimmed[0] == '[' {
+		var list []string
+		if err := json.Unmarshal(trimmed, &list); err != nil {
+			return err
+		}
+		n.Value = list
+		return nil
+	}
+	type rawDocNoise DocNoise
+	var raw rawDocNoise
+	if err := json.Unmarshal(trimmed, &raw); err != nil {
+		return err
+	}
+	*n = DocNoise(raw)
+	return nil
 }
 
 // ctxReader wraps an io.Reader with a context for cancellation support


### PR DESCRIPTION
## Describe the changes that are made

Two related schema-noise changes, scoped entirely to OSS:

**1. Strict mode now value-matches every candidate (`schemanoise`)**
Under `SchemaNoiseStrict`, `StrictReject` previously short-circuited to *allowed* for any mock with **no** learned `req_body_noise` — so a value change on an unmarked request-body field was silently served the recorded response. The empty-noise early-return is now gated on `!e.strict`: in strict mode **every** candidate is value-compared against its recorded request body, and a drift on a field not covered by configured/learned noise rejects it (HTTP path → phase `MatchPhaseStrict`).
- The diff still excludes user/global body noise and obfuscated values via `KnownNoise`.
- The non-strict (default) path is **unchanged** — it still tightens only mocks that already carry learned noise.

**2. Unified on-disk noise block (`mockdb`/`yaml`)**
The mock file split obfuscator value-regexes (top-level `noise:` list) from request-body schema noise (`req_body_noise:` map). Both now live under one `noise:` mapping:
```yaml
noise:
  req:                 # request-body schema field paths
    - body.tier_type
  value:               # obfuscator value-regexes (was top-level noise: [..])
    - "^tok-.*$"
```
- `noise.req` is a plain **path list** — the per-path regex values were dropped because the strict path only ever honoured whole-field "ignore", so they were dead weight for request-body noise.
- The change is confined to the **serialization boundary**: in-memory models (`Mock.Noise []string`, `MockSpec.ReqBodyNoise map`) are unchanged, so the matcher/engine keep their vocabulary. A new `DocNoise` type with custom YAML/JSON unmarshalers converts at encode/decode.
- **Backward compatible** (read both, write new only): legacy `noise:` lists and `req_body_noise:` maps still decode (list → `value`, map keys → `req`); new writes emit only the unified block. The `gob` format is unaffected (it gob-encodes `models.Mock` directly).

## Links & References

**Closes:** NA (no tracking issue)

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [x] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed (covered by unit tests; happy to add an e2e sample if maintainers prefer)

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

```
go test ./pkg/platform/yaml/... \
        ./pkg/agent/proxy/integrations/schemanoise/... \
        ./pkg/agent/proxy/integrations/http/...
```
New/updated tests: `TestEngineStrictAllows`, `TestEngineStrictReject` (no-learned-noise strict cases); `DocNoise` unmarshal/encode unit suite (`docnoise_test.go`); `TestLegacyNoiseFormats_StillDecode`; updated non-HTTP/persist round-trip tests to the unified format.

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA

## Additional checklist:
- [x] Have you read the Contributing Guidelines on issues?
- [x] Have you followed the PR Semantics guide for naming this PR?
- [x] Have you followed the Branch Semantics guide for naming your branch?
