### PR TITLE
fix(app-lifecycle): fully terminate stopped processes before returning (port-release race)

### DIFF
--- a/.github/workflows/test_workflow_scripts/java/spring_petclinic/java-linux.sh
+++ b/.github/workflows/test_workflow_scripts/java/spring_petclinic/java-linux.sh
@@ -32,9 +32,15 @@ wait_for_postgres() {
   # exists. To avoid the race we wait for the entrypoint to finish by looking
   # for its completion log line, then verify the database is queryable.
   for i in {1..120}; do
-    # The official entrypoint prints this line once all init is done.
-    if docker logs mypostgres 2>&1 | grep -q "database system is ready to accept connections"; then
-      # Entrypoint finished — now verify the target DB is reachable.
+    # The official postgres image runs a TEMP server (which logs the FIRST
+    # "ready to accept connections") to create POSTGRES_DB and run init scripts,
+    # then restarts into the REAL server (the SECOND "ready"). Matching only the
+    # first "ready" races the restart: the temp server already has petclinic so
+    # SELECT 1 passes, the check returns "ready", and the next client immediately
+    # hits "FATAL: the database system is starting up". Require the line at least
+    # twice = the temp server has shut down and the real server is up.
+    if [ "$(docker logs mypostgres 2>&1 | grep -c 'database system is ready to accept connections')" -ge 2 ]; then
+      # Real server up — verify the target DB is queryable right now.
       if docker exec mypostgres psql -U petclinic -d petclinic -c "SELECT 1" >/dev/null 2>&1; then
         echo "Postgres is ready and petclinic database is available."
         endsec; return 0

--- a/pkg/platform/http/utils/proc_stop_unix_test.go
+++ b/pkg/platform/http/utils/proc_stop_unix_test.go
@@ -1,0 +1,97 @@
+//go:build linux || darwin
+// +build linux darwin
+
+package utils
+
+import (
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// buildPortHolder compiles a tiny server that binds `port` and, on SIGTERM, waits
+// briefly before releasing it — simulating a graceful shutdown / contention-slowed
+// port release (mirrors a `go run`-style app whose :8080 lingers after SIGTERM).
+func buildPortHolder(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "main.go")
+	prog := `package main
+import ("net";"os";"os/signal";"syscall";"time")
+func main(){
+	ln,err:=net.Listen("tcp",":"+os.Args[1]); if err!=nil{os.Exit(3)}
+	ch:=make(chan os.Signal,1); signal.Notify(ch,syscall.SIGTERM)
+	<-ch
+	time.Sleep(1500*time.Millisecond) // graceful-ish delay before releasing the port
+	_=ln.Close(); os.Exit(0)
+}`
+	if err := os.WriteFile(src, []byte(prog), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(dir, "holder")
+	if out, err := exec.Command("go", "build", "-o", bin, src).CombinedOutput(); err != nil {
+		t.Fatalf("build holder: %v\n%s", err, out)
+	}
+	return bin
+}
+
+func ephemeralPort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ln.Close() }()
+	_, p, _ := net.SplitHostPort(ln.Addr().String())
+	return p
+}
+
+// TestStopCommandReleasesPortBeforeReturning guards the "address already in use"
+// app-lifecycle flake (go-docker-timefreeze): when keploy stops an app and then
+// starts the next, StopCommand must not return until the process group has actually
+// exited and freed its port. The buggy pgid path SIGTERMs and returns immediately,
+// so the next bind races a still-held port.
+func TestStopCommandReleasesPortBeforeReturning(t *testing.T) {
+	bin := buildPortHolder(t)
+	port := ephemeralPort(t)
+
+	cmd := exec.Command(bin, port)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true} // mirror NewAgentCommand
+	if err := StartCommand(cmd); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	// Reap on exit in the background, mirroring keploy's app-watch goroutine
+	// (so an exited process doesn't linger as a zombie).
+	go func() { _ = cmd.Wait() }()
+
+	// Wait until the holder has bound the port.
+	deadline := time.Now().Add(8 * time.Second)
+	for {
+		c, err := net.DialTimeout("tcp", "127.0.0.1:"+port, 100*time.Millisecond)
+		if err == nil {
+			_ = c.Close()
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("holder never bound the port")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if err := StopCommand(cmd, zap.NewNop()); err != nil {
+		t.Fatalf("StopCommand: %v", err)
+	}
+
+	// Contract: once StopCommand returns, the app is stopped and the port is free.
+	ln, err := net.Listen("tcp", ":"+port)
+	if err != nil {
+		t.Fatalf("port %s still held after StopCommand returned (app not fully stopped): %v", port, err)
+	}
+	_ = ln.Close()
+}

--- a/pkg/platform/http/utils/proc_unix.go
+++ b/pkg/platform/http/utils/proc_unix.go
@@ -4,6 +4,7 @@
 package utils
 
 import (
+	"errors"
 	"io"
 	"os"
 	"os/exec"
@@ -75,7 +76,59 @@ func StartCommand(cmd *exec.Cmd) error {
 	return cmd.Start()
 }
 
-// StopCommand tries graceful SIGTERM to the process group, then SIGKILL fallback.
+// gracefulStopTimeout bounds how long StopCommand waits for a SIGTERM'd process
+// group to exit before escalating to SIGKILL. StopCommand returns as soon as the
+// group is actually gone, so this is only the ceiling for a process that ignores
+// SIGTERM — the common case (a process that exits on SIGTERM) returns in well
+// under a second.
+const gracefulStopTimeout = 8 * time.Second
+
+// forceKillTimeout bounds the post-SIGKILL wait for the group to disappear.
+const forceKillTimeout = 3 * time.Second
+
+// groupGone reports whether no process remains in process group pgid. kill(-pgid, 0)
+// returns ESRCH once every member has exited and been reaped (keploy's app-watch
+// goroutine reaps the leader, so a graceful exit clears the group promptly).
+func groupGone(pgid int) bool {
+	return errors.Is(syscall.Kill(-pgid, 0), syscall.ESRCH)
+}
+
+// waitGroupGone polls until process group pgid is gone or timeout elapses.
+func waitGroupGone(pgid int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		if groupGone(pgid) {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// waitPIDGone polls until process pid is gone or timeout elapses (fallback path
+// where the process is not in its own group).
+func waitPIDGone(pid int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		if errors.Is(syscall.Kill(pid, 0), syscall.ESRCH) {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// StopCommand gracefully stops the app's process group: SIGTERM, then WAIT for the
+// group to actually exit so its resources (listening ports, sockets) are released,
+// then SIGKILL if it ignored SIGTERM. The wait is load-bearing: returning before
+// the group has exited races the next app start against a still-bound port and
+// surfaces as "listen tcp :PORT: bind: address already in use" (the
+// go-docker-timefreeze flake). The previous implementation SIGTERM'd the group and
+// returned immediately, doing neither the wait nor the documented SIGKILL fallback.
 func StopCommand(cmd *exec.Cmd, logger *zap.Logger) error {
 	if cmd == nil || cmd.Process == nil {
 		return nil
@@ -86,26 +139,39 @@ func StopCommand(cmd *exec.Cmd, logger *zap.Logger) error {
 	pgid, err := syscall.Getpgid(pid)
 	if err != nil {
 		logger.Debug("failed to get pgid; falling back to direct kill", zap.Int("pid", pid), zap.Error(err))
-		// Graceful
-		err = cmd.Process.Signal(syscall.SIGTERM)
-		if err != nil {
+		// Graceful SIGTERM to the leader only.
+		if sigErr := cmd.Process.Signal(syscall.SIGTERM); sigErr != nil {
 			// Process already finished is expected during graceful shutdown, not an error
-			if err.Error() == "os: process already finished" {
+			if sigErr.Error() == "os: process already finished" {
 				logger.Debug("process already finished during graceful shutdown", zap.Int("pid", pid))
 				return nil
 			}
-			logger.Debug("failed to send SIGTERM to process; falling back to kill", zap.Int("pid", pid), zap.Error(err))
+			logger.Debug("failed to send SIGTERM to process; falling back to kill", zap.Int("pid", pid), zap.Error(sigErr))
 		}
-		time.Sleep(3 * time.Second)
-		// Force
+		// Wait (bounded) for exit so the port is released, then force-kill.
+		if waitPIDGone(pid, gracefulStopTimeout) {
+			return nil
+		}
 		return cmd.Process.Kill()
 	}
 
-	// Graceful: SIGTERM group
+	// Graceful: SIGTERM the whole group.
 	if err := syscall.Kill(-pgid, syscall.SIGTERM); err != nil {
 		logger.Debug("failed to send SIGTERM to process group", zap.Int("pgid", pgid), zap.Error(err))
 	}
 
+	// Wait (bounded) for the group to fully exit so its port/sockets are released
+	// before we return — otherwise the next app start races a still-bound port.
+	if waitGroupGone(pgid, gracefulStopTimeout) {
+		return nil
+	}
+
+	// Ignored SIGTERM: force-kill the whole group and confirm it is gone.
+	logger.Debug("process group did not exit after SIGTERM; escalating to SIGKILL", zap.Int("pgid", pgid))
+	if err := syscall.Kill(-pgid, syscall.SIGKILL); err != nil {
+		logger.Debug("failed to send SIGKILL to process group", zap.Int("pgid", pgid), zap.Error(err))
+	}
+	waitGroupGone(pgid, forceKillTimeout)
 	return nil
 }
 

--- a/utils/interrupt_process_tree_unix_test.go
+++ b/utils/interrupt_process_tree_unix_test.go
@@ -1,0 +1,96 @@
+//go:build linux || darwin
+// +build linux darwin
+
+package utils
+
+import (
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// buildSignalIgnorer compiles a tiny server that binds `port` and IGNORES the
+// graceful signals (SIGINT/SIGTERM), simulating an app that under contention does
+// not exit on the graceful signal within the wait window — it only dies on SIGKILL.
+func buildSignalIgnorer(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "main.go")
+	prog := `package main
+import ("net";"os";"os/signal";"syscall";"time")
+func main(){
+	signal.Ignore(syscall.SIGINT, syscall.SIGTERM) // survive the graceful signal
+	ln,err:=net.Listen("tcp",":"+os.Args[1]); if err!=nil{os.Exit(3)}
+	_=ln
+	time.Sleep(10*time.Minute) // until SIGKILL'd
+}`
+	if err := os.WriteFile(src, []byte(prog), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(dir, "ignorer")
+	if out, err := exec.Command("go", "build", "-o", bin, src).CombinedOutput(); err != nil {
+		t.Fatalf("build ignorer: %v\n%s", err, out)
+	}
+	return bin
+}
+
+func ephemeralPortUtil(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ln.Close() }()
+	_, p, _ := net.SplitHostPort(ln.Addr().String())
+	return p
+}
+
+// TestInterruptProcessTreeEscalatesToSIGKILL guards the "address already in use"
+// app-lifecycle flake (go-docker-timefreeze): if the app ignores the graceful
+// signal (or is too contention-slow to exit within the wait), InterruptProcessTree
+// must escalate to SIGKILL so the app is actually dead and its port freed before
+// keploy starts the next app. The previous implementation gave up after the
+// graceful wait and returned with the app still alive.
+func TestInterruptProcessTreeEscalatesToSIGKILL(t *testing.T) {
+	bin := buildSignalIgnorer(t)
+	port := ephemeralPortUtil(t)
+
+	cmd := exec.Command(bin, port)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	go func() { _ = cmd.Wait() }() // reap on exit
+
+	// Wait until the ignorer has bound the port.
+	deadline := time.Now().Add(8 * time.Second)
+	for {
+		c, err := net.DialTimeout("tcp", "127.0.0.1:"+port, 100*time.Millisecond)
+		if err == nil {
+			_ = c.Close()
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("ignorer never bound the port")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Send the graceful signal it ignores; InterruptProcessTree must escalate.
+	if err := InterruptProcessTree(zap.NewNop(), cmd.Process.Pid, syscall.SIGINT); err != nil {
+		t.Fatalf("InterruptProcessTree: %v", err)
+	}
+
+	// Contract: once it returns, the process tree is dead and the port is free.
+	ln, err := net.Listen("tcp", ":"+port)
+	if err != nil {
+		t.Fatalf("port %s still held after InterruptProcessTree returned (process survived the graceful signal, never SIGKILL'd): %v", port, err)
+	}
+	_ = ln.Close()
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -942,6 +942,20 @@ Get-ChildProcesses $parent | Select-Object ProcessId, ParentProcessId, Name | Fo
 		if err != nil {
 			logger.Error("error waiting for process to exit", zap.Int("pid", pid), zap.Error(err))
 		}
+		// If it ignored the graceful signal (or was too contention-slow to exit
+		// within the wait), escalate to SIGKILL so it cannot keep holding resources
+		// (e.g. a listening port) and race the next app start with
+		// "address already in use" (the go-docker-timefreeze flake).
+		if running, rerr := isProcessRunning(pid); rerr != nil {
+			logger.Debug("could not verify process state after graceful signal", zap.Int("pid", pid), zap.Error(rerr))
+		} else if running {
+			logger.Debug("process still alive after graceful signal; escalating to SIGKILL", zap.Int("pgid", pid))
+			if killErr := SendSignal(logger, -pid, syscall.SIGKILL); killErr != nil {
+				logger.Error("error sending SIGKILL to the process group id", zap.Int("pgid", pid), zap.Error(killErr))
+			} else {
+				_ = waitForProcessExit(pid, 3*time.Second, logger)
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Problem
The `go-docker-timefreeze` CI lane intermittently failed with `listen tcp :8080: bind: address already in use`: when keploy stops a launched process and immediately starts the next, the previous instance could still hold its listening port under contention.

## Root cause
Two process-stop paths returned **before the process had actually exited**:
- **`InterruptProcessTree`** (utils/utils.go — the app stop path): sent the graceful signal, waited 3s, then returned even if the process was still alive. No SIGKILL escalation.
- **`StopCommand`** (pkg/platform/http/utils/proc_unix.go — the agent stop path): SIGTERM'd the process group and returned immediately, doing neither the wait nor the SIGKILL fallback its own doc comment promised.

So the next app/agent start raced a still-bound port.

## Fix
- `InterruptProcessTree`: after the graceful wait, if the process is still alive, escalate to SIGKILL on the group and wait again.
- `StopCommand`: SIGTERM → bounded wait for the group to exit (poll `kill(-pgid,0)` for ESRCH) → SIGKILL escalation.

Both return as soon as the group is actually gone, so the normal fast-exit path is unaffected (<1s).

## Tests
Two new red→green regression tests assert the port is free once the stop call returns:
- `proc_stop_unix_test.go` — a port-holder with a graceful-shutdown delay.
- `interrupt_process_tree_unix_test.go` — a process that ignores SIGINT/SIGTERM (must be SIGKILL'd).

Both were RED before the fix, GREEN after; package tests + golangci-lint clean.