### PR TITLE
fix: correct mismatched doc comments

### DIFF
--- a/pkg/service/runner/runner.go
+++ b/pkg/service/runner/runner.go
@@ -89,7 +89,7 @@ func (s *testSetSetup) snapshotConsumed() map[string]models.MockState {
 	return out
 }
 
-// NewRunner creates a Runner with all dependencies.
+// New creates a Runner with all dependencies.
 func New(
 	logger *zap.Logger,
 	testCaseDB TestCaseDB,

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -545,7 +545,6 @@ func GetLatestGitHubRelease(ctx context.Context, logger *zap.Logger) (GitHubRele
 	return release, nil
 }
 
-// FindDockerCmd checks if the cli is related to docker or not, it also returns if it is a docker compose file
 // ExtractCommandFromArgs parses os.Args to find the value of -c or --command flag.
 // Returns empty string if not found.
 func ExtractCommandFromArgs(args []string) string {


### PR DESCRIPTION
## Related Issue
N/A - small documentation correctness fix.

## Description

Two Go doc comments did not match their functions:

- `runner.New` had a doc comment starting with `// NewRunner creates ...`, but the function is named `New` (Go convention is for the comment to start with the function name).
- `ExtractCommandFromArgs` had a leftover `// FindDockerCmd checks ...` line sitting above its own (correct) doc comment - apparent copy-paste cruft. Removed the stray line.

Documentation-only change; no behaviour is affected.
