### PR TITLE
Fix CLA failure message signing phrase

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -34,7 +34,7 @@ jobs:
         if: failure() && github.event_name == 'pull_request_target'
         run: |
           gh pr comment ${{ github.event.pull_request.number }} --body "**The CLA check failed.** Please ensure you have:
-          - Signed the CLA by commenting **'I have read the CLA Document and I hereby sign the CLA.'**
+          - Signed the CLA by commenting **'I have read the CLA Document and I hereby sign the CLA'**
           - Used the correct email address in your commits (matches the one you used to sign the CLA).
           
           After fixing these issues, comment **'recheck'** to trigger the workflow again."


### PR DESCRIPTION
## Describe the changes that are made
- Updated the CLA failure message in `.github/workflows/cla.yml` to use the same signing phrase that the CLA workflow trigger checks for.
- This fixes an inconsistency where the failure message included a trailing period:
  `I have read the CLA Document and I hereby sign the CLA.`
- However, the workflow trigger expects the exact phrase without the trailing period:
  `I have read the CLA Document and I hereby sign the CLA`
- This improves the CLA signing experience for first-time contributors by preventing confusion when they copy the failure message.

## Links & References

**Closes:** #4323

### 🔗 Related PRs
- NA

### 🐞 Related Issues
- #4323

### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [x] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [x] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [x] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

The change can be verified by inspecting `.github/workflows/cla.yml` and confirming that the CLA failure message now uses the same signing phrase as the workflow trigger:

`I have read the CLA Document and I hereby sign the CLA`

No runtime tests were run because this is a text-only update to a GitHub Actions workflow message.

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA

## 🧠 Semantics for PR Title & Branch Name

Please ensure your PR title and branch name follow the Keploy semantics:

📌 [PR Semantics Guide](https://github.com/keploy/keploy/wiki/PR-Semantics)  
📌 [Branch Semantics Guide](https://github.com/keploy/keploy/wiki/Branch-Semantics)

**Examples:**

- **PR Title**: `fix: patch MongoDB document update bug`  
- **Branch Name**: `feat/#1-login-flow` (You may skip mentioning the issue number in the branch name if the change is small and the PR description clearly explains it.)

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?