### PR TITLE
fix(agent): free previous test-set's mock pool at replay boundary (auto-replay OOM relief)

### DIFF
--- a/pkg/agent/proxy/integrations/integrations.go
+++ b/pkg/agent/proxy/integrations/integrations.go
@@ -4,6 +4,7 @@ package integrations
 import (
 	"context"
 	"net"
+	"sync"
 	"time"
 
 	"go.keploy.io/server/v3/pkg/models"
@@ -66,6 +67,61 @@ type IntegrationsV2 interface {
 
 func Register(name IntegrationType, p *Parsers) {
 	Registered[name] = p
+}
+
+// boundaryResetHooks are callbacks run at every replay TEST-SET BOUNDARY
+// (MockManager.ResetForReplaySession, invoked from Proxy.Mock() before the
+// controller ships and the agent rebuilds the next set's pool). One replay
+// pod serves every test-set sequentially, so any per-session cache a parser
+// builds while serving set N would otherwise survive into set N+1 and stack
+// on top of the incoming pool — the transition double-residency that drives
+// the auto-replay agent OOM.
+//
+// The canonical registrant is mongo/v2's encoded-section LRU
+// (integrations/pkg/mongo/v2.ResetEncodeSectionCache): a rebuildable,
+// bounded-but-non-trivial cache of parsed ext-JSON sections that is only
+// valid for the mocks of the set currently being served. Dropping it at the
+// boundary returns that memory before the next set's bulk decode begins.
+//
+// Contract for hooks: cheap, idempotent, and safe to call concurrently with
+// active matchers. The reset fires at the boundary, but a long-lived parser
+// goroutine (e.g. the postgres-v3 runLoop kept warm across the boundary by
+// --keep-app-alive) can still be draining the previous set — a hook must
+// only drop REBUILDABLE state, never state whose loss would corrupt an
+// in-flight match. keploy cannot import the private integrations module
+// (dependency direction is integrations→keploy), so parsers self-register
+// here from their package init() instead of keploy calling them directly.
+var (
+	boundaryResetMu    sync.RWMutex
+	boundaryResetHooks []func()
+)
+
+// RegisterBoundaryResetHook adds fn to the set run by RunBoundaryResetHooks.
+// Intended to be called once from a parser's init(); there is deliberately
+// no unregister — parser registration is process-global and permanent, and
+// the hooks are re-run on every test-set boundary for the process lifetime.
+// A nil fn is ignored. Safe for concurrent use.
+func RegisterBoundaryResetHook(fn func()) {
+	if fn == nil {
+		return
+	}
+	boundaryResetMu.Lock()
+	boundaryResetHooks = append(boundaryResetHooks, fn)
+	boundaryResetMu.Unlock()
+}
+
+// RunBoundaryResetHooks invokes every registered boundary-reset hook. Called
+// by MockManager.ResetForReplaySession at each replay test-set boundary.
+// Snapshots the slice under a read lock so a hook that (indirectly) registers
+// another hook cannot deadlock or observe a torn slice.
+func RunBoundaryResetHooks() {
+	boundaryResetMu.RLock()
+	hooks := make([]func(), len(boundaryResetHooks))
+	copy(hooks, boundaryResetHooks)
+	boundaryResetMu.RUnlock()
+	for _, fn := range hooks {
+		fn()
+	}
 }
 
 // MockMemDb is the runtime mock pool contract consumed by every parser's

--- a/pkg/agent/proxy/mockmanager.go
+++ b/pkg/agent/proxy/mockmanager.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"fmt"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/miekg/dns"
 	"go.keploy.io/server/v3/pkg"
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations"
 	"go.keploy.io/server/v3/pkg/models"
 	"go.uber.org/zap"
 )
@@ -300,6 +302,24 @@ func (m *MockManager) IsClosed() bool {
 // previous test-set's connection pools into the next one.
 //
 // What it clears:
+//   - filtered / unfiltered / startup trees (+ their per-kind and
+//     stateless companions) and hitIdx: the previous test-set's mock
+//     pool. Freed HERE — at the boundary, before the controller ships
+//     and this manager decodes the NEXT set — rather than waiting for
+//     the next SetMocksWithWindow swap. That wait is the transition
+//     double-residency that drives the auto-replay agent OOM: with the
+//     old set's trees still resident while the next set's whole pool is
+//     gob-decoded and rebuilt, peak RSS is ~2× a single set's
+//     footprint. Swapping to fresh empties here (under the same
+//     swapMu→treesMu order SetMocksWithWindow uses) lets the old pool
+//     be reclaimed by the FreeOSMemory below before the next decode
+//     begins. Revisions are bumped so revision-gated parsers
+//     (keploy/integrations#203) drop their derived per-set indexes too
+//     instead of pinning the old cohort. Serving an empty pool in the
+//     brief reset→StoreMocks→SetMocksWithWindow gap is CORRECT: no test
+//     is active then, and the prior behaviour of serving the previous
+//     set's stale mocks in that gap was cross-test bleed, not a
+//     feature.
 //   - connectionTrees / connectionLastTs: per-connID dedicated trees
 //     populated by AddConnectionMock from the previous test-set's
 //     LifetimeConnection mocks. SetMocksWithWindow only seeds new
@@ -309,6 +329,9 @@ func (m *MockManager) IsClosed() bool {
 //     N+1's, and GetConnectionMocks (which returns the cached tree
 //     without consulting the freshly swapped unfiltered tree) would
 //     keep matching stale entries.
+//   - rebuildable parser caches (mongo/v2's encoded-section LRU, etc.)
+//     via integrations.RunBoundaryResetHooks — same rationale: valid
+//     only for the set just served, so drop them before the next set.
 //   - noConnMocks: the negative cache paired with connectionTrees;
 //     stale entries from the previous test-set would suppress fallback
 //     scans for connIDs that now legitimately have connection-scoped
@@ -325,21 +348,49 @@ func (m *MockManager) IsClosed() bool {
 //     test-sets' pre-firstTest mocks accidentally be classified as
 //     startup-init when they're really stale bleed from the previous
 //     test-set's tail.
-//   - filtered / unfiltered / startup trees: SetMocksWithWindow swaps
-//     these atomically on the next call from the orchestrator, so
-//     clearing them here would just briefly serve an empty pool to
-//     any parser racing the reset.
 //   - sweeperStop / closed: the idle sweeper goroutine keeps running
 //     across the reset; closing it would stop the per-connection
 //     idle reaping for the rest of the replay.
-//   - hitIdx: rebuilt by SetFilteredMocks/SetUnFilteredMocks on the
-//     next mock load, so an explicit clear here is redundant.
+//   - firstWindowStart: see the note above.
 //
-// Safe to call concurrently with active matchers — connMu guards
-// the maps and noConnMocks is a sync.Map. Matchers holding stale
-// references to the cleared trees still observe valid (empty) trees
-// rather than panicking.
+// Safe to call concurrently with active matchers — every field is
+// swapped under the lock that guards it (swapMu→treesMu for the pool
+// trees, hitMu for hitIdx, connMu for the connection maps), and
+// noConnMocks is a sync.Map. A matcher holding a stale reference to a
+// swapped-out tree still observes a valid (now-detached, non-empty)
+// tree rather than panicking; the GC reclaims it once that matcher
+// releases it. New lookups see the fresh empty trees.
 func (m *MockManager) ResetForReplaySession() {
+	// Free the previous test-set's mock pool NOW, before the controller
+	// decodes + ships the next set into this same manager. Swap to fresh
+	// empties under the documented swapMu→treesMu order so a concurrent
+	// GetFilteredMocksInWindow (swapMu.RLock) or GetFilteredMocks
+	// (treesMu.RLock) cannot observe a torn state.
+	m.swapMu.Lock()
+	m.treesMu.Lock()
+	m.filtered = NewTreeDb(customComparator)
+	m.unfiltered = NewTreeDb(customComparator)
+	m.startup = NewTreeDb(customComparator)
+	m.filteredByKind = make(map[models.Kind]*TreeDb)
+	m.unfilteredByKind = make(map[models.Kind]*TreeDb)
+	m.statelessFiltered = make(map[models.Kind]map[string][]*models.Mock)
+	m.statelessUnfiltered = make(map[models.Kind]map[string][]*models.Mock)
+	m.treesMu.Unlock()
+	m.swapMu.Unlock()
+
+	// hitIdx is guarded by its own leaf lock (hitMu), not treesMu.
+	m.hitMu.Lock()
+	m.hitIdx = make(map[string]*models.Mock)
+	m.hitMu.Unlock()
+
+	// Keep the (trees, revision) invariant the setters maintain: the pool
+	// changed, so every revision must advance. Revision-gated parsers
+	// (keploy/integrations#203) then rebuild their derived per-set indexes
+	// off the empty pool instead of pinning the old set's cohort alive
+	// through the next set's decode.
+	m.bumpRevisionAll()
+	m.bumpAllKindRevisions()
+
 	m.connMu.Lock()
 	m.connectionTrees = make(map[string]*TreeDb)
 	m.connectionLastTs = make(map[string]time.Time)
@@ -354,6 +405,35 @@ func (m *MockManager) ResetForReplaySession() {
 		return true
 	})
 	atomic.StoreUint64(&m.droppedOutOfWindow, 0)
+
+	// Drop rebuildable per-session parser caches (mongo/v2 encoded-section
+	// LRU, etc.). keploy cannot import the private integrations module, so
+	// parsers self-register these via integrations.RegisterBoundaryResetHook.
+	integrations.RunBoundaryResetHooks()
+
+	// Return the just-freed heap to the OS so the next set's bulk decode
+	// starts from a low RSS baseline instead of stacking on the previous
+	// set's high-water mark. This is the one point in the replay loop where
+	// a synchronous STW GC is worth its cost: it runs once per test-set
+	// boundary, while no test is active.
+	debug.FreeOSMemory()
+}
+
+// bumpAllKindRevisions advances every per-kind revision counter that has
+// ever been created on this manager. Used by ResetForReplaySession so a
+// parser gated on RevisionByKind (not just the global Revision) also sees
+// the boundary pool-swap and rebuilds. Snapshots the keys under revMu
+// before bumping because bumpRevisionKind takes revMu itself.
+func (m *MockManager) bumpAllKindRevisions() {
+	m.revMu.RLock()
+	kinds := make([]models.Kind, 0, len(m.revByKind))
+	for k := range m.revByKind {
+		kinds = append(kinds, k)
+	}
+	m.revMu.RUnlock()
+	for _, k := range kinds {
+		m.bumpRevisionKind(k)
+	}
 }
 
 // runIdleSweeper is the background loop that calls SweepIdleConnections

--- a/pkg/agent/proxy/mockmanager_reset_boundary_test.go
+++ b/pkg/agent/proxy/mockmanager_reset_boundary_test.go
@@ -1,0 +1,121 @@
+// Package proxy — PR A / Phase 0 test-set-boundary free tests.
+//
+// ResetForReplaySession runs at every replay test-set boundary
+// (Proxy.Mock → ResetForReplaySession) BEFORE the controller ships and
+// this manager decodes the next set. Phase 0 extends it to free the
+// previous set's mock pool (filtered / unfiltered / startup trees, their
+// per-kind + stateless companions, and hitIdx) and to run the registered
+// boundary-reset hooks, so the old set is not resident while the next
+// set's whole pool is decoded — the transition double-residency that
+// drives the auto-replay agent OOM.
+//
+// These tests assert the OBSERVABLE contract (pool emptied, revisions
+// advanced, manager still usable afterwards, hooks fired). The actual
+// RSS drop is measured in the load repro harness, not here — a byte-level
+// memory assertion in a unit test is inherently flaky (GC timing).
+package proxy
+
+import (
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// TestResetForReplaySession_FreesMockTrees verifies that a boundary reset
+// empties every mock tier, advances the revisions, and leaves the manager
+// able to load the next set (i.e. the reset frees rather than wedges).
+func TestResetForReplaySession_FreesMockTrees(t *testing.T) {
+	mm := NewMockManager(nil, nil, zap.NewNop())
+	defer mm.Close()
+
+	start := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	end := start.Add(10 * time.Second)
+
+	// Load a set spanning all three request-time tiers.
+	mStartup := newMockForTest("startup", start.Add(-1*time.Second), models.LifetimeSession)
+	mPerTest := newMockForTest("perTest", start.Add(5*time.Second), models.LifetimePerTest)
+	mSession := newMockForTest("session", start.Add(1*time.Second), models.LifetimeSession)
+	mm.SetMocksWithWindow(
+		[]*models.Mock{mStartup, mPerTest},
+		[]*models.Mock{mSession},
+		start, end,
+	)
+
+	// Sanity: all tiers populated before the reset.
+	if got, _ := mm.GetFilteredMocks(); len(got) == 0 {
+		t.Fatalf("precondition: per-test tree empty before reset")
+	}
+	if got, _ := mm.GetUnFilteredMocks(); len(got) == 0 {
+		t.Fatalf("precondition: session tree empty before reset")
+	}
+	if got, _ := mm.GetStartupMocks(); len(got) == 0 {
+		t.Fatalf("precondition: startup tree empty before reset")
+	}
+	// Stateless lookup map populated for the HTTP kind too.
+	if f, _ := mm.GetStatelessMocks(models.HTTP, "perTest"); len(f) == 0 {
+		t.Fatalf("precondition: stateless per-test map empty before reset")
+	}
+
+	revBefore := mm.Revision()
+	kindRevBefore := mm.RevisionByKind(models.HTTP)
+
+	mm.ResetForReplaySession()
+
+	// Every tier must now be empty.
+	if got, _ := mm.GetFilteredMocks(); len(got) != 0 {
+		t.Fatalf("per-test tree: want empty after reset, got %d", len(got))
+	}
+	if got, _ := mm.GetUnFilteredMocks(); len(got) != 0 {
+		t.Fatalf("session tree: want empty after reset, got %d", len(got))
+	}
+	if got, _ := mm.GetStartupMocks(); len(got) != 0 {
+		t.Fatalf("startup tree: want empty after reset, got %d", len(got))
+	}
+	if f, u := mm.GetStatelessMocks(models.HTTP, "perTest"); len(f) != 0 || len(u) != 0 {
+		t.Fatalf("stateless maps: want empty after reset, got f=%d u=%d", len(f), len(u))
+	}
+
+	// Revisions must have advanced so revision-gated parsers rebuild off
+	// the empty pool instead of pinning the old cohort.
+	if mm.Revision() == revBefore {
+		t.Fatalf("global revision: want advanced after reset, still %d", revBefore)
+	}
+	if mm.RevisionByKind(models.HTTP) == kindRevBefore {
+		t.Fatalf("HTTP kind revision: want advanced after reset, still %d", kindRevBefore)
+	}
+
+	// The manager must still accept the NEXT set — the reset frees, it
+	// does not wedge.
+	mNext := newMockForTest("next", start.Add(5*time.Second), models.LifetimePerTest)
+	mm.SetMocksWithWindow([]*models.Mock{mNext}, nil, start, end)
+	got, _ := mm.GetFilteredMocks()
+	if !containsMockNamed(got, "next") {
+		t.Fatalf("next set not loaded after reset; got %d mocks", len(got))
+	}
+	if containsMockNamed(got, "perTest") {
+		t.Fatalf("previous set's per-test mock leaked into next set after reset")
+	}
+}
+
+// TestResetForReplaySession_RunsBoundaryHooks verifies the boundary-reset
+// hook registry is invoked by ResetForReplaySession — the seam mongo/v2
+// uses to drop its encoded-section LRU at the set boundary.
+func TestResetForReplaySession_RunsBoundaryHooks(t *testing.T) {
+	var calls int
+	// No unregister exists by design (registration is process-global);
+	// the closure counter is local so leaking the hook past this test is
+	// harmless.
+	integrations.RegisterBoundaryResetHook(func() { calls++ })
+
+	mm := NewMockManager(nil, nil, zap.NewNop())
+	defer mm.Close()
+
+	before := calls
+	mm.ResetForReplaySession()
+	if calls != before+1 {
+		t.Fatalf("boundary reset hook: want invoked exactly once, delta=%d", calls-before)
+	}
+}


### PR DESCRIPTION
## Problem

The auto-replay agent OOM-kills mid-session. One replay pod serves **every test-set sequentially**, and today the previous set's mock pool (`filtered` / `unfiltered` / `startup` trees + their per-kind + stateless companions + `hitIdx`) stays resident until the **next** `SetMocksWithWindow` swaps it out. So during the window where the controller ships and the agent gob-decodes the next set's *whole* pool, **two sets are resident at once** — peak RSS ≈ 2× a single set's footprint.

That transition double-residency is a primary driver of the observed OOM: a test-set passes (e.g. 6/8), the pod `OOMKilled`s at the set boundary, and the restart breaks eBPF interception so the remaining sets all fail (wedge).

## Fix

`MockManager.ResetForReplaySession` already runs **at every test-set boundary** (`Proxy.Mock` → `ResetForReplaySession`, *before* the next set is decoded). This PR extends it to free the previous set right there instead of waiting for the next `SetMocksWithWindow`:

1. **Swap the mock trees to fresh empties** under the documented `swapMu → treesMu` lock order (same mechanism the setters use), clear `hitIdx` under `hitMu`.
2. **Bump the global + per-kind revisions** so revision-gated parsers (keploy/integrations#203) rebuild off the empty pool instead of pinning the old cohort alive through the next set's decode — keeps the `(trees, revision)` invariant the setters maintain.
3. **Run a new `integrations.RunBoundaryResetHooks` registry** so parsers can drop *rebuildable* per-session caches at the boundary. keploy can't import the private `integrations` module (dependency direction is integrations→keploy), so parsers self-register from their `init()`. First registrant will be mongo/v2's encoded-section LRU (separate integrations PR).
4. **`debug.FreeOSMemory()` once**, at the boundary, while no test is active — so the next set's bulk decode starts from a low RSS baseline instead of stacking on the previous set's high-water mark.

Serving an empty pool in the brief `reset → StoreMocks → SetMocksWithWindow` gap is **correct**: no test is active then, and the prior behaviour of serving the previous set's mocks in that gap was cross-test bleed, not a feature.

## Safety

- **Additive, non-breaking.** Every field is swapped under the lock that guards it; a matcher holding a stale tree reference still sees a valid (detached) tree, never a panic.
- `go test -race ./pkg/agent/proxy/` is clean.
- New test `mockmanager_reset_boundary_test.go`: asserts every tier empties, revisions advance, the manager still loads the next set (frees, doesn't wedge), no cross-set leak, and the boundary hook fires.

## Honest scope / confidence

This targets the **transition** double-residency, which matches the observed failure (set passes → OOM at boundary → wedge). It is a well-targeted, safe, *likely-effective* fix worth shipping and measuring on its own.

It is **not guaranteed** to fully eliminate the OOM: if a *single* set's cold-start burst alone exceeds the limit (bulk decode + all indexes + eBPF + app-boot storm), freeing the previous set won't be enough. The definitive, load-independent bound (index-in-RAM / payloads-on-disk, streamed `/storemocks`) is the follow-up redesign PR. Ship this, measure a few live cycles; if the OOM persists, the redesign closes it.

## Related

- Follow-on integrations PR registers mongo/v2's `ResetEncodeSectionCache` into the new boundary-reset hook + a memoryguard pressure hook.
- Prior art: integrations#235 (encode-cache LRU bound), agent v3.5.70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)