### PR TITLE
refactor: drop legacy top-level req_body_noise read-through

### DIFF
--- a/.github/workflows/schema_noise_detection_linux.yml
+++ b/.github/workflows/schema_noise_detection_linux.yml
@@ -5,7 +5,7 @@ name: Schema Noise Detection On Linux
 # created_at, so the outgoing Elasticsearch request body drifts every run):
 #
 #   --schema-noise-detection -> detect the drifting field (body.created_at) and
-#                               persist it as req_body_noise on the ES mock.
+#                               persist it under noise.req on the ES mock.
 #   test.schemaNoiseStrict    -> a drift on a NON-noise field is rejected.
 
 on:

--- a/pkg/platform/yaml/codec.go
+++ b/pkg/platform/yaml/codec.go
@@ -59,11 +59,6 @@ type NetworkTrafficDocJSON struct {
 	LastUpdated  *models.LastUpdated `json:"last_updated,omitempty"`
 	Curl         string              `json:"curl,omitempty"`
 	ConnectionID string              `json:"connectionId,omitempty"`
-	// ReqBodyNoise mirrors NetworkTrafficDoc.ReqBodyNoise: the LEGACY top-level
-	// req_body_noise key, no longer written but still read so older on-disk mocks
-	// keep matching. New mocks carry request-body noise under noise.req (DocNoise);
-	// on decode this legacy map's keys are folded in via ResolveReqBodyNoise.
-	ReqBodyNoise map[string][]string `json:"req_body_noise,omitempty"`
 }
 
 // DocToJSON converts a NetworkTrafficDoc to its JSON-friendly representation
@@ -88,7 +83,6 @@ func DocToJSON(doc *NetworkTrafficDoc) (*NetworkTrafficDocJSON, error) {
 		LastUpdated:  doc.LastUpdated,
 		Curl:         doc.Curl,
 		ConnectionID: doc.ConnectionID,
-		ReqBodyNoise: doc.ReqBodyNoise, // legacy read-through (see DocNoise)
 	}, nil
 }
 
@@ -153,7 +147,6 @@ func jsonDocToYamlDoc(jsonDoc *NetworkTrafficDocJSON) (*NetworkTrafficDoc, error
 		LastUpdated:  jsonDoc.LastUpdated,
 		Curl:         jsonDoc.Curl,
 		ConnectionID: jsonDoc.ConnectionID,
-		ReqBodyNoise: jsonDoc.ReqBodyNoise, // legacy read-through (see DocNoise)
 	}
 
 	// Convert json.RawMessage to a generic interface, then encode into yaml.Node

--- a/pkg/platform/yaml/docnoise_test.go
+++ b/pkg/platform/yaml/docnoise_test.go
@@ -86,23 +86,21 @@ func TestNewDocNoise_DropsRegexValuesAndSorts(t *testing.T) {
 	}
 }
 
-// TestResolveReqBodyNoise_PrefersNewFallsBackToLegacy checks decode resolution:
-// noise.req wins, else the legacy req_body_noise map's keys are used (regex
-// values dropped).
-func TestResolveReqBodyNoise_PrefersNewFallsBackToLegacy(t *testing.T) {
-	// New noise.req present -> used directly.
-	got := ResolveReqBodyNoise(&DocNoise{Req: []string{"body.a"}}, map[string][]string{"body.legacy": {}})
-	if _, ok := got["body.a"]; !ok || len(got) != 1 {
-		t.Fatalf("must prefer noise.req, got %v", got)
+// TestResolveReqBodyNoise checks decode resolution: request-body schema noise is
+// taken from the unified noise.req list, mapping each path to an empty regex list
+// (path-only representation). An absent noise block resolves to nil.
+func TestResolveReqBodyNoise(t *testing.T) {
+	// noise.req present -> its paths become the noise map.
+	got := ResolveReqBodyNoise(&DocNoise{Req: []string{"body.a"}})
+	if v, ok := got["body.a"]; !ok || len(got) != 1 || len(v) != 0 {
+		t.Fatalf("must resolve noise.req to a path-only map, got %v", got)
 	}
 
-	// No noise.req -> fall back to legacy keys, dropping regex values.
-	got = ResolveReqBodyNoise(nil, map[string][]string{"body.legacy": {"^x.*$"}})
-	if v, ok := got["body.legacy"]; !ok || len(v) != 0 {
-		t.Fatalf("legacy fallback must keep key and drop regex, got %v", got)
+	// No noise.req -> nil, so omitempty drops the key.
+	if ResolveReqBodyNoise(nil) != nil {
+		t.Fatal("absent noise block must resolve to nil")
 	}
-
-	if ResolveReqBodyNoise(nil, nil) != nil {
-		t.Fatal("no noise anywhere must resolve to nil")
+	if ResolveReqBodyNoise(&DocNoise{}) != nil {
+		t.Fatal("empty noise.req must resolve to nil")
 	}
 }

--- a/pkg/platform/yaml/mockdb/noise_nonhttp_test.go
+++ b/pkg/platform/yaml/mockdb/noise_nonhttp_test.go
@@ -32,7 +32,7 @@ func genericNoiseMock(name string) *models.Mock {
 // TestNonHTTPNoise_YAMLRoundTrip is the core of the persistence blocker: a
 // non-HTTP mock's learned MockSpec.ReqBodyNoise must survive the YAML encode →
 // disk → decode cycle. The per-kind GenericSchema envelope has no field for it,
-// so it rides on the shared NetworkTrafficDoc.ReqBodyNoise and is restored to
+// so it rides on the shared unified noise.req block and is restored to
 // MockSpec on read.
 func TestNonHTTPNoise_YAMLRoundTrip(t *testing.T) {
 	mock := genericNoiseMock("mock-0")
@@ -191,10 +191,7 @@ func reqNoiseHas(n *yaml.DocNoise, path string) bool {
 
 // TestLegacyNoiseFormats_StillDecode is the backward-compatibility guard: a mock
 // written in the OLD on-disk shape — a top-level `noise:` string list (obfuscator
-// value-regexes) plus a separate `req_body_noise:` map (with per-path regex values)
-// — must still decode. The legacy noise list folds into value-noise (Mock.Noise),
-// the req_body_noise keys fold into MockSpec.ReqBodyNoise, and the now-unused regex
-// values are dropped.
+// value-regexes) — must still decode, folding into value-noise (Mock.Noise).
 func TestLegacyNoiseFormats_StillDecode(t *testing.T) {
 	raw := []byte(`version: api.keploy.io/v1beta1
 kind: Http
@@ -213,9 +210,6 @@ spec:
     body: '{"ok":true}'
 noise:
   - "^tok-.*$"
-req_body_noise:
-  body.a: ["^x.*$"]
-  body.b: []
 `)
 
 	doc, err := yaml.UnmarshalDoc(yaml.FormatYAML, raw)
@@ -238,16 +232,5 @@ req_body_noise:
 
 	if len(m.Noise) != 1 || m.Noise[0] != "^tok-.*$" {
 		t.Fatalf("Mock.Noise must come from the legacy noise list, got %v", m.Noise)
-	}
-	rb := m.Spec.ReqBodyNoise
-	if _, ok := rb["body.a"]; !ok {
-		t.Fatalf("legacy req_body_noise key body.a lost on decode: %v", rb)
-	}
-	if _, ok := rb["body.b"]; !ok {
-		t.Fatalf("legacy req_body_noise key body.b lost on decode: %v", rb)
-	}
-	// The legacy per-path regex value must be dropped (req noise is path-only now).
-	if len(rb["body.a"]) != 0 {
-		t.Fatalf("legacy regex value on body.a must be dropped, got %v", rb["body.a"])
 	}
 }

--- a/pkg/platform/yaml/mockdb/util.go
+++ b/pkg/platform/yaml/mockdb/util.go
@@ -40,8 +40,7 @@ func EncodeMockJSON(mock *models.Mock, logger *zap.Logger) (*yaml.NetworkTraffic
 		// values are dropped). Request-body noise is only non-empty for a kind whose
 		// parser implements the schema-noise adapter and learned drift (HTTP, plus
 		// Pulsar in enterprise). NewDocNoise returns nil when there is nothing to
-		// write, so omitempty keeps the noise key out of the doc entirely. The legacy
-		// top-level req_body_noise key is no longer written (still read on decode).
+		// write, so omitempty keeps the noise key out of the doc entirely.
 		Noise: yaml.NewDocNoise(mock.Noise, mock.Spec.ReqBodyNoise),
 	}
 
@@ -245,8 +244,7 @@ func EncodeMock(mock *models.Mock, logger *zap.Logger) (*yaml.NetworkTrafficDoc,
 		// plus request-body schema-noise field PATHS (mock.Spec.ReqBodyNoise keys;
 		// regex values dropped). Set before the mapper/per-kind projection runs so it
 		// survives regardless of the spec envelope. NewDocNoise returns nil when
-		// empty, so omitempty drops the key. The legacy req_body_noise key is no
-		// longer written (still read on decode).
+		// empty, so omitempty drops the key.
 		Noise: yaml.NewDocNoise(mock.Noise, mock.Spec.ReqBodyNoise),
 	}
 	mapped, err := encodeWithMapper(mock, &yamlDoc)
@@ -635,8 +633,8 @@ func DecodeMocks(yamlMocks []*yaml.NetworkTrafficDoc, logger *zap.Logger) ([]*mo
 		if mapped {
 			// Restore kind-agnostic schema-noise carried on the doc envelope
 			// (the per-kind mapper rebuilt mock.Spec and can't know about it).
-			// Prefer the unified noise.req; fall back to the legacy req_body_noise key.
-			if rb := yaml.ResolveReqBodyNoise(m.Noise, m.ReqBodyNoise); len(rb) > 0 {
+			// Sourced from the unified noise.req block.
+			if rb := yaml.ResolveReqBodyNoise(m.Noise); len(rb) > 0 {
 				mock.Spec.ReqBodyNoise = rb
 			}
 			mocks = append(mocks, &mock)
@@ -808,9 +806,9 @@ func DecodeMocks(yamlMocks []*yaml.NetworkTrafficDoc, logger *zap.Logger) ([]*mo
 		}
 		// Restore kind-agnostic schema-noise carried on the doc envelope onto the
 		// freshly-built spec (the per-kind switch above replaced mock.Spec
-		// wholesale). Uniform across parsers — HTTP included. Prefer the unified
-		// noise.req; fall back to the legacy req_body_noise key.
-		if rb := yaml.ResolveReqBodyNoise(m.Noise, m.ReqBodyNoise); len(rb) > 0 {
+		// wholesale). Uniform across parsers — HTTP included. Sourced from the
+		// unified noise.req block.
+		if rb := yaml.ResolveReqBodyNoise(m.Noise); len(rb) > 0 {
 			mock.Spec.ReqBodyNoise = rb
 		}
 		mocks = append(mocks, &mock)
@@ -1513,9 +1511,8 @@ func DecodeMocksJSON(docs []*yaml.NetworkTrafficDocJSON, logger *zap.Logger) ([]
 		}
 		// Restore kind-agnostic schema-noise carried on the doc envelope (the
 		// per-kind switch above replaced mock.Spec wholesale). Uniform across
-		// parsers — HTTP included. Prefer the unified noise.req; fall back to the
-		// legacy req_body_noise key.
-		if rb := yaml.ResolveReqBodyNoise(m.Noise, m.ReqBodyNoise); len(rb) > 0 {
+		// parsers — HTTP included. Sourced from the unified noise.req block.
+		if rb := yaml.ResolveReqBodyNoise(m.Noise); len(rb) > 0 {
 			mock.Spec.ReqBodyNoise = rb
 		}
 		mocks = append(mocks, &mock)

--- a/pkg/platform/yaml/yaml.go
+++ b/pkg/platform/yaml/yaml.go
@@ -46,31 +46,20 @@ type NetworkTrafficDoc struct {
 	LastUpdated  *models.LastUpdated `json:"last_updated,omitempty" yaml:"last_updated,omitempty"`
 	Curl         string              `json:"curl" yaml:"curl,omitempty"`
 	ConnectionID string              `json:"connectionId" yaml:"connectionId,omitempty"`
-	// ReqBodyNoise is the LEGACY top-level schema-noise key (req_body_noise). It is
-	// no longer written — new mocks carry request-body noise under noise.req (see
-	// DocNoise) — but it is still read so older on-disk mocks keep matching. On
-	// decode its keys are folded into the unified noise via ResolveReqBodyNoise
-	// (regex values dropped, since the strict path only ever honoured whole-field
-	// "ignore"). Kept for backward compatibility only.
-	ReqBodyNoise map[string][]string `json:"req_body_noise,omitempty" yaml:"req_body_noise,omitempty"`
 }
 
 // DocNoise is the unified on-disk representation of a mock's noise, written under
-// the single `noise:` key. It supersedes the older layout that split a top-level
-// `noise:` string list (value-regexes) from a separate `req_body_noise:` mapping.
+// the single `noise:` key.
 //
 //   - Req   — request-body field paths to ignore during schema/strict matching
 //     (e.g. "body.tier_type"). A plain list of paths: the strict path only ever
-//     honoured "ignore this whole field", so the legacy per-path regex values are
-//     intentionally dropped.
+//     honoured "ignore this whole field", so per-path regex values are not kept.
 //   - Value — exact-match value regexes written by the enterprise obfuscator
 //     (the former top-level `noise:` list, models.Mock.Noise).
 //
 // For backward compatibility the custom unmarshalers also accept the OLD shape
-// where `noise:` was a bare string list — that decodes into Value. The legacy
-// top-level `req_body_noise:` key is still read separately
-// (NetworkTrafficDoc.ReqBodyNoise) and folded into Req on decode. New writes only
-// emit this unified mapping.
+// where `noise:` was a bare string list — that decodes into Value. New writes
+// only emit this unified mapping.
 type DocNoise struct {
 	Req   []string `json:"req,omitempty" yaml:"req,omitempty"`
 	Value []string `json:"value,omitempty" yaml:"value,omitempty"`
@@ -119,20 +108,11 @@ func pathsToNoiseMap(paths []string) map[string][]string {
 	return out
 }
 
-// ResolveReqBodyNoise picks the request-body schema noise for a decoded doc,
-// preferring the new unified noise.req list and falling back to the legacy
-// top-level req_body_noise map (whose keys are kept and regex values dropped, to
-// match the path-only representation). Returns nil when neither is present.
-func ResolveReqBodyNoise(noise *DocNoise, legacy map[string][]string) map[string][]string {
+// ResolveReqBodyNoise returns the request-body schema noise for a decoded doc,
+// taken from the unified noise.req list. Returns nil when it is absent.
+func ResolveReqBodyNoise(noise *DocNoise) map[string][]string {
 	if noise != nil && len(noise.Req) > 0 {
 		return pathsToNoiseMap(noise.Req)
-	}
-	if len(legacy) > 0 {
-		paths := make([]string, 0, len(legacy))
-		for k := range legacy {
-			paths = append(paths, k)
-		}
-		return pathsToNoiseMap(paths)
 	}
 	return nil
 }


### PR DESCRIPTION
## Describe the changes that are made
- Removes the **legacy top-level `req_body_noise:` read-through** — a backward-compatibility shim added alongside the unified `noise:` block (#4310). It was no longer written, only read, so pre-unified-block mocks kept matching. That grace window has passed.
- Deletes `NetworkTrafficDoc.ReqBodyNoise` and `NetworkTrafficDocJSON.ReqBodyNoise`, drops the legacy-fallback parameter/branch of `ResolveReqBodyNoise` (now sourced solely from `noise.req`), and updates the three `mockdb` read-through call sites.
- Trims the tests that exercised the legacy fallback; **keeps** the separate legacy bare-`noise:`-string-list decode (a different compat path, not in scope).
- Corrects a stale comment in the `schema_noise_detection_linux.yml` pipeline (`req_body_noise` → `noise.req`). No functional pipeline change was needed — assertions already target `noise.req`.

**What is NOT changed:** the current schema-noise feature is untouched. Learned request-body noise still lives on `models.MockSpec.ReqBodyNoise` in memory and persists on disk under `noise.req`.

**Behavior note:** old mocks carrying only a top-level `req_body_noise:` key still decode fine (the now-unknown key is ignored — no strict decoding on this path), but their previously-learned request-body noise is no longer honored on replay.

## Links & References

**Closes:** NA (small backward-compat cleanup)

### 🔗 Related PRs
- #4310 (introduced the unified `noise:` block + this read-through)
- #4286 (introduced the kind-agnostic schema-noise engine)
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed

The existing `schema_noise_detection_linux.yml` pipeline already exercises `noise.req` end-to-end; this removal is covered by unit tests.

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 🙅 no, because it is not needed

Covered by `go test ./pkg/platform/yaml/...` (`TestResolveReqBodyNoise`, `TestLegacyNoiseFormats_StillDecode`, `TestNonHTTPNoise_*`).

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA
