### PR TITLE
fix(matcher): use actual response status code in status_code_class assertion

### DIFF
--- a/pkg/matcher/http/match.go
+++ b/pkg/matcher/http/match.go
@@ -512,7 +512,7 @@ func AssertionMatch(tc *models.TestCase, actualResponse *models.HTTPResp, logger
 			} else {
 				classStr = class
 			}
-			actualClass := fmtSprintf234("%dxx", 200/100)
+			actualClass := fmtSprintf234("%dxx", actualResponse.StatusCode/100)
 			if classStr != actualClass {
 				pass = false
 				logger.Error("status_code_class assertion failed", zap.String("expected", class), zap.String("actual", actualClass))

--- a/pkg/matcher/http/match.go
+++ b/pkg/matcher/http/match.go
@@ -527,7 +527,7 @@ func AssertionMatch(tc *models.TestCase, actualResponse *models.HTTPResp, logger
 			} else {
 				classStr = class
 			}
-			actualClass := fmtSprintf234("%dxx", 200/100)
+			actualClass := fmtSprintf234("%dxx", actualResponse.StatusCode/100)
 			if classStr != actualClass {
 				pass = false
 				logger.Error("status_code_class assertion failed", zap.String("expected", class), zap.String("actual", actualClass))

--- a/pkg/matcher/http/match_test.go
+++ b/pkg/matcher/http/match_test.go
@@ -319,3 +319,51 @@ func TestMatch_CompareAll_JSONStillCompared(t *testing.T) {
 	assert.True(t, result.StatusCode.Normal)
 	assert.False(t, result.BodyResult[0].Normal)
 }
+
+// TestAssertionMatch_StatusCodeClass_ActualNon2xxPasses_3843 ensures that a status_code_class
+// assertion of "5xx" passes when the actual response status code is 500. This guards against
+// a regression where actualClass was computed from a hardcoded 200 instead of the real
+// response status code, causing status_code_class to always evaluate against "2xx".
+func TestAssertionMatch_StatusCodeClass_ActualNon2xxPasses_3843(t *testing.T) {
+	logger := zap.NewNop()
+	tc := &models.TestCase{
+		Name: "test-status-code-class-5xx-pass",
+		Assertions: map[models.AssertionType]interface{}{
+			models.StatusCodeClass: "5xx",
+		},
+	}
+	actualResponse := &models.HTTPResp{
+		StatusCode: 500,
+	}
+
+	// Act
+	pass, result := AssertionMatch(tc, actualResponse, logger)
+
+	// Assert
+	assert.True(t, pass, "Should pass because the actual status code 500 is in the 5xx class")
+	require.NotNil(t, result)
+}
+
+// TestAssertionMatch_StatusCodeClass_ActualNon2xxFailsAgainst2xx_3843 ensures that a
+// status_code_class assertion of "2xx" fails when the actual response status code is 500.
+// Prior to the fix, actualClass was always "2xx" regardless of the actual response, so this
+// assertion would have incorrectly passed.
+func TestAssertionMatch_StatusCodeClass_ActualNon2xxFailsAgainst2xx_3843(t *testing.T) {
+	logger := zap.NewNop()
+	tc := &models.TestCase{
+		Name: "test-status-code-class-2xx-fail",
+		Assertions: map[models.AssertionType]interface{}{
+			models.StatusCodeClass: "2xx",
+		},
+	}
+	actualResponse := &models.HTTPResp{
+		StatusCode: 500,
+	}
+
+	// Act
+	pass, result := AssertionMatch(tc, actualResponse, logger)
+
+	// Assert
+	assert.False(t, pass, "Should fail because the actual status code 500 is not in the 2xx class")
+	require.NotNil(t, result)
+}

--- a/pkg/matcher/http/match_test.go
+++ b/pkg/matcher/http/match_test.go
@@ -697,3 +697,51 @@ func TestMatch_SectionedHeaderNoise_ScopesToTheListedHeader(t *testing.T) {
 	require.True(t, ok, "X-Request-Id should be reported, got %v", verdicts)
 	assert.True(t, normal, "X-Request-Id is listed as noise")
 }
+
+// TestAssertionMatch_StatusCodeClass_ActualNon2xxPasses_3843 ensures that a status_code_class
+// assertion of "5xx" passes when the actual response status code is 500. This guards against
+// a regression where actualClass was computed from a hardcoded 200 instead of the real
+// response status code, causing status_code_class to always evaluate against "2xx".
+func TestAssertionMatch_StatusCodeClass_ActualNon2xxPasses_3843(t *testing.T) {
+	logger := zap.NewNop()
+	tc := &models.TestCase{
+		Name: "test-status-code-class-5xx-pass",
+		Assertions: map[models.AssertionType]interface{}{
+			models.StatusCodeClass: "5xx",
+		},
+	}
+	actualResponse := &models.HTTPResp{
+		StatusCode: 500,
+	}
+
+	// Act
+	pass, result := AssertionMatch(tc, actualResponse, logger)
+
+	// Assert
+	assert.True(t, pass, "Should pass because the actual status code 500 is in the 5xx class")
+	require.NotNil(t, result)
+}
+
+// TestAssertionMatch_StatusCodeClass_ActualNon2xxFailsAgainst2xx_3843 ensures that a
+// status_code_class assertion of "2xx" fails when the actual response status code is 500.
+// Prior to the fix, actualClass was always "2xx" regardless of the actual response, so this
+// assertion would have incorrectly passed.
+func TestAssertionMatch_StatusCodeClass_ActualNon2xxFailsAgainst2xx_3843(t *testing.T) {
+	logger := zap.NewNop()
+	tc := &models.TestCase{
+		Name: "test-status-code-class-2xx-fail",
+		Assertions: map[models.AssertionType]interface{}{
+			models.StatusCodeClass: "2xx",
+		},
+	}
+	actualResponse := &models.HTTPResp{
+		StatusCode: 500,
+	}
+
+	// Act
+	pass, result := AssertionMatch(tc, actualResponse, logger)
+
+	// Assert
+	assert.False(t, pass, "Should fail because the actual status code 500 is not in the 2xx class")
+	require.NotNil(t, result)
+}


### PR DESCRIPTION
## Describe the changes that are made
- Fixed the `status_code_class` assertion in `pkg/matcher/http/match.go` (`AssertionMatch`): `actualClass` was computed from a hardcoded literal `200` (`fmtSprintf234("%dxx", 200/100)`), so the assertion always evaluated against `"2xx"` regardless of what the server actually returned. Asserting `"2xx"` on a real `500` response incorrectly **passed**, and asserting `"5xx"` on a `500` incorrectly **failed** — the assertion type was effectively non-functional.
- One-line fix: compute the class from the real response — `fmtSprintf234("%dxx", actualResponse.StatusCode/100)`. The existing `classStr` normalization logic (handling both `"200"`-style and `"2xx"`-style user input) is untouched. `actualResponse` is already dereferenced unconditionally earlier in the same function, so no additional nil-guard is needed for consistency.
- Added two regression tests in `pkg/matcher/http/match_test.go` (the existing suite had **zero** coverage of `StatusCodeClass`, and all existing tests used actual status 200, which is why this bug was invisible):
  - actual `500` + assertion `"5xx"` → must pass
  - actual `500` + assertion `"2xx"` → must fail

## Links & References

**Closes:** #3843

### 🔗 Related PRs
- #3861 (earlier attempt at the same issue, inactive since Feb 25)
### 🐞 Related Issues
- #3843
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [x] 🐞 Bug Fix
- [x] ✅ Test

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed

## Added comments for hard-to-understand areas?
- [x] 👍 yes (doc comments on both regression tests explaining the guarded regression)

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

```
go test ./pkg/matcher/http/ -run TestAssertionMatch_StatusCodeClass -v
```

Both new tests fail on `main` before the fix and pass after it. Verified locally with `go build ./pkg/matcher/...` (clean) and the full `pkg/matcher/http` package tests (passing).

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA
