### PR TITLE
ci: harden flaky e2e jobs (port reuse, mongo flush, apt + release-download robustness)

### DIFF
--- a/.github/workflows/prepare_and_run.yml
+++ b/.github/workflows/prepare_and_run.yml
@@ -567,9 +567,21 @@ jobs:
     steps:
       - name: Upload latest release
         run: |
-          LATEST=$(curl -s https://api.github.com/repos/keploy/keploy/releases/latest | jq -r .tag_name)
-          URL="https://github.com/keploy/keploy/releases/download/${LATEST}/keploy_linux_amd64.tar.gz"
-          curl -L "$URL" -o keploy.tar.gz
+          # Fetch the latest released keploy binary. Use the
+          # /releases/latest/download/ redirect instead of an unauthenticated
+          # api.github.com call: that API is rate-limited to 60 req/hr/IP on
+          # shared runners, and when it throttles `jq .tag_name` returns null,
+          # the download URL 404s, and `curl -L` (no -f) silently saves the
+          # HTML error page so `tar` dies with "not in gzip format". -f fails
+          # on any HTTP error, --retry rides out transient blips, and the gzip
+          # check turns a bad asset into a clear message, not a cryptic tar error.
+          URL="https://github.com/keploy/keploy/releases/latest/download/keploy_linux_amd64.tar.gz"
+          curl -fL --retry 5 --retry-all-errors --retry-delay 5 "$URL" -o keploy.tar.gz
+          if ! gzip -t keploy.tar.gz 2>/dev/null; then
+            echo "::error::Downloaded keploy.tar.gz is not a valid gzip archive (latest release asset unavailable?)"
+            head -c 200 keploy.tar.gz || true
+            exit 1
+          fi
           tar -xzf keploy.tar.gz
           chmod +x keploy
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/prepare_and_run_integrations.yml
+++ b/.github/workflows/prepare_and_run_integrations.yml
@@ -67,9 +67,21 @@ jobs:
     steps:
       - name: Upload latest release
         run: |
-          LATEST=$(curl -s https://api.github.com/repos/keploy/keploy/releases/latest | jq -r .tag_name)
-          URL="https://github.com/keploy/keploy/releases/download/${LATEST}/keploy_linux_amd64.tar.gz"
-          curl -L "$URL" -o keploy.tar.gz
+          # Fetch the latest released keploy binary. Use the
+          # /releases/latest/download/ redirect instead of an unauthenticated
+          # api.github.com call: that API is rate-limited to 60 req/hr/IP on
+          # shared runners, and when it throttles `jq .tag_name` returns null,
+          # the download URL 404s, and `curl -L` (no -f) silently saves the
+          # HTML error page so `tar` dies with "not in gzip format". -f fails
+          # on any HTTP error, --retry rides out transient blips, and the gzip
+          # check turns a bad asset into a clear message, not a cryptic tar error.
+          URL="https://github.com/keploy/keploy/releases/latest/download/keploy_linux_amd64.tar.gz"
+          curl -fL --retry 5 --retry-all-errors --retry-delay 5 "$URL" -o keploy.tar.gz
+          if ! gzip -t keploy.tar.gz 2>/dev/null; then
+            echo "::error::Downloaded keploy.tar.gz is not a valid gzip archive (latest release asset unavailable?)"
+            head -c 200 keploy.tar.gz || true
+            exit 1
+          fi
           tar -xzf keploy.tar.gz
           chmod +x keploy
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/sample_tls_pcap.yml
+++ b/.github/workflows/sample_tls_pcap.yml
@@ -80,6 +80,20 @@ jobs:
 
       - name: Install tshark + openssl for pcap decryption check
         run: |
+          # GitHub's ubuntu-24.04 runner image ships third-party apt
+          # repositories (packages.microsoft.com — azure-cli + prod) that this
+          # job does not use: tshark and openssl come from the Ubuntu
+          # main/universe archives. That host intermittently serves a corrupt
+          # InRelease ("Clearsigned file isn't valid, got 'NOSPLIT'"), which
+          # makes `apt-get update` exit 100 and — under this step's default
+          # `bash -eo pipefail` shell — takes the whole job down before keploy
+          # ever runs. Drop every apt source pointing at that host so
+          # `apt-get update` only consults the repos we actually depend on.
+          # The `|| true` keeps a benign no-match (grep exit 1, which pipefail
+          # would otherwise propagate) from aborting the step, while a real
+          # `rm` failure still surfaces. Deterministic — no retry, no sleep.
+          { sudo grep -rlZ 'packages.microsoft.com' /etc/apt/sources.list.d/ 2>/dev/null || true; } \
+            | sudo xargs -0r rm -f
           sudo apt-get update -qq
           # Pre-accept the wireshark-common dump-cap suid prompt so the
           # apt install runs non-interactively.

--- a/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-native-windows.ps1
+++ b/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-native-windows.ps1
@@ -224,9 +224,38 @@ function Invoke-RecordIteration {
       Where-Object { $_.CommandLine -match 'keploy.*record' -or $_.CommandLine -match 'ginApp.exe' } |
       Select-Object -First 1
 
+    # Wait for keploy to FINISH persisting this iteration's testcases + mongo
+    # mocks to disk while it is STILL RUNNING, then stop it. keploy streams mocks
+    # to disk as it records and runs a final flush on shutdown; force-killing
+    # (taskkill /F) before that settles truncates or drops the mongo mocks, so
+    # replay fails with "[MongoDB] ... no_mocks". Poll the recorded mocks files
+    # until their total size stops growing (flush settled), bounded at 60s, then
+    # stop. (The old code slept 10s AFTER Kill-Tree — i.e. after keploy was
+    # already dead — so it never actually waited for the flush; that is the bug.)
+    # Watch BOTH mocks.yaml and mocks.json: the yaml iterations write mocks.yaml
+    # and the --storage-format json iterations write mocks.json, so filtering on
+    # mocks.yaml alone would see only the stale yaml files during a json
+    # iteration and break early. Do NOT glob mocks.* — that would also match
+    # keploy's transient mocks.<rand>.tmp atomic-write files and corrupt the
+    # size-stability signal.
+    $ksDir = Join-Path $currentDir 'keploy'
+    $deadline = (Get-Date).AddSeconds(60)
+    $lastSize = -1
+    $stable = 0
+    while ((Get-Date) -lt $deadline) {
+        $mockSum = (Get-ChildItem -Path $ksDir -Recurse -ErrorAction SilentlyContinue |
+                    Where-Object { $_.Name -eq 'mocks.yaml' -or $_.Name -eq 'mocks.json' } |
+                    Measure-Object -Property Length -Sum).Sum
+        if ($mockSum -and $mockSum -gt 0) {
+            if ($mockSum -eq $lastSize) { $stable++ } else { $stable = 0 }
+            if ($stable -ge 2) { break }   # size unchanged across ~6s => flush settled
+        }
+        $lastSize = $mockSum
+        Start-Sleep -Seconds 3
+    }
+    Write-Host "Recording flush settled (mocks size: $lastSize bytes); stopping keploy."
+
     if ($REC_PROC) { Kill-Tree -ProcessId $REC_PROC.ProcessId }
-    # Wait for keploy to flush mocks to disk
-    Start-Sleep -Seconds 10
 
     Write-Host "`n⬇️⬇️⬇️ Keploy Record Logs ($appName) ⬇️⬇️⬇️"
     Drain-JobOutput -Job $recJob -LogFile $logFile

--- a/.github/workflows/test_workflow_scripts/java/spring_petclinic/java-linux.sh
+++ b/.github/workflows/test_workflow_scripts/java/spring_petclinic/java-linux.sh
@@ -61,6 +61,35 @@ wait_for_http_port() {
   endsec; return 1
 }
 
+wait_for_port_free() {
+  # This job launches the app on the fixed port 9966 four times in sequence
+  # (yaml record, json record, yaml replay, json replay). Stopping keploy with
+  # `sudo kill` only signals keploy; the spring-boot JVM grandchild can still be
+  # closing its :9966 listening socket when the NEXT launch tries to bind it,
+  # and spring does not set SO_REUSEADDR — so the next app dies with
+  # "Port 9966 was already in use" (flaky, worse under loaded runners). Poll the
+  # actual kernel socket state until the port is free before each (re)launch,
+  # reaping a lingering JVM after a short grace so a wedged shutdown can't stall.
+  local port="${1:-9966}"
+  section "Ensure port ${port} is free before (re)launch"
+  local reaped=0
+  for i in $(seq 1 60); do
+    if ! ss -ltn "sport = :${port}" 2>/dev/null | grep -q LISTEN; then
+      echo "Port ${port} is free."
+      endsec; return 0
+    fi
+    if [[ "$i" -ge 5 && "$reaped" -eq 0 ]]; then
+      echo "Port ${port} still bound after ${i}s; reaping lingering spring-petclinic JVM"
+      sudo pkill -f 'spring-petclinic-rest.*jar' 2>/dev/null || true
+      reaped=1
+    fi
+    sleep 1
+  done
+  echo "::error::Port ${port} still bound after 60s"
+  ss -ltnp "sport = :${port}" 2>/dev/null || true
+  endsec; return 1
+}
+
 detect_api_prefix() {
   # returns either /petclinic/api or /api (echo to stdout), otherwise empty
   local base="http://localhost:9966"
@@ -621,11 +650,17 @@ send_request() {
   # Run the user's transaction logic
   run_transactions
 
-  # Let keploy persist, then stop it
+  # Let keploy persist, then stop it and its JVM child deterministically.
   sleep 10
   echo "$kp_pid Keploy PID"
   echo "Killing keploy"
   sudo kill "$kp_pid" 2>/dev/null || true
+  # Wait for keploy to exit gracefully, then reap the spring-boot JVM grandchild
+  # and hard-kill keploy as a fallback, so port 9966 is actually released before
+  # the next launch rather than depending on incidental latency.
+  for _ in $(seq 1 15); do kill -0 "$kp_pid" 2>/dev/null || break; sleep 1; done
+  sudo pkill -f 'spring-petclinic-rest.*jar' 2>/dev/null || true
+  sudo kill -9 "$kp_pid" 2>/dev/null || true
 }
 
 # ----- main -----
@@ -661,6 +696,8 @@ do_record_iteration() {
   section "Record iteration $i${label:+ (json)}"
 
   run_maven_build
+
+  wait_for_port_free 9966
 
   # shellcheck disable=SC2086
   "$RECORD_BIN" record $extra_flags \
@@ -730,6 +767,8 @@ docker rm mypostgres || true
 echo "Postgres stopped - Keploy should now use mocks for database interactions"
 endsec
 
+wait_for_port_free 9966
+
 section "Replay"
 set +e
 "$REPLAY_BIN" test \
@@ -789,6 +828,8 @@ if [[ $REPLAY_RC -ne 0 ]]; then
 fi
 
 if json_pass_supported; then
+  wait_for_port_free 9966
+
   section "Replay (json)"
   set +e
   "$REPLAY_BIN" test --storage-format json \

--- a/.github/workflows/test_workflow_scripts/python/flask-secret/python-linux.sh
+++ b/.github/workflows/test_workflow_scripts/python/flask-secret/python-linux.sh
@@ -39,6 +39,29 @@ wait_for_health() {
     return 1
 }
 
+wait_for_port_free() {
+    # The app (python3 main.py) is relaunched on the fixed port 8000 for every
+    # record/replay cycle. keploy is stopped between cycles, but the flask child
+    # can still be holding :8000 when the next launch tries to bind it, so the
+    # app dies at startup with "Address already in use" ->
+    # "user application terminated unexpectedly" (flaky, worse under load). Poll
+    # the actual socket state until the port is free before each (re)launch,
+    # reaping a lingering app after a short grace so a wedged shutdown can't stall.
+    local port="${1:-8000}"
+    for i in $(seq 1 60); do
+        if ! ss -ltn "sport = :${port}" 2>/dev/null | grep -q LISTEN; then
+            return 0
+        fi
+        if [ "$i" -ge 5 ]; then
+            sudo pkill -f 'python3 main.py' 2>/dev/null || true
+        fi
+        sleep 1
+    done
+    echo "::error::Port ${port} still bound after 60s"
+    ss -ltnp "sport = :${port}" 2>/dev/null || true
+    return 1
+}
+
 # Add coverage to requirements.txt
 echo "coverage" >> requirements.txt
 
@@ -113,6 +136,7 @@ for i in 1 2; do
     app_name="flaskSecret_${i}"
     send_request "secrets" &
     request_pid=$!
+    wait_for_port_free 8000 || true
     $RECORD_BIN record -c "python3 main.py" --metadata "suite=secrets,run=$i" 2>&1 | tee ${app_name}.txt
     if grep "ERROR" "${app_name}.txt"; then exit 1; fi
     if grep "WARNING: DATA RACE" "${app_name}.txt"; then exit 1; fi
@@ -133,6 +157,7 @@ sleep 5
 app_name="flaskAstro"
 send_request "astro" &
 request_pid=$!
+wait_for_port_free 8000 || true
 $RECORD_BIN record -c "python3 main.py" --metadata "suite=astro,endpoint=/astro" 2>&1 | tee ${app_name}.txt
 if grep "ERROR" "${app_name}.txt"; then exit 1; fi
 if grep "WARNING: DATA RACE" "${app_name}.txt"; then exit 1; fi
@@ -158,6 +183,7 @@ else
 fi
 
 # Testing phase
+wait_for_port_free 8000 || true
 $REPLAY_BIN test -c "python3 main.py" --delay 10 2>&1 | tee test_logs.txt
 if grep "ERROR" "test_logs.txt"; then exit 1; fi
 if grep "WARNING: DATA RACE" "test_logs.txt"; then exit 1; fi
@@ -198,6 +224,7 @@ fi
 
 # Run test with config path pointing to the new location
 echo "Running test with --config-path $CONFIG_TEST_DIR"
+wait_for_port_free 8000 || true
 $REPLAY_BIN test -c "python3 main.py" --delay 10 --config-path "$CONFIG_TEST_DIR" 2>&1 | tee config_path_test_logs.txt
 
 # Check if keploy.yml was created in the original location (should NOT happen)
@@ -240,6 +267,7 @@ echo "Removing astro test-set-2 to focus normalize on secret sets"
 rm -rf keploy/test-set-2
 
 echo "Running test again, this will fail as expected"
+wait_for_port_free 8000 || true
 $REPLAY_BIN test -c "python3 main.py" --delay 10 2>&1 | tee test_logs_fail.txt
 
 echo "Running the normalize command"
@@ -247,6 +275,7 @@ $REPLAY_BIN normalize 2>&1 | tee normalize_logs.txt
 if grep "ERROR" "normalize_logs.txt"; then exit 1; fi
 
 echo "Running test again, this time it will pass"
+wait_for_port_free 8000 || true
 $REPLAY_BIN test -c "python3 main.py" --delay 10 2>&1 | tee test_logs_pass.txt
 if grep "ERROR" "test_logs_pass.txt"; then exit 1; fi
 
@@ -282,6 +311,7 @@ rm -rf keploy
 app_name="flaskMisc"
 send_request "misc" &
 request_pid=$!
+wait_for_port_free 8000 || true
 $RECORD_BIN record -c "python3 main.py" --metadata "suite=misc" 2>&1 | tee ${app_name}.txt
 if grep "ERROR" "${app_name}.txt"; then
     echo "Error found in misc recording..."
@@ -307,6 +337,7 @@ if json_pass_supported; then
     app_name="flaskMisc_json"
     send_request "misc" &
     request_pid=$!
+    wait_for_port_free 8000 || true
     $RECORD_BIN record --storage-format json -c "python3 main.py" --metadata "suite=misc" 2>&1 | tee ${app_name}.txt
     if grep "ERROR" "${app_name}.txt"; then exit 1; fi
     if grep "WARNING: DATA RACE" "${app_name}.txt"; then exit 1; fi
@@ -328,6 +359,7 @@ fi
 
 # Final testing phase
 echo "Running test on the new 'misc' test suite..."
+wait_for_port_free 8000 || true
 $REPLAY_BIN test -c "python3 main.py" --delay 10 2>&1 | tee final_test_logs.txt
 if grep "ERROR" "final_test_logs.txt"; then
     echo "Error found in final test run..."
@@ -397,6 +429,7 @@ if [ "$final_test_passed" != true ]; then
 fi
 
 if json_pass_supported; then
+    wait_for_port_free 8000 || true
     $REPLAY_BIN test --storage-format json -c "python3 main.py" --delay 10 2>&1 | tee final_test_logs_json.txt
     if grep "ERROR" "final_test_logs_json.txt"; then
         cat final_test_logs_json.txt


### PR DESCRIPTION
## What

Fixes two **pre-existing E2E flakes on `main`** (both reproduce independently of any feature PR — they roll up into the `CI Gate (Linux)` / `CI Gate (Windows)` aggregators and redden unrelated PRs). Both are **harness races**; no product code, mocks, or assertions change.

### 1. `run_java_linux / spring-petclinic` — "Port 9966 was already in use"

The job relaunches spring-boot on the **fixed port 9966 four times per run** (yaml/json × record/replay). Teardown was `sudo kill "$kp_pid"` — a SIGTERM to keploy only, never reaping the spring-boot JVM grandchild nor waiting for the `:9966` socket to close. Spring sets no `SO_REUSEADDR`, so the next `bind(9966)` races the still-closing socket → *"Web server failed to start. Port 9966 was already in use."* → keploy *"user application terminated unexpectedly."* The record→record gaps were saved only by incidental `mvn` latency; the **yaml-replay → json-replay** gap has no such cushion, which is where it flakes hardest under loaded runners.

**Fix:** add a `wait_for_port_free` helper that polls the real kernel socket state (`ss -ltn "sport = :9966"`) until the port is free, reaping a lingering JVM after a short grace, and call it **before every launch**; make the record teardown deterministic (SIGTERM → bounded wait → `pkill` the JVM → `kill -9` fallback). **Reproduced locally:** SIGTERM-then-immediate-rebind → `EADDRINUSE`; the barrier fixes it.

### 2. `run_golang_native_windows / gin-mongo` — "[MongoDB] … no_mocks"

The record teardown did `Kill-Tree` (`taskkill /F`) **then** `Start-Sleep 10 "# Wait for keploy to flush mocks to disk"`. Flushing *after* a force-kill is a no-op — the process is already dead — so if keploy hadn't finished persisting the mongo mocks at the instant of the `/F`, they're truncated/dropped and replay fails with `[MongoDB] … no_mocks`.

**Fix:** poll the recorded mocks files (`mocks.yaml` **and** `mocks.json` — the yaml and `--storage-format json` iterations each write one; deliberately not `mocks.*`, which would match keploy's transient `mocks.<rand>.tmp` atomic-write files) until their total size stops growing — **with keploy still running** — then stop it, bounded at 60s. This mirrors the ordering of the non-flaky `http_pokeapi` Windows script (wait-for-recording-then-kill).

## Testing / verification

- **Java:** locally reproduced the `EADDRINUSE` race and verified the `ss`-poll barrier resolves it; `bash -n` clean. Independently reviewed (adversarial) — clean.
- **Windows:** verified by careful review against the working `http_pokeapi` script + keploy's mock-write path (yaml/json streamed during record, flushed on shutdown). No PowerShell interpreter was available to me locally, so **this side is verified by this PR's own Windows CI** — please watch `run_golang_native_windows / gin-mongo` here.

## Provenance (for prevention, not blame)

- Java barrier-less teardown: introduced in #2901 (`69fcc47d`); the JSON record/replay pass that doubled the same-port relaunches came later in #4063 (`0a0ac69c`).
- Windows force-kill teardown: #3291 (`e4ae7ea6`); the ineffective post-kill flush-sleep: #3950 (`ff3c0530`).

**Suggested review rule:** any harness that restarts a server on a fixed port must poll the socket free + reap the process tree before rebinding; any harness that stops a recorder must wait for its mocks to settle on disk before killing — never a bare `sleep`, never force-kill-then-sleep. (`Test-RecordingComplete` is copy-pasted per Windows script, so the correct pattern didn't reach gin-mongo.)

## Not covered

`run_sample_tls_pcap` (exit 100) is a **different** Linux-gate flake with a separate root cause — not addressed here.

---

### Update: also fixes `run_python_linux / flask-secret`

CI surfaced a **third** instance of the exact same root cause. The flask harness relaunches `python3 main.py` (flask on port **8000**) **10 times** across record + replay with no port-free barrier, so under load the app dies at startup with `Address already in use` → `user application terminated unexpectedly`. Same fix applied: a `wait_for_port_free` helper (`ss`-poll + reap `python3 main.py` after a grace) before all 10 launch sites. `bash -n` clean; independently reviewed clean.

So this PR now fixes **three same-family harness races**: java port-9966, python flask port-8000, and the windows mongo mock-flush ordering — the single prevention rule (poll-socket-free + reap before every relaunch; wait-for-mocks-settled before kill) covers all three.

---

### Update: also fixes `run_sample_tls_pcap` (exit 100)

A different class of flake in the same gate. This job died intermittently at its "Install tshark + openssl" step — *before keploy ran* — with `apt-get update` exit 100, because GitHub's `ubuntu-24.04` runner ships a `packages.microsoft.com` apt repo (azure-cli + prod) that this job doesn't use and that periodically serves a corrupt `InRelease`. Under the step's default `bash -eo pipefail` shell that takes the whole job down. Fix: drop that apt source before `apt-get update` (a benign no-match can't abort the step; a real Ubuntu-archive outage still fails loudly). Independently reviewed — the reviewer caught that a naive `grep | xargs` would itself trip `pipefail` on no-match, fixed with a brace-group `|| true`.

**Note (broader hygiene):** every keploy CI job that runs `apt-get update` on a GitHub `ubuntu-*` runner shares this exposure and would benefit from the same guard.