### PR TITLE
feat(telemetry): categorized stop_reason on graceful record/replay stops

### DIFF
--- a/pkg/models/tele.go
+++ b/pkg/models/tele.go
@@ -10,6 +10,7 @@ package models
 const (
 	TeleEventTestRun                = "TestRun"
 	TeleEventRecordSessionCompleted = "RecordSessionCompleted"
+	TeleEventTestRunAborted         = "TestRunAborted"
 )
 
 type TeleEvent struct {

--- a/pkg/platform/telemetry/stopreason.go
+++ b/pkg/platform/telemetry/stopreason.go
@@ -1,0 +1,64 @@
+package telemetry
+
+import "strings"
+
+// Stop-reason categories: a small, stable, low-cardinality enum describing
+// WHY a record/replay session ended. These are emitted only on graceful
+// stops (via RecordSessionCompleted / TestRunAborted) so dashboards can see
+// where users get stuck. Hard crashes/panics are intentionally NOT modelled
+// here — those are Sentry's job.
+//
+// Keep this list short and stable: it feeds a LowCardinality ClickHouse
+// column and a Superset funnel. Add a new code only for a genuinely new
+// class of graceful stop, never for one-off error text.
+const (
+	StopReasonCompleted        = "completed"             // clean exit / user Ctrl+C / record timer elapsed
+	StopReasonSetupFailed      = "setup_failed"          // environment/instrumentation setup failed
+	StopReasonNoTrafficFrames  = "no_traffic_frames"     // agent/proxy never established data frames
+	StopReasonTestsetLookup    = "testset_lookup_failed" // could not resolve/list test-set id(s)
+	StopReasonNoTestsets       = "no_testsets"           // `keploy test` run before anything was recorded
+	StopReasonInstrumentFailed = "instrument_failed"     // replay instrumentation failed
+	StopReasonHookError        = "hook_error"            // before-test / app-hook failure
+	StopReasonAppError         = "app_error"             // user application errored while running
+	StopReasonAppExited        = "app_exited"            // user application terminated unexpectedly
+	StopReasonDBWriteError     = "db_write_error"        // failed persisting test case / mock
+	StopReasonTestsetRunFailed = "testset_run_failed"    // a test set failed to run
+	StopReasonOther            = "other"                 // graceful stop with an uncategorized reason
+)
+
+// CategorizeStopReason maps a free-form stopReason string (as set in the
+// record/replay flows) to one of the stable categories above.
+//
+// The raw strings are deliberately NOT emitted: several interpolate the
+// underlying error via %v, which would explode column cardinality and
+// duplicate what Sentry already captures. An empty reason means a clean
+// stop and maps to "completed".
+func CategorizeStopReason(raw string) string {
+	r := strings.ToLower(strings.TrimSpace(raw))
+	switch {
+	case r == "" || strings.Contains(r, "completed successfully"):
+		return StopReasonCompleted
+	case strings.Contains(r, "no test sets found"):
+		return StopReasonNoTestsets
+	case strings.Contains(r, "test-set id") || strings.Contains(r, "all test set ids"):
+		return StopReasonTestsetLookup
+	case strings.Contains(r, "setting up the environment") || strings.Contains(r, "next test run id"):
+		return StopReasonSetupFailed
+	case strings.Contains(r, "data frames"):
+		return StopReasonNoTrafficFrames
+	case strings.Contains(r, "instrument"):
+		return StopReasonInstrumentFailed
+	case strings.Contains(r, "hook"):
+		return StopReasonHookError
+	case strings.Contains(r, "inserting test case") || strings.Contains(r, "inserting mock"):
+		return StopReasonDBWriteError
+	case strings.Contains(r, "terminated unexpectedly") || strings.Contains(r, "binary stopped"):
+		return StopReasonAppExited
+	case strings.Contains(r, "running the user application") || strings.Contains(r, "unknown error received from application"):
+		return StopReasonAppError
+	case strings.Contains(r, "run test set"):
+		return StopReasonTestsetRunFailed
+	default:
+		return StopReasonOther
+	}
+}

--- a/pkg/platform/telemetry/stopreason_test.go
+++ b/pkg/platform/telemetry/stopreason_test.go
@@ -14,16 +14,16 @@ func TestCategorizeStopReason(t *testing.T) {
 		"replay completed successfully": StopReasonCompleted,
 
 		// record.go
-		"failed to get new test-set id":                                                     StopReasonTestsetLookup,
-		"failed setting up the environment":                                                 StopReasonSetupFailed,
-		"failed to get data frames":                                                         StopReasonNoTrafficFrames,
-		"error in running the user application, hence stopping keploy":                      StopReasonAppError,
-		"user application terminated unexpectedly hence stopping keploy":                    StopReasonAppExited,
-		"internal error occurred while hooking into the application, hence stopping keploy": StopReasonHookError,
-		"keploy test mode binary stopped, hence stopping keploy":                            StopReasonAppExited,
-		"unknown error received from application, hence stopping keploy":                    StopReasonAppError,
-		"error while inserting test case into db, hence stopping keploy":                    StopReasonDBWriteError,
-		"error while inserting mock into db, hence stopping keploy":                         StopReasonDBWriteError,
+		"failed to get new test-set id":                                StopReasonTestsetLookup,
+		"failed setting up the environment":                            StopReasonSetupFailed,
+		"failed to get data frames":                                    StopReasonNoTrafficFrames,
+		"error in running the user application, hence stopping keploy": StopReasonAppError,
+		"user application terminated unexpectedly hence stopping keploy, please check application logs if this behaviour is not expected": StopReasonAppExited,
+		"internal error occurred while hooking into the application, hence stopping keploy":                                               StopReasonHookError,
+		"keploy test mode binary stopped, hence stopping keploy":                                                                          StopReasonAppExited,
+		"unknown error received from application, hence stopping keploy":                                                                  StopReasonAppError,
+		"error while inserting test case into db, hence stopping keploy":                                                                  StopReasonDBWriteError,
+		"error while inserting mock into db, hence stopping keploy":                                                                       StopReasonDBWriteError,
 
 		// replay.go (these interpolate %v in production; prefix must still match)
 		"no test sets found":                   StopReasonNoTestsets,

--- a/pkg/platform/telemetry/stopreason_test.go
+++ b/pkg/platform/telemetry/stopreason_test.go
@@ -1,0 +1,45 @@
+package telemetry
+
+import "testing"
+
+// TestCategorizeStopReason pins the mapping against the exact raw stopReason
+// strings set in the record (pkg/service/record/record.go) and replay
+// (pkg/service/replay/replay.go) flows. If one of those strings is reworded,
+// this test fails loudly instead of silently degrading a live funnel to
+// "other".
+func TestCategorizeStopReason(t *testing.T) {
+	cases := map[string]string{
+		// clean stops
+		"":                              StopReasonCompleted,
+		"replay completed successfully": StopReasonCompleted,
+
+		// record.go
+		"failed to get new test-set id":                                                     StopReasonTestsetLookup,
+		"failed setting up the environment":                                                 StopReasonSetupFailed,
+		"failed to get data frames":                                                         StopReasonNoTrafficFrames,
+		"error in running the user application, hence stopping keploy":                      StopReasonAppError,
+		"user application terminated unexpectedly hence stopping keploy":                    StopReasonAppExited,
+		"internal error occurred while hooking into the application, hence stopping keploy": StopReasonHookError,
+		"keploy test mode binary stopped, hence stopping keploy":                            StopReasonAppExited,
+		"unknown error received from application, hence stopping keploy":                    StopReasonAppError,
+		"error while inserting test case into db, hence stopping keploy":                    StopReasonDBWriteError,
+		"error while inserting mock into db, hence stopping keploy":                         StopReasonDBWriteError,
+
+		// replay.go (these interpolate %v in production; prefix must still match)
+		"no test sets found":                   StopReasonNoTestsets,
+		"failed to get all test set ids: boom": StopReasonTestsetLookup,
+		"failed to get next test run id: boom": StopReasonSetupFailed,
+		"failed to instrument: boom":           StopReasonInstrumentFailed,
+		"failed to run before test hook: boom": StopReasonHookError,
+		"failed to run test set: boom":         StopReasonTestsetRunFailed,
+
+		// unknown → other
+		"something totally unexpected": StopReasonOther,
+	}
+
+	for raw, want := range cases {
+		if got := CategorizeStopReason(raw); got != want {
+			t.Errorf("CategorizeStopReason(%q) = %q, want %q", raw, got, want)
+		}
+	}
+}

--- a/pkg/platform/telemetry/telemetry.go
+++ b/pkg/platform/telemetry/telemetry.go
@@ -141,14 +141,31 @@ func (tel *Telemetry) MockTestRun(utilizedMocks int) {
 // and "aborted" for an error path that surfaced a stopReason. Record
 // always captures one test-set per invocation, so a test-set count is
 // intentionally omitted.
-func (tel *Telemetry) RecordSessionCompleted(testCount, mockCount int64, durationMs int64, status string) {
+func (tel *Telemetry) RecordSessionCompleted(testCount, mockCount int64, durationMs int64, status string, stopReason string) {
 	dataMap := map[string]interface{}{
 		"test_count":  testCount,
 		"mock_count":  mockCount,
 		"duration_ms": durationMs,
 		"status":      status,
+		// Categorized (low-cardinality) reason the session ended — powers the
+		// "where do record sessions get stuck" funnel. Raw reason text is not
+		// sent; hard crashes go to Sentry. See CategorizeStopReason.
+		"stop_reason": CategorizeStopReason(stopReason),
 	}
 	tel.sendTracked(models.TeleEventRecordSessionCompleted, dataMap)
+}
+
+// TestRunAborted fires when a replay (`keploy test`) invocation stops
+// gracefully BEFORE the normal TestRun summary is emitted — e.g. setup or
+// instrumentation failed before any test set ran. It carries the same
+// categorized stop_reason so the replay funnel can show where test runs die
+// on the way in. Not emitted on user interrupt or on a completed run.
+func (tel *Telemetry) TestRunAborted(stopReason string) {
+	dataMap := map[string]interface{}{
+		"status":      "aborted",
+		"stop_reason": CategorizeStopReason(stopReason),
+	}
+	tel.sendTracked(models.TeleEventTestRunAborted, dataMap)
 }
 
 func (tel *Telemetry) RecordedTestSuite(testSet string, testsTotal int, mockTotal map[string]int, metadata map[string]interface{}) {

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -219,6 +219,7 @@ func (r *Recorder) Start(ctx context.Context) error {
 		if err := utils.DrainErrGroup(r.logger, "record", errGrp, 30*time.Second); err != nil {
 			utils.LogError(r.logger, err, "failed to stop recording")
 		}
+		totalMocks := 0
 		if recordingStarted {
 			mockCountMapMu.Lock()
 			mockCountSnapshot := make(map[string]int, len(mockCountMap))
@@ -229,18 +230,22 @@ func (r *Recorder) Start(ctx context.Context) error {
 			r.telemetry.RecordedTestSuite(newTestSetID, testCount, mockCountSnapshot, map[string]interface{}{
 				"host-domains": domainSet.ToSlice(),
 			})
-			totalMocks := 0
 			for _, c := range mockCountSnapshot {
 				totalMocks += c
 			}
-			// "completed" for a clean exit / user Ctrl+C, "aborted"
-			// when an error path set stopReason. Lets dashboards split
-			// successful sessions from failures without losing either.
+		}
+		// Emit the session summary on every graceful stop: either recording
+		// actually started, OR an error path set a stopReason before frames
+		// were established (setup/agent-not-ready/testset-lookup failures that
+		// previously emitted nothing — the highest-signal "stuck" cases).
+		// "completed" for a clean exit / user Ctrl+C, "aborted" when a
+		// stopReason was set; stop_reason carries the categorized cause.
+		if recordingStarted || stopReason != "" {
 			status := "completed"
 			if stopReason != "" {
 				status = "aborted"
 			}
-			r.telemetry.RecordSessionCompleted(int64(testCount), int64(totalMocks), time.Since(sessionStart).Milliseconds(), status)
+			r.telemetry.RecordSessionCompleted(int64(testCount), int64(totalMocks), time.Since(sessionStart).Milliseconds(), status, stopReason)
 		}
 		if s, ok := r.telemetry.(interface{ Shutdown() }); ok {
 			s.Shutdown()

--- a/pkg/service/record/service.go
+++ b/pkg/service/record/service.go
@@ -60,7 +60,7 @@ type Telemetry interface {
 	RecordedTestCaseMock(mockType string)
 	RecordedMocks(mockTotal map[string]int)
 	RecordedTestAndMocks()
-	RecordSessionCompleted(testCount, mockCount int64, durationMs int64, status string)
+	RecordSessionCompleted(testCount, mockCount int64, durationMs int64, status string, stopReason string)
 }
 
 type FrameChan struct {

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -289,6 +289,10 @@ func (r *Replayer) Start(ctx context.Context) error {
 
 	var hookCancel context.CancelFunc
 	var stopReason = "replay completed successfully"
+	// summaryEmitted flips true once the normal TestRun summary fires. If the
+	// run stops gracefully before that (setup/instrument failure), the defer
+	// emits a TestRunAborted with the categorized reason instead.
+	var summaryEmitted bool
 
 	// defering the stop function to stop keploy in case of any error in record or in case of context cancellation
 	defer func() {
@@ -297,6 +301,16 @@ func (r *Replayer) Start(ctx context.Context) error {
 			break
 		default:
 			r.logger.Info("stopping Keploy", zap.String("reason", stopReason))
+			// Keploy-initiated (not user Ctrl+C, which lands in the ctx.Done
+			// case above) graceful stop before any run summary was emitted —
+			// record why so the replay funnel can see where test runs die on
+			// setup. Graceful only; hard crashes are covered by Sentry.
+			if !summaryEmitted {
+				r.telemetry.TestRunAborted(stopReason)
+				if s, ok := r.telemetry.(interface{ Shutdown() }); ok {
+					s.Shutdown()
+				}
+			}
 		}
 
 		// Notify the agent that we are shutting down gracefully. It covers early exits before RunTestSet runs
@@ -341,6 +355,10 @@ func (r *Replayer) Start(ctx context.Context) error {
 		recordCmd := models.HighlightGrayString("keploy record")
 		errMsg := fmt.Sprintf("No test sets found in the keploy folder. Please record testcases using %s command", recordCmd)
 		utils.LogError(r.logger, err, errMsg)
+		// Ran `keploy test` before any tests were recorded — a distinct
+		// funnel signal, so surface it via the categorized stop reason
+		// rather than letting the default "completed" mask it.
+		stopReason = "no test sets found"
 		return fmt.Errorf("%s", errMsg)
 	}
 
@@ -807,6 +825,9 @@ func (r *Replayer) Start(ctx context.Context) error {
 	r.telemetry.TestRun(passed, failed, len(testSets), mocksConsumed, testRunStatus, map[string]interface{}{
 		"host-domains": runDomainSet.ToSlice(),
 	})
+	// The run reached its summary; the teardown defer must not also emit a
+	// TestRunAborted for this invocation.
+	summaryEmitted = true
 	// Shutdown is optional: the static Telemetry interface does not require it,
 	// but the concrete implementation exposes it for graceful drain of in-flight events.
 	if s, ok := r.telemetry.(interface{ Shutdown() }); ok {

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -278,6 +278,13 @@ func (r *Replayer) Start(ctx context.Context) error {
 
 	r.logger.Debug("Starting Keploy replay... Please wait.")
 
+	// parentCtx is the context as passed into Start — canceled only by a
+	// real user interrupt (SIGINT via utils.NewCtx). The errgroup-derived
+	// ctx below additionally cancels on ANY goroutine error, so it must NOT
+	// be used to detect user-abort: doing so would suppress TestRunAborted
+	// for exactly the internal graceful-abort paths this telemetry targets.
+	parentCtx := ctx
+
 	// creating error group to manage proper shutdown of all the go routines and to propagate the error to the caller
 	g, ctx := errgroup.WithContext(ctx)
 	ctx, cancel := context.WithCancel(context.WithValue(ctx, models.ErrGroupKey, g))
@@ -297,14 +304,16 @@ func (r *Replayer) Start(ctx context.Context) error {
 	// defering the stop function to stop keploy in case of any error in record or in case of context cancellation
 	defer func() {
 		select {
-		case <-ctx.Done():
+		case <-parentCtx.Done():
 			break
 		default:
 			r.logger.Info("stopping Keploy", zap.String("reason", stopReason))
-			// Keploy-initiated (not user Ctrl+C, which lands in the ctx.Done
-			// case above) graceful stop before any run summary was emitted —
-			// record why so the replay funnel can see where test runs die on
-			// setup. Graceful only; hard crashes are covered by Sentry.
+			// Keploy-initiated (not user Ctrl+C, which lands in the
+			// parentCtx.Done case above) graceful stop before any run summary
+			// was emitted — record why so the replay funnel can see where test
+			// runs die on setup. Graceful only; hard crashes are covered by
+			// Sentry. parentCtx (not the errgroup ctx) is checked so internal
+			// goroutine errors don't masquerade as user interrupts.
 			if !summaryEmitted {
 				r.telemetry.TestRunAborted(stopReason)
 				if s, ok := r.telemetry.(interface{ Shutdown() }); ok {

--- a/pkg/service/replay/service.go
+++ b/pkg/service/replay/service.go
@@ -101,6 +101,10 @@ type TestSetConfig interface {
 type Telemetry interface {
 	TestSetRun(success int, failure int, testSet string, runStatus string)
 	TestRun(success int, failure int, testSets int, mocksConsumed int, runStatus string, metadata map[string]interface{})
+	// TestRunAborted records a graceful replay stop that happened before the
+	// TestRun summary was emitted (e.g. setup/instrumentation failed before
+	// any test set ran), carrying a categorized stop_reason for the funnel.
+	TestRunAborted(stopReason string)
 	MockTestRun(utilizedMocks int)
 }
 


### PR DESCRIPTION
## What & why

Adds the CLI-side "where do users get stuck" signal for the **login → record → test** funnel (telemetry issue [keploy/telemetry#37](https://github.com/keploy/telemetry/issues/37)). Today the CLI records almost exclusively *successes*; graceful failures/abandonment emit nothing, so drop-off is invisible. This makes graceful stops carry a categorized reason — **without** duplicating Sentry (hard crashes stay there).

## Changes

**Record — one event type, `RecordSessionCompleted`:**
- Now emitted even when recording **never started** (pre-frame `setup_failed` / `no_traffic_frames` / `testset_lookup_failed`) — previously silent, the highest-signal "stuck" cases.
- Carries a categorized `stop_reason` alongside the existing `status`.

**Replay — new `TestRunAborted` event:**
- Fires when a run stops gracefully **before** its summary (setup/instrument/before-hook errors, a test set that errors out → `testset_run_failed`, or `keploy test` run before anything recorded → `no_testsets`).
- Normal pass/fail runs still emit `TestRun` as before. `TestRun (Run-Status=fail)` = red tests (a result); `TestRunAborted` = couldn't complete a run (stuck).

**Reason enum (`stopreason.go`):**
- `CategorizeStopReason` maps free-form reasons to a small, stable, LowCardinality set. Raw error text is **not** emitted (cardinality + Sentry overlap). Unit test pins every real record/replay string to its category.

## Scope / guarantees
- Graceful stops only — user Ctrl+C mid-replay and hard panics are excluded by design.
- `stop_reason` rides in `meta`, so it flows to ClickHouse via the existing pipeline with no ETL change; Superset funnel to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)