### PR TITLE
ci(echo-sql): fix flaky macOS docker lane — TCP-probe postgres readiness

### DIFF
--- a/.github/workflows/test_workflow_scripts/golang/echo_sql/golang-docker-macos.sh
+++ b/.github/workflows/test_workflow_scripts/golang/echo_sql/golang-docker-macos.sh
@@ -6,6 +6,25 @@ set -euo pipefail
 # for the below source make it such a way that if the file is not present or already present it does not error
 source ./../../.github/workflows/test_workflow_scripts/test-iid-macos.sh
 
+# ---------------------------------------------------------------------------
+# Docker daemon readiness barrier. On the self-hosted macOS runner Docker
+# Desktop / colima can still be finishing startup when the job begins; a
+# `docker compose build` fired against a not-yet-ready daemon fails the whole
+# lane. Poll `docker info` (bounded) rather than assuming the daemon is up.
+# ---------------------------------------------------------------------------
+wait_for_docker_daemon() {
+    local deadline=$(( SECONDS + 120 ))
+    until docker info >/dev/null 2>&1; do
+        if [ "$SECONDS" -ge "$deadline" ]; then
+            echo "ERROR: Docker daemon not ready after 120s. Is Docker Desktop/colima running on the runner?"
+            exit 1
+        fi
+        sleep 2
+    done
+    echo "Docker daemon is ready."
+}
+wait_for_docker_daemon
+
 # Function to find available port
 find_available_port() {
     local start_port=${1:-6000}
@@ -75,6 +94,35 @@ for file in $(find . -maxdepth 1 -type f \( -name "*.yml" -o -name "*.yaml" -o -
     fi
 done
 
+# ---------------------------------------------------------------------------
+# Defense-in-depth: normalize the Postgres health gate to a TCP probe.
+#
+# The DURABLE fix lives upstream in the sample's compose (keploy/samples-go#237).
+# Background: the stock healthcheck was `pg_isready -U postgres`, which probes the
+# UNIX SOCKET. During the postgres image's first-boot init the entrypoint runs a
+# TEMPORARY socket-only server (listen_addresses empty, init.sql runs) before the
+# real server binds 0.0.0.0:5432 — so the socket probe flips the container
+# "healthy" seconds before the TCP listener exists; Compose then releases go-app,
+# whose TCP connect (host=postgresDb:5432, 10s single-attempt, NO retry) is
+# refused and it Fatal()s -> exit 1, the app port never opens, record fails. Wide
+# on the emulated amd64 postgres:10.5 image on Apple-silicon runners, so the race
+# is near-permanent there. (Reproduced deterministically on Linux by widening the
+# init window: socket healthcheck -> go-app exit 1 "connect: connection refused";
+# TCP healthcheck -> connects cleanly.)
+#
+# We also fix it here, IDEMPOTENTLY, so this lane stays green even when it checks
+# out a samples-go revision predating #237, and to cover the path where keploy
+# recreates (rather than reuses) the postgres service. Once #237 is in the pinned
+# samples-go these seds simply no-op (the target strings are already gone). go-app
+# is additionally protected by the wait_for_postgres_ready TCP barrier below.
+# ---------------------------------------------------------------------------
+for cf in docker-compose.yml docker-compose.yaml; do
+    [ -f "$cf" ] || continue
+    sed -i '' 's|pg_isready -U postgres -d postgres|pg_isready -h 127.0.0.1 -p 5432 -U postgres -d postgres|g' "$cf" 2>/dev/null || true
+    sed -i '' 's|start_period: 30s|start_period: 90s|g' "$cf" 2>/dev/null || true
+    sed -i '' 's|retries: 5|retries: 30|g' "$cf" 2>/dev/null || true
+done
+
 # Build Docker Image(s)
 docker compose build
 
@@ -100,16 +148,74 @@ container_kill() {
     sudo kill $pid
 }
 
+# Dump app + DB diagnostics. Called when a readiness barrier times out so the CI
+# log shows WHY (app exited, DB unreachable, ...) instead of a bare timeout.
+dump_diag() {
+    echo "===== DIAGNOSTICS (${1:-unknown}) ====="
+    docker compose ps -a 2>&1 || true
+    echo "----- app container logs (${APP_CONTAINER}) -----"
+    docker logs --tail 200 "$APP_CONTAINER" 2>&1 || true
+    echo "----- postgres container logs (${DB_CONTAINER}) -----"
+    docker logs --tail 200 "$DB_CONTAINER" 2>&1 || true
+    echo "===== END DIAGNOSTICS ====="
+}
+
+# Bring Postgres up and block until it accepts TCP connections BEFORE keploy
+# starts the app, so:
+#   1. the go-app never races a not-yet-listening DB (its connect has a 10s,
+#      NO-RETRY timeout and Fatal()s -> exit 1 on failure), and
+#   2. the slow, emulated DB init does NOT eat into the --record-timer window
+#      (that timer starts counting the moment keploy runs `docker compose up`).
+# When keploy's `docker compose up` reuses this already-running postgres (same
+# project + service name), `depends_on: service_healthy` releases the app
+# immediately against a fully-initialised DB. If keploy instead recreates the
+# service, the TCP healthcheck (fixed in samples-go#237, and force-normalized by
+# the sed above) is what keeps the gate correct — so the app is protected on
+# either path.
+wait_for_postgres_ready() {
+    echo "Pre-starting postgres and waiting for it to accept TCP connections..."
+    docker compose up -d postgres
+    local ready=false
+    for _ in $(seq 1 90); do
+        # Probe over TCP (127.0.0.1), exactly like the app connects. This only
+        # succeeds once the REAL server is listening, so it survives the init
+        # temp-server bounce (socket-up / TCP-down) that fools pg_isready's
+        # default socket probe.
+        if docker exec "$DB_CONTAINER" pg_isready -h 127.0.0.1 -p 5432 -U postgres -d postgres >/dev/null 2>&1; then
+            ready=true
+            break
+        fi
+        sleep 2
+    done
+    if [ "$ready" = false ]; then
+        echo "ERROR: postgres (${DB_CONTAINER}) did not accept TCP connections within 180s."
+        dump_diag "postgres-readiness timeout"
+        exit 1
+    fi
+    echo "Postgres is TCP-ready."
+}
+
 send_request(){
     echo "Sending requests to the application..."
-    sleep 10
-    app_started=false
-    while [ "$app_started" = false ]; do
-        if curl -X GET http://localhost:${APP_PORT}/health; then
+    # Bounded wait-for-app-readiness barrier. Poll the app port until it actually
+    # serves an HTTP response (any status is fine — /health maps to GET /:param
+    # and 404s, which still proves the HTTP server AND its DB connection are up).
+    # No bare sleep as the barrier; on timeout dump app + DB logs and fail loudly
+    # instead of looping forever against a dead port (the old `while` loop hung
+    # until the job/record timer, hiding the real cause).
+    local app_started=false
+    for _ in $(seq 1 60); do
+        if curl --silent --output /dev/null "http://localhost:${APP_PORT}/health"; then
             app_started=true
+            break
         fi
-        sleep 3
+        sleep 2
     done
+    if [ "$app_started" = false ]; then
+        echo "ERROR: app on port ${APP_PORT} did not become ready within 120s."
+        dump_diag "app-readiness timeout"
+        return 1
+    fi
     echo "App started"
     # Make curl calls to record the test cases and mocks.
     curl --request POST \
@@ -139,6 +245,12 @@ do_record_iteration() {
     local label="${extra_flags:+_json}"
     local container_name="${APP_CONTAINER}"
     local log_file_name="${APP_CONTAINER}_${i}${label}"
+
+    # Deterministic barrier: DB must be up and TCP-ready before keploy launches
+    # the app (see wait_for_postgres_ready). keploy's `docker compose up` reuses
+    # this postgres, so the app connects on its first, no-retry attempt.
+    wait_for_postgres_ready
+
     send_request &
 
     # shellcheck disable=SC2086


### PR DESCRIPTION
## What

Fixes the flaky `run_golang_docker_macos / echo-sql` lane (issue #4335).

**Root cause:** the echo-sql sample's compose healthcheck is `pg_isready -U postgres`, which probes the **unix socket**. During the postgres image's first-boot init a temporary socket-only server runs `init.sql` while TCP is not yet listening — so the socket probe reports `healthy` before `127.0.0.1:5432` accepts. `depends_on: service_healthy` then releases `go-app`, whose TCP connect (`host=postgresDb:5432`, single attempt, no retry) is refused → the app `Fatal()`s → exit 1 → record fails. On the emulated amd64 `postgres:10.5` image on Apple-silicon runners the init window is wide, so it's near-permanent. Reproduced deterministically on Linux by widening the init window.

## Fix

The **durable** fix is upstream in the sample: **keploy/samples-go#237** switches the healthcheck to a TCP probe (benefits both CI lanes + all downstream users). This PR hardens the macOS lane's CI orchestration so it is robust regardless of samples-go ordering:

- **Pre-start postgres and block on a TCP-ready barrier** (`wait_for_postgres_ready`) before keploy launches the app — the app's connect is single-attempt/no-retry, and this also keeps the slow emulated init out of the `--record-timer` window.
- **Idempotently normalize the compose healthcheck to a TCP probe** as defense-in-depth — a no-op once #237 is in the pinned samples-go, and it also covers the path where keploy recreates (vs reuses) the postgres service.
- **Docker-daemon readiness barrier** for a cold colima / Docker Desktop on the self-hosted runner.
- **Replace bare `sleep` barriers with bounded condition-polls** that dump app + DB diagnostics and fail loudly on timeout, instead of the old `sleep 10` + unbounded loop that hung until the timer and hid the cause.

No retries/skips/sleeps-as-barriers added to the product path; Linux lane (`golang-docker.sh`) is untouched and stays green.

Fixes #4335
