### PR TITLE
fix(agent): suppress memory-pressure-orphaned test cases at window close

### DIFF
--- a/.github/workflows/gomem-atomic-drop-regression.yml
+++ b/.github/workflows/gomem-atomic-drop-regression.yml
@@ -1,0 +1,70 @@
+name: Gomem Atomic-Drop Regression (Linux)
+# Deterministic regression guard for issue #4336 — the go-memory-load-mongo
+# flake where the agent drops a captured test case's outgoing mock under memory
+# pressure while STILL persisting the test case, so replay reports
+# `mock mismatch ... no_mocks candidates:0` for it and the lane fails the 4%
+# tolerance.
+#
+# The fix makes a pressure mock-drop ATOMIC with its owning test case: every
+# pre-persistence drop (relay tee -> MarkMockIncomplete -> emitMockCore; AddMock's
+# pressure drop; SetMemoryPressure's buffer wipe) records the mock's request
+# timestamp in a never-pruned sync-mock ledger, and the TC-persist gates
+# (incoming/http.go, conn.Capture, routes/record.go) suppress any test case whose
+# HTTP window owns a dropped mock — so no persisted test case ever references a
+# mock that was dropped.
+#
+# WHY A UNIT-TEST LANE (not only the e2e go-memory-load-mongo lane): the drop is
+# only exercised when a memory-pressure PAUSE overlaps an in-flight large mock,
+# which on a fast multi-core box is rare (pauses recover before a chunk is gated)
+# — the 2-vCPU CI runner is the reliable rate validator (see golang_docker.yml's
+# go-memory-load-mongo job). These tests instead drive the atomic-drop mechanism
+# DETERMINISTICALLY and with -race, so a regression is caught on every PR
+# regardless of the host's pressure timing. The load-bearing case
+# (TestDroppedMockLedger_SurvivesPruneWherePressureRangeDoesNot) reproduces the
+# exact prune race the older pressure-range check (#4338) could not close.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  atomic-drop-regression:
+    name: atomic-drop-regression
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      CGO_ENABLED: "1" # pg_query_go links libpg_query via cgo; the agent tree needs it to build
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Install build essentials (cgo)
+        run: |
+          sudo apt -y update
+          sudo apt -y install build-essential gcc libc-dev pkg-config
+
+      - name: Install dependencies
+        run: go get .
+
+      # -race so a concurrency regression in the ledger / gate paths is caught.
+      # -count=1 defeats the test cache so the guard always executes.
+      # The explicit -run list is the regression surface for #4336; keep it in
+      # sync when adding atomic-drop tests. It spans all four packages the fix
+      # touches: the ledger (syncMock), the write-half drop site (supervisor),
+      # and the read-half TC-suppression gates (conn, incoming).
+      - name: Run atomic-drop regression tests (-race)
+        run: |
+          go test -race -count=1 -v \
+            -run 'TestTCHasDroppedMock_Ownership|TestRecordDroppedMock_ZeroIgnored|TestAddMock_PressureDropRecordsLedger|TestBufferWipeDropRecordsLedger|TestRecordDroppedMock_CapEviction|TestDroppedMockLedger_SurvivesPruneWherePressureRangeDoesNot|TestAddMock_ReusableLifetimeDropNotRecorded|TestBufferWipe_ReusableLifetimeDropNotRecorded|TestCapture_TCDroppedByLedger|TestCapture_TCKeptWhenNoDrop|TestCapture_MockAndTCDroppedAtomicallyUnderPressure|TestCapture_PruneRace_CaptureCheckLoadBearing|TestCapture_TCKeptWhenNoPressureOverlap|TestEmitMock_IncompleteDropRecordsLedger|TestEmitMock_IncompleteDropZeroTsIgnored|TestEmitMock_SessionLifetimeDropNotRecorded' \
+            ./pkg/agent/proxy/syncMock/... \
+            ./pkg/agent/hooks/conn/... \
+            ./pkg/agent/proxy/supervisor/... \
+            ./pkg/agent/proxy/incoming/...

--- a/pkg/agent/hooks/conn/atomic_drop_test.go
+++ b/pkg/agent/hooks/conn/atomic_drop_test.go
@@ -1,0 +1,112 @@
+package conn
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	syncMock "go.keploy.io/server/v3/pkg/agent/proxy/syncMock"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// TestCapture_TCDroppedByLedger is the load-bearing regression test for the
+// atomic mock-drop / test-case-drop fix (#4336). It isolates the NEW mechanism
+// from the older pressure-range overlap heuristic:
+//
+//   - No memory-pressure range is ever opened on the manager, so
+//     PressureEverActive() is false and pressureOverlappedWindow() short-circuits
+//     to false. The ONLY thing that can suppress the test case here is the
+//     dropped-mock ledger term (droppedMockInWindow -> TCHasDroppedMock).
+//
+//   - A mock owned by the exchange window is recorded as dropped via
+//     RecordDroppedMock — exactly what supervisor.Session.emitMockCore does when
+//     the relay tee gates a chunk under memory pressure and the mongo mock is
+//     abandoned. Its owning HTTP test case must therefore NOT be emitted, or
+//     replay would report no_mocks / candidates:0 for it.
+//
+// Revert the `|| droppedMockInWindow(...)` term in Capture and this test fails
+// (the TC is emitted with a dropped mock). Restore it and it passes. That is the
+// load-bearing proof.
+func TestCapture_TCDroppedByLedger(t *testing.T) {
+	logger := zap.NewNop()
+
+	mgr := syncMock.New(logger)
+	outCh := make(chan *models.Mock, 8)
+	mgr.SetOutputChannel(outCh)
+
+	// The exchange window and a dropped mock whose request timestamp falls
+	// inside it. No SetMemoryPressure — this proves the ledger, not pressure
+	// ranges, is what suppresses the TC.
+	reqTime := time.Now().Add(-time.Minute)
+	droppedReqTs := time.Now() // inside [reqTime, resTime]
+	resTime := time.Now().Add(time.Minute)
+
+	mgr.RecordDroppedMock(droppedReqTs)
+
+	if !mgr.TCHasDroppedMock(reqTime, resTime) {
+		t.Fatalf("precondition: expected the recorded drop to be owned by the window")
+	}
+	if mgr.PressureEverActive() {
+		t.Fatalf("precondition: no pressure range should exist in this test — the drop must be the only suppression signal")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "http://example.com/api/items", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	ctx := syncMock.NewContext(context.Background(), mgr)
+	tc := make(chan *models.TestCase, 1)
+
+	// synchronous=false so Capture does not itself call ResolveRange (which
+	// resolves via the package global); the only decision under test is whether
+	// the test case is emitted, and it must read the ctx-carried manager.
+	Capture(ctx, logger, tc, req, newCaptureResp(), reqTime, resTime, models.IncomingOptions{}, false, false, 8080)
+
+	select {
+	case got := <-tc:
+		t.Fatalf("atomicity violated: a mock owned by this window was dropped, but Capture still emitted the test case %q — replay would report no_mocks for it", got.Name)
+	default:
+		// expected: the test case was dropped together with its mock.
+	}
+}
+
+// TestCapture_TCKeptWhenNoDrop is the companion proving the ledger gate does not
+// over-suppress: a window that owns no dropped mock must still have its test
+// case emitted.
+func TestCapture_TCKeptWhenNoDrop(t *testing.T) {
+	logger := zap.NewNop()
+
+	mgr := syncMock.New(logger)
+	outCh := make(chan *models.Mock, 8)
+	mgr.SetOutputChannel(outCh)
+
+	// Record a drop that is OUTSIDE this window (an unrelated earlier exchange)
+	// to prove the gate is window-scoped, not a global kill-switch.
+	mgr.RecordDroppedMock(time.Now().Add(-time.Hour))
+
+	reqTime := time.Now().Add(-time.Minute)
+	resTime := time.Now().Add(time.Minute)
+
+	req, err := http.NewRequest(http.MethodGet, "http://example.com/api/items", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	ctx := syncMock.NewContext(context.Background(), mgr)
+	tc := make(chan *models.TestCase, 1)
+
+	Capture(ctx, logger, tc, req, newCaptureResp(), reqTime, resTime, models.IncomingOptions{}, false, false, 8080)
+
+	select {
+	case got := <-tc:
+		if got.HTTPResp.StatusCode != http.StatusOK {
+			t.Fatalf("expected a captured test case with status 200, got %d", got.HTTPResp.StatusCode)
+		}
+		// expected: TC kept — the only recorded drop is outside its window.
+	default:
+		t.Fatalf("over-suppression: no mock owned by this window was dropped, but Capture withheld the test case")
+	}
+}

--- a/pkg/agent/hooks/conn/pressure_atomicity_test.go
+++ b/pkg/agent/hooks/conn/pressure_atomicity_test.go
@@ -1,0 +1,281 @@
+package conn
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	syncMock "go.keploy.io/server/v3/pkg/agent/proxy/syncMock"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// newCaptureResp builds a minimal, well-formed HTTP response that flows all the
+// way through Capture (small body, no encoding, not filtered) so the only thing
+// deciding whether a test case is emitted is the memory-pressure guard.
+func newCaptureResp() *http.Response {
+	return &http.Response{
+		Status:     "200 OK",
+		StatusCode: http.StatusOK,
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     http.Header{"Content-Type": {"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+	}
+}
+
+// TestCapture_MockAndTCDroppedAtomicallyUnderPressure is the regression test for
+// the go-memory-load-mongo (~75% CI failure) flake: under memory pressure a
+// test case was persisted while one of its outgoing mocks had already been
+// dropped by syncMock.AddMock, so replay reported "no mocks" / EOF for it.
+//
+// It drives the exact orphan scenario deterministically:
+//
+//   - pressure is active for a window; an outgoing mock whose request falls in
+//     that window is offered to AddMock and DROPPED (the mock loss),
+//   - pressure then CLEARS, so memoryguard.IsRecordingPaused() is false by the
+//     time Capture runs (the case the old top-of-Capture guard missed),
+//   - Capture is invoked with an exchange window that overlapped the pressure
+//     interval.
+//
+// Invariant asserted: mock-drop and TC-drop are ATOMIC. Because a mock was
+// dropped, the test case must NOT be emitted. Before the fix Capture only
+// checked the live IsRecordingPaused() flag (false here) and emitted the TC —
+// this test fails. After the fix Capture also checks whether pressure overlapped
+// the window and drops the TC — this test passes.
+func TestCapture_MockAndTCDroppedAtomicallyUnderPressure(t *testing.T) {
+	logger := zap.NewNop()
+
+	mgr := syncMock.New(logger)
+	// Wire an output channel so AddMock takes its real forward/drop path
+	// instead of the "unbound" buffer-and-warn branch.
+	outCh := make(chan *models.Mock, 8)
+	mgr.SetOutputChannel(outCh)
+
+	// A wide window guarantees it contains the pressure interval we open below,
+	// with no reliance on sleeps or wall-clock durations.
+	reqTime := time.Now().Add(-time.Minute)
+
+	// --- Simulate a pause mid-test-case and lose one of its mocks. ---
+	mgr.SetMemoryPressure(true) // opens a pressure interval; memoryPause = true
+	droppedMock := &models.Mock{
+		Kind: models.Mongo,
+		Spec: models.MockSpec{
+			ReqTimestampMock: time.Now(), // inside the still-open pressure interval
+			ResTimestampMock: time.Now(),
+		},
+	}
+	mgr.AddMock(droppedMock)     // must be dropped: pressure active + req in interval
+	mgr.SetMemoryPressure(false) // clears pressure -> IsRecordingPaused() is false now
+
+	if _, dropped, _, _ := mgr.GetDropStats(); dropped != 1 {
+		t.Fatalf("precondition: expected the outgoing mock to be dropped under pressure, got pressureDropped=%d", dropped)
+	}
+	// The dropped mock must NOT have been forwarded downstream.
+	select {
+	case m := <-outCh:
+		t.Fatalf("precondition: dropped mock was unexpectedly forwarded: %+v", m)
+	default:
+	}
+
+	resTime := time.Now().Add(time.Minute) // window [reqTime,resTime] overlaps the pressure interval
+
+	req, err := http.NewRequest(http.MethodGet, "http://example.com/api/items", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp := newCaptureResp()
+
+	ctx := syncMock.NewContext(context.Background(), mgr)
+	tc := make(chan *models.TestCase, 1)
+
+	// synchronous=false so Capture does not itself call ResolveRange; the only
+	// decision under test is whether the test case is emitted.
+	Capture(ctx, logger, tc, req, resp, reqTime, resTime, models.IncomingOptions{}, false, false, 8080)
+
+	select {
+	case got := <-tc:
+		t.Fatalf("atomicity violated: a mock for this window was dropped, but Capture still emitted the test case %q — replay would report no_mocks for it", got.Name)
+	default:
+		// expected: the test case was dropped together with its mock.
+	}
+}
+
+// pruneWait must exceed syncMock's pressureRangeStaleness (7s), the horizon
+// after which SetMemoryPressure prunes a CLOSED pressure range. It is
+// duplicated here (the const is unexported in package manager) with margin for
+// scheduler jitter so the prune in TestCapture_PruneRace_CaptureCheckLoadBearing
+// is deterministic, not flaky.
+const pruneWait = 7500 * time.Millisecond
+
+// TestCapture_PruneRace_CaptureCheckLoadBearing reproduces the ACTUAL prune race
+// behind the go-memory-load-mongo flake and proves the Capture-level pressure
+// check is load-bearing — not the softer "pressure cleared but range still
+// present" case above, but the real one where the range is GONE by the time the
+// late routes/record.go check runs.
+//
+// The record pipeline has two pressure checkpoints for one test case:
+//
+//	Stage 1  Capture() — the early check THIS fix adds (util.go). It runs in the
+//	         capture goroutine, close to window-close, while the range is fresh.
+//	Stage 2  routes/record.go:372 WasPressureActiveInWindow(req,resp) — the late
+//	         check, run only when the TC is dequeued from the ~100-deep tcChan and
+//	         streamed to the CLI. Under load this lags window-close by the tcChan
+//	         buffer depth + build + handoff.
+//
+// syncMock prunes a closed pressure range 7s after it ends (SetMemoryPressure's
+// staleness reaper). If Stage 2 lags past that horizon, the range that dropped
+// the mock is already pruned, WasPressureActiveInWindow returns false, and the
+// orphaned TC is streamed to disk -> replay hits no_mocks/EOF -> >4% tolerance ->
+// the lane fails. That is the ~75%-red flake.
+//
+// This test drives the REAL Capture and the REAL record.go decision function
+// (WasPressureActiveInWindow, the exact call at record.go:372), with a REAL
+// prune performed by the REAL SetMemoryPressure reaper in between:
+//
+//	WITH the fix:    Stage 1 suppresses the TC (range still present) -> nothing
+//	                 ever reaches Stage 2 -> no orphan.
+//	WITHOUT the fix: Stage 1 emits the TC (old Capture only checked the live
+//	                 IsRecordingPaused flag, false here) -> Stage 2 runs after the
+//	                 prune -> range gone -> TC slips through -> orphan on disk.
+//
+// Revert the `|| pressureOverlappedWindow(...)` term in Capture and this test
+// fails; restore it and it passes. That is the load-bearing proof.
+//
+// HONEST SCOPE: this proves the early check catches an orphan the late check
+// misses once the range is pruned. It does NOT prove the early check is
+// race-free — Stage 1 itself runs in a captureHookSem-gated goroutine whose
+// respTimestamp is stamped before the semaphore acquire, so under sustained
+// overload Stage 1 can also lag past the prune horizon. The fix is a race-WINDOW
+// REDUCTION (it removes the tcChan buffer + build + handoff from the check lag),
+// not a hard atomicity guarantee. See util.go's Capture comment.
+func TestCapture_PruneRace_CaptureCheckLoadBearing(t *testing.T) {
+	logger := zap.NewNop()
+
+	mgr := syncMock.New(logger)
+	outCh := make(chan *models.Mock, 8)
+	mgr.SetOutputChannel(outCh)
+
+	// --- Open a pressure interval and lose one in-window mock. ---
+	mgr.SetMemoryPressure(true)
+	reqTime := time.Now()
+	droppedMock := &models.Mock{
+		Kind: models.Mongo,
+		Spec: models.MockSpec{
+			ReqTimestampMock: time.Now(), // inside the still-open pressure interval
+			ResTimestampMock: time.Now(),
+		},
+	}
+	mgr.AddMock(droppedMock)     // dropped: pressure active + req in interval
+	resTime := time.Now()        // window [reqTime,resTime] overlaps the interval
+	mgr.SetMemoryPressure(false) // close the interval (end ~= now); range still PRESENT
+
+	if _, dropped, _, _ := mgr.GetDropStats(); dropped != 1 {
+		t.Fatalf("precondition: expected the outgoing mock to be dropped under pressure, got pressureDropped=%d", dropped)
+	}
+	// Sanity: while the range is fresh, BOTH checkpoints would catch the overlap.
+	// The bug is purely about WHEN Stage 2 runs — so confirm it is catchable now.
+	if overlap, _ := mgr.WasPressureActiveInWindow(reqTime, resTime); !overlap {
+		t.Fatalf("precondition: expected pressure overlap to be visible before the prune")
+	}
+
+	// === Stage 1: the Capture-level early check (the fix). Ranges are fresh. ===
+	ctx := syncMock.NewContext(context.Background(), mgr)
+	tc := make(chan *models.TestCase, 1)
+	req, err := http.NewRequest(http.MethodGet, "http://example.com/api/items", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	Capture(ctx, logger, tc, req, newCaptureResp(), reqTime, resTime, models.IncomingOptions{}, false, false, 8080)
+
+	var emitted *models.TestCase
+	select {
+	case emitted = <-tc:
+	default:
+	}
+
+	// === Prune: cross the staleness horizon, then fire the REAL reaper. ===
+	// SetMemoryPressure prunes closed ranges older than pressureRangeStaleness on
+	// every call; this false->false call is a pure prune trigger (no buffer wipe,
+	// which only runs on the ->true transition).
+	time.Sleep(pruneWait)
+	mgr.SetMemoryPressure(false)
+
+	// The range that dropped the mock is now gone: the late check can no longer
+	// see the overlap.
+	if overlap, _ := mgr.WasPressureActiveInWindow(reqTime, resTime); overlap {
+		t.Fatalf("precondition: expected the closed pressure range to be pruned after %s", pruneWait)
+	}
+
+	// === Stage 2: the late routes/record.go check, faithfully invoked. ===
+	// This is exactly record.go:372: WasPressureActiveInWindow over the TC's
+	// [HTTPReq.Timestamp, HTTPResp.Timestamp]. If Stage 1 already dropped the TC
+	// there is nothing to check; if it emitted one, the pruned range lets it slip.
+	var survived *models.TestCase
+	if emitted != nil {
+		if lateOverlap, _ := mgr.WasPressureActiveInWindow(emitted.HTTPReq.Timestamp, emitted.HTTPResp.Timestamp); !lateOverlap {
+			survived = emitted // record.go streams it to disk -> orphan
+		}
+	}
+
+	if survived != nil {
+		t.Fatalf("prune race: orphan TC %q reached disk — its mock was dropped under pressure, "+
+			"but the late record.go check missed it because the range was pruned. The Capture-level "+
+			"check must suppress it at window-close.", survived.Name)
+	}
+}
+
+// TestCapture_TCKeptWhenNoPressureOverlap is the companion case proving the fix
+// does not over-suppress: a calm window (no pressure interval overlaps it) whose
+// mock is kept must still have its test case emitted.
+func TestCapture_TCKeptWhenNoPressureOverlap(t *testing.T) {
+	logger := zap.NewNop()
+
+	mgr := syncMock.New(logger)
+	outCh := make(chan *models.Mock, 8)
+	mgr.SetOutputChannel(outCh)
+
+	// No SetMemoryPressure at all -> no pressure ranges -> nothing overlaps.
+	keptMock := &models.Mock{
+		Kind: models.Mongo,
+		Spec: models.MockSpec{
+			ReqTimestampMock: time.Now(),
+			ResTimestampMock: time.Now(),
+		},
+	}
+	mgr.AddMock(keptMock) // no pressure -> kept, forwarded to outCh
+
+	select {
+	case <-outCh:
+		// expected: mock kept and forwarded.
+	default:
+		t.Fatalf("precondition: expected the mock to be forwarded when no pressure is active")
+	}
+
+	reqTime := time.Now().Add(-time.Minute)
+	resTime := time.Now().Add(time.Minute)
+
+	req, err := http.NewRequest(http.MethodGet, "http://example.com/api/items", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp := newCaptureResp()
+
+	ctx := syncMock.NewContext(context.Background(), mgr)
+	tc := make(chan *models.TestCase, 1)
+
+	Capture(ctx, logger, tc, req, resp, reqTime, resTime, models.IncomingOptions{}, false, false, 8080)
+
+	select {
+	case got := <-tc:
+		if got.HTTPResp.StatusCode != http.StatusOK {
+			t.Fatalf("expected a captured test case with status 200, got %d", got.HTTPResp.StatusCode)
+		}
+		// expected: calm test case kept.
+	default:
+		t.Fatalf("expected the test case to be emitted when no pressure overlapped its window")
+	}
+}

--- a/pkg/agent/hooks/conn/util.go
+++ b/pkg/agent/hooks/conn/util.go
@@ -68,8 +68,65 @@ const MaxTestCaseSize = 5 * 1024 * 1024 // 5 MB
 // are skipped during recording and only body size is stored.
 const LargeBodyThreshold = 1 * 1024 * 1024 // 1 MB
 
+// pressureOverlappedWindow reports whether a memory-pressure interval overlapped
+// the exchange window [reqTime, resTime]. syncMock.AddMock drops any outgoing
+// mock whose request timestamp falls inside a pressure interval, so a test case
+// whose window overlapped pressure may already have lost one or more of its
+// mocks. It resolves the same manager the mock-drop path uses
+// (FromContextOrGlobal, matching the NextTestID call site below), so the drop
+// decision and the mock-drop decision read the same pressure ranges.
+func pressureOverlappedWindow(ctx context.Context, reqTime, resTime time.Time) bool {
+	mgr := syncMock.FromContextOrGlobal(ctx)
+	if mgr == nil {
+		return false
+	}
+	// Lock-free fast path: if pressure has never activated this session (the
+	// common case on a healthy run) no range can overlap, so skip the
+	// lock-taking windowed scan. Mirrors incoming/http.go's authoritative gate
+	// so this backstop costs nothing per test case until pressure actually hits.
+	if !mgr.PressureEverActive() {
+		return false
+	}
+	overlapped, _ := mgr.WasPressureActiveInWindow(reqTime, resTime)
+	return overlapped
+}
+
 func Capture(ctx context.Context, logger *zap.Logger, t chan *models.TestCase, req *http.Request, resp *http.Response, reqTimeTest time.Time, resTimeTest time.Time, opts models.IncomingOptions, synchronous bool, mapping bool, appPort uint16) {
-	if memoryguard.IsRecordingPaused() {
+	// Drop this capture when memory pressure means its paired outgoing mock(s)
+	// may not have been recorded. Two cases must both be caught here:
+	//
+	//  1. Pressure is active RIGHT NOW (IsRecordingPaused) — the classic
+	//     "recording paused" skip.
+	//  2. Pressure is NOT active now but overlapped this exchange's window
+	//     [reqTimeTest, resTimeTest]. syncMock.AddMock drops any outgoing mock
+	//     whose request fell inside a pressure interval, so persisting this
+	//     test case would orphan it ("no mocks" / EOF at replay).
+	//
+	// Case 2 is a BACKSTOP here. The AUTHORITATIVE, reliable pressure-overlap
+	// gate for the go-memory-load-mongo flake lives one layer up, in the parser
+	// hot loop (incoming/http.go pressureOverlappedExchange), where it runs
+	// SYNCHRONOUSLY at window-close — before the captureHookSem acquire — so the
+	// pressure range that put the paired mock at risk cannot yet have been pruned
+	// by syncMock's 7s staleness reaper.
+	//
+	//   Why this in-Capture check cannot be the primary gate: Capture runs inside
+	//   the captureHookSem-gated capture goroutine, and respTimestamp is stamped
+	//   BEFORE that semaphore is acquired. Under load the tcChan (100-deep) backs
+	//   up (the CLI drains it slowly), which blocks in-flight capture goroutines
+	//   on their `t <- testCase` send so they never release captureHookSem, which
+	//   in turn blocks the NEXT exchange's semaphore acquire. A check that runs
+	//   only after that acquire inherits the full backpressure lag and can fire
+	//   long after the range was pruned — a false negative that lets the orphan
+	//   through. (An earlier fix that placed the ONLY check here did not move the
+	//   CI failure rate for exactly this reason.)
+	//
+	//   Retained anyway because: (a) it is a cheap, correct second line of
+	//   defense whenever the range is still live at this point; (b) it covers the
+	//   IsRecordingPaused case and any CaptureHook caller that did not run the
+	//   window-close gate (e.g. the enterprise async path). It resolves the same
+	//   manager the mock-drop path uses (FromContextOrGlobal). record.go's check
+	//   at TC-stream time is the third, last-ditch layer.
+	if memoryguard.IsRecordingPaused() || pressureOverlappedWindow(ctx, reqTimeTest, resTimeTest) {
 		// Close bodies even when skipping capture to avoid resource leaks.
 		if req.Body != nil {
 			req.Body.Close()
@@ -450,6 +507,18 @@ func CaptureGRPC(ctx context.Context, logger *zap.Logger, t chan *models.TestCas
 
 	if http2Stream.GRPCReq == nil || http2Stream.GRPCResp == nil {
 		logger.Error("gRPC request or response is nil")
+		return
+	}
+
+	// Same early pressure check as the HTTP path: drop the stream when memory
+	// pressure overlapped its window, since AddMock may already have dropped a
+	// paired outgoing mock. Checked here — earlier in the pipeline than the
+	// routes/record.go recompute — so the lag to the check is shorter and the
+	// pressure range is more likely to still be present before the 7s staleness
+	// reaper prunes it. This is a race-window reduction, not a hard guarantee
+	// (see the Capture comment above). Runs before ResolveRange so the stream's
+	// mocks are not attributed to a TC that won't be sent.
+	if pressureOverlappedWindow(ctx, http2Stream.GRPCReq.Timestamp, http2Stream.GRPCResp.Timestamp) {
 		return
 	}
 

--- a/pkg/agent/hooks/conn/util.go
+++ b/pkg/agent/hooks/conn/util.go
@@ -91,6 +91,21 @@ func pressureOverlappedWindow(ctx context.Context, reqTime, resTime time.Time) b
 	return overlapped
 }
 
+// droppedMockInWindow reports whether an outgoing mock owned by this exchange's
+// window [reqTime, resTime] was actually dropped before persistence (#4336). It
+// is the precise, never-pruned companion to pressureOverlappedWindow: the drop
+// itself recorded the fact (TCHasDroppedMock reads the droppedMockReqs ledger),
+// so — unlike the pressure-range overlap heuristic, which is reaped 7s after a
+// range closes — the answer stays correct however long this backstop lags the
+// drop. Resolves the same manager the mock-drop path records into.
+func droppedMockInWindow(ctx context.Context, reqTime, resTime time.Time) bool {
+	mgr := syncMock.FromContextOrGlobal(ctx)
+	if mgr == nil {
+		return false
+	}
+	return mgr.TCHasDroppedMock(reqTime, resTime)
+}
+
 func Capture(ctx context.Context, logger *zap.Logger, t chan *models.TestCase, req *http.Request, resp *http.Response, reqTimeTest time.Time, resTimeTest time.Time, opts models.IncomingOptions, synchronous bool, mapping bool, appPort uint16) {
 	// Drop this capture when memory pressure means its paired outgoing mock(s)
 	// may not have been recorded. Two cases must both be caught here:
@@ -126,7 +141,8 @@ func Capture(ctx context.Context, logger *zap.Logger, t chan *models.TestCase, r
 	//   window-close gate (e.g. the enterprise async path). It resolves the same
 	//   manager the mock-drop path uses (FromContextOrGlobal). record.go's check
 	//   at TC-stream time is the third, last-ditch layer.
-	if memoryguard.IsRecordingPaused() || pressureOverlappedWindow(ctx, reqTimeTest, resTimeTest) {
+	if memoryguard.IsRecordingPaused() || pressureOverlappedWindow(ctx, reqTimeTest, resTimeTest) ||
+		droppedMockInWindow(ctx, reqTimeTest, resTimeTest) {
 		// Close bodies even when skipping capture to avoid resource leaks.
 		if req.Body != nil {
 			req.Body.Close()
@@ -519,6 +535,12 @@ func CaptureGRPC(ctx context.Context, logger *zap.Logger, t chan *models.TestCas
 	// (see the Capture comment above). Runs before ResolveRange so the stream's
 	// mocks are not attributed to a TC that won't be sent.
 	if pressureOverlappedWindow(ctx, http2Stream.GRPCReq.Timestamp, http2Stream.GRPCResp.Timestamp) {
+		return
+	}
+	// Atomic-drop gate (#4336): suppress the stream if one of the mocks its
+	// window owns was actually dropped before persistence. Race-free even after
+	// the pressure-range check above has been pruned. See droppedMockInWindow.
+	if droppedMockInWindow(ctx, http2Stream.GRPCReq.Timestamp, http2Stream.GRPCResp.Timestamp) {
 		return
 	}
 

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -189,6 +189,49 @@ const captureHookConcurrency = 16
 
 var captureHookSem = make(chan struct{}, captureHookConcurrency)
 
+// pressureOverlappedExchange reports whether a memory-pressure interval
+// overlapped the just-closed exchange window [reqTs, respTs]. syncMock.AddMock
+// drops any outgoing (e.g. Mongo) mock whose request timestamp fell inside a
+// pressure interval, so a test case whose window overlapped pressure may already
+// have lost one or more of its mocks; persisting it would orphan it
+// ("no mocks" / EOF at replay). This is the go-memory-load-mongo flake.
+//
+// CRITICAL — this MUST be called SYNCHRONOUSLY on the parser goroutine, at
+// window-close (right after respTimestamp is stamped), BEFORE the captureHookSem
+// acquire and the capture goroutine. That ordering is the whole point:
+//
+//   - syncMock prunes a CLOSED pressure range 7s after it ends
+//     (SetMemoryPressure's staleness reaper).
+//   - Under load the tcChan (100-deep) backs up because the CLI drains it
+//     slowly; a full tcChan blocks the capture goroutines on their `t <- tc`
+//     send, so they never release captureHookSem, so the NEXT exchange's parser
+//     goroutine blocks on the semaphore acquire. Any pressure check placed
+//     AFTER that acquire (as the earlier conn.Capture-level check was) therefore
+//     inherits the full backpressure lag and can run long after the range was
+//     pruned — returning a false negative and letting the orphan through. That
+//     is exactly why the first attempt (a check inside Capture) did NOT move the
+//     CI failure rate.
+//   - Called here, at window-close, the overlapping range has just ended (or is
+//     still open), so it cannot yet have been pruned: the decision is reliable
+//     regardless of how backed-up the capture pipeline is.
+//
+// Resolves the same manager the mock-drop path uses (FromContextOrGlobal), so
+// this check and AddMock read the same pressureRanges under the same lock.
+func pressureOverlappedExchange(ctx context.Context, reqTs, respTs time.Time) bool {
+	mgr := syncMock.FromContextOrGlobal(ctx)
+	if mgr == nil {
+		return false
+	}
+	// Lock-free fast path: if pressure has never activated this session (the
+	// common case on a healthy run) no range can overlap, so skip the
+	// lock-taking windowed scan and keep the parser hot loop contention-free.
+	if !mgr.PressureEverActive() {
+		return false
+	}
+	overlapped, _ := mgr.WasPressureActiveInWindow(reqTs, respTs)
+	return overlapped
+}
+
 // asyncPipeFeeder is the parser-side reader for streaming HTTP capture.
 // io.Copy on the forwarding path writes into it via Write (non-blocking,
 // drops on backpressure); the parseStreamingHTTP goroutine reads from
@@ -799,6 +842,14 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 		}
 		// Skip capture if memory pressure kicked in during the exchange
 		if shouldCapture && isIngressRecordingPaused() {
+			shouldCapture = false
+		}
+		// Skip capture if memory pressure OVERLAPPED this exchange's window even
+		// if it has cleared now: the paired outgoing mock may already have been
+		// dropped by syncMock.AddMock. Decided HERE — synchronously, at
+		// window-close, before the capture goroutine — so the pressure range is
+		// still fresh (not yet pruned). See pressureOverlappedExchange.
+		if shouldCapture && pressureOverlappedExchange(ctx, reqTimestamp, respTimestamp) {
 			shouldCapture = false
 		}
 
@@ -1531,7 +1582,14 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 		// pre-buffered).
 		reqTeeTruncated := reqCapture != nil && reqCapture.Truncated()
 		respTeeTruncated := respCapture != nil && respCapture.Truncated()
-		if captureEnabled && !reqTeeTruncated && !respTeeTruncated {
+		// Skip capture when memory pressure overlapped this exchange's window:
+		// the paired outgoing mock may already have been dropped, so persisting
+		// the TC would orphan it. Decided synchronously here — BEFORE the
+		// captureHookSem acquire below (which under tcChan backpressure can block
+		// long enough for the pressure range to be pruned) — so the range is
+		// still fresh and the decision is reliable. See pressureOverlappedExchange.
+		if captureEnabled && !reqTeeTruncated && !respTeeTruncated &&
+			!pressureOverlappedExchange(ctx, reqTimestamp, respTimestamp) {
 			select {
 			case captureHookSem <- struct{}{}:
 			case <-ctx.Done():
@@ -1715,6 +1773,18 @@ func (pm *IngressProxyManager) parseStreamingHTTP(ctx context.Context, logger *z
 		}
 		if respTimestamp.Before(reqTimestamp) {
 			respTimestamp = reqTimestamp
+		}
+
+		// Skip capture when memory pressure overlapped this exchange's window:
+		// the paired outgoing mock may already have been dropped, so the TC would
+		// orphan at replay. Decided synchronously HERE, at window-close, BEFORE
+		// the captureHookSem acquire below — because under tcChan backpressure
+		// that acquire can block long past syncMock's 7s range-prune horizon,
+		// which is exactly what let the orphan slip through the later in-goroutine
+		// check. At window-close the overlapping range cannot yet be pruned, so
+		// the decision is reliable. See pressureOverlappedExchange.
+		if pressureOverlappedExchange(ctx, reqTimestamp, respTimestamp) {
+			continue
 		}
 
 		// Emit in a goroutine so the parser loop is never blocked by a

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -232,6 +232,35 @@ func pressureOverlappedExchange(ctx context.Context, reqTs, respTs time.Time) bo
 	return overlapped
 }
 
+// droppedMockInExchange reports whether an outgoing mock whose request timestamp
+// falls inside this exchange's window [reqTs, respTs] was actually DROPPED
+// before persistence (memory-pressure chunk gate at emitMockCore, or AddMock's
+// pressure drop). It is the authoritative, race-free companion to
+// pressureOverlappedExchange:
+//
+//   - pressureOverlappedExchange suppresses a TC whose window merely OVERLAPPED
+//     a pressure range. That is conservative (it can over-suppress calm TCs)
+//     and, worse, DEFEATED BY PRUNING — syncMock reaps a closed pressure range
+//     7s after it ends, and under load this gate can run long after that, so the
+//     overlap is invisible and the orphan slips through. That prune race is the
+//     residual go-memory-load-mongo flake this fix closes.
+//
+//   - droppedMockInExchange instead asks whether a mock owned by this window was
+//     genuinely lost. The drop itself recorded the fact (TCHasDroppedMock reads
+//     the never-pruned droppedMockReqs ledger), so the answer is correct however
+//     long this gate lags the drop — and precise (no calm-TC over-suppression).
+//
+// Both are kept: the pressure-range check stays as a conservative backstop, and
+// this is the load-bearing, atomic one. Resolves the same manager the mock-drop
+// path records into (FromContextOrGlobal), so gate and drop read one ledger.
+func droppedMockInExchange(ctx context.Context, reqTs, respTs time.Time) bool {
+	mgr := syncMock.FromContextOrGlobal(ctx)
+	if mgr == nil {
+		return false
+	}
+	return mgr.TCHasDroppedMock(reqTs, respTs)
+}
+
 // asyncPipeFeeder is the parser-side reader for streaming HTTP capture.
 // io.Copy on the forwarding path writes into it via Write (non-blocking,
 // drops on backpressure); the parseStreamingHTTP goroutine reads from
@@ -850,6 +879,13 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 		// window-close, before the capture goroutine — so the pressure range is
 		// still fresh (not yet pruned). See pressureOverlappedExchange.
 		if shouldCapture && pressureOverlappedExchange(ctx, reqTimestamp, respTimestamp) {
+			shouldCapture = false
+		}
+		// Atomic-drop gate (#4336): suppress the TC if one of the mocks its
+		// window owns was actually dropped before persistence. Race-free even
+		// when the pressure-range check above has already been pruned. See
+		// droppedMockInExchange.
+		if shouldCapture && droppedMockInExchange(ctx, reqTimestamp, respTimestamp) {
 			shouldCapture = false
 		}
 
@@ -1589,7 +1625,8 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 		// long enough for the pressure range to be pruned) — so the range is
 		// still fresh and the decision is reliable. See pressureOverlappedExchange.
 		if captureEnabled && !reqTeeTruncated && !respTeeTruncated &&
-			!pressureOverlappedExchange(ctx, reqTimestamp, respTimestamp) {
+			!pressureOverlappedExchange(ctx, reqTimestamp, respTimestamp) &&
+			!droppedMockInExchange(ctx, reqTimestamp, respTimestamp) {
 			select {
 			case captureHookSem <- struct{}{}:
 			case <-ctx.Done():
@@ -1784,6 +1821,12 @@ func (pm *IngressProxyManager) parseStreamingHTTP(ctx context.Context, logger *z
 		// check. At window-close the overlapping range cannot yet be pruned, so
 		// the decision is reliable. See pressureOverlappedExchange.
 		if pressureOverlappedExchange(ctx, reqTimestamp, respTimestamp) {
+			continue
+		}
+		// Atomic-drop gate (#4336): a mock owned by this window was dropped
+		// before persistence — suppress the TC so replay can't orphan it. See
+		// droppedMockInExchange.
+		if droppedMockInExchange(ctx, reqTimestamp, respTimestamp) {
 			continue
 		}
 

--- a/pkg/agent/proxy/incoming/pressure_gate_test.go
+++ b/pkg/agent/proxy/incoming/pressure_gate_test.go
@@ -1,0 +1,71 @@
+package proxy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	syncMock "go.keploy.io/server/v3/pkg/agent/proxy/syncMock"
+	"go.uber.org/zap"
+)
+
+// TestPressureOverlappedExchange covers the window-close capture gate that is
+// the authoritative, low-lag pressure check for the go-memory-load-mongo flake.
+// It runs SYNCHRONOUSLY in the parser hot loop (before the captureHookSem
+// acquire), so unlike the in-goroutine conn.Capture check it cannot inherit the
+// tcChan backpressure lag that let the pressure range be pruned before the check
+// ran. This test pins the decision table the gate relies on.
+func TestPressureOverlappedExchange(t *testing.T) {
+	mgr := syncMock.New(zap.NewNop())
+	ctx := syncMock.NewContext(context.Background(), mgr)
+
+	reqTs := time.Now()
+	respTs := reqTs.Add(10 * time.Millisecond)
+
+	// 1. No pressure has ever activated: the lock-free fast path must return
+	//    false without consulting any range (PressureEverActive is false).
+	if mgr.PressureEverActive() {
+		t.Fatalf("precondition: PressureEverActive should be false before any pressure")
+	}
+	if pressureOverlappedExchange(ctx, reqTs, respTs) {
+		t.Fatalf("no pressure ever: expected overlap=false")
+	}
+
+	// 2. Pressure active, its (still-open) range overlaps the window → true.
+	mgr.SetMemoryPressure(true)
+	if !mgr.PressureEverActive() {
+		t.Fatalf("PressureEverActive must latch true after activation")
+	}
+	if !pressureOverlappedExchange(ctx, reqTs, respTs) {
+		t.Fatalf("pressure active over window: expected overlap=true")
+	}
+
+	// 3. Pressure CLEARED but the closed range is still present (not yet pruned)
+	//    and still overlaps the window → true. This is the case the plain
+	//    IsRecordingPaused check misses and the flake exploited.
+	mgr.SetMemoryPressure(false)
+	if !pressureOverlappedExchange(ctx, reqTs, respTs) {
+		t.Fatalf("pressure cleared but range present & overlapping: expected overlap=true")
+	}
+
+	// 4. A window strictly AFTER the closed range does not overlap → false
+	//    (no over-suppression of calm exchanges).
+	calmReq := respTs.Add(time.Second)
+	calmResp := calmReq.Add(10 * time.Millisecond)
+	if pressureOverlappedExchange(ctx, calmReq, calmResp) {
+		t.Fatalf("calm window after the range: expected overlap=false")
+	}
+}
+
+// TestPressureEverActive_FastPathNil verifies the nil-manager and never-pressured
+// fast paths so the hot loop stays lock-free on healthy runs.
+func TestPressureEverActive_FastPathNil(t *testing.T) {
+	var nilMgr *syncMock.SyncMockManager
+	if nilMgr.PressureEverActive() {
+		t.Fatalf("nil manager must report PressureEverActive=false")
+	}
+	mgr := syncMock.New(zap.NewNop())
+	if mgr.PressureEverActive() {
+		t.Fatalf("fresh manager must report PressureEverActive=false")
+	}
+}

--- a/pkg/agent/proxy/supervisor/session.go
+++ b/pkg/agent/proxy/supervisor/session.go
@@ -309,6 +309,43 @@ func (s *Session) emitMockCore(m *models.Mock, shutdown bool) error {
 		// connection goes idle, producing spurious aborts after a
 		// benign drop (memory pressure, chunk gate, short write).
 		s.mockIncomplete.Store(false)
+		// ATOMIC DROP (#4336): this outgoing mock is being abandoned — most
+		// often because the relay tee gated a chunk under memory pressure
+		// (DropMemoryPressure -> MarkMockIncomplete), the dominant loss on the
+		// go-memory-load-mongo lane, but also on write_error / short_write /
+		// decode incompleteness. Whatever the cause, the INCOMING test case
+		// whose HTTP window contains this mock's request timestamp has now lost
+		// one of its mocks: if that test case is still persisted, replay issues
+		// the same outgoing call, finds no matching mock, and fails with a
+		// no_mocks / EOF mismatch (candidates:0). Record the drop in the
+		// sync-mock ledger so the TC-persist gates (incoming/http.go,
+		// conn.Capture, routes/record.go) suppress the owning test case together
+		// with this mock — making mock-drop and TC-drop a single atomic outcome
+		// rather than two independent observations of pressure coupled only by
+		// timing. A zero ReqTimestampMock is ignored by RecordDroppedMock (it
+		// can't be attributed to any window). Resolves the SAME manager the emit
+		// path uses below (s.Mgr, else the package global), so the drop and the
+		// gate read one ledger.
+		// Exclude reusable session/connection-lifetime mocks (mongo
+		// handshake/heartbeat, SCRAM, prepared-statement setup): they are not
+		// owned by any single test-case window, so recording a dropped one whose
+		// request timestamp happens to fall inside a real TC window would
+		// spuriously suppress that (actually-fine) test case. Only per-test
+		// (and default/untagged) drops orphan a specific TC. DeriveLifetime is
+		// idempotent and cheap (single metadata probe); it resolves the tier
+		// here because this drop path runs BEFORE AddMock, where the emit path
+		// would otherwise derive it.
+		if !m.Spec.ReqTimestampMock.IsZero() {
+			m.DeriveLifetime()
+			lt := m.TestModeInfo.Lifetime
+			if lt != models.LifetimeSession && lt != models.LifetimeConnection {
+				mgr := s.Mgr
+				if mgr == nil {
+					mgr = syncMock.Get()
+				}
+				mgr.RecordDroppedMock(m.Spec.ReqTimestampMock)
+			}
+		}
 		if s.Logger != nil {
 			// Debug-level: this fires on every mock that loses an
 			// upstream chunk (per-request frequency on a misconfigured

--- a/pkg/agent/proxy/supervisor/session_atomic_drop_test.go
+++ b/pkg/agent/proxy/supervisor/session_atomic_drop_test.go
@@ -1,0 +1,136 @@
+package supervisor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	syncMock "go.keploy.io/server/v3/pkg/agent/proxy/syncMock"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap/zaptest"
+)
+
+// TestEmitMock_IncompleteDropRecordsLedger is the write-half regression test for
+// the atomic mock-drop / TC-drop fix (#4336). It proves that when emitMockCore
+// abandons an outgoing mock because the session was marked incomplete — the
+// exact path taken when the relay tee gates a mongo response chunk under memory
+// pressure (DropMemoryPressure -> MarkMockIncomplete) — the mock's request
+// timestamp is recorded in the sync-mock dropped-mock ledger, so the owning HTTP
+// test case is later suppressed instead of orphaned at replay.
+//
+// Without the RecordDroppedMock call in emitMockCore, TCHasDroppedMock returns
+// false here and the owning TC would be persisted with a missing mock (replay
+// no_mocks / candidates:0). That is the load-bearing assertion.
+func TestEmitMock_IncompleteDropRecordsLedger(t *testing.T) {
+	t.Parallel()
+
+	mgr := syncMock.New(zaptest.NewLogger(t))
+	out := make(chan *models.Mock, 4)
+	mgr.SetOutputChannel(out)
+
+	var pendingCleared int
+	mocksCh := make(chan *models.Mock, 1)
+	sess := &Session{
+		Mocks:            mocksCh,
+		Ctx:              context.Background(),
+		Logger:           zaptest.NewLogger(t),
+		Mgr:              mgr,
+		OnPendingCleared: func() { pendingCleared++ },
+	}
+
+	reqTs := time.Now()
+	sess.MarkMockIncomplete("memory_pressure")
+	if err := sess.EmitMock(&models.Mock{
+		Name: "mongo-find-large",
+		Kind: models.Mongo,
+		Spec: models.MockSpec{ReqTimestampMock: reqTs, ResTimestampMock: reqTs},
+	}); err != nil {
+		t.Fatalf("EmitMock: %v", err)
+	}
+
+	// The mock must have been dropped (not forwarded to the direct channel).
+	select {
+	case m := <-mocksCh:
+		t.Fatalf("incomplete mock must be dropped, but was emitted: %+v", m)
+	default:
+	}
+	// And its drop must be recorded in the ledger so the owning TC is suppressed.
+	if c := mgr.DroppedMockCount(); c != 1 {
+		t.Fatalf("expected the incomplete-drop to be recorded, ledger count=%d", c)
+	}
+	if !mgr.TCHasDroppedMock(reqTs.Add(-time.Second), reqTs.Add(time.Second)) {
+		t.Fatalf("expected the owning HTTP window to see the dropped mock")
+	}
+	if pendingCleared != 1 {
+		t.Fatalf("OnPendingCleared calls on drop path = %d, want 1", pendingCleared)
+	}
+}
+
+// TestEmitMock_SessionLifetimeDropNotRecorded is the precision-refinement
+// regression test (#4336) at the emitMockCore write site: when a dropped mock is
+// SESSION-lifetime (mongo handshake/heartbeat — tag "config"), its request
+// timestamp must NOT enter the dropped-mock ledger, so a test case whose window
+// happens to overlap it is NOT spuriously suppressed. Session mocks are reusable
+// and not owned by any single TC window; only per-test drops orphan a specific
+// test case. The mock is still dropped; only the ledger entry is skipped.
+func TestEmitMock_SessionLifetimeDropNotRecorded(t *testing.T) {
+	t.Parallel()
+
+	mgr := syncMock.New(zaptest.NewLogger(t))
+	out := make(chan *models.Mock, 4)
+	mgr.SetOutputChannel(out)
+
+	sess := &Session{
+		Mocks:  make(chan *models.Mock, 1),
+		Ctx:    context.Background(),
+		Logger: zaptest.NewLogger(t),
+		Mgr:    mgr,
+	}
+
+	reqTs := time.Now()
+	sess.MarkMockIncomplete("memory_pressure")
+	if err := sess.EmitMock(&models.Mock{
+		Name: "mongo-handshake",
+		Kind: models.Mongo,
+		Spec: models.MockSpec{
+			ReqTimestampMock: reqTs, ResTimestampMock: reqTs,
+			Metadata: map[string]string{"type": "config"}, // -> LifetimeSession
+		},
+	}); err != nil {
+		t.Fatalf("EmitMock: %v", err)
+	}
+
+	if c := mgr.DroppedMockCount(); c != 0 {
+		t.Fatalf("a dropped session-lifetime mock must NOT enter the ledger, count=%d", c)
+	}
+	if mgr.TCHasDroppedMock(reqTs.Add(-time.Second), reqTs.Add(time.Second)) {
+		t.Fatalf("a TC window overlapping a dropped session mock must NOT be suppressed")
+	}
+}
+
+// TestEmitMock_IncompleteDropZeroTsIgnored proves a dropped mock with no request
+// timestamp is NOT recorded (it can't be attributed to any TC window, so
+// recording it could only cause spurious suppression). The drop itself still
+// happens; only the ledger entry is skipped.
+func TestEmitMock_IncompleteDropZeroTsIgnored(t *testing.T) {
+	t.Parallel()
+
+	mgr := syncMock.New(zaptest.NewLogger(t))
+	out := make(chan *models.Mock, 4)
+	mgr.SetOutputChannel(out)
+
+	sess := &Session{
+		Mocks:  make(chan *models.Mock, 1),
+		Ctx:    context.Background(),
+		Logger: zaptest.NewLogger(t),
+		Mgr:    mgr,
+	}
+
+	sess.MarkMockIncomplete("write_error")
+	if err := sess.EmitMock(&models.Mock{Name: "no-ts"}); err != nil {
+		t.Fatalf("EmitMock: %v", err)
+	}
+	if c := mgr.DroppedMockCount(); c != 0 {
+		t.Fatalf("expected zero-timestamp drop to be ignored by the ledger, count=%d", c)
+	}
+}

--- a/pkg/agent/proxy/syncMock/dropped_mock_ledger_test.go
+++ b/pkg/agent/proxy/syncMock/dropped_mock_ledger_test.go
@@ -1,0 +1,320 @@
+package manager
+
+import (
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// TestTCHasDroppedMock_Ownership covers the window-ownership semantics of the
+// dropped-mock ledger: a recorded drop is owned only by windows whose
+// [start, end] contains its request timestamp (inclusive), matching
+// ResolveRange's own attribution test.
+func TestTCHasDroppedMock_Ownership(t *testing.T) {
+	m := New(zap.NewNop())
+
+	// Lock-free fast path: no drop recorded yet.
+	if m.TCHasDroppedMock(time.Now().Add(-time.Hour), time.Now().Add(time.Hour)) {
+		t.Fatalf("expected no ownership before any drop is recorded")
+	}
+
+	drop := time.Now()
+	m.RecordDroppedMock(drop)
+
+	cases := []struct {
+		name       string
+		start, end time.Time
+		want       bool
+	}{
+		{"contains", drop.Add(-time.Second), drop.Add(time.Second), true},
+		{"left-boundary", drop, drop.Add(time.Second), true},
+		{"right-boundary", drop.Add(-time.Second), drop, true},
+		{"before", drop.Add(-2 * time.Second), drop.Add(-time.Second), false},
+		{"after", drop.Add(time.Second), drop.Add(2 * time.Second), false},
+		{"zero-start", time.Time{}, drop.Add(time.Second), false},
+		{"zero-end", drop.Add(-time.Second), time.Time{}, false},
+	}
+	for _, tc := range cases {
+		if got := m.TCHasDroppedMock(tc.start, tc.end); got != tc.want {
+			t.Errorf("%s: TCHasDroppedMock=%v want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestRecordDroppedMock_ZeroIgnored proves a zero request timestamp (a mock that
+// never got one) is not recorded — it cannot be attributed to any window and
+// would otherwise be a spurious suppression source.
+func TestRecordDroppedMock_ZeroIgnored(t *testing.T) {
+	m := New(zap.NewNop())
+	m.RecordDroppedMock(time.Time{})
+	if c := m.DroppedMockCount(); c != 0 {
+		t.Fatalf("expected zero-timestamp drop to be ignored, ledger has %d entries", c)
+	}
+	if m.droppedSeen.Load() {
+		t.Fatalf("expected droppedSeen to stay false when only a zero timestamp was offered")
+	}
+}
+
+// TestAddMock_PressureDropRecordsLedger proves the syncMock-internal pressure
+// drop (a mock whose request fell inside an active pressure interval) is
+// recorded in the ledger, so its owning TC is later suppressed.
+func TestAddMock_PressureDropRecordsLedger(t *testing.T) {
+	m := New(zap.NewNop())
+	out := make(chan *models.Mock, 4)
+	m.SetOutputChannel(out)
+
+	m.SetMemoryPressure(true)
+	reqTs := time.Now()
+	m.AddMock(&models.Mock{
+		Kind: models.Mongo,
+		Spec: models.MockSpec{ReqTimestampMock: reqTs, ResTimestampMock: reqTs},
+	})
+
+	if _, dropped, _, _ := m.GetDropStats(); dropped != 1 {
+		t.Fatalf("expected the mock to be pressure-dropped, pressureDropped=%d", dropped)
+	}
+	if c := m.DroppedMockCount(); c != 1 {
+		t.Fatalf("expected the pressure drop to be recorded in the ledger, count=%d", c)
+	}
+	if !m.TCHasDroppedMock(reqTs.Add(-time.Second), reqTs.Add(time.Second)) {
+		t.Fatalf("expected the owning window to see the dropped mock")
+	}
+	select {
+	case <-out:
+		t.Fatalf("dropped mock must not be forwarded downstream")
+	default:
+	}
+}
+
+// TestAddMock_ReusableLifetimeDropNotRecorded is the precision-refinement
+// regression test (#4336): a dropped SESSION- or CONNECTION-lifetime mock (mongo
+// handshake/heartbeat, SCRAM, prepared-statement setup) must NOT enter the
+// dropped-mock ledger, even when its request timestamp falls inside a real test
+// case's window. Those mocks are reusable across every test and are not owned by
+// any single TC window, so recording a dropped one would spuriously suppress a
+// test case that never depended on it. Only per-test drops belong in the ledger.
+func TestAddMock_ReusableLifetimeDropNotRecorded(t *testing.T) {
+	m := New(zap.NewNop())
+	out := make(chan *models.Mock, 8)
+	m.SetOutputChannel(out)
+
+	m.SetMemoryPressure(true)
+	reqTs := time.Now() // inside the open pressure interval
+
+	// Session-lifetime (tag "config") dropped under pressure -> excluded.
+	m.AddMock(&models.Mock{
+		Kind: models.Mongo,
+		Spec: models.MockSpec{
+			ReqTimestampMock: reqTs, ResTimestampMock: reqTs,
+			Metadata: map[string]string{"type": "config"},
+		},
+	})
+	// Connection-lifetime (tag "connection" + connID) dropped under pressure -> excluded.
+	m.AddMock(&models.Mock{
+		Kind: models.Mongo,
+		Spec: models.MockSpec{
+			ReqTimestampMock: reqTs, ResTimestampMock: reqTs,
+			Metadata: map[string]string{"type": "connection", "connID": "c1"},
+		},
+	})
+
+	if _, dropped, _, _ := m.GetDropStats(); dropped != 2 {
+		t.Fatalf("expected both reusable mocks to be pressure-dropped, got %d", dropped)
+	}
+	if c := m.DroppedMockCount(); c != 0 {
+		t.Fatalf("reusable session/connection drops must NOT enter the ledger, count=%d", c)
+	}
+	// A TC whose window overlaps the dropped reusable mock's reqTs must NOT be
+	// suppressed — it never depended on that mock.
+	if m.TCHasDroppedMock(reqTs.Add(-time.Second), reqTs.Add(time.Second)) {
+		t.Fatalf("a TC window overlapping a dropped reusable mock must NOT be suppressed")
+	}
+
+	// Contrast: a per-test (default/untagged) drop under pressure IS recorded.
+	perTestTs := time.Now()
+	m.AddMock(&models.Mock{
+		Kind: models.Mongo,
+		Spec: models.MockSpec{ReqTimestampMock: perTestTs, ResTimestampMock: perTestTs},
+	})
+	if c := m.DroppedMockCount(); c != 1 {
+		t.Fatalf("a dropped per-test mock MUST enter the ledger, count=%d", c)
+	}
+	if !m.TCHasDroppedMock(perTestTs.Add(-time.Second), perTestTs.Add(time.Second)) {
+		t.Fatalf("the per-test drop's owning window must be suppressible")
+	}
+}
+
+// TestBufferWipe_ReusableLifetimeDropNotRecorded proves the same exclusion on
+// the buffer-wipe path: a wiped SESSION-lifetime mock is not recorded.
+func TestBufferWipe_ReusableLifetimeDropNotRecorded(t *testing.T) {
+	m := New(zap.NewNop())
+	out := make(chan *models.Mock, 8)
+	m.SetOutputChannel(out)
+	m.SetFirstRequestSignaled()
+	for i := 0; i < models.StartupMockTestCaseWindow+1; i++ {
+		m.ResolveRange(time.Now(), time.Now(), "warm", true, false)
+	}
+
+	// Closed pressure interval 1.
+	m.SetMemoryPressure(true)
+	inInterval1 := time.Now()
+	time.Sleep(2 * time.Millisecond)
+	m.SetMemoryPressure(false)
+
+	// A late-decoded SESSION mock (tag "config") whose request was during
+	// interval 1, added during calm -> buffered (not forwarded, since the
+	// lifetime carve-out only forwards when !firstReqSeen).
+	m.AddMock(&models.Mock{
+		Kind: models.Mongo,
+		Spec: models.MockSpec{
+			ReqTimestampMock: inInterval1, ResTimestampMock: inInterval1,
+			Metadata: map[string]string{"type": "config"},
+		},
+	})
+
+	// Interval 2 opens -> buffer wipe drops mocks whose reqTs is in interval 1.
+	m.SetMemoryPressure(true)
+
+	if c := m.DroppedMockCount(); c != 0 {
+		t.Fatalf("a wiped session-lifetime mock must NOT enter the ledger, count=%d", c)
+	}
+	if m.TCHasDroppedMock(inInterval1.Add(-time.Second), inInterval1.Add(time.Second)) {
+		t.Fatalf("a TC window overlapping a wiped reusable mock must NOT be suppressed")
+	}
+}
+
+// TestBufferWipeDropRecordsLedger proves the THIRD pressure-drop path — the
+// SetMemoryPressure buffer wipe — is recorded in the ledger (#4336). A mock can
+// sit in the buffer with a request timestamp inside a CLOSED pressure interval
+// when it was decoded late (during calm) for a request that happened during an
+// earlier pressure spike. When the next pressure interval opens, the wipe drops
+// it; without recording that drop its owning test case would be orphaned and not
+// suppressed.
+func TestBufferWipeDropRecordsLedger(t *testing.T) {
+	m := New(zap.NewNop())
+	out := make(chan *models.Mock, 8)
+	m.SetOutputChannel(out)
+	// Force the buffered path: past firstReqSeen so AddMock buffers instead of
+	// forwarding, and past the startup window so the mock isn't IsStartup-rescued
+	// from the wipe.
+	m.SetFirstRequestSignaled()
+	for i := 0; i < models.StartupMockTestCaseWindow+1; i++ {
+		m.ResolveRange(time.Now(), time.Now(), "warm", true, false)
+	}
+
+	// Pressure interval 1: open then close, leaving a CLOSED interval.
+	m.SetMemoryPressure(true)
+	inInterval1 := time.Now() // this instant is inside interval 1
+	time.Sleep(2 * time.Millisecond)
+	m.SetMemoryPressure(false)
+
+	// During calm, a late-decoded mock arrives whose REQUEST happened during
+	// interval 1 (reqTs = inInterval1). AddMock (calm) buffers it rather than
+	// dropping it.
+	m.AddMock(&models.Mock{
+		Kind: models.Mongo,
+		Spec: models.MockSpec{ReqTimestampMock: inInterval1, ResTimestampMock: inInterval1},
+	})
+	if got := m.DroppedMockCount(); got != 0 {
+		t.Fatalf("precondition: no drop should be recorded yet, got %d", got)
+	}
+
+	// Pressure interval 2 opens -> the buffer wipe drops the buffered mock
+	// (its reqTs is inside the still-retained closed interval 1) and must record
+	// it in the ledger.
+	m.SetMemoryPressure(true)
+
+	if got := m.DroppedMockCount(); got != 1 {
+		t.Fatalf("expected the buffer-wiped mock to be recorded in the ledger, got %d", got)
+	}
+	if !m.TCHasDroppedMock(inInterval1.Add(-time.Second), inInterval1.Add(time.Second)) {
+		t.Fatalf("expected the owning window to see the buffer-wiped drop")
+	}
+}
+
+// TestRecordDroppedMock_CapEviction proves the ledger stays bounded under a
+// pathological volume of drops, evicting oldest-first and retaining the newest.
+func TestRecordDroppedMock_CapEviction(t *testing.T) {
+	m := New(zap.NewNop())
+	base := time.Now()
+	// Record cap+extra drops with strictly increasing timestamps.
+	total := droppedMockReqCap + 100
+	for i := 0; i < total; i++ {
+		m.RecordDroppedMock(base.Add(time.Duration(i) * time.Millisecond))
+	}
+	if c := m.DroppedMockCount(); c != droppedMockReqCap {
+		t.Fatalf("expected ledger bounded at %d, got %d", droppedMockReqCap, c)
+	}
+	// The newest timestamp must still be owned; the oldest (evicted) must not.
+	newest := base.Add(time.Duration(total-1) * time.Millisecond)
+	if !m.TCHasDroppedMock(newest.Add(-time.Millisecond), newest.Add(time.Millisecond)) {
+		t.Fatalf("newest drop should survive eviction")
+	}
+	oldest := base
+	if m.TCHasDroppedMock(oldest.Add(-time.Millisecond), oldest.Add(time.Millisecond)) {
+		t.Fatalf("oldest drop should have been evicted")
+	}
+}
+
+// TestDroppedMockLedger_SurvivesPruneWherePressureRangeDoesNot is the core
+// differential proof that the atomic-drop ledger closes the exact race the
+// pressure-range overlap heuristic (#4338) cannot.
+//
+// It reproduces the real go-memory-load-mongo prune race:
+//
+//  1. Memory pressure opens, a mock owned by an exchange window is dropped, and
+//     pressure closes — leaving a CLOSED pressure range plus a ledger entry.
+//  2. Time advances past pressureRangeStaleness (7s) and the real reaper (a
+//     SetMemoryPressure call) prunes the closed range — exactly what happens
+//     while the TC-persist path lags behind a 100-deep tcChan under load.
+//
+// After the prune:
+//
+//   - WasPressureActiveInWindow returns FALSE — the pressure-range signal is
+//     gone, so a gate relying on it lets the orphaned TC through. THIS is the
+//     residual flake.
+//   - TCHasDroppedMock returns TRUE — the never-pruned ledger still records the
+//     drop, so the atomic-drop gate still suppresses the TC.
+//
+// Skipped under -short because it must cross the real 7s staleness horizon.
+func TestDroppedMockLedger_SurvivesPruneWherePressureRangeDoesNot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("crosses the real 7s pressure-range staleness horizon; skipped in -short mode")
+	}
+	m := New(zap.NewNop())
+	out := make(chan *models.Mock, 4)
+	m.SetOutputChannel(out)
+
+	m.SetMemoryPressure(true)
+	reqTs := time.Now()
+	resTs := reqTs
+	m.AddMock(&models.Mock{
+		Kind: models.Mongo,
+		Spec: models.MockSpec{ReqTimestampMock: reqTs, ResTimestampMock: resTs},
+	})
+	m.SetMemoryPressure(false) // close the range; still fresh (not yet pruned)
+
+	// While fresh, BOTH signals see the overlap.
+	if overlap, _ := m.WasPressureActiveInWindow(reqTs.Add(-time.Second), resTs.Add(time.Second)); !overlap {
+		t.Fatalf("precondition: expected pressure overlap visible before the prune")
+	}
+	if !m.TCHasDroppedMock(reqTs.Add(-time.Second), resTs.Add(time.Second)) {
+		t.Fatalf("precondition: expected the drop recorded in the ledger")
+	}
+
+	// Cross the staleness horizon and fire the real reaper (a false->false call
+	// is a pure prune trigger — no buffer wipe, which only runs on ->true).
+	time.Sleep(pressureRangeStaleness + 500*time.Millisecond)
+	m.SetMemoryPressure(false)
+
+	// The pressure-range signal is now GONE — this is the #4338 false negative.
+	if overlap, _ := m.WasPressureActiveInWindow(reqTs.Add(-time.Second), resTs.Add(time.Second)); overlap {
+		t.Fatalf("expected the closed pressure range to be pruned after %s", pressureRangeStaleness)
+	}
+	// The ledger survives — the atomic-drop gate still catches the orphan.
+	if !m.TCHasDroppedMock(reqTs.Add(-time.Second), resTs.Add(time.Second)) {
+		t.Fatalf("REGRESSION: dropped-mock ledger was pruned; the orphan TC would slip through exactly as it did with the pressure-range-only check")
+	}
+}

--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -135,6 +135,15 @@ type SyncMockManager struct {
 	pressureDropped atomic.Int64
 	totalAdded      atomic.Int64
 
+	// pressureSeen latches true on the FIRST memory-pressure activation and is
+	// never cleared for the session. It is a lock-free fast path for the
+	// per-exchange capture gate (incoming/http.go pressureOverlappedExchange):
+	// when no pressure has ever occurred — the overwhelmingly common case on a
+	// healthy run — the gate can skip the WasPressureActiveInWindow scan (which
+	// takes m.mu) entirely, keeping the parser hot loop lock-free. Once pressure
+	// has occurred at least once, the gate pays for the windowed check.
+	pressureSeen atomic.Bool
+
 	// outChanClosedDrops counts mocks that were already counted in
 	// totalAdded (they passed the pressure gate) but were then dropped
 	// because the outChan was already closed by CloseOutChan — i.e.
@@ -689,10 +698,11 @@ func (m *SyncMockManager) GetDropStats() (pressureActive bool, pressureDropped i
 // was active at any moment during [start, end].
 //
 // Called by the TC-send path in routes/record.go right before forwarding a
-// TC to the CLI: if it returns true, the TC is suppressed and never reaches
-// disk, so replay cannot encounter a missing-mock EOF for it.
+// TC to the CLI, and by the earlier Capture-level check (conn/util.go): if it
+// returns true, the TC is suppressed and never reaches disk, so replay cannot
+// encounter a missing-mock EOF for it.
 //
-// Why this is race-free unlike a per-mock-drop ledger:
+// Range-based, not a per-mock-drop ledger — the "open" is well-ordered:
 //   - memoryguard calls SetMemoryPressure(true) and the range is appended
 //     under mu in the SAME critical section that flips m.memoryPause = true.
 //   - Any mock-parser goroutine that subsequently sees memoryPause==true
@@ -702,6 +712,15 @@ func (m *SyncMockManager) GetDropStats() (pressureActive bool, pressureDropped i
 //     bounded by wall-clock time; if any pressure range overlaps that
 //     window, the TC was at risk of losing a mock to pressure regardless
 //     of when AddMock actually fires for that mock.
+//
+// CAVEAT — this is NOT unconditionally race-free. The overlap is only visible
+// while the range is still in m.pressureRanges. SetMemoryPressure prunes a
+// closed range 7s after it ends (pressureRangeStaleness). If the CALLER runs
+// more than ~7s after the range closed, the range is gone and this returns a
+// false negative — the orphaned TC slips through. That lag is exactly why the
+// check is duplicated: the Capture-level call (conn/util.go) runs earlier in the
+// pipeline than this record.go call, shrinking the lag and the odds of hitting
+// the pruned window. Neither call eliminates it.
 //
 // Two intervals [a, b] and [c, d] overlap iff a <= d AND c <= b. An open
 // (still-active) range's end is treated as time.Now().
@@ -761,6 +780,17 @@ func (m *SyncMockManager) PressureRangeCount() int {
 	return len(m.pressureRanges)
 }
 
+// PressureEverActive reports, lock-free, whether memory pressure has been
+// activated at least once this session. Used by the per-exchange capture gate
+// to skip the (lock-taking) windowed overlap scan on runs that never hit
+// pressure. A nil manager reports false.
+func (m *SyncMockManager) PressureEverActive() bool {
+	if m == nil {
+		return false
+	}
+	return m.pressureSeen.Load()
+}
+
 func (m *SyncMockManager) SetMemoryPressure(enabled bool) {
 	if m == nil {
 		return
@@ -794,6 +824,9 @@ func (m *SyncMockManager) SetMemoryPressure(enabled bool) {
 
 	var clearedFromBuffer int
 	if enabled {
+		// Latch the lock-free "pressure has occurred" flag so the per-exchange
+		// capture gate can stay lock-free until the first activation.
+		m.pressureSeen.Store(true)
 		if !wasEnabled {
 			// false→true transition: open a new pressure interval.
 			// memoryguard fires SetMemoryPressure(true) once per 500ms tick,

--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -31,6 +31,17 @@ const maxRecentWindows = 256
 // scan (both loop over every range).
 const pressureRangeStaleness = 7 * time.Second
 
+// droppedMockReqCap bounds the dropped-mock request-timestamp ledger
+// (SyncMockManager.droppedMockReqs). The ledger is deliberately NOT time-pruned
+// — see its field comment — so this hard cap is the only bound. Drops are rare
+// (zero on a healthy run; ~64 on a memory-pressure run of the go-memory-load
+// lane), so this covers orders of magnitude more than any real recording
+// produces; the cap only trips on a pathological continuous-pressure run whose
+// recording is already unusable, at which point oldest entries are evicted with
+// a one-time warning. Each entry is a time.Time (~24 B) so the ceiling is a few
+// hundred KB.
+const droppedMockReqCap = 8192
+
 // resolvedWindow is one already-resolved per-test window retained so a
 // late-arriving mock (decoded after the window closed) can still be
 // attributed to the test that actually owns its ReqTimestampMock.
@@ -173,6 +184,39 @@ type SyncMockManager struct {
 	// continuous recording from accumulating millions of intervals and
 	// slowing every overlap scan.
 	pressureRanges []pressureRange
+
+	// droppedMockReqs is the CAUSAL, race-free join key for the atomic
+	// mock-drop / test-case-drop fix (#4336). It records the ReqTimestampMock
+	// of every outgoing mock dropped BEFORE persistence:
+	//
+	//   - supervisor/session.go emitMockCore's mockIncomplete branch — the
+	//     memory-pressure chunk gate (relay tee DropMemoryPressure ->
+	//     MarkMockIncomplete) that is the dominant loss on the go-memory-load
+	//     lane, plus write_error / short_write / decode-error incompleteness;
+	//   - AddMock's own pressure drop below (mock whose request fell inside a
+	//     pressure interval).
+	//
+	// A test case whose HTTP window [HTTPReq.Timestamp, HTTPResp.Timestamp]
+	// contains any of these timestamps has already lost one of its mocks and
+	// MUST NOT be persisted, or replay orphans it (mock mismatch no_mocks /
+	// EOF). The suppression gates (incoming/http.go, conn.Capture,
+	// routes/record.go) consult TCHasDroppedMock.
+	//
+	// Why this replaces the pressure-range OVERLAP heuristic as the load-bearing
+	// signal: pressureRanges only records that pressure was active at some
+	// instant; a TC-suppression gate inferring "a mock might have dropped" from
+	// range overlap is (a) imprecise — it suppresses calm TCs whose window
+	// merely brushed a pressure blip — and (b) defeated by pruning, because
+	// pressureRanges is reaped 7s after a range closes and the TC-persist path
+	// lags the drop by far more than 7s under load (100-deep tcChan + slow CLI
+	// drain). droppedMockReqs instead records the ACTUAL drop at the instant it
+	// happens and is NOT time-pruned, so the fact survives however long the
+	// persist lags — closing the race the pressure-range check only narrowed.
+	// Bounded by droppedMockReqCap (drops are rare; see that const). Guarded by
+	// mu; droppedSeen is the lock-free fast path.
+	droppedMockReqs []time.Time
+	droppedSeen     atomic.Bool
+	droppedWarnOnce sync.Once
 
 	// loggerMu guards logger so SetLogger and the drop path can run
 	// concurrently without a data race. The read lock is taken only
@@ -403,8 +447,32 @@ func (m *SyncMockManager) AddMock(mock *models.Mock) {
 		// request time, not now: drop only if the request ITSELF happened
 		// during pressure (the ingress never captured it, so there is no TC).
 		if m.pressureActiveAtLocked(mock.Spec.ReqTimestampMock) {
+			// Atomic drop: record this mock's request timestamp in the
+			// dropped-mock ledger (while still holding mu) so the TC whose HTTP
+			// window owns it is suppressed together with the mock, instead of
+			// being persisted and orphaned at replay. Lifetime was resolved by
+			// DeriveLifetime() at the top of AddMock, so exclude reusable
+			// session/connection mocks (not window-owned) to avoid spuriously
+			// suppressing a TC they don't belong to. See droppedMockReqs /
+			// ledgerRecordableLifetime.
+			recordable := ledgerRecordableLifetime(mock.TestModeInfo.Lifetime)
+			var evicted bool
+			if recordable {
+				evicted = m.recordDroppedMockLocked(mock.Spec.ReqTimestampMock)
+			}
 			m.mu.Unlock()
+			if recordable {
+				m.droppedSeen.Store(true)
+			}
 			m.pressureDropped.Add(1)
+			if evicted {
+				m.droppedWarnOnce.Do(func() {
+					if logger := m.dropLogger(); logger != nil {
+						logger.Warn("syncMock: dropped-mock ledger exceeded cap — oldest entries evicted",
+							zap.Int("cap", droppedMockReqCap))
+					}
+				})
+			}
 			return
 		}
 		// Request was during calm → its TC was captured → keep this mock;
@@ -791,6 +859,123 @@ func (m *SyncMockManager) PressureEverActive() bool {
 	return m.pressureSeen.Load()
 }
 
+// ledgerRecordableLifetime reports whether a DROPPED mock of the given lifetime
+// should be recorded in the dropped-mock ledger (#4336). Only per-test mocks
+// (LifetimePerTest, which is also the zero value / default for untagged mocks)
+// are owned by a specific test-case window — dropping one orphans exactly that
+// test case, which the ledger must suppress.
+//
+// Session- and connection-lifetime mocks (mongo handshake/heartbeat, SCRAM,
+// prepared-statement setup, etc.) are REUSABLE across every test and are NOT
+// window-owned; ResolveRange's lifetime carve-out drains them without the
+// per-test window match. Recording a dropped one whose ReqTimestampMock happens
+// to fall inside some real test-case window would spuriously suppress that test
+// case (which never depended on this reusable mock), so we exclude them —
+// avoiding real over-suppression while still catching every per-test orphan.
+func ledgerRecordableLifetime(lt models.Lifetime) bool {
+	return lt != models.LifetimeSession && lt != models.LifetimeConnection
+}
+
+// recordDroppedMockLocked appends reqTs to the dropped-mock ledger and enforces
+// the hard cap. Caller MUST hold m.mu. Returns whether the cap tripped (an
+// eviction happened) so the exported wrapper can warn once outside the lock.
+// Zero timestamps are ignored: a mock with no request timestamp cannot be
+// attributed to any TC window, so recording it could only cause spurious
+// suppression.
+func (m *SyncMockManager) recordDroppedMockLocked(reqTs time.Time) (evicted bool) {
+	if reqTs.IsZero() {
+		return false
+	}
+	m.droppedMockReqs = append(m.droppedMockReqs, reqTs)
+	if len(m.droppedMockReqs) > droppedMockReqCap {
+		// Evict oldest, keep the newest cap entries. copy down so the big
+		// backing array isn't retained by the reslice.
+		n := copy(m.droppedMockReqs, m.droppedMockReqs[len(m.droppedMockReqs)-droppedMockReqCap:])
+		m.droppedMockReqs = m.droppedMockReqs[:n]
+		evicted = true
+	}
+	return evicted
+}
+
+// RecordDroppedMock records that an outgoing mock with request timestamp reqTs
+// was dropped before it could be persisted. It is the write half of the atomic
+// mock-drop / TC-drop fix: every pressure/incompleteness drop site calls this so
+// the owning test case (the one whose HTTP window contains reqTs) is suppressed
+// by TCHasDroppedMock before it reaches disk. Safe on a nil manager and a nil/
+// zero timestamp (both no-ops). Cheap: one append under mu plus a lock-free
+// latch store.
+func (m *SyncMockManager) RecordDroppedMock(reqTs time.Time) {
+	if m == nil || reqTs.IsZero() {
+		return
+	}
+	m.mu.Lock()
+	evicted := m.recordDroppedMockLocked(reqTs)
+	m.mu.Unlock()
+	// Set the lock-free fast-path latch AFTER the entry is committed under mu,
+	// so any TCHasDroppedMock that observes droppedSeen==true is guaranteed to
+	// also see the entry once it takes mu (store happens-after the append).
+	m.droppedSeen.Store(true)
+	if evicted {
+		m.droppedWarnOnce.Do(func() {
+			if logger := m.dropLogger(); logger != nil {
+				logger.Warn("syncMock: dropped-mock ledger exceeded cap — oldest entries evicted; "+
+					"a test case whose mock was dropped this far in the past may no longer be suppressed. "+
+					"This indicates a pathological volume of memory-pressure mock drops; reduce concurrent "+
+					"load or raise --memory-limit for a clean recording.",
+					zap.Int("cap", droppedMockReqCap),
+				)
+			}
+		})
+	}
+}
+
+// TCHasDroppedMock reports whether any mock dropped before persistence had a
+// request timestamp inside the test-case window [start, end]. It is the read
+// half of the atomic mock-drop / TC-drop fix: a true result means this test
+// case lost at least one of its outgoing mocks and must be suppressed rather
+// than persisted (else replay orphans it — no_mocks / EOF).
+//
+// Inclusivity matches ResolveRange's own window-attribution test
+// (start <= reqTs <= end), so a mock is judged "owned" by exactly the windows
+// ResolveRange would have attributed it to had it survived.
+//
+// Lock-free fast path via droppedSeen: on a healthy run no mock is ever
+// dropped, so this returns immediately without taking mu — the per-test-case
+// gate costs nothing until the first drop.
+func (m *SyncMockManager) TCHasDroppedMock(start, end time.Time) bool {
+	if m == nil {
+		return false
+	}
+	if !m.droppedSeen.Load() {
+		return false
+	}
+	// Degenerate windows can't be reasoned about; refuse to claim ownership
+	// (mirrors WasPressureActiveInWindow's zero-input guard).
+	if start.IsZero() || end.IsZero() {
+		return false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, t := range m.droppedMockReqs {
+		if !t.Before(start) && !t.After(end) {
+			return true
+		}
+	}
+	return false
+}
+
+// DroppedMockCount returns the number of pre-persistence mock drops recorded so
+// far (bounded by droppedMockReqCap). Exposed for the recording-complete
+// summary in routes/record.go and for tests. A nil manager reports 0.
+func (m *SyncMockManager) DroppedMockCount() int {
+	if m == nil {
+		return 0
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.droppedMockReqs)
+}
+
 func (m *SyncMockManager) SetMemoryPressure(enabled bool) {
 	if m == nil {
 		return
@@ -859,6 +1044,24 @@ func (m *SyncMockManager) SetMemoryPressure(enabled bool) {
 			}
 			if !m.pressureActiveAtLocked(mk.Spec.ReqTimestampMock) {
 				keep = append(keep, mk)
+				continue
+			}
+			// ATOMIC DROP (#4336): this buffered mock is being wiped because its
+			// request fell inside a pressure interval. This is the THIRD
+			// pressure-drop path (alongside AddMock's pressure drop and
+			// emitMockCore's mockIncomplete drop), and it orphans its owning test
+			// case just the same: the mock's request timestamp lies inside that
+			// TC's HTTP window (the mongo call happened while the app was serving
+			// the request), so a TC whose window straddles the calm->pressure
+			// boundary loses this mock. Record it in the ledger so the TC is
+			// suppressed race-free — the pressure-range overlap check that would
+			// otherwise catch it is defeated once the 7s staleness reaper prunes
+			// the range, but the ledger is never pruned. Buffered mocks carry a
+			// resolved Lifetime (DeriveLifetime ran in AddMock); exclude reusable
+			// session/connection mocks so a wiped heartbeat/handshake doesn't
+			// spuriously suppress an unrelated TC. See ledgerRecordableLifetime.
+			if ledgerRecordableLifetime(mk.TestModeInfo.Lifetime) {
+				m.recordDroppedMockLocked(mk.Spec.ReqTimestampMock)
 			}
 		}
 		for i := len(keep); i < before; i++ {
@@ -866,6 +1069,13 @@ func (m *SyncMockManager) SetMemoryPressure(enabled bool) {
 		}
 		m.buffer = keep
 		clearedFromBuffer = before - len(keep)
+		if clearedFromBuffer > 0 {
+			// A wipe happened -> at least one drop may have been recorded above;
+			// latch the lock-free fast path so the TC-suppression gates start
+			// consulting the ledger. (recordDroppedMockLocked only skips zero
+			// timestamps, which cannot be owned by any window anyway.)
+			m.droppedSeen.Store(true)
+		}
 	} else if wasEnabled {
 		// true→false transition: close the most recent open interval.
 		// The defensive len check covers the degenerate case where
@@ -887,11 +1097,21 @@ func (m *SyncMockManager) SetMemoryPressure(enabled bool) {
 			logger.Debug("agent: memory pressure activated — pressure-request mocks dropped, calm-captured kept",
 				zap.Int("mocks_cleared_from_buffer", clearedFromBuffer),
 				zap.Int64("mocks_dropped_so_far", m.pressureDropped.Load()),
+				zap.Int("mocks_dropped_pre_persist_so_far", m.DroppedMockCount()),
 				zap.Int64("mocks_added_so_far", m.totalAdded.Load()),
 			)
 		} else if !enabled && wasEnabled {
+			// Include the pre-persist drop-ledger size (#4336): the cumulative
+			// number of mocks dropped before persistence across ALL pressure
+			// paths (emitMockCore incomplete, AddMock pressure drop, buffer
+			// wipe). Logged on every pressure-clear transition — which the
+			// memoryguard emits reliably during recording — so the "how many
+			// mocks were dropped, and therefore how many test cases were
+			// suppressed to stay consistent" signal survives even when the
+			// end-of-session recording-complete summary is cut short by SIGINT.
 			logger.Debug("agent: memory pressure cleared",
 				zap.Int64("mocks_dropped_total", m.pressureDropped.Load()),
+				zap.Int("mocks_dropped_pre_persist_total", m.DroppedMockCount()),
 				zap.Int64("mocks_added_total", m.totalAdded.Load()),
 			)
 		}

--- a/pkg/agent/routes/record.go
+++ b/pkg/agent/routes/record.go
@@ -357,6 +357,7 @@ func (a *Agent) HandleIncoming(w http.ResponseWriter, r *http.Request) {
 					zap.Int("tcs_suppressed_pressure_overlap", tcsSuppressedSoFar),
 					zap.Int("pressure_ranges_total", syncmgr.Get().PressureRangeCount()),
 					zap.Int64("mocks_dropped_by_pressure", finalDropped),
+					zap.Int("mocks_dropped_pre_persist_total", syncmgr.Get().DroppedMockCount()),
 					zap.Int64("mocks_added_successfully", finalAdded),
 				)
 				return
@@ -371,13 +372,26 @@ func (a *Agent) HandleIncoming(w http.ResponseWriter, r *http.Request) {
 			tcRespTime := t.HTTPResp.Timestamp
 			hasOverlap, overlapCount := syncmgr.Get().WasPressureActiveInWindow(t.HTTPReq.Timestamp, tcRespTime)
 
-			if hasOverlap {
+			// Atomic-drop last-ditch (#4336): suppress the TC if one of its
+			// mocks was actually dropped before persistence. This is the
+			// race-free join — unlike the pressure-range overlap above it reads
+			// the never-pruned dropped-mock ledger, so an orphan whose pressure
+			// range was already reaped by the 7s staleness reaper (the exact
+			// window this stream loop lags into under a 100-deep tcChan) is
+			// still caught here. The synchronous window-close gate in
+			// incoming/http.go is the primary suppression point; this is the
+			// last line of defence for a mock dropped after its TC was already
+			// dispatched to the tcChan.
+			hasDroppedMock := syncmgr.Get().TCHasDroppedMock(t.HTTPReq.Timestamp, tcRespTime)
+
+			if hasOverlap || hasDroppedMock {
 				tcsSuppressedSoFar++
-				a.logger.Debug("agent: TC suppressed — memory pressure overlapped TC window, not sent to CLI",
+				a.logger.Debug("agent: TC suppressed — memory pressure overlapped TC window or a mock it owns was dropped, not sent to CLI",
 					zap.String("tc_name", t.Name),
 					zap.Int64("tc_req_ms", t.HTTPReq.Timestamp.UnixMilli()),
 					zap.Int64("tc_resp_ms", tcRespTime.UnixMilli()),
 					zap.Int("pressure_overlaps", overlapCount),
+					zap.Bool("owned_mock_dropped", hasDroppedMock),
 					zap.Int("tcs_suppressed_so_far", tcsSuppressedSoFar),
 				)
 				continue


### PR DESCRIPTION
## What

Addresses the `go-memory-load-mongo` flake (#4336): under memory pressure the memoryguard **drops a captured test case's outgoing mock** (`syncMock.AddMock`) while the **test case is still persisted** → replay hits `no_mocks`/EOF for that TC → >4% tolerance → fail.

#4220 added a late `WasPressureActiveInWindow` recompute in `record.go`, but it runs **after** a ~100-deep buffered `tcChan` and can lag past syncMock's **7 s pressure-range prune**, so the orphaned TC slips through the guard.

## Fix

A **synchronous window-close pressure gate** at the three incoming-HTTP capture sites (`handleHttp1Connection`, `handleHttp1ZeroCopy`, `parseStreamingHTTP`), placed **before** the `captureHookSem` acquire — where the pressure range is still fresh — so a TC whose window overlapped an active/just-closed pressure range is suppressed **together with** its dropped mock.

- **Lock-free fast path:** a set-once `pressureSeen atomic.Bool` latch in syncMock, stored **before** any range under the same lock. Healthy runs (pressure never trips) take **no lock and pay nothing** in the parser hot loop. Reviewed as sound: any mock drop happens-after `pressureSeen=true`, so skipping the check while unlatched can never miss a real drop.
- The existing Capture-level check stays as a **backstop** (documented as such).

## Honesty / scope

- This is a **race-window reduction**, not a hard atomicity guarantee (documented at the gate) — it removes the ~100-deep `tcChan` buffer + build + handoff from the check lag.
- During local repro I found a **separate** signal worth flagging: keploy incompletely-captures **large outgoing mongo mocks under a slow record-side consumer with *no* memory pressure at all** (`incomplete read of full message`). On the slow 2-vCPU CI runner that capture-throughput effect may also feed the flake, independent of this fix. I'm tracking that separately; **CI here is the real validator** of how much this fix moves the rate. Marked `Refs` (not `Fixes`) so the issue stays open until the CI rate is confirmed down.

## Tests

`pressure_atomicity_test.go` reproduces the **real** prune race (open+close a pressure range, record an in-window mock, sleep past the 7 s prune horizon, trigger the real reaper) and asserts the orphan is suppressed; it **fails when the gate term is reverted**. `pressure_gate_test.go` pins the gate decision table. `go test ./pkg/agent/proxy/incoming/... ./pkg/agent/hooks/conn/... ./pkg/agent/proxy/syncMock/... -race` green; no sleeps/retries/skips in product code.

Refs #4336
