### PR TITLE
ci(windows): let all 4 docker-windows runners work concurrently

### DIFF
--- a/.github/workflows/golang_docker_windows.yml
+++ b/.github/workflows/golang_docker_windows.yml
@@ -2,9 +2,35 @@ name: Golang On Docker (Windows)
 on:
   workflow_call:
 
-concurrency:
-  group: windows-docker-runner
-  cancel-in-progress: false
+# NO workflow-level concurrency group here on purpose.
+#
+# This reusable workflow runs on a pool of 4 self-hosted Windows
+# runners that share ONE physical VM. It used to carry
+#   concurrency: { group: windows-docker-runner, cancel-in-progress: false }
+# whose group was a CONSTANT string, so GitHub allowed only ONE run of
+# this workflow across the entire repo at a time — every other run
+# queued and 3 of the 4 runners sat idle. That constant group was a
+# band-aid for the fact that concurrent jobs collided on shared-VM
+# resources: the host-published keploy proxy port (-p 16789:16789), a
+# machine-wide keploy.exe kill that would abort a sibling's CLI, and the
+# shared docker-compose project name (network/volumes). (This lane
+# intercepts via a per-job eBPF keploy-agent container in the compose
+# network, not the host WinDivert driver, so driver coexistence is not
+# the concern here.)
+#
+# Those collisions are now removed at the source: every shared-VM
+# resource is made per-job unique and every kill is job-scoped (see
+# golang-docker-windows.ps1 and the "Recover stale runner state" step
+# below). With the collisions gone, serialization is pure waste, so it
+# is deleted — all 4 runners can now pick up jobs in parallel.
+#
+# Superseded-push cancellation is still handled one level up: the only
+# caller, prepare_and_run.yml, sets
+#   concurrency: { group: <workflow>-<pr#/ref>, cancel-in-progress: true }
+# which cancels the whole run (this job included) when a new commit
+# lands on the same PR/branch. The 4-runner pool is the natural
+# concurrency cap. This mirrors the sibling golang_native_windows.yml,
+# which also runs with no concurrency group.
 
 jobs:
   golang_docker_windows:
@@ -59,18 +85,58 @@ jobs:
         run: |
           $ErrorActionPreference = 'Continue'
           try {
-            Get-Process -Name 'keploy' -ErrorAction SilentlyContinue | ForEach-Object {
-              Write-Host "Stopping leftover keploy.exe pid=$($_.Id)"
-              try { $_ | Stop-Process -Force -ErrorAction SilentlyContinue } catch {}
-            }
-            foreach ($name in @('WinDivert', 'WinDivert64')) {
-              $svc = Get-Service -Name $name -ErrorAction SilentlyContinue
-              if ($svc -and $svc.Status -ne 'Stopped') {
-                Write-Host "Stopping kernel driver service $name (status=$($svc.Status))"
-                try { Stop-Service -Name $name -Force -ErrorAction SilentlyContinue } catch {}
-              }
-            }
             $ws = $env:GITHUB_WORKSPACE
+            # Prefix with a trailing separator so `...\keploy` can't be
+            # mistaken for a sibling `...\keploy2`. Each self-hosted
+            # runner has a distinct $GITHUB_WORKSPACE, so the exe path is
+            # the reliable ownership key (see TEST PLAN assumption).
+            $wsPrefix = if ($ws) { $ws.TrimEnd('\','/') + '\' } else { $null }
+
+            # Job-scoped cleanup ONLY. Four self-hosted runners share this
+            # VM, so a bare `Get-Process -Name keploy | Stop-Process` (the
+            # old behaviour) would kill a sibling job's HOST keploy CLI
+            # (the process orchestrating that job's `docker compose up`),
+            # aborting its whole run. Our keploy binaries live under
+            # $ws\bin. Kill only THIS workspace's leftover keploy (e.g.
+            # from a prior interrupted run in this same workspace).
+            $ownKeploy = @(Get-Process -ErrorAction SilentlyContinue | Where-Object {
+              $_.ProcessName -like 'keploy*' -and $_.Path -and $wsPrefix -and
+              $_.Path.StartsWith($wsPrefix, [System.StringComparison]::OrdinalIgnoreCase)
+            })
+            foreach ($p in $ownKeploy) {
+              Write-Host "Stopping this workspace's leftover keploy pid=$($p.Id) path=$($p.Path)"
+              try { $p | Stop-Process -Force -ErrorAction SilentlyContinue } catch {}
+            }
+
+            # WinDivert reset is DEFENSIVE here: this docker-compose lane
+            # intercepts inside the compose network via a per-job eBPF
+            # keploy-agent container, so it does not load the host Windows
+            # WinDivert driver (that is the native-Windows lane's path).
+            # But WinDivert is still a SINGLE machine-wide kernel service,
+            # so if some other keploy on this VM ever did load it, the old
+            # UNCONDITIONAL `Stop-Service` would break that sibling. Only
+            # reset it when NO OTHER keploy is running. Our own leftovers
+            # were already killed above, so restrict the gate to keploy
+            # NOT under this workspace (or with an unreadable path —
+            # counted as "other" to stay conservative).
+            $otherKeploy = @(Get-Process -ErrorAction SilentlyContinue | Where-Object {
+              $_.ProcessName -like 'keploy*' -and -not (
+                $_.Path -and $wsPrefix -and
+                $_.Path.StartsWith($wsPrefix, [System.StringComparison]::OrdinalIgnoreCase)
+              )
+            })
+            if ($otherKeploy.Count -eq 0) {
+              foreach ($name in @('WinDivert', 'WinDivert64')) {
+                $svc = Get-Service -Name $name -ErrorAction SilentlyContinue
+                if ($svc -and $svc.Status -ne 'Stopped') {
+                  Write-Host "No other keploy running on this VM; resetting stale kernel driver service $name (status=$($svc.Status))"
+                  try { Stop-Service -Name $name -Force -ErrorAction SilentlyContinue } catch {}
+                }
+              }
+            } else {
+              Write-Host "Skipping WinDivert driver reset: $($otherKeploy.Count) other keploy process(es) running on this VM (sibling jobs may be capturing)."
+            }
+
             if ($ws -and (Test-Path $ws)) {
               $gitDir = Join-Path $ws '.git'
               $items = @(Get-ChildItem -Path $ws -Force -ErrorAction SilentlyContinue)

--- a/.github/workflows/test_workflow_scripts/golang/go-dedup/golang-docker-windows.ps1
+++ b/.github/workflows/test_workflow_scripts/golang/go-dedup/golang-docker-windows.ps1
@@ -22,7 +22,19 @@ if (-not $env:USERPROFILE -or $env:USERPROFILE -eq '') {
   if ($candidate -and $candidate -ne '') { $env:USERPROFILE = $candidate }
 }
 
-# Create Keploy config/home so docker doesn’t fall back to NetworkService
+# Create Keploy config/home so docker doesn’t fall back to NetworkService.
+#
+# Concurrency note: $USERPROFILE\.keploy(-config) is shared across all
+# jobs on this VM user, but that is SAFE. Recorded testcases/mocks/
+# reports land in the per-workspace ./keploy dir (cfg.Path defaults to
+# the CWD, which is this runner's own workspace) — NOT here. The only
+# thing keploy ever writes under ~/.keploy is keploy.yaml, a single
+# non-critical "update available" prompt flag (installation id is
+# machine-derived, not file-based). Worst case if two jobs race that
+# write is a re-shown update prompt; it never corrupts test data or
+# leaks state across jobs. Isolating it would mean overriding
+# USERPROFILE, which would break the docker volume-mount semantics this
+# block exists for, for zero correctness benefit — so it is left shared.
 try {
   if ($env:USERPROFILE -and $env:USERPROFILE -ne '') {
     $keployCfg = Join-Path $env:USERPROFILE ".keploy-config"
@@ -49,16 +61,33 @@ function Get-RunnerWorkPath {
 function Remove-KeployDirs {
   param([string[]]$Candidates)
 
-  # Stop any leftover keploy processes so files aren't locked
+  # Stop any leftover keploy processes so files aren't locked — but ONLY
+  # THIS job's own keploy, identified by executable path. Four runners
+  # share one VM; the old bare name/path/cmdline match would taskkill a
+  # sibling job's keploy (same exe name from its own workspace) mid-run.
+  # Our keploy exes live in the per-workspace bin dir
+  # ($GITHUB_WORKSPACE\bin\keploy-*.exe); when run locally (no
+  # workspace) fall back to the resolved RECORD_BIN/REPLAY_BIN paths.
+  $binDir = if ($env:GITHUB_WORKSPACE) { Join-Path $env:GITHUB_WORKSPACE 'bin' } else { $null }
+  # Trailing separator so a bin dir can't prefix-match a sibling dir.
+  $binDirPrefix = if ($binDir) { $binDir.TrimEnd('\','/') + '\' } else { $null }
+  $ownExePaths = @()
+  foreach ($b in @($env:RECORD_BIN, $env:REPLAY_BIN)) {
+    if ($b) {
+      $resolved = (Get-Command $b -ErrorAction SilentlyContinue).Source
+      if ($resolved) { $ownExePaths += $resolved }
+    }
+  }
   try {
     Get-Process -ErrorAction SilentlyContinue |
+      Where-Object { $_.ProcessName -like 'keploy*' -and $_.Path } |
       Where-Object {
-        $_.ProcessName -in @('keploy','keploy-record','keploy-replay') -or
-        $_.Path -like '*\keploy*.exe' -or
-        $_.CommandLine -like '*keploy*'
+        ($ownExePaths -contains $_.Path) -or
+        ($binDirPrefix -and $_.Path.StartsWith($binDirPrefix, [System.StringComparison]::OrdinalIgnoreCase))
       } |
       Sort-Object StartTime -Descending |
       ForEach-Object {
+        Write-Host "Stopping this job's leftover keploy pid=$($_.Id) path=$($_.Path)"
         taskkill /PID $_.Id /T /F | Out-Null 2>$null
       }
   } catch {}
@@ -103,9 +132,59 @@ function Find-FreePort {
   throw 'No free TCP port found'
 }
 
-$appPort = Find-FreePort
+# Allocate FOUR distinct free ports up-front so concurrent jobs on the
+# same self-hosted VM never share a port:
+#   $appPort      - host port docker publishes the sample on
+#   $proxyPort    - keploy --proxy-port       (see below - HOST-published)
+#   $incomingPort - keploy --incoming-proxy-port
+#   $dnsPort      - keploy --dns-port
+#
+# In docker-compose mode keploy injects a per-job `keploy-agent`
+# container into the compose project and intercepts via eBPF INSIDE the
+# compose network (pkg/client/app AddKeployAgentToCompose). That agent
+# container publishes only {AgentPort, ProxyPort, AppPorts} to the host
+# (pkg/platform/docker/docker.go GenerateKeployAgentService); dns-port
+# is forwarded to the container but bound in the container's own netns,
+# and incoming-proxy-port is not forwarded at all. So:
+#   - --proxy-port is the ESSENTIAL fix: it is host-published as
+#     `-p <proxyPort>:<proxyPort>`, so two jobs on the default 16789
+#     make the second `docker compose up` fail with "port is already
+#     allocated". AgentPort is separately OS-assigned (unique), and the
+#     app host port is $appPort. Making --proxy-port unique per job is
+#     what actually unblocks concurrency here.
+#   - --dns-port / --incoming-proxy-port are container-scoped in this
+#     mode and do NOT collide across jobs; we still pass unique values
+#     as harmless belt-and-suspenders (deterministic, and correct if a
+#     future/native path ever binds them on the host).
+# Each Find-FreePort call re-probes OS availability from a fresh random
+# high port; we de-dup so the four never coincide.
+function New-UniqueFreePort {
+  param([int[]]$Exclude = @())
+  while ($true) {
+    $p = Find-FreePort
+    if ($Exclude -notcontains $p) { return $p }
+  }
+}
+$appPort      = New-UniqueFreePort
+$proxyPort    = New-UniqueFreePort -Exclude @($appPort)
+$incomingPort = New-UniqueFreePort -Exclude @($appPort, $proxyPort)
+$dnsPort      = New-UniqueFreePort -Exclude @($appPort, $proxyPort, $incomingPort)
+
 $id = ([guid]::NewGuid()).ToString().Split('-')[0]
 $containerName = "dedup-go-$id"
+
+# Unique docker-compose PROJECT per job. Compose derives the project
+# name (and thus the default network `<project>_default` plus any named
+# volumes) from the working-directory BASENAME, which is `go-dedup` for
+# EVERY concurrent runner (each runner's workspace has a different
+# parent path but the same leaf dir). Without an explicit project name,
+# one job's `docker compose down` would tear down a sibling job's
+# network/containers. Pin the project to the per-job guid and EXPORT it
+# so every `docker compose` call in this script AND the `docker compose
+# up` that keploy spawns share the same, job-unique project.
+$env:COMPOSE_PROJECT_NAME = "keploy-$id"
+Write-Host "Using COMPOSE_PROJECT_NAME = $env:COMPOSE_PROJECT_NAME"
+Write-Host "Allocated ports -> app:$appPort proxy:$proxyPort incoming:$incomingPort dns:$dnsPort"
 
 $dcFile = Join-Path (Get-Location) 'docker-compose.yml'
 if (Test-Path $dcFile) {
@@ -226,6 +305,11 @@ $recArgs = @(
   'record',
   '-c', '"docker compose up"',
   '--container-name', $containerName,
+  # Per-job unique keploy ports so concurrent runs on the shared VM do
+  # not collide on bind (see the allocation block above).
+  '--proxy-port', "$proxyPort",
+  '--incoming-proxy-port', "$incomingPort",
+  '--dns-port', "$dnsPort",
   '--generate-github-actions=false'
 )
 
@@ -368,12 +452,31 @@ do {
 
 
 
-# If we don't have a PID (some environments), try a short polling fallback to find the process
+# If we don't have a PID (some environments), try a short polling
+# fallback to find the process. Scope the name match to THIS job's own
+# keploy exe path — a bare `Get-Process -Name keploy-record` would also
+# match a sibling job's keploy-record.exe (same name, own workspace) on
+# the shared VM and we'd end up killing the wrong process tree.
 if (-not $REC_PID -or $REC_PID -eq 0) {
   $exeName = [System.IO.Path]::GetFileNameWithoutExtension($env:RECORD_BIN)
+  $recBinDir = if ($env:GITHUB_WORKSPACE) { Join-Path $env:GITHUB_WORKSPACE 'bin' } else { $null }
+  # Trailing separator so a bin dir can't prefix-match a sibling dir.
+  $recBinDirPrefix = if ($recBinDir) { $recBinDir.TrimEnd('\','/') + '\' } else { $null }
+  $ownRecord = (Get-Command $env:RECORD_BIN -ErrorAction SilentlyContinue).Source
   for ($i = 0; $i -lt 10; $i++) {
     Start-Sleep -Seconds 1
-    $p = Get-Process -Name $exeName -ErrorAction SilentlyContinue | Sort-Object StartTime -Descending | Select-Object -First 1
+    # Wrapped so a property access on an exiting process can't turn into
+    # a terminating error under $ErrorActionPreference='Stop'.
+    try {
+      $p = Get-Process -Name $exeName -ErrorAction SilentlyContinue |
+        Where-Object {
+          $_.Path -and (
+            ($ownRecord -and $_.Path -eq $ownRecord) -or
+            ($recBinDirPrefix -and $_.Path.StartsWith($recBinDirPrefix, [System.StringComparison]::OrdinalIgnoreCase))
+          )
+        } |
+        Sort-Object StartTime -Descending | Select-Object -First 1
+    } catch { $p = $null }
     if ($p) { $REC_PID = $p.Id; break }
   }
 }
@@ -435,6 +538,11 @@ $testArgs = @(
   # reachable listener on the host. Without this flag replay
   # dials :8080 and gets TCP RST (run 24630753752, tests 1-9).
   '--port', "$appPort",
+  # Per-job unique keploy ports (must match the record phase's isolation
+  # so concurrent replays on the shared VM never collide on bind).
+  '--proxy-port', "$proxyPort",
+  '--incoming-proxy-port', "$incomingPort",
+  '--dns-port', "$dnsPort",
   '--generate-github-actions=false'
 )
 
@@ -491,6 +599,10 @@ $testArgsJson = @(
   '--api-timeout', '60',
   '--delay', '30',
   '--port', "$appPort",
+  # Per-job unique keploy ports (same isolation as the yaml replay).
+  '--proxy-port', "$proxyPort",
+  '--incoming-proxy-port', "$incomingPort",
+  '--dns-port', "$dnsPort",
   '--generate-github-actions=false'
 )
 $prevEap = $ErrorActionPreference


### PR DESCRIPTION
## Problem

The `golang_docker_windows` reusable workflow runs on a pool of **4 self-hosted Windows runners that share one physical VM**, but only **one job ran at a time** — the other 3 runners sat idle while jobs queued.

## Root cause

The workflow carried:

```yaml
concurrency:
  group: windows-docker-runner   # constant string
  cancel-in-progress: false
```

A **constant** group serializes the workflow **repo-wide**, so GitHub allowed a single run at a time. It was a band-aid for concurrent jobs colliding on shared-VM resources.

## Fix

Remove the serialization and eliminate the underlying collisions so all 4 runners can work in parallel:

- **Deleted the constant `concurrency` group.** Superseded-push cancellation is already handled one level up by the only caller, `prepare_and_run.yml` (`group: <workflow>-<pr#/ref>`, `cancel-in-progress: true`); the 4-runner pool is the natural concurrency cap. Mirrors `golang_native_windows.yml`, which runs with no group.
- **Per-job unique keploy `--proxy-port`** (the essential fix): in docker-compose mode keploy injects a per-job eBPF `keploy-agent` container and only `--proxy-port` is host-published (`-p <port>:<port>`), so two jobs on the default 16789 made the second `docker compose up` fail with "port is already allocated". `--dns-port`/`--incoming-proxy-port` are container-scoped and passed unique as belt-and-suspenders.
- **Per-job unique `COMPOSE_PROJECT_NAME`** (`keploy-<guid>`), exported so keploy's spawned `compose up` inherits it — otherwise every runner's project defaulted to the `go-dedup` dir basename and one job's `compose down` could tear down a sibling's network/containers.
- **Job-scoped process kills**: the "Recover stale runner state" step and `Remove-KeployDirs` now only kill keploy processes whose exe path is under this job's `$GITHUB_WORKSPACE`, and the WinDivert-service stop is gated on "no other keploy running" — the previous machine-wide `Get-Process keploy | Stop-Process` / unconditional `Stop-Service` would abort a sibling job mid-run.
- Unique app host port + container name were already handled; this extends the same per-job isolation to every remaining shared resource.

## Validation

Ran **two full keploy record+replay pipelines concurrently on the actual 4-runner VM** (isolated workspaces mirroring two runners):

| | job A | job B |
|---|---|---|
| compose project | `keploy-e0879780` | `keploy-af9036fb` |
| ports app/proxy/incoming/dns | `52615/57256/49959/51877` | `57071/52107/53680/59945` |
| recorded | 9 tests | 9 tests |
| replay (yaml + json) | **PASSED** | **PASSED** |

Both green simultaneously — distinct ports, distinct compose projects, each killed only its own keploy PID, zero bind collisions. `actionlint` clean.

Confirmed on the VM: 4 runner services each with their own `_work` root (distinct `$GITHUB_WORKSPACE`), and this lane captures via a containerized eBPF agent (not the host WinDivert driver), so there is no host driver-coexistence concern — the host collision surface is exactly the resources isolated above.
