### PR TITLE
fix(proxy/ingress): don't bind the app port during agent shutdown (flask-8000 port-reuse race)

### DIFF
--- a/pkg/agent/proxy/incoming/incoming.go
+++ b/pkg/agent/proxy/incoming/incoming.go
@@ -150,6 +150,15 @@ func (pm *IngressProxyManager) TCChan() chan *models.TestCase {
 // StartIngressProxy starts a new ingress proxy on the given original app port if it's not already running.
 // It delegates to the registered IngressHook (default: Go TCP forwarder).
 func (pm *IngressProxyManager) StartIngressProxy(ctx context.Context, origAppPort, newAppPort uint16) {
+	// If the agent is already shutting down, do not arm a new forwarder.
+	// WatchBindEvents delivers bind events over a buffered channel, so
+	// ListenForIngressEvents can still drain late/stale events after the context
+	// is canceled. Binding then would leave a listener holding the app's port
+	// (commonly 8000) for the next record run ("address already in use") and would
+	// also surface as a spurious ERROR log. Silently skip during teardown.
+	if ctx.Err() != nil {
+		return
+	}
 	pm.mu.Lock()
 	if _, ok := pm.active[origAppPort]; ok {
 		pm.mu.Unlock()
@@ -170,8 +179,16 @@ func (pm *IngressProxyManager) StartIngressProxy(ctx context.Context, origAppPor
 
 	if err := hook.StartIngress(ctx, origAppPort, newAppPort); err != nil {
 		close(startDone)
-		pm.logger.Error("Ingress hook failed to start; verify hook configuration/permissions and required kernel features, or disable the custom ingress hook",
-			zap.Uint16("orig_port", origAppPort), zap.Uint16("new_port", newAppPort), zap.Error(err))
+		if ctx.Err() != nil {
+			// The agent is shutting down (context canceled or deadline exceeded); a
+			// start failure here is expected teardown, not a real error. Keep it out
+			// of ERROR so it doesn't trip error-grep gates in CI record output.
+			pm.logger.Debug("Ingress forwarder start aborted; agent shutting down",
+				zap.Uint16("orig_port", origAppPort), zap.Uint16("new_port", newAppPort), zap.Error(err))
+		} else {
+			pm.logger.Error("Ingress hook failed to start; verify hook configuration/permissions and required kernel features, or disable the custom ingress hook",
+				zap.Uint16("orig_port", origAppPort), zap.Uint16("new_port", newAppPort), zap.Error(err))
+		}
 		pm.mu.Lock()
 		delete(pm.active, origAppPort)
 		pm.mu.Unlock()
@@ -270,9 +287,30 @@ func (h *goTCPIngressHook) StartIngress(ctx context.Context, origPort, newPort u
 			zap.Uint16("orig_port", origPort))
 	}
 
+	// If the agent is already shutting down, do NOT bind the ingress listener.
+	// A forwarder bound during teardown (e.g. from a late/stale bind event whose
+	// target wait above returned context.Canceled) can outlive StopAll's snapshot
+	// and linger holding the app's port (commonly 8000), so the next record run's
+	// application fails to bind it with "address already in use" — the flaky
+	// port-8000 reuse failure. Aborting here is safe: a canceled context means no
+	// ingress traffic will be served anyway.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		logger.Debug("Skipping ingress forwarder bind; agent context canceled (shutting down)",
+			zap.String("target", newAppAddr), zap.Error(ctxErr))
+		return ctxErr
+	}
+
 	listener, err := net.Listen("tcp4", origAppAddr)
 	if err != nil {
 		return fmt.Errorf("ingress proxy failed to listen on %s: %w", origAppAddr, err)
+	}
+	// Close the residual race: if the context was canceled while net.Listen was
+	// binding, release the port immediately and do NOT register the forwarder —
+	// otherwise it would linger holding the port and leave a stale forwarder entry
+	// that blocks re-arming it later.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		_ = listener.Close()
+		return ctxErr
 	}
 	tcpListener, ok := listener.(*net.TCPListener)
 	if !ok {
@@ -286,6 +324,12 @@ func (h *goTCPIngressHook) StartIngress(ctx context.Context, origPort, newPort u
 
 	go func() {
 		defer close(done)
+		// Release the listener (and its bound port) whenever the accept loop exits,
+		// even if StopIngress is never called for this forwarder (e.g. it raced with
+		// shutdown and missed StopAll's snapshot). Close is idempotent — StopIngress
+		// may also close it — and this runs before close(done) so a StopIngress
+		// waiter observes the port freed. Prevents the port from lingering post-exit.
+		defer func() { _ = listener.Close() }()
 		sem := make(chan struct{}, 1)
 		for {
 			select {

--- a/pkg/agent/proxy/incoming/incoming_test.go
+++ b/pkg/agent/proxy/incoming/incoming_test.go
@@ -3,8 +3,13 @@ package proxy
 import (
 	"context"
 	"net"
+	"strconv"
 	"testing"
 	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestWaitForIngressTargetReady(t *testing.T) {
@@ -58,5 +63,139 @@ func TestWaitForIngressTargetWhenKnownSkipsUnknownPort(t *testing.T) {
 	}
 	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
 		t.Fatalf("unknown redirected port should skip immediately, took %s", elapsed)
+	}
+}
+
+func newTestIngressHook() *goTCPIngressHook {
+	return newGoTCPIngressHook(&IngressProxyManager{logger: zap.NewNop()})
+}
+
+func freeTCPPort(t *testing.T) uint16 {
+	t.Helper()
+	// Probe on 0.0.0.0 (the address the forwarder binds) so the port we hand back
+	// is actually free for that bind, then release it for the caller to claim.
+	ln, err := net.Listen("tcp4", "0.0.0.0:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := uint16(ln.Addr().(*net.TCPAddr).Port)
+	_ = ln.Close()
+	return port
+}
+
+// A forwarder must NOT bind the app port when the agent context is already
+// canceled (shutting down). Binding during teardown leaves the listener holding
+// the port, so the next record run's application fails to bind it with "address
+// already in use" — the flaky port-8000 reuse failure.
+func TestStartIngressSkipsBindWhenContextCanceled(t *testing.T) {
+	hook := newTestIngressHook()
+	port := freeTCPPort(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // agent already shutting down
+
+	if err := hook.StartIngress(ctx, port, 0); err == nil {
+		t.Fatal("expected StartIngress to abort on a canceled context, got nil")
+	}
+
+	// The port must be free — the fix must not have bound it.
+	ln, err := net.Listen("tcp4", "0.0.0.0:"+strconv.Itoa(int(port)))
+	if err != nil {
+		t.Fatalf("port %d should be free after a canceled StartIngress, but bind failed: %v", port, err)
+	}
+	_ = ln.Close()
+
+	hook.mu.Lock()
+	_, registered := hook.forwarders[port]
+	hook.mu.Unlock()
+	if registered {
+		t.Fatalf("no forwarder should be registered for port %d after a canceled StartIngress", port)
+	}
+}
+
+// The normal path must bind the port and fully release it on StopIngress, so a
+// subsequent run can rebind it immediately.
+func TestStartIngressReleasesPortOnStop(t *testing.T) {
+	hook := newTestIngressHook()
+	port := freeTCPPort(t)
+
+	if err := hook.StartIngress(context.Background(), port, 0); err != nil {
+		t.Fatalf("StartIngress: %v", err)
+	}
+
+	// Port is bound now.
+	if ln, err := net.Listen("tcp4", "0.0.0.0:"+strconv.Itoa(int(port))); err == nil {
+		_ = ln.Close()
+		t.Fatalf("port %d should be bound by the running forwarder", port)
+	}
+
+	if err := hook.StopIngress(port); err != nil {
+		t.Fatalf("StopIngress: %v", err)
+	}
+
+	// Port must be released.
+	ln, err := net.Listen("tcp4", "0.0.0.0:"+strconv.Itoa(int(port)))
+	if err != nil {
+		t.Fatalf("port %d should be free after StopIngress, but bind failed: %v", port, err)
+	}
+	_ = ln.Close()
+}
+
+// The teardown guard in StartIngressProxy must be SILENT: a bind event drained
+// after context cancel must not arm a forwarder AND must not emit an ERROR log
+// (the flask-secret CI lane fails on any ERROR in the record output).
+func TestStartIngressProxySilentOnCanceledContext(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	pm := &IngressProxyManager{
+		logger: zap.New(core),
+		active: make(map[uint16]proxyStop),
+	}
+	pm.ingressHook = newGoTCPIngressHook(pm)
+
+	port := freeTCPPort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // agent already shutting down
+
+	pm.StartIngressProxy(ctx, port, 0)
+
+	if n := logs.FilterLevelExact(zapcore.ErrorLevel).Len(); n != 0 {
+		t.Fatalf("expected no ERROR logs when skipping a forwarder during teardown, got %d: %v", n, logs.All())
+	}
+	pm.mu.Lock()
+	_, active := pm.active[port]
+	pm.mu.Unlock()
+	if active {
+		t.Fatalf("no forwarder should be armed for port %d after a canceled StartIngressProxy", port)
+	}
+	if ln, err := net.Listen("tcp4", "0.0.0.0:"+strconv.Itoa(int(port))); err != nil {
+		t.Fatalf("port %d should be free after a canceled StartIngressProxy, bind failed: %v", port, err)
+	} else {
+		_ = ln.Close()
+	}
+}
+
+// When the accept loop exits because its context was canceled (and StopIngress is
+// never called), the deferred listener.Close must still release the port so the
+// next run can rebind it. Without that defer this test times out.
+func TestStartIngressReleasesPortWhenAcceptLoopExits(t *testing.T) {
+	hook := newTestIngressHook()
+	port := freeTCPPort(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := hook.StartIngress(ctx, port, 0); err != nil {
+		t.Fatalf("StartIngress: %v", err)
+	}
+	cancel() // cancel WITHOUT calling StopIngress
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if ln, err := net.Listen("tcp4", "0.0.0.0:"+strconv.Itoa(int(port))); err == nil {
+			_ = ln.Close()
+			return // port released by the accept-loop defer
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("port %d not released within 5s after context cancel without StopIngress", port)
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
 }


### PR DESCRIPTION
## Problem

The `run_python_linux / flask-secret` CI lane fails intermittently during **record**:

```
 * Serving Flask app 'main'
Address already in use
Port 8000 is in use by another program.
```

The record log of the *previous* run in the same lane shows keploy binding port 8000 **during its own shutdown**, right before the next app start fails:

```
Redirected ingress target was not listening before proxy bind; starting ingress forwarder anyway {"error": "context canceled"}
Started ingress forwarding {"orig_port": 8000, "new_port": 49286}
```

## Root cause

`WatchBindEvents` delivers bind events over a **buffered** channel. On shutdown the producer stops, but `ListenForIngressEvents` keeps draining already-buffered events, each calling `StartIngressProxy(canceledCtx, …)`. The Go TCP ingress hook (`goTCPIngressHook.StartIngress`) then **binds the app's port (8000) even though the context is already canceled**, and the accept loop only closed the listener via `StopIngress` — so a forwarder armed during teardown can linger holding the port, and the next `keploy record` run's application fails to bind it with "address already in use".

## Fix

Refuse to arm/keep an ingress forwarder once the agent is shutting down, and always release the listener:

- **`StartIngressProxy`** — return early (silently) when `ctx.Err() != nil`, *before* reserving the active slot.
- **`StartIngress`** — abort the bind if `ctx` is canceled before **or during** `net.Listen`; when it races the bind, close the listener and return without registering a forwarder (no stale entry, no lingering port).
- **Accept loop** — `defer listener.Close()` so the port is released whenever the loop exits, even if `StopIngress` is never called for a forwarder that raced shutdown.
- **Logging** — route canceled/deadline start failures to `Debug`, not `ERROR`, so teardown doesn't trip CI error-grep gates (otherwise this fix would just re-flake the lane with a new signature).

## Tests (`pkg/agent/proxy/incoming/incoming_test.go`)

- `TestStartIngressSkipsBindWhenContextCanceled` — canceled ctx → no bind, port free.
- `TestStartIngressProxySilentOnCanceledContext` — canceled ctx → **zero ERROR logs** (zap observer), no forwarder armed, port free.
- `TestStartIngressReleasesPortWhenAcceptLoopExits` — cancel without `StopIngress` → the accept-loop defer frees the port.
- `TestStartIngressReleasesPortOnStop` — normal bind + `StopIngress` release path.

`go vet` clean; all tests pass under `-race -count=3` (no flake); `go build ./pkg/agent/...` OK. Adversarially reviewed and iterated to clean.
