### PR TITLE
fix(replay): rewind consumed-mock pool between mock-consistency retry cycles

### DIFF
--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1558,6 +1558,31 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		totalConsumedMocks[m.Name] = m
 		passingTotalConsumedMocks[m.Name] = m
 	}
+
+	// Snapshot the post-setup consumed-mock baseline. These are the
+	// reusable/session mocks (driver handshake, auth, connection pool
+	// warm-up) consumed during application bootstrap, before any test
+	// fires. Each mock-consistency retry cycle re-runs the passing tests
+	// as a fresh forward pass, so its serving pool must START from this
+	// baseline — see the rewind at the top of the replay loop below.
+	baselineConsumedMocks := make(map[string]models.MockState, len(totalConsumedMocks))
+	for k, v := range totalConsumedMocks {
+		baselineConsumedMocks[k] = v
+	}
+	// Persistent union of every MockState consumed across ALL retry cycles.
+	// totalConsumedMocks is rewound to baselineConsumedMocks at the start of
+	// each retry cycle, so after the loop it no longer holds the full set of
+	// consumed mocks. Two post-loop readers need that full union: the
+	// run-level Mocks-Consumed telemetry (r.consumedMockNames) and the
+	// schema-noise-detection persistence (PersistMockNoise, which reads the
+	// learned ReqBodyNoise off each MockState value — including mocks a later
+	// test failed on). Fold consumed mocks in here as cycles complete; last
+	// write wins, matching the pre-rewind behavior where a re-consumed mock's
+	// final-cycle MockState overwrote earlier ones.
+	allConsumedAcrossCycles := make(map[string]models.MockState, len(totalConsumedMocks))
+	for k, v := range totalConsumedMocks {
+		allConsumedAcrossCycles[k] = v
+	}
 	// Build a lookup of mock name -> summary and protocol from the mock registry (once per test set).
 	type mockInfo struct {
 		summary  string
@@ -1634,6 +1659,29 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		itr = 5
 	}
 	for replay := 0; replay < itr; replay++ {
+		// Mock-consistency retry cycles (replay > 0) re-run the tests that
+		// passed the previous cycle as a fresh forward pass. Rewind the
+		// consumed-mock filter to the post-setup baseline so each re-run
+		// test's PER-TEST single-use mocks — consumed via DeleteFilteredMock
+		// and flagged Usage=Deleted during the previous cycle — are served
+		// again. Without this rewind those mocks stay in totalConsumedMocks
+		// as Deleted; the agent's filterOutDeleted then strips them from the
+		// retry pool and every test that drives a per-test mock (MongoDB
+		// find/update, SQL query, non-idempotent HTTP) fails the retry with
+		// match_phase=no_mocks even though it passed the first pass. The
+		// window filter alone can't save them: the mock IS in the window,
+		// it's the Deleted flag that removes it. Mocks consumed in the prior
+		// cycle are folded into allConsumedAcrossCycles first so the post-loop
+		// readers (Mocks-Consumed telemetry and PersistMockNoise) stay complete.
+		if replay > 0 {
+			for k, v := range totalConsumedMocks {
+				allConsumedAcrossCycles[k] = v
+			}
+			totalConsumedMocks = make(map[string]models.MockState, len(baselineConsumedMocks))
+			for k, v := range baselineConsumedMocks {
+				totalConsumedMocks[k] = v
+			}
+		}
 		var nextTestsToRun []*models.TestCase
 		var currentFailures int
 		var currentObsolete int
@@ -2658,6 +2706,17 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		}
 	}
 
+	// Fold every mock consumed since the last rewind into the cross-cycle
+	// union — the final main-loop cycle's mocks and the streaming Phase 2
+	// mocks (Phase 2 appends to totalConsumedMocks and never rewinds).
+	// Earlier retry cycles were already folded at each rewind above. This
+	// must run after Phase 2's last write so the post-loop readers
+	// (PersistMockNoise and the Mocks-Consumed telemetry) see the complete
+	// union of everything consumed across all cycles and phases.
+	for k, v := range totalConsumedMocks {
+		allConsumedAcrossCycles[k] = v
+	}
+
 	timeTaken := time.Since(startTime)
 
 	testCaseResults, err := r.reportDB.GetTestCaseResults(runTestSetCtx, testRunID, testSetID)
@@ -2819,7 +2878,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			PersistMockNoise(ctx context.Context, testSetID string, mockStates map[string]models.MockState) error
 		}
 		if p, ok := r.mockDB.(mockNoisePersister); ok {
-			if err := p.PersistMockNoise(runTestSetCtx, testSetID, totalConsumedMocks); err != nil {
+			if err := p.PersistMockNoise(runTestSetCtx, testSetID, allConsumedAcrossCycles); err != nil {
 				utils.LogError(r.logger, err, "failed to persist learned request-body noise onto mocks")
 			}
 		} else {
@@ -2998,10 +3057,13 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		}
 	}
 
-	// Merge mock NAMES (not the count) into the run-level distinct
-	// set so duplicates across test sets aren't double-counted.
+	// Merge mock NAMES (not the count) into the run-level distinct set so
+	// duplicates across test sets aren't double-counted. allConsumedAcrossCycles
+	// is the cross-cycle union (folded at each rewind and once after the loop),
+	// so names consumed only in an earlier retry cycle aren't lost from the
+	// Mocks-Consumed telemetry.
 	r.completeTestReportMu.Lock()
-	for name := range totalConsumedMocks {
+	for name := range allConsumedAcrossCycles {
 		r.consumedMockNames[name] = struct{}{}
 	}
 	r.completeTestReportMu.Unlock()


### PR DESCRIPTION
## Problem

The mock-consistency retry re-runs previously-passing tests to validate mock consistency whenever a replay cycle had a failure (`RunTestSet`, `for replay := 0; replay < itr; replay++`, `itr=5` under `RetryPassing`; re-runs the passing set, breaks on `currentFailures==0 || replay==2`). But it never resets `totalConsumedMocks` between cycles.

Per-test single-use mocks (`LifetimePerTest`: MongoDB find/update/insert, SQL query, non-idempotent HTTP) are consumed during a cycle via `DeleteFilteredMock` and recorded into `totalConsumedMocks` flagged `Usage=Deleted`. That map is the sole gate the agent uses (`SendMockFilterParamsToAgent` → `filterOutDeleted`) to decide which mocks to serve. So on every retry cycle the agent strips those per-test mocks from the serving pool and the re-run passing tests fail with `match_phase=no_mocks, candidates:0` — even though they passed the first pass and their mocks are recorded and correct.

Net effect: **once any single flaky failure in cycle 0 triggers the retry, every subsequent-cycle test that drives a per-test mock is turned into a false `no_mocks` failure.** A real product bug for anyone running with `RetryPassing`, independent of protocol.

## Root cause & reproduction

Deterministic local repro (a mongo sample under `RetryPassing`): induce exactly one cycle-0 failure (corrupt a single unrelated mock) so the retry fires. On unfixed keploy the previously-passing mongo tests then fail the retry with `no_mocks`; with the fix they pass. Measured on the fixed binary: **0 spurious `no_mocks` across 8 runs** (the retry still fires every run — the path is exercised, not disabled — and only the intentionally-corrupted test fails); on the unfixed binary the passing mongo tests fail the retry **100% of runs**.

> Scope note: this is distinct from the memoryguard mock-drop flake on the `go-memory-load-mongo` lanes (`--memory-limit 200`), where mocks are dropped at *record* time under memory pressure and are already absent in cycle 0. That is a separate issue; this PR does not address it.

## Fix

Rewind the consumed-mock serving filter to a post-setup baseline at the start of each retry cycle, so each re-run pass serves the same pool the first pass saw:

- Snapshot `baselineConsumedMocks` right after the setup-consumed population (bootstrap/handshake/auth/session mocks) — before the loop.
- At the top of each retry cycle (`replay > 0`), rewind `totalConsumedMocks` to that baseline; the per-test mocks (still in the window; only removed by the `Deleted` flag) are served again.
- Keep a cross-cycle **MockState** union (`allConsumedAcrossCycles`) so the two post-loop readers stay complete despite the rewind:
  - `r.consumedMockNames` (Mocks-Consumed telemetry) — identical output on both the no-retry and retry paths.
  - `PersistMockNoise` (the `--schema-noise-detection` prune-free path) — still persists learned `req_body_noise` from **all** consumed mocks (including a mock a later test failed on, and including streaming Phase 2 mocks). Passing the rewound map here would silently drop that noise; the union preserves it (last-write-wins, matching pre-rewind behavior).

Session/bootstrap mocks (in the baseline) and the passing-test persistence/pruning union (`passingTotalConsumedMocks`) are untouched. When `RetryPassing` is off (`itr=1`) the rewind never runs and behavior is byte-for-byte unchanged.

## Validation

- Deterministic repro above (bug replicated before the fix; fix verified).
- `go build`/`go vet` clean (`-mod=readonly`).
- Independently code-reviewed across three rounds — the review caught and I fixed two refactor regressions (a dropped `PersistMockNoise` noise-union, and a fold placed before streaming Phase 2's writes) before this was opened.
