### PR TITLE
fix(agent): retain memory-pressure ranges by count, not 7s age, to fix orphan test cases (Fixes #4336)

### DIFF
--- a/pkg/agent/proxy/syncMock/pressure_range_retention_test.go
+++ b/pkg/agent/proxy/syncMock/pressure_range_retention_test.go
@@ -1,0 +1,62 @@
+package manager
+
+import (
+	"testing"
+	"time"
+)
+
+// TestPressureRangesRetainedBeyondFormerStaleness is the regression guard for
+// the #4336 orphan-TC fix. The pressure-range history must be retained by
+// COUNT, not by wall-clock age: routes/record.go's test-case stream can lag the
+// recorder by far more than the former 7s staleness horizon, so a range that
+// caused a mock drop must still be queryable when the lagging TC is finally
+// checked. Under the old age-based prune the range was reaped and the orphan
+// slipped through (replay: match_phase=no_mocks); under the count cap it
+// survives. This test fails against the pre-fix time-prune and passes after.
+func TestPressureRangesRetainedBeyondFormerStaleness(t *testing.T) {
+	t.Parallel()
+
+	// A pressure interval that opened and closed a full minute ago — well
+	// beyond the former 7s staleness horizon that used to prune it.
+	old := time.Now().Add(-time.Minute)
+	mgr := &SyncMockManager{
+		pressureRanges: []pressureRange{{start: old.Add(-time.Second), end: old}},
+	}
+
+	// memoryguard keeps ticking SetMemoryPressure long after that interval
+	// closed. Every such call ran the old age-based prune, which would have
+	// dropped the minute-old range. The count cap must not.
+	mgr.SetMemoryPressure(true)
+	mgr.SetMemoryPressure(false)
+	mgr.SetMemoryPressure(true)
+	mgr.SetMemoryPressure(false)
+
+	// The exact query routes/record.go makes when it belatedly processes a TC
+	// whose HTTP window overlaps that old pressure interval. It must still see
+	// the pressure so it suppresses the orphan.
+	has, count := mgr.WasPressureActiveInWindow(old.Add(-time.Second), old)
+	if !has || count == 0 {
+		t.Fatalf("pressure range older than the former 7s staleness was lost (has=%v count=%d); a lagging record.go would fail to suppress the orphan TC and replay would report match_phase=no_mocks", has, count)
+	}
+}
+
+// TestPressureRangeCountCapEvictsOldest verifies the memory bound: past
+// maxPressureRanges intervals the slice is capped (oldest evicted, newest kept),
+// so retention-by-count cannot leak unbounded over a long recording.
+func TestPressureRangeCountCapEvictsOldest(t *testing.T) {
+	t.Parallel()
+
+	mgr := &SyncMockManager{}
+	// Each true→false pair appends exactly one closed range.
+	for i := 0; i < maxPressureRanges+64; i++ {
+		mgr.SetMemoryPressure(true)
+		mgr.SetMemoryPressure(false)
+	}
+
+	mgr.mu.Lock()
+	n := len(mgr.pressureRanges)
+	mgr.mu.Unlock()
+	if n > maxPressureRanges {
+		t.Fatalf("pressureRanges exceeded the count cap: got %d, want <= %d", n, maxPressureRanges)
+	}
+}

--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -20,16 +20,21 @@ const defaultMockBufferCapacity = 100
 // staleness cutoff keeps reachable, while staying O(1) memory.
 const maxRecentWindows = 256
 
-// pressureRangeStaleness bounds how long a CLOSED memory-pressure interval is
-// retained in SyncMockManager.pressureRanges. It is the same 7 s staleness
-// horizon the mock buffer and recentWindows already use: a pressure range that
-// ended longer ago than this can no longer overlap any still-live mock or test
-// window (both are stale-dropped at the same cutoff), so it is safe to prune.
-// Without this, the slice would grow by one entry per pressure transition for
-// the entire recording — under continuous recording that is an unbounded memory
-// leak and an ever-slower WasPressureActiveInWindow / pressureActiveAtLocked
-// scan (both loop over every range).
-const pressureRangeStaleness = 7 * time.Second
+// maxPressureRanges bounds SyncMockManager.pressureRanges by COUNT, not by
+// wall-clock age. An earlier version time-pruned closed ranges 7 s after they
+// ended, on the assumption that nothing older could still be queried. That is
+// wrong for the orphan-TC suppression in routes/record.go: the test-case stream
+// lags the recorder — a backed-up channel plus a slow CLI drain routinely puts
+// it MORE than 7 s behind — so a range that caused a mock drop is reaped before
+// the TC whose window overlaps it is ever checked, and the orphan is persisted
+// (replay then fails match_phase=no_mocks). Retention therefore must be
+// independent of how far record.go lags. Keep the newest maxPressureRanges
+// intervals and evict the oldest: memoryguard opens at most one range per
+// pause/resume cycle (a few per second of sustained pressure at most), so this
+// holds hundreds of recording sessions' worth of history — far more than
+// record.go could ever lag behind — while staying O(1) memory and keeping the
+// O(n) WasPressureActiveInWindow / pressureActiveAtLocked scans bounded.
+const maxPressureRanges = 8192
 
 // resolvedWindow is one already-resolved per-test window retained so a
 // late-arriving mock (decoded after the window closed) can still be
@@ -152,17 +157,26 @@ type SyncMockManager struct {
 	//
 	// This is the join key for the Bug 0 TC-suppression fix:
 	// WasPressureActiveInWindow checks whether any range overlaps a TC's
-	// [HTTPReq.Timestamp, HTTPResp.Timestamp] window. Using pressure ranges
-	// instead of per-mock drop timestamps is RACE-FREE — memoryguard records
-	// the start the instant it flips memoryPause, BEFORE any mock-parser
-	// goroutine sees the result; so even if the paired AddMock fires AFTER
-	// the TC has reached routes/record.go, the overlap is already visible.
+	// [HTTPReq.Timestamp, HTTPResp.Timestamp] window. Using pressure INTERVALS
+	// instead of per-mock drop timestamps is what makes suppression parser-
+	// agnostic: any parser (mongo in keploy/integrations, postgres, http…) that
+	// drops captured bytes on memoryguard.IsRecordingPaused() drops within an
+	// interval this slice records, so record.go catches the overlap without the
+	// parser reporting anything. Note the ordering is NOT a strict happens-before
+	// on m.memoryPause: memoryguard flips the GLOBAL recordingPaused flag (which
+	// the parser reads) just BEFORE it calls SetMemoryPressure to open the range,
+	// so there is a sub-microsecond gap where a parser could drop with no range
+	// yet recorded. Correctness does not rely on that gap being closed — it rests
+	// on record.go querying the range much later (by which time it exists), and
+	// on the drop preceding the mock's HTTPResp.Timestamp by far more than the
+	// open latency, so the TC window still overlaps the recorded interval.
 	//
-	// Bounded, not unbounded: SetMemoryPressure prunes closed ranges older
-	// than pressureRangeStaleness on every call, so the slice stays small
-	// (~the last few seconds) no matter how long recording runs. This keeps
-	// continuous recording from accumulating millions of intervals and
-	// slowing every overlap scan.
+	// Bounded, not unbounded: SetMemoryPressure caps the slice at
+	// maxPressureRanges by COUNT (evicting the oldest), NOT by wall-clock age.
+	// Age-based pruning would reap a range before a lagging routes/record.go
+	// could check the TC it orphaned; a count cap is independent of that lag
+	// while still keeping continuous recording from accumulating unbounded
+	// intervals and slowing every overlap scan.
 	pressureRanges []pressureRange
 
 	// loggerMu guards logger so SetLogger and the drop path can run
@@ -775,23 +789,6 @@ func (m *SyncMockManager) SetMemoryPressure(enabled bool) {
 	wasEnabled := m.memoryPause
 	m.memoryPause = enabled
 
-	// Prune the pressure-range history to the staleness horizon so it stays
-	// bounded under continuous recording (mentor review #4220, syncMock.go:119).
-	// Keep the currently-open range (end == zero) and any range that ended
-	// within the last pressureRangeStaleness; drop the rest. memoryguard calls
-	// this every 500 ms, so the slice never holds more than ~the last few
-	// seconds of history regardless of recording length. In-place filter,
-	// preserving order (the open range, if any, is newest so stays last).
-	if cutoff := now.Add(-pressureRangeStaleness); len(m.pressureRanges) > 0 {
-		kept := m.pressureRanges[:0]
-		for _, r := range m.pressureRanges {
-			if r.end.IsZero() || r.end.After(cutoff) {
-				kept = append(kept, r)
-			}
-		}
-		m.pressureRanges = kept
-	}
-
 	var clearedFromBuffer int
 	if enabled {
 		if !wasEnabled {
@@ -841,6 +838,18 @@ func (m *SyncMockManager) SetMemoryPressure(enabled bool) {
 		if n := len(m.pressureRanges); n > 0 && m.pressureRanges[n-1].end.IsZero() {
 			m.pressureRanges[n-1].end = now
 		}
+	}
+
+	// Bound the range history by count (see maxPressureRanges). Evict the
+	// oldest intervals: routes/record.go consumes TCs oldest-first, so anything
+	// beyond the newest maxPressureRanges was streamed and checked long ago.
+	// Copy into a right-sized slice so the backing array does not pin the
+	// evicted entries. Eviction is rare (only past thousands of pressure
+	// cycles) so the allocation is not a hot path.
+	if n := len(m.pressureRanges); n > maxPressureRanges {
+		trimmed := make([]pressureRange, maxPressureRanges)
+		copy(trimmed, m.pressureRanges[n-maxPressureRanges:])
+		m.pressureRanges = trimmed
 	}
 	m.mu.Unlock() // NEVER hold mu while logging — logging inside a lock causes a deadlock under I/O pressure (see BUG 5: 70-minute CI hang)
 

--- a/pkg/agent/proxy/syncMock/syncMock_test.go
+++ b/pkg/agent/proxy/syncMock/syncMock_test.go
@@ -1717,43 +1717,53 @@ func TestSetMemoryPressurePreservesStartupMocks(t *testing.T) {
 	}
 }
 
-// TestSetMemoryPressurePrunesStaleRanges asserts the pressureRanges history is
-// bounded: SetMemoryPressure drops CLOSED ranges that ended longer ago than the
-// staleness horizon, but always keeps a still-open range. Without this the slice
-// would grow unbounded under continuous recording (mentor review #4220:119).
-func TestSetMemoryPressurePrunesStaleRanges(t *testing.T) {
+// TestSetMemoryPressureRetainsClosedRanges asserts pressureRanges is retained by
+// COUNT, not pruned by wall-clock age (the #4336 fix). A range that closed long
+// ago must survive so a lagging routes/record.go still finds it when it
+// belatedly checks the TC that range orphaned — age-pruning it (as the old code
+// did after 7s) let the orphan through and replay reported match_phase=no_mocks.
+// A still-open range is likewise always kept.
+func TestSetMemoryPressureRetainsClosedRanges(t *testing.T) {
 	t.Parallel()
 
 	now := time.Now()
 
-	// Two stale closed ranges (ended well before the horizon) + one recent one.
+	// Two ranges that closed long ago + one recent. None may be dropped by age.
 	mgr := &SyncMockManager{
 		pressureRanges: []pressureRange{
-			{start: now.Add(-60 * time.Second), end: now.Add(-50 * time.Second)}, // stale → prune
-			{start: now.Add(-30 * time.Second), end: now.Add(-20 * time.Second)}, // stale → prune
-			{start: now.Add(-4 * time.Second), end: now.Add(-2 * time.Second)},   // recent → keep
+			{start: now.Add(-60 * time.Second), end: now.Add(-50 * time.Second)},
+			{start: now.Add(-30 * time.Second), end: now.Add(-20 * time.Second)},
+			{start: now.Add(-4 * time.Second), end: now.Add(-2 * time.Second)},
 		},
 	}
-	// memoryPause is already false, so calling with false is a no-op transition
-	// that still runs the prune.
+	// memoryPause is already false, so this is a no-op transition — it must NOT
+	// drop any range by age.
 	mgr.SetMemoryPressure(false)
-	if got := len(mgr.pressureRanges); got != 1 {
-		t.Fatalf("expected stale closed ranges pruned to 1 recent range; got %d", got)
+	if got := len(mgr.pressureRanges); got != 3 {
+		t.Fatalf("closed ranges must be retained (not age-pruned); want 3, got %d", got)
 	}
 
-	// A still-open range (end == zero) must never be pruned, even if it started
-	// long ago (a single long pressure spell).
+	// A still-open range (end == zero) is kept alongside a long-closed one.
 	mgr2 := &SyncMockManager{
 		memoryPause: true,
 		pressureRanges: []pressureRange{
-			{start: now.Add(-60 * time.Second), end: now.Add(-50 * time.Second)}, // stale closed → prune
-			{start: now.Add(-40 * time.Second)},                                  // open → keep
+			{start: now.Add(-60 * time.Second), end: now.Add(-50 * time.Second)}, // closed, old → retained
+			{start: now.Add(-40 * time.Second)},                                  // open → kept
 		},
 	}
-	// true→true: no new range opened, just the prune.
+	// true→true: no new range opened, and no age-prune.
 	mgr2.SetMemoryPressure(true)
-	if got := len(mgr2.pressureRanges); got != 1 || !mgr2.pressureRanges[0].end.IsZero() {
-		t.Fatalf("expected only the open range kept; got %d ranges", got)
+	if got := len(mgr2.pressureRanges); got != 2 {
+		t.Fatalf("expected both the old closed range and the open range retained; got %d", got)
+	}
+	openFound := false
+	for _, r := range mgr2.pressureRanges {
+		if r.end.IsZero() {
+			openFound = true
+		}
+	}
+	if !openFound {
+		t.Fatal("the still-open range must be preserved")
 	}
 }
 


### PR DESCRIPTION
Fixes #4336. (This PR was reworked — see history — from a per-drop ledger to a much smaller, parser-agnostic retention fix; the ledger instrumented the wrong drop sites for mongo.)

## Problem

`go-memory-load-mongo` (~75% red) fails at replay with `match_phase=no_mocks`:

```
mock mismatch: no matching mock for outgoing call
  {"protocol":"MongoDB","actual":"findAndModify on large_payloads","match_phase":"no_mocks","candidates":0}
```

Under `--memory-limit 200` the agent's memory guard pauses recording at 80%, and each protocol parser (mongo lives in `keploy/integrations`, plus postgres, http…) independently stops decoding captured bytes while `memoryguard.IsRecordingPaused()`. A mock dropped that way **orphans** its test case: the ingress TC is persisted but its paired egress mock was never recorded, so replay has nothing to match.

## Why the existing suppressor misses it

#4220 already handles this: `SetMemoryPressure` records each memory-pressure interval into `pressureRanges` **centrally** (so it's parser-agnostic — it doesn't matter which parser dropped), and `routes/record.go` suppresses any TC whose HTTP window `[HTTPReq.Timestamp, HTTPResp.Timestamp]` overlaps a recorded interval (`WasPressureActiveInWindow`). A suppressed TC is never sent, so it can't orphan.

The bug: `SetMemoryPressure` prunes closed intervals **7s** after they end (`pressureRangeStaleness`), but the `record.go` test-case stream lags the recorder by **more** than that under load (a backed-up channel + slow CLI drain). So the interval that caused a drop is reaped before the lagging TC is checked, the overlap query comes back empty, and the orphan is persisted.

## Fix

Replace the age-based prune with a **count cap** (`maxPressureRanges = 8192`, evict oldest). Retention becomes independent of how far `record.go` lags: memoryguard opens at most one interval per pause/resume cycle, so 8192 holds hundreds of recording sessions' worth of history and never evicts an interval a lagging `record.go` still needs, while keeping the slice bounded and the O(n) overlap scans fast.

- **keploy-only** — `pkg/agent/proxy/syncMock/syncMock.go`. No parser or `integrations` change; the suppression already reads the central interval list.
- `WasPressureActiveInWindow` / `pressureActiveAtLocked` / the `record.go` gate are unchanged.
- Coverage-for-correctness: under sustained pressure a few extra TCs are suppressed (any overlapping a pause) rather than persisted-then-failing. Suppression only ever removes orphan-prone TCs; a suppressed TC's successfully-captured mocks become harmless orphan *mocks* (replay ignores unused mocks). It does not weaken the tolerance, change the limit, or alter the sample.

## Validation

- Rewrote the obsolete age-prune test to assert the retention contract, and added two deterministic regression guards: a range older than the former 7s horizon survives repeated `SetMemoryPressure` ticks (fails against the pre-fix prune), and the count cap evicts the oldest.
- `go build`/`vet`/`gofmt` clean; `go test -race ./pkg/agent/proxy/syncMock/...` green.
- Independently reviewed across four lenses (mongo-correctness, over-suppression blast radius, buffer-wipe interaction, mechanics).

## Known residual (out of scope; `integrations`)

`integrations/pkg/mongo/v2/encode.go:102` falls back to full passthrough for a whole mongo connection if it's *established* while paused — so a pooled connection born during a pressure spike that later serves calm-period queries produces no mocks, and those calm TCs overlap no pressure interval and aren't suppressed. This is a pre-existing `integrations` limitation this keploy-only fix can't address; it's mostly mitigated because pool connections open at startup (calm) and use the per-exchange gate that resumes when pressure clears. If residual mongo orphans remain after this lands, the follow-up is in the mongo parser (re-check pause per exchange, or tag passthrough'd connections).
