### PR TITLE
fix(replay): deadline-bound reset re-sends so a slow docker app boot doesn't fail the first test

### DIFF
--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -3993,24 +3993,66 @@ func (r *Replayer) copyDirContents(src, dst string) error {
 	return nil
 }
 
-// maxResetResends bounds how many times a transport-reset test request is
-// re-sent. The reset is docker's userland-proxy resetting freshly-accepted
-// host-port conns in bursts under load; under heavy CI contention that burst
-// outlasts a couple of back-to-back attempts, so re-send work-slow — more
-// attempts, spread by resetResendBackoff, to ride the burst out. Each attempt is
-// gated on no-mock-consumed + port readiness, and a non-reset failure (genuinely
-// broken app) still stops immediately, so the extra attempts only ever add
-// latency on the reset path.
-const maxResetResends = 6
+// The reset is docker's userland-proxy resetting freshly-accepted host-port
+// conns in bursts under load: `-p 8080:8080` makes docker-proxy accept() on the
+// host port the instant `docker run` starts, long before the containerized app
+// is listen()ing, so the port-readiness gate and the first requests race a
+// still-booting app. Under heavy CI contention that boot outlasts a slow app for
+// far longer than a couple of back-to-back attempts. A FIXED attempt count (the
+// old maxResetResends=6, ~10s of wall clock) was exhausted a few seconds before
+// a contended app finished booting — failing only the FIRST test with
+// status_code=0 while every later test passed. So the re-send is now bounded by
+// a DEADLINE (resetResendMaxWait) rather than a count: keep re-sending the real
+// request until the app answers or the readiness budget runs out. Each attempt
+// is still gated on no-mock-consumed + port readiness, and a non-reset failure
+// (genuinely broken app) still stops immediately, so the extra attempts only
+// ever add latency on the reset path.
 
-// resetResendBackoff grows the pause between reset re-sends (attempt*backoff) so
-// the bounded attempts spread across the docker-proxy reset window instead of
-// hammering it back-to-back.
+// resetResendBackoff grows the pause between reset re-sends (attempt*backoff, up
+// to resetResendBackoffCap) so the attempts spread across the docker-proxy reset
+// window instead of hammering it back-to-back.
 const resetResendBackoff = 300 * time.Millisecond
+
+// resetResendBackoffCap bounds the growing per-attempt backoff so the longer
+// deadline window doesn't turn the tail attempts into multi-second sleeps.
+const resetResendBackoffCap = 2 * time.Second
 
 // resetResendReadyTimeout caps the per-attempt app-port readiness re-poll done
 // before re-sending. It only ever adds latency on the (rare) reset path.
 const resetResendReadyTimeout = 5 * time.Second
+
+// resetResendFloor is the default re-send budget when the user set no
+// HealthPollTimeout — enough headroom for a contended docker app to finish
+// booting past docker-proxy's premature accept. A genuinely-dead app on this
+// default path therefore fails ~this long after the first reset (vs the old
+// ~10s fixed budget), an acceptable trade for not false-failing a slow boot.
+const resetResendFloor = 30 * time.Second
+
+// resetResendCeiling caps the re-send budget even when HealthPollTimeout is set
+// very large, so the narrow "docker-proxy resets forever while the app never
+// binds" mode (a crash-looping container — ECONNRESET is retryable, unlike the
+// ECONNREFUSED of nothing-listening which still fails fast) cannot hang a single
+// test case for many minutes.
+const resetResendCeiling = 2 * time.Minute
+
+// resetResendMaxWait is the TOTAL wall-clock budget for re-sending a reset test
+// request while the app boots. A reset means the request was never processed (0
+// mocks consumed — enforced each iteration by resetResendUnsafe), so re-sending
+// within this budget is always safe: it only ever converts a transient
+// docker-proxy reset into the real response, and a genuinely-dead app still
+// fails, just after the budget. When the user set a HealthPollTimeout (their own
+// app-readiness ceiling) the budget scales up with it, clamped to
+// resetResendCeiling; otherwise it defaults to resetResendFloor.
+func (r *Replayer) resetResendMaxWait() time.Duration {
+	if r.config != nil && r.config.Test.HealthPollTimeout > 0 {
+		wait := r.config.Test.HealthPollTimeout
+		if wait > resetResendCeiling {
+			wait = resetResendCeiling
+		}
+		return wait
+	}
+	return resetResendFloor
+}
 
 // retryResetOnce re-sends a test request that failed with a transport-level
 // connection reset / unexpected EOF (origErr), but ONLY when doing so is
@@ -4052,7 +4094,8 @@ const resetResendReadyTimeout = 5 * time.Second
 // successful re-send's consumption is still accounted by the subsequent per-test
 // GetConsumedMocks in RunTestSet (loopErr becomes nil, so that block runs).
 func (r *Replayer) retryResetOnce(ctx context.Context, testCase *models.TestCase, testSetID string, origErr error) (interface{}, bool, []models.MockState) {
-	for attempt := 1; attempt <= maxResetResends; attempt++ {
+	deadline := time.Now().Add(r.resetResendMaxWait())
+	for attempt := 1; time.Now().Before(deadline); attempt++ {
 		if ctx.Err() != nil {
 			return nil, false, nil
 		}
@@ -4076,7 +4119,7 @@ func (r *Replayer) retryResetOnce(ctx context.Context, testCase *models.TestCase
 
 		r.logger.Warn("test request reset by app/proxy before any mock was consumed; re-sending — the request was never processed, so this is not a retry of an assertion",
 			zap.Int("attempt", attempt),
-			zap.Int("maxRetries", maxResetResends),
+			zap.Duration("budgetRemaining", time.Until(deadline)),
 			zap.String("testSetID", testSetID),
 			zap.String("testCaseID", testCase.Name),
 			zap.Error(origErr))
@@ -4095,12 +4138,16 @@ func (r *Replayer) retryResetOnce(ctx context.Context, testCase *models.TestCase
 			return nil, false, nil
 		}
 		origErr = err
-		// Back off (growing) before the next re-send so the bounded attempts
+		// Back off (growing, capped) before the next re-send so the attempts
 		// spread across the docker-proxy reset burst rather than hammering it.
+		backoff := time.Duration(attempt) * resetResendBackoff
+		if backoff > resetResendBackoffCap {
+			backoff = resetResendBackoffCap
+		}
 		select {
 		case <-ctx.Done():
 			return nil, false, nil
-		case <-time.After(time.Duration(attempt) * resetResendBackoff):
+		case <-time.After(backoff):
 		}
 	}
 	return nil, false, nil

--- a/pkg/service/replay/reset_resend_test.go
+++ b/pkg/service/replay/reset_resend_test.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"syscall"
 	"testing"
+	"time"
 
 	"go.keploy.io/server/v3/config"
 	"go.keploy.io/server/v3/pkg/agent/proxy"
@@ -162,26 +163,66 @@ func TestRetryResetOnce_FailSafeOnConsumedFetchError(t *testing.T) {
 	}
 }
 
-// A persistently reset app stops after maxResetResends and reports not-retried,
-// so the caller surfaces the original transport error (no fabricated success).
-// Driven by a REAL MockManager that records nothing, so every per-call drain is
-// empty and every attempt is deemed safe-to-resend.
+// A persistently reset app stops after the re-send DEADLINE and reports
+// not-retried, so the caller surfaces the original transport error (no
+// fabricated success). Driven by a REAL MockManager that records nothing, so
+// every per-call drain is empty and every attempt is deemed safe-to-resend. A
+// short HealthPollTimeout makes the re-send budget small so the test is fast
+// while still proving the loop is bounded by wall-clock (not the old fixed
+// count) and terminates.
 func TestRetryResetOnce_BoundedAndStopsWithoutFabricating(t *testing.T) {
 	mm := proxy.NewMockManager(nil, nil, zap.NewNop())
 	defer mm.Close()
-	hook := &realMockManagerHook{mm: mm, failFirst: 100} // always resets
+	hook := &realMockManagerHook{mm: mm, failFirst: 1_000_000} // always resets
 	r := newTestReplayer(hook)
+	r.config.Test.HealthPollTimeout = 1500 * time.Millisecond // short re-send budget
 	tc := &models.TestCase{Name: "get-root-1", Kind: models.HTTP}
 
+	start := time.Now()
 	resp, retried, drained := r.retryResetOnce(context.Background(), tc, "test-set-0", connResetURLErr())
+	elapsed := time.Since(start)
+
 	if retried || resp != nil {
 		t.Fatalf("a persistently reset app must not yield a fabricated response; retried=%v resp=%#v", retried, resp)
 	}
 	if len(drained) != 0 {
 		t.Fatalf("no mock was consumed, so nothing should be drained, got %#v", drained)
 	}
-	if got := atomic.LoadInt32(&hook.calls); got != maxResetResends {
-		t.Fatalf("expected exactly %d bounded re-sends, got %d", maxResetResends, got)
+	// Deadline-bounded: it must loop more than once (proving it is no longer
+	// capped at the old fixed 6) yet still terminate near the budget.
+	if got := atomic.LoadInt32(&hook.calls); got < 2 {
+		t.Fatalf("expected the re-send to loop until the deadline (>=2 attempts), got %d", got)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("a 1.5s re-send budget should bound the loop well under 5s, took %s", elapsed)
+	}
+}
+
+// resetResendMaxWait defaults to the floor, passes a configured HealthPollTimeout
+// through, clamps a very large one to the ceiling (so a crash-looping container
+// can't hang a test for minutes), and is nil-config safe.
+func TestResetResendMaxWait_FloorAndCeiling(t *testing.T) {
+	cases := []struct {
+		name string
+		hpt  time.Duration
+		want time.Duration
+	}{
+		{"unset uses floor", 0, resetResendFloor},
+		{"negative uses floor", -1 * time.Second, resetResendFloor},
+		{"below ceiling passes through", 45 * time.Second, 45 * time.Second},
+		{"above ceiling clamps", 10 * time.Minute, resetResendCeiling},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &Replayer{config: &config.Config{}}
+			r.config.Test.HealthPollTimeout = tc.hpt
+			if got := r.resetResendMaxWait(); got != tc.want {
+				t.Fatalf("HealthPollTimeout=%s: want %s, got %s", tc.hpt, tc.want, got)
+			}
+		})
+	}
+	if got := (&Replayer{}).resetResendMaxWait(); got != resetResendFloor {
+		t.Fatalf("nil config: want floor %s, got %s", resetResendFloor, got)
 	}
 }
 


### PR DESCRIPTION
## Problem

Under heavy CI load the `go-docker-timefreeze` e2e lane intermittently fails **only the first test** (`get-root-1`, `status_code=0`) while every later test passes. Root cause: `-p host:port` makes docker-proxy `accept()` on the host port the instant `docker run` starts — long before the containerized app `listen()`s — so the TCP readiness gate and the first requests race a still-booting app and get connection-reset. `retryResetOnce` re-sends the reset, but was capped at a **fixed 6 attempts (~10s)**, which a contended app outlasted by a few seconds.

Observed on keploy/enterprise pipeline 5867: 17/18 passed, only `get-root-1` failed after the 6 resets — the app came up ~a second later.

## Fix

Bound the reset re-send by a **wall-clock deadline** (`resetResendMaxWait`) instead of a fixed count: keep re-sending the *real* request until the app answers or the readiness budget runs out.

- Budget = `HealthPollTimeout` (the user's own app-readiness ceiling) clamped to **2m**, else a **30s floor**.
- Backoff now grows and is **capped at 2s**.

### Safety — unchanged
The no-fabrication guarantee is fully preserved:
- Each attempt still gates on **zero mocks consumed** (`resetResendUnsafe`) before re-sending — never re-runs a request that already burned a single-use mock.
- Any **non-reset** error still stops immediately — never retries a real assertion/mismatch.
- `ctx.Done()` still exits.
- A crash-looping container (docker-proxy resets forever, ECONNRESET) is bounded by the 2m ceiling; nothing-listening (ECONNREFUSED) still fails fast.

## Tests
- `go build`, `go vet`, all `TestRetryResetOnce_*` pass (incl. `-race`).
- Updated `TestRetryResetOnce_BoundedAndStopsWithoutFabricating` from fixed-count to deadline-bounded.
- Added `TestResetResendMaxWait_FloorAndCeiling` (floor / passthrough / ceiling clamp / nil-config).