### PR TITLE
fix(agent): fall back to legacy /storemocks framing when an old agent rejects the stream (HTTP 400)

### DIFF
--- a/pkg/platform/http/agent.go
+++ b/pkg/platform/http/agent.go
@@ -637,10 +637,51 @@ func (a *AgentClient) AfterTestRun(ctx context.Context, testRunID string, testSe
 
 }
 
-// StoreMocks streams the mock corpus to the agent over an io.Pipe: a gob
-// MockStreamHeader, then filtered mocks followed by unfiltered mocks, one gob
-// frame each.
+// StoreMocks sends the mock corpus to the agent. It streams by default (a gob
+// MockStreamHeader over an io.Pipe, then filtered then unfiltered mocks, one gob
+// frame each) — streaming was added (#4327) so the agent doesn't buffer the
+// whole corpus and OOM on large recordings.
+//
+// Backward compatibility: a pre-streaming agent (keploy <= v3.5.84) gob-decodes
+// the request body as a single StoreMocksReq and fails the instant it meets the
+// MockStreamHeader ("type mismatch: no fields matched"), returning HTTP 400.
+// Rather than lockstep-break every rolling upgrade where the deployed agent
+// image lags the controller (a fresh streaming controller talking to an
+// already-running old agent), StoreMocks transparently retries such a 400 with
+// the legacy single-shot framing the old agent understands. An agent old enough
+// to reject the stream is old enough to have handled single-shot before — and
+// predates the large-corpus recordings streaming exists for — so the fallback
+// is safe; a genuine bad-request 400 simply fails again on the retry.
 func (a *AgentClient) StoreMocks(ctx context.Context, filtered []*models.Mock, unFiltered []*models.Mock) error {
+	// A dedicated cancelable context for the stream request: cancelling it tears
+	// down the transport's read of the io.Pipe body, which unblocks the encoder
+	// goroutine's pw.Write if the agent responded (e.g. 400) before consuming the
+	// whole stream — so the fallback path can't leak that goroutine.
+	streamCtx, cancelStream := context.WithCancel(ctx)
+
+	res, err := a.storeMocksStream(streamCtx, filtered, unFiltered)
+	if err != nil {
+		cancelStream()
+		return err
+	}
+
+	if res.StatusCode == http.StatusBadRequest {
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+		cancelStream()
+		a.logger.Warn("agent rejected streaming /storemocks with HTTP 400; retrying with legacy single-shot framing. The usual cause is a deployed agent that predates streaming (keploy <= v3.5.84) during a rolling upgrade — align the agent image with the controller's keploy version to use streaming and avoid buffering the whole mock corpus. (A new agent that returns 400 for another reason will simply fail the legacy retry too, surfacing the real error.)")
+		return a.storeMocksLegacy(ctx, filtered, unFiltered)
+	}
+
+	defer cancelStream()
+	defer res.Body.Close()
+	return decodeStoreMocksResp(res)
+}
+
+// storeMocksStream POSTs the corpus as a gob stream (MockStreamHeader + one
+// frame per mock) and returns the raw response so the caller can decide whether
+// to fall back on a 400.
+func (a *AgentClient) storeMocksStream(ctx context.Context, filtered []*models.Mock, unFiltered []*models.Mock) (*http.Response, error) {
 	pr, pw := io.Pipe()
 	go func() {
 		enc := gob.NewEncoder(pw)
@@ -680,15 +721,53 @@ func (a *AgentClient) StoreMocks(ctx context.Context, filtered []*models.Mock, u
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
 		fmt.Sprintf("%s/storemocks", a.conf.Agent.AgentURI), pr)
 	if err != nil {
+		// The transport never took ownership of pr, so nothing else will ever
+		// close it — close the pipe so the encoder goroutine's blocked pw.Write
+		// returns instead of leaking. (Do() closes req.Body itself on its own
+		// error path per the RoundTripper contract, but here Do was never
+		// reached.)
+		_ = pw.CloseWithError(err)
 		utils.LogError(a.logger, err, "failed to create request for storemocks")
-		return fmt.Errorf("create request for storemocks: %s", err.Error())
+		return nil, fmt.Errorf("create request for storemocks: %s", err.Error())
 	}
 	req.Header.Set("Content-Type", models.StoreMocksStreamContentType)
 	req.Header.Set("Accept", "application/x-gob")
 
 	res, err := a.client.Do(req)
 	if err != nil {
-		return fmt.Errorf("send request for storemocks: %s", err.Error())
+		return nil, fmt.Errorf("send request for storemocks: %s", err.Error())
+	}
+	return res, nil
+}
+
+// storeMocksLegacy POSTs the corpus in the pre-streaming single-shot framing:
+// one gob-encoded StoreMocksReq with Content-Type application/x-gob. Used only
+// as the compatibility fallback when a deployed agent rejects the stream (see
+// StoreMocks). It buffers the whole corpus in memory the way the pre-#4327 path
+// did — acceptable here because it only runs against an old agent that never
+// supported streaming anyway.
+func (a *AgentClient) storeMocksLegacy(ctx context.Context, filtered []*models.Mock, unFiltered []*models.Mock) error {
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(models.StoreMocksReq{
+		Filtered:   filtered,
+		UnFiltered: unFiltered,
+	}); err != nil {
+		utils.LogError(a.logger, err, "failed to gob-encode request body for storemocks (legacy)")
+		return fmt.Errorf("gob encode request for storemocks (legacy): %s", err.Error())
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		fmt.Sprintf("%s/storemocks", a.conf.Agent.AgentURI), &buf)
+	if err != nil {
+		utils.LogError(a.logger, err, "failed to create legacy request for storemocks")
+		return fmt.Errorf("create legacy request for storemocks: %s", err.Error())
+	}
+	req.Header.Set("Content-Type", "application/x-gob")
+	req.Header.Set("Accept", "application/x-gob")
+
+	res, err := a.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send legacy request for storemocks: %s", err.Error())
 	}
 	defer res.Body.Close()
 	return decodeStoreMocksResp(res)

--- a/pkg/platform/http/agent_fallback_test.go
+++ b/pkg/platform/http/agent_fallback_test.go
@@ -1,0 +1,117 @@
+package http_test
+
+// Backward-compat fallback: when a deployed agent is older than the streaming
+// controller (keploy <= v3.5.84), it gob-decodes the stream body as a single
+// StoreMocksReq and returns HTTP 400. AgentClient.StoreMocks must transparently
+// retry that 400 with the legacy single-shot framing so a rolling upgrade (new
+// controller, old agent still running) doesn't break storemocks — the exact
+// failure seen as `storemocks http 400` in k8s auto-replay.
+
+import (
+	"context"
+	"encoding/gob"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// bigCorpus builds n minimal mocks — enough of them to push the gob stream past
+// the socket send buffer, so the client's encoder goroutine is still mid-write
+// (blocked on pw.Write) when the old agent replies 400 and the fallback fires.
+func bigCorpus(n int) []*models.Mock {
+	out := make([]*models.Mock, n)
+	for i := range out {
+		out[i] = &models.Mock{Name: "m", Kind: models.HTTP}
+	}
+	return out
+}
+
+// legacyAgent is an httptest handler that behaves like a pre-streaming agent:
+// it rejects the streaming Content-Type with 400 and only accepts the legacy
+// single-shot StoreMocksReq gob framing.
+func legacyAgent(streamCalls, legacyCalls, filtered, unfiltered *int, mu *sync.Mutex) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/agent/storemocks", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Content-Type") == models.StoreMocksStreamContentType {
+			// Faithful to a real pre-streaming agent: it gob-decodes a PREFIX of
+			// the body and bails on the header mismatch WITHOUT draining the rest,
+			// leaving the client's encoder goroutine blocked mid-write on pw.Write.
+			// This asserts the fallback still completes cleanly through that
+			// mid-write state. It does NOT prove the no-goroutine-leak invariant —
+			// httptest tearing down the undrained connection can unblock the
+			// encoder on its own, and -race does not detect leaks; the anti-leak
+			// reasoning lives in the StoreMocks/storeMocksStream code comments.
+			var prefix [16]byte
+			_, _ = io.ReadFull(r.Body, prefix[:])
+			mu.Lock()
+			*streamCalls++
+			mu.Unlock()
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		var req models.StoreMocksReq
+		if err := gob.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		mu.Lock()
+		*legacyCalls++
+		*filtered, *unfiltered = len(req.Filtered), len(req.UnFiltered)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		_ = gob.NewEncoder(w).Encode(models.AgentResp{IsSuccess: true})
+	})
+	return mux
+}
+
+// TestStoreMocks_FallsBackToLegacyOn400 proves a fresh streaming controller
+// still stores mocks against an old (pre-streaming) agent: the stream is
+// rejected with 400 and the corpus is re-sent verbatim in the legacy framing.
+func TestStoreMocks_FallsBackToLegacyOn400(t *testing.T) {
+	var mu sync.Mutex
+	var streamCalls, legacyCalls, filtered, unfiltered int
+
+	srv := httptest.NewServer(legacyAgent(&streamCalls, &legacyCalls, &filtered, &unfiltered, &mu))
+	defer srv.Close()
+
+	client := newClient(t, srv.URL+"/agent")
+	// A corpus large enough to overflow the socket send buffer, so the stream's
+	// encoder goroutine is still blocked on pw.Write when the old agent's 400
+	// arrives — the realistic mid-write state the fallback must complete through.
+	f, u := bigCorpus(20000), bigCorpus(5000)
+	if err := client.StoreMocks(context.Background(), f, u); err != nil {
+		t.Fatalf("StoreMocks should succeed via legacy fallback against an old agent: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if streamCalls != 1 || legacyCalls != 1 {
+		t.Fatalf("expected 1 stream attempt then 1 legacy retry; got stream=%d legacy=%d", streamCalls, legacyCalls)
+	}
+	if filtered != len(f) || unfiltered != len(u) {
+		t.Fatalf("legacy retry corpus mismatch: got f=%d u=%d want f=%d u=%d", filtered, unfiltered, len(f), len(u))
+	}
+}
+
+// TestStoreMocks_GenuineBadRequestStillFails proves the fallback does not MASK a
+// real error: if both the stream and the legacy retry 400, StoreMocks surfaces
+// the failure instead of silently passing.
+func TestStoreMocks_GenuineBadRequestStillFails(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/agent/storemocks", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusBadRequest)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := newClient(t, srv.URL+"/agent")
+	f, u := fixtures()
+	if err := client.StoreMocks(context.Background(), f, u); err == nil {
+		t.Fatal("StoreMocks must fail when both stream and legacy return 400 (genuine bad request), not silently pass")
+	}
+}

--- a/pkg/platform/http/agent_stream_integration_test.go
+++ b/pkg/platform/http/agent_stream_integration_test.go
@@ -4,8 +4,9 @@ package http_test
 // (DefaultRoutes) wired to a stub Service, behind an httptest server, driven by
 // the real AgentClient. Proves the client streams the corpus and the real
 // /storemocks handler decodes the header and drives StoreMocksStream. Streaming
-// is the only wire format (client and agent ship in lockstep) — no negotiation,
-// no legacy fallback.
+// is the default wire format; StoreMocks falls back to the legacy single-shot
+// framing only when an older agent rejects the stream with 400 (covered in
+// agent_fallback_test.go).
 
 import (
 	"context"
@@ -73,8 +74,8 @@ func fixtures() (filtered, unfiltered []*models.Mock) {
 }
 
 // End-to-end: the client streams to the real agent routes, which decode the
-// header and drive StoreMocksStream. (Streaming is the only path now — client
-// and agent ship in lockstep, so there's no negotiation or legacy fallback.)
+// header and drive StoreMocksStream. (Streaming is the default path; the legacy
+// single-shot fallback for older agents is covered in agent_fallback_test.go.)
 func TestStoreMocks_StreamsToAgent(t *testing.T) {
 	svc := &stubSvc{}
 	r := chi.NewRouter()


### PR DESCRIPTION
## Problem

The controller streams mocks to the agent (`MockStreamHeader` + one gob frame per mock, `Content-Type: application/x-gob-stream`) to avoid buffering the entire mock corpus in memory (the agent OOM streaming was added to fix). But a **pre-streaming agent** (keploy ≤ v3.5.84) gob-decodes the request body as a single `StoreMocksReq`, immediately hits the `MockStreamHeader` (`gob: type mismatch: no fields matched`), and returns **HTTP 400**.

So during any **rolling upgrade** where a fresh streaming controller talks to an already-running old agent, `storemocks` breaks outright — the `storemocks http 400` failure observed in k8s auto-replay CI (blocks the trust-all TLS PRs: k8s-proxy #613/#617, enterprise #2219).

The streaming controller shipped "lockstep, no fallback", so there was no path back to the framing the old agent understands.

## Fix

`AgentClient.StoreMocks` now transparently retries a streaming **400** with the **legacy single-shot framing** (`application/x-gob`, a single `StoreMocksReq{Filtered,UnFiltered}` gob) the old agent understands. This is the durable, root-cause fix for the rolling-upgrade break — no chart `imagePullPolicy` hacks or agent-image republishing needed.

Key correctness properties:
- **No goroutine leak on either path.** The stream POST runs under a dedicated cancelable context; on a 400 the fallback drains+closes the response body and cancels that context, which tears down the transport's read of the `io.Pipe` body and unblocks the encoder goroutine still blocked mid-`pw.Write`. Also closes a **pre-existing latent pipe leak** on the `NewRequestWithContext` error path.
- **Cannot mask a real error.** Only an exact HTTP 400 triggers fallback; any other non-2xx surfaces as-is. If the legacy retry also fails, its error is returned. A new agent that 400s for an unrelated reason simply fails the legacy retry too, surfacing the real error rather than silently storing 0 mocks (gob errors `type mismatch` in both directions — verified).

## Tests

- `agent_fallback_test.go`:
  - `TestStoreMocks_FallsBackToLegacyOn400` — a faithful old-agent stub (reads a prefix, does not drain, returns 400); a large corpus (`bigCorpus`) overflows the socket buffer so the encoder goroutine is genuinely blocked mid-write when the 400 arrives; asserts 1 stream attempt → 1 legacy retry with the corpus intact.
  - `TestStoreMocks_GenuineBadRequestStillFails` — both stream and legacy 400 ⇒ `StoreMocks` surfaces the error (no silent pass).
- `agent_stream_integration_test.go` — the default streaming path against the real agent routes stays green.

`go test -race ./pkg/platform/http/` green.