### PR TITLE
fix(agent): set perf_event_paranoid via procfs write, not the sysctl CLI

### DIFF
--- a/pkg/platform/http/agent.go
+++ b/pkg/platform/http/agent.go
@@ -1337,9 +1337,11 @@ func (a *AgentClient) Setup(ctx context.Context, cmd string, opts models.SetupOp
 		// Lower perf_event_paranoid to allow eBPF programs to attach to syscall tracepoints
 		// like sys_socket via perf_event_open. Ubuntu/Debian default (4) blocks this for
 		// unprivileged users, so setting 2 relaxes the restriction and enables tracing.
+		// Write the value straight to the procfs knob instead of shelling out to the
+		// `sysctl` binary, which isn't guaranteed to be present in minimal images.
 		if runtime.GOOS == "linux" {
-			cmd := exec.Command("sysctl", "-w", "kernel.perf_event_paranoid=2")
-			if err := cmd.Run(); err != nil {
+			const perfEventParanoidPath = "/proc/sys/kernel/perf_event_paranoid"
+			if err := os.WriteFile(perfEventParanoidPath, []byte("2\n"), 0644); err != nil {
 				a.logger.Error("Failed to relax host perf_event_paranoid. Tracepoints may fail.", zap.Error(err))
 				return err
 			}


### PR DESCRIPTION
## What

Replace the `exec.Command("sysctl", "-w", "kernel.perf_event_paranoid=2")` call in the agent setup path with a direct write to the procfs knob:

```go
os.WriteFile("/proc/sys/kernel/perf_event_paranoid", []byte("2\n"), 0644)
```

## Why

Lowering `perf_event_paranoid` is needed so eBPF programs can attach to syscall tracepoints via `perf_event_open` (Ubuntu/Debian default of `4` blocks this for unprivileged users).

Doing it through `sysctl -w` makes tracepoint setup depend on the `sysctl` CLI binary being installed — which isn't guaranteed in minimal images. If `sysctl` is missing, `Setup` aborts with `exec: "sysctl": executable file not found` and tracing silently never comes up.

The dotted sysctl name `kernel.perf_event_paranoid` maps 1:1 to `/proc/sys/kernel/perf_event_paranoid`, so writing the value directly to that path is exactly what `sysctl -w` does under the hood — same effect, same root requirement, no dynamic-CLI dependency.

## Behavior

- Control flow and error handling unchanged: on failure it logs and `return err`, aborting `Setup` as before.
- Privilege requirement unchanged (`sysctl -w` already needed write access to the same knob).
- Still guarded by `runtime.GOOS == "linux"`.

## Verification

- `go build ./pkg/platform/http/` and `go vet ./pkg/platform/http/` pass; `gofmt` clean; `os/exec` still used elsewhere in the file (no dangling import).
- Confirmed on a host that `sysctl -n kernel.perf_event_paranoid` and `cat /proc/sys/kernel/perf_event_paranoid` return the same value, and that `os.WriteFile("2\n")` flips the knob `3 → 2` identically to `sysctl -w`.