### PR TITLE
fix(replay): serve config mocks in recorded order under mapping-based replay

### DIFF
--- a/pkg/util.go
+++ b/pkg/util.go
@@ -2986,15 +2986,35 @@ func FilterTcsMocksMapping(ctx context.Context, logger *zap.Logger, m []*models.
 func FilterConfigMocksMapping(ctx context.Context, logger *zap.Logger, m []*models.Mock, mocksPresentInMapping []string) []*models.Mock {
 	filteredMocks, unfilteredMocks := filterByMapping(ctx, logger, m, mocksPresentInMapping)
 
-	sort.SliceStable(filteredMocks, func(i, j int) bool {
-		return filteredMocks[i].Spec.ReqTimestampMock.Before(filteredMocks[j].Spec.ReqTimestampMock)
+	// filterByMapping partitions the config pool by per-test mapping-name
+	// membership and tags each mock's IsFiltered flag for consumption
+	// tracking — but its partition boundary MUST NOT dictate serving ORDER.
+	// The config pool is served to the matcher in SortOrder (treedb), which is
+	// restamped from this slice's order (MockManager.SetUnFilteredMocks). A
+	// stateful, cursor-based matcher replays a recorded revision SEQUENCE in
+	// that order — e.g. the Couchbase GET_CLUSTER_CONFIG / cluster-config poll
+	// (couchbase match.go pick). Concatenating [in-mapping] ++ [not-in-mapping]
+	// splits that sequence across the mapping boundary (a revision consumed
+	// inside one test's window sorts before an earlier bootstrap revision that
+	// no test mapped), so the cursor walks the revisions out of recorded order,
+	// the topology appears to go backwards, and gocb's WaitUntilReady never
+	// converges (108x WAIT_FOR_CONFIG, ~6m45s degraded bootstrap) — even though
+	// the identical recording replays fine under timestamp-based filtering.
+	//
+	// Sort the WHOLE pool by ReqTimestampMock so mapping-mode config ORDERING
+	// matches the timestamp branch (FilterConfigMocksTierAware, which puts every
+	// session/config mock in one chronological slice). Only ORDERING is unified
+	// here — membership still differs slightly from that branch (it additionally
+	// drops res<req mocks); ordering is the property the cursor-based matcher
+	// depends on. The IsFiltered
+	// flags set above are preserved on each mock; only the order changes. This
+	// keeps per-test data-tier scoping untouched (that is FilterTcsMocksMapping)
+	// while restoring recorded-order replay for order-sensitive config mocks.
+	all := append(filteredMocks, unfilteredMocks...)
+	sort.SliceStable(all, func(i, j int) bool {
+		return all[i].Spec.ReqTimestampMock.Before(all[j].Spec.ReqTimestampMock)
 	})
-
-	sort.SliceStable(unfilteredMocks, func(i, j int) bool {
-		return unfilteredMocks[i].Spec.ReqTimestampMock.Before(unfilteredMocks[j].Spec.ReqTimestampMock)
-	})
-
-	return append(filteredMocks, unfilteredMocks...)
+	return all
 }
 
 // strictWindowEnvOverride holds the result of one-time env-var parsing

--- a/pkg/util_test.go
+++ b/pkg/util_test.go
@@ -2001,3 +2001,83 @@ func TestAgentReadyTimeout(t *testing.T) {
 		t.Fatalf("DefaultAgentReadyTimeout %v is shorter than the agent healthcheck budget (~310s)", DefaultAgentReadyTimeout)
 	}
 }
+
+// TestFilterConfigMocksMapping_PreservesRecordedRevisionOrder is the unit-level
+// reproduction of the couchbase-java mapping-based-replay flake.
+//
+// filterByMapping partitions the config pool into [in-mapping] and
+// [not-in-mapping] by per-test mapping membership. The pre-fix
+// FilterConfigMocksMapping returned append(inMapping, notInMapping...), which
+// splits an order-sensitive recorded revision SEQUENCE (e.g. the Couchbase
+// GET_CLUSTER_CONFIG cluster-config poll) across the mapping boundary: a later
+// revision that some test mapped sorts BEFORE an earlier bootstrap revision
+// that no test mapped. The config pool is served to the matcher in this
+// slice's order (MockManager.SetUnFilteredMocks restamps SortOrder from it), so
+// a stateful cursor-based matcher then walks revisions out of recorded order
+// and gocb's WaitUntilReady never converges (the 108x WAIT_FOR_CONFIG /
+// ~6m45s degraded bootstrap seen only under mapping-based replay#2).
+//
+// This test pins the fixed invariant: FilterConfigMocksMapping returns the
+// config pool in strict ReqTimestampMock (recorded) order — identical to what
+// the timestamp branch (FilterConfigMocksTierAware) produces — regardless of
+// which revisions a given test mapped. Fails on the pre-fix concatenation
+// (returns [cfg-rev-2 cfg-rev-1 cfg-rev-3]); passes on the sorted fix.
+func TestFilterConfigMocksMapping_PreservesRecordedRevisionOrder(t *testing.T) {
+	logger := zap.NewNop()
+	ctx := context.Background()
+
+	base := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	mk := func(name string, offsetMs int) *models.Mock {
+		ts := base.Add(time.Duration(offsetMs) * time.Millisecond)
+		return &models.Mock{
+			Name:    name,
+			Version: "api.keploy.io/v1beta1",
+			Spec: models.MockSpec{
+				// Couchbase cluster-config-poll mocks carry the config tier.
+				Metadata:         map[string]string{"type": "config"},
+				ReqTimestampMock: ts,
+				ResTimestampMock: ts.Add(time.Millisecond),
+			},
+		}
+	}
+
+	// Three cluster-config-poll revisions recorded in strict chronological
+	// order: rev1 (t+0) < rev2 (t+100ms) < rev3 (t+200ms).
+	rev1 := mk("cfg-rev-1", 0)
+	rev2 := mk("cfg-rev-2", 100)
+	rev3 := mk("cfg-rev-3", 200)
+	input := []*models.Mock{rev1, rev2, rev3}
+
+	// Only the MIDDLE revision is present in this test's mapping. filterByMapping
+	// therefore returns filtered=[rev2], unfiltered=[rev1, rev3]; the pre-fix
+	// append(filtered, unfiltered...) hoisted rev2 ahead of the earlier rev1.
+	mocksPresentInMapping := []string{"cfg-rev-2"}
+
+	got := FilterConfigMocksMapping(ctx, logger, input, mocksPresentInMapping)
+	require.Len(t, got, 3, "all three config-tier revisions must be returned")
+
+	gotOrder := make([]string, len(got))
+	for i, m := range got {
+		gotOrder[i] = m.Name
+	}
+	// This exact-order equality is the load-bearing invariant: strict recorded
+	// (ReqTimestampMock) order — the property the stateful cursor-based matcher
+	// (couchbase GET_CLUSTER_CONFIG pick) relies on — NOT mapping-partition
+	// order. Pre-fix this was [cfg-rev-2 cfg-rev-1 cfg-rev-3], the couchbase bug.
+	assert.Equal(t, []string{"cfg-rev-1", "cfg-rev-2", "cfg-rev-3"}, gotOrder,
+		"config pool must be served in recorded (ReqTimestampMock) order; a mapped "+
+			"revision hoisted ahead of an earlier one is the couchbase-java flake")
+
+	// The IsFiltered tagging that filterByMapping applies for consumption
+	// tracking must survive the reorder — only ORDER changes, not membership.
+	byName := make(map[string]*models.Mock, len(got))
+	for _, m := range got {
+		byName[m.Name] = m
+	}
+	assert.True(t, byName["cfg-rev-2"].TestModeInfo.IsFiltered,
+		"mapped revision must remain IsFiltered=true after reorder")
+	assert.False(t, byName["cfg-rev-1"].TestModeInfo.IsFiltered,
+		"unmapped revision must remain IsFiltered=false after reorder")
+	assert.False(t, byName["cfg-rev-3"].TestModeInfo.IsFiltered,
+		"unmapped revision must remain IsFiltered=false after reorder")
+}


### PR DESCRIPTION
## Problem

The `couchbase-java` e2e lane flakes on **replay** under mapping-based replay (`hasMeaningfulMappings: true`, replay #2). The application's `gocb` Couchbase driver never finishes bootstrap: `WaitUntilReady` loops 100+ times on `WAIT_FOR_CONFIG` and the cluster topology appears to move backwards, so the run stalls for minutes and the tests fail. The *identical* recording replays fine under timestamp-based filtering (replay #1) — so the recording is good; the divergence is entirely in the mapping-based filter path.

## Root cause

`FilterConfigMocksMapping` (`pkg/util.go`) built its result like this:

```go
filteredMocks, unfilteredMocks := filterByMapping(...)   // partitions by per-test mapping membership
sort.SliceStable(filteredMocks, byReqTimestamp)          // sort each partition chronologically
sort.SliceStable(unfilteredMocks, byReqTimestamp)
return append(filteredMocks, unfilteredMocks...)         // [in-mapping] ++ [not-in-mapping]
```

`filterByMapping`'s partition boundary encodes **per-test mapping membership** — which mocks a given test's mapping references — and tags each mock's `IsFiltered` flag for consumption tracking. It says nothing about **serving order**.

But the config pool *is* served to the matcher in `SortOrder`, and `MockManager.SetUnFilteredMocks` restamps `SortOrder` from this returned slice's order. Concatenating `[in-mapping] ++ [not-in-mapping]` therefore splits the recorded revision **sequence** of order-sensitive config mocks across the mapping boundary: a cluster-config revision that was consumed inside one test's window (→ in-mapping) sorts **ahead of** an earlier bootstrap revision that no test mapped (→ not-in-mapping).

For a stateful, cursor-based matcher — the Couchbase `GET_CLUSTER_CONFIG` / cluster-config poll — that means the cursor walks revisions out of recorded order, the topology it advertises appears to regress, and `gocb`'s `WaitUntilReady` never converges.

The timestamp branch (`FilterConfigMocksTierAware`) has no such split: it places every session/config-tier mock into one chronological slice, which is why replay #1 is healthy.

## Fix

Sort the **whole** config pool by `ReqTimestampMock` so mapping-mode ordering matches the timestamp branch:

```go
all := append(filteredMocks, unfilteredMocks...)
sort.SliceStable(all, func(i, j int) bool {
    return all[i].Spec.ReqTimestampMock.Before(all[j].Spec.ReqTimestampMock)
})
return all
```

- **Ordering only.** The `IsFiltered` tags `filterByMapping` set for consumption tracking travel with each mock (pointers) and are untouched; per-test data-tier scoping (`FilterTcsMocksMapping`) is not affected.
- **Parity, not guesswork.** The result is byte-for-byte the same *ordering* the known-good timestamp path produces for this homogeneous config pool, so the fix cannot regress below the proven baseline.

## Test

`TestFilterConfigMocksMapping_PreservesRecordedRevisionOrder` (`pkg/util_test.go`) is the unit-level reproduction: three cluster-config revisions recorded chronologically, with only the middle one present in the test's mapping. It asserts the returned pool is in strict recorded order.

- **Fails on pre-fix** code (per-partition-sort + concat): returns `[cfg-rev-2, cfg-rev-1, cfg-rev-3]` — the mapped revision hoisted ahead of the earlier one.
- **Passes on the fix**: `[cfg-rev-1, cfg-rev-2, cfg-rev-3]`.

Full `./pkg/` suite is green; `gofmt`/`go vet` clean.

## Scope

One focused ordering fix. The pre-existing timestamp/mapping *membership* differences are intentionally left untouched — only the serving order that the cursor-based matcher depends on is unified.
