### PR TITLE
fix(agent): suppress test cases whose mock was capacity-dropped (+ measure deferred residual)

### DIFF
--- a/pkg/agent/proxy/syncMock/capacity_drop_suppression_test.go
+++ b/pkg/agent/proxy/syncMock/capacity_drop_suppression_test.go
@@ -1,0 +1,475 @@
+package manager
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// fullOutChanManager returns a manager whose outChan is a tiny-capacity,
+// never-drained channel already filled to capacity, so the very next
+// sendToOutChanOwned exhausts the send budget and takes the capacity-drop
+// branch. Each forced drop costs a real sendBudget (200ms) of wall-clock, so
+// tests that need MANY distinct drops should drive recordDroppedTC directly
+// instead of routing through the send path.
+func fullOutChanManager(t *testing.T) *SyncMockManager {
+	t.Helper()
+	ch := make(chan *models.Mock, 1)
+	mgr := &SyncMockManager{
+		buffer: make([]*models.Mock, 0, defaultMockBufferCapacity),
+	}
+	mgr.SetOutputChannel(ch)
+	// Fill the single slot so every subsequent send hits the drop branch.
+	ch <- &models.Mock{}
+	return mgr
+}
+
+func newMock() *models.Mock {
+	return &models.Mock{Spec: models.MockSpec{ReqTimestampMock: time.Now()}}
+}
+
+// TestCapacityDropRecordsOwningTCPrecisely proves the core contract: a
+// capacity-dropped mock records its OWNER by exact name, so record.go can
+// suppress precisely that TC — never a concurrent peer, and never an
+// anonymous (owner="") send.
+func TestCapacityDropRecordsOwningTCPrecisely(t *testing.T) {
+	t.Parallel()
+
+	mgr := fullOutChanManager(t)
+
+	// A single owned send that overflows past the budget.
+	mgr.sendToOutChanOwned(newMock(), "test-7")
+
+	if got := mgr.DropCount(); got != 1 {
+		t.Fatalf("expected DropCount()==1 after a forced capacity drop, got %d", got)
+	}
+	if !mgr.WasMockDroppedForTC("test-7") {
+		t.Fatalf("expected WasMockDroppedForTC(\"test-7\")==true; the owning TC must be recorded for suppression")
+	}
+	if mgr.WasMockDroppedForTC("test-8") {
+		t.Fatalf("expected WasMockDroppedForTC(\"test-8\")==false; a concurrent peer TC must NOT be over-suppressed")
+	}
+	if mgr.WasMockDroppedForTC("") {
+		t.Fatalf("expected WasMockDroppedForTC(\"\")==false; the empty owner must never be recorded")
+	}
+	if got := mgr.DroppedTCCount(); got != 1 {
+		t.Fatalf("expected DroppedTCCount()==1, got %d", got)
+	}
+}
+
+// TestCapacityDropOwnerEmptyRecordsNothing pins that an anonymous send
+// (owner="") that is capacity-dropped bumps the raw drop counter but records
+// NO TC name — session/connection/startup/anonymous carve-outs must never
+// suppress a TC.
+func TestCapacityDropOwnerEmptyRecordsNothing(t *testing.T) {
+	t.Parallel()
+
+	mgr := fullOutChanManager(t)
+
+	mgr.sendToOutChanOwned(newMock(), "")
+
+	if got := mgr.DropCount(); got != 1 {
+		t.Fatalf("expected DropCount()==1, got %d", got)
+	}
+	if got := mgr.DroppedTCCount(); got != 0 {
+		t.Fatalf("expected DroppedTCCount()==0 for an owner=\"\" drop, got %d", got)
+	}
+}
+
+// TestCapacityDropOnClosedChannelRecordsOwner covers the second drop site: a
+// send to an already-closed outChan is a genuine, undeliverable drop and must
+// record the owner (else the TC reaches replay mock-less).
+func TestCapacityDropOnClosedChannelRecordsOwner(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan *models.Mock, 1)
+	mgr := &SyncMockManager{
+		buffer: make([]*models.Mock, 0, defaultMockBufferCapacity),
+	}
+	mgr.SetOutputChannel(ch)
+	mgr.CloseOutChan() // outChanClosed = true
+
+	mgr.sendToOutChanOwned(newMock(), "test-closed")
+
+	if !mgr.WasMockDroppedForTC("test-closed") {
+		t.Fatalf("a send to a closed outChan must record the owning TC for suppression")
+	}
+	// The closed-channel path is an early return, not the budget branch, so
+	// DropCount() (budget drops only) stays 0 — the owner ledger is the
+	// signal here. Pin that contract explicitly: a closed-channel drop must
+	// NOT touch the send-budget drop counter.
+	if got := mgr.DropCount(); got != 0 {
+		t.Fatalf("closed-channel drop is an early return, not the budget branch: expected DropCount()==0, got %d", got)
+	}
+	if mgr.WasMockDroppedForTC("test-other") {
+		t.Fatalf("closed-channel drop must not record an unrelated TC")
+	}
+}
+
+// TestCapacityDropCountBoundedFIFO inserts more than maxDroppedTCNames
+// distinct owners via forced drops and asserts the set is count-bounded FIFO:
+// exactly maxDroppedTCNames retained, the oldest evicted, the newest kept.
+// Drives recordDroppedTC directly to avoid paying maxDroppedTCNames*sendBudget
+// of wall-clock — the eviction logic under test lives entirely in
+// recordDroppedTC and the forced-drop path is already covered above.
+func TestCapacityDropCountBoundedFIFO(t *testing.T) {
+	t.Parallel()
+
+	mgr := &SyncMockManager{}
+
+	const extra = 64
+	total := maxDroppedTCNames + extra
+	for i := 0; i < total; i++ {
+		mgr.recordDroppedTC(fmt.Sprintf("tc-%d", i))
+	}
+
+	if got := mgr.DroppedTCCount(); got != maxDroppedTCNames {
+		t.Fatalf("expected DroppedTCCount()==%d (count-bounded), got %d", maxDroppedTCNames, got)
+	}
+
+	// The oldest `extra` names must have been evicted...
+	for i := 0; i < extra; i++ {
+		name := fmt.Sprintf("tc-%d", i)
+		if mgr.WasMockDroppedForTC(name) {
+			t.Fatalf("expected oldest owner %q to be evicted under the count cap", name)
+		}
+	}
+	// ...and the newest maxDroppedTCNames retained.
+	for i := extra; i < total; i++ {
+		name := fmt.Sprintf("tc-%d", i)
+		if !mgr.WasMockDroppedForTC(name) {
+			t.Fatalf("expected newest owner %q to be retained under the count cap", name)
+		}
+	}
+}
+
+// TestRecordDroppedTCIdempotent pins that recording the same owner twice does
+// not grow the set or the FIFO order (dedup), so a TC that loses several mocks
+// counts once.
+func TestRecordDroppedTCIdempotent(t *testing.T) {
+	t.Parallel()
+
+	mgr := &SyncMockManager{}
+	mgr.recordDroppedTC("dup")
+	mgr.recordDroppedTC("dup")
+	mgr.recordDroppedTC("dup")
+
+	if got := mgr.DroppedTCCount(); got != 1 {
+		t.Fatalf("expected DroppedTCCount()==1 for a repeated owner, got %d", got)
+	}
+	mgr.droppedMu.Lock()
+	orderLen := len(mgr.droppedTCOrder)
+	mgr.droppedMu.Unlock()
+	if orderLen != 1 {
+		t.Fatalf("expected droppedTCOrder len==1 for a repeated owner, got %d", orderLen)
+	}
+}
+
+// TestCapacityDropConcurrentNoRaceNoDeadlock drives N goroutines that force
+// capacity drops with distinct owners into a full, undrained outChan, while a
+// second set of goroutines concurrently reads WasMockDroppedForTC. Run under
+// -race it must stay clean and must not deadlock (the leaf-lock ordering:
+// droppedMu is only ever taken while holding outChanMu.RLock, and takes no
+// other lock).
+func TestCapacityDropConcurrentNoRaceNoDeadlock(t *testing.T) {
+	t.Parallel()
+
+	// A never-drained, capacity-1 channel: after it is primed full, every
+	// send falls to the budget branch and drops. Use a short-lived manager
+	// with the real sendBudget — keep N small so total wall-clock is bounded
+	// (the sends run concurrently, so ~sendBudget total, not N*sendBudget).
+	ch := make(chan *models.Mock, 1)
+	mgr := &SyncMockManager{
+		buffer: make([]*models.Mock, 0, defaultMockBufferCapacity),
+	}
+	mgr.SetOutputChannel(ch)
+	ch <- &models.Mock{} // prime full
+
+	const writers = 16
+	const readers = 8
+	var writerWG, readerWG sync.WaitGroup
+	stop := make(chan struct{})
+
+	for i := 0; i < writers; i++ {
+		writerWG.Add(1)
+		go func(id int) {
+			defer writerWG.Done()
+			mgr.sendToOutChanOwned(newMock(), fmt.Sprintf("owner-%d", id))
+		}(i)
+	}
+
+	for i := 0; i < readers; i++ {
+		readerWG.Add(1)
+		go func(id int) {
+			defer readerWG.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = mgr.WasMockDroppedForTC(fmt.Sprintf("owner-%d", id))
+					_ = mgr.DroppedTCCount()
+				}
+			}
+		}(i)
+	}
+
+	// Join writers first (each takes one bounded-block drop, all concurrent
+	// so ~sendBudget total), then stop and join the readers.
+	writerWG.Wait()
+	close(stop)
+	readerWG.Wait()
+
+	if got := mgr.DroppedTCCount(); got != writers {
+		t.Fatalf("expected %d distinct owners recorded, got %d", writers, got)
+	}
+	for i := 0; i < writers; i++ {
+		if !mgr.WasMockDroppedForTC(fmt.Sprintf("owner-%d", i)) {
+			t.Fatalf("owner-%d was not recorded after concurrent forced drops", i)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end owner-threading through the three send loops.
+//
+// The tests above drive sendToOutChanOwned / recordDroppedTC directly. The
+// tests below close the remaining gap: that ResolveRange, FlushOwnedWindows,
+// and DeleteMocksStrictlyBefore each thread the CORRECT owner into that send
+// path — a per-test mock's real test name on its owned branch, and "" on the
+// session/connection/startup carve-outs. A future edit that mis-tags a branch
+// (owned → "" orphans the TC; carve-out → testName over-suppresses) currently
+// passes every test; these fail on it. Each is mutation-verified in the task
+// report by flipping the branch's owner tag and observing red→revert→green.
+// ---------------------------------------------------------------------------
+
+// TestResolveRangeInWindowDropAttributesOwner exercises the ResolveRange
+// in-window owned branch end-to-end: a per-test mock whose ReqTimestampMock
+// lands inside [start,end] is matched (keep==true, outChan bound), tagged with
+// the resolving test's name, then capacity-dropped on a full outChan. The
+// owning TC must be recorded so record.go suppresses exactly it. Guards the
+// `owner: testName` tag at the ResolveRange in-window append — flip it to
+// owner:"" and this test goes red.
+func TestResolveRangeInWindowDropAttributesOwner(t *testing.T) {
+	t.Parallel()
+
+	mgr := fullOutChanManager(t)
+
+	now := time.Now()
+	start := now.Add(-2 * time.Second)
+	end := now
+	// Per-test mock (zero Lifetime == LifetimePerTest, not startup) whose
+	// timestamp is strictly inside the window so the direct [start,end] match
+	// claims it on the owned branch.
+	inWindow := &models.Mock{
+		Spec: models.MockSpec{ReqTimestampMock: now.Add(-time.Second)},
+	}
+	mgr.mu.Lock()
+	mgr.buffer = append(mgr.buffer, inWindow)
+	mgr.mu.Unlock()
+
+	mgr.ResolveRange(start, end, "test-42", true, false)
+
+	// The mock was genuinely sent and dropped on the budget branch...
+	if got := mgr.DropCount(); got != 1 {
+		t.Fatalf("expected the in-window mock to be sent and capacity-dropped (DropCount()==1), got %d", got)
+	}
+	// ...and its owning TC recorded for precise suppression.
+	if !mgr.WasMockDroppedForTC("test-42") {
+		t.Fatalf("expected WasMockDroppedForTC(\"test-42\")==true; the in-window owned mock dropped, so its TC must be suppressed")
+	}
+	if mgr.WasMockDroppedForTC("test-99") {
+		t.Fatalf("expected WasMockDroppedForTC(\"test-99\")==false; a non-owning TC must never be over-suppressed")
+	}
+	if got := mgr.DroppedTCCount(); got != 1 {
+		t.Fatalf("expected exactly one distinct owner recorded, got %d", got)
+	}
+}
+
+// TestResolveRangeSessionCarveOutRecordsNothing exercises the ResolveRange
+// lifetime carve-out: a session-scoped mock is reusable across every test and
+// must NEVER suppress a TC even when it is itself capacity-dropped. It is
+// tagged owner="" on the carve-out branch, so a drop bumps DropCount but
+// records no TC. Guards `ownedMock{mock: mock}` (no owner) at the lifetime
+// carve-out append — tag it with testName and DroppedTCCount()==0 goes to 1.
+func TestResolveRangeSessionCarveOutRecordsNothing(t *testing.T) {
+	t.Parallel()
+
+	mgr := fullOutChanManager(t)
+
+	now := time.Now()
+	start := now.Add(-2 * time.Second)
+	end := now
+	// Session-lifetime mock, timestamp in-window (irrelevant — the lifetime
+	// carve-out fires before any window match). Seeded directly so the
+	// Lifetime we set survives (bypassing AddMock's DeriveLifetime).
+	sessionMock := &models.Mock{
+		Spec: models.MockSpec{ReqTimestampMock: now.Add(-time.Second)},
+	}
+	sessionMock.TestModeInfo.Lifetime = models.LifetimeSession
+	mgr.mu.Lock()
+	mgr.buffer = append(mgr.buffer, sessionMock)
+	mgr.mu.Unlock()
+
+	mgr.ResolveRange(start, end, "test-42", true, false)
+
+	// It WAS sent and dropped (proves the carve-out reached the send path)...
+	if got := mgr.DropCount(); got != 1 {
+		t.Fatalf("expected the session mock to be flushed and capacity-dropped (DropCount()==1), got %d", got)
+	}
+	// ...yet no TC was recorded — a session mock must never suppress a test.
+	if got := mgr.DroppedTCCount(); got != 0 {
+		t.Fatalf("expected DroppedTCCount()==0 for a dropped session mock; a session/connection carve-out must never suppress a TC, got %d", got)
+	}
+	if mgr.WasMockDroppedForTC("test-42") {
+		t.Fatalf("a dropped session mock must not suppress test-42")
+	}
+}
+
+// TestFlushOwnedWindowsDropAttributesOwner exercises the FlushOwnedWindows
+// owner-window branch end-to-end. A prior ResolveRange registers test-7's
+// window in recentWindows (the real, documented registration path); a late
+// mock whose timestamp falls inside it is then flushed on the ticker path,
+// tagged with test-7, and capacity-dropped on a full outChan. The owning TC
+// must be recorded. Guards `owner: w.testName` at the FlushOwnedWindows
+// ownerWindow append — flip it to owner:"" and this test goes red.
+func TestFlushOwnedWindowsDropAttributesOwner(t *testing.T) {
+	t.Parallel()
+
+	mgr := fullOutChanManager(t)
+
+	now := time.Now()
+	winStart := now.Add(-2 * time.Second)
+	winEnd := now
+	// Register test-7's resolved window via a real ResolveRange with an empty
+	// buffer: it appends {winStart,winEnd,"test-7"} to recentWindows and sends
+	// nothing (no budget paid here).
+	mgr.ResolveRange(winStart, winEnd, "test-7", true, false)
+
+	// A late per-test mock (not session, not startup) whose ReqTimestampMock
+	// falls inside test-7's now-resolved window — only the ownerWindow branch
+	// can claim it, so the test tightly guards that branch's owner tag.
+	lateMock := &models.Mock{
+		Spec: models.MockSpec{ReqTimestampMock: now.Add(-time.Second)},
+	}
+	mgr.mu.Lock()
+	mgr.buffer = append(mgr.buffer, lateMock)
+	mgr.mu.Unlock()
+
+	mgr.FlushOwnedWindows()
+
+	if got := mgr.DropCount(); got != 1 {
+		t.Fatalf("expected the late owner-window mock to be flushed and capacity-dropped (DropCount()==1), got %d", got)
+	}
+	if !mgr.WasMockDroppedForTC("test-7") {
+		t.Fatalf("expected WasMockDroppedForTC(\"test-7\")==true; a late mock flushed into test-7's window then dropped must suppress test-7")
+	}
+	if got := mgr.DroppedTCCount(); got != 1 {
+		t.Fatalf("expected exactly one distinct owner recorded, got %d", got)
+	}
+}
+
+// TestFlushOwnedWindowsStartupCarveOutRecordsNothing is the negative control
+// for FlushOwnedWindows: a startup mock owns no test, rides the startup-rescue
+// branch tagged owner="", and must record nothing even when capacity-dropped.
+// Guards against the startup rescue being mis-tagged with a real test name.
+func TestFlushOwnedWindowsStartupCarveOutRecordsNothing(t *testing.T) {
+	t.Parallel()
+
+	mgr := fullOutChanManager(t)
+
+	// A startup mock owns no resolved window (recentWindows is empty), so it
+	// falls to the startup-rescue branch. Timestamp is arbitrary.
+	startupMock := &models.Mock{
+		Spec: models.MockSpec{ReqTimestampMock: time.Now()},
+	}
+	startupMock.TestModeInfo.IsStartup = true
+	mgr.mu.Lock()
+	mgr.buffer = append(mgr.buffer, startupMock)
+	mgr.mu.Unlock()
+
+	mgr.FlushOwnedWindows()
+
+	if got := mgr.DropCount(); got != 1 {
+		t.Fatalf("expected the startup mock to be flushed and capacity-dropped (DropCount()==1), got %d", got)
+	}
+	if got := mgr.DroppedTCCount(); got != 0 {
+		t.Fatalf("expected DroppedTCCount()==0 for a dropped startup mock; the startup carve-out must never suppress a TC, got %d", got)
+	}
+}
+
+// TestDeleteMocksStrictlyBeforeDropAttributesOwner exercises the
+// DeleteMocksStrictlyBefore owner-window RESCUE branch end-to-end. A prior
+// ResolveRange registers test-3's window; a late kept mock whose timestamp is
+// before the cleanup horizon AND inside test-3's window is rescued (not
+// deleted as duplicate debris), tagged with test-3, and capacity-dropped on a
+// full outChan. The owning TC must be recorded. Guards `owner: w.testName` at
+// the DeleteMocksStrictlyBefore rescue append — flip it to owner:"" → red.
+func TestDeleteMocksStrictlyBeforeDropAttributesOwner(t *testing.T) {
+	t.Parallel()
+
+	mgr := fullOutChanManager(t)
+
+	now := time.Now()
+	winStart := now.Add(-3 * time.Second)
+	winEnd := now.Add(-1 * time.Second)
+	// Register test-3's resolved window (empty buffer → no send).
+	mgr.ResolveRange(winStart, winEnd, "test-3", true, false)
+
+	// Late kept mock: before the cleanup horizon (now) AND inside test-3's
+	// window, not session, not startup — only the ownerWindow rescue can claim
+	// it, so this tightly guards that branch's owner tag.
+	lateMock := &models.Mock{
+		Spec: models.MockSpec{ReqTimestampMock: now.Add(-2 * time.Second)},
+	}
+	mgr.mu.Lock()
+	mgr.buffer = append(mgr.buffer, lateMock)
+	mgr.mu.Unlock()
+
+	mgr.DeleteMocksStrictlyBefore(now)
+
+	if got := mgr.DropCount(); got != 1 {
+		t.Fatalf("expected the rescued owner-window mock to be flushed and capacity-dropped (DropCount()==1), got %d", got)
+	}
+	if !mgr.WasMockDroppedForTC("test-3") {
+		t.Fatalf("expected WasMockDroppedForTC(\"test-3\")==true; a late kept mock rescued into test-3's window then dropped must suppress test-3")
+	}
+	if got := mgr.DroppedTCCount(); got != 1 {
+		t.Fatalf("expected exactly one distinct owner recorded, got %d", got)
+	}
+}
+
+// TestDeleteMocksStrictlyBeforeSessionCarveOutRecordsNothing is the negative
+// control for DeleteMocksStrictlyBefore: a session mock before the horizon is
+// flushed on the lifetime carve-out tagged owner="", and must record nothing
+// when capacity-dropped. Guards against that carve-out being mis-tagged with a
+// real test name.
+func TestDeleteMocksStrictlyBeforeSessionCarveOutRecordsNothing(t *testing.T) {
+	t.Parallel()
+
+	mgr := fullOutChanManager(t)
+
+	now := time.Now()
+	// Session mock before the cleanup horizon → lifetime carve-out flush,
+	// owner "".
+	sessionMock := &models.Mock{
+		Spec: models.MockSpec{ReqTimestampMock: now.Add(-2 * time.Second)},
+	}
+	sessionMock.TestModeInfo.Lifetime = models.LifetimeConnection
+	sessionMock.Spec.Metadata = map[string]string{"connID": "c-1"}
+	mgr.mu.Lock()
+	mgr.buffer = append(mgr.buffer, sessionMock)
+	mgr.mu.Unlock()
+
+	mgr.DeleteMocksStrictlyBefore(now)
+
+	if got := mgr.DropCount(); got != 1 {
+		t.Fatalf("expected the connection mock to be flushed and capacity-dropped (DropCount()==1), got %d", got)
+	}
+	if got := mgr.DroppedTCCount(); got != 0 {
+		t.Fatalf("expected DroppedTCCount()==0 for a dropped connection mock; a session/connection carve-out must never suppress a TC, got %d", got)
+	}
+}

--- a/pkg/agent/proxy/syncMock/revoke_on_drop_test.go
+++ b/pkg/agent/proxy/syncMock/revoke_on_drop_test.go
@@ -1,0 +1,250 @@
+package manager
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// pendingRevokesSnapshot returns a copy of m.pendingRevokes under the leaf
+// lock, so a test can assert on the queue without racing the drain path.
+func pendingRevokesSnapshot(m *SyncMockManager) []string {
+	m.droppedMu.Lock()
+	defer m.droppedMu.Unlock()
+	out := make([]string, len(m.pendingRevokes))
+	copy(out, m.pendingRevokes)
+	return out
+}
+
+// containsName reports whether the comma-joined revoked_tests payload carries
+// the exact TC name (split-and-membership, not a substring test — so "test-1"
+// is not spuriously matched by "test-10").
+func containsName(payload, name string) bool {
+	for _, n := range strings.Split(payload, ",") {
+		if strings.TrimSpace(n) == name {
+			return true
+		}
+	}
+	return false
+}
+
+// TestRevokeDisabledQueuesAndSendsNothing is case (a): with revokeCapable=false
+// (an older CLI, or the default), recordDroppedTC must queue NOTHING and
+// drainPendingRevokes must emit NOTHING — the version-skew guard for the
+// deferred-orphan revoke protocol.
+func TestRevokeDisabledQueuesAndSendsNothing(t *testing.T) {
+	t.Parallel()
+
+	// A working, drainable outChan so a stray send would be observable.
+	ch := make(chan *models.Mock, 4)
+	mgr := &SyncMockManager{
+		buffer: make([]*models.Mock, 0, defaultMockBufferCapacity),
+	}
+	mgr.SetOutputChannel(ch)
+	// revokeCapable left at its zero value (false) — do NOT call SetRevokeCapable.
+
+	mgr.recordDroppedTC("test-1")
+
+	if got := pendingRevokesSnapshot(mgr); len(got) != 0 {
+		t.Fatalf("revokeCapable=false: recordDroppedTC must queue nothing, got pendingRevokes=%v", got)
+	}
+	// The drop itself is still recorded for stream-time suppression — only the
+	// LIVE revoke emission is gated. Sanity-check that the suppression ledger is
+	// unaffected by the capability flag.
+	if !mgr.WasMockDroppedForTC("test-1") {
+		t.Fatalf("revokeCapable=false must NOT disable the suppression ledger; test-1 should still be recorded")
+	}
+
+	mgr.drainPendingRevokes()
+
+	if got := len(ch); got != 0 {
+		t.Fatalf("revokeCapable=false: drainPendingRevokes must send nothing, got %d frame(s) on outChan", got)
+	}
+}
+
+// TestRevokeEnabledDeliversOneFrame is case (b): with revokeCapable=true, a
+// drop queues the owner, and drainPendingRevokes into a working outChan
+// delivers exactly ONE RevokedTests control frame whose
+// Metadata["revoked_tests"] carries the name, and empties pendingRevokes.
+func TestRevokeEnabledDeliversOneFrame(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan *models.Mock, 4)
+	mgr := &SyncMockManager{
+		buffer: make([]*models.Mock, 0, defaultMockBufferCapacity),
+	}
+	mgr.SetOutputChannel(ch)
+	mgr.SetRevokeCapable(true)
+
+	mgr.recordDroppedTC("test-5")
+
+	if got := pendingRevokesSnapshot(mgr); len(got) != 1 || got[0] != "test-5" {
+		t.Fatalf("revokeCapable=true: a drop must queue the owner, got pendingRevokes=%v", got)
+	}
+
+	mgr.drainPendingRevokes()
+
+	// Exactly one frame delivered.
+	if got := len(ch); got != 1 {
+		t.Fatalf("expected exactly ONE revoke frame delivered, got %d", got)
+	}
+	frame := <-ch
+	if frame.Kind != models.RevokedTests {
+		t.Fatalf("expected a Kind=%q control frame, got %q", models.RevokedTests, frame.Kind)
+	}
+	if frame.Spec.Metadata == nil {
+		t.Fatalf("revoke frame must carry Spec.Metadata")
+	}
+	if payload := frame.Spec.Metadata["revoked_tests"]; !containsName(payload, "test-5") {
+		t.Fatalf("revoke frame Metadata[\"revoked_tests\"]=%q must contain \"test-5\"", payload)
+	}
+
+	// The queue must be empty after a successful drain.
+	if got := pendingRevokesSnapshot(mgr); len(got) != 0 {
+		t.Fatalf("drainPendingRevokes must empty pendingRevokes on delivery, got %v", got)
+	}
+}
+
+// TestRevokeBatchesMultipleNamesInOneFrame pins that a batch of queued names is
+// carried in a SINGLE comma-joined frame (one frame per drain, not one per
+// name) — the wire-efficiency contract the comma-join relies on.
+func TestRevokeBatchesMultipleNamesInOneFrame(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan *models.Mock, 8)
+	mgr := &SyncMockManager{
+		buffer: make([]*models.Mock, 0, defaultMockBufferCapacity),
+	}
+	mgr.SetOutputChannel(ch)
+	mgr.SetRevokeCapable(true)
+
+	names := []string{"test-1", "test-2", "test-3"}
+	for _, n := range names {
+		mgr.recordDroppedTC(n)
+	}
+
+	mgr.drainPendingRevokes()
+
+	if got := len(ch); got != 1 {
+		t.Fatalf("expected ONE batched revoke frame for %d names, got %d frame(s)", len(names), got)
+	}
+	frame := <-ch
+	for _, n := range names {
+		if payload := frame.Spec.Metadata["revoked_tests"]; !containsName(payload, n) {
+			t.Fatalf("batched revoke frame Metadata[\"revoked_tests\"]=%q missing %q", payload, n)
+		}
+	}
+}
+
+// TestRevokeUndeliverableReQueues is case (c): when trySendControlFrame cannot
+// deliver (a full outChan here), the batch must be RE-QUEUED, not lost, so a
+// later tick can retry while the stream is still open.
+func TestRevokeUndeliverableReQueues(t *testing.T) {
+	t.Parallel()
+
+	// Capacity-1 channel primed full so the non-blocking control send fails.
+	ch := make(chan *models.Mock, 1)
+	mgr := &SyncMockManager{
+		buffer: make([]*models.Mock, 0, defaultMockBufferCapacity),
+	}
+	mgr.SetOutputChannel(ch)
+	mgr.SetRevokeCapable(true)
+	ch <- &models.Mock{} // prime full → trySendControlFrame takes the default (drop) branch
+
+	mgr.recordDroppedTC("test-9")
+	mgr.drainPendingRevokes()
+
+	// The name must survive for the next tick.
+	if got := pendingRevokesSnapshot(mgr); len(got) != 1 || got[0] != "test-9" {
+		t.Fatalf("undeliverable revoke must be re-queued, got pendingRevokes=%v", got)
+	}
+
+	// Drain the primed slot, then a second drain must now deliver the frame.
+	<-ch
+	mgr.drainPendingRevokes()
+	if got := len(ch); got != 1 {
+		t.Fatalf("after the outChan drained, the re-queued revoke must deliver on the next drain, got %d", got)
+	}
+	frame := <-ch
+	if frame.Kind != models.RevokedTests || !containsName(frame.Spec.Metadata["revoked_tests"], "test-9") {
+		t.Fatalf("re-delivered frame wrong: kind=%q payload=%q", frame.Kind, frame.Spec.Metadata["revoked_tests"])
+	}
+	if got := pendingRevokesSnapshot(mgr); len(got) != 0 {
+		t.Fatalf("pendingRevokes must be empty after the retried delivery, got %v", got)
+	}
+}
+
+// TestRevokeConcurrentDrainCloseNoDeadlock is case (d): it drives drops through
+// the REAL send path so a writer goroutine actually holds outChanMu.RLock and
+// THEN takes droppedMu (inside recordDroppedTC) — the exact ordering the drain
+// must never invert. A saturated, never-drained capacity-1 outChan forces every
+// sendToOutChanOwned to the send-budget drop; drainPendingRevokes (snapshot
+// under droppedMu, RELEASE, then trySendControlFrame's outChanMu.RLock) and a
+// racing CloseOutChan (outChanMu.Lock) run concurrently. Under -race this must
+// stay clean and must NOT deadlock — had someone held droppedMu across the send,
+// the outChanMu.RLock→droppedMu vs droppedMu→outChanMu.RLock cycle would form
+// here (writer-preferring RWMutex + a pending CloseOutChan writer).
+func TestRevokeConcurrentDrainCloseNoDeadlock(t *testing.T) {
+	t.Parallel()
+
+	// Capacity-1, primed full, NEVER drained: every sendToOutChanOwned exhausts
+	// its send budget and drops, so the writer holds outChanMu.RLock across the
+	// select and then takes droppedMu inside recordDroppedTC.
+	ch := make(chan *models.Mock, 1)
+	mgr := &SyncMockManager{
+		buffer: make([]*models.Mock, 0, defaultMockBufferCapacity),
+	}
+	mgr.SetOutputChannel(ch)
+	mgr.SetRevokeCapable(true)
+	ch <- &models.Mock{} // prime full
+
+	const writers = 16
+	const drainers = 8
+	var wg sync.WaitGroup
+
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			// Real send path: outChanMu.RLock held across the select, then
+			// recordDroppedTC (droppedMu) on the budget drop.
+			mgr.sendToOutChanOwned(&models.Mock{}, fmt.Sprintf("owner-%d", id))
+		}(i)
+	}
+	for i := 0; i < drainers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 64; j++ {
+				mgr.drainPendingRevokes()
+			}
+		}()
+	}
+	// One closer racing the drains — CloseOutChan runs FlushOwnedWindows then
+	// seals the channel under outChanMu.Lock.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		mgr.CloseOutChan()
+	}()
+
+	// Fail loudly on a deadlock rather than hanging the whole suite.
+	waitDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(waitDone)
+	}()
+	select {
+	case <-waitDone:
+	case <-time.After(30 * time.Second):
+		t.Fatal("concurrent sendToOutChanOwned + drainPendingRevokes + CloseOutChan deadlocked")
+	}
+
+	// A final post-close drain must be safe (trySendControlFrame sees the
+	// closed channel and re-queues; no send-on-closed panic).
+	mgr.drainPendingRevokes()
+}

--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"math/rand"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -148,6 +149,24 @@ type SyncMockManager struct {
 	droppedMu      sync.Mutex
 	droppedTCNames map[string]struct{}
 	droppedTCOrder []string
+
+	// revokeCapable gates the deferred-orphan revoke protocol: it is set true
+	// (via SetRevokeCapable) only when the CLI negotiated
+	// OutgoingOptions.SupportsDroppedRevoke on the /outgoing request. When
+	// false (an older CLI, or the default), recordDroppedTC queues NOTHING and
+	// drainPendingRevokes sends NOTHING — so a CLI that can't divert the
+	// reserved Kind=RevokedTests control frame never receives one. atomic so
+	// the send path can read it without taking a lock.
+	revokeCapable atomic.Bool
+
+	// pendingRevokes is the FIFO of dropped-TC names still to be emitted to the
+	// CLI as RevokedTests control frames. Appended by recordDroppedTC when a
+	// NEW capacity-drop owner is recorded AND revokeCapable is set; drained by
+	// drainPendingRevokes on every FlushOwnedWindows tick and at CloseOutChan.
+	// Guarded by the SAME droppedMu leaf lock as droppedTCNames (it fits the
+	// leaf discipline — droppedMu takes no other lock while held), so a drop
+	// records the owner and queues the revoke under one lock acquisition.
+	pendingRevokes []string
 
 	// testCounter generates this session's sequential test IDs
 	// ("test-1", "test-2", …). Per-instance so concurrent capture
@@ -306,6 +325,15 @@ func (m *SyncMockManager) SetOutputChannel(out chan<- *models.Mock) {
 	if out != m.outChan {
 		m.outChan = out
 		m.outChanClosed = false
+		// New session (distinct channel = re-record): drop any revokes still
+		// queued from a prior session so a name orphaned there can't be
+		// delivered onto THIS session's /outgoing stream. droppedMu is a leaf;
+		// taking it here under outChanMu.Lock keeps the same outChanMu→droppedMu
+		// order the send path already uses (outChanMu.RLock→recordDroppedTC), so
+		// there is no new lock-ordering hazard.
+		m.droppedMu.Lock()
+		m.pendingRevokes = nil
+		m.droppedMu.Unlock()
 	}
 }
 
@@ -435,6 +463,57 @@ func (m *SyncMockManager) sendToOutChanOwned(mock *models.Mock, owner string) {
 	}
 }
 
+// trySendControlFrame attempts a NON-blocking send of a reserved-Kind control
+// frame (a revoke) on outChan. Returns true iff delivered. Unlike
+// sendToOutChanOwned it does NOT bump dropCount and does NOT record a drop or
+// fire the "recording is lossy" log — a control frame is not a mock. If the
+// channel is closed/nil or full, it returns false and the caller re-queues.
+func (m *SyncMockManager) trySendControlFrame(mock *models.Mock) bool {
+	m.outChanMu.RLock()
+	defer m.outChanMu.RUnlock()
+	if m.outChanClosed || m.outChan == nil {
+		return false
+	}
+	select {
+	case m.outChan <- mock:
+		return true
+	default:
+		return false
+	}
+}
+
+// drainPendingRevokes emits a revoke control frame for every test case queued
+// by recordDroppedTC. It SNAPSHOTS the queue under droppedMu, releases the
+// lock, then sends — holding droppedMu across trySendControlFrame (which takes
+// outChanMu.RLock) would invert the leaf-lock order and can 3-way deadlock
+// against CloseOutChan's outChanMu.Lock under load. Undelivered names are
+// re-queued for the next tick (eventual delivery while the stream is open).
+func (m *SyncMockManager) drainPendingRevokes() {
+	if m == nil || !m.revokeCapable.Load() {
+		return
+	}
+	m.droppedMu.Lock()
+	if len(m.pendingRevokes) == 0 {
+		m.droppedMu.Unlock()
+		return
+	}
+	batch := m.pendingRevokes
+	m.pendingRevokes = nil
+	m.droppedMu.Unlock()
+
+	frame := &models.Mock{
+		Kind: models.RevokedTests,
+		Spec: models.MockSpec{Metadata: map[string]string{"revoked_tests": strings.Join(batch, ",")}},
+	}
+	if !m.trySendControlFrame(frame) {
+		// Re-queue the whole batch under a fresh lock (new drops may have
+		// appended meanwhile — keep the retries ahead of them).
+		m.droppedMu.Lock()
+		m.pendingRevokes = append(batch, m.pendingRevokes...)
+		m.droppedMu.Unlock()
+	}
+}
+
 // DropCount exposes the cumulative drop counter for tests and
 // external observability. The value is monotonically increasing;
 // readers that need a delta should snapshot and diff.
@@ -468,6 +547,27 @@ func (m *SyncMockManager) recordDroppedTC(name string) {
 		k := copy(m.droppedTCOrder, m.droppedTCOrder[1:])
 		m.droppedTCOrder = m.droppedTCOrder[:k]
 	}
+	// Deferred-orphan revoke: if the TC already streamed to the CLI, a drop now
+	// is undetectable by stream-time suppression, so queue the name for LIVE
+	// delivery as a RevokedTests control frame. Only when the CLI negotiated the
+	// capability (revokeCapable) — an older CLI would mis-persist the frame.
+	// Queued under the already-held droppedMu; the name is NEW here (the dedup
+	// return above guarantees it), so pendingRevokes never accumulates dupes.
+	if m.revokeCapable.Load() {
+		m.pendingRevokes = append(m.pendingRevokes, name)
+	}
+}
+
+// SetRevokeCapable enables (or disables) emission of RevokedTests control
+// frames for the deferred-orphan revoke protocol. The agent service calls it
+// from GetOutgoing with OutgoingOptions.SupportsDroppedRevoke, so emission is
+// gated strictly on what the connecting CLI negotiated — default false means an
+// older CLI never triggers a revoke frame.
+func (m *SyncMockManager) SetRevokeCapable(v bool) {
+	if m == nil {
+		return
+	}
+	m.revokeCapable.Store(v)
 }
 
 // WasMockDroppedForTC reports whether a mock owned by test `name` was dropped on
@@ -704,6 +804,11 @@ func (m *SyncMockManager) FlushOwnedWindows() {
 	outChanBound, _ := m.outChanStatus()
 	if !outChanBound {
 		m.mu.Unlock()
+		// Still drain pending revokes: an unbound outChan means
+		// trySendControlFrame can't deliver, so the batch is re-queued for a
+		// later tick — but the drain must be REACHED on every tick regardless
+		// of buffer/channel state so the tail can't be starved.
+		m.drainPendingRevokes()
 		return
 	}
 	mappingChan := m.mappingChan
@@ -781,6 +886,13 @@ func (m *SyncMockManager) FlushOwnedWindows() {
 			}
 		}
 	}
+	// Deliver any queued deferred-orphan revokes on the same open stream. Runs
+	// on EVERY tick (the proxy invokes FlushOwnedWindows periodically and
+	// CloseOutChan calls it once at shutdown) so a capacity-dropped TC that
+	// already streamed is signalled to the CLI while the /outgoing stream is
+	// still open. Snapshot-then-send inside drainPendingRevokes keeps droppedMu
+	// off the send path — do NOT hoist it under m.mu.
+	m.drainPendingRevokes()
 }
 
 func (m *SyncMockManager) SetFirstRequestSignaled() {

--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -36,6 +36,12 @@ const maxRecentWindows = 256
 // O(n) WasPressureActiveInWindow / pressureActiveAtLocked scans bounded.
 const maxPressureRanges = 8192
 
+// maxDroppedTCNames bounds SyncMockManager.droppedTCNames /
+// droppedTCOrder. COUNT-bounded (like maxPressureRanges), not age-bounded:
+// record.go can lag the recorder, so a dropped owner name must stay
+// queryable until the lagging TC is checked.
+const maxDroppedTCNames = 8192
+
 // resolvedWindow is one already-resolved per-test window retained so a
 // late-arriving mock (decoded after the window closed) can still be
 // attributed to the test that actually owns its ReqTimestampMock.
@@ -123,6 +129,26 @@ type SyncMockManager struct {
 	// if this struct ever got embedded or reordered.
 	dropCount atomic.Uint64
 
+	// droppedMu guards droppedTCNames / droppedTCOrder. It is a DEDICATED
+	// LEAF lock: it is only ever taken while (optionally) holding
+	// outChanMu.RLock, and it takes no other lock while held — so it can
+	// never participate in a lock-ordering cycle with m.mu or outChanMu.
+	// Do NOT reuse m.mu or outChanMu here.
+	//
+	// droppedTCNames is the set of test-case names that OWNED a mock which
+	// was dropped on the outChan capacity path (send-budget exhaustion or an
+	// already-closed channel). Unlike the memory-pressure path — which
+	// records pressureRanges so record.go suppresses the overlapping TC — a
+	// capacity drop feeds nothing into pressureRanges, so the owning TC would
+	// otherwise reach replay mock-less (match_phase=no_mocks). record.go
+	// queries this set by EXACT test name (WasMockDroppedForTC) and suppresses
+	// any TC in it, so suppression cannot over-suppress a concurrent TC.
+	// droppedTCOrder is the FIFO insertion order used to evict the oldest name
+	// once the set exceeds maxDroppedTCNames (count-bounded, see the const).
+	droppedMu      sync.Mutex
+	droppedTCNames map[string]struct{}
+	droppedTCOrder []string
+
 	// testCounter generates this session's sequential test IDs
 	// ("test-1", "test-2", …). Per-instance so concurrent capture
 	// sessions in one process number their testcases independently.
@@ -190,6 +216,15 @@ type SyncMockManager struct {
 // active. end is zero while the interval is still open (pressure not cleared yet).
 type pressureRange struct {
 	start, end time.Time
+}
+
+// ownedMock pairs a buffered mock with the name of the test case that owns it,
+// so the send path can record the OWNING TC when a capacity drop occurs. owner
+// is "" for mocks not owned by a specific test (session/connection/startup/
+// anonymous carve-outs) — those record nothing on a drop.
+type ownedMock struct {
+	mock  *models.Mock
+	owner string
 }
 
 // Global instance is initialized at package load time
@@ -340,9 +375,26 @@ const sendDropSampleRate uint64 = 1024
 // customer-facing recording-loss flake and is strictly worse than a
 // 200 ms worst-case shutdown delay.
 func (m *SyncMockManager) sendToOutChan(mock *models.Mock) {
+	m.sendToOutChanOwned(mock, "")
+}
+
+// sendToOutChanOwned is sendToOutChan with the owning test name threaded
+// through so a capacity drop can be attributed to the TC that owns the mock.
+// When owner != "" and the mock is genuinely undeliverable — the outChan is
+// closed/nil, or the bounded send budget is exhausted — the owner is recorded
+// via recordDroppedTC so record.go suppresses (rather than streams) that TC at
+// replay. owner == "" (session/connection/startup/anonymous) records nothing.
+// See sendToOutChan's doc comment for the locking rationale.
+func (m *SyncMockManager) sendToOutChanOwned(mock *models.Mock, owner string) {
 	m.outChanMu.RLock()
 	defer m.outChanMu.RUnlock()
 	if m.outChanClosed || m.outChan == nil {
+		// Genuinely undeliverable → a real drop. Record the owner (under the
+		// outChanMu.RLock already held; droppedMu is a leaf lock) so the
+		// orphaned TC is suppressed instead of reaching replay mock-less.
+		if owner != "" {
+			m.recordDroppedTC(owner)
+		}
 		return
 	}
 	select {
@@ -358,6 +410,9 @@ func (m *SyncMockManager) sendToOutChan(mock *models.Mock) {
 		timer.Stop()
 	case <-timer.C:
 		n := m.dropCount.Add(1)
+		if owner != "" {
+			m.recordDroppedTC(owner)
+		}
 		// The existing per-1024 sampled Error fires at n==1 AND every
 		// subsequent 1024th drop. Per-Copilot review on #4176, the
 		// "your recording is now lossy" wording lives on the same n==1
@@ -388,6 +443,55 @@ func (m *SyncMockManager) DropCount() uint64 {
 		return 0
 	}
 	return m.dropCount.Load()
+}
+
+// recordDroppedTC remembers that a mock owned by test `name` was dropped on the
+// outChan capacity path. Idempotent per name (the set dedups) and count-bounded
+// FIFO at maxDroppedTCNames: past the cap the oldest name is evicted so a long
+// recording can't leak unbounded. Takes only droppedMu (a leaf lock).
+func (m *SyncMockManager) recordDroppedTC(name string) {
+	if m == nil || name == "" {
+		return
+	}
+	m.droppedMu.Lock()
+	defer m.droppedMu.Unlock()
+	if m.droppedTCNames == nil {
+		m.droppedTCNames = make(map[string]struct{})
+	}
+	if _, ok := m.droppedTCNames[name]; ok {
+		return
+	}
+	m.droppedTCNames[name] = struct{}{}
+	m.droppedTCOrder = append(m.droppedTCOrder, name)
+	if len(m.droppedTCOrder) > maxDroppedTCNames {
+		delete(m.droppedTCNames, m.droppedTCOrder[0])
+		k := copy(m.droppedTCOrder, m.droppedTCOrder[1:])
+		m.droppedTCOrder = m.droppedTCOrder[:k]
+	}
+}
+
+// WasMockDroppedForTC reports whether a mock owned by test `name` was dropped on
+// the outChan capacity path. record.go calls this by EXACT test name so a
+// suppression can never spill onto a concurrent TC that kept all its mocks.
+func (m *SyncMockManager) WasMockDroppedForTC(name string) bool {
+	if m == nil || name == "" {
+		return false
+	}
+	m.droppedMu.Lock()
+	defer m.droppedMu.Unlock()
+	_, ok := m.droppedTCNames[name]
+	return ok
+}
+
+// DroppedTCCount returns the number of distinct test cases that lost a mock to
+// a capacity drop. Exposed for the session-summary log in routes/record.go.
+func (m *SyncMockManager) DroppedTCCount() int {
+	if m == nil {
+		return 0
+	}
+	m.droppedMu.Lock()
+	defer m.droppedMu.Unlock()
+	return len(m.droppedTCNames)
 }
 
 func (m *SyncMockManager) AddMock(mock *models.Mock) {
@@ -593,7 +697,7 @@ func (m *SyncMockManager) FlushOwnedWindows() {
 		return
 	}
 
-	var mocksToSend []*models.Mock
+	var mocksToSend []ownedMock
 	var lateMappings map[string][]string
 
 	m.mu.Lock()
@@ -621,8 +725,9 @@ func (m *SyncMockManager) FlushOwnedWindows() {
 		}
 		if lt := mock.TestModeInfo.Lifetime; lt == models.LifetimeSession || lt == models.LifetimeConnection {
 			// Reusable across tests; flush verbatim (never renamed),
-			// matching ResolveRange's lifetime carve-out.
-			mocksToSend = append(mocksToSend, mock)
+			// matching ResolveRange's lifetime carve-out. Owned by no
+			// specific test → owner "" (a capacity drop records nothing).
+			mocksToSend = append(mocksToSend, ownedMock{mock: mock})
 			continue
 		}
 		if w, ok := ownerWindow(mock.Spec.ReqTimestampMock); ok {
@@ -633,7 +738,9 @@ func (m *SyncMockManager) FlushOwnedWindows() {
 				}
 				lateMappings[w.testName] = append(lateMappings[w.testName], mock.Name)
 			}
-			mocksToSend = append(mocksToSend, mock)
+			// Owned by the matched window's test → tag it so a capacity
+			// drop suppresses that TC.
+			mocksToSend = append(mocksToSend, ownedMock{mock: mock, owner: w.testName})
 			continue
 		}
 		// STARTUP RESCUE: a startup-window mock the ownerWindow check above
@@ -641,10 +748,10 @@ func (m *SyncMockManager) FlushOwnedWindows() {
 		// window hasn't resolved yet on this ticker tick). Flush it to disk
 		// proactively rather than leaving it parked in the buffer where a dedup
 		// cleanup, stale-cutoff, or memory-pressure wipe could reap it before it
-		// is ever persisted.
+		// is ever persisted. Owns no specific test → owner "".
 		if isStartupMock(mock) {
 			mock.Name = "mock-" + generateRandomString(8)
-			mocksToSend = append(mocksToSend, mock)
+			mocksToSend = append(mocksToSend, ownedMock{mock: mock})
 			continue
 		}
 		// Not attributable yet — a future (possibly out-of-order) request
@@ -660,8 +767,8 @@ func (m *SyncMockManager) FlushOwnedWindows() {
 
 	// Send AFTER releasing m.mu — sendToOutChan takes outChanMu and may
 	// block up to sendBudget; holding m.mu across it would wedge AddMock.
-	for _, mock := range mocksToSend {
-		m.sendToOutChan(mock)
+	for _, om := range mocksToSend {
+		m.sendToOutChanOwned(om.mock, om.owner)
 	}
 	if mappingChan != nil {
 		for tn, ids := range lateMappings {
@@ -897,7 +1004,7 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 	// would keep mu held, blocking every AddMock waiting to enqueue.
 	// We have outChanMu (inside sendToOutChan) to guard the actual
 	// send against close, so m.mu release here is safe.
-	var mocksToSend []*models.Mock
+	var mocksToSend []ownedMock
 	var associatedMockIDs []string
 	var mappingEntry *models.TestMockMapping
 	// lateMappings accumulates mock IDs for mocks retroactively binned
@@ -1015,8 +1122,8 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 			// recorder writes whatever Name the mock already
 			// carries. They also don't belong in the per-test
 			// associatedMockIDs mapping (which is purely about
-			// per-test matches).
-			mocksToSend = append(mocksToSend, mock)
+			// per-test matches). Owned by no specific test → owner "".
+			mocksToSend = append(mocksToSend, ownedMock{mock: mock})
 			continue
 		}
 
@@ -1041,7 +1148,9 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 				}
 				mock.Name = "mock-" + generateRandomString(8)
 				associatedMockIDs = append(associatedMockIDs, mock.Name)
-				mocksToSend = append(mocksToSend, mock)
+				// Owned by THIS window's test → tag it so a capacity
+				// drop suppresses testName rather than orphaning it.
+				mocksToSend = append(mocksToSend, ownedMock{mock: mock, owner: testName})
 			} else if isStartupMock(mock) {
 				// STARTUP RESCUE (static-dedup duplicate window): keep==false
 				// means the enterprise static-dedup deemed THIS test case a
@@ -1060,7 +1169,9 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 					continue
 				}
 				mock.Name = "mock-" + generateRandomString(8)
-				mocksToSend = append(mocksToSend, mock)
+				// Duplicate's synthetic testName owns no real mapping →
+				// owner "" (records nothing on a capacity drop).
+				mocksToSend = append(mocksToSend, ownedMock{mock: mock})
 			}
 			// We successfully matched and handled this mock.
 			// We discard it from the buffer so it doesn't get processed again.
@@ -1095,7 +1206,9 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 					}
 					lateMappings[ownerW.testName] = append(lateMappings[ownerW.testName], mock.Name)
 				}
-				mocksToSend = append(mocksToSend, mock)
+				// Owned by the retro-matched window's test → tag it so a
+				// capacity drop suppresses that TC.
+				mocksToSend = append(mocksToSend, ownedMock{mock: mock, owner: ownerW.testName})
 				lateBinned++
 			}
 			// Handled (flushed or retained); drop from the current buffer.
@@ -1119,7 +1232,8 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 				continue
 			}
 			mock.Name = "mock-" + generateRandomString(8)
-			mocksToSend = append(mocksToSend, mock)
+			// Boot/startup traffic owns no specific test → owner "".
+			mocksToSend = append(mocksToSend, ownedMock{mock: mock})
 			continue
 		}
 
@@ -1226,12 +1340,13 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 		)
 	}
 
-	// Route mock sends through sendToOutChan so the close-vs-send
-	// race is serialized the same way AddMock does it. Mapping
-	// channel is never closed by the shutdown path today — if that
-	// ever changes, lift the mapping send under an equivalent guard.
-	for _, mock := range mocksToSend {
-		m.sendToOutChan(mock)
+	// Route mock sends through sendToOutChanOwned so the close-vs-send
+	// race is serialized the same way AddMock does it, and a capacity
+	// drop is attributed to the owning TC. Mapping channel is never
+	// closed by the shutdown path today — if that ever changes, lift the
+	// mapping send under an equivalent guard.
+	for _, om := range mocksToSend {
+		m.sendToOutChanOwned(om.mock, om.owner)
 	}
 	if mappingEntry != nil && mappingChan != nil {
 		select {
@@ -1283,7 +1398,7 @@ func (m *SyncMockManager) DeleteMocksStrictlyBefore(timestamp time.Time) {
 		return
 	}
 
-	var mocksToSend []*models.Mock
+	var mocksToSend []ownedMock
 	var lateMappings map[string][]string
 
 	m.mu.Lock()
@@ -1316,10 +1431,11 @@ func (m *SyncMockManager) DeleteMocksStrictlyBefore(timestamp time.Time) {
 
 		// Session/connection mocks outlive any single test window and must
 		// survive a per-test cleanup. Flush when we can persist them now,
-		// otherwise retain for a later drain.
+		// otherwise retain for a later drain. Owned by no specific test →
+		// owner "".
 		if lt := mock.TestModeInfo.Lifetime; lt == models.LifetimeSession || lt == models.LifetimeConnection {
 			if outChanBound {
-				mocksToSend = append(mocksToSend, mock)
+				mocksToSend = append(mocksToSend, ownedMock{mock: mock})
 				continue
 			}
 			m.buffer[keepIdx] = mock
@@ -1344,7 +1460,9 @@ func (m *SyncMockManager) DeleteMocksStrictlyBefore(timestamp time.Time) {
 				}
 				lateMappings[w.testName] = append(lateMappings[w.testName], mock.Name)
 			}
-			mocksToSend = append(mocksToSend, mock)
+			// Owned by the rescued window's test → tag it so a capacity
+			// drop suppresses that TC.
+			mocksToSend = append(mocksToSend, ownedMock{mock: mock, owner: w.testName})
 			continue
 		}
 
@@ -1364,7 +1482,8 @@ func (m *SyncMockManager) DeleteMocksStrictlyBefore(timestamp time.Time) {
 				continue
 			}
 			mock.Name = "mock-" + generateRandomString(8)
-			mocksToSend = append(mocksToSend, mock)
+			// Startup/boot traffic owns no specific test → owner "".
+			mocksToSend = append(mocksToSend, ownedMock{mock: mock})
 			continue
 		}
 
@@ -1382,8 +1501,8 @@ func (m *SyncMockManager) DeleteMocksStrictlyBefore(timestamp time.Time) {
 
 	// Send AFTER releasing m.mu — sendToOutChan takes outChanMu and may
 	// block up to sendBudget; holding m.mu across it would wedge AddMock.
-	for _, mock := range mocksToSend {
-		m.sendToOutChan(mock)
+	for _, om := range mocksToSend {
+		m.sendToOutChanOwned(om.mock, om.owner)
 	}
 	if mappingChan != nil {
 		for tn, ids := range lateMappings {

--- a/pkg/agent/routes/record.go
+++ b/pkg/agent/routes/record.go
@@ -358,6 +358,8 @@ func (a *Agent) HandleIncoming(w http.ResponseWriter, r *http.Request) {
 					zap.Int("pressure_ranges_total", syncmgr.Get().PressureRangeCount()),
 					zap.Int64("mocks_dropped_by_pressure", finalDropped),
 					zap.Int64("mocks_added_successfully", finalAdded),
+					zap.Uint64("mocks_dropped_capacity", syncmgr.Get().DropCount()),
+					zap.Int("tcs_dropped_capacity", syncmgr.Get().DroppedTCCount()),
 				)
 				return
 			}
@@ -370,14 +372,22 @@ func (a *Agent) HandleIncoming(w http.ResponseWriter, r *http.Request) {
 			// mock's goroutine runs relative to this handler.
 			tcRespTime := t.HTTPResp.Timestamp
 			hasOverlap, overlapCount := syncmgr.Get().WasPressureActiveInWindow(t.HTTPReq.Timestamp, tcRespTime)
+			// A capacity drop (outChan overflow / already-closed channel)
+			// feeds nothing into pressureRanges, so the pressure-overlap check
+			// above cannot catch it. Suppress by EXACT owning test name so a
+			// TC whose mock was capacity-dropped is not streamed mock-less
+			// (replay: match_phase=no_mocks), without over-suppressing any
+			// concurrent TC that kept all its mocks.
+			mockDropped := syncmgr.Get().WasMockDroppedForTC(t.Name)
 
-			if hasOverlap {
+			if hasOverlap || mockDropped {
 				tcsSuppressedSoFar++
-				a.logger.Debug("agent: TC suppressed — memory pressure overlapped TC window, not sent to CLI",
+				a.logger.Debug("agent: TC suppressed — memory pressure overlapped TC window or a mock was capacity-dropped, not sent to CLI",
 					zap.String("tc_name", t.Name),
 					zap.Int64("tc_req_ms", t.HTTPReq.Timestamp.UnixMilli()),
 					zap.Int64("tc_resp_ms", tcRespTime.UnixMilli()),
 					zap.Int("pressure_overlaps", overlapCount),
+					zap.Bool("capacity_drop", mockDropped),
 					zap.Int("tcs_suppressed_so_far", tcsSuppressedSoFar),
 				)
 				continue

--- a/pkg/models/instrument.go
+++ b/pkg/models/instrument.go
@@ -101,6 +101,14 @@ type OutgoingOptions struct {
 	// before dialing and deadlocks otherwise. When nil/empty, the
 	// proxy falls back to the built-in defaults [3306, 4000].
 	MysqlPorts []uint32
+	// SupportsDroppedRevoke is a capability flag set by the CLI on the
+	// /outgoing request: when true, the CLI understands the reserved
+	// Kind=RevokedTests control frame (it diverts it into a revoke set and
+	// deletes those test cases at finalize) rather than trying to persist it
+	// as a mock. The agent emits revoke frames ONLY when this is true, so an
+	// older CLI that never sets it never receives one — the version-skew
+	// guard for the deferred-orphan revoke protocol. Record path only.
+	SupportsDroppedRevoke bool
 }
 
 type ConditionalDstCfg struct {

--- a/pkg/models/mock.go
+++ b/pkg/models/mock.go
@@ -48,6 +48,17 @@ const (
 	// GenericResponses payload slices and owns the typed frame model +
 	// the YAML mapper, so no Aerospike-specific type lives in OSS core.
 	Aerospike Kind = "Aerospike"
+
+	// RevokedTests is a RESERVED control Kind — it is NOT a real mock and no
+	// traffic parser ever produces it. The recorder emits a Mock with this Kind
+	// on the /outgoing stream to tell the CLI to revoke (delete) test cases
+	// whose owned mock was capacity-dropped AFTER the TC had already streamed
+	// (the deferred-orphan case that stream-time suppression cannot catch). The
+	// revoked TC names ride in Spec.Metadata. The CLI diverts this frame into a
+	// revoke set instead of persisting it; the agent emits it ONLY to a CLI that
+	// negotiated OutgoingOptions.SupportsDroppedRevoke, so an older CLI (which
+	// never sets that flag) never receives it and cannot mis-persist it.
+	RevokedTests Kind = "keploy-revoked-tests"
 )
 
 // MockName constants for the PostgresV3 parser. The integrations-side

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -16,6 +16,7 @@ import (
 	coreAgent "go.keploy.io/server/v3/pkg/agent"
 	"go.keploy.io/server/v3/pkg/agent/memoryguard"
 	proxyPkg "go.keploy.io/server/v3/pkg/agent/proxy"
+	syncMock "go.keploy.io/server/v3/pkg/agent/proxy/syncMock"
 	pTls "go.keploy.io/server/v3/pkg/agent/proxy/tls"
 	"go.keploy.io/server/v3/pkg/models"
 	kdocker "go.keploy.io/server/v3/pkg/platform/docker"
@@ -465,6 +466,14 @@ func (a *Agent) GetOutgoing(ctx context.Context, opts models.OutgoingOptions) (<
 	if err != nil {
 		return nil, err
 	}
+
+	// Gate the deferred-orphan revoke protocol on what THIS CLI negotiated.
+	// The proxy wires its outChan into the package-global syncMock manager
+	// (syncMock.Get()) inside Record above; flip revoke emission on/off to
+	// match the decoded capability before returning the stream so an older CLI
+	// (SupportsDroppedRevoke=false, the default) never receives a RevokedTests
+	// control frame it can't divert.
+	syncMock.Get().SetRevokeCapable(opts.SupportsDroppedRevoke)
 
 	return m, nil
 }

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -170,6 +170,19 @@ func (r *Recorder) Start(ctx context.Context) error {
 	domainSet := telemetry.NewDomainSet()
 	var recordingStarted bool
 
+	// Deferred-orphan revoke bookkeeping. revokedNames collects TC names the
+	// agent signalled via Kind=RevokedTests control frames (their owned mock
+	// was capacity-dropped AFTER the TC streamed); insertedNames records which
+	// TCs actually persisted. At finalize we delete the intersection so a
+	// revoke that raced ahead of its TC's persistence is still caught. Both are
+	// written only by the mock/TC consumer goroutines and read at teardown
+	// AFTER those goroutines drain, but the mutexes are cheap insurance against
+	// a force-shutdown teardown racing an in-flight consumer.
+	revokedNames := map[string]struct{}{}
+	var revokedMu sync.Mutex
+	insertedNames := map[string]struct{}{}
+	var insertedMu sync.Mutex
+
 	// defering the stop function to stop keploy in case of any error in record or in case of context cancellation
 	defer func() {
 		select {
@@ -219,6 +232,66 @@ func (r *Recorder) Start(ctx context.Context) error {
 		if err := utils.DrainErrGroup(r.logger, "record", errGrp, 30*time.Second); err != nil {
 			utils.LogError(r.logger, err, "failed to stop recording")
 		}
+
+		// Deferred-orphan revoke: delete TCs whose owned mock was capacity-dropped
+		// AFTER the TC streamed (the agent signalled them live via RevokedTests
+		// control frames). Applied here — after all inserts drained — so a revoke
+		// that raced ahead of its TC's persistence is still caught by the intersect.
+		// Snapshot both sets under their OWN locks before intersecting. On the
+		// DrainErrGroup TIMEOUT path a wedged consumer goroutine can still be
+		// writing these maps (DrainErrGroup returns after its timeout WITHOUT
+		// joining a goroutine that ignores cancellation — see utils/drain.go),
+		// so an unguarded read here could hit a fatal "concurrent map read and
+		// map write". The two maps are never locked together elsewhere, so
+		// snapshot each independently (lock, copy, unlock) — no nesting, no
+		// ordering hazard.
+		revokedMu.Lock()
+		revokedSnap := make([]string, 0, len(revokedNames))
+		for n := range revokedNames {
+			revokedSnap = append(revokedSnap, n)
+		}
+		revokedMu.Unlock()
+
+		var toDelete []string
+		insertedMu.Lock()
+		for _, n := range revokedSnap {
+			if _, ok := insertedNames[n]; ok {
+				toDelete = append(toDelete, n)
+			}
+		}
+		insertedMu.Unlock()
+		if len(toDelete) > 0 {
+			// DeleteTests is on the concrete *testdb.TestYaml but NOT on the record
+			// TestDB interface (enterprise implements that interface; don't break it).
+			// Reach it by runtime assertion; degrade to a warning if unavailable.
+			if td, ok := r.testDB.(interface {
+				DeleteTests(ctx context.Context, testSetID string, testCaseIDs []string) error
+			}); ok {
+				deleted := 0
+				for _, n := range toDelete {
+					if err := td.DeleteTests(ctx, newTestSetID, []string{n}); err != nil {
+						r.logger.Warn("deferred-orphan revoke: failed to delete a capacity-orphaned test case; leaving it in the set",
+							zap.String("testSetID", newTestSetID), zap.String("testCase", n), zap.Error(err))
+						continue
+					}
+					deleted++
+				}
+				if deleted > 0 {
+					// Guard under insertedMu so this decrement can't race the
+					// (possibly still-live, on the drain-timeout path) testCount++
+					// in the TC-insert loop, which now runs under the same lock.
+					insertedMu.Lock()
+					testCount -= deleted
+					insertedMu.Unlock()
+					r.logger.Info("deferred-orphan revoke: removed capacity-orphaned test cases whose mock was dropped after streaming",
+						zap.Int("revoked", deleted), zap.String("testSetID", newTestSetID))
+				}
+			} else {
+				r.logger.Warn("deferred-orphan revoke: testDB does not support DeleteTests; leaving orphaned test cases in the set",
+					zap.Int("count", len(toDelete)))
+			}
+		}
+
 		totalMocks := 0
 		if recordingStarted {
 			mockCountMapMu.Lock()
@@ -421,7 +494,15 @@ func (r *Recorder) Start(ctx context.Context) error {
 				}
 				insertTestErrChan <- err
 			} else {
+				// testCount and insertedNames are both TC-insert state; write
+				// them under one insertedMu section so the finalize revoke block
+				// (which reads insertedNames and adjusts testCount, possibly
+				// while this goroutine is still live on the drain-timeout path)
+				// can't race them.
+				insertedMu.Lock()
 				testCount++
+				insertedNames[testCase.Name] = struct{}{}
+				insertedMu.Unlock()
 				r.telemetry.RecordedTestAndMocks()
 				if hookErr := r.hooks.AfterTestCaseInsert(ctx, &TestCaseContext{
 					TestCase: testCase, TestSetID: newTestSetID,
@@ -438,6 +519,22 @@ func (r *Recorder) Start(ctx context.Context) error {
 
 	errGrp.Go(func() error {
 		for mock := range frames.Outgoing {
+			// Deferred-orphan revoke: a reserved-Kind control frame, NOT a mock.
+			// Divert it into the revoke set (applied at finalize) BEFORE any
+			// domain-extraction / hook / InsertMock / correlation work — it
+			// carries no traffic and must never be persisted.
+			if mock.GetKind() == string(models.RevokedTests) {
+				if mock.Spec.Metadata != nil {
+					for _, n := range strings.Split(mock.Spec.Metadata["revoked_tests"], ",") {
+						if n = strings.TrimSpace(n); n != "" {
+							revokedMu.Lock()
+							revokedNames[n] = struct{}{}
+							revokedMu.Unlock()
+						}
+					}
+				}
+				continue
+			}
 			domainSet.AddAll(telemetry.ExtractDomainsFromMock(mock))
 			tempID := mock.Name
 			if hookErr := r.hooks.BeforeMockInsert(ctx, &MockContext{
@@ -659,6 +756,11 @@ func (r *Recorder) GetTestAndMockChans(ctx context.Context) (FrameChan, error) {
 		CapturePackets:            r.config.Record.CapturePackets,
 		OpportunisticTLSIntercept: r.config.Record.OpportunisticTLSIntercept,
 		MysqlPorts:                r.config.MysqlPorts,
+		// Advertise that this CLI understands the reserved Kind=RevokedTests
+		// control frame: it diverts such a frame into a revoke set and deletes
+		// those deferred-orphan test cases at finalize instead of persisting it
+		// as a mock. The agent emits revoke frames ONLY when this is true.
+		SupportsDroppedRevoke: true,
 	})
 	if err != nil {
 


### PR DESCRIPTION
## What & why

`go-memory-load-mongo (record_build_replay_latest)` flakes at replay with `mongo mock miss … match_phase="no_mocks", candidates=0` — a recorded test case reaches replay with an **empty** per-test mock pool. Root cause: under high request concurrency the recorder drops mocks on the bounded `outChan` **capacity** path (send-budget exhaustion after 200 ms, or a send to an already-closed channel). Unlike the memory-pressure drop path — which records `pressureRanges` so `record.go` suppresses the overlapping TC — a capacity drop fed **nothing** into suppression, so the owning TC was streamed to the CLI mock-less and failed at replay.

## The fix (current-window closure)

Record the **owning test-case name** of every capacity-dropped mock in a count-bounded (`maxDroppedTCNames = 8192`) set behind a dedicated **leaf** mutex, and have `record.go` suppress by **exact test name** any TC in that set. Exact-name lookup makes suppression structurally immune to over-suppressing a concurrent TC that kept all its mocks.

- Split `sendToOutChan(mock)` → thin wrapper over `sendToOutChanOwned(mock, owner)`; record the owner on the send-budget drop and on the previously-silent closed-channel early return (when `owner != ""`).
- Thread `owner = resolved test name` through the three builder send loops (`FlushOwnedWindows`, `ResolveRange` in-window + retro-bin, `DeleteMocksStrictlyBefore` owner-window rescue). Session/connection/startup/anonymous carve-outs keep `owner=""` and record nothing.
- `record.go` ORs `WasMockDroppedForTC(t.Name)` beside the pressure-overlap check.

This closes the **current-window** orphan — the observed failure, where the drop is recorded synchronously inside the test's own `ResolveRange` before the TC is streamed (verified happens-before). It is 100% of the observed 25/335 failures.

## Measure-first for the deferred residual

The stream-time check is one-shot at receive time, so a mock capacity-dropped **later** for an already-streamed TC (a deferred/late-mock orphan) can't be caught by it. Rather than build the delivery machinery (barrier + finalized-set sentinel + CLI delete) blind — it needs core-teardown changes that risk **all** record paths, for a residual never observed in this lane — this PR first **measures** it:

- The agent logs `deferred_orphans_after_stream` (TCs streamed whose owned mock was dropped-and-recorded afterwards) in the `agent: recording complete` line, emitted on both handler exit paths.
- The `go-memory-load-mongo` e2e captures that counter from the agent container (streamed to a file, since the CLI removes the container on shutdown). Non-fatal.

If CI shows the deferred count is ~0, Layer 1 was the whole fix. If >0, the targeted delivery fix is built next — grounded in the measured corners, not speculation.

## Verification

- `go build ./... && go vet ./pkg/agent/... && go test -race ./pkg/agent/proxy/syncMock/...` green.
- New unit tests: forced-drop precise-owner recording, empty-owner-records-nothing, closed-channel path, count-bounded FIFO eviction, idempotency, a `-race` concurrency test, and **end-to-end owner-threading through all three send loops** (each mutation-verified: flipping the owner tag turns the guard red).
- Two independent adversarial reviews (concurrency/lock-ordering, owner attribution, FIFO math, namespace match, regression) — clean, no over-suppression, no deadlock (`droppedMu` is a true leaf).

## Notes

The `chore` commit's instrumentation is temporary — to be removed or folded into the delivery fix once the residual is sized.
