### PR TITLE
fix(agent): suppress test cases whose mock was voided as incomplete (go-memory-load-mongo no_mocks)

### DIFF
--- a/pkg/agent/proxy/supervisor/orphan_window_test.go
+++ b/pkg/agent/proxy/supervisor/orphan_window_test.go
@@ -1,0 +1,160 @@
+package supervisor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	syncMock "go.keploy.io/server/v3/pkg/agent/proxy/syncMock"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap/zaptest"
+)
+
+// TestEmitMockIncompleteRecordsOrphanWindow is the root-cause repro for the
+// go-memory-load-mongo no_mocks flake. When a parser marks its mock incomplete
+// (reassembly overflow, a decode error on the post-pressure realignment tail,
+// per-conn cap, short write) the NEXT emitMockCore drops the mock SILENTLY —
+// and before this fix it told NO ONE, so the test case that owns the operation
+// still streamed to the CLI and reached replay mock-less (match_phase=no_mocks).
+// The fix records the dropped mock's wire window as an orphan window so
+// record.go suppresses the owning TC. This drives the real EmitMock path.
+func TestEmitMockIncompleteRecordsOrphanWindow(t *testing.T) {
+	t.Parallel()
+	mgr := &syncMock.SyncMockManager{}
+	ch := make(chan *models.Mock, 1)
+	base := time.Now()
+	reqTs := base.Add(10 * time.Millisecond)
+	resTs := base.Add(30 * time.Millisecond)
+	sess := &Session{
+		Mocks:  ch,
+		Ctx:    context.Background(),
+		Logger: zaptest.NewLogger(t),
+		Mgr:    mgr,
+	}
+
+	// Precondition (the bug): with no orphan window recorded, a TC whose HTTP
+	// window spans the operation is NOT suppressible — it would reach replay.
+	if ok, _ := mgr.WasMockOrphanedInWindow(base, base.Add(50*time.Millisecond)); ok {
+		t.Fatalf("no orphan window should exist before any incomplete drop")
+	}
+
+	// A mock is voided by the incomplete flag; its wire window is [reqTs, resTs].
+	sess.MarkMockIncomplete("request decode error")
+	dropped := &models.Mock{
+		Name: "find-customers",
+		Spec: models.MockSpec{ReqTimestampMock: reqTs, ResTimestampMock: resTs},
+	}
+	if err := sess.EmitMock(dropped); err != nil {
+		t.Fatalf("EmitMock returned err: %v", err)
+	}
+
+	// The mock itself must NOT have leaked to the sink (still dropped).
+	select {
+	case got := <-ch:
+		t.Fatalf("incomplete mock leaked to channel: %v", got.Name)
+	default:
+	}
+
+	// The fix: the owning TC (HTTP window overlapping [reqTs, resTs]) is now
+	// suppressible via the recorded orphan window.
+	if ok, cnt := mgr.WasMockOrphanedInWindow(base, base.Add(50*time.Millisecond)); !ok || cnt != 1 {
+		t.Fatalf("incomplete drop must record an orphan window over the mock's wire window; got ok=%v cnt=%d", ok, cnt)
+	}
+	// A concurrent TC that does NOT overlap the voided op is not suppressed.
+	if ok, _ := mgr.WasMockOrphanedInWindow(base.Add(100*time.Millisecond), base.Add(200*time.Millisecond)); ok {
+		t.Fatalf("a TC window not overlapping the voided op must not be suppressed")
+	}
+}
+
+// TestEmitMockIncompleteSkipsSessionLifetimeMock pins the guard that a voided
+// SESSION/CONNECTION mock (a reusable mongo handshake/heartbeat, served from
+// the session tier at replay regardless of the drop) does NOT record an orphan
+// window — recording it would only risk over-suppressing a healthy per-test TC
+// that overlaps its window, since a stale mockIncomplete flag can void a
+// reusable mock that belongs to no test at all.
+func TestEmitMockIncompleteSkipsSessionLifetimeMock(t *testing.T) {
+	t.Parallel()
+	for _, lt := range []models.Lifetime{models.LifetimeSession, models.LifetimeConnection} {
+		mgr := &syncMock.SyncMockManager{}
+		sess := &Session{
+			Mocks:  make(chan *models.Mock, 1),
+			Ctx:    context.Background(),
+			Logger: zaptest.NewLogger(t),
+			Mgr:    mgr,
+		}
+		sess.MarkMockIncomplete("memory_pressure")
+		reusable := &models.Mock{
+			Name: "hello-heartbeat",
+			Spec: models.MockSpec{
+				ReqTimestampMock: time.Now(),
+				ResTimestampMock: time.Now().Add(time.Millisecond),
+			},
+			TestModeInfo: models.TestModeInfo{Lifetime: lt},
+		}
+		if err := sess.EmitMock(reusable); err != nil {
+			t.Fatalf("EmitMock: %v", err)
+		}
+		if got := mgr.OrphanRangeCount(); got != 0 {
+			t.Fatalf("a voided %v mock must NOT record an orphan window; count=%d", lt, got)
+		}
+	}
+}
+
+// TestEmitMockHealthyRecordsNoOrphanWindow is the control: a normal emit (no
+// incomplete flag) must NOT record an orphan window, so healthy TCs are never
+// spuriously suppressed.
+func TestEmitMockHealthyRecordsNoOrphanWindow(t *testing.T) {
+	t.Parallel()
+	mgr := &syncMock.SyncMockManager{}
+	ch := make(chan *models.Mock, 1)
+	sess := &Session{
+		Mocks:  ch,
+		Ctx:    context.Background(),
+		Logger: zaptest.NewLogger(t),
+		Mgr:    mgr,
+	}
+	// RouteMocksViaSyncMock is false → direct-channel emit; the mock delivers
+	// and NO orphan window is recorded.
+	m := &models.Mock{Name: "ok", Spec: models.MockSpec{ReqTimestampMock: time.Now()}}
+	if err := sess.EmitMock(m); err != nil {
+		t.Fatalf("EmitMock: %v", err)
+	}
+	if got := mgr.OrphanRangeCount(); got != 0 {
+		t.Fatalf("healthy emit must not record an orphan window; count=%d", got)
+	}
+	select {
+	case got := <-ch:
+		if got.Name != "ok" {
+			t.Fatalf("wrong mock delivered: %v", got.Name)
+		}
+	default:
+		t.Fatalf("healthy mock was not delivered")
+	}
+}
+
+// TestRecordOrphanWindowPublicPath covers the no-mock-built case: a parser that
+// voids an operation BEFORE any mock is emitted (reassembly overflow, decode
+// error) reports the operation's own wire window via Session.RecordOrphanWindow,
+// making that TC suppressible even though emitMockCore never ran for it. Also
+// pins the nil-session and zero-start guards are no-ops.
+func TestRecordOrphanWindowPublicPath(t *testing.T) {
+	t.Parallel()
+	mgr := &syncMock.SyncMockManager{}
+	sess := &Session{Ctx: context.Background(), Mgr: mgr}
+
+	opStart := time.Now()
+	opEnd := opStart.Add(5 * time.Millisecond)
+	sess.RecordOrphanWindow(opStart, opEnd)
+
+	if ok, _ := mgr.WasMockOrphanedInWindow(opStart.Add(-time.Millisecond), opEnd.Add(time.Millisecond)); !ok {
+		t.Fatalf("RecordOrphanWindow must make the failing op's TC suppressible")
+	}
+
+	// Guards: nil session and zero-start are no-ops (must not panic or record).
+	var nilSess *Session
+	nilSess.RecordOrphanWindow(opStart, opEnd)
+	sess.RecordOrphanWindow(time.Time{}, opEnd)
+	if got := mgr.OrphanRangeCount(); got != 1 {
+		t.Fatalf("guards must be no-ops; expected exactly 1 window, got %d", got)
+	}
+}

--- a/pkg/agent/proxy/supervisor/session.go
+++ b/pkg/agent/proxy/supervisor/session.go
@@ -188,9 +188,18 @@ func (s *Session) AddPostRecordHook(h PostRecordHook) {
 // "why was a mock withheld?" (memory pressure, channel full, dropped
 // chunk, parser-internal inconsistency) can enable --debug to see it;
 // subsequent calls within the same session are no-ops and emit nothing.
-// Production runs stay quiet because the forward path is unaffected —
-// only mock recording is impacted, which is an internal concern not a
-// user-facing problem.
+// Production runs stay quiet because the forward path is unaffected.
+//
+// A voided mock is NOT harmless: the test case that owns the operation
+// still streams to the CLI, so dropping its mock silently orphans that TC
+// at replay (match_phase=no_mocks). When a mock DOES reach emitMockCore
+// and is dropped by this flag, emitMockCore records the mock's wire window
+// as an orphan window so record.go suppresses the owning TC. When the
+// parser voids an operation BEFORE any mock is built (a reassembly
+// overflow, or a decode error on the realignment tail after a
+// memory-pressure gap), no mock reaches emitMockCore — the parser should
+// additionally call Session.RecordOrphanWindow with that operation's wire
+// window so its TC is suppressed too.
 //
 // The relay calls this when it gates a chunk at the tee; parsers call
 // it when they cannot continue decoding a mock cleanly. Safe to call
@@ -222,6 +231,37 @@ func (s *Session) IsMockIncomplete() bool {
 		return false
 	}
 	return s.mockIncomplete.Load()
+}
+
+// orphanManager resolves the SyncMockManager this session records into,
+// preferring the per-app s.Mgr and falling back to the package-global. Mirrors
+// the manager resolution in emitMockCore's RouteMocksViaSyncMock branch so an
+// orphan window lands on the SAME manager that owns the dropped mock.
+func (s *Session) orphanManager() *syncMock.SyncMockManager {
+	if s == nil {
+		return nil
+	}
+	if s.Mgr != nil {
+		return s.Mgr
+	}
+	return syncMock.Get()
+}
+
+// RecordOrphanWindow lets a parser report that the operation whose wire window
+// is [start, end] lost its mock because the parser could not build one at all —
+// e.g. a client/server reassembly overflow, or a decode error on the
+// realignment tail after a memory-pressure gap. In those cases NO mock reaches
+// emitMockCore (the mockIncomplete flag instead voids the NEXT mock, which may
+// belong to a different TC), so the failing operation's own TC would leak
+// unless the parser reports its window here. record.go then suppresses any TC
+// whose HTTP window overlaps. Complements MarkMockIncomplete: MarkMockIncomplete
+// voids the mock; RecordOrphanWindow makes that void visible to TC suppression
+// by the operation's own captured timestamps. Safe with a nil session or a zero
+// start (both no-ops — see (*SyncMockManager).RecordOrphanWindow).
+func (s *Session) RecordOrphanWindow(start, end time.Time) {
+	if mgr := s.orphanManager(); mgr != nil {
+		mgr.RecordOrphanWindow(start, end)
+	}
 }
 
 // EmitMock sends m to the mocks channel. If the session's active mock
@@ -309,6 +349,29 @@ func (s *Session) emitMockCore(m *models.Mock, shutdown bool) error {
 		// connection goes idle, producing spurious aborts after a
 		// benign drop (memory pressure, chunk gate, short write).
 		s.mockIncomplete.Store(false)
+		// The mock is abandoned, but the test case that owns this
+		// operation still streams to the CLI — dropping the mock without
+		// telling anyone orphans that TC (replay match_phase=no_mocks).
+		// Record the mock's own wire window as an orphan window so
+		// record.go suppresses the owning TC, exactly as it does for a
+		// memory-pressure drop via WasPressureActiveInWindow. The
+		// timestamps are the parser's captured values — the same clock the
+		// TC's HTTP window is compared against — so a zero timestamp
+		// (parser left it unset) is simply ignored by RecordOrphanWindow
+		// rather than over-claiming.
+		//
+		// Only PER-TEST mocks orphan a specific TC. A voided SESSION or
+		// CONNECTION mock (a mongo handshake/heartbeat and the like) is
+		// reusable and served from the session tier at replay regardless of
+		// this drop, so recording its window would gain nothing and only
+		// risk over-suppressing a healthy per-test TC that happens to
+		// overlap it. Skip those — the stale mockIncomplete flag can void a
+		// reusable mock that belongs to no test at all.
+		if mgr := s.orphanManager(); mgr != nil &&
+			m.TestModeInfo.Lifetime != models.LifetimeSession &&
+			m.TestModeInfo.Lifetime != models.LifetimeConnection {
+			mgr.RecordOrphanWindow(m.Spec.ReqTimestampMock, m.Spec.ResTimestampMock)
+		}
 		if s.Logger != nil {
 			// Debug-level: this fires on every mock that loses an
 			// upstream chunk (per-request frequency on a misconfigured

--- a/pkg/agent/proxy/syncMock/orphan_window_test.go
+++ b/pkg/agent/proxy/syncMock/orphan_window_test.go
@@ -1,0 +1,137 @@
+package manager
+
+import (
+	"testing"
+	"time"
+)
+
+// TestOrphanWindowOverlapSemantics pins the join contract record.go relies on:
+// a recorded non-pressure mock-void window suppresses exactly the TCs whose
+// HTTP [req, resp] window overlaps it, and no others.
+func TestOrphanWindowOverlapSemantics(t *testing.T) {
+	t.Parallel()
+	mgr := &SyncMockManager{}
+	base := time.Now()
+	ms := func(n int) time.Time { return base.Add(time.Duration(n) * time.Millisecond) }
+
+	// A mock voided over the wire window [10ms, 20ms].
+	mgr.RecordOrphanWindow(ms(10), ms(20))
+
+	// A TC whose HTTP window [0, 15ms] straddles the void → suppressed.
+	if ok, cnt := mgr.WasMockOrphanedInWindow(ms(0), ms(15)); !ok || cnt != 1 {
+		t.Fatalf("straddling TC window must be suppressed; got ok=%v cnt=%d", ok, cnt)
+	}
+	// A TC fully inside the void → suppressed.
+	if ok, _ := mgr.WasMockOrphanedInWindow(ms(12), ms(18)); !ok {
+		t.Fatalf("TC window inside the void must be suppressed")
+	}
+	// A TC that touches the boundary (end == void.start) → overlaps (closed
+	// intervals), suppressed.
+	if ok, _ := mgr.WasMockOrphanedInWindow(ms(5), ms(10)); !ok {
+		t.Fatalf("boundary-touching TC window must be suppressed")
+	}
+	// A TC entirely after the void → NOT suppressed (no over-suppression of a
+	// concurrent TC that kept all its mocks).
+	if ok, _ := mgr.WasMockOrphanedInWindow(ms(30), ms(40)); ok {
+		t.Fatalf("non-overlapping TC window must NOT be suppressed")
+	}
+	// A TC entirely before the void ([0, 5ms] ends before void start 10ms) →
+	// NOT suppressed.
+	if ok, _ := mgr.WasMockOrphanedInWindow(ms(0), ms(5)); ok {
+		t.Fatalf("TC window ending before the void start must NOT be suppressed")
+	}
+}
+
+// TestOrphanWindowDegenerateInputs pins the guards: a zero start is ignored
+// (never poison the suppressor into over-claiming), a zero/inverted end is
+// clamped to a valid point interval, and a degenerate TC query is refused
+// rather than matching everything.
+func TestOrphanWindowDegenerateInputs(t *testing.T) {
+	t.Parallel()
+	mgr := &SyncMockManager{}
+	base := time.Now()
+
+	// Zero start → ignored, records nothing.
+	mgr.RecordOrphanWindow(time.Time{}, base)
+	if got := mgr.OrphanRangeCount(); got != 0 {
+		t.Fatalf("zero-start orphan window must be ignored; count=%d", got)
+	}
+
+	// Zero end → clamped to start (a point interval at `base`).
+	mgr.RecordOrphanWindow(base, time.Time{})
+	if got := mgr.OrphanRangeCount(); got != 1 {
+		t.Fatalf("zero-end window must still record as a point; count=%d", got)
+	}
+	if ok, _ := mgr.WasMockOrphanedInWindow(base.Add(-time.Millisecond), base.Add(time.Millisecond)); !ok {
+		t.Fatalf("a TC window spanning the point void must be suppressed")
+	}
+
+	// Inverted end (before start) → clamped to start (point interval).
+	mgr.RecordOrphanWindow(base.Add(100*time.Millisecond), base.Add(50*time.Millisecond))
+	if ok, _ := mgr.WasMockOrphanedInWindow(base.Add(99*time.Millisecond), base.Add(101*time.Millisecond)); !ok {
+		t.Fatalf("inverted-end window must clamp to a point at start and still suppress")
+	}
+
+	// Degenerate TC query (zero start or end) → refused, never over-suppresses.
+	if ok, _ := mgr.WasMockOrphanedInWindow(time.Time{}, base); ok {
+		t.Fatalf("zero-start TC query must be refused")
+	}
+	if ok, _ := mgr.WasMockOrphanedInWindow(base, time.Time{}); ok {
+		t.Fatalf("zero-end TC query must be refused")
+	}
+}
+
+// TestOrphanRangeCountBoundedAndEvictsOldest pins that orphanRanges stays
+// count-bounded under a continuous stream of voids: it grows to at most 2×cap
+// then compacts IN PLACE back toward cap (the amortized-O(1) scheme that avoids
+// a per-call realloc on the hot per-void path), and compaction evicts the
+// OLDEST windows first — so a lagging record.go still sees the most recent
+// voids it might need to suppress.
+func TestOrphanRangeCountBoundedAndEvictsOldest(t *testing.T) {
+	t.Parallel()
+	mgr := &SyncMockManager{}
+	base := time.Now()
+	ms := func(n int) time.Time { return base.Add(time.Duration(n) * time.Millisecond) }
+
+	// Insert past the 2×cap compaction trigger so eviction fires at least once.
+	total := 2*maxPressureRanges + 100
+	for i := 0; i < total; i++ {
+		mgr.RecordOrphanWindow(ms(i), ms(i))
+	}
+	// Count must stay within [cap, 2×cap] — never unbounded.
+	got := mgr.OrphanRangeCount()
+	if got < maxPressureRanges || got > 2*maxPressureRanges {
+		t.Fatalf("orphanRanges count must stay in [%d, %d]; got %d", maxPressureRanges, 2*maxPressureRanges, got)
+	}
+	// The oldest window was evicted by compaction → no longer suppressible.
+	if ok, _ := mgr.WasMockOrphanedInWindow(ms(0), ms(0)); ok {
+		t.Fatalf("oldest orphan window must be evicted after compaction")
+	}
+	// The newest window is retained.
+	last := ms(total - 1)
+	if ok, _ := mgr.WasMockOrphanedInWindow(last, last); !ok {
+		t.Fatalf("newest orphan window must be retained")
+	}
+}
+
+// TestOrphanWindowIndependentOfPressureRanges pins that the two suppressors are
+// separate: recording an orphan window does not create a pressure range and
+// vice-versa, so the session-summary telemetry (pressure_ranges_total vs
+// orphan_ranges_total) stays accurate.
+func TestOrphanWindowIndependentOfPressureRanges(t *testing.T) {
+	t.Parallel()
+	mgr := &SyncMockManager{}
+	base := time.Now()
+
+	mgr.RecordOrphanWindow(base, base.Add(time.Millisecond))
+	if mgr.PressureRangeCount() != 0 {
+		t.Fatalf("orphan window must not create a pressure range")
+	}
+	if got := mgr.OrphanRangeCount(); got != 1 {
+		t.Fatalf("expected 1 orphan range, got %d", got)
+	}
+	// A pressure-only window is not seen by the orphan query.
+	if ok, _ := mgr.WasPressureActiveInWindow(base, base.Add(time.Millisecond)); ok {
+		t.Fatalf("no pressure range should exist")
+	}
+}

--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -224,6 +224,25 @@ type SyncMockManager struct {
 	// intervals and slowing every overlap scan.
 	pressureRanges []pressureRange
 
+	// orphanRanges records every [start, end] wire window over which a mock was
+	// VOIDED for a reason OTHER than memory pressure — a parser marked its mock
+	// incomplete (client/server reassembly overflow, a decode error on the
+	// realignment tail after a memory-pressure gap, per-conn cap, short write)
+	// so supervisor.emitMockCore dropped it, or the parser reported the failing
+	// operation's window directly. It is the exact complement of pressureRanges:
+	// memory-pressure drops happen while memoryguard.IsRecordingPaused() is true
+	// and therefore fall inside a pressureRanges interval, but these voids happen
+	// while recording is NOT paused, so WasPressureActiveInWindow structurally
+	// cannot see them and the orphaned TC would reach replay mock-less
+	// (match_phase=no_mocks). WasMockOrphanedInWindow checks overlap against a
+	// TC's [HTTPReq.Timestamp, HTTPResp.Timestamp] window with the same interval
+	// semantics as pressureRanges, and record.go ORs the two. Count-bounded at
+	// maxPressureRanges (oldest evicted), guarded by mu — a continuous stream of
+	// voids can't grow it unbounded or slow the overlap scan. Entries always
+	// carry a concrete end (RecordOrphanWindow clamps a zero/degenerate end to
+	// start), so no open-interval "extend to now" handling is needed here.
+	orphanRanges []pressureRange
+
 	// loggerMu guards logger so SetLogger and the drop path can run
 	// concurrently without a data race. The read lock is taken only
 	// on the (sampled, cold) Error path, so contention is negligible.
@@ -992,6 +1011,73 @@ func (m *SyncMockManager) PressureRangeCount() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return len(m.pressureRanges)
+}
+
+// RecordOrphanWindow records that a mock owned by some test case was voided
+// over the wire window [start, end] for a NON-pressure reason (a parser marked
+// it incomplete, or emitMockCore dropped it under the mockIncomplete flag).
+// record.go suppresses any TC whose HTTP [req, resp] window overlaps, so the
+// orphaned TC is not streamed mock-less. A degenerate window (start == end, a
+// single operation instant) is valid — the overlap test treats it as a
+// zero-width interval. Bounded by count like pressureRanges (oldest evicted).
+//
+// A zero start is IGNORED: a caller with no reliable wire timestamp must not
+// poison the suppressor into over-claiming (which would silently drop healthy
+// TCs). A zero or inverted end is clamped to start so the entry is a valid
+// point interval rather than an empty or reversed one.
+func (m *SyncMockManager) RecordOrphanWindow(start, end time.Time) {
+	if m == nil || start.IsZero() {
+		return
+	}
+	if end.IsZero() || end.Before(start) {
+		end = start
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.orphanRanges = append(m.orphanRanges, pressureRange{start: start, end: end})
+	// Orphan windows are recorded per voided mock — far more frequently than
+	// pressure ranges (a few per second) — so avoid the reallocate-and-copy on
+	// EVERY call past the cap that SetMemoryPressure can afford. Let the slice
+	// grow to 2×cap, then compact IN PLACE (reuse the backing array, non-
+	// overlapping src/dst) back to the newest cap. Amortized O(1) per call, zero
+	// allocation once warmed, scan bounded at 2×cap, still evicting oldest-first.
+	if n := len(m.orphanRanges); n > 2*maxPressureRanges {
+		m.orphanRanges = append(m.orphanRanges[:0], m.orphanRanges[n-maxPressureRanges:]...)
+	}
+}
+
+// WasMockOrphanedInWindow returns (true, count) if a non-pressure mock void was
+// recorded overlapping [start, end] — the orphan-window twin of
+// WasPressureActiveInWindow. record.go ORs the two so a TC is suppressed
+// whether its mock was lost to memory pressure OR to a parser-side void. Every
+// orphanRanges entry has a concrete end (RecordOrphanWindow guarantees it), so
+// no open-interval handling is needed. Degenerate TC inputs are refused (return
+// false) rather than over-suppressing, matching WasPressureActiveInWindow.
+func (m *SyncMockManager) WasMockOrphanedInWindow(start, end time.Time) (bool, int) {
+	if m == nil || start.IsZero() || end.IsZero() {
+		return false, 0
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	count := 0
+	for _, r := range m.orphanRanges {
+		// Standard interval-overlap test: [r.start, r.end] vs [start, end].
+		if !r.start.After(end) && !r.end.Before(start) {
+			count++
+		}
+	}
+	return count > 0, count
+}
+
+// OrphanRangeCount returns the number of non-pressure mock-void windows
+// recorded so far. Exposed for the session-summary log in routes/record.go.
+func (m *SyncMockManager) OrphanRangeCount() int {
+	if m == nil {
+		return 0
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.orphanRanges)
 }
 
 func (m *SyncMockManager) SetMemoryPressure(enabled bool) {

--- a/pkg/agent/routes/record.go
+++ b/pkg/agent/routes/record.go
@@ -360,6 +360,7 @@ func (a *Agent) HandleIncoming(w http.ResponseWriter, r *http.Request) {
 					zap.Int64("mocks_added_successfully", finalAdded),
 					zap.Uint64("mocks_dropped_capacity", syncmgr.Get().DropCount()),
 					zap.Int("tcs_dropped_capacity", syncmgr.Get().DroppedTCCount()),
+					zap.Int("orphan_ranges_total", syncmgr.Get().OrphanRangeCount()),
 				)
 				return
 			}
@@ -380,14 +381,24 @@ func (a *Agent) HandleIncoming(w http.ResponseWriter, r *http.Request) {
 			// concurrent TC that kept all its mocks.
 			mockDropped := syncmgr.Get().WasMockDroppedForTC(t.Name)
 
-			if hasOverlap || mockDropped {
+			// A non-pressure mock void (parser marked its mock incomplete —
+			// reassembly overflow, a decode error on the realignment tail after
+			// a pressure gap, per-conn cap, short write) records an orphan
+			// window but feeds NEITHER the pressure ranges NOR the capacity
+			// ledger above. Without this check such a void reaches replay
+			// mock-less (match_phase=no_mocks) exactly like the two cases above.
+			// Overlap by the TC's own HTTP window, same as the pressure check.
+			orphanOverlap, orphanCount := syncmgr.Get().WasMockOrphanedInWindow(t.HTTPReq.Timestamp, tcRespTime)
+
+			if hasOverlap || mockDropped || orphanOverlap {
 				tcsSuppressedSoFar++
-				a.logger.Debug("agent: TC suppressed — memory pressure overlapped TC window or a mock was capacity-dropped, not sent to CLI",
+				a.logger.Debug("agent: TC suppressed — memory pressure overlapped TC window, a mock was capacity-dropped, or a mock was voided (incomplete) in the TC window; not sent to CLI",
 					zap.String("tc_name", t.Name),
 					zap.Int64("tc_req_ms", t.HTTPReq.Timestamp.UnixMilli()),
 					zap.Int64("tc_resp_ms", tcRespTime.UnixMilli()),
 					zap.Int("pressure_overlaps", overlapCount),
 					zap.Bool("capacity_drop", mockDropped),
+					zap.Int("orphan_overlaps", orphanCount),
 					zap.Int("tcs_suppressed_so_far", tcsSuppressedSoFar),
 				)
 				continue


### PR DESCRIPTION
integration-ref: fix/mongo-v2-report-orphan-windows

## What

Closes the **actual** `go-memory-load-mongo (record_build_replay_latest)` flake — test cases reaching replay with an empty mock pool (`match_phase="no_mocks", candidates=0`).

Root cause (code-proven): under memory pressure the private mongo/v2 parser marks a mock **incomplete** on a reassembly overflow or a wire decode error (the realignment tail after a pressure gap). `supervisor.emitMockCore` then drops that mock **silently and tells no suppression layer**. The HTTP test case that owns the operation still streams to the CLI, so it persists mock-less and fails at replay.

Existing suppression covered two drop paths but not this one:
- memory-pressure drops → `pressureRanges` / `WasPressureActiveInWindow`
- outChan capacity drops → owning-TC ledger / `WasMockDroppedForTC` (#4352)
- **`MarkMockIncomplete` void → fed neither → orphan.** ← this PR

> Note: #4352 (capacity-drop suppression) was **not** the fix for this lane — CI proved the outChan path never fires here. This PR is.

## How

Record a non-pressure **orphan window** for a voided mock and suppress any TC whose HTTP `[req, resp]` window overlaps it — the same time-window join pressure suppression already uses.

- `syncMock`: `orphanRanges` (count-bounded, `m.mu`-guarded, amortized in-place compaction since voids are recorded per-mock) + `RecordOrphanWindow` / `WasMockOrphanedInWindow` / `OrphanRangeCount`.
- `supervisor.emitMockCore`: record the dropped mock's own wire window — **per-test mocks only** (a voided SESSION/CONNECTION mock is served from the session tier at replay; recording it would only over-suppress a healthy TC).
- `record.go`: OR `WasMockOrphanedInWindow` into the TC-suppression check; add `orphan_ranges_total` to the summary.
- New `Session.RecordOrphanWindow` lets a parser report the window of an op it voided **before any mock was built** (`MarkMockIncomplete` only voids the *next* mock). The companion parser change is **keploy/integrations#245** (wired here via `integration-ref` so CI validates both together).

All timestamps are wall-clock (`HTTPReq/Resp`, mongo `readAt/writtenAt`, pressure ranges all derive from `time.Now()`), so the overlap join is clock-consistent.

## Tests
Orphan-window overlap/bounds/degenerate guards; `emitMockCore` records the voided per-test mock's window (**mutation-verified** — neutering the record call turns the repro red); the SESSION/CONNECTION skip guard; a healthy-emit control. `go build/vet/test -race` green. Independent adversarial review (verdict SHIP).
