### PR TITLE
fix: de-flake OSS record-robustness lanes (mongo tee-drop + mysql prepare-EOF + gRPC harness)

### DIFF
--- a/.github/workflows/test_workflow_scripts/fuzzer/grpc/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/fuzzer/grpc/golang-linux.sh
@@ -135,22 +135,37 @@ ensure_success_phrase() {
 }
 
 # wait_port_free NAME PORT [TIMEOUT_SEC]
-# Block until nothing is listening on localhost:PORT (or TIMEOUT_SEC elapses).
-# Deterministic replacement for a fixed `sleep` after killing a process that
-# owns a port: the next bind must not race a socket that is still being
-# released, which is what surfaces as "listen tcp :PORT: bind: address already
-# in use" and fails the run intermittently. Returns as soon as the port is
-# actually free, so it is normally sub-second. `nc -z` is already used elsewhere
-# in this script to poll for a port coming UP; here we poll for it going DOWN.
+# Block until localhost:PORT is genuinely BIND-able again (or TIMEOUT_SEC
+# elapses). Deterministic replacement for a fixed `sleep` after killing a
+# process that owns a port: the next phase's server must not race a socket that
+# is still being released, which surfaces as
+# "listen tcp :PORT: bind: address already in use" and fails the run
+# intermittently.
+#
+# This must NOT use `nc -z`: a connect probe only detects a LISTENING socket, so
+# it reports the port "free" the instant the previous listener stops accepting —
+# while a socket the previous keploy phase left on the port in a NON-listen
+# state (TIME-WAIT from a server-side close, or a still-closing FIN-WAIT /
+# CLOSE-WAIT) is invisible to it yet still blocks a fresh bind(). That gap is the
+# exact intermittent EADDRINUSE this guard exists to prevent. `ss` sees every
+# TCP state, so we poll it for ANY socket whose LOCAL port is PORT and only
+# proceed once none remain. The timeout must exceed the 60s TCP TIME-WAIT so a
+# genuine TIME-WAIT (which a non-SO_REUSEADDR listener cannot bind over) is
+# waited out rather than raced; normal transitions have no lingering socket and
+# return sub-second. On timeout the offending sockets are dumped for triage.
 wait_port_free() {
-  local name=$1 port=$2 timeout=${3:-30}
+  local name=$1 port=$2 timeout=${3:-90}
   local deadline=$(( $(date +%s) + timeout ))
-  # Bare `nc -z` (no -w): on some netcat builds -w makes -z report an occupied
-  # port as free, which would defeat the whole check. Wall-clock deadline (not
-  # an iteration count) so a slow per-probe nc can't stretch the bound.
-  while nc -z localhost "$port" 2>/dev/null; do
+  # Command substitution (not `ss | grep -q`): a pipe lets `grep -q` close early,
+  # `ss` catch SIGPIPE, and `set -o pipefail` propagate that as a non-zero
+  # condition — which would falsely read as "port free" while it is still held.
+  # `[ -n "$(...)" ]` has no pipe, so the check stays deterministic under pipefail.
+  while [ -n "$(ss -Htan "sport = :$port" 2>/dev/null)" ]; do
     if [ "$(date +%s)" -ge "$deadline" ]; then
-      echo "⚠️ $name still holding port $port after ${timeout}s"
+      echo "⚠️ $name still holding port $port after ${timeout}s:"
+      # Root-owned (keploy launches the server under sudo), so dump with
+      # privileges to surface the holding PID for triage.
+      run_with_keploy_privileges ss -Htanp "sport = :$port" 2>/dev/null || true
       return 1
     fi
     sleep 1

--- a/.github/workflows/test_workflow_scripts/fuzzer/grpc/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/fuzzer/grpc/golang-linux.sh
@@ -134,6 +134,31 @@ ensure_success_phrase() {
  exit 1
 }
 
+# wait_port_free NAME PORT [TIMEOUT_SEC]
+# Block until nothing is listening on localhost:PORT (or TIMEOUT_SEC elapses).
+# Deterministic replacement for a fixed `sleep` after killing a process that
+# owns a port: the next bind must not race a socket that is still being
+# released, which is what surfaces as "listen tcp :PORT: bind: address already
+# in use" and fails the run intermittently. Returns as soon as the port is
+# actually free, so it is normally sub-second. `nc -z` is already used elsewhere
+# in this script to poll for a port coming UP; here we poll for it going DOWN.
+wait_port_free() {
+  local name=$1 port=$2 timeout=${3:-30}
+  local deadline=$(( $(date +%s) + timeout ))
+  # Bare `nc -z` (no -w): on some netcat builds -w makes -z report an occupied
+  # port as free, which would defeat the whole check. Wall-clock deadline (not
+  # an iteration count) so a slow per-probe nc can't stretch the bound.
+  while nc -z localhost "$port" 2>/dev/null; do
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      echo "⚠️ $name still holding port $port after ${timeout}s"
+      return 1
+    fi
+    sleep 1
+  done
+  echo "✅ $name port $port is free"
+  return 0
+}
+
 
 if [ "$MODE" = "incoming" ]; then
  echo "🧪 Testing with incoming requests"
@@ -188,7 +213,15 @@ if [ "$MODE" = "incoming" ]; then
  echo "Ensuring fuzzer server is stopped..."
  sleep 10
  sudo pkill -f "$FUZZER_SERVER_BIN" || true
- sleep 2 # Give a moment for the port to be released
+ # The HTTP client started above (:18080) is otherwise never stopped in the
+ # incoming path, so it leaks into the json cycle where a fresh client cannot
+ # bind :18080 (and the stale one silently serves /run against a dead server).
+ # Stop it here, at the source of the leak.
+ sudo pkill -f "$FUZZER_CLIENT_BIN" || true
+ # Wait for the ports to be released instead of a fixed sleep that races the
+ # yaml replay's server re-bind on :50051.
+ wait_port_free "gRPC server" 50051 || true
+ wait_port_free "HTTP client" 18080 || true
 
  echo "Waiting for processes to settle"
 
@@ -240,14 +273,23 @@ if [ "$MODE" = "incoming" ]; then
 
  if json_pass_supported; then
    echo "🧪 Re-running incoming with --storage-format json"
-   # The yaml replay above started the fuzzer server with `keploy -c`.
-   # Keploy stops itself, but the server child it spawned can keep
-   # owning :50051, so the json record's app-launch fails with
-   # "listen tcp :50051: bind: address already in use" and keploy
-   # bails before capturing any test case. Force-kill anything still
-   # holding :50051 before the json record's app starts.
+   # Before the json cycle rebinds :50051 (server) and :18080 (client), make
+   # sure the yaml cycle's processes are gone AND their ports are released.
+   # Two leftovers otherwise race the json binds:
+   #   * :50051 — the yaml replay's `keploy test -c` server can still be
+   #     unwinding when `keploy test` returns; the json record's app then hits
+   #     "listen tcp :50051: bind: address already in use" and keploy bails
+   #     before capturing any test case.
+   #   * :18080 — the yaml cycle's HTTP client is never stopped, so a fresh
+   #     json client cannot bind it and the stale one silently serves /run
+   #     against a server that never came up (1000 nil mismatches).
+   # Kill both and WAIT for the sockets to close (bounded) rather than trusting
+   # a fixed sleep. (The yaml teardown already stops the client; this is the
+   # defensive backstop at the actual bind boundary.)
    sudo pkill -f "$FUZZER_SERVER_BIN" || true
-   sleep 2
+   sudo pkill -f "$FUZZER_CLIENT_BIN" || true
+   wait_port_free "gRPC server" 50051 || true
+   wait_port_free "HTTP client" 18080 || true
    if [[ "$RECORD_SRC" == "latest" ]]; then
      "$RECORD_BIN" record --storage-format json -c "$FUZZER_SERVER_BIN" $BIG_PAYLOAD_FLAG 2>&1 | tee record_incoming_json.txt &
    else

--- a/pkg/agent/proxy/fakeconn/fakeconn.go
+++ b/pkg/agent/proxy/fakeconn/fakeconn.go
@@ -117,6 +117,26 @@ func newWithLogger(ch <-chan Chunk, localAddr, remoteAddr net.Addr, log logger) 
 	}
 }
 
+// HasBuffered reports whether this FakeConn currently holds input the
+// parser has not yet consumed: a Chunk queued on the relay-owned
+// channel, or residual bytes stashed by a partial Read. It is used by
+// the supervisor's hang watchdog to distinguish a parser that is idle —
+// blocked on an empty read, e.g. a pooled DB connection sitting between
+// requests — from one genuinely stuck with input to process. Cheap: a
+// channel-length read plus a short mutex-guarded buffer check. The
+// result is a point-in-time hint (a chunk may arrive the instant after
+// it returns false); callers must tolerate that, which the watchdog
+// does by re-checking every tick.
+func (f *FakeConn) HasBuffered() bool {
+	if len(f.ch) > 0 {
+		return true
+	}
+	f.mu.Lock()
+	n := f.buf.Len()
+	f.mu.Unlock()
+	return n > 0
+}
+
 // Read implements io.Reader / net.Conn. It first drains any bytes
 // left over from a previous Chunk, then blocks for the next Chunk
 // (subject to read deadline and Close).

--- a/pkg/agent/proxy/fakeconn/fakeconn_test.go
+++ b/pkg/agent/proxy/fakeconn/fakeconn_test.go
@@ -52,6 +52,40 @@ func TestReadFromChunks(t *testing.T) {
 	}
 }
 
+func TestHasBuffered(t *testing.T) {
+	t.Parallel()
+	ch := make(chan Chunk, 2)
+	f := New(ch, nil, nil)
+
+	if f.HasBuffered() {
+		t.Fatalf("empty FakeConn: HasBuffered = true, want false")
+	}
+
+	// A queued chunk counts as unconsumed input.
+	ch <- Chunk{Dir: FromClient, Bytes: []byte("hello"), ReadAt: time.Unix(1, 0)}
+	if !f.HasBuffered() {
+		t.Fatalf("queued chunk: HasBuffered = false, want true")
+	}
+
+	// A partial Read leaves the remainder stashed → still buffered.
+	buf := make([]byte, 2)
+	if n, err := f.Read(buf); err != nil || n != 2 {
+		t.Fatalf("Read: n=%d err=%v", n, err)
+	}
+	if !f.HasBuffered() {
+		t.Fatalf("after partial read (3 bytes stashed): HasBuffered = false, want true")
+	}
+
+	// Drain the stash → nothing left → not buffered (parser is now idle).
+	rest := make([]byte, 3)
+	if n, err := f.Read(rest); err != nil || n != 3 {
+		t.Fatalf("Read rest: n=%d err=%v", n, err)
+	}
+	if f.HasBuffered() {
+		t.Fatalf("after consuming all bytes: HasBuffered = true, want false")
+	}
+}
+
 func TestLastWrittenTimeZeroBeforeAnyChunk(t *testing.T) {
 	t.Parallel()
 	ch := make(chan Chunk)

--- a/pkg/agent/proxy/integrations/http/http.go
+++ b/pkg/agent/proxy/integrations/http/http.go
@@ -116,6 +116,18 @@ func (h *HTTP) MatchType(_ context.Context, buf []byte) bool {
 // knob is the env KEPLOY_NEW_RELAY=off handled in proxy_v2.go.
 func (h *HTTP) IsV2() bool { return true }
 
+// SupportsAbortRecovery opts HTTP into the supervisor's per-generation parser
+// respawn (proxy_v2.go). After an abort silences the relay tees, recovery
+// reattaches fresh streams and re-runs RecordOutgoing so a later request on the
+// same pooled connection still records, instead of raw-forwarding for the rest
+// of the connection's life.
+//
+// Safe for HTTP because it is client-initiates-on-reuse — the next client byte
+// on a pooled keep-alive connection is always a fresh request boundary — and
+// the parser holds no per-connection state across RecordOutgoing calls (the
+// HTTP struct carries only a logger; all framing state is local to recordV2).
+func (h *HTTP) SupportsAbortRecovery() bool { return true }
+
 // RecordOutgoing dispatches to the V2 path when the supervisor has
 // attached a session via RecordSession.V2, and to the legacy path
 // otherwise. Keeping both paths live lets the dispatcher / rollback

--- a/pkg/agent/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match.go
@@ -965,6 +965,30 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 					}
 				}
 
+				// The COM_STMT_PREPARE response's parameter-definition block is
+				// ALWAYS terminated by an EOF packet unless CLIENT_DEPRECATE_EOF
+				// was negotiated. Clients that do NOT negotiate DEPRECATE_EOF
+				// (e.g. go-sql-driver) call readUntilEOF() after the param defs
+				// (see database/sql mysql connection.go: prepare) and block
+				// forever if that terminator is missing — the synthesized
+				// PREPARE_OK then hangs the connection until the client's
+				// context deadline fires, which surfaces as "driver: bad
+				// connection" and cascades across the whole pool. Emit a
+				// legacy EOF terminator here, mirroring the recorder
+				// (record_v2.go only captures EOFAfterParamDefs when
+				// !DeprecateEOF), so a synthesized response is wire-complete.
+				var eofAfterParamDefs []byte
+				if numParams > 0 && !decodeCtx.DeprecateEOF() {
+					// Legacy EOF: header(len=5, seq) + payload
+					// (0xFE | warnings=0 | status_flags=AUTOCOMMIT). Param
+					// defs occupy sequence ids 2..(1+numParams), so the
+					// terminator is at 2+numParams.
+					eofAfterParamDefs = []byte{
+						0x05, 0x00, 0x00, byte(2 + numParams),
+						0xFE, 0x00, 0x00, 0x02, 0x00,
+					}
+				}
+
 				prepareOk := &mysql.StmtPrepareOkPacket{
 					Status:             0,
 					StatementID:        newStmtID,
@@ -974,7 +998,7 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 					WarningAvailable:   true,
 					WarningCount:       0,
 					ParamDefs:          paramDefs,
-					EOFAfterParamDefs:  []byte{},
+					EOFAfterParamDefs:  eofAfterParamDefs,
 					ColumnDefs:         nil,
 					EOFAfterColumnDefs: []byte{},
 				}

--- a/pkg/agent/proxy/integrations/mysql/replayer/synthesize_prepare_eof_test.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/synthesize_prepare_eof_test.go
@@ -1,0 +1,97 @@
+package replayer
+
+import (
+	"context"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/wire"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.keploy.io/server/v3/pkg/models/mysql"
+	"go.uber.org/zap"
+)
+
+// prepareReq builds a COM_STMT_PREPARE request for the given query.
+func prepareReq(query string) mysql.Request {
+	return mysql.Request{PacketBundle: mysql.PacketBundle{
+		Header: &mysql.PacketInfo{
+			Header: &mysql.Header{SequenceID: 0},
+			Type:   mysql.CommandStatusToString(mysql.COM_STMT_PREPARE),
+		},
+		Message: &mysql.StmtPreparePacket{Command: mysql.COM_STMT_PREPARE, Query: query},
+	}}
+}
+
+// TestSynthesizedPrepareOK_ParamDefEOF is the regression guard for the MySQL
+// fuzzer hang: when a COM_STMT_PREPARE has no recorded mock, matchCommand
+// synthesizes a COM_STMT_PREPARE_OK. For a client that did NOT negotiate
+// CLIENT_DEPRECATE_EOF (e.g. go-sql-driver), the parameter-definition block
+// MUST be terminated by an EOF packet, or the driver's readUntilEOF() blocks
+// forever ("driver: bad connection", whole-pool cascade, 1000s deadlock).
+// DEPRECATE_EOF clients must NOT get the terminator, and a zero-param prepare
+// has no param-def block so needs none either.
+func TestSynthesizedPrepareOK_ParamDefEOF(t *testing.T) {
+	logger := zap.NewNop()
+	// A non-empty pool with NO recorded COM_STMT_PREPARE for our query: the
+	// pool must be non-empty (an entirely empty db bails with "no mysql mocks
+	// found" before the synthesize path), but nothing matches the prepare, so
+	// matchCommand falls through to synthesizing a PREPARE_OK.
+	emptyDb := &fakeMockDb{session: []*models.Mock{execMock("unrelated-filler", "x")}}
+
+	synth := func(t *testing.T, dctx *wire.DecodeContext, query string) *mysql.StmtPrepareOkPacket {
+		t.Helper()
+		resp, ok, _, err := matchCommand(context.Background(), logger, prepareReq(query), emptyDb, dctx, nil, nil)
+		if err != nil || !ok || resp == nil {
+			t.Fatalf("expected a synthesized PREPARE_OK (ok=%v err=%v resp=%v)", ok, err, resp)
+		}
+		pkt, isPrep := resp.PacketBundle.Message.(*mysql.StmtPrepareOkPacket)
+		if !isPrep {
+			t.Fatalf("expected *StmtPrepareOkPacket, got %T", resp.PacketBundle.Message)
+		}
+		return pkt
+	}
+
+	t.Run("non-DEPRECATE_EOF client gets a well-formed param-def EOF", func(t *testing.T) {
+		dctx := newDecodeCtx()                                            // ServerCaps=0, ClientCaps=0 → DeprecateEOF()==false
+		pkt := synth(t, dctx, "SELECT id FROM t WHERE a BETWEEN ? AND ?") // 2 params
+
+		if pkt.NumParams != 2 {
+			t.Fatalf("NumParams = %d, want 2", pkt.NumParams)
+		}
+		eof := pkt.EOFAfterParamDefs
+		// Legacy EOF: 4-byte header + 5-byte payload = 9 bytes.
+		if len(eof) != 9 {
+			t.Fatalf("EOFAfterParamDefs len = %d (%v), want 9-byte legacy EOF packet", len(eof), eof)
+		}
+		if eof[4] != 0xFE {
+			t.Fatalf("EOF marker = 0x%02x, want 0xFE", eof[4])
+		}
+		// payload length field (3-byte LE) must be 5.
+		if eof[0] != 0x05 || eof[1] != 0x00 || eof[2] != 0x00 {
+			t.Fatalf("EOF length header = %v, want [5 0 0]", eof[:3])
+		}
+		// sequence id must follow the param defs (seq 2..1+numParams), i.e. 2+numParams.
+		if want := byte(2 + pkt.NumParams); eof[3] != want {
+			t.Fatalf("EOF sequence id = %d, want %d (2+numParams)", eof[3], want)
+		}
+	})
+
+	t.Run("DEPRECATE_EOF client gets no terminator", func(t *testing.T) {
+		dctx := newDecodeCtx()
+		dctx.ServerCaps = wire.CLIENT_DEPRECATE_EOF
+		dctx.ClientCaps = wire.CLIENT_DEPRECATE_EOF
+		pkt := synth(t, dctx, "SELECT id FROM t WHERE a = ?") // 1 param
+		if len(pkt.EOFAfterParamDefs) != 0 {
+			t.Fatalf("DEPRECATE_EOF client must get no param-def EOF, got %v", pkt.EOFAfterParamDefs)
+		}
+	})
+
+	t.Run("zero-param prepare needs no param-def EOF", func(t *testing.T) {
+		pkt := synth(t, newDecodeCtx(), "SELECT 1")
+		if pkt.NumParams != 0 {
+			t.Fatalf("NumParams = %d, want 0", pkt.NumParams)
+		}
+		if len(pkt.EOFAfterParamDefs) != 0 {
+			t.Fatalf("zero-param prepare must have no param-def EOF, got %v", pkt.EOFAfterParamDefs)
+		}
+	})
+}

--- a/pkg/agent/proxy/proxy_v2.go
+++ b/pkg/agent/proxy/proxy_v2.go
@@ -193,6 +193,16 @@ func (p *Proxy) recordViaSupervisor(
 	svSess.Directives = r.Directives()
 	svSess.Acks = r.Acks()
 
+	// Teach the hang watchdog to tell an idle parser from a stuck one:
+	// only declare a hang when the relay still holds unconsumed input.
+	// A pooled DB connection sitting between requests (parser blocked on
+	// an empty read) must not be aborted — aborting PauseTees's it and
+	// permanently stops recording on a live connection that gets reused,
+	// which is the go-memory-load-mongo recording dead zone. Set before
+	// Run; the watchdog only consults it once `pending` is armed, which
+	// happens after Run tees the first client chunk.
+	sv.SetActivityProbe(r.HasBufferedInput)
+
 	// Run the relay in its own goroutine under the supervisor's lifetime.
 	// The supervisor's Close (via sv.SessionOnAbort below) closes the
 	// FakeConns so the parser's reads unblock on abort.

--- a/pkg/agent/proxy/proxy_v2.go
+++ b/pkg/agent/proxy/proxy_v2.go
@@ -163,8 +163,23 @@ func (p *Proxy) recordViaSupervisor(
 		TLSUpgradeFn:         newProxyTLSUpgradeFn(logger),
 		BumpActivity:         sv.BumpActivity,
 		OnMarkMockIncomplete: svSess.MarkMockIncomplete,
-		OnClientChunkTeed:    sv.MarkPendingWork,
-		RealCertHook:         realCertHook,
+		// Time-attributed complement to OnMarkMockIncomplete: the dropped
+		// chunk's own wire instant is recorded as a zero-width orphan
+		// window so record.go suppresses TCs whose HTTP window contains
+		// it. Unlike the session flag (which voids a later, unrelated
+		// mock — why relay-layer drops under load orphaned TCs the
+		// pressure/next-mock windows never covered), this lands inside the
+		// dropped op's OWN TC window. Attribution is by time only — a
+		// concurrent healthy TC straddling this instant, or a per-test TC
+		// overlapping a dropped reusable/heartbeat chunk, may also be
+		// suppressed; that over-suppression is the accepted "drop the TC
+		// rather than orphan it" tradeoff (see tee.drop). Fast-follow:
+		// thread per-op identity to suppress by exact TC.
+		OnTeeDropWindow: func(_ string, ts time.Time) {
+			svSess.RecordOrphanWindow(ts, ts)
+		},
+		OnClientChunkTeed: sv.MarkPendingWork,
+		RealCertHook:      realCertHook,
 		// User-tunable record-buffer caps. Snapshotted onto the Proxy
 		// at startup from config.Record.RecordBuffer (yaml/flag/env).
 		// Zero values fall through to relay package defaults via

--- a/pkg/agent/proxy/proxy_v2.go
+++ b/pkg/agent/proxy/proxy_v2.go
@@ -243,6 +243,11 @@ func (p *Proxy) recordViaSupervisor(
 
 	for gen := 0; ; gen++ {
 		if gen > 0 {
+			// MEAS(abort-recovery): TEMP INFO — remove before merge.
+			logger.Info("MEAS abort-recovery respawn",
+				zap.String("parser", string(parserType)),
+				zap.Int64("clientConnID", clientConnID),
+				zap.Int("gen", gen))
 			// Respawn: the previous generation aborted (tees paused, its
 			// FakeConns Closed by SessionOnAbort). Swap in fresh FakeConns over
 			// the same still-open tee channels so the new Session wires them.
@@ -345,6 +350,13 @@ func (p *Proxy) recordViaSupervisor(
 		// watchdog) is stopped by the time Run returns — no explicit Close here.
 
 		if !result.FallthroughToPassthrough {
+			// MEAS(abort-recovery): TEMP INFO — remove before merge.
+			logger.Info("MEAS recordViaSupervisor clean-return",
+				zap.String("parser", string(parserType)),
+				zap.Int64("clientConnID", clientConnID),
+				zap.Int("gen", gen),
+				zap.String("status", result.Status.String()),
+				zap.Error(result.Err))
 			// Parser returned normally or with an error. Cancel the relay and
 			// drain, then report the outcome.
 			relayCancel()
@@ -377,6 +389,15 @@ func (p *Proxy) recordViaSupervisor(
 			zap.Bool("recoverable", recoverable),
 			zap.String("next_step", "set KEPLOY_NEW_RELAY=off to force legacy path for this parser, or KEPLOY_DISABLE_PARSING=1 to disable record parsing entirely"),
 		)
+		// MEAS(abort-recovery): TEMP INFO — remove before merge.
+		logger.Info("MEAS abort detected (fallthrough)",
+			zap.String("parser", string(parserType)),
+			zap.Int64("clientConnID", clientConnID),
+			zap.Int("gen", gen),
+			zap.String("status", result.Status.String()),
+			zap.Bool("recoverable", recoverable),
+			zap.Bool("sawClientChunk", genSawClientChunk.Load()),
+			zap.Error(result.Err))
 
 		// Abort-recovery: for an opted-in parser on a still-alive pooled
 		// connection, respawn a fresh parser generation so recording resumes
@@ -400,6 +421,18 @@ func (p *Proxy) recordViaSupervisor(
 		// than reliably recording a corrupt mock — graceful degradation, not
 		// silent corruption.
 		if !recoverable || gen+1 >= maxAbortRecoveryGenerations || !genSawClientChunk.Load() {
+			// MEAS(abort-recovery): TEMP INFO — remove before merge.
+			reason := "budget"
+			if !recoverable {
+				reason = "not-recoverable"
+			} else if !genSawClientChunk.Load() {
+				reason = "no-client-chunk"
+			}
+			logger.Info("MEAS abort-recovery give-up",
+				zap.String("parser", string(parserType)),
+				zap.Int64("clientConnID", clientConnID),
+				zap.Int("gen", gen),
+				zap.String("reason", reason))
 			<-relayDone
 			return nil
 		}
@@ -420,6 +453,12 @@ func (p *Proxy) recordViaSupervisor(
 				zap.String("parser", string(parserType)),
 				zap.Int("generation", gen),
 			)
+			// MEAS(abort-recovery): TEMP INFO — remove before merge.
+			logger.Info("MEAS abort-recovery give-up",
+				zap.String("parser", string(parserType)),
+				zap.Int64("clientConnID", clientConnID),
+				zap.Int("gen", gen),
+				zap.String("reason", "parser-exit-grace"))
 			<-relayDone
 			return nil
 		}
@@ -428,6 +467,11 @@ func (p *Proxy) recordViaSupervisor(
 		// exited there is nothing left to reattach to next iteration.
 		select {
 		case <-relayDone:
+			// MEAS(abort-recovery): TEMP INFO — remove before merge.
+			logger.Info("MEAS abort-recovery relay-exited-before-respawn",
+				zap.String("parser", string(parserType)),
+				zap.Int64("clientConnID", clientConnID),
+				zap.Int("gen", gen))
 			return nil
 		default:
 		}

--- a/pkg/agent/proxy/proxy_v2.go
+++ b/pkg/agent/proxy/proxy_v2.go
@@ -216,6 +216,21 @@ func (p *Proxy) recordViaSupervisor(
 		recoverable = rp.SupportsAbortRecovery()
 	}
 
+	// Memory-pressure self-management opt-in (duck-typed like the others). A
+	// parser that stays byte-synced across a memoryguard pause and sheds
+	// memory itself (mongo/v2 skip-discards whole messages under pressure)
+	// tells the relay to STOP dropping its chunks under memory pressure. A
+	// mid-message pressure drop desyncs the length-prefix reassembler, which
+	// then cannot re-anchor on the app's large multi-chunk messages under the
+	// pressure sawtooth and silently stops recording the pooled connection for
+	// the rest of the run — the go-memory-load-mongo tail dead zone. Only the
+	// memory_pressure tee-drop is suppressed; capacity drops and the
+	// abort/finalize pause are unchanged, so genuine mid-message byte loss
+	// still triggers the parser's resync.
+	if pm, ok := parser.(interface{ SelfManagesMemoryPressure() bool }); ok && pm.SelfManagesMemoryPressure() {
+		r.SetPressureSelfManaged(true)
+	}
+
 	// Run the relay in its own goroutine under the connection's lifetime.
 	// The relay is created ONCE and outlives every parser generation; each
 	// generation's SessionOnAbort closes the current FakeConns so the parser's

--- a/pkg/agent/proxy/proxy_v2.go
+++ b/pkg/agent/proxy/proxy_v2.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"go.keploy.io/server/v3/pkg/agent/proxy/directive"
@@ -56,6 +57,30 @@ func newRelayDisabled() bool {
 //     the kind of stall the V2 architecture is meant to eliminate.
 //     See invariant I1 in pkg/agent/proxy/README.md.)
 //
+// dropVoidsMock reports whether an OnMarkMockIncomplete callback of the given
+// reason should void the in-flight mock. This is a DENY-list, not an allow-list:
+// every reason voids the mock EXCEPT the two deliberate bulk-silence drops. The
+// callback fires for far more than tee drops — write_error / short_write
+// (relay.go), abort_mock (directive AbortMock), and pre_dispatch_drain_* all
+// mean bytes never reached the peer and the mock must NOT be recorded as
+// complete, for EVERY parser (the callback is wired before the recoverable
+// opt-in check). Only these two are excluded:
+//
+//   - paused: PauseTees (abort — session dead) or KindPauseDir (mock already
+//     finalized) — there is no live mock to void. Critically, during
+//     abort-recovery the tees stay paused while the FRESH generation's session
+//     is already published as curSess, so voiding here would silently drop the
+//     recovered generation's first mock.
+//   - memory_pressure: already covered by pressureRanges in record.go; voiding
+//     here only mis-attributes the loss to a later, unrelated mock.
+//
+// (This is the OPPOSITE filter to the tee's onDropAt orphan-window allow-list,
+// which restricts to channel_full/per_conn_cap to avoid flooding orphanRanges —
+// the two policies are not interchangeable.)
+func dropVoidsMock(reason string) bool {
+	return reason != relay.DropPaused && reason != relay.DropMemoryPressure
+}
+
 // The caller remains responsible for closing srcConn/dstConn in its
 // deferred cleanup; this helper never closes them.
 func (p *Proxy) recordViaSupervisor(
@@ -69,48 +94,21 @@ func (p *Proxy) recordViaSupervisor(
 	clientConnID, destConnID int64,
 	opts models.OutgoingOptions,
 ) error {
-	sv := supervisor.New(supervisor.Config{
-		Logger: logger,
-		// Leave HangBudget / MemCap / PanicReporter defaulted by the
-		// supervisor package. Tune via config once we have production
-		// telemetry on the fallback rate.
-	})
-	defer sv.Close()
-
-	// Parser-facing session is constructed before the relay so its
-	// MarkMockIncomplete / ClearPendingWork hooks can be wired into
-	// the relay's tee callbacks below. ClientStream/DestStream and
-	// the directive channels are patched in after r := relay.New().
-	// Ctx is overwritten by Supervisor.Run with the supervised
-	// lifetime context.
-	svSess := &supervisor.Session{
-		Mocks:            mocks,
-		Logger:           logger,
-		ClientConnID:     fmt.Sprint(clientConnID),
-		DestConnID:       fmt.Sprint(destConnID),
-		Opts:             opts,
-		OnPendingCleared: sv.ClearPendingWork,
-		// Route EmitMock through the SyncMockManager (obtained via
-		// syncMock.Get(), then mgr.AddMock) so V2 parsers pick up the
-		// same firstReqSeen session-window buffering, lifetime
-		// derivation, and drop accounting that legacy parsers (http,
-		// mysql, generic) get. Without this, V2-recorded mocks
-		// captured before the first app test request bypass the
-		// session window and are lost at replay — the symptom that
-		// broke postgres e2e record-build-replay-build runs in
-		// integrations#133 (the app's startup DB queries never found
-		// their mocks).
-		RouteMocksViaSyncMock: true,
-		// Per-app manager carried on the parser ctx by a multi-app caller
-		// (nil otherwise ⇒ EmitMock uses the package-global). Routes V2
-		// parser mocks to the right app's manager, like the legacy parsers.
-		Mgr: syncMock.FromContext(ctx),
-		// Legacy fields kept populated so a migrated parser can still
-		// consult them for fields we haven't promoted yet. The parser
-		// must not touch Ingress/Egress net.Conn values on the V2 path.
-		TLSUpgrader: nil,
-		ErrGroup:    errGrp,
-	}
+	// The relay is created ONCE per connection, but on the abort-recovery
+	// path several parser generations run over its lifetime (see the
+	// generation loop below). Its tee callbacks are wired at relay.New()
+	// time, so they must route to the CURRENT generation's Supervisor and
+	// Session rather than capture a stale gen-0 one. curSv/curSess hold the
+	// live generation; the relay callbacks load them per-call. For a parser
+	// that does not opt into abort recovery there is exactly one generation,
+	// so this indirection is behaviourally identical to a direct wire.
+	var curSv atomic.Pointer[supervisor.Supervisor]
+	var curSess atomic.Pointer[supervisor.Session]
+	// genSawClientChunk records whether the CURRENT generation ever had a
+	// client chunk teed to it. Reset per generation and used as the progress
+	// guard that stops an abort-recovery respawn from spinning on a parser
+	// that dies before reading anything.
+	var genSawClientChunk atomic.Bool
 
 	// Build the relay. It owns srcConn/dstConn for the duration of its
 	// Run call but never closes them. The caller's deferred Close still
@@ -159,10 +157,21 @@ func (p *Proxy) recordViaSupervisor(
 	}
 
 	r := relay.New(relay.Config{
-		Logger:               logger,
-		TLSUpgradeFn:         newProxyTLSUpgradeFn(logger),
-		BumpActivity:         sv.BumpActivity,
-		OnMarkMockIncomplete: svSess.MarkMockIncomplete,
+		Logger:       logger,
+		TLSUpgradeFn: newProxyTLSUpgradeFn(logger),
+		BumpActivity: func() {
+			if s := curSv.Load(); s != nil {
+				s.BumpActivity()
+			}
+		},
+		OnMarkMockIncomplete: func(reason string) {
+			if !dropVoidsMock(reason) {
+				return
+			}
+			if s := curSess.Load(); s != nil {
+				s.MarkMockIncomplete(reason)
+			}
+		},
 		// Time-attributed complement to OnMarkMockIncomplete: for a genuine
 		// per-op byte-loss drop (channel_full/per_conn_cap only — the tee
 		// excludes memory_pressure/paused, which would flood the ring and
@@ -175,10 +184,17 @@ func (p *Proxy) recordViaSupervisor(
 		// over-suppression is the accepted "drop the TC rather than orphan
 		// it" tradeoff. Fast-follow: thread per-op identity for exact-TC.
 		OnTeeDropWindow: func(_ string, ts time.Time) {
-			svSess.RecordOrphanWindow(ts, ts)
+			if s := curSess.Load(); s != nil {
+				s.RecordOrphanWindow(ts, ts)
+			}
 		},
-		OnClientChunkTeed: sv.MarkPendingWork,
-		RealCertHook:      realCertHook,
+		OnClientChunkTeed: func() {
+			genSawClientChunk.Store(true)
+			if s := curSv.Load(); s != nil {
+				s.MarkPendingWork()
+			}
+		},
+		RealCertHook: realCertHook,
 		// User-tunable record-buffer caps. Snapshotted onto the Proxy
 		// at startup from config.Record.RecordBuffer (yaml/flag/env).
 		// Zero values fall through to relay package defaults via
@@ -188,120 +204,234 @@ func (p *Proxy) recordViaSupervisor(
 		PreDispatchPause: preDispatchPause,
 	}, srcConn, dstConn)
 
-	svSess.ClientStream = r.ClientStream()
-	svSess.DestStream = r.DestStream()
-	svSess.Directives = r.Directives()
-	svSess.Acks = r.Acks()
+	// Abort-recovery opt-in (duck-typed like WantsPreDispatchPause): only
+	// parsers that declare SupportsAbortRecovery participate in the
+	// generation loop below; all others keep the historical behaviour — one
+	// generation, then permanent raw passthrough after an abort. Safe only
+	// for client-initiates-on-reuse protocols (http, mongo) where the next
+	// client byte on a pooled connection is always a fresh request boundary;
+	// a server-first-on-reuse protocol must stay opted out.
+	recoverable := false
+	if rp, ok := parser.(interface{ SupportsAbortRecovery() bool }); ok {
+		recoverable = rp.SupportsAbortRecovery()
+	}
 
-	// Teach the hang watchdog to tell an idle parser from a stuck one:
-	// only declare a hang when the relay still holds unconsumed input.
-	// A pooled DB connection sitting between requests (parser blocked on
-	// an empty read) must not be aborted — aborting PauseTees's it and
-	// permanently stops recording on a live connection that gets reused,
-	// which is the go-memory-load-mongo recording dead zone. Set before
-	// Run; the watchdog only consults it once `pending` is armed, which
-	// happens after Run tees the first client chunk.
-	sv.SetActivityProbe(r.HasBufferedInput)
-
-	// Run the relay in its own goroutine under the supervisor's lifetime.
-	// The supervisor's Close (via sv.SessionOnAbort below) closes the
-	// FakeConns so the parser's reads unblock on abort.
+	// Run the relay in its own goroutine under the connection's lifetime.
+	// The relay is created ONCE and outlives every parser generation; each
+	// generation's SessionOnAbort closes the current FakeConns so the parser's
+	// reads unblock on abort.
 	relayDone := make(chan error, 1)
 	relayCtx, relayCancel := context.WithCancel(ctx)
 	defer relayCancel()
-	go func() { relayDone <- r.Run(relayCtx) }()
+	// The relay goroutine is launched inside the loop, once generation 0 is
+	// fully wired (see below) — starting it earlier leaves a startup window
+	// where the first teed chunk's callbacks find curSv/curSess still nil.
 
-	sv.SessionOnAbort = func() {
-		// Pause the tees FIRST so every subsequent chunk drops
-		// cheaply via the pause fast-path (atomic-bool check) instead
-		// of falling through to the channel-full DropChannelFull
-		// branch, which also logs at Debug. On a long-lived
-		// post-abort connection the spam would otherwise be one
-		// log line per chunk for the rest of the connection.
-		//
-		// Pausing does NOT stop the real-socket forwarders — every
-		// byte still reaches its peer. The relay's raw forwarding
-		// continues until peer close; only parser-side delivery is
-		// suppressed.
-		r.PauseTees()
+	// maxAbortRecoveryGenerations bounds respawns so a genuinely broken
+	// parser (one that aborts on every request) cannot spin forever; after
+	// the ceiling the connection falls back to permanent raw passthrough.
+	const maxAbortRecoveryGenerations = 8
 
-		// Then unblock the parser's ClientStream/DestStream reads so
-		// the supervisor's cancel-select can observe the parser
-		// goroutine exiting promptly.
-		_ = r.ClientStream().Close()
-		_ = r.DestStream().Close()
-	}
+	// parserExitGrace bounds how long recovery waits for the aborted
+	// generation's parser goroutine to retire before reattaching its streams.
+	// After SessionOnAbort closes the FakeConns an I/O-bound parser unblocks in
+	// microseconds; the generous ceiling only trips for a parser genuinely
+	// wedged in a CPU loop that ignores ctx and Closed reads, in which case we
+	// abandon recovery rather than race the still-live goroutine on the shared
+	// tee channel.
+	const parserExitGrace = 2 * time.Second
 
-	// Adapter: the parser's RecordOutgoing takes *integrations.RecordSession
-	// but the supervisor's ParserFunc takes *supervisor.Session. Build a
-	// RecordSession whose V2 field points at the supervisor.Session.
-	//
-	// On the V2 path, Ingress/Egress/TLSUpgrader are intentionally nil so
-	// that a parser bug that reaches for the legacy fields surfaces as an
-	// obvious nil panic (which the supervisor catches) rather than a
-	// silent misuse of sockets the relay owns. ErrGroup remains populated
-	// because the legacy integration helper layer (ReadBytes, etc.) still
-	// retrieves it via context.Value in shared code; once every parser
-	// migrates off that accessor the field will be set to nil here as
-	// well.
-	result := sv.Run(ctx, func(parserCtx context.Context, sv2sess *supervisor.Session) error {
-		recSess := &integrations.RecordSession{
-			Ingress:      nil,
-			Egress:       nil,
-			Mocks:        mocks,
-			ErrGroup:     errGrp,
-			TLSUpgrader:  nil,
-			Logger:       logger,
-			ClientConnID: fmt.Sprint(clientConnID),
-			DestConnID:   fmt.Sprint(destConnID),
-			Opts:         opts,
-			V2:           sv2sess,
+	for gen := 0; ; gen++ {
+		if gen > 0 {
+			// Respawn: the previous generation aborted (tees paused, its
+			// FakeConns Closed by SessionOnAbort). Swap in fresh FakeConns over
+			// the same still-open tee channels so the new Session wires them.
+			// The tees stay paused until ResumeTees below — after everything is
+			// wired — so no chunk is delivered to a half-built generation.
+			r.ReattachStreams()
 		}
-		return parser.RecordOutgoing(parserCtx, recSess)
-	}, svSess)
 
-	if result.FallthroughToPassthrough {
+		sv := supervisor.New(supervisor.Config{
+			Logger: logger,
+			// Leave HangBudget / MemCap / PanicReporter defaulted by the
+			// supervisor package. Tune via config once we have production
+			// telemetry on the fallback rate.
+		})
+
+		// Fresh Session per generation. A reused Session would carry a stuck
+		// MarkMockIncomplete flag: during the paused window between abort and
+		// respawn every dropped chunk (DropPaused) still fires onDrop →
+		// MarkMockIncomplete, so a reused Session's next EmitMock would
+		// silently drop the new generation's mocks. The app-scoped
+		// SyncMockManager (Mgr) IS preserved across generations, so
+		// record-session-window continuity (firstReqSeen, lifetime derivation)
+		// is unaffected. RouteMocksViaSyncMock keeps V2 mocks on the same
+		// session-window path as legacy parsers (integrations#133).
+		svSess := &supervisor.Session{
+			Mocks:                 mocks,
+			Logger:                logger,
+			ClientConnID:          fmt.Sprint(clientConnID),
+			DestConnID:            fmt.Sprint(destConnID),
+			Opts:                  opts,
+			OnPendingCleared:      sv.ClearPendingWork,
+			RouteMocksViaSyncMock: true,
+			Mgr:                   syncMock.FromContext(ctx),
+			TLSUpgrader:           nil,
+			ErrGroup:              errGrp,
+		}
+		svSess.ClientStream = r.ClientStream()
+		svSess.DestStream = r.DestStream()
+		svSess.Directives = r.Directives()
+		svSess.Acks = r.Acks()
+
+		// Publish this generation to the relay's indirected tee callbacks
+		// before any chunk is delivered, and reset the per-generation progress
+		// guard.
+		curSv.Store(sv)
+		curSess.Store(svSess)
+		genSawClientChunk.Store(false)
+
+		// Teach the hang watchdog to tell an idle parser from a stuck one:
+		// only declare a hang when the relay still holds unconsumed input.
+		sv.SetActivityProbe(r.HasBufferedInput)
+
+		sv.SessionOnAbort = func() {
+			// Pause the tees FIRST so subsequent chunks drop cheaply via the
+			// pause fast-path instead of the channel-full branch (which logs at
+			// Debug per chunk). Pausing does NOT stop the real-socket
+			// forwarders — every byte still reaches its peer.
+			r.PauseTees()
+			// Then unblock the parser's reads so the supervisor's
+			// cancel-select observes the parser goroutine exiting promptly.
+			_ = r.ClientStream().Close()
+			_ = r.DestStream().Close()
+		}
+
+		if gen > 0 {
+			// This generation is fully wired (streams, curSv/curSess, probe,
+			// abort hook); admit chunks again.
+			r.ResumeTees()
+		} else {
+			// Generation 0 is now fully wired. Launch the relay so the first
+			// teed chunk's callbacks (BumpActivity / MarkPendingWork /
+			// MarkMockIncomplete) route to this live supervisor/session instead
+			// of no-oping on the nil guard. The relay is created ONCE and
+			// outlives every generation.
+			go func() { relayDone <- r.Run(relayCtx) }()
+		}
+
+		// Adapter: the parser's RecordOutgoing takes *integrations.RecordSession
+		// but the supervisor's ParserFunc takes *supervisor.Session. On the V2
+		// path Ingress/Egress/TLSUpgrader are nil so a parser bug that reaches
+		// for the legacy fields surfaces as an obvious nil panic (which the
+		// supervisor catches) rather than a silent misuse of sockets the relay
+		// owns.
+		result := sv.Run(ctx, func(parserCtx context.Context, sv2sess *supervisor.Session) error {
+			recSess := &integrations.RecordSession{
+				Ingress:      nil,
+				Egress:       nil,
+				Mocks:        mocks,
+				ErrGroup:     errGrp,
+				TLSUpgrader:  nil,
+				Logger:       logger,
+				ClientConnID: fmt.Sprint(clientConnID),
+				DestConnID:   fmt.Sprint(destConnID),
+				Opts:         opts,
+				V2:           sv2sess,
+			}
+			return parser.RecordOutgoing(parserCtx, recSess)
+		}, svSess)
+		// sv.Run already ran `defer s.Close()`, so the supervisor (and its
+		// watchdog) is stopped by the time Run returns — no explicit Close here.
+
+		if !result.FallthroughToPassthrough {
+			// Parser returned normally or with an error. Cancel the relay and
+			// drain, then report the outcome.
+			relayCancel()
+			relayErr := <-relayDone
+			if relayErr != nil && !errors.Is(relayErr, context.Canceled) {
+				logger.Debug("relay exited with error", zap.Error(relayErr))
+			}
+			if result.Err != nil {
+				if isNetworkClosedErr(result.Err) {
+					logger.Debug("V2 parser exited with network-closed error", zap.Error(result.Err))
+					return nil
+				}
+				return result.Err
+			}
+			logger.Debug("V2 parser recorded outgoing message successfully",
+				zap.String("parser", string(parserType)),
+				zap.String("status", result.Status.String()),
+			)
+			return nil
+		}
+
+		// ABORT (fallthrough). The relay is still alive and forwarding raw; the
+		// tees are paused and this generation's FakeConns were Closed by
+		// SessionOnAbort.
 		logger.Debug("parser supervisor triggered passthrough fallback; relay continues raw forwarding until peer close",
 			zap.String("parser", string(parserType)),
 			zap.String("status", result.Status.String()),
 			zap.Error(result.Err),
+			zap.Int("generation", gen),
+			zap.Bool("recoverable", recoverable),
 			zap.String("next_step", "set KEPLOY_NEW_RELAY=off to force legacy path for this parser, or KEPLOY_DISABLE_PARSING=1 to disable record parsing entirely"),
 		)
-		// Crucial invariant (I1): the relay keeps forwarding client↔dest
-		// bytes end-to-end during the fallback. We do NOT cancel it here
-		// — cancelling would introduce a gap between the relay stopping
-		// and any replacement read loop starting, exactly the kind of
-		// stall the V2 architecture is meant to eliminate.
+
+		// Abort-recovery: for an opted-in parser on a still-alive pooled
+		// connection, respawn a fresh parser generation so recording resumes
+		// on the next request instead of the connection being permanently
+		// silenced (the go-memory-load-mongo recording dead zone). Give up —
+		// keeping the historical I1 raw passthrough — when the parser is not
+		// opted in, the generation budget is exhausted, or this generation
+		// never saw a client chunk (a parser that dies before reading anything
+		// would otherwise respawn-spin). In every give-up case we do NOT cancel
+		// the relay: it keeps forwarding client↔dest bytes raw until a peer
+		// close triggers a normal Run exit — no stall gap (invariant I1).
 		//
-		// SessionOnAbort has already closed the FakeConns so no further
-		// tee chunks reach the parser side (no partial mocks, I4). The
-		// relay's forwarder goroutines continue draining srcConn/dstConn
-		// until either peer closes the connection, which triggers a
-		// normal Run exit.
-		<-relayDone
-		return nil
-	}
-
-	// Non-fallthrough path: parser returned normally or with an error.
-	// Cancel the relay and drain.
-	relayCancel()
-	relayErr := <-relayDone
-	if relayErr != nil && !errors.Is(relayErr, context.Canceled) {
-		logger.Debug("relay exited with error", zap.Error(relayErr))
-	}
-
-	if result.Err != nil {
-		if isNetworkClosedErr(result.Err) {
-			logger.Debug("V2 parser exited with network-closed error", zap.Error(result.Err))
+		// Scope note: this cleanly recovers the target dead-zone (an abort
+		// between requests — the previous response was dropped at the tee under
+		// memory pressure (armed, not yet paused; the pause comes later with the
+		// abort), never staged, so the reattached generation reads a clean
+		// request boundary). If instead the abort fires MID-request, partial
+		// bytes of the aborted op may remain staged and the reattached
+		// generation reads them mid-frame; a framed protocol desyncs and
+		// re-aborts (bounded by the generation ceiling, then passthrough) rather
+		// than reliably recording a corrupt mock — graceful degradation, not
+		// silent corruption.
+		if !recoverable || gen+1 >= maxAbortRecoveryGenerations || !genSawClientChunk.Load() {
+			<-relayDone
 			return nil
 		}
-		return result.Err
+
+		// Wait for THIS generation's parser goroutine to fully retire before the
+		// next iteration reattaches its streams. On the hang and outer-cancel
+		// grace abort paths sv.Run returns while the parser goroutine is still
+		// alive — it unblocks asynchronously once SessionOnAbort Closed its
+		// FakeConns. The old (now-Closed) FakeConn and the reattached one drain
+		// the SAME tee out-channel, so respawning while the old goroutine can
+		// still read would let it steal a resumed chunk from the new generation
+		// (silent mock loss). If it does not exit within the grace it is
+		// genuinely wedged; give up recovery rather than race it.
+		select {
+		case <-sv.ParserDone():
+		case <-time.After(parserExitGrace):
+			logger.Debug("previous parser generation did not exit within recovery grace; abandoning abort recovery",
+				zap.String("parser", string(parserType)),
+				zap.Int("generation", gen),
+			)
+			<-relayDone
+			return nil
+		}
+
+		// The connection may already be over (peer closed). If the relay has
+		// exited there is nothing left to reattach to next iteration.
+		select {
+		case <-relayDone:
+			return nil
+		default:
+		}
 	}
-	logger.Debug("V2 parser recorded outgoing message successfully",
-		zap.String("parser", string(parserType)),
-		zap.String("status", result.Status.String()),
-	)
-	return nil
 }
 
 // newProxyTLSUpgradeFn adapts keploy's existing TLS helpers into the

--- a/pkg/agent/proxy/proxy_v2.go
+++ b/pkg/agent/proxy/proxy_v2.go
@@ -163,18 +163,17 @@ func (p *Proxy) recordViaSupervisor(
 		TLSUpgradeFn:         newProxyTLSUpgradeFn(logger),
 		BumpActivity:         sv.BumpActivity,
 		OnMarkMockIncomplete: svSess.MarkMockIncomplete,
-		// Time-attributed complement to OnMarkMockIncomplete: the dropped
-		// chunk's own wire instant is recorded as a zero-width orphan
-		// window so record.go suppresses TCs whose HTTP window contains
-		// it. Unlike the session flag (which voids a later, unrelated
-		// mock — why relay-layer drops under load orphaned TCs the
-		// pressure/next-mock windows never covered), this lands inside the
-		// dropped op's OWN TC window. Attribution is by time only — a
-		// concurrent healthy TC straddling this instant, or a per-test TC
-		// overlapping a dropped reusable/heartbeat chunk, may also be
-		// suppressed; that over-suppression is the accepted "drop the TC
-		// rather than orphan it" tradeoff (see tee.drop). Fast-follow:
-		// thread per-op identity to suppress by exact TC.
+		// Time-attributed complement to OnMarkMockIncomplete: for a genuine
+		// per-op byte-loss drop (channel_full/per_conn_cap only — the tee
+		// excludes memory_pressure/paused, which would flood the ring and
+		// mass-suppress healthy TCs), the dropped chunk's own wire instant
+		// is recorded as a zero-width orphan window so record.go suppresses
+		// TCs whose HTTP window contains it. Unlike the session flag (which
+		// voids a later, unrelated mock), this lands inside the dropped op's
+		// OWN TC window. Attribution is by time only — a concurrent healthy
+		// TC straddling this instant may also be suppressed; that bounded
+		// over-suppression is the accepted "drop the TC rather than orphan
+		// it" tradeoff. Fast-follow: thread per-op identity for exact-TC.
 		OnTeeDropWindow: func(_ string, ts time.Time) {
 			svSess.RecordOrphanWindow(ts, ts)
 		},

--- a/pkg/agent/proxy/relay/config.go
+++ b/pkg/agent/proxy/relay/config.go
@@ -125,16 +125,18 @@ type Config struct {
 	// the supervisor will record in telemetry. Nil is safe.
 	OnMarkMockIncomplete func(reason string)
 
-	// OnTeeDropWindow is invoked on tee-chunk drops with the drop reason
-	// AND the dropped chunk's wire timestamp (coalesced per operation,
-	// not one call per chunk). Callers wire this to the supervisor's
-	// RecordOrphanWindow so TCs whose HTTP window contains that instant
-	// are suppressed — the dropped chunk's mock cannot be recorded, so
-	// replaying its TC would orphan it (match_phase=no_mocks). The
-	// decode-lag-immune, time-attributed complement to
-	// OnMarkMockIncomplete (which only voids a later, possibly-unrelated
-	// mock via the session flag). Attribution is by time, so a concurrent
-	// or reusable-mock overlap may over-suppress a healthy TC — an
+	// OnTeeDropWindow is invoked ONLY for genuine per-operation byte-loss
+	// drops (channel_full, per_conn_cap) with the drop reason AND the
+	// dropped chunk's wire timestamp (coalesced per operation, not one call
+	// per chunk). memory_pressure and paused drops do NOT invoke it — they
+	// fire per-chunk for a sustained interval and would flood/mass-suppress
+	// (see tee.drop). Callers wire this to the supervisor's
+	// RecordOrphanWindow so TCs whose HTTP window contains that instant are
+	// suppressed — the dropped chunk's mock cannot be recorded, so replaying
+	// its TC would orphan it (match_phase=no_mocks). The decode-lag-immune,
+	// time-attributed complement to OnMarkMockIncomplete (which only voids a
+	// later, possibly-unrelated mock via the session flag). Attribution is
+	// by time, so a concurrent overlap may over-suppress a healthy TC — an
 	// accepted coverage-for-stability tradeoff. Nil is safe.
 	OnTeeDropWindow func(reason string, ts time.Time)
 

--- a/pkg/agent/proxy/relay/config.go
+++ b/pkg/agent/proxy/relay/config.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"net"
+	"time"
 
 	"go.keploy.io/server/v3/pkg/agent/memoryguard"
 	"go.uber.org/zap"
@@ -124,6 +125,19 @@ type Config struct {
 	// the supervisor will record in telemetry. Nil is safe.
 	OnMarkMockIncomplete func(reason string)
 
+	// OnTeeDropWindow is invoked on tee-chunk drops with the drop reason
+	// AND the dropped chunk's wire timestamp (coalesced per operation,
+	// not one call per chunk). Callers wire this to the supervisor's
+	// RecordOrphanWindow so TCs whose HTTP window contains that instant
+	// are suppressed — the dropped chunk's mock cannot be recorded, so
+	// replaying its TC would orphan it (match_phase=no_mocks). The
+	// decode-lag-immune, time-attributed complement to
+	// OnMarkMockIncomplete (which only voids a later, possibly-unrelated
+	// mock via the session flag). Attribution is by time, so a concurrent
+	// or reusable-mock overlap may over-suppress a healthy TC — an
+	// accepted coverage-for-stability tradeoff. Nil is safe.
+	OnTeeDropWindow func(reason string, ts time.Time)
+
 	// OnClientChunkTeed is invoked after each successful tee of a
 	// client-to-dest chunk into the parser's FakeConn. Callers wire
 	// this to the supervisor's MarkPendingWork so the activity
@@ -194,6 +208,9 @@ func (c Config) withDefaults() Config {
 	}
 	if out.OnMarkMockIncomplete == nil {
 		out.OnMarkMockIncomplete = func(string) {}
+	}
+	if out.OnTeeDropWindow == nil {
+		out.OnTeeDropWindow = func(string, time.Time) {}
 	}
 	return out
 }

--- a/pkg/agent/proxy/relay/relay.go
+++ b/pkg/agent/proxy/relay/relay.go
@@ -159,6 +159,7 @@ func New(cfg Config, src, dst net.Conn) *Relay {
 		cfg.TeeChanBuf,
 		cfg.MemoryGuardCheck,
 		cfg.OnMarkMockIncomplete,
+		cfg.OnTeeDropWindow,
 		cfg.Logger,
 	)
 	r.teeD2C = newTee(
@@ -167,6 +168,7 @@ func New(cfg Config, src, dst net.Conn) *Relay {
 		cfg.TeeChanBuf,
 		cfg.MemoryGuardCheck,
 		cfg.OnMarkMockIncomplete,
+		cfg.OnTeeDropWindow,
 		cfg.Logger,
 	)
 

--- a/pkg/agent/proxy/relay/relay.go
+++ b/pkg/agent/proxy/relay/relay.go
@@ -247,6 +247,20 @@ func (r *Relay) ResumeTees() {
 	r.teeD2C.setPaused(false)
 }
 
+// SetPressureSelfManaged toggles the memory-pressure drop opt-out on both
+// tees. When enabled the tees stop dropping chunks under memoryguard pressure
+// and rely on the parser to shed memory itself while staying byte-synced — so
+// a length-prefix reassembler is never desynced by a mid-message pressure drop
+// (the root of the go-memory-load-mongo tail dead zone). Opted into per
+// connection in recordViaSupervisor by parsers that implement
+// SelfManagesMemoryPressure() (mongo/v2). Capacity drops
+// (channel_full/per_conn_cap) and the abort/finalize pause are unaffected, so
+// a genuine mid-message byte loss still triggers the parser's resync.
+func (r *Relay) SetPressureSelfManaged(v bool) {
+	r.teeC2D.setPressureSelfManaged(v)
+	r.teeD2C.setPressureSelfManaged(v)
+}
+
 // ReattachStreams builds fresh client/dest FakeConns over the SAME still-open
 // tee out-channels and atomically swaps them in, returning the new pair. The
 // previous FakeConns were one-way Closed by SessionOnAbort and cannot be

--- a/pkg/agent/proxy/relay/relay.go
+++ b/pkg/agent/proxy/relay/relay.go
@@ -42,11 +42,15 @@ type Relay struct {
 	teeD2C *tee
 
 	// clientStream is the FakeConn parsers read to consume
-	// client-produced bytes.
-	clientStream *fakeconn.FakeConn
+	// client-produced bytes. Held behind an atomic pointer so the
+	// abort-recovery path (ReattachStreams) can swap in a fresh FakeConn
+	// for a new parser generation while the SessionOnAbort callback may
+	// concurrently read it. The forwarder hot path never touches this —
+	// it reads the tees directly — so the swap has no bearing on I1.
+	clientStream atomic.Pointer[fakeconn.FakeConn]
 	// destStream is the FakeConn parsers read to consume
-	// destination-produced bytes.
-	destStream *fakeconn.FakeConn
+	// destination-produced bytes; same atomic treatment as clientStream.
+	destStream atomic.Pointer[fakeconn.FakeConn]
 
 	// directives is the parser-writable directive channel. The
 	// processor goroutine reads from here.
@@ -177,13 +181,13 @@ func New(cfg Config, src, dst net.Conn) *Relay {
 		localAddr = src.LocalAddr()
 		remoteAddr = src.RemoteAddr()
 	}
-	r.clientStream = fakeconn.New(r.teeC2D.readCh(), localAddr, remoteAddr)
+	r.clientStream.Store(fakeconn.New(r.teeC2D.readCh(), localAddr, remoteAddr))
 	var destLocal, destRemote net.Addr
 	if dst != nil {
 		destLocal = dst.LocalAddr()
 		destRemote = dst.RemoteAddr()
 	}
-	r.destStream = fakeconn.New(r.teeD2C.readCh(), destLocal, destRemote)
+	r.destStream.Store(fakeconn.New(r.teeD2C.readCh(), destLocal, destRemote))
 
 	return r
 }
@@ -191,12 +195,12 @@ func New(cfg Config, src, dst net.Conn) *Relay {
 // ClientStream returns the parser-facing FakeConn populated with
 // chunks read from the real client (bytes flowing client → dest).
 // Safe to call before or after Run starts.
-func (r *Relay) ClientStream() *fakeconn.FakeConn { return r.clientStream }
+func (r *Relay) ClientStream() *fakeconn.FakeConn { return r.clientStream.Load() }
 
 // DestStream returns the parser-facing FakeConn populated with chunks
 // read from the real destination (bytes flowing dest → client). Safe
 // to call before or after Run starts.
-func (r *Relay) DestStream() *fakeconn.FakeConn { return r.destStream }
+func (r *Relay) DestStream() *fakeconn.FakeConn { return r.destStream.Load() }
 
 // Directives returns the parser-writable directive channel. Parsers
 // send [directive.Directive] values here; the relay's directive
@@ -230,6 +234,49 @@ func (r *Relay) PauseTees() {
 	r.teeD2C.setPaused(true)
 }
 
+// ResumeTees reverses PauseTees: it re-arms both tees so subsequent
+// chunks are delivered to the parser-facing FakeConns again. Used only by
+// the abort-recovery respawn path in recordViaSupervisor to bring a still-
+// alive pooled connection back into recording after its parser generation
+// aborted (any trigger: hang / mem-cap / panic / parser error). Reuses
+// setPaused(false), the same primitive handleResumeDir uses to reverse a
+// KindPauseDir pause. Callers MUST ReattachStreams (fresh FakeConns) before
+// the resumed tees deliver, because SessionOnAbort Closed the old ones.
+func (r *Relay) ResumeTees() {
+	r.teeC2D.setPaused(false)
+	r.teeD2C.setPaused(false)
+}
+
+// ReattachStreams builds fresh client/dest FakeConns over the SAME still-open
+// tee out-channels and atomically swaps them in, returning the new pair. The
+// previous FakeConns were one-way Closed by SessionOnAbort and cannot be
+// revived; the tees themselves stay open until Run's teardown, so their out
+// channels remain valid receivers for a fresh FakeConn.
+//
+// Only the recordViaSupervisor goroutine calls this, one generation at a time,
+// so it never races itself. Run's teardown Close (on peer close) CAN race it —
+// recordViaSupervisor does a non-blocking relayDone check before looping but
+// the relay may exit in the gap. That race is benign: every stream field is an
+// atomic Pointer (Store/Load), and once the drain goroutines close the tee out
+// channels a freshly attached FakeConn simply reads io.EOF instead of blocking.
+func (r *Relay) ReattachStreams() (client, dest *fakeconn.FakeConn) {
+	var localAddr, remoteAddr net.Addr
+	if src := r.src.Load(); src != nil && *src != nil {
+		localAddr = (*src).LocalAddr()
+		remoteAddr = (*src).RemoteAddr()
+	}
+	var destLocal, destRemote net.Addr
+	if dst := r.dst.Load(); dst != nil && *dst != nil {
+		destLocal = (*dst).LocalAddr()
+		destRemote = (*dst).RemoteAddr()
+	}
+	nc := fakeconn.New(r.teeC2D.readCh(), localAddr, remoteAddr)
+	nd := fakeconn.New(r.teeD2C.readCh(), destLocal, destRemote)
+	r.clientStream.Store(nc)
+	r.destStream.Store(nd)
+	return nc, nd
+}
+
 // HasBufferedInput reports whether either direction currently holds
 // input the parser has not yet consumed — bytes staged in a tee, or a
 // chunk queued/stashed in a FakeConn. The supervisor's hang watchdog
@@ -247,7 +294,7 @@ func (r *Relay) PauseTees() {
 // FakeConn's own synchronised buffer check.
 func (r *Relay) HasBufferedInput() bool {
 	return r.teeC2D.hasStagedBytes() || r.teeD2C.hasStagedBytes() ||
-		r.clientStream.HasBuffered() || r.destStream.HasBuffered()
+		r.clientStream.Load().HasBuffered() || r.destStream.Load().HasBuffered()
 }
 
 // Run starts the forwarder, drain, and directive-processor goroutines
@@ -394,8 +441,8 @@ func (r *Relay) run(ctx context.Context) error {
 	r.teeD2C.waitDone()
 
 	// Close the FakeConns so any blocked parser Read returns ErrClosed.
-	_ = r.clientStream.Close()
-	_ = r.destStream.Close()
+	_ = r.clientStream.Load().Close()
+	_ = r.destStream.Load().Close()
 
 	// Signal the directive processor to exit and wait for it. Use the
 	// idempotent closer because either forwarder's defer may have

--- a/pkg/agent/proxy/relay/relay.go
+++ b/pkg/agent/proxy/relay/relay.go
@@ -230,6 +230,26 @@ func (r *Relay) PauseTees() {
 	r.teeD2C.setPaused(true)
 }
 
+// HasBufferedInput reports whether either direction currently holds
+// input the parser has not yet consumed — bytes staged in a tee, or a
+// chunk queued/stashed in a FakeConn. The supervisor's hang watchdog
+// consults this (via SetActivityProbe) so a parser that is merely idle —
+// blocked reading an empty stream, e.g. a pooled DB connection sitting
+// between requests — is not mistaken for one that is hung. A hang is
+// declared only when there is genuinely unconsumed input the parser is
+// failing to make progress on. Without this discriminator, an idle
+// connection whose last exchange was abandoned (its response dropped
+// under memory pressure, so no mock was emitted to clear the
+// supervisor's `pending` flag) is false-hanged after the budget and
+// permanently silenced via PauseTees — recording never resumes on the
+// live pooled connection, producing the go-memory-load-mongo recording
+// dead zone. Safe for concurrent use: atomic byte counters plus the
+// FakeConn's own synchronised buffer check.
+func (r *Relay) HasBufferedInput() bool {
+	return r.teeC2D.hasStagedBytes() || r.teeD2C.hasStagedBytes() ||
+		r.clientStream.HasBuffered() || r.destStream.HasBuffered()
+}
+
 // Run starts the forwarder, drain, and directive-processor goroutines
 // and blocks until both forwarders exit. Exits happen on:
 //

--- a/pkg/agent/proxy/relay/relay_test.go
+++ b/pkg/agent/proxy/relay/relay_test.go
@@ -337,6 +337,46 @@ func TestDirectiveAbortMock(t *testing.T) {
 	}
 }
 
+// TestHasBufferedInput is the discriminator behind the hang-watchdog
+// idle-vs-stuck gate: HasBufferedInput must report true exactly while a
+// teed chunk sits unconsumed by the parser, and false once the parser
+// has drained it (or before any traffic). This is what stops an idle
+// pooled connection from being false-hanged and permanently silenced.
+func TestHasBufferedInput(t *testing.T) {
+	t.Parallel()
+	h := newHarness(t, Config{})
+
+	pollUntil := func(want bool) {
+		t.Helper()
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if h.r.HasBufferedInput() == want {
+				return
+			}
+			time.Sleep(2 * time.Millisecond)
+		}
+		t.Fatalf("HasBufferedInput never became %v", want)
+	}
+
+	// Idle relay, no traffic: nothing buffered.
+	if h.r.HasBufferedInput() {
+		t.Fatalf("fresh relay: HasBufferedInput = true, want false")
+	}
+
+	// Drain the dest side so the client→dest forward completes (net.Pipe
+	// is synchronous), then send a client request. With no parser reading
+	// the client FakeConn, the teed chunk is unconsumed input.
+	go func() { _, _ = io.Copy(io.Discard, h.destSvc) }()
+	h.writeClient([]byte("find-request-bytes"))
+	pollUntil(true)
+
+	// The parser consumes the teed chunk → idle again.
+	if _, err := h.r.ClientStream().ReadChunk(); err != nil {
+		t.Fatalf("ReadChunk: %v", err)
+	}
+	pollUntil(false)
+}
+
 func TestDirectivePauseResume(t *testing.T) {
 	t.Parallel()
 	h := newHarness(t, Config{})

--- a/pkg/agent/proxy/relay/relay_test.go
+++ b/pkg/agent/proxy/relay/relay_test.go
@@ -250,6 +250,43 @@ func TestTeeDropOnMemoryGuard(t *testing.T) {
 	}
 }
 
+// TestRelaySetPressureSelfManagedDeliversUnderMemoryGuard is the relay-level
+// counterpart to TestTeeDropOnMemoryGuard: with SetPressureSelfManaged(true)
+// the parser-facing FakeConn STILL receives chunks while the memory guard is
+// asserting pressure (the parser sheds memory itself and must stay byte-synced),
+// and no memory_pressure drop is recorded. Real traffic flows either way.
+func TestRelaySetPressureSelfManagedDeliversUnderMemoryGuard(t *testing.T) {
+	t.Parallel()
+	var pressure atomic.Bool
+	pressure.Store(true)
+	drops := newDropSink()
+
+	h := newHarness(t, Config{
+		MemoryGuardCheck:     pressure.Load,
+		OnMarkMockIncomplete: drops.record,
+	})
+	h.r.SetPressureSelfManaged(true)
+
+	go h.writeClient([]byte("visible"))
+	got := h.readDest(len("visible"))
+	if string(got) != "visible" {
+		t.Fatalf("dest got %q, want %q", got, "visible")
+	}
+
+	// The FakeConn DOES receive the chunk despite active memory pressure.
+	_ = h.r.ClientStream().SetReadDeadline(time.Now().Add(2 * time.Second))
+	c, err := h.r.ClientStream().ReadChunk()
+	if err != nil {
+		t.Fatalf("ClientStream should have delivered the chunk under self-managed pressure, got err %v", err)
+	}
+	if string(c.Bytes) != "visible" {
+		t.Fatalf("FakeConn got %q, want %q", c.Bytes, "visible")
+	}
+	if drops.count(DropMemoryPressure) != 0 {
+		t.Fatalf("self-managed relay must record no memory_pressure drop, got %v", drops.snapshot())
+	}
+}
+
 func TestTeeDropOnPerConnCap(t *testing.T) {
 	t.Parallel()
 	drops := newDropSink()

--- a/pkg/agent/proxy/relay/relay_test.go
+++ b/pkg/agent/proxy/relay/relay_test.go
@@ -1149,3 +1149,93 @@ func TestDirectiveUpgradeTLS_PreDispatch_FlushesC2DStashBeforePreambleRead(t *te
 		t.Fatalf("no UpgradeTLS ack — handler hung (likely a regression: C2D stash not flushed before preamble read)")
 	}
 }
+
+// TestAbortRecovery_ResumeTeesReattachRecordsAgain reproduces the recording
+// dead zone at the relay-primitive level and proves ResumeTees +
+// ReattachStreams recover it — deterministically, with no supervisor, timers,
+// or memory guard.
+//
+// Bug: the supervisor abort path pauses the tees and Closes the parser-facing
+// FakeConns. On a POOLED connection the real sockets keep forwarding, but every
+// further request is dropped (paused) and the Closed FakeConns deliver nothing,
+// so recording is permanently silenced on a live connection. The fix swaps in
+// fresh FakeConns over the still-open tee channels and un-pauses the tees so
+// the next request records again.
+func TestAbortRecovery_ResumeTeesReattachRecordsAgain(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	req1 := []byte("REQUEST-ONE")
+	req2 := []byte("REQUEST-TWO")
+	req3 := []byte("REQUEST-THREE")
+
+	// Baseline: a request forwards to the peer AND tees to the parser stream.
+	go h.writeClient(req1)
+	if got := h.readDest(len(req1)); string(got) != string(req1) {
+		t.Fatalf("baseline forward: got %q want %q", got, req1)
+	}
+	if got := mustReadChunkStr(t, h.r.ClientStream()); got != string(req1) {
+		t.Fatalf("baseline record: got %q want %q", got, req1)
+	}
+
+	// Induce an abort exactly as SessionOnAbort does.
+	h.r.PauseTees()
+	_ = h.r.ClientStream().Close()
+	_ = h.r.DestStream().Close()
+
+	// A new request still forwards to the peer (raw path alive) but is NOT
+	// recorded — the paused tee drops it. Gate on the drop count so the drop is
+	// observed BEFORE recovery; otherwise a late tee push could leak req2 into
+	// the reattached stream (a test race, not a product concern).
+	beforeDrops, _ := h.r.DropCounts()
+	go h.writeClient(req2)
+	if got := h.readDest(len(req2)); string(got) != string(req2) {
+		t.Fatalf("post-abort forward: got %q want %q", got, req2)
+	}
+	waitForClientDrop(t, h.r, beforeDrops)
+
+	// The Closed parser stream yields ErrClosed — recording is silenced.
+	_ = h.r.ClientStream().SetReadDeadline(time.Now().Add(300 * time.Millisecond))
+	if _, err := h.r.ClientStream().ReadChunk(); !errors.Is(err, fakeconn.ErrClosed) {
+		t.Fatalf("post-abort record: expected recording silenced (ErrClosed), got err=%v", err)
+	}
+
+	// Recover: fresh FakeConns over the same tees, then un-pause.
+	nc, _ := h.r.ReattachStreams()
+	h.r.ResumeTees()
+
+	// The next request records again on the fresh stream.
+	go h.writeClient(req3)
+	if got := h.readDest(len(req3)); string(got) != string(req3) {
+		t.Fatalf("post-recovery forward: got %q want %q", got, req3)
+	}
+	if got := mustReadChunkStr(t, nc); got != string(req3) {
+		t.Fatalf("post-recovery record: got %q want %q — ReattachStreams+ResumeTees did not restore recording", got, req3)
+	}
+}
+
+// mustReadChunkStr reads one chunk with a bounded deadline and returns its
+// bytes as a string, failing the test on error.
+func mustReadChunkStr(t *testing.T, s *fakeconn.FakeConn) string {
+	t.Helper()
+	_ = s.SetReadDeadline(time.Now().Add(time.Second))
+	c, err := s.ReadChunk()
+	if err != nil {
+		t.Fatalf("ReadChunk: %v", err)
+	}
+	return string(c.Bytes)
+}
+
+// waitForClientDrop blocks until the client→dest tee's drop count exceeds prev,
+// confirming the paused tee dropped the just-forwarded chunk. Bounded so a
+// wedged test fails fast instead of hanging.
+func waitForClientDrop(t *testing.T, r *Relay, prev uint64) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if c, _ := r.DropCounts(); c > prev {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("client→dest tee did not drop the post-abort chunk within 1s")
+}

--- a/pkg/agent/proxy/relay/tee.go
+++ b/pkg/agent/proxy/relay/tee.go
@@ -247,18 +247,30 @@ func (t *tee) drop(reason string, ts time.Time) {
 		t.onDrop(reason)
 	}
 	// Report the dropped chunk's own wire instant so the supervisor can
-	// record an orphan window and suppress a TC whose HTTP window
-	// contains it. Recorded on the forward path (decode-lag immune),
-	// unlike the onDrop next-mock-void which attributes the loss to a
-	// later mock. Attribution is by time only (the tee has no TC or mock
-	// identity): it correctly catches the dropped operation's own TC, but
-	// a concurrent healthy TC on another connection whose HTTP window
-	// straddles this instant — or a per-test TC overlapping a dropped
-	// REUSABLE (session/heartbeat) chunk — may also be suppressed. That
-	// over-suppression trades a little coverage for no orphaned replay,
-	// the same tradeoff the pressure-range path already makes. Coalesced
-	// per operation to keep the bounded orphanRanges ring from flooding.
-	if t.onDropAt != nil && !ts.IsZero() {
+	// record an orphan window and suppress a TC whose HTTP window contains
+	// it — but ONLY for genuine per-operation byte loss: channel_full and
+	// per_conn_cap. Recorded on the forward path (decode-lag immune), unlike
+	// the onDrop next-mock-void which attributes the loss to a later mock.
+	// Attribution is by time only (the tee has no TC/mock identity), so a
+	// concurrent healthy TC whose HTTP window straddles this instant may
+	// also be suppressed — the same coverage-for-stability tradeoff the
+	// pressure-range path makes; exact-owner attribution is a fast-follow.
+	//
+	// memory_pressure and paused are DELIBERATELY EXCLUDED — both drop every
+	// chunk for a sustained interval, so each would write thousands of
+	// zero-width instants into the count-bounded, global orphanRanges ring.
+	// That (a) floods the ring, evicting the real channel_full/per_conn_cap
+	// windows before the >7s-lagging record.go reads them, and (b)
+	// mass-suppresses healthy TCs on every connection whose window contains
+	// one of those instants — turning one visible replay orphan into many
+	// silent coverage losses.
+	//   - memory_pressure: a pause lasts seconds and is ALREADY covered by
+	//     pressureRanges (which record.go consults, and which cover any TC
+	//     straddling the pause) — recording it here is pure redundant flood.
+	//   - paused: setPaused(true) comes from PauseTees (abort — session is
+	//     dead) or KindPauseDir (the mock was finalized, further traffic is
+	//     noise); both raw-forward until close with no live mock to suppress.
+	if (reason == DropChannelFull || reason == DropPerConnCap) && t.onDropAt != nil && !ts.IsZero() {
 		n := ts.UnixNano()
 		last := t.lastDropRecNanos.Load()
 		if last == 0 || n-last >= dropWindowCoalesceNanos || last-n >= dropWindowCoalesceNanos {

--- a/pkg/agent/proxy/relay/tee.go
+++ b/pkg/agent/proxy/relay/tee.go
@@ -149,6 +149,12 @@ func newTee(dir fakeconn.Direction, capBytes int64, chanBuf int, memCheck func()
 // relay can wrap it in a [fakeconn.FakeConn].
 func (t *tee) readCh() <-chan fakeconn.Chunk { return t.out }
 
+// hasStagedBytes reports whether the tee is holding chunks that have
+// been read from the socket but not yet drained to the FakeConn. Part
+// of the relay's "unconsumed input" signal (see Relay.HasBufferedInput)
+// the hang watchdog uses to avoid false-hanging an idle parser.
+func (t *tee) hasStagedBytes() bool { return t.bytes.Load() > 0 }
+
 // dropCount returns the number of chunks dropped since construction.
 // Safe to call concurrently.
 func (t *tee) dropCount() uint64 { return t.drops.Load() }

--- a/pkg/agent/proxy/relay/tee.go
+++ b/pkg/agent/proxy/relay/tee.go
@@ -90,6 +90,22 @@ type tee struct {
 	// while still forwarding real bytes.
 	paused atomic.Bool
 
+	// pressureSelfManaged, when set, makes push SKIP the memoryguard
+	// (memCheck) drop path: the parser owns memory-pressure handling for
+	// this connection. A length-prefix reassembler (mongo/v2) that is fed a
+	// mid-message chunk drop can no longer trust its buffer head and must
+	// content-scan to re-anchor — which, for the app's large multi-chunk
+	// messages under the memory guard's sawtooth, can never buffer a whole
+	// message before the next drop and so stays permanently desynced,
+	// silently stopping recording for the pooled connection (the
+	// go-memory-load-mongo tail dead zone). Such a parser instead stays
+	// byte-synced across a pause and sheds memory itself (skip-discarding
+	// whole messages), so the tee must NOT drop its chunks for pressure.
+	// Only the memory_pressure path is skipped; the paused (abort/finalize)
+	// and capacity (channel_full/per_conn_cap) drop paths are unaffected —
+	// a genuine mid-message capacity drop still fires so the parser resyncs.
+	pressureSelfManaged atomic.Bool
+
 	// drops counts dropped chunks for this direction. Exposed via
 	// [tee.dropCount] for diagnostics and tests.
 	drops atomic.Uint64
@@ -163,6 +179,10 @@ func (t *tee) dropCount() uint64 { return t.drops.Load() }
 // reason [DropPaused] without consuming capacity.
 func (t *tee) setPaused(p bool) { t.paused.Store(p) }
 
+// setPressureSelfManaged toggles whether push skips the memoryguard
+// (DropMemoryPressure) drop path for this tee. See the field doc.
+func (t *tee) setPressureSelfManaged(v bool) { t.pressureSelfManaged.Store(v) }
+
 // push admits a chunk into staging. Returns true on success, false on
 // drop. A drop invokes onDrop with the reason string and does not
 // alter the byte counter.
@@ -182,7 +202,7 @@ func (t *tee) push(c fakeconn.Chunk) bool {
 		t.drop(DropPaused, teeChunkTs(c))
 		return false
 	}
-	if t.memCheck != nil && t.memCheck() {
+	if t.memCheck != nil && t.memCheck() && !t.pressureSelfManaged.Load() {
 		t.drop(DropMemoryPressure, teeChunkTs(c))
 		return false
 	}

--- a/pkg/agent/proxy/relay/tee.go
+++ b/pkg/agent/proxy/relay/tee.go
@@ -3,6 +3,7 @@ package relay
 import (
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"go.keploy.io/server/v3/pkg/agent/proxy/fakeconn"
 	"go.uber.org/zap"
@@ -28,6 +29,17 @@ const (
 	DropPaused = "paused"
 )
 
+// dropWindowCoalesceNanos is the minimum gap between two onDropAt
+// orphan-window recordings on the same tee. One overflowing operation is
+// many chunks sharing near-identical wire timestamps; without coalescing
+// each would push a separate zero-width window into the count-bounded
+// orphanRanges ring. 1ms comfortably collapses a single operation's chunk
+// burst (sub-millisecond on the wire) while still recording distinct
+// windows for operations that are milliseconds apart — small enough that
+// even a tight burst of orphaned reads (observed ~1.8ms apart) each keep
+// their own window.
+const dropWindowCoalesceNanos = int64(1_000_000)
+
 // tee is the accounting wrapper around the internal staging channel
 // between the forwarder goroutines and the FakeConn. For each direction
 // the forwarder calls push(c); that either enqueues the chunk onto an
@@ -50,6 +62,17 @@ type tee struct {
 	memCheck func() bool
 	onDrop   func(reason string)
 
+	// onDropAt is called on every drop with the reason AND the wire
+	// timestamp of the dropped chunk. Unlike onDrop (which sets the
+	// session's global incomplete-mock flag, voiding some LATER,
+	// possibly-unrelated mock), this reports the EXACT instant the
+	// lost bytes were on the wire — so the supervisor can record an
+	// orphan window that overlaps the owning TC's own HTTP window and
+	// suppress precisely that TC. Recorded synchronously on the
+	// forward path, so it is immune to parser decode lag (the reason
+	// the previous next-mock-void attribution missed most orphans).
+	onDropAt func(reason string, ts time.Time)
+
 	// staging is the internal buffered channel. Forwarders push into
 	// it; the drain goroutine pulls out.
 	staging chan fakeconn.Chunk
@@ -70,6 +93,19 @@ type tee struct {
 	// drops counts dropped chunks for this direction. Exposed via
 	// [tee.dropCount] for diagnostics and tests.
 	drops atomic.Uint64
+
+	// lastDropRecNanos is the wire timestamp (UnixNano) of the most
+	// recent chunk for which onDropAt actually recorded an orphan
+	// window. onDropAt fires PER CHUNK, but one overflowing operation
+	// is hundreds of chunks sharing near-identical timestamps; recording
+	// a window for every one would flood the count-bounded orphanRanges
+	// ring (evicting windows for earlier, not-yet-checked TCs). We
+	// coalesce: a new drop within dropWindowCoalesceNanos of the last
+	// recorded one is skipped — collapsing an operation's chunk burst to
+	// ~one window while still separating distinct operations (which are
+	// milliseconds apart). Best-effort under concurrent pushes (a benign
+	// extra record at worst); onDrop/MarkMockIncomplete is unaffected.
+	lastDropRecNanos atomic.Int64
 
 	// closeMu is held in read mode during a push's channel send and
 	// in write mode by close. This ensures no in-flight send is racing
@@ -92,13 +128,14 @@ type tee struct {
 // newTee wires a staging channel, an out channel, and a drain
 // goroutine that moves chunks from staging to out while maintaining
 // the bytes counter.
-func newTee(dir fakeconn.Direction, capBytes int64, chanBuf int, memCheck func() bool, onDrop func(reason string), logger *zap.Logger) *tee {
+func newTee(dir fakeconn.Direction, capBytes int64, chanBuf int, memCheck func() bool, onDrop func(reason string), onDropAt func(reason string, ts time.Time), logger *zap.Logger) *tee {
 	t := &tee{
 		dir:      dir,
 		logger:   logger,
 		cap:      capBytes,
 		memCheck: memCheck,
 		onDrop:   onDrop,
+		onDropAt: onDropAt,
 		staging:  make(chan fakeconn.Chunk, chanBuf),
 		out:      make(chan fakeconn.Chunk, chanBuf),
 		done:     make(chan struct{}),
@@ -136,11 +173,11 @@ func (t *tee) push(c fakeconn.Chunk) bool {
 		return false
 	}
 	if t.paused.Load() {
-		t.drop(DropPaused)
+		t.drop(DropPaused, teeChunkTs(c))
 		return false
 	}
 	if t.memCheck != nil && t.memCheck() {
-		t.drop(DropMemoryPressure)
+		t.drop(DropMemoryPressure, teeChunkTs(c))
 		return false
 	}
 	n := int64(len(c.Bytes))
@@ -152,7 +189,7 @@ func (t *tee) push(c fakeconn.Chunk) bool {
 	// an over- or under-count of one chunk; the cap is a soft limit
 	// by contract.
 	if t.bytes.Load()+n > t.cap {
-		t.drop(DropPerConnCap)
+		t.drop(DropPerConnCap, teeChunkTs(c))
 		return false
 	}
 
@@ -173,9 +210,24 @@ func (t *tee) push(c fakeconn.Chunk) bool {
 		return true
 	default:
 		t.closeMu.RUnlock()
-		t.drop(DropChannelFull)
+		t.drop(DropChannelFull, teeChunkTs(c))
 		return false
 	}
+}
+
+// teeChunkTs returns the wire timestamp of a chunk for orphan-window
+// attribution: the client-read time (ReadAt) when set, else the
+// dest-write time (WrittenAt). Both are stamped by the forwarder with
+// the same wall clock the ingress uses for HTTP TC request/response
+// timestamps, so a [ts, ts] window recorded here overlaps the owning
+// TC's HTTP window. A pre-dispatch stash chunk carries only ReadAt; a
+// forwarded chunk carries both. Zero when neither is set (the caller
+// then records nothing).
+func teeChunkTs(c fakeconn.Chunk) time.Time {
+	if !c.ReadAt.IsZero() {
+		return c.ReadAt
+	}
+	return c.WrittenAt
 }
 
 // drop bumps counters and notifies. Kept small so push stays inlineable.
@@ -189,10 +241,30 @@ func (t *tee) push(c fakeconn.Chunk) bool {
 // "incomplete mock" enable --debug to see them, normal runs stay
 // quiet. Subsequent drops still increment drops_total and fire onDrop
 // unchanged — only the log emission is rate-limited.
-func (t *tee) drop(reason string) {
+func (t *tee) drop(reason string, ts time.Time) {
 	n := t.drops.Add(1)
 	if t.onDrop != nil {
 		t.onDrop(reason)
+	}
+	// Report the dropped chunk's own wire instant so the supervisor can
+	// record an orphan window and suppress a TC whose HTTP window
+	// contains it. Recorded on the forward path (decode-lag immune),
+	// unlike the onDrop next-mock-void which attributes the loss to a
+	// later mock. Attribution is by time only (the tee has no TC or mock
+	// identity): it correctly catches the dropped operation's own TC, but
+	// a concurrent healthy TC on another connection whose HTTP window
+	// straddles this instant — or a per-test TC overlapping a dropped
+	// REUSABLE (session/heartbeat) chunk — may also be suppressed. That
+	// over-suppression trades a little coverage for no orphaned replay,
+	// the same tradeoff the pressure-range path already makes. Coalesced
+	// per operation to keep the bounded orphanRanges ring from flooding.
+	if t.onDropAt != nil && !ts.IsZero() {
+		n := ts.UnixNano()
+		last := t.lastDropRecNanos.Load()
+		if last == 0 || n-last >= dropWindowCoalesceNanos || last-n >= dropWindowCoalesceNanos {
+			t.lastDropRecNanos.Store(n)
+			t.onDropAt(reason, ts)
+		}
 	}
 	if t.logger != nil && n&(n-1) == 0 {
 		// n is a power of two (1, 2, 4, 8, ...) — log this drop.

--- a/pkg/agent/proxy/relay/tee_test.go
+++ b/pkg/agent/proxy/relay/tee_test.go
@@ -117,17 +117,18 @@ func TestTee_DropOnMemoryPressure(t *testing.T) {
 
 func TestTee_DropOnPerConnCap(t *testing.T) {
 	t.Parallel()
-	// Cap at 4 bytes; first 3-byte push fits, second also fits (6 > 4) → drop.
+	// A single chunk LARGER than the cap always trips per_conn_cap on the
+	// calling goroutine (bytes.Load()+n > cap with n > cap), independent of
+	// the drain goroutine. The old two-small-push form ("abc" then "def",
+	// cap 4) relied on the drain NOT yet having decremented the byte counter
+	// when the second push ran — a ~1/12000 race. Oversized is deterministic.
 	tt, _, rec := newTestTee(t, 4, 16, nil)
 
-	if !tt.push(mkChunk("abc")) {
-		t.Fatalf("first push should succeed")
+	if tt.push(mkChunk("abcde")) { // 5 bytes > cap 4
+		t.Fatalf("oversized push must trip per_conn_cap")
 	}
-	if tt.push(mkChunk("def")) {
-		t.Fatalf("second push should be dropped (per_conn_cap)")
-	}
-	if rec.count(DropPerConnCap) < 1 {
-		t.Fatalf("want at least 1 per_conn_cap drop, got %v", rec.snapshot())
+	if rec.count(DropPerConnCap) != 1 {
+		t.Fatalf("want 1 per_conn_cap drop, got %v", rec.snapshot())
 	}
 }
 
@@ -168,12 +169,12 @@ func TestTee_PausedDropsWithoutCapUsage(t *testing.T) {
 	}
 }
 
-// TestTee_DropRecordsWindowAt is the guard for the orphan-window fix:
-// every drop path must report the dropped chunk's OWN wire timestamp via
-// onDropAt (so the supervisor can suppress the TC whose HTTP window
-// contains it), and a successful push must report nothing. A regression
-// that stops threading the timestamp — or reverts drop() to not calling
-// onDropAt — makes this fail.
+// TestTee_DropRecordsWindowAt is the guard for the orphan-window fix and
+// its whitelist: a genuine per-op byte-loss drop (per_conn_cap, channel_full)
+// reports the dropped chunk's OWN wire timestamp via onDropAt, while the
+// sustained-interval reasons (memory_pressure, paused) report NOTHING — they
+// would flood the bounded ring and mass-suppress healthy TCs. A successful
+// push reports nothing. channel_full is covered by the coalesce test below.
 func TestTee_DropRecordsWindowAt(t *testing.T) {
 	t.Parallel()
 	stamp := time.Unix(1700000000, 12345)
@@ -181,38 +182,43 @@ func TestTee_DropRecordsWindowAt(t *testing.T) {
 		return fakeconn.Chunk{Dir: fakeconn.FromClient, Bytes: []byte(payload), ReadAt: stamp}
 	}
 
-	// memory_pressure
+	// memory_pressure: drops, but records NO orphan window (pressureRanges
+	// already cover it; per-chunk recording over a pause floods the ring).
 	var paused atomic.Bool
 	paused.Store(true)
 	tt, _, rec := newTestTee(t, 1<<20, 4, paused.Load)
 	if tt.push(chunkAt("x")) {
 		t.Fatalf("push should have dropped under memory pressure")
 	}
-	reasons, tss := rec.atSnapshot()
-	if len(reasons) != 1 || reasons[0] != DropMemoryPressure {
-		t.Fatalf("want one memory_pressure window, got reasons %v", reasons)
+	if rec.count(DropMemoryPressure) != 1 {
+		t.Fatalf("want 1 memory_pressure drop via onDrop, got %v", rec.snapshot())
 	}
-	if !tss[0].Equal(stamp) {
-		t.Fatalf("window ts = %v, want the dropped chunk's ReadAt %v", tss[0], stamp)
+	if reasons, _ := rec.atSnapshot(); len(reasons) != 0 {
+		t.Fatalf("memory_pressure must record NO orphan window, got %v", reasons)
 	}
 
-	// paused
+	// paused: drops, but records NO orphan window (an aborted connection
+	// stays paused raw-forwarding until close — recording every chunk would
+	// mass-suppress healthy TCs for the connection's whole remaining life).
 	tt2, _, rec2 := newTestTee(t, 1<<20, 4, nil)
 	tt2.setPaused(true)
 	if tt2.push(chunkAt("y")) {
 		t.Fatalf("push while paused should drop")
 	}
-	// per_conn_cap on the same tee after resume (cap 1<<20 won't trip; use a tiny-cap tee)
+	if rec2.count(DropPaused) != 1 {
+		t.Fatalf("want 1 paused drop via onDrop, got %v", rec2.snapshot())
+	}
+	if rs2, _ := rec2.atSnapshot(); len(rs2) != 0 {
+		t.Fatalf("paused must record NO orphan window, got %v", rs2)
+	}
+
+	// per_conn_cap: genuine per-op loss → records a window at the chunk's ts.
+	// Oversized chunk (len > cap) for determinism: it never enters staging,
+	// so t.bytes stays 0 and the cap check trips independent of the drain
+	// goroutine — unlike a two-small-push form which races the drain.
 	tt3, _, rec3 := newTestTee(t, 4, 16, nil)
-	if !tt3.push(chunkAt("abc")) {
-		t.Fatalf("first push should fit under cap")
-	}
-	if tt3.push(chunkAt("def")) {
-		t.Fatalf("second push should exceed per_conn_cap")
-	}
-	rs2, ts2 := rec2.atSnapshot()
-	if len(rs2) != 1 || rs2[0] != DropPaused || !ts2[0].Equal(stamp) {
-		t.Fatalf("paused: want one paused window at %v, got %v / %v", stamp, rs2, ts2)
+	if tt3.push(chunkAt("abcde")) { // 5 bytes > cap 4
+		t.Fatalf("oversized push must trip per_conn_cap")
 	}
 	rs3, ts3 := rec3.atSnapshot()
 	if len(rs3) != 1 || rs3[0] != DropPerConnCap || !ts3[0].Equal(stamp) {
@@ -256,38 +262,43 @@ func TestTee_DropWindowChannelFullCoalesceFallback(t *testing.T) {
 	}
 
 	// --- distinct operations (>1ms apart) each keep their own window ---
-	// Use the paused path so every push drops deterministically (the
-	// channel_full path races the drain goroutine on which pushes drop).
-	var alwaysPaused atomic.Bool
-	alwaysPaused.Store(true)
-	tt2, _, rec2 := newTestTee(t, 1<<30, 4, alwaysPaused.Load)
+	// Use per_conn_cap with OVERSIZED chunks (len > cap) for deterministic
+	// drops that DO record windows: a chunk bigger than the cap always trips
+	// per_conn_cap on the calling goroutine (bytes.Load()+n > cap, n > cap),
+	// independent of the drain goroutine. memory_pressure/paused no longer
+	// record windows, and channel_full races the drain.
+	tt2, _, rec2 := newTestTee(t, 4, 16, nil) // cap=4; 5-byte chunks always trip
 	base := time.Unix(1700000000, 0)
 	for i := 0; i < 6; i++ {
 		ts := base.Add(time.Duration(i) * 2 * time.Millisecond) // 2ms apart
-		if tt2.push(fakeconn.Chunk{Dir: fakeconn.FromClient, Bytes: []byte("y"), ReadAt: ts}) {
-			t.Fatalf("push should drop under pressure")
+		if tt2.push(fakeconn.Chunk{Dir: fakeconn.FromClient, Bytes: []byte("yyyyy"), ReadAt: ts}) {
+			t.Fatalf("oversized push must trip per_conn_cap")
 		}
 	}
-	if rs2, _ := rec2.atSnapshot(); len(rs2) != 6 {
+	rs2, _ := rec2.atSnapshot()
+	if len(rs2) != 6 {
 		t.Fatalf("distinct 2ms-apart drops must each record (no coalescing): want 6 windows, got %d", len(rs2))
+	}
+	for _, r := range rs2 {
+		if r != DropPerConnCap {
+			t.Fatalf("want per_conn_cap windows, got %v", rs2)
+		}
 	}
 
 	// --- WrittenAt fallback when ReadAt is zero (dest-side pre-forward stamp) ---
-	var paused atomic.Bool
-	paused.Store(true)
-	tt3, _, rec3 := newTestTee(t, 1<<20, 4, paused.Load)
+	tt3, _, rec3 := newTestTee(t, 4, 16, nil)
 	wStamp := time.Unix(1700000001, 777)
-	if tt3.push(fakeconn.Chunk{Dir: fakeconn.FromDest, Bytes: []byte("z"), WrittenAt: wStamp}) {
-		t.Fatalf("push should drop under pressure")
+	if tt3.push(fakeconn.Chunk{Dir: fakeconn.FromDest, Bytes: []byte("zzzzz"), WrittenAt: wStamp}) {
+		t.Fatalf("oversized push must trip per_conn_cap")
 	}
-	if rs3, ts3 := rec3.atSnapshot(); len(rs3) != 1 || !ts3[0].Equal(wStamp) {
-		t.Fatalf("WrittenAt fallback: want one window at %v, got %v / %v", wStamp, rs3, ts3)
+	if rs3, ts3 := rec3.atSnapshot(); len(rs3) != 1 || rs3[0] != DropPerConnCap || !ts3[0].Equal(wStamp) {
+		t.Fatalf("WrittenAt fallback: want one per_conn_cap window at %v, got %v / %v", wStamp, rs3, ts3)
 	}
 
-	// --- zero-timestamp chunk records NO window ---
-	tt4, _, rec4 := newTestTee(t, 1<<20, 4, paused.Load)
-	if tt4.push(fakeconn.Chunk{Dir: fakeconn.FromClient, Bytes: []byte("q")}) {
-		t.Fatalf("push should drop under pressure")
+	// --- zero-timestamp chunk records NO window (even for a recorded reason) ---
+	tt4, _, rec4 := newTestTee(t, 4, 16, nil)
+	if tt4.push(fakeconn.Chunk{Dir: fakeconn.FromClient, Bytes: []byte("qqqqq")}) {
+		t.Fatalf("oversized push must trip per_conn_cap")
 	}
 	if rs4, _ := rec4.atSnapshot(); len(rs4) != 0 {
 		t.Fatalf("zero-ts chunk must record no window, got %v", rs4)

--- a/pkg/agent/proxy/relay/tee_test.go
+++ b/pkg/agent/proxy/relay/tee_test.go
@@ -115,6 +115,123 @@ func TestTee_DropOnMemoryPressure(t *testing.T) {
 	}
 }
 
+// TestTee_PressureSelfManagedSkipsMemoryPressureDrop locks in the deep fix
+// for the go-memory-load-mongo tail dead zone: a tee whose parser self-manages
+// memory pressure (mongo/v2) must NOT drop chunks under memoryguard pressure,
+// so the length-prefix reassembler is never desynced by a mid-message drop and
+// stays byte-synced across the pause.
+func TestTee_PressureSelfManagedSkipsMemoryPressureDrop(t *testing.T) {
+	t.Parallel()
+	var memPressure atomic.Bool // the memCheck (memoryguard) signal, not the paused flag
+	memPressure.Store(true)
+	tt, _, rec := newTestTee(t, 1<<20, 4, memPressure.Load)
+	tt.setPressureSelfManaged(true)
+
+	if !tt.push(mkChunk("hello")) {
+		t.Fatalf("pressureSelfManaged tee must deliver (not drop) under memory pressure")
+	}
+	got := <-tt.readCh()
+	if string(got.Bytes) != "hello" {
+		t.Fatalf("got bytes %q, want %q", got.Bytes, "hello")
+	}
+	if rec.count(DropMemoryPressure) != 0 {
+		t.Fatalf("self-managed tee must record no memory_pressure drop, got %v", rec.snapshot())
+	}
+}
+
+// TestTee_PressureSelfManagedStillDropsCapacityAndPaused guards the boundary
+// of the opt-out: only the memory_pressure path is suppressed. Genuine
+// mid-message byte loss (per_conn_cap AND channel_full) and the abort/finalize
+// pause MUST still drop — the capacity paths so the parser resyncs on real byte
+// loss (and memory stays bounded), the pause because an aborted/finalized
+// session has no live mock.
+func TestTee_PressureSelfManagedStillDropsCapacityAndPaused(t *testing.T) {
+	t.Parallel()
+
+	// per_conn_cap still fires even while pressure is active and self-managed.
+	var pressure atomic.Bool
+	pressure.Store(true)
+	ttCap, _, recCap := newTestTee(t, 4, 16, pressure.Load)
+	ttCap.setPressureSelfManaged(true)
+	if ttCap.push(mkChunk("abcde")) { // 5 bytes > cap 4
+		t.Fatalf("oversized push must still trip per_conn_cap under self-managed pressure")
+	}
+	if recCap.count(DropPerConnCap) != 1 {
+		t.Fatalf("want 1 per_conn_cap drop, got %v", recCap.snapshot())
+	}
+	if recCap.count(DropMemoryPressure) != 0 {
+		t.Fatalf("memory_pressure must be opted out, got %v", recCap.snapshot())
+	}
+
+	// channel_full still fires: with a large cap but chanBuf=1 and no reader,
+	// staging saturates and the self-managed tee must drop (bounding memory)
+	// rather than silently backlog forever.
+	var pressure2 atomic.Bool
+	pressure2.Store(true)
+	ttChan, _, recChan := newTestTee(t, 1<<30, 1, pressure2.Load)
+	ttChan.setPressureSelfManaged(true)
+	for i := 0; i < 10; i++ {
+		ttChan.push(mkChunk("x"))
+	}
+	time.Sleep(20 * time.Millisecond) // let the drain goroutine settle its buffer
+	if recChan.count(DropChannelFull) == 0 {
+		t.Fatalf("self-managed tee must still drop on channel_full, got %v", recChan.snapshot())
+	}
+	if recChan.count(DropMemoryPressure) != 0 {
+		t.Fatalf("memory_pressure must be opted out, got %v", recChan.snapshot())
+	}
+
+	// paused (PauseTees abort / KindPauseDir finalize) still drops.
+	ttPause, _, recPause := newTestTee(t, 1<<20, 4, nil)
+	ttPause.setPressureSelfManaged(true)
+	ttPause.setPaused(true)
+	if ttPause.push(mkChunk("x")) {
+		t.Fatalf("paused tee must still drop under self-managed pressure")
+	}
+	if recPause.count(DropPaused) != 1 {
+		t.Fatalf("want 1 paused drop, got %v", recPause.snapshot())
+	}
+}
+
+// TestTee_PressureSelfManagedSurvivesPauseResume is the load-bearing invariant
+// for the abort-recovery interaction: the mongo opt-in is set ONCE per
+// connection, before the parser-generation loop, and the relay/tees outlive
+// every generation. A SessionOnAbort → PauseTees → ResumeTees respawn cycle
+// must NOT clobber pressureSelfManaged — otherwise the recovered generation
+// would resume dropping mongo chunks under pressure and re-open the very dead
+// zone this fixes. setPaused mirrors what Pause/ResumeTees drive.
+func TestTee_PressureSelfManagedSurvivesPauseResume(t *testing.T) {
+	t.Parallel()
+	var memPressure atomic.Bool
+	memPressure.Store(true)
+	tt, _, rec := newTestTee(t, 1<<20, 4, memPressure.Load)
+	tt.setPressureSelfManaged(true)
+
+	// Delivered under pressure before the abort.
+	if !tt.push(mkChunk("before")) {
+		t.Fatalf("pre-abort push must deliver under self-managed pressure")
+	}
+	<-tt.readCh()
+
+	// Abort: PauseTees drops; then ResumeTees re-arms delivery.
+	tt.setPaused(true)
+	if tt.push(mkChunk("during-abort")) {
+		t.Fatalf("push while paused (aborted) must drop")
+	}
+	tt.setPaused(false)
+
+	// After resume, the self-managed opt-out MUST still hold under pressure.
+	if !tt.push(mkChunk("after")) {
+		t.Fatalf("post-resume push must still deliver under self-managed pressure — pressureSelfManaged was clobbered by the pause/resume cycle")
+	}
+	if string((<-tt.readCh()).Bytes) != "after" {
+		t.Fatalf("post-resume chunk mismatch")
+	}
+	if rec.count(DropMemoryPressure) != 0 {
+		t.Fatalf("no memory_pressure drop expected across the whole cycle, got %v", rec.snapshot())
+	}
+}
+
 func TestTee_DropOnPerConnCap(t *testing.T) {
 	t.Parallel()
 	// A single chunk LARGER than the cap always trips per_conn_cap on the

--- a/pkg/agent/proxy/relay/tee_test.go
+++ b/pkg/agent/proxy/relay/tee_test.go
@@ -14,7 +14,7 @@ import (
 func newTestTee(t *testing.T, capBytes int64, buf int, memCheck func() bool) (*tee, func(reason string), *dropRecorder) {
 	t.Helper()
 	rec := &dropRecorder{}
-	t2 := newTee(fakeconn.FromClient, capBytes, buf, memCheck, rec.record, nil)
+	t2 := newTee(fakeconn.FromClient, capBytes, buf, memCheck, rec.record, rec.recordAt, nil)
 	t.Cleanup(func() {
 		t2.close()
 		t2.waitDone()
@@ -22,16 +22,38 @@ func newTestTee(t *testing.T, capBytes int64, buf int, memCheck func() bool) (*t
 	return t2, rec.record, rec
 }
 
-// dropRecorder collects drop reasons for assertion.
+// dropRecorder collects drop reasons for assertion. It also records the
+// (reason, ts) pairs delivered via the onDropAt callback so tests can
+// assert the accurately-attributed orphan-window path.
 type dropRecorder struct {
 	mu      sync.Mutex
 	reasons []string
+	atTs    []time.Time
+	atReas  []string
 }
 
 func (d *dropRecorder) record(reason string) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.reasons = append(d.reasons, reason)
+}
+
+func (d *dropRecorder) recordAt(reason string, ts time.Time) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.atReas = append(d.atReas, reason)
+	d.atTs = append(d.atTs, ts)
+}
+
+// atSnapshot returns the (reason, ts) pairs seen via onDropAt.
+func (d *dropRecorder) atSnapshot() ([]string, []time.Time) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	rs := make([]string, len(d.atReas))
+	copy(rs, d.atReas)
+	ts := make([]time.Time, len(d.atTs))
+	copy(ts, d.atTs)
+	return rs, ts
 }
 
 func (d *dropRecorder) snapshot() []string {
@@ -146,9 +168,135 @@ func TestTee_PausedDropsWithoutCapUsage(t *testing.T) {
 	}
 }
 
+// TestTee_DropRecordsWindowAt is the guard for the orphan-window fix:
+// every drop path must report the dropped chunk's OWN wire timestamp via
+// onDropAt (so the supervisor can suppress the TC whose HTTP window
+// contains it), and a successful push must report nothing. A regression
+// that stops threading the timestamp — or reverts drop() to not calling
+// onDropAt — makes this fail.
+func TestTee_DropRecordsWindowAt(t *testing.T) {
+	t.Parallel()
+	stamp := time.Unix(1700000000, 12345)
+	chunkAt := func(payload string) fakeconn.Chunk {
+		return fakeconn.Chunk{Dir: fakeconn.FromClient, Bytes: []byte(payload), ReadAt: stamp}
+	}
+
+	// memory_pressure
+	var paused atomic.Bool
+	paused.Store(true)
+	tt, _, rec := newTestTee(t, 1<<20, 4, paused.Load)
+	if tt.push(chunkAt("x")) {
+		t.Fatalf("push should have dropped under memory pressure")
+	}
+	reasons, tss := rec.atSnapshot()
+	if len(reasons) != 1 || reasons[0] != DropMemoryPressure {
+		t.Fatalf("want one memory_pressure window, got reasons %v", reasons)
+	}
+	if !tss[0].Equal(stamp) {
+		t.Fatalf("window ts = %v, want the dropped chunk's ReadAt %v", tss[0], stamp)
+	}
+
+	// paused
+	tt2, _, rec2 := newTestTee(t, 1<<20, 4, nil)
+	tt2.setPaused(true)
+	if tt2.push(chunkAt("y")) {
+		t.Fatalf("push while paused should drop")
+	}
+	// per_conn_cap on the same tee after resume (cap 1<<20 won't trip; use a tiny-cap tee)
+	tt3, _, rec3 := newTestTee(t, 4, 16, nil)
+	if !tt3.push(chunkAt("abc")) {
+		t.Fatalf("first push should fit under cap")
+	}
+	if tt3.push(chunkAt("def")) {
+		t.Fatalf("second push should exceed per_conn_cap")
+	}
+	rs2, ts2 := rec2.atSnapshot()
+	if len(rs2) != 1 || rs2[0] != DropPaused || !ts2[0].Equal(stamp) {
+		t.Fatalf("paused: want one paused window at %v, got %v / %v", stamp, rs2, ts2)
+	}
+	rs3, ts3 := rec3.atSnapshot()
+	if len(rs3) != 1 || rs3[0] != DropPerConnCap || !ts3[0].Equal(stamp) {
+		t.Fatalf("per_conn_cap: want one per_conn_cap window at %v, got %v / %v", stamp, rs3, ts3)
+	}
+
+	// A successful push records NO window.
+	tt4, _, rec4 := newTestTee(t, 1<<20, 4, nil)
+	if !tt4.push(chunkAt("ok")) {
+		t.Fatalf("healthy push should succeed")
+	}
+	if rs, _ := rec4.atSnapshot(); len(rs) != 0 {
+		t.Fatalf("healthy push must record no orphan window, got %v", rs)
+	}
+}
+
+// TestTee_DropWindowChannelFullCoalesceFallback covers the paths
+// TestTee_DropRecordsWindowAt does not: the channel_full drop (the
+// primary target of the fix, and the only path where drop() runs after
+// closeMu.RUnlock), per-operation coalescing of a chunk burst, the
+// WrittenAt fallback when ReadAt is unset, and the zero-timestamp guard.
+func TestTee_DropWindowChannelFullCoalesceFallback(t *testing.T) {
+	t.Parallel()
+
+	// --- channel_full + coalescing: many same-instant chunk drops -> ONE window ---
+	stamp := time.Unix(1700000000, 500000)
+	tt, _, rec := newTestTee(t, 1<<30, 1, nil) // buf=1, never drained -> staging fills
+	for i := 0; i < 20; i++ {
+		tt.push(fakeconn.Chunk{Dir: fakeconn.FromClient, Bytes: []byte("x"), ReadAt: stamp})
+	}
+	time.Sleep(20 * time.Millisecond)
+	if rec.count(DropChannelFull) == 0 {
+		t.Fatalf("expected channel_full drops, got %v", rec.snapshot())
+	}
+	rs, tss := rec.atSnapshot()
+	if len(rs) != 1 {
+		t.Fatalf("coalescing failed: want exactly 1 window for the same-instant burst, got %d (%v)", len(rs), rs)
+	}
+	if rs[0] != DropChannelFull || !tss[0].Equal(stamp) {
+		t.Fatalf("want one channel_full window at %v, got %v / %v", stamp, rs, tss)
+	}
+
+	// --- distinct operations (>1ms apart) each keep their own window ---
+	// Use the paused path so every push drops deterministically (the
+	// channel_full path races the drain goroutine on which pushes drop).
+	var alwaysPaused atomic.Bool
+	alwaysPaused.Store(true)
+	tt2, _, rec2 := newTestTee(t, 1<<30, 4, alwaysPaused.Load)
+	base := time.Unix(1700000000, 0)
+	for i := 0; i < 6; i++ {
+		ts := base.Add(time.Duration(i) * 2 * time.Millisecond) // 2ms apart
+		if tt2.push(fakeconn.Chunk{Dir: fakeconn.FromClient, Bytes: []byte("y"), ReadAt: ts}) {
+			t.Fatalf("push should drop under pressure")
+		}
+	}
+	if rs2, _ := rec2.atSnapshot(); len(rs2) != 6 {
+		t.Fatalf("distinct 2ms-apart drops must each record (no coalescing): want 6 windows, got %d", len(rs2))
+	}
+
+	// --- WrittenAt fallback when ReadAt is zero (dest-side pre-forward stamp) ---
+	var paused atomic.Bool
+	paused.Store(true)
+	tt3, _, rec3 := newTestTee(t, 1<<20, 4, paused.Load)
+	wStamp := time.Unix(1700000001, 777)
+	if tt3.push(fakeconn.Chunk{Dir: fakeconn.FromDest, Bytes: []byte("z"), WrittenAt: wStamp}) {
+		t.Fatalf("push should drop under pressure")
+	}
+	if rs3, ts3 := rec3.atSnapshot(); len(rs3) != 1 || !ts3[0].Equal(wStamp) {
+		t.Fatalf("WrittenAt fallback: want one window at %v, got %v / %v", wStamp, rs3, ts3)
+	}
+
+	// --- zero-timestamp chunk records NO window ---
+	tt4, _, rec4 := newTestTee(t, 1<<20, 4, paused.Load)
+	if tt4.push(fakeconn.Chunk{Dir: fakeconn.FromClient, Bytes: []byte("q")}) {
+		t.Fatalf("push should drop under pressure")
+	}
+	if rs4, _ := rec4.atSnapshot(); len(rs4) != 0 {
+		t.Fatalf("zero-ts chunk must record no window, got %v", rs4)
+	}
+}
+
 func TestTee_ClosePreventsSendPanic(t *testing.T) {
 	t.Parallel()
-	tt := newTee(fakeconn.FromClient, 1<<20, 4, nil, nil, nil)
+	tt := newTee(fakeconn.FromClient, 1<<20, 4, nil, nil, nil, nil)
 
 	// Spawn pushers racing with close; no panic expected.
 	var wg sync.WaitGroup
@@ -169,7 +317,7 @@ func TestTee_ClosePreventsSendPanic(t *testing.T) {
 
 func TestTee_CloseIsIdempotent(t *testing.T) {
 	t.Parallel()
-	tt := newTee(fakeconn.FromClient, 1<<20, 4, nil, nil, nil)
+	tt := newTee(fakeconn.FromClient, 1<<20, 4, nil, nil, nil, nil)
 	tt.close()
 	tt.close() // must not panic
 	tt.waitDone()
@@ -195,7 +343,7 @@ func TestTee_StagedChunkSurvivesClose(t *testing.T) {
 	const iters = 200
 	for i := 0; i < iters; i++ {
 		rec := &dropRecorder{}
-		tt := newTee(fakeconn.FromClient, 1<<30, 4, nil, rec.record, nil)
+		tt := newTee(fakeconn.FromClient, 1<<30, 4, nil, rec.record, rec.recordAt, nil)
 
 		// Admit a chunk into staging, then immediately tear the tee
 		// down — mirroring the forwarder pushing the final response

--- a/pkg/agent/proxy/supervisor/orphan_window_test.go
+++ b/pkg/agent/proxy/supervisor/orphan_window_test.go
@@ -1,0 +1,160 @@
+package supervisor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	syncMock "go.keploy.io/server/v3/pkg/agent/proxy/syncMock"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap/zaptest"
+)
+
+// TestEmitMockIncompleteRecordsOrphanWindow is the root-cause repro for the
+// go-memory-load-mongo no_mocks flake. When a parser marks its mock incomplete
+// (reassembly overflow, a decode error on the post-pressure realignment tail,
+// per-conn cap, short write) the NEXT emitMockCore drops the mock SILENTLY —
+// and before this fix it told NO ONE, so the test case that owns the operation
+// still streamed to the CLI and reached replay mock-less (match_phase=no_mocks).
+// The fix records the dropped mock's wire window as an orphan window so
+// record.go suppresses the owning TC. This drives the real EmitMock path.
+func TestEmitMockIncompleteRecordsOrphanWindow(t *testing.T) {
+	t.Parallel()
+	mgr := &syncMock.SyncMockManager{}
+	ch := make(chan *models.Mock, 1)
+	base := time.Now()
+	reqTs := base.Add(10 * time.Millisecond)
+	resTs := base.Add(30 * time.Millisecond)
+	sess := &Session{
+		Mocks:  ch,
+		Ctx:    context.Background(),
+		Logger: zaptest.NewLogger(t),
+		Mgr:    mgr,
+	}
+
+	// Precondition (the bug): with no orphan window recorded, a TC whose HTTP
+	// window spans the operation is NOT suppressible — it would reach replay.
+	if ok, _ := mgr.WasMockOrphanedInWindow(base, base.Add(50*time.Millisecond)); ok {
+		t.Fatalf("no orphan window should exist before any incomplete drop")
+	}
+
+	// A mock is voided by the incomplete flag; its wire window is [reqTs, resTs].
+	sess.MarkMockIncomplete("request decode error")
+	dropped := &models.Mock{
+		Name: "find-customers",
+		Spec: models.MockSpec{ReqTimestampMock: reqTs, ResTimestampMock: resTs},
+	}
+	if err := sess.EmitMock(dropped); err != nil {
+		t.Fatalf("EmitMock returned err: %v", err)
+	}
+
+	// The mock itself must NOT have leaked to the sink (still dropped).
+	select {
+	case got := <-ch:
+		t.Fatalf("incomplete mock leaked to channel: %v", got.Name)
+	default:
+	}
+
+	// The fix: the owning TC (HTTP window overlapping [reqTs, resTs]) is now
+	// suppressible via the recorded orphan window.
+	if ok, cnt := mgr.WasMockOrphanedInWindow(base, base.Add(50*time.Millisecond)); !ok || cnt != 1 {
+		t.Fatalf("incomplete drop must record an orphan window over the mock's wire window; got ok=%v cnt=%d", ok, cnt)
+	}
+	// A concurrent TC that does NOT overlap the voided op is not suppressed.
+	if ok, _ := mgr.WasMockOrphanedInWindow(base.Add(100*time.Millisecond), base.Add(200*time.Millisecond)); ok {
+		t.Fatalf("a TC window not overlapping the voided op must not be suppressed")
+	}
+}
+
+// TestEmitMockIncompleteSkipsSessionLifetimeMock pins the guard that a voided
+// SESSION/CONNECTION mock (a reusable mongo handshake/heartbeat, served from
+// the session tier at replay regardless of the drop) does NOT record an orphan
+// window — recording it would only risk over-suppressing a healthy per-test TC
+// that overlaps its window, since a stale mockIncomplete flag can void a
+// reusable mock that belongs to no test at all.
+func TestEmitMockIncompleteSkipsSessionLifetimeMock(t *testing.T) {
+	t.Parallel()
+	for _, lt := range []models.Lifetime{models.LifetimeSession, models.LifetimeConnection} {
+		mgr := &syncMock.SyncMockManager{}
+		sess := &Session{
+			Mocks:  make(chan *models.Mock, 1),
+			Ctx:    context.Background(),
+			Logger: zaptest.NewLogger(t),
+			Mgr:    mgr,
+		}
+		sess.MarkMockIncomplete("memory_pressure")
+		reusable := &models.Mock{
+			Name: "hello-heartbeat",
+			Spec: models.MockSpec{
+				ReqTimestampMock: time.Now(),
+				ResTimestampMock: time.Now().Add(time.Millisecond),
+			},
+			TestModeInfo: models.TestModeInfo{Lifetime: lt},
+		}
+		if err := sess.EmitMock(reusable); err != nil {
+			t.Fatalf("EmitMock: %v", err)
+		}
+		if got := mgr.OrphanRangeCount(); got != 0 {
+			t.Fatalf("a voided %v mock must NOT record an orphan window; count=%d", lt, got)
+		}
+	}
+}
+
+// TestEmitMockHealthyRecordsNoOrphanWindow is the control: a normal emit (no
+// incomplete flag) must NOT record an orphan window, so healthy TCs are never
+// spuriously suppressed.
+func TestEmitMockHealthyRecordsNoOrphanWindow(t *testing.T) {
+	t.Parallel()
+	mgr := &syncMock.SyncMockManager{}
+	ch := make(chan *models.Mock, 1)
+	sess := &Session{
+		Mocks:  ch,
+		Ctx:    context.Background(),
+		Logger: zaptest.NewLogger(t),
+		Mgr:    mgr,
+	}
+	// RouteMocksViaSyncMock is false → direct-channel emit; the mock delivers
+	// and NO orphan window is recorded.
+	m := &models.Mock{Name: "ok", Spec: models.MockSpec{ReqTimestampMock: time.Now()}}
+	if err := sess.EmitMock(m); err != nil {
+		t.Fatalf("EmitMock: %v", err)
+	}
+	if got := mgr.OrphanRangeCount(); got != 0 {
+		t.Fatalf("healthy emit must not record an orphan window; count=%d", got)
+	}
+	select {
+	case got := <-ch:
+		if got.Name != "ok" {
+			t.Fatalf("wrong mock delivered: %v", got.Name)
+		}
+	default:
+		t.Fatalf("healthy mock was not delivered")
+	}
+}
+
+// TestRecordOrphanWindowPublicPath covers the no-mock-built case: a parser that
+// voids an operation BEFORE any mock is emitted (reassembly overflow, decode
+// error) reports the operation's own wire window via Session.RecordOrphanWindow,
+// making that TC suppressible even though emitMockCore never ran for it. Also
+// pins the nil-session and zero-start guards are no-ops.
+func TestRecordOrphanWindowPublicPath(t *testing.T) {
+	t.Parallel()
+	mgr := &syncMock.SyncMockManager{}
+	sess := &Session{Ctx: context.Background(), Mgr: mgr}
+
+	opStart := time.Now()
+	opEnd := opStart.Add(5 * time.Millisecond)
+	sess.RecordOrphanWindow(opStart, opEnd)
+
+	if ok, _ := mgr.WasMockOrphanedInWindow(opStart.Add(-time.Millisecond), opEnd.Add(time.Millisecond)); !ok {
+		t.Fatalf("RecordOrphanWindow must make the failing op's TC suppressible")
+	}
+
+	// Guards: nil session and zero-start are no-ops (must not panic or record).
+	var nilSess *Session
+	nilSess.RecordOrphanWindow(opStart, opEnd)
+	sess.RecordOrphanWindow(time.Time{}, opEnd)
+	if got := mgr.OrphanRangeCount(); got != 1 {
+		t.Fatalf("guards must be no-ops; expected exactly 1 window, got %d", got)
+	}
+}

--- a/pkg/agent/proxy/supervisor/session.go
+++ b/pkg/agent/proxy/supervisor/session.go
@@ -188,9 +188,18 @@ func (s *Session) AddPostRecordHook(h PostRecordHook) {
 // "why was a mock withheld?" (memory pressure, channel full, dropped
 // chunk, parser-internal inconsistency) can enable --debug to see it;
 // subsequent calls within the same session are no-ops and emit nothing.
-// Production runs stay quiet because the forward path is unaffected —
-// only mock recording is impacted, which is an internal concern not a
-// user-facing problem.
+// Production runs stay quiet because the forward path is unaffected.
+//
+// A voided mock is NOT harmless: the test case that owns the operation
+// still streams to the CLI, so dropping its mock silently orphans that TC
+// at replay (match_phase=no_mocks). When a mock DOES reach emitMockCore
+// and is dropped by this flag, emitMockCore records the mock's wire window
+// as an orphan window so record.go suppresses the owning TC. When the
+// parser voids an operation BEFORE any mock is built (a reassembly
+// overflow, or a decode error on the realignment tail after a
+// memory-pressure gap), no mock reaches emitMockCore — the parser should
+// additionally call Session.RecordOrphanWindow with that operation's wire
+// window so its TC is suppressed too.
 //
 // The relay calls this when it gates a chunk at the tee; parsers call
 // it when they cannot continue decoding a mock cleanly. Safe to call
@@ -222,6 +231,37 @@ func (s *Session) IsMockIncomplete() bool {
 		return false
 	}
 	return s.mockIncomplete.Load()
+}
+
+// orphanManager resolves the SyncMockManager this session records into,
+// preferring the per-app s.Mgr and falling back to the package-global. Mirrors
+// the manager resolution in emitMockCore's RouteMocksViaSyncMock branch so an
+// orphan window lands on the SAME manager that owns the dropped mock.
+func (s *Session) orphanManager() *syncMock.SyncMockManager {
+	if s == nil {
+		return nil
+	}
+	if s.Mgr != nil {
+		return s.Mgr
+	}
+	return syncMock.Get()
+}
+
+// RecordOrphanWindow lets a parser report that the operation whose wire window
+// is [start, end] lost its mock because the parser could not build one at all —
+// e.g. a client/server reassembly overflow, or a decode error on the
+// realignment tail after a memory-pressure gap. In those cases NO mock reaches
+// emitMockCore (the mockIncomplete flag instead voids the NEXT mock, which may
+// belong to a different TC), so the failing operation's own TC would leak
+// unless the parser reports its window here. record.go then suppresses any TC
+// whose HTTP window overlaps. Complements MarkMockIncomplete: MarkMockIncomplete
+// voids the mock; RecordOrphanWindow makes that void visible to TC suppression
+// by the operation's own captured timestamps. Safe with a nil session or a zero
+// start (both no-ops — see (*SyncMockManager).RecordOrphanWindow).
+func (s *Session) RecordOrphanWindow(start, end time.Time) {
+	if mgr := s.orphanManager(); mgr != nil {
+		mgr.RecordOrphanWindow(start, end)
+	}
 }
 
 // EmitMock sends m to the mocks channel. If the session's active mock
@@ -309,6 +349,29 @@ func (s *Session) emitMockCore(m *models.Mock, shutdown bool) error {
 		// connection goes idle, producing spurious aborts after a
 		// benign drop (memory pressure, chunk gate, short write).
 		s.mockIncomplete.Store(false)
+		// The mock is abandoned, but the test case that owns this
+		// operation still streams to the CLI — dropping the mock without
+		// telling anyone orphans that TC (replay match_phase=no_mocks).
+		// Record the mock's own wire window as an orphan window so
+		// record.go suppresses the owning TC, exactly as it does for a
+		// memory-pressure drop via WasPressureActiveInWindow. The
+		// timestamps are the parser's captured values — the same clock the
+		// TC's HTTP window is compared against — so a zero timestamp
+		// (parser left it unset) is simply ignored by RecordOrphanWindow
+		// rather than over-claiming.
+		//
+		// Only PER-TEST mocks orphan a specific TC. A voided SESSION or
+		// CONNECTION mock (a mongo handshake/heartbeat and the like) is
+		// reusable and served from the session tier at replay regardless of
+		// this drop, so recording its window would gain nothing and only
+		// risk over-suppressing a healthy per-test TC that happens to
+		// overlap it. Skip those — the stale mockIncomplete flag can void a
+		// reusable mock that belongs to no test at all.
+		if mgr := s.orphanManager(); mgr != nil &&
+			m.TestModeInfo.Lifetime != models.LifetimeSession &&
+			m.TestModeInfo.Lifetime != models.LifetimeConnection {
+			mgr.RecordOrphanWindow(m.Spec.ReqTimestampMock, m.Spec.ResTimestampMock)
+		}
 		if s.Logger != nil {
 			// Debug-level: this fires on every mock that loses an
 			// upstream chunk (per-request frequency on a misconfigured

--- a/pkg/agent/proxy/supervisor/supervisor.go
+++ b/pkg/agent/proxy/supervisor/supervisor.go
@@ -115,6 +115,15 @@ type Supervisor struct {
 	// abortOnce guards SessionOnAbort invocation.
 	abortOnce sync.Once
 
+	// parserDone is closed when the parser goroutine launched by Run has
+	// fully returned. On the fallthrough abort paths (hang, outer-cancel
+	// grace) Run returns BEFORE the parser goroutine exits — it unblocks
+	// asynchronously once SessionOnAbort closes its FakeConns. A caller that
+	// reuses the underlying streams (abort-recovery in proxy_v2.go) must wait
+	// on this before handing those streams to a new generation, otherwise the
+	// still-live old goroutine can steal a chunk off the shared tee channel.
+	parserDone chan struct{}
+
 	// closed guards repeated Close calls.
 	closed atomic.Bool
 }
@@ -141,6 +150,7 @@ func New(cfg Config) *Supervisor {
 		hungCh:     make(chan struct{}),
 		wdStop:     make(chan struct{}),
 		wdDone:     make(chan struct{}),
+		parserDone: make(chan struct{}),
 	}
 	s.lastProgressNano.Store(time.Now().UnixNano())
 	go s.watchdogLoop()
@@ -168,6 +178,12 @@ func (s *Supervisor) SetActivityProbe(fn func() bool) {
 		s.activityProbe.Store(&fn)
 	}
 }
+
+// ParserDone returns a channel closed when the parser goroutine started by Run
+// has fully returned. It is closed even on the fallthrough abort paths where
+// Run itself returns early, so a caller that recycles the parser's streams can
+// wait for the old goroutine to retire before reattaching them.
+func (s *Supervisor) ParserDone() <-chan struct{} { return s.parserDone }
 
 // MarkPendingWork indicates an in-flight request is awaiting a
 // response. The watchdog only fires while pending. Calling it when
@@ -257,6 +273,10 @@ func (s *Supervisor) Run(ctx context.Context, fn ParserFunc, sess *Session) Resu
 				}
 			}
 			done <- ret
+			// Signal exit AFTER publishing the result so a caller waiting on
+			// ParserDone observes a fully-retired goroutine (no lingering
+			// read of the shared streams).
+			close(s.parserDone)
 		}()
 		ret.err = fn(runCtx, sess)
 	}()

--- a/pkg/agent/proxy/supervisor/supervisor.go
+++ b/pkg/agent/proxy/supervisor/supervisor.go
@@ -73,6 +73,15 @@ type Supervisor struct {
 	lastProgressNano atomic.Int64
 	pending          atomic.Bool
 
+	// activityProbe, when set, reports whether the parser currently
+	// has unconsumed input (bytes staged/queued but not yet read).
+	// The watchdog declares a hang only when the probe is absent or
+	// returns true, so a parser idle-blocked on an empty read — a
+	// pooled connection between requests — is never false-hanged.
+	// Wired by the dispatcher to the relay's buffered-input check via
+	// SetActivityProbe, after the relay is built but before Run.
+	activityProbe atomic.Pointer[func() bool]
+
 	// Abort path: hung is closed by the watchdog when the activity
 	// budget is exceeded while pending work is outstanding.
 	// memCapExceeded is set by callers that detect a memory-cap
@@ -143,6 +152,21 @@ func New(cfg Config) *Supervisor {
 // timer. Cheap; a single atomic store.
 func (s *Supervisor) BumpActivity() {
 	s.lastProgressNano.Store(time.Now().UnixNano())
+}
+
+// SetActivityProbe installs a probe the hang watchdog consults before
+// declaring a parser hung: the hang fires only when the probe is absent
+// or reports unconsumed input. This lets the dispatcher distinguish a
+// parser genuinely stuck with work to do (abort it) from one merely
+// idle-blocked waiting for the next request on a quiet pooled connection
+// (leave it alone — aborting would PauseTees the connection and
+// permanently stop recording even though it is alive and will be
+// reused). Call once between New and Run; a nil fn is ignored, leaving
+// the legacy always-eligible behaviour.
+func (s *Supervisor) SetActivityProbe(fn func() bool) {
+	if fn != nil {
+		s.activityProbe.Store(&fn)
+	}
 }
 
 // MarkPendingWork indicates an in-flight request is awaiting a
@@ -415,6 +439,21 @@ func (s *Supervisor) watchdogLoop() {
 				continue
 			}
 			if time.Since(time.Unix(0, last)) > s.cfg.HangBudget {
+				// Only a parser that still has unconsumed input can be
+				// "hung": one blocked on an empty read is idle-waiting
+				// for the next request (normal for a pooled connection),
+				// not stuck. Aborting it fires SessionOnAbort →
+				// PauseTees and permanently stops recording on a live
+				// connection that will be reused — the recording dead
+				// zone. Re-check next tick; a genuine stall keeps the
+				// probe true and fires then. (A parser that consumed all
+				// input and then spins with no new bytes arriving is the
+				// one residual case this does not catch; in the V2
+				// architecture the relay forwards independently so that
+				// leaks at most a goroutine and never stalls traffic.)
+				if p := s.activityProbe.Load(); p != nil && !(*p)() {
+					continue
+				}
 				s.hungOnce.Do(func() { close(s.hungCh) })
 				return
 			}

--- a/pkg/agent/proxy/supervisor/supervisor_test.go
+++ b/pkg/agent/proxy/supervisor/supervisor_test.go
@@ -197,6 +197,82 @@ func TestHangNotDetectedWhenIdle(t *testing.T) {
 	}
 }
 
+// TestHangNotFiredWhenIdleNoUnconsumedInput is the regression for the
+// go-memory-load-mongo recording dead zone. A pooled connection whose
+// last exchange was abandoned (its response dropped under memory
+// pressure, so no mock cleared `pending`) sits idle between requests
+// with the parser blocked on an empty read. The activity probe reports
+// no unconsumed input; the watchdog MUST NOT declare a hang, because
+// aborting would PauseTees the live connection and permanently stop
+// recording. Without the probe gate this false-hangs after the budget.
+func TestHangNotFiredWhenIdleNoUnconsumedInput(t *testing.T) {
+	t.Parallel()
+	aborted := make(chan struct{})
+	s := New(shortCfg(t)) // 50ms budget
+	s.SessionOnAbort = func() { close(aborted) }
+	// Parser is idle: caught up, nothing left to read.
+	s.SetActivityProbe(func() bool { return false })
+	// A request was teed but never produced a mock (abandoned exchange),
+	// so `pending` is stuck armed.
+	s.MarkPendingWork()
+
+	done := make(chan Result, 1)
+	go func() {
+		done <- s.Run(context.Background(),
+			func(ctx context.Context, sess *Session) error {
+				<-ctx.Done()
+				return ctx.Err()
+			},
+			&Session{})
+	}()
+
+	// Five budgets of wallclock: an idle parser must survive.
+	select {
+	case r := <-done:
+		t.Fatalf("watchdog aborted an idle parser (false-hang): %+v", r)
+	case <-aborted:
+		t.Fatalf("SessionOnAbort fired for an idle parser (false-hang)")
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	// Cleanup.
+	s.Close()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatalf("parser did not exit after Close")
+	}
+}
+
+// TestHangFiredWhenUnconsumedInputPresent proves the probe gate does not
+// weaken genuine hang detection: a parser that still has unconsumed
+// input but makes no progress within the budget is still aborted.
+func TestHangFiredWhenUnconsumedInputPresent(t *testing.T) {
+	t.Parallel()
+	aborted := make(chan struct{})
+	s := New(shortCfg(t))
+	s.SessionOnAbort = func() { close(aborted) }
+	// Parser has input it is failing to make progress on.
+	s.SetActivityProbe(func() bool { return true })
+	s.MarkPendingWork()
+
+	res := s.Run(context.Background(),
+		func(ctx context.Context, sess *Session) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+		&Session{})
+
+	if res.Status != StatusHung {
+		t.Fatalf("status: got %s, want hung", res.Status)
+	}
+	select {
+	case <-aborted:
+	case <-time.After(time.Second):
+		t.Fatalf("SessionOnAbort not invoked for a genuinely stuck parser")
+	}
+}
+
 func TestHangResetOnActivity(t *testing.T) {
 	t.Parallel()
 	cfg := Config{

--- a/pkg/agent/proxy/supervisor/supervisor_test.go
+++ b/pkg/agent/proxy/supervisor/supervisor_test.go
@@ -273,6 +273,61 @@ func TestHangFiredWhenUnconsumedInputPresent(t *testing.T) {
 	}
 }
 
+// TestParserDoneSignalsGoroutineExitAfterHang locks in the invariant
+// abort-recovery relies on: on the hang path Run returns BEFORE the parser
+// goroutine exits (it is parked off-ctx, e.g. blocked in FakeConn.Read), and
+// ParserDone stays open until that goroutine actually returns. Recovery waits
+// on ParserDone before reattaching the parser's streams so the dying goroutine
+// cannot steal a resumed chunk off the shared tee channel.
+func TestParserDoneSignalsGoroutineExitAfterHang(t *testing.T) {
+	t.Parallel()
+	s := New(shortCfg(t))
+	// Parser has unconsumed input but makes no progress -> hang fires.
+	s.SetActivityProbe(func() bool { return true })
+	s.MarkPendingWork()
+
+	release := make(chan struct{})
+	exited := make(chan struct{})
+
+	res := s.Run(context.Background(),
+		func(ctx context.Context, sess *Session) error {
+			// Deliberately ignore ctx cancellation to model a parser parked in
+			// FakeConn.Read (which does not observe ctx and only unblocks on
+			// Close). It returns only when the test releases it — standing in
+			// for SessionOnAbort closing the FakeConns.
+			<-release
+			close(exited)
+			return nil
+		},
+		&Session{})
+
+	if res.Status != StatusHung {
+		t.Fatalf("status: got %s, want hung", res.Status)
+	}
+
+	// Run has returned on the hang path, but the parser goroutine is still
+	// blocked on release. ParserDone MUST NOT be closed yet.
+	select {
+	case <-s.ParserDone():
+		t.Fatal("ParserDone closed while the parser goroutine is still alive")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Release the parser (models SessionOnAbort unblocking the read).
+	close(release)
+
+	select {
+	case <-s.ParserDone():
+	case <-time.After(time.Second):
+		t.Fatal("ParserDone did not close after the parser goroutine exited")
+	}
+	select {
+	case <-exited:
+	case <-time.After(time.Second):
+		t.Fatal("parser goroutine did not return")
+	}
+}
+
 func TestHangResetOnActivity(t *testing.T) {
 	t.Parallel()
 	cfg := Config{

--- a/pkg/agent/proxy/syncMock/orphan_window_test.go
+++ b/pkg/agent/proxy/syncMock/orphan_window_test.go
@@ -1,0 +1,137 @@
+package manager
+
+import (
+	"testing"
+	"time"
+)
+
+// TestOrphanWindowOverlapSemantics pins the join contract record.go relies on:
+// a recorded non-pressure mock-void window suppresses exactly the TCs whose
+// HTTP [req, resp] window overlaps it, and no others.
+func TestOrphanWindowOverlapSemantics(t *testing.T) {
+	t.Parallel()
+	mgr := &SyncMockManager{}
+	base := time.Now()
+	ms := func(n int) time.Time { return base.Add(time.Duration(n) * time.Millisecond) }
+
+	// A mock voided over the wire window [10ms, 20ms].
+	mgr.RecordOrphanWindow(ms(10), ms(20))
+
+	// A TC whose HTTP window [0, 15ms] straddles the void → suppressed.
+	if ok, cnt := mgr.WasMockOrphanedInWindow(ms(0), ms(15)); !ok || cnt != 1 {
+		t.Fatalf("straddling TC window must be suppressed; got ok=%v cnt=%d", ok, cnt)
+	}
+	// A TC fully inside the void → suppressed.
+	if ok, _ := mgr.WasMockOrphanedInWindow(ms(12), ms(18)); !ok {
+		t.Fatalf("TC window inside the void must be suppressed")
+	}
+	// A TC that touches the boundary (end == void.start) → overlaps (closed
+	// intervals), suppressed.
+	if ok, _ := mgr.WasMockOrphanedInWindow(ms(5), ms(10)); !ok {
+		t.Fatalf("boundary-touching TC window must be suppressed")
+	}
+	// A TC entirely after the void → NOT suppressed (no over-suppression of a
+	// concurrent TC that kept all its mocks).
+	if ok, _ := mgr.WasMockOrphanedInWindow(ms(30), ms(40)); ok {
+		t.Fatalf("non-overlapping TC window must NOT be suppressed")
+	}
+	// A TC entirely before the void ([0, 5ms] ends before void start 10ms) →
+	// NOT suppressed.
+	if ok, _ := mgr.WasMockOrphanedInWindow(ms(0), ms(5)); ok {
+		t.Fatalf("TC window ending before the void start must NOT be suppressed")
+	}
+}
+
+// TestOrphanWindowDegenerateInputs pins the guards: a zero start is ignored
+// (never poison the suppressor into over-claiming), a zero/inverted end is
+// clamped to a valid point interval, and a degenerate TC query is refused
+// rather than matching everything.
+func TestOrphanWindowDegenerateInputs(t *testing.T) {
+	t.Parallel()
+	mgr := &SyncMockManager{}
+	base := time.Now()
+
+	// Zero start → ignored, records nothing.
+	mgr.RecordOrphanWindow(time.Time{}, base)
+	if got := mgr.OrphanRangeCount(); got != 0 {
+		t.Fatalf("zero-start orphan window must be ignored; count=%d", got)
+	}
+
+	// Zero end → clamped to start (a point interval at `base`).
+	mgr.RecordOrphanWindow(base, time.Time{})
+	if got := mgr.OrphanRangeCount(); got != 1 {
+		t.Fatalf("zero-end window must still record as a point; count=%d", got)
+	}
+	if ok, _ := mgr.WasMockOrphanedInWindow(base.Add(-time.Millisecond), base.Add(time.Millisecond)); !ok {
+		t.Fatalf("a TC window spanning the point void must be suppressed")
+	}
+
+	// Inverted end (before start) → clamped to start (point interval).
+	mgr.RecordOrphanWindow(base.Add(100*time.Millisecond), base.Add(50*time.Millisecond))
+	if ok, _ := mgr.WasMockOrphanedInWindow(base.Add(99*time.Millisecond), base.Add(101*time.Millisecond)); !ok {
+		t.Fatalf("inverted-end window must clamp to a point at start and still suppress")
+	}
+
+	// Degenerate TC query (zero start or end) → refused, never over-suppresses.
+	if ok, _ := mgr.WasMockOrphanedInWindow(time.Time{}, base); ok {
+		t.Fatalf("zero-start TC query must be refused")
+	}
+	if ok, _ := mgr.WasMockOrphanedInWindow(base, time.Time{}); ok {
+		t.Fatalf("zero-end TC query must be refused")
+	}
+}
+
+// TestOrphanRangeCountBoundedAndEvictsOldest pins that orphanRanges stays
+// count-bounded under a continuous stream of voids: it grows to at most 2×cap
+// then compacts IN PLACE back toward cap (the amortized-O(1) scheme that avoids
+// a per-call realloc on the hot per-void path), and compaction evicts the
+// OLDEST windows first — so a lagging record.go still sees the most recent
+// voids it might need to suppress.
+func TestOrphanRangeCountBoundedAndEvictsOldest(t *testing.T) {
+	t.Parallel()
+	mgr := &SyncMockManager{}
+	base := time.Now()
+	ms := func(n int) time.Time { return base.Add(time.Duration(n) * time.Millisecond) }
+
+	// Insert past the 2×cap compaction trigger so eviction fires at least once.
+	total := 2*maxPressureRanges + 100
+	for i := 0; i < total; i++ {
+		mgr.RecordOrphanWindow(ms(i), ms(i))
+	}
+	// Count must stay within [cap, 2×cap] — never unbounded.
+	got := mgr.OrphanRangeCount()
+	if got < maxPressureRanges || got > 2*maxPressureRanges {
+		t.Fatalf("orphanRanges count must stay in [%d, %d]; got %d", maxPressureRanges, 2*maxPressureRanges, got)
+	}
+	// The oldest window was evicted by compaction → no longer suppressible.
+	if ok, _ := mgr.WasMockOrphanedInWindow(ms(0), ms(0)); ok {
+		t.Fatalf("oldest orphan window must be evicted after compaction")
+	}
+	// The newest window is retained.
+	last := ms(total - 1)
+	if ok, _ := mgr.WasMockOrphanedInWindow(last, last); !ok {
+		t.Fatalf("newest orphan window must be retained")
+	}
+}
+
+// TestOrphanWindowIndependentOfPressureRanges pins that the two suppressors are
+// separate: recording an orphan window does not create a pressure range and
+// vice-versa, so the session-summary telemetry (pressure_ranges_total vs
+// orphan_ranges_total) stays accurate.
+func TestOrphanWindowIndependentOfPressureRanges(t *testing.T) {
+	t.Parallel()
+	mgr := &SyncMockManager{}
+	base := time.Now()
+
+	mgr.RecordOrphanWindow(base, base.Add(time.Millisecond))
+	if mgr.PressureRangeCount() != 0 {
+		t.Fatalf("orphan window must not create a pressure range")
+	}
+	if got := mgr.OrphanRangeCount(); got != 1 {
+		t.Fatalf("expected 1 orphan range, got %d", got)
+	}
+	// A pressure-only window is not seen by the orphan query.
+	if ok, _ := mgr.WasPressureActiveInWindow(base, base.Add(time.Millisecond)); ok {
+		t.Fatalf("no pressure range should exist")
+	}
+}

--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -224,6 +224,25 @@ type SyncMockManager struct {
 	// intervals and slowing every overlap scan.
 	pressureRanges []pressureRange
 
+	// orphanRanges records every [start, end] wire window over which a mock was
+	// VOIDED for a reason OTHER than memory pressure — a parser marked its mock
+	// incomplete (client/server reassembly overflow, a decode error on the
+	// realignment tail after a memory-pressure gap, per-conn cap, short write)
+	// so supervisor.emitMockCore dropped it, or the parser reported the failing
+	// operation's window directly. It is the exact complement of pressureRanges:
+	// memory-pressure drops happen while memoryguard.IsRecordingPaused() is true
+	// and therefore fall inside a pressureRanges interval, but these voids happen
+	// while recording is NOT paused, so WasPressureActiveInWindow structurally
+	// cannot see them and the orphaned TC would reach replay mock-less
+	// (match_phase=no_mocks). WasMockOrphanedInWindow checks overlap against a
+	// TC's [HTTPReq.Timestamp, HTTPResp.Timestamp] window with the same interval
+	// semantics as pressureRanges, and record.go ORs the two. Count-bounded at
+	// maxPressureRanges (oldest evicted), guarded by mu — a continuous stream of
+	// voids can't grow it unbounded or slow the overlap scan. Entries always
+	// carry a concrete end (RecordOrphanWindow clamps a zero/degenerate end to
+	// start), so no open-interval "extend to now" handling is needed here.
+	orphanRanges []pressureRange
+
 	// loggerMu guards logger so SetLogger and the drop path can run
 	// concurrently without a data race. The read lock is taken only
 	// on the (sampled, cold) Error path, so contention is negligible.
@@ -992,6 +1011,73 @@ func (m *SyncMockManager) PressureRangeCount() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return len(m.pressureRanges)
+}
+
+// RecordOrphanWindow records that a mock owned by some test case was voided
+// over the wire window [start, end] for a NON-pressure reason (a parser marked
+// it incomplete, or emitMockCore dropped it under the mockIncomplete flag).
+// record.go suppresses any TC whose HTTP [req, resp] window overlaps, so the
+// orphaned TC is not streamed mock-less. A degenerate window (start == end, a
+// single operation instant) is valid — the overlap test treats it as a
+// zero-width interval. Bounded by count like pressureRanges (oldest evicted).
+//
+// A zero start is IGNORED: a caller with no reliable wire timestamp must not
+// poison the suppressor into over-claiming (which would silently drop healthy
+// TCs). A zero or inverted end is clamped to start so the entry is a valid
+// point interval rather than an empty or reversed one.
+func (m *SyncMockManager) RecordOrphanWindow(start, end time.Time) {
+	if m == nil || start.IsZero() {
+		return
+	}
+	if end.IsZero() || end.Before(start) {
+		end = start
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.orphanRanges = append(m.orphanRanges, pressureRange{start: start, end: end})
+	// Orphan windows are recorded per voided mock — far more frequently than
+	// pressure ranges (a few per second) — so avoid the reallocate-and-copy on
+	// EVERY call past the cap that SetMemoryPressure can afford. Let the slice
+	// grow to 2×cap, then compact IN PLACE (reuse the backing array, non-
+	// overlapping src/dst) back to the newest cap. Amortized O(1) per call, zero
+	// allocation once warmed, scan bounded at 2×cap, still evicting oldest-first.
+	if n := len(m.orphanRanges); n > 2*maxPressureRanges {
+		m.orphanRanges = append(m.orphanRanges[:0], m.orphanRanges[n-maxPressureRanges:]...)
+	}
+}
+
+// WasMockOrphanedInWindow returns (true, count) if a non-pressure mock void was
+// recorded overlapping [start, end] — the orphan-window twin of
+// WasPressureActiveInWindow. record.go ORs the two so a TC is suppressed
+// whether its mock was lost to memory pressure OR to a parser-side void. Every
+// orphanRanges entry has a concrete end (RecordOrphanWindow guarantees it), so
+// no open-interval handling is needed. Degenerate TC inputs are refused (return
+// false) rather than over-suppressing, matching WasPressureActiveInWindow.
+func (m *SyncMockManager) WasMockOrphanedInWindow(start, end time.Time) (bool, int) {
+	if m == nil || start.IsZero() || end.IsZero() {
+		return false, 0
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	count := 0
+	for _, r := range m.orphanRanges {
+		// Standard interval-overlap test: [r.start, r.end] vs [start, end].
+		if !r.start.After(end) && !r.end.Before(start) {
+			count++
+		}
+	}
+	return count > 0, count
+}
+
+// OrphanRangeCount returns the number of non-pressure mock-void windows
+// recorded so far. Exposed for the session-summary log in routes/record.go.
+func (m *SyncMockManager) OrphanRangeCount() int {
+	if m == nil {
+		return 0
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.orphanRanges)
 }
 
 func (m *SyncMockManager) SetMemoryPressure(enabled bool) {

--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -1029,11 +1029,23 @@ func (m *SyncMockManager) RecordOrphanWindow(start, end time.Time) {
 	if m == nil || start.IsZero() {
 		return
 	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.recordOrphanWindowLocked(start, end)
+}
+
+// recordOrphanWindowLocked appends an orphan window; the caller MUST already
+// hold m.mu. Split out from RecordOrphanWindow so in-loop droppers that already
+// run under m.mu — the stale-cutoff reap in ResolveRange — can record a window
+// without releasing and reacquiring the lock. m.mu is not reentrant, so calling
+// the public method from inside the ResolveRange critical section would deadlock.
+func (m *SyncMockManager) recordOrphanWindowLocked(start, end time.Time) {
+	if start.IsZero() {
+		return
+	}
 	if end.IsZero() || end.Before(start) {
 		end = start
 	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
 	m.orphanRanges = append(m.orphanRanges, pressureRange{start: start, end: end})
 	// Orphan windows are recorded per voided mock — far more frequently than
 	// pressure ranges (a few per second) — so avoid the reallocate-and-copy on
@@ -1445,6 +1457,30 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 		// lifetime carve-out at the top of the loop and never reach
 		// this branch.)
 		if mockTime.Before(cutoffTime) {
+			// This per-test mock decoded too late (the recorder fell behind —
+			// memory-pressure GC pauses under a load spike delay decode by
+			// seconds) to land in any live window, and is now past the 7 s
+			// horizon. Its owning TC was already captured at the ingress, so a
+			// silent reap here strands it: replay finds the operation with no
+			// recorded mock and reports match_phase=no_mocks. This is the tail
+			// of the go-memory-load-mongo flake that survived the pressure-range
+			// and resync-orphan suppressors — both cover the *drop* of chunks,
+			// but here the chunks were delivered and framed; the mock is lost at
+			// this stale-cutoff reap while draining the buffer, out of their reach.
+			//
+			// Record the mock's own wire window as an orphan window so record.go
+			// suppresses the owning TC instead of streaming it mock-less. This
+			// completes the same suppression contract the other post-capture
+			// mock-loss paths already honour — emitMockCore's incomplete-mock
+			// drop records an orphan window (session.go), and the sendToOutChan
+			// capacity drop records the owning TC name (recordDroppedTC) — via
+			// whichever ledger fits; here the wire window is what we have. Only
+			// per-test mocks reach this branch (session/connection tiers are
+			// carved out at the top of the loop), so every reap is a genuine
+			// per-TC orphan. Done under m.mu via the *Locked variant since the
+			// public RecordOrphanWindow would re-lock and deadlock inside this
+			// critical section.
+			m.recordOrphanWindowLocked(mock.Spec.ReqTimestampMock, mock.Spec.ResTimestampMock)
 			// Per-mock diagnostic: a per-test mock that fell off the
 			// stale-buffer cutoff almost always means the recorder
 			// kept emitting after the dedup queue had advanced past

--- a/pkg/agent/proxy/syncMock/syncMock_test.go
+++ b/pkg/agent/proxy/syncMock/syncMock_test.go
@@ -1366,6 +1366,71 @@ func TestResolveRangeRecordsLateMockInOldWindowButDropsOrphan(t *testing.T) {
 	if !sent[0].Spec.ReqTimestampMock.Equal(inWindowTs) {
 		t.Fatalf("expected the in-window mock flushed; got ts %v (orphan must be dropped)", sent[0].Spec.ReqTimestampMock)
 	}
+	// The reaped orphan owns a TC captured at ingress: dropping it from the
+	// output stream is correct, but it MUST leave an orphan window covering its
+	// own wire instant so record.go suppresses that TC instead of streaming it
+	// mock-less. Without this the go-memory-load-mongo stale-cutoff strand
+	// reaches replay as match_phase=no_mocks.
+	if ok, _ := mgr.WasMockOrphanedInWindow(orphanTs, orphanTs); !ok {
+		t.Fatalf("expected an orphan window covering the stale-cutoff-reaped mock at %v", orphanTs)
+	}
+}
+
+// TestStaleCutoffOrphanWindowCoversOwningTCHTTPWindow is the direct regression
+// for the go-memory-load-mongo `no_mocks` tail (keploy #4354): under a memory-
+// pressure load spike the recorder falls behind, a per-test mongo mock decodes
+// >7 s after its request, misses every live window, and is reaped by the stale-
+// cutoff. Its owning test case was already captured at the HTTP ingress, so the
+// reap MUST leave an orphan window spanning the mock's [req, res] wire window;
+// record.go ORs WasMockOrphanedInWindow into its TC suppressor, so a TC whose
+// HTTP [req, resp] window straddles the reaped operation is suppressed rather
+// than streamed mock-less. Verified by mutation: deleting the
+// recordOrphanWindowLocked call in the stale-cutoff branch fails this test.
+func TestStaleCutoffOrphanWindowCoversOwningTCHTTPWindow(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan *models.Mock, 8)
+	mgr := &SyncMockManager{}
+	mgr.SetOutputChannel(ch)
+	mgr.SetFirstRequestSignaled()
+	// Past the startup window so the reaped mock is a genuine non-startup per-
+	// test orphan (inside the window every ingest is tagged IsStartup + rescued).
+	mgr.resolvedTestCount = models.StartupMockTestCaseWindow
+
+	// A mongo mock decoded far too late: its wire window is ancient (>7 s) and
+	// owns no live window, so it hits the stale cutoff. Both timestamps are set,
+	// as on a real recorded mongo exchange (req → response). Kind Mongo matters:
+	// it is NOT in kindsWithImplicitSessionLifetime, so it derives to
+	// LifetimePerTest and genuinely reaches the per-test stale-cutoff branch
+	// rather than being carved out as a session/connection mock upstream.
+	reqTs := time.Now().Add(-25 * time.Second)
+	resTs := reqTs.Add(3 * time.Millisecond)
+	mgr.AddMock(&models.Mock{
+		Kind: models.Mongo,
+		Spec: models.MockSpec{ReqTimestampMock: reqTs, ResTimestampMock: resTs},
+	})
+
+	// A later resolve for an unrelated current test drains the buffer; the
+	// ancient mock is reaped by the stale cutoff.
+	now := time.Now()
+	mgr.ResolveRange(now, now.Add(5*time.Millisecond), "current-test", true, false)
+
+	// The stale mock must NOT have been flushed to the output stream.
+	select {
+	case m := <-ch:
+		t.Fatalf("stale mock must be reaped, not flushed; got ts %v", m.Spec.ReqTimestampMock)
+	default:
+	}
+
+	// The owning TC's HTTP [req, resp] window brackets the mongo operation
+	// (app receives the HTTP request, queries mongo, returns the response), so a
+	// window straddling [reqTs, resTs] must report the mock as orphaned →
+	// record.go suppresses it. Pre-fix this returns false and the TC strands.
+	httpReq := reqTs.Add(-1 * time.Millisecond)
+	httpResp := resTs.Add(1 * time.Millisecond)
+	if ok, n := mgr.WasMockOrphanedInWindow(httpReq, httpResp); !ok {
+		t.Fatalf("expected the reaped stale mock to leave an orphan window covering the owning TC HTTP window [%v,%v] (got ok=%v n=%d)", httpReq, httpResp, ok, n)
+	}
 }
 
 // TestDeleteMocksStrictlyBeforeRescuesLateKeptMock is the regression for

--- a/pkg/agent/proxy/v2_integration_test.go
+++ b/pkg/agent/proxy/v2_integration_test.go
@@ -16,10 +16,12 @@ import (
 	"testing"
 	"time"
 
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations"
 	"go.keploy.io/server/v3/pkg/agent/proxy/relay"
 	"go.keploy.io/server/v3/pkg/agent/proxy/supervisor"
 	"go.keploy.io/server/v3/pkg/models"
 	"go.uber.org/zap/zaptest"
+	"golang.org/x/sync/errgroup"
 )
 
 // Two independent net.Pipes: one for the (app-client, proxy-client-side)
@@ -426,5 +428,191 @@ func TestV2_KillSwitchLifecycle(t *testing.T) {
 	ks.Reset()
 	if ks.Enabled() {
 		t.Fatal("Reset did not disable")
+	}
+}
+
+// -------- Abort-recovery parser --------
+
+// recoverableFakeParser is a V2 parser that opts into abort recovery. Its
+// FIRST generation reads one request, drains the paired response, then returns
+// an error (→ StatusError → FallthroughToPassthrough → the generation loop
+// must respawn). Every later generation reads a request+response and emits a
+// mock. It announces each generation start on genStarted and each request it
+// read on readReqs, so the test can gate steps deterministically and prove a
+// fresh generation ran on the SAME pooled connection after the abort.
+type recoverableFakeParser struct {
+	gen        atomic.Int32
+	genStarted chan int
+	readReqs   chan string
+}
+
+func (p *recoverableFakeParser) IsV2() bool                  { return true }
+func (p *recoverableFakeParser) SupportsAbortRecovery() bool { return true }
+
+// MatchType / MockOutgoing satisfy the integrations.Integrations interface;
+// unused on the record path this test exercises.
+func (p *recoverableFakeParser) MatchType(_ context.Context, _ []byte) bool { return true }
+func (p *recoverableFakeParser) MockOutgoing(_ context.Context, _ net.Conn, _ *models.ConditionalDstCfg, _ integrations.MockMemDb, _ models.OutgoingOptions) error {
+	return nil
+}
+
+func (p *recoverableFakeParser) RecordOutgoing(_ context.Context, sess *integrations.RecordSession) error {
+	g := int(p.gen.Add(1))
+	p.genStarted <- g
+	v2 := sess.V2
+	c, err := v2.ClientStream.ReadChunk()
+	if err != nil {
+		return err // clean teardown (ErrClosed) — a normal exit, not a fallthrough
+	}
+	p.readReqs <- string(c.Bytes)
+	// Drain the paired response so no bytes from this exchange leak into the
+	// next generation's fresh stream.
+	r, rerr := v2.DestStream.ReadChunk()
+	if g == 1 {
+		return errParserDecode{} // abort → the loop must recover
+	}
+	if rerr != nil {
+		return rerr
+	}
+	return v2.EmitMock(&models.Mock{
+		Name: "recovered",
+		Spec: models.MockSpec{
+			ReqTimestampMock: c.ReadAt,
+			ResTimestampMock: r.WrittenAt,
+			Metadata:         map[string]string{"req": string(c.Bytes)},
+		},
+	})
+}
+
+// TestDropVoidsMock pins the mock-void policy as a DENY-list: every
+// OnMarkMockIncomplete reason voids the in-flight mock EXCEPT the two deliberate
+// bulk-silence drops. Genuine byte-loss reasons — channel_full, per_conn_cap,
+// write_error, short_write, abort_mock, pre_dispatch_drain_* — mean the peer
+// never got the bytes, so the mock must not be recorded as complete (this
+// applies to every parser, not just recovery opt-ins). "paused" must NOT void
+// (during recovery the fresh session is already published, so voiding would drop
+// its first mock); "memory_pressure" is covered by pressureRanges.
+func TestDropVoidsMock(t *testing.T) {
+	cases := []struct {
+		reason string
+		want   bool
+	}{
+		{relay.DropChannelFull, true},
+		{relay.DropPerConnCap, true},
+		{"write_error", true},
+		{"short_write", true},
+		{"abort_mock", true},
+		{"pre_dispatch_drain_c2d_write_error", true},
+		{"pre_dispatch_drain_d2c_short_write", true},
+		{"some_future_byte_loss_reason", true},
+		{relay.DropPaused, false},
+		{relay.DropMemoryPressure, false},
+	}
+	for _, c := range cases {
+		if got := dropVoidsMock(c.reason); got != c.want {
+			t.Errorf("dropVoidsMock(%q) = %v, want %v", c.reason, got, c.want)
+		}
+	}
+}
+
+// TestV2_AbortRecovery_RespawnsAndRecordsNextRequest drives the real
+// recordViaSupervisor generation loop end-to-end: generation 1 aborts (error
+// return) and the loop must respawn a fresh parser generation that records the
+// NEXT request on the same pooled connection — instead of the connection being
+// permanently silenced (the go-memory-load-mongo recording dead zone). Every
+// step is gated on an explicit signal, so there are no sleeps or timing races.
+func TestV2_AbortRecovery_RespawnsAndRecordsNextRequest(t *testing.T) {
+	pp := newPipePair(t)
+	parser := &recoverableFakeParser{
+		genStarted: make(chan int, 8),
+		readReqs:   make(chan string, 8),
+	}
+
+	// Destination echoes each request with a "reply:" prefix, forever.
+	go func() {
+		buf := make([]byte, 64)
+		for {
+			n, err := pp.destSrv.Read(buf)
+			if err != nil {
+				return
+			}
+			if _, err := pp.destSrv.Write(append([]byte("reply:"), buf[:n]...)); err != nil {
+				return
+			}
+		}
+	}()
+
+	mocks := make(chan *models.Mock, 8)
+	var eg errgroup.Group
+	p := &Proxy{}
+	done := make(chan error, 1)
+	go func() {
+		done <- p.recordViaSupervisor(context.Background(), pp.proxySrc, pp.proxyDst,
+			parser, "testparser", mocks, &eg, zaptest.NewLogger(t), 1, 2, models.OutgoingOptions{})
+	}()
+
+	writeAndDrainReply := func(req string) {
+		if _, err := pp.clientApp.Write([]byte(req)); err != nil {
+			t.Fatalf("client write %q: %v", req, err)
+		}
+		_ = pp.clientApp.SetReadDeadline(time.Now().Add(2 * time.Second))
+		b := make([]byte, 64)
+		if _, err := pp.clientApp.Read(b); err != nil {
+			t.Fatalf("client read reply for %q: %v", req, err)
+		}
+	}
+
+	// Generation 1 starts and blocks on its first read.
+	if g := recvIntWithin(t, parser.genStarted, 2*time.Second); g != 1 {
+		t.Fatalf("first generation index = %d, want 1", g)
+	}
+	// Drive gen 1: it reads req-one and the reply, then returns an error →
+	// abort → the loop respawns generation 2.
+	writeAndDrainReply("req-one")
+	if got := recvStrWithin(t, parser.readReqs, 2*time.Second); got != "req-one" {
+		t.Fatalf("gen 1 read %q, want req-one", got)
+	}
+
+	// Generation 2 must be respawned (proving recovery) and be ready to read.
+	if g := recvIntWithin(t, parser.genStarted, 3*time.Second); g != 2 {
+		t.Fatalf("second generation index = %d, want 2 — abort-recovery did not respawn a fresh parser generation", g)
+	}
+	// Drive gen 2: it must record the NEXT request on the reused connection.
+	writeAndDrainReply("req-two")
+	if got := recvStrWithin(t, parser.readReqs, 3*time.Second); got != "req-two" {
+		t.Fatalf("gen 2 read %q, want req-two — recording did not resume on the reused connection after abort", got)
+	}
+	if g := parser.gen.Load(); g < 2 {
+		t.Fatalf("parser ran %d generation(s), want >= 2", g)
+	}
+
+	// Gen 2 returns cleanly (StatusOK) after emitting, so recordViaSupervisor
+	// returns on its own.
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("recordViaSupervisor did not return after a clean generation")
+	}
+}
+
+func recvIntWithin(t *testing.T, ch chan int, d time.Duration) int {
+	t.Helper()
+	select {
+	case v := <-ch:
+		return v
+	case <-time.After(d):
+		t.Fatalf("no int received within %v", d)
+		return 0
+	}
+}
+
+func recvStrWithin(t *testing.T, ch chan string, d time.Duration) string {
+	t.Helper()
+	select {
+	case v := <-ch:
+		return v
+	case <-time.After(d):
+		t.Fatalf("no string received within %v", d)
+		return ""
 	}
 }

--- a/pkg/agent/routes/record.go
+++ b/pkg/agent/routes/record.go
@@ -360,6 +360,7 @@ func (a *Agent) HandleIncoming(w http.ResponseWriter, r *http.Request) {
 					zap.Int64("mocks_added_successfully", finalAdded),
 					zap.Uint64("mocks_dropped_capacity", syncmgr.Get().DropCount()),
 					zap.Int("tcs_dropped_capacity", syncmgr.Get().DroppedTCCount()),
+					zap.Int("orphan_ranges_total", syncmgr.Get().OrphanRangeCount()),
 				)
 				return
 			}
@@ -380,14 +381,24 @@ func (a *Agent) HandleIncoming(w http.ResponseWriter, r *http.Request) {
 			// concurrent TC that kept all its mocks.
 			mockDropped := syncmgr.Get().WasMockDroppedForTC(t.Name)
 
-			if hasOverlap || mockDropped {
+			// A non-pressure mock void (parser marked its mock incomplete —
+			// reassembly overflow, a decode error on the realignment tail after
+			// a pressure gap, per-conn cap, short write) records an orphan
+			// window but feeds NEITHER the pressure ranges NOR the capacity
+			// ledger above. Without this check such a void reaches replay
+			// mock-less (match_phase=no_mocks) exactly like the two cases above.
+			// Overlap by the TC's own HTTP window, same as the pressure check.
+			orphanOverlap, orphanCount := syncmgr.Get().WasMockOrphanedInWindow(t.HTTPReq.Timestamp, tcRespTime)
+
+			if hasOverlap || mockDropped || orphanOverlap {
 				tcsSuppressedSoFar++
-				a.logger.Debug("agent: TC suppressed — memory pressure overlapped TC window or a mock was capacity-dropped, not sent to CLI",
+				a.logger.Debug("agent: TC suppressed — memory pressure overlapped TC window, a mock was capacity-dropped, or a mock was voided (incomplete) in the TC window; not sent to CLI",
 					zap.String("tc_name", t.Name),
 					zap.Int64("tc_req_ms", t.HTTPReq.Timestamp.UnixMilli()),
 					zap.Int64("tc_resp_ms", tcRespTime.UnixMilli()),
 					zap.Int("pressure_overlaps", overlapCount),
 					zap.Bool("capacity_drop", mockDropped),
+					zap.Int("orphan_overlaps", orphanCount),
 					zap.Int("tcs_suppressed_so_far", tcsSuppressedSoFar),
 				)
 				continue


### PR DESCRIPTION
Single PR de-flaking the OSS record-robustness CI lanes. Three independent root causes, each found from evidence (recording artifacts, job logs, wire-protocol tracing) and independently reviewed (SHIP, no CRITICAL/MAJOR), with mutation-verified regression tests.

## 1. `fix(agent)` — relay tee-drop orphan-window suppression (mongo lane)

`go-memory-load-mongo (record_build_replay_latest)` flaked at `no_mocks candidates=0`. Under record load the relay `tee` drops chunks (`channel_full`, `per_conn_cap`, `memory_pressure`, `paused`) to keep the forward path non-blocking, but signalled the loss only via `MarkMockIncomplete` — a session-global flag that voids the *next, unrelated* mock and records *its* window. So the dropped operation's own TC reached replay mock-less. Ground-truth from the failing lane's recording artifact: **19 of 26 orphaned TCs were dropped in calm periods** (channel_full/per_conn_cap, no memory pressure) that no pressure range or next-mock window covered.

Fix: record the **dropped chunk's own wire timestamp** as a zero-width orphan window (`OnTeeDropWindow` → `RecordOrphanWindow`), so `record.go` suppresses the TC whose HTTP window contains it. Accurate (same wall clock as the HTTP TC) and decode-lag-immune (recorded synchronously on the forward path). Per-operation coalescing bounds the ring. **Validated: 25/314 → 7/296 (2.36% vs 4% gate).**

## 2. `fix(mysql)` — synthesized PREPARE_OK missing param-def EOF (mysql fuzzer lane)

`MySQL Fuzzer (record_build_replay_build)` hung ~1000s then failed. Replaying an unmocked `COM_STMT_PREPARE`, keploy synthesized a `COM_STMT_PREPARE_OK` with `EOFAfterParamDefs` empty; a non-`DEPRECATE_EOF` client (go-sql-driver) calls `readUntilEOF()` after the param defs and **blocks forever** → `driver: bad connection` cascade across the 32-conn pool → replay `POST /run` deadline. Fix: emit a legacy EOF (seq `2+numParams`) gated on `numParams>0 && !DeprecateEOF()`, byte-symmetric with the recorder. Mutation-verified regression test. Wire bytes + seq id independently verified against go-sql-driver source. **Both MySQL + gRPC fuzzer lanes passed all three variants in CI.**

## 3. `fix(ci)` — gRPC incoming fuzzer port-reuse race (gRPC fuzzer lane)

`gRPC Fuzzer incoming (record_build_replay_build)` intermittently hit `bind: address already in use` → 1000/1000 nil mismatches. The json cycle raced the yaml cycle's `:50051`/`:18080` binds: the yaml client on `:18080` was never killed, and a fixed `sleep 2` raced the server release. Fix: bounded `wait_port_free` (poll `nc -z` until the socket is gone) + kill the leaked client. Deterministic, non-masking (a genuinely stuck port lets the authoritative bind error surface). keploy's own app-stop is robust (process-group SIGINT→SIGKILL + synchronous drain) — this is a harness-owned leak.

## 4. `fix(agent)` — recover recording after a parser abort (mongo lane, root cause)

The tee-drop suppression (§1) hides the *symptom* but a deeper cause remained: under sustained memory pressure a supervisor abort (hang / outer-cancel grace / panic / mem-cap) calls `PauseTees` on a **still-alive pooled connection**, permanently silencing egress recording while raw forwarding continues — mongo capture dies ~1 min in while HTTP keeps recording, stranding the tail TCs as `no_mocks`. The shipped false-hang gate closed only one of the abort triggers.

Fix: make abort **recoverable**. `recordViaSupervisor` now runs a per-generation parser respawn loop over a relay that outlives every generation. On a `FallthroughToPassthrough` result for an opted-in parser (`SupportsAbortRecovery`), it waits for the aborted parser goroutine to retire (new `Supervisor.ParserDone`), reattaches fresh `FakeConn` streams over the same still-open tees, un-pauses them, and re-runs the parser so the next request records again. Bounded by an 8-generation ceiling + a saw-client-chunk guard; non-opted-in parsers keep the historical single-generation passthrough (zero behaviour change off the abort path).

Also fixes two correctness issues the respawn surfaced: (a) `ParserDone` closes the dying-goroutine steal window on the shared tee channel; (b) the `OnMarkMockIncomplete` callback no longer voids a mock on `paused`/`memory_pressure` drops (a deny-list), fixing a latent mis-attribution for **every** parser while preserving voiding for genuine byte loss (`channel_full`, `per_conn_cap`, `write_error`, `short_write`, `abort_mock`, `pre_dispatch_drain_*`).

HTTP opts in here; mongo opts in via **keploy/integrations#248** (paired below). Deterministic tests: end-to-end respawn loop, `ParserDone` goroutine-exit, stream reattach, and the void policy — all mutation-verified. Two independent adversarial reviews (both MAJOR findings fixed and re-confirmed).

## Notes
- `record_latest_replay_build` mongo lanes record with the *released* binary (no fix) → resolve on the next release, not a regression here.
- Other rotating flakes on this pipeline (main is red ~7/10 runs) are pre-existing and unrelated to these changes.


<!-- TEMPORARY cross-repo CI pairing: builds the mongo lane against keploy/integrations#248 (mongo v2 abort-recovery opt-in — the integrations half of §4). #246 (reassembly resync) has already merged to integrations `main`. REMOVE this tag before merging, once #248 lands on integrations `main`. -->
Integration-Ref: fix/mongo-v2-abort-recovery-optin
