### PR TITLE
fix(agent): gate mock residency on config strict-window, not a separate env

### DIFF
--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -740,11 +740,14 @@ func (a *Agent) StoreMocksStream(ctx context.Context, header models.MockStreamHe
 		unfiltered: make([]*models.Mock, 0, presizeCap(header.UnfilteredCount)),
 	}
 
-	// Engage the on-disk store only under strict mock-window: lax promotes
-	// out-of-window mocks to the session tier, so it needs the whole per-test set
-	// anyway. Best-effort — fall back to full-resident if it can't be created.
+	// Engage the on-disk store when strict mock-window is in effect — the OSS
+	// config flag config.Test.StrictMockWindow, on by default (seeded by
+	// config.New(); KEPLOY_STRICT_MOCK_WINDOW=0 opts out). Under lax the filter
+	// promotes out-of-window mocks, needing the whole per-test set every test, so
+	// windowing to disk would only add reload cost. Best-effort — fall back to
+	// full-resident if the store can't be created.
 	var disk *proxyPkg.DiskMocks
-	if pkg.IsStrictMockWindow(false) {
+	if pkg.IsStrictMockWindow(a.config != nil && a.config.Test.StrictMockWindow) {
 		d, diskErr := proxyPkg.NewDiskMocks(a.logger)
 		if diskErr != nil {
 			a.logger.Warn("on-disk mock store unavailable; keeping per-test mocks resident", zap.Error(diskErr))
@@ -853,7 +856,7 @@ func earliestReqTimestamp(filtered, unfiltered []*models.Mock) time.Time {
 // the old full-resident path): mapping -> named mocks; strict -> window +
 // startup band; lax -> all. Resident ineligible mocks are merged in; with no
 // disk store (legacy path) the resident slice is returned unchanged.
-func (a *Agent) loadPerTestMocks(resident []*models.Mock, disk *proxyPkg.DiskMocks, params models.MockFilterParams, agentStrict bool, firstWindowStart time.Time) ([]*models.Mock, error) {
+func (a *Agent) loadPerTestMocks(resident []*models.Mock, disk *proxyPkg.DiskMocks, params models.MockFilterParams, firstWindowStart time.Time) ([]*models.Mock, error) {
 	if disk == nil {
 		return resident, nil
 	}
@@ -865,7 +868,7 @@ func (a *Agent) loadPerTestMocks(resident []*models.Mock, disk *proxyPkg.DiskMoc
 	case params.UseMappingBased && len(params.MockMapping) > 0:
 		mode = "mapping"
 		loaded, err = disk.LoadByNames(params.MockMapping)
-	case pkg.IsStrictMockWindow(agentStrict) && !params.AfterTime.IsZero() && !params.BeforeTime.IsZero():
+	case pkg.IsStrictMockWindow(a.config != nil && a.config.Test.StrictMockWindow) && !params.AfterTime.IsZero() && !params.BeforeTime.IsZero():
 		mode = "strict-window"
 		loaded, err = disk.LoadWindow(params.AfterTime, params.BeforeTime)
 		if err == nil && !firstWindowStart.IsZero() {
@@ -979,7 +982,7 @@ func (a *Agent) UpdateMockParams(ctx context.Context, params models.MockFilterPa
 	}
 
 	// Load only what the filter will keep for this call (see loadPerTestMocks).
-	originalFiltered, err := a.loadPerTestMocks(residentFiltered, disk, params, agentStrict, firstWindowStart)
+	originalFiltered, err := a.loadPerTestMocks(residentFiltered, disk, params, firstWindowStart)
 	if err != nil {
 		utils.LogError(a.logger, err, "failed to load this test's per-test mocks from the agent's on-disk store; the temp file may be unreadable or the pool was superseded mid-test")
 		return err

--- a/pkg/service/agent/storemocks_stream_test.go
+++ b/pkg/service/agent/storemocks_stream_test.go
@@ -10,10 +10,20 @@ import (
 	"testing"
 	"time"
 
+	"go.keploy.io/server/v3/config"
 	"go.keploy.io/server/v3/pkg"
 	"go.keploy.io/server/v3/pkg/models"
 	"go.uber.org/zap"
 )
+
+// strictAgent returns a test agent whose OSS config sets the strict mock-window
+// flag — the same flag config.New() seeds true by default, which gates residency.
+func strictAgent(strict bool) *Agent {
+	a := newTestAgent()
+	a.config = &config.Config{}
+	a.config.Test.StrictMockWindow = strict
+	return a
+}
 
 // --- helpers ---
 
@@ -140,79 +150,84 @@ func diskEligibleMock(name string, req time.Time) *models.Mock {
 // The on-disk store must still reconstruct the eligible mocks by window, and the freeze
 // anchor must reflect the earliest on-disk timestamp.
 func TestStoreMocksStream_PerTestMocksGoToDisk(t *testing.T) {
-	prevHooks := ActiveHooks
-	ch := &captureHook{}
-	ActiveHooks = ch
-	defer func() { ActiveHooks = prevHooks }()
-
-	a := newTestAgent()
 	base := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
 
-	ineligible := &models.Mock{Name: "pt-missing", Kind: models.Mongo, Spec: models.MockSpec{ReqTimestampMock: base.Add(5 * time.Second)}} // no res ts
-	cfg := &models.Mock{Name: "cfg-1", Kind: models.Mongo, Spec: models.MockSpec{
-		ReqTimestampMock: base.Add(3 * time.Second), ResTimestampMock: base.Add(3 * time.Second).Add(time.Millisecond),
-		Metadata: map[string]string{"type": "config"},
-	}}
-	// filtered (per-test) region: 2 eligible + 1 ineligible; unfiltered: 1 config.
-	filtered := []*models.Mock{
-		diskEligibleMock("pt-2", base.Add(2*time.Second)),
-		diskEligibleMock("pt-1", base.Add(1*time.Second)), // earliest → freeze anchor
-		ineligible,
-	}
-	unfiltered := []*models.Mock{cfg}
+	// Residency follows the OSS config flag config.Test.StrictMockWindow — run
+	// both modes and assert against the code's own gate, pkg.IsStrictMockWindow(strict),
+	// which stays correct even if the ambient KEPLOY_STRICT_MOCK_WINDOW env overrides.
+	for _, strict := range []bool{true, false} {
+		strict := strict
+		t.Run(map[bool]string{true: "strict", false: "lax"}[strict], func(t *testing.T) {
+			prevHooks := ActiveHooks
+			ch := &captureHook{}
+			ActiveHooks = ch
+			defer func() { ActiveHooks = prevHooks }()
 
-	header, dec := readHeaderAndDecoder(t, encodeStreamBody(t, filtered, unfiltered))
-	if err := a.StoreMocksStream(context.Background(), header, dec); err != nil {
-		t.Fatalf("StoreMocksStream: %v", err)
-	}
+			a := strictAgent(strict)
+			wantDisk := pkg.IsStrictMockWindow(strict)
 
-	st := loadStorage(t, a)
+			ineligible := &models.Mock{Name: "pt-missing", Kind: models.Mongo, Spec: models.MockSpec{ReqTimestampMock: base.Add(5 * time.Second)}} // no res ts
+			cfg := &models.Mock{Name: "cfg-1", Kind: models.Mongo, Spec: models.MockSpec{
+				ReqTimestampMock: base.Add(3 * time.Second), ResTimestampMock: base.Add(3 * time.Second).Add(time.Millisecond),
+				Metadata: map[string]string{"type": "config"},
+			}}
+			// filtered (per-test): 2 eligible + 1 ineligible; unfiltered: 1 config.
+			filtered := []*models.Mock{
+				diskEligibleMock("pt-2", base.Add(2*time.Second)),
+				diskEligibleMock("pt-1", base.Add(1*time.Second)), // earliest → freeze anchor
+				ineligible,
+			}
+			unfiltered := []*models.Mock{cfg}
 
-	// The on-disk store engages ONLY under strict mock-window (the RAM-bound
-	// mode); under lax it's a no-op so per-test mocks stay resident (avoids
-	// reloading the full pool from disk every test). Assert the path that
-	// matches the effective mode, exactly like util_test.go branches on strict.
-	if pkg.IsStrictMockWindow(false) {
-		if st.diskMocks == nil {
-			t.Fatal("strict mode: expected an on-disk store")
-		}
-		if got := st.diskMocks.Len(); got != 2 {
-			t.Fatalf("expected 2 on-disk eligible per-test mocks, got %d", got)
-		}
-		// only the ineligible per-test mock stays resident in filtered
-		if len(st.filtered) != 1 || st.filtered[0].Name != "pt-missing" {
-			t.Fatalf("resident filtered should be just the ineligible mock, got %v", sigs(st.filtered))
-		}
-		// the store reconstructs the eligible mocks for the whole window
-		got, err := st.diskMocks.LoadWindow(base, base.Add(3*time.Second))
-		if err != nil {
-			t.Fatalf("LoadWindow: %v", err)
-		}
-		if len(got) != 2 {
-			t.Fatalf("LoadWindow should reconstruct 2 eligible mocks, got %d", len(got))
-		}
-	} else {
-		if st.diskMocks != nil {
-			t.Fatal("lax mode: on-disk store must NOT engage (no RAM bound to gain)")
-		}
-		// lax fallback: all 3 per-test mocks stay resident, exactly as before.
-		if len(st.filtered) != 3 {
-			t.Fatalf("lax mode: all 3 per-test mocks should be resident, got %d", len(st.filtered))
-		}
-	}
+			header, dec := readHeaderAndDecoder(t, encodeStreamBody(t, filtered, unfiltered))
+			if err := a.StoreMocksStream(context.Background(), header, dec); err != nil {
+				t.Fatalf("StoreMocksStream: %v", err)
+			}
+			st := loadStorage(t, a)
 
-	// config stays resident in unfiltered in BOTH modes (reused across session).
-	if len(st.unfiltered) != 1 || st.unfiltered[0].Name != "cfg-1" {
-		t.Fatalf("config should be resident in unfiltered, got %v", sigs(st.unfiltered))
-	}
-	// freeze anchor must be the earliest request timestamp (pt-1 @ base+1s) in
-	// both modes — proving finalizeClientMocks folds the on-disk store's earliest
-	// into the anchor under strict, and reads it from the resident slice under lax.
-	if !ch.called {
-		t.Fatal("SetFreezeAnchor was not called")
-	}
-	if !ch.anchor.Equal(base.Add(1 * time.Second)) {
-		t.Fatalf("freeze anchor should be earliest ts %v, got %v", base.Add(1*time.Second), ch.anchor)
+			if wantDisk {
+				// Strict: eligible per-test mocks live on disk; only the
+				// ineligible one stays resident in filtered.
+				if st.diskMocks == nil {
+					t.Fatal("strict mode: expected an on-disk store")
+				}
+				if got := st.diskMocks.Len(); got != 2 {
+					t.Fatalf("expected 2 on-disk eligible per-test mocks, got %d", got)
+				}
+				if len(st.filtered) != 1 || st.filtered[0].Name != "pt-missing" {
+					t.Fatalf("resident filtered should be just the ineligible mock, got %v", sigs(st.filtered))
+				}
+				got, err := st.diskMocks.LoadWindow(base, base.Add(3*time.Second))
+				if err != nil {
+					t.Fatalf("LoadWindow: %v", err)
+				}
+				if len(got) != 2 {
+					t.Fatalf("LoadWindow should reconstruct 2 eligible mocks, got %d", len(got))
+				}
+			} else {
+				// Lax: no on-disk store — all 3 per-test mocks stay resident.
+				if st.diskMocks != nil {
+					t.Fatal("lax mode: on-disk store must NOT engage (no RAM bound to gain)")
+				}
+				if len(st.filtered) != 3 {
+					t.Fatalf("lax mode: all 3 per-test mocks should be resident, got %d", len(st.filtered))
+				}
+			}
+
+			// config stays resident in unfiltered in BOTH modes.
+			if len(st.unfiltered) != 1 || st.unfiltered[0].Name != "cfg-1" {
+				t.Fatalf("config should be resident in unfiltered, got %v", sigs(st.unfiltered))
+			}
+			// freeze anchor = earliest request timestamp (pt-1 @ base+1s) in both
+			// modes: folded from the on-disk store under strict, from the resident
+			// slice under lax.
+			if !ch.called {
+				t.Fatal("SetFreezeAnchor was not called")
+			}
+			if !ch.anchor.Equal(base.Add(1 * time.Second)) {
+				t.Fatalf("freeze anchor should be earliest ts %v, got %v", base.Add(1*time.Second), ch.anchor)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Describe the changes that are made

The agent-side windowed disk-backed mock residency (shipped in #4350 / v3.5.92) engaged **only** when the `KEPLOY_STRICT_MOCK_WINDOW` env was set — the gate read `pkg.IsStrictMockWindow(false)`, ignoring `config.Test.StrictMockWindow` entirely. That left the auto-replay OOM fix **dormant by default** and forced a separate enablement env + chart plumbing.

This gates residency on the **config strict-window flag** instead (default `true`; `KEPLOY_STRICT_MOCK_WINDOW=0` still opts out), in both:
- `StoreMocksStream` — on-disk store creation, and
- `loadPerTestMocks` — window vs. all load.

So residency now simply **follows strict mode: on by default**, off only when strict is disabled — no separate switch.

**Why gating on strict is correct (not arbitrary):** only strict *drops* out-of-window per-test mocks, so loading just the window is safe. Under lax those mocks are *promoted* and needed every test, so windowing to disk would only add reload cost with zero RAM saving. `loadPerTestMocks` keys off the config value directly because on the `WindowedProxy` path `agentStrict` is deliberately forced `false` (strict is enforced downstream by `SetMocksWithWindow`).

## Links & References

**Closes:** NA
- Follow-up to #4350. Lets us drop the separate strict-window plumbing (k8s-proxy) and the k8s-env enable line.

## What type of PR is this?
- [x] 🐞 Bug Fix

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed

`TestStoreMocksStream_PerTestMocksGoToDisk` now covers **both** strict and lax via config, asserting against the code's own gate (`pkg.IsStrictMockWindow(strict)`) so it stays correct under any ambient env override. `go test ./pkg/service/agent/ ./pkg/agent/proxy/` green; `go vet` clean.

## Self Review done?
- [x] ✅ yes