### PR TITLE
fix: de-flake mysql + gRPC fuzzer lanes

### DIFF
--- a/.github/workflows/test_workflow_scripts/fuzzer/grpc/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/fuzzer/grpc/golang-linux.sh
@@ -134,6 +134,31 @@ ensure_success_phrase() {
  exit 1
 }
 
+# wait_port_free NAME PORT [TIMEOUT_SEC]
+# Block until nothing is listening on localhost:PORT (or TIMEOUT_SEC elapses).
+# Deterministic replacement for a fixed `sleep` after killing a process that
+# owns a port: the next bind must not race a socket that is still being
+# released, which is what surfaces as "listen tcp :PORT: bind: address already
+# in use" and fails the run intermittently. Returns as soon as the port is
+# actually free, so it is normally sub-second. `nc -z` is already used elsewhere
+# in this script to poll for a port coming UP; here we poll for it going DOWN.
+wait_port_free() {
+  local name=$1 port=$2 timeout=${3:-30}
+  local deadline=$(( $(date +%s) + timeout ))
+  # Bare `nc -z` (no -w): on some netcat builds -w makes -z report an occupied
+  # port as free, which would defeat the whole check. Wall-clock deadline (not
+  # an iteration count) so a slow per-probe nc can't stretch the bound.
+  while nc -z localhost "$port" 2>/dev/null; do
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      echo "⚠️ $name still holding port $port after ${timeout}s"
+      return 1
+    fi
+    sleep 1
+  done
+  echo "✅ $name port $port is free"
+  return 0
+}
+
 
 if [ "$MODE" = "incoming" ]; then
  echo "🧪 Testing with incoming requests"
@@ -188,7 +213,15 @@ if [ "$MODE" = "incoming" ]; then
  echo "Ensuring fuzzer server is stopped..."
  sleep 10
  sudo pkill -f "$FUZZER_SERVER_BIN" || true
- sleep 2 # Give a moment for the port to be released
+ # The HTTP client started above (:18080) is otherwise never stopped in the
+ # incoming path, so it leaks into the json cycle where a fresh client cannot
+ # bind :18080 (and the stale one silently serves /run against a dead server).
+ # Stop it here, at the source of the leak.
+ sudo pkill -f "$FUZZER_CLIENT_BIN" || true
+ # Wait for the ports to be released instead of a fixed sleep that races the
+ # yaml replay's server re-bind on :50051.
+ wait_port_free "gRPC server" 50051 || true
+ wait_port_free "HTTP client" 18080 || true
 
  echo "Waiting for processes to settle"
 
@@ -240,14 +273,23 @@ if [ "$MODE" = "incoming" ]; then
 
  if json_pass_supported; then
    echo "🧪 Re-running incoming with --storage-format json"
-   # The yaml replay above started the fuzzer server with `keploy -c`.
-   # Keploy stops itself, but the server child it spawned can keep
-   # owning :50051, so the json record's app-launch fails with
-   # "listen tcp :50051: bind: address already in use" and keploy
-   # bails before capturing any test case. Force-kill anything still
-   # holding :50051 before the json record's app starts.
+   # Before the json cycle rebinds :50051 (server) and :18080 (client), make
+   # sure the yaml cycle's processes are gone AND their ports are released.
+   # Two leftovers otherwise race the json binds:
+   #   * :50051 — the yaml replay's `keploy test -c` server can still be
+   #     unwinding when `keploy test` returns; the json record's app then hits
+   #     "listen tcp :50051: bind: address already in use" and keploy bails
+   #     before capturing any test case.
+   #   * :18080 — the yaml cycle's HTTP client is never stopped, so a fresh
+   #     json client cannot bind it and the stale one silently serves /run
+   #     against a server that never came up (1000 nil mismatches).
+   # Kill both and WAIT for the sockets to close (bounded) rather than trusting
+   # a fixed sleep. (The yaml teardown already stops the client; this is the
+   # defensive backstop at the actual bind boundary.)
    sudo pkill -f "$FUZZER_SERVER_BIN" || true
-   sleep 2
+   sudo pkill -f "$FUZZER_CLIENT_BIN" || true
+   wait_port_free "gRPC server" 50051 || true
+   wait_port_free "HTTP client" 18080 || true
    if [[ "$RECORD_SRC" == "latest" ]]; then
      "$RECORD_BIN" record --storage-format json -c "$FUZZER_SERVER_BIN" $BIG_PAYLOAD_FLAG 2>&1 | tee record_incoming_json.txt &
    else

--- a/pkg/agent/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match.go
@@ -965,6 +965,30 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 					}
 				}
 
+				// The COM_STMT_PREPARE response's parameter-definition block is
+				// ALWAYS terminated by an EOF packet unless CLIENT_DEPRECATE_EOF
+				// was negotiated. Clients that do NOT negotiate DEPRECATE_EOF
+				// (e.g. go-sql-driver) call readUntilEOF() after the param defs
+				// (see database/sql mysql connection.go: prepare) and block
+				// forever if that terminator is missing — the synthesized
+				// PREPARE_OK then hangs the connection until the client's
+				// context deadline fires, which surfaces as "driver: bad
+				// connection" and cascades across the whole pool. Emit a
+				// legacy EOF terminator here, mirroring the recorder
+				// (record_v2.go only captures EOFAfterParamDefs when
+				// !DeprecateEOF), so a synthesized response is wire-complete.
+				var eofAfterParamDefs []byte
+				if numParams > 0 && !decodeCtx.DeprecateEOF() {
+					// Legacy EOF: header(len=5, seq) + payload
+					// (0xFE | warnings=0 | status_flags=AUTOCOMMIT). Param
+					// defs occupy sequence ids 2..(1+numParams), so the
+					// terminator is at 2+numParams.
+					eofAfterParamDefs = []byte{
+						0x05, 0x00, 0x00, byte(2 + numParams),
+						0xFE, 0x00, 0x00, 0x02, 0x00,
+					}
+				}
+
 				prepareOk := &mysql.StmtPrepareOkPacket{
 					Status:             0,
 					StatementID:        newStmtID,
@@ -974,7 +998,7 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 					WarningAvailable:   true,
 					WarningCount:       0,
 					ParamDefs:          paramDefs,
-					EOFAfterParamDefs:  []byte{},
+					EOFAfterParamDefs:  eofAfterParamDefs,
 					ColumnDefs:         nil,
 					EOFAfterColumnDefs: []byte{},
 				}

--- a/pkg/agent/proxy/integrations/mysql/replayer/synthesize_prepare_eof_test.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/synthesize_prepare_eof_test.go
@@ -1,0 +1,97 @@
+package replayer
+
+import (
+	"context"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/wire"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.keploy.io/server/v3/pkg/models/mysql"
+	"go.uber.org/zap"
+)
+
+// prepareReq builds a COM_STMT_PREPARE request for the given query.
+func prepareReq(query string) mysql.Request {
+	return mysql.Request{PacketBundle: mysql.PacketBundle{
+		Header: &mysql.PacketInfo{
+			Header: &mysql.Header{SequenceID: 0},
+			Type:   mysql.CommandStatusToString(mysql.COM_STMT_PREPARE),
+		},
+		Message: &mysql.StmtPreparePacket{Command: mysql.COM_STMT_PREPARE, Query: query},
+	}}
+}
+
+// TestSynthesizedPrepareOK_ParamDefEOF is the regression guard for the MySQL
+// fuzzer hang: when a COM_STMT_PREPARE has no recorded mock, matchCommand
+// synthesizes a COM_STMT_PREPARE_OK. For a client that did NOT negotiate
+// CLIENT_DEPRECATE_EOF (e.g. go-sql-driver), the parameter-definition block
+// MUST be terminated by an EOF packet, or the driver's readUntilEOF() blocks
+// forever ("driver: bad connection", whole-pool cascade, 1000s deadlock).
+// DEPRECATE_EOF clients must NOT get the terminator, and a zero-param prepare
+// has no param-def block so needs none either.
+func TestSynthesizedPrepareOK_ParamDefEOF(t *testing.T) {
+	logger := zap.NewNop()
+	// A non-empty pool with NO recorded COM_STMT_PREPARE for our query: the
+	// pool must be non-empty (an entirely empty db bails with "no mysql mocks
+	// found" before the synthesize path), but nothing matches the prepare, so
+	// matchCommand falls through to synthesizing a PREPARE_OK.
+	emptyDb := &fakeMockDb{session: []*models.Mock{execMock("unrelated-filler", "x")}}
+
+	synth := func(t *testing.T, dctx *wire.DecodeContext, query string) *mysql.StmtPrepareOkPacket {
+		t.Helper()
+		resp, ok, _, err := matchCommand(context.Background(), logger, prepareReq(query), emptyDb, dctx, nil, nil)
+		if err != nil || !ok || resp == nil {
+			t.Fatalf("expected a synthesized PREPARE_OK (ok=%v err=%v resp=%v)", ok, err, resp)
+		}
+		pkt, isPrep := resp.PacketBundle.Message.(*mysql.StmtPrepareOkPacket)
+		if !isPrep {
+			t.Fatalf("expected *StmtPrepareOkPacket, got %T", resp.PacketBundle.Message)
+		}
+		return pkt
+	}
+
+	t.Run("non-DEPRECATE_EOF client gets a well-formed param-def EOF", func(t *testing.T) {
+		dctx := newDecodeCtx()                                            // ServerCaps=0, ClientCaps=0 → DeprecateEOF()==false
+		pkt := synth(t, dctx, "SELECT id FROM t WHERE a BETWEEN ? AND ?") // 2 params
+
+		if pkt.NumParams != 2 {
+			t.Fatalf("NumParams = %d, want 2", pkt.NumParams)
+		}
+		eof := pkt.EOFAfterParamDefs
+		// Legacy EOF: 4-byte header + 5-byte payload = 9 bytes.
+		if len(eof) != 9 {
+			t.Fatalf("EOFAfterParamDefs len = %d (%v), want 9-byte legacy EOF packet", len(eof), eof)
+		}
+		if eof[4] != 0xFE {
+			t.Fatalf("EOF marker = 0x%02x, want 0xFE", eof[4])
+		}
+		// payload length field (3-byte LE) must be 5.
+		if eof[0] != 0x05 || eof[1] != 0x00 || eof[2] != 0x00 {
+			t.Fatalf("EOF length header = %v, want [5 0 0]", eof[:3])
+		}
+		// sequence id must follow the param defs (seq 2..1+numParams), i.e. 2+numParams.
+		if want := byte(2 + pkt.NumParams); eof[3] != want {
+			t.Fatalf("EOF sequence id = %d, want %d (2+numParams)", eof[3], want)
+		}
+	})
+
+	t.Run("DEPRECATE_EOF client gets no terminator", func(t *testing.T) {
+		dctx := newDecodeCtx()
+		dctx.ServerCaps = wire.CLIENT_DEPRECATE_EOF
+		dctx.ClientCaps = wire.CLIENT_DEPRECATE_EOF
+		pkt := synth(t, dctx, "SELECT id FROM t WHERE a = ?") // 1 param
+		if len(pkt.EOFAfterParamDefs) != 0 {
+			t.Fatalf("DEPRECATE_EOF client must get no param-def EOF, got %v", pkt.EOFAfterParamDefs)
+		}
+	})
+
+	t.Run("zero-param prepare needs no param-def EOF", func(t *testing.T) {
+		pkt := synth(t, newDecodeCtx(), "SELECT 1")
+		if pkt.NumParams != 0 {
+			t.Fatalf("NumParams = %d, want 0", pkt.NumParams)
+		}
+		if len(pkt.EOFAfterParamDefs) != 0 {
+			t.Fatalf("zero-param prepare must have no param-def EOF, got %v", pkt.EOFAfterParamDefs)
+		}
+	})
+}


### PR DESCRIPTION
De-flakes two intermittently-red fuzzer lanes (both fail on `main` too, pass on rerun). Root-caused from the failing job logs; each fix independently reviewed (SHIP, no CRITICAL/MAJOR).

## `fix(mysql)` — synthesized PREPARE_OK missing its param-def EOF (product bug)

`MySQL Fuzzer (record_build_replay_build)` hangs ~1000s then fails. During replay of the 4000-op fuzz, keploy synthesizes a `COM_STMT_PREPARE_OK` for an unmocked prepared statement but left `EOFAfterParamDefs` empty unconditionally. A client that did **not** negotiate `CLIENT_DEPRECATE_EOF` (go-sql-driver) calls `readUntilEOF()` after the parameter definitions and **blocks forever** without that terminator → the prepare deadlocks the connection until the app's run-context deadline fires → `driver: bad connection` cascades across the 32-conn pool → keploy's replay `POST /run` times out. Zero `no_mocks` — it is not an orphan, it is a malformed synthetic packet.

Fix: emit a legacy EOF packet after the param defs, gated on `numParams>0 && !DeprecateEOF()`, byte-symmetric with what the recorder captures (`record_v2.go`). Sequence id `2+numParams` follows the param defs (`2..1+numParams`) — verified contiguous against go-sql-driver's `ErrPktSync` check. No change for DEPRECATE_EOF clients, recorded prepares, or zero-param statements. New regression test drives the real `matchCommand` synthesize path (mutation-verified).

## `fix(ci)` — gRPC incoming fuzzer port-reuse race (harness bug)

`gRPC Fuzzer incoming (record_build_replay_build)` intermittently fails with 1000/1000 nil mismatches. The incoming path runs a yaml then a json record→replay cycle reusing `:50051` (gRPC server) and `:18080` (fuzzer HTTP client). The yaml client on `:18080` is never killed, and a fixed `sleep 2` races the yaml replay's server releasing `:50051`; the json cycle then hits `bind: address already in use`, keploy bails before capturing a test case, and the stale client's RPCs hit a dead server.

Fix: a bounded `wait_port_free` helper (poll `nc -z` until the socket is gone, wall-clock deadline) plus killing the leaked client, replacing the two blind sleeps. Deterministic and non-masking — a genuinely stuck port past the bound lets the authoritative bind error surface. keploy's own app-stop (process-group SIGINT→SIGKILL + synchronous drain) is robust; the async teardown is the harness's own `pkill`, so the wait is the correct compensation. Scope is incoming-only (the reported flake); outgoing is benign.

## Testing
- `go build` / `go vet` / `go test` green for the mysql replayer package; new `synthesize_prepare_eof_test.go` mutation-verified (neuter the gate → red).
- gRPC harness: `bash -n` clean; `wait_port_free` unit-behavior confirmed (free-immediately / free-on-release / timeout-at-bound).
- Independent adversarial review verified the mysql wire bytes + sequence id against the actual go-sql-driver source.

Independent of PR #4354 (the mongo tee-drop orphan-window fix); together the three close the record-robustness fuzzer/memory-load flakes.
