### PR TITLE
[MEASUREMENT — DO NOT MERGE] mongo residual orphan-window engagement

### DIFF
--- a/.github/workflows/test_workflow_scripts/fuzzer/grpc/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/fuzzer/grpc/golang-linux.sh
@@ -134,6 +134,31 @@ ensure_success_phrase() {
  exit 1
 }
 
+# wait_port_free NAME PORT [TIMEOUT_SEC]
+# Block until nothing is listening on localhost:PORT (or TIMEOUT_SEC elapses).
+# Deterministic replacement for a fixed `sleep` after killing a process that
+# owns a port: the next bind must not race a socket that is still being
+# released, which is what surfaces as "listen tcp :PORT: bind: address already
+# in use" and fails the run intermittently. Returns as soon as the port is
+# actually free, so it is normally sub-second. `nc -z` is already used elsewhere
+# in this script to poll for a port coming UP; here we poll for it going DOWN.
+wait_port_free() {
+  local name=$1 port=$2 timeout=${3:-30}
+  local deadline=$(( $(date +%s) + timeout ))
+  # Bare `nc -z` (no -w): on some netcat builds -w makes -z report an occupied
+  # port as free, which would defeat the whole check. Wall-clock deadline (not
+  # an iteration count) so a slow per-probe nc can't stretch the bound.
+  while nc -z localhost "$port" 2>/dev/null; do
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      echo "⚠️ $name still holding port $port after ${timeout}s"
+      return 1
+    fi
+    sleep 1
+  done
+  echo "✅ $name port $port is free"
+  return 0
+}
+
 
 if [ "$MODE" = "incoming" ]; then
  echo "🧪 Testing with incoming requests"
@@ -188,7 +213,15 @@ if [ "$MODE" = "incoming" ]; then
  echo "Ensuring fuzzer server is stopped..."
  sleep 10
  sudo pkill -f "$FUZZER_SERVER_BIN" || true
- sleep 2 # Give a moment for the port to be released
+ # The HTTP client started above (:18080) is otherwise never stopped in the
+ # incoming path, so it leaks into the json cycle where a fresh client cannot
+ # bind :18080 (and the stale one silently serves /run against a dead server).
+ # Stop it here, at the source of the leak.
+ sudo pkill -f "$FUZZER_CLIENT_BIN" || true
+ # Wait for the ports to be released instead of a fixed sleep that races the
+ # yaml replay's server re-bind on :50051.
+ wait_port_free "gRPC server" 50051 || true
+ wait_port_free "HTTP client" 18080 || true
 
  echo "Waiting for processes to settle"
 
@@ -240,14 +273,23 @@ if [ "$MODE" = "incoming" ]; then
 
  if json_pass_supported; then
    echo "🧪 Re-running incoming with --storage-format json"
-   # The yaml replay above started the fuzzer server with `keploy -c`.
-   # Keploy stops itself, but the server child it spawned can keep
-   # owning :50051, so the json record's app-launch fails with
-   # "listen tcp :50051: bind: address already in use" and keploy
-   # bails before capturing any test case. Force-kill anything still
-   # holding :50051 before the json record's app starts.
+   # Before the json cycle rebinds :50051 (server) and :18080 (client), make
+   # sure the yaml cycle's processes are gone AND their ports are released.
+   # Two leftovers otherwise race the json binds:
+   #   * :50051 — the yaml replay's `keploy test -c` server can still be
+   #     unwinding when `keploy test` returns; the json record's app then hits
+   #     "listen tcp :50051: bind: address already in use" and keploy bails
+   #     before capturing any test case.
+   #   * :18080 — the yaml cycle's HTTP client is never stopped, so a fresh
+   #     json client cannot bind it and the stale one silently serves /run
+   #     against a server that never came up (1000 nil mismatches).
+   # Kill both and WAIT for the sockets to close (bounded) rather than trusting
+   # a fixed sleep. (The yaml teardown already stops the client; this is the
+   # defensive backstop at the actual bind boundary.)
    sudo pkill -f "$FUZZER_SERVER_BIN" || true
-   sleep 2
+   sudo pkill -f "$FUZZER_CLIENT_BIN" || true
+   wait_port_free "gRPC server" 50051 || true
+   wait_port_free "HTTP client" 18080 || true
    if [[ "$RECORD_SRC" == "latest" ]]; then
      "$RECORD_BIN" record --storage-format json -c "$FUZZER_SERVER_BIN" $BIG_PAYLOAD_FLAG 2>&1 | tee record_incoming_json.txt &
    else

--- a/pkg/agent/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match.go
@@ -965,6 +965,30 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 					}
 				}
 
+				// The COM_STMT_PREPARE response's parameter-definition block is
+				// ALWAYS terminated by an EOF packet unless CLIENT_DEPRECATE_EOF
+				// was negotiated. Clients that do NOT negotiate DEPRECATE_EOF
+				// (e.g. go-sql-driver) call readUntilEOF() after the param defs
+				// (see database/sql mysql connection.go: prepare) and block
+				// forever if that terminator is missing — the synthesized
+				// PREPARE_OK then hangs the connection until the client's
+				// context deadline fires, which surfaces as "driver: bad
+				// connection" and cascades across the whole pool. Emit a
+				// legacy EOF terminator here, mirroring the recorder
+				// (record_v2.go only captures EOFAfterParamDefs when
+				// !DeprecateEOF), so a synthesized response is wire-complete.
+				var eofAfterParamDefs []byte
+				if numParams > 0 && !decodeCtx.DeprecateEOF() {
+					// Legacy EOF: header(len=5, seq) + payload
+					// (0xFE | warnings=0 | status_flags=AUTOCOMMIT). Param
+					// defs occupy sequence ids 2..(1+numParams), so the
+					// terminator is at 2+numParams.
+					eofAfterParamDefs = []byte{
+						0x05, 0x00, 0x00, byte(2 + numParams),
+						0xFE, 0x00, 0x00, 0x02, 0x00,
+					}
+				}
+
 				prepareOk := &mysql.StmtPrepareOkPacket{
 					Status:             0,
 					StatementID:        newStmtID,
@@ -974,7 +998,7 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 					WarningAvailable:   true,
 					WarningCount:       0,
 					ParamDefs:          paramDefs,
-					EOFAfterParamDefs:  []byte{},
+					EOFAfterParamDefs:  eofAfterParamDefs,
 					ColumnDefs:         nil,
 					EOFAfterColumnDefs: []byte{},
 				}

--- a/pkg/agent/proxy/integrations/mysql/replayer/synthesize_prepare_eof_test.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/synthesize_prepare_eof_test.go
@@ -1,0 +1,97 @@
+package replayer
+
+import (
+	"context"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/wire"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.keploy.io/server/v3/pkg/models/mysql"
+	"go.uber.org/zap"
+)
+
+// prepareReq builds a COM_STMT_PREPARE request for the given query.
+func prepareReq(query string) mysql.Request {
+	return mysql.Request{PacketBundle: mysql.PacketBundle{
+		Header: &mysql.PacketInfo{
+			Header: &mysql.Header{SequenceID: 0},
+			Type:   mysql.CommandStatusToString(mysql.COM_STMT_PREPARE),
+		},
+		Message: &mysql.StmtPreparePacket{Command: mysql.COM_STMT_PREPARE, Query: query},
+	}}
+}
+
+// TestSynthesizedPrepareOK_ParamDefEOF is the regression guard for the MySQL
+// fuzzer hang: when a COM_STMT_PREPARE has no recorded mock, matchCommand
+// synthesizes a COM_STMT_PREPARE_OK. For a client that did NOT negotiate
+// CLIENT_DEPRECATE_EOF (e.g. go-sql-driver), the parameter-definition block
+// MUST be terminated by an EOF packet, or the driver's readUntilEOF() blocks
+// forever ("driver: bad connection", whole-pool cascade, 1000s deadlock).
+// DEPRECATE_EOF clients must NOT get the terminator, and a zero-param prepare
+// has no param-def block so needs none either.
+func TestSynthesizedPrepareOK_ParamDefEOF(t *testing.T) {
+	logger := zap.NewNop()
+	// A non-empty pool with NO recorded COM_STMT_PREPARE for our query: the
+	// pool must be non-empty (an entirely empty db bails with "no mysql mocks
+	// found" before the synthesize path), but nothing matches the prepare, so
+	// matchCommand falls through to synthesizing a PREPARE_OK.
+	emptyDb := &fakeMockDb{session: []*models.Mock{execMock("unrelated-filler", "x")}}
+
+	synth := func(t *testing.T, dctx *wire.DecodeContext, query string) *mysql.StmtPrepareOkPacket {
+		t.Helper()
+		resp, ok, _, err := matchCommand(context.Background(), logger, prepareReq(query), emptyDb, dctx, nil, nil)
+		if err != nil || !ok || resp == nil {
+			t.Fatalf("expected a synthesized PREPARE_OK (ok=%v err=%v resp=%v)", ok, err, resp)
+		}
+		pkt, isPrep := resp.PacketBundle.Message.(*mysql.StmtPrepareOkPacket)
+		if !isPrep {
+			t.Fatalf("expected *StmtPrepareOkPacket, got %T", resp.PacketBundle.Message)
+		}
+		return pkt
+	}
+
+	t.Run("non-DEPRECATE_EOF client gets a well-formed param-def EOF", func(t *testing.T) {
+		dctx := newDecodeCtx()                                            // ServerCaps=0, ClientCaps=0 → DeprecateEOF()==false
+		pkt := synth(t, dctx, "SELECT id FROM t WHERE a BETWEEN ? AND ?") // 2 params
+
+		if pkt.NumParams != 2 {
+			t.Fatalf("NumParams = %d, want 2", pkt.NumParams)
+		}
+		eof := pkt.EOFAfterParamDefs
+		// Legacy EOF: 4-byte header + 5-byte payload = 9 bytes.
+		if len(eof) != 9 {
+			t.Fatalf("EOFAfterParamDefs len = %d (%v), want 9-byte legacy EOF packet", len(eof), eof)
+		}
+		if eof[4] != 0xFE {
+			t.Fatalf("EOF marker = 0x%02x, want 0xFE", eof[4])
+		}
+		// payload length field (3-byte LE) must be 5.
+		if eof[0] != 0x05 || eof[1] != 0x00 || eof[2] != 0x00 {
+			t.Fatalf("EOF length header = %v, want [5 0 0]", eof[:3])
+		}
+		// sequence id must follow the param defs (seq 2..1+numParams), i.e. 2+numParams.
+		if want := byte(2 + pkt.NumParams); eof[3] != want {
+			t.Fatalf("EOF sequence id = %d, want %d (2+numParams)", eof[3], want)
+		}
+	})
+
+	t.Run("DEPRECATE_EOF client gets no terminator", func(t *testing.T) {
+		dctx := newDecodeCtx()
+		dctx.ServerCaps = wire.CLIENT_DEPRECATE_EOF
+		dctx.ClientCaps = wire.CLIENT_DEPRECATE_EOF
+		pkt := synth(t, dctx, "SELECT id FROM t WHERE a = ?") // 1 param
+		if len(pkt.EOFAfterParamDefs) != 0 {
+			t.Fatalf("DEPRECATE_EOF client must get no param-def EOF, got %v", pkt.EOFAfterParamDefs)
+		}
+	})
+
+	t.Run("zero-param prepare needs no param-def EOF", func(t *testing.T) {
+		pkt := synth(t, newDecodeCtx(), "SELECT 1")
+		if pkt.NumParams != 0 {
+			t.Fatalf("NumParams = %d, want 0", pkt.NumParams)
+		}
+		if len(pkt.EOFAfterParamDefs) != 0 {
+			t.Fatalf("zero-param prepare must have no param-def EOF, got %v", pkt.EOFAfterParamDefs)
+		}
+	})
+}

--- a/pkg/agent/proxy/proxy_v2.go
+++ b/pkg/agent/proxy/proxy_v2.go
@@ -163,8 +163,23 @@ func (p *Proxy) recordViaSupervisor(
 		TLSUpgradeFn:         newProxyTLSUpgradeFn(logger),
 		BumpActivity:         sv.BumpActivity,
 		OnMarkMockIncomplete: svSess.MarkMockIncomplete,
-		OnClientChunkTeed:    sv.MarkPendingWork,
-		RealCertHook:         realCertHook,
+		// Time-attributed complement to OnMarkMockIncomplete: the dropped
+		// chunk's own wire instant is recorded as a zero-width orphan
+		// window so record.go suppresses TCs whose HTTP window contains
+		// it. Unlike the session flag (which voids a later, unrelated
+		// mock — why relay-layer drops under load orphaned TCs the
+		// pressure/next-mock windows never covered), this lands inside the
+		// dropped op's OWN TC window. Attribution is by time only — a
+		// concurrent healthy TC straddling this instant, or a per-test TC
+		// overlapping a dropped reusable/heartbeat chunk, may also be
+		// suppressed; that over-suppression is the accepted "drop the TC
+		// rather than orphan it" tradeoff (see tee.drop). Fast-follow:
+		// thread per-op identity to suppress by exact TC.
+		OnTeeDropWindow: func(_ string, ts time.Time) {
+			svSess.RecordOrphanWindow(ts, ts)
+		},
+		OnClientChunkTeed: sv.MarkPendingWork,
+		RealCertHook:      realCertHook,
 		// User-tunable record-buffer caps. Snapshotted onto the Proxy
 		// at startup from config.Record.RecordBuffer (yaml/flag/env).
 		// Zero values fall through to relay package defaults via

--- a/pkg/agent/proxy/relay/config.go
+++ b/pkg/agent/proxy/relay/config.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"net"
+	"time"
 
 	"go.keploy.io/server/v3/pkg/agent/memoryguard"
 	"go.uber.org/zap"
@@ -124,6 +125,19 @@ type Config struct {
 	// the supervisor will record in telemetry. Nil is safe.
 	OnMarkMockIncomplete func(reason string)
 
+	// OnTeeDropWindow is invoked on tee-chunk drops with the drop reason
+	// AND the dropped chunk's wire timestamp (coalesced per operation,
+	// not one call per chunk). Callers wire this to the supervisor's
+	// RecordOrphanWindow so TCs whose HTTP window contains that instant
+	// are suppressed — the dropped chunk's mock cannot be recorded, so
+	// replaying its TC would orphan it (match_phase=no_mocks). The
+	// decode-lag-immune, time-attributed complement to
+	// OnMarkMockIncomplete (which only voids a later, possibly-unrelated
+	// mock via the session flag). Attribution is by time, so a concurrent
+	// or reusable-mock overlap may over-suppress a healthy TC — an
+	// accepted coverage-for-stability tradeoff. Nil is safe.
+	OnTeeDropWindow func(reason string, ts time.Time)
+
 	// OnClientChunkTeed is invoked after each successful tee of a
 	// client-to-dest chunk into the parser's FakeConn. Callers wire
 	// this to the supervisor's MarkPendingWork so the activity
@@ -194,6 +208,9 @@ func (c Config) withDefaults() Config {
 	}
 	if out.OnMarkMockIncomplete == nil {
 		out.OnMarkMockIncomplete = func(string) {}
+	}
+	if out.OnTeeDropWindow == nil {
+		out.OnTeeDropWindow = func(string, time.Time) {}
 	}
 	return out
 }

--- a/pkg/agent/proxy/relay/relay.go
+++ b/pkg/agent/proxy/relay/relay.go
@@ -159,6 +159,7 @@ func New(cfg Config, src, dst net.Conn) *Relay {
 		cfg.TeeChanBuf,
 		cfg.MemoryGuardCheck,
 		cfg.OnMarkMockIncomplete,
+		cfg.OnTeeDropWindow,
 		cfg.Logger,
 	)
 	r.teeD2C = newTee(
@@ -167,6 +168,7 @@ func New(cfg Config, src, dst net.Conn) *Relay {
 		cfg.TeeChanBuf,
 		cfg.MemoryGuardCheck,
 		cfg.OnMarkMockIncomplete,
+		cfg.OnTeeDropWindow,
 		cfg.Logger,
 	)
 

--- a/pkg/agent/proxy/relay/tee.go
+++ b/pkg/agent/proxy/relay/tee.go
@@ -3,6 +3,7 @@ package relay
 import (
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"go.keploy.io/server/v3/pkg/agent/proxy/fakeconn"
 	"go.uber.org/zap"
@@ -28,6 +29,17 @@ const (
 	DropPaused = "paused"
 )
 
+// dropWindowCoalesceNanos is the minimum gap between two onDropAt
+// orphan-window recordings on the same tee. One overflowing operation is
+// many chunks sharing near-identical wire timestamps; without coalescing
+// each would push a separate zero-width window into the count-bounded
+// orphanRanges ring. 1ms comfortably collapses a single operation's chunk
+// burst (sub-millisecond on the wire) while still recording distinct
+// windows for operations that are milliseconds apart — small enough that
+// even a tight burst of orphaned reads (observed ~1.8ms apart) each keep
+// their own window.
+const dropWindowCoalesceNanos = int64(1_000_000)
+
 // tee is the accounting wrapper around the internal staging channel
 // between the forwarder goroutines and the FakeConn. For each direction
 // the forwarder calls push(c); that either enqueues the chunk onto an
@@ -50,6 +62,17 @@ type tee struct {
 	memCheck func() bool
 	onDrop   func(reason string)
 
+	// onDropAt is called on every drop with the reason AND the wire
+	// timestamp of the dropped chunk. Unlike onDrop (which sets the
+	// session's global incomplete-mock flag, voiding some LATER,
+	// possibly-unrelated mock), this reports the EXACT instant the
+	// lost bytes were on the wire — so the supervisor can record an
+	// orphan window that overlaps the owning TC's own HTTP window and
+	// suppress precisely that TC. Recorded synchronously on the
+	// forward path, so it is immune to parser decode lag (the reason
+	// the previous next-mock-void attribution missed most orphans).
+	onDropAt func(reason string, ts time.Time)
+
 	// staging is the internal buffered channel. Forwarders push into
 	// it; the drain goroutine pulls out.
 	staging chan fakeconn.Chunk
@@ -70,6 +93,19 @@ type tee struct {
 	// drops counts dropped chunks for this direction. Exposed via
 	// [tee.dropCount] for diagnostics and tests.
 	drops atomic.Uint64
+
+	// lastDropRecNanos is the wire timestamp (UnixNano) of the most
+	// recent chunk for which onDropAt actually recorded an orphan
+	// window. onDropAt fires PER CHUNK, but one overflowing operation
+	// is hundreds of chunks sharing near-identical timestamps; recording
+	// a window for every one would flood the count-bounded orphanRanges
+	// ring (evicting windows for earlier, not-yet-checked TCs). We
+	// coalesce: a new drop within dropWindowCoalesceNanos of the last
+	// recorded one is skipped — collapsing an operation's chunk burst to
+	// ~one window while still separating distinct operations (which are
+	// milliseconds apart). Best-effort under concurrent pushes (a benign
+	// extra record at worst); onDrop/MarkMockIncomplete is unaffected.
+	lastDropRecNanos atomic.Int64
 
 	// closeMu is held in read mode during a push's channel send and
 	// in write mode by close. This ensures no in-flight send is racing
@@ -92,13 +128,14 @@ type tee struct {
 // newTee wires a staging channel, an out channel, and a drain
 // goroutine that moves chunks from staging to out while maintaining
 // the bytes counter.
-func newTee(dir fakeconn.Direction, capBytes int64, chanBuf int, memCheck func() bool, onDrop func(reason string), logger *zap.Logger) *tee {
+func newTee(dir fakeconn.Direction, capBytes int64, chanBuf int, memCheck func() bool, onDrop func(reason string), onDropAt func(reason string, ts time.Time), logger *zap.Logger) *tee {
 	t := &tee{
 		dir:      dir,
 		logger:   logger,
 		cap:      capBytes,
 		memCheck: memCheck,
 		onDrop:   onDrop,
+		onDropAt: onDropAt,
 		staging:  make(chan fakeconn.Chunk, chanBuf),
 		out:      make(chan fakeconn.Chunk, chanBuf),
 		done:     make(chan struct{}),
@@ -136,11 +173,11 @@ func (t *tee) push(c fakeconn.Chunk) bool {
 		return false
 	}
 	if t.paused.Load() {
-		t.drop(DropPaused)
+		t.drop(DropPaused, teeChunkTs(c))
 		return false
 	}
 	if t.memCheck != nil && t.memCheck() {
-		t.drop(DropMemoryPressure)
+		t.drop(DropMemoryPressure, teeChunkTs(c))
 		return false
 	}
 	n := int64(len(c.Bytes))
@@ -152,7 +189,7 @@ func (t *tee) push(c fakeconn.Chunk) bool {
 	// an over- or under-count of one chunk; the cap is a soft limit
 	// by contract.
 	if t.bytes.Load()+n > t.cap {
-		t.drop(DropPerConnCap)
+		t.drop(DropPerConnCap, teeChunkTs(c))
 		return false
 	}
 
@@ -173,9 +210,24 @@ func (t *tee) push(c fakeconn.Chunk) bool {
 		return true
 	default:
 		t.closeMu.RUnlock()
-		t.drop(DropChannelFull)
+		t.drop(DropChannelFull, teeChunkTs(c))
 		return false
 	}
+}
+
+// teeChunkTs returns the wire timestamp of a chunk for orphan-window
+// attribution: the client-read time (ReadAt) when set, else the
+// dest-write time (WrittenAt). Both are stamped by the forwarder with
+// the same wall clock the ingress uses for HTTP TC request/response
+// timestamps, so a [ts, ts] window recorded here overlaps the owning
+// TC's HTTP window. A pre-dispatch stash chunk carries only ReadAt; a
+// forwarded chunk carries both. Zero when neither is set (the caller
+// then records nothing).
+func teeChunkTs(c fakeconn.Chunk) time.Time {
+	if !c.ReadAt.IsZero() {
+		return c.ReadAt
+	}
+	return c.WrittenAt
 }
 
 // drop bumps counters and notifies. Kept small so push stays inlineable.
@@ -189,10 +241,30 @@ func (t *tee) push(c fakeconn.Chunk) bool {
 // "incomplete mock" enable --debug to see them, normal runs stay
 // quiet. Subsequent drops still increment drops_total and fire onDrop
 // unchanged — only the log emission is rate-limited.
-func (t *tee) drop(reason string) {
+func (t *tee) drop(reason string, ts time.Time) {
 	n := t.drops.Add(1)
 	if t.onDrop != nil {
 		t.onDrop(reason)
+	}
+	// Report the dropped chunk's own wire instant so the supervisor can
+	// record an orphan window and suppress a TC whose HTTP window
+	// contains it. Recorded on the forward path (decode-lag immune),
+	// unlike the onDrop next-mock-void which attributes the loss to a
+	// later mock. Attribution is by time only (the tee has no TC or mock
+	// identity): it correctly catches the dropped operation's own TC, but
+	// a concurrent healthy TC on another connection whose HTTP window
+	// straddles this instant — or a per-test TC overlapping a dropped
+	// REUSABLE (session/heartbeat) chunk — may also be suppressed. That
+	// over-suppression trades a little coverage for no orphaned replay,
+	// the same tradeoff the pressure-range path already makes. Coalesced
+	// per operation to keep the bounded orphanRanges ring from flooding.
+	if t.onDropAt != nil && !ts.IsZero() {
+		n := ts.UnixNano()
+		last := t.lastDropRecNanos.Load()
+		if last == 0 || n-last >= dropWindowCoalesceNanos || last-n >= dropWindowCoalesceNanos {
+			t.lastDropRecNanos.Store(n)
+			t.onDropAt(reason, ts)
+		}
 	}
 	if t.logger != nil && n&(n-1) == 0 {
 		// n is a power of two (1, 2, 4, 8, ...) — log this drop.

--- a/pkg/agent/proxy/relay/tee.go
+++ b/pkg/agent/proxy/relay/tee.go
@@ -247,18 +247,27 @@ func (t *tee) drop(reason string, ts time.Time) {
 		t.onDrop(reason)
 	}
 	// Report the dropped chunk's own wire instant so the supervisor can
-	// record an orphan window and suppress a TC whose HTTP window
-	// contains it. Recorded on the forward path (decode-lag immune),
-	// unlike the onDrop next-mock-void which attributes the loss to a
-	// later mock. Attribution is by time only (the tee has no TC or mock
-	// identity): it correctly catches the dropped operation's own TC, but
-	// a concurrent healthy TC on another connection whose HTTP window
-	// straddles this instant — or a per-test TC overlapping a dropped
-	// REUSABLE (session/heartbeat) chunk — may also be suppressed. That
-	// over-suppression trades a little coverage for no orphaned replay,
-	// the same tradeoff the pressure-range path already makes. Coalesced
-	// per operation to keep the bounded orphanRanges ring from flooding.
-	if t.onDropAt != nil && !ts.IsZero() {
+	// record an orphan window and suppress a TC whose HTTP window contains
+	// it — for the non-pressure drop reasons only. Recorded on the forward
+	// path (decode-lag immune), unlike the onDrop next-mock-void which
+	// attributes the loss to a later mock. Attribution is by time only (the
+	// tee has no TC or mock identity): it correctly catches the dropped
+	// operation's own TC, but a concurrent healthy TC whose HTTP window
+	// straddles this instant may also be suppressed — the same coverage-for-
+	// stability tradeoff the pressure-range path makes.
+	//
+	// memory_pressure is deliberately EXCLUDED: the memoryguard already
+	// records the whole pause as a pressureRange, and during a pause EVERY
+	// chunk drops with this reason for the pause's full (multi-second)
+	// duration — so recording a per-chunk window here is both redundant
+	// (pressureRange covers any TC straddling the pause; no TC is captured
+	// wholly within one) AND actively harmful: it floods the count-bounded
+	// orphanRanges ring with thousands of pause-interval windows that
+	// overlap no TC, EVICTING the genuinely-uncovered channel_full/
+	// per_conn_cap/parser windows from calm periods that are the whole point
+	// of this path. Coalescing alone can't fix that (1ms coalescing over a
+	// multi-second pause still yields thousands). Skip it here.
+	if reason != DropMemoryPressure && t.onDropAt != nil && !ts.IsZero() {
 		n := ts.UnixNano()
 		last := t.lastDropRecNanos.Load()
 		if last == 0 || n-last >= dropWindowCoalesceNanos || last-n >= dropWindowCoalesceNanos {

--- a/pkg/agent/proxy/relay/tee_test.go
+++ b/pkg/agent/proxy/relay/tee_test.go
@@ -181,19 +181,20 @@ func TestTee_DropRecordsWindowAt(t *testing.T) {
 		return fakeconn.Chunk{Dir: fakeconn.FromClient, Bytes: []byte(payload), ReadAt: stamp}
 	}
 
-	// memory_pressure
+	// memory_pressure: drops, but records NO orphan window (the memoryguard
+	// already records the pause as a pressureRange; a per-chunk window here
+	// would flood the bounded ring for the pause's whole duration).
 	var paused atomic.Bool
 	paused.Store(true)
 	tt, _, rec := newTestTee(t, 1<<20, 4, paused.Load)
 	if tt.push(chunkAt("x")) {
 		t.Fatalf("push should have dropped under memory pressure")
 	}
-	reasons, tss := rec.atSnapshot()
-	if len(reasons) != 1 || reasons[0] != DropMemoryPressure {
-		t.Fatalf("want one memory_pressure window, got reasons %v", reasons)
+	if rec.count(DropMemoryPressure) != 1 {
+		t.Fatalf("want 1 memory_pressure drop recorded via onDrop, got %v", rec.snapshot())
 	}
-	if !tss[0].Equal(stamp) {
-		t.Fatalf("window ts = %v, want the dropped chunk's ReadAt %v", tss[0], stamp)
+	if reasons, _ := rec.atSnapshot(); len(reasons) != 0 {
+		t.Fatalf("memory_pressure must record NO orphan window (pressureRange covers it), got %v", reasons)
 	}
 
 	// paused
@@ -256,16 +257,16 @@ func TestTee_DropWindowChannelFullCoalesceFallback(t *testing.T) {
 	}
 
 	// --- distinct operations (>1ms apart) each keep their own window ---
-	// Use the paused path so every push drops deterministically (the
-	// channel_full path races the drain goroutine on which pushes drop).
-	var alwaysPaused atomic.Bool
-	alwaysPaused.Store(true)
-	tt2, _, rec2 := newTestTee(t, 1<<30, 4, alwaysPaused.Load)
+	// Use the DropPaused path (setPaused) for deterministic drops that DO
+	// record windows — memory_pressure no longer records one, and the
+	// channel_full path races the drain goroutine on which pushes drop.
+	tt2, _, rec2 := newTestTee(t, 1<<30, 4, nil)
+	tt2.setPaused(true)
 	base := time.Unix(1700000000, 0)
 	for i := 0; i < 6; i++ {
 		ts := base.Add(time.Duration(i) * 2 * time.Millisecond) // 2ms apart
 		if tt2.push(fakeconn.Chunk{Dir: fakeconn.FromClient, Bytes: []byte("y"), ReadAt: ts}) {
-			t.Fatalf("push should drop under pressure")
+			t.Fatalf("push while paused should drop")
 		}
 	}
 	if rs2, _ := rec2.atSnapshot(); len(rs2) != 6 {
@@ -273,21 +274,21 @@ func TestTee_DropWindowChannelFullCoalesceFallback(t *testing.T) {
 	}
 
 	// --- WrittenAt fallback when ReadAt is zero (dest-side pre-forward stamp) ---
-	var paused atomic.Bool
-	paused.Store(true)
-	tt3, _, rec3 := newTestTee(t, 1<<20, 4, paused.Load)
+	tt3, _, rec3 := newTestTee(t, 1<<20, 4, nil)
+	tt3.setPaused(true)
 	wStamp := time.Unix(1700000001, 777)
 	if tt3.push(fakeconn.Chunk{Dir: fakeconn.FromDest, Bytes: []byte("z"), WrittenAt: wStamp}) {
-		t.Fatalf("push should drop under pressure")
+		t.Fatalf("push while paused should drop")
 	}
 	if rs3, ts3 := rec3.atSnapshot(); len(rs3) != 1 || !ts3[0].Equal(wStamp) {
 		t.Fatalf("WrittenAt fallback: want one window at %v, got %v / %v", wStamp, rs3, ts3)
 	}
 
 	// --- zero-timestamp chunk records NO window ---
-	tt4, _, rec4 := newTestTee(t, 1<<20, 4, paused.Load)
+	tt4, _, rec4 := newTestTee(t, 1<<20, 4, nil)
+	tt4.setPaused(true)
 	if tt4.push(fakeconn.Chunk{Dir: fakeconn.FromClient, Bytes: []byte("q")}) {
-		t.Fatalf("push should drop under pressure")
+		t.Fatalf("push while paused should drop")
 	}
 	if rs4, _ := rec4.atSnapshot(); len(rs4) != 0 {
 		t.Fatalf("zero-ts chunk must record no window, got %v", rs4)

--- a/pkg/agent/proxy/relay/tee_test.go
+++ b/pkg/agent/proxy/relay/tee_test.go
@@ -14,7 +14,7 @@ import (
 func newTestTee(t *testing.T, capBytes int64, buf int, memCheck func() bool) (*tee, func(reason string), *dropRecorder) {
 	t.Helper()
 	rec := &dropRecorder{}
-	t2 := newTee(fakeconn.FromClient, capBytes, buf, memCheck, rec.record, nil)
+	t2 := newTee(fakeconn.FromClient, capBytes, buf, memCheck, rec.record, rec.recordAt, nil)
 	t.Cleanup(func() {
 		t2.close()
 		t2.waitDone()
@@ -22,16 +22,38 @@ func newTestTee(t *testing.T, capBytes int64, buf int, memCheck func() bool) (*t
 	return t2, rec.record, rec
 }
 
-// dropRecorder collects drop reasons for assertion.
+// dropRecorder collects drop reasons for assertion. It also records the
+// (reason, ts) pairs delivered via the onDropAt callback so tests can
+// assert the accurately-attributed orphan-window path.
 type dropRecorder struct {
 	mu      sync.Mutex
 	reasons []string
+	atTs    []time.Time
+	atReas  []string
 }
 
 func (d *dropRecorder) record(reason string) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.reasons = append(d.reasons, reason)
+}
+
+func (d *dropRecorder) recordAt(reason string, ts time.Time) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.atReas = append(d.atReas, reason)
+	d.atTs = append(d.atTs, ts)
+}
+
+// atSnapshot returns the (reason, ts) pairs seen via onDropAt.
+func (d *dropRecorder) atSnapshot() ([]string, []time.Time) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	rs := make([]string, len(d.atReas))
+	copy(rs, d.atReas)
+	ts := make([]time.Time, len(d.atTs))
+	copy(ts, d.atTs)
+	return rs, ts
 }
 
 func (d *dropRecorder) snapshot() []string {
@@ -146,9 +168,135 @@ func TestTee_PausedDropsWithoutCapUsage(t *testing.T) {
 	}
 }
 
+// TestTee_DropRecordsWindowAt is the guard for the orphan-window fix:
+// every drop path must report the dropped chunk's OWN wire timestamp via
+// onDropAt (so the supervisor can suppress the TC whose HTTP window
+// contains it), and a successful push must report nothing. A regression
+// that stops threading the timestamp — or reverts drop() to not calling
+// onDropAt — makes this fail.
+func TestTee_DropRecordsWindowAt(t *testing.T) {
+	t.Parallel()
+	stamp := time.Unix(1700000000, 12345)
+	chunkAt := func(payload string) fakeconn.Chunk {
+		return fakeconn.Chunk{Dir: fakeconn.FromClient, Bytes: []byte(payload), ReadAt: stamp}
+	}
+
+	// memory_pressure
+	var paused atomic.Bool
+	paused.Store(true)
+	tt, _, rec := newTestTee(t, 1<<20, 4, paused.Load)
+	if tt.push(chunkAt("x")) {
+		t.Fatalf("push should have dropped under memory pressure")
+	}
+	reasons, tss := rec.atSnapshot()
+	if len(reasons) != 1 || reasons[0] != DropMemoryPressure {
+		t.Fatalf("want one memory_pressure window, got reasons %v", reasons)
+	}
+	if !tss[0].Equal(stamp) {
+		t.Fatalf("window ts = %v, want the dropped chunk's ReadAt %v", tss[0], stamp)
+	}
+
+	// paused
+	tt2, _, rec2 := newTestTee(t, 1<<20, 4, nil)
+	tt2.setPaused(true)
+	if tt2.push(chunkAt("y")) {
+		t.Fatalf("push while paused should drop")
+	}
+	// per_conn_cap on the same tee after resume (cap 1<<20 won't trip; use a tiny-cap tee)
+	tt3, _, rec3 := newTestTee(t, 4, 16, nil)
+	if !tt3.push(chunkAt("abc")) {
+		t.Fatalf("first push should fit under cap")
+	}
+	if tt3.push(chunkAt("def")) {
+		t.Fatalf("second push should exceed per_conn_cap")
+	}
+	rs2, ts2 := rec2.atSnapshot()
+	if len(rs2) != 1 || rs2[0] != DropPaused || !ts2[0].Equal(stamp) {
+		t.Fatalf("paused: want one paused window at %v, got %v / %v", stamp, rs2, ts2)
+	}
+	rs3, ts3 := rec3.atSnapshot()
+	if len(rs3) != 1 || rs3[0] != DropPerConnCap || !ts3[0].Equal(stamp) {
+		t.Fatalf("per_conn_cap: want one per_conn_cap window at %v, got %v / %v", stamp, rs3, ts3)
+	}
+
+	// A successful push records NO window.
+	tt4, _, rec4 := newTestTee(t, 1<<20, 4, nil)
+	if !tt4.push(chunkAt("ok")) {
+		t.Fatalf("healthy push should succeed")
+	}
+	if rs, _ := rec4.atSnapshot(); len(rs) != 0 {
+		t.Fatalf("healthy push must record no orphan window, got %v", rs)
+	}
+}
+
+// TestTee_DropWindowChannelFullCoalesceFallback covers the paths
+// TestTee_DropRecordsWindowAt does not: the channel_full drop (the
+// primary target of the fix, and the only path where drop() runs after
+// closeMu.RUnlock), per-operation coalescing of a chunk burst, the
+// WrittenAt fallback when ReadAt is unset, and the zero-timestamp guard.
+func TestTee_DropWindowChannelFullCoalesceFallback(t *testing.T) {
+	t.Parallel()
+
+	// --- channel_full + coalescing: many same-instant chunk drops -> ONE window ---
+	stamp := time.Unix(1700000000, 500000)
+	tt, _, rec := newTestTee(t, 1<<30, 1, nil) // buf=1, never drained -> staging fills
+	for i := 0; i < 20; i++ {
+		tt.push(fakeconn.Chunk{Dir: fakeconn.FromClient, Bytes: []byte("x"), ReadAt: stamp})
+	}
+	time.Sleep(20 * time.Millisecond)
+	if rec.count(DropChannelFull) == 0 {
+		t.Fatalf("expected channel_full drops, got %v", rec.snapshot())
+	}
+	rs, tss := rec.atSnapshot()
+	if len(rs) != 1 {
+		t.Fatalf("coalescing failed: want exactly 1 window for the same-instant burst, got %d (%v)", len(rs), rs)
+	}
+	if rs[0] != DropChannelFull || !tss[0].Equal(stamp) {
+		t.Fatalf("want one channel_full window at %v, got %v / %v", stamp, rs, tss)
+	}
+
+	// --- distinct operations (>1ms apart) each keep their own window ---
+	// Use the paused path so every push drops deterministically (the
+	// channel_full path races the drain goroutine on which pushes drop).
+	var alwaysPaused atomic.Bool
+	alwaysPaused.Store(true)
+	tt2, _, rec2 := newTestTee(t, 1<<30, 4, alwaysPaused.Load)
+	base := time.Unix(1700000000, 0)
+	for i := 0; i < 6; i++ {
+		ts := base.Add(time.Duration(i) * 2 * time.Millisecond) // 2ms apart
+		if tt2.push(fakeconn.Chunk{Dir: fakeconn.FromClient, Bytes: []byte("y"), ReadAt: ts}) {
+			t.Fatalf("push should drop under pressure")
+		}
+	}
+	if rs2, _ := rec2.atSnapshot(); len(rs2) != 6 {
+		t.Fatalf("distinct 2ms-apart drops must each record (no coalescing): want 6 windows, got %d", len(rs2))
+	}
+
+	// --- WrittenAt fallback when ReadAt is zero (dest-side pre-forward stamp) ---
+	var paused atomic.Bool
+	paused.Store(true)
+	tt3, _, rec3 := newTestTee(t, 1<<20, 4, paused.Load)
+	wStamp := time.Unix(1700000001, 777)
+	if tt3.push(fakeconn.Chunk{Dir: fakeconn.FromDest, Bytes: []byte("z"), WrittenAt: wStamp}) {
+		t.Fatalf("push should drop under pressure")
+	}
+	if rs3, ts3 := rec3.atSnapshot(); len(rs3) != 1 || !ts3[0].Equal(wStamp) {
+		t.Fatalf("WrittenAt fallback: want one window at %v, got %v / %v", wStamp, rs3, ts3)
+	}
+
+	// --- zero-timestamp chunk records NO window ---
+	tt4, _, rec4 := newTestTee(t, 1<<20, 4, paused.Load)
+	if tt4.push(fakeconn.Chunk{Dir: fakeconn.FromClient, Bytes: []byte("q")}) {
+		t.Fatalf("push should drop under pressure")
+	}
+	if rs4, _ := rec4.atSnapshot(); len(rs4) != 0 {
+		t.Fatalf("zero-ts chunk must record no window, got %v", rs4)
+	}
+}
+
 func TestTee_ClosePreventsSendPanic(t *testing.T) {
 	t.Parallel()
-	tt := newTee(fakeconn.FromClient, 1<<20, 4, nil, nil, nil)
+	tt := newTee(fakeconn.FromClient, 1<<20, 4, nil, nil, nil, nil)
 
 	// Spawn pushers racing with close; no panic expected.
 	var wg sync.WaitGroup
@@ -169,7 +317,7 @@ func TestTee_ClosePreventsSendPanic(t *testing.T) {
 
 func TestTee_CloseIsIdempotent(t *testing.T) {
 	t.Parallel()
-	tt := newTee(fakeconn.FromClient, 1<<20, 4, nil, nil, nil)
+	tt := newTee(fakeconn.FromClient, 1<<20, 4, nil, nil, nil, nil)
 	tt.close()
 	tt.close() // must not panic
 	tt.waitDone()
@@ -195,7 +343,7 @@ func TestTee_StagedChunkSurvivesClose(t *testing.T) {
 	const iters = 200
 	for i := 0; i < iters; i++ {
 		rec := &dropRecorder{}
-		tt := newTee(fakeconn.FromClient, 1<<30, 4, nil, rec.record, nil)
+		tt := newTee(fakeconn.FromClient, 1<<30, 4, nil, rec.record, rec.recordAt, nil)
 
 		// Admit a chunk into staging, then immediately tear the tee
 		// down — mirroring the forwarder pushing the final response

--- a/pkg/agent/proxy/supervisor/orphan_window_test.go
+++ b/pkg/agent/proxy/supervisor/orphan_window_test.go
@@ -1,0 +1,160 @@
+package supervisor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	syncMock "go.keploy.io/server/v3/pkg/agent/proxy/syncMock"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap/zaptest"
+)
+
+// TestEmitMockIncompleteRecordsOrphanWindow is the root-cause repro for the
+// go-memory-load-mongo no_mocks flake. When a parser marks its mock incomplete
+// (reassembly overflow, a decode error on the post-pressure realignment tail,
+// per-conn cap, short write) the NEXT emitMockCore drops the mock SILENTLY —
+// and before this fix it told NO ONE, so the test case that owns the operation
+// still streamed to the CLI and reached replay mock-less (match_phase=no_mocks).
+// The fix records the dropped mock's wire window as an orphan window so
+// record.go suppresses the owning TC. This drives the real EmitMock path.
+func TestEmitMockIncompleteRecordsOrphanWindow(t *testing.T) {
+	t.Parallel()
+	mgr := &syncMock.SyncMockManager{}
+	ch := make(chan *models.Mock, 1)
+	base := time.Now()
+	reqTs := base.Add(10 * time.Millisecond)
+	resTs := base.Add(30 * time.Millisecond)
+	sess := &Session{
+		Mocks:  ch,
+		Ctx:    context.Background(),
+		Logger: zaptest.NewLogger(t),
+		Mgr:    mgr,
+	}
+
+	// Precondition (the bug): with no orphan window recorded, a TC whose HTTP
+	// window spans the operation is NOT suppressible — it would reach replay.
+	if ok, _ := mgr.WasMockOrphanedInWindow(base, base.Add(50*time.Millisecond)); ok {
+		t.Fatalf("no orphan window should exist before any incomplete drop")
+	}
+
+	// A mock is voided by the incomplete flag; its wire window is [reqTs, resTs].
+	sess.MarkMockIncomplete("request decode error")
+	dropped := &models.Mock{
+		Name: "find-customers",
+		Spec: models.MockSpec{ReqTimestampMock: reqTs, ResTimestampMock: resTs},
+	}
+	if err := sess.EmitMock(dropped); err != nil {
+		t.Fatalf("EmitMock returned err: %v", err)
+	}
+
+	// The mock itself must NOT have leaked to the sink (still dropped).
+	select {
+	case got := <-ch:
+		t.Fatalf("incomplete mock leaked to channel: %v", got.Name)
+	default:
+	}
+
+	// The fix: the owning TC (HTTP window overlapping [reqTs, resTs]) is now
+	// suppressible via the recorded orphan window.
+	if ok, cnt := mgr.WasMockOrphanedInWindow(base, base.Add(50*time.Millisecond)); !ok || cnt != 1 {
+		t.Fatalf("incomplete drop must record an orphan window over the mock's wire window; got ok=%v cnt=%d", ok, cnt)
+	}
+	// A concurrent TC that does NOT overlap the voided op is not suppressed.
+	if ok, _ := mgr.WasMockOrphanedInWindow(base.Add(100*time.Millisecond), base.Add(200*time.Millisecond)); ok {
+		t.Fatalf("a TC window not overlapping the voided op must not be suppressed")
+	}
+}
+
+// TestEmitMockIncompleteSkipsSessionLifetimeMock pins the guard that a voided
+// SESSION/CONNECTION mock (a reusable mongo handshake/heartbeat, served from
+// the session tier at replay regardless of the drop) does NOT record an orphan
+// window — recording it would only risk over-suppressing a healthy per-test TC
+// that overlaps its window, since a stale mockIncomplete flag can void a
+// reusable mock that belongs to no test at all.
+func TestEmitMockIncompleteSkipsSessionLifetimeMock(t *testing.T) {
+	t.Parallel()
+	for _, lt := range []models.Lifetime{models.LifetimeSession, models.LifetimeConnection} {
+		mgr := &syncMock.SyncMockManager{}
+		sess := &Session{
+			Mocks:  make(chan *models.Mock, 1),
+			Ctx:    context.Background(),
+			Logger: zaptest.NewLogger(t),
+			Mgr:    mgr,
+		}
+		sess.MarkMockIncomplete("memory_pressure")
+		reusable := &models.Mock{
+			Name: "hello-heartbeat",
+			Spec: models.MockSpec{
+				ReqTimestampMock: time.Now(),
+				ResTimestampMock: time.Now().Add(time.Millisecond),
+			},
+			TestModeInfo: models.TestModeInfo{Lifetime: lt},
+		}
+		if err := sess.EmitMock(reusable); err != nil {
+			t.Fatalf("EmitMock: %v", err)
+		}
+		if got := mgr.OrphanRangeCount(); got != 0 {
+			t.Fatalf("a voided %v mock must NOT record an orphan window; count=%d", lt, got)
+		}
+	}
+}
+
+// TestEmitMockHealthyRecordsNoOrphanWindow is the control: a normal emit (no
+// incomplete flag) must NOT record an orphan window, so healthy TCs are never
+// spuriously suppressed.
+func TestEmitMockHealthyRecordsNoOrphanWindow(t *testing.T) {
+	t.Parallel()
+	mgr := &syncMock.SyncMockManager{}
+	ch := make(chan *models.Mock, 1)
+	sess := &Session{
+		Mocks:  ch,
+		Ctx:    context.Background(),
+		Logger: zaptest.NewLogger(t),
+		Mgr:    mgr,
+	}
+	// RouteMocksViaSyncMock is false → direct-channel emit; the mock delivers
+	// and NO orphan window is recorded.
+	m := &models.Mock{Name: "ok", Spec: models.MockSpec{ReqTimestampMock: time.Now()}}
+	if err := sess.EmitMock(m); err != nil {
+		t.Fatalf("EmitMock: %v", err)
+	}
+	if got := mgr.OrphanRangeCount(); got != 0 {
+		t.Fatalf("healthy emit must not record an orphan window; count=%d", got)
+	}
+	select {
+	case got := <-ch:
+		if got.Name != "ok" {
+			t.Fatalf("wrong mock delivered: %v", got.Name)
+		}
+	default:
+		t.Fatalf("healthy mock was not delivered")
+	}
+}
+
+// TestRecordOrphanWindowPublicPath covers the no-mock-built case: a parser that
+// voids an operation BEFORE any mock is emitted (reassembly overflow, decode
+// error) reports the operation's own wire window via Session.RecordOrphanWindow,
+// making that TC suppressible even though emitMockCore never ran for it. Also
+// pins the nil-session and zero-start guards are no-ops.
+func TestRecordOrphanWindowPublicPath(t *testing.T) {
+	t.Parallel()
+	mgr := &syncMock.SyncMockManager{}
+	sess := &Session{Ctx: context.Background(), Mgr: mgr}
+
+	opStart := time.Now()
+	opEnd := opStart.Add(5 * time.Millisecond)
+	sess.RecordOrphanWindow(opStart, opEnd)
+
+	if ok, _ := mgr.WasMockOrphanedInWindow(opStart.Add(-time.Millisecond), opEnd.Add(time.Millisecond)); !ok {
+		t.Fatalf("RecordOrphanWindow must make the failing op's TC suppressible")
+	}
+
+	// Guards: nil session and zero-start are no-ops (must not panic or record).
+	var nilSess *Session
+	nilSess.RecordOrphanWindow(opStart, opEnd)
+	sess.RecordOrphanWindow(time.Time{}, opEnd)
+	if got := mgr.OrphanRangeCount(); got != 1 {
+		t.Fatalf("guards must be no-ops; expected exactly 1 window, got %d", got)
+	}
+}

--- a/pkg/agent/proxy/supervisor/session.go
+++ b/pkg/agent/proxy/supervisor/session.go
@@ -188,9 +188,18 @@ func (s *Session) AddPostRecordHook(h PostRecordHook) {
 // "why was a mock withheld?" (memory pressure, channel full, dropped
 // chunk, parser-internal inconsistency) can enable --debug to see it;
 // subsequent calls within the same session are no-ops and emit nothing.
-// Production runs stay quiet because the forward path is unaffected —
-// only mock recording is impacted, which is an internal concern not a
-// user-facing problem.
+// Production runs stay quiet because the forward path is unaffected.
+//
+// A voided mock is NOT harmless: the test case that owns the operation
+// still streams to the CLI, so dropping its mock silently orphans that TC
+// at replay (match_phase=no_mocks). When a mock DOES reach emitMockCore
+// and is dropped by this flag, emitMockCore records the mock's wire window
+// as an orphan window so record.go suppresses the owning TC. When the
+// parser voids an operation BEFORE any mock is built (a reassembly
+// overflow, or a decode error on the realignment tail after a
+// memory-pressure gap), no mock reaches emitMockCore — the parser should
+// additionally call Session.RecordOrphanWindow with that operation's wire
+// window so its TC is suppressed too.
 //
 // The relay calls this when it gates a chunk at the tee; parsers call
 // it when they cannot continue decoding a mock cleanly. Safe to call
@@ -222,6 +231,37 @@ func (s *Session) IsMockIncomplete() bool {
 		return false
 	}
 	return s.mockIncomplete.Load()
+}
+
+// orphanManager resolves the SyncMockManager this session records into,
+// preferring the per-app s.Mgr and falling back to the package-global. Mirrors
+// the manager resolution in emitMockCore's RouteMocksViaSyncMock branch so an
+// orphan window lands on the SAME manager that owns the dropped mock.
+func (s *Session) orphanManager() *syncMock.SyncMockManager {
+	if s == nil {
+		return nil
+	}
+	if s.Mgr != nil {
+		return s.Mgr
+	}
+	return syncMock.Get()
+}
+
+// RecordOrphanWindow lets a parser report that the operation whose wire window
+// is [start, end] lost its mock because the parser could not build one at all —
+// e.g. a client/server reassembly overflow, or a decode error on the
+// realignment tail after a memory-pressure gap. In those cases NO mock reaches
+// emitMockCore (the mockIncomplete flag instead voids the NEXT mock, which may
+// belong to a different TC), so the failing operation's own TC would leak
+// unless the parser reports its window here. record.go then suppresses any TC
+// whose HTTP window overlaps. Complements MarkMockIncomplete: MarkMockIncomplete
+// voids the mock; RecordOrphanWindow makes that void visible to TC suppression
+// by the operation's own captured timestamps. Safe with a nil session or a zero
+// start (both no-ops — see (*SyncMockManager).RecordOrphanWindow).
+func (s *Session) RecordOrphanWindow(start, end time.Time) {
+	if mgr := s.orphanManager(); mgr != nil {
+		mgr.RecordOrphanWindow(start, end)
+	}
 }
 
 // EmitMock sends m to the mocks channel. If the session's active mock
@@ -309,6 +349,29 @@ func (s *Session) emitMockCore(m *models.Mock, shutdown bool) error {
 		// connection goes idle, producing spurious aborts after a
 		// benign drop (memory pressure, chunk gate, short write).
 		s.mockIncomplete.Store(false)
+		// The mock is abandoned, but the test case that owns this
+		// operation still streams to the CLI — dropping the mock without
+		// telling anyone orphans that TC (replay match_phase=no_mocks).
+		// Record the mock's own wire window as an orphan window so
+		// record.go suppresses the owning TC, exactly as it does for a
+		// memory-pressure drop via WasPressureActiveInWindow. The
+		// timestamps are the parser's captured values — the same clock the
+		// TC's HTTP window is compared against — so a zero timestamp
+		// (parser left it unset) is simply ignored by RecordOrphanWindow
+		// rather than over-claiming.
+		//
+		// Only PER-TEST mocks orphan a specific TC. A voided SESSION or
+		// CONNECTION mock (a mongo handshake/heartbeat and the like) is
+		// reusable and served from the session tier at replay regardless of
+		// this drop, so recording its window would gain nothing and only
+		// risk over-suppressing a healthy per-test TC that happens to
+		// overlap it. Skip those — the stale mockIncomplete flag can void a
+		// reusable mock that belongs to no test at all.
+		if mgr := s.orphanManager(); mgr != nil &&
+			m.TestModeInfo.Lifetime != models.LifetimeSession &&
+			m.TestModeInfo.Lifetime != models.LifetimeConnection {
+			mgr.RecordOrphanWindow(m.Spec.ReqTimestampMock, m.Spec.ResTimestampMock)
+		}
 		if s.Logger != nil {
 			// Debug-level: this fires on every mock that loses an
 			// upstream chunk (per-request frequency on a misconfigured

--- a/pkg/agent/proxy/syncMock/orphan_window_test.go
+++ b/pkg/agent/proxy/syncMock/orphan_window_test.go
@@ -1,0 +1,137 @@
+package manager
+
+import (
+	"testing"
+	"time"
+)
+
+// TestOrphanWindowOverlapSemantics pins the join contract record.go relies on:
+// a recorded non-pressure mock-void window suppresses exactly the TCs whose
+// HTTP [req, resp] window overlaps it, and no others.
+func TestOrphanWindowOverlapSemantics(t *testing.T) {
+	t.Parallel()
+	mgr := &SyncMockManager{}
+	base := time.Now()
+	ms := func(n int) time.Time { return base.Add(time.Duration(n) * time.Millisecond) }
+
+	// A mock voided over the wire window [10ms, 20ms].
+	mgr.RecordOrphanWindow(ms(10), ms(20))
+
+	// A TC whose HTTP window [0, 15ms] straddles the void → suppressed.
+	if ok, cnt := mgr.WasMockOrphanedInWindow(ms(0), ms(15)); !ok || cnt != 1 {
+		t.Fatalf("straddling TC window must be suppressed; got ok=%v cnt=%d", ok, cnt)
+	}
+	// A TC fully inside the void → suppressed.
+	if ok, _ := mgr.WasMockOrphanedInWindow(ms(12), ms(18)); !ok {
+		t.Fatalf("TC window inside the void must be suppressed")
+	}
+	// A TC that touches the boundary (end == void.start) → overlaps (closed
+	// intervals), suppressed.
+	if ok, _ := mgr.WasMockOrphanedInWindow(ms(5), ms(10)); !ok {
+		t.Fatalf("boundary-touching TC window must be suppressed")
+	}
+	// A TC entirely after the void → NOT suppressed (no over-suppression of a
+	// concurrent TC that kept all its mocks).
+	if ok, _ := mgr.WasMockOrphanedInWindow(ms(30), ms(40)); ok {
+		t.Fatalf("non-overlapping TC window must NOT be suppressed")
+	}
+	// A TC entirely before the void ([0, 5ms] ends before void start 10ms) →
+	// NOT suppressed.
+	if ok, _ := mgr.WasMockOrphanedInWindow(ms(0), ms(5)); ok {
+		t.Fatalf("TC window ending before the void start must NOT be suppressed")
+	}
+}
+
+// TestOrphanWindowDegenerateInputs pins the guards: a zero start is ignored
+// (never poison the suppressor into over-claiming), a zero/inverted end is
+// clamped to a valid point interval, and a degenerate TC query is refused
+// rather than matching everything.
+func TestOrphanWindowDegenerateInputs(t *testing.T) {
+	t.Parallel()
+	mgr := &SyncMockManager{}
+	base := time.Now()
+
+	// Zero start → ignored, records nothing.
+	mgr.RecordOrphanWindow(time.Time{}, base)
+	if got := mgr.OrphanRangeCount(); got != 0 {
+		t.Fatalf("zero-start orphan window must be ignored; count=%d", got)
+	}
+
+	// Zero end → clamped to start (a point interval at `base`).
+	mgr.RecordOrphanWindow(base, time.Time{})
+	if got := mgr.OrphanRangeCount(); got != 1 {
+		t.Fatalf("zero-end window must still record as a point; count=%d", got)
+	}
+	if ok, _ := mgr.WasMockOrphanedInWindow(base.Add(-time.Millisecond), base.Add(time.Millisecond)); !ok {
+		t.Fatalf("a TC window spanning the point void must be suppressed")
+	}
+
+	// Inverted end (before start) → clamped to start (point interval).
+	mgr.RecordOrphanWindow(base.Add(100*time.Millisecond), base.Add(50*time.Millisecond))
+	if ok, _ := mgr.WasMockOrphanedInWindow(base.Add(99*time.Millisecond), base.Add(101*time.Millisecond)); !ok {
+		t.Fatalf("inverted-end window must clamp to a point at start and still suppress")
+	}
+
+	// Degenerate TC query (zero start or end) → refused, never over-suppresses.
+	if ok, _ := mgr.WasMockOrphanedInWindow(time.Time{}, base); ok {
+		t.Fatalf("zero-start TC query must be refused")
+	}
+	if ok, _ := mgr.WasMockOrphanedInWindow(base, time.Time{}); ok {
+		t.Fatalf("zero-end TC query must be refused")
+	}
+}
+
+// TestOrphanRangeCountBoundedAndEvictsOldest pins that orphanRanges stays
+// count-bounded under a continuous stream of voids: it grows to at most 2×cap
+// then compacts IN PLACE back toward cap (the amortized-O(1) scheme that avoids
+// a per-call realloc on the hot per-void path), and compaction evicts the
+// OLDEST windows first — so a lagging record.go still sees the most recent
+// voids it might need to suppress.
+func TestOrphanRangeCountBoundedAndEvictsOldest(t *testing.T) {
+	t.Parallel()
+	mgr := &SyncMockManager{}
+	base := time.Now()
+	ms := func(n int) time.Time { return base.Add(time.Duration(n) * time.Millisecond) }
+
+	// Insert past the 2×cap compaction trigger so eviction fires at least once.
+	total := 2*maxPressureRanges + 100
+	for i := 0; i < total; i++ {
+		mgr.RecordOrphanWindow(ms(i), ms(i))
+	}
+	// Count must stay within [cap, 2×cap] — never unbounded.
+	got := mgr.OrphanRangeCount()
+	if got < maxPressureRanges || got > 2*maxPressureRanges {
+		t.Fatalf("orphanRanges count must stay in [%d, %d]; got %d", maxPressureRanges, 2*maxPressureRanges, got)
+	}
+	// The oldest window was evicted by compaction → no longer suppressible.
+	if ok, _ := mgr.WasMockOrphanedInWindow(ms(0), ms(0)); ok {
+		t.Fatalf("oldest orphan window must be evicted after compaction")
+	}
+	// The newest window is retained.
+	last := ms(total - 1)
+	if ok, _ := mgr.WasMockOrphanedInWindow(last, last); !ok {
+		t.Fatalf("newest orphan window must be retained")
+	}
+}
+
+// TestOrphanWindowIndependentOfPressureRanges pins that the two suppressors are
+// separate: recording an orphan window does not create a pressure range and
+// vice-versa, so the session-summary telemetry (pressure_ranges_total vs
+// orphan_ranges_total) stays accurate.
+func TestOrphanWindowIndependentOfPressureRanges(t *testing.T) {
+	t.Parallel()
+	mgr := &SyncMockManager{}
+	base := time.Now()
+
+	mgr.RecordOrphanWindow(base, base.Add(time.Millisecond))
+	if mgr.PressureRangeCount() != 0 {
+		t.Fatalf("orphan window must not create a pressure range")
+	}
+	if got := mgr.OrphanRangeCount(); got != 1 {
+		t.Fatalf("expected 1 orphan range, got %d", got)
+	}
+	// A pressure-only window is not seen by the orphan query.
+	if ok, _ := mgr.WasPressureActiveInWindow(base, base.Add(time.Millisecond)); ok {
+		t.Fatalf("no pressure range should exist")
+	}
+}

--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -224,6 +224,25 @@ type SyncMockManager struct {
 	// intervals and slowing every overlap scan.
 	pressureRanges []pressureRange
 
+	// orphanRanges records every [start, end] wire window over which a mock was
+	// VOIDED for a reason OTHER than memory pressure — a parser marked its mock
+	// incomplete (client/server reassembly overflow, a decode error on the
+	// realignment tail after a memory-pressure gap, per-conn cap, short write)
+	// so supervisor.emitMockCore dropped it, or the parser reported the failing
+	// operation's window directly. It is the exact complement of pressureRanges:
+	// memory-pressure drops happen while memoryguard.IsRecordingPaused() is true
+	// and therefore fall inside a pressureRanges interval, but these voids happen
+	// while recording is NOT paused, so WasPressureActiveInWindow structurally
+	// cannot see them and the orphaned TC would reach replay mock-less
+	// (match_phase=no_mocks). WasMockOrphanedInWindow checks overlap against a
+	// TC's [HTTPReq.Timestamp, HTTPResp.Timestamp] window with the same interval
+	// semantics as pressureRanges, and record.go ORs the two. Count-bounded at
+	// maxPressureRanges (oldest evicted), guarded by mu — a continuous stream of
+	// voids can't grow it unbounded or slow the overlap scan. Entries always
+	// carry a concrete end (RecordOrphanWindow clamps a zero/degenerate end to
+	// start), so no open-interval "extend to now" handling is needed here.
+	orphanRanges []pressureRange
+
 	// loggerMu guards logger so SetLogger and the drop path can run
 	// concurrently without a data race. The read lock is taken only
 	// on the (sampled, cold) Error path, so contention is negligible.
@@ -992,6 +1011,73 @@ func (m *SyncMockManager) PressureRangeCount() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return len(m.pressureRanges)
+}
+
+// RecordOrphanWindow records that a mock owned by some test case was voided
+// over the wire window [start, end] for a NON-pressure reason (a parser marked
+// it incomplete, or emitMockCore dropped it under the mockIncomplete flag).
+// record.go suppresses any TC whose HTTP [req, resp] window overlaps, so the
+// orphaned TC is not streamed mock-less. A degenerate window (start == end, a
+// single operation instant) is valid — the overlap test treats it as a
+// zero-width interval. Bounded by count like pressureRanges (oldest evicted).
+//
+// A zero start is IGNORED: a caller with no reliable wire timestamp must not
+// poison the suppressor into over-claiming (which would silently drop healthy
+// TCs). A zero or inverted end is clamped to start so the entry is a valid
+// point interval rather than an empty or reversed one.
+func (m *SyncMockManager) RecordOrphanWindow(start, end time.Time) {
+	if m == nil || start.IsZero() {
+		return
+	}
+	if end.IsZero() || end.Before(start) {
+		end = start
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.orphanRanges = append(m.orphanRanges, pressureRange{start: start, end: end})
+	// Orphan windows are recorded per voided mock — far more frequently than
+	// pressure ranges (a few per second) — so avoid the reallocate-and-copy on
+	// EVERY call past the cap that SetMemoryPressure can afford. Let the slice
+	// grow to 2×cap, then compact IN PLACE (reuse the backing array, non-
+	// overlapping src/dst) back to the newest cap. Amortized O(1) per call, zero
+	// allocation once warmed, scan bounded at 2×cap, still evicting oldest-first.
+	if n := len(m.orphanRanges); n > 2*maxPressureRanges {
+		m.orphanRanges = append(m.orphanRanges[:0], m.orphanRanges[n-maxPressureRanges:]...)
+	}
+}
+
+// WasMockOrphanedInWindow returns (true, count) if a non-pressure mock void was
+// recorded overlapping [start, end] — the orphan-window twin of
+// WasPressureActiveInWindow. record.go ORs the two so a TC is suppressed
+// whether its mock was lost to memory pressure OR to a parser-side void. Every
+// orphanRanges entry has a concrete end (RecordOrphanWindow guarantees it), so
+// no open-interval handling is needed. Degenerate TC inputs are refused (return
+// false) rather than over-suppressing, matching WasPressureActiveInWindow.
+func (m *SyncMockManager) WasMockOrphanedInWindow(start, end time.Time) (bool, int) {
+	if m == nil || start.IsZero() || end.IsZero() {
+		return false, 0
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	count := 0
+	for _, r := range m.orphanRanges {
+		// Standard interval-overlap test: [r.start, r.end] vs [start, end].
+		if !r.start.After(end) && !r.end.Before(start) {
+			count++
+		}
+	}
+	return count > 0, count
+}
+
+// OrphanRangeCount returns the number of non-pressure mock-void windows
+// recorded so far. Exposed for the session-summary log in routes/record.go.
+func (m *SyncMockManager) OrphanRangeCount() int {
+	if m == nil {
+		return 0
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.orphanRanges)
 }
 
 func (m *SyncMockManager) SetMemoryPressure(enabled bool) {

--- a/pkg/agent/routes/record.go
+++ b/pkg/agent/routes/record.go
@@ -360,6 +360,7 @@ func (a *Agent) HandleIncoming(w http.ResponseWriter, r *http.Request) {
 					zap.Int64("mocks_added_successfully", finalAdded),
 					zap.Uint64("mocks_dropped_capacity", syncmgr.Get().DropCount()),
 					zap.Int("tcs_dropped_capacity", syncmgr.Get().DroppedTCCount()),
+					zap.Int("orphan_ranges_total", syncmgr.Get().OrphanRangeCount()),
 				)
 				return
 			}
@@ -380,14 +381,24 @@ func (a *Agent) HandleIncoming(w http.ResponseWriter, r *http.Request) {
 			// concurrent TC that kept all its mocks.
 			mockDropped := syncmgr.Get().WasMockDroppedForTC(t.Name)
 
-			if hasOverlap || mockDropped {
+			// A non-pressure mock void (parser marked its mock incomplete —
+			// reassembly overflow, a decode error on the realignment tail after
+			// a pressure gap, per-conn cap, short write) records an orphan
+			// window but feeds NEITHER the pressure ranges NOR the capacity
+			// ledger above. Without this check such a void reaches replay
+			// mock-less (match_phase=no_mocks) exactly like the two cases above.
+			// Overlap by the TC's own HTTP window, same as the pressure check.
+			orphanOverlap, orphanCount := syncmgr.Get().WasMockOrphanedInWindow(t.HTTPReq.Timestamp, tcRespTime)
+
+			if hasOverlap || mockDropped || orphanOverlap {
 				tcsSuppressedSoFar++
-				a.logger.Debug("agent: TC suppressed — memory pressure overlapped TC window or a mock was capacity-dropped, not sent to CLI",
+				a.logger.Debug("agent: TC suppressed — memory pressure overlapped TC window, a mock was capacity-dropped, or a mock was voided (incomplete) in the TC window; not sent to CLI",
 					zap.String("tc_name", t.Name),
 					zap.Int64("tc_req_ms", t.HTTPReq.Timestamp.UnixMilli()),
 					zap.Int64("tc_resp_ms", tcRespTime.UnixMilli()),
 					zap.Int("pressure_overlaps", overlapCount),
 					zap.Bool("capacity_drop", mockDropped),
+					zap.Int("orphan_overlaps", orphanCount),
 					zap.Int("tcs_suppressed_so_far", tcsSuppressedSoFar),
 				)
 				continue

--- a/pkg/agent/routes/record.go
+++ b/pkg/agent/routes/record.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -341,8 +342,61 @@ func (a *Agent) HandleIncoming(w http.ResponseWriter, r *http.Request) {
 	// Use select (not for-range) so context cancellation is checked
 	// concurrently with channel receive — otherwise the handler blocks
 	// forever during shutdown when no test cases are arriving.
-	var tcsSentSoFar int       // TCs sent to CLI this session
-	var tcsSuppressedSoFar int // TCs suppressed because pressure overlapped the TC's HTTP window
+	var tcsSentSoFar atomic.Int64       // TCs sent to CLI this session
+	var tcsSuppressedSoFar atomic.Int64 // TCs suppressed because pressure overlapped the TC's HTTP window
+
+	// MEASUREMENT (temporary, throwaway branch): remember every SENT TC window;
+	// a periodic tick re-checks them against the CURRENT range sets. If the
+	// tee-drop orphan windows are being recorded (orphan_ranges_total climbs)
+	// but retro_suppressible >> tcs_suppressed, the windows are recorded too
+	// late to catch the TC (race); if retro ≈ tcs_suppressed AND
+	// orphan_ranges is high, the windows don't overlap the orphaned TCs
+	// (value/coverage gap); if orphan_ranges stays low, the tee-drop windows
+	// aren't being recorded at all. Emitted periodically so it survives the
+	// teardown SIGKILL.
+	type sentWin struct{ req, resp time.Time }
+	var sentMu sync.Mutex
+	var sentWins []sentWin
+	measureDone := make(chan struct{})
+	defer close(measureDone)
+	go func() {
+		tk := time.NewTicker(5 * time.Second)
+		defer tk.Stop()
+		for {
+			select {
+			case <-measureDone:
+				return
+			case <-tk.C:
+				mgr := syncmgr.Get()
+				sentMu.Lock()
+				snap := make([]sentWin, len(sentWins))
+				copy(snap, sentWins)
+				sentMu.Unlock()
+				retro := 0
+				for _, sw := range snap {
+					if o, _ := mgr.WasMockOrphanedInWindow(sw.req, sw.resp); o {
+						retro++
+						continue
+					}
+					if p, _ := mgr.WasPressureActiveInWindow(sw.req, sw.resp); p {
+						retro++
+					}
+				}
+				_, dropped, added, _ := mgr.GetDropStats()
+				a.logger.Info("agent: recording progress [MEASUREMENT]",
+					zap.Int64("tcs_sent_to_cli", tcsSentSoFar.Load()),
+					zap.Int64("tcs_suppressed", tcsSuppressedSoFar.Load()),
+					zap.Int("retro_suppressible_sent", retro),
+					zap.Int("orphan_ranges_total", mgr.OrphanRangeCount()),
+					zap.Int("pressure_ranges_total", mgr.PressureRangeCount()),
+					zap.Int64("mocks_dropped_by_pressure", dropped),
+					zap.Int64("mocks_added", added),
+					zap.Uint64("mocks_dropped_capacity", mgr.DropCount()),
+				)
+			}
+		}
+	}()
+
 	for {
 		select {
 		case <-r.Context().Done():
@@ -353,8 +407,8 @@ func (a *Agent) HandleIncoming(w http.ResponseWriter, r *http.Request) {
 				// Channel closed = recording session over.
 				_, finalDropped, finalAdded, _ := syncmgr.Get().GetDropStats()
 				a.logger.Info("agent: recording complete",
-					zap.Int("tcs_sent_to_cli", tcsSentSoFar),
-					zap.Int("tcs_suppressed_pressure_overlap", tcsSuppressedSoFar),
+					zap.Int64("tcs_sent_to_cli", tcsSentSoFar.Load()),
+					zap.Int64("tcs_suppressed_pressure_overlap", tcsSuppressedSoFar.Load()),
 					zap.Int("pressure_ranges_total", syncmgr.Get().PressureRangeCount()),
 					zap.Int64("mocks_dropped_by_pressure", finalDropped),
 					zap.Int64("mocks_added_successfully", finalAdded),
@@ -391,7 +445,7 @@ func (a *Agent) HandleIncoming(w http.ResponseWriter, r *http.Request) {
 			orphanOverlap, orphanCount := syncmgr.Get().WasMockOrphanedInWindow(t.HTTPReq.Timestamp, tcRespTime)
 
 			if hasOverlap || mockDropped || orphanOverlap {
-				tcsSuppressedSoFar++
+				tcsSuppressedSoFar.Add(1)
 				a.logger.Debug("agent: TC suppressed — memory pressure overlapped TC window, a mock was capacity-dropped, or a mock was voided (incomplete) in the TC window; not sent to CLI",
 					zap.String("tc_name", t.Name),
 					zap.Int64("tc_req_ms", t.HTTPReq.Timestamp.UnixMilli()),
@@ -399,12 +453,15 @@ func (a *Agent) HandleIncoming(w http.ResponseWriter, r *http.Request) {
 					zap.Int("pressure_overlaps", overlapCount),
 					zap.Bool("capacity_drop", mockDropped),
 					zap.Int("orphan_overlaps", orphanCount),
-					zap.Int("tcs_suppressed_so_far", tcsSuppressedSoFar),
+					zap.Int64("tcs_suppressed_so_far", tcsSuppressedSoFar.Load()),
 				)
 				continue
 			}
 
-			tcsSentSoFar++
+			tcsSentSoFar.Add(1)
+			sentMu.Lock()
+			sentWins = append(sentWins, sentWin{req: t.HTTPReq.Timestamp, resp: tcRespTime})
+			sentMu.Unlock()
 			// Stream each test case as JSON
 			// 1. Write metadata (JSON)
 			header := textproto.MIMEHeader{}


### PR DESCRIPTION
integration-ref: fix/mongo-v2-report-orphan-windows

**[MEASUREMENT — DO NOT MERGE, DO NOT REVIEW]** Throwaway branch to diagnose the residual go-memory-load-mongo orphans on #4354. Builds against integrations #245 (parser-level reportOrphanWindow) + adds periodic orphan-window-engagement telemetry to record.go. Reads `orphan_ranges_total` / `retro_suppressible_sent` / `tcs_suppressed` on the mongo lane to determine whether the tee-drop windows + #245 parser windows cover the post-pause realignment-tail orphans. Will be closed after reading telemetry.
