### PR TITLE
fix(agent): free OS memory at replay test-set boundary + dedicated agent pprof port

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,13 +77,21 @@ func start(ctx context.Context) {
 		}()
 	}
 
-	// Start pprof HTTP server for live profiling if PPROF_PORT is set
-	if pprofPort := os.Getenv("PPROF_PORT"); pprofPort != "" {
+	// Start pprof HTTP server for live profiling. PPROF_AGENT_PORT takes
+	// precedence over PPROF_PORT so the agent can bind a port distinct from
+	// the instrumented app, which also honors PPROF_PORT and would otherwise
+	// win the bind in a shared network namespace (making the agent's profiler
+	// unreachable).
+	pprofPort := os.Getenv("PPROF_AGENT_PORT")
+	if pprofPort == "" {
+		pprofPort = os.Getenv("PPROF_PORT")
+	}
+	if pprofPort != "" {
 		go func() {
 			addr := "localhost:" + pprofPort
 			logger.Info("pprof server starting", zap.String("addr", addr))
 			if err := http.ListenAndServe(addr, nil); err != nil {
-				logger.Error("pprof server failed; check that PPROF_PORT is a valid port and not already in use, or unset the env var to disable",
+				logger.Error("pprof server failed; check that the pprof port is valid and not already in use, or unset PPROF_AGENT_PORT/PPROF_PORT to disable",
 					zap.String("port", pprofPort), zap.Error(err))
 			}
 		}()

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -15,6 +15,8 @@ import (
 	"math"
 	"net"
 	"os"
+	"runtime"
+	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
@@ -2761,6 +2763,20 @@ func (p *Proxy) Mock(_ context.Context, opts models.OutgoingOptions) error {
 		p.setMockManager(NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), p.logger))
 	} else {
 		mm.ResetForReplaySession()
+		// Return the previous test-set's transient memory to the OS at the
+		// set boundary. The runtime keeps freed pages mapped (up to
+		// GOMEMLIMIT) for reuse, so without this the next set inherits the
+		// prior set's high-water RSS and a large-body serve transient can
+		// tip it past the cgroup limit. Mock() is per test-set, so this is
+		// a boundary op, not a hot path.
+		var before, after runtime.MemStats
+		runtime.ReadMemStats(&before)
+		debug.FreeOSMemory()
+		runtime.ReadMemStats(&after)
+		p.logger.Info("replay: returned memory to OS at test-set boundary",
+			zap.Uint64("heapInuse_before_mb", before.HeapInuse/(1024*1024)),
+			zap.Uint64("heapInuse_after_mb", after.HeapInuse/(1024*1024)),
+			zap.Uint64("heapReleased_delta_mb", (after.HeapReleased-before.HeapReleased)/(1024*1024)))
 	}
 
 	if !opts.Mocking {


### PR DESCRIPTION
## What
Two agent-side changes for the auto-replay OOM work (bundled — both are small, same release, and the second enables verifying the first):

1. **Free OS memory at the test-set boundary.** In `Proxy.Mock`'s MockManager-reuse branch, right after `ResetForReplaySession`, force `debug.FreeOSMemory()` so the runtime returns the previous set's freed pages to the OS before the next set runs. Adds a before→after memstats log.

2. **Dedicated agent pprof port (`PPROF_AGENT_PORT`).** The replay agent and the instrumented app share a pod network namespace and both default their pprof server to `PPROF_PORT` (6060), so whichever binds first wins and the other's profiler is unreachable. Read `PPROF_AGENT_PORT` first (falling back to `PPROF_PORT`) so ops can give the agent a distinct port and its heap becomes reachable via `kubectl port-forward`.

## Why
In auto-replay one agent serves multiple test sets sequentially. Per set the flow is `ResetForReplaySession → StoreMocks → filter`, so a set's mocks are logically released before the next — but under `GOMEMLIMIT` the Go runtime keeps freed pages mapped, inflating RSS across sets. (1) hands those pages back at the boundary. (2) is what let us actually profile the agent (the app was winning :6060), and is needed to confirm where the remaining memory goes.

## Notes
- Both are opt-in / behavior-preserving: (1) only runs at the reuse boundary; (2) falls back to `PPROF_PORT` when `PPROF_AGENT_PORT` is unset, so existing deployments are unaffected until they set the new var.