### PR TITLE
fix(agent): dedicated agent pprof port via PPROF_AGENT_PORT

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,13 +77,21 @@ func start(ctx context.Context) {
 		}()
 	}
 
-	// Start pprof HTTP server for live profiling if PPROF_PORT is set
-	if pprofPort := os.Getenv("PPROF_PORT"); pprofPort != "" {
+	// Start pprof HTTP server for live profiling. PPROF_AGENT_PORT takes
+	// precedence over PPROF_PORT so the agent can bind a port distinct from
+	// the instrumented app, which also honors PPROF_PORT and would otherwise
+	// win the bind in a shared network namespace (making the agent's profiler
+	// unreachable).
+	pprofPort := os.Getenv("PPROF_AGENT_PORT")
+	if pprofPort == "" {
+		pprofPort = os.Getenv("PPROF_PORT")
+	}
+	if pprofPort != "" {
 		go func() {
 			addr := "localhost:" + pprofPort
 			logger.Info("pprof server starting", zap.String("addr", addr))
 			if err := http.ListenAndServe(addr, nil); err != nil {
-				logger.Error("pprof server failed; check that PPROF_PORT is a valid port and not already in use, or unset the env var to disable",
+				logger.Error("pprof server failed; check that the pprof port is valid and not already in use, or unset PPROF_AGENT_PORT/PPROF_PORT to disable",
 					zap.String("port", pprofPort), zap.Error(err))
 			}
 		}()


### PR DESCRIPTION
## What
The replay agent reads `PPROF_AGENT_PORT` first (falling back to `PPROF_PORT`) when starting its pprof server, so it can bind a port distinct from the instrumented app.

## Why
The replay agent and the instrumented app share a pod network namespace and both default their pprof server to `PPROF_PORT` (6060). Whichever binds first wins, leaving the other's profiler unreachable — which blocked capturing the agent's heap during auto-replay OOM investigation (`kubectl port-forward :6060` reached the app, not the agent). With this, ops can set `PPROF_AGENT_PORT` (e.g. 6061) so the agent's profiler is reachable.

## Compatibility
Behavior-preserving: falls back to `PPROF_PORT` when `PPROF_AGENT_PORT` is unset, so existing deployments are unaffected until they opt in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)