### PR TITLE
fix(proxy/http): preserve chunked transfer-encoding and record bodiless keepalive responses

### DIFF
--- a/pkg/agent/proxy/integrations/http/chunk_test.go
+++ b/pkg/agent/proxy/integrations/http/chunk_test.go
@@ -184,3 +184,21 @@ func TestChunkedResponseEmptyBody(t *testing.T) {
 		t.Fatalf("chunkedResponse stuck in loop after %d reads", destConn.readCount)
 	}
 }
+
+// TestToChunkedBody verifies replay re-framing of a de-chunked body back into
+// HTTP/1.1 chunked wire form: one data chunk (hex size) plus the zero-length
+// terminator, and just the terminator for an empty body.
+func TestToChunkedBody(t *testing.T) {
+	if got := toChunkedBody(""); got != "0\r\n\r\n" {
+		t.Errorf("empty body: got %q, want %q", got, "0\r\n\r\n")
+	}
+	if got := toChunkedBody("hello"); got != "5\r\nhello\r\n0\r\n\r\n" {
+		t.Errorf("simple body: got %q, want %q", got, "5\r\nhello\r\n0\r\n\r\n")
+	}
+	// 30-byte body exercises a multi-digit hex chunk size (0x1e).
+	body := `{"changed":true,"version":117}`
+	want := "1e\r\n" + body + "\r\n0\r\n\r\n"
+	if got := toChunkedBody(body); got != want {
+		t.Errorf("multi-digit length: got %q, want %q", got, want)
+	}
+}

--- a/pkg/agent/proxy/integrations/http/decode.go
+++ b/pkg/agent/proxy/integrations/http/decode.go
@@ -283,7 +283,7 @@ func (h *HTTP) decodeHTTP(ctx context.Context, reqBuf []byte, clientConn net.Con
 
 			responseString := buildReplayResponse(statusLine, header, respBody)
 
-			h.Logger.Debug(fmt.Sprintf("Mock Response sending back to client:\n%v", responseString))
+			h.Logger.Debug("sending mock response to client", zap.Int("bytes", len(responseString)))
 
 			_, err = clientConn.Write([]byte(responseString))
 			if err != nil {
@@ -330,7 +330,7 @@ func buildReplayResponse(statusLine string, header http.Header, respBody string)
 	var b strings.Builder
 	b.WriteString(statusLine)
 	for key, values := range header {
-		if key == "Content-Length" {
+		if strings.EqualFold(key, "Content-Length") {
 			if isChunked {
 				continue
 			}

--- a/pkg/agent/proxy/integrations/http/decode.go
+++ b/pkg/agent/proxy/integrations/http/decode.go
@@ -373,15 +373,21 @@ func buildReplayResponse(statusLine string, header http.Header, respBody string)
 	var b strings.Builder
 	b.WriteString(statusLine)
 	for key, values := range header {
+		// Content-Length is authoritative here, so drop whatever the recorded
+		// map carried (any casing) and re-emit a single correct one below.
 		if strings.EqualFold(key, "Content-Length") {
-			if isChunked {
-				continue
-			}
-			values = []string{strconv.Itoa(len(respBody))}
+			continue
 		}
 		for _, value := range values {
 			fmt.Fprintf(&b, "%s: %s\r\n", key, value)
 		}
+	}
+	// A non-chunked response always gets exactly one Content-Length derived from
+	// the body — even if the recorded map omitted it — so the client can delimit
+	// the body instead of waiting for EOF (which hangs on keepalive connections).
+	// Chunked responses carry none; the last-chunk marker delimits the body.
+	if !isChunked {
+		fmt.Fprintf(&b, "Content-Length: %d\r\n", len(respBody))
 	}
 	b.WriteString("\r\n")
 	b.WriteString(respBody)

--- a/pkg/agent/proxy/integrations/http/decode.go
+++ b/pkg/agent/proxy/integrations/http/decode.go
@@ -274,9 +274,14 @@ func (h *HTTP) decodeHTTP(ctx context.Context, reqBuf []byte, clientConn net.Con
 			// Fetching the response headers
 			header := pkg.ToHTTPHeader(stub.Spec.HTTPResp.Header)
 
-			//Check if the content encoding is present in the header
-			if encoding, ok := header["Content-Encoding"]; ok && len(encoding) > 0 {
-				compressedBody, err := pkg.Compress(h.Logger, encoding[0], []byte(body))
+			// Re-compress the body if the recorded response declared a
+			// Content-Encoding (the record path stored it decompressed). Match the
+			// key case-insensitively: pkg.ToHTTPHeader preserves the recorded
+			// casing, so a direct header["Content-Encoding"] lookup could miss a
+			// non-canonical key and send an unencoded body under a Content-Encoding
+			// header, corrupting the response.
+			if encoding := headerGetFold(header, "Content-Encoding"); encoding != "" {
+				compressedBody, err := pkg.Compress(h.Logger, encoding, []byte(body))
 				if err != nil {
 					utils.LogError(h.Logger, err, "failed to compress the response body", zap.Any("metadata", utils.GetReqMeta(request)))
 					errCh <- err
@@ -340,6 +345,18 @@ func headerHasChunked(header http.Header) bool {
 		}
 	}
 	return false
+}
+
+// headerGetFold returns the first value of the header whose key matches name
+// case-insensitively, or "". Unlike http.Header.Get it does not assume the key
+// is in canonical form — pkg.ToHTTPHeader preserves the recorded key casing.
+func headerGetFold(header http.Header, name string) string {
+	for key, values := range header {
+		if strings.EqualFold(key, name) && len(values) > 0 {
+			return values[0]
+		}
+	}
+	return ""
 }
 
 // buildReplayResponse serializes a recorded response onto the wire: status

--- a/pkg/agent/proxy/integrations/http/decode.go
+++ b/pkg/agent/proxy/integrations/http/decode.go
@@ -323,6 +323,25 @@ func (h *HTTP) decodeHTTP(ctx context.Context, reqBuf []byte, clientConn net.Con
 	}
 }
 
+// headerHasChunked reports whether the header map declares chunked
+// transfer-encoding. It scans keys case-insensitively rather than using
+// http.Header.Get: pkg.ToHTTPHeader preserves the recorded key casing, so a
+// non-canonical key (e.g. "transfer-encoding") would be invisible to Get and
+// wrongly send an unchunked body under a Transfer-Encoding: chunked header.
+func headerHasChunked(header http.Header) bool {
+	for key, values := range header {
+		if !strings.EqualFold(key, "Transfer-Encoding") {
+			continue
+		}
+		for _, v := range values {
+			if strings.Contains(strings.ToLower(v), "chunked") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // buildReplayResponse serializes a recorded response onto the wire: status
 // line, headers, blank line, body. When the header carries Transfer-Encoding:
 // chunked the body — already Content-Encoding-applied by the caller — is
@@ -330,7 +349,7 @@ func (h *HTTP) decodeHTTP(ctx context.Context, reqBuf []byte, clientConn net.Con
 // message must not carry both framings. Otherwise Content-Length is recomputed
 // from the (possibly compressed) body length.
 func buildReplayResponse(statusLine string, header http.Header, respBody string) string {
-	isChunked := strings.Contains(strings.ToLower(header.Get("Transfer-Encoding")), "chunked")
+	isChunked := headerHasChunked(header)
 	if isChunked {
 		respBody = toChunkedBody(respBody)
 	}

--- a/pkg/agent/proxy/integrations/http/decode.go
+++ b/pkg/agent/proxy/integrations/http/decode.go
@@ -328,6 +328,19 @@ func (h *HTTP) decodeHTTP(ctx context.Context, reqBuf []byte, clientConn net.Con
 	}
 }
 
+// transferEncodingIsChunked reports whether a Transfer-Encoding header value
+// declares chunked. Transfer-Encoding is a comma-separated token list, so
+// "chunked" is matched as a whole token (case-insensitive, whitespace-trimmed)
+// rather than a substring — otherwise tokens like "xchunked" would false-match.
+func transferEncodingIsChunked(value string) bool {
+	for _, tok := range strings.Split(value, ",") {
+		if strings.EqualFold(strings.TrimSpace(tok), "chunked") {
+			return true
+		}
+	}
+	return false
+}
+
 // headerHasChunked reports whether the header map declares chunked
 // transfer-encoding. It scans keys case-insensitively rather than using
 // http.Header.Get: pkg.ToHTTPHeader preserves the recorded key casing, so a
@@ -339,7 +352,7 @@ func headerHasChunked(header http.Header) bool {
 			continue
 		}
 		for _, v := range values {
-			if strings.Contains(strings.ToLower(v), "chunked") {
+			if transferEncodingIsChunked(v) {
 				return true
 			}
 		}

--- a/pkg/agent/proxy/integrations/http/decode.go
+++ b/pkg/agent/proxy/integrations/http/decode.go
@@ -263,7 +263,6 @@ func (h *HTTP) decodeHTTP(ctx context.Context, reqBuf []byte, clientConn net.Con
 
 			body := stub.Spec.HTTPResp.Body
 			var respBody string
-			var responseString string
 
 			// Fetching the response headers
 			header := pkg.ToHTTPHeader(stub.Spec.HTTPResp.Header)
@@ -282,17 +281,7 @@ func (h *HTTP) decodeHTTP(ctx context.Context, reqBuf []byte, clientConn net.Con
 				respBody = body
 			}
 
-			var headers string
-			for key, values := range header {
-				if key == "Content-Length" {
-					values = []string{strconv.Itoa(len(respBody))}
-				}
-				for _, value := range values {
-					headerLine := fmt.Sprintf("%s: %s\r\n", key, value)
-					headers += headerLine
-				}
-			}
-			responseString = statusLine + headers + "\r\n" + "" + respBody
+			responseString := buildReplayResponse(statusLine, header, respBody)
 
 			h.Logger.Debug(fmt.Sprintf("Mock Response sending back to client:\n%v", responseString))
 
@@ -325,4 +314,44 @@ func (h *HTTP) decodeHTTP(ctx context.Context, reqBuf []byte, clientConn net.Con
 		}
 		return err
 	}
+}
+
+// buildReplayResponse serializes a recorded response onto the wire: status
+// line, headers, blank line, body. When the header carries Transfer-Encoding:
+// chunked the body — already Content-Encoding-applied by the caller — is
+// re-framed into HTTP/1.1 chunks and Content-Length is suppressed, since a
+// message must not carry both framings. Otherwise Content-Length is recomputed
+// from the (possibly compressed) body length.
+func buildReplayResponse(statusLine string, header http.Header, respBody string) string {
+	isChunked := strings.Contains(strings.ToLower(header.Get("Transfer-Encoding")), "chunked")
+	if isChunked {
+		respBody = toChunkedBody(respBody)
+	}
+	var b strings.Builder
+	b.WriteString(statusLine)
+	for key, values := range header {
+		if key == "Content-Length" {
+			if isChunked {
+				continue
+			}
+			values = []string{strconv.Itoa(len(respBody))}
+		}
+		for _, value := range values {
+			fmt.Fprintf(&b, "%s: %s\r\n", key, value)
+		}
+	}
+	b.WriteString("\r\n")
+	b.WriteString(respBody)
+	return b.String()
+}
+
+// toChunkedBody frames body as a single HTTP/1.1 chunk followed by the
+// zero-length terminating chunk (RFC 7230 §4.1). An empty body becomes just
+// the terminator. Used on replay to reproduce the chunked transfer-encoding a
+// response was recorded with, since the stored body is de-chunked.
+func toChunkedBody(body string) string {
+	if len(body) == 0 {
+		return "0\r\n\r\n"
+	}
+	return fmt.Sprintf("%x\r\n%s\r\n0\r\n\r\n", len(body), body)
 }

--- a/pkg/agent/proxy/integrations/http/http.go
+++ b/pkg/agent/proxy/integrations/http/http.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"strconv"
 	"time"
 
 	"go.keploy.io/server/v3/pkg"
@@ -239,8 +238,10 @@ func (h *HTTP) parseFinalHTTP(ctx context.Context, mock *FinalHTTP, destPort uin
 		}
 
 		h.Logger.Debug("This is the response body: " + string(respBody))
-		//Set the content length to the headers.
-		respParsed.Header.Set("Content-Length", strconv.Itoa(len(respBody)))
+		// Preserve chunked framing when the raw response was chunked; otherwise
+		// record the decoded body length as Content-Length. Shared with the V2
+		// path (buildHTTPMock) so both record paths stay byte-for-byte identical.
+		applyRecordedResponseFraming(respParsed.Header, mock.Resp, len(respBody))
 	}
 
 	// store the request and responses as mocks

--- a/pkg/agent/proxy/integrations/http/http.go
+++ b/pkg/agent/proxy/integrations/http/http.go
@@ -241,7 +241,7 @@ func (h *HTTP) parseFinalHTTP(ctx context.Context, mock *FinalHTTP, destPort uin
 		// Preserve chunked framing when the raw response was chunked; otherwise
 		// record the decoded body length as Content-Length. Shared with the V2
 		// path (buildHTTPMock) so both record paths stay byte-for-byte identical.
-		applyRecordedResponseFraming(respParsed.Header, mock.Resp, len(respBody))
+		applyRecordedResponseFraming(respParsed.Header, mock.Resp, len(respBody), req.Method)
 	}
 
 	// store the request and responses as mocks

--- a/pkg/agent/proxy/integrations/http/http.go
+++ b/pkg/agent/proxy/integrations/http/http.go
@@ -237,7 +237,7 @@ func (h *HTTP) parseFinalHTTP(ctx context.Context, mock *FinalHTTP, destPort uin
 			}
 		}
 
-		h.Logger.Debug("This is the response body: " + string(respBody))
+		h.Logger.Debug("recorded response body", zap.Int("bytes", len(respBody)))
 		// Preserve chunked framing when the raw response was chunked; otherwise
 		// record the decoded body length as Content-Length. Shared with the V2
 		// path (buildHTTPMock) so both record paths stay byte-for-byte identical.

--- a/pkg/agent/proxy/integrations/http/recordv2.go
+++ b/pkg/agent/proxy/integrations/http/recordv2.go
@@ -43,10 +43,13 @@ func (h *HTTP) recordV2(ctx context.Context, sess *supervisor.Session) error {
 	if sess == nil {
 		return errors.New("recordV2: nil supervisor session")
 	}
+
 	logger := sess.Logger
 	if logger == nil {
 		logger = h.Logger
 	}
+
+	logger.Debug("V2 HTTP record: starting request/response loop", zap.String("client", sess.ClientConnID), zap.String("dest", sess.DestConnID))
 
 	destPort := destPortFromAddr(sess.DestStream)
 
@@ -61,6 +64,8 @@ func (h *HTTP) recordV2(ctx context.Context, sess *supervisor.Session) error {
 		// it via ReadChunk so the timestamp is carried regardless of
 		// what ReadBytes does underneath.
 		firstChunk, err := sess.ClientStream.ReadChunk()
+		logger.Debug("V2 HTTP record: first chunk bytes", zap.String("bytes", string(firstChunk.Bytes)))
+
 		if err != nil {
 			if errors.Is(err, io.EOF) || errors.Is(err, fakeconn.ErrClosed) {
 				logger.Debug("V2 HTTP record: client stream ended at start of request", zap.Error(err))
@@ -100,7 +105,9 @@ func (h *HTTP) recordV2(ctx context.Context, sess *supervisor.Session) error {
 
 		// --- Response side --------------------------------------------
 		firstRespChunk, err := sess.DestStream.ReadChunk()
+		logger.Debug("V2 HTTP record: first response chunk bytes", zap.String("bytes", string(firstRespChunk.Bytes)))
 		if err != nil {
+			logger.Debug("V2 HTTP record: failed to read initial response chunk", zap.Error(err))
 			if errors.Is(err, io.EOF) || errors.Is(err, fakeconn.ErrClosed) {
 				sess.MarkMockIncomplete("http decode error: server closed before response")
 				logger.Debug("V2 HTTP record: dest stream ended before response", zap.Error(err))
@@ -114,13 +121,15 @@ func (h *HTTP) recordV2(ctx context.Context, sess *supervisor.Session) error {
 			return err
 		}
 		if len(firstRespChunk.Bytes) == 0 {
+			logger.Debug("V2 HTTP record: empty initial response chunk")
 			sess.MarkMockIncomplete("http decode error: empty initial response chunk")
 			return nil
 		}
 		finalResp := append([]byte(nil), firstRespChunk.Bytes...)
 		resTs := firstRespChunk.WrittenAt
-
-		gotLastWritten, err := h.readResponseV2(ctx, sess.DestStream, &finalResp)
+		logger.Debug("V2 HTTP record: initial response chunk", zap.String("bytes", string(finalResp)))
+		gotLastWritten, err := h.readResponseV2(ctx, sess.DestStream, &finalResp, methodFromRequestLine(finalReq))
+		logger.Debug("V2 HTTP record: completed response read", zap.String("bytes", string(finalResp)))
 		if err != nil {
 			if errors.Is(err, io.EOF) || errors.Is(err, fakeconn.ErrClosed) {
 				// Legacy encodeHTTP treats EOF after some bytes as
@@ -139,7 +148,7 @@ func (h *HTTP) recordV2(ctx context.Context, sess *supervisor.Session) error {
 		} else if !gotLastWritten.IsZero() {
 			resTs = gotLastWritten
 		}
-
+		logger.Debug("V2 HTTP record: completed request/response pair", zap.String("client", sess.ClientConnID), zap.String("dest", sess.DestConnID), zap.Int("reqBytes", len(finalReq)), zap.Int("respBytes", len(finalResp)), zap.Time("reqTs", reqTs), zap.Time("resTs", resTs))
 		// Build and emit the mock. Identical shape to the legacy path.
 		mock, err := h.buildHTTPMock(&FinalHTTP{
 			Req:              finalReq,
@@ -186,6 +195,8 @@ func (h *HTTP) readRequestV2(ctx context.Context, stream *fakeconn.FakeConn, fin
 	}
 
 	contentLengthHeader, transferEncodingHeader := parseHeaders(*finalReq)
+	logger := h.Logger
+	logger.Debug("V2 HTTP record: parsed headers", zap.String("content-length", contentLengthHeader), zap.String("transfer-encoding", transferEncodingHeader))
 
 	if contentLengthHeader != "" {
 		contentLength, err := strconv.Atoi(contentLengthHeader)
@@ -254,7 +265,7 @@ func (h *HTTP) readRequestV2(ctx context.Context, stream *fakeconn.FakeConn, fin
 // Returns (lastWrittenAt, err). err may be io.EOF for the legitimate
 // "server closed after sending a full response" case; the caller
 // decides whether to emit a mock.
-func (h *HTTP) readResponseV2(ctx context.Context, stream *fakeconn.FakeConn, finalResp *[]byte) (time.Time, error) {
+func (h *HTTP) readResponseV2(ctx context.Context, stream *fakeconn.FakeConn, finalResp *[]byte, requestMethod string) (time.Time, error) {
 	var lastWr time.Time
 
 	// 1. Complete headers.
@@ -273,6 +284,16 @@ func (h *HTTP) readResponseV2(ctx context.Context, stream *fakeconn.FakeConn, fi
 			return lastWr, io.EOF
 		}
 		*finalResp = append(*finalResp, chunk.Bytes...)
+	}
+
+	// RFC 7230 §3.3.3 rule 1: a response to a HEAD request and any 1xx / 204 /
+	// 304 response have no message body and end at the header terminator,
+	// regardless of Content-Length / Transfer-Encoding. Without this a 204
+	// (which carries neither framing header) falls into the read-until-EOF
+	// branch below and, on a keepalive connection, swallows every subsequent
+	// response into this one — so only the first mock is ever recorded.
+	if responseHasNoBody(requestMethod, parseStatusCode(*finalResp)) {
+		return lastWr, nil
 	}
 
 	// 2. Parse headers for body framing.
@@ -353,12 +374,53 @@ func (h *HTTP) readResponseV2(ctx context.Context, stream *fakeconn.FakeConn, fi
 		}
 		*finalResp = append(*finalResp, chunk.Bytes...)
 	}
+
 }
 
 // parseHeaders extracts Content-Length and Transfer-Encoding header
 // values (if any) from an HTTP message whose headers end with CRLFCRLF.
 // The parse is the same loose style the chunk.go helpers use: split on
 // '\n', trim '\r', skip malformed lines.
+// methodFromRequestLine returns the HTTP method (first token of the request
+// line) from raw request bytes, or "" if it can't be determined.
+func methodFromRequestLine(req []byte) string {
+	sp := bytes.IndexByte(req, ' ')
+	if sp <= 0 {
+		return ""
+	}
+	return string(req[:sp])
+}
+
+// parseStatusCode returns the numeric status code from a response's status
+// line ("HTTP/1.1 204 No Content"), or 0 if it can't be parsed.
+func parseStatusCode(resp []byte) int {
+	end := bytes.IndexByte(resp, '\n')
+	if end < 0 {
+		end = len(resp)
+	}
+	fields := strings.Fields(string(resp[:end]))
+	if len(fields) < 2 {
+		return 0
+	}
+	code, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return 0
+	}
+	return code
+}
+
+// responseHasNoBody reports whether an HTTP response is defined to carry no
+// message body per RFC 7230 §3.3.3 rule 1: a response to a HEAD request, or a
+// 1xx / 204 / 304 status. Such a response ends at the header terminator
+// regardless of Content-Length / Transfer-Encoding, so the recorder must not
+// wait for a body.
+func responseHasNoBody(requestMethod string, statusCode int) bool {
+	if strings.EqualFold(requestMethod, "HEAD") {
+		return true
+	}
+	return statusCode == 204 || statusCode == 304 || (statusCode >= 100 && statusCode < 200)
+}
+
 func parseHeaders(msg []byte) (contentLength string, transferEncoding string) {
 	lines := strings.Split(string(msg), "\n")
 	for _, line := range lines {
@@ -380,6 +442,24 @@ func parseHeaders(msg []byte) (contentLength string, transferEncoding string) {
 		}
 	}
 	return contentLength, transferEncoding
+}
+
+// applyRecordedResponseFraming sets the body-framing headers for a recorded
+// response. net/http.ReadResponse strips the hop-by-hop Transfer-Encoding
+// header out of the header map and decodes the chunked body, so respParsed.Header
+// alone can't tell us whether the response was chunked on the wire. We therefore
+// inspect the raw response bytes: if they were chunked, preserve
+// Transfer-Encoding: chunked and omit Content-Length (a message must not carry
+// both — RFC 7230 §3.3.3); otherwise record the decoded body length as
+// Content-Length, as before.
+func applyRecordedResponseFraming(header http.Header, rawResp []byte, bodyLen int) {
+	_, transferEncoding := parseHeaders(rawResp)
+	if strings.Contains(strings.ToLower(transferEncoding), "chunked") {
+		header.Set("Transfer-Encoding", "chunked")
+		header.Del("Content-Length")
+		return
+	}
+	header.Set("Content-Length", strconv.Itoa(bodyLen))
 }
 
 // destPortFromAddr extracts the destination TCP port from a FakeConn's
@@ -433,7 +513,18 @@ func (h *HTTP) buildHTTPMock(m *FinalHTTP, destPort uint, connID string, opts mo
 		}
 	}
 
+	// _, reqTransferEncoding := parseHeaders(m.Req)
+
 	respParsed, err := http.ReadResponse(bufio.NewReader(bytes.NewReader(m.Resp)), req)
+
+	// if reqTransferEncoding != "" {
+	// 	req.Header.Set("Transfer-Encoding", reqTransferEncoding)
+	// }
+
+	for key, values := range req.Header {
+		h.Logger.Debug("Request header", zap.String("key", key), zap.Strings("values", values))
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("parse response: %w", err)
 	}
@@ -450,7 +541,7 @@ func (h *HTTP) buildHTTPMock(m *FinalHTTP, destPort uint, connID string, opts mo
 				return nil, fmt.Errorf("decompress response body: %w", err)
 			}
 		}
-		respParsed.Header.Set("Content-Length", strconv.Itoa(len(respBody)))
+		applyRecordedResponseFraming(respParsed.Header, m.Resp, len(respBody))
 	}
 
 	meta := map[string]string{

--- a/pkg/agent/proxy/integrations/http/recordv2.go
+++ b/pkg/agent/proxy/integrations/http/recordv2.go
@@ -344,8 +344,7 @@ func (h *HTTP) readResponseV2(ctx context.Context, stream *fakeconn.FakeConn, fi
 		return lastWr, nil
 	}
 
-	if transferEncodingHeader != "" &&
-		strings.Contains(strings.ToLower(transferEncodingHeader), "chunked") {
+	if transferEncodingIsChunked(transferEncodingHeader) {
 		// Chunked: read until we see the last-chunk terminator as a
 		// suffix of finalResp. pUtil terminator detection (see chunk.go
 		// chunkedTerminator) uses HasSuffix so a body chunk that shares
@@ -478,7 +477,7 @@ func parseHeaders(msg []byte) (contentLength string, transferEncoding string) {
 // Content-Length, as before.
 func applyRecordedResponseFraming(header http.Header, rawResp []byte, bodyLen int, requestMethod string) {
 	_, transferEncoding := parseHeaders(rawResp)
-	if strings.Contains(strings.ToLower(transferEncoding), "chunked") {
+	if transferEncodingIsChunked(transferEncoding) {
 		header.Set("Transfer-Encoding", "chunked")
 		header.Del("Content-Length")
 		return

--- a/pkg/agent/proxy/integrations/http/recordv2.go
+++ b/pkg/agent/proxy/integrations/http/recordv2.go
@@ -195,8 +195,6 @@ func (h *HTTP) readRequestV2(ctx context.Context, stream *fakeconn.FakeConn, fin
 	}
 
 	contentLengthHeader, transferEncodingHeader := parseHeaders(*finalReq)
-	logger := h.Logger
-	logger.Debug("V2 HTTP record: parsed headers", zap.String("content-length", contentLengthHeader), zap.String("transfer-encoding", transferEncodingHeader))
 
 	if contentLengthHeader != "" {
 		contentLength, err := strconv.Atoi(contentLengthHeader)
@@ -377,10 +375,6 @@ func (h *HTTP) readResponseV2(ctx context.Context, stream *fakeconn.FakeConn, fi
 
 }
 
-// parseHeaders extracts Content-Length and Transfer-Encoding header
-// values (if any) from an HTTP message whose headers end with CRLFCRLF.
-// The parse is the same loose style the chunk.go helpers use: split on
-// '\n', trim '\r', skip malformed lines.
 // methodFromRequestLine returns the HTTP method (first token of the request
 // line) from raw request bytes, or "" if it can't be determined.
 func methodFromRequestLine(req []byte) string {
@@ -421,6 +415,10 @@ func responseHasNoBody(requestMethod string, statusCode int) bool {
 	return statusCode == 204 || statusCode == 304 || (statusCode >= 100 && statusCode < 200)
 }
 
+// parseHeaders extracts Content-Length and Transfer-Encoding header
+// values (if any) from an HTTP message whose headers end with CRLFCRLF.
+// The parse is the same loose style the chunk.go helpers use: split on
+// '\n', trim '\r', skip malformed lines.
 func parseHeaders(msg []byte) (contentLength string, transferEncoding string) {
 	// Only the header section carries framing info; slice to the CRLFCRLF
 	// terminator so we never convert/split a large (possibly streaming) body.

--- a/pkg/agent/proxy/integrations/http/recordv2.go
+++ b/pkg/agent/proxy/integrations/http/recordv2.go
@@ -129,7 +129,6 @@ func (h *HTTP) recordV2(ctx context.Context, sess *supervisor.Session) error {
 		resTs := firstRespChunk.WrittenAt
 		logger.Debug("V2 HTTP record: initial response chunk", zap.Int("bytes", len(finalResp)))
 		gotLastWritten, err := h.readResponseV2(ctx, sess.DestStream, &finalResp, methodFromRequestLine(finalReq))
-		logger.Debug("V2 HTTP record: completed response read", zap.Int("bytes", len(finalResp)))
 		if err != nil {
 			if errors.Is(err, io.EOF) || errors.Is(err, fakeconn.ErrClosed) {
 				// Legacy encodeHTTP treats EOF after some bytes as
@@ -302,11 +301,11 @@ func (h *HTTP) readResponseV2(ctx context.Context, stream *fakeconn.FakeConn, fi
 		}
 	}
 
-	// RFC 7230 §3.3.3 rule 1: a HEAD response and 204 / 304 / 101 responses have
-	// no message body and end at the header terminator, regardless of
-	// Content-Length / Transfer-Encoding. Without this a 204 (which carries
-	// neither framing header) falls into the read-until-EOF branch below and, on
-	// a keepalive connection, swallows every subsequent response into this one.
+	// Bodiless terminal responses — HEAD, 204, 205, 304, 101 (see
+	// responseHasNoBody for the per-status basis) — end at the header terminator
+	// regardless of Content-Length / Transfer-Encoding. Without this a 204 (which
+	// carries neither framing header) falls into the read-until-EOF branch below
+	// and, on a keepalive connection, swallows every subsequent response.
 	if responseHasNoBody(requestMethod, parseStatusCode(*finalResp)) {
 		return lastWr, nil
 	}

--- a/pkg/agent/proxy/integrations/http/recordv2.go
+++ b/pkg/agent/proxy/integrations/http/recordv2.go
@@ -476,11 +476,17 @@ func parseHeaders(msg []byte) (contentLength string, transferEncoding string) {
 // Transfer-Encoding: chunked and omit Content-Length (a message must not carry
 // both — RFC 7230 §3.3.3); otherwise record the decoded body length as
 // Content-Length, as before.
-func applyRecordedResponseFraming(header http.Header, rawResp []byte, bodyLen int) {
+func applyRecordedResponseFraming(header http.Header, rawResp []byte, bodyLen int, requestMethod string) {
 	_, transferEncoding := parseHeaders(rawResp)
 	if strings.Contains(strings.ToLower(transferEncoding), "chunked") {
 		header.Set("Transfer-Encoding", "chunked")
 		header.Del("Content-Length")
+		return
+	}
+	// A HEAD response carries no body, but its Content-Length (when present)
+	// describes the body a GET would return. Preserve the recorded header value
+	// instead of overwriting it with the empty HEAD body length (0).
+	if strings.EqualFold(requestMethod, "HEAD") {
 		return
 	}
 	header.Set("Content-Length", strconv.Itoa(bodyLen))
@@ -555,7 +561,7 @@ func (h *HTTP) buildHTTPMock(m *FinalHTTP, destPort uint, connID string, opts mo
 				return nil, fmt.Errorf("decompress response body: %w", err)
 			}
 		}
-		applyRecordedResponseFraming(respParsed.Header, m.Resp, len(respBody))
+		applyRecordedResponseFraming(respParsed.Header, m.Resp, len(respBody), req.Method)
 	}
 
 	meta := map[string]string{

--- a/pkg/agent/proxy/integrations/http/recordv2.go
+++ b/pkg/agent/proxy/integrations/http/recordv2.go
@@ -266,30 +266,47 @@ func (h *HTTP) readRequestV2(ctx context.Context, stream *fakeconn.FakeConn, fin
 func (h *HTTP) readResponseV2(ctx context.Context, stream *fakeconn.FakeConn, finalResp *[]byte, requestMethod string) (time.Time, error) {
 	var lastWr time.Time
 
-	// 1. Complete headers.
-	for !hasCompleteHeaders(*finalResp) {
-		if err := ctx.Err(); err != nil {
-			return lastWr, err
+	// 1. Read the status line + headers, skipping any provisional 1xx interim
+	// responses. A provisional 1xx (100 Continue, 102, 103, ...) has no body and
+	// is followed by the real response on the same connection, so the mock must
+	// capture the final response — not the interim. 101 Switching Protocols is
+	// terminal (the connection then speaks another protocol) and is handled by
+	// the bodiless check below.
+	for {
+		for !hasCompleteHeaders(*finalResp) {
+			if err := ctx.Err(); err != nil {
+				return lastWr, err
+			}
+			chunk, err := stream.ReadChunk()
+			if err != nil {
+				return lastWr, err
+			}
+			if !chunk.WrittenAt.IsZero() {
+				lastWr = chunk.WrittenAt
+			}
+			if len(chunk.Bytes) == 0 {
+				return lastWr, io.EOF
+			}
+			*finalResp = append(*finalResp, chunk.Bytes...)
 		}
-		chunk, err := stream.ReadChunk()
-		if err != nil {
-			return lastWr, err
+		status := parseStatusCode(*finalResp)
+		if status < 100 || status >= 200 || status == 101 {
+			break
 		}
-		if !chunk.WrittenAt.IsZero() {
-			lastWr = chunk.WrittenAt
+		// Discard the interim 1xx header block, keeping any bytes of the
+		// following response that already arrived, then loop to read it.
+		if idx := bytes.Index(*finalResp, []byte("\r\n\r\n")); idx >= 0 {
+			*finalResp = append([]byte(nil), (*finalResp)[idx+4:]...)
+		} else {
+			*finalResp = (*finalResp)[:0]
 		}
-		if len(chunk.Bytes) == 0 {
-			return lastWr, io.EOF
-		}
-		*finalResp = append(*finalResp, chunk.Bytes...)
 	}
 
-	// RFC 7230 §3.3.3 rule 1: a response to a HEAD request and any 1xx / 204 /
-	// 304 response have no message body and end at the header terminator,
-	// regardless of Content-Length / Transfer-Encoding. Without this a 204
-	// (which carries neither framing header) falls into the read-until-EOF
-	// branch below and, on a keepalive connection, swallows every subsequent
-	// response into this one — so only the first mock is ever recorded.
+	// RFC 7230 §3.3.3 rule 1: a HEAD response and 204 / 304 / 101 responses have
+	// no message body and end at the header terminator, regardless of
+	// Content-Length / Transfer-Encoding. Without this a 204 (which carries
+	// neither framing header) falls into the read-until-EOF branch below and, on
+	// a keepalive connection, swallows every subsequent response into this one.
 	if responseHasNoBody(requestMethod, parseStatusCode(*finalResp)) {
 		return lastWr, nil
 	}
@@ -404,15 +421,17 @@ func parseStatusCode(resp []byte) int {
 }
 
 // responseHasNoBody reports whether an HTTP response is defined to carry no
-// message body per RFC 7230 §3.3.3 rule 1: a response to a HEAD request, or a
-// 1xx / 204 / 304 status. Such a response ends at the header terminator
-// regardless of Content-Length / Transfer-Encoding, so the recorder must not
-// wait for a body.
+// message body and is terminal for the request (RFC 7230 §3.3.3 rule 1): a
+// response to a HEAD request, or a 204 / 304 / 101 status. Such a response ends
+// at the header terminator regardless of Content-Length / Transfer-Encoding, so
+// the recorder must not wait for a body. Provisional 1xx (100 Continue, 102,
+// 103, ...) are interim, NOT terminal — they are skipped by readResponseV2's
+// interim loop and never reach here.
 func responseHasNoBody(requestMethod string, statusCode int) bool {
 	if strings.EqualFold(requestMethod, "HEAD") {
 		return true
 	}
-	return statusCode == 204 || statusCode == 304 || (statusCode >= 100 && statusCode < 200)
+	return statusCode == 204 || statusCode == 304 || statusCode == 101
 }
 
 // parseHeaders extracts Content-Length and Transfer-Encoding header

--- a/pkg/agent/proxy/integrations/http/recordv2.go
+++ b/pkg/agent/proxy/integrations/http/recordv2.go
@@ -64,7 +64,7 @@ func (h *HTTP) recordV2(ctx context.Context, sess *supervisor.Session) error {
 		// it via ReadChunk so the timestamp is carried regardless of
 		// what ReadBytes does underneath.
 		firstChunk, err := sess.ClientStream.ReadChunk()
-		logger.Debug("V2 HTTP record: first chunk bytes", zap.String("bytes", string(firstChunk.Bytes)))
+		logger.Debug("V2 HTTP record: first request chunk", zap.Int("bytes", len(firstChunk.Bytes)))
 
 		if err != nil {
 			if errors.Is(err, io.EOF) || errors.Is(err, fakeconn.ErrClosed) {
@@ -105,7 +105,7 @@ func (h *HTTP) recordV2(ctx context.Context, sess *supervisor.Session) error {
 
 		// --- Response side --------------------------------------------
 		firstRespChunk, err := sess.DestStream.ReadChunk()
-		logger.Debug("V2 HTTP record: first response chunk bytes", zap.String("bytes", string(firstRespChunk.Bytes)))
+		logger.Debug("V2 HTTP record: first response chunk", zap.Int("bytes", len(firstRespChunk.Bytes)))
 		if err != nil {
 			logger.Debug("V2 HTTP record: failed to read initial response chunk", zap.Error(err))
 			if errors.Is(err, io.EOF) || errors.Is(err, fakeconn.ErrClosed) {
@@ -127,9 +127,9 @@ func (h *HTTP) recordV2(ctx context.Context, sess *supervisor.Session) error {
 		}
 		finalResp := append([]byte(nil), firstRespChunk.Bytes...)
 		resTs := firstRespChunk.WrittenAt
-		logger.Debug("V2 HTTP record: initial response chunk", zap.String("bytes", string(finalResp)))
+		logger.Debug("V2 HTTP record: initial response chunk", zap.Int("bytes", len(finalResp)))
 		gotLastWritten, err := h.readResponseV2(ctx, sess.DestStream, &finalResp, methodFromRequestLine(finalReq))
-		logger.Debug("V2 HTTP record: completed response read", zap.String("bytes", string(finalResp)))
+		logger.Debug("V2 HTTP record: completed response read", zap.Int("bytes", len(finalResp)))
 		if err != nil {
 			if errors.Is(err, io.EOF) || errors.Is(err, fakeconn.ErrClosed) {
 				// Legacy encodeHTTP treats EOF after some bytes as
@@ -422,6 +422,11 @@ func responseHasNoBody(requestMethod string, statusCode int) bool {
 }
 
 func parseHeaders(msg []byte) (contentLength string, transferEncoding string) {
+	// Only the header section carries framing info; slice to the CRLFCRLF
+	// terminator so we never convert/split a large (possibly streaming) body.
+	if idx := bytes.Index(msg, []byte("\r\n\r\n")); idx >= 0 {
+		msg = msg[:idx]
+	}
 	lines := strings.Split(string(msg), "\n")
 	for _, line := range lines {
 		line = strings.TrimRight(line, "\r")
@@ -513,17 +518,7 @@ func (h *HTTP) buildHTTPMock(m *FinalHTTP, destPort uint, connID string, opts mo
 		}
 	}
 
-	// _, reqTransferEncoding := parseHeaders(m.Req)
-
 	respParsed, err := http.ReadResponse(bufio.NewReader(bytes.NewReader(m.Resp)), req)
-
-	// if reqTransferEncoding != "" {
-	// 	req.Header.Set("Transfer-Encoding", reqTransferEncoding)
-	// }
-
-	for key, values := range req.Header {
-		h.Logger.Debug("Request header", zap.String("key", key), zap.Strings("values", values))
-	}
 
 	if err != nil {
 		return nil, fmt.Errorf("parse response: %w", err)

--- a/pkg/agent/proxy/integrations/http/recordv2.go
+++ b/pkg/agent/proxy/integrations/http/recordv2.go
@@ -421,17 +421,20 @@ func parseStatusCode(resp []byte) int {
 }
 
 // responseHasNoBody reports whether an HTTP response is defined to carry no
-// message body and is terminal for the request (RFC 7230 §3.3.3 rule 1): a
-// response to a HEAD request, or a 204 / 304 / 101 status. Such a response ends
-// at the header terminator regardless of Content-Length / Transfer-Encoding, so
-// the recorder must not wait for a body. Provisional 1xx (100 Continue, 102,
-// 103, ...) are interim, NOT terminal — they are skipped by readResponseV2's
-// interim loop and never reach here.
+// message body and is terminal for the request: a response to a HEAD request,
+// or a 204 / 205 / 304 / 101 status. Such a response ends at the header
+// terminator regardless of Content-Length / Transfer-Encoding, so the recorder
+// must not wait for a body (otherwise it swallows the next response on a
+// keepalive connection). HEAD / 204 / 304 are RFC 7230 §3.3.3 rule 1; 205 (Reset
+// Content) is treated the same because RFC 7231 §6.3.6 forbids a 205 sender from
+// generating a payload. Provisional 1xx (100 Continue, 102, 103, ...) are
+// interim, NOT terminal — they are skipped by readResponseV2's interim loop and
+// never reach here.
 func responseHasNoBody(requestMethod string, statusCode int) bool {
 	if strings.EqualFold(requestMethod, "HEAD") {
 		return true
 	}
-	return statusCode == 204 || statusCode == 304 || statusCode == 101
+	return statusCode == 204 || statusCode == 205 || statusCode == 304 || statusCode == 101
 }
 
 // parseHeaders extracts Content-Length and Transfer-Encoding header

--- a/pkg/agent/proxy/integrations/http/recordv2_test.go
+++ b/pkg/agent/proxy/integrations/http/recordv2_test.go
@@ -676,3 +676,49 @@ func TestResponseHasNoBody(t *testing.T) {
 		}
 	}
 }
+
+// TestRecordV2_HeadResponsePreservesContentLength verifies a HEAD response keeps
+// the upstream Content-Length (the size the body would be for GET) in the mock
+// instead of having it overwritten to 0 by the empty HEAD body. It also guards
+// against readResponseV2 waiting for a HEAD body that never arrives.
+func TestRecordV2_HeadResponsePreservesContentLength(t *testing.T) {
+	t.Parallel()
+	h := &HTTP{Logger: zaptest.NewLogger(t)}
+	sess, sendReq, closeReq, sendResp, closeResp, mocks := newTestSession(t)
+
+	req := []byte("HEAD /file HTTP/1.1\r\nHost: ex.com\r\n\r\n")
+	// HEAD response: Content-Length describes the would-be GET body; no body follows.
+	resp := []byte("HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\nContent-Length: 1234\r\n\r\n")
+
+	base := time.Unix(1_700_005_000, 0)
+	sendReq(req, base, base)
+	sendResp(resp, base.Add(time.Millisecond), base.Add(time.Millisecond))
+	closeReq()
+	closeResp()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- h.recordV2(ctx, sess) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("recordV2 returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("recordV2 did not exit within 2s (HEAD Content-Length body wrongly awaited?)")
+	}
+
+	select {
+	case m := <-mocks:
+		if got := m.Spec.HTTPResp.Header["Content-Length"]; got != "1234" {
+			t.Errorf("Content-Length = %q, want \"1234\" (must not be overwritten to 0)", got)
+		}
+		if m.Spec.HTTPResp.Body != "" {
+			t.Errorf("body = %q, want empty (HEAD)", m.Spec.HTTPResp.Body)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no mock emitted")
+	}
+}

--- a/pkg/agent/proxy/integrations/http/recordv2_test.go
+++ b/pkg/agent/proxy/integrations/http/recordv2_test.go
@@ -649,3 +649,30 @@ func TestRecordV2_Interim100ContinueThenFinal(t *testing.T) {
 		t.Fatal("no mock emitted")
 	}
 }
+
+// TestResponseHasNoBody locks in the bodiless-terminal status set. HEAD, 204,
+// 205, 304 and 101 are terminal with no body; a normal 200, a provisional 1xx
+// (handled by the interim loop, not here), and a redirect are not.
+func TestResponseHasNoBody(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		method string
+		status int
+		want   bool
+	}{
+		{"GET", 204, true},
+		{"GET", 205, true},
+		{"GET", 304, true},
+		{"GET", 101, true},
+		{"HEAD", 200, true},
+		{"head", 200, true}, // case-insensitive method
+		{"GET", 200, false},
+		{"GET", 100, false}, // provisional; skipped upstream, not terminal
+		{"GET", 302, false},
+	}
+	for _, c := range cases {
+		if got := responseHasNoBody(c.method, c.status); got != c.want {
+			t.Errorf("responseHasNoBody(%q, %d) = %v, want %v", c.method, c.status, got, c.want)
+		}
+	}
+}

--- a/pkg/agent/proxy/integrations/http/recordv2_test.go
+++ b/pkg/agent/proxy/integrations/http/recordv2_test.go
@@ -602,3 +602,50 @@ func TestRecordV2_KeepAlive204ThenChunked(t *testing.T) {
 		t.Errorf("mock[1] Transfer-Encoding = %q, want chunked", te)
 	}
 }
+
+// TestRecordV2_Interim100ContinueThenFinal verifies provisional 1xx responses
+// are skipped during recording: a 100 Continue followed by the real 200 on the
+// same connection must record ONE mock for the 200, not the interim 100.
+func TestRecordV2_Interim100ContinueThenFinal(t *testing.T) {
+	t.Parallel()
+	h := &HTTP{Logger: zaptest.NewLogger(t)}
+	sess, sendReq, closeReq, sendResp, closeResp, mocks := newTestSession(t)
+
+	req := []byte("POST /submit HTTP/1.1\r\nHost: ex.com\r\nContent-Length: 0\r\n\r\n")
+	// Interim 100 Continue, then the final 200 with a Content-Length body.
+	body := `{"ok":"done"}` // 13 bytes
+	resp := []byte("HTTP/1.1 100 Continue\r\n\r\n" +
+		"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 13\r\n\r\n" + body)
+
+	base := time.Unix(1_700_004_000, 0)
+	sendReq(req, base, base)
+	sendResp(resp, base.Add(time.Millisecond), base.Add(time.Millisecond))
+	closeReq()
+	closeResp()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- h.recordV2(ctx, sess) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("recordV2 returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("recordV2 did not exit within 2s")
+	}
+
+	select {
+	case m := <-mocks:
+		if m.Spec.HTTPResp.StatusCode != 200 {
+			t.Errorf("status = %d, want 200 (interim 100 Continue must be skipped)", m.Spec.HTTPResp.StatusCode)
+		}
+		if m.Spec.HTTPResp.Body != body {
+			t.Errorf("body = %q, want %q", m.Spec.HTTPResp.Body, body)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no mock emitted")
+	}
+}

--- a/pkg/agent/proxy/integrations/http/recordv2_test.go
+++ b/pkg/agent/proxy/integrations/http/recordv2_test.go
@@ -274,6 +274,14 @@ func TestRecordV2_ChunkedTransferEncoding(t *testing.T) {
 		if m.Spec.HTTPResp.Body != "hello world" {
 			t.Errorf("body = %q, want %q", m.Spec.HTTPResp.Body, "hello world")
 		}
+		// A chunked response must be recorded with Transfer-Encoding preserved
+		// and Content-Length omitted (the two framings are mutually exclusive).
+		if te := m.Spec.HTTPResp.Header["Transfer-Encoding"]; te != "chunked" {
+			t.Errorf("Transfer-Encoding = %q, want %q", te, "chunked")
+		}
+		if cl, ok := m.Spec.HTTPResp.Header["Content-Length"]; ok {
+			t.Errorf("Content-Length = %q present in chunked mock; want it omitted", cl)
+		}
 	case <-time.After(time.Second):
 		t.Fatal("no mock emitted")
 	}
@@ -519,5 +527,78 @@ func TestIsV2(t *testing.T) {
 	h := &HTTP{Logger: zaptest.NewLogger(t)}
 	if !h.IsV2() {
 		t.Fatal("HTTP parser IsV2 returned false — dispatcher would route to legacy path")
+	}
+}
+
+// TestRecordV2_KeepAlive204ThenChunked reproduces the keepalive long-poll bug:
+// a 204 (no Content-Length, no Transfer-Encoding) followed by a second response
+// on the SAME connection. Before the RFC 7230 §3.3.3 bodiless-response rule was
+// added, the 204 fell into read-until-EOF and swallowed the second response, so
+// only one (corrupt) mock was emitted. Now each response is framed independently.
+func TestRecordV2_KeepAlive204ThenChunked(t *testing.T) {
+	t.Parallel()
+	h := &HTTP{Logger: zaptest.NewLogger(t)}
+	sess, sendReq, closeReq, sendResp, closeResp, mocks := newTestSession(t)
+
+	req := []byte("GET /config HTTP/1.1\r\nHost: ex.com\r\nContent-Length: 0\r\n\r\n")
+	resp204 := []byte("HTTP/1.1 204 No Content\r\nDate: Sun, 12 Jul 2026 19:39:55 GMT\r\n\r\n")
+	// 30-byte JSON body (0x1e) framed as a single chunk + terminator.
+	body := `{"changed":true,"version":117}`
+	resp200 := []byte("HTTP/1.1 200 OK\r\n" +
+		"Content-Type: application/json\r\n" +
+		"Transfer-Encoding: chunked\r\n\r\n" +
+		"1e\r\n" + body + "\r\n0\r\n\r\n")
+
+	base := time.Unix(1_700_003_000, 0)
+	// Two request/response pairs on one keepalive connection.
+	sendReq(req, base, base)
+	sendReq(req, base.Add(time.Second), base.Add(time.Second))
+	sendResp(resp204, base.Add(time.Millisecond), base.Add(time.Millisecond))
+	sendResp(resp200, base.Add(time.Second), base.Add(time.Second))
+	closeReq()
+	closeResp()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- h.recordV2(ctx, sess) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("recordV2 returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("recordV2 did not exit within 2s (204 likely swallowed the next response)")
+	}
+
+	var got []*models.Mock
+	for {
+		select {
+		case m := <-mocks:
+			got = append(got, m)
+			continue
+		case <-time.After(200 * time.Millisecond):
+		}
+		break
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("emitted %d mocks, want 2 (204 then chunked 200)", len(got))
+	}
+	if got[0].Spec.HTTPResp.StatusCode != 204 {
+		t.Errorf("mock[0] status = %d, want 204", got[0].Spec.HTTPResp.StatusCode)
+	}
+	if got[0].Spec.HTTPResp.Body != "" {
+		t.Errorf("mock[0] body = %q, want empty", got[0].Spec.HTTPResp.Body)
+	}
+	if got[1].Spec.HTTPResp.StatusCode != 200 {
+		t.Errorf("mock[1] status = %d, want 200", got[1].Spec.HTTPResp.StatusCode)
+	}
+	if got[1].Spec.HTTPResp.Body != body {
+		t.Errorf("mock[1] body = %q, want %q", got[1].Spec.HTTPResp.Body, body)
+	}
+	if te := got[1].Spec.HTTPResp.Header["Transfer-Encoding"]; te != "chunked" {
+		t.Errorf("mock[1] Transfer-Encoding = %q, want chunked", te)
 	}
 }

--- a/pkg/agent/proxy/integrations/http/replay_test.go
+++ b/pkg/agent/proxy/integrations/http/replay_test.go
@@ -1,0 +1,69 @@
+package http
+
+import (
+	"bufio"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestBuildReplayResponse_Chunked verifies that a mock recorded with
+// Transfer-Encoding: chunked replays as a valid chunked HTTP response: the wire
+// bytes parse back with the correct de-chunked body, chunked framing intact,
+// and no Content-Length (the two framings are mutually exclusive).
+func TestBuildReplayResponse_Chunked(t *testing.T) {
+	statusLine := "HTTP/1.1 200 OK\r\n"
+	header := http.Header{
+		"Content-Type":      []string{"application/json"},
+		"Transfer-Encoding": []string{"chunked"},
+	}
+	body := `{"changed":true,"version":117}`
+
+	raw := buildReplayResponse(statusLine, header, body)
+
+	if strings.Contains(strings.ToLower(raw), "content-length") {
+		t.Errorf("chunked replay must not carry Content-Length:\n%s", raw)
+	}
+
+	resp, err := http.ReadResponse(bufio.NewReader(strings.NewReader(raw)), nil)
+	if err != nil {
+		t.Fatalf("ReadResponse failed on replayed bytes: %v\nraw:\n%s", err, raw)
+	}
+	defer resp.Body.Close()
+
+	if len(resp.TransferEncoding) != 1 || resp.TransferEncoding[0] != "chunked" {
+		t.Errorf("TransferEncoding = %v, want [chunked]", resp.TransferEncoding)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	if string(got) != body {
+		t.Errorf("de-chunked body = %q, want %q", got, body)
+	}
+}
+
+// TestBuildReplayResponse_ContentLength verifies the non-chunked path recomputes
+// Content-Length from the actual body (ignoring any stale recorded value).
+func TestBuildReplayResponse_ContentLength(t *testing.T) {
+	statusLine := "HTTP/1.1 200 OK\r\n"
+	header := http.Header{
+		"Content-Type":   []string{"application/json"},
+		"Content-Length": []string{"999"}, // stale; must be recomputed
+	}
+	body := "hello"
+
+	raw := buildReplayResponse(statusLine, header, body)
+
+	resp, err := http.ReadResponse(bufio.NewReader(strings.NewReader(raw)), nil)
+	if err != nil {
+		t.Fatalf("ReadResponse failed: %v\nraw:\n%s", err, raw)
+	}
+	defer resp.Body.Close()
+
+	if resp.ContentLength != int64(len(body)) {
+		t.Errorf("ContentLength = %d, want %d", resp.ContentLength, len(body))
+	}
+	got, _ := io.ReadAll(resp.Body)
+	if string(got) != body {
+		t.Errorf("body = %q, want %q", got, body)
+	}
+}

--- a/pkg/agent/proxy/integrations/http/replay_test.go
+++ b/pkg/agent/proxy/integrations/http/replay_test.go
@@ -39,7 +39,10 @@ func TestBuildReplayResponse_Chunked(t *testing.T) {
 	if resp.ContentLength != -1 {
 		t.Errorf("chunked ContentLength = %d, want -1 (unknown)", resp.ContentLength)
 	}
-	got, _ := io.ReadAll(resp.Body)
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
 	if string(got) != body {
 		t.Errorf("de-chunked body = %q, want %q", got, body)
 	}
@@ -66,7 +69,10 @@ func TestBuildReplayResponse_ContentLength(t *testing.T) {
 	if resp.ContentLength != int64(len(body)) {
 		t.Errorf("ContentLength = %d, want %d", resp.ContentLength, len(body))
 	}
-	got, _ := io.ReadAll(resp.Body)
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
 	if string(got) != body {
 		t.Errorf("body = %q, want %q", got, body)
 	}
@@ -95,7 +101,10 @@ func TestBuildReplayResponse_ChunkedLowercaseKey(t *testing.T) {
 	if len(resp.TransferEncoding) != 1 || resp.TransferEncoding[0] != "chunked" {
 		t.Errorf("TransferEncoding = %v, want [chunked]", resp.TransferEncoding)
 	}
-	got, _ := io.ReadAll(resp.Body)
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
 	if string(got) != body {
 		t.Errorf("de-chunked body = %q, want %q", got, body)
 	}
@@ -127,7 +136,10 @@ func TestBuildReplayResponse_MissingContentLength(t *testing.T) {
 	if resp.ContentLength != int64(len(body)) {
 		t.Errorf("ContentLength = %d, want %d", resp.ContentLength, len(body))
 	}
-	got, _ := io.ReadAll(resp.Body)
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
 	if string(got) != body {
 		t.Errorf("body = %q, want %q", got, body)
 	}

--- a/pkg/agent/proxy/integrations/http/replay_test.go
+++ b/pkg/agent/proxy/integrations/http/replay_test.go
@@ -71,3 +71,32 @@ func TestBuildReplayResponse_ContentLength(t *testing.T) {
 		t.Errorf("body = %q, want %q", got, body)
 	}
 }
+
+// TestBuildReplayResponse_ChunkedLowercaseKey ensures chunked detection is
+// case-insensitive. pkg.ToHTTPHeader preserves the recorded key casing, so a
+// mock header map may carry a lowercase "transfer-encoding" key; replay must
+// still chunk the body rather than emit a chunked header over an unframed body.
+func TestBuildReplayResponse_ChunkedLowercaseKey(t *testing.T) {
+	statusLine := "HTTP/1.1 200 OK\r\n"
+	header := http.Header{
+		"content-type":      []string{"application/json"}, // non-canonical
+		"transfer-encoding": []string{"chunked"},          // non-canonical
+	}
+	body := "hello world"
+
+	raw := buildReplayResponse(statusLine, header, body)
+
+	resp, err := http.ReadResponse(bufio.NewReader(strings.NewReader(raw)), nil)
+	if err != nil {
+		t.Fatalf("ReadResponse failed on replayed bytes (body likely sent unchunked under a chunked header): %v\nraw:\n%s", err, raw)
+	}
+	defer resp.Body.Close()
+
+	if len(resp.TransferEncoding) != 1 || resp.TransferEncoding[0] != "chunked" {
+		t.Errorf("TransferEncoding = %v, want [chunked]", resp.TransferEncoding)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	if string(got) != body {
+		t.Errorf("de-chunked body = %q, want %q", got, body)
+	}
+}

--- a/pkg/agent/proxy/integrations/http/replay_test.go
+++ b/pkg/agent/proxy/integrations/http/replay_test.go
@@ -100,3 +100,35 @@ func TestBuildReplayResponse_ChunkedLowercaseKey(t *testing.T) {
 		t.Errorf("de-chunked body = %q, want %q", got, body)
 	}
 }
+
+// TestBuildReplayResponse_MissingContentLength ensures a non-chunked response
+// always gets exactly one Content-Length derived from the body, even when the
+// recorded header map omits it — otherwise the client waits for EOF to delimit
+// the body and can hang on a keepalive connection.
+func TestBuildReplayResponse_MissingContentLength(t *testing.T) {
+	statusLine := "HTTP/1.1 200 OK\r\n"
+	header := http.Header{
+		"Content-Type": []string{"application/json"}, // deliberately no Content-Length
+	}
+	body := "hello world"
+
+	raw := buildReplayResponse(statusLine, header, body)
+
+	if n := strings.Count(raw, "Content-Length:"); n != 1 {
+		t.Errorf("Content-Length header count = %d, want exactly 1\nraw:\n%s", n, raw)
+	}
+
+	resp, err := http.ReadResponse(bufio.NewReader(strings.NewReader(raw)), nil)
+	if err != nil {
+		t.Fatalf("ReadResponse failed: %v\nraw:\n%s", err, raw)
+	}
+	defer resp.Body.Close()
+
+	if resp.ContentLength != int64(len(body)) {
+		t.Errorf("ContentLength = %d, want %d", resp.ContentLength, len(body))
+	}
+	got, _ := io.ReadAll(resp.Body)
+	if string(got) != body {
+		t.Errorf("body = %q, want %q", got, body)
+	}
+}

--- a/pkg/agent/proxy/integrations/http/replay_test.go
+++ b/pkg/agent/proxy/integrations/http/replay_test.go
@@ -144,3 +144,27 @@ func TestBuildReplayResponse_MissingContentLength(t *testing.T) {
 		t.Errorf("body = %q, want %q", got, body)
 	}
 }
+
+// TestTransferEncodingIsChunked verifies chunked is matched as a whole
+// comma-separated token (case-insensitive), not a substring.
+func TestTransferEncodingIsChunked(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"chunked", true},
+		{"CHUNKED", true},
+		{" chunked ", true},
+		{"gzip, chunked", true},
+		{"chunked, gzip", true},
+		{"xchunked", false},
+		{"chunkedx", false},
+		{"gzip", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := transferEncodingIsChunked(c.in); got != c.want {
+			t.Errorf("transferEncodingIsChunked(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}

--- a/pkg/agent/proxy/integrations/http/replay_test.go
+++ b/pkg/agent/proxy/integrations/http/replay_test.go
@@ -22,10 +22,6 @@ func TestBuildReplayResponse_Chunked(t *testing.T) {
 
 	raw := buildReplayResponse(statusLine, header, body)
 
-	if strings.Contains(strings.ToLower(raw), "content-length") {
-		t.Errorf("chunked replay must not carry Content-Length:\n%s", raw)
-	}
-
 	resp, err := http.ReadResponse(bufio.NewReader(strings.NewReader(raw)), nil)
 	if err != nil {
 		t.Fatalf("ReadResponse failed on replayed bytes: %v\nraw:\n%s", err, raw)
@@ -34,6 +30,14 @@ func TestBuildReplayResponse_Chunked(t *testing.T) {
 
 	if len(resp.TransferEncoding) != 1 || resp.TransferEncoding[0] != "chunked" {
 		t.Errorf("TransferEncoding = %v, want [chunked]", resp.TransferEncoding)
+	}
+	// Assert on the parsed response (not a raw substring — a body could itself
+	// contain "content-length"): chunked responses must not carry Content-Length.
+	if cl := resp.Header.Get("Content-Length"); cl != "" {
+		t.Errorf("chunked replay must not carry Content-Length, got %q", cl)
+	}
+	if resp.ContentLength != -1 {
+		t.Errorf("chunked ContentLength = %d, want -1 (unknown)", resp.ContentLength)
 	}
 	got, _ := io.ReadAll(resp.Body)
 	if string(got) != body {


### PR DESCRIPTION
## What & why

Two record/replay fidelity bugs in the outgoing **HTTP** integration, both surfaced by recording a long-polling config server (204 long-poll + periodic chunked 200) behind a keepalive connection.

### 1. Chunked transfer-encoding was lost in mocks
`net/http.ReadResponse` moves the hop-by-hop `Transfer-Encoding` header out of the header map into `resp.TransferEncoding`, and the recorder then set a synthetic `Content-Length` from the de-chunked body. Result: a chunked upstream response was recorded — and replayed — as `Content-Length`, never `Transfer-Encoding: chunked`.

- **Record:** new shared helper `applyRecordedResponseFraming` (used by both the V2 `buildHTTPMock` and the legacy `parseFinalHTTP`, so they stay byte-for-byte identical) preserves `Transfer-Encoding: chunked` and omits `Content-Length` when the raw response was chunked.
- **Replay:** `buildReplayResponse` re-frames the stored (de-chunked) body into HTTP/1.1 chunks and suppresses `Content-Length`, since a message must not carry both framings.

### 2. Bodiless responses swallowed the keepalive stream
`readResponseV2` determined body length only from `Content-Length`, then chunked, then read-until-EOF. A `204 No Content` (and `1xx`/`304`, and responses to `HEAD`) legitimately carries **neither** framing header, so it fell into the read-until-EOF branch and consumed every *subsequent* response on the same keepalive connection. Only the first — now corrupted — mock was ever emitted.

Fix: add the **RFC 7230 §3.3.3 rule 1** short-circuit — HEAD / 1xx / 204 / 304 responses end at the header terminator regardless of framing headers. Also removed leftover `in here-*` debug logging in `readResponseV2`.

## Tests
- `TestRecordV2_ChunkedTransferEncoding` — now asserts the mock preserves `Transfer-Encoding: chunked` and omits `Content-Length`.
- `TestToChunkedBody` / `TestBuildReplayResponse_*` — replay re-framing; the chunked case is parsed back with `http.ReadResponse` to prove valid chunked framing, correct de-chunked body, and no Content-Length.
- `TestRecordV2_KeepAlive204ThenChunked` — 204 then chunked 200 on one keepalive connection must emit **2** mocks; verified to fail (1 mock) without the rule-1 fix.

`gofmt` + `go vet` clean; full `pkg/agent/proxy/integrations/http` suite passes; full binary builds.

> Note: existing recorded `test-set-*` mocks were captured before this fix, so they still show `Content-Length`; re-record to capture `Transfer-Encoding: chunked`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
