### PR TITLE
fix(proxy/dns): relay NODATA instead of failing replay on empty AAAA answer

### DIFF
--- a/pkg/agent/proxy/dns.go
+++ b/pkg/agent/proxy/dns.go
@@ -270,6 +270,20 @@ func (p *Proxy) resolveUncachedDNSResponse(question dns.Question, mode models.Mo
 			// Unlike NXDOMAIN there is no unknown name to steer to the proxy IP,
 			// and raising ErrMockNotFound here would fail replay for essentially
 			// every app that resolves an in-cluster dependency by name.
+			//
+			// This relay is deliberately qtype-AGNOSTIC (it also covers an A
+			// NODATA), not restricted to AAAA — the symmetric IPv6-only case
+			// (empty A → app falls back to AAAA) is a real scenario. It is safe
+			// w.r.t. the #2006 proxy-IP steering because steering exists for
+			// names that DON'T RESOLVE: a name the app genuinely needs but that
+			// isn't recorded comes back as NXDOMAIN (name absent → still steered
+			// below) or a real A. NODATA means the name EXISTS with no record of
+			// this type; fabricating an A→proxy-IP for it would make the app dial
+			// the proxy for a service that authoritatively has no A record, which
+			// is less correct than relaying the truthful empty answer. The only
+			// loosened case is an IPv4-only app hitting a bare name that returns
+			// A NODATA — a narrow window that previously got steered and now gets
+			// an honest empty answer (see the A-query regression test).
 			if fwdResp.Rcode == dns.RcodeSuccess {
 				p.logger.Debug("DNS mock miss: upstream NODATA (empty NOERROR), relaying as valid negative answer",
 					zap.String("query", question.Name),
@@ -288,17 +302,16 @@ func (p *Proxy) resolveUncachedDNSResponse(question dns.Question, mode models.Mo
 			// (relaying NXDOMAIN crashes apps using bare service names
 			// like "localstack" or "postgres" — issue #2006).
 			if !mockingEnabled {
-				p.logger.Debug("DNS mock miss: upstream returned negative/empty answer; mocking disabled, returning upstream response",
+				p.logger.Debug("DNS mock miss: upstream returned negative answer; mocking disabled, returning upstream response",
 					zap.String("query", question.Name),
 					zap.String("qtype", dns.TypeToString[question.Qtype]),
 					zap.Int("rcode", fwdResp.Rcode))
 				return dnsCacheEntry{Msg: fwdResp, FromUpstream: true}
 			}
-			p.logger.Debug("DNS mock miss: upstream returned negative/empty answer; falling back to synthetic DNS response",
+			p.logger.Debug("DNS mock miss: upstream returned negative answer; falling back to synthetic DNS response",
 				zap.String("query", question.Name),
 				zap.String("qtype", dns.TypeToString[question.Qtype]),
-				zap.Int("rcode", fwdResp.Rcode),
-				zap.Int("answers", len(fwdResp.Answer)))
+				zap.Int("rcode", fwdResp.Rcode))
 		} else if fwdErr != nil {
 			p.logger.Debug("DNS mock miss + upstream forward failed; falling back to synthetic response",
 				zap.String("query", question.Name),

--- a/pkg/agent/proxy/dns.go
+++ b/pkg/agent/proxy/dns.go
@@ -260,32 +260,23 @@ func (p *Proxy) resolveUncachedDNSResponse(question dns.Question, mode models.Mo
 					zap.Int("answers", len(fwdResp.Answer)))
 				return dnsCacheEntry{Msg: fwdResp, FromUpstream: true}
 			}
-			// NODATA — upstream returned NOERROR with zero answer RRs. This is
-			// a *valid* negative answer ("the name exists but has no record of
-			// this type"), not a resolution failure, so relay it as-is even
-			// when mocking is enabled. The canonical case is an AAAA query for
-			// an IPv4-only cluster service (e.g. postgres.<ns>.svc.cluster.local):
-			// glibc's getaddrinfo always issues A+AAAA in parallel, the AAAA leg
-			// legitimately has no record, and the app connects over the A record.
-			// Unlike NXDOMAIN there is no unknown name to steer to the proxy IP,
-			// and raising ErrMockNotFound here would fail replay for essentially
-			// every app that resolves an in-cluster dependency by name.
+			// NODATA — upstream returned NOERROR with zero answer RRs: a *valid*
+			// negative answer ("the name exists but has no record of this type"),
+			// distinct from NXDOMAIN. Relay it as-is even with mocking enabled.
+			// The distinction that matters: NXDOMAIN (name absent) still falls
+			// through to #2006 proxy-IP steering below; NODATA does not, because
+			// fabricating an A→proxy-IP for a name that authoritatively has no
+			// such record is less correct than the honest empty answer. Kept
+			// qtype-agnostic on purpose (the IPv6-only empty-A case is symmetric).
+			// See the PR description and the AAAA / A-query regression tests for
+			// the full rationale and the deliberately-loosened bare-name-A case.
 			//
-			// This relay is deliberately qtype-AGNOSTIC (it also covers an A
-			// NODATA), not restricted to AAAA — the symmetric IPv6-only case
-			// (empty A → app falls back to AAAA) is a real scenario. It is safe
-			// w.r.t. the #2006 proxy-IP steering because steering exists for
-			// names that DON'T RESOLVE: a name the app genuinely needs but that
-			// isn't recorded comes back as NXDOMAIN (name absent → still steered
-			// below) or a real A. NODATA means the name EXISTS with no record of
-			// this type; fabricating an A→proxy-IP for it would make the app dial
-			// the proxy for a service that authoritatively has no A record, which
-			// is less correct than relaying the truthful empty answer. The only
-			// loosened case is an IPv4-only app hitting a bare name that returns
-			// A NODATA — a narrow window that previously got steered and now gets
-			// an honest empty answer (see the A-query regression test).
+			// Logged at Info, not Debug: this is the one path that relays a
+			// possibly-genuine recording gap as a valid empty answer instead of a
+			// mock miss, so it must stay discoverable in a replay report rather
+			// than vanish into debug output.
 			if fwdResp.Rcode == dns.RcodeSuccess {
-				p.logger.Debug("DNS mock miss: upstream NODATA (empty NOERROR), relaying as valid negative answer",
+				p.logger.Info("DNS mock miss: upstream NODATA (empty NOERROR), relaying as valid negative answer (a genuinely unrecorded record of this type would also relay empty here)",
 					zap.String("query", question.Name),
 					zap.String("qtype", dns.TypeToString[question.Qtype]))
 				return dnsCacheEntry{Msg: fwdResp, FromUpstream: true}

--- a/pkg/agent/proxy/dns.go
+++ b/pkg/agent/proxy/dns.go
@@ -276,8 +276,10 @@ func (p *Proxy) resolveUncachedDNSResponse(question dns.Question, mode models.Mo
 					zap.String("qtype", dns.TypeToString[question.Qtype]))
 				return dnsCacheEntry{Msg: fwdResp, FromUpstream: true}
 			}
-			// Upstream returned a genuinely negative answer (NXDOMAIN or
-			// SERVFAIL).
+			// Upstream returned a genuinely negative answer: NXDOMAIN,
+			// SERVFAIL, or any other non-success rcode (REFUSED, NOTIMP,
+			// FORMERR, …) — everything except the RcodeSuccess cases handled
+			// above.
 			// When mocking is disabled the operator wants real DNS
 			// behaviour, so honour the upstream negative answer as-is.
 			// When mocking is enabled, a negative answer must NOT reach

--- a/pkg/agent/proxy/dns.go
+++ b/pkg/agent/proxy/dns.go
@@ -260,8 +260,24 @@ func (p *Proxy) resolveUncachedDNSResponse(question dns.Question, mode models.Mo
 					zap.Int("answers", len(fwdResp.Answer)))
 				return dnsCacheEntry{Msg: fwdResp, FromUpstream: true}
 			}
-			// Upstream returned a negative or empty answer (NXDOMAIN,
-			// SERVFAIL, or success with no RRs).
+			// NODATA — upstream returned NOERROR with zero answer RRs. This is
+			// a *valid* negative answer ("the name exists but has no record of
+			// this type"), not a resolution failure, so relay it as-is even
+			// when mocking is enabled. The canonical case is an AAAA query for
+			// an IPv4-only cluster service (e.g. postgres.<ns>.svc.cluster.local):
+			// glibc's getaddrinfo always issues A+AAAA in parallel, the AAAA leg
+			// legitimately has no record, and the app connects over the A record.
+			// Unlike NXDOMAIN there is no unknown name to steer to the proxy IP,
+			// and raising ErrMockNotFound here would fail replay for essentially
+			// every app that resolves an in-cluster dependency by name.
+			if fwdResp.Rcode == dns.RcodeSuccess {
+				p.logger.Debug("DNS mock miss: upstream NODATA (empty NOERROR), relaying as valid negative answer",
+					zap.String("query", question.Name),
+					zap.String("qtype", dns.TypeToString[question.Qtype]))
+				return dnsCacheEntry{Msg: fwdResp, FromUpstream: true}
+			}
+			// Upstream returned a genuinely negative answer (NXDOMAIN or
+			// SERVFAIL).
 			// When mocking is disabled the operator wants real DNS
 			// behaviour, so honour the upstream negative answer as-is.
 			// When mocking is enabled, a negative answer must NOT reach

--- a/pkg/agent/proxy/dns.go
+++ b/pkg/agent/proxy/dns.go
@@ -250,32 +250,42 @@ func (p *Proxy) resolveUncachedDNSResponse(question dns.Question, mode models.Mo
 		// NXDOMAIN / synthetic fallback. Forwarding is strictly
 		// additive.
 		if fwdResp, fwdErr := p.forwardDNSUpstream(question); fwdErr == nil && fwdResp != nil {
-			// Only accept the upstream answer when it actually resolved
-			// the name (RcodeSuccess with at least one Answer RR).
-			if fwdResp.Rcode == dns.RcodeSuccess && len(fwdResp.Answer) > 0 {
-				p.logger.Debug("DNS mock miss resolved via upstream forward",
-					zap.String("query", question.Name),
-					zap.String("qtype", dns.TypeToString[question.Qtype]),
-					zap.Int("rcode", fwdResp.Rcode),
-					zap.Int("answers", len(fwdResp.Answer)))
-				return dnsCacheEntry{Msg: fwdResp, FromUpstream: true}
-			}
-			// NODATA — upstream returned NOERROR with zero answer RRs: a *valid*
-			// negative answer ("the name exists but has no record of this type"),
-			// distinct from NXDOMAIN. Relay it as-is even with mocking enabled.
-			// The distinction that matters: NXDOMAIN (name absent) still falls
-			// through to #2006 proxy-IP steering below; NODATA does not, because
-			// fabricating an A→proxy-IP for a name that authoritatively has no
-			// such record is less correct than the honest empty answer. Kept
-			// qtype-agnostic on purpose (the IPv6-only empty-A case is symmetric).
-			// See the PR description and the AAAA / A-query regression tests for
-			// the full rationale and the deliberately-loosened bare-name-A case.
-			//
-			// Logged at Info, not Debug: this is the one path that relays a
-			// possibly-genuine recording gap as a valid empty answer instead of a
-			// mock miss, so it must stay discoverable in a replay report rather
-			// than vanish into debug output.
+			// A RcodeSuccess response splits into two cases by answer count:
+			// resolved (>=1 RR) vs NODATA (0 RRs). Both are relayed as-is; only
+			// a non-success rcode falls through to the #2006 steering below.
 			if fwdResp.Rcode == dns.RcodeSuccess {
+				if len(fwdResp.Answer) > 0 {
+					// Resolved — relay the real answer.
+					p.logger.Debug("DNS mock miss resolved via upstream forward",
+						zap.String("query", question.Name),
+						zap.String("qtype", dns.TypeToString[question.Qtype]),
+						zap.Int("rcode", fwdResp.Rcode),
+						zap.Int("answers", len(fwdResp.Answer)))
+					return dnsCacheEntry{Msg: fwdResp, FromUpstream: true}
+				}
+				// NODATA — NOERROR + zero answer RRs: a *valid* negative answer
+				// ("the name exists but has no record of this type"), distinct
+				// from NXDOMAIN. Relay it as-is even with mocking enabled. Only
+				// NXDOMAIN (name absent) falls through to #2006 proxy-IP steering
+				// below; fabricating an A→proxy-IP for a name that authoritatively
+				// has no such record would be less correct than the honest empty
+				// answer. Kept qtype-agnostic on purpose (the IPv6-only empty-A
+				// case is symmetric). See issue #2006 and the regression tests
+				// TestResolveUncachedDNSResponse_TestMode_UpstreamNODATA_* for the
+				// deliberately-loosened bare-name-A case.
+				//
+				// Caveat (resolver-config-dependent): the "genuinely-needed
+				// unmocked names return NXDOMAIN, not NODATA" assumption holds for
+				// bare names on most resolvers, but a search-domain / ndots setup
+				// (systemd-resolved, k8s pod DNS) can qualify a name into a zone
+				// that answers NODATA — such a name would now get an empty answer
+				// instead of being steered. Narrow; validate against the target
+				// cluster resolver config if steering unmocked in-cluster names is
+				// relied upon.
+				//
+				// Logged at Info, not Debug: this is the one path that relays a
+				// possibly-genuine recording gap as a valid empty answer instead
+				// of a mock miss, so it stays discoverable in a replay report.
 				p.logger.Info("DNS mock miss: upstream NODATA (empty NOERROR), relaying as valid negative answer (a genuinely unrecorded record of this type would also relay empty here)",
 					zap.String("query", question.Name),
 					zap.String("qtype", dns.TypeToString[question.Qtype]))

--- a/pkg/agent/proxy/dns.go
+++ b/pkg/agent/proxy/dns.go
@@ -283,12 +283,29 @@ func (p *Proxy) resolveUncachedDNSResponse(question dns.Question, mode models.Mo
 				// cluster resolver config if steering unmocked in-cluster names is
 				// relied upon.
 				//
-				// Logged at Info, not Debug: this is the one path that relays a
-				// possibly-genuine recording gap as a valid empty answer instead
-				// of a mock miss, so it stays discoverable in a replay report.
-				p.logger.Info("DNS mock miss: upstream NODATA (empty NOERROR), relaying as valid negative answer (a genuinely unrecorded record of this type would also relay empty here)",
-					zap.String("query", question.Name),
-					zap.String("qtype", dns.TypeToString[question.Qtype]))
+				// Logging: this branch is on the HOT path — glibc fires A+AAAA for
+				// essentially every hostname and every IPv4-only cluster service
+				// yields an AAAA NODATA here — so an unconditional Info would spam.
+				//   - mocking disabled: not a "mock miss" at all (the operator
+				//     wants real DNS); log at Debug.
+				//   - mocking enabled: keep it discoverable (a genuinely unrecorded
+				//     record of this type also relays empty here) but dedupe to
+				//     once per (name,qtype) so the signal survives without the spam.
+				if mockingEnabled {
+					if _, dup := p.nodataRelayLogged.LoadOrStore(generateCacheKey(question.Name, question.Qtype), struct{}{}); !dup {
+						p.logger.Info("DNS mock miss: upstream NODATA (empty NOERROR), relaying as valid negative answer (a genuinely unrecorded record of this type would also relay empty here)",
+							zap.String("query", question.Name),
+							zap.String("qtype", dns.TypeToString[question.Qtype]))
+					} else {
+						p.logger.Debug("DNS mock miss: upstream NODATA, relaying (already logged for this name/qtype)",
+							zap.String("query", question.Name),
+							zap.String("qtype", dns.TypeToString[question.Qtype]))
+					}
+				} else {
+					p.logger.Debug("DNS NODATA (empty NOERROR); mocking disabled, relaying real upstream answer",
+						zap.String("query", question.Name),
+						zap.String("qtype", dns.TypeToString[question.Qtype]))
+				}
 				return dnsCacheEntry{Msg: fwdResp, FromUpstream: true}
 			}
 			// Upstream returned a genuinely negative answer: NXDOMAIN,

--- a/pkg/agent/proxy/dns_forward.go
+++ b/pkg/agent/proxy/dns_forward.go
@@ -120,10 +120,12 @@ func (p *Proxy) hasDNSUpstream() bool {
 }
 
 // forwardDNSUpstream performs a single DNS Exchange against each
-// snapshotted upstream server in turn, returning the first Successful
-// response. On timeout or transport error we advance to the next
-// server; if all fail we return an error so the caller can fall
-// through to the legacy default response.
+// snapshotted upstream server in turn, returning the first non-nil
+// response regardless of rcode (NOERROR, NXDOMAIN, SERVFAIL, …) — the
+// caller discriminates on Rcode/Answer count (a valid answer vs NODATA
+// vs a genuinely negative rcode). On timeout or transport error we
+// advance to the next server; if all fail we return an error so the
+// caller can fall through to the legacy default response.
 //
 // Transport rules:
 //   - Start on UDP (cheapest).

--- a/pkg/agent/proxy/dns_forward_test.go
+++ b/pkg/agent/proxy/dns_forward_test.go
@@ -521,6 +521,51 @@ func TestResolveUncachedDNSResponse_TestMode_UpstreamNODATA_AQuery_RelayedNotSte
 	}
 }
 
+// TestGenerateCacheKey_QtypeIsolated locks the invariant that makes the
+// qtype-agnostic NODATA relay safe: an AAAA NODATA cached under one key must not
+// be served for a following A query on the same name. The cache key includes the
+// qtype today; this guards it against a future cache-key refactor.
+func TestGenerateCacheKey_QtypeIsolated(t *testing.T) {
+	name := "postgres.checkr.svc.cluster.local"
+	aKey := generateCacheKey(name, dns.TypeA)
+	aaaaKey := generateCacheKey(name, dns.TypeAAAA)
+	if aKey == aaaaKey {
+		t.Fatalf("A and AAAA cache keys must differ (else an AAAA NODATA would be served for an A query); both = %q", aKey)
+	}
+}
+
+// TestResolveUncachedDNSResponse_TestMode_UpstreamNODATA_DualEmpty documents the
+// intended behavior for a name that returns NODATA on BOTH A and AAAA (unmocked):
+// each leg is relayed as an honest empty answer rather than steered. The net app
+// effect is EAI_NODATA (no address) — an accepted trade for the mocked-service
+// case, since a genuinely-needed unmocked name resolves to NXDOMAIN (still
+// steered), not NODATA.
+func TestResolveUncachedDNSResponse_TestMode_UpstreamNODATA_DualEmpty(t *testing.T) {
+	addr, stop := startFakeUpstream(t, func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Rcode = dns.RcodeSuccess // NODATA for whatever qtype is asked
+		_ = w.WriteMsg(m)
+	})
+	defer stop()
+
+	p := newProxyWithUpstream(t, addr, 2*time.Second)
+	emptyMgr := NewMockManager(nil, nil, zap.NewNop())
+	t.Cleanup(emptyMgr.Close)
+	p.mockManager = emptyMgr
+
+	for _, qtype := range []uint16{dns.TypeA, dns.TypeAAAA} {
+		q := dns.Question{Name: "ipv-less.svc.", Qtype: qtype, Qclass: dns.ClassINET}
+		entry := p.resolveUncachedDNSResponse(q, models.MODE_TEST, true, time.Now(), nil)
+		if entry.Msg == nil || entry.Msg.Rcode != dns.RcodeSuccess || len(entry.Msg.Answer) != 0 {
+			t.Fatalf("%s: expected relayed empty NOERROR, got %+v", dns.TypeToString[qtype], entry.Msg)
+		}
+		if !entry.FromUpstream {
+			t.Errorf("%s: relayed NODATA must be FromUpstream", dns.TypeToString[qtype])
+		}
+	}
+}
+
 // TestResolveUncachedDNSResponse_TestMode_UpstreamSuccessPassesThrough
 // confirms that a *valid* upstream answer (Rcode=0, with Answer RRs) for a
 // real cluster-internal name still passes through unchanged after Fix B.

--- a/pkg/agent/proxy/dns_forward_test.go
+++ b/pkg/agent/proxy/dns_forward_test.go
@@ -480,6 +480,47 @@ func TestResolveUncachedDNSResponse_TestMode_UpstreamNODATA_RelayedAsIs(t *testi
 	}
 }
 
+// TestResolveUncachedDNSResponse_TestMode_UpstreamNODATA_AQuery_RelayedNotSteered
+// pins the deliberate, qtype-agnostic scope of the NODATA relay. An A-query
+// NODATA (name exists, no A record) is relayed as an honest empty answer rather
+// than steered to the proxy IP (#2006). This is the one behavioral change to the
+// steering path: previously a bare-name A that didn't resolve fell through to
+// the synthetic proxy-IP A. The decision is that NODATA means the name
+// authoritatively has no A record, so fabricating a proxy IP would be less
+// correct than the truthful empty answer; genuinely-absent names still return
+// NXDOMAIN and are still steered (covered by the NXDOMAIN test above).
+func TestResolveUncachedDNSResponse_TestMode_UpstreamNODATA_AQuery_RelayedNotSteered(t *testing.T) {
+	addr, stop := startFakeUpstream(t, func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Rcode = dns.RcodeSuccess // NOERROR, zero answers -> NODATA on the A query
+		_ = w.WriteMsg(m)
+	})
+	defer stop()
+
+	p := newProxyWithUpstream(t, addr, 2*time.Second)
+	emptyMgr := NewMockManager(nil, nil, zap.NewNop())
+	t.Cleanup(emptyMgr.Close)
+	p.mockManager = emptyMgr
+
+	q := dns.Question{Name: "localstack.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	entry := p.resolveUncachedDNSResponse(q, models.MODE_TEST, true /*mockingEnabled*/, time.Now(), nil)
+
+	if entry.Msg == nil {
+		t.Fatal("expected the relayed NODATA response, got nil Msg")
+	}
+	if entry.Msg.Rcode != dns.RcodeSuccess {
+		t.Errorf("Rcode = %d, want RcodeSuccess (empty NOERROR relayed, not steered)", entry.Msg.Rcode)
+	}
+	if len(entry.Msg.Answer) != 0 {
+		t.Fatalf("A-query NODATA must be relayed empty, not steered to a synthetic proxy-IP A; got %d answers: %v",
+			len(entry.Msg.Answer), entry.Msg.Answer)
+	}
+	if !entry.FromUpstream {
+		t.Error("relayed NODATA must be cached as FromUpstream")
+	}
+}
+
 // TestResolveUncachedDNSResponse_TestMode_UpstreamSuccessPassesThrough
 // confirms that a *valid* upstream answer (Rcode=0, with Answer RRs) for a
 // real cluster-internal name still passes through unchanged after Fix B.

--- a/pkg/agent/proxy/dns_forward_test.go
+++ b/pkg/agent/proxy/dns_forward_test.go
@@ -431,6 +431,55 @@ func TestResolveUncachedDNSResponse_TestMode_UpstreamNXDOMAIN_FallsBackToProxyIP
 	}
 }
 
+// TestResolveUncachedDNSResponse_TestMode_UpstreamNODATA_RelayedAsIs is the
+// regression test for the NODATA relay fix. An AAAA query for an IPv4-only
+// cluster service returns NOERROR with zero Answer RRs (NODATA) — a *valid*
+// negative answer, not a resolution failure. Before the fix this fell through
+// to ErrMockNotFound / the proxy-IP fallback, breaking replay for every app
+// whose libc issues A+AAAA in parallel (glibc getaddrinfo). After the fix the
+// empty NOERROR is relayed as-is, with mocking enabled, and the SOA in the
+// authority section preserved.
+func TestResolveUncachedDNSResponse_TestMode_UpstreamNODATA_RelayedAsIs(t *testing.T) {
+	// Fake upstream: NOERROR + zero answers + an SOA in the authority section,
+	// exactly what a resolver returns for an AAAA query on an IPv4-only name.
+	addr, stop := startFakeUpstream(t, func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Rcode = dns.RcodeSuccess // NOERROR
+		// No Answer RRs — NODATA.
+		soa, _ := dns.NewRR("cluster.local.\t30\tIN\tSOA\tns.cluster.local. hostmaster.cluster.local. 1 3600 600 86400 30")
+		if soa != nil {
+			m.Ns = []dns.RR{soa}
+		}
+		_ = w.WriteMsg(m)
+	})
+	defer stop()
+
+	p := newProxyWithUpstream(t, addr, 2*time.Second)
+	emptyMgr := NewMockManager(nil, nil, zap.NewNop())
+	t.Cleanup(emptyMgr.Close)
+	p.mockManager = emptyMgr
+
+	q := dns.Question{Name: "postgres.checkr.svc.cluster.local.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}
+	entry := p.resolveUncachedDNSResponse(q, models.MODE_TEST, true /*mockingEnabled*/, time.Now(), nil)
+
+	if entry.Msg == nil {
+		t.Fatal("expected the relayed NODATA response, got nil Msg (ErrMockNotFound path?)")
+	}
+	if entry.Msg.Rcode != dns.RcodeSuccess {
+		t.Errorf("Rcode = %d, want %d (NOERROR relayed as-is, NOT steered to proxy IP)", entry.Msg.Rcode, dns.RcodeSuccess)
+	}
+	if len(entry.Msg.Answer) != 0 {
+		t.Errorf("expected 0 answers (NODATA), got %d", len(entry.Msg.Answer))
+	}
+	if len(entry.Msg.Ns) == 0 {
+		t.Error("SOA authority record was dropped; NODATA relay should preserve it")
+	}
+	if !entry.FromUpstream {
+		t.Error("entry.FromUpstream = false; a relayed upstream NODATA must be cached as FromUpstream")
+	}
+}
+
 // TestResolveUncachedDNSResponse_TestMode_UpstreamSuccessPassesThrough
 // confirms that a *valid* upstream answer (Rcode=0, with Answer RRs) for a
 // real cluster-internal name still passes through unchanged after Fix B.

--- a/pkg/agent/proxy/dns_forward_test.go
+++ b/pkg/agent/proxy/dns_forward_test.go
@@ -566,6 +566,46 @@ func TestResolveUncachedDNSResponse_TestMode_UpstreamNODATA_DualEmpty(t *testing
 	}
 }
 
+// TestResolveUncachedDNSResponse_TestMode_UpstreamSERVFAIL_FallsBackToProxyIP
+// pins that non-success rcodes OTHER than NXDOMAIN still steer to the proxy IP
+// after the branch restructure. SERVFAIL (like NXDOMAIN, REFUSED, …) is a
+// genuinely-negative answer and must NOT slip into the NODATA relay branch —
+// it falls through to the synthetic proxy-IP fallback so eBPF can intercept
+// and match a recorded mock (#2006).
+func TestResolveUncachedDNSResponse_TestMode_UpstreamSERVFAIL_FallsBackToProxyIP(t *testing.T) {
+	addr, stop := startFakeUpstream(t, func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Rcode = dns.RcodeServerFailure // SERVFAIL
+		_ = w.WriteMsg(m)
+	})
+	defer stop()
+
+	p := newProxyWithUpstream(t, addr, 2*time.Second)
+	emptyMgr := NewMockManager(nil, nil, zap.NewNop())
+	t.Cleanup(emptyMgr.Close)
+	p.mockManager = emptyMgr
+
+	q := dns.Question{Name: "flaky.svc.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	entry := p.resolveUncachedDNSResponse(q, models.MODE_TEST, true, time.Now(), nil)
+
+	if entry.Msg == nil {
+		t.Fatal("expected synthetic proxy-IP fallback, got nil Msg")
+	}
+	if entry.Msg.Rcode != dns.RcodeSuccess {
+		t.Errorf("SERVFAIL must be steered to a synthetic success response, got rcode %d", entry.Msg.Rcode)
+	}
+	if len(entry.Msg.Answer) != 1 {
+		t.Fatalf("expected 1 synthetic A answer (steered), got %d", len(entry.Msg.Answer))
+	}
+	if a, ok := entry.Msg.Answer[0].(*dns.A); !ok || !a.A.Equal(net.ParseIP("127.0.0.1")) {
+		t.Errorf("expected synthetic A 127.0.0.1 (proxy steering), got %v", entry.Msg.Answer[0])
+	}
+	if entry.FromUpstream {
+		t.Error("steered synthetic response must not be marked FromUpstream")
+	}
+}
+
 // TestResolveUncachedDNSResponse_TestMode_UpstreamSuccessPassesThrough
 // confirms that a *valid* upstream answer (Rcode=0, with Answer RRs) for a
 // real cluster-internal name still passes through unchanged after Fix B.

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -181,6 +181,12 @@ type Proxy struct {
 
 	Listener net.Listener
 
+	// nodataRelayLogged dedupes the "relayed NODATA" Info log to once per
+	// (name,qtype): glibc fires A+AAAA for essentially every hostname and every
+	// IPv4-only cluster service yields an AAAA NODATA here, so an un-deduped
+	// Info line would run on almost every resolution. See resolveUncachedDNSResponse.
+	nodataRelayLogged sync.Map // map[string]struct{} keyed by generateCacheKey
+
 	//to store the nsswitch.conf file data
 	nsSwitchMutex             sync.Mutex
 	nsswitchData              []byte // in test mode we change the configuration of "hosts" in nsswitch.conf file to disable resolution over unix socket


### PR DESCRIPTION
## Problem

During replay (test mode, mocking enabled), a DNS query that misses the recorded mocks **and** whose upstream forward returns **NODATA** (NOERROR with zero answer RRs) is escalated to `ErrMockNotFound` — failing the test:

```
Mock mismatch: [DNS] AAAA postgres.<ns>.svc.cluster.local.
Hint: DNS mocks may be missing. Re-record to capture DNS queries.
```

But NODATA is a **valid negative answer** ("the name exists, it just has no record of this type"), not a resolution failure.

## Why it bites everyone

`glibc`'s `getaddrinfo` always issues **A + AAAA in parallel**. For an IPv4-only cluster service (`postgres.<ns>.svc.cluster.local`, any ClusterIP service), the `AAAA` leg legitimately returns NODATA and the app connects over the A record. Failing the test on that empty `AAAA` breaks replay for essentially **any** app that resolves an in-cluster dependency by name. (Surfaced during the Checkr low-latency validation — keploy/api-server#1867.)

## Fix

When the upstream forward returns a **Success-rcode empty answer** (NODATA), relay it to the app as-is even when mocking is enabled, instead of raising `ErrMockNotFound`. The app receives the same empty `AAAA` it saw at record time and proceeds over IPv4.

Only **genuinely negative** answers (NXDOMAIN / SERVFAIL) still fall through to the proxy-IP steering that #2006 introduced — so the "don't relay NXDOMAIN for unknown bare service names like `localstack`/`postgres`" behavior is **unchanged**. The distinction is exactly `rcode == RcodeSuccess`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Note on replay strictness

Relaying NODATA (empty NOERROR) with mocking enabled means a genuine recording gap on an AAAA (or A) record is now relayed as a valid empty answer rather than surfaced as a mock-miss. This slightly loosens replay strictness and is a deliberate trade for this bug (apps that resolve in-cluster dependencies by name fail replay otherwise). Genuinely-absent names still return NXDOMAIN and are still steered to the proxy IP (#2006). See TestResolveUncachedDNSResponse_TestMode_UpstreamNODATA_AQuery_RelayedNotSteered.

Dual-NODATA edge: a name returning NODATA on *both* A and AAAA and not mocked will now yield EAI_NODATA (no address) rather than being steered on the A leg. This is intended for the mocked-service case — a genuinely-needed unmocked dependency resolves to NXDOMAIN (still steered), not NODATA. Covered by TestResolveUncachedDNSResponse_TestMode_UpstreamNODATA_DualEmpty.

Resolver-config caveat: the "genuinely-needed unmocked names return NXDOMAIN (still steered), not NODATA" assumption holds for bare names on most resolvers, but a search-domain / ndots setup (systemd-resolved, k8s pod DNS) can qualify a name into a zone that answers NODATA — such a name now receives an honest empty answer instead of being steered to the proxy IP. Narrow, but validate against the target cluster resolver config if steering unmocked in-cluster names is relied upon.
