### PR TITLE
fix(util): cap decompression output to prevent OOM bomb

### DIFF
--- a/pkg/agent/hooks/conn/util.go
+++ b/pkg/agent/hooks/conn/util.go
@@ -89,7 +89,7 @@ func Capture(ctx context.Context, logger *zap.Logger, t chan *models.TestCase, r
 		}
 
 		if req.Header.Get("Content-Encoding") != "" {
-			reqBody, err = pkg.Decompress(logger, req.Header.Get("Content-Encoding"), reqBody)
+			reqBody, err = pkg.Decompress(logger, req.Header.Get("Content-Encoding"), reqBody, MaxTestCaseSize)
 			if err != nil {
 				utils.LogError(logger, err, "failed to decode the http request body", zap.Any("metadata", utils.GetReqMeta(req)))
 				return
@@ -132,7 +132,7 @@ func Capture(ctx context.Context, logger *zap.Logger, t chan *models.TestCase, r
 	}
 
 	if resp.Header.Get("Content-Encoding") != "" {
-		respBody, err = pkg.Decompress(logger, resp.Header.Get("Content-Encoding"), respBody)
+		respBody, err = pkg.Decompress(logger, resp.Header.Get("Content-Encoding"), respBody, MaxTestCaseSize)
 		if err != nil {
 			utils.LogError(logger, err, "failed to decompress the response body")
 			return

--- a/pkg/agent/hooks/conn/util.go
+++ b/pkg/agent/hooks/conn/util.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -80,6 +81,15 @@ func Capture(ctx context.Context, logger *zap.Logger, t chan *models.TestCase, r
 		return
 	}
 
+	// Registered before any early return below (e.g. a decompression
+	// failure on the request body) so resp.Body never leaks.
+	defer func() {
+		err := resp.Body.Close()
+		if err != nil {
+			utils.LogError(logger, err, "failed to close the http response body")
+		}
+	}()
+
 	var reqBody []byte
 	if req.Body != nil { // Read
 		var err error
@@ -91,18 +101,20 @@ func Capture(ctx context.Context, logger *zap.Logger, t chan *models.TestCase, r
 		if req.Header.Get("Content-Encoding") != "" {
 			reqBody, err = pkg.Decompress(logger, req.Header.Get("Content-Encoding"), reqBody, MaxTestCaseSize)
 			if err != nil {
+				if errors.Is(err, pkg.ErrDecompressedTooLarge) {
+					// Oversized, not corrupt: same condition as the post-
+					// decompression MaxTestCaseSize check further down, hit
+					// earlier — log it the same way, not as a decode failure.
+					logger.Error("HTTP test case data exceeds 5MB limit, skipping capture",
+						zap.String("url", req.URL.String()),
+						zap.String("method", req.Method))
+					return
+				}
 				utils.LogError(logger, err, "failed to decode the http request body", zap.Any("metadata", utils.GetReqMeta(req)))
 				return
 			}
 		}
 	}
-
-	defer func() {
-		err := resp.Body.Close()
-		if err != nil {
-			utils.LogError(logger, err, "failed to close the http response body")
-		}
-	}()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -134,6 +146,12 @@ func Capture(ctx context.Context, logger *zap.Logger, t chan *models.TestCase, r
 	if resp.Header.Get("Content-Encoding") != "" {
 		respBody, err = pkg.Decompress(logger, resp.Header.Get("Content-Encoding"), respBody, MaxTestCaseSize)
 		if err != nil {
+			if errors.Is(err, pkg.ErrDecompressedTooLarge) {
+				logger.Error("HTTP test case data exceeds 5MB limit, skipping capture",
+					zap.String("url", req.URL.String()),
+					zap.String("method", req.Method))
+				return
+			}
 			utils.LogError(logger, err, "failed to decompress the response body")
 			return
 		}

--- a/pkg/agent/hooks/conn/util_test.go
+++ b/pkg/agent/hooks/conn/util_test.go
@@ -1,12 +1,102 @@
 package conn
 
 import (
+	"bytes"
+	"context"
+	"io"
 	"net/http"
 	"testing"
+	"time"
 
+	"go.keploy.io/server/v3/pkg"
 	"go.keploy.io/server/v3/pkg/models"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
+
+// trackCloser wraps a response body and records whether Close was called.
+type trackCloser struct {
+	io.Reader
+	closed bool
+}
+
+func (tc *trackCloser) Close() error { tc.closed = true; return nil }
+
+// gzipBomb returns a gzip stream that inflates to MaxTestCaseSize+1 bytes.
+func gzipBomb(t *testing.T) []byte {
+	t.Helper()
+	data, err := pkg.Compress(zap.NewNop(), "gzip", make([]byte, MaxTestCaseSize+1))
+	if err != nil {
+		t.Fatalf("compress bomb: %v", err)
+	}
+	return data
+}
+
+// TestCapture_DecompressOverLimit pins the behavior when a body inflates
+// past MaxTestCaseSize during capture (#3867): the exchange is dropped with
+// the regular size-limit message (not a corrupt-stream error), no testcase
+// is emitted, and resp.Body is closed even on the request-side early return.
+func TestCapture_DecompressOverLimit(t *testing.T) {
+	newCapture := func(t *testing.T, reqBody []byte, reqEncoding string, respBody []byte, respEncoding string) (*observer.ObservedLogs, *trackCloser, chan *models.TestCase) {
+		t.Helper()
+		core, logs := observer.New(zap.ErrorLevel)
+		logger := zap.New(core)
+
+		req, err := http.NewRequest(http.MethodPost, "http://localhost:8080/upload", bytes.NewReader(reqBody))
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		if reqEncoding != "" {
+			req.Header.Set("Content-Encoding", reqEncoding)
+		}
+
+		body := &trackCloser{Reader: bytes.NewReader(respBody)}
+		resp := &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{},
+			Body:       body,
+		}
+		if respEncoding != "" {
+			resp.Header.Set("Content-Encoding", respEncoding)
+		}
+
+		tcChan := make(chan *models.TestCase, 1)
+		Capture(context.Background(), logger, tcChan, req, resp, time.Now(), time.Now(), models.IncomingOptions{}, true, false, 8080)
+		return logs, body, tcChan
+	}
+
+	assertDropped := func(t *testing.T, logs *observer.ObservedLogs, body *trackCloser, tcChan chan *models.TestCase) {
+		t.Helper()
+		select {
+		case tc := <-tcChan:
+			t.Fatalf("expected capture to be dropped, got testcase %q", tc.Name)
+		default:
+		}
+		if !body.closed {
+			t.Error("resp.Body must be closed when capture returns early")
+		}
+		// Exactly ONE Error-level log — the size-limit drop. Anything else
+		// (Capture's decode-failure messages, or Decompress's internal
+		// "failed to read the ... compressed data") is the oversized body
+		// being misreported as a corrupt stream.
+		if n := logs.Len(); n != 1 {
+			t.Errorf("want exactly 1 error log (the size-limit drop), got %d: %v", n, logs.All())
+		}
+		if n := logs.FilterMessageSnippet("exceeds 5MB limit").Len(); n != 1 {
+			t.Errorf("want 1 size-limit log, got %d (all: %v)", n, logs.All())
+		}
+	}
+
+	t.Run("RequestBody", func(t *testing.T) {
+		logs, body, tcChan := newCapture(t, gzipBomb(t), "gzip", []byte("ok"), "")
+		assertDropped(t, logs, body, tcChan)
+	})
+
+	t.Run("ResponseBody", func(t *testing.T) {
+		logs, body, tcChan := newCapture(t, []byte("hi"), "", gzipBomb(t), "gzip")
+		assertDropped(t, logs, body, tcChan)
+	})
+}
 
 func TestIsFiltered_FilterPolicy(t *testing.T) {
 	logger := zap.NewNop()

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -176,7 +176,9 @@ var feederInFlightBytes atomic.Int64
 // *http.Response (each carrying up to MaxTestCaseSize=5MB of body) and
 // runs io.ReadAll a second time inside Capture to materialise its own
 // reqBody/respBody copy, so peak transient memory per in-flight
-// goroutine is ~10 MB. Without a cap the parser launches one goroutine
+// goroutine is ~10 MB — a bound that holds only because Capture caps
+// decompression at MaxTestCaseSize per body (pkg.Decompress).
+// Without a cap the parser launches one goroutine
 // per HTTP exchange unconditionally; the go-memory-load workload
 // (k6 firing 42 concurrent VUs against /large_payload endpoints)
 // piles hundreds of these goroutines up faster than the unbuffered

--- a/pkg/agent/proxy/integrations/http/decode.go
+++ b/pkg/agent/proxy/integrations/http/decode.go
@@ -106,7 +106,7 @@ func (h *HTTP) decodeHTTP(ctx context.Context, reqBuf []byte, clientConn net.Con
 			}
 
 			if input.header.Get("Content-Encoding") != "" {
-				input.body, err = pkg.Decompress(h.Logger, input.header.Get("Content-Encoding"), input.body)
+				input.body, err = pkg.Decompress(h.Logger, input.header.Get("Content-Encoding"), input.body, pkg.MaxDecompressedSize)
 				if err != nil {
 					utils.LogError(h.Logger, err, "failed to decode the http request body", zap.Any("metadata", utils.GetReqMeta(request)))
 					errCh <- err

--- a/pkg/agent/proxy/integrations/http/http.go
+++ b/pkg/agent/proxy/integrations/http/http.go
@@ -207,7 +207,7 @@ func (h *HTTP) parseFinalHTTP(ctx context.Context, mock *FinalHTTP, destPort uin
 		}
 
 		if req.Header.Get("Content-Encoding") != "" {
-			reqBody, err = pkg.Decompress(h.Logger, req.Header.Get("Content-Encoding"), reqBody)
+			reqBody, err = pkg.Decompress(h.Logger, req.Header.Get("Content-Encoding"), reqBody, pkg.MaxDecompressedSize)
 			if err != nil {
 				utils.LogError(h.Logger, err, "failed to decode the http request body", zap.Any("metadata", utils.GetReqMeta(req)))
 				return err
@@ -233,7 +233,7 @@ func (h *HTTP) parseFinalHTTP(ctx context.Context, mock *FinalHTTP, destPort uin
 		}
 
 		if respParsed.Header.Get("Content-Encoding") != "" {
-			respBody, err = pkg.Decompress(h.Logger, respParsed.Header.Get("Content-Encoding"), respBody)
+			respBody, err = pkg.Decompress(h.Logger, respParsed.Header.Get("Content-Encoding"), respBody, pkg.MaxDecompressedSize)
 			if err != nil {
 				utils.LogError(h.Logger, err, "failed to decode the http response body", zap.Any("metadata", utils.GetReqMeta(req)))
 				return err

--- a/pkg/agent/proxy/integrations/http/recordv2.go
+++ b/pkg/agent/proxy/integrations/http/recordv2.go
@@ -470,7 +470,7 @@ func (h *HTTP) buildHTTPMock(m *FinalHTTP, destPort uint, connID string, opts mo
 			return nil, fmt.Errorf("read request body: %w", err)
 		}
 		if req.Header.Get("Content-Encoding") != "" {
-			reqBody, err = pkg.Decompress(h.Logger, req.Header.Get("Content-Encoding"), reqBody)
+			reqBody, err = pkg.Decompress(h.Logger, req.Header.Get("Content-Encoding"), reqBody, pkg.MaxDecompressedSize)
 			if err != nil {
 				return nil, fmt.Errorf("decompress request body: %w", err)
 			}
@@ -489,7 +489,7 @@ func (h *HTTP) buildHTTPMock(m *FinalHTTP, destPort uint, connID string, opts mo
 			return nil, fmt.Errorf("read response body: %w", err)
 		}
 		if respParsed.Header.Get("Content-Encoding") != "" {
-			respBody, err = pkg.Decompress(h.Logger, respParsed.Header.Get("Content-Encoding"), respBody)
+			respBody, err = pkg.Decompress(h.Logger, respParsed.Header.Get("Content-Encoding"), respBody, pkg.MaxDecompressedSize)
 			if err != nil {
 				return nil, fmt.Errorf("decompress response body: %w", err)
 			}

--- a/pkg/platform/storage/storage.go
+++ b/pkg/platform/storage/storage.go
@@ -16,13 +16,39 @@ import (
 	"sync"
 	"time"
 
+	"go.keploy.io/server/v3/pkg"
 	"go.keploy.io/server/v3/utils"
 	"go.uber.org/zap"
 )
 
+// maxMockDownloadBytes caps the decompressed size of a downloaded mock
+// archive. Mock sets legitimately reach hundreds of MB, so this is far
+// looser than pkg.MaxDecompressedSize while still bounding a decompression
+// bomb from a malicious or compromised server (#3867).
+const maxMockDownloadBytes = 1 << 30 // 1 GiB
+
 type Storage struct {
 	serverURL string
 	logger    *zap.Logger
+}
+
+// gzipBodyReadCloser decompresses through gz and closes BOTH the gzip
+// reader and the underlying HTTP response body — gzip.Reader.Close alone
+// does not close its source, which previously leaked the connection.
+type gzipBodyReadCloser struct {
+	gz   *gzip.Reader
+	body io.ReadCloser
+}
+
+func (g *gzipBodyReadCloser) Read(p []byte) (int, error) { return g.gz.Read(p) }
+
+func (g *gzipBodyReadCloser) Close() error {
+	gzErr := g.gz.Close()
+	bodyErr := g.body.Close()
+	if gzErr != nil {
+		return gzErr
+	}
+	return bodyErr
 }
 
 type MockUploadResponse struct {
@@ -197,7 +223,13 @@ func (s *Storage) Download(ctx context.Context, mockName string, appName string,
 			}()
 			return nil, fmt.Errorf("failed to create gzip reader: %w", err)
 		}
-		return gr, nil // gr is an io.Reader, decompressing transparently
+		// Cap decompressed output so a malicious/compromised server cannot
+		// OOM the client with a decompression bomb (#3867). The reader
+		// decompresses transparently; reads past the cap fail with
+		// pkg.ErrDecompressedTooLarge. Returned as a ReadCloser whose Close
+		// releases both the gzip reader and the HTTP connection — matching
+		// the non-gzip branch, which hands back resp.Body directly.
+		return pkg.NewCappedReadCloser(&gzipBodyReadCloser{gz: gr, body: resp.Body}, maxMockDownloadBytes), nil
 	}
 
 	return resp.Body, nil

--- a/pkg/platform/storage/storage_test.go
+++ b/pkg/platform/storage/storage_test.go
@@ -1,0 +1,117 @@
+package storage
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/rand"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.keploy.io/server/v3/pkg"
+	"go.uber.org/zap"
+)
+
+// zeroReader yields an endless stream of zero bytes — the shape of a
+// decompression bomb (tiny compressed, huge inflated).
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
+
+// TestDownload_GzipBombCapped pins the mock-download cap (#3867): a server
+// response inflating past maxMockDownloadBytes must fail the read with
+// pkg.ErrDecompressedTooLarge instead of streaming unbounded data. The
+// consumer reads through io.Copy(io.Discard, ...) so the test itself stays
+// at constant memory.
+func TestDownload_GzipBombCapped(t *testing.T) {
+	// Compresses maxMockDownloadBytes+64KiB of zeros to ~1MB, then appends
+	// an incompressible 8MiB random tail INSIDE the same gzip stream. The
+	// cap fires while that tail is still unread on the wire, so the
+	// connection is genuinely half-read — letting the test distinguish a
+	// released connection from a leaked one (an all-zeros bomb is consumed
+	// to EOF by flate's read-ahead before the cap error surfaces, and a
+	// fully-read body is pooled, not closed).
+	var bomb bytes.Buffer
+	gw, err := gzip.NewWriterLevel(&bomb, gzip.BestSpeed)
+	require.NoError(t, err)
+	_, err = io.CopyN(gw, zeroReader{}, maxMockDownloadBytes+64*1024)
+	require.NoError(t, err)
+	_, err = io.CopyN(gw, rand.Reader, 8*1024*1024)
+	require.NoError(t, err)
+	require.NoError(t, gw.Close())
+
+	// Observe actual connection closure, not just a nil Close() — closing
+	// only the gzip reader (not resp.Body) would still return nil.
+	connClosed := make(chan struct{}, 4)
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		_, _ = w.Write(bomb.Bytes())
+	}))
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateClosed {
+			connClosed <- struct{}{}
+		}
+	}
+	server.Start()
+	defer server.Close()
+
+	s := New(server.URL, zap.NewNop())
+	r, err := s.Download(context.Background(), "mock", "app", "user", "token")
+	require.NoError(t, err)
+
+	_, err = io.Copy(io.Discard, r)
+	require.ErrorIs(t, err, pkg.ErrDecompressedTooLarge)
+
+	// The abandoned half-read connection must actually be released: the
+	// gzip path returns a ReadCloser whose Close closes resp.Body, and a
+	// half-read connection cannot be reused, so the transport must close
+	// it — observed as the server's ConnState reaching StateClosed.
+	rc, ok := r.(io.Closer)
+	require.True(t, ok, "gzip Download path must return an io.Closer")
+	require.NoError(t, rc.Close())
+	select {
+	case <-connClosed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("HTTP connection not closed after Close() — resp.Body is leaking")
+	}
+}
+
+// TestDownload_GzipSmallPayload verifies a legitimate gzipped download still
+// decompresses transparently and completely.
+func TestDownload_GzipSmallPayload(t *testing.T) {
+	payload := []byte(`{"mocks":"content"}`)
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	_, err := gw.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, gw.Close())
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		_, _ = w.Write(buf.Bytes())
+	}))
+	defer server.Close()
+
+	s := New(server.URL, zap.NewNop())
+	r, err := s.Download(context.Background(), "mock", "app", "user", "token")
+	require.NoError(t, err)
+
+	got, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Equal(t, payload, got)
+
+	rc, ok := r.(io.Closer)
+	require.True(t, ok, "gzip Download path must return an io.Closer")
+	require.NoError(t, rc.Close())
+}

--- a/pkg/service/tools/extract_test.go
+++ b/pkg/service/tools/extract_test.go
@@ -1,0 +1,68 @@
+package tools
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.keploy.io/server/v3/pkg"
+)
+
+// writeTarGz writes a tar.gz at path containing a single regular file named
+// name with contentSize zero bytes.
+func writeTarGz(t *testing.T, path, name string, contentSize int64) {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     name,
+		Mode:     0o755,
+		Size:     contentSize,
+		Typeflag: tar.TypeReg,
+	}))
+	_, err := tw.Write(make([]byte, contentSize))
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0o644))
+}
+
+// TestExtractTarGz_DecompressionBombCapped pins the self-update extraction
+// cap (#3867): an archive whose tar stream inflates past the limit must fail
+// with pkg.ErrDecompressedTooLarge instead of exhausting disk/RAM. Uses the
+// extractTarGzWithLimit seam so the test works with a small archive; the
+// production entry point passes maxExtractedArchiveBytes.
+func TestExtractTarGz_DecompressionBombCapped(t *testing.T) {
+	dir := t.TempDir()
+	archive := filepath.Join(dir, "bomb.tar.gz")
+	writeTarGz(t, archive, "keploy", 2*1024*1024) // inflates to ~2 MiB
+
+	outDir := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(outDir, 0o755))
+	err := extractTarGzWithLimit(archive, outDir, 1024*1024)
+	require.ErrorIs(t, err, pkg.ErrDecompressedTooLarge)
+}
+
+// TestExtractTarGz_UnderLimitExtracts verifies a legitimate archive under
+// the cap still extracts completely.
+func TestExtractTarGz_UnderLimitExtracts(t *testing.T) {
+	dir := t.TempDir()
+	archive := filepath.Join(dir, "ok.tar.gz")
+	const contentSize = 2 * 1024 * 1024
+	writeTarGz(t, archive, "keploy", contentSize)
+
+	outDir := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(outDir, 0o755))
+	// Limit leaves headroom for tar framing above the file content.
+	require.NoError(t, extractTarGzWithLimit(archive, outDir, 4*1024*1024))
+
+	info, err := os.Stat(filepath.Join(outDir, "keploy"))
+	require.NoError(t, err)
+	assert.Equal(t, int64(contentSize), info.Size())
+}

--- a/pkg/service/tools/tools.go
+++ b/pkg/service/tools/tools.go
@@ -17,6 +17,7 @@ import (
 
 	glamour "charm.land/glamour/v2"
 	"go.keploy.io/server/v3/config"
+	"go.keploy.io/server/v3/pkg"
 	"go.keploy.io/server/v3/pkg/platform/yaml"
 	"go.keploy.io/server/v3/pkg/service/export"
 	postmanimport "go.keploy.io/server/v3/pkg/service/import"
@@ -206,7 +207,18 @@ func (t *Tools) downloadAndUpdate(ctx context.Context, logger *zap.Logger, downl
 	return nil
 }
 
+// maxExtractedArchiveBytes caps the decompressed size of the self-update
+// tarball. A keploy release archive is well under this; the bound stops a
+// crafted artifact from exhausting disk or RAM (#3867).
+const maxExtractedArchiveBytes = 1 << 30 // 1 GiB
+
 func extractTarGz(gzipPath, destDir string) error {
+	return extractTarGzWithLimit(gzipPath, destDir, maxExtractedArchiveBytes)
+}
+
+// extractTarGzWithLimit is the testable seam: the production cap stays a
+// constant while tests exercise the bound without gigabyte archives.
+func extractTarGzWithLimit(gzipPath, destDir string, limit int64) error {
 	file, err := os.Open(gzipPath)
 	if err != nil {
 		return err
@@ -229,7 +241,11 @@ func extractTarGz(gzipPath, destDir string) error {
 		}
 	}()
 
-	tarReader := tar.NewReader(gzipReader)
+	// Cap total decompressed output: the update artifact is a keploy
+	// release tarball (well under the cap), and without a bound a crafted
+	// archive can exhaust disk/RAM via io.Copy below (#3867). Note /tmp is
+	// commonly tmpfs, so the copy target may be RAM-backed.
+	tarReader := tar.NewReader(pkg.NewCappedReader(gzipReader, limit))
 
 	for {
 		header, err := tarReader.Next()

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -743,7 +743,7 @@ func SimulateHTTP(ctx context.Context, tc *models.TestCase, testSet string, logg
 
 	// Decompress if needed
 	if httpResp.Header.Get("Content-Encoding") != "" {
-		respBody, err = Decompress(logger, httpResp.Header.Get("Content-Encoding"), respBody)
+		respBody, err = Decompress(logger, httpResp.Header.Get("Content-Encoding"), respBody, MaxDecompressedSize)
 		if err != nil {
 			utils.LogError(logger, err, "failed to decode response body")
 			return nil, err
@@ -3632,9 +3632,11 @@ func IsCSV(data []byte) bool {
 	return false
 }
 
-// maxDecompressedSize bounds Decompress output so a decompression bomb (tiny
-// payload expanding to gigabytes) surfaces as an error, not an OOM. See #3867.
-const maxDecompressedSize = 100 * 1024 * 1024 // 100 MiB (~20x the 5 MiB body cap)
+// MaxDecompressedSize caps Decompress on paths with no downstream size limit
+// (replay, mock decode, SimulateHTTP) so a decompression bomb errors instead
+// of OOMing. The capture path passes the tighter conn.MaxTestCaseSize, since
+// larger testcases are dropped anyway. See #3867.
+const MaxDecompressedSize = 100 * 1024 * 1024 // 100 MiB
 
 // readAllCapped reads r up to limit bytes, erroring instead of allocating
 // unbounded memory if the stream exceeds it.
@@ -3649,12 +3651,16 @@ func readAllCapped(r io.Reader, limit int64) ([]byte, error) {
 	return data, nil
 }
 
-func Decompress(logger *zap.Logger, encoding string, data []byte) ([]byte, error) {
-	switch encoding {
+// Decompress inflates data per the given Content-Encoding, reading at most
+// limit bytes (see MaxDecompressedSize) so a bomb errors instead of OOMing.
+// The encoding is matched case-insensitively after trimming; an unsupported
+// non-empty encoding is returned undecompressed with a warning.
+func Decompress(logger *zap.Logger, encoding string, data []byte, limit int64) ([]byte, error) {
+	switch strings.ToLower(strings.TrimSpace(encoding)) {
 	case "br":
 		logger.Debug("decompressing brotli compressed data")
 		reader := brotli.NewReader(bytes.NewReader(data))
-		decodedData, err := readAllCapped(reader, maxDecompressedSize)
+		decodedData, err := readAllCapped(reader, limit)
 		if err != nil {
 			utils.LogError(logger, err, "failed to read the brotli compressed data")
 			return nil, err
@@ -3668,14 +3674,20 @@ func Decompress(logger *zap.Logger, encoding string, data []byte) ([]byte, error
 			return nil, err
 		}
 		defer reader.Close()
-		decodedData, err := readAllCapped(reader, maxDecompressedSize)
+		decodedData, err := readAllCapped(reader, limit)
 		if err != nil {
 			utils.LogError(logger, err, "failed to read the gzip compressed data")
 			return nil, err
 		}
 		return decodedData, nil
+	case "":
+		// No Content-Encoding: body is already uncompressed.
+		return data, nil
+	default:
+		logger.Warn("unsupported Content-Encoding; storing body without decompression",
+			zap.String("encoding", encoding))
+		return data, nil
 	}
-	return data, nil
 }
 
 func Compress(logger *zap.Logger, encoding string, data []byte) ([]byte, error) {

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -822,9 +822,11 @@ func SimulateHTTPStreaming(ctx context.Context, tc *models.TestCase, testSet str
 			utils.LogError(logger, gzErr, "failed to create gzip reader for streaming response")
 			return nil, gzErr
 		}
-		streamReader = &gzipReadCloser{gzipReader: gzipReader, underlying: httpResp.Body}
+		// Cap decompressed output so a bomb fails the test instead of
+		// OOMing while CompareHTTPStream accumulates the body (#3867).
+		streamReader = NewCappedReadCloser(&gzipReadCloser{gzipReader: gzipReader, underlying: httpResp.Body}, MaxDecompressedSize)
 	case "br":
-		streamReader = &brotliReadCloser{reader: brotli.NewReader(httpResp.Body), underlying: httpResp.Body}
+		streamReader = NewCappedReadCloser(&brotliReadCloser{reader: brotli.NewReader(httpResp.Body), underlying: httpResp.Body}, MaxDecompressedSize)
 	case "":
 		// no-op, use httpResp.Body directly
 	default:
@@ -3644,6 +3646,53 @@ const MaxDecompressedSize = 100 * 1024 * 1024 // 100 MiB
 // different handling (e.g. capture drops oversized bodies with the regular
 // size-limit message instead of a scary bomb error).
 var ErrDecompressedTooLarge = errors.New("decompressed size exceeds limit")
+
+// NewCappedReader wraps r so cumulative reads past limit fail with an error
+// wrapping ErrDecompressedTooLarge instead of streaming unbounded data. It
+// bounds streaming decompression (replay streams, mock downloads, archive
+// extraction) where readAllCapped's materialize-everything shape doesn't
+// fit. A stream of exactly limit bytes still reaches its natural EOF; the
+// error surfaces only when the stream holds at least one byte more.
+func NewCappedReader(r io.Reader, limit int64) io.Reader {
+	return &cappedReader{r: r, limit: limit}
+}
+
+type cappedReader struct {
+	r     io.Reader
+	read  int64
+	limit int64
+}
+
+func (c *cappedReader) Read(p []byte) (int, error) {
+	if c.read > c.limit {
+		return 0, fmt.Errorf("%w of %d bytes (possible decompression bomb)", ErrDecompressedTooLarge, c.limit)
+	}
+	// Budget reads to limit+1: an exactly-limit stream hits its natural
+	// EOF, while a single extra byte reveals an oversized stream.
+	if max := c.limit + 1 - c.read; int64(len(p)) > max {
+		p = p[:max]
+	}
+	n, err := c.r.Read(p)
+	c.read += int64(n)
+	if c.read > c.limit {
+		return 0, fmt.Errorf("%w of %d bytes (possible decompression bomb)", ErrDecompressedTooLarge, c.limit)
+	}
+	return n, err
+}
+
+// NewCappedReadCloser applies NewCappedReader to a ReadCloser, preserving
+// Close so consumers can still release the underlying resource (e.g. an
+// HTTP response body) after a capped read.
+func NewCappedReadCloser(rc io.ReadCloser, limit int64) io.ReadCloser {
+	return &cappedReadCloser{Reader: NewCappedReader(rc, limit), closer: rc}
+}
+
+type cappedReadCloser struct {
+	io.Reader
+	closer io.Closer
+}
+
+func (c *cappedReadCloser) Close() error { return c.closer.Close() }
 
 // readAllCapped reads r to EOF, failing with ErrDecompressedTooLarge once
 // the stream exceeds limit bytes. Unlike io.ReadAll, buffer capacity is

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -3632,12 +3632,29 @@ func IsCSV(data []byte) bool {
 	return false
 }
 
+// maxDecompressedSize bounds Decompress output so a decompression bomb (tiny
+// payload expanding to gigabytes) surfaces as an error, not an OOM. See #3867.
+const maxDecompressedSize = 100 * 1024 * 1024 // 100 MiB (~20x the 5 MiB body cap)
+
+// readAllCapped reads r up to limit bytes, erroring instead of allocating
+// unbounded memory if the stream exceeds it.
+func readAllCapped(r io.Reader, limit int64) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(r, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("decompressed size exceeds limit of %d bytes (possible decompression bomb)", limit)
+	}
+	return data, nil
+}
+
 func Decompress(logger *zap.Logger, encoding string, data []byte) ([]byte, error) {
 	switch encoding {
 	case "br":
 		logger.Debug("decompressing brotli compressed data")
 		reader := brotli.NewReader(bytes.NewReader(data))
-		decodedData, err := io.ReadAll(reader)
+		decodedData, err := readAllCapped(reader, maxDecompressedSize)
 		if err != nil {
 			utils.LogError(logger, err, "failed to read the brotli compressed data")
 			return nil, err
@@ -3651,7 +3668,7 @@ func Decompress(logger *zap.Logger, encoding string, data []byte) ([]byte, error
 			return nil, err
 		}
 		defer reader.Close()
-		decodedData, err := io.ReadAll(reader)
+		decodedData, err := readAllCapped(reader, maxDecompressedSize)
 		if err != nil {
 			utils.LogError(logger, err, "failed to read the gzip compressed data")
 			return nil, err

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -3638,23 +3638,58 @@ func IsCSV(data []byte) bool {
 // larger testcases are dropped anyway. See #3867.
 const MaxDecompressedSize = 100 * 1024 * 1024 // 100 MiB
 
-// readAllCapped reads r up to limit bytes, erroring instead of allocating
-// unbounded memory if the stream exceeds it.
+// ErrDecompressedTooLarge reports that a body inflated past the caller's
+// limit during Decompress. Callers use errors.Is against it to distinguish
+// an oversized (but valid) body from a corrupt stream, which deserve
+// different handling (e.g. capture drops oversized bodies with the regular
+// size-limit message instead of a scary bomb error).
+var ErrDecompressedTooLarge = errors.New("decompressed size exceeds limit")
+
+// readAllCapped reads r to EOF, failing with ErrDecompressedTooLarge once
+// the stream exceeds limit bytes. Unlike io.ReadAll, buffer capacity is
+// never grown past limit+1, so at most limit+1 bytes are read from r and
+// the returned slice retains no doubling slack (io.ReadAll can retain ~2x
+// the limit near the cap).
 func readAllCapped(r io.Reader, limit int64) ([]byte, error) {
-	data, err := io.ReadAll(io.LimitReader(r, limit+1))
-	if err != nil {
-		return nil, err
+	errTooLarge := fmt.Errorf("%w of %d bytes (possible decompression bomb)", ErrDecompressedTooLarge, limit)
+	startCap := int64(64 * 1024)
+	if startCap > limit+1 {
+		startCap = limit + 1
 	}
-	if int64(len(data)) > limit {
-		return nil, fmt.Errorf("decompressed size exceeds limit of %d bytes (possible decompression bomb)", limit)
+	data := make([]byte, 0, startCap)
+	for {
+		if len(data) == cap(data) {
+			if int64(len(data)) > limit {
+				return nil, errTooLarge
+			}
+			newCap := int64(cap(data)) * 2
+			if newCap > limit+1 {
+				newCap = limit + 1
+			}
+			grown := make([]byte, len(data), newCap)
+			copy(grown, data)
+			data = grown
+		}
+		n, err := r.Read(data[len(data):cap(data)])
+		data = data[:len(data)+n]
+		if err == io.EOF {
+			if int64(len(data)) > limit {
+				return nil, errTooLarge
+			}
+			return data, nil
+		}
+		if err != nil {
+			return nil, err
+		}
 	}
-	return data, nil
 }
 
 // Decompress inflates data per the given Content-Encoding, reading at most
-// limit bytes (see MaxDecompressedSize) so a bomb errors instead of OOMing.
-// The encoding is matched case-insensitively after trimming; an unsupported
-// non-empty encoding is returned undecompressed with a warning.
+// limit bytes (see MaxDecompressedSize) so a bomb errors instead of OOMing;
+// errors.Is(err, ErrDecompressedTooLarge) distinguishes that from a corrupt
+// stream. The encoding is matched case-insensitively after trimming —
+// Compress uses the same matching, so a recorded body round-trips at replay.
+// An unsupported encoding (e.g. zstd, deflate) is returned undecompressed.
 func Decompress(logger *zap.Logger, encoding string, data []byte, limit int64) ([]byte, error) {
 	switch strings.ToLower(strings.TrimSpace(encoding)) {
 	case "br":
@@ -3662,7 +3697,12 @@ func Decompress(logger *zap.Logger, encoding string, data []byte, limit int64) (
 		reader := brotli.NewReader(bytes.NewReader(data))
 		decodedData, err := readAllCapped(reader, limit)
 		if err != nil {
-			utils.LogError(logger, err, "failed to read the brotli compressed data")
+			// Over-limit is reported by the caller (e.g. Capture logs it as
+			// the regular size-limit drop) — logging it here too would
+			// double-report every oversized body as a decode failure.
+			if !errors.Is(err, ErrDecompressedTooLarge) {
+				utils.LogError(logger, err, "failed to read the brotli compressed data")
+			}
 			return nil, err
 		}
 		return decodedData, nil
@@ -3676,22 +3716,33 @@ func Decompress(logger *zap.Logger, encoding string, data []byte, limit int64) (
 		defer reader.Close()
 		decodedData, err := readAllCapped(reader, limit)
 		if err != nil {
-			utils.LogError(logger, err, "failed to read the gzip compressed data")
+			// See the brotli branch: over-limit is the caller's to report.
+			if !errors.Is(err, ErrDecompressedTooLarge) {
+				utils.LogError(logger, err, "failed to read the gzip compressed data")
+			}
 			return nil, err
 		}
 		return decodedData, nil
-	case "":
-		// No Content-Encoding: body is already uncompressed.
+	case "", "identity":
+		// No Content-Encoding, or "identity" (RFC 9110 §8.4.1): the body
+		// is already uncompressed.
 		return data, nil
 	default:
-		logger.Warn("unsupported Content-Encoding; storing body without decompression",
+		// Common on proxied traffic (zstd, deflate, ...) — debug, not warn,
+		// matching the streaming path in SimulateHTTPStreaming.
+		logger.Debug("unsupported Content-Encoding; storing body without decompression",
 			zap.String("encoding", encoding))
 		return data, nil
 	}
 }
 
+// Compress deflates data per the given Content-Encoding. The encoding is
+// matched case-insensitively after trimming — symmetric with Decompress, so
+// a body stored decompressed at record time is re-compressed at replay even
+// when the recorded header used a non-canonical spelling (e.g. "GZIP").
+// An unsupported encoding is returned uncompressed, mirroring Decompress.
 func Compress(logger *zap.Logger, encoding string, data []byte) ([]byte, error) {
-	switch encoding {
+	switch strings.ToLower(strings.TrimSpace(encoding)) {
 	case "gzip":
 		logger.Debug("compressing data using gzip")
 		var compressedBuffer bytes.Buffer

--- a/pkg/util_test.go
+++ b/pkg/util_test.go
@@ -957,7 +957,7 @@ func TestCompressDecompress_AllEncodings_555(t *testing.T) {
 		compressedData, err := Compress(logger, "gzip", originalData)
 		require.NoError(t, err)
 		assert.NotEqual(t, originalData, compressedData)
-		decompressedData, err := Decompress(logger, "gzip", compressedData)
+		decompressedData, err := Decompress(logger, "gzip", compressedData, MaxDecompressedSize)
 		require.NoError(t, err)
 		assert.Equal(t, originalData, decompressedData)
 	})
@@ -967,7 +967,7 @@ func TestCompressDecompress_AllEncodings_555(t *testing.T) {
 		compressedData, err := Compress(logger, "br", originalData)
 		require.NoError(t, err)
 		assert.NotEqual(t, originalData, compressedData)
-		decompressedData, err := Decompress(logger, "br", compressedData)
+		decompressedData, err := Decompress(logger, "br", compressedData, MaxDecompressedSize)
 		require.NoError(t, err)
 		assert.Equal(t, originalData, decompressedData)
 	})
@@ -977,33 +977,49 @@ func TestCompressDecompress_AllEncodings_555(t *testing.T) {
 		compressedData, err := Compress(logger, "unknown", originalData)
 		require.NoError(t, err)
 		assert.Equal(t, originalData, compressedData)
-		decompressedData, err := Decompress(logger, "unknown", originalData)
+		decompressedData, err := Decompress(logger, "unknown", originalData, MaxDecompressedSize)
 		require.NoError(t, err)
 		assert.Equal(t, originalData, decompressedData)
 	})
 
 	t.Run("DecompressError", func(t *testing.T) {
 		invalidGzipData := []byte("not gzip")
-		_, err := Decompress(logger, "gzip", invalidGzipData)
+		_, err := Decompress(logger, "gzip", invalidGzipData, MaxDecompressedSize)
 		require.Error(t, err)
 
 		invalidBrotliData := []byte{0xce, 0xb2, 0xcf, 0x81}
-		_, err = Decompress(logger, "br", invalidBrotliData)
+		_, err = Decompress(logger, "br", invalidBrotliData, MaxDecompressedSize)
 		require.Error(t, err)
 	})
 
-	// Guards against a decompression bomb: a small compressed payload that would
-	// expand past the cap must error rather than allocate unbounded memory (#3867).
-	t.Run("DecompressionBombGuard", func(t *testing.T) {
-		payload := strings.Repeat("a", 100)
-
-		// Under and at the limit: returned intact.
-		out, err := readAllCapped(strings.NewReader(payload), int64(len(payload)))
+	// Content-Encoding is matched case-insensitively after trimming.
+	t.Run("EncodingNormalized", func(t *testing.T) {
+		originalData := []byte("normalize me")
+		compressedData, err := Compress(logger, "gzip", originalData)
 		require.NoError(t, err)
-		assert.Equal(t, payload, string(out))
+		for _, enc := range []string{"GZIP", " gzip", "gzip "} {
+			decompressedData, err := Decompress(logger, enc, compressedData, MaxDecompressedSize)
+			require.NoError(t, err, "encoding %q", enc)
+			assert.Equal(t, originalData, decompressedData, "encoding %q", enc)
+		}
+	})
 
-		// Over the limit: errors instead of returning oversized data.
-		_, err = readAllCapped(strings.NewReader(payload), int64(len(payload)-1))
+	// A payload inflating past the caller's limit must error, not OOM (#3867).
+	// Uses real gzip/brotli through the public API so it fails if the
+	// LimitReader wiring is ever reverted.
+	t.Run("DecompressionBomb", func(t *testing.T) {
+		const limit = 1024
+		bomb := make([]byte, 8*1024) // 8 KiB of zeros: tiny compressed, inflates past limit
+
+		gzipBomb, err := Compress(logger, "gzip", bomb)
+		require.NoError(t, err)
+		_, err = Decompress(logger, "gzip", gzipBomb, limit)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "decompression bomb")
+
+		brBomb, err := Compress(logger, "br", bomb)
+		require.NoError(t, err)
+		_, err = Decompress(logger, "br", brBomb, limit)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "decompression bomb")
 	})

--- a/pkg/util_test.go
+++ b/pkg/util_test.go
@@ -991,6 +991,22 @@ func TestCompressDecompress_AllEncodings_555(t *testing.T) {
 		_, err = Decompress(logger, "br", invalidBrotliData)
 		require.Error(t, err)
 	})
+
+	// Guards against a decompression bomb: a small compressed payload that would
+	// expand past the cap must error rather than allocate unbounded memory (#3867).
+	t.Run("DecompressionBombGuard", func(t *testing.T) {
+		payload := strings.Repeat("a", 100)
+
+		// Under and at the limit: returned intact.
+		out, err := readAllCapped(strings.NewReader(payload), int64(len(payload)))
+		require.NoError(t, err)
+		assert.Equal(t, payload, string(out))
+
+		// Over the limit: errors instead of returning oversized data.
+		_, err = readAllCapped(strings.NewReader(payload), int64(len(payload)-1))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "decompression bomb")
+	})
 }
 
 // TestFilterMocks_678 validates the filtering and sorting of mocks in Test and Config modes.

--- a/pkg/util_test.go
+++ b/pkg/util_test.go
@@ -2,6 +2,7 @@ package pkg
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/rand"
 	"fmt"
@@ -16,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/andybalholm/brotli"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.keploy.io/server/v3/pkg/models"
@@ -1116,6 +1118,118 @@ func TestReadAllCapped_556(t *testing.T) {
 		_, err := readAllCapped(rand.Reader, limit)
 		require.ErrorIs(t, err, ErrDecompressedTooLarge)
 	})
+}
+
+// TestNewCappedReader_557 covers the streaming counterpart of readAllCapped:
+// exact-limit streams reach EOF, one extra byte errors, and the error is
+// sticky across subsequent reads.
+func TestNewCappedReader_557(t *testing.T) {
+	t.Run("ExactLimitReachesEOF", func(t *testing.T) {
+		r := NewCappedReader(bytes.NewReader(make([]byte, 1024)), 1024)
+		data, err := io.ReadAll(r)
+		require.NoError(t, err)
+		assert.Len(t, data, 1024)
+	})
+
+	t.Run("OverLimitErrorsAndSticks", func(t *testing.T) {
+		r := NewCappedReader(bytes.NewReader(make([]byte, 1025)), 1024)
+		_, err := io.Copy(io.Discard, r)
+		require.ErrorIs(t, err, ErrDecompressedTooLarge)
+		// Error must persist on further reads — a consumer retrying the
+		// stream must not see a clean EOF.
+		_, err = r.Read(make([]byte, 1))
+		require.ErrorIs(t, err, ErrDecompressedTooLarge)
+	})
+
+	t.Run("SmallChunkedReads", func(t *testing.T) {
+		r := NewCappedReader(bytes.NewReader(make([]byte, 100)), 1024)
+		var total int
+		buf := make([]byte, 7)
+		for {
+			n, err := r.Read(buf)
+			total += n
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err)
+		}
+		assert.Equal(t, 100, total)
+	})
+
+	t.Run("UnboundedStreamStops", func(t *testing.T) {
+		_, err := io.Copy(io.Discard, NewCappedReader(rand.Reader, 64*1024))
+		require.ErrorIs(t, err, ErrDecompressedTooLarge)
+	})
+}
+
+// zeroReader yields an endless stream of zero bytes (compresses extremely
+// well — the shape of a decompression bomb).
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
+
+// TestSimulateHTTPStreaming_DecompressionBomb_558 pins the streaming replay
+// wiring (#3867): a response inflating past MaxDecompressedSize must fail
+// the stream read with ErrDecompressedTooLarge instead of OOMing while the
+// body accumulates.
+func TestSimulateHTTPStreaming_DecompressionBomb_558(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+	const bombSize = MaxDecompressedSize + 64*1024
+
+	makeBomb := func(t *testing.T, encoding string) []byte {
+		t.Helper()
+		var buf bytes.Buffer
+		var w io.WriteCloser
+		switch encoding {
+		case "gzip":
+			w, _ = gzip.NewWriterLevel(&buf, gzip.BestSpeed)
+		case "br":
+			w = brotli.NewWriterLevel(&buf, brotli.BestSpeed)
+		}
+		_, err := io.CopyN(w, zeroReader{}, bombSize)
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+		return buf.Bytes()
+	}
+
+	for _, encoding := range []string{"gzip", "br"} {
+		t.Run(encoding, func(t *testing.T) {
+			bomb := makeBomb(t, encoding)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Encoding", encoding)
+				w.Header().Set("Content-Type", "application/octet-stream")
+				_, _ = w.Write(bomb)
+			}))
+			defer server.Close()
+
+			tc := &models.TestCase{
+				Name: "decompression-bomb-" + encoding,
+				HTTPReq: models.HTTPReq{
+					Method: "GET",
+					URL:    server.URL,
+					// Explicit Accept-Encoding disables the transport's
+					// transparent decompression, so the body arrives
+					// compressed with Content-Encoding intact — the same
+					// shape SimulateHTTPStreaming handles in production.
+					Header: map[string]string{"Accept-Encoding": encoding},
+				},
+			}
+
+			streamResp, err := SimulateHTTPStreaming(ctx, tc, "test-set", logger, SimulationConfig{APITimeout: 10})
+			require.NoError(t, err)
+			require.NotNil(t, streamResp)
+			defer streamResp.Reader.Close()
+
+			_, err = io.Copy(io.Discard, streamResp.Reader)
+			require.ErrorIs(t, err, ErrDecompressedTooLarge)
+		})
+	}
 }
 
 // TestFilterMocks_678 validates the filtering and sorting of mocks in Test and Config modes.

--- a/pkg/util_test.go
+++ b/pkg/util_test.go
@@ -1,7 +1,9 @@
 package pkg
 
 import (
+	"bytes"
 	"context"
+	"crypto/rand"
 	"fmt"
 	"io"
 	"mime"
@@ -18,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.keploy.io/server/v3/pkg/models"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 // TestSimulateHTTP_NewRequestError_303 ensures that SimulateHTTP returns an error
@@ -992,21 +995,49 @@ func TestCompressDecompress_AllEncodings_555(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	// Content-Encoding is matched case-insensitively after trimming.
-	t.Run("EncodingNormalized", func(t *testing.T) {
+	// Content-Encoding is matched case-insensitively after trimming — on
+	// BOTH sides. Decompress-only normalization would store plaintext at
+	// record time while Compress (exact match) replays it un-compressed
+	// under a Content-Encoding header, breaking the app's client decoder.
+	t.Run("EncodingNormalizedRoundTrip", func(t *testing.T) {
 		originalData := []byte("normalize me")
-		compressedData, err := Compress(logger, "gzip", originalData)
-		require.NoError(t, err)
-		for _, enc := range []string{"GZIP", " gzip", "gzip "} {
+		for _, enc := range []string{"GZIP", " gzip", "gzip ", "BR", " br "} {
+			compressedData, err := Compress(logger, enc, originalData)
+			require.NoError(t, err, "encoding %q", enc)
+			assert.NotEqual(t, originalData, compressedData, "Compress must not pass %q through", enc)
 			decompressedData, err := Decompress(logger, enc, compressedData, MaxDecompressedSize)
 			require.NoError(t, err, "encoding %q", enc)
 			assert.Equal(t, originalData, decompressedData, "encoding %q", enc)
 		}
 	})
 
+	// "identity" (RFC 9110 §8.4.1) means no transformation — must pass
+	// through unchanged, hitting the explicit identity case rather than the
+	// unsupported-encoding fallback (observed via its log line, the only
+	// difference between the two paths).
+	t.Run("IdentityEncoding", func(t *testing.T) {
+		core, logs := observer.New(zap.DebugLevel)
+		obsLogger := zap.New(core)
+		originalData := []byte("plain body")
+		out, err := Decompress(obsLogger, "identity", originalData, MaxDecompressedSize)
+		require.NoError(t, err)
+		assert.Equal(t, originalData, out)
+		assert.Zero(t, logs.FilterMessageSnippet("unsupported Content-Encoding").Len(),
+			"identity must not hit the unsupported-encoding fallback")
+		out, err = Compress(obsLogger, "identity", originalData)
+		require.NoError(t, err)
+		assert.Equal(t, originalData, out)
+		// A genuinely unknown encoding does hit the fallback, at debug level.
+		_, err = Decompress(obsLogger, "zstd", originalData, MaxDecompressedSize)
+		require.NoError(t, err)
+		require.Equal(t, 1, logs.FilterMessageSnippet("unsupported Content-Encoding").Len())
+		assert.Equal(t, zap.DebugLevel, logs.FilterMessageSnippet("unsupported Content-Encoding").All()[0].Level)
+	})
+
 	// A payload inflating past the caller's limit must error, not OOM (#3867).
-	// Uses real gzip/brotli through the public API so it fails if the
-	// LimitReader wiring is ever reverted.
+	// Uses real gzip/brotli through the public API so it fails if the capped
+	// read wiring is ever reverted. The sentinel lets callers distinguish
+	// oversized-but-valid from corrupt streams.
 	t.Run("DecompressionBomb", func(t *testing.T) {
 		const limit = 1024
 		bomb := make([]byte, 8*1024) // 8 KiB of zeros: tiny compressed, inflates past limit
@@ -1014,14 +1045,76 @@ func TestCompressDecompress_AllEncodings_555(t *testing.T) {
 		gzipBomb, err := Compress(logger, "gzip", bomb)
 		require.NoError(t, err)
 		_, err = Decompress(logger, "gzip", gzipBomb, limit)
-		require.Error(t, err)
+		require.ErrorIs(t, err, ErrDecompressedTooLarge)
 		assert.Contains(t, err.Error(), "decompression bomb")
 
 		brBomb, err := Compress(logger, "br", bomb)
 		require.NoError(t, err)
 		_, err = Decompress(logger, "br", brBomb, limit)
-		require.Error(t, err)
+		require.ErrorIs(t, err, ErrDecompressedTooLarge)
 		assert.Contains(t, err.Error(), "decompression bomb")
+	})
+
+	// A body of exactly the limit is legal; limit+1 is not. Also pins the
+	// corrupt-stream case to NOT match the sentinel.
+	t.Run("DecompressionLimitBoundary", func(t *testing.T) {
+		const limit = 1024
+
+		atLimit, err := Compress(logger, "gzip", make([]byte, limit))
+		require.NoError(t, err)
+		out, err := Decompress(logger, "gzip", atLimit, limit)
+		require.NoError(t, err)
+		assert.Len(t, out, limit)
+
+		overByOne, err := Compress(logger, "gzip", make([]byte, limit+1))
+		require.NoError(t, err)
+		_, err = Decompress(logger, "gzip", overByOne, limit)
+		require.ErrorIs(t, err, ErrDecompressedTooLarge)
+
+		_, err = Decompress(logger, "gzip", []byte("not gzip"), limit)
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, ErrDecompressedTooLarge)
+	})
+}
+
+// TestReadAllCapped_556 exercises the capped reader directly: boundary
+// sizes, tiny limits below the initial buffer, and that buffer capacity
+// never overshoots limit+1 (the reason it replaced io.ReadAll+LimitReader).
+func TestReadAllCapped_556(t *testing.T) {
+	t.Run("Boundaries", func(t *testing.T) {
+		for _, tc := range []struct {
+			name    string
+			size    int64
+			limit   int64
+			wantErr bool
+		}{
+			{"empty", 0, 1024, false},
+			{"under", 1023, 1024, false},
+			{"exact", 1024, 1024, false},
+			{"overByOne", 1025, 1024, true},
+			{"zeroLimitEmpty", 0, 0, false},
+			{"zeroLimitOne", 1, 0, true},
+			{"aboveInitialBuffer", 100 * 1024, 200 * 1024, false},
+			{"growthThenError", 300 * 1024, 200 * 1024, true},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				data, err := readAllCapped(bytes.NewReader(make([]byte, tc.size)), tc.limit)
+				if tc.wantErr {
+					require.ErrorIs(t, err, ErrDecompressedTooLarge)
+					return
+				}
+				require.NoError(t, err)
+				assert.Equal(t, tc.size, int64(len(data)))
+				assert.LessOrEqual(t, int64(cap(data)), tc.limit+1, "capacity must never overshoot limit+1")
+			})
+		}
+	})
+
+	t.Run("UnboundedStreamStops", func(t *testing.T) {
+		// An infinite reader must error at the cap, not hang or OOM.
+		const limit = 64 * 1024
+		_, err := readAllCapped(rand.Reader, limit)
+		require.ErrorIs(t, err, ErrDecompressedTooLarge)
 	})
 }
 


### PR DESCRIPTION
Decompress() read gzip/brotli streams unbounded; cap at 100 MiB via io.LimitReader and error past it, so a decompression bomb no longer OOMs.

Closes #3867

## Describe the changes that are made
- `Decompress()` in `pkg/util.go` ran an unbounded `io.ReadAll` on gzip/brotli readers, so a small compressed body could expand to gigabytes and OOM the process at record/replay time (decompression bomb).
- Wrapped both branches in a `readAllCapped` helper (`io.LimitReader` + size check) that returns an error past a cap instead of allocating unbounded memory. All callers already handle `Decompress`'s error return, so no caller changes were needed.
- Added a `DecompressionBombGuard` regression test.

**Why 100 MiB?** keploy already caps a raw captured body at 5 MiB (`MaxTestCaseSize`), but bodies are captured compressed and decompression legitimately expands them — so the cap needs headroom above 5 MiB. 100 MiB (~20×) covers any realistic payload while still bounding a GB-scale bomb. It's a single named constant — happy to change it if the team prefers a different value.

## Links & References

**Closes:** #3867

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- #3867
### 📄 Related Documents
- NA


## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [x] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
NA. Verify with:

```
go test -tags=viper_bind_struct -run TestCompressDecompress_AllEncodings_555 ./pkg/
```
---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?