### PR TITLE
feat(replay): add TCP-accept app-readiness gate for non-docker apps

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -192,6 +192,7 @@ type Test struct {
 	Delay                       uint64              `json:"delay" yaml:"delay" mapstructure:"delay"`
 	HealthURL                   string              `json:"healthUrl" yaml:"healthUrl" mapstructure:"healthUrl"`                         // optional HTTP(S) URL polled before firing the first test; empty preserves the fixed --delay behavior
 	HealthPollTimeout           time.Duration       `json:"healthPollTimeout" yaml:"healthPollTimeout" mapstructure:"healthPollTimeout"` // ceiling for the pre-test health poll loop before falling back to --delay
+	AppReadyProbeAddr           string              `json:"appReadyProbeAddr" yaml:"appReadyProbeAddr" mapstructure:"appReadyProbeAddr"` // optional host:port TCP-polled after the --delay floor (bounded by healthPollTimeout) before firing the first test — the TCP-accept analog of healthUrl for apps with no HTTP health endpoint (e.g. a k8s replay pod's app Service, or a native app on a fixed port). Empty preserves the fixed --delay behavior. Unlike test.port it NEVER affects request routing; it is only a readiness probe.
 	Host                        string              `json:"host" yaml:"host" mapstructure:"host"`
 	Port                        uint32              `json:"port" yaml:"port" mapstructure:"port"`
 	GRPCPort                    uint32              `json:"grpcPort" yaml:"grpcPort" mapstructure:"grpcPort"`

--- a/pkg/service/replay/app_ready_probe_test.go
+++ b/pkg/service/replay/app_ready_probe_test.go
@@ -1,0 +1,130 @@
+package replay
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"go.keploy.io/server/v3/config"
+)
+
+// An app whose ready-probe address is already listening must return immediately
+// (the gate adds no latency for a ready app). This is the non-docker analog of
+// the docker published-port gate — the path a k8s replay pod's app Service or a
+// native app on a fixed host:port takes.
+func TestWaitForAppReady_ProbeAddrGate_ReadyAddr(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	cfg := &config.Config{}
+	cfg.Test.Delay = 0 // no floor; isolate the probe gate
+	cfg.Test.AppReadyProbeAddr = ln.Addr().String()
+
+	start := time.Now()
+	if !waitForAppReady(context.Background(), zap.NewNop(), cfg) {
+		t.Fatal("waitForAppReady returned false for a listening probe address")
+	}
+	// pkg.WaitForPort probes once before its 1s ticker, so an already-listening
+	// address returns without the first-tick floor — guard that it stays instant.
+	if elapsed := time.Since(start); elapsed > 900*time.Millisecond {
+		t.Fatalf("ready probe address should return promptly (leading dial), took %v", elapsed)
+	}
+}
+
+// An app whose probe address never listens must still return true (proceed
+// anyway, matching the historical fixed-delay behavior — the gate never blocks
+// forever and never weakens the run) after the bounded ceiling.
+func TestWaitForAppReady_ProbeAddrGate_DeadAddrProceeds(t *testing.T) {
+	// Pick an address nothing is listening on by opening then closing a listener.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+
+	cfg := &config.Config{}
+	cfg.Test.Delay = 0
+	cfg.Test.AppReadyProbeAddr = addr
+	cfg.Test.HealthPollTimeout = 1 * time.Second // tiny ceiling for the test
+
+	start := time.Now()
+	if !waitForAppReady(context.Background(), zap.NewNop(), cfg) {
+		t.Fatal("waitForAppReady should proceed (return true) after the ceiling on a dead probe address")
+	}
+	if elapsed := time.Since(start); elapsed < 900*time.Millisecond {
+		t.Fatalf("should have waited ~the ceiling before proceeding, took only %v", elapsed)
+	}
+}
+
+// ctx cancellation during the probe wait must unblock immediately and report
+// not-ready (false), preserving the "false only on ctx cancel" contract.
+func TestWaitForAppReady_ProbeAddrGate_CtxCancel(t *testing.T) {
+	ln, _ := net.Listen("tcp", "127.0.0.1:0")
+	addr := ln.Addr().String()
+	ln.Close()
+
+	cfg := &config.Config{}
+	cfg.Test.Delay = 0
+	cfg.Test.AppReadyProbeAddr = addr
+	cfg.Test.HealthPollTimeout = 30 * time.Second
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	if waitForAppReady(ctx, zap.NewNop(), cfg) {
+		t.Fatal("waitForAppReady should return false when ctx is cancelled mid-probe")
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Fatalf("ctx cancel should unblock promptly, took %v", elapsed)
+	}
+}
+
+// A malformed probe address must NOT fail the run: it is logged and skipped, and
+// waitForAppReady falls through to true (never a false-classified user abort).
+func TestWaitForAppReady_ProbeAddrGate_InvalidAddrProceeds(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Test.Delay = 0
+	cfg.Test.AppReadyProbeAddr = "not-a-host-port" // no colon → SplitHostPort errors
+
+	start := time.Now()
+	if !waitForAppReady(context.Background(), zap.NewNop(), cfg) {
+		t.Fatal("waitForAppReady should proceed (return true) on a malformed probe address")
+	}
+	if elapsed := time.Since(start); elapsed > 1*time.Second {
+		t.Fatalf("invalid probe address should skip the probe and return promptly, took %v", elapsed)
+	}
+}
+
+// The ":<port>" shorthand (empty host) must be treated as localhost — parity with
+// the docker published-port gate — not rejected as invalid. A listener on that
+// port must satisfy the gate.
+func TestWaitForAppReady_ProbeAddrGate_EmptyHostShorthand(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	_, port, _ := net.SplitHostPort(ln.Addr().String())
+
+	cfg := &config.Config{}
+	cfg.Test.Delay = 0
+	cfg.Test.AppReadyProbeAddr = ":" + port // empty host → localhost
+
+	start := time.Now()
+	if !waitForAppReady(context.Background(), zap.NewNop(), cfg) {
+		t.Fatal("waitForAppReady should treat \":<port>\" as localhost and pass for a listening port")
+	}
+	// The leading dial in pkg.WaitForPort makes an already-ready port return
+	// without the 1s ticker floor.
+	if elapsed := time.Since(start); elapsed > 900*time.Millisecond {
+		t.Fatalf("ready port should return promptly (leading dial), took %v", elapsed)
+	}
+}

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -239,6 +240,43 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 					zap.String("port", port),
 					zap.Duration("ceiling", ceiling),
 					zap.Error(err))
+			}
+		}
+
+		// Non-docker apps whose ready address is known — a k8s replay pod's app
+		// Service, a remote host, a native app on a fixed host:port — gate on that
+		// address accepting a TCP connection. This is the TCP-accept analog of the
+		// docker published-port gate above (and of --health-url) for apps that
+		// expose no HTTP health endpoint. dockerPublishedHostPort only fires for a
+		// docker `-p` publish, so this covers everyone else who can name the app's
+		// address. Bounded by its own HealthPollTimeout ceiling (default 60s) and
+		// the same best-effort contract: it can only ever wait LONGER than --delay,
+		// never shorter, and a warn-not-fail on timeout so replay never regresses
+		// vs the pure --delay behavior. It is purely a readiness probe and never
+		// rewrites a request target (unlike test.port).
+		if addr := strings.TrimSpace(cfg.Test.AppReadyProbeAddr); addr != "" {
+			host, port, err := net.SplitHostPort(addr)
+			if err != nil || port == "" {
+				logger.Error("invalid test.appReadyProbeAddr; expected host:port — skipping the readiness probe",
+					zap.String("addr", addr),
+					zap.Error(err))
+			} else {
+				if host == "" {
+					host = "127.0.0.1" // ":<port>" shorthand → localhost, parity with the docker gate
+				}
+				ceiling := cfg.Test.HealthPollTimeout
+				if ceiling <= 0 {
+					ceiling = 60 * time.Second
+				}
+				if err := pkg.WaitForPort(ctx, host, port, ceiling); err != nil {
+					if ctx.Err() != nil {
+						return false
+					}
+					logger.Warn("app ready-probe address did not accept a connection within the ceiling; firing tests anyway (replay may see connection refused)",
+						zap.String("addr", addr),
+						zap.Duration("ceiling", ceiling),
+						zap.Error(err))
+				}
 			}
 		}
 		return true

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -2753,6 +2753,18 @@ func ExtractHostAndPort(curlCmd string) (string, string, error) {
 }
 
 func WaitForPort(ctx context.Context, host string, port string, timeout time.Duration) error {
+	addr := net.JoinHostPort(host, port)
+	// Probe once up front so an already-listening port returns without paying
+	// the ticker's first-tick (1s) latency below — this is what makes the
+	// readiness gates truly instant for an app that is already accepting.
+	if conn, err := net.DialTimeout("tcp", addr, 800*time.Millisecond); err == nil {
+		_ = conn.Close()
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 
@@ -2763,7 +2775,7 @@ func WaitForPort(ctx context.Context, host string, port string, timeout time.Dur
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, port), 800*time.Millisecond)
+			conn, err := net.DialTimeout("tcp", addr, 800*time.Millisecond)
 			if err == nil {
 				err := conn.Close()
 				if err != nil {


### PR DESCRIPTION
## Describe the changes that are made

`waitForAppReady` gates the first replayed request on the user app being up. It prefers `test.healthUrl` (HTTP poll), otherwise sleeps a fixed `--delay`. It *additionally* waits for the app to accept a **TCP connection** — but only for docker `-p` published ports (`dockerPublishedHostPort`). For every other deployment shape (a k8s replay pod's app Service, a remote host, a native app on a fixed port) it falls back to the pure fixed-delay sleep. A slow-booting app (e.g. a JVM) that isn't listening yet when `--delay` elapses then eats a `connection refused` on the very first test request.

This PR generalizes that TCP-accept gate:

- New **routing-neutral** config field `test.appReadyProbeAddr` (`host:port`). When set, `waitForAppReady` polls it via `pkg.WaitForPort` **after** the `--delay` floor, bounded by `test.healthPollTimeout` (default 60s) — the TCP-accept analog of the docker published-port gate and of `test.healthUrl`, for apps with no HTTP health endpoint.
  - Warns-not-fails on timeout and returns `false` **only** on ctx cancellation, so it can only ever wait *longer* than `--delay`, never shorter, and never regresses the existing behavior.
  - Unlike `test.port` it **never** rewrites a request target — it is purely a readiness probe.
  - Empty host (`":<port>"`) defaults to `127.0.0.1`, matching the docker gate.
- `pkg.WaitForPort` now probes once **before** its 1s ticker, so an already-listening address returns without the first-tick latency. The existing docker readiness gate benefits from the same change (truly instant for a ready app).

Motivation: in Kubernetes DaemonSet-mode auto-replay each test-set gets a fresh replay pod whose app is never a docker `-p` publish, so the readiness wait degraded to a pure fixed delay and slow-booting apps failed their first request. The orchestrator can now set `appReadyProbeAddr` to the app Service's `host:port` and get self-tuning readiness — instant for a fast app, waits exactly as long as a slow one needs, bounded by the poll ceiling.

## Links & References

**Closes:** NA
### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [x] 🍕 Feature

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed

_Covered by unit tests (`pkg/service/replay/app_ready_probe_test.go`): ready-addr returns instantly, dead-addr proceeds after the ceiling (never blocks forever), ctx-cancel returns false, malformed addr is logged-and-skipped (never a false user-abort), and the `":<port>"` localhost shorthand. Also validated end-to-end in a live k8s DaemonSet auto-replay: the readiness probe fires and the first-request connection-refused is eliminated._

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

```yaml
# keploy.yml
test:
  appReadyProbeAddr: "my-app.default.svc.cluster.local:8443"  # host:port to TCP-poll before firing tests
  healthPollTimeout: 60s                                       # ceiling for the poll
  delay: 5                                                     # floor, still honored
```
`go test ./pkg/service/replay/ -run ProbeAddrGate -v`

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA
