### PR TITLE
feat(cloud-replay): orchestrate via the Docker SDK when the compose CLI is unavailable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cilium/ebpf v0.21.0
 	github.com/cloudflare/cfssl v1.6.4
 	github.com/docker/docker v28.5.2+incompatible
-	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/fatih/color v1.18.0
 	github.com/k0kubun/pp/v3 v3.2.0
@@ -139,7 +139,7 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/containerd/errdefs v0.3.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
-	github.com/distribution/reference v0.6.0 // indirect
+	github.com/distribution/reference v0.6.0
 	github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707 // indirect
 	github.com/fatih/semgroup v1.2.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -54,8 +54,24 @@ type App struct {
 	keployContainer string
 	composeFile     string // path to the temp compose file (set during SetupCompose)
 	composeContent  []byte // in-memory compose YAML; set when InMemoryCompose is used
-	EnableTesting   bool
-	Mode            models.Mode
+	// sdkStack tracks the containers the Docker-SDK compose orchestrator
+	// (compose_sdk.go) created for a `keploy cloud replay` run, so
+	// composeSDKTeardown can stop/remove them. Populated only on the in-memory
+	// compose path. sdkStackMu guards it: runComposeSDK (app-run goroutine)
+	// appends/reads it while ComposeDownOnSetupFailure -> ComposeDown ->
+	// composeSDKTeardown (the replay orchestrator goroutine, which bypasses
+	// run()'s downOnce) can concurrently snapshot+clear it.
+	sdkStackMu sync.Mutex
+	sdkStack   []sdkContainerRef
+	// useSDKCompose selects the Docker-SDK orchestrator over the `docker compose`
+	// CLI for the in-memory (cloud replay) path. Decided once in
+	// setupComposeInMemory (Setup, single goroutine — before Run/teardown
+	// goroutines exist, so the later reads in run()/ComposeDown are race-free):
+	// the SDK is used only as a FALLBACK when the compose CLI is unavailable
+	// (e.g. a distroless image with no compose plugin).
+	useSDKCompose bool
+	EnableTesting bool
+	Mode          models.Mode
 }
 
 func (a *App) Setup(ctx context.Context) error {
@@ -280,10 +296,33 @@ func (a *App) setupComposeInMemory(extraArgs []string) error {
 	// Ensure the command uses stdin ("-f -") and has the exit-code-from flags.
 	a.cmd = ensureInMemoryComposeFlags(a.cmd, a.composeService)
 
-	a.logger.Info("Running application using in-memory Keploy-generated Docker Compose (no file written to disk)",
-		zap.String("cmd", a.cmd))
+	// Choose the orchestration backend for this cloud-replay run. Prefer the
+	// `docker compose` CLI when it is installed; fall back to the Docker SDK
+	// (compose_sdk.go) only when it is not — e.g. a distroless/shell-free image
+	// that ships no compose plugin. Decided here (Setup, single goroutine) so
+	// run() and ComposeDown read the same, already-settled choice without a race.
+	if dockerComposeCLIAvailable() {
+		a.logger.Info("docker compose CLI is available; running the in-memory cloud-replay stack via docker compose",
+			zap.String("cmd", a.cmd))
+	} else {
+		a.useSDKCompose = true
+		a.logger.Info("docker compose CLI is not available; falling back to the Docker SDK to orchestrate the in-memory cloud-replay stack",
+			zap.String("cmd", a.cmd))
+	}
 
 	return nil
+}
+
+// dockerComposeCLIAvailable reports whether the `docker compose` v2 CLI plugin
+// is usable — i.e. the docker binary is on PATH AND the compose plugin is
+// installed. `docker compose version` needs no shell (docker is a binary), so
+// this also works on a shell-free image; it returns false when either the
+// docker binary or the compose plugin is missing, which is exactly when cloud
+// replay should fall back to the Docker SDK.
+func dockerComposeCLIAvailable() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return exec.CommandContext(ctx, "docker", "compose", "version").Run() == nil
 }
 
 func (a *App) SetAppCommand(appCommand string) {
@@ -516,6 +555,16 @@ func (a *App) ComposeDown() {
 	// agent/app container names even when the down consumes its full budget
 	// (that name-freeing is exactly what avoids "container name already in use"
 	// on the next compose up).
+	// In-memory compose (`keploy cloud replay`) that was brought up via the
+	// Docker SDK fallback: tear it down the same way (no `docker compose`/`docker`
+	// CLI). composeSDKTeardown is self-bounded. When the CLI path was used
+	// instead (compose plugin available), fall through to the `docker compose
+	// down` branch below.
+	if len(a.composeContent) > 0 && a.useSDKCompose {
+		a.composeSDKTeardown()
+		return
+	}
+
 	downCtx, downCancel := context.WithTimeout(context.Background(), composeDownCmdBudget)
 	defer downCancel()
 
@@ -523,19 +572,15 @@ func (a *App) ComposeDown() {
 
 	switch {
 	case len(a.composeContent) > 0:
-		// In-memory mode: pipe compose YAML via stdin, no file on disk.
-		// Preserve project-scoping flags (-p/--project-name, --project-directory)
-		// from the original command so teardown targets the correct project.
+		// In-memory mode over the compose CLI: pipe the YAML via stdin, no file
+		// on disk. Preserve project-scoping flags (-p/--project-name,
+		// --project-directory) so teardown targets the correct project.
 		a.logger.Debug("Running docker compose down using in-memory compose content")
 		args := []string{"compose", "-f", "-"}
 		args = append(args, extractProjectFlags(a.cmd)...)
 		// --timeout 1: stop containers fast instead of the default 10s graceful
-		// wait PER container. Between test-sets `keploy test` restarts the whole
-		// compose stack; under loaded CI a slow `down` was exceeding the
-		// per-test-set teardown drain budget and being abandoned, leaving a
-		// half-removed agent container that the next test-set's `up` then
-		// collided with ("container name already in use" -> dependency
-		// keploy-agent failed to start -> test-set abandoned, no report).
+		// wait PER container, so a slow down between test-sets can't exceed the
+		// teardown-drain budget and leave a half-removed agent for the next up.
 		args = append(args, "down", "--timeout", "1")
 		downCmd = exec.CommandContext(downCtx, "docker", args...)
 		downCmd.Stdin = bytes.NewReader(a.composeContent)
@@ -1121,6 +1166,19 @@ func (a *App) run(ctx context.Context) models.AppError {
 	composeDown := func() { downOnce.Do(a.ComposeDown) }
 	if a.kind == utils.DockerCompose {
 		defer composeDown()
+	}
+
+	// `keploy cloud replay` path (in-memory compose) WHEN the `docker compose`
+	// CLI is unavailable: orchestrate the stack directly through the Docker SDK
+	// instead. useSDKCompose was decided in setupComposeInMemory (it is true only
+	// when the compose plugin is absent). Placed before the compose-CLI pre-run
+	// guards below (removeStaleComposeAgentWithin / docker-compose ps), which are
+	// not applicable to the SDK path. The deferred composeDown() above routes to
+	// composeSDKTeardown when useSDKCompose is set. When the compose CLI IS
+	// available this falls through to the unchanged CLI path, and the normal
+	// file-based `keploy test`/`keploy record` compose path is untouched.
+	if a.useSDKCompose && len(a.composeContent) > 0 {
+		return a.runComposeSDK(ctx)
 	}
 
 	// dockerRunName is the resolved user-app container name; reused by the

--- a/pkg/client/app/compose_sdk.go
+++ b/pkg/client/app/compose_sdk.go
@@ -1,0 +1,710 @@
+package app
+
+// compose_sdk.go is the Docker-SDK compose orchestrator used ONLY by
+// `keploy cloud replay` (the in-memory compose path, uniquely identified by
+// len(a.composeContent) > 0). Instead of shelling out to `docker compose -f -
+// up/down/ps`, it drives the Docker daemon directly through the moby client
+// already embedded in docker.Client, faithfully reproducing what
+// `docker compose up --abort-on-container-exit --exit-code-from <app>` does for
+// the bounded stack cloud replay generates: the injected keploy-agent service
+// plus the app container(s) reconstructed from a single Kubernetes deployment.
+// The app's real infra dependencies are NOT run (they are served from recorded
+// mocks by the keploy proxy), so there is no general dependency graph to
+// resolve — only "start the agent, wait until it is healthy, then start the
+// app sharing the agent's net/pid namespace, and wait for the app to exit".
+//
+// The normal file-based `keploy test`/`keploy record` compose replay path is
+// untouched and keeps using the compose CLI.
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/distribution/reference"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	imagetypes "github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/api/types/registry"
+	volumetypes "github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/docker/go-connections/nat"
+	"go.keploy.io/server/v3/pkg"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.keploy.io/server/v3/pkg/platform/docker"
+	"go.uber.org/zap"
+)
+
+// sdkComposeProject is the compose "project" label the SDK path stamps on the
+// containers/volumes it creates, so logTargetContainer/recentAppLogs' label
+// filter keeps working and the stack is easy to identify.
+const sdkComposeProject = "keploy-cloud-replay"
+
+// sdkTeardownBudget is the single hard deadline for the entire SDK teardown, so
+// even a multi-container stack stays well inside the record/replay
+// teardown-drain budget (utils.DrainErrGroup, 30s). Every per-container stop /
+// remove derives its context from this parent.
+const sdkTeardownBudget = 25 * time.Second
+
+// sdkContainerRef tracks a container the orchestrator created so teardown can
+// stop/remove it. isApp marks the app service(s) (they get a coverage-flush
+// grace on stop, unlike the agent).
+type sdkContainerRef struct {
+	id      string
+	name    string
+	service string
+	isApp   bool
+}
+
+// runComposeSDK brings the cloud-replay stack up via the Docker SDK and blocks
+// until the app container exits (the --exit-code-from semantics), returning its
+// exit code as a models.AppError. Teardown is handled by the caller's deferred
+// ComposeDown -> composeSDKTeardown.
+func (a *App) runComposeSDK(ctx context.Context) models.AppError {
+	model, err := docker.ParseComposeForSDK(a.composeContent)
+	if err != nil {
+		return models.AppError{AppErrorType: models.ErrCommandError, Err: err}
+	}
+
+	agentSvc, appSvcs := a.classifyComposeServices(model)
+	if agentSvc == nil {
+		return models.AppError{AppErrorType: models.ErrCommandError,
+			Err: fmt.Errorf("keploy-agent service not found in the generated cloud-replay compose")}
+	}
+	if len(appSvcs) == 0 {
+		return models.AppError{AppErrorType: models.ErrCommandError,
+			Err: fmt.Errorf("no application service found in the generated cloud-replay compose")}
+	}
+
+	// Free any container names left over by a prior run (SDK, no `docker rm`
+	// CLI) so create can't hit "name already in use".
+	a.sdkPreClean(ctx, model)
+
+	// Pre-create the named volumes compose would (keploy-tls-certs, the shared
+	// /tmp volume). Idempotent; docker would auto-create on mount anyway.
+	a.sdkEnsureVolumes(ctx, model)
+
+	a.logger.Info("Bringing up the cloud-replay stack via the Docker SDK (no docker compose CLI)",
+		zap.String("agent", agentSvc.Key), zap.Int("app_services", len(appSvcs)))
+
+	// 1. Agent first — it owns the net/pid namespace the app joins and carries
+	//    the healthcheck the app's start is gated on.
+	agentID, aerr := a.sdkCreateAndStart(ctx, *agentSvc, "")
+	if aerr.Err != nil {
+		return aerr
+	}
+
+	// Preserve the log line the CLI path emitted (utils.ExecuteCommand) and the
+	// e2e guard asserts on ("Starting Application ?:").
+	a.logger.Info("Starting Application :", zap.String("via", "docker-sdk"))
+
+	// 2. Gate on agent readiness: container healthcheck (compose
+	//    depends_on: service_healthy) + an HTTP /agent/ready fallback, bounded
+	//    by the agent's own readiness budget so a broken health binary can never
+	//    hang app start forever.
+	if rerr := a.waitAgentReady(ctx, agentID); rerr != nil {
+		return models.AppError{AppErrorType: models.ErrCommandError, Err: rerr, AppLogs: a.recentAppLogs(ctx)}
+	}
+
+	// 3. App service(s) — share the agent's net + pid namespace.
+	for _, svc := range appSvcs {
+		if _, cerr := a.sdkCreateAndStart(ctx, svc, agentID); cerr.Err != nil {
+			return cerr
+		}
+	}
+
+	// 4. Stream container logs to the terminal (compose up streams both the
+	//    agent and app logs); stop the pumps when the app exits / we tear down.
+	logCtx, cancelLogs := context.WithCancel(ctx)
+	defer cancelLogs()
+	a.startSDKLogPumps(logCtx)
+
+	// 5. Wait for the app (the --exit-code-from target) to exit.
+	return a.sdkWaitForApp(ctx)
+}
+
+// classifyComposeServices splits the parsed model into the keploy-agent service
+// (matched by the fixed service key or the agent container_name) and the app
+// service(s) (everything else).
+func (a *App) classifyComposeServices(model *docker.ComposeModel) (*docker.ServiceSpec, []docker.ServiceSpec) {
+	var agent *docker.ServiceSpec
+	var apps []docker.ServiceSpec
+	for i := range model.Services {
+		s := model.Services[i]
+		if s.Key == keployAgentComposeService || (a.keployContainer != "" && s.ContainerName == a.keployContainer) {
+			cp := s
+			agent = &cp
+			continue
+		}
+		apps = append(apps, s)
+	}
+	return agent, apps
+}
+
+// sdkCreateAndStart translates a compose service to a container and starts it.
+// agentID is empty for the agent itself (standalone networking, publishes
+// ports); for app services it is the started agent's container id, so the app
+// shares the agent's net/pid namespace (compose `service:keploy-agent`).
+func (a *App) sdkCreateAndStart(ctx context.Context, svc docker.ServiceSpec, agentID string) (string, models.AppError) {
+	cfg, hostCfg, err := buildContainerSpec(svc, agentID)
+	if err != nil {
+		return "", models.AppError{AppErrorType: models.ErrCommandError, Err: err}
+	}
+
+	name := svc.ContainerName
+	if name == "" {
+		name = svc.Key
+	}
+
+	if err := a.sdkEnsureImage(ctx, svc.Image); err != nil {
+		return "", models.AppError{AppErrorType: models.ErrCommandError, Err: err}
+	}
+
+	// networkingConfig is nil: the agent uses the default bridge (its published
+	// ports are reachable on the host regardless of the user network, and cloud
+	// replay has no cross-container networking because dependencies are mocked),
+	// and the app shares the agent's namespace.
+	created, err := a.docker.ContainerCreate(ctx, cfg, hostCfg, nil, nil, name)
+	if err != nil {
+		return "", models.AppError{AppErrorType: models.ErrCommandError,
+			Err: fmt.Errorf("failed to create container %q: %w", name, err)}
+	}
+	// Track before start so teardown removes it even if start fails. Guarded:
+	// a concurrent ComposeDownOnSetupFailure may snapshot+clear the stack.
+	a.sdkTrack(sdkContainerRef{id: created.ID, name: name, service: svc.Key, isApp: agentID != ""})
+
+	if err := a.docker.ContainerStart(ctx, created.ID, container.StartOptions{}); err != nil {
+		return "", models.AppError{AppErrorType: models.ErrCommandError,
+			Err: fmt.Errorf("failed to start container %q: %w", name, err)}
+	}
+	a.logger.Debug("started cloud-replay container via SDK",
+		zap.String("service", svc.Key), zap.String("name", name), zap.String("id", created.ID))
+	return created.ID, models.AppError{}
+}
+
+// buildContainerSpec translates a parsed compose service into the Docker SDK
+// container.Config + container.HostConfig, faithfully reproducing what
+// `docker compose up` would create for it. It is pure (no daemon) so the
+// translation is unit-testable. agentID is empty for the agent (standalone:
+// publishes ports, keeps DNS); for app services it is the agent's container id,
+// so the app joins the agent's net/pid namespace and carries no ports/DNS.
+func buildContainerSpec(svc docker.ServiceSpec, agentID string) (*container.Config, *container.HostConfig, error) {
+	cfg := &container.Config{
+		Image:      svc.Image,
+		Env:        svc.Env,
+		Labels:     composeSDKLabels(svc),
+		WorkingDir: svc.WorkingDir,
+	}
+	if len(svc.Entrypoint) > 0 {
+		cfg.Entrypoint = svc.Entrypoint
+	}
+	if len(svc.Command) > 0 {
+		cfg.Cmd = svc.Command
+	}
+	if hc := svc.Healthcheck; hc != nil && len(hc.Test) > 0 {
+		cfg.Healthcheck = &container.HealthConfig{
+			Test:        hc.Test,
+			Interval:    hc.Interval,
+			Timeout:     hc.Timeout,
+			Retries:     hc.Retries,
+			StartPeriod: hc.StartPeriod,
+		}
+	}
+
+	hostCfg := &container.HostConfig{
+		Binds:       svc.Binds,
+		CapAdd:      svc.CapAdd,
+		SecurityOpt: svc.SecurityOpt,
+		Tmpfs:       svc.Tmpfs,
+		// Force restart=no. cloud replay emits `restart: unless-stopped`, but
+		// under --abort-on-container-exit the daemon must NOT auto-restart the
+		// app: it would break exit-code capture and leave the stack up.
+		RestartPolicy: container.RestartPolicy{Name: container.RestartPolicyDisabled},
+	}
+
+	if _, ok := docker.IsShareServiceNamespace(svc.PidMode); ok {
+		hostCfg.PidMode = container.PidMode("container:" + agentID)
+	}
+	if _, shareNet := docker.IsShareServiceNamespace(svc.NetworkMode); shareNet {
+		// Joining another container's network namespace forbids ports, DNS and
+		// network attachment on this container (the daemon rejects them). All of
+		// that lives on the agent, which owns the namespace.
+		hostCfg.NetworkMode = container.NetworkMode("container:" + agentID)
+	} else {
+		hostCfg.DNS = svc.DNS
+		hostCfg.DNSSearch = svc.DNSSearch
+		hostCfg.DNSOptions = svc.DNSOpt
+		if len(svc.Ports) > 0 {
+			exposed, bindings, perr := nat.ParsePortSpecs(svc.Ports)
+			if perr != nil {
+				return nil, nil, fmt.Errorf("service %s: invalid ports %v: %w", svc.Key, svc.Ports, perr)
+			}
+			cfg.ExposedPorts = exposed
+			hostCfg.PortBindings = bindings
+		}
+	}
+	return cfg, hostCfg, nil
+}
+
+// waitAgentReady blocks until the keploy-agent reports ready, reproducing
+// compose's `depends_on: keploy-agent: condition: service_healthy` gate: it
+// polls the container's healthcheck AND, as a safety net, an HTTP /agent/ready
+// probe, bounded by the agent's readiness budget (pkg.AgentReadyTimeout).
+func (a *App) waitAgentReady(ctx context.Context, agentID string) error {
+	deadline := time.Now().Add(pkg.AgentReadyTimeout())
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		info, err := a.docker.ContainerInspect(ctx, agentID)
+		if err == nil && info.State != nil {
+			if info.State.Status == container.StateExited || info.State.Status == container.StateDead {
+				return fmt.Errorf("keploy-agent exited before becoming ready (status=%s, exitCode=%d)",
+					info.State.Status, info.State.ExitCode)
+			}
+			if info.State.Health != nil && info.State.Health.Status == container.Healthy {
+				return nil
+			}
+		} else if err != nil {
+			a.logger.Debug("failed to inspect keploy-agent while waiting for readiness", zap.Error(err))
+		}
+
+		// Fallback: a 200 from /agent/ready means the agent is genuinely ready,
+		// so this unblocks even if the container health binary is unavailable.
+		if a.agentHTTPReady(ctx) {
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out after %s waiting for keploy-agent to become ready", pkg.AgentReadyTimeout())
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+// agentHTTPReady POSTs the agent readiness endpoint and reports whether it
+// returned 200. Best-effort: any transport/URL error is treated as "not ready".
+func (a *App) agentHTTPReady(ctx context.Context) bool {
+	if a.opts.AgentPort == 0 {
+		return false
+	}
+	client := &http.Client{Timeout: 2 * time.Second}
+	// The router mounts the agent routes under /agent, so the readiness handler
+	// (registered as POST /agent/ready) is reachable at /agent/agent/ready; try
+	// the unprefixed path too in case the mount changes.
+	for _, path := range []string{"/agent/agent/ready", "/agent/ready"} {
+		url := fmt.Sprintf("http://127.0.0.1:%d%s", a.opts.AgentPort, path)
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+		if err != nil {
+			continue
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			continue
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode == http.StatusOK {
+			return true
+		}
+	}
+	return false
+}
+
+// sdkWaitForApp blocks until the app container (the --exit-code-from target)
+// exits, mapping its exit code to a models.AppError the same way the CLI path
+// maps `docker compose up`'s exit.
+func (a *App) sdkWaitForApp(ctx context.Context) models.AppError {
+	waitName := a.container
+	if waitName == "" {
+		// Defensive: fall back to the first app container if --container-name was
+		// somehow unset (cloud replay always sets it). Snapshot under the lock —
+		// a concurrent ComposeDownOnSetupFailure may drain the stack.
+		for _, c := range a.sdkSnapshotStack() {
+			if c.isApp {
+				waitName = c.name
+				break
+			}
+		}
+	}
+
+	waitCh, errCh := a.docker.ContainerWait(ctx, waitName, container.WaitConditionNotRunning)
+	select {
+	case <-ctx.Done():
+		a.logger.Debug("context cancelled while waiting for the cloud-replay app to exit", zap.Error(ctx.Err()))
+		return models.AppError{AppErrorType: models.ErrCtxCanceled, Err: ctx.Err()}
+	case werr := <-errCh:
+		if ctx.Err() != nil {
+			return models.AppError{AppErrorType: models.ErrCtxCanceled, Err: ctx.Err()}
+		}
+		return models.AppError{AppErrorType: models.ErrUnExpected,
+			Err:     fmt.Errorf("failed while waiting for the cloud-replay app container: %w", werr),
+			AppLogs: a.recentAppLogs(ctx)}
+	case res := <-waitCh:
+		appLogs := a.recentAppLogs(ctx)
+		if res.Error != nil && res.Error.Message != "" {
+			return models.AppError{AppErrorType: models.ErrUnExpected,
+				Err: fmt.Errorf("cloud-replay app wait reported an error: %s", res.Error.Message), AppLogs: appLogs}
+		}
+		if res.StatusCode != 0 {
+			return models.AppError{AppErrorType: models.ErrUnExpected,
+				Err: fmt.Errorf("cloud-replay app container exited with code %d", res.StatusCode), AppLogs: appLogs}
+		}
+		return models.AppError{AppErrorType: models.ErrAppStopped, Err: nil, AppLogs: appLogs}
+	}
+}
+
+// composeSDKTeardown stops and removes the containers the SDK orchestrator
+// created, reproducing `docker compose down` (WITHOUT -v, so named volumes are
+// kept). It is idempotent and bounded on its own deadlines so it never overruns
+// the record/replay teardown-drain budget, even on a saturated daemon. Routed
+// to from ComposeDown's in-memory branch.
+func (a *App) composeSDKTeardown() {
+	// One hard deadline for the WHOLE teardown so an O(N-container) stack (a
+	// multi-container deployment) can never overrun the record/replay
+	// teardown-drain budget (utils.DrainErrGroup, 30s). Every per-container op
+	// derives its context from this parent, so once the deadline passes the
+	// remaining ops fail fast rather than each burning its own budget.
+	ctx, cancel := context.WithTimeout(context.Background(), sdkTeardownBudget)
+	defer cancel()
+
+	// Snapshot + clear atomically so a concurrent ComposeDownOnSetupFailure and
+	// the run()-deferred ComposeDown don't double-process or race the slice; the
+	// second caller sees an empty stack and falls through to the name backstop.
+	stack := a.sdkDrainStack()
+
+	// Stop the app container(s) first with a coverage-flush grace (SIGINT +
+	// grace), so Go's GOCOVERDIR / Java's jacoco land on the host-mounted paths
+	// before removal. Mirrors the CLI path's cmdCancel grace.
+	graceSecs := int(graceBudget / time.Second)
+	for _, c := range stack {
+		if c.isApp {
+			a.sdkStopContainer(ctx, c.id, "SIGINT", &graceSecs)
+		}
+	}
+
+	// Then stop (fast) the non-app containers and remove everything. The app is
+	// already stopped (with grace) above, so it is only removed here.
+	zero := 0
+	for _, c := range stack {
+		if !c.isApp {
+			a.sdkStopContainer(ctx, c.id, "", &zero)
+		}
+		a.sdkRemoveContainer(ctx, c.id)
+	}
+
+	// Backstop: force-remove the agent + app by name. This is the only cleanup
+	// when teardown ran before a successful up (empty stack), and it also closes
+	// the setup-failure race window where runComposeSDK started a container AFTER
+	// this teardown snapshotted the stack (that container would otherwise leak
+	// and collide with the next run's create). Idempotent.
+	a.sdkForceRemoveByName(ctx, a.container)
+	a.sdkForceRemoveByName(ctx, a.keployContainer)
+}
+
+func (a *App) sdkStopContainer(parent context.Context, id, signal string, timeoutSecs *int) {
+	ctx, cancel := context.WithTimeout(parent, composeDownCmdBudget)
+	defer cancel()
+	if err := a.docker.ContainerStop(ctx, id, container.StopOptions{Signal: signal, Timeout: timeoutSecs}); err != nil {
+		a.logger.Debug("SDK container stop finished (may already be stopped, or the bounded deadline elapsed)",
+			zap.String("id", id), zap.Error(err))
+	}
+}
+
+func (a *App) sdkRemoveContainer(parent context.Context, id string) {
+	ctx, cancel := context.WithTimeout(parent, forceRemoveBudget)
+	defer cancel()
+	if err := a.docker.ContainerRemove(ctx, id, container.RemoveOptions{Force: true}); err != nil {
+		a.logger.Debug("SDK container remove finished (may already be gone, or the bounded deadline elapsed)",
+			zap.String("id", id), zap.Error(err))
+	}
+}
+
+func (a *App) sdkForceRemoveByName(parent context.Context, name string) {
+	if name == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(parent, forceRemoveBudget)
+	defer cancel()
+	if err := a.docker.ContainerRemove(ctx, name, container.RemoveOptions{Force: true}); err != nil {
+		a.logger.Debug("SDK force-remove by name finished (may already be gone)",
+			zap.String("container", name), zap.Error(err))
+	}
+}
+
+// sdkPreClean force-removes any leftover containers (by name) from a prior run
+// so create cannot hit a name conflict. The SDK equivalent of the CLI path's
+// removeStaleComposeAgentWithin/ensureContainerNameFreeWithin, minus the
+// compose-`ps` dance (there is no compose project to reconcile).
+func (a *App) sdkPreClean(ctx context.Context, model *docker.ComposeModel) {
+	seen := map[string]bool{}
+	remove := func(n string) {
+		if n == "" || seen[n] {
+			return
+		}
+		seen[n] = true
+		a.sdkForceRemoveByName(ctx, n)
+	}
+	remove(a.container)
+	remove(a.keployContainer)
+	for _, s := range model.Services {
+		remove(s.ContainerName)
+	}
+}
+
+// sdkEnsureVolumes pre-creates the top-level named volumes (idempotent). Docker
+// auto-creates named volumes referenced in Binds, but creating them up front
+// avoids a create race between the agent and app mounting the same volume.
+func (a *App) sdkEnsureVolumes(ctx context.Context, model *docker.ComposeModel) {
+	for name, spec := range model.Volumes {
+		if spec.External {
+			continue
+		}
+		volName := name
+		if spec.Name != "" {
+			volName = spec.Name
+		}
+		opts := volumetypes.CreateOptions{Name: volName, Labels: map[string]string{
+			"com.docker.compose.project": sdkComposeProject,
+			"com.docker.compose.volume":  name,
+		}}
+		if spec.Driver != "" {
+			opts.Driver = spec.Driver
+		}
+		if _, err := a.docker.VolumeCreate(ctx, opts); err != nil {
+			a.logger.Debug("failed to pre-create named volume (continuing; docker auto-creates it on mount)",
+				zap.String("volume", volName), zap.Error(err))
+		}
+	}
+}
+
+// sdkEnsureImage pulls the service image if it is not already present locally,
+// resolving registry credentials from the host docker config (matching what the
+// compose CLI does for `up`'s implicit pull). If the image is present it is a
+// no-op.
+func (a *App) sdkEnsureImage(ctx context.Context, ref string) error {
+	if ref == "" {
+		return fmt.Errorf("service has no image")
+	}
+	images, err := a.docker.ImageList(ctx, imagetypes.ListOptions{
+		Filters: filters.NewArgs(filters.Arg("reference", ref)),
+	})
+	if err == nil && len(images) > 0 {
+		return nil
+	}
+
+	a.logger.Info("Pulling image for cloud replay", zap.String("image", ref))
+	rc, perr := a.docker.ImagePull(ctx, ref, imagetypes.PullOptions{RegistryAuth: a.sdkResolveAuth(ref)})
+	if perr != nil {
+		return fmt.Errorf("failed to pull image %q (pre-pull it or check registry credentials): %w", ref, perr)
+	}
+	defer func() { _ = rc.Close() }()
+	// Draining the stream blocks until the pull completes (or fails).
+	if _, err := io.Copy(io.Discard, rc); err != nil {
+		return fmt.Errorf("failed while pulling image %q: %w", ref, err)
+	}
+	return nil
+}
+
+// sdkResolveAuth returns the base64 X-Registry-Auth header for ref's registry,
+// resolved from the host docker config's static `auths` entries. Credential
+// helpers (credsStore/credHelpers) are intentionally not invoked (they require
+// executing helper binaries, which the shell-free cloud image cannot do); a
+// private image behind a cred helper must be pre-pulled. Returns "" when no
+// static credential is found (anonymous pull).
+func (a *App) sdkResolveAuth(ref string) string {
+	named, err := reference.ParseNormalizedNamed(ref)
+	if err != nil {
+		return ""
+	}
+	domain := reference.Domain(named)
+
+	cfgDir := os.Getenv("DOCKER_CONFIG")
+	if cfgDir == "" {
+		home, herr := os.UserHomeDir()
+		if herr != nil {
+			return ""
+		}
+		cfgDir = filepath.Join(home, ".docker")
+	}
+	data, err := os.ReadFile(filepath.Join(cfgDir, "config.json"))
+	if err != nil {
+		return ""
+	}
+
+	var cfg struct {
+		Auths map[string]struct {
+			Auth          string `json:"auth"`
+			Username      string `json:"username"`
+			Password      string `json:"password"`
+			IdentityToken string `json:"identitytoken"`
+		} `json:"auths"`
+	}
+	if json.Unmarshal(data, &cfg) != nil {
+		return ""
+	}
+
+	entry, ok := cfg.Auths[domain]
+	if !ok {
+		for _, alt := range dockerHubAuthAliases(domain) {
+			if e, found := cfg.Auths[alt]; found {
+				entry, ok = e, true
+				break
+			}
+		}
+	}
+	if !ok {
+		return ""
+	}
+
+	ac := registry.AuthConfig{
+		ServerAddress: domain,
+		Username:      entry.Username,
+		Password:      entry.Password,
+		IdentityToken: entry.IdentityToken,
+	}
+	if entry.Auth != "" && (ac.Username == "" || ac.Password == "") {
+		if dec, derr := base64.StdEncoding.DecodeString(entry.Auth); derr == nil {
+			if u, p, found := strings.Cut(string(dec), ":"); found {
+				ac.Username, ac.Password = u, p
+			}
+		}
+	}
+	encoded, err := registry.EncodeAuthConfig(ac)
+	if err != nil {
+		return ""
+	}
+	return encoded
+}
+
+// dockerHubAuthAliases lists the config.json keys Docker Hub credentials are
+// stored under, since reference.Domain normalises hub images to "docker.io".
+func dockerHubAuthAliases(domain string) []string {
+	if domain == "docker.io" || domain == "registry-1.docker.io" || domain == "index.docker.io" {
+		return []string{"https://index.docker.io/v1/", "index.docker.io", "registry-1.docker.io", "docker.io"}
+	}
+	return nil
+}
+
+func composeSDKLabels(svc docker.ServiceSpec) map[string]string {
+	labels := map[string]string{}
+	for k, v := range svc.Labels {
+		labels[k] = v
+	}
+	// Compose-parity labels so logTargetContainer/recentAppLogs' label filter
+	// keeps resolving the app container.
+	labels["com.docker.compose.project"] = sdkComposeProject
+	labels["com.docker.compose.service"] = svc.Key
+	labels["io.keploy.cloud-replay"] = "true"
+	return labels
+}
+
+// startSDKLogPumps streams each stack container's logs to the terminal (compose
+// up streams both the agent and app). Pumps exit when logCtx is cancelled.
+func (a *App) startSDKLogPumps(logCtx context.Context) {
+	for _, c := range a.sdkSnapshotStack() {
+		go a.pumpContainerLogs(logCtx, c.id, c.service)
+	}
+}
+
+// sdkTrack appends a created container to the tracked stack under the lock.
+func (a *App) sdkTrack(ref sdkContainerRef) {
+	a.sdkStackMu.Lock()
+	a.sdkStack = append(a.sdkStack, ref)
+	a.sdkStackMu.Unlock()
+}
+
+// sdkSnapshotStack returns a copy of the tracked stack under the lock.
+func (a *App) sdkSnapshotStack() []sdkContainerRef {
+	a.sdkStackMu.Lock()
+	defer a.sdkStackMu.Unlock()
+	return append([]sdkContainerRef(nil), a.sdkStack...)
+}
+
+// sdkDrainStack atomically returns the tracked stack and clears it, so only one
+// teardown caller ever processes a given container.
+func (a *App) sdkDrainStack() []sdkContainerRef {
+	a.sdkStackMu.Lock()
+	defer a.sdkStackMu.Unlock()
+	stack := a.sdkStack
+	a.sdkStack = nil
+	return stack
+}
+
+func (a *App) pumpContainerLogs(ctx context.Context, id, service string) {
+	rc, err := a.docker.ContainerLogs(ctx, id, container.LogsOptions{
+		ShowStdout: true,
+		ShowStderr: true,
+		Follow:     true,
+		Tail:       "all",
+	})
+	if err != nil {
+		a.logger.Debug("failed to stream cloud-replay container logs", zap.String("service", service), zap.Error(err))
+		return
+	}
+	defer func() { _ = rc.Close() }()
+
+	var mu sync.Mutex
+	prefix := service + " | "
+	outW := newPrefixWriter(os.Stdout, prefix, &mu)
+	errW := newPrefixWriter(os.Stdout, prefix, &mu)
+	// StdCopy demuxes docker's multiplexed stdout/stderr stream.
+	if _, err := stdcopy.StdCopy(outW, errW, rc); err != nil && ctx.Err() == nil {
+		a.logger.Debug("cloud-replay container log stream ended", zap.String("service", service), zap.Error(err))
+	}
+}
+
+// prefixWriter prepends a fixed prefix at the start of every line it writes,
+// so interleaved multi-container logs stay readable (like compose's
+// "<service> | " prefixing). The shared mutex serialises the container's stdout
+// and stderr writers onto the same underlying os.Stdout.
+type prefixWriter struct {
+	w      io.Writer
+	prefix []byte
+	mu     *sync.Mutex
+	atBOL  bool
+}
+
+func newPrefixWriter(w io.Writer, prefix string, mu *sync.Mutex) *prefixWriter {
+	return &prefixWriter{w: w, prefix: []byte(prefix), mu: mu, atBOL: true}
+}
+
+func (p *prefixWriter) Write(b []byte) (int, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	total := len(b)
+	for len(b) > 0 {
+		if p.atBOL {
+			if _, err := p.w.Write(p.prefix); err != nil {
+				return total - len(b), err
+			}
+			p.atBOL = false
+		}
+		if i := bytes.IndexByte(b, '\n'); i >= 0 {
+			if _, err := p.w.Write(b[:i+1]); err != nil {
+				return total - len(b), err
+			}
+			p.atBOL = true
+			b = b[i+1:]
+			continue
+		}
+		if _, err := p.w.Write(b); err != nil {
+			return total - len(b), err
+		}
+		break
+	}
+	return total, nil
+}

--- a/pkg/client/app/compose_sdk_test.go
+++ b/pkg/client/app/compose_sdk_test.go
@@ -1,0 +1,189 @@
+package app
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/go-connections/nat"
+	"go.keploy.io/server/v3/pkg/platform/docker"
+)
+
+// agentSpec is a representative parsed keploy-agent service (standalone
+// networking, publishes ports, owns the namespace).
+func agentSpec() docker.ServiceSpec {
+	return docker.ServiceSpec{
+		Key:           "keploy-agent",
+		ContainerName: "keploy-v3-abc",
+		Image:         "ghcr.io/keploy/keploy-enterprise:v2",
+		Env:           []string{"BINARY_TO_DOCKER=true"},
+		Ports:         []string{"16789:16789", "26789:26789"},
+		Binds:         []string{"keploy-tls-certs:/tmp/keploy-tls", "/sys/fs/cgroup:/sys/fs/cgroup"},
+		Tmpfs:         map[string]string{"/sys/fs/bpf": "exec,mode=0755"},
+		CapAdd:        []string{"BPF", "SYS_ADMIN"},
+		SecurityOpt:   []string{"seccomp:unconfined"},
+		Command:       []string{"--port", "16789"},
+		DNSSearch:     []string{"default.svc.cluster.local"},
+		Healthcheck: &docker.Healthcheck{
+			Test:        []string{"CMD", "/app/keploy-enterprise", "health", "--check=agent-ready"},
+			Interval:    5 * time.Second,
+			Timeout:     5 * time.Second,
+			Retries:     60,
+			StartPeriod: 10 * time.Second,
+		},
+	}
+}
+
+// appSpec is a representative parsed app service that shares the agent's
+// net/pid namespace and (like every cloud-replay app) carries restart:
+// unless-stopped in the source YAML.
+func appSpec() docker.ServiceSpec {
+	return docker.ServiceSpec{
+		Key:           "my-app",
+		ContainerName: "my-app",
+		Image:         "example.com/my-app:1.0",
+		Env:           []string{"NODE_EXTRA_CA_CERTS=/tmp/keploy-tls/ca.crt"},
+		Binds:         []string{"keploy-tls-certs:/tmp/keploy-tls:ro"},
+		WorkingDir:    "/srv",
+		Entrypoint:    []string{"/entrypoint.sh"},
+		Command:       []string{"serve"},
+		PidMode:       "service:keploy-agent",
+		NetworkMode:   "service:keploy-agent",
+		// These would be rejected by the daemon on a container: netns and must be
+		// dropped for the app; modifyAppServiceForKeploy already moves them to the
+		// agent, but buildContainerSpec must also not set them.
+		DNSSearch: []string{"should.be.ignored"},
+		Ports:     []string{"8080:8080"},
+	}
+}
+
+func TestBuildContainerSpec_Agent(t *testing.T) {
+	cfg, hostCfg, err := buildContainerSpec(agentSpec(), "")
+	if err != nil {
+		t.Fatalf("buildContainerSpec(agent): %v", err)
+	}
+
+	// restart is always neutralised to "no".
+	if hostCfg.RestartPolicy.Name != container.RestartPolicyDisabled {
+		t.Errorf("agent RestartPolicy = %q, want %q", hostCfg.RestartPolicy.Name, container.RestartPolicyDisabled)
+	}
+	// standalone networking -> not sharing a namespace
+	if hostCfg.NetworkMode != "" || hostCfg.PidMode != "" {
+		t.Errorf("agent should not share a namespace: net=%q pid=%q", hostCfg.NetworkMode, hostCfg.PidMode)
+	}
+	// ports published on the agent
+	if _, ok := hostCfg.PortBindings[nat.Port("16789/tcp")]; !ok {
+		t.Errorf("agent PortBindings missing 16789/tcp: %v", hostCfg.PortBindings)
+	}
+	if _, ok := cfg.ExposedPorts[nat.Port("26789/tcp")]; !ok {
+		t.Errorf("agent ExposedPorts missing 26789/tcp: %v", cfg.ExposedPorts)
+	}
+	// DNS search stays on the agent
+	if len(hostCfg.DNSSearch) != 1 || hostCfg.DNSSearch[0] != "default.svc.cluster.local" {
+		t.Errorf("agent DNSSearch = %v", hostCfg.DNSSearch)
+	}
+	// eBPF privileges + tmpfs
+	if !contains(hostCfg.CapAdd, "SYS_ADMIN") || !contains(hostCfg.SecurityOpt, "seccomp:unconfined") {
+		t.Errorf("agent caps/security_opt = %v / %v", hostCfg.CapAdd, hostCfg.SecurityOpt)
+	}
+	if hostCfg.Tmpfs["/sys/fs/bpf"] != "exec,mode=0755" {
+		t.Errorf("agent tmpfs = %v", hostCfg.Tmpfs)
+	}
+	// healthcheck carried through
+	if cfg.Healthcheck == nil || len(cfg.Healthcheck.Test) != 4 || cfg.Healthcheck.Retries != 60 {
+		t.Errorf("agent healthcheck = %+v", cfg.Healthcheck)
+	}
+	// compose-parity labels for logTargetContainer
+	if cfg.Labels["com.docker.compose.service"] != "keploy-agent" {
+		t.Errorf("agent labels = %v", cfg.Labels)
+	}
+}
+
+func TestBuildContainerSpec_App(t *testing.T) {
+	cfg, hostCfg, err := buildContainerSpec(appSpec(), "agent123")
+	if err != nil {
+		t.Fatalf("buildContainerSpec(app): %v", err)
+	}
+
+	if hostCfg.RestartPolicy.Name != container.RestartPolicyDisabled {
+		t.Errorf("app RestartPolicy = %q, want disabled", hostCfg.RestartPolicy.Name)
+	}
+	// shares the agent's net + pid namespace
+	if hostCfg.NetworkMode != container.NetworkMode("container:agent123") {
+		t.Errorf("app NetworkMode = %q, want container:agent123", hostCfg.NetworkMode)
+	}
+	if hostCfg.PidMode != container.PidMode("container:agent123") {
+		t.Errorf("app PidMode = %q, want container:agent123", hostCfg.PidMode)
+	}
+	// no ports / DNS on the app (daemon rejects them with a container: netns)
+	if len(hostCfg.PortBindings) != 0 || len(cfg.ExposedPorts) != 0 {
+		t.Errorf("app must not publish ports: bindings=%v exposed=%v", hostCfg.PortBindings, cfg.ExposedPorts)
+	}
+	if len(hostCfg.DNSSearch) != 0 {
+		t.Errorf("app must not set DNSSearch on a shared netns, got %v", hostCfg.DNSSearch)
+	}
+	// entrypoint/command/workdir/env/binds carried through
+	if cfg.WorkingDir != "/srv" || len(cfg.Entrypoint) != 1 || len(cfg.Cmd) != 1 {
+		t.Errorf("app cfg entrypoint/cmd/workdir wrong: %+v", cfg)
+	}
+	if len(hostCfg.Binds) != 1 || hostCfg.Binds[0] != "keploy-tls-certs:/tmp/keploy-tls:ro" {
+		t.Errorf("app binds = %v", hostCfg.Binds)
+	}
+}
+
+// TestSDKStack_ConcurrentTrackAndDrain exercises the sdkStack mutex under the
+// exact concurrency the setup-failure path creates: runComposeSDK (app-run
+// goroutine) appending via sdkTrack while ComposeDownOnSetupFailure (replay
+// orchestrator goroutine) snapshots+clears via sdkDrainStack. Run with -race.
+func TestSDKStack_ConcurrentTrackAndDrain(t *testing.T) {
+	a := &App{}
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 500; i++ {
+			a.sdkTrack(sdkContainerRef{id: "c", name: "n", service: "s", isApp: i%2 == 0})
+		}
+	}()
+
+	drained := 0
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 500; i++ {
+			drained += len(a.sdkDrainStack())
+			_ = a.sdkSnapshotStack()
+		}
+	}()
+
+	wg.Wait()
+	// Whatever wasn't drained by the racing goroutine remains tracked; the two
+	// together must account for every tracked container (none lost or double
+	// counted).
+	if total := drained + len(a.sdkDrainStack()); total != 500 {
+		t.Fatalf("tracked/drained mismatch: got %d, want 500", total)
+	}
+}
+
+func TestBuildContainerSpec_AgentDNSOpt(t *testing.T) {
+	spec := agentSpec()
+	spec.DNSOpt = []string{"ndots:2"}
+	_, hostCfg, err := buildContainerSpec(spec, "")
+	if err != nil {
+		t.Fatalf("buildContainerSpec: %v", err)
+	}
+	if len(hostCfg.DNSOptions) != 1 || hostCfg.DNSOptions[0] != "ndots:2" {
+		t.Errorf("agent DNSOptions = %v, want [ndots:2]", hostCfg.DNSOptions)
+	}
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/platform/docker/compose_model.go
+++ b/pkg/platform/docker/compose_model.go
@@ -1,0 +1,572 @@
+package docker
+
+// compose_model.go turns the FINAL (fully hook-modified) in-memory
+// docker-compose document that `keploy cloud replay` produces into a focused,
+// typed model the Docker-SDK orchestrator (pkg/client/app/compose_sdk.go)
+// consumes to bring the stack up WITHOUT shelling out to the `docker compose`
+// CLI.
+//
+// Scope: this parser deliberately covers ONLY the compose subset keploy itself
+// emits for cloud replay — the injected keploy-agent service plus the app
+// container(s) reconstructed from a single Kubernetes deployment. It is not a
+// general-purpose compose loader. Everything here is pure (no docker daemon,
+// no filesystem beyond os.Getenv for env inheritance) so it is unit-testable
+// exactly like parseComposeServiceStates in pkg/client/app.
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ComposeModel is the typed view of a cloud-replay compose document.
+type ComposeModel struct {
+	// Services in document order. The orchestrator starts keploy-agent first
+	// (identified by key/container_name), then the app service(s).
+	Services []ServiceSpec
+	// Networks / Volumes are the top-level declarations. The orchestrator only
+	// needs the named volumes (to pre-create them); user networks are not
+	// recreated because cloud replay has no cross-container networking (the
+	// app's dependencies are served from recorded mocks, and the app shares the
+	// agent's network namespace).
+	Networks map[string]NetworkSpec
+	Volumes  map[string]VolumeSpec
+}
+
+// ServiceSpec is a single compose service reduced to the fields cloud replay
+// uses. Anything compose supports but cloud replay never generates is omitted.
+type ServiceSpec struct {
+	Key            string              // compose service key (stable; --exit-code-from targets this)
+	ContainerName  string              // container_name
+	Image          string              // resolved (${VAR} expanded)
+	Env            []string            // resolved "KEY=VALUE" (host-inherit + ${VAR} expanded)
+	Ports          []string            // compose short-form, e.g. "16789:16789"
+	Networks       []string            // network keys this service attaches to (informational)
+	NetworkAliases map[string][]string // network key -> aliases
+	Binds          []string            // bind AND named-volume mounts: "src:dst[:ro]"
+	Tmpfs          map[string]string   // tmpfs target -> options
+	CapAdd         []string
+	SecurityOpt    []string
+	Command        []string // CMD
+	Entrypoint     []string // ENTRYPOINT
+	WorkingDir     string
+	DependsOn      []DependsOn
+	Healthcheck    *Healthcheck
+	PidMode        string // raw compose value, e.g. "service:keploy-agent"
+	NetworkMode    string // raw compose value, e.g. "service:keploy-agent"
+	DNS            []string
+	DNSSearch      []string
+	DNSOpt         []string
+	Labels         map[string]string
+	// Restart is intentionally NOT captured. cloud replay emits
+	// `restart: unless-stopped`, but under `--abort-on-container-exit` the app
+	// must NOT be auto-restarted by the daemon (it would break exit-code capture
+	// and teardown), so the orchestrator always forces RestartPolicy=no.
+}
+
+// DependsOn is one entry of a service's depends_on. Condition is
+// "service_healthy" / "service_started" / "service_completed_successfully"
+// ("service_started" when the short (list) form is used).
+type DependsOn struct {
+	Service   string
+	Condition string
+}
+
+// Healthcheck mirrors container.HealthConfig (durations already parsed).
+type Healthcheck struct {
+	Test        []string
+	Interval    time.Duration
+	Timeout     time.Duration
+	Retries     int
+	StartPeriod time.Duration
+	Disable     bool
+}
+
+// NetworkSpec / VolumeSpec capture only what the orchestrator might act on.
+type NetworkSpec struct {
+	Driver   string
+	External bool
+	Name     string
+}
+
+type VolumeSpec struct {
+	Driver   string
+	External bool
+	Name     string
+}
+
+// ServiceCondHealthy is the depends_on condition that gates a service's start
+// on another service reporting healthy (compose `condition: service_healthy`).
+const ServiceCondHealthy = "service_healthy"
+
+// composeServicePrefix is compose's syntax for "share this namespace with
+// another service" used by `pid:`/`network_mode:` (e.g. "service:keploy-agent").
+const composeServicePrefix = "service:"
+
+// ParseComposeForSDK parses the final cloud-replay compose YAML into a
+// ComposeModel. Env values are resolved the way `docker compose up` would
+// (bare-key / empty-value host inheritance and ${VAR} expansion) so the
+// SDK path produces identical container environments to the CLI path.
+func ParseComposeForSDK(content []byte) (*ComposeModel, error) {
+	var c Compose
+	if err := yaml.Unmarshal(content, &c); err != nil {
+		return nil, fmt.Errorf("failed to parse compose YAML for SDK orchestration: %w", err)
+	}
+
+	m := &ComposeModel{
+		Networks: map[string]NetworkSpec{},
+		Volumes:  map[string]VolumeSpec{},
+	}
+
+	if c.Services.Kind == yaml.MappingNode {
+		for i := 0; i+1 < len(c.Services.Content); i += 2 {
+			key := c.Services.Content[i].Value
+			svc, err := parseServiceNode(key, c.Services.Content[i+1])
+			if err != nil {
+				return nil, fmt.Errorf("service %q: %w", key, err)
+			}
+			m.Services = append(m.Services, svc)
+		}
+	}
+
+	if len(m.Services) == 0 {
+		return nil, fmt.Errorf("compose document has no services")
+	}
+
+	if c.Volumes.Kind == yaml.MappingNode {
+		for i := 0; i+1 < len(c.Volumes.Content); i += 2 {
+			name := c.Volumes.Content[i].Value
+			m.Volumes[name] = parseVolumeNode(c.Volumes.Content[i+1])
+		}
+	}
+	if c.Networks.Kind == yaml.MappingNode {
+		for i := 0; i+1 < len(c.Networks.Content); i += 2 {
+			name := c.Networks.Content[i].Value
+			m.Networks[name] = parseNetworkNode(c.Networks.Content[i+1])
+		}
+	}
+
+	return m, nil
+}
+
+func parseServiceNode(key string, n *yaml.Node) (ServiceSpec, error) {
+	svc := ServiceSpec{Key: key}
+	if n.Kind != yaml.MappingNode {
+		return svc, fmt.Errorf("expected a mapping, got kind %d", n.Kind)
+	}
+
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		field := n.Content[i].Value
+		val := n.Content[i+1]
+
+		switch field {
+		case "image":
+			svc.Image = expandComposeValue(val.Value)
+		case "container_name":
+			svc.ContainerName = val.Value
+		case "working_dir":
+			svc.WorkingDir = val.Value
+		case "pid":
+			svc.PidMode = val.Value
+		case "network_mode":
+			svc.NetworkMode = val.Value
+		case "environment":
+			svc.Env = parseEnvNode(val)
+		case "ports":
+			svc.Ports = nodeToStringSlice(val)
+		case "command":
+			svc.Command = nodeToStringSlice(val)
+		case "entrypoint":
+			svc.Entrypoint = nodeToStringSlice(val)
+		case "cap_add":
+			svc.CapAdd = nodeToStringSlice(val)
+		case "security_opt":
+			svc.SecurityOpt = nodeToStringSlice(val)
+		case "dns":
+			svc.DNS = nodeToStringSlice(val)
+		case "dns_search":
+			svc.DNSSearch = nodeToStringSlice(val)
+		case "dns_opt":
+			svc.DNSOpt = nodeToStringSlice(val)
+		case "volumes":
+			svc.Binds = nodeToStringSlice(val)
+		case "tmpfs":
+			svc.Tmpfs = parseTmpfsNode(val)
+		case "networks":
+			svc.Networks, svc.NetworkAliases = parseNetworksNode(val)
+		case "depends_on":
+			svc.DependsOn = parseDependsOnNode(val)
+		case "healthcheck":
+			hc, err := parseHealthcheckNode(val)
+			if err != nil {
+				return svc, fmt.Errorf("healthcheck: %w", err)
+			}
+			svc.Healthcheck = hc
+		case "labels":
+			svc.Labels = parseLabelsNode(val)
+		case "restart":
+			// Intentionally dropped — see ServiceSpec.Restart note.
+		default:
+			// Ignored by design. The cases above are exactly what cloud replay's
+			// K8s->compose reconstruction emits (enterprise DockerComposeService:
+			// image/container_name/ports/environment/volumes/networks/entrypoint/
+			// command/working_dir/restart/depends_on/dns_search) plus what the
+			// injected keploy-agent service and the enterprise compose hooks add
+			// (cap_add/security_opt/tmpfs/healthcheck/pid/network_mode). That
+			// reconstruction has no `user`, ulimits, sysctls, stop_signal, etc.,
+			// so no other compose field can reach here; if the generator ever
+			// starts emitting one that affects the run, add a case for it (and the
+			// matching container.Config/HostConfig field in buildContainerSpec).
+		}
+	}
+	return svc, nil
+}
+
+// parseEnvNode resolves an `environment:` node (list or map form) into a slice
+// of "KEY=VALUE" the way docker compose would at `up` time:
+//   - list "KEY=VALUE"       -> value expanded
+//   - list "KEY" (no '=')    -> inherited from the host env (os.Getenv)
+//   - map  KEY: VALUE        -> value expanded
+//   - map  KEY: (null/empty) -> inherited from the host env (os.Getenv)
+func parseEnvNode(n *yaml.Node) []string {
+	var out []string
+	switch n.Kind {
+	case yaml.SequenceNode:
+		for _, item := range n.Content {
+			entry := item.Value
+			if k, v, ok := strings.Cut(entry, "="); ok {
+				out = append(out, k+"="+expandComposeValue(v))
+			} else {
+				// Bare key -> inherit from host (the mechanism the enterprise
+				// hook uses to pass KEPLOY_COUCHBASE_PASSWORD without writing the
+				// cleartext into the YAML).
+				out = append(out, entry+"="+os.Getenv(entry))
+			}
+		}
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(n.Content); i += 2 {
+			key := n.Content[i].Value
+			valNode := n.Content[i+1]
+			// A null/empty value is compose's inherit-from-host form.
+			if valNode.Tag == "!!null" || (valNode.Kind == yaml.ScalarNode && valNode.Value == "" && valNode.Tag != "!!str") {
+				out = append(out, key+"="+os.Getenv(key))
+				continue
+			}
+			out = append(out, key+"="+expandComposeValue(valNode.Value))
+		}
+	}
+	return out
+}
+
+// parseNetworksNode handles both the list form (["net"]) and the map form
+// ({net: {aliases: [...]}}), returning the ordered network keys and any aliases.
+func parseNetworksNode(n *yaml.Node) ([]string, map[string][]string) {
+	var keys []string
+	aliases := map[string][]string{}
+	switch n.Kind {
+	case yaml.SequenceNode:
+		for _, item := range n.Content {
+			keys = append(keys, item.Value)
+		}
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(n.Content); i += 2 {
+			key := n.Content[i].Value
+			keys = append(keys, key)
+			cfg := n.Content[i+1]
+			if cfg.Kind == yaml.MappingNode {
+				for j := 0; j+1 < len(cfg.Content); j += 2 {
+					if cfg.Content[j].Value == "aliases" {
+						aliases[key] = nodeToStringSlice(cfg.Content[j+1])
+					}
+				}
+			}
+		}
+	}
+	if len(aliases) == 0 {
+		aliases = nil
+	}
+	return keys, aliases
+}
+
+// parseDependsOnNode handles the list form (implicit service_started) and the
+// map form ({svc: {condition: service_healthy}}).
+func parseDependsOnNode(n *yaml.Node) []DependsOn {
+	var deps []DependsOn
+	switch n.Kind {
+	case yaml.SequenceNode:
+		for _, item := range n.Content {
+			deps = append(deps, DependsOn{Service: item.Value, Condition: "service_started"})
+		}
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(n.Content); i += 2 {
+			dep := DependsOn{Service: n.Content[i].Value, Condition: "service_started"}
+			cfg := n.Content[i+1]
+			if cfg.Kind == yaml.MappingNode {
+				for j := 0; j+1 < len(cfg.Content); j += 2 {
+					if cfg.Content[j].Value == "condition" {
+						dep.Condition = cfg.Content[j+1].Value
+					}
+				}
+			}
+			deps = append(deps, dep)
+		}
+	}
+	return deps
+}
+
+func parseTmpfsNode(n *yaml.Node) map[string]string {
+	entries := nodeToStringSlice(n)
+	if len(entries) == 0 {
+		return nil
+	}
+	out := map[string]string{}
+	for _, e := range entries {
+		// Compose tmpfs short form: "/target[:opts]".
+		if target, opts, ok := strings.Cut(e, ":"); ok {
+			out[target] = opts
+		} else {
+			out[e] = ""
+		}
+	}
+	return out
+}
+
+func parseLabelsNode(n *yaml.Node) map[string]string {
+	out := map[string]string{}
+	switch n.Kind {
+	case yaml.SequenceNode:
+		for _, item := range n.Content {
+			if k, v, ok := strings.Cut(item.Value, "="); ok {
+				out[k] = v
+			} else {
+				out[item.Value] = ""
+			}
+		}
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(n.Content); i += 2 {
+			out[n.Content[i].Value] = n.Content[i+1].Value
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// composeHealthcheckRaw is the intermediate form for a `healthcheck:` node so
+// the test field (string or list) and duration strings can be normalised.
+type composeHealthcheckRaw struct {
+	Test        yaml.Node `yaml:"test"`
+	Interval    string    `yaml:"interval"`
+	Timeout     string    `yaml:"timeout"`
+	Retries     int       `yaml:"retries"`
+	StartPeriod string    `yaml:"start_period"`
+	Disable     bool      `yaml:"disable"`
+}
+
+func parseHealthcheckNode(n *yaml.Node) (*Healthcheck, error) {
+	var raw composeHealthcheckRaw
+	if err := n.Decode(&raw); err != nil {
+		return nil, err
+	}
+
+	hc := &Healthcheck{Retries: raw.Retries, Disable: raw.Disable}
+
+	// test: a scalar is compose's shell form; a sequence is the explicit
+	// ["CMD"|"CMD-SHELL", ...] form. keploy's agent uses the CMD (exec) form.
+	switch raw.Test.Kind {
+	case yaml.ScalarNode:
+		if raw.Test.Value != "" {
+			hc.Test = []string{"CMD-SHELL", raw.Test.Value}
+		}
+	case yaml.SequenceNode:
+		hc.Test = nodeToStringSlice(&raw.Test)
+	}
+
+	for _, d := range []struct {
+		raw string
+		dst *time.Duration
+	}{
+		{raw.Interval, &hc.Interval},
+		{raw.Timeout, &hc.Timeout},
+		{raw.StartPeriod, &hc.StartPeriod},
+	} {
+		if d.raw == "" {
+			continue
+		}
+		parsed, err := time.ParseDuration(d.raw)
+		if err != nil {
+			return nil, fmt.Errorf("invalid duration %q: %w", d.raw, err)
+		}
+		*d.dst = parsed
+	}
+	return hc, nil
+}
+
+func parseVolumeNode(n *yaml.Node) VolumeSpec {
+	var v VolumeSpec
+	if n.Kind != yaml.MappingNode {
+		return v
+	}
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		switch n.Content[i].Value {
+		case "driver":
+			v.Driver = n.Content[i+1].Value
+		case "external":
+			v.External = n.Content[i+1].Value == "true"
+		case "name":
+			v.Name = n.Content[i+1].Value
+		}
+	}
+	return v
+}
+
+func parseNetworkNode(n *yaml.Node) NetworkSpec {
+	var net NetworkSpec
+	if n.Kind != yaml.MappingNode {
+		return net
+	}
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		switch n.Content[i].Value {
+		case "driver":
+			net.Driver = n.Content[i+1].Value
+		case "external":
+			net.External = n.Content[i+1].Value == "true"
+		case "name":
+			net.Name = n.Content[i+1].Value
+		}
+	}
+	return net
+}
+
+// nodeToStringSlice normalises a scalar or sequence node into a string slice.
+// A scalar becomes a single-element slice; a sequence yields its scalar values.
+func nodeToStringSlice(n *yaml.Node) []string {
+	switch n.Kind {
+	case yaml.ScalarNode:
+		if n.Value == "" {
+			return nil
+		}
+		return []string{n.Value}
+	case yaml.SequenceNode:
+		out := make([]string, 0, len(n.Content))
+		for _, item := range n.Content {
+			out = append(out, item.Value)
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+// expandComposeValue expands ${VAR}, $VAR and ${VAR:-default}/${VAR-default}
+// from the host environment and unescapes $$ -> $, matching how docker compose
+// interpolates a compose document at `up` time. It intentionally supports only
+// the subset of compose interpolation the generated documents can contain;
+// unknown ${...} constructs resolve to empty (compose's default) rather than
+// erroring, keeping the SDK path strictly more lenient than the CLI.
+func expandComposeValue(s string) string {
+	if !strings.Contains(s, "$") {
+		return s
+	}
+	var b strings.Builder
+	for i := 0; i < len(s); {
+		if s[i] != '$' {
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+		// "$$" -> literal "$"
+		if i+1 < len(s) && s[i+1] == '$' {
+			b.WriteByte('$')
+			i += 2
+			continue
+		}
+		// "${...}" braced form (supports :- / - default operators)
+		if i+1 < len(s) && s[i+1] == '{' {
+			end := strings.IndexByte(s[i+2:], '}')
+			if end == -1 {
+				// Unterminated — emit verbatim.
+				b.WriteByte(s[i])
+				i++
+				continue
+			}
+			expr := s[i+2 : i+2+end]
+			b.WriteString(resolveBracedVar(expr))
+			i += 2 + end + 1
+			continue
+		}
+		// "$VAR" bare form
+		if j := scanVarName(s[i+1:]); j > 0 {
+			b.WriteString(os.Getenv(s[i+1 : i+1+j]))
+			i += 1 + j
+			continue
+		}
+		// A lone '$' not starting a variable — emit verbatim.
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
+}
+
+// resolveBracedVar resolves the inside of a ${...} expression, honouring the
+// :-default and -default operators (empty vs unset). Other operators fall back
+// to a plain lookup.
+func resolveBracedVar(expr string) string {
+	if idx := strings.Index(expr, ":-"); idx != -1 {
+		name, def := expr[:idx], expr[idx+2:]
+		if v := os.Getenv(name); v != "" {
+			return v
+		}
+		return def
+	}
+	if idx := strings.Index(expr, "-"); idx != -1 {
+		name, def := expr[:idx], expr[idx+1:]
+		if v, ok := os.LookupEnv(name); ok {
+			return v
+		}
+		return def
+	}
+	// Strip a trailing :?msg / ?msg (required-var operator) — the SDK path does
+	// not fail the run on it; it just resolves the value (possibly empty).
+	if idx := strings.IndexAny(expr, ":?"); idx != -1 {
+		expr = expr[:idx]
+	}
+	return os.Getenv(expr)
+}
+
+// scanVarName returns the length of the leading POSIX shell variable name in s
+// ([A-Za-z_][A-Za-z0-9_]*), or 0 if s does not start with one.
+func scanVarName(s string) int {
+	if len(s) == 0 {
+		return 0
+	}
+	c := s[0]
+	if !(c == '_' || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) {
+		return 0
+	}
+	i := 1
+	for i < len(s) {
+		c := s[i]
+		if c == '_' || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') {
+			i++
+			continue
+		}
+		break
+	}
+	return i
+}
+
+// IsShareServiceNamespace reports whether a compose pid:/network_mode: value
+// refers to another service's namespace ("service:<name>") and returns that
+// service name. The SDK orchestrator translates this to the started container's
+// id ("container:<id>").
+func IsShareServiceNamespace(mode string) (string, bool) {
+	if strings.HasPrefix(mode, composeServicePrefix) {
+		return strings.TrimPrefix(mode, composeServicePrefix), true
+	}
+	return "", false
+}

--- a/pkg/platform/docker/compose_model_test.go
+++ b/pkg/platform/docker/compose_model_test.go
@@ -1,0 +1,253 @@
+package docker
+
+import (
+	"testing"
+	"time"
+)
+
+// goldenCloudReplayCompose mirrors the FINAL (fully hook-modified) compose
+// document `keploy cloud replay` produces: the injected keploy-agent service
+// (with the enterprise shell-free healthcheck rewrite, low-latency cap_add /
+// security_opt / tmpfs, and the bare-key host-inherit env) plus the app service
+// (namespace-shared, TLS env, depends_on: service_healthy, restart:
+// unless-stopped). It exercises every field the SDK orchestrator relies on.
+const goldenCloudReplayCompose = `
+services:
+  keploy-agent:
+    image: ghcr.io/keploy/keploy-enterprise:v2.0.0
+    container_name: keploy-v3-abc123
+    cap_add:
+      - BPF
+      - PERFMON
+      - NET_ADMIN
+      - SYS_ADMIN
+    security_opt:
+      - seccomp:unconfined
+      - apparmor:unconfined
+    environment:
+      - BINARY_TO_DOCKER=true
+      - CERT_EXPORT_PATH=/tmp/keploy-tls
+      - KEPLOY_COUCHBASE_PASSWORD
+    ports:
+      - "16789:16789"
+      - "26789:26789"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup
+      - keploy-tls-certs:/tmp/keploy-tls
+      - keploy-sockets-vol:/tmp
+    tmpfs:
+      - /sys/fs/bpf:exec,mode=0755
+    command:
+      - --port
+      - "16789"
+      - --mode
+      - test
+    dns_search:
+      - default.svc.cluster.local
+      - svc.cluster.local
+    healthcheck:
+      test:
+        - CMD
+        - /app/keploy-enterprise
+        - health
+        - --check=agent-ready
+      interval: 5s
+      timeout: 5s
+      retries: 60
+      start_period: 10s
+    networks:
+      default:
+        aliases:
+          - my-app
+  my-app:
+    image: my-registry.example.com/team/my-app:1.4.2
+    container_name: my-app
+    restart: unless-stopped
+    working_dir: /srv
+    environment:
+      PGCHANNELBINDING: disable
+      NODE_EXTRA_CA_CERTS: /tmp/keploy-tls/ca.crt
+      UPSTREAM_URL: http://${BACKEND_HOST}:9000
+      INHERITED_TOKEN:
+    volumes:
+      - keploy-tls-certs:/tmp/keploy-tls:ro
+      - /tmp/keploy-cloud-replay-x/cfg:/etc/app:ro
+    depends_on:
+      keploy-agent:
+        condition: service_healthy
+    pid: service:keploy-agent
+    network_mode: service:keploy-agent
+volumes:
+  keploy-tls-certs:
+  keploy-sockets-vol:
+`
+
+func TestParseComposeForSDK_Golden(t *testing.T) {
+	t.Setenv("KEPLOY_COUCHBASE_PASSWORD", "s3cr3t")
+	t.Setenv("BACKEND_HOST", "backend.internal")
+	t.Setenv("INHERITED_TOKEN", "tok-42")
+
+	model, err := ParseComposeForSDK([]byte(goldenCloudReplayCompose))
+	if err != nil {
+		t.Fatalf("ParseComposeForSDK: %v", err)
+	}
+	if len(model.Services) != 2 {
+		t.Fatalf("expected 2 services, got %d", len(model.Services))
+	}
+
+	var agent, app *ServiceSpec
+	for i := range model.Services {
+		switch model.Services[i].Key {
+		case "keploy-agent":
+			agent = &model.Services[i]
+		case "my-app":
+			app = &model.Services[i]
+		}
+	}
+	if agent == nil || app == nil {
+		t.Fatalf("missing service(s): agent=%v app=%v", agent, app)
+	}
+
+	// --- agent ---
+	if agent.ContainerName != "keploy-v3-abc123" {
+		t.Errorf("agent container_name = %q", agent.ContainerName)
+	}
+	wantCaps := []string{"BPF", "PERFMON", "NET_ADMIN", "SYS_ADMIN"}
+	if !eqStrs(agent.CapAdd, wantCaps) {
+		t.Errorf("agent cap_add = %v, want %v", agent.CapAdd, wantCaps)
+	}
+	if !eqStrs(agent.SecurityOpt, []string{"seccomp:unconfined", "apparmor:unconfined"}) {
+		t.Errorf("agent security_opt = %v", agent.SecurityOpt)
+	}
+	if got := agent.Tmpfs["/sys/fs/bpf"]; got != "exec,mode=0755" {
+		t.Errorf("agent tmpfs[/sys/fs/bpf] = %q", got)
+	}
+	if !eqStrs(agent.Ports, []string{"16789:16789", "26789:26789"}) {
+		t.Errorf("agent ports = %v", agent.Ports)
+	}
+	if !eqStrs(agent.DNSSearch, []string{"default.svc.cluster.local", "svc.cluster.local"}) {
+		t.Errorf("agent dns_search = %v", agent.DNSSearch)
+	}
+	// bare-key host inheritance (the couchbase password mechanism)
+	if !hasEnv(agent.Env, "KEPLOY_COUCHBASE_PASSWORD=s3cr3t") {
+		t.Errorf("agent env missing inherited KEPLOY_COUCHBASE_PASSWORD=s3cr3t: %v", agent.Env)
+	}
+	if !hasEnv(agent.Env, "BINARY_TO_DOCKER=true") {
+		t.Errorf("agent env missing BINARY_TO_DOCKER: %v", agent.Env)
+	}
+	// agent owns its namespace (no service: sharing)
+	if agent.NetworkMode != "" || agent.PidMode != "" {
+		t.Errorf("agent should not share a namespace: net=%q pid=%q", agent.NetworkMode, agent.PidMode)
+	}
+	// healthcheck: the enterprise shell-free CMD form, durations parsed
+	if hc := agent.Healthcheck; hc == nil {
+		t.Error("agent healthcheck not parsed")
+	} else {
+		wantTest := []string{"CMD", "/app/keploy-enterprise", "health", "--check=agent-ready"}
+		if !eqStrs(hc.Test, wantTest) {
+			t.Errorf("agent healthcheck test = %v, want %v", hc.Test, wantTest)
+		}
+		if hc.Interval != 5*time.Second || hc.Timeout != 5*time.Second || hc.StartPeriod != 10*time.Second {
+			t.Errorf("agent healthcheck durations: interval=%v timeout=%v start=%v", hc.Interval, hc.Timeout, hc.StartPeriod)
+		}
+		if hc.Retries != 60 {
+			t.Errorf("agent healthcheck retries = %d", hc.Retries)
+		}
+	}
+
+	// --- app ---
+	if app.WorkingDir != "/srv" {
+		t.Errorf("app working_dir = %q", app.WorkingDir)
+	}
+	// namespace sharing translated later to container:<id>
+	svcName, shared := IsShareServiceNamespace(app.NetworkMode)
+	if !shared || svcName != "keploy-agent" {
+		t.Errorf("app network_mode = %q (shared=%v svc=%q)", app.NetworkMode, shared, svcName)
+	}
+	if _, shared := IsShareServiceNamespace(app.PidMode); !shared {
+		t.Errorf("app pid = %q, want service:keploy-agent", app.PidMode)
+	}
+	// app carries no ports/networks (removed by modifyAppServiceForKeploy)
+	if len(app.Ports) != 0 {
+		t.Errorf("app should have no ports, got %v", app.Ports)
+	}
+	// ${VAR} expansion in a map-form value
+	if !hasEnv(app.Env, "UPSTREAM_URL=http://backend.internal:9000") {
+		t.Errorf("app env UPSTREAM_URL not expanded: %v", app.Env)
+	}
+	// map-form null value inherits from host
+	if !hasEnv(app.Env, "INHERITED_TOKEN=tok-42") {
+		t.Errorf("app env INHERITED_TOKEN not inherited: %v", app.Env)
+	}
+	if !hasEnv(app.Env, "NODE_EXTRA_CA_CERTS=/tmp/keploy-tls/ca.crt") {
+		t.Errorf("app env missing TLS cert var: %v", app.Env)
+	}
+	// depends_on: service_healthy
+	if len(app.DependsOn) != 1 || app.DependsOn[0].Service != "keploy-agent" || app.DependsOn[0].Condition != ServiceCondHealthy {
+		t.Errorf("app depends_on = %+v", app.DependsOn)
+	}
+	// bind (:ro) + named volume both captured verbatim for HostConfig.Binds
+	if !eqStrs(app.Binds, []string{"keploy-tls-certs:/tmp/keploy-tls:ro", "/tmp/keploy-cloud-replay-x/cfg:/etc/app:ro"}) {
+		t.Errorf("app binds = %v", app.Binds)
+	}
+
+	// --- top-level named volumes ---
+	if _, ok := model.Volumes["keploy-tls-certs"]; !ok {
+		t.Errorf("top-level volume keploy-tls-certs missing: %v", model.Volumes)
+	}
+	if _, ok := model.Volumes["keploy-sockets-vol"]; !ok {
+		t.Errorf("top-level volume keploy-sockets-vol missing: %v", model.Volumes)
+	}
+}
+
+func TestExpandComposeValue(t *testing.T) {
+	t.Setenv("FOO", "bar")
+	t.Setenv("EMPTY", "")
+	cases := map[string]string{
+		"plain":                "plain",
+		"$FOO":                 "bar",
+		"${FOO}":               "bar",
+		"a-${FOO}-b":           "a-bar-b",
+		"$$FOO":                "$FOO", // $$ escapes to a literal $
+		"${MISSING:-fallback}": "fallback",
+		"${EMPTY:-fallback}":   "fallback", // :- uses default when empty
+		"${FOO:-fallback}":     "bar",
+		"pre$$post":            "pre$post",
+		// $2 / $10 are not valid variable names so they are kept verbatim, while
+		// $abc IS a (here unset) variable and expands to empty — documents how an
+		// unescaped literal '$' is handled (compose users escape with $$).
+		"$2y$10$abc": "$2y$10",
+	}
+	for in, want := range cases {
+		if got := expandComposeValue(in); got != want {
+			t.Errorf("expandComposeValue(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestParseComposeForSDK_NoServices(t *testing.T) {
+	if _, err := ParseComposeForSDK([]byte("volumes:\n  v:\n")); err == nil {
+		t.Error("expected error for a compose document with no services")
+	}
+}
+
+func eqStrs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func hasEnv(env []string, want string) bool {
+	for _, e := range env {
+		if e == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What

`keploy cloud replay` reconstructs the app from its Kubernetes deployment as an **in-memory docker-compose** document and, until now, always ran it by shelling out to `docker compose -f - up` (plus `docker compose down`/`ps` and `docker rm` on teardown).

This adds a **Docker-SDK orchestrator** (the moby client already embedded in `docker.Client`) that is used **only as a fallback when the `docker compose` CLI is unavailable** — e.g. a distroless/shell-free image that ships no compose plugin. When the compose CLI is present, the existing CLI path runs unchanged.

## Why

- On a shell-free / distroless image with no compose CLI plugin, `docker compose -f - up` cannot run at all.
- The CLI teardown path (compose-`ps` classification, name-conflict reap retries, PTY handling) is fragile; the SDK path talks to the daemon socket directly.

## How

- `setupComposeInMemory` probes `docker compose version` **once during Setup** and sets `useSDKCompose` (true only when the CLI is absent). Being set in Setup (single goroutine), it is read race-free by `run()` and `ComposeDown`.
- SDK path (`pkg/client/app/compose_sdk.go`): create the `keploy-agent` → gate the app's start on the agent's container healthcheck (with an HTTP `/agent/ready` fallback bounded by `AgentReadyTimeout`) → start the app sharing the agent's net/pid namespace → stream logs → `ContainerWait` for the app's exit code (`--exit-code-from` semantics) → bounded, mutex-guarded teardown.
- A daemon-free parser (`pkg/platform/docker/compose_model.go`) turns the final hook-modified compose YAML into a typed model.

The generated compose is **bounded** (the injected `keploy-agent` + the app container(s); the app's infra dependencies are served from recorded mocks, not run), so the orchestrator faithfully reproduces the subset it uses:

- `restart` forced to `no` (so `--abort-on-container-exit` exit-code capture works),
- `pid`/`network_mode: service:keploy-agent` → `container:<agentID>`, ports and DNS on the **agent** only,
- `cap_add` / `security_opt` / `tmpfs` / healthcheck / named+bind volumes,
- env resolution matching `docker compose up` (bare-key host inheritance for `KEPLOY_COUCHBASE_PASSWORD`, `${VAR}` expansion).

## Scope / safety

- Limited to the in-memory (cloud replay) path via the single `useSDKCompose` decision — up-via-SDK ⟺ down-via-SDK, CLI-up ⟺ CLI-down.
- The normal file-based `keploy test` / `keploy record` compose path is **untouched**.
- `go.mod`: promotes `go-connections` and `distribution/reference` from indirect → direct (now imported directly); `go mod tidy` is a no-op.

## Testing

- Daemon-free unit tests: the YAML→model parser, env resolution (`${VAR}`/`$$`/host-inherit), the container-spec translation (netns/pid, ports on agent only, `restart=no`, healthcheck, caps/security_opt/tmpfs), and the concurrent teardown stack (`-race`).
- `go build ./...`, `go vet`, `gofmt`, `go test -race` — all green.
- An independent review of the staged diff was run and its findings folded in (unsynchronized `sdkStack` read in the wait fallback; documented the parser's deliberate field-omission).

## Follow-up (separate, enterprise repo)

An e2e guard (`.woodpecker/selfhosted-cloud-replay-e2e.yml`, step 2s) that runs cloud replay with the compose CLI made unavailable and asserts the SDK path is prepared, and lands **with the enterprise `go.keploy.io/server/v3` pin bump** to the release carrying this change (it can't pass against the current pin).
