### PR TITLE
fix(mysql): skip connections joined mid-stream instead of failing recording

### DIFF
--- a/pkg/agent/proxy/integrations/mysql/recorder/conn.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/conn.go
@@ -3,6 +3,7 @@ package recorder
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -65,7 +66,12 @@ func handleInitialHandshake(ctx context.Context, logger *zap.Logger, clientConn,
 	// Decode server handshake packet
 	handshakePkt, err := wire.DecodePayload(ctx, logger, handshake, clientConn, decodeCtx)
 	if err != nil {
-		utils.LogError(logger, err, "failed to decode handshake packet")
+		// A mid-stream join (first captured server packet is not the greeting)
+		// is an expected condition the caller skips gracefully — don't log it
+		// as an error. Any other decode failure is a genuine error.
+		if !errors.Is(err, wire.ErrServerGreetingNotFound) {
+			utils.LogError(logger, err, "failed to decode handshake packet")
+		}
 		return res, err
 	}
 

--- a/pkg/agent/proxy/integrations/mysql/recorder/midstream_test.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/midstream_test.go
@@ -1,0 +1,136 @@
+package recorder
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	connphase "go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/wire/phase/conn"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+	"golang.org/x/sync/errgroup"
+)
+
+// These tests reproduce the customer failure where non-TLS MySQL recording
+// captured 0 mocks: the DS-mode proxyless eBPF path joins a connection that
+// was opened before recording started (a pre-warmed JDBC pool), so the first
+// server packet it sees is a query response, NOT the HandshakeV10 greeting.
+// The parser needs the greeting (server capability flags) to decode anything,
+// so it returned "server Greetings not found" and the whole connection's
+// recording was aborted with three ERROR logs.
+//
+// A connection we joined mid-stream is genuinely un-recordable (we can never
+// reconstruct the greeting after the fact), so the correct behavior is to skip
+// it gracefully — return nil, emit no mock, no ERROR — while surfacing a single
+// WARN so the "0 mocks" symptom is explained. Connections captured from their
+// first byte are unaffected: their greeting is present and recording proceeds.
+
+// midStreamServerPacket returns a server-side OK packet (payload[0] == 0x00),
+// standing in for whatever response first arrives on a connection Keploy joined
+// after the greeting was already exchanged. Crucially payload[0] != 0x0a, so
+// the decoder does not mistake it for a HandshakeV10 greeting.
+func midStreamServerPacket(t *testing.T) []byte {
+	t.Helper()
+	// Any valid server capability set works — we only need well-formed OK
+	// bytes whose first byte is not the HandshakeV10 protocol version.
+	greeting, err := connphase.DecodeHandshakeV10(context.Background(), zap.NewNop(), cannedHandshakeV10(t)[4:])
+	if err != nil {
+		t.Fatalf("decode handshake for caps: %v", err)
+	}
+	return cannedOK(t, 1, greeting.CapabilityFlags)
+}
+
+// observedLogger returns a logger whose entries can be inspected, so a test can
+// assert the graceful skip produced no ERROR logs (the customer-visible symptom
+// was three ERRORs per connection) and did surface the WARN that explains it.
+func observedLogger() (*zap.Logger, *observer.ObservedLogs) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	return zap.New(core), logs
+}
+
+func assertGracefulSkipLogs(t *testing.T, logs *observer.ObservedLogs) {
+	t.Helper()
+	if n := logs.FilterLevelExact(zapcore.ErrorLevel).Len(); n != 0 {
+		for _, e := range logs.FilterLevelExact(zapcore.ErrorLevel).All() {
+			t.Logf("unexpected ERROR log: %s", e.Message)
+		}
+		t.Fatalf("a graceful mid-stream skip must emit no ERROR logs, got %d", n)
+	}
+	if n := logs.FilterLevelExact(zapcore.WarnLevel).Len(); n == 0 {
+		t.Fatalf("a mid-stream skip must surface exactly one WARN so missing mocks are explained, got 0")
+	}
+}
+
+// TestRecord_MidStreamNoGreeting_SkipsGracefully drives the legacy Record path
+// (the one the customer hit — mysql.go recordLegacy) with a connection whose
+// first server packet is not the greeting.
+func TestRecord_MidStreamNoGreeting_SkipsGracefully(t *testing.T) {
+	// Not parallel: Record routes emitted mocks through the process-global
+	// syncMock singleton, which wireSyncMockOutput binds.
+	logger, logs := observedLogger()
+	mocks := make(chan *models.Mock, 8)
+	wireSyncMockOutput(t, mocks)
+
+	clientConn := newPipeConn()
+	destConn := newPipeConn()
+	// First byte we ever see from the server is a query OK, not the greeting.
+	destConn.push(midStreamServerPacket(t))
+
+	g, gctx := errgroup.WithContext(context.Background())
+	ctx, cancel := context.WithTimeout(gctx, 2*time.Second)
+	defer cancel()
+	ctx = context.WithValue(ctx, models.ErrGroupKey, g)
+	ctx = context.WithValue(ctx, models.ClientConnectionIDKey, "midstream-conn")
+
+	err := Record(ctx, logger, clientConn, destConn, mocks, models.OutgoingOptions{
+		DstCfg: &models.ConditionalDstCfg{Addr: "127.0.0.1:3306", Port: 3306},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Record must skip a mid-stream (greeting-less) connection gracefully, got error: %v", err)
+	}
+
+	select {
+	case m := <-mocks:
+		t.Fatalf("no mock should be emitted for an un-decodable mid-stream connection, got %+v", m)
+	default:
+	}
+	assertGracefulSkipLogs(t, logs)
+}
+
+// TestRecordV2_MidStreamNoGreeting_SkipsGracefully drives the V2 relay path
+// with the same mid-stream scenario, so both record entry points are covered.
+func TestRecordV2_MidStreamNoGreeting_SkipsGracefully(t *testing.T) {
+	t.Parallel()
+	h := newV2Harness(t)
+	logger, logs := observedLogger()
+	h.sess.Logger = logger
+
+	base := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	// First DestStream packet is a query OK, not the HandshakeV10 greeting.
+	h.pushDest(midStreamServerPacket(t), base)
+
+	done := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		done <- RecordV2(ctx, logger, h.sess)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("RecordV2 must skip a mid-stream (greeting-less) connection gracefully, got error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("RecordV2 did not return; mid-stream skip should be immediate")
+	}
+
+	select {
+	case m := <-h.mocks:
+		t.Fatalf("no mock should be emitted for an un-decodable mid-stream connection, got %+v", m)
+	default:
+	}
+	assertGracefulSkipLogs(t, logs)
+}

--- a/pkg/agent/proxy/integrations/mysql/recorder/record.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record.go
@@ -97,6 +97,18 @@ func Record(ctx context.Context, logger *zap.Logger, clientConn, destConn net.Co
 					zap.String("connKey", opts.ConnKey))
 				return nil
 			}
+			// A connection whose first captured server packet is not the
+			// HandshakeV10 greeting was joined mid-stream (opened before
+			// recording started, e.g. a pre-warmed connection pool). Its
+			// greeting — and thus the server capability flags needed to
+			// decode any of its packets — can never be recovered, so skip it
+			// gracefully instead of failing the capture. Connections captured
+			// from their first byte are unaffected.
+			if errors.Is(err, wire.ErrServerGreetingNotFound) {
+				logger.Warn("skipping MySQL connection joined mid-stream: no server greeting was captured, so it cannot be recorded. This connection was opened before recording started (e.g. a pre-warmed connection pool). To capture it, restart the application after starting the recording so its connections are re-established and captured from the greeting.",
+					zap.String("connKey", opts.ConnKey))
+				return nil
+			}
 			utils.LogError(logger, err, "failed to handle initial handshake")
 			errCh <- err
 			return nil

--- a/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
@@ -90,6 +90,14 @@ func RecordV2(ctx context.Context, logger *zap.Logger, sess *supervisor.Session)
 			logger.Debug("EOF during MySQL V2 initial handshake")
 			return nil
 		}
+		// Joined mid-stream (connection opened before recording started, e.g.
+		// a pre-warmed pool): the server greeting was never captured, so the
+		// connection is un-decodable. Skip it gracefully rather than failing
+		// the capture. See wire.ErrServerGreetingNotFound.
+		if errors.Is(err, wire.ErrServerGreetingNotFound) {
+			logger.Warn("skipping MySQL connection joined mid-stream: no server greeting was captured, so it cannot be recorded. This connection was opened before recording started (e.g. a pre-warmed connection pool). To capture it, restart the application after starting the recording so its connections are re-established and captured from the greeting.")
+			return nil
+		}
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}

--- a/pkg/agent/proxy/integrations/mysql/wire/decode.go
+++ b/pkg/agent/proxy/integrations/mysql/wire/decode.go
@@ -3,6 +3,7 @@ package wire
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 
@@ -18,6 +19,15 @@ import (
 	"go.keploy.io/server/v3/pkg/models/mysql"
 	"go.uber.org/zap"
 )
+
+// ErrServerGreetingNotFound is returned when a packet is decoded on a
+// connection for which no server greeting (HandshakeV10) was ever captured.
+// The greeting carries the server capability flags every later packet is
+// decoded against, so without it the connection is un-decodable. In practice
+// this means recording joined the connection mid-stream — it was opened before
+// recording started, e.g. a pre-warmed JDBC connection pool. Callers should
+// treat it as a signal to skip that connection, not as a hard error.
+var ErrServerGreetingNotFound = errors.New("server Greetings not found")
 
 // DecodePayload is used to decode mysql packets that don't consist of multiple packets within them, because we are reading per packet.
 func DecodePayload(ctx context.Context, logger *zap.Logger, data []byte, clientConn net.Conn, decodeCtx *DecodeContext) (*mysql.PacketBundle, error) {
@@ -67,7 +77,7 @@ func handleQueryStmtResponse(ctx context.Context, logger *zap.Logger, packet mys
 
 	sg, ok := decodeCtx.ServerGreetings.Load(clientConn)
 	if !ok {
-		return parsedPacket, fmt.Errorf("server Greetings not found")
+		return parsedPacket, ErrServerGreetingNotFound
 	}
 
 	logger.Debug("Last operation when handling client query", zap.Any("last operation", mysql.CommandStatusToString(lastOp)))
@@ -145,7 +155,7 @@ func decodePacket(ctx context.Context, logger *zap.Logger, packet mysql.Packet, 
 	if payloadType != mysql.HandshakeV10 {
 		sg, ok = decodeCtx.ServerGreetings.Load(clientConn)
 		if !ok {
-			return parsedPacket, fmt.Errorf("server Greetings not found")
+			return parsedPacket, ErrServerGreetingNotFound
 		}
 	}
 


### PR DESCRIPTION
## Describe the changes that are made

Non-TLS MySQL recording could capture **0 mocks** when the application uses a pre-warmed connection pool (e.g. a JDBC pool), on the DaemonSet-mode proxyless eBPF capture path.

**Root cause.** The MySQL recorder needs the server's `HandshakeV10` greeting (packet seq 0) as the *first* packet on a connection — it carries the server capability flags that every subsequent packet is decoded against. When Keploy joins a connection **mid-stream** — i.e. the connection was already open before recording started, as with a pre-warmed pool — the first captured server packet is a query response, not the greeting. The decoder returned a plain `fmt.Errorf("server Greetings not found")`, which bubbled up as **three ERROR logs** and aborted that connection's recording:

```
ERROR  failed to decode handshake packet   {"error": "failed to decode packet: server Greetings not found"}
ERROR  failed to handle initial handshake  {"error": "failed to decode packet: server Greetings not found"}
ERROR  failed to encode the mysql message into the yaml  {"error": "..."}
```

HTTP (stateless) recorded fine on the same run, which is the tell-tale asymmetry: HTTP is recordable mid-stream, MySQL is not.

**Fix.** A mid-stream connection is genuinely un-recordable — the greeting can never be recovered after the fact — so the correct behavior is a graceful **per-connection skip**, not a hard failure that surfaces as errors.

- `wire.DecodePayload` now returns a typed sentinel `wire.ErrServerGreetingNotFound` instead of an untyped error.
- Both record paths — legacy `Record` and `RecordV2` — detect the sentinel and skip the connection cleanly, exactly mirroring the existing `io.EOF`-during-handshake handling: return `nil`, emit no mock, no ERROR.
- A single **WARN** explains the skip and the remedy (restart the app after starting recording so its pooled connections are re-established and captured from the greeting), so the "0 mocks" symptom is no longer silent.

Connections captured from their first byte are completely unaffected: their greeting is present and recording proceeds normally. The skip is strictly scoped to the initial handshake — the only place a mid-stream join is detectable — and is per-connection, so skipping one connection never affects another.

## Links & References

**Closes:** NA (customer-reported; no tracked issue)
- NA

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed

The failure is deterministic at the parser level, so it is covered by hermetic unit tests (`TestRecord_MidStreamNoGreeting_SkipsGracefully` and `TestRecordV2_MidStreamNoGreeting_SkipsGracefully`) that feed a mid-stream first server packet and assert both record entry points return `nil`, emit no mock, log **no ERROR**, and surface the explanatory WARN. Reproducing a mid-stream/pre-warmed-pool join in an e2e pipeline would be inherently timing-dependent (flaky); the unit tests pin the exact condition deterministically (and pass under `-race`).

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

```
go test ./pkg/agent/proxy/integrations/mysql/recorder/ -run MidStreamNoGreeting -race -v
```

The tests fail on the pre-fix code (both record paths return `server Greetings not found`) and pass after the fix (graceful skip, no ERROR, one WARN).

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA

## Additional checklist:
- [x] Have you read the Contributing Guidelines on issues?
- [x] Have you followed the PR Semantics guide for naming this PR?
- [x] Have you followed the Branch Semantics guide for naming your branch?
