### PR TITLE
fix(agent,replay): make docker-mode agent bind + reset re-send robust to userland-proxy flake

### DIFF
--- a/pkg/agent/routes/server.go
+++ b/pkg/agent/routes/server.go
@@ -5,17 +5,37 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
+	"syscall"
 	"time"
 
 	"go.uber.org/zap"
 )
 
+// bindRetryBudget bounds how long StartAgentServer keeps retrying a transient
+// "address already in use" before giving up. In docker mode the agent publishes
+// its HTTP port to the host; when keploy sessions run back-to-back (e.g. a CI
+// driver that records then replays then replays-with-mappings, each a fresh
+// keploy process), the previous session's agent — or, more precisely, its
+// docker userland-proxy holding the published host port — can still own the
+// port for a short window while it tears down. That owner WILL release the
+// port, so a transient bind failure must not be fatal: hard-failing here leaves
+// the agent's readiness file unwritten and the container healthcheck fails for
+// its full ceiling (~300s) before the run aborts. The budget is kept well under
+// that ceiling (see pkg/platform/docker) so the retry always has room to land.
+const bindRetryBudget = 90 * time.Second
+
+// bindRetryInterval is the delay between bind attempts. A departing agent's port
+// frees within a second or two, so a sub-second cadence recovers quickly without
+// busy-spinning.
+const bindRetryInterval = 500 * time.Millisecond
+
 func StartAgentServer(ctx context.Context, logger *zap.Logger, port int, router http.Handler) {
 	logger.Info("Starting Agent's HTTP server on :", zap.Int("port", port))
 
+	addr := fmt.Sprintf(":%d", port)
 	srv := &http.Server{
-		Addr:    fmt.Sprintf(":%d", port),
 		Handler: router,
 	}
 
@@ -37,9 +57,47 @@ func StartAgentServer(ctx context.Context, logger *zap.Logger, port int, router 
 		}
 	}()
 
-	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+	// Bind explicitly (with bounded retry on a transiently-held port) so a
+	// previous session's not-yet-released host port doesn't permanently fail
+	// this agent's startup; then serve on the acquired listener.
+	listener, err := listenWithRetry(srvCtx, logger, addr, bindRetryBudget, bindRetryInterval)
+	if err != nil {
+		logger.Error("failed to start HTTP server; verify port availability and network configuration", zap.Error(err))
+		return
+	}
+
+	if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
 		logger.Error("failed to start HTTP server; verify port availability and network configuration", zap.Error(err))
 		return
 	}
 	logger.Info("HTTP server stopped")
+}
+
+// listenWithRetry binds a TCP listener on addr, retrying only the transient
+// "address already in use" case until the port frees or budget elapses. Every
+// other listen error (and a cancelled context) is returned immediately — the
+// retry is strictly for a port a departing owner is still releasing, never a
+// mask for a genuine misconfiguration.
+func listenWithRetry(ctx context.Context, logger *zap.Logger, addr string, budget, interval time.Duration) (net.Listener, error) {
+	deadline := time.Now().Add(budget)
+	for {
+		ln, err := net.Listen("tcp", addr)
+		if err == nil {
+			return ln, nil
+		}
+		// Only "address already in use" is transient here; anything else is a
+		// real failure the operator must see now.
+		if !errors.Is(err, syscall.EADDRINUSE) || !time.Now().Before(deadline) {
+			return nil, err
+		}
+		logger.Warn("agent HTTP port is transiently in use (a previous session's agent is likely still releasing it); retrying bind",
+			zap.String("addr", addr),
+			zap.Duration("retry_in", interval),
+			zap.Error(err))
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(interval):
+		}
+	}
 }

--- a/pkg/agent/routes/server_test.go
+++ b/pkg/agent/routes/server_test.go
@@ -1,0 +1,142 @@
+package routes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"syscall"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// grabPort binds an ephemeral port and returns the listener (still holding the
+// port), the numeric port, and the ":port" address StartAgentServer would use.
+func grabPort(t *testing.T) (net.Listener, int, string) {
+	t.Helper()
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("listen ephemeral: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	return ln, port, fmt.Sprintf(":%d", port)
+}
+
+// TestListenWithRetry_RecoversWhenPortFrees reproduces the couchbase-node flake:
+// a previous session's agent still holds the published host port when this agent
+// binds. The bind must not hard-fail — once the departing owner releases the
+// port the retry acquires it.
+func TestListenWithRetry_RecoversWhenPortFrees(t *testing.T) {
+	holder, _, addr := grabPort(t)
+
+	// Release the port shortly, mimicking the previous agent finishing teardown.
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		_ = holder.Close()
+	}()
+
+	ln, err := listenWithRetry(context.Background(), zap.NewNop(), addr, 5*time.Second, 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("expected bind to recover after the port freed, got: %v", err)
+	}
+	_ = ln.Close()
+}
+
+// TestListenWithRetry_GivesUpAfterBudget ensures the retry is bounded: a port
+// that never frees fails after the budget rather than hanging forever.
+func TestListenWithRetry_GivesUpAfterBudget(t *testing.T) {
+	holder, _, addr := grabPort(t)
+	defer func() { _ = holder.Close() }()
+
+	start := time.Now()
+	_, err := listenWithRetry(context.Background(), zap.NewNop(), addr, 300*time.Millisecond, 50*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected an error when the port stays occupied past the budget")
+	}
+	if elapsed := time.Since(start); elapsed < 300*time.Millisecond {
+		t.Fatalf("gave up before the budget elapsed: %v", elapsed)
+	}
+}
+
+// TestListenWithRetry_HonorsContextCancel ensures a cancelled context unblocks
+// the retry loop promptly instead of waiting out the budget.
+func TestListenWithRetry_HonorsContextCancel(t *testing.T) {
+	holder, _, addr := grabPort(t)
+	defer func() { _ = holder.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err := listenWithRetry(ctx, zap.NewNop(), addr, 10*time.Second, 50*time.Millisecond)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("did not honor cancel promptly: %v", elapsed)
+	}
+}
+
+// TestListenWithRetry_ReturnsImmediatelyOnNonAddrInUse ensures the retry is
+// strictly for "address already in use": any other listen error (here, an
+// out-of-range port) surfaces at once and is never retried — the retry must not
+// mask a genuine misconfiguration.
+func TestListenWithRetry_ReturnsImmediatelyOnNonAddrInUse(t *testing.T) {
+	start := time.Now()
+	_, err := listenWithRetry(context.Background(), zap.NewNop(), "127.0.0.1:99999", 10*time.Second, time.Second)
+	if err == nil {
+		t.Fatal("expected an error for an invalid port")
+	}
+	if errors.Is(err, syscall.EADDRINUSE) {
+		t.Fatalf("an out-of-range port must not be classified as address-in-use: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("a non-address-in-use error must not be retried: took %v", elapsed)
+	}
+}
+
+// TestStartAgentServer_ServesAfterTransientPortConflict is the end-to-end proof:
+// the agent HTTP server starts while the port is still held, and begins serving
+// once it frees — exactly the previous-session-teardown race from CI.
+func TestStartAgentServer_ServesAfterTransientPortConflict(t *testing.T) {
+	holder, port, _ := grabPort(t)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Release the port after the server has already started retrying.
+	go func() {
+		time.Sleep(400 * time.Millisecond)
+		_ = holder.Close()
+	}()
+
+	go StartAgentServer(ctx, zap.NewNop(), port, handler)
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/", port)
+	client := &http.Client{Timeout: 500 * time.Millisecond}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		resp, err := client.Get(url)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return // server recovered and is serving
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("agent HTTP server never started serving after the port freed (last err: %v)", err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}

--- a/pkg/service/replay/hooks.go
+++ b/pkg/service/replay/hooks.go
@@ -41,7 +41,7 @@ func (h *Hooks) SimulateRequest(ctx context.Context, tc *models.TestCase, testSe
 
 	// Extract URL replacements and port mappings: merge global + per-test-set
 	// (test-set level overrides global for same key)
-	urlReplacements, portMappings := h.mergeReplaceWith(testSetID)
+	urlReplacements, portMappings := mergeReplaceWith(h.cfg.Test, testSetID)
 
 	switch tc.Kind {
 	case models.HTTP:
@@ -156,9 +156,11 @@ func effectiveHTTPConfigPort(tc *models.TestCase, cfg config.Test) uint32 {
 }
 
 // mergeReplaceWith extracts and merges URL replacements and port mappings
-// from global and per-test-set replaceWith configuration.
-func (h *Hooks) mergeReplaceWith(testSetID string) (map[string]string, map[uint32]uint32) {
-	rw := h.cfg.Test.ReplaceWith
+// from global and per-test-set replaceWith configuration. It is a free function
+// (reading only config.Test) so the reset-resend readiness probe can resolve the
+// same effective dial target the simulation uses — see resolveProbeTarget.
+func mergeReplaceWith(testCfg config.Test, testSetID string) (map[string]string, map[uint32]uint32) {
+	rw := testCfg.ReplaceWith
 	hasData := len(rw.Global.URL) > 0 || len(rw.Global.Port) > 0 || len(rw.TestSets) > 0
 	if !hasData {
 		return nil, nil

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -4098,11 +4098,11 @@ func (r *Replayer) retryResetOnce(ctx context.Context, testCase *models.TestCase
 			return nil, false, drained
 		}
 
-		// Re-gate on the app's published host port accepting a connection so we
-		// re-send only once the app/proxy is ready again, not blindly. Best
-		// effort: if we can't determine a waitable port (native app, unmapped
-		// publish) we proceed — the bounded attempts still protect us.
-		r.waitForResetResendReady(ctx)
+		// Re-gate on the app actually serving again (HTTP-level, on the same
+		// endpoint the request dials) so we re-send only once the app/proxy is
+		// ready, not blindly. Best effort: if we can't determine a probeable
+		// target we proceed — the bounded attempts still protect us.
+		r.waitForResetResendReady(ctx, testCase, testSetID)
 
 		r.logger.Warn("test request reset by app/proxy before any mock was consumed; re-sending — the request was never processed, so this is not a retry of an assertion",
 			zap.Int("attempt", attempt),
@@ -4159,16 +4159,35 @@ func (r *Replayer) resetResendUnsafe(ctx context.Context) (bool, []models.MockSt
 	return false, nil
 }
 
-// waitForResetResendReady best-effort gates a reset re-send on the app's
-// published docker host port accepting a TCP connection again, bounded by
-// resetResendReadyTimeout. It is a no-op for native apps / unmapped publishes.
-func (r *Replayer) waitForResetResendReady(ctx context.Context) {
+// waitForResetResendReady best-effort gates a reset re-send on the app actually
+// serving again, bounded by resetResendReadyTimeout.
+//
+// It prefers an HTTP-level probe against the SAME endpoint the test request is
+// dialed to — resolved via resolveProbeTarget, which mirrors the simulation's
+// ResolveTestTarget (ConfigHost/--host, replaceWith, port precedence) rather than
+// the raw recorded URL. This makes the gate address-family-correct (an IPv6
+// "localhost" dial is gated on the IPv6 path, not a mismatched IPv4 127.0.0.1)
+// and, unlike a bare TCP-accept gate, it does not declare readiness while
+// docker's userland-proxy is still accepting-then-resetting connections
+// mid-response. For a non-HTTP or unresolvable target it falls back to the docker
+// published host-port TCP gate (no-op for native apps / unmapped publishes). On
+// timeout it returns and lets the bounded re-send attempts run.
+func (r *Replayer) waitForResetResendReady(ctx context.Context, testCase *models.TestCase, testSetID string) {
+	wctx, cancel := context.WithTimeout(ctx, resetResendReadyTimeout)
+	defer cancel()
+
+	if scheme, host, port, ok := resolveProbeTarget(r.config.Test, testCase, testSetID, r.logger); ok {
+		if err := waitForHTTPServing(wctx, scheme, host, port); err != nil {
+			r.logger.Debug("app not serving HTTP before reset re-send; re-sending anyway",
+				zap.String("host", host), zap.String("port", port), zap.Error(err))
+		}
+		return
+	}
+
 	host, port, ok := dockerPublishedHostPort(r.config.Command)
 	if !ok {
 		return
 	}
-	wctx, cancel := context.WithTimeout(ctx, resetResendReadyTimeout)
-	defer cancel()
 	if err := pkg.WaitForPort(wctx, host, port, resetResendReadyTimeout); err != nil {
 		r.logger.Debug("app host port not ready before reset re-send; re-sending anyway",
 			zap.String("host", host), zap.String("port", port), zap.Error(err))

--- a/pkg/service/replay/reset_resend_readiness_test.go
+++ b/pkg/service/replay/reset_resend_readiness_test.go
@@ -1,0 +1,174 @@
+package replay
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"go.keploy.io/server/v3/config"
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// TestResolveProbeTarget verifies the reset-resend readiness gate resolves its
+// probe target from the ACTUAL dial target — mirroring the simulation's
+// ResolveTestTarget (ConfigHost/--host override, port precedence) — not the raw
+// recorded URL. The first case is the couchbase-java regression: a recorded
+// 127.0.0.1 with the default ConfigHost "localhost" must probe localhost (→ the
+// IPv6 path that resets), NOT the recorded IPv4 127.0.0.1 (which never resets and
+// would make the fix inert).
+func TestResolveProbeTarget(t *testing.T) {
+	httpTC := func(url string) *models.TestCase {
+		return &models.TestCase{Kind: models.HTTP, HTTPReq: models.HTTPReq{URL: url}}
+	}
+	cases := []struct {
+		name                           string
+		cfg                            config.Test
+		tc                             *models.TestCase
+		wantScheme, wantHost, wantPort string
+		wantOK                         bool
+	}{
+		{
+			name:       "configHost rewrites recorded 127.0.0.1 to localhost (couchbase-java repro)",
+			cfg:        config.Test{Host: "localhost"},
+			tc:         httpTC("http://127.0.0.1:8080/health"),
+			wantScheme: "http", wantHost: "localhost", wantPort: "8080", wantOK: true,
+		},
+		{
+			name:       "empty configHost defaults to localhost",
+			cfg:        config.Test{},
+			tc:         httpTC("http://127.0.0.1:8080/health"),
+			wantScheme: "http", wantHost: "localhost", wantPort: "8080", wantOK: true,
+		},
+		{
+			name:       "configHost can point the other way (localhost -> 127.0.0.1)",
+			cfg:        config.Test{Host: "127.0.0.1"},
+			tc:         httpTC("http://localhost:9000/x"),
+			wantScheme: "http", wantHost: "127.0.0.1", wantPort: "9000", wantOK: true,
+		},
+		{
+			name:       "config port override wins over the recorded port",
+			cfg:        config.Test{Host: "localhost", Port: 7777},
+			tc:         httpTC("http://127.0.0.1:8080/x"),
+			wantScheme: "http", wantHost: "localhost", wantPort: "7777", wantOK: true,
+		},
+		{
+			name:       "https default port",
+			cfg:        config.Test{Host: "example.com"},
+			tc:         httpTC("https://recorded-host/health"),
+			wantScheme: "https", wantHost: "example.com", wantPort: "443", wantOK: true,
+		},
+		{
+			name:   "non-http test case is not probeable",
+			cfg:    config.Test{Host: "localhost"},
+			tc:     &models.TestCase{Kind: models.GRPC_EXPORT},
+			wantOK: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			scheme, host, port, ok := resolveProbeTarget(c.cfg, c.tc, "test-set-0", zap.NewNop())
+			if ok != c.wantOK || scheme != c.wantScheme || host != c.wantHost || port != c.wantPort {
+				t.Fatalf("got (%q,%q,%q,%v), want (%q,%q,%q,%v)",
+					scheme, host, port, ok, c.wantScheme, c.wantHost, c.wantPort, c.wantOK)
+			}
+		})
+	}
+	if _, _, _, ok := resolveProbeTarget(config.Test{Host: "localhost"}, nil, "test-set-0", zap.NewNop()); ok {
+		t.Fatal("a nil test case must not be probeable")
+	}
+}
+
+// resettingThenServing starts a TCP server that RST-closes the first resetCount
+// accepted connections (mimicking docker's userland-proxy resetting freshly
+// accepted host-port conns under load) and then answers subsequent connections
+// with a valid HTTP response. It returns the listen address and a stop func.
+func resettingThenServing(t *testing.T, resetCount int) (string, func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	var mu sync.Mutex
+	accepted := 0
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			mu.Lock()
+			n := accepted
+			accepted++
+			mu.Unlock()
+
+			if n < resetCount {
+				// Force an RST rather than a graceful FIN: SetLinger(0) makes
+				// Close send a reset, reproducing "connection reset by peer".
+				if tcp, ok := conn.(*net.TCPConn); ok {
+					_ = tcp.SetLinger(0)
+				}
+				_ = conn.Close()
+				continue
+			}
+			go func(c net.Conn) {
+				defer func() { _ = c.Close() }()
+				_ = c.SetReadDeadline(time.Now().Add(time.Second))
+				buf := make([]byte, 1024)
+				_, _ = c.Read(buf) // consume the request line/headers
+				_, _ = c.Write([]byte("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
+			}(conn)
+		}
+	}()
+	return ln.Addr().String(), func() { _ = ln.Close() }
+}
+
+// TestWaitForHTTPServing_WaitsThroughResetsUntilServing is the couchbase-java
+// repro: a bare TCP-accept gate would pass immediately (the handshake completes
+// before the app resets), but waitForHTTPServing keeps probing through the reset
+// burst and only returns once the app answers a real HTTP response.
+func TestWaitForHTTPServing_WaitsThroughResetsUntilServing(t *testing.T) {
+	addr, stop := resettingThenServing(t, 3) // reset the first 3 connections
+	defer stop()
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("split host port: %v", err)
+	}
+
+	// A plain TCP dial succeeds even while the server is in its reset phase —
+	// this is exactly why the old TCP-accept gate was insufficient.
+	if c, derr := net.DialTimeout("tcp", addr, time.Second); derr == nil {
+		_ = c.Close()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := waitForHTTPServing(ctx, "http", host, port); err != nil {
+		t.Fatalf("expected app to become ready after the reset burst, got: %v", err)
+	}
+}
+
+// TestWaitForHTTPServing_TimesOutWhenNeverServing ensures the probe stays bounded
+// by ctx when the app never serves — the caller then proceeds with its bounded
+// re-send attempts rather than blocking forever.
+func TestWaitForHTTPServing_TimesOutWhenNeverServing(t *testing.T) {
+	addr, stop := resettingThenServing(t, 1<<30) // always reset
+	defer stop()
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("split host port: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 700*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	if err := waitForHTTPServing(ctx, "http", host, port); err == nil {
+		t.Fatal("expected a timeout error when the app never serves an HTTP response")
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Fatalf("probe overran its context deadline: %v", elapsed)
+	}
+}

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -171,6 +171,134 @@ func dockerPublishedHostPort(cmd string) (host, port string, ok bool) {
 	return "", "", false
 }
 
+// keployReadinessProbePath is the path the reset-resend readiness probe requests.
+// It is deliberately one no real app routes, so a well-behaved server answers it
+// with a 404 WITHOUT invoking an application handler — the probe therefore never
+// consumes a mock or triggers an app side effect. Any HTTP response to it (the
+// 404 included) still proves the proxy→app path is serving.
+const keployReadinessProbePath = "/keploy/__readiness_probe__"
+
+// resetProbeRequestTimeout bounds a single readiness probe round-trip.
+const resetProbeRequestTimeout = 800 * time.Millisecond
+
+// resetProbeInterval is the pause between readiness probe attempts.
+const resetProbeInterval = 200 * time.Millisecond
+
+// resolveProbeTarget returns the scheme, host and port the test case's HTTP
+// request is ACTUALLY dialed to, so the readiness probe hits the SAME endpoint
+// (and address family) the real request will. It must mirror the simulation's
+// resolution — the recorded tc.HTTPReq.URL is NOT the dial target: SimulateHTTP
+// rewrites it via ResolveTestTarget (ConfigHost/--host override, replaceWith,
+// port precedence). In the couchbase suite the recorded host is 127.0.0.1 but
+// the default ConfigHost "localhost" rewrites it to localhost → IPv6 ::1, which
+// is exactly the path that resets; probing the recorded 127.0.0.1 would gate on
+// IPv4 (which never resets) and defeat the fix. Returns ok=false for a nil /
+// non-HTTP test case or an unresolvable target (the caller then falls back to
+// the docker published-port TCP gate).
+//
+// It resolves from the pre-template-render URL, so a {{ }} placeholder in the
+// host/port (as opposed to the path/query/body, where they actually live) would
+// make the probe target diverge from the dial. That is best-effort only: a wrong
+// target just times out within resetResendReadyTimeout and the bounded re-send
+// still runs, so it never affects correctness.
+func resolveProbeTarget(testCfg config.Test, tc *models.TestCase, testSetID string, logger *zap.Logger) (scheme, host, port string, ok bool) {
+	if tc == nil || tc.Kind != models.HTTP {
+		return "", "", "", false
+	}
+	urlReplacements, portMappings := mergeReplaceWith(testCfg, testSetID)
+	hostToUse := testCfg.Host
+	if hostToUse == "" {
+		hostToUse = "localhost"
+	}
+	configPort := effectiveHTTPConfigPort(tc, testCfg)
+
+	target, err := pkg.ResolveTestTarget(tc.HTTPReq.URL, urlReplacements, portMappings, hostToUse, tc.AppPort, configPort, true, logger)
+	if err != nil {
+		return "", "", "", false
+	}
+	u, err := url.Parse(strings.TrimSpace(target))
+	if err != nil || u == nil {
+		return "", "", "", false
+	}
+	scheme = u.Scheme
+	if scheme != "http" && scheme != "https" {
+		return "", "", "", false
+	}
+	host = u.Hostname()
+	if host == "" {
+		return "", "", "", false
+	}
+	port = u.Port()
+	if port == "" {
+		if scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	return scheme, host, port, true
+}
+
+// waitForHTTPServing polls until an HTTP round-trip to host:port completes with
+// ANY status — proving the proxy→app path actually serves — or ctx expires. A
+// transport reset / refusal / timeout counts as not-ready and keeps waiting.
+//
+// This is the HTTP-level counterpart to a bare TCP-accept gate: docker's
+// userland-proxy ACCEPTS a freshly-published host-port connection and only then
+// resets it mid-response under load, so a completed TCP handshake does NOT imply
+// the next request will land. Only a finished HTTP exchange proves the app is
+// truly reachable. Fresh (keep-alive-disabled) connections mirror the real
+// per-request connect the proxy resets. The probe hits a keploy-reserved 404
+// path (see keployReadinessProbePath) so a well-behaved app answers it without
+// invoking a handler; and in the reset (failure) state the userland-proxy resets
+// the probe before the app ever sees it, so it never reaches application code.
+func waitForHTTPServing(ctx context.Context, scheme, host, port string) error {
+	target := fmt.Sprintf("%s://%s%s", scheme, net.JoinHostPort(host, port), keployReadinessProbePath)
+	client := &http.Client{
+		Timeout: resetProbeRequestTimeout,
+		// Don't follow redirects — any 3xx already proves the app serves.
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+		Transport: &http.Transport{
+			// Fresh connection per probe so we exercise the same connect the
+			// userland-proxy resets, rather than reusing a warm one.
+			DisableKeepAlives: true,
+			// Never route a loopback readiness probe through an env proxy.
+			Proxy: nil,
+		},
+	}
+	defer client.CloseIdleConnections()
+
+	probe := func() bool {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+		if err != nil {
+			return false
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return false // transport reset / refused / timeout → not ready yet
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		return true // any HTTP response means the app is serving
+	}
+
+	if probe() {
+		return nil
+	}
+	ticker := time.NewTicker(resetProbeInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if probe() {
+				return nil
+			}
+		}
+	}
+}
+
 func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config) bool {
 	delay := time.Duration(cfg.Test.Delay) * time.Second
 


### PR DESCRIPTION
## Describe the changes that are made

Two robustness fixes for docker-mode record/replay that surface as **flaky couchbase e2e** (the couchbase drivers run three keploy sessions back-to-back — record, replay, replay-with-mappings — each a fresh keploy process whose in-docker `keploy-agent` publishes its HTTP port to the host).

### 1. `fix(agent)` — retry the agent HTTP bind when the port is transiently held
When sessions run back-to-back, the previous session's agent — or its docker userland-proxy still holding the published host port — can own the port for a short window while it tears down. `StartAgentServer` bound via `ListenAndServe` and **hard-failed** on `address already in use`, so it never wrote the agent readiness file and the container healthcheck failed for its full **~300s** ceiling before the run aborted.

Now the listener is bound explicitly with **bounded retry**: on `syscall.EADDRINUSE`, retry until the port frees or a **90s** budget (well under the 300s healthcheck ceiling) elapses, then `Serve` on the acquired listener. Any other listen error and a cancelled context return immediately, so the retry never masks a genuine misconfiguration.

### 2. `fix(replay)` — gate a reset re-send on HTTP-level readiness of the **real dial target**
The reset re-send (`retryResetOnce`) recovers a request that docker's userland-proxy reset before the app processed it. Its readiness gate did a **bare TCP-accept** on the docker published host port — but the userland-proxy *accepts* a freshly-published host-port connection and only then resets it mid-response under load, so accept-success didn't imply the next request would land; and it probed a host that could differ from the one the request actually dials (an IPv4 `127.0.0.1` gate vs an IPv6 `localhost` request). So the bounded re-sends fired into the resetting path and exhausted.

Now the gate resolves the probe target **the same way `SimulateHTTP` does** (`ResolveTestTarget`: ConfigHost/`--host`, replaceWith, port precedence — not the raw recorded URL) and probes it at the **HTTP level**: any completed HTTP response proves the proxy→app path serves; a transport reset keeps waiting within the bounded window. The probe uses fresh (keep-alive-disabled) connections to a keploy-reserved 404 path, so a well-behaved app answers without invoking a handler (side-effect free). It falls back to the previous docker published-port TCP gate for non-HTTP / unresolvable targets. `mergeReplaceWith` becomes a free function so the Replayer resolves the same effective target without depending on the injected `TestHooks` impl.

Both fixes are covered by unit tests that reproduce the failure (a held-then-freed port; a server that RST-closes then serves) and prove recovery. Two independent reviewer passes (blunt/adversarial); the first caught a real blocker — an earlier draft probed the *recorded* host instead of the resolved dial target — which is fixed and now has a regression test.

## Links & References

**Closes:** NA (surfaced via enterprise couchbase e2e flakes; no public issue)

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed

Unit tests reproduce both failure modes deterministically (`pkg/agent/routes/server_test.go`, `pkg/service/replay/reset_resend_readiness_test.go`). The end-to-end coverage is the existing enterprise couchbase record+replay lanes that surfaced these flakes.

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed
