### PR TITLE
fix: mount a cgroup2 hierarchy for the eBPF agent on legacy cgroup v1 hosts

### DIFF
--- a/.github/workflows/e2e-cgroup-v2-selfmount.yml
+++ b/.github/workflows/e2e-cgroup-v2-selfmount.yml
@@ -1,0 +1,72 @@
+# E2E guard for the cgroup2 self-mount fallback.
+#
+# On a legacy cgroup v1 host no cgroup2 (unified) hierarchy is visible, so the
+# keploy agent mounts one itself via the mount(2) syscall (pkg/agent/
+# cgroup_mount_linux.go) before attaching its eBPF cgroup hooks. This job builds
+# the root-only integration test (behind the cgroupmount_integration build tag,
+# so it never runs in the normal `go test ./...` job) and runs it as root, which
+# exercises the real mount syscall + cgroup2 verification + idempotency.
+#
+# The full end-to-end interception on a real cgroup v1 host is covered by the
+# enterprise cloud-replay e2e (it runs cloud replay under a DinD daemon that
+# presents a legacy cgroup view); this OSS job guards the mount primitive itself.
+#
+# NOTE: this repo carries no Woodpecker pipeline (only .github/workflows/*); if
+# Woodpecker is adopted, mirror this into .woodpecker/.
+name: e2e-cgroup-v2-selfmount
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'pkg/agent/utils.go'
+      - 'pkg/agent/cgroup_mount_linux.go'
+      - 'pkg/agent/cgroup_mount_linux_test.go'
+      - '.github/workflows/e2e-cgroup-v2-selfmount.yml'
+  pull_request:
+    paths:
+      - 'pkg/agent/utils.go'
+      - 'pkg/agent/cgroup_mount_linux.go'
+      - 'pkg/agent/cgroup_mount_linux_test.go'
+      - '.github/workflows/e2e-cgroup-v2-selfmount.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  selfmount:
+    name: cgroup2 self-mount
+    runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: "1"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Install build essentials
+        run: |
+          sudo apt -y update
+          sudo apt -y install build-essential gcc libc-dev pkg-config
+
+      - name: Install dependencies
+        run: go mod download
+
+      # Compile the tagged test binary as the runner user (build cache is
+      # available here), then run it as root — mounting cgroup2 needs
+      # CAP_SYS_ADMIN. Compiling and running are split so root never touches the
+      # user's Go cache.
+      - name: Build cgroup2 self-mount integration test
+        run: go test -c -tags cgroupmount_integration -o /tmp/cgroup-selfmount.test ./pkg/agent/
+
+      # Run as root (sudo => euid 0, so the test does not self-skip) and assert
+      # the test actually executed: `go test -c` still emits a binary and a
+      # -run that matches nothing exits 0, so grep for the explicit PASS line to
+      # fail loudly if the build tag ever drifts and the test silently vanishes.
+      - name: Run cgroup2 self-mount integration test (root)
+        run: |
+          sudo /tmp/cgroup-selfmount.test -test.run TestCgroupV2SelfMount -test.v | tee /tmp/cgroup-selfmount.out
+          grep -q 'PASS: TestCgroupV2SelfMount' /tmp/cgroup-selfmount.out

--- a/cli/provider/compat_linux.go
+++ b/cli/provider/compat_linux.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	"github.com/moby/moby/pkg/parsers/kernel"
+	"go.keploy.io/server/v3/pkg/agent"
 	"go.uber.org/zap"
 )
 
@@ -22,6 +23,15 @@ func isCompatible(logger *zap.Logger) error {
 		logger.Error(errMsg)
 		return errors.New(errMsg)
 	}
-	// TODO check for cgroup v2 support
+
+	// keploy's eBPF interception attaches cgroup-sock-addr / sock_ops programs,
+	// which the kernel permits only on a cgroup v2 (unified) hierarchy. Warn
+	// early — before any image pull — when none is mounted. This is non-fatal:
+	// on a legacy cgroup v1 host the agent mounts a cgroup2 hierarchy itself at
+	// runtime (keploy grants it CAP_SYS_ADMIN for docker/compose runs), so we
+	// let the run proceed and surface a precise error only if that mount fails.
+	if !agent.CgroupV2Available() {
+		logger.Warn("cgroup v2 (unified hierarchy) not detected; keploy's eBPF agent requires it and will attempt to mount a cgroup2 hierarchy at runtime. If startup fails with 'cgroup2 not mounted', switch the host to unified cgroup v2 (boot with systemd.unified_cgroup_hierarchy=1) or mount a cgroup2 hierarchy before running keploy.")
+	}
 	return nil
 }

--- a/pkg/agent/cgroup_mount_linux.go
+++ b/pkg/agent/cgroup_mount_linux.go
@@ -1,0 +1,71 @@
+//go:build linux
+
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
+)
+
+// keployCgroupV2Mountpoint is the container-local path at which keploy mounts a
+// cgroup2 (unified) hierarchy when the host exposes none (legacy cgroup v1). It
+// is deliberately not under the bind-mounted /sys/fs/cgroup so the mount stays
+// private to the agent's mount namespace and never mutates host state.
+const keployCgroupV2Mountpoint = "/run/keploy/cgroupv2"
+
+// mountCgroupV2 mounts the kernel's unified cgroup v2 hierarchy at a
+// keploy-owned mount point and returns it. It is called only when no cgroup2
+// mount is already present (legacy cgroup v1 host).
+//
+// The mount is performed with mount(2) directly — no `mount` binary is spawned,
+// so the distroless agent image stays shell-/tool-free. It requires
+// CAP_SYS_ADMIN and an unconfined seccomp/AppArmor profile; both are granted to
+// the agent service only when the host is detected to lack cgroup v2 (see
+// GenerateKeployAgentService), keeping the agent least-privileged elsewhere.
+//
+// The mount is intentionally NOT unmounted on teardown:
+//   - In the containerized agent (cloud replay / docker) it lives in the
+//     container's mount namespace and is reclaimed automatically when the
+//     container exits, so there is no host mutation to undo.
+//   - In native mode it persists, but it is a benign, controller-less *view* of
+//     the kernel's always-present v2 hierarchy (as systemd itself keeps mounted
+//     at /sys/fs/cgroup/unified); /run is tmpfs so it clears on reboot. It is
+//     idempotent — a re-run finds it via findCgroupV2Mount and skips
+//     re-mounting, so mounts never accumulate — and leaving it avoids yanking
+//     the cgroup path out from under a concurrent keploy process that reused it.
+func mountCgroupV2(logger *zap.Logger) (string, error) {
+	logger.Info("no cgroup2 (unified) hierarchy is mounted; mounting one for eBPF hooks (host appears to use legacy cgroup v1)",
+		zap.String("mountpoint", keployCgroupV2Mountpoint))
+
+	if err := os.MkdirAll(keployCgroupV2Mountpoint, 0o755); err != nil {
+		return "", fmt.Errorf("cgroup2 not mounted and keploy could not create a mount point at %s: %w", keployCgroupV2Mountpoint, err)
+	}
+
+	if err := unix.Mount("none", keployCgroupV2Mountpoint, "cgroup2", 0, ""); err != nil {
+		switch {
+		case errors.Is(err, unix.EPERM):
+			return "", fmt.Errorf("cgroup2 not mounted and keploy could not mount it (%w): the host uses legacy cgroup v1 and the keploy-agent lacks the privileges to mount a cgroup2 hierarchy. Run the agent with CAP_SYS_ADMIN and an unconfined AppArmor profile, or switch the host to unified cgroup v2 (boot with systemd.unified_cgroup_hierarchy=1)", err)
+		case errors.Is(err, unix.ENODEV):
+			return "", fmt.Errorf("cgroup2 not mounted and this kernel provides no cgroup2 (unified) hierarchy (%w): a kernel with cgroup v2 support (>= 4.5) is required", err)
+		default:
+			return "", fmt.Errorf("cgroup2 not mounted and keploy failed to mount a cgroup2 hierarchy at %s: %w", keployCgroupV2Mountpoint, err)
+		}
+	}
+
+	// The mounted view is rooted at the mounting process's cgroup namespace
+	// root, so the eBPF cgroup hooks attach there. On a legacy cgroup v1 host —
+	// the only host that reaches this fallback — the v2 hierarchy carries no
+	// controller delegation, so every process (agent + app) sits at that root
+	// and a root attach captures them regardless of cgroup namespace. This does
+	// assume the agent runs under the host cgroup namespace (Docker's default on
+	// cgroup v1 hosts); if a non-default cgroupns=private is forced on a host
+	// that *does* delegate the v2 tree, the app may fall outside the attached
+	// subtree — the symptom is captured-nothing, so surface the assumption here.
+	logger.Info("mounted cgroup2 hierarchy for eBPF hooks (attaching at the host cgroup-namespace root)",
+		zap.String("mountpoint", keployCgroupV2Mountpoint))
+	return keployCgroupV2Mountpoint, nil
+}

--- a/pkg/agent/cgroup_mount_linux_test.go
+++ b/pkg/agent/cgroup_mount_linux_test.go
@@ -1,0 +1,77 @@
+//go:build linux && cgroupmount_integration
+
+// This integration test exercises the real mount(2) fallback that keploy uses
+// on a legacy cgroup v1 host. It needs root/CAP_SYS_ADMIN and is therefore
+// excluded from the normal `go test ./...` unit run by the cgroupmount_integration
+// build tag; the e2e-cgroup-v2-selfmount workflow builds it with that tag and
+// runs the resulting binary as root.
+
+package agent
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
+)
+
+// cgroup2SuperMagic is CGROUP2_SUPER_MAGIC from <linux/magic.h>; statfs reports
+// it for a genuine cgroup2 mount.
+const cgroup2SuperMagic = 0x63677270
+
+// TestCgroupV2SelfMount verifies the syscall self-mount path end to end:
+//   - mountCgroupV2 succeeds and returns the keploy mount point,
+//   - the mount point is a real cgroup2 filesystem (statfs magic + a readable
+//     cgroup.controllers file, both hallmarks of a cgroup2 root),
+//   - DetectCgroupPath is idempotent: with a cgroup2 mount now present it
+//     returns a path without erroring or stacking another mount.
+//
+// It runs on a cgroup v2 CI host too: mounting an additional view of the always
+// present kernel v2 hierarchy at a fresh path succeeds regardless of the host's
+// default cgroup mode, which is exactly the operation the legacy-v1 fallback
+// performs.
+func TestCgroupV2SelfMount(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root/CAP_SYS_ADMIN to mount cgroup2")
+	}
+
+	// Clean slate in case a previous run left the mount behind.
+	_ = unix.Unmount(keployCgroupV2Mountpoint, unix.MNT_DETACH)
+
+	path, err := mountCgroupV2(zap.NewNop())
+	if err != nil {
+		t.Fatalf("mountCgroupV2: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := unix.Unmount(keployCgroupV2Mountpoint, unix.MNT_DETACH); err != nil {
+			t.Logf("cleanup unmount %s: %v", keployCgroupV2Mountpoint, err)
+		}
+	})
+	if path != keployCgroupV2Mountpoint {
+		t.Fatalf("mountCgroupV2 returned %q, want %q", path, keployCgroupV2Mountpoint)
+	}
+
+	var st unix.Statfs_t
+	if err := unix.Statfs(path, &st); err != nil {
+		t.Fatalf("statfs(%s): %v", path, err)
+	}
+	if int64(st.Type) != cgroup2SuperMagic {
+		t.Fatalf("statfs type = %#x, want cgroup2 magic %#x — %s is not a cgroup2 mount", st.Type, cgroup2SuperMagic, path)
+	}
+	if _, err := os.ReadFile(path + "/cgroup.controllers"); err != nil {
+		t.Fatalf("reading cgroup.controllers from %s (hallmark of a cgroup2 root): %v", path, err)
+	}
+
+	// Idempotency: a cgroup2 mount now exists, so DetectCgroupPath must find one
+	// and return without error. (On a v2 CI host it returns the host's
+	// /sys/fs/cgroup, scanned before our /run mount — either way, no re-mount and
+	// no error, which is the property under test.)
+	found, err := DetectCgroupPath(zap.NewNop())
+	if err != nil {
+		t.Fatalf("DetectCgroupPath after mount: %v", err)
+	}
+	if found == "" {
+		t.Fatal("DetectCgroupPath returned an empty path with a cgroup2 mount present")
+	}
+}

--- a/pkg/agent/cgroup_mount_others.go
+++ b/pkg/agent/cgroup_mount_others.go
@@ -1,0 +1,15 @@
+//go:build !linux
+
+package agent
+
+import (
+	"errors"
+
+	"go.uber.org/zap"
+)
+
+// mountCgroupV2 is a stub on non-Linux platforms, where keploy's eBPF
+// interception (and therefore cgroup v2) does not apply.
+func mountCgroupV2(_ *zap.Logger) (string, error) {
+	return "", errors.New("cgroup2 not mounted: mounting a cgroup2 hierarchy is only supported on Linux")
+}

--- a/pkg/agent/utils.go
+++ b/pkg/agent/utils.go
@@ -3,39 +3,73 @@ package agent
 import (
 	"bufio"
 	"context"
-	"errors"
+	"io"
 	"os"
 	"strings"
 
 	"go.keploy.io/server/v3/pkg/models"
-	"go.keploy.io/server/v3/utils"
 	"go.uber.org/zap"
 )
 
-// detectCgroupPath returns the first-found mount point of type cgroup2
-// and stores it in the cgroupPath global variable.
+// DetectCgroupPath returns the mount point of a cgroup2 (unified) hierarchy,
+// mounting one itself if the host exposes none.
+//
+// keploy's network interception attaches cgroup-sock-addr / sock_ops eBPF
+// programs, which the Linux kernel permits only on a cgroup **v2** hierarchy
+// (cgroup v1 has no equivalent attach point). On a native v2 host — or when the
+// agent's `-v /sys/fs/cgroup:/sys/fs/cgroup` bind-mount exposes a v2/hybrid
+// host's hierarchy — that mount is found and returned as-is.
+//
+// On a pure cgroup v1 host no cgroup2 mount is visible. Because the single
+// kernel-wide v2 hierarchy always exists (kernel >= 4.5) and the agent runs
+// under cgroupns=host on v1 hosts, keploy mounts a view of it itself (see
+// mountCgroupV2), yielding the same host-rooted attach point it gets on a v2
+// host. Interception stays scoped to the target app by the pid-namespace filter
+// in the BPF programs, not by the cgroup subtree, so a host-rooted attach is
+// safe on shared nodes.
 func DetectCgroupPath(logger *zap.Logger) (string, error) {
-	f, err := os.Open("/proc/mounts")
+	path, err := findCgroupV2Mount("/proc/mounts")
 	if err != nil {
 		return "", err
 	}
-	defer func() {
-		err := f.Close()
-		if err != nil {
-			utils.LogError(logger, err, "failed to close /proc/mounts file")
-		}
-	}()
+	if path != "" {
+		return path, nil
+	}
+	return mountCgroupV2(logger)
+}
 
-	scanner := bufio.NewScanner(f)
+// CgroupV2Available reports whether a cgroup2 (unified) hierarchy is already
+// mounted, without attempting to mount one. The preflight check
+// (cli/provider.isCompatible) uses it to warn early when cgroup v2 is missing.
+// Compose generation makes the analogous decision via the docker package's own
+// hostCgroupV2Available, which fails toward the opposite default (see there).
+func CgroupV2Available() bool {
+	path, err := findCgroupV2Mount("/proc/mounts")
+	return err == nil && path != ""
+}
+
+// findCgroupV2Mount scans a mounts table file (e.g. /proc/mounts) and returns
+// the mount point of the first cgroup2 entry, or "" if none is present.
+func findCgroupV2Mount(mountsFile string) (string, error) {
+	f, err := os.Open(mountsFile)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+	return scanCgroupV2Mount(f), nil
+}
+
+// scanCgroupV2Mount is the pure, testable core of findCgroupV2Mount.
+func scanCgroupV2Mount(r io.Reader) string {
+	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
-		// example fields: cgroup2 /sys/fs/cgroup/unified cgroup2 rw,nosuid,nodev,noexec,relatime 0 0
+		// e.g.: cgroup2 /sys/fs/cgroup cgroup2 rw,nosuid,nodev,noexec,relatime 0 0
 		fields := strings.Split(scanner.Text(), " ")
 		if len(fields) >= 3 && fields[2] == "cgroup2" {
-			return fields[1], nil
+			return fields[1]
 		}
 	}
-
-	return "", errors.New("cgroup2 not mounted")
+	return ""
 }
 
 func GetPortToSendToKernel(_ context.Context, rules []models.BypassRule) []uint {

--- a/pkg/agent/utils_test.go
+++ b/pkg/agent/utils_test.go
@@ -1,0 +1,56 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScanCgroupV2Mount(t *testing.T) {
+	cases := []struct {
+		name    string
+		mounts  string
+		wantMnt string
+	}{
+		{
+			name: "pure v2 (unified) host",
+			mounts: "proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0\n" +
+				"cgroup2 /sys/fs/cgroup cgroup2 rw,nosuid,nodev,noexec,relatime,nsdelegate 0 0\n",
+			wantMnt: "/sys/fs/cgroup",
+		},
+		{
+			name: "hybrid host: v1 controllers + v2 unified subtree",
+			mounts: "tmpfs /sys/fs/cgroup tmpfs ro,nosuid,nodev,noexec 0 0\n" +
+				"cgroup2 /sys/fs/cgroup/unified cgroup2 rw,nosuid,nodev,noexec,relatime 0 0\n" +
+				"cgroup /sys/fs/cgroup/memory cgroup rw,nosuid,nodev,noexec,relatime,memory 0 0\n",
+			wantMnt: "/sys/fs/cgroup/unified",
+		},
+		{
+			name: "pure legacy v1 host: no cgroup2 anywhere",
+			mounts: "tmpfs /sys/fs/cgroup tmpfs ro,nosuid,nodev,noexec 0 0\n" +
+				"cgroup /sys/fs/cgroup/memory cgroup rw,nosuid,nodev,noexec,relatime,memory 0 0\n" +
+				"cgroup /sys/fs/cgroup/cpu,cpuacct cgroup rw,nosuid,nodev,noexec,relatime,cpu,cpuacct 0 0\n",
+			wantMnt: "",
+		},
+		{
+			name:    "empty mounts table",
+			mounts:  "",
+			wantMnt: "",
+		},
+		{
+			name: "cgroup2 token must be the fstype field, not the source name",
+			// A v1 source literally named "cgroup2" with fstype "cgroup" must
+			// not be mistaken for a v2 mount.
+			mounts:  "cgroup2 /sys/fs/cgroup/net cgroup rw,net_cls 0 0\n",
+			wantMnt: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := scanCgroupV2Mount(strings.NewReader(tc.mounts))
+			if got != tc.wantMnt {
+				t.Errorf("scanCgroupV2Mount() = %q, want %q", got, tc.wantMnt)
+			}
+		})
+	}
+}

--- a/pkg/platform/docker/cgroup.go
+++ b/pkg/platform/docker/cgroup.go
@@ -1,0 +1,59 @@
+package docker
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// cgroupV2AvailableOnHost reports whether the host generating the compose
+// already has a cgroup2 hierarchy mounted. It is a package var so tests can
+// exercise both the v1 and v2 branches of GenerateKeployAgentService without
+// depending on the test host's /proc/mounts.
+var cgroupV2AvailableOnHost = hostCgroupV2Available
+
+// hostCgroupV2Available reports whether a cgroup2 (unified) hierarchy is mounted
+// on the host generating the compose. On a pure cgroup v1 host none is present,
+// so the keploy-agent must mount one itself at runtime (see
+// agent.DetectCgroupPath) — which needs CAP_SYS_ADMIN and an unconfined
+// seccomp/AppArmor profile. Those are granted to the agent service only in that
+// case, so the agent stays least-privileged on the common cgroup v2 host.
+func hostCgroupV2Available() bool {
+	f, err := os.Open("/proc/mounts")
+	if err != nil {
+		// /proc/mounts is unreadable or absent (e.g. the CLI host is macOS /
+		// Windows, where Docker runs in a Linux VM). Assume v2 and do not
+		// broaden the agent's privileges; the agent's own runtime check emits a
+		// precise error if a mount turns out to be required.
+		return true
+	}
+	defer func() { _ = f.Close() }()
+	return scanForCgroupV2(f)
+}
+
+// scanForCgroupV2 is the pure, testable core of hostCgroupV2Available.
+func scanForCgroupV2(r io.Reader) bool {
+	sc := bufio.NewScanner(r)
+	for sc.Scan() {
+		fields := strings.Split(sc.Text(), " ")
+		if len(fields) >= 3 && fields[2] == "cgroup2" {
+			return true
+		}
+	}
+	return false
+}
+
+// appendCapIfMissing appends a cap_add entry unless the capability is already
+// present, so a host-specific grant (e.g. SYS_ADMIN for the cgroup2 mount) does
+// not duplicate one added for another reason (e.g. the channel-binding shim).
+func appendCapIfMissing(caps []*yaml.Node, name, comment string) []*yaml.Node {
+	for _, c := range caps {
+		if c.Kind == yaml.ScalarNode && c.Value == name {
+			return caps
+		}
+	}
+	return append(caps, &yaml.Node{Kind: yaml.ScalarNode, Value: name, LineComment: comment})
+}

--- a/pkg/platform/docker/cgroup_test.go
+++ b/pkg/platform/docker/cgroup_test.go
@@ -1,0 +1,136 @@
+package docker
+
+import (
+	"strings"
+	"testing"
+
+	"go.keploy.io/server/v3/config"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+)
+
+func TestScanForCgroupV2(t *testing.T) {
+	cases := []struct {
+		name   string
+		mounts string
+		want   bool
+	}{
+		{
+			name:   "v2 present",
+			mounts: "cgroup2 /sys/fs/cgroup cgroup2 rw,nosuid,nodev,noexec,relatime,nsdelegate 0 0\n",
+			want:   true,
+		},
+		{
+			name:   "v2 present in a hybrid layout",
+			mounts: "tmpfs /sys/fs/cgroup tmpfs ro 0 0\ncgroup2 /sys/fs/cgroup/unified cgroup2 rw 0 0\n",
+			want:   true,
+		},
+		{
+			name:   "legacy v1 only",
+			mounts: "tmpfs /sys/fs/cgroup tmpfs ro 0 0\ncgroup /sys/fs/cgroup/memory cgroup rw,memory 0 0\n",
+			want:   false,
+		},
+		{
+			name:   "empty",
+			mounts: "",
+			want:   false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := scanForCgroupV2(strings.NewReader(tc.mounts)); got != tc.want {
+				t.Errorf("scanForCgroupV2() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func capValues(caps []*yaml.Node) []string {
+	out := make([]string, 0, len(caps))
+	for _, c := range caps {
+		out = append(out, c.Value)
+	}
+	return out
+}
+
+// TestGenerateKeployAgentService_CgroupV2Mount asserts the agent service is
+// granted exactly the extra privileges it needs to self-mount a cgroup2
+// hierarchy on a legacy cgroup v1 host, and none of them on a cgroup v2 host.
+//
+// Not parallel: it toggles the package-level cgroupV2AvailableOnHost that
+// GenerateKeployAgentService reads. Go runs non-parallel tests to completion
+// before any t.Parallel() test resumes, so the save/restore is race-free w.r.t.
+// the other generator tests in this package.
+func TestGenerateKeployAgentService_CgroupV2Mount(t *testing.T) {
+	orig := cgroupV2AvailableOnHost
+	defer func() { cgroupV2AvailableOnHost = orig }()
+
+	newSvc := func() *yaml.Node {
+		t.Helper()
+		node, err := (&Impl{
+			logger: zap.NewNop(),
+			conf:   &config.Config{},
+		}).GenerateKeployAgentService(models.SetupOptions{
+			KeployContainer: "keploy-agent",
+			AgentPort:       16789,
+			ProxyPort:       16790,
+			DnsPort:         16791,
+			Mode:            models.MODE_TEST,
+		})
+		if err != nil {
+			t.Fatalf("GenerateKeployAgentService: %v", err)
+		}
+		return node
+	}
+
+	// Legacy cgroup v1 host: SYS_ADMIN + unconfined seccomp/AppArmor so the
+	// agent can mount(2) a cgroup2 hierarchy itself.
+	cgroupV2AvailableOnHost = func() bool { return false }
+	v1 := newSvc()
+	if caps := mappingValue(v1, "cap_add"); !sequenceContains(caps, "SYS_ADMIN") {
+		t.Errorf("v1 host: expected SYS_ADMIN in cap_add, got %s", formatSequence(caps))
+	}
+	secOpt := mappingValue(v1, "security_opt")
+	// AppArmor must be unconfined (its default profile denies mount); seccomp is
+	// NOT relaxed — the default profile already permits mount(2) with SYS_ADMIN.
+	if !sequenceContains(secOpt, "apparmor:unconfined") {
+		t.Errorf("v1 host: expected apparmor:unconfined, got %s", formatSequence(secOpt))
+	}
+	if sequenceContains(secOpt, "seccomp:unconfined") {
+		t.Errorf("v1 host: seccomp:unconfined is an over-grant (SYS_ADMIN already unblocks mount in default seccomp); got %s", formatSequence(secOpt))
+	}
+
+	// cgroup v2 host: least-privilege — no cgroup-mount SYS_ADMIN, no security_opt.
+	cgroupV2AvailableOnHost = func() bool { return true }
+	v2 := newSvc()
+	if sequenceContains(mappingValue(v2, "cap_add"), "SYS_ADMIN") {
+		t.Errorf("v2 host: SYS_ADMIN must not be granted for the cgroup mount")
+	}
+	if so := mappingValue(v2, "security_opt"); so != nil {
+		t.Errorf("v2 host: no security_opt should be added, got %s", formatSequence(so))
+	}
+}
+
+func TestAppendCapIfMissing(t *testing.T) {
+	base := []*yaml.Node{
+		{Kind: yaml.ScalarNode, Value: "BPF"},
+		{Kind: yaml.ScalarNode, Value: "SYS_ADMIN"},
+	}
+
+	// Already present -> unchanged (no duplicate).
+	got := appendCapIfMissing(base, "SYS_ADMIN", "dup")
+	if vals := capValues(got); len(vals) != 2 {
+		t.Errorf("appendCapIfMissing added a duplicate SYS_ADMIN: %v", vals)
+	}
+
+	// Missing -> appended once with the comment.
+	got = appendCapIfMissing(base, "PERFMON", "needed")
+	vals := capValues(got)
+	if len(vals) != 3 || vals[2] != "PERFMON" {
+		t.Fatalf("appendCapIfMissing did not append PERFMON: %v", vals)
+	}
+	if got[2].LineComment != "needed" {
+		t.Errorf("appended cap missing comment: %q", got[2].LineComment)
+	}
+}

--- a/pkg/platform/docker/docker.go
+++ b/pkg/platform/docker/docker.go
@@ -661,8 +661,19 @@ func (idc *Impl) GenerateKeployAgentService(opts models.SetupOptions) (*yaml.Nod
 		// tls-server-end-point digest with bpf_probe_write_user, which the
 		// verifier gates behind CAP_SYS_ADMIN — CAP_BPF/CAP_PERFMON alone are
 		// insufficient. Only grant it when the shim is explicitly enabled.
-		capAdd = append(capAdd, &yaml.Node{Kind: yaml.ScalarNode, Value: "SYS_ADMIN",
-			LineComment: "required by the channel-binding shim (bpf_probe_write_user)"})
+		capAdd = appendCapIfMissing(capAdd, "SYS_ADMIN",
+			"required by the channel-binding shim (bpf_probe_write_user)")
+	}
+
+	// On a host without a cgroup2 (unified) hierarchy (legacy cgroup v1), the
+	// agent mounts one itself at runtime for its eBPF cgroup hooks
+	// (agent.DetectCgroupPath). mount(2) needs CAP_SYS_ADMIN and an unconfined
+	// seccomp/AppArmor profile, so grant them — but only in that case, to keep
+	// the agent least-privileged on the common cgroup v2 host.
+	needsCgroupV2Mount := !cgroupV2AvailableOnHost()
+	if needsCgroupV2Mount {
+		capAdd = appendCapIfMissing(capAdd, "SYS_ADMIN",
+			"required to mount a cgroup2 hierarchy for eBPF hooks (host uses legacy cgroup v1)")
 	}
 
 	// Create the service YAML node structure
@@ -682,6 +693,20 @@ func (idc *Impl) GenerateKeployAgentService(opts models.SetupOptions) (*yaml.Nod
 				"Review and allow only what your security policy permits."},
 			{Kind: yaml.SequenceNode, Content: capAdd},
 		},
+	}
+
+	if needsCgroupV2Mount {
+		// Docker's default seccomp profile already permits mount(2) once
+		// CAP_SYS_ADMIN is granted (the mount rule includes CAP_SYS_ADMIN), so
+		// seccomp need not be relaxed. Its default AppArmor profile, however,
+		// denies mount outright, so AppArmor must be unconfined for the agent to
+		// mount a cgroup2 hierarchy on a legacy cgroup v1 host.
+		serviceNode.Content = append(serviceNode.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Value: "security_opt", HeadComment: "Required to mount a cgroup2 hierarchy for eBPF hooks on a legacy cgroup v1 host."},
+			&yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{
+				{Kind: yaml.ScalarNode, Value: "apparmor:unconfined"},
+			}},
+		)
 	}
 
 	// Add environment variables


### PR DESCRIPTION
## Problem

On a pure/legacy **cgroup v1** host — e.g. Debian 11 in a privileged docker-in-docker CI pod — `keploy cloud replay` aborts before it ever runs the app:

```
Keploy(agent): failed to detect the cgroup path {"error": "cgroup2 not mounted"}
Keploy(agent): failed to load hooks {"error": "cgroup2 not mounted"}
dependency keploy-agent failed to start
```

keploy's network interception attaches cgroup-sock-addr / sock_ops eBPF programs, which the Linux kernel permits **only on a cgroup v2 (unified) hierarchy**. `DetectCgroupPath` scans `/proc/mounts` for a `cgroup2` mount and, finding none on a v1 host, fails hard.

## Fix

When no cgroup2 mount is visible, the agent now mounts one itself via the **`mount(2)` syscall** — no `mount` binary is spawned, keeping the distroless agent image shell-/tool-free:

```go
unix.Mount("none", "/run/keploy/cgroupv2", "cgroup2", 0, "")
```

The single kernel-wide v2 hierarchy always exists (kernel ≥ 4.5). Under `cgroupns=host` (Docker's default on cgroup v1 hosts) the mount is **host-rooted** — the exact attach point the agent already gets on a v2 host through the `-v /sys/fs/cgroup` bind-mount. On a legacy host the v2 tree carries no controller delegation, so every process sits at that root and a root attach captures the app regardless of cgroup namespace.

**Interception stays scoped to the target app by the pid-namespace filter in the BPF programs** (`AgentInfo.KeployAgentInode/Dev` from `/proc/self/ns/pid`), *not* by the cgroup subtree — the app joins the agent's pid-ns via `pid: service:keploy-agent`. So a host-rooted attach does not touch unrelated workloads on a shared node, and this reproduces the existing v2 attach model rather than widening it.

## Privileges (least-privilege gated)

`mount(2)` needs `CAP_SYS_ADMIN` and an unconfined AppArmor profile (Docker's default AppArmor denies mount; its default **seccomp already permits mount once CAP_SYS_ADMIN is held**, so seccomp is deliberately *not* relaxed). `GenerateKeployAgentService` grants exactly `SYS_ADMIN` + `security_opt: [apparmor:unconfined]` **only when the host lacks cgroup2** — the common v2 host is unchanged and stays least-privileged.

A non-fatal preflight warning (`cli/provider/compat_linux.go`, replacing a stale `// TODO`) surfaces the situation early, before the image pull.

## Scope

- OSS-only change; no exported API changed. `enterprise` builds unchanged against it (cloud replay reuses `GenerateKeployAgentService`).
- The mount is intentionally **not** unmounted: in a container it is reclaimed on exit; in native mode it is a benign, controller-less view of the always-present v2 hierarchy (as systemd keeps at `/sys/fs/cgroup/unified`), `/run` is tmpfs, and it is idempotent — a re-run finds it via `/proc/mounts` and never stacks a second mount.

## Testing

- Pure unit tests for the `/proc/mounts` scanner (v2 / hybrid / legacy / edge cases) and both privilege branches of the agent-service generator.
- A **root-only integration test** (build tag `cgroupmount_integration`, excluded from the normal `go test ./...`) that performs a real `mount(2)`, verifies the mount is a genuine cgroup2 fs (`statfs` magic `0x63677270` + readable `cgroup.controllers`), and asserts idempotency.
- New workflow **`.github/workflows/e2e-cgroup-v2-selfmount.yml`** builds the tagged test and runs it as root, with a guard that fails loudly if the test ever stops executing.
- `go build ./...`, `go vet`, `go test -race`, gofmt — all green; Windows/darwin cross-compile of the linux/non-linux split verified.

## Follow-up (separate, enterprise repo)

A full end-to-end guard that runs `cloud replay` under a DinD daemon presenting a **legacy cgroup view** (asserting the self-mount path drives a complete replay) belongs in the enterprise `selfhosted-cloud-replay-e2e.yml`, and will land with the enterprise `go.keploy.io/server/v3` pin bump to the release carrying this change.
