### PR TITLE
feat(async): shared env transport for async-egress lanes

### DIFF
--- a/pkg/models/asynclanes_env.go
+++ b/pkg/models/asynclanes_env.go
@@ -18,17 +18,20 @@ import (
 const AsyncLanesEnvVar = "KEPLOY_ASYNC_LANES"
 
 // EncodeAsyncLanesEnv returns the base64-JSON AsyncLanesEnvVar value for lanes,
-// or "" when there are none — so a producer adds no env entry for a non-async
-// recording and the consumer leaves async off.
-func EncodeAsyncLanesEnv(lanes []AsyncLane) string {
+// or ("", nil) when there are none — so a producer adds no env entry for a
+// non-async recording and the consumer leaves async off. It surfaces a marshal
+// failure (wrapped with the env-var name) rather than swallowing it, symmetric
+// with DecodeAsyncLanesEnv, so a producer never silently ships a recording with
+// async disabled when encoding actually failed.
+func EncodeAsyncLanesEnv(lanes []AsyncLane) (string, error) {
 	if len(lanes) == 0 {
-		return ""
+		return "", nil
 	}
 	b, err := json.Marshal(lanes)
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("marshal %s: %w", AsyncLanesEnvVar, err)
 	}
-	return base64.StdEncoding.EncodeToString(b)
+	return base64.StdEncoding.EncodeToString(b), nil
 }
 
 // DecodeAsyncLanesEnv decodes an AsyncLanesEnvVar value into lanes. Empty input

--- a/pkg/models/asynclanes_env.go
+++ b/pkg/models/asynclanes_env.go
@@ -1,0 +1,49 @@
+package models
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+)
+
+// AsyncLanesEnvVar is the agent env var that carries a recording's async-egress
+// lanes (base64-encoded JSON of []AsyncLane). It is the wire contract between a
+// config producer that HAS the lanes (e.g. the k8s-proxy, from its record API)
+// and an in-cluster agent that has no keploy.yml and reads all of its config
+// from env vars into config.Config.Async.Lanes at startup.
+//
+// Both ends MUST use this const and the Encode/Decode pair below so the
+// contract (env-var name + base64-JSON shape) lives in exactly one place and
+// cannot silently drift between the producing and consuming services.
+const AsyncLanesEnvVar = "KEPLOY_ASYNC_LANES"
+
+// EncodeAsyncLanesEnv returns the base64-JSON AsyncLanesEnvVar value for lanes,
+// or "" when there are none — so a producer adds no env entry for a non-async
+// recording and the consumer leaves async off.
+func EncodeAsyncLanesEnv(lanes []AsyncLane) string {
+	if len(lanes) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(lanes)
+	if err != nil {
+		return ""
+	}
+	return base64.StdEncoding.EncodeToString(b)
+}
+
+// DecodeAsyncLanesEnv decodes an AsyncLanesEnvVar value into lanes. Empty input
+// yields nil lanes with no error (async simply stays off).
+func DecodeAsyncLanesEnv(s string) ([]AsyncLane, error) {
+	if s == "" {
+		return nil, nil
+	}
+	raw, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s: %w", AsyncLanesEnvVar, err)
+	}
+	var lanes []AsyncLane
+	if err := json.Unmarshal(raw, &lanes); err != nil {
+		return nil, fmt.Errorf("unmarshal %s: %w", AsyncLanesEnvVar, err)
+	}
+	return lanes, nil
+}

--- a/pkg/models/asynclanes_env_test.go
+++ b/pkg/models/asynclanes_env_test.go
@@ -3,11 +3,11 @@ package models
 import "testing"
 
 func TestEncodeAsyncLanesEnvEmpty(t *testing.T) {
-	if got := EncodeAsyncLanesEnv(nil); got != "" {
-		t.Fatalf("nil lanes must encode to empty, got %q", got)
+	if got, err := EncodeAsyncLanesEnv(nil); got != "" || err != nil {
+		t.Fatalf("nil lanes must encode to (\"\", nil), got (%q, %v)", got, err)
 	}
-	if got := EncodeAsyncLanesEnv([]AsyncLane{}); got != "" {
-		t.Fatalf("empty lanes must encode to empty, got %q", got)
+	if got, err := EncodeAsyncLanesEnv([]AsyncLane{}); got != "" || err != nil {
+		t.Fatalf("empty lanes must encode to (\"\", nil), got (%q, %v)", got, err)
 	}
 }
 
@@ -26,7 +26,10 @@ func TestAsyncLanesEnvRoundTrip(t *testing.T) {
 		MatchQuery:     map[string]string{"watch": "true"},
 		VolatileParams: []string{"version"},
 	}}
-	enc := EncodeAsyncLanesEnv(in)
+	enc, err := EncodeAsyncLanesEnv(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
 	if enc == "" {
 		t.Fatal("non-empty lanes must encode to a non-empty value")
 	}

--- a/pkg/models/asynclanes_env_test.go
+++ b/pkg/models/asynclanes_env_test.go
@@ -1,0 +1,49 @@
+package models
+
+import "testing"
+
+func TestEncodeAsyncLanesEnvEmpty(t *testing.T) {
+	if got := EncodeAsyncLanesEnv(nil); got != "" {
+		t.Fatalf("nil lanes must encode to empty, got %q", got)
+	}
+	if got := EncodeAsyncLanesEnv([]AsyncLane{}); got != "" {
+		t.Fatalf("empty lanes must encode to empty, got %q", got)
+	}
+}
+
+func TestDecodeAsyncLanesEnvEmpty(t *testing.T) {
+	lanes, err := DecodeAsyncLanesEnv("")
+	if err != nil || lanes != nil {
+		t.Fatalf("empty input must decode to (nil, nil), got (%v, %v)", lanes, err)
+	}
+}
+
+func TestAsyncLanesEnvRoundTrip(t *testing.T) {
+	in := []AsyncLane{{
+		Name:           "config-watch",
+		Type:           "httpPoll",
+		Match:          map[string]string{"pathRegex": "^/v1/buckets/app-config$"},
+		MatchQuery:     map[string]string{"watch": "true"},
+		VolatileParams: []string{"version"},
+	}}
+	enc := EncodeAsyncLanesEnv(in)
+	if enc == "" {
+		t.Fatal("non-empty lanes must encode to a non-empty value")
+	}
+	out, err := DecodeAsyncLanesEnv(enc)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out) != 1 || out[0].Type != "httpPoll" || out[0].Name != "config-watch" ||
+		out[0].Match["pathRegex"] != "^/v1/buckets/app-config$" ||
+		out[0].MatchQuery["watch"] != "true" || len(out[0].VolatileParams) != 1 ||
+		out[0].VolatileParams[0] != "version" {
+		t.Fatalf("round-trip lost lane data: %+v", out)
+	}
+}
+
+func TestDecodeAsyncLanesEnvBadInput(t *testing.T) {
+	if _, err := DecodeAsyncLanesEnv("!!!not-base64!!!"); err == nil {
+		t.Fatal("invalid base64 must return an error")
+	}
+}


### PR DESCRIPTION
## What

Adds the single home for the async-egress **lane env-transport wire contract** in `pkg/models`:

- `models.AsyncLanesEnvVar` — the agent env var name (`KEPLOY_ASYNC_LANES`)
- `models.EncodeAsyncLanesEnv([]AsyncLane) string` — base64-JSON encode (empty → "")
- `models.DecodeAsyncLanesEnv(string) ([]AsyncLane, error)` — decode (empty → nil, no error)

## Why

The async-egress engine (#4368) reads its lanes from `config.Config.Async.Lanes`. In-cluster there is no `keploy.yml`, so a config **producer** that has the lanes (the k8s-proxy, from its record API) hands them to the **consumer** agent (which reads all config from env) via this env var.

Today that contract is **hand-copied on both ends** — the k8s-proxy defines its own `AsyncLanesEnvVar` + `EncodeAsyncLanesEnv`, and the enterprise agent its own const + `parseAsyncLanesB64`. Both hardcode the same env-var name and each implements half the base64-JSON codec; they agree only by convention and can silently drift (a renamed var or a changed shape has no compiler to catch it).

This moves the contract into OSS `pkg/models` (where `AsyncLane` already lives and both services already import), so the producer and consumer share **one** source of truth. Follow-ups in keploy/k8s-proxy and keploy/enterprise switch both ends to these helpers and delete their local copies.

## Tests

`asynclanes_env_test.go` — empty encode/decode, round-trip fidelity (incl. httpPoll lane + matchQuery + volatileParams), and bad-base64 decode error.

## Notes

- Additive, zero behavior change to any existing path — no current caller uses these yet (the consuming PRs land after this).
- Depends on nothing; #4368 (the async engine) is already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Signed-off-by: Aditya Sharma <aditya282003@gmail.com>