### PR TITLE
fix: grant cloud-replay agent cgroup2-mount privileges regardless of host detection

### DIFF
--- a/pkg/platform/docker/cgroup_test.go
+++ b/pkg/platform/docker/cgroup_test.go
@@ -66,28 +66,25 @@ func TestGenerateKeployAgentService_CgroupV2Mount(t *testing.T) {
 	orig := cgroupV2AvailableOnHost
 	defer func() { cgroupV2AvailableOnHost = orig }()
 
-	newSvc := func() *yaml.Node {
+	newSvc := func(opts models.SetupOptions) *yaml.Node {
 		t.Helper()
+		opts.KeployContainer = "keploy-agent"
+		opts.AgentPort, opts.ProxyPort, opts.DnsPort = 16789, 16790, 16791
+		opts.Mode = models.MODE_TEST
 		node, err := (&Impl{
 			logger: zap.NewNop(),
 			conf:   &config.Config{},
-		}).GenerateKeployAgentService(models.SetupOptions{
-			KeployContainer: "keploy-agent",
-			AgentPort:       16789,
-			ProxyPort:       16790,
-			DnsPort:         16791,
-			Mode:            models.MODE_TEST,
-		})
+		}).GenerateKeployAgentService(opts)
 		if err != nil {
 			t.Fatalf("GenerateKeployAgentService: %v", err)
 		}
 		return node
 	}
 
-	// Legacy cgroup v1 host: SYS_ADMIN + unconfined seccomp/AppArmor so the
-	// agent can mount(2) a cgroup2 hierarchy itself.
+	// Legacy cgroup v1 host: SYS_ADMIN + unconfined AppArmor so the agent can
+	// mount(2) a cgroup2 hierarchy itself.
 	cgroupV2AvailableOnHost = func() bool { return false }
-	v1 := newSvc()
+	v1 := newSvc(models.SetupOptions{})
 	if caps := mappingValue(v1, "cap_add"); !sequenceContains(caps, "SYS_ADMIN") {
 		t.Errorf("v1 host: expected SYS_ADMIN in cap_add, got %s", formatSequence(caps))
 	}
@@ -101,14 +98,34 @@ func TestGenerateKeployAgentService_CgroupV2Mount(t *testing.T) {
 		t.Errorf("v1 host: seccomp:unconfined is an over-grant (SYS_ADMIN already unblocks mount in default seccomp); got %s", formatSequence(secOpt))
 	}
 
-	// cgroup v2 host: least-privilege — no cgroup-mount SYS_ADMIN, no security_opt.
+	// Normal file-based docker on a cgroup v2 host: least-privilege — no
+	// cgroup-mount SYS_ADMIN, no security_opt (this process and the agent share
+	// the same cgroup view, so detection is reliable).
 	cgroupV2AvailableOnHost = func() bool { return true }
-	v2 := newSvc()
+	v2 := newSvc(models.SetupOptions{})
 	if sequenceContains(mappingValue(v2, "cap_add"), "SYS_ADMIN") {
 		t.Errorf("v2 host: SYS_ADMIN must not be granted for the cgroup mount")
 	}
 	if so := mappingValue(v2, "security_opt"); so != nil {
 		t.Errorf("v2 host: no security_opt should be added, got %s", formatSequence(so))
+	}
+
+	// Cloud replay (in-memory compose) on a host that reports cgroup v2: the
+	// grant must STILL fire, because cloud replay runs in a nested/DinD
+	// environment where this process's cgroup view (the pod) can differ from the
+	// agent container's, so cgroupV2AvailableOnHost() cannot rule out a
+	// self-mount. Skipping the grant here is what left the agent with EPERM.
+	cgroupV2AvailableOnHost = func() bool { return true }
+	cloud := newSvc(models.SetupOptions{InMemoryCompose: []byte("services: {}\n")})
+	if caps := mappingValue(cloud, "cap_add"); !sequenceContains(caps, "SYS_ADMIN") {
+		t.Errorf("cloud replay: expected SYS_ADMIN even when host reports cgroup v2, got %s", formatSequence(caps))
+	}
+	cloudSecOpt := mappingValue(cloud, "security_opt")
+	if !sequenceContains(cloudSecOpt, "apparmor:unconfined") {
+		t.Errorf("cloud replay: expected apparmor:unconfined even when host reports cgroup v2, got %s", formatSequence(cloudSecOpt))
+	}
+	if sequenceContains(cloudSecOpt, "seccomp:unconfined") {
+		t.Errorf("cloud replay: seccomp:unconfined is an over-grant (SYS_ADMIN already unblocks mount in default seccomp); got %s", formatSequence(cloudSecOpt))
 	}
 }
 

--- a/pkg/platform/docker/docker.go
+++ b/pkg/platform/docker/docker.go
@@ -665,15 +665,23 @@ func (idc *Impl) GenerateKeployAgentService(opts models.SetupOptions) (*yaml.Nod
 			"required by the channel-binding shim (bpf_probe_write_user)")
 	}
 
-	// On a host without a cgroup2 (unified) hierarchy (legacy cgroup v1), the
-	// agent mounts one itself at runtime for its eBPF cgroup hooks
-	// (agent.DetectCgroupPath). mount(2) needs CAP_SYS_ADMIN and an unconfined
-	// seccomp/AppArmor profile, so grant them — but only in that case, to keep
-	// the agent least-privileged on the common cgroup v2 host.
-	needsCgroupV2Mount := !cgroupV2AvailableOnHost()
-	if needsCgroupV2Mount {
+	// The agent self-mounts a cgroup2 (unified) hierarchy at runtime for its
+	// eBPF cgroup hooks (agent.DetectCgroupPath) when the host exposes none;
+	// mount(2) needs CAP_SYS_ADMIN and an unconfined AppArmor profile. Grant
+	// those when either:
+	//   - the compose-generating host itself lacks cgroup2 (legacy cgroup v1), or
+	//   - this is the in-memory (cloud replay) path: it runs in a nested / DinD
+	//     environment where THIS process's cgroup view (the pod) can differ from
+	//     the agent container's — the pod may see a cgroup2 mount that the agent
+	//     does not inherit — so cgroupV2AvailableOnHost() cannot reliably predict
+	//     whether the agent will need to self-mount. Skipping the grant there
+	//     leaves the agent unable to mount and it fails with EPERM.
+	// Otherwise (normal file-based docker on a cgroup v2 host, where this process
+	// and the agent share the same cgroup view) keep the agent least-privileged.
+	grantCgroupMountPrivileges := !cgroupV2AvailableOnHost() || len(opts.InMemoryCompose) > 0
+	if grantCgroupMountPrivileges {
 		capAdd = appendCapIfMissing(capAdd, "SYS_ADMIN",
-			"required to mount a cgroup2 hierarchy for eBPF hooks (host uses legacy cgroup v1)")
+			"lets the agent mount a cgroup2 hierarchy for eBPF hooks if the host has none (legacy cgroup v1, or cloud replay's nested/DinD env)")
 	}
 
 	// Create the service YAML node structure
@@ -695,14 +703,16 @@ func (idc *Impl) GenerateKeployAgentService(opts models.SetupOptions) (*yaml.Nod
 		},
 	}
 
-	if needsCgroupV2Mount {
+	if grantCgroupMountPrivileges {
 		// Docker's default seccomp profile already permits mount(2) once
 		// CAP_SYS_ADMIN is granted (the mount rule includes CAP_SYS_ADMIN), so
 		// seccomp need not be relaxed. Its default AppArmor profile, however,
 		// denies mount outright, so AppArmor must be unconfined for the agent to
-		// mount a cgroup2 hierarchy on a legacy cgroup v1 host.
+		// mount a cgroup2 hierarchy when the host has none (legacy cgroup v1
+		// hosts, and cloud replay's nested/DinD env where the agent may need to
+		// self-mount even though this process sees cgroup2).
 		serviceNode.Content = append(serviceNode.Content,
-			&yaml.Node{Kind: yaml.ScalarNode, Value: "security_opt", HeadComment: "Required to mount a cgroup2 hierarchy for eBPF hooks on a legacy cgroup v1 host."},
+			&yaml.Node{Kind: yaml.ScalarNode, Value: "security_opt", HeadComment: "Lets the agent mount a cgroup2 hierarchy for eBPF hooks when the host has none (legacy cgroup v1, or cloud replay's nested env)."},
 			&yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{
 				{Kind: yaml.ScalarNode, Value: "apparmor:unconfined"},
 			}},


### PR DESCRIPTION
## The failure (from a customer)

`keploy cloud replay` on a **legacy cgroup v1 host** inside a **privileged DinD pod** aborts before running the app:

```
Keploy(agent): no cgroup2 (unified) hierarchy is mounted; mounting one for eBPF hooks (host appears to use legacy cgroup v1)
Keploy(agent): failed to detect the cgroup path {"error":"cgroup2 not mounted and keploy could not mount it (operation not permitted): the host uses legacy cgroup v1 and the keploy-agent lacks the privileges to mount a cgroup2 hierarchy..."}
```

The self-mount fix (#4369) *ran*, but hit **`operation not permitted` (EPERM)** — the agent has no `CAP_SYS_ADMIN`.

## Root cause

`GenerateKeployAgentService` grants the agent `SYS_ADMIN` + `security_opt: apparmor:unconfined` **only when `cgroupV2AvailableOnHost()` reports no cgroup2**. That check reads the **compose-generating process's** `/proc/mounts` — which, in cloud replay, runs in the **pod**, while the **agent** runs in a **nested DinD container**. The pod can see a cgroup2 mount the agent does not inherit, so detection returned "v2 present," the grant was **skipped**, and the agent (which genuinely has no cgroup2 and correctly tries to self-mount) failed with EPERM.

This is a detection divergence: in a nested/DinD environment the generating process's cgroup view cannot predict the agent container's.

## Fix

Grant the mount privileges for the **in-memory (cloud replay) path unconditionally**:

```go
grantCgroupMountPrivileges := !cgroupV2AvailableOnHost() || len(opts.InMemoryCompose) > 0
```

- **Cloud replay** (`InMemoryCompose` set — the enterprise cloud command's path, gated identically at `SetupCompose`): always grant, since the pod's cgroup view is not a reliable predictor of the agent's.
- **Normal file-based `keploy test`/`record`** on a cgroup v2 host, where the generating process and the agent share the same cgroup view: unchanged, least-privileged. (`InMemoryCompose` is `yaml/json/mapstructure:"-"` and is never set on the file-based path, so no over-grant there.)

`seccomp` is deliberately **not** relaxed — Docker's default seccomp already permits `mount(2)` once `CAP_SYS_ADMIN` is held; only AppArmor must be unconfined (its default profile denies `mount`).

## Testing

- New generator test case: `InMemoryCompose` set + host reports cgroup v2 ⇒ `SYS_ADMIN` + `apparmor:unconfined` **are** granted (and `seccomp:unconfined` is **not**). Existing v1/v2 branches unchanged.
- `go build ./...`, `go vet`, `go test -race ./pkg/platform/docker/` — green.

## Follow-up (noted, not blocking)

The in-memory-compose signal is a proxy for "runs in a nested/DinD env where cgroup detection is unreliable." It is 1:1 with cloud replay today. A cleaner long-term shape is an explicit `SetupOptions` intent flag set by the cloud-replay caller; deferred to avoid coordinated churn on this hotfix.
