### PR TITLE
fix(replay): don't prune recorded mocks on a run that proves nothing

### DIFF
--- a/pkg/service/replay/mock_pruning_guard_test.go
+++ b/pkg/service/replay/mock_pruning_guard_test.go
@@ -1,0 +1,188 @@
+package replay
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// connRefusedResult builds a TestResult shaped exactly like CreateFailedTestResult
+// produces for a request the app never answered: synthetic status_code 0 plus the
+// AppConnectionError category on the TOP-LEVEL FailureInfo.
+func connRefusedResult(name string) models.TestResult {
+	return models.TestResult{
+		Name:   name,
+		Status: models.TestStatusFailed,
+		FailureInfo: models.FailureInfo{
+			Risk:     models.High,
+			Category: []models.FailureCategory{models.AppConnectionError},
+		},
+	}
+}
+
+func mockDiffResult(name string) models.TestResult {
+	return models.TestResult{
+		Name:   name,
+		Status: models.TestStatusFailed,
+		FailureInfo: models.FailureInfo{
+			Risk:     models.High,
+			Category: []models.FailureCategory{models.StatusCodeChanged},
+		},
+	}
+}
+
+func passedResult(name string) models.TestResult {
+	return models.TestResult{Name: name, Status: models.TestStatusPassed}
+}
+
+// TestAnyAppConnectionError verifies detection reads the top-level FailureInfo —
+// Result.FailureInfo is tagged json:"-" and is empty after a report-DB round-trip,
+// so keying off it would silently never fire.
+func TestAnyAppConnectionError(t *testing.T) {
+	if !anyAppConnectionError([]models.TestResult{passedResult("a"), connRefusedResult("b")}) {
+		t.Fatal("expected AppConnectionError to be detected on the top-level FailureInfo")
+	}
+	if anyAppConnectionError([]models.TestResult{passedResult("a"), mockDiffResult("b")}) {
+		t.Fatal("a genuine mock-diff failure must not be reported as an app connection error")
+	}
+	if anyAppConnectionError(nil) {
+		t.Fatal("no results must not report an app connection error")
+	}
+
+	// Category set ONLY on the non-serialized Result.FailureInfo must NOT count:
+	// this pins the field-path choice so a refactor can't silently regress it.
+	buried := models.TestResult{Name: "x", Status: models.TestStatusFailed}
+	buried.Result.FailureInfo.Category = []models.FailureCategory{models.AppConnectionError}
+	if anyAppConnectionError([]models.TestResult{buried}) {
+		t.Fatal("must read TestResult.FailureInfo, not the json:\"-\" Result.FailureInfo")
+	}
+}
+
+// TestShouldSkipPruning_AppUnreachableRunNeverPrunes is the regression test for the
+// data-loss incident: 9 recorded test cases, every one failing with connection
+// refused because the replay pod's app container crash-looped. RemoveUnusedMocks=true
+// and PreserveFailedMocks=false (exactly what k8s-proxy auto-replay sets), which
+// previously left skipPruning=false — so UpdateMocks ran with an EMPTY keep-set and
+// deleted the recorded mocks. A crashed container must never destroy mocks.
+func TestShouldSkipPruning_AppUnreachableRunNeverPrunes(t *testing.T) {
+	results := make([]models.TestResult, 0, 9)
+	for _, n := range []string{"get-users-1", "post-users-1", "get-users-by-id-1", "get-users-by-id-2",
+		"get-users-by-id-3", "get-actuator-health-1", "get-api-students-1", "get-employees-1", "get-books-1"} {
+		results = append(results, connRefusedResult(n))
+	}
+
+	// PreserveFailedMocks=false is the incident configuration.
+	if !shouldSkipPruning(0, len(results), 0, false, results) {
+		t.Fatal("an all-connection-refused run must skip pruning even with PreserveFailedMocks=false")
+	}
+	// ...and the guard must not depend on that flag being set.
+	if !shouldSkipPruning(0, len(results), 0, true, results) {
+		t.Fatal("an all-connection-refused run must skip pruning with PreserveFailedMocks=true too")
+	}
+}
+
+// TestShouldSkipPruning_ZeroPassingNeverPrunes covers the general zero-signal case:
+// no passing test means an empty keep-set, which carries no information about which
+// mocks are needed — regardless of WHY the tests failed.
+func TestShouldSkipPruning_ZeroPassingNeverPrunes(t *testing.T) {
+	allMockDiff := []models.TestResult{mockDiffResult("a"), mockDiffResult("b")}
+	if !shouldSkipPruning(0, 2, 0, false, allMockDiff) {
+		t.Fatal("zero passing tests must skip pruning: an empty keep-set is 'no information', not 'delete everything'")
+	}
+	if !shouldSkipPruning(0, 0, 0, false, nil) {
+		t.Fatal("a run with no results at all must skip pruning")
+	}
+}
+
+// TestShouldSkipPruning_PruningStillWorks guards against over-correction: a healthy
+// run with real signal must still prune, or RemoveUnusedMocks silently becomes a
+// no-op and mocks accumulate forever.
+func TestShouldSkipPruning_PruningStillWorks(t *testing.T) {
+	// All passing, no failures: the canonical prune case.
+	allPass := []models.TestResult{passedResult("a"), passedResult("b")}
+	if shouldSkipPruning(2, 0, 0, false, allPass) {
+		t.Fatal("a fully passing run must prune unused mocks")
+	}
+	// Mixed pass/fail with PreserveFailedMocks=false: there IS a keep-set from the
+	// passing tests, so pruning is justified (pre-existing behaviour, preserved).
+	mixed := []models.TestResult{passedResult("a"), mockDiffResult("b")}
+	if shouldSkipPruning(1, 1, 0, false, mixed) {
+		t.Fatal("a run with passing tests must still prune when PreserveFailedMocks is false")
+	}
+	// Same input, PreserveFailedMocks=true: the opt-in safety net still applies.
+	if !shouldSkipPruning(1, 1, 0, true, mixed) {
+		t.Fatal("PreserveFailedMocks must still skip pruning when a test failed")
+	}
+	// Obsolete alone must also trip PreserveFailedMocks.
+	if !shouldSkipPruning(1, 0, 1, true, allPass) {
+		t.Fatal("PreserveFailedMocks must skip pruning when a test is obsolete")
+	}
+}
+
+// TestShouldSkipPruning_PassingRunWithAConnectionErrorIsStillZeroSignal verifies a
+// partially-unreachable run does not prune: if any request never reached the app,
+// that test's mocks look "unused" purely because of the transport failure, and
+// pruning would delete them.
+func TestShouldSkipPruning_PassingRunWithAConnectionErrorIsStillZeroSignal(t *testing.T) {
+	mixed := []models.TestResult{passedResult("a"), connRefusedResult("b")}
+	if !shouldSkipPruning(1, 1, 0, false, mixed) {
+		t.Fatal("a run containing any app-connection failure must not prune, even if other tests passed")
+	}
+}
+
+// TestShouldPrune_WiresTheGuardIntoTheDecision pins the WIRING, not just the
+// predicate.
+//
+// The data-loss bug is the whole conjunction — a correct shouldSkipPruning that
+// is not consulted deletes mocks exactly as before. Testing only the predicate
+// leaves that gap: disconnecting it at the call site kept every other test in
+// this file green. shouldPrune is the single expression RunTestSet evaluates, so
+// asserting on it covers the guard AND its wiring.
+func TestShouldPrune_WiresTheGuardIntoTheDecision(t *testing.T) {
+	appUnreachable := []models.TestResult{{
+		Status:      models.TestStatusFailed,
+		FailureInfo: models.FailureInfo{Category: []models.FailureCategory{models.AppConnectionError}},
+	}}
+	healthy := []models.TestResult{{Status: models.TestStatusPassed}}
+
+	tests := []struct {
+		name              string
+		removeUnusedMocks bool
+		instrument        bool
+		success, failure  int
+		results           []models.TestResult
+		want              bool
+		why               string
+	}{
+		{
+			name: "app unreachable must not prune", removeUnusedMocks: true, instrument: true,
+			success: 0, failure: 3, results: appUnreachable, want: false,
+			why: "the guard must reach the decision: every request failed to connect, so nothing " +
+				"vouches for any mock and pruning would destroy the recording over an infra fault",
+		},
+		{
+			name: "healthy passing run still prunes", removeUnusedMocks: true, instrument: true,
+			success: 3, failure: 0, results: healthy, want: true,
+			why: "RemoveUnusedMocks is a documented feature; the guard must not disable it",
+		},
+		{
+			name: "feature off never prunes", removeUnusedMocks: false, instrument: true,
+			success: 3, failure: 0, results: healthy, want: false,
+			why: "pruning is opt-in",
+		},
+		{
+			name: "not instrumenting never prunes", removeUnusedMocks: true, instrument: false,
+			success: 3, failure: 0, results: healthy, want: false,
+			why: "without instrumentation there is no trustworthy consumed-mock set at all",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldPrune(tt.removeUnusedMocks, tt.instrument, tt.success, tt.failure, 0, false, tt.results)
+			if got != tt.want {
+				t.Errorf("shouldPrune = %v, want %v: %s", got, tt.want, tt.why)
+			}
+		})
+	}
+}

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -2867,11 +2867,25 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		}
 	}
 
-	// remove the unused mocks by the test cases of a testset (if the base path is not provided )
-	// When PreserveFailedMocks is enabled (k8s-proxy autoreplay), skip pruning if any test
-	// failed or was marked obsolete so all recorded mocks remain available for UI inspection.
-	skipPruning := r.config.Test.PreserveFailedMocks && (failure > 0 || obsolete > 0)
-	if r.config.Test.RemoveUnusedMocks && r.instrument && !skipPruning {
+	// Remove the mocks no test case consumed (when no base path is provided).
+	//
+	// Pruning keeps what the tests consumed and deletes the rest, so it is only
+	// sound when a mock going unconsumed actually means the app didn't need it. A
+	// run whose app could not reach its dependencies fails every test and consumes
+	// nothing — pruning that would delete the recording's mocks because of an
+	// infrastructure fault. shouldPrune holds them; see shouldSkipPruning for the
+	// full set of reasons.
+	pruneEnabled := r.config.Test.RemoveUnusedMocks && r.instrument
+	prune := shouldPrune(r.config.Test.RemoveUnusedMocks, r.instrument, success, failure, obsolete,
+		r.config.Test.PreserveFailedMocks, testCaseResults)
+	if pruneEnabled && !prune {
+		r.logger.Warn("skipping mock pruning: this run's consumed-mock set is not trustworthy enough to delete against, so recorded mocks are preserved",
+			zap.String("testSetID", testSetID),
+			zap.Int("passed", success),
+			zap.Int("failed", failure),
+			zap.Bool("appUnreachable", anyAppConnectionError(testCaseResults)))
+	}
+	if prune {
 		noisyTestCases := r.hookImpl.GetNoisyTestCaseNames(testSetID)
 		if len(noisyTestCases) > 0 {
 			added := retainNoisyTestCaseMocks(noisyTestCases, actualTestMockMappings, passingTotalConsumedMocks)
@@ -3754,6 +3768,85 @@ func appendCategoryUnique(cats []models.FailureCategory, c models.FailureCategor
 		}
 	}
 	return append(cats, c)
+}
+
+// anyAppConnectionError reports whether any test in the run failed because the
+// application produced no response at all (connection refused/reset/EOF). Such a
+// test says nothing about which mocks are needed — its request never reached the
+// app — so it must not be read as evidence that mocks are unused.
+//
+// Reads the TOP-LEVEL TestResult.FailureInfo, not Result.FailureInfo, for the
+// simple reason that CreateFailedTestResult only sets the category there. Both
+// survive the report store (it holds the structs in memory; ReportResults reads
+// Result.FailureInfo.Risk off the very same values), so this is about where the
+// category is written, not about what survives.
+func anyAppConnectionError(results []models.TestResult) bool {
+	for _, tr := range results {
+		for _, c := range tr.FailureInfo.Category {
+			if c == models.AppConnectionError {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// pruneInputUntrustworthy reports whether a run's consumed-mock set is too weak
+// to justify deleting anything.
+//
+// Pruning keeps what the tests consumed and deletes the rest, which is only sound
+// when a test not consuming a mock actually means "the app didn't need it". Two
+// cases break that:
+//
+//   - success == 0: no test passed, so nothing vouches for any mock. The keep-set
+//     collapses to what the startup/never-executed paths contributed, and every
+//     mock a real request would have used is deleted.
+//   - any AppConnectionError: those requests never reached the app, so they
+//     consumed no mocks for want of a connection, not for want of need.
+//
+// Both mean "no information", and pruning reads that as "delete" — which is the
+// bug. Note this is NOT the same as "the run produced no signal at all": a run
+// can have passing tests AND one connection error, and it lands here because that
+// one test's mocks would be wrongly deleted. Callers must not describe it as a
+// zero-passing run.
+func pruneInputUntrustworthy(success int, results []models.TestResult) bool {
+	return success == 0 || anyAppConnectionError(results)
+}
+
+// shouldSkipPruning decides whether a completed run is allowed to delete recorded
+// mocks. Pruning is destructive and its input (the keep-set) is only trustworthy
+// when the run actually produced signal, so there are two independent reasons to
+// refuse:
+//
+//   - the keep-set is untrustworthy (pruneInputUntrustworthy): no test passed, or
+//     some request never reached the app. Mocks went unconsumed for lack of
+//     evidence, not because they are unused. This reason is deliberately
+//     INDEPENDENT of preserveFailedMocks: callers turn that flag off (k8s-proxy
+//     auto-replay sets it false), so it cannot serve as the safety net here. A
+//     crashed container must never be able to destroy mocks.
+//   - preserveFailedMocks (opt-in): a caller that wants every recorded mock kept
+//     available for inspection whenever anything failed or went obsolete.
+//
+// shouldPrune is the COMPLETE gate on the destructive prune: it must be enabled
+// (RemoveUnusedMocks), keploy must be instrumenting the run, and the run's
+// consumed-mock set must be trustworthy enough to delete against.
+//
+// It exists as one function because the data-loss bug lives in this conjunction,
+// not in shouldSkipPruning alone — a correct predicate that isn't wired into the
+// decision deletes mocks just the same. Keeping the whole condition here means a
+// unit test can pin the wiring instead of only the predicate.
+func shouldPrune(removeUnusedMocks, instrument bool, success, failure, obsolete int, preserveFailedMocks bool, results []models.TestResult) bool {
+	if !removeUnusedMocks || !instrument {
+		return false
+	}
+	return !shouldSkipPruning(success, failure, obsolete, preserveFailedMocks, results)
+}
+
+func shouldSkipPruning(success, failure, obsolete int, preserveFailedMocks bool, results []models.TestResult) bool {
+	if pruneInputUntrustworthy(success, results) {
+		return true
+	}
+	return preserveFailedMocks && (failure > 0 || obsolete > 0)
 }
 
 func (r *Replayer) CreateFailedTestResult(testCase *models.TestCase, testSetID string, started time.Time, errorMessage string) *models.TestResult {


### PR DESCRIPTION
## The bug

Pruning keeps the mocks the tests consumed and deletes the rest. That inference only holds when a mock going unconsumed means **the app did not need it** — and it does not hold when the app never ran properly.

When a replayed app can't reach its dependencies (its database is down, a container crash-looped), **every test fails and consumes nothing**. `RemoveUnusedMocks` reads that empty consumed-set as *"none of these are needed"* and deletes them — **permanently destroying the recording because of an infrastructure fault**.

The user is left with test cases and no mocks: the very state that made the run fail in the first place. Re-recording is the only way back.

This is how it surfaced — an auto-replay whose app couldn't reach MySQL came back with the recording's mocks gone.

## The fix

Refuse to prune when the consumed-mock set cannot justify a deletion:

| Condition | Why it proves nothing |
|---|---|
| no test passed | nothing vouches for any mock, so every mock a real request would have used gets deleted |
| any `AppConnectionError` (conn refused/reset/EOF) | that request never reached the app — it consumed no mocks for want of a *connection*, not for want of *need* |

Both mean "no information", and pruning reads no-information as *delete*.

The guard is deliberately **independent of `PreserveFailedMocks`**: callers turn that flag off (k8s-proxy auto-replay sets it `false`), so it cannot serve as the safety net here. A crashed container must never be able to destroy recorded mocks.

## `RemoveUnusedMocks` is not quietly disabled

| Run | Before | After |
|---|---|---|
| all pass | prune | **prune** |
| mixed pass/fail, `preserveFailedMocks=false` | prune | **prune** |
| mixed, `preserveFailedMocks=true` | skip | skip |
| all fail (genuine regressions) | prune | **skip** |
| all fail (app unreachable) | **prune** ← the bug | **skip** |
| ≥1 connection error + some passes | prune | **skip** |

Healthy runs are untouched. Only failing runs change, and only in the non-destructive direction.

**One consequence worth knowing:** a test set where *every* test fails for genuine regressions also stops pruning until at least one test passes. That's intentional — a run with no passing test can't distinguish an unused mock from an unreached one — and it's `Warn`-logged rather than silent.

## Note on the design

The whole condition lives in `shouldPrune` rather than at the call site, because **the bug is the conjunction**: a correct predicate that isn't consulted deletes mocks just the same. That isn't hypothetical — while writing this I confirmed that stubbing the call site kept every predicate test green. The tests now cover the wiring, verified by disconnecting the guard and watching them fail.

## Tests

`mock_pruning_guard_test.go` — mutation-verified: reverting the predicate fails 4 tests, disconnecting the guard from the decision fails the wiring test. Full `pkg/service/replay` suite green; build, vet, gofmt clean.
