### PR TITLE
fix: scope generated id parsing by prefix

### DIFF
--- a/pkg/platform/yaml/utils.go
+++ b/pkg/platform/yaml/utils.go
@@ -157,37 +157,6 @@ func Contains(elems []string, v string) bool {
 	return false
 }
 
-func NewSessionIndex(path string, Logger *zap.Logger) (string, error) {
-	indx := 0
-	dir, err := ReadDir(path, fs.FileMode(os.O_RDONLY))
-	if err != nil {
-		Logger.Debug("creating a folder for the keploy generated testcases", zap.Error(err))
-		return fmt.Sprintf("%s%v", models.TestSetPattern, indx), nil
-	}
-
-	files, err := dir.ReadDir(0)
-	if err != nil {
-		return "", err
-	}
-
-	for _, v := range files {
-		// fmt.Println("name for the file", v.Name())
-		fileName := filepath.Base(v.Name())
-		fileNamePackets := strings.Split(fileName, "-")
-		if len(fileNamePackets) == 3 {
-			fileIndx, err := strconv.Atoi(fileNamePackets[2])
-			if err != nil {
-				Logger.Debug("failed to convert the index string to integer", zap.Error(err))
-				continue
-			}
-			if indx < fileIndx+1 {
-				indx = fileIndx + 1
-			}
-		}
-	}
-	return fmt.Sprintf("%s%v", models.TestSetPattern, indx), nil
-}
-
 func ValidatePath(path string) (string, error) {
 	// Validate the input to prevent directory traversal attack
 	if strings.Contains(path, "..") {

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -2646,15 +2646,12 @@ func ReadSessionIndices(path string, Logger *zap.Logger) ([]string, error) {
 func NextID(IDs []string, identifier string) string {
 	latestIndx := 0
 	for _, ID := range IDs {
-		namePackets := strings.Split(ID, "-")
-		if len(namePackets) == 3 {
-			Indx, err := strconv.Atoi(namePackets[2])
-			if err != nil {
-				continue
-			}
-			if latestIndx < Indx+1 {
-				latestIndx = Indx + 1
-			}
+		Indx, ok := parseIDIndex(ID, identifier)
+		if !ok {
+			continue
+		}
+		if latestIndx < Indx+1 {
+			latestIndx = Indx + 1
 		}
 	}
 	return fmt.Sprintf("%s%v", identifier, latestIndx)
@@ -2663,18 +2660,30 @@ func NextID(IDs []string, identifier string) string {
 func LastID(IDs []string, identifier string) string {
 	latestIndx := 0
 	for _, ID := range IDs {
-		namePackets := strings.Split(ID, "-")
-		if len(namePackets) == 3 {
-			Indx, err := strconv.Atoi(namePackets[2])
-			if err != nil {
-				continue
-			}
-			if latestIndx < Indx {
-				latestIndx = Indx
-			}
+		Indx, ok := parseIDIndex(ID, identifier)
+		if !ok {
+			continue
+		}
+		if latestIndx < Indx {
+			latestIndx = Indx
 		}
 	}
 	return fmt.Sprintf("%s%v", identifier, latestIndx)
+}
+
+func parseIDIndex(ID, identifier string) (int, bool) {
+	if !strings.HasPrefix(ID, identifier) {
+		return 0, false
+	}
+	suffix := strings.TrimPrefix(ID, identifier)
+	if suffix == "" {
+		return 0, false
+	}
+	Indx, err := strconv.Atoi(suffix)
+	if err != nil {
+		return 0, false
+	}
+	return Indx, true
 }
 
 var (

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -2572,7 +2572,11 @@ func parseIDIndex(ID, identifier string) (int, bool) {
 		return 0, false
 	}
 	suffix := strings.TrimPrefix(ID, identifier)
-	if suffix == "" {
+	// Digits only. strconv.Atoi accepts a leading sign, so without this a
+	// directory literally named "test-set--1" would parse as index -1 and a
+	// "test-set-+5" as 5. Neither is an ID keploy generates, and the old
+	// len(Split(ID, "-")) == 3 check rejected both.
+	if suffix == "" || strings.ContainsFunc(suffix, func(r rune) bool { return r < '0' || r > '9' }) {
 		return 0, false
 	}
 	Indx, err := strconv.Atoi(suffix)

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -2542,15 +2542,12 @@ func ReadSessionIndices(path string, Logger *zap.Logger) ([]string, error) {
 func NextID(IDs []string, identifier string) string {
 	latestIndx := 0
 	for _, ID := range IDs {
-		namePackets := strings.Split(ID, "-")
-		if len(namePackets) == 3 {
-			Indx, err := strconv.Atoi(namePackets[2])
-			if err != nil {
-				continue
-			}
-			if latestIndx < Indx+1 {
-				latestIndx = Indx + 1
-			}
+		Indx, ok := parseIDIndex(ID, identifier)
+		if !ok {
+			continue
+		}
+		if latestIndx < Indx+1 {
+			latestIndx = Indx + 1
 		}
 	}
 	return fmt.Sprintf("%s%v", identifier, latestIndx)
@@ -2559,18 +2556,30 @@ func NextID(IDs []string, identifier string) string {
 func LastID(IDs []string, identifier string) string {
 	latestIndx := 0
 	for _, ID := range IDs {
-		namePackets := strings.Split(ID, "-")
-		if len(namePackets) == 3 {
-			Indx, err := strconv.Atoi(namePackets[2])
-			if err != nil {
-				continue
-			}
-			if latestIndx < Indx {
-				latestIndx = Indx
-			}
+		Indx, ok := parseIDIndex(ID, identifier)
+		if !ok {
+			continue
+		}
+		if latestIndx < Indx {
+			latestIndx = Indx
 		}
 	}
 	return fmt.Sprintf("%s%v", identifier, latestIndx)
+}
+
+func parseIDIndex(ID, identifier string) (int, bool) {
+	if !strings.HasPrefix(ID, identifier) {
+		return 0, false
+	}
+	suffix := strings.TrimPrefix(ID, identifier)
+	if suffix == "" {
+		return 0, false
+	}
+	Indx, err := strconv.Atoi(suffix)
+	if err != nil {
+		return 0, false
+	}
+	return Indx, true
 }
 
 var (

--- a/pkg/util_test.go
+++ b/pkg/util_test.go
@@ -20,6 +20,74 @@ import (
 	"go.uber.org/zap"
 )
 
+func TestNextIDIgnoresOtherPrefixes(t *testing.T) {
+	tests := []struct {
+		name       string
+		ids        []string
+		identifier string
+		want       string
+	}{
+		{
+			name:       "custom metadata name with numeric suffix does not affect test-set sequence",
+			ids:        []string{"test-set-0", "checkout-flow-999"},
+			identifier: models.TestSetPattern,
+			want:       "test-set-1",
+		},
+		{
+			name:       "test-set IDs do not affect test-run sequence",
+			ids:        []string{"test-run-2", "test-set-99"},
+			identifier: models.TestRunTemplateName,
+			want:       "test-run-3",
+		},
+		{
+			name:       "invalid suffix is ignored",
+			ids:        []string{"test-set-0", "test-set-0 copy", "test-set-final"},
+			identifier: models.TestSetPattern,
+			want:       "test-set-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, NextID(tt.ids, tt.identifier))
+		})
+	}
+}
+
+func TestLastIDIgnoresOtherPrefixes(t *testing.T) {
+	tests := []struct {
+		name       string
+		ids        []string
+		identifier string
+		want       string
+	}{
+		{
+			name:       "custom metadata name with numeric suffix does not affect latest test run",
+			ids:        []string{"test-run-2", "checkout-flow-999"},
+			identifier: models.TestRunTemplateName,
+			want:       "test-run-2",
+		},
+		{
+			name:       "test runs do not affect latest test set",
+			ids:        []string{"test-set-1", "test-run-99"},
+			identifier: models.TestSetPattern,
+			want:       "test-set-1",
+		},
+		{
+			name:       "invalid suffix is ignored",
+			ids:        []string{"test-run-3", "test-run-3 copy", "test-run-final"},
+			identifier: models.TestRunTemplateName,
+			want:       "test-run-3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, LastID(tt.ids, tt.identifier))
+		})
+	}
+}
+
 // TestSimulateHTTP_NewRequestError_303 ensures that SimulateHTTP returns an error
 // when http.NewRequestWithContext fails. This is triggered by providing an invalid
 // HTTP method string in the test case.

--- a/pkg/util_test.go
+++ b/pkg/util_test.go
@@ -50,6 +50,24 @@ func TestNextIDIgnoresOtherPrefixes(t *testing.T) {
 			identifier: models.TestSetPattern,
 			want:       "test-set-1",
 		},
+		{
+			name:       "signed suffixes are not indices",
+			ids:        []string{"test-set-0", "test-set--1", "test-set-+5"},
+			identifier: models.TestSetPattern,
+			want:       "test-set-1",
+		},
+		{
+			name:       "empty set starts at zero",
+			ids:        nil,
+			identifier: models.TestSetPattern,
+			want:       "test-set-0",
+		},
+		{
+			name:       "bare prefix is not an index",
+			ids:        []string{"test-set-"},
+			identifier: models.TestSetPattern,
+			want:       "test-set-0",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/util_test.go
+++ b/pkg/util_test.go
@@ -25,6 +25,74 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 )
 
+func TestNextIDIgnoresOtherPrefixes(t *testing.T) {
+	tests := []struct {
+		name       string
+		ids        []string
+		identifier string
+		want       string
+	}{
+		{
+			name:       "custom metadata name with numeric suffix does not affect test-set sequence",
+			ids:        []string{"test-set-0", "checkout-flow-999"},
+			identifier: models.TestSetPattern,
+			want:       "test-set-1",
+		},
+		{
+			name:       "test-set IDs do not affect test-run sequence",
+			ids:        []string{"test-run-2", "test-set-99"},
+			identifier: models.TestRunTemplateName,
+			want:       "test-run-3",
+		},
+		{
+			name:       "invalid suffix is ignored",
+			ids:        []string{"test-set-0", "test-set-0 copy", "test-set-final"},
+			identifier: models.TestSetPattern,
+			want:       "test-set-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, NextID(tt.ids, tt.identifier))
+		})
+	}
+}
+
+func TestLastIDIgnoresOtherPrefixes(t *testing.T) {
+	tests := []struct {
+		name       string
+		ids        []string
+		identifier string
+		want       string
+	}{
+		{
+			name:       "custom metadata name with numeric suffix does not affect latest test run",
+			ids:        []string{"test-run-2", "checkout-flow-999"},
+			identifier: models.TestRunTemplateName,
+			want:       "test-run-2",
+		},
+		{
+			name:       "test runs do not affect latest test set",
+			ids:        []string{"test-set-1", "test-run-99"},
+			identifier: models.TestSetPattern,
+			want:       "test-set-1",
+		},
+		{
+			name:       "invalid suffix is ignored",
+			ids:        []string{"test-run-3", "test-run-3 copy", "test-run-final"},
+			identifier: models.TestRunTemplateName,
+			want:       "test-run-3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, LastID(tt.ids, tt.identifier))
+		})
+	}
+}
+
 // TestSimulateHTTP_NewRequestError_303 ensures that SimulateHTTP returns an error
 // when http.NewRequestWithContext fails. This is triggered by providing an invalid
 // HTTP method string in the test case.


### PR DESCRIPTION
## What this fixes :
[#4377](https://github.com/keploy/keploy/issues/4377)

## What changed

  This PR fixes ID generation for test sets and test runs.

  `NextID` and `LastID` now only use IDs that match the expected prefix, such as `test-set-` or `test-run-`. Custom names like `checkout-flow-999` are ignored when creating the next `test-set-N`.

  ## Why

  A custom metadata name ending in a number could make Keploy create a wrong next ID, for example `test-set-1000` instead of `test-set-1`.

  ## Tests

  - Added tests for mixed prefixes
  - Added tests for invalid suffixes like `test-set-0 copy`
  - Ran `go test ./...`
