### PR TITLE
feat(async): value-epoch replay for httpPoll lanes (fix long-poll boot deadlock)

### DIFF
--- a/.github/workflows/java_linux.yml
+++ b/.github/workflows/java_linux.yml
@@ -221,12 +221,17 @@ jobs:
           - job: record_build_replay_build
             record_src: build-no-race
             replay_src: build-no-race
-        # periodic: fast poller, stub answers immediately, lane type http ->
+        # periodic:      fast poller, stub answers immediately, lane type http ->
         #   asserts the async engine SERVED the polls (served >= 1).
-        # httppoll: one held long-poll (server timeout), lane type httpPoll ->
-        #   asserts kind:HttpPoll + pollDurationMs recorded and the engine HELD
-        #   it until its resolve testcase at replay (held >= 1).
-        scenario: [periodic, httppoll]
+        # httppoll:      one held long-poll (server timeout), lane type httpPoll ->
+        #   asserts it is recorded as a collapsed value epoch (kind Http, async
+        #   poll: true, no pollDurationMs) and SERVED on replay (served >= 1).
+        # boot_blocking: record as httppoll, but replay with the app boot-blocking
+        #   synchronously on the watch (BLOCK_BOOT_ON_WATCH) -> asserts the value-
+        #   epoch engine serves the startup epoch so the app boots and ingress
+        #   PASSES (the old anchor-hold engine would park it -> boot deadlock).
+        #   Needs keploy/samples-java#148 (the BLOCK_BOOT_ON_WATCH app support).
+        scenario: [periodic, httppoll, boot_blocking]
     name: async-config-poll (${{ matrix.scenario }} / ${{ matrix.config.job }})
     steps:
       - name: Checkout repository

--- a/.github/workflows/java_linux.yml
+++ b/.github/workflows/java_linux.yml
@@ -251,10 +251,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: keploy/samples-java
-          # TEMPORARY: pinned to the branch adding BLOCK_BOOT_ON_WATCH, which the
-          # boot_blocking scenario needs. Repoint to the default branch once
-          # keploy/samples-java#148 merges.
-          ref: async-boot-blocking-watch
           path: samples-java
 
       # Spring Boot 1.5 sample -> Java 8 (not the Java 17 the other jobs use);

--- a/.github/workflows/java_linux.yml
+++ b/.github/workflows/java_linux.yml
@@ -251,6 +251,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: keploy/samples-java
+          # TEMPORARY: pinned to the branch adding BLOCK_BOOT_ON_WATCH, which the
+          # boot_blocking scenario needs. Repoint to the default branch once
+          # keploy/samples-java#148 merges.
+          ref: async-boot-blocking-watch
           path: samples-java
 
       # Spring Boot 1.5 sample -> Java 8 (not the Java 17 the other jobs use);

--- a/.github/workflows/test_workflow_scripts/java/async_config_poll/java-linux.sh
+++ b/.github/workflows/test_workflow_scripts/java/async_config_poll/java-linux.sh
@@ -19,13 +19,16 @@
 #   httppoll  — the app opens a SINGLE watch poll (WATCH_ONCE) and the stub HOLDS
 #               it open for a server-timeout (POLL_HOLD_SECONDS) before answering
 #               (lane type: httpPoll, via keploy-httppoll.yml). Asserts the poll
-#               is recorded as an async poll (kind Http + async block poll: true
-#               with a pollDurationMs), and that at replay the async engine HELD
-#               it until its resolve testcase and
-#               then served it (held >= 1). NOTE: the >60s hang-watchdog
-#               exemption that lets a long-held poll be recorded at all is unit-
-#               tested (supervisor TestHangNotDetectedWhenSuspended); this e2e
-#               uses a short hold so CI stays fast.
+#               is recorded as an async poll (kind Http + async block poll: true,
+#               a collapsed value epoch — no pollDurationMs), and that at replay
+#               the async engine SERVED the recorded poll value (served >= 1).
+#               Under the value-epoch model the engine no longer "holds" a poll
+#               connection open pending an anchor; it serves the current epoch
+#               and merely paces an unchanged poll by throttle (see
+#               async.Engine.Decide / holdThrottle). NOTE: the >60s hang-
+#               watchdog exemption that lets a long-held poll be recorded at all
+#               is unit-tested (supervisor TestHangNotDetectedWhenSuspended);
+#               this e2e uses a short hold so CI stays fast.
 #
 # NOTE: this sample is deliberately Spring Boot 1.5 / Java 8, so this script does
 # NOT source update-java.sh (which pins Java 17). The calling workflow sets up
@@ -166,13 +169,16 @@ echo "== recorded mock kinds =="; grep -aE "^kind:" keploy/test-set-0/mocks.yaml
 echo "== async-stamped mocks =="; grep -acE '^async:$' keploy/test-set-0/mocks.yaml 2>/dev/null || true
 
 # httppoll: the single watch poll must be recorded as an async poll — the mock
-# keeps kind Http, and its top-level async block carries poll: true plus an
-# open-duration (pollDurationMs). This is the record-side proof of the feature.
+# keeps kind Http, and its top-level async block carries poll: true and
+# anchorPos: (a collapsed value epoch). Under the value-epoch model there is no
+# open-duration field any more: pollDurationMs must NOT appear. This is the
+# record-side proof of the feature.
 if [[ "$SCENARIO" == "httppoll" ]]; then
   hp=$(grep -acE '^ +poll: true$' keploy/test-set-0/mocks.yaml 2>/dev/null || true)
   [[ "${hp:-0}" -ge 1 ]] || { echo "::error::httppoll: no async poll (poll: true) mock recorded — the long-poll was not captured"; exit 1; }
-  grep -aq 'pollDurationMs:' keploy/test-set-0/mocks.yaml || { echo "::error::httppoll: recorded poll mock has no pollDurationMs"; exit 1; }
-  echo "httppoll: recorded ${hp} async poll mock(s) with pollDurationMs."
+  grep -aq 'poll: true' keploy/test-set-0/mocks.yaml || { echo "::error::httppoll: recorded poll mock missing 'poll: true' in its async block"; exit 1; }
+  ! grep -aq 'pollDurationMs:' keploy/test-set-0/mocks.yaml || { echo "::error::httppoll: recorded poll mock still carries the retired pollDurationMs field"; exit 1; }
+  echo "httppoll: recorded ${hp} async poll mock(s) as value epochs (poll: true, no pollDurationMs)."
 fi
 endsec
 
@@ -222,12 +228,15 @@ if [[ "$flags" -ne 0 ]]; then
 fi
 echo "Async-egress engine served ${served} watch poll(s) with no shape drift."
 
-# httppoll: the poll must have been HELD until its resolve testcase (not served
-# on arrival). held >= 1 is the replay-side proof of the feature.
+# httppoll: the recorded poll value must have been served on replay. Under the
+# value-epoch model the engine no longer "holds" a poll connection open (held
+# is always 0 — retained in the log line only for output-format stability, see
+# LogReport); served >= 1 (parsed from the same "async egress verdict" line
+# checked generically above) is the replay-side proof of the feature for this
+# scenario's single long-poll mock.
 if [[ "$SCENARIO" == "httppoll" ]]; then
-  held=$(grep -aoE '"held": [0-9]+' test_logs.txt | tail -n1 | grep -oE '[0-9]+' || true)
-  [[ "${held:-0}" -ge 1 ]] || { echo "::error::httppoll: async engine held 0 polls — the poll was not held until its resolve testcase"; exit 1; }
-  echo "httppoll: async engine held ${held} poll(s) until their resolve testcase."
+  [[ "${served:-0}" -ge 1 ]] || { echo "::error::httppoll: async engine served 0 watch polls — the recorded poll value was not served on replay"; exit 1; }
+  echo "httppoll: async engine served ${served} poll value(s) recorded via the async poll."
 fi
 endsec
 

--- a/.github/workflows/test_workflow_scripts/java/async_config_poll/java-linux.sh
+++ b/.github/workflows/test_workflow_scripts/java/async_config_poll/java-linux.sh
@@ -74,9 +74,28 @@ case "$SCENARIO" in
     POLL_SETTLE=$((POLL_HOLD_SECONDS + 5))   # hold + margin for the poll to resolve & be recorded
     cp keploy-httppoll.yml keploy.yml        # activate the httpPoll lane for this run
     ;;
+  boot_blocking)
+    # Record the watch on the background daemon (as httppoll), but REPLAY with the
+    # app boot-BLOCKING synchronously on the watch=true poll (BLOCK_BOOT_ON_WATCH).
+    # This is the boot-deadlock shape: the old anchor-hold engine parked the poll
+    # so the app never became ready; the value-epoch engine serves the startup
+    # epoch immediately, so the app boots and the ingress tests pass. Uses the
+    # httpPoll lane config. CI runs the build binary (= the value-epoch engine),
+    # so this cell guards the fix; the old-engine deadlock is shown out of CI.
+    APP_ENV="env WATCH_ONCE=true RULES_DELAY_MS=600"                   # record: background watch
+    REPLAY_APP_ENV="env BLOCK_BOOT_ON_WATCH=true RULES_DELAY_MS=600"   # replay: boot blocks on the watch
+    POLL_HOLD_SECONDS=5
+    STUB_ENV="POLL_HOLD_SECONDS=${POLL_HOLD_SECONDS}"
+    POLL_SETTLE=$((POLL_HOLD_SECONDS + 5))
+    cp keploy-httppoll.yml keploy.yml        # activate the httpPoll lane for this run
+    ;;
   *)
-    echo "::error::unknown SCENARIO='$SCENARIO' (expected periodic|httppoll)"; exit 1 ;;
+    echo "::error::unknown SCENARIO='$SCENARIO' (expected periodic|httppoll|boot_blocking)"; exit 1 ;;
 esac
+
+# Most scenarios drive the app identically at record and replay; boot_blocking
+# overrides only the replay env (to boot-block on the watch), so default it here.
+REPLAY_APP_ENV="${REPLAY_APP_ENV:-$APP_ENV}"
 
 wait_for_mysql() {
   section "Wait for MySQL (real networked server)"
@@ -173,12 +192,12 @@ echo "== async-stamped mocks =="; grep -acE '^async:$' keploy/test-set-0/mocks.y
 # anchorPos: (a collapsed value epoch). Under the value-epoch model there is no
 # open-duration field any more: pollDurationMs must NOT appear. This is the
 # record-side proof of the feature.
-if [[ "$SCENARIO" == "httppoll" ]]; then
+if [[ "$SCENARIO" == "httppoll" || "$SCENARIO" == "boot_blocking" ]]; then
   hp=$(grep -acE '^ +poll: true$' keploy/test-set-0/mocks.yaml 2>/dev/null || true)
-  [[ "${hp:-0}" -ge 1 ]] || { echo "::error::httppoll: no async poll (poll: true) mock recorded — the long-poll was not captured"; exit 1; }
-  grep -aq 'poll: true' keploy/test-set-0/mocks.yaml || { echo "::error::httppoll: recorded poll mock missing 'poll: true' in its async block"; exit 1; }
-  ! grep -aq 'pollDurationMs:' keploy/test-set-0/mocks.yaml || { echo "::error::httppoll: recorded poll mock still carries the retired pollDurationMs field"; exit 1; }
-  echo "httppoll: recorded ${hp} async poll mock(s) as value epochs (poll: true, no pollDurationMs)."
+  [[ "${hp:-0}" -ge 1 ]] || { echo "::error::${SCENARIO}: no async poll (poll: true) mock recorded — the long-poll was not captured"; exit 1; }
+  grep -aq 'poll: true' keploy/test-set-0/mocks.yaml || { echo "::error::${SCENARIO}: recorded poll mock missing 'poll: true' in its async block"; exit 1; }
+  ! grep -aq 'pollDurationMs:' keploy/test-set-0/mocks.yaml || { echo "::error::${SCENARIO}: recorded poll mock still carries the retired pollDurationMs field"; exit 1; }
+  echo "${SCENARIO}: recorded ${hp} async poll mock(s) as value epochs (poll: true, no pollDurationMs)."
 fi
 endsec
 
@@ -190,7 +209,7 @@ endsec
 
 section "Replay"
 set +e
-"$REPLAY_BIN" test -c "$APP_ENV $APP_JAVA -jar $JAR" --delay 25 --api-timeout 60 2>&1 | tee test_logs.txt
+"$REPLAY_BIN" test -c "$REPLAY_APP_ENV $APP_JAVA -jar $JAR" --delay 25 --api-timeout 60 2>&1 | tee test_logs.txt
 REPLAY_RC=$?
 set -e
 echo "Replay exit code: $REPLAY_RC"
@@ -237,6 +256,20 @@ echo "Async-egress engine served ${served} watch poll(s) with no shape drift."
 if [[ "$SCENARIO" == "httppoll" ]]; then
   [[ "${served:-0}" -ge 1 ]] || { echo "::error::httppoll: async engine served 0 watch polls — the recorded poll value was not served on replay"; exit 1; }
   echo "httppoll: async engine served ${served} poll value(s) recorded via the async poll."
+fi
+
+# boot_blocking: the app boot-BLOCKED on the synchronous watch=true poll. The
+# value-epoch engine must have SERVED it from the startup epoch so boot could
+# proceed — the ingress tests above only PASS because the app became ready. Had
+# the engine parked it (the old anchor-hold behavior) the app would never have
+# accepted connections and those tests would have failed with connection-
+# refused. Assert the app's own "boot watch returned" log line so a regression
+# that re-introduces parking is caught even if timing masked the failures.
+if [[ "$SCENARIO" == "boot_blocking" ]]; then
+  grep -aq "BLOCK_BOOT_ON_WATCH: synchronous config watch returned" test_logs.txt \
+    || { echo "::error::boot_blocking: the app's boot-blocking config watch never returned — the poll was parked instead of served (value-epoch regression)"; exit 1; }
+  [[ "${served:-0}" -ge 1 ]] || { echo "::error::boot_blocking: async engine served 0 watch polls on replay"; exit 1; }
+  echo "boot_blocking: boot-blocking config watch served from the startup epoch; app booted and ingress PASSED."
 fi
 endsec
 

--- a/pkg/agent/proxy/integrations/async/async.go
+++ b/pkg/agent/proxy/integrations/async/async.go
@@ -27,6 +27,19 @@ type AsyncParser interface {
 	// async response conveys, so the recorder can detect when the value changes
 	// across poll cycles (identical value => identical key). Volatile/no-signal
 	// fields (e.g. Date headers) are excluded.
+	//
+	// The HTTP implementation fingerprints status + body only: a value signal
+	// carried ONLY in a non-volatile response header (e.g. an ETag or version
+	// header alongside an unchanged body) is out of scope and would be treated
+	// as unchanged (collapsed). That matches the body-carries-the-version
+	// contract of the config-watch lane this engine targets.
+	//
+	// NOTE: this is a REQUIRED addition to the exported interface — any
+	// out-of-tree AsyncParser implementer must add it. Verified: the only
+	// in-tree implementer is *http.HTTP (plus test fakes), and the sibling repos
+	// that consume this module (keploy-enterprise, k8s-proxy) implement no
+	// AsyncParser (they only declare AsyncLane config + use the env-var wire
+	// contract), so this bump breaks no known consumer.
 	ResponseValueKey(m *models.Mock, lane models.AsyncLane) string
 }
 

--- a/pkg/agent/proxy/integrations/async/async.go
+++ b/pkg/agent/proxy/integrations/async/async.go
@@ -22,6 +22,12 @@ type AsyncParser interface {
 	// EmptyResponse returns the parser's "no data yet" keep-alive payload for
 	// the lane, served when no async mock is armed. Always synthesizable.
 	EmptyResponse(lane models.AsyncLane) ([]byte, error)
+
+	// ResponseValueKey returns a stable fingerprint of the VALUE a recorded
+	// async response conveys, so the recorder can detect when the value changes
+	// across poll cycles (identical value => identical key). Volatile/no-signal
+	// fields (e.g. Date headers) are excluded.
+	ResponseValueKey(m *models.Mock, lane models.AsyncLane) string
 }
 
 // AsyncAware is an optional interface a parser implements so the proxy can

--- a/pkg/agent/proxy/integrations/async/async_test.go
+++ b/pkg/agent/proxy/integrations/async/async_test.go
@@ -20,7 +20,8 @@ func (f *fakeParser) MatchRequestShape(_, _ *models.Mock, _ models.AsyncLane) (b
 	}
 	return false, "shape drift"
 }
-func (f *fakeParser) EmptyResponse(_ models.AsyncLane) ([]byte, error) { return f.empty, nil }
+func (f *fakeParser) EmptyResponse(_ models.AsyncLane) ([]byte, error)       { return f.empty, nil }
+func (f *fakeParser) ResponseValueKey(*models.Mock, models.AsyncLane) string { return string(f.empty) }
 
 // compile-time assertion the fake satisfies the interface.
 var _ AsyncParser = (*fakeParser)(nil)

--- a/pkg/agent/proxy/integrations/async/engine.go
+++ b/pkg/agent/proxy/integrations/async/engine.go
@@ -253,7 +253,9 @@ func (e *Engine) Decide(ctx context.Context, lane models.AsyncLane, live *models
 		e.mu.Unlock()
 		return e.keepAlive(p, lane)
 	}
-	e.holdThrottle(ctx, lane.ThrottleDuration()) // pace + wake-early; holds e.mu
+	if lane.IsPoll() {
+		e.holdThrottle(ctx, lane.ThrottleDuration()) // pace + wake-early; holds e.mu
+	}
 	cur := s.currentEpoch(e.completed)
 	e.mu.Unlock()
 	if cur == nil {

--- a/pkg/agent/proxy/integrations/async/engine.go
+++ b/pkg/agent/proxy/integrations/async/engine.go
@@ -9,19 +9,32 @@ import (
 	"go.uber.org/zap"
 )
 
-// asyncEntry is a recorded async mock with its ordering/anchor ints taken from
-// the mock's Async block at Load, so the hot path never re-reads them.
-type asyncEntry struct {
-	mock      *models.Mock
-	seq       int
-	anchorPos int
-	poll      bool // Async.Poll: HOLD this delivery at Decide until anchorPos is reached
+// epoch is one value in a lane's timeline: the recorded response that becomes
+// current at effectiveFromPos (a completed-count; 0 = initial/boot) and stays
+// current until the next epoch.
+type epoch struct {
+	effectiveFromPos int
+	seq              int
+	mock             *models.Mock
 }
 
 type laneStream struct {
 	lane   models.AsyncLane
-	mocks  []asyncEntry // sorted by seq
-	cursor int          // next unconsumed index
+	epochs []epoch // sorted by (effectiveFromPos, seq)
+}
+
+// currentEpoch returns the last epoch with effectiveFromPos <= completed, or
+// nil if no epoch is effective yet.
+func (s *laneStream) currentEpoch(completed int) *epoch {
+	var cur *epoch
+	for i := range s.epochs {
+		if s.epochs[i].effectiveFromPos <= completed {
+			cur = &s.epochs[i]
+			continue
+		}
+		break // sorted ascending; nothing later qualifies
+	}
+	return cur
 }
 
 // ReportSnapshot is a point-in-time copy of the engine's verdict tallies.
@@ -48,8 +61,8 @@ type Engine struct {
 	completed  int                    // number of testcases completed
 	windowSeen bool                   // AdvanceWindow: first window doesn't count as a completed test
 
-	pass, flag, held int
-	flags            []string
+	pass, flag int
+	flags      []string
 
 	logOnce         sync.Once // LogReport fires at most once (multiple shutdown seams call it)
 	nonWindowedOnce sync.Once // WarnNonWindowed fires at most once (SetMocks runs per test-set)
@@ -126,10 +139,9 @@ func (e *Engine) laneByName(name string) (models.AsyncLane, bool) {
 	return models.AsyncLane{}, false
 }
 
-// Load partitions async-tagged mocks into per-lane, seq-ordered streams.
-// It is run-once: the first call partitions and sorts; subsequent calls are
-// no-ops so a re-Load after Decide has advanced a cursor cannot re-serve an
-// already-consumed mock.
+// Load partitions async-tagged mocks into per-lane epoch timelines, sorted by
+// (effectiveFromPos, seq). It is run-once: the first call partitions and
+// sorts; subsequent calls are no-ops.
 func (e *Engine) Load(mocks []*models.Mock) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -150,16 +162,18 @@ func (e *Engine) Load(mocks []*models.Mock) {
 			s = &laneStream{lane: lane}
 			e.streams[name] = s
 		}
-		s.mocks = append(s.mocks, asyncEntry{
-			mock:      m,
-			seq:       m.Spec.Async.Seq,
-			anchorPos: m.Spec.Async.AnchorPos,
-			poll:      m.Spec.Async.Poll,
+		s.epochs = append(s.epochs, epoch{
+			effectiveFromPos: m.Spec.Async.AnchorPos,
+			seq:              m.Spec.Async.Seq,
+			mock:             m,
 		})
 	}
 	for _, s := range e.streams {
-		sort.SliceStable(s.mocks, func(i, j int) bool {
-			return s.mocks[i].seq < s.mocks[j].seq
+		sort.SliceStable(s.epochs, func(i, j int) bool {
+			if s.epochs[i].effectiveFromPos != s.epochs[j].effectiveFromPos {
+				return s.epochs[i].effectiveFromPos < s.epochs[j].effectiveFromPos
+			}
+			return s.epochs[i].seq < s.epochs[j].seq
 		})
 	}
 	e.loaded = true
@@ -225,73 +239,23 @@ func (e *Engine) LaneFor(m *models.Mock) (models.AsyncLane, bool) {
 	return models.AsyncLane{}, false
 }
 
-// Decide returns the recorded mock to serve, or a keep-alive payload.
-//
-// A POLL delivery (asyncEntry.poll, from the mock's Async.Poll) is HELD
-// here on e.cond until completed reaches its anchorPos or ctx is done.
-// cond.Wait releases e.mu while parked, so AdvanceWindow/OnTestComplete are
-// NEVER gated by an outstanding held poll — that is the non-blocking
-// invariant this method must preserve. A non-poll delivery that isn't armed
-// yet returns a keep-alive immediately (unchanged pre-hold behavior). The
-// (potentially expensive) shape match itself still runs OUTSIDE the engine
-// lock, in decideServe, so poll traffic on one lane never serializes
-// unrelated lanes' Load/Report/advance.
-//
-// The hold is a re-peek LOOP, not a single wait-then-serve: under concurrent
-// same-lane Decide calls, another consumer can advance s.cursor while this
-// call is parked in cond.Wait. Every wake (and the initial pass) re-reads the
-// CURRENT s.mocks[s.cursor] and re-checks its own anchorPos before serving —
-// serving a stale, pre-wait entry could arm a later, not-yet-armed delivery.
-func (e *Engine) Decide(ctx context.Context, lane models.AsyncLane, live *models.Mock) (*models.Mock, []byte, error) {
+// Decide returns the recorded response currently in effect for the lane (the
+// last epoch with effectiveFromPos <= completed), or a keep-alive when no epoch
+// is effective yet / the lane is unknown. It never blocks on an anchor.
+func (e *Engine) Decide(_ context.Context, lane models.AsyncLane, live *models.Mock) (*models.Mock, []byte, error) {
 	e.mu.Lock()
 	p := e.parsers[lane.BaseType()]
-	// A ctx-done bridge wakes a parked cond.Wait below on cancellation
-	// (normal progress is covered by AdvanceWindow/OnTestComplete broadcasts).
-	// It is only needed once we actually park, so it is registered lazily
-	// before the first Wait — the immediate-return paths that dominate
-	// non-poll async traffic never pay for it. stopBridge is idempotent and
-	// safe to call after the callback has run.
-	var stopBridge func() bool // context.AfterFunc's stop; nil until we park
-	defer func() {
-		if stopBridge != nil {
-			stopBridge()
-		}
-	}()
-
-	for {
-		s := e.streams[lane.Name]
-		if s == nil || s.cursor >= len(s.mocks) {
-			e.mu.Unlock()
-			return e.keepAlive(p, lane) // exhausted / unknown lane
-		}
-		entry := s.mocks[s.cursor]
-		if e.completed >= entry.anchorPos {
-			if entry.poll {
-				e.held++
-			}
-			recorded := entry.mock
-			s.cursor++
-			e.mu.Unlock()
-			return e.decideServe(p, lane, recorded, live)
-		}
-		if !entry.poll {
-			// non-poll, not armed: immediate keep-alive (unchanged behavior).
-			e.mu.Unlock()
-			return e.keepAlive(p, lane)
-		}
-		if ctx.Err() != nil {
-			e.mu.Unlock()
-			return e.keepAlive(p, lane)
-		}
-		if stopBridge == nil {
-			stopBridge = context.AfterFunc(ctx, func() {
-				e.mu.Lock()
-				e.cond.Broadcast()
-				e.mu.Unlock()
-			})
-		}
-		e.cond.Wait() // releases e.mu; loop re-peeks the (possibly advanced) cursor on wake
+	s := e.streams[lane.Name]
+	if s == nil || len(s.epochs) == 0 {
+		e.mu.Unlock()
+		return e.keepAlive(p, lane)
 	}
+	cur := s.currentEpoch(e.completed)
+	e.mu.Unlock()
+	if cur == nil {
+		return e.keepAlive(p, lane)
+	}
+	return e.decideServe(p, lane, cur.mock, live)
 }
 
 // keepAlive returns the parser's "no data yet" payload for lane. Nil-safe:
@@ -331,19 +295,13 @@ func (e *Engine) decideServe(p AsyncParser, lane models.AsyncLane, recorded, liv
 	return recorded, nil, nil // serve recorded either way
 }
 
-// Report snapshots verdict tallies, counting undrained armed mocks as not-exercised.
+// Report snapshots verdict tallies. Under the epoch model every epoch is
+// always serveable (re-selectable, never consumed), so there is no
+// not-exercised or held count to compute.
 func (e *Engine) Report() ReportSnapshot {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	ne := 0
-	for _, s := range e.streams {
-		for i := s.cursor; i < len(s.mocks); i++ {
-			if e.completed >= s.mocks[i].anchorPos {
-				ne++
-			}
-		}
-	}
-	out := ReportSnapshot{Pass: e.pass, Flag: e.flag, NotExercised: ne, Held: e.held}
+	out := ReportSnapshot{Pass: e.pass, Flag: e.flag, NotExercised: 0, Held: 0}
 	out.Flags = append(out.Flags, e.flags...)
 	return out
 }

--- a/pkg/agent/proxy/integrations/async/engine.go
+++ b/pkg/agent/proxy/integrations/async/engine.go
@@ -240,11 +240,21 @@ func (e *Engine) LaneFor(m *models.Mock) (models.AsyncLane, bool) {
 	return models.AsyncLane{}, false
 }
 
-// Decide returns the recorded response currently in effect for the lane (the
-// last epoch with effectiveFromPos <= completed), or a keep-alive when no epoch
-// is effective yet / the lane is unknown. It never blocks on an anchor, but it
-// does hold each poll up to lane.ThrottleDuration() (see holdThrottle) so
-// unchanged polls are paced instead of served back-to-back.
+// Decide returns the recorded response currently in effect for the lane — the
+// last epoch with effectiveFromPos (Spec.Async.AnchorPos on disk) <= completed,
+// re-selectable — or a keep-alive when no epoch is effective yet / the lane is
+// unknown. It never blocks on an anchor.
+//
+// Scope note: this current-epoch SELECTION applies to EVERY async lane — poll
+// AND non-poll — not only poll lanes. It replaces the old consume-once cursor
+// (which served each recorded entry once, then keep-alived on drain). A non-poll
+// lane therefore now re-serves its last-effective epoch on every request rather
+// than walking a one-shot ordered sequence; sequential one-shot non-poll
+// delivery is intentionally no longer supported. The only async lane that exists
+// today (config-watch) is a value the client re-reads, for which current-epoch
+// is the correct model — TestNonPollServesReselectableCurrentEpoch pins this so a
+// future change can't regress it silently. Only the throttle hold below is gated
+// to poll lanes; unchanged in scope from the pre-value-epoch engine is nothing.
 func (e *Engine) Decide(ctx context.Context, lane models.AsyncLane, live *models.Mock) (*models.Mock, []byte, error) {
 	e.mu.Lock()
 	p := e.parsers[lane.BaseType()]
@@ -266,9 +276,18 @@ func (e *Engine) Decide(ctx context.Context, lane models.AsyncLane, live *models
 
 // holdThrottle blocks up to d, or until an AdvanceWindow/OnTestComplete
 // broadcast or ctx cancel, whichever comes first. Caller holds e.mu; it is
-// released while parked and re-held on return. This paces unchanged polls
-// (no busy loop) while letting a value change wake the poll early. Serving the
-// current epoch regardless on wake means a spurious wakeup is harmless.
+// released while parked and re-held on return.
+//
+// It paces EVERY poll — including the boot poll and a poll whose epoch already
+// advanced — so the guarantee is "answered within at most d", NOT "spaced d
+// apart". e.cond is shared across lanes and this is a single (non-looping) Wait,
+// so any lane's timer or any AdvanceWindow/OnTestComplete wakes every parked
+// poll; with several concurrent watch connections the per-poll pacing lower
+// bound collapses (fine — one poll per connection is in flight). A spurious or
+// early wake is harmless: Decide re-reads and serves the current epoch
+// regardless. Wake-early-on-change only shortens the wait when an AdvanceWindow
+// races the hold; a change that already happened before this poll arrived is
+// still served on this poll within d.
 func (e *Engine) holdThrottle(ctx context.Context, d time.Duration) {
 	if ctx.Err() != nil {
 		return

--- a/pkg/agent/proxy/integrations/async/engine.go
+++ b/pkg/agent/proxy/integrations/async/engine.go
@@ -338,9 +338,14 @@ func (e *Engine) Report() ReportSnapshot {
 }
 
 // LogReport emits the async verdict tally so it is visible in keploy's output
-// at end of replay: served-and-shape-matched, shape-flags (served despite
-// request drift), and armed-but-never-polled (not-exercised). Each shape flag
-// is logged at Info with a remediation hint.
+// at end of replay: served-and-shape-matched (served) and shape-flags (served
+// despite request drift). The not_exercised and held fields stay in the
+// emitted log line for output-format stability (CI greps them) but are always
+// 0 under the value-epoch model: every epoch is always serveable/re-
+// selectable, so nothing arms-but-never-gets-exercised, and Decide no longer
+// holds a lane's connection open — a poll lane is merely paced by throttle
+// (holdThrottle), served lanes serve immediately. Each shape flag is logged at
+// Info with a remediation hint.
 func (e *Engine) LogReport(logger *zap.Logger) {
 	e.logOnce.Do(func() {
 		s := e.Report()

--- a/pkg/agent/proxy/integrations/async/engine.go
+++ b/pkg/agent/proxy/integrations/async/engine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sort"
 	"sync"
+	"time"
 
 	"go.keploy.io/server/v3/pkg/models"
 	"go.uber.org/zap"
@@ -241,8 +242,10 @@ func (e *Engine) LaneFor(m *models.Mock) (models.AsyncLane, bool) {
 
 // Decide returns the recorded response currently in effect for the lane (the
 // last epoch with effectiveFromPos <= completed), or a keep-alive when no epoch
-// is effective yet / the lane is unknown. It never blocks on an anchor.
-func (e *Engine) Decide(_ context.Context, lane models.AsyncLane, live *models.Mock) (*models.Mock, []byte, error) {
+// is effective yet / the lane is unknown. It never blocks on an anchor, but it
+// does hold each poll up to lane.ThrottleDuration() (see holdThrottle) so
+// unchanged polls are paced instead of served back-to-back.
+func (e *Engine) Decide(ctx context.Context, lane models.AsyncLane, live *models.Mock) (*models.Mock, []byte, error) {
 	e.mu.Lock()
 	p := e.parsers[lane.BaseType()]
 	s := e.streams[lane.Name]
@@ -250,12 +253,37 @@ func (e *Engine) Decide(_ context.Context, lane models.AsyncLane, live *models.M
 		e.mu.Unlock()
 		return e.keepAlive(p, lane)
 	}
+	e.holdThrottle(ctx, lane.ThrottleDuration()) // pace + wake-early; holds e.mu
 	cur := s.currentEpoch(e.completed)
 	e.mu.Unlock()
 	if cur == nil {
 		return e.keepAlive(p, lane)
 	}
 	return e.decideServe(p, lane, cur.mock, live)
+}
+
+// holdThrottle blocks up to d, or until an AdvanceWindow/OnTestComplete
+// broadcast or ctx cancel, whichever comes first. Caller holds e.mu; it is
+// released while parked and re-held on return. This paces unchanged polls
+// (no busy loop) while letting a value change wake the poll early. Serving the
+// current epoch regardless on wake means a spurious wakeup is harmless.
+func (e *Engine) holdThrottle(ctx context.Context, d time.Duration) {
+	if ctx.Err() != nil {
+		return
+	}
+	timer := time.AfterFunc(d, func() {
+		e.mu.Lock()
+		e.cond.Broadcast()
+		e.mu.Unlock()
+	})
+	defer timer.Stop()
+	stop := context.AfterFunc(ctx, func() {
+		e.mu.Lock()
+		e.cond.Broadcast()
+		e.mu.Unlock()
+	})
+	defer stop()
+	e.cond.Wait() // releases e.mu; wakes on timer, broadcast, or ctx
 }
 
 // keepAlive returns the parser's "no data yet" payload for lane. Nil-safe:
@@ -269,10 +297,11 @@ func (e *Engine) keepAlive(p AsyncParser, lane models.AsyncLane) (*models.Mock, 
 	return nil, ka, err
 }
 
-// decideServe runs the shape-match/verdict for a recorded delivery that has
-// been armed (and, for polls, already released from its hold) and is about to
-// be served. ctx is accepted for symmetry with Decide/future cancellation-
-// aware matching; the match itself is synchronous today.
+// decideServe runs the shape-match/verdict for the epoch Decide selected as
+// current — after Decide's throttle hold (holdThrottle), if any, has elapsed
+// or been woken early — and is about to be served. It takes no ctx: the match
+// itself is synchronous and unlocked except for the pass/flag tally update, so
+// it never serializes unrelated lanes' Load/Report/advance.
 func (e *Engine) decideServe(p AsyncParser, lane models.AsyncLane, recorded, live *models.Mock) (*models.Mock, []byte, error) {
 	if p == nil {
 		if e.logger != nil {

--- a/pkg/agent/proxy/integrations/async/engine_test.go
+++ b/pkg/agent/proxy/integrations/async/engine_test.go
@@ -165,3 +165,36 @@ func TestLaneForResolvesByBaseType(t *testing.T) {
 		t.Fatalf("want LaneFor to resolve httpPoll lane via base type %q, got ok=%v lane=%+v", "http", ok, got)
 	}
 }
+
+// TestNonPollServesReselectableCurrentEpoch pins the intended NON-poll lane
+// behavior after the value-epoch change (see Decide's scope note): a non-poll
+// lane (IsPoll() == false) serves the current epoch — last with AnchorPos <=
+// completed — RE-SELECTABLY, so repeated requests re-serve it rather than
+// consuming each entry once and keep-aliving on drain (the old cursor model).
+// This guards Decide's all-lanes selection scope so a later change can't
+// silently revert non-poll lanes to one-shot ordered delivery.
+func TestNonPollServesReselectableCurrentEpoch(t *testing.T) {
+	e := newTestEngine(&fakeParser{matches: true, shapeOK: true, empty: []byte("KA")})
+	lane := models.AsyncLane{Name: "L", Type: "fake"} // non-poll: IsPoll() == false
+	e.Load([]*models.Mock{
+		asyncMock("L", 1, 0, "A"), // epoch effective from pos 0
+		asyncMock("L", 2, 1, "B"), // epoch effective from pos 1
+	})
+	// completed=0: current epoch is A, served on EVERY request (re-selectable,
+	// never consumed, never keep-alived on "drain").
+	for i := 0; i < 3; i++ {
+		rec, ka, _ := e.Decide(context.Background(), lane, &models.Mock{})
+		if rec == nil || rec.Spec.HTTPResp.Body != "A" {
+			t.Fatalf("req %d @completed=0: want re-selectable A, got rec=%v ka=%q", i, rec, ka)
+		}
+	}
+	// advance to completed=1: current epoch becomes B, also re-selectable.
+	e.AdvanceWindow() // windowSeen; completed stays 0
+	e.AdvanceWindow() // completed=1
+	for i := 0; i < 3; i++ {
+		rec, _, _ := e.Decide(context.Background(), lane, &models.Mock{})
+		if rec == nil || rec.Spec.HTTPResp.Body != "B" {
+			t.Fatalf("req %d @completed=1: want re-selectable B, got %v", i, rec)
+		}
+	}
+}

--- a/pkg/agent/proxy/integrations/async/engine_test.go
+++ b/pkg/agent/proxy/integrations/async/engine_test.go
@@ -2,9 +2,7 @@ package async
 
 import (
 	"context"
-	"sync"
 	"testing"
-	"time"
 
 	"go.keploy.io/server/v3/pkg/models"
 	"go.uber.org/zap"
@@ -25,17 +23,48 @@ func newTestEngine(p AsyncParser) *Engine {
 	return NewEngine(zap.NewNop(), []models.AsyncLane{lane}, map[string]AsyncParser{"fake": p})
 }
 
-func TestServesInSeqOrderWhenArmed(t *testing.T) {
+func TestServesCurrentEpochByCompleted(t *testing.T) {
 	e := newTestEngine(&fakeParser{matches: true, shapeOK: true, empty: []byte("KA")})
+	// epoch V0 at pos 0 (boot), epoch V1 at pos 2 (received after test-2).
 	e.Load([]*models.Mock{
-		asyncMock("L", 2, 0, "b"),
-		asyncMock("L", 1, 0, "a"), // out of order on purpose
+		asyncMock("L", 1, 0, "V0"),
+		asyncMock("L", 2, 2, "V1"),
 	})
 	lane := models.AsyncLane{Name: "L", Type: "fake"}
-	got1, _, _ := e.Decide(context.Background(), lane, &models.Mock{})
-	got2, _, _ := e.Decide(context.Background(), lane, &models.Mock{})
-	if got1.Spec.HTTPResp.Body != "a" || got2.Spec.HTTPResp.Body != "b" {
-		t.Fatalf("want a then b, got %q then %q", got1.Spec.HTTPResp.Body, got2.Spec.HTTPResp.Body)
+
+	// completed=0 (boot) -> V0
+	if rec, _, _ := e.Decide(context.Background(), lane, &models.Mock{}); rec == nil || rec.Spec.HTTPResp.Body != "V0" {
+		t.Fatalf("boot: want V0, got %v", rec)
+	}
+	e.AdvanceWindow() // windowSeen, completed=0
+	e.AdvanceWindow() // completed=1 (after test-1)
+	if rec, _, _ := e.Decide(context.Background(), lane, &models.Mock{}); rec == nil || rec.Spec.HTTPResp.Body != "V0" {
+		t.Fatalf("after test-1: want V0 (change not received), got %v", rec)
+	}
+	e.AdvanceWindow() // completed=2 (after test-2)
+	if rec, _, _ := e.Decide(context.Background(), lane, &models.Mock{}); rec == nil || rec.Spec.HTTPResp.Body != "V1" {
+		t.Fatalf("after test-2: want V1, got %v", rec)
+	}
+}
+
+func TestEpochIsReselectableNotConsumed(t *testing.T) {
+	e := newTestEngine(&fakeParser{matches: true, shapeOK: true, empty: []byte("KA")})
+	e.Load([]*models.Mock{asyncMock("L", 1, 0, "V0")})
+	lane := models.AsyncLane{Name: "L", Type: "fake"}
+	for i := 0; i < 3; i++ {
+		if rec, _, _ := e.Decide(context.Background(), lane, &models.Mock{}); rec == nil || rec.Spec.HTTPResp.Body != "V0" {
+			t.Fatalf("poll %d: epoch must be re-selectable, got %v", i, rec)
+		}
+	}
+}
+
+func TestKeepAliveWhenNoEpochEffective(t *testing.T) {
+	e := newTestEngine(&fakeParser{matches: true, shapeOK: true, empty: []byte("KA")})
+	e.Load([]*models.Mock{asyncMock("L", 1, 5, "late")}) // first epoch at pos 5
+	lane := models.AsyncLane{Name: "L", Type: "fake"}
+	rec, ka, _ := e.Decide(context.Background(), lane, &models.Mock{}) // completed=0 < 5
+	if rec != nil || string(ka) != "KA" {
+		t.Fatalf("no epoch effective yet: want keep-alive, got rec=%v ka=%q", rec, ka)
 	}
 }
 
@@ -61,17 +90,6 @@ func TestStartupArmedImmediately(t *testing.T) {
 	rec, _, _ := e.Decide(context.Background(), models.AsyncLane{Name: "L", Type: "fake"}, &models.Mock{})
 	if rec == nil || rec.Spec.HTTPResp.Body != "boot" {
 		t.Fatalf("startup mock should be armed immediately, got %v", rec)
-	}
-}
-
-func TestKeepAliveWhenDrained(t *testing.T) {
-	e := newTestEngine(&fakeParser{matches: true, shapeOK: true, empty: []byte("KA")})
-	e.Load([]*models.Mock{asyncMock("L", 1, 0, "a")})
-	lane := models.AsyncLane{Name: "L", Type: "fake"}
-	_, _, _ = e.Decide(context.Background(), lane, &models.Mock{}) // consume the only mock
-	rec, ka, _ := e.Decide(context.Background(), lane, &models.Mock{})
-	if rec != nil || string(ka) != "KA" {
-		t.Fatalf("drained lane should keep-alive, got rec=%v ka=%q", rec, ka)
 	}
 }
 
@@ -121,31 +139,6 @@ func TestLaneForFirstDeclaredWins(t *testing.T) {
 	}
 }
 
-// TestLoadIsIdempotent proves a second Load call with the same mocks is a
-// no-op once Decide has already advanced a stream's cursor: it must not
-// re-sort/re-serve an already-consumed mock.
-func TestLoadIsIdempotent(t *testing.T) {
-	e := newTestEngine(&fakeParser{matches: true, shapeOK: true, empty: []byte("KA")})
-	mocks := []*models.Mock{
-		asyncMock("L", 1, 0, "a"),
-		asyncMock("L", 2, 0, "b"),
-	}
-	lane := models.AsyncLane{Name: "L", Type: "fake"}
-
-	e.Load(mocks)
-	got1, _, _ := e.Decide(context.Background(), lane, &models.Mock{}) // consumes "a", cursor -> 1
-	if got1 == nil || got1.Spec.HTTPResp.Body != "a" {
-		t.Fatalf("first Decide: want %q, got %v", "a", got1)
-	}
-
-	e.Load(mocks) // re-Load same mocks; must be a no-op
-
-	got2, _, _ := e.Decide(context.Background(), lane, &models.Mock{}) // should serve "b", not re-serve "a"
-	if got2 == nil || got2.Spec.HTTPResp.Body != "b" {
-		t.Fatalf("second Decide after re-Load: want %q, got %v", "b", got2)
-	}
-}
-
 type holdStub struct{}
 
 func (holdStub) MatchesLane(*models.Mock, models.AsyncLane) bool { return true }
@@ -154,152 +147,6 @@ func (holdStub) MatchRequestShape(_, _ *models.Mock, _ models.AsyncLane) (bool, 
 }
 func (holdStub) EmptyResponse(models.AsyncLane) ([]byte, error)         { return []byte("204"), nil }
 func (holdStub) ResponseValueKey(*models.Mock, models.AsyncLane) string { return "" }
-
-// A poll delivery (Async.Poll) is HELD until completed reaches its anchorPos,
-// then served — while concurrent AdvanceWindow calls never block (the hold must
-// not sit on the lock). A non-poll delivery returns a keep-alive immediately.
-func TestDecideHoldsPollUntilAnchor(t *testing.T) {
-	lane := models.AsyncLane{Name: "L", Type: "httpPoll"}
-	e := NewEngine(zap.NewNop(), []models.AsyncLane{lane}, map[string]AsyncParser{"http": holdStub{}})
-	pollMock := &models.Mock{Kind: models.HTTP, Spec: models.MockSpec{
-		Async: &models.AsyncMeta{Lane: "L", Seq: 1, AnchorPos: 2, Poll: true},
-	}}
-	e.Load([]*models.Mock{pollMock})
-
-	done := make(chan *models.Mock, 1)
-	go func() {
-		rec, _, _ := e.Decide(context.Background(), lane, &models.Mock{})
-		done <- rec
-	}()
-	select {
-	case <-done:
-		t.Fatal("Decide returned before anchor reached; poll should be held")
-	case <-time.After(50 * time.Millisecond):
-	}
-	e.AdvanceWindow() // windowSeen=true, completed stays 0
-	e.AdvanceWindow() // completed=1
-	e.AdvanceWindow() // completed=2 -> arms
-	select {
-	case rec := <-done:
-		if rec != pollMock {
-			t.Fatalf("held poll served wrong mock: %+v", rec)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("held poll never released after anchor reached")
-	}
-}
-
-func TestDecidePollReleasesOnCtxCancel(t *testing.T) {
-	lane := models.AsyncLane{Name: "L", Type: "httpPoll"}
-	e := NewEngine(zap.NewNop(), []models.AsyncLane{lane}, map[string]AsyncParser{"http": holdStub{}})
-	e.Load([]*models.Mock{{Kind: models.HTTP, Spec: models.MockSpec{
-		Async: &models.AsyncMeta{Lane: "L", Seq: 1, AnchorPos: 5, Poll: true},
-	}}})
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan []byte, 1)
-	go func() { _, ka, _ := e.Decide(ctx, lane, &models.Mock{}); done <- ka }()
-	cancel()
-	select {
-	case ka := <-done:
-		if ka == nil {
-			t.Fatal("ctx-cancelled poll must release with a keep-alive")
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("ctx-cancel did not release the held poll")
-	}
-}
-
-// Plug-and-play: the hold is keyed on Async.Poll, NOT the HTTP kind. A
-// non-HTTP kind carrying Async.Poll is held the same way.
-func TestDecideHoldsNonHTTPPollKind(t *testing.T) {
-	lane := models.AsyncLane{Name: "L", Type: "mongoPoll"}
-	e := NewEngine(zap.NewNop(), []models.AsyncLane{lane}, map[string]AsyncParser{"mongo": holdStub{}})
-	e.Load([]*models.Mock{{Kind: models.Mongo, Spec: models.MockSpec{
-		Async: &models.AsyncMeta{Lane: "L", Seq: 1, AnchorPos: 1, Poll: true},
-	}}})
-	done := make(chan *models.Mock, 1)
-	go func() { rec, _, _ := e.Decide(context.Background(), lane, &models.Mock{}); done <- rec }()
-	select {
-	case <-done:
-		t.Fatal("non-HTTP poll returned before anchor; must be held on Async.Poll")
-	case <-time.After(50 * time.Millisecond):
-	}
-	e.AdvanceWindow() // windowSeen
-	e.AdvanceWindow() // completed=1 -> arms
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("non-HTTP poll never released")
-	}
-}
-
-// TestDecideConcurrentSameLaneServesInOrderByAnchor proves a parked poll's
-// wake re-peeks the CURRENT cursor entry rather than trusting the entry it
-// captured before parking. Two concurrent same-lane Decide calls both park on
-// mock1 (anchorPos 1, cursor 0). When completed reaches 1, only ONE of them
-// may serve mock1 and advance the cursor to mock2 (anchorPos 2) — the other
-// must re-check the (now-advanced) cursor's own anchor and stay parked, NOT
-// serve mock2 early just because it woke up. Without the re-peek loop, the
-// second caller trusts its stale pre-wait entry, whose anchorPos (1) is
-// already satisfied, and serves the not-yet-armed mock2 immediately.
-func TestDecideConcurrentSameLaneServesInOrderByAnchor(t *testing.T) {
-	lane := models.AsyncLane{Name: "L", Type: "httpPoll"}
-	e := NewEngine(zap.NewNop(), []models.AsyncLane{lane}, map[string]AsyncParser{"http": holdStub{}})
-	mock1 := &models.Mock{Kind: models.HTTP, Spec: models.MockSpec{
-		Async: &models.AsyncMeta{Lane: "L", Seq: 1, AnchorPos: 1, Poll: true},
-	}}
-	mock2 := &models.Mock{Kind: models.HTTP, Spec: models.MockSpec{
-		Async: &models.AsyncMeta{Lane: "L", Seq: 2, AnchorPos: 2, Poll: true},
-	}}
-	e.Load([]*models.Mock{mock1, mock2})
-
-	done := make(chan *models.Mock, 2)
-	var wg sync.WaitGroup
-	wg.Add(2)
-	for i := 0; i < 2; i++ {
-		go func() {
-			defer wg.Done()
-			rec, _, _ := e.Decide(context.Background(), lane, &models.Mock{})
-			done <- rec
-		}()
-	}
-
-	// Let both goroutines reach cond.Wait before advancing anything.
-	time.Sleep(50 * time.Millisecond)
-
-	e.AdvanceWindow() // windowSeen = true, completed stays 0
-	e.AdvanceWindow() // completed = 1: only mock1 (anchorPos 1) may resolve
-
-	select {
-	case rec := <-done:
-		if rec != mock1 {
-			t.Fatalf("completed=1: want mock1 (anchorPos 1) served, got %+v", rec)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("no Decide resolved after completed=1; mock1 should have armed")
-	}
-
-	// The other Decide must still be parked: mock2's anchorPos (2) is not yet
-	// reached. If it resolves here, it served a not-yet-armed delivery.
-	select {
-	case rec := <-done:
-		t.Fatalf("second Decide resolved before its anchor (completed=1); got %+v — served mock2 too early", rec)
-	case <-time.After(100 * time.Millisecond):
-	}
-
-	e.AdvanceWindow() // completed = 2: mock2 now armed
-
-	select {
-	case rec := <-done:
-		if rec != mock2 {
-			t.Fatalf("completed=2: want mock2 (anchorPos 2) served, got %+v", rec)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("second Decide never resolved after completed=2")
-	}
-
-	wg.Wait()
-}
 
 // TestLaneForResolvesByBaseType proves LaneFor routes a "httpPoll" lane's live
 // request to the parser registered under its base type "http" — without a

--- a/pkg/agent/proxy/integrations/async/engine_test.go
+++ b/pkg/agent/proxy/integrations/async/engine_test.go
@@ -18,8 +18,12 @@ func asyncMock(lane string, seq, anchorPos int, respBody string) *models.Mock {
 	}
 }
 
-func newTestEngine(p AsyncParser) *Engine {
-	lane := models.AsyncLane{Name: "L", Type: "fake"}
+func newTestEngine(p AsyncParser, laneName ...string) *Engine {
+	name := "L"
+	if len(laneName) > 0 {
+		name = laneName[0]
+	}
+	lane := models.AsyncLane{Name: name, Type: "fake"}
 	return NewEngine(zap.NewNop(), []models.AsyncLane{lane}, map[string]AsyncParser{"fake": p})
 }
 

--- a/pkg/agent/proxy/integrations/async/engine_test.go
+++ b/pkg/agent/proxy/integrations/async/engine_test.go
@@ -30,7 +30,7 @@ func TestServesCurrentEpochByCompleted(t *testing.T) {
 		asyncMock("L", 1, 0, "V0"),
 		asyncMock("L", 2, 2, "V1"),
 	})
-	lane := models.AsyncLane{Name: "L", Type: "fake"}
+	lane := models.AsyncLane{Name: "L", Type: "fake", ThrottleMs: 10} // keep the suite fast; default is 1s
 
 	// completed=0 (boot) -> V0
 	if rec, _, _ := e.Decide(context.Background(), lane, &models.Mock{}); rec == nil || rec.Spec.HTTPResp.Body != "V0" {
@@ -50,7 +50,7 @@ func TestServesCurrentEpochByCompleted(t *testing.T) {
 func TestEpochIsReselectableNotConsumed(t *testing.T) {
 	e := newTestEngine(&fakeParser{matches: true, shapeOK: true, empty: []byte("KA")})
 	e.Load([]*models.Mock{asyncMock("L", 1, 0, "V0")})
-	lane := models.AsyncLane{Name: "L", Type: "fake"}
+	lane := models.AsyncLane{Name: "L", Type: "fake", ThrottleMs: 10} // keep the suite fast; default is 1s
 	for i := 0; i < 3; i++ {
 		if rec, _, _ := e.Decide(context.Background(), lane, &models.Mock{}); rec == nil || rec.Spec.HTTPResp.Body != "V0" {
 			t.Fatalf("poll %d: epoch must be re-selectable, got %v", i, rec)
@@ -60,8 +60,8 @@ func TestEpochIsReselectableNotConsumed(t *testing.T) {
 
 func TestKeepAliveWhenNoEpochEffective(t *testing.T) {
 	e := newTestEngine(&fakeParser{matches: true, shapeOK: true, empty: []byte("KA")})
-	e.Load([]*models.Mock{asyncMock("L", 1, 5, "late")}) // first epoch at pos 5
-	lane := models.AsyncLane{Name: "L", Type: "fake"}
+	e.Load([]*models.Mock{asyncMock("L", 1, 5, "late")})               // first epoch at pos 5
+	lane := models.AsyncLane{Name: "L", Type: "fake", ThrottleMs: 10}  // keep the suite fast; default is 1s
 	rec, ka, _ := e.Decide(context.Background(), lane, &models.Mock{}) // completed=0 < 5
 	if rec != nil || string(ka) != "KA" {
 		t.Fatalf("no epoch effective yet: want keep-alive, got rec=%v ka=%q", rec, ka)
@@ -70,8 +70,8 @@ func TestKeepAliveWhenNoEpochEffective(t *testing.T) {
 
 func TestGatedByAnchorPosition(t *testing.T) {
 	e := newTestEngine(&fakeParser{matches: true, shapeOK: true, empty: []byte("KA")})
-	e.Load([]*models.Mock{asyncMock("L", 1, 1, "after-T1")}) // anchorPos=1
-	lane := models.AsyncLane{Name: "L", Type: "fake"}
+	e.Load([]*models.Mock{asyncMock("L", 1, 1, "after-T1")})          // anchorPos=1
+	lane := models.AsyncLane{Name: "L", Type: "fake", ThrottleMs: 10} // keep the suite fast; default is 1s
 
 	rec, ka, _ := e.Decide(context.Background(), lane, &models.Mock{}) // completed=0 -> not armed
 	if rec != nil || string(ka) != "KA" {
@@ -86,8 +86,8 @@ func TestGatedByAnchorPosition(t *testing.T) {
 
 func TestStartupArmedImmediately(t *testing.T) {
 	e := newTestEngine(&fakeParser{matches: true, shapeOK: true, empty: []byte("KA")})
-	e.Load([]*models.Mock{asyncMock("L", 1, 0, "boot")}) // anchorPos=0 (startup)
-	rec, _, _ := e.Decide(context.Background(), models.AsyncLane{Name: "L", Type: "fake"}, &models.Mock{})
+	e.Load([]*models.Mock{asyncMock("L", 1, 0, "boot")})                                                                   // anchorPos=0 (startup)
+	rec, _, _ := e.Decide(context.Background(), models.AsyncLane{Name: "L", Type: "fake", ThrottleMs: 10}, &models.Mock{}) // small throttle: keep the suite fast
 	if rec == nil || rec.Spec.HTTPResp.Body != "boot" {
 		t.Fatalf("startup mock should be armed immediately, got %v", rec)
 	}
@@ -96,7 +96,7 @@ func TestStartupArmedImmediately(t *testing.T) {
 func TestShapeMismatchServesAndFlags(t *testing.T) {
 	e := newTestEngine(&fakeParser{matches: true, shapeOK: false, empty: []byte("KA")})
 	e.Load([]*models.Mock{asyncMock("L", 1, 0, "a")})
-	rec, _, _ := e.Decide(context.Background(), models.AsyncLane{Name: "L", Type: "fake"}, &models.Mock{})
+	rec, _, _ := e.Decide(context.Background(), models.AsyncLane{Name: "L", Type: "fake", ThrottleMs: 10}, &models.Mock{}) // small throttle: keep the suite fast
 	if rec == nil {
 		t.Fatal("mismatch must still serve the recorded mock")
 	}
@@ -110,7 +110,7 @@ func TestShapeMismatchServesAndFlags(t *testing.T) {
 type otherFake struct{ fakeParser }
 
 func TestPluggableSecondTransport(t *testing.T) {
-	lane := models.AsyncLane{Name: "K", Type: "other"}
+	lane := models.AsyncLane{Name: "K", Type: "other", ThrottleMs: 10} // keep the suite fast; default is 1s
 	e := NewEngine(zap.NewNop(), []models.AsyncLane{lane},
 		map[string]AsyncParser{"other": &otherFake{fakeParser{matches: true, shapeOK: true, empty: []byte("EK")}}})
 	e.Load([]*models.Mock{asyncMock("K", 1, 0, "kafka-ish")})

--- a/pkg/agent/proxy/integrations/async/engine_test.go
+++ b/pkg/agent/proxy/integrations/async/engine_test.go
@@ -152,7 +152,8 @@ func (holdStub) MatchesLane(*models.Mock, models.AsyncLane) bool { return true }
 func (holdStub) MatchRequestShape(_, _ *models.Mock, _ models.AsyncLane) (bool, string) {
 	return true, ""
 }
-func (holdStub) EmptyResponse(models.AsyncLane) ([]byte, error) { return []byte("204"), nil }
+func (holdStub) EmptyResponse(models.AsyncLane) ([]byte, error)         { return []byte("204"), nil }
+func (holdStub) ResponseValueKey(*models.Mock, models.AsyncLane) string { return "" }
 
 // A poll delivery (Async.Poll) is HELD until completed reaches its anchorPos,
 // then served — while concurrent AdvanceWindow calls never block (the hold must

--- a/pkg/agent/proxy/integrations/async/engine_throttle_test.go
+++ b/pkg/agent/proxy/integrations/async/engine_throttle_test.go
@@ -1,0 +1,63 @@
+package async
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+func TestDecideHeldUpToThrottle(t *testing.T) {
+	e := newTestEngine(&fakeParser{matches: true, shapeOK: true, empty: []byte("KA")})
+	e.Load([]*models.Mock{asyncMock("L", 1, 0, "V0")})
+	lane := models.AsyncLane{Name: "L", Type: "fake", ThrottleMs: 80}
+	start := time.Now()
+	rec, _, _ := e.Decide(context.Background(), lane, &models.Mock{})
+	elapsed := time.Since(start)
+	if rec == nil || rec.Spec.HTTPResp.Body != "V0" {
+		t.Fatalf("want V0, got %v", rec)
+	}
+	if elapsed < 60*time.Millisecond {
+		t.Fatalf("unchanged poll should be paced by throttle (~80ms), returned in %v", elapsed)
+	}
+}
+
+func TestDecideWakesEarlyOnAdvance(t *testing.T) {
+	e := newTestEngine(&fakeParser{matches: true, shapeOK: true, empty: []byte("KA")})
+	e.Load([]*models.Mock{asyncMock("L", 1, 0, "V0"), asyncMock("L", 2, 1, "V1")})
+	lane := models.AsyncLane{Name: "L", Type: "fake", ThrottleMs: 5000} // long, must be cut short
+	e.AdvanceWindow()                                                   // windowSeen, completed=0
+	got := make(chan string, 1)
+	start := time.Now()
+	go func() {
+		rec, _, _ := e.Decide(context.Background(), lane, &models.Mock{})
+		got <- rec.Spec.HTTPResp.Body
+	}()
+	time.Sleep(20 * time.Millisecond)
+	e.AdvanceWindow() // completed=1 -> V1 effective, must wake the poll early
+	select {
+	case body := <-got:
+		if body != "V1" {
+			t.Fatalf("want V1 after advance, got %q", body)
+		}
+		if time.Since(start) > 1*time.Second {
+			t.Fatalf("did not wake early on advance (took %v of 5s throttle)", time.Since(start))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Decide did not wake early on AdvanceWindow")
+	}
+}
+
+func TestDecideReturnsOnCtxCancel(t *testing.T) {
+	e := newTestEngine(&fakeParser{matches: true, shapeOK: true, empty: []byte("KA")})
+	e.Load([]*models.Mock{asyncMock("L", 1, 0, "V0")})
+	lane := models.AsyncLane{Name: "L", Type: "fake", ThrottleMs: 5000}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { time.Sleep(20 * time.Millisecond); cancel() }()
+	start := time.Now()
+	_, _, _ = e.Decide(ctx, lane, &models.Mock{})
+	if time.Since(start) > 1*time.Second {
+		t.Fatalf("ctx cancel should end the hold promptly, took %v", time.Since(start))
+	}
+}

--- a/pkg/agent/proxy/integrations/async/engine_throttle_test.go
+++ b/pkg/agent/proxy/integrations/async/engine_throttle_test.go
@@ -11,7 +11,10 @@ import (
 func TestDecideHeldUpToThrottle(t *testing.T) {
 	e := newTestEngine(&fakeParser{matches: true, shapeOK: true, empty: []byte("KA")})
 	e.Load([]*models.Mock{asyncMock("L", 1, 0, "V0")})
-	lane := models.AsyncLane{Name: "L", Type: "fake", ThrottleMs: 80}
+	// Type must end in "Poll" (IsPoll) — the throttle hold is gated to poll
+	// lanes only; BaseType() still strips the suffix to "fake", resolving to
+	// the parser newTestEngine registered under that key.
+	lane := models.AsyncLane{Name: "L", Type: "fakePoll", ThrottleMs: 80}
 	start := time.Now()
 	rec, _, _ := e.Decide(context.Background(), lane, &models.Mock{})
 	elapsed := time.Since(start)
@@ -23,11 +26,31 @@ func TestDecideHeldUpToThrottle(t *testing.T) {
 	}
 }
 
+// TestDecideNonPollLaneSkipsThrottle proves the throttle hold (Fix: gate to
+// poll lanes only) does not apply to a non-poll async lane: Type "fake" does
+// not end in "Poll" (IsPoll false), so Decide must serve its current epoch
+// immediately even with a large ThrottleMs — the hold is a poll-only pacing
+// knob, not a blanket delay on every async Decide.
+func TestDecideNonPollLaneSkipsThrottle(t *testing.T) {
+	e := newTestEngine(&fakeParser{matches: true, shapeOK: true, empty: []byte("KA")})
+	e.Load([]*models.Mock{asyncMock("L", 1, 0, "V0")})
+	lane := models.AsyncLane{Name: "L", Type: "fake", ThrottleMs: 5000} // non-poll: large throttle must be ignored
+	start := time.Now()
+	rec, _, _ := e.Decide(context.Background(), lane, &models.Mock{})
+	elapsed := time.Since(start)
+	if rec == nil || rec.Spec.HTTPResp.Body != "V0" {
+		t.Fatalf("want V0, got %v", rec)
+	}
+	if elapsed >= 500*time.Millisecond {
+		t.Fatalf("non-poll lane must not be held by throttle, took %v (ThrottleMs=5000)", elapsed)
+	}
+}
+
 func TestDecideWakesEarlyOnAdvance(t *testing.T) {
 	e := newTestEngine(&fakeParser{matches: true, shapeOK: true, empty: []byte("KA")})
 	e.Load([]*models.Mock{asyncMock("L", 1, 0, "V0"), asyncMock("L", 2, 1, "V1")})
-	lane := models.AsyncLane{Name: "L", Type: "fake", ThrottleMs: 5000} // long, must be cut short
-	e.AdvanceWindow()                                                   // windowSeen, completed=0
+	lane := models.AsyncLane{Name: "L", Type: "fakePoll", ThrottleMs: 5000} // poll lane; long, must be cut short
+	e.AdvanceWindow()                                                       // windowSeen, completed=0
 	got := make(chan string, 1)
 	start := time.Now()
 	go func() {
@@ -52,7 +75,7 @@ func TestDecideWakesEarlyOnAdvance(t *testing.T) {
 func TestDecideReturnsOnCtxCancel(t *testing.T) {
 	e := newTestEngine(&fakeParser{matches: true, shapeOK: true, empty: []byte("KA")})
 	e.Load([]*models.Mock{asyncMock("L", 1, 0, "V0")})
-	lane := models.AsyncLane{Name: "L", Type: "fake", ThrottleMs: 5000}
+	lane := models.AsyncLane{Name: "L", Type: "fakePoll", ThrottleMs: 5000} // poll lane, so it actually holds
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() { time.Sleep(20 * time.Millisecond); cancel() }()
 	start := time.Now()

--- a/pkg/agent/proxy/integrations/async/epoch_contract_test.go
+++ b/pkg/agent/proxy/integrations/async/epoch_contract_test.go
@@ -1,0 +1,58 @@
+package async
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// Mocks exactly as the recorder emits them for a config-watch lane: epoch-0 at
+// boot (NOT_MODIFIED) and a change received after test-2 (AnchorPos=2).
+func TestBootAnsweredThenChangeAtAnchor(t *testing.T) {
+	lane := models.AsyncLane{Name: "cfg", Type: "fake", ThrottleMs: 10}
+	e := newTestEngine(&fakeParser{matches: true, shapeOK: true, empty: []byte("KA")}, "cfg")
+	e.Load([]*models.Mock{
+		asyncMock("cfg", 1, 0, "V0"), // initial, boot
+		asyncMock("cfg", 2, 2, "V1"), // change received after test-2
+	})
+
+	// Boot: no test has run (completed=0). The poll MUST be answered (this is the
+	// deadlock that used to hang the app), with the initial value.
+	ctx := context.Background()
+	if rec, _, _ := e.Decide(ctx, lane, &models.Mock{}); rec == nil || rec.Spec.HTTPResp.Body != "V0" {
+		t.Fatalf("boot poll must be answered with V0, got %v", rec)
+	}
+
+	// test-1 and test-2 windows still serve V0 (change not received yet).
+	e.AdvanceWindow() // windowSeen, completed=0 (test-1 running)
+	e.AdvanceWindow() // completed=1 (test-2 running)
+	if rec, _, _ := e.Decide(ctx, lane, &models.Mock{}); rec.Spec.HTTPResp.Body != "V0" {
+		t.Fatalf("test-2 must still see V0, got %q", rec.Spec.HTTPResp.Body)
+	}
+
+	// After test-2 completes, V1 is effective.
+	e.AdvanceWindow() // completed=2 (test-3 running)
+	if rec, _, _ := e.Decide(ctx, lane, &models.Mock{}); rec.Spec.HTTPResp.Body != "V1" {
+		t.Fatalf("test-3 must see V1, got %q", rec.Spec.HTTPResp.Body)
+	}
+}
+
+// A lane with only NOT_MODIFIED (single epoch-0) — the no-change case — always
+// answers immediately and never blocks, at any completed.
+func TestStableConfigNeverBlocks(t *testing.T) {
+	lane := models.AsyncLane{Name: "cfg", Type: "fake", ThrottleMs: 10}
+	e := newTestEngine(&fakeParser{matches: true, shapeOK: true, empty: []byte("KA")}, "cfg")
+	e.Load([]*models.Mock{asyncMock("cfg", 1, 0, "NOT_MODIFIED")})
+	for i := 0; i < 5; i++ {
+		start := time.Now()
+		rec, _, _ := e.Decide(context.Background(), lane, &models.Mock{})
+		if rec == nil || rec.Spec.HTTPResp.Body != "NOT_MODIFIED" {
+			t.Fatalf("poll %d: want NOT_MODIFIED, got %v", i, rec)
+		}
+		if time.Since(start) > 500*time.Millisecond {
+			t.Fatalf("poll %d took %v; must be throttle-bounded, never an open-ended park", i, time.Since(start))
+		}
+	}
+}

--- a/pkg/agent/proxy/integrations/async/epoch_contract_test.go
+++ b/pkg/agent/proxy/integrations/async/epoch_contract_test.go
@@ -11,15 +11,21 @@ import (
 // Mocks exactly as the recorder emits them for a config-watch lane: epoch-0 at
 // boot (NOT_MODIFIED) and a change received after test-2 (AnchorPos=2).
 func TestBootAnsweredThenChangeAtAnchor(t *testing.T) {
-	lane := models.AsyncLane{Name: "cfg", Type: "fake", ThrottleMs: 10}
+	// Type "fakePoll" so IsPoll() is true and Decide exercises the poll
+	// holdThrottle path (BaseType still resolves to the registered "fake"
+	// parser) — the boot poll below then genuinely covers the path that used to
+	// park on the old cond.Wait hold.
+	lane := models.AsyncLane{Name: "cfg", Type: "fakePoll", ThrottleMs: 10}
 	e := newTestEngine(&fakeParser{matches: true, shapeOK: true, empty: []byte("KA")}, "cfg")
 	e.Load([]*models.Mock{
 		asyncMock("cfg", 1, 0, "V0"), // initial, boot
 		asyncMock("cfg", 2, 2, "V1"), // change received after test-2
 	})
 
-	// Boot: no test has run (completed=0). The poll MUST be answered (this is the
-	// deadlock that used to hang the app), with the initial value.
+	// Boot: no test has run (completed=0). On the old anchor-hold engine a poll
+	// whose delivery anchored past the reachable window parked on cond.Wait here
+	// (the boot deadlock); the value-epoch engine MUST answer it now with the
+	// startup epoch (V0).
 	ctx := context.Background()
 	if rec, _, _ := e.Decide(ctx, lane, &models.Mock{}); rec == nil || rec.Spec.HTTPResp.Body != "V0" {
 		t.Fatalf("boot poll must be answered with V0, got %v", rec)
@@ -42,7 +48,11 @@ func TestBootAnsweredThenChangeAtAnchor(t *testing.T) {
 // A lane with only NOT_MODIFIED (single epoch-0) — the no-change case — always
 // answers immediately and never blocks, at any completed.
 func TestStableConfigNeverBlocks(t *testing.T) {
-	lane := models.AsyncLane{Name: "cfg", Type: "fake", ThrottleMs: 10}
+	// Type "fakePoll" so IsPoll() is true and Decide exercises the poll
+	// holdThrottle path (BaseType still resolves to the registered "fake"
+	// parser) — the boot poll below then genuinely covers the path that used to
+	// park on the old cond.Wait hold.
+	lane := models.AsyncLane{Name: "cfg", Type: "fakePoll", ThrottleMs: 10}
 	e := newTestEngine(&fakeParser{matches: true, shapeOK: true, empty: []byte("KA")}, "cfg")
 	e.Load([]*models.Mock{asyncMock("cfg", 1, 0, "NOT_MODIFIED")})
 	for i := 0; i < 5; i++ {

--- a/pkg/agent/proxy/integrations/http/async.go
+++ b/pkg/agent/proxy/integrations/http/async.go
@@ -114,6 +114,16 @@ func (h *HTTP) EmptyResponse(_ models.AsyncLane) ([]byte, error) {
 	return []byte("HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n"), nil
 }
 
+// ResponseValueKey fingerprints the value the client consumes: response status
+// + body. Volatile response headers (Date, etc.) are not part of the value; the
+// body carries the config version/data, so a real change materially alters it.
+func (h *HTTP) ResponseValueKey(m *models.Mock, _ models.AsyncLane) string {
+	if m == nil || m.Spec.HTTPResp == nil {
+		return ""
+	}
+	return fmt.Sprintf("%d\n%s", m.Spec.HTTPResp.StatusCode, m.Spec.HTTPResp.Body)
+}
+
 func hostAndPath(r *models.HTTPReq) (host, p string) {
 	if r.Header != nil && r.Header["Host"] != "" {
 		host = r.Header["Host"]

--- a/pkg/agent/proxy/integrations/http/async_valuekey_test.go
+++ b/pkg/agent/proxy/integrations/http/async_valuekey_test.go
@@ -1,0 +1,33 @@
+package http
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+func httpRespMock(status int, body string) *models.Mock {
+	return &models.Mock{Kind: models.HTTP, Spec: models.MockSpec{
+		HTTPResp: &models.HTTPResp{StatusCode: status, Body: body},
+	}}
+}
+
+func TestResponseValueKeyStableForSameValue(t *testing.T) {
+	h := &HTTP{}
+	lane := models.AsyncLane{Name: "L", Type: "httpPoll"}
+	a := h.ResponseValueKey(httpRespMock(200, `{"type":"NOT_MODIFIED"}`), lane)
+	b := h.ResponseValueKey(httpRespMock(200, `{"type":"NOT_MODIFIED"}`), lane)
+	if a != b {
+		t.Fatalf("same value must yield same key: %q vs %q", a, b)
+	}
+}
+
+func TestResponseValueKeyDiffersOnChange(t *testing.T) {
+	h := &HTTP{}
+	lane := models.AsyncLane{Name: "L", Type: "httpPoll"}
+	unchanged := h.ResponseValueKey(httpRespMock(200, `{"type":"NOT_MODIFIED"}`), lane)
+	changed := h.ResponseValueKey(httpRespMock(200, `{"version":39,"keys":{"flag":true}}`), lane)
+	if unchanged == changed {
+		t.Fatal("a changed body must yield a different key")
+	}
+}

--- a/pkg/agent/proxy/proxy_async_test.go
+++ b/pkg/agent/proxy/proxy_async_test.go
@@ -34,7 +34,8 @@ func (fakeAsyncParser) MatchesLane(_ *models.Mock, _ models.AsyncLane) bool { re
 func (fakeAsyncParser) MatchRequestShape(_, _ *models.Mock, _ models.AsyncLane) (bool, string) {
 	return true, ""
 }
-func (fakeAsyncParser) EmptyResponse(_ models.AsyncLane) ([]byte, error) { return []byte("KA"), nil }
+func (fakeAsyncParser) EmptyResponse(_ models.AsyncLane) ([]byte, error)           { return []byte("KA"), nil }
+func (fakeAsyncParser) ResponseValueKey(_ *models.Mock, _ models.AsyncLane) string { return "" }
 
 func asyncMock(lane string, seq int, body string) *models.Mock {
 	return &models.Mock{Kind: models.HTTP, Spec: models.MockSpec{

--- a/pkg/agent/proxy/proxy_async_test.go
+++ b/pkg/agent/proxy/proxy_async_test.go
@@ -45,9 +45,11 @@ func asyncMock(lane string, seq int, body string) *models.Mock {
 }
 
 // TestLoadAsyncMocksForwardsToEngine proves Proxy.LoadAsyncMocks hands the
-// complete corpus to the async engine's run-once Load, so a subsequent Decide
-// serves the first armed async mock in seq order (and the engine's Load filter
-// ignores the interleaved non-async mock).
+// complete corpus to the async engine's run-once Load (the engine's Load
+// filter ignores the interleaved non-async mock), and that under the
+// value-epoch model two epochs recorded at the same AnchorPos resolve to the
+// newest one: both "a" (seq 1) and "b" (seq 2) are effective at completed=0,
+// so Decide serves "b" — the last value received at that position.
 func TestLoadAsyncMocksForwardsToEngine(t *testing.T) {
 	lane := models.AsyncLane{Name: "L", Type: "fake"}
 	eng := async.NewEngine(zap.NewNop(), []models.AsyncLane{lane}, map[string]async.AsyncParser{"fake": fakeAsyncParser{}})
@@ -58,7 +60,7 @@ func TestLoadAsyncMocksForwardsToEngine(t *testing.T) {
 	p.LoadAsyncMocks([]*models.Mock{asyncMock("L", 1, "a"), nonAsync, asyncMock("L", 2, "b")})
 
 	rec, _, _ := eng.Decide(context.Background(), lane, &models.Mock{})
-	if rec == nil || rec.Spec.HTTPResp.Body != "a" {
-		t.Fatalf("want first async mock 'a', got %v", rec)
+	if rec == nil || rec.Spec.HTTPResp.Body != "b" {
+		t.Fatalf("want newest same-AnchorPos epoch 'b', got %v", rec)
 	}
 }

--- a/pkg/agent/proxy/proxy_async_test.go
+++ b/pkg/agent/proxy/proxy_async_test.go
@@ -51,7 +51,7 @@ func asyncMock(lane string, seq int, body string) *models.Mock {
 // newest one: both "a" (seq 1) and "b" (seq 2) are effective at completed=0,
 // so Decide serves "b" — the last value received at that position.
 func TestLoadAsyncMocksForwardsToEngine(t *testing.T) {
-	lane := models.AsyncLane{Name: "L", Type: "fake"}
+	lane := models.AsyncLane{Name: "L", Type: "fake", ThrottleMs: 10}
 	eng := async.NewEngine(zap.NewNop(), []models.AsyncLane{lane}, map[string]async.AsyncParser{"fake": fakeAsyncParser{}})
 	p := &Proxy{logger: zap.NewNop(), asyncEngine: eng}
 

--- a/pkg/models/async.go
+++ b/pkg/models/async.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"sort"
 	"strings"
+	"time"
 )
 
 // AsyncMeta is the async-egress engine's per-mock bookkeeping. It is carried in
@@ -46,6 +47,10 @@ type AsyncLane struct {
 	// (watch=false) as ordinary non-async egress.
 	MatchQuery     map[string]string `json:"matchQuery,omitempty" yaml:"matchQuery,omitempty" mapstructure:"matchQuery"`
 	VolatileParams []string          `json:"volatileParams,omitempty" yaml:"volatileParams,omitempty" mapstructure:"volatileParams"`
+	// ThrottleMs bounds how often an UNCHANGED poll is answered during replay,
+	// preventing a long-poll client from busy-looping when answers are instant.
+	// It never changes which value is served — purely a resource knob. 0 => 1s.
+	ThrottleMs int `json:"throttleMs,omitempty" yaml:"throttleMs,omitempty" mapstructure:"throttleMs"`
 }
 
 // EffectiveName returns the caller-supplied Name, or a deterministic name
@@ -125,6 +130,15 @@ func writeSortedKV(w io.Writer, m map[string]string) {
 // HELD open until their resolve testcase instead of served immediately.
 func (l AsyncLane) IsPoll() bool {
 	return len(l.Type) > len("Poll") && strings.EqualFold(l.Type[len(l.Type)-len("Poll"):], "Poll")
+}
+
+// ThrottleDuration is the maximum hold before an unchanged poll is answered at
+// replay. Defaults to 1s when ThrottleMs is unset or non-positive.
+func (l AsyncLane) ThrottleDuration() time.Duration {
+	if l.ThrottleMs <= 0 {
+		return time.Second
+	}
+	return time.Duration(l.ThrottleMs) * time.Millisecond
 }
 
 // BaseType returns the parser type backing the lane: the Type with any "Poll"

--- a/pkg/models/async.go
+++ b/pkg/models/async.go
@@ -13,15 +13,14 @@ import (
 // its OWN block — Spec.Async in memory, a top-level `async:` block on the
 // recorded doc — rather than merged into the owning parser's flat Spec.Metadata.
 // Its PRESENCE (non-nil) marks a mock as async egress; Poll marks a held
-// long-poll delivery whose open-duration is captured in PollDurationMs. A poll
-// mock keeps its base kind (e.g. Http) — poll-ness lives here, not in the Kind.
+// long-poll delivery. A poll mock keeps its base kind (e.g. Http) — poll-ness
+// lives here, not in the Kind.
 type AsyncMeta struct {
-	Lane           string `yaml:"lane" json:"lane" bson:"lane"`                                                             // lane name (routing identity)
-	Seq            int    `yaml:"seq" json:"seq" bson:"seq"`                                                                // per-lane order counter
-	AnchorAfter    string `yaml:"anchorAfter,omitempty" json:"anchorAfter,omitempty" bson:"anchorAfter,omitempty"`          // last completed testcase Name, or "startup" (readability)
-	AnchorPos      int    `yaml:"anchorPos" json:"anchorPos" bson:"anchorPos"`                                              // number of testcases completed before this egress fired
-	Poll           bool   `yaml:"poll,omitempty" json:"poll,omitempty" bson:"poll,omitempty"`                               // held long-poll delivery
-	PollDurationMs int64  `yaml:"pollDurationMs,omitempty" json:"pollDurationMs,omitempty" bson:"pollDurationMs,omitempty"` // recorded open-duration (ms), fidelity only
+	Lane        string `yaml:"lane" json:"lane" bson:"lane"`                                                    // lane name (routing identity)
+	Seq         int    `yaml:"seq" json:"seq" bson:"seq"`                                                       // per-lane order counter
+	AnchorAfter string `yaml:"anchorAfter,omitempty" json:"anchorAfter,omitempty" bson:"anchorAfter,omitempty"` // last completed testcase Name, or "startup" (readability)
+	AnchorPos   int    `yaml:"anchorPos" json:"anchorPos" bson:"anchorPos"`                                     // epoch effective-from: testcases completed before this value took effect (0 = boot)
+	Poll        bool   `yaml:"poll,omitempty" json:"poll,omitempty" bson:"poll,omitempty"`                      // held long-poll delivery
 }
 
 // AnchorStartup is the AsyncMeta.AnchorAfter value for async mocks that fired

--- a/pkg/models/async_test.go
+++ b/pkg/models/async_test.go
@@ -136,7 +136,7 @@ func TestAsyncLaneIsPollAndBaseType(t *testing.T) {
 // block can be mutated (e.g. by a gob-write path) without racing the original.
 func TestDeepCopyIsolatesAsyncMeta(t *testing.T) {
 	orig := &Mock{Kind: HTTP, Spec: MockSpec{
-		Async: &AsyncMeta{Lane: "L", Seq: 1, AnchorPos: 3, Poll: true, PollDurationMs: 8000},
+		Async: &AsyncMeta{Lane: "L", Seq: 1, AnchorPos: 3, Poll: true},
 	}}
 	c := orig.DeepCopy()
 	if c.Spec.Async == nil || *c.Spec.Async != *orig.Spec.Async {

--- a/pkg/models/async_throttle_test.go
+++ b/pkg/models/async_throttle_test.go
@@ -1,0 +1,21 @@
+package models
+
+import (
+	"testing"
+	"time"
+)
+
+func TestThrottleDurationDefault(t *testing.T) {
+	if got := (AsyncLane{}).ThrottleDuration(); got != time.Second {
+		t.Fatalf("unset throttle: want 1s, got %v", got)
+	}
+	if got := (AsyncLane{ThrottleMs: 0}).ThrottleDuration(); got != time.Second {
+		t.Fatalf("zero throttle: want 1s, got %v", got)
+	}
+}
+
+func TestThrottleDurationExplicit(t *testing.T) {
+	if got := (AsyncLane{ThrottleMs: 250}).ThrottleDuration(); got != 250*time.Millisecond {
+		t.Fatalf("want 250ms, got %v", got)
+	}
+}

--- a/pkg/platform/yaml/mockdb/httppoll_test.go
+++ b/pkg/platform/yaml/mockdb/httppoll_test.go
@@ -10,15 +10,14 @@ import (
 
 // An async mock keeps kind Http (poll-ness is not a distinct kind) and carries
 // its bookkeeping in a top-level async block that must round-trip through
-// mocks.yaml byte-equivalently — including a held long-poll's poll/pollDurationMs.
+// mocks.yaml byte-equivalently — including a held long-poll's poll flag.
 func TestAsyncBlockRoundTrips(t *testing.T) {
 	want := &models.AsyncMeta{
-		Lane:           "config-watch",
-		Seq:            1,
-		AnchorAfter:    "get-rules-1",
-		AnchorPos:      3,
-		Poll:           true,
-		PollDurationMs: 300099,
+		Lane:        "config-watch",
+		Seq:         1,
+		AnchorAfter: "get-rules-1",
+		AnchorPos:   3,
+		Poll:        true,
 	}
 	m := &models.Mock{
 		Version: models.GetVersion(),

--- a/pkg/service/record/asynchook.go
+++ b/pkg/service/record/asynchook.go
@@ -23,15 +23,16 @@ type AsyncRecorder struct {
 	lanes   []models.AsyncLane
 	parsers map[string]async.AsyncParser
 
-	mu    sync.Mutex
-	tests []testWindow   // ingress windows, by start timestamp
-	seq   map[string]int // per-lane counter
+	mu      sync.Mutex
+	tests   []testWindow      // ingress windows, by start timestamp
+	seq     map[string]int    // per-lane counter
+	lastKey map[string]string // per-poll-lane last emitted value key (change detection)
 }
 
 func NewAsyncRecorder(logger *zap.Logger, lanes []models.AsyncLane, parsers map[string]async.AsyncParser) *AsyncRecorder {
 	// Fill in any omitted lane names so the stamped Async.Lane value is the
 	// same deterministic key the replay engine re-derives.
-	return &AsyncRecorder{logger: logger, lanes: models.WithEffectiveNames(lanes), parsers: parsers, seq: map[string]int{}}
+	return &AsyncRecorder{logger: logger, lanes: models.WithEffectiveNames(lanes), parsers: parsers, seq: map[string]int{}, lastKey: map[string]string{}}
 }
 
 // AfterTestCaseInsert tracks each ingress testcase's window START. Uses the
@@ -75,28 +76,43 @@ func (r *AsyncRecorder) BeforeMockInsert(_ context.Context, info *MockContext) e
 		if !p.MatchesLane(m, lane) {
 			continue
 		}
+
+		if lane.IsPoll() {
+			// Poll lanes emit a minimal value-epoch timeline instead of a
+			// stamp-per-cycle: diff this response's value against the last
+			// emitted value for the lane. Unchanged => collapse (drop the
+			// mock); the first value => epoch-0 (effective from boot);
+			// a changed value => a new epoch anchored where it was received.
+			key := p.ResponseValueKey(m, lane)
+			r.mu.Lock()
+			prev, seen := r.lastKey[lane.Name]
+			if seen && key == prev {
+				r.mu.Unlock()
+				info.Skip = true // collapse unchanged cycle
+				return nil
+			}
+			var anchorID string
+			var pos int
+			if !seen {
+				anchorID, pos = models.AnchorStartup, 0 // initial value: effective from boot
+			} else {
+				anchorID, pos = r.anchorLocked(m.Spec.ResTimestampMock.UnixNano()) // change: where received
+			}
+			r.seq[lane.Name]++
+			seq := r.seq[lane.Name]
+			r.lastKey[lane.Name] = key
+			r.mu.Unlock()
+			m.Spec.Async = &models.AsyncMeta{Lane: lane.Name, Seq: seq, AnchorAfter: anchorID, AnchorPos: pos, Poll: true}
+			return nil
+		}
+
+		// non-poll async lane: unchanged (anchor by response completion).
 		r.mu.Lock()
 		r.seq[lane.Name]++
 		seq := r.seq[lane.Name]
-		// Anchor by the async COMPLETION time (response timestamp).
 		anchorID, anchorPos := r.anchorLocked(m.Spec.ResTimestampMock.UnixNano())
 		r.mu.Unlock()
-
-		// Async bookkeeping goes in its own block (Spec.Async), NOT the flat
-		// parser Metadata. The mock keeps its base kind (e.g. Http); poll-ness
-		// is Async.Poll, not a distinct Kind.
-		am := &models.AsyncMeta{
-			Lane:        lane.Name,
-			Seq:         seq,
-			AnchorAfter: anchorID,
-			AnchorPos:   anchorPos,
-		}
-		if lane.IsPoll() {
-			am.Poll = true
-			durMs := m.Spec.ResTimestampMock.Sub(m.Spec.ReqTimestampMock).Milliseconds()
-			am.PollDurationMs = max(durMs, 0)
-		}
-		m.Spec.Async = am
+		m.Spec.Async = &models.AsyncMeta{Lane: lane.Name, Seq: seq, AnchorAfter: anchorID, AnchorPos: anchorPos}
 		return nil
 	}
 	return nil

--- a/pkg/service/record/asynchook_test.go
+++ b/pkg/service/record/asynchook_test.go
@@ -2,6 +2,7 @@ package record
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -20,8 +21,18 @@ func (laneStub) MatchesLane(m *models.Mock, _ models.AsyncLane) bool {
 func (laneStub) MatchRequestShape(_, _ *models.Mock, _ models.AsyncLane) (bool, string) {
 	return true, ""
 }
-func (laneStub) EmptyResponse(_ models.AsyncLane) ([]byte, error)           { return nil, nil }
-func (laneStub) ResponseValueKey(_ *models.Mock, _ models.AsyncLane) string { return "" }
+func (laneStub) EmptyResponse(_ models.AsyncLane) ([]byte, error) { return nil, nil }
+
+// ResponseValueKey fingerprints status+body, mirroring the real HTTP parser
+// (pkg/agent/proxy/integrations/http/async.go) — a nil guard plus
+// status-code+body, so the recorder's diff/collapse tests exercise a real
+// value-change signal instead of a constant no-op key.
+func (laneStub) ResponseValueKey(m *models.Mock, _ models.AsyncLane) string {
+	if m == nil || m.Spec.HTTPResp == nil {
+		return ""
+	}
+	return fmt.Sprintf("%d\n%s", m.Spec.HTTPResp.StatusCode, m.Spec.HTTPResp.Body)
+}
 
 func egress(kind string, completedAt time.Time) *models.Mock {
 	return &models.Mock{Kind: models.HTTP, Spec: models.MockSpec{
@@ -148,8 +159,10 @@ func TestNonLaneEgressUntouched(t *testing.T) {
 	}
 }
 
-// A poll lane (Type ends in "Poll") sets Async.Poll + PollDurationMs and leaves
-// the mock's base kind (Http) unchanged — poll-ness is Async.Poll, not a Kind.
+// A poll lane (Type ends in "Poll") sets Async.Poll and leaves the mock's base
+// kind (Http) unchanged — poll-ness is Async.Poll, not a Kind. This is the
+// first (and only) BeforeMockInsert call for the lane on a fresh recorder, so
+// it takes the "first value" branch (epoch-0) regardless of timestamps.
 func TestPollLaneStampsPollMeta(t *testing.T) {
 	lane := models.AsyncLane{Type: "httpPoll", Match: map[string]string{"x": "y"}}
 	r := NewAsyncRecorder(zap.NewNop(), []models.AsyncLane{lane},
@@ -157,42 +170,14 @@ func TestPollLaneStampsPollMeta(t *testing.T) {
 
 	m := egress("lane", time.Unix(1000, 0))
 	m.Kind = models.HTTP
-	m.Spec.ReqTimestampMock = time.Unix(999, 0) // open 1s before resolve
 	_ = r.BeforeMockInsert(context.Background(), &MockContext{Mock: m})
 
 	a := m.Spec.Async
 	if a == nil || !a.Poll {
 		t.Fatalf("poll lane must set Async.Poll: %+v", a)
-	}
-	if a.PollDurationMs != 1000 {
-		t.Fatalf("PollDurationMs = %d want 1000", a.PollDurationMs)
 	}
 	if m.Kind != models.HTTP {
 		t.Fatalf("poll-lane mock kind = %q want Http (poll-ness is not a kind)", m.Kind)
-	}
-}
-
-// TestPollLaneClampsNegativePollDurationToZero pins the clamp at
-// asynchook.go ~lines 97-100: a poll mock whose ResTimestampMock lands BEFORE
-// its ReqTimestampMock (clock skew / test fixture oddity) must record
-// pollDurationMs as "0", never a negative number.
-func TestPollLaneClampsNegativePollDurationToZero(t *testing.T) {
-	lane := models.AsyncLane{Type: "httpPoll", Match: map[string]string{"x": "y"}}
-	r := NewAsyncRecorder(zap.NewNop(), []models.AsyncLane{lane},
-		map[string]async.AsyncParser{"http": laneStub{}}) // keyed by BaseType
-
-	m := egress("lane", time.Unix(1000, 0)) // ResTimestampMock = 1000
-	m.Kind = models.HTTP
-	m.Spec.ReqTimestampMock = time.Unix(1001, 0) // opens AFTER resolve -> negative raw duration
-	_ = r.BeforeMockInsert(context.Background(), &MockContext{Mock: m})
-
-	a := m.Spec.Async
-	if a == nil || !a.Poll {
-		t.Fatalf("poll lane must set Async.Poll: %+v", a)
-	}
-	if a.PollDurationMs != 0 {
-		t.Fatalf("PollDurationMs = %d want clamped 0 (ResTimestampMock before ReqTimestampMock)",
-			a.PollDurationMs)
 	}
 }
 
@@ -245,5 +230,117 @@ func TestAsyncPollMockExcludedFromPerTestMapping(t *testing.T) {
 	}
 	if len(got) != 1 || got[0].Name != syncMockName {
 		t.Fatalf("expected only the sync mock in the per-test mapping, got: %+v", got)
+	}
+}
+
+// --- poll value-epoch test helpers -----------------------------------------
+//
+// pollLane is the single httpPoll lane shared by the tests below. Its
+// Match/MatchQuery mirror a realistic config-watch long-poll endpoint; the
+// actual matching in this file is still driven by laneStub.MatchesLane
+// (Spec.Metadata["kind"] == "lane"), so these fields document intent for
+// readers rather than drive test mechanics.
+var pollLane = models.AsyncLane{
+	Name:       "config-watch",
+	Type:       "httpPoll",
+	Match:      map[string]string{"pathRegex": "^/v1/buckets/feature_flags$"},
+	MatchQuery: map[string]string{"watch": "true"},
+}
+
+// newPollRecorderForTest builds an AsyncRecorder wired to the single
+// pollLane above, backed by laneStub — mirroring the recorder construction
+// used by TestAsyncPollMockExcludedFromPerTestMapping.
+func newPollRecorderForTest(t *testing.T) *AsyncRecorder {
+	t.Helper()
+	return NewAsyncRecorder(zap.NewNop(), []models.AsyncLane{pollLane},
+		map[string]async.AsyncParser{"http": laneStub{}})
+}
+
+// pollRespMock builds a poll-lane egress mock whose Spec.HTTPReq matches the
+// lane (path /v1/buckets/feature_flags, query watch=true) and whose
+// Spec.HTTPResp carries the given status/body — the VALUE laneStub's
+// ResponseValueKey fingerprints for change detection.
+func pollRespMock(t *testing.T, status int, body string) *models.Mock {
+	t.Helper()
+	return pollRespMockAt(t, status, body, 0)
+}
+
+// pollRespMockAt is pollRespMock plus an explicit Spec.ResTimestampMock (unix
+// seconds), letting a test place a response's completion time relative to
+// recorded testcase windows (see anchorLocked).
+func pollRespMockAt(t *testing.T, status int, body string, resTsUnixSec int64) *models.Mock {
+	t.Helper()
+	return &models.Mock{
+		Kind: models.HTTP,
+		Spec: models.MockSpec{
+			Metadata: map[string]string{"kind": "lane"},
+			HTTPReq: &models.HTTPReq{
+				Method:    "GET",
+				URL:       "http://svc/v1/buckets/feature_flags?watch=true",
+				URLParams: map[string]string{"watch": "true"},
+			},
+			HTTPResp:         &models.HTTPResp{StatusCode: status, Body: body},
+			ResTimestampMock: time.Unix(resTsUnixSec, 0),
+		},
+	}
+}
+
+// testCtxAt builds a TestCaseContext whose TestCase.HTTPReq.Timestamp is set
+// to the given unix-seconds value, for feeding AfterTestCaseInsert so
+// anchorLocked can resolve a position against it.
+func testCtxAt(t *testing.T, name string, tsUnixSec int64) *TestCaseContext {
+	t.Helper()
+	return &TestCaseContext{
+		TestCase: &models.TestCase{Name: name, HTTPReq: models.HTTPReq{Timestamp: time.Unix(tsUnixSec, 0)}},
+	}
+}
+
+// The first poll response ever seen for a lane is never collapsed: it seeds
+// the epoch timeline at AnchorPos=0 (effective from boot), regardless of any
+// testcase windows recorded so far.
+func TestPollFirstResponseIsEpochZero(t *testing.T) {
+	rec := newPollRecorderForTest(t)
+	m := pollRespMock(t, 200, `{"type":"NOT_MODIFIED"}`)
+	info := &MockContext{Mock: m}
+	_ = rec.BeforeMockInsert(context.Background(), info)
+	if info.Skip {
+		t.Fatal("first poll response must not be skipped")
+	}
+	if a := m.Spec.Async; a == nil || a.AnchorPos != 0 || !a.Poll {
+		t.Fatalf("first response: want epoch-0 poll, got %+v", a)
+	}
+}
+
+// A poll cycle whose response VALUE is unchanged from the last emitted one
+// must be collapsed (Skip=true) rather than stamped as a new epoch.
+func TestPollUnchangedIsCollapsed(t *testing.T) {
+	rec := newPollRecorderForTest(t)
+	first := pollRespMock(t, 200, `{"type":"NOT_MODIFIED"}`)
+	_ = rec.BeforeMockInsert(context.Background(), &MockContext{Mock: first})
+	dup := pollRespMock(t, 200, `{"type":"NOT_MODIFIED"}`)
+	info := &MockContext{Mock: dup}
+	_ = rec.BeforeMockInsert(context.Background(), info)
+	if !info.Skip {
+		t.Fatal("unchanged poll cycle must be collapsed (Skip=true)")
+	}
+}
+
+// A poll response whose value CHANGED from the last emitted one must be
+// emitted (never collapsed) as a new epoch anchored where it was received.
+func TestPollChangeIsNewEpochAtResponsePos(t *testing.T) {
+	rec := newPollRecorderForTest(t)
+	// record two test windows so anchorLocked can resolve a position.
+	_ = rec.AfterTestCaseInsert(context.Background(), testCtxAt(t, "test-1", 100))
+	_ = rec.AfterTestCaseInsert(context.Background(), testCtxAt(t, "test-2", 200))
+	first := pollRespMock(t, 200, `{"type":"NOT_MODIFIED"}`)
+	_ = rec.BeforeMockInsert(context.Background(), &MockContext{Mock: first})
+	changed := pollRespMockAt(t, 200, `{"version":39}`, 250) // resTs after both windows
+	info := &MockContext{Mock: changed}
+	_ = rec.BeforeMockInsert(context.Background(), info)
+	if info.Skip {
+		t.Fatal("a changed poll response must be emitted, not collapsed")
+	}
+	if a := changed.Spec.Async; a == nil || a.AnchorPos != 2 {
+		t.Fatalf("change received after test-2: want AnchorPos=2, got %+v", a)
 	}
 }

--- a/pkg/service/record/asynchook_test.go
+++ b/pkg/service/record/asynchook_test.go
@@ -20,7 +20,8 @@ func (laneStub) MatchesLane(m *models.Mock, _ models.AsyncLane) bool {
 func (laneStub) MatchRequestShape(_, _ *models.Mock, _ models.AsyncLane) (bool, string) {
 	return true, ""
 }
-func (laneStub) EmptyResponse(_ models.AsyncLane) ([]byte, error) { return nil, nil }
+func (laneStub) EmptyResponse(_ models.AsyncLane) ([]byte, error)           { return nil, nil }
+func (laneStub) ResponseValueKey(_ *models.Mock, _ models.AsyncLane) string { return "" }
 
 func egress(kind string, completedAt time.Time) *models.Mock {
 	return &models.Mock{Kind: models.HTTP, Spec: models.MockSpec{

--- a/pkg/service/record/hooks.go
+++ b/pkg/service/record/hooks.go
@@ -17,6 +17,10 @@ type TestCaseContext struct {
 type MockContext struct {
 	Mock      *models.Mock
 	TestSetID string
+	// Skip, when set by a BeforeMockInsert hook, tells the recorder to DROP this
+	// mock (do not persist/map/correlate it) — e.g. the AsyncRecorder collapsing
+	// an unchanged poll cycle.
+	Skip bool
 }
 
 // RecordHooks allows enterprise (or any consumer) to inject behaviour into the

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -579,14 +579,18 @@ func (r *Recorder) Start(ctx context.Context) error {
 			}
 			domainSet.AddAll(telemetry.ExtractDomainsFromMock(mock))
 			tempID := mock.Name
-			if hookErr := r.hooks.BeforeMockInsert(ctx, &MockContext{
-				Mock: mock, TestSetID: newTestSetID,
-			}); hookErr != nil {
+			mockCtx := &MockContext{Mock: mock, TestSetID: newTestSetID}
+			if hookErr := r.hooks.BeforeMockInsert(ctx, mockCtx); hookErr != nil {
 				r.logger.Error("BeforeMockInsert hook failed; recording will continue but hook side-effects may be missing. Check your RecordHooks implementation.",
 					zap.Error(hookErr),
 					zap.String("testSetID", newTestSetID),
 					zap.String("mockName", mock.Name),
 					zap.String("mockKind", mock.GetKind()))
+			}
+			if mockCtx.Skip {
+				// A hook asked to drop this mock (collapsed async poll no-change
+				// cycle). Do not persist, map, or correlate it.
+				continue
 			}
 			// The AsyncRecorder hook sets Spec.Async in BeforeMockInsert above;
 			// remember it so the mapping goroutine below never per-test maps it.


### PR DESCRIPTION
## What & why

Replaying an async `httpPoll` lane (a long-poll "watch" dependency, e.g. a config-service watch) could **wedge the application under test at boot**:

- `Decide` parked the poll on an **un-timed** `cond.Wait` gated on a test-position anchor. If the anchor was never reached (e.g. the app blocks on the poll during startup, before any test window opens), the connection was held **indefinitely** until replay teardown.
- The keep-alive emitted while held was a bare `HTTP/1.1 204 No Content`. A client that reads the response body unconditionally treats a 204 (null entity) as an error and re-polls in a tight loop.
- The recorded `pollDurationMs` was **never read** at replay ("fidelity only") — replay reproduced neither the long-poll's duration nor its terminal response.

Net effect: a poll the app treats as a harmless background long-poll during recording becomes an open-ended, never-answered park during replay, which can deadlock a startup-blocking client and flag every case unreplayable.

## The fix: a value-epoch model

A poll lane is modeled as a **timeline of value epochs** — a value in effect from a test position until the next change.

**Record side** (`pkg/service/record/asynchook.go`)
- New `AsyncParser.ResponseValueKey` fingerprints the value a poll response conveys (status + body for HTTP).
- The recorder diffs each poll response against the last emitted value for the lane and emits a **minimal** timeline: the first value at `AnchorPos = 0` (boot), each genuine change at the test position where the app received it; **unchanged cycles are collapsed** (dropped via a new `MockContext.Skip`).

**Replay side** (`pkg/agent/proxy/integrations/async/engine.go`)
- `Decide` serves "the last epoch with `AnchorPos <= completed`" (re-selectable; no cursor consumption).
- Poll lanes are held **at most `throttleMs`** (new per-lane field, default 1000 ms) and **woken early on a value change** — pacing unchanged polls without a busy-loop, never an indefinite park.
- The bare-204 keep-alive is gone from the poll path — the current epoch's real recorded response is served.

**Removed:** `AsyncMeta.PollDurationMs` (unused).

## Behavior change / scope

- **Recorded bundle format changes for poll lanes** (poll cycles are now collapsed value-epochs; `pollDurationMs` dropped). This is **not backward compatible** — existing poll-lane test sets should be re-recorded.
- The **throttle hold** is gated to `httpPoll` lanes (`lane.IsPoll()`); non-poll async lanes are **not** paced.
- **However, the current-epoch _selection_ model applies to _all_ async lanes, not only poll lanes** (updated from an earlier, narrower scope claim per review). Non-poll lanes switch from the old consume-once cursor (serve each entry once, keep-alive on drain) to **re-selectable current-epoch**; sequential one-shot non-poll delivery is intentionally no longer supported. The only async lane that exists today (config-watch) is a value the client re-reads, for which current-epoch is correct. `TestNonPollServesReselectableCurrentEpoch` pins this so a later change can't regress it silently.
- Verified no out-of-tree `AsyncParser` implementer exists in the sibling repos (`keploy-enterprise`, `k8s-proxy`) that the new required `ResponseValueKey` method would break; both only declare `AsyncLane` config and use the env-var wire contract.

## Tests

- Unit: `throttleMs` default; `ResponseValueKey` fingerprinting; engine epoch selection + throttle hold (held-up-to-throttle, wake-early-on-advance, ctx-cancel, non-poll-skips-throttle, non-poll-re-selectable); recorder diff/collapse/anchoring.
- Integration: record→replay epoch contract (boot answered at `completed=0` on a poll lane, change served at its anchor, stable config never blocks).
- Updated the `async_config_poll` (httppoll) e2e assertions for the epoch model.

All touched packages build and pass; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
