### PR TITLE
feat(docker): invoke the compose service hook per-service

### DIFF
--- a/pkg/platform/docker/compose_service_hook_test.go
+++ b/pkg/platform/docker/compose_service_hook_test.go
@@ -1,0 +1,127 @@
+package docker
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// envSeqValue returns the value of KEY in a service's list-form `environment`
+// ("KEY=value"), or "" if absent.
+func envSeqValue(serviceNode *yaml.Node, key string) string {
+	env := mappingValueByKey(serviceNode, "environment")
+	if env == nil || env.Kind != yaml.SequenceNode {
+		return ""
+	}
+	prefix := key + "="
+	for _, n := range env.Content {
+		if n.Kind == yaml.ScalarNode && strings.HasPrefix(n.Value, prefix) {
+			return strings.TrimPrefix(n.Value, prefix)
+		}
+	}
+	return ""
+}
+
+// The per-service ComposeServiceHook contract: modifyAppServiceForKeploy must
+// invoke the hook for the RECORDED APP service (not only keploy-agent), and it
+// must do so AFTER it has set the app's JAVA_TOOL_OPTIONS truststore — so a
+// downstream hook (the enterprise low-latency hook) can append the deterministic
+// JVM -javaagent to an already-populated JAVA_TOOL_OPTIONS. This is what replaces
+// jattach for compose Java TLS capture.
+func TestModifyAppServiceForKeploy_InvokesHookForAppServiceAfterTrustStore(t *testing.T) {
+	var seenNames []string
+	var appNode *yaml.Node
+	var jtoAtHookTime string
+
+	prev := ComposeServiceHook
+	t.Cleanup(func() { ComposeServiceHook = prev })
+	ComposeServiceHook = func(serviceName string, serviceNode *yaml.Node) {
+		seenNames = append(seenNames, serviceName)
+		if serviceName == "app" {
+			appNode = serviceNode
+			jtoAtHookTime = envSeqValue(serviceNode, "JAVA_TOOL_OPTIONS")
+		}
+	}
+
+	compose := buildComposeForDNSMigration("app", nil)
+	if err := newImpl().modifyAppServiceForKeploy(compose, "app"); err != nil {
+		t.Fatalf("modifyAppServiceForKeploy returned error: %v", err)
+	}
+
+	// The hook fired for the app service exactly once.
+	appHookCalls := 0
+	for _, n := range seenNames {
+		if n == "app" {
+			appHookCalls++
+		}
+	}
+	if appHookCalls != 1 {
+		t.Fatalf("expected the hook called once for the app service, saw %v", seenNames)
+	}
+	// It received the actual app service node (so it can mutate it in place).
+	if appNode != findServiceByName(compose, "app") {
+		t.Fatalf("hook received a node that is not the app service node")
+	}
+	// Ordering: the truststore JAVA_TOOL_OPTIONS was already set when the hook ran,
+	// so the enterprise hook's -javaagent append composes onto it rather than
+	// clobbering it.
+	if !strings.Contains(jtoAtHookTime, "trustStore") {
+		t.Fatalf("hook must run AFTER the truststore is set; JAVA_TOOL_OPTIONS at hook time = %q", jtoAtHookTime)
+	}
+}
+
+// The identifier the hook receives for the app service must be the
+// --container-name value the downstream matches on, NOT the compose map key.
+// When a service is selected by its `container_name` (different from its key),
+// passing the key would make the enterprise app hook silently miss and Java TLS
+// go uncaptured.
+func TestModifyAppServiceForKeploy_HookIdentifierIsContainerNameNotKey(t *testing.T) {
+	var appIdentifier string
+	prev := ComposeServiceHook
+	t.Cleanup(func() { ComposeServiceHook = prev })
+	ComposeServiceHook = func(serviceIdentifier string, _ *yaml.Node) {
+		appIdentifier = serviceIdentifier // only the app hook fires in modifyAppServiceForKeploy
+	}
+
+	// Service KEY is "web", but container_name is "my-app"; recorded with
+	// --container-name my-app.
+	webSvc := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{
+		{Kind: yaml.ScalarNode, Value: "image"},
+		{Kind: yaml.ScalarNode, Value: "app:latest"},
+		{Kind: yaml.ScalarNode, Value: "container_name"},
+		{Kind: yaml.ScalarNode, Value: "my-app"},
+	}}
+	compose := &Compose{}
+	compose.Services = yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{
+		{Kind: yaml.ScalarNode, Value: "keploy-agent"},
+		{Kind: yaml.MappingNode, Content: []*yaml.Node{}},
+		{Kind: yaml.ScalarNode, Value: "web"},
+		webSvc,
+	}}
+
+	if err := newImpl().modifyAppServiceForKeploy(compose, "my-app"); err != nil {
+		t.Fatalf("modifyAppServiceForKeploy returned error: %v", err)
+	}
+	if appIdentifier != "my-app" {
+		t.Fatalf("hook received %q, want the --container-name value \"my-app\" (not the service key \"web\")", appIdentifier)
+	}
+}
+
+// A nil ComposeServiceHook must be a no-op (OSS-only builds have no enterprise
+// hook registered) — modifyAppServiceForKeploy must still succeed.
+func TestModifyAppServiceForKeploy_NilHookIsNoOp(t *testing.T) {
+	prev := ComposeServiceHook
+	t.Cleanup(func() { ComposeServiceHook = prev })
+	ComposeServiceHook = nil
+
+	compose := buildComposeForDNSMigration("app", nil)
+	if err := newImpl().modifyAppServiceForKeploy(compose, "app"); err != nil {
+		t.Fatalf("modifyAppServiceForKeploy with nil hook returned error: %v", err)
+	}
+	// The app still gets its truststore JAVA_TOOL_OPTIONS from OSS.
+	appSvc := findServiceByName(compose, "app")
+	if !strings.Contains(envSeqValue(appSvc, "JAVA_TOOL_OPTIONS"), "trustStore") {
+		t.Fatalf("app service missing truststore JAVA_TOOL_OPTIONS")
+	}
+}

--- a/pkg/platform/docker/docker.go
+++ b/pkg/platform/docker/docker.go
@@ -40,9 +40,19 @@ const (
 	defaultTimeoutForDockerQuery = 1 * time.Minute
 )
 
-// ComposeServiceHook is called after the keploy-agent Docker Compose service
-// node is built, allowing downstream callers to mutate it.
-var ComposeServiceHook func(serviceNode *yaml.Node)
+// ComposeServiceHook is called for each keploy-managed Docker Compose service
+// node during generation so a downstream caller (the enterprise low-latency hook)
+// can mutate the right one. E.g. it adds the deterministic JVM agent (-javaagent
+// in JAVA_TOOL_OPTIONS, jar delivered via the shared keploy-tls volume) to the APP
+// service, and low-latency caps/tmpfs to the AGENT service.
+//
+// The identifier passed is what the downstream matches on, NOT the compose map
+// key: "keploy-agent" for the agent service, and the caller-supplied
+// appContainerName (the --container-name value) for the recorded app service. This
+// matters because the app service can be selected by its `container_name` rather
+// than its service key, so passing the map key would make the app hook silently
+// miss (and Java TLS would go uncaptured) whenever the two differ.
+var ComposeServiceHook func(serviceIdentifier string, serviceNode *yaml.Node)
 
 type Impl struct {
 	nativeDockerClient.APIClient
@@ -914,7 +924,7 @@ func (idc *Impl) GenerateKeployAgentService(opts models.SetupOptions) (*yaml.Nod
 	// Allow callers to mutate the fully-built service node. This runs last
 	// so the hook can see and modify all fields including volumes.
 	if ComposeServiceHook != nil {
-		ComposeServiceHook(serviceNode)
+		ComposeServiceHook("keploy-agent", serviceNode)
 	}
 
 	return serviceNode, nil
@@ -1078,6 +1088,19 @@ func (idc *Impl) modifyAppServiceForKeploy(compose *Compose, appContainerName st
 
 			// Add network mode sharing
 			idc.addServiceProperty(serviceContentNode, "network_mode", fmt.Sprintf("service:%s", "keploy-agent"))
+
+			// Let a downstream caller mutate the APP service too — the enterprise
+			// low-latency hook uses this to append the deterministic JVM agent
+			// (-javaagent in JAVA_TOOL_OPTIONS). The app shares keploy-agent's PID
+			// AND network namespace (set above), so the JVM reaches the JSSE
+			// listener on 127.0.0.1 and its PID is directly resolvable — no jattach.
+			// Pass appContainerName (the --container-name value the downstream
+			// matches on), NOT serviceName (the compose map key): this service may
+			// have been selected by its container_name, in which case the key differs
+			// and the app hook would silently miss.
+			if ComposeServiceHook != nil {
+				ComposeServiceHook(appContainerName, serviceContentNode)
+			}
 
 			break
 		}


### PR DESCRIPTION
## What

Makes the Docker Compose generation hook (`ComposeServiceHook`) fire **per-service** so a downstream (enterprise low-latency) hook can mutate both the `keploy-agent` service **and** the recorded **app** service.

This is the OSS half of moving Docker Compose Java (SunJSSE) TLS capture off **jattach** onto env-based `-javaagent` injection. The app already shares `keploy-agent`'s PID and network namespaces, so the injected agent loads from `premain` and reaches the in-agent JSSE listener on loopback — deterministic, no reactive attach.

## Changes

- `ComposeServiceHook` signature: `func(*yaml.Node)` → `func(serviceIdentifier string, serviceNode *yaml.Node)`.
- Called for the agent service (`"keploy-agent"`) and now for the app service inside `modifyAppServiceForKeploy`, **after** the truststore is appended to the app's `JAVA_TOOL_OPTIONS`, so the downstream hook composes onto it rather than clobbering it.
- The identifier passed for the app service is the caller's `appContainerName` (the `--container-name` value the downstream matches on), **not** the compose map key. The app service can be selected by its `container_name` rather than its service key, so passing the key would make the app hook silently miss and leave Java TLS uncaptured whenever the two differ.

## Tests

`compose_service_hook_test.go`:
- hook fires for the app service, receiving the app service node, after the truststore is set (ordering);
- the identifier is the `--container-name` value even when it differs from the service key;
- a nil hook (OSS-only builds register none) is a no-op and the app still gets its truststore `JAVA_TOOL_OPTIONS`.

Enterprise builds register the real hook and are updated to the new signature in the enterprise repo; OSS-only builds are unaffected (nil hook).
