### PR TITLE
fix(config): don't synthesize a default Mongo password

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -57,7 +57,7 @@ test:
   skipCoverage: false
   coverageReportPath: ""
   ignoreOrdering: true
-  mongoPassword: "default@123"
+  mongoPassword: ""
   language: ""
   removeUnusedMocks: false
   fallBackOnMiss: false


### PR DESCRIPTION
## Description

MongoDB has no default password, so keploy should not invent one. The default `test.mongoPassword` in `config/default.go` changes from `"default@123"` to `""`.

When unset, the replay agent auto-resolves the real password from the app's own `mongodb://` connection string in its environment (see keploy/integrations#252), so no operator configuration is needed and no placeholder secret is ever used as a real credential.

Nothing in the codebase depends on the literal `"default@123"` — the field is inert plumbing here (passed through as an `OutgoingOptions` string); redaction and CLI guards use `!= ""`, so empty is handled correctly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `go build ./config/...` passes; empty string is valid YAML and a safe default at every read site.
- Validated end-to-end: with the default now empty, DaemonSet auto-replay reached `Successfully connected to MongoDB` over SCRAM-SHA-256 with the password auto-resolved from the app env (no `test.mongoPassword` set).

## Checklist

- [x] Follows style guidelines; self-reviewed
- [x] No new warnings; builds locally
- [x] Signed off (DCO)