### PR TITLE
fix(record): eliminate mongo replay no_mocks (mapping-stream loss + recentWindows eviction + resync-hole orphan suppression)

### DIFF
--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -3215,7 +3215,7 @@ func (p *Proxy) CloseErrorChannel() {
 func (p *Proxy) Mapping(ctx context.Context, mappingCh chan models.TestMockMapping) {
 	mgr := syncMock.Get()
 	if mgr != nil {
-		mgr.SetMappingChannel(mappingCh)
+		mgr.SetMappingChannel(ctx, mappingCh)
 	}
 }
 

--- a/pkg/agent/proxy/supervisor/session.go
+++ b/pkg/agent/proxy/supervisor/session.go
@@ -234,6 +234,37 @@ func (s *Session) IsMockIncomplete() bool {
 	return s.mockIncomplete.Load()
 }
 
+// RecordOrphanWindow marks a [start,end] interval during which a mock could not
+// be framed for a NON-pressure reason (currently a mongo/v2 reassembly resync
+// hole — a dropped chunk desyncs the framer, so a message delivered during the
+// hole is never turned into a mock). It routes to the session's
+// SyncMockManager (the per-app s.Mgr, or the package singleton) — matching how
+// EmitMock resolves the manager — so record.go's TC-suppression treats the hole
+// like a memory-pressure interval and suppresses every TC whose window overlaps
+// it, instead of shipping that TC mock-less (replay would then report
+// match_phase=no_mocks). This is the keploy side of the enterprise mongo
+// parser's OPTIONAL orphanWindowRecorder capability (integrations pkg/mongo/v2):
+// the parser probes for this method via an interface assertion, so pins without
+// it simply degrade resync-orphan suppression to a no-op. RecordOrphanWindow
+// itself no-ops on a zero start and a nil manager.
+//
+// Reader/writer symmetry: the suppressor (routes/record.go) must query
+// WasMockOrphanedInWindow on the SAME manager this writes to. In OSS that always
+// holds — nothing calls syncMock.NewContext, so s.Mgr is always nil and both the
+// write here and the read there resolve to syncMock.Get(). A multi-app composer
+// that sets a per-app s.Mgr must likewise give its suppressor a per-app reader;
+// there is no global fan-out for orphan windows (unlike memory pressure).
+func (s *Session) RecordOrphanWindow(start, end time.Time) {
+	if s == nil {
+		return
+	}
+	mgr := s.Mgr
+	if mgr == nil {
+		mgr = syncMock.Get()
+	}
+	mgr.RecordOrphanWindow(start, end)
+}
+
 // EmitMock sends m to the mocks channel. If the session's active mock
 // is marked incomplete, EmitMock returns nil without sending (the mock
 // is dropped on the floor and the incomplete flag is cleared, matching

--- a/pkg/agent/proxy/syncMock/mapping_overflow_test.go
+++ b/pkg/agent/proxy/syncMock/mapping_overflow_test.go
@@ -1,0 +1,118 @@
+package manager
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// TestSendMapping_NeverDropsWhenRecorderIsSlow pins the guarantee behind the
+// go-memory-load-mongo "no_mocks" flake.
+//
+// The recorder rewrites the whole of mappings.yaml to persist a mapping, so it
+// drains this channel in bursts, not continuously. The send used to be a bare
+// `select { case ch <- m: default: }` — the moment the buffer was full the
+// mapping was thrown away, with nothing logged. Those tests then had no mocks
+// attributed to them and replay reported no_mocks/candidates:0 for exactly them.
+//
+// A slow recorder must cost latency, never data.
+func TestSendMapping_NeverDropsWhenRecorderIsSlow(t *testing.T) {
+	const total = 500 // well past any buffer the recorder gives us
+
+	m := &SyncMockManager{}
+	// A deliberately small buffer: the real one is 100 and a heavy recording
+	// overruns it. Anything that fits trivially would not exercise the overflow.
+	ch := make(chan models.TestMockMapping, 4)
+	m.SetMappingChannel(context.Background(), ch)
+
+	// The recorder: reads in bursts with stalls between, as a batching writer does.
+	got := make(chan []string, 1)
+	go func() {
+		names := make([]string, 0, total)
+		for m := range ch {
+			names = append(names, m.TestName)
+			if len(names)%32 == 0 {
+				time.Sleep(2 * time.Millisecond) // the file rewrite
+			}
+		}
+		got <- names
+	}()
+
+	want := make([]string, 0, total)
+	for i := 0; i < total; i++ {
+		name := fmt.Sprintf("post-orders-%d", i)
+		want = append(want, name)
+		m.sendMapping(ch, models.TestMockMapping{TestName: name, MockIDs: []string{"mock-" + name}})
+	}
+
+	// Let the overflow drainer finish handing over its backlog.
+	deadline := time.After(15 * time.Second)
+	for {
+		m.mappingOverflowMu.Lock()
+		left, draining := len(m.mappingOverflow), m.mappingDraining
+		m.mappingOverflowMu.Unlock()
+		if left == 0 && !draining {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("overflow never drained: %d mappings still queued", left)
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+	close(ch)
+
+	var names []string
+	select {
+	case names = <-got:
+	case <-time.After(5 * time.Second):
+		t.Fatal("recorder never finished")
+	}
+
+	if len(names) != total {
+		t.Fatalf("recorder received %d of %d mappings: a mapping the agent resolved but "+
+			"could not hand over must be queued, never discarded — every dropped one is a "+
+			"test that replays as no_mocks", len(names), total)
+	}
+	// Order matters: the recorder upserts by test name, and out-of-order delivery
+	// would let a stale entry overwrite a newer one.
+	for i := range want {
+		if names[i] != want[i] {
+			t.Fatalf("mapping %d delivered out of order: got %q want %q", i, names[i], want[i])
+		}
+	}
+}
+
+// TestSendMapping_StopsWhenStreamIsGone asserts the drainer cannot outlive the
+// recorder's stream. Without the stream-ctx escape a blocking hand-off to a
+// channel nobody reads would wedge the goroutine forever.
+func TestSendMapping_StopsWhenStreamIsGone(t *testing.T) {
+	m := &SyncMockManager{}
+	ch := make(chan models.TestMockMapping) // unbuffered, never read
+	ctx, cancel := context.WithCancel(context.Background())
+	m.SetMappingChannel(ctx, ch)
+
+	for i := 0; i < 10; i++ {
+		m.sendMapping(ch, models.TestMockMapping{TestName: fmt.Sprintf("t-%d", i)})
+	}
+
+	cancel() // the recorder disconnected
+
+	deadline := time.After(5 * time.Second)
+	for {
+		m.mappingOverflowMu.Lock()
+		draining := m.mappingDraining
+		m.mappingOverflowMu.Unlock()
+		if !draining {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("overflow drainer did not stop after the mapping stream went away")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+}

--- a/pkg/agent/proxy/syncMock/orphan_window_test.go
+++ b/pkg/agent/proxy/syncMock/orphan_window_test.go
@@ -1,0 +1,192 @@
+package manager
+
+import (
+	"testing"
+	"time"
+)
+
+// TestWasMockOrphanedInWindowSuppressesOverlappingTC verifies the keploy side of
+// the enterprise mongo parser's resync-orphan suppression: a [start,end] hole
+// recorded via RecordOrphanWindow is reported by WasMockOrphanedInWindow, which
+// record.go queries alongside WasPressureActiveInWindow so a TC whose HTTP window
+// overlaps the hole is suppressed (rather than shipped mock-less → replay
+// match_phase=no_mocks). Kept on a separate orphanRanges slice so it can't
+// corrupt the pressureRanges open/close state machine.
+func TestWasMockOrphanedInWindowSuppressesOverlappingTC(t *testing.T) {
+	t.Parallel()
+
+	m := &SyncMockManager{}
+	base := time.Now()
+	holeStart := base.Add(1 * time.Second)
+	holeEnd := base.Add(3 * time.Second)
+	m.RecordOrphanWindow(holeStart, holeEnd)
+
+	// A TC whose window overlaps the hole must be flagged (→ suppressed).
+	if ok, n := m.WasMockOrphanedInWindow(base.Add(2*time.Second), base.Add(2500*time.Millisecond)); !ok || n < 1 {
+		t.Fatalf("expected the resync hole to flag an overlapping TC window; got ok=%v n=%d", ok, n)
+	}
+	// The parser probes single instants (WasMockOrphanedInWindow(t, t)): a point
+	// inside the hole overlaps.
+	if ok, _ := m.WasMockOrphanedInWindow(base.Add(2*time.Second), base.Add(2*time.Second)); !ok {
+		t.Fatalf("an instant inside the hole must overlap")
+	}
+	// A TC touching the hole's edge overlaps too (inclusive interval test).
+	if ok, _ := m.WasMockOrphanedInWindow(base.Add(3*time.Second), base.Add(4*time.Second)); !ok {
+		t.Fatalf("a TC window touching the hole's end must overlap")
+	}
+	// TCs entirely before/after the hole must NOT be suppressed.
+	if ok, _ := m.WasMockOrphanedInWindow(base, base.Add(500*time.Millisecond)); ok {
+		t.Fatalf("a TC window entirely before the hole must not be suppressed")
+	}
+	if ok, _ := m.WasMockOrphanedInWindow(base.Add(5*time.Second), base.Add(6*time.Second)); ok {
+		t.Fatalf("a TC window entirely after the hole must not be suppressed")
+	}
+}
+
+// TestWasMockOrphanedInWindowIndependentOfPressure verifies the two suppressor
+// queries scan disjoint slices: a pressure range is invisible to
+// WasMockOrphanedInWindow AND an orphan window is invisible to
+// WasPressureActiveInWindow. Uses DISJOINT intervals so each direction is proven
+// directly, so record.go attributes a suppression to its real cause instead of
+// mislabeling an orphan as pressure.
+func TestWasMockOrphanedInWindowIndependentOfPressure(t *testing.T) {
+	t.Parallel()
+
+	base := time.Now()
+	// Pressure [0s,2s] and orphan [3s,4s] are DISJOINT.
+	m := &SyncMockManager{
+		pressureRanges: []pressureRange{{start: base, end: base.Add(2 * time.Second)}},
+	}
+	m.RecordOrphanWindow(base.Add(3*time.Second), base.Add(4*time.Second))
+
+	win := func(off int) (time.Time, time.Time) {
+		s := base.Add(time.Duration(off) * time.Millisecond)
+		return s, s.Add(300 * time.Millisecond)
+	}
+
+	// A window over the orphan-only region [3s,4s]: orphaned yes, pressure NO.
+	s, e := win(3500)
+	if ok, n := m.WasMockOrphanedInWindow(s, e); !ok || n != 1 {
+		t.Fatalf("orphan-only window: WasMockOrphanedInWindow got ok=%v n=%d, want true 1", ok, n)
+	}
+	if ok, _ := m.WasPressureActiveInWindow(s, e); ok {
+		t.Fatalf("orphan-only window must NOT be reported by WasPressureActiveInWindow (it must not see orphanRanges)")
+	}
+
+	// A window over the pressure-only region [0s,2s]: pressure yes, orphaned NO.
+	s, e = win(500)
+	if ok, n := m.WasMockOrphanedInWindow(s, e); ok || n != 0 {
+		t.Fatalf("pressure-only window must NOT be reported orphaned (WasMockOrphanedInWindow must not see pressureRanges); got ok=%v n=%d", ok, n)
+	}
+	if ok, _ := m.WasPressureActiveInWindow(s, e); !ok {
+		t.Fatalf("sanity: pressure-only window must still be reported by WasPressureActiveInWindow")
+	}
+}
+
+// TestRecordOrphanWindowDegenerateInputs pins the no-op / safety contracts.
+func TestRecordOrphanWindowDegenerateInputs(t *testing.T) {
+	t.Parallel()
+
+	m := &SyncMockManager{}
+	base := time.Now()
+
+	// Zero start is dropped (no wire ts to attribute).
+	m.RecordOrphanWindow(time.Time{}, base.Add(time.Second))
+	if ok, _ := m.WasMockOrphanedInWindow(base, base.Add(time.Second)); ok {
+		t.Fatalf("a zero-start orphan window must be dropped, not recorded")
+	}
+
+	// end < start is clamped to a point interval (start,start); it overlaps only
+	// a TC window that contains that instant, never blankets everything.
+	m.RecordOrphanWindow(base.Add(2*time.Second), base.Add(1*time.Second))
+	if ok, _ := m.WasMockOrphanedInWindow(base.Add(2*time.Second), base.Add(2*time.Second)); !ok {
+		t.Fatalf("clamped point interval must overlap a TC window at that instant")
+	}
+	if ok, _ := m.WasMockOrphanedInWindow(base.Add(1500*time.Millisecond), base.Add(1800*time.Millisecond)); ok {
+		t.Fatalf("clamped point interval must NOT overlap a window before it (no inverted range)")
+	}
+
+	// A zero END (with non-zero start) is < start, so it clamps to a point too —
+	// never a zero-end interval that the (no open-interval handling) overlap scan
+	// would mistreat. Point at base+5s overlaps only that instant.
+	m.RecordOrphanWindow(base.Add(5*time.Second), time.Time{})
+	if ok, _ := m.WasMockOrphanedInWindow(base.Add(5*time.Second), base.Add(5*time.Second)); !ok {
+		t.Fatalf("zero-end orphan window must clamp to a point at start, overlapping that instant")
+	}
+	if ok, _ := m.WasMockOrphanedInWindow(base.Add(6*time.Second), base.Add(10*time.Second)); ok {
+		t.Fatalf("zero-end clamp must NOT create an open interval matching everything after start")
+	}
+
+	// Degenerate query inputs (zero start/end) and nil receiver must be safe.
+	if ok, n := m.WasMockOrphanedInWindow(time.Time{}, base); ok || n != 0 {
+		t.Fatalf("zero-start query must return (false,0); got (%v,%d)", ok, n)
+	}
+	var nilM *SyncMockManager
+	nilM.RecordOrphanWindow(base, base.Add(time.Second)) // must not panic
+	if ok, n := nilM.WasMockOrphanedInWindow(base, base.Add(time.Second)); ok || n != 0 {
+		t.Fatalf("nil receiver query must return (false,0); got (%v,%d)", ok, n)
+	}
+}
+
+// TestRecordOrphanWindowCountCap verifies the ring caps at maxPressureRanges,
+// evicting the OLDEST intervals and retaining the newest — so continuous
+// recording can't grow orphanRanges unbounded and slow every overlap scan.
+func TestRecordOrphanWindowCountCap(t *testing.T) {
+	t.Parallel()
+
+	m := &SyncMockManager{}
+	base := time.Now()
+	// Record one more than the cap; interval i lives at [base+i, base+i+1] ms.
+	total := maxPressureRanges + 100
+	for i := 0; i < total; i++ {
+		s := base.Add(time.Duration(i) * time.Millisecond)
+		m.RecordOrphanWindow(s, s.Add(time.Millisecond))
+	}
+
+	m.mu.Lock()
+	got := len(m.orphanRanges)
+	oldest := m.orphanRanges[0].start
+	newest := m.orphanRanges[len(m.orphanRanges)-1].start
+	m.mu.Unlock()
+
+	if got != maxPressureRanges {
+		t.Fatalf("orphanRanges not capped: got %d, want %d", got, maxPressureRanges)
+	}
+	// The first (total-maxPressureRanges) intervals must have been evicted, so
+	// the oldest surviving start is interval index (total-maxPressureRanges).
+	wantOldest := base.Add(time.Duration(total-maxPressureRanges) * time.Millisecond)
+	if !oldest.Equal(wantOldest) {
+		t.Fatalf("cap evicted the wrong end: oldest survivor=%v, want %v (newest should be kept)", oldest, wantOldest)
+	}
+	wantNewest := base.Add(time.Duration(total-1) * time.Millisecond)
+	if !newest.Equal(wantNewest) {
+		t.Fatalf("cap dropped the newest interval: newest survivor=%v, want %v", newest, wantNewest)
+	}
+}
+
+// TestRecordOrphanWindowDoesNotTouchPressureRanges guards the isolation
+// invariant: orphan windows must NOT be appended to pressureRanges, whose
+// open/close state machine assumes the last element is the still-open interval.
+func TestRecordOrphanWindowDoesNotTouchPressureRanges(t *testing.T) {
+	t.Parallel()
+
+	m := &SyncMockManager{}
+	// Open a real pressure interval (last element, end==zero).
+	m.SetMemoryPressure(true)
+	base := time.Now()
+	m.RecordOrphanWindow(base, base.Add(time.Second))
+	// Closing pressure must still find and close the open interval — i.e. the
+	// orphan window did not become the last pressureRanges element.
+	m.SetMemoryPressure(false)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i, r := range m.pressureRanges {
+		if r.end.IsZero() {
+			t.Fatalf("pressureRanges[%d] left open after close — RecordOrphanWindow corrupted the open/close state machine", i)
+		}
+	}
+	if len(m.orphanRanges) != 1 {
+		t.Fatalf("expected the orphan window in orphanRanges (got %d), not pressureRanges", len(m.orphanRanges))
+	}
+}

--- a/pkg/agent/proxy/syncMock/recent_window_eviction_test.go
+++ b/pkg/agent/proxy/syncMock/recent_window_eviction_test.go
@@ -1,0 +1,109 @@
+package manager
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// TestLateOwnedMockSurvivesWindowBurst is the regression for the
+// go-memory-load-mongo replay `no_mocks` flake.
+//
+// Scenario (exactly what the summary endpoint does under load): a test case
+// issues a small `find` (fast decode, mapped in-window) AND a large `aggregate`
+// (a big Mongo response that finishes decoding much later, so it lands in the
+// buffer AFTER its HTTP window resolved and must be retro-binned to that
+// window). Meanwhile the recorder keeps resolving new test windows at a high
+// burst rate.
+//
+// The bug: recentWindows was bounded ONLY by a 256-entry COUNT cap (its
+// documented 7s age-prune was a no-op). Under a burst, >256 windows resolve
+// within the ~7s the stale-cutoff keeps the aggregate reachable, so the
+// aggregate's owning window is evicted from the ring BEFORE its slow decode
+// lands. ownerWindow() then misses, the aggregate is never attributed to its
+// test, and replay serves an empty per-test pool for the aggregate query
+// (match_phase=no_mocks). The fast `find` — mapped in-window immediately —
+// survives, so the test ends with exactly one of its two mocks.
+//
+// The fix keeps a window queryable for the full 7s staleness horizon (real
+// age-prune + a count cap large enough to hold a realistic burst), so the late
+// aggregate always finds its owning window and is retro-binned.
+//
+// This test drives the manager directly (no e2e): it resolves a window, then
+// bursts far more than the OLD 256-cap of later windows — all within the 7s
+// horizon — before the late owned mock arrives. Pre-fix (256 cap) the owning
+// window is evicted and the mock is orphaned (no late mapping); post-fix it is
+// retained and the mock is retro-binned to its test.
+func TestLateOwnedMockSurvivesWindowBurst(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan *models.Mock, 1<<16)
+	mapCh := make(chan models.TestMockMapping, 1<<16)
+	mgr := &SyncMockManager{}
+	mgr.SetOutputChannel(ch)
+	mgr.SetMappingChannel(context.Background(), mapCh)
+	mgr.SetFirstRequestSignaled()
+
+	// All timestamps are recent (base ~= now) so the 7s stale-cutoff / age-prune
+	// keeps EVERY window and the late mock in play — the ONLY variable under test
+	// is ring eviction by the count cap.
+	base := time.Now()
+
+	// The summary test's HTTP window W. Its small `find` maps in-window here;
+	// the large `aggregate` is still decoding, so the buffer is empty for W.
+	wStart := base
+	wEnd := base.Add(5 * time.Millisecond)
+	mgr.ResolveRange(wStart, wEnd, "summary-42", true, true)
+
+	// Burst: resolve far more than the old 256-cap of later, non-overlapping
+	// windows, all packed within a few hundred ms (i.e. well inside 7s — exactly
+	// what go-memory-load-mongo does: ~1000 windows resolve within one 7s span).
+	const burst = 512 // > old maxRecentWindows (256), << new cap (8192)
+	for i := 0; i < burst; i++ {
+		s := wEnd.Add(time.Duration(i+1) * time.Millisecond)
+		mgr.ResolveRange(s, s, fmt.Sprintf("later-%d", i), true, true)
+	}
+
+	// Now the large aggregate finally finishes decoding and lands in the buffer.
+	// Its recorded ReqTimestampMock lies INSIDE W (it was issued during the
+	// summary request), so it belongs to "summary-42".
+	aggTs := wStart.Add(2 * time.Millisecond)
+	mgr.mu.Lock()
+	mgr.buffer = append(mgr.buffer,
+		&models.Mock{Kind: models.Mongo, Spec: models.MockSpec{ReqTimestampMock: aggTs}},
+	)
+	mgr.mu.Unlock()
+
+	// One periodic owned-window flush (the 1s ticker path) retro-bins owned late
+	// mocks. It can only attribute the aggregate if W is still in recentWindows.
+	mgr.FlushOwnedWindows()
+
+	// The aggregate must be attributed to summary-42: it has a valid owning
+	// window, so it must NOT be left orphaned in the buffer.
+	mgr.mu.Lock()
+	remaining := len(mgr.buffer)
+	mgr.mu.Unlock()
+	if remaining != 0 {
+		t.Fatalf("late aggregate was orphaned: its owning window (summary-42) was evicted from recentWindows before the mock arrived, so ownerWindow() missed and the mock is stranded in the buffer (%d left). This is the go-memory-load-mongo no_mocks bug.", remaining)
+	}
+
+	// And it must have produced a late mapping for summary-42 (the delta that
+	// completes the test's per-test mock pool at replay).
+	var lateForSummary int
+	for drained := false; !drained; {
+		select {
+		case mp := <-mapCh:
+			if mp.TestName == "summary-42" {
+				lateForSummary += len(mp.MockIDs)
+			}
+		default:
+			drained = true
+		}
+	}
+	if lateForSummary < 1 {
+		t.Fatalf("expected a late TestMockMapping attributing the aggregate to summary-42; got none — the aggregate was not retro-binned to its owning window")
+	}
+}

--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -16,11 +16,24 @@ const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 const defaultMockBufferCapacity = 100
 
 // maxRecentWindows bounds the recently-resolved-window ring (see
-// SyncMockManager.recentWindows). The ring is also time-pruned to the
-// 7 s staleness horizon, so this cap only matters under a burst of very
-// short test windows; 256 covers far more than the ~7 s of history the
-// staleness cutoff keeps reachable, while staying O(1) memory.
-const maxRecentWindows = 256
+// SyncMockManager.recentWindows) by COUNT — the ring is deliberately NOT
+// age-pruned (ResolveRange's retro-bin rescues in-window mocks from windows far
+// older than the 7 s stale-cutoff; see that function and
+// TestResolveRangeRecordsLateMockInOldWindowButDropsOrphan). The cap must
+// therefore hold far more than the windows that can resolve while a test's
+// LATE-decoded mock (e.g. a large async Mongo aggregate response) is still in
+// flight — otherwise the owning window is evicted before the mock lands,
+// ownerWindow() misses, and the mock is orphaned from its test's mapping →
+// replay match_phase=no_mocks for that query. The previous 256 was far too
+// small: heavy-load recordings burst well past 1000 resolved windows within a
+// single 7 s span (go-memory-load-mongo: ~1000 windows/7 s peak), so a slow
+// aggregate's window was evicted long before it could be retro-binned. The
+// window only has to survive the mock's decode-lag plus one FlushOwnedWindows
+// tick (~1 s) — retro-bin fires on the NEXT ResolveRange or that periodic tick,
+// not at test end — so at the ~143 windows/s peak, 8192 (≈57 s of history) is a
+// ~50x margin. It matches maxPressureRanges, which guards the SAME consumer-lag
+// class of bug, and stays O(1) memory (~64 B/window).
+const maxRecentWindows = 8192
 
 // maxPressureRanges bounds SyncMockManager.pressureRanges by COUNT, not by
 // wall-clock age. An earlier version time-pruned closed ranges 7 s after they
@@ -104,7 +117,7 @@ type SyncMockManager struct {
 	// firstReqSeen's lifecycle (set forward-only within a record session).
 	resolvedTestCount int
 
-	// recentWindows is a bounded, time-pruned ring of the most recently
+	// recentWindows is a COUNT-bounded ring of the most recently
 	// RESOLVED per-test windows. It exists to close the async-emit vs
 	// window-bin race: a parser decodes/emits a mock a few ms after the
 	// real wire event (the presaved ReqTimestampMock is correct, but the
@@ -119,8 +132,14 @@ type SyncMockManager struct {
 	// such late arrivals into the window that actually owns them, so the
 	// recorder persists them with their (correct, in-window) timestamps
 	// and replay's timestamp filter picks them up for the right test.
-	// Pruned to the same staleness horizon as the buffer cutoff so it
-	// can't reattach ancient mocks or grow without bound.
+	// Bounded by COUNT (maxRecentWindows), NOT by age: it must retain
+	// windows far older than the 7 s buffer stale-cutoff, because a late
+	// mock legitimately belongs to a long-past window (a large async
+	// response can decode tens of seconds after its window closed, and a
+	// long-running test — the ~56 s mongo fuzzer /run — spans that horizon
+	// by itself). Age-pruning would strand those mocks (see
+	// TestResolveRangeRecordsLateMockInOldWindowButDropsOrphan); the count
+	// cap bounds memory instead.
 	recentWindows []resolvedWindow
 
 	// outChanMu guards outChan and outChanClosed together. Senders
@@ -1337,17 +1356,18 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 	//      window before SetOutputChannel.
 	cutoffTime := time.Now().Add(-7 * time.Second)
 
-	// Prune the recently-resolved-window ring to the same staleness
-	// horizon as the buffer cutoff, so retroactive binning below can't
-	// reattach a mock to an ancient window (which would defeat the
-	// stale-cutoff's buffer-bound guarantee).
-	if len(m.recentWindows) > 0 {
-		kept := m.recentWindows[:0]
-		for _, w := range m.recentWindows {
-			kept = append(kept, w)
-		}
-		m.recentWindows = kept
-	}
+	// The recentWindows ring is intentionally NOT age-pruned. The retro-bin below
+	// deliberately rescues an in-window mock whose owning window is FAR older than
+	// the 7 s stale-cutoff: a long-running test (e.g. the mongo fuzzer's ~56 s
+	// /run) emits per-test mocks across its whole window, and a large async Mongo
+	// response can finish decoding tens of seconds after that window closed —
+	// time-pruning would strand those mocks (see
+	// TestResolveRangeRecordsLateMockInOldWindowButDropsOrphan). Retention is
+	// therefore bounded by COUNT (maxRecentWindows) only, mirroring
+	// maxPressureRanges, which guards the very same consumer-lag class of bug. The
+	// eviction happens at the append-and-cap below; keeping the count high enough
+	// (8192, was 256) is what stops a burst from evicting a window while its test's
+	// late aggregate mock is still decoding — the go-memory-load-mongo no_mocks bug.
 	// ownerWindow returns the recently-resolved window whose [start,end]
 	// contains t (inclusive, matching the current-window test below).
 	// Windows are non-overlapping FIFO request windows, so at most one
@@ -1568,7 +1588,7 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 	// AFTER the match loop, so the current window's own mocks went through
 	// the direct [start,end] path above, never the ring. Skipped for the
 	// no-keep / unbound cases is unnecessary — an empty-but-recorded
-	// window is harmless and pruned by age.
+	// window is harmless and aged out by the count cap below.
 	m.recentWindows = append(m.recentWindows, resolvedWindow{
 		start:    start,
 		end:      end,

--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"context"
 	"math/rand"
 	"strings"
 	"sync"
@@ -71,9 +72,23 @@ func generateRandomString(n int) string {
 type SyncMockManager struct {
 	// mu guards buffer, firstReqSeen, memoryPause, mappingChan,
 	// recentWindows, resolvedTestCount.
-	mu           sync.Mutex
-	buffer       []*models.Mock
-	mappingChan  chan<- models.TestMockMapping
+	mu          sync.Mutex
+	buffer      []*models.Mock
+	mappingChan chan<- models.TestMockMapping
+
+	// mappingOverflow holds mappings the recorder was not ready to take. The
+	// capture path must never block, but a mapping must never be dropped either
+	// (a lost one becomes a no_mocks failure at replay), so overflow is queued
+	// here and handed over by a single drainer goroutine. Guarded by
+	// mappingOverflowMu, which is a leaf: never take m.mu while holding it.
+	mappingOverflowMu sync.Mutex
+	mappingOverflow   []models.TestMockMapping
+	mappingDraining   bool
+	mappingStreamCtx  context.Context
+	// mappingGen identifies the current stream. Bumped on every
+	// SetMappingChannel so a drainer left over from a previous stream retires
+	// instead of clearing the new stream's queue.
+	mappingGen   uint64
 	firstReqSeen bool
 	memoryPause  bool
 
@@ -337,10 +352,154 @@ func (m *SyncMockManager) SetOutputChannel(out chan<- *models.Mock) {
 	}
 }
 
-func (m *SyncMockManager) SetMappingChannel(ch chan<- models.TestMockMapping) {
+// mappingOverflowCap bounds the queue of mappings the recorder has not taken yet.
+// Unbounded would be worse than the drop it replaces: the agent already carries a
+// large resident footprint, and trading bounded partial loss for an OOM kill loses
+// the WHOLE recording. Sized far above any real backlog — the recorder drains in
+// batches, so reaching this means it is wedged, not merely slow.
+const mappingOverflowCap = 10000
+
+// SetMappingChannel installs the recorder's mapping stream. streamCtx must be the
+// ctx of the HTTP request serving that stream: it is the only signal that the
+// recorder has gone away, and the overflow drainer needs it to know when a
+// blocking hand-off can never complete.
+//
+// A new stream fully supersedes the old one. mappingGen is bumped so any drainer
+// still blocked on the previous stream retires instead of draining this stream's
+// queue into a channel nobody reads — and so it cannot clear a queue that is no
+// longer its own.
+func (m *SyncMockManager) SetMappingChannel(streamCtx context.Context, ch chan<- models.TestMockMapping) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	m.mappingChan = ch
+	m.mu.Unlock()
+
+	m.mappingOverflowMu.Lock()
+	m.mappingStreamCtx = streamCtx
+	// Anything the previous stream never handed over belongs to a recording that
+	// has already ended.
+	m.mappingOverflow = nil
+	m.mappingGen++
+	// The previous drainer (if any) retires on its generation check, so this
+	// stream starts with no drainer and the next overflow spawns a fresh one.
+	m.mappingDraining = false
+	m.mappingOverflowMu.Unlock()
+}
+
+// sendMapping hands a mapping to the recorder without ever blocking the capture
+// path and without ever discarding the mapping.
+//
+// This used to be a bare non-blocking send with a `default:` that threw the
+// mapping away. That is a data-loss bug, not a backpressure policy: the recorder
+// only rewrites mappings.yaml so fast, and once its 100-slot buffer filled — which
+// a heavy concurrent recording reliably does — the dropped mappings surfaced at
+// replay as "no_mocks" for those tests, with nothing logged anywhere. Measured: a
+// recorder that stalls to write received 4 of 500 mappings.
+//
+// The capture path still must never block (ResolveRange runs from the ingress
+// hook), so the fast path stays non-blocking; anything that does not fit is queued
+// and handed over by a single drainer goroutine that CAN block. Ordering: once a
+// drainer is live every mapping queues behind it, so the fast path can never
+// overtake an entry the drainer is mid-send on.
+func (m *SyncMockManager) sendMapping(ch chan<- models.TestMockMapping, entry models.TestMockMapping) {
+	m.mappingOverflowMu.Lock()
+	if m.mappingDraining {
+		// A drainer is live — it may be mid-send with overflow momentarily empty,
+		// so gate on the drainer, not on the queue length, or this would overtake.
+		if len(m.mappingOverflow) >= mappingOverflowCap {
+			m.mappingOverflowMu.Unlock()
+			m.reportMappingOverflowFull()
+			return
+		}
+		m.mappingOverflow = append(m.mappingOverflow, entry)
+		m.mappingOverflowMu.Unlock()
+		return
+	}
+	m.mappingOverflowMu.Unlock()
+
+	select {
+	case ch <- entry:
+		return
+	default:
+	}
+
+	m.mappingOverflowMu.Lock()
+	if m.mappingDraining {
+		// Another caller started a drainer while we were trying the fast path.
+		m.mappingOverflow = append(m.mappingOverflow, entry)
+		m.mappingOverflowMu.Unlock()
+		return
+	}
+	m.mappingOverflow = append(m.mappingOverflow, entry)
+	m.mappingDraining = true
+	gen := m.mappingGen
+	streamCtx := m.mappingStreamCtx
+	m.mappingOverflowMu.Unlock()
+
+	go m.drainMappingOverflow(ch, streamCtx, gen)
+}
+
+// reportMappingOverflowFull logs the only case in which a mapping is still lost:
+// the recorder has wedged and the queue has hit its cap. Never silent.
+func (m *SyncMockManager) reportMappingOverflowFull() {
+	if logger := m.dropLogger(); logger != nil {
+		logger.Error("mapping overflow is full; dropping mappings",
+			zap.Int("cap", mappingOverflowCap),
+			zap.String("next_step", "the recorder is not draining the mapping stream; affected tests will be missing from mappings.yaml and replay will report no_mocks for them — report this with the record logs"))
+	}
+}
+
+// drainMappingOverflow hands queued mappings over one at a time, blocking until
+// each is taken. It runs on its own goroutine so the capture path never waits.
+//
+// gen pins it to the stream it was started for: if the recorder reconnects,
+// SetMappingChannel bumps the generation and this drainer retires without touching
+// the new stream's queue or its drainer slot.
+func (m *SyncMockManager) drainMappingOverflow(ch chan<- models.TestMockMapping, streamCtx context.Context, gen uint64) {
+	var done <-chan struct{}
+	if streamCtx != nil {
+		done = streamCtx.Done()
+	}
+
+	for {
+		m.mappingOverflowMu.Lock()
+		if m.mappingGen != gen {
+			// Superseded: the new stream owns mappingDraining and the queue now.
+			m.mappingOverflowMu.Unlock()
+			return
+		}
+		if len(m.mappingOverflow) == 0 {
+			m.mappingDraining = false
+			m.mappingOverflowMu.Unlock()
+			return
+		}
+		entry := m.mappingOverflow[0]
+		m.mappingOverflow = m.mappingOverflow[1:]
+		m.mappingOverflowMu.Unlock()
+
+		select {
+		case ch <- entry:
+		case <-done:
+			// The recorder's stream is gone, so this can never be delivered. That
+			// is real data loss — say so loudly; it was silent before.
+			m.mappingOverflowMu.Lock()
+			if m.mappingGen != gen {
+				// A new stream took over while we blocked; its queue is not ours
+				// to clear and its drainer slot is not ours to release.
+				m.mappingOverflowMu.Unlock()
+				return
+			}
+			lost := len(m.mappingOverflow) + 1
+			m.mappingOverflow = nil
+			m.mappingDraining = false
+			m.mappingOverflowMu.Unlock()
+			if logger := m.dropLogger(); logger != nil {
+				logger.Error("mapping stream closed with mappings still queued",
+					zap.Int("lost_mappings", lost),
+					zap.String("next_step", "these tests will be missing from mappings.yaml and replay will report no_mocks for them; re-record the test set"))
+			}
+			return
+		}
+	}
 }
 
 // SetLogger installs a zap.Logger for drop-path reporting. Callers
@@ -880,10 +1039,7 @@ func (m *SyncMockManager) FlushOwnedWindows() {
 			if len(ids) == 0 {
 				continue
 			}
-			select {
-			case mappingChan <- models.TestMockMapping{TestName: tn, MockIDs: ids}:
-			default:
-			}
+			m.sendMapping(mappingChan, models.TestMockMapping{TestName: tn, MockIDs: ids})
 		}
 	}
 	// Deliver any queued deferred-orphan revokes on the same open stream. Runs
@@ -1461,24 +1617,19 @@ func (m *SyncMockManager) ResolveRange(start, end time.Time, testName string, ke
 		m.sendToOutChanOwned(om.mock, om.owner)
 	}
 	if mappingEntry != nil && mappingChan != nil {
-		select {
-		case mappingChan <- *mappingEntry:
-		default:
-		}
+		m.sendMapping(mappingChan, *mappingEntry)
 	}
-	// Retroactive mapping entries for mocks late-binned into past windows.
-	// The recorder Upserts mappings by test name, so a second entry for an
-	// already-resolved test merges into its existing mapping rather than
-	// replacing it.
+	// Retroactive mapping entries for mocks late-binned into past windows. These
+	// are a DELTA for an already-resolved test, not its full set, so the recorder
+	// MUST union them into that test's existing mapping. It used to replace, which
+	// silently deleted the mocks the original resolution recorded — see
+	// mergeMockEntries in the mapping store.
 	if mappingChan != nil {
 		for tn, ids := range lateMappings {
 			if len(ids) == 0 {
 				continue
 			}
-			select {
-			case mappingChan <- models.TestMockMapping{TestName: tn, MockIDs: ids}:
-			default:
-			}
+			m.sendMapping(mappingChan, models.TestMockMapping{TestName: tn, MockIDs: ids})
 		}
 	}
 }
@@ -1621,10 +1772,7 @@ func (m *SyncMockManager) DeleteMocksStrictlyBefore(timestamp time.Time) {
 			if len(ids) == 0 {
 				continue
 			}
-			select {
-			case mappingChan <- models.TestMockMapping{TestName: tn, MockIDs: ids}:
-			default:
-			}
+			m.sendMapping(mappingChan, models.TestMockMapping{TestName: tn, MockIDs: ids})
 		}
 	}
 }

--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -258,6 +258,29 @@ type SyncMockManager struct {
 	// intervals and slowing every overlap scan.
 	pressureRanges []pressureRange
 
+	// orphanRanges records [start,end] intervals over which a mock could NOT be
+	// framed for a reason OTHER than the memory-guard pause — currently a mongo/v2
+	// reassembly resync hole: a dropped chunk desyncs the framer, so a message
+	// delivered during the hole is DELIVERED (not dropped) yet never turned into a
+	// mock. Like pressureRanges it feeds a suppressor query — WasMockOrphanedInWindow,
+	// which record.go checks alongside WasPressureActiveInWindow — so record.go
+	// suppresses every TC whose window overlaps the hole rather than shipping it
+	// mock-less (replay would report match_phase=no_mocks). Kept SEPARATE from
+	// pressureRanges — whose open/close state machine (SetMemoryPressure) assumes
+	// the last element is the still-open interval — so appending a CLOSED orphan
+	// interval here can't corrupt that invariant. Recorded via RecordOrphanWindow
+	// by the enterprise mongo parser (integrations orphanWindowRecorder); intervals
+	// are always closed. Count-capped at maxPressureRanges like its sibling.
+	//
+	// NOTE: the count cap and the zero/inverted-input guards bound the NUMBER of
+	// intervals and neutralize degenerate ones (zero start dropped, inverted
+	// end clamped to a point), but they do NOT bound an interval's
+	// WIDTH. A suppression is session-global for every TC whose window overlaps a
+	// hole, so keeping the hole narrow (last-good frame → resync point, not the
+	// whole connection lifetime) is the recorder's responsibility, not enforced
+	// here — same inherent trade-off as interval-based pressure suppression.
+	orphanRanges []pressureRange
+
 	// loggerMu guards logger so SetLogger and the drop path can run
 	// concurrently without a data race. The read lock is taken only
 	// on the (sampled, cold) Error path, so contention is negligible.
@@ -1098,7 +1121,10 @@ func (m *SyncMockManager) GetDropStats() (pressureActive bool, pressureDropped i
 //
 // Called by the TC-send path in routes/record.go right before forwarding a
 // TC to the CLI: if it returns true, the TC is suppressed and never reaches
-// disk, so replay cannot encounter a missing-mock EOF for it.
+// disk, so replay cannot encounter a missing-mock EOF for it. record.go
+// queries WasMockOrphanedInWindow alongside this so a TC stranded by EITHER
+// cause is suppressed; the two are kept as separate methods so each scans only
+// its own slice and diagnostics attribute a suppression to its real cause.
 //
 // Why this is race-free unlike a per-mock-drop ledger:
 //   - memoryguard calls SetMemoryPressure(true) and the range is appended
@@ -1138,6 +1164,64 @@ func (m *SyncMockManager) WasPressureActiveInWindow(start, end time.Time) (bool,
 		}
 	}
 	return count > 0, count
+}
+
+// WasMockOrphanedInWindow returns (true, overlapCount) if any recorded
+// resync-hole orphan window (see RecordOrphanWindow) overlaps [start, end]. It
+// is the orphan-window twin of WasPressureActiveInWindow: routes/record.go
+// queries BOTH before forwarding a TC and suppresses it if EITHER overlaps, so
+// a TC stranded by a mongo/v2 reassembly resync hole — a delivered-but-
+// unframable op that was never turned into a mock — is never shipped mock-less
+// (replay would report match_phase=no_mocks).
+//
+// Kept as a SEPARATE method rather than folded into WasPressureActiveInWindow
+// so each scans only its own slice, the two suppression causes stay distinct in
+// diagnostics, and the enterprise mongo parser's orphanWindowChecker probe
+// (WasMockOrphanedInWindow) resolves against it. orphanRanges are always CLOSED
+// [start,end] (RecordOrphanWindow supplies both bounds), so no open-interval
+// (end==zero → now) handling is needed. Same degenerate-input guard as its twin.
+func (m *SyncMockManager) WasMockOrphanedInWindow(start, end time.Time) (bool, int) {
+	if m == nil || start.IsZero() || end.IsZero() {
+		return false, 0
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	count := 0
+	for _, r := range m.orphanRanges {
+		if !r.start.After(end) && !r.end.Before(start) {
+			count++
+		}
+	}
+	return count > 0, count
+}
+
+// RecordOrphanWindow records a [start,end] interval during which a mock could
+// not be framed for a NON-pressure reason (currently a mongo/v2 reassembly
+// resync hole). It feeds WasMockOrphanedInWindow so record.go suppresses every
+// TC whose window overlaps the hole — the same coverage-for-stability tradeoff
+// the memory-pressure suppressor makes — instead of shipping that TC mock-less
+// (replay would then report match_phase=no_mocks). This satisfies the enterprise
+// mongo parser's OPTIONAL orphanWindowRecorder capability (integrations
+// pkg/mongo/v2): older keploy pins that lack this method degrade the parser's
+// resync-orphan suppression to a no-op rather than failing to compile. A zero
+// start is dropped (no wire ts to attribute); an end before start is clamped.
+func (m *SyncMockManager) RecordOrphanWindow(start, end time.Time) {
+	if m == nil || start.IsZero() {
+		return
+	}
+	if end.Before(start) {
+		end = start
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.orphanRanges = append(m.orphanRanges, pressureRange{start: start, end: end})
+	// Count-cap like pressureRanges: evict the oldest, copy down so the backing
+	// array isn't retained.
+	if n := len(m.orphanRanges); n > maxPressureRanges {
+		trimmed := make([]pressureRange, maxPressureRanges)
+		copy(trimmed, m.orphanRanges[n-maxPressureRanges:])
+		m.orphanRanges = trimmed
+	}
 }
 
 // pressureActiveAtLocked reports whether instant t fell inside any recorded

--- a/pkg/agent/proxy/syncMock/syncMock_test.go
+++ b/pkg/agent/proxy/syncMock/syncMock_test.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"context"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1383,7 +1384,7 @@ func TestDeleteMocksStrictlyBeforeRescuesLateKeptMock(t *testing.T) {
 	mapCh := make(chan models.TestMockMapping, 8)
 	mgr := &SyncMockManager{}
 	mgr.SetOutputChannel(ch)
-	mgr.SetMappingChannel(mapCh)
+	mgr.SetMappingChannel(context.Background(), mapCh)
 	mgr.SetFirstRequestSignaled()
 
 	base := time.Now().Add(-1 * time.Second)
@@ -1485,7 +1486,7 @@ func TestFlushOwnedWindowsPersistsLateMocksDuringRecording(t *testing.T) {
 	mapCh := make(chan models.TestMockMapping, 8)
 	mgr := &SyncMockManager{}
 	mgr.SetOutputChannel(ch)
-	mgr.SetMappingChannel(mapCh)
+	mgr.SetMappingChannel(context.Background(), mapCh)
 	mgr.SetFirstRequestSignaled()
 
 	base := time.Now().Add(-1 * time.Second)

--- a/pkg/agent/routes/record.go
+++ b/pkg/agent/routes/record.go
@@ -342,7 +342,7 @@ func (a *Agent) HandleIncoming(w http.ResponseWriter, r *http.Request) {
 	// concurrently with channel receive — otherwise the handler blocks
 	// forever during shutdown when no test cases are arriving.
 	var tcsSentSoFar int       // TCs sent to CLI this session
-	var tcsSuppressedSoFar int // TCs suppressed because pressure overlapped the TC's HTTP window
+	var tcsSuppressedSoFar int // TCs suppressed: pressure OR resync-hole overlapped the TC's HTTP window, or its mock was capacity-dropped
 	for {
 		select {
 		case <-r.Context().Done():
@@ -354,7 +354,7 @@ func (a *Agent) HandleIncoming(w http.ResponseWriter, r *http.Request) {
 				_, finalDropped, finalAdded, _ := syncmgr.Get().GetDropStats()
 				a.logger.Info("agent: recording complete",
 					zap.Int("tcs_sent_to_cli", tcsSentSoFar),
-					zap.Int("tcs_suppressed_pressure_overlap", tcsSuppressedSoFar),
+					zap.Int("tcs_suppressed_total", tcsSuppressedSoFar),
 					zap.Int("pressure_ranges_total", syncmgr.Get().PressureRangeCount()),
 					zap.Int64("mocks_dropped_by_pressure", finalDropped),
 					zap.Int64("mocks_added_successfully", finalAdded),
@@ -371,7 +371,12 @@ func (a *Agent) HandleIncoming(w http.ResponseWriter, r *http.Request) {
 			// drops) because that check is race-free regardless of when the
 			// mock's goroutine runs relative to this handler.
 			tcRespTime := t.HTTPResp.Timestamp
-			hasOverlap, overlapCount := syncmgr.Get().WasPressureActiveInWindow(t.HTTPReq.Timestamp, tcRespTime)
+			hasPressure, pressureOverlaps := syncmgr.Get().WasPressureActiveInWindow(t.HTTPReq.Timestamp, tcRespTime)
+			// A mongo/v2 reassembly resync hole strands a delivered-but-unframable
+			// op: its TC records mock-less though no pressure range covers it. The
+			// enterprise parser reports the hole via Session.RecordOrphanWindow;
+			// suppress any TC whose window overlaps it, same as for pressure.
+			hasOrphan, orphanOverlaps := syncmgr.Get().WasMockOrphanedInWindow(t.HTTPReq.Timestamp, tcRespTime)
 			// A capacity drop (outChan overflow / already-closed channel)
 			// feeds nothing into pressureRanges, so the pressure-overlap check
 			// above cannot catch it. Suppress by EXACT owning test name so a
@@ -380,13 +385,14 @@ func (a *Agent) HandleIncoming(w http.ResponseWriter, r *http.Request) {
 			// concurrent TC that kept all its mocks.
 			mockDropped := syncmgr.Get().WasMockDroppedForTC(t.Name)
 
-			if hasOverlap || mockDropped {
+			if hasPressure || hasOrphan || mockDropped {
 				tcsSuppressedSoFar++
-				a.logger.Debug("agent: TC suppressed — memory pressure overlapped TC window or a mock was capacity-dropped, not sent to CLI",
+				a.logger.Debug("agent: TC suppressed — memory pressure / resync-hole overlapped TC window or a mock was capacity-dropped, not sent to CLI",
 					zap.String("tc_name", t.Name),
 					zap.Int64("tc_req_ms", t.HTTPReq.Timestamp.UnixMilli()),
 					zap.Int64("tc_resp_ms", tcRespTime.UnixMilli()),
-					zap.Int("pressure_overlaps", overlapCount),
+					zap.Int("pressure_overlaps", pressureOverlaps),
+					zap.Int("resync_orphan_overlaps", orphanOverlaps),
 					zap.Bool("capacity_drop", mockDropped),
 					zap.Int("tcs_suppressed_so_far", tcsSuppressedSoFar),
 				)

--- a/pkg/platform/yaml/mapdb/db.go
+++ b/pkg/platform/yaml/mapdb/db.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"go.keploy.io/server/v3/pkg/models"
 	"go.keploy.io/server/v3/pkg/platform/yaml"
@@ -96,9 +97,58 @@ func (db *MappingDb) Insert(ctx context.Context, mapping *models.Mapping) error 
 	return nil
 }
 
-// Upsert updates a single test-mock mapping.
-// If the file doesn't exist, it creates it.
+// Upsert writes a single test's mock entries, creating the file if absent. It is a one-entry UpsertBatch —
+// prefer UpsertBatch when several mappings are ready at once, because each call
+// rewrites the whole file (see UpsertBatch's note on cost).
 func (db *MappingDb) Upsert(ctx context.Context, testSetID string, testID string, mockEntries []models.MockEntry) error {
+	return db.UpsertBatch(ctx, testSetID, map[string][]models.MockEntry{testID: mockEntries})
+}
+
+// mergeMockEntries unions new entries into existing ones, keyed by mock name and
+// preserving recorded order (existing first, then genuinely new arrivals).
+//
+// A test's mapping is built up in more than one go: the agent emits a test's
+// mocks when its window resolves, and emits more later for mocks it retroactively
+// bins into that already-resolved window. Those later emissions are a DELTA, not
+// a replacement — overwriting on the second one silently deletes the mocks the
+// first one recorded, and the test then replays with a short pool or none at all,
+// which is a no_mocks failure. Union, never replace.
+func mergeMockEntries(existing, incoming []models.MockEntry) []models.MockEntry {
+	if len(existing) == 0 {
+		return incoming
+	}
+	seen := make(map[string]struct{}, len(existing))
+	for _, e := range existing {
+		seen[e.Name] = struct{}{}
+	}
+	merged := existing
+	for _, e := range incoming {
+		if _, dup := seen[e.Name]; dup {
+			continue
+		}
+		seen[e.Name] = struct{}{}
+		merged = append(merged, e)
+	}
+	return merged
+}
+
+// UpsertBatch merges every supplied test's mock entries into mappings.yaml in a
+// SINGLE read-modify-write. Entries for a test already present are unioned with
+// what is on disk, never replaced — see mergeMockEntries.
+//
+// Why this exists: the file is stored as one document, so persisting a mapping
+// means reading, decoding, re-encoding and rewriting all of it. Doing that once
+// per mapping is quadratic in the number of tests — measured at 368 tests, the
+// first write costs 164us and the last 19.45ms, a 118x slowdown, ~2.7s of pure
+// rewriting. That is slow enough to back-pressure the agent's mapping stream,
+// and the agent DROPS mappings it cannot hand over (its send is non-blocking so
+// that capture is never stalled). The lost mappings then surface at replay as
+// "no_mocks" for the affected tests. Batching keeps the cost linear so the
+// stream is never the bottleneck.
+func (db *MappingDb) UpsertBatch(ctx context.Context, testSetID string, byTest map[string][]models.MockEntry) error {
+	if len(byTest) == 0 {
+		return nil
+	}
 
 	mappingPath := filepath.Join(db.path, testSetID)
 	fileName := db.MapFileName
@@ -141,21 +191,30 @@ func (db *MappingDb) Upsert(ctx context.Context, testSetID string, testID string
 		}
 	}
 
-	found := false
+	// Index the existing entries once so a batch of N tests costs one pass
+	// rather than N linear scans.
+	at := make(map[string]int, len(mapping.TestCases))
 	for i, t := range mapping.TestCases {
-		if t.ID == testID {
-			mapping.TestCases[i].Mocks = mockEntries
-			found = true
-			break
-		}
+		at[t.ID] = i
 	}
 
-	if !found {
-		newTest := models.MappedTestCase{
-			ID:    testID,
-			Mocks: mockEntries,
+	// Append in a stable order. Go randomises map iteration, and mappings.yaml
+	// is a recorded artifact that gets diffed and reviewed — an unstable test
+	// order would make every re-record look like a change.
+	newIDs := make([]string, 0, len(byTest))
+	for testID := range byTest {
+		if i, ok := at[testID]; ok {
+			mapping.TestCases[i].Mocks = mergeMockEntries(mapping.TestCases[i].Mocks, byTest[testID])
+			continue
 		}
-		mapping.TestCases = append(mapping.TestCases, newTest)
+		newIDs = append(newIDs, testID)
+	}
+	sort.Strings(newIDs)
+	for _, testID := range newIDs {
+		mapping.TestCases = append(mapping.TestCases, models.MappedTestCase{
+			ID:    testID,
+			Mocks: byTest[testID],
+		})
 	}
 
 	encodedData, err := EncodeMappingF(mapping, db.logger, effFormat)
@@ -176,10 +235,9 @@ func (db *MappingDb) Upsert(ctx context.Context, testSetID string, testID string
 		return err
 	}
 
-	db.logger.Debug("Successfully upserted test-mock mapping",
+	db.logger.Debug("Successfully upserted test-mock mappings",
 		zap.String("testSetID", testSetID),
-		zap.String("testID", testID),
-		zap.Int("mockCount", len(mockEntries)))
+		zap.Int("tests", len(byTest)))
 
 	return nil
 }

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -24,6 +24,38 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+const (
+	// mappingDrainGrace hard-caps how long recording shutdown waits for the agent
+	// to flush the test<->mock mappings it has already resolved. Bounded so a
+	// wedged agent cannot hang exit, and kept under the 30s DrainErrGroup budget
+	// that Start's teardown gives the group this drain runs in — overshooting that
+	// would trade a lost tail for a teardown timeout, which is no better.
+	mappingDrainGrace = 15 * time.Second
+
+	// mappingIdleGrace ends the shutdown drain once the mapping stream falls idle.
+	// The agent holds the stream open for the whole session, so idleness — not EOF
+	// — is what signals the tail is through. Sized well above the agent's
+	// per-mapping flush latency so a slow flush is not mistaken for completion.
+	mappingIdleGrace = 3 * time.Second
+)
+
+// stopTimer disarms t, draining its channel if it had already fired, so a later
+// Reset starts from a clean state.
+func stopTimer(t *time.Timer) {
+	if !t.Stop() {
+		select {
+		case <-t.C:
+		default:
+		}
+	}
+}
+
+// resetTimer re-arms t for d, safely draining any pending fire first.
+func resetTimer(t *time.Timer, d time.Duration) {
+	stopTimer(t)
+	t.Reset(d)
+}
+
 // consumeMappings correlates each test<->mock mapping the agent streams to its
 // real mock entries and persists it to mappings.yaml. It runs until mappings is
 // closed by the producer, and returns only then — ctx bounds nothing here by
@@ -904,11 +936,48 @@ func (r *Recorder) GetTestAndMockChans(ctx context.Context) (FrameChan, error) {
 	g.Go(func() error {
 		defer close(mappingChan)
 
-		// Create context that cancels with parent
+		// A mapping is the LAST artifact a recorded test produces: it is derived,
+		// and the agent can only emit it once that test's mock range has resolved.
+		// So when recording stops, a burst for the most recently recorded tests is
+		// still queued inside the agent. Tearing the stream down the instant ctx was
+		// done dropped that burst SILENTLY — the entries never reach the consumer, so
+		// not even a write error is logged. mappings.yaml then omitted the tail of
+		// every endpoint, and replay reported "no_mocks" (candidates: 0) for exactly
+		// those tests, because resolveMockSets picks mapping-based selection per test
+		// SET and has no per-test fallback for a test that is missing.
+		//
+		// It is tempting to assume the tail has already been flushed by now because
+		// teardown stops the app first. That is only true for the NATIVE path: under
+		// docker-compose keploy never runs the app at all (see the CommandType check
+		// above), runAppErrGrp is empty, its drain returns instantly, and reqCtxCancel
+		// therefore fires within milliseconds of SIGINT — with the agent's queue still
+		// full. Docker-compose is what most e2e lanes and many users run, and it is
+		// where this bug was measured: 27 of 342 tests lost, all tails.
+		//
+		// So on shutdown keep the stream open and keep draining. Stop as soon as the
+		// tail is through — the agent closing the stream, or the stream falling idle —
+		// and hard-cap the total wait so a wedged agent cannot hang exit.
 		mapCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 		defer cancel()
+
+		drained := make(chan struct{})
+		defer close(drained)
 		go func() {
-			<-ctx.Done()
+			select {
+			case <-drained:
+				return // finished before shutdown — nothing to wait for
+			case <-ctx.Done():
+			}
+			select {
+			case <-drained: // tail fully drained
+			case <-time.After(mappingDrainGrace):
+				// Hitting the cap means the agent never finished flushing, so the
+				// tail is truncated here — the same damage this drain prevents.
+				// Say so: silence is what made the original bug so hard to find.
+				r.logger.Warn("timed out draining test-mock mappings on shutdown",
+					zap.Duration("waited", mappingDrainGrace),
+					zap.String("next_step", "mappings.yaml may be missing the last recorded tests and replay can report no_mocks for them; re-record the test set and report this if it recurs"))
+			}
 			cancel()
 		}()
 
@@ -921,24 +990,50 @@ func (r *Recorder) GetTestAndMockChans(ctx context.Context) (FrameChan, error) {
 			return fmt.Errorf("failed to get mappings: %w", err)
 		}
 
+		// idle is armed only once shutdown has begun. While recording is live, gaps
+		// between mappings are normal and must never end the stream; once shutdown
+		// starts, a gap long enough means the agent has nothing left to flush (it
+		// holds the stream open for the whole session, so it will not close it).
+		idle := time.NewTimer(mappingIdleGrace)
+		defer idle.Stop()
+		stopTimer(idle)
+
 		for {
+			// While recording is live, wake on ctx.Done(); once draining, wait on the
+			// idle timer instead. Arming both would let an already-closed ctx.Done()
+			// spin the loop.
+			var idleC <-chan time.Time
+			var shutdownC <-chan struct{}
+			if ctx.Err() != nil {
+				resetTimer(idle, mappingIdleGrace)
+				idleC = idle.C
+			} else {
+				shutdownC = ctx.Done()
+			}
+
 			select {
-			case <-ctx.Done():
-				return ctx.Err()
+			case <-shutdownC:
+				// Shutdown began: re-loop to arm the idle timer and start draining.
+				continue
+			case <-mapCtx.Done():
+				// Hard cap reached, or the stream was torn down.
+				return nil
+			case <-idleC:
+				// Draining and nothing for mappingIdleGrace: the tail is through.
+				return nil
 			case m, ok := <-ch:
 				if !ok {
 					return nil
 				}
 				select {
-				case <-ctx.Done():
+				case <-mapCtx.Done():
 					// Hand off the mapping we already took off the stream before
-					// unwinding — cancellation is not a licence to drop data we
-					// are holding. Both cases are ready once ctx is done, so the
-					// runtime picks at random and this would otherwise lose the
-					// last in-flight mapping about half the time, which is the
-					// tail this fix exists to keep. The consumer is still ranging
-					// (it stops only when this goroutine closes the channel on
-					// return), so the send completes. Mirrors the outgoing
+					// unwinding — cancellation is not a licence to drop data we are
+					// holding. Both cases are ready once mapCtx is done, so the
+					// runtime picks at random and this would otherwise lose the last
+					// in-flight mapping about half the time. The consumer is still
+					// ranging (it stops only when this goroutine closes the channel
+					// on return), so the send completes. Mirrors the outgoing
 					// producer above.
 					mappingChan <- m
 					return ctx.Err()

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -24,6 +24,44 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// consumeMappings correlates each test<->mock mapping the agent streams to its
+// real mock entries and persists it to mappings.yaml. It runs until mappings is
+// closed by the producer, and returns only then — ctx bounds nothing here by
+// design.
+//
+// Mappings are the last artifact a recorded test produces (the agent resolves a
+// test's mock range only once that test is done), so the tail of every endpoint
+// arrives while recording is already shutting down. Writes therefore run on a
+// context detached from ctx: on a cancelled one the yaml store refuses every
+// write and those tests vanish from mappings.yaml, which replay then reports as
+// no_mocks. Detaching here rather than relying on the caller keeps that
+// guarantee local to the loop that depends on it — see the persistCtx note in
+// Start for the same requirement on the test-case and mock stores.
+func (r *Recorder) consumeMappings(ctx context.Context, testSetID string, mappings <-chan models.TestMockMapping, correlationMap, asyncMockIDs *sync.Map) error {
+	persistCtx := context.WithoutCancel(ctx)
+
+	for mapping := range mappings {
+		realMockEntries := r.resolveMappingEntries(mapping, correlationMap, asyncMockIDs)
+
+		// Write to mappings.yaml
+		if len(realMockEntries) > 0 {
+			err := r.mappingDb.Upsert(persistCtx, testSetID, mapping.TestName, realMockEntries)
+			if err != nil {
+				// Deliberately not utils.LogError: it suppresses
+				// context.Canceled, which is exactly the class this write used
+				// to fail with, so the lost tail left no trace in the logs at
+				// all. A mapping that goes missing here is a no_mocks failure
+				// at replay — it must never be silent again.
+				r.logger.Error("failed to save mapping",
+					zap.String("test", mapping.TestName),
+					zap.Error(err),
+					zap.String("next_step", "this test's mocks will be missing from mappings.yaml and replay will report no_mocks for it; re-record the test set"))
+			}
+		}
+	}
+	return nil
+}
+
 type Recorder struct {
 	logger          *zap.Logger
 	testDB          TestDB
@@ -168,6 +206,34 @@ func (r *Recorder) Start(ctx context.Context) error {
 	// creating error group to manage proper shutdown of all the go routines and to propagate the error to the caller
 	errGrp, _ := errgroup.WithContext(ctx)
 	ctx = context.WithValue(ctx, models.ErrGroupKey, errGrp)
+
+	// persistCtx is the context the test-case and mock stores are written on,
+	// detached from ctx on purpose. (consumeMappings makes the same guarantee for
+	// mappings.yaml itself.)
+	//
+	// Capture and persistence are driven by different contexts, and the gap
+	// between them is where recorded data used to disappear. The agent streams on
+	// reqCtx (see below), which is WithoutCancel'd and so survives SIGINT — it
+	// stops only at reqCtxCancel() in teardown, AFTER the user app has been
+	// stopped and drained. The consumer goroutines below, however, are children of
+	// ctx, which cancels the instant SIGINT lands. So for the whole teardown
+	// window (a NotifyGracefulShutdown of up to 10s, then an app drain of up to
+	// 30s) the agent kept handing us test cases, mocks and mappings while every
+	// store refused to write them: the yaml path returns ctx.Err() on a cancelled
+	// ctx, and the callers below treated that as "shutting down, skip" — silently.
+	//
+	// The damage was worst for mappings, which are emitted LAST (the agent can
+	// only resolve a test's mock range once that test is done), so the tail of
+	// every endpoint landed squarely in that window: mappings.yaml lost those
+	// tests and replay reported "no_mocks" (candidates: 0) for exactly them. A
+	// dropped mock insert compounded it by also skipping its correlationMap entry,
+	// stranding the mapping that referenced it even when the mapping did arrive.
+	//
+	// Writes must therefore outlive cancellation. This does NOT risk a hung
+	// teardown: the consumers are `range` loops that end when the agent closes its
+	// streams (at reqCtxCancel), each write is a local file op, and Start's
+	// teardown still bounds the whole group with DrainErrGroup.
+	persistCtx := context.WithoutCancel(ctx)
 
 	runAppErrGrp, _ := errgroup.WithContext(ctx)
 	runAppCtx := context.WithoutCancel(ctx)
@@ -529,9 +595,18 @@ func (r *Recorder) Start(ctx context.Context) error {
 					zap.String("testSetID", newTestSetID),
 					zap.String("testCaseName", testCase.Name))
 			}
-			err := r.testDB.InsertTestCase(ctx, testCase, newTestSetID, true)
+			err := r.testDB.InsertTestCase(persistCtx, testCase, newTestSetID, true)
 			if err != nil {
-				if ctx.Err() == context.Canceled {
+				if ctx.Err() != nil {
+					// Once shutdown has begun nothing reads insertTestErrChan —
+					// Start's select has returned and the channel is closed on
+					// Start's way out — so reporting through it is unsafe. Log
+					// instead of dropping the error on the floor: with persistCtx
+					// the write no longer fails merely because we are shutting
+					// down, so an error here is real and the operator needs it.
+					utils.LogError(r.logger, err, "failed to record test case during shutdown",
+						zap.String("testCaseName", testCase.Name),
+						zap.String("testSetID", newTestSetID))
 					continue
 				}
 				insertTestErrChan <- err
@@ -597,9 +672,17 @@ func (r *Recorder) Start(ctx context.Context) error {
 			if mock.IsAsync() {
 				asyncMockIDs.Store(tempID, struct{}{})
 			}
-			err := r.mockDB.InsertMock(ctx, mock, newTestSetID)
+			err := r.mockDB.InsertMock(persistCtx, mock, newTestSetID)
 			if err != nil {
-				if ctx.Err() == context.Canceled {
+				if ctx.Err() != nil {
+					// See the sibling note on the test-case insert: insertMockErrChan
+					// is no longer safe to report through once teardown has begun. A
+					// skipped mock also skips its correlationMap entry below, which
+					// strands the mapping that references it — so this must be loud.
+					utils.LogError(r.logger, err, "failed to record mock during shutdown",
+						zap.String("mockName", mock.Name),
+						zap.String("mockKind", mock.GetKind()),
+						zap.String("testSetID", newTestSetID))
 					continue
 				}
 				insertMockErrChan <- err
@@ -632,18 +715,7 @@ func (r *Recorder) Start(ctx context.Context) error {
 	})
 
 	errGrp.Go(func() error {
-		for mapping := range frames.Mappings {
-			realMockEntries := r.resolveMappingEntries(mapping, &correlationMap, &asyncMockIDs)
-
-			// Write to mappings.yaml
-			if len(realMockEntries) > 0 {
-				err := r.mappingDb.Upsert(ctx, newTestSetID, mapping.TestName, realMockEntries)
-				if err != nil {
-					utils.LogError(r.logger, err, "failed to save mapping")
-				}
-			}
-		}
-		return nil
+		return r.consumeMappings(ctx, newTestSetID, frames.Mappings, &correlationMap, &asyncMockIDs)
 	})
 
 	if r.config.CommandType != string(utils.DockerCompose) {
@@ -859,6 +931,16 @@ func (r *Recorder) GetTestAndMockChans(ctx context.Context) (FrameChan, error) {
 				}
 				select {
 				case <-ctx.Done():
+					// Hand off the mapping we already took off the stream before
+					// unwinding — cancellation is not a licence to drop data we
+					// are holding. Both cases are ready once ctx is done, so the
+					// runtime picks at random and this would otherwise lose the
+					// last in-flight mapping about half the time, which is the
+					// tail this fix exists to keep. The consumer is still ranging
+					// (it stops only when this goroutine closes the channel on
+					// return), so the send completes. Mirrors the outgoing
+					// producer above.
+					mappingChan <- m
 					return ctx.Err()
 				case mappingChan <- m:
 				}

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -31,6 +32,19 @@ const (
 	// that Start's teardown gives the group this drain runs in — overshooting that
 	// would trade a lost tail for a teardown timeout, which is no better.
 	mappingDrainGrace = 15 * time.Second
+
+	// mappingFlushBatch is how many mappings accumulate before mappings.yaml is
+	// rewritten. Each rewrite re-encodes the whole file, so writing per mapping is
+	// quadratic (368 tests: 164us for the first, 19.45ms for the last, ~2.7s of
+	// pure rewriting) — slow enough to back-pressure the agent's mapping stream,
+	// which then DROPS what it cannot hand over. Batching keeps the consumer far
+	// ahead of the stream.
+	mappingFlushBatch = 32
+
+	// mappingFlushInterval bounds how long a partial batch waits, so a long
+	// recording still persists mappings as it goes instead of holding them all in
+	// memory until the stream closes.
+	mappingFlushInterval = 2 * time.Second
 
 	// mappingIdleGrace ends the shutdown drain once the mapping stream falls idle.
 	// The agent holds the stream open for the whole session, so idleness — not EOF
@@ -56,6 +70,29 @@ func resetTimer(t *time.Timer, d time.Duration) {
 	t.Reset(d)
 }
 
+// mergeMockEntries unions incoming entries into existing ones by mock name,
+// preserving recorded order. Mirrors the mapping store's merge: a test's mapping
+// arrives in more than one piece and the later pieces are deltas, so replacing
+// would delete mocks the earlier piece recorded.
+func mergeMockEntries(existing, incoming []models.MockEntry) []models.MockEntry {
+	if len(existing) == 0 {
+		return incoming
+	}
+	seen := make(map[string]struct{}, len(existing))
+	for _, e := range existing {
+		seen[e.Name] = struct{}{}
+	}
+	merged := existing
+	for _, e := range incoming {
+		if _, dup := seen[e.Name]; dup {
+			continue
+		}
+		seen[e.Name] = struct{}{}
+		merged = append(merged, e)
+	}
+	return merged
+}
+
 // consumeMappings correlates each test<->mock mapping the agent streams to its
 // real mock entries and persists it to mappings.yaml. It runs until mappings is
 // closed by the producer, and returns only then — ctx bounds nothing here by
@@ -72,25 +109,81 @@ func resetTimer(t *time.Timer, d time.Duration) {
 func (r *Recorder) consumeMappings(ctx context.Context, testSetID string, mappings <-chan models.TestMockMapping, correlationMap, asyncMockIDs *sync.Map) error {
 	persistCtx := context.WithoutCancel(ctx)
 
+	// pending batches mappings so the file is rewritten once per batch instead of
+	// once per test. flushMu guards it because the ticker below flushes too.
+	pending := make(map[string][]models.MockEntry, mappingFlushBatch)
+	var flushMu sync.Mutex
+
+	flush := func() {
+		flushMu.Lock()
+		defer flushMu.Unlock()
+		if len(pending) == 0 {
+			return
+		}
+		if err := r.mappingDb.UpsertBatch(persistCtx, testSetID, pending); err != nil {
+			// Deliberately not utils.LogError: it suppresses context.Canceled,
+			// which is exactly the class this write used to fail with, so a lost
+			// batch left no trace at all. A mapping that goes missing here is a
+			// no_mocks failure at replay — it must never be silent again.
+			names := make([]string, 0, len(pending))
+			for tn := range pending {
+				names = append(names, tn)
+			}
+			sort.Strings(names)
+			r.logger.Error("failed to save mappings",
+				zap.Strings("tests", names),
+				zap.Error(err),
+				zap.String("next_step", "these tests' mocks will be missing from mappings.yaml and replay will report no_mocks for them; re-record the test set"))
+		}
+		clear(pending)
+	}
+
+	// A partial batch must not sit in memory until the stream closes: recording
+	// can run for hours, and an operator watching mappings.yaml should see it
+	// grow. The ticker bounds how long a mapping stays unpersisted without
+	// putting a file rewrite on the per-mapping path.
+	ticker := time.NewTicker(mappingFlushInterval)
+	defer ticker.Stop()
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				flush()
+			}
+		}
+	}()
+
 	for mapping := range mappings {
 		realMockEntries := r.resolveMappingEntries(mapping, correlationMap, asyncMockIDs)
 
-		// Write to mappings.yaml
-		if len(realMockEntries) > 0 {
-			err := r.mappingDb.Upsert(persistCtx, testSetID, mapping.TestName, realMockEntries)
-			if err != nil {
-				// Deliberately not utils.LogError: it suppresses
-				// context.Canceled, which is exactly the class this write used
-				// to fail with, so the lost tail left no trace in the logs at
-				// all. A mapping that goes missing here is a no_mocks failure
-				// at replay — it must never be silent again.
-				r.logger.Error("failed to save mapping",
-					zap.String("test", mapping.TestName),
-					zap.Error(err),
-					zap.String("next_step", "this test's mocks will be missing from mappings.yaml and replay will report no_mocks for it; re-record the test set"))
-			}
+		if len(realMockEntries) == 0 {
+			continue
+		}
+
+		flushMu.Lock()
+		// Union, don't replace: the agent emits a test's mocks when its window
+		// resolves and emits more later for mocks retroactively binned into that
+		// window. Those later emissions are a DELTA — overwriting would delete the
+		// mocks already recorded for the test and replay it with a short pool.
+		pending[mapping.TestName] = mergeMockEntries(pending[mapping.TestName], realMockEntries)
+		full := len(pending) >= mappingFlushBatch
+		flushMu.Unlock()
+
+		// Flush on size only. Draining the channel is the priority: every
+		// millisecond spent rewriting mappings.yaml is a millisecond the agent
+		// cannot hand over its next mapping, and it DROPS what it cannot hand
+		// over. The ticker flushes whatever a partial batch leaves behind.
+		if full {
+			flush()
 		}
 	}
+
+	// The stream is closed: persist whatever the last partial batch holds.
+	flush()
 	return nil
 }
 

--- a/pkg/service/record/record_test.go
+++ b/pkg/service/record/record_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,7 +14,134 @@ import (
 	"go.keploy.io/server/v3/pkg/platform/yaml/mapdb"
 	"go.keploy.io/server/v3/pkg/platform/yaml/mockdb"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 )
+
+// fakeInstr is a minimal Instrumentation whose mapping stream is driven by the
+// test. GetIncoming/GetOutgoing return live-but-silent channels so
+// GetTestAndMockChans wires up exactly as it does in production.
+type fakeInstr struct {
+	mappings chan models.TestMockMapping
+	incoming chan *models.TestCase
+	outgoing chan *models.Mock
+}
+
+func (f *fakeInstr) Setup(context.Context, string, models.SetupOptions) error { return nil }
+func (f *fakeInstr) GetIncoming(context.Context, models.IncomingOptions) (<-chan *models.TestCase, error) {
+	return f.incoming, nil
+}
+func (f *fakeInstr) GetOutgoing(context.Context, models.OutgoingOptions) (<-chan *models.Mock, error) {
+	return f.outgoing, nil
+}
+func (f *fakeInstr) GetMappings(context.Context, models.IncomingOptions) (<-chan models.TestMockMapping, error) {
+	return f.mappings, nil
+}
+func (f *fakeInstr) Run(context.Context, models.RunOptions) models.AppError { return models.AppError{} }
+func (f *fakeInstr) MakeAgentReadyForDockerCompose(context.Context) error   { return nil }
+func (f *fakeInstr) NotifyGracefulShutdown(context.Context) error           { return nil }
+func (f *fakeInstr) StreamPcapArtifacts(context.Context, string) error      { return nil }
+
+// TestGetTestAndMockChans_DrainsMappingTailOnShutdown is the other half of the
+// go-memory-load-mongo reproduction: persisting the tail is worthless if the tail
+// never arrives.
+//
+// Recording stops and the agent still has resolved mappings queued. The pre-fix
+// code cancelled the mapping stream the instant ctx was done, so those never
+// reached the consumer at all — no write was attempted, so no error was logged.
+// Measured in CI even WITH the write fixed: 27 of 342 tests lost, all tails.
+//
+// It is tempting to assume teardown stops the app first and the agent has already
+// flushed. That holds only for the native path: under docker-compose keploy never
+// runs the app, so reqCtx is cancelled within milliseconds of SIGINT with the
+// agent's queue still full. That is the configuration this bug was measured in.
+func TestGetTestAndMockChans_DrainsMappingTailOnShutdown(t *testing.T) {
+	f := &fakeInstr{
+		mappings: make(chan models.TestMockMapping),
+		incoming: make(chan *models.TestCase),
+		outgoing: make(chan *models.Mock),
+	}
+	r := &Recorder{logger: zap.NewNop(), instrumentation: f, config: &config.Config{}}
+
+	g, gctx := errgroup.WithContext(context.Background())
+	ctx, cancel := context.WithCancel(gctx)
+	ctx = context.WithValue(ctx, models.ErrGroupKey, g)
+
+	frames, err := r.GetTestAndMockChans(ctx)
+	require.NoError(t, err)
+
+	var got []string
+	collected := make(chan struct{})
+	go func() {
+		defer close(collected)
+		for m := range frames.Mappings {
+			got = append(got, m.TestName)
+		}
+	}()
+
+	// Recording stops FIRST — the real ordering. The agent has already resolved
+	// these tests and flushes them on the still-open stream immediately after.
+	cancel()
+
+	tail := []string{"post-orders-63", "post-orders-64", "post-orders-65"}
+	for _, tn := range tail {
+		select {
+		case f.mappings <- models.TestMockMapping{TestName: tn, MockIDs: []string{"mock-" + tn}}:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("mapping for %q was never accepted after shutdown began: the stream was "+
+				"torn down while the agent still had it queued, so this test is dropped from "+
+				"mappings.yaml and replay reports no_mocks for it", tn)
+		}
+	}
+	close(f.mappings)
+
+	select {
+	case <-collected:
+	case <-time.After(5 * time.Second):
+		t.Fatal("mapping consumer did not finish after the stream closed")
+	}
+
+	assert.Equal(t, tail, got,
+		"every mapping the agent flushes after shutdown begins must reach the consumer; "+
+			"a missing tail is the go-memory-load-mongo no_mocks flake")
+}
+
+// TestGetTestAndMockChans_MappingDrainStopsWhenIdle guards the drain itself: the
+// agent holds the stream open for the whole session and never closes it, so the
+// drain cannot wait for EOF — it must end once the stream falls idle, or recording
+// would hang on exit. This one does not fail pre-fix (there was no drain to hang);
+// it pins the bound that makes the drain safe.
+func TestGetTestAndMockChans_MappingDrainStopsWhenIdle(t *testing.T) {
+	f := &fakeInstr{
+		mappings: make(chan models.TestMockMapping),
+		incoming: make(chan *models.TestCase),
+		outgoing: make(chan *models.Mock),
+	}
+	r := &Recorder{logger: zap.NewNop(), instrumentation: f, config: &config.Config{}}
+
+	g, gctx := errgroup.WithContext(context.Background())
+	ctx, cancel := context.WithCancel(gctx)
+	ctx = context.WithValue(ctx, models.ErrGroupKey, g)
+
+	frames, err := r.GetTestAndMockChans(ctx)
+	require.NoError(t, err)
+
+	closed := make(chan struct{})
+	go func() {
+		defer close(closed)
+		for range frames.Mappings { //nolint:revive // draining
+		}
+	}()
+
+	// Shut down and send nothing more: the stream stays open (as the real agent's
+	// does), so the drain must exit on the idle bound rather than hang.
+	cancel()
+
+	select {
+	case <-closed:
+	case <-time.After(mappingIdleGrace + 10*time.Second):
+		t.Fatal("mapping drain did not stop after the stream fell idle — shutdown would hang")
+	}
+}
 
 // These tests pin the contract behind the go-memory-load-mongo "no_mocks" flake:
 // a record session that is shutting down must still persist everything the agent

--- a/pkg/service/record/record_test.go
+++ b/pkg/service/record/record_test.go
@@ -2,6 +2,7 @@ package record
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -242,6 +243,145 @@ func TestConsumeMappings_UpsertsIntoExistingFile(t *testing.T) {
 		"the tail mapping must be merged into the existing mappings.yaml during shutdown")
 	assert.Len(t, saved["post-orders-1"], 1,
 		"upserting the tail must not lose mappings written earlier in the session")
+}
+
+// countingMapDb records how many file rewrites the consumer asks for.
+type countingMapDb struct {
+	mu      sync.Mutex
+	writes  int
+	byTest  map[string][]models.MockEntry
+	perCall []int
+}
+
+func (c *countingMapDb) Insert(context.Context, *models.Mapping) error { return nil }
+func (c *countingMapDb) Upsert(ctx context.Context, testSetID, testID string, e []models.MockEntry) error {
+	return c.UpsertBatch(ctx, testSetID, map[string][]models.MockEntry{testID: e})
+}
+func (c *countingMapDb) UpsertBatch(_ context.Context, _ string, byTest map[string][]models.MockEntry) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.writes++
+	c.perCall = append(c.perCall, len(byTest))
+	for k, v := range byTest {
+		c.byTest[k] = v
+	}
+	return nil
+}
+
+// TestConsumeMappings_BatchesWrites pins the fix for the slow-consumer half of
+// the go-memory-load-mongo flake.
+//
+// mappings.yaml is one document, so each write re-encodes the whole file. Writing
+// per mapping is quadratic — measured at 368 tests, 164us for the first write and
+// 19.45ms for the last, ~2.7s of pure rewriting. That is slow enough to
+// back-pressure the agent's mapping stream, and the agent discards what it cannot
+// hand over, so the tests behind the backlog replay as no_mocks.
+//
+// The consumer must therefore drain the stream far faster than it writes: batch
+// the mappings and rewrite once per batch.
+func TestConsumeMappings_BatchesWrites(t *testing.T) {
+	const total = 320
+	db := &countingMapDb{byTest: map[string][]models.MockEntry{}}
+	r := &Recorder{logger: zap.NewNop(), config: &config.Config{}, mappingDb: db}
+
+	var correlationMap, asyncMockIDs sync.Map
+	mappings := make(chan models.TestMockMapping, total)
+	for i := 0; i < total; i++ {
+		name := fmt.Sprintf("post-orders-%d", i)
+		correlationMap.Store("temp-"+name, models.MockEntry{Name: "mock-" + name, Kind: string(models.Mongo)})
+		mappings <- models.TestMockMapping{TestName: name, MockIDs: []string{"temp-" + name}}
+	}
+	close(mappings)
+
+	require.NoError(t, r.consumeMappings(context.Background(), "test-set-0", mappings, &correlationMap, &asyncMockIDs))
+
+	db.mu.Lock()
+	writes, saved := db.writes, len(db.byTest)
+	db.mu.Unlock()
+
+	assert.Equal(t, total, saved, "every mapping must still be persisted")
+	assert.LessOrEqual(t, writes, total/mappingFlushBatch+2,
+		"mappings must be batched, not written one file-rewrite per test: %d writes for %d "+
+			"mappings means the consumer is quadratic again and will back-pressure the agent "+
+			"into dropping the tail", writes, total)
+	assert.Greater(t, writes, 0, "mappings must actually reach the store")
+}
+
+// TestConsumeMappings_LateMockDoesNotWipeEarlierOnes pins the delta semantics of
+// a test's mapping.
+//
+// The agent emits a test's mocks when its window resolves, then emits MORE later
+// for mocks it retroactively bins into that already-resolved window. The second
+// emission carries only the late mock — it is a delta. Replacing on it deletes
+// the mocks the first emission recorded, and the test then replays against a short
+// pool (or an empty one), which is the same no_mocks failure by another route.
+func TestConsumeMappings_LateMockDoesNotWipeEarlierOnes(t *testing.T) {
+	const testSetID, test = "test-set-0", "post-orders-1"
+	dir := t.TempDir()
+	r := &Recorder{
+		logger:    zap.NewNop(),
+		config:    &config.Config{},
+		mappingDb: mapdb.New(zap.NewNop(), dir, "mappings"),
+	}
+
+	var correlationMap, asyncMockIDs sync.Map
+	for _, id := range []string{"a", "b", "c"} {
+		correlationMap.Store("temp-"+id, models.MockEntry{Name: "mock-" + id, Kind: string(models.Mongo)})
+	}
+
+	// Resolution emits a and b; a later retroactive bin emits only c.
+	mappings := make(chan models.TestMockMapping, 2)
+	mappings <- models.TestMockMapping{TestName: test, MockIDs: []string{"temp-a", "temp-b"}}
+	mappings <- models.TestMockMapping{TestName: test, MockIDs: []string{"temp-c"}}
+	close(mappings)
+
+	require.NoError(t, r.consumeMappings(context.Background(), testSetID, mappings, &correlationMap, &asyncMockIDs))
+
+	saved, _, err := mapdb.New(zap.NewNop(), dir, "mappings").Get(context.Background(), testSetID)
+	require.NoError(t, err)
+
+	names := make([]string, 0, 3)
+	for _, e := range saved[test] {
+		names = append(names, e.Name)
+	}
+	assert.ElementsMatch(t, []string{"mock-a", "mock-b", "mock-c"}, names,
+		"a late-binned mock is a DELTA: it must be unioned into the test's mapping, not "+
+			"replace it — dropping mock-a/mock-b here means this test replays with a short "+
+			"mock pool and reports a mismatch")
+}
+
+// TestConsumeMappings_FlushesPartialBatchOnTicker covers the path a batching
+// consumer must not get wrong: a recording that produces fewer than a full batch
+// (or trails off) must still persist, rather than holding mappings in memory until
+// the stream closes. Exercises the ticker concurrently with the feed.
+func TestConsumeMappings_FlushesPartialBatchOnTicker(t *testing.T) {
+	db := &countingMapDb{byTest: map[string][]models.MockEntry{}}
+	r := &Recorder{logger: zap.NewNop(), config: &config.Config{}, mappingDb: db}
+
+	var correlationMap, asyncMockIDs sync.Map
+	mappings := make(chan models.TestMockMapping)
+
+	// Feed slowly and never fill a batch, keeping the stream open throughout.
+	go func() {
+		defer close(mappings)
+		for i := 0; i < 3; i++ {
+			name := fmt.Sprintf("post-orders-%d", i)
+			correlationMap.Store("temp-"+name, models.MockEntry{Name: "mock-" + name, Kind: string(models.Mongo)})
+			mappings <- models.TestMockMapping{TestName: name, MockIDs: []string{"temp-" + name}}
+			time.Sleep(mappingFlushInterval + 200*time.Millisecond)
+		}
+	}()
+
+	require.NoError(t, r.consumeMappings(context.Background(), "test-set-0", mappings, &correlationMap, &asyncMockIDs))
+
+	db.mu.Lock()
+	writes, saved := db.writes, len(db.byTest)
+	db.mu.Unlock()
+
+	assert.Equal(t, 3, saved, "every mapping must be persisted")
+	assert.Greater(t, writes, 1,
+		"a partial batch must be flushed by the ticker as recording proceeds, not held in "+
+			"memory until the stream closes: got %d write(s)", writes)
 }
 
 // TestMockStore_RefusesCancelledContext is the reason persistCtx exists, pinned

--- a/pkg/service/record/record_test.go
+++ b/pkg/service/record/record_test.go
@@ -1,0 +1,151 @@
+package record
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.keploy.io/server/v3/config"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.keploy.io/server/v3/pkg/platform/yaml/mapdb"
+	"go.keploy.io/server/v3/pkg/platform/yaml/mockdb"
+	"go.uber.org/zap"
+)
+
+// These tests pin the contract behind the go-memory-load-mongo "no_mocks" flake:
+// a record session that is shutting down must still persist everything the agent
+// has already streamed to it.
+//
+// Why the tail is special: recording stops on SIGINT, which cancels the root
+// context immediately, but the agent's streams run on reqCtx — deliberately
+// WithoutCancel'd — and keep delivering right through teardown (a graceful-
+// shutdown notify of up to 10s, then an app drain of up to 30s). Every store
+// call in that window used to run on the cancelled context and refuse to write.
+// Mappings are emitted last (the agent resolves a test's mock range only once
+// that test is done), so the tail of every endpoint landed exactly there: in CI,
+// 21 of 327 tests were absent from mappings.yaml, and replay reported
+// no_mocks/candidates:0 for precisely those tests.
+
+// TestConsumeMappings_PersistsTailAfterShutdown asserts on mappings.yaml itself
+// — the artifact replay actually reads. Accepting a mapping off the channel is
+// worthless if the write then discards it.
+func TestConsumeMappings_PersistsTailAfterShutdown(t *testing.T) {
+	const testSetID = "test-set-0"
+	dir := t.TempDir()
+
+	r := &Recorder{
+		logger:    zap.NewNop(),
+		config:    &config.Config{},
+		mappingDb: mapdb.New(zap.NewNop(), dir, "mappings"),
+	}
+
+	// The mock loop has already correlated these tempIDs.
+	var correlationMap, asyncMockIDs sync.Map
+	tail := []string{"post-orders-58", "post-orders-59", "post-orders-60"}
+	for _, tn := range tail {
+		correlationMap.Store("temp-"+tn, models.MockEntry{
+			Name: "mock-" + tn,
+			Kind: string(models.Mongo),
+		})
+	}
+
+	mappings := make(chan models.TestMockMapping, len(tail))
+	for _, tn := range tail {
+		mappings <- models.TestMockMapping{TestName: tn, MockIDs: []string{"temp-" + tn}}
+	}
+	close(mappings)
+
+	// Recording has been cancelled: the state every tail mapping is written in.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.NoError(t, r.consumeMappings(ctx, testSetID, mappings, &correlationMap, &asyncMockIDs))
+
+	require.FileExists(t, filepath.Join(dir, testSetID, "mappings.yaml"),
+		"no mappings.yaml on disk: every mapping written during shutdown was discarded "+
+			"by the cancelled context, and replay reports no_mocks for the tail")
+
+	// Read back through the same store replay uses, on a live context.
+	saved, meaningful, err := mapdb.New(zap.NewNop(), dir, "mappings").Get(context.Background(), testSetID)
+	require.NoError(t, err)
+	require.True(t, meaningful, "mappings.yaml exists but holds no mock entries")
+
+	for _, tn := range tail {
+		assert.Len(t, saved[tn], 1,
+			"test %q was streamed by the agent during shutdown and must be mapped in "+
+				"mappings.yaml; dropping it is the go-memory-load-mongo no_mocks flake", tn)
+	}
+}
+
+// TestConsumeMappings_UpsertsIntoExistingFile covers the path production actually
+// takes. The sibling test starts from an empty dir, so it only exercises the
+// create-file gate; by the time the tail arrives in a real run, mappings.yaml
+// already holds hundreds of tests and the write goes through the read-modify-write
+// path instead. Both must survive cancellation.
+func TestConsumeMappings_UpsertsIntoExistingFile(t *testing.T) {
+	const testSetID = "test-set-0"
+	dir := t.TempDir()
+	db := mapdb.New(zap.NewNop(), dir, "mappings")
+
+	// An earlier, healthy part of the session — written while ctx was live.
+	require.NoError(t, db.Upsert(context.Background(), testSetID, "post-orders-1",
+		[]models.MockEntry{{Name: "mock-1", Kind: string(models.Mongo)}}))
+
+	r := &Recorder{logger: zap.NewNop(), config: &config.Config{}, mappingDb: db}
+
+	var correlationMap, asyncMockIDs sync.Map
+	correlationMap.Store("temp-tail", models.MockEntry{Name: "mock-tail", Kind: string(models.Mongo)})
+
+	mappings := make(chan models.TestMockMapping, 1)
+	mappings <- models.TestMockMapping{TestName: "post-orders-60", MockIDs: []string{"temp-tail"}}
+	close(mappings)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.NoError(t, r.consumeMappings(ctx, testSetID, mappings, &correlationMap, &asyncMockIDs))
+
+	saved, _, err := mapdb.New(zap.NewNop(), dir, "mappings").Get(context.Background(), testSetID)
+	require.NoError(t, err)
+	assert.Len(t, saved["post-orders-60"], 1,
+		"the tail mapping must be merged into the existing mappings.yaml during shutdown")
+	assert.Len(t, saved["post-orders-1"], 1,
+		"upserting the tail must not lose mappings written earlier in the session")
+}
+
+// TestMockStore_RefusesCancelledContext is the reason persistCtx exists, pinned
+// at the store boundary.
+//
+// It documents why threading the recording context into a record-time write is a
+// data-loss bug rather than a style preference — and it guards the second half of
+// the failure: the mock consumer skips correlationMap.Store when its insert
+// fails, so a dropped tail mock also strands the mapping that references it. The
+// mapping is then uncorrelatable and no row is written for that test at all, which
+// is the same no_mocks symptom by a different route.
+func TestMockStore_RefusesCancelledContext(t *testing.T) {
+	dir := t.TempDir()
+	db := mockdb.New(zap.NewNop(), dir, "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	mock := &models.Mock{
+		Version: models.V1Beta1,
+		Kind:    models.Mongo,
+		Name:    "mock-tail",
+		Spec:    models.MockSpec{Metadata: map[string]string{}},
+	}
+
+	err := db.InsertMock(ctx, mock, "test-set-0")
+	require.Error(t, err,
+		"if the mock store ever starts accepting a cancelled context this test is "+
+			"obsolete; until then, record-time writes must not run on the recording context")
+	require.ErrorIs(t, err, context.Canceled)
+
+	// The same insert on a detached context — what Start now passes — persists.
+	require.NoError(t, db.InsertMock(context.WithoutCancel(ctx), mock, "test-set-0"),
+		"detaching the write from cancellation is what keeps the tail of a recording")
+}

--- a/pkg/service/record/service.go
+++ b/pkg/service/record/service.go
@@ -48,6 +48,11 @@ type MockDB interface {
 type MappingDb interface {
 	Insert(ctx context.Context, mapping *models.Mapping) error
 	Upsert(ctx context.Context, testSetID string, testID string, mockEntries []models.MockEntry) error
+	// UpsertBatch persists several tests' mappings in one file rewrite. Recording
+	// must use this rather than a per-mapping Upsert: the per-mapping cost grows
+	// with the file, and a slow consumer back-pressures the agent's mapping stream
+	// into dropping entries (its send is non-blocking so capture is never stalled).
+	UpsertBatch(ctx context.Context, testSetID string, byTest map[string][]models.MockEntry) error
 }
 
 type TestSetConfig interface {


### PR DESCRIPTION
## Summary

Consolidated record-side reliability fixes for the dominant keploy OSS CI flake: **`go-memory-load-mongo` replay `no_mocks`** (and the same class on other Mongo lanes). It supersedes #4371 (whose commits it includes) and adds a distinct, separately-root-caused fix.

The `no_mocks` flake has **two independent record-side root causes**, both fixed here:

### 1. Test→mock mapping **stream loss** under load (from #4371)
The agent streams test→mock mappings to the CLI on a separate channel from mocks. Under heavy concurrent load these were dropped in several places (non-blocking `default:` sends once a 100-slot buffer filled; O(n²) per-mapping `mapdb.Upsert` full-file rewrites; shutdown stream teardown; cancelled-ctx writes; delta-replace instead of merge). Result: a whole test's mapping never reaches disk → replay serves an empty per-test pool → `no_mocks`. (Commits: *persist recorded data streamed during shutdown*, *drain the agent's mapping tail on record shutdown*, *stop dropping test-mock mappings under load*.)

### 2. Late-mock **attribution eviction** (new — the fix #4371 was missing)
`syncMock.recentWindows` retro-bins a per-test mock that decodes **after** its HTTP window closed (a large async Mongo `aggregate` response lands in the buffer late) back to its owning test. The ring was bounded **only** by a 256-entry count cap — its documented 7s age-prune was a **verbatim no-op** (a loop that copied every element with no age predicate).

Under load, recordings **burst well past 1000 resolved windows within a single 7s span** (measured on `go-memory-load-mongo`: ~1000 windows/7s peak). At 256 the owning window was evicted from the ring long before the slow aggregate landed, so `ownerWindow()` missed and the aggregate was **orphaned** from its test. The fast `find` mock (mapped in-window) survived, so the test recorded with **1 of its 2 mocks**, and replay served an empty per-test pool for the aggregate query (`match_phase=no_mocks`, `candidates:0`).

**Fix:** raise `maxRecentWindows` **256 → 8192**, matching `maxPressureRanges` which guards the same consumer-lag class of bug. The ring is deliberately **count-bounded, not age-pruned** — the retro-bin legitimately rescues in-window mocks from windows far older than the 7s stale-cutoff (a ~56s mongo-fuzzer `/run` spans that horizon by itself), so age-pruning would strand them. A window only has to survive the mock's decode-lag plus one ~1s flush tick, so 8192 (~57s at the peak rate) is a ~50× margin at O(1) memory. Removed the dead no-op loop and corrected the docstrings it contradicted.

## Proof

- **Deterministic unit test** `TestLateOwnedMockSurvivesWindowBurst`: resolves a window, bursts 512 later windows (>256, <8192, all <7s), then a late owned mock arrives — asserts it's retro-binned. **Fail-before (cap 256, orphaned) / pass-after (cap 8192).**
- **Independent review:** clean (correctness, no long-window-rescue regression, perf, sufficiency, test quality all verified).
- **E2e:** reproduced the flake locally (dockerized Mongo API + k6 load + CPU/disk throttling to mimic the 2-vCPU runner), then validated the fix: **0 orphaned-mapping losses across 7,587 recorded tests / 4 reproducing runs**, vs partial losses before. The `recentWindows` root cause and its reachability (>256 windows/7s) were confirmed against real recordings.

## Scope / honesty

This PR fixes the **dominant** `go-memory-load-mongo no_mocks` flake. It does **not** claim to fix every red lane:
- A **rarer, distinct** residual `no_mocks` remains (whole-TC mapping absent, ~0.03%, under the lane's 4% tolerance) — a separate follow-up.
- The **port-in-use** flake (`spring-petclinic`, `connect-tunnel`, `grpc-fuzzer`) is a CI-load-specific teardown race that **does not reproduce locally** (teardown is robust on an unloaded box even under SIGKILL) — not fixed here to avoid a speculative, unproven change.
- The **macOS/Windows Docker-Desktop readiness** failures are CI-runner-capacity/infra, not keploy code.
