### PR TITLE
fix(replay): don't log a transport reset as ERROR before the caller can retry it

### DIFF
--- a/pkg/util.go
+++ b/pkg/util.go
@@ -705,6 +705,27 @@ func doRequestWithConnRefusedRetry(ctx context.Context, logger *zap.Logger, clie
 	}
 }
 
+// logSendFailure reports a failed test request at the severity its finality
+// actually warrants. A transport-level reset (IsTransportConnReset — dominated
+// under loaded CI by docker's userland proxy resetting a freshly-accepted
+// host-side connection before the app processes it) is not yet a final
+// failure: the replay orchestration (Replayer.retryResetOnce) safely re-sends
+// this exact error class once it proves zero mocks were consumed, and usually
+// recovers it. Logging ERROR here — before that caller has any chance to
+// retry — makes a routine, self-healing retry indistinguishable from a fatal
+// crash to anything scanning logs for "ERROR" (several downstream CI lanes did
+// exactly that, treating an already-recovered retry as a hard pipeline
+// failure). Every other error here (DNS failure, TLS failure, or an
+// ECONNREFUSED that already exhausted doRequestWithConnRefusedRetry's own
+// retries) is not retried by anything upstream, so it keeps logging at ERROR.
+func logSendFailure(logger *zap.Logger, err error) {
+	if IsTransportConnReset(err) {
+		logger.Warn("failed to send testcase request to app (transport reset; may be retried by the caller)", zap.Error(err))
+		return
+	}
+	utils.LogError(logger, err, "failed to send testcase request to app")
+}
+
 func SimulateHTTP(ctx context.Context, tc *models.TestCase, testSet string, logger *zap.Logger, cfg SimulationConfig) (*models.HTTPResp, error) {
 	templatedResponse := tc.HTTPResp // keep a copy of the original templatized response
 
@@ -722,7 +743,7 @@ func SimulateHTTP(ctx context.Context, tc *models.TestCase, testSet string, logg
 	// Execute the request (re-sending only on a pre-response connection-refused)
 	httpResp, errHTTPReq := doRequestWithConnRefusedRetry(ctx, logger, prepared.Client, prepared.Request)
 	if errHTTPReq != nil {
-		utils.LogError(logger, errHTTPReq, "failed to send testcase request to app")
+		logSendFailure(logger, errHTTPReq)
 		return nil, errHTTPReq
 	}
 
@@ -799,7 +820,7 @@ func SimulateHTTPStreaming(ctx context.Context, tc *models.TestCase, testSet str
 	// Execute the request (re-sending only on a pre-response connection-refused)
 	httpResp, errHTTPReq := doRequestWithConnRefusedRetry(ctx, logger, prepared.Client, prepared.Request)
 	if errHTTPReq != nil {
-		utils.LogError(logger, errHTTPReq, "failed to send testcase request to app")
+		logSendFailure(logger, errHTTPReq)
 		return nil, errHTTPReq
 	}
 

--- a/pkg/util_logsendfailure_test.go
+++ b/pkg/util_logsendfailure_test.go
@@ -1,0 +1,54 @@
+package pkg
+
+import (
+	"errors"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// TestLogSendFailure_TransportResetLogsWarn pins the fix: a transport-level
+// reset (IsTransportConnReset — dominated under loaded CI by docker's
+// userland proxy resetting a freshly-accepted connection before the app
+// processes it) must log at WARN, not ERROR, because the caller
+// (Replayer.retryResetOnce) safely re-sends this exact error class and
+// usually recovers it. Logging ERROR here — before the caller has any chance
+// to retry — made a routine, self-healing retry indistinguishable from a
+// fatal crash to any downstream tooling (several CI lanes) that scans logs
+// for "ERROR". If this test starts failing, someone reverted the fix.
+func TestLogSendFailure_TransportResetLogsWarn(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	logger := zap.New(core)
+
+	logSendFailure(logger, connResetErr("http://127.0.0.1:8080/health"))
+
+	entries := logs.All()
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly 1 log entry, got %d", len(entries))
+	}
+	if entries[0].Level != zapcore.WarnLevel {
+		t.Fatalf("expected a transport reset to log at WARN, got %s: %q", entries[0].Level, entries[0].Message)
+	}
+}
+
+// TestLogSendFailure_NonResetErrorStaysError confirms the fix is scoped
+// correctly: an error that is NOT a transport reset (e.g. a genuinely fatal
+// failure, or an ECONNREFUSED that already exhausted its own bounded retries
+// in doRequestWithConnRefusedRetry) is never retried by anything upstream, so
+// it must keep logging at ERROR -- no signal lost for a real failure.
+func TestLogSendFailure_NonResetErrorStaysError(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	logger := zap.New(core)
+
+	logSendFailure(logger, errors.New("boom: dns lookup failed"))
+
+	entries := logs.All()
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly 1 log entry, got %d", len(entries))
+	}
+	if entries[0].Level != zapcore.ErrorLevel {
+		t.Fatalf("expected a non-reset error to log at ERROR, got %s: %q", entries[0].Level, entries[0].Message)
+	}
+}


### PR DESCRIPTION
## TL;DR
`SimulateHTTP`/`SimulateHTTPStreaming` log any HTTP send failure at `ERROR` the instant it occurs — including a transport-level reset that the replay orchestration (`Replayer.retryResetOnce`) will safely retry and usually recover moments later. This makes a routine, self-healing retry indistinguishable from a fatal crash to anything scanning logs for "ERROR". Downgrades that specific, retryable error class to `WARN`; every other error keeps logging at `ERROR`.

## Background
Two retry mechanisms exist for replay HTTP requests:
- `doRequestWithConnRefusedRetry` (pkg/util.go) — retries a pre-response `ECONNREFUSED` internally, bounded, before returning.
- `Replayer.retryResetOnce` (pkg/service/replay/replay.go) — retries a transport reset (`ECONNRESET`/`EPIPE`/EOF) at the orchestration layer, but *only* when it can prove zero mocks were consumed by the failed request (otherwise a retry would re-run non-idempotent logic against already-exhausted single-use mocks).

`SimulateHTTP` calls `doRequestWithConnRefusedRetry`, and if that returns an error, immediately logs it at `ERROR` via `utils.LogError` and returns. The caller (`RunTestSet`, replay.go:1827) only *then* checks `pkg.IsTransportConnReset(loopErr)` and hands it to `retryResetOnce` — by which point the `ERROR` line has already been written, regardless of whether the retry goes on to succeed.

## The bug
A transport reset dominated under loaded CI by docker's userland proxy resetting a freshly-accepted host-side connection before the app ever processes the request (see the existing comment on `IsTransportConnReset`) gets logged as `ERROR failed to send testcase request to app`, then a few lines later `retryResetOnce` logs its own `WARN test request reset by app/proxy before any mock was consumed; re-sending`, retries, and the test ultimately passes. The `ERROR` line is still sitting in the log, describing a condition that was fully recovered.

We saw this cause real CI failures: several lanes (Couchbase ×5 languages, Memcached ×4, Redis-TLS, Zookeeper-fuzzer, Aerospike-fuzzer, gRPC-fuzzer) grep their captured logs for `ERROR.*Keploy` (with a maintained exclusion list for a few already-known-benign lines) and fail the whole pipeline the moment they see this line — even when the actual test-run summary shows 100% pass (`Total tests: 34, Total test passed: 34, Total test failed: 0`).

## Evidence
```
🐰 Keploy: ... ERROR failed to send testcase request to app {"error": "Get \"http://localhost:8080/health\": read tcp [::1]:34066->[::1]:8080: read: connection reset by peer"}
...
🐰 Keploy: ... WARN test request reset by app/proxy before any mock was consumed; re-sending — the request was never processed, so this is not a retry of an assertion {"attempt": 1, "maxRetries": 6, ...}
...
 TESTRUN SUMMARY. For test-set: "test-set-0"
    Total tests:        34
    Total test passed:  34
    Total test failed:  0
```
Full 34/34 pass, yet the CI script's log-scrape sees the `ERROR` line and reports:
```
Critical Keploy errors in .../record-0.txt
pipeline failed (exit=1)
```

## Root cause
`pkg/util.go`'s `SimulateHTTP`/`SimulateHTTPStreaming` classify every send failure as `ERROR` unconditionally, before the caller's retry decision is made — the wrong layer to assign final severity, since this function has no visibility into whether its caller will retry.

## The fix
Both call sites now route through a new `logSendFailure` helper that checks `IsTransportConnReset` (already defined in the same file) and logs at `WARN` for that specific, often-recoverable class, keeping `ERROR` for everything else — a DNS failure, a TLS failure, or an `ECONNREFUSED` that already exhausted `doRequestWithConnRefusedRetry`'s own bounded retries, none of which are retried by anything upstream.

```go
func logSendFailure(logger *zap.Logger, err error) {
	if IsTransportConnReset(err) {
		logger.Warn("failed to send testcase request to app (transport reset; may be retried by the caller)", zap.Error(err))
		return
	}
	utils.LogError(logger, err, "failed to send testcase request to app")
}
```

## Verification
- `go build ./...`, `go vet ./pkg/...`, `gofmt -l` all clean.
- Added `pkg/util_logsendfailure_test.go`: asserts a transport-reset error logs at `WARN`, a non-reset error logs at `ERROR`. Falsified by reverting only `pkg/util.go` — the test file fails to compile (`undefined: logSendFailure`), confirming it pins the fix.
- Ran the full `pkg` test suite before and after the change: the same 1-2 pre-existing, environment-specific tests (`TestDialTCPWithConnRefusedRetry_RetriesBoundedOnPersistentRefusal`, occasionally `TestSimulateHTTP_RecoversBriefConnRefused_RefuseInteg`) fail/flake identically with or without this change — confirmed by stashing the fix and re-running the identical tests against unmodified code.

## Test plan
- [x] `go build`, `go vet`, `gofmt`
- [x] New regression test added and falsification-checked
- [x] Full `pkg` suite run, pre-existing flakes isolated and confirmed unrelated
- [ ] Downstream `enterprise` repo bumps its `go.keploy.io/server/v3` pin to pick this up once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)