### PR TITLE
fix(replay): keep mixed-protocol destinations on HTTP/1.1 in ALPN

### DIFF
--- a/pkg/agent/proxy/alpn_http1_gate_test.go
+++ b/pkg/agent/proxy/alpn_http1_gate_test.go
@@ -1,0 +1,75 @@
+package proxy
+
+import (
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+func http1MockForTest(name string, header map[string]string, url string) *models.Mock {
+	mk := newMockForTest(name, time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC), models.LifetimeSession)
+	mk.Kind = models.HTTP
+	mk.Spec.HTTPReq = &models.HTTPReq{URL: url, Header: header}
+	return mk
+}
+
+func TestReplayTargetHasHTTP1Mock(t *testing.T) {
+	tests := []struct {
+		name    string
+		mocks   []*models.Mock
+		sniHost string
+		port    uint32
+		want    bool
+	}{
+		{
+			name:  "host header with port matches on port",
+			mocks: []*models.Mock{http1MockForTest("a", map[string]string{"Host": "openbao.svc:8200"}, "/v1/auth/kubernetes/login")},
+			port:  8200,
+			want:  true,
+		},
+		{
+			name:  "host header key is matched case-insensitively",
+			mocks: []*models.Mock{http1MockForTest("a", map[string]string{"host": "openbao.svc:8200"}, "/v1/login")},
+			port:  8200,
+			want:  true,
+		},
+		{
+			name:  "absolute url is used when host header is absent",
+			mocks: []*models.Mock{http1MockForTest("a", nil, "http://openbao.svc:8200/v1/login")},
+			port:  8200,
+			want:  true,
+		},
+		{
+			name:    "host disambiguates when sni is known",
+			mocks:   []*models.Mock{http1MockForTest("a", map[string]string{"Host": "openbao.svc:8200"}, "/v1/login")},
+			sniHost: "vault.other",
+			port:    8200,
+			want:    false,
+		},
+		{
+			name:  "different port does not match",
+			mocks: []*models.Mock{http1MockForTest("a", map[string]string{"Host": "openbao.svc:8200"}, "/v1/login")},
+			port:  9999,
+			want:  false,
+		},
+		{
+			name:  "no http1 mocks",
+			mocks: []*models.Mock{h2MockForTest("h2", "openbao.svc:8200")},
+			port:  8200,
+			want:  false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mm := NewMockManager(nil, nil, zap.NewNop())
+			defer mm.Close()
+			mm.SetUnFilteredMocks(tc.mocks)
+			p := &Proxy{mockManager: mm}
+			if got := p.replayTargetHasHTTP1Mock(tc.sniHost, tc.port); got != tc.want {
+				t.Fatalf("replayTargetHasHTTP1Mock(%q, %d) = %v, want %v", tc.sniHost, tc.port, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -936,6 +936,30 @@ func (p *Proxy) replayTargetHasHTTP2Mock(sniHost string, port uint32) bool {
 	})
 }
 
+func (p *Proxy) replayTargetHasHTTP1Mock(sniHost string, port uint32) bool {
+	m := p.getMockManager()
+	if m == nil {
+		return false
+	}
+	return m.HasMocksByKind(models.HTTP, func(mk *models.Mock) bool {
+		if mk.Spec.HTTPReq == nil {
+			return false
+		}
+		host := ""
+		for k, v := range mk.Spec.HTTPReq.Header {
+			if strings.EqualFold(k, "Host") {
+				host = v
+				break
+			}
+		}
+		if host == "" {
+			host = mk.Spec.HTTPReq.URL
+		}
+		h, pt := hostPortFromAuthority(host, "")
+		return http2DestMatches(strings.ToLower(h), pt, sniHost, port)
+	})
+}
+
 // http2DestMatches reports whether a recorded Http2 destination (aHost:aPort,
 // aHost lower-cased) matches the connection destination sniHost:port. A
 // discriminator unknown on either side (missing port, missing SNI/host) is not
@@ -2085,7 +2109,8 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 			}
 			preferH2 := rule.OutgoingOptions.PreferH2
 			if !preferH2 {
-				preferH2 = p.replayTargetHasHTTP2Mock(sniHost, destInfo.Port)
+				preferH2 = p.replayTargetHasHTTP2Mock(sniHost, destInfo.Port) &&
+					!p.replayTargetHasHTTP1Mock(sniHost, destInfo.Port)
 			}
 			if preferH2 {
 				hsCtx = pTls.WithPreferH2(ctx)


### PR DESCRIPTION
## Problem

On **replay**, the MITM decides its client-facing ALPN offer per connection *before* it has seen the request. Today it advertises **h2** whenever the destination (scoped by SNI/host + port) has **any** recorded `kind:Http2` mock:

```go
preferH2 = p.replayTargetHasHTTP2Mock(sniHost, destInfo.Port)
```

That is correct for a destination that is purely HTTP/2. It breaks a destination that was recorded with **both** HTTP/1.1 and HTTP/2 mocks on the same `host:port`.

A real example: an OpenBao/Vault endpoint (`:8200`). Its `kubernetes-auth` **login** was recorded over **HTTP/1.1** (`kind: Http`), while other calls to the same host were HTTP/2. On replay the check sees the HTTP/2 mocks and advertises h2; the client (which offers `h2,http/1.1`) negotiates **h2**, and the HTTP/1.1-recorded login can no longer be served intact. The application's Vault client sees `unexpected EOF`, OpenBao client init fails, and the app **exits at startup** — before a single test runs.

When this app is driven under `keploy cloud replay ... up --abort-on-container-exit`, the startup exit tears the whole run down, producing **zero test reports** (a "catastrophic setup" failure rather than test results).

## Fix

Prefer h2 **only when the destination is exclusively HTTP/2** in the recording. A new `replayTargetHasHTTP1Mock` mirrors the existing h2 check for `kind:Http` mocks (keyed off the request's `Host` header, falling back to the URL), and gates the preference:

```go
preferH2 = p.replayTargetHasHTTP2Mock(sniHost, destInfo.Port) &&
    !p.replayTargetHasHTTP1Mock(sniHost, destInfo.Port)
```

ALPN must be chosen before the request is known, so a mixed `host:port` is inherently ambiguous at this point — this change resolves that ambiguity by biasing to **HTTP/1.1**, where the recorded HTTP/1.1 mocks match reliably. Note that a client offering only `h2` is still given h2 (it is never downgraded); only a client offering **both** `h2` and `http/1.1` is affected by the bias.

## Validation (live `keploy cloud replay`, real prod test data)

Reproduced end-to-end against the `api-server` app with a locally built agent.

**Before (stock agent):**
```
server.go:682  failed to initialize OpenBao client  error="kubernetes auth: login: unexpected EOF"
api-server exited with code 1
Compose Aborting on container exit
→ 0 tests, no reports
```

**After (patched agent):**
```
authenticated to OpenBao via Kubernetes service account  {role: api-server, lease_duration: 3600}
Starting server {port: 8081}
...
Total test passed: 72
Total test failed: 40
→ reports generated (normal test-run outcome)
```

The app now boots and the full smart-set executes. (The remaining per-test failures are independent response/nondeterminism diffs, not the startup barrier this PR removes.)

Unit test added: `TestReplayTargetHasHTTP1Mock` covers host-header extraction (present / case-insensitive / URL fallback), host disambiguation, port mismatch, and the h2-only case.

## Scope & behavior

- One file of production code (`pkg/agent/proxy/proxy.go`): one new helper + a one-line guard at the ALPN decision. Replay-only (`MODE_TEST`); record path untouched.
- **Single-protocol destinations are unchanged** — pure-HTTP/2 still gets h2, pure-HTTP/1.1 stays as-is.
- **A genuinely mixed same `host:port` is now biased to HTTP/1.1** (the changed case). This trades the previous unconditional h2 (which broke the HTTP/1.1 flow and could abort the whole app) for HTTP/1.1; the residual is that an HTTP/2-recorded request to that same dest, on a dual-protocol client, would now be sent as HTTP/1.1. That is a narrower failure (one request mismatch) than the startup abort it replaces, and h2-only clients are never downgraded.

## Known limitations (inherent to per-connection ALPN)

- **Transparent-proxyless path, no SNI:** matching falls back to port-only. A session with an h2-only host **and** an unrelated h1-only host on the **same port** (e.g. `:443`) could group them, downgrading the h2 host for a dual-protocol client. The CONNECT/sidecar path (where the OpenBao target lives) has SNI, so host disambiguates there.
- **Port-less `Host` header on a non-default port:** if a recorded HTTP/1.1 `Host` omits its port while the dest is non-default (e.g. `:8200`), the h1 check won't recognize the destination and the gate silently no-ops. In practice clients include the port in `Host` for non-default ports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
