### PR TITLE
test(ci): verify keploy against integrations#253 (http2 Content-Length) — DO NOT MERGE

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,7 +24,7 @@ env:
   # when set (so operators can override without editing this file),
   # falling back to `main`. Pin to a specific SHA via the repo var if
   # a feat branch needs to carry a cross-repo change.
-  INTEGRATION_REF: ${{ vars.INTEGRATION_REF || 'main' }}
+  INTEGRATION_REF: 2945fbebf686a3ea92bf8e076f0753bb17a6535e
 
 jobs:
   golangci:

--- a/.github/workflows/prepare_and_run.yml
+++ b/.github/workflows/prepare_and_run.yml
@@ -33,7 +33,7 @@ env:
   # three workflows track the same integrations ref. Pin to a specific
   # SHA via the repo var if a feat branch needs to carry a cross-repo
   # change.
-  INTEGRATION_REF: ${{ vars.INTEGRATION_REF || 'main' }}
+  INTEGRATION_REF: 2945fbebf686a3ea92bf8e076f0753bb17a6535e
 
 jobs:
   # -------------------------------------------------------------------


### PR DESCRIPTION
## Purpose (do not merge)

Verification-only PR to run keploy's HTTP/HTTP2 parser CI against **keploy/integrations#253** (`fix(http2): recompute Content-Length on replay instead of trusting the recorded value`, `pkg/http2/decode.go`).

keploy OSS doesn't import integrations via `go.mod` — CI injects it at build time via `./.github/actions/setup-private-parsers`, pinned by the `INTEGRATION_REF` env (normally `vars.INTEGRATION_REF`, currently `main`).

## What this changes

Hardcodes `INTEGRATION_REF` to `2945fbebf686a3ea92bf8e076f0753bb17a6535e` (the head of integrations#253) in the two PR workflows so every leg checks out that integrations commit:
- `.github/workflows/prepare_and_run.yml` — the e2e/parser test legs (linux/amd64, arm64, darwin, windows)
- `.github/workflows/golangci-lint.yml` — lint/compile against the pinned integrations

The literal overrides the repo-level `vars.INTEGRATION_REF` (= `main`) so this PR is guaranteed to exercise #253, not main.

## How to read it

If `prepare_and_run.yml` (HTTP/HTTP2 e2e) and `golangci-lint` go green, the http2 Content-Length fix doesn't regress keploy's HTTP parsing. Green here → safe to merge integrations#253.

**Do not merge this PR** — revert the `INTEGRATION_REF` pin (back to `${{ vars.INTEGRATION_REF || 'main' }}`) before merge; it's only here to trigger the cross-repo CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)