### PR TITLE
feat(mysql): detect MySQL on any port instead of a fixed port list

### DIFF
--- a/.github/workflows/java_linux.yml
+++ b/.github/workflows/java_linux.yml
@@ -132,6 +132,83 @@ jobs:
           cd samples-java/mysql-dual-conn
           source $GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/java/mysql_dual_conn/java-linux.sh
 
+  # Automatic MySQL port detection: same sample, relocated to :3307 by the
+  # script so nothing in the default port list or the config covers it.
+  # The cross-version cells self-skip via a capability probe — the feature
+  # needs detection at record time AND mock-derived recall at replay time,
+  # so a mixed-version pair cannot exercise it. See the script header.
+  mysql_auto_port:
+    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - job: record_latest_replay_build
+            record_src: latest
+            replay_src: build-no-race
+          - job: record_build_replay_latest
+            record_src: build-no-race
+            replay_src: latest
+          - job: record_build_replay_build
+            record_src: build-no-race
+            replay_src: build-no-race
+            # Both binaries come from this commit, so the capability
+            # probe must succeed. Setting this turns a probe failure
+            # into a hard error instead of a silent skip, so this cell
+            # can never go green without asserting the behaviour.
+            require_auto_detect: "true"
+    name: mysql-auto-port (${{ matrix.config.job }})
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - id: record
+        uses: ./.github/actions/download-binary
+        with:
+          src: ${{ matrix.config.record_src }}
+
+      - id: replay
+        uses: ./.github/actions/download-binary
+        with:
+          src: ${{ matrix.config.replay_src }}
+
+      - name: Checkout samples-java repository
+        uses: actions/checkout@v4
+        with:
+          repository: keploy/samples-java
+          path: samples-java
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+          cache-dependency-path: samples-java/mysql-dual-conn/pom.xml
+
+      - name: Run mysql-dual-conn app on a non-default MySQL port
+        env:
+          RECORD_BIN: ${{ steps.record.outputs.path }}
+          REPLAY_BIN: ${{ steps.replay.outputs.path }}
+          REQUIRE_MYSQL_AUTO_DETECT: ${{ matrix.config.require_auto_detect }}
+        run: |
+          cd samples-java/mysql-dual-conn
+          source $GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/java/mysql_auto_port/java-linux.sh
+
+      - name: Upload mysql-auto-port recordings and logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mysql-auto-port-${{ matrix.config.job }}-recordings
+          path: |
+            samples-java/mysql-dual-conn/keploy/
+            samples-java/mysql-dual-conn/test_logs.txt
+            samples-java/mysql-dual-conn/autoPort_record.txt
+            samples-java/mysql-dual-conn/mvn_build.log
+          if-no-files-found: warn
+          retention-days: 7
+
   tidb_stmt_cache:
     if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest

--- a/.github/workflows/test_workflow_scripts/java/mysql_auto_port/java-linux.sh
+++ b/.github/workflows/test_workflow_scripts/java/mysql_auto_port/java-linux.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+
+# E2E test for automatic MySQL port detection.
+#
+# MySQL is a server-speaks-first protocol, so keploy's generic dispatch
+# path — which blocks reading the client before dialing upstream —
+# deadlocks on it. The historical workaround was a port allowlist
+# ([3306, 4000] plus the `mysqlPorts` config key); anything else hung
+# the handshake and the app died with
+#
+#   Lost connection to server at 'handshake: reading initial
+#   communication packet'
+#
+# This test moves the sample's MySQL onto 3307 — a port in NEITHER the
+# built-in defaults NOR any config — and asserts the full round trip
+# still works:
+#
+#   record: the server's HandshakeV10 is read off the wire and matched,
+#           so the traffic lands as `kind: MySQL` mocks (not Generic).
+#   replay: MySQL is shut down entirely, so the port can only come from
+#           the recorded mocks' destAddr metadata.
+#
+# The guard that makes this meaningful is assert_no_mysql_ports_config:
+# if anyone ever adds 3307 to the defaults or to the sample's config,
+# this test silently stops testing detection — so it fails loudly
+# instead.
+#
+# Compat matrix: this behaviour needs BOTH binaries to support it. A
+# record binary without detection hangs the handshake and records
+# nothing; a replay binary without mock-derived port recall hangs the
+# same way with the mocks already in hand. So the cross-version cells
+# (record_latest_replay_build / record_build_replay_latest) skip via the
+# capability probe below, exactly like the --storage-format json pass
+# does, and only record_build_replay_build asserts the behaviour.
+
+set -Eeuo pipefail
+
+MYSQL_PORT=3307
+
+section() { echo "::group::$*"; }
+endsec()  { echo "::endgroup::"; }
+
+die() {
+  rc=$?
+  echo "::error::Pipeline failed (exit=$rc). Dumping context…"
+  echo "== docker ps =="; docker ps || true
+  echo "== mysql logs (last 200 lines) =="; docker compose logs --tail 200 mysql || true
+  echo "== keploy tree (depth 4) =="; find ./keploy -maxdepth 4 -type f -print 2>/dev/null | sort | head -n 20 || true
+  echo "== *.txt logs (last 100 lines) =="; for f in ./*.txt; do [[ -f "$f" ]] && { echo "--- $f ---"; tail -n 100 "$f"; }; done
+  exit "$rc"
+}
+trap die ERR
+
+# mysql_auto_detect_supported: true when this binary ships automatic
+# MySQL port detection. Probed via the generated default config, which
+# only carries the disableMysqlAutoDetect key on binaries that have the
+# feature. Generated into a throwaway dir so the sample's own keploy.yml
+# is never touched.
+mysql_auto_detect_supported() {
+  local bin="$1"
+  local probe_dir
+  probe_dir=$(mktemp -d)
+  ( cd "$probe_dir" && "$bin" config --generate >/dev/null 2>&1 ) || { rm -rf "$probe_dir"; return 1; }
+  local rc=1
+  grep -q "disableMysqlAutoDetect" "$probe_dir/keploy.yml" 2>/dev/null && rc=0
+  rm -rf "$probe_dir"
+  return "$rc"
+}
+
+# Move the sample off 3306 without touching the samples repo: rewrite
+# the compose publish port and both JDBC URLs in place.
+relocate_mysql_port() {
+  section "Relocate MySQL to :${MYSQL_PORT} (off the default list)"
+  sed -i "s|\"3306:3306\"|\"${MYSQL_PORT}:3306\"|" docker-compose.yml
+  sed -i "s|jdbc:mysql://localhost:3306/|jdbc:mysql://localhost:${MYSQL_PORT}/|g" \
+    src/main/resources/application.properties
+
+  grep -q "\"${MYSQL_PORT}:3306\"" docker-compose.yml \
+    || { echo "::error::compose port rewrite failed"; exit 1; }
+  grep -q "localhost:${MYSQL_PORT}" src/main/resources/application.properties \
+    || { echo "::error::JDBC URL rewrite failed"; exit 1; }
+
+  echo "compose:"; grep -n "3306\|${MYSQL_PORT}" docker-compose.yml
+  echo "jdbc:"; grep -n "jdbc-url" src/main/resources/application.properties
+  endsec
+}
+
+# The whole point of this test is that NOTHING tells keploy about
+# ${MYSQL_PORT}. If a config or the built-in default list ever starts
+# covering it, the test would keep passing while testing nothing — so
+# assert both here.
+assert_no_mysql_ports_config() {
+  section "Assert ${MYSQL_PORT} is not pre-configured anywhere"
+
+  # 1. The built-in default list in the source. Without this check,
+  #    adding ${MYSQL_PORT} to defaultMysqlPorts would make this test
+  #    green while it silently stopped exercising detection.
+  local defaults_src="$GITHUB_WORKSPACE/pkg/agent/proxy/proxy.go"
+  if [[ -f "$defaults_src" ]]; then
+    local defaults_line
+    defaults_line=$(grep -E "^var defaultMysqlPorts" "$defaults_src" || true)
+    echo "built-in defaults: ${defaults_line:-<not found>}"
+    if [[ -z "$defaults_line" ]]; then
+      echo "::error::could not find defaultMysqlPorts in $defaults_src — the guard below cannot run; update this script if the variable was renamed"
+      exit 1
+    fi
+    if grep -qE "(^|[^0-9])${MYSQL_PORT}([^0-9]|$)" <<<"$defaults_line"; then
+      echo "::error::${MYSQL_PORT} is now a built-in default MySQL port — this test no longer exercises auto-detection. Pick a different port."
+      exit 1
+    fi
+  else
+    echo "::error::$defaults_src not found; cannot verify the built-in default port list"
+    exit 1
+  fi
+
+  # 2. The generated config.
+  if [[ -f keploy.yml ]]; then
+    if grep -E "^\s*mysqlPorts:" keploy.yml | grep -q "${MYSQL_PORT}"; then
+      echo "::error::keploy.yml lists ${MYSQL_PORT} in mysqlPorts — this test no longer exercises auto-detection"
+      exit 1
+    fi
+    if grep -qE "^\s*disableMysqlAutoDetect:\s*true" keploy.yml; then
+      echo "::error::auto-detection is disabled in keploy.yml — this test cannot pass by design"
+      exit 1
+    fi
+    echo "keploy.yml mysql settings:"; grep -nE "mysqlPorts|disableMysqlAutoDetect" keploy.yml || echo "(none — using defaults)"
+  else
+    echo "no keploy.yml yet (will be generated with defaults)"
+  fi
+  endsec
+}
+
+wait_for_mysql() {
+  section "Wait for MySQL readiness on :${MYSQL_PORT}"
+  for _ in {1..120}; do
+    if docker compose exec -T mysql mysql -uroot -prootpass -e "SELECT 1" >/dev/null 2>&1; then
+      echo "MySQL is ready."
+      endsec; return 0
+    fi
+    sleep 1
+  done
+  echo "::error::MySQL did not become ready in time"
+  endsec; return 1
+}
+
+# A hung MySQL handshake shows up exactly here: the app never finishes
+# booting because its connection pool is stuck waiting for a greeting.
+# So this timing out IS the regression signal.
+wait_for_app() {
+  section "Wait for app HTTP port"
+  for _ in {1..60}; do
+    if curl -sS http://localhost:8080/api/oms -o /dev/null 2>/dev/null; then
+      echo "App is responding."
+      endsec; return 0
+    fi
+    sleep 1
+  done
+  echo "::error::App did not start in time — a stuck MySQL handshake on :${MYSQL_PORT} is the likely cause (auto-detection regression)"
+  endsec; return 1
+}
+
+run_maven_build() {
+  : > mvn_build.log
+  for attempt in 1 2 3; do
+    if {
+      echo "===== Maven build attempt ${attempt}/3 ====="
+      mvn -B -U clean package -Dmaven.test.skip=true -q
+    } 2>&1 | tee -a mvn_build.log; then
+      return 0
+    fi
+    echo "Maven build failed on attempt ${attempt}/3; retrying."
+    [[ "$attempt" -lt 3 ]] && sleep $((attempt * 10))
+  done
+  echo "::error::Maven build failed after 3 attempts. See mvn_build.log."
+  return 1
+}
+
+send_request() {
+  local kp_pid="$1"
+  wait_for_app
+
+  echo "=== Query both databases ==="
+  curl -sS http://localhost:8080/api/query-both || true
+  echo "=== Query OMS only ==="
+  curl -sS http://localhost:8080/api/oms || true
+  echo "=== Query Camunda only ==="
+  curl -sS http://localhost:8080/api/camunda || true
+
+  sleep 10
+  echo "Sending SIGINT to keploy (pid $kp_pid) for graceful shutdown"
+  sudo kill -INT "$kp_pid" 2>/dev/null || true
+}
+
+# --- Main ---
+
+source "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/test-iid.sh"
+
+if ! mysql_auto_detect_supported "${RECORD_BIN:-keploy}" \
+  || ! mysql_auto_detect_supported "${REPLAY_BIN:-keploy}"; then
+  # REQUIRE_MYSQL_AUTO_DETECT is set by the matrix cell where BOTH
+  # binaries are built from this commit. There, "unsupported" can only
+  # mean the feature regressed or the probe broke — never a version
+  # skew — so skipping would turn real coverage into a silent green.
+  # The cross-version cells leave it unset and skip legitimately.
+  if [[ "${REQUIRE_MYSQL_AUTO_DETECT:-}" == "true" ]]; then
+    echo "::error::both binaries are built from this commit, yet the capability probe"
+    echo "::error::reports no automatic MySQL port detection. Either the feature"
+    echo "::error::regressed, or 'keploy config --generate' no longer emits"
+    echo "::error::disableMysqlAutoDetect. Not skipping — this cell must assert."
+    exit 1
+  fi
+  echo "Skipping: automatic MySQL port detection requires BOTH the record and"
+  echo "replay binaries to support it. Detection happens at record time and the"
+  echo "port is recalled from mocks at replay time, so a mixed-version cell"
+  echo "cannot exercise it. This is expected for the cross-version matrix cells."
+  exit 0
+fi
+
+sudo rm -rf keploy/ keploy.yml
+
+relocate_mysql_port
+
+section "Start MySQL"
+docker compose up -d
+wait_for_mysql
+endsec
+
+section "Build"
+source "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/update-java.sh"
+run_maven_build
+endsec
+
+JAR_NAME=$(ls target/mysql-dual-conn-*.jar 2>/dev/null | head -n1)
+if [[ -z "$JAR_NAME" ]]; then
+  echo "::error::JAR not found after build"
+  exit 1
+fi
+
+assert_no_mysql_ports_config
+
+section "Record (MySQL on :${MYSQL_PORT}, nothing configured)"
+"$RECORD_BIN" record -c "java -jar $JAR_NAME" > autoPort_record.txt 2>&1 &
+KEPLOY_PID=$!
+send_request "$KEPLOY_PID"
+set +e
+wait "$KEPLOY_PID"
+RECORD_RC=$?
+set -e
+echo "Record exit code: $RECORD_RC"
+# No data-race grep here: every cell of this job uses the `build-no-race`
+# artifact, so the race detector is not compiled in and the check could
+# never fire. Race coverage for this code path lives in the Go unit
+# tests (pkg/agent/proxy/mysql_detect_test.go, run under -race).
+endsec
+
+# The config is generated on the first record run — re-assert now that
+# it exists, so a bad default can't sneak the test past.
+assert_no_mysql_ports_config
+
+section "Assert MySQL was auto-detected during record"
+if ! grep -q "detected MySQL wire protocol on a non-default port" autoPort_record.txt; then
+  echo "::error::keploy did not report detecting MySQL on :${MYSQL_PORT}"
+  tail -n 120 autoPort_record.txt
+  exit 1
+fi
+grep "detected MySQL wire protocol on a non-default port" autoPort_record.txt
+
+MOCKS_FILE=$(ls -1 ./keploy/test-set-*/mocks.yaml 2>/dev/null | head -n1 || true)
+if [[ -z "$MOCKS_FILE" ]]; then
+  echo "::error::No mocks.yaml recorded"
+  exit 1
+fi
+
+# Detection is only real if the traffic was parsed AS MySQL. Landing in
+# the Generic parser would still produce mocks, so assert the kind.
+MYSQL_MOCKS=$(grep -c "^kind: MySQL" "$MOCKS_FILE" || true)
+if [[ "${MYSQL_MOCKS:-0}" -lt 1 ]]; then
+  echo "::error::No 'kind: MySQL' mocks in $MOCKS_FILE — traffic was not routed to the MySQL parser"
+  grep -o "^kind: .*" "$MOCKS_FILE" | sort | uniq -c || true
+  exit 1
+fi
+echo "Recorded $MYSQL_MOCKS MySQL mocks"
+
+# And the destAddr must carry the non-default port — that metadata is
+# what replay reads back to recover the port.
+if ! grep -q "destAddr: .*:${MYSQL_PORT}" "$MOCKS_FILE"; then
+  echo "::error::No mock records destAddr on :${MYSQL_PORT}; replay would have nothing to recall"
+  grep -o "destAddr: .*" "$MOCKS_FILE" | sort -u || true
+  exit 1
+fi
+grep -o "destAddr: .*" "$MOCKS_FILE" | sort -u
+endsec
+
+section "Shutdown MySQL before replay"
+docker compose down || true
+echo "MySQL is gone — replay must serve every query from mocks, and can only"
+echo "know :${MYSQL_PORT} is MySQL by recalling it from those mocks."
+endsec
+
+section "Replay"
+set +e
+"$REPLAY_BIN" test -c "java -jar $JAR_NAME" \
+  --delay 20 --api-timeout 60 \
+  2>&1 | tee test_logs.txt
+REPLAY_RC=$?
+set -e
+echo "Replay exit code: $REPLAY_RC"
+endsec
+
+section "Assert MySQL port was recalled from mocks during replay"
+if ! grep -q "recovered MySQL ports from recorded mocks" test_logs.txt; then
+  echo "::error::replay did not recover the MySQL port from mocks"
+  tail -n 120 test_logs.txt
+  exit 1
+fi
+grep "recovered MySQL ports from recorded mocks" test_logs.txt
+endsec
+
+section "Check reports"
+RUN_DIR=$(ls -1dt ./keploy/reports/test-run-* 2>/dev/null | head -n1 || true)
+if [[ -z "${RUN_DIR:-}" ]]; then
+  echo "::error::No test-run directory found under ./keploy/reports"
+  [[ $REPLAY_RC -ne 0 ]] && exit "$REPLAY_RC" || exit 1
+fi
+echo "Using reports from: $RUN_DIR"
+
+all_passed=true
+found_any=false
+for rpt in "$RUN_DIR"/test-set-*-report.yaml; do
+  [[ -f "$rpt" ]] || continue
+  found_any=true
+  status=$(awk '/^status:/{print $2; exit}' "$rpt")
+  echo "Test status for $(basename "$rpt"): ${status:-<missing>}"
+  [[ "$status" == "PASSED" ]] || all_passed=false
+done
+endsec
+
+if [[ "$found_any" == "false" ]]; then
+  echo "::error::No test report files found in $RUN_DIR"
+  exit 1
+fi
+if [[ "$all_passed" != "true" ]]; then
+  echo "::error::Some tests failed during replay"
+  exit 1
+fi
+if [[ $REPLAY_RC -ne 0 ]]; then
+  echo "Replay exited with code $REPLAY_RC but all tests passed. Ignoring exit code."
+fi
+
+echo "MySQL auto-port-detection e2e passed: recorded and replayed on :${MYSQL_PORT} with no port configuration."
+exit 0

--- a/config/config.go
+++ b/config/config.go
@@ -10,48 +10,60 @@ import (
 )
 
 type Config struct {
-	Path                  string              `json:"path" yaml:"path" mapstructure:"path"`
-	StorageFormat         string              `json:"storageFormat" yaml:"storageFormat" mapstructure:"storageFormat"` // serialization format for testcases/mocks/reports: "yaml" (default) or "json"
-	AppName               string              `json:"appName" yaml:"appName" mapstructure:"appName"`
-	AppID                 uint64              `json:"appId" yaml:"appId" mapstructure:"appId"` // deprecated field
-	Command               string              `json:"command" yaml:"command" mapstructure:"command"`
-	Templatize            Templatize          `json:"templatize" yaml:"templatize" mapstructure:"templatize"`
-	Port                  uint32              `json:"port" yaml:"port" mapstructure:"port"`
-	E2E                   bool                `json:"e2e" yaml:"e2e" mapstructure:"e2e"`
-	DNSPort               uint32              `json:"dnsPort" yaml:"dnsPort" mapstructure:"dnsPort"`
-	ProxyPort             uint32              `json:"proxyPort" yaml:"proxyPort" mapstructure:"proxyPort"`
-	IncomingProxyPort     uint16              `json:"incomingProxyPort" yaml:"incomingProxyPort" mapstructure:"incomingProxyPort"`
-	Debug                 bool                `json:"debug" yaml:"debug" mapstructure:"debug"`
-	DisableTele           bool                `json:"disableTele" yaml:"disableTele" mapstructure:"disableTele"`
-	DisableANSI           bool                `json:"disableANSI" yaml:"disableANSI" mapstructure:"disableANSI"`
-	JSONOutput            bool                `json:"jsonOutput" yaml:"jsonOutput" mapstructure:"jsonOutput"`
-	InDocker              bool                `json:"inDocker" yaml:"-" mapstructure:"inDocker"`
-	ContainerName         string              `json:"containerName" yaml:"containerName" mapstructure:"containerName"`
-	NetworkName           string              `json:"networkName" yaml:"networkName" mapstructure:"networkName"`
-	BuildDelay            uint64              `json:"buildDelay" yaml:"buildDelay" mapstructure:"buildDelay"`
-	Test                  Test                `json:"test" yaml:"test" mapstructure:"test"`
-	Record                Record              `json:"record" yaml:"record" mapstructure:"record"`
-	Report                Report              `json:"report" yaml:"report" mapstructure:"report"`
-	Normalize             Normalize           `json:"normalize" yaml:"-" mapstructure:"normalize"`
-	DisableMapping        bool                `json:"disableMapping" yaml:"disableMapping" mapstructure:"disableMapping"`
-	RetryPassing          bool                `json:"retryPassing" yaml:"retryPassing" mapstructure:"retryPassing"`
-	ConfigPath            string              `json:"configPath" yaml:"configPath" mapstructure:"configPath"`
-	BypassRules           []models.BypassRule `json:"bypassRules" yaml:"bypassRules" mapstructure:"bypassRules"`
-	MysqlPorts            []uint32            `json:"mysqlPorts" yaml:"mysqlPorts" mapstructure:"mysqlPorts"`
-	EnableTesting         bool                `json:"enableTesting" yaml:"-" mapstructure:"enableTesting"`
-	GenerateGithubActions bool                `json:"generateGithubActions" yaml:"generateGithubActions" mapstructure:"generateGithubActions"`
-	KeployContainer       string              `json:"keployContainer" yaml:"keployContainer" mapstructure:"keployContainer"`
-	KeployNetwork         string              `json:"keployNetwork" yaml:"keployNetwork" mapstructure:"keployNetwork"`
-	CommandType           string              `json:"cmdType" yaml:"cmdType" mapstructure:"cmdType"`
-	Contract              Contract            `json:"contract" yaml:"contract" mapstructure:"contract"`
-	Agent                 Agent               `json:"agent" yaml:"agent" mapstructure:"agent"`
-	Async                 Async               `json:"async" yaml:"async" mapstructure:"async"`
-	InCi                  bool                `json:"inCi" yaml:"inCi" mapstructure:"inCi"`
-	InstallationID        string              `json:"-" yaml:"-" mapstructure:"-"`
-	ServerPort            uint32              `json:"serverPort" yaml:"serverPort" mapstructure:"serverPort"`
-	Version               string              `json:"-" yaml:"-" mapstructure:"-"`
-	APIServerURL          string              `json:"-" yaml:"-" mapstructure:"-"`
-	GitHubClientID        string              `json:"-" yaml:"-" mapstructure:"-"`
+	Path              string              `json:"path" yaml:"path" mapstructure:"path"`
+	StorageFormat     string              `json:"storageFormat" yaml:"storageFormat" mapstructure:"storageFormat"` // serialization format for testcases/mocks/reports: "yaml" (default) or "json"
+	AppName           string              `json:"appName" yaml:"appName" mapstructure:"appName"`
+	AppID             uint64              `json:"appId" yaml:"appId" mapstructure:"appId"` // deprecated field
+	Command           string              `json:"command" yaml:"command" mapstructure:"command"`
+	Templatize        Templatize          `json:"templatize" yaml:"templatize" mapstructure:"templatize"`
+	Port              uint32              `json:"port" yaml:"port" mapstructure:"port"`
+	E2E               bool                `json:"e2e" yaml:"e2e" mapstructure:"e2e"`
+	DNSPort           uint32              `json:"dnsPort" yaml:"dnsPort" mapstructure:"dnsPort"`
+	ProxyPort         uint32              `json:"proxyPort" yaml:"proxyPort" mapstructure:"proxyPort"`
+	IncomingProxyPort uint16              `json:"incomingProxyPort" yaml:"incomingProxyPort" mapstructure:"incomingProxyPort"`
+	Debug             bool                `json:"debug" yaml:"debug" mapstructure:"debug"`
+	DisableTele       bool                `json:"disableTele" yaml:"disableTele" mapstructure:"disableTele"`
+	DisableANSI       bool                `json:"disableANSI" yaml:"disableANSI" mapstructure:"disableANSI"`
+	JSONOutput        bool                `json:"jsonOutput" yaml:"jsonOutput" mapstructure:"jsonOutput"`
+	InDocker          bool                `json:"inDocker" yaml:"-" mapstructure:"inDocker"`
+	ContainerName     string              `json:"containerName" yaml:"containerName" mapstructure:"containerName"`
+	NetworkName       string              `json:"networkName" yaml:"networkName" mapstructure:"networkName"`
+	BuildDelay        uint64              `json:"buildDelay" yaml:"buildDelay" mapstructure:"buildDelay"`
+	Test              Test                `json:"test" yaml:"test" mapstructure:"test"`
+	Record            Record              `json:"record" yaml:"record" mapstructure:"record"`
+	Report            Report              `json:"report" yaml:"report" mapstructure:"report"`
+	Normalize         Normalize           `json:"normalize" yaml:"-" mapstructure:"normalize"`
+	DisableMapping    bool                `json:"disableMapping" yaml:"disableMapping" mapstructure:"disableMapping"`
+	RetryPassing      bool                `json:"retryPassing" yaml:"retryPassing" mapstructure:"retryPassing"`
+	ConfigPath        string              `json:"configPath" yaml:"configPath" mapstructure:"configPath"`
+	BypassRules       []models.BypassRule `json:"bypassRules" yaml:"bypassRules" mapstructure:"bypassRules"`
+	// MysqlPorts pins extra destination ports to the MySQL parser,
+	// skipping auto-detection for them. Rarely needed now that ports are
+	// detected automatically (see DisableMysqlAutoDetect); keep it for
+	// deployments that want the ~250ms first-connection probe skipped,
+	// or that disable detection entirely. Built-in defaults: 3306, 4000.
+	MysqlPorts []uint32 `json:"mysqlPorts" yaml:"mysqlPorts" mapstructure:"mysqlPorts"`
+	// DisableMysqlAutoDetect turns off automatic MySQL port detection.
+	// With detection on (the default), keploy identifies MySQL on any
+	// port by reading the server's handshake during record and by
+	// recalling the port from recorded mocks during replay. Turn it off
+	// to restore the strict port-list behaviour — then MySQL on a port
+	// outside MysqlPorts will hang its handshake.
+	DisableMysqlAutoDetect bool     `json:"disableMysqlAutoDetect" yaml:"disableMysqlAutoDetect" mapstructure:"disableMysqlAutoDetect"`
+	EnableTesting          bool     `json:"enableTesting" yaml:"-" mapstructure:"enableTesting"`
+	GenerateGithubActions  bool     `json:"generateGithubActions" yaml:"generateGithubActions" mapstructure:"generateGithubActions"`
+	KeployContainer        string   `json:"keployContainer" yaml:"keployContainer" mapstructure:"keployContainer"`
+	KeployNetwork          string   `json:"keployNetwork" yaml:"keployNetwork" mapstructure:"keployNetwork"`
+	CommandType            string   `json:"cmdType" yaml:"cmdType" mapstructure:"cmdType"`
+	Contract               Contract `json:"contract" yaml:"contract" mapstructure:"contract"`
+	Agent                  Agent    `json:"agent" yaml:"agent" mapstructure:"agent"`
+	Async                  Async    `json:"async" yaml:"async" mapstructure:"async"`
+	InCi                   bool     `json:"inCi" yaml:"inCi" mapstructure:"inCi"`
+	InstallationID         string   `json:"-" yaml:"-" mapstructure:"-"`
+	ServerPort             uint32   `json:"serverPort" yaml:"serverPort" mapstructure:"serverPort"`
+	Version                string   `json:"-" yaml:"-" mapstructure:"-"`
+	APIServerURL           string   `json:"-" yaml:"-" mapstructure:"-"`
+	GitHubClientID         string   `json:"-" yaml:"-" mapstructure:"-"`
 	// InMemoryCompose holds docker-compose YAML content in memory to avoid writing
 	// sensitive environment variables (secrets, tokens) to disk. When set, the
 	// compose command uses "-f -" and pipes this content via stdin.

--- a/config/default.go
+++ b/config/default.go
@@ -110,6 +110,19 @@ async:
     lanes: []
 configPath: ""
 bypassRules: []
+# MySQL is detected automatically on any port: at record time keploy
+# reads the server's handshake to identify it, and at replay time it
+# recalls the port from the recorded mocks. You normally do not need to
+# configure anything here.
+#
+# mysqlPorts pins extra ports to the MySQL parser, skipping detection
+# for them (the built-in list is 3306 and 4000). Useful only to avoid
+# the ~250ms probe on the first connection to a port, or alongside
+# disableMysqlAutoDetect.
+mysqlPorts: []
+# Set to true to turn detection off and go back to matching mysqlPorts
+# strictly. MySQL on any other port will then hang its handshake.
+disableMysqlAutoDetect: false
 disableMapping: false
 contract:
   driven: "consumer"

--- a/pkg/agent/proxy/mysql_detect.go
+++ b/pkg/agent/proxy/mysql_detect.go
@@ -1,0 +1,620 @@
+// Package proxy — automatic MySQL wire-protocol detection.
+//
+// # Why this exists
+//
+// MySQL is a *server-speaks-first* protocol: the server sends its Initial
+// Handshake Packet (HandshakeV10) the moment the TCP connection is
+// accepted, and the client stays silent until it arrives. The proxy's
+// generic dispatch path does the opposite — it blocks reading the client
+// (util.ReadInitialBuf, see handleConnection) *before* dialing upstream,
+// so it can sniff the protocol and pick a parser.
+//
+// Those two facts deadlock: the client waits for a greeting that the
+// proxy has not fetched, and the proxy waits for bytes the client will
+// never send. The app eventually fails with the MySQL client's classic
+//
+//	ERROR 2013 (HY000): Lost connection to server at
+//	'handshake: reading initial communication packet'
+//
+// The historical fix was a hardcoded port list — [3306, 4000] plus an
+// opt-in `mysqlPorts` config key — that short-circuits dispatch and
+// dials upstream eagerly. That works only if the user's MySQL happens
+// to sit on a port keploy already knows, which excludes ProxySQL
+// (6033), MaxScale (4006), Vitess/PlanetScale (15306), StarRocks and
+// Doris (9030), OceanBase (2881), and the very common 3307/3308
+// multi-instance and Cloud SQL Auth Proxy layouts.
+//
+// # What this file does instead
+//
+// It replaces "is this a known MySQL port?" with "does this connection
+// actually behave like MySQL?", answered differently per mode because
+// the two modes have fundamentally different information available.
+//
+//	RECORD — a real upstream exists, so ask it. If the client stays
+//	silent past a short window the connection is server-speaks-first;
+//	dial upstream, read whatever it greets with, and run the existing
+//	MySQL.MatchType content matcher over those bytes. A positive match
+//	routes to the MySQL parser and *learns* the port, so every later
+//	connection to it takes the zero-cost fast path.
+//
+//	REPLAY — there is no upstream to greet anyone; mocks are served
+//	from disk. Content detection is impossible by construction, so the
+//	answer has to come from what record already observed. Every MySQL
+//	mock carries Metadata["destAddr"] ("host:port"), so the port set is
+//	derived from the loaded mocks (see DeriveMysqlPortsFromMocks).
+//
+// Together: auto-detect at record, auto-recall at replay. `mysqlPorts`
+// remains as an escape hatch but is no longer required for correctness.
+//
+// # Cost
+//
+// Only connections whose client is silent past clientSilenceWindow pay
+// anything at all. Client-speaks-first protocols (HTTP, gRPC, Redis,
+// Postgres, Mongo, Kafka) send bytes immediately and return from
+// probeMysql on the first read, so the hot path is unchanged. Ports on
+// the configured/default/learned list skip the probe entirely.
+package proxy
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations"
+	"go.keploy.io/server/v3/pkg/agent/proxy/util"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// Probe tuning. All three are overridable by env var so a slow or
+// heavily contended environment can be adjusted without a rebuild;
+// the defaults are what ships.
+const (
+	// defaultClientSilenceWindow is how long the client gets to send
+	// its first byte before we conclude the connection is
+	// server-speaks-first. MySQL clients send *nothing* here, so any
+	// traffic at all is a definitive negative. Kept short because it
+	// is pure added latency on the (rare) silent-client path, and
+	// because a detected port is learned — a connection pool pays it
+	// at most once per port.
+	defaultClientSilenceWindow = 250 * time.Millisecond
+
+	// defaultServerGreetingWindow bounds the wait for the upstream's
+	// first bytes once we have decided the client is silent. Sending
+	// the handshake is the first thing mysqld does on accept, so this
+	// window only has to absorb scheduling jitter and a loaded
+	// container — 2s is generous by a wide margin. It matters that it
+	// IS generous: a port that stays silent through it is cached as
+	// non-MySQL for the session (see mysqlPortRegistry), so an
+	// under-sized window would misclassify a very slow server.
+	defaultServerGreetingWindow = 2 * time.Second
+
+	// defaultMockDeriveWait bounds how long a replay-mode connection
+	// waits for the mock set to be loaded before giving up on port
+	// derivation. This matters only for the docker-compose replay
+	// path, where the app container is started before StoreMocks
+	// lands; every other path stores mocks before the app runs. A
+	// bounded wait keeps that race deterministic instead of guessing.
+	defaultMockDeriveWait = 20 * time.Second
+)
+
+func envDuration(key string, def time.Duration) time.Duration {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil || d <= 0 {
+		return def
+	}
+	return d
+}
+
+func clientSilenceWindow() time.Duration {
+	return envDuration("KEPLOY_MYSQL_CLIENT_SILENCE_WINDOW", defaultClientSilenceWindow)
+}
+
+func serverGreetingWindow() time.Duration {
+	return envDuration("KEPLOY_MYSQL_SERVER_GREETING_WINDOW", defaultServerGreetingWindow)
+}
+
+func mockDeriveWait() time.Duration {
+	return envDuration("KEPLOY_MYSQL_MOCK_DERIVE_WAIT", defaultMockDeriveWait)
+}
+
+// mysqlPortRegistry caches what the proxy has learned about each
+// destination port, so a port is probed at most once per session.
+//
+// Positives (`ports`) come from either source:
+//
+//   - record: a port whose upstream answered with a HandshakeV10 that
+//     MySQL.MatchType accepted.
+//   - replay: a port parsed out of a loaded MySQL mock's destAddr.
+//
+// Negatives (`notMysql`) exist because the probe is not free — a
+// silent client costs a wait, and reaching the upstream costs a dial.
+// Without a negative cache every connection to a non-MySQL port pays
+// that again, which for a pool of pre-opened sockets is a permanent
+// per-connection tax rather than a one-time discovery cost. A port is
+// cached negative once the probe reaches a conclusion about it:
+//
+//   - the client spoke first (a MySQL connection never does), or
+//   - the upstream greeted with something that is not a HandshakeV10, or
+//   - the upstream stayed silent for the whole greeting window, which
+//     mysqld never does (see defaultServerGreetingWindow).
+//
+// Negatives are advisory only: the configured mysqlPorts list and the
+// built-in defaults are consulted first, so an explicit config always
+// wins over a cached negative.
+//
+// Matching is by port rather than host:port on purpose. The recorded
+// destAddr's *host* is not stable across runs — container IPs change
+// between record and replay — while the port comes from the app's DSN
+// and does not. This also keeps the semantics identical to the
+// existing `mysqlPorts` config key, which has always been port-only.
+type mysqlPortRegistry struct {
+	mu       sync.RWMutex
+	ports    map[uint32]struct{}
+	notMysql map[uint32]struct{}
+	derived  bool
+	// derivedCh is closed the first time DeriveFromMocks runs, so a
+	// replay connection that arrives before mocks are stored can block
+	// on it instead of guessing. Never closed twice (guarded by mu +
+	// the derived flag).
+	derivedCh chan struct{}
+}
+
+func newMysqlPortRegistry() *mysqlPortRegistry {
+	return &mysqlPortRegistry{
+		ports:     make(map[uint32]struct{}),
+		notMysql:  make(map[uint32]struct{}),
+		derivedCh: make(chan struct{}),
+	}
+}
+
+// Has reports whether port has been learned or derived.
+func (r *mysqlPortRegistry) Has(port uint32) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, ok := r.ports[port]
+	return ok
+}
+
+// Learn records a port as MySQL-speaking. Returns true if this was a
+// new observation, so the caller can log the discovery exactly once.
+// Clears any cached negative: a positive is strictly better evidence.
+func (r *mysqlPortRegistry) Learn(port uint32) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.notMysql, port)
+	if _, ok := r.ports[port]; ok {
+		return false
+	}
+	r.ports[port] = struct{}{}
+	return true
+}
+
+// IsKnownNotMysql reports whether the probe has already concluded this
+// port does not speak MySQL, so the probe can be skipped entirely.
+func (r *mysqlPortRegistry) IsKnownNotMysql(port uint32) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, ok := r.notMysql[port]
+	return ok
+}
+
+// LearnNotMysql caches a negative verdict. Returns true if this was a
+// new observation, so the caller can log it exactly once. A port that
+// is already a known positive is never demoted — DeriveFromMocks and a
+// real handshake are both stronger evidence than a probe timeout.
+func (r *mysqlPortRegistry) LearnNotMysql(port uint32) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.ports[port]; ok {
+		return false
+	}
+	if _, ok := r.notMysql[port]; ok {
+		return false
+	}
+	r.notMysql[port] = struct{}{}
+	return true
+}
+
+// Ports returns a snapshot, for logging.
+func (r *mysqlPortRegistry) Ports() []uint32 {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]uint32, 0, len(r.ports))
+	for p := range r.ports {
+		out = append(out, p)
+	}
+	return out
+}
+
+// DeriveFromMocks adds every port referenced by a MySQL mock's
+// destAddr metadata and marks derivation complete, releasing any
+// replay connections parked in WaitDerived. It is safe to call
+// repeatedly (once per test-set); later calls union additional ports
+// and are no-ops for the completion signal.
+func (r *mysqlPortRegistry) DeriveFromMocks(mockSets ...[]*models.Mock) []uint32 {
+	var added []uint32
+
+	r.mu.Lock()
+	for _, mocks := range mockSets {
+		for _, m := range mocks {
+			if m == nil || m.Kind != models.MySQL {
+				continue
+			}
+			port, ok := portFromAddr(m.Spec.Metadata["destAddr"])
+			if !ok {
+				continue
+			}
+			if _, exists := r.ports[port]; !exists {
+				r.ports[port] = struct{}{}
+				added = append(added, port)
+			}
+		}
+	}
+	if !r.derived {
+		r.derived = true
+		close(r.derivedCh)
+	}
+	r.mu.Unlock()
+
+	return added
+}
+
+// WaitDerived blocks until DeriveFromMocks has run, ctx is cancelled,
+// or timeout elapses. Returns true only if derivation actually
+// completed. Callers reach this only on a silent-client replay
+// connection, so the wait never touches normal traffic.
+func (r *mysqlPortRegistry) WaitDerived(ctx context.Context, timeout time.Duration) bool {
+	r.mu.RLock()
+	done := r.derived
+	ch := r.derivedCh
+	r.mu.RUnlock()
+	if done {
+		return true
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-ch:
+		return true
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return false
+	}
+}
+
+// portFromAddr pulls the port out of a recorded destAddr. Handles
+// "127.0.0.1:3306", "db:3306" and the IPv6 "[::1]:3306" form.
+func portFromAddr(addr string) (uint32, bool) {
+	if addr == "" {
+		return 0, false
+	}
+	_, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return 0, false
+	}
+	port, err := strconv.ParseUint(portStr, 10, 32)
+	if err != nil || port == 0 {
+		return 0, false
+	}
+	return uint32(port), true
+}
+
+// deriveMysqlPorts recovers the MySQL port set from the mocks a replay
+// run has just loaded, and unblocks any connection parked in
+// WaitDerived. Called from SetMocks / SetMocksWithWindow before the
+// mocks are published to the manager.
+//
+// Only replay reaches these callers, so derivedCh is never closed in
+// record mode. That is safe because WaitDerived is only reachable under
+// MODE_TEST — and it is bounded anyway (timeout plus ctx cancellation),
+// so even an aborted replay that never stores mocks releases its parked
+// connections rather than hanging them.
+func (p *Proxy) deriveMysqlPorts(mockSets ...[]*models.Mock) {
+	if p.mysqlPorts == nil {
+		return
+	}
+	added := p.mysqlPorts.DeriveFromMocks(mockSets...)
+	if len(added) > 0 {
+		p.logger.Info("recovered MySQL ports from recorded mocks; replay will route them to the MySQL parser",
+			zap.Uint32s("ports", added))
+	}
+}
+
+// mysqlProbe is what probeMysql learned, together with any connection
+// state it had to create or consume while learning it.
+//
+// SrcConn and DstConn must always be adopted by the caller: the probe
+// may have consumed bytes off either socket, and the returned conns
+// replay them. Ignoring them loses the client's first packet or the
+// server's greeting.
+type mysqlProbe struct {
+	// IsMySQL routes the connection to the MySQL parser.
+	IsMySQL bool
+	// SrcConn is srcConn, wrapped to replay any client bytes the
+	// probe consumed. Never nil.
+	SrcConn net.Conn
+	// DstConn is a pre-dialed upstream, wrapped to replay the
+	// server greeting the probe consumed. nil when the probe never
+	// dialed, in which case the caller dials as usual.
+	DstConn net.Conn
+	// Reason is a short tag for debug logs.
+	Reason string
+}
+
+// probeMysql decides whether this connection should be handled by the
+// MySQL parser. See the package doc above for the design; the short
+// version is: known port → yes; client speaks first → no; client
+// silent → ask the upstream (record) or the recorded mocks (replay).
+//
+// It never returns a nil *mysqlProbe. A non-nil error means the
+// connection is unusable (upstream dial failure) and the caller should
+// abort — the probe's conns are still safe to inspect for cleanup.
+func (p *Proxy) probeMysql(
+	ctx context.Context,
+	srcConn net.Conn,
+	dstAddr string,
+	port uint32,
+	mode models.Mode,
+	opts models.OutgoingOptions,
+	logger *zap.Logger,
+) (*mysqlProbe, error) {
+	// ── Fast path: a port we already know ──
+	// Configured mysqlPorts, the built-in defaults, or a port learned
+	// earlier in this session / derived from mocks. Zero probe cost,
+	// and byte-identical to the pre-auto-detection behaviour.
+	if isMysqlPort(port, opts.MysqlPorts) {
+		return &mysqlProbe{IsMySQL: true, SrcConn: srcConn, Reason: "configured-port"}, nil
+	}
+	if p.mysqlPorts.Has(port) {
+		return &mysqlProbe{IsMySQL: true, SrcConn: srcConn, Reason: "known-port"}, nil
+	}
+	// A port already probed and found not to speak MySQL. Skipping here
+	// is what keeps the probe a one-time cost per port rather than a
+	// per-connection tax — without it, every connection to every
+	// non-MySQL port would re-pay the client wait and the upstream dial.
+	if p.mysqlPorts.IsKnownNotMysql(port) {
+		return &mysqlProbe{SrcConn: srcConn, Reason: "known-not-mysql"}, nil
+	}
+
+	// Auto-detection is opt-out: when disabled we behave exactly as
+	// before — unknown ports fall through to generic dispatch (and, for
+	// a real MySQL server, deadlock as they always did).
+	if opts.DisableMysqlAutoDetect {
+		return &mysqlProbe{SrcConn: srcConn, Reason: "auto-detect-disabled"}, nil
+	}
+
+	// notMysql caches a negative verdict and builds the probe result in
+	// one place, so no negative path can forget to do it.
+	notMysql := func(reason string, src net.Conn) *mysqlProbe {
+		if p.mysqlPorts.LearnNotMysql(port) {
+			logger.Debug("port does not speak MySQL; skipping detection for it from now on",
+				zap.Uint32("port", port),
+				zap.String("dstAddr", dstAddr),
+				zap.String("reason", reason))
+		}
+		return &mysqlProbe{SrcConn: src, Reason: reason}
+	}
+
+	// ── Step 1: is the client silent? ──
+	// Only a server-speaks-first connection can be MySQL at this point.
+	// Any client byte is a definitive negative and costs one read.
+	clientBytes, err := readWithin(srcConn, clientSilenceWindow())
+	if len(clientBytes) > 0 {
+		return notMysql("client-spoke-first", replayConn(srcConn, clientBytes, logger)), nil
+	}
+	if err != nil && !isTimeout(err) {
+		// EOF or a real network error: nothing to detect. Hand the
+		// connection back untouched and let the existing path produce
+		// its usual diagnostics.
+		return &mysqlProbe{SrcConn: srcConn, Reason: "client-read-error"}, nil
+	}
+
+	logger.Debug("client silent past the probe window; treating as server-speaks-first",
+		zap.String("dstAddr", dstAddr),
+		zap.Uint32("port", port),
+		zap.Duration("window", clientSilenceWindow()))
+
+	// ── Step 2a: replay — there is no upstream, so ask the mocks ──
+	if mode == models.MODE_TEST {
+		if !p.mysqlPorts.WaitDerived(ctx, mockDeriveWait()) {
+			logger.Debug("mysql port derivation did not complete before the deadline",
+				zap.Uint32("port", port), zap.Duration("waited", mockDeriveWait()))
+			return &mysqlProbe{SrcConn: srcConn, Reason: "mocks-not-derived"}, nil
+		}
+		if p.mysqlPorts.Has(port) {
+			logger.Debug("recalled mysql port from recorded mocks", zap.Uint32("port", port))
+			return &mysqlProbe{IsMySQL: true, SrcConn: srcConn, Reason: "derived-from-mocks"}, nil
+		}
+		return &mysqlProbe{SrcConn: srcConn, Reason: "no-mysql-mock-for-port"}, nil
+	}
+
+	// ── Step 2b: record — dial upstream and let the server identify itself ──
+	//
+	// This probe connection is deliberately NOT handed back to the
+	// caller on a negative verdict. Two reasons:
+	//
+	//  1. Leak safety. The generic path reassigns dstConn on several
+	//     branches (TLS dial, CONNECT, Postgres SSL upstream) without
+	//     closing what was there, so a pre-dialed socket handed over on
+	//     a non-MySQL verdict would be dropped unreferenced. That is
+	//     reachable: a slow TLS client can be silent past the client
+	//     window and only then send its ClientHello.
+	//
+	//  2. Staleness. Generic dispatch dials just-in-time, right before
+	//     forwarding the client's first bytes. Handing it a socket
+	//     opened seconds earlier — while we were waiting on a client
+	//     that is slow by definition — risks an upstream idle timeout
+	//     closing it before the first byte is ever written.
+	//
+	// Redialing costs one extra connection on the first probe of a
+	// port; the negative cache makes it exactly once. A server-speaks-
+	// first protocol simply re-greets on the fresh connection, so
+	// discarding this one loses nothing.
+	dstConn, err := net.Dial("tcp", dstAddr)
+	if err != nil {
+		return &mysqlProbe{SrcConn: srcConn, Reason: "upstream-dial-failed"}, err
+	}
+	dstAdopted := false
+	defer func() {
+		if !dstAdopted {
+			_ = dstConn.Close()
+		}
+	}()
+
+	greeting, err := readGreetingWithin(ctx, dstConn, serverGreetingWindow(), p.Integrations[integrations.MYSQL])
+	if len(greeting) == 0 {
+		if err != nil && !isTimeout(err) {
+			logger.Debug("upstream produced no greeting; not classifying as mysql",
+				zap.String("dstAddr", dstAddr), zap.Error(err))
+			return notMysql("upstream-read-error", srcConn), nil
+		}
+		// Both ends silent. mysqld greets immediately on accept, so a
+		// full greeting window of silence rules MySQL out.
+		return notMysql("no-greeting", srcConn), nil
+	}
+
+	// Reuse the parser's own content matcher rather than reimplementing
+	// handshake parsing here — it already validates the HandshakeV10
+	// shape and is deliberately strict about false positives.
+	parser, ok := p.Integrations[integrations.MYSQL]
+	if !ok {
+		// No MySQL parser registered in this build: nothing could route
+		// there anyway. Don't cache a negative — this says nothing about
+		// the port, only about the build.
+		logger.Debug("mysql parser not registered; skipping content detection")
+		return &mysqlProbe{SrcConn: srcConn, Reason: "mysql-parser-unregistered"}, nil
+	}
+
+	if !parser.MatchType(ctx, greeting) {
+		return notMysql("greeting-not-mysql", srcConn), nil
+	}
+
+	if p.mysqlPorts.Learn(port) {
+		logger.Info("detected MySQL wire protocol on a non-default port; routing it to the MySQL parser for the rest of this session",
+			zap.Uint32("port", port),
+			zap.String("dstAddr", dstAddr),
+			zap.String("note", "set mysqlPorts in keploy.yml to skip detection, or disableMysqlAutoDetect: true to turn this off"))
+	}
+
+	// Positive verdict: keep the connection. The greeting is already on
+	// the wire and the client responds to it immediately, so there is no
+	// staleness window here — this is exactly what the pre-existing
+	// isMysqlPort branch did, minus the hardcoded port list.
+	dstAdopted = true
+	return &mysqlProbe{
+		IsMySQL: true,
+		SrcConn: srcConn,
+		DstConn: replayConn(dstConn, greeting, logger),
+		Reason:  "detected-handshake",
+	}, nil
+}
+
+// readGreetingWithin accumulates the upstream's first bytes until the
+// MySQL matcher can reach a verdict, the overall window expires, or the
+// peer closes.
+//
+// A single Read is not enough. MySQL.MatchType needs the complete first
+// packet (it rejects a buffer shorter than the declared packet length),
+// so a HandshakeV10 split across two TCP segments would be judged "not
+// MySQL" and the connection would fall through to the generic path —
+// re-introducing exactly the deadlock this detection exists to remove,
+// with a debug line that actively points the wrong way. Rare, but a
+// hard hang when it happens, so we keep reading until the matcher
+// commits or we run out of time.
+//
+// matcher may be nil (no MySQL parser registered); then this degrades
+// to a single bounded read, which is all the caller needs.
+func readGreetingWithin(ctx context.Context, conn net.Conn, window time.Duration, matcher integrations.Integrations) ([]byte, error) {
+	deadline := time.Now().Add(window)
+	if err := conn.SetReadDeadline(deadline); err != nil {
+		return nil, err
+	}
+	defer func() { _ = conn.SetReadDeadline(time.Time{}) }()
+
+	var greeting []byte
+	buf := make([]byte, 4096)
+	for {
+		n, err := conn.Read(buf)
+		if n > 0 {
+			greeting = append(greeting, buf[:n]...)
+			// Stop as soon as the verdict is knowable. A positive is
+			// final; for a negative we still need to be sure we are not
+			// looking at a half-delivered handshake, so keep reading
+			// until the window closes or the greeting grows past any
+			// plausible handshake (MatchType caps packets at 512 bytes).
+			if matcher != nil && matcher.MatchType(ctx, greeting) {
+				return greeting, nil
+			}
+			if len(greeting) > 1024 {
+				return greeting, nil
+			}
+		}
+		if err != nil {
+			return greeting, err
+		}
+		if !time.Now().Before(deadline) {
+			return greeting, nil
+		}
+	}
+}
+
+// readWithin reads once from conn under a deadline. A timeout is
+// reported as a normal (nil-byte, timeout-error) outcome rather than a
+// failure — "said nothing in time" is a legitimate probe result. The
+// deadline is always cleared so later reads are unaffected.
+//
+// Any bytes read before an error are returned, so no data is ever lost
+// to a mid-read failure.
+func readWithin(conn net.Conn, window time.Duration) ([]byte, error) {
+	if err := conn.SetReadDeadline(time.Now().Add(window)); err != nil {
+		return nil, err
+	}
+	defer func() { _ = conn.SetReadDeadline(time.Time{}) }()
+
+	buf := make([]byte, 4096)
+	n, err := conn.Read(buf)
+	if n > 0 {
+		return buf[:n], err
+	}
+	return nil, err
+}
+
+// replayConn wraps conn so the already-consumed prefix is handed back
+// on the next reads, then reads pass through to the socket. Writes,
+// deadlines and Close all go straight to the real connection via the
+// embedded net.Conn.
+func replayConn(conn net.Conn, prefix []byte, logger *zap.Logger) net.Conn {
+	if len(prefix) == 0 {
+		return conn
+	}
+	return &util.Conn{
+		Conn:   conn,
+		Reader: util.NewPrefixReader(prefix, conn),
+		Logger: logger,
+	}
+}
+
+func isTimeout(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, os.ErrDeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return netErr.Timeout()
+	}
+	return false
+}

--- a/pkg/agent/proxy/mysql_detect_test.go
+++ b/pkg/agent/proxy/mysql_detect_test.go
@@ -1,0 +1,603 @@
+package proxy
+
+import (
+	"context"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations"
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// mysqlGreeting is a real MySQL 8.0 Initial Handshake Packet (HandshakeV10):
+// 3-byte length + seq 0 + 0x0a protocol version + "8.0.46\0" + salt/caps.
+func mysqlGreeting() []byte {
+	return []byte{
+		0x4a, 0x00, 0x00, 0x00, 0x0a, '8', '.', '0', '.', '4', '6', 0x00,
+		0x0a, 0x00, 0x00, 0x00, 0x38, 0x0a, 0x6e, 0x21, 0x50, 0x54, 0x57, 0x65,
+		0x00, 0xff, 0xff, 0xff, 0x02, 0x00, 0xff, 0xdf, 0x15, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x59, 0x3a, 0x3e, 0x0f,
+		0x69, 0x2b, 0x1e, 0x51, 0x77, 0x1a, 0x2f, 0x59, 0x00, 'c', 'a', 'c',
+		'h', 'i', 'n', 'g', '_', 's', 'h', 'a', '2', '_', 'p', 'a', 's', 's',
+		'w', 'o', 'r', 'd', 0x00,
+	}
+}
+
+func testProxy(t *testing.T) *Proxy {
+	t.Helper()
+	return &Proxy{
+		logger:     zap.NewNop(),
+		mysqlPorts: newMysqlPortRegistry(),
+		Integrations: map[integrations.IntegrationType]integrations.Integrations{
+			integrations.MYSQL: mysql.New(zap.NewNop()),
+		},
+	}
+}
+
+// serverThatGreets starts a listener that writes greeting to every
+// accepted connection, mimicking a server-speaks-first upstream.
+func serverThatGreets(t *testing.T, greeting []byte) (addr string, port uint32) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			if len(greeting) > 0 {
+				_, _ = c.Write(greeting)
+			}
+			// Hold the connection open so the probe's read does not
+			// race a close.
+			go func(c net.Conn) {
+				_, _ = io.Copy(io.Discard, c)
+				_ = c.Close()
+			}(c)
+		}
+	}()
+
+	tcpAddr := ln.Addr().(*net.TCPAddr)
+	return ln.Addr().String(), uint32(tcpAddr.Port)
+}
+
+// clientPair returns the two ends of an in-memory-ish TCP connection.
+// The returned "app" end is what a client app would hold; "srv" is what
+// the proxy sees as srcConn.
+func clientPair(t *testing.T) (app net.Conn, srv net.Conn) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		srv, _ = ln.Accept()
+	}()
+
+	app, err = net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	wg.Wait()
+	if srv == nil {
+		t.Fatal("accept failed")
+	}
+	t.Cleanup(func() { _ = app.Close(); _ = srv.Close() })
+	return app, srv
+}
+
+// The headline case: a real MySQL server on a port nobody configured.
+// Before auto-detection this deadlocked in ReadInitialBuf and the app
+// died with "Lost connection ... reading initial communication packet".
+func TestProbeDetectsMysqlOnUnconfiguredPort(t *testing.T) {
+	p := testProxy(t)
+	greeting := mysqlGreeting()
+	dstAddr, port := serverThatGreets(t, greeting)
+
+	_, srcConn := clientPair(t) // app end stays silent, like a MySQL client
+
+	probe, err := p.probeMysql(context.Background(), srcConn, dstAddr, port,
+		models.MODE_RECORD, models.OutgoingOptions{}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if !probe.IsMySQL {
+		t.Fatalf("expected MySQL detection, got reason=%q", probe.Reason)
+	}
+	if probe.Reason != "detected-handshake" {
+		t.Errorf("reason = %q, want detected-handshake", probe.Reason)
+	}
+
+	// The greeting must survive the probe — the parser has to see the
+	// handshake it consumed, byte for byte.
+	if probe.DstConn == nil {
+		t.Fatal("expected a pre-dialed upstream conn")
+	}
+	got := make([]byte, len(greeting))
+	if _, err := io.ReadFull(probe.DstConn, got); err != nil {
+		t.Fatalf("replay greeting: %v", err)
+	}
+	if string(got) != string(greeting) {
+		t.Errorf("greeting was not replayed intact")
+	}
+
+	// And the port is learned, so the next connection skips the probe.
+	if !p.mysqlPorts.Has(port) {
+		t.Errorf("port %d was not learned", port)
+	}
+}
+
+// Second connection to a learned port must take the fast path — no
+// probe, no latency, no upstream dial.
+func TestProbeFastPathAfterLearning(t *testing.T) {
+	p := testProxy(t)
+	p.mysqlPorts.Learn(7777)
+
+	_, srcConn := clientPair(t)
+	start := time.Now()
+	probe, err := p.probeMysql(context.Background(), srcConn, "127.0.0.1:7777", 7777,
+		models.MODE_RECORD, models.OutgoingOptions{}, zap.NewNop())
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if !probe.IsMySQL || probe.Reason != "known-port" {
+		t.Fatalf("IsMySQL=%v reason=%q, want true/known-port", probe.IsMySQL, probe.Reason)
+	}
+	if probe.DstConn != nil {
+		t.Error("fast path must not dial upstream")
+	}
+	if elapsed > 50*time.Millisecond {
+		t.Errorf("fast path took %v, expected it to be immediate", elapsed)
+	}
+}
+
+// Configured / default ports keep their exact pre-existing behaviour.
+func TestProbeConfiguredPortsUnchanged(t *testing.T) {
+	p := testProxy(t)
+	_, srcConn := clientPair(t)
+
+	probe, err := p.probeMysql(context.Background(), srcConn, "127.0.0.1:3306", 3306,
+		models.MODE_RECORD, models.OutgoingOptions{}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if !probe.IsMySQL || probe.Reason != "configured-port" {
+		t.Fatalf("IsMySQL=%v reason=%q, want true/configured-port", probe.IsMySQL, probe.Reason)
+	}
+}
+
+// A client that speaks first is never MySQL, and its bytes must not be
+// swallowed by the probe.
+func TestProbeClientSpeaksFirstPreservesBytes(t *testing.T) {
+	p := testProxy(t)
+	app, srcConn := clientPair(t)
+
+	payload := []byte("GET /health HTTP/1.1\r\nHost: x\r\n\r\n")
+	if _, err := app.Write(payload); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	probe, err := p.probeMysql(context.Background(), srcConn, "127.0.0.1:9999", 9999,
+		models.MODE_RECORD, models.OutgoingOptions{}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if probe.IsMySQL {
+		t.Fatal("HTTP request classified as MySQL")
+	}
+	if probe.Reason != "client-spoke-first" {
+		t.Errorf("reason = %q, want client-spoke-first", probe.Reason)
+	}
+	if probe.DstConn != nil {
+		t.Error("must not dial upstream once the client has spoken")
+	}
+
+	got := make([]byte, len(payload))
+	if _, err := io.ReadFull(probe.SrcConn, got); err != nil {
+		t.Fatalf("replay client bytes: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Errorf("client bytes lost: got %q want %q", got, payload)
+	}
+}
+
+// A silent client in front of a non-MySQL server must fall through to
+// generic dispatch with the upstream conn and its bytes intact.
+func TestProbeSilentClientNonMysqlServer(t *testing.T) {
+	p := testProxy(t)
+	banner := []byte("220 smtp.example.com ESMTP Postfix\r\n")
+	dstAddr, port := serverThatGreets(t, banner)
+
+	_, srcConn := clientPair(t)
+
+	probe, err := p.probeMysql(context.Background(), srcConn, dstAddr, port,
+		models.MODE_RECORD, models.OutgoingOptions{}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if probe.IsMySQL {
+		t.Fatal("SMTP banner classified as MySQL")
+	}
+	if probe.Reason != "greeting-not-mysql" {
+		t.Errorf("reason = %q, want greeting-not-mysql", probe.Reason)
+	}
+	if p.mysqlPorts.Has(port) {
+		t.Error("non-MySQL port must not be learned as MySQL")
+	}
+	// The probe connection must NOT be handed to the caller on a
+	// negative verdict. Generic dispatch reassigns dstConn on its TLS /
+	// CONNECT / Postgres-SSL branches without closing what was there, so
+	// a handed-over socket would leak; and it dials just-in-time, so a
+	// socket opened while waiting on a slow client can go stale before
+	// the first byte is written. The upstream re-greets on the fresh
+	// dial, so nothing is lost by dropping this one.
+	if probe.DstConn != nil {
+		t.Error("probe must not hand its upstream conn to the caller on a negative verdict")
+	}
+	// And the verdict is cached, so the next connection to this port
+	// skips the probe entirely rather than re-paying the wait + dial.
+	if !p.mysqlPorts.IsKnownNotMysql(port) {
+		t.Error("negative verdict was not cached")
+	}
+}
+
+// Regression test for the leak the negative-verdict path used to have:
+// probeMysql dials upstream, and on a non-MySQL verdict that socket
+// must be closed by the probe itself.
+func TestProbeClosesUpstreamOnNegativeVerdict(t *testing.T) {
+	p := testProxy(t)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	closed := make(chan struct{}, 1)
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		_, _ = c.Write([]byte("220 smtp.example.com ESMTP\r\n"))
+		// Block until the peer closes; that read returns EOF exactly
+		// when the probe has released its end.
+		_, _ = io.Copy(io.Discard, c)
+		closed <- struct{}{}
+	}()
+
+	tcpAddr := ln.Addr().(*net.TCPAddr)
+	_, srcConn := clientPair(t)
+
+	probe, err := p.probeMysql(context.Background(), srcConn, ln.Addr().String(),
+		uint32(tcpAddr.Port), models.MODE_RECORD, models.OutgoingOptions{}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if probe.IsMySQL {
+		t.Fatal("SMTP classified as MySQL")
+	}
+
+	select {
+	case <-closed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("probe leaked its upstream connection on a negative verdict")
+	}
+}
+
+// Once a port is known not to speak MySQL, later connections must skip
+// the probe entirely — no client wait, no upstream dial. Without this
+// the probe is a per-connection tax on every non-MySQL port.
+func TestProbeSkipsKnownNegativePort(t *testing.T) {
+	p := testProxy(t)
+	p.mysqlPorts.LearnNotMysql(8443)
+
+	_, srcConn := clientPair(t)
+	start := time.Now()
+	probe, err := p.probeMysql(context.Background(), srcConn, "127.0.0.1:8443", 8443,
+		models.MODE_RECORD, models.OutgoingOptions{}, zap.NewNop())
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if probe.IsMySQL || probe.Reason != "known-not-mysql" {
+		t.Fatalf("IsMySQL=%v reason=%q, want false/known-not-mysql", probe.IsMySQL, probe.Reason)
+	}
+	if probe.DstConn != nil {
+		t.Error("cached negative must not dial upstream")
+	}
+	if elapsed > 50*time.Millisecond {
+		t.Errorf("cached negative took %v; the probe was not skipped", elapsed)
+	}
+}
+
+// A HandshakeV10 split across TCP segments must still be detected.
+// MatchType needs the complete first packet, so a single Read on a
+// fragmented greeting would return "not MySQL" and re-introduce the
+// very deadlock this feature removes.
+func TestProbeDetectsFragmentedGreeting(t *testing.T) {
+	p := testProxy(t)
+	greeting := mysqlGreeting()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		// Split mid-packet: the first write carries the 4-byte header
+		// and a few body bytes, so MatchType cannot decide from it.
+		_, _ = c.Write(greeting[:10])
+		time.Sleep(120 * time.Millisecond)
+		_, _ = c.Write(greeting[10:])
+		_, _ = io.Copy(io.Discard, c)
+	}()
+
+	tcpAddr := ln.Addr().(*net.TCPAddr)
+	_, srcConn := clientPair(t)
+
+	probe, err := p.probeMysql(context.Background(), srcConn, ln.Addr().String(),
+		uint32(tcpAddr.Port), models.MODE_RECORD, models.OutgoingOptions{}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if !probe.IsMySQL {
+		t.Fatalf("fragmented handshake not detected, reason=%q", probe.Reason)
+	}
+
+	// Every byte of the split greeting must still reach the parser.
+	got := make([]byte, len(greeting))
+	if _, err := io.ReadFull(probe.DstConn, got); err != nil {
+		t.Fatalf("replay greeting: %v", err)
+	}
+	if string(got) != string(greeting) {
+		t.Error("fragmented greeting was not reassembled intact")
+	}
+}
+
+// A client that speaks first proves the port is not MySQL, so that
+// verdict is cached too — otherwise every HTTP connection on a
+// non-standard port keeps paying the client-silence window.
+func TestProbeCachesClientSpokeFirstAsNegative(t *testing.T) {
+	p := testProxy(t)
+	app, srcConn := clientPair(t)
+	if _, err := app.Write([]byte("GET / HTTP/1.1\r\n\r\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	probe, err := p.probeMysql(context.Background(), srcConn, "127.0.0.1:9443", 9443,
+		models.MODE_RECORD, models.OutgoingOptions{}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if probe.IsMySQL {
+		t.Fatal("HTTP classified as MySQL")
+	}
+	if !p.mysqlPorts.IsKnownNotMysql(9443) {
+		t.Error("client-spoke-first verdict was not cached")
+	}
+}
+
+// An explicit positive must never be overridden by a cached negative —
+// config and recorded mocks are stronger evidence than a probe timeout.
+func TestRegistryPositiveBeatsNegative(t *testing.T) {
+	r := newMysqlPortRegistry()
+
+	r.LearnNotMysql(3307)
+	if !r.IsKnownNotMysql(3307) {
+		t.Fatal("negative not recorded")
+	}
+
+	// A real handshake later on the same port clears the negative.
+	r.Learn(3307)
+	if !r.Has(3307) {
+		t.Error("positive not recorded")
+	}
+	if r.IsKnownNotMysql(3307) {
+		t.Error("negative must be cleared by a positive")
+	}
+
+	// And a stale negative can no longer demote a known positive.
+	r.LearnNotMysql(3307)
+	if r.IsKnownNotMysql(3307) {
+		t.Error("known positive was demoted by a negative")
+	}
+	if !r.Has(3307) {
+		t.Error("known positive was lost")
+	}
+}
+
+// Opting out restores the strict port-list behaviour exactly.
+func TestProbeAutoDetectDisabled(t *testing.T) {
+	p := testProxy(t)
+	dstAddr, port := serverThatGreets(t, mysqlGreeting())
+	_, srcConn := clientPair(t)
+
+	probe, err := p.probeMysql(context.Background(), srcConn, dstAddr, port,
+		models.MODE_RECORD, models.OutgoingOptions{DisableMysqlAutoDetect: true}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if probe.IsMySQL {
+		t.Fatal("auto-detection ran despite being disabled")
+	}
+	if probe.Reason != "auto-detect-disabled" {
+		t.Errorf("reason = %q, want auto-detect-disabled", probe.Reason)
+	}
+}
+
+// Replay has no upstream to greet anyone, so the port must come from
+// the recorded mocks' destAddr.
+func TestReplayRecallsPortFromMocks(t *testing.T) {
+	p := testProxy(t)
+	mocks := []*models.Mock{
+		{Kind: models.MySQL, Spec: models.MockSpec{Metadata: map[string]string{"destAddr": "172.19.0.3:6033"}}},
+		{Kind: models.HTTP, Spec: models.MockSpec{Metadata: map[string]string{"destAddr": "1.2.3.4:80"}}},
+	}
+	p.deriveMysqlPorts(mocks)
+
+	if !p.mysqlPorts.Has(6033) {
+		t.Fatal("MySQL mock port 6033 not derived")
+	}
+	if p.mysqlPorts.Has(80) {
+		t.Error("HTTP mock port must not be derived as MySQL")
+	}
+
+	_, srcConn := clientPair(t)
+	probe, err := p.probeMysql(context.Background(), srcConn, "172.19.0.9:6033", 6033,
+		models.MODE_TEST, models.OutgoingOptions{}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	// Note the host differs from the recorded one (container IPs change
+	// between runs) — matching is by port for exactly this reason.
+	if !probe.IsMySQL || probe.Reason != "known-port" {
+		t.Fatalf("IsMySQL=%v reason=%q, want true/known-port", probe.IsMySQL, probe.Reason)
+	}
+}
+
+// Replay must never dial upstream while probing — there is nothing to
+// dial, and doing so would leak a connection to a real server.
+func TestReplayNeverDials(t *testing.T) {
+	p := testProxy(t)
+	p.deriveMysqlPorts(nil) // signal derivation with no MySQL mocks
+
+	_, srcConn := clientPair(t)
+	probe, err := p.probeMysql(context.Background(), srcConn, "127.0.0.1:1", 1,
+		models.MODE_TEST, models.OutgoingOptions{}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if probe.DstConn != nil {
+		t.Fatal("replay probe dialed upstream")
+	}
+	if probe.Reason != "no-mysql-mock-for-port" {
+		t.Errorf("reason = %q, want no-mysql-mock-for-port", probe.Reason)
+	}
+}
+
+// The compose replay path starts the app before mocks are stored. A
+// connection arriving in that gap must park until derivation lands
+// rather than guess wrong.
+func TestReplayWaitsForMockDerivation(t *testing.T) {
+	t.Setenv("KEPLOY_MYSQL_MOCK_DERIVE_WAIT", "5s")
+	p := testProxy(t)
+
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		p.deriveMysqlPorts([]*models.Mock{
+			{Kind: models.MySQL, Spec: models.MockSpec{Metadata: map[string]string{"destAddr": "db:15306"}}},
+		})
+	}()
+
+	_, srcConn := clientPair(t)
+	start := time.Now()
+	probe, err := p.probeMysql(context.Background(), srcConn, "db:15306", 15306,
+		models.MODE_TEST, models.OutgoingOptions{}, zap.NewNop())
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if !probe.IsMySQL {
+		t.Fatalf("expected MySQL after derivation landed, reason=%q", probe.Reason)
+	}
+	if probe.Reason != "derived-from-mocks" {
+		t.Errorf("reason = %q, want derived-from-mocks", probe.Reason)
+	}
+	if elapsed > 3*time.Second {
+		t.Errorf("waited %v, expected to wake as soon as mocks landed", elapsed)
+	}
+}
+
+// The wait is bounded — a run with no mocks at all must not hang.
+func TestReplayDeriveWaitIsBounded(t *testing.T) {
+	t.Setenv("KEPLOY_MYSQL_MOCK_DERIVE_WAIT", "300ms")
+	p := testProxy(t)
+
+	_, srcConn := clientPair(t)
+	start := time.Now()
+	probe, err := p.probeMysql(context.Background(), srcConn, "127.0.0.1:9", 9,
+		models.MODE_TEST, models.OutgoingOptions{}, zap.NewNop())
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if probe.IsMySQL {
+		t.Fatal("classified as MySQL with no mocks at all")
+	}
+	if probe.Reason != "mocks-not-derived" {
+		t.Errorf("reason = %q, want mocks-not-derived", probe.Reason)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("wait was not bounded: %v", elapsed)
+	}
+}
+
+func TestPortFromAddr(t *testing.T) {
+	cases := []struct {
+		in   string
+		want uint32
+		ok   bool
+	}{
+		{"127.0.0.1:3306", 3306, true},
+		{"db:6033", 6033, true},
+		{"[::1]:4000", 4000, true},
+		{"[fd00::2]:15306", 15306, true},
+		{"", 0, false},
+		{"127.0.0.1", 0, false},
+		{"127.0.0.1:0", 0, false},
+		{"127.0.0.1:notaport", 0, false},
+	}
+	for _, c := range cases {
+		got, ok := portFromAddr(c.in)
+		if got != c.want || ok != c.ok {
+			t.Errorf("portFromAddr(%q) = (%d,%v), want (%d,%v)", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+func TestRegistryConcurrentAccess(t *testing.T) {
+	r := newMysqlPortRegistry()
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			r.Learn(uint32(3000 + i%8))
+			r.Has(uint32(3000 + i%8))
+			r.Ports()
+			r.DeriveFromMocks([]*models.Mock{
+				{Kind: models.MySQL, Spec: models.MockSpec{Metadata: map[string]string{"destAddr": "h:3306"}}},
+			})
+		}(i)
+	}
+	wg.Wait()
+	if !r.Has(3306) {
+		t.Error("expected 3306 after concurrent derivation")
+	}
+}

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -126,6 +126,12 @@ type Proxy struct {
 	integrationsPriority []ParserPriority
 	errChannel           chan error
 
+	// mysqlPorts holds destination ports known to speak the MySQL wire
+	// protocol beyond the configured/default list — learned from a real
+	// handshake during record, and derived from the loaded mocks'
+	// destAddr metadata during replay. See mysql_detect.go.
+	mysqlPorts *mysqlPortRegistry
+
 	// activeTestErrors accumulates mock-not-found errors during active test
 	// execution. The continuous drain goroutine routes errors here when non-nil.
 	// When nil (no window), mock-not-found errors fall to pendingMockErrors and
@@ -684,6 +690,7 @@ func New(logger *zap.Logger, info agent.DestInfo, opts *config.Config) *Proxy {
 		caJavaHome:                opts.Agent.CAJavaHome,
 		dnsCache:                  newDNSCache(),
 		recordedDNSMocks:          newRecordedDNSMocksCache(),
+		mysqlPorts:                newMysqlPortRegistry(),
 		// dnsForwardTimeout is the per-forward deadline for upstream DNS
 		// exchanges. 2 s is long enough to absorb a single UDP retransmit
 		// against CoreDNS (~500 ms default) while keeping app-side lookup
@@ -1733,15 +1740,45 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 		outgoingOpts.Synchronous = true
 	}
 
-	// MySQL wire-protocol ports (MySQL, TiDB, MariaDB, custom proxies).
-	// Configurable via outgoingOpts.MysqlPorts (Config.MysqlPorts in
-	// keploy.yml); defaults to [3306, 4000] when unset.
-	if isMysqlPort(uint32(destInfo.Port), outgoingOpts.MysqlPorts) {
+	// Decide whether this connection speaks MySQL. Historically this was
+	// a pure port check against outgoingOpts.MysqlPorts (defaults
+	// [3306, 4000]); probeMysql keeps that as its zero-cost fast path
+	// and adds automatic detection for every other port — by reading the
+	// upstream's handshake during record, and by recalling ports from
+	// the recorded mocks during replay. See mysql_detect.go for why the
+	// two modes need different mechanisms.
+	//
+	// The probe may consume bytes off either socket and may dial
+	// upstream, so its connections are adopted unconditionally — both
+	// on the MySQL path and on the fall-through to generic dispatch.
+	probe, err := p.probeMysql(parserCtx, srcConn, dstAddr, uint32(destInfo.Port), rule.Mode, outgoingOpts, p.logger)
+	if probe != nil {
+		if probe.SrcConn != nil {
+			srcConn = probe.SrcConn
+		}
+		if probe.DstConn != nil {
+			dstConn = probe.DstConn
+		}
+	}
+	if err != nil {
+		utils.LogError(p.logger, err, "failed to dial the conn to destination server while probing for MySQL", zap.Uint32("proxy port", p.Port), zap.String("server address", dstAddr), zap.String("next_step", util.NextStepDialDestination))
+		return err
+	}
+	p.logger.Debug("mysql probe result",
+		zap.Bool("isMySQL", probe.IsMySQL),
+		zap.String("reason", probe.Reason),
+		zap.Uint32("destPort", destInfo.Port))
+
+	if probe.IsMySQL {
 		if rule.Mode != models.MODE_TEST {
-			dstConn, err = net.Dial("tcp", dstAddr)
-			if err != nil {
-				utils.LogError(p.logger, err, "failed to dial the conn to destination server", zap.Uint32("proxy port", p.Port), zap.String("server address", dstAddr), zap.String("next_step", util.NextStepDialDestination))
-				return err
+			// probeMysql already dialed when it had to read the
+			// upstream greeting; dstConn then replays those bytes.
+			if dstConn == nil {
+				dstConn, err = net.Dial("tcp", dstAddr)
+				if err != nil {
+					utils.LogError(p.logger, err, "failed to dial the conn to destination server", zap.Uint32("proxy port", p.Port), zap.String("server address", dstAddr), zap.String("next_step", util.NextStepDialDestination))
+					return err
+				}
 			}
 			dstCfg := &models.ConditionalDstCfg{
 				Addr: dstAddr,
@@ -2838,6 +2875,12 @@ func (p *Proxy) LoadAsyncMocks(mocks []*models.Mock) {
 }
 
 func (p *Proxy) SetMocks(_ context.Context, filtered []*models.Mock, unFiltered []*models.Mock) error {
+	// Replay cannot detect MySQL from content — no upstream exists to
+	// send a handshake — so the port set is recovered here, from the
+	// destAddr every MySQL mock records. Must happen before the mocks
+	// are published, so a connection that wakes on SetFilteredMocks
+	// already sees the derived ports.
+	p.deriveMysqlPorts(filtered, unFiltered)
 	if m := p.getMockManager(); m != nil {
 		m.SetFilteredMocks(filtered)
 		m.SetUnFilteredMocks(unFiltered)
@@ -2857,6 +2900,7 @@ func (p *Proxy) SetMocks(_ context.Context, filtered []*models.Mock, unFiltered 
 // single call so concurrent readers cannot observe a torn (newMocks,
 // oldWindow) view. Used to satisfy the WindowedProxy extension interface.
 func (p *Proxy) SetMocksWithWindow(_ context.Context, filtered, unFiltered []*models.Mock, start, end time.Time) error {
+	p.deriveMysqlPorts(filtered, unFiltered)
 	if m := p.getMockManager(); m != nil {
 		m.SetMocksWithWindow(filtered, unFiltered, start, end)
 		p.dnsCache.Purge()

--- a/pkg/models/instrument.go
+++ b/pkg/models/instrument.go
@@ -100,7 +100,17 @@ type OutgoingOptions struct {
 	// protocol; the generic dispatch path waits to peek client bytes
 	// before dialing and deadlocks otherwise. When nil/empty, the
 	// proxy falls back to the built-in defaults [3306, 4000].
+	//
+	// Since automatic detection landed this list is an optimisation and
+	// an escape hatch rather than a requirement: a port listed here
+	// skips the detection probe entirely. See DisableMysqlAutoDetect.
 	MysqlPorts []uint32
+	// DisableMysqlAutoDetect turns off automatic MySQL port detection,
+	// restoring the strict "MysqlPorts or nothing" behaviour. With
+	// detection on (the default), a MySQL server on any port is
+	// identified from its handshake at record time and recalled from
+	// the recorded mocks' destAddr at replay time.
+	DisableMysqlAutoDetect bool
 	// SupportsDroppedRevoke is a capability flag set by the CLI on the
 	// /outgoing request: when true, the CLI understands the reserved
 	// Kind=RevokedTests control frame (it diverts it into a revoke set and

--- a/pkg/service/mock/mock.go
+++ b/pkg/service/mock/mock.go
@@ -74,6 +74,11 @@ func (r *MockLoader) LoadMocks(ctx context.Context, testSetID string, testCaseNa
 		MongoPassword: r.outgoingCfg.MongoPassword,
 		SQLDelay:      r.outgoingCfg.SQLDelay,
 		Mocking:       r.outgoingCfg.Mocking,
+		// Same MySQL routing knobs the record/replay paths pass. Without
+		// them a MockLoader session ignores mysqlPorts entirely and
+		// honours neither the pinned ports nor disableMysqlAutoDetect.
+		MysqlPorts:             r.outgoingCfg.MysqlPorts,
+		DisableMysqlAutoDetect: r.outgoingCfg.DisableMysqlAutoDetect,
 	}); err != nil {
 		return fmt.Errorf("MockLoader: failed to enable mock-outgoing: %w", err)
 	}

--- a/pkg/service/mock/service.go
+++ b/pkg/service/mock/service.go
@@ -73,4 +73,13 @@ type OutgoingConfig struct {
 
 	// Mocking enables or disables mock interception entirely.
 	Mocking bool
+
+	// MysqlPorts pins extra destination ports to the MySQL parser,
+	// skipping auto-detection for them. Mirrors Config.MysqlPorts.
+	MysqlPorts []uint32
+
+	// DisableMysqlAutoDetect turns off automatic MySQL port detection,
+	// restoring strict MysqlPorts matching. Mirrors
+	// Config.DisableMysqlAutoDetect.
+	DisableMysqlAutoDetect bool
 }

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -978,6 +978,7 @@ func (r *Recorder) GetTestAndMockChans(ctx context.Context) (FrameChan, error) {
 		CapturePackets:            r.config.Record.CapturePackets,
 		OpportunisticTLSIntercept: r.config.Record.OpportunisticTLSIntercept,
 		MysqlPorts:                r.config.MysqlPorts,
+		DisableMysqlAutoDetect:    r.config.DisableMysqlAutoDetect,
 		// Advertise that this CLI understands the reserved Kind=RevokedTests
 		// control frame: it diverts such a frame into a revoke set and deletes
 		// those deferred-orphan test cases at finalize instead of persisting it

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1246,6 +1246,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			SchemaNoiseDetection:   r.config.Test.SchemaNoiseDetection,
 			SchemaNoiseStrict:      r.config.Test.SchemaNoiseStrict,
 			MysqlPorts:             r.config.MysqlPorts,
+			DisableMysqlAutoDetect: r.config.DisableMysqlAutoDetect,
 		})
 		if err != nil {
 			if ctx.Err() != context.Canceled {
@@ -1446,6 +1447,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			SchemaNoiseDetection:   r.config.Test.SchemaNoiseDetection,
 			SchemaNoiseStrict:      r.config.Test.SchemaNoiseStrict,
 			MysqlPorts:             r.config.MysqlPorts,
+			DisableMysqlAutoDetect: r.config.DisableMysqlAutoDetect,
 		})
 		if err != nil {
 			if ctx.Err() != context.Canceled {

--- a/pkg/service/runner/runner.go
+++ b/pkg/service/runner/runner.go
@@ -383,6 +383,7 @@ func (r *Runner) setupTestSet(parentCtx context.Context, testSetID string, backd
 		outOpts.SchemaNoiseDetection = r.config.Test.SchemaNoiseDetection
 		outOpts.SchemaNoiseStrict = r.config.Test.SchemaNoiseStrict
 		outOpts.MysqlPorts = r.config.MysqlPorts
+		outOpts.DisableMysqlAutoDetect = r.config.DisableMysqlAutoDetect
 	}
 	noiseCfg := map[string]map[string][]string{}
 	if headerNoise, ok := r.globalNoise["header"]; ok {


### PR DESCRIPTION
## Describe the changes that are made

MySQL is a **server-speaks-first** protocol: the server sends its `HandshakeV10` the moment the TCP connection is accepted, and the client stays silent until it arrives. The proxy's generic dispatch does the opposite — it blocks reading the client (`util.ReadInitialBuf`, `proxy.go`) *before* dialing upstream, so it can sniff the protocol and pick a parser.

Those two deadlock. The app dies with the MySQL client's classic:

```
ERROR 2013 (HY000): Lost connection to server at 'handshake: reading initial communication packet'
```

The workaround was a port allowlist — `[3306, 4000]` plus an **undocumented** `mysqlPorts` key. Anything else hangs: ProxySQL (`6033`), MaxScale (`4006`), StarRocks/Doris (`9030`), OceanBase (`2881`), and the very common `3307`/`3308` multi-instance and Cloud SQL Auth Proxy layouts. A user hitting this has no discoverable knob.

### What this changes

Replaces *"is this a known MySQL port?"* with *"does this connection actually behave like MySQL?"*, answered differently per mode because each mode has different information available:

| Mode | Mechanism |
|---|---|
| **Record** | A real upstream exists, so ask it. If the client is silent past a short window, the connection is server-speaks-first: dial upstream and run the **existing** `MySQL.MatchType` over its greeting. |
| **Replay** | No upstream exists to greet anyone — content detection is impossible by construction. Every MySQL mock already carries `Metadata["destAddr"]`, so the port set is derived from the loaded mocks in `SetMocks`/`SetMocksWithWindow`. |

Auto-detect at record, auto-recall at replay. **No parser changes** — `MySQL.MatchType` already worked; generic dispatch already routes MySQL correctly (`recordViaSupervisor` honours `IsV2()`). The old special-case existed purely because of dial ordering.

### Cost

Zero on the hot path:

- Configured/default ports take the same zero-cost branch as before.
- Client-speaks-first protocols (HTTP, gRPC, Redis, Postgres, Mongo) return on the first read.
- **Both** verdicts are cached per port, so a port is probed at most once per session.

### Notable correctness details

- **On a negative verdict the probe closes its own upstream connection** rather than handing it to the caller. Generic dispatch reassigns `dstConn` on its TLS / CONNECT / Postgres-SSL branches without closing what was there — reachable when a slow TLS client is silent past the client window and only *then* sends its ClientHello — and it dials just-in-time, so a socket opened while waiting on a slow client could go stale before first use.
- **The greeting read accumulates until the matcher can commit.** `MatchType` needs the complete first packet, so a `HandshakeV10` split across TCP segments would otherwise be judged "not MySQL" and re-introduce the exact hang this removes.
- Matching is **by port, not host:port** — container IPs change between record and replay, ports don't. Same semantics `mysqlPorts` always had.

### Config

`mysqlPorts` still works as an escape hatch and is now documented. `disableMysqlAutoDetect: true` restores the strict port-list behaviour.

### Verification

Reproduced the deadlock first, then verified the fix end to end against `samples-java/mysql-dual-conn` relocated to `:3307` with **no** port configuration:

- **Record** — auto-detects and writes 29 `kind: MySQL` mocks with `destAddr: [127.0.0.1]:3307`.
- **Replay** — MySQL container **shut down entirely**, port recalled from mocks, **PASSED**.
- **Negative control** — with `disableMysqlAutoDetect: true` the app never finishes booting (stuck handshake) and records nothing, confirming what the feature actually fixes.

17 unit tests pass under `-race`, including regression tests for the connection leak and the fragmented handshake.

## Links & References

**Closes:** NA

### 🔗 Related PRs
- keploy/docs#894 — documents `mysqlPorts`, the new `disableMysqlAutoDetect`, and adds a troubleshooting entry for the handshake symptom.
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [x] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [x] 👍 yes

`java_linux.yml` → `mysql_auto_port`, reusing the `mysql-dual-conn` sample relocated to `:3307` by the script (no samples-repo change needed). It asserts the detection log, `kind: MySQL` mocks, the recorded `destAddr` port, the replay-side recall log, and `status: PASSED` with MySQL down. Guards against passing vacuously by checking `3307` is in neither `defaultMysqlPorts` nor the generated config.

The cross-version cells self-skip via a capability probe — the feature needs detection at record time **and** mock-derived recall at replay time, so a mixed-version pair cannot exercise it. The both-from-source cell sets `REQUIRE_MYSQL_AUTO_DETECT=true` so it errors instead of skipping.

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 📜 README.md

Documented in `keploy/docs` (linked above) — config reference plus a troubleshooting entry. The in-tree config template and Go doc comments also explain the behaviour.
