### PR TITLE
fix(proxy): bound three unbounded process-lifetime caches

### DIFF
--- a/pkg/agent/proxy/dns.go
+++ b/pkg/agent/proxy/dns.go
@@ -82,6 +82,18 @@ const (
 	// recordedDNSMocksTTL is the TTL for recorded DNS mock entries.
 	// Recording sessions typically don't last longer than this.
 	recordedDNSMocksTTL = 30 * time.Minute
+
+	// nodataRelayLogMaxSize / nodataRelayLogTTL bound the "relayed NODATA"
+	// log-dedupe tracker. Deliberately the same shape and numbers as
+	// recordedDNSMocks: identical key space (the generateCacheKey
+	// (name, qtype) pair, which is app-controlled and therefore unbounded —
+	// per-request hostnames and search-domain permutations mint a fresh key
+	// every time) and identical lifetime expectations. Re-logging a line
+	// after eviction or expiry is harmless — this tracker only suppresses
+	// duplicate log output, it carries no replay state — so the bound has
+	// no correctness cost.
+	nodataRelayLogMaxSize = 1024
+	nodataRelayLogTTL     = 30 * time.Minute
 )
 
 // newDNSCache creates a new thread-safe, size-bounded, TTL-expiring DNS cache.
@@ -119,6 +131,35 @@ func shouldCacheDNSResponse(mode models.Mode, resp dnsCacheEntry) bool {
 // newRecordedDNSMocksCache creates a bounded, TTL-expiring cache for DNS mock deduplication.
 func newRecordedDNSMocksCache() *expirable.LRU[string, bool] {
 	return expirable.NewLRU[string, bool](recordedDNSMocksMaxSize, nil, recordedDNSMocksTTL)
+}
+
+// newNodataRelayLogCache creates the bounded, TTL-expiring tracker that dedupes
+// the "relayed NODATA" Info log to once per (name, qtype).
+func newNodataRelayLogCache() *expirable.LRU[string, bool] {
+	return expirable.NewLRU[string, bool](nodataRelayLogMaxSize, nil, nodataRelayLogTTL)
+}
+
+// shouldLogNodataRelay reports whether the "relayed NODATA" Info line has not
+// yet been emitted for this (name, qtype), recording it as emitted when it
+// returns true.
+//
+// Non-atomic Get-then-Add on purpose: this is a log-dedupe, so the worst a
+// concurrent race can do is print the same line twice. It mirrors the
+// recordedDNSMocks dedupe a few hundred lines below.
+//
+// Nil-tolerant because the tracker is one optional field on a large struct: a
+// construction path that forgets it should lose deduplication, not take the
+// DNS server down mid-resolution. (It also keeps the bare &Proxy{} literals in
+// this package's tests exercising the surrounding DNS logic.)
+func (p *Proxy) shouldLogNodataRelay(key string) bool {
+	if p.nodataRelayLogged == nil {
+		return true
+	}
+	if _, dup := p.nodataRelayLogged.Get(key); dup {
+		return false
+	}
+	p.nodataRelayLogged.Add(key, true)
+	return true
 }
 
 func generateCacheKey(name string, qtype uint16) string {
@@ -292,7 +333,7 @@ func (p *Proxy) resolveUncachedDNSResponse(question dns.Question, mode models.Mo
 				//     record of this type also relays empty here) but dedupe to
 				//     once per (name,qtype) so the signal survives without the spam.
 				if mockingEnabled {
-					if _, dup := p.nodataRelayLogged.LoadOrStore(generateCacheKey(question.Name, question.Qtype), struct{}{}); !dup {
+					if p.shouldLogNodataRelay(generateCacheKey(question.Name, question.Qtype)) {
 						p.logger.Info("DNS mock miss: upstream NODATA (empty NOERROR), relaying as valid negative answer (a genuinely unrecorded record of this type would also relay empty here)",
 							zap.String("query", question.Name),
 							zap.String("qtype", dns.TypeToString[question.Qtype]))

--- a/pkg/agent/proxy/dns_test.go
+++ b/pkg/agent/proxy/dns_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -256,4 +257,119 @@ func TestDNSCacheLifecycle_DedupeStillCatchesDuplicates(t *testing.T) {
 			t.Fatalf("dedupe cache must consistently signal a duplicate (iter=%d)", i)
 		}
 	}
+}
+
+// TestShouldLogNodataRelay_DedupesPerNameAndQtype locks in the behaviour the
+// tracker exists for: the "relayed NODATA" Info line is emitted once per
+// (name, qtype) and suppressed thereafter.
+func TestShouldLogNodataRelay_DedupesPerNameAndQtype(t *testing.T) {
+	p := &Proxy{logger: zap.NewNop(), nodataRelayLogged: newNodataRelayLogCache()}
+
+	keyA := generateCacheKey("payments.svc.cluster.local", dns.TypeAAAA)
+	keyB := generateCacheKey("payments.svc.cluster.local", dns.TypeA)
+
+	if !p.shouldLogNodataRelay(keyA) {
+		t.Fatal("first sighting of a (name,qtype) must log")
+	}
+	if p.shouldLogNodataRelay(keyA) {
+		t.Error("second sighting of the same (name,qtype) must be suppressed")
+	}
+	if !p.shouldLogNodataRelay(keyB) {
+		t.Error("a different qtype for the same name is a different key and must log")
+	}
+}
+
+// TestShouldLogNodataRelay_IsBounded is the retention contract. The key is
+// (name, qtype) and the name is chosen by the application under test — a
+// client resolving per-request hostnames, or a k8s search-domain/ndots setup
+// fanning one lookup into many qualified names, mints keys without limit. The
+// tracker only suppresses duplicate log output, so capping it is free; letting
+// it grow costs the agent memory for its entire lifetime.
+func TestShouldLogNodataRelay_IsBounded(t *testing.T) {
+	p := &Proxy{logger: zap.NewNop(), nodataRelayLogged: newNodataRelayLogCache()}
+
+	const distinct = nodataRelayLogMaxSize + 500
+	for i := 0; i < distinct; i++ {
+		p.shouldLogNodataRelay(generateCacheKey(fmt.Sprintf("req-%d.tenant.example", i), dns.TypeA))
+	}
+
+	if got := p.nodataRelayLogged.Len(); got > nodataRelayLogMaxSize {
+		t.Errorf("nodataRelayLogged holds %d entries after %d distinct names, must never exceed the %d cap: the tracker is following its input, not bounding it",
+			got, distinct, nodataRelayLogMaxSize)
+	}
+}
+
+// TestShouldLogNodataRelay_NilTrackerNeverPanics covers the many unit tests
+// (and any future caller) that build a bare &Proxy{} literal: an uninitialised
+// tracker must degrade to "never dedupe", not crash the DNS server.
+func TestShouldLogNodataRelay_NilTrackerNeverPanics(t *testing.T) {
+	p := &Proxy{logger: zap.NewNop()}
+	key := generateCacheKey("bare.proxy.literal", dns.TypeA)
+	if !p.shouldLogNodataRelay(key) || !p.shouldLogNodataRelay(key) {
+		t.Error("a nil tracker must report every sighting as loggable")
+	}
+}
+
+// TestResetRecordedDNSMocks_ClearsBothTrackers pins the session boundary. Both
+// DNS dedupe trackers are per-session state: carrying them across a
+// record/replay session boundary silently suppresses the current session's
+// first-sighting signals.
+func TestResetRecordedDNSMocks_ClearsBothTrackers(t *testing.T) {
+	p := &Proxy{
+		logger:            zap.NewNop(),
+		recordedDNSMocks:  newRecordedDNSMocksCache(),
+		nodataRelayLogged: newNodataRelayLogCache(),
+	}
+
+	key := generateCacheKey("carryover.example", dns.TypeA)
+	p.recordedDNSMocks.Add(key, true)
+	if !p.shouldLogNodataRelay(key) {
+		t.Fatal("first sighting must log")
+	}
+
+	p.ResetRecordedDNSMocks()
+
+	if p.recordedDNSMocks.Len() != 0 {
+		t.Errorf("recordedDNSMocks still holds %d entries after reset", p.recordedDNSMocks.Len())
+	}
+	if p.nodataRelayLogged.Len() != 0 {
+		t.Errorf("nodataRelayLogged still holds %d entries after reset", p.nodataRelayLogged.Len())
+	}
+	if !p.shouldLogNodataRelay(key) {
+		t.Error("after a session reset the same (name,qtype) must log again")
+	}
+}
+
+// TestResetRecordedDNSMocks_PurgesInPlace guards against reintroducing a
+// goroutine + heap leak that is worse than the retention this file fixes.
+//
+// expirable.NewLRU with a non-zero TTL starts a janitor goroutine whose done
+// channel is never closed, and that goroutine captures the cache. Allocating a
+// replacement tracker on every reset would therefore strand one goroutine per
+// reset and pin every discarded entry beyond the reach of the GC. The reset
+// must clear the existing trackers, not swap in new ones — which also keeps
+// the pointer stable for the DNS handler goroutines reading it concurrently.
+func TestResetRecordedDNSMocks_PurgesInPlace(t *testing.T) {
+	p := &Proxy{
+		logger:            zap.NewNop(),
+		recordedDNSMocks:  newRecordedDNSMocksCache(),
+		nodataRelayLogged: newNodataRelayLogCache(),
+	}
+	beforeMocks, beforeNodata := p.recordedDNSMocks, p.nodataRelayLogged
+
+	p.ResetRecordedDNSMocks()
+
+	if p.recordedDNSMocks != beforeMocks {
+		t.Error("recordedDNSMocks was reallocated: the discarded cache and its janitor goroutine leak for the process lifetime")
+	}
+	if p.nodataRelayLogged != beforeNodata {
+		t.Error("nodataRelayLogged was reallocated: the discarded cache and its janitor goroutine leak for the process lifetime")
+	}
+}
+
+// TestResetRecordedDNSMocks_NilTrackersNeverPanic covers the bare &Proxy{}
+// literals: a reset on an uninitialised proxy must be a no-op, not a crash.
+func TestResetRecordedDNSMocks_NilTrackersNeverPanic(t *testing.T) {
+	p := &Proxy{logger: zap.NewNop()}
+	p.ResetRecordedDNSMocks()
 }

--- a/pkg/agent/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match.go
@@ -7,8 +7,8 @@ import (
 	"io"
 	"reflect"
 	"strings"
-	"sync"
 
+	lru "github.com/hashicorp/golang-lru/v2"
 	"go.keploy.io/server/v3/pkg"
 	"go.keploy.io/server/v3/pkg/agent/proxy/integrations"
 	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/wire"
@@ -21,7 +21,42 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 )
 
-var querySigCache sync.Map // map[string]string
+// querySigCacheSize bounds querySigCache.
+//
+// The cache is keyed by the RAW SQL text, and that key space is NOT finite:
+// a client that inlines literals (`... WHERE id = 91827`) mints a brand new
+// key for every request, so a sync.Map here grows for as long as the agent
+// runs. The value, by contrast, is a pure memo — getQueryStructure builds a
+// fresh parser, parses, and joins the AST node type names, with no package or
+// closure state — so evicting an entry only costs one re-parse and can never
+// change a match verdict.
+//
+// Entry cost, measured against the pinned vitess: the signature runs 3-13x the
+// length of the SQL text (it is the joined reflect type name of every AST
+// node), so a realistic entry is 0.5-1.8 KB and this cap is a few MB. Multi-KB
+// ORM statements cost proportionally more; the cap is on entries, not bytes.
+const querySigCacheSize = 2048
+
+var querySigCache = newQuerySigCache()
+
+// newQuerySigCache builds the memo as a 2Q cache rather than a plain LRU.
+// matchCommand rescans the entire candidate mock pool for every live command
+// and looks up the live query's signature once per candidate, so a pool with
+// more distinct SQL texts than the cap would evict the live query between
+// candidates under plain-LRU recency and re-parse it N times per command —
+// strictly worse than the unbounded map this replaces. 2Q keeps the
+// repeatedly-touched live query in its frequent list while the once-touched
+// candidates churn through the smaller recent list.
+func newQuerySigCache() *lru.TwoQueueCache[string, string] {
+	c, err := lru.New2Q[string, string](querySigCacheSize)
+	if err != nil {
+		// New2Q only errors on a non-positive size and querySigCacheSize is a
+		// const > 0, so this is unreachable — but fail loudly rather than
+		// leave a nil cache that panics on the first match.
+		panic(fmt.Sprintf("mysql replayer: invalid querySigCacheSize %d: %v", querySigCacheSize, err))
+	}
+	return c
+}
 
 // recorded PREP registry per recorded connection
 type prepEntry struct { // minimal, enough for lookup
@@ -50,12 +85,12 @@ func hasPrefixFold(s, p string) bool {
 }
 
 func getQueryStructureCached(sql string) (string, error) {
-	if v, ok := querySigCache.Load(sql); ok {
-		return v.(string), nil
+	if v, ok := querySigCache.Get(sql); ok {
+		return v, nil
 	}
 	sig, err := getQueryStructure(sql)
 	if err == nil {
-		querySigCache.Store(sql, sig)
+		querySigCache.Add(sql, sig)
 	}
 	return sig, err
 }

--- a/pkg/agent/proxy/integrations/mysql/replayer/match_test.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match_test.go
@@ -1,0 +1,111 @@
+package replayer
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestQuerySigCacheIsBounded pins the retention contract on querySigCache.
+//
+// The cache key is the raw SQL text. A client that inlines literals mints a
+// fresh key on every request, so an unbounded map here grows for as long as
+// the agent process lives. The cache must therefore cap out instead of
+// tracking the number of distinct inputs.
+func TestQuerySigCacheIsBounded(t *testing.T) {
+	querySigCache.Purge()
+	t.Cleanup(querySigCache.Purge)
+
+	// Every query below is a distinct string only because of the inlined
+	// literal — exactly the shape that makes the key space infinite.
+	const distinct = querySigCacheSize + 500
+	for i := 0; i < distinct; i++ {
+		if _, err := getQueryStructureCached(fmt.Sprintf("SELECT name FROM users WHERE id = %d", i)); err != nil {
+			t.Fatalf("getQueryStructureCached(%d) returned an error: %v", i, err)
+		}
+	}
+
+	if got := querySigCache.Len(); got > querySigCacheSize {
+		t.Errorf("querySigCache holds %d entries after %d distinct queries, must never exceed the %d cap: the cache is tracking its input, not bounding it",
+			got, distinct, querySigCacheSize)
+	}
+}
+
+// TestQuerySigCacheSurvivesPoolScan pins the reason the memo is a 2Q cache and
+// not a plain LRU. matchCommand rescans the whole candidate mock pool for each
+// live command and looks the live query's signature up once per candidate. A
+// pool holding more distinct SQL texts than the cap would, under plain-LRU
+// recency, evict the live query between candidates and re-parse it on every
+// iteration — strictly worse than the unbounded map this replaced. The
+// repeatedly-touched query must survive a scan larger than the whole cache.
+func TestQuerySigCacheSurvivesPoolScan(t *testing.T) {
+	querySigCache.Purge()
+	t.Cleanup(querySigCache.Purge)
+
+	const liveQuery = "SELECT name FROM users WHERE id = 4242"
+
+	// Two touches: 2Q promotes on the second access, which is what the
+	// per-candidate lookups in a real pool scan provide.
+	for i := 0; i < 2; i++ {
+		if _, err := getQueryStructureCached(liveQuery); err != nil {
+			t.Fatalf("warming the live query returned an error: %v", err)
+		}
+	}
+
+	// Scan a candidate pool twice the size of the cache.
+	for i := 0; i < querySigCacheSize*2; i++ {
+		if _, err := getQueryStructureCached(fmt.Sprintf("SELECT total FROM orders WHERE customer = %d", i)); err != nil {
+			t.Fatalf("scanning candidate %d returned an error: %v", i, err)
+		}
+	}
+
+	if !querySigCache.Contains(liveQuery) {
+		t.Error("the live query was evicted by a candidate-pool scan: every candidate now costs a re-parse of the same query")
+	}
+}
+
+// TestQuerySigCacheMemoIsStable guards the other half of the bound: evicting
+// an entry may cost a re-parse but must never change the answer, because
+// getQueryStructure is a pure function of the SQL text. If that stopped
+// holding, bounding the cache would silently change match verdicts.
+func TestQuerySigCacheMemoIsStable(t *testing.T) {
+	querySigCache.Purge()
+	t.Cleanup(querySigCache.Purge)
+
+	const sql = "SELECT name FROM users WHERE id = 7 AND status = 'active'"
+
+	first, err := getQueryStructureCached(sql)
+	if err != nil {
+		t.Fatalf("first call returned an error: %v", err)
+	}
+	cached, err := getQueryStructureCached(sql)
+	if err != nil {
+		t.Fatalf("cached call returned an error: %v", err)
+	}
+	if cached != first {
+		t.Errorf("cached signature %q != first signature %q", cached, first)
+	}
+
+	// Force the entry out the way an eviction would, then recompute.
+	querySigCache.Purge()
+	recomputed, err := getQueryStructureCached(sql)
+	if err != nil {
+		t.Fatalf("post-eviction call returned an error: %v", err)
+	}
+	if recomputed != first {
+		t.Errorf("signature after eviction %q != original %q: eviction is not side-effect free", recomputed, first)
+	}
+}
+
+// TestQuerySigCacheSkipsUnparseableSQL keeps the pre-existing behaviour that a
+// parse failure is not memoized, so a bad key can never occupy a cache slot.
+func TestQuerySigCacheSkipsUnparseableSQL(t *testing.T) {
+	querySigCache.Purge()
+	t.Cleanup(querySigCache.Purge)
+
+	if _, err := getQueryStructureCached("%%% not sql %%%"); err == nil {
+		t.Fatal("expected unparseable SQL to return an error")
+	}
+	if got := querySigCache.Len(); got != 0 {
+		t.Errorf("querySigCache holds %d entries after a parse failure, want 0", got)
+	}
+}

--- a/pkg/agent/proxy/integrations/mysql/replayer/schema_noise.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/schema_noise.go
@@ -3,10 +3,11 @@ package replayer
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
-	"sync"
 
+	lru "github.com/hashicorp/golang-lru/v2"
 	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/schemanoise"
 	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/util"
 	"go.keploy.io/server/v3/pkg/matcher"
@@ -173,21 +174,40 @@ type queryShape struct {
 	ok       bool
 }
 
+// queryShapeCacheSize bounds queryShapeCache. Same reasoning as match.go's
+// querySigCacheSize: the key is the raw SQL text (unbounded once a client
+// inlines literals) while the value is a pure memo of a deterministic parse,
+// so an eviction costs one re-parse and can never change a match verdict. Kept
+// equal to querySigCacheSize because both caches are fed from exactly the same
+// SQL texts on the same code paths.
+const queryShapeCacheSize = querySigCacheSize
+
 // queryShapeCache memoizes extractQueryShape per SQL text — the same query is
 // re-canonicalized for every candidate mock during a pool scan, and mock-side
-// texts repeat across commands. Sibling of match.go's querySigCache.
-var queryShapeCache sync.Map // map[string]*queryShape
+// texts repeat across commands. Sibling of match.go's querySigCache, 2Q for
+// the same scan-resistance reason documented on newQuerySigCache.
+var queryShapeCache = newQueryShapeCache()
+
+func newQueryShapeCache() *lru.TwoQueueCache[string, *queryShape] {
+	c, err := lru.New2Q[string, *queryShape](queryShapeCacheSize)
+	if err != nil {
+		// Unreachable: New2Q only errors on a non-positive size. Fail loudly
+		// rather than leave a nil cache that panics on the first lookup.
+		panic(fmt.Sprintf("mysql replayer: invalid queryShapeCacheSize %d: %v", queryShapeCacheSize, err))
+	}
+	return c
+}
 
 // extractQueryShape parses sql with the vitess parser (the one the matcher
 // already uses for AST-structure signatures) and splits it into template +
 // literals + comments — the MySQL equivalent of the "give it a query, get its
 // fields" helper the Postgres integration uses. Results are memoized.
 func extractQueryShape(sql string) *queryShape {
-	if v, ok := queryShapeCache.Load(sql); ok {
-		return v.(*queryShape)
+	if v, ok := queryShapeCache.Get(sql); ok {
+		return v
 	}
 	shape := computeQueryShape(sql)
-	queryShapeCache.Store(sql, shape)
+	queryShapeCache.Add(sql, shape)
 	return shape
 }
 

--- a/pkg/agent/proxy/integrations/mysql/replayer/schema_noise_test.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/schema_noise_test.go
@@ -3,6 +3,7 @@ package replayer
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -579,4 +580,56 @@ func TestMatchCommand_TraceCommentDrift(t *testing.T) {
 			t.Fatalf("strict must serve when only the noised comment drifts (ok=%v err=%v)", ok, err)
 		}
 	})
+}
+
+// TestQueryShapeCacheIsBounded pins the retention contract on queryShapeCache.
+// Same reasoning as match_test.go's TestQuerySigCacheIsBounded: the key is the
+// raw SQL text, so a client that inlines literals mints an unbounded number of
+// keys and the cache must cap out rather than track its input.
+func TestQueryShapeCacheIsBounded(t *testing.T) {
+	queryShapeCache.Purge()
+	t.Cleanup(queryShapeCache.Purge)
+
+	const distinct = queryShapeCacheSize + 500
+	for i := 0; i < distinct; i++ {
+		extractQueryShape(fmt.Sprintf("SELECT name FROM users WHERE id = %d", i))
+	}
+
+	if got := queryShapeCache.Len(); got > queryShapeCacheSize {
+		t.Errorf("queryShapeCache holds %d entries after %d distinct queries, must never exceed the %d cap: the cache is tracking its input, not bounding it",
+			got, distinct, queryShapeCacheSize)
+	}
+}
+
+// TestQueryShapeCacheMemoIsStable proves eviction is safe: computeQueryShape is
+// a pure function of the SQL text, so a purged entry recomputes identically.
+// Without that property, bounding the cache could change drift verdicts.
+func TestQueryShapeCacheMemoIsStable(t *testing.T) {
+	queryShapeCache.Purge()
+	t.Cleanup(queryShapeCache.Purge)
+
+	const sql = "SELECT customer FROM orders WHERE amount > 50 AND region = 'apac'"
+
+	first := extractQueryShape(sql)
+	if !first.ok {
+		t.Fatal("expected parseable SQL")
+	}
+
+	queryShapeCache.Purge()
+	recomputed := extractQueryShape(sql)
+	if !recomputed.ok {
+		t.Fatal("expected parseable SQL after eviction")
+	}
+	if recomputed.template != first.template || recomputed.comments != first.comments {
+		t.Errorf("shape after eviction differs: template %q vs %q, comments %q vs %q",
+			recomputed.template, first.template, recomputed.comments, first.comments)
+	}
+	if len(recomputed.literals) != len(first.literals) {
+		t.Fatalf("literals after eviction = %v, want %v", recomputed.literals, first.literals)
+	}
+	for i := range first.literals {
+		if recomputed.literals[i] != first.literals[i] {
+			t.Errorf("literals[%d] after eviction = %q, want %q", i, recomputed.literals[i], first.literals[i])
+		}
+	}
 }

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -199,7 +199,13 @@ type Proxy struct {
 	// (name,qtype): glibc fires A+AAAA for essentially every hostname and every
 	// IPv4-only cluster service yields an AAAA NODATA here, so an un-deduped
 	// Info line would run on almost every resolution. See resolveUncachedDNSResponse.
-	nodataRelayLogged sync.Map // map[string]struct{} keyed by generateCacheKey
+	//
+	// Bounded + TTL-expiring (not a sync.Map): the key is app-controlled, so a
+	// client that resolves per-request hostnames — or a k8s search-domain setup
+	// fanning one lookup into many qualified names — would otherwise grow this
+	// forever in a long-lived agent. Allocated once in New and purged, never
+	// replaced, by ResetRecordedDNSMocks.
+	nodataRelayLogged *expirable.LRU[string, bool] // keyed by generateCacheKey
 
 	//to store the nsswitch.conf file data
 	nsSwitchMutex             sync.Mutex
@@ -690,6 +696,7 @@ func New(logger *zap.Logger, info agent.DestInfo, opts *config.Config) *Proxy {
 		caJavaHome:                opts.Agent.CAJavaHome,
 		dnsCache:                  newDNSCache(),
 		recordedDNSMocks:          newRecordedDNSMocksCache(),
+		nodataRelayLogged:         newNodataRelayLogCache(),
 		mysqlPorts:                newMysqlPortRegistry(),
 		// dnsForwardTimeout is the per-forward deadline for upstream DNS
 		// exchanges. 2 s is long enough to absorb a single UDP retransmit
@@ -858,12 +865,27 @@ func (p *Proxy) GetIntegrations() map[integrations.IntegrationType]integrations.
 	return result
 }
 
-// ResetRecordedDNSMocks clears the DNS mock deduplication tracker.
-// This should be called when starting a new recording session to ensure
-// DNS mocks are recorded fresh for the new session.
+// ResetRecordedDNSMocks clears the per-session DNS deduplication trackers.
+// This should be called when starting a new recording session so DNS mocks are
+// recorded fresh, and so the once-per-(name,qtype) NODATA relay notice is
+// re-surfaced for the new session instead of being suppressed by state left
+// over from the previous one.
+//
+// Purges in place rather than reallocating. expirable.NewLRU with a non-zero
+// TTL starts a janitor goroutine whose done channel is never closed (see the
+// note in hashicorp/golang-lru v2's expirable_lru.go), and that goroutine
+// captures the cache — so every replacement cache would strand a goroutine
+// AND pin the discarded entries beyond the reach of the GC. Purge keeps both
+// trackers at one allocation for the process lifetime, and avoids swapping a
+// pointer that the DNS handler goroutines read concurrently.
 func (p *Proxy) ResetRecordedDNSMocks() {
-	p.recordedDNSMocks = newRecordedDNSMocksCache()
-	p.logger.Debug("DNS mock deduplication tracker reset")
+	if p.recordedDNSMocks != nil {
+		p.recordedDNSMocks.Purge()
+	}
+	if p.nodataRelayLogged != nil {
+		p.nodataRelayLogged.Purge()
+	}
+	p.logger.Debug("DNS deduplication trackers reset")
 }
 
 // SetGracefulShutdown sets the graceful shutdown flag to indicate the application is shutting down


### PR DESCRIPTION
## What

Three caches grew for the lifetime of the agent process because their key space is chosen by the **application under test**, not by the recording. In a long-lived DaemonSet agent that means they never stop growing.

| Cache | Key | Why unbounded |
|---|---|---|
| `querySigCache` (`mysql/replayer/match.go`) | raw SQL text | a client that inlines literals (`... WHERE id = 91827`) mints a new key per request |
| `queryShapeCache` (`mysql/replayer/schema_noise.go`) | raw SQL text | same |
| `Proxy.nodataRelayLogged` (`agent/proxy/dns.go`) | `(dns name, qtype)` | per-request hostnames + k8s search-domain expansion mint keys without limit |

## How

**The two MySQL memos → bounded 2Q caches (2048).** Both values are pure memos of a deterministic vitess parse — fresh parser, no package or closure state — so an eviction costs one re-parse and can never change a match verdict. (`getQueryStructure` and `computeQueryShape` were both re-read to confirm this; neither result is used as an identity or consumption token, only compared for equality.)

2Q rather than plain LRU because `matchCommand` rescans the whole candidate mock pool per live command and looks the live query's signature up *once per candidate*. Under plain-LRU recency, a pool holding more distinct SQL texts than the cap would evict the live query between candidates and re-parse it N times per command — strictly worse than the unbounded map this replaces. 2Q keeps the repeatedly-touched query in its frequent list while the once-touched candidates churn through the recent list. `TestQuerySigCacheSurvivesPoolScan` pins exactly this.

**The DNS log-dedupe → the bounded, TTL-expiring LRU its sibling already uses.** `recordedDNSMocks`, in the same file, was already `expirable.LRU` at 1024 entries / 30 min; `nodataRelayLogged` was a bare `sync.Map`. Same key space, same lifetime, and re-logging a line after eviction is harmless because the tracker only suppresses duplicate output.

`ResetRecordedDNSMocks` now clears both trackers, and **purges in place rather than reallocating**. `expirable.NewLRU` with a non-zero TTL starts a janitor goroutine whose `done` channel is never closed (the library says so in a comment), and that goroutine captures the cache — so a replacement would strand a goroutine *and* pin the discarded entries beyond the reach of the GC. Purging also avoids swapping a pointer that the DNS handler goroutines read concurrently. This matches the existing `p.dnsCache.Purge()` pattern elsewhere in `proxy.go`.

## Sizing

- **2048** for the SQL memos. Measured against the pinned vitess, a signature runs **3-13x** the length of the query text (it is the joined `reflect` type name of every AST node), so a realistic entry is 0.5-1.8 KB and the cap is a few MB.
- **1024 entries / 30 min** for the DNS tracker — reuses the sibling's existing constants.

## Testing

New unit tests in `match_test.go`, `schema_noise_test.go` and `dns_test.go` (one test file per source file, per repo convention). Every bound and cleanup was **mutation-tested** — removed, confirmed a test goes red, restored:

| Mutation | Test that caught it |
|---|---|
| `querySigCache` unbounded | `TestQuerySigCacheIsBounded` |
| `queryShapeCache` unbounded | `TestQueryShapeCacheIsBounded` |
| plain LRU instead of 2Q | `TestQuerySigCacheSurvivesPoolScan` |
| `nodataRelayLogged` unbounded | `TestShouldLogNodataRelay_IsBounded` |
| reset stops clearing the tracker | `TestResetRecordedDNSMocks_ClearsBothTrackers` |
| reset reallocates instead of purging | `TestResetRecordedDNSMocks_PurgesInPlace` |
| dedupe stops suppressing | `TestShouldLogNodataRelay_DedupesPerNameAndQtype` |

`go build ./...`, `go vet ./...`, `gofmt -l .`, `go test ./... -count=1` all clean, plus `-race` on `pkg/agent/proxy`, `pkg/agent/proxy/integrations/mysql/replayer` and `pkg/matcher`.

## Notes / non-changes

- **`pkg/matcher/utils.go`'s `regexCache` was investigated and deliberately left alone.** It is keyed by regex *pattern*, and every pattern reaches it from a test case's `Noise` map (parsed from the recorded YAML) or an async lane's `pathRegex` config. That key space is finite by construction, so it is a bounded memo, not a leak.
- `recordedDNSMocks` is only ever consulted under `case models.MODE_RECORD`, so none of this changes replay behaviour.