### PR TITLE
fix: stop shipping test cases whose mocks were never captured

### DIFF
--- a/pkg/agent/proxy/proxy_v2.go
+++ b/pkg/agent/proxy/proxy_v2.go
@@ -9,6 +9,8 @@ import (
 	"net"
 	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.keploy.io/server/v3/pkg/agent/proxy/directive"
@@ -23,6 +25,79 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 )
+
+const (
+	// orphanIdleGrace is how long a retired connection must carry no bytes
+	// before its suppression window is closed. Longer than any plausible
+	// gap WITHIN one app request (the window must never close mid-request
+	// and let a half-covered test case through), short enough that a
+	// connection idling between bursts stops suppressing quickly.
+	orphanIdleGrace = 1 * time.Second
+
+	// orphanIdleCheck is how often idleness is re-evaluated. The window can
+	// therefore over-cover by up to orphanIdleCheck past the true idle
+	// point, which errs toward suppressing — the safe direction.
+	orphanIdleCheck = 250 * time.Millisecond
+)
+
+// orphanWindowOpener is the slice of supervisor.Session that trackOrphanWhileActive
+// needs, so the loop can be tested without a live connection.
+type orphanWindowOpener interface {
+	OpenOrphanWindow(start time.Time) func()
+}
+
+// trackOrphanWhileActive keeps a suppression window open only while a retired
+// connection is actually carrying bytes, and closes it whenever the connection
+// falls idle.
+//
+// A retired connection can no longer be captured, but that only costs a test
+// case if the app USED it while serving that test case. A single window held
+// from the fallthrough to end-of-session says "everything after this point is
+// unreliable", which for a connection that then sat idle for ten minutes
+// throws away ten minutes of perfectly good recording — and on a fallthrough
+// early in a run, the entire run. Following activity instead suppresses the
+// spans that can really have lost a mock and nothing else.
+//
+// It always returns with its window closed. stop must be closed by the caller
+// once the connection has ended.
+// idleGrace and checkEvery are parameters rather than the package constants
+// so the loop is testable in milliseconds; production passes
+// orphanIdleGrace / orphanIdleCheck.
+func trackOrphanWhileActive(stop <-chan struct{}, sess orphanWindowOpener, lastForwardNanos *atomic.Int64, idleGrace, checkEvery time.Duration) {
+	closeWindow := sess.OpenOrphanWindow(time.Now())
+	defer func() {
+		if closeWindow != nil {
+			closeWindow()
+		}
+	}()
+
+	ticker := time.NewTicker(checkEvery)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-stop:
+			return
+		case now := <-ticker.C:
+			idle := now.Sub(time.Unix(0, lastForwardNanos.Load())) > idleGrace
+			switch {
+			case idle && closeWindow != nil:
+				closeWindow()
+				closeWindow = nil
+			case !idle && closeWindow == nil:
+				// Traffic resumed on a connection that still cannot be
+				// captured. Reopen from the RESUME instant, not from now:
+				// the tick only tells us traffic happened at some point in
+				// the last checkEvery, and bytes moved from
+				// lastForwardNanos onwards. Opening at `now` would leave up
+				// to checkEvery of live traffic uncovered, and a request
+				// served entirely inside that hole is exactly the
+				// mock-less test case this exists to catch.
+				closeWindow = sess.OpenOrphanWindow(time.Unix(0, lastForwardNanos.Load()))
+			}
+		}
+	}
+}
 
 // newRelayDisabled reports whether the new supervisor+relay architecture
 // is disabled via environment. Set KEPLOY_NEW_RELAY to 0/false/off/no to
@@ -163,13 +238,61 @@ func (p *Proxy) recordViaSupervisor(
 		realCertHook = p.cbshim.RegisterReal
 	}
 
+	// lastForwardNanos is when this connection last moved a byte in either
+	// direction, stamped by the wrapped BumpActivity below. Read by the
+	// activity-scoped suppression loop.
+	var lastForwardNanos atomic.Int64
+	lastForwardNanos.Store(time.Now().UnixNano())
+
+	// ONE suppression tracker per connection, started by whichever cause
+	// fires first and stopped when the connection ends.
+	//
+	// Both causes — a tee desync and a retired parser — leave the connection
+	// in the same state: it can no longer be captured. So they share one
+	// activity-scoped window rather than opening two. They are also not
+	// independent: the incident's chain was memory-pressure drop → parser
+	// starves mid-frame → hang watchdog → passthrough fallthrough, so the
+	// DESYNC fires first. Giving it a plain open-ended window of its own
+	// would subsume the fallthrough's scoped one (WasMockOrphanedInWindow
+	// ORs the ranges) and silently restore the whole-session suppression
+	// this design exists to avoid.
+	var (
+		trackerOnce sync.Once
+		trackerStop = make(chan struct{})
+	)
+	startOrphanTracking := func() {
+		trackerOnce.Do(func() {
+			go trackOrphanWhileActive(trackerStop, svSess, &lastForwardNanos, orphanIdleGrace, orphanIdleCheck)
+		})
+	}
+	// Safe whether or not the tracker ever started — closing a channel with
+	// no reader is a no-op — and it guarantees the goroutine cannot outlive
+	// the connection.
+	defer close(trackerStop)
+
 	r := relay.New(relay.Config{
-		Logger:               logger,
-		TLSUpgradeFn:         newProxyTLSUpgradeFn(logger),
-		BumpActivity:         sv.BumpActivity,
+		Logger:       logger,
+		TLSUpgradeFn: newProxyTLSUpgradeFn(logger),
+		// Wrapped to also stamp when this connection last carried bytes.
+		// After a parser is retired the relay keeps forwarding, so this is
+		// the signal that says WHEN the dead connection was actually in
+		// use — which is what bounds the suppression window below to the
+		// periods that can really have cost a mock.
+		BumpActivity: func() {
+			sv.BumpActivity()
+			lastForwardNanos.Store(time.Now().UnixNano())
+		},
 		OnMarkMockIncomplete: svSess.MarkMockIncomplete,
 		OnClientChunkTeed:    sv.MarkPendingWork,
 		RealCertHook:         realCertHook,
+		// A hole in this connection's capture. Remember when it opened so
+		// the teardown below can mark the whole span: from here on the
+		// parser frames from the wrong offset and emits nothing, so every
+		// test case overlapping the span must be suppressed rather than
+		// shipped mock-less (replay would report match_phase=no_mocks).
+		// Suppression is what closes the failure by construction —
+		// retirement below only restores capture for what follows.
+		OnCaptureDesync: func(string) { startOrphanTracking() },
 		// User-tunable record-buffer caps. Snapshotted onto the Proxy
 		// at startup from config.Record.RecordBuffer (yaml/flag/env).
 		// Zero values fall through to relay package defaults via
@@ -243,11 +366,47 @@ func (p *Proxy) recordViaSupervisor(
 	}, svSess)
 
 	if result.FallthroughToPassthrough {
+		// A cancel that lands after the supervisor's grace period is the
+		// NORMAL way a `keploy record` stop ends a live V2 connection —
+		// the parser is blocked in FakeConn.Read, which observes only
+		// Close and read deadlines, so it cannot return inside the grace.
+		// There is no "rest of the connection" left to lose, so neither
+		// the warning nor the suppression window applies: emitting them
+		// would tell the user their recording is broken at the exact
+		// moment they are reading the logs, on every clean stop.
+		shuttingDown := result.Status == supervisor.StatusCanceled && ctx.Err() != nil
+
+		if !shuttingDown {
+			// Warn, not Debug. This is permanent, silent capture loss for
+			// the rest of a connection's life, and several of the exits
+			// that land here (StatusError, StatusMemCap) log nothing of
+			// their own — so at Debug a whole recording could come back
+			// unreplayable without a single line above Debug to explain
+			// it. Bounded: one line per connection, only on a retired
+			// parser.
+			//
+			// result.Err is deliberately NOT attached here. For
+			// StatusPanicked it reads "supervisor: parser panic: ..."
+			// (wrapPanic), and the memory-load lane scripts grep record.txt
+			// for /panic:|fatal error:/ under `set -Eeuo pipefail` to catch
+			// a CRASHED keploy. A recovered, structured, handled panic is
+			// not a crash, but the token is the token: putting it in an
+			// Info-level line would convert "some tests failed" into "Fatal
+			// error detected in record.txt" and kill the lane before it
+			// reaches its report. Status names the mechanism; the full
+			// error follows at Debug.
+			logger.Warn("parser retired; this connection can no longer be recorded and its test cases will be suppressed",
+				zap.String("parser", string(parserType)),
+				zap.String("status", result.Status.String()),
+				zap.String("clientConnID", svSess.ClientConnID),
+				zap.String("next_step", "user traffic is unaffected — the relay keeps forwarding raw bytes — but no further mock can be captured on this connection, so tests recorded against it are dropped rather than shipped unreplayable. Re-run with --debug for the underlying error. If this repeats, set KEPLOY_NEW_RELAY=off to force the legacy path for this parser, or KEPLOY_DISABLE_PARSING=1 to disable record parsing entirely"),
+			)
+		}
 		logger.Debug("parser supervisor triggered passthrough fallback; relay continues raw forwarding until peer close",
 			zap.String("parser", string(parserType)),
 			zap.String("status", result.Status.String()),
+			zap.Bool("shutting_down", shuttingDown),
 			zap.Error(result.Err),
-			zap.String("next_step", "set KEPLOY_NEW_RELAY=off to force legacy path for this parser, or KEPLOY_DISABLE_PARSING=1 to disable record parsing entirely"),
 		)
 		// Crucial invariant (I1): the relay keeps forwarding client↔dest
 		// bytes end-to-end during the fallback. We do NOT cancel it here
@@ -260,6 +419,34 @@ func (p *Proxy) recordViaSupervisor(
 		// relay's forwarder goroutines continue draining srcConn/dstConn
 		// until either peer closes the connection, which triggers a
 		// normal Run exit.
+		//
+		// That is correct for USER TRAFFIC and wrong for RECORDING, and
+		// until now nothing said so. From this instant the connection
+		// emits no further mock — there is no path anywhere that puts a
+		// parser back on a live connection — while the app keeps issuing
+		// requests over it perfectly happily. On a pooled client the peer
+		// never closes, so "until peer close" means "until shutdown": every
+		// test case recorded from here on is streamed with no mocks behind
+		// it and fails replay with match_phase=no_mocks. Left silent, that
+		// is indistinguishable from a healthy recording until replay.
+		//
+		// So mark the span un-capturable for as long as it lasts. The TC
+		// suppressor in pkg/agent/routes/record.go drops every test case
+		// whose window overlaps it, which is the same coverage-for-honesty
+		// trade the memory-pressure and resync-hole suppressors already
+		// make: a smaller recording in which every test replays, instead of
+		// a larger one that lies.
+		// The tracker goroutine owns its window and closes it on the way
+		// out; `defer close(trackerStop)` at the top of this function is
+		// what stops it, so the close survives a panic here rather than
+		// only the happy path. An orphan window that never closes would
+		// suppress every test case for the REST OF THE SESSION.
+		if !shuttingDown {
+			// Shared with the desync path — see startOrphanTracking. If a
+			// tee already desynced this connection the tracker is running,
+			// and this is a no-op rather than a second window.
+			startOrphanTracking()
+		}
 		<-relayDone
 		return nil
 	}

--- a/pkg/agent/proxy/proxy_v2_test.go
+++ b/pkg/agent/proxy/proxy_v2_test.go
@@ -1,0 +1,172 @@
+package proxy
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeOrphanSession records the open/close calls trackOrphanWhileActive makes.
+type fakeOrphanSession struct {
+	mu     sync.Mutex
+	opens  int
+	closes int
+	// starts records the instant each window claims to begin. Discarding
+	// this argument would hide a window that opens LATER than the traffic
+	// it is meant to cover, which is a silent hole in the suppression.
+	starts []time.Time
+}
+
+func (f *fakeOrphanSession) OpenOrphanWindow(start time.Time) func() {
+	f.mu.Lock()
+	f.opens++
+	f.starts = append(f.starts, start)
+	f.mu.Unlock()
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			f.mu.Lock()
+			f.closes++
+			f.mu.Unlock()
+		})
+	}
+}
+
+func (f *fakeOrphanSession) counts() (opens, closes int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.opens, f.closes
+}
+
+func (f *fakeOrphanSession) lastStart() time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.starts) == 0 {
+		return time.Time{}
+	}
+	return f.starts[len(f.starts)-1]
+}
+
+// bumped stamps "the connection just moved a byte".
+func bumped() *atomic.Int64 {
+	var n atomic.Int64
+	n.Store(time.Now().UnixNano())
+	return &n
+}
+
+// TestTrackOrphanWhileActiveFollowsTraffic pins the scoping that keeps a
+// retired connection from suppressing the whole recording.
+//
+// A connection whose parser was retired can no longer be captured, but that
+// only costs a test case if the app USED it while serving that test case.
+// Holding one window from the fallthrough to end-of-session throws away every
+// later test — on an early fallthrough, the entire run — even though the dead
+// connection may have sat idle throughout. These tests pin that the window
+// tracks activity instead.
+func TestTrackOrphanWhileActiveFollowsTraffic(t *testing.T) {
+	t.Parallel()
+
+	const (
+		grace = 40 * time.Millisecond
+		check = 10 * time.Millisecond
+	)
+
+	t.Run("suppresses immediately, then stops once the connection goes idle", func(t *testing.T) {
+		t.Parallel()
+		sess := &fakeOrphanSession{}
+		stop := make(chan struct{})
+		done := make(chan struct{})
+		go func() { trackOrphanWhileActive(stop, sess, bumped(), grace, check); close(done) }()
+
+		// A window must exist from the outset: the connection is broken now.
+		waitFor(t, time.Second, func() bool { o, _ := sess.counts(); return o == 1 })
+
+		// No traffic from here, so the hole must stop growing.
+		waitFor(t, time.Second, func() bool { _, c := sess.counts(); return c == 1 })
+
+		close(stop)
+		<-done
+		if o, c := sess.counts(); o != c {
+			t.Fatalf("opens=%d closes=%d: every window must be closed on exit, or the "+
+				"leftover one suppresses the rest of the session", o, c)
+		}
+	})
+
+	t.Run("re-suppresses when traffic resumes on the dead connection", func(t *testing.T) {
+		t.Parallel()
+		sess := &fakeOrphanSession{}
+		last := bumped()
+		stop := make(chan struct{})
+		done := make(chan struct{})
+		go func() { trackOrphanWhileActive(stop, sess, last, grace, check); close(done) }()
+
+		// Let it go idle and close the first window.
+		waitFor(t, time.Second, func() bool { _, c := sess.counts(); return c == 1 })
+
+		// The app uses the connection again. It still cannot be captured, so
+		// suppression must resume — otherwise these test cases ship mock-less.
+		resume := time.Now()
+		last.Store(resume.UnixNano())
+		waitFor(t, time.Second, func() bool { o, _ := sess.counts(); return o == 2 })
+
+		// The reopened window must cover the traffic that triggered it. The
+		// tick only observes the resume up to checkEvery late, so opening at
+		// tick time would leave that span uncovered — and a request served
+		// entirely inside it is precisely the mock-less test case this is
+		// meant to suppress.
+		if start := sess.lastStart(); start.After(resume) {
+			t.Fatalf("reopened at %v, after the resume at %v (gap %v): traffic in that gap is "+
+				"left unsuppressed", start, resume, start.Sub(resume))
+		}
+
+		close(stop)
+		<-done
+		if o, c := sess.counts(); o != c {
+			t.Fatalf("opens=%d closes=%d, want equal", o, c)
+		}
+	})
+
+	t.Run("a connection that stays busy is suppressed without interruption", func(t *testing.T) {
+		t.Parallel()
+		sess := &fakeOrphanSession{}
+		last := bumped()
+		stop := make(chan struct{})
+		done := make(chan struct{})
+		go func() { trackOrphanWhileActive(stop, sess, last, grace, check); close(done) }()
+
+		// Keep it hot for several grace periods.
+		deadline := time.Now().Add(6 * grace)
+		for time.Now().Before(deadline) {
+			last.Store(time.Now().UnixNano())
+			time.Sleep(check / 2)
+		}
+
+		if o, c := sess.counts(); o != 1 || c != 0 {
+			t.Fatalf("opens=%d closes=%d, want 1/0: a continuously busy connection must stay "+
+				"covered by ONE window — churning it would leave gaps that let mock-less "+
+				"test cases through", o, c)
+		}
+
+		close(stop)
+		<-done
+		if _, c := sess.counts(); c != 1 {
+			t.Fatalf("closes=%d, want 1 after stop", c)
+		}
+	})
+}
+
+// waitFor polls cond until it holds or the timeout expires. Polling rather than
+// sleeping a fixed span keeps these tests fast when the machine is idle and
+// tolerant when CI is loaded.
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("condition not met within %s", timeout)
+}

--- a/pkg/agent/proxy/relay/config.go
+++ b/pkg/agent/proxy/relay/config.go
@@ -160,6 +160,25 @@ type Config struct {
 	// the supervisor will record in telemetry. Nil is safe.
 	OnMarkMockIncomplete func(reason string)
 
+	// OnCaptureDesync is invoked at most once per direction, the first time
+	// a chunk is dropped on that tee. Nil is safe.
+	//
+	// It is NOT a louder OnMarkMockIncomplete. That one is per-mock and is
+	// cleared by Session.MarkMockComplete after each cycle; this one reports
+	// that the connection's byte stream now has a hole, which no later mock
+	// recovers from. Downstream parsers frame by length prefix, so after a
+	// hole the next header is read mid-body and every subsequent frame on
+	// the connection is garbage — the connection keeps carrying user traffic
+	// perfectly while producing zero further mocks, and the test cases
+	// recorded against it replay as match_phase=no_mocks.
+	//
+	// The expected implementation is to record the start of the hole and,
+	// when the connection ends, mark that whole span so the test cases
+	// overlapping it are suppressed instead of shipped mock-less. That is
+	// the half that closes the failure by construction; retirement (below)
+	// is the best-effort half that gets capture going again.
+	OnCaptureDesync func(reason string)
+
 	// OnClientChunkTeed is invoked after each successful tee of a
 	// client-to-dest chunk into the parser's FakeConn. Callers wire
 	// this to the supervisor's MarkPendingWork so the activity

--- a/pkg/agent/proxy/relay/relay.go
+++ b/pkg/agent/proxy/relay/relay.go
@@ -172,6 +172,11 @@ func New(cfg Config, src, dst net.Conn) *Relay {
 		cfg.Logger,
 	)
 
+	// Assigned after construction rather than threaded through newTee's
+	// positional signature, which is already at seven arguments.
+	r.teeC2D.onDesync = cfg.OnCaptureDesync
+	r.teeD2C.onDesync = cfg.OnCaptureDesync
+
 	var localAddr, remoteAddr net.Addr
 	if src != nil {
 		localAddr = src.LocalAddr()

--- a/pkg/agent/proxy/relay/tee.go
+++ b/pkg/agent/proxy/relay/tee.go
@@ -106,6 +106,23 @@ type tee struct {
 	memCheck func() bool
 	onDrop   func(reason string)
 
+	// onDesync fires exactly once per tee, on the first dropped chunk.
+	// Set by [New] from [Config.OnCaptureDesync]; nil is safe.
+	//
+	// A drop is not a lost mock, it is a lost STREAM POSITION. The parsers
+	// downstream frame a byte stream (mongo, mysql, postgres all read a
+	// length header and then that many bytes), so a hole does not cost one
+	// message — the next header is read from the middle of a body and every
+	// subsequent frame on that connection is garbage. onDrop's per-mock
+	// [Session.MarkMockIncomplete] is therefore not enough: it is cleared by
+	// MarkMockComplete after each cycle, while the damage is permanent and
+	// connection-scoped. This hook exists so the owner can mark the span and
+	// suppress the test cases recorded in it, instead of shipping them
+	// mock-less for replay to fail on.
+	onDesync func(reason string)
+	// desynced makes onDesync and its log fire once, not once per chunk.
+	desynced atomic.Bool
+
 	// mu guards q, qBytes and closed. It is never held across a send on
 	// out, so a stalled consumer cannot block push.
 	mu sync.Mutex
@@ -272,10 +289,50 @@ func (t *tee) push(c fakeconn.Chunk) bool {
 // "incomplete mock" enable --debug to see them, normal runs stay
 // quiet. Subsequent drops still increment drops_total and fire onDrop
 // unchanged — only the log emission is rate-limited.
+// isDesyncingDrop reports whether losing a chunk for this reason leaves the
+// downstream parser stranded mid-frame.
+//
+// The test is "did the capture pipeline lose bytes the parser was going to
+// need", not "was a mock affected". [DropPerConnCap] and
+// [DropMemoryPressure] are both unilateral: the parser is mid-stream and
+// simply never receives those bytes. [DropPaused] is not — see the caller.
+func isDesyncingDrop(reason string) bool {
+	return reason == DropPerConnCap || reason == DropMemoryPressure
+}
+
 func (t *tee) drop(reason string) {
 	n := t.drops.Add(1)
 	if t.onDrop != nil {
 		t.onDrop(reason)
+	}
+	// The first UNINTENDED drop desyncs this connection's capture
+	// permanently — see the onDesync field comment. Report it ONCE at Warn,
+	// not Debug: from here on, every mock this connection would have
+	// produced is silently absent, and a test case recorded against it
+	// replays as match_phase=no_mocks. That is the one thing this package
+	// promises never to do quietly.
+	//
+	// DropPaused is excluded deliberately. A pause is requested by the
+	// parser (to suspend capture while still forwarding) and by
+	// SessionOnAbort, which pauses precisely so teardown chunks take the
+	// cheap drop path — the parser either knows about the gap or the
+	// connection is already ending. Treating that as a desync would fire
+	// this warning on every normal abort and cancel a relay that is already
+	// shutting down.
+	if isDesyncingDrop(reason) && !t.desynced.Swap(true) {
+		if t.logger != nil {
+			next := "a dropped chunk leaves the parser mid-frame, so no further mock can be framed on this connection; test cases recorded against it are suppressed rather than shipped mock-less. If reason=per_conn_cap, raise record.recordBuffer.maxMemoryPerConnection"
+			t.logger.Warn("relay: capture desynced; this connection can no longer be recorded",
+				zap.String("dir", t.dir.String()),
+				zap.String("reason", reason),
+				zap.String("next_step", next),
+			)
+		}
+		// Report the hole so the owner can suppress the test cases that
+		// overlap it, instead of shipping them mock-less.
+		if t.onDesync != nil {
+			t.onDesync(reason)
+		}
 	}
 	if t.logger != nil && n&(n-1) == 0 {
 		// n is a power of two (1, 2, 4, 8, ...) — log this drop.

--- a/pkg/agent/proxy/relay/tee_test.go
+++ b/pkg/agent/proxy/relay/tee_test.go
@@ -741,3 +741,88 @@ func TestNewWiresTheStallGraceIntoBothTees(t *testing.T) {
 		t.Errorf("zero-config stallGrace = %v, want %v", got, DefaultConsumerStallGrace)
 	}
 }
+
+// TestAnUnintendedDropReportsCaptureDesync pins the signal that a connection's
+// capture is finished.
+//
+// This is the guard for a proven production data-loss bug: under memory
+// pressure the agent dropped egress chunks while continuing to record test
+// cases, so a recording ended with test cases that had no mocks at all and
+// replayed as match_phase=no_mocks. The drop was reported only through the
+// per-mock MarkMockIncomplete (cleared after every cycle) and a sampled Debug
+// line, so a whole failing run contained zero errors. What makes it permanent
+// is framing: the parsers read a length prefix and then that many bytes, so a
+// hole means every later frame on the connection is read from the wrong offset.
+// Hence exactly once, on the first unintended drop, and never for a pause.
+func TestAnUnintendedDropReportsCaptureDesync(t *testing.T) {
+	t.Parallel()
+
+	t.Run("memory pressure mid-capture desyncs the connection", func(t *testing.T) {
+		t.Parallel()
+		var desyncs []string
+		pressure := false
+		tt := newTee(fakeconn.FromClient, 1<<20, 4, testStallGrace, func() bool { return pressure }, nil, nil)
+		tt.onDesync = func(reason string) { desyncs = append(desyncs, reason) }
+		t.Cleanup(tt.close)
+
+		// Capture is underway: this is the connection a reconnect can rescue.
+		if !tt.push(fakeconn.Chunk{Bytes: []byte("framed")}) {
+			t.Fatal("first push should have been teed")
+		}
+		pressure = true
+		if tt.push(fakeconn.Chunk{Bytes: []byte("abc")}) {
+			t.Fatal("push should have dropped under memory pressure")
+		}
+		if len(desyncs) != 1 || desyncs[0] != DropMemoryPressure {
+			t.Fatalf("onDesync calls = %v, want exactly [%s]: a lost chunk leaves the parser "+
+				"mid-frame, and nothing else reports that the connection is now uncapturable",
+				desyncs, DropMemoryPressure)
+		}
+
+		// Sustained pressure must not re-report: one connection, one event.
+		for i := 0; i < 5; i++ {
+			tt.push(fakeconn.Chunk{Bytes: []byte("more")})
+		}
+		if len(desyncs) != 1 {
+			t.Errorf("onDesync fired %d times, want 1 — it is per-connection, not per-chunk", len(desyncs))
+		}
+	})
+
+	t.Run("exceeding the per-connection cap desyncs the connection", func(t *testing.T) {
+		t.Parallel()
+		var desyncs []string
+		// Cap admits the first chunk and refuses the second.
+		tt := newTee(fakeconn.FromClient, 8, 4, testStallGrace, nil, nil, nil)
+		tt.onDesync = func(reason string) { desyncs = append(desyncs, reason) }
+		t.Cleanup(tt.close)
+
+		if !tt.push(fakeconn.Chunk{Bytes: []byte("abcd")}) {
+			t.Fatal("first push should have fit under the cap")
+		}
+		if tt.push(fakeconn.Chunk{Bytes: []byte("too long for the cap")}) {
+			t.Fatal("push should have refused a chunk over the cap")
+		}
+		if len(desyncs) != 1 || desyncs[0] != DropPerConnCap {
+			t.Fatalf("onDesync calls = %v, want exactly [%s]: a capped-out chunk is lost to the "+
+				"parser just as surely as a pressure-dropped one", desyncs, DropPerConnCap)
+		}
+	})
+
+	t.Run("a deliberate pause does NOT desync the connection", func(t *testing.T) {
+		t.Parallel()
+		var desyncs []string
+		tt := newTee(fakeconn.FromClient, 1<<20, 4, testStallGrace, nil, nil, nil)
+		tt.onDesync = func(reason string) { desyncs = append(desyncs, reason) }
+		t.Cleanup(tt.close)
+
+		tt.setPaused(true)
+		if tt.push(fakeconn.Chunk{Bytes: []byte("abc")}) {
+			t.Fatal("push should have dropped while paused")
+		}
+		if len(desyncs) != 0 {
+			t.Fatalf("onDesync fired %v on a pause; a pause is requested by the parser or by "+
+				"SessionOnAbort at teardown, so treating it as a desync would warn on every "+
+				"normal abort and cancel a relay that is already shutting down", desyncs)
+		}
+	})
+}

--- a/pkg/agent/proxy/supervisor/session.go
+++ b/pkg/agent/proxy/supervisor/session.go
@@ -265,6 +265,25 @@ func (s *Session) RecordOrphanWindow(start, end time.Time) {
 	mgr.RecordOrphanWindow(start, end)
 }
 
+// OpenOrphanWindow is the open-ended twin of RecordOrphanWindow, for a hole
+// whose end is not yet known. It resolves the manager the same way and returns
+// the closer; see SyncMockManager.OpenOrphanWindow.
+//
+// The caller is the V2 dispatcher on a passthrough fallthrough: once a parser
+// is retired the relay raw-forwards the rest of that connection, so it emits no
+// further mock and every test case recorded against it would otherwise ship
+// mock-less and replay as match_phase=no_mocks.
+func (s *Session) OpenOrphanWindow(start time.Time) func() {
+	if s == nil {
+		return func() {}
+	}
+	mgr := s.Mgr
+	if mgr == nil {
+		mgr = syncMock.Get()
+	}
+	return mgr.OpenOrphanWindow(start)
+}
+
 // EmitMock sends m to the mocks channel. If the session's active mock
 // is marked incomplete, EmitMock returns nil without sending (the mock
 // is dropped on the floor and the incomplete flag is cleared, matching

--- a/pkg/agent/proxy/syncMock/orphan_window_test.go
+++ b/pkg/agent/proxy/syncMock/orphan_window_test.go
@@ -190,3 +190,117 @@ func TestRecordOrphanWindowDoesNotTouchPressureRanges(t *testing.T) {
 		t.Fatalf("expected the orphan window in orphanRanges (got %d), not pressureRanges", len(m.orphanRanges))
 	}
 }
+
+// TestOpenOrphanWindowSuppressesWhileStillOpen covers the hole whose end is not
+// yet known: a connection whose parser was retired, leaving the relay to raw-
+// forward the rest of its life.
+//
+// The open case is the load-bearing one. record.go queries these ranges as each
+// test case is STREAMED, so a hole that is only recorded once its width is known
+// — i.e. when the connection finally closes, which for a pooled connection means
+// at shutdown — arrives long after the mock-less test cases it should have
+// suppressed were already written to disk. This is the exact shape that made a
+// real recording ship 18 unreplayable tests.
+func TestOpenOrphanWindowSuppressesWhileStillOpen(t *testing.T) {
+	t.Parallel()
+
+	m := &SyncMockManager{}
+	// The hole opened in the past: an OPEN interval extends to now, so the
+	// span it covers is [base, now]. Timestamps must sit inside that, the way
+	// a real TC's recorded window does — a future timestamp is outside an
+	// open hole by definition.
+	base := time.Now().Add(-2 * time.Second)
+
+	// A test case recorded BEFORE the hole opens must not be suppressed.
+	before := base.Add(-1 * time.Second)
+	if orphaned, _ := m.WasMockOrphanedInWindow(before, before.Add(time.Millisecond)); orphaned {
+		t.Fatal("a TC recorded before any hole was opened must not be suppressed")
+	}
+
+	closeHole := m.OpenOrphanWindow(base)
+
+	// Still open: a TC recorded since then must be suppressed even though
+	// nothing has told the manager when the hole ends.
+	during := time.Now().Add(-1 * time.Second)
+	if orphaned, n := m.WasMockOrphanedInWindow(during, during.Add(time.Millisecond)); !orphaned || n != 1 {
+		t.Fatalf("orphaned=%v count=%d during an OPEN hole, want true/1: the connection is "+
+			"un-capturable right now, so this TC would be shipped mock-less and fail replay "+
+			"with match_phase=no_mocks", orphaned, n)
+	}
+
+	closeHole()
+
+	// The hole is bounded now: traffic after it is capturable again.
+	//
+	// The sleep is load-bearing, not padding. An OPEN hole's end is "now at
+	// query time", so a timestamp taken only microseconds after the close is
+	// still inside an open interval and this assertion would pass whether or
+	// not the closer did anything — a closer that silently did nothing was a
+	// surviving mutant until this sleep put real distance between the close
+	// instant and the timestamp under test.
+	time.Sleep(20 * time.Millisecond)
+	after := time.Now()
+	if orphaned, _ := m.WasMockOrphanedInWindow(after, after.Add(time.Millisecond)); orphaned {
+		t.Fatal("a TC recorded after the hole closed must not be suppressed — closing must " +
+			"bound the window, or one retired parser silently suppresses the rest of the session")
+	}
+	// And what happened inside it stays suppressed.
+	if orphaned, _ := m.WasMockOrphanedInWindow(during, during.Add(time.Millisecond)); !orphaned {
+		t.Fatal("a TC inside the closed hole must still be suppressed")
+	}
+
+	// Idempotent: a double close must not move the end.
+	closeHole()
+	if orphaned, _ := m.WasMockOrphanedInWindow(during, during.Add(time.Millisecond)); !orphaned {
+		t.Fatal("closing twice changed the recorded window")
+	}
+}
+
+// TestOrphanRangeCountSplitsClosedFromOpen pins the operator-facing counter.
+//
+// The closer stamps r.end in place instead of removing the entry, so counting
+// the slice lengths reports every cleanly-closed window as still open. That
+// number is the ONLY signal that this suppressor fired at all, and a
+// still-open window is the one that keeps suppressing to the end of the
+// session — so getting the split backwards actively misleads.
+func TestOrphanRangeCountSplitsClosedFromOpen(t *testing.T) {
+	t.Parallel()
+
+	m := &SyncMockManager{}
+	base := time.Now().Add(-time.Minute)
+
+	closeA := m.OpenOrphanWindow(base)
+	m.OpenOrphanWindow(base.Add(time.Second)) // deliberately left open
+	closeA()
+
+	// A conventional bounded hole (the mongo resync path) lands elsewhere and
+	// must still be counted as closed.
+	m.RecordOrphanWindow(base.Add(2*time.Second), base.Add(3*time.Second))
+
+	if closed, open := m.OrphanRangeCount(); closed != 2 || open != 1 {
+		t.Fatalf("OrphanRangeCount() = (closed=%d, open=%d), want (2, 1)", closed, open)
+	}
+}
+
+// TestOpenOrphanWindowIgnoresZeroStart pins the degenerate input, matching
+// RecordOrphanWindow's refusal to make a claim on one. Suppressing from a zero
+// start would match every TC ever recorded.
+func TestOpenOrphanWindowIgnoresZeroStart(t *testing.T) {
+	t.Parallel()
+
+	m := &SyncMockManager{}
+	closeHole := m.OpenOrphanWindow(time.Time{})
+
+	// Queried while still OPEN and against a LONG-PAST window, deliberately.
+	// A zero start means "the beginning of time", so the range it would
+	// create covers every test case ever recorded — and closing first, or
+	// probing only the present, hides that: the closed end is later than a
+	// present-day timestamp, so the overlap test says no. Probing the past
+	// with the hole still open is what actually catches an accepted zero.
+	past := time.Now().Add(-365 * 24 * time.Hour)
+	if orphaned, _ := m.WasMockOrphanedInWindow(past, past.Add(time.Millisecond)); orphaned {
+		t.Fatal("a zero-start hole must suppress nothing; it would otherwise match every TC ever recorded")
+	}
+
+	closeHole() // must not panic
+}

--- a/pkg/agent/proxy/syncMock/syncMock.go
+++ b/pkg/agent/proxy/syncMock/syncMock.go
@@ -281,6 +281,24 @@ type SyncMockManager struct {
 	// here — same inherent trade-off as interval-based pressure suppression.
 	orphanRanges []pressureRange
 
+	// orphanOpen holds orphan intervals whose end is not yet known: a
+	// connection that is CURRENTLY un-capturable and may stay that way for
+	// the rest of the session.
+	//
+	// It exists because [RecordOrphanWindow] can only be called once the
+	// hole's width is known, and by then the test cases inside it have
+	// already been streamed to the CLI and written to disk — the suppressor
+	// in routes/record.go reads these ranges as each TC is streamed, not
+	// afterwards. A parser that resyncs (mongo/v2) knows its hole's end
+	// immediately and keeps using RecordOrphanWindow; a connection that
+	// fell through to raw passthrough does not, because it stays broken
+	// until it closes, which for a pooled connection means until shutdown.
+	//
+	// Held as POINTERS so the closer returned by [OpenOrphanWindow] can set
+	// the end later without depending on a slice index, which the overflow
+	// trim below would invalidate.
+	orphanOpen []*pressureRange
+
 	// loggerMu guards logger so SetLogger and the drop path can run
 	// concurrently without a data race. The read lock is taken only
 	// on the (sampled, cold) Error path, so contention is negligible.
@@ -1192,7 +1210,61 @@ func (m *SyncMockManager) WasMockOrphanedInWindow(start, end time.Time) (bool, i
 			count++
 		}
 	}
+	// Still-open holes extend to now, matching WasPressureActiveInWindow's
+	// treatment of an open pressure interval. Without this a connection that
+	// is un-capturable RIGHT NOW would suppress nothing, which is precisely
+	// the window whose test cases must not be shipped mock-less.
+	now := time.Now()
+	for _, r := range m.orphanOpen {
+		rEnd := r.end
+		if rEnd.IsZero() {
+			rEnd = now
+		}
+		if !r.start.After(end) && !rEnd.Before(start) {
+			count++
+		}
+	}
 	return count > 0, count
+}
+
+// OpenOrphanWindow marks the start of a hole whose end is not yet known and
+// returns the closer that ends it. The returned func is idempotent and safe to
+// call from any goroutine; not calling it leaves the hole open, which is the
+// correct reading for a connection that stays un-capturable until shutdown.
+//
+// Use this when capture for a connection has failed in a way it cannot recover
+// from — the parser has been retired and the relay is raw-forwarding — as
+// opposed to [RecordOrphanWindow], which suits a parser that has already
+// resynced and therefore knows the hole's width.
+//
+// A zero start is ignored and yields a no-op closer, mirroring
+// RecordOrphanWindow's refusal to make a claim on a degenerate input.
+func (m *SyncMockManager) OpenOrphanWindow(start time.Time) func() {
+	if m == nil || start.IsZero() {
+		return func() {}
+	}
+	r := &pressureRange{start: start}
+
+	m.mu.Lock()
+	m.orphanOpen = append(m.orphanOpen, r)
+	// Count-cap as for orphanRanges. Dropping the OLDEST open hole is the
+	// conservative choice available: it under-suppresses rather than
+	// retaining unbounded per-connection state on a long recording.
+	if n := len(m.orphanOpen); n > maxPressureRanges {
+		trimmed := make([]*pressureRange, maxPressureRanges)
+		copy(trimmed, m.orphanOpen[n-maxPressureRanges:])
+		m.orphanOpen = trimmed
+	}
+	m.mu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			m.mu.Lock()
+			r.end = time.Now()
+			m.mu.Unlock()
+		})
+	}
 }
 
 // RecordOrphanWindow records a [start,end] interval during which a mock could
@@ -1240,6 +1312,36 @@ func (m *SyncMockManager) pressureActiveAtLocked(t time.Time) bool {
 		}
 	}
 	return false
+}
+
+// OrphanRangeCount returns how many orphan intervals have been recorded, split
+// into closed and still-open. Exposed for the session-summary log in
+// routes/record.go so a run with a high tcs_suppressed_total says WHICH
+// suppressor fired: memory pressure (pressure_ranges_total) or a connection
+// that could no longer be captured (this). Without the split, an operator
+// seeing most of their tests suppressed has no way to tell the two apart, and
+// a still-open interval is the one that keeps suppressing to the end of the
+// session — worth surfacing separately.
+func (m *SyncMockManager) OrphanRangeCount() (closed, open int) {
+	if m == nil {
+		return 0, 0
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// orphanOpen holds windows that have been closed too: the closer stamps
+	// r.end in place rather than removing the entry, so the slice is not the
+	// open count. Reporting len() for both would tell an operator whose
+	// windows all closed cleanly that suppression ran to end of session —
+	// the exact wrong diagnosis, in the field added to prevent one.
+	closed = len(m.orphanRanges)
+	for _, r := range m.orphanOpen {
+		if r.end.IsZero() {
+			open++
+		} else {
+			closed++
+		}
+	}
+	return closed, open
 }
 
 // PressureRangeCount returns the total number of pressure intervals recorded

--- a/pkg/agent/routes/record.go
+++ b/pkg/agent/routes/record.go
@@ -40,6 +40,15 @@ type Agent struct {
 // into /tmp on the host. Production code MUST NOT mutate it.
 var agentReadyFilePath = kdocker.AgentReadyFile
 
+// massSuppressionPercent is the share of a session's test cases that must be
+// suppressed before the completion summary is raised from Info to Warn.
+//
+// Not a threshold that changes behaviour — nothing is suppressed differently —
+// only one that decides whether the operator is told loudly. Set well above the
+// handful of test cases a brief memory-pressure blip costs, and well below the
+// point where the recording has quietly become unrepresentative.
+const massSuppressionPercent = 25
+
 // firstCARefusalLog ensures we emit exactly one Info-level line the
 // first time /agent/ready is called before the CA bundle is written.
 // This is the observability signal operators rely on — subsequent
@@ -352,10 +361,27 @@ func (a *Agent) HandleIncoming(w http.ResponseWriter, r *http.Request) {
 			if !ok {
 				// Channel closed = recording session over.
 				_, finalDropped, finalAdded, _ := syncmgr.Get().GetDropStats()
-				a.logger.Info("agent: recording complete",
+				orphanClosed, orphanOpen := syncmgr.Get().OrphanRangeCount()
+				// Suppression protects replay from test cases whose mocks
+				// were never captured, but it is coarse: the windows are
+				// timestamp-based and session-wide, so a connection that
+				// stays busy while un-capturable can take a large share of
+				// the run with it — including test cases that other,
+				// healthy connections served completely. At a few percent
+				// that is the intended trade; at a third of the session the
+				// operator has a materially thinner recording than they
+				// think, and must be told at a level they actually see.
+				logRecordingComplete := a.logger.Info
+				if total := tcsSentSoFar + tcsSuppressedSoFar; total > 0 &&
+					tcsSuppressedSoFar*100/total >= massSuppressionPercent {
+					logRecordingComplete = a.logger.Warn
+				}
+				logRecordingComplete("agent: recording complete",
 					zap.Int("tcs_sent_to_cli", tcsSentSoFar),
 					zap.Int("tcs_suppressed_total", tcsSuppressedSoFar),
 					zap.Int("pressure_ranges_total", syncmgr.Get().PressureRangeCount()),
+					zap.Int("orphan_ranges_total", orphanClosed),
+					zap.Int("orphan_ranges_still_open", orphanOpen),
 					zap.Int64("mocks_dropped_by_pressure", finalDropped),
 					zap.Int64("mocks_added_successfully", finalAdded),
 					zap.Uint64("mocks_dropped_capacity", syncmgr.Get().DropCount()),


### PR DESCRIPTION
## Describe the changes that are made

A test case recorded without the mocks its request depended on cannot replay: the agent reports `match_phase=no_mocks, candidates=0`, closes the connection, and the app under test sees an unexpected EOF. Recordings were shipping such test cases **silently**.

**Root cause**, from the artifact of a failing `go-memory-load-mongo` run (`30553219538`): all 855 mongo mocks span `14:58:55–14:59:42`, while the 18 tests that failed replay were recorded `14:59:55–15:01:04` — every one of them *after* egress capture had already died, 82 s before ingress capture did.

When the supervisor retires a V2 parser (hung / panicked / mem-capped / plain error), `recordViaSupervisor`'s `FallthroughToPassthrough` branch drops the parser and leaves the relay raw-forwarding until peer close. That is correct for user traffic and wrong for recording: no code path ever puts a parser back on a live connection, so from that instant the connection serves requests perfectly while producing **zero mocks**. On a pooled client the peer never closes, so "until peer close" means "until shutdown". The per-connection mock timeline shows exactly that — mid-connection gaps of 3–18 s recover, then the last two live connections fall silent 52 ms apart and no new connection ever appears (the k6 profile ramps down, so the pool opens no replacements). It was logged at `Debug`, and several supervisor exits that reach it log nothing at all, so a whole run could come back unreplayable without a single line above `Debug` to explain it. It sits in the shared dispatcher above every parser, so it is protocol-independent.

**Fix.** Mark the span instead of hiding it:

- `syncMock.OpenOrphanWindow(start) func()` — an orphan interval whose **end is not yet known**. The existing TC suppressor drops every test case overlapping it rather than streaming it mock-less. Open-ended is load-bearing: those ranges are consulted as each test case is *streamed*, so a window recorded once its width is known (at connection close, i.e. shutdown) lands long after the test cases inside it were already written to disk. Zero end = "extends to now", the convention `WasPressureActiveInWindow` already used.
- `trackOrphanWhileActive` scopes the window to **traffic, not wall-clock**: open only while the dead connection is actually forwarding bytes, closed after 1 s idle, reopened from the resume instant. A single window held to end-of-session would discard the rest of the recording, and a test case served entirely while the dead connection sat idle cannot be missing mocks from it.
- A tee desync and a retired parser start the **same** tracker. They leave the connection in the same state, and on this very chain the desync fires first — giving it a window of its own would subsume the scoped one and quietly restore whole-session suppression.
- The first unintended tee drop (`per_conn_cap` / `memory_pressure`, not a deliberate pause) now warns **once per connection** instead of a sampled `Debug`.

**Known limitation, stated plainly:** suppression is timestamp-based, so a connection that stays busy while un-capturable also suppresses test cases that healthy connections served completely. Per-connection attribution is the real fix and is not in this PR. To keep that visible, the completion summary is raised from `Info` to `Warn` once a quarter of a session is suppressed, and reports orphan ranges separately from memory-pressure ones so an operator can tell which suppressor fired.

**Why the fallthrough `Warn` omits the parser error:** for a recovered panic that string contains `parser panic:`, and the memory-load lane scripts grep `record.txt` for `/panic:|fatal error:/` to detect a *crashed* keploy. The error stays on a `Debug` line so a handled fault cannot masquerade as a crash. A cancel arriving after the supervisor's grace period is the normal end of a live connection at stop, so it neither warns nor suppresses.

## Links & References

**Closes:** NA

### 🔗 Related PRs
- Stacked on #4390 (base branch is `fix/tee-spill-boot-nomocks`); merge that first.
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [x] 🐞 Bug Fix

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed

The `go-memory-load-*` e2e lanes already exercise this path — they are where the bug was found. The mechanism itself is covered by unit tests, which are deterministic where the lane is not.

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

`go test ./pkg/agent/proxy/... ./pkg/agent/routes/... -race -count=1`

New coverage, each mutation-checked (the production line was reverted one at a time and the test confirmed to fail):
- `TestTrackOrphanWhileActiveFollowsTraffic` — suppress immediately, stop on idle, resume on traffic, one uninterrupted window while continuously busy, and the reopen never starts after the resume instant.
- `TestAnUnintendedDropReportsCaptureDesync` — pressure and cap desync; a deliberate pause does not.
- `TestOpenOrphanWindowSuppressesWhileStillOpen`, `TestOrphanRangeCountSplitsClosedFromOpen`, `TestOpenOrphanWindowIgnoresZeroStart`.

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA
