### PR TITLE
fix(mysql): preserve pipelined command response order

### DIFF
--- a/.github/workflows/test_workflow_scripts/java/tidb_stmt_cache/java-linux.sh
+++ b/.github/workflows/test_workflow_scripts/java/tidb_stmt_cache/java-linux.sh
@@ -78,9 +78,59 @@ send_request() {
   for v in 100 200 300 400 500; do curl -sS "http://localhost:8080/api/kv/insert-select/$v" || true; echo; done
   echo "=== orphaned cross-query, identical param shape (/api/cross) ==="
   for v in 7 8 9; do curl -sS "http://localhost:8080/api/cross/$v" || true; echo; done
+
+  # Streamed-BLOB writes (keploy#4262). setBinaryStream makes Connector/J send
+  # the value out of band and pipeline COM_STMT_RESET -> COM_STMT_SEND_LONG_DATA
+  # -> COM_STMT_EXECUTE per re-execution. Driven repeatedly on purpose: the
+  # RESET only appears when the statement is re-executed from the cache.
+  echo "=== streamed BLOB via SEND_LONG_DATA (/api/blob) ==="
+  for _ in 1 2 3; do curl -sS "http://localhost:8080/api/blob/2048" || true; echo; done
+
   sleep 10
   echo "Sending SIGINT to keploy ($kp_pid) for graceful shutdown"
   sudo kill -INT "$kp_pid" 2>/dev/null || true
+}
+
+# Regression guard for keploy#4262 (streamed-BLOB EXECUTE dropped at record).
+#
+# Asserted on the RECORDED ARTIFACT, not just the replay report. A parameter
+# sent with COM_STMT_SEND_LONG_DATA is absent from the COM_STMT_EXECUTE
+# payload while still being non-NULL in the null bitmap, so a decoder that
+# reads a value for every non-NULL parameter runs off the end, rejects the
+# command, and the EXECUTE never reaches the recorder at all. The recording
+# then contains RESET and SEND_LONG_DATA mocks but no EXECUTE, and replay
+# fails with "Can not read response from server".
+assert_blob_execute_recorded() {
+  section "Guard: streamed-BLOB EXECUTE is recorded (keploy#4262)"
+  local mocks execs slds
+  mocks=$(find ./keploy -name 'mocks.yaml' -o -name 'mocks.json' 2>/dev/null)
+  if [[ -z "$mocks" ]]; then
+    echo "::error::keploy#4262 guard: no mock files under ./keploy"
+    endsec; return 1
+  fi
+
+  # grep -h | wc -l rather than summing per-file -c counts: no bc dependency
+  # (not installed on every runner) and it behaves the same for one file or
+  # several. An unreadable mocks file yields 0 and trips the vacuity check
+  # below rather than passing silently.
+  # shellcheck disable=SC2086
+  slds=$(grep -h 'requestOperation: COM_STMT_SEND_LONG_DATA' $mocks 2>/dev/null | wc -l)
+  # shellcheck disable=SC2086
+  execs=$(grep -h 'requestOperation: COM_STMT_EXECUTE' $mocks 2>/dev/null | wc -l)
+
+  if [[ "${slds:-0}" -eq 0 ]]; then
+    echo "::error::keploy#4262 guard: no COM_STMT_SEND_LONG_DATA mocks — /api/blob did not"
+    echo "::error::produce a streamed write, so this guard would assert nothing."
+    endsec; return 1
+  fi
+  if [[ "${execs:-0}" -eq 0 ]]; then
+    echo "::error::keploy#4262 regression: ${slds} SEND_LONG_DATA mocks but ZERO COM_STMT_EXECUTE"
+    echo "::error::mocks. The streamed-BLOB EXECUTE is being dropped at decode time; replay will"
+    echo "::error::fail with 'Can not read response from server'."
+    endsec; return 1
+  fi
+  echo "OK: ${execs} COM_STMT_EXECUTE and ${slds} COM_STMT_SEND_LONG_DATA mocks recorded."
+  endsec
 }
 
 # Drops the COM_STMT_PREPARE mock for "SELECT ? AS v" from every recorded
@@ -157,6 +207,9 @@ send_request "$KEPLOY_PID"
 set +e; wait "$KEPLOY_PID"; echo "Record exit: $?"; set -e
 if grep -q "WARNING: DATA RACE" record.txt; then echo "::error::Data race during record"; cat record.txt; exit 1; fi
 endsec
+
+# Before any mock mutation below, while the recording is still pristine.
+assert_blob_execute_recorded
 
 section "Shutdown TiDB before test mode"
 docker compose down || true

--- a/pkg/agent/proxy/integrations/mysql/recorder/pipelined_commands_test.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/pipelined_commands_test.go
@@ -1,0 +1,158 @@
+package recorder
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/wire"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.keploy.io/server/v3/pkg/models/mysql"
+	"go.uber.org/zap/zaptest"
+)
+
+func stmtResetCommand(seq byte, statementID uint32) []byte {
+	payload := make([]byte, 5)
+	payload[0] = mysql.COM_STMT_RESET
+	binary.LittleEndian.PutUint32(payload[1:], statementID)
+	return wrapPacket(payload, seq)
+}
+
+func stmtSendLongDataCommand(seq byte, statementID uint32, parameterID uint16, data []byte) []byte {
+	payload := make([]byte, 7+len(data))
+	payload[0] = mysql.COM_STMT_SEND_LONG_DATA
+	binary.LittleEndian.PutUint32(payload[1:], statementID)
+	binary.LittleEndian.PutUint16(payload[5:], parameterID)
+	copy(payload[7:], data)
+	return wrapPacket(payload, seq)
+}
+
+func stmtExecuteCommand(seq byte, statementID uint32) []byte {
+	payload := make([]byte, 10)
+	payload[0] = mysql.COM_STMT_EXECUTE
+	binary.LittleEndian.PutUint32(payload[1:], statementID)
+	payload[5] = 0 // CURSOR_TYPE_NO_CURSOR
+	binary.LittleEndian.PutUint32(payload[6:], 1)
+	return wrapPacket(payload, seq)
+}
+
+func okResponseWithAffectedRows(seq byte, affectedRows byte) []byte {
+	payload := []byte{
+		mysql.OK,
+		affectedRows,
+		0x00,       // last_insert_id
+		0x02, 0x00, // status_flags = AUTOCOMMIT
+		0x00, 0x00, // warnings
+	}
+	return wrapPacket(payload, seq)
+}
+
+// TestAsyncMySQLDecode_PipelinedResetLongDataExecute verifies that response-
+// bearing commands remain FIFO-ordered when a client pipelines them around a
+// no-response COM_STMT_SEND_LONG_DATA packet. Connector/J uses this sequence
+// for repeated streamed BLOB writes:
+//
+//	COM_STMT_RESET -> COM_STMT_SEND_LONG_DATA -> COM_STMT_EXECUTE
+//
+// RESET and EXECUTE each receive an OK packet; SEND_LONG_DATA receives none.
+// The affected-row counts intentionally differ so the test catches both a
+// missing command and a response paired with the wrong request.
+func TestAsyncMySQLDecode_PipelinedResetLongDataExecute(t *testing.T) {
+	const statementID = uint32(7)
+
+	clientConn := newPipeConn()
+	decodeCtx := buildPostHandshakeDecodeCtx(clientConn)
+	decodeCtx.LastOp.Store(clientConn, wire.RESET)
+	decodeCtx.PreparedStatements[statementID] = &mysql.StmtPrepareOkPacket{
+		StatementID: statementID,
+	}
+
+	mocks := make(chan *models.Mock, 8)
+	wireSyncMockOutput(t, mocks)
+	ctx := context.WithValue(context.Background(), models.ClientConnectionIDKey, "pipelined-commands")
+
+	base := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	decodeItems := make(chan mysqlDecodeItem, 5)
+	decodeItems <- mysqlDecodeItem{
+		fromClient: true,
+		data:       stmtResetCommand(0, statementID),
+		ts:         base,
+	}
+	decodeItems <- mysqlDecodeItem{
+		fromClient: true,
+		data:       stmtSendLongDataCommand(0, statementID, 0, []byte("blob-chunk")),
+		ts:         base.Add(time.Millisecond),
+	}
+	decodeItems <- mysqlDecodeItem{
+		fromClient: true,
+		data:       stmtExecuteCommand(0, statementID),
+		ts:         base.Add(2 * time.Millisecond),
+	}
+	decodeItems <- mysqlDecodeItem{
+		data: okResponseWithAffectedRows(1, 0),
+		ts:   base.Add(3 * time.Millisecond),
+	}
+	decodeItems <- mysqlDecodeItem{
+		data: okResponseWithAffectedRows(1, 1),
+		ts:   base.Add(4 * time.Millisecond),
+	}
+	close(decodeItems)
+
+	asyncMySQLDecode(
+		ctx,
+		zaptest.NewLogger(t),
+		decodeItems,
+		mocks,
+		decodeCtx,
+		clientConn,
+		models.OutgoingOptions{DstCfg: &models.ConditionalDstCfg{Addr: "127.0.0.1:3306"}},
+	)
+
+	byOperation := make(map[string]*models.Mock)
+	for {
+		select {
+		case mock := <-mocks:
+			if mock != nil {
+				byOperation[mock.Spec.Metadata["requestOperation"]] = mock
+			}
+		default:
+			goto collected
+		}
+	}
+
+collected:
+	if len(byOperation) != 3 {
+		t.Fatalf("recorded operations = %v, want RESET, SEND_LONG_DATA, and EXECUTE", byOperation)
+	}
+
+	sendLongData := byOperation["COM_STMT_SEND_LONG_DATA"]
+	if sendLongData == nil {
+		t.Fatal("COM_STMT_SEND_LONG_DATA mock was not recorded")
+	}
+	if got := len(sendLongData.Spec.MySQLResponses); got != 0 {
+		t.Fatalf("COM_STMT_SEND_LONG_DATA responses = %d, want 0", got)
+	}
+
+	assertOKAffectedRows := func(operation string, want uint64) {
+		t.Helper()
+		mock := byOperation[operation]
+		if mock == nil {
+			t.Fatalf("%s mock was not recorded", operation)
+		}
+		if got := len(mock.Spec.MySQLResponses); got != 1 {
+			t.Fatalf("%s responses = %d, want 1", operation, got)
+		}
+		okPacket, ok := mock.Spec.MySQLResponses[0].PacketBundle.Message.(*mysql.OKPacket)
+		if !ok {
+			t.Fatalf("%s response type = %T, want *mysql.OKPacket",
+				operation, mock.Spec.MySQLResponses[0].PacketBundle.Message)
+		}
+		if okPacket.AffectedRows != want {
+			t.Fatalf("%s affected rows = %d, want %d", operation, okPacket.AffectedRows, want)
+		}
+	}
+
+	assertOKAffectedRows("COM_STMT_RESET", 0)
+	assertOKAffectedRows("COM_STMT_EXECUTE", 1)
+}

--- a/pkg/agent/proxy/integrations/mysql/recorder/pipelined_queue_test.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/pipelined_queue_test.go
@@ -1,0 +1,362 @@
+package recorder
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/wire"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.keploy.io/server/v3/pkg/models/mysql"
+	"go.uber.org/zap/zaptest"
+)
+
+func queuedExecute(seq byte, id uint32) []byte {
+	p := make([]byte, 10)
+	p[0] = mysql.COM_STMT_EXECUTE
+	binary.LittleEndian.PutUint32(p[1:], id)
+	p[5] = 0
+	binary.LittleEndian.PutUint32(p[6:], 1)
+	return wrapPacket(p, seq)
+}
+
+func queuedOK(seq byte, affected byte) []byte {
+	return wrapPacket([]byte{mysql.OK, affected, 0x00, 0x02, 0x00, 0x00, 0x00}, seq)
+}
+
+func newQueueHarness(t *testing.T, name string) (*pipeConn, *wire.DecodeContext, chan *models.Mock, context.Context, uint32) {
+	t.Helper()
+	const stmtID = uint32(11)
+	clientConn := newPipeConn()
+	decodeCtx := buildPostHandshakeDecodeCtx(clientConn)
+	decodeCtx.LastOp.Store(clientConn, wire.RESET)
+	decodeCtx.PreparedStatements[stmtID] = &mysql.StmtPrepareOkPacket{StatementID: stmtID}
+	mocks := make(chan *models.Mock, 512)
+	wireSyncMockOutput(t, mocks)
+	return clientConn, decodeCtx, mocks, context.WithValue(context.Background(), models.ClientConnectionIDKey, name), stmtID
+}
+
+// The command FIFO holds commands the server has not answered yet. On a
+// healthy connection it is a handful deep, but a connection whose responses
+// stop arriving would otherwise accumulate one entry per command for the life
+// of the process — the same unbounded-growth shape the heldResp guard beside
+// it is explicitly capped against.
+func TestAsyncMySQLDecode_PipelinedQueueIsBounded(t *testing.T) {
+	clientConn, decodeCtx, mocks, ctx, stmtID := newQueueHarness(t, "queue-bound")
+
+	// Far more commands than the cap, and not a single response.
+	const commands = 5000
+	base := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	items := make(chan mysqlDecodeItem, commands+4)
+	for i := 0; i < commands; i++ {
+		items <- mysqlDecodeItem{fromClient: true, data: queuedExecute(0, stmtID), ts: base.Add(time.Duration(i) * time.Millisecond)}
+	}
+	// One response at the end: it must still pair with a queued command
+	// rather than being dropped, i.e. the queue is bounded, not disabled.
+	items <- mysqlDecodeItem{fromClient: false, data: queuedOK(1, 7), ts: base.Add(time.Hour)}
+	close(items)
+
+	asyncMySQLDecode(ctx, zaptest.NewLogger(t), items, mocks, decodeCtx, clientConn, models.OutgoingOptions{})
+	close(mocks)
+
+	// The trailing response pairs with whatever sits at the head of the FIFO,
+	// and that is what makes the bound observable: trimmed, the head is one of
+	// the LAST few commands; unbounded, it is still command #0 from 5000
+	// commands ago. Asserting only "one response paired" passes either way —
+	// the timestamp is what distinguishes them.
+	paired := 0
+	var pairedAt time.Time
+	for m := range mocks {
+		if len(m.Spec.MySQLResponses) > 0 {
+			paired++
+			pairedAt = m.Spec.ReqTimestampMock
+		}
+	}
+	if paired != 1 {
+		t.Fatalf("got %d responses paired, want 1 — the queue should still serve the trailing "+
+			"response after being trimmed", paired)
+	}
+
+	oldestKept := base.Add(time.Duration(commands-maxPipelinedCommandsForTest) * time.Millisecond)
+	if pairedAt.Before(oldestKept) {
+		t.Errorf("the response paired with a command from %s, but only the last %d commands "+
+			"should still be queued (oldest kept: %s). The queue is not being trimmed, so a "+
+			"connection whose responses stop arriving accumulates one entry per command for "+
+			"the life of the process",
+			pairedAt.Format("15:04:05.000"), maxPipelinedCommandsForTest, oldestKept.Format("15:04:05.000"))
+	}
+}
+
+// Mirrors the cap inside asyncMySQLDecode. Kept local so the test fails loudly
+// if the production bound is raised without revisiting this assertion.
+const maxPipelinedCommandsForTest = 32
+
+func queuedQuery(seq byte, sql string) []byte {
+	p := append([]byte{mysql.COM_QUERY}, []byte(sql)...)
+	return wrapPacket(p, seq)
+}
+
+// Drains without closing: the mock channel is still registered with the
+// process-global sync-mock manager, which tracks closure with its own flag.
+func drainMocks(t *testing.T, mocks chan *models.Mock) []*models.Mock {
+	t.Helper()
+	var out []*models.Mock
+	for {
+		select {
+		case m := <-mocks:
+			out = append(out, m)
+		default:
+			return out
+		}
+	}
+}
+
+// A response that fails to decode used to cost one exchange and no more: the
+// next client command reassigned pendingCommand and the machine carried on.
+// With the FIFO nothing on the client path clears pendingCommand, so an
+// undecodable response can leave state==stateExpectCommand with a command
+// still active — a pair activateNextCommand reports as "already active"
+// without setting stateExpectResponse, after which the switch matches nothing
+// and every later packet on the connection is silently dropped.
+func TestAsyncMySQLDecode_UndecodableResponseDoesNotKillTheConnection(t *testing.T) {
+	clientConn, decodeCtx, mocks, ctx, stmtID := newQueueHarness(t, "bad-response")
+
+	base := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	items := make(chan mysqlDecodeItem, 16)
+	// Exchange 1: its response is a LOCAL INFILE packet the decoder rejects.
+	items <- mysqlDecodeItem{fromClient: true, data: queuedExecute(0, stmtID), ts: base}
+	items <- mysqlDecodeItem{fromClient: false, data: wrapPacket([]byte{0xfb, 'x'}, 1), ts: base.Add(time.Millisecond)}
+	// Exchanges 2 and 3 are perfectly ordinary and must still be recorded.
+	items <- mysqlDecodeItem{fromClient: true, data: queuedExecute(0, stmtID), ts: base.Add(2 * time.Millisecond)}
+	items <- mysqlDecodeItem{fromClient: false, data: queuedOK(1, 2), ts: base.Add(3 * time.Millisecond)}
+	items <- mysqlDecodeItem{fromClient: true, data: queuedExecute(0, stmtID), ts: base.Add(4 * time.Millisecond)}
+	items <- mysqlDecodeItem{fromClient: false, data: queuedOK(1, 3), ts: base.Add(5 * time.Millisecond)}
+	close(items)
+
+	asyncMySQLDecode(ctx, zaptest.NewLogger(t), items, mocks, decodeCtx, clientConn, models.OutgoingOptions{})
+
+	paired := 0
+	for _, m := range drainMocks(t, mocks) {
+		if len(m.Spec.MySQLResponses) > 0 {
+			paired++
+		}
+	}
+	if paired < 2 {
+		t.Errorf("only %d exchanges recorded after one undecodable response; the two clean "+
+			"exchanges that followed were lost, so the decoder is wedged for the life of the "+
+			"connection", paired)
+	}
+}
+
+// A result set whose terminator never arrives parks the decoder in a
+// column/row state. activateNextCommand is only reachable from the
+// stateExpectCommand guard, so without a force-flush nothing recovers: later
+// commands queue and later RESPONSES are appended as rows of the stuck set.
+func TestAsyncMySQLDecode_UnterminatedResultSetDoesNotSwallowTheConnection(t *testing.T) {
+	clientConn, decodeCtx, mocks, ctx, _ := newQueueHarness(t, "stuck-resultset")
+
+	base := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	items := make(chan mysqlDecodeItem, 16)
+	// A SELECT answered with "1 column" then a column def — and then nothing.
+	items <- mysqlDecodeItem{fromClient: true, data: queuedQuery(0, "SELECT 1"), ts: base}
+	items <- mysqlDecodeItem{fromClient: false, data: wrapPacket([]byte{0x01}, 1), ts: base.Add(time.Millisecond)}
+	// Two ordinary exchanges follow; both must still be recorded.
+	items <- mysqlDecodeItem{fromClient: true, data: queuedQuery(0, "INSERT 1"), ts: base.Add(2 * time.Millisecond)}
+	items <- mysqlDecodeItem{fromClient: false, data: queuedOK(1, 2), ts: base.Add(3 * time.Millisecond)}
+	items <- mysqlDecodeItem{fromClient: true, data: queuedQuery(0, "INSERT 2"), ts: base.Add(4 * time.Millisecond)}
+	items <- mysqlDecodeItem{fromClient: false, data: queuedOK(1, 3), ts: base.Add(5 * time.Millisecond)}
+	close(items)
+
+	asyncMySQLDecode(ctx, zaptest.NewLogger(t), items, mocks, decodeCtx, clientConn, models.OutgoingOptions{})
+
+	if got := len(drainMocks(t, mocks)); got < 3 {
+		t.Errorf("recorded %d mocks, want at least 3 — the unterminated result set never "+
+			"released the decoder, so the two exchanges after it were swallowed", got)
+	}
+}
+
+// The general pipelining case, not just Connector/J's RESET+SLD+EXECUTE.
+// wire.DecodePayload dispatches on LastOp, so with COM_QUERY still set the
+// second pipelined command decodes as that query's RESPONSE and is queued as a
+// phantom TextResultSet "command" that eats a real response slot.
+func TestAsyncMySQLDecode_PipelinedSameOpCommandsAreNotDecodedAsResponses(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cmd  func(byte) []byte
+		want string
+	}{
+		{"COM_QUERY", func(s byte) []byte { return queuedQuery(s, "INSERT INTO t VALUES (1)") }, "COM_QUERY"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clientConn, decodeCtx, mocks, ctx, _ := newQueueHarness(t, "pipelined-"+tc.name)
+
+			base := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+			items := make(chan mysqlDecodeItem, 16)
+			items <- mysqlDecodeItem{fromClient: true, data: tc.cmd(0), ts: base}
+			items <- mysqlDecodeItem{fromClient: true, data: tc.cmd(0), ts: base.Add(time.Millisecond)}
+			items <- mysqlDecodeItem{fromClient: false, data: queuedOK(1, 1), ts: base.Add(2 * time.Millisecond)}
+			items <- mysqlDecodeItem{fromClient: false, data: queuedOK(1, 2), ts: base.Add(3 * time.Millisecond)}
+			close(items)
+
+			asyncMySQLDecode(ctx, zaptest.NewLogger(t), items, mocks, decodeCtx, clientConn, models.OutgoingOptions{})
+
+			for _, m := range drainMocks(t, mocks) {
+				op := ""
+				if len(m.Spec.MySQLRequests) > 0 {
+					op = m.Spec.MySQLRequests[0].Header.Type
+				}
+				if op != tc.want {
+					t.Errorf("recorded a mock whose REQUEST is %q; a client packet was decoded "+
+						"as a response because LastOp still named the previous command", op)
+				}
+			}
+		})
+	}
+}
+
+func rResetCmd(seq byte, id uint32) []byte {
+	p := make([]byte, 5)
+	p[0] = mysql.COM_STMT_RESET
+	binary.LittleEndian.PutUint32(p[1:], id)
+	return wrapPacket(p, seq)
+}
+
+func queuedPrepare(seq byte, sql string) []byte {
+	return wrapPacket(append([]byte{mysql.COM_STMT_PREPARE}, []byte(sql)...), seq)
+}
+
+func queuedPrepareOK(seq byte, stmtID uint32) []byte {
+	p := make([]byte, 12)
+	p[0] = mysql.OK
+	binary.LittleEndian.PutUint32(p[1:], stmtID)
+	binary.LittleEndian.PutUint16(p[5:], 0) // num columns
+	binary.LittleEndian.PutUint16(p[7:], 0) // num params
+	p[9] = 0                                // filler
+	binary.LittleEndian.PutUint16(p[10:], 0)
+	return wrapPacket(p, seq)
+}
+
+// activateNextCommand restores decodeCtx.LastOp for the command it activates.
+// Without that, the response decoder uses whatever op the LAST pipelined
+// command left behind, and a COM_STMT_PREPARE's response degrades from a
+// StmtPrepareOkPacket to a plain OK — losing the statement id, so every
+// COM_STMT_EXECUTE against it fails at replay.
+func TestAsyncMySQLDecode_ActivateRestoresTheOpForItsOwnResponse(t *testing.T) {
+	clientConn, decodeCtx, mocks, ctx, stmtID := newQueueHarness(t, "restore-lastop")
+
+	base := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	items := make(chan mysqlDecodeItem, 8)
+	// Pipelined: PREPARE then RESET, so LastOp ends up on RESET before any
+	// response is read. PREPARE's response must still decode as a prepare OK.
+	items <- mysqlDecodeItem{fromClient: true, data: queuedPrepare(0, "SELECT 1"), ts: base}
+	items <- mysqlDecodeItem{fromClient: true, data: rResetCmd(0, stmtID), ts: base.Add(time.Millisecond)}
+	items <- mysqlDecodeItem{fromClient: false, data: queuedPrepareOK(1, stmtID), ts: base.Add(2 * time.Millisecond)}
+	items <- mysqlDecodeItem{fromClient: false, data: queuedOK(1, 0), ts: base.Add(3 * time.Millisecond)}
+	close(items)
+
+	asyncMySQLDecode(ctx, zaptest.NewLogger(t), items, mocks, decodeCtx, clientConn, models.OutgoingOptions{})
+
+	for _, m := range drainMocks(t, mocks) {
+		if len(m.Spec.MySQLRequests) == 0 || m.Spec.MySQLRequests[0].Header.Type != "COM_STMT_PREPARE" {
+			continue
+		}
+		if len(m.Spec.MySQLResponses) == 0 {
+			t.Fatal("COM_STMT_PREPARE recorded with no response")
+		}
+		if _, ok := m.Spec.MySQLResponses[0].Message.(*mysql.StmtPrepareOkPacket); !ok {
+			t.Errorf("COM_STMT_PREPARE's response decoded as %T, want *mysql.StmtPrepareOkPacket — "+
+				"the activated command's operation was not restored, so the response was decoded "+
+				"as the next pipelined command's", m.Spec.MySQLResponses[0].Message)
+		}
+		return
+	}
+	t.Fatal("no COM_STMT_PREPARE mock was recorded")
+}
+
+// The inverse race to pipelining: on loopback a response can reach the decoder
+// before its own command. It is parked in heldResp and must be replayed once a
+// command arrives, or the exchange is recorded with no response at all — which
+// is what silently lost mocks for fast connection-pool validation queries.
+func TestAsyncMySQLDecode_ResponseArrivingBeforeItsCommandIsReplayed(t *testing.T) {
+	clientConn, decodeCtx, mocks, ctx, stmtID := newQueueHarness(t, "held-response")
+
+	base := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	items := make(chan mysqlDecodeItem, 8)
+	// Response first, command second.
+	items <- mysqlDecodeItem{fromClient: false, data: queuedOK(1, 4), ts: base.Add(time.Millisecond)}
+	items <- mysqlDecodeItem{fromClient: true, data: queuedExecute(0, stmtID), ts: base}
+	close(items)
+
+	asyncMySQLDecode(ctx, zaptest.NewLogger(t), items, mocks, decodeCtx, clientConn, models.OutgoingOptions{})
+
+	for _, m := range drainMocks(t, mocks) {
+		if len(m.Spec.MySQLRequests) > 0 && m.Spec.MySQLRequests[0].Header.Type == "COM_STMT_EXECUTE" {
+			if len(m.Spec.MySQLResponses) == 0 {
+				t.Fatal("the out-of-order response was never replayed, so the command was " +
+					"recorded with no response and replay has nothing to answer with")
+			}
+			return
+		}
+	}
+	t.Fatal("no COM_STMT_EXECUTE mock was recorded")
+}
+
+// The full streamed-BLOB sequence, end to end through the recorder — the one
+// issue #4262 actually reports. Connector/J sends the BLOB out of band, so the
+// EXECUTE payload carries no value for that parameter while the null bitmap
+// still marks it NOT NULL. Unless the decoder is told the value arrived via
+// COM_STMT_SEND_LONG_DATA, it reads past the end, rejects the command, and the
+// EXECUTE never becomes a mock at all — replay then has nothing to answer the
+// live EXECUTE with and Connector/J reports
+// "Can not read response from server".
+func TestAsyncMySQLDecode_StreamedBlobExecuteIsRecorded(t *testing.T) {
+	const stmtID = uint32(21)
+
+	clientConn := newPipeConn()
+	decodeCtx := buildPostHandshakeDecodeCtx(clientConn)
+	decodeCtx.LastOp.Store(clientConn, wire.RESET)
+	// One BLOB parameter, supplied by SEND_LONG_DATA rather than by EXECUTE.
+	decodeCtx.PreparedStatements[stmtID] = &mysql.StmtPrepareOkPacket{
+		StatementID: stmtID,
+		NumParams:   1,
+	}
+
+	mocks := make(chan *models.Mock, 32)
+	wireSyncMockOutput(t, mocks)
+	ctx := context.WithValue(context.Background(), models.ClientConnectionIDKey, "streamed-blob")
+
+	// EXECUTE with the parameter bound but its value absent.
+	execute := wrapPacket([]byte{
+		mysql.COM_STMT_EXECUTE,
+		byte(stmtID), 0x00, 0x00, 0x00,
+		0x00,                   // flags
+		0x01, 0x00, 0x00, 0x00, // iteration count
+		0x00,       // NULL bitmap: parameter 0 is NOT null
+		0x01,       // new params bind flag
+		0xfc, 0x00, // MYSQL_TYPE_BLOB
+	}, 0)
+
+	base := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	items := make(chan mysqlDecodeItem, 16)
+	items <- mysqlDecodeItem{fromClient: true, data: rResetCmd(0, stmtID), ts: base}
+	items <- mysqlDecodeItem{fromClient: true, data: stmtSendLongDataCommand(0, stmtID, 0, []byte("blob-bytes")), ts: base.Add(time.Millisecond)}
+	items <- mysqlDecodeItem{fromClient: true, data: execute, ts: base.Add(2 * time.Millisecond)}
+	items <- mysqlDecodeItem{fromClient: false, data: queuedOK(1, 0), ts: base.Add(3 * time.Millisecond)}
+	items <- mysqlDecodeItem{fromClient: false, data: queuedOK(1, 1), ts: base.Add(4 * time.Millisecond)}
+	close(items)
+
+	asyncMySQLDecode(ctx, zaptest.NewLogger(t), items, mocks, decodeCtx, clientConn, models.OutgoingOptions{})
+
+	seen := map[string]bool{}
+	for _, m := range drainMocks(t, mocks) {
+		if len(m.Spec.MySQLRequests) > 0 {
+			seen[m.Spec.MySQLRequests[0].Header.Type] = true
+		}
+	}
+	for _, want := range []string{"COM_STMT_RESET", "COM_STMT_SEND_LONG_DATA", "COM_STMT_EXECUTE"} {
+		if !seen[want] {
+			t.Errorf("no %s mock recorded; got %v", want, seen)
+		}
+	}
+}

--- a/pkg/agent/proxy/integrations/mysql/recorder/query.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/query.go
@@ -524,8 +524,26 @@ func asyncMySQLDecode(ctx context.Context, logger *zap.Logger, decodeChan <-chan
 
 	state := stateExpectCommand
 
-	// Current command being processed.
+	// maxPipelinedCommands bounds the FIFO below. Real clients pipeline a
+	// short burst — Connector/J's streamed-BLOB sequence is two
+	// response-bearing commands (RESET then EXECUTE) — so this is generous
+	// for legitimate traffic while still bounding a connection whose
+	// responses have stopped arriving.
+	const maxPipelinedCommands = 32
+
+	type queuedCommand struct {
+		bundle       *mysql.PacketBundle
+		reqTimestamp time.Time
+		op           byte
+	}
+
+	// Response-bearing commands wait here until the server replies. MySQL
+	// clients may pipeline commands before reading responses (notably
+	// Connector/J's RESET -> SEND_LONG_DATA -> EXECUTE sequence), so a single
+	// pendingCommand slot is insufficient. No-response commands are recorded
+	// immediately and never enter this queue.
 	var (
+		commandQueue      []queuedCommand
 		pendingCommand    *mysql.PacketBundle
 		reqTimestamp      time.Time
 		resTimestamp      time.Time
@@ -542,13 +560,54 @@ func asyncMySQLDecode(ctx context.Context, logger *zap.Logger, decodeChan <-chan
 		stmtPrepareOk   *mysql.StmtPrepareOkPacket
 	)
 
+	resetActiveExchange := func() {
+		pendingCommand = nil
+		pendingRespBundle = nil
+		textResultSet = nil
+		binaryResultSet = nil
+		stmtPrepareOk = nil
+		remainingCols = 0
+		remainingParams = 0
+		state = stateExpectCommand
+	}
+
+	activateNextCommand := func() bool {
+		if pendingCommand != nil {
+			return true
+		}
+		if len(commandQueue) == 0 {
+			return false
+		}
+
+		next := commandQueue[0]
+		commandQueue[0] = queuedCommand{}
+		commandQueue = commandQueue[1:]
+
+		pendingCommand = next.bundle
+		reqTimestamp = next.reqTimestamp
+		lastOp = next.op
+		pendingRespBundle = nil
+		textResultSet = nil
+		binaryResultSet = nil
+		stmtPrepareOk = nil
+		remainingCols = 0
+		remainingParams = 0
+		state = stateExpectResponse
+
+		// DecodePayload consults LastOp to decide how to decode the response.
+		// Client-side decoding may already have advanced LastOp to a later
+		// pipelined command, so restore the operation at the head of the FIFO.
+		decodeCtx.LastOp.Store(clientConn, lastOp)
+		return true
+	}
+
 	flushMock := func() {
 		if pendingCommand == nil || pendingRespBundle == nil {
 			return
 		}
-		// If the recorder is force-flushing mid-result-set (i.e., the
-		// next client command arrived before we observed the trailing
-		// EOF / OK_with_EOF terminator from the server), the encoded
+		// If the recorder is force-flushing mid-result-set (i.e., a new client
+		// command arrived, or the connection closed, before we observed the
+		// trailing EOF / OK_with_EOF terminator from the server), the encoded
 		// mock would otherwise have FinalResponse == nil and the replay
 		// encoder would emit no terminator. Drivers that strictly
 		// require the terminator — most notably Connector/J on Java 8 —
@@ -598,9 +657,7 @@ func asyncMySQLDecode(ctx context.Context, logger *zap.Logger, decodeChan <-chan
 		}
 		// (res>=req order is clamped centrally in recordMock for every mysql mock.)
 		recordMock(ctx, requests, responses, mockType, pendingCommand.Header.Type, respOp, mocks, reqTimestamp, resTimestamp, opts)
-		pendingCommand = nil
-		pendingRespBundle = nil
-		state = stateExpectCommand
+		resetActiveExchange()
 	}
 
 	// heldResp buffers a response that reached the decoder BEFORE its command.
@@ -640,22 +697,54 @@ func asyncMySQLDecode(ctx context.Context, logger *zap.Logger, decodeChan <-chan
 					break
 				}
 
-				// If we had an incomplete exchange, flush it.
-				if state != stateExpectCommand && pendingCommand != nil {
-					flushMock()
+				// A partially-read result set does not end on its own: if the
+				// trailing EOF/OK terminator is lost, or DeprecateEOF was
+				// mis-negotiated so IsResultSetTerminator never fires, the
+				// decoder parks in a column/row state forever. activateNextCommand
+				// is only reachable from the stateExpectCommand guard, so nothing
+				// would ever recover it — every later command would queue and
+				// every later RESPONSE would be appended as a row of the stuck
+				// result set.
+				//
+				// A new client command is the signal the server is done. This is
+				// deliberately NOT the pre-FIFO "flush any incomplete exchange":
+				// that also fired in stateExpectResponse, where no response byte
+				// has arrived yet, and silently discarded the command — which is
+				// the pipelining bug (#4262) this change exists to fix. Here we
+				// hold a genuine partial response, and
+				// closeIncompleteResultSetForFlush synthesizes the terminator so
+				// the mock is still replayable.
+				if pendingCommand != nil {
+					switch state {
+					case stateExpectColumns, stateExpectEOFAfterColumns, stateExpectRows:
+						logger.Debug("MySQL result set never terminated; flushing it before the next command",
+							zap.String("nextCommand", "pending"))
+						resTimestamp = item.ts
+						flushMock()
+					}
 				}
 
-				reqTimestamp = item.ts
+				// wire.DecodePayload dispatches on LastOp: with COM_QUERY or
+				// COM_STMT_EXECUTE still set it decodes the packet as that
+				// command's RESPONSE. Fine when commands and responses alternate,
+				// wrong the moment a client pipelines — the second command comes
+				// back a TextResultSet/BinaryProtocolResultSet, is neither a
+				// no-response command nor a 0x unknown, and is queued as a phantom
+				// command that eats a real response slot.
+				//
+				// A client packet is never a response, and LastOp no longer has to
+				// survive the client path: activateNextCommand restores the right
+				// op per exchange before the response is decoded.
+				if op, ok := decodeCtx.LastOp.Load(clientConn); ok &&
+					(op == mysql.COM_QUERY || op == mysql.COM_STMT_EXECUTE) {
+					decodeCtx.LastOp.Store(clientConn, wire.RESET)
+				}
 
 				commandPkt, err := wire.DecodePayload(ctx, logger, pkt, clientConn, decodeCtx)
 				if err != nil {
 					logger.Debug("failed to decode MySQL command in async decoder", zap.Error(err))
-					state = stateExpectCommand
-					pendingCommand = nil
 					continue
 				}
-
-				pendingCommand = commandPkt
 
 				// Handle no-response commands — record mock with empty
 				// responses, matching the synchronous recorder behavior.
@@ -665,11 +754,8 @@ func asyncMySQLDecode(ctx context.Context, logger *zap.Logger, decodeChan <-chan
 				// response time on this keep-alive connection and put
 				// ResTimestampMock before ReqTimestampMock.
 				if wire.IsNoResponseCommand(commandPkt.Header.Type) {
-					requests := []mysql.Request{{PacketBundle: *pendingCommand}}
-					recordMock(ctx, requests, []mysql.Response{}, "mocks", pendingCommand.Header.Type, "NO Response Packet", mocks, reqTimestamp, reqTimestamp, opts)
-					pendingCommand = nil
-					pendingRespBundle = nil
-					state = stateExpectCommand
+					requests := []mysql.Request{{PacketBundle: *commandPkt}}
+					recordMock(ctx, requests, []mysql.Response{}, "mocks", commandPkt.Header.Type, "NO Response Packet", mocks, item.ts, item.ts, opts)
 					continue
 				}
 
@@ -678,21 +764,47 @@ func asyncMySQLDecode(ctx context.Context, logger *zap.Logger, decodeChan <-chan
 				if strings.HasPrefix(commandPkt.Header.Type, "0x") {
 					logger.Debug("Skipping unknown command packet to avoid stream desync",
 						zap.String("type", commandPkt.Header.Type))
-					requests := []mysql.Request{{PacketBundle: *pendingCommand}}
-					recordMock(ctx, requests, []mysql.Response{}, "mocks", pendingCommand.Header.Type, "NO Response Packet", mocks, reqTimestamp, reqTimestamp, opts)
-					pendingCommand = nil
-					pendingRespBundle = nil
-					state = stateExpectCommand
+					requests := []mysql.Request{{PacketBundle: *commandPkt}}
+					recordMock(ctx, requests, []mysql.Response{}, "mocks", commandPkt.Header.Type, "NO Response Packet", mocks, item.ts, item.ts, opts)
 					continue
 				}
 
-				// Determine the command type for response handling.
-				op, opOk := decodeCtx.LastOp.Load(clientConn)
-				if opOk {
+				// Determine the command type for response handling. A miss
+				// here is not a reason to drop the command: the old code
+				// carried the previous op forward, and losing the mock
+				// entirely is worse than decoding its response with a stale
+				// hint — the mock is what replay needs to exist at all.
+				if op, ok := decodeCtx.LastOp.Load(clientConn); ok {
 					lastOp = op
+				} else {
+					logger.Debug("MySQL command decoded without an operation; carrying the previous one forward",
+						zap.String("type", commandPkt.Header.Type))
 				}
 
-				state = stateExpectResponse
+				// Bounded, like the heldResp guard below it. The queue only
+				// holds commands the server has not answered yet, so in
+				// healthy operation it is a handful deep at most; growth past
+				// this means responses have stopped arriving and the oldest
+				// entries are never going to be paired. Dropping the oldest
+				// keeps a long-lived pooled connection from accumulating them
+				// for the life of the process.
+				if len(commandQueue) >= maxPipelinedCommands {
+					// Clear it rather than dropping the head. Dropping one entry
+					// shifts the FIFO by exactly one, so every response from here
+					// on pairs with the wrong command — silently, and for the life
+					// of the connection. Overflow already means the pairing is
+					// lost, so lose these mocks loudly instead of emitting that
+					// many mis-paired ones.
+					logger.Warn("MySQL pipelined command queue overflowed; dropping unanswered commands",
+						zap.Int("dropped", len(commandQueue)),
+						zap.Int("limit", maxPipelinedCommands))
+					commandQueue = commandQueue[:0]
+				}
+				commandQueue = append(commandQueue, queuedCommand{
+					bundle:       commandPkt,
+					reqTimestamp: item.ts,
+					op:           lastOp,
+				})
 
 				// If this command's response raced ahead and was held, replay it
 				// now — before any further decodeChan items — so it pairs with this
@@ -710,7 +822,11 @@ func asyncMySQLDecode(ctx context.Context, logger *zap.Logger, decodeChan <-chan
 			// it when the command arrives, instead of dropping it below at
 			// "received MySQL response with no pending command" — which silently
 			// lost the query mock for fast connection-pool-validation exchanges.
-			if state == stateExpectCommand && pendingCommand == nil {
+			// len(commandQueue) matters as much as pendingCommand: a pipelined
+			// burst leaves commands queued with none active, and those responses
+			// belong to the head of that queue. Holding them here instead would
+			// strand every response after the first in a pipelined exchange.
+			if state == stateExpectCommand && pendingCommand == nil && len(commandQueue) == 0 {
 				heldResp = append(heldResp, item)
 				if len(heldResp) > 128 { // bound: a genuine orphan can't grow unboundedly
 					heldResp = heldResp[1:]
@@ -730,9 +846,11 @@ func asyncMySQLDecode(ctx context.Context, logger *zap.Logger, decodeChan <-chan
 				}
 
 				if state == stateExpectCommand {
-					// Unexpected server data without a pending command.
-					logger.Debug("received MySQL response with no pending command")
-					continue
+					if !activateNextCommand() {
+						// Unexpected server data without a pending command.
+						logger.Debug("received MySQL response with no pending command")
+						continue
+					}
 				}
 
 				switch state {
@@ -742,14 +860,28 @@ func asyncMySQLDecode(ctx context.Context, logger *zap.Logger, decodeChan <-chan
 						&remainingCols, &remainingParams)
 					if state == stateExpectCommand {
 						resTimestamp = item.ts
-						flushMock()
+						if pendingRespBundle == nil {
+							// The response failed to decode. flushMock would
+							// early-return on the nil bundle and leave
+							// pendingCommand set with state back at
+							// stateExpectCommand — a pair that activateNextCommand
+							// reports as "already active" without ever setting
+							// stateExpectResponse, so the switch below matches
+							// nothing and every later packet on this connection is
+							// silently dropped. Drop this one exchange instead and
+							// resync on the queue, which is what the pre-FIFO code
+							// achieved by reassigning pendingCommand per command.
+							resetActiveExchange()
+						} else {
+							flushMock()
+						}
 					}
 
 				case stateExpectColumns:
 					col, _, err := rowscols.DecodeColumn(ctx, logger, pkt)
 					if err != nil {
 						logger.Debug("failed to decode column definition in async decoder", zap.Error(err))
-						state = stateExpectCommand
+						resetActiveExchange()
 						continue
 					}
 					if textResultSet != nil {
@@ -831,7 +963,7 @@ func asyncMySQLDecode(ctx context.Context, logger *zap.Logger, decodeChan <-chan
 					col, _, err := rowscols.DecodeColumn(ctx, logger, pkt)
 					if err != nil {
 						logger.Debug("failed to decode param definition in async decoder", zap.Error(err))
-						state = stateExpectCommand
+						resetActiveExchange()
 						continue
 					}
 					if stmtPrepareOk != nil {
@@ -870,7 +1002,7 @@ func asyncMySQLDecode(ctx context.Context, logger *zap.Logger, decodeChan <-chan
 					col, _, err := rowscols.DecodeColumn(ctx, logger, pkt)
 					if err != nil {
 						logger.Debug("failed to decode stmt column definition in async decoder", zap.Error(err))
-						state = stateExpectCommand
+						resetActiveExchange()
 						continue
 					}
 					if stmtPrepareOk != nil {

--- a/pkg/agent/proxy/integrations/mysql/recorder/query.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/query.go
@@ -375,8 +375,19 @@ func asyncMySQLDecode(ctx context.Context, logger *zap.Logger, decodeChan <-chan
 
 	state := stateExpectCommand
 
-	// Current command being processed.
+	type queuedCommand struct {
+		bundle       *mysql.PacketBundle
+		reqTimestamp time.Time
+		op           byte
+	}
+
+	// Response-bearing commands wait here until the server replies. MySQL
+	// clients may pipeline commands before reading responses (notably
+	// Connector/J's RESET -> SEND_LONG_DATA -> EXECUTE sequence), so a single
+	// pendingCommand slot is insufficient. No-response commands are recorded
+	// immediately and never enter this queue.
 	var (
+		commandQueue      []queuedCommand
 		pendingCommand    *mysql.PacketBundle
 		reqTimestamp      time.Time
 		resTimestamp      time.Time
@@ -392,6 +403,47 @@ func asyncMySQLDecode(ctx context.Context, logger *zap.Logger, decodeChan <-chan
 		binaryResultSet *mysql.BinaryProtocolResultSet
 		stmtPrepareOk   *mysql.StmtPrepareOkPacket
 	)
+
+	resetActiveExchange := func() {
+		pendingCommand = nil
+		pendingRespBundle = nil
+		textResultSet = nil
+		binaryResultSet = nil
+		stmtPrepareOk = nil
+		remainingCols = 0
+		remainingParams = 0
+		state = stateExpectCommand
+	}
+
+	activateNextCommand := func() bool {
+		if pendingCommand != nil {
+			return true
+		}
+		if len(commandQueue) == 0 {
+			return false
+		}
+
+		next := commandQueue[0]
+		commandQueue[0] = queuedCommand{}
+		commandQueue = commandQueue[1:]
+
+		pendingCommand = next.bundle
+		reqTimestamp = next.reqTimestamp
+		lastOp = next.op
+		pendingRespBundle = nil
+		textResultSet = nil
+		binaryResultSet = nil
+		stmtPrepareOk = nil
+		remainingCols = 0
+		remainingParams = 0
+		state = stateExpectResponse
+
+		// DecodePayload consults LastOp to decide how to decode the response.
+		// Client-side decoding may already have advanced LastOp to a later
+		// pipelined command, so restore the operation at the head of the FIFO.
+		decodeCtx.LastOp.Store(clientConn, lastOp)
+		return true
+	}
 
 	flushMock := func() {
 		if pendingCommand == nil || pendingRespBundle == nil {
@@ -448,9 +500,7 @@ func asyncMySQLDecode(ctx context.Context, logger *zap.Logger, decodeChan <-chan
 			mockType = "connection"
 		}
 		recordMock(ctx, requests, responses, mockType, pendingCommand.Header.Type, respOp, mocks, reqTimestamp, resTimestamp, opts)
-		pendingCommand = nil
-		pendingRespBundle = nil
-		state = stateExpectCommand
+		resetActiveExchange()
 	}
 
 	for item := range decodeChan {
@@ -468,22 +518,11 @@ func asyncMySQLDecode(ctx context.Context, logger *zap.Logger, decodeChan <-chan
 					break
 				}
 
-				// If we had an incomplete exchange, flush it.
-				if state != stateExpectCommand && pendingCommand != nil {
-					flushMock()
-				}
-
-				reqTimestamp = item.ts
-
 				commandPkt, err := wire.DecodePayload(ctx, logger, pkt, clientConn, decodeCtx)
 				if err != nil {
 					logger.Debug("failed to decode MySQL command in async decoder", zap.Error(err))
-					state = stateExpectCommand
-					pendingCommand = nil
 					continue
 				}
-
-				pendingCommand = commandPkt
 
 				// Handle no-response commands — record mock with empty
 				// responses, matching the synchronous recorder behavior.
@@ -493,11 +532,8 @@ func asyncMySQLDecode(ctx context.Context, logger *zap.Logger, decodeChan <-chan
 				// response time on this keep-alive connection and put
 				// ResTimestampMock before ReqTimestampMock.
 				if wire.IsNoResponseCommand(commandPkt.Header.Type) {
-					requests := []mysql.Request{{PacketBundle: *pendingCommand}}
-					recordMock(ctx, requests, []mysql.Response{}, "mocks", pendingCommand.Header.Type, "NO Response Packet", mocks, reqTimestamp, reqTimestamp, opts)
-					pendingCommand = nil
-					pendingRespBundle = nil
-					state = stateExpectCommand
+					requests := []mysql.Request{{PacketBundle: *commandPkt}}
+					recordMock(ctx, requests, []mysql.Response{}, "mocks", commandPkt.Header.Type, "NO Response Packet", mocks, item.ts, item.ts, opts)
 					continue
 				}
 
@@ -506,21 +542,23 @@ func asyncMySQLDecode(ctx context.Context, logger *zap.Logger, decodeChan <-chan
 				if strings.HasPrefix(commandPkt.Header.Type, "0x") {
 					logger.Debug("Skipping unknown command packet to avoid stream desync",
 						zap.String("type", commandPkt.Header.Type))
-					requests := []mysql.Request{{PacketBundle: *pendingCommand}}
-					recordMock(ctx, requests, []mysql.Response{}, "mocks", pendingCommand.Header.Type, "NO Response Packet", mocks, reqTimestamp, reqTimestamp, opts)
-					pendingCommand = nil
-					pendingRespBundle = nil
-					state = stateExpectCommand
+					requests := []mysql.Request{{PacketBundle: *commandPkt}}
+					recordMock(ctx, requests, []mysql.Response{}, "mocks", commandPkt.Header.Type, "NO Response Packet", mocks, item.ts, item.ts, opts)
 					continue
 				}
 
 				// Determine the command type for response handling.
-				op, opOk := decodeCtx.LastOp.Load(clientConn)
-				if opOk {
-					lastOp = op
+				op, ok := decodeCtx.LastOp.Load(clientConn)
+				if !ok {
+					logger.Debug("MySQL command decoded without an operation",
+						zap.String("type", commandPkt.Header.Type))
+					continue
 				}
-
-				state = stateExpectResponse
+				commandQueue = append(commandQueue, queuedCommand{
+					bundle:       commandPkt,
+					reqTimestamp: item.ts,
+					op:           op,
+				})
 			}
 
 		} else {
@@ -538,9 +576,11 @@ func asyncMySQLDecode(ctx context.Context, logger *zap.Logger, decodeChan <-chan
 				}
 
 				if state == stateExpectCommand {
-					// Unexpected server data without a pending command.
-					logger.Debug("received MySQL response with no pending command")
-					continue
+					if !activateNextCommand() {
+						// Unexpected server data without a pending command.
+						logger.Debug("received MySQL response with no pending command")
+						continue
+					}
 				}
 
 				switch state {

--- a/pkg/agent/proxy/integrations/mysql/wire/decode.go
+++ b/pkg/agent/proxy/integrations/mysql/wire/decode.go
@@ -3,6 +3,7 @@ package wire
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"net"
@@ -396,7 +397,7 @@ func decodePacket(ctx context.Context, logger *zap.Logger, packet mysql.Packet, 
 
 	case payloadType == mysql.COM_STMT_EXECUTE:
 		logger.Debug("COM_STMT_EXECUTE packet", zap.Any("Type", payloadType))
-		pkt, err := preparedstmt.DecodeStmtExecute(ctx, logger, payload, decodeCtx.PreparedStatements, decodeCtx.ClientCapabilities)
+		pkt, err := preparedstmt.DecodeStmtExecute(ctx, logger, payload, decodeCtx.PreparedStatements, decodeCtx.ClientCapabilities, decodeCtx.LongDataParams[stmtIDFromExecute(payload)])
 		if err != nil {
 			return parsedPacket, fmt.Errorf("failed to decode COM_STMT_EXECUTE packet: %w", err)
 		}
@@ -422,6 +423,11 @@ func decodePacket(ctx context.Context, logger *zap.Logger, packet mysql.Packet, 
 			return parsedPacket, fmt.Errorf("failed to decode COM_STMT_RESET packet: %w", err)
 		}
 
+		// COM_STMT_RESET discards any long data buffered on the server, so
+		// drop our record of it too — otherwise the next EXECUTE would skip a
+		// parameter whose value is genuinely in the payload.
+		delete(decodeCtx.LongDataParams, pkt.StatementID)
+
 		setPacketInfo(ctx, parsedPacket, pkt, mysql.CommandStatusToString(mysql.COM_STMT_RESET), clientConn, mysql.COM_STMT_RESET, decodeCtx)
 
 		logger.Debug("COM_STMT_RESET decoded", zap.Any("parsed packet", parsedPacket))
@@ -433,6 +439,16 @@ func decodePacket(ctx context.Context, logger *zap.Logger, packet mysql.Packet, 
 			return parsedPacket, fmt.Errorf("failed to decode COM_STMT_SEND_LONG_DATA packet: %w", err)
 		}
 
+		// Remember that this parameter's value travelled out of band, so the
+		// following COM_STMT_EXECUTE knows not to look for it in its payload.
+		if decodeCtx.LongDataParams == nil {
+			decodeCtx.LongDataParams = make(map[uint32]map[uint16]bool)
+		}
+		if decodeCtx.LongDataParams[pkt.StatementID] == nil {
+			decodeCtx.LongDataParams[pkt.StatementID] = make(map[uint16]bool)
+		}
+		decodeCtx.LongDataParams[pkt.StatementID][pkt.ParameterID] = true
+
 		setPacketInfo(ctx, parsedPacket, pkt, mysql.CommandStatusToString(mysql.COM_STMT_SEND_LONG_DATA), clientConn, mysql.COM_STMT_SEND_LONG_DATA, decodeCtx)
 		logger.Debug("COM_STMT_SEND_LONG_DATA decoded", zap.Any("parsed packet", parsedPacket))
 	default:
@@ -441,4 +457,15 @@ func decodePacket(ctx context.Context, logger *zap.Logger, packet mysql.Packet, 
 	}
 
 	return parsedPacket, nil
+}
+
+// stmtIDFromExecute peeks the statement id out of a COM_STMT_EXECUTE payload
+// so the caller can look up which of its parameters arrived earlier via
+// COM_STMT_SEND_LONG_DATA. Returns 0 for a payload too short to carry one,
+// which simply means "no long data recorded".
+func stmtIDFromExecute(payload []byte) uint32 {
+	if len(payload) < 5 {
+		return 0
+	}
+	return binary.LittleEndian.Uint32(payload[1:5])
 }

--- a/pkg/agent/proxy/integrations/mysql/wire/phase/query/preparedstmt/stmtExecutePacket.go
+++ b/pkg/agent/proxy/integrations/mysql/wire/phase/query/preparedstmt/stmtExecutePacket.go
@@ -16,7 +16,10 @@ import (
 
 // COM_STMT_EXECUTE: https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_stmt_execute.html
 
-func DecodeStmtExecute(_ context.Context, logger *zap.Logger, data []byte, preparedStmts map[uint32]*mysql.StmtPrepareOkPacket, clientCapabilities uint32) (*mysql.StmtExecutePacket, error) {
+// longDataParams names the parameters whose value was streamed ahead with
+// COM_STMT_SEND_LONG_DATA and is therefore ABSENT from this packet, even
+// though the null bitmap reports them as non-NULL. May be nil.
+func DecodeStmtExecute(_ context.Context, logger *zap.Logger, data []byte, preparedStmts map[uint32]*mysql.StmtPrepareOkPacket, clientCapabilities uint32, longDataParams map[uint16]bool) (*mysql.StmtExecutePacket, error) {
 	if len(data) < 10 {
 		return &mysql.StmtExecutePacket{}, fmt.Errorf("packet length too short for COM_STMT_EXECUTE")
 	}
@@ -169,6 +172,17 @@ func DecodeStmtExecute(_ context.Context, logger *zap.Logger, data []byte, prepa
 			bitIndex := i % 8
 			if byteIndex < len(packet.NullBitmap) && (packet.NullBitmap[byteIndex]&(1<<bitIndex)) != 0 {
 				// Parameter is NULL, set value to nil and continue
+				packet.Parameters[i].Value = nil
+				continue
+			}
+
+			// A parameter sent with COM_STMT_SEND_LONG_DATA has no value in
+			// this packet — the server already holds it — but it is not NULL
+			// either, so the bitmap check above does not catch it. Reading a
+			// value here is what made every streamed-BLOB EXECUTE fail to
+			// decode and vanish from the recording (#4262). The bytes live in
+			// the SEND_LONG_DATA mock that precedes this one.
+			if longDataParams[uint16(i)] {
 				packet.Parameters[i].Value = nil
 				continue
 			}

--- a/pkg/agent/proxy/integrations/mysql/wire/phase/query/preparedstmt/stmtExecutePacket_test.go
+++ b/pkg/agent/proxy/integrations/mysql/wire/phase/query/preparedstmt/stmtExecutePacket_test.go
@@ -44,7 +44,7 @@ func TestDecodeStmtExecute_ParameterCountFix(t *testing.T) {
 	// Test with CLIENT_QUERY_ATTRIBUTES disabled (common case)
 	clientCapabilities := uint32(0)
 
-	packet, err := DecodeStmtExecute(ctx, logger, data, preparedStmts, clientCapabilities)
+	packet, err := DecodeStmtExecute(ctx, logger, data, preparedStmts, clientCapabilities, nil)
 
 	if err != nil {
 		t.Fatalf("DecodeStmtExecute failed: %v", err)
@@ -91,7 +91,7 @@ func TestDecodeStmtExecute_NoParameters(t *testing.T) {
 	ctx := context.Background()
 	clientCapabilities := uint32(0)
 
-	packet, err := DecodeStmtExecute(ctx, logger, data, preparedStmts, clientCapabilities)
+	packet, err := DecodeStmtExecute(ctx, logger, data, preparedStmts, clientCapabilities, nil)
 
 	if err != nil {
 		t.Fatalf("DecodeStmtExecute failed: %v", err)
@@ -134,7 +134,7 @@ func TestDecodeStmtExecute_DateTimeThenString(t *testing.T) {
 	ctx := context.Background()
 	clientCapabilities := uint32(0)
 
-	packet, err := DecodeStmtExecute(ctx, logger, data, preparedStmts, clientCapabilities)
+	packet, err := DecodeStmtExecute(ctx, logger, data, preparedStmts, clientCapabilities, nil)
 	if err != nil {
 		t.Fatalf("DecodeStmtExecute failed: %v", err)
 	}
@@ -189,7 +189,7 @@ func TestDecodeStmtExecute_QueryAttrsExtension(t *testing.T) {
 
 	clientCapabilities := mysql.CLIENT_QUERY_ATTRIBUTES
 
-	packet, err := DecodeStmtExecute(context.Background(), zap.NewNop(), data, preparedStmts, clientCapabilities)
+	packet, err := DecodeStmtExecute(context.Background(), zap.NewNop(), data, preparedStmts, clientCapabilities, nil)
 	if err != nil {
 		t.Fatalf("DecodeStmtExecute failed: %v", err)
 	}
@@ -244,7 +244,7 @@ func TestDecodeStmtExecute_QueryAttrsExtensionTwoStrings(t *testing.T) {
 
 	clientCapabilities := mysql.CLIENT_QUERY_ATTRIBUTES
 
-	packet, err := DecodeStmtExecute(context.Background(), zap.NewNop(), data, preparedStmts, clientCapabilities)
+	packet, err := DecodeStmtExecute(context.Background(), zap.NewNop(), data, preparedStmts, clientCapabilities, nil)
 	if err != nil {
 		t.Fatalf("DecodeStmtExecute failed: %v", err)
 	}
@@ -329,7 +329,7 @@ func TestDecodeStmtExecute_IntegerAsDouble(t *testing.T) {
 
 			clientCapabilities := mysql.CLIENT_QUERY_ATTRIBUTES
 
-			packet, err := DecodeStmtExecute(context.Background(), zap.NewNop(), data, preparedStmts, clientCapabilities)
+			packet, err := DecodeStmtExecute(context.Background(), zap.NewNop(), data, preparedStmts, clientCapabilities, nil)
 			if err != nil {
 				t.Fatalf("DecodeStmtExecute failed: %v", err)
 			}
@@ -380,7 +380,7 @@ func TestDecodeStmtExecute_QueryAttrsExtensionZeroParams(t *testing.T) {
 		0x00, // length-encoded parameter_count = 0
 	}
 
-	packet, err := DecodeStmtExecute(context.Background(), zap.NewNop(), data, preparedStmts, mysql.CLIENT_QUERY_ATTRIBUTES)
+	packet, err := DecodeStmtExecute(context.Background(), zap.NewNop(), data, preparedStmts, mysql.CLIENT_QUERY_ATTRIBUTES, nil)
 	if err != nil {
 		t.Fatalf("DecodeStmtExecute failed: %v", err)
 	}
@@ -389,5 +389,55 @@ func TestDecodeStmtExecute_QueryAttrsExtensionZeroParams(t *testing.T) {
 	}
 	if len(packet.Parameters) != 0 {
 		t.Fatalf("Parameters: expected len 0, got %d", len(packet.Parameters))
+	}
+}
+
+// A parameter whose value was streamed ahead with COM_STMT_SEND_LONG_DATA is
+// absent from the COM_STMT_EXECUTE payload, but the null bitmap still reports
+// it as NOT NULL — the server already holds the bytes. Reading a value for it
+// walks off the end of the packet, so the command is rejected and never
+// recorded, which is what dropped every streamed-BLOB EXECUTE from the trace
+// and made replay fail with "Can not read response from server" (#4262).
+func TestDecodeStmtExecute_ParameterSentAsLongData(t *testing.T) {
+	const stmtID = uint32(7)
+	preparedStmts := map[uint32]*mysql.StmtPrepareOkPacket{
+		stmtID: {StatementID: stmtID, NumParams: 1},
+	}
+
+	// One parameter, not NULL, types bound — and no value bytes, because the
+	// value travelled in a preceding COM_STMT_SEND_LONG_DATA.
+	data := []byte{
+		0x17,                   // COM_STMT_EXECUTE
+		0x07, 0x00, 0x00, 0x00, // statement id
+		0x00,                   // flags
+		0x01, 0x00, 0x00, 0x00, // iteration count
+		0x00,       // NULL bitmap: parameter 0 is NOT null
+		0x01,       // new params bind flag
+		0xfc, 0x00, // type = MYSQL_TYPE_BLOB, unsigned = false
+	}
+
+	logger := zap.NewNop()
+
+	// Without the long-data hint the decoder looks for a value that is not
+	// there and rejects the whole command.
+	if _, err := DecodeStmtExecute(context.Background(), logger, data, preparedStmts, 0, nil); err == nil {
+		t.Fatal("premise broken: the payload is supposed to be short by one parameter value")
+	}
+
+	longData := map[uint16]bool{0: true}
+	packet, err := DecodeStmtExecute(context.Background(), logger, data, preparedStmts, 0, longData)
+	if err != nil {
+		t.Fatalf("a parameter sent via COM_STMT_SEND_LONG_DATA must not make the EXECUTE "+
+			"undecodable — the command is then dropped and replay has no mock for it: %v", err)
+	}
+	if packet.StatementID != stmtID {
+		t.Errorf("StatementID = %d, want %d", packet.StatementID, stmtID)
+	}
+	if len(packet.Parameters) != 1 {
+		t.Fatalf("got %d parameters, want 1", len(packet.Parameters))
+	}
+	if packet.Parameters[0].Value != nil {
+		t.Errorf("the long-sent parameter carries %v; its bytes live in the SEND_LONG_DATA "+
+			"mock, not here", packet.Parameters[0].Value)
 	}
 }

--- a/pkg/agent/proxy/integrations/mysql/wire/util.go
+++ b/pkg/agent/proxy/integrations/mysql/wire/util.go
@@ -26,6 +26,21 @@ type DecodeContext struct {
 	RecordedClientCaps uint32 // caps from the recorded config mock
 	PreferRecordedCaps bool   // if true, prefer RecordedClientCaps over ClientCaps
 
+	// LongDataParams records which parameters of a prepared statement had
+	// their value streamed ahead of time with COM_STMT_SEND_LONG_DATA
+	// (stmtID -> set of parameter ids).
+	//
+	// It has to be tracked out of band because the wire gives no other clue:
+	// a long-sent parameter is simply ABSENT from the COM_STMT_EXECUTE
+	// payload while still being non-NULL in the null bitmap, so a decoder
+	// that reads a value for every non-NULL parameter walks off the end of
+	// the packet and rejects the command. That is what dropped every
+	// streamed-BLOB EXECUTE from the recording (#4262).
+	//
+	// The server discards long data when the statement executes or resets,
+	// so the entry is cleared at both points.
+	LongDataParams map[uint32]map[uint16]bool
+
 	//runtime stmt-id → query mapping set when COM_STMT_PREP matches
 	StmtIDToQuery map[uint32]string
 	// Statement ID counter for generating unique statement IDs during replay
@@ -156,7 +171,12 @@ func IsGenericResponsePkt(packet *mysql.PacketBundle) bool {
 
 func IsNoResponseCommand(command string) bool {
 	switch command {
-	case mysql.CommandStatusToString(mysql.COM_STMT_CLOSE), mysql.CommandStatusToString(mysql.COM_STMT_SEND_LONG_DATA):
+	// COM_QUIT is answered only by the server closing the socket. Leaving it
+	// out made the async recorder queue it as a response-bearing command,
+	// where it is never paired and, worse, keeps the queue non-empty — which
+	// suppresses the heldResp guard for any genuinely orphaned response that
+	// follows it.
+	case mysql.CommandStatusToString(mysql.COM_STMT_CLOSE), mysql.CommandStatusToString(mysql.COM_STMT_SEND_LONG_DATA), mysql.CommandStatusToString(mysql.COM_QUIT):
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Describe the changes that are made

- Queue response-bearing MySQL commands until their corresponding server packets arrive.
- Preserve FIFO pairing when Connector/J pipelines `COM_STMT_RESET`, `COM_STMT_SEND_LONG_DATA`, and `COM_STMT_EXECUTE`.
- Keep no-response commands such as `COM_STMT_SEND_LONG_DATA` outside the response queue.
- Restore the queued command operation before decoding its response, preventing a later pipelined command from changing the response decoder state.
- Add a deterministic regression test that distinguishes RESET's zero-row OK from EXECUTE's affected-row OK.

## Links & References

**Closes:** #4262

### 🔗 Related PRs

- NA

### 🐞 Related Issues

- #4262

### 📄 Related Documents

- NA

## What type of PR is this? (check all applicable)

- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?

- [ ] 👍 yes
- [x] 🙅 no, because the protocol-level regression is covered deterministically in the MySQL recorder package
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?

- [x] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?

- [x] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

```bash
go test ./pkg/agent/proxy/integrations/mysql/recorder -run TestAsyncMySQLDecode_PipelinedResetLongDataExecute -count=1
go test ./pkg/agent/proxy/integrations/mysql/... -count=1
go test -race ./pkg/agent/proxy/integrations/mysql/recorder -count=1
```

## Self Review done?

- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?

- NA

## 🧠 Semantics for PR Title & Branch Name

- **PR Title:** `fix(mysql): preserve pipelined command response order`
- **Branch Name:** `fix/issue-4262-mysql-pipelining`

---

## Additional checklist:

- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?
