### PR TITLE
fix(proxy): stop non-TLS opportunistic-intercept path from hanging forever

### DIFF
--- a/pkg/agent/proxy/opportunistic_tls.go
+++ b/pkg/agent/proxy/opportunistic_tls.go
@@ -88,7 +88,10 @@ func (p *Proxy) opportunisticTLSIntercept(ctx context.Context, srcConn net.Conn,
 		// setting an already-expired deadline. Without this, a goroutine
 		// blocked in from.Read() can't observe ctx cancellation until the
 		// opportunisticPeekChunkTimeout (5 s) fires — adding a 5 s stall
-		// to every TLS connection before hijackAndMITM can start.
+		// to every TLS connection before hijackAndMITM can start. Safe to
+		// force here: once we've decided to hijack, any bytes the peer
+		// was mid-read on are discarded anyway (MITM starts fresh), so
+		// there's no in-flight progress to lose by cutting it off instantly.
 		_ = srcConn.SetReadDeadline(time.Now())
 		_ = dstConn.SetReadDeadline(time.Now())
 		wg.Wait()
@@ -120,8 +123,28 @@ func (p *Proxy) opportunisticTLSIntercept(ctx context.Context, srcConn net.Conn,
 			// Drain the OTHER side too so both goroutines exit; then
 			// either fall through to a pure relay (budget-exhaustion
 			// case) or close on the error path.
-			otherErr := waitForOther(ctx, sniffCh, &wg)
+			//
+			// cancelRelay runs BEFORE waitForOther, not after: waitForOther
+			// blocks until the peer's sniffAndRelayLoop goroutine exits,
+			// and that goroutine only checks ctx.Done() between reads —
+			// on every ordinary read timeout it just continues. If we
+			// waited first and cancelled after, a peer with nothing left
+			// to send would never be told to stop and waitForOther would
+			// hang forever (#4398).
+			//
+			// Deliberately NOT forcing an expired read deadline here (as
+			// cleanup() does for the isTLS path): the peer may be mid-Read
+			// on a connection that's genuinely still relaying real bytes
+			// toward its own budget completion, not idle. Forcing an
+			// instant cutoff would abort that in-flight progress and turn
+			// a legitimate pass-through into a spurious timeout error.
+			// Cancelling relayCtx alone still bounds the wait to at most
+			// one opportunisticPeekChunkTimeout (5 s, the same per-read
+			// cap sniffAndRelayLoop already uses) instead of forever, while
+			// letting an actively-progressing peer finish naturally if it
+			// completes before that.
 			cancelRelay()
+			otherErr := waitForOther(ctx, sniffCh, &wg)
 
 			if res.err == nil && otherErr == nil {
 				// Budget hit on both sides without TLS — the

--- a/pkg/agent/proxy/opportunistic_tls.go
+++ b/pkg/agent/proxy/opportunistic_tls.go
@@ -158,20 +158,49 @@ func (p *Proxy) opportunisticTLSIntercept(ctx context.Context, srcConn net.Conn,
 			// and the next read — continuePlainRelay's io.Copy — gets them
 			// intact.
 			//
-			// Two honest limits on "bounded". The poke is best-effort: a
-			// peer between its loop-top ctx check and its own
-			// SetReadDeadline (:213-219) will overwrite this deadline with
-			// a fresh 5 s one and park anyway. And it only bounds a peer
-			// blocked in Read — one blocked in to.Write() at :262 has no
-			// write deadline to expire and is not bounded at all.
+			// The poke is best-effort, not a guarantee: a peer sitting
+			// between its loop-top ctx check and its own SetReadDeadline
+			// will overwrite this deadline with a fresh one and park
+			// anyway. It also only reaches a peer blocked in Read — one
+			// blocked in to.Write() is bounded by that call's own write
+			// deadline instead. Either way the wait is capped at one
+			// opportunisticPeekChunkTimeout rather than forever.
 			cancelRelay()
 			_ = srcConn.SetReadDeadline(time.Now())
 			_ = dstConn.SetReadDeadline(time.Now())
-			otherErr := waitForOther(ctx, sniffCh, &wg)
+			other := waitForOther(ctx, sniffCh, &wg)
 			_ = srcConn.SetReadDeadline(time.Time{})
 			_ = dstConn.SetReadDeadline(time.Time{})
 
-			if res.err == nil && otherErr == nil {
+			// The peer caught a ClientHello while we were taking the
+			// non-TLS branch on this side. Those bytes were withheld from
+			// the upstream so they could be replayed, and they exist
+			// nowhere else — dropping them leaves the upstream waiting
+			// for a handshake it will never see while the app waits for a
+			// ServerHello that can never come.
+			//
+			// Forward them and carry on as a plain relay rather than
+			// hijacking. Interception was already abandoned on this
+			// connection: only the src side sets isTLS, so res must be
+			// the dst result, and the res.err == nil guard narrows that
+			// to dst budget exhaustion — the upstream sent a full
+			// opportunisticPeekMaxBytes of pre-TLS bytes before the
+			// ClientHello landed. Real STARTTLS preambles are orders of
+			// magnitude under 64 KiB, so this is a defensive path, and
+			// handing an unexercised corner to hijackAndMITM would risk
+			// more than passing the handshake through costs. The app and
+			// the upstream then negotiate TLS directly; keploy simply
+			// does not intercept this one.
+			if res.err == nil && other.isTLS && len(other.buffered) > 0 {
+				if werr := replayWithheldHandshake(dstConn, other.buffered); werr != nil {
+					_ = srcConn.Close()
+					_ = dstConn.Close()
+					return firstNonShutdownErr(werr, nil)
+				}
+				return p.continuePlainRelay(ctx, srcConn, dstConn)
+			}
+
+			if res.err == nil && other.err == nil {
 				// Budget hit on both sides without TLS — the
 				// goroutines have already been forwarding bytes
 				// during their peek window. After they exit, finish
@@ -184,7 +213,7 @@ func (p *Proxy) opportunisticTLSIntercept(ctx context.Context, srcConn net.Conn,
 			// at end-of-conversation; demote them to nil.
 			_ = srcConn.Close()
 			_ = dstConn.Close()
-			return firstNonShutdownErr(res.err, otherErr)
+			return firstNonShutdownErr(res.err, other.err)
 		}
 	}
 }
@@ -249,7 +278,7 @@ func (p *Proxy) sniffAndRelayLoop(ctx context.Context, side string, from, to net
 				// picked at random.
 				return
 			}
-			pushSignal(ctx, sniffCh, sniffResult{side: side, isTLS: false, err: err})
+			pushSignal(sniffCh, sniffResult{side: side, isTLS: false, err: err})
 			return
 		}
 		if n == 0 {
@@ -265,13 +294,66 @@ func (p *Proxy) sniffAndRelayLoop(ctx context.Context, side string, from, to net
 		if side == "src" && pTls.IsTLSHandshake(chunk) {
 			persisted := make([]byte, n)
 			copy(persisted, chunk)
-			pushSignal(ctx, sniffCh, sniffResult{side: side, isTLS: true, buffered: persisted})
+			pushSignal(sniffCh, sniffResult{side: side, isTLS: true, buffered: persisted})
 			return
 		}
 
-		// Forward to the other side verbatim.
-		if _, werr := to.Write(chunk); werr != nil {
-			pushSignal(ctx, sniffCh, sniffResult{side: side, isTLS: false, err: werr})
+		// Forward to the other side verbatim, under a write deadline.
+		//
+		// Without one this is the #4398 leak again from the other end: a
+		// peer that has stopped reading fills the send buffer, Write
+		// blocks forever, and cancelRelay is invisible to a blocked
+		// Write — so wg.Wait() never returns and the connection's two
+		// goroutines and two sockets are pinned for the life of the
+		// process. The parent's expired-deadline poke does not help
+		// either; it sets a READ deadline.
+		//
+		// A timeout is retried rather than reported. A slow consumer is
+		// not an error, and abandoning a partially written chunk would
+		// punch a hole in a stream we are supposed to relay verbatim —
+		// these bytes are already out of the kernel buffer, so nothing
+		// else can re-send them. The deadline exists to regain control
+		// every opportunisticPeekChunkTimeout, not to cap the transfer.
+		//
+		// Once the context is cancelled we stop retrying, which bounds
+		// shutdown to one window. A peer draining too slowly to finish
+		// the chunk inside that window IS cut off — Write only returns a
+		// nil error once the whole slice is out — and the connection is
+		// then closed rather than relayed on with a hole in it.
+		written := 0
+		var werr error
+		for written < len(chunk) {
+			_ = to.SetWriteDeadline(time.Now().Add(opportunisticPeekChunkTimeout))
+			var wn int
+			wn, werr = to.Write(chunk[written:])
+			_ = to.SetWriteDeadline(time.Time{})
+			written += wn
+			if werr == nil {
+				continue
+			}
+			if isTimeoutErr(werr) && ctx.Err() == nil {
+				// Slow consumer; keep going now that ctx has been rechecked.
+				werr = nil
+				continue
+			}
+			if written == len(chunk) {
+				// Everything got out despite the error; nothing was lost,
+				// so don't fail a chunk that actually landed.
+				werr = nil
+				break
+			}
+			// A real write error, or cancellation with the chunk not fully
+			// out. Both are reported, including the written == 0 case:
+			// unlike a cut-short Read — whose bytes are still in the
+			// kernel buffer for continuePlainRelay to pick up — this chunk
+			// was already consumed out of `from` and lives only in buf, so
+			// returning quietly would punch a hole in a stream we are
+			// supposed to relay verbatim and leave the connection up to
+			// carry the corruption. Closing is the honest outcome.
+			break
+		}
+		if werr != nil {
+			pushSignal(sniffCh, sniffResult{side: side, isTLS: false, err: werr})
 			return
 		}
 
@@ -280,7 +362,7 @@ func (p *Proxy) sniffAndRelayLoop(ctx context.Context, side string, from, to net
 			// Budget exhausted; sniffCh "no TLS" but keep relaying
 			// until ctx is cancelled (the parent will start a clean
 			// io.Copy after both goroutines exit).
-			pushSignal(ctx, sniffCh, sniffResult{side: side, isTLS: false})
+			pushSignal(sniffCh, sniffResult{side: side, isTLS: false})
 			return
 		}
 	}
@@ -512,37 +594,85 @@ func closeWriteIfPossible(c net.Conn) error {
 	return nil
 }
 
-// pushSignal sends a result on the channel unless ctx is cancelled.
-// The channel is buffered with capacity 2 so this never blocks in
-// the normal path; the ctx.Done branch is only there so a cancelled
-// goroutine doesn't deadlock if the parent has already moved on.
-func pushSignal(ctx context.Context, ch chan<- sniffResult, res sniffResult) {
-	select {
-	case ch <- res:
-	case <-ctx.Done():
-	}
+// pushSignal publishes a goroutine's verdict. The send is unguarded on
+// purpose: sniffCh has capacity 2, exactly two sniffAndRelayLoop
+// goroutines run per connection, and every call site returns
+// immediately afterwards — so at most two sends ever occur and the
+// buffer can never be full.
+//
+// This used to select over ctx.Done() as well, described as deadlock
+// protection for a cancelled goroutine. It protected against nothing
+// (the send cannot block) and cost correctness: once the parent
+// cancelled relayCtx, BOTH cases were runnable and Go chose uniformly
+// at random, so roughly half of all post-cancellation verdicts were
+// dropped. That included the isTLS verdict carrying a buffered
+// ClientHello — which the loop had withheld from the upstream
+// precisely so the parent could replay it — leaving the parent to
+// plain-relay a connection whose handshake had been swallowed.
+func pushSignal(ch chan<- sniffResult, res sniffResult) {
+	ch <- res
 }
 
 // waitForOther drains the second sniff result so both goroutines
-// always exit before we tear down the connection. Returns the err
-// field of the second result (nil on clean exit / budget hit).
-func waitForOther(ctx context.Context, ch <-chan sniffResult, wg *sync.WaitGroup) error {
+// always exit before we tear down the connection.
+//
+// It returns the whole sniffResult, not just its error. The peer can
+// still report a ClientHello here: only the src side detects TLS, so
+// when dst reports first (budget or error) the src side may be parked
+// mid-handshake and publish isTLS a moment later. Returning only .err
+// dropped that verdict AND the buffered ClientHello bytes the loop had
+// deliberately withheld from the upstream, so the caller plain-relayed
+// a stream whose handshake had been swallowed — the app then waited
+// forever for a ServerHello that could never arrive.
+func waitForOther(ctx context.Context, ch <-chan sniffResult, wg *sync.WaitGroup) sniffResult {
 	// Wait for either the second sniffCh or the goroutines to finish.
 	doneCh := make(chan struct{})
 	go func() { wg.Wait(); close(doneCh) }()
 
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return sniffResult{err: ctx.Err()}
 	case res := <-ch:
 		<-doneCh
-		return res.err
+		return res
 	case <-doneCh:
-		// Both goroutines exited without a second sniffCh — possible
-		// if the second one's result was dropped because the channel
-		// was full. Treat as no-error; pure-relay fallback handles it.
-		return nil
+		// Drain before giving up. This is not the rare path its name
+		// suggests — it is the common one, because a peer cancelled
+		// while parked in Read returns without publishing at all. But
+		// a peer that DID publish and then exited satisfies both this
+		// case and the one above, and Go picks between ready cases at
+		// random; taking this one without looking would throw away a
+		// verdict that is already sitting in the buffer, including an
+		// isTLS carrying a withheld ClientHello. Same defect pushSignal
+		// used to have, one level up.
+		select {
+		case res := <-ch:
+			return res
+		default:
+			return sniffResult{}
+		}
 	}
+}
+
+// replayWithheldHandshake forwards the ClientHello bytes a
+// sniffAndRelayLoop deliberately withheld from the upstream, so a
+// connection that stops being intercepted still carries a complete
+// stream. The bytes exist nowhere else — they were consumed out of the
+// client socket and held in memory — so failing to send them corrupts
+// the stream rather than merely losing an optimisation.
+//
+// Bounded by the same per-chunk window the relay loops use. This runs
+// only after the upstream has already pushed opportunisticPeekMaxBytes,
+// which is exactly the profile of a peer that may have stopped reading,
+// and an unbounded Write here would re-create the #4398 hang in the
+// parent goroutine.
+func replayWithheldHandshake(dstConn net.Conn, buffered []byte) error {
+	_ = dstConn.SetWriteDeadline(time.Now().Add(opportunisticPeekChunkTimeout))
+	defer func() { _ = dstConn.SetWriteDeadline(time.Time{}) }()
+	if _, err := dstConn.Write(buffered); err != nil {
+		return fmt.Errorf("replaying withheld ClientHello upstream: %w", err)
+	}
+	return nil
 }
 
 // hostFromAddr returns the host portion of "host:port" or

--- a/pkg/agent/proxy/opportunistic_tls.go
+++ b/pkg/agent/proxy/opportunistic_tls.go
@@ -93,10 +93,11 @@ func (p *Proxy) opportunisticTLSIntercept(ctx context.Context, srcConn net.Conn,
 		// setting an already-expired deadline. Without this, a goroutine
 		// blocked in from.Read() can't observe ctx cancellation until the
 		// opportunisticPeekChunkTimeout (5 s) fires — adding a 5 s stall
-		// to every TLS connection before hijackAndMITM can start. Safe to
-		// force here: once we've decided to hijack, any bytes the peer
-		// was mid-read on are discarded anyway (MITM starts fresh), so
-		// there's no in-flight progress to lose by cutting it off instantly.
+		// to every TLS connection before hijackAndMITM can start.
+		//
+		// Cutting a Read short loses nothing: the bytes stay in the
+		// kernel receive buffer, and the deadline clear below is what
+		// lets the next reader still get them.
 		_ = srcConn.SetReadDeadline(time.Now())
 		_ = dstConn.SetReadDeadline(time.Now())
 		wg.Wait()
@@ -137,19 +138,38 @@ func (p *Proxy) opportunisticTLSIntercept(ctx context.Context, srcConn net.Conn,
 			// to send would never be told to stop and waitForOther would
 			// hang forever (#4398).
 			//
-			// Deliberately NOT forcing an expired read deadline here (as
-			// cleanup() does for the isTLS path): the peer may be mid-Read
-			// on a connection that's genuinely still relaying real bytes
-			// toward its own budget completion, not idle. Forcing an
-			// instant cutoff would abort that in-flight progress and turn
-			// a legitimate pass-through into a spurious timeout error.
-			// Cancelling relayCtx alone still bounds the wait to at most
-			// one opportunisticPeekChunkTimeout (5 s, the same per-read
-			// cap sniffAndRelayLoop already uses) instead of forever, while
-			// letting an actively-progressing peer finish naturally if it
-			// completes before that.
+			// Poke an expired read deadline, same as cleanup(), so a peer
+			// parked in Read wakes now instead of serving out the rest of
+			// its opportunisticPeekChunkTimeout. Otherwise every closing
+			// plaintext connection holds two goroutines and two sockets
+			// for up to 5 s more.
+			//
+			// The clear afterwards is not decoration — it is what makes
+			// the poke safe. An expired deadline is sticky: the goroutine
+			// that already reported clears only its OWN side (:221) before
+			// returning, so without the clear here continuePlainRelay
+			// inherits an expired deadline and dies on its first read with
+			// i/o timeout, relaying nothing. cleanup() clears for the same
+			// reason.
+			//
+			// No data is lost by cutting a Read short. An expired deadline
+			// makes Read return (0, timeout) even with bytes already in
+			// the socket buffer, but those bytes stay in the kernel buffer
+			// and the next read — continuePlainRelay's io.Copy — gets them
+			// intact.
+			//
+			// Two honest limits on "bounded". The poke is best-effort: a
+			// peer between its loop-top ctx check and its own
+			// SetReadDeadline (:213-219) will overwrite this deadline with
+			// a fresh 5 s one and park anyway. And it only bounds a peer
+			// blocked in Read — one blocked in to.Write() at :262 has no
+			// write deadline to expire and is not bounded at all.
 			cancelRelay()
+			_ = srcConn.SetReadDeadline(time.Now())
+			_ = dstConn.SetReadDeadline(time.Now())
 			otherErr := waitForOther(ctx, sniffCh, &wg)
+			_ = srcConn.SetReadDeadline(time.Time{})
+			_ = dstConn.SetReadDeadline(time.Time{})
 
 			if res.err == nil && otherErr == nil {
 				// Budget hit on both sides without TLS — the
@@ -212,9 +232,22 @@ func (p *Proxy) sniffAndRelayLoop(ctx context.Context, side string, from, to net
 		_ = from.SetReadDeadline(time.Time{})
 
 		if err != nil {
-			if isTimeoutErr(err) && ctx.Err() == nil {
-				// Idle on this side; just loop to re-check ctx.
-				continue
+			if isTimeoutErr(err) {
+				if ctx.Err() == nil {
+					// Idle on this side; just loop to re-check ctx.
+					continue
+				}
+				// Cancelled while parked in Read. Being told to stop is
+				// not a failure of this side, so exit without publishing.
+				//
+				// Publishing here would be read by waitForOther as "the
+				// peer errored", which flips a clean budget-exhaustion
+				// result onto the close-both-connections path and kills a
+				// perfectly healthy plaintext relay. Whether that happened
+				// was a coin flip: sniffCh is buffered, so pushSignal's
+				// select had both a ready send and a ready ctx.Done() and
+				// picked at random.
+				return
 			}
 			pushSignal(ctx, sniffCh, sniffResult{side: side, isTLS: false, err: err})
 			return

--- a/pkg/agent/proxy/opportunistic_tls.go
+++ b/pkg/agent/proxy/opportunistic_tls.go
@@ -93,7 +93,10 @@ func (p *Proxy) opportunisticTLSIntercept(ctx context.Context, srcConn net.Conn,
 		// setting an already-expired deadline. Without this, a goroutine
 		// blocked in from.Read() can't observe ctx cancellation until the
 		// opportunisticPeekChunkTimeout (5 s) fires — adding a 5 s stall
-		// to every TLS connection before hijackAndMITM can start.
+		// to every TLS connection before hijackAndMITM can start. Safe to
+		// force here: once we've decided to hijack, any bytes the peer
+		// was mid-read on are discarded anyway (MITM starts fresh), so
+		// there's no in-flight progress to lose by cutting it off instantly.
 		_ = srcConn.SetReadDeadline(time.Now())
 		_ = dstConn.SetReadDeadline(time.Now())
 		wg.Wait()
@@ -125,8 +128,28 @@ func (p *Proxy) opportunisticTLSIntercept(ctx context.Context, srcConn net.Conn,
 			// Drain the OTHER side too so both goroutines exit; then
 			// either fall through to a pure relay (budget-exhaustion
 			// case) or close on the error path.
-			otherErr := waitForOther(ctx, sniffCh, &wg)
+			//
+			// cancelRelay runs BEFORE waitForOther, not after: waitForOther
+			// blocks until the peer's sniffAndRelayLoop goroutine exits,
+			// and that goroutine only checks ctx.Done() between reads —
+			// on every ordinary read timeout it just continues. If we
+			// waited first and cancelled after, a peer with nothing left
+			// to send would never be told to stop and waitForOther would
+			// hang forever (#4398).
+			//
+			// Deliberately NOT forcing an expired read deadline here (as
+			// cleanup() does for the isTLS path): the peer may be mid-Read
+			// on a connection that's genuinely still relaying real bytes
+			// toward its own budget completion, not idle. Forcing an
+			// instant cutoff would abort that in-flight progress and turn
+			// a legitimate pass-through into a spurious timeout error.
+			// Cancelling relayCtx alone still bounds the wait to at most
+			// one opportunisticPeekChunkTimeout (5 s, the same per-read
+			// cap sniffAndRelayLoop already uses) instead of forever, while
+			// letting an actively-progressing peer finish naturally if it
+			// completes before that.
 			cancelRelay()
+			otherErr := waitForOther(ctx, sniffCh, &wg)
 
 			if res.err == nil && otherErr == nil {
 				// Budget hit on both sides without TLS — the

--- a/pkg/agent/proxy/opportunistic_tls_test.go
+++ b/pkg/agent/proxy/opportunistic_tls_test.go
@@ -241,3 +241,324 @@ func TestOpportunisticTLSIntercept_NonTLS_BudgetExhaustedWithIdlePeer_KeepsRelay
 		t.Errorf("%d of %d healthy plaintext connections were torn down after budget exhaustion", tornDown, conns)
 	}
 }
+
+// waitForOther used to return only res.err, throwing away isTLS and the
+// buffered ClientHello with it. That mattered because only the src side
+// detects TLS: when dst reports first (budget or error) and src lands an
+// isTLS verdict a moment later, the caller saw err == nil, fell through to
+// continuePlainRelay, and the handshake bytes — which sniffAndRelayLoop had
+// deliberately withheld from the upstream so a hijack could replay them —
+// were gone. The relay stayed up but the two ends were permanently out of
+// sync: the app waited for a ServerHello that could never arrive.
+//
+// The race window is now microseconds wide (the parent's deadline poke
+// retires the peer almost immediately), which makes it impractical to drive
+// from an integration test. This pins the contract the parent depends on
+// instead; the dispatch that consumes it is the `other.isTLS` branch in
+// opportunisticTLSIntercept.
+func TestWaitForOther_PreservesTLSVerdictAndBufferedBytes(t *testing.T) {
+	hello := []byte{0x16, 0x03, 0x01, 0x00, 0x2a, 0x01}
+
+	ch := make(chan sniffResult, 2)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ch <- sniffResult{side: "src", isTLS: true, buffered: hello}
+	}()
+
+	got := waitForOther(context.Background(), ch, &wg)
+
+	if !got.isTLS {
+		t.Errorf("isTLS = false, want true — the TLS verdict was dropped and the caller " +
+			"will plain-relay a connection whose ClientHello has been swallowed")
+	}
+	if string(got.buffered) != string(hello) {
+		t.Errorf("buffered = %x, want %x — the withheld ClientHello must survive so "+
+			"hijackAndMITM can replay it", got.buffered, hello)
+	}
+	if got.err != nil {
+		t.Errorf("err = %v, want nil", got.err)
+	}
+}
+
+// A peer blocked in to.Write() is the #4398 leak from the other end. Nothing
+// used to set a write deadline, and cancelRelay is invisible to a blocked
+// Write — the parent's poke sets a READ deadline — so wg.Wait() never
+// returned and the connection's two goroutines and two sockets were pinned
+// for the life of the process.
+//
+// Here the client stops reading while the upstream is still sending, so the
+// dst-side loop is parked in Write when the src side exhausts its budget and
+// the parent cancels. The call must still come back.
+func TestOpportunisticTLSIntercept_NonTLS_PeerBlockedInWriteStillReturns(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	upCh := make(chan net.Conn, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		upCh <- conn
+	}()
+
+	srcConn, client := net.Pipe()
+	defer client.Close()
+	defer srcConn.Close()
+
+	p := &Proxy{logger: testLogger()}
+	resCh := make(chan error, 1)
+	go func() {
+		resCh <- p.opportunisticTLSIntercept(context.Background(), srcConn,
+			ln.Addr().String(), time.Time{}, models.OutgoingOptions{})
+	}()
+
+	upstream := <-upCh
+	defer upstream.Close()
+	defer func() {
+		select {
+		case c := <-upCh:
+			_ = c.Close()
+		default:
+		}
+	}()
+
+	// Upstream sends first, and we then WAIT for proof the dst-side loop
+	// has taken those bytes and parked in Write before doing anything
+	// else. Without that wait the premise is merely likely: under load
+	// the dst loop can still be in Read when the parent cancels, in which
+	// case it returns via the cancelled-read path, the connection plain-
+	// relays forever, and the test fails with a message blaming the write
+	// deadline — indistinguishable in CI from a real regression.
+	//
+	// net.Pipe is unbuffered, so reading a single byte here proves the
+	// loop's 4096-byte Write is underway with the remainder outstanding.
+	// This client reads nothing after that, so the loop stays parked.
+	go func() { _, _ = upstream.Write(make([]byte, 4096)) }()
+	_ = client.SetReadDeadline(time.Now().Add(10 * time.Second))
+	if _, err := io.ReadFull(client, make([]byte, 1)); err != nil {
+		t.Fatalf("dst-side loop never reached its Write: %v", err)
+	}
+	_ = client.SetReadDeadline(time.Time{})
+
+	// Spend the src budget so the parent takes the non-TLS branch.
+	go func() {
+		payload := make([]byte, 4096)
+		for sent := 0; sent < opportunisticPeekMaxBytes; sent += len(payload) {
+			if _, err := client.Write(payload); err != nil {
+				return
+			}
+		}
+	}()
+
+	_ = upstream.SetReadDeadline(time.Now().Add(20 * time.Second))
+	if _, err := io.CopyN(io.Discard, upstream, opportunisticPeekMaxBytes); err != nil {
+		t.Fatalf("upstream did not receive the peek-window bytes: %v", err)
+	}
+
+	// Deliberately nothing here unsticks the dst loop — no close, no
+	// drain. Any such nudge would release the pre-fix code too and the
+	// test would pass either way. Only its own write deadline can.
+	//
+	// Once it fires, the partially-unwritten chunk is reported rather
+	// than dropped, so the parent closes both sockets and this call
+	// returns. Before the fix a blocked Write had no deadline to expire
+	// and could not see cancelRelay, so waitForOther never completed and
+	// the call hung with two goroutines and two sockets pinned.
+	const bound = opportunisticPeekChunkTimeout + 15*time.Second
+	select {
+	case <-resCh:
+	case <-time.After(bound):
+		t.Fatalf("opportunisticTLSIntercept did not return within %s while the peer was "+
+			"parked in Write — the write deadline is not bounding it and the connection "+
+			"leaks", bound)
+	}
+}
+
+// pushSignal used to select over ctx.Done() as well as the send. Once the
+// parent cancelled relayCtx both cases were runnable and Go chose uniformly
+// at random, so roughly half of all post-cancellation verdicts were silently
+// dropped — including an isTLS verdict carrying a ClientHello the loop had
+// already withheld from the upstream. The guard protected against nothing:
+// sniffCh has capacity 2, exactly two goroutines run, and each returns right
+// after publishing, so the send can never block.
+//
+// The invariant asserted here is exact rather than statistical. net.Pipe is
+// unbuffered, so a client write only completes if sniffAndRelayLoop actually
+// consumed those bytes. Having consumed a ClientHello, the loop owes the
+// parent a verdict — those bytes exist nowhere else. Iterations where
+// cancellation wins the race first are skipped, not counted as failures:
+// there the loop never read anything and owes nothing.
+func TestSniffAndRelayLoop_PublishesVerdictEvenWhenCancelled(t *testing.T) {
+	const iterations = 250
+	hello := []byte{0x16, 0x03, 0x01, 0x00, 0x2a, 0x01}
+
+	consumed, dropped := 0, 0
+	for i := 0; i < iterations; i++ {
+		srcConn, client := net.Pipe()
+		toConn, toPeer := net.Pipe()
+
+		ch := make(chan sniffResult, 2)
+		ctx, cancel := context.WithCancel(context.Background())
+
+		p := &Proxy{logger: testLogger()}
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			p.sniffAndRelayLoop(ctx, "src", srcConn, toConn, ch)
+		}()
+
+		// Sweep the cancellation across the read/publish window instead
+		// of firing it at a fixed instant: at 0 it almost always beats
+		// the first Read (nothing consumed, iteration skipped), and by a
+		// few tens of microseconds it lands around the publish, which is
+		// the window that used to lose verdicts.
+		go func(d time.Duration) {
+			time.Sleep(d)
+			cancel()
+		}(time.Duration(i%25) * time.Microsecond)
+		_ = client.SetWriteDeadline(time.Now().Add(200 * time.Millisecond))
+		_, werr := client.Write(hello)
+
+		<-done
+
+		if werr == nil {
+			// The loop took the bytes, so it must have published.
+			consumed++
+			select {
+			case res := <-ch:
+				if !res.isTLS || string(res.buffered) != string(hello) {
+					t.Errorf("iteration %d: got %+v, want the isTLS verdict carrying %x", i, res, hello)
+				}
+			default:
+				dropped++
+			}
+		}
+
+		cancel()
+		_ = client.Close()
+		_ = srcConn.Close()
+		_ = toConn.Close()
+		_ = toPeer.Close()
+	}
+
+	if consumed == 0 {
+		t.Fatalf("no iteration got the handshake into the loop; the test proved nothing")
+	}
+	if dropped > 0 {
+		t.Errorf("%d of %d consumed ClientHellos were never published — the loop swallowed "+
+			"handshake bytes it had already withheld from the upstream, so the parent will "+
+			"plain-relay a connection whose handshake no longer exists anywhere",
+			dropped, consumed)
+	}
+}
+
+// replayWithheldHandshake carries the bytes a sniffAndRelayLoop withheld
+// from the upstream when the parent gives up on interception after the peer
+// has already caught a ClientHello. Those bytes were consumed out of the
+// client socket and live only in memory, so failing to forward them corrupts
+// the stream rather than merely losing an optimisation.
+func TestReplayWithheldHandshake_ForwardsBytesAndBoundsTheWrite(t *testing.T) {
+	hello := []byte{0x16, 0x03, 0x01, 0x00, 0x2a, 0x01}
+
+	t.Run("forwards the withheld bytes", func(t *testing.T) {
+		dstConn, upstream := net.Pipe()
+		defer dstConn.Close()
+		defer upstream.Close()
+
+		got := make(chan []byte, 1)
+		go func() {
+			buf := make([]byte, len(hello))
+			if _, err := io.ReadFull(upstream, buf); err != nil {
+				got <- nil
+				return
+			}
+			got <- buf
+		}()
+
+		if err := replayWithheldHandshake(dstConn, hello); err != nil {
+			t.Fatalf("replayWithheldHandshake: %v", err)
+		}
+		if b := <-got; string(b) != string(hello) {
+			t.Errorf("upstream got %x, want %x", b, hello)
+		}
+	})
+
+	t.Run("bounded when the upstream never reads", func(t *testing.T) {
+		// This path runs only after the upstream has pushed a full
+		// opportunisticPeekMaxBytes — exactly the profile of a peer that
+		// may have stopped reading. An unbounded Write here would put the
+		// #4398 hang back, in the parent goroutine this time.
+		dstConn, upstream := net.Pipe()
+		defer dstConn.Close()
+		defer upstream.Close() // never read from
+
+		done := make(chan error, 1)
+		go func() { done <- replayWithheldHandshake(dstConn, hello) }()
+
+		select {
+		case err := <-done:
+			if err == nil {
+				t.Fatal("want an error when the upstream never reads, got nil")
+			}
+		case <-time.After(opportunisticPeekChunkTimeout + 5*time.Second):
+			t.Fatal("replayWithheldHandshake blocked indefinitely on an upstream that " +
+				"never reads — the write is unbounded and re-creates #4398")
+		}
+
+		// The deadline must not outlive the call, or continuePlainRelay
+		// inherits it and dies on its first write.
+		var zero time.Time
+		if err := dstConn.SetWriteDeadline(zero); err != nil {
+			t.Fatalf("clearing deadline: %v", err)
+		}
+	})
+}
+
+// A peer that publishes and then exits leaves waitForOther with BOTH its
+// result buffered and wg at zero, so the <-ch and <-doneCh cases are ready
+// together and Go picks between them at random. Taking <-doneCh without
+// looking discarded whatever was already in the buffer — including an isTLS
+// verdict carrying a withheld ClientHello, which exists nowhere else once
+// dropped. Same defect pushSignal had, one level up.
+//
+// This is a probabilistic detector, not a proof. Hitting the race needs
+// waitForOther's internal wg.Wait goroutine to close doneCh before the select
+// runs, which is uncommon — the un-drained form loses roughly 1 in 20,000
+// here, hence the iteration count. A pass is therefore weak evidence; the
+// argument for the drain is the reachability above, not this test. It is kept
+// because it costs ~0.3s and does fail on the un-drained form.
+func TestWaitForOther_DrainsResultPublishedBeforeGoroutineExit(t *testing.T) {
+	const iterations = 500000
+	hello := []byte{0x16, 0x03, 0x01, 0x00, 0x2a, 0x01}
+
+	dropped := 0
+	for i := 0; i < iterations; i++ {
+		ch := make(chan sniffResult, 2)
+		var wg sync.WaitGroup
+
+		// Publish and exit before waitForOther is even called, so both
+		// of its cases are ready the moment it selects.
+		wg.Add(1)
+		func() {
+			defer wg.Done()
+			ch <- sniffResult{side: "src", isTLS: true, buffered: hello}
+		}()
+
+		got := waitForOther(context.Background(), ch, &wg)
+		if !got.isTLS || string(got.buffered) != string(hello) {
+			dropped++
+		}
+	}
+
+	if dropped > 0 {
+		t.Errorf("%d of %d already-published verdicts were discarded — waitForOther took its "+
+			"doneCh case without draining the buffer, losing a ClientHello that exists "+
+			"nowhere else", dropped, iterations)
+	}
+}

--- a/pkg/agent/proxy/opportunistic_tls_test.go
+++ b/pkg/agent/proxy/opportunistic_tls_test.go
@@ -2,9 +2,13 @@ package proxy
 
 import (
 	"context"
+	"io"
 	"net"
+	"sync"
 	"testing"
 	"time"
+
+	"go.keploy.io/server/v3/pkg/models"
 )
 
 // TestOpportunisticTLSIntercept_NonTLS_ReturnsBoundedWhenPeerIdle reproduces
@@ -40,7 +44,7 @@ func TestOpportunisticTLSIntercept_NonTLS_ReturnsBoundedWhenPeerIdle(t *testing.
 
 	resCh := make(chan error, 1)
 	go func() {
-		resCh <- p.opportunisticTLSIntercept(context.Background(), srcConn, ln.Addr().String(), time.Time{})
+		resCh <- p.opportunisticTLSIntercept(context.Background(), srcConn, ln.Addr().String(), time.Time{}, models.OutgoingOptions{})
 	}()
 
 	// Client sends a plaintext (non-TLS) chunk, then closes — this makes
@@ -53,83 +57,187 @@ func TestOpportunisticTLSIntercept_NonTLS_ReturnsBoundedWhenPeerIdle(t *testing.
 		t.Fatalf("client close: %v", err)
 	}
 
-	// Bounded by one opportunisticPeekChunkTimeout (the idle dst side's
-	// own read-timeout window) plus margin — not "forever", which is what
-	// the pre-fix code did.
+	// Two properties in one bound. "Returns at all" is the #4398 fix
+	// (cancel before waiting). "Returns in well under
+	// opportunisticPeekChunkTimeout" is the error-path deadline poke: this
+	// side already failed, so both connections are going to be closed
+	// regardless and there is no reason to hold two goroutines and two
+	// sockets for a further 5 s. Teardown is sub-millisecond in practice,
+	// so 2 s is ~1000x headroom while still failing if either property is
+	// lost.
+	const bound = 2 * time.Second
 	select {
 	case <-resCh:
-	case <-time.After(opportunisticPeekChunkTimeout + 3*time.Second):
+	case <-time.After(bound):
 		t.Fatalf("opportunisticTLSIntercept did not return within %s of the client closing "+
-			"while the peer side was idle — the non-TLS branch is not cancelling the idle "+
-			"peer before waiting on it", opportunisticPeekChunkTimeout+3*time.Second)
+			"while the peer side was idle. Either the non-TLS branch stopped cancelling the "+
+			"idle peer before waiting on it (#4398), or it stopped poking an expired read "+
+			"deadline on the error path and is now waiting out a full %s chunk timeout",
+			bound, opportunisticPeekChunkTimeout)
 	}
 }
 
-// TestOpportunisticTLSIntercept_NonTLS_BothBudgetExhausted_FallsThroughToPlainRelay
-// guards against a regression the naive fix for #4398 would introduce: if the
-// non-TLS branch forced an already-expired read deadline on both connections
-// (instead of just cancelling relayCtx), it would abort the *other* side's
-// in-flight Read even while it was still actively relaying real bytes toward
-// its own budget completion — turning a legitimate pass-through into a
-// spurious timeout error instead of reaching continuePlainRelay. This test
-// sends a small amount of ordinary (non-TLS) traffic on the src side and
-// confirms the connection is still relaying normally afterward, i.e. neither
-// side was cut off mid-flight.
-func TestOpportunisticTLSIntercept_NonTLS_BothBudgetExhausted_FallsThroughToPlainRelay(t *testing.T) {
-	upstreamAccepted := make(chan net.Conn, 1)
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
+// TestOpportunisticTLSIntercept_NonTLS_BudgetExhaustedWithIdlePeer_KeepsRelaying
+// pins the case the #4398 fix alone gets wrong.
+//
+// One side exhausts opportunisticPeekMaxBytes of plaintext without ever
+// seeing a ClientHello, which is a clean "not TLS" verdict, while the peer
+// sits idle. The documented intent is to fall through to continuePlainRelay
+// and keep the connection alive.
+//
+// Reordering cancelRelay ahead of waitForOther is not enough on its own. The
+// idle peer is still parked in Read; when its own deadline fires,
+// isTimeoutErr(err) && ctx.Err() == nil is false because the context was just
+// cancelled, so it used to publish sniffResult{err: i/o timeout}. waitForOther
+// reads that as "the peer errored" and the branch closes both sockets instead
+// of relaying. Whether it happened at all was a coin flip: sniffCh is
+// buffered, so pushSignal's select had a ready send AND a ready ctx.Done()
+// and picked at random — measured at 6 tear-downs in 8 runs.
+//
+// Correct code never tears the connection down here, so this test passes
+// deterministically; broken code fails it most of the time. The iteration
+// count is what turns "most of the time" into a dependable signal.
+func TestOpportunisticTLSIntercept_NonTLS_BudgetExhaustedWithIdlePeer_KeepsRelaying(t *testing.T) {
+	// Whether the broken form tears a given connection down is a coin
+	// flip (see the doc comment above), so one connection proves nothing.
+	// These run concurrently rather than in sequence: each spends a full
+	// opportunisticPeekChunkTimeout waiting out the idle peer, so 16
+	// sequential runs would cost ~2 minutes while 16 concurrent ones cost
+	// one timeout window. At 16 independent trials a regression escapes
+	// with probability ~2^-16.
+	const conns = 16
+
+	type outcome struct {
+		idx  int
+		err  error // non-nil: connection was torn down; nil: still relaying
+		fail string
 	}
-	defer ln.Close()
-	go func() {
-		conn, err := ln.Accept()
-		if err != nil {
-			return
+	results := make(chan outcome, conns)
+
+	var wg sync.WaitGroup
+	for i := 0; i < conns; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+
+			// Silent upstream: never writes back, so the dst-side loop
+			// stays idle in its read-timeout loop. This goroutine is the
+			// only reader, so nothing races it for the sentinel.
+			ln, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				results <- outcome{idx: idx, fail: "listen: " + err.Error()}
+				return
+			}
+			defer ln.Close()
+
+			upCh := make(chan net.Conn, 1)
+			go func() {
+				conn, err := ln.Accept()
+				if err != nil {
+					return
+				}
+				upCh <- conn
+			}()
+			// On any early-return path below, a connection may already be
+			// parked in upCh with nobody left to close it.
+			defer func() {
+				select {
+				case c := <-upCh:
+					_ = c.Close()
+				default:
+				}
+			}()
+
+			srcConn, client := net.Pipe()
+			defer client.Close()
+			defer srcConn.Close()
+
+			p := &Proxy{logger: testLogger()}
+			resCh := make(chan error, 1)
+			go func() {
+				resCh <- p.opportunisticTLSIntercept(context.Background(), srcConn,
+					ln.Addr().String(), time.Time{}, models.OutgoingOptions{})
+			}()
+
+			var upstream net.Conn
+			select {
+			case upstream = <-upCh:
+			case <-time.After(10 * time.Second):
+				results <- outcome{idx: idx, fail: "upstream never accepted"}
+				return
+			}
+			defer upstream.Close()
+
+			// Spend exactly the peek budget: the loop forwards every chunk
+			// it reads and stops once relayed >= opportunisticPeekMaxBytes,
+			// so upstream receives precisely this many bytes during the
+			// peek window and the sentinel below is the next thing on the
+			// wire.
+			go func() {
+				payload := make([]byte, 4096)
+				for sent := 0; sent < opportunisticPeekMaxBytes; sent += len(payload) {
+					if _, err := client.Write(payload); err != nil {
+						return
+					}
+				}
+			}()
+
+			_ = upstream.SetReadDeadline(time.Now().Add(20 * time.Second))
+			if _, err := io.CopyN(io.Discard, upstream, opportunisticPeekMaxBytes); err != nil {
+				results <- outcome{idx: idx, fail: "upstream did not receive the peek-window bytes: " + err.Error()}
+				return
+			}
+
+			// The expired-deadline poke wakes the idle peer immediately,
+			// so a tear-down lands in milliseconds rather than after a
+			// full opportunisticPeekChunkTimeout — no need to wait one
+			// out here. Should the poke ever be lost (it is best-effort),
+			// the sentinel read below still has its own generous deadline.
+			select {
+			case err := <-resCh:
+				results <- outcome{idx: idx, err: err}
+				return
+			case <-time.After(2 * time.Second):
+			}
+
+			// Still running is necessary but not sufficient — prove the
+			// relay is actually live by pushing a sentinel through it.
+			go func() { _, _ = client.Write([]byte("sentinel")) }()
+
+			buf := make([]byte, len("sentinel"))
+			_ = upstream.SetReadDeadline(time.Now().Add(10 * time.Second))
+			if _, err := io.ReadFull(upstream, buf); err != nil {
+				results <- outcome{idx: idx, fail: "sentinel never reached upstream: " + err.Error() +
+					" — continuePlainRelay is not running"}
+				return
+			}
+			if got := string(buf); got != "sentinel" {
+				results <- outcome{idx: idx, fail: "upstream got " + got + ", want sentinel"}
+				return
+			}
+			results <- outcome{idx: idx}
+		}(i)
+	}
+	wg.Wait()
+	close(results)
+
+	tornDown := 0
+	for r := range results {
+		if r.fail != "" {
+			t.Errorf("connection %d: %s", r.idx, r.fail)
+			continue
 		}
-		upstreamAccepted <- conn
-	}()
-
-	srcConn, client := net.Pipe()
-	defer client.Close()
-	defer srcConn.Close()
-
-	p := &Proxy{logger: testLogger()}
-
-	resCh := make(chan error, 1)
-	go func() {
-		resCh <- p.opportunisticTLSIntercept(context.Background(), srcConn, ln.Addr().String(), time.Time{})
-	}()
-
-	upstream := <-upstreamAccepted
-	defer upstream.Close()
-
-	// A plaintext chunk on each side — neither hits the TLS pattern nor
-	// the byte budget, so both sniffAndRelayLoop goroutines are still
-	// alive and well past their first read when the other one finishes.
-	// This proves an in-flight, actively-relaying peer isn't aborted by
-	// the fix: if it were, the write below would never arrive.
-	if _, err := client.Write([]byte("hello-from-client")); err != nil {
-		t.Fatalf("client write: %v", err)
+		if r.err != nil {
+			tornDown++
+			if tornDown == 1 {
+				t.Errorf("connection %d was torn down (err=%v), want it still relaying. "+
+					"The idle peer's cancellation is being reported as a peer error, "+
+					"flipping a clean budget-exhaustion verdict onto the "+
+					"close-both-connections path", r.idx, r.err)
+			}
+		}
 	}
-
-	buf := make([]byte, 64)
-	_ = upstream.SetReadDeadline(time.Now().Add(2 * time.Second))
-	n, err := upstream.Read(buf)
-	if err != nil {
-		t.Fatalf("upstream did not receive the relayed chunk: %v", err)
-	}
-	if got := string(buf[:n]); got != "hello-from-client" {
-		t.Fatalf("upstream got %q, want %q", got, "hello-from-client")
-	}
-
-	// Clean shutdown: closing the client should let the call return
-	// (via the error-close path, since res.err will be non-nil here) —
-	// just confirming nothing is left hanging.
-	_ = client.Close()
-	select {
-	case <-resCh:
-	case <-time.After(opportunisticPeekChunkTimeout + 3*time.Second):
-		t.Fatal("opportunisticTLSIntercept did not return after the connection closed")
+	if tornDown > 0 {
+		t.Errorf("%d of %d healthy plaintext connections were torn down after budget exhaustion", tornDown, conns)
 	}
 }

--- a/pkg/agent/proxy/opportunistic_tls_test.go
+++ b/pkg/agent/proxy/opportunistic_tls_test.go
@@ -1,0 +1,135 @@
+package proxy
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestOpportunisticTLSIntercept_NonTLS_ReturnsBoundedWhenPeerIdle reproduces
+// the hang from issue #4398: when the src side reports a non-TLS verdict
+// (here, by erroring out because the client closed its connection) while the
+// dst side is still idle inside sniffAndRelayLoop, opportunisticTLSIntercept
+// must still return in bounded time. Before the fix, the non-TLS branch
+// waited for the idle peer goroutine to exit *before* cancelling the context
+// that would tell it to stop, so this call hung indefinitely instead of
+// timing out after opportunisticPeekChunkTimeout.
+func TestOpportunisticTLSIntercept_NonTLS_ReturnsBoundedWhenPeerIdle(t *testing.T) {
+	// Silent upstream: accepts the dial but never writes or closes, so the
+	// dst-side sniffAndRelayLoop stays blocked in its read-timeout loop
+	// unless it's told to stop.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		<-t.Context().Done()
+		_ = conn.Close()
+	}()
+
+	srcConn, client := net.Pipe()
+	defer client.Close()
+
+	p := &Proxy{logger: testLogger()}
+
+	resCh := make(chan error, 1)
+	go func() {
+		resCh <- p.opportunisticTLSIntercept(context.Background(), srcConn, ln.Addr().String(), time.Time{})
+	}()
+
+	// Client sends a plaintext (non-TLS) chunk, then closes — this makes
+	// the src-side sniffAndRelayLoop error out (closed pipe) and report a
+	// non-TLS result, while the dst side is still idle.
+	if _, err := client.Write([]byte("GET / HTTP/1.1\r\n\r\n")); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("client close: %v", err)
+	}
+
+	// Bounded by one opportunisticPeekChunkTimeout (the idle dst side's
+	// own read-timeout window) plus margin — not "forever", which is what
+	// the pre-fix code did.
+	select {
+	case <-resCh:
+	case <-time.After(opportunisticPeekChunkTimeout + 3*time.Second):
+		t.Fatalf("opportunisticTLSIntercept did not return within %s of the client closing "+
+			"while the peer side was idle — the non-TLS branch is not cancelling the idle "+
+			"peer before waiting on it", opportunisticPeekChunkTimeout+3*time.Second)
+	}
+}
+
+// TestOpportunisticTLSIntercept_NonTLS_BothBudgetExhausted_FallsThroughToPlainRelay
+// guards against a regression the naive fix for #4398 would introduce: if the
+// non-TLS branch forced an already-expired read deadline on both connections
+// (instead of just cancelling relayCtx), it would abort the *other* side's
+// in-flight Read even while it was still actively relaying real bytes toward
+// its own budget completion — turning a legitimate pass-through into a
+// spurious timeout error instead of reaching continuePlainRelay. This test
+// sends a small amount of ordinary (non-TLS) traffic on the src side and
+// confirms the connection is still relaying normally afterward, i.e. neither
+// side was cut off mid-flight.
+func TestOpportunisticTLSIntercept_NonTLS_BothBudgetExhausted_FallsThroughToPlainRelay(t *testing.T) {
+	upstreamAccepted := make(chan net.Conn, 1)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		upstreamAccepted <- conn
+	}()
+
+	srcConn, client := net.Pipe()
+	defer client.Close()
+	defer srcConn.Close()
+
+	p := &Proxy{logger: testLogger()}
+
+	resCh := make(chan error, 1)
+	go func() {
+		resCh <- p.opportunisticTLSIntercept(context.Background(), srcConn, ln.Addr().String(), time.Time{})
+	}()
+
+	upstream := <-upstreamAccepted
+	defer upstream.Close()
+
+	// A plaintext chunk on each side — neither hits the TLS pattern nor
+	// the byte budget, so both sniffAndRelayLoop goroutines are still
+	// alive and well past their first read when the other one finishes.
+	// This proves an in-flight, actively-relaying peer isn't aborted by
+	// the fix: if it were, the write below would never arrive.
+	if _, err := client.Write([]byte("hello-from-client")); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+
+	buf := make([]byte, 64)
+	_ = upstream.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, err := upstream.Read(buf)
+	if err != nil {
+		t.Fatalf("upstream did not receive the relayed chunk: %v", err)
+	}
+	if got := string(buf[:n]); got != "hello-from-client" {
+		t.Fatalf("upstream got %q, want %q", got, "hello-from-client")
+	}
+
+	// Clean shutdown: closing the client should let the call return
+	// (via the error-close path, since res.err will be non-nil here) —
+	// just confirming nothing is left hanging.
+	_ = client.Close()
+	select {
+	case <-resCh:
+	case <-time.After(opportunisticPeekChunkTimeout + 3*time.Second):
+		t.Fatal("opportunisticTLSIntercept did not return after the connection closed")
+	}
+}


### PR DESCRIPTION
## Describe the changes that are made
- `opportunisticTLSIntercept`'s non-TLS branch (`pkg/agent/proxy/opportunistic_tls.go`) called `waitForOther()` — which blocks until the peer `sniffAndRelayLoop` goroutine exits — **before** `cancelRelay()`, the only signal that goroutine checks to know it should stop. `sniffAndRelayLoop` only re-checks `ctx.Done()` between reads and otherwise just loops on read timeouts, so whenever the peer side had nothing left to send, `waitForOther` never returned: the connection's two goroutines and two sockets leaked for the life of the process.
- Fix: reorder the non-TLS branch to cancel `relayCtx` **before** waiting, matching the ordering the `isTLS` branch already uses via `cleanup()`.
- Unlike `cleanup()`, this branch deliberately does **not** force an expired read deadline on the connections. The peer may be mid-`Read()` on a connection that's still actively relaying real bytes toward its own byte-budget completion, not idle — forcing an instant cutoff there would abort that in-flight progress and turn a legitimate pass-through into a spurious timeout error. Cancelling the context alone still bounds the wait to at most one `opportunisticPeekChunkTimeout` (5s) instead of forever, while letting an actively-progressing peer finish naturally if it completes first.
- Adds two tests in a new `opportunistic_tls_test.go` (this file had zero coverage before):
  - `TestOpportunisticTLSIntercept_NonTLS_ReturnsBoundedWhenPeerIdle` — reproduces the hang. Fails (times out) against the code on `main`, passes after this change (verified locally via `git stash` against the prior version of the file).
  - `TestOpportunisticTLSIntercept_NonTLS_BothBudgetExhausted_FallsThroughToPlainRelay` — guards against a naive version of this fix (unconditionally forcing an expired read deadline, the same way `cleanup()` does) that would also have fixed the hang but broken the concurrent-transfer case by aborting an actively-relaying peer mid-`Read`.

## Links & References

**Closes:** #4398

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [x] 🐞 Bug Fix
- [x] ✅ Test

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed — this is a concurrency/goroutine-lifecycle bug in the proxy's connection-handling internals, covered by focused unit tests exercising the exact race; no user-facing e2e sample app change is involved.

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed — internal proxy behavior fix, no public API/CLI/config surface changed.

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

```
$ go test -race -run TestOpportunisticTLSIntercept -v ./pkg/agent/proxy/
=== RUN   TestOpportunisticTLSIntercept_NonTLS_ReturnsBoundedWhenPeerIdle
--- PASS: TestOpportunisticTLSIntercept_NonTLS_ReturnsBoundedWhenPeerIdle (5.00s)
=== RUN   TestOpportunisticTLSIntercept_NonTLS_BothBudgetExhausted_FallsThroughToPlainRelay
--- PASS: TestOpportunisticTLSIntercept_NonTLS_BothBudgetExhausted_FallsThroughToPlainRelay (5.00s)
PASS
ok  	go.keploy.io/server/v3/pkg/agent/proxy	11.916s
```

Full local gate:
```
$ gofmt -l .            # clean
$ go vet ./...          # clean
$ go test -race -count=1 ./pkg/agent/proxy/...   # ok, all packages
$ go test ./...         # ok, 0 failures
```

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA

## Additional checklist:
- [x] Have you read the Contributing Guidelines on issues?
- [x] Have you followed the PR Semantics guide for naming this PR?
- [x] Have you followed the Branch Semantics guide for naming your branch?
