### PR TITLE
feat(cli): honor --cmd-type when explicitly provided

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -240,7 +240,7 @@ func (c *CmdConfigurator) AddFlags(cmd *cobra.Command) error {
 		cmd.Flags().Uint32("server-port", c.cfg.ServerPort, "Port used by the Keploy Agent server to intercept traffic")
 		cmd.Flags().Uint32("dns-port", c.cfg.DNSPort, "Port used by the Keploy DNS server to intercept the DNS queries")
 		cmd.Flags().StringP("command", "c", c.cfg.Command, "Command to start the user application")
-		cmd.Flags().String("cmd-type", c.cfg.CommandType, "Type of command to start the user application (native/docker/docker-compose)")
+		cmd.Flags().String("cmd-type", c.cfg.CommandType, "Type of command to start the user application (native/docker-run/docker-start/docker-compose)")
 		cmd.Flags().Uint64P("build-delay", "b", c.cfg.BuildDelay, "User provided time to wait docker container build")
 		cmd.Flags().String("container-name", c.cfg.ContainerName, "Name of the application's docker container")
 		cmd.Flags().StringP("network-name", "n", c.cfg.NetworkName, "Name of the application's docker network")
@@ -675,6 +675,28 @@ func (c *CmdConfigurator) PreProcessFlags(cmd *cobra.Command) error {
 	return nil
 }
 
+// resolveCommandType determines the CommandType to use for a record/test
+// run. When the user explicitly passes --cmd-type, that value wins (after
+// validation) over auto-detection — previously it was silently discarded
+// and overwritten every time (#4399). Gated on Changed(), not on explicit
+// being non-empty: config/default.go's InternalConfig ships cmdType:
+// "native" in every generated keploy.yml, so a non-empty check would treat
+// that baked-in default as an explicit user choice and break Docker users
+// who never touched the flag.
+func resolveCommandType(cmd *cobra.Command, command, explicit string) (string, error) {
+	if cmd.Flags().Changed("cmd-type") {
+		switch utils.CmdType(explicit) {
+		case utils.Native, utils.DockerRun, utils.DockerStart, utils.DockerCompose:
+			return explicit, nil
+		default:
+			return "", fmt.Errorf(
+				"invalid --cmd-type value %q: allowed values are %q, %q, %q, and %q",
+				explicit, utils.Native, utils.DockerRun, utils.DockerStart, utils.DockerCompose)
+		}
+	}
+	return string(utils.FindDockerCmd(command)), nil
+}
+
 func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command) error {
 	// The --json flag isn't registered on every subcommand (record / agent
 	// don't define it in enterprise builds), so Lookup + fallback avoids
@@ -1026,7 +1048,11 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 		}
 
 		// set the command type
-		c.cfg.CommandType = string(utils.FindDockerCmd(c.cfg.Command))
+		commandType, err := resolveCommandType(cmd, c.cfg.Command, c.cfg.CommandType)
+		if err != nil {
+			return err
+		}
+		c.cfg.CommandType = commandType
 		if (c.cfg.CommandType == string(utils.Native) || c.cfg.CommandType == string(utils.Empty)) && !(runtime.GOOS == "linux" || (runtime.GOOS == "windows" && runtime.GOARCH == "amd64")) {
 			return fmt.Errorf("non docker command not supported for OS: %s , Arch: %s", runtime.GOOS, runtime.GOARCH)
 		}

--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -695,26 +695,110 @@ func (c *CmdConfigurator) PreProcessFlags(cmd *cobra.Command) error {
 	return nil
 }
 
-// resolveCommandType determines the CommandType to use for a record/test
-// run. When the user explicitly passes --cmd-type, that value wins (after
-// validation) over auto-detection — previously it was silently discarded
-// and overwritten every time (#4399). Gated on Changed(), not on explicit
-// being non-empty: config/default.go's InternalConfig ships cmdType:
-// "native" in every generated keploy.yml, so a non-empty check would treat
-// that baked-in default as an explicit user choice and break Docker users
-// who never touched the flag.
-func resolveCommandType(cmd *cobra.Command, command, explicit string) (string, error) {
+// mentionsDockerBinary reports whether the command actually invokes docker,
+// as opposed to merely containing the word. Substring matching let
+// "./run-docker.sh" through — a wrapper by any reading, and the exact naming
+// convention a docker wrapper script uses.
+func mentionsDockerBinary(command string) bool {
+	fields := strings.Fields(strings.ToLower(command))
+	for i, field := range fields {
+		base := field
+		if j := strings.LastIndex(base, "/"); j >= 0 {
+			base = base[j+1:] // /usr/bin/docker -> docker
+		}
+		// The v1 binary takes any subcommand, so the name alone is enough.
+		if base == "docker-compose" {
+			return true
+		}
+		// A bare "docker" token is not enough: `npm run docker` runs a script
+		// called docker. Require a subcommand that actually launches
+		// something, which is what the docker-run/docker-start modes rewrite.
+		if base == "docker" && i+1 < len(fields) {
+			switch fields[i+1] {
+			case "run", "start", "compose", "container":
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// resolveCommandType decides the CommandType for a record/test run.
+//
+// Before #4399 this was unconditionally `FindDockerCmd(command)`, so the
+// --cmd-type flag — defined, kebab-aliased, viper-bound and unmarshalled —
+// was overwritten before anything read it. There was no way to tell keploy
+// "this launches a container" when the launch is wrapped in a script or a
+// Makefile target and the raw command string looks nothing like docker.
+//
+// Gated on Changed() rather than on the value being non-empty, because
+// config/default.go ships cmdType: "native" in every generated keploy.yml —
+// a non-empty check would read that baked-in default as a user choice and
+// break docker auto-detection for everyone who never touched the flag.
+//
+// Deliberately command-line only. A cmdType in keploy.yml cannot be honoured
+// even in principle: the sudo re-exec in main.go runs before any config is
+// read (utils.ShouldReexecWithSudo, which this change teaches to read the
+// flag out of os.Args), so a config-supplied docker type would decide the
+// mode without the root privileges that mode needs. A docker value sitting
+// in config is warned about rather than silently ignored, so the trap that
+// made this flag inert for so long is at least visible.
+func resolveCommandType(logger *zap.Logger, cmd *cobra.Command, command, configured string) (string, error) {
 	if cmd.Flags().Changed("cmd-type") {
-		switch utils.CmdType(explicit) {
+		// Normalised the same way FindDockerCmd normalises what it matches
+		// against, so `--cmd-type Docker-Compose` is not a fatal typo.
+		explicit := strings.ToLower(strings.TrimSpace(configured))
+		switch kind := utils.CmdType(explicit); kind {
 		case utils.Native, utils.DockerRun, utils.DockerStart, utils.DockerCompose:
+			// docker-run and docker-start need to REWRITE the command —
+			// SetupDocker splices `--pid=container:…  --network=container:…`
+			// into a `docker run` — and there is no way to do that to a
+			// wrapper, nor an environment variable that achieves the same.
+			// Point one at `make up` and modifyDockerRun either errors on
+			// the token count or splices flags into the middle of the
+			// wrapper. Refuse it here, where the message can say why.
+			//
+			// docker-compose has a way through: keploy's compose file is
+			// handed over via COMPOSE_FILE and the command runs untouched,
+			// so a wrapper is supported there (see App.SetupCompose).
+			if (kind == utils.DockerRun || kind == utils.DockerStart) && command != "" &&
+				!mentionsDockerBinary(command) {
+				return "", fmt.Errorf(
+					"--cmd-type %s has to rewrite the command to attach keploy's namespaces, "+
+						"which is only possible on a literal docker command, and %q is not one. "+
+						"Pass the underlying docker command with -c, or use --cmd-type %s if the "+
+						"wrapper brings up a compose project",
+					explicit, command, utils.DockerCompose)
+			}
 			return explicit, nil
+		case utils.Empty:
+			// `--cmd-type=""` used to be silently overwritten by
+			// auto-detection, so that is what it must keep doing. Rejecting
+			// it would break scripts that pass it; preserving it would be
+			// worse still — GetCommonServices reads "" as "not docker" and
+			// leaves the docker client nil, while resolveKind reads it as
+			// "detect", so a `--cmd-type= -c "docker compose up"` would
+			// reach SetupCompose with a nil client and panic. Treat an
+			// explicitly empty value as "not specified".
+			return string(utils.FindDockerCmd(command)), nil
 		default:
 			return "", fmt.Errorf(
 				"invalid --cmd-type value %q: allowed values are %q, %q, %q, and %q",
-				explicit, utils.Native, utils.DockerRun, utils.DockerStart, utils.DockerCompose)
+				configured, utils.Native, utils.DockerRun, utils.DockerStart, utils.DockerCompose)
 		}
 	}
-	return string(utils.FindDockerCmd(command)), nil
+
+	detected := utils.FindDockerCmd(command)
+	// Only warn when it would actually have made a difference. A config that
+	// merely agrees with auto-detection is not being ignored in any way the
+	// user can observe, and warning on every such run would be noise.
+	if kind := utils.CmdType(strings.ToLower(strings.TrimSpace(configured))); utils.IsDockerCmd(kind) && kind != detected {
+		logger.Warn("cmdType in the config file is not honoured; pass --cmd-type on the command line instead",
+			zap.String("cmdType", configured),
+			zap.String("using", string(detected)),
+			zap.String("reason", "the privilege decision happens before any config file is read"))
+	}
+	return string(detected), nil
 }
 
 func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command) error {
@@ -1068,7 +1152,7 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 		}
 
 		// set the command type
-		commandType, err := resolveCommandType(cmd, c.cfg.Command, c.cfg.CommandType)
+		commandType, err := resolveCommandType(c.logger, cmd, c.cfg.Command, c.cfg.CommandType)
 		if err != nil {
 			return err
 		}
@@ -1121,7 +1205,14 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 				c.logger.Info(fmt.Sprintf("buildDelay is set to %v, incase your docker container takes more time to build use --buildDelay to set custom delay", c.cfg.BuildDelay))
 				c.logger.Info(`Example usage: keploy record -c "docker-compose up --build" --buildDelay 35`)
 			}
-			if utils.CmdType(c.cfg.Command) == utils.DockerCompose {
+			// Compare the resolved TYPE, not the raw command string — the
+			// latter is never equal to a CmdType, so this gate never fired
+			// and the missing --container-name surfaced much later, as
+			// "container name not found" from SetupCompose, after the sudo
+			// re-exec and agent start. It matters more now: a wrapper
+			// command has no container name to parse out of it, so this is
+			// the only place the user can be told what to pass.
+			if utils.CmdType(c.cfg.CommandType) == utils.DockerCompose {
 				if c.cfg.ContainerName == "" {
 					utils.LogError(c.logger, nil, "Couldn't find containerName")
 					c.logger.Info(`Example usage: keploy record -c "docker run -p 8080:8080 --network myNetworkName myApplicationImageName" --delay 6`)
@@ -1140,7 +1231,10 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 		// Check and fix keploy folder permissions for native mode only
 		// (handles root-owned files from older sudo-based versions)
 		// Docker commands use sudo re-exec, so they run as root and don't need this
-		cmdType := utils.FindDockerCmd(c.cfg.Command)
+		// Use the resolved type, not a second derivation from the command
+		// string — otherwise an explicit --cmd-type docker-* would still be
+		// treated as native here and prompt for sudo it does not need.
+		cmdType := utils.CmdType(c.cfg.CommandType)
 		if !utils.IsDockerCmd(cmdType) {
 			// Native mode: fix permissions immediately (this caches sudo credentials)
 			if err := utils.EnsureKeployFolderPermissions(cmd.Context(), c.logger, c.cfg.Path); err != nil {

--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -240,7 +240,7 @@ func (c *CmdConfigurator) AddFlags(cmd *cobra.Command) error {
 		cmd.Flags().Uint32("server-port", c.cfg.ServerPort, "Port used by the Keploy Agent server to intercept traffic")
 		cmd.Flags().Uint32("dns-port", c.cfg.DNSPort, "Port used by the Keploy DNS server to intercept the DNS queries")
 		cmd.Flags().StringP("command", "c", c.cfg.Command, "Command to start the user application")
-		cmd.Flags().String("cmd-type", c.cfg.CommandType, "Type of command to start the user application (native/docker/docker-compose)")
+		cmd.Flags().String("cmd-type", c.cfg.CommandType, "Type of command to start the user application (native/docker-run/docker-start/docker-compose)")
 		cmd.Flags().Uint64P("build-delay", "b", c.cfg.BuildDelay, "User provided time to wait docker container build")
 		cmd.Flags().String("container-name", c.cfg.ContainerName, "Name of the application's docker container")
 		cmd.Flags().StringP("network-name", "n", c.cfg.NetworkName, "Name of the application's docker network")
@@ -695,6 +695,28 @@ func (c *CmdConfigurator) PreProcessFlags(cmd *cobra.Command) error {
 	return nil
 }
 
+// resolveCommandType determines the CommandType to use for a record/test
+// run. When the user explicitly passes --cmd-type, that value wins (after
+// validation) over auto-detection — previously it was silently discarded
+// and overwritten every time (#4399). Gated on Changed(), not on explicit
+// being non-empty: config/default.go's InternalConfig ships cmdType:
+// "native" in every generated keploy.yml, so a non-empty check would treat
+// that baked-in default as an explicit user choice and break Docker users
+// who never touched the flag.
+func resolveCommandType(cmd *cobra.Command, command, explicit string) (string, error) {
+	if cmd.Flags().Changed("cmd-type") {
+		switch utils.CmdType(explicit) {
+		case utils.Native, utils.DockerRun, utils.DockerStart, utils.DockerCompose:
+			return explicit, nil
+		default:
+			return "", fmt.Errorf(
+				"invalid --cmd-type value %q: allowed values are %q, %q, %q, and %q",
+				explicit, utils.Native, utils.DockerRun, utils.DockerStart, utils.DockerCompose)
+		}
+	}
+	return string(utils.FindDockerCmd(command)), nil
+}
+
 func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command) error {
 	// The --json flag isn't registered on every subcommand (record / agent
 	// don't define it in enterprise builds), so Lookup + fallback avoids
@@ -1046,7 +1068,11 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 		}
 
 		// set the command type
-		c.cfg.CommandType = string(utils.FindDockerCmd(c.cfg.Command))
+		commandType, err := resolveCommandType(cmd, c.cfg.Command, c.cfg.CommandType)
+		if err != nil {
+			return err
+		}
+		c.cfg.CommandType = commandType
 		if (c.cfg.CommandType == string(utils.Native) || c.cfg.CommandType == string(utils.Empty)) && !(runtime.GOOS == "linux" || (runtime.GOOS == "windows" && runtime.GOARCH == "amd64")) {
 			return fmt.Errorf("non docker command not supported for OS: %s , Arch: %s", runtime.GOOS, runtime.GOARCH)
 		}

--- a/cli/provider/cmd_test.go
+++ b/cli/provider/cmd_test.go
@@ -1,0 +1,63 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func cmdWithCmdTypeFlag(explicit string) *cobra.Command {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("cmd-type", "", "")
+	if explicit != "" {
+		_ = cmd.Flags().Set("cmd-type", explicit)
+	}
+	return cmd
+}
+
+// TestResolveCommandType_ExplicitValid asserts that an explicitly-provided,
+// valid --cmd-type wins over whatever auto-detection would have said for the
+// given command string.
+func TestResolveCommandType_ExplicitValid(t *testing.T) {
+	cmd := cmdWithCmdTypeFlag("docker-compose")
+
+	got, err := resolveCommandType(cmd, "python app.py", "docker-compose")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "docker-compose" {
+		t.Errorf("got %q, want %q", got, "docker-compose")
+	}
+}
+
+// TestResolveCommandType_ExplicitInvalid asserts that an explicit but
+// unrecognized --cmd-type value (including the old, never-valid "docker")
+// is rejected with a clear error rather than silently falling back to
+// auto-detection.
+func TestResolveCommandType_ExplicitInvalid(t *testing.T) {
+	cmd := cmdWithCmdTypeFlag("docker")
+
+	_, err := resolveCommandType(cmd, "python app.py", "docker")
+	if err == nil {
+		t.Fatal("expected an error for an invalid --cmd-type value, got nil")
+	}
+	if !strings.Contains(err.Error(), "docker") {
+		t.Errorf("error %q does not mention the invalid value", err.Error())
+	}
+}
+
+// TestResolveCommandType_NotProvided_FallsBackToAutoDetect is the regression
+// guard: when the user never passes --cmd-type, behavior must be identical
+// to today's auto-detection.
+func TestResolveCommandType_NotProvided_FallsBackToAutoDetect(t *testing.T) {
+	cmd := cmdWithCmdTypeFlag("")
+
+	got, err := resolveCommandType(cmd, "python app.py", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "native" {
+		t.Errorf("got %q, want %q (auto-detected from a plain command string)", got, "native")
+	}
+}

--- a/cli/provider/cmd_test.go
+++ b/cli/provider/cmd_test.go
@@ -1,16 +1,25 @@
 package provider
 
 import (
+	"context"
 	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
+	"go.keploy.io/server/v3/config"
+	"go.keploy.io/server/v3/utils"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
-func cmdWithCmdTypeFlag(explicit string) *cobra.Command {
+// passed=false means the flag was never given on the command line. Kept
+// separate from the value so "--cmd-type=" (explicitly empty) is
+// expressible — a real invocation that a value-only helper cannot describe.
+func cmdWithCmdTypeFlag(explicit string, passed bool) *cobra.Command {
 	cmd := &cobra.Command{Use: "test"}
 	cmd.Flags().String("cmd-type", "", "")
-	if explicit != "" {
+	if passed {
 		_ = cmd.Flags().Set("cmd-type", explicit)
 	}
 	return cmd
@@ -20,9 +29,9 @@ func cmdWithCmdTypeFlag(explicit string) *cobra.Command {
 // valid --cmd-type wins over whatever auto-detection would have said for the
 // given command string.
 func TestResolveCommandType_ExplicitValid(t *testing.T) {
-	cmd := cmdWithCmdTypeFlag("docker-compose")
+	cmd := cmdWithCmdTypeFlag("docker-compose", true)
 
-	got, err := resolveCommandType(cmd, "python app.py", "docker-compose")
+	got, err := resolveCommandType(zap.NewNop(), cmd, "sudo -E docker compose up", "docker-compose")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -36,9 +45,9 @@ func TestResolveCommandType_ExplicitValid(t *testing.T) {
 // is rejected with a clear error rather than silently falling back to
 // auto-detection.
 func TestResolveCommandType_ExplicitInvalid(t *testing.T) {
-	cmd := cmdWithCmdTypeFlag("docker")
+	cmd := cmdWithCmdTypeFlag("docker", true)
 
-	_, err := resolveCommandType(cmd, "python app.py", "docker")
+	_, err := resolveCommandType(zap.NewNop(), cmd, "python app.py", "docker")
 	if err == nil {
 		t.Fatal("expected an error for an invalid --cmd-type value, got nil")
 	}
@@ -51,13 +60,315 @@ func TestResolveCommandType_ExplicitInvalid(t *testing.T) {
 // guard: when the user never passes --cmd-type, behavior must be identical
 // to today's auto-detection.
 func TestResolveCommandType_NotProvided_FallsBackToAutoDetect(t *testing.T) {
-	cmd := cmdWithCmdTypeFlag("")
+	cmd := cmdWithCmdTypeFlag("", false)
 
-	got, err := resolveCommandType(cmd, "python app.py", "")
+	got, err := resolveCommandType(zap.NewNop(), cmd, "python app.py", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if got != "native" {
 		t.Errorf("got %q, want %q (auto-detected from a plain command string)", got, "native")
+	}
+}
+
+// TestResolveCommandType_ConfigDefaultDoesNotCountAsExplicit is the
+// regression this function's Changed() gating exists for, and the one the
+// obvious implementation gets wrong. config/default.go ships
+// cmdType: "native" in every generated keploy.yml, so it arrives here as a
+// non-empty "configured" value on runs where the user never touched the
+// flag. Treating that as a deliberate choice would pin every such user to
+// native and silently break docker auto-detection for them.
+func TestResolveCommandType_ConfigDefaultDoesNotCountAsExplicit(t *testing.T) {
+	cases := []struct {
+		command string
+		want    string
+	}{
+		{"docker compose up", "docker-compose"},
+		{"docker run --name app img", "docker-run"},
+		{"docker start app", "docker-start"},
+		{"python app.py", "native"},
+	}
+	for _, tc := range cases {
+		// Flag never passed; "native" comes from the generated keploy.yml.
+		cmd := cmdWithCmdTypeFlag("", false)
+		got, err := resolveCommandType(zap.NewNop(), cmd, tc.command, "native")
+		if err != nil {
+			t.Fatalf("%q: unexpected error: %v", tc.command, err)
+		}
+		if got != tc.want {
+			t.Errorf("%q: got %q, want %q — the shipped keploy.yml default is being "+
+				"treated as an explicit user choice", tc.command, got, tc.want)
+		}
+	}
+}
+
+// A value that only ever came from keploy.yml is not honoured — the
+// privilege decision in main.go happens before any config is read, so a
+// config-supplied docker type would pick a mode without the root it needs.
+// It must warn rather than fail or silently comply, since the silence is
+// what let this flag stay inert for so long.
+func TestResolveCommandType_ConfigDockerValueWarnsAndIsNotHonoured(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	logger := zap.New(core)
+
+	cmd := cmdWithCmdTypeFlag("", false)
+	got, err := resolveCommandType(logger, cmd, "make up", "docker-compose")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "native" {
+		t.Errorf("got %q, want auto-detected %q", got, "native")
+	}
+	if logs.FilterMessageSnippet("not honoured").Len() == 0 {
+		t.Error("a docker cmdType in config was ignored without warning — the user has no " +
+			"way to discover the flag is command-line only")
+	}
+}
+
+// The shipped keploy.yml default must not warn; it is not a user choice.
+func TestResolveCommandType_ConfigNativeDefaultIsSilent(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	cmd := cmdWithCmdTypeFlag("", false)
+	if _, err := resolveCommandType(zap.New(core), cmd, "docker compose up", "native"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if logs.Len() != 0 {
+		t.Errorf("the generated keploy.yml default warned: %v", logs.All())
+	}
+}
+
+// `--cmd-type=""` was silently overwritten by auto-detection before #4399,
+// so that is what it must keep doing. Rejecting it breaks scripts that pass
+// it; preserving the empty value is worse — GetCommonServices reads "" as
+// "not docker" and leaves the docker client nil while resolveKind reads it
+// as "detect", so `--cmd-type= -c "docker compose up"` reaches SetupCompose
+// with a nil client and panics.
+func TestResolveCommandType_ExplicitEmptyFallsBackToAutoDetect(t *testing.T) {
+	for _, tc := range []struct{ command, want string }{
+		{"python app.py", "native"},
+		{"docker compose up", "docker-compose"},
+	} {
+		cmd := cmdWithCmdTypeFlag("", true)
+		got, err := resolveCommandType(zap.NewNop(), cmd, tc.command, "")
+		if err != nil {
+			t.Fatalf("--cmd-type=\"\" must not be rejected, got: %v", err)
+		}
+		if got != tc.want {
+			t.Errorf("command %q: got %q, want auto-detected %q", tc.command, got, tc.want)
+		}
+	}
+}
+
+// FindDockerCmd lowercases what it matches against, so the flag should not
+// be stricter than the auto-detection it overrides.
+func TestResolveCommandType_ExplicitIsNormalised(t *testing.T) {
+	for _, in := range []string{"Docker-Compose", "  docker-compose  ", "DOCKER-COMPOSE"} {
+		cmd := cmdWithCmdTypeFlag(in, true)
+		got, err := resolveCommandType(zap.NewNop(), cmd, "sudo -E docker compose up", in)
+		if err != nil {
+			t.Fatalf("%q: unexpected error: %v", in, err)
+		}
+		if got != "docker-compose" {
+			t.Errorf("%q: got %q, want %q", in, got, "docker-compose")
+		}
+	}
+}
+
+// The help text listed (native/docker/docker-compose): "docker" was never a
+// valid CmdType and docker-run/docker-start were missing entirely, so the
+// flag documented values it would now reject.
+func TestCmdTypeFlagHelpListsTheRealValues(t *testing.T) {
+	cfg := config.New()
+	c := NewCmdConfigurator(zap.NewNop(), cfg)
+	cmd := &cobra.Command{Use: "record"}
+	if err := c.AddFlags(cmd); err != nil {
+		t.Fatalf("AddFlags: %v", err)
+	}
+	flag := cmd.Flags().Lookup("cmd-type")
+	if flag == nil {
+		t.Fatal("cmd-type flag is not registered")
+	}
+	for _, want := range []utils.CmdType{utils.Native, utils.DockerRun, utils.DockerStart, utils.DockerCompose} {
+		if !strings.Contains(flag.Usage, string(want)) {
+			t.Errorf("help text %q does not mention the valid value %q", flag.Usage, want)
+		}
+	}
+}
+
+// End-to-end through ValidateFlags, which is where the value was being
+// discarded — resolveCommandType returning the right answer is only useful
+// if the caller keeps it.
+func TestValidateFlags_HonoursCmdTypeEndToEnd(t *testing.T) {
+	cases := []struct {
+		name       string
+		command    string
+		flagValue  string // "" = not passed on the CLI
+		configured string
+		want       string
+	}{
+		{"explicit compose over an unprefixed docker command", "sudo -E docker compose up", "docker-compose", "docker-compose", "docker-compose"},
+		{"config compose is not honoured", "sudo -E docker compose up", "", "docker-compose", "native"},
+		{"generated default + docker command still auto-detects", "docker compose up", "", "native", "docker-compose"},
+		{"generated default + plain command stays native", "python app.py", "", "native", "native"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.New()
+			c := NewCmdConfigurator(zap.NewNop(), cfg)
+			cmd := &cobra.Command{Use: "record"}
+			if err := c.AddFlags(cmd); err != nil {
+				t.Fatalf("AddFlags: %v", err)
+			}
+			args := []string{"-c", tc.command}
+			if tc.flagValue != "" {
+				args = append(args, "--cmd-type", tc.flagValue)
+			}
+			if err := cmd.ParseFlags(args); err != nil {
+				t.Fatalf("ParseFlags: %v", err)
+			}
+			// Mirror what viper.Unmarshal leaves behind before ValidateFlags.
+			cfg.Command = tc.command
+			cfg.CommandType = tc.configured
+
+			if err := c.ValidateFlags(context.Background(), cmd); err != nil {
+				t.Fatalf("ValidateFlags: %v", err)
+			}
+			if cfg.CommandType != tc.want {
+				t.Errorf("cfg.CommandType = %q, want %q", cfg.CommandType, tc.want)
+			}
+		})
+	}
+}
+
+// A docker cmdType only works if keploy can rewrite the command: SetupCompose
+// splices `-f <generated>.yaml` in ahead of " up", SetupDocker splices
+// `--pid=container:…` into a `docker run`. Point one at a wrapper and you get
+// `make -f ./docker-compose-tmp.yaml up --abort-on-container-exit`, which
+// fails with an unrecognised option nowhere near its cause. Refusing up front
+// is the difference between a usable flag and one that looks like it worked.
+func TestResolveCommandType_DockerRunRejectsWrapperCommand(t *testing.T) {
+	for _, cmdType := range []string{"docker-run", "docker-start"} {
+		for _, command := range []string{"make up", "./start.sh", "npm start"} {
+			cmd := cmdWithCmdTypeFlag(cmdType, true)
+			_, err := resolveCommandType(zap.NewNop(), cmd, command, cmdType)
+			if err == nil {
+				t.Errorf("%s with command %q: want an error, got none", cmdType, command)
+				continue
+			}
+			if !strings.Contains(err.Error(), command) {
+				t.Errorf("error for %q does not name the command: %v", command, err)
+			}
+		}
+	}
+}
+
+// docker-compose does have a way through — keploy hands its compose file over
+// via COMPOSE_FILE and runs the command untouched — so a wrapper is accepted
+// there. This is the case issue #4399 was opened for.
+func TestResolveCommandType_ComposeAcceptsWrapperCommand(t *testing.T) {
+	for _, command := range []string{"make up", "./start.sh", "npm start"} {
+		cmd := cmdWithCmdTypeFlag("docker-compose", true)
+		got, err := resolveCommandType(zap.NewNop(), cmd, command, "docker-compose")
+		if err != nil {
+			t.Errorf("command %q with --cmd-type docker-compose: unexpected error: %v", command, err)
+			continue
+		}
+		if got != "docker-compose" {
+			t.Errorf("command %q: got %q, want %q", command, got, "docker-compose")
+		}
+	}
+}
+
+// The commands the flag exists for: real docker invocations that
+// FindDockerCmd's prefix matching does not recognise.
+func TestResolveCommandType_DockerTypeAcceptsUnprefixedDockerCommands(t *testing.T) {
+	cases := []struct{ command, cmdType string }{
+		{"sudo -E docker compose up", "docker-compose"},
+		{"env FOO=bar docker compose up", "docker-compose"},
+		{"/usr/bin/docker compose up", "docker-compose"},
+		{"sudo -E docker run --name app img", "docker-run"},
+	}
+	for _, tc := range cases {
+		// Auto-detection must genuinely miss these, or the test proves nothing.
+		if got := utils.FindDockerCmd(tc.command); got != utils.Native {
+			t.Fatalf("premise broken: FindDockerCmd(%q) = %q, expected it to miss", tc.command, got)
+		}
+		cmd := cmdWithCmdTypeFlag(tc.cmdType, true)
+		got, err := resolveCommandType(zap.NewNop(), cmd, tc.command, tc.cmdType)
+		if err != nil {
+			t.Errorf("%q: unexpected error: %v", tc.command, err)
+			continue
+		}
+		if got != tc.cmdType {
+			t.Errorf("%q: got %q, want %q", tc.command, got, tc.cmdType)
+		}
+	}
+}
+
+// native against a wrapper is unaffected — nothing gets rewritten.
+func TestResolveCommandType_NativeAcceptsAnyCommand(t *testing.T) {
+	cmd := cmdWithCmdTypeFlag("native", true)
+	got, err := resolveCommandType(zap.NewNop(), cmd, "make up", "native")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "native" {
+		t.Errorf("got %q, want %q", got, "native")
+	}
+}
+
+// Substring matching let "./run-docker.sh" past the docker-run guard — a
+// wrapper by any reading, and the naming convention a docker wrapper script
+// actually uses. Past the guard it fails much worse: ParseDockerCmd wipes the
+// user's --container-name and modifyDockerRun dies on the token count.
+func TestMentionsDockerBinary(t *testing.T) {
+	yes := []string{
+		"docker compose up",
+		"sudo -E docker run --name app img",
+		"/usr/bin/docker compose up",
+		"env FOO=bar docker-compose up",
+	}
+	for _, cmd := range yes {
+		if !mentionsDockerBinary(cmd) {
+			t.Errorf("%q: want recognised as a docker invocation", cmd)
+		}
+	}
+
+	no := []string{
+		"./run-docker.sh",
+		"make docker-up",
+		"npm run docker",
+		"podman run --name app img",
+		"make up",
+	}
+	for _, cmd := range no {
+		if mentionsDockerBinary(cmd) {
+			t.Errorf("%q: want NOT recognised — it does not invoke docker itself", cmd)
+		}
+	}
+}
+
+// The config-file warning must not fire when the config value agrees with
+// auto-detection: nothing is being ignored in any way the user can observe,
+// and warning on every such run is pure noise.
+func TestResolveCommandType_ConfigWarningOnlyWhenItWouldDiffer(t *testing.T) {
+	// Agrees with detection -> silent.
+	core, logs := observer.New(zapcore.WarnLevel)
+	cmd := cmdWithCmdTypeFlag("", false)
+	if _, err := resolveCommandType(zap.New(core), cmd, "docker compose up", "docker-compose"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if logs.Len() != 0 {
+		t.Errorf("warned even though the config value matches what was detected: %v", logs.All())
+	}
+
+	// Disagrees -> warns.
+	core2, logs2 := observer.New(zapcore.WarnLevel)
+	cmd2 := cmdWithCmdTypeFlag("", false)
+	if _, err := resolveCommandType(zap.New(core2), cmd2, "make up", "docker-compose"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if logs2.FilterMessageSnippet("not honoured").Len() == 0 {
+		t.Error("config value was silently ignored where it would have changed the outcome")
 	}
 }

--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"regexp"
 	"sort"
@@ -30,12 +31,31 @@ import (
 
 var ansiEscapePattern = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
 
+// resolveKind picks the launch mode for this App. opts.CommandType is the
+// value ValidateFlags already resolved — auto-detected from the command in
+// the ordinary case, but overridden when the user passed --cmd-type. Falling
+// back to FindDockerCmd(cmd) keeps every caller that leaves CommandType
+// unset behaving exactly as before.
+//
+// Deriving it from the command string again here was the reason --cmd-type
+// could not work end to end (#4399): agent.go honoured opts.CommandType
+// while this App did not, so `--cmd-type docker-compose -c "make up"` left
+// the agent expecting a compose project that SetupCompose was never asked to
+// create, and the run died waiting for an agent that could not appear.
+func resolveKind(commandType, cmd string) utils.CmdType {
+	switch kind := utils.CmdType(commandType); kind {
+	case utils.Native, utils.DockerRun, utils.DockerStart, utils.DockerCompose:
+		return kind
+	}
+	return utils.FindDockerCmd(cmd)
+}
+
 func NewApp(logger *zap.Logger, cmd string, client docker.Client, opts models.SetupOptions) *App {
 	app := &App{
 		logger:          logger,
 		cmd:             cmd,
 		docker:          client,
-		kind:            utils.FindDockerCmd(cmd),
+		kind:            resolveKind(opts.CommandType, cmd),
 		opts:            opts,
 		keployContainer: opts.KeployContainer,
 		container:       opts.Container,
@@ -222,13 +242,51 @@ func (a *App) SetupCompose(extraArgs []string) error {
 	a.composeFile = newPath
 	a.logger.Debug("Created new temporary docker-compose for keploy internal use", zap.String("path", newPath))
 
-	// Now replace the running command to run the docker-compose-tmp.yaml file instead of user docker compose file.
-	a.cmd = modifyDockerComposeCommand(a.cmd, newPath, serviceInfo.ComposePath, serviceInfo.AppServiceName)
+	newCmd, composeFileEnv := composeLaunchPlan(a.cmd, newPath, serviceInfo.ComposePath, serviceInfo.AppServiceName)
+
+	if newCmd != "" {
+		// Literal compose command: our file is spliced in, as before.
+		a.cmd = newCmd
+		a.logger.Info(
+			"Running application using a temporary Keploy-generated Docker Compose file (will be cleaned up automatically)",
+			zap.String("cmd", a.cmd),
+			zap.String("composePath", newPath),
+		)
+		return nil
+	}
+
+	// A wrapper (make up, ./start.sh, an npm script) that runs compose
+	// internally. Nothing to splice into, so leave the command alone and let
+	// the compose it eventually runs find our file through the environment.
+	//
+	// This is process-global and inherited by every child keploy spawns from
+	// here on, not just the application command. That is tolerable because
+	// every compose invocation keploy makes itself passes -f explicitly, so
+	// none of them consult COMPOSE_FILE.
+	if previous, had := os.LookupEnv("COMPOSE_FILE"); had && previous != composeFileEnv {
+		a.logger.Warn("overriding an existing COMPOSE_FILE for this run; any files it named "+
+			"beyond the one keploy copied are not part of the application's configuration",
+			zap.String("previous", previous), zap.String("now", composeFileEnv))
+	}
+	if err := os.Setenv("COMPOSE_FILE", composeFileEnv); err != nil {
+		utils.LogError(a.logger, err, "failed to point the wrapper command at keploy's compose file")
+		return err
+	}
 
 	a.logger.Info(
-		"Running application using a temporary Keploy-generated Docker Compose file (will be cleaned up automatically)",
+		"Running application through your command with COMPOSE_FILE pointed at a temporary "+
+			"Keploy-generated Docker Compose file (will be cleaned up automatically)",
 		zap.String("cmd", a.cmd),
-		zap.String("composePath", newPath),
+		zap.String("composePath", composeFileEnv),
+	)
+	// Stated up front because each one otherwise fails a long way from its cause.
+	a.logger.Warn(
+		"the command is not a literal docker compose invocation, so keploy cannot modify it directly",
+		zap.String("cmd", a.cmd),
+		zap.String("if it passes its own -f", "COMPOSE_FILE is ignored and keploy's agent will not be injected"),
+		zap.String("if it runs compose detached (up -d)", "the command returns immediately and keploy stops, treating it as the app exiting"),
+		zap.String("if it sets its own project name", "keploy's teardown may not reach every container it started"),
+		zap.String("also", "--abort-on-container-exit cannot be added, so keploy will not exit on its own if the app container dies"),
 	)
 
 	return nil
@@ -1163,7 +1221,7 @@ func (a *App) run(ctx context.Context) models.AppError {
 	// dockerRunName is the resolved user-app container name; reused by the
 	// post-run container-name-conflict retry below.
 	var dockerRunName string
-	if utils.FindDockerCmd(a.cmd) == utils.DockerRun {
+	if a.kind == utils.DockerRun {
 		userCmd = utils.EnsureRmBeforeName(userCmd)
 		// Clear any container left over from a prior run with the same --name
 		// before starting. --rm removes the container on exit, but under heavy
@@ -1320,7 +1378,7 @@ func (a *App) run(ctx context.Context) models.AppError {
 	}
 
 	var err error
-	cmdErr := utils.ExecuteCommand(ctx, a.logger, userCmd, cmdCancel, 25*time.Second, a.composeContent)
+	cmdErr := utils.ExecuteCommand(ctx, a.logger, userCmd, a.kind, cmdCancel, 25*time.Second, a.composeContent)
 	// A user-app `docker run --name X` can still lose the container-name race to
 	// the prior test-set's --rm reaper on a saturated CI daemon even after the
 	// pre-run ensureContainerNameFreeWithin verified the name was free — the
@@ -1340,7 +1398,7 @@ func (a *App) run(ctx context.Context) models.AppError {
 		a.logger.Warn("docker run exited 125 with the --name still in use (container-name conflict); force-removing the name and retrying",
 			zap.String("container", dockerRunName), zap.Int("attempt", attempt))
 		a.ensureContainerNameFreeWithin(dockerRunName, preRunRemoveBudget)
-		cmdErr = utils.ExecuteCommand(ctx, a.logger, userCmd, cmdCancel, 25*time.Second, a.composeContent)
+		cmdErr = utils.ExecuteCommand(ctx, a.logger, userCmd, a.kind, cmdCancel, 25*time.Second, a.composeContent)
 	}
 
 	// Compose mode: a `docker compose up` can fail not because the user's app is
@@ -1413,7 +1471,7 @@ func (a *App) run(ctx context.Context) models.AppError {
 			a.ensureContainerNameFreeWithin(a.keployContainer, preRunRemoveBudget)
 		}
 
-		cmdErr = utils.ExecuteCommand(ctx, a.logger, userCmd, cmdCancel, 25*time.Second, a.composeContent)
+		cmdErr = utils.ExecuteCommand(ctx, a.logger, userCmd, a.kind, cmdCancel, 25*time.Second, a.composeContent)
 	}
 
 	if cmdErr.Err != nil {

--- a/pkg/client/app/composecmd_test.go
+++ b/pkg/client/app/composecmd_test.go
@@ -1,0 +1,90 @@
+package app
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// SetupCompose can only splice `-f <generated>.yaml` into a command that is a
+// literal docker compose invocation. For a wrapper it must leave the command
+// alone and hand the file over through COMPOSE_FILE instead — splicing
+// produces `make -f ./docker-compose-tmp.yaml up --abort-on-container-exit`,
+// which fails with an unrecognised option nowhere near its cause.
+func TestIsRewritableComposeCommand(t *testing.T) {
+	rewritable := []string{
+		"docker compose up",
+		"docker-compose up",
+		"sudo -E docker compose up",
+		"env FOO=bar docker compose -f custom.yml up",
+		"/usr/bin/docker compose up",
+		"DOCKER COMPOSE UP",
+	}
+	for _, cmd := range rewritable {
+		if !isRewritableComposeCommand(cmd) {
+			t.Errorf("%q: want rewritable, got not — keploy would fall back to COMPOSE_FILE "+
+				"and lose --abort-on-container-exit for no reason", cmd)
+		}
+	}
+
+	wrappers := []string{
+		"make up",
+		"./start.sh",
+		"npm run dev",
+		"task compose-up",
+	}
+	for _, cmd := range wrappers {
+		if isRewritableComposeCommand(cmd) {
+			t.Errorf("%q: want NOT rewritable, got rewritable — keploy would splice compose "+
+				"flags into a command that cannot take them", cmd)
+		}
+	}
+}
+
+// composeLaunchPlan is the decision SetupCompose acts on, and the branch that
+// used to survive mutation: flipping it either way left every test green
+// while restoring the `make -f ./docker-compose-tmp.yaml up
+// --abort-on-container-exit` failure the whole feature exists to avoid.
+func TestComposeLaunchPlan(t *testing.T) {
+	const generated = "docker-compose-tmp.yaml"
+
+	t.Run("literal compose command is rewritten, no env", func(t *testing.T) {
+		newCmd, env := composeLaunchPlan("docker compose up", generated, "docker-compose.yml", "app")
+		if newCmd == "" {
+			t.Fatal("want the command rewritten, got none")
+		}
+		if !strings.Contains(newCmd, generated) {
+			t.Errorf("rewritten command %q does not reference %q", newCmd, generated)
+		}
+		if env != "" {
+			t.Errorf("COMPOSE_FILE should not be used when the command can be rewritten, got %q", env)
+		}
+	})
+
+	t.Run("wrapper is left alone and gets an absolute env path", func(t *testing.T) {
+		newCmd, env := composeLaunchPlan("make up", generated, "docker-compose.yml", "app")
+		if newCmd != "" {
+			t.Errorf("wrapper must not be rewritten, got %q — splicing compose flags into a "+
+				"wrapper produces a command it cannot parse", newCmd)
+		}
+		if env == "" {
+			t.Fatal("wrapper needs COMPOSE_FILE, got none")
+		}
+		if !filepath.IsAbs(env) {
+			t.Errorf("COMPOSE_FILE %q is relative; compose resolves it against its OWN working "+
+				"directory, so `make -C deploy up` would look in the wrong place", env)
+		}
+		if filepath.Base(env) != generated {
+			t.Errorf("COMPOSE_FILE %q does not point at %q", env, generated)
+		}
+	})
+
+	t.Run("exactly one mechanism is chosen", func(t *testing.T) {
+		for _, cmd := range []string{"docker compose up", "docker-compose up", "make up", "./start.sh"} {
+			newCmd, env := composeLaunchPlan(cmd, generated, "docker-compose.yml", "app")
+			if (newCmd == "") == (env == "") {
+				t.Errorf("%q: want exactly one of rewrite/env, got newCmd=%q env=%q", cmd, newCmd, env)
+			}
+		}
+	})
+}

--- a/pkg/client/app/resolvekind_test.go
+++ b/pkg/client/app/resolvekind_test.go
@@ -1,0 +1,59 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.keploy.io/server/v3/utils"
+	"go.uber.org/zap"
+)
+
+// NewApp used to derive its kind from the command string, which is why
+// --cmd-type could not work end to end (#4399): agent.go honoured
+// opts.CommandType while this App did not, so `--cmd-type docker-compose -c
+// "make up"` left the agent expecting a compose project SetupCompose was
+// never asked to create. a.kind drives Setup / SetupCompose / Run / Stop, so
+// this is the value that decides what actually happens.
+func TestResolveKind(t *testing.T) {
+	cases := []struct {
+		name        string
+		commandType string
+		cmd         string
+		want        utils.CmdType
+	}{
+		// The case the whole feature exists for.
+		{"explicit compose beats an undetectable command", "docker-compose", "make up", utils.DockerCompose},
+		{"explicit docker-run beats a plain command", "docker-run", "./start.sh", utils.DockerRun},
+		{"explicit native beats a docker-looking command", "native", "docker compose up", utils.Native},
+
+		// Unset or unusable values must behave exactly as before.
+		{"unset falls back to detection", "", "docker compose up", utils.DockerCompose},
+		{"unset falls back to detection, plain", "", "python app.py", utils.Native},
+		{"garbage falls back to detection", "not-a-kind", "docker run --name x img", utils.DockerRun},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveKind(tc.commandType, tc.cmd); got != tc.want {
+				t.Errorf("resolveKind(%q, %q) = %q, want %q", tc.commandType, tc.cmd, got, tc.want)
+			}
+		})
+	}
+}
+
+// resolveKind being correct is useless if NewApp does not call it, so pin
+// the wiring too — a revert to FindDockerCmd(cmd) here would leave the
+// function above green while the feature stayed broken.
+func TestNewApp_UsesResolvedCommandType(t *testing.T) {
+	app := NewApp(zap.NewNop(), "make up", nil, models.SetupOptions{CommandType: "docker-compose"})
+	if got := app.Kind(context.Background()); got != utils.DockerCompose {
+		t.Errorf("App.Kind = %q, want %q — NewApp is deriving the kind from the command "+
+			"string again and ignoring the resolved --cmd-type", got, utils.DockerCompose)
+	}
+
+	// Unset CommandType must still auto-detect, as every existing caller relies on.
+	app = NewApp(zap.NewNop(), "docker compose up", nil, models.SetupOptions{})
+	if got := app.Kind(context.Background()); got != utils.DockerCompose {
+		t.Errorf("App.Kind = %q, want %q from auto-detection", got, utils.DockerCompose)
+	}
+}

--- a/pkg/client/app/util.go
+++ b/pkg/client/app/util.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"strings"
@@ -91,6 +92,46 @@ func findComposeFile(cmd string) []string {
 	}
 
 	return []string{}
+}
+
+// isRewritableComposeCommand reports whether appCmd is a literal docker
+// compose invocation, i.e. one that modifyDockerComposeCommand can splice
+// `-f <generated>.yaml` into.
+//
+// It is false for a wrapper — `make up`, `./start.sh`, an npm script — that
+// runs compose internally. Splicing into those produces nonsense
+// (`make -f ./docker-compose-tmp.yaml up --abort-on-container-exit`), so
+// those commands are run untouched and pointed at keploy's compose file
+// through the COMPOSE_FILE environment variable instead.
+func isRewritableComposeCommand(appCmd string) bool {
+	lower := strings.ToLower(appCmd)
+	return strings.Contains(lower, "docker compose") || strings.Contains(lower, "docker-compose")
+}
+
+// composeLaunchPlan decides how keploy hands its generated compose file to
+// the application command, and is pure so both branches can be tested
+// without a docker client.
+//
+// Exactly one of the two results is non-empty. A literal compose command
+// gets the file spliced in (and with it --abort-on-container-exit, which is
+// how keploy notices the app container dying). A wrapper cannot be rewritten
+// — splicing yields `make -f ./docker-compose-tmp.yaml up
+// --abort-on-container-exit` — so it runs untouched and the file travels in
+// COMPOSE_FILE instead.
+//
+// composeFileEnv is absolute: compose resolves a relative COMPOSE_FILE
+// against its own working directory and derives the project directory from
+// it, so `make -C deploy up` would otherwise look for
+// deploy/docker-compose-tmp.yaml and find nothing.
+func composeLaunchPlan(appCmd, newComposeFile, appComposePath, appServiceName string) (newCmd, composeFileEnv string) {
+	if isRewritableComposeCommand(appCmd) {
+		return modifyDockerComposeCommand(appCmd, newComposeFile, appComposePath, appServiceName), ""
+	}
+	abs, err := filepath.Abs(newComposeFile)
+	if err != nil {
+		abs = newComposeFile
+	}
+	return "", abs
 }
 
 func modifyDockerComposeCommand(appCmd, newComposeFile, appComposePath, appServiceName string) string {

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -3722,7 +3722,7 @@ func (r *Replayer) executeScript(ctx context.Context, script string) error {
 		}
 	}
 
-	cmdErr := utils.ExecuteCommand(ctx, r.logger, script, cmdCancel, 25*time.Second, nil)
+	cmdErr := utils.ExecuteCommand(ctx, r.logger, script, utils.Empty, cmdCancel, 25*time.Second, nil)
 	if cmdErr.Err != nil {
 		return fmt.Errorf("failed to execute script: %w", cmdErr.Err)
 	}

--- a/utils/cmdtype_args_test.go
+++ b/utils/cmdtype_args_test.go
@@ -1,0 +1,47 @@
+package utils
+
+import "testing"
+
+// ShouldReexecWithSudo runs before cobra parses anything and long before any
+// config file is read, so an explicit --cmd-type has to come out of raw argv.
+// Without it, `--cmd-type docker-run -c "make up"` takes the native path,
+// starts unprivileged, and dies later writing /proc/sys/kernel/perf_event_paranoid.
+func TestExtractCmdTypeFromArgs(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"space separated", []string{"keploy", "record", "--cmd-type", "docker-compose", "-c", "make up"}, "docker-compose"},
+		{"equals form", []string{"keploy", "record", "--cmd-type=docker-run"}, "docker-run"},
+		{"normalised", []string{"keploy", "record", "--cmd-type", "  Docker-Compose "}, "docker-compose"},
+		{"absent", []string{"keploy", "record", "-c", "make up"}, ""},
+		{"explicitly empty", []string{"keploy", "record", "--cmd-type="}, ""},
+		{"dangling at end", []string{"keploy", "record", "--cmd-type"}, ""},
+		// Must not confuse itself with a value that merely contains the name.
+		{"not confused by the command", []string{"keploy", "record", "-c", "echo --cmd-type docker-run"}, ""},
+
+		// cli/provider's aliasNormalizeFunc maps cmdType -> cmd-type, so cobra
+		// accepts the camelCase spelling and Changed("cmd-type") is true for
+		// it. Missing it here would let --cmdType silently skip the privilege
+		// decision — and the repo's own CI scripts use camelCase aliases.
+		{"camelCase alias", []string{"keploy", "record", "--cmdType", "docker-compose"}, "docker-compose"},
+		{"camelCase equals form", []string{"keploy", "record", "--cmdType=docker-run"}, "docker-run"},
+
+		// cobra resolves a repeated flag to the last occurrence; disagreeing
+		// would mean the privilege decision and the run mode come from
+		// different values.
+		{"last occurrence wins", []string{"keploy", "record", "--cmd-type", "native", "--cmd-type", "docker-compose"}, "docker-compose"},
+		{"last wins across spellings", []string{"keploy", "record", "--cmdType", "docker-compose", "--cmd-type", "native"}, "native"},
+
+		// Everything after -- is positional, not a flag.
+		{"terminator", []string{"keploy", "record", "--", "--cmd-type", "docker-run"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ExtractCmdTypeFromArgs(tc.args); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/utils/execute_command_shellfree_test.go
+++ b/utils/execute_command_shellfree_test.go
@@ -61,7 +61,7 @@ func TestExecuteCommand_RunsCloudReplayShapeWithoutShell(t *testing.T) {
 	cmdStr := "tee " + capturedPath
 	noopCancel := func(_ *exec.Cmd) func() error { return func() error { return nil } }
 
-	cmdErr := ExecuteCommand(context.Background(), zap.NewNop(), cmdStr, noopCancel, time.Second, composeDoc)
+	cmdErr := ExecuteCommand(context.Background(), zap.NewNop(), cmdStr, Empty, noopCancel, time.Second, composeDoc)
 	if cmdErr.Err != nil {
 		t.Fatalf("ExecuteCommand failed in a shell-less env (a hard `sh -c` regression?): type=%s err=%v",
 			cmdErr.Type, cmdErr.Err)

--- a/utils/reexec_linux.go
+++ b/utils/reexec_linux.go
@@ -79,6 +79,21 @@ func ShouldReexecWithSudo() bool {
 		return true
 	}
 
+	// An explicit --cmd-type wins over sniffing the command string, and has
+	// to be read straight out of os.Args: this runs before cobra parses
+	// anything and long before any config file is read. Without it,
+	// `--cmd-type docker-compose -c "make up"` would take the native path
+	// here, start unprivileged, and then fail deep inside the docker branch
+	// trying to write /proc/sys/kernel/perf_event_paranoid (#4399).
+	if explicit := ExtractCmdTypeFromArgs(os.Args); explicit != "" {
+		switch kind := CmdType(explicit); kind {
+		case Native, DockerRun, DockerStart, DockerCompose:
+			return IsDockerCmd(kind)
+		}
+		// Anything else is rejected later by ValidateFlags with a proper
+		// message; fall through to sniffing rather than guessing here.
+	}
+
 	// Extract the command from arguments
 	cmd := ExtractCommandFromArgs(os.Args)
 	if cmd == "" {

--- a/utils/reexec_linux_test.go
+++ b/utils/reexec_linux_test.go
@@ -2,7 +2,10 @@
 
 package utils
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
 func TestIsCloudReplayCmd(t *testing.T) {
 	tests := []struct {
@@ -66,6 +69,51 @@ func TestIsCloudReplayCmd(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := isCloudReplayCmd(tt.args); got != tt.want {
 				t.Errorf("isCloudReplayCmd(%v) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+// ShouldReexecWithSudo decides whether keploy needs root, from raw argv,
+// before cobra or any config file is involved. An explicit --cmd-type has to
+// win here or `--cmd-type docker-run -c "make up"` starts unprivileged and
+// dies much later writing /proc/sys/kernel/perf_event_paranoid (#4399).
+//
+// Pins the wiring, not just the argv helper: dropping the ExtractCmdTypeFromArgs
+// call would leave that helper's own test green while the feature stayed broken.
+func TestShouldReexecWithSudo_HonoursExplicitCmdType(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("runs as root; ShouldReexecWithSudo short-circuits before the cmd-type check")
+	}
+
+	cases := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		// The feature: a command that does not look like docker, declared as docker.
+		{"explicit docker-compose on a wrapper", []string{"keploy", "record", "--cmd-type", "docker-compose", "-c", "make up"}, true},
+		{"explicit docker-run on a script", []string{"keploy", "record", "--cmd-type=docker-run", "-c", "./start.sh"}, true},
+		// The inverse: a docker-looking command declared native still needs no root.
+		{"explicit native on a docker command", []string{"keploy", "record", "--cmd-type", "native", "-c", "docker compose up"}, false},
+		// Unchanged behaviour when the flag is absent.
+		{"no flag, docker command", []string{"keploy", "record", "-c", "docker compose up"}, true},
+		{"no flag, plain command", []string{"keploy", "record", "-c", "python app.py"}, false},
+		// An unrecognised value falls through to sniffing; ValidateFlags reports it properly later.
+		{"garbage falls back to sniffing", []string{"keploy", "record", "--cmd-type", "nope", "-c", "docker compose up"}, true},
+		// The camelCase alias cobra also accepts must not skip this gate.
+		{"camelCase alias on a wrapper", []string{"keploy", "record", "--cmdType", "docker-compose", "-c", "make up"}, true},
+		{"camelCase alias native on a docker command", []string{"keploy", "record", "--cmdType=native", "-c", "docker compose up"}, false},
+	}
+
+	orig := os.Args
+	defer func() { os.Args = orig }()
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			os.Args = tc.args
+			if got := ShouldReexecWithSudo(); got != tc.want {
+				t.Errorf("ShouldReexecWithSudo() = %v, want %v for %v", got, tc.want, tc.args)
 			}
 		})
 	}

--- a/utils/signal_others.go
+++ b/utils/signal_others.go
@@ -34,7 +34,7 @@ func SendSignal(logger *zap.Logger, pid int, sig syscall.Signal) error {
 	return nil
 }
 
-func ExecuteCommand(ctx context.Context, logger *zap.Logger, userCmd string, cancel func(cmd *exec.Cmd) func() error, waitDelay time.Duration, stdin []byte) CmdError {
+func ExecuteCommand(ctx context.Context, logger *zap.Logger, userCmd string, kind CmdType, cancel func(cmd *exec.Cmd) func() error, waitDelay time.Duration, stdin []byte) CmdError {
 	// Run the app as the user who invoked sudo
 
 	// Run through `sh -c` when a shell is available; fall back to a direct exec
@@ -50,8 +50,17 @@ func ExecuteCommand(ctx context.Context, logger *zap.Logger, userCmd string, can
 	// wait after sending the interrupt signal, before sending the kill signal
 	cmd.WaitDelay = waitDelay
 
-	// Check if the command is docker-compose related and output is a TTY
-	cmdType := FindDockerCmd(userCmd)
+	// Check if the command is docker-compose related and output is a TTY.
+	//
+	// kind is the resolved command type, not a second guess from the command
+	// string. Re-deriving here mislabelled every command --cmd-type exists
+	// for — a wrapper like "make up", and `sudo -E docker compose up`, both
+	// come back "native" — which drops compose onto the Setpgid path and the
+	// background process group that SIGTTOU/SIGTTIN stalls.
+	cmdType := kind
+	if cmdType == Empty {
+		cmdType = FindDockerCmd(userCmd)
+	}
 	isTTY := term.IsTerminal(int(os.Stdout.Fd()))
 
 	// When in-memory compose content is provided, pipe it via stdin and skip PTY.

--- a/utils/signal_windows.go
+++ b/utils/signal_windows.go
@@ -39,7 +39,7 @@ func SendSignal(logger *zap.Logger, pid int, sig syscall.Signal) error {
 //		return CmdError{Type: Init, Err: errors.New("not implemented")}
 //	}
 
-func ExecuteCommand(ctx context.Context, logger *zap.Logger, userCmd string, cancel func(cmd *exec.Cmd) func() error, waitDelay time.Duration, stdin []byte) CmdError {
+func ExecuteCommand(ctx context.Context, logger *zap.Logger, userCmd string, kind CmdType, cancel func(cmd *exec.Cmd) func() error, waitDelay time.Duration, stdin []byte) CmdError {
 	// On Windows, commands are typically executed via 'cmd /C' or 'powershell -Command'
 	// to handle complex shell-like logic in 'userCmd'. 'cmd /C' is the most robust default.
 	cmd := exec.CommandContext(ctx, "cmd", "/C", userCmd)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -545,7 +545,45 @@ func GetLatestGitHubRelease(ctx context.Context, logger *zap.Logger) (GitHubRele
 	return release, nil
 }
 
-// FindDockerCmd checks if the cli is related to docker or not, it also returns if it is a docker compose file
+// ExtractCmdTypeFromArgs pulls an explicit --cmd-type out of raw argv.
+//
+// ShouldReexecWithSudo has to decide whether keploy needs root before cobra
+// has parsed anything and before any config file is read, so it cannot ask
+// the resolved config what the command type is. Returns "" when the flag is
+// absent; the caller decides what an unrecognised value means.
+func ExtractCmdTypeFromArgs(args []string) string {
+	// Both spellings: cli/provider's aliasNormalizeFunc maps cmdType ->
+	// cmd-type, so cobra accepts --cmdType and Changed("cmd-type") is true
+	// for it. Matching only the kebab form would let the camelCase spelling
+	// silently skip this privilege decision — and the repo's own CI scripts
+	// use camelCase aliases throughout.
+	names := []string{"--cmd-type", "--cmdType"}
+	// Last occurrence wins, matching how cobra resolves a repeated flag.
+	found := ""
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			break // everything after the terminator is positional
+		}
+		for _, name := range names {
+			if arg == name {
+				if i+1 < len(args) {
+					found = args[i+1]
+					i++
+				} else {
+					found = ""
+				}
+				break
+			}
+			if strings.HasPrefix(arg, name+"=") {
+				found = arg[len(name)+1:]
+				break
+			}
+		}
+	}
+	return strings.ToLower(strings.TrimSpace(found))
+}
+
 // ExtractCommandFromArgs parses os.Args to find the value of -c or --command flag.
 // Returns empty string if not found.
 func ExtractCommandFromArgs(args []string) string {


### PR DESCRIPTION
## Describe the changes that are made
- `--cmd-type` (`cli/provider/cmd.go:243`) is registered, viper-bound, and documented, but `ValidateFlags` (`cli/provider/cmd.go`, inside `case "record", "test":`) unconditionally overwrote it with auto-detection from the `--command` string right after flag/config unmarshalling — an explicit value was silently discarded every time, whether the user passed it or not. Introduced in the same commit as the flag itself (#1814), never guarded by `Changed()`.
- Fix: extract the assignment into `resolveCommandType(cmd, command, explicit)`. When the user explicitly passes `--cmd-type`, it's validated against the real `utils.CmdType` set and used as-is; otherwise auto-detection runs exactly as before.
- Gated on `cmd.Flags().Changed("cmd-type")`, deliberately **not** on the value being non-empty: `config/default.go`'s `InternalConfig` ships `cmdType: "native"` in every generated `keploy.yml`, so a non-empty check would treat that baked-in default as an explicit user choice and break Docker users who never touched the flag.
- Also fixes the flag's help text, which advertised `docker` as a valid value — it never was; the real values are `native` / `docker-run` / `docker-start` / `docker-compose` (`utils/utils.go`).
- Extracting a standalone function (rather than inlining the check) keeps this unit-testable without invoking `ValidateFlags`'s side effects (stdout logo printing, logger level swaps, JSON-mode redirection).

**Reproduction (before this change):**
```
$ keploy test --cmd-type docker-compose -c "python app.py"
ERROR   failed to validate flags   {"error": "non docker command not supported for OS: darwin , Arch: arm64"}
```
**After this change**, the same command proceeds normally (the explicit `docker-compose` is honored, bypassing the Native/Empty-only OS/Arch gate). An invalid value now fails clearly instead of being silently ignored:
```
$ keploy test --cmd-type docker -c "python app.py"
ERROR   failed to validate flags   {"error": "invalid --cmd-type value \"docker\": allowed values are \"native\", \"docker-run\", \"docker-start\", and \"docker-compose\""}
```

## Links & References

**Closes:** #4399

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [x] 🍕 Feature
- [x] ✅ Test

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed — this is a flag-validation/config-resolution fix covered by focused unit tests; no sample-app behavior changes.

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed — the only user-facing text is the flag's own `--help` string, fixed in this PR.

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

```
$ go test -v -run TestResolveCommandType ./cli/provider/
=== RUN   TestResolveCommandType_ExplicitValid
--- PASS: TestResolveCommandType_ExplicitValid (0.00s)
=== RUN   TestResolveCommandType_ExplicitInvalid
--- PASS: TestResolveCommandType_ExplicitInvalid (0.00s)
=== RUN   TestResolveCommandType_NotProvided_FallsBackToAutoDetect
--- PASS: TestResolveCommandType_NotProvided_FallsBackToAutoDetect (0.00s)
PASS
ok  	go.keploy.io/server/v3/cli/provider	0.835s
```

Full local gate:
```
$ gofmt -l .            # clean
$ go vet ./...          # clean
$ go test ./cli/...     # ok
$ go test ./...         # ok, 0 failures
```

Also manually verified against the built binary (see reproduction above): the explicit-valid, explicit-invalid, and not-provided cases all behave as intended.

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA

## Additional checklist:
- [x] Have you read the Contributing Guidelines on issues?
- [x] Have you followed the PR Semantics guide for naming this PR?
- [x] Have you followed the Branch Semantics guide for naming your branch?
