### PR TITLE
ci: cap cleanup_windows so a busy Windows fleet cannot park a whole run

### DIFF
--- a/.github/workflows/prepare_and_run.yml
+++ b/.github/workflows/prepare_and_run.yml
@@ -1036,6 +1036,18 @@ jobs:
     if: ${{ always() && ((github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main')) }}
     runs-on: [self-hosted, Windows, X64]
     needs: [run_golang_docker_windows, run_golang_native_windows]
+    # The only self-hosted job in the repo that had no cap, so it inherited
+    # GitHub's 360-minute default. Because it is `if: always()` and the final
+    # `gate_windows` needs it, a Windows fleet that is busy or offline parks it
+    # in the queue and the ENTIRE run stays in_progress behind it for six
+    # hours — the PR shows no verdict and `gh run rerun --failed` refuses,
+    # because that requires a completed run. Observed on run 30620482988: 60+
+    # minutes queued with zero steps executed while every other job had long
+    # finished. 10 minutes matches its macOS twin `clean_up_docker_macos`; the
+    # work itself is `docker rm -f` and a lock-file delete. Losing a cleanup
+    # pass is cheap and self-correcting — the next push schedules a fresh one,
+    # as the concurrency comment at the top of this file already notes.
+    timeout-minutes: 10
     steps:
       - name: Pre-checkout git isolation
         shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'


### PR DESCRIPTION
## Describe the changes that are made

`cleanup_windows` was the only self-hosted job in the repo without `timeout-minutes`, so it inherited GitHub's **360-minute** default. Every other job on those runners is capped at 10 or 30, and the comments in this very file explain why — *"bound the wall-clock so a hung self-hosted Windows runner cannot sit on a self-hosted Windows runner for 6h"*.

```
$ python3 -c "…"   # every self-hosted job vs its cap
build-windows-amd64    runs-on=[self-hosted, Windows, X64]  timeout=30
precheck-windows       runs-on=[self-hosted, Windows, X64]  timeout=30
precheck-macos         runs-on=[self-hosted, macOS, native] timeout=10
clean_up_docker_macos  runs-on=[self-hosted, macOS, native] timeout=10
cleanup_windows        runs-on=[self-hosted, Windows, X64]  timeout=(default 360)   ← 
```

It is the worst one to have missed. It runs `if: always()` and `gate_windows` needs it, so when the Windows fleet is busy or offline the job sits in the queue **with zero steps executed** and the entire run stays `in_progress` behind it — for up to six hours. Two concrete consequences:

- the pull request shows no verdict for that whole time, and
- `gh run rerun --failed` refuses with *"run … cannot be rerun; its workflow file may be broken"*, because re-running requires a **completed** run. So the one recovery action is unavailable exactly when it is needed.

Observed on run `30620482988`: every other job had finished and one lane had genuinely failed, but `cleanup_windows` had been queued 60+ minutes without ever acquiring a runner, and the run could not be re-run. The run had to be cancelled by hand to reach a terminal state.

`10` matches its macOS twin `clean_up_docker_macos`. The work is `docker rm -f` scoped to this job's own containers plus a lock-file delete, so a lost cleanup pass is cheap and self-correcting — the next push schedules a fresh `always()` cleanup, which is the same convergence argument the `concurrency` comment at the top of this file already makes for concurrency-cancels.

## Links & References

**Closes:** NA

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [x] 🔁 CI

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

```bash
python3 - <<'PY'
import yaml
d = yaml.safe_load(open('.github/workflows/prepare_and_run.yml'))
bad = [n for n, j in d['jobs'].items()
       if isinstance(j, dict) and 'self-hosted' in str(j.get('runs-on'))
       and 'timeout-minutes' not in j]
print('self-hosted jobs without timeout-minutes:', bad or 'NONE')
PY
# before: ['cleanup_windows']
# after:  NONE
```

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA