### PR TITLE
ci(proxy-stress-test): make the lane able to fail

### DIFF
--- a/.github/workflows/test_workflow_scripts/golang/proxy_stress_test/golang-docker.sh
+++ b/.github/workflows/test_workflow_scripts/golang/proxy_stress_test/golang-docker.sh
@@ -12,6 +12,17 @@ docker compose build
 sudo rm -rf keploy/
 $RECORD_BIN config --generate
 
+# The sample checks in its own keploy.yml carrying the globalNoise that ignores
+# the wall-clock `duration` field these endpoints report (see samples-go
+# proxy-stress-test/keploy.yml). `config --generate` above is a no-op when that
+# file exists, so the noise applies here and to a bare `./test.sh` run alike —
+# deliberately not patched in from CI, so the two cannot drift.
+grep -q 'duration' ./keploy.yml || {
+    echo "FAIL: the sample's keploy.yml is missing the duration noise; without it"
+    echo "      /api/transfer, /api/batch-transfer and /api/post-transfer mismatch on every replay."
+    exit 1
+}
+
 container_kill() {
     REC_PID="$(pgrep -n -f "$(basename "${RECORD_BIN:-keploy}") record" || true)"
     echo "Keploy record PID: $REC_PID"
@@ -109,7 +120,10 @@ echo "Services stopped"
 test_container="proxyStressApp"
 # timeout -s INT: hard ceiling so a stuck replay can't hang the job (matches the
 # record path); the "No reports — replay hung" guard below then fails it fast.
-timeout -s INT 600 $REPLAY_BIN test -c 'docker compose up' --containerName "$test_container" --apiTimeout 60 --delay 15 --generate-github-actions=false |& tee "${test_container}.txt" || true
+set +e
+timeout -s INT 600 $REPLAY_BIN test -c 'docker compose up' --containerName "$test_container" --apiTimeout 60 --delay 15 --generate-github-actions=false |& tee "${test_container}.txt"
+replay_rc=${PIPESTATUS[0]}
+set -e
 
 if grep "WARNING: DATA RACE" "${test_container}.txt"; then echo "FAIL: Data race during replay"; exit 1; fi
 if grep -q "panic:" "${test_container}.txt"; then echo "FAIL: Panic during replay"; cat "${test_container}.txt"; exit 1; fi
@@ -120,9 +134,52 @@ if [ "$report_count" -eq 0 ]; then echo "FAIL: No reports — replay hung"; cat 
 if grep -q "Error channel is full" "${test_container}.txt"; then echo "FAIL: Error channel overflow"; cat "${test_container}.txt"; exit 1; fi
 if grep -q "incomplete or invalid response packet" "${test_container}.txt"; then echo "FAIL: PG decode failure"; cat "${test_container}.txt"; exit 1; fi
 
+# Enforce the report status. This loop used to only `echo` it, so the lane was
+# green through four consecutive FAILED test sets — 11 of 18 tests failing —
+# and had been for weeks. Everything else in this script (data race, panic,
+# zero test cases, zero reports) checks for the run not happening; nothing
+# checked whether it passed.
+all_passed=true
+seen_reports=0
 for report_file in ./keploy/reports/test-run-0/test-set-*-report.yaml; do
-    [ -f "$report_file" ] && echo "$(basename "$report_file"): $(grep 'status:' "$report_file" | head -1 | awk '{print $2}')"
+    [ -f "$report_file" ] || continue
+    seen_reports=$((seen_reports + 1))
+    status=$(grep 'status:' "$report_file" | head -1 | awk '{print $2}')
+    echo "$(basename "$report_file"): $status"
+    if [ "$status" != "PASSED" ]; then
+        all_passed=false
+    fi
 done
+# A glob that matched nothing leaves the loop body unexecuted, which would
+# otherwise sail through as "all passed".
+if [ "$seen_reports" -eq 0 ]; then
+    echo "FAIL: no test-set reports under ./keploy/reports/test-run-0"
+    cat "${test_container}.txt"
+    exit 1
+fi
+# Every recorded test-set must have produced a report. Checking only the
+# reports that exist means a test-set whose replay died before writing one is
+# invisible: the survivors all say PASSED and the loop above is satisfied.
+recorded_sets=$(find ./keploy -maxdepth 1 -type d -name 'test-set-*' | wc -l)
+if [ "$seen_reports" -ne "$recorded_sets" ]; then
+    echo "FAIL: $recorded_sets test-sets recorded but $seen_reports reported — they must match; a replay died before writing its report"
+    cat "${test_container}.txt"
+    exit 1
+fi
+if [ "$all_passed" != true ]; then
+    echo "FAIL: one or more yaml test sets did not pass"
+    cat "${test_container}.txt"
+    exit 1
+fi
+# Asserted last so the per-report diagnostics above are printed first. Catches
+# anything keploy fails at AFTER the final report is written — coverage,
+# mock pruning, teardown — which leaves every report PASSED and would
+# otherwise go green.
+if [ "$replay_rc" -ne 0 ]; then
+    echo "FAIL: every test set passed but keploy exited $replay_rc"
+    cat "${test_container}.txt"
+    exit 1
+fi
 
 if json_pass_supported; then
     # Reuse the compose service name (`proxyStressApp`) — there is no
@@ -130,10 +187,36 @@ if json_pass_supported; then
     # auto-detected per file by NewMockReaderAny / GetTestCases on the
     # replay side, so the --storage-format flag here only affects what
     # extension the json *report* gets written under.
-    timeout -s INT 600 $REPLAY_BIN test --storage-format json -c 'docker compose up' --containerName "$test_container" --apiTimeout 60 --delay 15 --generate-github-actions=false |& tee "${test_container}_json.txt" || true
+    set +e
+    timeout -s INT 600 $REPLAY_BIN test --storage-format json -c 'docker compose up' --containerName "$test_container" --apiTimeout 60 --delay 15 --generate-github-actions=false |& tee "${test_container}_json.txt"
+    json_replay_rc=${PIPESTATUS[0]}
+    set -e
     if grep "WARNING: DATA RACE" "${test_container}_json.txt"; then echo "FAIL: Data race during json replay"; exit 1; fi
     if grep -q "panic:" "${test_container}_json.txt"; then echo "FAIL: Panic during json replay"; cat "${test_container}_json.txt"; exit 1; fi
-    json_scan_reports || true
+    # json_scan_reports already emits ::error:: annotations for FAILED sets and
+    # returns non-zero. The `|| true` that used to be here threw that away, so
+    # the lane printed four "##[error] ... status=FAILED" lines and then
+    # declared itself passed on the very next line.
+    if ! json_scan_reports; then
+        echo "FAIL: one or more json test sets did not pass"
+        cat "${test_container}_json.txt"
+        exit 1
+    fi
+    # json_scan_reports only inspects the reports that EXIST — the same hole the
+    # yaml pass has above, so it needs the same denominator. A test set whose
+    # replay died before writing its report is otherwise invisible: the
+    # survivors all say PASSED and the scan is satisfied.
+    json_reports=$(find ./keploy/reports -type f -path '*/test-run-*/test-set-*-report.json' | wc -l)
+    if [ "$json_reports" -ne "$recorded_sets" ]; then
+        echo "FAIL: $recorded_sets test-sets recorded but only $json_reports json reports written — a replay died before writing its report"
+        cat "${test_container}_json.txt"
+        exit 1
+    fi
+    if [ "$json_replay_rc" -ne 0 ]; then
+        echo "FAIL: every json test set passed but keploy exited $json_replay_rc"
+        cat "${test_container}_json.txt"
+        exit 1
+    fi
     echo "Proxy stress test PASSED — yaml + json"
 else
     echo "Proxy stress test PASSED — yaml only (json pass skipped for compat-matrix cell)"


### PR DESCRIPTION
## Describe the changes that are made

The `run_golang_docker / proxy-stress-test` lane reported success while **all four of its test sets FAILED** — 11 of 18 tests — and had been doing so since at least 17 Jul. From job [91143335341](https://github.com/keploy/keploy/actions/runs/30626434484/job/91143335341):

```
Total tests: 18   Total test passed: 7   Total test failed: 11
test-set-0-report.yaml: FAILED
test-set-1-report.yaml: FAILED
test-set-2-report.yaml: FAILED
test-set-3-report.yaml: FAILED
##[error]test-set-3-report.json (json) status=FAILED
##[error]test-set-1-report.json (json) status=FAILED
##[error]test-set-0-report.json (json) status=FAILED
##[error]test-set-2-report.json (json) status=FAILED
Proxy stress test PASSED — yaml + json
```

Four GitHub error annotations, then "PASSED", then a green job.

**The gate could not fail on a test failure.** It checked only for the run *not happening* — data race, panic, zero test cases, zero reports, error-channel overflow, PG decode failure — and nothing for whether the tests passed:

| | problem |
|---|---|
| report-status loop | only `echo`ed the status it read; never compared, never exited |
| `json_scan_reports \|\| true` | discarded the one check that *did* detect the failure — it returns non-zero and emits those `::error::` annotations |
| `\|& tee … \|\| true` (×2) | threw away keploy's exit code; without `pipefail`, `$?` would have been `tee`'s anyway |

Not a one-off: every sampled run since 17 Jul shows the same 4-sets-FAILED / green-job pair.

### What this changes

- Every test-set report must say `PASSED`, on **both** the yaml and json passes.
- The **number of reports must equal the number of recorded test-sets**, so a test-set whose replay died before writing one cannot hide behind the survivors. Checking only the reports that exist is precisely how the old yaml loop and `json_scan_reports` both miss that case.
- A glob matching nothing now fails instead of sailing through as "all passed".
- keploy's exit status is captured via `PIPESTATUS` and asserted **last**, after the per-report diagnostics print, so a failure *after* the final report is written (coverage, mock pruning, teardown) is still caught without losing the log.

The underlying test failures are fixed in keploy/samples-go#238 — the endpoints report wall-clock durations in their bodies, and the sample recorded against live `httpbin.org`. This lane now *requires* the sample's checked-in `keploy.yml` to carry the duration noise and fails loudly if it does not, rather than patching the config from CI where it would drift from the sample's own `./test.sh`.

## Links & References

**Closes:** NA

### 🔗 Related PRs
- keploy/samples-go#238 — fixes the actual test failures. **Land that first**, or this lane goes red (correctly).
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [x] 🔁 CI

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed

This *is* the e2e pipeline; the change is to make it capable of failing.

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

Each branch was verified by lifting the enforcement block out of the script and running it against fixtures built from the real failing run:

| scenario | old gate | new gate |
|---|---|---|
| 4 sets all FAILED (the actual 31 Jul run) | **exit 0** | exit 1 — `one or more yaml test sets did not pass` |
| 4 sets all PASSED (fixed state) | exit 0 | exit 0 |
| one PASSED, one FAILED | exit 0 | exit 1 |
| 4 recorded but only 3 reported (replay died) | exit 0 | exit 1 — `…they must match; a replay died before writing its report` |
| no reports at all | exit 0 | exit 1 |
| all PASSED but keploy exited non-zero | exit 0 | exit 1 — `every test set passed but keploy exited 1` |

End-to-end, with samples-go#238 applied, a full local record → replay cycle goes 5 passed / 0 failed with `test-set-0-report.yaml: PASSED`.

## Self Review done?
- [x] ✅ yes

Reviewed by an independent agent, which caught that the noise config belonged in the sample rather than in this script (the sample's own `./test.sh` already enforces report status, so patching only CI would have left `./test.sh` failing 3 of 5 and the two would drift), and that the json pass needed the same report-count denominator as the yaml pass. Both are addressed above.

## Any relevant screenshots, recordings or logs?

A broader sweep of every script under `test_workflow_scripts/` found this is not the only lane with a gate that cannot fail — 20 confirmed findings across 12 scripts, the worst being `golang/connect_tunnel/golang-linux.sh:365`, which greps for the literal `"test passed"`. keploy prints that string on every run (`Total test passed: 0`), so two of that lane's three matrix cells cannot fail either. Those are deliberately **not** in this PR; they need the same treatment lane by lane, each with its underlying failures fixed first.