### PR TITLE
fix(replay): gate the --keep-app-alive readiness skip on an observed accept

### DIFF
--- a/pkg/service/replay/app_ready_observed_test.go
+++ b/pkg/service/replay/app_ready_observed_test.go
@@ -1,0 +1,43 @@
+package replay
+
+import "testing"
+
+// --keep-app-alive skips the readiness wait for every test-set after the first,
+// reasoning that the app "already passed its readiness check during the first
+// test-set". The probe is best-effort — on timeout it warns and fires the tests
+// anyway — so that reasoning holds only when the check actually passed.
+//
+// Measured on a real cluster: replay pod created at T+0, readiness probe engaged
+// at T+4s, a later test-set logged "app already warm" at T+4.4s, and the app
+// first accepted a connection at ~T+30s. The run finished at T+20s having
+// refused every request. Ordinal position is not evidence of readiness; an
+// observed accept is.
+func TestAppReadyObservedGatesTheWarmSkip(t *testing.T) {
+	orig := appReadyObserved.Load()
+	t.Cleanup(func() { appReadyObserved.Store(orig) })
+
+	// The predicate the two call sites use, mirrored here so the intent is
+	// asserted independently of the surrounding replay plumbing.
+	warmSkip := func(serveTest, isFirstTestSet bool) bool {
+		return serveTest && !isFirstTestSet && appReadyObserved.Load()
+	}
+
+	appReadyObserved.Store(false)
+	if warmSkip(true, false) {
+		t.Fatal("must NOT skip the readiness wait before the app has ever been seen accepting a connection: that is exactly the run where every test gets connection refused")
+	}
+	if warmSkip(true, true) {
+		t.Fatal("the first test-set always waits")
+	}
+
+	appReadyObserved.Store(true)
+	if !warmSkip(true, false) {
+		t.Fatal("once the app has been observed ready, later test-sets should skip the wait — that is the whole point of --keep-app-alive")
+	}
+	if warmSkip(false, false) {
+		t.Fatal("without the one-shot spawn (serveTest=false) the wait must run every test-set, matching the historical lifecycle")
+	}
+	if warmSkip(true, true) {
+		t.Fatal("the first test-set waits even when a previous run observed readiness")
+	}
+}

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1349,7 +1349,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		// one-shot spawn was suppressed (cmdType == Empty / instrument
 		// off), serveTest will be false here and the readiness wait
 		// runs every test-set, matching the historical lifecycle.
-		if serveTest && !r.isFirstTestSet {
+		if serveTest && !r.isFirstTestSet && appReadyObserved.Load() {
 			r.logger.Debug("--keep-app-alive: skipping waitForAppReady on post-first test-set; app already warm")
 		} else if !waitForAppReady(runTestSetCtx, r.logger, r.config) {
 			return models.TestSetStatusUserAbort, context.Canceled
@@ -1512,7 +1512,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			// effectiveKeepAlive predicate) — identical to the compose
 			// branch above — so the readiness skip arms only when the
 			// one-shot spawn actually fired.
-			if serveTest && !r.isFirstTestSet {
+			if serveTest && !r.isFirstTestSet && appReadyObserved.Load() {
 				r.logger.Debug("--keep-app-alive: skipping waitForAppReady on post-first test-set; app already warm")
 			} else if !waitForAppReady(runTestSetCtx, r.logger, r.config) {
 				return models.TestSetStatusUserAbort, context.Canceled

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/olekukonko/tablewriter"
@@ -299,6 +300,24 @@ func waitForHTTPServing(ctx context.Context, scheme, host, port string) error {
 	}
 }
 
+// appReadyObserved records whether the app under replay has EVER been seen
+// accepting a connection on cfg.Test.AppReadyProbeAddr in this process.
+//
+// It exists because --keep-app-alive skips the readiness wait for every
+// test-set after the first, on the stated reasoning that the app "already
+// passed its readiness check during the first test-set". That reasoning is only
+// sound if the check actually passed. The probe is best-effort — on timeout it
+// warns and fires the tests anyway — so an app that never came up produces a
+// first test-set that "completed" the wait, and every later test-set then skips
+// waiting for an app that has never been listening.
+//
+// Measured on a real cluster: a replay pod created at T+0 had its readiness
+// probe engage at T+4s and a later test-set log "app already warm" at T+4.4s;
+// the app first accepted connections at ~T+30s. The whole run finished at T+20s
+// having refused every request. Gating the skip on an OBSERVED accept makes the
+// optimisation apply only when it is true.
+var appReadyObserved atomic.Bool
+
 func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config) bool {
 	delay := time.Duration(cfg.Test.Delay) * time.Second
 
@@ -404,6 +423,12 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 						zap.String("addr", addr),
 						zap.Duration("ceiling", ceiling),
 						zap.Error(err))
+				} else {
+					// The app accepted a connection at least once. Only this
+					// observation makes it safe for a later test-set to skip the
+					// wait under --keep-app-alive; "not the first test-set" does
+					// not, because the app may never have come up at all.
+					appReadyObserved.Store(true)
 				}
 			}
 		}


### PR DESCRIPTION
## `--keep-app-alive` can skip the readiness wait for an app that was never ready

`waitForAppReady` is skipped whenever `serveTest && !isFirstTestSet`, on the reasoning quoted in the code — the app *"has already passed its readiness check during the first test-set"*.

That reasoning has two independent holes, and I hit both on a live cluster.

**1. "Passed" isn't checked.** The readiness probe is best-effort by contract: when the app fails to accept within `HealthPollTimeout` it logs

```
app ready-probe address did not accept a connection within the ceiling;
firing tests anyway (replay may see connection refused)
```

and **returns true anyway**, deliberately, so replay never regresses versus plain `--delay`. So a first test-set can "complete" its wait against an app that never came up.

**2. The wait can be skipped before any wait has happened.** Measured on a real Kubernetes auto-replay, with `delay: 75` explicitly configured:

```
10:02:42.336  replay pod created
10:02:46.836  --keep-app-alive: skipping waitForAppReady; app already warm
10:02:46.854  starting test for ...
```

First test fired **4.5s** after pod creation — not 75s, not even the 10s default. A skip log lands 18ms before it. The app on that image first accepts at ~30s. Every request was refused; every test came back red, attributed to the application rather than to it still booting.

So the delay knob is not the lever people assume: while the skip arms, no configured delay applies at all.

## Fix

Record whether the probe has ever observed the app accept a connection, and require that observation before taking the skip:

```go
if serveTest && !r.isFirstTestSet && appReadyObserved.Load() {
```

Ordinal position is not evidence of readiness; an observed accept is. This is deliberately the weakest condition that closes both holes — it does not change the probe's warn-don't-fail contract, and it does not depend on which test-set happens to be processed first.

## Unchanged

- the first test-set still waits;
- the skip still arms only when the one-shot spawn actually fired (`serveTest`), so a `cmdType` where the spawn was suppressed still waits every test-set;
- the probe still warns rather than fails on timeout — nothing that previously succeeded now blocks.

Only the previously-wrong case changes: the wait is no longer skipped when the app has never been seen accepting.

## Testing

`TestAppReadyObservedGatesTheWarmSkip` covers the four combinations (never-observed / observed × first / later test-set). `go test -race ./pkg/service/replay/...` green.

Honest limitation: the test asserts the predicate, mirroring the two call sites, so it would not catch someone deleting a call site outright — the same gap the existing `serveTest` / `isFirstTestSet` logic already has.

## Note on what this does not fix

On the cluster where this was measured, a second, unrelated defect records some test cases with an ephemeral `app_port`, so they dial a port nothing listens on. That is a separate issue in a different component; this PR only removes the "tests fire at an app that was never up" failure mode.
