### PR TITLE
fix(replay): abort on container failure, not exit, when a one-shot init is present

### DIFF
--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -278,13 +278,49 @@ func (a *App) setupComposeInMemory(extraArgs []string) error {
 	a.composeContent = content
 
 	// Ensure the command uses stdin ("-f -") and has the exit-code-from flags.
-	preferFailureAbort := strings.Contains(string(a.composeContent), "service_completed_successfully")
+	preferFailureAbort := composeHasCompletionDependency(&compose)
 	a.cmd = ensureInMemoryComposeFlags(a.cmd, a.composeService, preferFailureAbort)
 
 	a.logger.Info("Running application using in-memory Keploy-generated Docker Compose (no file written to disk)",
 		zap.String("cmd", a.cmd))
 
 	return nil
+}
+
+func composeHasCompletionDependency(compose *docker.Compose) bool {
+	if compose == nil || compose.Services.Content == nil {
+		return false
+	}
+	for i := 0; i+1 < len(compose.Services.Content); i += 2 {
+		service := compose.Services.Content[i+1]
+		if service == nil {
+			continue
+		}
+		for j := 0; j+1 < len(service.Content); j += 2 {
+			if service.Content[j].Value == "depends_on" && dependsOnRequiresCompletion(service.Content[j+1]) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func dependsOnRequiresCompletion(dependsOn *yaml.Node) bool {
+	if dependsOn == nil || dependsOn.Kind != yaml.MappingNode {
+		return false
+	}
+	for i := 0; i+1 < len(dependsOn.Content); i += 2 {
+		dep := dependsOn.Content[i+1]
+		if dep == nil || dep.Kind != yaml.MappingNode {
+			continue
+		}
+		for j := 0; j+1 < len(dep.Content); j += 2 {
+			if dep.Content[j].Value == "condition" && dep.Content[j+1].Value == "service_completed_successfully" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (a *App) SetAppCommand(appCommand string) {

--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -278,7 +278,8 @@ func (a *App) setupComposeInMemory(extraArgs []string) error {
 	a.composeContent = content
 
 	// Ensure the command uses stdin ("-f -") and has the exit-code-from flags.
-	a.cmd = ensureInMemoryComposeFlags(a.cmd, a.composeService)
+	preferFailureAbort := strings.Contains(string(a.composeContent), "service_completed_successfully")
+	a.cmd = ensureInMemoryComposeFlags(a.cmd, a.composeService, preferFailureAbort)
 
 	a.logger.Info("Running application using in-memory Keploy-generated Docker Compose (no file written to disk)",
 		zap.String("cmd", a.cmd))

--- a/pkg/client/app/util.go
+++ b/pkg/client/app/util.go
@@ -26,7 +26,7 @@ var composeSubcommands = map[string]bool{
 // It tokenizes the arguments, strips all -f/--file flags (including dangling
 // ones without a value), and injects a single "-f -" before the first compose
 // subcommand to avoid producing multiple stdin readers.
-func ensureInMemoryComposeFlags(appCmd, serviceName string) string {
+func ensureInMemoryComposeFlags(appCmd, serviceName string, preferFailureAbort bool) string {
 	parts := strings.Fields(appCmd)
 
 	// Strip every existing -f/--file flag and its value, including dangling
@@ -62,7 +62,7 @@ func ensureInMemoryComposeFlags(appCmd, serviceName string) string {
 		result = append(result, "-f", "-")
 	}
 
-	return ensureComposeExitOnAppFailure(strings.Join(result, " "), serviceName)
+	return ensureComposeExitOnAppFailure(strings.Join(result, " "), serviceName, preferFailureAbort)
 }
 
 func findComposeFile(cmd string) []string {
@@ -124,24 +124,24 @@ func modifyDockerComposeCommand(appCmd, newComposeFile, appComposePath, appServi
 				// Check if this file matches the appComposePath
 				if actualFile == appComposePath {
 					modifiedCmd = strings.Replace(appCmd, fullMatch, fmt.Sprintf("-f %s", newComposeFile), 1)
-					return ensureComposeExitOnAppFailure(modifiedCmd, appServiceName)
+					return ensureComposeExitOnAppFailure(modifiedCmd, appServiceName, false)
 				}
 			}
 		}
 		// If no matching compose path found, return original command
 		modifiedCmd = appCmd
-		return ensureComposeExitOnAppFailure(modifiedCmd, appServiceName)
+		return ensureComposeExitOnAppFailure(modifiedCmd, appServiceName, false)
 	}
 
 	// If the pattern doesn't exist, inject the new Compose file right after "docker-compose" or "docker compose"
 	upIdx := strings.Index(appCmd, " up")
 	if upIdx != -1 {
 		modifiedCmd = fmt.Sprintf("%s -f %s%s", appCmd[:upIdx], newComposeFile, appCmd[upIdx:])
-		return ensureComposeExitOnAppFailure(modifiedCmd, appServiceName)
+		return ensureComposeExitOnAppFailure(modifiedCmd, appServiceName, false)
 	}
 
 	modifiedCmd = fmt.Sprintf("%s -f %s", appCmd, newComposeFile)
-	return ensureComposeExitOnAppFailure(modifiedCmd, appServiceName)
+	return ensureComposeExitOnAppFailure(modifiedCmd, appServiceName, false)
 }
 
 func isDetachMode(logger *zap.Logger, command string, kind utils.CmdType) bool {
@@ -178,16 +178,21 @@ func isDetachMode(logger *zap.Logger, command string, kind utils.CmdType) bool {
 //   - serviceName: the name of the service whose exit code should be monitored (empty string skips --exit-code-from)
 //
 // Returns: the modified command with the necessary flags added
-func ensureComposeExitOnAppFailure(appCmd, serviceName string) string {
+func ensureComposeExitOnAppFailure(appCmd, serviceName string, preferFailureAbort bool) string {
 	// If the user already passed one of these flags, don't touch the command.
-	if strings.Contains(appCmd, "--abort-on-container-exit") || strings.Contains(appCmd, "--exit-code-from") {
+	if strings.Contains(appCmd, "--abort-on-container-exit") || strings.Contains(appCmd, "--abort-on-container-failure") || strings.Contains(appCmd, "--exit-code-from") {
 		return appCmd
 	}
 
 	// Arguments we want to inject.
-	args := []string{"--abort-on-container-exit"}
-	if serviceName != "" {
-		args = append(args, "--exit-code-from", serviceName)
+	var args []string
+	if preferFailureAbort {
+		args = []string{"--abort-on-container-failure"}
+	} else {
+		args = []string{"--abort-on-container-exit"}
+		if serviceName != "" {
+			args = append(args, "--exit-code-from", serviceName)
+		}
 	}
 
 	parts := strings.Fields(appCmd)


### PR DESCRIPTION
## Problem

Cloud replay renders a recorded pod's **init containers** as one-shot compose services (`restart: "no"`, the app `depends_on` them with `condition: service_completed_successfully`). Keploy runs the compose with:

```
docker compose -f - up --abort-on-container-exit --exit-code-from <app>
```

`--abort-on-container-exit` stops the whole stack the instant **any** container exits — including a one-shot init exiting **0**, which it *must* do for the app to start. Result: the app is torn down before it ever runs.

```
prepare-mongo-tls  exited with code 0        <-- init did its job (as designed)
Compose  Aborting on container exit...        <-- flag fires on that success
api-server  Stopping / Stopped                <-- app killed before it runs
→ "user application failed under --keep-app-alive: exit status 1"  (no report)
```

The flag has been correct for its intent (catch the **app** crashing) since #3256, but it's a blunt "any container" instrument. It became fatal once init containers started being rendered as one-shot compose services, because a one-shot init's success is indistinguishable from an app crash under `--abort-on-container-exit`.

## Fix

When the in-memory compose contains a one-shot init (detected by `service_completed_successfully` in the compose content), inject **`--abort-on-container-failure`** instead of `--abort-on-container-exit --exit-code-from <app>`.

- `--abort-on-container-failure` aborts only on a **non-zero** exit → the init's clean exit-0 is ignored, while a real app crash is still caught.
- `--exit-code-from` is dropped because it *implies* `--abort-on-container-exit`. There is **no** container-state polling on the compose path (`waitTillExit()` is skipped for `DockerCompose`), so after this change `--abort-on-container-failure` is the **only** signal that catches an app crash: it makes `docker compose up` itself exit non-zero, surfaced through `cmdErr` from `utils.ExecuteCommand`. Note that compose now returns its **own** exit status rather than the app's (via the old `--exit-code-from <app>`) — equivalent for pass/fail, but the specific code changes meaning.
- Only the **in-memory** compose path (`setupComposeInMemory` → `ensureInMemoryComposeFlags`) is switched. The user-provided-compose-file path (`modifyDockerComposeCommand`) passes `false`, so its behavior is unchanged.

~18 lines across `pkg/client/app/{app.go,util.go}`.

## Why this and not the alternatives

- **Two-phase (pre-run the init, then `up`)** was tested and *fails*: even with `--no-recreate`, compose re-runs the one-shot init as a dependency, it exits 0 again, and `--abort-on-container-exit` aborts anyway.
- **Detached + monitor** would work but keploy deliberately forbids detached mode (`isDetachMode`), so it's a larger lifecycle refactor.
- `--abort-on-container-failure` keeps the flag's original purpose (catch app crashes) while removing the only false positive (a one-shot init's success), with zero change to non-init flows.

## Verification

Reproduced against a real deployment whose recorded manifest carries a `prepare-mongo-tls` init, running the exact cloud-replay command with the stock vs. patched binary:

| | Stock | Patched |
|---|---|---|
| Injected cmd | `up --abort-on-container-exit --exit-code-from …` | `up --abort-on-container-failure` |
| `Aborting on container exit` | fires on init exit-0 | never |
| App | torn down, never ran | agent healthy, app booted, ran |
| Replay | catastrophic, no report | ran to a full report |
