### PR TITLE
fix(agent): exit non-zero when the agent fails to start, and name the cause

### DIFF
--- a/cli/agent.go
+++ b/cli/agent.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/spf13/cobra"
@@ -21,6 +22,12 @@ func Agent(ctx context.Context, logger *zap.Logger, conf *config.Config, service
 		Use:   "agent",
 		Short: "starts keploy agent for hooking and starting proxy",
 		// Hidden: true,
+		// Runtime failures below are reported by their own log line and by the
+		// process exit status; without this, cobra would dump the whole usage
+		// text after every one of them and bury the actual error. Bad flags
+		// still print their own message via SetFlagErrorFunc (the error, not
+		// the usage listing).
+		SilenceUsage: true,
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return cmdConfigurator.Validate(ctx, cmd)
 		},
@@ -28,14 +35,15 @@ func Agent(ctx context.Context, logger *zap.Logger, conf *config.Config, service
 			svc, err := serviceFactory.GetService(ctx, cmd.Name())
 			if err != nil {
 				utils.LogError(logger, err, "failed to get service")
-				return nil
+				return err
 			}
 
 			var a agent.Service
 			var ok bool
 			if a, ok = svc.(agent.Service); !ok {
-				utils.LogError(logger, nil, "service doesn't satisfy agent service interface")
-				return nil
+				err = errors.New("service doesn't satisfy agent service interface")
+				utils.LogError(logger, err, "failed to start agent")
+				return err
 			}
 
 			// Self-terminate (gracefully) if the parent keploy client dies
@@ -85,7 +93,21 @@ func Agent(ctx context.Context, logger *zap.Logger, conf *config.Config, service
 			err = a.Setup(ctx, startAgentCh)
 			if err != nil {
 				utils.LogError(logger, err, "failed to setup agent")
-				return nil
+				// A cancelled context is how the agent is asked to stop
+				// (SIGINT/SIGTERM, parent exit) — that is a normal shutdown,
+				// not a failure, and must keep exiting 0. Anything else means
+				// the agent never came up: it must exit non-zero so kubelet,
+				// docker and CI see a failure instead of "Completed".
+				//
+				// Check the CONTEXT as well as the error: a shutdown that
+				// races agent startup surfaces as whatever error the
+				// interrupted step happened to produce, which need not carry
+				// context.Canceled. We own this context, so its state is the
+				// authoritative answer to "was this a shutdown?".
+				if errors.Is(err, context.Canceled) || ctx.Err() != nil {
+					return nil
+				}
+				return err
 			}
 
 			return nil

--- a/cli/agent_test.go
+++ b/cli/agent_test.go
@@ -1,0 +1,147 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"go.keploy.io/server/v3/config"
+	"go.keploy.io/server/v3/pkg/service/agent"
+	"go.uber.org/zap"
+)
+
+// stubAgent satisfies agent.Service by embedding it: only Setup is ever called
+// on this path, so the remaining methods stay nil and would panic loudly if the
+// command ever started using them.
+type stubAgent struct {
+	agent.Service
+	setupErr error
+}
+
+func (s stubAgent) Setup(context.Context, chan int) error { return s.setupErr }
+
+type stubFactory struct {
+	svc interface{}
+	err error
+}
+
+func (f stubFactory) GetService(context.Context, string) (interface{}, error) {
+	return f.svc, f.err
+}
+
+// stubConfigurator registers only the flags Agent's RunE reads back.
+type stubConfigurator struct{}
+
+func (stubConfigurator) AddFlags(cmd *cobra.Command) error {
+	cmd.Flags().Uint32("client-pid", 0, "")
+	// Kept true by the tests so the parent-death watchdog stays disabled;
+	// it watches a real PID and has no place in a unit test.
+	cmd.Flags().Bool("is-docker", true, "")
+	return nil
+}
+func (stubConfigurator) ValidateFlags(context.Context, *cobra.Command) error { return nil }
+func (stubConfigurator) Validate(context.Context, *cobra.Command) error      { return nil }
+
+func runAgent(t *testing.T, f ServiceFactory) error {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd := Agent(ctx, zap.NewNop(), &config.Config{}, f, stubConfigurator{})
+	if cmd == nil {
+		t.Fatal("Agent returned a nil command")
+	}
+	cmd.SetArgs([]string{"--is-docker=true"})
+	cmd.SetOut(nopWriter{})
+	cmd.SetErr(nopWriter{})
+	return cmd.Execute()
+}
+
+type nopWriter struct{}
+
+func (nopWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// An agent that cannot set up must report a FAILURE to its caller. Returning
+// nil here makes keploy exit 0, so kubelet records a dead agent as
+// "Reason: Completed, Exit Code: 0" and every orchestrator above it reads a
+// hard failure as a clean shutdown.
+func TestAgent_SetupFailurePropagates(t *testing.T) {
+	want := errors.New("failed to hook into the app")
+
+	err := runAgent(t, stubFactory{svc: stubAgent{setupErr: want}})
+
+	if !errors.Is(err, want) {
+		t.Fatalf("setup failure did not propagate: got %v, want %v", err, want)
+	}
+}
+
+// A cancelled context is how the agent is asked to STOP (SIGINT/SIGTERM,
+// parent exit). That is a normal shutdown and must keep exiting 0, or every
+// clean stop would be reported as a crash.
+func TestAgent_GracefulCancellationIsNotAFailure(t *testing.T) {
+	err := runAgent(t, stubFactory{svc: stubAgent{setupErr: context.Canceled}})
+
+	if err != nil {
+		t.Fatalf("graceful cancellation reported as failure: %v", err)
+	}
+}
+
+// Wrapped cancellations count as graceful too — Setup returns the context
+// error through layers of its own wrapping.
+func TestAgent_WrappedCancellationIsNotAFailure(t *testing.T) {
+	err := runAgent(t, stubFactory{svc: stubAgent{
+		setupErr: errors.Join(errors.New("shutting down proxy"), context.Canceled),
+	}})
+
+	if err != nil {
+		t.Fatalf("wrapped cancellation reported as failure: %v", err)
+	}
+}
+
+func TestAgent_ServiceLookupFailurePropagates(t *testing.T) {
+	want := errors.New("no service")
+
+	err := runAgent(t, stubFactory{err: want})
+
+	if !errors.Is(err, want) {
+		t.Fatalf("service lookup failure did not propagate: got %v, want %v", err, want)
+	}
+}
+
+// A service that does not implement agent.Service is a wiring bug; it must not
+// exit 0 either.
+func TestAgent_WrongServiceTypePropagates(t *testing.T) {
+	err := runAgent(t, stubFactory{svc: struct{}{}})
+
+	if err == nil {
+		t.Fatal("wrong service type reported success")
+	}
+}
+
+// A successful setup must stay quiet.
+func TestAgent_SuccessReturnsNil(t *testing.T) {
+	if err := runAgent(t, stubFactory{svc: stubAgent{}}); err != nil {
+		t.Fatalf("successful setup returned %v", err)
+	}
+}
+
+// The real shutdown shape: agent.Hook wraps whatever error the interrupted
+// step produced, so a stop that races startup need NOT carry context.Canceled.
+// The command owns the context, so its state is the authoritative answer to
+// "was this a shutdown?" — without that check a deleted pod would report a
+// crash and get restarted.
+func TestAgent_CancelledContextIsNotAFailureEvenWithAnUnrelatedError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // shutdown already requested before Setup returns
+
+	cmd := Agent(ctx, zap.NewNop(), &config.Config{},
+		stubFactory{svc: stubAgent{setupErr: errors.New("failed to hook into the app")}},
+		stubConfigurator{})
+	cmd.SetArgs([]string{"--is-docker=true"})
+	cmd.SetOut(nopWriter{})
+	cmd.SetErr(nopWriter{})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("shutdown during startup reported as failure: %v", err)
+	}
+}

--- a/cli/config.go
+++ b/cli/config.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"io"
 	"path/filepath"
 
 	"go.keploy.io/server/v3/config"
@@ -32,12 +33,29 @@ func Config(ctx context.Context, logger *zap.Logger, cfg *config.Config, service
 				utils.LogError(logger, err, "failed to get generate flag")
 				return err
 			}
+			force, err := cmd.Flags().GetBool("force")
+			if err != nil {
+				utils.LogError(logger, err, "failed to get force flag")
+				return err
+			}
 
 			if isGenerate {
 				filePath := filepath.Join(cfg.Path, "keploy.yml")
-				if !cfg.InCi && utils.CheckFileExists(filePath) {
+				if !force && !cfg.InCi && utils.CheckFileExists(filePath) {
 					override, err := utils.AskForConfirmation(ctx, "Config file already exists. Do you want to override it?")
 					if err != nil {
+						// EOF means nothing answered the prompt — no terminal and
+						// nothing piped in. That is every scripted invocation: CI,
+						// Makefile, `docker run` without -i, systemd, cron. Failing
+						// there blames the caller for something they cannot fix, and
+						// overwriting unasked would silently discard a hand-edited
+						// config. Keep the file, say so, and point at --force.
+						if errors.Is(err, io.EOF) {
+							logger.Warn("config file already exists and nothing answered the override prompt, so it was left untouched",
+								zap.String("path", filePath),
+								zap.String("hint", "re-run with --force to overwrite it non-interactively"))
+							return nil
+						}
 						utils.LogError(logger, err, "failed to ask for confirmation")
 						return err
 					}
@@ -54,7 +72,8 @@ func Config(ctx context.Context, logger *zap.Logger, cfg *config.Config, service
 				var tools toolsSvc.Service
 				var ok bool
 				if tools, ok = svc.(toolsSvc.Service); !ok {
-					utils.LogError(logger, nil, "service doesn't satisfy tools service interface")
+					err = errors.New("service doesn't satisfy tools service interface")
+					utils.LogError(logger, err, "failed to generate config")
 					return err
 				}
 				if err := tools.CreateConfig(ctx, filePath, ""); err != nil {

--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -1,0 +1,161 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"go.keploy.io/server/v3/config"
+	"go.uber.org/zap"
+)
+
+// configConfigurator registers only the flags Config's RunE reads back.
+type configConfigurator struct{}
+
+func (configConfigurator) AddFlags(cmd *cobra.Command) error {
+	cmd.Flags().Bool("generate", false, "")
+	cmd.Flags().Bool("force", false, "")
+	return nil
+}
+func (configConfigurator) ValidateFlags(context.Context, *cobra.Command) error { return nil }
+func (configConfigurator) Validate(context.Context, *cobra.Command) error      { return nil }
+
+// countingFactory records whether the command got as far as building a service,
+// i.e. whether it decided to go ahead and write the config.
+type countingFactory struct{ called int }
+
+func (f *countingFactory) GetService(context.Context, string) (interface{}, error) {
+	f.called++
+	// Returning a non-Service value stops the command right here. The tests below
+	// only care WHETHER we got this far — i.e. whether the command decided to go
+	// ahead and write the config — so they assert on `called`, not on the error
+	// the type assertion then (correctly) produces.
+	return struct{}{}, nil
+}
+
+// withStdin points os.Stdin at a file holding the given content ("" == immediate
+// EOF, which is what a CI runner, `docker run` without -i, systemd and cron all
+// deliver).
+func withStdin(t *testing.T, content string) {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "stdin")
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatalf("write stdin file: %v", err)
+	}
+	f, err := os.Open(p)
+	if err != nil {
+		t.Fatalf("open stdin file: %v", err)
+	}
+	old := os.Stdin
+	os.Stdin = f
+	t.Cleanup(func() { os.Stdin = old; _ = f.Close() })
+}
+
+func runConfig(t *testing.T, dir string, f *countingFactory, args ...string) error {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd := Config(ctx, zap.NewNop(), &config.Config{Path: dir}, f, configConfigurator{})
+	if cmd == nil {
+		t.Fatal("Config returned a nil command")
+	}
+	cmd.SetArgs(args)
+	cmd.SetOut(nopWriter{})
+	cmd.SetErr(nopWriter{})
+	return cmd.Execute()
+}
+
+func seedConfig(t *testing.T) (dir, path, content string) {
+	t.Helper()
+	dir = t.TempDir()
+	path = filepath.Join(dir, "keploy.yml")
+	content = "version: original\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	return dir, path, content
+}
+
+// Nothing answers the prompt when stdin is at EOF — no terminal, nothing piped.
+// That is every scripted invocation (CI, Makefile, `docker run` without -i,
+// systemd, cron). It used to surface as a confirmation ERROR, so the command
+// failed for a reason the caller could not fix. Keep the config and succeed.
+func TestConfig_GenerateWithExistingFileAndNoAnswer_KeepsConfigAndSucceeds(t *testing.T) {
+	dir, path, original := seedConfig(t)
+	withStdin(t, "")
+	f := &countingFactory{}
+
+	if err := runConfig(t, dir, f, "--generate"); err != nil {
+		t.Fatalf("non-interactive config --generate failed: %v", err)
+	}
+	if f.called != 0 {
+		t.Error("proceeded to overwrite an existing config without any confirmation")
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back config: %v", err)
+	}
+	if string(got) != original {
+		t.Errorf("existing config was modified without confirmation: %q", string(got))
+	}
+}
+
+// --force is the sanctioned non-interactive override: without it there is no way
+// to regenerate an existing config from a script.
+func TestConfig_ForceOverwritesWithoutAsking(t *testing.T) {
+	dir, _, _ := seedConfig(t)
+	withStdin(t, "")
+	f := &countingFactory{}
+
+	_ = runConfig(t, dir, f, "--generate", "--force") // stub service errors after this point
+	if f.called != 1 {
+		t.Errorf("--force did not proceed to regenerate the config (factory calls = %d)", f.called)
+	}
+}
+
+// A piped answer must still work — `echo y | keploy config --generate` is the
+// standard scripted way to answer a prompt, and keying on EOF (rather than on
+// "is stdin a terminal") is what preserves it.
+func TestConfig_PipedYesStillOverwrites(t *testing.T) {
+	dir, _, _ := seedConfig(t)
+	withStdin(t, "y\n")
+	f := &countingFactory{}
+
+	_ = runConfig(t, dir, f, "--generate") // stub service errors after this point
+	if f.called != 1 {
+		t.Errorf("piped 'y' did not overwrite (factory calls = %d)", f.called)
+	}
+}
+
+// A piped "n" must be honoured, and must not be confused with "could not ask".
+func TestConfig_PipedNoKeepsConfig(t *testing.T) {
+	dir, path, original := seedConfig(t)
+	withStdin(t, "n\n")
+	f := &countingFactory{}
+
+	if err := runConfig(t, dir, f, "--generate"); err != nil {
+		t.Fatalf("piped-no run failed: %v", err)
+	}
+	if f.called != 0 {
+		t.Error("piped 'n' still overwrote the config")
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != original {
+		t.Errorf("config modified after declining: %q", string(got))
+	}
+}
+
+// With no config present there is nothing to confirm, so generation proceeds
+// even at EOF.
+func TestConfig_NoExistingFileGeneratesAtEOF(t *testing.T) {
+	dir := t.TempDir()
+	withStdin(t, "")
+	f := &countingFactory{}
+
+	_ = runConfig(t, dir, f, "--generate") // stub service errors after this point
+	if f.called != 1 {
+		t.Errorf("did not generate when no config existed (factory calls = %d)", f.called)
+	}
+}

--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -201,6 +201,7 @@ func (c *CmdConfigurator) AddFlags(cmd *cobra.Command) error {
 	case "config":
 		cmd.Flags().StringP("path", "p", ".", "Path to local directory where generated config is stored")
 		cmd.Flags().Bool("generate", false, "Generate a new keploy configuration file")
+		cmd.Flags().Bool("force", false, "Overwrite an existing configuration file without asking (for non-interactive use)")
 	case "templatize":
 		cmd.Flags().StringP("path", "p", ".", "Path to local directory where generated testcases/mocks are stored")
 		cmd.Flags().StringSliceP("testsets", "t", c.cfg.Templatize.TestSets, "Testsets to run e.g. --testsets \"test-set-1, test-set-2\"")

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 	setVersion()
 	ctx := utils.NewCtx()
 	start(ctx)
-	os.Exit(utils.ErrCode)
+	os.Exit(utils.ErrCode())
 }
 
 func setVersion() {
@@ -233,10 +233,19 @@ func start(ctx context.Context) {
 	cmdConfigurator := provider.NewCmdConfigurator(logger, conf)
 	rootCmd := cli.Root(ctx, logger, svcProvider, cmdConfigurator)
 	if err := rootCmd.Execute(); err != nil {
+		// A failed command must exit non-zero. Without this the error is
+		// logged and then discarded, and keploy exits 0 — so an agent that
+		// never loaded its hooks is reported to kubelet as
+		// "Reason: Completed, Exit Code: 0", and every orchestrator above it
+		// (Kubernetes, docker, CI) reads a hard failure as a clean shutdown.
+		utils.SetErrCode(1)
 		if strings.HasPrefix(err.Error(), "unknown command") || strings.HasPrefix(err.Error(), "unknown shorthand") {
 			fmt.Println("Error: ", err.Error())
 			fmt.Println("Run 'keploy --help' for usage.")
-			os.Exit(1)
+			// No os.Exit here: the exit status is already 1 (above), and
+			// exiting inline would skip every deferred cleanup in start() —
+			// the debug-file flush, the profile writers, the log-file close
+			// and the umask restore.
 		}
 	}
 

--- a/pkg/agent/hooks/linux/hooks.go
+++ b/pkg/agent/hooks/linux/hooks.go
@@ -159,6 +159,14 @@ func (h *Hooks) load(ctx context.Context, opts agent.HookCfg, setupOpts config.A
 		} else {
 			fmt.Printf("SYSCALL FAILURE: %v\n", err)
 		}
+		// Loading the programs is where an agent with NO eBPF capabilities at
+		// all fails — earlier than any attach, and far more common than the
+		// tracepoint case below. Give it the same actionable diagnosis instead
+		// of a bare errno.
+		if hint := PerfEventPermissionHint(err); hint != "" {
+			utils.LogError(h.logger, err, "failed to load eBPF programs", zap.String("hint", hint))
+			return fmt.Errorf("%w: %s", err, hint)
+		}
 		return err
 	}
 	//getting all the ebpf maps with proper synchronization
@@ -185,6 +193,13 @@ func (h *Hooks) load(ctx context.Context, opts agent.HookCfg, setupOpts config.A
 	} else {
 		socket, err := link.Tracepoint("syscalls", "sys_enter_socket", objs.SyscallProbeEntrySocket, nil)
 		if err != nil {
+			// A bare "permission denied" here is close to undiagnosable from
+			// the outside — most often it is the node's perf_event_paranoid
+			// sysctl, not anything about this install. Say which.
+			if hint := PerfEventPermissionHint(err); hint != "" {
+				utils.LogError(h.logger, err, "failed to attach the tracepoint hook on sys_socket", zap.String("hint", hint))
+				return fmt.Errorf("%w: %s", err, hint)
+			}
 			utils.LogError(h.logger, err, "failed to attach the tracepoint hook on sys_socket")
 			return err
 		}

--- a/pkg/agent/hooks/linux/perm_hint.go
+++ b/pkg/agent/hooks/linux/perm_hint.go
@@ -1,0 +1,89 @@
+//go:build linux
+
+package linux
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/cilium/ebpf"
+)
+
+// perfEventParanoidPath is the sysctl that governs who may call
+// perf_event_open. Overridable so the hint can be unit-tested.
+var perfEventParanoidPath = "/proc/sys/kernel/perf_event_paranoid"
+
+// PerfEventPermissionHint explains a permission failure from an eBPF attach,
+// or returns "" when err is not a permission error.
+//
+// Attaching a tracepoint/kprobe/uprobe goes through perf_event_open, which the
+// kernel gates on kernel.perf_event_paranoid. Debian/Ubuntu kernels carry an
+// out-of-tree LEVEL 3 (mainline only defines 0..2) whose check is
+// `perf_paranoid_any() && !capable(CAP_SYS_ADMIN)` — so CAP_PERFMON does NOT
+// satisfy it. An agent running with the usual eBPF capability set
+// (CAP_BPF + CAP_PERFMON, no CAP_SYS_ADMIN) therefore fails with a bare
+// "permission denied" on those distros, however new the kernel is.
+//
+// That is genuinely hard to diagnose from the outside: the same binary, image
+// and kernel work on a node with paranoid <= 2 and fail on one with 3, and the
+// syscall error says nothing about the sysctl. Naming the sysctl, its value and
+// the capability turns it into a one-line fix.
+//
+// The paranoid level is NOT namespaced: a container inherits its node's value,
+// so reading it from inside the agent reports the node's setting.
+//
+// Exported so the enterprise attach sites (kretprobes/uprobes, which use the
+// same syscall) can report the same diagnosis.
+func PerfEventPermissionHint(err error) string {
+	if err == nil || !errors.Is(err, os.ErrPermission) {
+		return ""
+	}
+	// A rejected eBPF program is NOT a permission problem, but it looks like
+	// one: the kernel answers BPF_PROG_LOAD with EACCES when the verifier
+	// rejects the program, and VerifierError.Unwrap() exposes that errno — so
+	// errors.Is(_, os.ErrPermission) is true for every verifier failure. Left
+	// unchecked this tells an operator staring at a verifier log to grant
+	// CAP_SYS_ADMIN and change a node sysctl, neither of which can help.
+	var ve *ebpf.VerifierError
+	if errors.As(err, &ve) {
+		return ""
+	}
+	// Not every permission error on this path is the perf_event_open gate:
+	// attaching a tracepoint first READS the event id out of tracefs, and an
+	// EACCES there arrives as an *os.PathError. Blaming the sysctl for that
+	// would send the reader down entirely the wrong path, so answer the
+	// question actually asked.
+	var pathErr *os.PathError
+	if errors.As(err, &pathErr) {
+		// Only prescribe a debugfs mount when the unreadable path actually IS
+		// tracefs. Uprobe attaches open the TARGET BINARY through this same
+		// helper, and telling an operator to mount /sys/kernel/debug when the
+		// agent simply cannot read /app/bin/server is a wrong answer stated
+		// confidently.
+		if strings.HasPrefix(pathErr.Path, "/sys/kernel/debug") || strings.HasPrefix(pathErr.Path, "/sys/kernel/tracing") {
+			return fmt.Sprintf("cannot read %s — the agent needs tracefs/debugfs access; "+
+				"mount /sys/kernel/debug (and /sys/kernel/tracing) into the agent container", pathErr.Path)
+		}
+		return fmt.Sprintf("cannot read %s — the agent needs read access to that path", pathErr.Path)
+	}
+	level, readErr := perfEventParanoidLevel()
+	if readErr == nil && level > 2 {
+		return fmt.Sprintf("kernel.perf_event_paranoid is %d on this node, which denies perf_event_open to any process without CAP_SYS_ADMIN "+
+			"(CAP_PERFMON is NOT sufficient at this level) — grant the keploy agent CAP_SYS_ADMIN, or set kernel.perf_event_paranoid<=2 on the node", level)
+	}
+	// Either the sysctl is unreadable or it is permissive, so paranoid is not
+	// the explanation. Fall back to the capability requirement itself.
+	return "the keploy agent needs CAP_BPF and CAP_PERFMON (kernel >= 5.8), or CAP_SYS_ADMIN, to attach eBPF probes"
+}
+
+// perfEventParanoidLevel reads the node's kernel.perf_event_paranoid value.
+func perfEventParanoidLevel() (int, error) {
+	raw, err := os.ReadFile(perfEventParanoidPath)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(strings.TrimSpace(string(raw)))
+}

--- a/pkg/agent/hooks/linux/perm_hint_test.go
+++ b/pkg/agent/hooks/linux/perm_hint_test.go
@@ -1,0 +1,175 @@
+//go:build linux
+
+package linux
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/cilium/ebpf"
+)
+
+// withParanoid points the hint at a temp file holding the given contents.
+func withParanoid(t *testing.T, contents string) {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "perf_event_paranoid")
+	if err := os.WriteFile(p, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write temp sysctl: %v", err)
+	}
+	old := perfEventParanoidPath
+	perfEventParanoidPath = p
+	t.Cleanup(func() { perfEventParanoidPath = old })
+}
+
+func TestPerfEventPermissionHint_ParanoidThreeNamesSysctlAndCap(t *testing.T) {
+	withParanoid(t, "3\n")
+
+	got := PerfEventPermissionHint(syscall.EPERM)
+
+	for _, want := range []string{"kernel.perf_event_paranoid", "3", "CAP_SYS_ADMIN", "CAP_PERFMON is NOT sufficient"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("hint %q missing %q", got, want)
+		}
+	}
+}
+
+// EACCES is the other permission errno perf_event_open can return; it must be
+// diagnosed identically, not fall through as an unrelated error.
+func TestPerfEventPermissionHint_EACCESIsAPermissionError(t *testing.T) {
+	withParanoid(t, "3\n")
+
+	if got := PerfEventPermissionHint(syscall.EACCES); got == "" {
+		t.Error("EACCES produced no hint")
+	}
+}
+
+// With a permissive sysctl the paranoid level is NOT the explanation, so the
+// hint must not blame it — claiming the wrong cause is worse than a generic
+// message.
+func TestPerfEventPermissionHint_PermissiveParanoidFallsBackToCapabilities(t *testing.T) {
+	withParanoid(t, "2\n")
+
+	got := PerfEventPermissionHint(syscall.EPERM)
+
+	if strings.Contains(got, "perf_event_paranoid") {
+		t.Errorf("hint blames the sysctl at a permissive level: %q", got)
+	}
+	if !strings.Contains(got, "CAP_BPF") {
+		t.Errorf("hint %q does not state the capability requirement", got)
+	}
+}
+
+// An unreadable sysctl must degrade to the capability hint rather than
+// reporting a bogus level (Atoi of "" yields 0, which must not be treated as a
+// successful read).
+func TestPerfEventPermissionHint_UnreadableSysctlFallsBack(t *testing.T) {
+	old := perfEventParanoidPath
+	perfEventParanoidPath = filepath.Join(t.TempDir(), "does-not-exist")
+	t.Cleanup(func() { perfEventParanoidPath = old })
+
+	got := PerfEventPermissionHint(syscall.EPERM)
+
+	if strings.Contains(got, "perf_event_paranoid") {
+		t.Errorf("hint blames the sysctl it could not read: %q", got)
+	}
+	if got == "" {
+		t.Error("unreadable sysctl produced no hint at all")
+	}
+}
+
+// Only permission failures get this explanation; anything else must pass
+// through untouched so its own error is not masked.
+func TestPerfEventPermissionHint_NonPermissionErrorsAreIgnored(t *testing.T) {
+	withParanoid(t, "3\n")
+
+	if got := PerfEventPermissionHint(errors.New("no such file or directory")); got != "" {
+		t.Errorf("non-permission error produced hint %q", got)
+	}
+	if got := PerfEventPermissionHint(nil); got != "" {
+		t.Errorf("nil error produced hint %q", got)
+	}
+}
+
+// The exact error shape cilium/ebpf produces: link/perf_event.go wraps the
+// raw errno from unix.PerfEventOpen with %w. If errors.Is stopped matching
+// through that wrapping the hint would silently never fire, so pin it.
+func TestPerfEventPermissionHint_MatchesCiliumEbpfErrorShape(t *testing.T) {
+	withParanoid(t, "3\n")
+
+	err := fmt.Errorf("opening tracepoint perf event: %w", syscall.EPERM)
+
+	if got := PerfEventPermissionHint(err); !strings.Contains(got, "CAP_SYS_ADMIN") {
+		t.Errorf("library error shape not diagnosed: %q", got)
+	}
+}
+
+// link.Tracepoint reads the tracefs event id BEFORE it calls perf_event_open,
+// and an EACCES there is also os.ErrPermission. Blaming the paranoid sysctl for
+// a missing debugfs mount would send the reader down the wrong path entirely.
+func TestPerfEventPermissionHint_TracefsErrorIsNotBlamedOnTheSysctl(t *testing.T) {
+	withParanoid(t, "3\n")
+
+	err := fmt.Errorf("reading event id: %w", &os.PathError{
+		Op:   "open",
+		Path: "/sys/kernel/tracing/events/syscalls/sys_enter_socket/id",
+		Err:  syscall.EACCES,
+	})
+
+	got := PerfEventPermissionHint(err)
+
+	if strings.Contains(got, "perf_event_paranoid") {
+		t.Errorf("filesystem permission error blamed on the sysctl: %q", got)
+	}
+	if !strings.Contains(got, "/sys/kernel/tracing") {
+		t.Errorf("hint %q does not name the unreadable path", got)
+	}
+}
+
+// Uprobe attaches open the TARGET BINARY through this same helper. A permission
+// error there must not be answered with "mount debugfs" — that is a confidently
+// wrong answer that sends the operator to the wrong system.
+func TestPerfEventPermissionHint_NonTracefsPathIsNotADebugfsProblem(t *testing.T) {
+	withParanoid(t, "3\n")
+
+	err := fmt.Errorf("open executable: %w", &os.PathError{
+		Op: "open", Path: "/app/bin/server", Err: syscall.EACCES,
+	})
+
+	got := PerfEventPermissionHint(err)
+
+	if strings.Contains(got, "debugfs") || strings.Contains(got, "/sys/kernel") {
+		t.Errorf("non-tracefs path answered with a debugfs prescription: %q", got)
+	}
+	if !strings.Contains(got, "/app/bin/server") {
+		t.Errorf("hint %q does not name the unreadable path", got)
+	}
+}
+
+// The kernel answers BPF_PROG_LOAD with EACCES when the VERIFIER rejects a
+// program, and VerifierError.Unwrap() exposes that errno — so a verifier
+// failure satisfies errors.Is(_, os.ErrPermission) and would otherwise be
+// answered with "grant CAP_SYS_ADMIN / change kernel.perf_event_paranoid".
+// Neither can fix a program the verifier refused; the operator would burn a
+// support cycle on permissions while staring at a verifier log.
+func TestPerfEventPermissionHint_VerifierRejectionIsNotAPermissionProblem(t *testing.T) {
+	withParanoid(t, "3\n")
+
+	ve := &ebpf.VerifierError{
+		Cause: syscall.EACCES,
+		Log:   []string{"invalid mem access 'inv'"},
+	}
+
+	if got := PerfEventPermissionHint(ve); got != "" {
+		t.Errorf("verifier rejection diagnosed as a permission problem: %q", got)
+	}
+	// ...including when it is wrapped, which is how it reaches the caller.
+	wrapped := fmt.Errorf("load program: %w", ve)
+	if got := PerfEventPermissionHint(wrapped); got != "" {
+		t.Errorf("wrapped verifier rejection diagnosed as a permission problem: %q", got)
+	}
+}

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -511,6 +511,11 @@ func (a *Agent) MockOutgoing(ctx context.Context, opts models.OutgoingOptions) e
 }
 
 func (a *Agent) Hook(ctx context.Context, opts models.HookOptions) error {
+	// hookErr is the class marker callers match on; every return below wraps
+	// the underlying cause into it rather than replacing it. Erasing the cause
+	// here made two things impossible upstream: telling a shutdown
+	// (context.Canceled, which must exit 0) from a real failure, and surfacing
+	// the actual reason — e.g. the eBPF attach hint — in the agent's own error.
 	hookErr := errors.New("failed to hook into the app")
 
 	parentErrGrp := ctx.Value(models.ErrGroupKey).(*errgroup.Group)
@@ -565,7 +570,7 @@ func (a *Agent) Hook(ctx context.Context, opts models.HookOptions) error {
 
 	if err != nil {
 		utils.LogError(a.logger, err, "failed to load hooks")
-		return hookErr
+		return fmt.Errorf("%w: %w", hookErr, err)
 	}
 
 	if a.proxyStarted {
@@ -581,7 +586,7 @@ func (a *Agent) Hook(ctx context.Context, opts models.HookOptions) error {
 	DNSIPv4, err := utils.GetContainerIPv4()
 	if err != nil {
 		utils.LogError(a.logger, err, "failed to get container IP")
-		return hookErr
+		return fmt.Errorf("%w: %w", hookErr, err)
 	}
 	if coreAgent.ProxyHook != nil {
 		a.Proxy.SetAuxiliaryHook(coreAgent.ProxyHook)
@@ -603,7 +608,7 @@ func (a *Agent) Hook(ctx context.Context, opts models.HookOptions) error {
 		// StartProxy propagates auxiliary-hook failures (keploy#4078)
 		// rather than swallowing them.
 		proxyCtxCancel()
-		return hookErr
+		return fmt.Errorf("%w: %w", hookErr, err)
 	}
 
 	a.proxyStarted = true

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -918,7 +918,7 @@ func (r *Replayer) Start(ctx context.Context) error {
 	// return non-zero error code so that pipeline processes
 	// know that there is a failure in tests
 	if !testRunResult {
-		utils.ErrCode = 1
+		utils.SetErrCode(1)
 	}
 	return nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -24,6 +24,7 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"text/template"
 	"time"
@@ -45,7 +46,16 @@ var WarningSign = "\U000026A0"
 var TemplatizedValues = map[string]interface{}{}
 var SecretValues = map[string]interface{}{}
 
-var ErrCode = 0
+// errCode is the process exit status keploy will finish with. It is written
+// from worker goroutines (a recovered panic) and read by main, so it is atomic:
+// a plain int here would be a data race with no happens-before edge.
+var errCode atomic.Int32
+
+// SetErrCode records the exit status the process should finish with.
+func SetErrCode(code int) { errCode.Store(int32(code)) }
+
+// ErrCode returns the recorded process exit status.
+func ErrCode() int { return int(errCode.Load()) }
 
 // IsShutdownError checks if the error is related to shutdown (EOF, connection closed, etc.)
 // This is useful for gracefully handling errors during application shutdown.
@@ -456,6 +466,10 @@ func Recover(logger *zap.Logger) {
 	sentry.Flush(2 * time.Second)
 	if r := recover(); r != nil {
 		HandleRecovery(logger, r, "Recovered from panic")
+		// A recovered panic is a failure, whatever else happens next. Without
+		// this the process still exits 0 and kubelet/docker/CI record a crash
+		// as "Reason: Completed, Exit Code: 0".
+		SetErrCode(1)
 		err := Stop(logger, fmt.Sprintf("Recovered from: %s", r))
 		if err != nil {
 			LogError(logger, err, "failed to stop the global context")


### PR DESCRIPTION
## Describe the changes that are made

**The agent reported a total startup failure to its supervisor as success.**

Every fatal branch of the `agent` command logged the error and then `return nil`, and `main.go` discarded the `Execute()` error unless it began with `"unknown command"`, so `utils.ErrCode` stayed `0`. An agent that could not load its eBPF hooks exited **0**, and kubelet recorded it as `Reason: Completed, Exit Code: 0` — docker and CI read it the same way.

Fixing it takes three layers, because the middle one was erasing the evidence:

1. **`cli/agent.go`** — fatal branches return their error instead of `nil`. A cancelled context still exits 0 (that is how the agent is asked to stop), and the check consults the **context** as well as the error, because a stop that races startup surfaces as whatever error the interrupted step happened to produce.
2. **`main.go`** — a non-nil `Execute()` error now sets a non-zero exit status. Without this, (1) alone still exits 0. The `os.Exit(1)` in the unknown-command branch is removed: it is now redundant and was skipping every deferred cleanup in `start()` (debug-file flush, profile writers, log close, umask restore).
3. **`pkg/service/agent/agent.go`** — three `return hookErr` sites replaced the underlying cause with a bare sentinel, so the CLI could not distinguish a shutdown from a real failure and the reason never reached the operator. They now wrap, keeping `errors.Is(err, hookErr)` true.

`utils.ErrCode` becomes an `atomic.Int32` behind `SetErrCode`/`ErrCode()` so `utils.Recover` can mark a recovered panic as a failure — `Recover` already cancels the global context, so a panic aborted the run and then still reported success. A plain `int` written from worker goroutines would have been a data race.

**Plus: the eBPF attach failure that prompted this is now self-diagnosing.** `perf_event_open` is gated on `kernel.perf_event_paranoid`, and Debian/Ubuntu kernels carry an out-of-tree **level 3** that requires `CAP_SYS_ADMIN` — **`CAP_PERFMON` does not satisfy it**. On such a node an agent with the usual eBPF capability set fails every attach with a bare `permission denied`, however new the kernel is. `PerfEventPermissionHint` names the sysctl, its value and the capability. It deliberately stays silent for two look-alikes that are `errors.Is(err, os.ErrPermission)` but have entirely different causes:

- **eBPF verifier rejections** — the kernel answers `BPF_PROG_LOAD` with `EACCES` and `VerifierError.Unwrap()` exposes it, so an unguarded hint would tell operators to grant `CAP_SYS_ADMIN` for a program bug;
- **tracefs / target-binary permission errors** (`*os.PathError`) — `link.Tracepoint` reads a tracefs event id, and uprobes open the target binary, before the syscall.

⚠️ **Behaviour change worth calling out:** invocations that fail validation (e.g. `keploy record` with no `-c`) now exit **1** instead of **0**. That is correct, but it is user-visible for anyone whose CI tolerated a misconfigured invocation.

## Links & References

**Closes:** NA

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed

Unit tests cover each behaviour, and each was mutation-checked (revert the guard, confirm the suite goes red): `cli/agent_test.go` (error propagation, graceful-cancel, cancelled-context-with-unrelated-error) and `pkg/agent/hooks/linux/perm_hint_test.go` (paranoid>2, permissive level, unreadable sysctl, verifier rejection, tracefs vs non-tracefs path, the exact cilium/ebpf error shape).

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

Verified live on a kind cluster whose node has `kernel.perf_event_paranoid=3`, running the agent with the standard eBPF capability set (`BPF, PERFMON, NET_ADMIN, SYS_RESOURCE, SYS_PTRACE`, no `SYS_ADMIN`) — released build vs this branch, same node, same pod spec:

| agent | terminal state | what the operator sees |
|---|---|---|
| released | `Succeeded / exitCode=0 / Completed` | only `opening tracepoint perf event: permission denied` |
| **this PR** | **`Failed / exitCode=1 / Error`** | the sysctl, its value and the remedy |

```
ERROR  failed to attach the tracepoint hook on sys_socket
  {"hint": "kernel.perf_event_paranoid is 3 on this node, which denies perf_event_open
   to any process without CAP_SYS_ADMIN (CAP_PERFMON is NOT sufficient at this level)
   — grant the keploy agent CAP_SYS_ADMIN, or set kernel.perf_event_paranoid<=2 on the node"}
```

The cause also now propagates all the way up, which it previously did not:

```
ERROR  failed to hook into the app
  {"error": "failed to hook into the app: opening tracepoint perf event: permission denied:
   kernel.perf_event_paranoid is 3 on this node, ..."}
```

The RCA was established by a single-variable A/B on that node: paranoid=3 without `SYS_ADMIN` fails; **with** `SYS_ADMIN` passes; seccomp `Unconfined` without `SYS_ADMIN` still fails (so seccomp is not involved); and paranoid=**2** without `SYS_ADMIN` passes.

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- Included above.
