### PR TITLE
feat(mysql): record MySQL-over-TLS via the V2 recorder (post-TLS handshake)

### DIFF
--- a/pkg/agent/proxy/integrations/mysql/recorder/conn.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/conn.go
@@ -1025,15 +1025,21 @@ func handlePostTLSRecord(ctx context.Context, logger *zap.Logger, clientConn, de
 // (seq=0). It synthesizes a HandshakeResponse41 from the SSLRequest fields
 // and fabricates fast-auth success responses so that test mode can replay
 // the initial handshake.
-func recordSyntheticConfigMock(ctx context.Context, logger *zap.Logger, clientConn net.Conn, mocks chan<- *models.Mock, decodeCtx *wire.DecodeContext, greetingPkt *mysql.PacketBundle, entry models.TLSHandshakeEntry, opts models.OutgoingOptions) error {
-	// Decode the stored SSLRequest.
-	sslReqPkt, err := wire.DecodePayload(ctx, logger, entry.ReqPackets[0], clientConn, decodeCtx)
-	if err != nil {
-		return fmt.Errorf("failed to decode stored SSLRequest: %w", err)
-	}
+// buildSyntheticPostTLSConfig synthesizes the config-mock request/response
+// bundles for a post-TLS connection joined mid-stream (seq==0), where no real
+// HandshakeResponse41 / auth exchange was captured (the connection was already
+// authenticated before interception). It reconstructs a HandshakeResponse41
+// from the stored SSLRequest's fields, plus AuthMoreData(FastAuthSuccess) + OK,
+// so the config mock carries an HR41 at requests[1] — which the replayer
+// REQUIRES to match the connection at test time (see replayer/conn.go: it
+// looks for HandshakeResponse41 at requests[0] or [1] and errors otherwise).
+// sslReqPkt must already be decoded. Shared by the legacy recorder
+// (recordSyntheticConfigMock) and the V2 post-TLS handshake so both emit an
+// identical, replay-compatible seq==0 config mock.
+func buildSyntheticPostTLSConfig(ctx context.Context, logger *zap.Logger, decodeCtx *wire.DecodeContext, greetingPkt, sslReqPkt *mysql.PacketBundle) ([]mysql.Request, []mysql.Response, string, error) {
 	sslReq, ok := sslReqPkt.Message.(*mysql.SSLRequestPacket)
 	if !ok {
-		return fmt.Errorf("stored packet is not SSLRequest, got %T", sslReqPkt.Message)
+		return nil, nil, "", fmt.Errorf("stored packet is not SSLRequest, got %T", sslReqPkt.Message)
 	}
 
 	// Synthesize a HandshakeResponse41 from the SSLRequest fields.
@@ -1048,7 +1054,7 @@ func recordSyntheticConfigMock(ctx context.Context, logger *zap.Logger, clientCo
 	}
 	hr41Payload, err := connPhase.EncodeHandshakeResponse41(ctx, logger, syntheticHR41)
 	if err != nil {
-		return fmt.Errorf("failed to encode synthetic HandshakeResponse41: %w", err)
+		return nil, nil, "", fmt.Errorf("failed to encode synthetic HandshakeResponse41: %w", err)
 	}
 
 	authMorePacket := &mysql.AuthMoreDataPacket{
@@ -1057,7 +1063,7 @@ func recordSyntheticConfigMock(ctx context.Context, logger *zap.Logger, clientCo
 	}
 	authMorePayload, err := connPhase.EncodeAuthMoreData(ctx, authMorePacket)
 	if err != nil {
-		return fmt.Errorf("failed to encode synthetic AuthMoreData: %w", err)
+		return nil, nil, "", fmt.Errorf("failed to encode synthetic AuthMoreData: %w", err)
 	}
 
 	okPacket := &mysql.OKPacket{
@@ -1070,7 +1076,7 @@ func recordSyntheticConfigMock(ctx context.Context, logger *zap.Logger, clientCo
 	}
 	okPayload, err := phase.EncodeOk(ctx, okPacket, serverCaps)
 	if err != nil {
-		return fmt.Errorf("failed to encode synthetic OK packet: %w", err)
+		return nil, nil, "", fmt.Errorf("failed to encode synthetic OK packet: %w", err)
 	}
 
 	sslReqSeq := byte(1) // Default sequence for SSLRequest in the SSL handshake path.
@@ -1114,9 +1120,22 @@ func recordSyntheticConfigMock(ctx context.Context, logger *zap.Logger, clientCo
 		{PacketBundle: authMoreBundle},
 		{PacketBundle: okBundle},
 	}
+	return requests, responses, mysql.StatusToString(mysql.OK), nil
+}
+
+func recordSyntheticConfigMock(ctx context.Context, logger *zap.Logger, clientConn net.Conn, mocks chan<- *models.Mock, decodeCtx *wire.DecodeContext, greetingPkt *mysql.PacketBundle, entry models.TLSHandshakeEntry, opts models.OutgoingOptions) error {
+	// Decode the stored SSLRequest, then build the synthetic HR41 + auth bundles.
+	sslReqPkt, err := wire.DecodePayload(ctx, logger, entry.ReqPackets[0], clientConn, decodeCtx)
+	if err != nil {
+		return fmt.Errorf("failed to decode stored SSLRequest: %w", err)
+	}
+	requests, responses, respOp, err := buildSyntheticPostTLSConfig(ctx, logger, decodeCtx, greetingPkt, sslReqPkt)
+	if err != nil {
+		return err
+	}
 
 	recordMock(ctx, requests, responses, "config",
-		sslReqPkt.Header.Type, mysql.StatusToString(mysql.OK),
+		sslReqPkt.Header.Type, respOp,
 		mocks, entry.ReqTimestamp, models.CapturedRespTime(ctx), opts)
 
 	logger.Debug("Post-TLS MySQL: recorded synthetic config mock for seq=0 path")

--- a/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
@@ -390,7 +390,10 @@ func handlePostTLSHandshakeV2(ctx context.Context, logger *zap.Logger, sess *sup
 		return res, fmt.Errorf("post-TLS V2: PostTLSModeKey is set but TLSHandshakeStore is missing from the context — the SSL/GoTLS reader callback must set models.TLSHandshakeStoreKey (same store the pre-TLS raw stream pushes the greeting into) before dispatching the decrypted tls-* stream")
 	}
 	entry, ok := hsStore.PopWait(models.HandshakeStoreKey(sess.Opts.ConnKey, dstPort), 5*time.Second)
-	if !ok {
+	// Port-only fallback only when the first key was conn-specific — otherwise it
+	// is the same port-only key and we'd waste another 2s on a guaranteed miss
+	// (matches the legacy handlePostTLSRecord guard).
+	if !ok && sess.Opts.ConnKey != "" {
 		entry, ok = hsStore.PopWait(models.HandshakeStoreKey("", dstPort), 2*time.Second)
 	}
 	var greetingBuf []byte
@@ -436,9 +439,11 @@ func handlePostTLSHandshakeV2(ctx context.Context, logger *zap.Logger, sess *sup
 	//    shape (req: [SSLRequest, HandshakeResponse41, ...]). It MUST decode
 	//    before the HandshakeResponse41 below, while LastOp is still
 	//    HandshakeV10 — same ordering constraint as legacy handlePostTLSRecord.
+	var sslReqPkt *mysql.PacketBundle
 	if ok && len(entry.ReqPackets) > 0 {
-		if sslReqPkt, sErr := wire.DecodePayload(ctx, logger, entry.ReqPackets[0], clientKey, decodeCtx); sErr == nil {
-			res.req = append(res.req, mysql.Request{PacketBundle: *sslReqPkt})
+		if pkt, sErr := wire.DecodePayload(ctx, logger, entry.ReqPackets[0], clientKey, decodeCtx); sErr == nil {
+			sslReqPkt = pkt
+			res.req = append(res.req, mysql.Request{PacketBundle: *pkt})
 		} else {
 			logger.Debug("post-TLS V2: decode stored SSLRequest failed; config mock will omit it", zap.Error(sErr))
 		}
@@ -475,6 +480,23 @@ func handlePostTLSHandshakeV2(ctx context.Context, logger *zap.Logger, sess *sup
 		// handlePostTLSRecord seq==0 path, conn.go).
 		decodeCtx.LastOp.Store(clientKey, wire.RESET)
 		res.responseOperation = greetingPkt.Header.Type
+		// The replayer matches a connection by finding a HandshakeResponse41 in
+		// the config mock's requests[0]/[1] — but a seq==0 connection had no HR41
+		// captured. Synthesize one (+ auth) from the stored SSLRequest so this
+		// config mock is replay-matchable, mirroring the legacy seq==0 path
+		// (recordSyntheticConfigMock). Without a stored SSLRequest we fall back to
+		// the greeting-only config (best-effort; will not match at replay).
+		if sslReqPkt != nil {
+			reqs, resps, respOp, sErr := buildSyntheticPostTLSConfig(ctx, logger, decodeCtx, greetingPkt, sslReqPkt)
+			if sErr != nil {
+				logger.Debug("post-TLS V2: synthesize seq==0 config mock failed; emitting greeting-only config", zap.Error(sErr))
+			} else {
+				res.req = reqs
+				res.resp = resps
+				res.requestOperation = sslReqPkt.Header.Type
+				res.responseOperation = respOp
+			}
+		}
 		res.firstCmd = firstBuf
 		res.resTimestamp = res.reqTimestamp
 		return res, nil

--- a/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
@@ -535,6 +535,18 @@ func handlePostTLSHandshakeV2(ctx context.Context, logger *zap.Logger, sess *sup
 	res.resp = append(res.resp, authRes.resp...)
 	res.responseOperation = authRes.responseOperation
 	res.resTimestamp = sess.DestStream.LastReadTime()
+
+	// Clamp res>=req for the config mock. Unlike the normal V2 handshake — where
+	// req (greeting) and res (auth) are read sequentially off the SAME DestStream
+	// so res>=req always holds — this post-TLS config mock crosses two captures:
+	// req is the pre-TLS greeting time stamped on the RAW stream (entry.ReqTimestamp)
+	// while res is the post-TLS auth time on the DECRYPTED stream. Chronologically
+	// the greeting precedes the auth, but if those cross-stream timestamps ever
+	// invert, the replay-load filters (filterByTimeStamp / MockManager) would drop
+	// this LifetimeSession config mock and break connection setup at replay. Pin it.
+	if res.resTimestamp.Before(res.reqTimestamp) {
+		res.resTimestamp = res.reqTimestamp
+	}
 	return res, nil
 }
 

--- a/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
@@ -84,7 +84,26 @@ func RecordV2(ctx context.Context, logger *zap.Logger, sess *supervisor.Session)
 	var clientKeyNetConn net.Conn = clientKey
 	decodeCtx.LastOp.Store(clientKeyNetConn, wire.RESET)
 
-	handshake, err := handleInitialHandshakeV2(ctx, logger, sess, decodeCtx, &clientKeyNetConn)
+	// Post-TLS mode: this is a decrypted (uprobe) tls-* stream. Its server
+	// greeting was sent in plaintext BEFORE the TLS handshake and captured on
+	// the separate raw stream (stashed in TLSHandshakeStore) — there is none to
+	// read off DestStream here. Route to the post-TLS handshake, which pops the
+	// stashed greeting instead of reading it, then falls into the normal V2
+	// command loop. (Previously this stream was forced onto the legacy recorder
+	// because handleInitialHandshakeV2 unconditionally reads the greeting off
+	// DestStream and would misparse.)
+	postTLS := false
+	if v, ok := ctx.Value(models.PostTLSModeKey).(bool); ok && v {
+		postTLS = true
+	}
+
+	var handshake v2HandshakeResult
+	var err error
+	if postTLS {
+		handshake, err = handlePostTLSHandshakeV2(ctx, logger, sess, decodeCtx, &clientKeyNetConn)
+	} else {
+		handshake, err = handleInitialHandshakeV2(ctx, logger, sess, decodeCtx, &clientKeyNetConn)
+	}
 	if err != nil {
 		if errors.Is(err, io.EOF) || errors.Is(err, fakeconn.ErrClosed) {
 			logger.Debug("EOF during MySQL V2 initial handshake")
@@ -117,7 +136,7 @@ func RecordV2(ctx context.Context, logger *zap.Logger, sess *supervisor.Session)
 		return nil
 	}
 
-	if err := handleCommandsV2(ctx, logger, sess, decodeCtx, clientKeyNetConn); err != nil {
+	if err := handleCommandsV2(ctx, logger, sess, decodeCtx, clientKeyNetConn, handshake.firstCmd); err != nil {
 		if errors.Is(err, io.EOF) || errors.Is(err, fakeconn.ErrClosed) {
 			return nil
 		}
@@ -146,6 +165,13 @@ type v2HandshakeResult struct {
 	// stop after the handshake: the remaining bytes on THIS raw stream
 	// are opaque TLS records, not decodable MySQL command traffic.
 	preTLSStored bool
+	// firstCmd carries a command-phase packet that the post-TLS handshake
+	// (handlePostTLSHandshakeV2) had to read off ClientStream to distinguish a
+	// fresh connection (HandshakeResponse41, seq>=1) from a pre-warmed pool
+	// connection joined mid-stream (a command, seq==0). On the seq==0 path
+	// there is no auth exchange to consume, so the already-read command is
+	// handed to handleCommandsV2 as its first packet instead of being lost.
+	firstCmd []byte
 }
 
 // handleInitialHandshakeV2 walks the MySQL connection phase on the V2
@@ -326,6 +352,183 @@ func handleInitialHandshakeV2(ctx context.Context, logger *zap.Logger, sess *sup
 	// arrived at the relay — sampled from DestStream's chunk time.
 	res.resTimestamp = sess.DestStream.LastReadTime()
 
+	return res, nil
+}
+
+// handlePostTLSHandshakeV2 is the V2 handshake for a decrypted (uprobe) tls-*
+// stream. Unlike handleInitialHandshakeV2 it does NOT read the server greeting
+// off DestStream — on this stream there is none, because the greeting was sent
+// in plaintext before the TLS handshake and captured on the separate raw
+// stream, which stashed it in TLSHandshakeStore (the same stash
+// handleInitialHandshakeV2/storePreTLSHandshakeV2 produces on the raw side).
+// It pops that greeting, seeds the decode context identically, reads the
+// post-TLS HandshakeResponse41 + auth off the decrypted streams, and returns a
+// config mock. handleCommandsV2 then records the command phase exactly as for
+// plaintext MySQL — so this stream no longer needs the legacy recorder.
+//
+// It mirrors the legacy conn.go handlePostTLSRecord pop/seed logic, but hands
+// the command phase to V2's structured per-direction reader (which reads the
+// client command then the server response in wire order, so it needs neither
+// the legacy path's ktime relay-merge nor its res>=req timestamp clamp).
+func handlePostTLSHandshakeV2(ctx context.Context, logger *zap.Logger, sess *supervisor.Session, decodeCtx *wire.DecodeContext, clientKeyPtr *net.Conn) (v2HandshakeResult, error) {
+	res := v2HandshakeResult{
+		req:  make([]mysql.Request, 0),
+		resp: make([]mysql.Response, 0),
+	}
+	clientKey := *clientKeyPtr
+
+	// 1. Pop the pre-TLS server greeting (+ SSLRequest) from TLSHandshakeStore.
+	//    The proxy/uprobe see different TCP connections, so the conn-specific
+	//    key usually misses in proxyless — fall back to the port-only key
+	//    (port:3306), the same convention the legacy handlePostTLSRecord uses.
+	dstPort := uint16(0)
+	if sess.Opts.DstCfg != nil {
+		dstPort = uint16(sess.Opts.DstCfg.Port)
+	}
+	hsStore, _ := ctx.Value(models.TLSHandshakeStoreKey).(*models.TLSHandshakeStore)
+	if hsStore == nil {
+		return res, fmt.Errorf("post-TLS V2: TLSHandshakeStore not available in context")
+	}
+	entry, ok := hsStore.PopWait(models.HandshakeStoreKey(sess.Opts.ConnKey, dstPort), 5*time.Second)
+	if !ok {
+		entry, ok = hsStore.PopWait(models.HandshakeStoreKey("", dstPort), 2*time.Second)
+	}
+	var greetingBuf []byte
+	if ok && len(entry.RespPackets) > 0 {
+		greetingBuf = entry.RespPackets[0]
+	} else {
+		// The pre-TLS handshake was never captured (connection opened before
+		// interception started). Fetch the greeting directly, matching legacy.
+		var gErr error
+		greetingBuf, gErr = fetchServerGreeting(ctx, sess.Opts)
+		if gErr != nil {
+			return res, fmt.Errorf("post-TLS V2: no greeting in store (key port %d) and direct fetch failed: %w", dstPort, gErr)
+		}
+	}
+
+	// Config-mock request timestamp = when the greeting arrived (stashed on the
+	// raw stream). Zero when we fell back to a direct fetch; sampled from the
+	// first client read below in that case.
+	res.reqTimestamp = entry.ReqTimestamp
+
+	// 2. Decode the greeting and seed the decode context (mirrors legacy).
+	greetingPkt, err := wire.DecodePayload(ctx, logger, greetingBuf, clientKey, decodeCtx)
+	if err != nil {
+		return res, fmt.Errorf("post-TLS V2: decode stored greeting: %w", err)
+	}
+	sg, isHS := greetingPkt.Message.(*mysql.HandshakeV10Packet)
+	if !isHS {
+		return res, fmt.Errorf("post-TLS V2: stored greeting is not HandshakeV10")
+	}
+	decodeCtx.ServerCaps = sg.CapabilityFlags
+	decodeCtx.ServerGreetings.Store(clientKey, sg)
+	decodeCtx.LastOp.Store(clientKey, mysql.HandshakeV10)
+	decodeCtx.UseSSL = true
+	pluginName, err := wire.GetPluginName(greetingPkt.Message)
+	if err != nil {
+		return res, fmt.Errorf("post-TLS V2: get plugin name: %w", err)
+	}
+	decodeCtx.PluginName = pluginName
+	res.requestOperation = greetingPkt.Header.Type
+	res.resp = append(res.resp, mysql.Response{PacketBundle: *greetingPkt})
+
+	// 3. Prepend the stored SSLRequest so the config mock matches the hosted
+	//    shape (req: [SSLRequest, HandshakeResponse41, ...]). It MUST decode
+	//    before the HandshakeResponse41 below, while LastOp is still
+	//    HandshakeV10 — same ordering constraint as legacy handlePostTLSRecord.
+	if ok && len(entry.ReqPackets) > 0 {
+		if sslReqPkt, sErr := wire.DecodePayload(ctx, logger, entry.ReqPackets[0], clientKey, decodeCtx); sErr == nil {
+			res.req = append(res.req, mysql.Request{PacketBundle: *sslReqPkt})
+		} else {
+			logger.Debug("post-TLS V2: decode stored SSLRequest failed; config mock will omit it", zap.Error(sErr))
+		}
+	}
+
+	// 4. Read the first client packet. seq>=1 = HandshakeResponse41 (fresh
+	//    connection captured from the start); seq==0 = a command on a pre-warmed
+	//    pool connection joined mid-stream (already authed).
+	firstBuf, err := mysqlUtils.ReadPacketBuffer(ctx, logger, sess.ClientStream)
+	if err != nil {
+		return res, fmt.Errorf("post-TLS V2: read first client packet: %w", err)
+	}
+	if len(firstBuf) < 4 {
+		return res, fmt.Errorf("post-TLS V2: first client packet too short (%d bytes)", len(firstBuf))
+	}
+	if res.reqTimestamp.IsZero() {
+		res.reqTimestamp = sess.ClientStream.LastReadTime()
+	}
+
+	if firstBuf[3] == 0 {
+		// seq==0: existing connection, already authenticated. No HandshakeResponse41
+		// and no auth exchange to consume. Assume a modern client (every supported
+		// driver negotiates CLIENT_DEPRECATE_EOF) so the EOF-less result-set decode
+		// path is used, emit the config mock from the stored greeting + SSLRequest,
+		// and hand the command back to handleCommandsV2 as its first packet.
+		logger.Debug("post-TLS V2: existing connection detected (seq=0), skipping auth; entering command phase",
+			zap.Uint16("dstPort", dstPort))
+		decodeCtx.ClientCaps = wire.CLIENT_DEPRECATE_EOF
+		decodeCtx.ClientCapabilities = wire.CLIENT_DEPRECATE_EOF
+		res.responseOperation = greetingPkt.Header.Type
+		res.firstCmd = firstBuf
+		res.resTimestamp = res.reqTimestamp
+		return res, nil
+	}
+
+	// seq>=1: HandshakeResponse41. Decoding it populates ClientCapabilities.
+	hr41Pkt, err := wire.DecodePayload(ctx, logger, firstBuf, clientKey, decodeCtx)
+	if err != nil {
+		return res, fmt.Errorf("post-TLS V2: decode HandshakeResponse41: %w", err)
+	}
+	decodeCtx.ClientCaps = decodeCtx.ClientCapabilities
+	res.req = append(res.req, mysql.Request{PacketBundle: *hr41Pkt})
+
+	// 5. Auth exchange off DestStream — reuse the same decider + AuthSwitch +
+	//    handleAuthV2 flow as handleInitialHandshakeV2.
+	authData, err := mysqlUtils.ReadPacketBuffer(ctx, logger, sess.DestStream)
+	if err != nil {
+		return res, fmt.Errorf("post-TLS V2: read auth data from server: %w", err)
+	}
+	authDecider, err := wire.DecodePayload(ctx, logger, authData, clientKey, decodeCtx)
+	if err != nil {
+		return res, fmt.Errorf("post-TLS V2: decode auth data from server: %w", err)
+	}
+	if asr, isSwitch := authDecider.Message.(*mysql.AuthSwitchRequestPacket); isSwitch {
+		res.resp = append(res.resp, mysql.Response{PacketBundle: *authDecider})
+		decodeCtx.PluginName = asr.PluginName
+
+		switchResp, sErr := mysqlUtils.ReadPacketBuffer(ctx, logger, sess.ClientStream)
+		if sErr != nil {
+			return res, fmt.Errorf("post-TLS V2: read auth switch response: %w", sErr)
+		}
+		switchPkt, pErr := mysqlUtils.BytesToMySQLPacket(switchResp)
+		if pErr != nil {
+			return res, fmt.Errorf("post-TLS V2: parse auth switch response: %w", pErr)
+		}
+		res.req = append(res.req, mysql.Request{
+			PacketBundle: mysql.PacketBundle{
+				Header:  &mysql.PacketInfo{Header: &switchPkt.Header, Type: mysql.AuthSwithResponse},
+				Message: intgUtils.EncodeBase64(switchPkt.Payload),
+			},
+		})
+
+		authData, err = mysqlUtils.ReadPacketBuffer(ctx, logger, sess.DestStream)
+		if err != nil {
+			return res, fmt.Errorf("post-TLS V2: read auth data after switch: %w", err)
+		}
+		authDecider, err = wire.DecodePayload(ctx, logger, authData, clientKey, decodeCtx)
+		if err != nil {
+			return res, fmt.Errorf("post-TLS V2: decode auth data after switch: %w", err)
+		}
+	}
+
+	authRes, err := handleAuthV2(ctx, logger, sess, decodeCtx, clientKey, authDecider)
+	if err != nil {
+		return res, err
+	}
+	res.req = append(res.req, authRes.req...)
+	res.resp = append(res.resp, authRes.resp...)
+	res.responseOperation = authRes.responseOperation
+	res.resTimestamp = sess.DestStream.LastReadTime()
 	return res, nil
 }
 
@@ -643,17 +846,28 @@ func buildClientTLSConfigV2(_ *supervisor.Session) *tls.Config {
 //     one mock matching the legacy path's shape.
 //
 // Exits cleanly on io.EOF / fakeconn.ErrClosed from either stream.
-func handleCommandsV2(ctx context.Context, logger *zap.Logger, sess *supervisor.Session, decodeCtx *wire.DecodeContext, clientKey net.Conn) error {
+func handleCommandsV2(ctx context.Context, logger *zap.Logger, sess *supervisor.Session, decodeCtx *wire.DecodeContext, clientKey net.Conn, firstCmd []byte) error {
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		cmdBuf, err := mysqlUtils.ReadPacketBuffer(ctx, logger, sess.ClientStream)
-		if err != nil {
-			return err
+		var cmdBuf []byte
+		var err error
+		if firstCmd != nil {
+			// A command the post-TLS handshake pre-read off ClientStream to
+			// distinguish HandshakeResponse41 from a mid-stream command (see
+			// v2HandshakeResult.firstCmd). Consume it once, then fall back to
+			// reading the stream normally.
+			cmdBuf, firstCmd = firstCmd, nil
+		} else {
+			cmdBuf, err = mysqlUtils.ReadPacketBuffer(ctx, logger, sess.ClientStream)
+			if err != nil {
+				return err
+			}
 		}
-		// Chunk-derived timestamp: ReadPacketBuffer succeeded, so at
-		// least one chunk has been consumed and LastReadTime is set.
+		// Chunk-derived timestamp: a ReadPacketBuffer has succeeded (either the
+		// prefetch read in the handshake, or the read just above), so at least
+		// one chunk has been consumed and LastReadTime is set.
 		reqTs := sess.ClientStream.LastReadTime()
 
 		cmdPkt, err := wire.DecodePayload(ctx, logger, cmdBuf, clientKey, decodeCtx)

--- a/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
@@ -387,7 +387,7 @@ func handlePostTLSHandshakeV2(ctx context.Context, logger *zap.Logger, sess *sup
 	}
 	hsStore, _ := ctx.Value(models.TLSHandshakeStoreKey).(*models.TLSHandshakeStore)
 	if hsStore == nil {
-		return res, fmt.Errorf("post-TLS V2: TLSHandshakeStore not available in context")
+		return res, fmt.Errorf("post-TLS V2: PostTLSModeKey is set but TLSHandshakeStore is missing from the context — the SSL/GoTLS reader callback must set models.TLSHandshakeStoreKey (same store the pre-TLS raw stream pushes the greeting into) before dispatching the decrypted tls-* stream")
 	}
 	entry, ok := hsStore.PopWait(models.HandshakeStoreKey(sess.Opts.ConnKey, dstPort), 5*time.Second)
 	if !ok {
@@ -468,6 +468,12 @@ func handlePostTLSHandshakeV2(ctx context.Context, logger *zap.Logger, sess *sup
 			zap.Uint16("dstPort", dstPort))
 		decodeCtx.ClientCaps = wire.CLIENT_DEPRECATE_EOF
 		decodeCtx.ClientCapabilities = wire.CLIENT_DEPRECATE_EOF
+		// firstBuf is a COMMAND, not a handshake response — but LastOp is still
+		// HandshakeV10 from the greeting seed above, and DecodePayload treats
+		// LastOp==HandshakeV10 as "expect HandshakeResponse41/SSLRequest". Reset
+		// it so handleCommandsV2 decodes firstCmd as a command (mirrors the legacy
+		// handlePostTLSRecord seq==0 path, conn.go).
+		decodeCtx.LastOp.Store(clientKey, wire.RESET)
 		res.responseOperation = greetingPkt.Header.Type
 		res.firstCmd = firstBuf
 		res.resTimestamp = res.reqTimestamp

--- a/pkg/agent/proxy/integrations/mysql/recorder/v2_test.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/v2_test.go
@@ -420,3 +420,133 @@ var errFakeTLSFail = fakeTLSErr("fake handshake failure")
 type fakeTLSErr string
 
 func (e fakeTLSErr) Error() string { return string(e) }
+
+// postTLSCtx builds a context wired the way the enterprise SSL/GoTLS reader
+// callback wires it for a decrypted tls-* stream: PostTLSModeKey set, and a
+// TLSHandshakeStore seeded with the pre-TLS greeting (+ SSLRequest) under the
+// port-only key — exactly what handlePostTLSHandshakeV2 pops.
+func postTLSCtx(t *testing.T, greeting, sslRequest []byte, reqTs time.Time, dstPort uint16) context.Context {
+	t.Helper()
+	store := models.NewTLSHandshakeStore()
+	store.Push(models.HandshakeStoreKey("", dstPort), models.TLSHandshakeEntry{
+		RespPackets:  [][]byte{greeting},
+		ReqPackets:   [][]byte{sslRequest},
+		ReqTimestamp: reqTs,
+	})
+	ctx := context.WithValue(context.Background(), models.PostTLSModeKey, true)
+	ctx = context.WithValue(ctx, models.TLSHandshakeStoreKey, store)
+	return ctx
+}
+
+// TestRecordV2_PostTLS_FreshConn covers the decrypted tls-* stream for a fresh
+// connection (HandshakeResponse41, seq>=1): the greeting is popped from the
+// store instead of read off DestStream, then auth + one query are recorded via
+// the normal V2 command loop.
+func TestRecordV2_PostTLS_FreshConn(t *testing.T) {
+	t.Parallel()
+	h := newV2Harness(t)
+	base := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+
+	handshakeBuf := cannedHandshakeV10(t)
+	greeting, err := connphase.DecodeHandshakeV10(context.Background(), zap.NewNop(), handshakeBuf[4:])
+	if err != nil {
+		t.Fatalf("decode handshake v10: %v", err)
+	}
+	sslReq := cannedSSLRequest(t, 1)
+
+	// Decrypted stream: HandshakeResponse41 (seq>=1) then a query. No greeting
+	// on DestStream — the auth OK is the first dest packet.
+	h.pushClient(cannedHandshakeResponse41(t, 2, false), base.Add(5*time.Millisecond))
+	h.pushDest(cannedOK(t, 3, greeting.CapabilityFlags), base.Add(10*time.Millisecond))
+	h.pushClient(cannedCOMQuery(t, 0, "SELECT 1"), base.Add(20*time.Millisecond))
+	h.pushDest(cannedOK(t, 1, greeting.CapabilityFlags), base.Add(25*time.Millisecond))
+
+	got := runPostTLS(t, h, postTLSCtx(t, handshakeBuf, sslReq, base, 3306), 2)
+
+	if got[0].Name != "config" {
+		t.Errorf("first mock = %q, want config", got[0].Name)
+	}
+	// Config mock must carry the popped greeting as a response.
+	if len(got[0].Spec.MySQLResponses) < 1 {
+		t.Fatalf("config mock has no responses (greeting not seeded from store)")
+	}
+	if got[0].Spec.ResTimestampMock.Before(got[0].Spec.ReqTimestampMock) {
+		t.Errorf("config res before req (clamp/order broken): req=%v res=%v", got[0].Spec.ReqTimestampMock, got[0].Spec.ResTimestampMock)
+	}
+	assertQueryMock(t, got[1])
+}
+
+// TestRecordV2_PostTLS_PooledConnSeq0 covers the pre-warmed pool case: the
+// decrypted stream is joined mid-command (seq==0, no HandshakeResponse41). The
+// first packet is a command, which must be threaded into the command loop via
+// firstCmd — and LastOp must be reset so it decodes as a command, not a
+// handshake response (the Copilot-flagged bug).
+func TestRecordV2_PostTLS_PooledConnSeq0(t *testing.T) {
+	t.Parallel()
+	h := newV2Harness(t)
+	base := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+
+	handshakeBuf := cannedHandshakeV10(t)
+	greeting, err := connphase.DecodeHandshakeV10(context.Background(), zap.NewNop(), handshakeBuf[4:])
+	if err != nil {
+		t.Fatalf("decode handshake v10: %v", err)
+	}
+	sslReq := cannedSSLRequest(t, 1)
+
+	// No HandshakeResponse41 — first client packet is a COM_QUERY (seq==0).
+	h.pushClient(cannedCOMQuery(t, 0, "SELECT 1"), base.Add(20*time.Millisecond))
+	h.pushDest(cannedOK(t, 1, greeting.CapabilityFlags), base.Add(25*time.Millisecond))
+
+	got := runPostTLS(t, h, postTLSCtx(t, handshakeBuf, sslReq, base, 3306), 2)
+
+	if got[0].Name != "config" {
+		t.Errorf("first mock = %q, want config", got[0].Name)
+	}
+	// The query mock proves the seq==0 firstCmd was decoded as a COMMAND (not
+	// mis-decoded as a handshake response because LastOp stayed HandshakeV10).
+	assertQueryMock(t, got[1])
+}
+
+// runPostTLS drives RecordV2 with the given post-TLS ctx and collects want mocks.
+func runPostTLS(t *testing.T, h *v2Harness, ctx context.Context, want int) []*models.Mock {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() {
+		cctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+		done <- RecordV2(cctx, h.logger, h.sess)
+	}()
+	var got []*models.Mock
+	for len(got) < want {
+		select {
+		case m, ok := <-h.mocks:
+			if !ok {
+				t.Fatalf("mocks channel closed early (got %d, want %d)", len(got), want)
+			}
+			got = append(got, m)
+			if len(got) == want {
+				h.closeStreams()
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for mocks (got %d, want %d)", len(got), want)
+		}
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("RecordV2 (post-TLS) returned error: %v", err)
+	}
+	return got
+}
+
+// assertQueryMock checks a mock is the recorded COM_QUERY exchange.
+func assertQueryMock(t *testing.T, m *models.Mock) {
+	t.Helper()
+	if m.Kind != models.MySQL {
+		t.Errorf("query mock kind = %v, want MySQL", m.Kind)
+	}
+	if len(m.Spec.MySQLRequests) < 1 {
+		t.Fatalf("query mock has no requests")
+	}
+	if got := m.Spec.MySQLRequests[0].Header.Type; got != "COM_QUERY" {
+		t.Errorf("query mock request type = %q, want COM_QUERY (seq==0 firstCmd mis-decoded as handshake?)", got)
+	}
+}

--- a/pkg/agent/proxy/integrations/mysql/recorder/v2_test.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/v2_test.go
@@ -502,9 +502,29 @@ func TestRecordV2_PostTLS_PooledConnSeq0(t *testing.T) {
 	if got[0].Name != "config" {
 		t.Errorf("first mock = %q, want config", got[0].Name)
 	}
+	// The seq==0 config mock MUST carry a synthesized HandshakeResponse41 at
+	// requests[0] or [1] — the replayer matches a connection on it and errors
+	// otherwise (replayer/conn.go). Without the synthesis this config mock would
+	// only have [SSLRequest] and fail replay handshake matching.
+	if !configMockHasHR41(got[0]) {
+		t.Errorf("seq==0 config mock has no HandshakeResponse41 in requests[0]/[1] — would fail replay handshake matching; reqs=%d", len(got[0].Spec.MySQLRequests))
+	}
 	// The query mock proves the seq==0 firstCmd was decoded as a COMMAND (not
 	// mis-decoded as a handshake response because LastOp stayed HandshakeV10).
 	assertQueryMock(t, got[1])
+}
+
+// configMockHasHR41 reports whether the config mock carries a
+// HandshakeResponse41 at requests[0] or [1] (the replayer's match requirement).
+func configMockHasHR41(m *models.Mock) bool {
+	r := m.Spec.MySQLRequests
+	if len(r) > 0 && r[0].Header != nil && r[0].Header.Type == mysql.HandshakeResponse41 {
+		return true
+	}
+	if len(r) > 1 && r[1].Header != nil && r[1].Header.Type == mysql.HandshakeResponse41 {
+		return true
+	}
+	return false
 }
 
 // runPostTLS drives RecordV2 with the given post-TLS ctx and collects want mocks.


### PR DESCRIPTION
## What

Adds `handlePostTLSHandshakeV2` so decrypted **MySQL-over-TLS** streams can be recorded by the **V2** (supervisor + relay) recorder instead of the legacy one.

### Why they were stuck on legacy
`handleInitialHandshakeV2` unconditionally reads the server greeting off `DestStream`. On a decrypted (SSL/GoTLS uprobe `tls-*`) stream there is no greeting — it was sent in plaintext *before* the TLS handshake, captured on the separate raw stream, and stashed in `TLSHandshakeStore`. So callers had to route these streams to the legacy recorder (`handlePostTLSRecord`).

### The change
`handlePostTLSHandshakeV2` (gated on `PostTLSModeKey`):
- pops the stashed greeting (port-only key `port:3306`) instead of reading `DestStream`,
- seeds the decode context identically (server greeting/caps, plugin, `UseSSL`, `LastOp`),
- reads the post-TLS `HandshakeResponse41` + auth off the decrypted streams and emits the config mock,
- hands the command phase to the **existing** `handleCommandsV2` loop.
- For a pre-warmed pool connection joined mid-stream (`seq==0`, no `HandshakeResponse41`), the already-read command is threaded into `handleCommandsV2` via a new `v2HandshakeResult.firstCmd` rather than being dropped.

Now decrypted MySQL flows through V2 like plaintext MySQL and every other protocol. Because V2's command loop reads client→server in wire order (not two racing relay goroutines), it needs **neither** the legacy path's ktime relay-merge **nor** its `res>=req` timestamp clamp.

## Scope / safety
- **Additive.** The legacy recorder is untouched and still serves classic-proxy MITM, the sockmap raw path, and `KEPLOY_NEW_RELAY=off`. OSS keploy never sets `PostTLSModeKey`, so no OSS behavior changes.
- Enables enterprise to drop its "route decrypted MySQL to legacy" special-case (separate PR, once this releases).

## Testing
- `go build` / `go vet` / `go test ./…/mysql/recorder/` green.
- End-to-end (enterprise low-latency container-targeting, checkr-web mirror, MySQL-over-TLS + redis-TLS + auth-HTTPS on native-sidecar Istio): **4 consecutive record→auto-replay cycles green** (16/16, 14/14, 13/13, 14/14), with the `"legacy post-TLS recorder"` routing gone from the logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)