### PR TITLE
fix(matcher): sectioned noise no longer disables the whole body assertion

### DIFF
--- a/pkg/matcher/grpc/match.go
+++ b/pkg/matcher/grpc/match.go
@@ -190,28 +190,21 @@ func Match(tc *models.TestCase, actualResp *models.GrpcResp, noiseConfig map[str
 	// Handle noise configuration first - needed for JSON comparison
 	noise := tc.Noise
 
+	// Copy before merging: noiseConfig is the caller's long-lived global map.
 	var (
-		bodyNoise   = noiseConfig["body"]
-		headerNoise = noiseConfig["header"] // need to handle noisy header separately (not implemented yet for grpc)
+		bodyNoise   = matcher.CloneNoiseMap(noiseConfig["body"])
+		headerNoise = matcher.CloneNoiseMap(noiseConfig["header"]) // need to handle noisy header separately (not implemented yet for grpc)
 	)
 
-	if bodyNoise == nil {
-		bodyNoise = map[string][]string{}
+	// Merge test-case-specific noise with global noise (similar to HTTP matcher).
+	// TODO: gRPC has never honoured the whole-body skip sentinel that the HTTP
+	// matcher applies, so skipBody is dropped here to preserve that behaviour.
+	tcBodyNoise, tcHeaderNoise, _ := matcher.SplitNoise(noise, logger)
+	for field, regexArr := range tcBodyNoise {
+		bodyNoise[field] = regexArr
 	}
-
-	if headerNoise == nil {
-		headerNoise = map[string][]string{}
-	}
-
-	// Merge test-case-specific noise with global noise (similar to HTTP matcher)
-	for field, regexArr := range noise {
-		a := strings.Split(field, ".")
-		if len(a) > 1 && a[0] == "body" {
-			x := strings.Join(a[1:], ".")
-			bodyNoise[strings.ToLower(x)] = regexArr
-		} else if a[0] == "header" {
-			headerNoise[strings.ToLower(a[len(a)-1])] = regexArr
-		}
+	for field, regexArr := range tcHeaderNoise {
+		headerNoise[field] = regexArr
 	}
 
 	// Compare decoded data - use JSON comparison if both are valid JSON, otherwise use canonicalization

--- a/pkg/matcher/grpc/noise_test.go
+++ b/pkg/matcher/grpc/noise_test.go
@@ -1,0 +1,108 @@
+// Package grpc noise tests.
+package grpc
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+func grpcTestCase(decoded string, noise map[string][]string) *models.TestCase {
+	return &models.TestCase{
+		Name: "grpc-noise",
+		GrpcResp: models.GrpcResp{
+			Headers: models.GrpcHeaders{
+				PseudoHeaders:   map[string]string{":status": "200"},
+				OrdinaryHeaders: map[string]string{"content-type": "application/grpc"},
+			},
+			Body: models.GrpcLengthPrefixedMessage{
+				CompressionFlag: 0,
+				MessageLength:   uint32(len(decoded)),
+				DecodedData:     decoded,
+			},
+			Trailers: models.GrpcHeaders{
+				OrdinaryHeaders: map[string]string{"grpc-status": "0"},
+			},
+		},
+		Noise: noise,
+	}
+}
+
+func grpcActual(decoded string) *models.GrpcResp {
+	return &models.GrpcResp{
+		Headers: models.GrpcHeaders{
+			PseudoHeaders:   map[string]string{":status": "200"},
+			OrdinaryHeaders: map[string]string{"content-type": "application/grpc"},
+		},
+		Body: models.GrpcLengthPrefixedMessage{
+			CompressionFlag: 0,
+			MessageLength:   uint32(len(decoded)),
+			DecodedData:     decoded,
+		},
+		Trailers: models.GrpcHeaders{
+			OrdinaryHeaders: map[string]string{"grpc-status": "0"},
+		},
+	}
+}
+
+// TestMatch_SectionedBodyNoise covers the gRPC matcher's half of the sectioned
+// noise contract. It had no noise coverage at all before.
+func TestMatch_SectionedBodyNoise(t *testing.T) {
+	const recorded = `{"stock":99,"name":"Laptop"}`
+
+	t.Run("listed path is ignored", func(t *testing.T) {
+		tc := grpcTestCase(recorded, map[string][]string{"body": {"stock"}})
+		actual := grpcActual(`{"stock":100,"name":"Laptop"}`)
+		// MessageLength is derived from the payload and differs by design here;
+		// only the decoded-body verdict is under test.
+		_, res := Match(tc, actual, map[string]map[string][]string{}, false, zap.NewNop(), false)
+		if !decodedDataNormal(res) {
+			t.Errorf("expected the decoded body to match: only the listed noisy path differs")
+		}
+	})
+
+	t.Run("unlisted field is still compared", func(t *testing.T) {
+		tc := grpcTestCase(recorded, map[string][]string{"body": {"stock"}})
+		actual := grpcActual(`{"stock":100,"name":"Tablet"}`)
+		_, res := Match(tc, actual, map[string]map[string][]string{}, false, zap.NewNop(), false)
+		if decodedDataNormal(res) {
+			t.Errorf("expected a decoded-body mismatch: name differs and is not noise")
+		}
+	})
+}
+
+// TestMatch_DoesNotMutateSharedNoiseConfig is the regression test for the worst
+// instance of the shared-map leak: replay passes its long-lived global noise
+// config straight into the gRPC matcher without copying, so a test case's own
+// noise used to persist for the remainder of the run.
+func TestMatch_DoesNotMutateSharedNoiseConfig(t *testing.T) {
+	shared := map[string]map[string][]string{"body": {}, "header": {}}
+
+	tc := grpcTestCase(`{"total":1}`, map[string][]string{
+		"body":       {"total"},
+		"body.stock": {},
+	})
+	Match(tc, grpcActual(`{"total":2}`), shared, false, zap.NewNop(), false)
+
+	if len(shared["body"]) != 0 {
+		t.Errorf("shared global noise config was mutated: %v", shared["body"])
+	}
+
+	// A later test case declaring no noise must still catch the difference.
+	clean := grpcTestCase(`{"total":1}`, nil)
+	_, res := Match(clean, grpcActual(`{"total":2}`), shared, false, zap.NewNop(), false)
+	if decodedDataNormal(res) {
+		t.Errorf("noise from an earlier test case leaked into a later one")
+	}
+}
+
+// decodedDataNormal returns the verdict for the gRPC decoded-body result.
+func decodedDataNormal(res *models.Result) bool {
+	for _, b := range res.BodyResult {
+		if b.Type == models.GrpcData {
+			return b.Normal
+		}
+	}
+	return false
+}

--- a/pkg/matcher/http/absmatch.go
+++ b/pkg/matcher/http/absmatch.go
@@ -324,26 +324,18 @@ func CompareHTTPResp(tcs1, tcs2 *models.TestCase, noiseConfig models.GlobalNoise
 
 	noise := noise1
 
+	// Copy before merging: noiseConfig is the caller's long-lived global map.
 	var (
-		bodyNoise   = noiseConfig["body"]
-		headerNoise = noiseConfig["header"]
+		bodyNoise   = matcher.CloneNoiseMap(noiseConfig["body"])
+		headerNoise = matcher.CloneNoiseMap(noiseConfig["header"])
 	)
 
-	if bodyNoise == nil {
-		bodyNoise = map[string][]string{}
+	tcBodyNoise, tcHeaderNoise, skipBody := matcher.SplitNoise(noise, logger)
+	for field, regexArr := range tcBodyNoise {
+		bodyNoise[field] = regexArr
 	}
-	if headerNoise == nil {
-		headerNoise = map[string][]string{}
-	}
-
-	for field, regexArr := range noise {
-		a := strings.Split(field, ".")
-		if len(a) > 1 && a[0] == "body" {
-			x := strings.Join(a[1:], ".")
-			bodyNoise[strings.ToLower(x)] = regexArr
-		} else if a[0] == "header" {
-			headerNoise[strings.ToLower(a[len(a)-1])] = regexArr
-		}
+	for field, regexArr := range tcHeaderNoise {
+		headerNoise[field] = regexArr
 	}
 
 	// compare http resp headers
@@ -376,7 +368,7 @@ func CompareHTTPResp(tcs1, tcs2 *models.TestCase, noiseConfig models.GlobalNoise
 	// stores the json body after removing the noise
 	cleanExp, cleanAct := tcs1.HTTPResp.Body, tcs2.HTTPResp.Body
 	var jsonComparisonResult matcher.JSONComparisonResult
-	if !matcher.Contains(matcher.MapToArray(noise), "body") && bodyType1 == models.JSON {
+	if !skipBody && bodyType1 == models.JSON {
 		//validate the stored json
 		validatedJSON, err := matcher.ValidateAndMarshalJSON(logger, &cleanExp, &cleanAct)
 		if err != nil {
@@ -405,7 +397,7 @@ func CompareHTTPResp(tcs1, tcs2 *models.TestCase, noiseConfig models.GlobalNoise
 		logger.Debug("cleanExp", zap.Any("cleanExp", cleanExp))
 		logger.Debug("cleanAct", zap.Any("cleanAct", cleanAct))
 	} else {
-		if !matcher.Contains(matcher.MapToArray(noise), "body") && tcs1.HTTPResp.Body != tcs2.HTTPResp.Body {
+		if !skipBody && tcs1.HTTPResp.Body != tcs2.HTTPResp.Body {
 			pass = false
 			bodyRes = false
 		}

--- a/pkg/matcher/http/absmatch_test.go
+++ b/pkg/matcher/http/absmatch_test.go
@@ -1,0 +1,100 @@
+package http
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+func absTestCase(body string, noise map[string][]string) *models.TestCase {
+	return &models.TestCase{
+		Name:    "abs",
+		HTTPReq: models.HTTPReq{Method: "GET", URL: "http://localhost:8080/x", Body: ""},
+		HTTPResp: models.HTTPResp{
+			StatusCode: 200,
+			Header:     map[string]string{"Content-Type": "application/json"},
+			Body:       body,
+		},
+		Noise: noise,
+	}
+}
+
+// TestCompareHTTPResp_SectionedBodyNoise covers CompareHTTPResp, which had no
+// test file at all. It shares the sectioned-noise contract with Match.
+func TestCompareHTTPResp_SectionedBodyNoise(t *testing.T) {
+	const recorded = `{"stock":99,"name":"Laptop"}`
+	noise := func() map[string][]string { return map[string][]string{"body": {"stock"}} }
+
+	t.Run("listed path is ignored", func(t *testing.T) {
+		pass, _ := CompareHTTPResp(
+			absTestCase(recorded, noise()),
+			absTestCase(`{"stock":100,"name":"Laptop"}`, noise()),
+			models.GlobalNoise{}, false, zap.NewNop())
+		if !pass {
+			t.Errorf("expected pass: only the listed noisy path differs")
+		}
+	})
+
+	t.Run("unlisted field is still compared", func(t *testing.T) {
+		pass, _ := CompareHTTPResp(
+			absTestCase(recorded, noise()),
+			absTestCase(`{"stock":100,"name":"Tablet"}`, noise()),
+			models.GlobalNoise{}, false, zap.NewNop())
+		if pass {
+			t.Errorf("expected failure: name differs and is not noise")
+		}
+	})
+
+	t.Run("empty section list still ignores the whole body", func(t *testing.T) {
+		skip := func() map[string][]string { return map[string][]string{"body": {}} }
+		pass, _ := CompareHTTPResp(
+			absTestCase(recorded, skip()),
+			absTestCase(`{"stock":1,"name":"totally-different"}`, skip()),
+			models.GlobalNoise{}, false, zap.NewNop())
+		if !pass {
+			t.Errorf("an empty list on the bare key means ignore the whole body")
+		}
+	})
+}
+
+// TestCompareHTTPResp_SectionedNoise_NonJSONBody covers the non-JSON branch,
+// which was the half of this function left on the old whole-body-skip semantics.
+func TestCompareHTTPResp_SectionedNoise_NonJSONBody(t *testing.T) {
+	noise := func() map[string][]string { return map[string][]string{"body": {"stock"}} }
+
+	pass, _ := CompareHTTPResp(
+		absTestCase("plain recorded text", noise()),
+		absTestCase("plain REPLAYED text", noise()),
+		models.GlobalNoise{}, false, zap.NewNop())
+	if pass {
+		t.Errorf("expected failure: a sectioned path list must not skip a non-JSON body")
+	}
+}
+
+// TestCompareHTTPResp_DoesNotMutateSharedNoiseConfig pins that the caller's
+// long-lived global noise config is not widened by a test case's own noise.
+func TestCompareHTTPResp_DoesNotMutateSharedNoiseConfig(t *testing.T) {
+	shared := models.GlobalNoise{"body": {}, "header": {}}
+
+	noise := func() map[string][]string {
+		return map[string][]string{"body": {"total"}, "body.stock": {}}
+	}
+	CompareHTTPResp(
+		absTestCase(`{"total":1}`, noise()),
+		absTestCase(`{"total":2}`, noise()),
+		shared, false, zap.NewNop())
+
+	if len(shared["body"]) != 0 {
+		t.Fatalf("shared global noise config was mutated: %v", shared["body"])
+	}
+
+	// A later comparison declaring no noise must still catch the difference.
+	pass, _ := CompareHTTPResp(
+		absTestCase(`{"total":1}`, map[string][]string{}),
+		absTestCase(`{"total":2}`, map[string][]string{}),
+		shared, false, zap.NewNop())
+	if pass {
+		t.Errorf("noise from an earlier comparison leaked into a later one")
+	}
+}

--- a/pkg/matcher/http/decode_test.go
+++ b/pkg/matcher/http/decode_test.go
@@ -1,0 +1,126 @@
+package http
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/platform/yaml"
+	"go.keploy.io/server/v3/pkg/platform/yaml/testdb"
+	"go.uber.org/zap"
+	yamlv3 "gopkg.in/yaml.v3"
+)
+
+// TestMatch_DecodedFromYAML_SectionedNoise runs a recorded test-case file
+// through the production YAML decoder and then through Match, so the whole
+// path — decode, SplitNoise, compare — is covered rather than a hand-built
+// TestCase. The fixture is a verbatim trim of a real recorded HTTP test case,
+// including its indexed noise path.
+func TestMatch_DecodedFromYAML_SectionedNoise(t *testing.T) {
+	const fixture = `version: api.keploy.io/v1beta1
+kind: Http
+name: get-order-details
+spec:
+  metadata: {}
+  req:
+    method: GET
+    proto_major: 1
+    proto_minor: 1
+    url: http://localhost:8080/api/v1/orders/5978a5ae/details
+    header:
+      Accept: '*/*'
+    body: ""
+    timestamp: 2026-08-05T08:22:51.125846719Z
+  resp:
+    status_code: 200
+    header:
+      Content-Type: application/json; charset=utf-8
+    body: '{"created_at":"2026-08-05T08:22:51Z","items":[{"product":{"name":"Laptop","price":1200,"stock":99}}]}'
+    status_message: OK
+    proto_major: 0
+    proto_minor: 0
+    timestamp: 2026-08-05T08:22:51.131208762Z
+  objects: []
+  assertions:
+    noise:
+      body:
+        - items.0.product.stock
+      body.created_at: []
+      header:
+        - Content-Length
+      header.Date: []
+  created: 1785918171
+  app_port: 8080
+`
+	path := t.TempDir() + "/tc.yaml"
+	if err := os.WriteFile(path, []byte(fixture), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var doc yaml.NetworkTrafficDoc
+	if err := yamlv3.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	tc, err := testdb.Decode(&doc, zap.NewNop())
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+
+	// Sanity-check that the decoder really produced the sectioned shape; if it
+	// stops doing so, this test would silently stop covering the bug.
+	if got := tc.Noise["body"]; len(got) != 1 || got[0] != "items.0.product.stock" {
+		t.Fatalf("decoded noise[body] = %v, want the sectioned path list", got)
+	}
+
+	// An indexed path is what real recordings carry, and it matches nothing:
+	// the JSON walker keys array elements without a position, so the effective
+	// path is "items.product.stock". Silencing this by dropping numeric segments
+	// is unsafe under the matcher's substring semantics — see
+	// TestJSONDiffWithNoiseControl_IndexedPathIsNotSupported. Until the walker
+	// carries positions, such a field fails loudly instead of passing silently,
+	// which is the upgrade impact for suites recorded with indexed noise paths.
+	t.Run("indexed noise path does not silence its own field", func(t *testing.T) {
+		actual := tc.HTTPResp
+		actual.Body = strings.Replace(tc.HTTPResp.Body, `"stock":99`, `"stock":100`, 1)
+		pass, _ := Match(tc, &actual, map[string]map[string][]string{}, false, false, zap.NewNop(), false)
+		if pass {
+			t.Errorf("if this now passes, indexed noise paths became supported; " +
+				"update SplitNoise's docs and this test")
+		}
+	})
+
+	t.Run("index-free path is honoured end to end", func(t *testing.T) {
+		tc2, err := testdb.Decode(&doc, zap.NewNop())
+		if err != nil {
+			t.Fatalf("Decode: %v", err)
+		}
+		tc2.Noise["body"] = []string{"items.product.stock"}
+		actual := tc2.HTTPResp
+		actual.Body = strings.Replace(tc2.HTTPResp.Body, `"stock":99`, `"stock":100`, 1)
+		pass, _ := Match(tc2, &actual, map[string]map[string][]string{}, false, false, zap.NewNop(), false)
+		if !pass {
+			t.Errorf("expected pass: only the listed noisy path differs")
+		}
+	})
+
+	t.Run("real regression is caught", func(t *testing.T) {
+		tc2, err := testdb.Decode(&doc, zap.NewNop())
+		if err != nil {
+			t.Fatalf("Decode: %v", err)
+		}
+		actual := tc2.HTTPResp
+		actual.Body = strings.NewReplacer(
+			`"stock":99`, `"stock":100`,
+			`"name":"Laptop"`, `"name":"Tablet"`,
+			`"price":1200`, `"price":1999`,
+		).Replace(tc2.HTTPResp.Body)
+		pass, _ := Match(tc2, &actual, map[string]map[string][]string{}, false, false, zap.NewNop(), false)
+		if pass {
+			t.Errorf("expected failure: name and price differ and are not noise")
+		}
+	})
+}

--- a/pkg/matcher/http/match.go
+++ b/pkg/matcher/http/match.go
@@ -84,38 +84,38 @@ func Match(tc *models.TestCase, actualResponse *models.HTTPResp, noiseConfig map
 	}
 
 	noise := tc.Noise
+	// Copy the shared config maps before merging this test case's noise into
+	// them, otherwise each test case permanently widens the noise applied to
+	// every later one.
 	var (
-		bodyNoise   = noiseConfig["body"]
-		headerNoise = noiseConfig["header"]
+		bodyNoise    = matcherUtils.CloneNoiseMap(noiseConfig["body"])
+		headerNoise  = matcherUtils.CloneNoiseMap(noiseConfig["header"])
+		wildcardBody bool
 	)
-	if bodyNoise != nil {
-		if ignoreFields, ok := bodyNoise["*"]; ok && len(ignoreFields) > 0 && ignoreFields[0] == "*" {
-			if noise["body"] == nil {
-				noise["body"] = make([]string, 0)
-			}
-		}
-	} else {
-		bodyNoise = map[string][]string{}
-	}
-	if headerNoise == nil {
-		headerNoise = map[string][]string{}
-	}
+	// wildcardBody carries this on its own. Writing the sentinel back into
+	// tc.Noise used to be how it reached the body-skip check; that mutated the
+	// caller's test case, panicked when tc.Noise was nil, and could be persisted
+	// back to disk by a later re-encode.
+	ignoreFields, hasWildcard := bodyNoise["*"]
+	wildcardBody = hasWildcard && len(ignoreFields) > 0 && ignoreFields[0] == "*"
 
-	for field, regexArr := range noise {
-		a := strings.Split(field, ".")
-		if len(a) > 1 && a[0] == "body" {
-			x := strings.Join(a[1:], ".")
-			bodyNoise[strings.ToLower(x)] = regexArr
-		} else if a[0] == "header" {
-			headerNoise[strings.ToLower(a[len(a)-1])] = regexArr
-		}
+	tcBodyNoise, tcHeaderNoise, skipBody := matcherUtils.SplitNoise(noise, logger)
+	// The global wildcard means "ignore every response body" on its own; it
+	// must not depend on the test case also carrying a bare "body" key, which
+	// stops being the skip sentinel once that key lists field paths.
+	skipBody = skipBody || wildcardBody
+	for field, regexArr := range tcBodyNoise {
+		bodyNoise[field] = regexArr
+	}
+	for field, regexArr := range tcHeaderNoise {
+		headerNoise[field] = regexArr
 	}
 
 	// stores the json body after removing the noise
 	cleanExp, cleanAct := tc.HTTPResp.Body, actualResponse.Body
 
 	var jsonComparisonResult matcherUtils.JSONComparisonResult
-	if !matcherUtils.Contains(matcherUtils.MapToArray(noise), "body") && bodyType == models.JSON && jsonValid234([]byte(tc.HTTPResp.Body)) {
+	if !skipBody && bodyType == models.JSON && jsonValid234([]byte(tc.HTTPResp.Body)) {
 		//validate the stored json
 		validatedJSON, err := matcherUtils.ValidateAndMarshalJSON(logger, &cleanExp, &cleanAct)
 		if err != nil {
@@ -139,7 +139,7 @@ func Match(tc *models.TestCase, actualResponse *models.HTTPResp, noiseConfig map
 		if !compareAll && bodyType != models.JSON {
 			logger.Debug("Skipping body comparison for non-JSON response", zap.String("bodyType", string(bodyType)))
 			// Mark body as passing when compareAll is false and body is not JSON
-		} else if !matcherUtils.Contains(matcherUtils.MapToArray(noise), "body") && tc.HTTPResp.Body != actualResponse.Body {
+		} else if !skipBody && tc.HTTPResp.Body != actualResponse.Body {
 			pass = false
 		}
 	}

--- a/pkg/matcher/http/match_test.go
+++ b/pkg/matcher/http/match_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"strings"
 	"testing"
 
 	"errors"
@@ -11,7 +12,15 @@ import (
 	"go.uber.org/zap"
 )
 
-// TestMatch_HeaderNoiseUpdate_123 ensures that the `headerNoise` map is updated correctly when the `noise` map contains a "header" key.
+// TestMatch_HeaderNoiseUpdate_123 ensures a test case's "header.<name>" noise is
+// applied when comparing headers.
+//
+// This used to assert that Match wrote the merged entry back into the caller's
+// noiseConfig map. That was only observable because Match merged into the
+// caller's map in place, which let one test case's noise leak into every later
+// one in the same run. Match now merges into a copy, so the merge is asserted
+// through its effect on the comparison instead, and the absence of the leak is
+// asserted explicitly.
 func TestMatch_HeaderNoiseUpdate_123(t *testing.T) {
 	// Arrange
 	logger := zap.NewNop()
@@ -22,12 +31,13 @@ func TestMatch_HeaderNoiseUpdate_123(t *testing.T) {
 			Body:       `{"key":"value"}`,
 		},
 		Noise: map[string][]string{
-			"header.Content-Type": {"regex"},
+			"header.Content-Type": {".*"},
 		},
 	}
+	// Content-Type differs; the test case's header noise must absorb it.
 	actualResponse := &models.HTTPResp{
 		StatusCode: 200,
-		Header:     map[string]string{"Content-Type": "application/json"},
+		Header:     map[string]string{"Content-Type": "text/plain"},
 		Body:       `{"key":"value"}`,
 	}
 	noiseConfig := map[string]map[string][]string{
@@ -40,9 +50,8 @@ func TestMatch_HeaderNoiseUpdate_123(t *testing.T) {
 
 	// Assert
 	require.NotNil(t, result)
-	assert.True(t, pass)
-	assert.Contains(t, noiseConfig["header"], "content-type")
-	assert.Equal(t, []string{"regex"}, noiseConfig["header"]["content-type"])
+	assert.True(t, pass, "the differing Content-Type is covered by the test case's header noise")
+	assert.Empty(t, noiseConfig["header"], "the caller's noise config must not be mutated")
 }
 
 // TestMatch_FailureAndDiffLogging_890 tests the Match function with comprehensive failures
@@ -235,8 +244,10 @@ func TestMatch_BodyNoiseWildcard_789(t *testing.T) {
 	require.NotNil(t, result)
 	assert.True(t, result.StatusCode.Normal)
 	assert.True(t, result.BodyResult[0].Normal)
-	// Check that tc.Noise["body"] was initialized
-	assert.NotNil(t, tc.Noise["body"])
+	// Match used to record the wildcard by writing a sentinel into tc.Noise.
+	// That mutated the caller's test case (and panicked when tc.Noise was nil),
+	// so the wildcard is now tracked locally and tc.Noise is left alone.
+	assert.NotContains(t, tc.Noise, "body")
 }
 
 // TestMatch_CompareAll_Disabled tests that when compareAll is false (default),
@@ -318,4 +329,371 @@ func TestMatch_CompareAll_JSONStillCompared(t *testing.T) {
 	require.NotNil(t, result)
 	assert.True(t, result.StatusCode.Normal)
 	assert.False(t, result.BodyResult[0].Normal)
+}
+
+// The tests below cover the "sectioned" noise shape, where the key is the bare
+// section name and the value lists the field paths to ignore:
+//
+//	noise:
+//	  body:
+//	    - items.product.stock
+//	  header:
+//	    - X-Request-Id
+//
+// This is the shape recorded test cases carry. It has
+// to mean "ignore these paths", not "ignore this whole section" — the bare key
+// only means whole-section when its list is empty (the wildcard sentinel that
+// TestMatch_BodyNoiseWildcard_789 covers).
+
+// TestMatch_SectionedBodyNoise_DoesNotDisableWholeBody is a regression test for
+// a silent false negative: a sectioned body-noise entry disabled the body
+// assertion entirely, so a test case with any auto-detected noisy field passed
+// no matter what the handler returned.
+func TestMatch_SectionedBodyNoise_DoesNotDisableWholeBody(t *testing.T) {
+	logger := zap.NewNop()
+	tc := &models.TestCase{
+		Name: "test-sectioned-body-noise",
+		HTTPResp: models.HTTPResp{
+			StatusCode: 200,
+			Body:       `{"items":[{"product":{"name":"Laptop","price":1200,"stock":99}}]}`,
+		},
+		Noise: map[string][]string{
+			"body": {"items.product.stock"},
+		},
+	}
+	// stock is noise, but name and price are real regressions.
+	actualResponse := &models.HTTPResp{
+		StatusCode: 200,
+		Body:       `{"items":[{"product":{"name":"Tablet","price":1999,"stock":100}}]}`,
+	}
+
+	pass, result := Match(tc, actualResponse, map[string]map[string][]string{}, false, false, logger, true)
+
+	assert.False(t, pass, "should fail: name and price differ and are not listed as noise")
+	require.NotNil(t, result)
+	assert.False(t, result.BodyResult[0].Normal)
+}
+
+// TestMatch_SectionedBodyNoise_IgnoresListedPaths is the other half of the
+// contract: the paths that ARE listed must still be ignored.
+func TestMatch_SectionedBodyNoise_IgnoresListedPaths(t *testing.T) {
+	logger := zap.NewNop()
+	tc := &models.TestCase{
+		Name: "test-sectioned-body-noise-ignored",
+		HTTPResp: models.HTTPResp{
+			StatusCode: 200,
+			Body:       `{"items":[{"product":{"name":"Laptop","price":1200,"stock":99}}]}`,
+		},
+		Noise: map[string][]string{
+			"body": {"items.product.stock"},
+		},
+	}
+	// Only the noisy field differs.
+	actualResponse := &models.HTTPResp{
+		StatusCode: 200,
+		Body:       `{"items":[{"product":{"name":"Laptop","price":1200,"stock":100}}]}`,
+	}
+
+	pass, result := Match(tc, actualResponse, map[string]map[string][]string{}, false, false, logger, true)
+
+	assert.True(t, pass, "should pass: the only difference is the listed noisy path")
+	require.NotNil(t, result)
+	assert.True(t, result.BodyResult[0].Normal)
+}
+
+// TestMatch_SectionedBodyNoise_MixedWithDottedKeys covers the shape a real
+// recorded test case has, where both key styles appear together.
+func TestMatch_SectionedBodyNoise_MixedWithDottedKeys(t *testing.T) {
+	logger := zap.NewNop()
+	tc := &models.TestCase{
+		Name: "test-sectioned-and-dotted-noise",
+		HTTPResp: models.HTTPResp{
+			StatusCode: 200,
+			Body:       `{"created_at":"2026-08-05T08:22:51Z","stock":99,"name":"Laptop"}`,
+		},
+		Noise: map[string][]string{
+			"body":            {"stock"},
+			"body.created_at": {},
+		},
+	}
+	actualResponse := &models.HTTPResp{
+		StatusCode: 200,
+		Body:       `{"created_at":"2027-01-01T00:00:00Z","stock":100,"name":"Tablet"}`,
+	}
+
+	pass, result := Match(tc, actualResponse, map[string]map[string][]string{}, false, false, logger, true)
+
+	assert.False(t, pass, "should fail on name; created_at and stock are both noise")
+	require.NotNil(t, result)
+	assert.False(t, result.BodyResult[0].Normal)
+}
+
+// TestMatch_EmptySectionedBodyNoise_IgnoresWholeBody pins the sentinel meaning
+// of the bare key with an empty list, so the fix above cannot regress it.
+func TestMatch_EmptySectionedBodyNoise_IgnoresWholeBody(t *testing.T) {
+	logger := zap.NewNop()
+	tc := &models.TestCase{
+		Name: "test-empty-sectioned-body-noise",
+		HTTPResp: models.HTTPResp{
+			StatusCode: 200,
+			Body:       `{"id":1,"name":"keploy"}`,
+		},
+		Noise: map[string][]string{
+			"body": {},
+		},
+	}
+	actualResponse := &models.HTTPResp{
+		StatusCode: 200,
+		Body:       `{"id":2,"name":"totally-different"}`,
+	}
+
+	pass, result := Match(tc, actualResponse, map[string]map[string][]string{}, false, false, logger, true)
+
+	assert.True(t, pass, "an empty list on the bare key still means ignore the whole body")
+	require.NotNil(t, result)
+	assert.True(t, result.BodyResult[0].Normal)
+}
+
+// TestMatch_SectionedHeaderNoise_DoesNotDisableAllHeaders is the header analog
+// of the body regression: `header: [X-Request-Id]` silenced every header.
+func TestMatch_SectionedHeaderNoise_DoesNotDisableAllHeaders(t *testing.T) {
+	logger := zap.NewNop()
+	tc := &models.TestCase{
+		Name: "test-sectioned-header-noise",
+		HTTPResp: models.HTTPResp{
+			StatusCode: 200,
+			Header: map[string]string{
+				"X-Request-Id": "abc",
+				"Content-Type": "application/json",
+			},
+			Body: `{"ok":true}`,
+		},
+		Noise: map[string][]string{
+			"header": {"X-Request-Id"},
+		},
+	}
+	actualResponse := &models.HTTPResp{
+		StatusCode: 200,
+		Header: map[string]string{
+			"X-Request-Id": "zzz",        // noise
+			"Content-Type": "text/plain", // real regression
+		},
+		Body: `{"ok":true}`,
+	}
+
+	pass, result := Match(tc, actualResponse, map[string]map[string][]string{}, false, false, logger, true)
+
+	assert.False(t, pass, "should fail: Content-Type differs and is not listed as noise")
+	require.NotNil(t, result)
+}
+
+// TestMatch_SectionedHeaderNoise_IgnoresListedHeaders is the other half.
+func TestMatch_SectionedHeaderNoise_IgnoresListedHeaders(t *testing.T) {
+	logger := zap.NewNop()
+	tc := &models.TestCase{
+		Name: "test-sectioned-header-noise-ignored",
+		HTTPResp: models.HTTPResp{
+			StatusCode: 200,
+			Header: map[string]string{
+				"X-Request-Id": "abc",
+				"Content-Type": "application/json",
+			},
+			Body: `{"ok":true}`,
+		},
+		Noise: map[string][]string{
+			"header": {"X-Request-Id"},
+		},
+	}
+	actualResponse := &models.HTTPResp{
+		StatusCode: 200,
+		Header: map[string]string{
+			"X-Request-Id": "zzz",
+			"Content-Type": "application/json",
+		},
+		Body: `{"ok":true}`,
+	}
+
+	pass, result := Match(tc, actualResponse, map[string]map[string][]string{}, false, false, logger, true)
+
+	assert.True(t, pass, "should pass: the only differing header is listed as noise")
+	require.NotNil(t, result)
+}
+
+// Real payloads captured from a keploy cloud replay of order-service-4,
+// test case get-api-v1-orders-by-id-details-1.
+const realWorldRecordedBody = `{"created_at":"2026-08-05T08:22:51Z","id":"5978a5ae-792b-4a19-a97b-d2802674b467","items":[{"product":{"description":"A powerful and portable laptop.","id":"26c7d38d-8b7d-11f1-a6c8-da00f699ab49","name":"Laptop","price":1200,"stock":99},"productId":"26c7d38d-8b7d-11f1-a6c8-da00f699ab49","quantity":1}],"status":"PENDING","total_amount":1200,"updated_at":"2026-08-05T08:22:51Z","user":{"created_at":"2026-08-05T08:22:50Z","email":"alice_1785918170@example.com","id":"669e858c-b6ee-4313-b59d-f6fa1f51e33f","username":"alice_1785918170"},"userId":"669e858c-b6ee-4313-b59d-f6fa1f51e33f"}`
+
+// Untampered replay: stock drifts 99 -> 100 (the field marked as noise).
+const realWorldUntamperedBody = `{"created_at":"2026-08-05T08:22:51Z","id":"5978a5ae-792b-4a19-a97b-d2802674b467","items":[{"product":{"description":"A powerful and portable laptop.","id":"26c7d38d-8b7d-11f1-a6c8-da00f699ab49","name":"Laptop","price":1200,"stock":100},"productId":"26c7d38d-8b7d-11f1-a6c8-da00f699ab49","quantity":1}],"status":"PENDING","total_amount":1200,"updated_at":"2026-08-05T08:22:51Z","user":{"created_at":"2026-08-05T08:22:50Z","email":"alice_1785918170@example.com","id":"669e858c-b6ee-4313-b59d-f6fa1f51e33f","username":"alice_1785918170"},"userId":"669e858c-b6ee-4313-b59d-f6fa1f51e33f"}`
+
+// Tampered replay: product mock returned Tablet/1999, user mock returned zzzzz.
+const realWorldTamperedBody = `{"created_at":"2026-08-05T08:22:51Z","id":"5978a5ae-792b-4a19-a97b-d2802674b467","items":[{"product":{"description":"A powerful and portable laptop.","id":"26c7d38d-8b7d-11f1-a6c8-da00f699ab49","name":"Tablet","price":1999,"stock":100},"productId":"26c7d38d-8b7d-11f1-a6c8-da00f699ab49","quantity":1}],"status":"PENDING","total_amount":1200,"updated_at":"2026-08-05T08:22:51Z","user":{"created_at":"2026-08-05T08:22:50Z","email":"zzzzz_1785918170@example.com","id":"669e858c-b6ee-4313-b59d-f6fa1f51e33f","username":"zzzzz_1785918170"},"userId":"669e858c-b6ee-4313-b59d-f6fa1f51e33f"}`
+
+func realWorldNoise() map[string][]string {
+	return map[string][]string{
+		"body":                 {"items.product.stock"},
+		"body.created_at":      {},
+		"body.updated_at":      {},
+		"body.user.created_at": {},
+		"header":               {"X-Request-Id"},
+		"header.Date":          {},
+	}
+}
+
+func TestMatch_RealWorldRecordedNoise(t *testing.T) {
+	for _, c := range []struct {
+		name     string
+		actual   string
+		wantPass bool
+	}{
+		{"untampered replay passes (only the noisy stock drifts)", realWorldUntamperedBody, true},
+		{"tampered downstream mock is caught", realWorldTamperedBody, false},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			tc := &models.TestCase{
+				Name: "get-api-v1-orders-by-id-details-1",
+				HTTPResp: models.HTTPResp{
+					StatusCode: 200,
+					Header: map[string]string{
+						"Content-Type": "application/json; charset=utf-8",
+						"Date":         "Wed, 05 Aug 2026 08:22:51 GMT",
+						"X-Request-Id": "req-recorded",
+					},
+					Body: realWorldRecordedBody,
+				},
+				Noise: realWorldNoise(),
+			}
+			// Date and X-Request-Id drift on every replay and are both noise;
+			// Content-Type is not, and is identical here.
+			actual := &models.HTTPResp{
+				StatusCode: 200,
+				Header: map[string]string{
+					"Content-Type": "application/json; charset=utf-8",
+					"Date":         "Thu, 06 Aug 2026 09:00:00 GMT",
+					"X-Request-Id": "req-replayed",
+				},
+				Body: c.actual,
+			}
+			pass, _ := Match(tc, actual, map[string]map[string][]string{}, false, false, zap.NewNop(), false)
+			if pass != c.wantPass {
+				t.Errorf("pass = %v, want %v", pass, c.wantPass)
+			}
+		})
+	}
+}
+
+// TestMatch_SectionedBodyNoise_ShortPathDoesNotLeak guards against a tempting
+// but wrong "fix" for indexed noise paths: dropping the numeric segment from
+// "0.id" yields the bare segment "id", and because noise keys are matched with
+// strings.Contains that would silence every field whose name merely contains
+// "id" — "width", "video" and "paid" all do.
+func TestMatch_SectionedBodyNoise_ShortPathDoesNotLeak(t *testing.T) {
+	logger := zap.NewNop()
+	tc := &models.TestCase{
+		Name: "test-short-stripped-path",
+		HTTPResp: models.HTTPResp{
+			StatusCode: 200,
+			Body:       `{"width":10,"video":"a","paid":true}`,
+		},
+		Noise: map[string][]string{"body": {"0.id"}},
+	}
+	actualResponse := &models.HTTPResp{
+		StatusCode: 200,
+		Body:       `{"width":99,"video":"b","paid":false}`,
+	}
+
+	pass, _ := Match(tc, actualResponse, map[string]map[string][]string{}, false, false, logger, false)
+
+	assert.False(t, pass, "width/video/paid must not be silenced by a noise path that strips to \"id\"")
+}
+
+// TestMatch_GlobalWildcardBody_SurvivesSectionedNoise pins that the global
+// "ignore every body" config keeps working on a test case that also carries a
+// sectioned body-noise key — that key is no longer the skip sentinel itself.
+func TestMatch_GlobalWildcardBody_SurvivesSectionedNoise(t *testing.T) {
+	logger := zap.NewNop()
+	tc := &models.TestCase{
+		Name: "test-wildcard-with-sectioned-noise",
+		HTTPResp: models.HTTPResp{
+			StatusCode: 200,
+			Body:       `{"id":1,"name":"keploy","stock":99}`,
+		},
+		Noise: map[string][]string{"body": {"stock"}},
+	}
+	actualResponse := &models.HTTPResp{
+		StatusCode: 200,
+		Body:       `{"id":2,"name":"totally-different","stock":100}`,
+	}
+	noiseConfig := map[string]map[string][]string{"body": {"*": {"*"}}}
+
+	pass, _ := Match(tc, actualResponse, noiseConfig, false, false, logger, false)
+
+	assert.True(t, pass, "the global body wildcard still means ignore the whole body")
+}
+
+// TestMatch_DoesNotMutateSharedNoiseConfig pins that a test case's own noise
+// does not leak into the caller's global config and soften every later case.
+func TestMatch_DoesNotMutateSharedNoiseConfig(t *testing.T) {
+	logger := zap.NewNop()
+	shared := map[string]map[string][]string{
+		"body":   {},
+		"header": {},
+	}
+
+	// Both key shapes are merged in, so both must be copied. The dotted shape is
+	// the one that leaked before this change; the sectioned shape leaks only now
+	// that it produces entries at all.
+	noisy := &models.TestCase{
+		Name:     "case-with-noise",
+		HTTPResp: models.HTTPResp{StatusCode: 200, Body: `{"total":1,"stock":1}`},
+		Noise:    map[string][]string{"body": {"total"}, "body.stock": {}},
+	}
+	Match(noisy, &models.HTTPResp{StatusCode: 200, Body: `{"total":2,"stock":2}`}, shared, false, false, logger, false)
+
+	assert.Empty(t, shared["body"], "the shared global noise config must be left untouched")
+
+	// A later test case that declares no noise must still catch both differences.
+	clean := &models.TestCase{
+		Name:     "case-without-noise",
+		HTTPResp: models.HTTPResp{StatusCode: 200, Body: `{"total":1,"stock":1}`},
+	}
+	pass, _ := Match(clean, &models.HTTPResp{StatusCode: 200, Body: `{"total":2,"stock":2}`}, shared, false, false, logger, false)
+
+	assert.False(t, pass, "noise from an earlier test case must not carry over")
+}
+
+// TestMatch_SectionedHeaderNoise_ScopesToTheListedHeader asserts on the
+// per-header verdicts rather than only the overall pass flag, so the test
+// cannot be satisfied by the body assertion failing instead.
+func TestMatch_SectionedHeaderNoise_ScopesToTheListedHeader(t *testing.T) {
+	logger := zap.NewNop()
+	tc := &models.TestCase{
+		Name: "test-sectioned-header-scope",
+		HTTPResp: models.HTTPResp{
+			StatusCode: 200,
+			Header:     map[string]string{"X-Request-Id": "abc", "Content-Type": "application/json"},
+			Body:       `{"ok":true}`,
+		},
+		Noise: map[string][]string{"header": {"X-Request-Id"}},
+	}
+	actualResponse := &models.HTTPResp{
+		StatusCode: 200,
+		Header:     map[string]string{"X-Request-Id": "zzz", "Content-Type": "text/plain"},
+		Body:       `{"ok":true}`,
+	}
+
+	pass, result := Match(tc, actualResponse, map[string]map[string][]string{}, false, false, logger, false)
+
+	assert.False(t, pass)
+	require.NotNil(t, result)
+	verdicts := map[string]bool{}
+	for _, h := range result.HeadersResult {
+		verdicts[strings.ToLower(h.Expected.Key)] = h.Normal
+	}
+	normal, ok := verdicts["content-type"]
+	require.True(t, ok, "Content-Type should be reported, got %v", verdicts)
+	assert.False(t, normal, "Content-Type is not noise and differs")
+	normal, ok = verdicts["x-request-id"]
+	require.True(t, ok, "X-Request-Id should be reported, got %v", verdicts)
+	assert.True(t, normal, "X-Request-Id is listed as noise")
 }

--- a/pkg/matcher/utils.go
+++ b/pkg/matcher/utils.go
@@ -106,6 +106,148 @@ func (ni noiseIndex) match(keyLower string) (regs []*regexp.Regexp, isNoisy bool
 	return nil, false
 }
 
+// CloneNoiseMap returns a copy of a noise map, so that merging a test case's
+// own noise into the shared global config cannot leak across test cases. The
+// callers hold long-lived config maps (Replayer/runner globals) that would
+// otherwise accumulate every test case's noise as the run progresses.
+func CloneNoiseMap(input map[string][]string) map[string][]string {
+	out := make(map[string][]string, len(input))
+	for key, values := range input {
+		out[key] = append([]string(nil), values...)
+	}
+	return out
+}
+
+// SplitNoise separates a test case's flat noise map into body-scoped and
+// header-scoped entries, and reports whether the body section should be
+// ignored wholesale.
+//
+// A noise key comes in one of two shapes:
+//
+//	dotted     "body.user.id": [regex...]      -> a single field path
+//	sectioned  "body": ["user.id", "total"]    -> a list of field paths
+//
+// Only a bare section key with an EMPTY list means "ignore this whole
+// section" — that is the sentinel a global `body: {"*": ["*"]}` config expands
+// to. A bare section key with a NON-empty list names the fields to ignore.
+//
+// Reading a non-empty sectioned list as the whole-section sentinel silently
+// disables the assertion for the entire body or header set, so any test case
+// carrying such an entry can never fail on its body (or on any header).
+//
+// Note this makes the sectioned values paths, not regexes. A regex there was
+// never evaluated — it only ever tripped the whole-section skip — so nothing
+// that worked stops working, but a suite that was passing because of that skip
+// will start reporting the differences it was hiding. A sectioned value that
+// looks like a regex is warned about, since the equivalent is the dotted form
+// `body.<path>: [regex]`.
+//
+// A dot-delimited path is matched against the JSON walker's own key syntax,
+// which does NOT carry array positions: every element of `items` is walked
+// under the key "items". So `items.stock` works and `items.0.stock` matches
+// nothing. Normalizing the latter is deliberately NOT done here — see
+// TestJSONDiffWithNoiseControl_IndexedPathIsNotSupported for why.
+//
+// OSS noise auto-detection emits the dotted, index-free shape; the sectioned
+// shape reaches us from hand-written YAML and from other producers of
+// test-case files.
+//
+// Header scope has no separate skip flag: CompareHeaders already treats the
+// presence of a "header" key as "all headers are noisy", so the sentinel is
+// passed through as that key.
+func SplitNoise(noise map[string][]string, logger *zap.Logger) (bodyNoise map[string][]string, headerNoise map[string][]string, skipBody bool) {
+	bodyNoise = map[string][]string{}
+	headerNoise = map[string][]string{}
+
+	// Sectioned keys are applied first so that a dotted key naming the same
+	// path always wins. Doing both in one pass would let map iteration order
+	// decide, which makes a run flaky rather than merely wrong.
+	for field, values := range noise {
+		switch strings.ToLower(field) {
+		case "body":
+			if len(values) == 0 {
+				skipBody = true
+				continue
+			}
+			for _, path := range values {
+				warnIfRegexShaped(logger, "body", path)
+				// An empty regex list means "ignore unconditionally", which is
+				// what a listed path is asking for.
+				bodyNoise[strings.ToLower(path)] = []string{}
+			}
+		case "header":
+			if len(values) == 0 {
+				headerNoise["header"] = []string{}
+				continue
+			}
+			for _, name := range values {
+				warnIfRegexShaped(logger, "header", name)
+				headerNoise[strings.ToLower(name)] = []string{}
+			}
+		}
+	}
+
+	for field, regexArr := range noise {
+		parts := strings.Split(field, ".")
+		if len(parts) < 2 {
+			continue
+		}
+		// Copy the value slice: the destination map is a clone the caller is
+		// free to mutate, so it must not alias the test case's own noise.
+		regexes := append([]string(nil), regexArr...)
+		switch strings.ToLower(parts[0]) {
+		case "body":
+			bodyNoise[strings.ToLower(strings.Join(parts[1:], "."))] = regexes
+		case "header":
+			headerNoise[strings.ToLower(parts[len(parts)-1])] = regexes
+		}
+	}
+
+	return bodyNoise, headerNoise, skipBody
+}
+
+// regexShapedTokens are substrings that cannot occur in a JSON field path but
+// are unmistakable in a regex. Single metacharacters are deliberately excluded:
+// `$` alone would flag every OpenAPI/JSON-Schema document key (`$ref`,
+// `$schema`, `$id`), and telling that user to move `$ref` into a regex position
+// is worse than saying nothing — as a regex it anchors to end-of-string and
+// matches nothing at all.
+var regexShapedTokens = []string{".*", ".+", `\d`, `\w`, `\s`, "[0-9", "[a-z", "[A-Z", "(?", "|"}
+
+// warnedRegexShaped dedupes the warning below. SplitNoise runs per test case —
+// and twice per case on the failure-assessment path — so warning unconditionally
+// would emit one line per case and bury the actual failures.
+var warnedRegexShaped sync.Map
+
+// warnIfRegexShaped flags a sectioned noise value that looks like a regex
+// rather than a field path. Such a value used to be inert — it only tripped the
+// whole-section skip — so silently reinterpreting it as a path would turn a
+// green suite red with no explanation.
+func warnIfRegexShaped(logger *zap.Logger, section, value string) {
+	if logger == nil || !looksLikeRegex(value) {
+		return
+	}
+	if _, seen := warnedRegexShaped.LoadOrStore(section+"\x00"+value, struct{}{}); seen {
+		return
+	}
+	logger.Warn("noise value looks like a regex but is read as a field path; use the dotted form to apply a regex",
+		zap.String("section", section),
+		zap.String("value", value),
+		zap.String("dotted_equivalent", section+".<path>: ["+value+"]"))
+}
+
+func looksLikeRegex(value string) bool {
+	if strings.HasPrefix(value, "^") || strings.HasSuffix(value, "$") {
+		return true
+	}
+	for _, tok := range regexShapedTokens {
+		if strings.Contains(value, tok) {
+			return true
+		}
+	}
+	return false
+}
+
 // JSONDiffWithNoiseControl compares JSON with support for both Path-based noise (e.g. "body.user.id")
 // and Global noise (e.g. "timestamp") to be ignored everywhere.
 func JSONDiffWithNoiseControl(validatedJSON ValidatedJSON, noise map[string][]string, ignoreOrdering bool) (JSONComparisonResult, error) {

--- a/pkg/matcher/utils_test.go
+++ b/pkg/matcher/utils_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 
 	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 // subsKeyMatchWithOriginal is a test helper that lets subtests pass
@@ -322,5 +325,314 @@ func TestCompareHeaders_UppercaseHeaderSentinel(t *testing.T) {
 	var res []models.HeaderResult
 	if ok := CompareHeaders(h1, h2, &res, noise); !ok {
 		t.Fatalf("uppercase 'Header' sentinel should mark all headers noisy; got match=false (res=%+v)", res)
+	}
+}
+
+func TestSplitNoise(t *testing.T) {
+	cases := []struct {
+		name       string
+		noise      map[string][]string
+		wantBody   map[string][]string
+		wantHeader map[string][]string
+		wantSkip   bool
+	}{
+		{
+			name:       "dotted body key keeps its regex list",
+			noise:      map[string][]string{"body.user.id": {".*"}},
+			wantBody:   map[string][]string{"user.id": {".*"}},
+			wantHeader: map[string][]string{},
+		},
+		{
+			name:       "dotted header key is scoped to the header name",
+			noise:      map[string][]string{"header.Date": {}},
+			wantBody:   map[string][]string{},
+			wantHeader: map[string][]string{"date": {}},
+		},
+		{
+			name:       "sectioned body key lists paths, it does not skip the body",
+			noise:      map[string][]string{"body": {"items.0.product.stock", "Total"}},
+			wantBody:   map[string][]string{"items.0.product.stock": {}, "total": {}},
+			wantHeader: map[string][]string{},
+		},
+		{
+			name:       "sectioned header key lists header names",
+			noise:      map[string][]string{"header": {"Content-Length"}},
+			wantBody:   map[string][]string{},
+			wantHeader: map[string][]string{"content-length": {}},
+		},
+		{
+			name:       "empty body key is the whole-section sentinel",
+			noise:      map[string][]string{"body": {}},
+			wantBody:   map[string][]string{},
+			wantHeader: map[string][]string{},
+			wantSkip:   true,
+		},
+		{
+			name:       "empty header key is the whole-section sentinel",
+			noise:      map[string][]string{"header": {}},
+			wantBody:   map[string][]string{},
+			wantHeader: map[string][]string{"header": {}},
+		},
+		{
+			name: "both shapes coexist",
+			noise: map[string][]string{
+				"body":            {"stock"},
+				"body.created_at": {},
+				"header":          {"Content-Length"},
+				"header.Date":     {},
+			},
+			wantBody:   map[string][]string{"stock": {}, "created_at": {}},
+			wantHeader: map[string][]string{"content-length": {}, "date": {}},
+		},
+		{
+			name:       "unrelated sections are dropped",
+			noise:      map[string][]string{"trailer.Foo": {}, "somethingelse": {"x"}},
+			wantBody:   map[string][]string{},
+			wantHeader: map[string][]string{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotBody, gotHeader, gotSkip := SplitNoise(tc.noise, nil)
+			if gotSkip != tc.wantSkip {
+				t.Errorf("skipBody = %v, want %v", gotSkip, tc.wantSkip)
+			}
+			if !noiseMapsEqual(gotBody, tc.wantBody) {
+				t.Errorf("bodyNoise = %v, want %v", gotBody, tc.wantBody)
+			}
+			if !noiseMapsEqual(gotHeader, tc.wantHeader) {
+				t.Errorf("headerNoise = %v, want %v", gotHeader, tc.wantHeader)
+			}
+		})
+	}
+}
+
+func noiseMapsEqual(got, want map[string][]string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for k, wv := range want {
+		gv, ok := got[k]
+		if !ok || len(gv) != len(wv) {
+			return false
+		}
+		for i := range wv {
+			if gv[i] != wv[i] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// TestSplitNoise_DottedWinsOverSectioned pins a deterministic merge when both
+// shapes name the same path. Resolving it by map iteration order would make a
+// run flaky rather than merely wrong.
+func TestSplitNoise_DottedWinsOverSectioned(t *testing.T) {
+	noise := map[string][]string{
+		"body":         {"user.id"},
+		"body.user.id": {"^[0-9]+$"},
+		"header":       {"Date"},
+		"header.Date":  {"^Mon"},
+	}
+	for i := 0; i < 200; i++ {
+		body, header, _ := SplitNoise(noise, nil)
+		if got := body["user.id"]; len(got) != 1 || got[0] != "^[0-9]+$" {
+			t.Fatalf("iteration %d: bodyNoise[user.id] = %v, want the dotted entry's regex", i, got)
+		}
+		if got := header["date"]; len(got) != 1 || got[0] != "^Mon" {
+			t.Fatalf("iteration %d: headerNoise[date] = %v, want the dotted entry's regex", i, got)
+		}
+	}
+}
+
+func TestSplitNoise_SectionNamesAreCaseInsensitive(t *testing.T) {
+	body, header, skip := SplitNoise(map[string][]string{
+		"Body":        {"Stock"},
+		"Header.Date": {},
+	}, nil)
+	if _, ok := body["stock"]; !ok {
+		t.Errorf("bodyNoise = %v, want a lowercased \"stock\" entry", body)
+	}
+	if _, ok := header["date"]; !ok {
+		t.Errorf("headerNoise = %v, want a lowercased \"date\" entry", header)
+	}
+	if skip {
+		t.Errorf("skipBody = true, want false")
+	}
+}
+
+func TestCloneNoiseMap(t *testing.T) {
+	original := map[string][]string{"a": {"x"}}
+	clone := CloneNoiseMap(original)
+	clone["b"] = []string{"y"}
+	clone["a"][0] = "mutated"
+
+	if _, ok := original["b"]; ok {
+		t.Errorf("adding to the clone must not add to the original")
+	}
+	if original["a"][0] != "x" {
+		t.Errorf("mutating a cloned value slice must not touch the original, got %v", original["a"])
+	}
+	if got := CloneNoiseMap(nil); got == nil || len(got) != 0 {
+		t.Errorf("CloneNoiseMap(nil) = %v, want an empty non-nil map", got)
+	}
+}
+
+// TestJSONDiffWithNoiseControl_IndexedPathIsNotSupported pins a known gap that
+// this change deliberately does NOT paper over.
+//
+// The JSON walker never adds an array position to its keys — every element of
+// `items` is walked under the key "items" — so an index-free path works and an
+// indexed one matches nothing. Normalizing the indexed form by dropping numeric
+// segments looks obvious and is a trap: noise keys are matched with
+// strings.Contains, so "items.0.id" would collapse to "items.id", which is a
+// substring of "items.idempotency_key" and would silence it. That trades this
+// change's silent false negative for a wider one, so the indexed form is left
+// unmatched (loud) until the walker itself carries positions.
+func TestJSONDiffWithNoiseControl_IndexedPathIsNotSupported(t *testing.T) {
+	exp := `{"items":[{"product":{"name":"Laptop","stock":99}}]}`
+	act := `{"items":[{"product":{"name":"Laptop","stock":100}}]}`
+
+	t.Run("index-free path is honoured", func(t *testing.T) {
+		e, a := exp, act
+		v, err := ValidateAndMarshalJSON(zap.NewNop(), &e, &a)
+		if err != nil {
+			t.Fatalf("ValidateAndMarshalJSON: %v", err)
+		}
+		res, err := JSONDiffWithNoiseControl(v, map[string][]string{"items.product.stock": {}}, false)
+		if err != nil {
+			t.Fatalf("JSONDiffWithNoiseControl: %v", err)
+		}
+		if !res.IsExact() {
+			t.Errorf("expected match: items.product.stock is the walker's own key syntax")
+		}
+	})
+
+	t.Run("indexed path matches nothing", func(t *testing.T) {
+		e, a := exp, act
+		v, err := ValidateAndMarshalJSON(zap.NewNop(), &e, &a)
+		if err != nil {
+			t.Fatalf("ValidateAndMarshalJSON: %v", err)
+		}
+		res, err := JSONDiffWithNoiseControl(v, map[string][]string{"items.0.product.stock": {}}, false)
+		if err != nil {
+			t.Fatalf("JSONDiffWithNoiseControl: %v", err)
+		}
+		if res.IsExact() {
+			t.Errorf("indexed noise paths are not supported yet; if this now passes, " +
+				"the walker gained positions and the docs on SplitNoise need updating")
+		}
+	})
+
+	t.Run("no normalization leak into a sibling", func(t *testing.T) {
+		e := `{"items":[{"id":"1","idempotency_key":"k1"}]}`
+		a := `{"items":[{"id":"1","idempotency_key":"TAMPERED"}]}`
+		v, err := ValidateAndMarshalJSON(zap.NewNop(), &e, &a)
+		if err != nil {
+			t.Fatalf("ValidateAndMarshalJSON: %v", err)
+		}
+		res, err := JSONDiffWithNoiseControl(v, map[string][]string{"items.0.id": {}}, false)
+		if err != nil {
+			t.Fatalf("JSONDiffWithNoiseControl: %v", err)
+		}
+		if res.IsExact() {
+			t.Errorf("idempotency_key must not be silenced by a noise path for id")
+		}
+	})
+}
+
+// TestJSONDiffWithNoiseControl_NumericObjectKey pins that a genuinely numeric
+// object key stays scoped to itself and does not bleed into a same-named
+// sibling one level up.
+func TestJSONDiffWithNoiseControl_NumericObjectKey(t *testing.T) {
+	exp := `{"data":{"2026":{"count":5},"count":7}}`
+	act := `{"data":{"2026":{"count":5},"count":999}}`
+	v, err := ValidateAndMarshalJSON(zap.NewNop(), &exp, &act)
+	if err != nil {
+		t.Fatalf("ValidateAndMarshalJSON: %v", err)
+	}
+	res, err := JSONDiffWithNoiseControl(v, map[string][]string{"data.2026.count": {}}, false)
+	if err != nil {
+		t.Fatalf("JSONDiffWithNoiseControl: %v", err)
+	}
+	if res.IsExact() {
+		t.Errorf("data.count is a different field from data.2026.count and must still be compared")
+	}
+}
+
+// TestLooksLikeRegex pins the heuristic behind the sectioned-noise warning.
+// It must not flag OpenAPI/JSON-Schema document keys: telling a user to move
+// "$ref" into a regex position is worse than silence, because as a regex it
+// anchors to end-of-string and matches nothing.
+func TestLooksLikeRegex(t *testing.T) {
+	regexes := []string{
+		`^[0-9]+$`,
+		`^\d{4}-\d{2}-\d{2}$`,
+		`.*`,
+		`id-.+`,
+		`\w+`,
+		`(?i)abc`,
+		`PENDING|PAID`,
+		`[a-z]{3}`,
+		`value$`,
+	}
+	for _, v := range regexes {
+		if !looksLikeRegex(v) {
+			t.Errorf("looksLikeRegex(%q) = false, want true", v)
+		}
+	}
+
+	paths := []string{
+		"items.product.stock",
+		"user.id",
+		"created_at",
+		"components.schemas.User.$ref",
+		"$schema",
+		"$id",
+		"definitions.Foo.$id",
+		"data.2026.count",
+		"items.0.product.stock",
+		"X-Request-Id",
+		"a+b",
+		"arr[0]",
+	}
+	for _, v := range paths {
+		if looksLikeRegex(v) {
+			t.Errorf("looksLikeRegex(%q) = true, want false (it is a field path)", v)
+		}
+	}
+}
+
+// TestWarnIfRegexShaped_DedupesAcrossCalls pins that the warning does not fire
+// once per test case. SplitNoise is on the per-test-case path (twice per case on
+// the failure-assessment path), so an undeduped warning would bury real output.
+func TestWarnIfRegexShaped_DedupesAcrossCalls(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	logger := zap.New(core)
+
+	noise := map[string][]string{"body": {`^[0-9]+$`}}
+	for i := 0; i < 50; i++ {
+		SplitNoise(noise, logger)
+	}
+
+	if got := logs.Len(); got != 1 {
+		t.Errorf("emitted %d warnings across 50 calls, want exactly 1", got)
+	}
+}
+
+// TestSplitNoise_NoWarningForPlainPaths guards the common case from noise.
+func TestSplitNoise_NoWarningForPlainPaths(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	logger := zap.New(core)
+
+	SplitNoise(map[string][]string{
+		"body":   {"items.product.stock", "components.schemas.User.$ref"},
+		"header": {"X-Request-Id"},
+	}, logger)
+
+	if got := logs.Len(); got != 0 {
+		t.Errorf("emitted %d warnings for plain field paths, want 0: %v", got, logs.All())
 	}
 }

--- a/pkg/service/replay/body_noise_test.go
+++ b/pkg/service/replay/body_noise_test.go
@@ -1,0 +1,76 @@
+package replay
+
+import (
+	"testing"
+)
+
+// TestBodyNoiseForTestCase covers the schema-addition helper's share of the
+// sectioned-noise contract. It had no test before.
+func TestBodyNoiseForTestCase(t *testing.T) {
+	cases := []struct {
+		name     string
+		tcNoise  map[string][]string
+		global   map[string]map[string][]string
+		wantKeys []string
+	}{
+		{
+			name:     "dotted key is scoped to its path",
+			tcNoise:  map[string][]string{"body.user.id": {".*"}},
+			wantKeys: []string{"user.id"},
+		},
+		{
+			name:     "sectioned key lists paths rather than skipping the body",
+			tcNoise:  map[string][]string{"body": {"stock", "Total"}},
+			wantKeys: []string{"stock", "total"},
+		},
+		{
+			name:     "both shapes merge",
+			tcNoise:  map[string][]string{"body": {"stock"}, "body.created_at": {}},
+			wantKeys: []string{"stock", "created_at"},
+		},
+		{
+			name:     "empty sectioned key contributes nothing",
+			tcNoise:  map[string][]string{"body": {}},
+			wantKeys: nil,
+		},
+		{
+			name:     "header noise does not bleed into body noise",
+			tcNoise:  map[string][]string{"header": {"Date"}, "header.Etag": {}},
+			wantKeys: nil,
+		},
+		{
+			name:     "global body noise is preserved",
+			tcNoise:  map[string][]string{"body": {"stock"}},
+			global:   map[string]map[string][]string{"body": {"global_field": {}}},
+			wantKeys: []string{"stock", "global_field"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			global := tc.global
+			if global == nil {
+				global = map[string]map[string][]string{}
+			}
+			got := bodyNoiseForTestCase(tc.tcNoise, global)
+			if len(got) != len(tc.wantKeys) {
+				t.Fatalf("bodyNoise = %v, want keys %v", got, tc.wantKeys)
+			}
+			for _, k := range tc.wantKeys {
+				if _, ok := got[k]; !ok {
+					t.Errorf("bodyNoise = %v, missing key %q", got, k)
+				}
+			}
+		})
+	}
+}
+
+// TestBodyNoiseForTestCase_DoesNotMutateGlobal pins that the helper copies the
+// global config rather than widening it for the rest of the run.
+func TestBodyNoiseForTestCase_DoesNotMutateGlobal(t *testing.T) {
+	global := map[string]map[string][]string{"body": {}}
+	bodyNoiseForTestCase(map[string][]string{"body": {"stock"}, "body.total": {}}, global)
+	if len(global["body"]) != 0 {
+		t.Errorf("global noise config was mutated: %v", global["body"])
+	}
+}

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -2494,7 +2494,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 					}
 					streamBodyNoise := map[string][]string{}
 					if bodyNoise, ok := noiseConfig["body"]; ok {
-						streamBodyNoise = cloneNoiseMap(bodyNoise)
+						streamBodyNoise = matcherUtils.CloneNoiseMap(bodyNoise)
 					}
 					jsonNoiseKeys := pkg.CollectStreamingGlobalNoiseKeys(streamBodyNoise, tc.Noise)
 
@@ -3427,31 +3427,17 @@ func normalizePassingHTTPResult(result *models.Result) {
 }
 
 func bodyNoiseForTestCase(testCaseNoise map[string][]string, noiseConfig map[string]map[string][]string) map[string][]string {
-	bodyNoise := cloneNoiseMap(noiseConfig["body"])
+	bodyNoise := matcherUtils.CloneNoiseMap(noiseConfig["body"])
 
-	for field, regexArr := range testCaseNoise {
-		parts := strings.Split(field, ".")
-		if len(parts) <= 1 || parts[0] != "body" {
-			continue
-		}
-
-		bodyNoise[strings.ToLower(strings.Join(parts[1:], "."))] = append([]string(nil), regexArr...)
+	// nil logger on purpose: Match already ran SplitNoise for this same test
+	// case and emitted any warning, so passing one here would only duplicate it.
+	tcBodyNoise, _, _ := matcherUtils.SplitNoise(testCaseNoise, nil)
+	for field, regexArr := range tcBodyNoise {
+		// SplitNoise already returns freshly-allocated slices.
+		bodyNoise[field] = regexArr
 	}
 
 	return bodyNoise
-}
-
-func cloneNoiseMap(input map[string][]string) map[string][]string {
-	if len(input) == 0 {
-		return map[string][]string{}
-	}
-
-	out := make(map[string][]string, len(input))
-	for key, values := range input {
-		out[key] = append([]string(nil), values...)
-	}
-
-	return out
 }
 
 func (r *Replayer) CompareGRPCResp(tc *models.TestCase, actualResp *models.GrpcResp, testSetID string, emitFailureLogs bool) (bool, *models.Result) {


### PR DESCRIPTION
## The bug

A test case's `noise` map accepts two key shapes:

```yaml
noise:
  body:                          # sectioned
    - items.0.product.stock
  body.created_at: []            # dotted
  header:                        # sectioned
    - Content-Length
  header.Date: []                # dotted
```

Only the dotted shape was parsed. A sectioned key fell through both branches of the split loop and then tripped `Contains(MapToArray(noise), "body")` — the sentinel for **ignore the entire response body**. The listed paths were never registered as noise, and every field in the body stopped being compared. `header: [<names>]` did the same to every response header.

The result is a silent false negative: a test case carrying a sectioned noise entry passes no matter what the service returns.

### How it shows up

Replaying a deliberately tampered downstream mock through such a test case reports `PASSED`, while the report file it writes records an expected/actual body differing in four fields:

```
STATUS       : PASSED
body_result  :
  normal   : True                                    ← the verdict
  expected : ..."name":"Laptop","price":1200..."alice_1785918170"...
  actual   : ..."name":"Tablet","price":1999..."zzzzz_1785918170"...
```

On one real recorded app, **45 of 94 test cases (47%)** had a dead body assertion and 20 also had dead header assertions. The paths responsible are exactly what noisy-field detection emits — `requestId`, `timestamp`, `id`, `uptime.*`, `randomData.*` — so the cases that most needed calibration are the ones silently gutted. `/health` and `/stats` became liveness checks that would pass if the handler returned `{}`.

## The fix

Disambiguate on the **value**, not the key:

- bare section key + **empty** list → ignore the whole section (this is what a global `body: {"*": ["*"]}` config expands to; unchanged)
- bare section key + **non-empty** list → those are the field paths to ignore

The four duplicated copies of the split loop (`http/match.go`, `http/absmatch.go`, `grpc/match.go`, `replay.go`) now share `SplitNoise`.

Three further defects surfaced while fixing this and are included:

- **The wildcard sentinel was recorded by writing into `tc.Noise`.** That mutated the caller's test case, panicked when `tc.Noise` was nil, and — because `buildHTTPSchema` serializes `tc.Noise` back out — could be **persisted to disk** by a later re-encode, permanently skipping that case's body even after the wildcard config was removed. The wildcard is now tracked locally.
- **Test-case noise was merged into the caller's global noise config in place**, so one case permanently widened the noise applied to every later case in the run. The gRPC path receives that long-lived config with no copy at all. Now merged into a clone.
- **Sectioned values are read as paths, not regexes.** A regex there was never evaluated — it only tripped the whole-section skip — so a regex-shaped value now warns once, naming the dotted form that does apply one.

## Deliberately not done: array-index normalization

Indexed paths like `items.0.product.stock` still match nothing, because the JSON walker keys array elements without a position (`items.product.stock`).

Normalizing by dropping numeric segments looks obvious and is a trap: noise keys are matched with `strings.Contains`, so `items.0.id` collapses to `items.id`, which is a substring of `items.idempotency_key` and silences it. That trades this PR's silent false negative for a wider one. Verified, so it is left unmatched — **loud** — and pinned by `TestJSONDiffWithNoiseControl_IndexedPathIsNotSupported` with a message telling the next person what to update if the walker ever carries positions.

`buildNoiseIndex` is byte-identical to `main`; `pkg/matcher/utils.go` is a pure insertion with no existing logic touched.

## Tests

~1,140 of the 1,303 added lines are tests. Three of the four changed packages have tests that fail on `main` and pass here; `pkg/matcher` is green on `main` by construction, since `utils.go` adds new functions with no behavioral delta.

- `pkg/matcher/http/absmatch_test.go` and `pkg/matcher/grpc/noise_test.go` are **new files** — neither call site had any noise coverage, and gRPC is where the shared-config leak was worst.
- `pkg/matcher/http/decode_test.go` runs a recorded YAML through `testdb.Decode` and then `Match`, and asserts the decoder really emits the sectioned shape so the fixture cannot silently stop covering the bug.
- `pkg/service/replay/body_noise_test.go` covers `bodyNoiseForTestCase`, previously untested.

`go build ./...`, `go test ./... -count=1`, `gofmt -l pkg/`, `go vet ./pkg/...` all clean.

## Upgrade impact — worth release notes

Suites that were green **only** because of the whole-section skip will start reporting the differences they were hiding. Every such failure is a real, previously-hidden difference rather than a new false positive, but users will experience it as a break, so it should be called out.

Two narrower cases:

- A sectioned value written as a regex is now read as a path. It silenced the whole section before and silences nothing now; the warning names the dotted equivalent.
- A test case whose only noise is an indexed path will now fail on that field. It was never actually matching — the whole-section skip was hiding it.

## Follow-up (separate issue)

`matchJSONWithNoiseHandlingIndexed`'s `case string:` does `if e == a || noisy` **after** the regex check, so a regex-guarded noise entry whose regex does not match is still marked as matching. `{"order.status": ["^(PENDING|PAID)$"]}` passes `PENDING` vs `GARBAGE`. Every regex-constrained noise entry is effectively an unconditional skip. Filed separately — same silent-false-negative family, different blast radius.
