### PR TITLE
fix(matcher): enforce regex-constrained noise instead of skipping the field

### DIFF
--- a/pkg/matcher/noise_regex_test.go
+++ b/pkg/matcher/noise_regex_test.go
@@ -1,0 +1,487 @@
+package matcher
+
+import (
+	"encoding/json"
+	"math"
+	"regexp"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// diffNoise is a small helper: compare two JSON documents under a noise map and
+// report whether the matcher considered them equal.
+func diffNoise(t *testing.T, expected, actual string, noise map[string][]string) bool {
+	t.Helper()
+	e, a := expected, actual
+	v, err := ValidateAndMarshalJSON(zap.NewNop(), &e, &a)
+	if err != nil {
+		t.Fatalf("ValidateAndMarshalJSON: %v", err)
+	}
+	res, err := JSONDiffWithNoiseControl(v, noise, false)
+	if err != nil {
+		t.Fatalf("JSONDiffWithNoiseControl: %v", err)
+	}
+	return res.IsExact()
+}
+
+// TestRegexNoise_EnforcesPattern pins the contract of a regex-guarded noise
+// entry: the field is ignored ONLY when the replayed value matches one of the
+// patterns. A value outside the pattern is a real difference.
+//
+// Previously the regex was decorative — a failed match fell through to
+// `if e == a || noisy`, where noisy was still true, so the field was accepted
+// anyway. Every regex-constrained noise entry was an unconditional skip, which
+// is the opposite of what the pattern says.
+func TestRegexNoise_EnforcesPattern(t *testing.T) {
+	cases := []struct {
+		name     string
+		expected string
+		actual   string
+		noise    map[string][]string
+		want     bool
+	}{
+		{
+			name:     "string: value inside the pattern is ignored",
+			expected: `{"order":{"status":"PENDING"}}`,
+			actual:   `{"order":{"status":"PAID"}}`,
+			noise:    map[string][]string{"order.status": {"^(PENDING|PAID)$"}},
+			want:     true,
+		},
+		{
+			name:     "string: value outside the pattern is a real difference",
+			expected: `{"order":{"status":"PENDING"}}`,
+			actual:   `{"order":{"status":"GARBAGE"}}`,
+			noise:    map[string][]string{"order.status": {"^(PENDING|PAID)$"}},
+			want:     false,
+		},
+		{
+			name:     "string: identical values still match even outside the pattern",
+			expected: `{"order":{"status":"GARBAGE"}}`,
+			actual:   `{"order":{"status":"GARBAGE"}}`,
+			noise:    map[string][]string{"order.status": {"^(PENDING|PAID)$"}},
+			want:     true,
+		},
+		{
+			name:     "string: an empty regex list still ignores unconditionally",
+			expected: `{"order":{"status":"PENDING"}}`,
+			actual:   `{"order":{"status":"GARBAGE"}}`,
+			noise:    map[string][]string{"order.status": {}},
+			want:     true,
+		},
+		{
+			name:     "number: value inside the pattern is ignored",
+			expected: `{"order":{"total":1200}}`,
+			actual:   `{"order":{"total":1250}}`,
+			noise:    map[string][]string{"order.total": {`^12\d\d$`}},
+			want:     true,
+		},
+		{
+			name:     "number: value outside the pattern is a real difference",
+			expected: `{"order":{"total":1200}}`,
+			actual:   `{"order":{"total":99999}}`,
+			noise:    map[string][]string{"order.total": {`^12\d\d$`}},
+			want:     false,
+		},
+		{
+			name:     "number: an empty regex list still ignores unconditionally",
+			expected: `{"order":{"total":1200}}`,
+			actual:   `{"order":{"total":99999}}`,
+			noise:    map[string][]string{"order.total": {}},
+			want:     true,
+		},
+		{
+			name:     "number: fractional values compare in their JSON form",
+			expected: `{"order":{"rate":12.5}}`,
+			actual:   `{"order":{"rate":12.75}}`,
+			noise:    map[string][]string{"order.rate": {`^12\.\d+$`}},
+			want:     true,
+		},
+		{
+			name:     "bool: value inside the pattern is ignored",
+			expected: `{"order":{"paid":true}}`,
+			actual:   `{"order":{"paid":false}}`,
+			noise:    map[string][]string{"order.paid": {"^(true|false)$"}},
+			want:     true,
+		},
+		{
+			name:     "bool: value outside the pattern is a real difference",
+			expected: `{"order":{"paid":true}}`,
+			actual:   `{"order":{"paid":false}}`,
+			noise:    map[string][]string{"order.paid": {"^true$"}},
+			want:     false,
+		},
+		{
+			name:     "bool: an empty regex list still ignores unconditionally",
+			expected: `{"order":{"paid":true}}`,
+			actual:   `{"order":{"paid":false}}`,
+			noise:    map[string][]string{"order.paid": {}},
+			want:     true,
+		},
+		{
+			name:     "several patterns: matching any one of them ignores the field",
+			expected: `{"order":{"status":"PENDING"}}`,
+			actual:   `{"order":{"status":"SHIPPED"}}`,
+			noise:    map[string][]string{"order.status": {"^PAID$", "^SHIPPED$"}},
+			want:     true,
+		},
+		{
+			name:     "several patterns: matching none of them is a real difference",
+			expected: `{"order":{"status":"PENDING"}}`,
+			actual:   `{"order":{"status":"CANCELLED"}}`,
+			noise:    map[string][]string{"order.status": {"^PAID$", "^SHIPPED$"}},
+			want:     false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := diffNoise(t, c.expected, c.actual, c.noise); got != c.want {
+				t.Errorf("IsExact() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestRegexNoise_DoesNotLeakToSiblings pins that enforcing the pattern does not
+// change which fields the entry applies to.
+func TestRegexNoise_DoesNotLeakToSiblings(t *testing.T) {
+	expected := `{"order":{"status":"PENDING","note":"hello"}}`
+	actual := `{"order":{"status":"PAID","note":"TAMPERED"}}`
+	noise := map[string][]string{"order.status": {"^(PENDING|PAID)$"}}
+
+	if diffNoise(t, expected, actual, noise) {
+		t.Errorf("note is not covered by the noise entry and must still be compared")
+	}
+}
+
+// TestRegexNoise_UnparseableRegexDoesNotSilenceTheField guards the failure mode
+// of a typo'd pattern. getCompiled falls back to a regexp that matches nothing,
+// so the field must be compared normally rather than silently skipped.
+func TestRegexNoise_UnparseableRegexDoesNotSilenceTheField(t *testing.T) {
+	noise := map[string][]string{"order.status": {"^(unclosed"}}
+
+	if diffNoise(t, `{"order":{"status":"PENDING"}}`, `{"order":{"status":"GARBAGE"}}`, noise) {
+		t.Errorf("an invalid pattern must not silence the field")
+	}
+	if !diffNoise(t, `{"order":{"status":"PENDING"}}`, `{"order":{"status":"PENDING"}}`, noise) {
+		t.Errorf("identical values must still match when the pattern is invalid")
+	}
+}
+
+// TestGetCompiled_InvalidPatternNeverReturnsNil is the regression test for a
+// crash: the "never matches" fallback used to be `(?!)`, a negative lookahead
+// that Go's RE2 engine rejects, so getCompiled cached a nil *regexp.Regexp and
+// the first noise comparison against it dereferenced nil. A typo in a noise
+// pattern took the whole run down with a SIGSEGV.
+func TestGetCompiled_InvalidPatternNeverReturnsNil(t *testing.T) {
+	for _, pattern := range []string{
+		`^(unclosed`,
+		`(?!)`,      // the old fallback itself
+		`(?<=look)`, // lookbehind, unsupported by RE2
+		`a{2,1}`,    // invalid repetition
+		`[z-a]`,     // invalid character range
+	} {
+		re := getCompiled(pattern)
+		if re == nil {
+			t.Fatalf("getCompiled(%q) = nil, want a non-nil never-matching regex", pattern)
+		}
+		// Must not panic, and must not match anything.
+		for _, s := range []string{"", "abc", "look", "aa"} {
+			if re.MatchString(s) {
+				t.Errorf("getCompiled(%q).MatchString(%q) = true, want false", pattern, s)
+			}
+		}
+	}
+}
+
+// TestGetCompiled_ValidPatternStillWorks guards the happy path and the cache.
+func TestGetCompiled_ValidPatternStillWorks(t *testing.T) {
+	re := getCompiled(`^ord-\d+$`)
+	if re == nil {
+		t.Fatal("getCompiled returned nil for a valid pattern")
+	}
+	if !re.MatchString("ord-42") || re.MatchString("ord-x") {
+		t.Errorf("compiled pattern does not behave as written")
+	}
+	// Second call comes from the cache and must be equivalent.
+	if again := getCompiled(`^ord-\d+$`); again != re {
+		t.Errorf("expected the cached instance on the second call")
+	}
+}
+
+// TestAnyRegexpMatchStr_ToleratesNilEntries is defence in depth: even if some
+// future path puts a nil into the list, matching must not crash.
+func TestAnyRegexpMatchStr_ToleratesNilEntries(t *testing.T) {
+	if anyRegexpMatchStr("abc", []*regexp.Regexp{nil}) {
+		t.Errorf("a nil pattern must not report a match")
+	}
+	if !anyRegexpMatchStr("abc", []*regexp.Regexp{nil, regexp.MustCompile(`^abc$`)}) {
+		t.Errorf("a valid pattern after a nil must still be evaluated")
+	}
+}
+
+// TestRegexNoise_GlobalKeyEnforcesPattern covers the shape most users actually
+// write. A noise key with no dot is a "global" key, ignored at any depth — and
+// it is what `body.status` becomes once http.Match strips the `body.` prefix.
+// Its patterns used to be discarded outright when the key was classified, so
+// enforcing them on the path-based branch alone left the common case unfixed.
+func TestRegexNoise_GlobalKeyEnforcesPattern(t *testing.T) {
+	cases := []struct {
+		name     string
+		expected string
+		actual   string
+		noise    map[string][]string
+		want     bool
+	}{
+		{
+			name:     "top level, value inside the pattern",
+			expected: `{"status":"PENDING"}`,
+			actual:   `{"status":"PAID"}`,
+			noise:    map[string][]string{"status": {"^(PENDING|PAID)$"}},
+			want:     true,
+		},
+		{
+			name:     "top level, value outside the pattern",
+			expected: `{"status":"PENDING"}`,
+			actual:   `{"status":"GARBAGE"}`,
+			noise:    map[string][]string{"status": {"^(PENDING|PAID)$"}},
+			want:     false,
+		},
+		{
+			name:     "nested, value outside the pattern",
+			expected: `{"order":{"status":"PENDING"}}`,
+			actual:   `{"order":{"status":"GARBAGE"}}`,
+			noise:    map[string][]string{"status": {"^(PENDING|PAID)$"}},
+			want:     false,
+		},
+		{
+			name:     "empty pattern list still ignores everywhere",
+			expected: `{"order":{"status":"PENDING"}}`,
+			actual:   `{"order":{"status":"GARBAGE"}}`,
+			noise:    map[string][]string{"status": {}},
+			want:     true,
+		},
+		{
+			name:     "number leaf under a global key",
+			expected: `{"total":1200}`,
+			actual:   `{"total":99999}`,
+			noise:    map[string][]string{"total": {`^12\d\d$`}},
+			want:     false,
+		},
+		{
+			name:     "unexpected extra key is excused only when it matches",
+			expected: `{"a":1}`,
+			actual:   `{"a":1,"status":"GARBAGE"}`,
+			noise:    map[string][]string{"status": {"^PAID$"}},
+			want:     false,
+		},
+		{
+			name:     "unexpected extra key matching the pattern is excused",
+			expected: `{"a":1}`,
+			actual:   `{"a":1,"status":"PAID"}`,
+			noise:    map[string][]string{"status": {"^PAID$"}},
+			want:     true,
+		},
+		{
+			// No value to match, so the entry covers it — the same rule applied
+			// to a container, and what this did before patterns were enforced.
+			name:     "a missing key is excused by a pattern-guarded entry",
+			expected: `{"a":1,"status":"PAID"}`,
+			actual:   `{"a":1}`,
+			noise:    map[string][]string{"status": {"^PAID$"}},
+			want:     true,
+		},
+		{
+			name:     "a missing key is excused by an empty pattern list",
+			expected: `{"a":1,"status":"PAID"}`,
+			actual:   `{"a":1}`,
+			noise:    map[string][]string{"status": {}},
+			want:     true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := diffNoise(t, c.expected, c.actual, c.noise); got != c.want {
+				t.Errorf("IsExact() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestRegexNoise_ContainerPathRelaxesLeafValues pins that a pattern on an object
+// path relaxes the VALUES beneath it. A pattern describes one scalar, so
+// applying it to every descendant would fail fields it was never written for.
+// The subtree is not wholly ignored though — see
+// TestRegexNoise_ContainerPathStillChecksStructure.
+func TestRegexNoise_ContainerPathRelaxesLeafValues(t *testing.T) {
+	expected := `{"user":{"session":{"token":"abcdef01","expiresAt":1700000000}}}`
+	actual := `{"user":{"session":{"token":"ffffffff","expiresAt":1799999999}}}`
+
+	if !diffNoise(t, expected, actual, map[string][]string{"user.session": {"^[a-f0-9]{8}$"}}) {
+		t.Errorf("a pattern on a container path must relax the values beneath it")
+	}
+	// A sibling outside the guarded subtree is unaffected.
+	exp2 := `{"user":{"session":{"token":"abcdef01"},"name":"alice"}}`
+	act2 := `{"user":{"session":{"token":"ffffffff"},"name":"TAMPERED"}}`
+	if diffNoise(t, exp2, act2, map[string][]string{"user.session": {"^[a-f0-9]{8}$"}}) {
+		t.Errorf("name is outside the guarded subtree and must still be compared")
+	}
+}
+
+// TestRegexNoise_ContainerPathStillChecksStructure pins that relaxing the VALUES
+// under a pattern-guarded container does not also stop checking its SHAPE. A key
+// removed, added or retyped inside is a schema change, not a volatile value, and
+// a pattern was never a request to ignore it. Only an empty pattern list — which
+// has always meant "ignore this subtree" — hides structure.
+func TestRegexNoise_ContainerPathStillChecksStructure(t *testing.T) {
+	guarded := map[string][]string{"user.session": {"^[a-f0-9]+$"}}
+	unconditional := map[string][]string{"user.session": {}}
+
+	cases := []struct {
+		name     string
+		expected string
+		actual   string
+	}{
+		{
+			name:     "key missing inside the guarded subtree",
+			expected: `{"user":{"session":{"token":"abcd","kind":"bearer"}}}`,
+			actual:   `{"user":{"session":{"token":"abcd"}}}`,
+		},
+		{
+			name:     "extra key inside the guarded subtree",
+			expected: `{"user":{"session":{"token":"abcd"}}}`,
+			actual:   `{"user":{"session":{"token":"abcd","injected":"x"}}}`,
+		},
+		{
+			name:     "scalar retyped to an object inside the guarded subtree",
+			expected: `{"user":{"session":{"token":"abcd"}}}`,
+			actual:   `{"user":{"session":{"token":{"evil":true}}}}`,
+		},
+		{
+			name:     "array length change under the guarded path",
+			expected: `{"user":{"session":["abcd","ef01"]}}`,
+			actual:   `{"user":{"session":["abcd"]}}`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if diffNoise(t, c.expected, c.actual, guarded) {
+				t.Errorf("a pattern must not hide a structural change")
+			}
+			if !diffNoise(t, c.expected, c.actual, unconditional) {
+				t.Errorf("an empty pattern list must still ignore the whole subtree")
+			}
+		})
+	}
+}
+
+// TestRegexNoise_ScalarRetypedToContainerIsReported is the direct regression for
+// a hole an earlier revision of this fix introduced: skipping a pattern-guarded
+// child whenever the REPLAYED value was a container meant a scalar swapped for
+// an object or array passed silently.
+func TestRegexNoise_ScalarRetypedToContainerIsReported(t *testing.T) {
+	noise := map[string][]string{"order.id": {`^ord-\d+$`}}
+	for _, actual := range []string{
+		`{"order":{"id":{"evil":true}}}`,
+		`{"order":{"id":["evil"]}}`,
+	} {
+		if diffNoise(t, `{"order":{"id":"ord-1"}}`, actual, noise) {
+			t.Errorf("a scalar replaced by a container must be reported, got a match for %s", actual)
+		}
+	}
+}
+
+// TestFormatJSONNumber matches encoding/json's own float rendering, so a
+// pattern written against the value Keploy prints in its diff matches at
+// replay. Plain 'f' formatting diverges at both extremes.
+func TestFormatJSONNumber(t *testing.T) {
+	for _, c := range []struct{ in float64 }{
+		{1200}, {1200.5}, {100.10}, {0}, {math.Copysign(0, -1)}, {-12.75},
+		{1e21}, {1e-7}, {5e-324}, {1e20}, {1e-6}, {123456789012345680000},
+	} {
+		want, err := json.Marshal(c.in)
+		if err != nil {
+			t.Fatalf("json.Marshal(%v): %v", c.in, err)
+		}
+		if got := formatJSONNumber(c.in); got != string(want) {
+			t.Errorf("formatJSONNumber(%v) = %q, encoding/json renders %q", c.in, got, want)
+		}
+	}
+}
+
+// TestRegexNoise_OverlappingEntriesAreDeterministic pins that two noise entries
+// whose paths overlap produce the same verdict on every run.
+//
+// noiseIndex.match returns the first matching entry, and buildNoiseIndex used to
+// append them in Go map order, which is randomized per process. That was
+// invisible while every entry meant "ignore unconditionally"; once patterns
+// decide the verdict it made a suite flip green/red between runs with no input
+// change. Entries are now ordered most-specific first.
+func TestRegexNoise_OverlappingEntriesAreDeterministic(t *testing.T) {
+	cases := []struct {
+		name  string
+		noise map[string][]string
+	}{
+		{"specific unconditional, general guarded", map[string][]string{"user.id": {`^\d+$`}, "order.user.id": {}}},
+		{"both guarded", map[string][]string{"user.id": {`^\d+$`}, "order.user.id": {`^u-\d+$`}}},
+		{"three overlapping", map[string][]string{"id": {`^\d+$`}, "user.id": {}, "order.user.id": {`^u-\d+$`}}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			first := diffNoise(t, `{"order":{"user":{"id":"u-1"}}}`, `{"order":{"user":{"id":"u-2"}}}`, c.noise)
+			for i := 0; i < 300; i++ {
+				if got := diffNoise(t, `{"order":{"user":{"id":"u-1"}}}`, `{"order":{"user":{"id":"u-2"}}}`, c.noise); got != first {
+					t.Fatalf("verdict flipped between runs (%v then %v) — entry order is not deterministic", first, got)
+				}
+			}
+		})
+	}
+}
+
+// TestRegexNoise_MostSpecificEntryWins pins which of two overlapping entries is
+// chosen, so the ordering is a documented contract rather than an accident.
+func TestRegexNoise_MostSpecificEntryWins(t *testing.T) {
+	// The longer path is the one the user meant for this field: it says the id
+	// looks like "u-<n>", so a value of that shape is ignored...
+	noise := map[string][]string{"id": {`^\d+$`}, "order.user.id": {`^u-\d+$`}}
+	if !diffNoise(t, `{"order":{"user":{"id":"u-1"}}}`, `{"order":{"user":{"id":"u-2"}}}`, noise) {
+		t.Errorf("the more specific entry should have matched and ignored this value")
+	}
+	// ...and a value outside it is still a real difference, rather than being
+	// rescued by the shorter, more general entry.
+	if diffNoise(t, `{"order":{"user":{"id":"u-1"}}}`, `{"order":{"user":{"id":"XXX"}}}`, noise) {
+		t.Errorf("a value outside the more specific entry's pattern must be reported")
+	}
+}
+
+// TestRegexNoise_ArrayOfScalarsEnforcesPattern covers the one container where a
+// pattern is unambiguous: `ids: ["^ord-\d+$"]` plainly means every id looks like
+// that, so it is applied per element.
+func TestRegexNoise_ArrayOfScalarsEnforcesPattern(t *testing.T) {
+	noise := map[string][]string{"order.ids": {`^ord-\d+$`}}
+
+	if !diffNoise(t, `{"order":{"ids":["ord-1","ord-2"]}}`, `{"order":{"ids":["ord-7","ord-9"]}}`, noise) {
+		t.Errorf("every element matches the pattern, so the array should be ignored")
+	}
+	if diffNoise(t, `{"order":{"ids":["ord-1","ord-2"]}}`, `{"order":{"ids":["ord-7","HACK"]}}`, noise) {
+		t.Errorf("an element outside the pattern must be reported")
+	}
+	// An empty pattern list keeps ignoring the array wholesale.
+	if !diffNoise(t, `{"order":{"ids":["ord-1"]}}`, `{"order":{"ids":["HACK"]}}`, map[string][]string{"order.ids": {}}) {
+		t.Errorf("an empty pattern list must still ignore the whole array")
+	}
+	// A length change is structural and is still reported.
+	if diffNoise(t, `{"order":{"ids":["ord-1","ord-2"]}}`, `{"order":{"ids":["ord-1"]}}`, noise) {
+		t.Errorf("an array length change must be reported")
+	}
+	// An array of objects has no single value for the pattern to describe, so it
+	// falls back to relaxing the element values, as a map does.
+	nested := map[string][]string{"order.items": {`^ord-\d+$`}}
+	if !diffNoise(t, `{"order":{"items":[{"id":"ord-1"}]}}`, `{"order":{"items":[{"id":"HACK"}]}}`, nested) {
+		t.Errorf("a non-scalar array relaxes its values rather than applying the pattern per element")
+	}
+}

--- a/pkg/matcher/utils.go
+++ b/pkg/matcher/utils.go
@@ -8,11 +8,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"mime"
 	"net/http"
 	"os"
 	"reflect"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -32,10 +34,13 @@ import (
 var (
 	regexCacheMu sync.RWMutex
 	regexCache   = make(map[string]*regexp.Regexp)
+	// neverMatches matches no input at all, not even the empty string.
+	neverMatches = regexp.MustCompile(`[^\s\S]`)
 )
 
 // getCompiled returns a cached compiled regexp for pattern.
-// It never panics: on invalid patterns, it returns a "never matches" regex (?!) and caches it.
+// It never panics and never returns nil: on invalid patterns it returns a
+// "never matches" regex and caches it.
 func getCompiled(pattern string) *regexp.Regexp {
 	regexCacheMu.RLock()
 	re := regexCache[pattern]
@@ -47,8 +52,13 @@ func getCompiled(pattern string) *regexp.Regexp {
 	// Compile outside the read lock.
 	compiled, err := regexp.Compile(pattern)
 	if err != nil {
-		// Fallback to a regex that never matches to avoid panics / repeated compiles
-		compiled, _ = regexp.Compile(`(?!)`)
+		// Fall back to a regex that never matches, to avoid repeated compiles of
+		// a pattern that will never work. It must be a pattern RE2 accepts:
+		// `(?!)` is a negative lookahead, which Go's regexp rejects, so the
+		// fallback used to leave `compiled` nil and every user of it dereferenced
+		// nil. `[^\s\S]` asks for a character that is neither whitespace nor
+		// non-whitespace, so it matches nothing at all — not even the empty string.
+		compiled = neverMatches
 	}
 
 	regexCacheMu.Lock()
@@ -85,15 +95,25 @@ func buildNoiseIndex(mp map[string][]string) noiseIndex {
 	}
 	out := noiseIndex{entries: make([]noiseEntry, 0, len(mp))}
 	for k, arr := range mp {
-		e := noiseEntry{keyLower: strings.ToLower(k)}
-		if len(arr) > 0 {
-			e.regexps = make([]*regexp.Regexp, 0, len(arr))
-			for _, p := range arr {
-				e.regexps = append(e.regexps, getCompiled(p))
-			}
-		}
-		out.entries = append(out.entries, e)
+		out.entries = append(out.entries, noiseEntry{
+			keyLower: strings.ToLower(k),
+			regexps:  compilePatterns(arr),
+		})
 	}
+
+	// match() returns the FIRST entry that matches, and entries arrive here in
+	// Go map order, which is randomized per process. That was invisible while
+	// every entry meant the same thing (ignore unconditionally); now that an
+	// entry's patterns decide the verdict, two overlapping entries would make a
+	// test pass or fail depending on the run. Order most-specific first so the
+	// winner is both deterministic and the one a user writing "user.id" and
+	// "order.user.id" would expect.
+	sort.Slice(out.entries, func(i, j int) bool {
+		if len(out.entries[i].keyLower) != len(out.entries[j].keyLower) {
+			return len(out.entries[i].keyLower) > len(out.entries[j].keyLower)
+		}
+		return out.entries[i].keyLower < out.entries[j].keyLower
+	})
 	return out
 }
 
@@ -111,12 +131,16 @@ func (ni noiseIndex) match(keyLower string) (regs []*regexp.Regexp, isNoisy bool
 func JSONDiffWithNoiseControl(validatedJSON ValidatedJSON, noise map[string][]string, ignoreOrdering bool) (JSONComparisonResult, error) {
 	// Split noise into Path-based (contains dots) and Global (no dots)
 	pathNoise := make(map[string][]string)
-	globalKeys := make(map[string]bool)
+	globalKeys := make(map[string][]*regexp.Regexp)
 
 	for k, v := range noise {
 		// If a key has no dots, treat it as a Global Key to be ignored everywhere.
+		// Its patterns are carried through: a global key is by far the most common
+		// shape (http.Match strips the "body." prefix, so "body.status" arrives
+		// here as the dot-free "status"), and dropping them here would leave every
+		// such entry an unconditional skip no matter what the caller wrote.
 		if !strings.Contains(k, ".") {
-			globalKeys[strings.ToLower(k)] = true
+			globalKeys[strings.ToLower(k)] = compilePatterns(v)
 		} else {
 			// Otherwise, it's a path-specific noise (e.g. "body.data.timestamp")
 			pathNoise[k] = v
@@ -124,11 +148,11 @@ func JSONDiffWithNoiseControl(validatedJSON ValidatedJSON, noise map[string][]st
 	}
 
 	idx := buildNoiseIndex(pathNoise)
-	return matchJSONWithNoiseHandlingIndexed("", validatedJSON.expected, validatedJSON.actual, idx, globalKeys, ignoreOrdering)
+	return matchJSONWithNoiseHandlingIndexed("", validatedJSON.expected, validatedJSON.actual, idx, globalKeys, ignoreOrdering, false)
 }
 
 // matchJSONWithNoiseHandlingIndexed now accepts globalKeys to skip specific keys at any depth.
-func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{}, ni noiseIndex, globalKeys map[string]bool, ignoreOrdering bool) (JSONComparisonResult, error) {
+func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{}, ni noiseIndex, globalKeys map[string][]*regexp.Regexp, ignoreOrdering bool, ancestorNoisy bool) (JSONComparisonResult, error) {
 	var out JSONComparisonResult
 	// Type check fast-path (JSON unmarshal produces these concrete types).
 	switch e := expected.(type) {
@@ -143,14 +167,7 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 		if !ok {
 			return out, errors.New("type not matched")
 		}
-		regs, noisy := ni.match(strings.ToLower(key))
-		if noisy && len(regs) != 0 {
-			if anyRegexpMatchStr(a, regs) {
-				out.matches, out.isExact = true, true
-				return out, nil
-			}
-		}
-		if e == a || noisy {
+		if e == a || ancestorNoisy || noisyForValue(ni, key, a) {
 			out.matches, out.isExact = true, true
 		}
 		return out, nil
@@ -160,8 +177,7 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 		if !ok {
 			return out, errors.New("type not matched")
 		}
-		_, noisy := ni.match(strings.ToLower(key))
-		if e == a || noisy {
+		if e == a || ancestorNoisy || noisyForValue(ni, key, strconv.FormatBool(a)) {
 			out.matches, out.isExact = true, true
 		}
 		return out, nil
@@ -171,8 +187,7 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 		if !ok {
 			return out, errors.New("type not matched")
 		}
-		_, noisy := ni.match(strings.ToLower(key))
-		if e == a || noisy {
+		if e == a || ancestorNoisy || noisyForValue(ni, key, formatJSONNumber(a)) {
 			out.matches, out.isExact = true, true
 		}
 		return out, nil
@@ -183,11 +198,17 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 			return out, errors.New("type not matched")
 		}
 
-		// If whole subtree is noisy (no regex guard), accept.
-		if regs, noisy := ni.match(strings.ToLower(key)); noisy && len(regs) == 0 {
+		// An entry with no patterns ignores the whole subtree, structure included.
+		regs, noisy := ni.match(strings.ToLower(key))
+		if noisy && len(regs) == 0 {
 			out.matches, out.isExact = true, true
 			return out, nil
 		}
+		// A pattern describes one scalar, so there is nothing here for it to
+		// match. Keep walking the structure — a key added, removed or retyped
+		// inside is still a real change — and let the descendant leaf VALUES be
+		// accepted, which is the most the pattern could have been asking for.
+		ancestorNoisy = ancestorNoisy || noisy
 
 		// Quick length check — allows early exit if extra/missing keys (ignoring noisy children).
 		// We still need to walk to account for noisy exclusions; so we won't return solely on len.
@@ -202,22 +223,33 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 
 		// 1) All expected keys must be present & match.
 		for k, v := range e {
-			if globalKeys[strings.ToLower(k)] {
+			val, ok := a[k]
+			if !ok {
+				// The replay dropped a key the recording had. There is no value
+				// for a pattern to match, so the entry covers it — the same rule
+				// noisyForRegexps applies to a container, and what this did
+				// before patterns were enforced at all.
+				if _, isGlobal := globalKeys[strings.ToLower(k)]; isGlobal {
+					continue
+				}
+				return out, nil
+			}
+
+			if regs, isGlobal := globalKeys[strings.ToLower(k)]; isGlobal && noisyForRegexps(regs, val) {
 				continue
 			}
 
-			val, ok := a[k]
-			if !ok {
-				return out, nil
-			}
 			childKeyLower := prefixLower + strings.ToLower(k)
 
-			// If child subtree is entirely noisy via path, skip deep compare.
+			// If the child subtree is entirely noisy via path, skip deep compare.
+			// A pattern-guarded child is NOT skipped here: it is walked so the
+			// pattern reaches the scalars, and so that a scalar replaced by an
+			// object or array is still reported.
 			if regs, noisy := ni.match(childKeyLower); noisy && len(regs) == 0 {
 				continue
 			}
 
-			res, err := matchJSONWithNoiseHandlingIndexed(prefix+k, v, val, ni, globalKeys, ignoreOrdering)
+			res, err := matchJSONWithNoiseHandlingIndexed(prefix+k, v, val, ni, globalKeys, ignoreOrdering, ancestorNoisy)
 			if err != nil || !res.matches {
 				return out, nil
 			}
@@ -230,11 +262,10 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 
 		// 2) No unexpected non-noisy keys in actual.
 		for k := range a {
-			if globalKeys[strings.ToLower(k)] {
+			if _, ok := e[k]; ok {
 				continue
 			}
-
-			if _, ok := e[k]; ok {
+			if regs, isGlobal := globalKeys[strings.ToLower(k)]; isGlobal && noisyForRegexps(regs, a[k]) {
 				continue
 			}
 			childKeyLower := prefixLower + strings.ToLower(k)
@@ -256,17 +287,26 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 			return out, nil
 		}
 
-		// If the whole slice is marked noisy-without-regex, accept.
-		if regs, noisy := ni.match(strings.ToLower(key)); noisy && len(regs) == 0 {
+		// No patterns ignores the whole slice, structure included.
+		regs, noisy := ni.match(strings.ToLower(key))
+		if noisy && len(regs) == 0 {
 			out.matches, out.isExact = true, true
 			return out, nil
+		}
+		// A pattern on an array of scalars is unambiguous — `ids: ["^ord-\d+$"]`
+		// says every id looks like that — so it is applied per element and the
+		// elements keep being compared. Only a heterogeneous or nested array
+		// falls back to relaxing its values wholesale, for the same reason a map
+		// does: there is no single value the pattern could be describing.
+		if noisy && !allJSONScalars(e) {
+			ancestorNoisy = true
 		}
 
 		// Fast path: if ordering matters, avoid O(n²).
 		if !ignoreOrdering {
 			isExact := true
 			for i := 0; i < len(e); i++ {
-				res, err := matchJSONWithNoiseHandlingIndexed(key, e[i], a[i], ni, globalKeys, ignoreOrdering)
+				res, err := matchJSONWithNoiseHandlingIndexed(key, e[i], a[i], ni, globalKeys, ignoreOrdering, ancestorNoisy)
 				if err != nil || !res.matches {
 					return out, nil
 				}
@@ -295,7 +335,7 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 						continue
 					}
 					childKey := key
-					res, err := matchJSONWithNoiseHandlingIndexed(childKey, e[i], a[j], ni, globalKeys, ignoreOrdering)
+					res, err := matchJSONWithNoiseHandlingIndexed(childKey, e[i], a[j], ni, globalKeys, ignoreOrdering, ancestorNoisy)
 					if err == nil && res.matches {
 						if !res.isExact {
 							isExact = false
@@ -327,11 +367,109 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 
 func anyRegexpMatchStr(s string, regs []*regexp.Regexp) bool {
 	for _, re := range regs {
-		if re.MatchString(s) {
+		if re != nil && re.MatchString(s) {
 			return true
 		}
 	}
 	return false
+}
+
+// noisyForValue reports whether the leaf at key should be ignored given the
+// value actually replayed.
+//
+// A noise entry with no patterns ignores the field unconditionally — that is
+// what auto-detected noise emits and it is unchanged. An entry WITH patterns
+// describes which values are volatile, so it ignores the field only when the
+// replayed value is one of them. Treating a pattern-guarded entry as an
+// unconditional skip makes the pattern decorative and silently stops asserting
+// the field, which is the opposite of what writing a pattern asks for.
+func noisyForValue(ni noiseIndex, key, actual string) bool {
+	regs, noisy := ni.match(strings.ToLower(key))
+	switch {
+	case !noisy:
+		return false
+	case len(regs) == 0:
+		return true
+	default:
+		return anyRegexpMatchStr(actual, regs)
+	}
+}
+
+// compilePatterns compiles a noise entry's patterns. A nil result means the
+// entry has none, i.e. it ignores its field unconditionally.
+func compilePatterns(patterns []string) []*regexp.Regexp {
+	if len(patterns) == 0 {
+		return nil
+	}
+	out := make([]*regexp.Regexp, 0, len(patterns))
+	for _, p := range patterns {
+		out = append(out, getCompiled(p))
+	}
+	return out
+}
+
+// noisyForRegexps reports whether a noise entry covers this value. With no
+// patterns it covers the field unconditionally; with patterns it covers only
+// the values they describe. A container has no single value to match, so a
+// pattern-guarded entry leaves it alone rather than reaching into it.
+func noisyForRegexps(regs []*regexp.Regexp, value interface{}) bool {
+	if len(regs) == 0 {
+		return true
+	}
+	s, ok := jsonScalarToString(value)
+	if !ok {
+		return true
+	}
+	return anyRegexpMatchStr(s, regs)
+}
+
+// allJSONScalars reports whether every element is a JSON scalar, i.e. the array
+// is homogeneous enough for a single pattern to describe each element.
+func allJSONScalars(vals []interface{}) bool {
+	for _, v := range vals {
+		if _, ok := jsonScalarToString(v); !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// jsonScalarToString renders a JSON scalar for pattern matching. The second
+// result is false for containers, which have no single value to match.
+func jsonScalarToString(v interface{}) (string, bool) {
+	switch t := v.(type) {
+	case nil:
+		return "null", true
+	case string:
+		return t, true
+	case bool:
+		return strconv.FormatBool(t), true
+	case float64:
+		return formatJSONNumber(t), true
+	}
+	return "", false
+}
+
+// formatJSONNumber renders a JSON number exactly as encoding/json would, so a
+// pattern written against the value Keploy prints in its diff matches at
+// replay. JSON numbers unmarshal to float64; reaching for plain 'f' formatting
+// diverges from the printed form at both extremes (1e21 would render as
+// "1000000000000000000000" and 1e-7 as "0.0000001").
+func formatJSONNumber(f float64) string {
+	abs := math.Abs(f)
+	format := byte('f')
+	if abs != 0 && (abs < 1e-6 || abs >= 1e21) {
+		format = 'e'
+	}
+	b := strconv.AppendFloat(nil, f, format, -1, 64)
+	if format == 'e' {
+		// Trim the exponent's leading zero, as encoding/json does: 1e-07 -> 1e-7.
+		if n := len(b); n >= 4 && b[n-4] == 'e' && b[n-3] == '-' && b[n-2] == '0' {
+			b[n-2] = b[n-1]
+			b = b[:n-1]
+		}
+	}
+	return string(b)
 }
 
 func findAndClaimPrimitiveEqual(x interface{}, arr []interface{}, used []bool) (int, bool) {
@@ -734,7 +872,11 @@ var ansiRegex *regexp.Regexp
 func init() {
 	re, err := regexp.Compile(`\x1b\[[0-9;]*[a-zA-Z]`)
 	if err != nil {
-		re, _ = regexp.Compile(`(?!)`)
+		// Same trap as getCompiled had: `(?!)` is not valid RE2, so this
+		// fallback used to leave ansiRegex nil and every use of it would panic.
+		// Unreachable while the pattern above is valid; kept correct so that
+		// editing that pattern cannot reintroduce the crash.
+		re = neverMatches
 	}
 	ansiRegex = re
 }


### PR DESCRIPTION
Fixes #4416.

## The bug

A noise entry reads `{"<field.path>": ["<pattern>", ...]}` and is understood as *ignore this field when its value matches one of these patterns*. It did not work that way.

In `matchJSONWithNoiseHandlingIndexed`, the `case string:` branch ran the match and, when the pattern did **not** match, fell through to:

```go
if e == a || noisy {   // noisy is still true here
    out.matches, out.isExact = true, true
}
```

so the field was accepted anyway. `case bool:` and `case float64:` discarded the pattern list entirely (`_, noisy := ni.match(...)`).

Every pattern-constrained noise entry was therefore an **unconditional skip** — the field was never asserted, which is the opposite of what writing a pattern asks for. All three of these passed:

| noise | recorded | replayed |
|---|---|---|
| `{"order.status": ["^(PENDING\|PAID)$"]}` | `"PENDING"` | `"GARBAGE"` |
| `{"order.total": ["^1200$"]}` | `1200` | `99999` |
| `{"order.paid": ["^true$"]}` | `true` | `false` |

## The fix

The three scalar branches now route through `noisyForValue`, which ignores the field only for values the patterns describe. **An entry with no patterns keeps ignoring unconditionally** — that is what noise auto-detection emits, and it is unchanged; there is a differential corpus below proving it.

Three further problems surfaced while fixing this and are included.

### A typo in a pattern crashed the process

`getCompiled`'s "never matches" fallback was `` `(?!)` `` — a negative lookahead, which Go's RE2 engine rejects. So `regexp.Compile` returned `(nil, err)`, the fallback assigned that nil, and the first comparison dereferenced it:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation]
  regexp.(*Regexp).MatchString(...)
  matcher.anyRegexpMatchStr(...)
```

Replaced with `` `[^\s\S]` `` (a character that is neither whitespace nor non-whitespace — matches nothing, not even the empty string), plus a nil guard. The identical dead fallback in the `ansiRegex` init is swept too; it is unreachable today but is the same trap for whoever next edits that pattern.

### Patterns were dropped for dot-free keys, which is the common shape

`JSONDiffWithNoiseControl` classifies a key with no dot as a "global key" and threw its patterns away. Since `http.Match` strips the `body.` prefix, `body.status` arrives here as the global key `status` — so enforcing patterns only on dotted paths would have left most real-world entries broken. `globalKeys` now carries its compiled patterns.

### Overlapping entries produced a nondeterministic verdict

`match()` returns the first matching entry, and `buildNoiseIndex` appended in Go map order. That was invisible while every entry meant the same thing; once patterns decide the outcome, a suite flips between runs with no input change:

```
noise: {"user.id": ["^\d+$"], "order.user.id": []}
same process, 400 runs -> true 73 / false 327
```

Entries are now ordered most-specific first, which is deterministic and is also the precedence a user writing both `user.id` and `order.user.id` would expect.

## Where a pattern applies

A pattern describes one scalar value, so that is where it is enforced.

- **Scalars** — enforced.
- **Objects** — the pattern relaxes the values beneath it, but the structural walk continues, so a key added, removed or retyped inside is still reported. This matches `main` exactly (verified below); it does not skip the subtree.
- **Arrays of scalars** — enforced per element. `ids: ["^ord-\d+$"]` unambiguously means every id looks like that. Length changes are still structural and still reported.
- **Arrays of objects / mixed arrays** — values relaxed, as with objects.
- **Numbers** — rendered exactly as `encoding/json` does, so a pattern written against the value Keploy prints in its diff matches at replay. Asserted against `json.Marshal` over 700k random floats including raw bit patterns and both format cutovers.

## Verification

Differential corpora against a `HEAD` tree, ~156k comparisons: **zero cases where this branch accepts something `main` rejects.** A 40k-case corpus in which every entry has an empty pattern list is byte-identical to `main`.

The tightenings attribute as 386 from global keys and 2 from path noise — i.e. the dot-free fix is most of what this delivers.

The crash fix reconfirms at scale: a 36k-case corpus containing an uncompilable pattern SIGSEGVs `main` partway through and completes here.

## Upgrade impact — worth release notes

Suites green because a pattern-guarded field was never really checked will start reporting the differences they were hiding. Those are genuine, previously-hidden regressions.

One rougher edge: an invalid pattern still silently becomes never-match with **no warning**, so glob-style input like `*` or `*id*` now yields a red test with no explanation. On `main` those were an unconditional skip for number and bool leaves. Fixing it properly means `getCompiled` surfacing the compile error to a logger; left as a follow-up rather than bolted on here.

## Not included, deliberately

- `case nil:` has no noise handling, so a pattern cannot cover a field that is `null` in the recording. Pre-existing and untouched.
- `risk.go`'s `collectJSON` still uses the old `len(regs)==0` rule, so a field the matcher now ignores is still named by the failure-assessment path. That path is reporting, not the pass/fail verdict.
- `SubstringKeyMatch` (used by `CompareHeaders`) has the same first-match-wins ambiguity and already carries a comment admitting it. Same remedy, separate change.
