### PR TITLE
fix(matcher): noise entries no longer silently disable assertions

### DIFF
--- a/pkg/matcher/grpc/match.go
+++ b/pkg/matcher/grpc/match.go
@@ -229,7 +229,7 @@ func Match(tc *models.TestCase, actualResp *models.GrpcResp, noiseConfig map[str
 			logger.Error("Failed to validate and marshal JSON for gRPC decoded data", zap.Error(err))
 			decodedDataNormal = false
 		} else if validatedJSON.IsIdentical() {
-			jsonComparisonResult, err = matcher.JSONDiffWithNoiseControl(validatedJSON, bodyNoise, ignoreOrdering)
+			jsonComparisonResult, err = matcher.JSONDiffWithNoiseControl(validatedJSON, bodyNoise, ignoreOrdering, logger)
 			decodedDataNormal = jsonComparisonResult.IsExact()
 			if err != nil {
 				logger.Error("Failed to perform JSON diff with noise control", zap.Error(err))

--- a/pkg/matcher/grpc/match.go
+++ b/pkg/matcher/grpc/match.go
@@ -190,28 +190,21 @@ func Match(tc *models.TestCase, actualResp *models.GrpcResp, noiseConfig map[str
 	// Handle noise configuration first - needed for JSON comparison
 	noise := tc.Noise
 
+	// Copy before merging: noiseConfig is the caller's long-lived global map.
 	var (
-		bodyNoise   = noiseConfig["body"]
-		headerNoise = noiseConfig["header"] // need to handle noisy header separately (not implemented yet for grpc)
+		bodyNoise   = matcher.CloneNoiseMap(noiseConfig["body"])
+		headerNoise = matcher.CloneNoiseMap(noiseConfig["header"]) // need to handle noisy header separately (not implemented yet for grpc)
 	)
 
-	if bodyNoise == nil {
-		bodyNoise = map[string][]string{}
+	// Merge test-case-specific noise with global noise (similar to HTTP matcher).
+	// TODO: gRPC has never honoured the whole-body skip sentinel that the HTTP
+	// matcher applies, so skipBody is dropped here to preserve that behaviour.
+	tcBodyNoise, tcHeaderNoise, _ := matcher.SplitNoise(noise, logger)
+	for field, regexArr := range tcBodyNoise {
+		bodyNoise[field] = regexArr
 	}
-
-	if headerNoise == nil {
-		headerNoise = map[string][]string{}
-	}
-
-	// Merge test-case-specific noise with global noise (similar to HTTP matcher)
-	for field, regexArr := range noise {
-		a := strings.Split(field, ".")
-		if len(a) > 1 && a[0] == "body" {
-			x := strings.Join(a[1:], ".")
-			bodyNoise[strings.ToLower(x)] = regexArr
-		} else if a[0] == "header" {
-			headerNoise[strings.ToLower(a[len(a)-1])] = regexArr
-		}
+	for field, regexArr := range tcHeaderNoise {
+		headerNoise[field] = regexArr
 	}
 
 	// Compare decoded data - use JSON comparison if both are valid JSON, otherwise use canonicalization

--- a/pkg/matcher/grpc/noise_test.go
+++ b/pkg/matcher/grpc/noise_test.go
@@ -1,0 +1,108 @@
+// Package grpc noise tests.
+package grpc
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+func grpcTestCase(decoded string, noise map[string][]string) *models.TestCase {
+	return &models.TestCase{
+		Name: "grpc-noise",
+		GrpcResp: models.GrpcResp{
+			Headers: models.GrpcHeaders{
+				PseudoHeaders:   map[string]string{":status": "200"},
+				OrdinaryHeaders: map[string]string{"content-type": "application/grpc"},
+			},
+			Body: models.GrpcLengthPrefixedMessage{
+				CompressionFlag: 0,
+				MessageLength:   uint32(len(decoded)),
+				DecodedData:     decoded,
+			},
+			Trailers: models.GrpcHeaders{
+				OrdinaryHeaders: map[string]string{"grpc-status": "0"},
+			},
+		},
+		Noise: noise,
+	}
+}
+
+func grpcActual(decoded string) *models.GrpcResp {
+	return &models.GrpcResp{
+		Headers: models.GrpcHeaders{
+			PseudoHeaders:   map[string]string{":status": "200"},
+			OrdinaryHeaders: map[string]string{"content-type": "application/grpc"},
+		},
+		Body: models.GrpcLengthPrefixedMessage{
+			CompressionFlag: 0,
+			MessageLength:   uint32(len(decoded)),
+			DecodedData:     decoded,
+		},
+		Trailers: models.GrpcHeaders{
+			OrdinaryHeaders: map[string]string{"grpc-status": "0"},
+		},
+	}
+}
+
+// TestMatch_SectionedBodyNoise covers the gRPC matcher's half of the sectioned
+// noise contract. It had no noise coverage at all before.
+func TestMatch_SectionedBodyNoise(t *testing.T) {
+	const recorded = `{"stock":99,"name":"Laptop"}`
+
+	t.Run("listed path is ignored", func(t *testing.T) {
+		tc := grpcTestCase(recorded, map[string][]string{"body": {"stock"}})
+		actual := grpcActual(`{"stock":100,"name":"Laptop"}`)
+		// MessageLength is derived from the payload and differs by design here;
+		// only the decoded-body verdict is under test.
+		_, res := Match(tc, actual, map[string]map[string][]string{}, false, zap.NewNop(), false)
+		if !decodedDataNormal(res) {
+			t.Errorf("expected the decoded body to match: only the listed noisy path differs")
+		}
+	})
+
+	t.Run("unlisted field is still compared", func(t *testing.T) {
+		tc := grpcTestCase(recorded, map[string][]string{"body": {"stock"}})
+		actual := grpcActual(`{"stock":100,"name":"Tablet"}`)
+		_, res := Match(tc, actual, map[string]map[string][]string{}, false, zap.NewNop(), false)
+		if decodedDataNormal(res) {
+			t.Errorf("expected a decoded-body mismatch: name differs and is not noise")
+		}
+	})
+}
+
+// TestMatch_DoesNotMutateSharedNoiseConfig is the regression test for the worst
+// instance of the shared-map leak: replay passes its long-lived global noise
+// config straight into the gRPC matcher without copying, so a test case's own
+// noise used to persist for the remainder of the run.
+func TestMatch_DoesNotMutateSharedNoiseConfig(t *testing.T) {
+	shared := map[string]map[string][]string{"body": {}, "header": {}}
+
+	tc := grpcTestCase(`{"total":1}`, map[string][]string{
+		"body":       {"total"},
+		"body.stock": {},
+	})
+	Match(tc, grpcActual(`{"total":2}`), shared, false, zap.NewNop(), false)
+
+	if len(shared["body"]) != 0 {
+		t.Errorf("shared global noise config was mutated: %v", shared["body"])
+	}
+
+	// A later test case declaring no noise must still catch the difference.
+	clean := grpcTestCase(`{"total":1}`, nil)
+	_, res := Match(clean, grpcActual(`{"total":2}`), shared, false, zap.NewNop(), false)
+	if decodedDataNormal(res) {
+		t.Errorf("noise from an earlier test case leaked into a later one")
+	}
+}
+
+// decodedDataNormal returns the verdict for the gRPC decoded-body result.
+func decodedDataNormal(res *models.Result) bool {
+	for _, b := range res.BodyResult {
+		if b.Type == models.GrpcData {
+			return b.Normal
+		}
+	}
+	return false
+}

--- a/pkg/matcher/http/absmatch.go
+++ b/pkg/matcher/http/absmatch.go
@@ -203,7 +203,7 @@ func CompareHTTPReq(tcs1, tcs2 *models.TestCase, _ models.GlobalNoise, ignoreOrd
 			return false, reqCompare
 		}
 		if validatedJSON.IsIdentical() {
-			jsonComparisonResult, err = matcher.JSONDiffWithNoiseControl(validatedJSON, reqBodyNoise, ignoreOrdering)
+			jsonComparisonResult, err = matcher.JSONDiffWithNoiseControl(validatedJSON, reqBodyNoise, ignoreOrdering, logger)
 			exact := jsonComparisonResult.IsExact()
 			if err != nil {
 				logger.Error("failed to compare json", zap.Error(err))
@@ -377,7 +377,7 @@ func CompareHTTPResp(tcs1, tcs2 *models.TestCase, noiseConfig models.GlobalNoise
 			return false, respCompare
 		}
 		if validatedJSON.IsIdentical() {
-			jsonComparisonResult, err = matcher.JSONDiffWithNoiseControl(validatedJSON, bodyNoise, ignoreOrdering)
+			jsonComparisonResult, err = matcher.JSONDiffWithNoiseControl(validatedJSON, bodyNoise, ignoreOrdering, logger)
 			exact := jsonComparisonResult.IsExact()
 			if err != nil {
 				logger.Error("failed to compare json", zap.Error(err))

--- a/pkg/matcher/http/absmatch.go
+++ b/pkg/matcher/http/absmatch.go
@@ -324,26 +324,18 @@ func CompareHTTPResp(tcs1, tcs2 *models.TestCase, noiseConfig models.GlobalNoise
 
 	noise := noise1
 
+	// Copy before merging: noiseConfig is the caller's long-lived global map.
 	var (
-		bodyNoise   = noiseConfig["body"]
-		headerNoise = noiseConfig["header"]
+		bodyNoise   = matcher.CloneNoiseMap(noiseConfig["body"])
+		headerNoise = matcher.CloneNoiseMap(noiseConfig["header"])
 	)
 
-	if bodyNoise == nil {
-		bodyNoise = map[string][]string{}
+	tcBodyNoise, tcHeaderNoise, skipBody := matcher.SplitNoise(noise, logger)
+	for field, regexArr := range tcBodyNoise {
+		bodyNoise[field] = regexArr
 	}
-	if headerNoise == nil {
-		headerNoise = map[string][]string{}
-	}
-
-	for field, regexArr := range noise {
-		a := strings.Split(field, ".")
-		if len(a) > 1 && a[0] == "body" {
-			x := strings.Join(a[1:], ".")
-			bodyNoise[strings.ToLower(x)] = regexArr
-		} else if a[0] == "header" {
-			headerNoise[strings.ToLower(a[len(a)-1])] = regexArr
-		}
+	for field, regexArr := range tcHeaderNoise {
+		headerNoise[field] = regexArr
 	}
 
 	// compare http resp headers
@@ -376,7 +368,7 @@ func CompareHTTPResp(tcs1, tcs2 *models.TestCase, noiseConfig models.GlobalNoise
 	// stores the json body after removing the noise
 	cleanExp, cleanAct := tcs1.HTTPResp.Body, tcs2.HTTPResp.Body
 	var jsonComparisonResult matcher.JSONComparisonResult
-	if !matcher.Contains(matcher.MapToArray(noise), "body") && bodyType1 == models.JSON {
+	if !skipBody && bodyType1 == models.JSON {
 		//validate the stored json
 		validatedJSON, err := matcher.ValidateAndMarshalJSON(logger, &cleanExp, &cleanAct)
 		if err != nil {
@@ -405,7 +397,7 @@ func CompareHTTPResp(tcs1, tcs2 *models.TestCase, noiseConfig models.GlobalNoise
 		logger.Debug("cleanExp", zap.Any("cleanExp", cleanExp))
 		logger.Debug("cleanAct", zap.Any("cleanAct", cleanAct))
 	} else {
-		if !matcher.Contains(matcher.MapToArray(noise), "body") && tcs1.HTTPResp.Body != tcs2.HTTPResp.Body {
+		if !skipBody && tcs1.HTTPResp.Body != tcs2.HTTPResp.Body {
 			pass = false
 			bodyRes = false
 		}

--- a/pkg/matcher/http/absmatch.go
+++ b/pkg/matcher/http/absmatch.go
@@ -194,7 +194,7 @@ func CompareHTTPReq(tcs1, tcs2 *models.TestCase, _ models.GlobalNoise, ignoreOrd
 	// stores the json body after removing the noise
 	cleanExp, cleanAct := tcs1.HTTPReq.Body, tcs2.HTTPReq.Body
 	var jsonComparisonResult matcher.JSONComparisonResult
-	if !matcher.Contains(matcher.MapToArray(reqBodyNoise), "body") && bodyType1 == models.JSON {
+	if bodyType1 == models.JSON {
 		//validate the stored json
 		validatedJSON, err := matcher.ValidateAndMarshalJSON(logger, &cleanExp, &cleanAct)
 		if err != nil {
@@ -224,7 +224,7 @@ func CompareHTTPReq(tcs1, tcs2 *models.TestCase, _ models.GlobalNoise, ignoreOrd
 		logger.Debug("cleanExp", zap.Any("cleanExp", cleanExp))
 		logger.Debug("cleanAct", zap.Any("cleanAct", cleanAct))
 	} else {
-		if !matcher.Contains(matcher.MapToArray(reqBodyNoise), "body") && tcs1.HTTPReq.Body != tcs2.HTTPReq.Body {
+		if tcs1.HTTPReq.Body != tcs2.HTTPReq.Body {
 			pass = false
 			bodyRes = false
 		}

--- a/pkg/matcher/http/absmatch_test.go
+++ b/pkg/matcher/http/absmatch_test.go
@@ -1,0 +1,100 @@
+package http
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+func absTestCase(body string, noise map[string][]string) *models.TestCase {
+	return &models.TestCase{
+		Name:    "abs",
+		HTTPReq: models.HTTPReq{Method: "GET", URL: "http://localhost:8080/x", Body: ""},
+		HTTPResp: models.HTTPResp{
+			StatusCode: 200,
+			Header:     map[string]string{"Content-Type": "application/json"},
+			Body:       body,
+		},
+		Noise: noise,
+	}
+}
+
+// TestCompareHTTPResp_SectionedBodyNoise covers CompareHTTPResp, which had no
+// test file at all. It shares the sectioned-noise contract with Match.
+func TestCompareHTTPResp_SectionedBodyNoise(t *testing.T) {
+	const recorded = `{"stock":99,"name":"Laptop"}`
+	noise := func() map[string][]string { return map[string][]string{"body": {"stock"}} }
+
+	t.Run("listed path is ignored", func(t *testing.T) {
+		pass, _ := CompareHTTPResp(
+			absTestCase(recorded, noise()),
+			absTestCase(`{"stock":100,"name":"Laptop"}`, noise()),
+			models.GlobalNoise{}, false, zap.NewNop())
+		if !pass {
+			t.Errorf("expected pass: only the listed noisy path differs")
+		}
+	})
+
+	t.Run("unlisted field is still compared", func(t *testing.T) {
+		pass, _ := CompareHTTPResp(
+			absTestCase(recorded, noise()),
+			absTestCase(`{"stock":100,"name":"Tablet"}`, noise()),
+			models.GlobalNoise{}, false, zap.NewNop())
+		if pass {
+			t.Errorf("expected failure: name differs and is not noise")
+		}
+	})
+
+	t.Run("empty section list still ignores the whole body", func(t *testing.T) {
+		skip := func() map[string][]string { return map[string][]string{"body": {}} }
+		pass, _ := CompareHTTPResp(
+			absTestCase(recorded, skip()),
+			absTestCase(`{"stock":1,"name":"totally-different"}`, skip()),
+			models.GlobalNoise{}, false, zap.NewNop())
+		if !pass {
+			t.Errorf("an empty list on the bare key means ignore the whole body")
+		}
+	})
+}
+
+// TestCompareHTTPResp_SectionedNoise_NonJSONBody covers the non-JSON branch,
+// which was the half of this function left on the old whole-body-skip semantics.
+func TestCompareHTTPResp_SectionedNoise_NonJSONBody(t *testing.T) {
+	noise := func() map[string][]string { return map[string][]string{"body": {"stock"}} }
+
+	pass, _ := CompareHTTPResp(
+		absTestCase("plain recorded text", noise()),
+		absTestCase("plain REPLAYED text", noise()),
+		models.GlobalNoise{}, false, zap.NewNop())
+	if pass {
+		t.Errorf("expected failure: a sectioned path list must not skip a non-JSON body")
+	}
+}
+
+// TestCompareHTTPResp_DoesNotMutateSharedNoiseConfig pins that the caller's
+// long-lived global noise config is not widened by a test case's own noise.
+func TestCompareHTTPResp_DoesNotMutateSharedNoiseConfig(t *testing.T) {
+	shared := models.GlobalNoise{"body": {}, "header": {}}
+
+	noise := func() map[string][]string {
+		return map[string][]string{"body": {"total"}, "body.stock": {}}
+	}
+	CompareHTTPResp(
+		absTestCase(`{"total":1}`, noise()),
+		absTestCase(`{"total":2}`, noise()),
+		shared, false, zap.NewNop())
+
+	if len(shared["body"]) != 0 {
+		t.Fatalf("shared global noise config was mutated: %v", shared["body"])
+	}
+
+	// A later comparison declaring no noise must still catch the difference.
+	pass, _ := CompareHTTPResp(
+		absTestCase(`{"total":1}`, map[string][]string{}),
+		absTestCase(`{"total":2}`, map[string][]string{}),
+		shared, false, zap.NewNop())
+	if pass {
+		t.Errorf("noise from an earlier comparison leaked into a later one")
+	}
+}

--- a/pkg/matcher/http/decode_test.go
+++ b/pkg/matcher/http/decode_test.go
@@ -1,0 +1,126 @@
+package http
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/platform/yaml"
+	"go.keploy.io/server/v3/pkg/platform/yaml/testdb"
+	"go.uber.org/zap"
+	yamlv3 "gopkg.in/yaml.v3"
+)
+
+// TestMatch_DecodedFromYAML_SectionedNoise runs a recorded test-case file
+// through the production YAML decoder and then through Match, so the whole
+// path — decode, SplitNoise, compare — is covered rather than a hand-built
+// TestCase. The fixture is a verbatim trim of a real recorded HTTP test case,
+// including its indexed noise path.
+func TestMatch_DecodedFromYAML_SectionedNoise(t *testing.T) {
+	const fixture = `version: api.keploy.io/v1beta1
+kind: Http
+name: get-order-details
+spec:
+  metadata: {}
+  req:
+    method: GET
+    proto_major: 1
+    proto_minor: 1
+    url: http://localhost:8080/api/v1/orders/5978a5ae/details
+    header:
+      Accept: '*/*'
+    body: ""
+    timestamp: 2026-08-05T08:22:51.125846719Z
+  resp:
+    status_code: 200
+    header:
+      Content-Type: application/json; charset=utf-8
+    body: '{"created_at":"2026-08-05T08:22:51Z","items":[{"product":{"name":"Laptop","price":1200,"stock":99}}]}'
+    status_message: OK
+    proto_major: 0
+    proto_minor: 0
+    timestamp: 2026-08-05T08:22:51.131208762Z
+  objects: []
+  assertions:
+    noise:
+      body:
+        - items.0.product.stock
+      body.created_at: []
+      header:
+        - Content-Length
+      header.Date: []
+  created: 1785918171
+  app_port: 8080
+`
+	path := t.TempDir() + "/tc.yaml"
+	if err := os.WriteFile(path, []byte(fixture), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var doc yaml.NetworkTrafficDoc
+	if err := yamlv3.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	tc, err := testdb.Decode(&doc, zap.NewNop())
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+
+	// Sanity-check that the decoder really produced the sectioned shape; if it
+	// stops doing so, this test would silently stop covering the bug.
+	if got := tc.Noise["body"]; len(got) != 1 || got[0] != "items.0.product.stock" {
+		t.Fatalf("decoded noise[body] = %v, want the sectioned path list", got)
+	}
+
+	// An indexed path is what real recordings carry, and it matches nothing:
+	// the JSON walker keys array elements without a position, so the effective
+	// path is "items.product.stock". Silencing this by dropping numeric segments
+	// is unsafe under the matcher's substring semantics — see
+	// TestJSONDiffWithNoiseControl_IndexedPathIsNotSupported. Until the walker
+	// carries positions, such a field fails loudly instead of passing silently,
+	// which is the upgrade impact for suites recorded with indexed noise paths.
+	t.Run("indexed noise path does not silence its own field", func(t *testing.T) {
+		actual := tc.HTTPResp
+		actual.Body = strings.Replace(tc.HTTPResp.Body, `"stock":99`, `"stock":100`, 1)
+		pass, _ := Match(tc, &actual, map[string]map[string][]string{}, false, false, zap.NewNop(), false)
+		if pass {
+			t.Errorf("if this now passes, indexed noise paths became supported; " +
+				"update SplitNoise's docs and this test")
+		}
+	})
+
+	t.Run("index-free path is honoured end to end", func(t *testing.T) {
+		tc2, err := testdb.Decode(&doc, zap.NewNop())
+		if err != nil {
+			t.Fatalf("Decode: %v", err)
+		}
+		tc2.Noise["body"] = []string{"items.product.stock"}
+		actual := tc2.HTTPResp
+		actual.Body = strings.Replace(tc2.HTTPResp.Body, `"stock":99`, `"stock":100`, 1)
+		pass, _ := Match(tc2, &actual, map[string]map[string][]string{}, false, false, zap.NewNop(), false)
+		if !pass {
+			t.Errorf("expected pass: only the listed noisy path differs")
+		}
+	})
+
+	t.Run("real regression is caught", func(t *testing.T) {
+		tc2, err := testdb.Decode(&doc, zap.NewNop())
+		if err != nil {
+			t.Fatalf("Decode: %v", err)
+		}
+		actual := tc2.HTTPResp
+		actual.Body = strings.NewReplacer(
+			`"stock":99`, `"stock":100`,
+			`"name":"Laptop"`, `"name":"Tablet"`,
+			`"price":1200`, `"price":1999`,
+		).Replace(tc2.HTTPResp.Body)
+		pass, _ := Match(tc2, &actual, map[string]map[string][]string{}, false, false, zap.NewNop(), false)
+		if pass {
+			t.Errorf("expected failure: name and price differ and are not noise")
+		}
+	})
+}

--- a/pkg/matcher/http/match.go
+++ b/pkg/matcher/http/match.go
@@ -84,38 +84,38 @@ func Match(tc *models.TestCase, actualResponse *models.HTTPResp, noiseConfig map
 	}
 
 	noise := tc.Noise
+	// Copy the shared config maps before merging this test case's noise into
+	// them, otherwise each test case permanently widens the noise applied to
+	// every later one.
 	var (
-		bodyNoise   = noiseConfig["body"]
-		headerNoise = noiseConfig["header"]
+		bodyNoise    = matcherUtils.CloneNoiseMap(noiseConfig["body"])
+		headerNoise  = matcherUtils.CloneNoiseMap(noiseConfig["header"])
+		wildcardBody bool
 	)
-	if bodyNoise != nil {
-		if ignoreFields, ok := bodyNoise["*"]; ok && len(ignoreFields) > 0 && ignoreFields[0] == "*" {
-			if noise["body"] == nil {
-				noise["body"] = make([]string, 0)
-			}
-		}
-	} else {
-		bodyNoise = map[string][]string{}
-	}
-	if headerNoise == nil {
-		headerNoise = map[string][]string{}
-	}
+	// wildcardBody carries this on its own. Writing the sentinel back into
+	// tc.Noise used to be how it reached the body-skip check; that mutated the
+	// caller's test case, panicked when tc.Noise was nil, and could be persisted
+	// back to disk by a later re-encode.
+	ignoreFields, hasWildcard := bodyNoise["*"]
+	wildcardBody = hasWildcard && len(ignoreFields) > 0 && ignoreFields[0] == "*"
 
-	for field, regexArr := range noise {
-		a := strings.Split(field, ".")
-		if len(a) > 1 && a[0] == "body" {
-			x := strings.Join(a[1:], ".")
-			bodyNoise[strings.ToLower(x)] = regexArr
-		} else if a[0] == "header" {
-			headerNoise[strings.ToLower(a[len(a)-1])] = regexArr
-		}
+	tcBodyNoise, tcHeaderNoise, skipBody := matcherUtils.SplitNoise(noise, logger)
+	// The global wildcard means "ignore every response body" on its own; it
+	// must not depend on the test case also carrying a bare "body" key, which
+	// stops being the skip sentinel once that key lists field paths.
+	skipBody = skipBody || wildcardBody
+	for field, regexArr := range tcBodyNoise {
+		bodyNoise[field] = regexArr
+	}
+	for field, regexArr := range tcHeaderNoise {
+		headerNoise[field] = regexArr
 	}
 
 	// stores the json body after removing the noise
 	cleanExp, cleanAct := tc.HTTPResp.Body, actualResponse.Body
 
 	var jsonComparisonResult matcherUtils.JSONComparisonResult
-	if !matcherUtils.Contains(matcherUtils.MapToArray(noise), "body") && bodyType == models.JSON && jsonValid234([]byte(tc.HTTPResp.Body)) {
+	if !skipBody && bodyType == models.JSON && jsonValid234([]byte(tc.HTTPResp.Body)) {
 		//validate the stored json
 		validatedJSON, err := matcherUtils.ValidateAndMarshalJSON(logger, &cleanExp, &cleanAct)
 		if err != nil {
@@ -139,7 +139,7 @@ func Match(tc *models.TestCase, actualResponse *models.HTTPResp, noiseConfig map
 		if !compareAll && bodyType != models.JSON {
 			logger.Debug("Skipping body comparison for non-JSON response", zap.String("bodyType", string(bodyType)))
 			// Mark body as passing when compareAll is false and body is not JSON
-		} else if !matcherUtils.Contains(matcherUtils.MapToArray(noise), "body") && tc.HTTPResp.Body != actualResponse.Body {
+		} else if !skipBody && tc.HTTPResp.Body != actualResponse.Body {
 			pass = false
 		}
 	}

--- a/pkg/matcher/http/match.go
+++ b/pkg/matcher/http/match.go
@@ -122,7 +122,7 @@ func Match(tc *models.TestCase, actualResponse *models.HTTPResp, noiseConfig map
 			return false, res
 		}
 		if validatedJSON.IsIdentical() {
-			jsonComparisonResult, err = matcherUtils.JSONDiffWithNoiseControl(validatedJSON, bodyNoise, ignoreOrdering)
+			jsonComparisonResult, err = matcherUtils.JSONDiffWithNoiseControl(validatedJSON, bodyNoise, ignoreOrdering, logger)
 			pass = jsonComparisonResult.IsExact()
 			if err != nil {
 				return false, res
@@ -318,7 +318,7 @@ func Match(tc *models.TestCase, actualResponse *models.HTTPResp, noiseConfig map
 				}
 				isBodyMismatch = false
 				if validatedJSON.IsIdentical() {
-					jsonComparisonResult, err = matcherUtils.JSONDiffWithNoiseControl(validatedJSON, bodyNoise, ignoreOrdering)
+					jsonComparisonResult, err = matcherUtils.JSONDiffWithNoiseControl(validatedJSON, bodyNoise, ignoreOrdering, logger)
 					if err != nil {
 						return false, res
 					}

--- a/pkg/matcher/http/match_test.go
+++ b/pkg/matcher/http/match_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"strings"
 	"testing"
 
 	"errors"
@@ -11,7 +12,15 @@ import (
 	"go.uber.org/zap"
 )
 
-// TestMatch_HeaderNoiseUpdate_123 ensures that the `headerNoise` map is updated correctly when the `noise` map contains a "header" key.
+// TestMatch_HeaderNoiseUpdate_123 ensures a test case's "header.<name>" noise is
+// applied when comparing headers.
+//
+// This used to assert that Match wrote the merged entry back into the caller's
+// noiseConfig map. That was only observable because Match merged into the
+// caller's map in place, which let one test case's noise leak into every later
+// one in the same run. Match now merges into a copy, so the merge is asserted
+// through its effect on the comparison instead, and the absence of the leak is
+// asserted explicitly.
 func TestMatch_HeaderNoiseUpdate_123(t *testing.T) {
 	// Arrange
 	logger := zap.NewNop()
@@ -22,12 +31,13 @@ func TestMatch_HeaderNoiseUpdate_123(t *testing.T) {
 			Body:       `{"key":"value"}`,
 		},
 		Noise: map[string][]string{
-			"header.Content-Type": {"regex"},
+			"header.Content-Type": {".*"},
 		},
 	}
+	// Content-Type differs; the test case's header noise must absorb it.
 	actualResponse := &models.HTTPResp{
 		StatusCode: 200,
-		Header:     map[string]string{"Content-Type": "application/json"},
+		Header:     map[string]string{"Content-Type": "text/plain"},
 		Body:       `{"key":"value"}`,
 	}
 	noiseConfig := map[string]map[string][]string{
@@ -40,9 +50,8 @@ func TestMatch_HeaderNoiseUpdate_123(t *testing.T) {
 
 	// Assert
 	require.NotNil(t, result)
-	assert.True(t, pass)
-	assert.Contains(t, noiseConfig["header"], "content-type")
-	assert.Equal(t, []string{"regex"}, noiseConfig["header"]["content-type"])
+	assert.True(t, pass, "the differing Content-Type is covered by the test case's header noise")
+	assert.Empty(t, noiseConfig["header"], "the caller's noise config must not be mutated")
 }
 
 // TestMatch_FailureAndDiffLogging_890 tests the Match function with comprehensive failures
@@ -235,8 +244,10 @@ func TestMatch_BodyNoiseWildcard_789(t *testing.T) {
 	require.NotNil(t, result)
 	assert.True(t, result.StatusCode.Normal)
 	assert.True(t, result.BodyResult[0].Normal)
-	// Check that tc.Noise["body"] was initialized
-	assert.NotNil(t, tc.Noise["body"])
+	// Match used to record the wildcard by writing a sentinel into tc.Noise.
+	// That mutated the caller's test case (and panicked when tc.Noise was nil),
+	// so the wildcard is now tracked locally and tc.Noise is left alone.
+	assert.NotContains(t, tc.Noise, "body")
 }
 
 // TestMatch_CompareAll_Disabled tests that when compareAll is false (default),
@@ -318,4 +329,371 @@ func TestMatch_CompareAll_JSONStillCompared(t *testing.T) {
 	require.NotNil(t, result)
 	assert.True(t, result.StatusCode.Normal)
 	assert.False(t, result.BodyResult[0].Normal)
+}
+
+// The tests below cover the "sectioned" noise shape, where the key is the bare
+// section name and the value lists the field paths to ignore:
+//
+//	noise:
+//	  body:
+//	    - items.product.stock
+//	  header:
+//	    - X-Request-Id
+//
+// This is the shape recorded test cases carry. It has
+// to mean "ignore these paths", not "ignore this whole section" — the bare key
+// only means whole-section when its list is empty (the wildcard sentinel that
+// TestMatch_BodyNoiseWildcard_789 covers).
+
+// TestMatch_SectionedBodyNoise_DoesNotDisableWholeBody is a regression test for
+// a silent false negative: a sectioned body-noise entry disabled the body
+// assertion entirely, so a test case with any auto-detected noisy field passed
+// no matter what the handler returned.
+func TestMatch_SectionedBodyNoise_DoesNotDisableWholeBody(t *testing.T) {
+	logger := zap.NewNop()
+	tc := &models.TestCase{
+		Name: "test-sectioned-body-noise",
+		HTTPResp: models.HTTPResp{
+			StatusCode: 200,
+			Body:       `{"items":[{"product":{"name":"Laptop","price":1200,"stock":99}}]}`,
+		},
+		Noise: map[string][]string{
+			"body": {"items.product.stock"},
+		},
+	}
+	// stock is noise, but name and price are real regressions.
+	actualResponse := &models.HTTPResp{
+		StatusCode: 200,
+		Body:       `{"items":[{"product":{"name":"Tablet","price":1999,"stock":100}}]}`,
+	}
+
+	pass, result := Match(tc, actualResponse, map[string]map[string][]string{}, false, false, logger, true)
+
+	assert.False(t, pass, "should fail: name and price differ and are not listed as noise")
+	require.NotNil(t, result)
+	assert.False(t, result.BodyResult[0].Normal)
+}
+
+// TestMatch_SectionedBodyNoise_IgnoresListedPaths is the other half of the
+// contract: the paths that ARE listed must still be ignored.
+func TestMatch_SectionedBodyNoise_IgnoresListedPaths(t *testing.T) {
+	logger := zap.NewNop()
+	tc := &models.TestCase{
+		Name: "test-sectioned-body-noise-ignored",
+		HTTPResp: models.HTTPResp{
+			StatusCode: 200,
+			Body:       `{"items":[{"product":{"name":"Laptop","price":1200,"stock":99}}]}`,
+		},
+		Noise: map[string][]string{
+			"body": {"items.product.stock"},
+		},
+	}
+	// Only the noisy field differs.
+	actualResponse := &models.HTTPResp{
+		StatusCode: 200,
+		Body:       `{"items":[{"product":{"name":"Laptop","price":1200,"stock":100}}]}`,
+	}
+
+	pass, result := Match(tc, actualResponse, map[string]map[string][]string{}, false, false, logger, true)
+
+	assert.True(t, pass, "should pass: the only difference is the listed noisy path")
+	require.NotNil(t, result)
+	assert.True(t, result.BodyResult[0].Normal)
+}
+
+// TestMatch_SectionedBodyNoise_MixedWithDottedKeys covers the shape a real
+// recorded test case has, where both key styles appear together.
+func TestMatch_SectionedBodyNoise_MixedWithDottedKeys(t *testing.T) {
+	logger := zap.NewNop()
+	tc := &models.TestCase{
+		Name: "test-sectioned-and-dotted-noise",
+		HTTPResp: models.HTTPResp{
+			StatusCode: 200,
+			Body:       `{"created_at":"2026-08-05T08:22:51Z","stock":99,"name":"Laptop"}`,
+		},
+		Noise: map[string][]string{
+			"body":            {"stock"},
+			"body.created_at": {},
+		},
+	}
+	actualResponse := &models.HTTPResp{
+		StatusCode: 200,
+		Body:       `{"created_at":"2027-01-01T00:00:00Z","stock":100,"name":"Tablet"}`,
+	}
+
+	pass, result := Match(tc, actualResponse, map[string]map[string][]string{}, false, false, logger, true)
+
+	assert.False(t, pass, "should fail on name; created_at and stock are both noise")
+	require.NotNil(t, result)
+	assert.False(t, result.BodyResult[0].Normal)
+}
+
+// TestMatch_EmptySectionedBodyNoise_IgnoresWholeBody pins the sentinel meaning
+// of the bare key with an empty list, so the fix above cannot regress it.
+func TestMatch_EmptySectionedBodyNoise_IgnoresWholeBody(t *testing.T) {
+	logger := zap.NewNop()
+	tc := &models.TestCase{
+		Name: "test-empty-sectioned-body-noise",
+		HTTPResp: models.HTTPResp{
+			StatusCode: 200,
+			Body:       `{"id":1,"name":"keploy"}`,
+		},
+		Noise: map[string][]string{
+			"body": {},
+		},
+	}
+	actualResponse := &models.HTTPResp{
+		StatusCode: 200,
+		Body:       `{"id":2,"name":"totally-different"}`,
+	}
+
+	pass, result := Match(tc, actualResponse, map[string]map[string][]string{}, false, false, logger, true)
+
+	assert.True(t, pass, "an empty list on the bare key still means ignore the whole body")
+	require.NotNil(t, result)
+	assert.True(t, result.BodyResult[0].Normal)
+}
+
+// TestMatch_SectionedHeaderNoise_DoesNotDisableAllHeaders is the header analog
+// of the body regression: `header: [X-Request-Id]` silenced every header.
+func TestMatch_SectionedHeaderNoise_DoesNotDisableAllHeaders(t *testing.T) {
+	logger := zap.NewNop()
+	tc := &models.TestCase{
+		Name: "test-sectioned-header-noise",
+		HTTPResp: models.HTTPResp{
+			StatusCode: 200,
+			Header: map[string]string{
+				"X-Request-Id": "abc",
+				"Content-Type": "application/json",
+			},
+			Body: `{"ok":true}`,
+		},
+		Noise: map[string][]string{
+			"header": {"X-Request-Id"},
+		},
+	}
+	actualResponse := &models.HTTPResp{
+		StatusCode: 200,
+		Header: map[string]string{
+			"X-Request-Id": "zzz",        // noise
+			"Content-Type": "text/plain", // real regression
+		},
+		Body: `{"ok":true}`,
+	}
+
+	pass, result := Match(tc, actualResponse, map[string]map[string][]string{}, false, false, logger, true)
+
+	assert.False(t, pass, "should fail: Content-Type differs and is not listed as noise")
+	require.NotNil(t, result)
+}
+
+// TestMatch_SectionedHeaderNoise_IgnoresListedHeaders is the other half.
+func TestMatch_SectionedHeaderNoise_IgnoresListedHeaders(t *testing.T) {
+	logger := zap.NewNop()
+	tc := &models.TestCase{
+		Name: "test-sectioned-header-noise-ignored",
+		HTTPResp: models.HTTPResp{
+			StatusCode: 200,
+			Header: map[string]string{
+				"X-Request-Id": "abc",
+				"Content-Type": "application/json",
+			},
+			Body: `{"ok":true}`,
+		},
+		Noise: map[string][]string{
+			"header": {"X-Request-Id"},
+		},
+	}
+	actualResponse := &models.HTTPResp{
+		StatusCode: 200,
+		Header: map[string]string{
+			"X-Request-Id": "zzz",
+			"Content-Type": "application/json",
+		},
+		Body: `{"ok":true}`,
+	}
+
+	pass, result := Match(tc, actualResponse, map[string]map[string][]string{}, false, false, logger, true)
+
+	assert.True(t, pass, "should pass: the only differing header is listed as noise")
+	require.NotNil(t, result)
+}
+
+// Real payloads captured from a keploy cloud replay of order-service-4,
+// test case get-api-v1-orders-by-id-details-1.
+const realWorldRecordedBody = `{"created_at":"2026-08-05T08:22:51Z","id":"5978a5ae-792b-4a19-a97b-d2802674b467","items":[{"product":{"description":"A powerful and portable laptop.","id":"26c7d38d-8b7d-11f1-a6c8-da00f699ab49","name":"Laptop","price":1200,"stock":99},"productId":"26c7d38d-8b7d-11f1-a6c8-da00f699ab49","quantity":1}],"status":"PENDING","total_amount":1200,"updated_at":"2026-08-05T08:22:51Z","user":{"created_at":"2026-08-05T08:22:50Z","email":"alice_1785918170@example.com","id":"669e858c-b6ee-4313-b59d-f6fa1f51e33f","username":"alice_1785918170"},"userId":"669e858c-b6ee-4313-b59d-f6fa1f51e33f"}`
+
+// Untampered replay: stock drifts 99 -> 100 (the field marked as noise).
+const realWorldUntamperedBody = `{"created_at":"2026-08-05T08:22:51Z","id":"5978a5ae-792b-4a19-a97b-d2802674b467","items":[{"product":{"description":"A powerful and portable laptop.","id":"26c7d38d-8b7d-11f1-a6c8-da00f699ab49","name":"Laptop","price":1200,"stock":100},"productId":"26c7d38d-8b7d-11f1-a6c8-da00f699ab49","quantity":1}],"status":"PENDING","total_amount":1200,"updated_at":"2026-08-05T08:22:51Z","user":{"created_at":"2026-08-05T08:22:50Z","email":"alice_1785918170@example.com","id":"669e858c-b6ee-4313-b59d-f6fa1f51e33f","username":"alice_1785918170"},"userId":"669e858c-b6ee-4313-b59d-f6fa1f51e33f"}`
+
+// Tampered replay: product mock returned Tablet/1999, user mock returned zzzzz.
+const realWorldTamperedBody = `{"created_at":"2026-08-05T08:22:51Z","id":"5978a5ae-792b-4a19-a97b-d2802674b467","items":[{"product":{"description":"A powerful and portable laptop.","id":"26c7d38d-8b7d-11f1-a6c8-da00f699ab49","name":"Tablet","price":1999,"stock":100},"productId":"26c7d38d-8b7d-11f1-a6c8-da00f699ab49","quantity":1}],"status":"PENDING","total_amount":1200,"updated_at":"2026-08-05T08:22:51Z","user":{"created_at":"2026-08-05T08:22:50Z","email":"zzzzz_1785918170@example.com","id":"669e858c-b6ee-4313-b59d-f6fa1f51e33f","username":"zzzzz_1785918170"},"userId":"669e858c-b6ee-4313-b59d-f6fa1f51e33f"}`
+
+func realWorldNoise() map[string][]string {
+	return map[string][]string{
+		"body":                 {"items.product.stock"},
+		"body.created_at":      {},
+		"body.updated_at":      {},
+		"body.user.created_at": {},
+		"header":               {"X-Request-Id"},
+		"header.Date":          {},
+	}
+}
+
+func TestMatch_RealWorldRecordedNoise(t *testing.T) {
+	for _, c := range []struct {
+		name     string
+		actual   string
+		wantPass bool
+	}{
+		{"untampered replay passes (only the noisy stock drifts)", realWorldUntamperedBody, true},
+		{"tampered downstream mock is caught", realWorldTamperedBody, false},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			tc := &models.TestCase{
+				Name: "get-api-v1-orders-by-id-details-1",
+				HTTPResp: models.HTTPResp{
+					StatusCode: 200,
+					Header: map[string]string{
+						"Content-Type": "application/json; charset=utf-8",
+						"Date":         "Wed, 05 Aug 2026 08:22:51 GMT",
+						"X-Request-Id": "req-recorded",
+					},
+					Body: realWorldRecordedBody,
+				},
+				Noise: realWorldNoise(),
+			}
+			// Date and X-Request-Id drift on every replay and are both noise;
+			// Content-Type is not, and is identical here.
+			actual := &models.HTTPResp{
+				StatusCode: 200,
+				Header: map[string]string{
+					"Content-Type": "application/json; charset=utf-8",
+					"Date":         "Thu, 06 Aug 2026 09:00:00 GMT",
+					"X-Request-Id": "req-replayed",
+				},
+				Body: c.actual,
+			}
+			pass, _ := Match(tc, actual, map[string]map[string][]string{}, false, false, zap.NewNop(), false)
+			if pass != c.wantPass {
+				t.Errorf("pass = %v, want %v", pass, c.wantPass)
+			}
+		})
+	}
+}
+
+// TestMatch_SectionedBodyNoise_ShortPathDoesNotLeak guards against a tempting
+// but wrong "fix" for indexed noise paths: dropping the numeric segment from
+// "0.id" yields the bare segment "id", and because noise keys are matched with
+// strings.Contains that would silence every field whose name merely contains
+// "id" — "width", "video" and "paid" all do.
+func TestMatch_SectionedBodyNoise_ShortPathDoesNotLeak(t *testing.T) {
+	logger := zap.NewNop()
+	tc := &models.TestCase{
+		Name: "test-short-stripped-path",
+		HTTPResp: models.HTTPResp{
+			StatusCode: 200,
+			Body:       `{"width":10,"video":"a","paid":true}`,
+		},
+		Noise: map[string][]string{"body": {"0.id"}},
+	}
+	actualResponse := &models.HTTPResp{
+		StatusCode: 200,
+		Body:       `{"width":99,"video":"b","paid":false}`,
+	}
+
+	pass, _ := Match(tc, actualResponse, map[string]map[string][]string{}, false, false, logger, false)
+
+	assert.False(t, pass, "width/video/paid must not be silenced by a noise path that strips to \"id\"")
+}
+
+// TestMatch_GlobalWildcardBody_SurvivesSectionedNoise pins that the global
+// "ignore every body" config keeps working on a test case that also carries a
+// sectioned body-noise key — that key is no longer the skip sentinel itself.
+func TestMatch_GlobalWildcardBody_SurvivesSectionedNoise(t *testing.T) {
+	logger := zap.NewNop()
+	tc := &models.TestCase{
+		Name: "test-wildcard-with-sectioned-noise",
+		HTTPResp: models.HTTPResp{
+			StatusCode: 200,
+			Body:       `{"id":1,"name":"keploy","stock":99}`,
+		},
+		Noise: map[string][]string{"body": {"stock"}},
+	}
+	actualResponse := &models.HTTPResp{
+		StatusCode: 200,
+		Body:       `{"id":2,"name":"totally-different","stock":100}`,
+	}
+	noiseConfig := map[string]map[string][]string{"body": {"*": {"*"}}}
+
+	pass, _ := Match(tc, actualResponse, noiseConfig, false, false, logger, false)
+
+	assert.True(t, pass, "the global body wildcard still means ignore the whole body")
+}
+
+// TestMatch_DoesNotMutateSharedNoiseConfig pins that a test case's own noise
+// does not leak into the caller's global config and soften every later case.
+func TestMatch_DoesNotMutateSharedNoiseConfig(t *testing.T) {
+	logger := zap.NewNop()
+	shared := map[string]map[string][]string{
+		"body":   {},
+		"header": {},
+	}
+
+	// Both key shapes are merged in, so both must be copied. The dotted shape is
+	// the one that leaked before this change; the sectioned shape leaks only now
+	// that it produces entries at all.
+	noisy := &models.TestCase{
+		Name:     "case-with-noise",
+		HTTPResp: models.HTTPResp{StatusCode: 200, Body: `{"total":1,"stock":1}`},
+		Noise:    map[string][]string{"body": {"total"}, "body.stock": {}},
+	}
+	Match(noisy, &models.HTTPResp{StatusCode: 200, Body: `{"total":2,"stock":2}`}, shared, false, false, logger, false)
+
+	assert.Empty(t, shared["body"], "the shared global noise config must be left untouched")
+
+	// A later test case that declares no noise must still catch both differences.
+	clean := &models.TestCase{
+		Name:     "case-without-noise",
+		HTTPResp: models.HTTPResp{StatusCode: 200, Body: `{"total":1,"stock":1}`},
+	}
+	pass, _ := Match(clean, &models.HTTPResp{StatusCode: 200, Body: `{"total":2,"stock":2}`}, shared, false, false, logger, false)
+
+	assert.False(t, pass, "noise from an earlier test case must not carry over")
+}
+
+// TestMatch_SectionedHeaderNoise_ScopesToTheListedHeader asserts on the
+// per-header verdicts rather than only the overall pass flag, so the test
+// cannot be satisfied by the body assertion failing instead.
+func TestMatch_SectionedHeaderNoise_ScopesToTheListedHeader(t *testing.T) {
+	logger := zap.NewNop()
+	tc := &models.TestCase{
+		Name: "test-sectioned-header-scope",
+		HTTPResp: models.HTTPResp{
+			StatusCode: 200,
+			Header:     map[string]string{"X-Request-Id": "abc", "Content-Type": "application/json"},
+			Body:       `{"ok":true}`,
+		},
+		Noise: map[string][]string{"header": {"X-Request-Id"}},
+	}
+	actualResponse := &models.HTTPResp{
+		StatusCode: 200,
+		Header:     map[string]string{"X-Request-Id": "zzz", "Content-Type": "text/plain"},
+		Body:       `{"ok":true}`,
+	}
+
+	pass, result := Match(tc, actualResponse, map[string]map[string][]string{}, false, false, logger, false)
+
+	assert.False(t, pass)
+	require.NotNil(t, result)
+	verdicts := map[string]bool{}
+	for _, h := range result.HeadersResult {
+		verdicts[strings.ToLower(h.Expected.Key)] = h.Normal
+	}
+	normal, ok := verdicts["content-type"]
+	require.True(t, ok, "Content-Type should be reported, got %v", verdicts)
+	assert.False(t, normal, "Content-Type is not noise and differs")
+	normal, ok = verdicts["x-request-id"]
+	require.True(t, ok, "X-Request-Id should be reported, got %v", verdicts)
+	assert.True(t, normal, "X-Request-Id is listed as noise")
 }

--- a/pkg/matcher/noise_regex_test.go
+++ b/pkg/matcher/noise_regex_test.go
@@ -3,10 +3,14 @@ package matcher
 import (
 	"encoding/json"
 	"math"
+	"net/http"
 	"regexp"
 	"testing"
 
+	"go.keploy.io/server/v3/pkg/models"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 // diffNoise is a small helper: compare two JSON documents under a noise map and
@@ -18,7 +22,7 @@ func diffNoise(t *testing.T, expected, actual string, noise map[string][]string)
 	if err != nil {
 		t.Fatalf("ValidateAndMarshalJSON: %v", err)
 	}
-	res, err := JSONDiffWithNoiseControl(v, noise, false)
+	res, err := JSONDiffWithNoiseControl(v, noise, false, nil)
 	if err != nil {
 		t.Fatalf("JSONDiffWithNoiseControl: %v", err)
 	}
@@ -284,13 +288,13 @@ func TestRegexNoise_GlobalKeyEnforcesPattern(t *testing.T) {
 			want:     true,
 		},
 		{
-			// No value to match, so the entry covers it — the same rule applied
-			// to a container, and what this did before patterns were enforced.
-			name:     "a missing key is excused by a pattern-guarded entry",
+			// A pattern has no value to match against, and a field disappearing
+			// is a schema change, not a volatile value.
+			name:     "a missing key is not excused by a pattern-guarded entry",
 			expected: `{"a":1,"status":"PAID"}`,
 			actual:   `{"a":1}`,
 			noise:    map[string][]string{"status": {"^PAID$"}},
-			want:     true,
+			want:     false,
 		},
 		{
 			name:     "a missing key is excused by an empty pattern list",
@@ -483,5 +487,187 @@ func TestRegexNoise_ArrayOfScalarsEnforcesPattern(t *testing.T) {
 	nested := map[string][]string{"order.items": {`^ord-\d+$`}}
 	if !diffNoise(t, `{"order":{"items":[{"id":"ord-1"}]}}`, `{"order":{"items":[{"id":"HACK"}]}}`, nested) {
 		t.Errorf("a non-scalar array relaxes its values rather than applying the pattern per element")
+	}
+}
+
+// TestRegexNoise_InvalidPatternIsReported pins that a pattern that cannot be
+// compiled is reported once. It silently matches nothing, so without a warning
+// the user sees a field they marked as noise start failing with no clue why.
+func TestRegexNoise_InvalidPatternIsReported(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	logger := zap.New(core)
+
+	// Use a pattern unique to this test: the warning dedupes per pattern for the
+	// life of the process.
+	bad := `^(unclosed-` + t.Name()
+	e, a := `{"order":{"status":"PENDING"}}`, `{"order":{"status":"GARBAGE"}}`
+	v, err := ValidateAndMarshalJSON(zap.NewNop(), &e, &a)
+	if err != nil {
+		t.Fatalf("ValidateAndMarshalJSON: %v", err)
+	}
+	noise := map[string][]string{"order.status": {bad}}
+
+	res, err := JSONDiffWithNoiseControl(v, noise, false, logger)
+	if err != nil {
+		t.Fatalf("JSONDiffWithNoiseControl: %v", err)
+	}
+	if res.IsExact() {
+		t.Errorf("an invalid pattern must not silence the field")
+	}
+	if logs.Len() != 1 {
+		t.Fatalf("emitted %d warnings, want exactly 1: %v", logs.Len(), logs.All())
+	}
+	if got := logs.All()[0].ContextMap()["pattern"]; got != bad {
+		t.Errorf("warning names pattern %v, want %q", got, bad)
+	}
+
+	// Repeated compilation of the same pattern must not repeat the warning.
+	for i := 0; i < 20; i++ {
+		if _, err := JSONDiffWithNoiseControl(v, noise, false, logger); err != nil {
+			t.Fatalf("JSONDiffWithNoiseControl: %v", err)
+		}
+	}
+	if logs.Len() != 1 {
+		t.Errorf("warning repeated %d times for one pattern, want 1", logs.Len())
+	}
+}
+
+// TestRegexNoise_ValidPatternWarnsNothing guards the common path from noise.
+func TestRegexNoise_ValidPatternWarnsNothing(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	logger := zap.New(core)
+
+	e, a := `{"order":{"status":"PENDING"}}`, `{"order":{"status":"PAID"}}`
+	v, err := ValidateAndMarshalJSON(zap.NewNop(), &e, &a)
+	if err != nil {
+		t.Fatalf("ValidateAndMarshalJSON: %v", err)
+	}
+	if _, err := JSONDiffWithNoiseControl(v, map[string][]string{"order.status": {"^(PENDING|PAID)$"}}, false, logger); err != nil {
+		t.Fatalf("JSONDiffWithNoiseControl: %v", err)
+	}
+	if logs.Len() != 0 {
+		t.Errorf("emitted %d warnings for a valid pattern, want 0: %v", logs.Len(), logs.All())
+	}
+}
+
+// TestRegexNoise_NullValuedFieldCanBeNoise covers a field recorded as null. A
+// nullable volatile field is exactly what a pattern is for, but the null branch
+// used to ignore noise entirely, so no entry could ever cover it.
+func TestRegexNoise_NullValuedFieldCanBeNoise(t *testing.T) {
+	recorded := `{"order":{"cancelledAt":null}}`
+	replayed := `{"order":{"cancelledAt":"2026-08-05T08:22:51Z"}}`
+
+	if !diffNoise(t, recorded, replayed, map[string][]string{"order.cancelledAt": {}}) {
+		t.Errorf("an empty pattern list must cover a field recorded as null")
+	}
+	if !diffNoise(t, recorded, replayed, map[string][]string{"order.cancelledAt": {`^\d{4}-`}}) {
+		t.Errorf("a matching pattern must cover a field recorded as null")
+	}
+	if diffNoise(t, recorded, replayed, map[string][]string{"order.cancelledAt": {`^nope$`}}) {
+		t.Errorf("a non-matching pattern must leave the difference reported")
+	}
+	if !diffNoise(t, recorded, `{"order":{"cancelledAt":null}}`, map[string][]string{}) {
+		t.Errorf("null replayed as null is unchanged")
+	}
+}
+
+// TestRegexNoise_UnexpectedKeyHonoursPattern pins that an extra key in the
+// replay is excused on the same terms under path noise as under a global entry.
+func TestRegexNoise_UnexpectedKeyHonoursPattern(t *testing.T) {
+	if !diffNoise(t, `{"a":1}`, `{"a":1,"trace":"ord-9"}`, map[string][]string{"trace": {`^ord-\d+$`}}) {
+		t.Errorf("an unexpected key matching its pattern should be excused")
+	}
+	if diffNoise(t, `{"a":1}`, `{"a":1,"trace":"HACK"}`, map[string][]string{"trace": {`^ord-\d+$`}}) {
+		t.Errorf("an unexpected key outside its pattern must be reported")
+	}
+}
+
+// TestRegexNoise_MissingKeyRuleIsConsistent pins that path noise and global
+// noise agree: only an unconditional entry excuses a key the replay dropped.
+func TestRegexNoise_MissingKeyRuleIsConsistent(t *testing.T) {
+	recorded := `{"order":{"a":1,"status":"PAID"}}`
+	replayed := `{"order":{"a":1}}`
+
+	for _, c := range []struct {
+		name  string
+		noise map[string][]string
+		want  bool
+	}{
+		{"global, unconditional", map[string][]string{"status": {}}, true},
+		{"global, pattern-guarded", map[string][]string{"status": {"^PAID$"}}, false},
+		{"path, unconditional", map[string][]string{"order.status": {}}, true},
+		{"path, pattern-guarded", map[string][]string{"order.status": {"^PAID$"}}, false},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if got := diffNoise(t, recorded, replayed, c.noise); got != c.want {
+				t.Errorf("IsExact() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestSubstringKeyMatch_IsDeterministic pins that overlapping header-noise keys
+// resolve the same way on every run. It used to range a map and take whichever
+// key came first, so a header could be noisy in one run and not the next.
+func TestSubstringKeyMatch_IsDeterministic(t *testing.T) {
+	mp := map[string][]string{
+		"id":              {"short"},
+		"request-id":      {"medium"},
+		"x-request-id":    {"long"},
+		"x-request-id-v2": {"longest"},
+	}
+	for i := 0; i < 300; i++ {
+		got, ok := SubstringKeyMatch("X-Request-Id", mp)
+		if !ok {
+			t.Fatalf("expected a match")
+		}
+		if len(got) != 1 || got[0] != "long" {
+			t.Fatalf("iteration %d: got %v, want the most specific matching key", i, got)
+		}
+	}
+}
+
+// TestCompareHeaders_InvalidPatternDoesNotPanic covers the other consumer of
+// getCompiled. MatchesAnyRegex dereferenced the same nil, so a typo in a header
+// noise pattern crashed the run exactly as a body one did.
+func TestCompareHeaders_InvalidPatternDoesNotPanic(t *testing.T) {
+	h1 := http.Header{"X-Trace": []string{"abc"}}
+	h2 := http.Header{"X-Trace": []string{"def"}}
+	res := &[]models.HeaderResult{}
+
+	// Must not panic, and an uncompilable pattern must not silence the header.
+	if CompareHeaders(h1, h2, res, map[string][]string{"x-trace": {"^(unclosed"}}) {
+		t.Errorf("an invalid pattern must not make a differing header noisy")
+	}
+}
+
+// TestMatchesAnyRegex_InvalidPatternDoesNotPanic is the direct guard.
+func TestMatchesAnyRegex_InvalidPatternDoesNotPanic(t *testing.T) {
+	ok, pattern := MatchesAnyRegex("anything", []string{"^(unclosed", `^any`})
+	if !ok || pattern != `^any` {
+		t.Errorf("got (%v, %q), want the valid pattern to still match", ok, pattern)
+	}
+	if ok, _ := MatchesAnyRegex("anything", []string{"^(unclosed"}); ok {
+		t.Errorf("an invalid pattern must not match")
+	}
+}
+
+// TestCompareHeaders_RegexEnforced pins that a header noise pattern constrains
+// the value, matching the body semantics.
+func TestCompareHeaders_RegexEnforced(t *testing.T) {
+	noise := map[string][]string{"x-trace": {`^ord-\d+$`}}
+
+	inPattern := &[]models.HeaderResult{}
+	if !CompareHeaders(
+		http.Header{"X-Trace": []string{"ord-1"}},
+		http.Header{"X-Trace": []string{"ord-2"}}, inPattern, noise) {
+		t.Errorf("a value inside the pattern should be ignored")
+	}
+
+	outOfPattern := &[]models.HeaderResult{}
+	if CompareHeaders(
+		http.Header{"X-Trace": []string{"ord-1"}},
+		http.Header{"X-Trace": []string{"HACK"}}, outOfPattern, noise) {
+		t.Errorf("a value outside the pattern must be reported")
 	}
 }

--- a/pkg/matcher/noise_regex_test.go
+++ b/pkg/matcher/noise_regex_test.go
@@ -1,0 +1,487 @@
+package matcher
+
+import (
+	"encoding/json"
+	"math"
+	"regexp"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// diffNoise is a small helper: compare two JSON documents under a noise map and
+// report whether the matcher considered them equal.
+func diffNoise(t *testing.T, expected, actual string, noise map[string][]string) bool {
+	t.Helper()
+	e, a := expected, actual
+	v, err := ValidateAndMarshalJSON(zap.NewNop(), &e, &a)
+	if err != nil {
+		t.Fatalf("ValidateAndMarshalJSON: %v", err)
+	}
+	res, err := JSONDiffWithNoiseControl(v, noise, false)
+	if err != nil {
+		t.Fatalf("JSONDiffWithNoiseControl: %v", err)
+	}
+	return res.IsExact()
+}
+
+// TestRegexNoise_EnforcesPattern pins the contract of a regex-guarded noise
+// entry: the field is ignored ONLY when the replayed value matches one of the
+// patterns. A value outside the pattern is a real difference.
+//
+// Previously the regex was decorative — a failed match fell through to
+// `if e == a || noisy`, where noisy was still true, so the field was accepted
+// anyway. Every regex-constrained noise entry was an unconditional skip, which
+// is the opposite of what the pattern says.
+func TestRegexNoise_EnforcesPattern(t *testing.T) {
+	cases := []struct {
+		name     string
+		expected string
+		actual   string
+		noise    map[string][]string
+		want     bool
+	}{
+		{
+			name:     "string: value inside the pattern is ignored",
+			expected: `{"order":{"status":"PENDING"}}`,
+			actual:   `{"order":{"status":"PAID"}}`,
+			noise:    map[string][]string{"order.status": {"^(PENDING|PAID)$"}},
+			want:     true,
+		},
+		{
+			name:     "string: value outside the pattern is a real difference",
+			expected: `{"order":{"status":"PENDING"}}`,
+			actual:   `{"order":{"status":"GARBAGE"}}`,
+			noise:    map[string][]string{"order.status": {"^(PENDING|PAID)$"}},
+			want:     false,
+		},
+		{
+			name:     "string: identical values still match even outside the pattern",
+			expected: `{"order":{"status":"GARBAGE"}}`,
+			actual:   `{"order":{"status":"GARBAGE"}}`,
+			noise:    map[string][]string{"order.status": {"^(PENDING|PAID)$"}},
+			want:     true,
+		},
+		{
+			name:     "string: an empty regex list still ignores unconditionally",
+			expected: `{"order":{"status":"PENDING"}}`,
+			actual:   `{"order":{"status":"GARBAGE"}}`,
+			noise:    map[string][]string{"order.status": {}},
+			want:     true,
+		},
+		{
+			name:     "number: value inside the pattern is ignored",
+			expected: `{"order":{"total":1200}}`,
+			actual:   `{"order":{"total":1250}}`,
+			noise:    map[string][]string{"order.total": {`^12\d\d$`}},
+			want:     true,
+		},
+		{
+			name:     "number: value outside the pattern is a real difference",
+			expected: `{"order":{"total":1200}}`,
+			actual:   `{"order":{"total":99999}}`,
+			noise:    map[string][]string{"order.total": {`^12\d\d$`}},
+			want:     false,
+		},
+		{
+			name:     "number: an empty regex list still ignores unconditionally",
+			expected: `{"order":{"total":1200}}`,
+			actual:   `{"order":{"total":99999}}`,
+			noise:    map[string][]string{"order.total": {}},
+			want:     true,
+		},
+		{
+			name:     "number: fractional values compare in their JSON form",
+			expected: `{"order":{"rate":12.5}}`,
+			actual:   `{"order":{"rate":12.75}}`,
+			noise:    map[string][]string{"order.rate": {`^12\.\d+$`}},
+			want:     true,
+		},
+		{
+			name:     "bool: value inside the pattern is ignored",
+			expected: `{"order":{"paid":true}}`,
+			actual:   `{"order":{"paid":false}}`,
+			noise:    map[string][]string{"order.paid": {"^(true|false)$"}},
+			want:     true,
+		},
+		{
+			name:     "bool: value outside the pattern is a real difference",
+			expected: `{"order":{"paid":true}}`,
+			actual:   `{"order":{"paid":false}}`,
+			noise:    map[string][]string{"order.paid": {"^true$"}},
+			want:     false,
+		},
+		{
+			name:     "bool: an empty regex list still ignores unconditionally",
+			expected: `{"order":{"paid":true}}`,
+			actual:   `{"order":{"paid":false}}`,
+			noise:    map[string][]string{"order.paid": {}},
+			want:     true,
+		},
+		{
+			name:     "several patterns: matching any one of them ignores the field",
+			expected: `{"order":{"status":"PENDING"}}`,
+			actual:   `{"order":{"status":"SHIPPED"}}`,
+			noise:    map[string][]string{"order.status": {"^PAID$", "^SHIPPED$"}},
+			want:     true,
+		},
+		{
+			name:     "several patterns: matching none of them is a real difference",
+			expected: `{"order":{"status":"PENDING"}}`,
+			actual:   `{"order":{"status":"CANCELLED"}}`,
+			noise:    map[string][]string{"order.status": {"^PAID$", "^SHIPPED$"}},
+			want:     false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := diffNoise(t, c.expected, c.actual, c.noise); got != c.want {
+				t.Errorf("IsExact() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestRegexNoise_DoesNotLeakToSiblings pins that enforcing the pattern does not
+// change which fields the entry applies to.
+func TestRegexNoise_DoesNotLeakToSiblings(t *testing.T) {
+	expected := `{"order":{"status":"PENDING","note":"hello"}}`
+	actual := `{"order":{"status":"PAID","note":"TAMPERED"}}`
+	noise := map[string][]string{"order.status": {"^(PENDING|PAID)$"}}
+
+	if diffNoise(t, expected, actual, noise) {
+		t.Errorf("note is not covered by the noise entry and must still be compared")
+	}
+}
+
+// TestRegexNoise_UnparseableRegexDoesNotSilenceTheField guards the failure mode
+// of a typo'd pattern. getCompiled falls back to a regexp that matches nothing,
+// so the field must be compared normally rather than silently skipped.
+func TestRegexNoise_UnparseableRegexDoesNotSilenceTheField(t *testing.T) {
+	noise := map[string][]string{"order.status": {"^(unclosed"}}
+
+	if diffNoise(t, `{"order":{"status":"PENDING"}}`, `{"order":{"status":"GARBAGE"}}`, noise) {
+		t.Errorf("an invalid pattern must not silence the field")
+	}
+	if !diffNoise(t, `{"order":{"status":"PENDING"}}`, `{"order":{"status":"PENDING"}}`, noise) {
+		t.Errorf("identical values must still match when the pattern is invalid")
+	}
+}
+
+// TestGetCompiled_InvalidPatternNeverReturnsNil is the regression test for a
+// crash: the "never matches" fallback used to be `(?!)`, a negative lookahead
+// that Go's RE2 engine rejects, so getCompiled cached a nil *regexp.Regexp and
+// the first noise comparison against it dereferenced nil. A typo in a noise
+// pattern took the whole run down with a SIGSEGV.
+func TestGetCompiled_InvalidPatternNeverReturnsNil(t *testing.T) {
+	for _, pattern := range []string{
+		`^(unclosed`,
+		`(?!)`,      // the old fallback itself
+		`(?<=look)`, // lookbehind, unsupported by RE2
+		`a{2,1}`,    // invalid repetition
+		`[z-a]`,     // invalid character range
+	} {
+		re := getCompiled(pattern)
+		if re == nil {
+			t.Fatalf("getCompiled(%q) = nil, want a non-nil never-matching regex", pattern)
+		}
+		// Must not panic, and must not match anything.
+		for _, s := range []string{"", "abc", "look", "aa"} {
+			if re.MatchString(s) {
+				t.Errorf("getCompiled(%q).MatchString(%q) = true, want false", pattern, s)
+			}
+		}
+	}
+}
+
+// TestGetCompiled_ValidPatternStillWorks guards the happy path and the cache.
+func TestGetCompiled_ValidPatternStillWorks(t *testing.T) {
+	re := getCompiled(`^ord-\d+$`)
+	if re == nil {
+		t.Fatal("getCompiled returned nil for a valid pattern")
+	}
+	if !re.MatchString("ord-42") || re.MatchString("ord-x") {
+		t.Errorf("compiled pattern does not behave as written")
+	}
+	// Second call comes from the cache and must be equivalent.
+	if again := getCompiled(`^ord-\d+$`); again != re {
+		t.Errorf("expected the cached instance on the second call")
+	}
+}
+
+// TestAnyRegexpMatchStr_ToleratesNilEntries is defence in depth: even if some
+// future path puts a nil into the list, matching must not crash.
+func TestAnyRegexpMatchStr_ToleratesNilEntries(t *testing.T) {
+	if anyRegexpMatchStr("abc", []*regexp.Regexp{nil}) {
+		t.Errorf("a nil pattern must not report a match")
+	}
+	if !anyRegexpMatchStr("abc", []*regexp.Regexp{nil, regexp.MustCompile(`^abc$`)}) {
+		t.Errorf("a valid pattern after a nil must still be evaluated")
+	}
+}
+
+// TestRegexNoise_GlobalKeyEnforcesPattern covers the shape most users actually
+// write. A noise key with no dot is a "global" key, ignored at any depth — and
+// it is what `body.status` becomes once http.Match strips the `body.` prefix.
+// Its patterns used to be discarded outright when the key was classified, so
+// enforcing them on the path-based branch alone left the common case unfixed.
+func TestRegexNoise_GlobalKeyEnforcesPattern(t *testing.T) {
+	cases := []struct {
+		name     string
+		expected string
+		actual   string
+		noise    map[string][]string
+		want     bool
+	}{
+		{
+			name:     "top level, value inside the pattern",
+			expected: `{"status":"PENDING"}`,
+			actual:   `{"status":"PAID"}`,
+			noise:    map[string][]string{"status": {"^(PENDING|PAID)$"}},
+			want:     true,
+		},
+		{
+			name:     "top level, value outside the pattern",
+			expected: `{"status":"PENDING"}`,
+			actual:   `{"status":"GARBAGE"}`,
+			noise:    map[string][]string{"status": {"^(PENDING|PAID)$"}},
+			want:     false,
+		},
+		{
+			name:     "nested, value outside the pattern",
+			expected: `{"order":{"status":"PENDING"}}`,
+			actual:   `{"order":{"status":"GARBAGE"}}`,
+			noise:    map[string][]string{"status": {"^(PENDING|PAID)$"}},
+			want:     false,
+		},
+		{
+			name:     "empty pattern list still ignores everywhere",
+			expected: `{"order":{"status":"PENDING"}}`,
+			actual:   `{"order":{"status":"GARBAGE"}}`,
+			noise:    map[string][]string{"status": {}},
+			want:     true,
+		},
+		{
+			name:     "number leaf under a global key",
+			expected: `{"total":1200}`,
+			actual:   `{"total":99999}`,
+			noise:    map[string][]string{"total": {`^12\d\d$`}},
+			want:     false,
+		},
+		{
+			name:     "unexpected extra key is excused only when it matches",
+			expected: `{"a":1}`,
+			actual:   `{"a":1,"status":"GARBAGE"}`,
+			noise:    map[string][]string{"status": {"^PAID$"}},
+			want:     false,
+		},
+		{
+			name:     "unexpected extra key matching the pattern is excused",
+			expected: `{"a":1}`,
+			actual:   `{"a":1,"status":"PAID"}`,
+			noise:    map[string][]string{"status": {"^PAID$"}},
+			want:     true,
+		},
+		{
+			// No value to match, so the entry covers it — the same rule applied
+			// to a container, and what this did before patterns were enforced.
+			name:     "a missing key is excused by a pattern-guarded entry",
+			expected: `{"a":1,"status":"PAID"}`,
+			actual:   `{"a":1}`,
+			noise:    map[string][]string{"status": {"^PAID$"}},
+			want:     true,
+		},
+		{
+			name:     "a missing key is excused by an empty pattern list",
+			expected: `{"a":1,"status":"PAID"}`,
+			actual:   `{"a":1}`,
+			noise:    map[string][]string{"status": {}},
+			want:     true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := diffNoise(t, c.expected, c.actual, c.noise); got != c.want {
+				t.Errorf("IsExact() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestRegexNoise_ContainerPathRelaxesLeafValues pins that a pattern on an object
+// path relaxes the VALUES beneath it. A pattern describes one scalar, so
+// applying it to every descendant would fail fields it was never written for.
+// The subtree is not wholly ignored though — see
+// TestRegexNoise_ContainerPathStillChecksStructure.
+func TestRegexNoise_ContainerPathRelaxesLeafValues(t *testing.T) {
+	expected := `{"user":{"session":{"token":"abcdef01","expiresAt":1700000000}}}`
+	actual := `{"user":{"session":{"token":"ffffffff","expiresAt":1799999999}}}`
+
+	if !diffNoise(t, expected, actual, map[string][]string{"user.session": {"^[a-f0-9]{8}$"}}) {
+		t.Errorf("a pattern on a container path must relax the values beneath it")
+	}
+	// A sibling outside the guarded subtree is unaffected.
+	exp2 := `{"user":{"session":{"token":"abcdef01"},"name":"alice"}}`
+	act2 := `{"user":{"session":{"token":"ffffffff"},"name":"TAMPERED"}}`
+	if diffNoise(t, exp2, act2, map[string][]string{"user.session": {"^[a-f0-9]{8}$"}}) {
+		t.Errorf("name is outside the guarded subtree and must still be compared")
+	}
+}
+
+// TestRegexNoise_ContainerPathStillChecksStructure pins that relaxing the VALUES
+// under a pattern-guarded container does not also stop checking its SHAPE. A key
+// removed, added or retyped inside is a schema change, not a volatile value, and
+// a pattern was never a request to ignore it. Only an empty pattern list — which
+// has always meant "ignore this subtree" — hides structure.
+func TestRegexNoise_ContainerPathStillChecksStructure(t *testing.T) {
+	guarded := map[string][]string{"user.session": {"^[a-f0-9]+$"}}
+	unconditional := map[string][]string{"user.session": {}}
+
+	cases := []struct {
+		name     string
+		expected string
+		actual   string
+	}{
+		{
+			name:     "key missing inside the guarded subtree",
+			expected: `{"user":{"session":{"token":"abcd","kind":"bearer"}}}`,
+			actual:   `{"user":{"session":{"token":"abcd"}}}`,
+		},
+		{
+			name:     "extra key inside the guarded subtree",
+			expected: `{"user":{"session":{"token":"abcd"}}}`,
+			actual:   `{"user":{"session":{"token":"abcd","injected":"x"}}}`,
+		},
+		{
+			name:     "scalar retyped to an object inside the guarded subtree",
+			expected: `{"user":{"session":{"token":"abcd"}}}`,
+			actual:   `{"user":{"session":{"token":{"evil":true}}}}`,
+		},
+		{
+			name:     "array length change under the guarded path",
+			expected: `{"user":{"session":["abcd","ef01"]}}`,
+			actual:   `{"user":{"session":["abcd"]}}`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if diffNoise(t, c.expected, c.actual, guarded) {
+				t.Errorf("a pattern must not hide a structural change")
+			}
+			if !diffNoise(t, c.expected, c.actual, unconditional) {
+				t.Errorf("an empty pattern list must still ignore the whole subtree")
+			}
+		})
+	}
+}
+
+// TestRegexNoise_ScalarRetypedToContainerIsReported is the direct regression for
+// a hole an earlier revision of this fix introduced: skipping a pattern-guarded
+// child whenever the REPLAYED value was a container meant a scalar swapped for
+// an object or array passed silently.
+func TestRegexNoise_ScalarRetypedToContainerIsReported(t *testing.T) {
+	noise := map[string][]string{"order.id": {`^ord-\d+$`}}
+	for _, actual := range []string{
+		`{"order":{"id":{"evil":true}}}`,
+		`{"order":{"id":["evil"]}}`,
+	} {
+		if diffNoise(t, `{"order":{"id":"ord-1"}}`, actual, noise) {
+			t.Errorf("a scalar replaced by a container must be reported, got a match for %s", actual)
+		}
+	}
+}
+
+// TestFormatJSONNumber matches encoding/json's own float rendering, so a
+// pattern written against the value Keploy prints in its diff matches at
+// replay. Plain 'f' formatting diverges at both extremes.
+func TestFormatJSONNumber(t *testing.T) {
+	for _, c := range []struct{ in float64 }{
+		{1200}, {1200.5}, {100.10}, {0}, {math.Copysign(0, -1)}, {-12.75},
+		{1e21}, {1e-7}, {5e-324}, {1e20}, {1e-6}, {123456789012345680000},
+	} {
+		want, err := json.Marshal(c.in)
+		if err != nil {
+			t.Fatalf("json.Marshal(%v): %v", c.in, err)
+		}
+		if got := formatJSONNumber(c.in); got != string(want) {
+			t.Errorf("formatJSONNumber(%v) = %q, encoding/json renders %q", c.in, got, want)
+		}
+	}
+}
+
+// TestRegexNoise_OverlappingEntriesAreDeterministic pins that two noise entries
+// whose paths overlap produce the same verdict on every run.
+//
+// noiseIndex.match returns the first matching entry, and buildNoiseIndex used to
+// append them in Go map order, which is randomized per process. That was
+// invisible while every entry meant "ignore unconditionally"; once patterns
+// decide the verdict it made a suite flip green/red between runs with no input
+// change. Entries are now ordered most-specific first.
+func TestRegexNoise_OverlappingEntriesAreDeterministic(t *testing.T) {
+	cases := []struct {
+		name  string
+		noise map[string][]string
+	}{
+		{"specific unconditional, general guarded", map[string][]string{"user.id": {`^\d+$`}, "order.user.id": {}}},
+		{"both guarded", map[string][]string{"user.id": {`^\d+$`}, "order.user.id": {`^u-\d+$`}}},
+		{"three overlapping", map[string][]string{"id": {`^\d+$`}, "user.id": {}, "order.user.id": {`^u-\d+$`}}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			first := diffNoise(t, `{"order":{"user":{"id":"u-1"}}}`, `{"order":{"user":{"id":"u-2"}}}`, c.noise)
+			for i := 0; i < 300; i++ {
+				if got := diffNoise(t, `{"order":{"user":{"id":"u-1"}}}`, `{"order":{"user":{"id":"u-2"}}}`, c.noise); got != first {
+					t.Fatalf("verdict flipped between runs (%v then %v) — entry order is not deterministic", first, got)
+				}
+			}
+		})
+	}
+}
+
+// TestRegexNoise_MostSpecificEntryWins pins which of two overlapping entries is
+// chosen, so the ordering is a documented contract rather than an accident.
+func TestRegexNoise_MostSpecificEntryWins(t *testing.T) {
+	// The longer path is the one the user meant for this field: it says the id
+	// looks like "u-<n>", so a value of that shape is ignored...
+	noise := map[string][]string{"id": {`^\d+$`}, "order.user.id": {`^u-\d+$`}}
+	if !diffNoise(t, `{"order":{"user":{"id":"u-1"}}}`, `{"order":{"user":{"id":"u-2"}}}`, noise) {
+		t.Errorf("the more specific entry should have matched and ignored this value")
+	}
+	// ...and a value outside it is still a real difference, rather than being
+	// rescued by the shorter, more general entry.
+	if diffNoise(t, `{"order":{"user":{"id":"u-1"}}}`, `{"order":{"user":{"id":"XXX"}}}`, noise) {
+		t.Errorf("a value outside the more specific entry's pattern must be reported")
+	}
+}
+
+// TestRegexNoise_ArrayOfScalarsEnforcesPattern covers the one container where a
+// pattern is unambiguous: `ids: ["^ord-\d+$"]` plainly means every id looks like
+// that, so it is applied per element.
+func TestRegexNoise_ArrayOfScalarsEnforcesPattern(t *testing.T) {
+	noise := map[string][]string{"order.ids": {`^ord-\d+$`}}
+
+	if !diffNoise(t, `{"order":{"ids":["ord-1","ord-2"]}}`, `{"order":{"ids":["ord-7","ord-9"]}}`, noise) {
+		t.Errorf("every element matches the pattern, so the array should be ignored")
+	}
+	if diffNoise(t, `{"order":{"ids":["ord-1","ord-2"]}}`, `{"order":{"ids":["ord-7","HACK"]}}`, noise) {
+		t.Errorf("an element outside the pattern must be reported")
+	}
+	// An empty pattern list keeps ignoring the array wholesale.
+	if !diffNoise(t, `{"order":{"ids":["ord-1"]}}`, `{"order":{"ids":["HACK"]}}`, map[string][]string{"order.ids": {}}) {
+		t.Errorf("an empty pattern list must still ignore the whole array")
+	}
+	// A length change is structural and is still reported.
+	if diffNoise(t, `{"order":{"ids":["ord-1","ord-2"]}}`, `{"order":{"ids":["ord-1"]}}`, noise) {
+		t.Errorf("an array length change must be reported")
+	}
+	// An array of objects has no single value for the pattern to describe, so it
+	// falls back to relaxing the element values, as a map does.
+	nested := map[string][]string{"order.items": {`^ord-\d+$`}}
+	if !diffNoise(t, `{"order":{"items":[{"id":"ord-1"}]}}`, `{"order":{"items":[{"id":"HACK"}]}}`, nested) {
+		t.Errorf("a non-scalar array relaxes its values rather than applying the pattern per element")
+	}
+}

--- a/pkg/matcher/noise_regex_test.go
+++ b/pkg/matcher/noise_regex_test.go
@@ -671,3 +671,123 @@ func TestCompareHeaders_RegexEnforced(t *testing.T) {
 		t.Errorf("a value outside the pattern must be reported")
 	}
 }
+
+// TestRegexNoise_UnexpectedContainerKeyIsReported pins that a pattern which
+// cannot describe a container does NOT excuse one appearing in the replay.
+// Reading "this pattern can't match an object" as "so ignore the object" would
+// let an injected subtree through unchecked.
+func TestRegexNoise_UnexpectedContainerKeyIsReported(t *testing.T) {
+	for _, injected := range []string{`{"evil":true}`, `[1]`} {
+		actual := `{"a":{"k":` + injected + `}}`
+		if diffNoise(t, `{"a":{}}`, actual, map[string][]string{"a.k": {"^zzz$"}}) {
+			t.Errorf("an injected container must be reported, got a match for %s", actual)
+		}
+		if diffNoise(t, `{"a":{}}`, actual, map[string][]string{"k": {"^zzz$"}}) {
+			t.Errorf("global entry: an injected container must be reported, got a match for %s", actual)
+		}
+		// An unconditional entry still covers it.
+		if !diffNoise(t, `{"a":{}}`, actual, map[string][]string{"a.k": {}}) {
+			t.Errorf("an unconditional entry must still cover %s", actual)
+		}
+	}
+}
+
+// TestRegexNoise_UnexpectedKeyPathForm covers the path-noise form of the
+// unexpected-key rule; the global form is covered above.
+func TestRegexNoise_UnexpectedKeyPathForm(t *testing.T) {
+	if !diffNoise(t, `{"o":{"a":1}}`, `{"o":{"a":1,"trace":"ord-9"}}`, map[string][]string{"o.trace": {`^ord-\d+$`}}) {
+		t.Errorf("an unexpected key matching its pattern should be excused")
+	}
+	if diffNoise(t, `{"o":{"a":1}}`, `{"o":{"a":1,"trace":"HACK"}}`, map[string][]string{"o.trace": {`^ord-\d+$`}}) {
+		t.Errorf("an unexpected key outside its pattern must be reported")
+	}
+}
+
+// TestRegexNoise_NullReplacedByContainerIsReported keeps the null branch in step
+// with the scalar one: a retype is a schema change, not a volatile value.
+func TestRegexNoise_NullReplacedByContainerIsReported(t *testing.T) {
+	for _, pattern := range []string{".*", "^$"} {
+		if diffNoise(t, `{"o":{"m":null}}`, `{"o":{"m":{"a":1}}}`, map[string][]string{"o.m": {pattern}}) {
+			t.Errorf("null replaced by an object must be reported even under pattern %q", pattern)
+		}
+	}
+	if !diffNoise(t, `{"o":{"m":null}}`, `{"o":{"m":{"a":1}}}`, map[string][]string{"o.m": {}}) {
+		t.Errorf("an unconditional entry must still cover the retype")
+	}
+}
+
+// TestSectionedNoise_WildcardIgnoresTheSection pins that a bare "*" keeps its
+// documented "ignore everything" meaning instead of becoming a field literally
+// named "*".
+func TestSectionedNoise_WildcardIgnoresTheSection(t *testing.T) {
+	body, header, skipBody := SplitNoise(map[string][]string{"body": {"*"}}, nil)
+	if !skipBody {
+		t.Errorf(`body: ["*"] must skip the whole body`)
+	}
+	if len(body) != 0 {
+		t.Errorf("bodyNoise = %v, want no field entries", body)
+	}
+	if _, _, _ = SplitNoise(map[string][]string{"header": {"*"}}, nil); true {
+		_, h, _ := SplitNoise(map[string][]string{"header": {"*"}}, nil)
+		if _, ok := h["header"]; !ok {
+			t.Errorf(`header: ["*"] must mark the whole header section noisy, got %v`, h)
+		}
+	}
+	_ = header
+}
+
+// TestCompilePatterns_SentinelsAreNotRegexes pins that the wildcard and the
+// empty string do not produce a spurious "invalid pattern" warning; "*" is not
+// valid regex syntax, and it is a documented config value.
+func TestCompilePatterns_SentinelsAreNotRegexes(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	logger := zap.New(core)
+
+	if got := compilePatterns([]string{"*"}, logger); got != nil {
+		t.Errorf(`compilePatterns(["*"]) = %v, want nil (unconditional)`, got)
+	}
+	if got := compilePatterns([]string{""}, logger); got != nil {
+		t.Errorf(`compilePatterns([""]) = %v, want nil (unconditional)`, got)
+	}
+	if logs.Len() != 0 {
+		t.Errorf("emitted %d warnings for sentinel values, want 0: %v", logs.Len(), logs.All())
+	}
+}
+
+// TestWarnIfIndexedPath pins the diagnostic for the one recorded shape that
+// silently stops matching: a noise path carrying an array position.
+func TestWarnIfIndexedPath(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	logger := zap.New(core)
+
+	SplitNoise(map[string][]string{"body": {"items.0.product.stock"}}, logger)
+	if logs.Len() != 1 {
+		t.Fatalf("emitted %d warnings, want 1: %v", logs.Len(), logs.All())
+	}
+	if got := logs.All()[0].ContextMap()["suggested"]; got != "items.product.stock" {
+		t.Errorf("suggested = %v, want the index-free path", got)
+	}
+
+	// An index-free path is fine and must not warn.
+	core2, logs2 := observer.New(zapcore.WarnLevel)
+	SplitNoise(map[string][]string{"body": {"items.product.stock"}}, zap.New(core2))
+	if logs2.Len() != 0 {
+		t.Errorf("emitted %d warnings for an index-free path, want 0", logs2.Len())
+	}
+}
+
+// TestGetCompiledE_ReportsErrorOnCacheHit pins that the compile error survives
+// the regex cache, so a later caller can still warn the user.
+func TestGetCompiledE_ReportsErrorOnCacheHit(t *testing.T) {
+	pattern := `^(unclosed-cachehit`
+	if _, err := getCompiledE(pattern); err == nil {
+		t.Fatal("first call should report the compile error")
+	}
+	re, err := getCompiledE(pattern)
+	if err == nil {
+		t.Errorf("second (cached) call lost the compile error")
+	}
+	if re == nil || re.MatchString("anything") {
+		t.Errorf("cached fallback must be a non-nil never-matching regex")
+	}
+}

--- a/pkg/matcher/risk.go
+++ b/pkg/matcher/risk.go
@@ -30,7 +30,7 @@ func ComputeFailureAssessmentJSON(expJSON, actJSON string, bodyNoise map[string]
 		return nil, err
 	}
 
-	idx := buildNoiseIndex(bodyNoise) // already in matcher/utils.go
+	idx := buildNoiseIndex(bodyNoise, nil) // already in matcher/utils.go
 
 	expMaps := pathMaps{types: map[string]string{}, values: map[string]string{}}
 	actMaps := pathMaps{types: map[string]string{}, values: map[string]string{}}
@@ -136,7 +136,7 @@ func ChangedJSONFieldPaths(expJSON, actJSON string, known map[string][]string, e
 		return nil
 	}
 
-	idx := buildNoiseIndex(known)
+	idx := buildNoiseIndex(known, nil)
 
 	expMaps := pathMaps{types: map[string]string{}, values: map[string]string{}}
 	actMaps := pathMaps{types: map[string]string{}, values: map[string]string{}}
@@ -192,7 +192,7 @@ func JSONFieldDiffs(expJSON, actJSON string, known map[string][]string, pathPref
 		return nil
 	}
 
-	idx := buildNoiseIndex(known)
+	idx := buildNoiseIndex(known, nil)
 
 	expMaps := pathMaps{types: map[string]string{}, values: map[string]string{}}
 	actMaps := pathMaps{types: map[string]string{}, values: map[string]string{}}
@@ -260,9 +260,14 @@ func JSONFieldDiffs(expJSON, actJSON string, known map[string][]string, pathPref
 
 func collectJSON(v interface{}, path string, ni noiseIndex, out *pathMaps) {
 	keyLower := strings.ToLower(path)
-	if regs, noisy := ni.match(keyLower); noisy && len(regs) == 0 {
-		// whole subtree is noisy → ignore
-		return
+	if regs, noisy := ni.match(keyLower); noisy {
+		// An entry with no patterns ignores the whole subtree. A pattern-guarded
+		// entry ignores only the values it describes, so it must be evaluated
+		// against this value — otherwise a field the matcher just reported as a
+		// difference would be missing from the report explaining it.
+		if len(regs) == 0 || noisyForRegexps(regs, v) {
+			return
+		}
 	}
 
 	switch t := v.(type) {

--- a/pkg/matcher/risk.go
+++ b/pkg/matcher/risk.go
@@ -265,7 +265,14 @@ func collectJSON(v interface{}, path string, ni noiseIndex, out *pathMaps) {
 		// entry ignores only the values it describes, so it must be evaluated
 		// against this value — otherwise a field the matcher just reported as a
 		// difference would be missing from the report explaining it.
-		if len(regs) == 0 || noisyForRegexps(regs, v) {
+		// An unconditional entry hides the whole subtree. A pattern-guarded one
+		// hides only a scalar it actually matches — the matcher keeps walking a
+		// guarded container, so dropping it here would report "nothing changed"
+		// for a test the matcher just failed.
+		if len(regs) == 0 {
+			return
+		}
+		if str, isScalar := jsonScalarToString(v); isScalar && anyRegexpMatchStr(str, regs) {
 			return
 		}
 	}

--- a/pkg/matcher/risk_noise_test.go
+++ b/pkg/matcher/risk_noise_test.go
@@ -1,0 +1,86 @@
+package matcher
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// TestFailureAssessment_AgreesWithTheMatcher pins that the failure report and
+// the pass/fail verdict use the same notion of "noisy".
+//
+// collectJSON used to treat any pattern-guarded entry as an unconditional skip,
+// so it dropped subtrees the matcher was still comparing. The user got a red
+// test alongside a report claiming nothing had changed.
+func TestFailureAssessment_AgreesWithTheMatcher(t *testing.T) {
+	cases := []struct {
+		name        string
+		expected    string
+		actual      string
+		noise       map[string][]string
+		wantFailure bool
+	}{
+		{
+			name:        "pattern-guarded container: matcher fails, report must explain it",
+			expected:    `{"a":{"b":{"c":"x"}}}`,
+			actual:      `{"a":{"b":{"c":"x","d":1}}}`,
+			noise:       map[string][]string{"a.b": {"^zzz$"}},
+			wantFailure: true,
+		},
+		{
+			name:        "pattern-guarded scalar the pattern matches: genuinely noise",
+			expected:    `{"a":{"b":"ord-1"}}`,
+			actual:      `{"a":{"b":"ord-2"}}`,
+			noise:       map[string][]string{"a.b": {`^ord-\d+$`}},
+			wantFailure: false,
+		},
+		{
+			name:        "pattern-guarded scalar outside the pattern: a real difference",
+			expected:    `{"a":{"b":"ord-1"}}`,
+			actual:      `{"a":{"b":"HACK"}}`,
+			noise:       map[string][]string{"a.b": {`^ord-\d+$`}},
+			wantFailure: true,
+		},
+		{
+			name:        "unconditional entry hides the subtree from both",
+			expected:    `{"a":{"b":{"c":"x"}}}`,
+			actual:      `{"a":{"b":{"c":"y","d":1}}}`,
+			noise:       map[string][]string{"a.b": {}},
+			wantFailure: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			exp, act := c.expected, c.actual
+			v, err := ValidateAndMarshalJSON(zap.NewNop(), &exp, &act)
+			if err != nil {
+				t.Fatalf("ValidateAndMarshalJSON: %v", err)
+			}
+			res, err := JSONDiffWithNoiseControl(v, c.noise, false, nil)
+			if err != nil {
+				t.Fatalf("JSONDiffWithNoiseControl: %v", err)
+			}
+			matcherFailed := !res.IsExact()
+			if matcherFailed != c.wantFailure {
+				t.Fatalf("matcher verdict failed=%v, want %v", matcherFailed, c.wantFailure)
+			}
+
+			fa, err := ComputeFailureAssessmentJSON(c.expected, c.actual, c.noise, false)
+			if err != nil {
+				t.Fatalf("ComputeFailureAssessmentJSON: %v", err)
+			}
+			reportSawSomething := fa != nil && (len(fa.AddedFields) > 0 ||
+				len(fa.RemovedFields) > 0 ||
+				len(fa.TypeChanges) > 0 ||
+				len(fa.ValueChanges) > 0)
+
+			if matcherFailed && !reportSawSomething {
+				t.Errorf("matcher failed the test but the report found nothing to explain it: %+v", fa)
+			}
+			if !matcherFailed && reportSawSomething {
+				t.Errorf("matcher passed but the report claims a change: %+v", fa)
+			}
+		})
+	}
+}

--- a/pkg/matcher/schema/match.go
+++ b/pkg/matcher/schema/match.go
@@ -210,7 +210,7 @@ func calculateSimilarityScore(mockOperation, testOperation *models.Operation, st
 func handleJSONDiff(validatedJSON matcher.ValidatedJSON, logDiffs matcher.DiffsPrinter, newLogger *pp.PrettyPrinter, logger *zap.Logger, _ string, _ string, _ string, _ string, mockBodyStr string, testBodyStr string, diffType string, mode models.SchemaMatchMode) (float64, bool, error) {
 	pass := true
 	differencesCount := 0.0
-	jsonComparisonResult, err := matcher.JSONDiffWithNoiseControl(validatedJSON, nil, false)
+	jsonComparisonResult, err := matcher.JSONDiffWithNoiseControl(validatedJSON, nil, false, logger)
 	if err != nil {
 		return differencesCount, false, err
 	}

--- a/pkg/matcher/utils.go
+++ b/pkg/matcher/utils.go
@@ -40,18 +40,28 @@ var (
 
 // getCompiled returns a cached compiled regexp for pattern.
 // It never panics and never returns nil: on invalid patterns it returns a
-// "never matches" regex and caches it.
+// "never matches" regex and caches it. Use getCompiledE when the caller can
+// report the mistake to the user.
 func getCompiled(pattern string) *regexp.Regexp {
+	re, _ := getCompiledE(pattern)
+	return re
+}
+
+// getCompiledE is getCompiled plus the compile error, so a caller holding a
+// logger can tell the user their pattern is broken instead of silently turning
+// it into a never-match — which reads as "my noise entry stopped working" with
+// no explanation.
+func getCompiledE(pattern string) (*regexp.Regexp, error) {
 	regexCacheMu.RLock()
 	re := regexCache[pattern]
 	regexCacheMu.RUnlock()
 	if re != nil {
-		return re
+		return re, nil
 	}
 
 	// Compile outside the read lock.
-	compiled, err := regexp.Compile(pattern)
-	if err != nil {
+	compiled, compileErr := regexp.Compile(pattern)
+	if compileErr != nil {
 		// Fall back to a regex that never matches, to avoid repeated compiles of
 		// a pattern that will never work. It must be a pattern RE2 accepts:
 		// `(?!)` is a negative lookahead, which Go's regexp rejects, so the
@@ -69,7 +79,26 @@ func getCompiled(pattern string) *regexp.Regexp {
 		compiled = old
 	}
 	regexCacheMu.Unlock()
-	return compiled
+	return compiled, compileErr
+}
+
+// warnedBadPattern dedupes the invalid-pattern warning. Noise is compiled once
+// per test case, so warning every time would emit one line per case.
+var warnedBadPattern sync.Map
+
+// warnInvalidPattern reports a pattern that could not be compiled. Such a
+// pattern silently matches nothing, so without this the user sees a field they
+// thought was noise start failing, with nothing pointing at the cause.
+func warnInvalidPattern(logger *zap.Logger, pattern string, err error) {
+	if logger == nil {
+		return
+	}
+	if _, seen := warnedBadPattern.LoadOrStore(pattern, struct{}{}); seen {
+		return
+	}
+	logger.Warn("ignoring an invalid noise pattern; it matches nothing, so the field it names is still compared",
+		zap.String("pattern", pattern),
+		zap.Error(err))
 }
 
 func MatchesAnyRegex(str string, regexArray []string) (bool, string) {
@@ -89,7 +118,7 @@ type noiseIndex struct {
 	entries []noiseEntry
 }
 
-func buildNoiseIndex(mp map[string][]string) noiseIndex {
+func buildNoiseIndex(mp map[string][]string, logger *zap.Logger) noiseIndex {
 	if mp == nil {
 		return noiseIndex{}
 	}
@@ -97,7 +126,7 @@ func buildNoiseIndex(mp map[string][]string) noiseIndex {
 	for k, arr := range mp {
 		out.entries = append(out.entries, noiseEntry{
 			keyLower: strings.ToLower(k),
-			regexps:  compilePatterns(arr),
+			regexps:  compilePatterns(arr, logger),
 		})
 	}
 
@@ -270,7 +299,7 @@ func looksLikeRegex(value string) bool {
 
 // JSONDiffWithNoiseControl compares JSON with support for both Path-based noise (e.g. "body.user.id")
 // and Global noise (e.g. "timestamp") to be ignored everywhere.
-func JSONDiffWithNoiseControl(validatedJSON ValidatedJSON, noise map[string][]string, ignoreOrdering bool) (JSONComparisonResult, error) {
+func JSONDiffWithNoiseControl(validatedJSON ValidatedJSON, noise map[string][]string, ignoreOrdering bool, logger *zap.Logger) (JSONComparisonResult, error) {
 	// Split noise into Path-based (contains dots) and Global (no dots)
 	pathNoise := make(map[string][]string)
 	globalKeys := make(map[string][]*regexp.Regexp)
@@ -282,14 +311,14 @@ func JSONDiffWithNoiseControl(validatedJSON ValidatedJSON, noise map[string][]st
 		// here as the dot-free "status"), and dropping them here would leave every
 		// such entry an unconditional skip no matter what the caller wrote.
 		if !strings.Contains(k, ".") {
-			globalKeys[strings.ToLower(k)] = compilePatterns(v)
+			globalKeys[strings.ToLower(k)] = compilePatterns(v, logger)
 		} else {
 			// Otherwise, it's a path-specific noise (e.g. "body.data.timestamp")
 			pathNoise[k] = v
 		}
 	}
 
-	idx := buildNoiseIndex(pathNoise)
+	idx := buildNoiseIndex(pathNoise, logger)
 	return matchJSONWithNoiseHandlingIndexed("", validatedJSON.expected, validatedJSON.actual, idx, globalKeys, ignoreOrdering, false)
 }
 
@@ -300,6 +329,19 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 	switch e := expected.(type) {
 	case nil:
 		if actual == nil {
+			out.matches, out.isExact = true, true
+			return out, nil
+		}
+		// A field recorded as null and replayed as something else. Nullable
+		// volatile fields are exactly what a pattern is for, so consult the
+		// noise entry against the replayed value rather than ignoring it.
+		if av, ok := jsonScalarToString(actual); ok {
+			if ancestorNoisy || noisyForValue(ni, key, av) {
+				out.matches, out.isExact = true, true
+			}
+			return out, nil
+		}
+		if ancestorNoisy || noisyForValue(ni, key, "") {
 			out.matches, out.isExact = true, true
 		}
 		return out, nil
@@ -367,11 +409,16 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 		for k, v := range e {
 			val, ok := a[k]
 			if !ok {
-				// The replay dropped a key the recording had. There is no value
-				// for a pattern to match, so the entry covers it — the same rule
-				// noisyForRegexps applies to a container, and what this did
-				// before patterns were enforced at all.
-				if _, isGlobal := globalKeys[strings.ToLower(k)]; isGlobal {
+				// The replay dropped a key the recording had. Only an entry that
+				// ignores the field unconditionally excuses that: a pattern has
+				// no value to match against, and a field disappearing is a schema
+				// change rather than a volatile value. Path noise and global noise
+				// agree on this — previously the global form excused it even when
+				// pattern-guarded, and the path form never excused it at all.
+				if regs, isGlobal := globalKeys[strings.ToLower(k)]; isGlobal && len(regs) == 0 {
+					continue
+				}
+				if regs, noisy := ni.match(prefixLower + strings.ToLower(k)); noisy && len(regs) == 0 {
 					continue
 				}
 				return out, nil
@@ -411,7 +458,7 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 				continue
 			}
 			childKeyLower := prefixLower + strings.ToLower(k)
-			if regs, noisy := ni.match(childKeyLower); noisy && len(regs) == 0 {
+			if regs, noisy := ni.match(childKeyLower); noisy && noisyForRegexps(regs, a[k]) {
 				continue // ignore unexpected but noisy subtree
 			}
 			return out, nil
@@ -539,13 +586,17 @@ func noisyForValue(ni noiseIndex, key, actual string) bool {
 
 // compilePatterns compiles a noise entry's patterns. A nil result means the
 // entry has none, i.e. it ignores its field unconditionally.
-func compilePatterns(patterns []string) []*regexp.Regexp {
+func compilePatterns(patterns []string, logger *zap.Logger) []*regexp.Regexp {
 	if len(patterns) == 0 {
 		return nil
 	}
 	out := make([]*regexp.Regexp, 0, len(patterns))
 	for _, p := range patterns {
-		out = append(out, getCompiled(p))
+		re, err := getCompiledE(p)
+		if err != nil {
+			warnInvalidPattern(logger, p, err)
+		}
+		out = append(out, re)
 	}
 	return out
 }
@@ -1660,11 +1711,19 @@ func CompareHeaders(h1 http.Header, h2 http.Header, res *[]models.HeaderResult, 
 	_, isHeaderNoisy := loweredNoise["header"]
 	for k, v := range h1 {
 		regexArr, isNoisy := SubstringKeyMatch(k, loweredNoise)
+		val, ok := h2[k]
 		if isNoisy && len(regexArr) != 0 {
-			isNoisy, _ = MatchesAnyRegex(v[0], regexArr)
+			// Constrain on the REPLAYED value, matching how body noise works:
+			// the replayed value is the one that varies, so testing the recorded
+			// one instead would let any replayed value through. A header the
+			// replay dropped has no value to match, so a pattern-guarded entry
+			// does not excuse it — only an unconditional entry does.
+			isNoisy = false
+			if ok && len(val) > 0 {
+				isNoisy, _ = MatchesAnyRegex(val[0], regexArr)
+			}
 		}
 		isNoisy = isNoisy || isHeaderNoisy
-		val, ok := h2[k]
 		if !isNoisy {
 			if !ok {
 				if checkKey(res, k) {
@@ -1807,12 +1866,23 @@ func MapToArray(mp map[string][]string) []string {
 // does not accept one today.
 func SubstringKeyMatch(s string, mp map[string][]string) ([]string, bool) {
 	sLower := strings.ToLower(s)
-	for key, val := range mp {
-		if strings.Contains(sLower, strings.ToLower(key)) {
-			return val, true
+	// Ranging a map picks an arbitrary winner when several keys match, so two
+	// runs of the same suite could disagree on whether a header is noisy.
+	// Resolve most-specific first — longest key, ties lexicographic — the same
+	// precedence buildNoiseIndex uses.
+	best, found := "", false
+	for key := range mp {
+		if !strings.Contains(sLower, strings.ToLower(key)) {
+			continue
+		}
+		if !found || len(key) > len(best) || (len(key) == len(best) && key < best) {
+			best, found = key, true
 		}
 	}
-	return []string{}, false
+	if !found {
+		return []string{}, false
+	}
+	return mp[best], true
 }
 
 // func CheckStringExist(s string, mp map[string][]string) ([]string, bool) {

--- a/pkg/matcher/utils.go
+++ b/pkg/matcher/utils.go
@@ -8,11 +8,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"mime"
 	"net/http"
 	"os"
 	"reflect"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -32,10 +34,13 @@ import (
 var (
 	regexCacheMu sync.RWMutex
 	regexCache   = make(map[string]*regexp.Regexp)
+	// neverMatches matches no input at all, not even the empty string.
+	neverMatches = regexp.MustCompile(`[^\s\S]`)
 )
 
 // getCompiled returns a cached compiled regexp for pattern.
-// It never panics: on invalid patterns, it returns a "never matches" regex (?!) and caches it.
+// It never panics and never returns nil: on invalid patterns it returns a
+// "never matches" regex and caches it.
 func getCompiled(pattern string) *regexp.Regexp {
 	regexCacheMu.RLock()
 	re := regexCache[pattern]
@@ -47,8 +52,13 @@ func getCompiled(pattern string) *regexp.Regexp {
 	// Compile outside the read lock.
 	compiled, err := regexp.Compile(pattern)
 	if err != nil {
-		// Fallback to a regex that never matches to avoid panics / repeated compiles
-		compiled, _ = regexp.Compile(`(?!)`)
+		// Fall back to a regex that never matches, to avoid repeated compiles of
+		// a pattern that will never work. It must be a pattern RE2 accepts:
+		// `(?!)` is a negative lookahead, which Go's regexp rejects, so the
+		// fallback used to leave `compiled` nil and every user of it dereferenced
+		// nil. `[^\s\S]` asks for a character that is neither whitespace nor
+		// non-whitespace, so it matches nothing at all — not even the empty string.
+		compiled = neverMatches
 	}
 
 	regexCacheMu.Lock()
@@ -85,15 +95,25 @@ func buildNoiseIndex(mp map[string][]string) noiseIndex {
 	}
 	out := noiseIndex{entries: make([]noiseEntry, 0, len(mp))}
 	for k, arr := range mp {
-		e := noiseEntry{keyLower: strings.ToLower(k)}
-		if len(arr) > 0 {
-			e.regexps = make([]*regexp.Regexp, 0, len(arr))
-			for _, p := range arr {
-				e.regexps = append(e.regexps, getCompiled(p))
-			}
-		}
-		out.entries = append(out.entries, e)
+		out.entries = append(out.entries, noiseEntry{
+			keyLower: strings.ToLower(k),
+			regexps:  compilePatterns(arr),
+		})
 	}
+
+	// match() returns the FIRST entry that matches, and entries arrive here in
+	// Go map order, which is randomized per process. That was invisible while
+	// every entry meant the same thing (ignore unconditionally); now that an
+	// entry's patterns decide the verdict, two overlapping entries would make a
+	// test pass or fail depending on the run. Order most-specific first so the
+	// winner is both deterministic and the one a user writing "user.id" and
+	// "order.user.id" would expect.
+	sort.Slice(out.entries, func(i, j int) bool {
+		if len(out.entries[i].keyLower) != len(out.entries[j].keyLower) {
+			return len(out.entries[i].keyLower) > len(out.entries[j].keyLower)
+		}
+		return out.entries[i].keyLower < out.entries[j].keyLower
+	})
 	return out
 }
 
@@ -253,12 +273,16 @@ func looksLikeRegex(value string) bool {
 func JSONDiffWithNoiseControl(validatedJSON ValidatedJSON, noise map[string][]string, ignoreOrdering bool) (JSONComparisonResult, error) {
 	// Split noise into Path-based (contains dots) and Global (no dots)
 	pathNoise := make(map[string][]string)
-	globalKeys := make(map[string]bool)
+	globalKeys := make(map[string][]*regexp.Regexp)
 
 	for k, v := range noise {
 		// If a key has no dots, treat it as a Global Key to be ignored everywhere.
+		// Its patterns are carried through: a global key is by far the most common
+		// shape (http.Match strips the "body." prefix, so "body.status" arrives
+		// here as the dot-free "status"), and dropping them here would leave every
+		// such entry an unconditional skip no matter what the caller wrote.
 		if !strings.Contains(k, ".") {
-			globalKeys[strings.ToLower(k)] = true
+			globalKeys[strings.ToLower(k)] = compilePatterns(v)
 		} else {
 			// Otherwise, it's a path-specific noise (e.g. "body.data.timestamp")
 			pathNoise[k] = v
@@ -266,11 +290,11 @@ func JSONDiffWithNoiseControl(validatedJSON ValidatedJSON, noise map[string][]st
 	}
 
 	idx := buildNoiseIndex(pathNoise)
-	return matchJSONWithNoiseHandlingIndexed("", validatedJSON.expected, validatedJSON.actual, idx, globalKeys, ignoreOrdering)
+	return matchJSONWithNoiseHandlingIndexed("", validatedJSON.expected, validatedJSON.actual, idx, globalKeys, ignoreOrdering, false)
 }
 
 // matchJSONWithNoiseHandlingIndexed now accepts globalKeys to skip specific keys at any depth.
-func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{}, ni noiseIndex, globalKeys map[string]bool, ignoreOrdering bool) (JSONComparisonResult, error) {
+func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{}, ni noiseIndex, globalKeys map[string][]*regexp.Regexp, ignoreOrdering bool, ancestorNoisy bool) (JSONComparisonResult, error) {
 	var out JSONComparisonResult
 	// Type check fast-path (JSON unmarshal produces these concrete types).
 	switch e := expected.(type) {
@@ -285,14 +309,7 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 		if !ok {
 			return out, errors.New("type not matched")
 		}
-		regs, noisy := ni.match(strings.ToLower(key))
-		if noisy && len(regs) != 0 {
-			if anyRegexpMatchStr(a, regs) {
-				out.matches, out.isExact = true, true
-				return out, nil
-			}
-		}
-		if e == a || noisy {
+		if e == a || ancestorNoisy || noisyForValue(ni, key, a) {
 			out.matches, out.isExact = true, true
 		}
 		return out, nil
@@ -302,8 +319,7 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 		if !ok {
 			return out, errors.New("type not matched")
 		}
-		_, noisy := ni.match(strings.ToLower(key))
-		if e == a || noisy {
+		if e == a || ancestorNoisy || noisyForValue(ni, key, strconv.FormatBool(a)) {
 			out.matches, out.isExact = true, true
 		}
 		return out, nil
@@ -313,8 +329,7 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 		if !ok {
 			return out, errors.New("type not matched")
 		}
-		_, noisy := ni.match(strings.ToLower(key))
-		if e == a || noisy {
+		if e == a || ancestorNoisy || noisyForValue(ni, key, formatJSONNumber(a)) {
 			out.matches, out.isExact = true, true
 		}
 		return out, nil
@@ -325,11 +340,17 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 			return out, errors.New("type not matched")
 		}
 
-		// If whole subtree is noisy (no regex guard), accept.
-		if regs, noisy := ni.match(strings.ToLower(key)); noisy && len(regs) == 0 {
+		// An entry with no patterns ignores the whole subtree, structure included.
+		regs, noisy := ni.match(strings.ToLower(key))
+		if noisy && len(regs) == 0 {
 			out.matches, out.isExact = true, true
 			return out, nil
 		}
+		// A pattern describes one scalar, so there is nothing here for it to
+		// match. Keep walking the structure — a key added, removed or retyped
+		// inside is still a real change — and let the descendant leaf VALUES be
+		// accepted, which is the most the pattern could have been asking for.
+		ancestorNoisy = ancestorNoisy || noisy
 
 		// Quick length check — allows early exit if extra/missing keys (ignoring noisy children).
 		// We still need to walk to account for noisy exclusions; so we won't return solely on len.
@@ -344,22 +365,33 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 
 		// 1) All expected keys must be present & match.
 		for k, v := range e {
-			if globalKeys[strings.ToLower(k)] {
+			val, ok := a[k]
+			if !ok {
+				// The replay dropped a key the recording had. There is no value
+				// for a pattern to match, so the entry covers it — the same rule
+				// noisyForRegexps applies to a container, and what this did
+				// before patterns were enforced at all.
+				if _, isGlobal := globalKeys[strings.ToLower(k)]; isGlobal {
+					continue
+				}
+				return out, nil
+			}
+
+			if regs, isGlobal := globalKeys[strings.ToLower(k)]; isGlobal && noisyForRegexps(regs, val) {
 				continue
 			}
 
-			val, ok := a[k]
-			if !ok {
-				return out, nil
-			}
 			childKeyLower := prefixLower + strings.ToLower(k)
 
-			// If child subtree is entirely noisy via path, skip deep compare.
+			// If the child subtree is entirely noisy via path, skip deep compare.
+			// A pattern-guarded child is NOT skipped here: it is walked so the
+			// pattern reaches the scalars, and so that a scalar replaced by an
+			// object or array is still reported.
 			if regs, noisy := ni.match(childKeyLower); noisy && len(regs) == 0 {
 				continue
 			}
 
-			res, err := matchJSONWithNoiseHandlingIndexed(prefix+k, v, val, ni, globalKeys, ignoreOrdering)
+			res, err := matchJSONWithNoiseHandlingIndexed(prefix+k, v, val, ni, globalKeys, ignoreOrdering, ancestorNoisy)
 			if err != nil || !res.matches {
 				return out, nil
 			}
@@ -372,11 +404,10 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 
 		// 2) No unexpected non-noisy keys in actual.
 		for k := range a {
-			if globalKeys[strings.ToLower(k)] {
+			if _, ok := e[k]; ok {
 				continue
 			}
-
-			if _, ok := e[k]; ok {
+			if regs, isGlobal := globalKeys[strings.ToLower(k)]; isGlobal && noisyForRegexps(regs, a[k]) {
 				continue
 			}
 			childKeyLower := prefixLower + strings.ToLower(k)
@@ -398,17 +429,26 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 			return out, nil
 		}
 
-		// If the whole slice is marked noisy-without-regex, accept.
-		if regs, noisy := ni.match(strings.ToLower(key)); noisy && len(regs) == 0 {
+		// No patterns ignores the whole slice, structure included.
+		regs, noisy := ni.match(strings.ToLower(key))
+		if noisy && len(regs) == 0 {
 			out.matches, out.isExact = true, true
 			return out, nil
+		}
+		// A pattern on an array of scalars is unambiguous — `ids: ["^ord-\d+$"]`
+		// says every id looks like that — so it is applied per element and the
+		// elements keep being compared. Only a heterogeneous or nested array
+		// falls back to relaxing its values wholesale, for the same reason a map
+		// does: there is no single value the pattern could be describing.
+		if noisy && !allJSONScalars(e) {
+			ancestorNoisy = true
 		}
 
 		// Fast path: if ordering matters, avoid O(n²).
 		if !ignoreOrdering {
 			isExact := true
 			for i := 0; i < len(e); i++ {
-				res, err := matchJSONWithNoiseHandlingIndexed(key, e[i], a[i], ni, globalKeys, ignoreOrdering)
+				res, err := matchJSONWithNoiseHandlingIndexed(key, e[i], a[i], ni, globalKeys, ignoreOrdering, ancestorNoisy)
 				if err != nil || !res.matches {
 					return out, nil
 				}
@@ -437,7 +477,7 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 						continue
 					}
 					childKey := key
-					res, err := matchJSONWithNoiseHandlingIndexed(childKey, e[i], a[j], ni, globalKeys, ignoreOrdering)
+					res, err := matchJSONWithNoiseHandlingIndexed(childKey, e[i], a[j], ni, globalKeys, ignoreOrdering, ancestorNoisy)
 					if err == nil && res.matches {
 						if !res.isExact {
 							isExact = false
@@ -469,11 +509,109 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 
 func anyRegexpMatchStr(s string, regs []*regexp.Regexp) bool {
 	for _, re := range regs {
-		if re.MatchString(s) {
+		if re != nil && re.MatchString(s) {
 			return true
 		}
 	}
 	return false
+}
+
+// noisyForValue reports whether the leaf at key should be ignored given the
+// value actually replayed.
+//
+// A noise entry with no patterns ignores the field unconditionally — that is
+// what auto-detected noise emits and it is unchanged. An entry WITH patterns
+// describes which values are volatile, so it ignores the field only when the
+// replayed value is one of them. Treating a pattern-guarded entry as an
+// unconditional skip makes the pattern decorative and silently stops asserting
+// the field, which is the opposite of what writing a pattern asks for.
+func noisyForValue(ni noiseIndex, key, actual string) bool {
+	regs, noisy := ni.match(strings.ToLower(key))
+	switch {
+	case !noisy:
+		return false
+	case len(regs) == 0:
+		return true
+	default:
+		return anyRegexpMatchStr(actual, regs)
+	}
+}
+
+// compilePatterns compiles a noise entry's patterns. A nil result means the
+// entry has none, i.e. it ignores its field unconditionally.
+func compilePatterns(patterns []string) []*regexp.Regexp {
+	if len(patterns) == 0 {
+		return nil
+	}
+	out := make([]*regexp.Regexp, 0, len(patterns))
+	for _, p := range patterns {
+		out = append(out, getCompiled(p))
+	}
+	return out
+}
+
+// noisyForRegexps reports whether a noise entry covers this value. With no
+// patterns it covers the field unconditionally; with patterns it covers only
+// the values they describe. A container has no single value to match, so a
+// pattern-guarded entry leaves it alone rather than reaching into it.
+func noisyForRegexps(regs []*regexp.Regexp, value interface{}) bool {
+	if len(regs) == 0 {
+		return true
+	}
+	s, ok := jsonScalarToString(value)
+	if !ok {
+		return true
+	}
+	return anyRegexpMatchStr(s, regs)
+}
+
+// allJSONScalars reports whether every element is a JSON scalar, i.e. the array
+// is homogeneous enough for a single pattern to describe each element.
+func allJSONScalars(vals []interface{}) bool {
+	for _, v := range vals {
+		if _, ok := jsonScalarToString(v); !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// jsonScalarToString renders a JSON scalar for pattern matching. The second
+// result is false for containers, which have no single value to match.
+func jsonScalarToString(v interface{}) (string, bool) {
+	switch t := v.(type) {
+	case nil:
+		return "null", true
+	case string:
+		return t, true
+	case bool:
+		return strconv.FormatBool(t), true
+	case float64:
+		return formatJSONNumber(t), true
+	}
+	return "", false
+}
+
+// formatJSONNumber renders a JSON number exactly as encoding/json would, so a
+// pattern written against the value Keploy prints in its diff matches at
+// replay. JSON numbers unmarshal to float64; reaching for plain 'f' formatting
+// diverges from the printed form at both extremes (1e21 would render as
+// "1000000000000000000000" and 1e-7 as "0.0000001").
+func formatJSONNumber(f float64) string {
+	abs := math.Abs(f)
+	format := byte('f')
+	if abs != 0 && (abs < 1e-6 || abs >= 1e21) {
+		format = 'e'
+	}
+	b := strconv.AppendFloat(nil, f, format, -1, 64)
+	if format == 'e' {
+		// Trim the exponent's leading zero, as encoding/json does: 1e-07 -> 1e-7.
+		if n := len(b); n >= 4 && b[n-4] == 'e' && b[n-3] == '-' && b[n-2] == '0' {
+			b[n-2] = b[n-1]
+			b = b[:n-1]
+		}
+	}
+	return string(b)
 }
 
 func findAndClaimPrimitiveEqual(x interface{}, arr []interface{}, used []bool) (int, bool) {
@@ -876,7 +1014,11 @@ var ansiRegex *regexp.Regexp
 func init() {
 	re, err := regexp.Compile(`\x1b\[[0-9;]*[a-zA-Z]`)
 	if err != nil {
-		re, _ = regexp.Compile(`(?!)`)
+		// Same trap as getCompiled had: `(?!)` is not valid RE2, so this
+		// fallback used to leave ansiRegex nil and every use of it would panic.
+		// Unreachable while the pattern above is valid; kept correct so that
+		// editing that pattern cannot reintroduce the crash.
+		re = neverMatches
 	}
 	ansiRegex = re
 }

--- a/pkg/matcher/utils.go
+++ b/pkg/matcher/utils.go
@@ -56,6 +56,13 @@ func getCompiledE(pattern string) (*regexp.Regexp, error) {
 	re := regexCache[pattern]
 	regexCacheMu.RUnlock()
 	if re != nil {
+		if bad, ok := badPatterns.Load(pattern); ok {
+			// Report the error on every call, not just the first: the cache is
+			// process-wide, so a later caller holding a logger must still be
+			// able to tell the user their pattern is broken.
+			err, _ := bad.(error)
+			return re, err
+		}
 		return re, nil
 	}
 
@@ -69,6 +76,7 @@ func getCompiledE(pattern string) (*regexp.Regexp, error) {
 		// nil. `[^\s\S]` asks for a character that is neither whitespace nor
 		// non-whitespace, so it matches nothing at all — not even the empty string.
 		compiled = neverMatches
+		badPatterns.Store(pattern, compileErr)
 	}
 
 	regexCacheMu.Lock()
@@ -81,6 +89,10 @@ func getCompiledE(pattern string) (*regexp.Regexp, error) {
 	regexCacheMu.Unlock()
 	return compiled, compileErr
 }
+
+// badPatterns remembers which patterns failed to compile, so the error survives
+// the regex cache.
+var badPatterns sync.Map
 
 // warnedBadPattern dedupes the invalid-pattern warning. Noise is compiled once
 // per test case, so warning every time would emit one line per case.
@@ -214,18 +226,21 @@ func SplitNoise(noise map[string][]string, logger *zap.Logger) (bodyNoise map[st
 	for field, values := range noise {
 		switch strings.ToLower(field) {
 		case "body":
-			if len(values) == 0 {
+			if len(values) == 0 || containsWildcard(values) {
+				// A bare "*" is the documented "ignore everything" wildcard, not
+				// a field literally named "*".
 				skipBody = true
 				continue
 			}
 			for _, path := range values {
 				warnIfRegexShaped(logger, "body", path)
+				warnIfIndexedPath(logger, "body", path)
 				// An empty regex list means "ignore unconditionally", which is
 				// what a listed path is asking for.
 				bodyNoise[strings.ToLower(path)] = []string{}
 			}
 		case "header":
-			if len(values) == 0 {
+			if len(values) == 0 || containsWildcard(values) {
 				headerNoise["header"] = []string{}
 				continue
 			}
@@ -272,6 +287,38 @@ var warnedRegexShaped sync.Map
 // rather than a field path. Such a value used to be inert — it only tripped the
 // whole-section skip — so silently reinterpreting it as a path would turn a
 // green suite red with no explanation.
+// arrayIndexSegment matches a path segment that is only digits, i.e. an array
+// position. The JSON walker keys array elements without a position, so such a
+// path matches nothing and the field it names silently starts being compared.
+var arrayIndexSegment = regexp.MustCompile(`(^|\.)\d+(\.|$)`)
+
+// warnIfIndexedPath reports a noise path carrying an array position. Recorded
+// test cases do carry this shape, and it is exactly the one that goes red with
+// no explanation, so it is worth a line even though the fix is the user's.
+func warnIfIndexedPath(logger *zap.Logger, section, value string) {
+	if logger == nil || !arrayIndexSegment.MatchString(value) {
+		return
+	}
+	if _, seen := warnedRegexShaped.LoadOrStore("idx\x00"+section+"\x00"+value, struct{}{}); seen {
+		return
+	}
+	logger.Warn("noise path contains an array index, which matches nothing; drop the index to cover every element",
+		zap.String("section", section),
+		zap.String("value", value),
+		zap.String("suggested", arrayIndexSegment.ReplaceAllString(value, "$1")))
+}
+
+// containsWildcard reports whether a sectioned noise list is the documented
+// "ignore everything" wildcard.
+func containsWildcard(values []string) bool {
+	for _, v := range values {
+		if strings.TrimSpace(v) == "*" {
+			return true
+		}
+	}
+	return false
+}
+
 func warnIfRegexShaped(logger *zap.Logger, section, value string) {
 	if logger == nil || !looksLikeRegex(value) {
 		return
@@ -341,7 +388,10 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 			}
 			return out, nil
 		}
-		if ancestorNoisy || noisyForValue(ni, key, "") {
+		// null replaced by a container: no single value for a pattern to match,
+		// and a retype is a schema change, so only an unconditional entry covers
+		// it. Same rule as a scalar replaced by a container.
+		if regs, noisy := ni.match(strings.ToLower(key)); ancestorNoisy || (noisy && len(regs) == 0) {
 			out.matches, out.isExact = true, true
 		}
 		return out, nil
@@ -424,7 +474,7 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 				return out, nil
 			}
 
-			if regs, isGlobal := globalKeys[strings.ToLower(k)]; isGlobal && noisyForRegexps(regs, val) {
+			if regs, isGlobal := globalKeys[strings.ToLower(k)]; isGlobal && noisyForRegexps(regs, val, true) {
 				continue
 			}
 
@@ -454,11 +504,11 @@ func matchJSONWithNoiseHandlingIndexed(key string, expected, actual interface{},
 			if _, ok := e[k]; ok {
 				continue
 			}
-			if regs, isGlobal := globalKeys[strings.ToLower(k)]; isGlobal && noisyForRegexps(regs, a[k]) {
+			if regs, isGlobal := globalKeys[strings.ToLower(k)]; isGlobal && noisyForRegexps(regs, a[k], false) {
 				continue
 			}
 			childKeyLower := prefixLower + strings.ToLower(k)
-			if regs, noisy := ni.match(childKeyLower); noisy && noisyForRegexps(regs, a[k]) {
+			if regs, noisy := ni.match(childKeyLower); noisy && noisyForRegexps(regs, a[k], false) {
 				continue // ignore unexpected but noisy subtree
 			}
 			return out, nil
@@ -592,26 +642,42 @@ func compilePatterns(patterns []string, logger *zap.Logger) []*regexp.Regexp {
 	}
 	out := make([]*regexp.Regexp, 0, len(patterns))
 	for _, p := range patterns {
+		if p == "" || p == "*" {
+			// "*" is the documented ignore-everything wildcard and "" says
+			// nothing; neither is a regex, so compiling them would only produce
+			// a spurious "invalid pattern" warning for a valid config.
+			continue
+		}
 		re, err := getCompiledE(p)
 		if err != nil {
 			warnInvalidPattern(logger, p, err)
 		}
 		out = append(out, re)
 	}
+	if len(out) == 0 {
+		// Every pattern was a sentinel, so the entry is unconditional.
+		return nil
+	}
 	return out
 }
 
 // noisyForRegexps reports whether a noise entry covers this value. With no
 // patterns it covers the field unconditionally; with patterns it covers only
-// the values they describe. A container has no single value to match, so a
-// pattern-guarded entry leaves it alone rather than reaching into it.
-func noisyForRegexps(regs []*regexp.Regexp, value interface{}) bool {
+// the values they describe.
+//
+// containersCovered decides the case where the value is a container and there
+// is therefore no single value for a pattern to match. Say true only where the
+// entry already covered the field before patterns were enforced, so that
+// behaviour is preserved; say false where the field is newly appearing in the
+// replay, because "a pattern that cannot match this" must not be read as
+// "ignore it" — that would let an injected object through unchecked.
+func noisyForRegexps(regs []*regexp.Regexp, value interface{}, containersCovered bool) bool {
 	if len(regs) == 0 {
 		return true
 	}
 	s, ok := jsonScalarToString(value)
 	if !ok {
-		return true
+		return containersCovered
 	}
 	return anyRegexpMatchStr(s, regs)
 }
@@ -1797,7 +1863,10 @@ func CompareHeaders(h1 http.Header, h2 http.Header, res *[]models.HeaderResult, 
 	for k, v := range h2 {
 		regexArr, isNoisy := SubstringKeyMatch(k, loweredNoise)
 		if isNoisy && len(regexArr) != 0 {
-			isNoisy, _ = MatchesAnyRegex(v[0], regexArr)
+			isNoisy = false
+			if len(v) > 0 {
+				isNoisy, _ = MatchesAnyRegex(v[0], regexArr)
+			}
 		}
 		isNoisy = isNoisy || isHeaderNoisy
 		val, ok := h1[k]

--- a/pkg/matcher/utils.go
+++ b/pkg/matcher/utils.go
@@ -106,6 +106,148 @@ func (ni noiseIndex) match(keyLower string) (regs []*regexp.Regexp, isNoisy bool
 	return nil, false
 }
 
+// CloneNoiseMap returns a copy of a noise map, so that merging a test case's
+// own noise into the shared global config cannot leak across test cases. The
+// callers hold long-lived config maps (Replayer/runner globals) that would
+// otherwise accumulate every test case's noise as the run progresses.
+func CloneNoiseMap(input map[string][]string) map[string][]string {
+	out := make(map[string][]string, len(input))
+	for key, values := range input {
+		out[key] = append([]string(nil), values...)
+	}
+	return out
+}
+
+// SplitNoise separates a test case's flat noise map into body-scoped and
+// header-scoped entries, and reports whether the body section should be
+// ignored wholesale.
+//
+// A noise key comes in one of two shapes:
+//
+//	dotted     "body.user.id": [regex...]      -> a single field path
+//	sectioned  "body": ["user.id", "total"]    -> a list of field paths
+//
+// Only a bare section key with an EMPTY list means "ignore this whole
+// section" — that is the sentinel a global `body: {"*": ["*"]}` config expands
+// to. A bare section key with a NON-empty list names the fields to ignore.
+//
+// Reading a non-empty sectioned list as the whole-section sentinel silently
+// disables the assertion for the entire body or header set, so any test case
+// carrying such an entry can never fail on its body (or on any header).
+//
+// Note this makes the sectioned values paths, not regexes. A regex there was
+// never evaluated — it only ever tripped the whole-section skip — so nothing
+// that worked stops working, but a suite that was passing because of that skip
+// will start reporting the differences it was hiding. A sectioned value that
+// looks like a regex is warned about, since the equivalent is the dotted form
+// `body.<path>: [regex]`.
+//
+// A dot-delimited path is matched against the JSON walker's own key syntax,
+// which does NOT carry array positions: every element of `items` is walked
+// under the key "items". So `items.stock` works and `items.0.stock` matches
+// nothing. Normalizing the latter is deliberately NOT done here — see
+// TestJSONDiffWithNoiseControl_IndexedPathIsNotSupported for why.
+//
+// OSS noise auto-detection emits the dotted, index-free shape; the sectioned
+// shape reaches us from hand-written YAML and from other producers of
+// test-case files.
+//
+// Header scope has no separate skip flag: CompareHeaders already treats the
+// presence of a "header" key as "all headers are noisy", so the sentinel is
+// passed through as that key.
+func SplitNoise(noise map[string][]string, logger *zap.Logger) (bodyNoise map[string][]string, headerNoise map[string][]string, skipBody bool) {
+	bodyNoise = map[string][]string{}
+	headerNoise = map[string][]string{}
+
+	// Sectioned keys are applied first so that a dotted key naming the same
+	// path always wins. Doing both in one pass would let map iteration order
+	// decide, which makes a run flaky rather than merely wrong.
+	for field, values := range noise {
+		switch strings.ToLower(field) {
+		case "body":
+			if len(values) == 0 {
+				skipBody = true
+				continue
+			}
+			for _, path := range values {
+				warnIfRegexShaped(logger, "body", path)
+				// An empty regex list means "ignore unconditionally", which is
+				// what a listed path is asking for.
+				bodyNoise[strings.ToLower(path)] = []string{}
+			}
+		case "header":
+			if len(values) == 0 {
+				headerNoise["header"] = []string{}
+				continue
+			}
+			for _, name := range values {
+				warnIfRegexShaped(logger, "header", name)
+				headerNoise[strings.ToLower(name)] = []string{}
+			}
+		}
+	}
+
+	for field, regexArr := range noise {
+		parts := strings.Split(field, ".")
+		if len(parts) < 2 {
+			continue
+		}
+		// Copy the value slice: the destination map is a clone the caller is
+		// free to mutate, so it must not alias the test case's own noise.
+		regexes := append([]string(nil), regexArr...)
+		switch strings.ToLower(parts[0]) {
+		case "body":
+			bodyNoise[strings.ToLower(strings.Join(parts[1:], "."))] = regexes
+		case "header":
+			headerNoise[strings.ToLower(parts[len(parts)-1])] = regexes
+		}
+	}
+
+	return bodyNoise, headerNoise, skipBody
+}
+
+// regexShapedTokens are substrings that cannot occur in a JSON field path but
+// are unmistakable in a regex. Single metacharacters are deliberately excluded:
+// `$` alone would flag every OpenAPI/JSON-Schema document key (`$ref`,
+// `$schema`, `$id`), and telling that user to move `$ref` into a regex position
+// is worse than saying nothing — as a regex it anchors to end-of-string and
+// matches nothing at all.
+var regexShapedTokens = []string{".*", ".+", `\d`, `\w`, `\s`, "[0-9", "[a-z", "[A-Z", "(?", "|"}
+
+// warnedRegexShaped dedupes the warning below. SplitNoise runs per test case —
+// and twice per case on the failure-assessment path — so warning unconditionally
+// would emit one line per case and bury the actual failures.
+var warnedRegexShaped sync.Map
+
+// warnIfRegexShaped flags a sectioned noise value that looks like a regex
+// rather than a field path. Such a value used to be inert — it only tripped the
+// whole-section skip — so silently reinterpreting it as a path would turn a
+// green suite red with no explanation.
+func warnIfRegexShaped(logger *zap.Logger, section, value string) {
+	if logger == nil || !looksLikeRegex(value) {
+		return
+	}
+	if _, seen := warnedRegexShaped.LoadOrStore(section+"\x00"+value, struct{}{}); seen {
+		return
+	}
+	logger.Warn("noise value looks like a regex but is read as a field path; use the dotted form to apply a regex",
+		zap.String("section", section),
+		zap.String("value", value),
+		zap.String("dotted_equivalent", section+".<path>: ["+value+"]"))
+}
+
+func looksLikeRegex(value string) bool {
+	if strings.HasPrefix(value, "^") || strings.HasSuffix(value, "$") {
+		return true
+	}
+	for _, tok := range regexShapedTokens {
+		if strings.Contains(value, tok) {
+			return true
+		}
+	}
+	return false
+}
+
 // JSONDiffWithNoiseControl compares JSON with support for both Path-based noise (e.g. "body.user.id")
 // and Global noise (e.g. "timestamp") to be ignored everywhere.
 func JSONDiffWithNoiseControl(validatedJSON ValidatedJSON, noise map[string][]string, ignoreOrdering bool) (JSONComparisonResult, error) {

--- a/pkg/matcher/utils_test.go
+++ b/pkg/matcher/utils_test.go
@@ -501,7 +501,7 @@ func TestJSONDiffWithNoiseControl_IndexedPathIsNotSupported(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ValidateAndMarshalJSON: %v", err)
 		}
-		res, err := JSONDiffWithNoiseControl(v, map[string][]string{"items.product.stock": {}}, false)
+		res, err := JSONDiffWithNoiseControl(v, map[string][]string{"items.product.stock": {}}, false, nil)
 		if err != nil {
 			t.Fatalf("JSONDiffWithNoiseControl: %v", err)
 		}
@@ -516,7 +516,7 @@ func TestJSONDiffWithNoiseControl_IndexedPathIsNotSupported(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ValidateAndMarshalJSON: %v", err)
 		}
-		res, err := JSONDiffWithNoiseControl(v, map[string][]string{"items.0.product.stock": {}}, false)
+		res, err := JSONDiffWithNoiseControl(v, map[string][]string{"items.0.product.stock": {}}, false, nil)
 		if err != nil {
 			t.Fatalf("JSONDiffWithNoiseControl: %v", err)
 		}
@@ -533,7 +533,7 @@ func TestJSONDiffWithNoiseControl_IndexedPathIsNotSupported(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ValidateAndMarshalJSON: %v", err)
 		}
-		res, err := JSONDiffWithNoiseControl(v, map[string][]string{"items.0.id": {}}, false)
+		res, err := JSONDiffWithNoiseControl(v, map[string][]string{"items.0.id": {}}, false, nil)
 		if err != nil {
 			t.Fatalf("JSONDiffWithNoiseControl: %v", err)
 		}
@@ -553,7 +553,7 @@ func TestJSONDiffWithNoiseControl_NumericObjectKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ValidateAndMarshalJSON: %v", err)
 	}
-	res, err := JSONDiffWithNoiseControl(v, map[string][]string{"data.2026.count": {}}, false)
+	res, err := JSONDiffWithNoiseControl(v, map[string][]string{"data.2026.count": {}}, false, nil)
 	if err != nil {
 		t.Fatalf("JSONDiffWithNoiseControl: %v", err)
 	}

--- a/pkg/matcher/utils_test.go
+++ b/pkg/matcher/utils_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 
 	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 // subsKeyMatchWithOriginal is a test helper that lets subtests pass
@@ -322,5 +325,314 @@ func TestCompareHeaders_UppercaseHeaderSentinel(t *testing.T) {
 	var res []models.HeaderResult
 	if ok := CompareHeaders(h1, h2, &res, noise); !ok {
 		t.Fatalf("uppercase 'Header' sentinel should mark all headers noisy; got match=false (res=%+v)", res)
+	}
+}
+
+func TestSplitNoise(t *testing.T) {
+	cases := []struct {
+		name       string
+		noise      map[string][]string
+		wantBody   map[string][]string
+		wantHeader map[string][]string
+		wantSkip   bool
+	}{
+		{
+			name:       "dotted body key keeps its regex list",
+			noise:      map[string][]string{"body.user.id": {".*"}},
+			wantBody:   map[string][]string{"user.id": {".*"}},
+			wantHeader: map[string][]string{},
+		},
+		{
+			name:       "dotted header key is scoped to the header name",
+			noise:      map[string][]string{"header.Date": {}},
+			wantBody:   map[string][]string{},
+			wantHeader: map[string][]string{"date": {}},
+		},
+		{
+			name:       "sectioned body key lists paths, it does not skip the body",
+			noise:      map[string][]string{"body": {"items.0.product.stock", "Total"}},
+			wantBody:   map[string][]string{"items.0.product.stock": {}, "total": {}},
+			wantHeader: map[string][]string{},
+		},
+		{
+			name:       "sectioned header key lists header names",
+			noise:      map[string][]string{"header": {"Content-Length"}},
+			wantBody:   map[string][]string{},
+			wantHeader: map[string][]string{"content-length": {}},
+		},
+		{
+			name:       "empty body key is the whole-section sentinel",
+			noise:      map[string][]string{"body": {}},
+			wantBody:   map[string][]string{},
+			wantHeader: map[string][]string{},
+			wantSkip:   true,
+		},
+		{
+			name:       "empty header key is the whole-section sentinel",
+			noise:      map[string][]string{"header": {}},
+			wantBody:   map[string][]string{},
+			wantHeader: map[string][]string{"header": {}},
+		},
+		{
+			name: "both shapes coexist",
+			noise: map[string][]string{
+				"body":            {"stock"},
+				"body.created_at": {},
+				"header":          {"Content-Length"},
+				"header.Date":     {},
+			},
+			wantBody:   map[string][]string{"stock": {}, "created_at": {}},
+			wantHeader: map[string][]string{"content-length": {}, "date": {}},
+		},
+		{
+			name:       "unrelated sections are dropped",
+			noise:      map[string][]string{"trailer.Foo": {}, "somethingelse": {"x"}},
+			wantBody:   map[string][]string{},
+			wantHeader: map[string][]string{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotBody, gotHeader, gotSkip := SplitNoise(tc.noise, nil)
+			if gotSkip != tc.wantSkip {
+				t.Errorf("skipBody = %v, want %v", gotSkip, tc.wantSkip)
+			}
+			if !noiseMapsEqual(gotBody, tc.wantBody) {
+				t.Errorf("bodyNoise = %v, want %v", gotBody, tc.wantBody)
+			}
+			if !noiseMapsEqual(gotHeader, tc.wantHeader) {
+				t.Errorf("headerNoise = %v, want %v", gotHeader, tc.wantHeader)
+			}
+		})
+	}
+}
+
+func noiseMapsEqual(got, want map[string][]string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for k, wv := range want {
+		gv, ok := got[k]
+		if !ok || len(gv) != len(wv) {
+			return false
+		}
+		for i := range wv {
+			if gv[i] != wv[i] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// TestSplitNoise_DottedWinsOverSectioned pins a deterministic merge when both
+// shapes name the same path. Resolving it by map iteration order would make a
+// run flaky rather than merely wrong.
+func TestSplitNoise_DottedWinsOverSectioned(t *testing.T) {
+	noise := map[string][]string{
+		"body":         {"user.id"},
+		"body.user.id": {"^[0-9]+$"},
+		"header":       {"Date"},
+		"header.Date":  {"^Mon"},
+	}
+	for i := 0; i < 200; i++ {
+		body, header, _ := SplitNoise(noise, nil)
+		if got := body["user.id"]; len(got) != 1 || got[0] != "^[0-9]+$" {
+			t.Fatalf("iteration %d: bodyNoise[user.id] = %v, want the dotted entry's regex", i, got)
+		}
+		if got := header["date"]; len(got) != 1 || got[0] != "^Mon" {
+			t.Fatalf("iteration %d: headerNoise[date] = %v, want the dotted entry's regex", i, got)
+		}
+	}
+}
+
+func TestSplitNoise_SectionNamesAreCaseInsensitive(t *testing.T) {
+	body, header, skip := SplitNoise(map[string][]string{
+		"Body":        {"Stock"},
+		"Header.Date": {},
+	}, nil)
+	if _, ok := body["stock"]; !ok {
+		t.Errorf("bodyNoise = %v, want a lowercased \"stock\" entry", body)
+	}
+	if _, ok := header["date"]; !ok {
+		t.Errorf("headerNoise = %v, want a lowercased \"date\" entry", header)
+	}
+	if skip {
+		t.Errorf("skipBody = true, want false")
+	}
+}
+
+func TestCloneNoiseMap(t *testing.T) {
+	original := map[string][]string{"a": {"x"}}
+	clone := CloneNoiseMap(original)
+	clone["b"] = []string{"y"}
+	clone["a"][0] = "mutated"
+
+	if _, ok := original["b"]; ok {
+		t.Errorf("adding to the clone must not add to the original")
+	}
+	if original["a"][0] != "x" {
+		t.Errorf("mutating a cloned value slice must not touch the original, got %v", original["a"])
+	}
+	if got := CloneNoiseMap(nil); got == nil || len(got) != 0 {
+		t.Errorf("CloneNoiseMap(nil) = %v, want an empty non-nil map", got)
+	}
+}
+
+// TestJSONDiffWithNoiseControl_IndexedPathIsNotSupported pins a known gap that
+// this change deliberately does NOT paper over.
+//
+// The JSON walker never adds an array position to its keys — every element of
+// `items` is walked under the key "items" — so an index-free path works and an
+// indexed one matches nothing. Normalizing the indexed form by dropping numeric
+// segments looks obvious and is a trap: noise keys are matched with
+// strings.Contains, so "items.0.id" would collapse to "items.id", which is a
+// substring of "items.idempotency_key" and would silence it. That trades this
+// change's silent false negative for a wider one, so the indexed form is left
+// unmatched (loud) until the walker itself carries positions.
+func TestJSONDiffWithNoiseControl_IndexedPathIsNotSupported(t *testing.T) {
+	exp := `{"items":[{"product":{"name":"Laptop","stock":99}}]}`
+	act := `{"items":[{"product":{"name":"Laptop","stock":100}}]}`
+
+	t.Run("index-free path is honoured", func(t *testing.T) {
+		e, a := exp, act
+		v, err := ValidateAndMarshalJSON(zap.NewNop(), &e, &a)
+		if err != nil {
+			t.Fatalf("ValidateAndMarshalJSON: %v", err)
+		}
+		res, err := JSONDiffWithNoiseControl(v, map[string][]string{"items.product.stock": {}}, false)
+		if err != nil {
+			t.Fatalf("JSONDiffWithNoiseControl: %v", err)
+		}
+		if !res.IsExact() {
+			t.Errorf("expected match: items.product.stock is the walker's own key syntax")
+		}
+	})
+
+	t.Run("indexed path matches nothing", func(t *testing.T) {
+		e, a := exp, act
+		v, err := ValidateAndMarshalJSON(zap.NewNop(), &e, &a)
+		if err != nil {
+			t.Fatalf("ValidateAndMarshalJSON: %v", err)
+		}
+		res, err := JSONDiffWithNoiseControl(v, map[string][]string{"items.0.product.stock": {}}, false)
+		if err != nil {
+			t.Fatalf("JSONDiffWithNoiseControl: %v", err)
+		}
+		if res.IsExact() {
+			t.Errorf("indexed noise paths are not supported yet; if this now passes, " +
+				"the walker gained positions and the docs on SplitNoise need updating")
+		}
+	})
+
+	t.Run("no normalization leak into a sibling", func(t *testing.T) {
+		e := `{"items":[{"id":"1","idempotency_key":"k1"}]}`
+		a := `{"items":[{"id":"1","idempotency_key":"TAMPERED"}]}`
+		v, err := ValidateAndMarshalJSON(zap.NewNop(), &e, &a)
+		if err != nil {
+			t.Fatalf("ValidateAndMarshalJSON: %v", err)
+		}
+		res, err := JSONDiffWithNoiseControl(v, map[string][]string{"items.0.id": {}}, false)
+		if err != nil {
+			t.Fatalf("JSONDiffWithNoiseControl: %v", err)
+		}
+		if res.IsExact() {
+			t.Errorf("idempotency_key must not be silenced by a noise path for id")
+		}
+	})
+}
+
+// TestJSONDiffWithNoiseControl_NumericObjectKey pins that a genuinely numeric
+// object key stays scoped to itself and does not bleed into a same-named
+// sibling one level up.
+func TestJSONDiffWithNoiseControl_NumericObjectKey(t *testing.T) {
+	exp := `{"data":{"2026":{"count":5},"count":7}}`
+	act := `{"data":{"2026":{"count":5},"count":999}}`
+	v, err := ValidateAndMarshalJSON(zap.NewNop(), &exp, &act)
+	if err != nil {
+		t.Fatalf("ValidateAndMarshalJSON: %v", err)
+	}
+	res, err := JSONDiffWithNoiseControl(v, map[string][]string{"data.2026.count": {}}, false)
+	if err != nil {
+		t.Fatalf("JSONDiffWithNoiseControl: %v", err)
+	}
+	if res.IsExact() {
+		t.Errorf("data.count is a different field from data.2026.count and must still be compared")
+	}
+}
+
+// TestLooksLikeRegex pins the heuristic behind the sectioned-noise warning.
+// It must not flag OpenAPI/JSON-Schema document keys: telling a user to move
+// "$ref" into a regex position is worse than silence, because as a regex it
+// anchors to end-of-string and matches nothing.
+func TestLooksLikeRegex(t *testing.T) {
+	regexes := []string{
+		`^[0-9]+$`,
+		`^\d{4}-\d{2}-\d{2}$`,
+		`.*`,
+		`id-.+`,
+		`\w+`,
+		`(?i)abc`,
+		`PENDING|PAID`,
+		`[a-z]{3}`,
+		`value$`,
+	}
+	for _, v := range regexes {
+		if !looksLikeRegex(v) {
+			t.Errorf("looksLikeRegex(%q) = false, want true", v)
+		}
+	}
+
+	paths := []string{
+		"items.product.stock",
+		"user.id",
+		"created_at",
+		"components.schemas.User.$ref",
+		"$schema",
+		"$id",
+		"definitions.Foo.$id",
+		"data.2026.count",
+		"items.0.product.stock",
+		"X-Request-Id",
+		"a+b",
+		"arr[0]",
+	}
+	for _, v := range paths {
+		if looksLikeRegex(v) {
+			t.Errorf("looksLikeRegex(%q) = true, want false (it is a field path)", v)
+		}
+	}
+}
+
+// TestWarnIfRegexShaped_DedupesAcrossCalls pins that the warning does not fire
+// once per test case. SplitNoise is on the per-test-case path (twice per case on
+// the failure-assessment path), so an undeduped warning would bury real output.
+func TestWarnIfRegexShaped_DedupesAcrossCalls(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	logger := zap.New(core)
+
+	noise := map[string][]string{"body": {`^[0-9]+$`}}
+	for i := 0; i < 50; i++ {
+		SplitNoise(noise, logger)
+	}
+
+	if got := logs.Len(); got != 1 {
+		t.Errorf("emitted %d warnings across 50 calls, want exactly 1", got)
+	}
+}
+
+// TestSplitNoise_NoWarningForPlainPaths guards the common case from noise.
+func TestSplitNoise_NoWarningForPlainPaths(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	logger := zap.New(core)
+
+	SplitNoise(map[string][]string{
+		"body":   {"items.product.stock", "components.schemas.User.$ref"},
+		"header": {"X-Request-Id"},
+	}, logger)
+
+	if got := logs.Len(); got != 0 {
+		t.Errorf("emitted %d warnings for plain field paths, want 0: %v", got, logs.All())
 	}
 }

--- a/pkg/service/replay/body_noise_test.go
+++ b/pkg/service/replay/body_noise_test.go
@@ -1,0 +1,76 @@
+package replay
+
+import (
+	"testing"
+)
+
+// TestBodyNoiseForTestCase covers the schema-addition helper's share of the
+// sectioned-noise contract. It had no test before.
+func TestBodyNoiseForTestCase(t *testing.T) {
+	cases := []struct {
+		name     string
+		tcNoise  map[string][]string
+		global   map[string]map[string][]string
+		wantKeys []string
+	}{
+		{
+			name:     "dotted key is scoped to its path",
+			tcNoise:  map[string][]string{"body.user.id": {".*"}},
+			wantKeys: []string{"user.id"},
+		},
+		{
+			name:     "sectioned key lists paths rather than skipping the body",
+			tcNoise:  map[string][]string{"body": {"stock", "Total"}},
+			wantKeys: []string{"stock", "total"},
+		},
+		{
+			name:     "both shapes merge",
+			tcNoise:  map[string][]string{"body": {"stock"}, "body.created_at": {}},
+			wantKeys: []string{"stock", "created_at"},
+		},
+		{
+			name:     "empty sectioned key contributes nothing",
+			tcNoise:  map[string][]string{"body": {}},
+			wantKeys: nil,
+		},
+		{
+			name:     "header noise does not bleed into body noise",
+			tcNoise:  map[string][]string{"header": {"Date"}, "header.Etag": {}},
+			wantKeys: nil,
+		},
+		{
+			name:     "global body noise is preserved",
+			tcNoise:  map[string][]string{"body": {"stock"}},
+			global:   map[string]map[string][]string{"body": {"global_field": {}}},
+			wantKeys: []string{"stock", "global_field"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			global := tc.global
+			if global == nil {
+				global = map[string]map[string][]string{}
+			}
+			got := bodyNoiseForTestCase(tc.tcNoise, global)
+			if len(got) != len(tc.wantKeys) {
+				t.Fatalf("bodyNoise = %v, want keys %v", got, tc.wantKeys)
+			}
+			for _, k := range tc.wantKeys {
+				if _, ok := got[k]; !ok {
+					t.Errorf("bodyNoise = %v, missing key %q", got, k)
+				}
+			}
+		})
+	}
+}
+
+// TestBodyNoiseForTestCase_DoesNotMutateGlobal pins that the helper copies the
+// global config rather than widening it for the rest of the run.
+func TestBodyNoiseForTestCase_DoesNotMutateGlobal(t *testing.T) {
+	global := map[string]map[string][]string{"body": {}}
+	bodyNoiseForTestCase(map[string][]string{"body": {"stock"}, "body.total": {}}, global)
+	if len(global["body"]) != 0 {
+		t.Errorf("global noise config was mutated: %v", global["body"])
+	}
+}

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -2494,7 +2494,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 					}
 					streamBodyNoise := map[string][]string{}
 					if bodyNoise, ok := noiseConfig["body"]; ok {
-						streamBodyNoise = cloneNoiseMap(bodyNoise)
+						streamBodyNoise = matcherUtils.CloneNoiseMap(bodyNoise)
 					}
 					jsonNoiseKeys := pkg.CollectStreamingGlobalNoiseKeys(streamBodyNoise, tc.Noise)
 
@@ -3427,31 +3427,17 @@ func normalizePassingHTTPResult(result *models.Result) {
 }
 
 func bodyNoiseForTestCase(testCaseNoise map[string][]string, noiseConfig map[string]map[string][]string) map[string][]string {
-	bodyNoise := cloneNoiseMap(noiseConfig["body"])
+	bodyNoise := matcherUtils.CloneNoiseMap(noiseConfig["body"])
 
-	for field, regexArr := range testCaseNoise {
-		parts := strings.Split(field, ".")
-		if len(parts) <= 1 || parts[0] != "body" {
-			continue
-		}
-
-		bodyNoise[strings.ToLower(strings.Join(parts[1:], "."))] = append([]string(nil), regexArr...)
+	// nil logger on purpose: Match already ran SplitNoise for this same test
+	// case and emitted any warning, so passing one here would only duplicate it.
+	tcBodyNoise, _, _ := matcherUtils.SplitNoise(testCaseNoise, nil)
+	for field, regexArr := range tcBodyNoise {
+		// SplitNoise already returns freshly-allocated slices.
+		bodyNoise[field] = regexArr
 	}
 
 	return bodyNoise
-}
-
-func cloneNoiseMap(input map[string][]string) map[string][]string {
-	if len(input) == 0 {
-		return map[string][]string{}
-	}
-
-	out := make(map[string][]string, len(input))
-	for key, values := range input {
-		out[key] = append([]string(nil), values...)
-	}
-
-	return out
 }
 
 func (r *Replayer) CompareGRPCResp(tc *models.TestCase, actualResp *models.GrpcResp, testSetID string, emitFailureLogs bool) (bool, *models.Result) {


### PR DESCRIPTION
Supersedes #4415 and #4417, which are closed in favour of this. Fixes #4416.

Noise is how a Keploy test case says "ignore this field". Four separate defects meant it was instead disabling assertions wholesale — a test case could pass no matter what the service returned. One of them crashed the process.

---

## 1. A sectioned noise entry disabled the entire body

Noise keys come in two shapes:

```yaml
noise:
  body:                          # sectioned
    - items.0.product.stock
  body.created_at: []            # dotted
```

Only the dotted shape was parsed. A sectioned key fell through the split loop and then tripped `Contains(MapToArray(noise), "body")` — the sentinel for *ignore the entire response body*. `header: [...]` did the same to every header.

Any test case carrying such an entry passed regardless of the response. Keploy's own report recorded the difference and still called it normal:

```
STATUS       : PASSED
body_result  :
  normal   : True                       ← the verdict
  expected : ..."name":"Laptop","price":1200..."alice_1785918170"...
  actual   : ..."name":"Tablet","price":1999..."zzzzz_1785918170"...
```

On one real recorded app, **45 of 94 test cases (47%)** had a dead body assertion and 20 also had dead headers. The paths responsible are what noise auto-detection emits — `requestId`, `timestamp`, `id`, `uptime.*` — so the cases that most needed calibration were the ones silently gutted. `/health` and `/stats` became liveness checks that would pass on `{}`.

Fixed by disambiguating on the value: a bare section key with an **empty** list keeps its whole-section meaning (the global `body: {"*": ["*"]}` wildcard expands to exactly this); a **non-empty** list names field paths. The four duplicated copies of the split loop now share `SplitNoise`.

## 2. A regex-constrained entry was an unconditional skip

`{"order.status": ["^(PENDING|PAID)$"]}` reads as "ignore status when it looks like this". The `case string:` branch ran the match and, when it failed, fell through to `if e == a || noisy` where `noisy` was still true. `case bool:` and `case float64:` discarded the patterns outright. All of these passed:

| noise | recorded | replayed |
|---|---|---|
| `{"order.status": ["^(PENDING\|PAID)$"]}` | `"PENDING"` | `"GARBAGE"` |
| `{"order.total": ["^1200$"]}` | `1200` | `99999` |
| `{"order.paid": ["^true$"]}` | `true` | `false` |

Patterns are now enforced against the replayed value. An entry with no patterns still ignores unconditionally.

## 3. A typo in a pattern crashed the run

`getCompiled`'s "never matches" fallback was `` `(?!)` `` — a negative lookahead, which RE2 rejects. So it cached a nil `*regexp.Regexp` and the first comparison dereferenced it:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation]
  regexp.(*Regexp).MatchString(...)
  matcher.anyRegexpMatchStr(...)
```

Replaced with `` `[^\s\S]` ``, which matches nothing at all. The identical dead fallback in the `ansiRegex` init is swept for the same reason.

## 4. Test-case noise leaked into every later test case

`Match` merged a test case's noise into the caller's long-lived global config **in place**, so each case permanently widened the noise applied to the rest of the run. The gRPC path receives that config with no copy at all. The wildcard sentinel was also written back into `tc.Noise`, which mutated the caller's test case, panicked when `tc.Noise` was nil, and — since `buildHTTPSchema` serializes `tc.Noise` — could be **persisted to disk**, permanently skipping that case's body.

---

## Everything else this closes

Rather than leave follow-ups, the review findings are all fixed here:

- **Dot-free keys ignored their patterns.** The HTTP matcher strips the `body.` prefix, so `body.status` arrives as the global key `status`. Enforcing patterns only on dotted paths would have left most real entries broken. Measured: 386 of 388 behavioural tightenings come from this.
- **Overlapping entries were nondeterministic.** `match()` returns the first hit and entries were built from a Go map, so a suite flipped green/red between runs on identical input (73/477 over 400 runs in one process). Entries are ordered most-specific first, in both the body index and `SubstringKeyMatch`.
- **An invalid pattern was silent.** `getCompiledE` returns the compile error and it is warned once per pattern, so a typo reads as a warning instead of a field mysteriously failing.
- **An indexed noise path matches nothing** (the walker keys array elements without a position) and that is the shape real recordings carry. It now warns and names the index-free path to use.
- **`body: ["*"]`** is the documented wildcard, not a field named `*`; it skips the section again, and `*` is no longer compiled as a regex, which was warning users their valid config was broken.
- **A pattern-guarded entry excused an injected container.** "This pattern cannot describe an object" was read as "so ignore the object", letting an injected subtree through. Decided explicitly per call site now.
- **`risk.go` disagreed with the verdict** — it dropped pattern-guarded subtrees the matcher was still walking, so a failing test came with a report saying "Schema and values are identical".
- **`CompareHeaders` constrained on the recorded value**, so any replayed value passed. Now the replayed one, matching body semantics.
- **`case nil:` ignored noise entirely**, so no entry could cover a nullable volatile field.
- Missing-key and unexpected-key rules made consistent between path and global noise; `getCompiledE` no longer loses the error on a cache hit; `CompareHeaders`' second loop no longer indexes an empty header value.

## Where a pattern applies

A pattern describes one scalar value, so that is where it is enforced.

| shape | behaviour |
|---|---|
| scalar | pattern enforced |
| array of scalars | enforced per element; length changes still reported |
| object / mixed array | leaf values relaxed, **structure still walked** — a key added, removed or retyped inside is reported |
| empty pattern list | ignores the whole subtree, structure included (unchanged) |

Numbers render exactly as `encoding/json` does, so a pattern written against the value Keploy prints in its diff matches at replay — verified against `json.Marshal` over 700k floats including raw bit patterns and both format cutovers.

## Verification

Differential corpus against `main`, **74,896 generated comparisons: 153 tightenings, zero cases where this branch accepts something `main` rejects.** The `main` side of that run *crashes partway through* on the invalid-pattern SIGSEGV fixed here.

A 40k-case corpus in which every entry has an empty pattern list is byte-identical to `main`, which is what protects all auto-detected noise.

~1,900 of the ~2,500 added lines are tests, including new files for `absmatch` and the gRPC matcher — neither had any noise coverage, and gRPC is where the config leak was worst. `decode_test.go` runs a recorded YAML through the production decoder and asserts the decoder really emits the sectioned shape, so the fixture cannot silently stop covering the bug.

`go build ./...`, `go test ./... -count=1`, `go test -race ./pkg/matcher/...`, `gofmt -l`, `go vet` all clean.

## Upgrade impact — worth release notes

Suites that were green **only** because an assertion was disabled will start reporting what they were hiding. Every such failure is a real, previously-hidden difference rather than a new false positive. The two shapes most likely to surface are a sectioned noise entry (whole body was skipped) and a pattern-guarded field whose replayed value never actually matched its pattern. Both now warn where a diagnostic is possible.
