### PR TITLE
ci(windows): move the Windows CGO build to a GitHub-hosted runner

### DIFF
--- a/.github/actions/download-image/action.yml
+++ b/.github/actions/download-image/action.yml
@@ -44,7 +44,7 @@ runs:
 
     - name: Wait for the Docker daemon (Windows)
       if: runner.os == 'Windows'
-      shell: powershell
+      shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'
       run: |
         $maxAttempts = 30
         $attempt = 0
@@ -117,17 +117,29 @@ runs:
       if: runner.os == 'Windows'
       # Use Windows PowerShell 5.1 (always preinstalled on Windows
       # runners) rather than pwsh (PowerShell 7, which not every
-      # self-hosted runner in the fleet ships — see the Bootstrap
-      # PowerShell environment step in prepare_and_run.yml's
-      # build-windows-amd64 job, which repairs *that* job but does
-      # not run in the pull-docker-image-windows job that invokes
-      # this action). Every cmdlet used below (Join-Path, Test-Path,
+      # self-hosted runner in the fleet ships).
+      #
+      # The explicit -ExecutionPolicy Bypass is now required, not
+      # decorative. GitHub's built-in `powershell` shell invokes
+      # `powershell -command ". '<script>'"` with no policy flag, and
+      # dot-sourcing a .ps1 is subject to ExecutionPolicy. Until
+      # recently this happened to work on the fleet because
+      # prepare_and_run.yml's "Bootstrap PowerShell environment" step
+      # wrote `Set-ExecutionPolicy -Scope CurrentUser -Bypass`, which
+      # persists in HKCU across jobs and runs — so any box that had run
+      # build-windows-amd64 was covered by a side effect. That step was
+      # deleted when build-windows-amd64 moved to GitHub-hosted
+      # windows-latest, so the guarantee is gone; a freshly provisioned
+      # runner would fail here. Carrying the flag ourselves makes this
+      # action independent of whatever else ran on the machine first.
+      #
+      # Every cmdlet used below (Join-Path, Test-Path,
       # Get-ChildItem, Select-String, [Environment]::NewLine,
       # string .Trim(), [string]::IsNullOrWhiteSpace) is 5.1-
       # compatible, so keeping the floor at 5.1 is free and avoids
       # a 'pwsh: command not found' step failure on unrepaired
       # runners.
-      shell: powershell
+      shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'
       run: |
         $ErrorActionPreference = 'Stop'
         $tar = Join-Path "${{ runner.temp }}" "keploy-image\image.tar"

--- a/.github/scripts/windows/ensure-mingw.ps1
+++ b/.github/scripts/windows/ensure-mingw.ps1
@@ -1,0 +1,76 @@
+# Put a MinGW-w64 gcc on PATH for the native windows/amd64 CGO build.
+#
+# keploy's Windows binary needs a real cgo link: pkg/agent/hooks/windows
+# carries `#cgo windows LDFLAGS: -l:libwindows_redirector.a ...`, so
+# `go build` fails at the link stage without gcc. That failure surfaces
+# as a cryptic "cannot find -l..." several minutes in, which is why this
+# resolves and verifies the toolchain up front instead.
+#
+# The runner image installs MinGW-w64 to C:\mingw64 and adds
+# C:\mingw64\bin to the machine PATH (actions/runner-images,
+# images/windows/scripts/build/Install-Mingw64.ps1), so that is the
+# candidate that resolves on a current image. The others are defensive,
+# covering older image generations and an MSYS2-provided toolchain.
+#
+# ONE copy, used by both Windows CGO build lanes — prepare_and_run.yml's
+# build-windows-amd64 (PR builds) and release.yml's build-windows (the
+# binary users download). They previously carried inline copies that had
+# genuinely DIVERGED:
+#
+#   - release.yml probed three paths, appended EVERY match with no
+#     `break`, and had no failure branch. Because GITHUB_PATH entries are
+#     prepended, appending every match means the LAST match wins — the
+#     inverse of the listed preference.
+#   - prepare_and_run.yml (self-hosted) probed five paths, took the first
+#     hit, fell back to `Get-Command gcc`, and downloaded a portable
+#     WinLibs toolchain if nothing was found — all of which existed to
+#     cope with unprovisioned fleet machines.
+#
+# So the two lanes could select different toolchains for the same build.
+# The self-hosted-only recovery is dropped deliberately: on a hosted
+# image MinGW is provisioned, and a `Get-Command gcc` fallback would be
+# actively wrong there because the image also ships Strawberry Perl's gcc
+# at C:\Strawberry\c\bin on the machine PATH. Explicitly prepending
+# C:\mingw64\bin is what keeps the toolchain deterministic.
+
+$ErrorActionPreference = 'Stop'
+
+$candidates = @(
+    'C:\mingw64\bin',
+    'C:\ProgramData\mingw64\mingw64\bin',
+    'C:\msys64\mingw64\bin'
+)
+
+# `break` + `throw` rather than `exit`: both would fail the step (the
+# runner invokes `pwsh -command ". '<step>'"` with $ErrorActionPreference
+# set to 'stop' and `exit $LASTEXITCODE` appended), so this is a
+# readability choice, not a correctness one — one exit path, and the
+# script stays usable when dot-sourced or run outside Actions.
+$resolved = $null
+foreach ($c in $candidates) {
+    if (Test-Path (Join-Path $c 'gcc.exe')) {
+        $resolved = $c
+        # First hit wins, deterministically. Without stopping here, a
+        # runner image carrying two toolchains would put both on PATH,
+        # and because GITHUB_PATH entries are prepended the LAST match
+        # would win — inverting the preference expressed above.
+        break
+    }
+}
+
+if (-not $resolved) {
+    # Fail here, naming what was searched, rather than letting the next
+    # step die on a bare "gcc: command not found". If a future runner
+    # image moves the toolchain, this says exactly what to fix.
+    throw ("No MinGW-w64 gcc.exe found. Searched: {0}. " -f ($candidates -join ', ')) +
+          'The runner image is expected to ship MinGW-w64 (actions/runner-images ' +
+          'Install-Mingw64.ps1). If the image moved it, add the new path to ' +
+          '.github/scripts/windows/ensure-mingw.ps1.'
+}
+
+# -Encoding utf8 matches every other GITHUB_PATH/GITHUB_ENV write in this
+# repo. Without it the encoding depends on the host shell (Windows
+# PowerShell 5.1 defaults to ASCII here, pwsh 7 to UTF-8), and this
+# script is called from both lanes.
+Add-Content -Path $env:GITHUB_PATH -Value $resolved -Encoding utf8
+Write-Host "Using MinGW at $resolved"

--- a/.github/workflows/prepare_and_run.yml
+++ b/.github/workflows/prepare_and_run.yml
@@ -21,8 +21,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Must match the default $IsoRoot in setup-git-isolation.ps1 / cleanup-git-isolation.ps1
-  _ISO_ROOT: .git-isolation
   # Central ref for the keploy/integrations commit every build leg in
   # this workflow checks out. Keeping it in one place means the 4
   # Add-Private-Parsers steps below (linux/amd64, linux/arm64,
@@ -166,318 +164,42 @@ jobs:
           path: keploy
 
   build-windows-amd64:
-    # Native windows/amd64 cgo build on self-hosted runner.
+    # Native windows/amd64 cgo build on a GitHub-hosted runner.
+    #
+    # Native rather than cross-compiled because
+    # pkg/agent/hooks/windows/redirector.go is `//go:build windows &&
+    # amd64` and cgo-links the in-repo libwindows_redirector.a against
+    # -lws2_32/-luserenv/-lntdll/-ladvapi32; the linux -> windows cross
+    # path does not handle that reliably.
+    #
+    # Hosted rather than self-hosted because nothing in this job needs
+    # the fleet: no Docker, no WinDivert kernel driver, no admin
+    # rights, no licensed software and no private network. The only
+    # non-public dependency (keploy/integrations) is fetched over
+    # public github.com by the setup-private-parsers action, and the
+    # 20 MB libwindows_redirector.a is committed in-repo. release.yml's
+    # `build-windows` job runs the identical windows/amd64 cgo build on
+    # windows-latest and ships every Windows release binary from it, so
+    # this configuration is proven in this repo rather than new.
     if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
-    runs-on: [self-hosted, Windows, X64]
-    # Bound wall-clock so a hung cgo link step (historically: a
+    runs-on: windows-latest
+    # Bound the wall-clock so a hung cgo link step (historically: a
     # deadlock inside libwindows_redirector.a's shutdown path) cannot
-    # sit on a self-hosted Windows runner for 6h. Healthy runs are
-    # ~5 min; 30 gives 6x headroom.
+    # sit on a runner for GitHub's 6h default. A healthy hosted run is
+    # ~5 min end to end with a cold module cache; 30 gives 6x headroom.
     timeout-minutes: 30
     steps:
-      # Bootstrap a consistent shell environment on every self-hosted
-      # Windows runner. Some runners in the fleet ship without pwsh
-      # (PowerShell Core) or with a Restricted ExecutionPolicy that
-      # blocks subsequent step scripts from running. This step makes
-      # every downstream `shell: powershell` and `shell: pwsh`
-      # invocation succeed regardless of which runner the scheduler
-      # picks. Run it unconditionally with explicit -ExecutionPolicy
-      # Bypass so it itself is not subject to the restriction it
-      # repairs.
-      - name: Bootstrap PowerShell environment
-        shell: 'powershell -ExecutionPolicy Bypass -NoProfile -Command "& ''{0}''"'
-        run: |
-          Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
-          # CurrentUser scope persists across subsequent GitHub Actions
-          # steps (each is a fresh powershell invocation, so Process scope
-          # would not carry over). Bypass here is scoped to the runner
-          # user account, not the machine.
-          try { Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy Bypass -Force } catch { Write-Host "::warning::CurrentUser scope write failed: $_" }
-          if (-not (Get-Command pwsh -ErrorAction SilentlyContinue)) {
-            Write-Host "pwsh not found; repairing runner (one-shot per-runner install)."
-            # Try choco first (fastest when present), then fall back to
-            # a portable ZIP download from the official PowerShell
-            # GitHub release so runners without choco are still
-            # repaired. 7.4.6 is the current LTS at time of writing;
-            # pinned to a known-good version so behaviour is
-            # reproducible.
-            $pwshVersion = "7.4.6"
-            $pwshBase = Join-Path $env:USERPROFILE ".pwsh-portable"
-            $pwshBin = Join-Path $pwshBase ("PowerShell-" + $pwshVersion + "-win-x64")
-            $pwshExe = Join-Path $pwshBin "pwsh.exe"
-            if (Get-Command choco -ErrorAction SilentlyContinue) {
-              try {
-                & choco install pwsh -y --no-progress
-                $env:Path = "$env:ProgramFiles\PowerShell\7;" + $env:Path
-                "$env:ProgramFiles\PowerShell\7" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-              } catch {
-                Write-Host "::warning::choco install failed: $_. Falling back to portable ZIP."
-              }
-            }
-            if (-not (Get-Command pwsh -ErrorAction SilentlyContinue) -and -not (Test-Path $pwshExe)) {
-              New-Item -Path $pwshBase -ItemType Directory -Force | Out-Null
-              $zipUrl = "https://github.com/PowerShell/PowerShell/releases/download/v$pwshVersion/PowerShell-$pwshVersion-win-x64.zip"
-              $zipPath = Join-Path $pwshBase ("pwsh-" + $pwshVersion + ".zip")
-              [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-              Invoke-WebRequest -Uri $zipUrl -OutFile $zipPath -UseBasicParsing
-              Expand-Archive -Path $zipPath -DestinationPath $pwshBin -Force
-              Remove-Item -Path $zipPath -Force -ErrorAction SilentlyContinue
-            }
-            if (Test-Path $pwshExe) {
-              $env:Path = "$pwshBin;" + $env:Path
-              $pwshBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-              Write-Host "Installed portable pwsh at $pwshExe"
-            }
-            if (-not (Get-Command pwsh -ErrorAction SilentlyContinue)) {
-              Write-Host "::warning::pwsh still unavailable after install attempts. Runner needs manual repair."
-            }
-          } else {
-            Write-Host "pwsh already available: $((Get-Command pwsh).Source)"
-          }
-
-      - name: Free runner disk space
-        # Use Windows PowerShell 5.1 (always preinstalled) instead of
-        # pwsh. The new win-runner-[1-4] pool doesn't ship
-        # PowerShell 7 - job 71974521109 failed at the first pwsh
-        # step with 'pwsh: command not found'. Every cmdlet used
-        # below (Get-PSDrive, Get-ChildItem, Where-Object, etc.) is
-        # PS5.1-compatible.
-        shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'
-        run: |
-          $ErrorActionPreference = 'Continue'
-          # The shared self-hosted Windows runners have hit "not
-          # enough space on the disk" mid-build (go build writes
-          # importcfg into SystemTemp and gets ENOSPC). Tiered
-          # cleanup: fast-path on healthy disk (>=4 GB free), light
-          # sweep (stale go-build temp + other runners' _diag /
-          # _temp + other-repo _work >7d), heavy sweep (user %TEMP%
-          # + Windows Update download cache), then last-resort go
-          # module/cache purge. Hard-fail under 2 GB so subsequent
-          # CGO builds don't die confused.
-          $targetFree = 4GB
-          $beforeC = (Get-PSDrive C).Free
-          Write-Host ("Free on C: before cleanup: {0:N0} bytes" -f $beforeC)
-          if ($beforeC -ge $targetFree) {
-            Write-Host ("Already have {0:N0} bytes free (>= {1:N0}); skipping cleanup" -f $beforeC, $targetFree)
-            exit 0
-          }
-
-          # 1. Stale go-build intermediate directories under SystemTemp.
-          foreach ($base in @("C:\WINDOWS\SystemTemp", "C:\Windows\Temp")) {
-            if (Test-Path $base) {
-              Get-ChildItem -Path $base -Directory -Force -ErrorAction SilentlyContinue |
-                Where-Object { $_.Name -like 'go-build*' } |
-                ForEach-Object {
-                  Write-Host "Removing $($_.FullName)"
-                  Remove-Item -Path $_.FullName -Recurse -Force -ErrorAction SilentlyContinue
-                }
-            }
-          }
-
-          # 2. Other runners' _diag/_temp + stale other-repo _work checkouts (>7 days).
-          $runnersRoot = "C:\actions-runners"
-          if (Test-Path $runnersRoot) {
-            foreach ($rel in @("_diag", "_temp")) {
-              Get-ChildItem -Path $runnersRoot -Directory -Force -ErrorAction SilentlyContinue | ForEach-Object {
-                $p = Join-Path $_.FullName $rel
-                if (Test-Path $p) {
-                  Write-Host "Purging $p (entries older than 1 day)"
-                  Get-ChildItem -Path $p -Force -ErrorAction SilentlyContinue |
-                    Where-Object { $_.LastWriteTime -lt (Get-Date).AddDays(-1) } |
-                    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
-                }
-              }
-            }
-            $thisRepoDir = $env:GITHUB_REPOSITORY.Split('/')[-1]
-            Get-ChildItem -Path $runnersRoot -Directory -Force -ErrorAction SilentlyContinue | ForEach-Object {
-              $work = Join-Path $_.FullName "_work"
-              if (Test-Path $work) {
-                Get-ChildItem -Path $work -Directory -Force -ErrorAction SilentlyContinue |
-                  Where-Object { $_.Name -ne $thisRepoDir -and $_.LastWriteTime -lt (Get-Date).AddDays(-7) } |
-                  ForEach-Object {
-                    Write-Host "Removing stale work dir $($_.FullName)"
-                    Remove-Item -Path $_.FullName -Recurse -Force -ErrorAction SilentlyContinue
-                  }
-              }
-            }
-          }
-
-          if ((Get-PSDrive C).Free -lt $targetFree) {
-            $userTemp = $env:TEMP
-            if ($userTemp -and (Test-Path $userTemp)) {
-              Write-Host "Sweeping $userTemp"
-              Get-ChildItem -Path $userTemp -Force -ErrorAction SilentlyContinue |
-                Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
-            }
-            $sd = "C:\Windows\SoftwareDistribution\Download"
-            if (Test-Path $sd) {
-              Write-Host "Sweeping $sd"
-              Get-ChildItem -Path $sd -Force -ErrorAction SilentlyContinue |
-                Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
-            }
-          }
-
-          if ((Get-PSDrive C).Free -lt $targetFree) {
-            foreach ($cache in @("$env:USERPROFILE\go\pkg\mod", "$env:LOCALAPPDATA\go-build")) {
-              if (Test-Path $cache) {
-                Write-Host "Removing $cache"
-                Remove-Item -Path $cache -Recurse -Force -ErrorAction SilentlyContinue
-              }
-            }
-          }
-
-          $afterC = (Get-PSDrive C).Free
-          Write-Host ("Free on C: after cleanup:  {0:N0} bytes (freed {1:N0})" -f $afterC, ($afterC - $beforeC))
-          if ($afterC -lt 2GB) {
-            Write-Error "Free on C: is under 2 GB after cleanup - not enough headroom for a CGO Windows build. The self-hosted runner operator should expand the C: volume; this job will fail during go build otherwise."
-            exit 1
-          }
-
-      - name: Create workflow start lock
-        shell: 'powershell -ExecutionPolicy Bypass -NoProfile -Command "& ''{0}''"'
-        run: |
-          $lockDir = Join-Path $env:USERPROFILE '.github-workflow-locks'
-          New-Item -Path $lockDir -ItemType Directory -Force | Out-Null
-          $timestamp = (Get-Date -UFormat %s)
-          $lockPath = Join-Path $lockDir "prepare-windows-workflow-$($env:GITHUB_RUN_ID).lock"
-          Set-Content -Path $lockPath -Value "started-$timestamp"
-          Write-Host "Created workflow start lock: $lockPath"
-
-      # Inline because this runs BEFORE checkout (workspace may not exist).
-      # Logic mirrors .github/scripts/windows/setup-git-isolation.ps1.
-      - name: Setup per-job git isolation
-        shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $isoName = $env:GIT_ISOLATION_ID
-          if ([string]::IsNullOrWhiteSpace($isoName)) {
-            $isoName = "$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT-$env:GITHUB_JOB-$([guid]::NewGuid().ToString('N'))"
-            $isoName = $isoName -replace '[^A-Za-z0-9._-]', '_'
-          }
-          $isoDir = Join-Path (Join-Path $env:USERPROFILE "${{ env._ISO_ROOT }}") $isoName
-          New-Item -Path $isoDir -ItemType Directory -Force | Out-Null
-
-          # Seed per-job gitconfig from the global one (if it exists)
-          $gitConfig = Join-Path $isoDir 'gitconfig'
-          $globalCfg = Join-Path $env:USERPROFILE '.gitconfig'
-          if (Test-Path $globalCfg) { Copy-Item $globalCfg $gitConfig -Force } else { New-Item -Path $gitConfig -ItemType File -Force | Out-Null }
-
-          # Remove inherited SSH redirect settings so the initial
-          # actions/checkout always uses HTTPS (before ssh-agent is loaded).
-          $staleKeys = @(
-              'url."git@github.com:".insteadOf',
-              'url."ssh://git@github.com/".insteadOf',
-              'core.sshCommand'
-          )
-          $savedPref = $PSNativeCommandUseErrorActionPreference
-          $PSNativeCommandUseErrorActionPreference = $false
-          foreach ($key in $staleKeys) {
-              git config --file $gitConfig --unset-all $key 2>$null
-          }
-          $PSNativeCommandUseErrorActionPreference = $savedPref
-
-          Set-Content -Path (Join-Path $isoDir '.active') -Value (Get-Date -UFormat '%s')
-
-          git config --file $gitConfig core.autocrlf false
-          if ($LASTEXITCODE -ne 0) { throw "git config core.autocrlf failed (exit $LASTEXITCODE)" }
-          git config --file $gitConfig core.eol lf
-          if ($LASTEXITCODE -ne 0) { throw "git config core.eol failed (exit $LASTEXITCODE)" }
-
-          # Per-job SSH known_hosts. Prefer ssh-keyscan so we pick up
-          # any host-key rotation automatically; fall back to GitHub's
-          # published keys (https://api.github.com/meta .ssh_keys) when
-          # ssh-keyscan returns nothing. Some self-hosted runners in
-          # this fleet ship without the OpenSSH client, or have egress
-          # policies that block port 22, so ssh-keyscan can be silent
-          # even though HTTPS git clones work fine.
-          $knownHosts = Join-Path $isoDir 'known_hosts'
-          $hostKeys = $null
-          if (Get-Command ssh-keyscan -ErrorAction SilentlyContinue) {
-              $hostKeys = & ssh-keyscan github.com 2>$null
-          }
-          if ([string]::IsNullOrWhiteSpace(($hostKeys | Out-String))) {
-              Write-Host "ssh-keyscan unavailable or empty; using GitHub published host keys."
-              $hostKeys = @(
-                  'github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl',
-                  'github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=',
-                  'github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk='
-              )
-          }
-          $hostKeys | Out-File -FilePath $knownHosts -Encoding ascii
-
-          "GIT_CONFIG_GLOBAL=$gitConfig" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "GIT_ISOLATION_ID=$isoName" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "GIT_SSH_COMMAND=ssh -o UserKnownHostsFile=`"$knownHosts`" -o GlobalKnownHostsFile=NUL -o StrictHostKeyChecking=yes" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-          Write-Host "Git isolation setup complete for $isoName"
-          Write-Host "  GIT_CONFIG_GLOBAL = $gitConfig"
-
-          $global:LASTEXITCODE = 0
-          exit 0
-
-      # Defensive recovery: if a prior run on this self-hosted runner was
-      # interrupted partway through cleanup, the workspace can end up with
-      # files present but the .git subdirectory missing or corrupt. In that
-      # state actions/checkout@v4 with clean:true fails at "git config
-      # --local" with "not a git repository" because clean tries to operate
-      # on a non-git tree. Wipe the workspace contents in that case so
-      # checkout starts from a fresh init. Healthy workspaces (with a valid
-      # .git) are left untouched so the existing checkout fast path
-      # (clean+fetch over an existing clone) keeps working.
-      - name: Recover stale runner state
-        continue-on-error: true
-        shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'
-        run: |
-          $ErrorActionPreference = 'Continue'
-          try {
-            # 1. Kill any keploy processes left over from a prior run on this
-            #    self-hosted runner. They hold open file handles into the
-            #    workspace bin/ (notably WinDivert64.sys, the kernel driver
-            #    keploy uses for Windows traffic redirection), which makes
-            #    actions/checkout's clean step fail with EPERM on unlink.
-            Get-Process -Name 'keploy' -ErrorAction SilentlyContinue | ForEach-Object {
-              Write-Host "Stopping leftover keploy.exe pid=$($_.Id)"
-              try { $_ | Stop-Process -Force -ErrorAction SilentlyContinue } catch {}
-            }
-
-            # 2. Stop the WinDivert kernel driver if it's still loaded.
-            #    keploy registers it as an SCM service named "WinDivert"
-            #    (or "WinDivert64" on some versions); leaving it running
-            #    pins the .sys file in the workspace and causes the same
-            #    EPERM observed at checkout-clean time.
-            foreach ($name in @('WinDivert', 'WinDivert64')) {
-              $svc = Get-Service -Name $name -ErrorAction SilentlyContinue
-              if ($svc -and $svc.Status -ne 'Stopped') {
-                Write-Host "Stopping kernel driver service $name (status=$($svc.Status))"
-                try { Stop-Service -Name $name -Force -ErrorAction SilentlyContinue } catch {}
-              }
-            }
-
-            # 3. If a prior run was interrupted partway through cleanup the
-            #    workspace can end up with files but no .git, which makes
-            #    actions/checkout's clean:true fail with "not a git
-            #    repository". Wipe in that case so checkout starts fresh.
-            #    Healthy workspaces (with valid .git) are left alone so the
-            #    existing fast path (clean+fetch over an existing clone)
-            #    keeps working.
-            $ws = $env:GITHUB_WORKSPACE
-            if ($ws -and (Test-Path $ws)) {
-              $gitDir = Join-Path $ws '.git'
-              $items = @(Get-ChildItem -Path $ws -Force -ErrorAction SilentlyContinue)
-              $hasFiles = $items.Count -gt 0
-              if ($hasFiles -and -not (Test-Path $gitDir)) {
-                Write-Host "::warning::Workspace $ws has files but no .git -- wiping for fresh checkout (prior run was interrupted)"
-                Remove-Item -Path (Join-Path $ws '*') -Recurse -Force -ErrorAction SilentlyContinue
-              }
-            }
-          } catch {
-            Write-Host "::warning::Recover stale runner state: $_"
-          }
-          exit 0
-
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
+          # persist-credentials/clean are belt-and-braces on an
+          # ephemeral hosted VM (the workspace is destroyed with the
+          # job), but they cost nothing and keep the checkout token out
+          # of .git/config. fetch-depth: 0 is carried over unchanged
+          # and matches release.yml's build-windows; nothing in this
+          # job reads git history (main.version is stamped from the
+          # github.sha context), so it is ~11s of insurance, not a
+          # requirement.
           persist-credentials: false
           fetch-depth: 0
           clean: true
@@ -486,67 +208,38 @@ jobs:
         uses: ./.github/actions/setup-private-parsers
         with:
           ssh-private-key: ${{ secrets.INTEGRATIONS_REPO_DEPLOY_KEY_PRIVATE }}
-          go-cache: false
+          # Was false only because the self-hosted disk sweep could
+          # delete GOMODCACHE mid-job. That sweep is gone, so cache
+          # like release.yml's build-windows does.
+          go-cache: true
           # See INTEGRATION_REF in the workflow-level env block.
           integration-ref: ${{ env.INTEGRATION_REF }}
 
-      - name: Add MinGW gcc to PATH
-        shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'
+      - name: Ensure MinGW gcc on PATH
+        # Shared with release.yml's build-windows so the PR build and
+        # the shipped binary can never resolve different toolchains —
+        # see the script header for why the two inline copies this
+        # replaces were a latent hazard.
+        shell: pwsh
         run: |
-          $candidates = @(
-            "C:\msys64\mingw64\bin",
-            "C:\mingw64\bin",
-            "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin",
-            "C:\tools\mingw64\bin",
-            "$env:USERPROFILE\.mingw64-portable\mingw64\bin"
-          )
-          $gccBin = $null
-          foreach ($c in $candidates) {
-            if (Test-Path (Join-Path $c "gcc.exe")) { $gccBin = $c; break }
-          }
-          if (-not $gccBin) {
-            $onPath = Get-Command gcc -ErrorAction SilentlyContinue
-            if ($onPath) { $gccBin = Split-Path $onPath.Source }
-          }
-          if (-not $gccBin) {
-            Write-Host "No MinGW found in known paths; installing portable MinGW-w64 14.2.0 (WinLibs ZIP)."
-            $portableRoot = Join-Path $env:USERPROFILE ".mingw64-portable"
-            $portableBin = Join-Path $portableRoot "mingw64\bin"
-            if (-not (Test-Path (Join-Path $portableBin "gcc.exe"))) {
-              New-Item -Path $portableRoot -ItemType Directory -Force | Out-Null
-              $mingwUrl = "https://github.com/brechtsanders/winlibs_mingw/releases/download/14.2.0posix-12.0.0-ucrt-r3/winlibs-x86_64-posix-seh-gcc-14.2.0-mingw-w64ucrt-12.0.0-r3.zip"
-              $archive = Join-Path $portableRoot "mingw64.zip"
-              [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-              Invoke-WebRequest -Uri $mingwUrl -OutFile $archive -UseBasicParsing
-              Expand-Archive -Path $archive -DestinationPath $portableRoot -Force
-              Remove-Item -Path $archive -Force -ErrorAction SilentlyContinue
-            }
-            if (Test-Path (Join-Path $portableBin "gcc.exe")) {
-              $gccBin = $portableBin
-            } else {
-              throw "MinGW install did not produce gcc.exe at $portableBin"
-            }
-          }
-          Write-Host "Using mingw gcc at $gccBin"
-          echo $gccBin >> $env:GITHUB_PATH
-          $env:Path = "$gccBin;$env:Path"
-          where.exe gcc
-          gcc --version
+          $script = Join-Path $Env:GITHUB_WORKSPACE '.github/scripts/windows/ensure-mingw.ps1'
+          & $script
 
       - name: CGO toolchain sanity
-        shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'
+        # Fails fast here (exit 127 on a missing gcc) instead of
+        # letting the cgo link stage fail 3 minutes into `go build`.
+        shell: bash
         run: |
-          Write-Host "PATH=$env:PATH"
-          where.exe gcc
           gcc --version
           go env CGO_ENABLED CC CXX GOOS GOARCH
 
       - name: Build Keploy (PR) - Windows (windows/amd64)
-        shell: 'powershell -ExecutionPolicy Bypass -NoProfile -Command "& ''{0}''"'
+        shell: bash
+        env:
+          GOOS: windows
+          GOARCH: amd64
+          CGO_ENABLED: "1"
         run: |
-          $env:GOOS = "windows"
-          $env:GOARCH = "amd64"
-          $env:CGO_ENABLED = "1"
           go build -tags=viper_bind_struct -ldflags="-X main.version=${{ github.sha }}" -o keploy.exe ./main.go
 
       - name: Upload build artifact (Windows CLI)
@@ -554,13 +247,6 @@ jobs:
         with:
           name: build-windows
           path: keploy.exe
-
-      - name: Prune stale git isolation dirs
-        if: always()
-        continue-on-error: true
-        shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'
-        run: |
-          & "$env:GITHUB_WORKSPACE\.github\scripts\windows\cleanup-git-isolation.ps1"
 
   upload-latest:
     runs-on: ubuntu-latest
@@ -893,23 +579,90 @@ jobs:
           echo "Docker cleanup completed."
 
   # -------------------------------------------------------------------
-  # Windows test jobs — self-hosted runner loads the linux/amd64 image
-  # (Docker Desktop on Windows runs linux containers via WSL2).
+  # Windows test jobs. Two lanes with different runner requirements:
+  #
+  #   * run_golang_native_windows — GitHub-hosted (windows-latest). Runs
+  #     keploy.exe directly against native sample apps; needs only the
+  #     WinDivert driver the artifact carries.
+  #   * run_golang_docker_windows — self-hosted, gated on
+  #     precheck-windows. Loads the linux/amd64 image and drives it from
+  #     the Windows keploy.exe, which requires Docker Desktop's WSL2
+  #     Linux engine (the sample stack and keploy's injected eBPF agent
+  #     sidecar are Linux containers). Hosted Windows runners ship
+  #     Docker in Windows-container mode only, so this lane cannot move.
   # -------------------------------------------------------------------
 
   precheck-windows:
-    # Pre-flight sanity on the self-hosted Windows runner: set up
-    # per-job git isolation and confirm Docker Desktop is up. Fails
-    # fast BEFORE the parallel Windows test jobs spin up. The docker
-    # image itself is loaded inside each downstream test job via the
+    # Pre-flight sanity on the self-hosted Windows runner: create the
+    # workflow start lock that cleanup_windows consumes, set up per-job
+    # git isolation, and start/confirm Docker Desktop. Fails fast
+    # BEFORE the parallel Windows test jobs spin up. The docker image
+    # itself is loaded inside each downstream test job via the
     # download-image composite action — pre-loading here would
     # duplicate the artifact download + docker load for every test.
+    #
+    # Stays self-hosted: its load-bearing step launches Docker Desktop,
+    # which is what gives run_golang_docker_windows a LINUX-container
+    # engine on a Windows host. GitHub-hosted Windows runners ship
+    # Docker in Windows-container mode only and cannot run the
+    # linux/amd64 sample stack or keploy's eBPF agent sidecar.
     if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     runs-on: [self-hosted, Windows, X64]
-    # Same rationale as build-windows-amd64: bound the wall-clock so a
-    # hung self-hosted Windows runner cannot stall the whole pipeline.
+    # Bound the wall-clock so a hung self-hosted Windows runner cannot
+    # stall the whole pipeline.
     timeout-minutes: 30
     steps:
+      # Marks "a Windows run is live on this shared VM" for
+      # cleanup-windows.ps1, which only runs its destructive
+      # `docker system prune -af --volumes` when NO lock files remain.
+      # This lock used to be written by build-windows-amd64; that job
+      # now runs on an ephemeral GitHub-hosted VM whose $USERPROFILE
+      # the self-hosted cleanup can never see, so the writer moved here
+      # — the earliest self-hosted job in the Windows lane, and the
+      # mirror of precheck-macos. Without a writer, cleanup would find
+      # zero locks on every run and prune a concurrent run's images and
+      # volumes mid-`docker compose up`.
+      - name: Create workflow start lock
+        shell: 'powershell -ExecutionPolicy Bypass -NoProfile -Command "& ''{0}''"'
+        run: |
+          $lockDir = Join-Path $env:USERPROFILE '.github-workflow-locks'
+          New-Item -Path $lockDir -ItemType Directory -Force | Out-Null
+          $timestamp = (Get-Date -UFormat %s)
+          $lockPath = Join-Path $lockDir "prepare-windows-workflow-$($env:GITHUB_RUN_ID).lock"
+          Set-Content -Path $lockPath -Value "started-$timestamp"
+          Write-Host "Created workflow start lock: $lockPath"
+
+      - name: Report fleet disk headroom
+        # The self-hosted fleet's only remaining reclamation is
+        # cleanup-windows.ps1's docker prune, which runs in a job with
+        # `continue-on-error: true` that nothing depends on — so a fleet
+        # filling up produces no signal anywhere. This is that signal.
+        #
+        # It lives HERE, in precheck-windows, deliberately: precheck is
+        # the earliest self-hosted Windows job AND is still a gate input,
+        # so an exhausted runner red-lights the PR with an actionable
+        # message instead of surfacing as a mid-build "no space left"
+        # three jobs later.
+        #
+        # Observe-only above the floor. It does NOT delete anything: the
+        # 98-line sweep this replaces used to purge GOMODCACHE and walk
+        # C:\actions-runners, which raced concurrent jobs on the shared
+        # box. Reporting is what was actually missing.
+        shell: 'powershell -ExecutionPolicy Bypass -NoProfile -Command "& ''{0}''"'
+        run: |
+          $c = Get-PSDrive -Name C
+          $freeGB = [math]::Round($c.Free / 1GB, 2)
+          $usedGB = [math]::Round($c.Used / 1GB, 2)
+          Write-Host "C: free ${freeGB} GB (used ${usedGB} GB) on $($env:COMPUTERNAME)"
+
+          if ($freeGB -lt 2) {
+            Write-Host "::error::Windows runner $($env:COMPUTERNAME) has only ${freeGB} GB free on C:. A CGO build plus a docker image load needs more than this; the runner operator should expand the volume or prune the docker cache."
+            exit 1
+          }
+          elseif ($freeGB -lt 6) {
+            Write-Host "::warning::Windows runner $($env:COMPUTERNAME) is low on disk: ${freeGB} GB free on C:. Cleanup is falling behind — check that cleanup_windows is still pruning."
+          }
+
       # Create a minimal per-job gitconfig BEFORE checkout to prevent
       # concurrent jobs' SSH redirects from leaking into our checkout.
       - name: Pre-checkout git isolation
@@ -929,7 +682,13 @@ jobs:
           "GIT_CONFIG_GLOBAL=$gitConfig" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "GIT_ISOLATION_ID=$isoName" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      # See build-windows-amd64's "Recover broken workspace" step for rationale.
+      # Self-hosted only: the workspace and the machine persist between
+      # runs, so a prior run interrupted mid-cleanup can leave a
+      # keploy.exe holding handles on WinDivert64.sys, the WinDivert
+      # kernel driver service still loaded, or a workspace with files
+      # but no .git. All three make actions/checkout's clean:true fail
+      # (EPERM on unlink, or "not a git repository"). The inline
+      # comments below cover each case.
       - name: Recover stale runner state
         continue-on-error: true
         shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'
@@ -1033,20 +792,31 @@ jobs:
     uses: ./.github/workflows/golang_native_windows.yml
 
   cleanup_windows:
+    # Disk hygiene for the shared self-hosted Windows VM: drop this
+    # run's workflow lock, kill containers older than 30 min, and prune
+    # Docker once no other run holds a lock. Stays self-hosted by
+    # definition — there is nothing to reclaim on an ephemeral hosted
+    # VM that is destroyed at job end.
     if: ${{ always() && ((github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main')) }}
     runs-on: [self-hosted, Windows, X64]
-    needs: [run_golang_docker_windows, run_golang_native_windows]
+    # Only the docker lane touches this VM. run_golang_native_windows
+    # runs entirely on GitHub-hosted windows-latest, so waiting on it
+    # would just park a self-hosted runner slot behind machines this
+    # job can never affect.
+    needs: [run_golang_docker_windows]
     # The only self-hosted job in the repo that had no cap, so it inherited
-    # GitHub's 360-minute default. Because it is `if: always()` and the final
-    # `gate_windows` needs it, a Windows fleet that is busy or offline parks it
-    # in the queue and the ENTIRE run stays in_progress behind it for six
-    # hours — the PR shows no verdict and `gh run rerun --failed` refuses,
-    # because that requires a completed run. Observed on run 30620482988: 60+
-    # minutes queued with zero steps executed while every other job had long
-    # finished. 10 minutes matches its macOS twin `clean_up_docker_macos`; the
-    # work itself is `docker rm -f` and a lock-file delete. Losing a cleanup
-    # pass is cheap and self-correcting — the next push schedules a fresh one,
-    # as the concurrency comment at the top of this file already notes.
+    # GitHub's 360-minute default. Because it is `if: always()`, a Windows
+    # fleet that is busy or offline parks it in the queue and the ENTIRE run
+    # stays in_progress behind it for six hours — the PR shows no verdict and
+    # `gh run rerun --failed` refuses, because that requires a completed run.
+    # Observed on run 30620482988: 60+ minutes queued with zero steps executed
+    # while every other job had long finished. (`gate_windows` no longer needs
+    # this job, so a slow cleanup no longer blocks the Windows verdict itself,
+    # but it still holds the run open.) 10 minutes matches its macOS twin
+    # `clean_up_docker_macos`; the work itself is `docker rm -f` and a
+    # lock-file delete. Losing a cleanup pass is cheap and self-correcting —
+    # the next push schedules a fresh one, as the concurrency comment at the
+    # top of this file already notes.
     timeout-minutes: 10
     steps:
       - name: Pre-checkout git isolation
@@ -1066,7 +836,13 @@ jobs:
           "GIT_CONFIG_GLOBAL=$gitConfig" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "GIT_ISOLATION_ID=$isoName" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      # See build-windows-amd64's "Recover broken workspace" step for rationale.
+      # Self-hosted only: the workspace and the machine persist between
+      # runs, so a prior run interrupted mid-cleanup can leave a
+      # keploy.exe holding handles on WinDivert64.sys, the WinDivert
+      # kernel driver service still loaded, or a workspace with files
+      # but no .git. All three make actions/checkout's clean:true fail
+      # (EPERM on unlink, or "not a git repository"). The inline
+      # comments below cover each case.
       - name: Recover stale runner state
         continue-on-error: true
         shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'
@@ -1127,11 +903,31 @@ jobs:
           & "$env:GITHUB_WORKSPACE\.github\scripts\windows\setup-git-isolation.ps1"
 
       - name: Remove workflow start lock
+        # `if: always()` is load-bearing, and newly so. cleanup-windows.ps1
+        # only prunes when NO lock files remain, so a leaked lock disables
+        # the shared VM's last disk reclamation permanently and silently.
+        # Three unguarded steps run before this one (git isolation, checkout,
+        # git isolation again) and setup-git-isolation.ps1 throws when
+        # ssh-keyscan comes back empty — a real fleet condition. Without
+        # always(), that throw strands the lock forever.
+        #
+        # The 24h reaper mirrors the macOS twin ("Remove workflow lock file"),
+        # and is the backstop for locks stranded by a cancelled or
+        # hard-killed run, which no `if:` can cover.
+        if: always()
         shell: 'powershell -ExecutionPolicy Bypass -NoProfile -Command "& ''{0}''"'
         run: |
           $lockDir = Join-Path $env:USERPROFILE '.github-workflow-locks'
           $lockPath = Join-Path $lockDir "prepare-windows-workflow-$($env:GITHUB_RUN_ID).lock"
           Remove-Item -Path $lockPath -Force -ErrorAction SilentlyContinue
+
+          Write-Host "Reaping workflow locks older than 24 hours..."
+          Get-ChildItem -Path $lockDir -Filter 'prepare-windows-workflow-*.lock' -ErrorAction SilentlyContinue |
+            Where-Object { $_.LastWriteTime -lt (Get-Date).AddDays(-1) } |
+            ForEach-Object {
+              Write-Host "  reaping stale lock: $($_.Name) (last written $($_.LastWriteTime))"
+              Remove-Item -Path $_.FullName -Force -ErrorAction SilentlyContinue
+            }
 
       - name: Check and cleanup long-running containers (Windows helper)
         id: count_stash
@@ -1247,13 +1043,20 @@ jobs:
   gate_windows:
     name: CI Gate (Windows)
     if: always()
+    # `cleanup_windows` is deliberately absent: it is self-hosted VM
+    # disk hygiene with zero product signal, yet as a gate input it
+    # could red-light a PR on its own whenever the fleet was busy or a
+    # docker prune hiccuped. Every job below carries real signal.
+    # precheck-windows must STAY — because this gate counts `skipped`
+    # as a pass, a failed precheck silently skips
+    # run_golang_docker_windows, and precheck's own `failure` is then
+    # the only thing that surfaces the lost docker-lane coverage.
     needs:
       - build-windows-amd64
       - build-docker-image-amd64
       - precheck-windows
       - run_golang_docker_windows
       - run_golang_native_windows
-      - cleanup_windows
     runs-on: ubuntu-latest
     steps:
       - name: Check all jobs passed
@@ -1264,7 +1067,6 @@ jobs:
             "${{ needs.precheck-windows.result }}" \
             "${{ needs.run_golang_docker_windows.result }}" \
             "${{ needs.run_golang_native_windows.result }}" \
-            "${{ needs.cleanup_windows.result }}" \
           )
           for r in "${results[@]}"; do
             if [[ "$r" != "success" && "$r" != "skipped" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,10 +278,11 @@ jobs:
   # ---------------------------------------------------------------
   # Windows native CGo build.
   #
-  # windows-latest ships MinGW-w64 (gcc.exe) via the pre-installed
-  # msys2/mingw64 toolchain on PATH, which satisfies pg_query_go's
-  # cgo link. Running native here avoids the linux → windows cross
-  # path that pg_query_go #138 documents as unreliable.
+  # windows-latest ships MinGW-w64 (gcc.exe) at C:\mingw64\bin, which
+  # the runner image puts on the machine PATH, and which satisfies
+  # pg_query_go's cgo link. Running native here avoids the
+  # linux → windows cross path that pg_query_go #138 documents as
+  # unreliable.
   # ---------------------------------------------------------------
   build-windows:
     runs-on: windows-latest
@@ -304,25 +305,14 @@ jobs:
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Ensure MinGW gcc on PATH
-        # windows-latest ships MinGW-w64 under
-        # C:\ProgramData\mingw64\mingw64\bin (hosted runner image).
-        # Append defensively — if a future image moves it, the job
-        # fails fast at gcc --version rather than later at `go build`
-        # with a cryptic 'cannot find -lpg_query' link error.
+        # Shared with prepare_and_run.yml's build-windows-amd64 so the
+        # binary users download is linked against the same toolchain the
+        # PR build verified — see the script header for why the two
+        # inline copies this replaces were a latent hazard.
         shell: pwsh
         run: |
-          $candidates = @(
-            'C:\ProgramData\mingw64\mingw64\bin',
-            'C:\msys64\mingw64\bin',
-            'C:\mingw64\bin'
-          )
-          foreach ($c in $candidates) {
-            if (Test-Path (Join-Path $c 'gcc.exe')) {
-              Add-Content -Path $env:GITHUB_PATH -Value $c
-              Write-Host "Using MinGW at $c"
-            }
-          }
-          # Verify once PATH is rewritten for the next step.
+          $script = Join-Path $Env:GITHUB_WORKSPACE '.github/scripts/windows/ensure-mingw.ps1'
+          & $script
 
       - name: Verify gcc
         shell: bash


### PR DESCRIPTION
## The problem

The self-hosted Windows fleet is failing **every open PR**. `precheck-windows` and/or `build-windows-amd64` record **zero steps**, never upload logs, and fail after 13–14 minutes on varying runners — the runner accepts the job and dies before executing anything.

| PR | build-windows-amd64 | precheck-windows |
|---|---|---|
| #4419 | fail | fail |
| #4413 | fail | pass |
| #4412 | pass | fail |
| #4410 | pass | fail |
| #4407 | fail | pass |
| #4406 | fail | pass |

The shuffling pattern is the tell: this is runner health, not a code defect.

## What moves, and why it's safe

**`build-windows-amd64` never needed self-hosted.** `release.yml`'s `build-windows` already performs the *identical* native windows/amd64 CGO build — including the `pg_query_go` cgo link, which is the hard part — on `windows-latest`. Every keploy release binary ships from it (5/5 recent releases green; v3.6.9 built in 4m42s with a cold module cache).

Of that job's 396 lines, **only ~6 steps do real work.** The rest existed solely to cope with shared, persistent machines and are deleted:

- `Bootstrap PowerShell environment` — installs/repairs pwsh (hosted ships 7.6.4)
- `Free runner disk space` — 98 lines, because the boxes run out of C:
- `Create workflow start lock` — cross-job coordination on a shared filesystem
- `Setup per-job git isolation` — 71 lines, so 4 concurrent checkouts don't clobber each other's global gitconfig
- `Recover stale runner state` — kills leftover `keploy.exe`, stops a stale WinDivert driver service
- `Prune stale git isolation dirs`

Job name, fork-PR guard, timeout and artifact contract are unchanged, so **no branch-protection or required-check edit is needed**.

## What deliberately stays self-hosted

`golang_docker_windows` — hosted `windows-latest` ships Docker in **Windows-containers-only** mode (LCOW was removed in Docker Engine 23.0), while that lane loads a `linux/amd64` image and injects a keploy-agent sidecar needing `cap_add BPF/PERFMON/NET_ADMIN` and `/sys/fs/cgroup`, `/sys/kernel/debug`, `/sys/fs/bpf` bind mounts. It is the only place a native `keploy.exe` drives Docker Desktop's Linux engine — exactly the configuration Windows users run. Moving it would trade real product coverage for a green checkmark.

`precheck-windows` and `cleanup_windows` stay because they serve it.

## Three couplings this would otherwise have broken

**1. The workflow start lock.** `cleanup-windows.ps1` prunes only when *no* lock files remain, so deleting its sole writer would have fired `docker system prune -af --volumes` on **every** run against the shared VM — possibly mid-`docker compose up` on a concurrent job. The lock step is relocated into `precheck-windows`. Its removal step also gains `if: always()` plus a 24h stale-lock reaper (mirroring the macOS twin): three unguarded steps precede it, and `setup-git-isolation.ps1` throws when `ssh-keyscan` returns empty — a real fleet condition — so a leaked lock would otherwise disable the VM's last reclamation permanently and silently.

**2. Disk observability.** With the sweep gone and `cleanup_windows` dropped from the gate, nothing would observe the fleet filling up — a slow-burn version of the failure this PR fixes. `precheck-windows` gains a disk-headroom report (`::warning::` under 6 GB, fail under 2 GB). It lives there because precheck is the earliest self-hosted job *and* still a gate input. It **observes only**: the old sweep purged `GOMODCACHE` and walked `C:\actions-runners`, racing concurrent jobs on the shared box.

**3. ExecutionPolicy.** `download-image`'s two Windows steps relied on a side effect — the deleted bootstrap step wrote `Set-ExecutionPolicy -Scope CurrentUser -Bypass`, which persists in HKCU across jobs and runs, so any box that had run `build-windows-amd64` was covered. That guarantee is gone; both steps now carry the flag explicitly.

## Gate

`cleanup_windows` leaves `gate_windows`' `needs` — it is VM hygiene with no product signal, and as a gate input a busy fleet could red-light a PR on its own. `precheck-windows` **stays** in the gate: the gate counts `skipped` as pass, so dropping it would let the docker lane skip invisibly.

## A latent bug this surfaced

The two inline MinGW probes had **diverged**. `release.yml` appended every match with no `break` — and since `GITHUB_PATH` entries are *prepended*, the **last** match won, inverting the listed preference. `prepare_and_run.yml` probed five paths with a `Get-Command` fallback and a portable-toolchain download. So the PR build and the shipped release binary could resolve **different toolchains**.

Now one shared `.github/scripts/windows/ensure-mingw.ps1` with a `break` and an explicit `throw`. The `Get-Command gcc` fallback is dropped on purpose: the hosted image also ships Strawberry Perl's gcc at `C:\Strawberry\c\bin` on the machine PATH, so explicitly prepending `C:\mingw64\bin` is what keeps selection deterministic.

## Verification

- All touched YAML parses; `actionlint` reports **8 findings before and after** (no new ones — the 8 are pre-existing macOS `native` label + shellcheck info)
- No job added, removed, or renamed (33 → 33)
- Artifact contract byte-identical (`build-windows` / `keploy.exe`); both consumers use `download-artifact`
- `_ISO_ROOT` has zero remaining references repo-wide
- No bare `shell: powershell` left anywhere under `.github/`

**Net: 3 self-hosted Windows job declarations instead of 4, ~300 lines of runner babysitting gone, and no change to what is tested.**

## Follow-ups (not in this PR)

- `GOOS=windows go build ./...` fails locally on `pkg/agent/hooks/windows` (needs cgo + mingw), on `main` too — so a genuine Windows compile error is masked for anyone checking before push.
- `gate_macos` still lists `clean_up_docker_macos` in `needs`; the rationale for dropping `cleanup_windows` applies identically to the macOS twin.