### PR TITLE
fix: survive binary response bodies instead of ending the recording

### DIFF
--- a/pkg/agent/proxy/relay/tee_test.go
+++ b/pkg/agent/proxy/relay/tee_test.go
@@ -35,6 +35,29 @@ func newTestTee(t *testing.T, capBytes int64, buf int, memCheck func() bool) (*t
 // newTestTeeWithConsumer is newTestTee plus control over the consumer's
 // liveness: closing the returned channel is what a parser abandoning its
 // FakeConn looks like to the tee.
+// newTestTeeQueued builds a tee whose drain loop is NOT started, so pushed
+// chunks stay in the queue.
+//
+// The per-connection cap is an OCCUPANCY cap: drain decrements qBytes as it
+// dequeues, so a delivered chunk stops counting against it — that is the
+// behaviour TestDrainingAChunkReturnsCapacity exists to pin, and it is correct.
+// The consequence is that any test asserting "this push is refused because the
+// earlier ones are still queued" is racing its own drainer. If drain wins, the
+// bytes are already released and the push legitimately succeeds; the test then
+// fails for a reason that has nothing to do with the cap. Measured at roughly
+// 1-in-40 runs, and 5-in-5 with a 50ms pause between the pushes.
+//
+// Not starting drain removes the race and lets those tests assert exactly what
+// the cap means. waitDone is deliberately absent from the cleanup: t.done is
+// closed by drain, which never runs here.
+func newTestTeeQueued(t *testing.T, capBytes int64, buf int) (*tee, *dropRecorder) {
+	t.Helper()
+	rec := &dropRecorder{}
+	t2 := newTee(fakeconn.FromClient, capBytes, buf, testStallGrace, nil, rec.record, nil)
+	t.Cleanup(t2.close)
+	return t2, rec
+}
+
 func newTestTeeWithConsumer(t *testing.T, capBytes int64, buf int) (*tee, *dropRecorder, chan struct{}) {
 	t.Helper()
 	rec := &dropRecorder{}
@@ -121,8 +144,11 @@ func TestTee_DropOnMemoryPressure(t *testing.T) {
 
 func TestTee_DropOnPerConnCap(t *testing.T) {
 	t.Parallel()
-	// Cap at 4 bytes; first 3-byte push fits, second also fits (6 > 4) → drop.
-	tt, _, rec := newTestTee(t, 4, 16, nil)
+	// Cap at 4 bytes; the first 3-byte push fits, the second would take the
+	// QUEUE to 6 > 4 → drop. Drain must not run: it releases bytes as it
+	// dequeues, which would let the second push through for reasons unrelated
+	// to the cap (see newTestTeeQueued).
+	tt, rec := newTestTeeQueued(t, 4, 16)
 
 	if !tt.push(mkChunk("abc")) {
 		t.Fatalf("first push should succeed")
@@ -261,8 +287,9 @@ func TestTee_CloseRacingSpillBacklog_Conserves(t *testing.T) {
 // without limit — preserving the OOM-safety contract.
 func TestTee_DropsWhenOverflowExceedsCap(t *testing.T) {
 	t.Parallel()
-	// cap=10 bytes, buf=1, no receiver. Each chunk is 4 bytes.
-	tt, _, rec := newTestTee(t, 10, 1, nil)
+	// cap=10 bytes, buf=1, no receiver. Each chunk is 4 bytes. Drain is not
+	// started so the queue actually accumulates (see newTestTeeQueued).
+	tt, rec := newTestTeeQueued(t, 10, 1)
 	// "aaaa" (staging) + "bbbb" (overflow, total 8) fit; "cccc" (total 12
 	// > 10) must drop on per_conn_cap.
 	if !tt.push(mkChunk("aaaa")) {

--- a/pkg/models/errors.go
+++ b/pkg/models/errors.go
@@ -137,3 +137,15 @@ func NewMockMismatchError(err error, report *MockMismatchReport) error {
 	}
 	return &mockMismatchError{err: err, report: report}
 }
+
+// ErrMockEncode marks a mock-persist failure caused by THIS mock's own payload
+// — an unsupported kind, a malformed spec, a value the encoder cannot represent
+// — rather than by the storage environment.
+//
+// The distinction decides whether a recording survives. The recorder treats a
+// failed mock insert as fatal and tears the whole session down, which is right
+// for disk-full or storage-gone (every subsequent mock fails too) and badly
+// wrong for one unencodable payload. A single gzip response body ended a
+// 46-hour production recording that way. Errors wrapped with this sentinel are
+// skipped and counted; everything else stays fatal.
+var ErrMockEncode = errors.New("mock encode failure")

--- a/pkg/models/http_stream_body.go
+++ b/pkg/models/http_stream_body.go
@@ -2,9 +2,11 @@ package models
 
 import (
 	"bufio"
+	"encoding/base64"
 	"encoding/json"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	yamlLib "gopkg.in/yaml.v3"
 )
@@ -86,8 +88,19 @@ func (h HTTPResp) MarshalYAML() (interface{}, error) {
 		// Streaming response — encode as a YAML sequence of chunks
 		bodyNode = encodeStreamChunksNode(chunks)
 	} else {
-		// Non-streaming response — encode body as a plain string scalar
-		if err := bodyNode.Encode(h.Body); err != nil {
+		// Non-streaming response, OR a stream whose bytes cannot survive the
+		// chunked representation — encode the body as a plain string scalar
+		// (yaml.v3 auto-promotes an untagged non-UTF-8 scalar to !!binary).
+		//
+		// Reconstruct the flat body from the chunks when the chunk form was
+		// rejected and Body is empty: StreamBody travels independently of Body
+		// over the transport, so a producer that populated only the chunk form
+		// would otherwise have its entire body silently written as "".
+		body := h.Body
+		if body == "" && len(h.StreamBody) > 0 {
+			body = streamChunksToLegacyBody(h.StreamBody, detectStreamBodyKind(h.Header))
+		}
+		if err := bodyNode.Encode(body); err != nil {
 			return nil, err
 		}
 	}
@@ -176,14 +189,57 @@ const (
 	streamBodyKindRaw     streamBodyKind = "raw" // All other streaming formats (NDJSON, plain text, binary)
 )
 
-// streamChunksForYAML returns the chunks to encode if this response has a streaming body.
-// Returns (nil, false) for non-streaming responses.
+// streamChunksAreUTF8 reports whether every key and value in an already-parsed
+// chunk list is valid UTF-8. The chunked representation puts arbitrary body
+// bytes into YAML scalars, and an SSE field NAME additionally goes through
+// strings.ToLower during parsing, which rewrites every invalid byte to U+FFFD
+// — so a body that fails this check must fall back to the flat scalar form
+// rather than be chunked.
+func streamChunksAreUTF8(chunks []HTTPStreamChunk) bool {
+	for _, c := range chunks {
+		for _, f := range c.Data {
+			if !utf8.ValidString(f.Key) || !utf8.ValidString(f.Value) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// streamChunksForYAML returns the chunks to encode if this response has a
+// streaming body, and (nil, false) for a non-streaming response or one whose
+// bytes cannot survive the chunked representation.
 func streamChunksForYAML(resp HTTPResp) ([]HTTPStreamChunk, bool) {
 	if len(resp.StreamBody) > 0 {
+		if !streamChunksAreUTF8(resp.StreamBody) {
+			return nil, false
+		}
 		return cloneStreamChunks(resp.StreamBody), true
 	}
 
 	if resp.Body != "" {
+		// A non-UTF-8 body is not a text stream, and must never reach the
+		// chunkers below.
+		//
+		// Two things go wrong if it does. The chunk encoder emits every key and
+		// value through stringNode, which stamps an explicit `!!str` tag, and
+		// yaml.v3 refuses that outright: "cannot marshal invalid UTF-8 data as
+		// !!str". That error is returned all the way out of InsertMock, and the
+		// recorder treats a failed insert as fatal — one gzip response body
+		// ended a 46-hour production recording of prod/api-server. Second, even
+		// when it does not abort, parseSSEBodyToChunks lower-cases the SSE field
+		// name, and strings.ToLower rewrites every invalid byte to U+FFFD, so
+		// the mock is silently corrupted and replays the wrong bytes.
+		//
+		// Falling through to the flat scalar body costs nothing and fixes both:
+		// yaml.v3 auto-promotes an untagged non-UTF-8 scalar to `!!binary` with
+		// base64, which is exactly how non-streaming bodies (application/json
+		// and friends) have always been stored. No schema change, and the
+		// decoder already handles it — decodeStreamBody dispatches on node kind
+		// and yaml.v3 base64-decodes `!!binary` scalars back into the string.
+		if !utf8.ValidString(resp.Body) {
+			return nil, false
+		}
 		kind := detectStreamBodyKind(resp.Header)
 		if kind == streamBodyKindSSE {
 			chunks := parseSSEBodyToChunks(resp.Body, resp.Timestamp)
@@ -347,8 +403,17 @@ func decodeStreamDataFields(dataNode *yamlLib.Node) ([]HTTPStreamDataField, erro
 		if keyNode == nil || valueNode == nil {
 			continue
 		}
+		// Keys decode the same way values do. stringNode can emit a key as
+		// !!binary, and yaml.v3 leaves the BASE64 TEXT in node.Value for those
+		// — reading Value raw would substitute the base64 for the real field
+		// name. TrimSpace stays off the binary branch: for decoded bytes it is
+		// not cosmetic, it would silently eat payload.
+		key := decodeYAMLScalarKey(keyNode)
+		if keyNode.Tag != "!!binary" {
+			key = strings.TrimSpace(key)
+		}
 		fields = append(fields, HTTPStreamDataField{
-			Key:   strings.TrimSpace(keyNode.Value),
+			Key:   key,
 			Value: yamlNodeToString(valueNode),
 		})
 	}
@@ -415,7 +480,18 @@ func streamChunksToLegacyBody(chunks []HTTPStreamChunk, kind streamBodyKind) str
 				if key == "" {
 					continue
 				}
-				lines = append(lines, strings.ToLower(key)+":"+field.Value)
+				// strings.ToLower rewrites every invalid byte to U+FFFD, so it
+				// must not touch a field name that is not valid UTF-8. This is
+				// reachable precisely because MarshalYAML now routes non-UTF-8
+				// chunks through here as its flat-body fallback — lower-casing
+				// them would reintroduce the silent corruption the fallback
+				// exists to avoid. SSE field names are ASCII in practice, so
+				// skipping the fold for the pathological case costs nothing.
+				name := key
+				if utf8.ValidString(name) {
+					name = strings.ToLower(name)
+				}
+				lines = append(lines, name+":"+field.Value)
 			}
 			if len(lines) == 0 {
 				continue
@@ -622,6 +698,15 @@ func yamlNodeToString(node *yamlLib.Node) string {
 		return ""
 	}
 	if node.Kind == yamlLib.ScalarNode {
+		// yaml.v3 leaves the BASE64 TEXT in node.Value for a !!binary scalar
+		// rather than the decoded bytes, so returning it raw would hand replay
+		// the base64 string and silently mismatch. Decode it here, mirroring
+		// stringNode. Whitespace strip: yaml.v3 folds long base64 scalars.
+		if node.Tag == "!!binary" {
+			if raw, err := base64.StdEncoding.DecodeString(stripBase64Whitespace(node.Value)); err == nil {
+				return string(raw)
+			}
+		}
 		return node.Value
 	}
 	// Complex node (mapping or sequence) — decode then re-encode as JSON.
@@ -639,6 +724,19 @@ func yamlNodeToString(node *yamlLib.Node) string {
 // stringNode creates a YAML scalar string node with the given value.
 // Used as a helper when constructing YAML trees programmatically.
 func stringNode(value string) *yamlLib.Node {
+	// Defence in depth behind streamChunksForYAML's guard. yaml.v3 hard-fails
+	// on invalid UTF-8 under an EXPLICIT tag ("cannot marshal invalid UTF-8
+	// data as !!str") but silently base64s it under `!!binary`, so stamping
+	// !!str on arbitrary bytes is what turns one bad chunk into a failed mock
+	// insert — and a failed insert used to end the whole recording.
+	// yamlNodeToString decodes this back, so the round-trip is lossless.
+	if !utf8.ValidString(value) {
+		return &yamlLib.Node{
+			Kind:  yamlLib.ScalarNode,
+			Tag:   "!!binary",
+			Value: base64.StdEncoding.EncodeToString([]byte(value)),
+		}
+	}
 	return &yamlLib.Node{
 		Kind:  yamlLib.ScalarNode,
 		Tag:   "!!str",

--- a/pkg/models/http_stream_body_test.go
+++ b/pkg/models/http_stream_body_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -191,4 +192,266 @@ func TestHTTPResp_MarshalYAML_SSEMultilineDataUsesSingleDataField(t *testing.T) 
 	assert.Contains(t, body, "data: |-")
 	assert.Contains(t, body, "line-1")
 	assert.Contains(t, body, "line-2")
+}
+
+// TestHTTPResp_YAML_NonUTF8BodyRoundTrips is the regression guard for the
+// defect that ended a 46-hour production recording of prod/api-server.
+//
+// A gzip-encoded response body is perfectly valid HTTP and invalid UTF-8. The
+// streaming chunk encoder used to stamp an explicit `!!str` tag on it, and
+// yaml.v3 refuses that outright — "cannot marshal invalid UTF-8 data as !!str".
+// That error surfaced as a failed mock insert, and the recorder treats a failed
+// insert as fatal, so ONE response body destroyed the whole session.
+//
+// The Content-Type matters: only the streaming kinds took the chunk path.
+// application/json always used the flat scalar body and always worked, which is
+// why this went unnoticed. text/event-stream additionally corrupted the bytes
+// silently, because parseSSEBodyToChunks lower-cases the field name and
+// strings.ToLower rewrites every invalid byte to U+FFFD.
+func TestHTTPResp_YAML_NonUTF8BodyRoundTrips(t *testing.T) {
+	// gzip magic + a deflate payload: real bytes an HTTP response carries.
+	body := string([]byte{
+		0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff,
+		0xca, 0x48, 0xcd, 0xc9, 0xc9, 0x07, 0x04, 0x00, 0x00, 0xff, 0xff,
+	})
+	if utf8.ValidString(body) {
+		t.Fatal("fixture must be invalid UTF-8, otherwise this test proves nothing")
+	}
+
+	for _, ct := range []string{
+		"application/octet-stream",
+		"text/plain",
+		"application/x-ndjson",
+		"text/event-stream",
+		"application/json", // control: always worked, must keep working
+	} {
+		t.Run(ct, func(t *testing.T) {
+			in := HTTPResp{
+				StatusCode: 200,
+				Header:     map[string]string{"Content-Type": ct},
+				Body:       body,
+				Timestamp:  time.Unix(1700000000, 0).UTC(),
+			}
+
+			out, err := yamlLib.Marshal(&in)
+			if err != nil {
+				t.Fatalf("marshalling a non-UTF-8 %s body failed: %v\n"+
+					"  this is the exact production failure: the encoder tags the body !!str, "+
+					"yaml.v3 rejects it, the mock insert fails, and the recorder tears down the session", ct, err)
+			}
+
+			var got HTTPResp
+			if err := yamlLib.Unmarshal(out, &got); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got.Body != in.Body {
+				t.Fatalf("body did not round-trip for %s\n  want % x\n  got  % x\n"+
+					"  (silent corruption: a mock recorded this way replays the wrong bytes)",
+					ct, in.Body, got.Body)
+			}
+		})
+	}
+}
+
+// TestHTTPResp_YAML_TextStreamsStillChunk guards the other direction: the UTF-8
+// guard must not disable streaming for ordinary text bodies, which is the whole
+// point of the chunk encoder.
+func TestHTTPResp_YAML_TextStreamsStillChunk(t *testing.T) {
+	in := HTTPResp{
+		StatusCode: 200,
+		Header:     map[string]string{"Content-Type": "application/octet-stream"},
+		Body:       "hello world",
+		Timestamp:  time.Unix(1700000000, 0).UTC(),
+	}
+	out, err := yamlLib.Marshal(&in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), "raw") {
+		t.Fatalf("a valid-UTF-8 octet-stream body stopped being chunked; the guard must only "+
+			"divert NON-UTF-8 bodies.\n---\n%s", out)
+	}
+	var got HTTPResp
+	if err := yamlLib.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Body != in.Body {
+		t.Fatalf("text body round-trip broke: want %q got %q", in.Body, got.Body)
+	}
+}
+
+// TestStringNode_NonUTF8UsesBinaryTagAndDecodesBack pins the two halves of
+// the encode/decode pair directly, rather than only through HTTPResp. An
+// explicit `!!str` on invalid UTF-8 makes yaml.v3 hard-fail ("cannot marshal
+// invalid UTF-8 data as !!str"), which aborted the mock insert and, before
+// the recorder learned to skip a bad mock, ended the whole recording. The
+// decode half matters just as much: yaml.v3 leaves the BASE64 TEXT in
+// node.Value for a !!binary scalar, so a yamlNodeToString that returned it
+// raw would hand replay the base64 string and mismatch every time.
+func TestStringNode_NonUTF8UsesBinaryTagAndDecodesBack(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"gzip_magic", string([]byte{0x1f, 0x8b, 0x08, 0x00, 0xff, 0xfe})},
+		{"lone_continuation", string([]byte{0x80})},
+		{"utf16_bom", string([]byte{0xff, 0xfe, 0x48, 0x00})},
+		{"long", strings.Repeat(string([]byte{0xff, 0xfe, 0x00, 0x8b}), 64)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.False(t, utf8.ValidString(tc.in), "fixture must be invalid UTF-8")
+
+			n := stringNode(tc.in)
+			assert.Equal(t, "!!binary", n.Tag,
+				"invalid UTF-8 must not be stamped !!str — yaml.v3 hard-fails on it")
+
+			// Go through a real marshal/unmarshal so the emitter's line
+			// folding is exercised, not just the in-memory node.
+			out, err := yamlLib.Marshal(n)
+			require.NoError(t, err, "marshalling a !!binary scalar must not fail")
+
+			var got yamlLib.Node
+			require.NoError(t, yamlLib.Unmarshal(out, &got))
+			require.Equal(t, yamlLib.DocumentNode, got.Kind)
+			assert.Equal(t, tc.in, yamlNodeToString(got.Content[0]),
+				"binary body did not survive the YAML round-trip")
+		})
+	}
+}
+
+// TestStringNode_UTF8StaysReadable guards the other direction: valid UTF-8
+// must keep its plain !!str form so mock files stay human-readable and
+// diffable. Base64-ing everything would "fix" the crash and ruin the files.
+func TestStringNode_UTF8StaysReadable(t *testing.T) {
+	for _, in := range []string{"", "hello", "café ☕", "{\"k\":\"v\"}"} {
+		n := stringNode(in)
+		assert.Equal(t, "!!str", n.Tag, "valid UTF-8 %q must stay !!str", in)
+		assert.Equal(t, in, n.Value)
+		assert.Equal(t, in, yamlNodeToString(n))
+	}
+}
+
+// TestYAMLNodeToString_FoldedBinaryScalar covers reading a mock file whose
+// !!binary scalar is wrapped across lines. yaml.v3 emits binary on one long
+// line, but the YAML spec says a !!binary payload may carry line breaks and
+// libyaml-based writers (PyYAML, ruby-psych) wrap at 80 columns by default.
+//
+// The `>` (folded) indicator is the case that bites: YAML joins folded lines
+// with a SPACE, and base64.StdEncoding rejects a space. (It happens to skip
+// \r and \n, so a `|` literal block would decode even without the strip and
+// would prove nothing here.) Without stripBase64Whitespace the decode errors
+// and yamlNodeToString falls through to handing replay the raw base64 text.
+func TestYAMLNodeToString_FoldedBinaryScalar(t *testing.T) {
+	want := strings.Repeat(string([]byte{0xff, 0xfe, 0x00, 0x8b}), 24)
+
+	const doc = `body: !!binary >-
+  //4Ai//+AIv//gCL//4Ai//+AIv//gCL//4Ai//+AIv//gCL//4Ai//+AIv//gCL//4Ai//+AIv/
+  /gCL//4Ai//+AIv//gCL//4Ai//+AIv//gCL//4Ai//+AIv//gCL
+`
+	var m struct {
+		Body yamlLib.Node `yaml:"body"`
+	}
+	require.NoError(t, yamlLib.Unmarshal([]byte(doc), &m))
+	require.Equal(t, "!!binary", m.Body.Tag)
+	assert.Contains(t, m.Body.Value, " ",
+		"fixture must actually fold to a space, otherwise this asserts nothing")
+
+	assert.Equal(t, want, yamlNodeToString(&m.Body),
+		"folded !!binary must decode to the original bytes, not the base64 text")
+}
+
+// TestHTTPResp_YAML_NonUTF8ChunksOnlyStillCarryTheBody covers the arm the
+// UTF-8 guard opens up. When the chunks fail the UTF-8 check, MarshalYAML falls
+// back to the flat scalar body — but StreamBody and Body travel independently
+// over the transport, so a producer that populated ONLY the chunk form has an
+// empty Body and the fallback would write `body: ""`, silently losing the whole
+// response. Guarding against a marshal failure by dropping the payload instead
+// is not a fix; the bytes have to reach the flat !!binary scalar.
+func TestHTTPResp_YAML_NonUTF8ChunksOnlyStillCarryTheBody(t *testing.T) {
+	raw := string([]byte{0x1f, 0x8b, 0x08, 0x00, 0xff, 0xfe})
+	require.False(t, utf8.ValidString(raw), "fixture must be invalid UTF-8")
+
+	in := HTTPResp{
+		StatusCode: 200,
+		Header:     map[string]string{"Content-Type": "application/octet-stream"},
+		// Body deliberately empty: only the chunk form is populated.
+		Timestamp: time.Unix(1700000000, 0).UTC(),
+		StreamBody: []HTTPStreamChunk{
+			{TS: time.Unix(1700000000, 0).UTC(), Data: []HTTPStreamDataField{{Key: "raw", Value: raw}}},
+		},
+	}
+
+	out, err := yamlLib.Marshal(&in)
+	require.NoError(t, err, "marshalling non-UTF-8 chunks must not fail")
+
+	var got HTTPResp
+	require.NoError(t, yamlLib.Unmarshal(out, &got))
+	assert.Equal(t, raw, got.Body,
+		"the response body was silently dropped: the chunk form was rejected for being non-UTF-8 "+
+			"and the flat fallback encoded an empty Body")
+}
+
+// TestDecodeStreamDataFields_BinaryKeyDecodes pins the key half of the chunk
+// decoder. stringNode can emit a data-field KEY as !!binary, and yaml.v3 leaves
+// the BASE64 TEXT in node.Value for those — reading Value raw substitutes the
+// base64 for the real field name. Uses a folded (`>-`) scalar so the whitespace
+// strip is exercised too: YAML joins folded lines with a space, which
+// base64.StdEncoding rejects.
+func TestDecodeStreamDataFields_BinaryKeyDecodes(t *testing.T) {
+	// base64 of the 48 bytes below, wrapped so the fold inserts a space.
+	const doc = `data:
+  ? !!binary >-
+    //4Ai//+AIv//gCL//4Ai//+AIv//gCL//4Ai//+AIv//gCL//4Ai//+AIv//gCL//4Ai//+AIv/
+    /gCL
+  : plain-value
+  ordinary-key: v2
+`
+	var m struct {
+		Data yamlLib.Node `yaml:"data"`
+	}
+	require.NoError(t, yamlLib.Unmarshal([]byte(doc), &m))
+
+	fields, err := decodeStreamDataFields(&m.Data)
+	require.NoError(t, err)
+	require.Len(t, fields, 2)
+
+	wantKey := strings.Repeat(string([]byte{0xff, 0xfe, 0x00, 0x8b}), 15)
+	assert.Equal(t, wantKey, fields[0].Key,
+		"a !!binary data-field key was not decoded — replay would see the base64 text as the field name")
+	assert.Equal(t, "plain-value", fields[0].Value)
+	// An ordinary key must still be trimmed as before.
+	assert.Equal(t, "ordinary-key", fields[1].Key)
+}
+
+// TestHTTPResp_YAML_NonUTF8SSEFieldNameSurvivesFallback covers the corner where
+// it is the SSE field NAME, not the value, that is not valid UTF-8.
+//
+// The chunk form is rejected for exactly that reason and MarshalYAML falls back
+// to the flat body — which for text/event-stream is rebuilt by
+// streamChunksToLegacyBody, and that used to lower-case every field name.
+// strings.ToLower rewrites each invalid byte to U+FFFD, so the fallback added to
+// stop the body being dropped would instead have shipped it corrupted: the same
+// silent mangling the UTF-8 guard exists to prevent, one layer down.
+func TestHTTPResp_YAML_NonUTF8SSEFieldNameSurvivesFallback(t *testing.T) {
+	badKey := string([]byte{0xff, 0xfe, 0x41})
+	require.False(t, utf8.ValidString(badKey), "fixture must be invalid UTF-8")
+
+	in := HTTPResp{
+		StatusCode: 200,
+		Header:     map[string]string{"Content-Type": "text/event-stream"},
+		Timestamp:  time.Unix(1700000000, 0).UTC(),
+		StreamBody: []HTTPStreamChunk{
+			{TS: time.Unix(1700000000, 0).UTC(), Data: []HTTPStreamDataField{{Key: badKey, Value: "v"}}},
+		},
+	}
+
+	out, err := yamlLib.Marshal(&in)
+	require.NoError(t, err)
+
+	var got HTTPResp
+	require.NoError(t, yamlLib.Unmarshal(out, &got))
+	assert.Contains(t, got.Body, badKey,
+		"the non-UTF-8 SSE field name was mangled to U+FFFD by strings.ToLower in the flat-body fallback")
+	assert.NotContains(t, got.Body, "�", "replacement characters appeared in the body")
 }

--- a/pkg/models/postgres_v3_cell.go
+++ b/pkg/models/postgres_v3_cell.go
@@ -40,6 +40,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	yaml "gopkg.in/yaml.v3"
@@ -312,11 +313,46 @@ func scalarFloatNode(f float64) *yaml.Node {
 }
 
 func scalarStrNode(s string) *yaml.Node {
+	// Same hazard as models.stringNode: an explicit !!str tag makes yaml.v3
+	// hard-fail on invalid UTF-8 ("cannot marshal invalid UTF-8 data as
+	// !!str"), which surfaces as a failed mock insert. Reachable here from
+	// hstore values and TSVector lexemes carrying non-UTF-8 bytes. !!binary
+	// stores them losslessly and yaml.v3 decodes it back on read.
+	if !utf8.ValidString(s) {
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!binary", Value: base64.StdEncoding.EncodeToString([]byte(s))}
+	}
 	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: s}
 }
 
 func scalarKeyNode(s string) *yaml.Node {
+	// Mapping KEYS need the same non-UTF-8 handling as values (scalarStrNode),
+	// but for a different reason: an untagged key never aborts the encoder, so
+	// nothing here is load-bearing for the recording surviving. What bites is
+	// the READ side, and decodeYAMLScalarKey is what fixes that.
+	//
+	// This arm only makes the on-disk tag explicit instead of leaving it to
+	// yaml.v3's auto-binarize-on-emit behaviour — the file is identical either
+	// way today. It is kept so the encoding is stated by this package rather
+	// than inherited from an emitter heuristic that a library upgrade could
+	// change underneath us.
+	if !utf8.ValidString(s) {
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!binary", Value: base64.StdEncoding.EncodeToString([]byte(s))}
+	}
 	return &yaml.Node{Kind: yaml.ScalarNode, Value: s}
+}
+
+// decodeYAMLScalarKey returns a mapping key's real bytes, undoing the !!binary
+// encoding scalarKeyNode applies to non-UTF-8 keys.
+func decodeYAMLScalarKey(k *yaml.Node) string {
+	if k != nil && k.Tag == "!!binary" {
+		if raw, err := base64.StdEncoding.DecodeString(stripBase64Whitespace(k.Value)); err == nil {
+			return string(raw)
+		}
+	}
+	if k == nil {
+		return ""
+	}
+	return k.Value
 }
 
 func marshalVec2Node(v pgtype.Vec2) *yaml.Node {
@@ -1563,16 +1599,17 @@ func decodePgHstoreMapping(node *yaml.Node) (pgtype.Hstore, error) {
 		if k.Kind != yaml.ScalarNode {
 			return nil, fmt.Errorf("pg/hstore: non-scalar key (kind=%d)", k.Kind)
 		}
+		key := decodeYAMLScalarKey(k)
 		if v.Kind == yaml.ScalarNode && v.Tag == "!!null" {
-			out[k.Value] = nil
+			out[key] = nil
 			continue
 		}
 		var s string
 		if err := v.Decode(&s); err != nil {
-			return nil, fmt.Errorf("pg/hstore value for %q: %w", k.Value, err)
+			return nil, fmt.Errorf("pg/hstore value for %q: %w", key, err)
 		}
 		sv := s
-		out[k.Value] = &sv
+		out[key] = &sv
 	}
 	return out, nil
 }

--- a/pkg/models/postgres_v3_cell_test.go
+++ b/pkg/models/postgres_v3_cell_test.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/gob"
 	"encoding/json"
 	"math/big"
@@ -10,6 +11,7 @@ import (
 	"reflect"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	yaml "gopkg.in/yaml.v3"
@@ -640,9 +642,14 @@ func TestPostgresV3Cell_BinaryWithFoldedWhitespace_Decodes(t *testing.T) {
 	// yaml-authored payload with a real line wrap inside the scalar —
 	// identical in effect to what yaml.v3 emits for long binary cells.
 	// The original bytes are the 12-byte sequence below; base64 is
-	// "AAECAwQFBgcICQoL", wrapped at position 6 across two lines. With
-	// the `|` indicator the newline becomes whitespace in the scalar.
-	body := "!!binary |\n  AAECAwQF\n  BgcICQoL\n"
+	// "AAECAwQFBgcICQoL", wrapped at position 8 across two lines.
+	//
+	// The `>` (folded) indicator is deliberate: it joins the two lines
+	// with a SPACE, which base64.StdEncoding rejects. A `|` literal
+	// block would join with \n, which the decoder happens to skip on
+	// its own — so that spelling would pass even with the strip removed
+	// and would pin nothing.
+	body := "!!binary >\n  AAECAwQF\n  BgcICQoL\n"
 
 	var c PostgresV3Cell
 	if err := yaml.Unmarshal([]byte(body), &c); err != nil {
@@ -655,5 +662,121 @@ func TestPostgresV3Cell_BinaryWithFoldedWhitespace_Decodes(t *testing.T) {
 	want := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B}
 	if !bytes.Equal(got, want) {
 		t.Errorf("folded !!binary decode: got %x, want %x", got, want)
+	}
+}
+
+// TestPostgresV3Cell_NonUTF8HstoreRoundTrips covers the sibling of the HTTP
+// body defect. scalarStrNode used to stamp an explicit `!!str` on hstore values
+// and TSVector lexemes, which makes yaml.v3 hard-fail on invalid UTF-8 — the
+// same "cannot marshal invalid UTF-8 data as !!str" that surfaces as a failed
+// mock insert. Keys had the mirror-image bug: they encoded fine (yaml.v3
+// auto-binarizes an untagged scalar) but decoded back as the BASE64 TEXT,
+// silently replacing the key.
+//
+// The mapping marshalPgHstoreYAML emits is untagged, so a bare
+// yaml.Unmarshal into a PostgresV3Cell yields a generic map — hstore is
+// reconstructed by decodePgHstoreMapping, which is what this drives.
+func TestPostgresV3Cell_NonUTF8HstoreRoundTrips(t *testing.T) {
+	binKey := string([]byte{0xff, 0xfe, 0x48, 0x8b})
+	binVal := string([]byte{0x1f, 0x8b, 0x08, 0x00})
+	if utf8.ValidString(binKey) || utf8.ValidString(binVal) {
+		t.Fatal("fixtures must be invalid UTF-8")
+	}
+	v := binVal
+	in := PostgresV3Cell{Value: pgtype.Hstore{binKey: &v}}
+
+	out, err := yaml.Marshal(&in)
+	if err != nil {
+		t.Fatalf("marshalling a non-UTF-8 hstore failed: %v\n"+
+			"  this aborts the mock insert exactly like the HTTP body case did", err)
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(out, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) != 1 {
+		t.Fatalf("unexpected document shape: kind=%d content=%d", doc.Kind, len(doc.Content))
+	}
+	h, err := decodePgHstoreMapping(doc.Content[0])
+	if err != nil {
+		t.Fatalf("decodePgHstoreMapping: %v", err)
+	}
+	gv, present := h[binKey]
+	if !present {
+		keys := make([]string, 0, len(h))
+		for k := range h {
+			keys = append(keys, k)
+		}
+		t.Fatalf("the binary hstore KEY did not round-trip: want % x, got keys %q", binKey, keys)
+	}
+	if gv == nil || *gv != binVal {
+		t.Fatalf("hstore VALUE did not round-trip: want % x", binVal)
+	}
+}
+
+// TestDecodePgHstoreMapping_FoldedBinaryKey pins the whitespace strip inside
+// decodeYAMLScalarKey. yaml.v3 emits binary on one long line, so the sibling
+// round-trip test can never produce a folded key on its own — but a mocks.yaml
+// may be written by a libyaml-based tool (PyYAML, ruby-psych, which wrap at 80
+// columns) or hand-edited. The `>` indicator joins lines with a SPACE, which
+// base64.StdEncoding rejects outright; without the strip the decode fails and
+// the key silently becomes the raw base64 text, replacing the real hstore key.
+func TestDecodePgHstoreMapping_FoldedBinaryKey(t *testing.T) {
+	const doc = `? !!binary >-
+    //4Ai//+AIv//gCL//4Ai//+AIv//gCL//4Ai//+AIv//gCL//4Ai//+AIv//gCL//4Ai//+AIv/
+    /gCL
+: some-value
+`
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(doc), &node); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+	mapping := node.Content[0]
+	if got := mapping.Content[0].Value; !bytes.Contains([]byte(got), []byte(" ")) {
+		t.Fatalf("fixture must actually fold to a space, otherwise this asserts nothing: %q", got)
+	}
+
+	h, err := decodePgHstoreMapping(mapping)
+	if err != nil {
+		t.Fatalf("decodePgHstoreMapping: %v", err)
+	}
+	wantKey := string(bytes.Repeat([]byte{0xff, 0xfe, 0x00, 0x8b}, 15))
+	v, ok := h[wantKey]
+	if !ok {
+		keys := make([]string, 0, len(h))
+		for k := range h {
+			keys = append(keys, k)
+		}
+		t.Fatalf("a folded !!binary hstore key was not decoded: want % x, got keys %q", wantKey, keys)
+	}
+	if v == nil || *v != "some-value" {
+		t.Fatalf("value for the folded key is wrong: %v", v)
+	}
+}
+
+// TestScalarKeyNode_TagsBinaryExplicitly pins what scalarKeyNode actually does.
+// Round-trip tests cannot: yaml.v3 auto-binarizes an untagged non-UTF-8 scalar
+// on emit, so the decoder sees !!binary whether or not this function tags it,
+// and deleting the arm leaves every round-trip green. The value of the arm is
+// that the tag is stated here rather than inherited from an emitter heuristic,
+// so that is what this asserts — at the node, before the emitter runs.
+func TestScalarKeyNode_TagsBinaryExplicitly(t *testing.T) {
+	binKey := string([]byte{0xff, 0xfe, 0x48, 0x8b})
+	if utf8.ValidString(binKey) {
+		t.Fatal("fixture must be invalid UTF-8")
+	}
+	n := scalarKeyNode(binKey)
+	if n.Tag != "!!binary" {
+		t.Errorf("non-UTF-8 key node tag = %q, want !!binary; the encoding is left to yaml.v3's "+
+			"auto-promotion instead of being stated by this package", n.Tag)
+	}
+	if n.Value != base64.StdEncoding.EncodeToString([]byte(binKey)) {
+		t.Errorf("non-UTF-8 key node value is not the base64 payload: %q", n.Value)
+	}
+
+	// Valid UTF-8 must stay a plain, readable key — base64-ing everything would
+	// "fix" the encoding and ruin the mock files.
+	if p := scalarKeyNode("plain"); p.Tag != "" || p.Value != "plain" {
+		t.Errorf("a valid UTF-8 key was not left plain: tag=%q value=%q", p.Tag, p.Value)
 	}
 }

--- a/pkg/platform/yaml/mockdb/db.go
+++ b/pkg/platform/yaml/mockdb/db.go
@@ -934,10 +934,25 @@ func (ys *MockYaml) InsertMock(ctx context.Context, mock *models.Mock, testSetID
 	case yaml.FormatJSON:
 		jsonDoc, handled, err := EncodeMockJSON(mock, ys.Logger)
 		if err != nil {
-			return fmt.Errorf("failed to encode mock (json): %w", err)
+			// No errMapperEncode arm here on purpose: EncodeMockJSON projects
+			// the OSS kinds itself and never invokes a registered mapper, so
+			// every error it returns is json.Marshal on keploy's own spec —
+			// i.e. genuinely a payload fault. The mapper case arrives as
+			// handled=false and is caught below.
+			return fmt.Errorf("%w (json): %w", models.ErrMockEncode, err)
 		}
 		if !handled {
-			return fmt.Errorf("mockdb: unsupported mock kind %q for JSON format", mock.Kind)
+			// EncodeMockJSON projects only the OSS kinds; it never consults the
+			// mapper registry. A kind an enterprise mapper owns therefore lands
+			// here looking exactly like "keploy cannot encode this" — and
+			// tagging it ErrMockEncode would make the recorder skip EVERY mock
+			// of that kind and revoke every test that touched it, finishing
+			// green with an empty test set. That is the outcome errMapperEncode
+			// exists to prevent, so stay fatal when a mapper is registered.
+			if hasMapperForKind(mock.Kind) {
+				return fmt.Errorf("%w: mockdb: kind %q has a registered MockYAMLMapper but the json format cannot encode it; record with storageFormat yaml", errMapperEncode, mock.Kind)
+			}
+			return fmt.Errorf("%w (json): unsupported mock kind %q", models.ErrMockEncode, mock.Kind)
 		}
 		if err := json.NewEncoder(writer).Encode(jsonDoc); err != nil {
 			return fmt.Errorf("failed to encode mock json: %w", err)
@@ -946,20 +961,36 @@ func (ys *MockYaml) InsertMock(ctx context.Context, mock *models.Mock, testSetID
 	default:
 		// YAML path — keeps streaming via yamlLib.Encoder for wire
 		// compatibility with pre-existing mocks.yaml files.
+		// The version header is keyed off isFileEmpty, which CreateFileF only
+		// reports true for the call that CREATED the file. So it has exactly one
+		// chance: skip it here and the whole test set loses its provenance
+		// comment, because every later InsertMock sees a file that exists.
+		// Write it before the encode.
 		if isFileEmpty {
 			if version := utils.GetVersionAsComment(); version != "" {
 				if _, err := writer.WriteString(version); err != nil {
 					return fmt.Errorf("failed to write version comment: %w", err)
 				}
 			}
-		} else {
+		}
+		// The SEPARATOR, by contrast, must wait for a successful encode. A
+		// skippable failure returns below and the deferred flush commits
+		// whatever is already buffered, so writing "---" first injected a stray
+		// empty YAML document into mocks.yaml for every dropped mock.
+		mockYaml, err := EncodeMock(mock, ys.Logger)
+		if err != nil {
+			// Only keploy's own encoders are pure enough to be skippable. A
+			// registered mapper can fail for environmental reasons, so those stay
+			// fatal — see errMapperEncode.
+			if errors.Is(err, errMapperEncode) {
+				return fmt.Errorf("failed to encode mock (yaml): %w", err)
+			}
+			return fmt.Errorf("%w (yaml): %w", models.ErrMockEncode, err)
+		}
+		if !isFileEmpty {
 			if _, err := writer.WriteString("---\n"); err != nil {
 				return fmt.Errorf("failed to write document separator: %w", err)
 			}
-		}
-		mockYaml, err := EncodeMock(mock, ys.Logger)
-		if err != nil {
-			return fmt.Errorf("failed to encode mock (yaml): %w", err)
 		}
 		encoder := yamlLib.NewEncoder(writer)
 		if err := encoder.Encode(&mockYaml); err != nil {
@@ -1458,8 +1489,21 @@ func (ys *MockYaml) GetFilteredMocks(ctx context.Context, testSetID string, afte
 	}
 
 	if !hasContent {
-		utils.LogError(ys.Logger, nil, "failed to read the mocks from file (empty)", zap.String("session", filepath.Base(path)))
-		return nil, fmt.Errorf("failed to get mocks, empty file")
+		// The file exists and parsed cleanly; it just holds no documents. That
+		// is now a reachable state rather than a corruption signal: a recording
+		// whose every mock was unencodable writes only the version comment (the
+		// recorder skips a bad mock instead of dying, and a skipped mock leaves
+		// no document behind). A malformed or truncated file does NOT land here
+		// — the decode above returns an error for that.
+		//
+		// So report zero mocks, loudly, instead of failing the whole test set.
+		// The hard error made every test in the set unrunnable and said nothing
+		// about why; zero mocks lets the run proceed and produce per-test
+		// results that point at the real problem.
+		ys.Logger.Warn("mock file contains no mocks; every test in this set will run without mocks",
+			zap.String("session", filepath.Base(path)),
+			zap.String("next_step", "check the recording logs for dropped mocks (mocks-dropped) — if non-zero, the payloads could not be encoded and the set needs re-recording"))
+		return nil, nil
 	}
 
 	// NO disk-level window filter: return every per-test mock this

--- a/pkg/platform/yaml/mockdb/db_test.go
+++ b/pkg/platform/yaml/mockdb/db_test.go
@@ -30,13 +30,18 @@ package mockdb
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"go.keploy.io/server/v3/pkg/models"
+	yaml "go.keploy.io/server/v3/pkg/platform/yaml"
+	"go.keploy.io/server/v3/utils"
 	"go.uber.org/zap"
+	yamlLib "gopkg.in/yaml.v3"
 )
 
 // bigHTTPMock builds a *models.Mock whose YAML encoding comfortably
@@ -201,4 +206,410 @@ func TestInsertMock_FlushOnCtxCancel(t *testing.T) {
 			t.Fatalf("first mock's body tail disappeared after cancelled second InsertMock (file size = %d)", len(afterBytes))
 		}
 	})
+}
+
+// TestInsertMock_ClassifiesPayloadFaultsVsEnvironment pins the contract the
+// recorder now depends on to survive a bad mock.
+//
+// A failed InsertMock used to tear the whole recording session down. That is
+// right for disk-full or storage-gone — every subsequent mock fails too — and
+// badly wrong for one mock whose own payload cannot be encoded, which is how a
+// single gzip response body ended a 46-hour production recording. The recorder
+// now skips ErrMockEncode and stays fatal on everything else, so the split has
+// to be exactly right HERE or the fix either does nothing or swallows real
+// storage failures.
+func TestInsertMock_ClassifiesPayloadFaultsVsEnvironment(t *testing.T) {
+	t.Run("payload fault is tagged skippable", func(t *testing.T) {
+		dir := t.TempDir()
+		ys := NewWithFormat(zap.NewNop(), dir, "mocks", yaml.FormatJSON)
+		// A kind the JSON encoder has no arm for: the mock itself is the
+		// problem, and no later mock is affected by it.
+		mock := &models.Mock{
+			Version: models.GetVersion(),
+			Name:    "bad-1",
+			Kind:    models.Kind("ThisKindDoesNotExist"),
+			Spec:    models.MockSpec{},
+		}
+		err := ys.InsertMock(context.Background(), mock, "set-0")
+		if err == nil {
+			t.Fatal("expected an encode failure for an unsupported kind")
+		}
+		if !errors.Is(err, models.ErrMockEncode) {
+			t.Fatalf("payload-fault error is NOT tagged ErrMockEncode, so the recorder will treat "+
+				"one bad mock as fatal and destroy the session: %v", err)
+		}
+	})
+
+	t.Run("environmental failure stays fatal", func(t *testing.T) {
+		dir := t.TempDir()
+		// Make the test-set directory unwritable: an I/O failure, not a payload
+		// problem. Every later mock would fail too, so this MUST stay fatal.
+		if err := os.Chmod(dir, 0o500); err != nil {
+			t.Skipf("cannot chmod temp dir: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+		if os.Geteuid() == 0 {
+			t.Skip("running as root; a read-only dir does not produce an I/O error")
+		}
+		ys := New(zap.NewNop(), dir, "mocks")
+		mock := &models.Mock{
+			Version: models.GetVersion(),
+			Name:    "ok-1",
+			Kind:    models.HTTP,
+			Spec: models.MockSpec{
+				Metadata: map[string]string{"type": "config"},
+				HTTPReq:  &models.HTTPReq{Method: "GET", URL: "http://example.com/", Timestamp: time.Unix(1, 0)},
+				HTTPResp: &models.HTTPResp{StatusCode: 200, Timestamp: time.Unix(2, 0)},
+			},
+		}
+		err := ys.InsertMock(context.Background(), mock, "set-0")
+		if err == nil {
+			t.Fatal("writing into a read-only directory unexpectedly succeeded; this test must " +
+				"actually exercise an I/O failure or it proves nothing")
+		}
+		// Name the failure so the test cannot quietly start passing on some other
+		// error: this is the mkdir of the test-set directory.
+		if !errors.Is(err, os.ErrPermission) {
+			t.Fatalf("expected a permission error from the read-only dir, got: %v", err)
+		}
+		if errors.Is(err, models.ErrMockEncode) {
+			t.Fatalf("an I/O failure was tagged ErrMockEncode, so the recorder would keep recording "+
+				"through a broken disk and silently lose every mock: %v", err)
+		}
+	})
+}
+
+// httpMock returns a minimal, valid HTTP mock — the shape every one of these
+// tests uses as its "good" mock.
+func httpMock(name string) *models.Mock {
+	return &models.Mock{
+		Version: models.GetVersion(),
+		Name:    name,
+		Kind:    models.HTTP,
+		Spec: models.MockSpec{
+			Metadata: map[string]string{"type": "config"},
+			HTTPReq:  &models.HTTPReq{Method: "GET", URL: "http://example.com/", Timestamp: time.Unix(1, 0)},
+			HTTPResp: &models.HTTPResp{StatusCode: 200, Timestamp: time.Unix(2, 0)},
+		},
+	}
+}
+
+// TestInsertMock_YAMLPayloadFaultIsSkippable covers the classification on the
+// DEFAULT storage format. The 46-hour production recording that died was
+// writing YAML, not JSON, so a sibling test that only exercises the JSON arm
+// leaves the path that actually broke unpinned.
+func TestInsertMock_YAMLPayloadFaultIsSkippable(t *testing.T) {
+	clearRegistry(t)
+	dir := t.TempDir()
+	ys := New(zap.NewNop(), dir, "mocks")
+	t.Cleanup(func() { _ = ys.Close() })
+
+	// No mapper registered for this kind, so EncodeMock falls to its default
+	// arm: keploy's own encoders cannot represent this mock, and no later mock
+	// is affected by that.
+	err := ys.InsertMock(context.Background(), &models.Mock{
+		Version: models.GetVersion(),
+		Name:    "bad-1",
+		Kind:    models.Kind("ThisKindDoesNotExist"),
+		Spec:    models.MockSpec{},
+	}, "set-0")
+	if err == nil {
+		t.Fatal("expected an encode failure for an unsupported kind on the yaml path")
+	}
+	if !errors.Is(err, models.ErrMockEncode) {
+		t.Fatalf("a yaml payload fault is NOT tagged ErrMockEncode, so the recorder treats one "+
+			"bad mock as fatal and tears down the session — the exact 46-hour failure: %v", err)
+	}
+}
+
+// TestInsertMock_MapperFailureStaysFatal is the other half of the
+// classification, and the one with the worse failure mode if it regresses.
+//
+// A registered MockYAMLMapper is out-of-tree code that may touch the filesystem
+// or the network, so its failure can be environmental (ENOSPC, EACCES) rather
+// than a property of this one mock. Tagging it skippable would drop EVERY mock
+// of that kind and finish green with an empty test set — silent total data loss
+// instead of a loud stop.
+func TestInsertMock_MapperFailureStaysFatal(t *testing.T) {
+	const kind = models.Kind("EnterpriseKind")
+
+	t.Run("yaml", func(t *testing.T) {
+		clearRegistry(t)
+		RegisterMockYAMLMapper(kind, MockYAMLMapper{
+			Encode: func(*models.Mock, *yaml.NetworkTrafficDoc) error {
+				return errors.New("mapper offload to assets dir failed: no space left on device")
+			},
+			Decode: func(*yaml.NetworkTrafficDoc, *models.Mock) error { return nil },
+		})
+		dir := t.TempDir()
+		ys := New(zap.NewNop(), dir, "mocks")
+		t.Cleanup(func() { _ = ys.Close() })
+
+		err := ys.InsertMock(context.Background(), &models.Mock{
+			Version: models.GetVersion(), Name: "m-1", Kind: kind,
+		}, "set-0")
+		if err == nil {
+			t.Fatal("a failing mapper must surface an error")
+		}
+		if errors.Is(err, models.ErrMockEncode) {
+			t.Fatalf("a mapper failure was tagged skippable; on a full disk the recorder would "+
+				"drop every mock of this kind and finish with an empty test set: %v", err)
+		}
+	})
+
+	// The JSON encoder does not consult the mapper registry at all — a
+	// mapper-owned kind reaches it as handled=false, indistinguishable from
+	// "keploy cannot encode this" unless InsertMock checks the registry.
+	t.Run("json_unhandled_kind_with_mapper", func(t *testing.T) {
+		clearRegistry(t)
+		RegisterMockYAMLMapper(kind, MockYAMLMapper{
+			Encode: func(*models.Mock, *yaml.NetworkTrafficDoc) error { return nil },
+			Decode: func(*yaml.NetworkTrafficDoc, *models.Mock) error { return nil },
+		})
+		dir := t.TempDir()
+		ys := NewWithFormat(zap.NewNop(), dir, "mocks", yaml.FormatJSON)
+		t.Cleanup(func() { _ = ys.Close() })
+
+		err := ys.InsertMock(context.Background(), &models.Mock{
+			Version: models.GetVersion(), Name: "m-1", Kind: kind,
+		}, "set-0")
+		if err == nil {
+			t.Fatal("the json encoder cannot encode a mapper-owned kind; that must be an error")
+		}
+		if errors.Is(err, models.ErrMockEncode) {
+			t.Fatalf("a mapper-owned kind was tagged skippable on the json path, so recording a "+
+				"Redis/Kafka/Pulsar app with storageFormat json would silently drop every one of "+
+				"those mocks and DELETE every test that touched them: %v", err)
+		}
+	})
+}
+
+// TestInsertMock_SkippedMockLeavesNoStrayDocument guards the file the recorder
+// leaves behind once a mock can be skipped. The document separator used to be
+// written before the encode was attempted, and the deferred flush commits it —
+// so every dropped mock injected an empty YAML document into mocks.yaml.
+func TestInsertMock_SkippedMockLeavesNoStrayDocument(t *testing.T) {
+	clearRegistry(t)
+	dir := t.TempDir()
+	ys := New(zap.NewNop(), dir, "mocks")
+
+	ctx := context.Background()
+	if err := ys.InsertMock(ctx, httpMock("good-1"), "set-0"); err != nil {
+		t.Fatalf("first mock: %v", err)
+	}
+	if err := ys.InsertMock(ctx, &models.Mock{
+		Version: models.GetVersion(), Name: "bad-1", Kind: models.Kind("ThisKindDoesNotExist"),
+	}, "set-0"); !errors.Is(err, models.ErrMockEncode) {
+		t.Fatalf("want a skippable encode error for the middle mock, got %v", err)
+	}
+	if err := ys.InsertMock(ctx, httpMock("good-2"), "set-0"); err != nil {
+		t.Fatalf("third mock: %v", err)
+	}
+	_ = ys.Close()
+
+	got, err := os.ReadFile(filepath.Join(dir, "set-0", "mocks.yaml"))
+	if err != nil {
+		t.Fatalf("read mocks.yaml: %v", err)
+	}
+	// Two mocks were written, so exactly one separator belongs in the file.
+	if n := strings.Count(string(got), "---\n"); n != 1 {
+		t.Errorf("mocks.yaml has %d document separators for 2 written mocks; the dropped mock "+
+			"left a stray empty document behind:\n%s", n, got)
+	}
+	// And the file must still parse as exactly two documents.
+	dec := yamlLib.NewDecoder(strings.NewReader(string(got)))
+	docs := 0
+	for {
+		var doc yamlLib.Node
+		if err := dec.Decode(&doc); err != nil {
+			break
+		}
+		docs++
+	}
+	if docs != 2 {
+		t.Errorf("mocks.yaml decodes to %d documents, want 2 (good-1, good-2)", docs)
+	}
+}
+
+// TestInsertMock_VersionHeaderSurvivesASkippedFirstMock covers the one-shot
+// nature of the version header. CreateFileF reports isFileEmpty=true only for
+// the call that CREATED the file, so if the first mock of a test set is
+// unencodable and the header write sits after the encode, the file is created
+// empty, the header is skipped, and every later InsertMock sees a file that
+// already exists — the whole test set loses its provenance comment permanently.
+func TestInsertMock_VersionHeaderSurvivesASkippedFirstMock(t *testing.T) {
+	clearRegistry(t)
+	dir := t.TempDir()
+	ys := New(zap.NewNop(), dir, "mocks")
+
+	ctx := context.Background()
+	// The FIRST mock of the set is the unencodable one.
+	if err := ys.InsertMock(ctx, &models.Mock{
+		Version: models.GetVersion(), Name: "bad-1", Kind: models.Kind("ThisKindDoesNotExist"),
+	}, "set-0"); !errors.Is(err, models.ErrMockEncode) {
+		t.Fatalf("want a skippable encode error for the first mock, got %v", err)
+	}
+	if err := ys.InsertMock(ctx, httpMock("good-1"), "set-0"); err != nil {
+		t.Fatalf("second mock: %v", err)
+	}
+	_ = ys.Close()
+
+	got, err := os.ReadFile(filepath.Join(dir, "set-0", "mocks.yaml"))
+	if err != nil {
+		t.Fatalf("read mocks.yaml: %v", err)
+	}
+	want := utils.GetVersionAsComment()
+	if want == "" {
+		t.Skip("no version comment configured in this build")
+	}
+	if !strings.HasPrefix(string(got), want) {
+		t.Errorf("mocks.yaml lost its version header because the first mock was skipped.\nwant prefix %q\ngot %q",
+			want, string(got[:min(len(got), 80)]))
+	}
+	// And it must still be a single valid document.
+	dec := yamlLib.NewDecoder(strings.NewReader(string(got)))
+	docs := 0
+	for {
+		var doc yamlLib.Node
+		if err := dec.Decode(&doc); err != nil {
+			break
+		}
+		docs++
+	}
+	if docs != 1 {
+		t.Errorf("mocks.yaml decodes to %d documents, want 1 (good-1)", docs)
+	}
+}
+
+// TestInsertMock_JSONBinaryBodyIsRefusedNotCorrupted covers the storageFormat
+// the headline fix does NOT cover.
+//
+// encoding/json has no lossless representation for a Go string holding invalid
+// UTF-8: it substitutes U+FFFD for every bad byte and returns no error. So a
+// gzip response body — the exact payload that killed the 46-hour recording —
+// used to be written to mocks.json silently corrupted, the recording reported
+// success, and the damage surfaced only at replay as an unexplained mismatch.
+// Silent corruption is worse than the crash it replaced; refuse the one mock
+// loudly instead, tagged skippable so the session still survives.
+func TestInsertMock_JSONBinaryBodyIsRefusedNotCorrupted(t *testing.T) {
+	clearRegistry(t)
+	gzipBody := string([]byte{0x1f, 0x8b, 0x08, 0x00, 0xff, 0xfe})
+
+	dir := t.TempDir()
+	ys := NewWithFormat(zap.NewNop(), dir, "mocks", yaml.FormatJSON)
+	t.Cleanup(func() { _ = ys.Close() })
+
+	mock := httpMock("bin-1")
+	mock.Spec.HTTPResp.Body = gzipBody
+
+	err := ys.InsertMock(context.Background(), mock, "set-0")
+	if err == nil {
+		got, rerr := os.ReadFile(filepath.Join(dir, "set-0", "mocks.json"))
+		// encoding/json escapes the replacement rune as the SIX-character ASCII
+		// sequence `\ufffd`, never as the raw rune — matching on "�" here
+		// would silently never fire and this diagnostic would be dead.
+		if rerr == nil && strings.Contains(string(got), `\ufffd`) {
+			t.Fatal("a binary response body was written to mocks.json with every invalid byte " +
+				"replaced by U+FFFD, and InsertMock reported SUCCESS — silent corruption that only " +
+				"surfaces at replay as an unexplained mismatch")
+		}
+		t.Fatal("a binary body must not be silently accepted on the json path")
+	}
+	if !errors.Is(err, models.ErrMockEncode) {
+		t.Fatalf("the refusal must be tagged skippable, or one binary body kills the whole session "+
+			"exactly like the original defect: %v", err)
+	}
+	// A UTF-8 body on the same path must still work — this must not become a
+	// blanket refusal of the json format.
+	if err := ys.InsertMock(context.Background(), httpMock("ok-1"), "set-0"); err != nil {
+		t.Fatalf("a normal UTF-8 body was refused on the json path: %v", err)
+	}
+}
+
+// TestGetFilteredMocks_HeaderOnlyFileIsZeroMocksNotAnError closes the loop
+// between the two halves of this change. Now that a recording SURVIVES
+// unencodable mocks, a test set whose every mock was dropped ends up with a
+// mocks.yaml holding only the version comment — a state that previously could
+// not occur, because such a recording died instead.
+//
+// Reading that file used to hard-fail with "failed to get mocks, empty file",
+// which makes every test in the set unrunnable and explains nothing. Report
+// zero mocks instead so the run proceeds and the per-test results point at the
+// real problem. A truncated or malformed file is unaffected: the decode returns
+// its own error well before this.
+func TestGetFilteredMocks_HeaderOnlyFileIsZeroMocksNotAnError(t *testing.T) {
+	clearRegistry(t)
+	dir := t.TempDir()
+	ys := New(zap.NewNop(), dir, "mocks")
+
+	// Every mock in the set is unencodable, so nothing but the header is written.
+	for _, n := range []string{"bad-1", "bad-2"} {
+		if err := ys.InsertMock(context.Background(), &models.Mock{
+			Version: models.GetVersion(), Name: n, Kind: models.Kind("ThisKindDoesNotExist"),
+		}, "set-0"); !errors.Is(err, models.ErrMockEncode) {
+			t.Fatalf("%s: want a skippable encode error, got %v", n, err)
+		}
+	}
+	_ = ys.Close()
+
+	got, err := os.ReadFile(filepath.Join(dir, "set-0", "mocks.yaml"))
+	if err != nil {
+		t.Fatalf("read mocks.yaml: %v", err)
+	}
+	if strings.Contains(string(got), "kind:") {
+		t.Fatalf("expected a document-less file, got:\n%s", got)
+	}
+
+	mocks, err := ys.GetFilteredMocks(context.Background(), "set-0", time.Time{}, time.Time{}, nil, nil)
+	if err != nil {
+		t.Fatalf("a document-less mock file failed the whole test set instead of reporting zero "+
+			"mocks; every test in the set becomes unrunnable with no explanation: %v", err)
+	}
+	if len(mocks) != 0 {
+		t.Errorf("want zero mocks from a document-less file, got %d", len(mocks))
+	}
+}
+
+// TestEncodeMockJSON_HTTP2BinaryBodyIsRefused is the sibling of the HTTP case.
+// EncodeMockJSON projects HTTP2Req.Body and HTTP2Resp.Body as plain strings
+// too, so a binary body on an Http2 mock hit the identical silent U+FFFD
+// corruption — one `case` away from the guard, and easy to miss because no OSS
+// path records an Http2 mock today (enterprise egress recorders do).
+func TestEncodeMockJSON_HTTP2BinaryBodyIsRefused(t *testing.T) {
+	gzipBody := string([]byte{0x1f, 0x8b, 0x08, 0x00, 0xff, 0xfe})
+
+	for _, tc := range []struct {
+		name string
+		spec models.MockSpec
+	}{
+		{"request", models.MockSpec{
+			HTTP2Req:  &models.HTTP2Req{Body: gzipBody},
+			HTTP2Resp: &models.HTTP2Resp{},
+		}},
+		{"response", models.MockSpec{
+			HTTP2Req:  &models.HTTP2Req{},
+			HTTP2Resp: &models.HTTP2Resp{Body: gzipBody},
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			doc, _, err := EncodeMockJSON(&models.Mock{
+				Version: models.GetVersion(), Name: "h2-1", Kind: models.HTTP2, Spec: tc.spec,
+			}, zap.NewNop())
+			if err == nil {
+				t.Fatalf("an http2 binary %s body was accepted; json.Marshal writes it with every "+
+					"invalid byte replaced by U+FFFD and reports success:\n%s", tc.name, doc.Spec)
+			}
+			if !errors.Is(err, models.ErrMockEncode) {
+				t.Fatalf("the refusal must be tagged skippable so the session survives: %v", err)
+			}
+		})
+	}
+
+	// A UTF-8 http2 body must still encode.
+	if _, _, err := EncodeMockJSON(&models.Mock{
+		Version: models.GetVersion(), Name: "h2-ok", Kind: models.HTTP2,
+		Spec: models.MockSpec{HTTP2Req: &models.HTTP2Req{Body: "{}"}, HTTP2Resp: &models.HTTP2Resp{Body: "{}"}},
+	}, zap.NewNop()); err != nil {
+		t.Fatalf("a normal UTF-8 http2 body was refused: %v", err)
+	}
 }

--- a/pkg/platform/yaml/mockdb/util.go
+++ b/pkg/platform/yaml/mockdb/util.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"go.keploy.io/server/v3/pkg/models"
 	"go.keploy.io/server/v3/pkg/models/mysql"
@@ -225,6 +226,25 @@ func EncodeMockJSON(mock *models.Mock, logger *zap.Logger) (*yaml.NetworkTraffic
 		return nil, false, nil
 	}
 
+	// encoding/json has no lossless representation for a Go string holding
+	// invalid UTF-8: it substitutes U+FFFD for every bad byte and returns NO
+	// error. A gzip-encoded response body is perfectly valid HTTP and invalid
+	// UTF-8, so on this path the recorder would write a corrupted body, report
+	// success, and only fail at replay as an unexplained mismatch.
+	//
+	// Refuse instead. Tagged as a payload fault so the recorder skips and counts
+	// this one mock and keeps recording (see models.ErrMockEncode) — the same
+	// treatment the YAML path gives a body it cannot represent, except YAML CAN
+	// represent it (as !!binary) and therefore does.
+	if field, ok := firstNonUTF8Body(mock); !ok {
+		err := fmt.Errorf("%w: mockdb: %s is not valid UTF-8 and the json format cannot store it losslessly; record with storageFormat yaml to keep binary bodies", models.ErrMockEncode, field)
+		utils.LogError(logger, err, "refusing to write a binary body as JSON",
+			zap.String("mock_name", mock.Name),
+			zap.String("mock_kind", string(mock.Kind)),
+			zap.String("next_step", "set storageFormat to yaml; the yaml encoder stores binary bodies as !!binary without loss"))
+		return nil, true, err
+	}
+
 	specBytes, err := json.Marshal(spec)
 	if err != nil {
 		utils.LogError(logger, err, "failed to marshal mock spec to JSON")
@@ -233,6 +253,38 @@ func EncodeMockJSON(mock *models.Mock, logger *zap.Logger) (*yaml.NetworkTraffic
 	doc.Spec = specBytes
 	return doc, true, nil
 }
+
+// firstNonUTF8Body reports whether every string field that can carry raw
+// response/request bytes is valid UTF-8, naming the first that is not.
+//
+// Covers every `string` field this encoder projects that can hold arbitrary
+// payload bytes: the HTTP and HTTP/2 request/response bodies. The remaining
+// projected fields are headers, URLs and timestamps, and []byte fields are not
+// at risk because encoding/json base64s them (Generic payloads take that path,
+// and gRPC DecodedData is protoscope text).
+func firstNonUTF8Body(mock *models.Mock) (string, bool) {
+	if mock == nil {
+		return "", true
+	}
+	if r := mock.Spec.HTTPReq; r != nil && !utf8.ValidString(r.Body) {
+		return "the request body", false
+	}
+	if r := mock.Spec.HTTPResp; r != nil && !utf8.ValidString(r.Body) {
+		return "the response body", false
+	}
+	if r := mock.Spec.HTTP2Req; r != nil && !utf8.ValidString(r.Body) {
+		return "the http2 request body", false
+	}
+	if r := mock.Spec.HTTP2Resp; r != nil && !utf8.ValidString(r.Body) {
+		return "the http2 response body", false
+	}
+	return "", true
+}
+
+// errMapperEncode marks a failure that came from a registered out-of-tree
+// MockYAMLMapper rather than from keploy's own encoders. See its use in
+// EncodeMock: mapper failures must stay fatal because they can be I/O.
+var errMapperEncode = errors.New("mock encode mapper failure")
 
 func EncodeMock(mock *models.Mock, logger *zap.Logger) (*yaml.NetworkTrafficDoc, error) {
 
@@ -254,7 +306,14 @@ func EncodeMock(mock *models.Mock, logger *zap.Logger) (*yaml.NetworkTrafficDoc,
 	}
 	mapped, err := encodeWithMapper(mock, &yamlDoc)
 	if err != nil {
-		wrapped := fmt.Errorf("mockdb: encode mapper for kind %q: %w", mock.Kind, err)
+		// Marked so callers do NOT classify this as a payload fault. A registered
+		// MockYAMLMapper is out-of-tree code that may touch the filesystem or the
+		// network (offloading large bodies to an assets dir, for example), so its
+		// failure can be environmental — ENOSPC, EACCES. Treating that as
+		// "skip this one mock and keep going" would silently drop EVERY mock and
+		// finish with an empty test set. Only keploy's own encoders below are
+		// pure enough to be safely skippable.
+		wrapped := fmt.Errorf("%w: mockdb: encode mapper for kind %q: %w", errMapperEncode, mock.Kind, err)
 		utils.LogError(logger, wrapped, "registered MockYAMLMapper.Encode returned an error; check the mapper for this kind", zap.String("kind", string(mock.Kind)))
 		return nil, wrapped
 	}

--- a/pkg/platform/yaml/mockdb/yaml_mapper.go
+++ b/pkg/platform/yaml/mockdb/yaml_mapper.go
@@ -78,6 +78,17 @@ func encodeWithMapper(mock *models.Mock, doc *yaml.NetworkTrafficDoc) (bool, err
 	return true, v.(MockYAMLMapper).Encode(mock, doc)
 }
 
+// hasMapperForKind reports whether an out-of-tree MockYAMLMapper is registered
+// for kind. The JSON encoder does not consult the mapper registry at all — it
+// projects the OSS kinds it knows and returns handled=false for anything else —
+// so callers need this to tell "kind keploy genuinely cannot encode" from "kind
+// an enterprise mapper owns", which must not be treated as a skippable payload
+// fault. See the errMapperEncode note in util.go.
+func hasMapperForKind(kind models.Kind) bool {
+	_, ok := mockYAMLMappers.Load(kind)
+	return ok
+}
+
 func decodeWithMapper(doc *yaml.NetworkTrafficDoc, mock *models.Mock) (bool, error) {
 	if doc == nil {
 		return false, nil

--- a/pkg/service/record/asynchook_test.go
+++ b/pkg/service/record/asynchook_test.go
@@ -221,7 +221,7 @@ func TestAsyncPollMockExcludedFromPerTestMapping(t *testing.T) {
 
 	r := &Recorder{logger: zap.NewNop()}
 	mapping := models.TestMockMapping{TestName: "T1", MockIDs: []string{pollMock.Name, syncMockName}}
-	got := r.resolveMappingEntries(mapping, &correlationMap, &asyncMockIDs)
+	got, _, _ := r.resolveMappingEntries(mapping, &correlationMap, &asyncMockIDs, &droppedMockSet{})
 
 	for _, e := range got {
 		if e.Name == pollMock.Name {

--- a/pkg/service/record/mapping_test.go
+++ b/pkg/service/record/mapping_test.go
@@ -1,9 +1,15 @@
 package record
 
 import (
+	"context"
+	"strconv"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.keploy.io/server/v3/config"
 	"go.keploy.io/server/v3/pkg/models"
 	"go.uber.org/zap"
 )
@@ -31,7 +37,7 @@ func TestResolveMappingEntriesExcludesAsyncMocks(t *testing.T) {
 		MockIDs:  []string{"sync-1", "async-1", "async-2"},
 	}
 
-	got := r.resolveMappingEntries(mapping, &correlationMap, &asyncMockIDs)
+	got, _, _ := r.resolveMappingEntries(mapping, &correlationMap, &asyncMockIDs, &droppedMockSet{})
 
 	if len(got) != 1 {
 		t.Fatalf("want exactly the 1 sync mock in the mapping, got %d: %+v", len(got), got)
@@ -55,11 +61,528 @@ func TestResolveMappingEntriesKeepsAllSyncMocks(t *testing.T) {
 	correlationMap.Store("m1", models.MockEntry{Name: "m1"})
 	correlationMap.Store("m2", models.MockEntry{Name: "m2"})
 
-	got := r.resolveMappingEntries(
+	got, _, _ := r.resolveMappingEntries(
 		models.TestMockMapping{TestName: "t", MockIDs: []string{"m1", "m2"}},
-		&correlationMap, &asyncMockIDs,
+		&correlationMap, &asyncMockIDs, &droppedMockSet{},
 	)
 	if len(got) != 2 {
 		t.Fatalf("want both sync mocks mapped, got %d: %+v", len(got), got)
+	}
+}
+
+// TestResolveMappingEntries_DroppedMockSkipsSpinAndRevokesOwner guards the two
+// consequences of letting a recording SURVIVE an unencodable mock.
+//
+// Dropping a mock means its correlationMap entry never arrives. Without the
+// droppedMockIDs short-circuit, resolveMappingEntries burns its full ~500ms
+// retry per dropped mock, serialized in the single mapping consumer — and the
+// agent DROPS mappings it cannot hand over, so a systematic encode failure
+// (one upstream gzipping every response) would corrupt mappings for unrelated,
+// healthy tests. And the test that owned the mock must be revoked, or it
+// replays with a short pool and fails for reasons that look like a product bug.
+func TestResolveMappingEntries_DroppedMockSkipsSpinAndRevokesOwner(t *testing.T) {
+	r := &Recorder{logger: zap.NewNop()}
+	var correlationMap, asyncMockIDs sync.Map
+	var droppedMockIDs droppedMockSet
+
+	correlationMap.Store("good", models.MockEntry{Name: "good"})
+	droppedMockIDs.add("dropped-1")
+	droppedMockIDs.add("dropped-2")
+
+	start := time.Now()
+	got, lostMock, _ := r.resolveMappingEntries(
+		models.TestMockMapping{TestName: "t", MockIDs: []string{"dropped-1", "good", "dropped-2"}},
+		&correlationMap, &asyncMockIDs, &droppedMockIDs,
+	)
+	elapsed := time.Since(start)
+
+	if !lostMock {
+		t.Error("the owning test was not flagged as having lost a mock, so it will not be revoked " +
+			"and will replay with a short mock pool")
+	}
+	if len(got) != 1 || got[0].Name != "good" {
+		t.Fatalf("want only the resolvable mock, got %+v", got)
+	}
+	// Each un-short-circuited dropped ID costs ~500ms. Two of them would be ~1s.
+	if elapsed > 200*time.Millisecond {
+		t.Fatalf("resolving 2 dropped mocks took %v — the correlation spin was not skipped. "+
+			"That stall is serialized in the mapping consumer and makes the agent drop "+
+			"mappings for unrelated healthy tests", elapsed)
+	}
+	// Consuming the IDs must free them: mocks and drops accumulate for the whole
+	// recording, and a set that only ever grows is a leak on a multi-day session.
+	if live := droppedMockIDs.liveLost.Load(); live != 0 {
+		t.Errorf("droppedMockSet still holds %d consumed entries; it grows unbounded over a long recording", live)
+	}
+}
+
+// TestResolveMappingEntries_DropRecordedAfterMappingArrives is the ordering the
+// short-circuit actually has to survive.
+//
+// Mocks and mappings arrive on two independent channels drained by two
+// independent goroutines — that race is the whole reason the correlation spin
+// exists — so a mapping routinely reaches resolveMappingEntries BEFORE the mock
+// goroutine has even attempted its insert. A drop check that runs once up front
+// therefore loses every time: it sees nothing, spins the full ~500ms anyway, and
+// then persists the test with a silently short mock pool. Both failures are the
+// exact ones the change claims to remove, so this drives the drop from a
+// separate goroutine that fires only after the resolve is already in its spin.
+func TestResolveMappingEntries_DropRecordedAfterMappingArrives(t *testing.T) {
+	r := &Recorder{logger: zap.NewNop()}
+	var correlationMap, asyncMockIDs sync.Map
+	var droppedMockIDs droppedMockSet
+
+	correlationMap.Store("good", models.MockEntry{Name: "good"})
+
+	// The mock loop gives up on "slow-drop" only after the mapping is in flight.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		droppedMockIDs.add("slow-drop")
+	}()
+
+	start := time.Now()
+	got, lostMock, _ := r.resolveMappingEntries(
+		models.TestMockMapping{TestName: "t", MockIDs: []string{"slow-drop", "good"}},
+		&correlationMap, &asyncMockIDs, &droppedMockIDs,
+	)
+	elapsed := time.Since(start)
+
+	if !lostMock {
+		t.Error("a drop recorded WHILE the mapping was resolving did not revoke the owning test — " +
+			"it is persisted with a short mock pool, which is the data loss this is meant to prevent")
+	}
+	if len(got) != 1 || got[0].Name != "good" {
+		t.Fatalf("want only the resolvable mock, got %+v", got)
+	}
+	if elapsed > 300*time.Millisecond {
+		t.Fatalf("resolve took %v — the spin ran to its full ~500ms timeout instead of "+
+			"noticing the concurrent drop", elapsed)
+	}
+}
+
+// TestDroppedMockSet_BoundedWhenNothingConsumes covers the entries that have no
+// consumer at all: a background egress mock whose owning test never completes is
+// never referenced by any mapping, so nothing ever take()s it. Unbounded, that
+// is a slow leak for the life of the recording.
+func TestDroppedMockSet_BoundedWhenNothingConsumes(t *testing.T) {
+	var d droppedMockSet
+	for i := 0; i < maxLiveDroppedMockIDs+500; i++ {
+		d.add("orphan-" + strconv.Itoa(i))
+	}
+	if live := d.liveLost.Load(); live > maxLiveDroppedMockIDs {
+		t.Fatalf("droppedMockSet grew to %d entries, past the %d cap", live, maxLiveDroppedMockIDs)
+	}
+	// Past the cap add() must say so, so the caller can report that further
+	// owning tests will not be revoked instead of silently believing they were.
+	if d.add("one-more") {
+		t.Error("add reported success past the cap; callers would log ownerRevocable=true for a test that is never revoked")
+	}
+}
+
+// TestConsumeMappings_CountsShortPoolTests pins the accounting for the one
+// data-loss path this change deliberately does NOT revoke.
+//
+// A mock that never correlates within the ~500ms spin is not the same fact as a
+// mock we know was dropped: it may well have been persisted and simply not
+// observed in time. Revoking on that inference would turn a latency event into
+// deterministic deletion of a customer's recorded test, so the test is still
+// persisted with a short pool — exactly as before this change.
+//
+// What was missing is the total. The loss used to surface only as scattered
+// per-occurrence log lines, so nobody could say how often it fires; that is the
+// stated reason the semantics were left alone. Counting it makes the frequency
+// measurable before anyone argues about changing them.
+func TestConsumeMappings_CountsShortPoolTests(t *testing.T) {
+	r := &Recorder{logger: zap.NewNop(), config: &config.Config{}, mappingDb: &countingMappingDB{}}
+	var correlationMap, asyncMockIDs sync.Map
+	var droppedMockIDs droppedMockSet
+	var shortPoolByTest sync.Map
+
+	// One mock per test: resolveMappingEntries consumes a correlation entry as
+	// it resolves it, so sharing an ID would make the second test look short too.
+	correlationMap.Store("m-short", models.MockEntry{Name: "m-short"})
+	correlationMap.Store("m-healthy", models.MockEntry{Name: "m-healthy"})
+
+	mappings := make(chan models.TestMockMapping, 2)
+	// "ghost" never correlates and was never recorded as dropped.
+	mappings <- models.TestMockMapping{TestName: "t-short", MockIDs: []string{"m-short", "ghost"}}
+	mappings <- models.TestMockMapping{TestName: "t-healthy", MockIDs: []string{"m-healthy"}}
+	close(mappings)
+
+	var revoked []string
+	require.NoError(t, r.consumeMappings(context.Background(), "set-0", mappings,
+		&correlationMap, &asyncMockIDs, &droppedMockIDs,
+		func(n string) { revoked = append(revoked, n) },
+		&shortPoolByTest))
+
+	assert.Empty(t, revoked,
+		"a correlation timeout must NOT revoke: it is an inference, not the known-drop fact, and "+
+			"deleting a recorded test on it turns a latency event into data destruction")
+	tests, mocks := totalShortPool(&shortPoolByTest)
+	assert.Equal(t, 1, tests,
+		"the test persisted with an incomplete mock set was not counted, so the loss stays invisible in aggregate")
+	assert.Equal(t, 1, mocks)
+}
+
+// countingMappingDB is a no-op MappingDb; these tests only care about the
+// correlation accounting, not what reaches mappings.yaml.
+type countingMappingDB struct{}
+
+func (countingMappingDB) Insert(context.Context, *models.Mapping) error { return nil }
+func (countingMappingDB) Upsert(context.Context, string, string, []models.MockEntry) error {
+	return nil
+}
+func (countingMappingDB) UpsertBatch(context.Context, string, map[string][]models.MockEntry) error {
+	return nil
+}
+
+// TestResolveMappingEntries_DroppedAsyncMockDoesNotRevoke guards the blast
+// radius of the revoke path.
+//
+// Async-egress mocks are deliberately excluded from per-test mappings — replay
+// serves them from the complete corpus — so a missing async mock is not a short
+// pool for any test. If a dropped async mock set droppedOwner, one unencodable
+// poll response would DELETE the healthy test whose request window that
+// background egress happened to fall in, while the recording finished green.
+// (Windows are non-overlapping FIFO and the entry is consumed on match, so it
+// is one test per dropped async mock — still silent destruction of recorded
+// data, which is the class this whole change exists to remove.)
+func TestResolveMappingEntries_DroppedAsyncMockDoesNotRevoke(t *testing.T) {
+	r := &Recorder{logger: zap.NewNop()}
+	var correlationMap, asyncMockIDs sync.Map
+	var droppedMockIDs droppedMockSet
+
+	correlationMap.Store("good", models.MockEntry{Name: "good"})
+
+	// Drive the mock loop's real ordering from a goroutine: the marker is
+	// stored, then the insert is attempted, then the drop is recorded — all
+	// while this mapping is already spinning. Pre-populating both maps before
+	// the call would miss the ordering entirely, which is how an earlier
+	// revision passed its own test while still deleting healthy tests.
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		asyncMockIDs.Store("async-bad", struct{}{})
+		time.Sleep(20 * time.Millisecond)
+		droppedMockIDs.add("async-bad") // the async mock failed to encode
+	}()
+
+	start := time.Now()
+	got, lostMock, uncorrelated := r.resolveMappingEntries(
+		models.TestMockMapping{TestName: "t", MockIDs: []string{"async-bad", "good"}},
+		&correlationMap, &asyncMockIDs, &droppedMockIDs,
+	)
+
+	if lostMock {
+		t.Error("a dropped ASYNC mock revoked the test whose window it fell in. Async mocks are " +
+			"excluded from per-test mappings by design, so their absence is never a short pool — " +
+			"this silently deletes a healthy recorded test and finishes green")
+	}
+	if uncorrelated != 0 {
+		t.Errorf("a dropped async mock was counted as a short pool (%d); its absence is by design", uncorrelated)
+	}
+	if len(got) != 1 || got[0].Name != "good" {
+		t.Fatalf("want only the sync mock, got %+v", got)
+	}
+	if elapsed := time.Since(start); elapsed > 300*time.Millisecond {
+		t.Fatalf("resolving a dropped async mock took %v — the drop did not short-circuit the spin", elapsed)
+	}
+}
+
+// TestResolveMappingEntries_AsyncMarkerSetDuringSpin is the mirror image of the
+// dropped-async case, and the reason the async decision cannot be made at a
+// single point in time.
+//
+// The mock loop publishes the async marker and then does file I/O before the
+// tempID reaches correlationMap, so a mapping routinely arrives while the
+// marker is still unset. An implementation that only checks async BEFORE the
+// spin therefore sees "not async", resolves the mock normally, and appends it
+// to the per-test mapping — leaking a background-egress mock into a test's mock
+// pool while the async engine also serves it from the corpus. That is exactly
+// what the exclusion exists to prevent, so the check has to happen at the point
+// the tempID's fate is actually settled.
+func TestResolveMappingEntries_AsyncMarkerSetDuringSpin(t *testing.T) {
+	r := &Recorder{logger: zap.NewNop()}
+	var correlationMap, asyncMockIDs sync.Map
+	var droppedMockIDs droppedMockSet
+
+	correlationMap.Store("good", models.MockEntry{Name: "good"})
+
+	// The mock loop's real ordering: mark async, then (later) publish the
+	// correlation entry — both after this mapping is already in the spin.
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		asyncMockIDs.Store("async-late", struct{}{})
+		time.Sleep(30 * time.Millisecond)
+		correlationMap.Store("async-late", models.MockEntry{Name: "async-late"})
+	}()
+
+	got, lostMock, uncorrelated := r.resolveMappingEntries(
+		models.TestMockMapping{TestName: "t", MockIDs: []string{"async-late", "good"}},
+		&correlationMap, &asyncMockIDs, &droppedMockIDs,
+	)
+
+	if lostMock || uncorrelated != 0 {
+		t.Errorf("a resolved async mock was treated as loss: lostMock=%v uncorrelated=%d", lostMock, uncorrelated)
+	}
+	for _, e := range got {
+		if e.Name == "async-late" {
+			t.Fatalf("an ASYNC mock leaked into the per-test mapping: %+v\n"+
+				"  replay serves async egress from the complete corpus, so a test that also lists it "+
+				"replays the same interaction twice", got)
+		}
+	}
+	if len(got) != 1 || got[0].Name != "good" {
+		t.Fatalf("want only the sync mock, got %+v", got)
+	}
+}
+
+// TestResolveMappingEntries_AsyncMockNeverCountsAsShortPool covers the timeout
+// settle point. An async mock that never correlates is not an incomplete mock
+// set for anyone — its absence is the design — so it must not inflate the
+// short-pool counters whose credibility is the justification for leaving the
+// correlation-timeout path unrevoked.
+func TestResolveMappingEntries_AsyncMockNeverCountsAsShortPool(t *testing.T) {
+	r := &Recorder{logger: zap.NewNop()}
+	var correlationMap, asyncMockIDs sync.Map
+	var droppedMockIDs droppedMockSet
+
+	correlationMap.Store("good", models.MockEntry{Name: "good"})
+	asyncMockIDs.Store("async-never", struct{}{})
+
+	got, lostMock, uncorrelated := r.resolveMappingEntries(
+		models.TestMockMapping{TestName: "t", MockIDs: []string{"async-never", "good"}},
+		&correlationMap, &asyncMockIDs, &droppedMockIDs,
+	)
+
+	if lostMock {
+		t.Error("an uncorrelated async mock revoked its test")
+	}
+	if uncorrelated != 0 {
+		t.Errorf("an uncorrelated async mock was counted as a short pool (%d); its absence is by design", uncorrelated)
+	}
+	if len(got) != 1 || got[0].Name != "good" {
+		t.Fatalf("want only the sync mock, got %+v", got)
+	}
+}
+
+// TestResolveMappingEntries_BenignSkipDoesNotRevokeOrCount covers the mocks a
+// RecordHook intentionally drops (a collapsed async poll no-change cycle). The
+// agent does not know about the skip, so the tempID still arrives in a mapping.
+// Short-circuiting the spin for it is right; revoking the test or counting it as
+// an incomplete mock set is not — poll lanes collapse most cycles by design, so
+// that would fire a data-loss alarm on every async-poll recording.
+func TestResolveMappingEntries_BenignSkipDoesNotRevokeOrCount(t *testing.T) {
+	r := &Recorder{logger: zap.NewNop()}
+	var correlationMap, asyncMockIDs sync.Map
+	var droppedMockIDs droppedMockSet
+
+	correlationMap.Store("good", models.MockEntry{Name: "good"})
+	droppedMockIDs.addBenign("hook-skipped")
+
+	start := time.Now()
+	got, lostMock, uncorrelated := r.resolveMappingEntries(
+		models.TestMockMapping{TestName: "t", MockIDs: []string{"hook-skipped", "good"}},
+		&correlationMap, &asyncMockIDs, &droppedMockIDs,
+	)
+	elapsed := time.Since(start)
+
+	if lostMock {
+		t.Error("a hook-skipped mock revoked its test; the skip is normal operation, not data loss")
+	}
+	if uncorrelated != 0 {
+		t.Errorf("a hook-skipped mock was counted as a short pool (%d)", uncorrelated)
+	}
+	if len(got) != 1 || got[0].Name != "good" {
+		t.Fatalf("want only the real mock, got %+v", got)
+	}
+	if elapsed > 200*time.Millisecond {
+		t.Fatalf("resolving a hook-skipped mock took %v — the spin was not short-circuited", elapsed)
+	}
+}
+
+// TestConsumeMappings_ShortPoolCountsDistinctTests pins the unit of the
+// counter. The agent emits a test's mocks as several DELTA mappings, so a
+// per-mapping counter reports more "tests with a short pool" than the set even
+// contains — and a test that gets revoked by a later delta must drop out of the
+// count entirely, because it is deleted rather than shipped incomplete.
+func TestConsumeMappings_ShortPoolCountsDistinctTests(t *testing.T) {
+	r := &Recorder{logger: zap.NewNop(), config: &config.Config{}, mappingDb: &countingMappingDB{}}
+	var correlationMap, asyncMockIDs sync.Map
+	var droppedMockIDs droppedMockSet
+	var shortPoolByTest sync.Map
+
+	correlationMap.Store("m1", models.MockEntry{Name: "m1"})
+	correlationMap.Store("m2", models.MockEntry{Name: "m2"})
+
+	mappings := make(chan models.TestMockMapping, 2)
+	// Two DELTA mappings for the SAME test, each carrying an uncorrelated mock.
+	mappings <- models.TestMockMapping{TestName: "t-1", MockIDs: []string{"m1", "ghost-a"}}
+	mappings <- models.TestMockMapping{TestName: "t-1", MockIDs: []string{"m2", "ghost-b"}}
+	close(mappings)
+
+	require.NoError(t, r.consumeMappings(context.Background(), "set-0", mappings,
+		&correlationMap, &asyncMockIDs, &droppedMockIDs, nil, &shortPoolByTest))
+
+	tests, mocks := totalShortPool(&shortPoolByTest)
+	assert.Equal(t, 1, tests,
+		"two delta mappings for one test counted as two tests; the reported figure can then exceed the test count")
+	assert.Equal(t, 2, mocks,
+		"the mock count is per uncorrelated mock and both deltas lost one")
+}
+
+// TestConsumeMappings_RevokeRollsBackShortPoolCounts covers the interaction
+// between the two paths: a test can look merely short-pooled on one delta
+// mapping and be revoked by a later one.
+//
+// The revoke wins — the test is deleted, so it never reaches replay with an
+// incomplete mock set. Leaving the earlier increment standing inflates
+// tests-short-pool and mocks-uncorrelated, and those numbers are the entire
+// stated justification for NOT revoking on a correlation timeout. A metric
+// that double-counts the cases it excludes cannot support that argument.
+func TestConsumeMappings_RevokeRollsBackShortPoolCounts(t *testing.T) {
+	r := &Recorder{logger: zap.NewNop(), config: &config.Config{}, mappingDb: &countingMappingDB{}}
+	var correlationMap, asyncMockIDs sync.Map
+	var droppedMockIDs droppedMockSet
+	var shortPoolByTest sync.Map
+
+	correlationMap.Store("m1", models.MockEntry{Name: "m1"})
+	correlationMap.Store("m2", models.MockEntry{Name: "m2"})
+	droppedMockIDs.add("really-dropped")
+
+	mappings := make(chan models.TestMockMapping, 2)
+	// Delta 1: only a correlation timeout → looks like a short pool.
+	mappings <- models.TestMockMapping{TestName: "t-1", MockIDs: []string{"m1", "ghost"}}
+	// Delta 2: a known drop → the test is revoked and deleted.
+	mappings <- models.TestMockMapping{TestName: "t-1", MockIDs: []string{"m2", "really-dropped"}}
+	close(mappings)
+
+	var revoked []string
+	require.NoError(t, r.consumeMappings(context.Background(), "set-0", mappings,
+		&correlationMap, &asyncMockIDs, &droppedMockIDs,
+		func(n string) { revoked = append(revoked, n) },
+		&shortPoolByTest))
+
+	assert.Equal(t, []string{"t-1"}, revoked, "the known drop must revoke the test")
+	tests, mocks := totalShortPool(&shortPoolByTest)
+	assert.Equal(t, 0, tests,
+		"a REVOKED test is still counted as shipping with a short mock pool; it is deleted, not shipped")
+	assert.Equal(t, 0, mocks,
+		"the uncorrelated mock of a revoked test still inflates mocks-uncorrelated")
+}
+
+// TestDroppedMockSet_BenignSkipsDoNotStarveDataLoss guards the budget split.
+//
+// Benign entries come from the highest-frequency path in the recorder — a poll
+// lane collapses most of its cycles by design — while data-loss entries are
+// rare. On a shared cap the benign traffic fills the set within minutes and
+// add() then fails closed for real drops: their owning tests stop being
+// revoked and their mappings go back to burning the full ~500ms spin, i.e. the
+// fix for the 46-hour bug quietly stops working with only a log field to show
+// for it. Benign entries are also not reliably consumed — several classes of
+// mock reach the recorder with no mapping referencing them at all — so they
+// accumulate permanently.
+func TestDroppedMockSet_BenignSkipsDoNotStarveDataLoss(t *testing.T) {
+	var d droppedMockSet
+	for i := int64(0); i < maxLiveBenignMockIDs+500; i++ {
+		d.addBenign("benign-" + strconv.FormatInt(i, 10))
+	}
+	if !d.add("a-real-drop") {
+		t.Fatal("benign hook-skips exhausted the data-loss budget: a genuinely dropped mock is no " +
+			"longer tracked, so its owning test is never revoked and its mapping spins the full ~500ms")
+	}
+	present, lost := d.take("a-real-drop")
+	if !present || !lost {
+		t.Fatalf("the real drop did not round-trip as data loss: present=%v lost=%v", present, lost)
+	}
+	if live := d.liveBenign.Load(); live > maxLiveBenignMockIDs {
+		t.Errorf("benign entries grew to %d, past their own %d cap", live, maxLiveBenignMockIDs)
+	}
+}
+
+// totalShortPool mirrors the aggregation Start's teardown does over
+// shortPoolByTest, so these tests assert on the numbers an operator actually
+// sees rather than on the intermediate map.
+func totalShortPool(m *sync.Map) (tests int, mocks int) {
+	m.Range(func(_, v any) bool {
+		tests++
+		n, _ := v.(int64)
+		mocks += int(n)
+		return true
+	})
+	return tests, mocks
+}
+
+// TestResolveMappingEntries_SkippedMockEntryIsFreed pins the retention half of
+// the hook-skip guard.
+//
+// asyncMockIDs is never pruned, and a hook-skipped mock is the highest-frequency
+// event in a poll-heavy recording — a poll lane collapses most of its cycles by
+// design. At roughly 105 bytes per entry a single 100ms lane retains hundreds of
+// megabytes for the life of the session, which is an OOM risk in the DaemonSet
+// embedding where Start is re-entered per session. So a SKIP-marked entry is
+// released once the mapping that references it has been resolved.
+//
+// An ordinary async entry must NOT be released: it is in correlationMap, so a
+// later mapping referencing a pruned entry would resolve it and append it,
+// leaking a background egress into a test's mock pool.
+func TestResolveMappingEntries_SkippedMockEntryIsFreed(t *testing.T) {
+	r := &Recorder{logger: zap.NewNop()}
+	var correlationMap, asyncMockIDs sync.Map
+	var droppedMockIDs droppedMockSet
+
+	correlationMap.Store("good", models.MockEntry{Name: "good"})
+	// A hook-skipped mock (never persisted) and a real async mock (persisted).
+	asyncMockIDs.Store("hook-skipped", skippedMockMarker)
+	droppedMockIDs.addBenign("hook-skipped")
+	asyncMockIDs.Store("real-async", struct{}{})
+	correlationMap.Store("real-async", models.MockEntry{Name: "real-async"})
+
+	got, lostMock, uncorrelated := r.resolveMappingEntries(
+		models.TestMockMapping{TestName: "t", MockIDs: []string{"hook-skipped", "real-async", "good"}},
+		&correlationMap, &asyncMockIDs, &droppedMockIDs,
+	)
+	if lostMock || uncorrelated != 0 {
+		t.Errorf("unexpected loss: lostMock=%v uncorrelated=%d", lostMock, uncorrelated)
+	}
+	if len(got) != 1 || got[0].Name != "good" {
+		t.Fatalf("want only the sync mock, got %+v", got)
+	}
+
+	if _, still := asyncMockIDs.Load("hook-skipped"); still {
+		t.Error("a consumed hook-skip entry was retained; asyncMockIDs is never pruned, so on a " +
+			"poll-heavy recording this grows for the whole session and is an OOM risk under the DaemonSet")
+	}
+	if _, still := asyncMockIDs.Load("real-async"); !still {
+		t.Error("an ORDINARY async entry was pruned. It is in correlationMap, so a later mapping " +
+			"would now resolve and append it — leaking a background egress into a test's mock pool")
+	}
+}
+
+// TestMarkSkippedMock_TagsTheEntryAsReleasable pins the one line that decides
+// whether a hook-skipped entry can ever be freed.
+//
+// Every behavioural test still passes if this stores a plain struct{}{}: the
+// mock is still excluded from mappings, still not revoked, still not counted.
+// The only difference is that releaseSkippedMock no longer recognises it and
+// the entry is retained for the life of the session — a silent return of the
+// OOM risk. So assert the stored value directly.
+func TestMarkSkippedMock_TagsTheEntryAsReleasable(t *testing.T) {
+	var asyncMockIDs sync.Map
+	var dropped droppedMockSet
+
+	markSkippedMock(&asyncMockIDs, &dropped, "hook-skipped")
+
+	v, ok := asyncMockIDs.Load("hook-skipped")
+	if !ok {
+		t.Fatal("a hook-skipped mock was not marked at all; it would be per-test mapped and could " +
+			"revoke a healthy test")
+	}
+	if _, releasable := v.(skippedMock); !releasable {
+		t.Errorf("the entry is marked but NOT as releasable (%T). releaseSkippedMock will skip it, "+
+			"so it is retained for the whole session — the OOM risk returns with every test green", v)
+	}
+	if present, lost := dropped.take("hook-skipped"); !present || lost {
+		t.Errorf("the skip was not registered as a BENIGN drop (present=%v lost=%v); it would either "+
+			"burn the ~500ms correlation spin or, if lost, revoke a healthy test", present, lost)
 	}
 }

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"time"
 
@@ -106,13 +107,23 @@ func mergeMockEntries(existing, incoming []models.MockEntry) []models.MockEntry 
 // no_mocks. Detaching here rather than relying on the caller keeps that
 // guarantee local to the loop that depends on it — see the persistCtx note in
 // Start for the same requirement on the test-case and mock stores.
-func (r *Recorder) consumeMappings(ctx context.Context, testSetID string, mappings <-chan models.TestMockMapping, correlationMap, asyncMockIDs *sync.Map) error {
+// shortPoolByTest is required, not optional: it is how the one data-loss path
+// this function deliberately does not revoke stays visible. It maps a test name
+// to the number of its mocks that never correlated. Totals are computed at
+// teardown rather than accumulated here, because a test can also be revoked by
+// the AGENT (a RevokedTests control frame this function never sees) and a
+// revoked test is deleted, not shipped with a short pool.
+func (r *Recorder) consumeMappings(ctx context.Context, testSetID string, mappings <-chan models.TestMockMapping, correlationMap, asyncMockIDs *sync.Map, droppedMockIDs *droppedMockSet, revokeTest func(string), shortPoolByTest *sync.Map) error {
 	persistCtx := context.WithoutCancel(ctx)
 
 	// pending batches mappings so the file is rewritten once per batch instead of
 	// once per test. flushMu guards it because the ticker below flushes too.
 	pending := make(map[string][]models.MockEntry, mappingFlushBatch)
 	var flushMu sync.Mutex
+
+	// Both are touched only by this loop (the ticker goroutine below flushes
+	// `pending` under flushMu and never reads these), so plain maps are safe.
+	revokedHere := map[string]struct{}{}
 
 	flush := func() {
 		flushMu.Lock()
@@ -158,7 +169,42 @@ func (r *Recorder) consumeMappings(ctx context.Context, testSetID string, mappin
 	}()
 
 	for mapping := range mappings {
-		realMockEntries := r.resolveMappingEntries(mapping, correlationMap, asyncMockIDs)
+		realMockEntries, lostMock, uncorrelated := r.resolveMappingEntries(mapping, correlationMap, asyncMockIDs, droppedMockIDs)
+
+		// Persisted anyway (see resolveMappingEntries), so record that this test
+		// reaches replay with an incomplete mock set.
+		//
+		// Counted per DISTINCT TEST, not per mapping: the agent emits a test's
+		// mocks as several delta mappings (see the merge note below), so a
+		// per-mapping counter would report more "tests" than the set contains.
+		// A revoked test is excluded — it is deleted at finalize, so it never
+		// reaches replay with a short pool at all.
+		if uncorrelated > 0 && !lostMock {
+			if _, revoked := revokedHere[mapping.TestName]; !revoked {
+				prev, _ := shortPoolByTest.Load(mapping.TestName)
+				n, _ := prev.(int64)
+				shortPoolByTest.Store(mapping.TestName, n+int64(uncorrelated))
+			}
+		}
+
+		// This test owned at least one mock we could not persist. Replaying it
+		// with a short pool produces a guaranteed failure that looks like a
+		// product regression, so revoke it the same way the agent's own
+		// capacity-drop path does (RevokedTests) and let finalize delete it.
+		if lostMock {
+			revokedHere[mapping.TestName] = struct{}{}
+			// Drop whatever an EARLIER delta recorded for this test. The revoke
+			// can arrive after a delta that saw only a correlation timeout, and a
+			// deleted test never reaches replay with a short pool at all —
+			// leaving the entry in place inflates the very metric whose
+			// credibility is the reason the timeout path is not revoked.
+			// (Teardown applies the same exclusion for the agent's own revokes,
+			// keyed on tests it actually managed to DELETE.)
+			shortPoolByTest.Delete(mapping.TestName)
+			if revokeTest != nil {
+				revokeTest(mapping.TestName)
+			}
+		}
 
 		if len(realMockEntries) == 0 {
 			continue
@@ -242,6 +288,141 @@ func (r *Recorder) SetRecordHooks(hooks RecordHooks) {
 	}
 }
 
+// maxLiveDroppedMockIDs bounds droppedMockSet. Every dropped mock is meant to
+// be consumed by the one mapping that references it, but a mock nothing ever
+// maps — a background egress whose owning test never completes — has no
+// consumer, so an unbounded set would grow for the life of the recording.
+//
+// Past the cap we stop tracking, and BOTH benefits lapse for further drops:
+// their owning tests are no longer revoked, and their mappings go back to
+// burning the full ~500ms correlation spin. That is the deliberate trade — a
+// recording with 10k dropped mocks is systematically broken and the teardown
+// Warn plus the mocks-dropped telemetry still report the true scale — but it is
+// not free, so the cap is set well above any plausible healthy session.
+const maxLiveDroppedMockIDs = 10000
+
+// maxLiveBenignMockIDs bounds the BENIGN half of droppedMockSet separately, and
+// that separation is the point. Benign entries come from the highest-frequency
+// path in the recorder — a poll lane collapses most of its cycles by design —
+// while data-loss entries are rare. On a shared budget the benign traffic would
+// fill the set within minutes and `add` would then fail closed for real drops,
+// silently disabling the revoke this whole change exists to provide. Benign
+// entries are also not reliably consumed: several classes of mock reach the
+// recorder with no mapping referencing them at all, so nothing ever takes them.
+// Package-level var, not a const, only so a test can shrink it to prove that
+// the correctness guarantee (asyncMockIDs) holds when this best-effort cache
+// declines an entry. Never reassigned in production code.
+var maxLiveBenignMockIDs int64 = 10000
+
+// droppedMockSet is the set of mock tempIDs that will never reach
+// correlationMap, handed to the mapping consumer so it can skip the correlation
+// spin for them instead of burning ~500ms each.
+//
+// Entries carry whether the absence is DATA LOSS or intentional, because the
+// two demand opposite handling. A mock we failed to persist means its owning
+// test must be revoked. A mock we chose not to persist — a hook-collapsed async
+// poll cycle — is normal operation: revoking there would delete healthy tests
+// and counting it would fire a data-loss alarm on every async-poll recording.
+//
+// take() removes the ID as it reports it: entries are consumed exactly once,
+// which is what keeps the set from growing across a multi-day recording.
+type droppedMockSet struct {
+	ids sync.Map // map[string]bool — value: true = data loss, false = intentional
+	// Separate budgets: see maxLiveBenignMockIDs.
+	liveLost   atomic.Int64
+	liveBenign atomic.Int64
+}
+
+func (d *droppedMockSet) store(tempID string, lost bool) bool {
+	counter, limit := &d.liveBenign, maxLiveBenignMockIDs
+	if lost {
+		counter, limit = &d.liveLost, int64(maxLiveDroppedMockIDs)
+	}
+	if counter.Load() >= limit {
+		return false
+	}
+	if _, loaded := d.ids.LoadOrStore(tempID, lost); !loaded {
+		counter.Add(1)
+	}
+	return true
+}
+
+// add records a mock the recorder FAILED to persist. It reports whether the ID
+// was tracked; false means the set is at capacity and the owning test will NOT
+// be revoked.
+func (d *droppedMockSet) add(tempID string) bool { return d.store(tempID, true) }
+
+// addBenign records a mock the recorder intentionally did not persist. The
+// owning test is left alone — only the correlation spin is short-circuited.
+func (d *droppedMockSet) addBenign(tempID string) bool { return d.store(tempID, false) }
+
+// take reports whether tempID is in the set and, if so, whether its absence is
+// data loss. It removes the entry.
+func (d *droppedMockSet) take(tempID string) (present, lost bool) {
+	v, ok := d.ids.LoadAndDelete(tempID)
+	if !ok {
+		return false, false
+	}
+	if v.(bool) {
+		d.liveLost.Add(-1)
+	} else {
+		d.liveBenign.Add(-1)
+	}
+	return true, v.(bool)
+}
+
+// skippedMockMarker tags an asyncMockIDs entry that exists ONLY because a
+// RecordHook asked us not to persist the mock (a collapsed async poll cycle).
+// Ordinary async-egress mocks are stored as struct{}{}.
+//
+// The distinction exists so the entry can be freed. asyncMockIDs is otherwise
+// never pruned, and skips are the highest-frequency event in a poll-heavy
+// recording — at ~105 bytes per entry, a single 100ms lane would retain
+// hundreds of MB for the life of the session, which is an OOM risk in the
+// DaemonSet embedding where Start is re-entered per session.
+//
+// The release is best-effort, not a bound: it happens when a mapping consumes
+// the tempID, so a run with mappings disabled (--disable-mapping), or a skipped
+// mock no mapping ever references, retains its entry for the whole session.
+// Those runs are back to the pre-marker growth; the marker helps the common
+// case, it does not cap the worst one.
+type skippedMock struct{}
+
+var skippedMockMarker = skippedMock{}
+
+// markSkippedMock records a mock a RecordHook asked us not to persist, in both
+// places the mapping consumer looks.
+//
+// Extracted so the marker choice is directly assertable. It is the load-bearing
+// line: storing a plain struct{}{} here instead of skippedMockMarker still
+// satisfies every behavioural test — the entry is simply never released again,
+// and the leak returns silently.
+func markSkippedMock(asyncMockIDs *sync.Map, dropped *droppedMockSet, tempID string) {
+	// CORRECTNESS, unconditional: Skip means "never persisted", so this tempID
+	// must never reach a per-test mapping and must never read as loss. It cannot
+	// be gated on mock.IsAsync() — AsyncRecorder sets Skip and returns BEFORE
+	// assigning Spec.Async, so a collapsed cycle reports IsAsync()==false and the
+	// guard would be a no-op.
+	asyncMockIDs.Store(tempID, skippedMockMarker)
+	// SPEED, best-effort: short-circuits the ~500ms correlation spin. Capped, so
+	// it eventually declines entries; that costs latency, never correctness.
+	dropped.addBenign(tempID)
+}
+
+// releaseSkippedMock frees a SKIP-marked asyncMockIDs entry once a mapping has
+// consumed it. Ordinary async entries are deliberately left in place.
+//
+// The asymmetry is not fussiness. A real async mock IS in correlationMap, so if
+// a later mapping referenced a pruned entry it would resolve and be appended —
+// leaking a background egress into a test's mock pool. A skipped mock was never
+// persisted, so a later mapping referencing a pruned entry simply fails to
+// correlate: no revoke, no leak, at worst one spin and one counter tick.
+func releaseSkippedMock(asyncMockIDs *sync.Map, tempID string, v any) {
+	if _, skipped := v.(skippedMock); skipped {
+		asyncMockIDs.Delete(tempID)
+	}
+}
+
 // resolveMappingEntries correlates a test's mapping tempIDs to the persisted
 // MockEntries in correlationMap, dropping each consumed tempID as it goes. It
 // EXCLUDES async-egress mocks (those in asyncMockIDs): they are served at replay
@@ -251,11 +432,16 @@ func (r *Recorder) SetRecordHooks(hooks RecordHooks) {
 // purely by timestamp and has no async awareness). The Mock loop stores the
 // async marker before it publishes the tempID to correlationMap, so a resolved
 // tempID always has its async status already decided.
-func (r *Recorder) resolveMappingEntries(mapping models.TestMockMapping, correlationMap, asyncMockIDs *sync.Map) []models.MockEntry {
+func (r *Recorder) resolveMappingEntries(mapping models.TestMockMapping, correlationMap, asyncMockIDs *sync.Map, droppedMockIDs *droppedMockSet) ([]models.MockEntry, bool, int) {
 	var realMockEntries []models.MockEntry
+	droppedOwner := false
+	uncorrelated := 0
 	for _, tempID := range mapping.MockIDs {
+		// Async-egress mocks are deliberately excluded from per-test mappings
 		var realEntry models.MockEntry
 		found := false
+		dropped := false
+		lostMock := false
 		// Simple retry loop (fast spin) to wait for the Mock Loop.
 		for i := 0; i < 50; i++ { // Wait up to ~500ms
 			if val, ok := correlationMap.Load(tempID); ok {
@@ -263,9 +449,72 @@ func (r *Recorder) resolveMappingEntries(mapping models.TestMockMapping, correla
 				found = true
 				break
 			}
+			// A mock we gave up persisting will NEVER reach correlationMap, so
+			// without this the spin burns its full ~500ms per dropped mock —
+			// serialized in the single mapping consumer, which the agent cannot
+			// outrun: it DROPS mappings it cannot hand over, so the stall would
+			// corrupt unrelated healthy tests.
+			//
+			// The check MUST be inside the spin. Mocks and mappings arrive on
+			// two independent channels drained by two independent goroutines —
+			// that race is the whole reason the spin exists — so a mapping
+			// routinely arrives BEFORE its mock is even attempted. Checking
+			// once up front loses to that ordering every time: the test is
+			// silently persisted with a short mock pool AND the full stall is
+			// still paid.
+			if present, lost := droppedMockIDs.take(tempID); present {
+				// A benign skip (hook-collapsed poll cycle) short-circuits the
+				// spin but is NOT loss: it must not revoke and must not be
+				// counted as a short pool.
+				dropped = true
+				lostMock = lost
+				break
+			}
 			time.Sleep(10 * time.Millisecond)
 		}
+		if dropped {
+			// Async status is decided HERE, not earlier. The mock loop stores
+			// the async marker before it attempts the insert, so by the time a
+			// drop is recorded the marker is already published — but a mapping
+			// routinely reaches this loop before either happens, so a check made
+			// up front would simply miss. Getting this wrong DELETES healthy
+			// tests: async-egress mocks are excluded from per-test mappings by
+			// design (see the doc above), so a dropped one is never a short pool
+			// for anybody, yet without this it would set droppedOwner and revoke
+			// the test that merely overlapped it in time.
+			if v, isAsync := asyncMockIDs.Load(tempID); isAsync {
+				releaseSkippedMock(asyncMockIDs, tempID, v)
+				continue
+			}
+			if lostMock {
+				droppedOwner = true
+			}
+			continue
+		}
 		if !found {
+			// Deliberately NOT treated as a drop. A drop is a fact — we know the
+			// mock was abandoned. A correlation timeout is an inference: the mock
+			// may well have been persisted and simply not observed inside 500ms,
+			// and revoking on that guess would convert a latency event into
+			// deterministic deletion of a customer's recorded test. So the test
+			// is still persisted, with a short pool, exactly as before.
+			//
+			// It is counted, though. Persisting a test whose mock set is
+			// incomplete is real data loss whatever the cause, and it was
+			// previously visible only as a per-occurrence log line — no total, so
+			// nobody could say how often it fires. The count is reported at
+			// teardown and in telemetry so the frequency is measurable BEFORE
+			// anyone argues about changing the semantics.
+			// Third and last settle point. If the async marker landed at any
+			// point during the spin, this tempID's absence is by design and must
+			// not be reported as an incomplete mock set — async-egress mocks are
+			// never part of a per-test mapping. Only a tempID we still cannot
+			// classify after the full wait is real, unexplained loss.
+			if v, isAsync := asyncMockIDs.Load(tempID); isAsync {
+				releaseSkippedMock(asyncMockIDs, tempID, v)
+				continue
+			}
+			uncorrelated++
 			r.logger.Error("Failed to correlate mock mapping",
 				zap.String("test", mapping.TestName),
 				zap.String("tempMockID", tempID),
@@ -273,12 +522,19 @@ func (r *Recorder) resolveMappingEntries(mapping models.TestMockMapping, correla
 			continue
 		}
 		correlationMap.Delete(tempID)
-		if _, isAsync := asyncMockIDs.Load(tempID); isAsync {
+		// The other settle point. The doc's invariant — the mock loop stores the
+		// async marker before it publishes the tempID to correlationMap — makes
+		// this the moment async status is knowable for a RESOLVED mock. Checking
+		// only before the spin would let an async mock whose marker landed mid-
+		// spin resolve normally and leak into the per-test mapping, which is
+		// exactly what this exclusion exists to prevent.
+		if v, isAsync := asyncMockIDs.Load(tempID); isAsync {
+			releaseSkippedMock(asyncMockIDs, tempID, v)
 			continue
 		}
 		realMockEntries = append(realMockEntries, realEntry)
 	}
-	return realMockEntries
+	return realMockEntries, droppedOwner, uncorrelated
 }
 
 // GetRecordHooks returns the current hooks.
@@ -391,6 +647,22 @@ func (r *Recorder) Start(ctx context.Context) error {
 	var err error
 	var testCount = 0
 	var mockCountMap = make(map[string]int)
+	// droppedMockCount / droppedMockKinds are the missing half of mockCountMap,
+	// which only ever counts successes. A mock whose own payload cannot be
+	// encoded is now skipped rather than fatal (see the ErrMockEncode branch in
+	// the consumer below), and a skipped mock must never be silent — these feed
+	// the teardown log and the RecordedTestSuite telemetry.
+	var droppedMockCount = 0
+	// shortPoolByTest maps a test name to how many of its mocks never
+	// correlated, i.e. tests persisted with an INCOMPLETE mock set (see the
+	// !found branch in resolveMappingEntries). Unlike a dropped mock this does
+	// not revoke the test, so without a total the loss shows up only as
+	// scattered per-occurrence log lines. Kept per-test rather than
+	// pre-aggregated so the teardown block can subtract EVERY revoke path — the
+	// agent's RevokedTests control frame revokes tests consumeMappings never
+	// sees, and a revoked test is deleted rather than shipped short.
+	var shortPoolByTest sync.Map
+	var droppedMockKinds = make(map[string]int)
 	// mockCountMap is written by the mock-consumer goroutine and read at
 	// teardown for telemetry. Guard both with a mutex so that if teardown
 	// ever runs while the consumer is still draining (e.g. a force-shutdown),
@@ -482,6 +754,13 @@ func (r *Recorder) Start(ctx context.Context) error {
 		}
 		revokedMu.Unlock()
 
+		// Names whose delete actually SUCCEEDED. A revoke is not always applied:
+		// DeleteTests is reached by runtime assertion because it is deliberately
+		// not on the record TestDB interface, and an individual delete can fail and
+		// warn. A test that stays in the set IS shipped with a short mock pool, so
+		// only a genuinely deleted one may be excluded from the totals below.
+		deletedSet := map[string]struct{}{}
+
 		var toDelete []string
 		insertedMu.Lock()
 		for _, n := range revokedSnap {
@@ -504,6 +783,7 @@ func (r *Recorder) Start(ctx context.Context) error {
 							zap.String("testSetID", newTestSetID), zap.String("testCase", n), zap.Error(err))
 						continue
 					}
+					deletedSet[n] = struct{}{}
 					deleted++
 				}
 				if deleted > 0 {
@@ -529,10 +809,65 @@ func (r *Recorder) Start(ctx context.Context) error {
 			for k, v := range mockCountMap {
 				mockCountSnapshot[k] = v
 			}
+			// Snapshot the drop counters under the same lock that guards them.
+			droppedSnapshot := droppedMockCount
+			droppedKindSnapshot := make(map[string]int, len(droppedMockKinds))
+			for k, v := range droppedMockKinds {
+				droppedKindSnapshot[k] = v
+			}
 			mockCountMapMu.Unlock()
-			r.telemetry.RecordedTestSuite(newTestSetID, testCount, mockCountSnapshot, map[string]interface{}{
-				"host-domains": domainSet.ToSlice(),
+			// Say it on the way out too, so an operator sees the holes even with
+			// telemetry disabled.
+			// Totalled here, not accumulated as we went, so every revoke path is
+			// accounted for: revokedNames holds both consumeMappings' own revokes
+			// and the agent's RevokedTests frames. Subtract on DELETED, not
+			// merely revoked — a revoke that could not be applied leaves the test
+			// in the set, still short, so it must stay in the count.
+			shortPoolTests, shortPoolMocks := 0, 0
+			shortPoolByTest.Range(func(k, v any) bool {
+				name, _ := k.(string)
+				if _, gone := deletedSet[name]; gone {
+					return true
+				}
+				shortPoolTests++
+				n, _ := v.(int64)
+				shortPoolMocks += int(n)
+				return true
 			})
+			if shortPoolTests > 0 {
+				r.logger.Warn("recording finished with test cases whose mock set is INCOMPLETE: some mocks never correlated to their mapping, and unlike a dropped mock this does not revoke the test — these will fail at replay",
+					zap.Int("testsWithShortMockPool", shortPoolTests),
+					zap.Int("mocksUncorrelated", shortPoolMocks),
+					zap.String("testSetID", newTestSetID),
+					zap.String("next_step", "ensure the mapping store is enabled and reduce recording parallelism; re-record the test set if this count is non-trivial"))
+			}
+			if droppedSnapshot > 0 {
+				r.logger.Warn("recording finished with mocks dropped; the tests that owned them were revoked rather than recorded with a short mock pool",
+					zap.Int("mocksDropped", droppedSnapshot),
+					zap.Any("byKind", droppedKindSnapshot),
+					zap.String("testSetID", newTestSetID),
+					zap.String("next_step", "check byKind: an unencodable payload is a parser/encoder bug worth reporting; drops during shutdown are usually I/O and re-recording recovers them"))
+			}
+			suiteMeta := map[string]interface{}{
+				"host-domains": domainSet.ToSlice(),
+			}
+			// Report skipped mocks alongside the recorded ones. mockCountSnapshot
+			// counts only successes, so without this a recording with holes is
+			// indistinguishable from a clean one in telemetry.
+			if droppedSnapshot > 0 {
+				suiteMeta["mocks-dropped"] = droppedSnapshot
+				suiteMeta["mocks-dropped-by-kind"] = droppedKindSnapshot
+			}
+			// Gated separately from the drops. The motivating case for these two
+			// is a correlation timeout under parallelism with a perfectly
+			// healthy encoder — zero drops — which is exactly the recording the
+			// drop gate excludes, so folding them in there would leave the
+			// frequency invisible in the one case they were added to measure.
+			if shortPoolTests > 0 {
+				suiteMeta["tests-short-pool"] = shortPoolTests
+				suiteMeta["mocks-uncorrelated"] = shortPoolMocks
+			}
+			r.telemetry.RecordedTestSuite(newTestSetID, testCount, mockCountSnapshot, suiteMeta)
 			for _, c := range mockCountSnapshot {
 				totalMocks += c
 			}
@@ -566,8 +901,14 @@ func (r *Recorder) Start(ctx context.Context) error {
 	// select below that does not depend on a close, and the size-1 buffer
 	// absorbs the lone send (the two sender branches are mutually exclusive),
 	// so leaving the channel open to be GC'd is correct and race-free.
-	defer close(insertTestErrChan)
-	defer close(insertMockErrChan)
+	// insertTestErrChan / insertMockErrChan are NOT closed either, for exactly
+	// the reason spelled out for appErrChan above. Their producer is the
+	// consumer goroutine spawned below, which can still be mid-send when Start
+	// returns during teardown; closing here raced that send and panicked with
+	// "send on closed channel", taking down the whole control plane in the
+	// DaemonSet embedding. The sole consumer is a single receive in the select
+	// below that does not depend on a close, and the size-10 buffers absorb any
+	// in-flight send, so leaving them open to be GC'd is correct and race-free.
 
 	newTestSetID, err = r.GetNextTestSetID(ctx)
 	if err != nil {
@@ -652,6 +993,11 @@ func (r *Recorder) Start(ctx context.Context) error {
 	// asyncMockIDs holds tempIDs of async mocks (Spec.Async set); resolveMappingEntries uses it
 	// to keep async-egress mocks out of the per-test mappings (see its doc).
 	var asyncMockIDs sync.Map
+	// droppedMockIDs holds tempIDs of mocks the recorder gave up persisting.
+	// The mapping consumer checks it so it never burns its ~500ms correlation
+	// spin on a mock that will never arrive, and so it can revoke the owning
+	// test rather than replay it with a short mock pool.
+	var droppedMockIDs droppedMockSet
 	// fetching test cases and mocks from the application and inserting them into the database
 	frames, err := r.GetTestAndMockChans(reqCtx)
 	if err != nil {
@@ -723,18 +1069,29 @@ func (r *Recorder) Start(ctx context.Context) error {
 			err := r.testDB.InsertTestCase(persistCtx, testCase, newTestSetID, true)
 			if err != nil {
 				if ctx.Err() != nil {
-					// Once shutdown has begun nothing reads insertTestErrChan —
-					// Start's select has returned and the channel is closed on
-					// Start's way out — so reporting through it is unsafe. Log
-					// instead of dropping the error on the floor: with persistCtx
-					// the write no longer fails merely because we are shutting
-					// down, so an error here is real and the operator needs it.
+					// Once shutdown has begun nothing reads insertTestErrChan:
+					// Start's select has already returned, and this loop keeps
+					// draining for the whole app-drain window. Log instead of
+					// dropping the error on the floor: with persistCtx the write
+					// no longer fails merely because we are shutting down, so an
+					// error here is real and the operator needs it.
 					utils.LogError(r.logger, err, "failed to record test case during shutdown",
 						zap.String("testCaseName", testCase.Name),
 						zap.String("testSetID", newTestSetID))
 					continue
 				}
-				insertTestErrChan <- err
+				// Non-blocking for the same reason as the mock loop's sibling
+				// send below: on a disk-full EVERY insert errors here, and this
+				// loop keeps draining long after Start's one-shot select has
+				// taken the first error. A blocking send would park forever once
+				// the buffer filled, wedging this goroutine and the forwarder
+				// feeding frames.Incoming, timing out DrainErrGroup and leaking
+				// both past teardown. The buffer guarantees the first error —
+				// the only one acted on — still lands.
+				select {
+				case insertTestErrChan <- err:
+				default:
+				}
 			} else {
 				// testCount and insertedNames are both TC-insert state; write
 				// them under one insertedMu section so the finalize revoke block
@@ -790,6 +1147,24 @@ func (r *Recorder) Start(ctx context.Context) error {
 			if mockCtx.Skip {
 				// A hook asked to drop this mock (collapsed async poll no-change
 				// cycle). Do not persist, map, or correlate it.
+				//
+				// The agent does not know we skipped it, so its tempID is still
+				// in the mapping it streams, and two separate things must be
+				// true for that not to hurt:
+				//
+				//  1. asyncMockIDs — CORRECTNESS, and unconditional. Skip means
+				//     "never persisted", so this tempID must never appear in a
+				//     per-test mapping and must never be read as loss. Note it
+				//     cannot be gated on mock.IsAsync(): AsyncRecorder sets
+				//     info.Skip and returns BEFORE it assigns Spec.Async, so a
+				//     collapsed cycle reports IsAsync()==false. Gating on it
+				//     would make this whole guard a no-op.
+				//  2. droppedMockIDs — SPEED, and best-effort. It short-circuits
+				//     the ~500ms correlation spin, but it is capped, so on a very
+				//     long poll-heavy recording it eventually declines entries.
+				//     That costs latency, never correctness, because (1) is not
+				//     capped.
+				markSkippedMock(&asyncMockIDs, &droppedMockIDs, tempID)
 				continue
 			}
 			// The AsyncRecorder hook sets Spec.Async in BeforeMockInsert above;
@@ -804,13 +1179,87 @@ func (r *Recorder) Start(ctx context.Context) error {
 					// is no longer safe to report through once teardown has begun. A
 					// skipped mock also skips its correlationMap entry below, which
 					// strands the mapping that references it — so this must be loud.
+					//
+					// Bookkeep EVERY error class here, not just ErrMockEncode: past
+					// this point the mock is lost whatever the cause, and the
+					// consequences are identical — the owning test would otherwise be
+					// persisted with a short pool after its mapping burned the full
+					// correlation spin, invisible to both the teardown Warn and the
+					// telemetry. Nothing is being made non-fatal: teardown is already
+					// under way.
+					mockCountMapMu.Lock()
+					droppedMockCount++
+					droppedMockKinds[mock.GetKind()]++
+					mockCountMapMu.Unlock()
+					droppedMockIDs.add(tempID)
 					utils.LogError(r.logger, err, "failed to record mock during shutdown",
 						zap.String("mockName", mock.Name),
 						zap.String("mockKind", mock.GetKind()),
 						zap.String("testSetID", newTestSetID))
 					continue
 				}
-				insertMockErrChan <- err
+				if errors.Is(err, models.ErrMockEncode) {
+					// THIS mock's payload cannot be encoded — an unsupported
+					// kind or a value the encoder cannot represent. Unlike a
+					// disk-full or storage-gone error it says nothing about the
+					// next mock, so killing the session throws away everything
+					// recorded so far: one gzip response body ended a 46-hour
+					// production recording exactly this way. Drop the one mock
+					// and keep recording.
+					mockCountMapMu.Lock()
+					droppedMockCount++
+					droppedMockKinds[mock.GetKind()]++
+					dropped := droppedMockCount
+					mockCountMapMu.Unlock()
+					// Tell the mapping consumer so it revokes the owning test
+					// instead of spinning on an ID that will never arrive.
+					tracked := droppedMockIDs.add(tempID)
+					// Loud on the first, then sampled: a recording that quietly
+					// grows holes is worse than one that dies, so this must stay
+					// visible without drowning the log on a systematic failure.
+					if dropped == 1 || dropped%100 == 0 {
+						utils.LogError(r.logger, err, "dropping ONE unencodable mock and CONTINUING to record; the test that owns it is revoked, not recorded short",
+							zap.String("mockName", mock.Name),
+							zap.String("mockKind", mock.GetKind()),
+							zap.String("testSetID", newTestSetID),
+							zap.Int("mocksDroppedSoFar", dropped),
+							zap.Bool("ownerRevocable", tracked))
+					}
+					continue
+				}
+				// Environmental (I/O, storage gone): every later mock fails too,
+				// so stopping is still correct — but stopping is not instant.
+				// Start's select takes the first error and teardown then runs
+				// for the whole app-drain window with this loop still draining,
+				// so errors 2..N land here too. Bookkeep them exactly like the
+				// shutdown branch: the mock is lost whatever the cause, and
+				// without this the teardown Warn and the mocks-dropped telemetry
+				// undercount while every owning test is persisted with a short
+				// pool instead of revoked.
+				mockCountMapMu.Lock()
+				droppedMockCount++
+				droppedMockKinds[mock.GetKind()]++
+				dropped := droppedMockCount
+				mockCountMapMu.Unlock()
+				droppedMockIDs.add(tempID)
+				if dropped == 1 || dropped%100 == 0 {
+					utils.LogError(r.logger, err, "failed to record mock (environmental); stopping the session",
+						zap.String("mockName", mock.Name),
+						zap.String("mockKind", mock.GetKind()),
+						zap.String("testSetID", newTestSetID),
+						zap.Int("mocksDroppedSoFar", dropped))
+				}
+				// The send must not block: once the buffer filled, a blocking
+				// send would wedge this goroutine forever — which in turn wedges
+				// the forwarder feeding frames.Outgoing, times out both
+				// DrainErrGroup budgets, and leaks the pair past teardown (it
+				// matters in the DaemonSet embedding, where Start is re-entered
+				// per session). Only the FIRST error is acted on anyway; the
+				// buffer guarantees it lands.
+				select {
+				case insertMockErrChan <- err:
+				default:
+				}
 			} else {
 				if hookErr := r.hooks.AfterMockInsert(ctx, &MockContext{
 					Mock: mock, TestSetID: newTestSetID,
@@ -840,7 +1289,15 @@ func (r *Recorder) Start(ctx context.Context) error {
 	})
 
 	errGrp.Go(func() error {
-		return r.consumeMappings(ctx, newTestSetID, frames.Mappings, &correlationMap, &asyncMockIDs)
+		return r.consumeMappings(ctx, newTestSetID, frames.Mappings, &correlationMap, &asyncMockIDs, &droppedMockIDs,
+			func(testName string) {
+				// Reuse the deferred-orphan revoke path the agent's own
+				// capacity-drop uses: finalize deletes these test cases instead
+				// of letting them reach replay without their mocks.
+				revokedMu.Lock()
+				revokedNames[testName] = struct{}{}
+				revokedMu.Unlock()
+			}, &shortPoolByTest)
 	})
 
 	if r.config.CommandType != string(utils.DockerCompose) {
@@ -915,8 +1372,22 @@ func (r *Recorder) GetTestAndMockChans(ctx context.Context) (FrameChan, error) {
 	}
 
 	// Create channels to receive incoming and outgoing data
-	incomingChan := make(chan *models.TestCase)
-	outgoingChan := make(chan *models.Mock)
+	// One slot each, and it is load-bearing rather than a tuning knob. Both
+	// forwarders below hand over an item they have ALREADY taken from the agent
+	// when ctx is cancelled, so that the tail is not silently dropped — and that
+	// send has to complete even when nothing is consuming.
+	//
+	// Nothing consuming is a real state, not a hypothetical: Start can return at
+	// its post-setup `ctx.Err()` gate before it ever spawns the consumers, while
+	// these forwarders run on reqCtx (WithoutCancel) and keep pulling from the
+	// agent. Teardown's reqCtxCancel() then drives both into the handover, and on
+	// an unbuffered channel they would park forever — a 30s DrainErrGroup timeout
+	// on every affected Ctrl+C plus a goroutine leaked for the process lifetime,
+	// which compounds in the DaemonSet embedding where Start is re-entered per
+	// session. The handover fires at most once per forwarder, so one slot is
+	// exactly sufficient.
+	incomingChan := make(chan *models.TestCase, 1)
+	outgoingChan := make(chan *models.Mock, 1)
 	mappingChan := make(chan models.TestMockMapping)
 
 	g, ok := ctx.Value(models.ErrGroupKey).(*errgroup.Group)
@@ -947,9 +1418,23 @@ func (r *Recorder) GetTestAndMockChans(ctx context.Context) (FrameChan, error) {
 				if !ok {
 					return nil
 				}
-				// forward but remain cancelable
+				// This test case has ALREADY been taken from the agent — the
+				// agent considers it delivered and will not re-send it. Returning
+				// here on a cancelled ctx therefore drops it silently, with no
+				// log and no counter, while its mocks and its mapping are still
+				// persisted: the set ships with orphaned mocks and a mappings.yaml
+				// entry for a test that does not exist. Since SIGINT lands while
+				// the agent is still handing over the tail, that is exactly the
+				// window the tail is in.
+				//
+				// Hand it over anyway and then stop, mirroring the outgoing
+				// forwarder below. The consumer writes on persistCtx (detached
+				// from ctx) precisely so a shutdown-time hand-off still reaches
+				// disk, and incomingChan carries a slot for exactly this send, so
+				// it completes even if Start returned before spawning a consumer.
 				select {
 				case <-ctx.Done():
+					incomingChan <- tc
 					return ctx.Err()
 				case incomingChan <- tc:
 				}

--- a/pkg/service/record/record_test.go
+++ b/pkg/service/record/record_test.go
@@ -2,6 +2,7 @@ package record
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"sync"
@@ -191,7 +192,7 @@ func TestConsumeMappings_PersistsTailAfterShutdown(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	require.NoError(t, r.consumeMappings(ctx, testSetID, mappings, &correlationMap, &asyncMockIDs))
+	require.NoError(t, r.consumeMappings(ctx, testSetID, mappings, &correlationMap, &asyncMockIDs, &droppedMockSet{}, nil, &sync.Map{}))
 
 	require.FileExists(t, filepath.Join(dir, testSetID, "mappings.yaml"),
 		"no mappings.yaml on disk: every mapping written during shutdown was discarded "+
@@ -235,7 +236,7 @@ func TestConsumeMappings_UpsertsIntoExistingFile(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	require.NoError(t, r.consumeMappings(ctx, testSetID, mappings, &correlationMap, &asyncMockIDs))
+	require.NoError(t, r.consumeMappings(ctx, testSetID, mappings, &correlationMap, &asyncMockIDs, &droppedMockSet{}, nil, &sync.Map{}))
 
 	saved, _, err := mapdb.New(zap.NewNop(), dir, "mappings").Get(context.Background(), testSetID)
 	require.NoError(t, err)
@@ -293,7 +294,7 @@ func TestConsumeMappings_BatchesWrites(t *testing.T) {
 	}
 	close(mappings)
 
-	require.NoError(t, r.consumeMappings(context.Background(), "test-set-0", mappings, &correlationMap, &asyncMockIDs))
+	require.NoError(t, r.consumeMappings(context.Background(), "test-set-0", mappings, &correlationMap, &asyncMockIDs, &droppedMockSet{}, nil, &sync.Map{}))
 
 	db.mu.Lock()
 	writes, saved := db.writes, len(db.byTest)
@@ -335,7 +336,7 @@ func TestConsumeMappings_LateMockDoesNotWipeEarlierOnes(t *testing.T) {
 	mappings <- models.TestMockMapping{TestName: test, MockIDs: []string{"temp-c"}}
 	close(mappings)
 
-	require.NoError(t, r.consumeMappings(context.Background(), testSetID, mappings, &correlationMap, &asyncMockIDs))
+	require.NoError(t, r.consumeMappings(context.Background(), testSetID, mappings, &correlationMap, &asyncMockIDs, &droppedMockSet{}, nil, &sync.Map{}))
 
 	saved, _, err := mapdb.New(zap.NewNop(), dir, "mappings").Get(context.Background(), testSetID)
 	require.NoError(t, err)
@@ -372,7 +373,7 @@ func TestConsumeMappings_FlushesPartialBatchOnTicker(t *testing.T) {
 		}
 	}()
 
-	require.NoError(t, r.consumeMappings(context.Background(), "test-set-0", mappings, &correlationMap, &asyncMockIDs))
+	require.NoError(t, r.consumeMappings(context.Background(), "test-set-0", mappings, &correlationMap, &asyncMockIDs, &droppedMockSet{}, nil, &sync.Map{}))
 
 	db.mu.Lock()
 	writes, saved := db.writes, len(db.byTest)
@@ -416,4 +417,712 @@ func TestMockStore_RefusesCancelledContext(t *testing.T) {
 	// The same insert on a detached context — what Start now passes — persists.
 	require.NoError(t, db.InsertMock(context.WithoutCancel(ctx), mock, "test-set-0"),
 		"detaching the write from cancellation is what keeps the tail of a recording")
+}
+
+// ── End-to-end fakes for the skip-and-revoke chain ───────────────────────────
+
+type recTestDB struct {
+	mu       sync.Mutex
+	inserted []string
+	deleted  []string
+}
+
+func (d *recTestDB) GetAllTestSetIDs(context.Context) ([]string, error) { return nil, nil }
+func (d *recTestDB) InsertTestCase(_ context.Context, tc *models.TestCase, _ string, _ bool) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.inserted = append(d.inserted, tc.Name)
+	return nil
+}
+func (d *recTestDB) DeleteTests(_ context.Context, _ string, ids []string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.deleted = append(d.deleted, ids...)
+	return nil
+}
+
+// recMockDB fails exactly the mocks named in unencodable, with the sentinel the
+// recorder classifies as "skip this one and keep going".
+type recMockDB struct {
+	mu          sync.Mutex
+	unencodable map[string]bool
+	inserted    []string
+}
+
+func (d *recMockDB) InsertMock(_ context.Context, m *models.Mock, _ string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.unencodable[m.Name] {
+		return fmt.Errorf("%w (yaml): cannot marshal invalid UTF-8 data as !!str", models.ErrMockEncode)
+	}
+	d.inserted = append(d.inserted, m.Name)
+	return nil
+}
+func (d *recMockDB) DeleteMocksForSet(context.Context, string) error { return nil }
+func (d *recMockDB) GetCurrMockID() int64                            { return 0 }
+func (d *recMockDB) ResetCounterID()                                 {}
+
+type recMappingDB struct {
+	mu      sync.Mutex
+	batches []map[string][]models.MockEntry
+}
+
+func (d *recMappingDB) Insert(context.Context, *models.Mapping) error                    { return nil }
+func (d *recMappingDB) Upsert(context.Context, string, string, []models.MockEntry) error { return nil }
+func (d *recMappingDB) UpsertBatch(_ context.Context, _ string, byTest map[string][]models.MockEntry) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	cp := make(map[string][]models.MockEntry, len(byTest))
+	for k, v := range byTest {
+		cp[k] = append([]models.MockEntry(nil), v...)
+	}
+	d.batches = append(d.batches, cp)
+	return nil
+}
+
+type recTelemetry struct {
+	mu    sync.Mutex
+	suite map[string]interface{}
+}
+
+func (tl *recTelemetry) RecordedTestSuite(_ string, _ int, _ map[string]int, metadata map[string]interface{}) {
+	tl.mu.Lock()
+	defer tl.mu.Unlock()
+	tl.suite = metadata
+}
+func (tl *recTelemetry) RecordedTestCaseMock(string)                                {}
+func (tl *recTelemetry) RecordedMocks(map[string]int)                               {}
+func (tl *recTelemetry) RecordedTestAndMocks()                                      {}
+func (tl *recTelemetry) RecordSessionCompleted(int64, int64, int64, string, string) {}
+
+type recTestSetConf struct{}
+
+func (recTestSetConf) Read(context.Context, string) (*models.TestSet, error) { return nil, nil }
+func (recTestSetConf) Write(context.Context, string, *models.TestSet) error  { return nil }
+
+// blockingInstr is fakeInstr whose Run blocks until ctx is done, so the test
+// controls when the session ends.
+type blockingInstr struct{ *fakeInstr }
+
+func (b *blockingInstr) Run(ctx context.Context, _ models.RunOptions) models.AppError {
+	<-ctx.Done()
+	return models.AppError{AppErrorType: models.ErrCtxCanceled}
+}
+
+// TestStart_UnencodableMockIsSkippedAndItsTestRevoked is the end-to-end guard
+// for the defect that ended a 46-hour production recording: ONE HTTP response
+// body carrying invalid UTF-8 failed to encode, and the recorder treated a
+// failed mock insert as fatal, tearing the whole session down.
+//
+// It pins the full chain, which no narrower test reaches:
+//   - the session SURVIVES the unencodable mock, and mocks recorded after it
+//     still land (the 46-hour loss was everything after the bad one);
+//   - the dropped mock's ID reaches the mapping consumer, so the test that
+//     owned it is REVOKED rather than persisted with a silently short mock
+//     pool that fails at replay looking like a product regression;
+//   - the drop is counted, so an operator and telemetry see the hole.
+func TestStart_UnencodableMockIsSkippedAndItsTestRevoked(t *testing.T) {
+	f := &fakeInstr{
+		mappings: make(chan models.TestMockMapping),
+		incoming: make(chan *models.TestCase),
+		outgoing: make(chan *models.Mock),
+	}
+	testDB := &recTestDB{}
+	mockDB := &recMockDB{unencodable: map[string]bool{"mock-bad": true}}
+	mappingDB := &recMappingDB{}
+	tele := &recTelemetry{}
+
+	r := &Recorder{
+		logger:          zap.NewNop(),
+		testDB:          testDB,
+		mockDB:          mockDB,
+		mappingDb:       mappingDB,
+		telemetry:       tele,
+		instrumentation: &blockingInstr{f},
+		testSetConf:     recTestSetConf{},
+		hooks:           BaseRecordHooks{},
+		config:          &config.Config{},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Start(ctx) }()
+
+	ts := time.Unix(1700000000, 0)
+	httpMock := func(name string) *models.Mock {
+		return &models.Mock{
+			Version: models.GetVersion(), Name: name, Kind: models.HTTP,
+			Spec: models.MockSpec{ReqTimestampMock: ts, ResTimestampMock: ts},
+		}
+	}
+	// Every send is bounded. If the recorder treats the unencodable mock as
+	// fatal it stops consuming, and an unguarded send would simply deadlock —
+	// the regression would surface as a CI timeout with no explanation instead
+	// of a named failure.
+	sendMock := func(name string) {
+		t.Helper()
+		select {
+		case f.outgoing <- httpMock(name):
+		case <-time.After(10 * time.Second):
+			t.Fatalf("the recorder stopped consuming mocks at %q — it tore the session down instead "+
+				"of skipping the one unencodable mock (the 46-hour production failure)", name)
+		}
+	}
+	sendTest := func(name string) {
+		t.Helper()
+		select {
+		case f.incoming <- &models.TestCase{Name: name, Kind: models.HTTP}:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("the recorder stopped consuming test cases at %q", name)
+		}
+	}
+	sendMapping := func(testName string, mockIDs ...string) {
+		t.Helper()
+		select {
+		case f.mappings <- models.TestMockMapping{TestName: testName, MockIDs: mockIDs}:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("the recorder stopped consuming mappings at %q", testName)
+		}
+	}
+
+	sendMock("mock-good-1")
+	sendMock("mock-bad")
+	// Recorded AFTER the failure: under the old fatal behaviour this one, and
+	// everything else for the rest of the session, was lost.
+	sendMock("mock-good-2")
+
+	sendTest("test-1")
+	sendTest("test-2")
+
+	// test-1 owns the dropped mock; test-2 is healthy and must be untouched.
+	sendMapping("test-1", "mock-good-1", "mock-bad")
+	sendMapping("test-2", "mock-good-2")
+
+	// Let the consumers drain before teardown.
+	require.Eventually(t, func() bool {
+		mappingDB.mu.Lock()
+		defer mappingDB.mu.Unlock()
+		return len(mappingDB.batches) > 0
+	}, 5*time.Second, 20*time.Millisecond, "no mapping batch was ever persisted")
+
+	cancel()
+	close(f.outgoing)
+	close(f.incoming)
+	close(f.mappings)
+
+	select {
+	case err := <-done:
+		require.NoError(t, err, "the session died on an unencodable mock — this is the 46-hour production failure")
+	case <-time.After(90 * time.Second):
+		t.Fatal("Start did not return")
+	}
+
+	mockDB.mu.Lock()
+	insertedMocks := append([]string(nil), mockDB.inserted...)
+	mockDB.mu.Unlock()
+	assert.Contains(t, insertedMocks, "mock-good-2",
+		"the mock recorded AFTER the unencodable one is missing: the session was torn down instead of skipping one mock")
+	assert.NotContains(t, insertedMocks, "mock-bad")
+
+	testDB.mu.Lock()
+	deleted := append([]string(nil), testDB.deleted...)
+	testDB.mu.Unlock()
+	assert.Contains(t, deleted, "test-1",
+		"the test that owned the dropped mock was NOT revoked; it is persisted with a short mock pool "+
+			"and fails at replay looking like a product regression")
+	assert.NotContains(t, deleted, "test-2", "a healthy test was revoked")
+
+	tele.mu.Lock()
+	suite := tele.suite
+	tele.mu.Unlock()
+	require.NotNil(t, suite, "no test-suite telemetry was recorded")
+	assert.EqualValues(t, 1, suite["mocks-dropped"],
+		"the dropped mock was not counted, so a recording growing holes looks clean in telemetry: %v", suite)
+}
+
+// TestStart_ShortPoolReachesTelemetryWithoutAnyDrops pins the reporting path
+// for the one data-loss class this change deliberately does NOT revoke.
+//
+// A mock that never correlates leaves its test persisted with an incomplete
+// mock set. Not revoking it is a judgement call — a timeout is an inference,
+// not the known-drop fact — and the ONLY thing that makes that call defensible
+// is that the frequency becomes measurable. The motivating case is a
+// correlation timeout under parallelism with a perfectly healthy encoder, i.e.
+// ZERO dropped mocks, so gating the counters behind the drop counter would
+// leave them invisible in exactly the recording they were added to measure.
+func TestStart_ShortPoolReachesTelemetryWithoutAnyDrops(t *testing.T) {
+	f := &fakeInstr{
+		mappings: make(chan models.TestMockMapping),
+		incoming: make(chan *models.TestCase),
+		outgoing: make(chan *models.Mock),
+	}
+	testDB := &recTestDB{}
+	// No unencodable mocks at all: this recording has zero drops.
+	mockDB := &recMockDB{unencodable: map[string]bool{}}
+	tele := &recTelemetry{}
+
+	r := &Recorder{
+		logger:          zap.NewNop(),
+		testDB:          testDB,
+		mockDB:          mockDB,
+		mappingDb:       &recMappingDB{},
+		telemetry:       tele,
+		instrumentation: &blockingInstr{f},
+		testSetConf:     recTestSetConf{},
+		hooks:           BaseRecordHooks{},
+		config:          &config.Config{},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Start(ctx) }()
+
+	ts := time.Unix(1700000000, 0)
+	select {
+	case f.outgoing <- &models.Mock{
+		Version: models.GetVersion(), Name: "mock-1", Kind: models.HTTP,
+		Spec: models.MockSpec{ReqTimestampMock: ts, ResTimestampMock: ts},
+	}:
+	case <-time.After(10 * time.Second):
+		t.Fatal("recorder never consumed the mock")
+	}
+	select {
+	case f.incoming <- &models.TestCase{Name: "test-1", Kind: models.HTTP}:
+	case <-time.After(10 * time.Second):
+		t.Fatal("recorder never consumed the test case")
+	}
+	// "ghost" was never streamed as a mock, so it never correlates — the
+	// pre-existing "Failed to correlate mock mapping" path.
+	select {
+	case f.mappings <- models.TestMockMapping{TestName: "test-1", MockIDs: []string{"mock-1", "ghost"}}:
+	case <-time.After(10 * time.Second):
+		t.Fatal("recorder never consumed the mapping")
+	}
+
+	cancel()
+	close(f.outgoing)
+	close(f.incoming)
+	close(f.mappings)
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(90 * time.Second):
+		t.Fatal("Start did not return")
+	}
+
+	// Not revoked — the timeout is an inference, so the test still ships.
+	testDB.mu.Lock()
+	deleted := append([]string(nil), testDB.deleted...)
+	testDB.mu.Unlock()
+	assert.NotContains(t, deleted, "test-1",
+		"a correlation timeout revoked a test; that converts a latency event into data destruction")
+
+	tele.mu.Lock()
+	suite := tele.suite
+	tele.mu.Unlock()
+	require.NotNil(t, suite, "no test-suite telemetry was recorded")
+	assert.EqualValues(t, 1, suite["tests-short-pool"],
+		"a test shipped with an incomplete mock set but nothing reached telemetry, so the frequency "+
+			"stays unmeasurable — which is the whole justification for not revoking: %v", suite)
+	assert.EqualValues(t, 1, suite["mocks-uncorrelated"], "%v", suite)
+	assert.NotContains(t, suite, "mocks-dropped", "this recording dropped nothing")
+}
+
+// TestStart_AgentRevokedTestIsNotCountedAsShortPool closes the second revoke
+// path. consumeMappings revokes a test whose mock it KNOWS was dropped, but the
+// agent independently revokes tests via a RevokedTests control frame when it
+// capacity-drops a mock after the test streamed — a revoke consumeMappings
+// never sees.
+//
+// A capacity-dropped test is a prime candidate for also having an uncorrelated
+// mock, so counting it would inflate tests-short-pool with exactly the
+// population the metric claims to exclude. Since that metric's credibility is
+// the entire justification for not revoking on a correlation timeout, both
+// revoke paths have to be subtracted, which is why the totals are computed at
+// teardown instead of accumulated as mappings arrive.
+func TestStart_AgentRevokedTestIsNotCountedAsShortPool(t *testing.T) {
+	f := &fakeInstr{
+		mappings: make(chan models.TestMockMapping),
+		incoming: make(chan *models.TestCase),
+		outgoing: make(chan *models.Mock),
+	}
+	testDB := &recTestDB{}
+	tele := &recTelemetry{}
+
+	r := &Recorder{
+		logger:          zap.NewNop(),
+		testDB:          testDB,
+		mockDB:          &recMockDB{unencodable: map[string]bool{}},
+		mappingDb:       &recMappingDB{},
+		telemetry:       tele,
+		instrumentation: &blockingInstr{f},
+		testSetConf:     recTestSetConf{},
+		hooks:           BaseRecordHooks{},
+		config:          &config.Config{},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Start(ctx) }()
+
+	ts := time.Unix(1700000000, 0)
+	send := func(m *models.Mock) {
+		t.Helper()
+		select {
+		case f.outgoing <- m:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("recorder never consumed mock %q", m.Name)
+		}
+	}
+	send(&models.Mock{
+		Version: models.GetVersion(), Name: "mock-1", Kind: models.HTTP,
+		Spec: models.MockSpec{ReqTimestampMock: ts, ResTimestampMock: ts},
+	})
+	select {
+	case f.incoming <- &models.TestCase{Name: "test-1", Kind: models.HTTP}:
+	case <-time.After(10 * time.Second):
+		t.Fatal("recorder never consumed the test case")
+	}
+	// "ghost" never correlates → test-1 looks short-pooled...
+	select {
+	case f.mappings <- models.TestMockMapping{TestName: "test-1", MockIDs: []string{"mock-1", "ghost"}}:
+	case <-time.After(10 * time.Second):
+		t.Fatal("recorder never consumed the mapping")
+	}
+	// ...but the AGENT then revokes it via its own control frame.
+	send(&models.Mock{
+		Version: models.GetVersion(),
+		Name:    "revoke-frame",
+		Kind:    models.RevokedTests,
+		Spec:    models.MockSpec{Metadata: map[string]string{"revoked_tests": "test-1"}},
+	})
+
+	cancel()
+	close(f.outgoing)
+	close(f.incoming)
+	close(f.mappings)
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(90 * time.Second):
+		t.Fatal("Start did not return")
+	}
+
+	testDB.mu.Lock()
+	deleted := append([]string(nil), testDB.deleted...)
+	testDB.mu.Unlock()
+	require.Contains(t, deleted, "test-1", "the agent's RevokedTests frame did not delete the test")
+
+	tele.mu.Lock()
+	suite := tele.suite
+	tele.mu.Unlock()
+	require.NotNil(t, suite)
+	assert.NotContains(t, suite, "tests-short-pool",
+		"a test the AGENT revoked is still counted as shipping with a short mock pool; it was "+
+			"deleted, so the metric over-counts exactly the population it claims to exclude: %v", suite)
+}
+
+// TestStart_HookSkippedMockIsExcludedFromMappings pins the guard that a naive
+// reading of the code makes look unnecessary.
+//
+// A RecordHook can ask the recorder to drop a mock (AsyncRecorder does this for
+// a collapsed poll cycle whose value did not change). The agent does not know
+// about the skip, so the tempID still arrives in the mapping it streams. The
+// recorder must therefore mark it itself.
+//
+// The trap: AsyncRecorder sets info.Skip and returns BEFORE assigning
+// Spec.Async, so a skipped mock reports IsAsync()==false. Gating the marker on
+// mock.IsAsync() — the obvious thing to write — makes the guard a silent no-op,
+// and the skipped tempID then burns the full ~500ms correlation spin and is
+// reported as an incomplete mock set on a healthy test. This test drives the
+// real hook rather than a fake so that trap cannot be re-introduced.
+func TestStart_HookSkippedMockIsExcludedFromMappings(t *testing.T) {
+	f := &fakeInstr{
+		mappings: make(chan models.TestMockMapping),
+		incoming: make(chan *models.TestCase),
+		outgoing: make(chan *models.Mock),
+	}
+	testDB := &recTestDB{}
+	tele := &recTelemetry{}
+
+	// Force the BEST-EFFORT half (droppedMockSet's benign cache) to decline
+	// every entry, which is the steady state of a long poll-heavy recording.
+	// What remains is the unconditional asyncMockIDs marker — the correctness
+	// guarantee — and this test exists to prove it carries the load alone.
+	prevCap := maxLiveBenignMockIDs
+	maxLiveBenignMockIDs = 0
+	t.Cleanup(func() { maxLiveBenignMockIDs = prevCap })
+
+	r := &Recorder{
+		logger:          zap.NewNop(),
+		testDB:          testDB,
+		mockDB:          &recMockDB{unencodable: map[string]bool{}},
+		mappingDb:       &recMappingDB{},
+		telemetry:       tele,
+		instrumentation: &blockingInstr{f},
+		testSetConf:     recTestSetConf{},
+		hooks:           skipEverythingHooks{},
+		config:          &config.Config{},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Start(ctx) }()
+
+	ts := time.Unix(1700000000, 0)
+	select {
+	case f.outgoing <- &models.Mock{
+		Version: models.GetVersion(), Name: "poll-collapsed", Kind: models.HTTP,
+		Spec: models.MockSpec{ReqTimestampMock: ts, ResTimestampMock: ts},
+	}:
+	case <-time.After(10 * time.Second):
+		t.Fatal("recorder never consumed the mock")
+	}
+	select {
+	case f.incoming <- &models.TestCase{Name: "test-1", Kind: models.HTTP}:
+	case <-time.After(10 * time.Second):
+		t.Fatal("recorder never consumed the test case")
+	}
+
+	select {
+	case f.mappings <- models.TestMockMapping{TestName: "test-1", MockIDs: []string{"poll-collapsed"}}:
+	case <-time.After(10 * time.Second):
+		t.Fatal("recorder never consumed the mapping")
+	}
+
+	cancel()
+	close(f.outgoing)
+	close(f.incoming)
+	close(f.mappings)
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(90 * time.Second):
+		t.Fatal("Start did not return")
+	}
+
+	testDB.mu.Lock()
+	deleted := append([]string(nil), testDB.deleted...)
+	testDB.mu.Unlock()
+	assert.NotContains(t, deleted, "test-1", "a hook-skipped mock revoked its test; the skip is normal operation")
+
+	tele.mu.Lock()
+	suite := tele.suite
+	tele.mu.Unlock()
+	require.NotNil(t, suite)
+	assert.NotContains(t, suite, "tests-short-pool",
+		"a hook-skipped mock was reported as an incomplete mock set. Poll lanes collapse most "+
+			"cycles by design, so this alarms on every async-poll recording: %v", suite)
+}
+
+// skipEverythingHooks reproduces AsyncRecorder's collapsed-cycle contract
+// exactly: set Skip and return WITHOUT assigning Spec.Async.
+type skipEverythingHooks struct{ BaseRecordHooks }
+
+func (skipEverythingHooks) BeforeMockInsert(_ context.Context, info *MockContext) error {
+	info.Skip = true
+	return nil
+}
+
+// failingDeleteTestDB accepts inserts but cannot delete — the shape of an
+// embedding whose TestDB does not really support the revoke.
+type failingDeleteTestDB struct{ recTestDB }
+
+func (d *failingDeleteTestDB) DeleteTests(context.Context, string, []string) error {
+	return errors.New("delete not supported here")
+}
+
+// TestStart_FailedRevokeKeepsTheTestInTheShortPoolCount covers the gap between
+// "revoked" and "actually deleted".
+//
+// The revoke is best-effort: DeleteTests is reached by runtime assertion
+// (it is deliberately not on the record TestDB interface so enterprise
+// implementations keep compiling), and an individual delete can fail and only
+// warn. When that happens the test REMAINS in the set, still carrying an
+// incomplete mock set — so subtracting it from tests-short-pool on the strength
+// of the revoke alone under-reports exactly the embedding that cannot apply the
+// revoke, which is the one an operator most needs to hear about.
+func TestStart_FailedRevokeKeepsTheTestInTheShortPoolCount(t *testing.T) {
+	f := &fakeInstr{
+		mappings: make(chan models.TestMockMapping),
+		incoming: make(chan *models.TestCase),
+		outgoing: make(chan *models.Mock),
+	}
+	testDB := &failingDeleteTestDB{}
+	tele := &recTelemetry{}
+
+	r := &Recorder{
+		logger:          zap.NewNop(),
+		testDB:          testDB,
+		mockDB:          &recMockDB{unencodable: map[string]bool{}},
+		mappingDb:       &recMappingDB{},
+		telemetry:       tele,
+		instrumentation: &blockingInstr{f},
+		testSetConf:     recTestSetConf{},
+		hooks:           BaseRecordHooks{},
+		config:          &config.Config{},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Start(ctx) }()
+
+	ts := time.Unix(1700000000, 0)
+	send := func(m *models.Mock) {
+		t.Helper()
+		select {
+		case f.outgoing <- m:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("recorder never consumed mock %q", m.Name)
+		}
+	}
+	send(&models.Mock{
+		Version: models.GetVersion(), Name: "mock-1", Kind: models.HTTP,
+		Spec: models.MockSpec{ReqTimestampMock: ts, ResTimestampMock: ts},
+	})
+	select {
+	case f.incoming <- &models.TestCase{Name: "test-1", Kind: models.HTTP}:
+	case <-time.After(10 * time.Second):
+		t.Fatal("recorder never consumed the test case")
+	}
+	select {
+	case f.mappings <- models.TestMockMapping{TestName: "test-1", MockIDs: []string{"mock-1", "ghost"}}:
+	case <-time.After(10 * time.Second):
+		t.Fatal("recorder never consumed the mapping")
+	}
+	send(&models.Mock{
+		Version: models.GetVersion(), Name: "revoke-frame", Kind: models.RevokedTests,
+		Spec: models.MockSpec{Metadata: map[string]string{"revoked_tests": "test-1"}},
+	})
+
+	cancel()
+	close(f.outgoing)
+	close(f.incoming)
+	close(f.mappings)
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(90 * time.Second):
+		t.Fatal("Start did not return")
+	}
+
+	tele.mu.Lock()
+	suite := tele.suite
+	tele.mu.Unlock()
+	require.NotNil(t, suite)
+	assert.EqualValues(t, 1, suite["tests-short-pool"],
+		"the revoke FAILED, so test-1 is still in the set with an incomplete mock set — but it was "+
+			"subtracted from the count anyway, hiding the problem in the very embedding that cannot "+
+			"apply the revoke: %v", suite)
+}
+
+// TestGetTestAndMockChans_ForwardsInFlightTestCaseOnShutdown is the test-case
+// half of the tail-loss family this branch is named after.
+//
+// The mock and mapping forwarders both hand over what they have already taken
+// from the agent when ctx is cancelled — the mock one by forwarding then
+// returning, the mapping one via a drain grace period. The incoming (test-case)
+// forwarder did not: it returned ctx.Err() with a test case already in hand.
+//
+// The agent counts that test case as delivered and never re-sends it, and its
+// MOCKS and its MAPPING are still persisted (the stores write on persistCtx,
+// detached from ctx, precisely so the tail survives). So the test case vanished
+// with no log and no counter, leaving the set with orphaned mocks and a
+// mappings.yaml entry naming a test that does not exist. SIGINT lands while the
+// agent is streaming the tail, so this is exactly the window the tail is in.
+func TestGetTestAndMockChans_ForwardsInFlightTestCaseOnShutdown(t *testing.T) {
+	f := &fakeInstr{
+		mappings: make(chan models.TestMockMapping),
+		incoming: make(chan *models.TestCase),
+		outgoing: make(chan *models.Mock),
+	}
+	r := &Recorder{logger: zap.NewNop(), instrumentation: f, config: &config.Config{}}
+
+	g, gctx := errgroup.WithContext(context.Background())
+	ctx, cancel := context.WithCancel(gctx)
+	ctx = context.WithValue(ctx, models.ErrGroupKey, g)
+
+	frames, err := r.GetTestAndMockChans(ctx)
+	require.NoError(t, err)
+
+	// The agent hands over a test case, then shutdown begins. The send returns,
+	// so from the agent's point of view this test case is delivered.
+	f.incoming <- &models.TestCase{Name: "tail-test", Kind: models.HTTP}
+	cancel()
+
+	select {
+	case tc, ok := <-frames.Incoming:
+		require.True(t, ok, "the incoming channel closed without delivering the in-flight test case")
+		assert.Equal(t, "tail-test", tc.Name)
+	case <-time.After(5 * time.Second):
+		t.Fatal("a test case already taken from the agent was DROPPED on shutdown. The agent will " +
+			"not re-send it, but its mocks and its mapping are still persisted, so the test set " +
+			"ships with orphaned mocks and a mappings.yaml entry for a test that does not exist")
+	}
+
+	close(f.incoming)
+	close(f.outgoing)
+	close(f.mappings)
+	_ = g.Wait()
+}
+
+// TestGetTestAndMockChans_ShutdownHandoffDoesNotWedgeWithoutAConsumer is the
+// safety net for the in-flight handover above.
+//
+// Both forwarders deliberately hand over an item already taken from the agent
+// when ctx is cancelled, so the tail is not silently dropped. That send must
+// complete even when NOTHING is consuming — which is a reachable state, not a
+// hypothetical: Start can return at its post-setup ctx.Err() gate before it
+// spawns the consumers, while these forwarders run on reqCtx (WithoutCancel)
+// and keep pulling from the agent. On an unbuffered channel the handover parks
+// forever: a 30s DrainErrGroup timeout on every affected Ctrl+C and a goroutine
+// leaked for the process lifetime, which compounds in the DaemonSet embedding
+// where Start is re-entered per session.
+//
+// This drives that exact window — take an item, cancel, never consume — for
+// both the test-case and the mock forwarder.
+func TestGetTestAndMockChans_ShutdownHandoffDoesNotWedgeWithoutAConsumer(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		send func(f *fakeInstr)
+	}{
+		{"incoming", func(f *fakeInstr) { f.incoming <- &models.TestCase{Name: "tail", Kind: models.HTTP} }},
+		{"outgoing", func(f *fakeInstr) { f.outgoing <- &models.Mock{Name: "tail", Kind: models.HTTP} }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &fakeInstr{
+				mappings: make(chan models.TestMockMapping),
+				incoming: make(chan *models.TestCase),
+				outgoing: make(chan *models.Mock),
+			}
+			r := &Recorder{logger: zap.NewNop(), instrumentation: f, config: &config.Config{}}
+
+			g, gctx := errgroup.WithContext(context.Background())
+			ctx, cancel := context.WithCancel(gctx)
+			ctx = context.WithValue(ctx, models.ErrGroupKey, g)
+
+			_, err := r.GetTestAndMockChans(ctx)
+			require.NoError(t, err)
+
+			// The agent hands an item over; the forwarder now holds it. Nothing
+			// is reading the frame channels — this is the "Start returned early"
+			// shape.
+			tc.send(f)
+			cancel()
+
+			done := make(chan error, 1)
+			go func() { done <- g.Wait() }()
+			select {
+			case <-done:
+			case <-time.After(10 * time.Second):
+				t.Fatal("the shutdown handover WEDGED with no consumer. In production this is a 30s " +
+					"DrainErrGroup timeout on Ctrl+C plus a goroutine held for the process lifetime, " +
+					"re-leaked on every session in the DaemonSet embedding")
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Describe the changes that are made

A gzip-encoded HTTP response body is valid HTTP and invalid UTF-8. The streaming-chunk YAML encoder stamped an explicit `!!str` tag on it; yaml.v3 refuses that outright (`cannot marshal invalid UTF-8 data as !!str`); the mock insert returned an error; and the recorder treated a failed mock insert as fatal. **One response body ended a 46-hour recording.**

Two independent faults, so two fixes.

**Encode correctly.** `stringNode` emits `!!binary` + base64 for a scalar that is not valid UTF-8, and `yamlNodeToString` decodes it back — yaml.v3 leaves the *base64 text* in `node.Value` for a binary scalar, so reading it raw would hand replay the base64 string. The same treatment covers postgres hstore values, hstore **keys** (they encoded fine but decoded back as the base64 text, silently replacing the key) and TSVector lexemes. Valid UTF-8 keeps its plain form so mock files stay readable and diffable. Where a body genuinely cannot be represented — the `json` storage format, where `encoding/json` substitutes U+FFFD and returns **no error** — it is refused loudly instead of written corrupted.

**Contain the blast radius.** A mock whose payload cannot be encoded says nothing about the next mock, so it is skipped and counted rather than killing the session. `models.ErrMockEncode` marks that class. Failures from a registered `MockYAMLMapper` (out-of-tree code that may touch disk or network) and all writer/IO failures stay **fatal**, because those *do* predict the next mock and skipping them would finish green with an empty test set. A dropped mock's tempID reaches the mapping consumer, so the test that owned it is revoked rather than persisted with a silently short mock pool.

### Also fixed while proving the above

- **A test case already taken from the agent was dropped** when the incoming forwarder saw a cancelled ctx. The agent counts it delivered and never re-sends, while its mocks and mapping are still persisted — so the set shipped with orphaned mocks and a `mappings.yaml` entry naming a test that does not exist. It is now handed over before returning, matching the outgoing forwarder; both channels carry one slot so that handover cannot wedge when `Start` returned before spawning its consumers.
- **Blocking error reporting.** Both insert channels used a blocking send, so a full disk parked the goroutine once the buffer filled and leaked it past teardown. Non-blocking now; the first error still lands.
- **Async-egress mocks** are excluded from per-test mappings by design, so a dropped one is nobody's short pool. Its status is settled at each of the three points a tempID's fate is decided, because the marker is published concurrently and a single check loses the race in one direction or the other — leaking the mock into a mapping, or deleting a healthy test.
- **Hook-skipped mocks** (a collapsed async poll cycle) are marked releasable so the entry is freed once consumed, rather than retained for the whole session.
- **Tests persisted with an uncorrelated mock are now counted and reported.** That path is deliberately still *not* revoked: a correlation timeout is an inference, not the known-drop fact, and deleting a recorded test on it turns a latency event into data destruction. It is measured instead (`tests-short-pool`, `mocks-uncorrelated`), which is what a decision on the semantics needs.
- **A document-less `mocks.yaml`** (every mock dropped) now reads as zero mocks instead of failing the entire test set.

## Links & References

**Closes:** NA

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

The failure is a property of the encoders and the recorder's error classification, both reachable directly. It is covered by unit tests instead, and every one of them was mutation-verified: revert the production line and the test fails with its stated diagnostic. Several of the defects listed above were found *because* an earlier revision's tests passed under mutation.

## Added comments for hard-to-understand areas?
- [x] 👍 yes

Particularly around the three async settle points (why one check is not enough), the `ErrMockEncode` / `errMapperEncode` split (why one is skippable and the other must stay fatal), and the two-layer skip guard (unconditional correctness vs. capped best-effort speed).

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

```go
// Before: this returns an error, and the recorder treats it as fatal.
// After:  it marshals, and round-trips byte-exactly.
in := models.HTTPResp{
    StatusCode: 200,
    Header:     map[string]string{"Content-Type": "application/octet-stream"},
    Body:       string([]byte{0x1f, 0x8b, 0x08, 0x00, 0xff, 0xfe}), // gzip magic
}
out, err := yaml.Marshal(&in)
```

```bash
go test ./pkg/models/ ./pkg/platform/yaml/mockdb/ ./pkg/service/record/
```

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?

The original production failure:

```
cannot marshal invalid UTF-8 data as !!str
```

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?
