### PR TITLE
fix(mysql): decode FLOAT/DOUBLE as IEEE-754 bit patterns

### DIFF
--- a/.github/workflows/java_linux.yml
+++ b/.github/workflows/java_linux.yml
@@ -95,6 +95,13 @@ jobs:
           - job: record_build_replay_build
             record_src: build-no-race
             replay_src: build-no-race
+            # FLOAT/DOUBLE column fidelity (keploy#4426) needs BOTH
+            # binaries to carry the fix: a record binary without it
+            # writes the IEEE-754 bit pattern into the mock, and a
+            # replay binary without it panics on a correctly recorded
+            # FLOAT. So only this cell exercises the fixture; the
+            # cross-version cells leave the flag unset and skip.
+            numeric_fidelity: "true"
     name: mysql-dual-conn (${{ matrix.config.job }})
     steps:
       - name: Checkout repository
@@ -128,6 +135,7 @@ jobs:
         env:
           RECORD_BIN: ${{ steps.record.outputs.path }}
           REPLAY_BIN: ${{ steps.replay.outputs.path }}
+          MYSQL_NUMERIC_FIDELITY: ${{ matrix.config.numeric_fidelity }}
         run: |
           cd samples-java/mysql-dual-conn
           source $GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/java/mysql_dual_conn/java-linux.sh

--- a/.github/workflows/test_workflow_scripts/java/mysql_dual_conn/java-linux.sh
+++ b/.github/workflows/test_workflow_scripts/java/mysql_dual_conn/java-linux.sh
@@ -95,6 +95,25 @@ send_request() {
   echo "=== /api/oms/stmt-reset/5 (trigger COM_STMT_RESET) ==="
   curl -sS http://localhost:8080/api/oms/stmt-reset/5 || true
 
+  # Column-type fidelity (keploy#4426). Both endpoints bind a parameter,
+  # so Connector/J issues COM_STMT_EXECUTE and MySQL answers with a
+  # BINARY-protocol result set — the format whose FLOAT/DOUBLE columns
+  # carry raw IEEE-754 bytes. An unparameterised SELECT would come back
+  # as a text result set (every value a string) and would not touch this
+  # code path at all.
+  #
+  # Gated: see the MYSQL_NUMERIC_FIDELITY note at the guard below.
+  if [[ "${MYSQL_NUMERIC_FIDELITY:-}" == "true" ]]; then
+    echo "=== /api/oms/numerics (FLOAT/DOUBLE/BIGINT UNSIGNED, binary rows) ==="
+    curl -sS http://localhost:8080/api/oms/numerics || true
+
+    # Binds a FLOAT parameter: float32 on the wire, float64 out of the
+    # mock file. Exercises the COM_STMT_EXECUTE parameter decode and the
+    # matcher's mixed-width float comparison.
+    echo "=== /api/oms/float-param/9.99 (FLOAT bound parameter) ==="
+    curl -sS http://localhost:8080/api/oms/float-param/9.99 || true
+  fi
+
   # Let keploy persist, then gracefully stop it
   sleep 10
   echo "$kp_pid Keploy PID"
@@ -176,6 +195,103 @@ if json_pass_supported; then
 fi
 
 sleep 5
+
+# --- Regression guard for keploy#4426 (FLOAT/DOUBLE decoded as bit patterns) ---
+# This one has to be asserted on the RECORDED ARTIFACT, not on the replay
+# report. The defect corrupted values at record time: a FLOAT column
+# holding 9.99 was written to the mock as 1.0926057e+09 and a DOUBLE as
+# 4.621813488089437e+18, because the wire bytes were converted numerically
+# instead of reinterpreted as IEEE-754. Record and replay were wrong in the
+# same direction, so a report-status check alone can pass while every
+# recorded row is nonsense.
+#
+# Compat matrix: this needs BOTH binaries to carry the fix. A record
+# binary without it writes the bit pattern into the mock; a replay
+# binary without it type-asserts ce.Value.(float32) on a correctly
+# recorded FLOAT and panics, tearing down the connection. So a
+# mixed-version cell cannot exercise the fixture either way, and
+# MYSQL_NUMERIC_FIDELITY is set only on record_build_replay_build —
+# exactly the pattern mysql_auto_port uses for port detection.
+#
+# There is no CLI capability to probe here (the fix adds no flag), so
+# the matrix cell states the fact directly rather than a probe guessing
+# at it. The flag being unset therefore means "skewed cell", never
+# "feature missing", so this cannot silently go green on the cell that
+# is supposed to assert.
+section "Guard: FLOAT/DOUBLE column fidelity (keploy#4426)"
+if [[ "${MYSQL_NUMERIC_FIDELITY:-}" != "true" ]]; then
+  echo "Skipping: FLOAT/DOUBLE column fidelity needs BOTH the record and replay"
+  echo "binaries to carry the keploy#4426 fix. Expected for cross-version cells."
+  endsec
+else
+  # Closes the ::group:: before exiting, so the ::error:: annotations
+  # don't render inside a collapsed section.
+  guard_fail() {
+    echo "::error::$*"
+    endsec
+    exit 1
+  }
+
+  mapfile -t mock_files < <(find ./keploy \( -name 'mocks.yaml' -o -name 'mocks.json' \) | sort)
+  if [[ ${#mock_files[@]} -eq 0 ]]; then
+    guard_fail "keploy#4426 guard: no mock files found under ./keploy"
+  fi
+
+  # The negative check runs on every file. The positive checks run only on
+  # files that actually captured the fixture, so adding a future test-set
+  # that doesn't hit /api/oms/numerics can't turn this into a false
+  # failure — but at least one file must carry it, or the negative check
+  # would be vacuous.
+  #
+  # Per file rather than across the set: the YAML and JSON storage formats
+  # decode numbers through different code, so a JSON-only regression must
+  # not be masked by the YAML file happening to hold the right value.
+  fixture_seen=false
+  for mf in "${mock_files[@]}"; do
+    echo "--- checking $mf"
+
+    # The exact corruptions this bug produced for a column holding 9.99.
+    if grep -qE '1\.0926057e\+09|4\.621813488089437e\+18' "$mf"; then
+      grep -nE '1\.0926057e\+09|4\.621813488089437e\+18' "$mf" | head -10
+      guard_fail "keploy#4426 regression in $mf: a FLOAT/DOUBLE column was recorded as its IEEE-754 bit pattern"
+    fi
+
+    # Optional space after the colon so this keeps working if the JSON
+    # mock writer ever gains SetIndent.
+    if ! grep -qE '"?table"?: ?"?numeric_fidelity"?' "$mf"; then
+      echo "    (no numeric_fidelity rows in this file — skipping positive checks)"
+      continue
+    fi
+    fixture_seen=true
+
+    if ! grep -qE '"?name"?: ?"?price_f"?' "$mf"; then
+      guard_fail "keploy#4426 guard: numeric_fidelity present in $mf but no price_f column"
+    fi
+
+    # Unquoted 9.99. A quoted "9.99" means the row arrived as a TEXT result
+    # set, whose values are length-encoded strings — that path never touches
+    # the binary decode this guard exists to protect.
+    if ! grep -qE '(value: 9\.99$|"value": ?9\.99)' "$mf"; then
+      grep -nE '"?name"?: ?"?(price_f|ratio_d)"?' -A 1 "$mf" | head -20
+      guard_fail "keploy#4426 guard: no unquoted 9.99 in $mf — a quoted \"9.99\" means a TEXT result set, which does not exercise the binary decode path"
+    fi
+
+    # BIGINT UNSIGNED above MaxInt64 has no lossless float64 form, so a
+    # format that routes it through one collapses distinct rows onto the
+    # same number (18446744073709551615 -> 18446744073709552000, or
+    # -9223372036854775808 once that float is narrowed to an integer).
+    if ! grep -q '18446744073709551615' "$mf"; then
+      grep -nE '"?name"?: ?"?big_u"?' -A 1 "$mf" | head -20
+      guard_fail "keploy#4426 guard: BIGINT UNSIGNED max lost precision in $mf"
+    fi
+  done
+
+  if [[ "$fixture_seen" != "true" ]]; then
+    guard_fail "keploy#4426 guard: no mock file captured the numeric_fidelity table — /api/oms/numerics was never recorded, so this guard asserted nothing"
+  fi
+  echo "OK: FLOAT/DOUBLE/BIGINT UNSIGNED columns recorded with their real values."
+  endsec
+fi
 
 section "Shutdown MySQL before test mode"
 docker compose down || true

--- a/pkg/agent/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match.go
@@ -1581,6 +1581,12 @@ func paramValueEqual(a, b interface{}, nc *util.NoiseChecker) bool {
 			// float64(9.99). Widening asks the float32 to carry precision
 			// it never had — float64(float32(9.99)) is 9.989999771118164,
 			// so a correctly recorded FLOAT param never matched itself.
+			//
+			// This is the same direction the int/uint arms below already
+			// take. Narrowing does collide for magnitudes float32 cannot
+			// hold (1e-300 compares equal to 0), but a float32 only ever
+			// enters here from a FieldTypeFloat decode and a MySQL FLOAT
+			// cannot carry those, so no real column reaches the collision.
 			return av == float32(bv)
 		case int:
 			return av == float32(bv)

--- a/pkg/agent/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match.go
@@ -1574,7 +1574,14 @@ func paramValueEqual(a, b interface{}, nc *util.NoiseChecker) bool {
 		case float32:
 			return av == bv
 		case float64:
-			return float64(av) == bv
+			// Compare at float32 precision, not float64. One side is
+			// genuinely a float32 (FieldTypeFloat off the wire) and the
+			// other has been through YAML, which writes a float32 in its
+			// shortest 32-bit form ("9.99") and reads it back as
+			// float64(9.99). Widening asks the float32 to carry precision
+			// it never had — float64(float32(9.99)) is 9.989999771118164,
+			// so a correctly recorded FLOAT param never matched itself.
+			return av == float32(bv)
 		case int:
 			return av == float32(bv)
 		case int32:
@@ -1591,7 +1598,8 @@ func paramValueEqual(a, b interface{}, nc *util.NoiseChecker) bool {
 		case float64:
 			return av == bv
 		case float32:
-			return av == float64(bv)
+			// Narrow, don't widen — see the float32 arm above.
+			return float32(av) == bv
 		case int:
 			return av == float64(bv)
 		case int32:

--- a/pkg/agent/proxy/integrations/mysql/replayer/match_float_test.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match_float_test.go
@@ -1,0 +1,124 @@
+package replayer
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/util"
+	"gopkg.in/yaml.v3"
+)
+
+// yamlRoundTrip puts a value through the same serializer the mock file goes
+// through, and hands back whatever concrete type comes out the other side.
+// The point is to prove the type erasure rather than hard-code the constant
+// it produces.
+func yamlRoundTrip(t *testing.T, v interface{}) interface{} {
+	t.Helper()
+	b, err := yaml.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal %v: %v", v, err)
+	}
+	var out interface{}
+	if err := yaml.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal %q: %v", b, err)
+	}
+	return out
+}
+
+// A FLOAT parameter read off the wire is a float32. The same parameter read
+// back out of the mock YAML is a float64, because yaml.v3 resolves an
+// untagged scalar by its shape and never yields float32. paramValueEqual sees
+// that mixed pair on every FLOAT comparison, so a recorded FLOAT param has to
+// match itself across it.
+func TestParamValueEqual_FloatParamMatchesItselfAcrossYAML(t *testing.T) {
+	nc := util.NewNoiseChecker(nil)
+
+	// Fractional values only. A whole-numbered float32 comes back as an int
+	// and takes a different arm — covered separately below.
+	for _, want := range []float32{9.99, -0.1, 1.5, 3.4e38, 1e-9} {
+		restored := yamlRoundTrip(t, want)
+
+		if _, ok := restored.(float64); !ok {
+			t.Fatalf("%v: expected YAML to restore a float64, got %T — "+
+				"this test is asserting the wrong thing", want, restored)
+		}
+
+		// Both argument orders: which side is the live param and which is
+		// the recorded one is not fixed at the call sites.
+		if !paramValueEqual(want, restored, nc) {
+			t.Errorf("live float32 %v vs recorded %v (%T): no match, want match",
+				want, restored, restored)
+		}
+		if !paramValueEqual(restored, want, nc) {
+			t.Errorf("recorded %v (%T) vs live float32 %v: no match, want match",
+				restored, restored, want)
+		}
+	}
+}
+
+// A whole-numbered FLOAT param is erased harder: yaml.v3 writes float32(2)
+// as "2", which resolves back to int, not float64. That pair goes through the
+// float32/int arm, which was already correct — this pins it so the erasure
+// stays covered.
+func TestParamValueEqual_WholeFloatParamRestoresAsInt(t *testing.T) {
+	nc := util.NewNoiseChecker(nil)
+
+	for _, want := range []float32{0, 2, -7, 1000} {
+		restored := yamlRoundTrip(t, want)
+
+		if _, ok := restored.(int); !ok {
+			t.Fatalf("%v: expected YAML to restore an int, got %T", want, restored)
+		}
+		if !paramValueEqual(want, restored, nc) {
+			t.Errorf("live float32 %v vs recorded %v (%T): no match, want match",
+				want, restored, restored)
+		}
+		if !paramValueEqual(restored, want, nc) {
+			t.Errorf("recorded %v (%T) vs live float32 %v: no match, want match",
+				restored, restored, want)
+		}
+	}
+}
+
+// Narrowing must not make the comparison blind: values that are genuinely
+// different at float32 precision still have to compare unequal.
+func TestParamValueEqual_DistinctFloatsStillDiffer(t *testing.T) {
+	nc := util.NewNoiseChecker(nil)
+
+	cases := []struct {
+		a float32
+		b float64
+	}{
+		{9.99, 10.5},
+		{9.99, -9.99},
+		{0, 1e-30},
+		{1.5, 1.6},
+	}
+	for _, c := range cases {
+		if paramValueEqual(c.a, c.b, nc) {
+			t.Errorf("float32(%v) vs float64(%v): matched, want no match", c.a, c.b)
+		}
+		if paramValueEqual(c.b, c.a, nc) {
+			t.Errorf("float64(%v) vs float32(%v): matched, want no match", c.b, c.a)
+		}
+	}
+}
+
+// A DOUBLE parameter is float64 on both sides and must keep full precision —
+// the fix narrows only the mixed float32/float64 arms, not this one.
+func TestParamValueEqual_DoubleKeepsFullPrecision(t *testing.T) {
+	nc := util.NewNoiseChecker(nil)
+
+	// These two are equal as float32 and distinct as float64. If DOUBLE
+	// comparison ever started narrowing, this would match.
+	a := 9.99
+	b := 9.989999771118164
+	if a == b {
+		t.Fatal("test constants are equal as float64; pick different ones")
+	}
+	if paramValueEqual(a, b, nc) {
+		t.Error("two distinct float64 values matched: DOUBLE comparison lost precision")
+	}
+	if !paramValueEqual(a, yamlRoundTrip(t, a), nc) {
+		t.Error("float64 did not match itself across YAML")
+	}
+}

--- a/pkg/agent/proxy/integrations/mysql/wire/phase/query/preparedstmt/stmtExecutePacket.go
+++ b/pkg/agent/proxy/integrations/mysql/wire/phase/query/preparedstmt/stmtExecutePacket.go
@@ -246,7 +246,8 @@ func DecodeStmtExecute(_ context.Context, logger *zap.Logger, data []byte, prepa
 				if len(data[pos:]) < 4 {
 					return nil, fmt.Errorf("malformed FieldTypeFloat value")
 				}
-				param.Value = float32(binary.LittleEndian.Uint32(data[pos : pos+4]))
+				// IEEE-754 reinterpret, exactly as FieldTypeDouble below.
+				param.Value = math.Float32frombits(binary.LittleEndian.Uint32(data[pos : pos+4]))
 				pos += 4
 
 			case mysql.FieldTypeDouble:

--- a/pkg/agent/proxy/integrations/mysql/wire/phase/query/queryPacket.go
+++ b/pkg/agent/proxy/integrations/mysql/wire/phase/query/queryPacket.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math"
 	"strings"
 
 	intUtil "go.keploy.io/server/v3/pkg/agent/proxy/integrations/util"
@@ -165,14 +166,18 @@ func DecodeQuery(_ context.Context, logger *zap.Logger, data []byte, clientCapab
 				if len(data[pos:]) < 4 {
 					return nil, fmt.Errorf("malformed FieldTypeFloat value")
 				}
-				param.Value = float32(binary.LittleEndian.Uint32(data[pos : pos+4]))
+				// IEEE-754 reinterpret, NOT a numeric cast — the wire bytes
+				// encode the float's bit pattern. Same defect as the one
+				// fixed in stmtExecutePacket.go; query attributes carry it
+				// on both FLOAT and DOUBLE.
+				param.Value = math.Float32frombits(binary.LittleEndian.Uint32(data[pos : pos+4]))
 				pos += 4
 
 			case mysql.FieldTypeDouble:
 				if len(data[pos:]) < 8 {
 					return nil, fmt.Errorf("malformed FieldTypeDouble value")
 				}
-				param.Value = float64(binary.LittleEndian.Uint64(data[pos : pos+8]))
+				param.Value = math.Float64frombits(binary.LittleEndian.Uint64(data[pos : pos+8]))
 				pos += 8
 
 			// Support DATE types in query attributes.

--- a/pkg/agent/proxy/integrations/mysql/wire/phase/query/rowscols/binaryProtocolRowPacket.go
+++ b/pkg/agent/proxy/integrations/mysql/wire/phase/query/rowscols/binaryProtocolRowPacket.go
@@ -7,7 +7,9 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -141,14 +143,21 @@ func readBinaryValue(data []byte, col *mysql.ColumnDefinition41) (*binaryValueRe
 		if len(data) < 4 {
 			return nil, 0, errors.New("malformed FieldTypeFloat value")
 		}
-		res.value = float32(binary.LittleEndian.Uint32(data[:4]))
+		// IEEE-754 reinterpret, NOT a numeric cast. Same defect that
+		// stmtExecutePacket.go's FieldTypeDouble param carried: the wire
+		// bytes ARE the bit pattern, so float32(uint32(...)) reads 9.99
+		// out as 1.09154e+09. Result-set columns are the other half of
+		// that bug — the bad value lands in mocks.yaml at RECORD time,
+		// so it survives re-recording and cannot be fixed at replay.
+		res.value = math.Float32frombits(binary.LittleEndian.Uint32(data[:4]))
 		return res, 4, nil
 
 	case mysql.FieldTypeDouble:
 		if len(data) < 8 {
 			return nil, 0, errors.New("malformed FieldTypeDouble value")
 		}
-		res.value = float64(binary.LittleEndian.Uint64(data[:8]))
+		// As above: 9.99 was being recorded as 4.6218134880894373e+18.
+		res.value = math.Float64frombits(binary.LittleEndian.Uint64(data[:8]))
 		return res, 8, nil
 
 	case mysql.FieldTypeDate, mysql.FieldTypeNewDate:
@@ -236,14 +245,16 @@ func EncodeBinaryRow(_ context.Context, _ *zap.Logger, row *mysql.BinaryRow, col
 
 		switch ce.Type {
 		case mysql.FieldTypeLong:
+			n, err := coerceToInt64(ce.Value)
+			if err != nil {
+				return nil, fmt.Errorf("column %q: %w", col.Name, err)
+			}
 			if ce.Unsigned {
-				v := uint32(ce.Value.(int))
-				if err := binary.Write(body, binary.LittleEndian, v); err != nil {
+				if err := binary.Write(body, binary.LittleEndian, uint32(n)); err != nil {
 					return nil, err
 				}
 			} else {
-				v := int32(ce.Value.(int))
-				if err := binary.Write(body, binary.LittleEndian, v); err != nil {
+				if err := binary.Write(body, binary.LittleEndian, int32(n)); err != nil {
 					return nil, err
 				}
 			}
@@ -281,51 +292,65 @@ func EncodeBinaryRow(_ context.Context, _ *zap.Logger, row *mysql.BinaryRow, col
 			}
 
 		case mysql.FieldTypeTiny:
+			n, err := coerceToInt64(ce.Value)
+			if err != nil {
+				return nil, fmt.Errorf("column %q: %w", col.Name, err)
+			}
 			if ce.Unsigned {
-				if err := body.WriteByte(uint8(ce.Value.(int))); err != nil {
+				if err := body.WriteByte(uint8(n)); err != nil {
 					return nil, err
 				}
 			} else {
-				if err := body.WriteByte(byte(int8(ce.Value.(int)))); err != nil {
+				if err := body.WriteByte(byte(int8(n))); err != nil {
 					return nil, err
 				}
 			}
 
 		case mysql.FieldTypeShort, mysql.FieldTypeYear:
+			n, err := coerceToInt64(ce.Value)
+			if err != nil {
+				return nil, fmt.Errorf("column %q: %w", col.Name, err)
+			}
 			if ce.Unsigned {
-				v := uint16(ce.Value.(int))
-				if err := binary.Write(body, binary.LittleEndian, v); err != nil {
+				if err := binary.Write(body, binary.LittleEndian, uint16(n)); err != nil {
 					return nil, err
 				}
 			} else {
-				v := int16(ce.Value.(int))
-				if err := binary.Write(body, binary.LittleEndian, v); err != nil {
+				if err := binary.Write(body, binary.LittleEndian, int16(n)); err != nil {
 					return nil, err
 				}
 			}
 
 		case mysql.FieldTypeLongLong:
+			n, err := coerceToInt64(ce.Value)
+			if err != nil {
+				return nil, fmt.Errorf("column %q: %w", col.Name, err)
+			}
 			if ce.Unsigned {
-				v := uint64(ce.Value.(int))
-				if err := binary.Write(body, binary.LittleEndian, v); err != nil {
+				if err := binary.Write(body, binary.LittleEndian, uint64(n)); err != nil {
 					return nil, err
 				}
 			} else {
-				v := int64(ce.Value.(int))
-				if err := binary.Write(body, binary.LittleEndian, v); err != nil {
+				if err := binary.Write(body, binary.LittleEndian, n); err != nil {
 					return nil, err
 				}
 			}
 
 		case mysql.FieldTypeFloat:
-			v := float32(ce.Value.(float32))
-			if err := binary.Write(body, binary.LittleEndian, v); err != nil {
+			f, err := coerceToFloat64(ce.Value)
+			if err != nil {
+				return nil, fmt.Errorf("column %q: %w", col.Name, err)
+			}
+			if err := binary.Write(body, binary.LittleEndian, float32(f)); err != nil {
 				return nil, err
 			}
 
 		case mysql.FieldTypeDouble:
-			v := float64(ce.Value.(float64))
-			if err := binary.Write(body, binary.LittleEndian, v); err != nil {
+			f, err := coerceToFloat64(ce.Value)
+			if err != nil {
+				return nil, fmt.Errorf("column %q: %w", col.Name, err)
+			}
+			if err := binary.Write(body, binary.LittleEndian, f); err != nil {
 				return nil, err
 			}
 
@@ -364,6 +389,100 @@ func writeLenEncBytes(buf *bytes.Buffer, b []byte) error {
 	}
 	_, err := buf.Write(b)
 	return err
+}
+
+// coerceToInt64 / coerceToFloat64 exist because ce.Value is an
+// interface{} that has been through a serializer, and no serializer
+// preserves Go's numeric types.
+//
+// YAML (mocks.yaml, the OSS record/replay store) resolves an untagged
+// scalar by shape, not by the column's declared FieldType: `9.99` comes
+// back float64 and `10` comes back int — so a FieldTypeFloat column
+// yields float64, and a FieldTypeDouble column whose value happens to be
+// integral yields int. JSON is worse: encoding/json gives float64 for
+// every number.
+//
+// The old code type-asserted nakedly (`ce.Value.(float32)`), which
+// panics rather than errors. A panic here is not a failed row, it tears
+// down the proxy's connection handler and the application under replay
+// sees "invalid connection" with nothing pointing at the cause.
+//
+// pkg/models/mysql.coerceValueForFieldType solves the same problem for
+// the JSON path. It cannot be reused here without an import cycle, and
+// it does not cover the YAML path at all — which is the one the OSS
+// binary actually uses.
+func coerceToInt64(v interface{}) (int64, error) {
+	switch t := v.(type) {
+	case int:
+		return int64(t), nil
+	case int8:
+		return int64(t), nil
+	case int16:
+		return int64(t), nil
+	case int32:
+		return int64(t), nil
+	case int64:
+		return t, nil
+	case uint:
+		return int64(t), nil
+	case uint8:
+		return int64(t), nil
+	case uint16:
+		return int64(t), nil
+	case uint32:
+		return int64(t), nil
+	case uint64:
+		// Wraps for values above MaxInt64. That is intended: the caller
+		// immediately narrows to uint32/uint64 for the unsigned branch,
+		// so the bit pattern is what survives, not the sign.
+		return int64(t), nil
+	case float32:
+		return int64(t), nil
+	case float64:
+		return int64(t), nil
+	default:
+		return 0, fmt.Errorf("cannot coerce %T to integer", v)
+	}
+}
+
+func coerceToFloat64(v interface{}) (float64, error) {
+	switch t := v.(type) {
+	case float64:
+		return t, nil
+	case float32:
+		// Widen through the shortest decimal form. float64(float32(9.99))
+		// is 9.989999771118164; parsing "9.99" back gives the float64 a
+		// human wrote down. Narrowing to float32 later is exact either
+		// way, but DOUBLE columns holding a float32 must not inherit the
+		// float32 representation error.
+		return strconv.ParseFloat(strconv.FormatFloat(float64(t), 'g', -1, 32), 64)
+	case int:
+		return float64(t), nil
+	case int8:
+		return float64(t), nil
+	case int16:
+		return float64(t), nil
+	case int32:
+		return float64(t), nil
+	case int64:
+		return float64(t), nil
+	case uint:
+		return float64(t), nil
+	case uint8:
+		return float64(t), nil
+	case uint16:
+		return float64(t), nil
+	case uint32:
+		return float64(t), nil
+	case uint64:
+		return float64(t), nil
+	case string:
+		// DECIMAL-typed values recorded before a schema change, and any
+		// path that stringified the scalar.
+		return strconv.ParseFloat(t, 64)
+	default:
+		return 0, fmt.Errorf("cannot coerce %T to float", v)
+	}
 }
 
 // accepts string, []byte, time.Time, or fmt.Stringer; returns a normalized string.

--- a/pkg/agent/proxy/integrations/mysql/wire/phase/query/rowscols/binaryProtocolRowPacket.go
+++ b/pkg/agent/proxy/integrations/mysql/wire/phase/query/rowscols/binaryProtocolRowPacket.go
@@ -393,24 +393,22 @@ func writeLenEncBytes(buf *bytes.Buffer, b []byte) error {
 
 // coerceToInt64 / coerceToFloat64 exist because ce.Value is an
 // interface{} that has been through a serializer, and no serializer
-// preserves Go's numeric types.
+// preserves Go's numeric types. yaml.v3 resolves an untagged scalar by
+// its shape rather than by the column's declared FieldType: `9.99`
+// comes back float64 and `10` comes back int, so a FieldTypeFloat
+// column yields float64 and an integral FieldTypeDouble yields int.
 //
-// YAML (mocks.yaml, the OSS record/replay store) resolves an untagged
-// scalar by shape, not by the column's declared FieldType: `9.99` comes
-// back float64 and `10` comes back int — so a FieldTypeFloat column
-// yields float64, and a FieldTypeDouble column whose value happens to be
-// integral yields int. JSON is worse: encoding/json gives float64 for
-// every number.
+// Type-asserting instead (`ce.Value.(float32)`) panics rather than
+// errors, and a panic here is not a failed row — it tears down the
+// proxy's connection handler, so the application under replay sees
+// "invalid connection" with nothing pointing at the cause.
 //
-// The old code type-asserted nakedly (`ce.Value.(float32)`), which
-// panics rather than errors. A panic here is not a failed row, it tears
-// down the proxy's connection handler and the application under replay
-// sees "invalid connection" with nothing pointing at the cause.
-//
-// pkg/models/mysql.coerceValueForFieldType solves the same problem for
-// the JSON path. It cannot be reused here without an import cycle, and
-// it does not cover the YAML path at all — which is the one the OSS
-// binary actually uses.
+// pkg/models/mysql.coerceValueForFieldType is a different job, not a
+// duplicate: it restores the Go type a JSON-recorded value should have
+// had (which decides what fmt.Sprint writes for a text-protocol row),
+// and it only runs on the JSON mock format. These two run on every
+// format and answer the narrower question of what integer or float the
+// binary encoder should write.
 func coerceToInt64(v interface{}) (int64, error) {
 	switch t := v.(type) {
 	case int:
@@ -437,12 +435,45 @@ func coerceToInt64(v interface{}) (int64, error) {
 		// so the bit pattern is what survives, not the sign.
 		return int64(t), nil
 	case float32:
-		return int64(t), nil
+		return exactInt64(float64(t))
 	case float64:
-		return int64(t), nil
+		return exactInt64(t)
 	default:
 		return 0, fmt.Errorf("cannot coerce %T to integer", v)
 	}
+}
+
+// exactInt64 converts only when the float names an integer that int64
+// can hold. Go leaves an out-of-range float→int conversion
+// implementation-defined — on amd64 it saturates to MinInt64, so
+// 1e300 and 1.8e19 both land on the same value and a corrupt mock
+// replays as a plausible-looking wrong number instead of an error.
+// Values above MaxInt64 that are genuinely wanted (BIGINT UNSIGNED)
+// reach the unsigned branch as uint64, not as a float.
+//
+// Erroring here is a deliberate trade and it is not free: the caller
+// fails the whole response, which drops the connection rather than the
+// row. A mock written by a keploy old enough to have stored the value
+// as a float (18446744073709551615 re-marshalled as
+// 1.8446744073709552e+19) is above MaxUint64 and unrecoverable — there
+// is no original left to encode. Replaying it as a different number
+// would be silent, undetectable corruption in a tool whose whole job
+// is fidelity, so the error names the column and says what to do. It
+// surfaces several frames up, where replayer/conn.go logs it and closes
+// the connection — the intermediate wrappers only add context.
+func exactInt64(f float64) (int64, error) {
+	if math.IsNaN(f) || math.IsInf(f, 0) || f != math.Trunc(f) {
+		return 0, fmt.Errorf("cannot coerce %v to integer: not a whole number; re-record this mock", f)
+	}
+	// 2^63 exactly. float64(math.MaxInt64) rounds *up* to this, so the
+	// upper bound has to be exclusive against 2^63 rather than
+	// inclusive against MaxInt64.
+	const twoPow63 = 9223372036854775808.0
+	if f < -twoPow63 || f >= twoPow63 {
+		return 0, fmt.Errorf("cannot coerce %v to integer: out of int64 range, "+
+			"the recorded value has already lost precision; re-record this mock", f)
+	}
+	return int64(f), nil
 }
 
 func coerceToFloat64(v interface{}) (float64, error) {
@@ -450,12 +481,7 @@ func coerceToFloat64(v interface{}) (float64, error) {
 	case float64:
 		return t, nil
 	case float32:
-		// Widen through the shortest decimal form. float64(float32(9.99))
-		// is 9.989999771118164; parsing "9.99" back gives the float64 a
-		// human wrote down. Narrowing to float32 later is exact either
-		// way, but DOUBLE columns holding a float32 must not inherit the
-		// float32 representation error.
-		return strconv.ParseFloat(strconv.FormatFloat(float64(t), 'g', -1, 32), 64)
+		return float64(t), nil
 	case int:
 		return float64(t), nil
 	case int8:

--- a/pkg/agent/proxy/integrations/mysql/wire/phase/query/rowscols/binaryProtocolRowPacket_coerce_test.go
+++ b/pkg/agent/proxy/integrations/mysql/wire/phase/query/rowscols/binaryProtocolRowPacket_coerce_test.go
@@ -1,0 +1,135 @@
+package rowscols
+
+import (
+	"math"
+	"testing"
+)
+
+// coerceToInt64 is handed whatever a serializer produced for an
+// integer column. When that is a float it cannot represent exactly,
+// converting anyway is implementation-defined in Go and saturates on
+// amd64 — 1e300 and 1.8e19 both become MinInt64, which the unsigned
+// branch then writes as a real-looking row value. Erroring keeps a
+// corrupt mock from replaying as a plausible wrong number.
+func TestCoerceToInt64RejectsUnrepresentableFloats(t *testing.T) {
+	for _, v := range []interface{}{
+		float64(1e300),
+		float64(-1e300),
+		float64(math.MaxUint64),
+		float64(9.5),
+		math.NaN(),
+		math.Inf(1),
+		math.Inf(-1),
+		float32(1e30),
+		float32(0.5),
+	} {
+		if got, err := coerceToInt64(v); err == nil {
+			t.Errorf("coerceToInt64(%T %v) = %d, want an error", v, v, got)
+		}
+	}
+}
+
+func TestCoerceToInt64AcceptsRepresentableFloats(t *testing.T) {
+	cases := []struct {
+		in   interface{}
+		want int64
+	}{
+		{float64(0), 0},
+		{float64(42), 42},
+		{float64(-42), -42},
+		{float64(1 << 53), 1 << 53},
+		{float32(2), 2},
+		{float32(-7), -7},
+	}
+	for _, c := range cases {
+		got, err := coerceToInt64(c.in)
+		if err != nil {
+			t.Errorf("coerceToInt64(%T %v): %v", c.in, c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("coerceToInt64(%T %v) = %d, want %d", c.in, c.in, got, c.want)
+		}
+	}
+}
+
+// BIGINT UNSIGNED above MaxInt64 arrives as uint64, not as a float,
+// and has to keep its bit pattern through the signed intermediate.
+func TestCoerceToInt64PreservesUint64BitPattern(t *testing.T) {
+	for _, want := range []uint64{math.MaxUint64, math.MaxUint64 - 1, math.MaxInt64 + 1} {
+		got, err := coerceToInt64(want)
+		if err != nil {
+			t.Fatalf("coerceToInt64(uint64 %d): %v", want, err)
+		}
+		if uint64(got) != want {
+			t.Errorf("coerceToInt64(uint64 %d) round-tripped to %d", want, uint64(got))
+		}
+	}
+}
+
+// coerceToFloat64 widens a float32 by plain conversion, NOT by routing
+// it through its shortest decimal form. Asserting the narrowing round
+// trip alone would pass either way — float32→shortest-decimal→float64
+// is exact by construction — so pin the widened value itself.
+func TestCoerceToFloat64WidensFloat32ByConversion(t *testing.T) {
+	got, err := coerceToFloat64(float32(9.99))
+	if err != nil {
+		t.Fatalf("coerceToFloat64(float32 9.99): %v", err)
+	}
+	// float64(float32(9.99)), not the 9.99 a human wrote.
+	if want := 9.989999771118164; got != want {
+		t.Errorf("coerceToFloat64(float32 9.99) = %v, want %v", got, want)
+	}
+
+	// Whatever the widening, narrowing back at the FLOAT encode site
+	// must be exact.
+	for _, want := range []float32{9.99, -0.1, 0, 3.4e38, 1e-9} {
+		got, err := coerceToFloat64(want)
+		if err != nil {
+			t.Fatalf("coerceToFloat64(float32 %v): %v", want, err)
+		}
+		if float32(got) != want {
+			t.Errorf("coerceToFloat64(float32 %v) = %v, narrows back to %v", want, got, float32(got))
+		}
+	}
+}
+
+// The bound exactInt64 exists to get right: exclusive against 2^63
+// rather than inclusive against MaxInt64, because float64(MaxInt64)
+// rounds up to 2^63 and so never names MaxInt64 itself. Without these,
+// relaxing the check to `f > float64(math.MaxInt64)` keeps the suite
+// green while letting an out-of-range value through.
+func TestExactInt64Boundaries(t *testing.T) {
+	const twoPow63 = 9223372036854775808.0
+
+	accept := []struct {
+		in   float64
+		want int64
+	}{
+		{-twoPow63, math.MinInt64},                   // exactly representable
+		{9223372036854774784.0, 9223372036854774784}, // largest float64 below 2^63
+		{0, 0},
+		{-1, -1},
+	}
+	for _, c := range accept {
+		got, err := exactInt64(c.in)
+		if err != nil {
+			t.Errorf("exactInt64(%v): unexpected error %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("exactInt64(%v) = %d, want %d", c.in, got, c.want)
+		}
+	}
+
+	reject := []float64{
+		twoPow63,               // == float64(math.MaxInt64); not representable as int64
+		float64(math.MaxInt64), // the same value, spelled the way a reader expects
+		-twoPow63 - 2048,       // first float64 step below MinInt64
+	}
+	for _, f := range reject {
+		if got, err := exactInt64(f); err == nil {
+			t.Errorf("exactInt64(%v) = %d, want an error", f, got)
+		}
+	}
+}

--- a/pkg/agent/proxy/integrations/mysql/wire/phase/query/rowscols/binaryProtocolRowPacket_float_test.go
+++ b/pkg/agent/proxy/integrations/mysql/wire/phase/query/rowscols/binaryProtocolRowPacket_float_test.go
@@ -1,0 +1,193 @@
+package rowscols
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models/mysql"
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+)
+
+// FLOAT and DOUBLE result-set columns carried two independent defects that
+// together made any schema with a real-typed column unusable.
+//
+//  1. RECORD side: readBinaryValue cast the wire bytes numerically
+//     (float64(binary.LittleEndian.Uint64(...))) instead of reinterpreting
+//     them as an IEEE-754 bit pattern. A DOUBLE column holding 9.99 was
+//     written to mocks.yaml as 4.621813488089437e+18. Because the damage
+//     happens at record time it survives into the artifact — re-recording
+//     does not help, and nothing downstream can recover the original.
+//
+//  2. REPLAY side: EncodeBinaryRow type-asserted ce.Value.(float32) for
+//     FieldTypeFloat. Values arrive from a serializer, and YAML resolves an
+//     untagged scalar by shape: "9.99" is float64, "10" is int. Neither is
+//     float32, so the assertion panicked. That panic is not a failed row —
+//     it unwinds the connection handler and the application under replay
+//     sees "invalid connection" with nothing naming the cause.
+//
+// The two interact: DOUBLE's assertion (.(float64)) happened to succeed on
+// YAML's float64, so DOUBLE corrupted silently while FLOAT crashed loudly.
+// That asymmetry is why the record-side bug went unnoticed.
+
+// buildBinaryRow lays out a binary protocol result-set row:
+// 4-byte header, 0x00 marker, null bitmap, then packed column values.
+func buildBinaryRow(t *testing.T, values []byte, numCols int) []byte {
+	t.Helper()
+	bitmapLen := (numCols + 7 + 2) / 8
+	body := make([]byte, 0, 1+bitmapLen+len(values))
+	body = append(body, 0x00)                       // packet header marker
+	body = append(body, make([]byte, bitmapLen)...) // no NULLs
+	body = append(body, values...)
+
+	pkt := make([]byte, 4, 4+len(body))
+	pkt[0] = byte(len(body))
+	pkt[1] = byte(len(body) >> 8)
+	pkt[2] = byte(len(body) >> 16)
+	pkt[3] = 1 // sequence id
+	return append(pkt, body...)
+}
+
+func floatCols() []*mysql.ColumnDefinition41 {
+	return []*mysql.ColumnDefinition41{
+		{Name: "price", Type: byte(mysql.FieldTypeFloat)},
+		{Name: "ratio", Type: byte(mysql.FieldTypeDouble)},
+	}
+}
+
+// TestDecodeBinaryRow_FloatDoubleAreBitPatterns pins the record-side fix.
+// The literals are the exact corruptions observed before it: MySQL sending
+// 9.99 produced 1.0926057e+09 for FLOAT and 4.621813488089437e+18 for
+// DOUBLE, which is what the uint bit pattern reads as when cast as a number.
+func TestDecodeBinaryRow_FloatDoubleAreBitPatterns(t *testing.T) {
+	const wantF32 = float32(9.99)
+	const wantF64 = float64(9.99)
+
+	vals := make([]byte, 12)
+	binary.LittleEndian.PutUint32(vals[0:4], math.Float32bits(wantF32))
+	binary.LittleEndian.PutUint64(vals[4:12], math.Float64bits(wantF64))
+
+	row, _, err := DecodeBinaryRow(context.Background(), zap.NewNop(),
+		buildBinaryRow(t, vals, 2), floatCols())
+	if err != nil {
+		t.Fatalf("DecodeBinaryRow: %v", err)
+	}
+
+	got32, ok := row.Values[0].Value.(float32)
+	if !ok {
+		t.Fatalf("FLOAT: expected float32, got %T", row.Values[0].Value)
+	}
+	if got32 != wantF32 {
+		t.Errorf("FLOAT: got %v, want %v (numeric cast would give 1.0926057e+09)", got32, wantF32)
+	}
+
+	got64, ok := row.Values[1].Value.(float64)
+	if !ok {
+		t.Fatalf("DOUBLE: expected float64, got %T", row.Values[1].Value)
+	}
+	if got64 != wantF64 {
+		t.Errorf("DOUBLE: got %v, want %v (numeric cast would give 4.621813488089437e+18)", got64, wantF64)
+	}
+}
+
+// TestEncodeBinaryRow_SurvivesYAMLRoundTrip pins the replay-side fix, through
+// the serializer that actually causes it. Encoding the in-memory row is not
+// enough: the bug only appears once the row has been through mocks.yaml,
+// because that is what erases float32 and collapses 10.0 to an int.
+func TestEncodeBinaryRow_SurvivesYAMLRoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		f32  float32
+		f64  float64
+	}{
+		// Fractional: YAML keeps a decimal point, so both come back float64.
+		{"fractional", 9.99, 9.99},
+		// Whole: yaml.v3 emits float64(10) as "10", which resolves back to
+		// int, not float64. The DOUBLE assertion panicked here too.
+		{"whole", 10, 10},
+		// Negative and zero, for the sign bit and the all-zero bit pattern.
+		{"negative", -0.5, -1234.5678},
+		{"zero", 0, 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			vals := make([]byte, 12)
+			binary.LittleEndian.PutUint32(vals[0:4], math.Float32bits(tc.f32))
+			binary.LittleEndian.PutUint64(vals[4:12], math.Float64bits(tc.f64))
+			wire := buildBinaryRow(t, vals, 2)
+
+			row, _, err := DecodeBinaryRow(context.Background(), zap.NewNop(), wire, floatCols())
+			if err != nil {
+				t.Fatalf("DecodeBinaryRow: %v", err)
+			}
+
+			// The round trip through the mock store.
+			blob, err := yaml.Marshal(row)
+			if err != nil {
+				t.Fatalf("yaml.Marshal: %v", err)
+			}
+			var restored mysql.BinaryRow
+			if err := yaml.Unmarshal(blob, &restored); err != nil {
+				t.Fatalf("yaml.Unmarshal: %v", err)
+			}
+
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("EncodeBinaryRow panicked on YAML-restored row: %v\nyaml was:\n%s", r, blob)
+				}
+			}()
+
+			got, err := EncodeBinaryRow(context.Background(), zap.NewNop(), &restored, floatCols())
+			if err != nil {
+				t.Fatalf("EncodeBinaryRow: %v\nyaml was:\n%s", err, blob)
+			}
+			if !bytes.Equal(got, wire) {
+				t.Errorf("wire bytes changed across record/store/replay:\n got %x\nwant %x\nyaml was:\n%s",
+					got, wire, blob)
+			}
+		})
+	}
+}
+
+// TestEncodeBinaryRow_IntegerColumnsSurviveYAML covers the same serializer
+// hazard on the integer columns, which used a naked ce.Value.(int). YAML
+// happens to give int for small integers, so these did not panic in practice
+// — but a BIGINT UNSIGNED above MaxInt64 resolves to uint64 and did.
+func TestEncodeBinaryRow_IntegerColumnsSurviveYAML(t *testing.T) {
+	cols := []*mysql.ColumnDefinition41{
+		{Name: "big", Type: byte(mysql.FieldTypeLongLong), Flags: 0x0020}, // UNSIGNED_FLAG
+	}
+	vals := make([]byte, 8)
+	binary.LittleEndian.PutUint64(vals, math.MaxUint64-1)
+	wire := buildBinaryRow(t, vals, 1)
+
+	row, _, err := DecodeBinaryRow(context.Background(), zap.NewNop(), wire, cols)
+	if err != nil {
+		t.Fatalf("DecodeBinaryRow: %v", err)
+	}
+	blob, err := yaml.Marshal(row)
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+	var restored mysql.BinaryRow
+	if err := yaml.Unmarshal(blob, &restored); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("EncodeBinaryRow panicked on BIGINT UNSIGNED: %v\nyaml was:\n%s", r, blob)
+		}
+	}()
+	got, err := EncodeBinaryRow(context.Background(), zap.NewNop(), &restored, cols)
+	if err != nil {
+		t.Fatalf("EncodeBinaryRow: %v\nyaml was:\n%s", err, blob)
+	}
+	if !bytes.Equal(got, wire) {
+		t.Errorf("wire bytes changed:\n got %x\nwant %x\nyaml was:\n%s", got, wire, blob)
+	}
+}

--- a/pkg/models/mysql/json.go
+++ b/pkg/models/mysql/json.go
@@ -31,6 +31,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"math"
 	"time"
 )
 
@@ -93,15 +94,12 @@ func (c *ColumnEntry) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return fmt.Errorf("ColumnEntry value: %w", err)
 	}
-	// Coerce based on the column's FieldType so the integrations-side
-	// wire encoder's strict `.(int) / .(float32) / .(float64)` type
-	// assertions in binaryProtocolRowPacket.go can succeed. Without
-	// this, a JSON-recorded float64(42.0) round-trips as `42` (Go's
-	// json.Marshal strips trailing zeros), then UnmarshalJSON
-	// recovers int(42), then the encoder's `.(float64)` assertion
-	// for FieldTypeDouble panics. The coercer doesn't help if the
-	// recorder put a non-numeric value in a numeric-typed column —
-	// that's a real bug in the recorder, not a JSON-roundtrip issue.
+	// Restore the concrete Go type the column's FieldType implies.
+	// json.Marshal strips trailing zeros, so a recorded float64(42.0)
+	// is written as `42` and recovered as int(42) — a DOUBLE column
+	// whose value is integral changes Go type across the round trip.
+	// That drift ends up back on disk, because UpdateMocks re-serializes
+	// what it decodes; see coerceValueForFieldType.
 	c.Value = coerceValueForFieldType(v, c.Type)
 	return nil
 }
@@ -211,22 +209,35 @@ func recoverJSONValue(raw any) (any, error) {
 	case bool:
 		return x, nil
 	case json.Number:
-		// Match yaml.v3's reflective default for !!int into
-		// interface{}: it returns Go `int`, NOT int64. The
-		// integrations-side wire encoder (binaryProtocolRowPacket.go
-		// line ~297) does `ce.Value.(int)` for FieldTypeLongLong
-		// and friends — an int64 there panics the encoder, the
-		// MySQL parser recovers but the connection is dropped, and
-		// the fuzzer reports `query execution failed: invalid
-		// connection` on every subsequent op. Return int when the
-		// integer literal fits, fall back to int64 only for values
-		// outside int's range (32-bit hosts; modern keploy runs on
-		// 64-bit so this branch is empty in practice).
+		// Mirror yaml.v3's reflective default for !!int into
+		// interface{}: Go `int` when the literal fits, int64 above
+		// that (32-bit hosts; empty in practice on 64-bit), and
+		// uint64 for an integer literal that overflows int64.
+		//
+		// The uint64 rung matters: a BIGINT UNSIGNED above MaxInt64
+		// fails Int64(), and falling straight through to Float64()
+		// loses every bit below 2^11 — 18446744073709551614 and
+		// 9223372036854775808 both landed on the same float64 and
+		// then on the same wrong integer. yaml.v3 already yields
+		// uint64 here, so this is also what keeps the two mock
+		// formats agreeing on the same Go type.
 		if i, err := x.Int64(); err == nil {
 			if int64(int(i)) == i {
 				return int(i), nil
 			}
 			return i, nil
+		}
+		// Decoded as a JSON number rather than with strconv, to stay
+		// symmetric with the rest of this file: x is a JSON token, and
+		// encoding/json is what defines whether it names an integer.
+		// Behaviour matches strconv.ParseUint(s, 10, 64) exactly for
+		// every form reachable here — it accepts a plain integer
+		// literal up to MaxUint64 and rejects signed, fractional,
+		// exponent and overflowing forms, all of which fall through to
+		// the float64 rung below.
+		var u uint64
+		if err := json.Unmarshal([]byte(x), &u); err == nil {
+			return u, nil
 		}
 		f, err := x.Float64()
 		if err != nil {
@@ -287,27 +298,37 @@ func decodeBinaryValue(v any) ([]byte, error) {
 	return b, nil
 }
 
-// coerceValueForFieldType narrows a recovered any-typed value into the
-// concrete Go type the integrations-side wire encoder type-asserts on.
-// The mapping is taken straight from
-// pkg/agent/proxy/integrations/mysql/wire/phase/query/rowscols/binaryProtocolRowPacket.go:
+// coerceValueForFieldType restores the concrete Go type that the
+// column's FieldType implies, so that a value recovered from JSON has
+// the same Go type it would have had coming off the wire or out of
+// YAML:
 //
-//	FieldTypeTiny / Short / Year / Long / LongLong / Int24
-//	    encoder uses ce.Value.(int)
-//	FieldTypeFloat
-//	    encoder uses ce.Value.(float32)
-//	FieldTypeDouble
-//	    encoder uses ce.Value.(float64)
+//	FieldTypeTiny / Short / Year / Long / LongLong / Int24 → int
+//	FieldTypeFloat                                         → float32
+//	FieldTypeDouble                                        → float64
 //
-// Unsigned columns share the same Go type — the encoder casts after
-// asserting (`uint32(ce.Value.(int))`), so the unsigned bit doesn't
-// change the expected primitive type.
+// No wire encoder depends on this any more: the binary-row encoder
+// coerces whatever it is handed, and text rows are length-encoded
+// strings on the wire, so DecodeTextRow stores every value as a string
+// and this function passes strings through untouched.
 //
-// String / BLOB / Date-Time columns are left as-is: the encoder for
-// those types accepts a wider type set (string for string-likes,
-// []byte or string for blobs, time.Time / string for date-times) and
-// my MarshalJSON already preserves the Go type through the
-// round-trip ([]byte / time.Time go through the $type envelope).
+// What still depends on it is the mock file itself. MockYaml.UpdateMocks
+// is a read-modify-write — it decodes every mock, drops the unused ones,
+// and writes the survivors back over the user's file (see
+// pkg/platform/yaml/mockdb/db.go). So whatever Go type comes out of here
+// is the type that gets re-serialized onto disk. Letting a DOUBLE column
+// come back as an int would rewrite `9.0` as `9` in a file users keep in
+// git, and would keep drifting on every subsequent run.
+//
+// Unsigned columns share the same Go type; the unsigned bit selects
+// the wire width at encode time, not the Go type here. An integer
+// literal above MaxInt64 arrives as uint64 (see recoverJSONValue) and
+// is left alone — narrowing it to int is exactly the corruption that
+// rung exists to prevent.
+//
+// String / BLOB / Date-Time columns are left as-is: MarshalJSON
+// already preserves their Go type through the round trip ([]byte and
+// time.Time go through the $type envelope).
 func coerceValueForFieldType(v any, ftype FieldType) any {
 	if v == nil {
 		return nil
@@ -319,11 +340,38 @@ func coerceValueForFieldType(v any, ftype FieldType) any {
 		case int:
 			return x
 		case int64:
-			return int(x)
+			// recoverJSONValue only yields int64 when the literal did
+			// not fit int, which is a 32-bit host. Narrowing anyway
+			// would truncate exactly the value that rung exists to
+			// preserve, so leave it wide when it does not fit.
+			//
+			// Bounds first, conversion second. `int64(int(x)) == x`
+			// would round-trip through the very conversion being
+			// tested, which is implementation-defined when out of
+			// range — the same mistake exactInt exists to avoid.
+			if x >= math.MinInt && x <= math.MaxInt {
+				return int(x)
+			}
+			return x
+		case uint64:
+			// Above MaxInt64. Leave the width alone; the encoder
+			// narrows to the column's wire width and keeps the bits.
+			return x
 		case float64:
-			return int(x)
+			if n, ok := exactInt(x); ok {
+				return n
+			}
+			// Not integral, or outside int's range. Converting anyway is
+			// implementation-defined in Go and saturates to MinInt on
+			// amd64, which turns a corrupt mock into a plausible-looking
+			// wrong number. Hand it on untouched and let the encoder's
+			// coercion reject it by name.
+			return x
 		case float32:
-			return int(x)
+			if n, ok := exactInt(float64(x)); ok {
+				return n
+			}
+			return x
 		}
 	case FieldTypeFloat:
 		switch x := v.(type) {
@@ -334,6 +382,12 @@ func coerceValueForFieldType(v any, ftype FieldType) any {
 		case int:
 			return float32(x)
 		case int64:
+			return float32(x)
+		case uint64:
+			// Reachable, not defensive: encoding/json writes a float64
+			// in 'f' format for any magnitude below 1e21, so a DOUBLE
+			// holding 1e19 is marshalled as the integer literal
+			// 10000000000000000000 and recovered as uint64.
 			return float32(x)
 		}
 	case FieldTypeDouble:
@@ -346,9 +400,42 @@ func coerceValueForFieldType(v any, ftype FieldType) any {
 			return float64(x)
 		case int64:
 			return float64(x)
+		case uint64:
+			// See the FieldTypeFloat arm above.
+			return float64(x)
 		}
 	}
 	return v
+}
+
+// exactInt reports whether f names an integer that survives the trip
+// through int without loss. Go leaves an out-of-range float→int
+// conversion implementation-defined, so the range has to be checked
+// before the conversion, not after.
+//
+// There are two conversions here and each needs its own bound.
+//
+// float64 -> int64 is bounded in float space, because 2^63 is the first
+// float64 at or above MaxInt64 (float64(MaxInt64) itself rounds *up* to
+// it), so MaxInt64 is unreachable from a float64 and the top bound has
+// to be exclusive against 2^63 rather than inclusive against MaxInt64.
+//
+// int64 -> int is then bounded in integer space. On a 64-bit host that
+// second bound cannot fire; on a 32-bit one it is the only thing
+// standing between a perfectly valid float64 and a truncated int.
+func exactInt(f float64) (int, bool) {
+	if math.IsNaN(f) || math.IsInf(f, 0) || f != math.Trunc(f) {
+		return 0, false
+	}
+	const twoPow63 = 9223372036854775808.0
+	if f < -twoPow63 || f >= twoPow63 {
+		return 0, false
+	}
+	n := int64(f)
+	if n < math.MinInt || n > math.MaxInt {
+		return 0, false
+	}
+	return int(n), true
 }
 
 func decodeTimestampValue(v any) (time.Time, error) {

--- a/pkg/models/mysql/json_bigint_test.go
+++ b/pkg/models/mysql/json_bigint_test.go
@@ -1,0 +1,181 @@
+package mysql
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+)
+
+// A BIGINT UNSIGNED above MaxInt64 fails json.Number.Int64(). Falling
+// straight through to Float64() from there keeps only the top 53 bits,
+// and coercing that float back to an integer is implementation-defined
+// in Go — on amd64 it saturates, so every value above MaxInt64 landed
+// on the same wrong number. yaml.v3 yields uint64 for these, so the
+// JSON mock format has to as well or the two formats replay the same
+// mock as different rows.
+func TestColumnEntryJSONBigintUnsignedKeepsValue(t *testing.T) {
+	for _, want := range []uint64{
+		math.MaxInt64 + 1,
+		math.MaxUint64 - 1,
+		math.MaxUint64,
+		18446744073709551000,
+	} {
+		in := ColumnEntry{Type: FieldTypeLongLong, Name: "big", Value: want, Unsigned: true}
+		blob, err := json.Marshal(in)
+		if err != nil {
+			t.Fatalf("marshal %d: %v", want, err)
+		}
+		var out ColumnEntry
+		if err := json.Unmarshal(blob, &out); err != nil {
+			t.Fatalf("unmarshal %s: %v", blob, err)
+		}
+		got, ok := out.Value.(uint64)
+		if !ok {
+			t.Fatalf("%d: got %v (%T), want a uint64 — json was %s",
+				want, out.Value, out.Value, blob)
+		}
+		if got != want {
+			t.Errorf("%d: round-tripped to %d — json was %s", want, got, blob)
+		}
+	}
+}
+
+// Two distinct BIGINT UNSIGNED values must not collapse onto each
+// other. The saturating int conversion made 18446744073709551614 and
+// 9223372036854775808 both become -9223372036854775808. Note this
+// property is restored by the exactInt guard alone — it passes with a
+// float64 on both sides too. TestColumnEntryJSONBigintUnsignedKeepsValue
+// is what pins the uint64 rung itself.
+func TestColumnEntryJSONBigintUnsignedStaysDistinct(t *testing.T) {
+	roundTrip := func(v uint64) any {
+		t.Helper()
+		blob, err := json.Marshal(ColumnEntry{Type: FieldTypeLongLong, Value: v, Unsigned: true})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var out ColumnEntry
+		if err := json.Unmarshal(blob, &out); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		return out.Value
+	}
+
+	a := roundTrip(math.MaxUint64 - 1)
+	b := roundTrip(math.MaxInt64 + 1)
+	if a == b {
+		t.Errorf("distinct BIGINT UNSIGNED values collapsed onto %v", a)
+	}
+}
+
+// An integer literal that still fits int must keep its existing Go
+// type — the uint64 rung is a fallback, not a replacement. Bounds are
+// spelled at int32 width so the file still compiles on a 32-bit host;
+// json_test.go covers the MaxInt64 case on 64-bit.
+func TestColumnEntryJSONInRangeIntegerStaysInt(t *testing.T) {
+	for _, want := range []int{0, 1, -1, math.MaxInt32, math.MinInt32} {
+		blob, err := json.Marshal(ColumnEntry{Type: FieldTypeLongLong, Value: want})
+		if err != nil {
+			t.Fatalf("marshal %d: %v", want, err)
+		}
+		var out ColumnEntry
+		if err := json.Unmarshal(blob, &out); err != nil {
+			t.Fatalf("unmarshal %s: %v", blob, err)
+		}
+		got, ok := out.Value.(int)
+		if !ok {
+			t.Fatalf("%d: got %v (%T), want int", want, out.Value, out.Value)
+		}
+		if got != want {
+			t.Errorf("%d: round-tripped to %d", want, got)
+		}
+	}
+}
+
+// coerceValueForFieldType must not narrow a float it cannot represent
+// as an int. Saturating here invents a plausible-looking number; the
+// value is passed through instead so the wire encoder can reject it by
+// column name.
+func TestCoerceValueForFieldTypeLeavesUnrepresentableFloats(t *testing.T) {
+	for _, v := range []float64{1e300, -1e300, 9.5, math.NaN(), math.Inf(1)} {
+		got := coerceValueForFieldType(v, FieldTypeLongLong)
+		if _, narrowed := got.(int); narrowed {
+			t.Errorf("%v was narrowed to int %v, want passed through", v, got)
+		}
+	}
+	// Integral and in range still narrows, as before.
+	if got := coerceValueForFieldType(float64(42), FieldTypeLongLong); got != 42 {
+		t.Errorf("float64(42) coerced to %v (%T), want int 42", got, got)
+	}
+}
+
+// encoding/json writes a float64 in 'f' format for any magnitude below
+// 1e21, so a DOUBLE column holding 1e19 is marshalled as the integer
+// literal 10000000000000000000 — above MaxInt64, so recoverJSONValue
+// hands back a uint64. The FLOAT/DOUBLE arms have to accept that or the
+// column silently changes Go type across the round trip and gets
+// re-serialized as an integer by UpdateMocks.
+func TestColumnEntryJSONLargeDoubleStaysFloat(t *testing.T) {
+	for _, ftype := range []FieldType{FieldTypeDouble, FieldTypeFloat} {
+		blob, err := json.Marshal(ColumnEntry{Type: ftype, Name: "d", Value: 1e19})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if want := `1e+19`; string(blob) == want {
+			t.Fatalf("premise broken: encoding/json wrote %s, expected an integer literal", blob)
+		}
+
+		var out ColumnEntry
+		if err := json.Unmarshal(blob, &out); err != nil {
+			t.Fatalf("unmarshal %s: %v", blob, err)
+		}
+		switch ftype {
+		case FieldTypeDouble:
+			got, ok := out.Value.(float64)
+			if !ok {
+				t.Errorf("DOUBLE: got %v (%T), want float64 — json was %s", out.Value, out.Value, blob)
+			} else if got != 1e19 {
+				t.Errorf("DOUBLE: got %v, want 1e19", got)
+			}
+		case FieldTypeFloat:
+			if _, ok := out.Value.(float32); !ok {
+				t.Errorf("FLOAT: got %v (%T), want float32 — json was %s", out.Value, out.Value, blob)
+			}
+		}
+	}
+}
+
+// exactInt's bound is width-dependent: on 64-bit float64(MaxInt) rounds
+// up to 2^63 and MaxInt is unreachable from a float64, while on 32-bit
+// float64(MaxInt) is exact and must be accepted. Deriving the cases
+// from math.MaxInt keeps this honest at both widths rather than
+// asserting one platform's answer.
+func TestExactIntBoundaries(t *testing.T) {
+	if got, ok := exactInt(float64(math.MinInt)); !ok || got != math.MinInt {
+		t.Errorf("exactInt(float64(MinInt)) = %d, %v; want %d, true", got, ok, math.MinInt)
+	}
+
+	// One float64 step past MaxInt is always out of range.
+	if got, ok := exactInt(float64(math.MaxInt) * 2); ok {
+		t.Errorf("exactInt(2*float64(MaxInt)) = %d, true; want rejected", got)
+	}
+
+	// float64(MaxInt) is exactly MaxInt only when int is 32-bit; on
+	// 64-bit it rounds up to 2^63, which int cannot hold. Compare the
+	// widths rather than the values — float64(math.MaxInt) ==
+	// math.MaxInt is a constant expression that converts the untyped
+	// constant to float64 and is therefore true at both widths.
+	const intIs64Bit = math.MaxInt > math.MaxInt32
+	got, ok := exactInt(float64(math.MaxInt))
+	switch {
+	case intIs64Bit && ok:
+		t.Errorf("exactInt(float64(MaxInt)) = %d, true; want rejected (rounds above MaxInt)", got)
+	case !intIs64Bit && (!ok || got != math.MaxInt):
+		t.Errorf("exactInt(float64(MaxInt)) = %d, %v; want %d, true", got, ok, math.MaxInt)
+	}
+
+	for _, f := range []float64{9.5, math.NaN(), math.Inf(1), math.Inf(-1)} {
+		if got, ok := exactInt(f); ok {
+			t.Errorf("exactInt(%v) = %d, true; want rejected", f, got)
+		}
+	}
+}

--- a/pkg/platform/yaml/mockdb/mysql_json_bigint_test.go
+++ b/pkg/platform/yaml/mockdb/mysql_json_bigint_test.go
@@ -1,0 +1,96 @@
+package mockdb
+
+import (
+	"encoding/json"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.keploy.io/server/v3/pkg/models/mysql"
+	"go.keploy.io/server/v3/pkg/platform/yaml"
+	"go.uber.org/zap"
+)
+
+// DecodeMocksJSON lands each MySQL packet body in a map[string]any before
+// retypeMySQLResponse re-marshals it into the concrete packet struct.
+// encoding/json's reflective default puts every number in that map as a
+// float64, so without UseNumber a BIGINT UNSIGNED column is destroyed in
+// the intermediate hop: 18446744073709551615 becomes 1.8446744073709552e+19
+// and re-marshals as 18446744073709552000, a literal now larger than
+// MaxUint64 that nothing downstream can recover.
+//
+// This is not confined to replay. UpdateMocks is a read-modify-write of
+// the user's mock file: it decodes through here, drops unused mocks and
+// writes the survivors back. So one `keploy test --remove-unused-mocks`
+// run rewrites 18446744073709551615 on disk as 18446744073709552000 —
+// permanent corruption of a file people keep in git.
+func TestDecodeMocksJSON_MySQLBigintUnsignedSurvivesRetype(t *testing.T) {
+	const want = uint64(18446744073709551615)
+
+	resp := mysql.Response{
+		PacketBundle: mysql.PacketBundle{
+			Header: &mysql.PacketInfo{
+				Header: &mysql.Header{PayloadLength: 12, SequenceID: 1},
+				Type:   string(mysql.Binary),
+			},
+			Message: &mysql.BinaryProtocolResultSet{
+				ColumnCount: 1,
+				Rows: []*mysql.BinaryRow{{
+					Header: mysql.Header{PayloadLength: 12, SequenceID: 1},
+					Values: []mysql.ColumnEntry{{
+						Type:     mysql.FieldTypeLongLong,
+						Name:     "big_u",
+						Value:    want,
+						Unsigned: true,
+					}},
+					RowNullBuffer: []byte{0},
+				}},
+			},
+		},
+	}
+
+	specJSON, err := json.Marshal(map[string]any{
+		"metadata":  map[string]string{},
+		"requests":  []mysql.Request{},
+		"responses": []mysql.Response{resp},
+	})
+	if err != nil {
+		t.Fatalf("marshal spec: %v", err)
+	}
+
+	doc := &yaml.NetworkTrafficDocJSON{
+		Version: models.GetVersion(),
+		Kind:    models.MySQL,
+		Name:    "mysql-bigint",
+		Spec:    json.RawMessage(specJSON),
+	}
+
+	mocks, err := DecodeMocksJSON([]*yaml.NetworkTrafficDocJSON{doc}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("DecodeMocksJSON: %v", err)
+	}
+	if len(mocks) != 1 {
+		t.Fatalf("got %d mocks, want 1", len(mocks))
+	}
+
+	resps := mocks[0].Spec.MySQLResponses
+	if len(resps) != 1 {
+		t.Fatalf("got %d responses, want 1", len(resps))
+	}
+	rs, ok := resps[0].Message.(*mysql.BinaryProtocolResultSet)
+	if !ok {
+		t.Fatalf("response message is %T, want *mysql.BinaryProtocolResultSet — spec was %s",
+			resps[0].Message, specJSON)
+	}
+	if len(rs.Rows) != 1 || len(rs.Rows[0].Values) != 1 {
+		t.Fatalf("unexpected row shape: %+v", rs.Rows)
+	}
+
+	got := rs.Rows[0].Values[0].Value
+	u, ok := got.(uint64)
+	if !ok {
+		t.Fatalf("value is %v (%T), want uint64 %d — the float64 intermediate ate it", got, got, want)
+	}
+	if u != want {
+		t.Errorf("value = %d, want %d", u, want)
+	}
+}

--- a/pkg/platform/yaml/mockdb/util.go
+++ b/pkg/platform/yaml/mockdb/util.go
@@ -1,6 +1,7 @@
 package mockdb
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -1508,9 +1509,32 @@ func DecodeMocksJSON(docs []*yaml.NetworkTrafficDocJSON, logger *zap.Logger) ([]
 				ReqTimestampMock time.Time         `json:"reqTimestampMock,omitempty"`
 				ResTimestampMock time.Time         `json:"resTimestampMock,omitempty"`
 			}
+			// UseNumber, not a plain Unmarshal. mysql.Request.Message is
+			// an interface{}, so this first pass lands every packet body
+			// in a map[string]any — and encoding/json's reflective default
+			// puts every number in there as float64. retypeMySQL* then
+			// re-marshals that map and unmarshals it into the concrete
+			// packet type, so anything float64 cannot represent is already
+			// gone before ColumnEntry.UnmarshalJSON ever runs.
+			//
+			// A BIGINT UNSIGNED column is the case that breaks:
+			// 18446744073709551615 comes back as 1.8446744073709552e+19 and
+			// re-marshals as 18446744073709552000 — a literal that is now
+			// larger than MaxUint64, so no amount of care downstream can
+			// recover it. json.Number keeps the original text through the
+			// intermediate hop and re-marshals verbatim.
 			var s mySpec
-			if err := json.Unmarshal(m.Spec, &s); err != nil {
+			dec := json.NewDecoder(bytes.NewReader(m.Spec))
+			dec.UseNumber()
+			if err := dec.Decode(&s); err != nil {
 				return nil, fmt.Errorf("failed to unmarshal mysql mock %q: %w", m.Name, err)
+			}
+			// Decode stops at the first complete value; json.Unmarshal
+			// rejects anything after it. Keep the stricter behaviour, so a
+			// truncated or concatenated spec still fails loudly instead of
+			// half-parsing into a mock with silently missing packets.
+			if dec.More() {
+				return nil, fmt.Errorf("failed to unmarshal mysql mock %q: unexpected trailing content after spec", m.Name)
 			}
 			for i := range s.Requests {
 				typed, err := retypeMySQLRequest(s.Requests[i].Header, s.Requests[i].Message)


### PR DESCRIPTION
## Describe the changes that are made

MySQL sends `FLOAT` and `DOUBLE` on the wire as a raw IEEE-754 bit pattern. Four decode sites
read those bytes with a **numeric conversion** instead of a reinterpret:

```go
res.value = float32(binary.LittleEndian.Uint32(data[:4]))   // FLOAT
res.value = float64(binary.LittleEndian.Uint64(data[:8]))   // DOUBLE
```

`float32(uint32(...))` compiles and is silently wrong — it converts the *integer value of the
bit pattern*. A column holding `9.99` is read as `1.0926057e+09` (FLOAT) and
`4.621813488089437e+18` (DOUBLE).

The result-set site is the damaging one: it corrupts at **record** time, so the wrong value is
written into `mocks.yaml` and survives re-recording. Replay then asserts against a value the
database never returned, and every test touching one of those columns fails on a body diff that
looks like a real regression.

**Fixed** with `math.Float32frombits` / `math.Float64frombits` at each site:

| File | Site |
|---|---|
| `wire/.../rowscols/binaryProtocolRowPacket.go` | result-set columns (FLOAT + DOUBLE) |
| `wire/.../preparedstmt/stmtExecutePacket.go` | FLOAT bound parameter |
| `wire/.../queryPacket.go` | FLOAT + DOUBLE query attributes |

Two follow-on defects on the same path are fixed alongside it, because the decode fix **alone
does not make a `FLOAT` column usable**:

**1. `EncodeBinaryRow` panicked instead of erroring.** It type-asserted `ce.Value` nakedly
(`ce.Value.(float32)`, `uint32(ce.Value.(int))`). No serializer preserves Go's numeric types —
`yaml.v3` resolves an untagged scalar by shape, so a `FLOAT` column comes back `float64`, an
integral `DOUBLE` comes back `int`, and a `BIGINT UNSIGNED` above `MaxInt64` comes back
`uint64`; `encoding/json` returns `float64` for every number. Once FLOAT values decoded
correctly, those assertions panicked — and a panic here tears down the proxy's connection
handler, so the application under replay sees `invalid connection` with nothing pointing at the
cause. Replaced with `coerceToInt64` / `coerceToFloat64`, which return a wrapped error naming
the column.

**2. `paramValueEqual` widened instead of narrowing.** A `FLOAT` param is `float32` off the wire
and `float64` out of the mock file. `float64(av) == bv` asks the `float32` to carry precision it
never had — `float64(float32(9.99))` is `9.989999771118164` — so a correctly recorded `FLOAT`
param never matched itself. Narrowed the two **mixed** arms to float32 precision.
`float64`/`float64` and `float32`/`float32` are untouched, so `DOUBLE` comparison keeps full
precision (pinned by a test).

**Blast radius:** `match.go` is the only change that affects users who have no FLOAT/DOUBLE
columns, and it changes only the two arms where one side is genuinely a `float32`. A comparison
cannot be more precise than its less precise side, so this is the correct semantics rather than
a loosening.

## Links & References

**Closes:** #4426

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

Covered by unit tests at the packet-codec and matcher level, which is where the defect is. Happy
to add an e2e case if you would prefer one — it would need a fixture schema carrying `FLOAT` and
`DOUBLE` columns, which I don't think the current e2e apps have.

## Added comments for hard-to-understand areas?
- [x] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

Each `frombits` site says why it is a reinterpret and not a cast, since the broken form compiles
and reads naturally. The coercion helpers carry a comment explaining the serializer type erasure
that makes them necessary.

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

```sql
CREATE TABLE t (id INT PRIMARY KEY, f FLOAT, d DOUBLE);
INSERT INTO t VALUES (1, 9.99, 9.99);
```

Record an endpoint that selects `f` and `d`, then read `keploy/test-set-N/mocks.yaml`.

- **Before:** the recorded rows hold `1.0926057e+09` and `4.621813488089437e+18`.
- **After:** they hold `9.99` and `9.99`, and `keploy test` passes.

The unit tests reproduce it without a database:

```
go test ./pkg/agent/proxy/integrations/mysql/wire/phase/query/rowscols/
go test ./pkg/agent/proxy/integrations/mysql/replayer/
```

Both new test files **fail on `main`** and pass with this change — verified by reverting each
production file individually and re-running:

- `TestDecodeBinaryRow_FloatDoubleAreBitPatterns` — `got 1.0926057e+09, want 9.99`
- `TestEncodeBinaryRow_SurvivesYAMLRoundTrip` — `panicked: interface {} is float64, not float32`
- `TestEncodeBinaryRow_IntegerColumnsSurviveYAML` — `panicked: interface {} is uint64, not int`
- `TestParamValueEqual_FloatParamMatchesItselfAcrossYAML` — `live float32 9.99 vs recorded 9.99 (float64): no match`

Three of the new tests are guards rather than regression tests and pass in both directions by
design: `TestParamValueEqual_DistinctFloatsStillDiffer` (narrowing must not make the comparison
blind), `TestParamValueEqual_DoubleKeepsFullPrecision` (DOUBLE must not start narrowing), and
`TestParamValueEqual_WholeFloatParamRestoresAsInt`.

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

`gofmt`, `go vet ./pkg/agent/proxy/integrations/mysql/...` and `go build ./...` are clean, and
the full `go test ./pkg/...` suite passes.

## Any relevant screenshots, recordings or logs?

Recorded `mocks.yaml` rows for a `FLOAT`/`DOUBLE` column holding `9.99`:

```yaml
# before
- {type: 4, name: price_f, value: 1.0926057e+09}
- {type: 5, name: price_d, value: 4.621813488089437e+18}
# after
- {type: 4, name: price_f, value: 9.99}
- {type: 5, name: price_d, value: 9.99}
```

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?
