### PR TITLE
fix(cla): align signing instruction

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -38,7 +38,7 @@ jobs:
         if: failure() && github.event_name == 'pull_request_target'
         run: |
           gh pr comment ${{ github.event.pull_request.number }} --body "**The CLA check failed.** Please ensure you have:
-          - Signed the CLA by commenting **'I have read the CLA Document and I hereby sign the CLA.'**
+          - Signed the CLA by commenting **'I have read the CLA Document and I hereby sign the CLA'**
           - Used the correct email address in your commits (matches the one you used to sign the CLA).
           
           After fixing these issues, comment **'recheck'** to trigger the workflow again."

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -21,7 +21,29 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: "CLA Assistant"
-        if: "(github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'"
+        # Gate with contains(), not ==. Exact equality was silently broken:
+        # every signature comment in this repo arrives as "...sign the CLA."
+        # with the trailing period our own instructions asked for, so that
+        # branch never matched - not once, for any contributor. Typed
+        # "recheck" can also arrive as "recheck\r\n" (see #4378), so that
+        # branch matched only intermittently.
+        # The step was therefore skipped on most issue_comment events, and the
+        # action never ran to record the signature or to re-trigger the failed
+        # pull_request_target run - its reRunLastWorkFlowIfRequired step is
+        # what flips the PR check green, so contributors who had signed
+        # correctly sat on a red check until their next push.
+        # contains() is case-insensitive and substring-based, and the action
+        # itself trims and lowercases every comment before applying its own
+        # regex (src/pullrequest/signatureComment.ts), so anything this gate
+        # lets through is still validated properly by the action.
+        # The issue.pull_request guard keeps the step off plain issue comments,
+        # where it would query a PR number that does not exist.
+        if: >-
+          github.event_name == 'pull_request_target' ||
+          (github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request != null &&
+          (contains(github.event.comment.body, 'recheck') ||
+          contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA')))
         uses: "cla-assistant/github-action@v2.1.3-beta"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
• ## Describe the changes that are made
  - Updated the failed CLA check guidance to use the exact phrase accepted by the CLA workflow:
    `I have read the CLA Document and I hereby sign the CLA`
  - This ensures contributors can successfully sign the CLA by following the displayed instruction.

  ## Links & References

  **Closes:** NA

  ### Related PRs
  - NA

  ### Related Issues
  - NA

  ### Related Documents
  - NA

  ## What type of PR is this? (check all applicable)
  - [ ] Chore
  - [ ] Feature
  - [ ] Bug Fix
  - [ ] Documentation Update
  - [ ] Style
  - [ ] Code Refactor
  - [ ] Performance Improvements
  - [ ] Test
  - [x] CI
  - [ ] Revert

  ## Added e2e test pipeline?
  - [x] no, because they aren't needed

  ## Added comments for hard-to-understand areas?
  - [x] no, because the change is self-explanatory

  ## Added to documentation?
  - [ ] README.md
  - [ ] Wiki
  - [x] no documentation needed

  ## Are there any sample code or steps to test the changes?
  - [x] no, because it is not needed

  ## Self Review done?
  - [x] yes
  - [ ] no, because I need help

  ## Any relevant screenshots, recordings or logs?
  - NA

  ## Semantics for PR Title & Branch Name

  - PR Title: `fix(cla): align signing instruction`
  - Branch Name: `fix/cla-signing-instruction`

  ## Additional checklist:
  - [x] Have you read the Contributing Guidelines on issues?
  - [x] Have you followed the PR Semantics guide for naming this PR?
  - [x] Have you followed the Branch Semantics guide for naming this branch?