### PR TITLE
fix(mysql): normalize tracer comments so SHOW FULL FIELDS stops cross-serving

### DIFF
--- a/pkg/agent/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match.go
@@ -1229,6 +1229,62 @@ func getQueryStructure(sql string) (string, error) {
 	return strings.Join(structureParts, "->"), nil
 }
 
+// stripSQLComments removes plain block comments (/* ... */) from a SQL string so
+// that per-statement tracer annotations do not defeat mock matching. Datadog DBM
+// sqlcommenter, sqlcommenter and marginalia append a UNIQUE comment to every
+// execution (e.g. `SELECT ... /*traceparent='00-<trace>-<span>-01',dddbs='app'*/`),
+// so the recorded and replayed text of the SAME statement never match
+// byte-for-byte. Without this, a non-DML statement (SHOW FULL FIELDS, SHOW INDEX,
+// ...) can't reach the exact-text path and falls to equal-payload-length-alone,
+// where the first same-length mock is cross-served — the wrong table's columns.
+//
+// MySQL executable comments (/*! ... */) and optimizer hints (/*+ ... */) are
+// semantic and are preserved. Content inside string literals ('...', "...") and
+// quoted identifiers (`+"`"+`...`+"`"+`) is left untouched so a literal containing "/*"
+// is not mistaken for a comment. The removed comment becomes a single space; only
+// leading/trailing whitespace is trimmed (interior spacing is left as-is, so a
+// recorded and replayed statement with the comment in the same position remain
+// byte-equal after stripping).
+func stripSQLComments(sql string) string {
+	if !strings.Contains(sql, "/*") {
+		return strings.TrimSpace(sql)
+	}
+	var b strings.Builder
+	b.Grow(len(sql))
+	var quote byte // 0 when not inside a literal; else the opening ' " or `+"`"+`
+	for i := 0; i < len(sql); {
+		c := sql[i]
+		if quote != 0 {
+			b.WriteByte(c)
+			if c == quote {
+				quote = 0
+			}
+			i++
+			continue
+		}
+		switch c {
+		case '\'', '"', '`':
+			quote = c
+			b.WriteByte(c)
+			i++
+			continue
+		}
+		if c == '/' && i+1 < len(sql) && sql[i+1] == '*' &&
+			!(i+2 < len(sql) && (sql[i+2] == '!' || sql[i+2] == '+')) {
+			end := strings.Index(sql[i+2:], "*/")
+			if end < 0 {
+				break // unterminated comment: drop the remainder
+			}
+			i = i + 2 + end + 2
+			b.WriteByte(' ')
+			continue
+		}
+		b.WriteByte(c)
+		i++
+	}
+	return strings.TrimSpace(b.String())
+}
+
 func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.PacketBundle, getQuery func(packet mysql.PacketBundle) string) (bool, int) {
 	matchCount := 0
 
@@ -1237,8 +1293,12 @@ func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.Packe
 		return false, 0
 	}
 
-	expectedQuery := getQuery(expected)
-	actualQuery := getQuery(actual)
+	// Normalize per-statement tracer comments out of both queries before any
+	// comparison (see stripSQLComments). A Datadog DBM / sqlcommenter build
+	// appends a unique /*traceparent=...*/ to every call, so without this the
+	// recorded and replayed text of the same statement never match.
+	expectedQuery := stripSQLComments(getQuery(expected))
+	actualQuery := stripSQLComments(getQuery(actual))
 
 	// Count placeholders in both queries - this is crucial for PREPARE statements
 	// to ensure we match mocks with the same number of parameters
@@ -1253,17 +1313,23 @@ func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.Packe
 		return false, 0
 	}
 
+	// Equal payload length is a weak similarity signal, kept for partial scoring —
+	// but it must NOT gate the exact-text match. The same statement carries a
+	// different-length trace comment from a writer (cluster-) vs reader
+	// (cluster-ro-) endpoint, so equal base SQL can have unequal packet lengths;
+	// gating exact match on length there sent the query to equal-length-alone
+	// cross-serving.
 	if actual.Header != nil && actual.Header.Header != nil &&
 		expected.Header != nil && expected.Header.Header != nil &&
 		actual.Header.Header.PayloadLength == expected.Header.Header.PayloadLength {
 		matchCount++
-		if expectedQuery == actualQuery {
-			matchCount++
-			log.Debug("Query Exact matched",
-				zap.String("expected query", expectedQuery),
-				zap.String("actual query", actualQuery))
-			return true, matchCount
-		}
+	}
+	if expectedQuery == actualQuery {
+		matchCount++
+		log.Debug("Query Exact matched (trace-comment normalized)",
+			zap.String("expected query", expectedQuery),
+			zap.String("actual query", actualQuery))
+		return true, matchCount
 	}
 
 	// A PURE single system-variable read (SELECT @@[session.]<var>, no columns

--- a/pkg/agent/proxy/integrations/mysql/replayer/match_tracecomment_test.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match_tracecomment_test.go
@@ -1,0 +1,122 @@
+package replayer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// TestMatchCommand_ShowFullFields_TraceCommentCrossServe reproduces the
+// cross-serving bug behind the auto-replay 500s.
+//
+// The app runs a Datadog DBM / sqlcommenter build that appends a unique
+// /*traceparent=...*/ comment to every statement, so the recorded and replayed
+// text of the SAME query never match byte-for-byte. For a non-DML statement like
+// SHOW FULL FIELDS, matchQuery then can't reach its exact-text return and falls
+// to equal-PayloadLength-alone (score 1). matchCommand serves the FIRST mock that
+// scored 1 — so a SHOW FULL FIELDS on one table is answered with another table's
+// column metadata, which surfaces in the app as `undefined method '...' for an
+// instance of <Model>`.
+//
+// Before the trace-comment normalization this test fails (the first same-length
+// mock's columns are served); after it, the correct table's mock matches
+// exactly and is served.
+func TestMatchCommand_ShowFullFields_TraceCommentCrossServe(t *testing.T) {
+	logger := zap.NewNop()
+	base := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+
+	// Two non-DML SHOW FULL FIELDS statements on different tables, each recorded
+	// with its own trace comment. readbackMock stamps the same PayloadLength on
+	// both — the equal-length condition the writer/reader prologues produce.
+	mockVersions := readbackMock(
+		"versions",
+		"SHOW FULL FIELDS FROM `versions` /*traceparent='00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1111111111111111-01'*/",
+		"COLS=versions", base)
+	mockAccounts := readbackMock(
+		"accounts",
+		"SHOW FULL FIELDS FROM `accounts` /*traceparent='00-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-2222222222222222-01'*/",
+		"COLS=accounts", base.Add(time.Second))
+
+	// versions is recorded FIRST, so a length-only score-1 match serves it.
+	db := &fakeMockDb{session: []*models.Mock{mockVersions, mockAccounts}}
+
+	// The live call is SHOW FULL FIELDS FROM accounts, carrying yet another
+	// trace comment (the replay-time span differs from the recorded one).
+	live := comQueryReq("SHOW FULL FIELDS FROM `accounts` /*traceparent='00-cccccccccccccccccccccccccccccccc-3333333333333333-01'*/")
+
+	resp, ok, _, err := matchCommand(context.Background(), logger, live, db, newDecodeCtx(), nil, nil)
+	if err != nil || !ok || resp == nil {
+		t.Fatalf("expected a match for SHOW FULL FIELDS FROM accounts, got ok=%v err=%v", ok, err)
+	}
+	if resp.Payload != "COLS=accounts" {
+		t.Fatalf("cross-serve: SHOW FULL FIELDS FROM `accounts` was answered with %q (a different table's columns) — the trace comment defeated exact matching and equal-length-alone served the first mock", resp.Payload)
+	}
+}
+
+func TestStripSQLComments(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"no comment", "SELECT 1", "SELECT 1"},
+		{"trailing sqlcommenter", "SELECT 1 /*traceparent='00-abc-def-01'*/", "SELECT 1"},
+		{"leading comment", "/*app='web'*/ SELECT 1", "SELECT 1"},
+		{"two show-full-fields differ only by comment collapse equal",
+			"SHOW FULL FIELDS FROM `accounts` /*t=1*/", "SHOW FULL FIELDS FROM `accounts`"},
+		{"preserve executable comment", "SELECT /*!40001 SQL_NO_CACHE */ 1", "SELECT /*!40001 SQL_NO_CACHE */ 1"},
+		{"preserve optimizer hint", "SELECT /*+ NO_INDEX(t) */ a FROM t", "SELECT /*+ NO_INDEX(t) */ a FROM t"},
+		{"do not strip inside string literal", "SELECT '/*not a comment*/' AS x", "SELECT '/*not a comment*/' AS x"},
+		{"do not strip inside backtick identifier", "SELECT `/*weird*/col` FROM t", "SELECT `/*weird*/col` FROM t"},
+		{"unterminated comment drops remainder", "SELECT 1 /*oops", "SELECT 1"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := stripSQLComments(c.in); got != c.want {
+				t.Errorf("stripSQLComments(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+
+	// The property that actually matters for matching: the same base statement
+	// with two different trace comments normalizes to the same string, and two
+	// different base statements do not.
+	a := stripSQLComments("SHOW FULL FIELDS FROM `accounts` /*traceparent='00-aaaa-1111-01'*/")
+	b := stripSQLComments("SHOW FULL FIELDS FROM `accounts` /*traceparent='00-bbbb-2222-01',dddbs='web'*/")
+	if a != b {
+		t.Errorf("same base query with different trace comments must normalize equal: %q vs %q", a, b)
+	}
+	c := stripSQLComments("SHOW FULL FIELDS FROM `versions` /*traceparent='00-cccc-3333-01'*/")
+	if a == c {
+		t.Errorf("different base queries must not normalize equal: %q == %q", a, c)
+	}
+}
+
+// TestMatchCommand_ShowFullFields_DifferentTableStillDistinct guards the fix
+// against over-normalization: stripping the trace comment must not make two
+// genuinely different SHOW FULL FIELDS statements collapse into one. The live
+// call for `users` must be served the users mock, not accounts.
+func TestMatchCommand_ShowFullFields_DifferentTableStillDistinct(t *testing.T) {
+	logger := zap.NewNop()
+	base := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+
+	mockAccounts := readbackMock("accounts",
+		"SHOW FULL FIELDS FROM `accounts` /*traceparent='00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1111111111111111-01'*/",
+		"COLS=accounts", base)
+	mockUsers := readbackMock("users",
+		"SHOW FULL FIELDS FROM `users` /*traceparent='00-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-2222222222222222-01'*/",
+		"COLS=users", base.Add(time.Second))
+	db := &fakeMockDb{session: []*models.Mock{mockAccounts, mockUsers}}
+
+	live := comQueryReq("SHOW FULL FIELDS FROM `users` /*traceparent='00-cccccccccccccccccccccccccccccccc-3333333333333333-01'*/")
+	resp, ok, _, err := matchCommand(context.Background(), logger, live, db, newDecodeCtx(), nil, nil)
+	if err != nil || !ok || resp == nil {
+		t.Fatalf("expected a match for SHOW FULL FIELDS FROM users, got ok=%v err=%v", ok, err)
+	}
+	if resp.Payload != "COLS=users" {
+		t.Fatalf("expected COLS=users, got %q — normalization must not merge distinct tables", resp.Payload)
+	}
+}


### PR DESCRIPTION
## Problem

On replay, an app built with **Datadog DBM / sqlcommenter** (or sqlcommenter / marginalia) returns wrong data for schema-introspection queries, surfacing as `undefined method '<col>' for an instance of <Model>` and 500s.

## Root cause

sqlcommenter appends a **unique `/*traceparent=...*/` comment to every statement**, so the recorded and replayed text of the same statement never match byte-for-byte. In `matchQuery`, the exact-text match is reached only inside an `if PayloadLength ==` block; a non-DML statement like `SHOW FULL FIELDS FROM <t>` therefore can't match exactly and falls through to **equal-`PayloadLength`-alone** (`matchCount == 1`). `matchCommand` then serves the **first** mock that scored 1 — so `SHOW FULL FIELDS FROM accounts` gets `versions`' columns. The writer (`cluster-`) vs reader (`cluster-ro-`) endpoints make the prologue 217/220 bytes, so even equal-base statements can differ in length.

This is the same class as the existing `rejectsCrossVariableRead` fix for `SELECT @@var`.

## Fix (`matchQuery`)

1. **Normalize** plain block comments (`/* ... */`) out of both queries before comparison (`stripSQLComments`). Executable comments (`/*!`) and optimizer hints (`/*+`) are preserved; content inside string literals and quoted identifiers is left untouched.
2. **Ungate** the exact-text match from equal `PayloadLength` (kept only as a partial-scoring signal), so a writer/reader length swing on the same base SQL still matches exactly.

## Tests (`match_tracecomment_test.go`)

- `TestMatchCommand_ShowFullFields_TraceCommentCrossServe` — faithful `matchCommand` reproduction: `SHOW FULL FIELDS FROM accounts` is answered `COLS=versions` **before** the fix, `COLS=accounts` after.
- `TestMatchCommand_ShowFullFields_DifferentTableStillDistinct` — guards against over-normalization (distinct tables stay distinct).
- `TestStripSQLComments` — preserves `/*!` / `/*+`, ignores `/*` inside literals/identifiers, and the normalize-equal / stay-distinct property.

Full `mysql/...` suite green; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)