### PR TITLE
fix(http): treat x-datadog-tags and W3C baggage as flaky headers

### DIFF
--- a/pkg/agent/proxy/integrations/http/match.go
+++ b/pkg/agent/proxy/integrations/http/match.go
@@ -68,6 +68,7 @@ var flakyHeaders = []string{
 	// ── W3C Trace Context / OpenTelemetry ────────────────────────────
 	"traceparent", // unique trace-id + span-id per request
 	"tracestate",  // vendor-specific trace context
+	"baggage",     // W3C Baggage — per-request correlation entries; tracers emit it inconsistently
 
 	// ── Zipkin B3 propagation ────────────────────────────────────────
 	"x-b3-traceid",
@@ -81,6 +82,7 @@ var flakyHeaders = []string{
 	"x-datadog-parent-id",
 	"x-datadog-sampling-priority",
 	"x-datadog-origin",
+	"x-datadog-tags", // propagated _dd.p.* tags; dd-trace emits it only on sampled/decorated spans, so it comes and goes per request
 
 	// ── Generic request/correlation IDs ──────────────────────────────
 	"x-request-id",     // Nginx, Envoy, HAProxy, AWS ALB, Heroku

--- a/pkg/agent/proxy/integrations/http/match_test.go
+++ b/pkg/agent/proxy/integrations/http/match_test.go
@@ -248,6 +248,34 @@ func TestHeadersContainKeys_FlakyHeaderSkippedByNoise(t *testing.T) {
 	}
 }
 
+func TestHeadersContainKeys_DatadogTagsAndBaggageAreFlaky(t *testing.T) {
+	// dd-trace-rb (and other tracers) emit x-datadog-tags and W3C baggage on some
+	// outbound calls and omit them on others, non-deterministically. A JWKS fetch
+	// recorded WITH them but replayed WITHOUT must still match its mock — otherwise
+	// the app never receives the verification key and returns 401. Regression for
+	// the auto-replay 401s where the report showed both headers as
+	// `recorded "", absent in live call`.
+	h := newHTTP()
+	mockHeaders := map[string]string{
+		"Host":           "oauth2.example.com",
+		"Accept":         "application/json",
+		"X-Datadog-Tags": "_dd.p.dm=-1,_dd.p.tid=66b0f1e300000000",
+		"Baggage":        "session.id=abc123",
+	}
+	actualHeaders := http.Header{
+		"Host":   {"oauth2.example.com"},
+		"Accept": {"application/json"},
+		// X-Datadog-Tags and Baggage are absent on this replay call.
+	}
+	noise := make(map[string][]string)
+	for _, hdr := range flakyHeaders {
+		noise[hdr] = []string{}
+	}
+	if !h.HeadersContainKeys(mockHeaders, actualHeaders, noise) {
+		t.Error("expected the JWKS mock to match when x-datadog-tags / baggage are absent at replay; these are non-deterministic trace headers and must be flaky-noise")
+	}
+}
+
 func TestHeadersContainKeys_StrictMode_FlakyHeaderCausesMismatch(t *testing.T) {
 	// Same setup as above but with empty noise (simulates --disableAutoHeaderNoise).
 	// Mock has X-Amz-Security-Token but request doesn't → should fail.


### PR DESCRIPTION
## Problem

On replay, a request whose auth depends on a JWKS/OIDC key fetch **401s**, because the recorded upstream key-fetch mock isn't matched.

## Root cause

HTTP header matching is **presence-only** (`HeadersContainKeys`): a header key present on the recorded request but absent on the live replay request fails the match unless the key is flaky-noise. `dd-trace-rb` (and other tracers) emit **`x-datadog-tags`** and **W3C `baggage`** only on sampled/decorated spans, so they appear on some outbound calls and not others. The JWKS fetch recorded WITH `x-datadog-tags` but replayed WITHOUT it is rejected → the app never gets the verification key → 401. The mismatch report shows it verbatim: `header.X-Datadog-Tags: recorded "", absent in live call` (and the same for `Baggage`).

`x-datadog-tags` was missing from `flakyHeaders` even though its siblings (`x-datadog-trace-id/parent-id/sampling-priority/origin`) are present.

## Fix

Add `x-datadog-tags` (Datadog block) and `baggage` (W3C block) to `flakyHeaders`. Regression test: a JWKS mock matches when both headers are absent at replay.

Full `http` integration suite green; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)