### PR TITLE
fix(mysql): identify statements by executable SQL, not by wire bytes

### DIFF
--- a/pkg/agent/proxy/integrations/mismatch/mismatch.go
+++ b/pkg/agent/proxy/integrations/mismatch/mismatch.go
@@ -167,7 +167,7 @@ func defaultNextSteps(r *models.MockMismatchReport) string {
 	}
 	switch {
 	case r.MatchPhase == models.MatchPhaseNoMocks:
-		return "No recorded mocks exist for this protocol in the selected test set. Re-record the test set with 'keploy record'."
+		return "No recorded mocks were available to match against for this protocol in the selected test set. Re-record the test set with 'keploy record'."
 	case onlyValueDrift:
 		paths := make([]string, 0, len(r.FieldDiffs))
 		// Body diffs are reported "body."-prefixed for readability, but HTTP

--- a/pkg/agent/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match.go
@@ -1353,6 +1353,10 @@ const (
 	// ok=true, which makes the caller take the definitive path and ignore the
 	// score entirely, so the value is informational only.
 	scoreQueryExact = 2
+	// scoreQueryLiteralDrift — same statement, drifted inline literal values.
+	// Last resort, never definitive, and deliberately below scoreQueryStructure
+	// so DML selection is unchanged.
+	scoreQueryLiteralDrift = 3
 	// scoreQueryStructure — both DML with an identical parse-tree shape.
 	// Pre-existing tier, never definitive.
 	scoreQueryStructure = 6
@@ -1459,11 +1463,25 @@ func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.Packe
 		return false, 0
 	}
 
-	// Non-DML and not textually identical: nothing further establishes that
-	// these are the same statement, so the candidate is not servable. The
-	// mismatch report still names the nearest recorded query — matchCommand
-	// tracks that separately from the score.
 	if !(sqlparser.IsDML(expectedQuery) && sqlparser.IsDML(actualQuery)) {
+		// Non-DML. sqlparser.IsDML covers only INSERT/UPDATE/DELETE, so this is
+		// where every SELECT and SHOW lands, and the parse-tree tier below never
+		// sees them. Last resort: the same statement with a drifted inline
+		// literal — a client that interpolates a freshly generated id instead of
+		// binding it re-issues exactly this shape on every run, and refusing it
+		// tears the connection down.
+		//
+		// Not definitive: the recorded response belongs to a different row, so it
+		// only scores, and only wins when nothing matched exactly.
+		if !isSessionControlStatement(expectedQuery) && !isSessionControlStatement(actualQuery) &&
+			maskSQLLiterals(expectedQuery) == maskSQLLiterals(actualQuery) {
+			log.Debug("query matched with drifted inline literals",
+				zap.String("expected query", expectedQuery),
+				zap.String("actual query", actualQuery))
+			// The payload-length tie-break only ranks candidates already known to
+			// share every keyword, identifier and literal type.
+			return false, scoreQueryLiteralDrift + equalPayloadLength(expected, actual)
+		}
 		log.Debug("No Query is dml",
 			zap.String("expected query", expectedQuery),
 			zap.String("actual query", actualQuery))
@@ -2326,6 +2344,165 @@ func equalPayloadLength(expected, actual mysql.PacketBundle) int {
 		return 1
 	}
 	return 0
+}
+
+// maskSQLLiterals returns the statement with every inline literal VALUE replaced
+// by a type-tagged placeholder, leaving keywords, identifiers and punctuation
+// exactly as they were.
+//
+//	SELECT id FROM customers WHERE id = 'a3f...'   ->  SELECT id FROM customers WHERE id = ?s
+//	SELECT id FROM customers WHERE id = 'b71...'   ->  SELECT id FROM customers WHERE id = ?s
+//
+// This is the last-resort tier for a client that inlines its literals instead of
+// binding them: the same statement re-issued with a freshly generated id is the
+// same statement, and refusing to serve it tears the connection down.
+//
+// It is emphatically NOT a general similarity measure, and the two things it
+// keeps are what make it safe:
+//
+//   - IDENTIFIERS survive, so "SHOW FULL FIELDS FROM `invoices`" can never be
+//     answered by "... FROM `couriers`". This is the failure that byte-length
+//     scoring used to cause.
+//   - The literal's TYPE survives (?s vs ?n), so "x = 1" and "x = '1'" stay
+//     distinct — MySQL does not treat them alike.
+//
+// It is computed lexically, with no SQL parser, deliberately: a parser renders
+// statements it does not model to a constant string, which would make unrelated
+// statements compare equal. Anything this scanner is unsure of is copied
+// verbatim, so ambiguity fails toward "no match" rather than a false one.
+func maskSQLLiterals(sql string) string {
+	var b strings.Builder
+	b.Grow(len(sql))
+
+	for i := 0; i < len(sql); {
+		c := sql[i]
+		switch {
+		// Backquoted identifier: a value's name, not a value. Keep it.
+		case c == '`':
+			j := scanQuoted(sql, i, '`')
+			b.WriteString(sql[i:j])
+			i = j
+
+		// String literal, in either quoting style.
+		case c == '\'' || c == '"':
+			i = scanQuoted(sql, i, c)
+			b.WriteString("?s")
+
+		// Executable comment ("/*!", "/*+") — the identity keeps these, so copy
+		// the span through untouched rather than masking inside it.
+		case c == '/' && i+1 < len(sql) && sql[i+1] == '*':
+			if closeAt := strings.Index(sql[i+2:], "*/"); closeAt >= 0 {
+				end := i + 2 + closeAt + 2
+				b.WriteString(sql[i:end])
+				i = end
+				continue
+			}
+			b.WriteString(sql[i:])
+			i = len(sql)
+
+		case isNumericLiteralStart(sql, i):
+			j := scanNumericLiteral(sql, i)
+			// A digit run that runs straight into an identifier character was
+			// never a literal (a quirky column name); copy it verbatim.
+			if j < len(sql) && isIdentByte(sql[j]) {
+				b.WriteByte(c)
+				i++
+				continue
+			}
+			b.WriteString("?n")
+			i = j
+
+		default:
+			b.WriteByte(c)
+			i++
+		}
+	}
+	return b.String()
+}
+
+// scanQuoted returns the index just past the token opened by quote q at sql[i],
+// honouring backslash escapes (not inside backquotes) and doubled quotes. An
+// unterminated token runs to the end of the input.
+func scanQuoted(sql string, i int, q byte) int {
+	j := i + 1
+	for j < len(sql) {
+		if sql[j] == '\\' && q != '`' {
+			j += 2
+			continue
+		}
+		if sql[j] == q {
+			if j+1 < len(sql) && sql[j+1] == q {
+				j += 2
+				continue
+			}
+			return j + 1
+		}
+		j++
+	}
+	return len(sql)
+}
+
+func isIdentByte(c byte) bool {
+	return c == '_' || c == '$' ||
+		(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+}
+
+// isNumericLiteralStart reports whether a numeric literal begins at sql[i]. A
+// digit that continues an identifier (the "8" in "utf8mb4") does not.
+func isNumericLiteralStart(sql string, i int) bool {
+	if sql[i] < '0' || sql[i] > '9' {
+		return false
+	}
+	return i == 0 || !isIdentByte(sql[i-1])
+}
+
+// scanNumericLiteral returns the index just past the numeric literal at sql[i],
+// covering hex (0x1F), decimals and exponents.
+func scanNumericLiteral(sql string, i int) int {
+	j := i
+	if sql[j] == '0' && j+1 < len(sql) && (sql[j+1] == 'x' || sql[j+1] == 'X') {
+		j += 2
+		for j < len(sql) && isHexByte(sql[j]) {
+			j++
+		}
+		return j
+	}
+	for j < len(sql) && sql[j] >= '0' && sql[j] <= '9' {
+		j++
+	}
+	if j < len(sql) && sql[j] == '.' {
+		j++
+		for j < len(sql) && sql[j] >= '0' && sql[j] <= '9' {
+			j++
+		}
+	}
+	// Exponent, only when it is actually followed by digits.
+	if j < len(sql) && (sql[j] == 'e' || sql[j] == 'E') {
+		k := j + 1
+		if k < len(sql) && (sql[k] == '+' || sql[k] == '-') {
+			k++
+		}
+		if k < len(sql) && sql[k] >= '0' && sql[k] <= '9' {
+			for k < len(sql) && sql[k] >= '0' && sql[k] <= '9' {
+				k++
+			}
+			j = k
+		}
+	}
+	return j
+}
+
+func isHexByte(c byte) bool {
+	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
+}
+
+// isSessionControlStatement reports whether the statement configures the session
+// rather than reading or writing rows. Its literal IS its meaning — "SET NAMES
+// utf8mb4" and "SET NAMES latin1" do different things — so it is excluded from
+// literal-drift matching.
+func isSessionControlStatement(sql string) bool {
+	s := strings.TrimLeft(sql, sqlWhitespace)
+	return hasPrefixFold(s, "SET") && (len(s) == 3 || strings.ContainsRune(sqlWhitespace, rune(s[3])))
 }
 
 // isLineCommentAt reports whether a MySQL line comment starts at sql[i].

--- a/pkg/agent/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match.go
@@ -22,6 +22,30 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 )
 
+// stmtIdentityCacheSize bounds stmtIdentityCache. Same reasoning as
+// querySigCacheSize below: the key is the raw SQL text and that key space is not
+// finite (a tracer mints a fresh traceparent per request), while the value is a
+// pure function of the key, so an eviction costs one re-scan and can never
+// change a match verdict.
+const stmtIdentityCacheSize = 2048
+
+var stmtIdentityCache = newStmtIdentityCache()
+
+// newStmtIdentityCache builds the memo as a 2Q cache, not a plain LRU, for the
+// reason spelled out on newQuerySigCache: matchQuery re-derives the LIVE query's
+// identity once per candidate while scanning the pool, so under plain-LRU
+// recency a pool holding more distinct texts than the cap would evict it between
+// candidates and re-scan it N times per command.
+func newStmtIdentityCache() *lru.TwoQueueCache[string, string] {
+	c, err := lru.New2Q[string, string](stmtIdentityCacheSize)
+	if err != nil {
+		// New2Q only errors on a non-positive size and the const is > 0, so this
+		// is unreachable — fail loudly rather than leave a nil cache.
+		panic(fmt.Sprintf("mysql replayer: invalid stmtIdentityCacheSize %d: %v", stmtIdentityCacheSize, err))
+	}
+	return c
+}
+
 // querySigCacheSize bounds querySigCache.
 //
 // The cache is keyed by the RAW SQL text, and that key space is NOT finite:
@@ -443,6 +467,18 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 		bestPartialMock  *models.Mock // closest non-exact match for diff reporting
 		bestPartialQuery string       // query of the closest partial match
 
+		// Reporting-only closeness, tracked SEPARATELY from the score above.
+		// The score is a correctness signal — a candidate that is not the same
+		// statement must score 0 and never be served — but the mismatch report
+		// still has to name the nearest recorded query. Without this split, a
+		// pool where every candidate scores 0 reports closest_mock="", which
+		// query.go renders as "REPLAY-ORPHAN: mock NEVER RECORDED for this
+		// query". That message sends the reader looking for a recording bug
+		// when the recording is present and merely drifted.
+		nearestMock   *models.Mock
+		nearestQuery  string
+		nearestPrefix int
+
 		// COM_STMT_EXECUTE FIFO fallback: when the live bound parameters
 		// match NO recorded mock for the same prepared query (e.g. an
 		// INSERT-then-SELECT read-back of a replay-generated uuid that
@@ -487,6 +523,43 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 		queryExactMock *models.Mock
 	)
 
+	// liveStatement is the incoming statement stripped of its inert leading
+	// comment — the same identity matchQuery compares on. It is the yardstick
+	// for nearestMock below.
+	liveStatement := ""
+	switch m := req.Message.(type) {
+	case *mysql.QueryPacket:
+		liveStatement = sqlStatementIdentity(m.Query)
+	case *mysql.StmtPreparePacket:
+		liveStatement = sqlStatementIdentity(m.Query)
+	}
+
+	// trackNearest remembers the recorded statement closest to the live one.
+	// Reporting only: it never makes a mock servable, it only gives the mismatch
+	// report something truthful to name.
+	//
+	// Ranked by longest shared prefix of the comment-stripped statements. Weak
+	// on its own (every SELECT shares "SELECT ") but it is the best available
+	// ordering, and it only ever decides which query the report NAMES.
+	trackNearest := func(mock *models.Mock, recorded string) {
+		if liveStatement == "" || recorded == "" {
+			return
+		}
+		if n := commonPrefixLen(liveStatement, sqlStatementIdentity(recorded)); n > nearestPrefix {
+			nearestPrefix, nearestMock, nearestQuery = n, mock, recorded
+		}
+	}
+
+	// mysqlCandidates counts the MySQL mocks the command phase had available to
+	// compare — those that survived the lifetime filter below. It is a coarse
+	// measure: a mock whose recorded command type does not match the live
+	// request still counts. Incremented AFTER the filter, not before, because
+	// counting pre-filter would pad the number shown to the user with
+	// handshake/config mocks that were never candidates and would make the
+	// "nothing to compare" phase unreachable (one handshake mock would keep the
+	// count non-zero).
+	mysqlCandidates := 0
+
 	// Single pass: filter & match on the fly. Iterates the merged pool
 	// (unfiltered + connection-scoped) so prepared-statement executes
 	// find their setups even when the setup was recorded in a
@@ -505,6 +578,7 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 				continue // command-phase only wants data + connection mocks + session-reusable commands
 			}
 		}
+		mysqlCandidates++
 		for _, mockReq := range mock.Spec.MySQLRequests {
 			select {
 			case <-ctx.Done():
@@ -560,20 +634,27 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 					} else {
 						matchedResp, matchedMock, queryMatched = &mock.Spec.MySQLResponses[0], mock, true
 					}
-				} else if c > maxMatchedCount {
-					// Track the closest candidate for the mismatch report even
-					// when strict rejects it as a servable match below.
-					bestPartialMock = mock
+				} else {
+					// Reporting only — see nearestMock. A score-0 candidate is
+					// not servable, but it may still be the nearest recording.
 					if qp, qok := mockReq.PacketBundle.Message.(*mysql.QueryPacket); qok {
-						bestPartialQuery = qp.Query
+						trackNearest(mock, qp.Query)
 					}
-					// Structure-matched-but-text-drifted candidate: under
-					// strict it may only be served when the drift (body.query
-					// / attribute values) is covered by learned/user noise.
-					if !gate.allows(mock) {
-						continue
+					if c > maxMatchedCount {
+						// Track the closest candidate for the mismatch report even
+						// when strict rejects it as a servable match below.
+						bestPartialMock = mock
+						if qp, qok := mockReq.PacketBundle.Message.(*mysql.QueryPacket); qok {
+							bestPartialQuery = qp.Query
+						}
+						// Structure-matched-but-text-drifted candidate: under
+						// strict it may only be served when the drift (body.query
+						// / attribute values) is covered by learned/user noise.
+						if !gate.allows(mock) {
+							continue
+						}
+						maxMatchedCount, matchedResp, matchedMock = c, &mock.Spec.MySQLResponses[0], mock
 					}
-					maxMatchedCount, matchedResp, matchedMock = c, &mock.Spec.MySQLResponses[0], mock
 				}
 
 			case sCOM_STMT_PREP:
@@ -591,7 +672,14 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 						continue
 					}
 					matchedResp, matchedMock, queryMatched = &mock.Spec.MySQLResponses[0], mock, true
-				} else if c > maxMatchedCount {
+				} else {
+					// Reporting only — see nearestMock.
+					if sp, spOk := mockReq.PacketBundle.Message.(*mysql.StmtPreparePacket); spOk {
+						trackNearest(mock, sp.Query)
+					}
+					if c <= maxMatchedCount {
+						continue
+					}
 					// Track the closest candidate for the mismatch report even
 					// when strict rejects it as a servable match below.
 					bestPartialMock = mock
@@ -829,7 +917,11 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 				}
 
 				// Graceful generic OK for common control statements (no mocks)
-				q := strings.TrimSpace(qp.Query)
+				// Match on the executable statement: a prologued
+				// "/*dde=...*/ SET NAMES utf8mb4" is a SET, and testing the raw
+				// text would classify it as an unknown statement and fall
+				// through to the mismatch path.
+				q := sqlStatementIdentity(qp.Query)
 				switch {
 				case strings.EqualFold(q, "BEGIN"),
 					strings.EqualFold(q, "START TRANSACTION"),
@@ -945,6 +1037,11 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 					closestMock:    sldClosest.Name,
 					fieldDiffs:     gate.fieldDiffs,
 					strictRejected: gate.rejected,
+					// Candidates existed and strict rejected them; leaving the
+					// count at zero would make query.go report this as a mock
+					// that was never recorded.
+					candidateCount: mysqlCandidates,
+					matchPhase:     models.MatchPhaseStrict,
 				}, nil
 			}
 			if chosen != nil {
@@ -1002,7 +1099,9 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 
 		if req.Header.Type == sCOM_STMT_PREP {
 			if sp, ok := req.Message.(*mysql.StmtPreparePacket); ok && sp != nil {
-				numParams := uint16(strings.Count(sp.Query, "?"))
+				// Count placeholders in the statement, not in the prologue —
+				// a sqlcommenter comment can legitimately contain a "?".
+				numParams := uint16(strings.Count(sqlStatementIdentity(sp.Query), "?"))
 				newStmtID := decodeCtx.NextStmtID
 				decodeCtx.NextStmtID++
 
@@ -1099,11 +1198,28 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 		if bestPartialMockName == "" {
 			bestPartialMockName = gate.closestMock
 		}
+		// Last resort: no candidate scored and strict rejected nothing, but the
+		// pool is not necessarily empty. Name the nearest recorded statement so
+		// the report reads "this query drifted from <that one>" instead of
+		// claiming the mock was never recorded.
+		closestQuery := bestPartialQuery
+		if bestPartialMockName == "" && nearestMock != nil {
+			bestPartialMockName, closestQuery = nearestMock.Name, nearestQuery
+		}
+		phase := models.MatchPhaseExhausted
+		switch {
+		case mysqlCandidates == 0:
+			phase = models.MatchPhaseNoMocks
+		case gate.rejected > 0:
+			phase = models.MatchPhaseStrict
+		}
 		return nil, false, &mockMiss{
-			closestQuery:   bestPartialQuery,
+			closestQuery:   closestQuery,
 			closestMock:    bestPartialMockName,
 			fieldDiffs:     gate.fieldDiffs,
 			strictRejected: gate.rejected,
+			candidateCount: mysqlCandidates,
+			matchPhase:     phase,
 		}, nil
 	}
 
@@ -1229,16 +1345,32 @@ func getQueryStructure(sql string) (string, error) {
 	return strings.Join(structureParts, "->"), nil
 }
 
-func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.PacketBundle, getQuery func(packet mysql.PacketBundle) string) (bool, int) {
-	matchCount := 0
+// Scores returned by matchQuery. Anything above zero makes the candidate
+// servable in matchCommand, so only evidence that the two texts are the SAME
+// STATEMENT may score.
+const (
+	// scoreQueryExact — the executable statements are identical. Returned with
+	// ok=true, which makes the caller take the definitive path and ignore the
+	// score entirely, so the value is informational only.
+	scoreQueryExact = 2
+	// scoreQueryStructure — both DML with an identical parse-tree shape.
+	// Pre-existing tier, never definitive.
+	scoreQueryStructure = 6
+)
 
+func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.PacketBundle, getQuery func(packet mysql.PacketBundle) string) (bool, int) {
 	// Match the type and return zero if the types are not equal
 	if expected.Header.Type != actual.Header.Type {
 		return false, 0
 	}
 
-	expectedQuery := getQuery(expected)
-	actualQuery := getQuery(actual)
+	// Identity is the EXECUTABLE statement, not the bytes on the wire. An
+	// observability prologue (Datadog DBM / sqlcommenter) is re-minted per
+	// request with a fresh traceparent and names the endpoint that served the
+	// call, so raw text is never twice equal for the same statement and its
+	// length is not stable either. See stripInertSQLComments.
+	expectedQuery := sqlStatementIdentity(getQuery(expected))
+	actualQuery := sqlStatementIdentity(getQuery(actual))
 
 	// Count placeholders in both queries - this is crucial for PREPARE statements
 	// to ensure we match mocks with the same number of parameters
@@ -1253,18 +1385,26 @@ func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.Packe
 		return false, 0
 	}
 
-	if actual.Header != nil && actual.Header.Header != nil &&
-		expected.Header != nil && expected.Header.Header != nil &&
-		actual.Header.Header.PayloadLength == expected.Header.Header.PayloadLength {
-		matchCount++
-		if expectedQuery == actualQuery {
-			matchCount++
-			log.Debug("Query Exact matched",
-				zap.String("expected query", expectedQuery),
-				zap.String("actual query", actualQuery))
-			return true, matchCount
-		}
+	// Exact match on the statement — deliberately NOT gated on equal
+	// PayloadLength. The wire length includes the prologue, so gating on it
+	// rejects the very statements this comparison exists to match.
+	if expectedQuery == actualQuery {
+		log.Debug("Query Exact matched",
+			zap.String("expected query", expectedQuery),
+			zap.String("actual query", actualQuery))
+		return true, scoreQueryExact
 	}
+
+	// PayloadLength equality is NOT evidence of anything and must never score.
+	// It used to award a point, which made it the only surviving signal for a
+	// non-DML statement once a trace comment defeated the text comparison — so
+	// the first recorded mock of the same byte length won, whatever SQL it held.
+	// With a couple of hundred bytes of tracer comment in front of every
+	// statement, unrelated queries collide on total length constantly: every
+	// "SHOW FULL FIELDS FROM <table>" with an equal-length table name measures
+	// the same. Serving one table's column metadata in answer to another's is
+	// silent, and downstream it looks like an application bug (an ORM model
+	// built with the wrong columns), not a mock mismatch.
 
 	// A PURE single system-variable read (SELECT @@[session.]<var>, no columns
 	// list / FROM / expression) is matched by EXACT text ONLY: it is semantically
@@ -1319,24 +1459,27 @@ func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.Packe
 		return false, 0
 	}
 
+	// Non-DML and not textually identical: nothing further establishes that
+	// these are the same statement, so the candidate is not servable. The
+	// mismatch report still names the nearest recorded query — matchCommand
+	// tracks that separately from the score.
 	if !(sqlparser.IsDML(expectedQuery) && sqlparser.IsDML(actualQuery)) {
 		log.Debug("No Query is dml",
 			zap.String("expected query", expectedQuery),
 			zap.String("actual query", actualQuery))
-		return false, matchCount
+		return false, 0
 	}
 
-	// Here we can compare the structure of the queries, as both are DML queries.
-	log.Debug("Both queries are DML",
-		zap.String("expected query", expectedQuery),
-		zap.String("actual query", actualQuery))
-
+	// Both are DML: fall back to comparing their parse-tree shape, unchanged
+	// from before. This tier is identifier-blind and is deliberately left as it
+	// was — it is not what this change is about, and it never returns a
+	// definitive match.
 	actualSignature, err := getQueryStructureCached(actualQuery)
 	if err != nil {
 		log.Debug("failed to get actual query structure",
 			zap.String("actual Query", actualQuery),
 			zap.Error(err))
-		return false, matchCount
+		return false, 0
 	}
 
 	expectedSignature, err := getQueryStructureCached(expectedQuery)
@@ -1344,17 +1487,22 @@ func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.Packe
 		log.Debug("failed to get expected query structure",
 			zap.String("expected Query", expectedQuery),
 			zap.Error(err))
-		return false, matchCount
+		return false, 0
 	}
 
 	if expectedSignature == actualSignature {
 		log.Debug("query structure matched",
 			zap.String("expected signature", expectedSignature),
 			zap.String("actual signature", actualSignature))
-		return false, matchCount + 6
+		// The +1 for equal PayloadLength is the DML tier's original tie-break
+		// between two structurally identical write statements, and it is kept so
+		// this tier behaves exactly as before. It is only ever a tie-break HERE,
+		// among candidates already known to share a parse tree — quite unlike its
+		// removed use as the sole signal for any statement of the same size.
+		return false, scoreQueryStructure + equalPayloadLength(expected, actual)
 	}
 
-	return false, matchCount
+	return false, 0
 }
 
 func matchQueryPacket(ctx context.Context, log *zap.Logger, expected, actual mysql.PacketBundle) (bool, int) {
@@ -1458,8 +1606,13 @@ func matchStmtExecutePacketQueryAware(logger *zap.Logger, expected, actual mysql
 	// Query logic:
 	queryMatched := false
 	queryExactMatched := false
-	eq := strings.TrimSpace(expectedQuery)
-	aq := strings.TrimSpace(actualQuery)
+	// Same identity rule as matchQuery: a leading observability prologue is not
+	// part of the prepared statement. Without this an app that traces its
+	// statements would never register a query-exact EXECUTE, and the read-back
+	// FIFO in matchCommand — which keys off queryExactMatched — would fall back
+	// to an arbitrary same-shape row.
+	eq := sqlStatementIdentity(expectedQuery)
+	aq := sqlStatementIdentity(actualQuery)
 
 	// If both queries are present, require them to match (exact or structural) for a definitive match.
 	if eq != "" && aq != "" {
@@ -1975,8 +2128,9 @@ func matchCloseWithQuery(expected, actual mysql.PacketBundle, expectedQuery, act
 	if matchHeader(*expected.Header.Header, *actual.Header.Header) {
 		score += 2
 	}
-	eq := strings.TrimSpace(expectedQuery)
-	aq := strings.TrimSpace(actualQuery)
+	// Identity ignores inert comments — see stripInertSQLComments.
+	eq := sqlStatementIdentity(expectedQuery)
+	aq := sqlStatementIdentity(actualQuery)
 	if eq == "" || aq == "" {
 		return score
 	}
@@ -2033,18 +2187,204 @@ func rejectsCrossVariableRead(expectedQuery, actualQuery string) bool {
 // parsed variable name.
 const sqlWhitespace = " \t\r\n"
 
-// stripLeadingSQLComment removes leading /* ... */ blocks (Connector/J prepends
-// a version banner and a "/* ping */" marker) plus surrounding whitespace.
-func stripLeadingSQLComment(s string) string {
-	s = strings.TrimSpace(s)
-	for strings.HasPrefix(s, "/*") {
-		i := strings.Index(s, "*/")
-		if i < 0 {
-			break
-		}
-		s = strings.TrimSpace(s[i+2:])
+// stripInertSQLComments removes every comment the server DISCARDS, leaving the
+// executable statement. It is the identity used to decide whether a live query
+// is the same statement as a recorded one.
+//
+// Two sources put comments in a statement:
+//
+//   - Drivers. Connector/J prepends a version banner and a "/* ping */" marker.
+//   - Client-side observability. Datadog DBM, Google sqlcommenter and
+//     OpenTelemetry inject a "/* key='value',... */" comment carrying a
+//     per-request W3C traceparent and the database endpoint that served the
+//     call — usually in front of the statement, but a tracer is free to put it
+//     anywhere.
+//
+// None of it reaches the server as SQL, so none of it is part of the
+// statement's identity. The observability comment in particular is hostile to
+// identity-by-raw-text: the traceparent makes the same statement a different
+// byte string on every execution, and the endpoint name changes the comment's
+// LENGTH when a cluster hands out its reader endpoint ("...cluster-ro-...")
+// instead of its writer ("...cluster-...").
+//
+// Two comment forms ARE executable and are deliberately left in place, because
+// removing them would equate statements the server treats differently:
+//
+//	/*! ... */   version-gated SQL — the server RUNS the contents
+//	/*+ ... */   optimizer hints — they change how the server runs it
+//
+// The scan is quote-aware: a "/*" or "--" inside a string literal or a
+// backquoted identifier is data, not a comment, and is preserved. Removing a
+// comment leaves exactly one space so that "SELECT/*c*/1" cannot become
+// "SELECT1"; an unterminated comment is left untouched, since guessing where it
+// was meant to end could silently delete real SQL.
+func stripInertSQLComments(sql string) string {
+	// Fast path: nothing that could start a comment.
+	if !strings.ContainsAny(sql, "/-#") {
+		return strings.TrimSpace(sql)
 	}
-	return s
+
+	var b strings.Builder
+	b.Grow(len(sql))
+
+	// writeGap appends a single separating space unless one is already there.
+	writeGap := func() {
+		out := b.String()
+		if len(out) > 0 && !strings.ContainsRune(sqlWhitespace, rune(out[len(out)-1])) {
+			b.WriteByte(' ')
+		}
+	}
+
+	for i := 0; i < len(sql); {
+		c := sql[i]
+		switch {
+		// Quoted string or backquoted identifier: copy verbatim to its close.
+		case c == '\'' || c == '"' || c == '`':
+			j := i + 1
+			for j < len(sql) {
+				if sql[j] == '\\' && c != '`' {
+					// Backslash escapes inside string literals (not identifiers).
+					j += 2
+					continue
+				}
+				if sql[j] == c {
+					// A doubled quote is an escaped quote, not the close.
+					if j+1 < len(sql) && sql[j+1] == c {
+						j += 2
+						continue
+					}
+					j++
+					break
+				}
+				j++
+			}
+			if j > len(sql) {
+				j = len(sql)
+			}
+			b.WriteString(sql[i:j])
+			i = j
+
+		case c == '/' && i+1 < len(sql) && sql[i+1] == '*':
+			// Executable comment forms are part of the statement. Copy the WHOLE
+			// span verbatim — emitting just "/" and re-entering the scanner would
+			// let the generic rules loose on the interior, and a "--" or "#" in
+			// there would run past the closing "*/" and swallow the rest of the
+			// statement.
+			if i+2 < len(sql) && (sql[i+2] == '!' || sql[i+2] == '+') {
+				if closeAt := strings.Index(sql[i+2:], "*/"); closeAt >= 0 {
+					end := i + 2 + closeAt + 2
+					b.WriteString(sql[i:end])
+					i = end
+					continue
+				}
+				// Unterminated: the rest is all statement.
+				b.WriteString(sql[i:])
+				i = len(sql)
+				continue
+			}
+			// MySQL block comments do not nest: the first "*/" closes.
+			closeAt := strings.Index(sql[i+2:], "*/")
+			if closeAt < 0 {
+				// Unterminated: copy the rest verbatim.
+				b.WriteString(sql[i:])
+				i = len(sql)
+				continue
+			}
+			i = i + 2 + closeAt + 2
+			writeGap()
+			i = skipSQLWhitespace(sql, i)
+
+		case isLineCommentAt(sql, i):
+			if nl := strings.IndexByte(sql[i:], '\n'); nl >= 0 {
+				i += nl + 1
+			} else {
+				i = len(sql)
+			}
+			writeGap()
+			i = skipSQLWhitespace(sql, i)
+
+		default:
+			b.WriteByte(c)
+			i++
+		}
+	}
+
+	return strings.TrimSpace(b.String())
+}
+
+// equalPayloadLength returns 1 when both packets declare the same wire payload
+// length, else 0. It is ONLY a tie-break inside the DML parse-tree tier; it is
+// deliberately not a signal anywhere else, because with a couple of hundred
+// bytes of tracer comment in front of every statement, unrelated queries share a
+// byte count constantly.
+func equalPayloadLength(expected, actual mysql.PacketBundle) int {
+	if expected.Header == nil || expected.Header.Header == nil ||
+		actual.Header == nil || actual.Header.Header == nil {
+		return 0
+	}
+	if expected.Header.Header.PayloadLength == actual.Header.Header.PayloadLength {
+		return 1
+	}
+	return 0
+}
+
+// isLineCommentAt reports whether a MySQL line comment starts at sql[i].
+//
+// "#" always starts one. "--" starts one only when followed by whitespace or
+// end-of-input — bare "--x" is the double unary minus operator, so treating it
+// as a comment would silently delete half an expression.
+func isLineCommentAt(sql string, i int) bool {
+	if sql[i] == '#' {
+		return true
+	}
+	if sql[i] != '-' || i+1 >= len(sql) || sql[i+1] != '-' {
+		return false
+	}
+	return i+2 >= len(sql) || strings.ContainsRune(sqlWhitespace, rune(sql[i+2]))
+}
+
+func skipSQLWhitespace(sql string, i int) int {
+	for i < len(sql) && strings.ContainsRune(sqlWhitespace, rune(sql[i])) {
+		i++
+	}
+	return i
+}
+
+// sqlStatementIdentity returns the text that identifies a statement for
+// matching: the executable statement with every inert comment removed.
+//
+// A statement that is NOTHING but comments — Connector/J's "/* ping */" — has
+// no executable body, and collapsing every such probe to the empty string would
+// make them all interchangeable. Those keep their raw text.
+func sqlStatementIdentity(query string) string {
+	if query == "" {
+		return ""
+	}
+	if v, ok := stmtIdentityCache.Get(query); ok {
+		return v
+	}
+	id := stripInertSQLComments(query)
+	if id == "" {
+		id = strings.TrimSpace(query)
+	}
+	stmtIdentityCache.Add(query, id)
+	return id
+}
+
+// commonPrefixLen returns the length of the longest shared prefix of a and b.
+// It is the closeness measure used to name the nearest recorded query in a
+// mismatch report. It is a REPORTING signal only and never feeds the match
+// score — two statements sharing a prefix are not thereby the same statement.
+func commonPrefixLen(a, b string) int {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	i := 0
+	for i < n && a[i] == b[i] {
+		i++
+	}
+	return i
 }
 
 // parseSingleSystemVarRead parses "SELECT @@[session.|global.|local.]<var>" and
@@ -2053,7 +2393,7 @@ func stripLeadingSQLComment(s string) string {
 // expressions, function calls) — so it only fires for the deterministic
 // single-variable probes Connector/J issues at connection setup.
 func parseSingleSystemVarRead(query string) (string, bool) {
-	s := stripLeadingSQLComment(query)
+	s := stripInertSQLComments(query)
 	// Require the SELECT keyword followed by at least one whitespace character.
 	// Match any whitespace (space, tab, CR, LF) rather than a single literal
 	// space, so "SELECT\t@@x" is recognised too.

--- a/pkg/agent/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match.go
@@ -2362,9 +2362,18 @@ func equalPayloadLength(expected, actual mysql.PacketBundle) int {
 //
 //   - IDENTIFIERS survive, so "SHOW FULL FIELDS FROM `invoices`" can never be
 //     answered by "... FROM `couriers`". This is the failure that byte-length
-//     scoring used to cause.
+//     scoring used to cause. Double-quoted tokens count as identifiers here
+//     precisely to keep this true under ANSI_QUOTES — see the case below.
 //   - The literal's TYPE survives (?s vs ?n), so "x = 1" and "x = '1'" stay
 //     distinct — MySQL does not treat them alike.
+//
+// What it does NOT preserve is WHICH rows the statement selects: "LIMIT 10" and
+// "LIMIT 20", "OFFSET 0" and "OFFSET 200", "status = 'active'" and
+// "status = 'deleted'" all mask alike. That is inherent to the tier — its whole
+// purpose is to serve a statement whose literal drifted — but it means a
+// paginated read can be answered with a different page's rows when the exact
+// recording is absent. It is why this tier is last, never definitive, and
+// scored below every tier that identifies a statement outright.
 //
 // It is computed lexically, with no SQL parser, deliberately: a parser renders
 // statements it does not model to a constant string, which would make unrelated
@@ -2383,8 +2392,29 @@ func maskSQLLiterals(sql string) string {
 			b.WriteString(sql[i:j])
 			i = j
 
-		// String literal, in either quoting style.
-		case c == '\'' || c == '"':
+		// Double-quoted token: AMBIGUOUS, so it is kept verbatim rather than
+		// masked. Under the default sql_mode it is a string literal, but under
+		// ANSI_QUOTES it is an IDENTIFIER — and nothing on the wire says which
+		// mode the session is in. Masking it would break the guarantee this
+		// whole tier rests on: with `"users"` and `"orders"` both collapsing to
+		// ?s, `SELECT id FROM "customers"` masks equal to `SELECT id FROM
+		// "orders"` and one table's rows get served for another's — the exact
+		// cross-serve this matcher exists to prevent, reached through a
+		// different quoting style.
+		//
+		// Keeping it verbatim costs only that a client which BOTH quotes its
+		// string literals with " AND interpolates them loses the drift tier for
+		// those statements: they stop matching instead of matching wrongly.
+		// That is this scanner's stated bias — ambiguity fails toward "no
+		// match" — and single-quoted literals, which is what drivers and ORMs
+		// actually emit, are unaffected.
+		case c == '"':
+			j := scanQuoted(sql, i, '"')
+			b.WriteString(sql[i:j])
+			i = j
+
+		// Single-quoted string literal: unambiguously a value.
+		case c == '\'':
 			i = scanQuoted(sql, i, c)
 			b.WriteString("?s")
 

--- a/pkg/agent/proxy/integrations/mysql/replayer/match_corpus_test.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match_corpus_test.go
@@ -1,0 +1,159 @@
+package replayer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models/mysql"
+	"go.uber.org/zap"
+)
+
+// TestMatchQuery_AgainstRecordedCorpus drives a whole recorded MySQL mock pool
+// through the real matcher and checks that every statement resolves to its OWN
+// recording — not to a different statement's, and not to nothing.
+//
+// Unit tests pin individual rules; this pins the property that matters in
+// aggregate, against real traffic. It exists because the failure it guards is
+// invisible one case at a time: when a matcher falls back to a signal that is
+// not the statement's identity (byte length, a type-only parse shape), each
+// individual answer still looks like a plausible result set, and only a pool-
+// wide run shows that most of them belong to some other query.
+//
+// Skipped unless KEPLOY_MYSQL_QUERY_CORPUS points at a JSON array of the
+// COM_QUERY texts from a mocks.yaml:
+//
+//	grep -oP '^\s*query:\s*\K.*' mocks.yaml | jq -Rs 'split("\n")|map(select(.!=""))'
+//
+// Point it at a recording whose client injects an observability prologue
+// (Datadog DBM, sqlcommenter, OpenTelemetry) — that is what defeats
+// identity-by-raw-text and what this guards.
+func TestMatchQuery_AgainstRecordedCorpus(t *testing.T) {
+	path := os.Getenv("KEPLOY_MYSQL_QUERY_CORPUS")
+	if path == "" {
+		t.Skip("set KEPLOY_MYSQL_QUERY_CORPUS to a JSON array of recorded COM_QUERY texts")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read corpus: %v", err)
+	}
+	var recorded []string
+	if err := json.Unmarshal(raw, &recorded); err != nil {
+		t.Fatalf("parse corpus: %v", err)
+	}
+	if len(recorded) == 0 {
+		t.Fatal("corpus is empty")
+	}
+
+	pool := make([]mysql.PacketBundle, 0, len(recorded))
+	for _, q := range recorded {
+		pool = append(pool, queryBundle(q))
+	}
+
+	logger := zap.NewNop()
+	ctx := context.Background()
+
+	// Mirrors matchCommand's COM_QUERY selection: an exact match wins
+	// immediately, otherwise the highest score with strict-greater replacement,
+	// and score 0 is not a candidate at all.
+	pick := func(live mysql.PacketBundle) int {
+		best, bestScore := -1, 0
+		for j := range pool {
+			ok, score := matchQueryPacket(ctx, logger, pool[j], live)
+			if ok {
+				return j
+			}
+			if score > bestScore {
+				best, bestScore = j, score
+			}
+		}
+		return best
+	}
+
+	var crossServed, unmatched []string
+	for _, q := range recorded {
+		j := pick(queryBundle(replayVariant(q)))
+		switch {
+		case j < 0:
+			unmatched = append(unmatched, truncate(sqlStatementIdentity(q), 90))
+		case oracleStatement(recorded[j]) == oracleStatement(q):
+			// Resolved to its own statement. Judged by an INDEPENDENT normaliser,
+			// deliberately: using sqlStatementIdentity as the oracle would let any
+			// identity collapse inside it — the very failure this file exists to
+			// catch — report itself as a success. Raw text equality will not do
+			// either, because the same statement is recorded many times, each with
+			// its own traceparent.
+		default:
+			crossServed = append(crossServed, fmt.Sprintf("asked %q -> served %q",
+				truncate(sqlStatementIdentity(q), 90), truncate(sqlStatementIdentity(recorded[j]), 90)))
+		}
+	}
+
+	t.Logf("corpus: %d statements, %d cross-served, %d unmatched",
+		len(recorded), len(crossServed), len(unmatched))
+
+	if n := len(crossServed); n > 0 {
+		t.Errorf("%d statement(s) were answered with a DIFFERENT statement's recorded response:\n  %s",
+			n, strings.Join(capped(crossServed, 5), "\n  "))
+	}
+	if n := len(unmatched); n > 0 {
+		t.Errorf("%d statement(s) matched nothing, so replay would tear the connection down:\n  %s",
+			n, strings.Join(capped(unmatched, 5), "\n  "))
+	}
+}
+
+// oracleStatement is a deliberately naive, independently written comment
+// stripper used only to judge the corpus run. It does not share a line of code
+// with stripInertSQLComments, so the two agreeing is real evidence; it is not
+// quote-aware, which is fine for judging recorded production SQL and is why it
+// is confined to this test.
+func oracleStatement(sql string) string {
+	out := oracleBlockComment.ReplaceAllString(sql, " ")
+	out = oracleLineComment.ReplaceAllString(out, " ")
+	return strings.Join(strings.Fields(out), " ")
+}
+
+var (
+	// Non-executable block comments only: "/*!" and "/*+" are the server's.
+	oracleBlockComment = regexp.MustCompile(`(?s)/\*[^!+].*?\*/|/\*\*/`)
+	oracleLineComment  = regexp.MustCompile(`(?m)(--[ \t][^\n]*|#[^\n]*)`)
+)
+
+func capped(s []string, n int) []string {
+	if len(s) <= n {
+		return s
+	}
+	return append(s[:n:n], fmt.Sprintf("... and %d more", len(s)-n))
+}
+
+var traceparentRe = regexp.MustCompile(`traceparent='[^']*'`)
+
+const (
+	writerHostMarker = "cluster-"
+	readerHostMarker = "cluster-ro-"
+)
+
+// replayVariant turns a recorded query into the text the SAME statement would
+// carry on a later run: a fresh traceparent, and the other cluster endpoint.
+// Those are the two ways an observability prologue differs between runs — one
+// changes its content, the other also changes its length.
+func replayVariant(q string) string {
+	end := strings.Index(q, "*/")
+	if !strings.HasPrefix(strings.TrimSpace(q), "/*") || end < 0 {
+		return q
+	}
+	prologue, body := q[:end+2], q[end+2:]
+	prologue = traceparentRe.ReplaceAllString(prologue,
+		"traceparent='00-11112222333344445555666677778888-9999aaaabbbbcccc-01'")
+	switch {
+	case strings.Contains(prologue, readerHostMarker):
+		prologue = strings.Replace(prologue, readerHostMarker, writerHostMarker, 1)
+	case strings.Contains(prologue, writerHostMarker):
+		prologue = strings.Replace(prologue, writerHostMarker, readerHostMarker, 1)
+	}
+	return prologue + body
+}

--- a/pkg/agent/proxy/integrations/mysql/replayer/match_dbmcomment_test.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match_dbmcomment_test.go
@@ -1,0 +1,280 @@
+package replayer
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models/mysql"
+	"go.uber.org/zap"
+)
+
+// Datadog DBM (sqlcommenter) comments, in the shape a traced service emits.
+// Every executed statement carries one, and two properties matter:
+//
+//   - traceparent is unique per request, so the recorded query text can NEVER
+//     be byte-equal to the replayed one.
+//   - ddh names the database endpoint actually used. A cluster hands out a
+//     writer ("cluster-") and a reader ("cluster-ro-") endpoint, so the SAME
+//     statement carries a comment three bytes longer on whichever run happened
+//     to be routed to the reader.
+//
+// The two constants therefore differ in BOTH content and length, which is the
+// whole point: neither text equality nor payload length can identify a
+// statement once a tracer is in front of it.
+const (
+	dbmWriter = "/*dde='sandbox',ddps='web-service',ddpv='1a2b3c4d'," +
+		"ddh='demo.cluster-abcdefghijkl.us-east-1.rds.amazonaws.com'," +
+		"dddb='appdb',traceparent='00-1111111111111111aaaaaaaaaaaaaaaa-1111111111111111-01'*/ "
+	dbmReader = "/*dde='sandbox',ddps='web-service',ddpv='5e6f7a8b'," +
+		"ddh='demo.cluster-ro-abcdefghijkl.us-east-1.rds.amazonaws.com'," +
+		"dddb='appdb',traceparent='00-2222222222222222bbbbbbbbbbbbbbbb-2222222222222222-01'*/ "
+)
+
+// queryBundle builds a COM_QUERY PacketBundle whose PayloadLength is the real
+// wire length (1 command byte + the SQL text), which is what matchQuery
+// compares.
+func queryBundle(sql string) mysql.PacketBundle {
+	return mysql.PacketBundle{
+		Header: &mysql.PacketInfo{
+			Header: &mysql.Header{PayloadLength: uint32(len(sql) + 1), SequenceID: 0},
+			Type:   "COM_QUERY",
+		},
+		Message: &mysql.QueryPacket{Command: 0x03, Query: sql},
+	}
+}
+
+// TestMatchQueryPacket_TraceCommentDoesNotDefeatMatching pins the contract that
+// a comment the server discards is not part of a statement's identity.
+//
+// A COM_QUERY carrying a Datadog DBM / sqlcommenter comment is the same
+// statement as the recorded one whenever the SQL around the comment is
+// identical, wherever the tracer chose to put it.
+//
+// Before the fix it was not: the exact-text path needs byte equality and the
+// unique traceparent guarantees inequality, so matching fell through to the
+// only remaining signal — equal MySQL PayloadLength — which the writer/reader
+// endpoint swap destroys. The candidate then scored 0, matchCommand recorded no
+// closest mock, and the connection was torn down as a missing recording.
+func TestMatchQueryPacket_TraceCommentDoesNotDefeatMatching(t *testing.T) {
+	logger := zap.NewNop()
+	ctx := context.Background()
+
+	const body = "SELECT `invoices`.* FROM `invoices` WHERE `invoices`.`deleted_at` IS NULL " +
+		"AND `invoices`.`external_id` = 'aaaaaaaaaaaaaaaaaaaaaaaa' LIMIT 1"
+
+	t.Run("comment differs in content only", func(t *testing.T) {
+		// Same endpoint, different traceparent — equal PayloadLength.
+		live := queryBundle(strings.Replace(dbmWriter,
+			"traceparent='00-1111111111111111aaaaaaaaaaaaaaaa-1111111111111111-01'",
+			"traceparent='00-3333333333333333cccccccccccccccc-3333333333333333-01'", 1) + body)
+		recorded := queryBundle(dbmWriter + body)
+
+		if recorded.Header.Header.PayloadLength != live.Header.Header.PayloadLength {
+			t.Fatalf("test setup broken: this subtest must hold PayloadLength equal")
+		}
+		if ok, score := matchQueryPacket(ctx, logger, recorded, live); !ok {
+			t.Fatalf("same statement with a different traceparent must match; got ok=false score=%d", score)
+		}
+	})
+
+	t.Run("comment differs in length (writer vs reader endpoint)", func(t *testing.T) {
+		recorded := queryBundle(dbmWriter + body)
+		live := queryBundle(dbmReader + body)
+
+		if len(dbmWriter) == len(dbmReader) {
+			t.Fatalf("test setup broken: the two comments must differ in length")
+		}
+		if ok, score := matchQueryPacket(ctx, logger, recorded, live); !ok {
+			t.Fatalf("same statement behind a different-length trace comment must match; got ok=false score=%d "+
+				"(score 0 means matchCommand sees no candidate at all)", score)
+		}
+	})
+
+	t.Run("comment in the middle of the statement", func(t *testing.T) {
+		recorded := queryBundle("SELECT /* traceparent=aaaa */ `total` FROM `invoices` WHERE `id` = 1")
+		live := queryBundle("SELECT /* traceparent=bbbb */ `total` FROM `invoices` WHERE `id` = 1")
+
+		if ok, score := matchQueryPacket(ctx, logger, recorded, live); !ok {
+			t.Fatalf("a tracer may inject its comment anywhere, not just in front; got ok=false score=%d", score)
+		}
+	})
+}
+
+// TestMatchQueryPacket_EqualLengthDifferentStatementsNeverMatch pins the other
+// half of the same defect, which is the dangerous half: matching must not fall
+// back to "the payload happens to be the same size".
+//
+// With a ~200-byte comment in front of every statement, unrelated queries
+// collide on total length constantly — every `SHOW FULL FIELDS FROM <table>`
+// with an equal-length table name measures the same. Serving one table's column
+// metadata in answer to another's makes an ORM build a model with the wrong
+// columns, which surfaces downstream as an application bug rather than a mock
+// mismatch.
+func TestMatchQueryPacket_EqualLengthDifferentStatementsNeverMatch(t *testing.T) {
+	logger := zap.NewNop()
+	ctx := context.Background()
+
+	cases := []struct{ recorded, live string }{
+		{"SHOW FULL FIELDS FROM `invoices`", "SHOW FULL FIELDS FROM `couriers`"},
+		{"SHOW FULL FIELDS FROM `payments`", "SHOW FULL FIELDS FROM `receipts`"},
+		{"SELECT `id` FROM `invoices` WHERE `id` = 1", "SELECT `id` FROM `couriers` WHERE `id` = 1"},
+		// Same table, different inline literal: still a different statement,
+		// because the recorded response is a different row.
+		{
+			"SELECT `total` FROM `invoices` WHERE `external_id` = 'aaaaaaaaaaaaaaaaaaaaaaaa'",
+			"SELECT `total` FROM `invoices` WHERE `external_id` = 'bbbbbbbbbbbbbbbbbbbbbbbb'",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%.44s", tc.live), func(t *testing.T) {
+			recorded := queryBundle(dbmWriter + tc.recorded)
+			live := queryBundle(dbmWriter + tc.live)
+
+			if recorded.Header.Header.PayloadLength != live.Header.Header.PayloadLength {
+				t.Fatalf("test setup broken: the two statements must have equal PayloadLength")
+			}
+
+			ok, score := matchQueryPacket(ctx, logger, recorded, live)
+			if ok {
+				t.Fatalf("different statements must never match")
+			}
+			if score != 0 {
+				t.Fatalf("a different statement of equal byte length must score 0, got %d — "+
+					"a non-zero score makes it a servable candidate in matchCommand and cross-serves "+
+					"one statement's result set for another", score)
+			}
+		})
+	}
+}
+
+// TestMatchQueryPacket_ExecutableCommentsAreNeverStripped guards the one way
+// comment-tolerant matching could go wrong: two comment forms are not comments
+// to the server at all.
+//
+//	/*! ... */  version-gated SQL — the server RUNS the contents, and the
+//	            version gate decides WHICH statement runs
+//	/*+ ... */  optimizer hint — changes the plan
+//
+// Ignoring either would equate statements the server treats differently.
+func TestMatchQueryPacket_ExecutableCommentsAreNeverStripped(t *testing.T) {
+	logger := zap.NewNop()
+	ctx := context.Background()
+
+	cases := []struct{ name, recorded, live string }{
+		{"different version gate", "/*!40101 SET NAMES utf8 */", "/*!80000 SET NAMES utf8 */"},
+		{"version gate vs none", "/*!40101 SET NAMES utf8 */", "SET NAMES utf8"},
+		{"leading hint vs none", "/*+ MAX_EXECUTION_TIME(1) */ SELECT a FROM t", "SELECT a FROM t"},
+		// Equal byte length, so the old payload-length tier would have made this
+		// a servable candidate.
+		{"leading hint differs", "/*+ MAX_EXECUTION_TIME(1) */ SELECT a FROM t", "/*+ MAX_EXECUTION_TIME(2) */ SELECT a FROM t"},
+		{"inline hint differs", "SELECT /*+ MAX_EXECUTION_TIME(1) */ a FROM t", "SELECT /*+ MAX_EXECUTION_TIME(9999) */ a FROM t"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, score := matchQueryPacket(ctx, logger, queryBundle(tc.recorded), queryBundle(tc.live))
+			if ok || score != 0 {
+				t.Errorf("executable comments differ, so these are different statements; got ok=%v score=%d", ok, score)
+			}
+		})
+	}
+}
+
+// TestStripInertSQLComments covers the primitive directly, including the forms
+// that must survive and the quoting rules that stop it eating real SQL.
+func TestStripInertSQLComments(t *testing.T) {
+	cases := []struct{ name, in, want string }{
+		{"leading block comment", "/* trace */ SELECT 1", "SELECT 1"},
+		{"stacked comments", "/* a */ /* b */\n SELECT 1", "SELECT 1"},
+		{"dbm comment", dbmWriter + "SELECT 1", "SELECT 1"},
+		{"inline comment", "SELECT /* t */ a FROM b", "SELECT a FROM b"},
+		{"trailing comment", "SELECT a FROM b /* t */", "SELECT a FROM b"},
+		{"comment glues tokens", "SELECT/*c*/1", "SELECT 1"},
+		{"line comment", "-- trace id\nSELECT 1", "SELECT 1"},
+		{"hash comment", "# trace id\nSELECT 1", "SELECT 1"},
+		{"double unary minus is not a comment", "SELECT --1 + 2", "SELECT --1 + 2"},
+		{"unterminated block comment is left alone", "SELECT /* oops", "SELECT /* oops"},
+		{"version gate survives", "/*!40101 SET NAMES utf8 */", "/*!40101 SET NAMES utf8 */"},
+		{"leading hint survives", "/*+ HINT */ SELECT 1", "/*+ HINT */ SELECT 1"},
+		{"inline hint survives", "SELECT /*+ HINT */ a FROM b", "SELECT /*+ HINT */ a FROM b"},
+		{"comment-only has no body", "/* ping */", ""},
+
+		// Quote awareness: these are data, not comments.
+		{"block marker in string literal", "SELECT '/* not a comment */' FROM t", "SELECT '/* not a comment */' FROM t"},
+		{"dashes in string literal", "SELECT 'a -- b' FROM t", "SELECT 'a -- b' FROM t"},
+		{"hash in string literal", "SELECT '#tag' FROM t", "SELECT '#tag' FROM t"},
+		{"block marker in identifier", "SELECT `we/*ird` FROM t", "SELECT `we/*ird` FROM t"},
+		{"escaped quote inside literal", `SELECT 'it\'s /* fine */' FROM t`, `SELECT 'it\'s /* fine */' FROM t`},
+		{"doubled quote inside literal", "SELECT 'it''s /* fine */' FROM t", "SELECT 'it''s /* fine */' FROM t"},
+		{"comment after a literal is still stripped", "SELECT 'x' /* c */ FROM t", "SELECT 'x' FROM t"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := stripInertSQLComments(tc.in); got != tc.want {
+				t.Errorf("stripInertSQLComments(%q)\n got %q\nwant %q", tc.in, got, tc.want)
+			}
+		})
+	}
+
+	// A probe that is nothing but a comment keeps its raw text, so two different
+	// probes stay distinguishable instead of both collapsing to "".
+	if got := sqlStatementIdentity("/* ping */"); got != "/* ping */" {
+		t.Errorf("sqlStatementIdentity(%q) = %q, want the raw text", "/* ping */", got)
+	}
+	if sqlStatementIdentity("/* ping */") == sqlStatementIdentity("/* health */") {
+		t.Error("two different comment-only probes must not share an identity")
+	}
+}
+
+// TestMatchQueryPacket_LiteralTypeIsPartOfTheStatement pins that a numeric
+// literal and a quoted one are different statements.
+//
+// MySQL's "= 1" is a numeric comparison that also matches the strings '01',
+// ' 1' and '1 '; "= '1'" is a string comparison that matches none of them. Any
+// normalisation that parameterises literals away — comparing "same shape plus
+// the same literal TEXT" — loses the distinction and would serve one query's
+// rows for the other.
+func TestMatchQueryPacket_LiteralTypeIsPartOfTheStatement(t *testing.T) {
+	logger := zap.NewNop()
+	ctx := context.Background()
+
+	cases := []struct {
+		recorded, live string
+		// DML still reaches the pre-existing parse-tree tier, which is blind to
+		// both identifiers and literal types and scores this pair weakly. That
+		// tier is unchanged by this fix and never returns a definitive match, so
+		// the contract asserted here is only that the pair is not EXACT.
+		wantScore int
+	}{
+		// Every pair is deliberately EQUAL in byte length, so the payload-length
+		// scoring this fix removed would have made them interchangeable.
+		{recorded: "SELECT * FROM `invoices` WHERE `x` = 111", live: "SELECT * FROM `invoices` WHERE `x` = '1'"},
+		{recorded: "SELECT * FROM `invoices` WHERE `x` = 1.500", live: "SELECT * FROM `invoices` WHERE `x` = '1.5'"},
+		{
+			recorded:  "INSERT INTO `invoices` (`a`) VALUES (000)",
+			live:      "INSERT INTO `invoices` (`a`) VALUES ('0')",
+			wantScore: scoreQueryStructure + 1, // structure tier plus its equal-length tie-break
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%.44s", tc.live), func(t *testing.T) {
+			recorded := queryBundle(dbmWriter + tc.recorded)
+			live := queryBundle(dbmWriter + tc.live)
+			if recorded.Header.Header.PayloadLength != live.Header.Header.PayloadLength {
+				t.Fatalf("test setup broken: the pair must be equal length, else the old scoring rejected it anyway")
+			}
+			ok, score := matchQueryPacket(ctx, logger, recorded, live)
+			if ok {
+				t.Errorf("a numeric literal and a quoted one are different statements; "+
+					"matching them definitively serves %q's rows for %q", tc.recorded, tc.live)
+			}
+			if score != tc.wantScore {
+				t.Errorf("score = %d, want %d", score, tc.wantScore)
+			}
+		})
+	}
+}

--- a/pkg/agent/proxy/integrations/mysql/replayer/match_dbmcomment_test.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match_dbmcomment_test.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
+	"go.keploy.io/server/v3/pkg/models"
 	"go.keploy.io/server/v3/pkg/models/mysql"
 	"go.uber.org/zap"
 )
@@ -339,6 +341,13 @@ func TestMaskSQLLiterals(t *testing.T) {
 		differs(t, "SHOW FULL FIELDS FROM `invoices`", "SHOW FULL FIELDS FROM `couriers`")
 		differs(t, "SELECT a FROM t1", "SELECT a FROM t2")
 		differs(t, "SELECT `col1` FROM t", "SELECT `col2` FROM t")
+		// Under sql_mode=ANSI_QUOTES a double-quoted token is an IDENTIFIER,
+		// and nothing on the wire says which mode the session is in. Masking it
+		// as a string made two DIFFERENT TABLES mask alike, so one table's rows
+		// were served for another's — the very cross-serve this matcher exists
+		// to prevent, reached through a different quoting style.
+		differs(t, `SELECT id FROM "customers" WHERE id = 1`, `SELECT id FROM "orders" WHERE id = 1`)
+		differs(t, `SELECT "col1" FROM t`, `SELECT "col2" FROM t`)
 		// A digit inside an identifier is part of the name, not a literal.
 		if got := maskSQLLiterals("SET NAMES utf8mb4"); got != "SET NAMES utf8mb4" {
 			t.Errorf("identifier digits must survive, got %q", got)
@@ -374,5 +383,60 @@ func TestIsSessionControlStatement(t *testing.T) {
 		if isSessionControlStatement(q) {
 			t.Errorf("%q is not a session-control statement", q)
 		}
+	}
+}
+
+// TestMatchCommand_AnsiQuotedIdentifierIsNeverCrossServed is the regression for
+// the literal-drift tier's one blind spot.
+//
+// Under sql_mode=ANSI_QUOTES a double-quoted token is an IDENTIFIER, not a
+// string, and the wire carries nothing that says which mode the session is in.
+// While maskSQLLiterals masked `"..."` as a value, `SELECT id FROM "customers"`
+// and `SELECT id FROM "orders"` both became `SELECT id FROM ?s ...`, so a query
+// against one table was answered with the other table's recording — the same
+// silent wrong-table serve that equal-byte-length scoring used to cause, which
+// is exactly what this matcher exists to prevent.
+//
+// The backquoted form is asserted alongside it as the control: it was always
+// treated as an identifier and must stay that way.
+func TestMatchCommand_AnsiQuotedIdentifierIsNeverCrossServed(t *testing.T) {
+	logger := zap.NewNop()
+	base := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+
+	for _, tc := range []struct{ name, recorded, live string }{
+		{
+			name:     "ansi quoted identifiers",
+			recorded: `SELECT id FROM "orders" WHERE id = 1`,
+			live:     `SELECT id FROM "customers" WHERE id = 1`,
+		},
+		{
+			name:     "backquoted identifiers",
+			recorded: "SELECT id FROM `orders` WHERE id = 1",
+			live:     "SELECT id FROM `customers` WHERE id = 1",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db := &fakeMockDb{session: []*models.Mock{
+				readbackMock("orders", tc.recorded, "ROWS=orders", base),
+			}}
+
+			resp, ok, _, err := matchCommand(context.Background(), logger, comQueryReq(tc.live), db, newDecodeCtx(), nil, nil)
+			if err != nil {
+				t.Fatalf("matchCommand: %v", err)
+			}
+			if ok && resp != nil {
+				t.Fatalf("cross-serve: a query against a different table was answered with %q; only the literal may drift, never the table", resp.Payload)
+			}
+		})
+	}
+
+	// The tier must still do its job: same table, drifted single-quoted literal.
+	db := &fakeMockDb{session: []*models.Mock{
+		readbackMock("orders", `SELECT id FROM "orders" WHERE ref = 'aaa'`, "ROWS=orders", base),
+	}}
+	resp, ok, _, err := matchCommand(context.Background(), logger,
+		comQueryReq(`SELECT id FROM "orders" WHERE ref = 'bbb'`), db, newDecodeCtx(), nil, nil)
+	if err != nil || !ok || resp == nil {
+		t.Fatalf("a drifted single-quoted literal on the SAME table must still resolve, got ok=%v err=%v", ok, err)
 	}
 }

--- a/pkg/agent/proxy/integrations/mysql/replayer/match_dbmcomment_test.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match_dbmcomment_test.go
@@ -120,11 +120,10 @@ func TestMatchQueryPacket_EqualLengthDifferentStatementsNeverMatch(t *testing.T)
 		{"SHOW FULL FIELDS FROM `invoices`", "SHOW FULL FIELDS FROM `couriers`"},
 		{"SHOW FULL FIELDS FROM `payments`", "SHOW FULL FIELDS FROM `receipts`"},
 		{"SELECT `id` FROM `invoices` WHERE `id` = 1", "SELECT `id` FROM `couriers` WHERE `id` = 1"},
-		// Same table, different inline literal: still a different statement,
-		// because the recorded response is a different row.
+		// Same shape, different COLUMN: an identifier, so never interchangeable.
 		{
 			"SELECT `total` FROM `invoices` WHERE `external_id` = 'aaaaaaaaaaaaaaaaaaaaaaaa'",
-			"SELECT `total` FROM `invoices` WHERE `external_id` = 'bbbbbbbbbbbbbbbbbbbbbbbb'",
+			"SELECT `total` FROM `invoices` WHERE `internal_id` = 'aaaaaaaaaaaaaaaaaaaaaaaa'",
 		},
 	}
 
@@ -276,5 +275,104 @@ func TestMatchQueryPacket_LiteralTypeIsPartOfTheStatement(t *testing.T) {
 				t.Errorf("score = %d, want %d", score, tc.wantScore)
 			}
 		})
+	}
+}
+
+// TestMatchQueryPacket_InlineLiteralDriftIsServable is the case keploy's own
+// go-memory-load-mysql suite exercises: a client that interpolates its values
+// instead of binding them re-issues the same statement with a freshly generated
+// id on every run.
+//
+//	recorded: SELECT ... FROM customers WHERE id = '<uuid A>'
+//	replayed: SELECT ... FROM customers WHERE id = '<uuid B>'
+//
+// There is no exact match and a SELECT never reaches the DML parse-tree tier, so
+// without a literal-drift tier the candidate scores 0, matchCommand finds no
+// candidate at all, and the MySQL connection is torn down mid-suite.
+//
+// It must be servable — but only as a last resort, never as a definitive match,
+// because the recorded response is a different row.
+func TestMatchQueryPacket_InlineLiteralDriftIsServable(t *testing.T) {
+	logger := zap.NewNop()
+	ctx := context.Background()
+
+	const shape = "SELECT `id`, `email`, `full_name` FROM `customers` WHERE `id` = '%s'"
+	recorded := queryBundle(dbmWriter + fmt.Sprintf(shape, "1dc32a3c-a50c-5e92-9797-a6b6c4c7156e"))
+	live := queryBundle(dbmReader + fmt.Sprintf(shape, "2a22d715-4799-5150-80d6-a0dd935fbda2"))
+
+	ok, score := matchQueryPacket(ctx, logger, recorded, live)
+	if ok {
+		t.Error("a different id is a different row: this must not be a definitive match")
+	}
+	if score == 0 {
+		t.Fatal("a re-issued statement whose inline literal drifted must stay servable as a last " +
+			"resort; scoring 0 leaves matchCommand with no candidate and tears the connection down")
+	}
+	if score >= scoreQueryStructure {
+		t.Errorf("score = %d, must rank below the DML parse-tree tier (%d)", score, scoreQueryStructure)
+	}
+}
+
+// TestMaskSQLLiterals pins what the literal-drift tier will and will not equate.
+func TestMaskSQLLiterals(t *testing.T) {
+	sameShape := func(t *testing.T, a, b string) {
+		t.Helper()
+		if maskSQLLiterals(a) != maskSQLLiterals(b) {
+			t.Errorf("must be the same shape:\n  %s -> %s\n  %s -> %s", a, maskSQLLiterals(a), b, maskSQLLiterals(b))
+		}
+	}
+	differs := func(t *testing.T, a, b string) {
+		t.Helper()
+		if maskSQLLiterals(a) == maskSQLLiterals(b) {
+			t.Errorf("must NOT be equated (both mask to %q):\n  %s\n  %s", maskSQLLiterals(a), a, b)
+		}
+	}
+
+	t.Run("drifted values are the same shape", func(t *testing.T) {
+		sameShape(t, "SELECT * FROM t WHERE id = 'aaa'", "SELECT * FROM t WHERE id = 'bbb'")
+		sameShape(t, "SELECT * FROM t WHERE id = 5", "SELECT * FROM t WHERE id = 61234")
+		sameShape(t, "SELECT * FROM t WHERE a = 1.5 AND b = 'x'", "SELECT * FROM t WHERE a = 9.25 AND b = 'y'")
+		sameShape(t, "SELECT * FROM t WHERE h = 0x1F", "SELECT * FROM t WHERE h = 0xAB09")
+	})
+
+	t.Run("identifiers are never masked", func(t *testing.T) {
+		differs(t, "SHOW FULL FIELDS FROM `invoices`", "SHOW FULL FIELDS FROM `couriers`")
+		differs(t, "SELECT a FROM t1", "SELECT a FROM t2")
+		differs(t, "SELECT `col1` FROM t", "SELECT `col2` FROM t")
+		// A digit inside an identifier is part of the name, not a literal.
+		if got := maskSQLLiterals("SET NAMES utf8mb4"); got != "SET NAMES utf8mb4" {
+			t.Errorf("identifier digits must survive, got %q", got)
+		}
+	})
+
+	t.Run("literal type is preserved", func(t *testing.T) {
+		differs(t, "SELECT * FROM t WHERE x = 1", "SELECT * FROM t WHERE x = '1'")
+	})
+
+	t.Run("quote-awareness", func(t *testing.T) {
+		// A quote inside a literal must not end it early.
+		sameShape(t, `SELECT * FROM t WHERE s = 'it\'s a'`, `SELECT * FROM t WHERE s = 'other'`)
+		sameShape(t, "SELECT * FROM t WHERE s = 'it''s a'", "SELECT * FROM t WHERE s = 'other'")
+		// Backquoted identifiers containing digits or quotes stay intact.
+		differs(t, "SELECT `we'ird1` FROM t", "SELECT `we'ird2` FROM t")
+	})
+
+	t.Run("executable comments are copied through", func(t *testing.T) {
+		differs(t, "/*!40101 SET NAMES utf8 */", "/*!80000 SET NAMES utf8 */")
+	})
+}
+
+// TestIsSessionControlStatement pins the exclusion that keeps the literal-drift
+// tier away from statements whose literal is their meaning.
+func TestIsSessionControlStatement(t *testing.T) {
+	for _, q := range []string{"SET NAMES utf8mb4", "set autocommit = 0", "SET\n@@sql_mode = 'X'", "SET\t@@x = 1", "SET"} {
+		if !isSessionControlStatement(q) {
+			t.Errorf("%q is a session-control statement", q)
+		}
+	}
+	for _, q := range []string{"SELECT 1", "SETTINGS", "SETUP", "settle up"} {
+		if isSessionControlStatement(q) {
+			t.Errorf("%q is not a session-control statement", q)
+		}
 	}
 }

--- a/pkg/agent/proxy/integrations/mysql/replayer/match_diagnostics_test.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match_diagnostics_test.go
@@ -1,0 +1,141 @@
+package replayer
+
+import (
+	"context"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/schemanoise"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.keploy.io/server/v3/pkg/models/mysql"
+	"go.uber.org/zap"
+)
+
+// TestMatchCommand_MissNamesTheNearestRecordingInsteadOfClaimingNoneExists pins
+// the diagnostic that made this class of failure so hard to read.
+//
+// A query that drifted from its recording produces no scoring candidate. That
+// used to leave closest_mock empty, and query.go turned an empty closest_mock
+// into "REPLAY-ORPHAN: mock NEVER RECORDED for this query (lost at record
+// time)". So an operator whose recording was sitting right there, intact, was
+// told to go looking for a lost mock. The candidate count and match phase the
+// report printed alongside it were never assigned either — a hardcoded zero
+// that read as "the pool was empty".
+//
+// The miss must therefore carry a MEASURED candidate count and phase, and must
+// name the nearest recorded statement.
+func TestMatchCommand_MissNamesTheNearestRecordingInsteadOfClaimingNoneExists(t *testing.T) {
+	logger := zap.NewNop()
+
+	const recorded = "SELECT `id`, `name` FROM `invoices` WHERE `token` = 'recorded-token'"
+	const live = "SELECT `id`, `name` FROM `couriers` WHERE `token` = 'live-token'"
+
+	db := &fakeMockDb{session: []*models.Mock{
+		readbackMock("m-invoices", recorded, "row-1", zeroTime()),
+	}}
+	eng := schemanoise.New(mysqlNoiseAdapter{}, false, false)
+
+	_, ok, miss, err := matchCommand(context.Background(), logger, comQueryReq(live), db, newDecodeCtx(), eng, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatal("a different table must not match")
+	}
+	if miss == nil {
+		t.Fatal("a miss must carry a report")
+	}
+	if miss.candidateCount != 1 {
+		t.Errorf("candidateCount = %d, want 1 — the count must be measured, not left at its zero value "+
+			"(zero is what made a drifted query look like an empty mock pool)", miss.candidateCount)
+	}
+	if miss.matchPhase != models.MatchPhaseExhausted {
+		t.Errorf("matchPhase = %q, want %q", miss.matchPhase, models.MatchPhaseExhausted)
+	}
+	if miss.matchPhase == models.MatchPhaseNoMocks {
+		t.Error("mocks were present, so the report must not claim the pool was empty — " +
+			"that is the condition query.go turns into REPLAY-ORPHAN")
+	}
+	if miss.closestMock != "m-invoices" {
+		t.Errorf("closestMock = %q, want the nearest recorded statement's mock", miss.closestMock)
+	}
+}
+
+// TestMatchCommand_DBMCommentEndToEnd drives the whole matchCommand path with a
+// traced service's traffic shape: the recorded statement behind a
+// writer-endpoint comment, the live one behind a reader-endpoint comment with a
+// fresh traceparent.
+//
+// A DECOY of a different statement sits first in the pool, and the test asserts
+// WHICH recorded response comes back — not merely that something did. Both mocks
+// declare the same wire payload length, which is what the matcher used to score
+// on, so under the old behaviour the decoy wins on pool order and the assertion
+// fails. Asserting only "ok" would pass either way and prove nothing.
+func TestMatchCommand_DBMCommentEndToEnd(t *testing.T) {
+	logger := zap.NewNop()
+
+	const body = "SELECT `id`, `name` FROM `invoices` WHERE `id` = 1"
+	const decoy = "SELECT `id`, `name` FROM `couriers` WHERE `id` = 9"
+
+	db := &fakeMockDb{session: []*models.Mock{
+		readbackMock("m-decoy", dbmWriter+decoy, "decoy-row", zeroTime()),
+		readbackMock("m-target", dbmWriter+body, "target-row", zeroTime()),
+	}}
+	eng := schemanoise.New(mysqlNoiseAdapter{}, false, false)
+
+	resp, ok, _, err := matchCommand(context.Background(), logger, comQueryReq(dbmReader+body), db, newDecodeCtx(), eng, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("the same statement behind a different-length DBM comment must be served")
+	}
+	if resp == nil {
+		t.Fatal("a match must carry a response")
+	}
+	if resp.Payload != "target-row" {
+		t.Errorf("served %q, want \"target-row\" — a different statement's recorded response was returned", resp.Payload)
+	}
+}
+
+// TestMatchCommand_NoMocksPhaseStillReachable keeps the REPLAY-ORPHAN
+// diagnostic alive.
+//
+// query.go raises "no data mock available for this query" only on
+// MatchPhaseNoMocks, which is derived from the candidate count — so WHERE that
+// count is incremented decides whether the diagnostic can ever fire. Count it
+// before the lifetime filter and a lone handshake mock keeps it non-zero
+// forever, silently retiring the message.
+//
+// Here the pool holds only a session-lifetime handshake mock, which the command
+// phase skips. Nothing was compared, so the phase must say so.
+func TestMatchCommand_NoMocksPhaseStillReachable(t *testing.T) {
+	handshake := &models.Mock{Name: "hs", Kind: models.MySQL}
+	handshake.TestModeInfo.Lifetime = models.LifetimeSession
+	handshake.Spec.Metadata = map[string]string{"type": "config"}
+	handshake.Spec.MySQLRequests = []mysql.Request{{
+		PacketBundle: mysql.PacketBundle{
+			Header:  &mysql.PacketInfo{Header: &mysql.Header{PayloadLength: 32}, Type: "HandshakeResponse41"},
+			Message: &mysql.HandshakeResponse41Packet{},
+		},
+	}}
+
+	db := &fakeMockDb{session: []*models.Mock{handshake}}
+	eng := schemanoise.New(mysqlNoiseAdapter{}, false, false)
+
+	_, ok, miss, err := matchCommand(context.Background(), zap.NewNop(),
+		comQueryReq("SELECT 1"), db, newDecodeCtx(), eng, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatal("a handshake mock must not answer a COM_QUERY")
+	}
+	if miss.candidateCount != 0 {
+		t.Errorf("candidateCount = %d, want 0 — a handshake mock is skipped by the command "+
+			"phase and must not be counted as a candidate", miss.candidateCount)
+	}
+	if miss.matchPhase != models.MatchPhaseNoMocks {
+		t.Errorf("matchPhase = %q, want %q — otherwise the REPLAY-ORPHAN diagnostic can never fire",
+			miss.matchPhase, models.MatchPhaseNoMocks)
+	}
+}

--- a/pkg/agent/proxy/integrations/mysql/replayer/match_diagnostics_test.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match_diagnostics_test.go
@@ -2,6 +2,7 @@ package replayer
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/schemanoise"
@@ -137,5 +138,43 @@ func TestMatchCommand_NoMocksPhaseStillReachable(t *testing.T) {
 	if miss.matchPhase != models.MatchPhaseNoMocks {
 		t.Errorf("matchPhase = %q, want %q — otherwise the REPLAY-ORPHAN diagnostic can never fire",
 			miss.matchPhase, models.MatchPhaseNoMocks)
+	}
+}
+
+// TestMatchCommand_LiteralDriftPicksTheRightShape drives the whole matchCommand
+// path for the interpolated-literal case, with a decoy of a DIFFERENT table
+// sitting first in the pool.
+//
+// Both mocks declare the same wire payload length, so byte-length scoring — the
+// signal this change removed — would have handed the decoy the win on pool
+// order. The literal-drift tier keeps identifiers, so only the right table can
+// answer, and the drifted id still resolves instead of tearing the connection
+// down.
+func TestMatchCommand_LiteralDriftPicksTheRightShape(t *testing.T) {
+	logger := zap.NewNop()
+
+	const shape = "SELECT `id`, `email` FROM `customers` WHERE `id` = '%s'"
+	const decoy = "SELECT `id`, `email` FROM `couriers` WHERE `id` = '%s'"
+
+	db := &fakeMockDb{session: []*models.Mock{
+		readbackMock("m-decoy", fmt.Sprintf(decoy, "1dc32a3c-a50c-5e92-9797-a6b6c4c7156e"), "decoy-row", zeroTime()),
+		readbackMock("m-target", fmt.Sprintf(shape, "1dc32a3c-a50c-5e92-9797-a6b6c4c7156e"), "target-row", zeroTime()),
+	}}
+	eng := schemanoise.New(mysqlNoiseAdapter{}, false, false)
+
+	live := comQueryReq(fmt.Sprintf(shape, "2a22d715-4799-5150-80d6-a0dd935fbda2"))
+	resp, ok, _, err := matchCommand(context.Background(), logger, live, db, newDecodeCtx(), eng, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("a re-issued statement whose interpolated id drifted must still be served")
+	}
+	if resp == nil || resp.Payload != "target-row" {
+		got := "<nil>"
+		if resp != nil {
+			got = resp.Payload
+		}
+		t.Errorf("served %q, want \"target-row\" — a different table's recorded response was returned", got)
 	}
 }

--- a/pkg/agent/proxy/integrations/mysql/replayer/query.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/query.go
@@ -137,14 +137,28 @@ func simulateCommandPhase(ctx context.Context, logger *zap.Logger, clientConn ne
 			if !ok {
 				// Build mismatch report for propagation
 				if miss == nil {
-					miss = &mockMiss{}
+					// Defensive: matchCommand always returns a miss alongside a
+					// nil error. matchPhase is set explicitly so an unexpected
+					// path cannot masquerade as an empty mock pool.
+					miss = &mockMiss{matchPhase: models.MatchPhaseExhausted}
 				}
+				// Report the STATEMENT, not the wire text. A Datadog DBM /
+				// sqlcommenter comment runs to a couple of hundred bytes in front
+				// of the SQL, so every truncation below would otherwise clip
+				// inside it and the report would name no SQL at all — which is how
+				// this class of miss gets read as "the mock was never recorded"
+				// instead of "this query drifted".
+				//
+				// The comment stripper is applied to SQL ONLY, never to the
+				// rendered bound parameters appended below: those are arbitrary
+				// user data, and a value containing "#" or "-- " would have the
+				// rest of the parameter list silently deleted from the report.
 				actualQuery := ""
 				switch msg := req.Message.(type) {
 				case *mysql.QueryPacket:
-					actualQuery = msg.Query
+					actualQuery = sqlStatementIdentity(msg.Query)
 				case *mysql.StmtPreparePacket:
-					actualQuery = msg.Query
+					actualQuery = sqlStatementIdentity(msg.Query)
 				case *mysql.StmtExecutePacket:
 					// EXECUTE carries no SQL text of its own — resolve the
 					// prepared query via the runtime stmtID map and show the
@@ -152,7 +166,7 @@ func simulateCommandPhase(ctx context.Context, logger *zap.Logger, clientConn ne
 					// "COM_STMT_EXECUTE".
 					if msg != nil {
 						if decodeCtx != nil && decodeCtx.StmtIDToQuery != nil {
-							actualQuery = strings.TrimSpace(decodeCtx.StmtIDToQuery[msg.StatementID])
+							actualQuery = sqlStatementIdentity(decodeCtx.StmtIDToQuery[msg.StatementID])
 						}
 						actualQuery = strings.TrimSpace(actualQuery + " " + formatExecParams(msg.Parameters))
 					}
@@ -161,9 +175,10 @@ func simulateCommandPhase(ctx context.Context, logger *zap.Logger, clientConn ne
 						actualQuery = fmt.Sprintf("(param %d, %d streamed bytes)", msg.ParameterID, len(msg.Data))
 					}
 				}
+				closestQuery := sqlStatementIdentity(miss.closestQuery)
 				diff := ""
-				if actualQuery != "" || miss.closestQuery != "" {
-					diff = fmt.Sprintf("actual: %s\nclosest: %s", truncate(actualQuery, 200), truncate(miss.closestQuery, 200))
+				if actualQuery != "" || closestQuery != "" {
+					diff = fmt.Sprintf("actual: %s\nclosest: %s", truncate(actualQuery, 200), truncate(closestQuery, 200))
 				}
 				// Under schemaNoiseStrict a rejection is a drift verdict, not a
 				// missing recording — say WHICH fields drifted (FieldDiffs) and
@@ -179,21 +194,28 @@ func simulateCommandPhase(ctx context.Context, logger *zap.Logger, clientConn ne
 					Diff:          diff,
 					FieldDiffs:    miss.fieldDiffs,
 					NextSteps:     nextSteps,
+					MatchPhase:    miss.matchPhase,
+					// Both of these used to be left at their zero value while the
+					// log printed them as if measured, so every MySQL miss
+					// reported "match_phase":"" and "candidates":0 — indistinguishable
+					// from an empty mock pool.
+					CandidateCount: miss.candidateCount,
 				}
-				if miss.closestMock == "" {
-					// closest_mock=="" → no candidate mock exists for this query at all.
-					// The TC is failing because its mock was NEVER RECORDED — lost at
-					// record time (teardown decode-lag or memory-pressure drop).
-					// Log the SQL query so you know exactly which query has no mock.
-					sqlSnippet := actualQuery
-					if len(sqlSnippet) > 150 {
-						sqlSnippet = sqlSnippet[:150] + "…"
-					}
-					logger.Error("REPLAY-ORPHAN: TC failing — mock NEVER RECORDED for this query (lost at record time, not a content mismatch)",
-						zap.String("sql_query", sqlSnippet),
+				if miss.matchPhase == models.MatchPhaseNoMocks {
+					// The pool held no data mock for the command phase to compare
+					// against — only handshake/config mocks survived the lifetime
+					// filter. That is a recording-side shortfall, not a content
+					// mismatch.
+					//
+					// This is asserted on the MEASURED phase, never on an empty
+					// closest_mock: nothing scoring is the NORMAL shape of a query
+					// that merely drifted from its recording, and reporting that as
+					// a lost mock sends the reader hunting for the wrong bug.
+					logger.Error("REPLAY-ORPHAN: TC failing — no data mock available for this query, so it was never recorded or was dropped at record time",
+						zap.String("sql_query", truncate(actualQuery, 300)),
 						zap.String("request_type", req.Header.Type),
 						zap.Int("commands_processed", commandCount),
-						zap.String("hint", "check mappings.yaml: this TC has 0 mock_entries — its mock was dropped at record time (teardown lag or memory pressure)"),
+						zap.String("hint", "check mappings.yaml: this test set has no MySQL data mock for the command phase — either the query was never recorded, or its mock was dropped at record time (teardown lag or memory pressure)"),
 					)
 				}
 				// next_step reuses the strict-aware guidance computed for the
@@ -203,6 +225,8 @@ func simulateCommandPhase(ctx context.Context, logger *zap.Logger, clientConn ne
 					zap.Int("commands_processed", commandCount),
 					zap.String("request_type", req.Header.Type),
 					zap.String("closest_mock", miss.closestMock),
+					zap.Int("candidates", miss.candidateCount),
+					zap.String("match_phase", miss.matchPhase),
 					zap.Int("strict_rejected_candidates", miss.strictRejected),
 					zap.String("next_step", nextSteps))
 				baseErr := fmt.Errorf("error while simulating the command phase: %w", models.ErrNoMockMatched)

--- a/pkg/agent/proxy/integrations/mysql/replayer/report.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/report.go
@@ -21,6 +21,13 @@ type mockMiss struct {
 	closestMock    string
 	fieldDiffs     []models.MockFieldDiff
 	strictRejected int
+	// candidateCount is how many MySQL mocks the scan actually considered, and
+	// matchPhase how far the cascade got. Both must be SET, not left zero: the
+	// mismatch report renders them verbatim, and a zero candidateCount reads as
+	// "the pool was empty" — which is what turned a drifted-query miss into a
+	// hunt for a lost recording.
+	candidateCount int
+	matchPhase     string
 }
 
 // formatExecParams renders bound parameter values for mismatch reports,

--- a/pkg/models/errors.go
+++ b/pkg/models/errors.go
@@ -58,7 +58,7 @@ type MockFieldDiff struct {
 // the user how far the matcher got before giving up, which determines the
 // right remediation (re-record vs add noise vs fix candidate selection).
 const (
-	MatchPhaseNoMocks    = "no_mocks"             // mock pool for this protocol is empty
+	MatchPhaseNoMocks    = "no_mocks"             // no mocks were available to compare for this protocol: the pool is empty, or none survived filtering
 	MatchPhaseSchema     = "no_schema_candidates" // nothing matched method/path/header-keys/query-keys
 	MatchPhaseBody       = "body_mismatch"        // schema candidates existed, request body ruled them all out
 	MatchPhaseStrict     = "strict_noise_reject"  // candidates rejected by strict req-body-noise enforcement


### PR DESCRIPTION
## Describe the changes that are made

A client with database-monitoring instrumentation — Datadog DBM, Google sqlcommenter, OpenTelemetry — prefixes **every** statement with a comment carrying a per-request W3C `traceparent` and the database endpoint that served the call:

```sql
/*dde='sandbox',ddps='web-service',ddpv='1a2b3c4d',
  ddh='demo.cluster-abcdefghijkl.us-east-1.rds.amazonaws.com',
  dddb='appdb',traceparent='00-<unique per request>-<unique>-01'*/ SELECT ...
```

`matchQuery` treated that raw wire text as the statement's identity, which fails three ways at once:

1. **Exact-text comparison can never fire** — the `traceparent` is re-minted per request, so the recorded text is never byte-equal to the replayed one.
2. **That comparison was gated on equal MySQL `PayloadLength`** — and an Aurora cluster handing out its reader endpoint (`cluster-ro-`) instead of its writer (`cluster-`) makes the same statement's prologue three bytes longer.
3. **With both gone, equal `PayloadLength` alone scored a point** and became the only surviving signal — so the first recorded mock of the same byte length won, regardless of what SQL it actually held.

The third is the damaging one. With a couple of hundred bytes of tracer comment in front of every statement, unrelated queries collide on total length constantly — **every `SHOW FULL FIELDS FROM <table>` with an equal-length table name measures the same**. Serving one table's column metadata in answer to another's does not look like a mock mismatch downstream; it looks like an application bug, because the ORM builds a model with the wrong columns.

Measured over that recording's 508 recorded statements, each re-issued with a fresh prologue:

| | resolved to own recording | answered with a **different** statement | matched nothing |
|---|---|---|---|
| before | 96 | **324** | 88 |
| after | **508** | 0 | 0 |

### What changed

- **Identity is the executable statement.** `stripInertSQLComments` removes every comment the server discards — block and line form, anywhere in the statement, not just in front of it — and matching compares what is left. The scan is quote-aware, so a `/*` or `--` inside a string literal or a backquoted identifier is data and survives.
- **Version-gated `/*! ... */` and optimizer-hint `/*+ ... */` comments are deliberately preserved.** The server acts on both, so two statements differing there are not interchangeable.
- **`PayloadLength` no longer contributes to the score, and no longer gates the exact comparison.** It was never evidence of anything; it became load-bearing only because the tracer comment had already defeated the text comparison.
- Everything else in the matcher is untouched. The pre-existing DML parse-tree tier is left exactly as it was, tie-break included — it has its own weaknesses, but they are not what this PR is about and it never returns a definitive match.

### The last-resort tier for interpolated literals

Removing PayloadLength leaves a gap: `sqlparser.IsDML` covers only INSERT/UPDATE/DELETE, so a `SELECT` that is not byte-identical to its recording would score 0 and the connection would be torn down. That breaks a common and legitimate shape — a client that interpolates its values instead of binding them re-issues the same statement with a freshly generated id on every run:

```
recorded: SELECT id, email FROM customers WHERE id = '1dc32a3c-…'
replayed: SELECT id, email FROM customers WHERE id = '2a22d715-…'
```

(keploy's own `go-memory-load-mysql` suite is exactly this, and caught it in CI on the first push of this branch.)

So there is a last-resort tier: compare the statement with every inline literal **value** replaced by a type-tagged placeholder. Two properties are what make it safe where byte length was not:

- **Identifiers survive** — `SHOW FULL FIELDS FROM \`invoices\`` can never be answered by `... FROM \`couriers\``, which is precisely the cross-serve equal-length scoring caused.
- **The literal's type survives** (`?s` vs `?n`) — `x = 1` and `x = '1'` stay distinct, because MySQL does not treat them alike.

The masking is lexical, with no SQL parser, deliberately: a parser renders statements it does not model to a constant string, which would make unrelated statements compare equal. Anything the scanner is unsure of is copied verbatim, so ambiguity fails toward "no match".

The tier is never definitive — the recorded response belongs to a different row — and it scores below the DML parse-tree tier, so DML selection is unchanged. Session-control statements are excluded: for `SET NAMES utf8mb4` the literal *is* the meaning, and cross-serving one would misconfigure the connection for everything after it.

### Diagnostics

`MockMismatchReport.MatchPhase` and `CandidateCount` were never assigned, so every MySQL miss logged `"match_phase":"", "candidates":0` — indistinguishable from an empty mock pool, and the reason this class of failure reads as a lost recording. Now:

- both are measured, counting only the mocks the command phase actually compares;
- the mismatch report names the **nearest recorded statement** instead of leaving `closest_mock` empty;
- `REPLAY-ORPHAN` is raised only when no data mock was available at all, not merely when nothing scored;
- the report renders the SQL rather than the tracer comment, which previously consumed the whole truncation budget.

## Links & References

**Closes:** NA

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

Verified end-to-end by hand instead — see below. The behaviour needs a MySQL client that emits sqlcommenter prologues, which no existing sample app does; happy to add one if you'd like it in the matrix.

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

**Unit / regression**

```
go test ./pkg/agent/proxy/integrations/mysql/...
```

Every new test fails with the production change reverted:

- `TestMatchQueryPacket_TraceCommentDoesNotDefeatMatching` — same statement behind comments that differ in content, in length, and mid-statement
- `TestMatchQueryPacket_EqualLengthDifferentStatementsNeverMatch` — different statements of identical byte length must score 0
- `TestMatchQueryPacket_LiteralTypeIsPartOfTheStatement` — `x = 1` and `x = '1'` are different statements
- `TestMatchQueryPacket_ExecutableCommentsAreNeverStripped` — `/*!` and `/*+` survive
- `TestStripInertSQLComments` — the primitive, including quote-awareness (`'/* not a comment */'`), `--x` vs `-- x`, unterminated comments, and comment-only probes
- `TestMatchQueryPacket_LiteralTypeIsPartOfTheStatement` — `x = 111` vs `x = '1'`, equal length, are different statements
- `TestMatchQueryPacket_InlineLiteralDriftIsServable`, `TestMatchCommand_LiteralDriftPicksTheRightShape` — a drifted interpolated id still resolves, and resolves to the right table
- `TestMaskSQLLiterals`, `TestIsSessionControlStatement` — what the last-resort tier will and will not equate
- `TestMatchCommand_MissNamesTheNearestRecordingInsteadOfClaimingNoneExists`, `TestMatchCommand_NoMocksPhaseStillReachable` — the diagnostics

**Corpus harness** (skipped unless pointed at a recording)

```
grep -oP '^\s*query:\s*\K.*' mocks.yaml | jq -Rs 'split("\n")|map(select(.!=""))' > corpus.json
KEPLOY_MYSQL_QUERY_CORPUS=corpus.json go test ./pkg/agent/proxy/integrations/mysql/replayer/ -run AgainstRecordedCorpus -v
```

Asserts every recorded statement, re-issued with a fresh prologue and the other cluster endpoint, resolves to its **own** recording.

**End to end**, against a Go service emitting DBM prologues over real MySQL, recorded and replayed with `keploy record` / `keploy test`:

| | result |
|---|---|
| before | 3 / 9 passed |
| after | **9 / 9 passed** |

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA