### PR TITLE
fix: avoid treating Postman folders as requests

### DIFF
--- a/pkg/service/import/import.go
+++ b/pkg/service/import/import.go
@@ -555,18 +555,37 @@ type PostmanResponse struct {
 }
 
 func (ic *ItemsContainer) UnmarshalJSON(data []byte) error {
-	var postmanItems []PostmanItem
-	if err := json.Unmarshal(data, &postmanItems); err == nil {
-		ic.PostmanItems = postmanItems
-	}
-
-	var items []TestData
-
-	if err := json.Unmarshal(data, &items); err != nil {
+	var rawItems []json.RawMessage
+	if err := json.Unmarshal(data, &rawItems); err != nil {
 		return err
 	}
 
-	ic.TestDataItems = items
+	for _, raw := range rawItems {
+		var shape struct {
+			Item    *json.RawMessage `json:"item"`
+			Request *json.RawMessage `json:"request"`
+		}
+		if err := json.Unmarshal(raw, &shape); err != nil {
+			return err
+		}
+
+		if shape.Item != nil {
+			var folder PostmanItem
+			if err := json.Unmarshal(raw, &folder); err != nil {
+				return err
+			}
+			ic.PostmanItems = append(ic.PostmanItems, folder)
+			continue
+		}
+
+		if shape.Request != nil {
+			var item TestData
+			if err := json.Unmarshal(raw, &item); err != nil {
+				return err
+			}
+			ic.TestDataItems = append(ic.TestDataItems, item)
+		}
+	}
 
 	return nil
 }

--- a/pkg/service/import/import_test.go
+++ b/pkg/service/import/import_test.go
@@ -1,0 +1,69 @@
+package postmanimport
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestItemsContainerUnmarshal_DoesNotTreatFoldersAsRequests(t *testing.T) {
+	data := []byte(`[
+		{
+			"name": "Users",
+			"item": [
+				{
+					"name": "List users",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": "https://api.example.test/users"
+					},
+					"response": []
+				}
+			]
+		}
+	]`)
+
+	var got ItemsContainer
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("UnmarshalJSON returned error: %v", err)
+	}
+
+	if len(got.PostmanItems) != 1 {
+		t.Fatalf("PostmanItems length = %d, want 1", len(got.PostmanItems))
+	}
+	if got.PostmanItems[0].Name != "Users" {
+		t.Fatalf("folder name = %q, want Users", got.PostmanItems[0].Name)
+	}
+	if len(got.TestDataItems) != 0 {
+		t.Fatalf("TestDataItems length = %d, want 0; folder was classified as a request", len(got.TestDataItems))
+	}
+}
+
+func TestItemsContainerUnmarshal_KeepsRootRequests(t *testing.T) {
+	data := []byte(`[
+		{
+			"name": "Health check",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": "https://api.example.test/health"
+			},
+			"response": []
+		}
+	]`)
+
+	var got ItemsContainer
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("UnmarshalJSON returned error: %v", err)
+	}
+
+	if len(got.PostmanItems) != 0 {
+		t.Fatalf("PostmanItems length = %d, want 0", len(got.PostmanItems))
+	}
+	if len(got.TestDataItems) != 1 {
+		t.Fatalf("TestDataItems length = %d, want 1", len(got.TestDataItems))
+	}
+	if got.TestDataItems[0].Name != "Health check" {
+		t.Fatalf("request name = %q, want Health check", got.TestDataItems[0].Name)
+	}
+}


### PR DESCRIPTION
## Describe the changes that are made

- Fixed Postman collection item parsing so folder entries are not also treated as API request entries.
- Updated `ItemsContainer.UnmarshalJSON` to classify each Postman item based on its shape:
  - items with nested `item` are treated as folders
  - items with `request` are treated as API requests
- Added regression tests to ensure:
  - Postman folders are not classified as request items
  - root-level Postman requests are still imported correctly

## Links & References

**Closes:** #4434

### 🔗 Related PRs
- NA

### 🐞 Related Issues
- #4434

### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)

- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?

- [x] 🙅 no, because they aren't needed

## Added comments for hard-to-understand areas?

- [x] 🙅 no, because the code is self-explanatory

## Added to documentation?

- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?

- [x] 👍 yes, mentioned below

Tested with:

```bash
go test ./pkg/service/import
go test ./pkg/service/tools ./pkg/service/import
```

<img width="1009" height="360" alt="Screenshot 2026-08-18 at 12 34 06 PM" src="https://github.com/user-attachments/assets/967003c4-b84d-43a2-be43-427eef7c64b3" />

Manual validation:

```bash
cd /private/tmp/keploy-postman-var-repro
printf 'yes\n' | /private/tmp/keploy-bin/keploy import postman --path collection.json --disable-ansi
```

Before this change, the command failed with:

```text
ERROR URL is empty {"testItem": "Users"}
ERROR failed to import Postman collection {"error": "URL is empty"}
```

After this change, the Postman collection imports successfully.

## Self Review done?

- [x] ✅ yes

## Any relevant screenshots, recordings or logs?

Postman import now succeeds with the folder-based collection repro.
<img width="1044" height="351" alt="Screenshot 2026-08-18 at 12 54 36 PM" src="https://github.com/user-attachments/assets/a7bedfa6-57b4-4184-b976-53ddc018afa9" />


## 🧠 Semantics for PR Title & Branch Name

PR title:

```text
fix: avoid treating Postman folders as requests
```

Branch name:

```text
fix/postman-folder-import
```

## Additional checklist:

- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?