### PR TITLE
fix(replay): stop reporting recoverable failures at ERROR

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -398,7 +398,7 @@ func (c *CmdConfigurator) AddUncommonFlags(cmd *cobra.Command) {
 		cmd.Flags().Uint32("sse-port", c.cfg.Test.SSEPort, "Custom SSE port to replace the actual port in the SSE testcases")
 		cmd.Flags().Uint64P("delay", "d", 5, "User provided time to run its application")
 		cmd.Flags().String("health-url", c.cfg.Test.HealthURL, "HTTP(S) URL polled before the first test is fired; first 2xx response proceeds immediately. Empty (default) preserves the fixed --delay behavior.")
-		cmd.Flags().Duration("health-poll-timeout", c.cfg.Test.HealthPollTimeout, "Ceiling for --health-url polling (e.g. 60s, 2m). If no 2xx is seen within this window, replay logs an info message and falls back to --delay.")
+		cmd.Flags().Duration("health-poll-timeout", c.cfg.Test.HealthPollTimeout, "Ceiling for --health-url polling (e.g. 60s, 2m). If no 2xx is seen within this window, replay warns and falls back to --delay.")
 		cmd.Flags().String("proto-file", c.cfg.Test.ProtoFile, "Path of main proto file")
 		cmd.Flags().String("proto-dir", c.cfg.Test.ProtoDir, "Path of the directory where all protos of a service are located")
 		cmd.Flags().StringArray("proto-include", c.cfg.Test.ProtoInclude, "Path of directories to be included while parsing import statements in proto files")

--- a/pkg/agent/routes/record.go
+++ b/pkg/agent/routes/record.go
@@ -182,7 +182,10 @@ func (a *Agent) HandleBeforeSimulate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := agent.ActiveHooks.BeforeSimulate(r.Context(), req.TimeStamp, req.TestSetID, req.TestCaseName); err != nil {
-		a.logger.Error("failed to execute before simulate hook", zap.Error(err))
+		// Warn: the caller treats a failed simulate hook as non-fatal and
+		// carries on, so this must not claim the run is broken. The 500 below
+		// still reports the failure to it.
+		utils.LogWarn(a.logger, err, "failed to execute before simulate hook")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -197,7 +200,10 @@ func (a *Agent) HandleAfterSimulate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := agent.ActiveHooks.AfterSimulate(r.Context(), req.TestSetID, req.TestCaseName); err != nil {
-		a.logger.Error("failed to execute after simulate hook", zap.Error(err))
+		// Warn: the caller treats a failed simulate hook as non-fatal and
+		// carries on, so this must not claim the run is broken. The 500 below
+		// still reports the failure to it.
+		utils.LogWarn(a.logger, err, "failed to execute after simulate hook")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/pkg/platform/http/agent.go
+++ b/pkg/platform/http/agent.go
@@ -484,8 +484,11 @@ func (a *AgentClient) BeforeSimulate(ctx context.Context, timestamp *time.Time, 
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
-		a.logger.Error("agent hook returned error", zap.Int("status", resp.StatusCode), zap.String("body", string(respBody)))
-		return fmt.Errorf("agent hook failed: %d", resp.StatusCode)
+		// Returned, not logged: the caller ignores a hook failure and carries on,
+		// so it owns the level. Logging here as well produced a second entry —
+		// at Error — for a failure that does not break the run. The body travels
+		// in the error so nothing is lost by staying quiet.
+		return fmt.Errorf("agent hook failed (status %d, body: %q)", resp.StatusCode, string(respBody))
 	}
 	return nil
 }
@@ -520,8 +523,8 @@ func (a *AgentClient) AfterSimulate(ctx context.Context, tcName string, testSetI
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
-		a.logger.Error("agent hook returned error", zap.Int("status", resp.StatusCode), zap.String("body", string(respBody)))
-		return fmt.Errorf("agent hook failed: %d", resp.StatusCode)
+		// See BeforeSimulate: returned, not logged — the caller owns the level.
+		return fmt.Errorf("agent hook failed (status %d, body: %q)", resp.StatusCode, string(respBody))
 	}
 	return nil
 }
@@ -555,8 +558,8 @@ func (a *AgentClient) BeforeTestRun(ctx context.Context, testRunID string) error
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
-		a.logger.Error("agent hook returned error", zap.Int("status", resp.StatusCode), zap.String("body", string(respBody)))
-		return fmt.Errorf("agent hook failed: %d", resp.StatusCode)
+		// See BeforeSimulate: returned, not logged — the caller owns the level.
+		return fmt.Errorf("agent hook failed (status %d, body: %q)", resp.StatusCode, string(respBody))
 	}
 	return nil
 
@@ -592,8 +595,8 @@ func (a *AgentClient) BeforeTestSetCompose(ctx context.Context, testRunID string
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
-		a.logger.Error("agent hook returned error", zap.Int("status", resp.StatusCode), zap.String("body", string(respBody)))
-		return fmt.Errorf("agent hook failed: %d", resp.StatusCode)
+		// See BeforeSimulate: returned, not logged — the caller owns the level.
+		return fmt.Errorf("agent hook failed (status %d, body: %q)", resp.StatusCode, string(respBody))
 	}
 	return nil
 
@@ -630,8 +633,8 @@ func (a *AgentClient) AfterTestRun(ctx context.Context, testRunID string, testSe
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
-		a.logger.Error("agent hook returned error", zap.Int("status", resp.StatusCode), zap.String("body", string(respBody)))
-		return fmt.Errorf("agent hook failed: %d", resp.StatusCode)
+		// See BeforeSimulate: returned, not logged — the caller owns the level.
+		return fmt.Errorf("agent hook failed (status %d, body: %q)", resp.StatusCode, string(respBody))
 	}
 	return nil
 

--- a/pkg/service/replay/app_ready_probe_test.go
+++ b/pkg/service/replay/app_ready_probe_test.go
@@ -3,10 +3,13 @@ package replay
 import (
 	"context"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	"go.keploy.io/server/v3/config"
 )
@@ -126,5 +129,57 @@ func TestWaitForAppReady_ProbeAddrGate_EmptyHostShorthand(t *testing.T) {
 	// without the 1s ticker floor.
 	if elapsed := time.Since(start); elapsed > 900*time.Millisecond {
 		t.Fatalf("ready port should return promptly (leading dial), took %v", elapsed)
+	}
+}
+
+// TestWaitForAppReady_HealthTimeoutWarnsWithConsequence pins the visibility of
+// the health-gate fallback.
+//
+// When the health probe never sees a 2xx, waitForAppReady deliberately proceeds
+// on a fixed delay rather than blocking or failing — that behaviour is not in
+// question here. What matters is that the operator can tell: firing a whole
+// suite at an app that never reported healthy typically produces every test
+// failing with no response at all, which is indistinguishable from a real
+// regression unless this line stands out. Reported at Info it drowned in a long
+// run; the sibling TCP port gate in the same function already reports the
+// identical situation at Warn.
+func TestWaitForAppReady_HealthTimeoutWarnsWithConsequence(t *testing.T) {
+	// An address nothing listens on, so the health probe can never see a 2xx.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+
+	cfg := &config.Config{}
+	cfg.Test.Delay = 0
+	cfg.Test.HealthURL = "http://" + addr + "/healthz"
+	cfg.Test.HealthPollTimeout = 300 * time.Millisecond
+
+	core, logs := observer.New(zapcore.DebugLevel)
+	if !waitForAppReady(context.Background(), zap.New(core), cfg) {
+		t.Fatal("the gate must still proceed after the ceiling; this test is about the log, not the fallback")
+	}
+
+	warns := logs.FilterLevelExact(zapcore.WarnLevel).All()
+	if len(warns) == 0 {
+		t.Fatalf("health-probe timeout must be reported at Warn — at Info it is invisible in a real run "+
+			"and the resulting all-tests-fail looks like a regression; got %v", logs.All())
+	}
+	var found bool
+	for _, w := range warns {
+		if strings.Contains(w.Message, "health probe timed out") {
+			found = true
+			if !strings.Contains(w.Message, "status_code got=0") {
+				t.Errorf("the warning must name the consequence so the failure mode is recognisable, got %q", w.Message)
+			}
+			if !strings.Contains(w.Message, "--health-poll-timeout") {
+				t.Errorf("the warning must name the knob to turn, got %q", w.Message)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("no health-probe-timeout warning found; got %v", warns)
 	}
 }

--- a/pkg/service/replay/health_poll_test.go
+++ b/pkg/service/replay/health_poll_test.go
@@ -96,7 +96,8 @@ func TestWaitForAppReady_503ThenOK(t *testing.T) {
 }
 
 // TestWaitForAppReady_NeverOK verifies the fallback path: when the health
-// endpoint never returns 2xx we log at INFO and sleep for --delay.
+// endpoint never returns 2xx we warn and sleep for --delay. The level itself is
+// pinned by TestWaitForAppReady_HealthTimeoutWarnsWithConsequence.
 func TestWaitForAppReady_NeverOK(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -130,7 +131,7 @@ func TestWaitForAppReady_NeverOK(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Fatalf("expected INFO 'health probe timed out' log, entries=%v", logs.All())
+		t.Fatalf("expected a 'health probe timed out' log, entries=%v", logs.All())
 	}
 }
 

--- a/pkg/service/replay/hooks.go
+++ b/pkg/service/replay/hooks.go
@@ -9,6 +9,7 @@ import (
 	"go.keploy.io/server/v3/config"
 	"go.keploy.io/server/v3/pkg"
 	"go.keploy.io/server/v3/pkg/models"
+	"go.keploy.io/server/v3/utils"
 	"go.uber.org/zap"
 )
 
@@ -46,7 +47,7 @@ func (h *Hooks) SimulateRequest(ctx context.Context, tc *models.TestCase, testSe
 	switch tc.Kind {
 	case models.HTTP:
 		if err := h.instrumentation.BeforeSimulate(ctx, &tc.HTTPReq.Timestamp, testSetID, tc.Name); err != nil {
-			h.logger.Error("failed to call BeforeSimulate hook", zap.Error(err))
+			h.warnHookFailed(err, "BeforeSimulate", tc.Name, testSetID)
 		}
 
 		hostToUse := h.cfg.Test.Host
@@ -76,7 +77,7 @@ func (h *Hooks) SimulateRequest(ctx context.Context, tc *models.TestCase, testSe
 			resp, err := pkg.SimulateHTTPStreaming(ctx, tc, testSetID, h.logger, cfg)
 
 			if afterErr := h.instrumentation.AfterSimulate(ctx, tc.Name, testSetID); afterErr != nil {
-				h.logger.Error("failed to call AfterSimulate hook", zap.Error(afterErr))
+				h.warnHookFailed(afterErr, "AfterSimulate", tc.Name, testSetID)
 			}
 
 			return resp, err
@@ -86,14 +87,14 @@ func (h *Hooks) SimulateRequest(ctx context.Context, tc *models.TestCase, testSe
 		resp, err := pkg.SimulateHTTP(ctx, tc, testSetID, h.logger, cfg)
 
 		if err := h.instrumentation.AfterSimulate(ctx, tc.Name, testSetID); err != nil {
-			h.logger.Error("failed to call AfterSimulate hook", zap.Error(err))
+			h.warnHookFailed(err, "AfterSimulate", tc.Name, testSetID)
 		}
 
 		return resp, err
 	case models.GRPC_EXPORT:
 
 		if err := h.instrumentation.BeforeSimulate(ctx, &tc.GrpcReq.Timestamp, testSetID, tc.Name); err != nil {
-			h.logger.Error("failed to call BeforeSimulate hook", zap.Error(err))
+			h.warnHookFailed(err, "BeforeSimulate", tc.Name, testSetID)
 		}
 
 		h.logger.Debug("Simulating gRPC request", zap.Any("Test case", tc))
@@ -115,7 +116,7 @@ func (h *Hooks) SimulateRequest(ctx context.Context, tc *models.TestCase, testSe
 		})
 
 		if err := h.instrumentation.AfterSimulate(ctx, tc.Name, testSetID); err != nil {
-			h.logger.Error("failed to call AfterSimulate hook", zap.Error(err))
+			h.warnHookFailed(err, "AfterSimulate", tc.Name, testSetID)
 		}
 
 		return resp, err
@@ -124,6 +125,27 @@ func (h *Hooks) SimulateRequest(ctx context.Context, tc *models.TestCase, testSe
 		return nil, fmt.Errorf("unsupported test case kind: %s", tc.Kind)
 	}
 
+}
+
+// warnHookFailed reports a Before/AfterSimulate hook failure.
+//
+// Warn, not Error, because these hooks are best-effort by construction and the
+// replay result does not depend on them: the default OSS implementation is a
+// no-op extension point (service/agent.AgentHook), the agent client already
+// swallows a transport failure calling them (Debug + nil), and every call site
+// here ignores the returned error and carries on. Reporting a failure the run
+// recovers from at Error breaks the contract keploy's own e2e scripts rely on —
+// they grade a run by grepping its log for "ERROR".
+//
+// The failure is still worth seeing, with the test case that hit it, because in
+// builds that DO implement these hooks (e.g. the enterprise time-freeze anchor)
+// a silent failure can shift later results.
+func (h *Hooks) warnHookFailed(err error, hook, testCase, testSetID string) {
+	utils.LogWarn(h.logger, err, "agent hook failed; replay continues",
+		zap.String("hook", hook),
+		zap.String("testCase", testCase),
+		zap.String("testSetID", testSetID),
+		zap.String("next_step", "check the agent is reachable and healthy; a failed hook does not by itself invalidate this test's result"))
 }
 
 func effectiveHTTPConfigPort(tc *models.TestCase, cfg config.Test) uint32 {
@@ -200,7 +222,9 @@ func (h *Hooks) BeforeTestRun(ctx context.Context, testRunID string) error {
 	h.logger.Debug("BeforeTestRun hook executed", zap.String("testRunID", testRunID))
 
 	if err := h.instrumentation.BeforeTestRun(ctx, testRunID); err != nil {
-		h.logger.Error("failed to call BeforeTestRun hook", zap.Error(err))
+		utils.LogWarn(h.logger, err, "agent hook failed; replay continues",
+			zap.String("hook", "BeforeTestRun"),
+			zap.String("testRunID", testRunID))
 	}
 
 	return nil
@@ -215,7 +239,9 @@ func (h *Hooks) BeforeTestSetCompose(ctx context.Context, testRunID string, test
 	// (handled by HandleBeforeTestSetCompose in the agent process).
 
 	if err := h.instrumentation.BeforeTestSetCompose(ctx, testRunID, testSetID, firstRun); err != nil {
-		h.logger.Error("failed to call BeforeTestSetCompose hook", zap.Error(err))
+		utils.LogWarn(h.logger, err, "agent hook failed; replay continues",
+			zap.String("hook", "BeforeTestSetCompose"),
+			zap.String("testSetID", testSetID))
 	}
 
 	return nil
@@ -243,7 +269,9 @@ func (h *Hooks) AfterTestRun(ctx context.Context, testRunID string, testSetIDs [
 	h.logger.Debug("AfterTestRun hook executed", zap.String("testRunID", testRunID), zap.Any("testSetIDs", testSetIDs), zap.Any("coverage", coverage))
 
 	if err := h.instrumentation.AfterTestRun(ctx, testRunID, testSetIDs, coverage); err != nil {
-		h.logger.Error("failed to call AfterTestRun hook", zap.Error(err))
+		utils.LogWarn(h.logger, err, "agent hook failed; replay continues",
+			zap.String("hook", "AfterTestRun"),
+			zap.String("testRunID", testRunID))
 	}
 	return nil
 }
@@ -251,7 +279,9 @@ func (h *Hooks) AfterTestRun(ctx context.Context, testRunID string, testSetIDs [
 func (h *Hooks) GetConsumedMocks(ctx context.Context) ([]models.MockState, error) {
 	consumedMocks, err := h.instrumentation.GetConsumedMocks(ctx)
 	if err != nil {
-		h.logger.Error("failed to get consumed mocks", zap.Error(err))
+		// Deliberately not logged here: the error is returned, and every caller
+		// already decides how loud it should be — some report it, some carry on
+		// at Debug. Logging it as well produced two entries for one failure.
 		return nil, err
 	}
 	return consumedMocks, nil

--- a/pkg/service/replay/hooks_logging_test.go
+++ b/pkg/service/replay/hooks_logging_test.go
@@ -1,0 +1,148 @@
+package replay
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/config"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// failingHookInstrumentation fails every agent hook and satisfies the rest of
+// Instrumentation with no-ops. Only the hook methods matter here.
+type failingHookInstrumentation struct {
+	Instrumentation // embedded: any method this test does not exercise panics loudly if reached
+	err             error
+}
+
+func (f *failingHookInstrumentation) BeforeSimulate(context.Context, *time.Time, string, string) error {
+	return f.err
+}
+func (f *failingHookInstrumentation) AfterSimulate(context.Context, string, string) error {
+	return f.err
+}
+func (f *failingHookInstrumentation) BeforeTestRun(context.Context, string) error { return f.err }
+func (f *failingHookInstrumentation) BeforeTestSetCompose(context.Context, string, string, bool) error {
+	return f.err
+}
+func (f *failingHookInstrumentation) AfterTestRun(context.Context, string, []string, models.TestCoverage) error {
+	return f.err
+}
+func (f *failingHookInstrumentation) GetConsumedMocks(context.Context) ([]models.MockState, error) {
+	return nil, f.err
+}
+
+// TestAgentHookFailuresAreNotErrors pins the contract that makes "an ERROR line
+// means the run is broken" hold on the hook path.
+//
+// Before/AfterSimulate and the test-run hooks are best-effort by construction:
+// the default OSS implementation is a no-op extension point, the agent client
+// swallows a transport failure calling them, and every call site here ignores
+// the returned error and carries on. A failure therefore does not invalidate the
+// run — but reported at Error it did fail the run, because keploy's e2e scripts
+// grade a run by grepping its log for "ERROR". One hook failure used to emit
+// three Error lines (agent handler, agent client, and here).
+//
+// The failure must still be visible, so Warn is required, not silence.
+func TestAgentHookFailuresAreNotErrors(t *testing.T) {
+	hookErr := errors.New("agent hook failed (status 500, body: \"boom\")")
+
+	// A listener that RSTs, so SimulateRequest's own send fails in the
+	// recoverable class and cannot contribute an ERROR of its own.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			c, aerr := ln.Accept()
+			if aerr != nil {
+				return
+			}
+			if tc, ok := c.(*net.TCPConn); ok {
+				_ = tc.SetLinger(0)
+			}
+			_ = c.Close()
+		}
+	}()
+
+	tc := &models.TestCase{
+		Name: "get-health", Kind: models.HTTP,
+		HTTPReq: models.HTTPReq{
+			Method: "GET",
+			URL:    "http://" + ln.Addr().String() + "/health",
+			Header: map[string]string{},
+		},
+		HTTPResp: models.HTTPResp{StatusCode: http.StatusOK},
+	}
+
+	cases := []struct {
+		name string
+		run  func(h *Hooks) error
+	}{
+		{"SimulateRequest (Before+AfterSimulate)", func(h *Hooks) error {
+			_, err := h.SimulateRequest(context.Background(), tc, "test-set-0")
+			return err
+		}},
+		{"BeforeTestRun", func(h *Hooks) error {
+			return h.BeforeTestRun(context.Background(), "test-run-0")
+		}},
+		{"BeforeTestSetCompose", func(h *Hooks) error {
+			return h.BeforeTestSetCompose(context.Background(), "test-run-0", "test-set-0", true)
+		}},
+		{"AfterTestRun", func(h *Hooks) error {
+			return h.AfterTestRun(context.Background(), "test-run-0", []string{"test-set-0"}, models.TestCoverage{})
+		}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			core, logs := observer.New(zapcore.DebugLevel)
+			cfg := &config.Config{}
+			cfg.Test.APITimeout = 5
+			h := &Hooks{
+				cfg:             cfg,
+				logger:          zap.New(core),
+				instrumentation: &failingHookInstrumentation{err: hookErr},
+			}
+
+			_ = c.run(h)
+
+			if n := logs.FilterLevelExact(zapcore.ErrorLevel).Len(); n != 0 {
+				t.Errorf("a failed best-effort agent hook produced %d ERROR line(s); the run carries on, "+
+					"and keploy's e2e scripts fail a run on any ERROR line: %v",
+					n, logs.FilterLevelExact(zapcore.ErrorLevel).All())
+			}
+			if logs.FilterLevelExact(zapcore.WarnLevel).Len() == 0 {
+				t.Errorf("the hook failure must still be visible at Warn, got %v", logs.All())
+			}
+		})
+	}
+}
+
+// TestGetConsumedMocksDoesNotDoubleReport pins that the pass-through no longer
+// logs an error it also returns: callers already report it (some at Error, some
+// deliberately at Debug), so logging here produced two entries for one failure.
+func TestGetConsumedMocksDoesNotDoubleReport(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	h := &Hooks{
+		cfg:             &config.Config{},
+		logger:          zap.New(core),
+		instrumentation: &failingHookInstrumentation{err: errors.New("agent unreachable")},
+	}
+
+	if _, err := h.GetConsumedMocks(context.Background()); err == nil {
+		t.Fatal("the error must still be returned so the caller can decide")
+	}
+	if n := logs.Len(); n != 0 {
+		t.Errorf("GetConsumedMocks must not log an error it returns (the caller does), got %v", logs.All())
+	}
+}

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -403,7 +403,12 @@ func (r *Replayer) Start(ctx context.Context) error {
 			}
 			r.config.Test.Language = language
 		} else if language != r.config.Test.Language && language != models.Unknown {
-			utils.LogError(r.logger, nil, "language detected is different from the language provided")
+			// Warn: only coverage is dropped, the test results themselves are
+			// unaffected, so this must not read as a broken run.
+			utils.LogWarn(r.logger, nil, "language detected is different from the language provided; skipping coverage",
+				zap.String("detected", language.String()),
+				zap.String("provided", r.config.Test.Language.String()),
+				zap.String("next_step", "pass --language matching the app, or drop the flag to use detection"))
 			r.config.Test.SkipCoverage = true
 		}
 	}
@@ -794,7 +799,7 @@ func (r *Replayer) Start(ctx context.Context) error {
 
 		err = r.hookImpl.AfterTestSetRun(ctx, testSet, testSetResult)
 		if err != nil {
-			utils.LogError(r.logger, err, "failed to execute after test set run hook", zap.String("testSet", testSet))
+			utils.LogWarn(r.logger, err, "AfterTestSetRun hook failed; replay continues", zap.String("testSet", testSet))
 		}
 
 		if i == 0 && !r.config.Test.SkipCoverage {
@@ -910,7 +915,7 @@ func (r *Replayer) Start(ctx context.Context) error {
 		if !r.afterTestRunCalled {
 			err = r.hookImpl.AfterTestRun(ctx, testRunID, testSets, coverageData)
 			if err != nil {
-				utils.LogError(r.logger, err, "failed to execute after test run hook")
+				utils.LogWarn(r.logger, err, "AfterTestRun hook failed; the run's results are unaffected")
 			}
 		}
 	}
@@ -1528,7 +1533,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 	}
 
 	if err := r.hookImpl.BeforeTestSetReplay(runTestSetCtx, testSetID); err != nil {
-		utils.LogError(r.logger, err, "BeforeTestSetReplay hook failed; inspect your custom hook implementation or disable it for this test set if this failure is expected",
+		utils.LogWarn(r.logger, err, "BeforeTestSetReplay hook failed; replay continues — inspect your custom hook implementation or disable it for this test set if this failure is expected",
 			zap.String("testSetID", testSetID),
 		)
 	}
@@ -1771,7 +1776,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			if replay == 0 {
 				if mutator, ok := r.hookImpl.(TestCaseMutator); ok {
 					if err := mutator.BeforeTestCaseRun(runTestSetCtx, testCase, testSetID); err != nil {
-						utils.LogError(r.logger, err, "BeforeTestCaseRun hook failed; replay continues with test case in current state",
+						utils.LogWarn(r.logger, err, "BeforeTestCaseRun hook failed; replay continues with test case in current state",
 							zap.String("testcase", testCase.Name),
 							zap.String("next_step", "check the BeforeTestCaseRun implementation and any external dependencies it uses (e.g. KMS, auth, network)"))
 					}
@@ -2397,7 +2402,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			// in Phase 1 is not needed here — each tc is executed exactly once.
 			if mutator, ok := r.hookImpl.(TestCaseMutator); ok {
 				if err := mutator.BeforeTestCaseRun(runTestSetCtx, tc, testSetID); err != nil {
-					utils.LogError(r.logger, err, "BeforeTestCaseRun hook failed; replay continues with test case in current state",
+					utils.LogWarn(r.logger, err, "BeforeTestCaseRun hook failed; replay continues with test case in current state",
 						zap.String("testcase", tc.Name),
 						zap.String("next_step", "check the BeforeTestCaseRun implementation and any external dependencies it uses (e.g. KMS, auth, network)"))
 				}
@@ -3103,7 +3108,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 	if r.isLastTestSet && r.instrument && cmdType == utils.DockerCompose {
 		r.afterTestRunCalled = true
 		if hookErr := r.hookImpl.AfterTestRun(ctx, r.testRunID, r.testRunTestSets, models.TestCoverage{}); hookErr != nil {
-			utils.LogError(r.logger, hookErr, "failed to execute after test run hook")
+			utils.LogWarn(r.logger, hookErr, "AfterTestRun hook failed; the run's results are unaffected")
 		}
 	}
 

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -463,10 +463,14 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 			if ctx.Err() != nil {
 				return false
 			}
-			// pollCeiling elapsed with no 2xx. Downgraded from Warn per
-			// repo logging guidelines; the message still tells operators
-			// exactly which knobs to turn.
-			logger.Info("health probe timed out, falling back to fixed delay — raise --health-poll-timeout (or test.healthPollTimeout in keploy.yml) or point --health-url at an endpoint that returns 2xx sooner",
+			// pollCeiling elapsed with no 2xx. Warn, not Info, and it names
+			// the consequence: we are about to fire the whole suite at an app
+			// that never reported healthy, so the likely outcome is every test
+			// failing with no response at all. That is indistinguishable from a
+			// real regression unless this line is visible, and it is the same
+			// situation the sibling TCP port gate above already reports at Warn
+			// ("firing tests anyway (replay may see status_code got=0)").
+			logger.Warn("health probe timed out; firing tests anyway (replay may see status_code got=0) — raise --health-poll-timeout (or test.healthPollTimeout in keploy.yml) or point --health-url at an endpoint that returns 2xx sooner",
 				zap.String("healthUrl", sanitizeHealthURL(cfg.Test.HealthURL)),
 				zap.Duration("pollTimeout", pollCeiling),
 				zap.Duration("fallbackDelay", delay),

--- a/pkg/service/runner/runner.go
+++ b/pkg/service/runner/runner.go
@@ -15,6 +15,8 @@ import (
 	httpMatcher "go.keploy.io/server/v3/pkg/matcher/http"
 	"go.keploy.io/server/v3/pkg/models"
 	"go.uber.org/zap"
+
+	"go.keploy.io/server/v3/utils"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -239,6 +241,12 @@ func (r *Runner) executeAndCompare(ctx context.Context, tc *models.TestCase, ser
 
 	actual, err := keployPkg.SimulateHTTP(ctx, &tcCopy, "", r.logger, keployPkg.SimulationConfig{})
 	if err != nil {
+		// SimulateHTTP reports a transport reset at Debug because the REPLAY
+		// caller re-sends it. This path has no such retry, so the failure is
+		// terminal here and has to be reported by us or it is only visible in
+		// the returned TestResult.
+		utils.LogError(r.logger, err, "failed to send test request to app",
+			zap.String("testCase", tc.Name))
 		return false, models.RespCompare{}, err
 	}
 

--- a/pkg/simulate_logging_test.go
+++ b/pkg/simulate_logging_test.go
@@ -1,0 +1,144 @@
+package pkg
+
+import (
+	"context"
+	"errors"
+	"net"
+	"syscall"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// startResetOnAccept accepts one connection and immediately RSTs it (linger 0),
+// which is what a docker-proxy / not-yet-ready app does to a replay request.
+// net/http surfaces it as ECONNRESET or a bare EOF depending on timing — both
+// are the recoverable class.
+func startResetOnAccept(t *testing.T) (baseURL string, stop func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			c, aerr := ln.Accept()
+			if aerr != nil {
+				return
+			}
+			if tc, ok := c.(*net.TCPConn); ok {
+				_ = tc.SetLinger(0) // close() now sends RST, not FIN
+			}
+			_ = c.Close()
+		}
+	}()
+	return "http://" + ln.Addr().String(), func() { _ = ln.Close(); <-done }
+}
+
+// TestSimulateHTTP_TransportResetIsNotLoggedAsError drives the REAL send path,
+// not the logging helper, because the call site is the thing that regressed.
+//
+// A transport-level reset is recoverable: the replay orchestration re-sends it
+// once it can prove the failed attempt consumed no mock, and it usually recovers
+// on the first re-send. Reporting it at ERROR is not cosmetic — keploy's own e2e
+// scripts fail a run on any ERROR line in the replay log (see
+// .github/workflows/test_workflow_scripts/golang/http_pokeapi/golang-linux.sh
+// and its siblings), so one recovered transient turned a suite whose every test
+// passed into a red build.
+//
+// The definitive ERROR is still emitted by the caller once the re-send is
+// refused or exhausted ("failed to simulate request" in RunTestSet), so nothing
+// is lost here.
+func TestSimulateHTTP_TransportResetIsNotLoggedAsError(t *testing.T) {
+	baseURL, stop := startResetOnAccept(t)
+	defer stop()
+
+	for _, tc := range []struct {
+		name string
+		call func(*zap.Logger) error
+	}{
+		{"SimulateHTTP", func(l *zap.Logger) error {
+			_, err := SimulateHTTP(context.Background(), pingTestCase(baseURL), "test-set", l, SimulationConfig{APITimeout: 5})
+			return err
+		}},
+		{"SimulateHTTPStreaming", func(l *zap.Logger) error {
+			_, err := SimulateHTTPStreaming(context.Background(), pingTestCase(baseURL), "test-set", l, SimulationConfig{APITimeout: 5})
+			return err
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			core, logs := observer.New(zapcore.DebugLevel)
+
+			err := tc.call(zap.New(core))
+			if err == nil {
+				t.Fatal("the request must still fail — this change is about the log level, not the outcome")
+			}
+			if !IsTransportConnReset(err) {
+				t.Fatalf("test setup broken: expected a transport reset, got %v", err)
+			}
+			if n := logs.FilterLevelExact(zapcore.ErrorLevel).Len(); n != 0 {
+				t.Errorf("%s logged %d ERROR line(s) for a re-sendable transport reset; keploy's e2e "+
+					"scripts treat any ERROR in the replay log as a failed run, so a transient the "+
+					"caller recovers from must not emit one: %v", tc.name, n, logs.FilterLevelExact(zapcore.ErrorLevel).All())
+			}
+			if logs.FilterLevelExact(zapcore.DebugLevel).Len() == 0 {
+				t.Errorf("%s should still record the reset at Debug for diagnosis", tc.name)
+			}
+		})
+	}
+}
+
+// TestSimulateHTTP_UnreachableAppStillLogsError keeps the downgrade narrow.
+// Only the class the caller can re-send is quietened; an app that is simply not
+// there is terminal on this path and must still be reported at ERROR.
+func TestSimulateHTTP_UnreachableAppStillLogsError(t *testing.T) {
+	// Reserve a port and release it, so connects are refused for good.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close()
+
+	core, logs := observer.New(zapcore.DebugLevel)
+	tc := &models.TestCase{
+		Name: "ping", Kind: models.HTTP,
+		HTTPReq: models.HTTPReq{Method: "GET", URL: "http://" + addr + "/ping", Header: map[string]string{}},
+	}
+	if _, err := SimulateHTTP(context.Background(), tc, "test-set", zap.New(core), SimulationConfig{APITimeout: 5}); err == nil {
+		t.Fatal("a refused port must fail")
+	}
+	if logs.FilterLevelExact(zapcore.ErrorLevel).Len() == 0 {
+		t.Errorf("a genuinely unreachable app is not re-sendable here and must still be an ERROR, got %v", logs.All())
+	}
+}
+
+// TestLogSimulateSendFailure_ClassifiesByRecoverability covers the policy itself
+// for error shapes that are awkward to produce over a real socket.
+func TestLogSimulateSendFailure_ClassifiesByRecoverability(t *testing.T) {
+	cases := []struct {
+		name      string
+		err       error
+		wantError bool
+	}{
+		{"EPIPE is recoverable", syscall.EPIPE, false},
+		{"connection refused is terminal here", syscall.ECONNREFUSED, true},
+		{"host unreachable is terminal", syscall.EHOSTUNREACH, true},
+		{"opaque failure is terminal", errors.New("no such host"), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			core, logs := observer.New(zapcore.DebugLevel)
+			logSimulateSendFailure(zap.New(core), tc.err)
+			gotError := logs.FilterLevelExact(zapcore.ErrorLevel).Len() > 0
+			if gotError != tc.wantError {
+				t.Errorf("ERROR logged = %v, want %v (logs: %v)", gotError, tc.wantError, logs.All())
+			}
+		})
+	}
+}

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -669,6 +669,33 @@ func IsTransportConnReset(err error) bool {
 	return false
 }
 
+// logSimulateSendFailure reports a failed test request at a level that matches
+// what can still be done about it.
+//
+// A transport-level connection reset is RECOVERABLE, not terminal: the replay
+// orchestration re-sends it once it can prove the app consumed nothing for the
+// failed request (see IsTransportConnReset and retryResetOnce), and the common
+// docker-proxy reset recovers on the first re-send. Reporting that at ERROR is
+// not a cosmetic choice — keploy's own e2e scripts fail a run on any ERROR line
+// in the REPLAY log (.github/workflows/test_workflow_scripts/golang/
+// http_pokeapi/golang-linux.sh and its python/node siblings all grep test_logs
+// for "ERROR"), so one recovered transient turns a suite whose every test passed
+// into a red build.
+//
+// Nothing is lost by reporting the recoverable class at Debug here. When the
+// re-send is refused or exhausted, RunTestSet logs the definitive
+// "failed to simulate request" / "failed to simulate streaming request" at
+// ERROR, and the non-replay caller (service/runner) returns the error in its
+// TestResult. Every other failure class is still an ERROR here.
+func logSimulateSendFailure(logger *zap.Logger, err error) {
+	if IsTransportConnReset(err) {
+		logger.Debug("test request failed with a transport reset; the caller decides whether to re-send",
+			zap.Error(err))
+		return
+	}
+	utils.LogError(logger, err, "failed to send testcase request to app")
+}
+
 // doRequestWithConnRefusedRetry executes client.Do, re-sending ONLY on a
 // pre-response connection-refused (bounded, ctx-aware backoff, request body
 // rewound via GetBody). Any other error, or a real response, returns
@@ -722,7 +749,7 @@ func SimulateHTTP(ctx context.Context, tc *models.TestCase, testSet string, logg
 	// Execute the request (re-sending only on a pre-response connection-refused)
 	httpResp, errHTTPReq := doRequestWithConnRefusedRetry(ctx, logger, prepared.Client, prepared.Request)
 	if errHTTPReq != nil {
-		utils.LogError(logger, errHTTPReq, "failed to send testcase request to app")
+		logSimulateSendFailure(logger, errHTTPReq)
 		return nil, errHTTPReq
 	}
 
@@ -799,7 +826,7 @@ func SimulateHTTPStreaming(ctx context.Context, tc *models.TestCase, testSet str
 	// Execute the request (re-sending only on a pre-response connection-refused)
 	httpResp, errHTTPReq := doRequestWithConnRefusedRetry(ctx, logger, prepared.Client, prepared.Request)
 	if errHTTPReq != nil {
-		utils.LogError(logger, errHTTPReq, "failed to send testcase request to app")
+		logSimulateSendFailure(logger, errHTTPReq)
 		return nil, errHTTPReq
 	}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -315,6 +315,30 @@ func LogError(logger *zap.Logger, err error, msg string, fields ...zap.Field) {
 	}
 }
 
+// LogWarn is the Warn-level sibling of LogError, for a failure the caller
+// deliberately continues past.
+//
+// It exists so that downgrading such a site does not silently lose LogError's
+// context.Canceled suppression: on shutdown every in-flight operation fails with
+// context.Canceled, and reporting that as a problem is noise either way.
+//
+// Use it when the run carries on and the outcome is still trustworthy — a
+// best-effort hook, a degraded optional feature. Keep utils.LogError for
+// anything that makes the run's result unreliable; keploy's e2e scripts grade a
+// run by grepping its log for "ERROR", so that level is a contract.
+func LogWarn(logger *zap.Logger, err error, msg string, fields ...zap.Field) {
+	if logger == nil {
+		fmt.Println("Failed to log warning. Logger is nil.")
+		return
+	}
+	if !errors.Is(err, context.Canceled) {
+		if err != nil {
+			fields = append(fields, zap.Error(err))
+		}
+		logger.Warn(msg, fields...)
+	}
+}
+
 // RemoveDoubleQuotes removes all double quotes from the values in the provided template map.
 // This function handles cases where the templating engine fails to parse values containing both single and double quotes.
 // For example:


### PR DESCRIPTION
## Describe the changes that are made

keploy's own e2e scripts fail a run on **any** `ERROR` line in the replay log — [`golang/http_pokeapi/golang-linux.sh:132`](../blob/main/.github/workflows/test_workflow_scripts/golang/http_pokeapi/golang-linux.sh) does `grep "ERROR" "test_logs.txt"`, and the python/node/sse siblings do the same. So an `ERROR` line is a **contract**, not just a log level. Two places broke it by reporting conditions keploy itself recovers from, which turns a run whose every test passed into a red build.

### 1. A transport reset is recoverable, so it must not be an ERROR

`SimulateHTTP` / `SimulateHTTPStreaming` logged every send failure at ERROR. But for a transport-level connection reset, `RunTestSet` re-sends the request through `retryResetOnce` once it can prove the failed attempt consumed no mock — and the common docker-proxy reset recovers on the first re-send. The log read:

```
ERROR  failed to send testcase request to app   … read: connection reset by peer
WARN   test request reset by app/proxy before any mock was consumed; re-sending —
       the request was never processed, so this is not a retry of an assertion
…
Total test passed: 32     Total test failed: 0
```

…and the build was red, on the ERROR line, for a run in which nothing failed.

`logSimulateSendFailure` now reports the re-sendable class (`IsTransportConnReset`) at Debug; **every other failure is still an ERROR**. Nothing is lost — the definitive ERROR is logged by the caller once the re-send is refused or exhausted (`failed to simulate request` / `failed to simulate streaming request`).

`pkg/service/runner` has no such retry, so a reset is terminal on that path and was only visible in the returned `TestResult`. It now logs the failure itself.

### 2. The health gate's timeout is not an Info-level event

`waitForAppReady`'s health-URL gate reported its timeout at Info and then fired the whole suite on a fixed delay (deliberate, and unchanged here). When an app is slower than `--health-poll-timeout`, the result is *every* test failing with no response at all — observed as **23 failures all reading `EXPECT 200 / ACTUAL 0`** — which is indistinguishable from a real regression unless that one line stands out.

It now warns and names the consequence, matching the **sibling TCP port gate in the same function**, which already reports the identical situation at Warn (`"firing tests anyway (replay may see status_code got=0)"`).

A malformed `--health-url` or `appReadyProbeAddr` deliberately **stays** at ERROR: those are permanent misconfigurations that will never succeed, unlike a transient timeout, and an existing test pins that intent.

### 3. The best-effort agent hooks — the bigger hole

A single failed hook emitted **three** ERROR lines — the agent handler, the agent client, and the replay caller — once per test case, while the run carried on and every test passed.

Ignoring a hook failure is correct, and the code already says so in three independent places: the default OSS implementation is a **no-op extension point** (`service/agent.AgentHook` returns nil for all of them), the agent client **already** swallows a transport failure calling one (`Debug`, `return nil`), and every call site discards the returned error. The bug was the level, not the ignoring.

| site | before | now |
|---|---|---|
| `replay/hooks.go` — Before/AfterSimulate, BeforeTestRun, BeforeTestSetCompose, AfterTestRun | 5 × `logger.Error`, ignored | Warn, once, **with the hook name and the test case** |
| `replay.go` — AfterTestSetRun, AfterTestRun ×2, BeforeTestSetReplay | Error; two already said *"replay continues"* in the message | Warn |
| `platform/http/agent.go` — non-2xx on 5 hook calls | logged Error **and** returned the error, so the caller logged it again | body folded into the returned error, no log — the caller owns the level |
| `agent/routes/record.go` — before/after-simulate handlers | Error | Warn; still answers 500 |
| `replay/hooks.go` — `GetConsumedMocks` | logged an error it also returned | returns it; callers already report it (some at Error, some deliberately at Debug) |

**Deliberately left at ERROR**, because these do mean something is wrong:
- a failed backup before deleting failing test cases — the run then does something destructive with no safety net;
- a malformed `--health-url` / `appReadyProbeAddr` — permanent misconfiguration that will never succeed, unlike a transient timeout, and an existing test pins that intent.

Adds `utils.LogWarn` so downgraded sites keep `LogError`'s `context.Canceled` suppression — on shutdown every in-flight call fails with it, and that is noise at any level.

## Links & References

**Closes:** NA

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

The regression is a log level, and the new tests drive the real `SimulateHTTP` / `SimulateHTTPStreaming` against a socket that RSTs on accept — the same shape as the existing `util_simulate_refuse_integration_test.go`, without needing CI credentials.

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

`--health-poll-timeout`'s flag help said "logs an info message"; updated in this PR.

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

```
go test ./pkg/ -run 'TestSimulateHTTP_TransportReset|TestSimulateHTTP_UnreachableApp|TestLogSimulateSendFailure' -v
go test ./pkg/service/replay/ -run TestWaitForAppReady -v
```

- `TestSimulateHTTP_TransportResetIsNotLoggedAsError` — drives **both** real entry points against a listener that RSTs on accept, and asserts zero ERROR lines. Deliberately not a unit test of the helper: reverting only the two call sites while keeping the helper leaves a helper-level test green, so it would not have guarded the regression.
- `TestSimulateHTTP_UnreachableAppStillLogsError` — a genuinely refused port must still ERROR, keeping the downgrade narrow.
- `TestWaitForAppReady_HealthTimeoutWarnsWithConsequence` — the timeout warns, names the consequence and names the knob.
- `TestAgentHookFailuresAreNotErrors` — drives the real `Hooks.SimulateRequest` / `BeforeTestRun` / `BeforeTestSetCompose` / `AfterTestRun` against an instrumentation stub that fails every hook, and asserts zero ERROR lines **and** at least one Warn (visible, not silenced).
- `TestGetConsumedMocksDoesNotDoubleReport` — the pass-through returns its error without also logging it.

Each fails when its production change is reverted.

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA