### PR TITLE
fix(windows): report a missing redirect destination instead of returning a zero address

### DIFF
--- a/pkg/agent/hooks/windows/redirector.go
+++ b/pkg/agent/hooks/windows/redirector.go
@@ -56,6 +56,15 @@ func StopRedirector() error {
 // Returns (destination, true) if found, or (empty, false) if not found
 func GetDestination(srcPort uint32) (WinDest, bool) {
 	dest := C.get_destination(C.uint(srcPort))
+	// The Rust side has no way to signal absence across the FFI boundary: a
+	// miss comes back as a zeroed WinDest, and ip_version is 0 only in that
+	// case (a real mapping is always 4 or 6). Returning true regardless made
+	// the miss indistinguishable from a hit, so callers built a destination
+	// out of the zero value and dialled 0.0.0.0:0 instead of taking their
+	// fallback path.
+	if dest.ip_version == 0 {
+		return WinDest{}, false
+	}
 	return WinDest{
 		IPVersion: uint32(dest.ip_version),
 		DestIP4:   uint32(dest.dest_ip4),


### PR DESCRIPTION
`GetDestination` could never fail:

```go
func GetDestination(srcPort uint32) (WinDest, bool) {
	dest := C.get_destination(C.uint(srcPort))
	return WinDest{...}, true   // always true
}
```

The Rust side has no way to signal absence across the FFI boundary — `get_destination` returns a **zeroed** `WinDest` for an unknown source port (`ffi.rs`, the `None =>` arm of the map lookup). The Go wrapper handed that back with `ok = true`, so `Hooks.Get` built an `agent.NetworkAddress` out of the zero value and returned `0.0.0.0:0` with no error.

That is indistinguishable from a real answer, and callers are written to expect a real one. `getActualDestination` (`pkg/agent/proxy/incoming/incoming_windows.go:37`) does:

```go
networkAddr, err := pm.hooks.Get(ctx, srcPort)
if err == nil && networkAddr != nil {
    ...
    return finalDestAddr        // takes the zero address as resolved
}
...
return fallbackAddr             // never reached on a miss
```

so the documented fallback path is dead on a miss.

`ip_version` is the discriminator: a real mapping is always 4 or 6, and only a miss leaves it 0. This keys the miss on that and lets callers fall back as intended. The doc comment on the function already promised this behaviour ("or (empty, false) if not found").

Found while tracing a Windows record-side defect where dependency connections were silently not intercepted; this is a separate latent bug in the same area and does not fix that one. The interception race itself is keploy/windows-redirector#3.

Windows build verified: `CGO_ENABLED=1 GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc go build`.