### PR TITLE
fix(proxy): sample live connections' network I/O, not only at teardown

### DIFF
--- a/pkg/agent/proxy/incoming/gRPC/record.go
+++ b/pkg/agent/proxy/incoming/gRPC/record.go
@@ -35,6 +35,10 @@ func RecordIncoming(ctx context.Context, logger *zap.Logger, clientConn, destCon
 		destConn.Close()
 	}()
 
+	// gRPC connections are long-lived (many multiplexed HTTP/2 streams over one
+	// socket), so sample destConn continuously while it's open rather than only at
+	// the teardown RecordConnNetworkIO below.
+	ossproxy.TrackConnNetworkIO(destConn)
 	defer func() {
 		if err := clientConn.Close(); err != nil &&
 			!strings.Contains(err.Error(), "use of closed network connection") {

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -527,6 +527,10 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 		)
 		return
 	}
+	// Sample this app-facing socket continuously while it's open (a kept-alive
+	// serving connection can outlive many requests), so its bytes aren't withheld
+	// until the teardown RecordConnNetworkIO below.
+	ossproxy.TrackConnNetworkIO(upConn)
 	defer func() {
 		// Ingress proxy: upConn is the app-facing socket (keploy → app on the
 		// redirected port). Record its TCP_INFO byte totals (true wire volume) into
@@ -1169,6 +1173,10 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 		upConn = newConn
 		upstreamReader = bufio.NewReader(upConn)
 		upConnHolder.Store(&connHolder{c: newConn})
+		// Track the redialed upstream socket too: a keep-alive upstream can serve
+		// many requests before it's retired, so sample it continuously rather than
+		// only at the redial/teardown RecordConnNetworkIO(h.c) above.
+		ossproxy.TrackConnNetworkIO(newConn)
 		return nil
 	}
 

--- a/pkg/agent/proxy/netstat.go
+++ b/pkg/agent/proxy/netstat.go
@@ -4,8 +4,10 @@ package proxy
 
 import (
 	"net"
+	"sync"
 	"sync/atomic"
 	"syscall"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
@@ -24,9 +26,14 @@ import (
 // resourceio package, so the dependency is inverted via a sink — mirroring the
 // existing captured-IO sink pattern.
 //
-// NOTE (v1 scope): reporting at teardown means a connection that stays open for the
-// whole recording won't contribute until it closes. Long-lived connections would
-// want periodic delta sampling of the live sockets; left as a follow-up.
+// Long-lived connections (DB/connection-pool sockets, keep-alive, gRPC streams)
+// stay open for the whole recording, so accounting ONLY at teardown would miss the
+// bulk of their bytes — exactly where an app's heaviest traffic (e.g. large DB
+// result sets) lives. To close that gap, a connection is registered with
+// TrackConnNetworkIO at setup and a background sampler folds each interval's byte
+// DELTA into the sink while it's still open; RecordConnNetworkIO takes the final
+// delta at teardown. Connections that are never tracked keep the original
+// teardown-only behavior (their full lifetime total, once, at close).
 
 // networkIOSink, when set, receives a connection's app-relative ingress/egress
 // byte totals (rx = bytes the app received, tx = bytes the app sent) at teardown.
@@ -44,10 +51,15 @@ func SetNetworkIOSink(sink func(rx, tx uint64)) {
 	networkIOSink.Store(&sink)
 }
 
-// RecordConnNetworkIO reads the kernel TCP_INFO byte counters off an app-facing
-// socket and forwards them to the sink. Best-effort and cheap (one getsockopt);
+// RecordConnNetworkIO takes the FINAL byte reading off an app-facing socket at
+// teardown and forwards it to the sink. Best-effort and cheap (one getsockopt);
 // a non-TCP conn or an unreadable fd is silently skipped. Call once per connection
 // just before closing it.
+//
+// If the connection was registered with TrackConnNetworkIO, only the DELTA since
+// the last periodic sample is forwarded (the sampler already counted the rest) and
+// the registry entry is removed. If it was never tracked, the connection's full
+// lifetime total is forwarded — preserving the original teardown-only behavior.
 //
 // Pass the socket that keploy owns facing the APP — the outgoing proxy's srcConn
 // (app dials keploy) or the ingress proxy's upConn (keploy dials the app). In both
@@ -62,10 +74,141 @@ func RecordConnNetworkIO(conn net.Conn) {
 		return
 	}
 	rx, tx, ok := readSocketBytes(conn)
-	if !ok || (rx == 0 && tx == 0) {
+
+	// Always drop any registry entry for this conn (it's closing), capturing its
+	// last sampled cursor so we can emit only the un-sampled tail.
+	liveConnsMu.Lock()
+	tc, tracked := liveConns[conn]
+	if tracked {
+		delete(liveConns, conn)
+	}
+	liveConnsMu.Unlock()
+
+	if !ok {
+		// Can't read final totals (fd already closed). For a tracked conn the
+		// periodic sampler already counted the bulk; only the sub-interval tail is
+		// lost. For an untracked conn nothing is recorded (unchanged from before).
 		return
 	}
-	(*sinkP)(rx, tx)
+
+	var drx, dtx uint64
+	if tracked {
+		drx = forwardDelta(rx, tc.lastRx)
+		dtx = forwardDelta(tx, tc.lastTx)
+	} else {
+		drx, dtx = rx, tx // never tracked → full lifetime total (original behavior)
+	}
+	if drx == 0 && dtx == 0 {
+		return
+	}
+	(*sinkP)(drx, dtx)
+}
+
+// netioSampleInterval is how often the background sampler reads live tracked
+// connections' TCP_INFO and folds the byte delta into the sink. Matches the
+// proxyless eBPF drain cadence.
+const netioSampleInterval = 15 * time.Second
+
+// trackedConn holds a live app-facing socket and the last cumulative (rx, tx) the
+// sampler observed on it, so each tick emits only the new bytes.
+type trackedConn struct {
+	conn   net.Conn
+	lastRx uint64
+	lastTx uint64
+}
+
+var (
+	liveConnsMu sync.Mutex
+	liveConns   = map[net.Conn]*trackedConn{}
+	samplerOnce sync.Once
+)
+
+// TrackConnNetworkIO registers an app-facing socket for continuous network-I/O
+// accounting. Call once when the connection is established, passing the SAME
+// (raw) conn later handed to RecordConnNetworkIO at teardown. The background
+// sampler then folds each interval's byte delta into the sink for as long as the
+// connection stays open, so long-lived connections are metered throughout their
+// life rather than only at close. No-op when no sink is installed or the conn
+// isn't a readable TCP socket.
+func TrackConnNetworkIO(conn net.Conn) {
+	if networkIOSink.Load() == nil || conn == nil {
+		return
+	}
+	// Only TCP sockets expose TCP_INFO; skip anything else so the registry and the
+	// sampler stay cheap and never chase un-readable fds.
+	if _, _, ok := readSocketBytes(conn); !ok {
+		return
+	}
+	startNetioSampler()
+	liveConnsMu.Lock()
+	if _, exists := liveConns[conn]; !exists {
+		// lastRx/lastTx start at 0: we register at connection setup (before traffic),
+		// so the first delta correctly counts from zero.
+		liveConns[conn] = &trackedConn{conn: conn}
+	}
+	liveConnsMu.Unlock()
+}
+
+// startNetioSampler launches (once) the daemon goroutine that periodically drains
+// live tracked connections. Process-lifetime; there is nothing to stop since the
+// agent process is torn down with the pod.
+func startNetioSampler() {
+	samplerOnce.Do(func() {
+		go func() {
+			t := time.NewTicker(netioSampleInterval)
+			defer t.Stop()
+			for range t.C {
+				sampleLiveConns()
+			}
+		}()
+	})
+}
+
+// sampleLiveConns reads each tracked connection's current TCP_INFO, forwards the
+// delta since its last reading to the sink, and advances the stored cursor. A
+// connection whose fd is momentarily unreadable is left in place (teardown removes
+// it and takes the final delta); a counter that went backwards contributes its
+// full current value (forwardDelta guard). Deltas — not absolutes — so a
+// connection is never double counted across ticks or against its teardown read.
+func sampleLiveConns() {
+	sinkP := networkIOSink.Load()
+	if sinkP == nil {
+		return
+	}
+	liveConnsMu.Lock()
+	snapshot := make([]*trackedConn, 0, len(liveConns))
+	for _, tc := range liveConns {
+		snapshot = append(snapshot, tc)
+	}
+	liveConnsMu.Unlock()
+
+	for _, tc := range snapshot {
+		rx, tx, ok := readSocketBytes(tc.conn)
+		if !ok {
+			continue
+		}
+		liveConnsMu.Lock()
+		if _, still := liveConns[tc.conn]; !still {
+			liveConnsMu.Unlock() // teardown removed it between snapshot and now
+			continue
+		}
+		drx := forwardDelta(rx, tc.lastRx)
+		dtx := forwardDelta(tx, tc.lastTx)
+		tc.lastRx, tc.lastTx = rx, tx
+		liveConnsMu.Unlock()
+		if drx > 0 || dtx > 0 {
+			(*sinkP)(drx, dtx)
+		}
+	}
+}
+
+// forwardDelta returns cur-prev for a monotonic counter, or the full cur when the
+// counter went backwards (fd/id reuse), so a reset never subtracts.
+func forwardDelta(cur, prev uint64) uint64 {
+	if cur >= prev {
+		return cur - prev
+	}
+	return cur
 }
 
 // readSocketBytes returns the app-relative (rx, tx) cumulative byte totals for a

--- a/pkg/agent/proxy/netstat_other.go
+++ b/pkg/agent/proxy/netstat_other.go
@@ -13,3 +13,6 @@ func SetNetworkIOSink(_ func(rx, tx uint64)) {}
 
 // RecordConnNetworkIO is a no-op on non-Linux.
 func RecordConnNetworkIO(_ net.Conn) {}
+
+// TrackConnNetworkIO is a no-op on non-Linux.
+func TrackConnNetworkIO(_ net.Conn) {}

--- a/pkg/agent/proxy/netstat_test.go
+++ b/pkg/agent/proxy/netstat_test.go
@@ -1,0 +1,163 @@
+//go:build linux
+
+package proxy
+
+import (
+	"io"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestForwardDelta(t *testing.T) {
+	cases := []struct{ cur, prev, want uint64 }{
+		{cur: 100, prev: 40, want: 60}, // normal growth
+		{cur: 40, prev: 40, want: 0},   // no change
+		{cur: 30, prev: 100, want: 30}, // counter went backwards (reset) → full current
+		{cur: 0, prev: 0, want: 0},
+	}
+	for _, c := range cases {
+		if got := forwardDelta(c.cur, c.prev); got != c.want {
+			t.Errorf("forwardDelta(%d, %d) = %d, want %d", c.cur, c.prev, got, c.want)
+		}
+	}
+}
+
+// TestNetworkIO_PeriodicSamplingNoDoubleCount exercises the core of the fix: a
+// tracked connection's bytes are folded in via periodic sampling AND at teardown,
+// as DELTAS, so the same bytes are never counted twice. It uses a real loopback
+// TCP pair because the accounting reads the kernel's TCP_INFO counters.
+func TestNetworkIO_PeriodicSamplingNoDoubleCount(t *testing.T) {
+	var rxTot, txTot atomic.Uint64
+	SetNetworkIOSink(func(rx, tx uint64) { rxTot.Add(rx); txTot.Add(tx) })
+	defer SetNetworkIOSink(nil)
+	// isolate the global registry for this test
+	liveConnsMu.Lock()
+	liveConns = map[net.Conn]*trackedConn{}
+	liveConnsMu.Unlock()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	type acc struct {
+		c   net.Conn
+		err error
+	}
+	accepted := make(chan acc, 1)
+	go func() { c, err := ln.Accept(); accepted <- acc{c, err} }()
+
+	client, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = client.Close() }()
+
+	a := <-accepted
+	if a.err != nil {
+		t.Fatal(a.err)
+	}
+	server := a.c // treat as the app-facing socket keploy owns
+	defer func() { _ = server.Close() }()
+
+	const n = 4096
+	// client -> server: server RECEIVES these bytes, so TCP_INFO Bytes_received
+	// grows → our mapping records them as tx (app egress relative to the peer).
+	drained := make(chan struct{})
+	go func() {
+		_, _ = io.ReadFull(server, make([]byte, n))
+		close(drained)
+	}()
+	if _, err := client.Write(make([]byte, n)); err != nil {
+		t.Fatal(err)
+	}
+	<-drained
+
+	TrackConnNetworkIO(server)
+
+	// TCP_INFO updates asynchronously; poll a few ticks for the first non-zero.
+	var afterFirst uint64
+	for i := 0; i < 50; i++ {
+		sampleLiveConns()
+		if afterFirst = txTot.Load(); afterFirst > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if afterFirst == 0 {
+		t.Fatal("expected non-zero tx after sampling a connection that received data")
+	}
+
+	// No new traffic: a second sample must add nothing (the delta property).
+	sampleLiveConns()
+	if got := txTot.Load(); got != afterFirst {
+		t.Fatalf("second sample double-counted: %d -> %d", afterFirst, got)
+	}
+
+	// Teardown takes only the final delta and deregisters.
+	RecordConnNetworkIO(server)
+	liveConnsMu.Lock()
+	_, still := liveConns[server]
+	liveConnsMu.Unlock()
+	if still {
+		t.Fatal("connection was not deregistered after RecordConnNetworkIO")
+	}
+
+	// The total must reflect the ~n payload bytes once — not doubled. TCP_INFO byte
+	// counters are payload octets (no headers), so a generous upper bound catches a
+	// gross double/triple count without being flaky.
+	if got := txTot.Load(); got < n || got > n*3 {
+		t.Fatalf("tx total out of expected band: got %d, want ~%d", got, n)
+	}
+}
+
+// TestRecordConnNetworkIO_UntrackedFullTotal asserts an untracked connection still
+// reports its full lifetime total at teardown (the original, unchanged behavior).
+func TestRecordConnNetworkIO_UntrackedFullTotal(t *testing.T) {
+	var txTot atomic.Uint64
+	SetNetworkIOSink(func(_, tx uint64) { txTot.Add(tx) })
+	defer SetNetworkIOSink(nil)
+	liveConnsMu.Lock()
+	liveConns = map[net.Conn]*trackedConn{}
+	liveConnsMu.Unlock()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ln.Close() }()
+	accepted := make(chan net.Conn, 1)
+	go func() { c, _ := ln.Accept(); accepted <- c }()
+	client, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = client.Close() }()
+	server := <-accepted
+	defer func() { _ = server.Close() }()
+
+	const n = 2048
+	drained := make(chan struct{})
+	go func() { _, _ = io.ReadFull(server, make([]byte, n)); close(drained) }()
+	if _, err := client.Write(make([]byte, n)); err != nil {
+		t.Fatal(err)
+	}
+	<-drained
+
+	// No TrackConnNetworkIO: teardown should report the connection's full total.
+	var got uint64
+	for i := 0; i < 50; i++ {
+		txTot.Store(0)
+		RecordConnNetworkIO(server) // untracked → absolute; safe to retry (idempotent read)
+		if got = txTot.Load(); got > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got < n || got > n*3 {
+		t.Fatalf("untracked total out of expected band: got %d, want ~%d", got, n)
+	}
+}

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -1794,6 +1794,11 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 	// bare *net.TCPConn (the RemoteAddr type-assert below relies on that), so read
 	// TCP_INFO off it at teardown instead of the wrapped srcConn.
 	origSrcConn := srcConn
+	// Register the raw app-facing socket for continuous network-I/O sampling, so a
+	// long-lived proxied connection (e.g. an app→DB connection-pool socket that
+	// stays open for the whole recording) is metered throughout its life — not only
+	// by the teardown RecordConnNetworkIO(origSrcConn) in the defer below.
+	TrackConnNetworkIO(origSrcConn)
 
 	defer func(start time.Time) {
 		duration := time.Since(start)


### PR DESCRIPTION
## Describe the changes that are made
Kernel network-I/O accounting (`pkg/agent/proxy/netstat.go`) previously read a proxied connection's `TCP_INFO` byte totals **only at teardown**. Its own v1 note called this out: a connection that stays open for the whole recording contributes nothing until it closes.

That silently undercounts the largest flows: **DB / connection-pool sockets, HTTP keep-alive, and gRPC streams** stay open the entire recording, so the heaviest traffic (e.g. large result sets pulled over a persistent pool) is missed — often by orders of magnitude — and the reported Rx/Tx skews toward whatever rides the short-lived connections.

**Fix:** register each app-facing socket with a new `TrackConnNetworkIO` at setup, and add a background sampler that folds each interval's byte **delta** into the sink while the connection is still open. `RecordConnNetworkIO` now takes only the **final delta** at teardown.

- Accounting is delta-based, so a connection is **never double counted** across ticks or against its teardown read (verified by a unit test).
- Connections that are never tracked keep the **original** teardown-only behavior (full lifetime total, once) — no regression.
- Tracked at every app-facing socket that carries traffic: egress proxy (`origSrcConn`, covers all protocols via the shared teardown defer), ingress HTTP (dialed `upConn` + each redialed keep-alive upstream), ingress gRPC (`destConn`). The readiness-probe dial transfers no data and is intentionally left unaccounted. Non-Linux keeps its no-op stub.

Producer-side only; no wire-format or API change.

## Links & References

**Closes:** NA

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [x] 🐞 Bug Fix

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

Unit tests in `pkg/agent/proxy/netstat_test.go` (real loopback sockets):
- `TestForwardDelta` — counter delta + reset guard.
- `TestNetworkIO_PeriodicSamplingNoDoubleCount` — a periodic sample followed by a no-traffic sample followed by teardown counts the bytes exactly once.
- `TestRecordConnNetworkIO_UntrackedFullTotal` — an untracked connection still reports its full total at teardown.

```
go test ./pkg/agent/proxy/ -run 'ForwardDelta|NetworkIO|RecordConnNetworkIO_Untracked'
```

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA