### PR TITLE
fix(cli): exit non-zero when logger initialization fails

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ func start(ctx context.Context) {
 	logger, logFile, err := log.New()
 	if err != nil {
 		fmt.Println("Failed to start the logger for the CLI", err)
+		utils.ErrCode = 1
 		return
 	}
 	utils.LogFile = logFile

--- a/main_test.go
+++ b/main_test.go
@@ -7,32 +7,44 @@ import (
 	"testing"
 
 	"go.keploy.io/server/v3/utils"
+	"go.keploy.io/server/v3/utils/log"
 )
 
 func TestStart_LoggerInitFailureSetsErrCode(t *testing.T) {
+	// t.TempDir() has to come before t.Chdir: cleanups run LIFO, so
+	// registering the temp dir first means its RemoveAll runs after the
+	// working directory has been restored. Windows cannot remove a directory
+	// that is still the process cwd.
 	tmpDir := t.TempDir()
 
-	// Creating a directory with the log file's name causes os.OpenFile
-	// (O_WRONLY|O_CREATE) in log.New() to fail with EISDIR on all platforms.
-	err := os.Mkdir(filepath.Join(tmpDir, "keploy-logs.txt"), 0755)
-	if err != nil {
+	// Creating a directory with the log file's name makes the os.OpenFile
+	// (O_WRONLY|O_CREATE) in log.New() fail on every platform - EISDIR on
+	// Unix, ERROR_ACCESS_DENIED on Windows.
+	if err := os.Mkdir(filepath.Join(tmpDir, "keploy-logs.txt"), 0755); err != nil {
 		t.Fatalf("failed to create dummy directory: %v", err)
 	}
 
-	origWd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("failed to get current working directory: %v", err)
-	}
+	// t.Chdir restores the working directory when the test ends. It also
+	// panics if the test is ever marked parallel, which this one can never
+	// be: it chdirs the whole process and writes the package-level
+	// utils.ErrCode.
+	t.Chdir(tmpDir)
 
-	if err := os.Chdir(tmpDir); err != nil {
-		t.Fatalf("failed to chdir to tmpDir: %v", err)
+	// start() only returns early while log.New() keeps failing here. log.New()
+	// opens the hardcoded relative path "keploy-logs.txt", so making that path
+	// configurable or absolute would break this setup - and start() would then
+	// fall through into the real CLI and reach an os.Exit, killing the whole
+	// test binary with nothing pointing back at this test. Assert the
+	// precondition instead of debugging that later.
+	if _, logFile, err := log.New(); err == nil {
+		if logFile != nil {
+			_ = logFile.Close()
+		}
+		t.Fatal("log.New() unexpectedly succeeded; start() would run the whole CLI inside the test binary")
 	}
-	t.Cleanup(func() {
-		_ = os.Chdir(origWd)
-		utils.ErrCode = 0
-	})
 
 	utils.ErrCode = 0
+	t.Cleanup(func() { utils.ErrCode = 0 })
 
 	start(context.Background())
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.keploy.io/server/v3/utils"
+)
+
+func TestStart_LoggerInitFailureSetsErrCode(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Creating a directory with the log file's name causes os.OpenFile
+	// (O_WRONLY|O_CREATE) in log.New() to fail with EISDIR on all platforms.
+	err := os.Mkdir(filepath.Join(tmpDir, "keploy-logs.txt"), 0755)
+	if err != nil {
+		t.Fatalf("failed to create dummy directory: %v", err)
+	}
+
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current working directory: %v", err)
+	}
+
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir to tmpDir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(origWd)
+		utils.ErrCode = 0
+	})
+
+	utils.ErrCode = 0
+
+	start(context.Background())
+
+	if utils.ErrCode != 1 {
+		t.Fatalf("expected utils.ErrCode = 1 on logger failure, got %d", utils.ErrCode)
+	}
+}


### PR DESCRIPTION
When log.New() fails during startup, start() returned without setting utils.ErrCode. The subsequent os.Exit(utils.ErrCode) in main() then exited with code 0, incorrectly signaling success to callers and CI scripts.

Set utils.ErrCode = 1 before returning so the process exits with status code 1, matching the existing CLI exit-code handling.

Fixes #2734

## Describe the changes that are made
- Set `utils.ErrCode = 1` when logger initialization fails during CLI startup.
- Add a regression test covering the logger initialization failure path.

## Links & References

**Closes:** #2734

### 🔗 Related PRs
- NA

### 🐞 Related Issues
- #2734

### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [ ] 👍 yes
- [x] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

### Testing

Added a regression test that creates a directory named `keploy-logs.txt` in a temporary working directory. This causes logger initialization to fail deterministically, allowing the test to verify that `utils.ErrCode` is set to `1`.

The local environment does not currently have the Go toolchain or a container runtime available, so the Go test suite could not be executed locally. CI should execute the test suite.

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
- NA