### PR TITLE
fix(proxy): serve recorded MySQL mocks when the app's endpoint has moved

### DIFF
--- a/.github/workflows/java_linux.yml
+++ b/.github/workflows/java_linux.yml
@@ -212,6 +212,8 @@ jobs:
           path: |
             samples-java/mysql-dual-conn/keploy/
             samples-java/mysql-dual-conn/test_logs.txt
+            samples-java/mysql-dual-conn/test_logs_drift.txt
+            samples-java/mysql-dual-conn/application.properties
             samples-java/mysql-dual-conn/autoPort_record.txt
             samples-java/mysql-dual-conn/mvn_build.log
           if-no-files-found: warn

--- a/.github/workflows/test_workflow_scripts/java/mysql_auto_port/java-linux.sh
+++ b/.github/workflows/test_workflow_scripts/java/mysql_auto_port/java-linux.sh
@@ -25,6 +25,15 @@
 # this test silently stops testing detection — so it fails loudly
 # instead.
 #
+# Phase 2 (endpoint drift) then replays a SECOND time with the app pointed at
+# a port nothing has ever seen, while the mocks still say ${MYSQL_PORT}. Port
+# recall is an equality test, and the environment does not always agree with
+# the recording — a rebuilt compose file, a pooler on one side only, a
+# per-environment port. When it disagrees, keploy still detects the connection
+# as server-speaks-first and used to discard that verdict for want of a port
+# match, leaving the app to block on a greeting that, in replay, only keploy
+# could ever send. Phase 2 requires the same tests to pass anyway.
+#
 # Compat matrix: this behaviour needs BOTH binaries to support it. A
 # record binary without detection hangs the handshake and records
 # nothing; a replay binary without mock-derived port recall hangs the
@@ -36,6 +45,9 @@
 set -Eeuo pipefail
 
 MYSQL_PORT=3307
+# The port the application is pointed at for the SECOND replay, to simulate an
+# environment whose database endpoint differs from the one that was recorded.
+DRIFT_PORT=3399
 
 section() { echo "::group::$*"; }
 endsec()  { echo "::endgroup::"; }
@@ -67,6 +79,17 @@ mysql_auto_detect_supported() {
   return "$rc"
 }
 
+# mysql_port_drift_supported: true when this binary can serve MySQL mocks on a
+# port the recording never saw. There is no config key for that behaviour, so
+# probe the binary for the warning it emits on that path — deliberately the
+# same string the assertion below greps for, so the probe cannot quietly drift
+# away from what is being asserted.
+mysql_port_drift_supported() {
+  local bin="$1"
+  [[ -f "$bin" ]] || return 1
+  grep -aq "serving MySQL mocks on a port the recording never saw" "$bin"
+}
+
 # Move the sample off 3306 without touching the samples repo: rewrite
 # the compose publish port and both JDBC URLs in place.
 relocate_mysql_port() {
@@ -90,10 +113,11 @@ relocate_mysql_port() {
 # covering it, the test would keep passing while testing nothing — so
 # assert both here.
 assert_no_mysql_ports_config() {
-  section "Assert ${MYSQL_PORT} is not pre-configured anywhere"
+  local port="${1:-$MYSQL_PORT}"
+  section "Assert ${port} is not pre-configured anywhere"
 
   # 1. The built-in default list in the source. Without this check,
-  #    adding ${MYSQL_PORT} to defaultMysqlPorts would make this test
+  #    adding ${port} to defaultMysqlPorts would make this test
   #    green while it silently stopped exercising detection.
   local defaults_src="$GITHUB_WORKSPACE/pkg/agent/proxy/proxy.go"
   if [[ -f "$defaults_src" ]]; then
@@ -104,8 +128,8 @@ assert_no_mysql_ports_config() {
       echo "::error::could not find defaultMysqlPorts in $defaults_src — the guard below cannot run; update this script if the variable was renamed"
       exit 1
     fi
-    if grep -qE "(^|[^0-9])${MYSQL_PORT}([^0-9]|$)" <<<"$defaults_line"; then
-      echo "::error::${MYSQL_PORT} is now a built-in default MySQL port — this test no longer exercises auto-detection. Pick a different port."
+    if grep -qE "(^|[^0-9])${port}([^0-9]|$)" <<<"$defaults_line"; then
+      echo "::error::${port} is now a built-in default MySQL port — this test no longer exercises auto-detection. Pick a different port."
       exit 1
     fi
   else
@@ -115,8 +139,8 @@ assert_no_mysql_ports_config() {
 
   # 2. The generated config.
   if [[ -f keploy.yml ]]; then
-    if grep -E "^\s*mysqlPorts:" keploy.yml | grep -q "${MYSQL_PORT}"; then
-      echo "::error::keploy.yml lists ${MYSQL_PORT} in mysqlPorts — this test no longer exercises auto-detection"
+    if grep -E "^\s*mysqlPorts:" keploy.yml | grep -q "${port}"; then
+      echo "::error::keploy.yml lists ${port} in mysqlPorts — this test no longer exercises auto-detection"
       exit 1
     fi
     if grep -qE "^\s*disableMysqlAutoDetect:\s*true" keploy.yml; then
@@ -316,36 +340,191 @@ fi
 grep "recovered MySQL ports from recorded mocks" test_logs.txt
 endsec
 
-section "Check reports"
-RUN_DIR=$(ls -1dt ./keploy/reports/test-run-* 2>/dev/null | head -n1 || true)
-if [[ -z "${RUN_DIR:-}" ]]; then
-  echo "::error::No test-run directory found under ./keploy/reports"
-  [[ $REPLAY_RC -ne 0 ]] && exit "$REPLAY_RC" || exit 1
-fi
-echo "Using reports from: $RUN_DIR"
+# check_reports asserts every test set in the most recent run passed.
+# Parameterised because this script replays twice — once on the recorded
+# endpoint, once after moving it.
+check_reports() {
+  local label="$1" replay_rc="$2" previous="${3:-}"
+  section "Check reports (${label})"
+  local run_dir
+  run_dir=$(latest_run_dir)
+  # A replay that dies before writing a report would otherwise leave the
+  # PREVIOUS phase's directory as the newest one, and its PASSED statuses would
+  # be read as this phase's.
+  if [[ -n "$previous" && "$run_dir" == "$previous" ]]; then
+    echo "::error::the ${label} replay produced no report of its own; the newest"
+    echo "::error::run directory is still the one from the previous phase."
+    endsec
+    exit 1
+  fi
+  if [[ -z "${run_dir:-}" ]]; then
+    echo "::error::No test-run directory found under ./keploy/reports (${label})"
+    endsec
+    [[ $replay_rc -ne 0 ]] && exit "$replay_rc" || exit 1
+  fi
+  echo "Using reports from: $run_dir"
 
-all_passed=true
-found_any=false
-for rpt in "$RUN_DIR"/test-set-*-report.yaml; do
-  [[ -f "$rpt" ]] || continue
-  found_any=true
-  status=$(awk '/^status:/{print $2; exit}' "$rpt")
-  echo "Test status for $(basename "$rpt"): ${status:-<missing>}"
-  [[ "$status" == "PASSED" ]] || all_passed=false
-done
+  local all_passed=true found_any=false status
+  for rpt in "$run_dir"/test-set-*-report.yaml; do
+    [[ -f "$rpt" ]] || continue
+    found_any=true
+    status=$(awk '/^status:/{print $2; exit}' "$rpt")
+    echo "Test status for $(basename "$rpt"): ${status:-<missing>}"
+    [[ "$status" == "PASSED" ]] || all_passed=false
+  done
+  endsec
+
+  if [[ "$found_any" == "false" ]]; then
+    echo "::error::No test report files found in $run_dir (${label})"
+    exit 1
+  fi
+  if [[ "$all_passed" != "true" ]]; then
+    echo "::error::Some tests failed during replay (${label})"
+    exit 1
+  fi
+  if [[ $replay_rc -ne 0 ]]; then
+    echo "Replay exited with code $replay_rc but all tests passed (${label}). Ignoring exit code."
+  fi
+}
+
+latest_run_dir() {
+  ls -1dt ./keploy/reports/test-run-* 2>/dev/null | head -n1 || true
+}
+
+# reports_all_passed answers the same question as check_reports without
+# exiting, so a caller can branch on the outcome. It takes the run directory
+# that existed BEFORE the replay: a replay whose app never started writes no
+# report at all, and without that argument this would read the previous
+# phase's report and cheerfully conclude everything passed.
+reports_all_passed() {
+  local previous="$1" run_dir status
+  run_dir=$(latest_run_dir)
+  [[ -n "${run_dir:-}" ]] || return 1
+  [[ "$run_dir" != "$previous" ]] || return 1
+  local found=false
+  for rpt in "$run_dir"/test-set-*-report.yaml; do
+    [[ -f "$rpt" ]] || continue
+    found=true
+    status=$(awk '/^status:/{print $2; exit}' "$rpt")
+    [[ "$status" == "PASSED" ]] || return 1
+  done
+  [[ "$found" == "true" ]]
+}
+
+check_reports "recorded endpoint" "$REPLAY_RC"
+
+# ---------------------------------------------------------------------------
+# Phase 2: endpoint drift
+# ---------------------------------------------------------------------------
+#
+# Everything above replays against the same endpoint that was recorded, so the
+# port can be recalled from the mocks' destAddr metadata. That recall is an
+# equality test, and it carries an assumption stated in the PR that introduced
+# it: "container IPs change between record and replay, ports don't."
+#
+# They do. A reconstructed environment — `keploy cloud replay` rebuilding a
+# compose file from a stored manifest, a pooler present in one environment and
+# not the other, a per-environment port — hands the application a different
+# endpoint than the recording saw. Detection still fires there: the client
+# opens the connection and says nothing, which is the MySQL signature and the
+# only server-speaks-first protocol keploy records. It was the port equality
+# check that discarded that evidence, and declining is not a neutral outcome —
+# in replay keploy IS the server, so nothing else will ever send the greeting.
+# The application blocks until its own timeout, every test touching the
+# dependency reports status_code 0, and the entire recorded mock set goes
+# unused while the recording itself is perfectly good. That is silent: no error
+# is printed, the tests simply fail as if the application were broken.
+#
+# So: point the application at a port nothing has ever seen, with MySQL still
+# shut down and the mocks still recorded on :${MYSQL_PORT}, and require the
+# same tests to pass anyway.
+if ! mysql_port_drift_supported "${REPLAY_BIN:-keploy}"; then
+  if [[ "${REQUIRE_MYSQL_AUTO_DETECT:-}" == "true" ]]; then
+    echo "::error::the replay binary is built from this commit yet does not report"
+    echo "::error::endpoint-drift inference. Either the feature regressed or the"
+    echo "::error::probe string changed. Not skipping — this cell must assert."
+    exit 1
+  fi
+  echo "Skipping the endpoint-drift phase: the replay binary predates it."
+  echo "MySQL auto-port-detection e2e passed: recorded and replayed on :${MYSQL_PORT} with no port configuration."
+  exit 0
+fi
+
+section "Point the app at :${DRIFT_PORT} (mocks still say :${MYSQL_PORT})"
+# The jar carries application.properties on its classpath, so editing the
+# source tree after the build changes nothing — the app would keep dialling
+# :${MYSQL_PORT} and this phase would assert against a drift that never
+# happened. Spring Boot ranks file:./ above classpath:/, so an override next to
+# the jar is what actually moves the endpoint, without a second build.
+if ! grep -E '^datasource\..*jdbc-url=' src/main/resources/application.properties > jdbc_lines.txt; then
+  echo "::error::no datasource.*.jdbc-url lines in the sample's application.properties;"
+  echo "::error::the sample renamed its datasource keys and this override no longer applies."
+  exit 1
+fi
+sed "s|localhost:${MYSQL_PORT}|localhost:${DRIFT_PORT}|g" jdbc_lines.txt > application.properties
+if ! grep -q "localhost:${DRIFT_PORT}" application.properties; then
+  echo "::error::JDBC URL override for :${DRIFT_PORT} was not written"
+  exit 1
+fi
+echo "override (file:./application.properties):"; cat application.properties
+echo "Recorded mocks still carry :${MYSQL_PORT}:"
+grep -o "destAddr: .*" "$MOCKS_FILE" | sort -u
 endsec
 
-if [[ "$found_any" == "false" ]]; then
-  echo "::error::No test report files found in $RUN_DIR"
-  exit 1
-fi
-if [[ "$all_passed" != "true" ]]; then
-  echo "::error::Some tests failed during replay"
-  exit 1
-fi
-if [[ $REPLAY_RC -ne 0 ]]; then
-  echo "Replay exited with code $REPLAY_RC but all tests passed. Ignoring exit code."
-fi
+# The drift port must be as unknown to keploy as the recorded one, or the
+# inference path is never reached and this phase asserts nothing.
+assert_no_mysql_ports_config "$DRIFT_PORT"
 
-echo "MySQL auto-port-detection e2e passed: recorded and replayed on :${MYSQL_PORT} with no port configuration."
+PRE_DRIFT_RUN_DIR=$(latest_run_dir)
+
+section "Replay after endpoint drift"
+set +e
+"$REPLAY_BIN" test -c "java -jar $JAR_NAME" \
+  --delay 20 --api-timeout 60 \
+  2>&1 | tee test_logs_drift.txt
+DRIFT_RC=$?
+set -e
+echo "Replay exit code: $DRIFT_RC"
+endsec
+
+section "Assert the mocks were served on the drifted port"
+# Passing tests alone would not prove the inference ran — a change that simply
+# made the port allowlist permissive would pass too. Require the warning that
+# says keploy knowingly served MySQL on a port the recording never saw. It is
+# logged at WARN, so unlike the port numbers (DEBUG) it is always present.
+# The port travels as a structured field, so match it too: a warning fired on
+# some other port would otherwise satisfy this assertion.
+if ! grep "serving MySQL mocks on a port the recording never saw" test_logs_drift.txt | grep -q "${DRIFT_PORT}"; then
+  # Two very different failures both land here, and the test outcome tells them
+  # apart. If the override never took effect the app is still talking to
+  # :${MYSQL_PORT}, which IS in the recorded set, so every test passes. If the
+  # override took effect and the inference is gone, the app blocks waiting for
+  # a greeting only keploy could send, its connection pool fails to initialise,
+  # and nothing passes.
+  if reports_all_passed "$PRE_DRIFT_RUN_DIR"; then
+    echo "::error::the drift warning is absent but every test passed, which means the"
+    echo "::error::application was still talking to :${MYSQL_PORT} — the file:./application.properties"
+    echo "::error::override did not take effect and this phase exercised nothing."
+    echo "::error::Check that Spring Boot still ranks file:./ above classpath:/ and that"
+    echo "::error::the datasource keys below still match the sample:"
+    cat application.properties
+  else
+    echo "::error::keploy did not serve the recorded MySQL mocks on :${DRIFT_PORT}."
+    echo "::error::The application blocked waiting for a server greeting that, in replay,"
+    echo "::error::only keploy could send — the endpoint-drift inference has regressed."
+    if [[ "$(latest_run_dir)" == "$PRE_DRIFT_RUN_DIR" ]]; then
+      echo "::error::(the drift replay produced no report at all: the app never finished starting)"
+    fi
+    grep -n "Communications link failure\|Failed to initialize pool" test_logs_drift.txt | head -n 5 || true
+  fi
+  tail -n 120 test_logs_drift.txt
+  exit 1
+fi
+grep "serving MySQL mocks on a port the recording never saw" test_logs_drift.txt | head -n 3
+endsec
+
+check_reports "drifted endpoint :${DRIFT_PORT}" "$DRIFT_RC" "$PRE_DRIFT_RUN_DIR"
+
+echo "MySQL auto-port-detection e2e passed: recorded and replayed on :${MYSQL_PORT} with"
+echo "no port configuration, and replayed again with the app moved to :${DRIFT_PORT}."
 exit 0

--- a/config/config.go
+++ b/config/config.go
@@ -49,21 +49,34 @@ type Config struct {
 	// recalling the port from recorded mocks during replay. Turn it off
 	// to restore the strict port-list behaviour — then MySQL on a port
 	// outside MysqlPorts will hang its handshake.
-	DisableMysqlAutoDetect bool     `json:"disableMysqlAutoDetect" yaml:"disableMysqlAutoDetect" mapstructure:"disableMysqlAutoDetect"`
-	EnableTesting          bool     `json:"enableTesting" yaml:"-" mapstructure:"enableTesting"`
-	GenerateGithubActions  bool     `json:"generateGithubActions" yaml:"generateGithubActions" mapstructure:"generateGithubActions"`
-	KeployContainer        string   `json:"keployContainer" yaml:"keployContainer" mapstructure:"keployContainer"`
-	KeployNetwork          string   `json:"keployNetwork" yaml:"keployNetwork" mapstructure:"keployNetwork"`
-	CommandType            string   `json:"cmdType" yaml:"cmdType" mapstructure:"cmdType"`
-	Contract               Contract `json:"contract" yaml:"contract" mapstructure:"contract"`
-	Agent                  Agent    `json:"agent" yaml:"agent" mapstructure:"agent"`
-	Async                  Async    `json:"async" yaml:"async" mapstructure:"async"`
-	InCi                   bool     `json:"inCi" yaml:"inCi" mapstructure:"inCi"`
-	InstallationID         string   `json:"-" yaml:"-" mapstructure:"-"`
-	ServerPort             uint32   `json:"serverPort" yaml:"serverPort" mapstructure:"serverPort"`
-	Version                string   `json:"-" yaml:"-" mapstructure:"-"`
-	APIServerURL           string   `json:"-" yaml:"-" mapstructure:"-"`
-	GitHubClientID         string   `json:"-" yaml:"-" mapstructure:"-"`
+	DisableMysqlAutoDetect bool `json:"disableMysqlAutoDetect" yaml:"disableMysqlAutoDetect" mapstructure:"disableMysqlAutoDetect"`
+	// DisableMysqlEndpointDrift stops replay from serving recorded MySQL
+	// mocks on a port the recording never saw. Detection still runs; only
+	// the inference is turned off.
+	//
+	// Leave it on (the default) unless a dependency is being misread. The
+	// inference fires when a replayed app opens a connection to an unknown
+	// port and says nothing, which is the MySQL signature — but a client that
+	// stays silent for the whole confirmation window and only then speaks
+	// looks the same, and it will be answered with a handshake it did not ask
+	// for. Pinning the real mapping with MysqlPorts is the better fix when you
+	// know it; this is the escape hatch when you do not, and unlike
+	// DisableMysqlAutoDetect it keeps record-time detection working.
+	DisableMysqlEndpointDrift bool     `json:"disableMysqlEndpointDrift" yaml:"disableMysqlEndpointDrift" mapstructure:"disableMysqlEndpointDrift"`
+	EnableTesting             bool     `json:"enableTesting" yaml:"-" mapstructure:"enableTesting"`
+	GenerateGithubActions     bool     `json:"generateGithubActions" yaml:"generateGithubActions" mapstructure:"generateGithubActions"`
+	KeployContainer           string   `json:"keployContainer" yaml:"keployContainer" mapstructure:"keployContainer"`
+	KeployNetwork             string   `json:"keployNetwork" yaml:"keployNetwork" mapstructure:"keployNetwork"`
+	CommandType               string   `json:"cmdType" yaml:"cmdType" mapstructure:"cmdType"`
+	Contract                  Contract `json:"contract" yaml:"contract" mapstructure:"contract"`
+	Agent                     Agent    `json:"agent" yaml:"agent" mapstructure:"agent"`
+	Async                     Async    `json:"async" yaml:"async" mapstructure:"async"`
+	InCi                      bool     `json:"inCi" yaml:"inCi" mapstructure:"inCi"`
+	InstallationID            string   `json:"-" yaml:"-" mapstructure:"-"`
+	ServerPort                uint32   `json:"serverPort" yaml:"serverPort" mapstructure:"serverPort"`
+	Version                   string   `json:"-" yaml:"-" mapstructure:"-"`
+	APIServerURL              string   `json:"-" yaml:"-" mapstructure:"-"`
+	GitHubClientID            string   `json:"-" yaml:"-" mapstructure:"-"`
 	// InMemoryCompose holds docker-compose YAML content in memory to avoid writing
 	// sensitive environment variables (secrets, tokens) to disk. When set, the
 	// compose command uses "-f -" and pipes this content via stdin.

--- a/config/default.go
+++ b/config/default.go
@@ -149,6 +149,13 @@ mysqlPorts: []
 # Set to true to turn detection off and go back to matching mysqlPorts
 # strictly. MySQL on any other port will then hang its handshake.
 disableMysqlAutoDetect: false
+# During replay, keploy serves recorded MySQL mocks even when the app
+# connects to a port the recording never saw — an app whose environment
+# was rebuilt does not always get the endpoint it had while recording,
+# and refusing would leave it waiting for a greeting only keploy can
+# send. Set to true if a non-MySQL dependency is being misread as MySQL;
+# unlike disableMysqlAutoDetect this keeps record-time detection on.
+disableMysqlEndpointDrift: false
 disableMapping: false
 contract:
   driven: "consumer"

--- a/pkg/agent/proxy/mysql_detect.go
+++ b/pkg/agent/proxy/mysql_detect.go
@@ -160,7 +160,35 @@ type mysqlPortRegistry struct {
 	mu       sync.RWMutex
 	ports    map[uint32]struct{}
 	notMysql map[uint32]struct{}
-	derived  bool
+	// inferred holds the endpoints that were served MySQL on behavioural
+	// evidence alone (a silent client on a port no mock names — see the
+	// endpoint-drift branch in probeMysql). It does two things: it keeps the
+	// warning to one line per endpoint, and it lets the next connection to the
+	// SAME endpoint skip the long confirmation wait, which a pool reopening
+	// connections would otherwise re-pay every time.
+	//
+	// It is deliberately not `ports`, and Has() must keep returning false for
+	// these: the silence check still runs on every connection, which is what
+	// rejects a client that speaks first, so no membership here can turn a
+	// working dependency into a permanent MySQL hijack.
+	//
+	// The key is the full "host:port", unlike everything else in this registry.
+	// Port-only matching is right for a recording — the host changes between
+	// record and replay, the port is the app's own configuration — but this map
+	// weakens a check rather than recalling recorded evidence, and a different
+	// service that merely shares a port number must not inherit that.
+	inferred map[string]struct{}
+	// fromMocks holds only the ports DeriveFromMocks read out of a recording.
+	// `ports` is the union of those and anything Learn() promoted during a
+	// record session, and the agent is one long-lived process that does not
+	// reset this registry between sessions — so `ports` being non-empty does
+	// NOT mean the recording being replayed contains MySQL. The endpoint-drift
+	// inference has to be gated on evidence from the recording itself, or a
+	// port learned while recording would arm it during a replay with no MySQL
+	// mocks at all, and the connection would be routed to a replayer with
+	// nothing to serve.
+	fromMocks map[uint32]struct{}
+	derived   bool
 	// derivedCh is closed the first time DeriveFromMocks runs, so a
 	// replay connection that arrives before mocks are stored can block
 	// on it instead of guessing. Never closed twice (guarded by mu +
@@ -172,6 +200,8 @@ func newMysqlPortRegistry() *mysqlPortRegistry {
 	return &mysqlPortRegistry{
 		ports:     make(map[uint32]struct{}),
 		notMysql:  make(map[uint32]struct{}),
+		inferred:  make(map[string]struct{}),
+		fromMocks: make(map[uint32]struct{}),
 		derivedCh: make(chan struct{}),
 	}
 }
@@ -224,7 +254,69 @@ func (r *mysqlPortRegistry) LearnNotMysql(port uint32) bool {
 	return true
 }
 
-// Ports returns a snapshot, for logging.
+// LearnInferred records that this endpoint has been served on inferred
+// evidence, returning true the first time so the caller logs once. It grants no
+// fast path: Has() is unaffected, so the next connection still has to prove it
+// is server-speaks-first before anything is served.
+func (r *mysqlPortRegistry) LearnInferred(dstAddr string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.inferred[dstAddr]; ok {
+		return false
+	}
+	r.inferred[dstAddr] = struct{}{}
+	return true
+}
+
+// IsInferred reports whether this endpoint has already been served on inferred
+// evidence. It shortens the confirmation the NEXT connection to the same
+// endpoint has to pass — see probeMysql — but never replaces the silence check
+// that precedes it.
+func (r *mysqlPortRegistry) IsInferred(dstAddr string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, ok := r.inferred[dstAddr]
+	return ok
+}
+
+// ResetSession forgets everything learned from a recording: the ports derived
+// from mocks and the endpoints inferred while serving them. The agent is one
+// long-lived process and this registry is allocated once, so without this the
+// gate on the drift inference would mean "any recording this process has ever
+// replayed" rather than "the recording being replayed now" — a test set holding
+// MySQL mocks would arm the inference for a later one that holds none, and a
+// silent connection there would be routed to a replayer with nothing to serve.
+//
+// Ports learned by probing a live server during a record session are kept:
+// those are facts about a real server, not about a recording.
+func (r *mysqlPortRegistry) ResetSession() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for port := range r.fromMocks {
+		delete(r.ports, port)
+	}
+	r.fromMocks = make(map[uint32]struct{})
+	r.inferred = make(map[string]struct{})
+	// Re-arm the derivation gate so a connection arriving before this
+	// session's mocks are stored parks instead of being decided against the
+	// previous session's port set.
+	r.derived = false
+	r.derivedCh = make(chan struct{})
+}
+
+// MockPorts returns the ports that came from a recording, as opposed to ones
+// learned by probing during a record session.
+func (r *mysqlPortRegistry) MockPorts() []uint32 {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]uint32, 0, len(r.fromMocks))
+	for p := range r.fromMocks {
+		out = append(out, p)
+	}
+	return out
+}
+
+// Ports returns a snapshot of every known MySQL port, for logging.
 func (r *mysqlPortRegistry) Ports() []uint32 {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -253,6 +345,7 @@ func (r *mysqlPortRegistry) DeriveFromMocks(mockSets ...[]*models.Mock) []uint32
 			if !ok {
 				continue
 			}
+			r.fromMocks[port] = struct{}{}
 			if _, exists := r.ports[port]; !exists {
 				r.ports[port] = struct{}{}
 				added = append(added, port)
@@ -409,7 +502,7 @@ func (p *Proxy) probeMysql(
 	// ── Step 1: is the client silent? ──
 	// Only a server-speaks-first connection can be MySQL at this point.
 	// Any client byte is a definitive negative and costs one read.
-	clientBytes, err := readWithin(srcConn, clientSilenceWindow())
+	clientBytes, err := readWithin(ctx, srcConn, clientSilenceWindow())
 	if len(clientBytes) > 0 {
 		return notMysql("client-spoke-first", replayConn(srcConn, clientBytes, logger)), nil
 	}
@@ -435,6 +528,67 @@ func (p *Proxy) probeMysql(
 		if p.mysqlPorts.Has(port) {
 			logger.Debug("recalled mysql port from recorded mocks", zap.Uint32("port", port))
 			return &mysqlProbe{IsMySQL: true, SrcConn: srcConn, Reason: "derived-from-mocks"}, nil
+		}
+		// The port is not one the recording saw. Reaching here already means
+		// the client opened the connection and then said nothing, so it is
+		// waiting to be greeted, and MySQL is the only server-speaks-first
+		// protocol keploy replays. Combined with "this recording contains
+		// MySQL mocks", a port that does not match is an environment
+		// difference — the replayed application was handed a different
+		// endpoint than it had at record time — not evidence that the
+		// connection isn't MySQL.
+		//
+		// Declining is not neutral. In replay keploy IS the server, so nothing
+		// else will ever send that greeting: the application blocks until its
+		// own timeout, every test touching that dependency reports
+		// status_code 0, and the whole recorded mock set goes unused while the
+		// recording is perfectly good.
+		//
+		// The gate is MockPorts, not Ports: the latter also holds ports learned
+		// by probing during a record session, and the agent process does not
+		// reset this registry between sessions, so it would arm this branch in
+		// a replay whose recording contains no MySQL at all.
+		if derived := p.mysqlPorts.MockPorts(); len(derived) > 0 && !opts.DisableMysqlEndpointDrift {
+			// Confirm before acting, because the silence window is a weak
+			// signal on its own — a slow TLS client can be quiet that long and
+			// only then send its ClientHello, and answering that with a
+			// HandshakeV10 breaks a connection that was working. A real MySQL
+			// client sends nothing at all until it is greeted, so a second,
+			// longer wait separates the two almost perfectly.
+			//
+			// Only the first connection to an endpoint pays it. After that the
+			// silence check above is confirmation enough: it is what rejects a
+			// client that speaks first, and it has already run. Re-paying the
+			// long wait on every connection would add it to each one a pool
+			// opens — in the bundle that motivated this change, 103 times.
+			// Keyed by endpoint, so a different host on the same port number
+			// does not inherit the shortcut.
+			if !p.mysqlPorts.IsInferred(dstAddr) {
+				late, lateErr := readWithin(ctx, srcConn, serverGreetingWindow())
+				if len(late) > 0 {
+					// It spoke, just slowly. Hand the bytes back and let the
+					// normal dispatch have it. The port is NOT cached as
+					// non-MySQL: this connection was not MySQL, but the next
+					// one on this port still deserves the same decision.
+					logger.Debug("client spoke after the extended window; not inferring MySQL",
+						zap.Uint32("port", port), zap.String("dstAddr", dstAddr),
+						zap.Duration("window", serverGreetingWindow()))
+					return &mysqlProbe{SrcConn: replayConn(srcConn, late, logger), Reason: "client-spoke-late"}, nil
+				}
+				if lateErr != nil && !isTimeout(lateErr) {
+					return &mysqlProbe{SrcConn: srcConn, Reason: "client-read-error"}, nil
+				}
+			}
+			// Bookkeeping only — this must not grant the fast path, or one
+			// inference would route every later connection on this port to the
+			// MySQL replayer without re-checking that the client is silent.
+			if p.mysqlPorts.LearnInferred(dstAddr) {
+				logger.Warn("serving MySQL mocks on a port the recording never saw: the replayed application connects to a different endpoint than it did at record time. Set mysqlPorts in keploy.yml to pin the mapping, or disableMysqlEndpointDrift: true if a non-MySQL dependency is being misread as MySQL here.",
+					zap.Uint32("port", port),
+					zap.String("dstAddr", dstAddr),
+					zap.Uint32s("recordedPorts", derived))
+			}
+			return &mysqlProbe{IsMySQL: true, SrcConn: srcConn, Reason: "inferred-endpoint-drift"}, nil
 		}
 		return &mysqlProbe{SrcConn: srcConn, Reason: "no-mysql-mock-for-port"}, nil
 	}
@@ -576,16 +730,61 @@ func readGreetingWithin(ctx context.Context, conn net.Conn, window time.Duration
 //
 // Any bytes read before an error are returned, so no data is ever lost
 // to a mid-read failure.
-func readWithin(conn net.Conn, window time.Duration) ([]byte, error) {
+func readWithin(ctx context.Context, conn net.Conn, window time.Duration) ([]byte, error) {
+	if ctx != nil && ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
 	if err := conn.SetReadDeadline(time.Now().Add(window)); err != nil {
 		return nil, err
 	}
-	defer func() { _ = conn.SetReadDeadline(time.Time{}) }()
+
+	// A read deadline is not cancellable, and this one can be seconds long.
+	// Tripping the deadline early is what actually unblocks the Read, so a
+	// Ctrl-C or an aborted test run does not have to sit through the rest of
+	// the window on every silent connection still in flight.
+	//
+	// The early return above covers a context that is already cancelled. This
+	// guard covers the other half: context.AfterFunc's stop() reports that the
+	// function has already started but does not wait for it, and it runs on its
+	// own goroutine — so a cancellation landing mid-read can call
+	// SetReadDeadline(now) AFTER the reset below, leaving a deadline in the past
+	// on a connection someone else is about to read. That surfaces as an
+	// immediate "i/o timeout" with data waiting, which is very hard to place
+	// from the outside. TestReadWithinLeavesNoDeadlineBehind pins the
+	// deterministic half; this guard closes the concurrent one, which cannot be
+	// tested without a fake conn that would deadlock on the same mutex.
+	var (
+		mu   sync.Mutex
+		done bool
+	)
+	if ctx != nil && ctx.Done() != nil {
+		stop := context.AfterFunc(ctx, func() {
+			mu.Lock()
+			defer mu.Unlock()
+			if !done {
+				_ = conn.SetReadDeadline(time.Now())
+			}
+		})
+		defer func() {
+			stop()
+			mu.Lock()
+			done = true
+			mu.Unlock()
+			_ = conn.SetReadDeadline(time.Time{})
+		}()
+	} else {
+		defer func() { _ = conn.SetReadDeadline(time.Time{}) }()
+	}
 
 	buf := make([]byte, 4096)
 	n, err := conn.Read(buf)
 	if n > 0 {
 		return buf[:n], err
+	}
+	if err != nil && isTimeout(err) && ctx != nil && ctx.Err() != nil {
+		// The deadline we tripped ourselves — report the cancellation, not a
+		// timeout the caller would read as "the client stayed silent".
+		return nil, ctx.Err()
 	}
 	return nil, err
 }

--- a/pkg/agent/proxy/mysql_detect_test.go
+++ b/pkg/agent/proxy/mysql_detect_test.go
@@ -601,3 +601,366 @@ func TestRegistryConcurrentAccess(t *testing.T) {
 		t.Error("expected 3306 after concurrent derivation")
 	}
 }
+
+// shortWindows shrinks the detection windows for tests that would otherwise
+// spend seconds asleep. It also widens the margin for the timing-sensitive
+// ones: with the production 250ms/2s pair, a test that writes at 400ms is only
+// 150ms clear of the silence window, and a GC pause or a loaded CI runner can
+// close that gap — which would land the write inside window 1 and fail the
+// assertion for a reason that has nothing to do with the behaviour under test.
+func shortWindows(t *testing.T) {
+	t.Helper()
+	t.Setenv("KEPLOY_MYSQL_CLIENT_SILENCE_WINDOW", "50ms")
+	t.Setenv("KEPLOY_MYSQL_SERVER_GREETING_WINDOW", "1s")
+}
+
+// The replayed application can be handed a different dependency endpoint than
+// it had at record time — a reconstructed environment materialises config that
+// a live cluster resolves by reference, so host AND port can drift. The client
+// still opens the connection and waits for a server greeting, which is the
+// signature this probe recognises. keploy is the server in replay, so declining
+// leaves nobody to answer: the app blocks to its own timeout, the test records
+// status_code 0, and the recorded MySQL mocks go unused.
+func TestReplayServesMocksWhenAppEndpointPortDrifted(t *testing.T) {
+	shortWindows(t)
+	p := testProxy(t)
+	p.deriveMysqlPorts([]*models.Mock{
+		{Kind: models.MySQL, Spec: models.MockSpec{Metadata: map[string]string{"destAddr": "127.0.0.1:3306"}}},
+	})
+
+	_, srcConn := clientPair(t)
+	probe, err := p.probeMysql(context.Background(), srcConn, "172.20.0.2:283", 283,
+		models.MODE_TEST, models.OutgoingOptions{}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if probe.DstConn != nil {
+		t.Fatal("replay probe dialed upstream")
+	}
+	if !probe.IsMySQL || probe.Reason != "inferred-endpoint-drift" {
+		t.Fatalf("IsMySQL=%v reason=%q, want true/inferred-endpoint-drift", probe.IsMySQL, probe.Reason)
+	}
+}
+
+// An inference is per-connection evidence and must never become a property of
+// the port. If it did, one slow client would put the port on the fast path and
+// every later connection — including one that speaks first — would be handed a
+// MySQL handshake, converting a working dependency into a dead one.
+func TestInferredPortDoesNotHijackLaterClientSpeaksFirst(t *testing.T) {
+	shortWindows(t)
+	p := testProxy(t)
+	p.deriveMysqlPorts([]*models.Mock{
+		{Kind: models.MySQL, Spec: models.MockSpec{Metadata: map[string]string{"destAddr": "127.0.0.1:3306"}}},
+	})
+
+	_, silent := clientPair(t)
+	first, err := p.probeMysql(context.Background(), silent, "172.20.0.2:8288", 8288,
+		models.MODE_TEST, models.OutgoingOptions{}, zap.NewNop())
+	if err != nil || !first.IsMySQL {
+		t.Fatalf("first probe: err=%v IsMySQL=%v", err, first.IsMySQL)
+	}
+	if p.mysqlPorts.Has(8288) {
+		t.Fatal("an inferred port must not enter the fast-path set")
+	}
+
+	// Same port, but this client sends a TLS ClientHello immediately.
+	client, srcConn := clientPair(t)
+	if _, err := client.Write([]byte{0x16, 0x03, 0x01, 0x00, 0x2f}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	second, err := p.probeMysql(context.Background(), srcConn, "172.20.0.2:8288", 8288,
+		models.MODE_TEST, models.OutgoingOptions{}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("second probe: %v", err)
+	}
+	if second.IsMySQL {
+		t.Fatalf("IsMySQL=true reason=%q: a client that speaks first must never be served a MySQL handshake", second.Reason)
+	}
+}
+
+// The registry outlives a single mode — one agent process serves both Record
+// and Mock on the same *Proxy — so a replay-only inference must not leak into
+// record, where it would drive MySQL.RecordOutgoing over a non-MySQL stream.
+func TestInferredPortDoesNotLeakIntoRecordMode(t *testing.T) {
+	shortWindows(t)
+	p := testProxy(t)
+	p.deriveMysqlPorts([]*models.Mock{
+		{Kind: models.MySQL, Spec: models.MockSpec{Metadata: map[string]string{"destAddr": "127.0.0.1:3306"}}},
+	})
+
+	_, silent := clientPair(t)
+	if _, err := p.probeMysql(context.Background(), silent, "172.20.0.2:283", 283,
+		models.MODE_TEST, models.OutgoingOptions{}, zap.NewNop()); err != nil {
+		t.Fatalf("replay probe: %v", err)
+	}
+	if p.mysqlPorts.Has(283) {
+		t.Fatal("inference leaked into the shared port set that record mode consults")
+	}
+}
+
+// 250ms of silence is a weak signal by itself: a slow TLS client can be quiet
+// that long and only then send its ClientHello. The confirmation window has to
+// catch that, and the port must not be demoted either — the next connection on
+// it still deserves the same evidence-based decision.
+func TestClientSpeakingLateIsNotInferredAsMysql(t *testing.T) {
+	shortWindows(t)
+	p := testProxy(t)
+	p.deriveMysqlPorts([]*models.Mock{
+		{Kind: models.MySQL, Spec: models.MockSpec{Metadata: map[string]string{"destAddr": "127.0.0.1:3306"}}},
+	})
+
+	client, srcConn := clientPair(t)
+	go func() {
+		time.Sleep(150 * time.Millisecond) // past the silence window (50ms), inside the confirm window (1s)
+		_, _ = client.Write([]byte{0x16, 0x03, 0x01, 0x00, 0x2f})
+	}()
+	probe, err := p.probeMysql(context.Background(), srcConn, "172.20.0.2:283", 283,
+		models.MODE_TEST, models.OutgoingOptions{}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if probe.IsMySQL {
+		t.Fatalf("IsMySQL=true reason=%q: a client that speaks within the confirm window is not MySQL", probe.Reason)
+	}
+	if p.mysqlPorts.IsKnownNotMysql(283) {
+		t.Error("a late-speaking client must not demote the port for later connections")
+	}
+}
+
+// The inference is gated on the RECORDING holding MySQL mocks. The registry
+// also accumulates ports learned by probing during a record session, and the
+// agent is one long-lived process that does not reset it between sessions — so
+// gating on "any known MySQL port" would arm the inference in a replay whose
+// recording contains no MySQL at all, and route a silent connection to a
+// replayer with nothing to serve.
+func TestReplayDoesNotInventMysqlWithoutMocks(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		arrange func(p *Proxy)
+	}{
+		{
+			name:    "no mocks at all",
+			arrange: func(p *Proxy) { p.deriveMysqlPorts(nil) },
+		},
+		{
+			name: "a port learned while recording, then a replay with no MySQL mocks",
+			arrange: func(p *Proxy) {
+				p.mysqlPorts.Learn(3307) // as a record session would
+				p.deriveMysqlPorts([]*models.Mock{
+					{Kind: models.HTTP, Spec: models.MockSpec{Metadata: map[string]string{"destAddr": "127.0.0.1:8080"}}},
+				})
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			shortWindows(t)
+			p := testProxy(t)
+			tc.arrange(p)
+
+			_, srcConn := clientPair(t)
+			probe, err := p.probeMysql(context.Background(), srcConn, "172.20.0.2:283", 283,
+				models.MODE_TEST, models.OutgoingOptions{}, zap.NewNop())
+			if err != nil {
+				t.Fatalf("probe: %v", err)
+			}
+			if probe.IsMySQL {
+				t.Fatalf("IsMySQL=true reason=%q: with no MySQL mocks in the recording there is nothing to serve", probe.Reason)
+			}
+		})
+	}
+}
+
+// The confirmation wait is paid once per port, not once per connection. A pool
+// opening many connections to a moved endpoint would otherwise add it to every
+// one of them — 103 times in the bundle that motivated this change. The
+// silence check still runs on each connection, which is what actually rejects
+// a client that speaks first.
+func TestInferredPortConfirmsOnlyOnce(t *testing.T) {
+	shortWindows(t)
+	p := testProxy(t)
+	p.deriveMysqlPorts([]*models.Mock{
+		{Kind: models.MySQL, Spec: models.MockSpec{Metadata: map[string]string{"destAddr": "127.0.0.1:3306"}}},
+	})
+
+	var elapsed []time.Duration
+	for i := 0; i < 2; i++ {
+		_, srcConn := clientPair(t)
+		start := time.Now()
+		probe, err := p.probeMysql(context.Background(), srcConn, "172.20.0.2:283", 283,
+			models.MODE_TEST, models.OutgoingOptions{}, zap.NewNop())
+		elapsed = append(elapsed, time.Since(start))
+		if err != nil || !probe.IsMySQL {
+			t.Fatalf("probe %d: err=%v IsMySQL=%v reason=%q", i, err, probe.IsMySQL, probe.Reason)
+		}
+	}
+	if elapsed[1] >= serverGreetingWindow() {
+		t.Errorf("second connection paid the confirmation window again (%v); it must only re-run the silence check", elapsed[1])
+	}
+	if elapsed[1] < clientSilenceWindow() {
+		t.Errorf("second connection skipped the silence check (%v): a client that speaks first would be hijacked", elapsed[1])
+	}
+}
+
+// The escape hatch has to work without also turning off record-time detection,
+// which is what disableMysqlAutoDetect would cost.
+func TestEndpointDriftCanBeDisabled(t *testing.T) {
+	shortWindows(t)
+	p := testProxy(t)
+	p.deriveMysqlPorts([]*models.Mock{
+		{Kind: models.MySQL, Spec: models.MockSpec{Metadata: map[string]string{"destAddr": "127.0.0.1:3306"}}},
+	})
+
+	_, srcConn := clientPair(t)
+	probe, err := p.probeMysql(context.Background(), srcConn, "172.20.0.2:283", 283,
+		models.MODE_TEST, models.OutgoingOptions{DisableMysqlEndpointDrift: true}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if probe.IsMySQL {
+		t.Fatalf("IsMySQL=true reason=%q: the inference was disabled", probe.Reason)
+	}
+	if probe.Reason != "no-mysql-mock-for-port" {
+		t.Errorf("reason = %q, want no-mysql-mock-for-port", probe.Reason)
+	}
+}
+
+// A cancelled run must not sit through the confirmation window on every silent
+// connection still in flight — the wait is several times the silence window,
+// and a read deadline is not cancellable on its own.
+func TestProbeUnblocksOnContextCancel(t *testing.T) {
+	shortWindows(t)
+	p := testProxy(t)
+	p.deriveMysqlPorts([]*models.Mock{
+		{Kind: models.MySQL, Spec: models.MockSpec{Metadata: map[string]string{"destAddr": "127.0.0.1:3306"}}},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(clientSilenceWindow() + 50*time.Millisecond)
+		cancel()
+	}()
+
+	_, srcConn := clientPair(t)
+	start := time.Now()
+	probe, err := p.probeMysql(ctx, srcConn, "172.20.0.2:283", 283,
+		models.MODE_TEST, models.OutgoingOptions{}, zap.NewNop())
+	took := time.Since(start)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if took >= clientSilenceWindow()+serverGreetingWindow() {
+		t.Errorf("probe ignored cancellation and waited the whole window (%v)", took)
+	}
+	if probe.IsMySQL {
+		t.Errorf("IsMySQL=true reason=%q: a cancelled probe must not produce a positive verdict", probe.Reason)
+	}
+}
+
+// A replay session must be judged on its OWN recording. The agent is one
+// long-lived process and the registry is allocated once, so without a per
+// session reset the drift gate would mean "any recording this process has ever
+// replayed": a test set holding MySQL mocks would arm the inference for a later
+// test set holding none, and a silent connection there would be routed to a
+// replayer with nothing to serve.
+func TestDriftGateIsScopedToTheCurrentRecording(t *testing.T) {
+	shortWindows(t)
+	p := testProxy(t)
+
+	// Session 1: a recording that does contain MySQL.
+	p.deriveMysqlPorts([]*models.Mock{
+		{Kind: models.MySQL, Spec: models.MockSpec{Metadata: map[string]string{"destAddr": "127.0.0.1:3306"}}},
+	})
+	if len(p.mysqlPorts.MockPorts()) != 1 {
+		t.Fatalf("session 1 should have derived one port, got %v", p.mysqlPorts.MockPorts())
+	}
+
+	// Session 2: a different app, whose recording contains no MySQL at all.
+	// Driving this through SetMocks rather than calling ResetSession() directly
+	// is the point — it pins that the reset is wired into the call the replayer
+	// actually makes for each test set.
+	if err := p.SetMocks(context.Background(),
+		[]*models.Mock{{Kind: models.HTTP, Spec: models.MockSpec{Metadata: map[string]string{"destAddr": "127.0.0.1:8080"}}}},
+		nil); err != nil {
+		t.Fatalf("SetMocks: %v", err)
+	}
+	if got := p.mysqlPorts.MockPorts(); len(got) != 0 {
+		t.Fatalf("session 1's mock-derived ports survived into session 2: %v", got)
+	}
+
+	_, srcConn := clientPair(t)
+	probe, err := p.probeMysql(context.Background(), srcConn, "10.0.0.9:5671", 5671,
+		models.MODE_TEST, models.OutgoingOptions{}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if probe.IsMySQL {
+		t.Fatalf("IsMySQL=true reason=%q: this recording has no MySQL mocks to serve", probe.Reason)
+	}
+}
+
+// The confirmation shortcut is keyed by endpoint, not by port number. Two
+// unrelated services routinely share a port, and one inference must not lower
+// the bar for the other — the shortcut skips the long wait, so a client that is
+// merely slow would be answered with a handshake it never asked for.
+func TestInferredShortcutIsPerEndpoint(t *testing.T) {
+	shortWindows(t)
+	p := testProxy(t)
+	p.deriveMysqlPorts([]*models.Mock{
+		{Kind: models.MySQL, Spec: models.MockSpec{Metadata: map[string]string{"destAddr": "127.0.0.1:3306"}}},
+	})
+
+	// First endpoint: silent client, inferred.
+	_, silent := clientPair(t)
+	first, err := p.probeMysql(context.Background(), silent, "172.20.0.2:283", 283,
+		models.MODE_TEST, models.OutgoingOptions{}, zap.NewNop())
+	if err != nil || !first.IsMySQL {
+		t.Fatalf("first probe: err=%v IsMySQL=%v reason=%q", err, first.IsMySQL, first.Reason)
+	}
+
+	// A different host on the same port, speaking after the silence window but
+	// well inside the confirmation window the first endpoint had to pass.
+	client, srcConn := clientPair(t)
+	go func() {
+		time.Sleep(clientSilenceWindow() * 3)
+		_, _ = client.Write([]byte{0x16, 0x03, 0x01, 0x00, 0x2f})
+	}()
+	second, err := p.probeMysql(context.Background(), srcConn, "10.9.9.9:283", 283,
+		models.MODE_TEST, models.OutgoingOptions{}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("second probe: %v", err)
+	}
+	if second.IsMySQL {
+		t.Fatalf("IsMySQL=true reason=%q: a different host on the same port inherited the shortcut", second.Reason)
+	}
+}
+
+// readWithin must not leave a deadline in the past on a connection it hands
+// back. context.AfterFunc reports that its function has started without waiting
+// for it, and that function runs on its own goroutine — so a cancelled probe
+// can land SetReadDeadline(now) after the reset and break the next read for
+// whoever gets the connection, surfacing as "i/o timeout" with data waiting.
+func TestReadWithinLeavesNoDeadlineBehind(t *testing.T) {
+	for i := 0; i < 200; i++ {
+		client, srcConn := clientPair(t)
+		if _, err := client.Write([]byte{0x42}); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // already cancelled: AfterFunc fires immediately
+		_, _ = readWithin(ctx, srcConn, time.Second)
+
+		if _, err := client.Write([]byte{0x43}); err != nil {
+			t.Fatalf("write 2: %v", err)
+		}
+		buf := make([]byte, 8)
+		if err := srcConn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+			t.Fatalf("set deadline: %v", err)
+		}
+		if _, err := srcConn.Read(buf); err != nil {
+			t.Fatalf("iteration %d: a later read failed on a connection readWithin handed back: %v", i, err)
+		}
+		_ = srcConn.Close()
+		_ = client.Close()
+	}
+}

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -3233,6 +3233,22 @@ func (p *Proxy) LoadAsyncMocks(mocks []*models.Mock) {
 }
 
 func (p *Proxy) SetMocks(_ context.Context, filtered []*models.Mock, unFiltered []*models.Mock) error {
+	// Forget the previous recording's MySQL ports before deriving this one's.
+	// The agent is a single long-lived process and this registry is allocated
+	// once, so without the reset the port set — and the endpoint-drift
+	// inference it arms — would mean "any recording this process has ever
+	// replayed" rather than "the recording being replayed now": a test set
+	// holding MySQL mocks would arm the inference for a later one holding
+	// none, and a silent connection there would be routed to a replayer with
+	// nothing to serve.
+	//
+	// This is the right hook rather than Mock(): RunTestSet has one branch that
+	// calls StoreMocks (→ here) BEFORE MockOutgoing (→ Mock), so resetting
+	// there would discard the ports this very test set had just derived. It is
+	// also not SetMocksWithWindow, which arrives repeatedly with a per-test
+	// SUBSET — resetting on those would drop ports mid-run.
+	p.mysqlPorts.ResetSession()
+
 	// Replay cannot detect MySQL from content — no upstream exists to
 	// send a handshake — so the port set is recovered here, from the
 	// destAddr every MySQL mock records. Must happen before the mocks

--- a/pkg/models/instrument.go
+++ b/pkg/models/instrument.go
@@ -129,6 +129,11 @@ type OutgoingOptions struct {
 	// identified from its handshake at record time and recalled from
 	// the recorded mocks' destAddr at replay time.
 	DisableMysqlAutoDetect bool
+	// DisableMysqlEndpointDrift stops replay from serving recorded MySQL
+	// mocks on a port the recording never saw. Detection still runs; only the
+	// inference that covers a moved endpoint is turned off. See
+	// Config.DisableMysqlEndpointDrift.
+	DisableMysqlEndpointDrift bool
 	// SupportsDroppedRevoke is a capability flag set by the CLI on the
 	// /outgoing request: when true, the CLI understands the reserved
 	// Kind=RevokedTests control frame (it diverts it into a revoke set and

--- a/pkg/service/mock/mock.go
+++ b/pkg/service/mock/mock.go
@@ -77,10 +77,11 @@ func (r *MockLoader) LoadMocks(ctx context.Context, testSetID string, testCaseNa
 		// Same MySQL routing knobs the record/replay paths pass. Without
 		// them a MockLoader session ignores mysqlPorts entirely and
 		// honours neither the pinned ports nor disableMysqlAutoDetect.
-		MysqlPorts:             r.outgoingCfg.MysqlPorts,
-		DisableMysqlAutoDetect: r.outgoingCfg.DisableMysqlAutoDetect,
-		PassThroughPorts:       r.outgoingCfg.PassThroughPorts,
-		PassThroughHosts:       r.outgoingCfg.PassThroughHosts,
+		MysqlPorts:                r.outgoingCfg.MysqlPorts,
+		DisableMysqlAutoDetect:    r.outgoingCfg.DisableMysqlAutoDetect,
+		DisableMysqlEndpointDrift: r.outgoingCfg.DisableMysqlEndpointDrift,
+		PassThroughPorts:          r.outgoingCfg.PassThroughPorts,
+		PassThroughHosts:          r.outgoingCfg.PassThroughHosts,
 	}); err != nil {
 		return fmt.Errorf("MockLoader: failed to enable mock-outgoing: %w", err)
 	}

--- a/pkg/service/mock/service.go
+++ b/pkg/service/mock/service.go
@@ -82,6 +82,8 @@ type OutgoingConfig struct {
 	// restoring strict MysqlPorts matching. Mirrors
 	// Config.DisableMysqlAutoDetect.
 	DisableMysqlAutoDetect bool
+	// DisableMysqlEndpointDrift mirrors Config.DisableMysqlEndpointDrift.
+	DisableMysqlEndpointDrift bool
 
 	// PassThroughPorts / PassThroughHosts mirror Config.Record.PassThroughPorts /
 	// PassThroughHosts so a standalone mock-serving session honours the same

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -1467,11 +1467,12 @@ func (r *Recorder) GetTestAndMockChans(ctx context.Context) (FrameChan, error) {
 		// record.upstreamTls.caCert on its own filesystem — the path precedence
 		// at proxy.New, the pool itself lazily on the first record session —
 		// and stamps it onto these options in Proxy.Record.
-		UpstreamTLSVerify:      r.config.Record.UpstreamTLS.Verify,
-		MysqlPorts:             r.config.MysqlPorts,
-		DisableMysqlAutoDetect: r.config.DisableMysqlAutoDetect,
-		PassThroughPorts:       r.config.Record.PassThroughPorts,
-		PassThroughHosts:       r.config.Record.PassThroughHosts,
+		UpstreamTLSVerify:         r.config.Record.UpstreamTLS.Verify,
+		MysqlPorts:                r.config.MysqlPorts,
+		DisableMysqlAutoDetect:    r.config.DisableMysqlAutoDetect,
+		DisableMysqlEndpointDrift: r.config.DisableMysqlEndpointDrift,
+		PassThroughPorts:          r.config.Record.PassThroughPorts,
+		PassThroughHosts:          r.config.Record.PassThroughHosts,
 		// Advertise that this CLI understands the reserved Kind=RevokedTests
 		// control frame: it diverts such a frame into a revoke set and deletes
 		// those deferred-orphan test cases at finalize instead of persisting it

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1236,19 +1236,20 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		}
 
 		err = r.instrumentation.MockOutgoing(runTestSetCtx, models.OutgoingOptions{
-			Rules:                  r.config.BypassRules,
-			MongoPassword:          r.config.Test.MongoPassword,
-			SQLDelay:               time.Duration(r.config.Test.Delay) * time.Second,
-			Mocking:                r.config.Test.Mocking,
-			Backdate:               testCases[0].HTTPReq.Timestamp,
-			NoiseConfig:            mockNoiseConfig,
-			DisableAutoHeaderNoise: r.config.Test.DisableAutoHeaderNoise,
-			SchemaNoiseDetection:   r.config.Test.SchemaNoiseDetection,
-			SchemaNoiseStrict:      r.config.Test.SchemaNoiseStrict,
-			MysqlPorts:             r.config.MysqlPorts,
-			DisableMysqlAutoDetect: r.config.DisableMysqlAutoDetect,
-			PassThroughPorts:       r.config.Record.PassThroughPorts,
-			PassThroughHosts:       r.config.Record.PassThroughHosts,
+			Rules:                     r.config.BypassRules,
+			MongoPassword:             r.config.Test.MongoPassword,
+			SQLDelay:                  time.Duration(r.config.Test.Delay) * time.Second,
+			Mocking:                   r.config.Test.Mocking,
+			Backdate:                  testCases[0].HTTPReq.Timestamp,
+			NoiseConfig:               mockNoiseConfig,
+			DisableAutoHeaderNoise:    r.config.Test.DisableAutoHeaderNoise,
+			SchemaNoiseDetection:      r.config.Test.SchemaNoiseDetection,
+			SchemaNoiseStrict:         r.config.Test.SchemaNoiseStrict,
+			MysqlPorts:                r.config.MysqlPorts,
+			DisableMysqlAutoDetect:    r.config.DisableMysqlAutoDetect,
+			DisableMysqlEndpointDrift: r.config.DisableMysqlEndpointDrift,
+			PassThroughPorts:          r.config.Record.PassThroughPorts,
+			PassThroughHosts:          r.config.Record.PassThroughHosts,
 		})
 		if err != nil {
 			if ctx.Err() != context.Canceled {
@@ -1439,19 +1440,20 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		}
 
 		err = r.instrumentation.MockOutgoing(runTestSetCtx, models.OutgoingOptions{
-			Rules:                  r.config.BypassRules,
-			MongoPassword:          r.config.Test.MongoPassword,
-			SQLDelay:               time.Duration(r.config.Test.Delay) * time.Second,
-			Mocking:                r.config.Test.Mocking,
-			Backdate:               testCases[0].HTTPReq.Timestamp,
-			NoiseConfig:            mockNoiseConfig,
-			DisableAutoHeaderNoise: r.config.Test.DisableAutoHeaderNoise,
-			SchemaNoiseDetection:   r.config.Test.SchemaNoiseDetection,
-			SchemaNoiseStrict:      r.config.Test.SchemaNoiseStrict,
-			MysqlPorts:             r.config.MysqlPorts,
-			DisableMysqlAutoDetect: r.config.DisableMysqlAutoDetect,
-			PassThroughPorts:       r.config.Record.PassThroughPorts,
-			PassThroughHosts:       r.config.Record.PassThroughHosts,
+			Rules:                     r.config.BypassRules,
+			MongoPassword:             r.config.Test.MongoPassword,
+			SQLDelay:                  time.Duration(r.config.Test.Delay) * time.Second,
+			Mocking:                   r.config.Test.Mocking,
+			Backdate:                  testCases[0].HTTPReq.Timestamp,
+			NoiseConfig:               mockNoiseConfig,
+			DisableAutoHeaderNoise:    r.config.Test.DisableAutoHeaderNoise,
+			SchemaNoiseDetection:      r.config.Test.SchemaNoiseDetection,
+			SchemaNoiseStrict:         r.config.Test.SchemaNoiseStrict,
+			MysqlPorts:                r.config.MysqlPorts,
+			DisableMysqlAutoDetect:    r.config.DisableMysqlAutoDetect,
+			DisableMysqlEndpointDrift: r.config.DisableMysqlEndpointDrift,
+			PassThroughPorts:          r.config.Record.PassThroughPorts,
+			PassThroughHosts:          r.config.Record.PassThroughHosts,
 		})
 		if err != nil {
 			if ctx.Err() != context.Canceled {

--- a/pkg/service/runner/runner.go
+++ b/pkg/service/runner/runner.go
@@ -384,6 +384,7 @@ func (r *Runner) setupTestSet(parentCtx context.Context, testSetID string, backd
 		outOpts.SchemaNoiseStrict = r.config.Test.SchemaNoiseStrict
 		outOpts.MysqlPorts = r.config.MysqlPorts
 		outOpts.DisableMysqlAutoDetect = r.config.DisableMysqlAutoDetect
+		outOpts.DisableMysqlEndpointDrift = r.config.DisableMysqlEndpointDrift
 		outOpts.PassThroughPorts = r.config.Record.PassThroughPorts
 		outOpts.PassThroughHosts = r.config.Record.PassThroughHosts
 		// Validate modes at load: NormalizeMode fails an unknown/typo'd mode CLOSED


### PR DESCRIPTION
## What goes wrong today

MySQL is server-speaks-first, so keploy identifies it by the client opening a connection and then saying nothing. #4389 gave record mode content detection, and gave replay a port-equality test against the ports derived from the recorded mocks' `destAddr` — on an assumption stated in that PR:

> Matching is by port, not host:port — container IPs change between record and replay, **ports don't**.

They do. Any environment rebuilt rather than reused — a compose file generated from a stored manifest, a pooler present on one side only, a per-environment port — hands the application a different endpoint than the recording saw.

A customer debug bundle shows the consequence, 103 times in a row:

```
DEBUG  client silent past the probe window; treating as server-speaks-first  {"dstAddr":"172.20.0.2:283","port":283,"window":"250ms"}
DEBUG  mysql probe result  {"isMySQL": false, "reason": "no-mysql-mock-for-port", "destPort": 283}
```

**Detection fired, correctly, and was then discarded.** Declining is not neutral here: in replay keploy *is* the server, so nothing else will ever send that greeting. The app blocked until its own timeout, 20 of 27 tests reported `status_code: 0`, and all 515 recorded MySQL mocks went unused — while the recording itself was perfectly good. Nothing in the output says any of this; it reads as a broken application.

## The change

When the port is unknown but the recording *does* contain MySQL mocks, take the client's silence as the evidence it already is.

- **Confirm first.** A slow TLS client can be quiet for the short window and only then send its ClientHello; answering that with a `HandshakeV10` breaks a connection that was working. A real MySQL client sends nothing at all until it is greeted, so a second, longer wait separates the two.
- **An inference never becomes a property of the port.** `Has()` still reports false, so every connection re-earns the verdict through the silence check and a client that speaks first is rejected exactly as before. What the endpoint records is that the long confirmation is already paid, so a pool reopening connections does not re-pay it — 103 times, in the bundle above. Keyed by `host:port`, so a different service sharing a port number does not inherit the shortcut.
- **The gate is the mock-derived ports**, not every port the registry knows. The agent is one long-lived process, so a port learned by probing during a *record* session would otherwise arm this during an unrelated replay. For the same reason the derived set is reset per test set — in `SetMocks`, not `Mock()`, because one branch of `RunTestSet` calls `StoreMocks` *before* `MockOutgoing` and resetting there would discard the ports that test set had just derived.
- **`disableMysqlEndpointDrift`** turns the inference off while keeping #4389's record-time detection, which `disableMysqlAutoDetect` would also throw away.
- **`readWithin` takes a context.** The confirmation wait is several times the silence window and a read deadline is not cancellable on its own, so an aborted run would otherwise sit through it on every silent connection still in flight.

## Testing

The `mysql_auto_port` e2e gains a second phase: replay again with the application pointed at a port nothing has ever seen (`:3399`) while the mocks still name the recorded one (`:3307`), and require the same tests to pass.

Run locally against a real MySQL and a real Spring Boot app:

- **With this change** — both phases pass, and the warning reports `{"port": 3399, "dstAddr": "[127.0.0.1]:3399", "recordedPorts": [3307]}`.
- **Against a binary built without it** — the phase fails exactly as the customer's bundle does: `Communications link failure`, HikariCP pool initialisation dead, the app never finishes starting, no report written.

The phase distinguishes its two failure modes rather than reporting one for both: if the property override silently stops taking effect the app is still talking to the recorded port, so every test passes and the warning is absent — which is reported as "this phase exercised nothing", not as a regression.

Every piece of the change is mutation-tested: reverting it in isolation fails a named unit test. Covered are the mock-derived gate, the per-session reset, the confirmation shortcut and its per-endpoint keying, the opt-out, context cancellation, the late-speaker rejection, and the record-mode isolation. The package is clean under `-race`, and the timing-sensitive tests hold over repeated runs pinned to a single CPU.

## Note on scope

This does not change record mode, and it does not change replay for any port the recording already names — those still take the existing recall path on the first check.