### PR TITLE
fix(proxy): run the MySQL per-recording reset on the path a stock agent takes

### DIFF
--- a/pkg/agent/proxy/mysql_detect.go
+++ b/pkg/agent/proxy/mysql_detect.go
@@ -314,6 +314,13 @@ func (r *mysqlPortRegistry) IsInferred(dstAddr string) bool {
 // its original close-once semantics.
 //
 // Ports learned by probing a live server during a record session are never
+// dropped: those are facts about a real server, not about a recording.
+func (r *mysqlPortRegistry) MarkSessionStale() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sessionStale = true
+}
+
 // MockPorts returns the ports that came from a recording, as opposed to ones
 // learned by probing during a record session.
 func (r *mysqlPortRegistry) MockPorts() []uint32 {
@@ -341,13 +348,7 @@ func (r *mysqlPortRegistry) Ports() []uint32 {
 // destAddr metadata and marks derivation complete, releasing any
 // replay connections parked in WaitDerived. It is safe to call
 // repeatedly (once per test-set); later calls union additional ports
-// and are no-ops for the completion signal.// dropped: those are facts about a real server, not about a recording.
-func (r *mysqlPortRegistry) MarkSessionStale() {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.sessionStale = true
-}
-
+// and are no-ops for the completion signal.
 func (r *mysqlPortRegistry) DeriveFromMocks(mockSets ...[]*models.Mock) []uint32 {
 	var added []uint32
 

--- a/pkg/agent/proxy/mysql_detect.go
+++ b/pkg/agent/proxy/mysql_detect.go
@@ -188,7 +188,11 @@ type mysqlPortRegistry struct {
 	// mocks at all, and the connection would be routed to a replayer with
 	// nothing to serve.
 	fromMocks map[uint32]struct{}
-	derived   bool
+	// sessionStale is set when a new replay session begins and consumed by the
+	// next DeriveFromMocks. See MarkSessionStale for why the swap is deferred
+	// to derive time rather than done eagerly.
+	sessionStale bool
+	derived      bool
 	// derivedCh is closed the first time DeriveFromMocks runs, so a
 	// replay connection that arrives before mocks are stored can block
 	// on it instead of guessing. Never closed twice (guarded by mu +
@@ -279,31 +283,37 @@ func (r *mysqlPortRegistry) IsInferred(dstAddr string) bool {
 	return ok
 }
 
-// ResetSession forgets everything learned from a recording: the ports derived
-// from mocks and the endpoints inferred while serving them. The agent is one
-// long-lived process and this registry is allocated once, so without this the
-// gate on the drift inference would mean "any recording this process has ever
-// replayed" rather than "the recording being replayed now" — a test set holding
-// MySQL mocks would arm the inference for a later one that holds none, and a
-// silent connection there would be routed to a replayer with nothing to serve.
+// MarkSessionStale says that the recording in force is about to be replaced, so
+// the next set of mocks should supersede rather than accumulate. The agent is a
+// single long-lived process and this registry is allocated once, so without it
+// the gate on the drift inference would mean "any recording this process has
+// ever replayed" rather than "the recording being replayed now" — a test set
+// holding MySQL mocks would arm the inference for a later one that holds none,
+// and a silent connection there would be routed to a replayer with nothing to
+// serve.
 //
-// Ports learned by probing a live server during a record session are kept:
-// those are facts about a real server, not about a recording.
-func (r *mysqlPortRegistry) ResetSession() {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	for port := range r.fromMocks {
-		delete(r.ports, port)
-	}
-	r.fromMocks = make(map[uint32]struct{})
-	r.inferred = make(map[string]struct{})
-	// Re-arm the derivation gate so a connection arriving before this
-	// session's mocks are stored parks instead of being decided against the
-	// previous session's port set.
-	r.derived = false
-	r.derivedCh = make(chan struct{})
-}
-
+// It only marks. The actual swap happens in DeriveFromMocks, when the
+// replacement is in hand, and that ordering is the whole point:
+//
+//   - Clearing here instead would blind the registry for the entire gap between
+//     Mock() and this test set's first mock delivery — which spans reading the
+//     whole recorded corpus off disk and shipping it to the agent. A connection
+//     opened in that gap loses the known-port fast path and parks in
+//     WaitDerived. That gap is real traffic: a reused compose stack or
+//     --keep-app-alive holds the application and its connection pool open
+//     across test-set boundaries, and a pool reconnecting there would stall.
+//   - Clearing here would also have to re-arm derivedCh, and replacing that
+//     channel strands anyone already parked on the old one: DeriveFromMocks
+//     closes the NEW channel, so the old waiter sleeps out the full derive
+//     deadline and is then told the mocks never arrived — which is precisely
+//     the "connection gets no MySQL and the test reports status_code 0"
+//     failure this whole mechanism exists to prevent.
+//
+// Swapping at derive time avoids both: the previous recording's ports stay
+// usable right up to the instant the new ones replace them, and derivedCh keeps
+// its original close-once semantics.
+//
+// Ports learned by probing a live server during a record session are never
 // MockPorts returns the ports that came from a recording, as opposed to ones
 // learned by probing during a record session.
 func (r *mysqlPortRegistry) MockPorts() []uint32 {
@@ -331,11 +341,27 @@ func (r *mysqlPortRegistry) Ports() []uint32 {
 // destAddr metadata and marks derivation complete, releasing any
 // replay connections parked in WaitDerived. It is safe to call
 // repeatedly (once per test-set); later calls union additional ports
-// and are no-ops for the completion signal.
+// and are no-ops for the completion signal.// dropped: those are facts about a real server, not about a recording.
+func (r *mysqlPortRegistry) MarkSessionStale() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sessionStale = true
+}
+
 func (r *mysqlPortRegistry) DeriveFromMocks(mockSets ...[]*models.Mock) []uint32 {
 	var added []uint32
 
 	r.mu.Lock()
+	// Consume the stale mark: this delivery is the replacement, so drop what the
+	// previous recording taught us before unioning in what this one does.
+	if r.sessionStale {
+		for port := range r.fromMocks {
+			delete(r.ports, port)
+		}
+		r.fromMocks = make(map[uint32]struct{})
+		r.inferred = make(map[string]struct{})
+		r.sessionStale = false
+	}
 	for _, mocks := range mockSets {
 		for _, m := range mocks {
 			if m == nil || m.Kind != models.MySQL {

--- a/pkg/agent/proxy/mysql_detect_test.go
+++ b/pkg/agent/proxy/mysql_detect_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"go.keploy.io/server/v3/pkg/agent"
 	"go.keploy.io/server/v3/pkg/agent/proxy/integrations"
 	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql"
 	"go.keploy.io/server/v3/pkg/models"
@@ -33,6 +34,16 @@ func testProxy(t *testing.T) *Proxy {
 	return &Proxy{
 		logger:     zap.NewNop(),
 		mysqlPorts: newMysqlPortRegistry(),
+		// Built the way proxy.New does, so tests can drive SetMocksWithWindow —
+		// the call a stock agent actually makes to publish a test set's mocks.
+		dnsCache: newDNSCache(),
+		// Preseeded so Mock() skips setupNsswitchConfig, which rewrites
+		// /etc/nsswitch.conf and only restores it on proxy shutdown — a unit
+		// test never shuts the proxy down, so as root this would permanently
+		// replace the host's DNS configuration, and as non-root it would fail
+		// the write and abort Mock() early. Either way the test's verdict would
+		// depend on privileges rather than on the code under test.
+		nsswitchData: []byte("preseeded-by-test"),
 		Integrations: map[integrations.IntegrationType]integrations.Integrations{
 			integrations.MYSQL: mysql.New(zap.NewNop()),
 		},
@@ -862,6 +873,13 @@ func TestProbeUnblocksOnContextCancel(t *testing.T) {
 // replayed": a test set holding MySQL mocks would arm the inference for a later
 // test set holding none, and a silent connection there would be routed to a
 // replayer with nothing to serve.
+//
+// Session 2 publishes its mocks through SetMocksWithWindow because that is the
+// call a stock agent makes — Agent.UpdateMockParams takes the WindowedProxy arm
+// and *Proxy implements it, so the SetMocks arm exists only for a third-party
+// proxy that does not. An earlier version of this test drove SetMocks and was
+// green while the production path leaked; TestProxyTakesTheWindowedMocksPath
+// below keeps that mistake from being made again.
 func TestDriftGateIsScopedToTheCurrentRecording(t *testing.T) {
 	shortWindows(t)
 	p := testProxy(t)
@@ -874,14 +892,23 @@ func TestDriftGateIsScopedToTheCurrentRecording(t *testing.T) {
 		t.Fatalf("session 1 should have derived one port, got %v", p.mysqlPorts.MockPorts())
 	}
 
-	// Session 2: a different app, whose recording contains no MySQL at all.
-	// Driving this through SetMocks rather than calling ResetSession() directly
-	// is the point — it pins that the reset is wired into the call the replayer
-	// actually makes for each test set.
-	if err := p.SetMocks(context.Background(),
+	// Session 2 begins. Going through Mock() rather than calling the registry
+	// directly is the point: it pins that the per-test-set entry point the
+	// replayer actually reaches is the one wired up.
+	if err := p.Mock(context.Background(), models.OutgoingOptions{}); err != nil {
+		t.Fatalf("Mock: %v", err)
+	}
+	// The previous recording's ports are still usable here, on purpose: the
+	// swap waits for the replacement so a pool reconnecting during the gap
+	// between Mock() and the first mock delivery keeps its fast path.
+	if got := p.mysqlPorts.MockPorts(); len(got) != 1 {
+		t.Fatalf("ports were dropped before the replacement arrived, leaving a blind window: %v", got)
+	}
+	// Now session 2's recording arrives, and it contains no MySQL at all.
+	if err := p.SetMocksWithWindow(context.Background(),
 		[]*models.Mock{{Kind: models.HTTP, Spec: models.MockSpec{Metadata: map[string]string{"destAddr": "127.0.0.1:8080"}}}},
-		nil); err != nil {
-		t.Fatalf("SetMocks: %v", err)
+		nil, time.Time{}, time.Time{}); err != nil {
+		t.Fatalf("SetMocksWithWindow: %v", err)
 	}
 	if got := p.mysqlPorts.MockPorts(); len(got) != 0 {
 		t.Fatalf("session 1's mock-derived ports survived into session 2: %v", got)
@@ -895,6 +922,19 @@ func TestDriftGateIsScopedToTheCurrentRecording(t *testing.T) {
 	}
 	if probe.IsMySQL {
 		t.Fatalf("IsMySQL=true reason=%q: this recording has no MySQL mocks to serve", probe.Reason)
+	}
+}
+
+// The reset above is only worth anything on the code path a real agent takes.
+// Agent.UpdateMockParams publishes mocks through SetMocksWithWindow when the
+// proxy implements WindowedProxy and through SetMocks when it does not, so if
+// this proxy ever stopped implementing it, every per-test-set guarantee in this
+// file would quietly move to a branch nothing exercises.
+func TestProxyTakesTheWindowedMocksPath(t *testing.T) {
+	var p interface{} = &Proxy{}
+	if _, ok := p.(agent.WindowedProxy); !ok {
+		t.Fatal("*Proxy no longer implements WindowedProxy: a stock agent would fall back to SetMocks, " +
+			"and any per-test-set reset wired into Mock() would need revisiting")
 	}
 }
 
@@ -962,5 +1002,62 @@ func TestReadWithinLeavesNoDeadlineBehind(t *testing.T) {
 		}
 		_ = srcConn.Close()
 		_ = client.Close()
+	}
+}
+
+// The session swap has to clear the inferred endpoints too, not just the ports.
+// An inference is evidence about the previous recording's environment; carrying
+// it into the next test set would let one connection's guess shorten the
+// confirmation for an endpoint the new recording never mentioned.
+func TestSessionSwapClearsInferredEndpoints(t *testing.T) {
+	shortWindows(t)
+	p := testProxy(t)
+	p.deriveMysqlPorts([]*models.Mock{
+		{Kind: models.MySQL, Spec: models.MockSpec{Metadata: map[string]string{"destAddr": "127.0.0.1:3306"}}},
+	})
+
+	_, silent := clientPair(t)
+	if probe, err := p.probeMysql(context.Background(), silent, "172.20.0.2:283", 283,
+		models.MODE_TEST, models.OutgoingOptions{}, zap.NewNop()); err != nil || !probe.IsMySQL {
+		t.Fatalf("setup probe: err=%v IsMySQL=%v", err, probe.IsMySQL)
+	}
+	if !p.mysqlPorts.IsInferred("172.20.0.2:283") {
+		t.Fatal("setup: endpoint should have been recorded as inferred")
+	}
+
+	p.mysqlPorts.MarkSessionStale()
+	p.deriveMysqlPorts([]*models.Mock{
+		{Kind: models.MySQL, Spec: models.MockSpec{Metadata: map[string]string{"destAddr": "127.0.0.1:3306"}}},
+	})
+	if p.mysqlPorts.IsInferred("172.20.0.2:283") {
+		t.Error("an inference from the previous recording survived the session swap")
+	}
+}
+
+// Deferring the swap to derive time is what keeps derivedCh close-once. If a
+// future change re-armed it at the boundary instead, a connection already
+// parked in WaitDerived would be left on the orphaned channel: the derive
+// closes the replacement, the waiter sleeps out the whole deadline and is then
+// told the mocks never arrived — the connection gets no MySQL and the test
+// reports status_code 0, which is the failure this mechanism exists to prevent.
+func TestSessionSwapDoesNotStrandDerivedWaiters(t *testing.T) {
+	p := testProxy(t)
+
+	parked := make(chan bool, 1)
+	go func() { parked <- p.mysqlPorts.WaitDerived(context.Background(), 5*time.Second) }()
+	time.Sleep(50 * time.Millisecond) // let it park on the current channel
+
+	p.mysqlPorts.MarkSessionStale()
+	p.deriveMysqlPorts([]*models.Mock{
+		{Kind: models.MySQL, Spec: models.MockSpec{Metadata: map[string]string{"destAddr": "127.0.0.1:3306"}}},
+	})
+
+	select {
+	case ok := <-parked:
+		if !ok {
+			t.Fatal("waiter woke reporting the mocks never derived")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiter stranded across the session boundary: it is still parked on a channel nothing will close")
 	}
 }

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -3152,6 +3152,26 @@ func (p *Proxy) Record(ctx context.Context, mocks chan<- *models.Mock, opts mode
 func (p *Proxy) Mock(_ context.Context, opts models.OutgoingOptions) error {
 	// Reset graceful shutdown flag for a new mocking session.
 	p.isGracefulShutdown.Store(false)
+	// Forget the previous recording's MySQL ports before this test set derives
+	// its own. The agent is a single long-lived process and this registry is
+	// allocated once, so without the reset the derived port set — and the
+	// endpoint-drift inference it arms — would mean "any recording this process
+	// has ever replayed" rather than "the recording being replayed now": a test
+	// set holding MySQL mocks would arm the inference for a later one holding
+	// none, and a silent connection there would be routed to a replayer with
+	// nothing to serve.
+	//
+	// Mock() is the hook because it is what the replayer reaches once per test
+	// set (Agent.MockOutgoing → here), and it runs before that set's first
+	// UpdateMockParams → SetMocksWithWindow delivers any mocks. SetMocks is NOT
+	// a candidate despite appearances: it is only the fallback arm for a
+	// third-party proxy that does not implement WindowedProxy, and this proxy
+	// does, so a stock agent never calls it. SetMocksWithWindow is not one
+	// either — it arrives repeatedly with a per-test SUBSET.
+	//
+	// This only marks; the swap happens when the replacement mocks arrive, so
+	// the boundary leaves no window in which known ports are forgotten.
+	p.mysqlPorts.MarkSessionStale()
 	// Mock is replay; no pcap capture during replay. Tear down any
 	// capture left over from a previous record session.
 	p.stopPacketCapture()
@@ -3233,22 +3253,6 @@ func (p *Proxy) LoadAsyncMocks(mocks []*models.Mock) {
 }
 
 func (p *Proxy) SetMocks(_ context.Context, filtered []*models.Mock, unFiltered []*models.Mock) error {
-	// Forget the previous recording's MySQL ports before deriving this one's.
-	// The agent is a single long-lived process and this registry is allocated
-	// once, so without the reset the port set — and the endpoint-drift
-	// inference it arms — would mean "any recording this process has ever
-	// replayed" rather than "the recording being replayed now": a test set
-	// holding MySQL mocks would arm the inference for a later one holding
-	// none, and a silent connection there would be routed to a replayer with
-	// nothing to serve.
-	//
-	// This is the right hook rather than Mock(): RunTestSet has one branch that
-	// calls StoreMocks (→ here) BEFORE MockOutgoing (→ Mock), so resetting
-	// there would discard the ports this very test set had just derived. It is
-	// also not SetMocksWithWindow, which arrives repeatedly with a per-test
-	// SUBSET — resetting on those would drop ports mid-run.
-	p.mysqlPorts.ResetSession()
-
 	// Replay cannot detect MySQL from content — no upstream exists to
 	// send a handshake — so the port set is recovered here, from the
 	// destAddr every MySQL mock records. Must happen before the mocks


### PR DESCRIPTION
Follow-up to #4442. The per-recording reset it added never runs.

## The defect

#4442 scoped the endpoint-drift inference to "the recording being replayed now" by calling `mysqlPortRegistry.ResetSession()` from `Proxy.SetMocks`. But `Agent.UpdateMockParams` publishes a test set's mocks like this:

```go
if wp, ok := a.Proxy.(coreAgent.WindowedProxy); ok { wp.SetMocksWithWindow(...) }
else                                              { a.Proxy.SetMocks(...) }
```

`*proxy.Proxy` implements `WindowedProxy`, so `SetMocks` is the fallback arm for a third-party proxy and a stock agent never takes it. `Agent.StoreMocks` never touches the Proxy at all — which is what #4442's comment assumed it did.

`ResetSession` has exactly one non-test caller, and it is that dead branch. The shipped test was green because it drove `SetMocks` directly, so it pinned the branch nothing executes.

**Effect on v3.6.18:** once any replayed test set contains MySQL mocks, the inference stays armed for every later test set in that agent process — including ones with no MySQL at all, where a silent connection on an unrelated port is answered by a replayer with nothing to serve.

## The fix

Hook it to `Proxy.Mock`, which `Agent.MockOutgoing` reaches once per test set and which already hosts the sibling per-session reset (`ResetForReplaySession`).

The reset is now a **mark**, consumed by the next `DeriveFromMocks`, rather than an immediate clear. Clearing at the boundary is its own bug, twice over:

- **It blinds the registry for the whole gap** between `Mock()` and that test set's first mock delivery — a span that includes reading the recorded corpus off disk and shipping it to the agent. A connection opened in that gap loses the known-port fast path and parks in `WaitDerived`. That is real traffic: a reused compose stack or `--keep-app-alive` deliberately holds the app and its connection pool open across test-set boundaries.
- **It must re-arm `derivedCh`, which strands existing waiters.** `WaitDerived` snapshots the channel; `ResetSession` replaces it; `DeriveFromMocks` then closes the *new* one. The old waiter sleeps out the full derive deadline and is told the mocks never arrived — precisely the "no MySQL served, `status_code 0`" failure this mechanism exists to prevent.

Swapping when the replacement is in hand avoids both, and lets `derivedCh` keep its original close-once semantics.

## Tests

The regression test now publishes session 2 through `SetMocksWithWindow` — the call a stock agent actually makes — and asserts the previous recording's ports survive until the replacement lands, so the blind window cannot come back.

`TestProxyTakesTheWindowedMocksPath` fails if `*Proxy` ever stops implementing `WindowedProxy`, so these guarantees cannot quietly migrate back onto a branch nothing exercises.

Two more cover parts of the swap nothing pinned: clearing the inferred endpoints, and not stranding a `WaitDerived` waiter across the boundary.

Mutation-tested — each of these fails the matching test: mark never consumed, hook removed from `Mock()`, `inferred` not cleared, and the eager-clear-plus-re-arm design (which fails both the blind-window and stranded-waiter assertions).

## One more thing: the test suite was rewriting /etc/nsswitch.conf

`testProxy` now preseeds `nsswitchData`. Without it, `Mock()` runs `setupNsswitchConfig`, which rewrites `/etc/nsswitch.conf` and only restores it on proxy shutdown — which a unit test never performs.

Run as root, `go test ./pkg/agent/proxy/` permanently collapsed the host's hosts line:

```
hosts:  files mymachines myhostname resolve [!UNAVAIL=return] dns
   ->   hosts: files dns
```

Run as non-root the write fails, `Mock()` aborts early, and the test's verdict silently depends on privileges instead of on the code. Verified in a mount namespace that the file is byte-identical after a root run with this change, and that it is still mutated without it.