### PR TITLE
fix(contract): support top-level JSON array request/response bodies (#4445)

### DIFF
--- a/pkg/models/openapi.go
+++ b/pkg/models/openapi.go
@@ -108,6 +108,7 @@ type Schema struct {
 	Type       string                            `json:"type" yaml:"type"`
 	Properties map[string]map[string]interface{} `json:"properties,omitempty" yaml:"properties,omitempty"`
 	Items      *Schema                           `json:"items,omitempty" yaml:"items,omitempty"`
+	Nullable   bool                              `json:"nullable,omitempty" yaml:"nullable,omitempty"`
 }
 
 type ParamSchema struct {

--- a/pkg/models/openapi.go
+++ b/pkg/models/openapi.go
@@ -95,8 +95,8 @@ type RequestBody struct {
 }
 
 type MediaType struct {
-	Schema  Schema                 `json:"schema" yaml:"schema"`
-	Example map[string]interface{} `json:"example" yaml:"example"`
+	Schema  Schema      `json:"schema" yaml:"schema"`
+	Example interface{} `json:"example" yaml:"example"`
 }
 
 type ResponseItem struct {
@@ -106,7 +106,8 @@ type ResponseItem struct {
 
 type Schema struct {
 	Type       string                            `json:"type" yaml:"type"`
-	Properties map[string]map[string]interface{} `json:"properties" yaml:"properties"`
+	Properties map[string]map[string]interface{} `json:"properties,omitempty" yaml:"properties,omitempty"`
+	Items      *Schema                           `json:"items,omitempty" yaml:"items,omitempty"`
 }
 
 type ParamSchema struct {

--- a/pkg/service/contract/contract.go
+++ b/pkg/service/contract/contract.go
@@ -48,8 +48,11 @@ func New(logger *zap.Logger, testDB TestDB, mockDB MockDB, openAPIDB OpenAPIDB, 
 func (s *contract) HTTPDocToOpenAPI(logger *zap.Logger, custom models.HTTPDoc) (models.OpenAPI, error) {
 
 	var err error
-	// Convert response body to an object (root may be an object or an array)
-	var responseBodyObject interface{}
+	// Convert response body to an object (root may be an object or an array).
+	// Defaults to an empty object so a body-less doc still serializes its
+	// example as {} rather than null, as it did before array roots were
+	// supported.
+	var responseBodyObject interface{} = map[string]interface{}{}
 	if custom.Spec.Response.Body != "" {
 		err := json.Unmarshal([]byte(custom.Spec.Response.Body), &responseBodyObject)
 		if err != nil {
@@ -65,8 +68,9 @@ func (s *contract) HTTPDocToOpenAPI(logger *zap.Logger, custom models.HTTPDoc) (
 	}
 	responseSchema := SchemaForBody(responseBodyObject, responseObjectProps)
 
-	// Convert request body to an object (root may be an object or an array)
-	var requestBodyObject interface{}
+	// Convert request body to an object (root may be an object or an array).
+	// Defaults to an empty object for the same reason as the response body.
+	var requestBodyObject interface{} = map[string]interface{}{}
 	if custom.Spec.Request.Body != "" {
 		err := json.Unmarshal([]byte(custom.Spec.Request.Body), &requestBodyObject)
 		if err != nil {

--- a/pkg/service/contract/contract.go
+++ b/pkg/service/contract/contract.go
@@ -48,8 +48,8 @@ func New(logger *zap.Logger, testDB TestDB, mockDB MockDB, openAPIDB OpenAPIDB, 
 func (s *contract) HTTPDocToOpenAPI(logger *zap.Logger, custom models.HTTPDoc) (models.OpenAPI, error) {
 
 	var err error
-	// Convert response body to an object
-	var responseBodyObject map[string]interface{}
+	// Convert response body to an object (root may be an object or an array)
+	var responseBodyObject interface{}
 	if custom.Spec.Response.Body != "" {
 		err := json.Unmarshal([]byte(custom.Spec.Response.Body), &responseBodyObject)
 		if err != nil {
@@ -58,11 +58,15 @@ func (s *contract) HTTPDocToOpenAPI(logger *zap.Logger, custom models.HTTPDoc) (
 
 	}
 
-	// Get the type of each value in the response body object
-	responseTypes := ExtractVariableTypes(responseBodyObject)
+	// Build the response schema, supporting both object and array roots.
+	var responseObjectProps map[string]map[string]interface{}
+	if obj, ok := responseBodyObject.(map[string]interface{}); ok {
+		responseObjectProps = ExtractVariableTypes(obj)
+	}
+	responseSchema := SchemaForBody(responseBodyObject, responseObjectProps)
 
-	// Convert request body to an object
-	var requestBodyObject map[string]interface{}
+	// Convert request body to an object (root may be an object or an array)
+	var requestBodyObject interface{}
 	if custom.Spec.Request.Body != "" {
 		err := json.Unmarshal([]byte(custom.Spec.Request.Body), &requestBodyObject)
 		if err != nil {
@@ -71,14 +75,18 @@ func (s *contract) HTTPDocToOpenAPI(logger *zap.Logger, custom models.HTTPDoc) (
 
 	}
 
-	// Get the type of each value in the request body object
-	requestTypes := ExtractVariableTypes(requestBodyObject)
+	// Build the request schema, supporting both object and array roots.
+	var requestObjectProps map[string]map[string]interface{}
+	if obj, ok := requestBodyObject.(map[string]interface{}); ok {
+		requestObjectProps = ExtractVariableTypes(obj)
+	}
+	requestSchema := SchemaForBody(requestBodyObject, requestObjectProps)
 
 	// Generate response by status code
 	byCode := GenerateResponse(Response{
 		Code:    custom.Spec.Response.StatusCode,
 		Message: custom.Spec.Response.StatusMessage,
-		Types:   responseTypes,
+		Schema:  responseSchema,
 		Body:    responseBodyObject,
 	})
 
@@ -133,10 +141,7 @@ func (s *contract) HTTPDocToOpenAPI(logger *zap.Logger, custom models.HTTPDoc) (
 				RequestBody: &models.RequestBody{
 					Content: map[string]models.MediaType{
 						"application/json": {
-							Schema: models.Schema{
-								Type:       "object",
-								Properties: requestTypes,
-							},
+							Schema:  requestSchema,
 							Example: requestBodyObject,
 						},
 					},
@@ -153,10 +158,7 @@ func (s *contract) HTTPDocToOpenAPI(logger *zap.Logger, custom models.HTTPDoc) (
 			RequestBody: &models.RequestBody{
 				Content: map[string]models.MediaType{
 					"application/json": {
-						Schema: models.Schema{
-							Type:       "object",
-							Properties: requestTypes,
-						},
+						Schema:  requestSchema,
 						Example: (requestBodyObject),
 					},
 				},
@@ -172,10 +174,7 @@ func (s *contract) HTTPDocToOpenAPI(logger *zap.Logger, custom models.HTTPDoc) (
 			RequestBody: &models.RequestBody{
 				Content: map[string]models.MediaType{
 					"application/json": {
-						Schema: models.Schema{
-							Type:       "object",
-							Properties: requestTypes,
-						},
+						Schema:  requestSchema,
 						Example: (requestBodyObject),
 					},
 				},

--- a/pkg/service/contract/httpdoc_array_test.go
+++ b/pkg/service/contract/httpdoc_array_test.go
@@ -1,0 +1,89 @@
+package contract
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+func httpDocWith(method, reqBody, respBody string) models.HTTPDoc {
+	return models.HTTPDoc{
+		Version: "api.keploy.io/v1beta1",
+		Kind:    "Http",
+		Name:    "gen",
+		Spec: models.HTTPSchema{
+			Request: models.HTTPReq{Method: models.Method(method), URL: "http://example.com/users", Body: reqBody},
+			Response: models.HTTPResp{
+				StatusCode: 200,
+				Header:     map[string]string{"Content-Type": "application/json"},
+				Body:       respBody,
+			},
+		},
+	}
+}
+
+// Regression test for #4445: a valid JSON body whose root is an array must not
+// crash the contract generator, and must produce a valid OpenAPI `type: array`
+// schema with an `items` schema.
+func TestHTTPDocToOpenAPI_TopLevelArrayResponse(t *testing.T) {
+	svc := &contract{}
+	oapi, err := svc.HTTPDocToOpenAPI(zap.NewNop(), httpDocWith("GET", "", `[{"id":1,"name":"Utkarsh"}]`))
+	if err != nil {
+		t.Fatalf("HTTPDocToOpenAPI failed on top-level array response body: %v", err)
+	}
+
+	got := oapi.Paths["/users"].Get.Responses["200"].Content["application/json"].Schema
+	if got.Type != "array" {
+		t.Fatalf("response schema type = %q, want \"array\"", got.Type)
+	}
+	if got.Items == nil {
+		t.Fatal("array response schema has nil Items")
+	}
+	if got.Items.Type != "object" {
+		t.Fatalf("array items type = %q, want \"object\"", got.Items.Type)
+	}
+	if _, ok := got.Items.Properties["id"]; !ok {
+		t.Fatalf("array items schema missing inferred property \"id\": %+v", got.Items.Properties)
+	}
+
+	// The generated document must be a valid OpenAPI spec.
+	if err := validateSchema(oapi); err != nil {
+		t.Fatalf("generated OpenAPI for array body is invalid: %v", err)
+	}
+}
+
+// A top-level array request body must be handled the same way.
+func TestHTTPDocToOpenAPI_TopLevelArrayRequest(t *testing.T) {
+	svc := &contract{}
+	oapi, err := svc.HTTPDocToOpenAPI(zap.NewNop(), httpDocWith("POST", `[1,2,3]`, `{"ok":true}`))
+	if err != nil {
+		t.Fatalf("HTTPDocToOpenAPI failed on top-level array request body: %v", err)
+	}
+	got := oapi.Paths["/users"].Post.RequestBody.Content["application/json"].Schema
+	if got.Type != "array" || got.Items == nil || got.Items.Type != "number" {
+		t.Fatalf("request schema = %+v, want type array with number items", got)
+	}
+	if err := validateSchema(oapi); err != nil {
+		t.Fatalf("generated OpenAPI for array request body is invalid: %v", err)
+	}
+}
+
+// An object root must keep producing an object schema (no behaviour change).
+func TestHTTPDocToOpenAPI_ObjectResponseUnchanged(t *testing.T) {
+	svc := &contract{}
+	oapi, err := svc.HTTPDocToOpenAPI(zap.NewNop(), httpDocWith("GET", "", `{"id":1,"name":"Utkarsh"}`))
+	if err != nil {
+		t.Fatalf("HTTPDocToOpenAPI failed on object response body: %v", err)
+	}
+	got := oapi.Paths["/users"].Get.Responses["200"].Content["application/json"].Schema
+	if got.Type != "object" {
+		t.Fatalf("response schema type = %q, want \"object\"", got.Type)
+	}
+	if _, ok := got.Properties["id"]; !ok {
+		t.Fatalf("object schema missing property \"id\": %+v", got.Properties)
+	}
+	if err := validateSchema(oapi); err != nil {
+		t.Fatalf("generated OpenAPI for object body is invalid: %v", err)
+	}
+}

--- a/pkg/service/contract/httpdoc_body_edge_test.go
+++ b/pkg/service/contract/httpdoc_body_edge_test.go
@@ -1,0 +1,94 @@
+package contract
+
+import (
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+)
+
+// TestHTTPDocToOpenAPI_EmptyBodiesKeepObjectExample guards the serialization of
+// body-less docs. Supporting array roots meant decoding into interface{} rather
+// than map[string]interface{}, and a nil interface marshals as `example: null`
+// where the nil map used to marshal as `example: {}`. Body-less docs are the
+// common case for GET endpoints, so that would have churned every regenerated
+// contract for no reason.
+func TestHTTPDocToOpenAPI_EmptyBodiesKeepObjectExample(t *testing.T) {
+	svc := &contract{}
+	oapi, err := svc.HTTPDocToOpenAPI(zap.NewNop(), httpDocWith("GET", "", ""))
+	if err != nil {
+		t.Fatalf("HTTPDocToOpenAPI failed on empty bodies: %v", err)
+	}
+
+	media := oapi.Paths["/users"].Get.Responses["200"].Content["application/json"]
+	if media.Schema.Type != "object" {
+		t.Errorf("response schema type = %q, want \"object\"", media.Schema.Type)
+	}
+	if media.Schema.Items != nil {
+		t.Errorf("object schema must not carry Items, got %+v", media.Schema.Items)
+	}
+
+	out, err := yaml.Marshal(media)
+	if err != nil {
+		t.Fatalf("failed to marshal media type: %v", err)
+	}
+	if got, want := string(out), "example: {}"; !strings.Contains(got, want) {
+		t.Errorf("serialized media type = %q, want it to contain %q", got, want)
+	}
+
+	if err := validateSchema(oapi); err != nil {
+		t.Fatalf("generated OpenAPI for empty bodies is invalid: %v", err)
+	}
+}
+
+// TestHTTPDocToOpenAPI_ArrayBodyEdgeCases covers the array roots the happy-path
+// tests do not: an empty array (no element to infer from) and an array of
+// arrays. OpenAPI requires every array schema to carry `items`, so a nil Items
+// here would produce a spec that fails validation.
+func TestHTTPDocToOpenAPI_ArrayBodyEdgeCases(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		wantItems string
+		nested    string // expected Items.Items type, "" when not an array of arrays
+	}{
+		{name: "empty array", body: `[]`, wantItems: "string"},
+		{name: "array of strings", body: `["a","b"]`, wantItems: "string"},
+		{name: "array of booleans", body: `[true]`, wantItems: "boolean"},
+		{name: "array of arrays", body: `[[1,2]]`, wantItems: "array", nested: "number"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &contract{}
+			oapi, err := svc.HTTPDocToOpenAPI(zap.NewNop(), httpDocWith("GET", "", tt.body))
+			if err != nil {
+				t.Fatalf("HTTPDocToOpenAPI failed on %s: %v", tt.name, err)
+			}
+
+			got := oapi.Paths["/users"].Get.Responses["200"].Content["application/json"].Schema
+			if got.Type != "array" {
+				t.Fatalf("schema type = %q, want \"array\"", got.Type)
+			}
+			if got.Items == nil {
+				t.Fatal("array schema has nil Items; OpenAPI requires items on an array schema")
+			}
+			if got.Items.Type != tt.wantItems {
+				t.Errorf("items type = %q, want %q", got.Items.Type, tt.wantItems)
+			}
+			if tt.nested != "" {
+				if got.Items.Items == nil {
+					t.Fatal("nested array schema has nil Items")
+				}
+				if got.Items.Items.Type != tt.nested {
+					t.Errorf("nested items type = %q, want %q", got.Items.Items.Type, tt.nested)
+				}
+			}
+
+			if err := validateSchema(oapi); err != nil {
+				t.Fatalf("generated OpenAPI for %s is invalid: %v", tt.name, err)
+			}
+		})
+	}
+}

--- a/pkg/service/contract/httpdoc_null_test.go
+++ b/pkg/service/contract/httpdoc_null_test.go
@@ -1,0 +1,89 @@
+package contract
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// TestHTTPDocToOpenAPI_NullValuesProduceValidSchemas covers bodies containing
+// JSON nulls. getType mapped a null to "string" while the generated example
+// kept the null, so kin-openapi rejected the document with `Value is not
+// nullable` and contract generation aborted. A list endpoint returning
+// [{"id":1,"deleted_at":null}] is the canonical case, and it failed even after
+// top-level arrays were supported.
+func TestHTTPDocToOpenAPI_NullValuesProduceValidSchemas(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "null field in array of objects", body: `[{"id":1,"deleted_at":null}]`},
+		{name: "array of nulls", body: `[null]`},
+		{name: "null before a real element", body: `[null,{"id":1}]`},
+		{name: "null field in object", body: `{"a":null}`},
+		{name: "null in nested object", body: `{"a":{"b":null}}`},
+		{name: "null inside a nested array", body: `{"tags":[null,"x"]}`},
+		{name: "null field in nested array of objects", body: `{"rows":[{"v":null}]}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &contract{}
+			oapi, err := svc.HTTPDocToOpenAPI(zap.NewNop(), httpDocWith("GET", "", tt.body))
+			if err != nil {
+				t.Fatalf("HTTPDocToOpenAPI failed on %s: %v", tt.body, err)
+			}
+			if err := validateSchema(oapi); err != nil {
+				t.Fatalf("generated OpenAPI for %s is invalid: %v", tt.body, err)
+			}
+		})
+	}
+}
+
+// TestHTTPDocToOpenAPI_NullItemsInferFromRealElement pins that a null does not
+// poison item-type inference: the type comes from the first non-null element
+// and the null only makes the items nullable.
+func TestHTTPDocToOpenAPI_NullItemsInferFromRealElement(t *testing.T) {
+	svc := &contract{}
+	oapi, err := svc.HTTPDocToOpenAPI(zap.NewNop(), httpDocWith("GET", "", `[null,{"id":1}]`))
+	if err != nil {
+		t.Fatalf("HTTPDocToOpenAPI failed: %v", err)
+	}
+
+	got := oapi.Paths["/users"].Get.Responses["200"].Content["application/json"].Schema
+	if got.Type != "array" {
+		t.Fatalf("schema type = %q, want \"array\"", got.Type)
+	}
+	if got.Items == nil {
+		t.Fatal("array schema has nil Items")
+	}
+	if got.Items.Type != "object" {
+		t.Errorf("items type = %q, want \"object\" inferred from the non-null element", got.Items.Type)
+	}
+	if !got.Items.Nullable {
+		t.Error("items should be marked nullable because the array contains a null")
+	}
+	if _, ok := got.Items.Properties["id"]; !ok {
+		t.Errorf("items schema missing property \"id\": %+v", got.Items.Properties)
+	}
+}
+
+// TestHTTPDocToOpenAPI_NoNullsStayNonNullable guards against marking everything
+// nullable: a body without nulls must not gain the flag.
+func TestHTTPDocToOpenAPI_NoNullsStayNonNullable(t *testing.T) {
+	svc := &contract{}
+	oapi, err := svc.HTTPDocToOpenAPI(zap.NewNop(), httpDocWith("GET", "", `[{"id":1}]`))
+	if err != nil {
+		t.Fatalf("HTTPDocToOpenAPI failed: %v", err)
+	}
+	got := oapi.Paths["/users"].Get.Responses["200"].Content["application/json"].Schema
+	if got.Items == nil {
+		t.Fatal("array schema has nil Items")
+	}
+	if got.Items.Nullable {
+		t.Error("items marked nullable for an array with no nulls")
+	}
+	if _, ok := got.Items.Properties["id"]["nullable"]; ok {
+		t.Error("non-null property gained a nullable flag")
+	}
+}

--- a/pkg/service/contract/utils.go
+++ b/pkg/service/contract/utils.go
@@ -20,8 +20,8 @@ import (
 type Response struct {
 	Code    int
 	Message string
-	Types   map[string]map[string]interface{}
-	Body    map[string]interface{}
+	Schema  models.Schema
+	Body    interface{}
 }
 
 // ExtractVariableTypes returns the type of each variable in the object.
@@ -83,16 +83,49 @@ func ExtractVariableTypes(obj map[string]interface{}) map[string]map[string]inte
 	return types
 }
 
+// SchemaForBody builds an OpenAPI schema for a decoded JSON body whose root
+// may be either an object or an array. For an object root it returns a
+// {type: object, properties: ...} schema (properties precomputed by the
+// caller via ExtractVariableTypes). For an array root it returns a
+// {type: array, items: ...} schema, inferring the item schema from the first
+// element. Any other root (or an empty body) falls back to an object schema so
+// existing behaviour is preserved.
+func SchemaForBody(body interface{}, objectProps map[string]map[string]interface{}) models.Schema {
+	arr, ok := body.([]interface{})
+	if !ok {
+		// Object root (or nil/empty body): keep the original object schema.
+		return models.Schema{Type: "object", Properties: objectProps}
+	}
+
+	items := &models.Schema{Type: "string"} // default for an empty array
+	if len(arr) > 0 {
+		switch first := arr[0].(type) {
+		case map[string]interface{}:
+			items = &models.Schema{
+				Type:       "object",
+				Properties: ExtractVariableTypes(first),
+			}
+		case []interface{}:
+			nested := SchemaForBody(first, nil)
+			items = &nested
+		case float64:
+			items = &models.Schema{Type: "number"}
+		case bool:
+			items = &models.Schema{Type: "boolean"}
+		case string:
+			items = &models.Schema{Type: "string"}
+		}
+	}
+	return models.Schema{Type: "array", Items: items}
+}
+
 func GenerateResponse(response Response) map[string]models.ResponseItem {
 	byCode := map[string]models.ResponseItem{
 		fmt.Sprintf("%d", response.Code): {
 			Description: response.Message,
 			Content: map[string]models.MediaType{
 				"application/json": {
-					Schema: models.Schema{
-						Type:       "object",
-						Properties: response.Types,
-					},
+					Schema:  response.Schema,
 					Example: (response.Body),
 				},
 			},

--- a/pkg/service/contract/utils.go
+++ b/pkg/service/contract/utils.go
@@ -48,6 +48,16 @@ func ExtractVariableTypes(obj map[string]interface{}) map[string]map[string]inte
 	}
 
 	for key, value := range obj {
+		// A JSON null carries no type. OpenAPI 3.0 still requires one, so keep
+		// the historical "string" default but mark the property nullable -
+		// without it the untouched example holds a null that kin-openapi
+		// rejects with `Value is not nullable`, aborting contract generation
+		// for any payload with a null field.
+		if value == nil {
+			types[key] = map[string]interface{}{"type": "string", "nullable": true}
+			continue
+		}
+
 		valueType := getType(value)
 		responseType := map[string]interface{}{
 			"type": valueType,
@@ -60,27 +70,55 @@ func ExtractVariableTypes(obj map[string]interface{}) map[string]map[string]inte
 			arrayItems := value.([]interface{})
 			arrayType := "string" // Default to string if array is empty
 
-			if len(arrayItems) > 0 {
-				firstElement := arrayItems[0]
+			// Infer from the first non-null element; a null anywhere in the
+			// array only means the items are nullable.
+			firstElement, nullable := firstNonNil(arrayItems)
+			if firstElement != nil {
 				arrayType = getType(firstElement)
 				if arrayType == "object" {
-					responseType["items"] = map[string]interface{}{
+					items := map[string]interface{}{
 						"type":       arrayType,
 						"properties": ExtractVariableTypes(firstElement.(map[string]interface{})),
 					}
+					if nullable {
+						items["nullable"] = true
+					}
+					responseType["items"] = items
 					types[key] = responseType
 					continue
 				}
 			}
-			responseType["items"] = map[string]interface{}{
+			items := map[string]interface{}{
 				"type": arrayType,
 			}
+			if nullable {
+				items["nullable"] = true
+			}
+			responseType["items"] = items
 		}
 
 		types[key] = responseType
 	}
 
 	return types
+}
+
+// firstNonNil returns the first non-null element of items along with whether
+// any element was null, so callers can infer an item type from real data while
+// still marking the schema nullable.
+func firstNonNil(items []interface{}) (interface{}, bool) {
+	var first interface{}
+	nullable := false
+	for _, item := range items {
+		if item == nil {
+			nullable = true
+			continue
+		}
+		if first == nil {
+			first = item
+		}
+	}
+	return first, nullable
 }
 
 // SchemaForBody builds an OpenAPI schema for a decoded JSON body whose root
@@ -98,24 +136,27 @@ func SchemaForBody(body interface{}, objectProps map[string]map[string]interface
 	}
 
 	items := &models.Schema{Type: "string"} // default for an empty array
-	if len(arr) > 0 {
-		switch first := arr[0].(type) {
-		case map[string]interface{}:
-			items = &models.Schema{
-				Type:       "object",
-				Properties: ExtractVariableTypes(first),
-			}
-		case []interface{}:
-			nested := SchemaForBody(first, nil)
-			items = &nested
-		case float64:
-			items = &models.Schema{Type: "number"}
-		case bool:
-			items = &models.Schema{Type: "boolean"}
-		case string:
-			items = &models.Schema{Type: "string"}
+	// Infer from the first non-null element; a null anywhere in the array only
+	// means the items are nullable, and inferring "string" from it would make
+	// kin-openapi reject the untouched example.
+	first, nullable := firstNonNil(arr)
+	switch v := first.(type) {
+	case map[string]interface{}:
+		items = &models.Schema{
+			Type:       "object",
+			Properties: ExtractVariableTypes(v),
 		}
+	case []interface{}:
+		nested := SchemaForBody(v, nil)
+		items = &nested
+	case float64:
+		items = &models.Schema{Type: "number"}
+	case bool:
+		items = &models.Schema{Type: "boolean"}
+	case string:
+		items = &models.Schema{Type: "string"}
 	}
+	items.Nullable = nullable
 	return models.Schema{Type: "array", Items: items}
 }
 


### PR DESCRIPTION
## What

Fixes #4445.

`HTTPDocToOpenAPI` unmarshalled request and response bodies into `map[string]interface{}`, so a valid JSON body whose **root is an array** — a common shape for list endpoints — failed:

```go
json.Unmarshal([]byte(`[{"id":1,"name":"Utkarsh"}]`), &map[string]interface{}{})
// json: cannot unmarshal array into Go value of type map[string]interface {}
```

The whole contract generation aborted for any test/mock with a top-level array body.

## Fix

- Decode request/response bodies into `interface{}` (root may be an object or an array).
- Add `SchemaForBody(body, objectProps)` which returns:
  - `{type: object, properties: ...}` for an object root (unchanged behaviour), or
  - `{type: array, items: ...}` for an array root, inferring the item schema from the first element (object / number / boolean / string / nested array).
- `models.Schema` gains an optional `Items *Schema`; `MediaType.Example` becomes `interface{}` so an array example can be represented. `properties`/`items` are `omitempty` so object schemas serialize exactly as before.
- `GenerateResponse` now takes the prebuilt schema instead of hardcoding `type: object`.

Object bodies produce byte-identical output to before.

## Verification (real results, Go 1.26)

`go test ./pkg/service/contract/` — all pass, including three new tests:

- `TestHTTPDocToOpenAPI_TopLevelArrayResponse` — array response → `type: array` with an `object` item schema whose properties are inferred.
- `TestHTTPDocToOpenAPI_TopLevelArrayRequest` — array request body → `type: array` with `number` items.
- `TestHTTPDocToOpenAPI_ObjectResponseUnchanged` — object root still yields an `object` schema (no regression).

Each new test also asserts the generated document passes `kin-openapi` validation (`validateSchema`), so the output is guaranteed to be a valid OpenAPI spec. `gofmt`/`go vet` clean.

Before this change the array cases returned the `cannot unmarshal array into ... map[string]interface {}` error; after, they produce valid schemas.
