### PR TITLE
chore(proxy): remove userspace TCP_INFO network-I/O accounting

### DIFF
--- a/pkg/agent/proxy/incoming/gRPC/record.go
+++ b/pkg/agent/proxy/incoming/gRPC/record.go
@@ -12,7 +12,6 @@ import (
 	"go.keploy.io/server/v3/pkg"
 	Utils "go.keploy.io/server/v3/pkg/agent/hooks/conn"
 	"go.keploy.io/server/v3/pkg/agent/memoryguard"
-	ossproxy "go.keploy.io/server/v3/pkg/agent/proxy"
 	"go.keploy.io/server/v3/pkg/models"
 	"go.uber.org/zap"
 	"golang.org/x/net/http2"
@@ -40,13 +39,6 @@ func RecordIncoming(ctx context.Context, logger *zap.Logger, clientConn, destCon
 			!strings.Contains(err.Error(), "use of closed network connection") {
 			logger.Debug("failed to close client connection", zap.Error(err))
 		}
-		// Ingress proxy: destConn is the app-facing socket (keploy → app). Record its
-		// TCP_INFO byte totals (true wire volume) into the usage-metering footprint
-		// before closing, so inbound gRPC serving traffic is metered too — the
-		// counterpart of the outgoing proxy's srcConn accounting. No-op unless a sink
-		// was installed. Best-effort: on ctx-cancel shutdown the socket may already be
-		// closed by the goroutine above, in which case the read is skipped.
-		ossproxy.RecordConnNetworkIO(destConn)
 		if err := destConn.Close(); err != nil &&
 			!strings.Contains(err.Error(), "use of closed network connection") {
 			logger.Debug("failed to close destination connection", zap.Error(err))

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -17,7 +17,6 @@ import (
 	"go.keploy.io/server/v3/pkg"
 	hooksUtils "go.keploy.io/server/v3/pkg/agent/hooks/conn"
 	"go.keploy.io/server/v3/pkg/agent/memoryguard"
-	ossproxy "go.keploy.io/server/v3/pkg/agent/proxy"
 	syncMock "go.keploy.io/server/v3/pkg/agent/proxy/syncMock"
 	"go.keploy.io/server/v3/pkg/models"
 	"go.uber.org/zap"
@@ -528,12 +527,6 @@ func (pm *IngressProxyManager) handleHttp1Connection(ctx context.Context, client
 		return
 	}
 	defer func() {
-		// Ingress proxy: upConn is the app-facing socket (keploy → app on the
-		// redirected port). Record its TCP_INFO byte totals (true wire volume) into
-		// the usage-metering footprint before closing, so the app's inbound serving
-		// traffic is metered too — the counterpart of the outgoing proxy's srcConn
-		// accounting. No-op unless a sink was installed.
-		ossproxy.RecordConnNetworkIO(upConn)
 		_ = upConn.Close()
 	}()
 
@@ -1123,12 +1116,6 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 	// happened mid-iteration).
 	defer func() {
 		if h := upConnHolder.Load(); h != nil {
-			// Record kernel network I/O off the upstream socket BEFORE closing it.
-			// This is the real teardown for the zero-copy path: the caller's outer
-			// defer (handleHttp1Connection) runs after this and would only ever see
-			// an already-closed conn, so the accounting has to happen here. No-op
-			// unless a sink was installed.
-			ossproxy.RecordConnNetworkIO(h.c)
 			_ = h.c.Close()
 		}
 	}()
@@ -1151,9 +1138,6 @@ func (pm *IngressProxyManager) handleHttp1ZeroCopy(ctx context.Context, clientCo
 		// shutdown sees a consistent view (either the old conn or the
 		// new one — never a torn pointer).
 		if h := upConnHolder.Load(); h != nil {
-			// Capture this upstream conn's byte totals before retiring it for a
-			// fresh one, so a mid-connection redial doesn't drop them.
-			ossproxy.RecordConnNetworkIO(h.c)
 			_ = h.c.Close()
 		}
 		// DialContext (instead of DialTimeout) so an in-flight dial

--- a/pkg/agent/proxy/netio_kernel.go
+++ b/pkg/agent/proxy/netio_kernel.go
@@ -4,7 +4,6 @@ package proxy
 
 import (
 	"context"
-	"sync/atomic"
 	"time"
 
 	"github.com/cilium/ebpf"
@@ -18,20 +17,14 @@ const netioBytesPinPath = "/sys/fs/bpf/keploy_netio_bytes"
 
 const netioDrainInterval = 15 * time.Second
 
-// kernelNetioActive flips true once the kernel keploy_netio_bytes counter is
-// confirmed producing bytes. RecordConnNetworkIO (the userspace TCP_INFO path)
-// then stands down, so the same traffic is never counted by both paths.
-var kernelNetioActive atomic.Bool
-
 type netioVal struct{ Rx, Tx uint64 }
 
 // StartKernelNetioDrain drains the kernel keploy_netio_bytes counter (per-cgroup
 // app rx/tx, tallied in-kernel at tcp_sendmsg/tcp_recvmsg) and folds per-interval
-// deltas into networkIOSink — the SAME sink the TCP_INFO path feeds, so the data
-// reaches the footprint identically. The map is opened lazily by its bpffs pin,
-// so this stays inert until the netio programs are loaded (or forever, on a
-// kernel without BTF — in which case the TCP_INFO fallback keeps running). Once it
-// sees the counter producing bytes it flips kernelNetioActive so TCP_INFO stops.
+// deltas into networkIOSink, which carries them into the usage-metering footprint.
+// The map is opened lazily by its bpffs pin, so this stays inert until the netio
+// programs are loaded (or forever, on a kernel without BTF — where no network I/O
+// is metered, since the userspace TCP_INFO fallback has been removed).
 func StartKernelNetioDrain(ctx context.Context, logger *zap.Logger) {
 	go func() {
 		t := time.NewTicker(netioDrainInterval)
@@ -55,16 +48,13 @@ func StartKernelNetioDrain(ctx context.Context, logger *zap.Logger) {
 					}
 					m = opened
 				}
-				rxDelta, txDelta, seen, ok := drainKernelNetio(m, last)
+				rxDelta, txDelta, ok := drainKernelNetio(m, last)
 				if !ok {
 					// Stale handle (map re-pinned). Drop and re-open next tick.
 					_ = m.Close()
 					m = nil
 					last = map[uint64]netioVal{}
 					continue
-				}
-				if seen && kernelNetioActive.CompareAndSwap(false, true) {
-					logger.Info("kernel network-I/O counter active — userspace TCP_INFO accounting stood down")
 				}
 				if rxDelta == 0 && txDelta == 0 {
 					continue
@@ -78,9 +68,9 @@ func StartKernelNetioDrain(ctx context.Context, logger *zap.Logger) {
 }
 
 // drainKernelNetio sums each cgroup's per-CPU rx/tx and returns the total NEW
-// bytes since the last drain (forward-delta, reset-safe), whether any counter is
-// non-zero (netio is live), and ok=false on a stale-handle iteration error.
-func drainKernelNetio(m *ebpf.Map, last map[uint64]netioVal) (rxDelta, txDelta uint64, seen, ok bool) {
+// bytes since the last drain (forward-delta, reset-safe), and ok=false on a
+// stale-handle iteration error.
+func drainKernelNetio(m *ebpf.Map, last map[uint64]netioVal) (rxDelta, txDelta uint64, ok bool) {
 	var (
 		key    uint64
 		perCPU []netioVal
@@ -94,15 +84,12 @@ func drainKernelNetio(m *ebpf.Map, last map[uint64]netioVal) (rxDelta, txDelta u
 			v.Tx += c.Tx
 		}
 		cur[key] = v
-		if v.Rx > 0 || v.Tx > 0 {
-			seen = true
-		}
 		p := last[key]
 		rxDelta += forwardDeltaU64(v.Rx, p.Rx)
 		txDelta += forwardDeltaU64(v.Tx, p.Tx)
 	}
 	if err := it.Err(); err != nil {
-		return 0, 0, false, false
+		return 0, 0, false
 	}
 	// Adopt the fresh snapshot; cgroups that vanished were already counted.
 	for k := range last {
@@ -113,7 +100,7 @@ func drainKernelNetio(m *ebpf.Map, last map[uint64]netioVal) (rxDelta, txDelta u
 	for k, v := range cur {
 		last[k] = v
 	}
-	return rxDelta, txDelta, seen, true
+	return rxDelta, txDelta, true
 }
 
 // forwardDeltaU64 returns cur-prev, or the full cur when the counter went

--- a/pkg/agent/proxy/netstat.go
+++ b/pkg/agent/proxy/netstat.go
@@ -3,108 +3,31 @@
 package proxy
 
 import (
-	"net"
 	"sync/atomic"
-	"syscall"
-
-	"golang.org/x/sys/unix"
 )
 
-// Kernel-sourced network I/O accounting for the PROXY capture path.
+// Network-I/O sink for the app's wire volume.
 //
-// The proxy owns the app-facing socket (srcConn), so the kernel's own per-socket
-// byte counters (TCP_INFO) are the authoritative measure of how much traffic the
-// app actually moved on that connection — the TRUE wire volume, BEFORE the capture
-// pipeline dedups/samples/drops artifacts. This is exactly what a per-captured-
-// artifact tally cannot see (and what the eBPF cgroup counter does for proxyless).
+// The app's true wire volume (rx = app ingress, tx = app egress, pre-dedup) is
+// now metered in-kernel by the app network-I/O counter (keploy_ebpf.c
+// keploy_netio_bytes, drained by StartKernelNetioDrain) — the userspace TCP_INFO
+// accounting that used to read each proxied socket at teardown has been removed in
+// favour of the continuous, single-counted kernel counter.
 //
-// We read TCP_INFO once at connection teardown (each connection's counters are
-// cumulative for its lifetime), and feed the totals to a sink the enterprise agent
-// wires to its resource snapshot. The OSS package can't import the enterprise
-// resourceio package, so the dependency is inverted via a sink — mirroring the
-// existing captured-IO sink pattern.
-//
-// NOTE (v1 scope): reporting at teardown means a connection that stays open for the
-// whole recording won't contribute until it closes. Long-lived connections would
-// want periodic delta sampling of the live sockets; left as a follow-up.
+// The sink is kept as the dependency-inversion seam: the OSS package can't import
+// the enterprise resourceio package, so the enterprise agent installs a sink here
+// and the kernel drain feeds it.
 
-// networkIOSink, when set, receives a connection's app-relative ingress/egress
-// byte totals (rx = bytes the app received, tx = bytes the app sent) at teardown.
-// nil ⇒ no accounting (default; the enterprise agent installs it).
+// networkIOSink, when set, receives app ingress/egress byte deltas from the kernel
+// netio drain. nil ⇒ no accounting (default; the enterprise agent installs it).
 var networkIOSink atomic.Pointer[func(rx, tx uint64)]
 
-// SetNetworkIOSink installs the accumulator invoked with each proxied connection's
-// app ingress/egress byte totals (from TCP_INFO). Safe to call once at startup.
-// Passing nil disables accounting.
+// SetNetworkIOSink installs the accumulator invoked with the app's ingress/egress
+// byte deltas. Safe to call once at startup. Passing nil disables accounting.
 func SetNetworkIOSink(sink func(rx, tx uint64)) {
 	if sink == nil {
 		networkIOSink.Store(nil)
 		return
 	}
 	networkIOSink.Store(&sink)
-}
-
-// RecordConnNetworkIO reads the kernel TCP_INFO byte counters off an app-facing
-// socket and forwards them to the sink. Best-effort and cheap (one getsockopt);
-// a non-TCP conn or an unreadable fd is silently skipped. Call once per connection
-// just before closing it.
-//
-// Pass the socket that keploy owns facing the APP — the outgoing proxy's srcConn
-// (app dials keploy) or the ingress proxy's upConn (keploy dials the app). In both
-// cases keploy is the app's peer, so the direction mapping is identical:
-//   - Bytes_received = bytes keploy RECEIVED on this socket = app → keploy = the
-//     app's EGRESS.  → tx
-//   - Bytes_acked    = bytes keploy SENT (and were acked) = keploy → app = the
-//     app's INGRESS. → rx
-func RecordConnNetworkIO(conn net.Conn) {
-	// When the in-kernel netio counter is live it is authoritative for the app's
-	// wire volume, so the userspace TCP_INFO path stands down to avoid double
-	// counting the same traffic. See StartKernelNetioDrain.
-	if kernelNetioActive.Load() {
-		return
-	}
-	sinkP := networkIOSink.Load()
-	if sinkP == nil || conn == nil {
-		return
-	}
-	rx, tx, ok := readSocketBytes(conn)
-	if !ok || (rx == 0 && tx == 0) {
-		return
-	}
-	(*sinkP)(rx, tx)
-}
-
-// readSocketBytes returns the app-relative (rx, tx) cumulative byte totals for a
-// TCP connection from the kernel's TCP_INFO. ok is false for a non-TCP conn, a
-// conn without a raw syscall handle, or a getsockopt failure.
-func readSocketBytes(conn net.Conn) (rx, tx uint64, ok bool) {
-	sc, err := rawConn(conn)
-	if err != nil || sc == nil {
-		return 0, 0, false
-	}
-	var (
-		info    *unix.TCPInfo
-		infoErr error
-	)
-	ctrlErr := sc.Control(func(fd uintptr) {
-		info, infoErr = unix.GetsockoptTCPInfo(int(fd), unix.SOL_TCP, unix.TCP_INFO)
-	})
-	if ctrlErr != nil || infoErr != nil || info == nil {
-		return 0, 0, false
-	}
-	// See direction note above: acked = app ingress (rx), received = app egress (tx).
-	return info.Bytes_acked, info.Bytes_received, true
-}
-
-// rawConn unwraps a net.Conn to its SyscallConn, tolerating the util wrappers the
-// proxy layers over the raw socket. Only *net.TCPConn (or a wrapper exposing
-// SyscallConn) yields a usable handle.
-func rawConn(conn net.Conn) (syscall.RawConn, error) {
-	type syscallConner interface {
-		SyscallConn() (syscall.RawConn, error)
-	}
-	if sc, ok := conn.(syscallConner); ok {
-		return sc.SyscallConn()
-	}
-	return nil, nil
 }

--- a/pkg/agent/proxy/netstat_other.go
+++ b/pkg/agent/proxy/netstat_other.go
@@ -4,20 +4,16 @@ package proxy
 
 import (
 	"context"
-	"net"
 
 	"go.uber.org/zap"
 )
 
-// Non-Linux stubs: kernel TCP_INFO byte counters are a Linux facility, so the
-// proxy network-I/O accounting is a no-op elsewhere (the agent runs on Linux in
-// production).
+// Non-Linux stubs: the kernel eBPF network-I/O counter is a Linux facility, so
+// the proxy network-I/O accounting is a no-op elsewhere (the agent runs on Linux
+// in production).
 
 // SetNetworkIOSink is a no-op on non-Linux.
 func SetNetworkIOSink(_ func(rx, tx uint64)) {}
-
-// RecordConnNetworkIO is a no-op on non-Linux.
-func RecordConnNetworkIO(_ net.Conn) {}
 
 // StartKernelNetioDrain is a no-op on non-Linux (the eBPF counter is Linux-only).
 func StartKernelNetioDrain(_ context.Context, _ *zap.Logger) {}

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -1792,14 +1792,6 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 	// making a new client connection id for each client connection
 	clientConnID := util.GetNextID()
 
-	// Keep a handle to the RAW accepted socket for kernel network-I/O accounting.
-	// srcConn gets reassigned to util.Conn / SafeConn wrappers below, and those
-	// embed net.Conn as an interface — so SyscallConn() is NOT promoted through
-	// them and RecordConnNetworkIO could not reach the fd. The entry value is the
-	// bare *net.TCPConn (the RemoteAddr type-assert below relies on that), so read
-	// TCP_INFO off it at teardown instead of the wrapped srcConn.
-	origSrcConn := srcConn
-
 	defer func(start time.Time) {
 		duration := time.Since(start)
 		p.logger.Debug("time taken by proxy to execute the flow", zap.Any("Client ConnectionID", clientConnID), zap.Int64("Duration(ms)", duration.Milliseconds()))
@@ -1923,13 +1915,6 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 		parserCtxCancel()
 
 		if srcConn != nil {
-			// Kernel-sourced network I/O: read this proxied connection's TCP_INFO
-			// byte totals (true wire volume, pre-dedup) into the usage-metering
-			// footprint just before closing. No-op unless a sink was installed.
-			// Read the RAW accepted socket (origSrcConn), not the wrapped srcConn:
-			// the util.Conn/SafeConn wrappers embed net.Conn as an interface, so
-			// SyscallConn() is not reachable through them.
-			RecordConnNetworkIO(origSrcConn)
 			err := srcConn.Close()
 			if err != nil {
 				if !strings.Contains(err.Error(), "use of closed network connection") {


### PR DESCRIPTION
## Related issue
Follow-up cleanup to #4446 (kernel app network-I/O counter drain).

## Description
The app's wire volume (rx = ingress, tx = egress, pre-dedup) is now metered **in-kernel** by the eBPF app network-I/O counter (`keploy_netio_bytes`, drained by `StartKernelNetioDrain` from #4446). This PR removes the older **userspace** path that read each proxied socket's `TCP_INFO` byte totals at connection teardown.

Removed:
- `proxy.go` — the `origSrcConn` raw-socket capture and its `RecordConnNetworkIO` teardown call.
- `incoming/http.go`, `incoming/gRPC/record.go` — the app-facing-socket `RecordConnNetworkIO` calls (and the now-unused `ossproxy` import).
- `netstat.go` — reduced to the `networkIOSink` seam only (`SetNetworkIOSink`); dropped `RecordConnNetworkIO`, `readSocketBytes`, the `rawConn` helper and the `kernelNetioActive` gate.
- `netstat_other.go` — the `RecordConnNetworkIO` non-Linux stub (and `net` import).

The kernel counter is continuous and single-counted, so it **replaces** the teardown-time `TCP_INFO` reads outright rather than running alongside them (no double-book, no gate needed).

## ⚠️ Merge ordering & tradeoff
- **Based on `feat/netio-kernel-drain` (#4446)** — merge this only **after #4446 is merged and runtime-validated** on the target kernels. Retarget to `main` at that point.
- On a kernel **without BTF** the eBPF netio programs do not load, and with this change there is **no userspace fallback** — network I/O is simply not metered there. CPU / RAM / disk metering are unaffected.

## Testing
- `go build ./pkg/agent/hooks/... ./pkg/agent/proxy/...` (linux) — passes.
- `CGO_ENABLED=0 GOOS=darwin go build ./pkg/agent/proxy/...` — passes.
- `gofmt` clean; no dangling references to removed symbols.

## Checklist
- [x] Builds on linux and (cgo-off) darwin
- [x] `gofmt` clean
- [x] Signed-off (DCO)