### PR TITLE
fix(replay): gate on app readiness for docker-compose apps too

### DIFF
--- a/pkg/service/replay/compose_readiness_test.go
+++ b/pkg/service/replay/compose_readiness_test.go
@@ -1,0 +1,160 @@
+package replay
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A compose replay had no readiness gate at all: dockerPublishedHostPort only
+// recognises -p/--publish, which `docker compose up` never carries, so the
+// fixed --delay was the whole protection — and keploy's own generated compose
+// holds the app behind the agent's healthcheck, routinely spending it.
+func TestComposePublishedHostPort(t *testing.T) {
+	write := func(t *testing.T, body string) string {
+		t.Helper()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "docker-compose.yml")
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+
+	for _, tc := range []struct {
+		name          string
+		compose       string
+		containerName string
+		wantHost      string
+		wantPort      string
+		wantOK        bool
+	}{
+		{
+			name: "app identified by container_name among several services",
+			compose: `services:
+  api:
+    container_name: parse_app
+    ports: ["6076:1337"]
+  mongo:
+    container_name: parse_mongo
+    ports: ["27017:27017"]
+`,
+			containerName: "parse_app", wantHost: "127.0.0.1", wantPort: "6076", wantOK: true,
+		},
+		{
+			name: "a db port is never mistaken for the app when the name does not match",
+			compose: `services:
+  api:
+    container_name: parse_app
+    ports: ["6076:1337"]
+  mongo:
+    container_name: parse_mongo
+    ports: ["27017:27017"]
+`,
+			containerName: "something_else", wantOK: false,
+		},
+		{
+			name: "lone publishing service is unambiguous even with no container_name",
+			compose: `services:
+  api:
+    ports: ["8080:8080"]
+  mongo:
+    image: mongo:7
+`,
+			wantHost: "127.0.0.1", wantPort: "8080", wantOK: true,
+		},
+		{
+			name: "explicit host ip is honoured",
+			compose: `services:
+  api:
+    container_name: app
+    ports: ["192.168.1.5:9090:80"]
+`,
+			containerName: "app", wantHost: "192.168.1.5", wantPort: "9090", wantOK: true,
+		},
+		{
+			name: "long form",
+			compose: `services:
+  api:
+    container_name: app
+    ports:
+      - target: 80
+        published: 8081
+        protocol: tcp
+`,
+			containerName: "app", wantHost: "127.0.0.1", wantPort: "8081", wantOK: true,
+		},
+		{
+			name: "container-only publish names no host port",
+			compose: `services:
+  api:
+    container_name: app
+    ports: ["8080"]
+`,
+			containerName: "app", wantOK: false,
+		},
+		{
+			name: "ranges are refused rather than guessed",
+			compose: `services:
+  api:
+    container_name: app
+    ports: ["8000-8010:8000-8010"]
+`,
+			containerName: "app", wantOK: false,
+		},
+		{
+			name: "two publishing services and no name match stays ambiguous",
+			compose: `services:
+  a:
+    ports: ["1111:1111"]
+  b:
+    ports: ["2222:2222"]
+`,
+			wantOK: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := write(t, tc.compose)
+			host, port, ok := composePublishedHostPort("docker compose -f "+path+" up", tc.containerName)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (host=%q port=%q)", ok, tc.wantOK, host, port)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if host != tc.wantHost || port != tc.wantPort {
+				t.Errorf("got %s:%s, want %s:%s", host, port, tc.wantHost, tc.wantPort)
+			}
+		})
+	}
+}
+
+// A non-compose command must be left exactly as it was: the -p gate owns that
+// case, and guessing a port here could make replay wait on something unrelated.
+func TestComposePublishedHostPortIgnoresNonCompose(t *testing.T) {
+	for _, cmd := range []string{
+		"docker run -p 8080:8080 myapp",
+		"go run ./cmd/app",
+		"npm start",
+		"",
+	} {
+		if _, _, ok := composePublishedHostPort(cmd, "app"); ok {
+			t.Errorf("claimed a port for a non-compose command: %q", cmd)
+		}
+	}
+}
+
+// A missing or unparseable compose file must decline, never panic or guess.
+func TestComposePublishedHostPortDegradesQuietly(t *testing.T) {
+	if _, _, ok := composePublishedHostPort("docker compose -f /nonexistent/compose.yml up", "app"); ok {
+		t.Error("claimed a port from a file that does not exist")
+	}
+	dir := t.TempDir()
+	bad := filepath.Join(dir, "docker-compose.yml")
+	if err := os.WriteFile(bad, []byte("services: [this is not: valid: yaml"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, ok := composePublishedHostPort("docker compose -f "+bad+" up", "app"); ok {
+		t.Error("claimed a port from unparseable YAML")
+	}
+}

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -11,6 +11,8 @@ import (
 	"path"
 	"sort"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 	"sync"
 	"time"
 
@@ -169,6 +171,151 @@ func dockerPublishedHostPort(cmd string) (host, port string, ok bool) {
 		return h, hp, true
 	}
 	return "", "", false
+}
+
+// composePublishedHostPort finds the host port the application's service
+// publishes in a docker-compose file, so a compose replay gets the same
+// readiness gate a `docker run -p` replay already gets.
+//
+// Without it, compose apps have no gate at all: dockerPublishedHostPort only
+// recognises -p/--publish on the command line, and `docker compose up` carries
+// none, so the fixed --delay is the entire protection. That is not a
+// theoretical gap — keploy's own generated compose holds the application behind
+// the agent's healthcheck (start_period 10s, interval 5s), so on a contended
+// machine the app starts as the delay expires, the first test window opens
+// while the app is still booting, and its bootstrap queries are scored against
+// a per-test pool that has nothing in it. The app then dies on a refused
+// dependency and every test in the set fails, while the diagnostic points at
+// the mocks and tells the user to re-record.
+//
+// Conservative like its sibling: it returns ok=false rather than guess. The
+// service is identified by container_name so a multi-service stack cannot be
+// mistaken for the app, falling back to a lone port-publishing service only
+// when the stack is unambiguous. Short and long port syntax are both read;
+// ranges and container-only publishes are skipped because neither names a host
+// port to wait on.
+func composePublishedHostPort(cmd, containerName string) (host, port string, ok bool) {
+	path, ok := composeFileFromCommand(cmd)
+	if !ok {
+		return "", "", false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", "", false
+	}
+	var doc struct {
+		Services map[string]struct {
+			ContainerName string      `yaml:"container_name"`
+			Ports         []yaml.Node `yaml:"ports"`
+		} `yaml:"services"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return "", "", false
+	}
+
+	type candidate struct{ host, port string }
+	var byName, only []candidate
+	published := 0
+	for _, svc := range doc.Services {
+		h, p, found := firstComposeHostPort(svc.Ports)
+		if !found {
+			continue
+		}
+		published++
+		only = append(only, candidate{h, p})
+		if containerName != "" && svc.ContainerName == containerName {
+			byName = append(byName, candidate{h, p})
+		}
+	}
+	if len(byName) == 1 {
+		return byName[0].host, byName[0].port, true
+	}
+	// No container_name match: only trust the stack when exactly one service
+	// publishes anything, so a db or cache port is never mistaken for the app.
+	if published == 1 {
+		return only[0].host, only[0].port, true
+	}
+	return "", "", false
+}
+
+// composeFileFromCommand returns the compose file the command operates on,
+// honouring an explicit -f/--file and otherwise falling back to the names
+// docker compose itself looks for in the working directory.
+func composeFileFromCommand(cmd string) (string, bool) {
+	fields := strings.Fields(cmd)
+	isCompose := false
+	for i, f := range fields {
+		if f == "compose" || strings.HasPrefix(f, "docker-compose") {
+			isCompose = true
+		}
+		if (f == "-f" || f == "--file") && i+1 < len(fields) {
+			return fields[i+1], true
+		}
+	}
+	if !isCompose {
+		return "", false
+	}
+	for _, name := range []string{"compose.yaml", "compose.yml", "docker-compose.yaml", "docker-compose.yml"} {
+		if _, err := os.Stat(name); err == nil {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+// firstComposeHostPort reads the first entry that names a host port, in either
+// the short form ("8080:80", "127.0.0.1:8080:80") or the long form
+// (published: 8080). Ranges and container-only publishes are skipped: neither
+// gives a single port that can be waited on.
+func firstComposeHostPort(ports []yaml.Node) (host, port string, ok bool) {
+	for i := range ports {
+		n := &ports[i]
+		switch n.Kind {
+		case yaml.ScalarNode:
+			if h, p, found := parseShortPortSpec(n.Value); found {
+				return h, p, true
+			}
+		case yaml.MappingNode:
+			var long struct {
+				Published interface{} `yaml:"published"`
+				HostIP    string      `yaml:"host_ip"`
+			}
+			if err := n.Decode(&long); err != nil || long.Published == nil {
+				continue
+			}
+			p := strings.TrimSpace(fmt.Sprintf("%v", long.Published))
+			if p == "" || strings.ContainsAny(p, "-") {
+				continue
+			}
+			h := long.HostIP
+			if h == "" {
+				h = "127.0.0.1"
+			}
+			return h, p, true
+		}
+	}
+	return "", "", false
+}
+
+// parseShortPortSpec reads docker's short port syntax, sharing
+// dockerPublishedHostPort's rules: the host port is the second-to-last
+// colon-separated segment, and anything without one (a bare container port, so
+// a random host port) or with a range is refused.
+func parseShortPortSpec(spec string) (host, port string, ok bool) {
+	spec = strings.SplitN(strings.TrimSpace(spec), "/", 2)[0]
+	segs := strings.Split(spec, ":")
+	if len(segs) < 2 {
+		return "", "", false
+	}
+	hp := segs[len(segs)-2]
+	if hp == "" || strings.ContainsAny(hp, "-") {
+		return "", "", false
+	}
+	h := "127.0.0.1"
+	if len(segs) >= 3 && segs[0] != "" {
+		h = segs[0]
+	}
+	return h, hp, true
 }
 
 // keployReadinessProbePath is the path the reset-resend readiness probe requests.
@@ -364,6 +511,26 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 					return false
 				}
 				logger.Warn("app host port did not become ready within the ceiling; firing tests anyway (replay may see status_code got=0)",
+					zap.String("host", host),
+					zap.String("port", port),
+					zap.Duration("ceiling", ceiling),
+					zap.Error(err))
+			}
+		}
+
+		// docker-compose apps: the same gate, with the host port read from the
+		// compose file instead of the command line. Identical contract to the
+		// -p gate above — best-effort, bounded, can only ever wait longer.
+		if host, port, ok := composePublishedHostPort(cfg.Command, cfg.ContainerName); ok {
+			ceiling := cfg.Test.HealthPollTimeout
+			if ceiling <= 0 {
+				ceiling = 60 * time.Second
+			}
+			if err := pkg.WaitForPort(ctx, host, port, ceiling); err != nil {
+				if ctx.Err() != nil {
+					return false
+				}
+				logger.Warn("compose app host port did not become ready within the ceiling; firing tests anyway (replay may see status_code got=0)",
 					zap.String("host", host),
 					zap.String("port", port),
 					zap.Duration("ceiling", ceiling),


### PR DESCRIPTION
## The gap

Replay has three ways to wait for the app before firing the first test: `--health-url`, a TCP gate on a docker `-p` published port, and `test.appReadyProbeAddr`.

**A docker-compose app gets none of them by default.** `dockerPublishedHostPort` only recognises `-p`/`--publish` on the command line, and `docker compose up` carries neither — so `ok=false` and the fixed `--delay` is the entire protection.

## Why that bites, and why keploy causes it

keploy's own generated `docker-compose-tmp.yaml` holds the application behind the agent's healthcheck (`start_period: 10s`, `interval: 5s`). Under contention those probes land on the 10s tick rather than the 5s one, so the app container starts right as a `--delay 10` budget expires.

The first test window then opens while the app is still booting. Its bootstrap queries are scored against a per-test pool that has nothing in it, the dependency connection is reset, and the app exits during startup — failing every test in the set.

The diagnostic actively misleads:

```
mock mismatch: match_phase "no_mocks", candidates: 0
"No recorded mocks were available to match against ... Re-record the test set with 'keploy record'."
```

The user is sent to re-record a recording that was perfectly good.

## Reproduction

On parse-server, the lane passes **53/53 at `--delay 10`** and fails **100% at `--delay 1`** with exactly that signature — on binaries whose only difference is unrelated to this. Adding a readiness gate makes `--delay 1` pass.

This surfaced while bisecting a CI failure that *looked* like a dependency regression: the failing cells were simply the ones whose app container happened to get ~0.8s of boot budget.

## The fix

`composePublishedHostPort` reads the host port out of the compose file and feeds the same `pkg.WaitForPort` gate the `-p` path already uses.

It is deliberately as conservative as its sibling and returns `ok=false` rather than guess:

- the app's service is identified by `container_name`
- it falls back to a lone port-publishing service only when the stack is unambiguous, so **a database or cache port is never mistaken for the app**
- short (`8080:80`, `127.0.0.1:8080:80`) and long (`published: 8080`) syntax are both read
- ranges and container-only publishes are skipped — neither names a single host port to wait on
- a missing or unparseable file declines quietly

Like the gates on either side it is best-effort and bounded by `healthPollTimeout`: it can only ever wait **longer** than `--delay`, never shorter, it warns rather than fails on timeout, and a ready port returns immediately. No assertion is weakened.

## Tests

Cover `container_name` selection among several services, the lone-service fallback, explicit host IPs, long-form ports, and every case that must decline: container-only publishes, ranges, an ambiguous multi-service stack, non-compose commands, and a missing or malformed file.

Mutation-checked — dropping the `container_name` disambiguation fails the multi-service test, and accepting ranges fails the range test.