### PR TITLE
feat(proxy): stop feeding a desynced tee to parsers that cannot resync

### DIFF
--- a/pkg/agent/proxy/integrations/integrations.go
+++ b/pkg/agent/proxy/integrations/integrations.go
@@ -64,6 +64,48 @@ type IntegrationsV2 interface {
 	IsV2() bool
 }
 
+// GapResyncCapable is the optional capability interface implemented by
+// parsers that can recover a byte stream after a HOLE in capture — bytes
+// the proxy observed on the wire, forwarded to the real peer, but never
+// delivered to the parser.
+//
+// Optional by design, in the same style as agent.WindowedProxy (pkg/agent/service.go): the
+// relay type-asserts for it and falls back to the conservative answer when
+// the assertion fails, so no existing parser breaks and third-party parsers
+// keep compiling.
+//
+// # Why the relay needs to ask
+//
+// Every V2 parser frames a length-prefixed byte stream (mongo, mysql,
+// postgres all read a header, then that many bytes). A hole therefore does
+// not cost one message: the next header is read from the middle of a body,
+// so every subsequent frame on the connection is garbage. That garbage is
+// not inert — a Postgres framer once read four bytes of misread row data as
+// a uint32 length and tried to allocate multiple gigabytes. So once the tee
+// has permanently desynced, continuing to feed the parser produces no mocks
+// and can produce a pathological allocation.
+//
+// Returning true asserts that the parser DETECTS the hole (the relay stamps
+// a monotonic fakeconn.Chunk.SeqNo per direction, and a dropped chunk
+// still consumes its ordinal, so a gap is visible as a SeqNo discontinuity)
+// and re-anchors on a real message boundary before framing resumes. mongo/v2
+// is the in-tree example: resyncReassemblyOnGap → beginResync →
+// resyncToNextHeader. Such a parser MUST keep receiving bytes after the
+// hole — that is the only way it can find the next boundary — so the relay
+// keeps feeding it.
+//
+// Returning false, or not implementing this at all, means the parser has no
+// recovery path. The relay then stops feeding that direction once it has
+// desynced. Forwarding to the real peer is unaffected either way: this
+// changes only what is CAPTURED, never what the application sees.
+type GapResyncCapable interface {
+	// CanResyncAfterGap reports whether this parser re-anchors its framer
+	// after a hole in the delivered byte stream. It is consulted once per
+	// connection, before the relay starts, so it must not depend on
+	// per-connection state.
+	CanResyncAfterGap() bool
+}
+
 func Register(name IntegrationType, p *Parsers) {
 	Registered[name] = p
 }

--- a/pkg/agent/proxy/proxy_v2.go
+++ b/pkg/agent/proxy/proxy_v2.go
@@ -227,6 +227,9 @@ func (p *Proxy) recordViaSupervisor(
 		preDispatchPause = pp.WantsPreDispatchPause()
 	}
 
+	// Opt-in gap resync. See [parserCanResyncAfterGap].
+	canResyncAfterGap := parserCanResyncAfterGap(parser)
+
 	// RealCertHook wires the V2-relay upstream-TLS chokepoint into
 	// the cbshim. The post-handshake upgradeDstConn carries the real
 	// upstream cert; we publish (connID = source-port-as-string,
@@ -311,6 +314,10 @@ func (p *Proxy) recordViaSupervisor(
 		TeeChanBuf:         p.recordBufferQueueSize,
 		ConsumerStallGrace: p.recordBufferStallGrace,
 		PreDispatchPause:   preDispatchPause,
+		// Default false — see relay.Config.ParserCanResyncAfterGap for why
+		// "cannot resync" is the safe default for everything that has not
+		// explicitly claimed otherwise.
+		ParserCanResyncAfterGap: canResyncAfterGap,
 	}, srcConn, dstConn)
 
 	svSess.ClientStream = r.ClientStream()
@@ -689,4 +696,36 @@ func (p *Proxy) waitForConnDrain(ctx context.Context) {
 		p.logger.Debug("shutdown drain grace expired; remaining connections will exit via ctx cancellation")
 		return
 	}
+}
+
+// parserCanResyncAfterGap reports whether parser can re-anchor its framer
+// after a HOLE in capture — bytes the proxy observed and forwarded but never
+// delivered to the parser, because a tee dropped them.
+//
+// The relay uses the answer to decide whether to keep feeding a tee that has
+// already desynced permanently. For a parser that cannot recover, feeding it
+// is worse than useless: every subsequent length prefix is read out of the
+// middle of a body, so the connection produces no further mocks, and a
+// postgres framer that read four bytes of misread row data as a uint32 length
+// once tried to allocate multiple gigabytes. For a parser that CAN recover it
+// is mandatory — mongo/v2 finds the next message boundary by content-scanning
+// the bytes that arrive after the hole, so cutting its feed would strand it
+// desynced for the life of a pooled connection.
+//
+// Absent the capability the answer is FALSE. A parser that has never heard of
+// this mechanism is precisely the one least likely to have a resync path, so
+// omission must not be an opt-in.
+//
+// The parser is already chosen by the time recordViaSupervisor builds the
+// relay, so the answer rides in through relay.Config exactly like
+// WantsPreDispatchPause — no post-construction setter is needed, and none is
+// offered: relay's tees read the flag from their forwarder goroutines without
+// synchronisation precisely because it is fixed before Run starts them.
+//
+// Asserted against the named [integrations.GapResyncCapable] rather than an
+// anonymous interface so the contract has one documented home; the assertion
+// still keeps non-implementers compiling.
+func parserCanResyncAfterGap(parser integrations.Integrations) bool {
+	gr, ok := parser.(integrations.GapResyncCapable)
+	return ok && gr.CanResyncAfterGap()
 }

--- a/pkg/agent/proxy/proxy_v2_test.go
+++ b/pkg/agent/proxy/proxy_v2_test.go
@@ -1,10 +1,17 @@
 package proxy
 
 import (
+	"context"
+	"net"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 )
 
 // fakeOrphanSession records the open/close calls trackOrphanWhileActive makes.
@@ -169,4 +176,315 @@ func waitFor(t *testing.T, timeout time.Duration, cond func() bool) {
 		time.Sleep(time.Millisecond)
 	}
 	t.Fatalf("condition not met within %s", timeout)
+}
+
+// stubParser is the minimum that satisfies integrations.Integrations. It
+// exists so the capability probe can be tested without dragging a real
+// protocol implementation in.
+type stubParser struct{}
+
+func (stubParser) MatchType(context.Context, []byte) bool { return false }
+func (stubParser) RecordOutgoing(context.Context, *integrations.RecordSession) error {
+	return nil
+}
+func (stubParser) MockOutgoing(context.Context, net.Conn, *models.ConditionalDstCfg, integrations.MockMemDb, models.OutgoingOptions) error {
+	return nil
+}
+
+// resyncParser claims the gap-resync capability, answering with whatever it
+// was built with — so the probe is pinned to the METHOD'S ANSWER, not merely
+// to the presence of the method.
+type resyncParser struct {
+	stubParser
+	can bool
+}
+
+func (r resyncParser) CanResyncAfterGap() bool { return r.can }
+
+// TestParserCanResyncAfterGapProbe pins the discovery rule that decides
+// whether a desynced connection keeps feeding its parser.
+//
+// The stakes are asymmetric, which is why the default matters more than the
+// opt-in. Wrongly answering false for mongo/v2 costs it its recovery: it
+// re-anchors by content-scanning the bytes that arrive after the hole, so
+// with no bytes it stays desynced for the life of a pooled connection.
+// Wrongly answering true for anything else keeps a mis-framing parser fed —
+// no mocks, and in the postgres case a bogus uint32 length read out of
+// misread row data driving a multi-gigabyte allocation.
+func TestParserCanResyncAfterGapProbe(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a parser without the capability cannot resync", func(t *testing.T) {
+		t.Parallel()
+		if parserCanResyncAfterGap(stubParser{}) {
+			t.Fatal("a parser that does not implement GapResyncCapable must default to " +
+				"false: never having heard of the capability is evidence AGAINST having a " +
+				"resync path, so omission must not opt a parser in")
+		}
+	})
+
+	t.Run("a parser that claims the capability is taken at its word", func(t *testing.T) {
+		t.Parallel()
+		if !parserCanResyncAfterGap(resyncParser{can: true}) {
+			t.Fatal("a parser implementing GapResyncCapable and returning true must keep " +
+				"its feed after a desync — that is the whole point of the capability")
+		}
+	})
+
+	t.Run("the method's answer is consulted, not just its presence", func(t *testing.T) {
+		t.Parallel()
+		if parserCanResyncAfterGap(resyncParser{can: false}) {
+			t.Fatal("CanResyncAfterGap() returned false but the probe said true: the " +
+				"capability is allowed to be answered dynamically (a parser may only " +
+				"resync under some configurations), so the return value is the contract")
+		}
+	})
+
+	t.Run("a nil parser cannot resync", func(t *testing.T) {
+		t.Parallel()
+		if parserCanResyncAfterGap(nil) {
+			t.Fatal("a nil parser must take the safe default rather than panic")
+		}
+	})
+}
+
+// feedProbe is a V2 parser that does nothing but record which chunks the
+// relay actually delivered to it on the client stream. It never emits a mock
+// and never returns while the connection is alive, so the supervisor leaves
+// it alone and the only thing under test is the feed.
+type feedProbe struct {
+	stubParser
+	mu   sync.Mutex
+	got  [][]byte
+	fedC chan struct{}
+}
+
+func newFeedProbe() *feedProbe {
+	return &feedProbe{fedC: make(chan struct{}, 64)}
+}
+
+func (f *feedProbe) IsV2() bool { return true }
+
+func (f *feedProbe) RecordOutgoing(ctx context.Context, s *integrations.RecordSession) error {
+	cs := s.V2.ClientStream
+	for {
+		c, err := cs.ReadChunk()
+		if err != nil {
+			// The stream is gone (test teardown). Park until the supervised
+			// context ends so the parser never "returns early", which would
+			// retire it and muddy the signal with a fallthrough.
+			<-ctx.Done()
+			return ctx.Err()
+		}
+		f.mu.Lock()
+		f.got = append(f.got, append([]byte(nil), c.Bytes...))
+		f.mu.Unlock()
+		select {
+		case f.fedC <- struct{}{}:
+		default:
+		}
+	}
+}
+
+func (f *feedProbe) delivered() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, 0, len(f.got))
+	for _, b := range f.got {
+		out = append(out, string(b))
+	}
+	return out
+}
+
+// resyncFeedProbe is the same parser with the gap-resync capability declared,
+// standing in for mongo/v2. The ONLY difference from feedProbe is this method
+// — which is precisely the variable under test.
+type resyncFeedProbe struct{ *feedProbe }
+
+func (resyncFeedProbe) CanResyncAfterGap() bool { return true }
+
+// desyncFeedHarness runs recordViaSupervisor over real socket pairs with a
+// per-connection cap small enough that the first write blows through it, and
+// returns the probe plus a func that writes from the application side.
+type desyncFeedHarness struct {
+	probe    *feedProbe
+	writeApp func(t *testing.T, b []byte)
+	destSeen func() string
+	stop     func()
+}
+
+func newDesyncFeedHarness(t *testing.T, parser integrations.Integrations, probe *feedProbe, perConnCap int64) *desyncFeedHarness {
+	t.Helper()
+
+	clientApp, srcConn := net.Pipe()
+	dstConn, destSvc := net.Pipe()
+
+	p := &Proxy{
+		recordBufferCap:        perConnCap,
+		recordBufferQueueSize:  64,
+		recordBufferStallGrace: 2 * time.Second,
+	}
+
+	// The destination must be drained or the relay's forward Write blocks on
+	// the synchronous pipe — and then nothing reaches the tee at all, which
+	// would make every assertion below vacuous.
+	var destMu sync.Mutex
+	var destBuf []byte
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, err := destSvc.Read(buf)
+			if n > 0 {
+				destMu.Lock()
+				destBuf = append(destBuf, buf[:n]...)
+				destMu.Unlock()
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = p.recordViaSupervisor(ctx, srcConn, dstConn, parser, "test",
+			make(chan *models.Mock, 8), &errgroup.Group{}, zap.NewNop(), 1, 2,
+			models.OutgoingOptions{})
+	}()
+
+	h := &desyncFeedHarness{
+		probe: probe,
+		writeApp: func(t *testing.T, b []byte) {
+			t.Helper()
+			if _, err := clientApp.Write(b); err != nil {
+				t.Fatalf("app write %q: %v", b, err)
+			}
+		},
+		destSeen: func() string {
+			destMu.Lock()
+			defer destMu.Unlock()
+			return string(destBuf)
+		},
+	}
+	h.stop = func() {
+		cancel()
+		_ = clientApp.Close()
+		_ = destSvc.Close()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Errorf("recordViaSupervisor did not return within 5s")
+		}
+		_ = srcConn.Close()
+		_ = dstConn.Close()
+	}
+	t.Cleanup(h.stop)
+	return h
+}
+
+// waitForDelivery blocks until the probe has been handed at least n chunks,
+// or fails. Returns true if it got there.
+func waitForDelivery(probe *feedProbe, n int, budget time.Duration) bool {
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		if len(probe.delivered()) >= n {
+			return true
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	return len(probe.delivered()) >= n
+}
+
+// TestRecordViaSupervisorWiresGapResyncCapabilityIntoTheRelay closes the loop
+// that the unit tests each cover only half of.
+//
+// parserCanResyncAfterGap is tested against hand-made parsers, and the relay's
+// gate is tested against a hand-set tee field — but nothing pinned the wire
+// BETWEEN them: that recordViaSupervisor probes the real parser and puts the
+// answer on relay.Config.ParserCanResyncAfterGap. Hardcoding that field to
+// false left every other test in this change passing while mongo/v2 silently
+// lost its feed, which is the regression this whole capability exists to
+// prevent. So this drives the production entry point over real sockets and
+// asserts on what the parser actually receives.
+func TestRecordViaSupervisorWiresGapResyncCapabilityIntoTheRelay(t *testing.T) {
+	t.Parallel()
+
+	// oversized blows through the 4-byte cap, so the tee refuses it with
+	// per_conn_cap and latches the permanent desync. followUp fits with room
+	// to spare, so the ONLY thing that can withhold it is the desync gate.
+	oversized := []byte("0123456789")
+	followUp := []byte("ok")
+
+	t.Run("a parser without the capability stops being fed after the desync", func(t *testing.T) {
+		t.Parallel()
+		probe := newFeedProbe()
+		h := newDesyncFeedHarness(t, probe, probe, 4)
+
+		h.writeApp(t, oversized)
+		h.writeApp(t, followUp)
+
+		// Give the relay well past the point where a delivery would have
+		// happened; the positive control below proves this budget is ample.
+		if waitForDelivery(probe, 1, 750*time.Millisecond) {
+			t.Fatalf("parser was fed %q after the connection desynced; it would frame "+
+				"those bytes from the wrong offset, produce no mock, and can read a "+
+				"bogus multi-gigabyte length out of misread payload", probe.delivered())
+		}
+
+		// The forward path is untouched — that is the invariant that makes
+		// cutting the feed safe to ship at all.
+		waitForCondition(t, 2*time.Second, func() bool {
+			return h.destSeen() == string(oversized)+string(followUp)
+		})
+	})
+
+	t.Run("a parser that declares the capability keeps its feed", func(t *testing.T) {
+		t.Parallel()
+		probe := newFeedProbe()
+		h := newDesyncFeedHarness(t, resyncFeedProbe{probe}, probe, 4)
+
+		h.writeApp(t, oversized)
+		h.writeApp(t, followUp)
+
+		if !waitForDelivery(probe, 1, 3*time.Second) {
+			t.Fatal("a parser declaring CanResyncAfterGap must keep receiving bytes after " +
+				"a desync — the post-hole bytes are the only thing it can re-anchor on. " +
+				"If this fails, recordViaSupervisor is not putting the probe's answer on " +
+				"relay.Config.ParserCanResyncAfterGap")
+		}
+		if got := probe.delivered(); got[0] != string(followUp) {
+			t.Fatalf("parser got %q, want the post-hole chunk %q", got, followUp)
+		}
+	})
+
+	t.Run("without a desync the same parser is fed normally", func(t *testing.T) {
+		t.Parallel()
+		// The negative case above asserts an absence, which passes just as
+		// well if the harness never delivers anything. This is the control:
+		// same parser, same bytes, a cap big enough that nothing desyncs.
+		probe := newFeedProbe()
+		h := newDesyncFeedHarness(t, probe, probe, 1<<20)
+
+		h.writeApp(t, oversized)
+
+		if !waitForDelivery(probe, 1, 3*time.Second) {
+			t.Fatal("a parser with no desync must be fed: the harness itself is broken " +
+				"if this fails, and the negative case above proves nothing")
+		}
+	})
+}
+
+// waitForCondition polls cond until it holds or the budget expires.
+func waitForCondition(t *testing.T, budget time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for condition")
 }

--- a/pkg/agent/proxy/relay/config.go
+++ b/pkg/agent/proxy/relay/config.go
@@ -262,6 +262,44 @@ type Config struct {
 	// ResumePreDispatch on entry — recordViaSupervisor only sets
 	// this when the parser implements an opt-in capability method.
 	PreDispatchPause bool
+
+	// ParserCanResyncAfterGap tells the tees whether the parser on the other
+	// end can re-anchor its framer after a HOLE in capture. Set by the
+	// dispatcher from the parser's optional
+	// [integrations.GapResyncCapable] capability.
+	//
+	// The default is FALSE, and that is the load-bearing choice.
+	//
+	// When a tee desyncs — a chunk lost to [DropPerConnCap] or
+	// [DropMemoryPressure] — the connection's captured byte stream has a
+	// hole in it. The tee already says so in its own words: it logs "capture
+	// desynced; this connection can no longer be recorded" and fires
+	// [Config.OnCaptureDesync] so the owner can suppress the test cases
+	// recorded over the hole. Until now it then kept pushing anyway, and a
+	// length-prefix framer reading from the wrong offset does not merely
+	// produce nothing: postgres read four bytes of misread row data as a
+	// uint32 length and attempted a multi-gigabyte allocation.
+	//
+	// So false stops the feed for every parser that has not claimed
+	// otherwise. Yes, that changes today's behaviour for every non-mongo
+	// parser — deliberately. What it gives up is the theoretical chance that
+	// a parser recovers by luck; what those parsers actually produce after a
+	// hole is garbage frames, and the honest accounting is that this
+	// connection's recording ended when the tee said it did. Defaulting the
+	// other way would mean a parser has to know about this mechanism to be
+	// protected by it, which inverts the safety: a third-party parser that
+	// never heard of the capability is precisely the one least likely to
+	// have a resync path.
+	//
+	// True is for parsers that genuinely re-anchor and therefore NEED the
+	// post-hole bytes to do it — mongo/v2 detects the SeqNo discontinuity
+	// and content-scans for the next validated message header. Cutting its
+	// feed would strand it desynced forever, which is a regression, not a
+	// fix.
+	//
+	// Either way the FORWARD path is untouched: the relay writes every byte
+	// to the real peer before it ever offers the chunk to a tee.
+	ParserCanResyncAfterGap bool
 }
 
 // withDefaults returns a copy of cfg with zero-valued optional fields

--- a/pkg/agent/proxy/relay/relay.go
+++ b/pkg/agent/proxy/relay/relay.go
@@ -177,6 +177,12 @@ func New(cfg Config, src, dst net.Conn) *Relay {
 	r.teeC2D.onDesync = cfg.OnCaptureDesync
 	r.teeD2C.onDesync = cfg.OnCaptureDesync
 
+	// Whether a desynced tee keeps feeding its parser. Assigned here, before
+	// Run spawns any forwarder, so push can read it without synchronisation.
+	// See [Config.ParserCanResyncAfterGap] for why the default is "cannot".
+	r.teeC2D.parserCanResync = cfg.ParserCanResyncAfterGap
+	r.teeD2C.parserCanResync = cfg.ParserCanResyncAfterGap
+
 	var localAddr, remoteAddr net.Addr
 	if src != nil {
 		localAddr = src.LocalAddr()

--- a/pkg/agent/proxy/relay/relay_test.go
+++ b/pkg/agent/proxy/relay/relay_test.go
@@ -1111,3 +1111,120 @@ func TestDirectiveUpgradeTLS_PreDispatch_FlushesC2DStashBeforePreambleRead(t *te
 		t.Fatalf("no UpgradeTLS ack — handler hung (likely a regression: C2D stash not flushed before preamble read)")
 	}
 }
+
+// waitForCond polls cond until it holds or the budget expires. Used where the
+// observable effect is produced by the forwarder goroutine, so there is no
+// synchronisation point the test can join on.
+func waitForCond(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// TestDesyncedRelayKeepsForwardingButStopsCapturing is the invariant that makes
+// the whole gate safe to ship: cutting a desynced parser's feed changes what is
+// CAPTURED and nothing else. The application's bytes still cross the proxy,
+// unchanged and in order, after capture has stopped.
+//
+// That holds by construction — the forwarder writes the payload to the real
+// peer BEFORE it ever offers the chunk to a tee, so push's verdict cannot
+// reach the wire — but "by construction" is exactly the kind of claim that
+// quietly stops being true, so it is pinned end to end through real sockets.
+func TestDesyncedRelayKeepsForwardingButStopsCapturing(t *testing.T) {
+	t.Parallel()
+	drops := newDropSink()
+
+	h := newHarness(t, Config{
+		// Small enough that the first client write blows straight through it.
+		PerConnCap:           4,
+		TeeChanBuf:           64,
+		OnMarkMockIncomplete: drops.record,
+		// ParserCanResyncAfterGap left false: the default, and what every
+		// parser but mongo/v2 gets.
+	})
+
+	// Round 1 — the loss. Oversized for the cap, so the tee drops it and
+	// latches the desync. The destination must still receive every byte.
+	first := []byte("0123456789")
+	go h.writeClient(first)
+	if got := h.readDest(len(first)); string(got) != string(first) {
+		t.Fatalf("dest got %q, want %q: a tee drop must never touch the forward path",
+			got, first)
+	}
+	waitForCond(t, "the c2d tee to latch its desync", h.r.teeC2D.desynced.Load)
+	if drops.count(DropPerConnCap) == 0 {
+		t.Fatalf("expected a %s drop, got %v", DropPerConnCap, drops.snapshot())
+	}
+
+	// Round 2 — after the desync. Two bytes fit the 4-byte cap with room to
+	// spare and the queue is empty, so the ONLY thing that can refuse this
+	// chunk is the desync gate.
+	second := []byte("ok")
+	go h.writeClient(second)
+	if got := h.readDest(len(second)); string(got) != string(second) {
+		t.Fatalf("dest got %q, want %q: the application must keep seeing its own "+
+			"traffic long after keploy has given up recording the connection", got, second)
+	}
+	waitForCond(t, "the post-desync chunk to be refused", func() bool {
+		return drops.count(DropDesynced) > 0
+	})
+
+	// And the parser was fed nothing at all — not the lost chunk (it never
+	// had it) and not the one after it (it could only mis-frame it).
+	_ = h.r.ClientStream().SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+	if c, err := h.r.ClientStream().ReadChunk(); err == nil {
+		t.Fatalf("ClientStream delivered %q after the connection desynced; the parser "+
+			"would frame it from the wrong offset, read a length prefix out of the middle "+
+			"of a body, and emit nothing but garbage", c.Bytes)
+	}
+}
+
+// TestDesyncedRelayKeepsFeedingAResyncCapableParser is the other half, and the
+// reason the gate is a capability rather than a blanket stop.
+//
+// mongo/v2 recovers from a hole by content-scanning the bytes that arrive
+// AFTER it for a chain-validated message header. Those bytes are the only
+// evidence it has. Cutting its feed at the desync would leave it resyncing
+// forever on a pooled connection — a regression of the fix that the resync
+// machinery is.
+func TestDesyncedRelayKeepsFeedingAResyncCapableParser(t *testing.T) {
+	t.Parallel()
+	drops := newDropSink()
+
+	h := newHarness(t, Config{
+		PerConnCap:              4,
+		TeeChanBuf:              64,
+		OnMarkMockIncomplete:    drops.record,
+		ParserCanResyncAfterGap: true,
+	})
+
+	first := []byte("0123456789")
+	go h.writeClient(first)
+	_ = h.readDest(len(first))
+	waitForCond(t, "the c2d tee to latch its desync", h.r.teeC2D.desynced.Load)
+
+	second := []byte("ok")
+	go h.writeClient(second)
+	_ = h.readDest(len(second))
+
+	_ = h.r.ClientStream().SetReadDeadline(time.Now().Add(2 * time.Second))
+	c, err := h.r.ClientStream().ReadChunk()
+	if err != nil {
+		t.Fatalf("ReadChunk after desync: %v — a resync-capable parser must keep "+
+			"receiving, because the post-hole bytes are the only thing it can re-anchor on",
+			err)
+	}
+	if string(c.Bytes) != string(second) {
+		t.Fatalf("parser got %q, want %q", c.Bytes, second)
+	}
+	if got := drops.count(DropDesynced); got != 0 {
+		t.Fatalf("%s drops = %d, want 0 for a resync-capable parser; reasons=%v",
+			DropDesynced, got, drops.snapshot())
+	}
+}

--- a/pkg/agent/proxy/relay/tee.go
+++ b/pkg/agent/proxy/relay/tee.go
@@ -68,6 +68,28 @@ const (
 	// so a lost tail is visible the way a BPF ring buffer's lost-sample
 	// count is.
 	DropConsumerGone = "consumer_gone"
+
+	// DropDesynced — the tee had already desynced permanently (see
+	// [isDesyncingDrop]) and the parser on the other end cannot re-anchor
+	// its framer after a hole, so there is nothing left worth delivering.
+	//
+	// This is a CONSEQUENCE reason, not a cause: the loss that mattered was
+	// reported once as [DropPerConnCap] or [DropMemoryPressure], and
+	// [tee.onDesync] already fired for it. Everything after that would be
+	// framed from the wrong offset — a length header read out of the middle
+	// of a body — which yields no mocks and, in the postgres case that
+	// motivated this, an attempted multi-gigabyte allocation from four bytes
+	// of misread row data. So the chunk is refused instead of admitted.
+	//
+	// Deliberately NOT part of [isDesyncingDrop]: treating it as a desync
+	// would re-enter the very branch that produced it. The desync latch is
+	// one-shot so onDesync could not double-fire, but excluding it keeps the
+	// predicate honest — this reason reports a connection that is ALREADY
+	// desynced, it never establishes one.
+	//
+	// The forward path is untouched. A chunk refused here has already been
+	// written to the real peer; only capture stops.
+	DropDesynced = "desynced"
 )
 
 // tee is the accounting buffer between the forwarder goroutines and the
@@ -121,7 +143,22 @@ type tee struct {
 	// mock-less for replay to fail on.
 	onDesync func(reason string)
 	// desynced makes onDesync and its log fire once, not once per chunk.
+	// It is also the latch push consults for [DropDesynced]: it is set for
+	// good on the first desyncing drop and never cleared, which is exactly
+	// right — the stream position is lost permanently, so there is no event
+	// that could legitimately clear it.
 	desynced atomic.Bool
+
+	// parserCanResync records whether the parser consuming this tee can
+	// re-anchor its framer after a hole (integrations.GapResyncCapable).
+	// Set by [New] from [Config.ParserCanResyncAfterGap]; the zero value is
+	// the SAFE one — "cannot resync" — so a tee built without the answer
+	// stops feeding rather than feeding garbage.
+	//
+	// Read-only after construction, so a plain bool rather than an atomic:
+	// [New] sets it before the forwarder goroutines that call push exist,
+	// and the relay never changes it mid-connection.
+	parserCanResync bool
 
 	// mu guards q, qBytes and closed. It is never held across a send on
 	// out, so a stalled consumer cannot block push.
@@ -232,6 +269,12 @@ func (t *tee) setPaused(p bool) { t.paused.Store(p) }
 // the forwarder — it can only fill the queue until the per-connection cap
 // refuses further chunks.
 //
+// push also refuses a chunk once the tee has DESYNCED permanently and the
+// parser cannot re-anchor after a hole — reason [DropDesynced]. This changes
+// only what is captured: the forwarder has already written the payload to
+// the real peer by the time it calls push, so the application sees the same
+// bytes at the same time either way.
+//
 // Once the tee has been closed push silently returns false without
 // invoking onDrop: the mock is already abandoned at that point, so
 // additional "drop" notifications would just add noise. The same applies
@@ -247,6 +290,23 @@ func (t *tee) push(c fakeconn.Chunk) bool {
 	}
 	if t.paused.Load() {
 		t.drop(DropPaused)
+		return false
+	}
+	// Permanently desynced AND the parser has no way back. Refuse.
+	//
+	// Ordered AFTER the pause check so a paused tee keeps reporting
+	// DropPaused exactly as before — a pause is requested, and the
+	// SessionOnAbort path depends on that cheap reason — and BEFORE the
+	// memory and cap checks so the remainder of a dead connection is
+	// attributed to the desync that killed it instead of re-reporting
+	// per_conn_cap / memory_pressure for every later chunk.
+	//
+	// The check is per DIRECTION, because a tee is: a hole in C2D corrupts
+	// only the request framer, and the response direction of the same
+	// connection may still be framing perfectly. Gating both on either
+	// would throw away capture that is still good.
+	if !t.parserCanResync && t.desynced.Load() {
+		t.drop(DropDesynced)
 		return false
 	}
 	if t.memCheck != nil && t.memCheck() {
@@ -296,6 +356,8 @@ func (t *tee) push(c fakeconn.Chunk) bool {
 // need", not "was a mock affected". [DropPerConnCap] and
 // [DropMemoryPressure] are both unilateral: the parser is mid-stream and
 // simply never receives those bytes. [DropPaused] is not — see the caller.
+// Nor is [DropDesynced]: that one is emitted BECAUSE the tee is already
+// desynced, so counting it here would make the predicate self-feeding.
 func isDesyncingDrop(reason string) bool {
 	return reason == DropPerConnCap || reason == DropMemoryPressure
 }

--- a/pkg/agent/proxy/relay/tee_test.go
+++ b/pkg/agent/proxy/relay/tee_test.go
@@ -853,3 +853,218 @@ func TestAnUnintendedDropReportsCaptureDesync(t *testing.T) {
 		}
 	})
 }
+
+// TestTee_DesyncedTeeStopsFeedingAParserThatCannotResync pins the gate that
+// this whole capability exists for.
+//
+// Before it, push never consulted t.desynced. So a tee that had already
+// logged "capture desynced; this connection can no longer be recorded" kept
+// admitting chunks and handing them to a parser framing from the wrong
+// offset. That is not a quiet waste: the parser reads whatever four bytes now
+// sit at the head as a length prefix, and a postgres framer that read them
+// out of misread row data tried to allocate multiple gigabytes.
+//
+// The gate is conditional, not blanket. mongo/v2 is BUILT to recover from a
+// hole — it sees the SeqNo discontinuity, discards the un-completable partial
+// and content-scans for the next chain-validated header — and it can only do
+// that from the bytes that arrive AFTER the hole. Cutting its feed would
+// strand it desynced for the life of a pooled connection, which is the exact
+// bug the resync machinery was written to fix.
+func TestTee_DesyncedTeeStopsFeedingAParserThatCannotResync(t *testing.T) {
+	t.Parallel()
+
+	// desyncByCap drives a tee into the permanent desynced state through the
+	// per-connection cap and returns it with 4 of its 8 bytes still occupied,
+	// so a following small chunk WOULD fit if the gate were not there.
+	// Drain is deliberately not started: a delivered chunk releases its bytes,
+	// which would make the residual occupancy racy.
+	desyncByCap := func(t *testing.T, canResync bool) (*tee, *dropRecorder, *int) {
+		t.Helper()
+		rec := &dropRecorder{}
+		desyncs := 0
+		tt := newTee(fakeconn.FromClient, 8, 4, testStallGrace, nil, rec.record, nil)
+		tt.parserCanResync = canResync
+		tt.onDesync = func(string) { desyncs++ }
+		t.Cleanup(tt.close)
+
+		if !tt.push(mkChunk("abcd")) {
+			t.Fatal("first push should have fit under the cap")
+		}
+		if tt.push(mkChunk("far too long for this cap")) {
+			t.Fatal("oversized push should have been refused by the cap")
+		}
+		if !tt.desynced.Load() {
+			t.Fatal("a per_conn_cap drop must have latched the desync")
+		}
+		return tt, rec, &desyncs
+	}
+
+	t.Run("a parser that cannot resync is cut off after the desync", func(t *testing.T) {
+		t.Parallel()
+		tt, rec, desyncs := desyncByCap(t, false)
+
+		// "x" fits: 4 queued + 1 <= cap of 8. The ONLY reason to refuse it is
+		// that the stream position is already lost.
+		if tt.push(mkChunk("x")) {
+			t.Fatal("push after a permanent desync must be refused: the parser would " +
+				"frame this chunk from the wrong offset, which yields no mock and can " +
+				"turn misread payload into a bogus multi-gigabyte length")
+		}
+		if got := rec.count(DropDesynced); got != 1 {
+			t.Fatalf("%s drops = %d, want 1; reasons=%v", DropDesynced, got, rec.snapshot())
+		}
+		// The cause was already reported once. Re-reporting it per chunk would
+		// blame the cap for the whole rest of the connection.
+		if got := rec.count(DropPerConnCap); got != 1 {
+			t.Fatalf("%s drops = %d, want exactly 1 (the original loss); reasons=%v",
+				DropPerConnCap, got, rec.snapshot())
+		}
+		if *desyncs != 1 {
+			t.Fatalf("onDesync fired %d times, want 1: %s reports a connection that is "+
+				"ALREADY desynced, so it must not re-enter the branch that produced it",
+				*desyncs, DropDesynced)
+		}
+	})
+
+	t.Run("a resync-capable parser keeps its feed after the desync", func(t *testing.T) {
+		t.Parallel()
+		tt, rec, _ := desyncByCap(t, true)
+
+		if !tt.push(mkChunk("x")) {
+			t.Fatal("a parser that re-anchors after a hole must keep receiving bytes — " +
+				"the post-hole bytes are the only thing it can resync ON. Cutting mongo/v2's " +
+				"feed here would strand it desynced for the life of a pooled connection")
+		}
+		if got := rec.count(DropDesynced); got != 0 {
+			t.Fatalf("%s drops = %d, want 0 for a resync-capable parser; reasons=%v",
+				DropDesynced, got, rec.snapshot())
+		}
+	})
+
+	t.Run("the gate keys off the desync latch, not off any drop", func(t *testing.T) {
+		t.Parallel()
+		rec := &dropRecorder{}
+		tt := newTee(fakeconn.FromClient, 1<<20, 4, testStallGrace, nil, rec.record, nil)
+		// Default: cannot resync. A pause must still not engage the gate.
+		t.Cleanup(tt.close)
+
+		tt.setPaused(true)
+		if tt.push(mkChunk("held")) {
+			t.Fatal("push while paused should have dropped")
+		}
+		tt.setPaused(false)
+		if !tt.push(mkChunk("resumed")) {
+			t.Fatal("a pause is requested, not a loss: it never desyncs the stream, so " +
+				"capture must resume the moment the pause lifts")
+		}
+		if got := rec.count(DropDesynced); got != 0 {
+			t.Fatalf("%s drops = %d, want 0 — a paused drop is not a hole", DropDesynced, got)
+		}
+	})
+
+	t.Run("a pause on an already-desynced tee still reports paused", func(t *testing.T) {
+		t.Parallel()
+		tt, rec, _ := desyncByCap(t, false)
+
+		tt.setPaused(true)
+		if tt.push(mkChunk("y")) {
+			t.Fatal("push while paused should have dropped")
+		}
+		// SessionOnAbort pauses precisely so teardown chunks take the cheap
+		// reason; the ordering in push must preserve that.
+		if got := rec.count(DropPaused); got != 1 {
+			t.Fatalf("%s drops = %d, want 1; reasons=%v", DropPaused, got, rec.snapshot())
+		}
+	})
+
+	t.Run("the desync reason outranks memory pressure and the cap", func(t *testing.T) {
+		t.Parallel()
+		// A dead connection's remaining chunks must be attributed to the
+		// desync that killed it, not re-reported as memory_pressure /
+		// per_conn_cap once per chunk for the rest of its life. Those two
+		// reasons name a CAUSE the operator can act on ("raise
+		// maxMemoryPerConnection"); repeating them after the stream position
+		// is already lost sends the operator after a knob that would not have
+		// saved this connection.
+		//
+		// Pinning it needs a chunk that BOTH later checks would also refuse,
+		// which is why pressure is switched on and the chunk is oversized.
+		rec := &dropRecorder{}
+		var pressure atomic.Bool
+		tt := newTee(fakeconn.FromClient, 8, 4, testStallGrace, pressure.Load, rec.record, nil)
+		t.Cleanup(tt.close)
+
+		if !tt.push(mkChunk("abcd")) {
+			t.Fatal("first push should have fit under the cap")
+		}
+		if tt.push(mkChunk("far too long for this cap")) {
+			t.Fatal("oversized push should have been refused by the cap")
+		}
+		if !tt.desynced.Load() {
+			t.Fatal("a per_conn_cap drop must have latched the desync")
+		}
+
+		pressure.Store(true)
+		if tt.push(mkChunk("also far too long for this cap")) {
+			t.Fatal("push after a permanent desync must be refused")
+		}
+		if got := rec.count(DropDesynced); got != 1 {
+			t.Fatalf("%s drops = %d, want 1 — the gate must run BEFORE the memory and "+
+				"cap checks; reasons=%v", DropDesynced, got, rec.snapshot())
+		}
+		if got := rec.count(DropMemoryPressure); got != 0 {
+			t.Fatalf("%s drops = %d, want 0: memory pressure did not cost this chunk, the "+
+				"already-lost stream position did; reasons=%v",
+				DropMemoryPressure, got, rec.snapshot())
+		}
+		if got := rec.count(DropPerConnCap); got != 1 {
+			t.Fatalf("%s drops = %d, want exactly 1 (the original loss); re-reporting the "+
+				"cap for every later chunk points the operator at a knob that would not "+
+				"have saved this connection; reasons=%v",
+				DropPerConnCap, got, rec.snapshot())
+		}
+	})
+
+	t.Run("the desynced reason is not itself a desyncing drop", func(t *testing.T) {
+		t.Parallel()
+		if isDesyncingDrop(DropDesynced) {
+			t.Fatalf("isDesyncingDrop(%q) = true; it must be false or the predicate feeds "+
+				"itself: the reason is emitted BECAUSE the tee already desynced", DropDesynced)
+		}
+	})
+}
+
+// TestNewWiresParserCanResyncIntoBothTees pins the plumbing from Config to
+// both directions.
+//
+// Both, because a parser's ability to re-anchor is a property of the PARSER,
+// not of a direction — while the desync latch that the flag gates is
+// per-direction, since a hole in the request stream says nothing about the
+// response framer. Wiring only one tee would leave the other silently on the
+// default.
+func TestNewWiresParserCanResyncIntoBothTees(t *testing.T) {
+	t.Parallel()
+
+	clientApp, srcProxy := net.Pipe()
+	dstProxy, destSvc := net.Pipe()
+	t.Cleanup(func() {
+		_ = clientApp.Close()
+		_ = srcProxy.Close()
+		_ = dstProxy.Close()
+		_ = destSvc.Close()
+	})
+
+	def := New(Config{Logger: zap.NewNop()}, srcProxy, dstProxy)
+	if def.teeC2D.parserCanResync || def.teeD2C.parserCanResync {
+		t.Fatalf("default parserCanResync = (c2d=%v, d2c=%v), want both false: a parser that "+
+			"never heard of the capability is the one least likely to have a resync path, "+
+			"so it must not be opted in by omission",
+			def.teeC2D.parserCanResync, def.teeD2C.parserCanResync)
+	}
+
+	on := New(Config{Logger: zap.NewNop(), ParserCanResyncAfterGap: true}, srcProxy, dstProxy)
+	if !on.teeC2D.parserCanResync || !on.teeD2C.parserCanResync {
+		t.Fatalf("with ParserCanResyncAfterGap=true, got (c2d=%v, d2c=%v), want both true",
+			on.teeC2D.parserCanResync, on.teeD2C.parserCanResync)
+	}
+}


### PR DESCRIPTION
## The contradiction

When a tee drops a chunk for `per_conn_cap` or `memory_pressure`, it punches a hole in the *captured* stream while the real bytes keep flowing to the peer. The tee already says exactly what that means:

> `relay: capture desynced; this connection can no longer be recorded`

and already fires `OnCaptureDesync` so the overlapping test cases get suppressed rather than shipped mock-less. Then `push` kept admitting chunks anyway — the code contradicting its own log line.

Feeding a length-delimited framer from the wrong offset produces no mocks, because every subsequent header is read out of the middle of a body. And it is not merely useless: **postgres read four bytes of misread row data as a uint32 length and tried to allocate multiple gigabytes**, taking the agent from 150 MiB to 1.49 GB in four seconds and OOM-killing the app sharing the box. keploy/integrations#261 capped that allocation; this removes the garbage that provoked it.

## Why not just stop pushing

`mongo/v2` is built to recover from a hole. `resyncReassemblyOnGap` detects the chunk-sequence discontinuity, `beginResync` discards the un-completable partial, and `resyncToNextHeader` content-scans the **post-hole** bytes for a boundary, accepting only on chained validation. Those bytes are its only evidence — cutting its feed would strand it.

So the parser declares the capability, through an optional interface discovered by type assertion, the same duck-typing already used for `WantsPreDispatchPause`:

```go
integrations.GapResyncCapable interface { CanResyncAfterGap() bool }
```

## Design notes

**No setter, and that's load-bearing.** The parser is already resolved before the relay is built (`MatchType` runs, then `recordViaSupervisor`), so the answer rides in on `relay.Config`. The tees read the flag unsynchronised from the forwarder goroutines, which is sound *only* because it is fixed before `Run` spawns them — a setter would quietly turn that into a data race.

**The zero value is "cannot resync", deliberately.** A parser that cannot re-anchor produces nothing either way, so stopping costs nothing while continuing costs an unbounded allocation. More importantly: if omission meant "can resync", a parser would have to *know about this mechanism* to be protected by it — and a third-party parser that has never heard of `GapResyncCapable` is precisely the one least likely to have a resync path. That inverts the safety.

Enterprise's couchbase reassembler reached the same conclusion independently — its `Next()` doc says a length-delimited binary protocol cannot be safely resynchronised by scanning for a magic byte, and it hard-stops on desync.

**Gate placement.** After the pause check (a pause is *requested*, and must keep reporting `DropPaused`), before the memory and cap checks — attributing the remainder of a dead connection to the desync that killed it beats re-reporting `per_conn_cap` and pointing an operator at a buffer knob that would not have saved it.

**Per direction.** The latch lives on the tee, so a hole in one direction does not cut the other's feed.

**`DropDesynced` is excluded from `isDesyncingDrop`** — it reports a connection that is already desynced and never establishes one.

**The forward path is untouched.** A refused chunk has already been written to the peer; only capture stops.

## Tests

The wiring is pinned end to end over real socket pairs: hardcoding `ParserCanResyncAfterGap` to either `true` or `false` fails `TestRecordViaSupervisorWiresGapResyncCapabilityIntoTheRelay`. That wire was completely untested when first written, which is why it now has its own test. Two ordering mutations in `push` are covered as well.

## Merge order

keploy first, then integrations — but loosely. integrations depends on keploy, not the reverse, and mongo declares `CanResyncAfterGap()` as a plain method rather than via embedding or a compile-time interface assertion, so the integrations side compiles against its current released pin with no bump. The capability simply has no effect until this ships. There is no window where either repo fails to build.