### PR TITLE
fix(cli): exit non-zero for every failed command, not just unknown ones

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"runtime"
@@ -233,11 +234,7 @@ func start(ctx context.Context) {
 	cmdConfigurator := provider.NewCmdConfigurator(logger, conf)
 	rootCmd := cli.Root(ctx, logger, svcProvider, cmdConfigurator)
 	if err := rootCmd.Execute(); err != nil {
-		if strings.HasPrefix(err.Error(), "unknown command") || strings.HasPrefix(err.Error(), "unknown shorthand") {
-			fmt.Println("Error: ", err.Error())
-			fmt.Println("Run 'keploy --help' for usage.")
-			os.Exit(1)
-		}
+		utils.ErrCode = exitCodeForCmdErr(err, os.Stderr)
 	}
 
 	// Restore keploy folder ownership if running under sudo (for Docker mode)
@@ -359,4 +356,26 @@ func printEnterpriseUpgradeBanner() {
 	fmt.Fprintln(os.Stderr, "  "+dim+"Install:"+reset+"  "+bold+"curl --silent -O -L https://keploy.io/ent/install.sh && source install.sh"+reset)
 	fmt.Fprintln(os.Stderr, orange+bar+reset)
 	fmt.Fprintln(os.Stderr)
+}
+
+// exitCodeForCmdErr maps an error returned by the root command onto the
+// process exit code, writing the unknown-command hint to w when that is what
+// went wrong.
+//
+// Any non-nil error means the command did not run successfully, so the
+// process must not report success. This used to convert only "unknown
+// command" and "unknown shorthand" into a non-zero exit; every other error
+// fell through with utils.ErrCode still 0. That silently exited 0 for all
+// flag-parsing errors - CmdConfigurator.AddFlags sets SilenceErrors and
+// prints them through SetFlagErrorFunc, so `keploy test --typo` showed a red
+// error message and still reported success to the shell and to CI.
+func exitCodeForCmdErr(err error, w io.Writer) int {
+	if err == nil {
+		return 0
+	}
+	if strings.HasPrefix(err.Error(), "unknown command") || strings.HasPrefix(err.Error(), "unknown shorthand") {
+		fmt.Fprintln(w, "Error: ", err.Error())
+		fmt.Fprintln(w, "Run 'keploy --help' for usage.")
+	}
+	return 1
 }

--- a/main_exitcode_test.go
+++ b/main_exitcode_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestExitCodeForCmdErr pins the CLI's exit-code contract: any error out of
+// rootCmd.Execute() has to produce a non-zero exit. Before this was
+// centralised, only "unknown command"/"unknown shorthand" did, so every
+// flag-parsing error left utils.ErrCode at 0 and `keploy test --typo`
+// reported success to the shell and to CI while printing a red error.
+func TestExitCodeForCmdErr(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantCode int
+		wantHint bool
+	}{
+		{
+			name:     "success",
+			err:      nil,
+			wantCode: 0,
+		},
+		{
+			name:     "unknown command still exits non-zero and hints",
+			err:      errors.New(`unknown command "recrd" for "keploy"`),
+			wantCode: 1,
+			wantHint: true,
+		},
+		{
+			name:     "unknown shorthand still exits non-zero and hints",
+			err:      errors.New(`unknown shorthand flag: 'z' in -z`),
+			wantCode: 1,
+			wantHint: true,
+		},
+		{
+			name:     "unknown flag exits non-zero",
+			err:      errors.New(`unknown flag: --nope`),
+			wantCode: 1,
+		},
+		{
+			name:     "invalid flag value exits non-zero",
+			err:      errors.New(`invalid argument "abc" for "--delay" flag: strconv.ParseUint: parsing "abc": invalid syntax`),
+			wantCode: 1,
+		},
+		{
+			name:     "arbitrary command failure exits non-zero",
+			err:      errors.New("failed to record: something went wrong"),
+			wantCode: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			got := exitCodeForCmdErr(tt.err, &out)
+			if got != tt.wantCode {
+				t.Errorf("exit code = %d, want %d", got, tt.wantCode)
+			}
+			hinted := strings.Contains(out.String(), "Run 'keploy --help' for usage.")
+			if hinted != tt.wantHint {
+				t.Errorf("usage hint printed = %v, want %v (output: %q)", hinted, tt.wantHint, out.String())
+			}
+		})
+	}
+}

--- a/main_exitcode_wiring_test.go
+++ b/main_exitcode_wiring_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"testing"
+
+	"go.keploy.io/server/v3/utils"
+)
+
+// subprocessEnv makes TestMain run the real CLI instead of the test suite, so
+// the tests below observe genuine process exit codes. Testing the helper in
+// isolation is not enough: the bug this guards against was the helper's result
+// never being assigned to utils.ErrCode, which a pure unit test cannot see.
+const subprocessEnv = "KEPLOY_EXITCODE_TEST_SUBPROCESS"
+
+func TestMain(m *testing.M) {
+	if os.Getenv(subprocessEnv) == "1" {
+		setVersion()
+		start(utils.NewCtx())
+		os.Exit(utils.ErrCode)
+	}
+	os.Exit(m.Run())
+}
+
+// runCLI re-executes this test binary as the keploy CLI with the given
+// arguments, in a scratch working directory, and returns the exit code.
+func runCLI(t *testing.T, args ...string) int {
+	t.Helper()
+
+	cmd := exec.Command(os.Args[0])
+	cmd.Args = append([]string{"keploy"}, args...)
+	cmd.Env = append(os.Environ(), subprocessEnv+"=1")
+	cmd.Dir = t.TempDir()
+
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return exitErr.ExitCode()
+		}
+		t.Fatalf("running %v: %v", args, err)
+	}
+	return 0
+}
+
+func TestCLIExitCodes(t *testing.T) {
+	// Startup does more than parse flags - it reads/creates the installation
+	// id, for one - and none of that is under test here. If the happy path
+	// cannot even reach exit 0 the environment is broken, and asserting the
+	// failure cases would only produce a misleading red.
+	if code := runCLI(t, "--help"); code != 0 {
+		t.Skipf("keploy --help exited %d; CLI startup is unusable in this environment", code)
+	}
+
+	tests := []struct {
+		name string
+		args []string
+		want int
+	}{
+		{name: "root help", args: []string{"--help"}, want: 0},
+		{name: "subcommand help", args: []string{"test", "--help"}, want: 0},
+		{name: "version flag", args: []string{"--version"}, want: 0},
+		{name: "unknown command", args: []string{"bogus-cmd"}, want: 1},
+		{name: "unknown flag", args: []string{"test", "--nope"}, want: 1},
+		{name: "invalid flag value", args: []string{"test", "--delay", "abc"}, want: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := runCLI(t, tt.args...); got != tt.want {
+				t.Errorf("keploy %v exit code = %d, want %d", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCLICleansUpLogFileOnUnknownCommand pins the other half of routing errors
+// through utils.ErrCode rather than os.Exit(1): the deferred cleanup in start()
+// now actually runs, so a failed invocation no longer strands a keploy-logs.txt
+// in the user's working directory.
+func TestCLICleansUpLogFileOnUnknownCommand(t *testing.T) {
+	if code := runCLI(t, "--help"); code != 0 {
+		t.Skipf("keploy --help exited %d; CLI startup is unusable in this environment", code)
+	}
+
+	dir := t.TempDir()
+	cmd := exec.Command(os.Args[0])
+	cmd.Args = []string{"keploy", "bogus-cmd"}
+	cmd.Env = append(os.Environ(), subprocessEnv+"=1")
+	cmd.Dir = dir
+	_ = cmd.Run()
+
+	if _, err := os.Stat(dir + "/keploy-logs.txt"); !os.IsNotExist(err) {
+		t.Errorf("keploy-logs.txt left behind after a failed command (stat err: %v)", err)
+	}
+}

--- a/utils/askconfirmation_test.go
+++ b/utils/askconfirmation_test.go
@@ -1,0 +1,39 @@
+package utils
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+// TestAskForConfirmation_NonInteractiveStdinDeclines covers the documented
+// contract that an unrecognised or interrupted answer degrades to "no". A
+// closed / non-TTY stdin yields io.EOF, which used to be returned as an error
+// and surfaced as a non-zero exit for callers like `keploy config --generate`
+// running in a Dockerfile, CI step or cron job.
+func TestAskForConfirmation_NonInteractiveStdinDeclines(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	// Closing the write end immediately makes every read return io.EOF, which
+	// is what a closed or redirected-from-/dev/null stdin looks like.
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close pipe writer: %v", err)
+	}
+
+	orig := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = orig
+		_ = r.Close()
+	})
+
+	override, err := AskForConfirmation(context.Background(), "Config file already exists. Do you want to override it?")
+	if err != nil {
+		t.Fatalf("AskForConfirmation returned error %v, want nil on EOF", err)
+	}
+	if override {
+		t.Error("AskForConfirmation returned true on EOF, want false (decline)")
+	}
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -386,6 +386,13 @@ func AskForConfirmation(ctx context.Context, s string) (bool, error) {
 		// Cobra caught SIGINT (Ctrl+C) and cancelled its root context
 		return false, nil
 	case err := <-errCh:
+		// A closed / non-TTY stdin (io.EOF) is not a failure: there is simply
+		// nobody to answer. Decline, exactly as the ctx.Done() branch above
+		// does for Ctrl+C, so non-interactive callers get the safe default
+		// instead of a hard error.
+		if errors.Is(err, io.EOF) {
+			return false, nil
+		}
 		return false, err
 	case response := <-respCh:
 		response = strings.ToLower(strings.TrimSpace(response))


### PR DESCRIPTION
## Describe the changes that are made

`main()` is `start(ctx)` then `os.Exit(utils.ErrCode)`, and `ErrCode` defaults to `0`. `start()` only turned an error out of `rootCmd.Execute()` into a non-zero exit when the message began with `"unknown command"` or `"unknown shorthand"` — every other error fell through with `ErrCode` still `0`.

That covers **all flag-parsing errors**. `CmdConfigurator.AddFlags` sets `SilenceErrors` and prints flag errors via `SetFlagErrorFunc`, so the user sees a red error and the process still reports success. A typo'd flag in a CI pipeline passes.

Verified on binaries built from `main` and from this branch, each run in a fresh temp cwd:

| command | `main` | this PR |
|---|---|---|
| `keploy bogus-cmd` | 1 | 1 |
| `keploy test --nope` | **0** | **1** |
| `keploy test --delay abc` | **0** | **1** |
| `keploy --help` | 0 | 0 |
| `keploy test --help` | 0 | 0 |
| `keploy record --help` | 0 | 0 |
| `keploy --version` | 0 | 0 |

### What changed

- The decision moves into `exitCodeForCmdErr`: **any** non-nil error is exit 1. String matching is now confined to deciding whether to print the unknown-command hint. cobra and pflag build these errors with `fmt.Errorf`, so there is no sentinel available for `errors.Is`.
- Routing through `utils.ErrCode` instead of `os.Exit(1)` means the deferred cleanup in `start()` actually runs on this path. `log.New()` creates `keploy-logs.txt` on every invocation, so the old `os.Exit` **stranded one in the user's working directory** after any unknown command. Now removed — there is a test for it.
- An existing `ErrCode` set by a command is left alone.
- Fixing the exit code turned one benign error fatal: `AskForConfirmation` returned `io.EOF` when stdin is not a TTY, so a repeat `keploy config --generate` in a Dockerfile / CI step / cron job would go **0 → 1**. Its doc comment already promises that an unrecognised or interrupted answer degrades to "no", and the `ctx.Done()` branch does exactly that; EOF now declines the override too.

### Known remaining inconsistency (follow-up, not in this PR)

`ValidateFlags` in `cli/provider/cmd.go` and the installation-id failure in `main.go` still call `os.Exit(1)` directly, bypassing both this path and every defer in `start()`. Those should become returned errors.

## Links & References

**Closes:** NA — found while reviewing #4441, which fixes the sibling case (logger-init failure exiting 0).

### 🔗 Related PRs
- #4441

### 🐞 Related Issues
- #2734 (same class: a failure path exiting 0)

## What type of PR is this? (check all applicable)
- [x] 🐞 Bug Fix

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed — covered by unit + subprocess tests below

## Are there any sample code or steps to test the changes?

```
cd $(mktemp -d)
keploy test --nope ; echo "exit=$?"   # main: 0, this PR: 1
keploy --help      ; echo "exit=$?"   # 0 on both
```

### Testing

- `main_exitcode_test.go` — table test over the mapping (nil, unknown command, unknown shorthand, unknown flag, invalid flag value, arbitrary failure).
- `main_exitcode_wiring_test.go` — re-execs the test binary as the real CLI via `TestMain` and asserts **actual process exit codes**, plus that `keploy-logs.txt` is no longer left behind. A helper-only test cannot catch the original bug, which was the result never being assigned to `utils.ErrCode`; both were mutation-tested (breaking the assignment fails the wiring test, restoring the old prefix-only logic fails both).
- `utils/askconfirmation_test.go` — EOF on stdin declines rather than erroring.

Local: `gofmt` clean, `go vet ./...` clean, `go test . ./cli/... ./utils/... ./pkg/...` all pass.

## Self Review done?
- [x] ✅ yes