### PR TITLE
fix(agent): make a wedged eBPF load say so instead of going silent

### DIFF
--- a/.github/workflows/test_workflow_scripts/golang/go-dedup/golang-docker-windows.ps1
+++ b/.github/workflows/test_workflow_scripts/golang/go-dedup/golang-docker-windows.ps1
@@ -342,6 +342,51 @@ function Sync-Logs {
     } catch {}
 }
 
+# Print keploy's logs by reading the FILES, not by draining the tail job.
+#
+# Sync-Logs is the only way keploy output reaches CI, and it depends on a
+# background `Get-Content -Wait` that is known to exit on its own — the comment
+# above the readiness loop documents exactly that, and run 24630134970 is the
+# example. When it dies, Receive-Job returns nothing and every subsequent line
+# keploy writes is lost. That is precisely what happened to the runs this
+# function exists for: the agent container reported
+# "dependency failed to start: container keploy-v3-… is unhealthy" into
+# $errLogPath, the file kept it, and CI printed none of it — so the visible
+# symptom was six failed HTTP requests and no cause. The reader was told to
+# "review the full logs in the file", on a CI runner they cannot log into.
+#
+# The files outlive the tail job, so on any failure path read them directly.
+function Show-KeployLogFiles {
+    param([string]$Reason)
+    Write-Host "`n=========================================================="
+    Write-Host "KEPLOY LOGS (read from disk) — $Reason"
+    Write-Host "  stdout: $logPath"
+    Write-Host "  stderr: $errLogPath"
+    Write-Host "=========================================================="
+    foreach ($f in @($logPath, $errLogPath)) {
+        if (Test-Path $f) {
+            $content = Get-Content -Path $f -ErrorAction SilentlyContinue
+            if ($content) {
+                Write-Host "--- $f ---"
+                $content | ForEach-Object { Write-Host $_ }
+            } else {
+                # An empty stdout log is itself the finding: it means keploy
+                # blocked before its first line, which is what a wedged
+                # bpf(BPF_PROG_LOAD) looks like from outside.
+                Write-Host "--- $f --- (EMPTY: keploy produced no output at all)"
+            }
+        } else {
+            Write-Host "--- $f --- (MISSING)"
+        }
+    }
+    Write-Host "=========================================================="
+    # Container state explains the compose-level failures the log text alone
+    # does not (unhealthy dependency, app container stuck in Created).
+    Write-Host "--- docker ps -a ---"
+    try { docker ps -a --format "{{.Names}} :: {{.Status}}" 2>&1 | ForEach-Object { Write-Host $_ } } catch {}
+    Write-Host "=========================================================="
+}
+
 # Wait for app readiness.
 #
 # Previous implementation broke on the first 200 response and sent
@@ -398,6 +443,10 @@ do {
 
 if ($okStreak -lt $stabilityCount) {
   Write-Warning "App readiness probe did not reach ${stabilityCount} consecutive 200s before deadline; continuing with traffic anyway — downstream record validation will surface the failure."
+  # The app never came up. Whatever explains that is in keploy's logs, and this
+  # is the last moment it is worth reading them before the traffic phase buries
+  # it under six identical connection failures.
+  Show-KeployLogFiles -Reason "app readiness probe timed out"
 } else {
   Write-Host "App readiness confirmed ($stabilityCount consecutive 200s). Settling ${settleSec}s before sending traffic…"
   Start-Sleep -Seconds $settleSec
@@ -442,6 +491,11 @@ if (Invoke-WithRetry -Name "DELETE products/…"  -Action { Invoke-RestMethod -M
 if (Invoke-WithRetry -Name "GET api/v2/users"   -Action { Invoke-RestMethod -Method GET    -Uri "$base/api/v2/users" -TimeoutSec 30 })                                                                                                           { $sent++ }
 
 Write-Host "Sent $sent request(s). Waiting for tests to flush to disk…"
+if ($sent -eq 0) {
+  # Zero requests means nothing can possibly have been recorded, so the run has
+  # already failed; everything after this is consequence, not cause.
+  Show-KeployLogFiles -Reason "every request failed; 0 of the intended requests were sent"
+}
 
 $pollUntil = (Get-Date).AddSeconds(60)
 do {
@@ -501,9 +555,15 @@ if ($REC_PID -and $REC_PID -ne 0) {
 
 # Verify recording
 $testSetPath = ".\keploy\test-set-$expectedTestSetIndex\tests"
-if (-not (Test-Path $testSetPath)) { Write-Error "Test directory not found at $testSetPath"; exit 1 }
+if (-not (Test-Path $testSetPath)) {
+  Show-KeployLogFiles -Reason "no test directory was created at $testSetPath"
+  Write-Error "Test directory not found at $testSetPath"; exit 1
+}
 $testCount = (Get-ChildItem -Path $testSetPath -Filter "*.yaml").Count
-if ($testCount -eq 0) { Write-Error "No test files were created. Review the full logs in the file '$logPath'"; exit 1 }
+if ($testCount -eq 0) {
+  Show-KeployLogFiles -Reason "no test files were created"
+  Write-Error "No test files were created; keploy's own logs are printed above."; exit 1
+}
 
 Write-Host "Successfully recorded $testCount test file(s) in test-set-$expectedTestSetIndex"
 

--- a/.github/workflows/test_workflow_scripts/golang/go-dedup/golang-native-windows.ps1
+++ b/.github/workflows/test_workflow_scripts/golang/go-dedup/golang-native-windows.ps1
@@ -169,6 +169,36 @@ function Sync-Logs {
     } catch {}
 }
 
+# Print keploy's logs by reading the FILES, not by draining the tail job.
+#
+# Sync-Logs is the only route keploy output has into CI, and it depends on a
+# background `Get-Content -Wait` that is known to exit on its own. When it does,
+# Receive-Job returns nothing and everything keploy writes afterwards is lost —
+# which is how a failure here came to show six identical HTTP errors and no
+# cause. The files outlive the tail job, so on any failure path read them.
+function Show-KeployLogFiles {
+    param([string]$Reason)
+    Write-Host "`n=========================================================="
+    Write-Host "KEPLOY LOGS (read from disk) — $Reason"
+    Write-Host "=========================================================="
+    foreach ($f in @($logPath, ".\keploy_agent.log")) {
+        if ($f -and (Test-Path $f)) {
+            $content = Get-Content -Path $f -ErrorAction SilentlyContinue
+            if ($content) {
+                Write-Host "--- $f ---"
+                $content | ForEach-Object { Write-Host $_ }
+            } else {
+                # An empty log is itself the finding: keploy blocked before its
+                # first line, which is what a wedged startup looks like.
+                Write-Host "--- $f --- (EMPTY: keploy produced no output at all)"
+            }
+        } else {
+            Write-Host "--- $f --- (MISSING)"
+        }
+    }
+    Write-Host "=========================================================="
+}
+
 # Wait for app readiness — same stability window + settle +
 # per-request retry scheme as the docker variant. See that
 # script's comment for the keploy#4076 flake that drove this.
@@ -204,6 +234,7 @@ do {
 
 if ($okStreak -lt $stabilityCount) {
   Write-Warning "App readiness probe did not reach ${stabilityCount} consecutive 200s before deadline; continuing with traffic anyway — downstream record validation will surface the failure."
+  Show-KeployLogFiles -Reason "app readiness probe timed out"
 } else {
   Write-Host "App readiness confirmed ($stabilityCount consecutive 200s). Settling ${settleSec}s before sending traffic…"
   Start-Sleep -Seconds $settleSec
@@ -243,6 +274,9 @@ if (Invoke-WithRetry -Name "DELETE products/…"  -Action { Invoke-RestMethod -M
 if (Invoke-WithRetry -Name "GET api/v2/users"   -Action { Invoke-RestMethod -Method GET    -Uri "$base/api/v2/users" -TimeoutSec 30 })                                                                                                           { $sent++ }
 
 Write-Host "Sent $sent request(s). Waiting for tests to flush to disk…"
+if ($sent -eq 0) {
+  Show-KeployLogFiles -Reason "every request failed; 0 of the intended requests were sent"
+}
 
 $pollUntil = (Get-Date).AddSeconds(60)
 do {
@@ -286,9 +320,15 @@ if ($REC_PID -and $REC_PID -ne 0) {
 
 # Verify recording
 $testSetPath = ".\keploy\test-set-$expectedTestSetIndex\tests"
-if (-not (Test-Path $testSetPath)) { Write-Error "Test directory not found at $testSetPath"; Get-Content .\keploy_agent.log; exit 1 }
+if (-not (Test-Path $testSetPath)) {
+  Show-KeployLogFiles -Reason "no test directory was created at $testSetPath"
+  Write-Error "Test directory not found at $testSetPath"; exit 1
+}
 $testCount = (Get-ChildItem -Path $testSetPath -Filter "*.yaml").Count
-if ($testCount -eq 0) { Write-Error "No test files were created. Review the full logs in the file '$logPath'"; exit 1 }
+if ($testCount -eq 0) {
+  Show-KeployLogFiles -Reason "no test files were created"
+  Write-Error "No test files were created; keploy's own logs are printed above."; exit 1
+}
 
 Write-Host "Successfully recorded $testCount test file(s) in test-set-$expectedTestSetIndex"
 

--- a/pkg/agent/hooks/linux/hooks.go
+++ b/pkg/agent/hooks/linux/hooks.go
@@ -151,8 +151,22 @@ func (h *Hooks) load(ctx context.Context, opts agent.HookCfg, setupOpts config.A
 		}
 	}
 
-	// Now load and assign into the kernel with the corrected spec
-	if err := spec.LoadAndAssign(&objs, bpfopts); err != nil {
+	// Now load and assign into the kernel with the corrected spec.
+	//
+	// This is the one call in agent startup that can block forever without
+	// saying anything: BPF_PROG_LOAD is uninterruptible, so a wedged kernel
+	// leaves the agent with no log output at all and the container merely
+	// "not ready". watchStall makes that state describe itself.
+	// Scoped to this one call by a closure rather than a plain defer: the rest of
+	// load() attaches tracepoints and resolves cgroups, and a watchdog left
+	// running across that would blame BPF_PROG_LOAD for whatever else was slow.
+	// The defer inside the closure keeps it from leaking if LoadAndAssign panics.
+	err = func() error {
+		stopStallWatch := watchStall(h.logger, "bpf(BPF_PROG_LOAD) via ebpf.CollectionSpec.LoadAndAssign", stallFirstReport, stallRepeatReport)
+		defer stopStallWatch()
+		return spec.LoadAndAssign(&objs, bpfopts)
+	}()
+	if err != nil {
 		var ve *ebpf.VerifierError
 		if errors.As(err, &ve) {
 			fmt.Printf("VERIFIER FAILURE:\n%s\n", strings.Join(ve.Log, "\n"))

--- a/pkg/agent/hooks/linux/stallwatch.go
+++ b/pkg/agent/hooks/linux/stallwatch.go
@@ -1,0 +1,80 @@
+//go:build linux
+
+package linux
+
+import (
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// Default thresholds for watchStall. Loading the whole eBPF collection is
+// normally well under a second, so 15s already means something is wrong, and
+// repeating every 30s keeps a wedged agent saying so for as long as it is up
+// without flooding the log.
+const (
+	stallFirstReport  = 15 * time.Second
+	stallRepeatReport = 30 * time.Second
+)
+
+// watchStall reports that a kernel call has not returned yet, and keeps
+// reporting until the returned stop func is called.
+//
+// It exists because bpf(BPF_PROG_LOAD) is uninterruptible. When the kernel
+// blocks inside it, no context cancellation frees the goroutine, the thread
+// sits in D state, and the process cannot be killed — SIGKILL leaves the
+// container as "tried to kill container, but did not receive an exit event".
+// This is not hypothetical: a stalled RCU-tasks grace period on the host
+// (kernel log: "tasks_rcu_exit_srcu_stall") makes every BPF_PROG_LOAD wait
+// forever at 0% CPU.
+//
+// The agent could not previously say any of that. It blocked before its first
+// log line, so the only visible symptom was a container that never became
+// ready, an empty log, and a healthcheck that timed out minutes later —
+// diagnosing it needed a goroutine dump taken off the CI host by hand.
+//
+// The syscall cannot be aborted, so this does not try to. It makes the failure
+// legible instead: what is blocked, for how long, and the kernel condition that
+// usually explains it.
+func watchStall(logger *zap.Logger, operation string, first, repeat time.Duration) (stop func()) {
+	if logger == nil {
+		return func() {}
+	}
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		start := time.Now()
+		timer := time.NewTimer(first)
+		defer timer.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-timer.C:
+				logger.Error("kernel call has not returned; the agent cannot become ready until it does",
+					zap.String("operation", operation),
+					zap.Duration("blockedFor", time.Since(start).Round(time.Second)),
+					zap.String("likelyCause", "a stalled RCU-tasks grace period makes bpf(BPF_PROG_LOAD) block indefinitely at 0% CPU; check the host kernel log for 'tasks_rcu_exit_srcu_stall'"),
+					zap.String("remediation", "on WSL2/Docker Desktop run 'wsl --shutdown', which reboots the shared kernel; terminating only the docker-desktop distro leaves the same kernel running and does not clear it"),
+				)
+				timer.Reset(repeat)
+			}
+		}
+	}()
+	// Idempotent, because the natural way to use this is `defer stop()` next to
+	// an explicit stop on some path, and a second close(done) would panic — a
+	// diagnostic helper must never be the thing that takes the process down.
+	//
+	// Waiting on stopped is what makes stop() synchronous: a caller that returns
+	// straight after stopping cannot race a final report out of a watchdog it
+	// already stopped, so a successful load can never emit a scary ERROR.
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			close(done)
+			<-stopped
+		})
+	}
+}

--- a/pkg/agent/hooks/linux/stallwatch_test.go
+++ b/pkg/agent/hooks/linux/stallwatch_test.go
@@ -1,0 +1,136 @@
+//go:build linux
+
+package linux
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func newObservedLogger() (*zap.Logger, *observer.ObservedLogs) {
+	core, logs := observer.New(zap.DebugLevel)
+	return zap.New(core), logs
+}
+
+// A call that returns promptly must produce no output at all. The agent loads
+// eBPF on every start, so a watchdog that chattered on the happy path would be
+// pure noise and would train readers to ignore it.
+func TestWatchStallSilentWhenCallReturnsQuickly(t *testing.T) {
+	logger, logs := newObservedLogger()
+	stop := watchStall(logger, "bpf(BPF_PROG_LOAD)", time.Hour, time.Hour)
+	// Give a watchdog that reports too eagerly real time to do so before
+	// stopping it. Stopping immediately would let a broken implementation win
+	// the race against its own first report and pass this test.
+	time.Sleep(50 * time.Millisecond)
+	stop()
+	if n := logs.Len(); n != 0 {
+		t.Fatalf("watchdog logged %d entries for a call that returned immediately: %v", n, logs.All())
+	}
+}
+
+// The point of the watchdog: a call that does not return must say so, name
+// itself, and carry the kernel condition that explains it. Before this, the
+// agent blocked before its first log line and the container looked merely
+// "not ready" for five minutes.
+func TestWatchStallReportsBlockedCall(t *testing.T) {
+	logger, logs := newObservedLogger()
+	stop := watchStall(logger, "bpf(BPF_PROG_LOAD) via ebpf.CollectionSpec.LoadAndAssign", 10*time.Millisecond, time.Hour)
+	defer stop()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for logs.Len() == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if logs.Len() == 0 {
+		t.Fatal("watchdog stayed silent while the call was still blocked")
+	}
+
+	e := logs.All()[0]
+	if e.Level != zap.ErrorLevel {
+		t.Errorf("a permanently blocked agent should report at ERROR; got %v", e.Level)
+	}
+	fields := e.ContextMap()
+	op, _ := fields["operation"].(string)
+	if !strings.Contains(op, "BPF_PROG_LOAD") {
+		t.Errorf("report must name the blocked operation; got %q", op)
+	}
+	// Without these two the reader still has to go and take a goroutine dump
+	// off the CI host, which is the situation this replaces.
+	if cause, _ := fields["likelyCause"].(string); !strings.Contains(cause, "tasks_rcu_exit_srcu_stall") {
+		t.Errorf("report must name the kernel symptom to grep for; got %q", cause)
+	}
+	if rem, _ := fields["remediation"].(string); !strings.Contains(rem, "wsl --shutdown") {
+		t.Errorf("report must name the remediation; got %q", rem)
+	}
+	if _, ok := fields["blockedFor"]; !ok {
+		t.Error("report must say how long the call has been blocked")
+	}
+}
+
+// It must keep reporting: a single line scrolls away, and the operator who
+// looks at a wedged container ten minutes later needs to see it is still stuck.
+func TestWatchStallRepeatsWhileBlocked(t *testing.T) {
+	logger, logs := newObservedLogger()
+	stop := watchStall(logger, "bpf(BPF_PROG_LOAD)", 10*time.Millisecond, 10*time.Millisecond)
+	defer stop()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for logs.Len() < 3 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if logs.Len() < 3 {
+		t.Fatalf("watchdog reported %d times; a still-blocked call must keep reporting", logs.Len())
+	}
+}
+
+// stop() must be synchronous: if it returned while the goroutine was mid-report,
+// a successful load could still emit a scary ERROR after the fact.
+func TestWatchStallStopIsRaceFree(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		logger, logs := newObservedLogger()
+		stop := watchStall(logger, "op", time.Microsecond, time.Microsecond)
+		time.Sleep(time.Duration(i%5) * time.Millisecond)
+		stop()
+		before := logs.Len()
+		time.Sleep(2 * time.Millisecond)
+		if after := logs.Len(); after != before {
+			t.Fatalf("watchdog logged %d more entries after stop() returned", after-before)
+		}
+	}
+}
+
+// stop() must tolerate being called more than once. The intended usage is
+// `defer stop()`, which pairs naturally with an explicit stop on some paths, and
+// a helper whose whole job is diagnosing a wedged startup must not be the thing
+// that panics the process with "close of closed channel".
+func TestWatchStallStopIsIdempotent(t *testing.T) {
+	logger, _ := newObservedLogger()
+	stop := watchStall(logger, "bpf(BPF_PROG_LOAD)", time.Hour, time.Hour)
+	stop()
+	stop() // would panic on a second close(done)
+	stop()
+}
+
+// Concurrent stops must be safe too, and every one of them must observe the
+// watchdog actually stopped rather than returning early.
+func TestWatchStallStopIsConcurrencySafe(t *testing.T) {
+	logger, _ := newObservedLogger()
+	stop := watchStall(logger, "bpf(BPF_PROG_LOAD)", time.Hour, time.Hour)
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() { defer wg.Done(); stop() }()
+	}
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("concurrent stop() calls deadlocked")
+	}
+}


### PR DESCRIPTION
Every Windows Docker CI job was failing, on `main` and on unrelated branches alike. What CI showed was six identical `The underlying connection was closed: The connection was closed unexpectedly` errors, `Sent 0 request(s)`, and no cause. Getting to the actual reason took SSH onto the runner, a `SIGQUIT` goroutine dump off a live container, and the kernel ring buffer.

This PR does not fix the kernel fault — that isn't ours. It fixes the fact that **nothing could say what was happening**.

### What was actually wrong

`docker compose up` aborted with `dependency failed to start: container keploy-v3-… is unhealthy`, so the app container never started. The agent was blocked here:

```
syscall.Syscall(0x141, 0x5, …)              ← __NR_bpf, BPF_PROG_LOAD
cilium/ebpf.(*CollectionSpec).LoadAndAssign
keploy/pkg/agent/hooks/linux.(*Hooks).load   hooks.go:155
```

The host kernel had a stalled RCU-tasks grace period (`dmesg`: `tasks_rcu_exit_srcu_stall`, ~9.4M jiffies on a 33-day-old WSL2 kernel), and `BPF_PROG_LOAD` waits on one. At **0% CPU** — blocked, not verifying. Uninterruptible, so no context cancellation frees it, `SIGKILL` does not kill it (`tried to kill container, but did not receive an exit event`), and the container can never be removed. **Eight had accumulated, one per failed job.**

Remediation on the runner was `wsl --shutdown`. Worth recording because I got it wrong first: `wsl --terminate docker-desktop` is **not** enough — WSL2 runs one shared utility VM, so the kernel and its stalled RCU state survive a distro restart. Kernel uptime confirmed it: 2,838,295s before, 48s after.

### The two defects this fixes

**1. The agent goes completely silent.** The block happens *before its first log line*, so the only symptom is a container that never becomes ready and an empty log — after which compose waits out its 60×5s healthcheck budget and blames the app. `watchStall` now reports at ERROR, repeating, naming the blocked call, elapsed time, the kernel symptom to grep for, and the remediation.

It is scoped to that one call by a closure, not a bare `defer` — the rest of `load()` attaches tracepoints and resolves cgroups, and a watchdog left running across that would blame `BPF_PROG_LOAD` for whatever else was slow. The `defer` inside the closure still covers a panic. `stop()` is idempotent: a helper whose job is diagnosing a wedged startup must never itself panic on a double close.

**2. CI threw the evidence away.** keploy's output reached the log only through a background `Get-Content -Wait` tail job that — as the scripts' own comments already record — exits on its own. Once it does, every subsequent line is lost. On failure the scripts printed `"Review the full logs in the file '$logPath'"`, naming a path on a CI runner nobody can log into. The file *did* contain `dependency failed to start: container keploy-v3-00f5 is unhealthy`; I only ever saw it by reading it off the runner by hand.

Both Windows scripts now read those files **from disk** at each of the four record-phase failure points (readiness timeout, zero requests sent, missing test-set dir, zero test files). An empty log is reported as a finding in its own right, because empty is exactly what a wedged `BPF_PROG_LOAD` looks like from outside.

### Verification

Six tests, green under `-race`. Every mutation kills exactly one named test:

| mutation | test that fails |
| --- | --- |
| watchdog reads a fixed threshold of 0 (fires on the happy path) | `TestWatchStallSilentWhenCallReturnsQuickly` |
| report at Warn instead of Error | `TestWatchStallReportsBlockedCall` |
| drop the `likelyCause`/`remediation` fields | `TestWatchStallReportsBlockedCall` |
| report once, never repeat | `TestWatchStallRepeatsWhileBlocked` |
| `stop()` stops waiting for the goroutine | `TestWatchStallStopIsRaceFree` |
| remove `sync.Once` | `TestWatchStallStopIsIdempotent` (panics `close of closed channel`) |

The PowerShell changes were parse-checked **on the actual Windows runner**, and `Show-KeployLogFiles` was executed there against empty, populated and missing files — it prints exactly the compose error that was previously discarded.

The runner itself is already fixed: all four Windows jobs went green on `main` in the run that started 33 seconds after the `wsl --shutdown`.