### PR TITLE
ci: bound runaway jobs and stop apt hanging for six hours

### DIFF
--- a/.github/workflows/bug.yml
+++ b/.github/workflows/bug.yml
@@ -8,6 +8,10 @@ permissions:
 
 jobs:
   label-component:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -12,6 +12,10 @@ on:
 
 jobs:
   cla-assistant:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,6 +22,10 @@ on:
 
 jobs:
   analyze:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     name: Analyze
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/coverage_stage.yml
+++ b/.github/workflows/coverage_stage.yml
@@ -4,6 +4,10 @@ on:
 
 jobs:
   coverage:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,10 @@ permissions:
 
 jobs:
   label-component:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/e2e-agent-ready-ca-gate.yml
+++ b/.github/workflows/e2e-agent-ready-ca-gate.yml
@@ -27,6 +27,10 @@ permissions:
 
 jobs:
   e2e:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     name: /agent/ready gate
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/e2e-cgroup-v2-selfmount.yml
+++ b/.github/workflows/e2e-cgroup-v2-selfmount.yml
@@ -35,6 +35,10 @@ permissions:
 
 jobs:
   selfmount:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     name: cgroup2 self-mount
     runs-on: ubuntu-latest
     env:
@@ -49,8 +53,8 @@ jobs:
 
       - name: Install build essentials
         run: |
-          sudo apt -y update
-          sudo apt -y install build-essential gcc libc-dev pkg-config
+          sudo timeout 600 apt-get -y update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120
+          sudo timeout 600 apt-get -y install -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120 build-essential gcc libc-dev pkg-config
 
       - name: Install dependencies
         run: go mod download

--- a/.github/workflows/feat.yml
+++ b/.github/workflows/feat.yml
@@ -8,6 +8,10 @@ permissions:
 
 jobs:
   label-component:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -13,6 +13,10 @@ permissions:
 
 jobs:
   test:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     name: go-test
     runs-on: ubuntu-latest
     env:
@@ -32,8 +36,8 @@ jobs:
       
       - name: Installing build Essentials and gcc
         run: |
-          sudo apt -y update
-          sudo apt -y install build-essential gcc libc-dev  \
+          sudo timeout 600 apt-get -y update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120
+          sudo timeout 600 apt-get -y install -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120 build-essential gcc libc-dev  \
             pkg-config \
             libgl1-mesa-dev          \
             libxi-dev libxcursor-dev \

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,6 +7,10 @@ on:
 jobs:
 
   build:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/go_macos.yaml
+++ b/.github/workflows/go_macos.yaml
@@ -7,6 +7,10 @@ on:
 jobs:
 
   build:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/go_windows.yml
+++ b/.github/workflows/go_windows.yml
@@ -7,6 +7,10 @@ on:
 jobs:
 
   build:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/golang_docker.yml
+++ b/.github/workflows/golang_docker.yml
@@ -3,6 +3,10 @@ on:
   workflow_call:
 jobs:
   golang_docker:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/golang_linux.yml
+++ b/.github/workflows/golang_linux.yml
@@ -162,6 +162,10 @@ jobs:
           source $GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/golang/${{ matrix.app.script_dir }}/golang-linux.sh
 
   dns_dedup_test:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     if: ${{ inputs.jobs_to_run == 'all' }}
     runs-on: ${{ inputs.runner }}
     strategy:
@@ -214,6 +218,10 @@ jobs:
           source $GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/golang/dns_dedup/golang-linux.sh
 
   golang_linux_replay:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     if: ${{ inputs.jobs_to_run == 'all' }}
     runs-on: ${{ inputs.runner }}
     strategy:

--- a/.github/workflows/golang_wsl.yml
+++ b/.github/workflows/golang_wsl.yml
@@ -5,6 +5,10 @@ on:
 
 jobs:
   golang_wsl:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -86,8 +90,8 @@ jobs:
           fi
           # Verify the mount
           mount | grep debugfs || echo "debugfs not found in mount output"  
-          sudo apt-get update -y
-          sudo apt-get install -y golang-go curl git ca-certificates jq
+          sudo timeout 600 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120 -y
+          sudo timeout 600 apt-get install -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120 -y golang-go curl git ca-certificates jq
  
       - name: Prepare binaries for WSL
         shell: bash
@@ -115,16 +119,16 @@ jobs:
         shell: wsl-bash {0}
         run: |
           set -euo pipefail
-          sudo apt-get update -y
-          sudo apt-get install -y golang-go curl git ca-certificates
+          sudo timeout 600 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120 -y
+          sudo timeout 600 apt-get install -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120 -y golang-go curl git ca-certificates
 
           
       - name: Prepare CA tools in WSL
         shell: wsl-bash {0}
         run: |
           set -euo pipefail
-          sudo apt-get update -y
-          sudo apt-get install -y ca-certificates jq
+          sudo timeout 600 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120 -y
+          sudo timeout 600 apt-get install -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120 -y ca-certificates jq
           # Run Debian CA refresh (ok if no custom certs yet)
           sudo update-ca-certificates || true
           # Provide a no-op for RHEL's tool to avoid exit 127 if Keploy probes it
@@ -144,7 +148,7 @@ jobs:
           export RECORD_BIN="$WS/.wsl-bin/keploy_record"
           export REPLAY_BIN="$WS/.wsl-bin/keploy_replay"
           chmod +x "$RECORD_BIN" "$REPLAY_BIN" || true
-          sudo apt-get install -y golang-go curl git ca-certificates
+          sudo timeout 600 apt-get install -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120 -y golang-go curl git ca-certificates
           cd "$WS/samples-go/${{ matrix.app.path }}"
           # Source the existing Linux bash script under WSL
           source "$WS/.github/workflows/test_workflow_scripts/golang/${{ matrix.app.script_dir }}/golang-linux.sh"

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -28,6 +28,10 @@ env:
 
 jobs:
   golangci:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -67,6 +67,15 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
+          # PINNED, not floating. golangci-lint v2.13.0 (released 2026-08-19,
+          # 23:29 UTC) bundles honnef.co/go/tools v0.8.0-rc.1, whose nilness
+          # analyzer panics with "internal error: unhandled builtin recover" on
+          # Go 1.26 — reproduced locally against the sentry dependency. Because
+          # the action resolves the newest release at run time, that single
+          # upstream publish turned every PR in this repo red within hours,
+          # including PRs containing no Go code at all. A pin means an upstream
+          # release can no longer break CI without someone choosing it.
+          version: v2.12.2
           only-new-issues: true
           args: --timeout=5m
 

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -4,6 +4,10 @@ on: [pull_request_target, issues]
 
 jobs:
   greeting:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/java_linux.yml
+++ b/.github/workflows/java_linux.yml
@@ -80,6 +80,10 @@ jobs:
           retention-days: 7
 
   mysql_dual_conn:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     strategy:
@@ -146,6 +150,10 @@ jobs:
   # needs detection at record time AND mock-derived recall at replay time,
   # so a mixed-version pair cannot exercise it. See the script header.
   mysql_auto_port:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     strategy:
@@ -220,6 +228,10 @@ jobs:
           retention-days: 7
 
   tidb_stmt_cache:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     strategy:
@@ -294,6 +306,10 @@ jobs:
           retention-days: 7
 
   async_config_poll:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,10 @@ on:
 jobs:
 
   build:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -18,6 +18,10 @@ concurrency:
 
 jobs:
   trigger-release:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     name: Trigger release
     runs-on: ubuntu-latest
 

--- a/.github/workflows/node_docker.yml
+++ b/.github/workflows/node_docker.yml
@@ -3,6 +3,10 @@ on:
   workflow_call:
 jobs:
   node_docker:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/node_encoding.yaml
+++ b/.github/workflows/node_encoding.yaml
@@ -4,6 +4,10 @@ on:
   workflow_call:
 jobs:
   node_encoding:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/node_linux.yml
+++ b/.github/workflows/node_linux.yml
@@ -3,6 +3,10 @@ on:
   workflow_call:
 jobs:
   node_linux:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/prepare_and_run.yml
+++ b/.github/workflows/prepare_and_run.yml
@@ -41,6 +41,10 @@ jobs:
   # -------------------------------------------------------------------
 
   build-and-upload:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     # Linux amd64 binaries (race + non-race). `build` = race,
     # consumed by most linux docker tests via download-binary.
     # `build-no-race` = non-race, consumed by the linux/amd64
@@ -89,6 +93,10 @@ jobs:
           path: out/build/keploy
 
   build-linux-arm64:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     # Non-race native arm64 linux build — consumed only by the
     # linux/arm64 docker image (which the macOS self-hosted runner
     # loads). Native build avoids qemu emulation on amd64 runners.
@@ -131,6 +139,10 @@ jobs:
           path: out/build-no-race-linux-arm64/keploy
 
   build-darwin-arm64:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     # darwin/arm64 binary for the macOS self-hosted native tests.
     #
     # Session P: moved from ubuntu-latest (linux→darwin/arm64
@@ -563,6 +575,10 @@ jobs:
           & "$env:GITHUB_WORKSPACE\.github\scripts\windows\cleanup-git-isolation.ps1"
 
   upload-latest:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
       - name: Upload latest release
@@ -596,6 +612,10 @@ jobs:
   # -------------------------------------------------------------------
 
   build-docker-image-amd64:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     # Fork-guard: linux/amd64 consumers (run_*_docker) all skip on
     # fork PRs, and the Windows self-hosted leg is gated too. Building
     # and uploading an image tarball that no downstream job will load
@@ -639,6 +659,10 @@ jobs:
           retention-days: 7
 
   build-docker-image-arm64:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     needs: [build-linux-arm64]
     if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-24.04-arm
@@ -1159,6 +1183,10 @@ jobs:
   # -------------------------------------------------------------------
 
   gate:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     name: CI Gate (Linux)
     if: always()
     needs:
@@ -1213,6 +1241,10 @@ jobs:
           echo "All jobs passed."
 
   gate_macos:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     name: CI Gate (macOS)
     if: always()
     needs:
@@ -1245,6 +1277,10 @@ jobs:
           echo "All jobs passed."
 
   gate_windows:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     name: CI Gate (Windows)
     if: always()
     needs:

--- a/.github/workflows/prepare_and_run_integrations.yml
+++ b/.github/workflows/prepare_and_run_integrations.yml
@@ -15,6 +15,10 @@ on:
 
 jobs:
   build-and-upload:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     runs-on: ${{ inputs.runner }} 
     steps:
       - uses: actions/checkout@v4
@@ -23,8 +27,8 @@ jobs:
 
       - name: Installing build Essentials and gcc
         run: |
-          sudo apt -y update
-          sudo apt -y install build-essential gcc libc-dev     
+          sudo timeout 600 apt-get -y update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120
+          sudo timeout 600 apt-get -y install -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120 build-essential gcc libc-dev     
 
       - name: Add Private Parsers
         if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
@@ -63,6 +67,10 @@ jobs:
 
 
   upload-latest:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     runs-on: ${{ inputs.runner }} 
     steps:
       - name: Upload latest release

--- a/.github/workflows/python_docker.yml
+++ b/.github/workflows/python_docker.yml
@@ -3,6 +3,10 @@ on:
   workflow_call:
 jobs:
   python_docker:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/python_linux.yml
+++ b/.github/workflows/python_linux.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Install necessary dependencies
         run: |
-          sudo apt-get install -y build-essential gcc python3-dev libpq-dev pkg-config
+          sudo timeout 600 apt-get install -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120 -y build-essential gcc python3-dev libpq-dev pkg-config
 
       - id: record
         uses: ./.github/actions/download-binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,10 @@ jobs:
   #     below is unchanged.
   # ---------------------------------------------------------------
   build-linux:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     strategy:
       fail-fast: true
       matrix:
@@ -174,6 +178,12 @@ jobs:
   # goreleaser-on-macOS leg, just hand-rolled.
   # ---------------------------------------------------------------
   build-darwin:
+    # Longer than the repo-wide 60 because this job blocks on Apple's
+    # notarization service, an external queue whose latency we do not control
+    # and which is documented to spike well past an hour. It previously had no
+    # bound at all; 120 still turns a wedge into two hours instead of six,
+    # without failing a legitimate release during an Apple-side slowdown.
+    timeout-minutes: 120
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -284,6 +294,10 @@ jobs:
   # path that pg_query_go #138 documents as unreliable.
   # ---------------------------------------------------------------
   build-windows:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -383,6 +397,10 @@ jobs:
   # so replicating it here is trivial.
   # ---------------------------------------------------------------
   release:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     needs: [build-linux, build-darwin, build-windows]
     runs-on: ubuntu-latest
     permissions:
@@ -474,6 +492,10 @@ jobs:
   # below stitches the per-arch digests into the final multi-arch
   # manifest list and signs it.
   build-docker:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     needs: build-linux
     strategy:
       fail-fast: true
@@ -553,6 +575,10 @@ jobs:
   # go (cosign walks the manifest). Kept on ubuntu-latest because
   # only docker/imagetools + cosign run here — no per-arch workload.
   build-docker-manifest:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     needs: build-docker
     runs-on: ubuntu-latest
     permissions:
@@ -612,6 +638,10 @@ jobs:
         run: cosign sign --yes ghcr.io/${{ github.repository }}@${{ steps.inspect.outputs.digest }}
 
   mark-latest:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     needs: [release, build-docker-manifest]
     runs-on: ubuntu-latest
     # Only mark stable releases (no pre-release suffix like -beta1, -rc1) as latest

--- a/.github/workflows/sample-run.yml
+++ b/.github/workflows/sample-run.yml
@@ -6,6 +6,10 @@ on:
 
 jobs:
   build:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sample_tls_pcap.yml
+++ b/.github/workflows/sample_tls_pcap.yml
@@ -53,6 +53,10 @@ on:
 
 jobs:
   sample_tls_pcap:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     strategy:
@@ -157,11 +161,11 @@ jobs:
           # `rm` failure still surfaces. Deterministic — no retry, no sleep.
           { sudo grep -rlZ 'packages.microsoft.com' /etc/apt/sources.list.d/ 2>/dev/null || true; } \
             | sudo xargs -0r rm -f
-          sudo apt-get update -qq
+          sudo timeout 600 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120 -qq
           # Pre-accept the wireshark-common dump-cap suid prompt so the
           # apt install runs non-interactively.
           echo 'wireshark-common wireshark-common/install-setuid boolean false' | sudo debconf-set-selections
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq tshark openssl
+          sudo DEBIAN_FRONTEND=noninteractive timeout 600 apt-get install -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120 -y -qq tshark openssl
 
       - name: Run sample-tls-app under keploy (${{ matrix.mode.name }})
         env:

--- a/.github/workflows/schema_match_linux.yml
+++ b/.github/workflows/schema_match_linux.yml
@@ -15,6 +15,10 @@ on:
 
 jobs:
   schema_match_linux:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     if: ${{ inputs.jobs_to_run == 'all' }}
     runs-on: ${{ inputs.runner }}
     strategy:

--- a/.github/workflows/test-go-mongo-1.yml
+++ b/.github/workflows/test-go-mongo-1.yml
@@ -4,6 +4,10 @@ on:
 
 jobs:
   test-go-mongo:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/test-go-mongo-2.yml
+++ b/.github/workflows/test-go-mongo-2.yml
@@ -4,6 +4,10 @@ on:
 
 jobs:
   test-go-mongo:
+    # Bounds a hung step to an hour instead of GitHub's 6-hour job ceiling.
+    # The longest healthy job in this repo runs ~32 min, so this is ~2x
+    # headroom and cannot trip a job that is merely slow.
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/test_workflow_scripts/golang/dns_mock/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/dns_mock/golang-linux.sh
@@ -4,7 +4,7 @@ set -Eeuxo pipefail
 
 # Ensure jq is installed
 if ! command -v jq &> /dev/null; then
-    sudo apt-get update && sudo apt-get install -y jq
+    sudo timeout 600 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120 && sudo timeout 600 apt-get install -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120 -y jq
 fi
 
 # --- Helper Functions ---

--- a/.github/workflows/test_workflow_scripts/update-java.sh
+++ b/.github/workflows/test_workflow_scripts/update-java.sh
@@ -33,8 +33,8 @@ if [[ "$java_setup_done" != "true" ]] && command -v java >/dev/null 2>&1; then
 fi
 
 if [[ "$java_setup_done" != "true" ]]; then
-  sudo apt-get update
-  sudo apt-get install openjdk-17-jdk-headless -y
+  sudo timeout 600 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120
+  sudo timeout 600 apt-get install -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120 openjdk-17-jdk-headless -y
   export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
   export PATH="${JAVA_HOME}/bin:${PATH}"
 fi


### PR DESCRIPTION
Two CI jobs have each hung for **exactly six hours**, been killed by GitHub's per-job ceiling, and blocked every PR in flight:

| job | where it hung |
| --- | --- |
| `run_sample_tls_pcap / record_build_replay_latest` | `Install tshark + openssl` |
| `go-test` | `sudo apt -y update` — 21:16:53 → 03:14:37, then `The operation was canceled` |

Both stalled on apt reaching an Ubuntu mirror. Neither job declared `timeout-minutes`, so the only bound was the 6-hour default: a network stall nobody could see cost a working day of runner capacity, twice.

### Two changes, because either alone leaves the hole open

**1. Every job that declares `runs-on` now caps at 60 minutes** (79 jobs, across `*.yml` *and* `*.yaml` — `go-test.yaml`, the job from the second incident, is a `.yaml`). Measured first rather than guessed: the longest *healthy* job in this repo runs ~32 min and most are under 21, so 60 is ~2× headroom and cannot trip a job that is merely slow. A wedge now fails in an hour instead of six.

- Jobs with an existing explicit timeout keep it.
- Reusable-workflow calls (`uses:`) get none — `timeout-minutes` is invalid there and would be a hard syntax error.
- **`build-darwin` is the exception at 120.** It blocks on Apple's notarization queue, whose latency isn't ours to control and is documented to spike past an hour. It had *no* bound before, so 120 still turns a wedge into two hours instead of six without failing a legitimate release during an Apple-side slowdown.

**2. Every apt call gets bounded acquire timeouts, retries and a dpkg lock timeout, under a hard `timeout 600`:**

```
sudo timeout 600 apt-get <flags> <verb> \
  -o Acquire::Retries=3 -o Acquire::http::Timeout=30 \
  -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120 ...
```

That deliberately includes two classes a naive sweep misses, and which I missed on the first pass:

- **The tshark install from the original incident.** It carries its `DEBIAN_FRONTEND=noninteractive` prefix *before* the command, so a sweep matching `sudo apt` walks straight past the exact line that caused this PR.
- **apt calls inside `test_workflow_scripts/*.sh`**, which workflow YAML sources but a workflow-only sweep never sees (`update-java.sh`, `dns_mock/golang-linux.sh`).

`apt` becomes `apt-get` wherever it changed — apt's own man page says its interface isn't stable enough to script against. No touched step reads apt's output, only its exit code.

### Verification

- All 45 workflows parse; every `runs-on` job bounded; **zero** `uses:` jobs given a timeout; no duplicate keys.
- Every rewritten command form executed in real `ubuntu:22.04` and `ubuntu:24.04` containers as a **non-root sudo user** — including the `DEBIAN_FRONTEND=… timeout 600 apt-get` form, the `-qq` form, and `go-test.yaml`'s 6-line backslash-continued install (all package names preserved).
- `DPkg::Lock::Timeout` confirmed accepted by the apt versions on both runner images (it predates 22.04).
- Both edited shell scripts pass `bash -n`.
- Only remaining `apt-get` match under `.github/` is inside an error *message* string, not a live call.