### PR TITLE
ci(windows): reap leaked keploy agent containers, and refuse to run on a wedged VM

### DIFF
--- a/.github/scripts/windows/cleanup-windows.ps1
+++ b/.github/scripts/windows/cleanup-windows.ps1
@@ -59,6 +59,18 @@ if ($shouldPrune) {
   try { docker system prune -af --volumes 2>&1 | Write-Host } catch { Write-Warning "docker system prune failed: $($_.Exception.Message)" }
 }
 
+# Reap keploy agent containers (keploy-v3-*) left behind by any run on this
+# runner. This is the guaranteed half: a cancelled or crashed job never gets to
+# run its own teardown, so without a sweep here those containers accumulate
+# until someone notices the VM is full of them. Warn rather than fail — a
+# teardown that fails the workflow would hide the real result of the run.
+try {
+  $reaper = Join-Path $PSScriptRoot 'reap-keploy-containers.ps1'
+  if (Test-Path $reaper) { & $reaper } else { Write-Warning "reaper script not found at $reaper" }
+} catch {
+  Write-Warning "keploy container reap failed: $($_.Exception.Message)"
+}
+
 # Output whether we stopped any containers (for workflow conditionals)
 # If running inside GitHub Actions, write to the GITHUB_OUTPUT file so the step can expose outputs
 if ($env:GITHUB_OUTPUT) {

--- a/.github/scripts/windows/reap-keploy-containers.ps1
+++ b/.github/scripts/windows/reap-keploy-containers.ps1
@@ -1,0 +1,89 @@
+# Remove keploy agent containers left behind on this runner's Docker VM, and
+# fail loudly if any of them cannot be removed.
+#
+# WHY THIS EXISTS
+# Every keploy record/replay run creates a keploy-v3-<hash> agent container.
+# Nothing removed them: "Recover stale runner state" only kills Windows
+# keploy.exe processes and resets the WinDivert driver, and the only `docker rm`
+# sweep in this repo is clean_up_docker_macos, which is macOS-only and filters
+# on app-container prefixes. They accumulated indefinitely — eight were found
+# alive on one runner, spanning six hours.
+#
+# THE TWO CASES, AND WHY THE SECOND ONE FAILS THE JOB
+# A leftover from a finished run is ordinary garbage; delete it and move on.
+# A container that will NOT die is something else: a task stuck in
+# uninterruptible kernel sleep. The observed cause is a stalled RCU-tasks grace
+# period (dmesg: tasks_rcu_exit_srcu_stall), which makes bpf(BPF_PROG_LOAD)
+# block forever at 0% CPU. The keploy agent then never becomes ready, compose
+# aborts the application on an unhealthy dependency, and every test case is
+# reported as a connection failure. Once the VM reaches that state EVERY
+# subsequent Docker job on this runner fails the same way, each burning its full
+# budget and reporting a misleading result. One accurate failure naming the
+# remediation is worth more than a day of those.
+[CmdletBinding()]
+param(
+    # Exit non-zero when containers survive removal. The pre-job caller wants
+    # that (do not start work on a wedged VM); the post-run cleanup caller does
+    # not, because failing teardown would mask the real result of the run.
+    [switch]$FailOnStuck
+)
+
+$ErrorActionPreference = 'Continue'
+
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    Write-Host "docker not on PATH; nothing to reap."
+    exit 0
+}
+docker info *> $null
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Docker daemon not reachable; skipping reap."
+    exit 0
+}
+
+# @() so a single leftover stays an array rather than a bare string that would
+# then be iterated one character at a time.
+$ids = @(docker ps -aq --filter "name=keploy-v3-" 2>$null | Where-Object { $_ })
+if ($ids.Count -eq 0) {
+    Write-Host "No leftover keploy-v3-* containers."
+    exit 0
+}
+
+Write-Host "Found $($ids.Count) leftover keploy-v3-* container(s); removing."
+foreach ($id in $ids) {
+    $name = (docker inspect --format '{{.Name}}' $id 2>$null)
+    if (-not $name) { $name = $id }
+    docker rm -f $id *> $null
+    # "requested", not "removed": whether it actually went is established by the
+    # re-query below, not by this call returning.
+    Write-Host "  requested removal of $name"
+}
+
+# Re-query rather than trust exit codes. `docker rm -f` returns 0 even when it
+# prints "No such container", so its status does not distinguish "removed" from
+# "could not remove" — but whether the container is still listed does, and that
+# is the fact this check is actually about.
+$stuck = @(docker ps -aq --filter "name=keploy-v3-" 2>$null | Where-Object { $_ })
+if ($stuck.Count -eq 0) {
+    Write-Host "All leftover keploy agent containers removed."
+    exit 0
+}
+
+$names = @()
+foreach ($id in $stuck) {
+    $n = (docker inspect --format '{{.Name}}' $id 2>$null)
+    if (-not $n) { $n = $id }
+    $names += $n
+}
+
+$msg = "Docker VM is wedged: $($stuck.Count) keploy agent container(s) survived 'docker rm -f' - $($names -join ', '). " +
+       "A container that outlives SIGKILL means a task is in uninterruptible kernel sleep, so every Docker job on this " +
+       "runner will keep failing until the VM is restarted. Remediation: run 'wsl --shutdown' on this host. " +
+       "NOT 'wsl --terminate docker-desktop' - WSL2 shares one utility VM, so terminating the distro comes back on the " +
+       "same wedged kernel. Confirm the restart took with: docker run --rm --entrypoint cat <image> /proc/uptime"
+
+if ($FailOnStuck) {
+    Write-Host "::error::$msg"
+    exit 1
+}
+Write-Host "::warning::$msg"
+exit 0

--- a/.github/workflows/golang_docker_windows.yml
+++ b/.github/workflows/golang_docker_windows.yml
@@ -79,17 +79,6 @@ jobs:
       # clean:true fails at "git config --local" with "not a git repository".
       # Wipe in that case so checkout starts fresh; healthy workspaces are
       # left alone.
-      - name: Reap leaked keploy agent containers
-        # Runs BEFORE the job's work and fails it if any container survives
-        # removal: a wedged Docker VM makes every keploy run on this runner
-        # report connection failures, so starting work on one only produces a
-        # misleading result. The guaranteed sweep after a run lives in
-        # cleanup-windows.ps1, which warns instead of failing.
-        shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'
-        run: |
-          & "$env:GITHUB_WORKSPACE\.github\scripts\windows\reap-keploy-containers.ps1" -FailOnStuck
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
       - name: Recover stale runner state
         continue-on-error: true
         shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'
@@ -166,6 +155,26 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: true
+
+      - name: Reap leaked keploy agent containers
+        # Runs after checkout (the script lives in the repo) but before any
+        # keploy work, and fails the job if any container survives
+        # removal: a wedged Docker VM makes every keploy run on this runner
+        # report connection failures, so starting work on one only produces a
+        # misleading result. The guaranteed sweep after a run lives in
+        # cleanup-windows.ps1, which warns instead of failing.
+        shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'
+        run: |
+          $reaper = Join-Path $env:GITHUB_WORKSPACE '.github\scripts\windows\reap-keploy-containers.ps1'
+          # Say so plainly if the script is not there. It lives in the repo, so
+          # this step must run after checkout; when it did not, PowerShell threw
+          # a bare CommandNotFoundException that said nothing about the cause.
+          if (-not (Test-Path $reaper)) {
+            Write-Host "::error::$reaper not found - this step must run AFTER 'Checkout repository'."
+            exit 1
+          }
+          & $reaper -FailOnStuck
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Setup per-job git isolation
         shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"' 

--- a/.github/workflows/golang_docker_windows.yml
+++ b/.github/workflows/golang_docker_windows.yml
@@ -79,6 +79,17 @@ jobs:
       # clean:true fails at "git config --local" with "not a git repository".
       # Wipe in that case so checkout starts fresh; healthy workspaces are
       # left alone.
+      - name: Reap leaked keploy agent containers
+        # Runs BEFORE the job's work and fails it if any container survives
+        # removal: a wedged Docker VM makes every keploy run on this runner
+        # report connection failures, so starting work on one only produces a
+        # misleading result. The guaranteed sweep after a run lives in
+        # cleanup-windows.ps1, which warns instead of failing.
+        shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'
+        run: |
+          & "$env:GITHUB_WORKSPACE\.github\scripts\windows\reap-keploy-containers.ps1" -FailOnStuck
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       - name: Recover stale runner state
         continue-on-error: true
         shell: 'powershell -ExecutionPolicy Bypass -NoLogo -NoProfile -Command ". ''{0}''"'


### PR DESCRIPTION
Every keploy record/replay run leaves a `keploy-v3-<hash>` agent container on the Windows runner's Docker VM. **Nothing removed them.** I found **eight alive on one runner, spanning six hours.**

I checked why rather than assuming:

- `Recover stale runner state` only kills Windows `keploy.exe` processes and resets the WinDivert driver — it never touches containers.
- The only `docker rm -f` sweep in the repo is **`clean_up_docker_macos`** — macOS-only, and it filters on app-container prefixes (`ginApp_`, `mongoDb_`, …), not `keploy-v3-*`.

So the Windows Docker jobs had no container cleanup at all.

### Swept in two places, because one isn't enough

**Before the docker job** — so it starts from a known state.
**In `cleanup-windows.ps1`** — the only half that runs when a job is **cancelled** or dies before its own teardown, which is exactly how these accumulate.

### The part that matters more than the sweep

A container that *won't die* isn't ordinary garbage. It means a task is in **uninterruptible kernel sleep**: a stalled RCU-tasks grace period (`tasks_rcu_exit_srcu_stall`) leaves `bpf(BPF_PROG_LOAD)` blocked forever at 0% CPU, so the agent never becomes ready, compose aborts the app on an unhealthy dependency, and every test case is reported as a connection failure.

Once a VM is in that state, **every later job fails the same way and reports a misleading result** — which is what produced days of confusing red. So the pre-job sweep **fails the job** and names the remediation:

```
::error::Docker VM is wedged: 1 keploy agent container(s) survived 'docker rm -f' …
Remediation: run 'wsl --shutdown' on this host. NOT 'wsl --terminate docker-desktop'
- WSL2 shares one utility VM, so terminating the distro comes back on the same wedged kernel.
```

That `--terminate` vs `--shutdown` distinction is in the message because I got it wrong first: terminating the distro left kernel uptime at 33 days and the wedge intact.

The cleanup caller only **warns** — failing teardown would bury the run's actual result.

### One subtlety worth calling out

Removal is verified by **re-querying**, not by exit status. `docker rm -f` returns **0 even when it prints `No such container`** (verified on the runner), so its exit code cannot distinguish "removed" from "could not remove". Whether the container is still listed can. My first draft trusted the exit code and would have missed the wedge entirely.

### Verified on the actual runner

| case | result |
| --- | --- |
| no leftovers | exit 0, no-op |
| 2 running + 1 exited leftover | all removed, 0 remaining, exit 0 |
| container survives removal, no flag | `::warning::`, exit 0 |
| container survives removal, `-FailOnStuck` | `::error::`, **exit 1** |

Also guards the boring cases: docker not on PATH, or daemon unreachable → exit 0 rather than failing the job.

### What this does *not* do

It cannot un-wedge a VM — nothing in userspace can kill a D-state task. It stops the accumulation, and turns "every Windows Docker job fails mysteriously" into one loud failure naming the fix. Complements #4456, which makes the agent itself announce the stall instead of going silent.