### PR TITLE
fix: scope generated IDs to identifier prefix

### DIFF
--- a/pkg/util.go
+++ b/pkg/util.go
@@ -2542,15 +2542,16 @@ func ReadSessionIndices(path string, Logger *zap.Logger) ([]string, error) {
 func NextID(IDs []string, identifier string) string {
 	latestIndx := 0
 	for _, ID := range IDs {
-		namePackets := strings.Split(ID, "-")
-		if len(namePackets) == 3 {
-			Indx, err := strconv.Atoi(namePackets[2])
-			if err != nil {
-				continue
-			}
-			if latestIndx < Indx+1 {
-				latestIndx = Indx + 1
-			}
+		if !strings.HasPrefix(ID, identifier) {
+			continue
+		}
+		suffix := ID[len(identifier):]
+		indx, err := strconv.Atoi(suffix)
+		if err != nil {
+			continue
+		}
+		if latestIndx < indx+1 {
+			latestIndx = indx + 1
 		}
 	}
 	return fmt.Sprintf("%s%v", identifier, latestIndx)
@@ -2559,15 +2560,16 @@ func NextID(IDs []string, identifier string) string {
 func LastID(IDs []string, identifier string) string {
 	latestIndx := 0
 	for _, ID := range IDs {
-		namePackets := strings.Split(ID, "-")
-		if len(namePackets) == 3 {
-			Indx, err := strconv.Atoi(namePackets[2])
-			if err != nil {
-				continue
-			}
-			if latestIndx < Indx {
-				latestIndx = Indx
-			}
+		if !strings.HasPrefix(ID, identifier) {
+			continue
+		}
+		suffix := ID[len(identifier):]
+		indx, err := strconv.Atoi(suffix)
+		if err != nil {
+			continue
+		}
+		if latestIndx < indx {
+			latestIndx = indx
 		}
 	}
 	return fmt.Sprintf("%s%v", identifier, latestIndx)

--- a/pkg/util_test.go
+++ b/pkg/util_test.go
@@ -2240,3 +2240,97 @@ func TestAgentReadyTimeout(t *testing.T) {
 		t.Fatalf("DefaultAgentReadyTimeout %v is shorter than the agent healthcheck budget (~310s)", DefaultAgentReadyTimeout)
 	}
 }
+
+func TestNextID(t *testing.T) {
+	tests := []struct {
+		name       string
+		ids        []string
+		identifier string
+		want       string
+	}{
+		{
+			name:       "issue 4377: ignores custom metadata ending in numbers with 3 packets",
+			ids:        []string{"test-set-0", "checkout-flow-999"},
+			identifier: "test-set-",
+			want:       "test-set-1",
+		},
+		{
+			name:       "sequential test sets",
+			ids:        []string{"test-set-0", "test-set-1", "test-set-2"},
+			identifier: "test-set-",
+			want:       "test-set-3",
+		},
+		{
+			name:       "unrelated prefixes and non-matching patterns are ignored",
+			ids:        []string{"other-0", "custom-name", "test-set-custom-99"},
+			identifier: "test-set-",
+			want:       "test-set-0",
+		},
+		{
+			name:       "gaps in sequence",
+			ids:        []string{"test-set-0", "test-set-5"},
+			identifier: "test-set-",
+			want:       "test-set-6",
+		},
+		{
+			name:       "out of order sequence",
+			ids:        []string{"test-set-10", "test-set-2"},
+			identifier: "test-set-",
+			want:       "test-set-11",
+		},
+		{
+			name:       "exact prefix without suffix or with non-numeric suffix",
+			ids:        []string{"test-set-", "test-set-abc", "test-set-1-mock"},
+			identifier: "test-set-",
+			want:       "test-set-0",
+		},
+		{
+			name:       "test-run identifier with unrelated test-set and custom IDs",
+			ids:        []string{"test-run-0", "test-run-1", "test-set-999", "checkout-flow-888"},
+			identifier: "test-run-",
+			want:       "test-run-2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NextID(tt.ids, tt.identifier)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestLastID(t *testing.T) {
+	tests := []struct {
+		name       string
+		ids        []string
+		identifier string
+		want       string
+	}{
+		{
+			name:       "ignores unrelated custom names and test sets",
+			ids:        []string{"test-run-0", "test-run-1", "checkout-flow-999", "test-set-50"},
+			identifier: "test-run-",
+			want:       "test-run-1",
+		},
+		{
+			name:       "highest ID returned with out of order sequence",
+			ids:        []string{"test-run-0", "test-run-12", "test-run-3"},
+			identifier: "test-run-",
+			want:       "test-run-12",
+		},
+		{
+			name:       "exact prefix or non-numeric suffixes ignored",
+			ids:        []string{"test-run-", "test-run-abc", "test-run-old-1"},
+			identifier: "test-run-",
+			want:       "test-run-0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := LastID(tt.ids, tt.identifier)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Describe the changes that are made

* Fix `NextID` and `LastID` to only consider IDs matching the supplied identifier prefix.
* Parse the numeric suffix only after the identifier prefix is matched.
* Prevent unrelated custom metadata IDs such as `checkout-flow-999` from affecting generated test-set IDs.
* Add regression tests covering the issue and related identifier/suffix cases.

## Links & References

**Closes:** #4377

### 🔗 Related PRs

* NA

### 🐞 Related Issues

* #4377

### 📄 Related Documents

* NA

## What type of PR is this? (check all applicable)

* [ ] 📦 Chore
* [ ] 🍕 Feature
* [x] 🐞 Bug Fix
* [ ] 📝 Documentation Update
* [ ] 🎨 Style
* [ ] 🧑‍💻 Code Refactor
* [ ] 🔥 Performance Improvements
* [x] ✅ Test
* [ ] 🔁 CI
* [ ] ⏩ Revert

## Added e2e test pipeline?

* [ ] 👍 yes
* [x] 🙅 no, because they aren't needed
* [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?

* [ ] 👍 yes
* [x] 🙅 no, because the code is self-explanatory

## Added to documentation?

* [ ] 📜 README.md
* [ ] 📓 Wiki
* [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?

* [x] 👍 yes, mentioned below
* [ ] 🙅 no, because it is not needed

### Testing

```bash
go test ./pkg -count=1
```

Result:

```text
ok  go.keploy.io/server/v3/pkg  4.824s
```

Also verified:

```bash
git diff --check
```

with no errors.

## Self Review done?

* [x] ✅ yes
* [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?

* NA

## 🧠 Semantics for PR Title & Branch Name

PR Title:
`fix: scope generated IDs to identifier prefix`

Branch:
`fix/next-id-prefix`

### Additional checklist:

* [x] Have you read the [[Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)](https://keploy.io/docs/keploy-explained/contribution-guide/)?
* [x] Have you followed the PR Semantics guide for naming this PR?
* [x] Have you followed the Branch Semantics guide for naming this PR?