### PR TITLE
fix(mysql): serve an error packet on mock-miss instead of tearing down the connection

### DIFF
--- a/pkg/agent/proxy/integrations/mysql/replayer/query.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/query.go
@@ -221,7 +221,7 @@ func simulateCommandPhase(ctx context.Context, logger *zap.Logger, clientConn ne
 				// next_step reuses the strict-aware guidance computed for the
 				// mismatch report above — under schemaNoiseStrict the accurate
 				// advice is "mark/learn the drifted fields", not "re-record".
-				logger.Error("Connection closing due to no matching mock found.",
+				logger.Error("No matching mock found for command.",
 					zap.Int("commands_processed", commandCount),
 					zap.String("request_type", req.Header.Type),
 					zap.String("closest_mock", miss.closestMock),
@@ -229,8 +229,23 @@ func simulateCommandPhase(ctx context.Context, logger *zap.Logger, clientConn ne
 					zap.String("match_phase", miss.matchPhase),
 					zap.Int("strict_rejected_candidates", miss.strictRejected),
 					zap.String("next_step", nextSteps))
-				baseErr := fmt.Errorf("error while simulating the command phase: %w", models.ErrNoMockMatched)
-				return models.NewMockMismatchError(baseErr, report)
+
+				// A single unmatched command must NOT tear down the whole client
+				// connection. Mirroring the HTTP replayer's serve-without-mock
+				// intent, degrade this one query to a MySQL ERR packet, surface
+				// the miss to the test report out-of-band, and keep reading the
+				// next command. Tearing the connection down here turns one
+				// drifted/unrecorded query into a multi-second app outage (and,
+				// with pooled drivers like Rails/Makara, a connection-pool
+				// blacklist cascade). handleCommandMockMiss preserves the
+				// historical fatal behaviour when no mismatch reporter is
+				// installed (older agent / non-test path), so a miss is never
+				// silently swallowed.
+				outcome := handleCommandMockMiss(ctx, logger, clientConn, req, report, decodeCtx, commandCount)
+				if outcome.err != nil {
+					return outcome.err
+				}
+				continue
 			}
 
 			logger.Debug("Matched the command with the mock", zap.Any("mock", resp))
@@ -301,4 +316,111 @@ func simulateCommandPhase(ctx context.Context, logger *zap.Logger, clientConn ne
 				zap.String("last_request", req.Header.Type))
 		}
 	}
+}
+
+// MySQL ERR packet fields for a command-phase mock-miss. 1105 (ER_UNKNOWN_ERROR)
+// with SQLSTATE HY000 is the generic server-error the client libraries surface
+// as an ordinary query failure — the app sees a failed query, not a dropped
+// connection.
+const (
+	mockMissErrorCode    uint16 = 1105 // ER_UNKNOWN_ERROR
+	mockMissSQLState            = "HY000"
+	mockMissErrorMessage        = "keploy: no matching mock for query"
+)
+
+// mockMissOutcome is the result of handling a command-phase mock-miss.
+type mockMissOutcome struct {
+	// err is non-nil only for a genuinely fatal outcome that must end the
+	// connection: a failure encoding/writing the ERR packet, or — when no
+	// mismatch reporter is installed to record the miss out-of-band — the
+	// original wrapped ErrNoMockMatched (preserving historical behaviour so a
+	// miss is never silently swallowed). When err is nil the caller keeps the
+	// connection open and reads the next command.
+	err error
+}
+
+// handleCommandMockMiss degrades a single unmatched command instead of tearing
+// down the whole client connection.
+//
+// This mirrors the HTTP replayer's serve-without-mock intent (see
+// http/decode.go): one drifted or unrecorded query becomes an error RESPONSE
+// for that query while the command loop keeps serving the connection. The miss
+// is still surfaced to the test report out-of-band via the MockMismatchReporter
+// installed on ctx (the same sink a returned ErrNoMockMatched feeds through the
+// proxy), so the test still fails with full diagnostics — it just no longer
+// takes the client connection down with it.
+//
+// When no reporter is installed (older agent, or a non-test path) reporting
+// out-of-band is impossible, so we fall back to the historical behaviour and
+// return the wrapped ErrNoMockMatched.
+func handleCommandMockMiss(ctx context.Context, logger *zap.Logger, clientConn net.Conn, req mysql.Request, report *models.MockMismatchReport, decodeCtx *wire.DecodeContext, commandCount int) mockMissOutcome {
+	baseErr := fmt.Errorf("error while simulating the command phase: %w", models.ErrNoMockMatched)
+	mismatchErr := models.NewMockMismatchError(baseErr, report)
+
+	// Surface the miss to the test report without returning (and thus closing
+	// the connection). If no reporter is installed we cannot report the miss
+	// out-of-band, so preserve the historical fatal behaviour.
+	if !models.ReportMockMismatch(ctx, mismatchErr) {
+		logger.Error("Connection closing due to no matching mock found (no mismatch reporter installed to degrade per-query).",
+			zap.Int("commands_processed", commandCount),
+			zap.String("request_type", req.Header.Type))
+		return mockMissOutcome{err: mismatchErr}
+	}
+
+	// No-response commands (COM_STMT_CLOSE / COM_STMT_SEND_LONG_DATA /
+	// COM_QUIT) leave the client not reading a reply; writing an ERR packet
+	// would desync the stream. Report the miss and continue without a write.
+	if wire.IsNoResponseCommand(req.Header.Type) {
+		logger.Warn("No matching mock for a no-response command; reported the miss and keeping the connection open (no error packet sent).",
+			zap.Int("commands_processed", commandCount),
+			zap.String("request_type", req.Header.Type))
+		return mockMissOutcome{}
+	}
+
+	if err := writeMockMissErr(ctx, logger, clientConn, req, decodeCtx); err != nil {
+		// Failing to write the degraded response is a genuine I/O/encode
+		// error — this one IS fatal for the connection.
+		utils.LogError(logger, err, "failed to write mock-miss error packet to client; closing connection",
+			zap.Int("commands_processed", commandCount),
+			zap.String("request_type", req.Header.Type))
+		return mockMissOutcome{err: err}
+	}
+
+	logger.Warn("No matching mock for command; served an error packet to the client and keeping the connection open.",
+		zap.Int("commands_processed", commandCount),
+		zap.String("request_type", req.Header.Type))
+	return mockMissOutcome{}
+}
+
+// writeMockMissErr encodes and writes a single MySQL ERR packet to the client
+// as the degraded response for an unmatched command. The response sequence id
+// is one past the client's command packet, as the MySQL protocol requires.
+func writeMockMissErr(ctx context.Context, logger *zap.Logger, clientConn net.Conn, req mysql.Request, decodeCtx *wire.DecodeContext) error {
+	var seqID uint8 = 1
+	if req.Header != nil && req.Header.Header != nil {
+		seqID = req.Header.Header.SequenceID + 1
+	}
+
+	errBundle := &mysql.PacketBundle{
+		Header: &mysql.PacketInfo{
+			Type:   mysql.StatusToString(mysql.ERR),
+			Header: &mysql.Header{SequenceID: seqID},
+		},
+		Message: &mysql.ERRPacket{
+			Header:         mysql.ERR,
+			ErrorCode:      mockMissErrorCode,
+			SQLStateMarker: "#",
+			SQLState:       mockMissSQLState,
+			ErrorMessage:   mockMissErrorMessage,
+		},
+	}
+
+	buf, err := wire.EncodeToBinary(ctx, logger, errBundle, clientConn, decodeCtx)
+	if err != nil {
+		return fmt.Errorf("failed to encode mock-miss ERR packet: %w", err)
+	}
+	if _, err := clientConn.Write(buf); err != nil {
+		return fmt.Errorf("failed to write mock-miss ERR packet: %w", err)
+	}
+	return nil
 }

--- a/pkg/agent/proxy/integrations/mysql/replayer/query_mockmiss_test.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/query_mockmiss_test.go
@@ -1,0 +1,215 @@
+package replayer
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/wire"
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/wire/phase"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.keploy.io/server/v3/pkg/models/mysql"
+	"go.uber.org/zap"
+)
+
+// TestHandleCommandMockMiss_ServesErrPacketAndKeepsConnection is the regression
+// guard for the outage this fix targets.
+//
+// Previously a command-phase mock-miss returned models.ErrNoMockMatched, which
+// unwound to `errCh <- err` in replay.go and dropped the client's TCP
+// connection — turning one drifted/unrecorded query into a multi-second app
+// outage (and, with pooled drivers, a connection-pool blacklist cascade).
+//
+// The fix mirrors the HTTP replayer's serve-without-mock intent: when a
+// mismatch reporter is installed (the normal test path), the miss is reported
+// out-of-band, a single MySQL ERR packet is written for that one query, and the
+// command loop keeps serving the connection. This test asserts exactly that
+// outcome at the replayer level — the miss does NOT propagate the fatal
+// teardown error, a well-formed ERR packet reaches the client, and the miss is
+// still surfaced to the test report.
+func TestHandleCommandMockMiss_ServesErrPacketAndKeepsConnection(t *testing.T) {
+	const caps = mysql.CLIENT_PROTOCOL_41
+
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	decodeCtx := newTestDecodeCtx(serverConn, caps)
+
+	// A reporter records the miss out-of-band, exactly like the proxy's
+	// sendMockNotFoundError sink in MODE_TEST.
+	var reported error
+	ctx := models.WithMockMismatchReporter(context.Background(), func(err error) {
+		reported = err
+	})
+
+	req := comQueryRequest("SELECT * FROM widgets WHERE id = 7", 0)
+	report := &models.MockMismatchReport{Protocol: "MySQL", ActualSummary: "COM_QUERY"}
+
+	// handleCommandMockMiss writes to serverConn; net.Pipe is unbuffered, so the
+	// write blocks until the client reads. Run the handler in a goroutine and
+	// read the ERR packet from the other end.
+	outCh := make(chan mockMissOutcome, 1)
+	go func() {
+		outCh <- handleCommandMockMiss(ctx, zap.NewNop(), serverConn, req, report, decodeCtx, 1)
+	}()
+
+	errPkt := readErrPacket(t, clientConn, caps)
+
+	var outcome mockMissOutcome
+	select {
+	case outcome = <-outCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleCommandMockMiss did not return")
+	}
+
+	// 1. The connection is NOT torn down: no fatal error propagates.
+	if outcome.err != nil {
+		t.Fatalf("expected no fatal error (connection kept open), got: %v", outcome.err)
+	}
+
+	// 2. A well-formed ERR packet was served for the one query.
+	if errPkt.Header != mysql.ERR {
+		t.Fatalf("expected ERR header 0x%x, got 0x%x", mysql.ERR, errPkt.Header)
+	}
+	if errPkt.ErrorCode != mockMissErrorCode {
+		t.Fatalf("expected error code %d (ER_UNKNOWN_ERROR), got %d", mockMissErrorCode, errPkt.ErrorCode)
+	}
+	if errPkt.SQLState != mockMissSQLState {
+		t.Fatalf("expected SQLSTATE %q, got %q", mockMissSQLState, errPkt.SQLState)
+	}
+	if !strings.Contains(errPkt.ErrorMessage, "keploy") {
+		t.Fatalf("expected error message to mention keploy, got %q", errPkt.ErrorMessage)
+	}
+
+	// 3. The miss is still surfaced to the test report (test still fails).
+	if reported == nil {
+		t.Fatal("expected the miss to be reported out-of-band, reporter was not called")
+	}
+	if !errors.Is(reported, models.ErrNoMockMatched) {
+		t.Fatalf("reported error should wrap ErrNoMockMatched, got: %v", reported)
+	}
+}
+
+// TestHandleCommandMockMiss_NoReporterPreservesFatalTeardown pins the
+// conservative fallback: when no mismatch reporter is installed (older agent,
+// or a non-test path) the miss cannot be surfaced out-of-band, so the handler
+// preserves the historical behaviour and returns the wrapped ErrNoMockMatched
+// rather than silently swallowing the miss.
+func TestHandleCommandMockMiss_NoReporterPreservesFatalTeardown(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	decodeCtx := newTestDecodeCtx(serverConn, mysql.CLIENT_PROTOCOL_41)
+	req := comQueryRequest("SELECT 1", 0)
+	report := &models.MockMismatchReport{Protocol: "MySQL"}
+
+	// No reporter installed on the context.
+	outcome := handleCommandMockMiss(context.Background(), zap.NewNop(), serverConn, req, report, decodeCtx, 1)
+
+	if outcome.err == nil {
+		t.Fatal("expected the fatal ErrNoMockMatched to be returned when no reporter is installed")
+	}
+	if !errors.Is(outcome.err, models.ErrNoMockMatched) {
+		t.Fatalf("expected wrapped ErrNoMockMatched, got: %v", outcome.err)
+	}
+}
+
+// TestHandleCommandMockMiss_NoResponseCommandKeepsConnectionWithoutWrite guards
+// the protocol edge: no-response commands (COM_STMT_CLOSE / COM_QUIT /
+// COM_STMT_SEND_LONG_DATA) leave the client not reading a reply, so writing an
+// ERR packet would desync the stream. The miss must still be reported and the
+// connection kept open, but no packet is written.
+func TestHandleCommandMockMiss_NoResponseCommandKeepsConnectionWithoutWrite(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	decodeCtx := newTestDecodeCtx(serverConn, mysql.CLIENT_PROTOCOL_41)
+
+	var reported error
+	ctx := models.WithMockMismatchReporter(context.Background(), func(err error) { reported = err })
+
+	req := mysql.Request{PacketBundle: mysql.PacketBundle{
+		Header: &mysql.PacketInfo{
+			Type:   mysql.CommandStatusToString(mysql.COM_QUIT),
+			Header: &mysql.Header{SequenceID: 0},
+		},
+		Message: &mysql.QueryPacket{},
+	}}
+	report := &models.MockMismatchReport{Protocol: "MySQL"}
+
+	// Fail the test if anything is written to the client (would block forever
+	// on net.Pipe if a write were attempted, so read in the background).
+	wrote := make(chan struct{}, 1)
+	go func() {
+		buf := make([]byte, 1)
+		_ = clientConn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+		if n, _ := clientConn.Read(buf); n > 0 {
+			wrote <- struct{}{}
+		}
+	}()
+
+	outcome := handleCommandMockMiss(ctx, zap.NewNop(), serverConn, req, report, decodeCtx, 1)
+	if outcome.err != nil {
+		t.Fatalf("expected connection kept open for no-response command, got: %v", outcome.err)
+	}
+	if reported == nil {
+		t.Fatal("expected the miss to still be reported for a no-response command")
+	}
+	select {
+	case <-wrote:
+		t.Fatal("no ERR packet should be written for a no-response command")
+	case <-time.After(600 * time.Millisecond):
+		// good: nothing written
+	}
+}
+
+// --- test helpers ---
+
+func newTestDecodeCtx(conn net.Conn, caps uint32) *wire.DecodeContext {
+	decodeCtx := &wire.DecodeContext{
+		Mode:            models.MODE_TEST,
+		LastOp:          wire.NewLastOpMap(),
+		ServerGreetings: wire.NewGreetings(),
+	}
+	decodeCtx.ServerGreetings.Store(conn, &mysql.HandshakeV10Packet{CapabilityFlags: caps})
+	return decodeCtx
+}
+
+func comQueryRequest(sql string, seqID uint8) mysql.Request {
+	return mysql.Request{PacketBundle: mysql.PacketBundle{
+		Header: &mysql.PacketInfo{
+			Type:   mysql.CommandStatusToString(mysql.COM_QUERY),
+			Header: &mysql.Header{SequenceID: seqID},
+		},
+		Message: &mysql.QueryPacket{Query: sql},
+	}}
+}
+
+// readErrPacket reads one MySQL packet off conn and decodes it as an ERR packet.
+func readErrPacket(t *testing.T, conn net.Conn, caps uint32) *mysql.ERRPacket {
+	t.Helper()
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+
+	header := make([]byte, 4)
+	if _, err := io.ReadFull(conn, header); err != nil {
+		t.Fatalf("failed to read packet header: %v", err)
+	}
+	payloadLen := uint32(header[0]) | uint32(header[1])<<8 | uint32(header[2])<<16
+	payload := make([]byte, payloadLen)
+	if _, err := io.ReadFull(conn, payload); err != nil {
+		t.Fatalf("failed to read packet payload: %v", err)
+	}
+
+	pkt, err := phase.DecodeERR(context.Background(), payload, caps)
+	if err != nil {
+		t.Fatalf("failed to decode ERR packet: %v", err)
+	}
+	return pkt
+}


### PR DESCRIPTION
## Describe the changes that are made
During replay, when a MySQL command has **no matching mock**, the replayer returned `models.ErrNoMockMatched`. That unwound to `errCh <- err` in `replay.go`, the command-phase goroutine returned, and the client's **entire TCP connection was dropped**. A single drifted or unrecorded query therefore took the whole connection down — a multi-second app outage, and with pooled drivers (e.g. Rails/Makara) a connection-pool blacklist cascade. This pattern was observed hundreds of times in a real customer's replay debug bundles.

### The HTTP contrast
The HTTP replayer (`pkg/agent/proxy/integrations/http/decode.go`) already handles this gracefully: its serve-without-mock path writes an error *response* for the one unmatched call and **keeps the connection open**. MySQL was asymmetric — one miss = connection teardown.

### The fix
On a command-phase mock-miss, `simulateCommandPhase` now:
- **surfaces the miss to the test report out-of-band** via the `MockMismatchReporter` installed on the context (the same sink a returned `ErrNoMockMatched` feeds through the proxy) — so the test still fails with full diagnostics;
- **writes a single MySQL ERR packet** (`1105 ER_UNKNOWN_ERROR`, SQLSTATE `HY000`, message `keploy: no matching mock for query`) as the degraded response for that one query; and
- **continues the command loop** to read the next command.

### Conservative fallbacks (nothing silently swallowed)
- If **no mismatch reporter** is installed (older agent / non-test path), the original wrapped `ErrNoMockMatched` is returned exactly as before.
- **No-response commands** (`COM_STMT_CLOSE` / `COM_STMT_SEND_LONG_DATA` / `COM_QUIT`) report the miss and keep the connection open *without* writing an ERR packet (a write would desync the stream).
- A **genuine I/O or encode failure** while writing the ERR packet is still fatal to the connection.
- **Matching logic, the record path, and all other error kinds are untouched.**

## Links & References
**Closes:** NA
### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA

## What type of PR is this? (check all applicable)
- [x] 🐞 Bug Fix

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed

> Scope note (honest): verification was done at the **replayer unit level** plus a full build — a full end-to-end record→replay cycle was **not** run as part of this PR. New replayer-level regression tests cover:
> 1. mock-miss with a reporter present → **ERR packet served + connection kept open + miss reported** (asserts the fatal teardown error does **not** propagate);
> 2. mock-miss with **no reporter** → wrapped `ErrNoMockMatched` returned (fallback preserved);
> 3. **no-response command** miss → connection kept open, no packet written, miss still reported.
>
> `go test ./pkg/agent/proxy/integrations/mysql/...` — all pass. `go build ./...` — clean.

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

```
go test ./pkg/agent/proxy/integrations/mysql/... 
go build ./...
```

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA

🤖 Generated with [Claude Code](https://claude.com/claude-code)