### PR TITLE
fix(ci): fail fast on a dead docker build and stop the readiness probe racing keploy

### DIFF
--- a/.github/workflows/golang_linux.yml
+++ b/.github/workflows/golang_linux.yml
@@ -75,7 +75,9 @@ jobs:
 
       - name: Install yq
         run: |
-          curl -sL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o yq
+          # -f so an HTTP error is not silently written into the yq binary
+          curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused \
+            https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o yq
           chmod +x yq
           sudo mv yq /usr/bin/
           
@@ -251,7 +253,9 @@ jobs:
 
       - name: Install yq
         run: |
-          curl -sL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o yq
+          # -f so an HTTP error is not silently written into the yq binary
+          curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused \
+            https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o yq
           chmod +x yq
           sudo mv yq /usr/bin/
 

--- a/.github/workflows/python_linux.yml
+++ b/.github/workflows/python_linux.yml
@@ -122,7 +122,14 @@ jobs:
         run: |
           DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
           mkdir -p $DOCKER_CONFIG/cli-plugins
-          curl -SL https://github.com/docker/compose/releases/download/v2.33.1/docker-compose-linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
+          # --fail matters more than the retries: without it curl writes the
+          # HTTP error body into the plugin file and exits 0, chmod +x happily
+          # marks it executable, and the failure only surfaces later as
+          # "docker: unknown command: docker compose". Observed on run
+          # 32473729951, where this fetched 92 bytes instead of the binary.
+          curl -fSL --retry 5 --retry-delay 2 --retry-connrefused \
+            https://github.com/docker/compose/releases/download/v2.33.1/docker-compose-linux-x86_64 \
+            -o $DOCKER_CONFIG/cli-plugins/docker-compose
           chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
           docker compose version
 

--- a/.github/workflows/test_workflow_scripts/docker-build-retry.sh
+++ b/.github/workflows/test_workflow_scripts/docker-build-retry.sh
@@ -1,0 +1,86 @@
+# Retry wrapper for image builds that pull public base images.
+#
+# Sourced via:
+#
+#   source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
+#
+# WHY THIS EXISTS
+#
+# Docker Hub meters anonymous pulls at 100 manifest requests per rolling
+# 3600s window, keyed to the *egress IP* rather than to the machine or the
+# job. Every runner behind a shared NAT therefore spends from one bucket,
+# so a build can 429 because of traffic this repo never generated. When it
+# happens BuildKit fails at `[internal] load metadata for <image>` and no
+# image is produced, after which every later step in the script fails for a
+# reason that has nothing to do with the real cause.
+#
+# Note this is a *mitigation, not a cure*: a retry cannot manufacture pull
+# budget. It helps because the window is rolling rather than an hourly
+# reset, so capacity trickles back continuously. The durable fixes are an
+# authenticated pull (which moves the meter off the shared IP onto an
+# account) or a pull-through registry mirror; both need credentials or
+# daemon config that this script cannot provide.
+#
+# WHY ONLY RATE LIMITS ARE RETRIED
+#
+# Retrying every failure would turn a genuine 30-second compile break into
+# a multi-minute one and push the compiler error far up the log. So a
+# non-rate-limit failure aborts on the first attempt, with its exit code.
+#
+# The match is on the *wording* and never on a bare "429": those three
+# digits also occur in ISO-8601 timestamps and layer byte counts in this
+# very output, and matching them would silently reclassify real breakage
+# as a rate limit.
+DOCKER_BUILD_RETRY_RE='toomanyrequests|too many requests|pull rate limit|rate limit exceeded'
+
+# docker_build_retry <command> [args...]
+#
+# Runs the build, echoing its output, and retries with exponential backoff
+# only while the failure looks like a Docker Hub rate limit.
+docker_build_retry() {
+    local _max="${DOCKER_BUILD_RETRY_ATTEMPTS:-4}"
+    local _backoff="${DOCKER_BUILD_RETRY_BACKOFF:-15}"
+    local _attempt=1
+    local _rc=0
+    local _log
+    local _restore_errexit=0
+
+    # Several callers run under `set -e`; some do not. Suspend it around the
+    # build so a failure lands in $_rc for inspection instead of killing the
+    # shell, then put the caller's setting back exactly as it was.
+    case "$-" in *e*) _restore_errexit=1 ;; esac
+
+    # Explicit template: BSD mktemp on the macOS runners has no default one.
+    _log="$(mktemp "${TMPDIR:-/tmp}/docker-build-retry.XXXXXX")"
+
+    while : ; do
+        echo "docker_build_retry: $* (attempt ${_attempt}/${_max})"
+
+        set +e
+        "$@" 2>&1 | tee "$_log"
+        _rc=${PIPESTATUS[0]}
+        if [ "$_restore_errexit" -eq 1 ]; then set -e; fi
+
+        if [ "$_rc" -eq 0 ]; then
+            rm -f "$_log"
+            return 0
+        fi
+
+        if ! grep -qiE "$DOCKER_BUILD_RETRY_RE" "$_log"; then
+            echo "::error::'$*' failed with exit code ${_rc}. Not a Docker Hub rate limit, so not retrying."
+            rm -f "$_log"
+            exit 1
+        fi
+
+        if [ "$_attempt" -ge "$_max" ]; then
+            echo "::error::'$*' failed after ${_max} attempts: Docker Hub pull rate limit (HTTP 429) did not clear. This is an infrastructure limit on the runner's egress IP, not a defect in this change."
+            rm -f "$_log"
+            exit 1
+        fi
+
+        echo "Docker Hub rate limit hit (exit ${_rc}); retrying in ${_backoff}s…"
+        sleep "$_backoff"
+        _attempt=$((_attempt + 1))
+        _backoff=$((_backoff * 2))
+    done
+}

--- a/.github/workflows/test_workflow_scripts/golang/echo_sql/golang-docker-macos.sh
+++ b/.github/workflows/test_workflow_scripts/golang/echo_sql/golang-docker-macos.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 # for the below source make it such a way that if the file is not present or already present it does not error
 source ./../../.github/workflows/test_workflow_scripts/test-iid-macos.sh
+source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
 
 # ---------------------------------------------------------------------------
 # Docker daemon readiness barrier. On the self-hosted macOS runner Docker
@@ -124,7 +125,7 @@ for cf in docker-compose.yml docker-compose.yaml; do
 done
 
 # Build Docker Image(s)
-docker compose build
+docker_build_retry docker compose build
 
 # Remove any preexisting keploy tests and mocks.
 rm -rf keploy/

--- a/.github/workflows/test_workflow_scripts/golang/echo_sql/golang-docker.sh
+++ b/.github/workflows/test_workflow_scripts/golang/echo_sql/golang-docker.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 source ./../../.github/workflows/test_workflow_scripts/test-iid.sh
+source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
 
 # Build Docker Image
-docker compose build
+docker_build_retry docker compose build
 
 # Remove any preexisting keploy tests and mocks.
 sudo rm -rf keploy/

--- a/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-docker-macos.sh
+++ b/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-docker-macos.sh
@@ -11,6 +11,7 @@ if [[ ! -f "${TEST_IID_SCRIPT}" ]]; then
   exit 1
 fi
 source "${TEST_IID_SCRIPT}"
+source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
 
 # Verify Docker Desktop is running -- never start it from CI.
 if ! docker info >/dev/null 2>&1; then
@@ -102,7 +103,7 @@ for file in $(find . -maxdepth 1 -type f \( -name "*.yml" -o -name "*.yaml" \));
 done
 
 # Build the app image with a unique tag.
-docker build -t "$APP_IMAGE" .
+docker_build_retry docker build -t "$APP_IMAGE" .
 
 send_request(){
     echo "Sending requests to the application..."

--- a/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-docker.sh
+++ b/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-docker.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ./../../.github/workflows/test_workflow_scripts/test-iid.sh
+source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
 
 # Start mongo before starting keploy.
 docker network create keploy-network
@@ -18,7 +19,7 @@ sudo rm -rf keploy/
 docker logs mongoDb &
 
 # Start keploy in record mode.
-docker build -t gin-mongo .
+docker_build_retry docker build -t gin-mongo .
 docker rm -f ginApp 2>/dev/null || true
 
 container_kill() {

--- a/.github/workflows/test_workflow_scripts/golang/go-dedup/golang-docker-windows.ps1
+++ b/.github/workflows/test_workflow_scripts/golang/go-dedup/golang-docker-windows.ps1
@@ -235,8 +235,99 @@ $env:APP_BASE_URL = "http://localhost:$appPort"
 Write-Host "Chosen app port: $appPort"
 Write-Host "Chosen container name: $containerName"
 
+# Build the sample image, retrying only a Docker Hub rate limit.
+#
+# Two independent failures used to compound here, and between them they
+# hid the real cause for nine minutes on run 32388095493 / job
+# 96488562918:
+#
+#   1. `docker compose build` ran bare. A native command's non-zero exit
+#      does NOT raise a terminating error in PowerShell 5.1 even under
+#      $ErrorActionPreference = 'Stop', so the script sailed straight past
+#      a build that had produced no image, waited out the full app
+#      readiness deadline, then sent six requests that could only fail
+#      with "Unable to connect to the remote server". The job's *reported*
+#      error was an unrelated taskkill on an already-dead PID. The 429 was
+#      still in the log, ~9 minutes further up.
+#
+#   2. Nothing retried. Docker Hub meters anonymous pulls at 100 manifest
+#      requests per rolling 3600s window keyed to the *egress IP*, and the
+#      self-hosted runners on this VM share one office NAT address — so
+#      the budget is routinely spent by traffic this repo never generated.
+#      Because the window rolls rather than resetting hourly, capacity
+#      trickles back continuously and a short backoff has a real chance of
+#      clearing it. It is a mitigation, not a cure: a retry cannot
+#      manufacture pull budget.
+#
+# Only a rate limit is retried. Retrying every failure would turn a
+# genuine 30-second compile break into a multi-minute one and push the
+# compiler error far up the log, so anything else throws on attempt 1.
+function Invoke-DockerBuildWithRetry {
+  param(
+    [string[]]$BuildArgs = @('compose', 'build'),
+    [int]$MaxAttempts = 4,
+    [int]$InitialBackoffSec = 15
+  )
+
+  $backoff = $InitialBackoffSec
+  for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+    Write-Host "docker $($BuildArgs -join ' ') (attempt $attempt/$MaxAttempts)…"
+
+    # docker writes all of its build progress to stderr, and under
+    # $ErrorActionPreference = 'Stop' the `2>&1` merge below turns the very
+    # first stderr line into a terminating NativeCommandError — which would
+    # abort here before the output could be examined for a 429 at all.
+    # Drop to 'Continue' for the duration of the call only.
+    $prevEap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    # Stream each line as it arrives AND accumulate it. Two reasons not to
+    # capture with `| Out-String` and print at the end:
+    #
+    # It would buffer the whole build, so a build that HANGS - the case the
+    # 330s agent budget exists to tolerate - would print nothing at all, and a
+    # cancelled or timed-out job would lose the build log entirely.
+    #
+    # And Out-String renders stderr ErrorRecords through the formatter, which
+    # hard-wraps at $Host.UI.RawUI.BufferSize.Width (120 on these runners, even
+    # with stdout redirected). Measured on the runner: that splits
+    # "Too Many Requests" across a line break for 17 of 81 realistic line
+    # lengths, so the match below would silently fail and report a 429 as "not
+    # a rate limit". It also injects a NativeCommandError block into every
+    # green build log that reads as though this helper crashed.
+    $sb = New-Object System.Text.StringBuilder
+    try {
+      & docker @BuildArgs 2>&1 | ForEach-Object {
+        $line = if ($_ -is [System.Management.Automation.ErrorRecord]) { $_.ToString() } else { [string]$_ }
+        [void]$sb.AppendLine($line)
+        Write-Host $line
+      }
+      $rc = $LASTEXITCODE
+    } finally {
+      $ErrorActionPreference = $prevEap
+    }
+    $output = $sb.ToString()
+
+    if ($rc -eq 0) { return }
+
+    # Match the wording, never a bare "429": those digits also appear in
+    # ISO-8601 timestamps and layer byte counts in this same output, and
+    # matching them would reclassify real breakage as a rate limit.
+    if ($output -match 'toomanyrequests|too\s+many\s+requests|pull\s+rate\s+limit|rate\s+limit\s+exceeded') {
+      if ($attempt -lt $MaxAttempts) {
+        Write-Warning "Docker Hub pull rate limit hit (exit $rc). Retrying in ${backoff}s…"
+        Start-Sleep -Seconds $backoff
+        $backoff = $backoff * 2
+        continue
+      }
+      throw "docker $($BuildArgs -join ' ') failed after $MaxAttempts attempts: the Docker Hub pull rate limit (HTTP 429) did not clear. This is an infrastructure limit on the runner's egress IP, not a defect in the change under test."
+    }
+
+    throw "docker $($BuildArgs -join ' ') failed with exit code $rc. The output above is the build error; this is not a Docker Hub rate limit, so it was not retried."
+  }
+}
+
 Write-Host "Building Docker image(s) with docker compose..."
-docker compose build
+Invoke-DockerBuildWithRetry
 
 # --- Clean previous keploy outputs ---
 $candidates = @(".\keploy")
@@ -408,7 +499,26 @@ function Show-KeployLogFiles {
 #      the remaining five — the prior `try { req1; req2; ... } catch`
 #      swallowed the first failure and sent $sent=0 requests.
 Write-Host "Waiting for app to respond on $base/hello/keploy …"
-$deadline       = (Get-Date).AddMinutes(5)
+# 7 minutes, not 5, because this probe races keploy's own agent-readiness
+# wait and used to lose. On the compose lane keploy waits
+# pkg.DefaultAgentReadyTimeout (330s, pkg/util.go) for the in-docker
+# keploy-agent to report healthy, and only reports the real failure after
+# that. At 5 minutes this loop gave up 30s BEFORE keploy could speak, so a
+# genuinely failed bring-up surfaced as six "Unable to connect to the
+# remote server" retries instead of the actual cause — observed on run
+# 32388095493 / job 96488562918.
+#
+# This costs a genuinely-failing job about 35s: the probe now waits for
+# keploy to die at ~335s rather than giving up at 300s while keploy is
+# still silent, and the traffic phase below still runs either way. What is
+# bought is the diagnostic - Show-KeployLogFiles now dumps a log that
+# contains keploy's own error instead of a mid-flight snapshot taken
+# before it had written one.
+# Raising it here rather than shrinking the agent's healthcheck budget is
+# deliberate — that budget ships to every user and exists to tolerate slow
+# docker daemons; buying prettier CI logs with product tolerance is the
+# wrong trade.
+$deadline       = (Get-Date).AddMinutes(7)
 $stabilityCount = 3
 $settleSec      = 5
 $okStreak       = 0

--- a/.github/workflows/test_workflow_scripts/golang/go_memory_load/golang-docker.sh
+++ b/.github/workflows/test_workflow_scripts/golang/go_memory_load/golang-docker.sh
@@ -3,6 +3,7 @@
 set -Eeuo pipefail
 
 source "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/test-iid.sh"
+source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
 
 APP_CONTAINER_NAME="${APP_CONTAINER_NAME:-load-test-api}"
 APP_HEALTH_URL="${APP_HEALTH_URL:-http://127.0.0.1:8080/healthz}"
@@ -426,7 +427,7 @@ run_loadtest() {
 }
 
 section "Building sample application images"
-docker compose build
+docker_build_retry docker compose build
 
 section "Cleaning previous artifacts"
 sudo rm -rf keploy/

--- a/.github/workflows/test_workflow_scripts/golang/go_memory_load_grpc/golang-docker.sh
+++ b/.github/workflows/test_workflow_scripts/golang/go_memory_load_grpc/golang-docker.sh
@@ -3,6 +3,7 @@
 set -Eeuo pipefail
 
 source "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/test-iid.sh"
+source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
 
 APP_CONTAINER_NAME="${APP_CONTAINER_NAME:-load-test-grpc-api}"
 APP_HEALTH_URL="${APP_HEALTH_URL:-http://127.0.0.1:8080/healthz}"
@@ -465,7 +466,7 @@ run_loadtest() {
 }
 
 section "Building sample application images"
-docker compose build
+docker_build_retry docker compose build
 
 section "Cleaning previous artifacts"
 sudo rm -rf keploy/

--- a/.github/workflows/test_workflow_scripts/golang/go_memory_load_mongo/golang-docker.sh
+++ b/.github/workflows/test_workflow_scripts/golang/go_memory_load_mongo/golang-docker.sh
@@ -3,6 +3,7 @@
 set -Eeuo pipefail
 
 source "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/test-iid.sh"
+source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
 
 APP_CONTAINER_NAME="${APP_CONTAINER_NAME:-load-test-mongo-api}"
 APP_HEALTH_URL="${APP_HEALTH_URL:-http://127.0.0.1:8080/healthz}"
@@ -519,7 +520,7 @@ run_loadtest() {
 }
 
 section "Building sample application images"
-docker compose build
+docker_build_retry docker compose build
 
 section "Cleaning previous artifacts"
 sudo rm -rf keploy/

--- a/.github/workflows/test_workflow_scripts/golang/go_memory_load_mysql/golang-docker.sh
+++ b/.github/workflows/test_workflow_scripts/golang/go_memory_load_mysql/golang-docker.sh
@@ -3,6 +3,7 @@
 set -Eeuo pipefail
 
 source "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/test-iid.sh"
+source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
 
 APP_CONTAINER_NAME="${APP_CONTAINER_NAME:-load-test-mysql-api}"
 APP_HEALTH_URL="${APP_HEALTH_URL:-http://127.0.0.1:8080/healthz}"
@@ -519,7 +520,7 @@ run_loadtest() {
 }
 
 section "Building sample application images"
-docker compose build
+docker_build_retry docker compose build
 
 section "Cleaning previous artifacts"
 sudo rm -rf keploy/

--- a/.github/workflows/test_workflow_scripts/golang/http_pokeapi/golang-native-windows.ps1
+++ b/.github/workflows/test_workflow_scripts/golang/http_pokeapi/golang-native-windows.ps1
@@ -167,7 +167,16 @@ function Show-Logs {
 
 # Wait for app readiness - http-pokeapi has a 2-second sleep at startup
 Write-Host "Waiting for app to respond on $base/api/greet..."
-$deadline = (Get-Date).AddMinutes(5)
+# 7 minutes, same value and same reasoning as the go-dedup docker lane.
+# This lane is native: there is no agent container and no compose
+# healthcheck. What still applies is keploy's own wait - it gives the
+# native agent up to pkg.DefaultAgentReadyTimeout (330s, pkg/util.go) to
+# report ready before launching `go run .`. That is a ceiling polled on a
+# 1s ticker, not a fixed cost, which is why healthy runs here finish in
+# 2-6 minutes. But when the agent does not come up, the old 5-minute
+# deadline expired before keploy had reported anything, and the probe fell
+# through to fire traffic at a port nothing was listening on.
+$deadline = (Get-Date).AddMinutes(7)
 $ready = $false
 do {
   # Check if the process is still running

--- a/.github/workflows/test_workflow_scripts/golang/proxy_stress_test/golang-docker.sh
+++ b/.github/workflows/test_workflow_scripts/golang/proxy_stress_test/golang-docker.sh
@@ -7,8 +7,9 @@
 # 4. HTTP MatchType: POST through forward proxy
 
 source ./../../.github/workflows/test_workflow_scripts/test-iid.sh
+source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
 
-docker compose build
+docker_build_retry docker compose build
 sudo rm -rf keploy/
 $RECORD_BIN config --generate
 

--- a/.github/workflows/test_workflow_scripts/node/express_mongoose/node-docker.sh
+++ b/.github/workflows/test_workflow_scripts/node/express_mongoose/node-docker.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ./../../.github/workflows/test_workflow_scripts/test-iid.sh
+source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
 
 # Start the docker container.
 docker network create keploy-network
@@ -10,7 +11,7 @@ docker run --name mongoDb --rm --net keploy-network -p 27017:27017 -d mongo
 sudo rm -rf keploy/
 
 # Build the image of the application.
-docker build -t node-app:1.0 .
+docker_build_retry docker build -t node-app:1.0 .
 
 container_kill() {
     # pid=$(pgrep -f "keploy record")

--- a/.github/workflows/test_workflow_scripts/python-docker-macos.sh
+++ b/.github/workflows/test_workflow_scripts/python-docker-macos.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 # for the below shource make it such a way that if the file is not present or already present it does not error
 source ./../../.github/workflows/test_workflow_scripts/test-iid-macos.sh
+source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
 
 # Function to find available port
 find_available_port() {
@@ -77,7 +78,7 @@ docker run --name "$DB_CONTAINER" --rm \
 rm -rf keploy/  # Clean up old test data
 rm ./keploy.yml >/dev/null 2>&1 || true
 
-docker build -t $APP_IMAGE .
+docker_build_retry docker build -t $APP_IMAGE .
 
 
 # Generate the keploy-config file.

--- a/.github/workflows/test_workflow_scripts/python-docker.sh
+++ b/.github/workflows/test_workflow_scripts/python-docker.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ./../../.github/workflows/test_workflow_scripts/test-iid.sh
+source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
 
 # Start mongo before starting keploy.
 docker network create keploy-network
@@ -8,7 +9,7 @@ docker run --name mongo --rm --net keploy-network -p 27017:27017 -d mongo
 
 # Set up environment
 rm -rf keploy/  # Clean up old test data
-docker build -t flask-app:1.0 .  # Build the Docker image
+docker_build_retry docker build -t flask-app:1.0 .  # Build the Docker image
 
 # Configure keploy
 sed -i 's/global: {}/global: {"header": {"Allow":[]}}/' "./keploy.yml"


### PR DESCRIPTION
## Describe the changes that are made

Two CI defects found while chasing a "regression" that turned out not to exist. Both make real failures hard to diagnose, which is how the non-existent regression cost four days.

### 1. The readiness probe gives up before keploy reports its own error

`keploy record -c "docker compose up"` waits `pkg.DefaultAgentReadyTimeout` — **330s** (`pkg/util.go`) — for the in-docker agent to report ready. That `select` watches only the timeout and the ready channel, **not** the app-error channel, so even after compose reports `dependency failed to start … unhealthy` at ~310s, keploy stays silent until 330s.

The Windows probes gave up at **300s**. So they always expired *just* before keploy said anything, then fell through and fired traffic at a dead port — filling the log with six `The underlying connection was closed` retries and no cause. Observed on run 32388095493 / job 96488562918.

Both probes now allow **420s**. This costs a genuinely-failing job ~35s; what it buys is that `Show-KeployLogFiles` finally dumps a log containing keploy's own error instead of a mid-flight snapshot taken before it had written one.

`http_pokeapi/golang-native-windows.ps1` gets the same value for a different reason — that lane is native, with no agent container and no compose healthcheck, but keploy still gives the native agent up to the same 330s before launching `go run .`.

Deliberately **not** changed: `retries` in `pkg/platform/docker/docker.go`. It ships to every user and exists to tolerate slow daemons (its comment records an observed 126s `docker run` of an already-local image). Lowering it also would not fix this, because keploy's CLI-side wait is a separate constant.

### 2. Docker Hub rate limiting aborts the build with a misleading error

3 of 10 failures of this job over a 7-day survey were `429 Too Many Requests` pulling `golang:1.25-alpine`. The sample app image then never builds, and every subsequent request fails with `Unable to connect to the remote server` — nothing in the log names the rate limit.

A shared `docker-build-retry.sh` (bash) and an inline `Invoke-DockerBuildWithRetry` (PowerShell) wrap the 12 explicit `docker compose build` sites: 4 attempts, 15s doubling backoff.

**It retries only on rate-limit wording** — `toomanyrequests`, `too\s+many\s+requests`, `pull rate limit`, `rate limit exceeded` — and never on a bare `429`, because those digits also occur in ISO-8601 timestamps and layer byte counts in the same output. A non-rate-limit failure aborts after exactly one invocation, so real build breakage still fails fast.

Making a dead build **fatal** is arguably the bigger win: `docker compose up` only re-resolves manifests when the image is absent, so the two further rate-limit exposures inside keploy's own compose up become unreachable once the build is required to succeed.

## Three things worth knowing before merging

**This is a mitigation, not a cure.** The limit is 100 pulls/hour per *egress IP*, shared across everything behind the same NAT. **The only real fix needs you**: create `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` secrets and add `docker/login-action` to the self-hosted lanes, which moves the meter onto an account. The repo currently has no Docker Hub credential at all — the only `docker/login-action` uses (`release.yml:504`, `:570`) target ghcr.io. A pull-through mirror in `daemon.json` is the alternative, but that is a daemon restart on a VM hosting 4 live runners.

**These lanes are fork-gated, so this cannot be verified from a fork** — it needs a branch inside `keploy/keploy`, which is what this is.

**Latent sites left alone, deliberately:** eleven other readiness loops have the same mismatch (`gin_mongo` native, `proxy_stress_test`, the `go_memory_load_*` family, the macOS lanes) and four are unbounded `while` loops that hang to the job cap. None has been observed failing, the macOS ones sit under a 30-min cap I could not measure against, and the unbounded loops are a different defect. Raising them blind risks *causing* timeouts.

## Verification

PowerShell was verified on a real Windows runner (PS 5.1.26100.8875), not reasoned about:

- Both `.ps1` files `Parser::ParseFile` clean; BOMs byte-identical to `main` (`efbbbf` / `3c230a`).
- Retry driven against a `docker.cmd` stub: `ok` → 1 invocation, rc 0; non-rate-limit → 1 invocation, throws; persistent limit → 3 invocations with 1s→2s backoff, throws; clears on attempt 3 → succeeds. Throw propagates to **exit 1** through CI's exact dot-source invocation.
- **`$ErrorActionPreference` guard is load-bearing**: docker writes all build progress to stderr, so under `'Stop'` the `2>&1` merge turns the first progress line into a terminating `NativeCommandError` before any output can be examined. The function drops to `'Continue'` for the call and restores in `finally`.
- **Output is streamed, not buffered**: verified a build's progress appears in the log at t=2s mid-build. Capturing with `| Out-String` would have gone dark for the whole build — losing the log entirely on a cancelled or timed-out job — and its formatter hard-wraps at the console width (120), splitting `Too Many Requests` across a line break for **17 of 81** realistic line lengths, which would have made the retry silently not fire and report a 429 as "not a rate limit".

Bash: all 13 changed files `bash -n` clean; `shellcheck` clean on the helper; `errexit` correctly saved/restored under `set -e` and `set -Eeuo pipefail`; verified not to retry on a `429 bytes`/timestamp false positive; `trap … EXIT` still fires.

## Links & References

**Closes:** NA

### 🐞 Related Issues
- NA — found while investigating a suspected Windows record regression that turned out to be the host WSL2 RCU stall already fixed in #4456 / #4459.

## What type of PR is this? (check all applicable)
- [x] 🔁 CI

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed — this changes the pipeline itself

## Self Review done?
- [x] ✅ yes
