### PR TITLE
fix(contract): stop array, scalar and array-root contracts from failing generation and matching

### DIFF
--- a/pkg/matcher/schema/match.go
+++ b/pkg/matcher/schema/match.go
@@ -92,53 +92,108 @@ func compareParameters(mockParameters, testParameters []models.Parameter) (bool,
 	return pass, nil
 }
 
-func compareResponseBodies(status string, mockOperation, testOperation *models.Operation, logDiffs matcher.DiffsPrinter, newLogger *pp.PrettyPrinter, logger *zap.Logger, testName, mockName, testSetID, mockSetID string, mode models.SchemaMatchMode) (float64, bool, bool, error) {
-	pass := true
-	overallScore := 0.0
-	matched := false
-	differencesCount := 0.0
-	if _, ok := testOperation.Responses[status]; ok {
-		mockResponseBodyStr, testResponseBodyStr, err := matcher.MarshalResponseBodies(status, mockOperation, testOperation)
-		if err != nil {
-			return differencesCount, false, false, err
-		}
-		overallScore = float64(len(mockOperation.Responses[status].Content["application/json"].Schema.Properties))
-		validatedJSON, err := matcher.ValidateAndMarshalJSON(logger, &mockResponseBodyStr, &testResponseBodyStr)
-		if err != nil {
-			return differencesCount, false, false, err
-		}
+func compareResponseBodies(status string, mockOperation, testOperation *models.Operation, logDiffs matcher.DiffsPrinter, newLogger *pp.PrettyPrinter, logger *zap.Logger, testName, mockName, testSetID, mockSetID string, mode models.SchemaMatchMode) (float64, bool, error) {
+	testResponse, ok := testOperation.Responses[status]
+	if !ok {
+		// The test case never produced this status code, so the mock is not a
+		// candidate for it. Returning before any arithmetic is the point: the
+		// old code set the sentinel and then divided it by the mock's property
+		// count on the way out, turning -1 into -Inf, or into NaN whenever the
+		// mock had no properties to divide by.
+		return NOTCANDIDATE, false, nil
+	}
 
+	mockResponseBodyStr, testResponseBodyStr, err := matcher.MarshalResponseBodies(status, mockOperation, testOperation)
+	if err != nil {
+		return NOTCANDIDATE, false, err
+	}
+
+	// Score from the schemas, in both modes, so a mock's score never depends on
+	// which mode computed it.
+	score := schemaSimilarity(
+		mockOperation.Responses[status].Content["application/json"].Schema,
+		testResponse.Content["application/json"].Schema,
+	)
+
+	validatedJSON, err := matcher.ValidateAndMarshalJSON(logger, &mockResponseBodyStr, &testResponseBodyStr)
+	if err != nil {
+		return NOTCANDIDATE, false, err
+	}
+
+	// CompareMode does not score; it re-runs the comparison for the chosen
+	// candidate purely to render the diff the user sees.
+	if mode == models.CompareMode {
 		if validatedJSON.IsIdentical() {
-			switch mode {
-			case models.CompareMode:
-				if _, matched, err = handleJSONDiff(validatedJSON, logDiffs, newLogger, logger, testName, mockName, testSetID, mockSetID, mockResponseBodyStr, testResponseBodyStr, "response", mode); err != nil {
-					return differencesCount, false, false, err
-				}
-			case models.IdentifyMode:
-				differencesCount, err = calculateSimilarityScore(mockOperation, testOperation, status)
-				if err != nil {
-					return differencesCount, false, false, err
-				}
+			if _, _, err = handleJSONDiff(validatedJSON, logDiffs, newLogger, logger, testName, mockName, testSetID, mockSetID, mockResponseBodyStr, testResponseBodyStr, "response", mode); err != nil {
+				return NOTCANDIDATE, false, err
 			}
 		} else {
-			differencesCount = overallScore
+			logDiffs.PushTypeDiff(fmt.Sprint(reflect.TypeOf(validatedJSON.Expected())), fmt.Sprint(reflect.TypeOf(validatedJSON.Actual())))
+			logs := newLogger.Sprintf("Contract Check failed for test: %s (%s) / mock: %s (%s) \n\n--------------------------------------------------------------------\n\n", testName, testSetID, mockName, mockSetID)
 
-			if mode == models.CompareMode {
-				logDiffs.PushTypeDiff(fmt.Sprint(reflect.TypeOf(validatedJSON.Expected())), fmt.Sprint(reflect.TypeOf(validatedJSON.Actual())))
-				logs := newLogger.Sprintf("Contract Check failed for test: %s (%s) / mock: %s (%s) \n\n--------------------------------------------------------------------\n\n", testName, testSetID, mockName, mockSetID)
-
-				if err := printAndRenderLogs(logs, newLogger, logDiffs, logger); err != nil {
-					return differencesCount, false, false, err
-				}
+			if err := printAndRenderLogs(logs, newLogger, logDiffs, logger); err != nil {
+				return NOTCANDIDATE, false, err
 			}
 		}
-	} else {
-		pass = false
-		differencesCount = -1
-
 	}
-	return differencesCount / overallScore, pass, matched, nil
+
+	return score, true, nil
 }
+
+// schemaSimilarity reports the fraction of what the mock's response schema
+// requires that the test's response schema provides: 1 means the test covers
+// the mock completely, 0 means it shares nothing with it. A test carrying extra
+// fields still scores 1 - the mock is what has to be satisfied.
+//
+// Every return is a literal or a division whose denominator is guaranteed
+// non-zero, which is the property that matters. The score used to be computed
+// as differencesCount/len(mockSchema.Properties), and an array-root, scalar-root
+// or body-less response has no properties at all: 0/0 = NaN. NaN loses every
+// comparison, so consumer's `pass && candidateScore > best` gate rejected it and
+// the mock was reported MISSED no matter which test it was scored against.
+//
+// It recurses into Items because that is the only thing an array-root schema
+// carries. Returning a flat 1 for "no properties" would make every array-root
+// mock score 1 against every array-root test, so ties would be broken by Go's
+// map iteration order and []int would match []string.
+//
+// Property comparison stays top-level and type-only, as it has always been:
+// recursing into nested object properties would move the scores of contracts
+// that match correctly today, which is a separate change.
+func schemaSimilarity(mock, test models.Schema) float64 {
+	if !sameSchemaType(mock.Type, test.Type) {
+		// An object response and an array response are not the same shape.
+		return 0
+	}
+
+	if len(mock.Properties) > 0 {
+		matches := 0.0
+		for key, mockProp := range mock.Properties {
+			if testProp, ok := test.Properties[key]; ok && sameSchemaType(mockProp["type"], testProp["type"]) {
+				matches++
+			}
+		}
+		return matches / float64(len(mock.Properties))
+	}
+
+	if mock.Type == "array" {
+		if mock.Items == nil {
+			// The mock says nothing about its elements, so there is nothing
+			// for the test to disagree with.
+			return 1
+		}
+		if test.Items == nil {
+			return 0
+		}
+		return schemaSimilarity(*mock.Items, *test.Items)
+	}
+
+	// A scalar root, or no JSON body on either side (a 204, or a DELETE with an
+	// empty response). The types already agreed above and there is nothing else
+	// in the contract to compare.
+	return 1
+}
+
 func Match(mock, test models.OpenAPI, testSetID string, mockSetID string, logger *zap.Logger, mode models.SchemaMatchMode) (float64, bool, error) {
 	pass := false
 
@@ -180,7 +235,7 @@ func Match(mock, test models.OpenAPI, testSetID string, mockSetID string, logger
 
 			}
 
-			if candidateScore, pass, _, err = compareResponseBodies(statusCode, mockOperation, testOperation, logDiffs, newLogger, logger, test.Info.Title, mock.Info.Title, testSetID, mockSetID, mode); err != nil {
+			if candidateScore, pass, err = compareResponseBodies(statusCode, mockOperation, testOperation, logDiffs, newLogger, logger, test.Info.Title, mock.Info.Title, testSetID, mockSetID, mode); err != nil {
 				return candidateScore, false, err
 			}
 
@@ -192,19 +247,6 @@ func Match(mock, test models.OpenAPI, testSetID string, mockSetID string, logger
 	}
 
 	return candidateScore, pass, nil
-}
-func calculateSimilarityScore(mockOperation, testOperation *models.Operation, status string) (float64, error) {
-	testParameters := testOperation.Responses[status].Content["application/json"].Schema.Properties
-	mockParameters := mockOperation.Responses[status].Content["application/json"].Schema.Properties
-	score := 0.0
-	for key, testParam := range testParameters {
-		if _, ok := mockParameters[key]; ok {
-			if sameSchemaType(testParam["type"], mockParameters[key]["type"]) {
-				score++
-			}
-		}
-	}
-	return score, nil
 }
 
 // sameSchemaType reports whether two OpenAPI type names describe the same

--- a/pkg/matcher/schema/score_test.go
+++ b/pkg/matcher/schema/score_test.go
@@ -1,0 +1,275 @@
+package schema
+
+import (
+	"math"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// objectSchema, arraySchema and scalarSchema build the response schema shapes
+// `keploy contract generate` emits for an object root, an array root and a
+// scalar root respectively.
+func objectSchema(props map[string]string) models.Schema {
+	s := models.Schema{Type: "object"}
+	if props != nil {
+		s.Properties = make(map[string]map[string]interface{}, len(props))
+		for name, typ := range props {
+			s.Properties[name] = map[string]interface{}{"type": typ}
+		}
+	}
+	return s
+}
+
+func arraySchema(items models.Schema) models.Schema {
+	return models.Schema{Type: "array", Items: &items}
+}
+
+func scalarSchema(typ string) models.Schema { return models.Schema{Type: typ} }
+
+// opWithResponse builds an operation whose request body is fixed (so
+// compareRequestBodies always admits the candidate and the response score is
+// what is under test) and whose 200 response carries the given schema.
+func opWithResponse(resp models.Schema) *models.Operation {
+	req := objectSchema(map[string]string{"q": "string"})
+	return &models.Operation{
+		RequestBody: &models.RequestBody{
+			Content: map[string]models.MediaType{"application/json": {Schema: req}},
+		},
+		Responses: map[string]models.ResponseItem{
+			"200": {Content: map[string]models.MediaType{"application/json": {Schema: resp}}},
+		},
+	}
+}
+
+// classify mirrors the trichotomy in consumer.ValidateMockAgainstTests: a mock
+// is PASSED at exactly 1.0, FAILED above 0, and MISSED at 0 - and the gate in
+// scoresForMocks only ever records a score that is both passing and strictly
+// better than the current one, so anything it rejects leaves the mock at its
+// initial 0.0 and it prints as MISSED.
+//
+// The product's trichotomy is not total: a NaN matches none of its three
+// branches. This helper is total on purpose, so a score that falls through
+// every branch is reported as "unclassified" instead of quietly vanishing.
+func classify(score float64, pass bool) string {
+	if !pass || !(score > 0.0) {
+		// Includes NaN, which loses every comparison.
+		return "missed"
+	}
+	switch {
+	case score == 1.0:
+		return "passed"
+	case score > 0.0 && score < 1.0:
+		return "failed"
+	default:
+		return "unclassified"
+	}
+}
+
+// TestMatch_ScoreIsAlwaysFinite is the regression test for the NaN score.
+//
+// The score used to be differencesCount/len(mockSchema.Properties). An array
+// root, a scalar root, a body-less response and an object with no fields all
+// have zero properties, so that expression was 0/0 for every one of them. NaN
+// loses every comparison, including the `candidateScore > best` gate in
+// consumer.scoresForMocks, so those mocks could never be recorded as matched:
+// they were reported MISSED against every test case, however well they matched.
+//
+// Each case asserts the score is finite before comparing it. NaN != want is
+// true, so a plain inequality check does fail on NaN - but it reports
+// "want 1, got NaN", which reads like an ordinary scoring change rather than
+// the arithmetic defect it is.
+func TestMatch_ScoreIsAlwaysFinite(t *testing.T) {
+	tests := []struct {
+		name       string
+		mock, test models.Schema
+		wantScore  float64
+		wantClass  string
+	}{
+		{
+			name: "array root matching itself",
+			mock: arraySchema(objectSchema(map[string]string{"id": "integer"})),
+			test: arraySchema(objectSchema(map[string]string{"id": "integer"})),
+			// The whole point of #4447: array-root contracts are reachable, and
+			// a perfect match has to be reportable as one.
+			wantScore: 1, wantClass: "passed",
+		},
+		{
+			name: "array root where the test carries an extra field",
+			mock: arraySchema(objectSchema(map[string]string{"id": "integer"})),
+			test: arraySchema(objectSchema(map[string]string{"id": "integer", "name": "string"})),
+			// The mock is what must be satisfied; extra fields on the test side
+			// are not a defect, exactly as for object roots.
+			wantScore: 1, wantClass: "passed",
+		},
+		{
+			name: "array root missing one of the mock's item fields",
+			mock: arraySchema(objectSchema(map[string]string{"id": "integer", "name": "string"})),
+			test: arraySchema(objectSchema(map[string]string{"id": "integer"})),
+			// Must discriminate: a flat 1.0 for "no properties at the root"
+			// would make every array-root mock tie with every other.
+			wantScore: 0.5, wantClass: "failed",
+		},
+		{
+			name:      "array root with disjoint item fields",
+			mock:      arraySchema(objectSchema(map[string]string{"id": "integer"})),
+			test:      arraySchema(objectSchema(map[string]string{"name": "string"})),
+			wantScore: 0, wantClass: "missed",
+		},
+		{
+			name:      "array of integer vs array of string",
+			mock:      arraySchema(scalarSchema("integer")),
+			test:      arraySchema(scalarSchema("string")),
+			wantScore: 0, wantClass: "missed",
+		},
+		{
+			name: "array of integer vs array of number across keploy versions",
+			mock: arraySchema(scalarSchema("integer")),
+			test: arraySchema(scalarSchema("number")),
+			// Same version-skew allowance sameSchemaType makes for properties;
+			// it has to survive the recursion into Items.
+			wantScore: 1, wantClass: "passed",
+		},
+		{
+			name:      "nested array roots",
+			mock:      arraySchema(arraySchema(scalarSchema("integer"))),
+			test:      arraySchema(arraySchema(scalarSchema("integer"))),
+			wantScore: 1, wantClass: "passed",
+		},
+		{
+			name:      "object with no fields on both sides",
+			mock:      objectSchema(nil),
+			test:      objectSchema(nil),
+			wantScore: 1, wantClass: "passed",
+		},
+		{
+			name: "no JSON response body on either side",
+			mock: models.Schema{},
+			test: models.Schema{},
+			// A 204, or a DELETE with an empty body. Path, method and status
+			// all agree and there is no body to disagree about.
+			wantScore: 1, wantClass: "passed",
+		},
+		{
+			name: "object mock vs array test",
+			mock: objectSchema(map[string]string{"id": "integer"}),
+			test: arraySchema(objectSchema(map[string]string{"id": "integer"})),
+			// This one used to score 1.0 and report PASSED - a false green. The
+			// two schemas are not the same response shape.
+			wantScore: 0, wantClass: "missed",
+		},
+		{
+			name:      "array mock vs object test",
+			mock:      arraySchema(objectSchema(map[string]string{"id": "integer"})),
+			test:      objectSchema(map[string]string{"id": "integer"}),
+			wantScore: 0, wantClass: "missed",
+		},
+		{
+			name: "object mock vs test with no response body",
+			mock: objectSchema(map[string]string{"id": "integer"}),
+			test: models.Schema{},
+			// Also a false green before: a JSON mock scored 1.0 against a test
+			// that returned no body at all.
+			wantScore: 0, wantClass: "missed",
+		},
+		{
+			name:      "object roots still score as they always did",
+			mock:      objectSchema(map[string]string{"a": "string", "b": "string"}),
+			test:      objectSchema(map[string]string{"a": "string"}),
+			wantScore: 0.5, wantClass: "failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, pass, err := Match(docWith(opWithResponse(tt.mock)), docWith(opWithResponse(tt.test)),
+				"test-set-0", "mock-set-0", zap.NewNop(), models.IdentifyMode)
+			if err != nil {
+				t.Fatalf("Match failed: %v", err)
+			}
+			// Check finiteness first and separately, so the failure names the
+			// real problem instead of looking like a changed expectation.
+			if math.IsNaN(got) || math.IsInf(got, 0) {
+				t.Fatalf("score is not a finite number: %v (NaN and +/-Inf lose every comparison, so this mock can never be recorded as matched)", got)
+			}
+			if got != tt.wantScore {
+				t.Errorf("score = %v, want %v", got, tt.wantScore)
+			}
+			if gotClass := classify(got, pass); gotClass != tt.wantClass {
+				t.Errorf("consumer would report %q, want %q (score %v, pass %v)", gotClass, tt.wantClass, got, pass)
+			}
+		})
+	}
+}
+
+// TestMatch_MissingStatusIsAFiniteSentinel pins the other arithmetic hazard in
+// the same expression: the "test never returned this status" sentinel was -1,
+// and dividing it by the mock's property count turned it into -Inf, or into NaN
+// when the mock had no properties for the sentinel to be divided by.
+func TestMatch_MissingStatusIsAFiniteSentinel(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		mock models.Schema
+	}{
+		{name: "object root", mock: objectSchema(map[string]string{"id": "integer"})},
+		{name: "array root", mock: arraySchema(scalarSchema("integer"))},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			testOp := opWithResponse(objectSchema(map[string]string{"id": "integer"}))
+			testOp.Responses = map[string]models.ResponseItem{
+				"404": testOp.Responses["200"],
+			}
+
+			got, pass, err := Match(docWith(opWithResponse(tt.mock)), docWith(testOp),
+				"test-set-0", "mock-set-0", zap.NewNop(), models.IdentifyMode)
+			if err != nil {
+				t.Fatalf("Match failed: %v", err)
+			}
+			if math.IsNaN(got) || math.IsInf(got, 0) {
+				t.Fatalf("score is not a finite number: %v", got)
+			}
+			if got != NOTCANDIDATE {
+				t.Errorf("score = %v, want %v (NOTCANDIDATE)", got, NOTCANDIDATE)
+			}
+			if pass {
+				t.Error("pass = true, want false: the test case never returned the mock's status code")
+			}
+		})
+	}
+}
+
+// TestSchemaSimilarity_Polarity asserts the score means similarity, not
+// difference. Individually plausible numbers survive an inverted polarity - the
+// ordering does not, and neither does the perfect/disjoint pair. One branch of
+// the old code assigned a variable literally named differencesCount into the
+// slot the ratio was computed from, so this is not a hypothetical mix-up.
+func TestSchemaSimilarity_Polarity(t *testing.T) {
+	mock := objectSchema(map[string]string{"a": "string", "b": "string", "c": "string", "d": "string"})
+
+	perfect := schemaSimilarity(mock, objectSchema(map[string]string{"a": "string", "b": "string", "c": "string", "d": "string"}))
+	partial := schemaSimilarity(mock, objectSchema(map[string]string{"a": "string", "b": "string"}))
+	disjoint := schemaSimilarity(mock, objectSchema(map[string]string{"z": "string"}))
+	shapeMismatch := schemaSimilarity(mock, arraySchema(scalarSchema("string")))
+
+	for name, score := range map[string]float64{
+		"perfect": perfect, "partial": partial, "disjoint": disjoint, "shapeMismatch": shapeMismatch,
+	} {
+		if math.IsNaN(score) || math.IsInf(score, 0) {
+			t.Fatalf("%s score is not a finite number: %v", name, score)
+		}
+	}
+
+	if perfect != 1.0 {
+		t.Errorf("a test covering the mock completely scored %v, want 1", perfect)
+	}
+	if disjoint != 0.0 {
+		t.Errorf("a test sharing no field with the mock scored %v, want 0", disjoint)
+	}
+	if shapeMismatch != 0.0 {
+		t.Errorf("a test of a different root shape scored %v, want 0", shapeMismatch)
+	}
+	if !(perfect > partial && partial > disjoint) {
+		t.Errorf("score is not ordered by similarity: perfect=%v partial=%v disjoint=%v", perfect, partial, disjoint)
+	}
+}

--- a/pkg/models/openapi.go
+++ b/pkg/models/openapi.go
@@ -105,7 +105,13 @@ type ResponseItem struct {
 }
 
 type Schema struct {
-	Type       string                            `json:"type" yaml:"type"`
+	// Type is omitempty because an untyped schema is the only thing OpenAPI 3.0
+	// offers for a value whose observations conflict (an array holding both a
+	// string and a number). `type: ""` is not a legal type and kin-openapi
+	// rejects it, so the key has to be absent rather than empty. Every schema
+	// inferred from consistent data still carries a type, so no contract that
+	// generates today changes shape.
+	Type       string                            `json:"type,omitempty" yaml:"type,omitempty"`
 	Properties map[string]map[string]interface{} `json:"properties,omitempty" yaml:"properties,omitempty"`
 	Items      *Schema                           `json:"items,omitempty" yaml:"items,omitempty"`
 	Nullable   bool                              `json:"nullable,omitempty" yaml:"nullable,omitempty"`

--- a/pkg/service/contract/consumer/score_test.go
+++ b/pkg/service/contract/consumer/score_test.go
@@ -1,0 +1,104 @@
+package consumer
+
+import (
+	"math"
+	"testing"
+
+	"go.keploy.io/server/v3/config"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// arrayRootDoc builds the contract `keploy contract generate` emits for an
+// endpoint whose response body is a JSON array - the shape #4447 made
+// reachable.
+func arrayRootDoc(title string, itemProps map[string]string) *models.OpenAPI {
+	props := make(map[string]map[string]interface{}, len(itemProps))
+	for name, typ := range itemProps {
+		props[name] = map[string]interface{}{"type": typ}
+	}
+	op := &models.Operation{
+		RequestBody: &models.RequestBody{
+			Content: map[string]models.MediaType{
+				"application/json": {Schema: models.Schema{Type: "object"}},
+			},
+		},
+		Responses: map[string]models.ResponseItem{
+			"200": {Content: map[string]models.MediaType{
+				"application/json": {Schema: models.Schema{
+					Type:  "array",
+					Items: &models.Schema{Type: "object", Properties: props},
+				}},
+			}},
+		},
+	}
+	return &models.OpenAPI{
+		OpenAPI: "3.0.0",
+		Info:    models.Info{Title: title, Version: "1.0.0"},
+		Paths:   map[string]models.PathItem{"/users": {Get: op}},
+	}
+}
+
+// TestScoresForMocks_ArrayRootMockIsRecorded is the end-to-end assertion for the
+// NaN score, at the layer that actually swallowed it.
+//
+// scoresForMocks seeds every mock at 0.0 and only overwrites that when
+// `pass && candidateScore > current`. A NaN loses that comparison, so an
+// array-root mock kept its seeded 0.0 and ValidateMockAgainstTests printed it
+// as MISSED - with no test set and no test name attached, because the branch
+// that records them never ran. A unit test on the score alone cannot catch a
+// regression here; only going through this gate can.
+func TestScoresForMocks_ArrayRootMockIsRecorded(t *testing.T) {
+	s := &consumer{logger: zap.NewNop(), config: &config.Config{}}
+
+	mock := arrayRootDoc("mock-users", map[string]string{"id": "integer", "name": "string"})
+	matching := arrayRootDoc("test-users", map[string]string{"id": "integer", "name": "string"})
+
+	mockSet := map[string]models.SchemaInfo{}
+	s.scoresForMocks([]*models.OpenAPI{mock}, mockSet,
+		map[string]map[string]*models.OpenAPI{"test-set-0": {"test-users": matching}}, "mock-set-0")
+
+	got, ok := mockSet["mock-users"]
+	if !ok {
+		t.Fatal("mock is missing from the score set entirely")
+	}
+	if math.IsNaN(got.Score) || math.IsInf(got.Score, 0) {
+		t.Fatalf("recorded score is not a finite number: %v", got.Score)
+	}
+	if got.Score != 1.0 {
+		t.Errorf("score = %v, want 1 (an array-root mock matching an identical test must be recorded as passed)", got.Score)
+	}
+	if got.Name != "test-users" {
+		t.Errorf("matched test name = %q, want %q: the gate never recorded which test matched", got.Name, "test-users")
+	}
+	if got.TestSetID != "test-set-0" {
+		t.Errorf("matched test set = %q, want %q", got.TestSetID, "test-set-0")
+	}
+}
+
+// TestScoresForMocks_BestCandidateWins asserts the score still discriminates
+// between candidates once array roots are scorable. Returning a flat 1.0 for
+// "the root schema has no properties" would fix the NaN while making every
+// array-root mock tie with every array-root test, leaving the winner to Go's
+// map iteration order.
+func TestScoresForMocks_BestCandidateWins(t *testing.T) {
+	s := &consumer{logger: zap.NewNop(), config: &config.Config{}}
+
+	mock := arrayRootDoc("mock-users", map[string]string{"id": "integer", "name": "string"})
+	best := arrayRootDoc("test-full", map[string]string{"id": "integer", "name": "string"})
+	partial := arrayRootDoc("test-partial", map[string]string{"id": "integer"})
+
+	for _, order := range []map[string]*models.OpenAPI{
+		{"test-full": best, "test-partial": partial},
+		{"test-partial": partial, "test-full": best},
+	} {
+		mockSet := map[string]models.SchemaInfo{}
+		s.scoresForMocks([]*models.OpenAPI{mock}, mockSet,
+			map[string]map[string]*models.OpenAPI{"test-set-0": order}, "mock-set-0")
+
+		got := mockSet["mock-users"]
+		if got.Score != 1.0 || got.Name != "test-full" {
+			t.Errorf("best candidate = %q at score %v, want \"test-full\" at 1", got.Name, got.Score)
+		}
+	}
+}

--- a/pkg/service/contract/httpdoc_scalarroot_test.go
+++ b/pkg/service/contract/httpdoc_scalarroot_test.go
@@ -1,0 +1,71 @@
+package contract
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// TestHTTPDocToOpenAPI_ScalarRoots covers JSON documents whose root is neither
+// an object nor an array. SchemaForBody used to describe every non-array root
+// as {type: object}, so the generated schema was violated by its own example
+// and validateSchema aborted the whole contract generate run - the same failure
+// mode as the array shapes, one root type over.
+//
+// An API answering `5`, `"ok"` or `true` is ordinary: JSON permits any value as
+// a document.
+func TestHTTPDocToOpenAPI_ScalarRoots(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "integer root", body: `5`, want: "integer"},
+		{name: "float root", body: `1.5`, want: "number"},
+		{name: "string root", body: `"hello"`, want: "string"},
+		{name: "boolean root", body: `true`, want: "boolean"},
+		{name: "large integer root", body: `9007199254740993`, want: "integer"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &contract{}
+			oapi, err := svc.HTTPDocToOpenAPI(zap.NewNop(), httpDocWith("GET", "", tt.body))
+			if err != nil {
+				t.Fatalf("HTTPDocToOpenAPI failed on %s: %v", tt.body, err)
+			}
+			got := oapi.Paths["/users"].Get.Responses["200"].Content["application/json"].Schema
+			if got.Type != tt.want {
+				t.Errorf("root schema type = %q, want %q", got.Type, tt.want)
+			}
+			if err := validateSchema(oapi); err != nil {
+				t.Fatalf("generated OpenAPI for %s is invalid: %v", tt.body, err)
+			}
+		})
+	}
+}
+
+// TestHTTPDocToOpenAPI_ObjectAndEmptyRootsUnchanged pins the two roots that must
+// keep their old shape: an object root still carries the caller's extracted
+// properties, and a body-less doc still serializes its example as {}.
+func TestHTTPDocToOpenAPI_ObjectAndEmptyRootsUnchanged(t *testing.T) {
+	svc := &contract{}
+
+	oapi, err := svc.HTTPDocToOpenAPI(zap.NewNop(), httpDocWith("GET", "", `{"id":1}`))
+	if err != nil {
+		t.Fatalf("object root failed: %v", err)
+	}
+	got := oapi.Paths["/users"].Get.Responses["200"].Content["application/json"].Schema
+	if got.Type != "object" || got.Properties["id"]["type"] != "integer" {
+		t.Errorf("object root = %+v, want type object with id integer", got)
+	}
+
+	empty, err := svc.HTTPDocToOpenAPI(zap.NewNop(), httpDocWith("GET", "", ""))
+	if err != nil {
+		t.Fatalf("empty body failed: %v", err)
+	}
+	gotEmpty := empty.Paths["/users"].Get.Responses["200"].Content["application/json"].Schema
+	if gotEmpty.Type != "object" {
+		t.Errorf("empty body root type = %q, want object", gotEmpty.Type)
+	}
+}

--- a/pkg/service/contract/httpdoc_shape_test.go
+++ b/pkg/service/contract/httpdoc_shape_test.go
@@ -1,0 +1,332 @@
+package contract
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// describeSchema renders a generated schema as a compact, deterministic string
+// so a test can pin the whole inferred shape - nesting included - instead of
+// reaching into one field. Notation: [x] is an array of x, {k:v} an object,
+// `any` an untyped schema, and a trailing ? means nullable.
+func describeSchema(s models.Schema) string {
+	out := s.Type
+	switch s.Type {
+	case "":
+		out = "any"
+	case "array":
+		inner := "<missing items>"
+		if s.Items != nil {
+			inner = describeSchema(*s.Items)
+		}
+		out = "[" + inner + "]"
+	case "object":
+		out = describeProps(s.Properties)
+	}
+	if s.Nullable {
+		out += "?"
+	}
+	return out
+}
+
+// describeProperty is describeSchema for the map form every schema below the
+// root is held in.
+func describeProperty(p map[string]interface{}) string {
+	typ, _ := p["type"].(string)
+	out := typ
+	switch typ {
+	case "":
+		out = "any"
+	case "array":
+		inner := "<missing items>"
+		if items, ok := p["items"].(map[string]interface{}); ok {
+			inner = describeProperty(items)
+		}
+		out = "[" + inner + "]"
+	case "object":
+		props, _ := p["properties"].(map[string]map[string]interface{})
+		out = describeProps(props)
+	}
+	if p["nullable"] == true {
+		out += "?"
+	}
+	return out
+}
+
+func describeProps(props map[string]map[string]interface{}) string {
+	keys := make([]string, 0, len(props))
+	for k := range props {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+":"+describeProperty(props[k]))
+	}
+	return "{" + strings.Join(parts, ",") + "}"
+}
+
+// generatedSchemas runs a body through the real generation path as both a
+// request and a response body, asserts the resulting document passes real
+// kin-openapi validation, and returns the two inferred shapes.
+//
+// Both directions matter: request and response schemas are built by the same
+// code but only the response carries an example, and it is the example that
+// kin-openapi checks the schema against.
+func generatedSchemas(t *testing.T, body string) (reqShape, respShape string) {
+	t.Helper()
+	svc := &contract{}
+
+	oapi, err := svc.HTTPDocToOpenAPI(zap.NewNop(), httpDocWith("POST", body, body))
+	if err != nil {
+		t.Fatalf("HTTPDocToOpenAPI(%s) failed: %v", body, err)
+	}
+	if err := validateSchema(oapi); err != nil {
+		t.Fatalf("generated contract for %s is not a valid OpenAPI document: %v", body, err)
+	}
+
+	post := oapi.Paths["/users"].Post
+	return describeSchema(post.RequestBody.Content["application/json"].Schema),
+		describeSchema(post.Responses["200"].Content["application/json"].Schema)
+}
+
+// TestHTTPDocToOpenAPI_NestedAndUninformativeArrays covers the shapes that
+// aborted `keploy contract generate` outright: the generator inferred an item
+// schema from a single chosen element, so anything that element failed to
+// reveal was either missing (an array of arrays got items:{type:array} with no
+// nested items, which OpenAPI forbids) or wrong (an empty or null element made
+// the item type default to "string", and the recorded example then violated the
+// schema the generator had just written).
+//
+// Every case here produced an invalid document before the fold replaced
+// sample-and-widen; generatedSchemas asserts validity, so these fail without
+// the fix regardless of the shape assertions.
+func TestHTTPDocToOpenAPI_NestedAndUninformativeArrays(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		// An array of arrays under an object key emitted items:{type: array}
+		// with no nested items. This aborted generation for a HOMOGENEOUS body
+		// too, so any object field holding an array of arrays was affected.
+		{name: "homogeneous array of arrays under a key", body: `{"a":[[1,2]]}`, want: `{a:[[integer]]}`},
+		{name: "mixed numeric array of arrays under a key", body: `{"a":[[1,1.5]]}`, want: `{a:[[number]]}`},
+		{name: "widening across sibling inner arrays", body: `{"a":[[1],[2,3.5]]}`, want: `{a:[[number]]}`},
+		{name: "three levels of nesting", body: `{"a":[[[1]]]}`, want: `{a:[[[integer]]]}`},
+		{name: "array of arrays of objects", body: `{"a":[[{"x":1}]]}`, want: `{a:[[{x:integer}]]}`},
+		{name: "array of arrays under a nested object", body: `{"a":{"b":[[1]]}}`, want: `{a:{b:[[integer]]}}`},
+		{name: "array of arrays under an array root", body: `[{"v":[[1,1.5]]}]`, want: `[{v:[[number]]}]`},
+		{name: "null beside an inner array", body: `{"a":[null,[1]]}`, want: `{a:[[integer]?]}`},
+
+		// An empty first element revealed no item type, so the schema said
+		// "string" and the example then failed validation.
+		{name: "empty array before an informative one", body: `[[],[1]]`, want: `[[integer]]`},
+		{name: "empty array then widening elements", body: `[[],[1],[1.5]]`, want: `[[number]]`},
+		{name: "empty array before an object", body: `[[],[{"x":1}]]`, want: `[[{x:integer}]]`},
+		{name: "empty array before a nested array", body: `[[],[[1]]]`, want: `[[[integer]]]`},
+		// Uninformative at depth 2: no "first informative element" rule that
+		// looks only at the top level can fix this one.
+		{name: "uninformative at depth two", body: `[[[]],[[1]]]`, want: `[[[integer]]]`},
+		// Uninformative through an object key rather than positionally.
+		{name: "empty array under an object key", body: `[{"v":[]},{"v":[1]}]`, want: `[{v:[integer]}]`},
+		{name: "empty array under a key one level deeper", body: `{"a":[{"v":[]},{"v":[1]}]}`, want: `{a:[{v:[integer]}]}`},
+		// A null sample is exactly as uninformative as an empty array, and the
+		// result must not depend on which element came first.
+		{name: "null property before a typed one", body: `[{"v":null},{"v":1}]`, want: `[{v:integer?}]`},
+		{name: "typed property before a null one", body: `[{"v":1},{"v":null}]`, want: `[{v:integer?}]`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotReq, gotResp := generatedSchemas(t, tt.body)
+			if gotReq != tt.want {
+				t.Errorf("request schema = %s, want %s", gotReq, tt.want)
+			}
+			if gotResp != tt.want {
+				t.Errorf("response schema = %s, want %s", gotResp, tt.want)
+			}
+		})
+	}
+}
+
+// TestHTTPDocToOpenAPI_ConflictingElementKinds pins what happens when elements
+// disagree on kind rather than merely on numeric width.
+//
+// OpenAPI 3.0 cannot say "string or integer" in a single type; oneOf is the
+// honest encoding and is deliberately out of scope. An untyped schema is the
+// only construct that accepts every kind, so that is what gets emitted - and
+// unlike the previous behaviour of believing the first element, it produces a
+// document the recorded example actually satisfies.
+func TestHTTPDocToOpenAPI_ConflictingElementKinds(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "string then integer", body: `["x",1]`, want: `[any]`},
+		{name: "integer then string", body: `[1,"x"]`, want: `[any]`},
+		{name: "array then string", body: `[[],"x"]`, want: `[any]`},
+		{name: "array then object", body: `[[],{}]`, want: `[any]`},
+		{name: "conflict one level down", body: `[[1],["x"]]`, want: `[[any]]`},
+		{name: "conflict under an object key", body: `{"a":[[1],["x"]]}`, want: `{a:[[any]]}`},
+		// A conflict that also saw a null must stay nullable, or kin-openapi
+		// rejects the null in the example: an untyped schema accepts every
+		// kind but still refuses null unless nullable is set.
+		{name: "null with conflicting kinds", body: `[null,"x",1]`, want: `[any?]`},
+		{name: "null with every kind", body: `[null,1,"x",[2],{"a":1}]`, want: `[any?]`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotReq, gotResp := generatedSchemas(t, tt.body)
+			if gotReq != tt.want {
+				t.Errorf("request schema = %s, want %s", gotReq, tt.want)
+			}
+			if gotResp != tt.want {
+				t.Errorf("response schema = %s, want %s", gotResp, tt.want)
+			}
+		})
+	}
+}
+
+// TestHTTPDocToOpenAPI_ShapesUnchanged is the regression guard for the fold.
+//
+// Replacing sample-and-widen with a fold over every element rewrote how every
+// schema is inferred, not just the broken shapes. These bodies all generated
+// valid contracts before, and every one of them must still produce exactly the
+// same schema, or the fix silently rewrites contracts that were already right.
+func TestHTTPDocToOpenAPI_ShapesUnchanged(t *testing.T) {
+	tests := []struct{ body, want string }{
+		{`[]`, `[string]`},
+		{`[1,2,3]`, `[integer]`},
+		{`[1,1.5]`, `[number]`},
+		{`[1.5,1]`, `[number]`},
+		{`["a","b"]`, `[string]`},
+		{`[true]`, `[boolean]`},
+		{`[[1,2]]`, `[[integer]]`},
+		{`[[1],[1.5]]`, `[[number]]`},
+		{`[[[1]]]`, `[[[integer]]]`},
+		{`[[{"x":1}]]`, `[[{x:integer}]]`},
+		{`[[]]`, `[[string]]`},
+		{`[[],[]]`, `[[string]]`},
+		{`[null]`, `[string?]`},
+		{`[null,[1]]`, `[[integer]?]`},
+		{`[null,1,1.5]`, `[number?]`},
+		{`[[null,1],[1.5]]`, `[[number?]]`},
+		{`[[null,1],[1.5,null]]`, `[[number?]]`},
+		{`[null,{"id":1}]`, `[{id:integer}?]`},
+		{`[{"id":1,"name":"Utkarsh"}]`, `[{id:integer,name:string}]`},
+		{`[{"id":1,"deleted_at":null}]`, `[{deleted_at:string?,id:integer}]`},
+		{`[{"a":1},{"a":1.5}]`, `[{a:number}]`},
+		{`[{"a":{"b":1}},{"a":{"b":1.5}}]`, `[{a:{b:number}}]`},
+		{`[{"v":[1]},{"v":[1.5]}]`, `[{v:[number]}]`},
+		{`[{"v":[null,1]},{"v":[1.5]}]`, `[{v:[number?]}]`},
+		// Only the keys the first object showed are described. OpenAPI allows
+		// undeclared properties, so this stays valid; unioning the keys would
+		// be better inference but is a separate change.
+		{`[{"a":1},{"b":2}]`, `[{a:integer}]`},
+		{`[{},{"x":1}]`, `[{}]`},
+		{`[{"v":[]}]`, `[{v:[string]}]`},
+		{`{"id":1}`, `{id:integer}`},
+		{`{"count":0}`, `{count:integer}`},
+		{`{"delta":-7}`, `{delta:integer}`},
+		{`{"price":1.5}`, `{price:number}`},
+		{`{"ratio":1.0}`, `{ratio:number}`},
+		{`{"big":1e10}`, `{big:number}`},
+		{`{"huge":9007199254740993}`, `{huge:integer}`},
+		{`{"ok":true}`, `{ok:boolean}`},
+		{`{"a":null}`, `{a:string?}`},
+		{`{"a":{"b":null}}`, `{a:{b:string?}}`},
+		{`{"tags":[null,"x"]}`, `{tags:[string?]}`},
+		{`{"rows":[{"v":null}]}`, `{rows:[{v:string?}]}`},
+		{`{"r":[{"v":[null,1]},{"v":[1.5]}]}`, `{r:[{v:[number?]}]}`},
+		{`{"prices":[10,9.99]}`, `{prices:[number]}`},
+		{`{"a":[]}`, `{a:[string]}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.body, func(t *testing.T) {
+			gotReq, gotResp := generatedSchemas(t, tt.body)
+			if gotReq != tt.want {
+				t.Errorf("request schema = %s, want %s", gotReq, tt.want)
+			}
+			if gotResp != tt.want {
+				t.Errorf("response schema = %s, want %s", gotResp, tt.want)
+			}
+		})
+	}
+}
+
+// TestItemSchemaFoldIsOrderIndependent asserts the property the fold is for:
+// merging is commutative, so the inferred item schema cannot depend on which
+// element the generator happened to look at first. Sample-and-widen could not
+// have this property - it is why [{"v":1},{"v":null}] and its reverse used to
+// disagree.
+func TestItemSchemaFoldIsOrderIndependent(t *testing.T) {
+	elements := []interface{}{
+		nil,
+		[]interface{}{},
+		[]interface{}{int64(1)},
+		[]interface{}{1.5},
+		map[string]interface{}{"v": int64(2)},
+	}
+
+	forward := itemSchema(elements)
+	finalizeSchema(forward)
+
+	reversed := make([]interface{}, len(elements))
+	for i, el := range elements {
+		reversed[len(elements)-1-i] = el
+	}
+	backward := itemSchema(reversed)
+	finalizeSchema(backward)
+
+	if got, want := describeProperty(backward), describeProperty(forward); got != want {
+		t.Errorf("reversed element order gave %s, want %s (same as forward order)", got, want)
+	}
+}
+
+// TestFinalizeSchemaIsIdempotent guards the one-shot contract finalizeSchema
+// documents: it must be safe to reach the same node twice (merged schemas share
+// subtrees), and running it again must never turn a filled-in default into
+// something else.
+func TestFinalizeSchemaIsIdempotent(t *testing.T) {
+	for _, body := range []interface{}{
+		[]interface{}{},
+		[]interface{}{nil, "x", int64(1)},
+		[]interface{}{map[string]interface{}{"v": nil}},
+	} {
+		s := itemSchema(body.([]interface{}))
+		finalizeSchema(s)
+		once := describeProperty(s)
+		finalizeSchema(s)
+		if twice := describeProperty(s); twice != once {
+			t.Errorf("finalizeSchema(%v) is not idempotent: once=%s twice=%s", body, once, twice)
+		}
+	}
+}
+
+// TestAnyTypeMarkerNeverEscapes is a belt-and-braces check that the internal
+// conflict marker cannot reach a generated contract: it is not a legal OpenAPI
+// type, so any leak would produce a document consumers cannot read.
+func TestAnyTypeMarkerNeverEscapes(t *testing.T) {
+	svc := &contract{}
+	for _, body := range []string{`["x",1]`, `[[1],["x"]]`, `{"a":[[1],["x"]]}`, `[null,1,"x"]`} {
+		oapi, err := svc.HTTPDocToOpenAPI(zap.NewNop(), httpDocWith("POST", body, body))
+		if err != nil {
+			t.Fatalf("HTTPDocToOpenAPI(%s): %v", body, err)
+		}
+		rendered := fmt.Sprintf("%#v", oapi)
+		for _, marker := range []string{anyType, unknownType} {
+			if strings.Contains(rendered, marker) {
+				t.Errorf("internal type marker %q leaked into the generated contract for %s", marker, body)
+			}
+		}
+	}
+}

--- a/pkg/service/contract/infer.go
+++ b/pkg/service/contract/infer.go
@@ -1,7 +1,6 @@
 package contract
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -14,6 +13,20 @@ import (
 )
 
 // InferSchema derives an OpenAPI 3.0 document from recorded HTTP test cases.
+//
+// Bodies are described by the same fold HTTPDocToOpenAPI uses (schemaForValue /
+// mergeSchemas / finalizeSchema) rather than by a second inference routine.
+// Keeping one implementation is the point: this used to decode with plain
+// encoding/json, so every JSON number arrived as a float64 and every integer
+// field was typed "number" - the same body run through the two surfaces of one
+// command produced two different contracts.
+//
+// Observations of the same operation are merged rather than one overwriting the
+// other. Request bodies used to be first-wins and responses last-wins, two
+// opposite policies in one function, which was invisible only while every
+// number was a float64: with integers typed as integers, a price of 10 in one
+// test case and 9.99 in another would otherwise produce a contract that depends
+// on the order the test cases happened to be walked in.
 func InferSchema(testCases []models.TestCase) (*openapi3.T, error) {
 	doc := &openapi3.T{
 		OpenAPI: "3.0.0",
@@ -23,6 +36,15 @@ func InferSchema(testCases []models.TestCase) (*openapi3.T, error) {
 		},
 		Paths: openapi3.NewPaths(),
 	}
+
+	// Raw, unfinalized schemas accumulated across every test case that touched
+	// the operation. They stay unfinalized until the fold is complete: filling
+	// in a default early turns "not observed yet" into a real type, and merging
+	// that with a later observation then reads as a conflict. The operation
+	// pointer identifies a path and method uniquely, which is exactly the key
+	// these are accumulated per.
+	requestSchemas := make(map[*openapi3.Operation]map[string]interface{})
+	responseSchemas := make(map[*openapi3.Operation]map[string]map[string]interface{})
 
 	for _, tc := range testCases {
 		method := strings.ToUpper(string(tc.HTTPReq.Method))
@@ -48,40 +70,55 @@ func InferSchema(testCases []models.TestCase) (*openapi3.T, error) {
 			pathItem.SetOperation(method, op)
 		}
 
-		if requestSchema, ok := inferSchemaFromBody(tc.HTTPReq.Body); ok && op.RequestBody == nil {
-			op.RequestBody = &openapi3.RequestBodyRef{
-				Value: &openapi3.RequestBody{
-					Required: false,
-					Content: openapi3.Content{
-						"application/json": &openapi3.MediaType{Schema: requestSchema},
-					},
-				},
-			}
+		if requestSchema, ok := inferSchemaFromBody(tc.HTTPReq.Body); ok {
+			requestSchemas[op] = mergeSchemas(requestSchemas[op], requestSchema)
 		}
 
 		statusCode := strconv.Itoa(tc.HTTPResp.StatusCode)
-		desc := tc.HTTPResp.StatusMessage
-		if desc == "" {
-			desc = http.StatusText(tc.HTTPResp.StatusCode)
-		}
-		if desc == "" {
-			desc = "response"
-		}
-		// Copy to avoid pointer aliasing across loop iterations
-		description := desc
-
-		response := &openapi3.Response{Description: &description}
-		if responseSchema, ok := inferSchemaFromBody(tc.HTTPResp.Body); ok {
-			response.Content = openapi3.Content{
-				"application/json": &openapi3.MediaType{Schema: responseSchema},
+		if op.Responses.Value(statusCode) == nil {
+			desc := tc.HTTPResp.StatusMessage
+			if desc == "" {
+				desc = http.StatusText(tc.HTTPResp.StatusCode)
 			}
+			if desc == "" {
+				desc = "response"
+			}
+			// Copy to avoid pointer aliasing across loop iterations
+			description := desc
+			op.Responses.Set(statusCode, &openapi3.ResponseRef{Value: &openapi3.Response{Description: &description}})
 		}
 
-		op.Responses.Set(statusCode, &openapi3.ResponseRef{Value: response})
+		if responseSchema, ok := inferSchemaFromBody(tc.HTTPResp.Body); ok {
+			if responseSchemas[op] == nil {
+				responseSchemas[op] = make(map[string]map[string]interface{})
+			}
+			responseSchemas[op][statusCode] = mergeSchemas(responseSchemas[op][statusCode], responseSchema)
+		}
 	}
 
 	if doc.Paths.Len() == 0 {
 		return nil, errors.New("no HTTP test cases found to infer schema")
+	}
+
+	// Every observation is in; resolve the placeholders and attach the result.
+	for op, schema := range requestSchemas {
+		finalizeSchema(schema)
+		op.RequestBody = &openapi3.RequestBodyRef{
+			Value: &openapi3.RequestBody{
+				Required: false,
+				Content: openapi3.Content{
+					"application/json": &openapi3.MediaType{Schema: openAPISchemaRef(schema)},
+				},
+			},
+		}
+	}
+	for op, byStatus := range responseSchemas {
+		for statusCode, schema := range byStatus {
+			finalizeSchema(schema)
+			op.Responses.Value(statusCode).Value.Content = openapi3.Content{
+				"application/json": &openapi3.MediaType{Schema: openAPISchemaRef(schema)},
+			}
+		}
 	}
 
 	return doc, nil
@@ -109,53 +146,49 @@ func extractPath(rawURL string) (string, error) {
 	return path, nil
 }
 
-func inferSchemaFromBody(body string) (*openapi3.SchemaRef, bool) {
+// inferSchemaFromBody returns a raw, unfinalized map-form schema for a recorded
+// body, or ok=false when the body is empty or not JSON this generator can
+// describe.
+func inferSchemaFromBody(body string) (map[string]interface{}, bool) {
 	trimmed := strings.TrimSpace(body)
 	if trimmed == "" {
 		return nil, false
 	}
 
-	var value any
-	if err := json.Unmarshal([]byte(trimmed), &value); err != nil {
+	// decodeJSONBody, not encoding/json: it keeps integer literals as int64, so
+	// an integer field is typed "integer" instead of "number", and an id above
+	// 2^53 stays exact. It is also stricter about trailing data, where a
+	// concatenated body would otherwise be described by its first document
+	// alone.
+	value, err := decodeJSONBody(trimmed)
+	if err != nil {
 		return nil, false
 	}
 
-	return inferSchemaRef(value), true
+	return schemaForValue(value), true
 }
 
-func inferSchemaRef(value any) *openapi3.SchemaRef {
-	switch v := value.(type) {
-	case nil:
-		s := openapi3.NewSchema()
-		s.Nullable = true
-		return openapi3.NewSchemaRef("", s)
-	case string:
-		return openapi3.NewSchemaRef("", openapi3.NewStringSchema())
-	case bool:
-		return openapi3.NewSchemaRef("", openapi3.NewBoolSchema())
-	case float64:
-		return openapi3.NewSchemaRef("", openapi3.NewFloat64Schema())
-	case []any:
-		arraySchema := openapi3.NewArraySchema()
-		if len(v) > 0 {
-			arraySchema.Items = inferSchemaRef(v[0])
-		} else {
-			// OpenAPI requires Items on array schemas; default to empty object.
-			arraySchema.Items = openapi3.NewSchemaRef("", openapi3.NewObjectSchema())
-		}
-		return openapi3.NewSchemaRef("", arraySchema)
-	case map[string]any:
-		objectSchema := openapi3.NewObjectSchema()
-		properties := make(openapi3.Schemas, len(v))
-
-		for key, val := range v {
-			properties[key] = inferSchemaRef(val)
-		}
-		objectSchema.Properties = properties
-		// Do not mark all fields Required from a single sample; inference
-		// from one observation cannot determine which fields are optional.
-		return openapi3.NewSchemaRef("", objectSchema)
-	default:
-		return openapi3.NewSchemaRef("", openapi3.NewStringSchema())
+// openAPISchemaRef converts a finalized map-form schema to the kin-openapi
+// representation this document is built from. A schema with no type is left
+// untyped, which is how a conflict between observations is expressed.
+func openAPISchemaRef(s map[string]interface{}) *openapi3.SchemaRef {
+	schema := openapi3.NewSchema()
+	if t, ok := s["type"].(string); ok && t != "" {
+		schema.Type = &openapi3.Types{t}
 	}
+	if s["nullable"] == true {
+		schema.Nullable = true
+	}
+	if props := propertiesOf(s); props != nil {
+		schema.Properties = make(openapi3.Schemas, len(props))
+		for key, prop := range props {
+			schema.Properties[key] = openAPISchemaRef(prop)
+		}
+	}
+	if items := itemsOf(s); items != nil {
+		schema.Items = openAPISchemaRef(items)
+	}
+	// Fields are deliberately not marked Required: inference cannot tell an
+	// optional field that happened to be present from a mandatory one.
+	return openapi3.NewSchemaRef("", schema)
 }

--- a/pkg/service/contract/infer_test.go
+++ b/pkg/service/contract/infer_test.go
@@ -69,7 +69,9 @@ func TestInferSchemaPOSTEndpointWithJSONBody(t *testing.T) {
 	schema := requestBody.Value.Content["application/json"].Schema
 	assertSchemaType(t, schema, "object")
 	assertSchemaType(t, schema.Value.Properties["name"], "string")
-	assertSchemaType(t, schema.Value.Properties["age"], "number")
+	// 30 is an integer literal. This asserted "number" while InferSchema
+	// decoded with encoding/json, which makes every JSON number a float64.
+	assertSchemaType(t, schema.Value.Properties["age"], "integer")
 }
 
 func TestInferSchemaMultipleEndpoints(t *testing.T) {
@@ -116,7 +118,8 @@ func TestInferSchemaTypeInferenceNestedObjects(t *testing.T) {
 	schema := response.Value.Content["application/json"].Schema
 
 	assertSchemaType(t, schema.Value.Properties["name"], "string")
-	assertSchemaType(t, schema.Value.Properties["age"], "number")
+	// See TestInferSchemaPOSTEndpointWithJSONBody: 30 is an integer.
+	assertSchemaType(t, schema.Value.Properties["age"], "integer")
 	assertSchemaType(t, schema.Value.Properties["active"], "boolean")
 
 	profile := schema.Value.Properties["profile"]

--- a/pkg/service/contract/infer_types_test.go
+++ b/pkg/service/contract/infer_types_test.go
@@ -92,6 +92,14 @@ func TestInferSchema_AgreesWithHTTPDocToOpenAPI(t *testing.T) {
 		`{"empty":[]}`,
 		`{"maybe":null}`,
 		`{"rows":[{"id":1},{"id":1.5}]}`,
+		`{"deep":{"inner":{"n":1,"f":1.5}}}`,
+		`{"aoa":[[1,2]]}`,
+		`{"rows":[{"v":[1,1.5]}]}`,
+		`[{"id":1,"tags":["a"]}]`,
+		`[1,2,3]`,
+		`5`,
+		`"hello"`,
+		`true`,
 	}
 
 	svc := &contract{}
@@ -105,13 +113,11 @@ func TestInferSchema_AgreesWithHTTPDocToOpenAPI(t *testing.T) {
 			}
 			generated := oapi.Paths["/users"].Post.Responses["200"].Content["application/json"].Schema
 
-			for name, prop := range inferred.Properties {
-				got := typeOf(t, prop.Value)
-				want, _ := generated.Properties[name]["type"].(string)
-				if got != want {
-					t.Errorf("property %q: InferSchema says %q, HTTPDocToOpenAPI says %q", name, got, want)
-				}
-			}
+			// Compare the whole tree, not just the top level: a depth-1
+			// comparison passes while the two surfaces disagree about a
+			// nested property or an array's item type, which is exactly the
+			// kind of drift this test exists to catch.
+			diffSchemaTrees(t, "", inferred, &generated)
 		})
 	}
 }
@@ -250,5 +256,73 @@ func TestInferSchema_UndescribableBodyIsSkipped(t *testing.T) {
 				t.Error("an undescribable response body produced response content")
 			}
 		})
+	}
+}
+
+// diffSchemaTrees walks an InferSchema result and its HTTPDocToOpenAPI
+// counterpart together, reporting the first type disagreement at any depth.
+// The two surfaces use different schema representations, so this compares the
+// type strings structurally rather than the structs.
+func diffSchemaTrees(t *testing.T, path string, inferred *openapi3.Schema, generated *models.Schema) {
+	t.Helper()
+	if inferred == nil || generated == nil {
+		return
+	}
+
+	at := path
+	if at == "" {
+		at = "<root>"
+	}
+	if got, want := typeOf(t, inferred), generated.Type; got != want {
+		t.Errorf("%s: InferSchema says %q, HTTPDocToOpenAPI says %q", at, got, want)
+		return
+	}
+
+	if inferred.Items != nil {
+		diffSchemaTrees(t, path+"[]", inferred.Items.Value, generated.Items)
+	}
+
+	for name, prop := range inferred.Properties {
+		want, ok := generated.Properties[name]["type"].(string)
+		if !ok {
+			t.Errorf("%s.%s: HTTPDocToOpenAPI has no type for this property", at, name)
+			continue
+		}
+		if got := typeOf(t, prop.Value); got != want {
+			t.Errorf("%s.%s: InferSchema says %q, HTTPDocToOpenAPI says %q", at, name, got, want)
+			continue
+		}
+		// Descend through the map-shaped representation the other surface uses.
+		diffPropTrees(t, at+"."+name, prop, generated.Properties[name])
+	}
+}
+
+func diffPropTrees(t *testing.T, path string, inferred *openapi3.SchemaRef, generated map[string]interface{}) {
+	t.Helper()
+	if inferred == nil || inferred.Value == nil || generated == nil {
+		return
+	}
+
+	if items, ok := generated["items"].(map[string]interface{}); ok && inferred.Value.Items != nil {
+		want, _ := items["type"].(string)
+		if got := typeOf(t, inferred.Value.Items.Value); got != want {
+			t.Errorf("%s[]: InferSchema says %q, HTTPDocToOpenAPI says %q", path, got, want)
+			return
+		}
+		diffPropTrees(t, path+"[]", inferred.Value.Items, items)
+	}
+
+	if props, ok := generated["properties"].(map[string]map[string]interface{}); ok {
+		for name, sub := range inferred.Value.Properties {
+			want, ok := props[name]["type"].(string)
+			if !ok {
+				continue
+			}
+			if got := typeOf(t, sub.Value); got != want {
+				t.Errorf("%s.%s: InferSchema says %q, HTTPDocToOpenAPI says %q", path, name, got, want)
+				continue
+			}
+			diffPropTrees(t, path+"."+name, sub, props[name])
+		}
 	}
 }

--- a/pkg/service/contract/infer_types_test.go
+++ b/pkg/service/contract/infer_types_test.go
@@ -1,0 +1,254 @@
+package contract
+
+import (
+	"context"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+	yamlLib "gopkg.in/yaml.v3"
+)
+
+func postCase(url, reqBody, respBody string, status int) models.TestCase {
+	return models.TestCase{
+		HTTPReq:  models.HTTPReq{Method: "POST", URL: url, Body: reqBody},
+		HTTPResp: models.HTTPResp{StatusCode: status, Body: respBody},
+	}
+}
+
+// inferredSchemas runs bodies through InferSchema and returns the request and
+// response schemas for POST /y, after asserting the document is valid.
+func inferredSchemas(t *testing.T, cases ...models.TestCase) (req, resp *openapi3.Schema) {
+	t.Helper()
+	doc, err := InferSchema(cases)
+	if err != nil {
+		t.Fatalf("InferSchema failed: %v", err)
+	}
+	if err := doc.Validate(context.Background()); err != nil {
+		t.Fatalf("InferSchema produced an invalid OpenAPI document: %v", err)
+	}
+	op := doc.Paths.Value("/y").Post
+	if op.RequestBody != nil {
+		req = op.RequestBody.Value.Content["application/json"].Schema.Value
+	}
+	if r := op.Responses.Value("200"); r != nil && r.Value.Content != nil {
+		resp = r.Value.Content["application/json"].Schema.Value
+	}
+	return req, resp
+}
+
+func typeOf(t *testing.T, s *openapi3.Schema) string {
+	t.Helper()
+	if s == nil {
+		return "<nil>"
+	}
+	if s.Type == nil {
+		return ""
+	}
+	return s.Type.Slice()[0]
+}
+
+// TestInferSchema_IntegersAreIntegers covers the defect directly: InferSchema
+// decoded with encoding/json, so every JSON number arrived as a float64 and
+// hit `case float64` -> NewFloat64Schema. An id of 1 was typed "number".
+func TestInferSchema_IntegersAreIntegers(t *testing.T) {
+	req, resp := inferredSchemas(t, postCase("http://x/y", `{"id":1,"price":1.5}`, `{"id":1,"price":1.5}`, 200))
+
+	for name, schema := range map[string]*openapi3.Schema{"request": req, "response": resp} {
+		if got := typeOf(t, schema.Properties["id"].Value); got != "integer" {
+			t.Errorf("%s id type = %q, want \"integer\"", name, got)
+		}
+		if got := typeOf(t, schema.Properties["price"].Value); got != "number" {
+			t.Errorf("%s price type = %q, want \"number\"", name, got)
+		}
+	}
+}
+
+// TestInferSchema_LargeIntegerStaysInteger guards the decoder swap rather than
+// the type switch: an id above 2^53 is only distinguishable from a float if the
+// body was decoded with UseNumber in the first place.
+func TestInferSchema_LargeIntegerStaysInteger(t *testing.T) {
+	_, resp := inferredSchemas(t, postCase("http://x/y", "", `{"id":9007199254740993}`, 200))
+	if got := typeOf(t, resp.Properties["id"].Value); got != "integer" {
+		t.Errorf("id type = %q, want \"integer\"", got)
+	}
+}
+
+// TestInferSchema_AgreesWithHTTPDocToOpenAPI is the reason this fix exists.
+//
+// `keploy contract generate` has two schema surfaces: HTTPDocToOpenAPI writes
+// the schema/ directory the matcher consumes, and InferSchema (behind --infer)
+// writes keploy/contract.yaml. They were separate implementations, and they
+// disagreed on the same body. This test fails the moment they drift apart
+// again, which no test of either one on its own can do.
+func TestInferSchema_AgreesWithHTTPDocToOpenAPI(t *testing.T) {
+	bodies := []string{
+		`{"id":1,"price":1.5,"name":"x","ok":true}`,
+		`{"id":9007199254740993}`,
+		`{"nested":{"count":2,"ratio":0.5}}`,
+		`{"prices":[10,9.99]}`,
+		`{"ids":[1,2,3]}`,
+		`{"empty":[]}`,
+		`{"maybe":null}`,
+		`{"rows":[{"id":1},{"id":1.5}]}`,
+	}
+
+	svc := &contract{}
+	for _, body := range bodies {
+		t.Run(body, func(t *testing.T) {
+			_, inferred := inferredSchemas(t, postCase("http://x/y", "", body, 200))
+
+			oapi, err := svc.HTTPDocToOpenAPI(zap.NewNop(), httpDocWith("POST", "", body))
+			if err != nil {
+				t.Fatalf("HTTPDocToOpenAPI failed: %v", err)
+			}
+			generated := oapi.Paths["/users"].Post.Responses["200"].Content["application/json"].Schema
+
+			for name, prop := range inferred.Properties {
+				got := typeOf(t, prop.Value)
+				want, _ := generated.Properties[name]["type"].(string)
+				if got != want {
+					t.Errorf("property %q: InferSchema says %q, HTTPDocToOpenAPI says %q", name, got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestInferSchema_ArrayItemsFoldOverEveryElement asserts InferSchema no longer
+// describes an array from its first element alone.
+func TestInferSchema_ArrayItemsFoldOverEveryElement(t *testing.T) {
+	tests := []struct {
+		body      string
+		wantItems string
+	}{
+		{`[1,1.5]`, "number"},
+		// Must not over-widen: a homogeneous integer array stays integer.
+		{`[1,2]`, "integer"},
+		{`[1.5,1]`, "number"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.body, func(t *testing.T) {
+			_, resp := inferredSchemas(t, postCase("http://x/y", "", tt.body, 200))
+			if got := typeOf(t, resp.Items.Value); got != tt.wantItems {
+				t.Errorf("items type = %q, want %q", got, tt.wantItems)
+			}
+		})
+	}
+
+	t.Run("object items widen per property", func(t *testing.T) {
+		_, resp := inferredSchemas(t, postCase("http://x/y", "", `[{"a":1},{"a":1.5}]`, 200))
+		if got := typeOf(t, resp.Items.Value.Properties["a"].Value); got != "number" {
+			t.Errorf("items.a type = %q, want \"number\"", got)
+		}
+	})
+
+	t.Run("null makes items nullable without pinning a type", func(t *testing.T) {
+		_, resp := inferredSchemas(t, postCase("http://x/y", "", `[null,1]`, 200))
+		if got := typeOf(t, resp.Items.Value); got != "integer" {
+			t.Errorf("items type = %q, want \"integer\"", got)
+		}
+		if !resp.Items.Value.Nullable {
+			t.Error("items are not nullable, but the array contained a null")
+		}
+	})
+}
+
+// TestInferSchema_IsOrderIndependent is the assertion that pins the merge fix.
+//
+// Request bodies were first-wins and responses last-wins - two opposite
+// policies in one function. That was invisible while every number was a
+// float64; once integers are typed as integers, a price of 10 in one test case
+// and 9.99 in another produces a different contract depending on which test
+// case is walked first, and contract.go only sorts test-set IDs, so ordering
+// within a set decides.
+func TestInferSchema_IsOrderIndependent(t *testing.T) {
+	first := postCase("http://x/y", `{"n":1}`, `{"n":1}`, 200)
+	second := postCase("http://x/y", `{"n":1.5}`, `{"n":1.5}`, 200)
+
+	forward, err := InferSchema([]models.TestCase{first, second})
+	if err != nil {
+		t.Fatalf("InferSchema failed: %v", err)
+	}
+	backward, err := InferSchema([]models.TestCase{second, first})
+	if err != nil {
+		t.Fatalf("InferSchema failed: %v", err)
+	}
+
+	forwardYAML, err := yamlLib.Marshal(forward)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	backwardYAML, err := yamlLib.Marshal(backward)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	if string(forwardYAML) != string(backwardYAML) {
+		t.Errorf("contract depends on test case order:\n--- first then second ---\n%s\n--- second then first ---\n%s", forwardYAML, backwardYAML)
+	}
+
+	// And the merged answer must be the one that describes both bodies.
+	req, resp := inferredSchemas(t, first, second)
+	if got := typeOf(t, req.Properties["n"].Value); got != "number" {
+		t.Errorf("request n type = %q, want \"number\" (1 and 1.5 were both observed)", got)
+	}
+	if got := typeOf(t, resp.Properties["n"].Value); got != "number" {
+		t.Errorf("response n type = %q, want \"number\" (1 and 1.5 were both observed)", got)
+	}
+}
+
+// TestInferSchema_LaterObservationDoesNotEraseEarlierOne pins the other half of
+// the overwrite bug: a response was Set unconditionally, so a test case with no
+// body replaced the schema a previous one had contributed.
+func TestInferSchema_LaterObservationDoesNotEraseEarlierOne(t *testing.T) {
+	req, resp := inferredSchemas(t,
+		postCase("http://x/y", `{"n":1}`, `{"n":1}`, 200),
+		postCase("http://x/y", "", "", 200),
+	)
+	if req == nil || req.Properties["n"] == nil {
+		t.Error("request schema was erased by a later body-less test case")
+	}
+	if resp == nil || resp.Properties["n"] == nil {
+		t.Error("response schema was erased by a later body-less test case")
+	}
+}
+
+// TestInferSchema_ConflictingObservations pins what a genuine type conflict
+// produces. OpenAPI 3.0 cannot express "string or integer" without oneOf, so an
+// untyped schema is emitted - a deliberate choice, and changing it should be a
+// deliberate test edit rather than a silent drift.
+func TestInferSchema_ConflictingObservations(t *testing.T) {
+	_, resp := inferredSchemas(t,
+		postCase("http://x/y", "", `{"v":1}`, 200),
+		postCase("http://x/y", "", `{"v":"one"}`, 200),
+	)
+	if got := typeOf(t, resp.Properties["v"].Value); got != "" {
+		t.Errorf("conflicting observations gave type %q, want an untyped schema", got)
+	}
+}
+
+// TestInferSchema_UndescribableBodyIsSkipped asserts a body the decoder rejects
+// contributes no content rather than aborting or being recorded as a string.
+// decodeJSONBody rejects a number that overflows float64, as encoding/json did,
+// and additionally rejects trailing data after the first JSON document.
+func TestInferSchema_UndescribableBodyIsSkipped(t *testing.T) {
+	for _, body := range []string{`{"a":1e400}`, `{"a":1}{"b":2}`, `not json`} {
+		t.Run(body, func(t *testing.T) {
+			doc, err := InferSchema([]models.TestCase{postCase("http://x/y", body, body, 200)})
+			if err != nil {
+				t.Fatalf("InferSchema failed: %v", err)
+			}
+			if err := doc.Validate(context.Background()); err != nil {
+				t.Fatalf("InferSchema produced an invalid OpenAPI document: %v", err)
+			}
+			op := doc.Paths.Value("/y").Post
+			if op.RequestBody != nil {
+				t.Error("an undescribable request body produced request content")
+			}
+			if r := op.Responses.Value("200"); r == nil || r.Value.Content != nil {
+				t.Error("an undescribable response body produced response content")
+			}
+		})
+	}
+}

--- a/pkg/service/contract/utils.go
+++ b/pkg/service/contract/utils.go
@@ -371,13 +371,23 @@ func extractVariableTypes(obj map[string]interface{}) map[string]map[string]inte
 // {type: object, properties: ...} schema (properties precomputed by the
 // caller via ExtractVariableTypes). For an array root it returns a
 // {type: array, items: ...} schema whose item schema is folded over every
-// element. Any other root (or an empty body) falls back to an object schema so
-// existing behaviour is preserved.
+// element. A scalar root is described by its own type.
 func SchemaForBody(body interface{}, objectProps map[string]map[string]interface{}) models.Schema {
 	arr, ok := body.([]interface{})
 	if !ok {
-		// Object root (or nil/empty body): keep the original object schema.
-		return models.Schema{Type: "object", Properties: objectProps}
+		// An object root keeps the properties the caller already extracted, and
+		// a nil body (no body recorded) stays an empty object so it still
+		// serializes its example as {}.
+		if _, isObject := body.(map[string]interface{}); isObject || body == nil {
+			return models.Schema{Type: "object", Properties: objectProps}
+		}
+		// A scalar root - 5, "ok", true - was previously described as an
+		// object, producing a schema its own example violates and aborting
+		// generation the same way the array shapes above did. JSON allows any
+		// value as a document, and an API answering `5` or `true` is ordinary.
+		scalar := schemaForValue(body)
+		finalizeSchema(scalar)
+		return schemaFromMap(scalar)
 	}
 
 	items := itemSchema(arr)

--- a/pkg/service/contract/utils.go
+++ b/pkg/service/contract/utils.go
@@ -103,182 +103,274 @@ func decodeJSONBody(body string) (interface{}, error) {
 	return normalizeJSONNumbers(v)
 }
 
-// widenSchemaForValue widens an item schema, inferred from one element of an
-// array, so that it also describes v.
+// Inference distinguishes three states that OpenAPI 3.0 itself cannot spell,
+// so they are carried as internal type markers and resolved by finalizeSchema.
+// Both are deliberately illegal type names: they can never collide with a type
+// inferred from data, and a leak into a generated contract is unmistakable.
 //
-// Item schemas are inferred from a single element while MediaType.Example
-// carries the whole body, and kin-openapi validates the example against the
-// schema. Without widening, [1, 1.5] infers items:integer from the first
-// element and then fails validation on the second - and a validateSchema
-// failure aborts the whole `keploy contract generate` run, so one
-// {"prices":[10, 9.99]} in a recorded response would take the command down.
+// Keeping them explicit - rather than encoding "unknown" as a missing type key -
+// is what makes finalizeSchema idempotent. Absence of a type would otherwise
+// mean both "nothing observed yet" and "already resolved to untyped", and a
+// second pass over a resolved node would turn an untyped schema into a string.
+const (
+	// unknownType means no element has been observed yet: an empty array, or a
+	// JSON null, which carries no type of its own. It is the identity element
+	// of mergeSchemas, so uninformative elements contribute nothing but
+	// nullability instead of pinning down a type there is no evidence for.
+	unknownType = "\x00unknown"
+	// anyType means the observations conflict, so no single OpenAPI 3.0 type
+	// describes them all.
+	anyType = "\x00conflict"
+)
+
+// getType maps a decoded JSON value onto an OpenAPI 3.0 type name.
 //
-// Widening the schema rather than rewriting the decoded body keeps every
-// recorded value exact, and does not depend on sibling elements lining up
-// positionally with the one the schema came from - a null anywhere in either
-// array would break that alignment.
-func widenSchemaForValue(s *models.Schema, v interface{}) {
-	if s == nil {
-		return
-	}
-	switch val := v.(type) {
+// int64 is produced by decodeJSONBody for integer literals; plain
+// encoding/json would make every number a float64 and this case unreachable.
+func getType(value interface{}) string {
+	switch value.(type) {
 	case float64:
-		if s.Type == "integer" {
-			s.Type = "number"
-		}
+		return "number"
+	case int, int32, int64:
+		return "integer"
+	case string:
+		return "string"
+	case bool:
+		return "boolean"
 	case map[string]interface{}:
-		for k, vv := range val {
-			if prop, ok := s.Properties[k]; ok {
-				widenPropertyForValue(prop, vv)
-			}
-		}
+		return "object"
 	case []interface{}:
-		for _, el := range val {
-			widenSchemaForValue(s.Items, el)
-		}
+		return "array"
+	default:
+		return "string"
 	}
 }
 
-// widenPropertyForValue is widenSchemaForValue for the map-shaped property
-// schemas ExtractVariableTypes produces.
-func widenPropertyForValue(prop map[string]interface{}, v interface{}) {
-	if prop == nil {
+// schemaForValue returns a map-form schema describing exactly v.
+//
+// The map form is canonical throughout inference because models.Schema's own
+// Properties field already is a map[string]map[string]interface{} - every
+// schema below the root is a map anyway, and the struct exists only because
+// models.MediaType.Schema is typed. Converting once at the root (schemaFromMap)
+// avoids maintaining the same merge rules over two representations.
+//
+// A JSON null carries no type, so it yields the unknownType marker plus
+// nullable: "unknown but nullable". See the marker constants for why that is
+// spelled out rather than left implicit.
+func schemaForValue(v interface{}) map[string]interface{} {
+	switch val := v.(type) {
+	case nil:
+		return map[string]interface{}{"type": unknownType, "nullable": true}
+	case map[string]interface{}:
+		return map[string]interface{}{"type": "object", "properties": extractVariableTypes(val)}
+	case []interface{}:
+		return map[string]interface{}{"type": "array", "items": itemSchema(val)}
+	default:
+		return map[string]interface{}{"type": getType(v)}
+	}
+}
+
+// itemSchema folds every element of arr into a single item schema.
+//
+// Inferring from one chosen element and patching the result afterwards cannot
+// work: an empty array, a null, or an element that simply lacks a key reveals
+// nothing, and no amount of patching recovers a type that was never observed.
+// [[], [1]] inferred "string" from the empty first element and then emitted a
+// schema its own example violated, which aborts `keploy contract generate`.
+// Folding instead makes "no evidence" the identity element, so uninformative
+// elements are skipped rather than believed.
+//
+// A nil accumulator means "nothing observed yet", which is why merging with it
+// yields the other side untouched.
+func itemSchema(arr []interface{}) map[string]interface{} {
+	var acc map[string]interface{}
+	for _, el := range arr {
+		acc = mergeSchemas(acc, schemaForValue(el))
+	}
+	if acc == nil {
+		// An empty array: no element was ever observed.
+		acc = map[string]interface{}{"type": unknownType}
+	}
+	return acc
+}
+
+// mergeSchemas returns the least schema that describes everything both a and b
+// describe. Nullability is the union of both sides.
+func mergeSchemas(a, b map[string]interface{}) map[string]interface{} {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+
+	nullable := a["nullable"] == true || b["nullable"] == true
+
+	aType, _ := a["type"].(string)
+	bType, _ := b["type"].(string)
+
+	var out map[string]interface{}
+	switch {
+	case aType == unknownType:
+		// Nothing was observed on this side, so it constrains nothing.
+		out = cloneSchema(b)
+	case bType == unknownType:
+		out = cloneSchema(a)
+	case aType == anyType || bType == anyType:
+		out = map[string]interface{}{"type": anyType}
+	case aType == bType:
+		switch aType {
+		case "object":
+			out = mergeObjectSchemas(a, b)
+		case "array":
+			out = map[string]interface{}{
+				"type":  "array",
+				"items": mergeSchemas(itemsOf(a), itemsOf(b)),
+			}
+		default:
+			out = map[string]interface{}{"type": aType}
+		}
+	case isNumericType(aType) && isNumericType(bType):
+		// The only widening OpenAPI 3.0 can express: every integer is a
+		// number, so [1, 1.5] is an array of number.
+		out = map[string]interface{}{"type": "number"}
+	default:
+		// string vs integer and friends. OpenAPI 3.0 has no single type for
+		// this; oneOf would be the honest encoding and is out of scope here,
+		// so record the conflict and let finalizeSchema emit an untyped schema
+		// rather than a typed one the recorded example would violate.
+		out = map[string]interface{}{"type": anyType}
+	}
+
+	if nullable {
+		out["nullable"] = true
+	} else {
+		delete(out, "nullable")
+	}
+	return out
+}
+
+// mergeObjectSchemas merges the properties of two object schemas.
+//
+// Only keys already present in a are kept, which is the historical behaviour:
+// an item schema describes the keys the first object showed, and OpenAPI allows
+// undeclared properties, so a later element with extra keys is still valid
+// against it. Unioning the keys would be better inference but changes the
+// schema emitted for bodies that generate fine today.
+func mergeObjectSchemas(a, b map[string]interface{}) map[string]interface{} {
+	aProps := propertiesOf(a)
+	bProps := propertiesOf(b)
+	merged := make(map[string]map[string]interface{}, len(aProps))
+	for key, aProp := range aProps {
+		if bProp, ok := bProps[key]; ok {
+			merged[key] = mergeSchemas(aProp, bProp)
+			continue
+		}
+		merged[key] = aProp
+	}
+	return map[string]interface{}{"type": "object", "properties": merged}
+}
+
+func propertiesOf(s map[string]interface{}) map[string]map[string]interface{} {
+	props, _ := s["properties"].(map[string]map[string]interface{})
+	return props
+}
+
+func itemsOf(s map[string]interface{}) map[string]interface{} {
+	items, _ := s["items"].(map[string]interface{})
+	return items
+}
+
+func isNumericType(t string) bool { return t == "integer" || t == "number" }
+
+func cloneSchema(s map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(s))
+	for k, v := range s {
+		out[k] = v
+	}
+	return out
+}
+
+// finalizeSchema fills in what the fold could not determine, in place.
+//
+// It must run exactly once, on the completed schema, never inside the
+// recursion. Materialising a default early turns "unknown" back into a real
+// type, and merging that with the first informative element then reads as a
+// conflict - which is precisely the bug this replaces.
+func finalizeSchema(s map[string]interface{}) {
+	if s == nil {
 		return
 	}
-	switch val := v.(type) {
-	case float64:
-		if prop["type"] == "integer" {
-			prop["type"] = "number"
+	switch t, _ := s["type"].(string); t {
+	case anyType:
+		// An untyped schema accepts any kind. Emitting a concrete type here
+		// would knowingly produce a document its own example violates.
+		delete(s, "type")
+	case unknownType:
+		// Zero evidence: [] or [null] never showed an element type. "string"
+		// is the historical default and is vacuously correct - there is no
+		// element for it to be wrong about.
+		s["type"] = "string"
+	case "object":
+		for _, prop := range propertiesOf(s) {
+			finalizeSchema(prop)
 		}
-	case map[string]interface{}:
-		sub, ok := prop["properties"].(map[string]map[string]interface{})
-		if !ok {
-			return
+	case "array":
+		items := itemsOf(s)
+		if items == nil {
+			// OpenAPI 3.0 rejects an array schema without items.
+			items = map[string]interface{}{"type": "string"}
+			s["items"] = items
 		}
-		for k, vv := range val {
-			if p, ok := sub[k]; ok {
-				widenPropertyForValue(p, vv)
-			}
-		}
-	case []interface{}:
-		items, ok := prop["items"].(map[string]interface{})
-		if !ok {
-			return
-		}
-		for _, el := range val {
-			widenPropertyForValue(items, el)
-		}
+		finalizeSchema(items)
 	}
+}
+
+// schemaFromMap converts a finalized map-form schema to the struct form
+// models.MediaType requires. Only the root needs it; everything below stays a
+// map, which is what models.Schema.Properties already holds.
+func schemaFromMap(s map[string]interface{}) models.Schema {
+	out := models.Schema{}
+	if t, ok := s["type"].(string); ok {
+		out.Type = t
+	}
+	if n, ok := s["nullable"].(bool); ok {
+		out.Nullable = n
+	}
+	if props := propertiesOf(s); props != nil {
+		out.Properties = props
+	}
+	if items := itemsOf(s); items != nil {
+		nested := schemaFromMap(items)
+		out.Items = &nested
+	}
+	return out
 }
 
 // ExtractVariableTypes returns the type of each variable in the object.
 func ExtractVariableTypes(obj map[string]interface{}) map[string]map[string]interface{} {
-	types := make(map[string]map[string]interface{}, len(obj))
-
-	getType := func(value interface{}) string {
-		switch value.(type) {
-		case float64:
-			return "number"
-		case int, int32, int64:
-			return "integer"
-		case string:
-			return "string"
-		case bool:
-			return "boolean"
-		case map[string]interface{}:
-			return "object"
-		case []interface{}:
-			return "array"
-		default:
-			return "string"
-		}
+	types := extractVariableTypes(obj)
+	for _, prop := range types {
+		finalizeSchema(prop)
 	}
-
-	for key, value := range obj {
-		// A JSON null carries no type. OpenAPI 3.0 still requires one, so keep
-		// the historical "string" default but mark the property nullable -
-		// without it the untouched example holds a null that kin-openapi
-		// rejects with `Value is not nullable`, aborting contract generation
-		// for any payload with a null field.
-		if value == nil {
-			types[key] = map[string]interface{}{"type": "string", "nullable": true}
-			continue
-		}
-
-		valueType := getType(value)
-		responseType := map[string]interface{}{
-			"type": valueType,
-		}
-
-		switch valueType {
-		case "object":
-			responseType["properties"] = ExtractVariableTypes(value.(map[string]interface{}))
-		case "array":
-			arrayItems := value.([]interface{})
-			arrayType := "string" // Default to string if array is empty
-
-			// Infer from the first non-null element; a null anywhere in the
-			// array only means the items are nullable.
-			firstElement, nullable := firstNonNil(arrayItems)
-			if firstElement != nil {
-				arrayType = getType(firstElement)
-				if arrayType == "object" {
-					items := map[string]interface{}{
-						"type":       arrayType,
-						"properties": ExtractVariableTypes(firstElement.(map[string]interface{})),
-					}
-					if nullable {
-						items["nullable"] = true
-					}
-					for _, el := range arrayItems {
-						widenPropertyForValue(items, el)
-					}
-					responseType["items"] = items
-					types[key] = responseType
-					continue
-				}
-			}
-			items := map[string]interface{}{
-				"type": arrayType,
-			}
-			if nullable {
-				items["nullable"] = true
-			}
-			for _, el := range arrayItems {
-				widenPropertyForValue(items, el)
-			}
-			responseType["items"] = items
-		}
-
-		types[key] = responseType
-	}
-
 	return types
 }
 
-// firstNonNil returns the first non-null element of items along with whether
-// any element was null, so callers can infer an item type from real data while
-// still marking the schema nullable.
-func firstNonNil(items []interface{}) (interface{}, bool) {
-	var first interface{}
-	nullable := false
-	for _, item := range items {
-		if item == nil {
-			nullable = true
-			continue
-		}
-		if first == nil {
-			first = item
-		}
+// extractVariableTypes is ExtractVariableTypes without finalization, for use
+// inside the fold. See finalizeSchema for why the two must stay separate.
+func extractVariableTypes(obj map[string]interface{}) map[string]map[string]interface{} {
+	types := make(map[string]map[string]interface{}, len(obj))
+	for key, value := range obj {
+		types[key] = schemaForValue(value)
 	}
-	return first, nullable
+	return types
 }
 
 // SchemaForBody builds an OpenAPI schema for a decoded JSON body whose root
 // may be either an object or an array. For an object root it returns a
 // {type: object, properties: ...} schema (properties precomputed by the
 // caller via ExtractVariableTypes). For an array root it returns a
-// {type: array, items: ...} schema, inferring the item schema from the first
+// {type: array, items: ...} schema whose item schema is folded over every
 // element. Any other root (or an empty body) falls back to an object schema so
 // existing behaviour is preserved.
 func SchemaForBody(body interface{}, objectProps map[string]map[string]interface{}) models.Schema {
@@ -288,35 +380,10 @@ func SchemaForBody(body interface{}, objectProps map[string]map[string]interface
 		return models.Schema{Type: "object", Properties: objectProps}
 	}
 
-	items := &models.Schema{Type: "string"} // default for an empty array
-	// Infer from the first non-null element; a null anywhere in the array only
-	// means the items are nullable, and inferring "string" from it would make
-	// kin-openapi reject the untouched example.
-	first, nullable := firstNonNil(arr)
-	switch v := first.(type) {
-	case map[string]interface{}:
-		items = &models.Schema{
-			Type:       "object",
-			Properties: ExtractVariableTypes(v),
-		}
-	case []interface{}:
-		nested := SchemaForBody(v, nil)
-		items = &nested
-	case int64:
-		items = &models.Schema{Type: "integer"}
-	case float64:
-		items = &models.Schema{Type: "number"}
-	case bool:
-		items = &models.Schema{Type: "boolean"}
-	case string:
-		items = &models.Schema{Type: "string"}
-	}
-	items.Nullable = nullable
-	// The schema came from one element; widen it until it describes them all.
-	for _, el := range arr {
-		widenSchemaForValue(items, el)
-	}
-	return models.Schema{Type: "array", Items: items}
+	items := itemSchema(arr)
+	finalizeSchema(items)
+	nested := schemaFromMap(items)
+	return models.Schema{Type: "array", Items: &nested}
 }
 
 func GenerateResponse(response Response) map[string]models.ResponseItem {


### PR DESCRIPTION
> Builds on #4463, now merged. Rebased onto `main`.

## Describe the changes that are made

Four pre-existing contract-generation defects, each in its own commit. Three were noted as follow-ups on #4463; the fourth was found while fixing them.

### 1. Any array-of-arrays under a key aborted `keploy contract generate`

`ExtractVariableTypes`' array branch handled only scalar and object element types and never recursed, emitting `items: {type: array}` with **no nested `items`**, which OpenAPI forbids:

```
{"aoa":[[1,2]]}   ->  when schema type is 'array', schema 'items' must be non-null
[[],[1],[1.5]]    ->  invalid example: Error at "/1/0": value must be a string
```

Note the first has no mixed types at all — **any** object field holding an array of arrays failed, not an edge case. The second is a separate cause: an empty array as the sample element defaulted the item type to `string`.

Item schemas are now built by folding over **every** element rather than sampling one, which subsumes both causes and the widening from #4463.

### 2. Array-root contracts scored `NaN` and could never match

`compareResponseBodies` computed `differencesCount / overallScore` where `overallScore = len(Schema.Properties)`. An array-root schema has no properties, so that is `0/0 = NaN`. `consumer.go:105` gates on `pass && candidateScore > current`, and **every** comparison against `NaN` is false — so an array-root mock was always reported **MISSED**. #4447 made array roots reachable, so this became user-visible.

### 3. `--infer` typed every integer as `number`

`infer.go` carried a second, separate inferrer used by `GenerateFromTests`. It emitted no example, so it had neither the precision nor the validation bug — but it still mistyped integers, and it *disagreed with the other surface on the same body*.

Rather than adding a third implementation, `InferSchema` now delegates to the same fold and converts to kin-openapi at the end. The two surfaces agree **by construction** instead of by two implementations happening to match, and `--infer` gets the array fixes for free. `infer.go` got smaller.

This also exposed a live inconsistency: request bodies were **first-wins** and responses **last-wins**, so two test cases recording `price: 10` and `price: 9.99` produced an order-dependent contract. Both now unify.

### 4. Scalar JSON roots aborted generation

Found while fixing the above. `SchemaForBody` described every non-array root as `{type: object}`:

```
5   "hello"   true   1.5   ->  invalid example: value must be an object
```

JSON permits any value as a document. This was also the last place the two inference surfaces disagreed.

## Verification

- `gofmt` clean · `go vet ./...` clean · `go test ./...` clean · `-race -count=2` clean on all touched packages · golangci-lint v2.12.2 **0 issues**.
- **3000 randomly generated JSON bodies** through the real `HTTPDocToOpenAPI` + `validateSchema` path, this branch vs its base: `317 FAIL→OK`, **`0` already-valid schemas changed**.
- **Matcher**: 1024-row `Match()` matrix vs base. Normal object-root mock × object-root test: **64 rows, 0 changed** — score, `pass` and consumer classification all identical.
- **Mutation-tested**: 19 mutations across the four fixes, all caught. Includes inverting the score polarity (caught by `consumer would report "missed", want "passed"`) and returning a flat `1.0` for array roots (caught by `consumer would report "passed", want "failed"`).
- **NaN assertions verified to actually catch NaN**: forcing the similarity function to return `math.NaN()` fatals every property-less subtest — *including* those whose expected score is `0`, where a classification-only assertion would have passed silently. `math.IsNaN`/`IsInf` is checked first and separately.
- **The agreement test walks the whole tree.** The depth-1 version passed while nested properties and array item types were forced to the wrong type; the recursive version fails both with the exact path (`<root>.prices[]: InferSchema says "string", HTTPDocToOpenAPI says "number"`).

## Deliberate changes to existing expectations

`infer_test.go` asserted `age: number` for the body `{"age":30}` in two places. `30` is an integer literal, so those assertions pinned the defect and now read `integer`. No assertion was weakened.

## Known limitation, stated rather than hidden

A genuine type conflict across observations (`{"id":1}` in one test, `{"id":"1"}` in another) keeps the first observation and marks it nullable. OpenAPI 3.0 has no single-type answer; `oneOf` is the correct encoding and is out of scope here. The code says so where it happens.

## Links & References

**Closes:** NA

### 🔗 Related PRs
- #4463 (base), #4447, #4450

## What type of PR is this? (check all applicable)
- [x] 🐞 Bug Fix

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed — no e2e lane covers contract generation

## Self Review done?
- [x] ✅ yes
