### PR TITLE
feat(cli): make the native-command platform gate an extension point

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -1157,7 +1157,7 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 			return err
 		}
 		c.cfg.CommandType = commandType
-		if (c.cfg.CommandType == string(utils.Native) || c.cfg.CommandType == string(utils.Empty)) && !(runtime.GOOS == "linux" || (runtime.GOOS == "windows" && runtime.GOARCH == "amd64")) {
+		if (c.cfg.CommandType == string(utils.Native) || c.cfg.CommandType == string(utils.Empty)) && !nativeCommandSupportedHere() {
 			return fmt.Errorf("non docker command not supported for OS: %s , Arch: %s", runtime.GOOS, runtime.GOARCH)
 		}
 		// memory-limit non-Docker gate is applied after flag parsing below

--- a/cli/provider/cmd_test.go
+++ b/cli/provider/cmd_test.go
@@ -211,6 +211,14 @@ func TestValidateFlags_HonoursCmdTypeEndToEnd(t *testing.T) {
 		{"generated default + docker command still auto-detects", "docker compose up", "", "native", "docker-compose"},
 		{"generated default + plain command stays native", "python app.py", "", "native", "native"},
 	}
+	// Two of these cases resolve to "native", which ValidateFlags refuses on a
+	// platform with no interception backend — so on macOS this test failed for
+	// a reason that has nothing to do with what it is checking. Pin the gate
+	// open: the platform policy has its own coverage in hooks_test.go.
+	original := NativeCommandSupported
+	t.Cleanup(func() { NativeCommandSupported = original })
+	RegisterNativeCommandSupport(func(string, string) bool { return true })
+
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := config.New()

--- a/cli/provider/hooks.go
+++ b/cli/provider/hooks.go
@@ -1,0 +1,57 @@
+package provider
+
+// Runtime extension points for builds that wrap this one.
+//
+// Same shape as pkg/agent/runtime_hooks.go and pkg/client/app/hooks.go: a
+// package-level default plus a Register function, set from an importing
+// package's init(). Go guarantees those complete before main, and the CLI reads
+// them on a single goroutine, so they are read without synchronization —
+// anything that installs one lazily (from a goroutine, or a PersistentPreRun)
+// would be an unsynchronized write and is not supported.
+
+import "runtime"
+
+// NativeCommandSupported reports whether this build can instrument an
+// application running directly on the host, as opposed to requiring the app to
+// run in Docker. ValidateFlags consults it to decide whether to accept a
+// non-docker command at all.
+//
+// Install a wider predicate with RegisterNativeCommandSupport.
+var NativeCommandSupported = DefaultNativeCommandSupported
+
+// DefaultNativeCommandSupported is the set of platforms with an in-tree
+// interception backend: eBPF on Linux (pkg/agent/hooks/linux) and the WinDivert
+// redirector on Windows/amd64 (pkg/agent/hooks/windows).
+//
+// macOS and Windows/arm64 have none — both resolve to the pkg/agent/hooks/others
+// stub, whose Load returns "eBPF hooks are not supported on non-Linux
+// platforms". Rejecting a native command up front is deliberate: it produces a
+// clear message about the platform instead of that stub's confusing eBPF error
+// much later in the run.
+//
+// goos and goarch are parameters rather than reads of runtime.GOOS/GOARCH so
+// the policy can be tested for every platform from any host.
+func DefaultNativeCommandSupported(goos, goarch string) bool {
+	return goos == "linux" || (goos == "windows" && goarch == "amd64")
+}
+
+// RegisterNativeCommandSupport installs the predicate used to decide whether a
+// non-docker command is accepted. A build shipping an interception backend this
+// module does not know about (for example a macOS one) calls this from init()
+// to widen the platform set, normally by delegating to
+// DefaultNativeCommandSupported and adding its own.
+//
+// A nil fn restores the default.
+func RegisterNativeCommandSupport(fn func(goos, goarch string) bool) {
+	if fn == nil {
+		NativeCommandSupported = DefaultNativeCommandSupported
+		return
+	}
+	NativeCommandSupported = fn
+}
+
+// nativeCommandSupportedHere applies the installed predicate to the platform
+// this binary is actually running on.
+func nativeCommandSupportedHere() bool {
+	return NativeCommandSupported(runtime.GOOS, runtime.GOARCH)
+}

--- a/cli/provider/hooks_test.go
+++ b/cli/provider/hooks_test.go
@@ -1,0 +1,102 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"go.keploy.io/server/v3/config"
+	"go.uber.org/zap"
+)
+
+// The default must stay exactly the set of platforms with an in-tree
+// interception backend. Widening it would let a native command through to the
+// hooks stub and fail with a confusing eBPF error instead of a clear one about
+// the platform; narrowing it would reject runs that work today.
+//
+// Taking goos/goarch as parameters is what makes every platform checkable from
+// any host — asserting against runtime.GOOS on the CI runner would only ever
+// exercise one row.
+func TestDefaultNativeCommandSupported(t *testing.T) {
+	cases := []struct {
+		goos, goarch string
+		want         bool
+	}{
+		{"linux", "amd64", true},
+		{"linux", "arm64", true},
+		{"linux", "386", true},
+		{"windows", "amd64", true},
+		{"windows", "arm64", false}, // falls through to the others stub
+		{"darwin", "arm64", false},
+		{"darwin", "amd64", false},
+		{"freebsd", "amd64", false},
+	}
+	for _, tc := range cases {
+		if got := DefaultNativeCommandSupported(tc.goos, tc.goarch); got != tc.want {
+			t.Errorf("DefaultNativeCommandSupported(%q, %q) = %v, want %v", tc.goos, tc.goarch, got, tc.want)
+		}
+	}
+}
+
+// The seam is only worth having if the gate actually consults it. A test that
+// merely assigns the var and reads it back would still pass if someone
+// re-inlined the platform condition at the call site and orphaned the var,
+// which is the regression this is exposed to.
+func TestValidateFlagsConsultsNativeCommandSupport(t *testing.T) {
+	cases := []struct {
+		name      string
+		supported bool
+		wantErr   bool
+	}{
+		{"a build with no backend for this platform rejects a native command", false, true},
+		{"a build that reports a backend accepts it", true, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			original := NativeCommandSupported
+			t.Cleanup(func() { NativeCommandSupported = original })
+			RegisterNativeCommandSupport(func(string, string) bool { return tc.supported })
+
+			cfg := config.New()
+			c := NewCmdConfigurator(zap.NewNop(), cfg)
+			cmd := &cobra.Command{Use: "record"}
+			if err := c.AddFlags(cmd); err != nil {
+				t.Fatalf("AddFlags: %v", err)
+			}
+			if err := cmd.ParseFlags([]string{"-c", "python app.py"}); err != nil {
+				t.Fatalf("ParseFlags: %v", err)
+			}
+			cfg.Command = "python app.py"
+
+			err := c.ValidateFlags(context.Background(), cmd)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("ValidateFlags accepted a native command on a build with no interception backend")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ValidateFlags: %v", err)
+			}
+			if cfg.CommandType != "native" {
+				t.Errorf("cfg.CommandType = %q, want %q — widening the gate must not reclassify the command", cfg.CommandType, "native")
+			}
+		})
+	}
+}
+
+func TestRegisterNativeCommandSupportNilRestoresTheDefault(t *testing.T) {
+	original := NativeCommandSupported
+	t.Cleanup(func() { NativeCommandSupported = original })
+
+	RegisterNativeCommandSupport(func(string, string) bool { return true })
+	if !NativeCommandSupported("darwin", "arm64") {
+		t.Fatal("the installed predicate was not used")
+	}
+
+	RegisterNativeCommandSupport(nil)
+	if NativeCommandSupported("darwin", "arm64") {
+		t.Error("a nil predicate must restore the default, which does not support darwin")
+	}
+}


### PR DESCRIPTION
## Describe the changes that are made

`ValidateFlags` rejects a non-docker command on any platform without an in-tree interception backend:

```go
if (CommandType == Native || CommandType == Empty) &&
   !(runtime.GOOS == "linux" || (runtime.GOOS == "windows" && runtime.GOARCH == "amd64")) {
    return fmt.Errorf("non docker command not supported for OS: %s , Arch: %s", ...)
}
```

That policy is right — without it a native run reaches the `pkg/agent/hooks/others` stub and fails with `eBPF hooks are not supported on non-Linux platforms`, which tells the user nothing. But it was a hard-coded expression at the call site, so a build that *does* ship an additional backend had no way to say so.

This turns it into an extension point, with **no behaviour change on any platform**.

- New `cli/provider/hooks.go`:
  - `DefaultNativeCommandSupported(goos, goarch)` — byte-equivalent to the old condition.
  - `NativeCommandSupported` — the installed predicate.
  - `RegisterNativeCommandSupport(fn)` — installs a wider one from an importing package's `init()`; `nil` restores the default.
- `cmd.go` call site now reads `!nativeCommandSupportedHere()`.

Two deliberate choices:

**Why a package-level var + `Register…`** — it matches the extension points already in `pkg/agent/runtime_hooks.go` (`EbpfLoadedHook`, `SkipProxyListener`, `ProxyHook`, …) and `pkg/client/app/hooks.go` (`HookImpl`), including the dedicated `hooks.go` file and the `Register…` setter. A build tag can't work here (an out-of-tree module can't flip one), an interface is overkill for a bool predicate, and a config field would leak a build capability into user-facing config.

**Why the predicate takes `goos, goarch`** rather than reading `runtime.GOOS` itself — so the policy is testable for every platform from any host. Asserting against the host would only ever exercise one row on the CI runner, and could never catch an inverted arch check.

### Drive-by fix

`TestValidateFlags_HonoursCmdTypeEndToEnd` has been **failing on macOS**: two of its cases resolve to `native`, and the gate refused them for a reason that has nothing to do with what the test checks.

```
cmd_test.go:234: ValidateFlags: non docker command not supported for OS: darwin , Arch: arm64
```

It now pins the gate open; the platform policy has its own coverage in `hooks_test.go`. `go test ./cli/provider/` passes on macOS for the first time.

## Links & References

**Closes:** NA

### 🔗 Related PRs
- Consumed by the enterprise macOS-native record/replay change, which registers a predicate adding `darwin`.
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [x] 🧑‍💻 Code Refactor
- [x] ✅ Test

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed

Behaviour is unchanged on every platform, so there is nothing new for an e2e to exercise. The unit tests cover the platform matrix and the call site.

## Added comments for hard-to-understand areas?
- [x] 👍 yes

`hooks.go` records *why* the gate exists (the `others` stub's error message) and states the concurrency contract: set from `init()`, read without synchronization.

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

```bash
go test ./cli/provider/ -run "NativeCommandSupport|HonoursCmdTypeEndToEnd" -v
go test ./cli/... -race
golangci-lint run ./cli/provider/
```

`TestDefaultNativeCommandSupported` covers linux/{amd64,arm64,386}, windows/{amd64,arm64}, darwin/{amd64,arm64} and freebsd — including that **windows/arm64 stays unsupported**, which the old inline condition also implied but nothing asserted.

## Self Review done?
- [x] ✅ yes

Reviewed independently before commit; the review is what produced the `goos, goarch` signature, the move to `hooks.go` with a `Register…` setter, the call-site test replacing a tautological one, and the macOS test fix.

## Any relevant screenshots, recordings or logs?

Before, on macOS:
```
--- FAIL: TestValidateFlags_HonoursCmdTypeEndToEnd/config_compose_is_not_honoured
    ValidateFlags: non docker command not supported for OS: darwin , Arch: arm64
```
After:
```
ok  	go.keploy.io/server/v3/cli/provider	0.877s
```
