### PR TITLE
fix(agent): stop elevating the native agent on platforms that do not need root

### DIFF
--- a/pkg/platform/http/agent.go
+++ b/pkg/platform/http/agent.go
@@ -1076,13 +1076,22 @@ func (a *AgentClient) startNativeAgent(ctx context.Context, opts models.SetupOpt
 		args = append(args, "--config-path", opts.ConfigPath)
 	}
 
-	// Check if sudo credentials are already cached (e.g., from permission fix)
-	// If cached, we can use sudo -n (non-interactive) and skip PTY
-	sudoCached := utils.AreSudoCredentialsCached()
+	// The PTY and the cached-credentials probe both exist for one reason: sudo
+	// may prompt for a password. On a platform where the agent is never
+	// elevated (darwin) there is no prompt, and taking the PTY path anyway is
+	// pure cost — startNativeAgentWithPTY puts the user's real terminal into
+	// raw mode for the whole run, swallows their keystrokes into a pty nothing
+	// reads, and closes the master on stop, which delivers SIGHUP to an agent
+	// that would otherwise have shut down gracefully.
+	elevates := agentUtils.AgentNeedsElevation(runtime.GOOS)
 
-	// Check if we need PTY for interactive input (e.g., sudo password)
-	// Skip PTY if credentials are already cached - use non-interactive sudo instead
-	if agentUtils.NeedsPTY() && !sudoCached {
+	sudoCached := false
+	if elevates {
+		// Cached credentials mean we can use sudo -n and skip the prompt.
+		sudoCached = utils.AreSudoCredentialsCached()
+	}
+
+	if elevates && agentUtils.NeedsPTY() && !sudoCached {
 		return a.startNativeAgentWithPTY(ctx, keployBin, args, grp)
 	}
 

--- a/pkg/platform/http/utils/elevate.go
+++ b/pkg/platform/http/utils/elevate.go
@@ -1,0 +1,31 @@
+package utils
+
+// AgentNeedsElevation reports whether the native agent must run as root on the
+// given platform.
+//
+// Windows does not either — it has its own command builder that never sudos.
+//
+// Linux does: the agent loads eBPF programs, attaches cgroup hooks and mounts
+// bpffs, none of which an unprivileged process can do.
+//
+// Darwin does not. There is no eBPF there; a build shipping a macOS
+// interception backend does it from userspace inside the application's own
+// process, and everything the agent binds — the proxy, the DNS server, its HTTP
+// control plane — is an unprivileged port.
+//
+// Elevating anyway is not free. `sudo` prompts for a password on a machine
+// where nothing needs one, and it splits the run across two users: the client
+// and the application stay as the invoking user while the agent becomes root.
+// That asymmetry breaks things that look unrelated — StopCommand's
+// kill(-pgid) returns EPERM against a root process group, and $TMPDIR is
+// per-user on macOS, so the two halves stop agreeing on where temporary files
+// live.
+//
+// goos is a parameter rather than a read of runtime.GOOS so the policy can be
+// exercised for every platform from any host. Asserting against the host would
+// only ever cover the one row CI happens to run on, and could not catch an
+// inverted platform check — the same reason cli/provider.DefaultNativeCommandSupported
+// is shaped this way.
+func AgentNeedsElevation(goos string) bool {
+	return goos == "linux"
+}

--- a/pkg/platform/http/utils/elevate_test.go
+++ b/pkg/platform/http/utils/elevate_test.go
@@ -1,0 +1,20 @@
+package utils
+
+import "testing"
+
+func TestAgentNeedsElevation(t *testing.T) {
+	cases := []struct {
+		goos string
+		want bool
+	}{
+		{"linux", true},    // eBPF, cgroup attach, bpffs mount
+		{"darwin", false},  // userspace interception, unprivileged ports
+		{"windows", false}, // has its own no-sudo command builder
+		{"freebsd", false},
+	}
+	for _, tc := range cases {
+		if got := AgentNeedsElevation(tc.goos); got != tc.want {
+			t.Errorf("AgentNeedsElevation(%q) = %v, want %v", tc.goos, got, tc.want)
+		}
+	}
+}

--- a/pkg/platform/http/utils/elevate_unix_test.go
+++ b/pkg/platform/http/utils/elevate_unix_test.go
@@ -1,0 +1,66 @@
+//go:build linux || darwin
+
+package utils
+
+import (
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// The predicate is only useful if the command builders consult it. A test that
+// merely called the predicate would still pass if someone re-inlined the old
+// `os.Geteuid() != 0` condition at the call sites.
+func TestAgentCommandElevatesOnlyWherePlatformRequiresIt(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root; both paths skip sudo and are indistinguishable")
+	}
+
+	elevates := AgentNeedsElevation(runtime.GOOS)
+
+	cases := []struct {
+		name string
+		args []string
+		want string // expected sudo flag, "" when not elevated
+	}{
+		{"NewAgentCommand", NewAgentCommand("/bin/true", []string{"agent"}, false).Args, ""},
+		{"NewAgentCommand cached creds", NewAgentCommand("/bin/true", []string{"agent"}, true).Args, "-n"},
+		{"NewAgentCommandForPTY", NewAgentCommandForPTY("/bin/true", []string{"agent"}).Args, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if len(tc.args) == 0 {
+				t.Fatal("no command built")
+			}
+			sudoed := strings.HasSuffix(tc.args[0], "sudo")
+			if sudoed != elevates {
+				t.Fatalf("sudo=%v on %s, want %v (args %v)", sudoed, runtime.GOOS, elevates, tc.args)
+			}
+
+			if !elevates {
+				if tc.args[0] != "/bin/true" {
+					t.Errorf("binary = %q, want the agent binary invoked directly", tc.args[0])
+				}
+				if len(tc.args) < 2 || tc.args[1] != "agent" {
+					t.Errorf("args = %v, want the agent args passed through unchanged", tc.args)
+				}
+				return
+			}
+
+			// Elevated: the agent binary and its args must still survive, and
+			// the cached-credentials variant must keep -n so it cannot prompt.
+			rest := tc.args[1:]
+			if tc.want != "" {
+				if len(rest) == 0 || rest[0] != tc.want {
+					t.Fatalf("args = %v, want %q immediately after sudo", tc.args, tc.want)
+				}
+				rest = rest[1:]
+			}
+			if len(rest) < 2 || rest[0] != "/bin/true" || rest[1] != "agent" {
+				t.Errorf("args after sudo = %v, want the agent binary and its args", rest)
+			}
+		})
+	}
+}

--- a/pkg/platform/http/utils/proc_unix.go
+++ b/pkg/platform/http/utils/proc_unix.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -20,14 +21,16 @@ import (
 	"golang.org/x/term"
 )
 
-// NewAgentCommand returns a command that runs elevated on Unix.
+// NewAgentCommand returns a command that runs the native agent, elevated on the
+// platforms that need it.
+// - If the platform does not need root at all (macOS), we run the binary directly.
 // - If already root, we run the binary directly.
 // - Otherwise we prefix with "sudo".
 // - If useCachedCreds is true, uses "sudo -n" (non-interactive) which relies on cached credentials.
 // - We put the process in its own group so we can signal the whole group.
 func NewAgentCommand(bin string, args []string, useCachedCreds bool) *exec.Cmd {
 	var cmd *exec.Cmd
-	if os.Geteuid() == 0 {
+	if !AgentNeedsElevation(runtime.GOOS) || os.Geteuid() == 0 {
 		cmd = exec.Command(bin, args...)
 	} else {
 		if useCachedCreds {
@@ -47,11 +50,12 @@ func NewAgentCommand(bin string, args []string, useCachedCreds bool) *exec.Cmd {
 	return cmd
 }
 
-// NewAgentCommandForPTY returns a command configured for PTY execution.
+// NewAgentCommandForPTY returns a command configured for PTY execution,
+// elevated on the platforms that need it (see NewAgentCommand).
 // Uses Setsid instead of Setpgid to allow PTY to become the controlling terminal.
 func NewAgentCommandForPTY(bin string, args []string) *exec.Cmd {
 	var cmd *exec.Cmd
-	if os.Geteuid() == 0 {
+	if !AgentNeedsElevation(runtime.GOOS) || os.Geteuid() == 0 {
 		cmd = exec.Command(bin, args...)
 	} else {
 		// sudo <bin> <args...>


### PR DESCRIPTION
## Describe the changes that are made

`keploy record` / `keploy test` with a **native** (non-docker) command starts a `keploy agent` child, and `NewAgentCommand` prefixed it with `sudo` whenever `euid != 0`:

```go
if os.Geteuid() == 0 { cmd = exec.Command(bin, args...) } else { /* sudo */ }
```

On Linux that is required — the agent loads eBPF programs, attaches cgroup hooks and mounts bpffs. **On macOS it is not.** There is no eBPF there, and every port the agent binds is unprivileged: proxy `16789`, DNS `26789`, incoming proxy `36789`, and an ephemeral control plane. So macOS users get a password prompt from a process that never needs one.

This adds `AgentNeedsElevation(goos)` and consults it in `NewAgentCommand` / `NewAgentCommandForPTY`.

**Linux is byte-identical.** The condition becomes `!AgentNeedsElevation(runtime.GOOS) || os.Geteuid() == 0`, and the first term is false on Linux. Windows already had its own builder that never sudos.

The predicate takes `goos` as a parameter rather than reading `runtime.GOOS` itself, so the policy is testable for every platform from any host — asserting against the host would only ever cover the one row CI runs on, and could not catch an inverted check. Same shape as `cli/provider.DefaultNativeCommandSupported` from #4467.

### The PTY goes with it

`startNativeAgent` routed through `startNativeAgentWithPTY` whenever `NeedsPTY()`. That PTY exists solely so `sudo` can prompt — its own doc says so. With no prompt it is pure cost:

- `makeRawInputOnly(os.Stdin)` puts the **user's real terminal** into `~ECHO ~ICANON` for the whole run; kill keploy hard and the shell is left with echo off.
- `io.Copy(ptmx, os.Stdin)` swallows every keystroke into a pty nothing reads.
- `NeedsPTY` tests stdin only, so `keploy record … > run.log` from an interactive shell still took the PTY path and OPOST rewrote the agent's output as `\r\n` into the log.
- `StopPTYCommand` closes the master first — deliberately, so "sudo sees EOF and exits". With no sudo that delivers **SIGHUP** to an agent that would otherwise have shut down gracefully.

So the native call site now also requires `AgentNeedsElevation`. The `AreSudoCredentialsCached()` probe (a `sudo -n -v` fork on every start) is skipped for the same reason. **The docker path's own `NeedsPTY` call site is deliberately left alone** — that is a separate behaviour change and does not belong here.

### Elevating cost more than the prompt

It split the run across two users — client and app as the invoking user, agent as root — which broke things that look unrelated:

- `StopCommand` does `kill(-pgid, SIGTERM)`. Against a **root** process group from a non-root client that is **EPERM**, so the forceful-stop fallback could never reap a macOS agent still holding 16789/26789.
- `$TMPDIR` is per-user on macOS (`/var/folders/<hash>/T`), so the root agent and the non-root client resolved *different* temp directories.
- `/tmp` is sticky, so a root-written `/tmp/agent.ready` could not be unlinked by a later non-root agent — a stale readiness marker, logged only at Debug.

## Links & References

**Fixes:** NA

### 🔗 Related PRs
- #4467 — the platform-gate extension point this builds on. The macOS backend that makes elevation unnecessary lives in the enterprise build.
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [x] 🐞 Bug Fix
- [x] ✅ Test

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed

Linux behaviour is provably unchanged, and the macOS behaviour is not observable in an OSS build (see below). The unit tests cover the platform matrix and both command builders.

## Added comments for hard-to-understand areas?
- [x] 👍 yes

`elevate.go` records *why* each platform is where it is, and `NeedsPTY`'s doc now says explicitly that it answers "could something prompt", not "should this platform elevate".

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

```bash
go test ./pkg/platform/http/... -count=1
GOOS=linux go vet ./pkg/platform/http/...      # and darwin, windows
golangci-lint run ./pkg/platform/http/...
```

`TestAgentCommandElevatesOnlyWherePlatformRequiresIt` asserts, on whatever host it runs, that sudo is present exactly when the platform requires it, that `-n` survives on the cached-credentials variant, and that the agent binary and its args pass through either way — so an inverted predicate or a re-inlined `euid != 0` fails it.

## Self Review done?
- [x] ✅ yes

Reviewed independently before commit. That review is what produced the `goos`-parameterised predicate (my first cut used `_darwin.go`/`_linux.go` files, which meant the darwin assertion could never run in CI — `go_macos.yaml` only runs `go build`, not `go test`), and the decision to gate the PTY rather than leave it.

**Honest caveat:** the darwin branch is **not observable in an OSS build today**. `cli/provider.DefaultNativeCommandSupported` returns false for darwin, so a native macOS command is rejected before `startNativeAgent` is reached. This only takes effect for a build that registers a macOS backend. It is still worth landing here because that is where the elevation decision lives.

**Follow-up worth an issue, not fixed here:** `tls/ca.go`'s `setupNativeForApp` branches only on `runtime.GOOS == "windows"`, so darwin falls into the Linux CA-store path and tries to write `/etc/ssl/certs/ca.crt`. Before this change that succeeded as root and left a root-owned file behind (and `updateCaStore` failed anyway — none of `caStoreUpdateCmd`'s entries exist on macOS). After it, it fails one step earlier with EACCES and leaves nothing behind — strictly better, but the correct macOS path is the Windows one (temp file + `SetEnvForPath`), which needs no root and is consistent with this change.

## Any relevant screenshots, recordings or logs?

Before, on macOS, every native run:
```
Password:
```
After: none — the agent is started directly.
