### PR TITLE
feat(mock): `keploy mock record|replay` — Keploy as a mocking framework for your own tests

### DIFF
--- a/.github/workflows/mock_linux.yml
+++ b/.github/workflows/mock_linux.yml
@@ -1,0 +1,50 @@
+name: Mock Mode Regression (Linux)
+# End-to-end guard for `keploy mock record|replay` — Keploy used as a
+# framework-agnostic mocking layer for a user's OWN test runner (here pytest).
+# Self-contained: the script embeds a tiny HTTP dependency and a pytest suite,
+# records the dependency calls, then replays them with the dependency STOPPED
+# and asserts (a) the suite still passes entirely from mocks, (b) per-test
+# mappings are written via the scope API, and (c) a failing runner propagates a
+# non-zero exit code. Runs the PR `build` binary for both record and replay.
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: 'The type of runner to use for this job'
+        type: string
+        required: false
+        default: 'ubuntu-latest'
+      jobs_to_run:
+        description: 'Controls which jobs to run. "all" runs everything.'
+        type: string
+        required: false
+        default: 'all'
+
+jobs:
+  mock_linux:
+    if: ${{ inputs.jobs_to_run == 'all' }}
+    runs-on: ${{ inputs.runner }}
+    name: mock-mode (record_replay_build)
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: keploy/keploy
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - id: record
+        uses: ./.github/actions/download-binary
+        with:
+          src: build
+
+      - name: Run mock-mode e2e
+        env:
+          RECORD_BIN: ${{ steps.record.outputs.path }}
+          REPLAY_BIN: ${{ steps.record.outputs.path }}
+        run: |
+          bash "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/mock/mock-linux.sh"

--- a/.github/workflows/prepare_and_run.yml
+++ b/.github/workflows/prepare_and_run.yml
@@ -730,6 +730,9 @@ jobs:
   run_python_linux:
     needs: [build-and-upload, upload-latest]
     uses: ./.github/workflows/python_linux.yml
+  run_mock_linux:
+    needs: [build-and-upload, upload-latest]
+    uses: ./.github/workflows/mock_linux.yml
   run_http_stale_pool_race_linux:
     # Regression guard for issue #4165 (upstream-pool half-close race
     # in handleHttp1ZeroCopy). Bursty client + gunicorn --keep-alive 2
@@ -1208,6 +1211,7 @@ jobs:
       - run_node_docker
       - run_python_docker
       - run_python_linux
+      - run_mock_linux
       - run_http_stale_pool_race_linux
       - run_outbound_fin_stall_linux
       - run_startup_mock_capture_linux
@@ -1231,6 +1235,7 @@ jobs:
             "${{ needs.run_node_docker.result }}" \
             "${{ needs.run_python_docker.result }}" \
             "${{ needs.run_python_linux.result }}" \
+            "${{ needs.run_mock_linux.result }}" \
             "${{ needs.run_http_stale_pool_race_linux.result }}" \
             "${{ needs.run_outbound_fin_stall_linux.result }}" \
             "${{ needs.run_startup_mock_capture_linux.result }}" \

--- a/.github/workflows/test_workflow_scripts/mock/mock-linux.sh
+++ b/.github/workflows/test_workflow_scripts/mock/mock-linux.sh
@@ -13,6 +13,17 @@ source "${GITHUB_WORKSPACE:-.}/.github/workflows/test_workflow_scripts/test-iid.
 # root also needs an installation-id so the sudo'd agent doesn't prompt
 sudo mkdir -p /root/.keploy && echo "ObjectID('123456789')" | sudo tee /root/.keploy/installation-id.yaml >/dev/null || true
 
+# Ensure pytest is importable by the same interpreter `python3 -m pytest` uses.
+# setup-python provides python3 but not pytest; install it once (idempotent).
+if ! python3 -c "import pytest" 2>/dev/null; then
+  # Keep everything on the SAME python3 the test command uses: ensurepip
+  # guarantees that interpreter has pip, then install pytest into it. (No
+  # cross-interpreter `pip3` fallback, which could land pytest where
+  # `python3 -m pytest` can't import it.)
+  python3 -m ensurepip --default-pip >/dev/null 2>&1 || true
+  python3 -m pip install --quiet --disable-pip-version-check pytest
+fi
+
 RECORD_BIN="${RECORD_BIN:-keploy}"
 REPLAY_BIN="${REPLAY_BIN:-keploy}"
 WORK="$(mktemp -d)"
@@ -60,7 +71,7 @@ def test_items():  assert get("/items/42")["path"]=="/items/42"
 def test_health(): assert get("/health")["path"]=="/health"
 PY
 
-start_dep() { python3 depserver.py "$PORT" & echo $!; }
+start_dep() { python3 depserver.py "$PORT" >dep.log 2>&1 & echo $!; }
 stop_dep()  { kill "$1" 2>/dev/null; sleep 1; }
 
 echo "== 1. record dependency calls =="

--- a/.github/workflows/test_workflow_scripts/mock/mock-linux.sh
+++ b/.github/workflows/test_workflow_scripts/mock/mock-linux.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Self-contained e2e for `keploy mock record|replay` — Keploy as a mocking
+# framework for a user's own test runner. Needs no external sample repo: it
+# embeds a tiny HTTP dependency and a pytest suite, records the dependency
+# calls, then replays them with the dependency STOPPED and asserts the runner
+# still passes and the exit code is propagated.
+#
+# Env: RECORD_BIN / REPLAY_BIN (the keploy binaries under test), set by the
+# .github/actions/download-binary composite action, as in the other lang scripts.
+set -uo pipefail
+
+source "${GITHUB_WORKSPACE:-.}/.github/workflows/test_workflow_scripts/test-iid.sh" 2>/dev/null || true
+# root also needs an installation-id so the sudo'd agent doesn't prompt
+sudo mkdir -p /root/.keploy && echo "ObjectID('123456789')" | sudo tee /root/.keploy/installation-id.yaml >/dev/null || true
+
+RECORD_BIN="${RECORD_BIN:-keploy}"
+REPLAY_BIN="${REPLAY_BIN:-keploy}"
+WORK="$(mktemp -d)"
+cd "$WORK"
+PORT=18999
+FAIL=0
+
+cat > depserver.py <<'PY'
+import http.server, json, socketserver, sys
+PORT=int(sys.argv[1]); c={'n':0}
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        c['n']+=1
+        body=json.dumps({"path":self.path,"counter":c['n']}).encode()
+        self.send_response(200); self.send_header("Content-Type","application/json")
+        self.send_header("Content-Length",str(len(body))); self.end_headers(); self.wfile.write(body)
+    def log_message(self,*a): pass
+socketserver.TCPServer.allow_reuse_address=True
+with socketserver.TCPServer(("127.0.0.1",PORT),H) as s: s.serve_forever()
+PY
+
+cat > conftest.py <<'PY'
+import os, json, urllib.request, pytest
+AGENT=os.environ.get("KEPLOY_MOCK_AGENT")
+def _post(p,b):
+    if not AGENT: return
+    try:
+        r=urllib.request.Request(AGENT+p,data=json.dumps(b).encode(),
+            headers={"Content-Type":"application/json"},method="POST")
+        urllib.request.urlopen(r,timeout=3).read()
+    except Exception: pass
+@pytest.fixture(autouse=True)
+def keploy_scope(request):
+    _post("/agent/scope/begin",{"name":request.node.name}); yield
+    _post("/agent/scope/end",{"name":request.node.name})
+PY
+
+cat > test_api.py <<PY
+import os, json, urllib.request
+BASE="http://127.0.0.1:$PORT"
+def get(p):
+    with urllib.request.urlopen(BASE+p, timeout=5) as r: return json.load(r)
+def test_users():  assert get("/users?id=1")["path"]=="/users?id=1"
+def test_items():  assert get("/items/42")["path"]=="/items/42"
+def test_health(): assert get("/health")["path"]=="/health"
+PY
+
+start_dep() { python3 depserver.py "$PORT" & echo $!; }
+stop_dep()  { kill "$1" 2>/dev/null; sleep 1; }
+
+echo "== 1. record dependency calls =="
+DEP_PID=$(start_dep); sleep 1
+sudo -E env PATH="$PATH" "$RECORD_BIN" mock record -c "python3 -m pytest -q -p no:cacheprovider test_api.py" --name e2e --disable-tele 2>&1 | tee rec.log
+stop_dep "$DEP_PID"
+MOCKS=$(grep -c '^kind:' keploy/e2e/mocks.yaml 2>/dev/null || echo 0)
+echo "recorded mocks: $MOCKS"
+[ "$MOCKS" -eq 3 ] || { echo "FAIL: expected 3 mocks, got $MOCKS"; FAIL=1; }
+[ -f keploy/e2e/mappings.yaml ] || { echo "FAIL: per-test mappings.yaml not written"; FAIL=1; }
+
+echo "== 2. replay with the dependency STOPPED (must serve from mocks) =="
+sudo -E env PATH="$PATH" "$REPLAY_BIN" mock replay -c "python3 -m pytest -q -p no:cacheprovider test_api.py" --name e2e --disable-tele 2>&1 | tee rep.log
+RC=${PIPESTATUS[0]}
+echo "replay exit=$RC"
+[ "$RC" -eq 0 ] || { echo "FAIL: replay should pass entirely from mocks (exit 0), got $RC"; FAIL=1; }
+grep -q "3 passed" rep.log || { echo "FAIL: pytest did not report 3 passed under replay"; FAIL=1; }
+
+echo "== 3. exit-code propagation: a failing runner must fail keploy =="
+cat > test_fail.py <<PY
+def test_boom(): assert False
+PY
+sudo -E env PATH="$PATH" "$REPLAY_BIN" mock replay -c "python3 -m pytest -q -p no:cacheprovider test_fail.py" --name e2e --disable-tele >/dev/null 2>&1
+RC=$?
+echo "failing-runner replay exit=$RC"
+[ "$RC" -ne 0 ] || { echo "FAIL: a failing runner must make keploy exit non-zero"; FAIL=1; }
+
+if [ "$FAIL" -eq 0 ]; then echo "MOCK E2E: PASSED"; else echo "MOCK E2E: FAILED"; fi
+exit "$FAIL"

--- a/cli/mock.go
+++ b/cli/mock.go
@@ -1,0 +1,132 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+	"go.keploy.io/server/v3/config"
+	mockSvc "go.keploy.io/server/v3/pkg/service/mock"
+	"go.keploy.io/server/v3/utils"
+	"go.uber.org/zap"
+)
+
+func init() {
+	Register("mock", Mock)
+}
+
+// Mock is the `keploy mock` parent command: use Keploy as a framework-agnostic
+// mocking layer for your OWN test runner (pytest, go test, jest/playwright,
+// mobile UI tests). Record captures the outgoing dependency calls your tests
+// make; replay serves them back so the suite runs hermetically.
+//
+// Enterprise re-registers "mock" to add cloud-registry subcommands
+// (download/upload/patch); it composes these OSS record/replay builders under
+// its own parent, so keep MockRecord/MockReplay exported and free of AddFlags
+// calls (the parent's loop adds flags — double registration panics).
+func Mock(ctx context.Context, logger *zap.Logger, _ *config.Config, serviceFactory ServiceFactory, cmdConfigurator CmdConfigurator) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "mock",
+		Short: "Use Keploy as a mocking framework for your own tests (record/replay dependency calls)",
+		Long: `Record the real outgoing calls your test suite makes, then replay them so the
+suite runs without the real dependencies — a language-agnostic VCR/WireMock at
+the network layer.
+
+Examples:
+  # Record the dependency calls pytest makes into the "default" mock set
+  keploy mock record -c "pytest"
+
+  # Replay them (dependencies can be offline)
+  keploy mock replay -c "pytest"
+
+  # A named set, refreshed on a merge to main, appending any new calls
+  keploy mock record -c "go test ./..." --name orders
+  keploy mock replay -c "go test ./..." --name orders --on-miss record`,
+	}
+
+	cmd.AddCommand(MockRecord(ctx, logger, serviceFactory, cmdConfigurator))
+	cmd.AddCommand(MockReplay(ctx, logger, serviceFactory, cmdConfigurator))
+	for _, subCmd := range cmd.Commands() {
+		if err := cmdConfigurator.AddFlags(subCmd); err != nil {
+			utils.LogError(logger, err, "failed to add flags to command", zap.String("command", subCmd.Name()))
+		}
+	}
+	return cmd
+}
+
+// MockRecord builds `keploy mock record`. Exported so enterprise can compose it.
+// It does NOT call AddFlags — the parent's loop does.
+func MockRecord(ctx context.Context, logger *zap.Logger, serviceFactory ServiceFactory, cmdConfigurator CmdConfigurator) *cobra.Command {
+	return &cobra.Command{
+		Use:     "record",
+		Short:   "Record the outgoing dependency calls your test command makes",
+		Example: `keploy mock record -c "pytest" --name default`,
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			return cmdConfigurator.Validate(ctx, cmd)
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			svc, err := serviceFactory.GetService(ctx, "mock-record")
+			if err != nil {
+				utils.LogError(logger, err, "failed to get service")
+				return nil
+			}
+			m, ok := svc.(mockSvc.Service)
+			if !ok {
+				utils.LogError(logger, nil, "service doesn't satisfy mock service interface")
+				return nil
+			}
+			// Ensure background goroutines (agent monitor, proxy streams) are
+			// torn down when Record returns, unless the user already interrupted.
+			defer func() {
+				select {
+				case <-ctx.Done():
+				default:
+					utils.ExecCancel()
+				}
+			}()
+			if err := m.Record(ctx); err != nil {
+				if ctx.Err() != context.Canceled {
+					utils.LogError(logger, err, "failed to record mocks")
+				}
+			}
+			return nil
+		},
+	}
+}
+
+// MockReplay builds `keploy mock replay`. Exported so enterprise can compose it.
+// It does NOT call AddFlags — the parent's loop does.
+func MockReplay(ctx context.Context, logger *zap.Logger, serviceFactory ServiceFactory, cmdConfigurator CmdConfigurator) *cobra.Command {
+	return &cobra.Command{
+		Use:     "replay",
+		Short:   "Replay recorded mocks while your test command runs",
+		Example: `keploy mock replay -c "pytest" --name default --on-miss fail`,
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			return cmdConfigurator.Validate(ctx, cmd)
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			svc, err := serviceFactory.GetService(ctx, "mock-replay")
+			if err != nil {
+				utils.LogError(logger, err, "failed to get service")
+				return nil
+			}
+			m, ok := svc.(mockSvc.Service)
+			if !ok {
+				utils.LogError(logger, nil, "service doesn't satisfy mock service interface")
+				return nil
+			}
+			defer func() {
+				select {
+				case <-ctx.Done():
+				default:
+					utils.ExecCancel()
+				}
+			}()
+			if err := m.Replay(ctx); err != nil {
+				if ctx.Err() != context.Canceled {
+					utils.LogError(logger, err, "failed to replay mocks")
+				}
+			}
+			return nil
+		},
+	}
+}

--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -179,6 +179,13 @@ func (c *CmdConfigurator) AddFlags(cmd *cobra.Command) error {
 	cmd.Flags().SetNormalizeFunc(aliasNormalizeFunc)
 	cmd.Flags().String("configPath", ".", "Path to the local directory where keploy configuration file is stored")
 
+	// `keploy mock record` / `keploy mock replay` — the subcommands are named
+	// "record"/"replay" so they would otherwise fall into the record/test flag
+	// branch (or the default error). Intercept them here.
+	if cmd.Parent() != nil && cmd.Parent().Name() == "mock" {
+		return c.addMockFlags(cmd)
+	}
+
 	switch cmd.Name() {
 	case "generate", "download":
 		cmd.Flags().StringSliceP("services", "s", c.cfg.Contract.Services, "Specify the services for which to generate/download contracts")
@@ -328,6 +335,10 @@ func (c *CmdConfigurator) AddFlags(cmd *cobra.Command) error {
 		// the value flows through but produces a no-op at proxy.New.
 		cmd.Flags().Bool("channel-binding-shim", c.cfg.Agent.ChannelBindingShim, "Internal: agent-side mirror of the channel-binding shim flag. Set by the orchestrator subprocess spawn; not intended to be set by users directly.")
 		_ = cmd.Flags().MarkHidden("channel-binding-shim")
+		// Internal orchestrator→agent flag: mock mode skips ingress/bind port
+		// relocation (the wrapped process is a test runner, not a server).
+		cmd.Flags().Bool("mock-mode", c.cfg.Agent.MockMode, "Internal: agent-side mirror of `keploy mock` mode; disables ingress port relocation. Set by the orchestrator, not by users.")
+		_ = cmd.Flags().MarkHidden("mock-mode")
 		cmd.Flags().Uint64P("build-delay", "b", c.cfg.Agent.BuildDelay, "User provided time to wait docker container build")
 		cmd.Flags().UintSlice("pass-through-ports", c.cfg.Agent.PassThroughPorts, "Ports to bypass the proxy server and ignore the traffic")
 		// --ca-java-home is the manual override for the app-aware Java
@@ -921,6 +932,12 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 		redactedCfg.InMemoryCompose = []byte(fmt.Sprintf("**** (%d bytes redacted)", len(redactedCfg.InMemoryCompose)))
 	}
 	c.logger.Debug("config has been initialised", zap.Any("for cmd", cmd.Name()), zap.Any("config", redactedCfg))
+
+	// `keploy mock record` / `keploy mock replay` validation runs on its own
+	// path (see addMockFlags) — the subcommands are named "record"/"replay".
+	if cmd.Parent() != nil && cmd.Parent().Name() == "mock" {
+		return c.validateMockFlags(ctx, cmd)
+	}
 
 	switch cmd.Name() {
 
@@ -1590,6 +1607,14 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 		}
 		c.cfg.Agent.ChannelBindingShim = channelBindingShim
 
+		mockMode, err := cmd.Flags().GetBool("mock-mode")
+		if err != nil {
+			errMsg := "failed to read the mock-mode flag"
+			utils.LogError(c.logger, err, errMsg)
+			return errors.New(errMsg)
+		}
+		c.cfg.Agent.MockMode = mockMode
+
 		// Upstream TLS verification, forwarded from the orchestrator. Gated on
 		// Changed() — but the gate now records that the flag was PRESENT
 		// (…Set) rather than leaving the agent to guess. The orchestrator
@@ -1937,4 +1962,146 @@ func (c *CmdConfigurator) UpdateConfigData(defaultCfg config.Config) config.Conf
 	defaultCfg.Test.DisableLineCoverage = c.cfg.Test.DisableLineCoverage
 	defaultCfg.StorageFormat = c.cfg.StorageFormat
 	return defaultCfg
+}
+
+// addMockFlags registers the flags for `keploy mock record` and
+// `keploy mock replay`. The set is intentionally small: two verbs, --name,
+// --on-miss, plus the command/path/docker knobs record and test already use.
+func (c *CmdConfigurator) addMockFlags(cmd *cobra.Command) error {
+	cmd.Flags().StringP("command", "c", c.cfg.Command, "Command that runs your test suite, e.g. \"pytest\" or \"go test ./...\"")
+	cmd.Flags().StringP("path", "p", ".", "Path to the local directory where the mock set is stored (keploy/<name>/)")
+	cmd.Flags().String("name", c.cfg.Mock.Name, "Name of the mock set to record into / replay from (default \"default\")")
+	cmd.Flags().String("cmd-type", c.cfg.CommandType, "Type of command (native/docker-run/docker-start/docker-compose)")
+	cmd.Flags().String("container-name", c.cfg.ContainerName, "Name of the application's docker container (docker/compose runs)")
+	cmd.Flags().StringP("network-name", "n", c.cfg.NetworkName, "Name of the application's docker network")
+	cmd.Flags().Uint64P("build-delay", "b", c.cfg.BuildDelay, "Time to wait for a docker container to build")
+	cmd.Flags().Uint32("proxy-port", c.cfg.ProxyPort, "Port used by the Keploy proxy to intercept outgoing calls")
+	cmd.Flags().Uint32("dns-port", c.cfg.DNSPort, "Port used by the Keploy DNS server")
+	cmd.Flags().UintSlice("pass-through-ports", config.GetByPassPorts(c.cfg), "Destination ports to leave untouched (never mocked)")
+	cmd.Flags().Bool("local", c.cfg.Mock.Local, "Use the local file-backed mock store even when a cloud registry is configured")
+
+	switch cmd.Name() {
+	case "record":
+		cmd.Flags().Duration("record-timer", c.cfg.Mock.RecordTimer, "Optional upper bound on the record session (e.g. \"30s\"); the runner exiting ends it first")
+	case "replay":
+		cmd.Flags().String("on-miss", c.cfg.Mock.OnMiss, "What to do when an outgoing call matches no recorded mock: fail | passthrough | record")
+		cmd.Flags().Bool("strict", c.cfg.Mock.Strict, "Exit non-zero if any recorded mock was missed (dependency contract drift)")
+		cmd.Flags().Uint64P("delay", "d", 0, "Seconds to wait for the runner to be ready before it starts issuing calls")
+	}
+	return nil
+}
+
+// validateMockFlags resolves and validates flags for the mock record/replay
+// subcommands. It mirrors the record/test path (command type, platform gate,
+// keploy folder resolution + permissions) but reads the mock-specific flags.
+func (c *CmdConfigurator) validateMockFlags(ctx context.Context, cmd *cobra.Command) error {
+	// Resolve the command type (native vs docker-*).
+	commandType, err := resolveCommandType(c.logger, cmd, c.cfg.Command, c.cfg.CommandType)
+	if err != nil {
+		return err
+	}
+	c.cfg.CommandType = commandType
+	if (c.cfg.CommandType == string(utils.Native) || c.cfg.CommandType == string(utils.Empty)) &&
+		!(runtime.GOOS == "linux" || (runtime.GOOS == "windows" && runtime.GOARCH == "amd64")) {
+		return fmt.Errorf("a native command is not supported on OS %s/%s for `keploy mock`; on macOS run your tests through a docker command (e.g. -c \"docker compose run tests\")", runtime.GOOS, runtime.GOARCH)
+	}
+
+	// Resolve the keploy folder path.
+	path, err := cmd.Flags().GetString("path")
+	if err != nil {
+		utils.LogError(c.logger, err, "failed to get the path")
+		return errors.New("failed to get the path")
+	}
+	absPath, err := utils.GetAbsPath(path)
+	if err != nil {
+		utils.LogError(c.logger, err, "error while getting absolute path")
+		return errors.New("failed to get the absolute path")
+	}
+	c.cfg.Path = absPath + "/keploy"
+
+	// Fix folder permissions (and cache sudo creds) for native runs.
+	if !utils.IsDockerCmd(utils.CmdType(c.cfg.CommandType)) {
+		if err := utils.EnsureKeployFolderPermissions(cmd.Context(), c.logger, c.cfg.Path); err != nil {
+			utils.LogError(c.logger, err, "failed to ensure keploy folder permissions")
+			return err
+		}
+	}
+
+	if c.cfg.Command == "" {
+		utils.LogError(c.logger, nil, "missing required -c flag or command in config file")
+		c.logger.Info(`Example usage: keploy mock record -c "pytest"`)
+		return errors.New("command is required for keploy mock")
+	}
+
+	// Pass-through ports.
+	bypassPorts, err := cmd.Flags().GetUintSlice("pass-through-ports")
+	if err != nil {
+		utils.LogError(c.logger, err, "failed to read pass-through-ports")
+		return errors.New("failed to read pass-through-ports")
+	}
+	config.SetByPassPorts(c.cfg, bypassPorts)
+
+	// Mock-set name.
+	name, err := cmd.Flags().GetString("name")
+	if err != nil {
+		utils.LogError(c.logger, err, "failed to get the name flag")
+		return errors.New("failed to get the name flag")
+	}
+	if name != "" {
+		c.cfg.Mock.Name = name
+	}
+	if c.cfg.Mock.Name == "" {
+		c.cfg.Mock.Name = "default"
+	}
+
+	local, err := cmd.Flags().GetBool("local")
+	if err != nil {
+		utils.LogError(c.logger, err, "failed to get the local flag")
+		return errors.New("failed to get the local flag")
+	}
+	c.cfg.Mock.Local = local
+
+	switch cmd.Name() {
+	case "record":
+		if cmd.Flags().Changed("record-timer") {
+			d, err := cmd.Flags().GetDuration("record-timer")
+			if err != nil {
+				utils.LogError(c.logger, err, "failed to get the record-timer flag")
+				return errors.New("failed to get the record-timer flag")
+			}
+			c.cfg.Mock.RecordTimer = d
+		}
+	case "replay":
+		onMiss, err := cmd.Flags().GetString("on-miss")
+		if err != nil {
+			utils.LogError(c.logger, err, "failed to get the on-miss flag")
+			return errors.New("failed to get the on-miss flag")
+		}
+		onMiss = strings.ToLower(strings.TrimSpace(onMiss))
+		if onMiss == "" {
+			onMiss = string(models.MissFail)
+		}
+		if !models.MissPolicy(onMiss).Valid() {
+			return fmt.Errorf("invalid --on-miss value %q: allowed values are fail, passthrough, record", onMiss)
+		}
+		c.cfg.Mock.OnMiss = onMiss
+
+		strict, err := cmd.Flags().GetBool("strict")
+		if err != nil {
+			utils.LogError(c.logger, err, "failed to get the strict flag")
+			return errors.New("failed to get the strict flag")
+		}
+		c.cfg.Mock.Strict = strict
+
+		if cmd.Flags().Changed("delay") {
+			d, err := cmd.Flags().GetUint64("delay")
+			if err != nil {
+				utils.LogError(c.logger, err, "failed to get the delay flag")
+				return errors.New("failed to get the delay flag")
+			}
+			c.cfg.Test.Delay = d
+		}
+	}
+
+	return nil
 }

--- a/cli/provider/core_service.go
+++ b/cli/provider/core_service.go
@@ -22,6 +22,7 @@ import (
 	testdb "go.keploy.io/server/v3/pkg/platform/yaml/testdb"
 	"go.keploy.io/server/v3/pkg/service/contract"
 	"go.keploy.io/server/v3/pkg/service/diff"
+	"go.keploy.io/server/v3/pkg/service/mock"
 	"go.keploy.io/server/v3/pkg/service/record"
 	"go.keploy.io/server/v3/pkg/service/replay"
 	"go.keploy.io/server/v3/pkg/service/report"
@@ -50,6 +51,12 @@ func Get(ctx context.Context, cmd string, cfg *config.Config, logger *zap.Logger
 		}
 	}
 	replaySvc := replay.NewReplayer(logger, commonServices.YamlTestDB, commonServices.YamlMockDb, commonServices.YamlReportDb, commonServices.YamlMappingDb, commonServices.YamlTestSetDB, tel, commonServices.Instrumentation, commonServices.Storage, cfg)
+	// mockSvc reuses the SAME AgentClient instrumentation, mock/mapping DBs and
+	// (in enterprise) RecordHooks that record/replay use, so every runtime
+	// behaviour those apply to the wrapped command — LD_PRELOAD/java-agent/Go
+	// binary TLS shims, time-freeze, secret obfuscation — applies to
+	// `keploy mock` unchanged. OSS uses the file-backed store.
+	mockSvc := mock.New(logger, commonServices.Instrumentation, commonServices.YamlMockDb, commonServices.YamlMappingDb, mock.FileStore{}, nil, cfg)
 	toolsSvc := tools.NewTools(logger, commonServices.YamlTestSetDB, commonServices.YamlTestDB, commonServices.YamlReportDb, tel, cfg)
 	reportSvc := report.New(logger, cfg, commonServices.YamlReportDb, commonServices.YamlTestDB)
 	diffSvc := diff.New(logger, commonServices.YamlReportDb, commonServices.YamlTestDB)
@@ -58,6 +65,8 @@ func Get(ctx context.Context, cmd string, cfg *config.Config, logger *zap.Logger
 		return recordSvc, nil
 	case "test":
 		return replaySvc, nil
+	case "mock-record", "mock-replay":
+		return mockSvc, nil
 	case "templatize", "config", "update", "export", "import", "sanitize", "normalize":
 		return toolsSvc, nil
 	case "contract":

--- a/cli/provider/service.go
+++ b/cli/provider/service.go
@@ -37,7 +37,7 @@ func (n *ServiceProvider) GetService(ctx context.Context, cmd string) (interface
 	tel.Ping(ctx)
 
 	switch cmd {
-	case "record", "test", "normalize", "contract", "config", "update", "export", "import", "templatize", "report", "sanitize", "diff":
+	case "record", "test", "normalize", "contract", "config", "update", "export", "import", "templatize", "report", "sanitize", "diff", "mock-record", "mock-replay":
 		return Get(ctx, cmd, n.cfg, n.logger, tel)
 	case "agent":
 		return GetAgent(ctx, cmd, n.cfg, n.logger)

--- a/config/config.go
+++ b/config/config.go
@@ -69,6 +69,7 @@ type Config struct {
 	KeployNetwork             string   `json:"keployNetwork" yaml:"keployNetwork" mapstructure:"keployNetwork"`
 	CommandType               string   `json:"cmdType" yaml:"cmdType" mapstructure:"cmdType"`
 	Contract                  Contract `json:"contract" yaml:"contract" mapstructure:"contract"`
+	Mock                      MockCmd  `json:"mock" yaml:"mock" mapstructure:"mock"`
 	Agent                     Agent    `json:"agent" yaml:"agent" mapstructure:"agent"`
 	Async                     Async    `json:"async" yaml:"async" mapstructure:"async"`
 	InCi                      bool     `json:"inCi" yaml:"inCi" mapstructure:"inCi"`
@@ -293,6 +294,34 @@ type RecordBuffer struct {
 	// you see drops with reason "consumer_gone"; lower it to cap how long
 	// a connection with a genuinely dead parser lingers at teardown.
 	ConsumerStallGrace time.Duration `json:"consumerStallGrace" yaml:"consumerStallGrace" mapstructure:"consumerStallGrace"`
+}
+
+// MockCmd configures the `keploy mock record|replay` flow — using Keploy as a
+// framework-agnostic mocking layer for a user's own test runner (pytest, go
+// test, jest/playwright, mobile UI tests). Unlike record/test it captures ONLY
+// outgoing dependency calls (no incoming test cases) into a single named mock
+// set, and on replay serves that set back to the wrapped runner.
+type MockCmd struct {
+	// Name is the mock set to record into / replay from (the on-disk directory
+	// under keploy/, and the registry key). Defaults to "default". Re-recording
+	// the same name overwrites its mocks in place so a CI "re-record on merge to
+	// main" job produces a reviewable diff rather than an accumulating pile of
+	// test-set-N directories.
+	Name string `json:"name" yaml:"name" mapstructure:"name"`
+	// OnMiss is the replay-time miss policy: "fail" (default — deterministic,
+	// a miss is a hard error), "passthrough" (dial the real dependency, don't
+	// persist), or "record" (dial the real dependency AND append the new call
+	// to the set — VCR-style new_episodes for incremental refresh).
+	OnMiss string `json:"onMiss" yaml:"onMiss" mapstructure:"onMiss"`
+	// Strict makes replay exit non-zero if any recorded mock was missed, so a
+	// drifted dependency contract fails the build even when the runner passed.
+	Strict bool `json:"strict" yaml:"strict" mapstructure:"strict"`
+	// Local forces the file-backed store even when a cloud registry is
+	// configured (enterprise). Registry-first by default; --local opts out.
+	Local bool `json:"local" yaml:"local" mapstructure:"local"`
+	// RecordTimer optionally bounds a record session (e.g. "30s"); the wrapped
+	// runner exiting on its own ends recording first in almost all cases.
+	RecordTimer time.Duration `json:"recordTimer" yaml:"recordTimer" mapstructure:"recordTimer"`
 }
 
 type Contract struct {

--- a/config/default.go
+++ b/config/default.go
@@ -157,6 +157,12 @@ disableMysqlAutoDetect: false
 # unlike disableMysqlAutoDetect this keeps record-time detection on.
 disableMysqlEndpointDrift: false
 disableMapping: false
+mock:
+  name: "default"
+  onMiss: "fail"
+  strict: false
+  local: false
+  recordTimer: 0s
 contract:
   driven: "consumer"
   mappings:

--- a/pkg/agent/hooks/linux/hooks.go
+++ b/pkg/agent/hooks/linux/hooks.go
@@ -252,8 +252,13 @@ func (h *Hooks) load(ctx context.Context, opts agent.HookCfg, setupOpts config.A
 	}
 	h.sockops = sockops
 
-	if opts.Mode == models.MODE_RECORD {
+	if opts.Mode == models.MODE_RECORD && !setupOpts.MockMode {
 
+		// Skipped in mock mode (--mock-mode): the wrapped process is a test
+		// runner, not a server. Relocating any port it binds (a pytest
+		// live_server, a Playwright webServer, an httptest.NewServer) would
+		// double-record the runner's own loopback traffic and can crash it on a
+		// startup race. Mock mode captures ONLY egress, so no bind/ingress hooks.
 		h.BindEvents = objs.BindEvents
 		cg4, err := link.AttachCgroup(link.CgroupOptions{
 			Path:    cGroupPath,
@@ -622,6 +627,15 @@ func (h *Hooks) RegisterClient(ctx context.Context, opts config.Agent, rules []m
 
 	if agent.ExtraPassThroughPortsHook != nil {
 		ports = append(ports, agent.ExtraPassThroughPortsHook()...)
+	}
+
+	// Mock mode: the wrapped test runner calls the agent's own HTTP server
+	// (the /agent/scope/* API) at localhost:<AgentPort>. That process is inside
+	// the intercepted PID tree, so without bypassing this port the runner's
+	// scope calls would be redirected into the proxy instead of reaching the
+	// agent. Kernel-level bypass the agent's own control port.
+	if opts.MockMode && opts.AgentPort != 0 {
+		ports = append(ports, uint(opts.AgentPort))
 	}
 
 	for i := 0; i < 10; i++ {

--- a/pkg/agent/proxy/integrations/http/decode.go
+++ b/pkg/agent/proxy/integrations/http/decode.go
@@ -344,6 +344,27 @@ func (h *HTTP) decodeHTTP(ctx context.Context, reqBuf []byte, clientConn net.Con
 						zap.String("next_step", report.NextSteps))
 				}
 
+				// On-miss policy (keploy mock replay --on-miss): passthrough or
+				// record dials the real dependency and relays the exchange so an
+				// unrecorded call succeeds instead of hard-failing. record also
+				// captures it for the CLI to append to the set at end-of-run.
+				if opts.OnMiss.PassesThroughOnMiss() {
+					handled, phErr := h.serveOnMiss(ctx, clientConn, reqBuf, request, input.body, dstCfg, opts)
+					if phErr != nil {
+						h.Logger.Debug("on-miss passthrough failed; falling back to hard miss", zap.Error(phErr), zap.Any("metadata", utils.GetReqMeta(request)))
+					} else if handled {
+						// Served live — continue the keep-alive loop for the next
+						// request on this connection. Not reported as a miss.
+						reqBuf, err = pUtil.ReadBytes(ctx, h.Logger, clientConn)
+						if err != nil {
+							h.Logger.Debug("client closed connection after on-miss passthrough", zap.Error(err))
+							errCh <- nil
+							return
+						}
+						continue
+					}
+				}
+
 				// No mock matched — send a 502 so the application gets a
 				// proper HTTP error instead of a silent connection close.
 				noMockBody := "keploy: no matching mock found for this HTTP request\n"

--- a/pkg/agent/proxy/integrations/http/onmiss.go
+++ b/pkg/agent/proxy/integrations/http/onmiss.go
@@ -148,9 +148,12 @@ func (h *HTTP) serveOnMiss(ctx context.Context, clientConn net.Conn, reqBuf []by
 }
 
 // dialUpstream opens a connection to the real dependency, wrapping it in TLS
-// when the original client connection was TLS (dstCfg.TLSCfg set). It mirrors
-// keploy's record-time posture of not being stricter than the app it stands in
-// for, so the upstream cert is not verified here.
+// when the original client connection was TLS (dstCfg.TLSCfg set). The upstream
+// certificate is verified against the system trust store (ServerName carried
+// over from the client's SNI). A dependency with a self-signed / untrusted cert
+// therefore fails the handshake here and the caller falls back to the hard miss
+// (502) rather than the proxy silently trusting an unverified upstream — this
+// on-miss path dials the real network, so it must not disable verification.
 func (h *HTTP) dialUpstream(ctx context.Context, dstCfg *models.ConditionalDstCfg) (net.Conn, error) {
 	d := &net.Dialer{Timeout: 30 * time.Second}
 	raw, err := d.DialContext(ctx, "tcp", dstCfg.Addr)
@@ -160,9 +163,11 @@ func (h *HTTP) dialUpstream(ctx context.Context, dstCfg *models.ConditionalDstCf
 	if dstCfg.TLSCfg == nil {
 		return raw, nil
 	}
-	cfg := dstCfg.TLSCfg.Clone()
-	cfg.InsecureSkipVerify = true
-	tlsConn := tls.Client(raw, cfg)
+	// Minimal upstream client config: verify against the system trust store
+	// (RootCAs nil) with the app's SNI as ServerName. We deliberately do NOT
+	// reuse dstCfg.TLSCfg — that is keploy's MITM SERVER config (leaf cert, CA)
+	// and must not leak into an upstream client dial. No skip-verify.
+	tlsConn := tls.Client(raw, &tls.Config{ServerName: dstCfg.TLSCfg.ServerName, MinVersion: tls.VersionTLS12})
 	if err := tlsConn.HandshakeContext(ctx); err != nil {
 		_ = raw.Close()
 		return nil, err

--- a/pkg/agent/proxy/integrations/http/onmiss.go
+++ b/pkg/agent/proxy/integrations/http/onmiss.go
@@ -1,0 +1,171 @@
+package http
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/tls"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"go.keploy.io/server/v3/pkg"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// On-miss policy for `keploy mock replay` (models.OutgoingOptions.OnMiss):
+//   - fail (default): the miss is a hard 502; nothing reaches the real upstream.
+//   - passthrough: dial the real dependency, relay the exchange, don't persist.
+//   - record: passthrough AND capture the exchange so the CLI appends it to the
+//     mock set at end-of-run (VCR "new_episodes" — incremental refresh).
+//
+// The capture buffer is a process-global drained once per run by the CLI via
+// GET /agent/mock/captured, so record-on-miss needs no live streaming and no
+// change to the proxy's mock-serving session mode.
+
+var (
+	capturedMu    sync.Mutex
+	capturedMocks []*models.Mock
+)
+
+// ResetCaptured clears the on-miss capture buffer at the start of a mock-serving
+// session so a reused agent process does not leak captures across runs.
+func ResetCaptured() {
+	capturedMu.Lock()
+	capturedMocks = nil
+	capturedMu.Unlock()
+}
+
+// DrainCaptured returns and clears the mocks captured on miss this run. The CLI
+// appends them to the active set.
+func DrainCaptured() []*models.Mock {
+	capturedMu.Lock()
+	out := capturedMocks
+	capturedMocks = nil
+	capturedMu.Unlock()
+	return out
+}
+
+func appendCaptured(m *models.Mock) {
+	capturedMu.Lock()
+	capturedMocks = append(capturedMocks, m)
+	capturedMu.Unlock()
+}
+
+// serveOnMiss handles an HTTP mock miss under a passthrough/record policy: it
+// dials the real upstream, relays the request and response, writes the response
+// back to the client, and (for record) captures a mock. It returns true when it
+// handled the exchange (the caller then continues the keep-alive loop), or false
+// when the policy is fail (the caller sends the 502). An error means the
+// upstream dial/relay failed and the caller should fall back to the 502.
+func (h *HTTP) serveOnMiss(ctx context.Context, clientConn net.Conn, reqBuf []byte, request *http.Request, reqBody []byte, dstCfg *models.ConditionalDstCfg, opts models.OutgoingOptions) (bool, error) {
+	if !opts.OnMiss.PassesThroughOnMiss() {
+		return false, nil
+	}
+	if dstCfg == nil || dstCfg.Addr == "" {
+		h.Logger.Debug("on-miss passthrough: no upstream address known; falling back to hard miss")
+		return false, nil
+	}
+
+	reqTs := time.Now()
+	dstConn, err := h.dialUpstream(ctx, dstCfg)
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		if cerr := dstConn.Close(); cerr != nil {
+			h.Logger.Debug("on-miss passthrough: failed to close upstream conn", zap.Error(cerr))
+		}
+	}()
+
+	// Forward the exact request bytes upstream.
+	if _, err := dstConn.Write(reqBuf); err != nil {
+		return false, err
+	}
+
+	// Read the upstream response.
+	respReader := bufio.NewReader(dstConn)
+	respParsed, err := http.ReadResponse(respReader, request)
+	if err != nil {
+		return false, err
+	}
+	respBody, err := io.ReadAll(respParsed.Body)
+	_ = respParsed.Body.Close()
+	if err != nil {
+		return false, err
+	}
+	resTs := time.Now()
+
+	// Relay the response to the client verbatim (re-serialize with a correct
+	// Content-Length; the app reads a normal HTTP response).
+	respParsed.Body = io.NopCloser(bytes.NewReader(respBody))
+	respParsed.ContentLength = int64(len(respBody))
+	var outBuf bytes.Buffer
+	if err := respParsed.Write(&outBuf); err != nil {
+		return false, err
+	}
+	if _, err := clientConn.Write(outBuf.Bytes()); err != nil {
+		return false, err
+	}
+
+	h.Logger.Info("on-miss: served an unrecorded call from the real dependency",
+		zap.String("method", request.Method),
+		zap.String("url", request.URL.String()),
+		zap.String("policy", string(opts.OnMiss)))
+
+	// record policy: capture the exchange for the CLI to persist.
+	if opts.OnMiss.RecordsOnMiss() {
+		appendCaptured(&models.Mock{
+			Version: models.GetVersion(),
+			Name:    "mocks",
+			Kind:    models.HTTP,
+			Spec: models.MockSpec{
+				Metadata: map[string]string{"type": "HTTP_CLIENT", "operation": request.Method},
+				HTTPReq: &models.HTTPReq{
+					Method:     models.Method(request.Method),
+					ProtoMajor: request.ProtoMajor,
+					ProtoMinor: request.ProtoMinor,
+					URL:        request.URL.String(),
+					Header:     pkg.ToYamlHTTPHeader(request.Header),
+					Body:       string(reqBody),
+					URLParams:  pkg.URLParams(request),
+				},
+				HTTPResp: &models.HTTPResp{
+					StatusCode: respParsed.StatusCode,
+					Header:     pkg.ToYamlHTTPHeader(respParsed.Header),
+					Body:       string(respBody),
+				},
+				Created:          time.Now().Unix(),
+				ReqTimestampMock: reqTs,
+				ResTimestampMock: resTs,
+			},
+		})
+	}
+	return true, nil
+}
+
+// dialUpstream opens a connection to the real dependency, wrapping it in TLS
+// when the original client connection was TLS (dstCfg.TLSCfg set). It mirrors
+// keploy's record-time posture of not being stricter than the app it stands in
+// for, so the upstream cert is not verified here.
+func (h *HTTP) dialUpstream(ctx context.Context, dstCfg *models.ConditionalDstCfg) (net.Conn, error) {
+	d := &net.Dialer{Timeout: 30 * time.Second}
+	raw, err := d.DialContext(ctx, "tcp", dstCfg.Addr)
+	if err != nil {
+		return nil, err
+	}
+	if dstCfg.TLSCfg == nil {
+		return raw, nil
+	}
+	cfg := dstCfg.TLSCfg.Clone()
+	cfg.InsecureSkipVerify = true
+	tlsConn := tls.Client(raw, cfg)
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		_ = raw.Close()
+		return nil, err
+	}
+	return tlsConn, nil
+}

--- a/pkg/agent/routes/record.go
+++ b/pkg/agent/routes/record.go
@@ -84,6 +84,15 @@ func (d DefaultRoutes) New(r chi.Router, agent agent.Service, logger *zap.Logger
 		r.Get("/consumedmocks", a.GetConsumedMocks)
 		r.Get("/mockerrors", a.GetMockErrors)
 		r.Post("/test-capture/begin", a.BeginTestErrorCapture)
+		// Per-test scope API for `keploy mock record|replay` — a user's test
+		// runner marks per-test boundaries so mocks are attributed / restricted
+		// per test. See pkg/agent/routes/scope.go.
+		r.Post("/scope/begin", a.HandleScopeBegin)
+		r.Post("/scope/end", a.HandleScopeEnd)
+		r.Get("/scope/windows", a.HandleScopeWindows)
+		r.Post("/scope/table", a.HandleScopeTable)
+		r.Get("/mock/stats", a.HandleMockStats)
+		r.Get("/mock/captured", a.HandleCapturedMocks)
 		r.Post("/agent/ready", a.MakeAgentReady)
 		r.Post("/graceful-shutdown", a.HandleGracefulShutdown)
 		// Long-lived streaming endpoints. /pcap/traffic emits a

--- a/pkg/agent/routes/scope.go
+++ b/pkg/agent/routes/scope.go
@@ -1,0 +1,143 @@
+package routes
+
+import (
+	"context"
+	"encoding/gob"
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/render"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// The scope API lets a user's own test runner mark per-test boundaries so the
+// `keploy mock record|replay` flow can attribute / restrict mocks per test.
+// Handlers reach the concrete capability via type-assertion so the
+// agent.Service interface stays unchanged (same pattern as BeginTestErrorCapture).
+
+type scopeBeginner interface {
+	BeginScope(ctx context.Context, name string) error
+}
+type scopeEnder interface {
+	EndScope(ctx context.Context, name string) error
+}
+type scopeWindowReader interface {
+	GetScopeWindows(ctx context.Context) ([]models.ScopeWindow, error)
+}
+type scopeTableSetter interface {
+	SetScopeTable(ctx context.Context, table map[string][]string) error
+}
+type mockStatsReader interface {
+	MockStats(ctx context.Context) (models.MockStats, error)
+}
+type capturedMockDrainer interface {
+	DrainCapturedMocks(ctx context.Context) ([]*models.Mock, error)
+}
+
+// HandleScopeBegin marks the start of a named per-test scope.
+func (a *Agent) HandleScopeBegin(w http.ResponseWriter, r *http.Request) {
+	var req models.ScopeReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if s, ok := a.svc.(scopeBeginner); ok {
+		if err := s.BeginScope(r.Context(), req.Name); err != nil {
+			a.logger.Debug("scope begin failed", zap.String("name", req.Name), zap.Error(err))
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+	render.Status(r, http.StatusOK)
+	render.JSON(w, r, map[string]string{"status": "ok"})
+}
+
+// HandleScopeEnd marks the end of a named per-test scope.
+func (a *Agent) HandleScopeEnd(w http.ResponseWriter, r *http.Request) {
+	var req models.ScopeReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if s, ok := a.svc.(scopeEnder); ok {
+		if err := s.EndScope(r.Context(), req.Name); err != nil {
+			a.logger.Debug("scope end failed", zap.String("name", req.Name), zap.Error(err))
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+	render.Status(r, http.StatusOK)
+	render.JSON(w, r, map[string]string{"status": "ok"})
+}
+
+// HandleScopeWindows returns the per-test windows collected during a record
+// session (consumed by the CLI to build mappings.yaml).
+func (a *Agent) HandleScopeWindows(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	windows := []models.ScopeWindow{}
+	if s, ok := a.svc.(scopeWindowReader); ok {
+		got, err := s.GetScopeWindows(r.Context())
+		if err != nil {
+			render.Status(r, http.StatusInternalServerError)
+			render.JSON(w, r, map[string]string{"error": err.Error()})
+			return
+		}
+		windows = got
+	}
+	render.Status(r, http.StatusOK)
+	render.JSON(w, r, windows)
+}
+
+// HandleScopeTable installs the replay-time per-test name→mock-names table.
+func (a *Agent) HandleScopeTable(w http.ResponseWriter, r *http.Request) {
+	var req models.ScopeTableReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if s, ok := a.svc.(scopeTableSetter); ok {
+		if err := s.SetScopeTable(r.Context(), req.Mappings); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+	render.Status(r, http.StatusOK)
+	render.JSON(w, r, map[string]string{"status": "ok"})
+}
+
+// HandleCapturedMocks returns (and clears) the mocks captured on miss during a
+// `--on-miss record` replay, gob-encoded like /storemocks.
+func (a *Agent) HandleCapturedMocks(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/x-gob")
+	mocks := []*models.Mock{}
+	if d, ok := a.svc.(capturedMockDrainer); ok {
+		got, err := d.DrainCapturedMocks(r.Context())
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		mocks = got
+	}
+	w.WriteHeader(http.StatusOK)
+	if err := gob.NewEncoder(w).Encode(mocks); err != nil {
+		a.logger.Debug("failed to encode captured mocks", zap.Error(err))
+	}
+}
+
+// HandleMockStats returns a non-draining snapshot of the mock session.
+func (a *Agent) HandleMockStats(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	stats := models.MockStats{}
+	if s, ok := a.svc.(mockStatsReader); ok {
+		got, err := s.MockStats(r.Context())
+		if err != nil {
+			render.Status(r, http.StatusInternalServerError)
+			render.JSON(w, r, map[string]string{"error": err.Error()})
+			return
+		}
+		stats = got
+	}
+	render.Status(r, http.StatusOK)
+	render.JSON(w, r, stats)
+}

--- a/pkg/client/app/app.go
+++ b/pkg/client/app/app.go
@@ -1477,7 +1477,7 @@ func (a *App) run(ctx context.Context) models.AppError {
 	if cmdErr.Err != nil {
 		switch cmdErr.Type {
 		case utils.Init:
-			return models.AppError{AppErrorType: models.ErrCommandError, Err: cmdErr.Err, AppLogs: a.recentAppLogs(ctx)}
+			return models.AppError{AppErrorType: models.ErrCommandError, Err: cmdErr.Err, AppLogs: a.recentAppLogs(ctx), ExitCode: exitCodeFromErr(cmdErr.Err)}
 		case utils.Runtime:
 			err = cmdErr.Err
 		}
@@ -1506,8 +1506,34 @@ func (a *App) run(ctx context.Context) models.AppError {
 		}
 
 		if err != nil {
-			return models.AppError{AppErrorType: models.ErrUnExpected, Err: err, AppLogs: appLogs}
+			return models.AppError{AppErrorType: models.ErrUnExpected, Err: err, AppLogs: appLogs, ExitCode: exitCodeFromErr(err)}
 		}
-		return models.AppError{AppErrorType: models.ErrAppStopped, Err: nil, AppLogs: appLogs}
+		return models.AppError{AppErrorType: models.ErrAppStopped, Err: nil, AppLogs: appLogs, ExitCode: 0}
 	}
+}
+
+// exitCodeFromErr extracts the process exit code from a command-wait error.
+// It returns the child's exit status for a normal non-zero exit (the case a
+// wrapped `pytest`/`go test` failure produces), 128+signal for a signalled
+// exit where the runtime exposes it, and -1 when no code can be determined
+// (nil error, or an error that is not an *exec.ExitError). The mock
+// record/replay flows use this to mirror the wrapped runner's exit status.
+func exitCodeFromErr(err error) int {
+	if err == nil {
+		return -1
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		// ExitCode() is -1 when the process was terminated by a signal; in
+		// that case fall back to the conventional 128+signal shell encoding
+		// so callers still get a non-zero, non-(-1) status to propagate.
+		if code := exitErr.ExitCode(); code >= 0 {
+			return code
+		}
+		if ws, ok := exitErr.Sys().(syscall.WaitStatus); ok && ws.Signaled() {
+			return 128 + int(ws.Signal())
+		}
+		return 1
+	}
+	return -1
 }

--- a/pkg/models/agent.go
+++ b/pkg/models/agent.go
@@ -22,6 +22,38 @@ type TestMockMapping struct {
 	MockIDs  []string `json:"mock_ids"`
 }
 
+// ScopeReq is the body of POST /agent/scope/begin and /agent/scope/end — a
+// test-runner plugin / glue-code marks a named per-test scope so the mock flow
+// can attribute captured mocks to a test (record) or restrict the served pool
+// to that test (replay).
+type ScopeReq struct {
+	Name string `json:"name"`
+}
+
+// ScopeWindow is one recorded per-test scope: the agent-clock interval during
+// which the named test made its outgoing calls. Record correlates captured
+// mocks into these windows by request timestamp to build mappings.yaml.
+type ScopeWindow struct {
+	Name  string    `json:"name"`
+	Start time.Time `json:"start"`
+	End   time.Time `json:"end"`
+}
+
+// ScopeTableReq is the body of POST /agent/scope/table — the replay CLI hands
+// the agent the per-test name→mock-names table (from mappings.yaml) so the
+// runner's /agent/scope/begin calls can restrict the served pool per test.
+type ScopeTableReq struct {
+	Mappings map[string][]string `json:"mappings"`
+}
+
+// MockStats is the body of GET /agent/mock/stats — a non-draining snapshot of
+// the mock session for the runner or the CLI end-of-run summary.
+type MockStats struct {
+	Loaded   int `json:"loaded"`
+	Consumed int `json:"consumed"`
+	Missed   int `json:"missed"`
+}
+
 type SetMocksReq struct {
 	Filtered   []*Mock `json:"filtered"`
 	UnFiltered []*Mock `json:"unFiltered"`

--- a/pkg/models/errors.go
+++ b/pkg/models/errors.go
@@ -9,6 +9,13 @@ type AppError struct {
 	AppErrorType AppErrorType
 	Err          error
 	AppLogs      string
+	// ExitCode is the wrapped application/test-runner's process exit code
+	// when it is known (a Runtime exit carrying an *exec.ExitError). It is
+	// -1 when no exit code is available (the command never started, was
+	// killed by a signal, or exited cleanly with code 0 via ErrAppStopped).
+	// The mock record/replay flows propagate this as keploy's own exit code
+	// so a wrapped `pytest`/`go test` failure fails the keploy process too.
+	ExitCode int
 }
 
 type AppErrorType string

--- a/pkg/models/instrument.go
+++ b/pkg/models/instrument.go
@@ -27,6 +27,46 @@ const (
 	AND MatchType = "AND"
 )
 
+// MissPolicy decides what the proxy does in MODE_TEST when an outgoing call
+// matches no recorded mock. It is the VCR-style "record mode" for the
+// `keploy mock replay` flow.
+type MissPolicy string
+
+const (
+	// MissFail is the historical, deterministic behaviour: a miss is a hard
+	// failure (HTTP 502 / protocol error, connection torn down) and never
+	// reaches the real dependency. This is the default.
+	MissFail MissPolicy = "fail"
+	// MissPassthrough dials the real upstream on a miss, relays the exchange,
+	// and does NOT persist it. The equivalent of VCR's `once` on an existing
+	// cassette / go-vcr passthrough — new calls succeed against the real
+	// dependency but the cassette is not grown.
+	MissPassthrough MissPolicy = "passthrough"
+	// MissRecord dials the real upstream on a miss, relays the exchange, AND
+	// captures it back into the active mock set (VCR `new_episodes`). Newly
+	// observed calls are appended so the next replay serves them from the mock.
+	MissRecord MissPolicy = "record"
+)
+
+// Valid reports whether p is a recognised policy; the empty string is treated
+// as MissFail by callers.
+func (p MissPolicy) Valid() bool {
+	switch p {
+	case "", MissFail, MissPassthrough, MissRecord:
+		return true
+	}
+	return false
+}
+
+// RecordsOnMiss reports whether the policy captures newly-seen calls.
+func (p MissPolicy) RecordsOnMiss() bool { return p == MissRecord }
+
+// PassesThroughOnMiss reports whether the policy dials the real upstream on a
+// miss (both passthrough and record do).
+func (p MissPolicy) PassesThroughOnMiss() bool {
+	return p == MissPassthrough || p == MissRecord
+}
+
 type FilterPolicy string
 
 const (
@@ -58,8 +98,14 @@ type OutgoingOptions struct {
 	TLSPrivateKey string
 	Synchronous   bool
 	// TODO: role of SQLDelay should be mentioned in the comments.
-	SQLDelay               time.Duration // This is the same as Application delay.
-	Mocking                bool          // used to enable/disable mocking
+	SQLDelay time.Duration // This is the same as Application delay.
+	Mocking  bool          // used to enable/disable mocking
+	// OnMiss selects what the proxy does in MODE_TEST when no recorded mock
+	// matches an outgoing call: "" / "fail" (deterministic hard miss, the
+	// default), "passthrough" (dial the real upstream, don't persist), or
+	// "record" (dial the real upstream AND capture the exchange back into the
+	// active mock set). Only consulted on the `keploy mock replay` path.
+	OnMiss                 MissPolicy
 	DstCfg                 *ConditionalDstCfg
 	Backdate               time.Time                      // used to set backdate in cacert request
 	NoiseConfig            map[string]map[string][]string // noise configuration for mock matching (body, header, etc.)
@@ -187,14 +233,20 @@ type SetupOptions struct {
 	DockerDelay     uint64
 	Synchronous     bool
 	// Cmd               string
-	AgentURI                  string
-	IsDocker                  bool
-	CommandType               string
-	EnableTesting             bool
-	ProxyPort                 uint32
-	IncomingProxyPort         uint16
-	DnsPort                   uint32
-	Mode                      Mode
+	AgentURI          string
+	IsDocker          bool
+	CommandType       string
+	EnableTesting     bool
+	ProxyPort         uint32
+	IncomingProxyPort uint16
+	DnsPort           uint32
+	Mode              Mode
+	// MockMode marks a `keploy mock record|replay` session: the agent must
+	// NOT relocate the application's listening ports (no ingress/bind hooks)
+	// because the wrapped process is a test runner, not a server whose
+	// incoming traffic becomes test cases. Only outgoing calls are captured
+	// (record) or served (replay). Forwarded to the agent via --mock-mode.
+	MockMode                  bool
 	GlobalPassthrough         bool
 	CapturePackets            bool
 	OpportunisticTLSIntercept bool

--- a/pkg/platform/docker/docker.go
+++ b/pkg/platform/docker/docker.go
@@ -603,6 +603,11 @@ func (idc *Impl) GenerateKeployAgentService(opts models.SetupOptions) (*yaml.Nod
 	if idc.conf.Debug {
 		command = append(command, "--debug")
 	}
+	if opts.MockMode {
+		// `keploy mock record|replay` — the containerised agent must skip
+		// ingress/bind relocation (the wrapped process is a test runner).
+		command = append(command, "--mock-mode")
+	}
 	if idc.conf.Record.Synchronous {
 		command = append(command, "--sync")
 	}

--- a/pkg/platform/docker/util.go
+++ b/pkg/platform/docker/util.go
@@ -203,7 +203,7 @@ func getAlias(ctx context.Context, logger *zap.Logger, opts models.SetupOptions,
 			proxyPortStr + appPortsStr +
 			" --cap-add=BPF --cap-add=PERFMON --cap-add=NET_ADMIN --cap-add=SYS_RESOURCE --cap-add=SYS_PTRACE " + Volumes +
 			" -v /sys/fs/cgroup:/sys/fs/cgroup -v /sys/kernel/debug:/sys/kernel/debug -v /sys/fs/bpf:/sys/fs/bpf " +
-			" --rm " + img + " --client-pid " + fmt.Sprintf("%d", opts.ClientNSPID) + " --mode " + string(opts.Mode) + " --dns-port " + fmt.Sprintf("%d", opts.DnsPort) + " --is-docker"
+			" --rm " + img + " --client-pid " + fmt.Sprintf("%d", opts.ClientNSPID) + " --mode " + string(opts.Mode) + " --dns-port " + fmt.Sprintf("%d", opts.DnsPort) + " --is-docker" + mockModeSuffix(opts)
 
 		if opts.EnableTesting {
 			alias += " --enable-testing"
@@ -280,7 +280,7 @@ func getAlias(ctx context.Context, logger *zap.Logger, opts models.SetupOptions,
 				" --cap-add=BPF --cap-add=PERFMON --cap-add=NET_ADMIN --cap-add=SYS_RESOURCE --cap-add=SYS_PTRACE " + Volumes +
 				" -v /sys/fs/cgroup:/sys/fs/cgroup -v /sys/kernel/debug:/sys/kernel/debug -v /sys/fs/bpf:/sys/fs/bpf " +
 				" --rm " + img + " --client-pid " + fmt.Sprintf("%d", opts.ClientNSPID) +
-				" --mode " + string(opts.Mode) + " --dns-port " + fmt.Sprintf("%d", opts.DnsPort) + " --is-docker"
+				" --mode " + string(opts.Mode) + " --dns-port " + fmt.Sprintf("%d", opts.DnsPort) + " --is-docker" + mockModeSuffix(opts)
 
 			if opts.EnableTesting {
 				alias += " --enable-testing"
@@ -343,7 +343,7 @@ func getAlias(ctx context.Context, logger *zap.Logger, opts models.SetupOptions,
 			" --cap-add=BPF --cap-add=PERFMON --cap-add=NET_ADMIN --cap-add=SYS_RESOURCE --cap-add=SYS_PTRACE " + Volumes +
 			" -v /sys/fs/cgroup:/sys/fs/cgroup -v debugfs:/sys/kernel/debug:rw -v /sys/fs/bpf:/sys/fs/bpf " +
 			" --rm " + img + " --client-pid " + fmt.Sprintf("%d", opts.ClientNSPID) +
-			" --mode " + string(opts.Mode) + " --dns-port " + fmt.Sprintf("%d", opts.DnsPort) + " --is-docker"
+			" --mode " + string(opts.Mode) + " --dns-port " + fmt.Sprintf("%d", opts.DnsPort) + " --is-docker" + mockModeSuffix(opts)
 
 		if opts.EnableTesting {
 			alias += " --enable-testing"
@@ -421,7 +421,7 @@ func getAlias(ctx context.Context, logger *zap.Logger, opts models.SetupOptions,
 				" --cap-add=BPF --cap-add=PERFMON --cap-add=NET_ADMIN --cap-add=SYS_RESOURCE --cap-add=SYS_PTRACE " + Volumes +
 				" -v /sys/fs/cgroup:/sys/fs/cgroup -v /sys/kernel/debug:/sys/kernel/debug -v /sys/fs/bpf:/sys/fs/bpf " +
 				" --rm " + img + " --client-pid " + fmt.Sprintf("%d", opts.ClientNSPID) +
-				" --mode " + string(opts.Mode) + " --dns-port " + fmt.Sprintf("%d", opts.DnsPort) + " --is-docker"
+				" --mode " + string(opts.Mode) + " --dns-port " + fmt.Sprintf("%d", opts.DnsPort) + " --is-docker" + mockModeSuffix(opts)
 
 			if opts.EnableTesting {
 				alias += " --enable-testing"
@@ -483,7 +483,7 @@ func getAlias(ctx context.Context, logger *zap.Logger, opts models.SetupOptions,
 			" --cap-add=BPF --cap-add=PERFMON --cap-add=NET_ADMIN --cap-add=SYS_RESOURCE --cap-add=SYS_PTRACE " + Volumes +
 			" -v /sys/fs/cgroup:/sys/fs/cgroup -v debugfs:/sys/kernel/debug:rw -v /sys/fs/bpf:/sys/fs/bpf " +
 			" --rm " + img + " --client-pid " + fmt.Sprintf("%d", opts.ClientNSPID) +
-			" --mode " + string(opts.Mode) + " --dns-port " + fmt.Sprintf("%d", opts.DnsPort) + " --is-docker"
+			" --mode " + string(opts.Mode) + " --dns-port " + fmt.Sprintf("%d", opts.DnsPort) + " --is-docker" + mockModeSuffix(opts)
 
 		if opts.EnableTesting {
 			alias += " --enable-testing"
@@ -581,4 +581,13 @@ func ParseDockerCmd(cmd string, kind utils.CmdType, idc Client) (string, string,
 	networkName := networkNameMatches[2]
 
 	return containerName, networkName, nil
+}
+
+// mockModeSuffix returns " --mock-mode" when the session is a `keploy mock`
+// record/replay run, so the containerised agent skips ingress/bind relocation.
+func mockModeSuffix(opts models.SetupOptions) string {
+	if opts.MockMode {
+		return " --mock-mode"
+	}
+	return ""
 }

--- a/pkg/platform/http/agent.go
+++ b/pkg/platform/http/agent.go
@@ -1029,6 +1029,9 @@ func (a *AgentClient) startNativeAgent(ctx context.Context, opts models.SetupOpt
 	if opts.ChannelBindingShim {
 		args = append(args, "--channel-binding-shim")
 	}
+	if opts.MockMode {
+		args = append(args, "--mock-mode")
+	}
 	// Upstream TLS verification. Forwarded UNCONDITIONALLY as =%t, the same
 	// pattern (and for the same reason) as --disable-mapping above: the
 	// orchestrator has already applied flag > yaml > default, and the native
@@ -1423,6 +1426,25 @@ func (a *AgentClient) Setup(ctx context.Context, cmd string, opts models.SetupOp
 		return err
 	}
 
+	// Mock mode: export the agent's scope-API address into the wrapped
+	// command's environment so a test-runner plugin / glue-code can mark
+	// per-test boundaries (POST {KEPLOY_MOCK_AGENT}/agent/scope/begin|end).
+	// The child inherits this process's environment. Native + docker-run put
+	// the child in the agent's netns, so localhost:<agentPort> reaches it;
+	// docker-compose shares the host loopback. Harmless when unused.
+	if opts.MockMode {
+		if err := os.Setenv("KEPLOY_MOCK_AGENT", fmt.Sprintf("http://localhost:%d", agentPort)); err != nil {
+			a.logger.Debug("failed to export KEPLOY_MOCK_AGENT", zap.Error(err))
+		}
+		session := "record"
+		if opts.Mode == models.MODE_TEST {
+			session = "replay"
+		}
+		if err := os.Setenv("KEPLOY_MOCK_SESSION", session); err != nil {
+			a.logger.Debug("failed to export KEPLOY_MOCK_SESSION", zap.Error(err))
+		}
+	}
+
 	err = usrApp.Setup(ctx)
 	if err != nil {
 		utils.LogError(a.logger, err, "failed to setup app")
@@ -1815,4 +1837,98 @@ func (a *AgentClient) streamPcapArtifact(ctx context.Context, urlPath, dstFile s
 		return copyErr
 	}
 	return nil
+}
+
+// GetScopeWindows fetches the per-test scope windows the wrapped runner reported
+// during a `keploy mock record` session (via /agent/scope/*), so the CLI can
+// correlate captured mocks into mappings.yaml. A missing endpoint (older agent)
+// returns an empty slice, degrading to suite-level recording.
+func (a *AgentClient) GetScopeWindows(ctx context.Context) ([]models.ScopeWindow, error) {
+	url := fmt.Sprintf("%s/scope/windows", a.conf.Agent.AgentURI)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create scope-windows request: %w", err)
+	}
+	res, err := a.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get scope windows: %w", err)
+	}
+	defer func() {
+		io.Copy(io.Discard, res.Body)
+		res.Body.Close()
+	}()
+	if res.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+	if res.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(res.Body)
+		return nil, fmt.Errorf("scope windows returned status %d: %s", res.StatusCode, string(body))
+	}
+	var windows []models.ScopeWindow
+	if err := json.NewDecoder(res.Body).Decode(&windows); err != nil {
+		return nil, fmt.Errorf("failed to decode scope windows: %w", err)
+	}
+	return windows, nil
+}
+
+// PushScopeTable hands the agent the replay-time per-test name→mock-names table
+// (from mappings.yaml) so the runner's /agent/scope/begin calls can restrict the
+// served pool per test. A missing endpoint (older agent) is a no-op.
+func (a *AgentClient) PushScopeTable(ctx context.Context, table map[string][]string) error {
+	url := fmt.Sprintf("%s/scope/table", a.conf.Agent.AgentURI)
+	body, err := json.Marshal(models.ScopeTableReq{Mappings: table})
+	if err != nil {
+		return fmt.Errorf("failed to marshal scope table: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create scope-table request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	res, err := a.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to push scope table: %w", err)
+	}
+	defer func() {
+		io.Copy(io.Discard, res.Body)
+		res.Body.Close()
+	}()
+	if res.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	if res.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(res.Body)
+		return fmt.Errorf("scope table returned status %d: %s", res.StatusCode, string(b))
+	}
+	return nil
+}
+
+// DrainCapturedMocks fetches (and clears) the mocks the proxy captured on miss
+// during a `--on-miss record` replay session. The CLI appends them to the set.
+func (a *AgentClient) DrainCapturedMocks(ctx context.Context) ([]*models.Mock, error) {
+	url := fmt.Sprintf("%s/mock/captured", a.conf.Agent.AgentURI)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create captured-mocks request: %w", err)
+	}
+	res, err := a.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get captured mocks: %w", err)
+	}
+	defer func() {
+		io.Copy(io.Discard, res.Body)
+		res.Body.Close()
+	}()
+	if res.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+	if res.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(res.Body)
+		return nil, fmt.Errorf("captured mocks returned status %d: %s", res.StatusCode, string(b))
+	}
+	var mocks []*models.Mock
+	if err := gob.NewDecoder(res.Body).Decode(&mocks); err != nil {
+		return nil, fmt.Errorf("failed to decode captured mocks: %w", err)
+	}
+	return mocks, nil
 }

--- a/pkg/platform/yaml/mockdb/db.go
+++ b/pkg/platform/yaml/mockdb/db.go
@@ -1737,3 +1737,13 @@ func (ys *MockYaml) GetCurrMockID() int64 {
 func (ys *MockYaml) ResetCounterID() {
 	atomic.StoreInt64(&ys.idCounter, -1)
 }
+
+// SetCounterID seeds the mock-name counter so the NEXT InsertMock names its
+// mock "mock-<id+1>". Used when APPENDING to an existing set (the `keploy mock
+// replay --on-miss record` incremental-refresh path) so newly-captured mocks
+// don't reuse names already present on disk. Recording a fresh set uses
+// ResetCounterID (seed -1 → first mock is mock-0); appending seeds from the
+// set's highest existing index instead.
+func (ys *MockYaml) SetCounterID(id int64) {
+	atomic.StoreInt64(&ys.idCounter, id)
+}

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -16,6 +16,7 @@ import (
 	coreAgent "go.keploy.io/server/v3/pkg/agent"
 	"go.keploy.io/server/v3/pkg/agent/memoryguard"
 	proxyPkg "go.keploy.io/server/v3/pkg/agent/proxy"
+	httpparser "go.keploy.io/server/v3/pkg/agent/proxy/integrations/http"
 	syncMock "go.keploy.io/server/v3/pkg/agent/proxy/syncMock"
 	pTls "go.keploy.io/server/v3/pkg/agent/proxy/tls"
 	"go.keploy.io/server/v3/pkg/models"
@@ -127,6 +128,17 @@ type Agent struct {
 	// with different IncomingOptions still update the proxy's filtering
 	// behavior instead of being silently ignored.
 	incomingMu sync.Mutex
+
+	// scope state backs the /agent/scope/* and /agent/mock/stats API that a
+	// user's test runner (pytest / go test / jest / glue-code) calls to mark
+	// per-test boundaries. In record mode it collects the agent-clock window for
+	// each named test; in test (replay) mode it uses the CLI-supplied table to
+	// restrict the served pool to one test's mocks. All fields guarded by scopeMu.
+	scopeMu      sync.Mutex
+	scopeOpen    map[string]time.Time // record: name -> begin time (agent clock)
+	scopeWindows []models.ScopeWindow // record: closed per-test windows
+	scopeTable   map[string][]string  // replay: test name -> mock names (from mappings.yaml)
+	loadedMocks  int                  // replay: count of mocks stored, for /agent/mock/stats
 }
 
 func New(logger *zap.Logger, hook coreAgent.Hooks, proxy coreAgent.Proxy, client kdocker.Client, ip coreAgent.IncomingProxy, config *config.Config) *Agent {
@@ -502,6 +514,12 @@ func (a *Agent) MockOutgoing(ctx context.Context, opts models.OutgoingOptions) e
 	}
 	a.logger.Debug("MockOutgoing function called", zap.Any("options", redactedOpts))
 
+	// A new mock-serving session begins here (called once per replay). Clear the
+	// on-miss capture buffer so a reused / long-lived agent process (compose,
+	// standalone) never drains one replay's captured-on-miss mocks into a later,
+	// unrelated set. Harmless when --on-miss is not "record" (buffer stays empty).
+	httpparser.ResetCaptured()
+
 	err := a.Proxy.Mock(ctx, opts)
 	if err != nil {
 		return err
@@ -740,6 +758,14 @@ func (a *Agent) finalizeClientMocks(ctx context.Context, storage *ClientMockStor
 		}
 	}
 	a.clientMocks.Store(uint64(0), storage)
+
+	// Track the loaded count for /agent/mock/stats.
+	a.scopeMu.Lock()
+	a.loadedMocks = len(storage.filtered) + len(storage.unfiltered)
+	if storage.diskMocks != nil {
+		a.loadedMocks += storage.diskMocks.Len()
+	}
+	a.scopeMu.Unlock()
 
 	// Seed the freeze anchor from the earliest request timestamp across the WHOLE
 	// pool, including on-disk mocks (they often carry the earliest, boot, times).

--- a/pkg/service/agent/scope.go
+++ b/pkg/service/agent/scope.go
@@ -1,0 +1,128 @@
+package agent
+
+import (
+	"context"
+	"time"
+
+	httpparser "go.keploy.io/server/v3/pkg/agent/proxy/integrations/http"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// The scope API lets a user's own test runner mark per-test boundaries so
+// Keploy can attribute captured mocks to a test (record) and serve only that
+// test's mocks (replay). A pytest fixture / go-test helper / jest hook / curl
+// script calls, using the KEPLOY_MOCK_AGENT URL Keploy exports into the wrapped
+// command:
+//
+//	POST {url}/agent/scope/begin  {"name":"<test>"}
+//	POST {url}/agent/scope/end    {"name":"<test>"}
+//
+// Scoping is entirely optional: with no scope calls the set records/replays
+// suite-level, which is still correct.
+
+// BeginScope opens a per-test scope. In record mode it stamps the begin time
+// (agent clock) so captured mocks can later be bucketed to this test. In test
+// mode it restricts the served pool to this test's mocks when the CLI supplied
+// a mapping table for it.
+func (a *Agent) BeginScope(ctx context.Context, name string) error {
+	if name == "" {
+		return nil
+	}
+	if a.config != nil && a.config.Agent.Mode == models.MODE_TEST {
+		a.scopeMu.Lock()
+		names, ok := a.scopeTable[name]
+		a.scopeMu.Unlock()
+		if !ok || len(names) == 0 {
+			// No per-test mapping for this test — leave the whole pool armed.
+			return nil
+		}
+		a.logger.Debug("scope begin: restricting served pool to test", zap.String("test", name), zap.Int("mocks", len(names)))
+		return a.UpdateMockParams(ctx, models.MockFilterParams{
+			MockMapping:     names,
+			UseMappingBased: true,
+			AfterTime:       models.BaseTime,
+			BeforeTime:      time.Now(),
+		})
+	}
+
+	// Record mode: mark the window start (agent clock). We deliberately do NOT
+	// touch the syncMock ingress-correlation machinery here — that is driven by
+	// incoming requests, which mock mode has none of. The window is correlated
+	// to captured mocks purely by request timestamp after the run.
+	a.scopeMu.Lock()
+	if a.scopeOpen == nil {
+		a.scopeOpen = make(map[string]time.Time)
+	}
+	a.scopeOpen[name] = time.Now()
+	a.scopeMu.Unlock()
+	a.logger.Debug("scope begin (record)", zap.String("test", name))
+	return nil
+}
+
+// EndScope closes a per-test scope. In record mode it records the [begin, now]
+// window for later correlation. In test mode it restores the whole pool so a
+// call made between tests still matches.
+func (a *Agent) EndScope(ctx context.Context, name string) error {
+	if name == "" {
+		return nil
+	}
+	if a.config != nil && a.config.Agent.Mode == models.MODE_TEST {
+		a.scopeMu.Lock()
+		_, scoped := a.scopeTable[name]
+		a.scopeMu.Unlock()
+		if !scoped {
+			return nil
+		}
+		a.logger.Debug("scope end: restoring whole pool", zap.String("test", name))
+		return a.UpdateMockParams(ctx, models.MockFilterParams{
+			AfterTime:  models.BaseTime,
+			BeforeTime: time.Now(),
+		})
+	}
+
+	a.scopeMu.Lock()
+	start, ok := a.scopeOpen[name]
+	if ok {
+		delete(a.scopeOpen, name)
+		a.scopeWindows = append(a.scopeWindows, models.ScopeWindow{Name: name, Start: start, End: time.Now()})
+	}
+	a.scopeMu.Unlock()
+	a.logger.Debug("scope end (record)", zap.String("test", name))
+	return nil
+}
+
+// GetScopeWindows returns the per-test windows collected this record session,
+// consumed by the CLI to build mappings.yaml.
+func (a *Agent) GetScopeWindows(_ context.Context) ([]models.ScopeWindow, error) {
+	a.scopeMu.Lock()
+	defer a.scopeMu.Unlock()
+	out := make([]models.ScopeWindow, len(a.scopeWindows))
+	copy(out, a.scopeWindows)
+	return out, nil
+}
+
+// SetScopeTable installs the replay-time per-test name→mock-names table the CLI
+// read from mappings.yaml.
+func (a *Agent) SetScopeTable(_ context.Context, table map[string][]string) error {
+	a.scopeMu.Lock()
+	a.scopeTable = table
+	a.scopeMu.Unlock()
+	return nil
+}
+
+// DrainCapturedMocks returns and clears the mocks captured on miss during a
+// `--on-miss record` replay session, so the CLI can append them to the set.
+func (a *Agent) DrainCapturedMocks(_ context.Context) ([]*models.Mock, error) {
+	return httpparser.DrainCaptured(), nil
+}
+
+// MockStats returns a non-draining snapshot for /agent/mock/stats. Consumed and
+// missed totals are surfaced in the CLI's end-of-run summary (they drain their
+// capture windows), so this live endpoint reports the loaded count only.
+func (a *Agent) MockStats(_ context.Context) (models.MockStats, error) {
+	a.scopeMu.Lock()
+	loaded := a.loadedMocks
+	a.scopeMu.Unlock()
+	return models.MockStats{Loaded: loaded}, nil
+}

--- a/pkg/service/mock/correlate_test.go
+++ b/pkg/service/mock/correlate_test.go
@@ -1,0 +1,92 @@
+package mock
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+func ts(sec int) time.Time { return time.Unix(int64(sec), 0) }
+
+func TestCorrelateScopes(t *testing.T) {
+	tests := []struct {
+		name    string
+		windows []models.ScopeWindow
+		mocks   []capturedMock
+		want    map[string][]string // test name -> mock names, order-independent
+	}{
+		{
+			name: "each mock buckets into its own window",
+			windows: []models.ScopeWindow{
+				{Name: "t1", Start: ts(10), End: ts(20)},
+				{Name: "t2", Start: ts(30), End: ts(40)},
+			},
+			mocks: []capturedMock{
+				{name: "mock-0", ts: ts(15)},
+				{name: "mock-1", ts: ts(35)},
+			},
+			want: map[string][]string{"t1": {"mock-0"}, "t2": {"mock-1"}},
+		},
+		{
+			name: "mock outside every window is dropped (stays reusable at replay)",
+			windows: []models.ScopeWindow{
+				{Name: "t1", Start: ts(10), End: ts(20)},
+			},
+			mocks: []capturedMock{
+				{name: "boot", ts: ts(5)}, // before any window
+				{name: "mock-0", ts: ts(15)},
+			},
+			want: map[string][]string{"t1": {"mock-0"}},
+		},
+		{
+			name: "overlapping windows resolve to the innermost (latest-started)",
+			windows: []models.ScopeWindow{
+				{Name: "outer", Start: ts(10), End: ts(40)},
+				{Name: "inner", Start: ts(20), End: ts(30)},
+			},
+			mocks: []capturedMock{
+				{name: "mock-0", ts: ts(25)}, // inside both; innermost wins
+			},
+			want: map[string][]string{"inner": {"mock-0"}},
+		},
+		{
+			name:    "no windows -> empty mapping (suite-level fallback)",
+			windows: nil,
+			mocks:   []capturedMock{{name: "mock-0", ts: ts(15)}},
+			want:    map[string][]string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := correlateScopes(tc.windows, tc.mocks)
+			require.Len(t, got, len(tc.want), "number of tests with mappings")
+			for name, wantNames := range tc.want {
+				entries, ok := got[name]
+				require.True(t, ok, "expected mapping for %q", name)
+				gotNames := make([]string, len(entries))
+				for i, e := range entries {
+					gotNames[i] = e.Name
+				}
+				require.ElementsMatch(t, wantNames, gotNames, "mock names for %q", name)
+			}
+		})
+	}
+}
+
+func TestMissPolicyValidAndBehaviour(t *testing.T) {
+	require.True(t, models.MissPolicy("").Valid())
+	require.True(t, models.MissFail.Valid())
+	require.True(t, models.MissPassthrough.Valid())
+	require.True(t, models.MissRecord.Valid())
+	require.False(t, models.MissPolicy("bogus").Valid())
+
+	require.False(t, models.MissFail.PassesThroughOnMiss())
+	require.True(t, models.MissPassthrough.PassesThroughOnMiss())
+	require.True(t, models.MissRecord.PassesThroughOnMiss())
+
+	require.False(t, models.MissPassthrough.RecordsOnMiss())
+	require.True(t, models.MissRecord.RecordsOnMiss())
+}

--- a/pkg/service/mock/mock.go
+++ b/pkg/service/mock/mock.go
@@ -2,247 +2,119 @@ package mock
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"go.keploy.io/server/v3/config"
 	"go.keploy.io/server/v3/pkg/models"
+	"go.keploy.io/server/v3/pkg/service/record"
 	"go.keploy.io/server/v3/utils"
 	"go.uber.org/zap"
 )
 
-// MockLoader implements Service. It sets up the proxy and loads mocks for a
-// given test set (and optionally a single test case) so that outgoing calls
-// from the application under test are served from those mocks. It has no
-// knowledge of running test cases or producing test reports.
-type MockLoader struct {
+// mockService implements Service for the `keploy mock record|replay` flow.
+type mockService struct {
 	logger          *zap.Logger
 	instrumentation Instrumentation
 	mockDB          MockDB
-	mappingDB       MappingDB
+	mappingDB       MappingDB // may be nil (suite-level only)
+	store           Store
+	hooks           record.RecordHooks // reused so enterprise obfuscation/encryption applies on record
 	config          *config.Config
-	outgoingCfg     OutgoingConfig
 }
 
-// NewMockLoader constructs a MockLoader.
-func NewMockLoader(
+// New constructs the mock record/replay service. mappingDB and hooks may be nil
+// (a nil hooks becomes a no-op; a nil mappingDB disables per-test scoping).
+// store must be non-nil — pass FileStore for OSS.
+func New(
 	logger *zap.Logger,
 	instrumentation Instrumentation,
 	mockDB MockDB,
 	mappingDB MappingDB,
+	store Store,
+	hooks record.RecordHooks,
 	cfg *config.Config,
-	outgoingCfg OutgoingConfig,
 ) Service {
-	return &MockLoader{
+	if hooks == nil {
+		hooks = record.BaseRecordHooks{}
+	}
+	if store == nil {
+		store = FileStore{}
+	}
+	return &mockService{
 		logger:          logger,
 		instrumentation: instrumentation,
 		mockDB:          mockDB,
 		mappingDB:       mappingDB,
+		store:           store,
+		hooks:           hooks,
 		config:          cfg,
-		outgoingCfg:     outgoingCfg,
 	}
 }
 
-// LoadMocks fetches mocks for testSetID (filtered to testCaseName when
-// non-empty) and pushes them into the proxy.
-//
-// Context lifetime contract: the caller owns ctx. LoadMocks does NOT
-// create an internal errgroup or cancel the context on return — that
-// would shut the proxy/hooks down the moment LoadMocks returned, which
-// defeats the "mocks loaded and serving" use case. Any goroutines the
-// instrumentation layer spawns are bound to the caller's ctx, so when
-// the caller cancels, both the proxy and the hooks tear down cleanly.
-// The caller is responsible for invoking NotifyGracefulShutdown on the
-// Instrumentation when the session ends.
-func (r *MockLoader) LoadMocks(ctx context.Context, testSetID string, testCaseName string) error {
-	r.logger.Debug("MockLoader: loading mocks", zap.String("testSetID", testSetID), zap.String("testCaseName", testCaseName))
-
-	// Step 1 – load eBPF hooks and start the proxy.
-	if err := r.instrumentation.Setup(ctx, r.config.Command, models.SetupOptions{
-		Container:   r.config.ContainerName,
-		CommandType: r.config.CommandType,
-		DockerDelay: r.config.BuildDelay,
-		BuildDelay:  r.config.BuildDelay,
-		Mode:        models.MODE_TEST,
-	}); err != nil {
-		return fmt.Errorf("MockLoader: failed to set up instrumentation: %w", err)
-	}
-
-	// Step 2 – put the proxy in mock-serving mode.
-	if err := r.instrumentation.MockOutgoing(ctx, models.OutgoingOptions{
-		Rules:         r.outgoingCfg.BypassRules,
-		MongoPassword: r.outgoingCfg.MongoPassword,
-		SQLDelay:      r.outgoingCfg.SQLDelay,
-		Mocking:       r.outgoingCfg.Mocking,
-		// Same MySQL routing knobs the record/replay paths pass. Without
-		// them a MockLoader session ignores mysqlPorts entirely and
-		// honours neither the pinned ports nor disableMysqlAutoDetect.
-		MysqlPorts:                r.outgoingCfg.MysqlPorts,
-		DisableMysqlAutoDetect:    r.outgoingCfg.DisableMysqlAutoDetect,
-		DisableMysqlEndpointDrift: r.outgoingCfg.DisableMysqlEndpointDrift,
-		PassThroughPorts:          r.outgoingCfg.PassThroughPorts,
-		PassThroughHosts:          r.outgoingCfg.PassThroughHosts,
-	}); err != nil {
-		return fmt.Errorf("MockLoader: failed to enable mock-outgoing: %w", err)
-	}
-
-	// Step 3 – resolve which mocks are needed using the mapping table.
-	mocksThatHaveMappings, mocksWeNeed, expectedMockMapping, useMappingBased := r.resolveMockSets(ctx, testSetID, testCaseName)
-
-	// Step 4 – fetch mocks from the database.
-	filteredMocks, unfilteredMocks, err := r.getMocks(ctx, testSetID, mocksThatHaveMappings, mocksWeNeed)
-	if err != nil {
-		return fmt.Errorf("MockLoader: failed to fetch mocks: %w", err)
-	}
-
-	// Step 5 – push the mocks into the proxy.
-	if err := r.instrumentation.StoreMocks(ctx, filteredMocks, unfilteredMocks); err != nil {
-		return fmt.Errorf("MockLoader: failed to store mocks: %w", err)
-	}
-
-	// Step 6 – send filtering parameters to the agent. Mirrors the
-	// setup-time call in Replayer.RunTestSet (see replay.go:1047): when
-	// no testCaseName is provided we send an empty mapping slice (the
-	// agent still honors useMappingBased via the mapping-registry it
-	// populated in Step 5); when a specific testCaseName is provided we
-	// send that test case's mock names so the agent can restrict
-	// serving to them (matches the per-test-case call at replay.go:1437).
-	err = r.SendMockFilterParamsToAgent(ctx, expectedMockMapping, models.BaseTime, time.Now(), nil, useMappingBased)
-	if err != nil {
-		return fmt.Errorf("MockLoader: failed to send mock filter params to agent: %w", err)
-	}
-
-	err = r.instrumentation.MakeAgentReadyForDockerCompose(ctx)
-	if err != nil {
-		utils.LogError(r.logger, err, "Failed to make the request to make agent ready for the docker compose")
-	}
-
-	r.logger.Info("MockLoader: mocks loaded successfully",
-		zap.String("testSetID", testSetID),
-		zap.Int("filtered", len(filteredMocks)),
-		zap.Int("unfiltered", len(unfilteredMocks)),
-		zap.Bool("useMappingBased", useMappingBased),
-		zap.Int("expectedMocks", len(expectedMockMapping)),
-	)
-	return nil
+// Overridable lets a downstream build (enterprise) swap the store and record
+// hooks on a constructed mock service — the same post-construction override
+// pattern Recorder.SetRecordHooks uses. The CLI's mock command type-asserts to
+// this so enterprise can inject a registry-backed store and secret-obfuscation
+// hooks without a mock-specific constructor.
+type Overridable interface {
+	SetStore(store Store)
+	SetRecordHooks(hooks record.RecordHooks)
 }
 
-// resolveMockSets uses the MappingDB (when available) to determine which mock
-// names are relevant, mirroring the logic in Replayer.determineMockingStrategy
-// (replay.go:~3460) and the mapping population block inside RunTestSet
-// (replay.go:~992).
-//
-// Returns:
-//   - mocksThatHaveMappings: all mock names that appear in any mapping entry
-//     for the test set (used by GetFilteredMocks / GetUnFilteredMocks to decide
-//     which bucket a mock belongs to).
-//   - mocksWeNeed: the subset of mapped mocks that this particular load
-//     actually requires (restricted to testCaseName when provided; all mapped
-//     mocks otherwise).
-//   - expectedMockMapping: ordered slice of expected mock names for the
-//     single test case (when testCaseName != ""), empty otherwise. Matches
-//     the "expectedNames" slice Replayer passes to SendMockFilterParamsToAgent
-//     at replay.go:~1433.
-//   - useMappingBased: true iff the MappingDB reports meaningful mappings
-//     exist for this test set, mirroring determineMockingStrategy's return.
-//
-// All outputs are zero-valued when no meaningful mappings exist, which causes
-// MockDB to fall back to timestamp-based filtering and the agent to ignore
-// mapping-based selection.
-func (r *MockLoader) resolveMockSets(ctx context.Context, testSetID string, testCaseName string) (mocksThatHaveMappings map[string]bool, mocksWeNeed map[string]bool, expectedMockMapping []string, useMappingBased bool) {
-	mocksThatHaveMappings = make(map[string]bool)
-	mocksWeNeed = make(map[string]bool)
-	expectedMockMapping = []string{}
-
-	if r.mappingDB == nil {
-		r.logger.Debug("MockLoader: no mapping DB, using timestamp-based filtering")
-		return
+// SetStore replaces the mock-set store (e.g. enterprise's registry-backed store).
+func (m *mockService) SetStore(store Store) {
+	if store != nil {
+		m.store = store
 	}
+}
 
-	testMockMappings, hasMeaningfulMappings, err := r.mappingDB.Get(ctx, testSetID)
-	if err != nil {
-		// Downgraded from Warn to Info per repo logging guideline — this
-		// path is a recoverable fallback (timestamp-based filtering is the
-		// documented next step), not an operator-actionable warning.
-		r.logger.Info("MockLoader: failed to get mappings, falling back to timestamp-based filtering",
-			zap.String("testSetID", testSetID), zap.Error(err))
-		return
+// SetRecordHooks replaces the record hooks (e.g. enterprise secret obfuscation).
+func (m *mockService) SetRecordHooks(hooks record.RecordHooks) {
+	if hooks != nil {
+		m.hooks = hooks
 	}
+}
 
-	if !hasMeaningfulMappings {
-		r.logger.Debug("MockLoader: no meaningful mappings found, using timestamp-based filtering",
-			zap.String("testSetID", testSetID))
-		return
+// setName returns the configured mock-set name, defaulting to "default".
+func (m *mockService) setName() string {
+	name := m.config.Mock.Name
+	if name == "" {
+		return "default"
 	}
+	return name
+}
 
-	useMappingBased = true
+// notifyShutdown tells the agent the session is ending so connection errors are
+// logged at debug level. Bounded so an unresponsive agent can't hang teardown.
+func (m *mockService) notifyShutdown() {
+	notifyCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := m.instrumentation.NotifyGracefulShutdown(notifyCtx); err != nil {
+		m.logger.Debug("failed to notify agent of graceful shutdown", zap.Error(err))
+	}
+}
 
-	// Populate the full set of mapped mock names.
-	for _, mocks := range testMockMappings {
-		for _, m := range mocks {
-			mocksThatHaveMappings[m.Name] = true
+// propagateExit mirrors the wrapped runner's exit status onto keploy's own
+// process exit code (utils.ErrCode), so a wrapped `pytest`/`go test` failure
+// fails the keploy process — the contract every CI job depends on. A clean
+// runner exit leaves ErrCode at 0. phase is "record" or "replay" for logging.
+func (m *mockService) propagateExit(appErr models.AppError, phase string) {
+	switch appErr.AppErrorType {
+	case models.ErrAppStopped:
+		// Clean exit (code 0). Success.
+		m.logger.Info("test command finished successfully", zap.String("phase", phase))
+	case models.ErrCtxCanceled, "":
+		// User interrupt or nothing to report — leave ErrCode untouched.
+	case models.ErrUnExpected, models.ErrCommandError:
+		code := appErr.ExitCode
+		if code <= 0 {
+			code = 1
 		}
+		utils.ErrCode = code
+		m.logger.Info("test command exited non-zero; mirroring its exit code",
+			zap.String("phase", phase), zap.Int("exitCode", code))
+	default:
+		utils.ErrCode = 1
+		m.logger.Info("test command did not complete cleanly", zap.String("phase", phase), zap.String("reason", string(appErr.AppErrorType)))
 	}
-
-	if testCaseName != "" {
-		// Only load the mocks that belong to this specific test case.
-		if mocks, ok := testMockMappings[testCaseName]; ok {
-			expectedMockMapping = make([]string, len(mocks))
-			for i, m := range mocks {
-				mocksWeNeed[m.Name] = true
-				expectedMockMapping[i] = m.Name
-			}
-		}
-	} else {
-		// No specific test case — load all mapped mocks.
-		mocksWeNeed = mocksThatHaveMappings
-	}
-
-	return
-}
-
-// getMocks fetches filtered and unfiltered mocks from MockDB for the given
-// testSetID, using the full time range (BaseTime → now) as the window.
-func (r *MockLoader) getMocks(ctx context.Context, testSetID string, mocksThatHaveMappings map[string]bool, mocksWeNeed map[string]bool) (filtered, unfiltered []*models.Mock, err error) {
-	afterTime := models.BaseTime
-	beforeTime := time.Now()
-
-	filtered, err = r.mockDB.GetFilteredMocks(ctx, testSetID, afterTime, beforeTime, mocksThatHaveMappings, mocksWeNeed)
-	if err != nil {
-		r.logger.Error("MockLoader: failed to get filtered mocks", zap.String("testSetID", testSetID), zap.Error(err))
-		return nil, nil, err
-	}
-
-	unfiltered, err = r.mockDB.GetUnFilteredMocks(ctx, testSetID, afterTime, beforeTime, mocksThatHaveMappings, mocksWeNeed)
-	if err != nil {
-		r.logger.Error("MockLoader: failed to get unfiltered mocks", zap.String("testSetID", testSetID), zap.Error(err))
-		return nil, nil, err
-	}
-
-	return filtered, unfiltered, nil
-}
-
-func (r *MockLoader) SendMockFilterParamsToAgent(ctx context.Context, expectedMockMapping []string, afterTime, beforeTime time.Time, totalConsumedMocks map[string]models.MockState, useMappingBased bool) error {
-
-	// Build filter parameters
-	params := models.MockFilterParams{
-		AfterTime:          afterTime,
-		BeforeTime:         beforeTime,
-		MockMapping:        expectedMockMapping,
-		UseMappingBased:    useMappingBased,
-		TotalConsumedMocks: totalConsumedMocks,
-	}
-
-	// Send parameters to agent for filtering and mock updates
-	err := r.instrumentation.UpdateMockParams(ctx, params)
-	if err != nil {
-		utils.LogError(r.logger, err, "failed to update mock parameters on agent")
-		return err
-	}
-
-	r.logger.Debug("Successfully sent mock filter parameters to agent",
-		zap.Bool("useMappingBased", useMappingBased),
-		zap.Int("mockMappingCount", len(expectedMockMapping)))
-
-	return nil
 }

--- a/pkg/service/mock/record.go
+++ b/pkg/service/mock/record.go
@@ -1,0 +1,232 @@
+package mock
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/models"
+	rec "go.keploy.io/server/v3/pkg/service/record"
+	"go.keploy.io/server/v3/utils"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+)
+
+// mockDrainGrace bounds how long Record waits for the agent to hand over the
+// last few mocks after the wrapped runner has exited. The outgoing stream
+// closes when we cancel its context; this only guards against a mock whose
+// agent-side parse completes in the window between the runner exiting and the
+// stream tearing down.
+const mockDrainGrace = 5 * time.Second
+
+// Record runs the wrapped test command and captures every outgoing dependency
+// call into the configured named mock set. It writes ONLY mocks (no incoming
+// test cases), overwrites the set in place so a re-record produces a clean
+// diff, correlates any per-test scopes the runner reported into mappings.yaml,
+// pushes the set to the store, and propagates the runner's exit code.
+func (m *mockService) Record(ctx context.Context) error {
+	name := m.setName()
+	m.logger.Info("Recording mocks for your test command",
+		zap.String("mock-set", name),
+		zap.String("command", m.config.Command))
+
+	errGrp, ctx := errgroup.WithContext(ctx)
+	ctx = context.WithValue(ctx, models.ErrGroupKey, errGrp)
+	ctx, cancel := context.WithCancel(ctx)
+	// Writes must outlive a SIGINT teardown so the tail of the recording still
+	// reaches disk (same rationale as pkg/service/record's persistCtx).
+	persistCtx := context.WithoutCancel(ctx)
+
+	var stopReason string
+	defer func() {
+		m.notifyShutdown()
+		// Cancel the errgroup ctx so the agent-monitor / app-runner goroutines
+		// (bound to this ctx by Setup/Run) observe cancellation and unwind,
+		// otherwise the drain below waits its full 30s budget every run.
+		cancel()
+		if err := utils.DrainErrGroup(m.logger, "mock-record", errGrp, 30*time.Second); err != nil {
+			utils.LogError(m.logger, err, "failed to drain mock-record goroutines")
+		}
+	}()
+
+	// 1. Instrument: start the agent, hooks and proxy in mock mode (no ingress
+	//    port relocation — the runner is not a server).
+	if err := m.instrumentation.Setup(ctx, m.config.Command, models.SetupOptions{
+		Container:   m.config.ContainerName,
+		CommandType: m.config.CommandType,
+		DockerDelay: m.config.BuildDelay,
+		BuildDelay:  m.config.BuildDelay,
+		Mode:        models.MODE_RECORD,
+		MockMode:    true,
+		ConfigPath:  m.config.ConfigPath,
+	}); err != nil {
+		if ctx.Err() != nil {
+			return nil
+		}
+		stopReason = "failed setting up the environment"
+		utils.LogError(m.logger, err, stopReason)
+		return fmt.Errorf("%s", stopReason)
+	}
+
+	// 2. Overwrite the named set in place: drop the previous mocks so the
+	//    re-record is a clean rewrite, not an append.
+	if err := m.mockDB.DeleteMocksForSet(persistCtx, name); err != nil {
+		m.logger.Debug("no existing mock set to overwrite (or delete failed)", zap.String("mock-set", name), zap.Error(err))
+	}
+	m.mockDB.ResetCounterID()
+
+	// 3. Arm the record proxy and stream captured mocks.
+	captureCtx, stopCapture := context.WithCancel(context.WithoutCancel(ctx))
+	defer stopCapture()
+	outgoing, err := m.instrumentation.GetOutgoing(captureCtx, models.OutgoingOptions{
+		Rules:                     m.config.BypassRules,
+		MongoPassword:             m.config.Test.MongoPassword,
+		MysqlPorts:                m.config.MysqlPorts,
+		DisableMysqlAutoDetect:    m.config.DisableMysqlAutoDetect,
+		DisableMysqlEndpointDrift: m.config.DisableMysqlEndpointDrift,
+		PassThroughPorts:          m.config.Record.PassThroughPorts,
+		PassThroughHosts:          m.config.Record.PassThroughHosts,
+	})
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil
+		}
+		stopReason = "failed to start capturing outgoing calls"
+		utils.LogError(m.logger, err, stopReason)
+		return fmt.Errorf("%s", stopReason)
+	}
+
+	// recorded remembers each captured mock's name + request timestamp so the
+	// scope-window correlation after the run can build mappings.yaml.
+	var recorded []capturedMock
+	mockCount := 0
+	consumerDone := make(chan struct{})
+	go func() {
+		defer utils.Recover(m.logger)
+		defer close(consumerDone)
+		for mk := range outgoing {
+			mctx := &rec.MockContext{Mock: mk, TestSetID: name}
+			if err := m.hooks.BeforeMockInsert(ctx, mctx); err != nil {
+				m.logger.Debug("BeforeMockInsert hook failed", zap.Error(err), zap.String("mock", mk.Name))
+			}
+			if mctx.Skip {
+				continue
+			}
+			if err := m.mockDB.InsertMock(persistCtx, mk, name); err != nil {
+				if errors.Is(err, models.ErrMockEncode) {
+					m.logger.Warn("dropping one unencodable mock and continuing", zap.String("kind", mk.GetKind()), zap.Error(err))
+					continue
+				}
+				utils.LogError(m.logger, err, "failed to persist mock", zap.String("mock", mk.Name))
+				continue
+			}
+			if err := m.hooks.AfterMockInsert(ctx, &rec.MockContext{Mock: mk, TestSetID: name}); err != nil {
+				m.logger.Debug("AfterMockInsert hook failed", zap.Error(err), zap.String("mock", mk.Name))
+			}
+			mockCount++
+			recorded = append(recorded, capturedMock{name: mk.Name, ts: mk.Spec.ReqTimestampMock})
+		}
+	}()
+
+	// 4. Optional record timer.
+	if m.config.Mock.RecordTimer > 0 {
+		errGrp.Go(func() error {
+			m.logger.Info("recording will stop after " + m.config.Mock.RecordTimer.String())
+			select {
+			case <-time.After(m.config.Mock.RecordTimer):
+				_ = utils.Stop(m.logger, "record timer elapsed")
+			case <-ctx.Done():
+			}
+			return nil
+		})
+	}
+
+	// 5. Run the wrapped runner and block until it exits. Its exit — clean or
+	//    failing — is the NORMAL end of a mock recording, not an app crash.
+	appErr := m.instrumentation.Run(ctx, models.RunOptions{AppCommand: m.config.Command})
+
+	// 6. Stop capturing and drain the last mocks.
+	stopCapture()
+	select {
+	case <-consumerDone:
+	case <-time.After(mockDrainGrace):
+		m.logger.Debug("timed out draining trailing mocks after runner exit")
+	}
+
+	if ctx.Err() != nil { // user Ctrl+C
+		m.logger.Info("recording stopped", zap.Int("mocks", mockCount), zap.String("mock-set", name))
+		return nil
+	}
+
+	// 7. Correlate per-test scope windows into mappings.yaml (best-effort).
+	if m.mappingDB != nil {
+		if reader, ok := m.instrumentation.(ScopeReader); ok {
+			windows, werr := reader.GetScopeWindows(persistCtx)
+			if werr != nil {
+				m.logger.Debug("failed to read per-test scope windows; recording suite-level", zap.Error(werr))
+			} else if len(windows) > 0 {
+				byTest := correlateScopes(windows, recorded)
+				if len(byTest) > 0 {
+					if err := m.mappingDB.UpsertBatch(persistCtx, name, byTest); err != nil {
+						m.logger.Warn("failed to write per-test mappings; replay will serve the whole set per test", zap.Error(err))
+					} else {
+						m.logger.Info("wrote per-test mock mappings", zap.Int("tests", len(byTest)), zap.String("mock-set", name))
+					}
+				}
+			}
+		}
+	}
+
+	// 8. Publish the set to the store (registry upload in enterprise; no-op on files).
+	if err := m.store.Push(persistCtx, name); err != nil {
+		m.logger.Warn("failed to publish mock set to the store", zap.String("mock-set", name), zap.Error(err))
+	}
+
+	m.logger.Info("recorded mocks", zap.Int("mocks", mockCount), zap.String("mock-set", name))
+	if mockCount == 0 {
+		m.logger.Warn("no outgoing calls were captured; the runner made no mockable dependency calls, or its traffic was not intercepted",
+			zap.String("next_step", "confirm the test command actually calls an external dependency (HTTP, MySQL, ...), and on macOS run it via a docker command"))
+	}
+
+	// 9. Propagate the runner's exit code so a CI 're-record on merge' job fails
+	//    when the tests fail.
+	m.propagateExit(appErr, "record")
+	return nil
+}
+
+// capturedMock is one recorded mock's name + request timestamp, used to
+// correlate mocks into per-test scope windows.
+type capturedMock struct {
+	name string
+	ts   time.Time
+}
+
+// correlateScopes buckets each recorded mock into the per-test scope window its
+// request timestamp falls within, producing the mappings.yaml structure. A mock
+// that matches no window (e.g. a boot-time handshake before the first scope)
+// is left out of every test's mapping — it stays reusable/session-tier at
+// replay, exactly as the timestamp-based fallback would treat it.
+func correlateScopes(windows []models.ScopeWindow, mocks []capturedMock) map[string][]models.MockEntry {
+	// Sort windows by start so overlapping scopes resolve to the innermost
+	// (latest-started) window deterministically.
+	sort.SliceStable(windows, func(i, j int) bool { return windows[i].Start.Before(windows[j].Start) })
+	byTest := make(map[string][]models.MockEntry)
+	for _, mk := range mocks {
+		best := -1
+		for i, w := range windows {
+			if mk.ts.Before(w.Start) || mk.ts.After(w.End) {
+				continue
+			}
+			if best == -1 || windows[i].Start.After(windows[best].Start) {
+				best = i
+			}
+		}
+		if best == -1 {
+			continue
+		}
+		byTest[windows[best].Name] = append(byTest[windows[best].Name], models.MockEntry{Name: mk.name})
+	}
+	return byTest
+}

--- a/pkg/service/mock/replay.go
+++ b/pkg/service/mock/replay.go
@@ -1,0 +1,278 @@
+package mock
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.keploy.io/server/v3/utils"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+)
+
+// Replay runs the wrapped test command with the configured named mock set
+// served in place of the real dependencies. It needs no incoming test cases —
+// the runner drives the requests, Keploy answers the outgoing calls from the
+// set. On a miss it applies the configured policy (fail / passthrough /
+// record). It propagates the runner's exit code, and with --strict also exits
+// non-zero when any recorded mock was missed.
+func (m *mockService) Replay(ctx context.Context) error {
+	name := m.setName()
+
+	// 0. Materialise the set locally (registry download in enterprise; no-op on files).
+	if err := m.store.Pull(ctx, name); err != nil {
+		utils.LogError(m.logger, err, "failed to fetch the mock set", zap.String("mock-set", name))
+		return err
+	}
+
+	policy := models.MissPolicy(m.config.Mock.OnMiss)
+	if !policy.Valid() {
+		return fmt.Errorf("invalid --on-miss value %q: allowed values are fail, passthrough, record", m.config.Mock.OnMiss)
+	}
+
+	m.logger.Info("Replaying mocks for your test command",
+		zap.String("mock-set", name),
+		zap.String("command", m.config.Command),
+		zap.String("on-miss", string(policy)))
+
+	errGrp, ctx := errgroup.WithContext(ctx)
+	ctx = context.WithValue(ctx, models.ErrGroupKey, errGrp)
+	ctx, cancel := context.WithCancel(ctx)
+
+	defer func() {
+		m.notifyShutdown()
+		// Cancel so agent-monitor / app-runner goroutines unwind before drain.
+		cancel()
+		if err := utils.DrainErrGroup(m.logger, "mock-replay", errGrp, 30*time.Second); err != nil {
+			utils.LogError(m.logger, err, "failed to drain mock-replay goroutines")
+		}
+	}()
+
+	// 1. Instrument in mock (test) mode — no ingress port relocation.
+	if err := m.instrumentation.Setup(ctx, m.config.Command, models.SetupOptions{
+		Container:   m.config.ContainerName,
+		CommandType: m.config.CommandType,
+		DockerDelay: m.config.BuildDelay,
+		BuildDelay:  m.config.BuildDelay,
+		Mode:        models.MODE_TEST,
+		MockMode:    true,
+		ConfigPath:  m.config.ConfigPath,
+	}); err != nil {
+		if ctx.Err() != nil {
+			return nil
+		}
+		utils.LogError(m.logger, err, "failed setting up the environment")
+		return err
+	}
+
+	// 2. Put the proxy in mock-serving mode with the miss policy.
+	if err := m.instrumentation.MockOutgoing(ctx, models.OutgoingOptions{
+		Rules:                     m.config.BypassRules,
+		MongoPassword:             m.config.Test.MongoPassword,
+		SQLDelay:                  time.Duration(m.config.Test.Delay) * time.Second,
+		Mocking:                   true,
+		OnMiss:                    policy,
+		MysqlPorts:                m.config.MysqlPorts,
+		DisableMysqlAutoDetect:    m.config.DisableMysqlAutoDetect,
+		DisableMysqlEndpointDrift: m.config.DisableMysqlEndpointDrift,
+		PassThroughPorts:          m.config.Record.PassThroughPorts,
+		PassThroughHosts:          m.config.Record.PassThroughHosts,
+	}); err != nil {
+		if ctx.Err() != nil {
+			return nil
+		}
+		utils.LogError(m.logger, err, "failed to enable mock serving")
+		return err
+	}
+
+	// 3. Load the whole set and push it into the proxy.
+	empty := map[string]bool{}
+	filtered, err := m.mockDB.GetFilteredMocks(ctx, name, models.BaseTime, time.Now(), empty, empty)
+	if err != nil {
+		utils.LogError(m.logger, err, "failed to load per-test mocks", zap.String("mock-set", name))
+		return err
+	}
+	unfiltered, err := m.mockDB.GetUnFilteredMocks(ctx, name, models.BaseTime, time.Now(), empty, empty)
+	if err != nil {
+		utils.LogError(m.logger, err, "failed to load session mocks", zap.String("mock-set", name))
+		return err
+	}
+	loaded := len(filtered) + len(unfiltered)
+	if loaded == 0 {
+		m.logger.Warn("the mock set is empty; the runner will hit a miss on every dependency call",
+			zap.String("mock-set", name),
+			zap.String("next_step", fmt.Sprintf("record it first with: keploy mock record -c %q --name %s", m.config.Command, name)))
+	}
+	if err := m.instrumentation.StoreMocks(ctx, filtered, unfiltered); err != nil {
+		utils.LogError(m.logger, err, "failed to store mocks on the agent")
+		return err
+	}
+
+	// 4. Hand the agent the per-test table so the runner's /agent/scope/begin
+	//    calls can narrow the served pool per test (best-effort / optional).
+	m.pushScopeTable(ctx, name)
+
+	// 5. Stage the whole pool as the initial serving window (BaseTime..now, no
+	//    mapping) — same call RunTestSet makes before the first test.
+	if err := m.instrumentation.UpdateMockParams(ctx, models.MockFilterParams{
+		AfterTime:  models.BaseTime,
+		BeforeTime: time.Now(),
+	}); err != nil {
+		utils.LogError(m.logger, err, "failed to arm the mock pool")
+		return err
+	}
+
+	if err := m.instrumentation.MakeAgentReadyForDockerCompose(ctx); err != nil {
+		m.logger.Debug("failed to make agent ready for docker compose", zap.Error(err))
+	}
+
+	// 6. Run the wrapped runner against the served mocks and block until it exits.
+	appErr := m.instrumentation.Run(ctx, models.RunOptions{AppCommand: m.config.Command})
+
+	if ctx.Err() != nil { // user Ctrl+C
+		return nil
+	}
+
+	// 7. Under --on-miss record, append any calls served live-from-upstream to
+	//    the set so the next replay serves them from the mock (VCR new_episodes).
+	if policy.RecordsOnMiss() {
+		m.persistCaptured(context.WithoutCancel(ctx), name)
+	}
+
+	// 8. Summarise what was served and missed.
+	missed := m.reportOutcome(ctx, loaded)
+
+	// 9. Exit code: mirror the runner; with --strict also fail on any miss.
+	m.propagateExit(appErr, "replay")
+	if m.config.Mock.Strict && missed > 0 && utils.ErrCode == 0 {
+		utils.ErrCode = 1
+		m.logger.Error("replay failed under --strict: recorded dependency calls were missed",
+			zap.Int("missed", missed),
+			zap.String("next_step", "a dependency contract drifted; re-record the set (keploy mock record) or add the new calls with --on-miss record"))
+	}
+	return nil
+}
+
+// persistCaptured appends any calls the proxy captured on miss (served live from
+// the real dependency under --on-miss record) to the set, then republishes it.
+func (m *mockService) persistCaptured(ctx context.Context, name string) {
+	drainer, ok := m.instrumentation.(MissCapturer)
+	if !ok {
+		return
+	}
+	captured, err := drainer.DrainCapturedMocks(ctx)
+	if err != nil {
+		m.logger.Debug("failed to drain captured-on-miss mocks", zap.Error(err))
+		return
+	}
+	if len(captured) == 0 {
+		return
+	}
+	// Seed the name counter to the set's highest existing mock-N so appended
+	// mocks get fresh names (InsertMock always renames to mock-<counter+1>);
+	// without this the replay-side counter starts at 0 and appended mocks reuse
+	// mock-0, mock-1, … colliding with the recorded set (consumed-mock tracking
+	// and mappings both key on name).
+	m.mockDB.SetCounterID(m.highestMockIndex(ctx, name))
+	appended := 0
+	for _, mk := range captured {
+		if mk == nil {
+			continue
+		}
+		if err := m.mockDB.InsertMock(ctx, mk, name); err != nil {
+			m.logger.Debug("failed to append a captured-on-miss mock", zap.Error(err))
+			continue
+		}
+		appended++
+	}
+	if appended > 0 {
+		m.logger.Info("appended new dependency calls to the mock set (--on-miss record)",
+			zap.Int("new", appended), zap.String("mock-set", name),
+			zap.String("next_step", "review the added mocks and commit them; the next replay serves them without the real dependency"))
+		if err := m.store.Push(ctx, name); err != nil {
+			m.logger.Warn("failed to publish the refreshed mock set", zap.Error(err))
+		}
+	}
+}
+
+// highestMockIndex returns the largest N across the set's existing "mock-N"
+// names, or -1 when the set is empty / has no mock-N names. Seeding the counter
+// to this value makes the next InsertMock name its mock "mock-<N+1>".
+func (m *mockService) highestMockIndex(ctx context.Context, name string) int64 {
+	all := map[string]bool{}
+	filtered, _ := m.mockDB.GetFilteredMocks(ctx, name, models.BaseTime, time.Now(), all, all)
+	unfiltered, _ := m.mockDB.GetUnFilteredMocks(ctx, name, models.BaseTime, time.Now(), all, all)
+	highest := int64(-1)
+	consider := func(mocks []*models.Mock) {
+		for _, mk := range mocks {
+			if mk == nil {
+				continue
+			}
+			if n, ok := strings.CutPrefix(mk.Name, "mock-"); ok {
+				if idx, err := strconv.ParseInt(n, 10, 64); err == nil && idx > highest {
+					highest = idx
+				}
+			}
+		}
+	}
+	consider(filtered)
+	consider(unfiltered)
+	return highest
+}
+
+// pushScopeTable reads mappings.yaml for the set (if per-test mappings exist)
+// and hands the agent the name→mock-names table so per-test scoping works.
+func (m *mockService) pushScopeTable(ctx context.Context, name string) {
+	if m.mappingDB == nil {
+		return
+	}
+	pusher, ok := m.instrumentation.(ScopePusher)
+	if !ok {
+		return
+	}
+	mappings, meaningful, err := m.mappingDB.Get(ctx, name)
+	if err != nil || !meaningful || len(mappings) == 0 {
+		return
+	}
+	table := make(map[string][]string, len(mappings))
+	for testName, entries := range mappings {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name)
+		}
+		table[testName] = names
+	}
+	if err := pusher.PushScopeTable(ctx, table); err != nil {
+		m.logger.Debug("failed to push per-test scope table; per-test scoping disabled for this run", zap.Error(err))
+		return
+	}
+	m.logger.Info("per-test scoping enabled", zap.Int("tests", len(table)), zap.String("mock-set", name))
+}
+
+// reportOutcome logs which mocks were consumed and which outgoing calls matched
+// nothing, and returns the number of distinct missed calls.
+func (m *mockService) reportOutcome(ctx context.Context, loaded int) int {
+	consumed, err := m.instrumentation.GetConsumedMocks(ctx)
+	if err != nil {
+		m.logger.Debug("failed to read consumed mocks", zap.Error(err))
+	}
+	misses, err := m.instrumentation.GetMockErrors(ctx)
+	if err != nil {
+		m.logger.Debug("failed to read mock misses", zap.Error(err))
+	}
+	m.logger.Info("mock replay summary",
+		zap.Int("loaded", loaded),
+		zap.Int("consumed", len(consumed)),
+		zap.Int("missed", len(misses)))
+	for _, miss := range misses {
+		m.logger.Warn("no recorded mock matched an outgoing call",
+			zap.String("protocol", miss.Protocol),
+			zap.String("call", miss.ActualSummary),
+			zap.String("destination", miss.Destination),
+			zap.String("next_step", "record this call with --on-miss record, or re-record the set"))
+	}
+	return len(misses)
+}

--- a/pkg/service/mock/service.go
+++ b/pkg/service/mock/service.go
@@ -1,3 +1,15 @@
+// Package mock implements the `keploy mock record|replay` flow: using Keploy as
+// a framework-agnostic mocking layer for a user's own test runner (pytest, go
+// test, jest/playwright, mobile UI tests). Unlike record/test it captures ONLY
+// outgoing dependency calls (no incoming test cases become test cases) into a
+// single named mock set, and on replay serves that set back to the wrapped
+// runner while propagating the runner's own exit code.
+//
+// The same *http.AgentClient instrumentation, RecordHooks and app hooks that
+// `record`/`test` use flow through here unchanged, so enterprise runtime
+// features (LD_PRELOAD / java-agent / go-binpatch TLS shims, time-freeze,
+// secret obfuscation, registry upload) apply to `keploy mock` with no
+// mock-specific wiring.
 package mock
 
 import (
@@ -7,87 +19,106 @@ import (
 	"go.keploy.io/server/v3/pkg/models"
 )
 
-// Service is the interface for the mock service which only handles mock loading,
-// without any test case or test set concerns.
+// Service is the mock record/replay flow. Record captures outgoing calls into
+// the configured named set; Replay serves that set to the wrapped runner.
+// Both return the wrapped runner's exit code (or an error only for setup
+// failures) and set utils.ErrCode so the keploy process mirrors the runner.
 type Service interface {
-	// LoadMocks fetches the mocks that belong to the given testSetID (and
-	// optionally a specific testCaseName) from the database, then pushes them
-	// into the proxy so outgoing calls from the application under test are
-	// intercepted and served from that mock list.
-	//
-	// If testCaseName is empty, all mocks for the test set are loaded.
-	LoadMocks(ctx context.Context, testSetID string, testCaseName string) error
+	Record(ctx context.Context) error
+	Replay(ctx context.Context) error
 }
 
-// Instrumentation is the subset of the agent/proxy capabilities that the mock
-// service needs.
+// Instrumentation is the subset of the agent/proxy control surface the mock
+// flow needs. It is satisfied verbatim by *pkg/platform/http.AgentClient — the
+// same client record/replay use — so the mock flow inherits every runtime
+// behaviour that client applies to the wrapped command.
 type Instrumentation interface {
-	// Setup prepares the environment (loads eBPF hooks, starts the proxy, etc.).
+	// Setup prepares the environment: starts the agent, loads hooks and the
+	// proxy, and prepares the wrapped command. opts.MockMode must be set so
+	// the agent does NOT relocate the runner's listening ports.
 	Setup(ctx context.Context, cmd string, opts models.SetupOptions) error
 
-	// MockOutgoing tells the proxy to start intercepting outgoing calls and
-	// serve them from the stored mock list.
+	// GetOutgoing switches the proxy to record mode and streams every captured
+	// outgoing call as a mock. Used by Record.
+	GetOutgoing(ctx context.Context, opts models.OutgoingOptions) (<-chan *models.Mock, error)
+
+	// MockOutgoing switches the proxy to mock-serving mode. Used by Replay.
 	MockOutgoing(ctx context.Context, opts models.OutgoingOptions) error
 
-	// StoreMocks pushes filtered and unfiltered mocks into the proxy so they
-	// can be matched against live outgoing traffic.
+	// StoreMocks pushes the loaded set into the proxy. Used by Replay.
 	StoreMocks(ctx context.Context, filtered []*models.Mock, unFiltered []*models.Mock) error
 
-	// UpdateMockParams sends filtering parameters to the agent so it knows
-	// how to select mocks for incoming requests (mapping-based vs timestamp-based).
+	// UpdateMockParams selects which mocks the proxy serves (whole pool, or —
+	// via MockMapping — a single scoped test's mocks). Used by Replay.
 	UpdateMockParams(ctx context.Context, params models.MockFilterParams) error
 
-	// NotifyGracefulShutdown signals the proxy that the session is ending so
-	// connection errors are logged at debug level instead of error level.
-	NotifyGracefulShutdown(ctx context.Context) error
+	// GetConsumedMocks / GetMockErrors report which mocks were served and which
+	// outgoing calls matched nothing, for the end-of-run summary and --strict.
+	GetConsumedMocks(ctx context.Context) ([]models.MockState, error)
+	GetMockErrors(ctx context.Context) ([]models.UnmatchedCall, error)
+
+	// Run runs the wrapped command and blocks until it exits, returning its
+	// exit status in AppError.ExitCode.
+	Run(ctx context.Context, opts models.RunOptions) models.AppError
+
 	MakeAgentReadyForDockerCompose(ctx context.Context) error
+	NotifyGracefulShutdown(ctx context.Context) error
 }
 
-// MockDB is the subset of storage operations the mock service needs to read
-// mocks from the filesystem / database.
+// ScopeReader is an optional Instrumentation extension: the per-test scope
+// windows the wrapped runner reported through the agent's /agent/scope/* API
+// during a record session. Record uses it to write mappings.yaml so replay can
+// serve mocks per test. When the instrumentation does not implement it (or the
+// runner made no scope calls) the set is recorded suite-level and replay serves
+// the whole pool — still correct, just without per-test isolation.
+type ScopeReader interface {
+	GetScopeWindows(ctx context.Context) ([]models.ScopeWindow, error)
+}
+
+// MissCapturer is an optional Instrumentation extension: under `--on-miss
+// record`, Replay drains the calls the proxy served live-from-upstream on a miss
+// and appends them to the set (VCR new_episodes).
+type MissCapturer interface {
+	DrainCapturedMocks(ctx context.Context) ([]*models.Mock, error)
+}
+
+// ScopePusher is an optional Instrumentation extension: Replay uses it to hand
+// the agent the per-test name→mock-names table (from mappings.yaml) so the
+// runner's /agent/scope/begin calls can restrict the served pool per test.
+type ScopePusher interface {
+	PushScopeTable(ctx context.Context, table map[string][]string) error
+}
+
+// MockDB reads and writes a named mock set on disk. It is exactly the surface
+// the yaml mockdb already implements, so OSS wires the file store directly and
+// enterprise wraps it with registry upload/download.
 type MockDB interface {
+	InsertMock(ctx context.Context, mock *models.Mock, testSetID string) error
+	DeleteMocksForSet(ctx context.Context, testSetID string) error
 	GetFilteredMocks(ctx context.Context, testSetID string, afterTime time.Time, beforeTime time.Time, mocksThatHaveMappings map[string]bool, mocksWeNeed map[string]bool) ([]*models.Mock, error)
 	GetUnFilteredMocks(ctx context.Context, testSetID string, afterTime time.Time, beforeTime time.Time, mocksThatHaveMappings map[string]bool, mocksWeNeed map[string]bool) ([]*models.Mock, error)
+	ResetCounterID()
+	// SetCounterID seeds the mock-name counter so the next InsertMock names its
+	// mock "mock-<id+1>" — used to append without reusing existing names.
+	SetCounterID(id int64)
 }
 
-// MappingDB gives the mock service access to the test-case → mock-name
-// mapping table so it can apply the same mapping-based filtering strategy
-// that the replayer uses.
+// MappingDB persists and reads the per-test mock mapping for a set. Optional:
+// nil disables per-test scoping (suite-level record/replay).
 type MappingDB interface {
+	UpsertBatch(ctx context.Context, testSetID string, byTest map[string][]models.MockEntry) error
 	Get(ctx context.Context, testSetID string) (map[string][]models.MockEntry, bool, error)
 }
 
-// OutgoingConfig holds the knobs that control how the proxy intercepts and
-// matches outgoing calls. These mirror the fields from models.OutgoingOptions
-// that are relevant to the mock service (no test-case-specific timestamps, etc.).
-type OutgoingConfig struct {
-	// BypassRules lists host/port patterns that should be passed through
-	// without being mocked.
-	BypassRules []models.BypassRule
-
-	// MongoPassword is used to decode encrypted Mongo wire traffic.
-	MongoPassword string
-
-	// SQLDelay mimics the application startup delay used during test runs.
-	SQLDelay time.Duration
-
-	// Mocking enables or disables mock interception entirely.
-	Mocking bool
-
-	// MysqlPorts pins extra destination ports to the MySQL parser,
-	// skipping auto-detection for them. Mirrors Config.MysqlPorts.
-	MysqlPorts []uint32
-
-	// DisableMysqlAutoDetect turns off automatic MySQL port detection,
-	// restoring strict MysqlPorts matching. Mirrors
-	// Config.DisableMysqlAutoDetect.
-	DisableMysqlAutoDetect bool
-	// DisableMysqlEndpointDrift mirrors Config.DisableMysqlEndpointDrift.
-	DisableMysqlEndpointDrift bool
-
-	// PassThroughPorts / PassThroughHosts mirror Config.Record.PassThroughPorts /
-	// PassThroughHosts so a standalone mock-serving session honours the same
-	// telemetry-egress passthrough rules as record/replay. See models.PassThroughRule.
-	PassThroughPorts []models.PassThroughRule
-	PassThroughHosts []models.PassThroughRule
+// Store is the mock-set persistence backend. OSS uses FileStore (mocks live on
+// disk, no remote sync). Enterprise plugs in a registry-backed store that
+// uploads after record and downloads before replay. Registry-first by default;
+// `--local` selects FileStore.
+type Store interface {
+	// Pull materialises the named set locally before replay. FileStore is a
+	// no-op (the set is already on disk).
+	Pull(ctx context.Context, name string) error
+	// Push publishes the named set after a successful record. FileStore is a
+	// no-op.
+	Push(ctx context.Context, name string) error
 }

--- a/pkg/service/mock/store.go
+++ b/pkg/service/mock/store.go
@@ -1,0 +1,15 @@
+package mock
+
+import "context"
+
+// FileStore is the OSS mock-set store: mocks live on disk under keploy/<name>/
+// and are committed to the repo (the VCR "cassette" model). Pull and Push are
+// no-ops because there is no remote to sync with. Enterprise replaces this with
+// a registry-backed store that uploads after record and downloads before replay.
+type FileStore struct{}
+
+// Pull is a no-op for file-backed sets (already on disk).
+func (FileStore) Pull(_ context.Context, _ string) error { return nil }
+
+// Push is a no-op for file-backed sets (nothing to publish).
+func (FileStore) Push(_ context.Context, _ string) error { return nil }


### PR DESCRIPTION
## What

Adds a **mock-only mode** so Keploy can be used as a language-agnostic mocking framework for a user's **own test runner** (pytest, `go test`, jest/playwright, mobile), not just for Keploy-generated test cases.

```bash
keploy mock record -c "pytest"        # capture the real dependency calls your tests make
keploy mock replay -c "pytest"        # serve them back — dependencies can be offline
keploy mock replay -c "go test ./..." --name orders --on-miss record --strict
```

## Why

Users repeatedly asked to use Keploy the way VCR.py / go-vcr / WireMock are used: run your own suite, record the outbound calls, replay them offline. Five prior attempts (#3381, #3452, #3582, #3699, #3714) stalled; the recurring gaps were **exit-code propagation**, **in-place refresh**, **per-test scoping without rewriting test code**, and an **on-miss policy**. This implements all four on current `main`.

## How it works

- **`pkg/service/mock`** — the record/replay service. Reuses the same `AgentClient` instrumentation, mock/mapping DBs and `RecordHooks` that record/test use, so enterprise runtime behaviour (LD_PRELOAD / java-agent / Go-binary TLS shims, time-freeze, secret obfuscation) applies with no mock-specific code. A pluggable `Store` (FileStore in OSS) lets enterprise back sets with the cloud registry.
- **Per-test scope API** — `POST /agent/scope/begin|end` (+ `/scope/table`, `/scope/windows`, `/mock/stats`, `/mock/captured`). Keploy exports `KEPLOY_MOCK_AGENT` into the wrapped command so a test-runner fixture/hook marks per-test boundaries; record writes `mappings.yaml`, replay scopes the served pool per test. No test-code rewriting.
- **On-miss policy** — `--on-miss fail|passthrough|record`. `passthrough` dials the real dependency on an unrecorded HTTP call; `record` also appends it to the set (VCR *new_episodes*) for incremental refresh.
- **Exit-code propagation** — `models.AppError` carries the child exit code, mirrored onto `utils.ErrCode`.
- **Mock mode** skips ingress/bind port relocation (the wrapped process is a runner, not a server) and kernel-bypasses the agent's own control port so the scope API is reachable; forwarded to native and docker agents via `--mock-mode`.

## Platforms

Linux (eBPF) and Windows amd64 (WinDivert) natively; macOS via a docker command (native rejected with a docker hint).

## Tests

- Table-driven unit tests for scope correlation and miss-policy logic.
- Self-contained e2e: `.github/workflows/mock_linux.yml` + `test_workflow_scripts/mock/mock-linux.sh` (embeds a dependency + pytest suite; asserts offline replay passes, per-test mappings are written, and a failing runner propagates a non-zero exit). Wired into `prepare_and_run.yml`'s gate.
- Verified locally end-to-end with pytest and `go test`: record → offline replay, exact exit-code mirroring (`sys.exit(7)` → keploy exits 7), per-test scoping, and all three on-miss policies.

## Notes

- Docs: keploy/docs PR adds the "Mock Your Own Tests" page.
- Enterprise: a companion PR composes these commands under the enterprise `mock` parent and adds a registry-backed store; it depends on this PR.