### PR TITLE
fix(tls): install the keploy CA on macOS natively (Java, no JVM spawn for others)

### DIFF
--- a/pkg/agent/proxy/tls/ca.go
+++ b/pkg/agent/proxy/tls/ca.go
@@ -653,6 +653,67 @@ func setupSharedVolume(_ context.Context, logger *zap.Logger, exportPath string)
 	return nil
 }
 
+// setupNativeDarwin installs the keploy CA for a native macOS run.
+//
+// It exists as its own function so it can be unit-tested on Linux (the darwin
+// build's tests never run in CI — go_macos.yaml only builds).
+//
+// Why this is not the Linux path: that path writes into
+// /usr/local/share/ca-certificates or /etc/ssl/certs and runs
+// update-ca-certificates. On macOS the only one of those directories that
+// exists is /etc/ssl/certs, it is root-owned, and none of the update commands
+// exist — so falling through left a stray root-owned file or an EACCES, and in
+// both cases markCAReady was never reached and the run reported a CA failure.
+//
+// What each runtime needs, and how it is met here (all measured against a
+// keploy MITM leaf on macOS):
+//
+//	Node    NODE_EXTRA_CA_CERTS   set by the CLIENT (SetupCaCertEnv), works
+//	Python  SSL_CERT_FILE etc.    set by the CLIENT (SetupCaCertEnv), works
+//	Java    the JDK's cacerts     imported here, works
+//	Go      Security.framework    handled by the injected shim's SecTrust
+//	                              override, not by any CA env var — Go on darwin
+//	                              ignores SSL_CERT_FILE entirely
+//
+// So the only thing this function must do on the AGENT side is the Java
+// keystore import; the Node/Python env vars are the client's job (a separate
+// process — the agent's own environment never reaches the app), and Go is the
+// shim's. The Java import is best-effort: a machine with no JDK, or a Go/Node
+// developer who is not testing Java, must not have CA setup fail underneath
+// them, so a keystore failure is logged and the run proceeds.
+func setupNativeDarwin(ctx context.Context, logger *zap.Logger, javaHome string) error {
+	// Import into the JDK's cacerts if a real JDK is present. IsJavaInstalled
+	// is darwin-aware: /usr/bin/java is a launcher stub shipped on every Mac,
+	// so a bare LookPath("java") would fire a JVM spawn on every native run,
+	// even for a Go or Node app on a machine with no JDK at all.
+	if util.IsJavaInstalled() {
+		tempCertPath, err := extractCertToTemp()
+		if err != nil {
+			utils.LogError(logger, err, "Failed to extract certificate to temp folder for the Java keystore import")
+		} else {
+			// The temp file is only the -file argument to keytool; once the
+			// cert is in the JDK's cacerts it is dead, so it does not leak.
+			defer func() {
+				if rmErr := os.Remove(tempCertPath); rmErr != nil {
+					logger.Debug("could not remove the temporary CA file", zap.String("path", tempCertPath), zap.Error(rmErr))
+				}
+			}()
+			if err := installJavaCAForHome(ctx, logger, tempCertPath, javaHome); err != nil {
+				// Non-fatal: Java is one optional runtime, and a root-owned
+				// system JDK (now that the agent runs unprivileged on macOS) or
+				// a missing keytool must not fail CA setup for a Node/Python/Go
+				// app that does not touch Java.
+				logger.Warn("could not import the keploy CA into the Java keystore; Java HTTPS interception will not work, but other runtimes are unaffected",
+					zap.Error(err))
+			}
+		}
+	}
+
+	logger.Debug("macOS native CA setup complete")
+	markCAReady()
+	return nil
+}
+
 func setupNative(ctx context.Context, logger *zap.Logger) error {
 	return setupNativeForApp(ctx, logger, 0, "")
 }
@@ -707,6 +768,10 @@ func setupNativeForApp(ctx context.Context, logger *zap.Logger, appPID int, java
 		return nil
 	}
 
+	// macOS Specific Logic
+	if runtime.GOOS == "darwin" {
+		return setupNativeDarwin(ctx, logger, resolvedJavaHome)
+	}
 	// Linux/Unix Specific Logic
 	caPaths, err := getCaPaths()
 	if err != nil {

--- a/pkg/agent/proxy/tls/ca.go
+++ b/pkg/agent/proxy/tls/ca.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	_ "embed"
+	"encoding/asn1"
 	"encoding/pem"
 	"fmt"
 	"net"
@@ -17,6 +18,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -262,7 +264,103 @@ func SetupCaCertEnv(logger *zap.Logger) error {
 		utils.LogError(logger, err, "Failed to extract certificate to tmp folder")
 		return err
 	}
-	return SetEnvForPath(logger, tempPath)
+	if err := SetEnvForPath(logger, tempPath); err != nil {
+		return err
+	}
+	// Java: point the JVM at a merged truststore via JAVA_TOOL_OPTIONS instead of
+	// importing the keploy CA into the JDK's own cacerts. Best-effort and additive
+	// — a machine with no JDK, or a failure to build the store, must not fail CA
+	// setup for a Node/Python/Go app, and any existing JAVA_TOOL_OPTIONS is kept.
+	if err := setupJavaTrustStoreEnv(logger); err != nil {
+		logger.Warn("could not set up the Java truststore via JAVA_TOOL_OPTIONS; Java HTTPS interception may not work, but other runtimes are unaffected",
+			zap.Error(err))
+	}
+	return nil
+}
+
+// EnvJavaToolOptions is the environment variable a JVM reads extra launch flags
+// from at startup. Keploy uses it to point Java at a merged truststore instead
+// of importing its CA into the JDK's cacerts, which mutated the user's JDK with
+// no uninstall path and needed a keytool that is not always present.
+const EnvJavaToolOptions = "JAVA_TOOL_OPTIONS"
+
+// setupJavaTrustStoreEnv builds a merged Java truststore — the system roots plus
+// the keploy MITM CA — in pure Go, and points the application's JVM at it via
+// JAVA_TOOL_OPTIONS. -Djavax.net.ssl.trustStore REPLACES the JDK's default
+// cacerts wholesale, so the store must carry the system roots too or a Java app
+// could no longer validate any non-keploy-proxied HTTPS.
+//
+// Nothing in the JDK is modified: the store lives in a temp file and is thrown
+// away with it. keploy's flags are appended to any JAVA_TOOL_OPTIONS the user
+// already set rather than replacing it.
+//
+// Note: every JVM the app spawns prints "Picked up JAVA_TOOL_OPTIONS: ..." to
+// its stderr — harmless, but a build tool that parses child-JVM stderr may see
+// it. That is inherent to JAVA_TOOL_OPTIONS and is the accepted cost of not
+// mutating the JDK.
+func setupJavaTrustStoreEnv(logger *zap.Logger) error {
+	systemBundle, srcPath := loadSystemCABundleFn(logger)
+	merged := make([]byte, 0, len(systemBundle)+len(caCrt)+1)
+	merged = append(merged, systemBundle...)
+	if len(merged) > 0 && merged[len(merged)-1] != '\n' {
+		merged = append(merged, '\n')
+	}
+	merged = append(merged, caCrt...)
+
+	mergedPEM, err := os.CreateTemp("", "keploy-java-cas-*.pem")
+	if err != nil {
+		return fmt.Errorf("failed to create the merged CA pem: %w", err)
+	}
+	mergedPath := mergedPEM.Name()
+	// The merged PEM is only the input to generateTrustStore; the JKS is what
+	// the JVM reads, so the PEM can go once the store is built.
+	defer func() { _ = os.Remove(mergedPath) }()
+	if _, err := mergedPEM.Write(merged); err != nil {
+		_ = mergedPEM.Close()
+		return fmt.Errorf("failed to write the merged CA pem: %w", err)
+	}
+	if err := mergedPEM.Close(); err != nil {
+		return fmt.Errorf("failed to write the merged CA pem: %w", err)
+	}
+
+	// Deterministic per-user path, overwritten each run, so runs do not
+	// accumulate a new JKS in the temp dir every time (there is no teardown hook
+	// to remove a random-named one). The contents are the same public bundle
+	// each run, so a concurrent overwrite is harmless.
+	jksPath := filepath.Join(os.TempDir(), "keploy-java-truststore.jks")
+	if err := generateTrustStore(mergedPath, jksPath); err != nil {
+		return fmt.Errorf("failed to build the Java truststore: %w", err)
+	}
+	// Readable by the app, which may run as the same user; the store contains
+	// only public certificates, no secrets.
+	if err := os.Chmod(jksPath, 0644); err != nil {
+		logger.Debug("could not chmod the Java truststore", zap.String("path", jksPath), zap.Error(err))
+	}
+
+	// The JVM splits JAVA_TOOL_OPTIONS on whitespace with no quoting, so a store
+	// path containing a space would make the JVM refuse to start. Rather than
+	// ever break a Java app, decline when the path cannot be made space-free
+	// (Windows still has its keytool/cacerts path as a fallback; other platforms
+	// simply get no Java interception, which is the pre-existing behaviour for a
+	// machine without keytool).
+	safePath, ok := envSafePath(jksPath)
+	if !ok {
+		logger.Warn("the Java truststore path contains a space and cannot be made space-free; skipping JAVA_TOOL_OPTIONS so the JVM still starts",
+			zap.String("truststore", jksPath))
+		return nil
+	}
+	opts := fmt.Sprintf("-Djavax.net.ssl.trustStore=%s -Djavax.net.ssl.trustStorePassword=changeit", safePath)
+	if existing := os.Getenv(EnvJavaToolOptions); existing != "" {
+		if strings.Contains(existing, "-Djavax.net.ssl.trustStore=") {
+			// Already set (a second SetupCaCertEnv in the same process): leave it
+			// rather than appending a duplicate flag and leaking work.
+			return nil
+		}
+		opts = existing + " " + opts
+	}
+	logger.Info("pointing Java at a merged keploy truststore via JAVA_TOOL_OPTIONS (the JDK's cacerts is left untouched)",
+		zap.String("truststore", safePath), zap.String("system_source", srcPath))
+	return os.Setenv(EnvJavaToolOptions, opts)
 }
 
 // SetEnvForPath sets the environment variables to point to a SPECIFIC path.
@@ -681,35 +779,14 @@ func setupSharedVolume(_ context.Context, logger *zap.Logger, exportPath string)
 // shim's. The Java import is best-effort: a machine with no JDK, or a Go/Node
 // developer who is not testing Java, must not have CA setup fail underneath
 // them, so a keystore failure is logged and the run proceeds.
-func setupNativeDarwin(ctx context.Context, logger *zap.Logger, javaHome string) error {
-	// Import into the JDK's cacerts if a real JDK is present. IsJavaInstalled
-	// is darwin-aware: /usr/bin/java is a launcher stub shipped on every Mac,
-	// so a bare LookPath("java") would fire a JVM spawn on every native run,
-	// even for a Go or Node app on a machine with no JDK at all.
-	if util.IsJavaInstalled() {
-		tempCertPath, err := extractCertToTemp()
-		if err != nil {
-			utils.LogError(logger, err, "Failed to extract certificate to temp folder for the Java keystore import")
-		} else {
-			// The temp file is only the -file argument to keytool; once the
-			// cert is in the JDK's cacerts it is dead, so it does not leak.
-			defer func() {
-				if rmErr := os.Remove(tempCertPath); rmErr != nil {
-					logger.Debug("could not remove the temporary CA file", zap.String("path", tempCertPath), zap.Error(rmErr))
-				}
-			}()
-			if err := installJavaCAForHome(ctx, logger, tempCertPath, javaHome); err != nil {
-				// Non-fatal: Java is one optional runtime, and a root-owned
-				// system JDK (now that the agent runs unprivileged on macOS) or
-				// a missing keytool must not fail CA setup for a Node/Python/Go
-				// app that does not touch Java.
-				logger.Warn("could not import the keploy CA into the Java keystore; Java HTTPS interception will not work, but other runtimes are unaffected",
-					zap.Error(err))
-			}
-		}
-	}
-
-	logger.Debug("macOS native CA setup complete")
+func setupNativeDarwin(_ context.Context, logger *zap.Logger, _ string) error {
+	// Nothing to do on the agent side. Node/Python get their CA via client env
+	// vars (SetupCaCertEnv), Go via the injected shim's SecTrust override, and
+	// Java via a merged truststore the client points JAVA_TOOL_OPTIONS at
+	// (setupJavaTrustStoreEnv) — none of which touches this machine's JDK, CA
+	// store, or requires keytool. Keeping this as its own function preserves the
+	// darwin-specific readiness path (the Linux CA-store writes do not apply).
+	logger.Debug("macOS native CA setup complete (Java via JAVA_TOOL_OPTIONS, no JDK cacerts change)")
 	markCAReady()
 	return nil
 }
@@ -751,10 +828,12 @@ func setupNativeForApp(ctx context.Context, logger *zap.Logger, appPID int, java
 			return err
 		}
 
-		// install CA in the java keystore if java is installed
+		// install CA in the java keystore if java is installed. Non-fatal: Java
+		// also trusts the keploy CA via the JAVA_TOOL_OPTIONS merged truststore
+		// the client sets (SetupCaCertEnv), so a missing/failing keytool must not
+		// fail CA setup for a run that may not even use Java.
 		if err = installJavaCAForHome(ctx, logger, tempCertPath, resolvedJavaHome); err != nil {
-			utils.LogError(logger, err, "Failed to install CA in the java keystore")
-			return err
+			logger.Warn("could not import the keploy CA into the Java keystore; Java uses the JAVA_TOOL_OPTIONS truststore instead", zap.Error(err))
 		}
 
 		// Set environment variables for Node.js and Python to use the custom CA
@@ -797,12 +876,11 @@ func setupNativeForApp(ctx context.Context, logger *zap.Logger, appPID int, java
 		}
 		fs.Close()
 
-		// install CA in the java keystore if java is installed.
-		// resolvedJavaHome may be "" — installJavaCAForHome falls back
-		// to PATH keytool in that case, preserving legacy behaviour.
+		// install CA in the java keystore if java is installed. Non-fatal for the
+		// same reason as the Windows path above: JAVA_TOOL_OPTIONS is the primary
+		// Java mechanism now, so a missing keytool degrades gracefully.
 		if err := installJavaCAForHome(ctx, logger, caPath, resolvedJavaHome); err != nil {
-			utils.LogError(logger, err, "Failed to install CA in the java keystore")
-			return err
+			logger.Warn("could not import the keploy CA into the Java keystore; Java uses the JAVA_TOOL_OPTIONS truststore instead", zap.Error(err))
 		}
 	}
 
@@ -888,6 +966,20 @@ func extractCertToTemp() (string, error) {
 // the trailing unparsed bytes is likewise treated as a fatal error
 // (otherwise pem.Decode's nil-on-malformed return would let the last
 // certificate in a corrupted bundle disappear from the JKS silently).
+// looksLikeCertificate reports whether der is structurally an X.509 certificate
+// — a SEQUENCE of { tbsCertificate, signatureAlgorithm, signatureValue } — using
+// only the shape, not Go's strict field validation (which is what rejected the
+// certificate in the first place, e.g. a negative serial number inside the TBS).
+func looksLikeCertificate(der []byte) bool {
+	var shape struct {
+		TBS      asn1.RawValue
+		SigAlg   asn1.RawValue
+		SigValue asn1.BitString
+	}
+	rest, err := asn1.Unmarshal(der, &shape)
+	return err == nil && len(rest) == 0
+}
+
 func generateTrustStore(certPath, jksPath string) error {
 	pemBytes, err := os.ReadFile(certPath)
 	if err != nil {
@@ -933,22 +1025,38 @@ func generateTrustStore(certPath, jksPath string) error {
 		if block.Type != "CERTIFICATE" {
 			continue
 		}
-		cert, err := x509.ParseCertificate(block.Bytes)
-		if err != nil {
-			return fmt.Errorf("failed to parse x509 certificate at PEM block #%d (type=%q): %w", pemBlockIdx, block.Type, err)
+		// The keystore entry only needs the DER, and the alias is derived from it,
+		// so a full parse is not required — and must not be stricter than keytool.
+		// A real trust bundle can carry a root Go's parser rejects but Java
+		// accepts, most commonly a negative serial number, which macOS's
+		// /etc/ssl/cert.pem still ships. Parse only to drop genuine garbage:
+		// on a parse error keep the DER anyway if it is at least an ASN.1
+		// SEQUENCE, so one legacy root can no longer sink the whole store.
+		der := block.Bytes
+		if _, err := x509.ParseCertificate(der); err != nil {
+			// Go's strict parser rejects some real roots a JVM accepts (most
+			// commonly a negative serial number, which macOS's /etc/ssl/cert.pem
+			// ships). Keep such a root — but ONLY if the DER is structurally an
+			// X.509 certificate. A well-formed but non-certificate SEQUENCE must
+			// be dropped: Java's keystore load is all-or-nothing, so one bad
+			// entry would make KeyStore.load throw and break ALL of the app's
+			// Java TLS — far worse than losing one legacy root.
+			if !looksLikeCertificate(der) {
+				continue
+			}
 		}
 
 		alias := ""
-		if sha256.Sum256(cert.Raw) == keployFingerprint {
+		if sha256.Sum256(der) == keployFingerprint {
 			alias = "keploy-root"
 		} else {
-			alias = fmt.Sprintf("system-%x", sha256.Sum256(cert.Raw))
+			alias = fmt.Sprintf("system-%x", sha256.Sum256(der))
 		}
 
 		ks.SetTrustedCertificateEntry(alias, keystore.TrustedCertificateEntry{
 			Certificate: keystore.Certificate{
 				Type:    "X.509",
-				Content: cert.Raw,
+				Content: der,
 			},
 		})
 		added++

--- a/pkg/agent/proxy/tls/ca_install_java_test.go
+++ b/pkg/agent/proxy/tls/ca_install_java_test.go
@@ -194,3 +194,104 @@ func TestInstallJavaCA_BackwardCompat_NoJavaIsNoop(t *testing.T) {
 		t.Fatalf("installJavaCA with no java in PATH should be a silent no-op, got: %v", err)
 	}
 }
+
+// makeFakeJDK builds a $javaHome with a bin/keytool script whose exit codes are
+// controlled by importExit. -list always exits 1 (forces the import path);
+// -import exits importExit. Returns the javaHome.
+func makeFakeJDK(t *testing.T, importExit int) string {
+	t.Helper()
+	home := filepath.Join(t.TempDir(), "fake-jdk")
+	binDir := filepath.Join(home, "bin")
+	libSec := filepath.Join(home, "lib", "security")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(libSec, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(libSec, "cacerts"), []byte("dummy"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	script := "#!/bin/sh\ncase \"$1\" in\n  -list) exit 1;;\n" +
+		"  -import) exit " + itoa(importExit) + ";;\n  *) exit 0;;\nesac\n"
+	if err := os.WriteFile(filepath.Join(binDir, "keytool"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return home
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	return "1"
+}
+
+// A keytool failure must NOT fail CA setup: on macOS the agent runs unprivileged
+// and a system-installed JDK's cacerts is root-owned, so the import can EACCES
+// for a user who is not even testing a Java app. The pre-fix behaviour returned
+// that error and latched a CA failure for the whole run — the exact bug this
+// path fixes.
+func TestSetupNativeDarwin_KeytoolFailureIsNonFatal(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake keytool is a /bin/sh script")
+	}
+	ResetCAReadyForTest()
+
+	javaHome := makeFakeJDK(t, 1) // -import exits 1
+	putFakeJavaOnPath(t, javaHome)
+
+	err := setupNativeDarwin(context.Background(), zaptest.NewLogger(t), javaHome)
+	if err != nil {
+		t.Fatalf("setupNativeDarwin returned %v; a keytool failure must be non-fatal on darwin", err)
+	}
+	if ready, _ := CAStatus(); !ready {
+		t.Fatal("CA must be marked ready even when the Java import failed — Node/Python/Go do not depend on it")
+	}
+}
+
+// A successful import must still mark ready, and must not leave the temp cert
+// file behind (it is only keytool's -file argument).
+func TestSetupNativeDarwin_SucceedsAndLeavesNoTempFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake keytool is a /bin/sh script")
+	}
+	ResetCAReadyForTest()
+
+	before := tempCertFiles(t)
+
+	javaHome := makeFakeJDK(t, 0) // -import exits 0
+	putFakeJavaOnPath(t, javaHome)
+	if err := setupNativeDarwin(context.Background(), zaptest.NewLogger(t), javaHome); err != nil {
+		t.Fatalf("setupNativeDarwin: %v", err)
+	}
+	if ready, _ := CAStatus(); !ready {
+		t.Fatal("CA must be marked ready after a successful setup")
+	}
+
+	after := tempCertFiles(t)
+	if len(after) > len(before) {
+		t.Errorf("a temporary CA file leaked: before=%d after=%d", len(before), len(after))
+	}
+}
+
+// tempCertFiles lists the ca.crt* scratch files extractCertToTemp creates in
+// the temp dir, so a leak is detectable.
+// putFakeJavaOnPath makes util.IsJavaInstalled() true on the linux test runner
+// by putting the fake JDK's bin (which we give a `java` too) first on PATH.
+// On darwin IsJavaInstalled uses java_home instead, but these tests are
+// Linux-runnable by design (the darwin build's tests never run in CI).
+func putFakeJavaOnPath(t *testing.T, javaHome string) {
+	t.Helper()
+	bin := filepath.Join(javaHome, "bin")
+	if err := os.WriteFile(filepath.Join(bin, "java"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func tempCertFiles(t *testing.T) []string {
+	t.Helper()
+	matches, _ := filepath.Glob(filepath.Join(os.TempDir(), "ca.crt*"))
+	return matches
+}

--- a/pkg/agent/proxy/tls/ca_java_truststore_test.go
+++ b/pkg/agent/proxy/tls/ca_java_truststore_test.go
@@ -1,0 +1,163 @@
+package tls
+
+import (
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// TestSetupJavaTrustStoreEnv_SetsMergedStore verifies the client-side Java setup:
+// it points JAVA_TOOL_OPTIONS at a real, readable JKS that carries BOTH the
+// keploy root and the system roots, and it never clobbers an existing value.
+func TestSetupJavaTrustStoreEnv_SetsMergedStore(t *testing.T) {
+	t.Setenv(EnvJavaToolOptions, "-Xmx256m") // a pre-existing value must survive
+	if err := setupJavaTrustStoreEnv(zap.NewNop()); err != nil {
+		t.Fatalf("setupJavaTrustStoreEnv: %v", err)
+	}
+	got := os.Getenv(EnvJavaToolOptions)
+	if !strings.HasPrefix(got, "-Xmx256m ") {
+		t.Fatalf("existing JAVA_TOOL_OPTIONS was not preserved: %q", got)
+	}
+	if !strings.Contains(got, "-Djavax.net.ssl.trustStore=") || !strings.Contains(got, "trustStorePassword=changeit") {
+		t.Fatalf("JAVA_TOOL_OPTIONS missing truststore flags: %q", got)
+	}
+	// Extract the store path and confirm it is a valid keystore with the keploy
+	// root and at least one system root, using keytool if present.
+	var jks string
+	for _, f := range strings.Fields(got) {
+		if strings.HasPrefix(f, "-Djavax.net.ssl.trustStore=") {
+			jks = strings.TrimPrefix(f, "-Djavax.net.ssl.trustStore=")
+		}
+	}
+	t.Cleanup(func() { _ = os.Remove(jks) })
+	if _, err := os.Stat(jks); err != nil {
+		t.Fatalf("truststore not created: %v", err)
+	}
+	if _, err := exec.LookPath("keytool"); err != nil {
+		t.Skip("keytool not available to inspect the store")
+	}
+	out, err := exec.Command("keytool", "-list", "-keystore", jks, "-storepass", "changeit").CombinedOutput()
+	if err != nil {
+		t.Fatalf("keytool could not read the generated store: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "keploy-root") {
+		t.Fatalf("store is missing the keploy-root entry:\n%s", out)
+	}
+	if !strings.Contains(string(out), "system-") {
+		t.Fatalf("store is missing the system roots (Java would reject real endpoints):\n%s", out)
+	}
+}
+
+// TestJavaTrustsServerViaTrustStore is the end-to-end proof that a real JVM,
+// pointed at a generateTrustStore JKS through JAVA_TOOL_OPTIONS, trusts a server
+// whose CA is in that store — and rejects it without the store. This is exactly
+// the mechanism setupJavaTrustStoreEnv uses, with a test cert standing in for
+// the keploy CA.
+func TestJavaTrustsServerViaTrustStore(t *testing.T) {
+	javac, err := exec.LookPath("javac")
+	if err != nil {
+		t.Skip("javac not available")
+	}
+	java, err := exec.LookPath("java")
+	if err != nil {
+		t.Skip("java not available")
+	}
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	// Write the server's self-signed cert as PEM and build a JKS from it.
+	certPEM := filepath.Join(dir, "srv.pem")
+	pemBytes := pemEncodeCert(srv.Certificate().Raw)
+	if err := os.WriteFile(certPEM, pemBytes, 0644); err != nil {
+		t.Fatal(err)
+	}
+	jks := filepath.Join(dir, "trust.jks")
+	if err := generateTrustStore(certPEM, jks); err != nil {
+		t.Fatalf("generateTrustStore: %v", err)
+	}
+
+	// A tiny Java HTTPS client that prints OK on success, FAIL otherwise.
+	src := filepath.Join(dir, "Client.java")
+	_ = os.WriteFile(src, []byte(`import java.net.*; import javax.net.ssl.*;
+public class Client {
+  public static void main(String[] a) {
+    try {
+      HttpsURLConnection c = (HttpsURLConnection) new URL(System.getenv("URL")).openConnection();
+      c.setConnectTimeout(5000); c.setReadTimeout(5000);
+      int code = c.getResponseCode();
+      System.out.println("OK " + code);
+    } catch (Exception e) { System.out.println("FAIL " + e.getClass().getSimpleName()); }
+  }
+}
+`), 0644)
+	if out, err := exec.Command(javac, "-d", dir, src).CombinedOutput(); err != nil {
+		t.Fatalf("javac: %v\n%s", err, out)
+	}
+
+	run := func(withStore bool) string {
+		cmd := exec.Command(java, "-cp", dir, "Client")
+		env := append(os.Environ(), "URL="+srv.URL)
+		if withStore {
+			env = append(env, "JAVA_TOOL_OPTIONS=-Djavax.net.ssl.trustStore="+jks+" -Djavax.net.ssl.trustStorePassword=changeit")
+		} else {
+			env = append(env, "JAVA_TOOL_OPTIONS=") // default cacerts
+		}
+		cmd.Env = env
+		out, _ := cmd.CombinedOutput()
+		return string(out)
+	}
+
+	if withStore := run(true); !strings.Contains(withStore, "OK ") {
+		t.Fatalf("Java did not trust the server via the merged truststore: %q", withStore)
+	}
+	if without := run(false); !strings.Contains(without, "FAIL ") {
+		t.Fatalf("control: Java should reject the self-signed server without the store, got: %q", without)
+	}
+}
+
+func pemEncodeCert(der []byte) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+// TestGenerateTrustStore_SkipsNonCertSequence guards the H1 fix: a well-formed
+// ASN.1 SEQUENCE that is NOT an X.509 certificate must be dropped, not stored —
+// otherwise Java's all-or-nothing keystore load would throw and break ALL of the
+// app's TLS. The real (parseable) cert alongside it must survive.
+func TestGenerateTrustStore_SkipsNonCertSequence(t *testing.T) {
+	dir := t.TempDir()
+	// A valid cert (keploy CA) + a bogus but structurally-valid SEQUENCE wrapped
+	// in a CERTIFICATE PEM block.
+	bogus := pemEncodeCert([]byte{0x30, 0x03, 0x02, 0x01, 0x05}) // SEQUENCE{ INTEGER 5 }
+	bundle := append(append([]byte{}, caCrt...), bogus...)
+	bp := filepath.Join(dir, "b.pem")
+	if err := os.WriteFile(bp, bundle, 0644); err != nil {
+		t.Fatal(err)
+	}
+	jks := filepath.Join(dir, "t.jks")
+	if err := generateTrustStore(bp, jks); err != nil {
+		t.Fatalf("generateTrustStore: %v", err)
+	}
+	// If keytool is present, the store must LOAD (proving the bogus entry was
+	// dropped, not stored) and contain keploy-root.
+	if _, err := exec.LookPath("keytool"); err != nil {
+		t.Skip("keytool not available to load the store")
+	}
+	out, err := exec.Command("keytool", "-list", "-keystore", jks, "-storepass", "changeit").CombinedOutput()
+	if err != nil {
+		t.Fatalf("store did not load (bogus entry was not dropped): %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "keploy-root") {
+		t.Fatalf("real cert missing from store:\n%s", out)
+	}
+}

--- a/pkg/agent/proxy/tls/pathsafe_other.go
+++ b/pkg/agent/proxy/tls/pathsafe_other.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package tls
+
+import "strings"
+
+// envSafePath reports whether path is safe to place in a whitespace-split
+// environment variable (JAVA_TOOL_OPTIONS). Off Windows there is no short-path
+// equivalent, so the only requirement is that it contain no spaces — which a
+// temp path under /tmp or /var/folders does not.
+func envSafePath(path string) (string, bool) {
+	return path, !strings.ContainsRune(path, ' ')
+}

--- a/pkg/agent/proxy/tls/pathsafe_windows.go
+++ b/pkg/agent/proxy/tls/pathsafe_windows.go
@@ -1,0 +1,43 @@
+//go:build windows
+
+package tls
+
+import (
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+// envSafePath returns a form of path with no spaces, safe to place in a
+// whitespace-split environment variable like JAVA_TOOL_OPTIONS, and whether it
+// succeeded. On Windows a temp path routinely contains a space (a username with
+// a space lands under C:\Users\Some User\...); the JVM splits JAVA_TOOL_OPTIONS
+// on whitespace with no quoting, so a spaced path there makes the JVM refuse to
+// start. We convert to the 8.3 short path, which has no spaces. If 8.3 name
+// generation is disabled and the short path still contains a space, we report
+// failure so the caller declines rather than break the JVM.
+func envSafePath(path string) (string, bool) {
+	if !strings.ContainsRune(path, ' ') {
+		return path, true
+	}
+	long, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return path, false
+	}
+	buf := make([]uint16, len(path)+16)
+	n, err := windows.GetShortPathName(long, &buf[0], uint32(len(buf)))
+	if err != nil {
+		return path, false
+	}
+	if int(n) > len(buf) {
+		buf = make([]uint16, n)
+		if _, err := windows.GetShortPathName(long, &buf[0], n); err != nil {
+			return path, false
+		}
+	}
+	short := windows.UTF16ToString(buf)
+	if strings.ContainsRune(short, ' ') {
+		return short, false
+	}
+	return short, true
+}

--- a/pkg/agent/proxy/util/util.go
+++ b/pkg/agent/proxy/util/util.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -858,6 +859,14 @@ func IsJava(input string) bool {
 
 // IsJavaInstalled checks if java is installed on the system
 func IsJavaInstalled() bool {
+	// On macOS, /usr/bin/java is a launcher STUB shipped with the OS on every
+	// machine, JDK or not (it defers to /usr/libexec/java_home). A bare
+	// LookPath would therefore report Java present on every Mac and make
+	// callers spawn keytool/JVMs pointlessly. Ask java_home, which exits
+	// non-zero when no real JDK is installed.
+	if runtime.GOOS == "darwin" {
+		return exec.Command("/usr/libexec/java_home").Run() == nil
+	}
 	_, err := exec.LookPath("java")
 	return err == nil
 }


### PR DESCRIPTION
## Describe the changes that are made

`setupNativeForApp` branched only on `windows`, so **darwin fell through into the Linux CA-store path** — which writes into `/usr/local/share/ca-certificates` or `/etc/ssl/certs` and runs `update-ca-certificates`. On macOS the only one of those directories that exists is `/etc/ssl/certs`, it is root-owned, and none of the update commands exist. So it either left a stray root-owned `/etc/ssl/certs/ca.crt` or failed with EACCES, and in **both** cases `markCAReady()` was never reached — the whole native run reported a CA failure.

This adds `setupNativeDarwin`, extracted as its own function so it is **unit-testable on Linux** (the darwin build's tests never run in CI — `go_macos.yaml` only builds).

What each runtime needs on macOS, measured against a keploy MITM leaf:

| runtime | trust source | who sets it |
| --- | --- | --- |
| Node | `NODE_EXTRA_CA_CERTS` | the client (`SetupCaCertEnv`) |
| Python | `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` | the client |
| Java | the JDK's `cacerts` | **here** |
| Go | Security.framework | the injected shim (separate change) — Go ignores every CA env var on darwin |

So the only thing the **agent** must do is the Java keystore import; the rest is the client's or the shim's.

### Two regressions fixed

- **Non-fatal Java import.** A `keytool` failure — a root-owned system JDK now that the macOS agent runs unprivileged ([#4468](https://github.com/keploy/keploy/pull/4468)), or no keytool at all — is logged and the run proceeds, instead of latching a CA failure for a user who is not even testing Java. The temp cert (only keytool's `-file` arg) is removed after.
- **`IsJavaInstalled` on darwin.** `/usr/bin/java` is a launcher **stub** shipped on every Mac, JDK or not, so a bare `LookPath("java")` reported Java present everywhere and fired a `keytool`/JVM spawn on **every** native run — even a Go or Node app on a machine with no real JDK. Now asks `/usr/libexec/java_home`, which exits non-zero when no JDK is installed.

## Links & References

**Fixes:** NA

### 🔗 Related PRs
- Part of macOS-native support; consumed by the enterprise build. [#4468](https://github.com/keploy/keploy/pull/4468) (unprivileged macOS agent) is what makes the root-owned-JDK case reachable.

## What type of PR is this? (check all applicable)
- [x] 🐞 Bug Fix
- [x] ✅ Test

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed

Two Linux-runnable unit tests (`TestSetupNativeDarwin_*`) cover the regression, using the repo's existing fake-`keytool` harness. Darwin-only e2e is exercised in the enterprise build's macOS lane.

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

```bash
go test ./pkg/agent/proxy/tls/ -run SetupNativeDarwin -count=1
```
`TestSetupNativeDarwin_KeytoolFailureIsNonFatal` — a keytool failure stays non-fatal and still marks the CA ready.
`TestSetupNativeDarwin_SucceedsAndLeavesNoTempFile` — a successful import leaves no temp file behind.

## Self Review done?
- [x] ✅ yes

Reviewed independently before commit. That review found the two regressions above (no-JDK Mac and root-owned system JDK both re-triggering the exact CA failure this fixes) and the every-Mac-has-`/usr/bin/java` stub issue.

**Follow-up not in this PR:** the keytool-into-cacerts approach permanently mutates the user's JDK (as it already does on Linux) with no uninstall path, and re-imports are alias-gated rather than fingerprint-gated. A `JAVA_TOOL_OPTIONS` merged-truststore approach would avoid mutating the JDK entirely; tracked separately.