### PR TITLE
fix(replay): stop failing a test on a response header the server mints per call

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -414,7 +414,7 @@ func (c *CmdConfigurator) AddUncommonFlags(cmd *cobra.Command) {
 		// the default does not break recordings without mapping data.
 		cmd.Flags().Bool("disable-mapping", c.cfg.DisableMapping, "Disable mapping of testcases during test mode")
 		cmd.Flags().Bool("retry-passing-test", c.cfg.RetryPassing, "Enable retry passing test mode")
-		cmd.Flags().Bool("disableAutoHeaderNoise", c.cfg.Test.DisableAutoHeaderNoise, "Disable automatic noise for flaky headers (e.g. AWS SigV4: Authorization, X-Amz-Date, X-Amz-Security-Token) during mock matching")
+		cmd.Flags().Bool("disableAutoHeaderNoise", c.cfg.Test.DisableAutoHeaderNoise, "Disable automatic noise for flaky headers: signing/tracing headers during mock matching, and per-request response headers (Date, X-Request-Id, trace ids) during response assertion")
 		cmd.Flags().String("mongo-password", c.cfg.Test.MongoPassword, "Authentication password for mocking MongoDB conn")
 		cmd.Flags().String("coverage-report-path", c.cfg.Test.CoverageReportPath, "Write a go coverage profile to the file in the given directory.")
 		cmd.Flags().VarP(&c.cfg.Test.Language, "language", "l", "Application programming language")

--- a/pkg/agent/proxy/integrations/http/async.go
+++ b/pkg/agent/proxy/integrations/http/async.go
@@ -217,13 +217,10 @@ func liveReqToMock(input *req) *models.Mock {
 	}}
 }
 
-// flakyHeaderNoise returns the package flaky-header list as a header-noise map.
-// Shared by MatchRequestShape and decode.go's auto-header-noise setup so the
-// two can't drift.
+// flakyHeaderNoise returns the flaky-header list as a header-noise map.
+// Shared by MatchRequestShape and decode.go's auto-header-noise setup so the two
+// can't drift. The response assertion shares the underlying models list but not
+// this function — it must compare names exactly, not through a noise map.
 func flakyHeaderNoise() map[string][]string {
-	nm := make(map[string][]string, len(flakyHeaders))
-	for _, fh := range flakyHeaders {
-		nm[fh] = []string{}
-	}
-	return nm
+	return models.FlakyHeaderNoise()
 }

--- a/pkg/agent/proxy/integrations/http/match.go
+++ b/pkg/agent/proxy/integrations/http/match.go
@@ -22,103 +22,10 @@ import (
 	"go.uber.org/zap"
 )
 
-// flakyHeaders lists HTTP header keys (lowercased) that are known to change
-// on every request due to cryptographic signatures, timestamps, credential
-// rotation, or per-request identifiers. These are automatically treated as
-// noise during mock matching so that replayed requests can find the correct
-// recorded mock even though these artifacts differ. Users who need strict
-// header matching can disable this with --disableAutoHeaderNoise.
-//
-// No single public library maintains such a list. Most recording/replay
-// tools (VCR, WireMock, Hoverfly) avoid the problem by not matching on
-// headers at all by default. Since Keploy does match on header keys, we
-// maintain this list covering the most common sources of non-determinism.
-//
-// Categories:
-//   - Cloud auth/signing:  AWS SigV4, GCP OAuth, Azure HMAC/Bearer
-//   - Tracing/correlation: W3C Trace Context, B3, Datadog, X-Request-Id
-//   - Webhook signatures:  Stripe, GitHub, Slack, Twilio, Shopify
-//   - SDK metadata:        per-call invocation IDs and attempt counters
-var flakyHeaders = []string{
-	// ── AWS SigV4 & SDK ──────────────────────────────────────────────
-	"authorization",         // signature changes every request (all cloud providers)
-	"x-amz-date",            // signing timestamp (yyyymmddThhmmssZ)
-	"x-amz-security-token",  // STS/IRSA session token — may appear or disappear
-	"x-amz-content-sha256",  // payload hash
-	"x-amz-credential",      // credential scope string
-	"x-amz-signature",       // explicit signature value (SigV4 query-string variant)
-	"x-amz-signedheaders",   // list of signed headers (varies with SDK)
-	"x-amz-expires",         // pre-signed URL expiry seconds
-	"x-amz-user-agent",      // SDK metadata
-	"x-amzn-trace-id",       // AWS X-Ray trace propagation
-	"amz-sdk-invocation-id", // unique per-call UUID from AWS SDK
-	"amz-sdk-request",       // attempt counter (attempt=1; max=3)
-	"date",                  // SigV4 fallback when X-Amz-Date absent. Globally ignored (Date is dynamic for all HTTP); disable per-test via DisableAutoHeaderNoise.
-
-	// ── GCP ──────────────────────────────────────────────────────────
-	"x-goog-api-client",     // SDK metadata (version, runtime info)
-	"x-goog-request-params", // routing parameters, may change with resource
-
-	// ── Azure ────────────────────────────────────────────────────────
-	"x-ms-date",                     // signing timestamp
-	"x-ms-client-request-id",        // client-generated UUID per call
-	"x-ms-content-sha256",           // body hash for HMAC auth
-	"x-ms-return-client-request-id", // echo control flag
-
-	// ── W3C Trace Context / OpenTelemetry ────────────────────────────
-	"traceparent", // unique trace-id + span-id per request
-	"tracestate",  // vendor-specific trace context
-
-	// ── Zipkin B3 propagation ────────────────────────────────────────
-	"x-b3-traceid",
-	"x-b3-spanid",
-	"x-b3-parentspanid",
-	"x-b3-sampled",
-	"b3", // single-header compact format
-
-	// ── Datadog ──────────────────────────────────────────────────────
-	"x-datadog-trace-id",
-	"x-datadog-parent-id",
-	"x-datadog-sampling-priority",
-	"x-datadog-origin",
-	"x-datadog-tags", // _dd.p.* propagation tags — emitted ONLY when the trace carries at least one (128-bit trace id, sampling decision). Absent whenever it carries none, so its very PRESENCE is per-request.
-
-	// ── Conditionally-emitted propagation headers ────────────────────
-	// Same class as the entries above, and listed separately because the
-	// hazard is different: these are absent outright on some requests rather
-	// than merely carrying a fresh value. HeadersContainKeys is presence-only,
-	// so a recorded header that the live request omits kills the candidate
-	// before any value comparison runs — a value-noise entry would not help.
-	"baggage",      // W3C Baggage (OpenTelemetry, Sentry) — present only when the context has baggage entries
-	"sentry-trace", // Sentry distributed tracing — present only when tracing is enabled for the transaction
-	"x-b3-flags",   // B3 debug flag — present only on debug-sampled traces
-
-	// ── Generic request/correlation IDs ──────────────────────────────
-	"x-request-id",     // Nginx, Envoy, HAProxy, AWS ALB, Heroku
-	"x-correlation-id", // cross-service correlation
-	"request-id",       // ASP.NET Core and others
-
-	// ── Webhook signatures (request-side, inbound webhooks) ──────────
-	"stripe-signature",
-	"x-hub-signature-256", // GitHub
-	"x-hub-signature",     // GitHub (legacy SHA-1)
-	"x-twilio-signature",
-	"x-shopify-hmac-sha256",
-	"x-slack-signature",
-	"x-slack-request-timestamp",
-	"webhook-signature", // Standard Webhooks spec
-	"webhook-timestamp", // Standard Webhooks spec
-	"webhook-id",        // Standard Webhooks spec
-
-	// ── Idempotency / CSRF ───────────────────────────────────────────
-	"idempotency-key",
-	"x-idempotency-key",
-	"x-csrf-token",
-	"x-xsrf-token",
-
-	// ── GCP trace (legacy) ───────────────────────────────────────────
-	"x-cloud-trace-context",
-}
+// flakyHeaders is retained for this package's tests, which enumerate the list.
+// models.FlakyHeaders is the definition; production code here reaches it via
+// flakyHeaderNoise().
+var flakyHeaders = models.FlakyHeaders
 
 type req struct {
 	method string

--- a/pkg/matcher/http/match.go
+++ b/pkg/matcher/http/match.go
@@ -27,7 +27,28 @@ var ppNew234 = pp.New
 var jsonMarshal234 = json.Marshal
 var jsonUnmarshal234 = json.Unmarshal
 
-func Match(tc *models.TestCase, actualResponse *models.HTTPResp, noiseConfig map[string]map[string][]string, ignoreOrdering bool, compareAll bool, logger *zap.Logger, emitFailureLogs bool) (bool, *models.Result) {
+// MatchOption tunes Match without changing its signature — enterprise and
+// k8s-proxy both call Match, so a new parameter would break them on their next
+// OSS bump.
+type MatchOption func(*matchOptions)
+
+type matchOptions struct{ autoHeaderNoise bool }
+
+// WithAutoHeaderNoise forgives a VALUE difference on response headers the server
+// mints fresh on every call — the HTTP date, request/correlation ids and
+// distributed-trace ids (models.IsVolatileResponseHeader).
+//
+// Presence is still asserted: a header that only one side carries stays a
+// failure. Off unless the caller asks.
+func WithAutoHeaderNoise(enabled bool) MatchOption {
+	return func(o *matchOptions) { o.autoHeaderNoise = enabled }
+}
+
+func Match(tc *models.TestCase, actualResponse *models.HTTPResp, noiseConfig map[string]map[string][]string, ignoreOrdering bool, compareAll bool, logger *zap.Logger, emitFailureLogs bool, opts ...MatchOption) (bool, *models.Result) {
+	var mo matchOptions
+	for _, opt := range opts {
+		opt(&mo)
+	}
 	// If the response body was skipped during recording (>1MB), compute body size comparison
 	// and clear the actual body so the normal comparison runs (empty vs empty).
 	var bodySizeResult models.IntResult
@@ -163,6 +184,49 @@ func Match(tc *models.TestCase, actualResponse *models.HTTPResp, noiseConfig map
 
 	if !matcherUtils.CompareHeaders(pkg.ToHTTPHeader(tc.HTTPResp.Header), pkg.ToHTTPHeader(actualResponse.Header), hRes, headerNoise) {
 		res.HeadersResult = *hRes
+
+		// Forgive a VALUE difference on a header the server mints fresh per call.
+		//
+		// Applied to the comparison RESULT, deliberately not by seeding
+		// headerNoise: that map is resolved by matcher.SubstringKeyMatch, which
+		// uses strings.Contains, so a "date" entry would also swallow
+		// "X-Candidate-Id" and "X-Validate-Token" — headers that merely contain
+		// the word. Matching the result's key exactly confines the forgiveness to
+		// the header it was meant for.
+		//
+		// Only when BOTH sides carried the header. CompareHeaders reports a
+		// missing or unexpected header with a nil Value on the absent side, and
+		// those stay failures: a server that stops emitting X-Request-Id, or
+		// starts emitting one it never did, is a real change and must not be
+		// hidden by a rule about values.
+		if mo.autoHeaderNoise {
+			for i := range res.HeadersResult {
+				hr := &res.HeadersResult[i]
+				if hr.Normal || hr.Expected.Value == nil || hr.Actual.Value == nil {
+					continue
+				}
+				name := hr.Expected.Key
+				if name == "" {
+					name = hr.Actual.Key
+				}
+				// An explicit user pattern outranks this. If the user wrote a
+				// regex for this header they narrowed it on purpose, and
+				// CompareHeaders already judged the replayed value against it —
+				// widening that into a blanket ignore would silently discard the
+				// constraint. Resolved through SubstringKeyMatch so the lookup
+				// sees the entry exactly as CompareHeaders did, whatever the
+				// user's casing. (An UNCONDITIONAL user entry never reaches here:
+				// CompareHeaders would already have marked the header normal.)
+				if patterns, constrained := matcherUtils.SubstringKeyMatch(name, headerNoise); constrained && len(patterns) > 0 {
+					continue
+				}
+				if models.IsVolatileResponseHeader(name) {
+					logger.Debug("ignoring value drift on a per-request-volatile response header",
+						zap.String("header", name))
+					hr.Normal = true
+				}
+			}
+		}
 
 		// If body matches but content-length differs, ignore the content-length difference
 		if res.BodyResult[0].Normal {

--- a/pkg/matcher/http/match_autoheadernoise_test.go
+++ b/pkg/matcher/http/match_autoheadernoise_test.go
@@ -1,0 +1,144 @@
+package http
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// pingCase reproduces checkr's get-ping-1 verbatim: a kubelet probe of /ping
+// whose status and body match exactly and whose ONLY difference is the
+// X-Request-Id Rails minted for that call. Values are the real ones from bundle
+// 17125508-9a11-4a5a-b780-2c8c8e11b58f.
+func pingCase() (*models.TestCase, *models.HTTPResp) {
+	tc := &models.TestCase{
+		Name: "get-ping-1",
+		HTTPResp: models.HTTPResp{
+			StatusCode: 200,
+			Header: map[string]string{
+				"Content-Type":    "text/plain; charset=utf-8",
+				"X-Frame-Options": "SAMEORIGIN",
+				"X-Request-Id":    "1aa063751102fc7793c0074ea388ecce",
+			},
+			Body: "200 OK",
+		},
+	}
+	actual := &models.HTTPResp{
+		StatusCode: 200,
+		Header: map[string]string{
+			"Content-Type":    "text/plain; charset=utf-8",
+			"X-Frame-Options": "SAMEORIGIN",
+			"X-Request-Id":    "e61200457948f19656cab129c18310c9",
+		},
+		Body: "200 OK",
+	}
+	return tc, actual
+}
+
+// THE DEFECT. Keploy already classifies X-Request-Id as per-request volatile and
+// auto-noises it for egress mock matching; nothing applied that knowledge to the
+// response assertion, so this case failed on a value the app mints per call.
+func TestMatch_AutoHeaderNoise_IgnoresPerRequestId(t *testing.T) {
+	tc, actual := pingCase()
+	pass, _ := Match(tc, actual, nil, false, false, zap.NewNop(), false, WithAutoHeaderNoise(true))
+	if !pass {
+		t.Fatal("a differing X-Request-Id must not fail a case whose status and body match")
+	}
+}
+
+// Default OFF: a caller that says nothing keeps the old, strict behaviour.
+func TestMatch_AutoHeaderNoise_OffByDefault(t *testing.T) {
+	tc, actual := pingCase()
+	if pass, _ := Match(tc, actual, nil, false, false, zap.NewNop(), false); pass {
+		t.Fatal("without the option the differing header must still fail")
+	}
+	if pass, _ := Match(tc, actual, nil, false, false, zap.NewNop(), false, WithAutoHeaderNoise(false)); pass {
+		t.Fatal("WithAutoHeaderNoise(false) must keep the old behaviour (--disableAutoHeaderNoise)")
+	}
+}
+
+// NO OVER-SUPPRESSION. headerNoise is resolved with strings.Contains, so seeding
+// the raw list would let "date" swallow "X-Candidate-Id" — a real header shape
+// for this very customer. Only exact names are seeded, so a genuine regression
+// in a lookalike header still fails.
+func TestMatch_AutoHeaderNoise_DoesNotSuppressLookalikeHeaders(t *testing.T) {
+	for _, victim := range []string{"X-Candidate-Id", "X-Validate-Token", "X-Web3-Addr"} {
+		// The Date header MUST be present: it is the trigger. An earlier version
+		// of this test omitted it, so the "date" key that does the damage was
+		// never in play and the test passed while the property it names was
+		// broken.
+		tc := &models.TestCase{
+			Name: "lookalike",
+			HTTPResp: models.HTTPResp{StatusCode: 200, Body: "ok", Header: map[string]string{
+				"Date": "Mon, 01 Jan 2026 00:00:00 GMT", victim: "expected",
+			}},
+		}
+		actual := &models.HTTPResp{StatusCode: 200, Body: "ok", Header: map[string]string{
+			"Date": "Tue, 02 Jan 2026 00:00:00 GMT", victim: "DRIFTED",
+		}}
+		if pass, _ := Match(tc, actual, nil, false, false, zap.NewNop(), false, WithAutoHeaderNoise(true)); pass {
+			t.Fatalf("%s is not a flaky header and must still be asserted", victim)
+		}
+	}
+}
+
+// A non-flaky header drifting alongside a flaky one must still fail the case.
+func TestMatch_AutoHeaderNoise_StillFailsOnRealHeaderDrift(t *testing.T) {
+	tc, actual := pingCase()
+	tc.HTTPResp.Header["X-Frame-Options"] = "SAMEORIGIN"
+	actual.Header["X-Frame-Options"] = "DENY"
+	if pass, _ := Match(tc, actual, nil, false, false, zap.NewNop(), false, WithAutoHeaderNoise(true)); pass {
+		t.Fatal("a real header change must still fail even with auto header noise on")
+	}
+}
+
+// An explicit user entry wins: auto-noise seeds only what nobody has spoken for.
+func TestMatch_AutoHeaderNoise_UserPatternWins(t *testing.T) {
+	tc, actual := pingCase()
+	// A pattern the replayed value does NOT satisfy: the user constrained this
+	// header, so the case must fail rather than be blanket-ignored.
+	tc.Noise = map[string][]string{"header.X-Request-Id": {"^1aa063"}}
+	if pass, _ := Match(tc, actual, nil, false, false, zap.NewNop(), false, WithAutoHeaderNoise(true)); pass {
+		t.Fatal("an explicit test-case pattern must not be widened into a blanket ignore")
+	}
+}
+
+// Presence is still asserted. A server that STOPS emitting a volatile header, or
+// STARTS emitting one it never did, is a real change — the forgiveness is about
+// values only, and applies solely when both sides carried the header.
+func TestMatch_AutoHeaderNoise_PresenceStillAsserted(t *testing.T) {
+	base := func(h map[string]string) *models.HTTPResp {
+		return &models.HTTPResp{StatusCode: 200, Header: h, Body: "ok"}
+	}
+	withDate := "Mon, 01 Jan 2026 00:00:00 GMT"
+
+	// dropped by the server
+	tc := &models.TestCase{Name: "dropped", HTTPResp: *base(map[string]string{
+		"Date": withDate, "X-Request-Id": "aaa"})}
+	if pass, _ := Match(tc, base(map[string]string{"Date": withDate}), nil, false, false,
+		zap.NewNop(), false, WithAutoHeaderNoise(true)); pass {
+		t.Fatal("a volatile header the server stopped emitting must still fail")
+	}
+
+	// appeared only in the actual response
+	tc2 := &models.TestCase{Name: "extra", HTTPResp: *base(map[string]string{"Date": withDate})}
+	if pass, _ := Match(tc2, base(map[string]string{"Date": withDate, "X-Request-Id": "zzz"}),
+		nil, false, false, zap.NewNop(), false, WithAutoHeaderNoise(true)); pass {
+		t.Fatal("a volatile header that appeared only on replay must still fail")
+	}
+}
+
+// Headers that are meaningful on a response are NOT in the volatile set, even
+// though they are in FlakyHeaders (which is curated for request volatility).
+func TestMatch_AutoHeaderNoise_KeepsMeaningfulResponseHeadersAsserted(t *testing.T) {
+	for _, hdr := range []string{"Authorization", "X-Csrf-Token", "X-Xsrf-Token", "Idempotency-Key"} {
+		tc := &models.TestCase{Name: hdr, HTTPResp: models.HTTPResp{StatusCode: 200, Body: "ok",
+			Header: map[string]string{"Date": "Mon, 01 Jan 2026 00:00:00 GMT", hdr: "expected"}}}
+		act := &models.HTTPResp{StatusCode: 200, Body: "ok",
+			Header: map[string]string{"Date": "Tue, 02 Jan 2026 00:00:00 GMT", hdr: "DRIFTED"}}
+		if pass, _ := Match(tc, act, nil, false, false, zap.NewNop(), false, WithAutoHeaderNoise(true)); pass {
+			t.Fatalf("%s is meaningful on a response and must stay asserted", hdr)
+		}
+	}
+}

--- a/pkg/models/flaky_headers.go
+++ b/pkg/models/flaky_headers.go
@@ -1,0 +1,169 @@
+package models
+
+import "strings"
+
+// FlakyHeaders lists HTTP header keys (lowercased) that are known to change
+// on every request due to cryptographic signatures, timestamps, credential
+// rotation, or per-request identifiers. These are automatically treated as
+// noise in TWO places, and the list is shared so the two cannot drift:
+//
+//   - egress mock matching, so a replayed request finds its recorded mock
+//     even though these artifacts differ (pkg/agent/proxy/integrations/http);
+//   - the recorded response assertion, so a test does not fail merely because
+//     the application minted a fresh id or timestamp (pkg/service/replay).
+//
+// Both are disabled together by --disableAutoHeaderNoise.
+//
+// It lives in models rather than beside either consumer because importing the
+// agent package from the matcher side would invert the layering, and copying
+// the list guarantees the two copies diverge.
+//
+// No single public library maintains such a list. Most recording/replay
+// tools (VCR, WireMock, Hoverfly) avoid the problem by not matching on
+// headers at all by default. Since Keploy does match on header keys, we
+// maintain this list covering the most common sources of non-determinism.
+//
+// Categories:
+//   - Cloud auth/signing:  AWS SigV4, GCP OAuth, Azure HMAC/Bearer
+//   - Tracing/correlation: W3C Trace Context, B3, Datadog, X-Request-Id
+//   - Webhook signatures:  Stripe, GitHub, Slack, Twilio, Shopify
+//   - SDK metadata:        per-call invocation IDs and attempt counters
+var FlakyHeaders = []string{
+	// ── AWS SigV4 & SDK ──────────────────────────────────────────────
+	"authorization",         // signature changes every request (all cloud providers)
+	"x-amz-date",            // signing timestamp (yyyymmddThhmmssZ)
+	"x-amz-security-token",  // STS/IRSA session token — may appear or disappear
+	"x-amz-content-sha256",  // payload hash
+	"x-amz-credential",      // credential scope string
+	"x-amz-signature",       // explicit signature value (SigV4 query-string variant)
+	"x-amz-signedheaders",   // list of signed headers (varies with SDK)
+	"x-amz-expires",         // pre-signed URL expiry seconds
+	"x-amz-user-agent",      // SDK metadata
+	"x-amzn-trace-id",       // AWS X-Ray trace propagation
+	"amz-sdk-invocation-id", // unique per-call UUID from AWS SDK
+	"amz-sdk-request",       // attempt counter (attempt=1; max=3)
+	"date",                  // SigV4 fallback when X-Amz-Date absent. Globally ignored (Date is dynamic for all HTTP); disable per-test via DisableAutoHeaderNoise.
+
+	// ── GCP ──────────────────────────────────────────────────────────
+	"x-goog-api-client",     // SDK metadata (version, runtime info)
+	"x-goog-request-params", // routing parameters, may change with resource
+
+	// ── Azure ────────────────────────────────────────────────────────
+	"x-ms-date",                     // signing timestamp
+	"x-ms-client-request-id",        // client-generated UUID per call
+	"x-ms-content-sha256",           // body hash for HMAC auth
+	"x-ms-return-client-request-id", // echo control flag
+
+	// ── W3C Trace Context / OpenTelemetry ────────────────────────────
+	"traceparent", // unique trace-id + span-id per request
+	"tracestate",  // vendor-specific trace context
+
+	// ── Zipkin B3 propagation ────────────────────────────────────────
+	"x-b3-traceid",
+	"x-b3-spanid",
+	"x-b3-parentspanid",
+	"x-b3-sampled",
+	"b3", // single-header compact format
+
+	// ── Datadog ──────────────────────────────────────────────────────
+	"x-datadog-trace-id",
+	"x-datadog-parent-id",
+	"x-datadog-sampling-priority",
+	"x-datadog-origin",
+	"x-datadog-tags", // _dd.p.* propagation tags — emitted ONLY when the trace carries at least one (128-bit trace id, sampling decision). Absent whenever it carries none, so its very PRESENCE is per-request.
+
+	// ── Conditionally-emitted propagation headers ────────────────────
+	// Same class as the entries above, and listed separately because the
+	// hazard is different: these are absent outright on some requests rather
+	// than merely carrying a fresh value. HeadersContainKeys is presence-only,
+	// so a recorded header that the live request omits kills the candidate
+	// before any value comparison runs — a value-noise entry would not help.
+	"baggage",      // W3C Baggage (OpenTelemetry, Sentry) — present only when the context has baggage entries
+	"sentry-trace", // Sentry distributed tracing — present only when tracing is enabled for the transaction
+	"x-b3-flags",   // B3 debug flag — present only on debug-sampled traces
+
+	// ── Generic request/correlation IDs ──────────────────────────────
+	"x-request-id",     // Nginx, Envoy, HAProxy, AWS ALB, Heroku
+	"x-correlation-id", // cross-service correlation
+	"request-id",       // ASP.NET Core and others
+
+	// ── Webhook signatures (request-side, inbound webhooks) ──────────
+	"stripe-signature",
+	"x-hub-signature-256", // GitHub
+	"x-hub-signature",     // GitHub (legacy SHA-1)
+	"x-twilio-signature",
+	"x-shopify-hmac-sha256",
+	"x-slack-signature",
+	"x-slack-request-timestamp",
+	"webhook-signature", // Standard Webhooks spec
+	"webhook-timestamp", // Standard Webhooks spec
+	"webhook-id",        // Standard Webhooks spec
+
+	// ── Idempotency / CSRF ───────────────────────────────────────────
+	"idempotency-key",
+	"x-idempotency-key",
+	"x-csrf-token",
+	"x-xsrf-token",
+
+	// ── GCP trace (legacy) ───────────────────────────────────────────
+	"x-cloud-trace-context",
+}
+
+// FlakyHeaderNoise returns FlakyHeaders as a header-noise map: every entry maps
+// to an EMPTY pattern list, which the matcher reads as "ignore this header
+// unconditionally" rather than "ignore it when it matches a regex".
+//
+// A fresh map is returned on every call so a caller is free to mutate it; the
+// current callers only read, but a shared map would make that a trap.
+func FlakyHeaderNoise() map[string][]string {
+	nm := make(map[string][]string, len(FlakyHeaders))
+	for _, h := range FlakyHeaders {
+		nm[h] = []string{}
+	}
+	return nm
+}
+
+// volatileResponseHeaders are response headers a server mints fresh on every
+// call, so comparing their VALUES asserts nothing.
+//
+// Deliberately NOT FlakyHeaders. That list is curated for REQUEST volatility --
+// its own comments say "webhook signatures (inbound)" -- and several entries are
+// meaningful when they appear on a response: a server issues x-csrf-token and
+// ceasing to issue one is a regression worth failing on; idempotency-key echo is
+// a correctness assertion in Stripe-style APIs; authorization appears in
+// token-refresh responses. Suppressing those would delete real coverage.
+//
+// This set is therefore only the identifiers and timing values that are, by
+// construction, different on every response: the HTTP date, request/correlation
+// ids, and distributed-trace ids.
+var volatileResponseHeaders = map[string]struct{}{
+	"date":                  {},
+	"x-request-id":          {},
+	"request-id":            {},
+	"x-correlation-id":      {},
+	"x-runtime":             {}, // Rails: per-request wall time
+	"traceparent":           {},
+	"tracestate":            {},
+	"b3":                    {},
+	"x-b3-traceid":          {},
+	"x-b3-spanid":           {},
+	"x-b3-parentspanid":     {},
+	"x-datadog-trace-id":    {},
+	"x-datadog-parent-id":   {},
+	"x-amzn-trace-id":       {},
+	"x-cloud-trace-context": {},
+	"sentry-trace":          {},
+}
+
+// IsVolatileResponseHeader reports whether name is EXACTLY one of the headers
+// whose response VALUE carries no assertable information, compared
+// case-insensitively.
+//
+// Exactness matters and is why callers must not route this through a noise map:
+// matcher.SubstringKeyMatch resolves noise keys with strings.Contains, so a
+// "date" entry there also suppresses "X-Candidate-Id" and "X-Validate-Token".
+// Consumers must compare header names through this function directly.
+func IsVolatileResponseHeader(name string) bool {
+	_, ok := volatileResponseHeaders[strings.ToLower(name)]
+	return ok
+}

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -3198,7 +3198,7 @@ func (r *Replayer) CompareHTTPResp(tc *models.TestCase, actualResponse *models.H
 		return pass, result
 	}
 
-	pass, result := httpMatcher.Match(tc, actualResponse, noiseConfig, r.config.Test.IgnoreOrdering, r.config.Test.CompareAll, r.logger, emitFailureLogs)
+	pass, result := httpMatcher.Match(tc, actualResponse, noiseConfig, r.config.Test.IgnoreOrdering, r.config.Test.CompareAll, r.logger, emitFailureLogs, r.autoHeaderNoiseOpt())
 	normalizeHTTPRespForReport(tc, actualResponse, originalBodySize)
 
 	return pass, result
@@ -3215,7 +3215,7 @@ func (r *Replayer) compareHTTPRespForReplay(tc *models.TestCase, actualResponse 
 	}
 
 	if emitFailureLogs {
-		pass, result := httpMatcher.Match(tc, cloneHTTPResp(actualResponse), noiseConfig, r.config.Test.IgnoreOrdering, r.config.Test.CompareAll, r.logger, false)
+		pass, result := httpMatcher.Match(tc, cloneHTTPResp(actualResponse), noiseConfig, r.config.Test.IgnoreOrdering, r.config.Test.CompareAll, r.logger, false, r.autoHeaderNoiseOpt())
 		if !pass && r.autoPassHTTPResponseSchemaAddition(tc, actualResponse, testSetID, noiseConfig, result) {
 			normalizeHTTPRespForReport(tc, actualResponse, originalBodySize)
 			return true, result
@@ -3226,13 +3226,24 @@ func (r *Replayer) compareHTTPRespForReplay(tc *models.TestCase, actualResponse 
 		}
 	}
 
-	pass, result := httpMatcher.Match(tc, actualResponse, noiseConfig, r.config.Test.IgnoreOrdering, r.config.Test.CompareAll, r.logger, emitFailureLogs)
+	pass, result := httpMatcher.Match(tc, actualResponse, noiseConfig, r.config.Test.IgnoreOrdering, r.config.Test.CompareAll, r.logger, emitFailureLogs, r.autoHeaderNoiseOpt())
 	normalizeHTTPRespForReport(tc, actualResponse, originalBodySize)
 	if !pass && r.autoPassHTTPResponseSchemaAddition(tc, actualResponse, testSetID, noiseConfig, result) {
 		return true, result
 	}
 
 	return pass, result
+}
+
+// autoHeaderNoiseOpt ignores response headers Keploy already treats as
+// per-request volatile for egress mock matching — X-Request-Id, Date, W3C and
+// Datadog trace ids, cloud signing headers — so a test whose status and body
+// match cannot fail on a value the application mints fresh every call.
+//
+// Honours the existing --disableAutoHeaderNoise flag, which until now only
+// covered mock matching. One switch, both places.
+func (r *Replayer) autoHeaderNoiseOpt() httpMatcher.MatchOption {
+	return httpMatcher.WithAutoHeaderNoise(!r.config.Test.DisableAutoHeaderNoise)
 }
 
 func (r *Replayer) httpNoiseConfig(testSetID string) map[string]map[string][]string {


### PR DESCRIPTION
A recorded case failed on replay with **status 200 matching, body matching, and six of seven headers matching**. The only difference:

```
X-Request-Id: 1aa063751102fc7793c0074ea388ecce   (recorded)
X-Request-Id: e61200457948f19656cab129c18310c9   (replayed)
```

Keploy already knows that header is minted fresh per request — it is in `flakyHeaders` and is auto-noised for **egress mock matching**. Nothing applied that knowledge to the **response assertion**, where the same volatility fails the test outright.

This forgives a **value** difference on the response headers that differ on every call: the HTTP date, request/correlation ids, and distributed-trace ids.

## Three things it deliberately does not do

**It does not reuse `flakyHeaders`.** That list is curated for *request* volatility — its own comments say "webhook signatures (inbound)" — and several entries are meaningful on a response. A server *issues* `x-csrf-token`, and ceasing to issue one is a regression worth failing on; `idempotency-key` echo is a correctness assertion in Stripe-style APIs; `authorization` appears in token-refresh responses. Suppressing those would delete real coverage, so the response set is its own, narrower list. There is a test pinning that those four stay asserted.

**It does not go through the noise map.** `headerNoise` is resolved by `SubstringKeyMatch`, which uses `strings.Contains`. A `date` entry therefore also suppresses any header *containing* that substring:

```
X-Candidate-Id     <- suppressed by "date"
X-Validate-Token   <- suppressed by "date"
X-Web3-Addr        <- suppressed by "b3"
```

Since `Date` is on virtually every response, seeding it would have silently switched off assertions on unrelated headers across the whole suite. I built that version first and measured it: with a `Date` header present, a drifted `X-Candidate-Id` **passed**. The forgiveness is applied to the comparison **result** instead, keyed on the exact header name.

**It does not weaken presence.** `CompareHeaders` reports a missing or unexpected header with a nil `Value` on the absent side, and those stay failures — a server that stops emitting `X-Request-Id`, or starts emitting one it never did, is a real change. An explicit user pattern also still wins: narrowing a header on purpose must not be widened into a blanket ignore.

## Scope and compatibility

Gated by the **existing** `--disableAutoHeaderNoise`, which until now covered only mock matching; its help text now says it covers both. No new flag.

`Match` takes the switch as a **variadic option** rather than a new parameter, because enterprise and k8s-proxy both call `Match` and a signature change would break them on their next OSS bump. Default off at the matcher; the replay caller turns it on unless the flag disables it.

The header list moves to `pkg/models` so the egress matcher and the response assertion cannot drift — `pkg/matcher` must not import `pkg/agent`, and two copies of a 52-entry list diverge.

## Verification

- 7 new tests. **Mutation-tested with a clean 1:1 mapping** — each mutation kills exactly one test, so there are no dead assertions:

| mutation | test killed |
|---|---|
| delete the forgiveness block | `IgnoresPerRequestId` |
| drop the presence guard | `PresenceStillAsserted` |
| drop the user-pattern guard | `UserPatternWins` |

- End-to-end check: `Date` + `X-Request-Id` drift **alone** → passes; the same drift **plus** an `X-Candidate-Id` change → still fails.
- `pkg/matcher` 120 pass / 0 fail (baseline 113/0); `pkg/agent/proxy/integrations/http` **104/104 unchanged**; `pkg/models` 118/0; `pkg/service/replay` 59/0.
- build, `go vet`, `gofmt` clean.