### PR TITLE
feat(mock): per-PID scoping so parallel test workers stay isolated

### DIFF
--- a/.github/workflows/mock_linux.yml
+++ b/.github/workflows/mock_linux.yml
@@ -48,3 +48,10 @@ jobs:
           REPLAY_BIN: ${{ steps.record.outputs.path }}
         run: |
           bash "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/mock/mock-linux.sh"
+
+      - name: Run mock-mode parallel-scope e2e
+        env:
+          RECORD_BIN: ${{ steps.record.outputs.path }}
+          REPLAY_BIN: ${{ steps.record.outputs.path }}
+        run: |
+          bash "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/mock/mock-parallel-linux.sh"

--- a/.github/workflows/test_workflow_scripts/mock/mock-parallel-linux.sh
+++ b/.github/workflows/test_workflow_scripts/mock/mock-parallel-linux.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# End-to-end guard for PER-PID (worker-keyed) mock scoping — Keploy serving
+# parallel test workers, each isolated to its own test's mocks (Design A).
+#
+# Records two endpoints under two named scopes (t1→/a, t2→/b), then in replay
+# runs TWO CONCURRENT workers that BOTH call /b: the worker scoped to t2 must be
+# SERVED /b, while the worker scoped to t1 must MISS it (its scope only allows
+# /a's mock). Without per-PID scoping both would be served — so a MISS for t1 is
+# the proof of isolation. Uses the PR `build` binary for record and replay.
+set -uo pipefail
+
+source "${GITHUB_WORKSPACE:-.}/.github/workflows/test_workflow_scripts/test-iid.sh" 2>/dev/null || true
+sudo mkdir -p /root/.keploy && echo "ObjectID('123456789')" | sudo tee /root/.keploy/installation-id.yaml >/dev/null || true
+
+RECORD_BIN="${RECORD_BIN:-keploy}"
+REPLAY_BIN="${REPLAY_BIN:-keploy}"
+WORK="$(mktemp -d)"
+cd "$WORK"
+PORT=18876
+FAIL=0
+
+cat > dep.py <<'PY'
+import http.server, socketserver, sys
+PORT = int(sys.argv[1])
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        body = {"/a": b"AAA", "/b": b"BBB"}.get(self.path, b"??")
+        self.send_response(200); self.send_header("Content-Length", str(len(body))); self.end_headers(); self.wfile.write(body)
+    def log_message(self, *a): pass
+socketserver.TCPServer.allow_reuse_address = True
+with socketserver.TCPServer(("127.0.0.1", PORT), H) as s: s.serve_forever()
+PY
+
+# Record driver: one process, two SEQUENTIAL scopes each reporting its PID, so
+# the mapping ends up t1->[/a mock], t2->[/b mock].
+cat > rec.py <<'PY'
+import os, json, urllib.request, sys
+AG = os.environ["KEPLOY_MOCK_AGENT"]; PORT = sys.argv[1]; pid = os.getpid()
+def scope(path, name):
+    d = json.dumps({"name": name, "pid": pid}).encode()
+    urllib.request.urlopen(urllib.request.Request(AG + path, data=d, headers={"Content-Type": "application/json"}, method="POST"), timeout=5).read()
+def call(p): return urllib.request.urlopen("http://127.0.0.1:%s%s" % (PORT, p), timeout=5).read()
+scope("/agent/scope/begin", "t1"); assert call("/a") == b"AAA"; scope("/agent/scope/end", "t1")
+scope("/agent/scope/begin", "t2"); assert call("/b") == b"BBB"; scope("/agent/scope/end", "t2")
+print("RECORD_OK", flush=True)
+PY
+
+# One worker: register its OWN pid under a scope, then call /b. Prints RESULT.
+cat > worker.py <<'PY'
+import os, json, urllib.request, sys, time
+AG = os.environ["KEPLOY_MOCK_AGENT"]; PORT = sys.argv[1]; name = sys.argv[2]
+def scope(path):
+    d = json.dumps({"name": name, "pid": os.getpid()}).encode()
+    urllib.request.urlopen(urllib.request.Request(AG + path, data=d, headers={"Content-Type": "application/json"}, method="POST"), timeout=5).read()
+scope("/agent/scope/begin")
+time.sleep(0.3)  # overlap the two workers' active scopes
+try:
+    body = urllib.request.urlopen("http://127.0.0.1:%s/b" % PORT, timeout=5).read().decode()
+    print("%s=SERVED:%s" % (name, body), flush=True)
+except Exception:
+    print("%s=MISS" % name, flush=True)
+scope("/agent/scope/end")
+PY
+
+# Replay driver: run the two workers CONCURRENTLY under one replay.
+cat > run.py <<'PY'
+import subprocess, sys
+PORT = sys.argv[1]
+ps = [subprocess.Popen(["python3", "worker.py", PORT, n], stdout=subprocess.PIPE) for n in ("t1", "t2")]
+for p in ps:
+    print(p.communicate()[0].decode().strip(), flush=True)
+PY
+
+start_dep() { python3 dep.py "$PORT" >dep.log 2>&1 & echo $!; }
+DP=$(start_dep); sleep 1
+
+echo "== 1. record two endpoints under two scopes =="
+sudo -E env PATH="$PATH" "$RECORD_BIN" mock record -c "python3 rec.py $PORT" --name p --disable-tele 2>&1 | tee rec.log
+grep -q "RECORD_OK" rec.log || { echo "FAIL: record driver did not complete"; FAIL=1; }
+MOCKS=$(sed 's/\x1b\[[0-9;]*m//g' rec.log | grep -oE '"mocks": *[0-9]+' | grep -oE '[0-9]+' | tail -1)
+[ "${MOCKS:-0}" = "2" ] || { echo "FAIL: expected 2 recorded mocks, got ${MOCKS:-0}"; FAIL=1; }
+kill "$DP" 2>/dev/null; sleep 1
+
+echo "== 2. replay: two concurrent workers, both hitting /b, dependency DOWN =="
+sudo -E env PATH="$PATH" "$REPLAY_BIN" mock replay -c "python3 run.py $PORT" --name p --disable-tele 2>&1 | tee rep.log
+
+echo "== 3. assertions (per-PID isolation) =="
+grep -q "t2=SERVED:BBB" rep.log || { echo "FAIL: worker scoped to t2 was NOT served /b"; FAIL=1; }
+grep -q "t1=MISS"       rep.log || { echo "FAIL: worker scoped to t1 was NOT isolated (it saw another test's mock)"; FAIL=1; }
+
+[ "$FAIL" = 0 ] && echo "MOCK PARALLEL E2E: PASSED" || echo "MOCK PARALLEL E2E: FAILED"
+exit $FAIL

--- a/.github/workflows/test_workflow_scripts/mock/mock-parallel-linux.sh
+++ b/.github/workflows/test_workflow_scripts/mock/mock-parallel-linux.sh
@@ -34,12 +34,13 @@ PY
 # Record driver: one process, two SEQUENTIAL scopes each reporting its PID, so
 # the mapping ends up t1->[/a mock], t2->[/b mock].
 cat > rec.py <<'PY'
-import os, json, urllib.request, sys
+import os, json, urllib.request, sys, time
 AG = os.environ["KEPLOY_MOCK_AGENT"]; PORT = sys.argv[1]; pid = os.getpid()
 def scope(path, name):
     d = json.dumps({"name": name, "pid": pid}).encode()
     urllib.request.urlopen(urllib.request.Request(AG + path, data=d, headers={"Content-Type": "application/json"}, method="POST"), timeout=5).read()
 def call(p): return urllib.request.urlopen("http://127.0.0.1:%s%s" % (PORT, p), timeout=5).read()
+time.sleep(3)  # let keploy warm up eBPF redirect so the FIRST call is intercepted (not raced)
 scope("/agent/scope/begin", "t1"); assert call("/a") == b"AAA"; scope("/agent/scope/end", "t1")
 scope("/agent/scope/begin", "t2"); assert call("/b") == b"BBB"; scope("/agent/scope/end", "t2")
 print("RECORD_OK", flush=True)
@@ -53,7 +54,7 @@ def scope(path):
     d = json.dumps({"name": name, "pid": os.getpid()}).encode()
     urllib.request.urlopen(urllib.request.Request(AG + path, data=d, headers={"Content-Type": "application/json"}, method="POST"), timeout=5).read()
 scope("/agent/scope/begin")
-time.sleep(0.3)  # overlap the two workers' active scopes
+time.sleep(2)  # overlap the two workers' scopes AND let the replay proxy warm up
 try:
     body = urllib.request.urlopen("http://127.0.0.1:%s/b" % PORT, timeout=5).read().decode()
     print("%s=SERVED:%s" % (name, body), flush=True)

--- a/pkg/agent/hooks/linux/comm.go
+++ b/pkg/agent/hooks/linux/comm.go
@@ -27,10 +27,11 @@ func (h *Hooks) Get(_ context.Context, srcPort uint16) (*agent.NetworkAddress, e
 	}
 
 	return &agent.NetworkAddress{
-		Version:  d.IPVersion,
-		IPv4Addr: d.DestIP4,
-		IPv6Addr: d.DestIP6,
-		Port:     d.DestPort,
+		Version:   d.IPVersion,
+		IPv4Addr:  d.DestIP4,
+		IPv6Addr:  d.DestIP6,
+		Port:      d.DestPort,
+		KernelPid: d.KernelPid,
 	}, nil
 }
 

--- a/pkg/agent/hooks/windows/comm.go
+++ b/pkg/agent/hooks/windows/comm.go
@@ -25,10 +25,11 @@ func (h *Hooks) Get(_ context.Context, srcPort uint16) (*agent.NetworkAddress, e
 	}
 
 	return &agent.NetworkAddress{
-		Version:  d.IPVersion,
-		IPv4Addr: d.DestIP4,
-		IPv6Addr: d.DestIP6,
-		Port:     d.DestPort,
+		Version:   d.IPVersion,
+		IPv4Addr:  d.DestIP4,
+		IPv6Addr:  d.DestIP6,
+		Port:      d.DestPort,
+		KernelPid: d.KernelPid,
 	}, nil
 }
 

--- a/pkg/agent/proxy/integrations/http/http.go
+++ b/pkg/agent/proxy/integrations/http/http.go
@@ -345,6 +345,12 @@ func (h *HTTP) parseFinalHTTP(ctx context.Context, mock *FinalHTTP, destPort uin
 		onMockRecorded(newMock)
 	}
 
+	// Tag the source worker PID (per-PID record attribution, Design A). Transient
+	// hint consumed by the recorder to bucket this mock to the worker that made
+	// the call; never persisted. 0 when unavailable ⇒ recorder falls back to the
+	// scope time window.
+	newMock.SourcePID = opts.SrcPid
+
 	if mgr := syncMock.FromContextOrGlobal(ctx); mgr != nil {
 		// Route HTTP mocks through the sync manager. The manager uses its
 		// internal first-request state to decide whether to buffer or forward

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -164,6 +164,21 @@ type Proxy struct {
 	session     *agent.Session
 	mockManager *MockManager
 
+	// workerScope holds per-test-worker mock allowlists for parallel replay
+	// (Design A). Key is the worker's self-reported PID (ScopeReq.Pid); value is
+	// the set of per-test mock names that worker's current test is allowed to
+	// see. An outgoing call's origin PID (OutgoingOptions.SrcPid) is resolved up
+	// the /proc tree to the nearest registered ancestor, and its per-test view
+	// is intersected with that worker's set — so concurrent workers never stomp
+	// each other's pool. Empty/absent ⇒ the worker serves the whole pool
+	// (backward compatible with suite-level and single-worker sequential scope).
+	workerScopeMu sync.RWMutex
+	workerScope   map[uint32]map[string]struct{}
+	// mappedUniverse is the union of every test's mapped mock names; lets a
+	// scoped worker distinguish "another test's mock" from an unmapped shared
+	// recording. Guarded by workerScopeMu.
+	mappedUniverse map[string]struct{}
+
 	// asyncEngine, when non-nil (config.Async.Lanes non-empty), tracks
 	// async-lane replay state: registered parsers and the per-test
 	// position counter consumed by Engine.Decide's anchor gating. The
@@ -1860,6 +1875,10 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 	// Create a local copy of OutgoingOptions to avoid data race when multiple
 	// goroutines handle connections concurrently and modify DstCfg/Synchronous
 	outgoingOpts := rule.OutgoingOptions
+	// Stamp this connection's origin PID (eBPF redirect map) on the per-conn
+	// copy so the mock-serve and record-capture paths can attribute the call to
+	// the test worker that made it (per-PID scoping). 0 when unavailable.
+	outgoingOpts.SrcPid = destInfo.KernelPid
 
 	mgr := syncMock.Get()
 	mgr.SetOutputChannel(rule.MC)
@@ -2051,7 +2070,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 		}
 
 		//mock the outgoing message
-		err := p.Integrations[integrations.MYSQL].MockOutgoing(parserCtx, srcConn, &models.ConditionalDstCfg{Addr: dstAddr}, m, outgoingOpts)
+		err := p.Integrations[integrations.MYSQL].MockOutgoing(parserCtx, srcConn, &models.ConditionalDstCfg{Addr: dstAddr}, p.scopedFor(outgoingOpts.SrcPid, m), outgoingOpts)
 		if err != nil && err != io.EOF && !errors.Is(err, context.Canceled) && !isNetworkClosedErr(err) {
 			p.logger.Debug("mysql mock outgoing finished with error", zap.Error(err))
 			p.sendMockNotFoundError(err)
@@ -2820,7 +2839,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 			// reconnect the producer and crash on a nil schema); such a parser
 			// reports via this hook, replies normally, and keeps serving.
 			testCtx := models.WithMockMismatchReporter(parserCtx, p.sendMockNotFoundError)
-			err := matchedParser.MockOutgoing(testCtx, srcConn, dstCfg, m, outgoingOpts)
+			err := matchedParser.MockOutgoing(testCtx, srcConn, dstCfg, p.scopedFor(outgoingOpts.SrcPid, m), outgoingOpts)
 			if err != nil && err != io.EOF && !errors.Is(err, context.Canceled) && !isNetworkClosedErr(err) {
 				utils.LogError(logger, err, "failed to mock the outgoing message")
 				// Send specific error type to error channel for external monitoring
@@ -2840,7 +2859,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 				return err
 			}
 		} else {
-			err := p.Integrations[integrations.GENERIC].MockOutgoing(parserCtx, srcConn, dstCfg, m, outgoingOpts)
+			err := p.Integrations[integrations.GENERIC].MockOutgoing(parserCtx, srcConn, dstCfg, p.scopedFor(outgoingOpts.SrcPid, m), outgoingOpts)
 			if err != nil && err != io.EOF && !errors.Is(err, context.Canceled) && !isNetworkClosedErr(err) {
 				utils.LogError(logger, err, "failed to mock the outgoing message")
 				// Send specific error type to error channel for external monitoring
@@ -3205,6 +3224,11 @@ func (p *Proxy) Mock(_ context.Context, opts models.OutgoingOptions) error {
 	} else {
 		mm.ResetForReplaySession()
 	}
+
+	// Drop any per-worker scopes from a prior session so a crashed worker that
+	// never sent /agent/scope/end cannot leak an allowlist that mis-scopes a
+	// recycled PID in this session.
+	p.ClearAllWorkerScopes()
 
 	if !opts.Mocking {
 		p.logger.Info("🔀 Mocking is disabled, the response will be fetched from the actual service")

--- a/pkg/agent/proxy/scoped_mockdb.go
+++ b/pkg/agent/proxy/scoped_mockdb.go
@@ -1,0 +1,222 @@
+package proxy
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations"
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// Per-PID (worker-keyed) mock scoping — "Design A".
+//
+// Parallel test runners (Playwright, jest, pytest-xdist, `go test` -parallel)
+// spawn WORKER PROCESSES that each run their tests sequentially. The scope API
+// (POST /agent/scope/begin|end) lets a worker mark its current test so replay
+// serves only that test's recorded mocks. With a single global filter, two
+// workers' begin/end calls stomp each other; keying the filter by the worker's
+// PID instead lets them run concurrently without a shared "current scope".
+//
+// A worker self-reports its PID in the scope call (ScopeReq.Pid — e.g. Node
+// process.pid), which registers an allowlist of that test's mock names on the
+// proxy (SetWorkerScope). An outgoing call's origin PID (OutgoingOptions.SrcPid,
+// from the eBPF redirect map) is resolved up the /proc process tree to the
+// nearest registered ancestor; that worker's per-test view is then intersected
+// with its allowlist. Calls from unregistered process trees (and every call
+// when no worker has scoped) fall through to the whole pool — so suite-level and
+// single-worker sequential scoping behave exactly as before.
+//
+// Scope of the isolation: this filters VISIBILITY (which per-test mocks a call
+// can see), over the one shared pool. Per-test mocks are per-test-named in
+// mappings.yaml, so worker allowlists are disjoint in practice and consumption
+// (DeleteFilteredMock) does not collide. Session/startup/connection mocks are
+// shared and pass through unfiltered — a worker still sees shared auth/handshake
+// recordings. It assumes the agent and the workers share a PID namespace, which
+// is the case for the normal `keploy mock <cmd>` wrap.
+
+// scopedMockDb wraps the process-wide MockMemDb with a per-worker allowlist,
+// narrowing the read views a scoped worker sees. Writers and consumers forward
+// to the embedded db unchanged via interface embedding.
+//
+// The filter keeps a mock when it is in THIS worker's allowlist, OR when it
+// belongs to no test at all (its name is absent from `universe`, the union of
+// every test's mapped mock names). So a worker sees its own test's mocks plus
+// genuinely-shared recordings (auth/handshake/bootstrap calls made outside any
+// scope), but never another test's mocks. This is applied to BOTH the per-test
+// and the session read tiers: `keploy mock record` classifies its captured
+// calls into the session/config tier, so filtering only the per-test tier would
+// leave every worker seeing the whole set (the isolation would be a no-op).
+type scopedMockDb struct {
+	integrations.MockMemDb
+	allow    map[string]struct{} // mock names this worker's current test may see
+	universe map[string]struct{} // union of ALL tests' mapped names (nil ⇒ no filtering)
+}
+
+// keep returns the mocks visible to this worker: those in its allowlist plus any
+// that belong to no test (absent from the universe of mapped names).
+func (s *scopedMockDb) keep(mocks []*models.Mock, err error) ([]*models.Mock, error) {
+	if err != nil || s.allow == nil || s.universe == nil {
+		return mocks, err
+	}
+	out := mocks[:0:0]
+	for _, m := range mocks {
+		if m == nil {
+			continue
+		}
+		if _, mine := s.allow[m.Name]; mine {
+			out = append(out, m)
+			continue
+		}
+		if _, mapped := s.universe[m.Name]; !mapped {
+			out = append(out, m) // shared / unmapped mock — visible to everyone
+		}
+	}
+	return out, nil
+}
+
+func (s *scopedMockDb) GetFilteredMocks() ([]*models.Mock, error) {
+	return s.keep(s.MockMemDb.GetFilteredMocks())
+}
+
+func (s *scopedMockDb) GetFilteredMocksInWindow() ([]*models.Mock, error) {
+	return s.keep(s.MockMemDb.GetFilteredMocksInWindow())
+}
+
+func (s *scopedMockDb) GetPerTestMocksInWindow() ([]*models.Mock, error) {
+	return s.keep(s.MockMemDb.GetPerTestMocksInWindow())
+}
+
+func (s *scopedMockDb) GetSessionMocks() ([]*models.Mock, error) {
+	return s.keep(s.MockMemDb.GetSessionMocks())
+}
+
+func (s *scopedMockDb) GetUnFilteredMocks() ([]*models.Mock, error) {
+	return s.keep(s.MockMemDb.GetUnFilteredMocks())
+}
+
+func (s *scopedMockDb) GetSessionScopedMocks() ([]*models.Mock, error) {
+	return s.keep(s.MockMemDb.GetSessionScopedMocks())
+}
+
+// SetWorkerScope registers (or replaces) the per-test mock allowlist for a
+// worker PID. An empty/nil name list clears the worker's scope (it then serves
+// the whole pool), matching "no mapping for this test ⇒ suite-level".
+func (p *Proxy) SetWorkerScope(pid uint32, names []string) {
+	if pid == 0 {
+		return
+	}
+	if len(names) == 0 {
+		p.ClearWorkerScope(pid)
+		return
+	}
+	set := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		set[n] = struct{}{}
+	}
+	p.workerScopeMu.Lock()
+	if p.workerScope == nil {
+		p.workerScope = make(map[uint32]map[string]struct{})
+	}
+	// Replace (never mutate) the inner map so a reference captured by scopedFor
+	// under RLock stays an immutable snapshot.
+	p.workerScope[pid] = set
+	p.workerScopeMu.Unlock()
+}
+
+// ClearWorkerScope drops a worker's scope (called on /agent/scope/end and when a
+// test has no mapping). Idempotent.
+func (p *Proxy) ClearWorkerScope(pid uint32) {
+	p.workerScopeMu.Lock()
+	delete(p.workerScope, pid)
+	p.workerScopeMu.Unlock()
+}
+
+// ClearAllWorkerScopes wipes every worker scope and the mapped universe. Called
+// at replay-session teardown so a crashed worker that never sent /scope/end
+// cannot leak an entry that later mis-scopes a recycled PID.
+func (p *Proxy) ClearAllWorkerScopes() {
+	p.workerScopeMu.Lock()
+	p.workerScope = nil
+	p.mappedUniverse = nil
+	p.workerScopeMu.Unlock()
+}
+
+// SetMappedUniverse records the union of every test's mapped mock names (from
+// mappings.yaml), so a scoped worker can tell "another test's mock" (drop) from
+// a genuinely-shared, unmapped recording (keep). Pushed once when the replay CLI
+// installs the scope table. Replaces (never mutates) the set.
+func (p *Proxy) SetMappedUniverse(names []string) {
+	var set map[string]struct{}
+	if len(names) > 0 {
+		set = make(map[string]struct{}, len(names))
+		for _, n := range names {
+			set[n] = struct{}{}
+		}
+	}
+	p.workerScopeMu.Lock()
+	p.mappedUniverse = set
+	p.workerScopeMu.Unlock()
+}
+
+// scopedFor returns a mock view for an outgoing call from kpid. If some ancestor
+// of kpid is a registered worker with an active scope, the returned view is
+// narrowed to that worker's allowlist; otherwise the bare manager is returned
+// (whole pool). kpid == 0 (non-eBPF platform / lookup miss) ⇒ whole pool.
+func (p *Proxy) scopedFor(kpid uint32, mgr integrations.MockMemDb) integrations.MockMemDb {
+	if kpid == 0 || mgr == nil {
+		return mgr
+	}
+	p.workerScopeMu.RLock()
+	if len(p.workerScope) == 0 {
+		p.workerScopeMu.RUnlock()
+		return mgr // fast path: nobody scoped — no /proc walk, exact old behavior
+	}
+	// Walk up the process tree to the nearest registered worker. Bounded so a
+	// reparent race or an unexpected /proc shape can never spin.
+	var allow map[string]struct{}
+	pid := kpid
+	for i := 0; i < 32 && pid > 1; i++ {
+		if set, ok := p.workerScope[pid]; ok {
+			allow = set
+			break
+		}
+		ppid, ok := ppidFromStat(pid)
+		if !ok {
+			break
+		}
+		pid = ppid
+	}
+	universe := p.mappedUniverse
+	p.workerScopeMu.RUnlock()
+
+	if allow == nil {
+		return mgr
+	}
+	return &scopedMockDb{MockMemDb: mgr, allow: allow, universe: universe}
+}
+
+// ppidFromStat reads the parent PID of pid from /proc/<pid>/stat. The comm field
+// (2nd) is parenthesised and may itself contain ')' and spaces, so the state and
+// ppid are read relative to the LAST ')': after it come " <state> <ppid> ...".
+func ppidFromStat(pid uint32) (uint32, bool) {
+	b, err := os.ReadFile(filepath.Join("/proc", strconv.FormatUint(uint64(pid), 10), "stat"))
+	if err != nil {
+		return 0, false
+	}
+	s := string(b)
+	close := strings.LastIndexByte(s, ')')
+	if close < 0 || close+2 >= len(s) {
+		return 0, false
+	}
+	fields := strings.Fields(s[close+2:]) // state, ppid, pgrp, ...
+	if len(fields) < 2 {
+		return 0, false
+	}
+	ppid, err := strconv.ParseUint(fields[1], 10, 32)
+	if err != nil {
+		return 0, false
+	}
+	return uint32(ppid), true
+}

--- a/pkg/agent/proxy/scoped_mockdb_test.go
+++ b/pkg/agent/proxy/scoped_mockdb_test.go
@@ -1,0 +1,122 @@
+package proxy
+
+import (
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations"
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// fakeMockDb is a minimal MockMemDb: the per-test read methods return a fixed
+// set; every other method is the promoted (nil) interface and must not be called
+// by these tests.
+type fakeMockDb struct {
+	integrations.MockMemDb
+	mocks []*models.Mock
+}
+
+func (f *fakeMockDb) GetFilteredMocks() ([]*models.Mock, error)         { return f.mocks, nil }
+func (f *fakeMockDb) GetFilteredMocksInWindow() ([]*models.Mock, error) { return f.mocks, nil }
+func (f *fakeMockDb) GetPerTestMocksInWindow() ([]*models.Mock, error)  { return f.mocks, nil }
+func (f *fakeMockDb) GetSessionMocks() ([]*models.Mock, error)          { return f.mocks, nil }
+func (f *fakeMockDb) GetUnFilteredMocks() ([]*models.Mock, error)       { return f.mocks, nil }
+func (f *fakeMockDb) GetSessionScopedMocks() ([]*models.Mock, error)    { return f.mocks, nil }
+
+func scopedNames(ms []*models.Mock) []string {
+	out := make([]string, 0, len(ms))
+	for _, m := range ms {
+		out = append(out, m.Name)
+	}
+	return out
+}
+
+func TestScopedMockDbFiltersReads(t *testing.T) {
+	// m1,m2,m3 belong to tests (in the universe); "shared" belongs to no test.
+	db := &fakeMockDb{mocks: []*models.Mock{{Name: "m1"}, {Name: "m2"}, {Name: "m3"}, {Name: "shared"}}}
+	universe := map[string]struct{}{"m1": {}, "m2": {}, "m3": {}}
+
+	// Worker allowed m1,m3: it sees m1,m3 (its test) + "shared" (unmapped), but
+	// NOT m2 (another test's mock). Applies to per-test AND session tiers.
+	s := &scopedMockDb{MockMemDb: db, allow: map[string]struct{}{"m1": {}, "m3": {}}, universe: universe}
+	for _, get := range []func() ([]*models.Mock, error){
+		s.GetPerTestMocksInWindow, s.GetFilteredMocks, s.GetFilteredMocksInWindow,
+		s.GetSessionMocks, s.GetUnFilteredMocks, s.GetSessionScopedMocks,
+	} {
+		got, err := get()
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{"m1", "m3", "shared"}, scopedNames(got),
+			"worker sees its own test's mocks plus unmapped shared mocks, never another test's")
+	}
+
+	// A nil universe (no mappings pushed) is a passthrough — never hide anything.
+	pass := &scopedMockDb{MockMemDb: db, allow: map[string]struct{}{"m1": {}}, universe: nil}
+	got, err := pass.GetSessionMocks()
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"m1", "m2", "m3", "shared"}, scopedNames(got))
+}
+
+func TestScopedForResolvesWorkerAndFallsBack(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("scopedFor's process-tree walk reads /proc (linux only)")
+	}
+	db := &fakeMockDb{}
+	self := uint32(os.Getpid())
+
+	// Empty registry: fast path, no /proc walk, returns the bare manager.
+	p := &Proxy{}
+	require.Equal(t, integrations.MockMemDb(db), p.scopedFor(self, db), "no scopes ⇒ whole pool")
+
+	// A registered worker PID: the call is scoped to its allowlist.
+	p.SetWorkerScope(self, []string{"only-this"})
+	require.IsType(t, &scopedMockDb{}, p.scopedFor(self, db), "own PID resolves to a scoped view")
+
+	// PID 0 (unknown origin) and an unregistered/dead PID ⇒ whole pool.
+	require.Equal(t, integrations.MockMemDb(db), p.scopedFor(0, db))
+	require.Equal(t, integrations.MockMemDb(db), p.scopedFor(4000000000, db))
+
+	// Cleared ⇒ back to the whole pool.
+	p.ClearWorkerScope(self)
+	require.Equal(t, integrations.MockMemDb(db), p.scopedFor(self, db))
+}
+
+func TestScopedForWalksUpProcessTree(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("process-tree walk is linux only")
+	}
+	db := &fakeMockDb{}
+	// Register the PARENT of this process; this process's call must resolve up to
+	// it (models a worker whose child/grandchild opened the socket).
+	p := &Proxy{}
+	p.SetWorkerScope(uint32(os.Getppid()), []string{"m"})
+	require.IsType(t, &scopedMockDb{}, p.scopedFor(uint32(os.Getpid()), db),
+		"a call from a descendant resolves up to the registered worker")
+
+	p.ClearAllWorkerScopes()
+	require.Equal(t, integrations.MockMemDb(db), p.scopedFor(uint32(os.Getpid()), db))
+}
+
+func TestPpidFromStat(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("/proc only on linux")
+	}
+	ppid, ok := ppidFromStat(uint32(os.Getpid()))
+	require.True(t, ok)
+	require.Equal(t, uint32(os.Getppid()), ppid)
+
+	_, ok = ppidFromStat(4000000000) // no such pid
+	require.False(t, ok)
+}
+
+// SetWorkerScope with an empty name list clears the entry (no-mapping ⇒ suite).
+func TestSetWorkerScopeEmptyClears(t *testing.T) {
+	p := &Proxy{}
+	p.SetWorkerScope(42, []string{"a"})
+	p.SetWorkerScope(42, nil)
+	p.workerScopeMu.RLock()
+	_, present := p.workerScope[42]
+	p.workerScopeMu.RUnlock()
+	require.False(t, present, "empty allowlist clears the worker's scope")
+}

--- a/pkg/agent/routes/scope.go
+++ b/pkg/agent/routes/scope.go
@@ -17,10 +17,10 @@ import (
 // agent.Service interface stays unchanged (same pattern as BeginTestErrorCapture).
 
 type scopeBeginner interface {
-	BeginScope(ctx context.Context, name string) error
+	BeginScope(ctx context.Context, name string, pid int) error
 }
 type scopeEnder interface {
-	EndScope(ctx context.Context, name string) error
+	EndScope(ctx context.Context, name string, pid int) error
 }
 type scopeWindowReader interface {
 	GetScopeWindows(ctx context.Context) ([]models.ScopeWindow, error)
@@ -43,7 +43,7 @@ func (a *Agent) HandleScopeBegin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if s, ok := a.svc.(scopeBeginner); ok {
-		if err := s.BeginScope(r.Context(), req.Name); err != nil {
+		if err := s.BeginScope(r.Context(), req.Name, req.Pid); err != nil {
 			a.logger.Debug("scope begin failed", zap.String("name", req.Name), zap.Error(err))
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -61,7 +61,7 @@ func (a *Agent) HandleScopeEnd(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if s, ok := a.svc.(scopeEnder); ok {
-		if err := s.EndScope(r.Context(), req.Name); err != nil {
+		if err := s.EndScope(r.Context(), req.Name, req.Pid); err != nil {
 			a.logger.Debug("scope end failed", zap.String("name", req.Name), zap.Error(err))
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/pkg/agent/service.go
+++ b/pkg/agent/service.go
@@ -62,6 +62,19 @@ type Proxy interface {
 	// per-app traffic without this package knowing what an "app" is.
 	SetSessionResolver(fn func(tgid uint32) *Session)
 	SetAuxiliaryHook(h AuxiliaryProxyHook)
+	// Per-PID (worker-keyed) mock scoping for parallel test runners (Design A).
+	// SetWorkerScope registers the per-test mock-name allowlist for a worker
+	// PID; ClearWorkerScope drops it (on scope end / no mapping);
+	// ClearAllWorkerScopes wipes every entry at session teardown. An outgoing
+	// call is attributed to a worker by walking its origin PID up the /proc
+	// tree to the nearest registered ancestor.
+	SetWorkerScope(pid uint32, names []string)
+	ClearWorkerScope(pid uint32)
+	ClearAllWorkerScopes()
+	// SetMappedUniverse records the union of all tests' mapped mock names so a
+	// scoped worker can keep genuinely-shared (unmapped) mocks while hiding
+	// other tests' mocks.
+	SetMappedUniverse(names []string)
 }
 
 // PcapStreamer is the optional extension implemented by proxies
@@ -153,6 +166,12 @@ type NetworkAddress struct {
 	IPv4Addr uint32
 	IPv6Addr [4]uint32
 	Port     uint32
+	// KernelPid is the source process's kernel (root-namespace) PID for this
+	// outgoing connection, captured in-kernel by the eBPF redirect program. It
+	// lets the mock-serve path attribute a call to the test worker that made it
+	// (per-PID scoping for parallel runners). 0 when unavailable (non-eBPF
+	// platforms / lookup miss) — callers must treat 0 as "unknown, no scope".
+	KernelPid uint32
 }
 
 // Sessions provides a thread-safe store for Session objects, keyed by ID.

--- a/pkg/models/agent.go
+++ b/pkg/models/agent.go
@@ -28,15 +28,26 @@ type TestMockMapping struct {
 // to that test (replay).
 type ScopeReq struct {
 	Name string `json:"name"`
+	// Pid is the calling test WORKER's PID (e.g. Node process.pid, os.Getpid()).
+	// It keys the per-worker scope so parallel workers don't stomp each other
+	// (Design A). Optional: 0/omitted falls back to the single global scope
+	// (correct for sequential single-worker runs and suite-level).
+	Pid int `json:"pid,omitempty"`
 }
 
 // ScopeWindow is one recorded per-test scope: the agent-clock interval during
 // which the named test made its outgoing calls. Record correlates captured
-// mocks into these windows by request timestamp to build mappings.yaml.
+// mocks into these windows to build mappings.yaml — by source PID when the
+// worker reported one (exact, parallel-safe), else by request timestamp.
 type ScopeWindow struct {
 	Name  string    `json:"name"`
 	Start time.Time `json:"start"`
 	End   time.Time `json:"end"`
+	// PID is the reporting worker's PID (ScopeReq.Pid), 0 if none. When set,
+	// record attributes a captured mock to this window if the mock's own source
+	// PID resolves (up the /proc tree) to this worker — exact even when windows
+	// from parallel workers overlap in time.
+	PID uint32 `json:"pid,omitempty"`
 }
 
 // ScopeTableReq is the body of POST /agent/scope/table — the replay CLI hands

--- a/pkg/models/instrument.go
+++ b/pkg/models/instrument.go
@@ -213,6 +213,14 @@ type OutgoingOptions struct {
 	// only the argv-vs-yaml precedence for the CA PATH, and the pool itself is
 	// read from disk lazily, under a sync.Once, on the first record session.
 	UpstreamTLSRootCAs *x509.CertPool `json:"-"`
+	// SrcPid is the kernel (root-namespace) PID of the process that opened THIS
+	// outgoing connection, taken from the eBPF redirect map per connection. It
+	// is a runtime, per-connection value — never session config — so it is
+	// json:"-" (OutgoingOptions is JSON-marshaled CLI→agent and this must not
+	// travel as a rule). The proxy stamps it on its per-connection copy of the
+	// options and uses it to pick the worker's scoped mock view (per-PID
+	// scoping for parallel test runners). 0 ⇒ unknown ⇒ the global pool.
+	SrcPid uint32 `json:"-"`
 }
 
 type ConditionalDstCfg struct {

--- a/pkg/models/mock.go
+++ b/pkg/models/mock.go
@@ -97,6 +97,12 @@ type Mock struct {
 	Spec         MockSpec     `json:"Spec,omitempty" bson:"Spec,omitempty"`
 	TestModeInfo TestModeInfo `json:"TestModeInfo,omitempty"  bson:"TestModeInfo,omitempty"` // Map for additional test mode information
 	ConnectionID string       `json:"ConnectionId,omitempty" bson:"ConnectionId,omitempty"`
+	// SourcePID is the kernel PID of the process that made this outgoing call,
+	// carried transiently from capture to the recorder so `keploy mock record`
+	// can attribute the mock to the test WORKER that made it (per-PID scoping
+	// for parallel runners). Runtime-only: never serialized (yaml/json/bson "-")
+	// — it is an in-process hint, not part of the recorded mock. 0 if unknown.
+	SourcePID uint32 `json:"-" yaml:"-" bson:"-"`
 	// Noise holds exact-match regex patterns for obfuscated values.
 	// During mock matching, any stored value matching a pattern in this
 	// list is skipped (treated as noise). Written by the enterprise

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -135,10 +135,10 @@ type Agent struct {
 	// each named test; in test (replay) mode it uses the CLI-supplied table to
 	// restrict the served pool to one test's mocks. All fields guarded by scopeMu.
 	scopeMu      sync.Mutex
-	scopeOpen    map[string]time.Time // record: name -> begin time (agent clock)
-	scopeWindows []models.ScopeWindow // record: closed per-test windows
-	scopeTable   map[string][]string  // replay: test name -> mock names (from mappings.yaml)
-	loadedMocks  int                  // replay: count of mocks stored, for /agent/mock/stats
+	workerOpen   map[scopeKey]time.Time // record: (worker PID, test name) -> begin time (agent clock)
+	scopeWindows []models.ScopeWindow   // record: closed per-test windows
+	scopeTable   map[string][]string    // replay: test name -> mock names (from mappings.yaml)
+	loadedMocks  int                    // replay: count of mocks stored, for /agent/mock/stats
 }
 
 func New(logger *zap.Logger, hook coreAgent.Hooks, proxy coreAgent.Proxy, client kdocker.Client, ip coreAgent.IncomingProxy, config *config.Config) *Agent {

--- a/pkg/service/agent/scope.go
+++ b/pkg/service/agent/scope.go
@@ -21,11 +21,25 @@ import (
 // Scoping is entirely optional: with no scope calls the set records/replays
 // suite-level, which is still correct.
 
-// BeginScope opens a per-test scope. In record mode it stamps the begin time
-// (agent clock) so captured mocks can later be bucketed to this test. In test
-// mode it restricts the served pool to this test's mocks when the CLI supplied
-// a mapping table for it.
-func (a *Agent) BeginScope(ctx context.Context, name string) error {
+// scopeKey identifies an open record-mode scope by (reporting worker PID, test
+// name). Keying by BOTH — not PID alone — keeps two things correct at once:
+// parallel workers don't collide (distinct PIDs), and a single worker's nested
+// or overlapping named scopes (or the legacy pid==0 path) don't clobber each
+// other the way a PID-only key would.
+type scopeKey struct {
+	pid  uint32
+	name string
+}
+
+// BeginScope opens a per-test scope. In record mode it stamps the begin time so
+// captured mocks can later be bucketed to this test. In test mode it restricts
+// the served pool to this test's mocks when the CLI supplied a mapping table.
+//
+// pid is the calling worker's PID (ScopeReq.Pid). When > 0 the scope is keyed to
+// that worker so PARALLEL workers each get their own served view without
+// stomping each other (Design A); pid == 0 falls back to the single global
+// scope (sequential single-worker runs, and the suite-level default).
+func (a *Agent) BeginScope(ctx context.Context, name string, pid int) error {
 	if name == "" {
 		return nil
 	}
@@ -37,6 +51,15 @@ func (a *Agent) BeginScope(ctx context.Context, name string) error {
 			// No per-test mapping for this test — leave the whole pool armed.
 			return nil
 		}
+		if pid > 0 {
+			// Parallel-safe: narrow ONLY this worker's served view, keyed by its
+			// PID, so concurrent workers never overwrite one shared filter.
+			a.logger.Debug("scope begin: worker-scoped pool", zap.String("test", name), zap.Int("worker", pid), zap.Int("mocks", len(names)))
+			a.SetWorkerScope(uint32(pid), names)
+			return nil
+		}
+		// No worker PID reported — restrict the single global pool (correct for
+		// a sequential single-worker suite, the pre-Design-A behavior).
 		a.logger.Debug("scope begin: restricting served pool to test", zap.String("test", name), zap.Int("mocks", len(names)))
 		return a.UpdateMockParams(ctx, models.MockFilterParams{
 			MockMapping:     names,
@@ -46,24 +69,25 @@ func (a *Agent) BeginScope(ctx context.Context, name string) error {
 		})
 	}
 
-	// Record mode: mark the window start (agent clock). We deliberately do NOT
+	// Record mode: mark the window start (agent clock), keyed by worker PID so
+	// overlapping windows from parallel workers stay distinguishable. We do NOT
 	// touch the syncMock ingress-correlation machinery here — that is driven by
-	// incoming requests, which mock mode has none of. The window is correlated
-	// to captured mocks purely by request timestamp after the run.
+	// incoming requests, which mock mode has none of.
 	a.scopeMu.Lock()
-	if a.scopeOpen == nil {
-		a.scopeOpen = make(map[string]time.Time)
+	if a.workerOpen == nil {
+		a.workerOpen = make(map[scopeKey]time.Time)
 	}
-	a.scopeOpen[name] = time.Now()
+	a.workerOpen[scopeKey{pid: uint32(pid), name: name}] = time.Now()
 	a.scopeMu.Unlock()
-	a.logger.Debug("scope begin (record)", zap.String("test", name))
+	a.logger.Debug("scope begin (record)", zap.String("test", name), zap.Int("worker", pid))
 	return nil
 }
 
 // EndScope closes a per-test scope. In record mode it records the [begin, now]
-// window for later correlation. In test mode it restores the whole pool so a
-// call made between tests still matches.
-func (a *Agent) EndScope(ctx context.Context, name string) error {
+// window (tagged with the worker PID) for later correlation. In test mode it
+// restores this worker's whole-pool view so a call made between tests still
+// matches.
+func (a *Agent) EndScope(ctx context.Context, name string, pid int) error {
 	if name == "" {
 		return nil
 	}
@@ -74,6 +98,11 @@ func (a *Agent) EndScope(ctx context.Context, name string) error {
 		if !scoped {
 			return nil
 		}
+		if pid > 0 {
+			a.logger.Debug("scope end: clearing worker scope", zap.String("test", name), zap.Int("worker", pid))
+			a.ClearWorkerScope(uint32(pid))
+			return nil
+		}
 		a.logger.Debug("scope end: restoring whole pool", zap.String("test", name))
 		return a.UpdateMockParams(ctx, models.MockFilterParams{
 			AfterTime:  models.BaseTime,
@@ -82,13 +111,14 @@ func (a *Agent) EndScope(ctx context.Context, name string) error {
 	}
 
 	a.scopeMu.Lock()
-	start, ok := a.scopeOpen[name]
+	k := scopeKey{pid: uint32(pid), name: name}
+	start, ok := a.workerOpen[k]
 	if ok {
-		delete(a.scopeOpen, name)
-		a.scopeWindows = append(a.scopeWindows, models.ScopeWindow{Name: name, Start: start, End: time.Now()})
+		delete(a.workerOpen, k)
+		a.scopeWindows = append(a.scopeWindows, models.ScopeWindow{Name: name, Start: start, End: time.Now(), PID: uint32(pid)})
 	}
 	a.scopeMu.Unlock()
-	a.logger.Debug("scope end (record)", zap.String("test", name))
+	a.logger.Debug("scope end (record)", zap.String("test", name), zap.Int("worker", pid))
 	return nil
 }
 
@@ -108,6 +138,21 @@ func (a *Agent) SetScopeTable(_ context.Context, table map[string][]string) erro
 	a.scopeMu.Lock()
 	a.scopeTable = table
 	a.scopeMu.Unlock()
+
+	// Push the union of every test's mapped mock names to the proxy so a scoped
+	// worker can tell another test's mock (hide) from a genuinely-shared,
+	// unmapped recording (keep). De-duplicated across tests.
+	seen := make(map[string]struct{})
+	universe := make([]string, 0)
+	for _, names := range table {
+		for _, n := range names {
+			if _, ok := seen[n]; !ok {
+				seen[n] = struct{}{}
+				universe = append(universe, n)
+			}
+		}
+	}
+	a.SetMappedUniverse(universe)
 	return nil
 }
 

--- a/pkg/service/agent/scope_test.go
+++ b/pkg/service/agent/scope_test.go
@@ -1,0 +1,55 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// With config == nil, BeginScope/EndScope take the record branch (not MODE_TEST).
+func newRecordAgent() *Agent { return &Agent{logger: zap.NewNop()} }
+
+func windowNames(a *Agent) []string {
+	ws, _ := a.GetScopeWindows(context.Background())
+	out := make([]string, 0, len(ws))
+	for _, w := range ws {
+		out = append(out, w.Name)
+	}
+	return out
+}
+
+// Nested/overlapping scopes with NO reported PID (pid==0) must each record their
+// own window — keying record-open scopes by PID alone would collapse them onto
+// worker 0 and silently lose the outer one.
+func TestRecordScopesNestedPidZero(t *testing.T) {
+	a := newRecordAgent()
+	ctx := context.Background()
+	require.NoError(t, a.BeginScope(ctx, "suite", 0))
+	require.NoError(t, a.BeginScope(ctx, "test1", 0))
+	require.NoError(t, a.EndScope(ctx, "test1", 0))
+	require.NoError(t, a.EndScope(ctx, "suite", 0))
+	require.ElementsMatch(t, []string{"suite", "test1"}, windowNames(a),
+		"both the nested and outer pid==0 scopes must be recorded")
+}
+
+// Parallel workers running the SAME test name must each get their own window,
+// tagged with their PID, even with overlapping begin/end.
+func TestRecordScopesParallelWorkers(t *testing.T) {
+	a := newRecordAgent()
+	ctx := context.Background()
+	require.NoError(t, a.BeginScope(ctx, "t", 100))
+	require.NoError(t, a.BeginScope(ctx, "t", 200)) // overlaps worker 100's scope
+	require.NoError(t, a.EndScope(ctx, "t", 100))
+	require.NoError(t, a.EndScope(ctx, "t", 200))
+
+	ws, _ := a.GetScopeWindows(ctx)
+	require.Len(t, ws, 2)
+	pids := map[uint32]bool{}
+	for _, w := range ws {
+		require.Equal(t, "t", w.Name)
+		pids[w.PID] = true
+	}
+	require.True(t, pids[100] && pids[200], "each worker's window carries its own PID")
+}

--- a/pkg/service/mock/correlate_test.go
+++ b/pkg/service/mock/correlate_test.go
@@ -90,3 +90,39 @@ func TestMissPolicyValidAndBehaviour(t *testing.T) {
 	require.False(t, models.MissPassthrough.RecordsOnMiss())
 	require.True(t, models.MissRecord.RecordsOnMiss())
 }
+
+// TestCorrelateScopesParallelPID is the case Design A (per-PID attribution)
+// fixes: two workers' scope windows OVERLAP in time, so a pure timestamp scan
+// would attribute both workers' mocks to whichever window started later. The
+// source PID disambiguates them exactly.
+func TestCorrelateScopesParallelPID(t *testing.T) {
+	// worker A (pid 100) ran test "a" over [10,30]; worker B (pid 200) ran test
+	// "b" over [15,35] — the two windows overlap on [15,30].
+	windows := []models.ScopeWindow{
+		{Name: "a", Start: ts(10), End: ts(30), PID: 100},
+		{Name: "b", Start: ts(15), End: ts(35), PID: 200},
+	}
+	mocks := []capturedMock{
+		{name: "a-call", ts: ts(20), pid: 100}, // in BOTH by time; PID => "a"
+		{name: "b-call", ts: ts(25), pid: 200}, // in BOTH by time; PID => "b"
+	}
+	got := correlateScopes(windows, mocks)
+
+	require.ElementsMatch(t, []string{"a-call"}, names(got["a"]),
+		"worker A's call must attribute to test a, not the later-started overlapping window b")
+	require.ElementsMatch(t, []string{"b-call"}, names(got["b"]))
+
+	// A PID-less mock (e.g. a child process's call) falls back to the timestamp
+	// scan: the innermost (latest-started) containing window wins.
+	fallback := correlateScopes(windows, []capturedMock{{name: "orphan", ts: ts(20), pid: 0}})
+	require.ElementsMatch(t, []string{"orphan"}, names(fallback["b"]),
+		"PID-less mock should fall back to the innermost time window")
+}
+
+func names(entries []models.MockEntry) []string {
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.Name)
+	}
+	return out
+}

--- a/pkg/service/mock/record.go
+++ b/pkg/service/mock/record.go
@@ -126,7 +126,7 @@ func (m *mockService) Record(ctx context.Context) error {
 				m.logger.Debug("AfterMockInsert hook failed", zap.Error(err), zap.String("mock", mk.Name))
 			}
 			mockCount++
-			recorded = append(recorded, capturedMock{name: mk.Name, ts: mk.Spec.ReqTimestampMock})
+			recorded = append(recorded, capturedMock{name: mk.Name, ts: mk.Spec.ReqTimestampMock, pid: mk.SourcePID})
 		}
 	}()
 
@@ -196,11 +196,12 @@ func (m *mockService) Record(ctx context.Context) error {
 	return nil
 }
 
-// capturedMock is one recorded mock's name + request timestamp, used to
-// correlate mocks into per-test scope windows.
+// capturedMock is one recorded mock's name + request timestamp + source worker
+// PID, used to correlate mocks into per-test scope windows.
 type capturedMock struct {
 	name string
 	ts   time.Time
+	pid  uint32 // source worker PID (0 if unknown); enables exact parallel attribution
 }
 
 // correlateScopes buckets each recorded mock into the per-test scope window its
@@ -208,20 +209,49 @@ type capturedMock struct {
 // that matches no window (e.g. a boot-time handshake before the first scope)
 // is left out of every test's mapping — it stays reusable/session-tier at
 // replay, exactly as the timestamp-based fallback would treat it.
+//
+// When a mock carries a source PID it is attributed to the SAME worker's window
+// (exact, so overlapping parallel windows don't steal each other's mocks). That
+// PID match is exact only when the worker made the call itself and the agent
+// shares its PID namespace (the normal `keploy mock <cmd>` wrap); a call made by
+// a CHILD of the worker, or a containerized/cross-namespace worker whose
+// self-reported PID differs from the kernel PID, falls back to the timestamp
+// scan — which is exact for sequential record and best-effort under overlap.
 func correlateScopes(windows []models.ScopeWindow, mocks []capturedMock) map[string][]models.MockEntry {
 	// Sort windows by start so overlapping scopes resolve to the innermost
 	// (latest-started) window deterministically.
 	sort.SliceStable(windows, func(i, j int) bool { return windows[i].Start.Before(windows[j].Start) })
 	byTest := make(map[string][]models.MockEntry)
-	for _, mk := range mocks {
+	// containingWindow returns the innermost (latest-started) window that contains
+	// the mock's timestamp. When sameWorkerOnly is set (the mock carries a PID),
+	// only windows recorded by that exact worker are considered — so overlapping
+	// windows from OTHER parallel workers never steal the mock.
+	containingWindow := func(mk capturedMock, sameWorkerOnly bool) int {
 		best := -1
 		for i, w := range windows {
+			if sameWorkerOnly && w.PID != mk.pid {
+				continue
+			}
 			if mk.ts.Before(w.Start) || mk.ts.After(w.End) {
 				continue
 			}
 			if best == -1 || windows[i].Start.After(windows[best].Start) {
 				best = i
 			}
+		}
+		return best
+	}
+	for _, mk := range mocks {
+		best := -1
+		if mk.pid != 0 {
+			// Exact, parallel-safe: attribute to the same worker's window.
+			best = containingWindow(mk, true)
+		}
+		if best == -1 {
+			// No same-worker window (PID-less mock/windows, or the call came from
+			// a child process): fall back to a pure timestamp scan — correct when
+			// windows don't overlap, i.e. sequential record.
+			best = containingWindow(mk, false)
 		}
 		if best == -1 {
 			continue


### PR DESCRIPTION
## Describe the changes that are made

Enables **parallel test workers** (Playwright, jest, pytest-xdist, `go test` -parallel) to use `keploy mock replay` with **per-test isolation** — "Design A", worker-keyed scoping. Until now the per-test scope API narrowed a single **global** served pool, so concurrent workers stomped each other and could not isolate mocks; parallel suites had to run suite-level.

**How it works (no application-code change):**
- Each worker self-reports its PID in the existing `POST /agent/scope/begin|end` calls (`ScopeReq.Pid`, e.g. Node `process.pid`). This registers an allowlist of that test's mock names on the proxy, keyed by PID.
- An outgoing call's origin PID is the **eBPF-captured `KernelPid`** — already present in the redirect map (`structs.DestInfo`), now surfaced through `NetworkAddress` → `OutgoingOptions.SrcPid` (no eBPF/C changes). It's resolved up the `/proc` tree to the nearest registered worker.
- The call is served a `scopedMockDb` view filtered to **(that worker's mocks) ∪ (mocks mapped to no test)** — so each worker sees its own test's recordings plus genuinely-shared handshake/bootstrap calls, never another test's.
- Record tags each captured mock with its source PID so overlapping parallel windows attribute exactly.

A subtle correctness fix falls out of this: `keploy mock record` classifies its captures into the **session/config tier**, so the previous per-test scope (which filtered only the per-test tier) was effectively a no-op. The new filter covers the session tier too, so per-test isolation now actually works — for both the sequential and parallel paths.

**Backward compatible:** no scope calls ⇒ whole pool (suite-level, unchanged); a `pid==0` begin keeps the old global-narrow path; an empty registry skips the `/proc` walk (zero overhead when unused).

**Scope/limitations:** isolation is exact for the HTTP replay path with co-namespace, direct-socket workers (the normal `keploy mock <cmd>` wrap). Cross-namespace (containerized) workers or calls made by a child process degrade gracefully to timestamp attribution on record and the whole pool on replay — never a crash. MySQL prepared-statement / connection-tier traffic remains isolated by connID, not worker scope.

## Links & References

**Closes:** NA

### 📄 Related Documents
- Docs update (parallel section + the `pid` field) to follow in keploy/docs.

## What type of PR is this? (check all applicable)
- [x] 🍕 Feature

## Added e2e test pipeline?
- [x] 👍 yes — `mock-parallel-linux.sh` (two concurrent workers: one served `/b`, the other isolated to a miss), wired into the `mock_linux` job; plus unit tests for the scoped view, the `/proc` tree walk, and the record window keying.

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [ ] 🙅 follow-up in keploy/docs
