### PR TITLE
chore(go): move the toolchain to Go 1.27.0

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -67,15 +67,24 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          # PINNED, not floating. golangci-lint v2.13.0 (released 2026-08-19,
-          # 23:29 UTC) bundles honnef.co/go/tools v0.8.0-rc.1, whose nilness
-          # analyzer panics with "internal error: unhandled builtin recover" on
-          # Go 1.26 — reproduced locally against the sentry dependency. Because
-          # the action resolves the newest release at run time, that single
-          # upstream publish turned every PR in this repo red within hours,
-          # including PRs containing no Go code at all. A pin means an upstream
-          # release can no longer break CI without someone choosing it.
-          version: v2.12.2
+          # PINNED, not floating: the action resolves the newest release at
+          # run time, so a single upstream publish can turn every PR in this
+          # repo red (that is exactly what v2.13.0 did — see below). A pin
+          # means an upstream release can no longer break CI without someone
+          # choosing it.
+          #
+          # This pin is coupled to the Go toolchain in go.mod and cannot lag
+          # behind it. Each release here bundles a fixed honnef.co/go/tools
+          # (staticcheck), whose IR builder must understand the stdlib of the
+          # Go version it analyzes:
+          #   v2.12.2  -> honnef v0.7.0      crashes on Go 1.27: "buildir:
+          #               package "poll" ... unexpected expr: *ast.KeyValueExpr"
+          #               (reproduced locally on go1.27.0).
+          #   v2.13.0  -> honnef v0.8.0-rc.1 nilness panics with "internal
+          #               error: unhandled builtin recover" on Go 1.26.
+          #   v2.13.1  -> honnef v0.8.0      clean on go1.27.0 (verified
+          #               locally: `golangci-lint run` reports 0 issues).
+          version: v2.13.1
           only-new-issues: true
           args: --timeout=5m
 

--- a/.github/workflows/java_linux.yml
+++ b/.github/workflows/java_linux.yml
@@ -369,6 +369,12 @@ jobs:
       - name: Set up Go (for the config-service stub)
         uses: actions/setup-go@v6
         with:
+          # Deliberately NOT go.mod's version: this Go is only used to build
+          # the config-service stub in keploy/samples-java, whose own
+          # async-config-poll/config-stub/go.mod declares `go 1.21`. It never
+          # compiles keploy itself (the binaries under test are downloaded by
+          # the download-binary steps above), so it is not part of the repo's
+          # toolchain bump and must track the sample instead.
           go-version: "1.21"
 
       - name: Run async-config-poll app

--- a/.github/workflows/keploy-performance-test.yml
+++ b/.github/workflows/keploy-performance-test.yml
@@ -62,7 +62,13 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          # No go-version here on purpose: actions/setup-go uses go-version and
+          # IGNORES go-version-file when both are set (docs/advanced-usage.md:
+          # "If both the go-version and the go-version-file inputs are provided
+          # then the go-version input is used"). A hardcoded version would
+          # therefore silently defeat the repo-aware selection below AND, since
+          # setup-go exports GOTOOLCHAIN=local, pin the job to a toolchain that
+          # cannot build a go.mod requiring a newer Go.
           go-version-file: ${{ github.event_name == 'workflow_dispatch' && 'keploy-to-test/go.mod' || 'keploy/go.mod' }}
           cache: true
           cache-dependency-path: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,15 +10,15 @@
 # This Dockerfile keeps the in-container `go build` path because
 # external users still need a single-command "build from source"
 # entry point. libpg_query / pg_query_go v6.2.2 requires CGo, so
-# the builder image MUST carry a working gcc — golang:1.26 (Debian
-# bookworm base) already ships gcc, so no extra apt install is
+# the builder image MUST carry a working gcc — golang:1.27 (Debian
+# trixie base) already ships gcc, so no extra apt install is
 # needed. CGO_ENABLED=1 is set explicitly so a mis-configured
 # builder (someone passing CGO_ENABLED=0 as a docker build-arg)
 # fails loud rather than producing a non-cgo binary that crashes
 # the moment the classifier tries to pg_query.Parse.
 #
 # === Build Stage ===
-FROM golang:1.26 AS build
+FROM golang:1.27 AS build
 
 # Set the working directory
 WORKDIR /app
@@ -29,7 +29,7 @@ ARG VERSION
 ARG SERVER_URL
 ARG GITHUB_APP_CLIENT_ID
 
-# pg_query_go links libpg_query via CGo. golang:1.26 (bookworm)
+# pg_query_go links libpg_query via CGo. golang:1.27 (trixie)
 # ships gcc; we set CGO_ENABLED=1 explicitly so ARG overrides can't
 # accidentally disable it. GOMAXPROCS=2 stays to avoid crashing qemu
 # under buildx multi-arch builds.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module go.keploy.io/server/v3
 
-go 1.26.0
-
-toolchain go1.26.1
+go 1.27.0
 
 require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,113 +3,58 @@ module go.keploy.io/server/v3
 go 1.27.0
 
 require (
-	github.com/Microsoft/go-winio v0.6.2 // indirect
-	github.com/cilium/ebpf v0.21.0
-	github.com/cloudflare/cfssl v1.6.4
-	github.com/docker/docker v28.5.2+incompatible
-	github.com/docker/go-connections v0.4.0 // indirect
-	github.com/docker/go-units v0.5.0 // indirect
-	github.com/fatih/color v1.18.0
-	github.com/k0kubun/pp/v3 v3.2.0
-	github.com/miekg/dns v1.1.57
-	github.com/morikuni/aec v1.0.0 // indirect
-	github.com/olekukonko/tablewriter v1.1.0
-	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.1 // indirect
-	github.com/spf13/cobra v1.10.1
-	go.uber.org/zap v1.27.0
-	golang.org/x/crypto v0.48.0 // indirect
-	golang.org/x/sys v0.41.0
-	google.golang.org/protobuf v1.36.9
-)
-
-require (
-	github.com/containerd/log v0.1.0 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
-	github.com/getkin/kin-openapi v0.126.0
-	github.com/go-errors/errors v1.4.2 // indirect
-	github.com/go-openapi/jsonpointer v0.21.0 // indirect
-	github.com/go-openapi/jsonreference v0.20.2 // indirect
-	github.com/go-openapi/swag v0.23.0 // indirect
-	github.com/google/certificate-transparency-go v1.2.1 // indirect
-	github.com/google/gnostic-models v0.7.0 // indirect
-	github.com/invopop/yaml v0.3.1
-	github.com/josharian/intern v1.0.0 // indirect
-	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
-	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
-	github.com/sagikazarmark/locafero v0.12.0 // indirect
-	github.com/sirupsen/logrus v1.9.3 // indirect
-	github.com/spf13/afero v1.15.0 // indirect
-	github.com/spf13/cast v1.10.0 // indirect
-	github.com/subosito/gotenv v1.6.0 // indirect
-	github.com/tidwall/gjson v1.18.0 // indirect
-	github.com/tidwall/match v1.2.0 // indirect
-	github.com/tidwall/pretty v1.2.1 // indirect
-	github.com/tidwall/sjson v1.2.5 // indirect
-	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
-)
-
-require gopkg.in/yaml.v3 v3.0.1
-
-require (
-	github.com/go-logr/logr v1.4.3 // indirect
-	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/jmoiron/sqlx v1.4.0 // indirect
-	github.com/klauspost/compress v1.18.0 // indirect
-	github.com/mattn/go-colorable v0.1.14 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mattn/go-runewidth v0.0.19 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
-	github.com/protocolbuffers/protoscope v0.0.0-20221109213918-8e7a6aafa2c9
-	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/spf13/pflag v1.0.10
-	github.com/weppos/publicsuffix-go v0.15.1-0.20210511084619-b1f36a2d6c0b // indirect
-	github.com/zmap/zcrypto v0.0.0-20210511125630-18f1e0152cfc // indirect
-	github.com/zmap/zlint/v3 v3.1.0 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/mod v0.32.0 // indirect
-	golang.org/x/net v0.50.0
-	golang.org/x/text v0.34.0
-	golang.org/x/tools v0.41.0
-	k8s.io/klog/v2 v2.130.1 // indirect
-)
-
-require (
 	charm.land/glamour/v2 v2.0.0
 	facette.io/natsort v0.0.0-20181210072756-2cd4dd1e2dcb
 	github.com/7sDream/geko v0.1.1
 	github.com/agnivade/levenshtein v1.1.1
 	github.com/andybalholm/brotli v1.2.0
 	github.com/bufbuild/protocompile v0.14.1
+	github.com/cilium/ebpf v0.21.0
+	github.com/cloudflare/cfssl v1.6.4
 	github.com/creack/pty v1.1.24
 	github.com/denisbrodbeck/machineid v1.0.1
+	github.com/docker/docker v28.5.2+incompatible
 	github.com/emirpasic/gods v1.18.1
+	github.com/fatih/color v1.18.0
+	github.com/getkin/kin-openapi v0.126.0
 	github.com/getsentry/sentry-go v0.28.1
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/go-chi/render v1.0.3
 	github.com/google/uuid v1.6.0
 	github.com/gopacket/gopacket v1.4.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
+	github.com/invopop/yaml v0.3.1
+	github.com/jackc/pgx/v5 v5.9.2
+	github.com/k0kubun/pp/v3 v3.2.0
 	github.com/keploy/jsonDiff v1.0.8
+	github.com/keploy/shlex v1.0.0
+	github.com/miekg/dns v1.1.57
+	github.com/moby/moby v26.0.2+incompatible
+	github.com/olekukonko/tablewriter v1.1.0
 	github.com/pavlo-v-chernykh/keystore-go/v4 v4.5.0
+	github.com/protocolbuffers/protoscope v0.0.0-20221109213918-8e7a6aafa2c9
+	github.com/spf13/cobra v1.10.1
+	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	github.com/wI2L/jsondiff v0.5.0
 	github.com/zricethezav/gitleaks/v8 v8.28.0
 	go.mongodb.org/mongo-driver/v2 v2.4.1
+	go.uber.org/zap v1.27.0
+	golang.org/x/net v0.50.0
 	golang.org/x/sync v0.19.0
+	golang.org/x/sys v0.41.0
 	golang.org/x/term v0.40.0
+	golang.org/x/text v0.34.0
+	golang.org/x/tools v0.41.0
 	google.golang.org/grpc v1.75.1
+	google.golang.org/protobuf v1.36.9
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.18.3
 	sigs.k8s.io/kustomize/kyaml v0.19.0
 	vitess.io/vitess v0.23.3
 )
-
-require github.com/keploy/shlex v1.0.0
 
 require (
 	charm.land/lipgloss/v2 v2.0.0 // indirect
@@ -118,10 +63,12 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
+	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/STARRY-S/zip v0.2.1 // indirect
 	github.com/ajg/form v1.5.1 // indirect
 	github.com/alecthomas/chroma/v2 v2.14.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/bodgit/plumbing v1.3.0 // indirect
 	github.com/bodgit/sevenzip v1.6.0 // indirect
 	github.com/bodgit/windows v1.0.1 // indirect
@@ -137,65 +84,104 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/containerd/errdefs v0.3.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
+	github.com/containerd/log v0.1.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/reference v0.6.0 // indirect
+	github.com/dlclark/regexp2 v1.11.0 // indirect
+	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707 // indirect
 	github.com/fatih/semgroup v1.2.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/gitleaks/go-gitdiff v0.9.1 // indirect
+	github.com/go-errors/errors v1.4.2 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-openapi/jsonpointer v0.21.0 // indirect
+	github.com/go-openapi/jsonreference v0.20.2 // indirect
+	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/golang/glog v1.2.5 // indirect
+	github.com/google/certificate-transparency-go v1.2.1 // indirect
+	github.com/google/gnostic-models v0.7.0 // indirect
+	github.com/gorilla/css v1.0.1 // indirect
 	github.com/h2non/filetype v1.1.3 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
-	github.com/jackc/pgx/v5 v5.9.2
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jmoiron/sqlx v1.4.0 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect
+	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/mattn/go-colorable v0.1.14 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/mholt/archives v0.1.2 // indirect
+	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/minio/minlz v1.0.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/sys/atomicwriter v0.1.0 // indirect
+	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
+	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
+	github.com/muesli/termenv v0.15.3-0.20240618155329-98d742f6907a // indirect
 	github.com/nwaples/rardecode/v2 v2.1.0 // indirect
 	github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 // indirect
 	github.com/olekukonko/errors v1.1.0 // indirect
 	github.com/olekukonko/ll v0.1.1 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencontainers/image-spec v1.1.1 // indirect
+	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20250313105119-ba97887b0a25 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rs/zerolog v1.33.0 // indirect
+	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/sorairolake/lzip-go v0.3.5 // indirect
+	github.com/spf13/afero v1.15.0 // indirect
+	github.com/spf13/cast v1.10.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
+	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/tetratelabs/wazero v1.9.0 // indirect
 	github.com/therootcompany/xz v1.0.1 // indirect
+	github.com/tidwall/gjson v1.18.0 // indirect
+	github.com/tidwall/match v1.2.0 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/ulikunitz/xz v0.5.12 // indirect
 	github.com/wasilibs/go-re2 v1.9.0 // indirect
 	github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52 // indirect
+	github.com/weppos/publicsuffix-go v0.15.1-0.20210511084619-b1f36a2d6c0b // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
+	github.com/yuin/goldmark v1.7.8 // indirect
+	github.com/yuin/goldmark-emoji v1.0.5 // indirect
+	github.com/zmap/zcrypto v0.0.0-20210511125630-18f1e0152cfc // indirect
+	github.com/zmap/zlint/v3 v3.1.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0 // indirect
 	go.opentelemetry.io/otel v1.38.0 // indirect
 	go.opentelemetry.io/otel/metric v1.38.0 // indirect
 	go.opentelemetry.io/otel/trace v1.38.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go4.org v0.0.0-20230225012048-214862532bf5 // indirect
+	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/exp v0.0.0-20250911091902-df9299821621 // indirect
+	golang.org/x/mod v0.32.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250929231259-57b25ae835d4 // indirect
-)
-
-require (
-	github.com/aymerick/douceur v0.2.0 // indirect
-	github.com/dlclark/regexp2 v1.11.0 // indirect
-	github.com/gorilla/css v1.0.1 // indirect
-	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
-	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
-	github.com/moby/moby v26.0.2+incompatible
-	github.com/muesli/termenv v0.15.3-0.20240618155329-98d742f6907a // indirect
-	github.com/yuin/goldmark v1.7.8 // indirect
-	github.com/yuin/goldmark-emoji v1.0.5 // indirect
+	k8s.io/klog/v2 v2.130.1 // indirect
+	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
+	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/tests/e2e/agent-ready-gated-on-ca/Dockerfile
+++ b/tests/e2e/agent-ready-gated-on-ca/Dockerfile
@@ -8,7 +8,7 @@
 # (We previously routed through ECR Public as a Hub mirror to dodge
 # Hub's anon rate limits, but ECR Public itself started returning
 # HTTP 429 on shared GHA runners — see PR #4101 CI flake.)
-FROM golang:1.26-bookworm AS build
+FROM golang:1.27-bookworm AS build
 WORKDIR /src
 
 # Copy the full keploy module so the harness build picks up the

--- a/tests/e2e/ca-bundle-merge/Dockerfile.setup
+++ b/tests/e2e/ca-bundle-merge/Dockerfile.setup
@@ -13,9 +13,9 @@
 # unauthenticated pull-rate-limits. Callers can still override with
 # `--build-arg GOLANG_IMAGE=…` (the docker-compose.yml forwards the
 # $GOLANG_IMAGE / $DEBIAN_IMAGE environment variables through, so CI runners
-# with a locally cached `golang:1.26-bookworm` can use the cache directly).
+# with a locally cached `golang:1.27-bookworm` can use the cache directly).
 
-ARG GOLANG_IMAGE=public.ecr.aws/docker/library/golang:1.26-bookworm
+ARG GOLANG_IMAGE=public.ecr.aws/docker/library/golang:1.27-bookworm
 ARG DEBIAN_IMAGE=public.ecr.aws/docker/library/debian:trixie-slim
 
 # BuildKit populates TARGETOS / TARGETARCH automatically based on the

--- a/tests/e2e/ca-bundle-merge/docker-compose.yml
+++ b/tests/e2e/ca-bundle-merge/docker-compose.yml
@@ -28,9 +28,9 @@ services:
         # Overridable for CI runners with specific images cached. The
         # defaults point at the ECR Public mirrors (see Dockerfile.setup) so
         # GHA runners aren't subject to Docker Hub's unauthenticated
-        # pull-rate-limits; runners with a local `golang:1.26-bookworm` layer
-        # cache can export GOLANG_IMAGE=golang:1.26-bookworm to reuse it.
-        GOLANG_IMAGE: ${GOLANG_IMAGE:-public.ecr.aws/docker/library/golang:1.26-bookworm}
+        # pull-rate-limits; runners with a local `golang:1.27-bookworm` layer
+        # cache can export GOLANG_IMAGE=golang:1.27-bookworm to reuse it.
+        GOLANG_IMAGE: ${GOLANG_IMAGE:-public.ecr.aws/docker/library/golang:1.27-bookworm}
         DEBIAN_IMAGE: ${DEBIAN_IMAGE:-public.ecr.aws/docker/library/debian:trixie-slim}
     image: kpl-ca-merge:local
     container_name: kpl-ca-merge-writer


### PR DESCRIPTION
## Describe the changes that are made

Moves the module to **Go 1.27.0** and brings every CI pin along with it.

| what | from | to |
|---|---|---|
| `go.mod` `go` directive | `1.26.0` | `1.27.0` |
| `go.mod` `toolchain` | `go1.26.1` | *removed* — see below |
| `Dockerfile`, 3 e2e Dockerfiles/compose | `golang:1.26` | `golang:1.27` |
| `golangci-lint.yml` pin | `v2.12.2` | `v2.13.1` — **required**, see below |
| `keploy-performance-test.yml` | `go-version: '1.26'` | `'1.27'` (pin kept; dead `go-version-file` removed) |
| `java_linux.yml` | `go-version: "1.21"` | unchanged, comment added |

~25 workflows use `go-version-file: go.mod` and follow automatically.

### The `go` directive is a compatibility opt-in, not just a toolchain selector

Go 1.27 flips two GODEBUG defaults. Measured on the real binary, same tree, only the `go` line differing:

```
go 1.26.0 -> DefaultGODEBUG=tracebacklabels=0,x509sslcertoverrideplatform=0
go 1.27.0 -> (no pin — 1.27 defaults active)
```

`tracebacklabels` is inert — nothing in the tree uses pprof labels.

**`x509sslcertoverrideplatform` is not, and it lands in the CA code.** With the new default, `crypto/x509.loadSystemRoots` on darwin/windows stops returning the platform pool and instead honours `SSL_CERT_FILE`, with the resulting pool containing **that file alone**.

keploy sets `SSL_CERT_FILE` in its *own* process (`pkg/agent/proxy/tls/ca.go`, `setEnvVars` → `os.Setenv`), and on the **native** path that file holds only the MITM CA — the merged system+keploy bundle is built for the docker/k8s path. So keploy's own root pool on macOS and Windows would shrink to its own CA, breaking its outbound HTTPS and falsifying the "nil `RootCAs` falls back to the platform pool" reasoning in four places in `pkg/agent/proxy`.

It is therefore **pinned to the old value** so this bump stays behaviour-neutral, with the reasoning recorded next to the directive.

> **Follow-up, deliberately not in this PR:** the new default is actually a *win* for users — an application built with `go 1.27` on macOS/Windows will now honour keploy's `SSL_CERT_FILE` injection, which it previously ignored. Unlocking that means teaching the native path to write a merged bundle the way `setEnvForSharedVolume` already does, then dropping the pin. That is a behaviour change with its own testing, not a version bump.

### golangci-lint had to move with it

The released **v2.12.2** binary CI downloads is built with `go1.26.2` and refuses a module targeting 1.27 outright:

```
can't load config: the Go language version (go1.26) used to build golangci-lint
is lower than the targeted Go version (1.27.0)          (exit 3)
```

**v2.13.1** is built with `go1.27.0` and reports `0 issues` on this tree. Without this the lint job fails the moment `go.mod` changes.

### Why `toolchain` is deleted rather than bumped

`go mod tidy` deletes a `toolchain` equal to the `go` directive (verified both ways), and `setup-private-parsers` runs `go mod tidy` inside CI — so keeping one guarantees a workspace that differs from the commit. `setup-go` falls back to the `go` directive (`installer.ts` `parseGoVersionFile`), and `actions/go-versions` publishes 1.27.0 as stable for all six platform/arch combos this repo uses. There is no `go1.27.1` to pin to instead.

For developers: with default `GOTOOLCHAIN=auto` a local 1.24 or 1.26 transparently fetches 1.27.0; with `GOTOOLCHAIN=local` the error is explicit (`go.mod requires go >= 1.27.0 (running go 1.24.4; GOTOOLCHAIN=local)`).

### Smaller corrections

- `keploy-performance-test.yml` carried **both** `go-version: '1.26'` and a `go-version-file` expression on one step. setup-go returns `go-version` whenever it is set and only *warns* that the file input is ignored (`src/main.ts:144-152`), so the expression had never executed.
  The **pin is kept** and moved to `1.27`: this job reports latency numbers that are only comparable across runs if the compiler is held still, so the Go version belongs to the harness rather than to the code under measurement. The dead expression is removed rather than left as misleading config. setup-go exports `GOTOOLCHAIN=local` (`main.ts:175-180`), so the pin does not auto-upgrade and must move with `go.mod` — it fails loudly if it doesn't. Since the pin tracks the newest targeted Go, a `workflow_dispatch` against a branch on an older Go still builds.
- `java_linux.yml`'s `"1.21"` is deliberate — it builds samples-java's `config-stub`, whose own `go.mod` declares 1.21, and never compiles keploy. Left alone with a comment so the next bump doesn't sweep it up.
- The Dockerfile comment claiming `golang:1.26` was a *bookworm* base was already stale: 1.26 and 1.27 are both Debian **trixie**, so the glibc floor does not move. Corrected rather than propagated.

## Known, non-blocking: CodeQL extraction degrades until GitHub ships a 1.27 bundle

`codeql.yml` has no `setup-go`, so it uses the runner's ambient toolchain and the CodeQL bundle's own Go extractor (built with go1.26.5). After this bump, **90 of 91 keploy packages fail extraction** with `package requires newer Go version go1.27 (application built with go1.26)` — while the job still **exits 0**.

Measured: the analysis still runs and today's alert set is **unchanged** (identical rule+file+line results before and after). It self-heals when GitHub ships a bundle built with Go 1.27, and `codeql.yml` floats on `@v3` so it picks that up with no edit here.

**There is no 1.27-capable bundle to pin to.** `codeql-bundle-v2.26.3` (2026-08-12) is the newest release with no newer prereleases, and github/codeql merged `Go: Update to 1.27` to main on **2026-08-19** — seven days after that cut. `tools:` accepts a path or URL to a bundle tarball, but none published contains the 1.27 extractor.

This is pre-existing debt rather than something this PR introduces — the job degrades the same way on *any* Go bump past the bundle's Go, and reports success regardless. Flagging it so that if a security alert goes quiet in the next few weeks, the cause is known. A guard that makes this class of degradation loud is tracked separately.

## Verification

Run with Go 1.27.0 (`/usr/local/go`):

- `gofmt -l .`, `go vet ./...`, `go build ./...`, `go mod tidy -diff` — all clean, no output
- `go test ./...` — no failures
- `go test -race -count=1` on `pkg/service/contract/...` and `pkg/matcher/...` — ok
- prebuilt **golangci-lint v2.13.1** (exactly what CI runs) — `0 issues`
- `actionlint` — **57 issues at HEAD, 57 at base**: identical, all pre-existing `SC2086`
- **Main Dockerfile built end to end**: the resulting binary is `go1.27.0`, `CGO_ENABLED=1`, so cgo and libpg_query still link
- Image bases confirmed by pulling: `golang:1.27` = Debian 13 trixie / glibc 2.41; `golang:1.27-bookworm` exists and is genuinely bookworm, so the e2e builds still resolve
- **Dependency set unchanged** through the `go mod tidy` regrouping: same 178 modules, same versions and indirect flags by `go mod edit -json`; `go.sum` untouched

## Toolchain resolution — verified in CI, not assumed

The open question was whether `setup-go` would resolve 1.27.0 from a `go.mod` with **no `toolchain` line**, and whether the self-hosted Windows runners (toolcache held only 1.26.1) could fetch it. Run `32578322692` settles both — every build job resolved the version from the `go` directive and fetched it:

| job | runner | result |
|---|---|---|
| `build-and-upload` (linux/amd64) | hosted ubuntu | `Setup go version spec 1.27.0` → `Successfully set up Go version 1.27.0` → `go version go1.27.0 linux/amd64` |
| `build-linux-arm64` | hosted | `spec 1.27.0` → downloaded → success |
| `build-darwin-arm64` | hosted macOS | `spec 1.27.0` → downloaded → success |
| `build-windows-amd64` | **self-hosted `win-runner-2`** | `spec 1.27.0` → downloaded (~83s, one-time) → success |

The Windows toolcache now holds both `1.26.1` and `1.27.0`, confirmed directly on the runner, so the download cost is not repeated. `Setup go version spec 1.27.0` also proves the `go`-directive fallback works with the `toolchain` line removed — the resolution this PR depends on.

Full run: **169 checks pass, 0 fail.**

One transient failure occurred on the *first* attempt, in `run_golang_native_windows / http-pokeapi`: the readiness probe accepts a single 200, and that run paid a cold toolchain download plus a cold build cache, so `go run .` bound the port ~24s after the probe passed. It succeeded on re-run with a warm cache. That probe weakness is pre-existing and independent of this bump — its docker sibling already requires 3 consecutive 200s — and is tracked separately.

## Links & References

**Closes:** NA

## What type of PR is this? (check all applicable)
- [x] 📦 Chore
- [x] 🔁 CI

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed — this changes the toolchain the existing pipeline uses

## Self Review done?
- [x] ✅ yes
