### PR TITLE
fix: stop counting an expected-negative DNS name as a mock mismatch

### DIFF
--- a/pkg/agent/proxy/dns.go
+++ b/pkg/agent/proxy/dns.go
@@ -290,6 +290,18 @@ func (p *Proxy) resolveUncachedDNSResponse(question dns.Question, mode models.Mo
 		// "mock not found" path: same error, same log line, same
 		// NXDOMAIN / synthetic fallback. Forwarding is strictly
 		// additive.
+		//
+		// Set when upstream gives a DEFINITIVE negative answer for this name.
+		// Capture deliberately drops non-Success rcodes (dns_capture.go: "skip
+		// non-Success rcodes (NXDOMAIN, SERVFAIL, REFUSED) … would pollute
+		// mocks.yaml"), so for such a name there was never a mock to record and
+		// its absence at replay is EXPECTED, not a defect. Reporting a mismatch
+		// here fails tests for names the resolver was only probing — with
+		// ndots:5 every hostname emits 2-3 search-expansion misses, so a single
+		// app doing one lookup can fail a test set on names that never resolved
+		// in production either. NODATA already relays without reporting (below);
+		// this makes NXDOMAIN consistent with it.
+		upstreamSaysAbsent := false
 		if fwdResp, fwdErr := p.forwardDNSUpstream(question); fwdErr == nil && fwdResp != nil {
 			// A RcodeSuccess response splits into two cases by answer count:
 			// resolved (>=1 RR) vs NODATA (0 RRs). Both are relayed as-is; only
@@ -367,6 +379,7 @@ func (p *Proxy) resolveUncachedDNSResponse(question dns.Question, mode models.Mo
 					zap.Int("rcode", fwdResp.Rcode))
 				return dnsCacheEntry{Msg: fwdResp, FromUpstream: true}
 			}
+			upstreamSaysAbsent = true
 			p.logger.Debug("DNS mock miss: upstream returned negative answer; falling back to synthetic DNS response",
 				zap.String("query", question.Name),
 				zap.String("qtype", dns.TypeToString[question.Qtype]),
@@ -377,7 +390,11 @@ func (p *Proxy) resolveUncachedDNSResponse(question dns.Question, mode models.Mo
 				zap.String("qtype", dns.TypeToString[question.Qtype]),
 				zap.Error(fwdErr))
 		}
-		if mockingEnabled {
+		// Still steer to the proxy IP below (issue #2006: relaying NXDOMAIN
+		// crashes apps using bare service names), but do NOT count an expected
+		// negative as a mock mismatch. If upstream was unreachable we cannot
+		// tell, so we keep reporting in that case.
+		if mockingEnabled && !upstreamSaysAbsent {
 			// Send mock not found error if we couldn't match any DNS
 			// mock and upstream forwarding also failed.
 			p.logger.Debug("mock miss",

--- a/pkg/agent/proxy/dns_forward_test.go
+++ b/pkg/agent/proxy/dns_forward_test.go
@@ -825,3 +825,198 @@ func TestForwardDNSUpstream_NoUpstreamConfigured(t *testing.T) {
 		t.Errorf("err = %v; want message containing 'no upstream'", err)
 	}
 }
+
+// collectDNSMismatchReports drains p.errChannel and returns the DNS
+// MockMismatchReports that resolveUncachedDNSResponse pushed onto it. The
+// steering-vs-reporting split of issue #4474 is only observable here: the
+// returned dnsCacheEntry looks identical whether or not a mismatch was
+// reported, so the assertions have to read the error channel.
+func collectDNSMismatchReports(t *testing.T, p *Proxy) []models.MockMismatchReport {
+	t.Helper()
+	var reports []models.MockMismatchReport
+	for {
+		select {
+		case err := <-p.errChannel:
+			parserErr, ok := err.(models.ParserError)
+			if !ok {
+				t.Fatalf("unexpected error type on errChannel: %T (%v)", err, err)
+			}
+			if parserErr.ParserErrorType != models.ErrMockNotFound {
+				t.Fatalf("unexpected parser error type on errChannel: %q", parserErr.ParserErrorType)
+			}
+			if parserErr.MismatchReport == nil {
+				t.Fatalf("ErrMockNotFound without a MismatchReport: %v", parserErr.Err)
+			}
+			reports = append(reports, *parserErr.MismatchReport)
+		default:
+			return reports
+		}
+	}
+}
+
+// newProxyForMismatchReporting is newProxyWithUpstream plus the two fields a
+// mock-miss needs to be observable: an empty mock manager (so every query is a
+// miss) and a buffered errChannel (SendError drops to the "channel full" log
+// branch when it is nil).
+func newProxyForMismatchReporting(t *testing.T, addr string, timeout time.Duration) *Proxy {
+	t.Helper()
+	p := newProxyWithUpstream(t, addr, timeout)
+	emptyMgr := NewMockManager(nil, nil, zap.NewNop())
+	t.Cleanup(emptyMgr.Close)
+	p.mockManager = emptyMgr
+	p.errChannel = make(chan error, 16)
+	return p
+}
+
+// TestResolveUncachedDNSResponse_TestMode_UpstreamNXDOMAIN_NoMockMismatch is the
+// regression test for issue #4474.
+//
+// Capture deliberately drops non-Success rcodes (enterprise
+// dns_capture.go: "skip non-Success rcodes (NXDOMAIN, SERVFAIL, REFUSED) …
+// would pollute mocks.yaml"), so for a name upstream reports as absent there
+// was never a mock to record — its absence at replay is expected, not a
+// defect. Replay used to report it as a mock mismatch anyway, and with the
+// Kubernetes default ndots:5 every hostname emits 2-3 search-expansion probes
+// that NXDOMAIN before the absolute name resolves, so a single lookup could
+// fail a whole test set on names that never resolved in production either.
+//
+// Both halves of the fix are asserted here: the #2006 proxy-IP steering is
+// untouched (the app still gets a synthetic A, never the NXDOMAIN), and no
+// MockMismatchReport is emitted.
+func TestResolveUncachedDNSResponse_TestMode_UpstreamNXDOMAIN_NoMockMismatch(t *testing.T) {
+	addr, stop := startFakeUpstream(t, func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Rcode = dns.RcodeNameError // NXDOMAIN
+		_ = w.WriteMsg(m)
+	})
+	defer stop()
+
+	p := newProxyForMismatchReporting(t, addr, 2*time.Second)
+
+	// A doubled search-expanded name, exactly the shape the resolver probes
+	// first under ndots:5 and the shape of all 16 mismatches in #4474.
+	q := dns.Question{
+		Name:   "mongo.prod.svc.cluster.local.prod.svc.cluster.local.",
+		Qtype:  dns.TypeA,
+		Qclass: dns.ClassINET,
+	}
+	entry := p.resolveUncachedDNSResponse(q, models.MODE_TEST, true /*mockingEnabled*/, time.Now(), nil)
+
+	// #2006 steering must be unchanged: the app still gets the synthetic
+	// proxy-IP answer so eBPF can intercept the connection.
+	if entry.Msg == nil {
+		t.Fatal("expected the synthetic proxy-IP fallback, got nil Msg")
+	}
+	if entry.Msg.Rcode != dns.RcodeSuccess {
+		t.Errorf("Rcode = %d, want %d — upstream NXDOMAIN must not reach the app (#2006)", entry.Msg.Rcode, dns.RcodeSuccess)
+	}
+	if len(entry.Msg.Answer) != 1 {
+		t.Fatalf("expected 1 synthetic A answer (steering intact), got %d", len(entry.Msg.Answer))
+	}
+	if a, ok := entry.Msg.Answer[0].(*dns.A); !ok || !a.A.Equal(net.ParseIP("127.0.0.1")) {
+		t.Errorf("expected synthetic A 127.0.0.1 (proxy steering), got %v", entry.Msg.Answer[0])
+	}
+	if entry.FromUpstream {
+		t.Error("steered synthetic response must not be marked FromUpstream")
+	}
+
+	// …and the expected negative must not be reported as a mock mismatch.
+	if reports := collectDNSMismatchReports(t, p); len(reports) != 0 {
+		t.Errorf("upstream NXDOMAIN reported as a mock mismatch (%d report(s)): %+v — capture never records such a name, so replay must not fail on its absence (#4474)",
+			len(reports), reports)
+	}
+}
+
+// TestResolveUncachedDNSResponse_TestMode_UpstreamSERVFAIL_NoMockMismatch pins
+// that the #4474 suppression covers every definitive non-Success rcode, not
+// just NXDOMAIN: capture skips SERVFAIL and REFUSED on the same grounds, so
+// there is no mock for such a name either. The steering is unchanged.
+func TestResolveUncachedDNSResponse_TestMode_UpstreamSERVFAIL_NoMockMismatch(t *testing.T) {
+	addr, stop := startFakeUpstream(t, func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Rcode = dns.RcodeServerFailure // SERVFAIL
+		_ = w.WriteMsg(m)
+	})
+	defer stop()
+
+	p := newProxyForMismatchReporting(t, addr, 2*time.Second)
+
+	q := dns.Question{Name: "flaky.svc.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	entry := p.resolveUncachedDNSResponse(q, models.MODE_TEST, true, time.Now(), nil)
+
+	if entry.Msg == nil || len(entry.Msg.Answer) != 1 {
+		t.Fatalf("expected the synthetic proxy-IP fallback to survive, got %+v", entry.Msg)
+	}
+	if reports := collectDNSMismatchReports(t, p); len(reports) != 0 {
+		t.Errorf("upstream SERVFAIL reported as a mock mismatch (%d report(s)): %+v", len(reports), reports)
+	}
+}
+
+// TestResolveUncachedDNSResponse_TestMode_UpstreamUnreachable_ReportsMismatch
+// pins the deliberate limit of the #4474 suppression. When the forward fails
+// we never learn whether the name would have resolved, so a missing mock is
+// still a candidate defect and must keep being reported — otherwise a broken
+// upstream would silently swallow every genuine DNS mock miss.
+func TestResolveUncachedDNSResponse_TestMode_UpstreamUnreachable_ReportsMismatch(t *testing.T) {
+	// Stall every real query past the forwarder deadline; answer only the
+	// readiness probe so startFakeUpstream returns promptly.
+	addr, stop := startFakeUpstream(t, func(w dns.ResponseWriter, r *dns.Msg) {
+		if len(r.Question) > 0 && strings.HasPrefix(r.Question[0].Name, "probe.test") {
+			m := new(dns.Msg)
+			m.SetReply(r)
+			_ = w.WriteMsg(m)
+			return
+		}
+		time.Sleep(400 * time.Millisecond)
+	})
+	defer stop()
+
+	p := newProxyForMismatchReporting(t, addr, 80*time.Millisecond)
+
+	q := dns.Question{Name: "unreachable.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	entry := p.resolveUncachedDNSResponse(q, models.MODE_TEST, true, time.Now(), nil)
+
+	if entry.Msg == nil || len(entry.Msg.Answer) != 1 {
+		t.Fatalf("expected the synthetic proxy-IP fallback, got %+v", entry.Msg)
+	}
+	reports := collectDNSMismatchReports(t, p)
+	if len(reports) != 1 {
+		t.Fatalf("expected exactly 1 mismatch report when upstream is unreachable, got %d: %+v", len(reports), reports)
+	}
+	if reports[0].Protocol != "DNS" {
+		t.Errorf("report protocol = %q, want %q", reports[0].Protocol, "DNS")
+	}
+	if !strings.Contains(reports[0].ActualSummary, "unreachable.example.com.") {
+		t.Errorf("report ActualSummary = %q; want it to name the query", reports[0].ActualSummary)
+	}
+}
+
+// TestResolveUncachedDNSResponse_TestMode_UpstreamNODATA_NoMockMismatch pins
+// that the NODATA branch is untouched by #4474: it already returned early
+// without reporting, and it still relays the honest empty NOERROR.
+func TestResolveUncachedDNSResponse_TestMode_UpstreamNODATA_NoMockMismatch(t *testing.T) {
+	addr, stop := startFakeUpstream(t, func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Rcode = dns.RcodeSuccess // NOERROR + zero answers -> NODATA
+		_ = w.WriteMsg(m)
+	})
+	defer stop()
+
+	p := newProxyForMismatchReporting(t, addr, 2*time.Second)
+
+	q := dns.Question{Name: "postgres.checkr.svc.cluster.local.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}
+	entry := p.resolveUncachedDNSResponse(q, models.MODE_TEST, true, time.Now(), nil)
+
+	if entry.Msg == nil || entry.Msg.Rcode != dns.RcodeSuccess || len(entry.Msg.Answer) != 0 {
+		t.Fatalf("expected the relayed empty NOERROR, got %+v", entry.Msg)
+	}
+	if !entry.FromUpstream {
+		t.Error("relayed NODATA must be cached as FromUpstream")
+	}
+	if reports := collectDNSMismatchReports(t, p); len(reports) != 0 {
+		t.Errorf("NODATA relay reported a mock mismatch (%d report(s)): %+v", len(reports), reports)
+	}
+}


### PR DESCRIPTION
## Describe the changes that are made

Capture and replay disagreed about DNS names that resolve to a negative answer.

**Capture** deliberately drops non-Success rcodes (`dns_capture.go`: *"skip non-Success rcodes (NXDOMAIN, SERVFAIL, REFUSED). These are usually search-domain expansion noise and would pollute mocks.yaml without adding replay value."*), pinned by `TestDNSCapture_SkipsNXDomainResponses`. That reasoning is sound — recording them would multiply DNS mocks several-fold.

**Replay** (`resolveUncachedDNSResponse`, `MODE_TEST`) treated their absence as a defect: on a mock miss it forwarded upstream, got a definitive negative answer, fell through to the synthetic response and reported `ErrMockNotFound` + a `MockMismatchReport`. So replay failed tests for exactly the names capture was never willing to record.

The cost is large under the Kubernetes default `ndots:5`, where every hostname emits 2–3 search-expansion probes that NXDOMAIN before the absolute name resolves. Measured on a cluster run: **16 DNS mismatches, every single one a search-expanded name**, against exactly 4 recorded mocks (the successful absolute lookups):

```
6 × A     mongo.<ns>.svc.cluster.local.<ns>.svc.cluster.local.
6 × AAAA  mongo.<ns>.svc.cluster.local.<ns>.svc.cluster.local.
2 × A     openbao-active.<ns>.svc.cluster.local.<ns>.svc.cluster.local.
2 × AAAA  openbao-active.<ns>.svc.cluster.local.<ns>.svc.cluster.local.
```

Note the inconsistency that was already in the function: **NODATA** (NOERROR + zero answers) relays and returns early, producing **no** mismatch. Only NXDOMAIN fell through to the report — even though capture skips both equally.

### The change

`resolveUncachedDNSResponse` now records whether upstream returned a **definitive** negative answer for the name (`upstreamSaysAbsent`) and gates only the mismatch report on it. For such a name there was never a mock to record, so its absence at replay is expected, not a defect. This makes NXDOMAIN consistent with the NODATA branch above it.

### Why NXDOMAIN is still not synthesised back to the app

The #2006 steering is **unchanged**. A negative answer must not reach the app when mocking is enabled: any unknown name has to resolve to the proxy IP so eBPF can intercept it and match against recorded mocks — relaying NXDOMAIN crashes apps that use bare service names like `localstack` or `postgres` (#2006). This PR touches *reporting* only; the response the app receives on this path is byte-for-byte what it was before, and the regression tests for #2006 (`..._UpstreamNXDOMAIN_FallsBackToProxyIP`, `..._UpstreamSERVFAIL_FallsBackToProxyIP`) still pass unmodified.

The `fwdErr != nil` case (upstream unreachable) deliberately keeps reporting: when the forward fails we cannot know whether the name would have resolved, so a missing mock is still a candidate defect. Suppressing it there would let a broken resolver silently swallow every genuine DNS mock miss.

### Tests

Four new cases alongside the existing `TestResolveUncachedDNSResponse_TestMode_*` set, using a buffered `errChannel` so the report itself is observable (the returned `dnsCacheEntry` looks identical either way):

- `..._UpstreamNXDOMAIN_NoMockMismatch` — steering intact (synthetic A → proxy IP, `Rcode=0`, not `FromUpstream`) **and** no mismatch reported. Uses the doubled search-expanded name from the issue. **Fails before this change, passes after.**
- `..._UpstreamSERVFAIL_NoMockMismatch` — the suppression covers every definitive non-Success rcode, since capture skips SERVFAIL/REFUSED on the same grounds. **Fails before, passes after.**
- `..._UpstreamUnreachable_ReportsMismatch` — a mismatch is still reported when the forward times out.
- `..._UpstreamNODATA_NoMockMismatch` — NODATA behaviour unchanged: honest empty NOERROR relayed, `FromUpstream`, no report.

Validated end to end on the cluster run that produced the evidence above: DNS mismatches **16 → 0**, and combined with the other fixes in the parent issue the run went to **8/8 passing**.

## Links & References

**Closes:** #4474
- Parent issue: #2426
- Must-not-regress: #2006

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- #4474, #2426, #2006
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed

The behaviour is fully covered by unit tests against a fake upstream resolver; reproducing it in the e2e pipeline would require a `ndots:5` Kubernetes resolver config.

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

```bash
go build -tags=viper_bind_struct ./...
go test ./pkg/agent/proxy/ -run 'TestResolveUncachedDNSResponse|TestForwardDNSUpstream|TestDNSCache' -v
```

Reverting `pkg/agent/proxy/dns.go` alone makes `..._UpstreamNXDOMAIN_NoMockMismatch` and `..._UpstreamSERVFAIL_NoMockMismatch` fail with a `MockMismatchReport` on the errChannel.

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA (cluster hostnames in the evidence above are redacted)

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
