### PR TITLE
feat(report): assert and report a test's dependencies, and emit a machine-readable verdict

### DIFF
--- a/.github/workflows/test_workflow_scripts/golang/mock_mismatch/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/mock_mismatch/golang-linux.sh
@@ -6,6 +6,22 @@
 # other suites, success here is INVERTED: we assert that replay SURFACES the
 # mismatch (the "MOCK MISMATCH" report with an unmatched outgoing call), not
 # that every test passed.
+#
+# The rest asserts the per-test DEPENDENCY contract (the DepResult writer,
+# `keploy report --format json` and --assert-dependencies) over BOTH of its
+# branches, using one recording:
+#
+#   phase 1-2 (steps 0-8)   the tier as an ordinary recording leaves it: every
+#                           dependency is session-tier, nothing is eligible, and
+#                           the honest verdict is NOT CHECKED;
+#   phase 3   (steps 9-11)  the same recording replayed with the per-test tier
+#                           in force, where the assertion RUNS: checked bit,
+#                           MISSING row, and the knob's OBSOLETE -> FAILED /
+#                           exit 0 -> non-zero delta.
+#
+# Neither phase is sufficient alone — a writer stuck at "checked" passes phase 3
+# and a writer stuck at "not checked" passes phase 1-2. Read the long comment
+# above step 0 and the one above step 9 before changing either.
 
 echo "$RECORD_BIN"
 echo "$REPLAY_BIN"
@@ -86,8 +102,18 @@ send_request() {
 }
 
 # Record one iteration of test cases + mocks.
+#
+# --sync IS LOAD-BEARING, not a style choice. mappings.yaml (the per-test
+# test<->mock mapping) is produced ONLY by synchronous record: the agent emits a
+# TestMockMapping from SyncMockManager.ResolveRange, and the only call site that
+# reaches it is the `if synchronous` branch of the capture hook
+# (pkg/agent/hooks/conn/util.go). A plain `keploy record` writes tests + mocks
+# and NO keploy/test-set-*/mappings.yaml, and without that file replay falls
+# back to timestamp-based mock filtering (useMappingBased=false), the per-test
+# dependency assertion is never armed, and every dependency assertion below
+# would be asserting a run in which nothing was even attempted.
 send_request &
-"$RECORD_BIN" record -c "./http-pokeapi" --generateGithubActions=false 2>&1 | tee record_logs.txt
+"$RECORD_BIN" record -c "./http-pokeapi" --sync --generateGithubActions=false 2>&1 | tee record_logs.txt
 if grep "WARNING: DATA RACE" record_logs.txt; then
     echo "::error::Race condition detected in recording"
     cat record_logs.txt
@@ -125,8 +151,27 @@ if [ "$mutated_any" != true ]; then
 fi
 
 # Replay. The mutated mocks no longer match → keploy must report the unmatched
-# outgoing call. The replay itself is EXPECTED to not all-pass here.
+# outgoing call.
+#
+# THIS RUN IS EXPECTED TO BE RED, for RESPONSE reasons. With no mock serving
+# /api/v2/ the app's outgoing call fails, so its responses drift from what was
+# recorded and the tests come back FAILED. Measured on this sample with this
+# tree's binary: every test FAILED and default_rc = 1.
+#
+# NOTE, because an earlier version of this comment claimed the opposite and it
+# is the first thing a reader hits: the OBSOLETE demotion does NOT happen in
+# this phase. Every dependency the mapping records here is session-tier, so
+# filteredExpectedNames is empty, isMockSubset returns true, mockSetMismatch is
+# false, and demoteToObsolete never fires. OBSOLETE appears only in phase 3,
+# where the tier flip makes the expectation list non-empty — see the comment
+# above step 9.
+#
+# default_rc is therefore NOT asserted on its own (step 6 says so too). It is
+# captured only as the BASELINE for step 7b, whose question is 'does turning
+# --assert-dependencies on change anything on a test set where it can assert
+# nothing?'.
 "$REPLAY_BIN" test -c "./http-pokeapi" --delay 7 --debug --generateGithubActions=false 2>&1 | tee test_logs.txt
+default_rc=${PIPESTATUS[0]}
 
 if grep "WARNING: DATA RACE" test_logs.txt; then
     echo "::error::Race condition detected in test"
@@ -174,5 +219,598 @@ if [ "$mismatch_reported" != true ]; then
     exit 1
 fi
 
-echo "mock-mismatch e2e passed: the forced HTTP /api/v2/ unmatched call was reported"
+# ---------------------------------------------------------------------------
+# Dependency assertions on the sync path (keploy-consumer-design-v2.md §7
+# slice 4): the DepResult writer, the `keploy report --format json` verdict
+# contract, and the --assert-dependencies knob. Everything below asserts on the
+# REPORT, the NDJSON and the EXIT CODE; only the ONE assertion that has no
+# machine-readable surface (the inert-knob warning) reads a log.
+#
+# WHAT THIS SAMPLE CAN PROVE, AND WHAT IT CANNOT — read this before "fixing" a
+# failure here by relaxing an assertion.
+#
+# The per-test dependency assertion covers PER-TEST TIER mocks only. Two classes
+# are excluded on purpose:
+#   * DNS — resolution order is not deterministic;
+#   * session/connection tier — recorded once at app boot and shared by every
+#     test, so "this test's window did not consume it" is not evidence of
+#     anything and asserting it would turn healthy tests RED at random.
+#
+# models.Mock.DeriveLifetime classifies an untagged (or non-canonically tagged)
+# HTTP / HTTP2 / Postgres / MySQL / Generic mock as SESSION tier. The HTTP
+# recorder tags its mocks "HTTP_CLIENT", which is non-canonical, so every mock
+# this sample records is session tier. Verified on a real recording of this very
+# sample:
+#
+#   name=mock-2 kind=Http lifetime="session" metaType="HTTP_CLIENT" reusable=true
+#   name=mock-3 kind=Http lifetime="session" metaType="HTTP_CLIENT" reusable=true
+#
+# So for the tier as recorded, the honest per-test dependency verdict is NOT
+# CHECKED: mappings.yaml exists and lists those mocks, the assertion is armed,
+# and every entry is filtered out before it can be asserted. In THIS phase there
+# is no missing-row path to exercise and --assert-dependencies cannot fail
+# anything.
+#
+# An earlier version of this suite asserted the opposite (a MISSING dep row, a
+# FAILED test set under the knob) in THIS phase, and could never pass. Do NOT
+# restore those assertions by making the writer count reusable-tier mocks: that
+# is the false RED the exclusion exists to prevent. The missing-row path is
+# earned instead in phase 3, by replaying the same recording with the lax
+# tier-promotion rule switched off so the mocks are genuinely per-test — see the
+# comment above step 9.
+#
+# The assertions below are therefore built so that a run which checked nothing
+# CANNOT satisfy them silently:
+#   * the mapping file must exist and list mock entries (otherwise "not checked"
+#     would be true for the boring reason that nothing was armed);
+#   * the inert warning must name the SESSION-TIER reason specifically — the
+#     reason ordering in dependencyAssertionInertReason puts "no usable
+#     mappings.yaml" ahead of it, so this string can only appear when the
+#     mapping precondition really held;
+#   * the false-green invariant (step 4) is universal, not sample-specific.
+# ---------------------------------------------------------------------------
+
+# 0. THE PRECONDITION, ASSERTED RATHER THAN ASSUMED. --sync must have produced a
+#    mappings.yaml that actually lists mocks. Without this, every "not checked"
+#    assertion below would also hold for a run where mapping was never armed,
+#    and the suite would be green while proving nothing.
+shopt -s nullglob
+mapping_files=( ./keploy/test-set-*/mappings.yaml )
+shopt -u nullglob
+if [ ${#mapping_files[@]} -eq 0 ]; then
+    echo "::error::no keploy/test-set-*/mappings.yaml was recorded. The per-test mock mapping is produced ONLY by synchronous record — check that '--sync' is still on the record command above and that the agent forwarded it."
+    ls -R ./keploy | head -40
+    exit 1
+fi
+mapping_has_entries=false
+for mp in "${mapping_files[@]}"; do
+    if grep -qE "^[[:space:]]*-[[:space:]]+name:" "$mp"; then
+        echo "✓ $(basename "$(dirname "$mp")")/mappings.yaml lists per-test mock entries"
+        mapping_has_entries=true
+    fi
+done
+if [ "$mapping_has_entries" != true ]; then
+    echo "::error::mappings.yaml exists but lists no mock entries; the dependency assertion has no expectation to work from and every check below would be vacuous"
+    head -30 "${mapping_files[0]}"
+    exit 1
+fi
+
+# 1. `keploy report --format json` must be machine-readable. The regression
+#    this catches: the ANSI logo, the "version:" line and zap INFO records went
+#    to STDOUT ahead of the NDJSON, so `| jq` failed to parse.
+"$REPLAY_BIN" report --format json > ndjson_out.txt 2> ndjson_err.txt
+report_rc=$?
+if [ "$report_rc" -ne 0 ]; then
+    echo "::error::keploy report --format json exited $report_rc"
+    cat ndjson_err.txt
+    exit 1
+fi
+if [ ! -s ndjson_out.txt ]; then
+    echo "::error::keploy report --format json produced no NDJSON on stdout"
+    cat ndjson_err.txt
+    exit 1
+fi
+# Every line must be a standalone JSON object carrying the schema version.
+# `jq -e` fails on a parse error AND on a false/null result, so this is one
+# assertion for "parseable" and "has the contract fields". dependencies_checked
+# is in the list because a consumer is REQUIRED to read it before treating an
+# empty `effects` as a clean dependency verdict — a projection that stops
+# emitting the key removes the only thing standing between an agent and a false
+# green.
+line_no=0
+while IFS= read -r line; do
+    line_no=$((line_no + 1))
+    if ! printf '%s' "$line" | jq -e 'has("schema_version") and has("test_case_id") and has("status") and has("effects") and has("dependencies_checked")' > /dev/null; then
+        echo "::error::NDJSON line $line_no is not a parseable verdict object"
+        echo "--- line $line_no ---"
+        printf '%s\n' "$line"
+        echo "--- full stdout (first 20 lines) ---"
+        head -20 ndjson_out.txt
+        exit 1
+    fi
+done < ndjson_out.txt
+echo "✓ keploy report --format json emitted $line_no parseable NDJSON verdict(s)"
+
+# --format junit has the same stdout contract.
+"$REPLAY_BIN" report --format junit > junit_out.xml 2> junit_err.txt
+if ! head -1 junit_out.xml | grep -q '^<?xml'; then
+    echo "::error::keploy report --format junit did not start with the XML declaration"
+    head -20 junit_out.xml
+    exit 1
+fi
+echo "✓ keploy report --format junit emitted a clean XML document"
+
+# 2. THE HONEST VERDICT FOR THIS SAMPLE. Every mapped dependency is session
+#    tier, so nothing is eligible and every verdict must say NOT CHECKED.
+#
+#    `dependencies_checked: true` here would mean the writer had claimed the
+#    assertion ran over a test whose every dependency it had just filtered away
+#    — which is what this sample used to produce (`dependencies_checked: true,
+#    dependencies_consumed: 0, effects: []`) and exactly the false green the
+#    whole projection exists to close.
+if ! jq -es 'length > 0 and all(.dependencies_checked == false)' ndjson_out.txt > /dev/null; then
+    echo "::error::a verdict reported dependencies_checked=true, but every mock this sample records is session-tier and therefore ineligible for the per-test assertion. Either the tier classification changed (check the recorder's metadata type tag) or the writer is claiming an assertion it did not run."
+    jq -s 'map({test_case_id, status, dependencies_checked, dependencies_consumed, effects: (.effects // [] | length)})' ndjson_out.txt
+    exit 1
+fi
+echo "✓ every verdict reports the dependency assertion as NOT CHECKED"
+
+# 3. ...and NOT CHECKED must be reported as nothing else. A verdict that says
+#    "not checked" while carrying dependency effects or a consumed count is
+#    self-contradictory: the consumer rule is `checked && any(matched==false)`,
+#    so rows under an unchecked verdict are invisible to every conforming
+#    reader.
+if ! jq -es 'map(select(.dependencies_checked == false and (((.effects // []) | length) > 0 or (.dependencies_consumed // 0) > 0))) | length == 0' ndjson_out.txt > /dev/null; then
+    echo "::error::a verdict reports dependency data under dependencies_checked=false; a conforming consumer never reads it, so it is data that cannot be acted on"
+    jq -s 'map(select(.dependencies_checked == false and (((.effects // []) | length) > 0 or (.dependencies_consumed // 0) > 0)))' ndjson_out.txt
+    exit 1
+fi
+
+# 4. THE FALSE-GREEN INVARIANT. Universal, not sample-specific: if the assertion
+#    really ran, at least one dependency was eligible, so consuming NONE of them
+#    means every one of them is missing and `effects` cannot be empty.
+#
+#    `checked=true, consumed=0, effects=[]` is therefore unreachable by
+#    construction — unless the writer starts setting the checked bit for a test
+#    it never had a dependency to check, which is the defect this step guards.
+#    It stays true (and keeps biting) for any sample, including one that later
+#    grows genuinely per-test mocks.
+if ! jq -es 'map(select(.dependencies_checked == true and (.dependencies_consumed // 0) == 0 and ((.effects // []) | length) == 0)) | length == 0' ndjson_out.txt > /dev/null; then
+    echo "::error::a verdict claims the dependency assertion ran and is clean while reporting zero consumed dependencies and zero effects. That combination cannot happen when something was actually eligible: it means the checked bit was set for a test with nothing to check."
+    jq -s 'map(select(.dependencies_checked == true and (.dependencies_consumed // 0) == 0 and ((.effects // []) | length) == 0))' ndjson_out.txt
+    exit 1
+fi
+echo "✓ no verdict claims a checked-and-clean dependency result with nothing eligible"
+
+# 5. The same statements on the PERSISTED report, which is the artifact users
+#    keep and the fleet report store ingests.
+shopt -s nullglob
+reports=( ./keploy/reports/test-run-*/test-set-*-report.yaml )
+shopt -u nullglob
+if [ ${#reports[@]} -eq 0 ]; then
+    echo "::error::the default replay wrote no test-set report"
+    exit 1
+fi
+for rf in "${reports[@]}"; do
+    # 5a. deps_checked is omitempty, so an honest not-checked test writes NO
+    #     key at all — byte-identical to every report recorded before this
+    #     field had a writer.
+    if grep -q 'deps_checked: true' "$rf"; then
+        echo "::error::$(basename "$rf") persisted deps_checked: true for a test set whose every mapped dependency is session-tier"
+        grep -n -B6 'deps_checked: true' "$rf" | head -40
+        exit 1
+    fi
+    # 5b. No missing rows either: nothing was asserted, so nothing can be
+    #     reported missing. A row here would be the false RED the tier
+    #     exclusion exists to prevent.
+    if grep -q 'actual: not consumed' "$rf"; then
+        echo "::error::$(basename "$rf") persisted a MISSING dependency row for a mock that is not attributable to a single test (session/connection tier). This is the false RED the tier filter exists to prevent."
+        grep -n -B6 'actual: not consumed' "$rf" | head -40
+        exit 1
+    fi
+    # 5c. THE REPORT-SIZE HALF OF THE CONTRACT. Only MISSING dependencies are
+    #     ever persisted as rows; the ones that WERE exercised are a count
+    #     (`deps_consumed`) plus the `deps_checked` bit. One row per consumed
+    #     dependency costs ~190 bytes of YAML, and a Postgres-chatty suite
+    #     consumes 50-200 mocks per test — 3-11 MB per test-set report, written
+    #     to disk, re-read by `keploy report` and uploaded to the fleet report
+    #     store, of `consumed/consumed` boilerplate no consumer reads.
+    if grep -q 'actual: consumed$' "$rf"; then
+        echo "::error::$(basename "$rf") persisted a MATCHED dependency row. The consumed side must be the deps_consumed count, never rows."
+        grep -n -B4 'actual: consumed$' "$rf" | head -30
+        exit 1
+    fi
+done
+echo "✓ the persisted reports carry the same not-checked verdict, and no matched rows"
+
+# 6. The exit code of the default run. This suite deliberately mutates mocks and
+#    its header says success is INVERTED, so the default replay may redden for
+#    RESPONSE reasons that have nothing to do with dependencies. It is captured
+#    as the baseline for step 7 and printed as context, never asserted on its
+#    own.
+echo "--- default replay exit code (diagnostic only): $default_rc ---"
+
+# 7. THE KNOB, over a test set where it cannot assert anything.
+#    --assert-dependencies must then be a NO-OP: same exit code as the default
+#    run, no test failed for a dependency, and ONE warning per test set saying
+#    why. A knob that reddens a run it cannot assert is worse than one that is
+#    silently inert.
+rm -rf ./keploy/reports
+"$REPLAY_BIN" test -c "./http-pokeapi" --delay 7 --assert-dependencies --generateGithubActions=false 2>&1 | tee assert_logs.txt
+assert_rc=${PIPESTATUS[0]}
+
+if grep "WARNING: DATA RACE" assert_logs.txt; then
+    echo "::error::Race condition detected under --assert-dependencies"
+    exit 1
+fi
+
+# 7a. THE WARNING, and the ONE assertion here that has to read a log because it
+#     has no machine-readable surface. It is also what makes every "not checked"
+#     assertion above non-vacuous: dependencyAssertionInertReason checks the
+#     set-wide preconditions FIRST, so a run with no usable mappings.yaml emits
+#     the "--update-test-mapping" reason instead. Matching the session-tier
+#     wording therefore proves the mapping was armed and the entries really were
+#     dropped on tier.
+#
+#     The other half of this assertion — that the string is not simply always
+#     printed — is step 11pre, which greps the SAME string out of a run with the
+#     knob on whose dependencies were eligible and were asserted. It has to be
+#     that run: warnDependencyAssertionInert returns at its first line when
+#     --assert-dependencies is off, so a knob-off log is silent whatever the
+#     reason logic does and proves nothing.
+if ! grep -q 'no eligible dependency to assert' assert_logs.txt; then
+    echo "::error::--assert-dependencies ran over a test set where nothing was eligible and never said so. The user is left with a report full of dependencies_checked=false and no explanation."
+    echo "--- inert / dependency lines in assert_logs.txt ---"
+    grep -inE 'assert-dependencies|inert|eligible|dependency' assert_logs.txt | head -20
+    exit 1
+fi
+if ! grep -q 'session/connection-tier' assert_logs.txt; then
+    echo "::error::the inert warning fired but named a different reason than the session/connection tier one. Reason ordering puts the set-wide preconditions first, so this means the mapping precondition ITSELF failed and every not-checked assertion above passed for the wrong reason."
+    grep -n 'inert\|eligible\|reason' assert_logs.txt | head -20
+    exit 1
+fi
+echo "✓ the run explains WHY nothing was asserted (session/connection-tier dependencies only)"
+
+# 7b. The knob changed nothing. Asserted as a DELTA against the default run
+#     rather than as a literal `exit 0`, because this suite mutates mocks on
+#     purpose and the response side may legitimately redden the run; the
+#     dependency contract is that turning the knob on adds no failure of its
+#     own.
+if [ "$assert_rc" -ne "$default_rc" ]; then
+    echo "::error::--assert-dependencies changed the run's exit code ($default_rc -> $assert_rc) on a test set where it has nothing to assert. Every mapped dependency here is session-tier and is excluded from the assertion, so the knob must not be able to fail anything."
+    tail -40 assert_logs.txt
+    exit 1
+fi
+echo "✓ --assert-dependencies left the exit code unchanged ($assert_rc): it cannot assert, so it fails nothing"
+
+# 7c. ...and nothing was labelled DEPENDENCY_MISSING or promoted through the
+#     dependency path. The exit code alone would not catch a test that the knob
+#     failed while another test happened to go green.
+shopt -s nullglob
+assert_reports=( ./keploy/reports/test-run-*/test-set-*-report.yaml )
+shopt -u nullglob
+if [ ${#assert_reports[@]} -eq 0 ]; then
+    echo "::error::--assert-dependencies wrote no report"
+    exit 1
+fi
+for rf in "${assert_reports[@]}"; do
+    if grep -q 'DEPENDENCY_MISSING' "$rf"; then
+        echo "::error::$(basename "$rf") labelled a test DEPENDENCY_MISSING under --assert-dependencies, but no dependency of this test set was ever eligible to be asserted"
+        grep -n -B10 'DEPENDENCY_MISSING' "$rf" | head -40
+        exit 1
+    fi
+    if grep -q 'deps_checked: true' "$rf"; then
+        echo "::error::$(basename "$rf") persisted deps_checked: true under --assert-dependencies. The knob changes the VERDICT a missing dependency produces, never whether the assertion ran."
+        exit 1
+    fi
+done
+echo "✓ --assert-dependencies failed nothing and claimed nothing"
+
+# 8. THE KNOB DOES NOT CHANGE WHAT IS PERSISTED. Re-project the knob run and
+#    assert the same verdict contract holds: the flag is documented as changing
+#    only the STATUS a lost dependency produces, so a consumer's parsing must be
+#    mode-independent.
+"$REPLAY_BIN" report --format json > ndjson_assert.txt 2> ndjson_assert_err.txt
+if [ ! -s ndjson_assert.txt ]; then
+    echo "::error::keploy report --format json produced no NDJSON after the --assert-dependencies run"
+    cat ndjson_assert_err.txt
+    exit 1
+fi
+if ! jq -es 'length > 0 and all(.dependencies_checked == false)' ndjson_assert.txt > /dev/null; then
+    echo "::error::--assert-dependencies changed the dependency verdict from NOT CHECKED to checked. The flag decides what a MISSING dependency does to the status; it can never make an ineligible dependency eligible."
+    jq -s 'map({test_case_id, status, dependencies_checked, dependencies_consumed})' ndjson_assert.txt
+    exit 1
+fi
+if ! jq -es 'map(select(.dependencies_checked == true and (.dependencies_consumed // 0) == 0 and ((.effects // []) | length) == 0)) | length == 0' ndjson_assert.txt > /dev/null; then
+    echo "::error::the knob run produced a checked-and-clean verdict with nothing eligible"
+    jq -s 'map(select(.dependencies_checked == true))' ndjson_assert.txt
+    exit 1
+fi
+echo "✓ the verdict contract is identical with the knob on"
+
+# ---------------------------------------------------------------------------
+# PHASE 3 — THE OTHER BRANCH, EARNED RATHER THAN FAKED.
+#
+# Everything above asserts the NOT-CHECKED branch. On its own that is only half
+# a test: a writer that returned "not checked" UNCONDITIONALLY would satisfy
+# every assertion up to here. Steps 9-11 replay the SAME recording with the
+# per-test tier actually in force, so the suite also pins the checked branch —
+# the `deps_checked` bit, the MISSING row and the knob's RED — the last of these
+# as a two-sided delta against the identical knob-off run, never as a grep for
+# the DEPENDENCY_MISSING label, which attachDepResults writes with or without
+# the flag. Between them the two phases bracket the writer: neither a
+# permanently-true nor a permanently-false `dependencies_checked` can pass.
+#
+# HOW THE TIER CHANGES, AND WHY THIS IS NOT A FAKE. Nothing is re-recorded and
+# no file is edited: the mocks, the mappings and the mutation are the same bytes
+# phases 1-2 just ran against. The only difference is KEPLOY_STRICT_MOCK_WINDOW=1
+# in the environment, which is a documented, product-supported knob.
+#
+# models.Mock.DeriveLifetime applies its precedence list top-to-bottom. The HTTP
+# recorder tags its mocks `type: HTTP_CLIENT`, which is neither "config" nor
+# "connection", so rules 2-3 do not fire, and rule 4 (the untagged kind
+# fallback) does not fire either because the tag is NOT empty. What classifies
+# these mocks as session in phases 1-2 is rule 5 — the LAX-MODE promotion that
+# reproduces pre-tag behaviour for a non-canonical tag on an implicit-session
+# kind. laxKindFallbackDisabled() gates rule 5 off when
+# KEPLOY_STRICT_MOCK_WINDOW is set to an enabling value, and with rule 5 gone
+# the recorder's own tag is honoured and the mocks land on rule 6:
+# LifetimePerTest. They are then eligible, and the assertion has something real
+# to run over.
+#
+# So the two phases are the two sides of one documented rule, not a test and a
+# workaround. Phase 1-2 is what an ordinary user gets today; phase 3 is what the
+# same recording means once the lax compat promotion is off — which is also the
+# shape every recording takes when a recorder starts tagging per-test tier
+# properly, so these assertions are the ones that will outlive the compat rule.
+#
+# WHY THE MISSING ROW IS DETERMINISTIC, not a timing race: the mocks were
+# mutated at the top of this script to an /api/v0-mismatch/ path the app never
+# requests, so the live call cannot match them however the windows fall. And the
+# EXPECTATION is read from mappings.yaml, not from the window-filtered set, so
+# even a mock dropped by strict windowing is still expected and still reported
+# unconsumed. "Not consumed" here is forced by construction.
+# ---------------------------------------------------------------------------
+
+# 9. THE CHECKED BRANCH, DEFAULT MODE. Same recording, per-test tier in force:
+#    the assertion now runs, finds the mutated mock was never consumed, and says
+#    so. `dependencies_checked` must be true, and — this is the invariant step 4
+#    asserts from the other direction — consuming none of an eligible set means
+#    every one of them is MISSING, so `effects` cannot be empty.
+rm -rf ./keploy/reports
+KEPLOY_STRICT_MOCK_WINDOW=1 "$REPLAY_BIN" test -c "./http-pokeapi" --delay 7 --generateGithubActions=false 2>&1 | tee strict_logs.txt
+strict_rc=${PIPESTATUS[0]}
+
+if grep "WARNING: DATA RACE" strict_logs.txt; then
+    echo "::error::Race condition detected in the per-test-tier run"
+    exit 1
+fi
+
+"$REPLAY_BIN" report --format json > ndjson_strict.txt 2> ndjson_strict_err.txt
+if [ ! -s ndjson_strict.txt ]; then
+    echo "::error::keploy report --format json produced no NDJSON after the per-test-tier run"
+    cat ndjson_strict_err.txt
+    exit 1
+fi
+
+# 9pre. THE PRECONDITION FOR `all(...)`, diagnosed separately so 9a's failure
+#       can only mean one thing.
+#
+#       Steps 9a/9b quantify over EVERY verdict, so they require every recorded
+#       test to have at least one eligible mapped dependency. That holds for
+#       this sample today (the recording maps one mock per test), but the
+#       mapping is produced from LIVE pokeapi.co calls inside a readiness loop:
+#       a test recorded without an outgoing call — an upstream hiccup, a
+#       short-circuited handler — gives hasExpectedMocks=false and hence
+#       dependencies_checked=false for that one test. 9a would then fail with a
+#       message blaming the DeriveLifetime rule-5 gate or the recorder's tag,
+#       neither of which moved, and the natural "fix" a maintainer reaches for
+#       is to weaken `all` to `any`. Assert the thin-recording cause HERE
+#       instead, with its own wording.
+missing_mapping=false
+for tcid in $(jq -r '.test_case_id' ndjson_strict.txt); do
+    found=false
+    for mp in ./keploy/test-set-*/mappings.yaml; do
+        [ -e "$mp" ] || continue
+        # Each mapping entry is `- id: <test>` followed by its mock_entry list;
+        # awk keeps the two bound to the same entry (independent greps could
+        # match a name under a different test).
+        # Exact id comparison, not a regex match: "test-1" must not be
+        # satisfied by "test-10". Written without gawk's \< \> word
+        # boundaries because CI runners default to mawk, where those are not
+        # supported and the match would silently never fire.
+        if awk -v want="$tcid" '
+            /^[[:space:]]*-[[:space:]]*id:/ {
+                v = $0
+                sub(/^[^:]*:[[:space:]]*/, "", v)
+                gsub(/["\r ]/, "", v)
+                inTest = (v == want)
+            }
+            /^[[:space:]]*-[[:space:]]+name:/ { if (inTest) { found = 1 } }
+            END { exit found ? 0 : 1 }
+        ' "$mp"; then
+            found=true
+            break
+        fi
+    done
+    if [ "$found" != true ]; then
+        echo "::error::recorded test '$tcid' has no mock entry in any mappings.yaml. The recording is THIN — that test made no outgoing call when it was recorded (upstream hiccup, or a short-circuited handler), so hasExpectedMocks is false and its dependency verdict is legitimately not-checked. This is NOT a tier-gate regression; re-record the sample. Steps 9a/9b quantify over every verdict and cannot run against a thin recording."
+        missing_mapping=true
+    fi
+done
+if [ "$missing_mapping" = true ]; then
+    for mp in ./keploy/test-set-*/mappings.yaml; do echo "--- $mp ---"; cat "$mp"; done
+    exit 1
+fi
+echo "✓ every recorded test maps at least one dependency, so 'all(...)' below is a real quantifier"
+
+# 9a. The tier flip must actually have happened. If this fails, the rule-5 gate
+#     or the recorder's tag changed and the WHOLE phase is asserting nothing —
+#     so it is checked before anything downstream of it. The thin-recording
+#     cause is ruled out by 9pre above, so this message names the real one.
+if ! jq -es 'length > 0 and all(.dependencies_checked == true)' ndjson_strict.txt > /dev/null; then
+    echo "::error::with KEPLOY_STRICT_MOCK_WINDOW=1 the recorded HTTP mocks should resolve to PER-TEST tier (DeriveLifetime rule 5 is gated off, so the recorder's 'HTTP_CLIENT' tag is honoured) and the assertion should run. It reported not-checked instead: either the recorder's metadata tag changed, or the lax-fallback gate no longer keys off KEPLOY_STRICT_MOCK_WINDOW."
+    jq -s 'map({test_case_id, status, dependencies_checked, dependencies_consumed, effects:(.effects//[]|length)})' ndjson_strict.txt
+    exit 1
+fi
+
+# 9b. ...and the assertion found the mutated dependency missing. This is the
+#     one path the not-checked phase can never reach: a real MISSING row, with
+#     matched=false, which is what a consumer's
+#     `checked && any(matched == false)` rule keys off.
+if ! jq -es 'length > 0 and all((.effects // []) | map(select(.matched == false)) | length > 0)' ndjson_strict.txt > /dev/null; then
+    echo "::error::the dependency assertion ran over the mutated mocks and reported no unexercised dependency. The mocks were rewritten to an /api/v0-mismatch/ path the app never requests, so every mapped per-test dependency MUST come back unconsumed."
+    jq -s 'map({test_case_id, dependencies_checked, dependencies_consumed, effects})' ndjson_strict.txt
+    exit 1
+fi
+echo "✓ with per-test-tier dependencies the assertion RAN and reported the vanished dependency"
+
+# 10. The persisted report carries the same thing: the checked bit, and the
+#     MISSING row as a row. `expected: consumed / actual: not consumed` is the
+#     literal shape the writer emits for a dependency that vanished.
+shopt -s nullglob
+strict_reports=( ./keploy/reports/test-run-*/test-set-*-report.yaml )
+shopt -u nullglob
+if [ ${#strict_reports[@]} -eq 0 ]; then
+    echo "::error::the per-test-tier run wrote no test-set report"
+    exit 1
+fi
+strict_rows=false
+for rf in "${strict_reports[@]}"; do
+    if grep -q 'deps_checked: true' "$rf" && grep -q 'actual: not consumed' "$rf"; then
+        strict_rows=true
+    fi
+    # The report-size contract from step 5c holds on THIS branch too, and here
+    # it is a much stronger statement: the assertion really ran, so a writer
+    # that persisted the consumed side as rows would have had the chance to.
+    if grep -q 'actual: consumed$' "$rf"; then
+        echo "::error::$(basename "$rf") persisted a MATCHED dependency row. The consumed side must be the deps_consumed count, never rows."
+        grep -n -B4 'actual: consumed$' "$rf" | head -30
+        exit 1
+    fi
+done
+if [ "$strict_rows" != true ]; then
+    echo "::error::no report carried deps_checked: true together with a MISSING dependency row, although the NDJSON projection of the same run did. The persisted report and the projection are supposed to be two views of one result."
+    for rf in "${strict_reports[@]}"; do echo "--- $rf ---"; grep -n -A12 'dep_result:' "$rf" | head -30; done
+    exit 1
+fi
+echo "✓ the persisted report carries deps_checked: true and the MISSING dependency row"
+
+# 11. THE KNOB'S ONE JOB, on the branch where it can do it. Phase 2 proved
+#     --assert-dependencies cannot redden a run it cannot assert. The complement
+#     — that it DOES redden a run whose assertion found a lost dependency — has
+#     no other coverage in this suite, and without it the flag could be a no-op
+#     in every mode and still pass.
+#
+#     ASSERTED AS A REAL DELTA against step 9's identical run: same binary, same
+#     environment, same mocks, only the flag differs.
+#
+#     What is NOT used as that delta, because it is knob-INDEPENDENT: the
+#     DEPENDENCY_MISSING label. attachDepResults appends it to the failure
+#     categories of every FAILED or OBSOLETE test that has missing rows, without
+#     consulting assertDependencies at all, so the knob-OFF run at step 9
+#     produces exactly the same label. Measured on this sample's knob-off strict
+#     run: all three verdicts carry "failure_categories":["DEPENDENCY_MISSING"]
+#     with status OBSOLETE. Grepping for it therefore passes even if the flag is
+#     a total no-op, which is the kind of assertion this PR exists to delete.
+#
+#     The two things that ARE knob-specific, and are what this step asserts:
+#       * THE STATUS. resolveTestOutcome sends the same (mockSetMismatch,
+#         response-failed) state to mismatchLogObsolete when the knob is off
+#         (OBSOLETE, failsTestSet=false) and to mismatchLogVetoedFailure when it
+#         is on (FAILED, failsTestSet=true). That is a deterministic branch on
+#         the flag, not a timing-dependent outcome.
+#       * THE EXIT CODE, as a two-sided delta. The baseline strict_rc must be 0
+#         AND the knob run must be non-zero, so the knob is provably the ONLY
+#         reason the run went red. Asserting only `strict_assert_rc != 0` would
+#         pass for the wrong reason the day a pokeapi drift flips the baseline
+#         red too — and this suite mutates mocks on purpose, so that is a live
+#         possibility rather than a hypothetical.
+rm -rf ./keploy/reports
+KEPLOY_STRICT_MOCK_WINDOW=1 "$REPLAY_BIN" test -c "./http-pokeapi" --delay 7 --assert-dependencies --generateGithubActions=false 2>&1 | tee strict_assert_logs.txt
+strict_assert_rc=${PIPESTATUS[0]}
+
+# 11pre. THE NEGATIVE CONTROL FOR STEP 7a, on the only run where it can fire.
+#        7a asserts the session-tier inert warning appears in phase 2; that is
+#        only meaningful if the warning is not printed unconditionally. This is
+#        the run that proves it: --assert-dependencies IS on (so
+#        warnDependencyAssertionInert does not return at its knob guard) and the
+#        dependencies ARE eligible and WERE asserted, so the reason must be "".
+#
+#        It deliberately reads strict_assert_logs.txt and NOT the step-9 log: the
+#        step-9 run passes no --assert-dependencies, and the warner returns on
+#        its first line when the knob is off, so the string is absent there
+#        whatever the reason logic does. An earlier version of this suite grepped
+#        that log and asserted nothing at all — mutating
+#        dependencyAssertionInertReason to return the tier reason unconditionally
+#        left it green.
+if grep -q 'no eligible dependency to assert' strict_assert_logs.txt; then
+    echo "::error::the no-eligible-dependency warning fired for a run with --assert-dependencies ON whose dependencies WERE eligible and WERE asserted (step 9 just proved the assertion ran and found a missing dependency on this exact recording). The reason is supposed to describe a state, not to be printed unconditionally — and step 7a's matching assertion is only meaningful if this one holds."
+    grep -n 'eligible' strict_assert_logs.txt | head -10
+    exit 1
+fi
+echo "✓ the inert warning stays silent when the assertion can actually run"
+
+shopt -s nullglob
+strict_assert_reports=( ./keploy/reports/test-run-*/test-set-*-report.yaml )
+shopt -u nullglob
+if [ ${#strict_assert_reports[@]} -eq 0 ]; then
+    echo "::error::the per-test-tier --assert-dependencies run wrote no report"
+    exit 1
+fi
+
+"$REPLAY_BIN" report --format json > ndjson_strict_assert.txt 2> ndjson_strict_assert_err.txt
+if [ ! -s ndjson_strict_assert.txt ]; then
+    echo "::error::keploy report --format json produced no NDJSON after the per-test-tier --assert-dependencies run"
+    cat ndjson_strict_assert_err.txt
+    exit 1
+fi
+
+# 11a. THE STATUS DELTA. Knob off -> OBSOLETE (demoted, test set survives);
+#      knob on -> FAILED. Same recording, same mocks, same environment.
+if ! jq -es 'length > 0 and all(.status == "OBSOLETE")' ndjson_strict.txt > /dev/null; then
+    echo "::error::the BASELINE run (step 9, per-test tier, NO --assert-dependencies) did not demote its tests to OBSOLETE, so there is no delta for --assert-dependencies to be measured against. A mock-set mismatch with a failing response is supposed to be demoted, not failed, until a veto flag says otherwise."
+    jq -s 'map({test_case_id, status, dependencies_checked, failure_categories})' ndjson_strict.txt
+    exit 1
+fi
+if ! jq -es 'length > 0 and all(.status == "FAILED")' ndjson_strict_assert.txt > /dev/null; then
+    echo "::error::--assert-dependencies did not turn the demoted tests into FAILED ones. Step 9 proved the assertion RAN on this recording and reported a missing dependency, and the baseline demoted those same tests to OBSOLETE; the flag's entire job is to veto that demotion. A DEPENDENCY_MISSING label alone is NOT evidence the flag worked — attachDepResults writes it on the knob-off run too."
+    jq -s 'map({test_case_id, status, dependencies_checked, failure_categories})' ndjson_strict_assert.txt
+    exit 1
+fi
+
+# 11b. THE EXIT-CODE DELTA, two-sided: the knob must be the ONLY reason this
+#      run is red.
+if [ "$strict_rc" -ne 0 ] || [ "$strict_assert_rc" -eq 0 ]; then
+    echo "::error::--assert-dependencies must be the ONLY reason this run is red: the baseline (step 9, same recording, same env, no knob) exited $strict_rc and must be 0, and the knob run exited $strict_assert_rc and must be non-zero. A baseline that is already red means this step could pass with the flag doing nothing."
+    echo "--- tail of baseline (strict_logs.txt) ---"
+    tail -20 strict_logs.txt
+    echo "--- tail of knob run (strict_assert_logs.txt) ---"
+    tail -40 strict_assert_logs.txt
+    exit 1
+fi
+echo "✓ --assert-dependencies vetoed the OBSOLETE demotion into a FAILED test set (baseline exit $strict_rc -> knob exit $strict_assert_rc)"
+
+# 11c. And the flag still did not invent the assertion: it changed the STATUS a
+#      missing dependency produces, not whether the check ran. Step 8 asserts
+#      this on the not-checked branch; here it is asserted where the bit is
+#      true, so "mode-independent parsing" is pinned from both sides.
+#      ndjson_strict_assert.txt was already generated for the status delta above.
+if ! jq -es 'length > 0 and all(.dependencies_checked == true and ((.effects // []) | map(select(.matched == false)) | length > 0))' ndjson_strict_assert.txt > /dev/null; then
+    echo "::error::the knob run's projection disagrees with the default run's on the same recording. --assert-dependencies decides what a missing dependency does to the status; the dependency data itself must be identical."
+    jq -s 'map({test_case_id, status, dependencies_checked, dependencies_consumed, effects:(.effects//[]|length)})' ndjson_strict_assert.txt
+    exit 1
+fi
+echo "✓ the knob changed the status, not the dependency data"
+
+echo "mock-mismatch e2e passed:"
+echo "  - the forced HTTP /api/v2/ unmatched call was reported;"
+echo "  - with the tier as an ordinary recording leaves it, every dependency is"
+echo "    session-tier, so the per-test assertion reported NOT CHECKED, said WHY,"
+echo "    and --assert-dependencies failed nothing it could not assert;"
+echo "  - with the per-test tier in force (KEPLOY_STRICT_MOCK_WINDOW=1) the same"
+echo "    recording drove the other branch: the assertion RAN and reported the"
+echo "    vanished dependency as MISSING, the inert warning stayed silent, and"
+echo "    --assert-dependencies moved those verdicts OBSOLETE -> FAILED and the"
+echo "    exit code 0 -> non-zero, which no knob-independent label can fake."
 exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,18 @@ test-reports
 
 #Ignore the test data
 testdata
+# ...except this one checked-in Go fixture directory. `testdata` is a name the
+# Go toolchain reserves and skips when building/packaging, so it is also the
+# standard place to check in a golden fixture; the blanket rule above was
+# silently swallowing those too, which is why this repo had no testdata dir at
+# all. Re-include the directory itself (git will not descend into an excluded
+# directory, so negating only its contents would not work) plus its contents.
+# Scoped to the exact directory ON PURPOSE: a `pkg/**/testdata/` negation would
+# silently change the default for every future testdata dir under pkg/,
+# including anything a contributor's local keploy run drops there. Widen it one
+# directory at a time, when a fixture actually needs it.
+!pkg/service/report/testdata/
+!pkg/service/report/testdata/**
 
 #Ignore the c and header files
 *.c

--- a/cli/examples.go
+++ b/cli/examples.go
@@ -3,11 +3,11 @@ package cli
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"go.keploy.io/server/v3/cli/provider"
 	"go.keploy.io/server/v3/config"
 	"go.keploy.io/server/v3/utils"
+	"go.keploy.io/server/v3/utils/log"
 	"go.uber.org/zap"
 
 	"github.com/spf13/cobra"
@@ -24,7 +24,7 @@ func Example(_ context.Context, logger *zap.Logger, _ *config.Config, _ ServiceF
 		Short: "Example to record and test via keploy",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			disableAnsi, _ := (cmd.Flags().GetBool("disable-ansi"))
-			provider.PrintLogo(os.Stdout, disableAnsi)
+			provider.PrintLogo(log.PrimarySink(), disableAnsi)
 			customSetup, err := cmd.Flags().GetBool("customSetup")
 			if err != nil {
 				utils.LogError(logger, nil, "failed to read the customSetup flag")

--- a/cli/export.go
+++ b/cli/export.go
@@ -2,13 +2,13 @@ package cli
 
 import (
 	"context"
-	"os"
 
 	"github.com/spf13/cobra"
 	"go.keploy.io/server/v3/cli/provider"
 	"go.keploy.io/server/v3/config"
 	toolsSvc "go.keploy.io/server/v3/pkg/service/tools"
 	"go.keploy.io/server/v3/utils"
+	"go.keploy.io/server/v3/utils/log"
 	"go.uber.org/zap"
 )
 
@@ -24,7 +24,7 @@ func Export(ctx context.Context, logger *zap.Logger, _ *config.Config, serviceFa
 		Example: "keploy export",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			disableAnsi, _ := (cmd.Flags().GetBool("disable-ansi"))
-			provider.PrintLogo(os.Stdout, disableAnsi)
+			provider.PrintLogo(log.PrimarySink(), disableAnsi)
 			return cmd.Help()
 		},
 	}
@@ -34,7 +34,7 @@ func Export(ctx context.Context, logger *zap.Logger, _ *config.Config, serviceFa
 		Example: "keploy export postman",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			disableAnsi, _ := (cmd.Flags().GetBool("disable-ansi"))
-			provider.PrintLogo(os.Stdout, disableAnsi)
+			provider.PrintLogo(log.PrimarySink(), disableAnsi)
 			svc, err := serviceFactory.GetService(ctx, "export")
 			if err != nil {
 				utils.LogError(logger, err, "failed to get service", zap.String("command", cmd.Name()))

--- a/cli/import.go
+++ b/cli/import.go
@@ -2,13 +2,13 @@ package cli
 
 import (
 	"context"
-	"os"
 
 	"github.com/spf13/cobra"
 	"go.keploy.io/server/v3/cli/provider"
 	"go.keploy.io/server/v3/config"
 	toolsSvc "go.keploy.io/server/v3/pkg/service/tools"
 	"go.keploy.io/server/v3/utils"
+	"go.keploy.io/server/v3/utils/log"
 	"go.uber.org/zap"
 )
 
@@ -24,7 +24,7 @@ func Import(ctx context.Context, logger *zap.Logger, _ *config.Config, serviceFa
 		Example: "keploy import",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			disableAnsi, _ := (cmd.Flags().GetBool("disable-ansi"))
-			provider.PrintLogo(os.Stdout, disableAnsi)
+			provider.PrintLogo(log.PrimarySink(), disableAnsi)
 			return cmd.Help()
 		},
 	}
@@ -35,7 +35,7 @@ func Import(ctx context.Context, logger *zap.Logger, _ *config.Config, serviceFa
 		Example: "keploy import postman",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			disableAnsi, _ := (cmd.Flags().GetBool("disable-ansi"))
-			provider.PrintLogo(os.Stdout, disableAnsi)
+			provider.PrintLogo(log.PrimarySink(), disableAnsi)
 			path, _ := cmd.Flags().GetString("path")
 			if path == "" {
 				path = "output.json"

--- a/cli/logo_sink_test.go
+++ b/cli/logo_sink_test.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Every logo/version-line writer must go through log.PrimarySink(), never a
+// hardcoded os.Stdout.
+//
+// This is a STRUCTURAL pin on purpose. Today the two decisions coincide: the
+// only mode that moves the sink to stderr (`--json`, `keploy report --format
+// json|junit`) is the same mode that suppresses the logo outright, so a
+// hardcoded os.Stdout has no observable effect and no behavioural test can
+// catch it — utils/log's own TestPrimarySinkResolvesStdoutLazily and
+// provider.TestPrintLogoFollowsTheLoggerSink cover the sink and the function,
+// but not these call sites. The invariant is still worth holding: it is what
+// makes the stdout/stderr split ONE mechanism instead of a suppression list
+// that every future machine-output mode has to remember to extend, which is
+// precisely how `--format json|junit` came to print the logo over its own
+// NDJSON in the first place.
+func TestLogoWritersUseThePrimarySink(t *testing.T) {
+	dirs := []string{".", "provider"}
+
+	found := 0
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read %s: %v", dir, err)
+		}
+		for _, e := range entries {
+			name := e.Name()
+			if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+				continue
+			}
+			path := filepath.Join(dir, name)
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, path, nil, 0)
+			if err != nil {
+				t.Fatalf("parse %s: %v", path, err)
+			}
+			ast.Inspect(file, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok || !isPrintLogoCall(call) || len(call.Args) == 0 {
+					return true
+				}
+				found++
+				var sb strings.Builder
+				if err := printer.Fprint(&sb, fset, call.Args[0]); err != nil {
+					t.Fatalf("print %s: %v", path, err)
+				}
+				if got := sb.String(); got != "log.PrimarySink()" {
+					pos := fset.Position(call.Pos())
+					t.Errorf("%s:%d: PrintLogo writes to %s; it must write to log.PrimarySink() so the "+
+						"logo follows the logger's stdout/stderr split", path, pos.Line, got)
+				}
+				return true
+			})
+		}
+	}
+
+	// Guard against the test silently covering nothing after a rename.
+	if found == 0 {
+		t.Fatal("no PrintLogo call sites found; this test is asserting nothing")
+	}
+	t.Logf("checked %d PrintLogo call sites", found)
+}
+
+func isPrintLogoCall(call *ast.CallExpr) bool {
+	switch fun := call.Fun.(type) {
+	case *ast.Ident:
+		return fun.Name == "PrintLogo"
+	case *ast.SelectorExpr:
+		return fun.Sel.Name == "PrintLogo"
+	}
+	return false
+}

--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -168,9 +168,17 @@ func (c *CmdConfigurator) AddFlags(cmd *cobra.Command) error {
 	//sets the displayment of flag-related errors
 	cmd.SilenceErrors = true
 	cmd.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
-		PrintLogo(os.Stdout, true)
-		color.Red(fmt.Sprintf("❌ error: %v", err))
-		fmt.Println()
+		// Through the logger's sink, not color.Red's own os.Stdout. This is an
+		// error path with a non-zero exit, so nothing downstream would parse
+		// the corrupted document anyway — but the stdout/stderr split is only
+		// one mechanism if every writer honours it, and a suppression list
+		// that each new console print has to remember to join is exactly how
+		// `--format json|junit` came to print the logo over its own NDJSON.
+		PrintLogo(log.PrimarySink(), true)
+		// "%s\n\n" reproduces color.Red's own trailing newline plus the
+		// fmt.Println() that used to follow it, so the rendered text is
+		// unchanged — only its destination moved.
+		fmt.Fprintf(log.PrimarySink(), "%s\n\n", color.RedString("❌ error: %v", err))
 		return err
 	})
 
@@ -268,7 +276,7 @@ func (c *CmdConfigurator) AddFlags(cmd *cobra.Command) error {
 		cmd.Flags().Bool("full", false, "Show full diffs (colorized for JSON) instead of compact table diff")
 		cmd.Flags().Bool("summary", false, "Print only the summary of the test run (optionally restrict with --test-sets)")
 		cmd.Flags().StringSlice("test-case", nil, "Filter to specific test case IDs (repeat or comma-separated). Alias: --tc")
-		cmd.Flags().String("format", "text", "Output format for test report (text or junit)")
+		cmd.Flags().String("format", "text", "Output format for test report: text (default), junit, or json. json emits NDJSON — one JSON object per test result, machine-readable, with a stable schema_version. junit and json write their document to stdout and every log line to stderr, so `keploy report --format json | jq` parses. Also settable as `report.format` in keploy.yml (this flag wins); an invalid value in the config is warned about and falls back to text, an invalid value on this flag is an error. Distinct from the global --json (whole-report blob) and from --storage-format (on-disk serialization).")
 	case "diff":
 		cmd.Flags().String("run1", "", "First test run ID to compare")
 		cmd.Flags().String("run2", "", "Second test run ID to compare")
@@ -453,6 +461,11 @@ func (c *CmdConfigurator) AddUncommonFlags(cmd *cobra.Command) {
 		cmd.Flags().Bool("schema-noise-detection", c.cfg.Test.SchemaNoiseDetection, "Detect request-body fields that drift between recording and replay and persist them as field-path noise (req_body_noise) during auto-replay matching. Available to any parser that implements the shared schema-noise adapter")
 		cmd.Flags().Bool("schema-noise-strict", c.cfg.Test.SchemaNoiseStrict, "Strictly enforce learned request-body noise during mock matching: a candidate mock carrying req_body_noise is rejected when any field OUTSIDE its learned/user-configured noise drifted. Available to any parser that implements the shared schema-noise adapter. Same behaviour the in-cluster replay path enforces; previously configurable only via keploy.yml")
 		cmd.Flags().Bool("strict-failure", c.cfg.Test.StrictFailure, "Mark response-failing tests as FAILED even if the consumed mock set also diverged from the recorded mapping (default behaviour demotes such cases to OBSOLETE). The per-test mappingDiff block is still written for diagnostics.")
+		// Default false is deliberate: today an expected-but-unconsumed mock
+		// demotes the test to OBSOLETE without failing the test set, so
+		// defaulting this true would flip existing suites red on upgrade.
+		// See keploy-consumer-design-v2.md §5 (false-pass row 0) and §7 slice 4.
+		cmd.Flags().Bool("assert-dependencies", c.cfg.Test.AssertDependencies, "Fail a test whose recorded per-test dependency was NOT observed during that test's window (an expected, mapped, non-reusable-tier mock went unconsumed): FAILED status, failed test set, non-zero exit. Default false — such a test is demoted to OBSOLETE today and the run still exits 0. Unlike --strict-failure (which promotes only tests whose RESPONSE also failed) this catches the response-matched-but-dependency-vanished case. ELIGIBILITY: only per-test-tier mocks are asserted; untagged HTTP/Postgres/MySQL egress is session-tier and is excluded, so for such a recording nothing is eligible and every test reports dependencies_checked=false (NOT CHECKED, not clean). keploy logs one warning per test set naming the reason whenever the assertion cannot run. Full contract: the assertDependencies doc in config.")
 		cmd.Flags().Bool("update-test-mapping", c.cfg.Test.UpdateTestMapping, "Update the mapping of testcases")
 		// Start the user app ONCE for the whole replay run instead of
 		// restarting it per test-set. Required to surface cross-test-set
@@ -822,6 +835,115 @@ func resolveCommandType(logger *zap.Logger, cmd *cobra.Command, command, configu
 	return string(detected), nil
 }
 
+// reportFormatSource says where the effective --format value came from, so the
+// two callers can react differently to an invalid one: a value the user typed
+// is a mistake worth stopping for, a stale value in keploy.yml is not.
+type reportFormatSource int
+
+const (
+	// reportFormatFromNone: this command has no report format at all.
+	reportFormatFromNone reportFormatSource = iota
+	// reportFormatFromFlag: --format was explicitly passed.
+	reportFormatFromFlag
+	// reportFormatFromConfig: the value came from keploy.yml /
+	// KEPLOY_REPORT_FORMAT.
+	reportFormatFromConfig
+	// reportFormatFromDefault: the flag's own default.
+	reportFormatFromDefault
+)
+
+// resolvedReportFormat returns the EFFECTIVE `keploy report --format` value
+// for this invocation — normalised (lower-cased, trimmed) but deliberately NOT
+// validated — together with where it came from.
+//
+// Precedence mirrors every other keploy setting: an explicitly passed flag
+// wins, otherwise the value PreProcessFlags already resolved from keploy.yml /
+// KEPLOY_REPORT_FORMAT, otherwise the flag's own default.
+//
+// cfgFormat is the config-resolved value (c.cfg.Report.Format). It has to be
+// consulted HERE and not only in the report arm: the two decisions that keep
+// stdout clean happen at the top of ValidateFlags, so a user with
+// `report: {format: json}` in keploy.yml would otherwise get the logo, the
+// version line and every zap record on stdout ahead of their NDJSON.
+//
+// Scoped to `keploy report` by NAME as well as by flag presence. Only that
+// command's stdout is a report document, and only it registers --format in the
+// OSS tree — but cli/provider is shared with the enterprise binary, where any
+// command that later grows an unrelated --format flag whose value happens to
+// be "json" or "junit" would otherwise silently suppress its logo and push its
+// logs to stderr. The keploy.yml `report.format` key is scoped the same way:
+// for `keploy test` the answer is "" even when the config carries a format.
+func resolvedReportFormat(cmd *cobra.Command, cfgFormat string) (string, reportFormatSource) {
+	if cmd.Name() != reportCmdName || cmd.Flags().Lookup("format") == nil {
+		return "", reportFormatFromNone
+	}
+	if !cmd.Flags().Changed("format") {
+		if v := strings.ToLower(strings.TrimSpace(cfgFormat)); v != "" {
+			return v, reportFormatFromConfig
+		}
+	}
+	format, err := cmd.Flags().GetString("format")
+	if err != nil {
+		return "", reportFormatFromNone
+	}
+	source := reportFormatFromDefault
+	if cmd.Flags().Changed("format") {
+		source = reportFormatFromFlag
+	}
+	return strings.ToLower(strings.TrimSpace(format)), source
+}
+
+// validateReportFormat resolves --format and applies the SOURCE-DEPENDENT
+// failure policy.
+//
+// A value the user typed is a mistake worth stopping for: they asked for
+// something keploy cannot produce, and silently giving them a text report
+// instead is worse than an error.
+//
+// A value sitting in keploy.yml is not. `report.format` ships in every
+// generated keploy.yml and was DEAD until this release, so anyone who set it
+// wrong got no feedback that it was wrong — exactly the population that would
+// be upgraded into a hard exit 1 on a command that used to work, with an error
+// naming a flag they never passed. One WARN naming the file, then text.
+func (c *CmdConfigurator) validateReportFormat(cmd *cobra.Command) error {
+	format, source := resolvedReportFormat(cmd, c.cfg.Report.Format)
+	if format == "" {
+		format = config.ReportFormatText
+	}
+	switch format {
+	case config.ReportFormatText, config.ReportFormatJUnit, config.ReportFormatJSON:
+		c.cfg.Report.Format = format
+		return nil
+	}
+	if source == reportFormatFromConfig {
+		c.logger.Warn("ignoring invalid report.format in the keploy config file; falling back to text",
+			zap.String("value", format),
+			zap.String("allowed", "text, junit, json"))
+		c.cfg.Report.Format = config.ReportFormatText
+		return nil
+	}
+	return fmt.Errorf("invalid --format value %q: allowed values are 'text', 'junit' and 'json'", format)
+}
+
+// isMachineReadableOutput reports whether this invocation's STDOUT is a
+// machine-readable document that must not be polluted with the logo, the
+// version line or zap records.
+//
+// Two independent sources say so:
+//   - the global --json flag (already resolved into jsonOutput by the caller);
+//   - `keploy report --format json|junit`, whose stdout is NDJSON / JUnit XML.
+func isMachineReadableOutput(cmd *cobra.Command, cfgFormat string, jsonOutput bool) bool {
+	if jsonOutput {
+		return true
+	}
+	format, _ := resolvedReportFormat(cmd, cfgFormat)
+	return config.IsMachineReportFormat(format)
+}
+
+// reportCmdName is the only command whose stdout is a report document, and so
+// the only one whose --format value can make stdout machine-readable.
+const reportCmdName = "report"
+
 func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command) error {
 	// The --json flag isn't registered on every subcommand (record / agent
 	// don't define it in enterprise builds), so Lookup + fallback avoids
@@ -838,8 +960,23 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 	}
 	c.cfg.JSONOutput = jsonOutput
 
-	// In JSON mode, redirect logs to stderr so they don't contaminate JSON on stdout
-	if c.cfg.JSONOutput {
+	// --format has to be read HERE, next to --json, not in the `report` arm
+	// several hundred lines below: the two decisions that keep stdout clean
+	// (redirect the logger to stderr, suppress the logo + version line)
+	// happen right now. Gating them on --json alone left
+	// `keploy report --format json|junit` writing the ANSI logo, the
+	// "version: <v>" line and every zap INFO record onto stdout ahead of the
+	// document, so `keploy report --format json 2>/dev/null | jq` could never
+	// parse. --format is still VALIDATED in the report arm; this read is
+	// deliberately permissive so an invalid value falls through to that
+	// error path rather than being rejected twice.
+	machine := isMachineReadableOutput(cmd, c.cfg.Report.Format, c.cfg.JSONOutput)
+
+	// Machine-readable stdout: send logs to stderr so they can't contaminate
+	// the document. RedirectToStderr also moves the package-level sink, so a
+	// later logger rebuild (--debug, --disable-ansi, agent mode) cannot put
+	// them back on stdout.
+	if machine {
 		logger, err := log.RedirectToStderr()
 		if err == nil {
 			*c.logger = *logger
@@ -848,8 +985,8 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 
 	disableAnsi, _ := (cmd.Flags().GetBool("disable-ansi"))
 	// Skip printing logo for agent command to avoid duplicate logos in native mode
-	if cmd.Name() != "agent" && !c.cfg.JSONOutput {
-		PrintLogo(os.Stdout, disableAnsi)
+	if cmd.Name() != "agent" && !machine {
+		PrintLogo(log.PrimarySink(), disableAnsi)
 	}
 	if c.cfg.Debug {
 		logger, err := log.ChangeLogLevel(zap.DebugLevel)
@@ -1035,22 +1172,14 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 		}
 		c.cfg.Report.TestCaseIDs = cleaned
 
-		format, err := cmd.Flags().GetString("format")
-		if err != nil {
-			utils.LogError(c.logger, err, "failed to get the format flag")
-			return errors.New("failed to get the format flag")
+		// Resolved, not read raw: an unconditional overwrite from the flag
+		// clobbered whatever PreProcessFlags had loaded from keploy.yml, so
+		// the `report.format` yaml/mapstructure key was silently dead. Same
+		// resolver the stdout-cleanliness decision at the top of this function
+		// uses, so the two can never disagree about which format is in effect.
+		if err := c.validateReportFormat(cmd); err != nil {
+			return err
 		}
-		format = strings.ToLower(strings.TrimSpace(format))
-		if format == "" {
-			format = "text"
-		}
-		switch format {
-		case "text", "junit":
-			// valid
-		default:
-			return fmt.Errorf("invalid --format value %q: allowed values are 'text' and 'junit'", format)
-		}
-		c.cfg.Report.Format = format
 	case "diff":
 		path, err := cmd.Flags().GetString("path")
 		if err != nil {

--- a/cli/provider/format_flag_test.go
+++ b/cli/provider/format_flag_test.go
@@ -1,0 +1,221 @@
+package provider
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"go.keploy.io/server/v3/config"
+	"go.keploy.io/server/v3/utils/log"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// reportCmd builds a fully-flagged `keploy report` command the way the CLI
+// does, so --format goes through the real registration and the real
+// ValidateFlags arm.
+func reportCmd(t *testing.T, cfg *config.Config, args ...string) (*CmdConfigurator, *cobra.Command) {
+	t.Helper()
+	c := NewCmdConfigurator(zap.NewNop(), cfg)
+	cmd := &cobra.Command{Use: "report"}
+	if err := c.AddFlags(cmd); err != nil {
+		t.Fatalf("AddFlags: %v", err)
+	}
+	if err := cmd.ParseFlags(args); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	return c, cmd
+}
+
+func TestReportFormatFlag_Validation(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		// cfgFormat is what PreProcessFlags resolved from keploy.yml /
+		// KEPLOY_REPORT_FORMAT before ValidateFlags runs.
+		cfgFormat  string
+		wantFormat string
+		wantErr    []string
+		// wantWarn are substrings the single config-fallback WARN must carry.
+		wantWarn []string
+	}{
+		{name: "default is text", args: nil, wantFormat: "text"},
+		{name: "text", args: []string{"--format", "text"}, wantFormat: "text"},
+		{name: "junit", args: []string{"--format", "junit"}, wantFormat: "junit"},
+		{name: "json is accepted", args: []string{"--format", "json"}, wantFormat: "json"},
+		{name: "case and padding are normalised", args: []string{"--format", "  JSON "}, wantFormat: "json"},
+		{name: "explicitly empty falls back to text", args: []string{"--format", ""}, wantFormat: "text"},
+		{
+			name:    "unknown value is rejected listing every valid one",
+			args:    []string{"--format", "xml"},
+			wantErr: []string{`invalid --format value "xml"`, "'text'", "'junit'", "'json'"},
+		},
+		{
+			name:    "a near-miss is rejected too",
+			args:    []string{"--format", "ndjson"},
+			wantErr: []string{`invalid --format value "ndjson"`, "'json'"},
+		},
+		{
+			// `report: {format: json}` in keploy.yml. This used to be
+			// clobbered: ValidateFlags read the raw flag (still "text",
+			// unchanged) and overwrote the resolved config value, so the
+			// yaml/mapstructure key existed and did nothing.
+			name: "the config value survives when no flag is passed",
+			args: nil, cfgFormat: "json", wantFormat: "json",
+		},
+		{
+			name: "a config value is normalised like a flag value",
+			args: nil, cfgFormat: "  JUnit ", wantFormat: "junit",
+		},
+		{
+			name: "an explicit flag beats the config value",
+			args: []string{"--format", "text"}, cfgFormat: "json", wantFormat: "text",
+		},
+		{
+			name: "an explicit flag beats the config value in the other direction too",
+			args: []string{"--format", "json"}, cfgFormat: "text", wantFormat: "json",
+		},
+		{
+			// SOURCE-DEPENDENT POLICY. `report.format` ships in every generated
+			// keploy.yml and was DEAD until this release, so a user who set it
+			// wrong got no feedback. Turning that into a hard exit 1 on upgrade
+			// — with an error naming a flag they never passed — punishes
+			// exactly the population most likely to have a stale value. Warn,
+			// name the file, fall back to text, keep exiting 0.
+			name: "an invalid CONFIG value warns and falls back to text",
+			args: nil, cfgFormat: "yaml",
+			wantFormat: "text",
+			wantWarn:   []string{"report.format", "falling back to text", "yaml"},
+		},
+		{
+			// ...but a value the user typed is a mistake worth stopping for:
+			// they asked for something keploy cannot produce.
+			name:    "an invalid FLAG value is still a hard error",
+			args:    []string{"--format", "xml"},
+			wantErr: []string{`invalid --format value "xml"`, "'json'"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// ValidateFlags moves the package-level logger sink for the
+			// machine formats; leave it as we found it.
+			t.Cleanup(log.TestOnlyResetSink)
+
+			cfg := config.New()
+			cfg.Report.Format = tc.cfgFormat
+			core, logs := observer.New(zapcore.WarnLevel)
+			c, cmd := reportCmd(t, cfg, tc.args...)
+			*c.logger = *zap.New(core)
+
+			err := c.ValidateFlags(context.Background(), cmd)
+			if len(tc.wantErr) > 0 {
+				if err == nil {
+					t.Fatalf("expected an error, got nil (format = %q)", cfg.Report.Format)
+				}
+				for _, want := range tc.wantErr {
+					if !strings.Contains(err.Error(), want) {
+						t.Errorf("error %q does not mention %q", err.Error(), want)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ValidateFlags: %v", err)
+			}
+			if cfg.Report.Format != tc.wantFormat {
+				t.Errorf("cfg.Report.Format = %q, want %q", cfg.Report.Format, tc.wantFormat)
+			}
+
+			warnings := logs.All()
+			if len(tc.wantWarn) == 0 {
+				if len(warnings) != 0 {
+					t.Errorf("a valid invocation emitted %d warning(s): %v", len(warnings), warnings)
+				}
+				return
+			}
+			if len(warnings) != 1 {
+				t.Fatalf("expected exactly one WARN, got %d: %v", len(warnings), warnings)
+			}
+			rendered := warnings[0].Message
+			for _, f := range warnings[0].Context {
+				rendered += " " + f.Key + "=" + f.String
+			}
+			for _, want := range tc.wantWarn {
+				if !strings.Contains(rendered, want) {
+					t.Errorf("warning %q does not mention %q", rendered, want)
+				}
+			}
+		})
+	}
+}
+
+func TestReportFormatFlagHelpListsJSON(t *testing.T) {
+	_, cmd := reportCmd(t, config.New())
+	flag := cmd.Flags().Lookup("format")
+	if flag == nil {
+		t.Fatal("format flag is not registered on `keploy report`")
+	}
+	// The knob's real contract, all of which a user has to be told: the values,
+	// that stdout becomes a machine document for two of them, that keploy.yml
+	// can set it, and which source wins.
+	for _, want := range []string{"text", "junit", "json", "NDJSON", "stderr", "report.format", "this flag wins"} {
+		if !strings.Contains(flag.Usage, want) {
+			t.Errorf("help text %q does not mention %q", flag.Usage, want)
+		}
+	}
+}
+
+// The dependency-assertion knob must exist, default to false, and say so.
+func TestAssertDependenciesFlag(t *testing.T) {
+	cfg := config.New()
+	c := NewCmdConfigurator(zap.NewNop(), cfg)
+	cmd := &cobra.Command{Use: "test"}
+	if err := c.AddFlags(cmd); err != nil {
+		t.Fatalf("AddFlags: %v", err)
+	}
+
+	flag := cmd.Flags().Lookup("assert-dependencies")
+	if flag == nil {
+		t.Fatal("assert-dependencies flag is not registered on `keploy test`")
+	}
+	if flag.DefValue != "false" {
+		t.Errorf("assert-dependencies default = %q, want \"false\" (backward compatibility)", flag.DefValue)
+	}
+	// The default is the whole point of the flag's contract; the help text has
+	// to state it, and has to distinguish itself from --strict-failure.
+	//
+	// The eligibility caveat is pinned for a product reason, not a cosmetic
+	// one: under default settings NO tag value makes an HTTP / Postgres /
+	// MySQL / Generic mock per-test tier (DeriveLifetime's kind fallback and
+	// its lax-mode promotion between them cover every tag), so for the majority
+	// of recordings this flag cannot fail anything and every test reports
+	// dependencies_checked=false. A user who turns it on in CI expecting a gate
+	// and is never told that is the support thread this line exists to prevent.
+	for _, want := range []string{
+		"Default false",
+		"--strict-failure",
+		"per-test-tier",
+		"dependencies_checked=false",
+		"NOT CHECKED",
+	} {
+		if !strings.Contains(flag.Usage, want) {
+			t.Errorf("help text %q does not mention %q", flag.Usage, want)
+		}
+	}
+	// ...and it must stay readable at a terminal. cobra does not wrap flag
+	// usage, so an unbounded string pushes every later flag off screen. This
+	// grew to 2087 characters once, which rendered as one line in a 94-line
+	// help output. The cap is a budget, not a style rule: the full contract
+	// lives in the config.Test.AssertDependencies doc comment and in the
+	// runtime WARN, both of which a user reaches when it matters.
+	if len(flag.Usage) > 1000 {
+		t.Errorf("assert-dependencies help is %d characters; keep it under 1000 and put the "+
+			"reasoning in the config doc comment instead", len(flag.Usage))
+	}
+	if cfg.Test.AssertDependencies {
+		t.Error("config default for Test.AssertDependencies must be false")
+	}
+}

--- a/cli/provider/machine_output_test.go
+++ b/cli/provider/machine_output_test.go
@@ -1,0 +1,387 @@
+package provider
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"go.keploy.io/server/v3/config"
+	"go.keploy.io/server/v3/utils"
+	"go.keploy.io/server/v3/utils/log"
+	"go.uber.org/zap"
+)
+
+// captureStdout swaps os.Stdout for a pipe, runs fn, and returns everything fn
+// wrote to it. The pipe is drained on a goroutine so a large logo cannot block
+// on the 64KB pipe buffer.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+
+	defer func() {
+		os.Stdout = orig
+		_ = r.Close()
+	}()
+	fn()
+	_ = w.Close()
+	return <-done
+}
+
+// captureStderr is captureStdout's other half, for the modes that move the
+// console sink off stdout.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+
+	defer func() {
+		os.Stderr = orig
+		_ = r.Close()
+	}()
+	fn()
+	_ = w.Close()
+	return <-done
+}
+
+func TestIsMachineReadableOutput(t *testing.T) {
+	cases := []struct {
+		name       string
+		cmd        string
+		args       []string
+		cfgFormat  string // what PreProcessFlags resolved from keploy.yml
+		jsonOutput bool
+		// extraFormatFlag registers a --format flag on a command that is not
+		// `keploy report`, the way an enterprise-only subcommand could.
+		extraFormatFlag bool
+		want            bool
+	}{
+		{name: "plain report", cmd: "report", want: false},
+		{name: "text format", cmd: "report", args: []string{"--format", "text"}, want: false},
+		{name: "json format", cmd: "report", args: []string{"--format", "json"}, want: true},
+		{name: "junit format", cmd: "report", args: []string{"--format", "junit"}, want: true},
+		{name: "case and padding normalised", cmd: "report", args: []string{"--format", " JUnit "}, want: true},
+		{name: "an invalid value is not machine output", cmd: "report", args: []string{"--format", "xml"}, want: false},
+		{name: "the global --json flag alone", cmd: "test", jsonOutput: true, want: true},
+		{name: "a command with no --format flag at all", cmd: "test", want: false},
+		{
+			// `report: {format: json}` in keploy.yml, no flag passed. This was
+			// silently ignored: the flag value was read raw, so the config key
+			// existed but did nothing, and stdout kept the logo.
+			name: "the config file alone selects a machine format",
+			cmd:  "report", cfgFormat: "json", want: true,
+		},
+		{name: "config junit too", cmd: "report", cfgFormat: "junit", want: true},
+		{name: "config text is not machine output", cmd: "report", cfgFormat: "text", want: false},
+		{
+			// An explicitly passed flag beats the config file, in both
+			// directions.
+			name: "an explicit --format text overrides a machine format in the config",
+			cmd:  "report", args: []string{"--format", "text"}, cfgFormat: "json", want: false,
+		},
+		{
+			name: "an explicit --format json overrides text in the config",
+			cmd:  "report", args: []string{"--format", "json"}, cfgFormat: "text", want: true,
+		},
+		{
+			// `keploy test` never emits a report document on stdout, so a
+			// report format in keploy.yml must not suppress its logo.
+			name: "a report format in the config does not affect keploy test",
+			cmd:  "test", cfgFormat: "json", want: false,
+		},
+		{
+			// cli/provider is shared with the enterprise binary. A command
+			// there that grows an unrelated --format flag whose value happens
+			// to be "json" must not have its logo suppressed and its logger
+			// pushed to stderr; only `keploy report` writes a report document
+			// on stdout. extraFormatFlag registers the flag on a non-report
+			// command to prove the scoping is by NAME, not merely by flag
+			// presence.
+			name: "a non-report command with its own --format json is not machine output",
+			cmd:  "diff", args: []string{"--format", "json"},
+			extraFormatFlag: true, want: false,
+		},
+		{
+			name: "...and its config value is ignored too",
+			cmd:  "diff", cfgFormat: "junit",
+			extraFormatFlag: true, want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := NewCmdConfigurator(zap.NewNop(), config.New())
+			cmd := &cobra.Command{Use: tc.cmd}
+			if err := c.AddFlags(cmd); err != nil {
+				t.Fatalf("AddFlags: %v", err)
+			}
+			if tc.extraFormatFlag {
+				cmd.Flags().String("format", "text", "an unrelated format flag on another command")
+			}
+			if err := cmd.ParseFlags(tc.args); err != nil {
+				t.Fatalf("ParseFlags: %v", err)
+			}
+			if got := isMachineReadableOutput(cmd, tc.cfgFormat, tc.jsonOutput); got != tc.want {
+				t.Errorf("isMachineReadableOutput() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// The regression this pins: `keploy report --format json 2>/dev/null | jq`
+// failed with "Invalid numeric literal" because the ANSI logo, the version
+// line and every zap INFO record went to STDOUT ahead of the NDJSON. Both the
+// log redirect and the logo suppression were gated on the global --json flag,
+// while --format was not read until several hundred lines later.
+//
+// The test drives the real ValidateFlags, captures the real os.Stdout, writes
+// the document the report service would write, and decodes every line.
+func TestMachineFormatsKeepStdoutParseable(t *testing.T) {
+	// Deliberately NOT calling log.New() (it would create keploy-logs.txt in
+	// the working directory): the rebuild helpers must work from an untouched
+	// LogCfg, which is what log.ensureLogCfg guarantees.
+
+	cases := []struct {
+		name      string
+		args      []string
+		cfgFormat string
+		debug     bool
+		rebuild   func(t *testing.T, logger **zap.Logger)
+		lines     []any
+	}{
+		{
+			name:  "--format json",
+			args:  []string{"--format", "json"},
+			lines: []any{map[string]string{"schema_version": "1"}, map[string]string{"schema_version": "1"}},
+		},
+		{
+			name:  "--format junit (same pre-existing bug)",
+			args:  []string{"--format", "junit"},
+			lines: []any{map[string]string{"schema_version": "1"}},
+		},
+		{
+			// --disable-ansi rebuilds the logger through ChangeColorEncoding,
+			// which used to hardcode os.Stdout and silently undo the redirect.
+			name: "--format json --disable-ansi",
+			args: []string{"--format", "json", "--disable-ansi"},
+			rebuild: func(t *testing.T, logger **zap.Logger) {
+				t.Helper()
+				l, err := log.ChangeColorEncoding()
+				if err != nil {
+					t.Fatalf("ChangeColorEncoding: %v", err)
+				}
+				**logger = *l
+			},
+			lines: []any{map[string]string{"schema_version": "1"}},
+		},
+		{
+			name:  "--format json --debug (ChangeLogLevel rebuild)",
+			args:  []string{"--format", "json"},
+			debug: true,
+			lines: []any{map[string]string{"schema_version": "1"}},
+		},
+		{
+			name: "--format json + agent mode (AddMode rebuild)",
+			args: []string{"--format", "json"},
+			rebuild: func(t *testing.T, logger **zap.Logger) {
+				t.Helper()
+				l, err := log.AddMode("agent")
+				if err != nil {
+					t.Fatalf("AddMode: %v", err)
+				}
+				**logger = *l
+			},
+			lines: []any{map[string]string{"schema_version": "1"}},
+		},
+		{
+			// No flag at all: the format comes from keploy.yml. Fixing the
+			// config binding without teaching the stdout gate about it would
+			// have put the logo, the version line and every zap record back on
+			// stdout ahead of the NDJSON for exactly these users.
+			name:      "report.format json from keploy.yml, no flag passed",
+			cfgFormat: "json",
+			lines:     []any{map[string]string{"schema_version": "1"}},
+		},
+		{
+			name:      "report.format junit from keploy.yml, no flag passed",
+			cfgFormat: "junit",
+			lines:     []any{map[string]string{"schema_version": "1"}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// ValidateFlags moves the package-level log sink to stderr and, on
+			// the --disable-ansi case, rewrites LogCfg. Both outlive the test,
+			// so restore them or every later test in this binary inherits them.
+			t.Cleanup(log.TestOnlyResetSink)
+
+			cfg := config.New()
+			cfg.Debug = tc.debug
+			cfg.Report.Format = tc.cfgFormat
+			c := NewCmdConfigurator(zap.New(nil), cfg)
+			cmd := &cobra.Command{Use: "report"}
+			if err := c.AddFlags(cmd); err != nil {
+				t.Fatalf("AddFlags: %v", err)
+			}
+			// Registered on the root command in the real CLI.
+			cmd.Flags().Bool("disable-ansi", false, "")
+			if err := cmd.ParseFlags(tc.args); err != nil {
+				t.Fatalf("ParseFlags: %v", err)
+			}
+
+			out := captureStdout(t, func() {
+				if err := c.ValidateFlags(t.Context(), cmd); err != nil {
+					t.Errorf("ValidateFlags: %v", err)
+					return
+				}
+				if tc.rebuild != nil {
+					tc.rebuild(t, &c.logger)
+				}
+				// Everything keploy logs from here on must land on stderr.
+				c.logger.Info("No test sets selected for report generation")
+				c.logger.Warn("Color encoding is disabled")
+
+				w := utils.NewJSONWriter(true)
+				for _, line := range tc.lines {
+					if err := w.Write(line); err != nil {
+						t.Errorf("write: %v", err)
+					}
+				}
+			})
+
+			if out == "" {
+				t.Fatal("nothing was written to stdout")
+			}
+			dec := json.NewDecoder(strings.NewReader(out))
+			n := 0
+			for {
+				var v map[string]any
+				err := dec.Decode(&v)
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					t.Fatalf("stdout is not parseable JSON (%v).\n--- stdout ---\n%s", err, out)
+				}
+				n++
+			}
+			if n != len(tc.lines) {
+				t.Fatalf("decoded %d objects, want %d.\n--- stdout ---\n%s", n, len(tc.lines), out)
+			}
+		})
+	}
+}
+
+// The text format keeps the logo: this is an interactive CLI, and suppressing
+// it for everyone would be a regression in the opposite direction.
+func TestTextFormatStillPrintsTheLogo(t *testing.T) {
+	t.Cleanup(log.TestOnlyResetSink)
+
+	cfg := config.New()
+	c := NewCmdConfigurator(zap.New(nil), cfg)
+	cmd := &cobra.Command{Use: "report"}
+	if err := c.AddFlags(cmd); err != nil {
+		t.Fatalf("AddFlags: %v", err)
+	}
+	if err := cmd.ParseFlags([]string{"--format", "text"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := c.ValidateFlags(t.Context(), cmd); err != nil {
+			t.Errorf("ValidateFlags: %v", err)
+		}
+	})
+	// The ANSI logo emits one escape sequence per character, so match on a
+	// glyph rather than on a word.
+	if !strings.Contains(out, "▓") {
+		t.Errorf("the logo disappeared from the default text mode:\n%q", out)
+	}
+}
+
+// The logo and the version line go through log.PrimarySink(), not a hardcoded
+// os.Stdout, so the stdout/stderr split is ONE mechanism rather than a per-
+// banner suppression list every future machine-output mode has to remember to
+// extend. With the logger redirected, nothing may reach stdout.
+func TestPrintLogoFollowsTheLoggerSink(t *testing.T) {
+	t.Cleanup(log.TestOnlyResetSink)
+
+	// Default: the sink is stdout, so the logo lands there.
+	onStdout := captureStdout(t, func() { PrintLogo(log.PrimarySink(), true) })
+	if !strings.Contains(onStdout, "OPEN SOURCE") {
+		t.Fatalf("the logo did not reach stdout by default:\n%q", onStdout)
+	}
+
+	if _, err := log.RedirectToStderr(); err != nil {
+		t.Fatalf("RedirectToStderr: %v", err)
+	}
+	afterRedirect := captureStdout(t, func() { PrintLogo(log.PrimarySink(), true) })
+	if afterRedirect != "" {
+		t.Fatalf("the logo still went to stdout after the logger moved to stderr; "+
+			"a machine-readable document would be corrupted by it:\n%q", afterRedirect)
+	}
+}
+
+// The flag-error path is console output like every other banner, so it follows
+// the logger's sink too.
+//
+// It is an error path with a non-zero exit, so no machine consumer was going
+// to parse what it corrupts — but color.Red writes to fatih/color's own
+// package-level Output, which snapshots os.Stdout at init and therefore cannot
+// follow the sink at all. Leaving one writer outside the mechanism turns the
+// stdout/stderr split back into a suppression list that every new console
+// print has to remember to join, which is how `--format json|junit` came to
+// print the logo over its own NDJSON in the first place.
+func TestFlagErrorFollowsTheLoggerSink(t *testing.T) {
+	t.Cleanup(log.TestOnlyResetSink)
+
+	c := NewCmdConfigurator(zap.NewNop(), config.New())
+	cmd := &cobra.Command{Use: "test"}
+	if err := c.AddFlags(cmd); err != nil {
+		t.Fatalf("AddFlags: %v", err)
+	}
+
+	const flagErr = "unknown flag: --not-a-real-flag"
+	var onStdout string
+	onStderr := captureStderr(t, func() {
+		// Redirected INSIDE the capture so the sink picks up the pipe, the
+		// way `--format json` moves it before anything prints.
+		if _, err := log.RedirectToStderr(); err != nil {
+			t.Fatalf("RedirectToStderr: %v", err)
+		}
+		onStdout = captureStdout(t, func() {
+			_ = cmd.FlagErrorFunc()(cmd, errors.New(flagErr))
+		})
+	})
+
+	if onStdout != "" {
+		t.Errorf("the flag-error path wrote to stdout with the logger on stderr:\n%q", onStdout)
+	}
+	if !strings.Contains(onStderr, flagErr) {
+		t.Errorf("the flag error never reached the logger's sink, so it went to a stdout this "+
+			"process had already declared machine-readable:\n%q", onStderr)
+	}
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -2,12 +2,12 @@ package cli
 
 import (
 	"context"
-	"os"
 
 	"github.com/spf13/cobra"
 	"go.keploy.io/server/v3/cli/provider"
 	"go.keploy.io/server/v3/config"
 	"go.keploy.io/server/v3/utils"
+	"go.keploy.io/server/v3/utils/log"
 	"go.uber.org/zap"
 )
 
@@ -21,7 +21,7 @@ func Root(ctx context.Context, logger *zap.Logger, svcFactory ServiceFactory, cm
 		Version: utils.Version,
 		PreRun: func(cmd *cobra.Command, _ []string) {
 			disableAnsi, _ := cmd.Flags().GetBool("disable-ansi")
-			provider.PrintLogo(os.Stdout, disableAnsi)
+			provider.PrintLogo(log.PrimarySink(), disableAnsi)
 		},
 	}
 
@@ -29,7 +29,7 @@ func Root(ctx context.Context, logger *zap.Logger, svcFactory ServiceFactory, cm
 
 	rootCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
 		disableAnsi, _ := cmd.Flags().GetBool("disable-ansi")
-		provider.PrintLogo(os.Stdout, disableAnsi)
+		provider.PrintLogo(log.PrimarySink(), disableAnsi)
 
 		// Use the default help function instead of calling the parent's HelpFunc
 		defaultHelpFunc(cmd, args)

--- a/cli/update.go
+++ b/cli/update.go
@@ -2,13 +2,13 @@ package cli
 
 import (
 	"context"
-	"os"
 
 	"github.com/spf13/cobra"
 	"go.keploy.io/server/v3/cli/provider"
 	"go.keploy.io/server/v3/config"
 	toolsSvc "go.keploy.io/server/v3/pkg/service/tools"
 	"go.keploy.io/server/v3/utils"
+	"go.keploy.io/server/v3/utils/log"
 	"go.uber.org/zap"
 )
 
@@ -24,7 +24,7 @@ func Update(ctx context.Context, logger *zap.Logger, _ *config.Config, serviceFa
 		Example: "keploy update",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			disableAnsi, _ := (cmd.Flags().GetBool("disable-ansi"))
-			provider.PrintLogo(os.Stdout, disableAnsi)
+			provider.PrintLogo(log.PrimarySink(), disableAnsi)
 			svc, err := serviceFactory.GetService(ctx, "update")
 			if err != nil {
 				utils.LogError(logger, err, "failed to get service", zap.String("command", cmd.Name()))

--- a/config/config.go
+++ b/config/config.go
@@ -441,10 +441,37 @@ type Test struct {
 	SchemaNoiseDetection        bool                `json:"schemaNoiseDetection" yaml:"schemaNoiseDetection" mapstructure:"schemaNoiseDetection"`                                          // detect request-body fields that drift between recording and replay and persist them as field-path noise (req_body_noise) during auto-replay matching; available to any parser implementing the shared schema-noise adapter
 	SchemaNoiseStrict           bool                `json:"schemaNoiseStrict" yaml:"schemaNoiseStrict" mapstructure:"schemaNoiseStrict"`                                                   // replay-path enforcement: for a mock that already carries learned req_body_noise, match strictly — every request-body field must match except the learned-noise paths, so a non-noise drift fails the match. Left false on the auto-replay path so it can still learn noise leniently. Available to any parser implementing the shared schema-noise adapter.
 	StrictFailure               bool                `json:"strictFailure" yaml:"strictFailure" mapstructure:"strictFailure"`                                                               // when true, a response-failing test (testPass=false) is marked FAILED even if the consumed mock set diverged from the recorded mapping. Default false preserves the historical demotion: response failures with mock-set mismatch are marked OBSOLETE so the user can re-record without seeing the response diff as a hard failure. Set true to surface every response divergence as a real test failure for CI gating; the per-test OBSOLETE label is replaced by FAILED but the mappingDiff (expected vs actual mocks, missing calls) is still written to the report for diagnostics.
+	AssertDependencies          bool                `json:"assertDependencies" yaml:"assertDependencies" mapstructure:"assertDependencies"`                                                // when true, a per-test dependency the recording says this test exercised (a mapped, non-reusable-tier mock) that goes UNCONSUMED during replay fails the test: FAILED status, failed test set, non-zero exit. DEFAULT FALSE ON PURPOSE — today such a test is silently demoted to OBSOLETE without failing the test set, so defaulting this true would flip every existing suite red on upgrade. See keploy-consumer-design-v2.md §5 false-pass row 0 ("worker stops producing -> expected mock unconsumed -> OBSOLETE, exit 0, verified_green") and §7 slice 4. Independent of strictFailure: that flag only promotes a test whose RESPONSE also failed, so it cannot catch the response-matched-but-dependency-vanished case this flag exists for. Regardless of this flag the DepResult rows are always written and always rendered, so the missing dependency is visible in the report / JUnit / --format json either way, and they are the same size either way — this flag changes the verdict only, never what is persisted. CAVEAT on what "unconsumed" can prove: the per-test consumed-mock set is drained the moment the response comes back, so an outgoing call the app makes AFTER writing its response (audit write, analytics POST, cache set, async token refresh) is attributed to the NEXT test and reads as missing here. The signal is "not observed during this test's window", not "never made". PRECONDITIONS — the signal it keys off (an armed per-test mock mapping) is not computed unless ALL hold: instrument mode (`keploy test -c "<cmd>"`, not --base-path / remote-agent), mapping enabled (NOT test.disableMapping), and the test set has a usable mappings.yaml (re-record, or run once with --update-test-mapping, for test sets recorded before mappings existed). ELIGIBILITY — even with all of those, only PER-TEST tier mocks are asserted. Session/connection-tier mocks are excluded (recorded once at app boot, shared across every test, so a per-test presence assertion on them fails healthy tests at random) and so is DNS (non-deterministic resolution order). models.Mock.DeriveLifetime classifies an UNTAGGED HTTP / HTTP2 / Postgres / MySQL / Generic mock as session-tier, so a recording whose mocks carry no per-test tier tag has NOTHING eligible: every test is reported dependencies_checked=false (NOT CHECKED — not "checked and clean") and this flag cannot fail anything, with one WARN per test set naming that reason. SCOPE — streaming (SSE/chunked) test cases are exempt whatever the preconditions say: RunTestSet defers them to a second pass that populates no DepResult and never resolves a dependency verdict, so this flag cannot fail a streaming test. When a precondition fails, or a test set defers streaming test cases, the replayer logs one WARN per test set naming the reason, rather than reporting a green run for an assertion that never executed. COVERAGE TODAY, recorded here so it is a decision rather than a support-thread discovery: DeriveLifetime's kind fallback (rule 4) catches the untagged case and its lax-mode promotion (rule 5) catches EVERY non-canonical tag for the same kind list, so under default settings there is no tag value that makes an HTTP / HTTP2 / MySQL / Postgres / PostgresV2 / Generic mock per-test tier — measured across all 42 kind x tag combinations. Since only per-test tier is eligible, this flag cannot fail a test in an HTTP, MySQL, Postgres or Generic suite; it reaches the checked branch only for Mongo / Redis / gRPC-style recordings, or when KEPLOY_STRICT_MOCK_WINDOW is set to an enabling value (a disk-load-time env gate that StrictMockWindow below deliberately does NOT control — see the Scope note on laxKindFallbackDisabled in pkg/models/lifetime.go). For every other suite the flag is inert by construction and its only signal is the one WARN per test set. Widening that is a FOLLOW-UP and needs one of: the tier taggers emitting a canonical per-test tag for HTTP/Postgres/MySQL, or the lax kind fallback being disabled for newly-recorded test sets. Until one of those lands, release notes for this flag must say which recordings it actually covers.
 	StrictMockWindow            bool                `json:"strictMockWindow" yaml:"strictMockWindow" mapstructure:"strictMockWindow"`                                                      // Strict containment: per-test (LifetimePerTest) mocks whose request timestamp falls outside the outer test window are DROPPED rather than promoted to the cross-test unfiltered pool, which eliminates cross-test mock bleed. Default TRUE now that every stateful-protocol recorder classifies mocks finely enough (session vs per-test for connection-alive commands, per-connection data mocks) that legitimate cross-test sharing is encoded as session/connection lifetime rather than implicit out-of-window reuse. Opt out by setting this to false in keploy.yaml, or export KEPLOY_STRICT_MOCK_WINDOW=0 at process start — the env var wins over config.
 	KeepAppAlive                bool                `json:"keepAppAlive" yaml:"keepAppAlive" mapstructure:"keepAppAlive"`                                                                  // Start the user app ONCE on the outer errgroup at Start() time instead of restarting it per test-set. Skips the per-test-set RunApplication spawn + NotifyGracefulShutdown (reuses the existing serveTest gating) and skips the --delay wait on every test-set after the first (the app is already warm after the boundary). Matches the production globality autoreplay shape where a single user-app process serves every test-set back-to-back; required for cross-test-set bugs that need a long-lived TCP connection (asyncpg pool, JDBC HikariCP pool, etc.) to surface — see keploy/integrations#203 for the session-tier staleness case. Works for every cmdType that manages a user application (docker-compose, docker-run, docker-start, native); cmdType == Empty (no -c) short-circuits the one-shot spawn since there's nothing to manage. Default FALSE preserves the historical per-test-set restart behaviour.
 	ConnectionPoolIdleRetention time.Duration       `json:"connectionPoolIdleRetention,omitempty" yaml:"connectionPoolIdleRetention,omitempty" mapstructure:"connectionPoolIdleRetention"` // How long a per-connID connection-scoped mock pool survives without activity before the idle sweeper reclaims it. Default 5m — enough for HikariCP-style pooled connections bridging test boundaries without activity. Extend for long-running integration tests that may idle a connection between requests for more than 5 minutes; shorter values make the sweeper more aggressive at cost of potentially reclaiming active connections. Zero / negative reverts to the default.
 	CmdUsed                     string              `json:"-" yaml:"-" mapstructure:"-"`                                                                                                   // Full command used for the test run (set at runtime)
+}
+
+// Report output formats for `keploy report --format`.
+//
+// ReportFormatJUnit and ReportFormatJSON are MACHINE formats: their stdout is
+// a single document a tool parses (XML / NDJSON). Anything else keploy would
+// otherwise print to stdout — the ANSI logo, the version line, zap records —
+// has to move to stderr for those two, which is why they are named constants
+// shared by the CLI (which decides that before the flag is validated) and by
+// the report service (which decides what to emit).
+const (
+	ReportFormatText  = "text"
+	ReportFormatJUnit = "junit"
+	ReportFormatJSON  = "json"
+)
+
+// IsMachineReportFormat reports whether a --format value makes stdout a
+// machine-readable document. The value is lower-cased and trimmed by the
+// flag validator before it reaches config; callers that read the raw flag
+// normalise it themselves.
+func IsMachineReportFormat(format string) bool {
+	switch format {
+	case ReportFormatJUnit, ReportFormatJSON:
+		return true
+	}
+	return false
 }
 
 type Report struct {
@@ -453,7 +480,29 @@ type Report struct {
 	ReportPath       string              `json:"reportPath" yaml:"reportPath" mapstructure:"reportPath"`
 	Summary          bool                `json:"summary" yaml:"summary" mapstructure:"summary"`
 	TestCaseIDs      []string            `json:"testCaseIDs" yaml:"testCaseIDs" mapstructure:"testCaseIDs"`
-	Format           string              `json:"format" yaml:"format" mapstructure:"format"`
+	// Format is `keploy report --format`: "text" (default), "junit" or
+	// "json" (NDJSON).
+	//
+	// BEHAVIOUR CHANGE, slice 4 (keploy-consumer-design-v2.md §7): this key is
+	// HONOURED as of this release. Before it, ValidateFlags overwrote whatever
+	// PreProcessFlags had loaded with an unconditional
+	// cmd.Flags().GetString("format"), so the yaml / mapstructure key was
+	// silently dead and a config saying `report: {format: junit}` still
+	// produced a text report. A user who set it expecting it to work now gets
+	// what they asked for, which is a stdout change on upgrade with no flag
+	// passed. Configs written by `keploy config --generate` carry
+	// `format: ""`, which still resolves to text.
+	//
+	// An explicitly passed --format always wins over this value; see
+	// cli/provider.resolvedReportFormat.
+	//
+	// An INVALID value here is a WARN and a fall back to text, not an error:
+	// the key was dead until this release, so anyone who set it wrong got no
+	// feedback, and turning that into a hard exit 1 would break a command that
+	// used to work with an error naming a flag the user never passed. An
+	// invalid value passed on --format IS an error — the user asked for
+	// something keploy cannot produce.
+	Format string `json:"format" yaml:"format" mapstructure:"format"`
 }
 
 type Globalnoise struct {

--- a/pkg/models/depresult.go
+++ b/pkg/models/depresult.go
@@ -1,0 +1,333 @@
+package models
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Dependency-assertion vocabulary for models.Result.DepResult.
+//
+// DepResult was declared long before anything wrote it: across keploy OSS,
+// enterprise and k8s-proxy it had ONE declaration, ONE reader and ZERO
+// writers. Slice 4 of keploy-consumer-design-v2.md ("DepResult on the sync
+// path") makes the replayer the first writer: for every HTTP/gRPC test, one
+// row per per-test dependency the recording says the test exercised that was
+// NOT observed during the test's window. The ones that WERE observed are not
+// rows at all — they are a count on the result (Result.DepsConsumed), so a
+// test that loses nothing still serializes `dep_result: []`.
+//
+// The one existing reader is k8s-proxy's report-download handler, which turns
+// each Normal==false row into a "dependency" diff — but only for tests whose
+// status is FAILED or OBSOLETE (it calls compactFailureDiffs on those alone).
+// A PASSED test carrying a missing dependency — the silent-green case this
+// slice exists to expose — therefore still shows as clean in the fleet report
+// until a companion k8s-proxy change surfaces it. OSS's text, JUnit and NDJSON
+// surfaces all show it today.
+//
+// The row NAME is a stable, human-first identifier that agents also parse, so
+// its shape is a one-way door:
+//
+//	deps[<i>] <type> <target> (presence)
+//
+// <i> indexes the test's RECORDED dependency list (the filtered mapping), not
+// the emitted rows, so a dependency keeps the same name from run to run
+// whatever else went missing in any particular run.
+//
+// SETTLED CONVENTION: the sync path uses `deps[i]`; `effects[i]` / `writes[i]`
+// are reserved for the consumer projector (design §2, slice 5), whose rows
+// carry field-level diffs decoded from a protocol payload. A sync-path row is
+// presence-only and covers outgoing reads as well as writes, so calling an
+// outgoing HTTP GET a "write" would be wrong, and keeping the prefixes
+// disjoint lets a consumer tell the two producers apart without a
+// schema-version bump. keploy-consumer-design-v2.md §2 and §7 slice 4 carry
+// the same convention.
+const (
+	// DepKeyPresence is the DepMetaResult.Key used by presence-only
+	// dependency assertions — the only per-dependency kind the sync path
+	// emits.
+	DepKeyPresence = "presence"
+
+	// DepKeyMissingCount is the DepMetaResult.Key of the OVERFLOW row that
+	// stands in for the missing dependencies past the per-test cap. See
+	// DepMissingOverflowRow.
+	DepKeyMissingCount = "missing_count"
+
+	// DepPresenceConsumed / DepPresenceMissing are the Expected/Actual values
+	// of a presence assertion. They are literal strings, not booleans, because
+	// DepMetaResult.Expected/Actual are strings in the persisted schema and
+	// must stay that way for on-disk compatibility.
+	DepPresenceConsumed = "consumed"
+	DepPresenceMissing  = "not consumed"
+
+	// DepNameSuffixPresence marks a row as PRODUCED BY THE SYNC-PATH PRESENCE
+	// WRITER. Every row this file builds carries it — the per-dependency rows
+	// and the missing-count overflow row — so one regex
+	// (`^deps\[[0-9*]+\] .* \(presence\)$`) matches the whole family and a
+	// consumer can tell a slice-4 sync row from a slice-5 `effects[i]` row,
+	// which carries field-level diffs decoded from a protocol payload, without
+	// a schema-version bump.
+	//
+	// It is deliberately NOT read as "this row asserts presence and nothing
+	// else": the overflow row asserts a COUNT (DepKeyMissingCount), and
+	// FormatDepResults special-cases it for exactly that reason. The suffix is
+	// a FAMILY MARKER, not an assertion kind.
+	DepNameSuffixPresence = "(presence)"
+
+	// DepSummaryIndex is the index token used by the missing-count overflow
+	// row, chosen so it cannot collide with a real `deps[<int>]` row.
+	DepSummaryIndex = "*"
+)
+
+// Normalised dependency protocol families used by DepResult.Type and by the
+// `effects[].type` field of the NDJSON contract.
+//
+// These are FAMILIES, not parser versions. models.Kind carries the parser
+// version (PostgresV2 / PostgresV3 / Http2), which is an implementation detail
+// of whichever recorder produced the mock: the same logical Postgres
+// dependency would otherwise render as "postgres", "postgresv2" or
+// "postgresv3" purely by recording vintage, and an agent keying on
+// `type == "postgres"` would silently miss most real recordings.
+const (
+	DepTypeHTTP     = "http"
+	DepTypePostgres = "postgres"
+	DepTypeGRPC     = "grpc"
+)
+
+// DepTypeForKind maps a mock Kind onto the stable protocol family used by
+// DepResult.Type. Kinds that already lowercase to their family (MySQL, Mongo,
+// Redis, Kafka, DNS, Generic, Aerospike, …) fall through to the default, so a
+// newly added Kind is handled sensibly without a code change — but
+// TestDepTypeForKind_CoversEveryKind fails until the new constant is
+// explicitly accounted for in the table, so a version-suffixed Kind cannot
+// slip through unnoticed.
+func DepTypeForKind(kind Kind) string {
+	switch kind {
+	case HTTP, HTTP2:
+		return DepTypeHTTP
+	case Postgres, PostgresV2, PostgresV3:
+		return DepTypePostgres
+	case GRPC_EXPORT:
+		return DepTypeGRPC
+	}
+	return strings.ToLower(strings.TrimSpace(string(kind)))
+}
+
+// DepRowName builds the stable DepResult.Name for a presence-checked
+// dependency. index is the dependency's position in the test's RECORDED
+// (filtered) dependency list — never its position among the emitted rows,
+// which would make the name depend on what else went missing in that run —
+// depType the normalised protocol family (see DepTypeForKind), and target a
+// human-meaningful destination (method + host/path, host:port, request
+// summary, …). depType and target are both optional: the mock pool does not
+// always carry them and a row must stay readable without them rather than
+// degrade to "deps[0]  (presence)".
+func DepRowName(index int, depType, target string) string {
+	return depRowName(strconv.Itoa(index), depType, target)
+}
+
+func depRowName(index, depType, target string) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "deps[%s]", index)
+	if depType != "" {
+		sb.WriteString(" ")
+		sb.WriteString(depType)
+	}
+	if target != "" {
+		sb.WriteString(" ")
+		sb.WriteString(target)
+	}
+	sb.WriteString(" ")
+	sb.WriteString(DepNameSuffixPresence)
+	return sb.String()
+}
+
+// DepMissingOverflowRow is the single row that stands in for the missing
+// dependencies beyond the per-test cap.
+//
+// WHY THERE IS A CAP AT ALL. The flagship case this slice exists to expose —
+// a downstream service removed, a worker that stopped producing, a mock pool
+// whose names drifted wholesale — makes EVERY expected per-test mock
+// unconsumed for EVERY test. Measured through reportdb.InsertReport over 100
+// tests x 200 mapped dependencies, an uncapped missing side wrote a 5.4 MB
+// test-set report where the pre-slice-4 build wrote 115 KB (47x), for a run
+// that today produces OBSOLETE tests and zero extra bytes. Reports are written
+// per test-set, re-read by `keploy report` and uploaded to the fleet report
+// store, so that growth lands in exactly the environment that can least afford
+// it — and it would land with the verdict knob OFF and no opt-in. The same
+// sizing argument is why the CONSUMED side is a plain count on the result
+// (Result.DepsConsumed) rather than one row per dependency.
+//
+// WHY THE ROW EXISTS RATHER THAN THE ROWS SIMPLY BEING TRUNCATED. It carries
+// Normal=false, so HasMissingDeps, MissingDepNames, the k8s-proxy report
+// handler and the NDJSON `matched: false` rule all still see the failure. A
+// silent truncation would under-report the very thing the slice makes visible;
+// this reports "and N more", which is a weaker claim but a true one.
+//
+// Expected "0" / Actual "<n>" reads as "expected nothing left unconsumed,
+// found n", matching the expected/actual vocabulary of every other row.
+func DepMissingOverflowRow(missing int) DepResult {
+	return DepResult{
+		// No Type: the overflow spans every protocol the test used, so any
+		// single family string here would be a lie.
+		Name: depRowName(DepSummaryIndex, "", fmt.Sprintf("%d more not consumed", missing)),
+		Meta: []DepMetaResult{{
+			Normal:   false,
+			Key:      DepKeyMissingCount,
+			Expected: "0",
+			Actual:   strconv.Itoa(missing),
+		}},
+	}
+}
+
+// IsDepMissingOverflow reports whether a row is the missing-count overflow row
+// rather than a per-dependency assertion.
+func IsDepMissingOverflow(d DepResult) bool {
+	return hasDepKey(d, DepKeyMissingCount)
+}
+
+func hasDepKey(d DepResult, key string) bool {
+	for _, m := range d.Meta {
+		if m.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
+// DepRowMatched reports whether every assertion carried by a dependency row
+// held. A row with no meta entries counts as matched: absence of a failed
+// assertion is not a failure.
+func DepRowMatched(d DepResult) bool {
+	for _, m := range d.Meta {
+		if !m.Normal {
+			return false
+		}
+	}
+	return true
+}
+
+// MissingDepNames returns the names of the dependency rows carrying at least
+// one failed assertion, in row order.
+func MissingDepNames(deps []DepResult) []string {
+	var out []string
+	for _, d := range deps {
+		if !DepRowMatched(d) {
+			out = append(out, d.Name)
+		}
+	}
+	return out
+}
+
+// DependenciesChecked reports whether the per-test dependency assertion
+// actually RAN for this test.
+//
+// It reads the persisted DepsChecked bit, NEVER len(DepResult): rows are
+// written only for dependencies that went MISSING, so a test that lost nothing
+// and a test whose assertion never executed (a --base-path / remote-agent run,
+// --disable-mapping, a test set with no usable mappings.yaml, a failed
+// per-test consumed-mock fetch, the deferred streaming path, a test the mapping
+// records no dependency for, a test whose every mapped dependency was
+// ineligible — session/connection tier or DNS, which is what an untagged
+// HTTP/Postgres/MySQL mock is — or any report written before this field had a
+// writer) all carry `dep_result: []` and are told apart only by this bit.
+//
+// A consumer MUST check this before reading "no failed rows" as "no dependency
+// regressions"; the two are not the same statement.
+func (r Result) DependenciesChecked() bool {
+	return r.DepsChecked
+}
+
+// HasMissingDeps reports whether any dependency assertion on this result
+// failed.
+func (r Result) HasMissingDeps() bool {
+	for _, d := range r.DepResult {
+		if !DepRowMatched(d) {
+			return true
+		}
+	}
+	return false
+}
+
+// FormatDepResults renders the full dependency-assertion block. Its only
+// callers are the two `keploy report` renderers (the compact one and --full),
+// which share it so they cannot drift from each other.
+//
+// It is NOT used by the live `keploy test` output: that path prints through
+// pkg/matcher's DiffsPrinter, which knows nothing about DepResult. During a
+// replay run a vanished dependency surfaces as the replayer's own log line
+// (per-test Debug with the knob off, Error with it on, plus one Warn per test
+// set) and in the persisted report; the expected-vs-actual block below appears
+// when the user runs `keploy report`.
+//
+// It returns the empty string for an empty row set, which is what keeps output
+// byte-identical for every test that has no per-test dependency bookkeeping
+// (i.e. everything recorded before this slice).
+//
+// Failed rows get one line per failed DepMetaResult in the same expected/actual
+// language the body-diff block uses. The writer emits no matched rows at all
+// (the consumed side is a count, Result.DepsConsumed), but the matched arm is
+// kept so a row from any other producer still renders as a compact
+// "consumed (presence only)" line, visually distinct from a real assertion
+// exactly as design §2 requires, rather than being silently dropped.
+func FormatDepResults(deps []DepResult) string {
+	if len(deps) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("=== DEPENDENCY ASSERTIONS ===\n")
+	for _, d := range deps {
+		if DepRowMatched(d) {
+			fmt.Fprintf(&sb, "  OK      %s - consumed (presence only)\n", d.Name)
+			continue
+		}
+		fmt.Fprintf(&sb, "  MISSING %s\n", d.Name)
+		if IsDepMissingOverflow(d) {
+			// The overflow row already reads "<n> more not consumed";
+			// appending `missing_count: expected "0", actual "<n>"` would
+			// restate it.
+			continue
+		}
+		for _, m := range d.Meta {
+			if m.Normal {
+				continue
+			}
+			key := m.Key
+			if key == "" {
+				key = DepKeyPresence
+			}
+			fmt.Fprintf(&sb, "      %s: expected %q, actual %q\n", key, m.Expected, m.Actual)
+		}
+	}
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+// DepNoticePrefix leads the compact one-line notice. Stable: CI log scrapers
+// and the agent loop grep for it.
+const DepNoticePrefix = "DEPENDENCY NOT EXERCISED:"
+
+// DepNoticeHint names the knob that turns the notice into a verdict.
+const DepNoticeHint = "reported only — run with --assert-dependencies to fail on this"
+
+// FormatDepNotice renders the COMPACT one-line notice for a test that did not
+// fail but lost a recorded outgoing call.
+//
+// This is the flagship silent-green case the slice exists to expose: the
+// response still matches (a deterministic dependency, a cached value, a
+// swallowed error) while the call the recording says the test makes was not
+// observed during the test's window. The replayer leaves such a test PASSED
+// by design — with --assert-dependencies off, which is the default, the
+// verdict does not change. Visibility must not depend on the knob, so the
+// notice is emitted whatever the status; only the FAILED/OBSOLETE path gets
+// the full block.
+//
+// Returns "" when nothing is missing, which keeps every pre-slice-4 report
+// byte-identical.
+func FormatDepNotice(deps []DepResult) string {
+	missing := MissingDepNames(deps)
+	if len(missing) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%s %s (%s)\n", DepNoticePrefix, strings.Join(missing, "; "), DepNoticeHint)
+}

--- a/pkg/models/depresult_test.go
+++ b/pkg/models/depresult_test.go
@@ -1,0 +1,553 @@
+package models
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestDepRowName(t *testing.T) {
+	tests := []struct {
+		name    string
+		index   int
+		depType string
+		target  string
+		want    string
+	}{
+		{name: "full row", index: 0, depType: "postgres", target: "orders", want: "deps[0] postgres orders (presence)"},
+		{name: "no target", index: 3, depType: "redis", target: "", want: "deps[3] redis (presence)"},
+		{name: "no type", index: 1, depType: "", target: "db:5432", want: "deps[1] db:5432 (presence)"},
+		{name: "neither", index: 2, depType: "", target: "", want: "deps[2] (presence)"},
+		{
+			name: "two calls to the same host stay distinguishable",
+			// The regression this guards: an HTTP target that collapses to the
+			// bare host makes every call to one service the same row name.
+			index: 4, depType: "http", target: "GET api.internal:8080/orders",
+			want: "deps[4] http GET api.internal:8080/orders (presence)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DepRowName(tt.index, tt.depType, tt.target); got != tt.want {
+				t.Errorf("DepRowName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDepTypeForKind(t *testing.T) {
+	tests := []struct {
+		kind Kind
+		want string
+	}{
+		// The whole point: parser versions collapse onto one family, so an
+		// agent keying on "postgres" cannot miss a v2/v3 recording.
+		{kind: Postgres, want: "postgres"},
+		{kind: PostgresV2, want: "postgres"},
+		{kind: PostgresV3, want: "postgres"},
+		{kind: HTTP, want: "http"},
+		{kind: HTTP2, want: "http"},
+		{kind: GRPC_EXPORT, want: "grpc"},
+		// Kinds whose lowercase form already IS the family.
+		{kind: MySQL, want: "mysql"},
+		{kind: Mongo, want: "mongo"},
+		{kind: REDIS, want: "redis"},
+		{kind: KAFKA, want: "kafka"},
+		{kind: DNS, want: "dns"},
+		{kind: GENERIC, want: "generic"},
+		{kind: Aerospike, want: "aerospike"},
+		{kind: RevokedTests, want: "keploy-revoked-tests"},
+		// Degenerate input must not produce a half-formed row name.
+		{kind: Kind(""), want: ""},
+		{kind: Kind("  Http  "), want: "http"},
+		{kind: Kind("SomeFutureProtocol"), want: "somefutureprotocol"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.kind), func(t *testing.T) {
+			if got := DepTypeForKind(tt.kind); got != tt.want {
+				t.Errorf("DepTypeForKind(%q) = %q, want %q", tt.kind, got, tt.want)
+			}
+		})
+	}
+}
+
+// kindConstantsInMockGo parses mock.go and returns every top-level constant
+// declared with the explicit type Kind, so the table above cannot silently
+// fall behind a newly added protocol.
+func kindConstantsInMockGo(t *testing.T) map[string]string {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "mock.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse mock.go: %v", err)
+	}
+	out := map[string]string{}
+	for _, decl := range f.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			ident, ok := vs.Type.(*ast.Ident)
+			if !ok || ident.Name != "Kind" {
+				continue
+			}
+			for i, name := range vs.Names {
+				if i >= len(vs.Values) {
+					continue
+				}
+				lit, ok := vs.Values[i].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				out[name.Name] = strings.Trim(lit.Value, `"`)
+			}
+		}
+	}
+	if len(out) == 0 {
+		t.Fatal("found no Kind constants in mock.go — the parser above is broken, not the code")
+	}
+	return out
+}
+
+// Every Kind constant declared in mock.go must have an explicit expectation in
+// TestDepTypeForKind. A new version-suffixed Kind (the PostgresV4 case) would
+// otherwise leak its parser version into the DepResult `type` contract and
+// into the row name, both of which are one-way doors.
+func TestDepTypeForKind_CoversEveryKind(t *testing.T) {
+	// Mirror of the table in TestDepTypeForKind, keyed by constant NAME so
+	// adding a constant here is a deliberate act.
+	covered := map[string]string{
+		"HTTP":         "http",
+		"HTTP2":        "http",
+		"GENERIC":      "generic",
+		"REDIS":        "redis",
+		"KAFKA":        "kafka",
+		"MySQL":        "mysql",
+		"Postgres":     "postgres",
+		"PostgresV2":   "postgres",
+		"PostgresV3":   "postgres",
+		"GRPC_EXPORT":  "grpc",
+		"Mongo":        "mongo",
+		"DNS":          "dns",
+		"Aerospike":    "aerospike",
+		"RevokedTests": "keploy-revoked-tests",
+	}
+
+	declared := kindConstantsInMockGo(t)
+	for name, value := range declared {
+		want, ok := covered[name]
+		if !ok {
+			t.Errorf("models.Kind constant %s (%q) is not covered by TestDepTypeForKind. "+
+				"Add it to both tables and check DepTypeForKind maps it to a protocol FAMILY, "+
+				"not a parser version — `type` is part of the NDJSON contract and of the row name.",
+				name, value)
+			continue
+		}
+		if got := DepTypeForKind(Kind(value)); got != want {
+			t.Errorf("DepTypeForKind(%s = %q) = %q, want %q", name, value, got, want)
+		}
+	}
+	for name := range covered {
+		if _, ok := declared[name]; !ok {
+			t.Errorf("the coverage table names %s, which no longer exists in mock.go", name)
+		}
+	}
+}
+
+// The consumed side is TWO SCALARS on the result, not rows. An earlier
+// revision of this slice persisted an aggregate `deps[*] N consumed` DepResult
+// row unconditionally, which cost +224 bytes of nested YAML per test on EVERY
+// report — including the ones where nothing is missing and the verdict knob is
+// off — to encode one bit and one small int. This pins the cheap encoding, and
+// pins that DependenciesChecked reads the BIT rather than inferring it from
+// len(DepResult): inferring is what forced the aggregate row to exist.
+func TestDependenciesCheckedReadsTheBitNotTheRows(t *testing.T) {
+	missing := DepResult{Name: "deps[0] postgres orders (presence)", Meta: []DepMetaResult{
+		{Normal: false, Key: DepKeyPresence, Expected: DepPresenceConsumed, Actual: DepPresenceMissing},
+	}}
+
+	tests := []struct {
+		name        string
+		result      Result
+		wantChecked bool
+		wantMissing bool
+		why         string
+	}{
+		{
+			name:   "never checked: the assertion did not run",
+			result: Result{},
+			why: "--base-path / remote-agent, --disable-mapping, no mappings.yaml, a failed " +
+				"consumed-mock fetch or a pre-slice-4 report. `dep_result: []` on its own " +
+				"cannot say this.",
+		},
+		{
+			name:        "checked and clean: nothing missing, nothing consumed",
+			result:      Result{DepsChecked: true},
+			wantChecked: true,
+			why: "The whole reason DepsChecked exists. Byte-identical to the row above on " +
+				"dep_result alone, and a consumer applying `any(matched == false)` would call " +
+				"both of them green.",
+		},
+		{
+			name:        "checked and clean with a consumed count",
+			result:      Result{DepsChecked: true, DepsConsumed: 20},
+			wantChecked: true,
+		},
+		{
+			name:        "checked and lossy",
+			result:      Result{DepsChecked: true, DepsConsumed: 3, DepResult: []DepResult{missing}},
+			wantChecked: true,
+			wantMissing: true,
+		},
+		{
+			name:        "rows without the bit are still not proof the assertion ran",
+			result:      Result{DepResult: []DepResult{missing}},
+			wantMissing: true,
+			why: "len(DepResult) > 0 must never be read as 'checked' — that inference is what " +
+				"the deleted aggregate row existed to prop up.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.result.DependenciesChecked(); got != tt.wantChecked {
+				t.Errorf("DependenciesChecked() = %v, want %v. %s", got, tt.wantChecked, tt.why)
+			}
+			if got := tt.result.HasMissingDeps(); got != tt.wantMissing {
+				t.Errorf("HasMissingDeps() = %v, want %v", got, tt.wantMissing)
+			}
+		})
+	}
+}
+
+// A clean CHECKED result must serialize with no dependency rows at all, so a
+// report whose tests lose nothing stays byte-compatible with a pre-slice-4
+// report apart from one short key. This is the hard constraint the aggregate
+// row violated; it is pinned on the YAML bytes, not on the struct.
+func TestCleanCheckedResultSerializesWithoutRows(t *testing.T) {
+	clean, err := yaml.Marshal(Result{DepsChecked: true, DepsConsumed: 20})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	unchecked, err := yaml.Marshal(Result{})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if !strings.Contains(string(clean), "dep_result: []") {
+		t.Errorf("a checked-and-clean result must still serialize `dep_result: []`:\n%s", clean)
+	}
+	if strings.Contains(string(clean), "deps[") {
+		t.Errorf("a checked-and-clean result must persist NO dependency rows:\n%s", clean)
+	}
+	for _, want := range []string{"deps_checked: true", "deps_consumed: 20"} {
+		if !strings.Contains(string(clean), want) {
+			t.Errorf("missing %q:\n%s", want, clean)
+		}
+	}
+
+	// omitempty: an UNCHECKED result — every pre-slice-4 report and every mode
+	// that cannot arm the mapping — must not grow either key.
+	for _, bad := range []string{"deps_checked", "deps_consumed"} {
+		if strings.Contains(string(unchecked), bad) {
+			t.Errorf("an unchecked result must not serialize %q; existing reports would change:\n%s",
+				bad, unchecked)
+		}
+	}
+
+	// The measured cost of the bit, pinned so a future revision cannot quietly
+	// re-inflate it. The deleted aggregate row cost +224 B per test.
+	if grew := len(clean) - len(unchecked); grew > 64 {
+		t.Errorf("a checked-and-clean result costs %d bytes over an unchecked one; "+
+			"the budget for encoding 'checked, N consumed' is one bit and one small int, "+
+			"not a nested row:\n%s", grew, clean)
+	}
+}
+
+// The overflow row is what keeps the flagship "every dependency vanished"
+// shape from writing a 5.4 MB test-set report. It must still read as a
+// FAILURE, or capping the missing side would silently un-report the thing the
+// slice exists to report.
+// The wire vocabulary, pinned as LITERALS. Everything else in this package
+// asserts these constants against themselves — renaming DepKeyMissingCount to
+// "presence" left the whole suite green — while `key` is a field of the NDJSON
+// contract (`effects[].key`) and of the persisted report YAML, which agents
+// and the k8s-proxy report handler both read. Changing one of these strings is
+// a schema change; it has to be a deliberate fixture update.
+func TestDepVocabularyLiterals(t *testing.T) {
+	for _, tt := range []struct{ got, want, what string }{
+		{DepKeyPresence, "presence", "DepKeyPresence"},
+		{DepKeyMissingCount, "missing_count", "DepKeyMissingCount"},
+		{DepPresenceConsumed, "consumed", "DepPresenceConsumed"},
+		{DepPresenceMissing, "not consumed", "DepPresenceMissing"},
+		{DepNameSuffixPresence, "(presence)", "DepNameSuffixPresence"},
+		{DepSummaryIndex, "*", "DepSummaryIndex"},
+		{DepNoticePrefix, "DEPENDENCY NOT EXERCISED:", "DepNoticePrefix"},
+		{DepNoticeHint, "reported only — run with --assert-dependencies to fail on this", "DepNoticeHint"},
+		{DepTypeHTTP, "http", "DepTypeHTTP"},
+		{DepTypePostgres, "postgres", "DepTypePostgres"},
+		{DepTypeGRPC, "grpc", "DepTypeGRPC"},
+	} {
+		if tt.got != tt.want {
+			t.Errorf("%s = %q, want %q. These strings are on the wire (NDJSON effects[].key / "+
+				"effects[].type and the persisted dep_result YAML) and in the CI-scraped notice "+
+				"line; changing one is a contract change, not a rename.", tt.what, tt.got, tt.want)
+		}
+	}
+	// The overflow key must stay distinct from the per-dependency key, or
+	// IsDepMissingOverflow stops telling "this named dependency went missing"
+	// apart from "3 more did".
+	if DepKeyMissingCount == DepKeyPresence {
+		t.Fatal("the overflow and presence keys are the same string")
+	}
+}
+
+func TestDepMissingOverflowRow(t *testing.T) {
+	row := DepMissingOverflowRow(150)
+
+	// The literal, not the builders: this name is on the wire (NDJSON
+	// `effects[].name`), in the persisted YAML and in the rendered block.
+	if row.Name != "deps[*] 150 more not consumed (presence)" {
+		t.Errorf("Name = %q", row.Name)
+	}
+	if row.Type != "" {
+		t.Errorf("the overflow spans protocols so Type must stay empty, got %q", row.Type)
+	}
+	if !IsDepMissingOverflow(row) {
+		t.Error("IsDepMissingOverflow must recognise its own row")
+	}
+	if DepRowMatched(row) {
+		t.Fatal("the overflow row must count as a FAILED assertion, otherwise capping the " +
+			"missing side hides the missing dependencies from HasMissingDeps, MissingDepNames, " +
+			"the k8s-proxy report handler and the NDJSON matched==false rule")
+	}
+	if len(row.Meta) != 1 || row.Meta[0].Key != DepKeyMissingCount ||
+		row.Meta[0].Expected != "0" || row.Meta[0].Actual != "150" {
+		t.Errorf("meta = %+v", row.Meta)
+	}
+
+	res := Result{DepsChecked: true, DepResult: []DepResult{row}}
+	if !res.HasMissingDeps() {
+		t.Error("a result carrying only the overflow row must report missing dependencies")
+	}
+	if names := MissingDepNames(res.DepResult); len(names) != 1 || names[0] != row.Name {
+		t.Errorf("MissingDepNames = %v", names)
+	}
+}
+
+// The overflow row shares the `deps[*] ... (presence)` grammar, which is the
+// family marker every sync-path row carries (see DepNameSuffixPresence). It is
+// told apart from a per-dependency row by its Meta key, never by the name.
+func TestAggregateRowsShareTheSyncPathNameGrammar(t *testing.T) {
+	for _, row := range []DepResult{DepMissingOverflowRow(3)} {
+		if !strings.HasPrefix(row.Name, "deps["+DepSummaryIndex+"] ") {
+			t.Errorf("%q does not use the aggregate index token", row.Name)
+		}
+		if !strings.HasSuffix(row.Name, " "+DepNameSuffixPresence) {
+			t.Errorf("%q does not carry the sync-path family marker", row.Name)
+		}
+	}
+}
+
+func TestDepRowMatchedAndMissingDepNames(t *testing.T) {
+	missing := DepResult{Name: "deps[0] postgres orders (presence)", Type: "postgres", Meta: []DepMetaResult{
+		{Normal: false, Key: DepKeyPresence, Expected: DepPresenceConsumed, Actual: DepPresenceMissing},
+	}}
+	ok := DepResult{Name: "deps[1] http api (presence)", Type: "http", Meta: []DepMetaResult{
+		{Normal: true, Key: DepKeyPresence, Expected: DepPresenceConsumed, Actual: DepPresenceConsumed},
+	}}
+	noMeta := DepResult{Name: "deps[2] redis (presence)", Type: "redis"}
+
+	tests := []struct {
+		name      string
+		result    Result
+		wantHas   bool
+		wantNames []string
+	}{
+		{name: "no rows", result: Result{}, wantHas: false},
+		{name: "all matched", result: Result{DepResult: []DepResult{ok, noMeta}}, wantHas: false},
+		{
+			name: "one missing", result: Result{DepResult: []DepResult{ok, missing}},
+			wantHas: true, wantNames: []string{"deps[0] postgres orders (presence)"},
+		},
+		{
+			name:   "a checked result with no rows has no missing dep",
+			result: Result{DepsChecked: true, DepsConsumed: 12},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.result.HasMissingDeps(); got != tt.wantHas {
+				t.Errorf("HasMissingDeps() = %v, want %v", got, tt.wantHas)
+			}
+			names := MissingDepNames(tt.result.DepResult)
+			if len(names) != len(tt.wantNames) {
+				t.Fatalf("MissingDepNames() = %v, want %v", names, tt.wantNames)
+			}
+			for i := range names {
+				if names[i] != tt.wantNames[i] {
+					t.Errorf("MissingDepNames()[%d] = %q, want %q", i, names[i], tt.wantNames[i])
+				}
+			}
+		})
+	}
+
+	if !DepRowMatched(noMeta) {
+		t.Error("a row with no assertions must count as matched")
+	}
+	if DepRowMatched(missing) {
+		t.Error("a row with a failed assertion must not count as matched")
+	}
+}
+
+func TestFormatDepResults(t *testing.T) {
+	tests := []struct {
+		name      string
+		deps      []DepResult
+		wantEmpty bool
+		contains  []string
+		absent    []string
+	}{
+		{
+			name:      "no rows renders nothing at all",
+			deps:      nil,
+			wantEmpty: true,
+		},
+		{
+			name: "missing row renders expected vs actual",
+			deps: []DepResult{{
+				Name: "deps[0] postgres orders (presence)",
+				Type: "postgres",
+				Meta: []DepMetaResult{{Normal: false, Key: DepKeyPresence, Expected: DepPresenceConsumed, Actual: DepPresenceMissing}},
+			}},
+			contains: []string{
+				"=== DEPENDENCY ASSERTIONS ===",
+				"MISSING deps[0] postgres orders (presence)",
+				`presence: expected "consumed", actual "not consumed"`,
+			},
+			absent: []string{"consumed (presence only)"},
+		},
+		{
+			name: "matched row collapses to one compact line",
+			deps: []DepResult{{
+				Name: "deps[0] http GET api.internal:80/orders (presence)",
+				Type: "http",
+				Meta: []DepMetaResult{{Normal: true, Key: DepKeyPresence, Expected: DepPresenceConsumed, Actual: DepPresenceConsumed}},
+			}},
+			contains: []string{"OK      deps[0] http GET api.internal:80/orders (presence) - consumed (presence only)"},
+			absent:   []string{"MISSING"},
+		},
+		{
+			// The overflow row already reads "<n> more not consumed";
+			// restating it as `missing_count: expected "0", actual "150"`
+			// would stutter.
+			name:     "the missing overflow does not stutter",
+			deps:     []DepResult{DepMissingOverflowRow(150)},
+			contains: []string{"MISSING deps[*] 150 more not consumed (presence)"},
+			absent:   []string{"missing_count:"},
+		},
+		{
+			name: "a meta with no key falls back to the presence key",
+			deps: []DepResult{{
+				Name: "deps[0] kafka orders (presence)",
+				Type: "kafka",
+				Meta: []DepMetaResult{{Normal: false, Expected: "1", Actual: "0"}},
+			}},
+			contains: []string{`presence: expected "1", actual "0"`},
+		},
+		{
+			name: "matched metas inside a failed row are not printed twice",
+			deps: []DepResult{{
+				Name: "deps[0] kafka orders (presence)",
+				Type: "kafka",
+				Meta: []DepMetaResult{
+					{Normal: true, Key: "protocol", Expected: "kafka", Actual: "kafka"},
+					{Normal: false, Key: "presence", Expected: "consumed", Actual: "not consumed"},
+				},
+			}},
+			contains: []string{`presence: expected "consumed", actual "not consumed"`},
+			absent:   []string{"protocol:"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatDepResults(tt.deps)
+			if tt.wantEmpty {
+				if got != "" {
+					t.Fatalf("expected empty output, got %q", got)
+				}
+				return
+			}
+			for _, want := range tt.contains {
+				if !strings.Contains(got, want) {
+					t.Errorf("output missing %q:\n%s", want, got)
+				}
+			}
+			for _, bad := range tt.absent {
+				if strings.Contains(got, bad) {
+					t.Errorf("output unexpectedly contains %q:\n%s", bad, got)
+				}
+			}
+		})
+	}
+}
+
+func TestFormatDepNotice(t *testing.T) {
+	missing := func(name string) DepResult {
+		return DepResult{Name: name, Meta: []DepMetaResult{
+			{Normal: false, Key: DepKeyPresence, Expected: DepPresenceConsumed, Actual: DepPresenceMissing},
+		}}
+	}
+	consumed := DepResult{Name: "deps[0] http x (presence)", Meta: []DepMetaResult{
+		{Normal: true, Key: DepKeyPresence, Expected: DepPresenceConsumed, Actual: DepPresenceConsumed},
+	}}
+
+	tests := []struct {
+		name string
+		deps []DepResult
+		want string
+	}{
+		{name: "nothing missing renders nothing", deps: nil, want: ""},
+		{name: "everything consumed renders nothing", deps: []DepResult{consumed}, want: ""},
+		{
+			name: "one missing dependency is one line",
+			deps: []DepResult{missing("deps[0] postgres INSERT (presence)")},
+			want: DepNoticePrefix + " deps[0] postgres INSERT (presence) (" + DepNoticeHint + ")\n",
+		},
+		{
+			name: "several missing dependencies stay on one line",
+			deps: []DepResult{missing("deps[0] a (presence)"), missing("deps[1] b (presence)")},
+			want: DepNoticePrefix + " deps[0] a (presence); deps[1] b (presence) (" + DepNoticeHint + ")\n",
+		},
+		{
+			// THE LITERAL, not the constants. Every other assertion on this
+			// line writes `DepNoticePrefix + ...`, i.e. compares the constant
+			// to itself: changing DepNoticePrefix to "DEPS:" left the whole
+			// suite green even though its own doc calls it a stable grep
+			// contract for CI log scrapers and the agent loop. Pinning the
+			// bytes once makes a change to either constant a deliberate
+			// fixture update. Same treatment goldenNDJSONLine gives
+			// schema_version.
+			name: "the rendered line is byte-stable (grep contract)",
+			deps: []DepResult{missing("deps[0] postgres INSERT (presence)")},
+			want: "DEPENDENCY NOT EXERCISED: deps[0] postgres INSERT (presence) " +
+				"(reported only — run with --assert-dependencies to fail on this)\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FormatDepNotice(tt.deps); got != tt.want {
+				t.Errorf("FormatDepNotice() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/models/testrun.go
+++ b/pkg/models/testrun.go
@@ -259,6 +259,13 @@ const (
 	// a content regression. The synthetic status_code=0 such a failure records
 	// must not be read as a STATUS_CODE_CHANGED regression.
 	AppConnectionError FailureCategory = "APP_CONNECTION_ERROR"
+	// DependencyMissing means a per-test dependency the recording says this
+	// test exercised (a mapped, non-reusable-tier mock) went unconsumed during
+	// replay — the app stopped making an outgoing call it used to make. Set by
+	// the replayer's DepResult writer alongside the DepResult rows themselves
+	// (keploy-consumer-design-v2.md §5, false-pass row 0). Attached only to
+	// FAILED/OBSOLETE tests so a passing test never grows a failure label.
+	DependencyMissing FailureCategory = "DEPENDENCY_MISSING"
 )
 
 // RejectionReason classifies why a test case was marked unreplayable during autoreplay.
@@ -323,8 +330,88 @@ type Result struct {
 	HeadersResult  []HeaderResult `json:"headers_result" bson:"headers_result" yaml:"headers_result"`
 	BodyResult     []BodyResult   `json:"body_result" bson:"body_result" yaml:"body_result"`
 	BodySizeResult IntResult      `json:"body_size_result,omitempty" bson:"body_size_result,omitempty" yaml:"body_size_result,omitempty"` // used when body was skipped (>1MB)
-	DepResult      []DepResult    `json:"dep_result" bson:"dep_result" yaml:"dep_result"`
-	TrailerResult  []HeaderResult `json:"trailer_result,omitempty" bson:"trailer_result,omitempty" yaml:"trailer_result,omitempty"`
+	// DepResult carries per-test DEPENDENCY assertions: ONE ROW PER OUTGOING
+	// DEPENDENCY THAT WENT MISSING — a call the recording says this test
+	// exercised that was NOT observed during the test's window
+	// (Meta[i].Normal == false). Written by the replayer's standard
+	// (non-streaming) per-test result block for every test — passed, failed or
+	// obsolete — from the existing expected-vs-consumed mock bookkeeping.
+	//
+	// EMPTY IS NOT "NOT CHECKED": it means nothing went missing OR the
+	// assertion never ran, and the two are told apart by DepsChecked below,
+	// never by len(DepResult). Read it through Result.DependenciesChecked().
+	//
+	// SCOPE, so an absent row is not misread as coverage: only mocks recorded
+	// as PER-TEST tier are asserted. Session/connection-tier mocks and DNS are
+	// excluded, and an untagged HTTP / HTTP2 / Postgres / MySQL / Generic mock
+	// is classified session-tier by Mock.DeriveLifetime — so an ordinary
+	// recorded outgoing call is NOT necessarily covered, and a recording whose
+	// mocks carry no tier tag produces no rows and DepsChecked=false for every
+	// test.
+	//
+	// The dependencies that WERE exercised are NOT persisted here, in any
+	// mode: they collapse into the DepsConsumed count. Measured through
+	// reportdb.InsertReport, one row per consumed dependency costs ~190 bytes
+	// of YAML each, and a Postgres-chatty suite consumes 50-200 mocks per
+	// test — 3-11 MB per test-set report of `consumed/consumed` boilerplate no
+	// consumer reads. The identities are already persisted by
+	// TestResult.MatchedCalls.
+	//
+	// COMPATIBILITY: statuses, exit codes and every other field are unchanged
+	// when nothing is missing and --assert-dependencies is off, and a test
+	// that loses nothing serializes `dep_result: []` exactly as it did before
+	// this field had a writer — the only added bytes are the two scalars
+	// below.
+	//
+	// Deliberately carries NO omitempty — every report written before this
+	// field had a writer already serializes `dep_result: []`, and adding
+	// omitempty would change every existing report on disk.
+	//
+	// See keploy-consumer-design-v2.md §2 and §7 slice 4.
+	DepResult []DepResult `json:"dep_result" bson:"dep_result" yaml:"dep_result"`
+
+	// DepsChecked is the persisted proof that the per-test dependency
+	// assertion RAN for this test, over AT LEAST ONE ELIGIBLE DEPENDENCY. It
+	// is the ONE BIT that makes `dep_result: []` unambiguous: without it a
+	// test that lost nothing and a test whose assertion never executed (a
+	// --base-path / remote-agent run, --disable-mapping, a test set with no
+	// usable mappings.yaml, a failed per-test consumed-mock fetch, the
+	// deferred streaming path, a test the mapping records no dependency for, a
+	// test whose every mapped dependency was ineligible, or any report written
+	// before this field had a writer) are byte-identical on disk — and a
+	// consumer applying the documented "any(matched == false)" rule reports
+	// "no dependency regressions" for a run in which the question was never
+	// asked.
+	//
+	// ELIGIBLE means recorded as PER-TEST tier. Session/connection-tier mocks
+	// are excluded from the assertion (shared across every test, so not
+	// attributable to one test's window) and so is DNS. Because
+	// Mock.DeriveLifetime classifies an untagged HTTP / HTTP2 / Postgres /
+	// MySQL / Generic mock as session-tier, a recording whose mocks carry no
+	// per-test tier tag has nothing eligible and this bit is false for every
+	// one of its tests — which is the honest answer, not a clean one.
+	//
+	// omitempty on purpose: false is the pre-slice-4 value, so an unchecked
+	// test and every report already on disk serialize exactly as before. A
+	// checked test costs one short key instead of the ~224-byte aggregate
+	// DepResult row an earlier revision of this slice wrote for the same bit.
+	//
+	// Read it through Result.DependenciesChecked().
+	DepsChecked bool `json:"deps_checked,omitempty" bson:"deps_checked,omitempty" yaml:"deps_checked,omitempty"`
+
+	// DepsConsumed is how many recorded per-test dependencies WERE observed
+	// during this test's window. Meaningful only when DepsChecked is true;
+	// omitempty keeps it off the wire for an unchecked test and for a checked
+	// test that consumed nothing.
+	//
+	// It replaces the per-dependency matched rows (see DepResult above): the
+	// magnitude is what a report consumer uses — "12 of 12 exercised" versus
+	// "0 of 12" is the difference between a healthy test and an app that never
+	// reached its database — while the identities live in
+	// TestResult.MatchedCalls.
+	DepsConsumed int `json:"deps_consumed,omitempty" bson:"deps_consumed,omitempty" yaml:"deps_consumed,omitempty"`
+
+	TrailerResult []HeaderResult `json:"trailer_result,omitempty" bson:"trailer_result,omitempty" yaml:"trailer_result,omitempty"`
 }
 
 type DepResult struct {

--- a/pkg/service/replay/depresult.go
+++ b/pkg/service/replay/depresult.go
@@ -1,0 +1,1010 @@
+package replay
+
+import (
+	"net/url"
+	"slices"
+	"sort"
+	"strings"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// mockDisplayInfo carries the human-facing identity of a loaded mock, built
+// once per test set from the mock registry and keyed by mock name. Hoisted out
+// of RunTestSet (where it used to be a function-local `mockInfo`) so the
+// DepResult writer below can be unit-tested without a full replay.
+//
+// Every field is best-effort: r.mockDB may be nil and GetUnFilteredMocks
+// errors are swallowed at the build site, so a lookup miss is normal and
+// consumers must degrade rather than assume a hit.
+type mockDisplayInfo struct {
+	summary  string
+	protocol string
+	target   string
+}
+
+// mockTargetFromSpec derives a human-meaningful destination for a mock.
+//
+// Neither models.MockEntry (the mapping / expected side) nor models.MockState
+// (the consumed side) records a destination, so the loaded *models.Mock is the
+// only place one exists. Priority order, MOST DISCRIMINATING first — the row
+// name has to tell five outgoing calls to the same service apart:
+//
+//  1. HTTP: method + host + path. A bare host collapses every call to one
+//     service into indistinguishable rows; `GET api.internal:8080/orders` is
+//     the string a human acts on and an agent keys off.
+//  2. Metadata["destAddr"] ("host:port", written by the MySQL and Postgres
+//     recorders) PLUS the mock's operation token when it has one, so the two
+//     protocols that route every call through a single address still produce
+//     distinct rows ("mysql:3306 COM_QUERY").
+//  3. The protocol-generic summary (models.MockSummaryFromSpec), which is what
+//     the report UI already shows for MatchedCalls. It beats the bare
+//     `operation` token below because for Mongo/MySQL/Postgres it is
+//     "<protocol> <operation>" rather than a naked verb.
+//  4. The operation token on its own — the only identifying thing some v1
+//     mocks carry.
+//
+// Returns "" when none is available; DepRowName renders correctly without it.
+func mockTargetFromSpec(mock *models.Mock) string {
+	if mock == nil {
+		return ""
+	}
+	if t := httpTargetFromReq(mock.Spec.HTTPReq); t != "" {
+		return t
+	}
+	md := mock.Spec.Metadata
+	op := mockOperationToken(md)
+	if v := strings.TrimSpace(md["destAddr"]); v != "" {
+		if op != "" {
+			return v + " " + op
+		}
+		return v
+	}
+	// MockSummaryFromSpec falls back to the bare Kind when a mock carries
+	// nothing identifying. That is already the row's `type` token, so using it
+	// as the target too would render "deps[0] redis Redis (presence)".
+	if s := strings.TrimSpace(models.MockSummaryFromSpec(mock)); s != "" && s != string(mock.Kind) {
+		return s
+	}
+	return op
+}
+
+// mockOperationToken returns the most specific operation verb a mock's
+// metadata carries.
+//
+// "operation" is the key every v1 recorder writes and the only one
+// models.MockSummaryFromSpec reads. The MySQL v2 recorder writes
+// "requestOperation"/"responseOperation" instead (see
+// integrations/mysql/recorder/record_v2.go), which is why MockSummaryFromSpec
+// returns a bare "MySQL" for those mocks — and why every MySQL dependency row
+// would otherwise collapse to the shared "mysql:3306" address with only the
+// index to tell them apart. The response side is deliberately not consulted:
+// it names the server's reply status ("OK"), not the call.
+func mockOperationToken(md map[string]string) string {
+	for _, key := range []string{"operation", "requestOperation"} {
+		if v := strings.TrimSpace(md[key]); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// httpTargetFromReq renders an outgoing HTTP call as "<METHOD> <host><path>".
+// The scheme is dropped (it is implied by the port and adds noise to a name
+// that is already long) but the path is not: the path is the only thing that
+// distinguishes two calls to the same service.
+func httpTargetFromReq(req *models.HTTPReq) string {
+	if req == nil {
+		return ""
+	}
+	method := strings.TrimSpace(string(req.Method))
+	raw := strings.TrimSpace(req.URL)
+	target := raw
+	if u, err := url.Parse(raw); err == nil && u.Host != "" {
+		target = u.Host + u.EscapedPath()
+	}
+	switch {
+	case method == "" && target == "":
+		return ""
+	case method == "":
+		return target
+	case target == "":
+		return method
+	}
+	return method + " " + target
+}
+
+// eligibleExpectedEntries is THE SINGLE DEFINITION of "which of the
+// dependencies the recording mapped to this test may the per-test assertion
+// look at". Both readers of that question call it, and they must, because the
+// two of them now decide different halves of one user-visible verdict:
+//
+//   - RunTestSet derives filteredExpectedNames from it (the list isMockSubset
+//     compares against, i.e. the mockSetMismatch verdict) AND noEligibleDeps
+//     from it (the latched WARN that tells the user WHY nothing was asserted);
+//   - buildDepResults iterates it, deciding the persisted deps_checked bit,
+//     deps_consumed and the MISSING rows.
+//
+// Before this was one function the predicate was written out twice, once at
+// each site. Nothing pinned that the two copies agreed, and widening one of
+// them alone produces exactly the silent-honesty regressions this slice exists
+// to close: widen it here only and the writer reports NOT-CHECKED while the
+// warner stays silent, so the user gets `dependencies_checked: false` with no
+// explanation; widen it at the call site only and the warning fires for test
+// sets whose assertion did run, training users to ignore the line. Both keep
+// the whole suite green, because each half is pinned separately and each half
+// is individually correct. Sharing the function makes
+// `noEligibleDeps == (len(expected) > 0 && len(eligible) == 0)` true BY
+// CONSTRUCTION rather than by two people remembering.
+//
+// WHAT IS EXCLUDED, and why it is not the bug:
+//
+//   - DNS: resolution order is non-deterministic.
+//   - Reusable tiers (session / connection / config): recorded once at app
+//     boot and shared across every test, so they are not deterministically
+//     attributed to one test's window. Asserting their presence per test would
+//     go "missing" at random and fail healthy tests.
+//
+// The exclusion is deliberate and is NOT relaxed to make the assertion cover
+// more recordings — that would trade a false green for a false red. What the
+// caller owes the user is an honest report that the assertion had nothing to
+// run over, which is what the eligibility guard in buildDepResults and the
+// warning keyed off noEligibleDeps between them provide.
+//
+// Returns a slice that aliases nothing in expected (entries are copied by
+// value), so callers may retain it.
+func eligibleExpectedEntries(
+	expected []models.MockEntry,
+	mockKindByName map[string]models.Kind,
+	reusableMockNames map[string]bool,
+) []models.MockEntry {
+	eligible := make([]models.MockEntry, 0, len(expected))
+	for _, m := range expected {
+		if isDNSMockEntry(m, mockKindByName) || reusableMockNames[m.Name] {
+			continue
+		}
+		eligible = append(eligible, m)
+	}
+	return eligible
+}
+
+// buildDepResults is the first writer of models.Result.DepResult
+// (keploy-consumer-design-v2.md §2 "Report — first ever writer of
+// models.Result.DepResult", §7 slice 4).
+//
+// It emits one presence row per per-test dependency the recording says this
+// test exercised that was NOT observed during the test's window — i.e. per
+// mapped mock that survives the SAME filters the existing consumed-vs-expected
+// assertion applies:
+//
+//   - DNS is excluded: resolution order is non-deterministic.
+//   - Reusable tiers (session / connection / config) are excluded: they are
+//     recorded once at app boot and shared across every test, so they are not
+//     deterministically attributed to a single test's window. Including them
+//     would emit rows that go "missing" at random.
+//
+// The dependencies that WERE observed are NOT persisted individually, in any
+// mode: they collapse into depAssertion.Consumed, a plain int on the result.
+// One row per consumed dependency costs ~190 bytes of YAML in a report that is
+// written per test-set, re-read by `keploy report` and uploaded to the fleet
+// report store; a Postgres-chatty suite consumes 50-200 mocks per test, so
+// that is 3-11 MB per test-set report of `consumed/consumed` boilerplate no
+// consumer reads, and the identities are already persisted by
+// TestResult.MatchedCalls.
+//
+// depAssertion.Checked IS THE ONE BIT THAT MAKES `dep_result: []`
+// UNAMBIGUOUS, and it is set when `valid` holds AND AT LEAST ONE MAPPED
+// DEPENDENCY SURVIVED THE FILTER ABOVE — even if nothing was missing and
+// nothing was consumed. Without the bit a test that lost nothing and a test
+// whose assertion never executed (a --base-path run, --disable-mapping, a test
+// set with no mappings.yaml, a failed consumed-mock fetch) are byte-identical
+// on disk, and an agent reading the NDJSON contract cannot tell "no dependency
+// regressions" from "this question was never asked" — which would re-create,
+// in the machine-readable surface, exactly the false-green this slice exists
+// to close.
+//
+// The eligibility half of that conjunction is not a detail: `valid` is
+// computed from the RUN's shape (instrument mode, a live mapping, a successful
+// consumed fetch) and says nothing about whether this test had a dependency
+// the assertion is allowed to look at. For an ordinary recording it usually
+// does not — see the eligibility guard at the bottom of this function — and
+// setting Checked from `valid` alone reported "the assertion ran and found
+// nothing missing" for tests where it never ran over a single dependency.
+//
+// An earlier revision of this slice encoded that same bit as an
+// unconditionally-written aggregate DepResult row, which cost +224 bytes of
+// nested YAML per test on EVERY report, forever, including the ones where
+// nothing is missing and the verdict knob is off. Two scalars with omitempty
+// carry the same information for ~40 bytes, and leave a clean test's
+// `dep_result: []` byte-identical to a pre-slice-4 report.
+//
+// The consumed side applies the same DNS + reusable-tier filter that
+// filteredMockNames does at the call site, so "this function produced a row
+// with Normal=false" and "isMockSubset(filteredMockNames, filteredExpected)
+// returned false" are the same signal computed from the same inputs. That
+// matters because the --assert-dependencies verdict keys off mockSetMismatch
+// while the rendered explanation comes from these rows: if the two used
+// different filters a user could get a FAILED test with nothing to look at.
+//
+// valid gates the whole thing (it becomes depAssertion.Checked). It must be
+// the SAME predicate that gates
+// mockSetMismatch (see depAssertionValid at the call site): an expected-vs-
+// consumed comparison is only a valid per-test assertion when the per-test
+// mock mapping was actually armed on the agent, which happens only in
+// instrument mode with mapping-based strategy and a successful per-test
+// consumed fetch. Returning the zero depAssertion (rather than a set of false
+// rows) keeps the report byte-identical to today for every other mode — the
+// same policy MockMismatches and MatchedCalls already use.
+//
+// This does NOT change how mocks are matched or served; it is a read-only
+// projection of bookkeeping the replay loop already computes.
+func buildDepResults(
+	expected []models.MockEntry,
+	consumed []models.MockState,
+	valid bool,
+	reusableMockNames map[string]bool,
+	mockKindByName map[string]models.Kind,
+	lookup map[string]mockDisplayInfo,
+) depAssertion {
+	if !valid || len(expected) == 0 {
+		return depAssertion{}
+	}
+
+	consumedNames := make(map[string]bool, len(consumed))
+	for _, m := range consumed {
+		if m.Kind == models.DNS || isReusableTierState(m) {
+			continue
+		}
+		consumedNames[m.Name] = true
+	}
+
+	var out []models.DepResult
+	consumedCount := 0
+	// missingOverflow counts the missing dependencies past depMissingRowCap.
+	// They collapse into one models.DepMissingOverflowRow instead of being
+	// written out individually — see that function for the sizing measurement
+	// and for why the collapsed row still carries Normal=false.
+	missingOverflow := 0
+	// depIndex counts positions in the FILTERED EXPECTED list, not in the
+	// emitted slice. The row name is documented as a stable identifier that
+	// agents correlate across runs (models.DepRowName), and indexing by output
+	// position made it depend on which OTHER dependencies happened to be
+	// missing in that particular run: with expectations [a b c], a run that
+	// lost only `a` and a run that lost only `c` both emitted "deps[0]",
+	// naming two different dependencies. Indexing by the recording makes the
+	// index a property of the mapping, so the same dependency keeps the same
+	// name whatever else happened.
+	//
+	// HONESTLY, though, it is a property of the mapping AND of the mock data
+	// this run managed to load: the skip below reads mockKindByName and
+	// reusableMockNames, both filled from the mocks RunTestSet fetched, and
+	// the registry fetch that backs `lookup` swallows its error (r.mockDB may
+	// also be nil). A run that classifies fewer entries as DNS or
+	// reusable-tier skips fewer of them and shifts every index after the
+	// first one it failed to classify. So the name is stable across runs that
+	// loaded the same mock set — which is the normal case, since rows are only
+	// built when depAssertionValid holds and that requires instrument mode —
+	// not stable unconditionally. An agent correlating rows across runs should
+	// treat the name as an identifier, not as a promise.
+	//
+	// eligibleExpectedEntries is the SHARED definition of the filter, the same
+	// call RunTestSet uses to build filteredExpectedNames and noEligibleDeps.
+	// It is not inlined here: the persisted Checked bit and the user-facing
+	// "why nothing was asserted" warning are then two computations of one
+	// question, and nothing would pin that they agree.
+	eligible := eligibleExpectedEntries(expected, mockKindByName, reusableMockNames)
+	depIndex := 0
+	for _, m := range eligible {
+		i := depIndex
+		depIndex++
+
+		if consumedNames[m.Name] {
+			consumedCount++
+			continue
+		}
+
+		if len(out) >= depMissingRowCap {
+			// Past the cap. The dependencies are visited in RECORDED order
+			// (depIndex above), so which ones make the cut is a property of
+			// the mapping and is stable across runs — a report diffed between
+			// two runs does not shuffle.
+			missingOverflow++
+			continue
+		}
+
+		depType := depTypeFor(m, mockKindByName, lookup)
+		out = append(out, models.DepResult{
+			Name: models.DepRowName(i, depType, depTargetFor(m, lookup)),
+			Type: depType,
+			Meta: []models.DepMetaResult{{
+				Normal:   false,
+				Key:      models.DepKeyPresence,
+				Expected: models.DepPresenceConsumed,
+				Actual:   models.DepPresenceMissing,
+			}},
+		})
+	}
+
+	// THE ELIGIBILITY GUARD, and the reason `valid` alone is not enough.
+	//
+	// `eligible` holds the entries that SURVIVED the shared filter. Zero means
+	// the recording mapped dependencies to this test and every one of them was
+	// excluded — DNS, or the reusable session/connection tier — so the
+	// assertion never had anything to run over. It is the same slice
+	// RunTestSet measures for noEligibleDeps, so the bit persisted here and the
+	// reason the user is shown cannot disagree.
+	//
+	// That is not a corner case, it is the DEFAULT for an ordinary recording.
+	// models.Mock.DeriveLifetime's kind fallback (pkg/models/lifetime.go)
+	// classifies untagged HTTP / HTTP2 / Postgres / MySQL / Generic egress as
+	// LifetimeSession, so isReusableTierMock is true for every mock a plain
+	// recording of an HTTP app produces and reusableMockNames skips all of
+	// them. Returning Checked=true here persisted `deps_checked: true,
+	// deps_consumed: 0, dep_result: []` — which models.Result.DepsChecked and
+	// the NDJSON `dependencies_checked` both document as "the assertion ran and
+	// found nothing missing" — for a test where nothing was ever ELIGIBLE to be
+	// checked. That is the false green this slice exists to close, re-created
+	// inside the surface built to close it.
+	//
+	// The fix is NOT to start asserting the excluded mocks. They are excluded
+	// deliberately (see the filter note in this function's doc comment):
+	// reusable-tier mocks are recorded once at app boot and shared across every
+	// test, so a per-test presence assertion over them goes "missing" at random
+	// and produces false REDs. The dishonest bit is the bug; the exclusion is
+	// the design.
+	//
+	// Consumed and Rows stay consistent by construction: with nothing eligible
+	// the loop above incremented consumedCount zero times and appended no rows,
+	// so the zero depAssertion loses no information.
+	//
+	// The user learns WHY from the per-test-set warning — see
+	// depInertNoEligibleDepsReason, which names this exact state.
+	if len(eligible) == 0 {
+		return depAssertion{}
+	}
+
+	if missingOverflow > 0 {
+		out = append(out, models.DepMissingOverflowRow(missingOverflow))
+	}
+
+	return depAssertion{Checked: true, Consumed: consumedCount, Rows: out}
+}
+
+// depAssertion is the complete per-test dependency verdict buildDepResults
+// produces: whether the assertion RAN, how many recorded dependencies were
+// exercised, and one row per dependency that was NOT.
+//
+// Checked and Consumed are scalars rather than a synthesised DepResult row on
+// purpose — see the sizing note on buildDepResults. The zero value is exactly
+// "the assertion did not run", which is what every mode that cannot arm the
+// per-test mock mapping returns.
+type depAssertion struct {
+	// Checked is the persisted proof that the assertion ran OVER AT LEAST ONE
+	// ELIGIBLE DEPENDENCY. True even when Consumed is 0 and Rows is empty;
+	// that combination is a real answer ("checked, nothing exercised, nothing
+	// missing"), not a missing one.
+	//
+	// It is FALSE when the mapping's every entry was filtered out as DNS or
+	// reusable-tier, which is the normal shape for a recording whose mocks
+	// carry no per-test tier tag. "Nothing was eligible" is not "nothing was
+	// missing", and reporting it as the latter is a false green.
+	Checked bool
+	// Consumed counts the recorded per-test dependencies that WERE observed.
+	Consumed int
+	// Rows carries one presence row per dependency that went missing, plus at
+	// most one models.DepMissingOverflowRow. Nil when nothing went missing.
+	Rows []models.DepResult
+}
+
+// depMissingRowCap bounds the number of INDIVIDUAL missing-dependency rows
+// persisted per test; the rest collapse into models.DepMissingOverflowRow.
+//
+// 50 is chosen so the cap is invisible for the shape this signal is actually
+// for — an app that stopped making one or a handful of recorded calls, which
+// is what a real regression looks like — while bounding the pathological shape
+// the slice's own flagship scenario produces: a downstream service removed, or
+// a mock pool whose names drifted wholesale, makes every mapped dependency of
+// every test unconsumed at once. Measured through reportdb.InsertReport at 100
+// tests x 200 mapped dependencies, the uncapped writer produced a 5.4 MB
+// test-set report against 115 KB pre-slice-4; with the cap that report is
+// bounded at ~1.4 MB and the FIRST 50 offenders (in recorded order) are still
+// named individually, which is more than a human or an agent acts on.
+//
+// Measured end to end through reportdb.InsertReport, 100 tests x 200 mapped
+// dependencies with NOTHING consumed (the all-missing shape):
+//
+//	pre-slice-4 (no dep_result at all) :    37,997 B
+//	uncapped                           : 4,829,097 B   (127x)
+//	capped at 50 + overflow row        : 1,272,797 B   (33x, 3.8x smaller)
+//
+// TestBuildDepResults_AllMissingStaysBounded pins the ratio on the real writer
+// output so the cap cannot be quietly removed.
+//
+// A user who wants every row has the mapping itself (mappings.yaml) and
+// TestResult.MockMismatches, both of which carry the full expected set.
+const depMissingRowCap = 50
+
+// depTypeFor resolves the normalised protocol family of a mapping entry,
+// preferring the entry's own Kind and falling back to the loaded-mock lookup
+// for entries recorded without one.
+func depTypeFor(m models.MockEntry, mockKindByName map[string]models.Kind, lookup map[string]mockDisplayInfo) string {
+	kind := m.Kind
+	if kind == "" {
+		if k, ok := mockKindByName[m.Name]; ok {
+			kind = string(k)
+		}
+	}
+	if kind == "" {
+		kind = lookup[m.Name].protocol
+	}
+	if kind == "" {
+		return ""
+	}
+	return models.DepTypeForKind(models.Kind(kind))
+}
+
+// depTargetFor resolves the human-meaningful destination of a mapping entry.
+// Empty is a legitimate answer (r.mockDB may be nil, or the mock carries
+// nothing identifying); DepRowName renders correctly without it.
+func depTargetFor(m models.MockEntry, lookup map[string]mockDisplayInfo) string {
+	return lookup[m.Name].target
+}
+
+// isDNSMockEntry reports whether a mapping entry refers to a DNS mock, using
+// the entry's own Kind first and the loaded-mock lookup as a fallback for
+// entries recorded without one. Extracted so buildDepResults and the inline
+// filteredExpectedNames loop in RunTestSet cannot drift apart.
+func isDNSMockEntry(m models.MockEntry, mockKindByName map[string]models.Kind) bool {
+	if strings.EqualFold(m.Kind, string(models.DNS)) {
+		return true
+	}
+	if kind, ok := mockKindByName[m.Name]; ok && kind == models.DNS {
+		return true
+	}
+	return false
+}
+
+// shouldEmitFailureLogs reports whether the response-diff logs are printed for
+// a test whose per-test mock set diverged.
+//
+// Historically a divergence meant "re-record", so the diff was suppressed as
+// noise and the test was quietly demoted to OBSOLETE. Under
+// --assert-dependencies that same test is about to be marked FAILED, and
+// suppressing its diffs would hand the user a red test with no explanation.
+// Knob off (the default) is byte-identical to before.
+func shouldEmitFailureLogs(mockSetMismatch, assertDependencies bool) bool {
+	return !mockSetMismatch || assertDependencies
+}
+
+// dependencyAssertionRejects reports whether the opt-in dependency assertion
+// (config.Test.AssertDependencies / --assert-dependencies) turns a diverged
+// per-test mock set into a real test failure.
+//
+// A diverged set means an expected per-test mock was not observed during the
+// test's window — the app stopped making an outgoing call the recording says
+// it makes. Today that is demoted to OBSOLETE and the run still exits 0
+// (keploy-consumer-design-v2.md §5, false-pass row 0). Default false keeps
+// that behaviour for every existing user; opting in fails the test, the test
+// set, and the process exit code.
+func dependencyAssertionRejects(mockSetMismatch, assertDependencies bool) bool {
+	return mockSetMismatch && assertDependencies
+}
+
+// demoteToObsolete reports whether a non-passing test whose mock set diverged
+// keeps the historical silent demotion to OBSOLETE (which does NOT fail the
+// test set and does NOT affect the exit code) rather than being marked FAILED.
+//
+// Three independent opt-ins veto the demotion: --schema-noise-strict
+// (strictMockReject), --assert-dependencies (depAssertFail) and
+// --strict-failure. All default false, so the default verdict is unchanged.
+func demoteToObsolete(mockSetMismatch, strictMockReject, depAssertFail, strictFailure bool) bool {
+	return mockSetMismatch && !strictMockReject && !depAssertFail && !strictFailure
+}
+
+// resolveTestStatus turns an ALREADY-RESOLVED response outcome plus the three
+// mock-set veto flags into a persisted models.TestStatus and into whether the
+// test set itself goes red (which is what drives the process exit code).
+//
+// It is deliberately NOT the entry point: `responseMatched` here means "the
+// response matched AND no veto promoted this test", i.e. it is downstream of
+// the promotions resolveTestOutcome performs. Call resolveTestOutcome — it
+// owns the promotions and is the seam the wiring test pins. This function
+// stays separate only because the demotion algebra is worth reading, and
+// asserting, on its own.
+//
+// failsSet is deliberately separate from "status == FAILED": OBSOLETE does not
+// fail the test set, and that asymmetry IS the silent-green hole
+// (keploy-consumer-design-v2.md §5, false-pass row 0).
+func resolveTestStatus(responseMatched, mockSetMismatch, strictMockReject, depAssertFail, strictFailure bool) (status models.TestStatus, failsSet bool) {
+	if responseMatched {
+		return models.TestStatusPassed, false
+	}
+	if demoteToObsolete(mockSetMismatch, strictMockReject, depAssertFail, strictFailure) {
+		return models.TestStatusObsolete, false
+	}
+	return models.TestStatusFailed, true
+}
+
+// mismatchLog names the log line RunTestSet emits for a diverged per-test mock
+// set. It exists so the CHOICE of line is a value this package can test,
+// rather than a branch buried in a 3000-line function where a reviewer proved
+// it could be neutered with the whole suite staying green.
+type mismatchLog int
+
+const (
+	// mismatchLogNone: the mock set matched, nothing to say.
+	mismatchLogNone mismatchLog = iota
+	// mismatchLogSchemaNoiseReject: the response matched but
+	// --schema-noise-strict rejected the mock (non-noise request-body drift).
+	mismatchLogSchemaNoiseReject
+	// mismatchLogDependencyReject: the response matched but
+	// --assert-dependencies promotes the unexercised dependency to a failure.
+	mismatchLogDependencyReject
+	// mismatchLogIgnoredResponseMatched: the response matched and no knob is
+	// on — the historical Debug line, and the silent-green case itself.
+	mismatchLogIgnoredResponseMatched
+	// mismatchLogObsolete: the response failed and the test is demoted.
+	mismatchLogObsolete
+	// mismatchLogVetoedFailure: the response failed and a veto flag keeps it
+	// FAILED instead of demoting it, so the line must name the flag rather
+	// than telling the user to re-record.
+	//
+	// CONSUMER-VISIBLE STRING CHANGE, for --strict-failure users only. This
+	// arm previously emitted the same line as mismatchLogObsolete ("mock
+	// mapping mismatch detected; marking testcase as obsolete. Re-record the
+	// test case or run with --update-test-mapping..."), which contradicted the
+	// verdict it was announcing and pointed the user at the wrong fix. It now
+	// says "marking testcase as FAILED" and carries a `reason` field naming
+	// the flag. The VERDICT is unchanged in every combination. Nothing in this
+	// repo greps the old literal (checked: .github/workflows and the e2e
+	// scripts have no match for "marking testcase"), but anyone counting
+	// demotions by scraping it externally loses those hits — call it out in
+	// the release notes.
+	mismatchLogVetoedFailure
+)
+
+// testOutcome is the complete per-test decision for a diverged (or clean)
+// mock set: the persisted status, whether the test set goes red, whether the
+// mismatch is recorded for the end-of-run report, and which log line explains
+// it.
+type testOutcome struct {
+	Status         models.TestStatus
+	FailsTestSet   bool
+	RecordMismatch bool
+	Log            mismatchLog
+	// VetoFlags names the flag(s) that kept a demotable test FAILED, for the
+	// mismatchLogVetoedFailure line. Empty otherwise.
+	VetoFlags string
+	// DepAssertFail is the resolved --assert-dependencies rejection, exposed
+	// because the caller logs it and because resolveTestStatus consumes it.
+	DepAssertFail bool
+}
+
+// resolveTestOutcome is THE per-test verdict: the single place that turns the
+// raw response outcome plus the three opt-in knobs into everything RunTestSet
+// does about it.
+//
+// It takes the PRE-PROMOTION response result. That is the whole point: the
+// flagship promotion this slice adds — the response MATCHED but a recorded
+// outgoing call was not observed, and --assert-dependencies is on — happens by
+// flipping the response result to false, so a verdict function that only saw
+// the post-flip value could never assert it. It used to live as
+// `case testPass && depAssertFail:` inside RunTestSet, where a reviewer
+// replaced the condition with `testPass && false` and the entire five-package
+// suite stayed green. Every branch below is now a table row in
+// TestResolveTestOutcome.
+//
+// Nothing here is reachable unless mockSetMismatch is true, which is itself
+// gated on depAssertionValid at the call site.
+func resolveTestOutcome(responseMatched, mockSetMismatch, schemaNoiseStrict, assertDependencies, strictFailure bool) testOutcome {
+	depAssertFail := dependencyAssertionRejects(mockSetMismatch, assertDependencies)
+	out := testOutcome{DepAssertFail: depAssertFail}
+
+	if !mockSetMismatch {
+		out.Status, out.FailsTestSet = resolveTestStatus(responseMatched, false, false, false, strictFailure)
+		return out
+	}
+
+	strictMockReject := false
+	switch {
+	case responseMatched && schemaNoiseStrict:
+		// Strict schema-noise: the expected mock was REJECTED because a
+		// non-noise request-body field drifted. The response can still match
+		// (a deterministic dependency), so the response check alone cannot
+		// catch it.
+		responseMatched = false
+		strictMockReject = true
+		out.Log = mismatchLogSchemaNoiseReject
+		out.RecordMismatch = true
+	case responseMatched && depAssertFail:
+		// The slice's flagship promotion: response matched, recorded outgoing
+		// call not observed, knob on -> a real FAILED test and a red run.
+		responseMatched = false
+		out.Log = mismatchLogDependencyReject
+		out.RecordMismatch = true
+	case responseMatched:
+		// The silent-green case with the knob off. The verdict does not
+		// change — visibility comes from the DepResult rows, which are written
+		// and rendered either way.
+		out.Log = mismatchLogIgnoredResponseMatched
+	case depAssertFail || strictFailure:
+		// The response failed AND a veto keeps the test FAILED. The historical
+		// "marking testcase as obsolete / re-record" wording would contradict
+		// the verdict and point the user at the wrong fix, so name the flag.
+		out.Log = mismatchLogVetoedFailure
+		out.VetoFlags = vetoFlagName(depAssertFail, strictFailure)
+		out.RecordMismatch = true
+	default:
+		out.Log = mismatchLogObsolete
+		out.RecordMismatch = true
+	}
+
+	out.Status, out.FailsTestSet = resolveTestStatus(responseMatched, mockSetMismatch, strictMockReject, depAssertFail, strictFailure)
+	return out
+}
+
+// depLogLevel says how loudly a missing dependency is reported per test.
+type depLogLevel int
+
+const (
+	// depLogNone: nothing missing, nothing to say.
+	depLogNone depLogLevel = iota
+	// depLogDebug: reported-only mode (the knob is off). An expected-but-
+	// unobserved mock is exactly the condition the OBSOLETE demotion exists to
+	// tolerate, so on a suite with a drifting mock pool this fires on every
+	// test of every run. Per-test it stays at Debug; RunTestSet emits ONE Warn
+	// per test set summarising the count, so the signal is not lost and the
+	// CLI does not grow hundreds of new Warn lines for users who never asked
+	// for the assertion.
+	depLogDebug
+	// depLogError: --assert-dependencies is on, the run is going red anyway.
+	depLogError
+)
+
+// attachDepResults writes the dependency rows onto a persisted test result and
+// applies the two side effects that go with them: the DEPENDENCY_MISSING
+// failure category and the per-test log level.
+//
+// Extracted from RunTestSet for the same reason resolveTestOutcome is: it is
+// the primary deliverable of this slice and it lived on an untested line
+// inside a 3000-line function, where deleting it left every test green.
+//
+// Returns the missing row names (for the test-set-level summary log) and the
+// level the caller should log them at.
+func attachDepResults(
+	tcResult *models.TestResult,
+	status models.TestStatus,
+	dep depAssertion,
+	assertDependencies bool,
+) (missingNames []string, level depLogLevel) {
+	if tcResult == nil {
+		return nil, depLogNone
+	}
+	tcResult.Result.DepResult = dep.Rows
+	// The two scalars are what make `dep_result: []` unambiguous. They are
+	// written even when nothing is missing — that is the whole point of
+	// DepsChecked — and left at their zero values when the assertion did not
+	// run, which omitempty then keeps off the wire entirely.
+	tcResult.Result.DepsChecked = dep.Checked
+	tcResult.Result.DepsConsumed = dep.Consumed
+
+	missingNames = models.MissingDepNames(dep.Rows)
+	if len(missingNames) == 0 {
+		return nil, depLogNone
+	}
+
+	// Only label FAILED/OBSOLETE tests: a PASSED test must never grow a
+	// failure category (printSummary and the k8s-proxy fleet report both read
+	// Category as a failure taxonomy). The ROWS stay on a passing test either
+	// way — that is what makes the silent-green case visible without the knob.
+	//
+	// slices.Clone breaks the aliasing with testResult.FailureInfo.Category,
+	// which the matcher owns and which is also shared with the persisted
+	// Result copy; appendCategoryUnique keeps a second writer of this category
+	// (slice 5's consumer projector is planned to add one) from duplicating it.
+	if status == models.TestStatusFailed || status == models.TestStatusObsolete {
+		tcResult.FailureInfo.Category = appendCategoryUnique(
+			slices.Clone(tcResult.FailureInfo.Category), models.DependencyMissing)
+	}
+
+	if assertDependencies {
+		return missingNames, depLogError
+	}
+	return missingNames, depLogDebug
+}
+
+// recordUnexercised is the SINGLE writer of the per-test-set set that
+// warnUnexercisedDependencies reports on.
+//
+// Only the reported-only level is collected: under --assert-dependencies the
+// per-test Error already fired and the run is red, so a summary Warn would be
+// noise on top of a failure. Extracted because emptying this map is otherwise
+// an invisible mutation — the wiring test pins the CALL to
+// warnUnexercisedDependencies, but a summary over an always-empty map is a
+// silent no-op, which is how the per-test Warn regression's replacement could
+// be deleted with the suite staying green.
+//
+// The status is kept, not just the name: the summary distinguishes the tests
+// whose response still matched (the silent-green population) from the ones
+// that were demoted, which are two different things to go and look at.
+//
+// AUTHORITATIVE FOR THE CURRENT CYCLE, not cumulative. --retry-passing re-runs
+// the passing tests up to five times and each cycle overwrites
+// finalTestCaseResults[name], so the PERSISTED rows are always the LAST
+// cycle's. A set that only ever inserted would keep a test that lost a
+// dependency in cycle 1 and consumed it in cycle 2, and the end-of-test-set
+// Warn would then name a test whose own report carries no missing row and
+// count it in responseStillMatched — a WARN contradicting every other surface,
+// in exactly the mock-consistency-flake scenario --retry-passing exists to
+// smooth over. Deleting on a clean cycle makes the summary agree with the
+// report by construction.
+func recordUnexercised(set map[string]models.TestStatus, name string, status models.TestStatus, level depLogLevel) {
+	if set == nil {
+		return
+	}
+	if level != depLogDebug {
+		delete(set, name)
+		return
+	}
+	set[name] = status
+}
+
+// vetoFlagName names the flag that turned a mock-set mismatch into a FAILED
+// verdict, so the log tells the user which knob to look at instead of pointing
+// them at re-recording.
+func vetoFlagName(depAssertFail, strictFailure bool) string {
+	switch {
+	case depAssertFail && strictFailure:
+		return "--assert-dependencies, --strict-failure"
+	case depAssertFail:
+		return "--assert-dependencies"
+	case strictFailure:
+		return "--strict-failure"
+	}
+	return ""
+}
+
+// dependencyAssertionInertReason explains why --assert-dependencies cannot run
+// over a WHOLE TEST SET (the first three cases), over the test cases whose
+// per-test consumed-mock fetch failed (the fourth), over the test cases whose
+// every recorded dependency is ineligible (the fifth), or over the streaming
+// subset of one (the sixth), or "" when it can run everywhere.
+//
+// The knob keys off mockSetMismatch, which needs an ARMED per-test mock
+// mapping. Three test-set-level preconditions can silently remove it, and a
+// user who puts --assert-dependencies in CI against a test set that fails any
+// of them gets a green run with no indication the assertion never executed — the same
+// silent-green class the slice exists to close.
+//
+// consumedFetchFailed is the FOURTH case. It is ranked above the two below it
+// because it is the only one of the three the operator can act on — see
+// depInertConsumedFetchReason for why absorbing it into the tier reason
+// mis-sent people to re-tag a recording that was fine.
+//
+// noEligibleDeps is the FIFTH case and the one an ordinary recording actually
+// hits. See depInertNoEligibleDepsReason: every mock the mapping records for a
+// test can be excluded from the assertion as DNS or reusable (session /
+// connection) tier, which is exactly what models.Mock.DeriveLifetime's kind
+// fallback makes of untagged HTTP / Postgres / MySQL egress. The assertion is
+// then armed, has a mapping, and still has nothing to look at. buildDepResults
+// reports that honestly as NOT-CHECKED; without this reason the user sees a
+// report full of `dependencies_checked: false` and no statement of why.
+//
+// deferredStreaming is the SIXTH case (it is checked last) and, with the two
+// above it, one of the three that are not test-set wide. RunTestSet splits
+// SSE/chunked test cases out of the main replay loop into a Phase-2 pass
+// (pkg.IsHTTPStreamingTestCase), and that pass deliberately writes no
+// DepResult and never calls resolveTestOutcome — see the NOTE on
+// models.Result.DepResult in the Phase-2 body — so --assert-dependencies
+// cannot promote anything there no matter how healthy the mapping is. Without
+// this case a CI run of --assert-dependencies over a set of streaming tests is
+// green for an assertion that never executed, which is the same silent green
+// as the other three.
+//
+// ORDER MATTERS: the three set-wide preconditions are checked first because
+// each of them already disables the assertion for the streaming tests too, so
+// naming one of them is strictly more informative than naming the deferral.
+// consumedFetchFailed comes next because it is actionable and the states below
+// it are not. noEligibleDeps outranks the streaming deferral for the same reason — the
+// tier classification comes from the RECORDING, so it applies to the deferred
+// streaming test cases as well, while the deferral says nothing about the
+// tests the main loop just asserted. In practice the two are never both true
+// at a call site: the main replay loop passes deferredStreaming=false (it only
+// ever sees the non-streaming bucket) and the Phase-2 pass has no filtered
+// expectation list to compute noEligibleDeps from, so it passes false.
+//
+// hasExpectedMocks is deliberately NOT one of them: it is a per-TEST condition
+// and "this test case makes no outgoing calls" is completely normal, so
+// warning on it would fire on every healthy suite.
+//
+// The cost of that choice, stated plainly because an earlier version of this
+// comment got it wrong: hasExpectedMocks is a conjunct of depAssertionValid at
+// the call site, so for such a test buildDepResults returns the ZERO
+// depAssertion at its `!valid` guard — Checked is false. `dependencies_checked`
+// is then false, byte-identical to a --base-path run or a failed consumed-mock
+// fetch. A test that makes no outgoing calls is therefore reported as UNCHECKED
+// rather than as "checked, nothing missing", and is indistinguishable on the
+// wire from the other unchecked modes. That is the conservative reading of the
+// documented rule ("read DepsChecked, never len(DepResult)",
+// models.Result.DependenciesChecked) and never a false green, but it does mean
+// `dependencies_checked` is false for every test in a suite that makes no
+// outgoing calls at all.
+//
+// It is not fixable by setting Checked here anyway: hasExpectedMocks
+// also gates mockSetMismatch, where dropping it would make isMockSubset
+// compare a non-empty consumed set against an empty expectation and demote
+// healthy tests to OBSOLETE. The two must keep using one predicate.
+//
+// noEligibleDeps is the NEIGHBOURING case and is treated differently on
+// purpose: there the recording DOES map dependencies to the test and every one
+// of them was filtered out, which a user reading a mapping full of entries has
+// no way to guess. Both report UNCHECKED; only that one is worth a line.
+func dependencyAssertionInertReason(instrument, useMappingBased, isMappingEnabled, consumedFetchFailed, deferredStreaming, noEligibleDeps bool) string {
+	switch {
+	case !instrument:
+		return "not instrument mode: the per-test mock mapping is never armed for --base-path / remote-agent runs, so which mock a request consumed is not attributable to a single test"
+	case !isMappingEnabled:
+		return "mapping is disabled (test.disableMapping / --disable-mapping): there is no per-test expectation to assert against"
+	case !useMappingBased:
+		return "this test set has no usable mappings.yaml (recorded before test-mock mapping existed, or the mapping database is unavailable): re-record it, or run once with --update-test-mapping"
+	case consumedFetchFailed:
+		return depInertConsumedFetchReason
+	case noEligibleDeps:
+		return depInertNoEligibleDepsReason
+	case deferredStreaming:
+		return depInertStreamingReason
+	}
+	return ""
+}
+
+// depInertStreamingReason is compared by identity in
+// dependencyAssertionInertMessage to pick the scope-accurate message, so it
+// lives as a constant rather than an inline string.
+const depInertStreamingReason = "this test set contains streaming (SSE/chunked) test cases, which are replayed in a deferred pass that writes no dependency rows and runs no dependency assertion: those test cases cannot be failed by the flag, however healthy the mapping is"
+
+// depInertConsumedFetchReason names the state where the assertion is fully
+// armed — instrument mode, mapping enabled, a usable mappings.yaml — and the
+// run still could not ask the question, because fetching the mocks THIS test
+// consumed failed. RunTestSet nils consumedMocks on that error and drops
+// instrumentConsumedFetchErr into depAssertionValid, so the writer returns the
+// zero depAssertion and the test is reported dependencies_checked=false.
+//
+// It OUTRANKS depInertNoEligibleDepsReason on purpose. Both states report the
+// same honest NOT-CHECKED, but only one of them is the user's to fix: a
+// transport failure talking to the agent is actionable, while the tier
+// classification is a property of the recording. When a test set hits both at
+// once (the fetch failed AND its mapping happened to be all-reusable) the
+// earlier wording blamed the tier and sent the operator to re-tag a recording
+// that was never the problem.
+//
+// It also closes a gap of its own. Before this arm existed a fetch failure on
+// a test set with perfectly eligible per-test dependencies produced NO warning
+// at all: the reason function returned "" and the run reported
+// dependencies_checked=false for those tests with nothing said. That is the
+// same silent class as the other five — an assertion the user asked for, which
+// did not execute, with no line saying so.
+const depInertConsumedFetchReason = "the per-test consumed-mock fetch failed for one or more test cases in this test set: the agent could not report which mocks the test actually consumed, so there is no observed set to compare the recording's mapping against. Their dependency verdict is dependencies_checked=false (NOT CHECKED), not clean — this is a transport/agent error, not a statement about the recording"
+
+// depInertNoEligibleDepsReason names the state where everything the assertion
+// needs is armed — instrument mode, mapping enabled, a usable mappings.yaml —
+// and there is still nothing to assert, because every dependency the recording
+// maps to these test cases is excluded from the per-test assertion.
+//
+// This is the DEFAULT for a recording whose mocks carry no per-test tier tag.
+// models.Mock.DeriveLifetime classifies untagged HTTP / HTTP2 / Postgres /
+// MySQL / Generic egress as session-tier (its documented legacy kind
+// fallback), and session/connection-tier mocks are deliberately excluded: they
+// are recorded once at app boot and shared across every test, so asserting
+// their presence per test would go "missing" at random and fail healthy tests.
+// DNS entries are excluded for the same class of reason (resolution order is
+// non-deterministic).
+//
+// The message has to say what the report will show, because the honest report
+// for this state (`dependencies_checked: false`) is indistinguishable on the
+// wire from the other not-run modes: this line is the only place the user
+// learns which one they are in.
+const depInertNoEligibleDepsReason = "every dependency the recording maps to these test cases is excluded from the per-test assertion: session/connection-tier mocks (which is how untagged HTTP/Postgres/MySQL egress is classified, so this is the norm for recordings whose mocks carry no per-test tier tag) are shared across every test and are not attributable to one test's window, and DNS is non-deterministic. Nothing is left to assert, so these tests are reported as dependencies_checked=false (NOT CHECKED) rather than as checked-and-clean"
+
+// dependencyAssertionInertMessage picks the headline for a reason.
+//
+// The three set-wide preconditions really do mean no dependency can fail ANY
+// test in this test set, and get the blanket sentence. The other two are
+// narrower claims and must not borrow it:
+//
+//   - the streaming deferral leaves a mixed test set's non-streaming tests
+//     fully asserted, so a set-wide sentence would be a false alarm about them;
+//   - no-eligible-dependencies is decided per test from that test's own mapped
+//     entries, and says specifically that the verdict for those tests is
+//     NOT-CHECKED rather than clean — which is the sentence that stops a
+//     reader treating an empty `dep_result` as a green dependency result.
+func dependencyAssertionInertMessage(reason string) string {
+	switch reason {
+	case depInertStreamingReason:
+		return "--assert-dependencies does not run for this test set's streaming test cases; no dependency can fail one of them"
+	case depInertNoEligibleDepsReason:
+		return "--assert-dependencies has no eligible dependency to assert for one or more test cases in this test set; their dependency verdict is NOT CHECKED, not clean"
+	case depInertConsumedFetchReason:
+		return "--assert-dependencies could not read the consumed mocks for one or more test cases in this test set; their dependency verdict is NOT CHECKED, not clean"
+	}
+	return "--assert-dependencies is inert for this test set; no dependency can fail a test here"
+}
+
+// warnDependencyAssertionInert emits ONE warning per test set when the user
+// asked for --assert-dependencies but the signal it keys off cannot be
+// computed, or has nothing to run over. warned is the per-test-set latch,
+// shared by the main replay loop and the deferred streaming pass: whichever
+// reaches it first wins, and a test set never emits this warning twice.
+//
+// The main replay loop calls this once per TEST CASE (with that test's own
+// consumedFetchFailed and noEligibleDeps), which is what lets the fourth and
+// fifth reasons fire at all — they are properties of a single test's fetch and
+// mapped entries, not of the test set. The latch keeps that one line per test
+// set regardless.
+//
+// The message is chosen from the reason (dependencyAssertionInertMessage)
+// because the scopes are not the same claim.
+func (r *Replayer) warnDependencyAssertionInert(testSetID string, useMappingBased, isMappingEnabled, consumedFetchFailed, deferredStreaming, noEligibleDeps bool, warned *bool) {
+	if !r.config.Test.AssertDependencies || warned == nil || *warned {
+		return
+	}
+	reason := dependencyAssertionInertReason(r.instrument, useMappingBased, isMappingEnabled, consumedFetchFailed, deferredStreaming, noEligibleDeps)
+	if reason == "" {
+		return
+	}
+	*warned = true
+	r.logger.Warn(dependencyAssertionInertMessage(reason),
+		zap.String("testset", testSetID),
+		zap.String("reason", reason))
+}
+
+// unexercisedSummary splits the collected tests into a sorted name list, a
+// capped sample and the count whose RESPONSE still matched.
+//
+// The passed count is the one that matters and the one the wording has to be
+// careful about: for a PASSED test the response really did match, which is the
+// silent-green case; for an OBSOLETE test it did not — that is why it was
+// demoted — so a blanket "the response still matched" would be wrong for
+// exactly the subset a user is most likely to investigate.
+func unexercisedSummary(tests map[string]models.TestStatus) (names, sample []string, passed int) {
+	names = make([]string, 0, len(tests))
+	for name, status := range tests {
+		names = append(names, name)
+		if status == models.TestStatusPassed {
+			passed++
+		}
+	}
+	sort.Strings(names)
+	sample = names
+	if len(sample) > depWarnSampleSize {
+		sample = sample[:depWarnSampleSize]
+	}
+	return names, sample, passed
+}
+
+// warnUnexercisedDependencies emits the single per-test-set summary for
+// dependencies that were recorded but not observed while the knob is off.
+// Under --assert-dependencies the per-test Error already fired and the run is
+// red, so this stays quiet.
+//
+// "not observed during the test's own window" is deliberate wording, not
+// hedging: GetConsumedMocks is drained immediately after the response comes
+// back, so an outgoing call the app makes AFTER writing its response (an audit
+// write, an analytics POST, a cache set) is attributed to the next test, not
+// this one. The data supports "keploy did not see this call inside this test's
+// window"; it does not support "the app never made this call".
+func (r *Replayer) warnUnexercisedDependencies(testSetID string, tests map[string]models.TestStatus) {
+	if len(tests) == 0 {
+		return
+	}
+	names, sample, passed := unexercisedSummary(tests)
+	r.logger.Warn("some tests did not exercise a dependency their recording says they use, and were not failed for it (run with --assert-dependencies to fail on this). Note that an outgoing call made AFTER the response is written is not attributable to this test's window",
+		zap.String("testset", testSetID),
+		zap.Int("tests", len(names)),
+		zap.Int("responseStillMatched", passed),
+		zap.Strings("sample", sample))
+}
+
+// depWarnSampleSize caps the per-test-set sample so a fully-drifted suite
+// cannot emit a thousand-name log line.
+const depWarnSampleSize = 5

--- a/pkg/service/replay/depresult_test.go
+++ b/pkg/service/replay/depresult_test.go
@@ -1,0 +1,2025 @@
+package replay
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.keploy.io/server/v3/config"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+	"gopkg.in/yaml.v3"
+)
+
+func consumed(name string, kind models.Kind) models.MockState {
+	return models.MockState{Name: name, Kind: kind}
+}
+
+func missingMeta() []models.DepMetaResult {
+	return []models.DepMetaResult{{
+		Normal:   false,
+		Key:      models.DepKeyPresence,
+		Expected: models.DepPresenceConsumed,
+		Actual:   models.DepPresenceMissing,
+	}}
+}
+
+func TestBuildDepResults(t *testing.T) {
+	tests := []struct {
+		name          string
+		expected      []models.MockEntry
+		consumedMocks []models.MockState
+		valid         bool
+		reusable      map[string]bool
+		kindByName    map[string]models.Kind
+		lookup        map[string]mockDisplayInfo
+		// want is the MISSING rows only. The consumed side is two scalars on
+		// the result, never rows — see buildDepResults' sizing note.
+		want         []models.DepResult
+		wantConsumed int
+		wantChecked  bool
+	}{
+		{
+			name:          "a consumed dependency is counted, never persisted as a row",
+			expected:      []models.MockEntry{{Name: "mock-1", Kind: "Postgres"}},
+			consumedMocks: []models.MockState{consumed("mock-1", models.Kind("Postgres"))},
+			valid:         true,
+			lookup:        map[string]mockDisplayInfo{"mock-1": {protocol: "Postgres", target: "db:5432"}},
+			want:          nil,
+			wantConsumed:  1,
+			wantChecked:   true,
+		},
+		{
+			name:          "unconsumed dependency yields a MISSING row unconditionally",
+			expected:      []models.MockEntry{{Name: "mock-1", Kind: "Postgres"}},
+			consumedMocks: nil,
+			valid:         true,
+			lookup:        map[string]mockDisplayInfo{"mock-1": {protocol: "Postgres", target: "db:5432"}},
+			want: []models.DepResult{
+				{
+					Name: "deps[0] postgres db:5432 (presence)",
+					Type: "postgres",
+					Meta: missingMeta(),
+				},
+			},
+			wantConsumed: 0,
+			wantChecked:  true,
+		},
+		{
+			name: "parser versions normalise onto one protocol family",
+			// postgresv3 / http2 must never reach the `type` contract: an agent
+			// keying on "postgres" would miss every v2/v3 recording.
+			expected: []models.MockEntry{
+				{Name: "pg", Kind: "PostgresV3"},
+				{Name: "h2", Kind: "Http2"},
+			},
+			valid:  true,
+			lookup: map[string]mockDisplayInfo{"pg": {target: "db:5432"}, "h2": {target: "GET api:443/v1"}},
+			want: []models.DepResult{
+				{Name: "deps[0] postgres db:5432 (presence)", Type: "postgres", Meta: missingMeta()},
+				{Name: "deps[1] http GET api:443/v1 (presence)", Type: "http", Meta: missingMeta()},
+			},
+			wantConsumed: 0,
+			wantChecked:  true,
+		},
+		{
+			name: "the consumed count covers only per-test dependencies",
+			expected: []models.MockEntry{
+				{Name: "m1", Kind: "Http"},
+				{Name: "m2", Kind: "Http"},
+				{Name: "gone", Kind: "Http"},
+				{Name: "session-1", Kind: "Http"},
+				{Name: "dns-1", Kind: "DNS"},
+			},
+			consumedMocks: []models.MockState{
+				consumed("m1", models.HTTP), consumed("m2", models.HTTP),
+				{Name: "session-1", Kind: models.HTTP, Lifetime: models.LifetimeSession},
+				consumed("dns-1", models.DNS),
+			},
+			valid:    true,
+			reusable: map[string]bool{"session-1": true},
+			lookup:   map[string]mockDisplayInfo{"gone": {target: "GET api:80/orders"}},
+			want: []models.DepResult{
+				// "gone" is the THIRD entry of the filtered expected list
+				// (m1, m2, gone), so its name is deps[2] whether or not m1 and
+				// m2 happened to be consumed in this run.
+				{Name: "deps[2] http GET api:80/orders (presence)", Type: "http", Meta: missingMeta()},
+			},
+			wantConsumed: 2,
+			wantChecked:  true,
+		},
+		{
+			name: "reusable-tier expected mocks are excluded from the assertion",
+			expected: []models.MockEntry{
+				{Name: "session-1", Kind: "MySQL"},
+				{Name: "mock-1", Kind: "MySQL"},
+			},
+			consumedMocks: []models.MockState{consumed("mock-1", models.Kind("MySQL"))},
+			valid:         true,
+			reusable:      map[string]bool{"session-1": true},
+			lookup:        map[string]mockDisplayInfo{"mock-1": {target: "mysql:3306"}},
+			want:          nil,
+			wantConsumed:  1,
+			wantChecked:   true,
+		},
+		{
+			name: "reusable-tier CONSUMED mocks do not satisfy a per-test expectation",
+			// Mirrors filteredMockNames at the call site: a mock consumed under
+			// a session/connection lifetime is not attributable to this test.
+			expected: []models.MockEntry{{Name: "mock-1", Kind: "MySQL"}},
+			consumedMocks: []models.MockState{
+				{Name: "mock-1", Kind: models.Kind("MySQL"), Lifetime: models.LifetimeSession},
+			},
+			valid: true,
+			want: []models.DepResult{
+				{
+					Name: "deps[0] mysql (presence)",
+					Type: "mysql",
+					Meta: missingMeta(),
+				},
+			},
+			wantConsumed: 0,
+			wantChecked:  true,
+		},
+		{
+			name: "DNS is excluded via the entry kind and via the lookup",
+			expected: []models.MockEntry{
+				{Name: "dns-1", Kind: "DNS"},
+				{Name: "dns-2", Kind: ""},
+				{Name: "mock-1", Kind: "Http"},
+			},
+			consumedMocks: []models.MockState{consumed("mock-1", models.HTTP)},
+			valid:         true,
+			kindByName:    map[string]models.Kind{"dns-2": models.DNS},
+			lookup:        map[string]mockDisplayInfo{"mock-1": {target: "GET api.internal:80/x"}},
+			want:          nil,
+			wantConsumed:  1,
+			wantChecked:   true,
+		},
+		{
+			name:          "an invalid assertion context yields no rows at all",
+			expected:      []models.MockEntry{{Name: "mock-1", Kind: "Postgres"}},
+			consumedMocks: []models.MockState{consumed("stale-mock", models.Kind("Postgres"))},
+			valid:         false,
+			want:          nil,
+		},
+		{
+			name:          "no expected mocks yields no rows",
+			expected:      nil,
+			consumedMocks: []models.MockState{consumed("mock-1", models.Kind("Postgres"))},
+			valid:         true,
+			want:          nil,
+		},
+		{
+			// The whole point of the unconditional Checked bit: "checked and
+			// clean" must be distinguishable on disk from "never checked",
+			// without persisting a single row to say so.
+			name:          "everything consumed still sets Checked, so the assertion is provably RUN",
+			expected:      []models.MockEntry{{Name: "m1", Kind: "Http"}, {Name: "m2", Kind: "Http"}},
+			consumedMocks: []models.MockState{consumed("m1", models.HTTP), consumed("m2", models.HTTP)},
+			valid:         true,
+			want:          nil,
+			wantConsumed:  2,
+			wantChecked:   true,
+		},
+		{
+			// THE FALSE GREEN THIS GUARD EXISTS TO CLOSE, and the shape an
+			// ordinary recording actually produces: every mapped entry is
+			// session-tier (what models.Mock.DeriveLifetime makes of untagged
+			// HTTP/Postgres/MySQL egress), so the filter removes all of them
+			// and the assertion never ran over a single dependency.
+			//
+			// This case USED to assert Checked=true, which persisted
+			// `deps_checked: true, deps_consumed: 0, dep_result: []` — the
+			// documented spelling of "checked, nothing missing" — for a test
+			// where nothing was ever eligible to be checked.
+			name:          "every mapped dependency filtered out means NOT checked, never checked-and-clean",
+			expected:      []models.MockEntry{{Name: "session-1", Kind: "Http"}},
+			consumedMocks: nil,
+			valid:         true,
+			reusable:      map[string]bool{"session-1": true},
+			want:          nil,
+			wantConsumed:  0,
+			wantChecked:   false,
+		},
+		{
+			// The same guard through the OTHER exclusion, so the fix cannot be
+			// narrowed to the reusable tier and leave DNS-only mappings lying.
+			name:          "a DNS-only mapping is not an assertion either",
+			expected:      []models.MockEntry{{Name: "dns-1", Kind: "DNS"}, {Name: "dns-2", Kind: ""}},
+			consumedMocks: []models.MockState{consumed("dns-1", models.DNS)},
+			valid:         true,
+			kindByName:    map[string]models.Kind{"dns-2": models.DNS},
+			want:          nil,
+			wantConsumed:  0,
+			wantChecked:   false,
+		},
+		{
+			// The BOUNDARY: one eligible entry among reusable ones is still a
+			// real assertion. A guard that keyed off "any entry was filtered"
+			// instead of "no entry survived" would silently stop reporting
+			// missing dependencies for every mixed mapping.
+			name: "one eligible entry among reusable ones still counts as checked",
+			expected: []models.MockEntry{
+				{Name: "session-1", Kind: "Http"},
+				{Name: "gone", Kind: "Http"},
+				{Name: "session-2", Kind: "Http"},
+			},
+			consumedMocks: nil,
+			valid:         true,
+			reusable:      map[string]bool{"session-1": true, "session-2": true},
+			lookup:        map[string]mockDisplayInfo{"gone": {target: "GET api:80/orders"}},
+			want: []models.DepResult{
+				{Name: "deps[0] http GET api:80/orders (presence)", Type: "http", Meta: missingMeta()},
+			},
+			wantConsumed: 0,
+			wantChecked:  true,
+		},
+		{
+			name:          "empty mock lookup still produces a readable row",
+			expected:      []models.MockEntry{{Name: "mock-1", Kind: "Redis"}},
+			consumedMocks: nil,
+			valid:         true,
+			want: []models.DepResult{
+				{
+					Name: "deps[0] redis (presence)",
+					Type: "redis",
+					Meta: missingMeta(),
+				},
+			},
+			wantConsumed: 0,
+			wantChecked:  true,
+		},
+		{
+			name:          "kind resolved from the lookup when the mapping entry has none",
+			expected:      []models.MockEntry{{Name: "mock-1", Kind: ""}},
+			consumedMocks: nil,
+			valid:         true,
+			kindByName:    map[string]models.Kind{"mock-1": models.Kind("Mongo")},
+			lookup:        map[string]mockDisplayInfo{"mock-1": {target: "MongoDB find"}},
+			want: []models.DepResult{
+				{
+					Name: "deps[0] mongo MongoDB find (presence)",
+					Type: "mongo",
+					Meta: missingMeta(),
+				},
+			},
+			wantConsumed: 0,
+			wantChecked:  true,
+		},
+		{
+			// depTypeFor's THIRD fallback: the mapping entry carries no Kind
+			// and the loaded-mock registry has none either, so the only
+			// protocol left is the one mockDisplayInfo captured. Deleting that
+			// arm used to leave the whole package green.
+			name:          "kind resolved from the display lookup when neither the entry nor the registry has one",
+			expected:      []models.MockEntry{{Name: "mock-1", Kind: ""}},
+			consumedMocks: nil,
+			valid:         true,
+			kindByName:    nil,
+			lookup:        map[string]mockDisplayInfo{"mock-1": {protocol: "PostgresV2", target: "db:5432 SELECT"}},
+			want: []models.DepResult{
+				{
+					// Normalised through models.DepTypeForKind on the way out:
+					// the lookup carries the PARSER VERSION, the row must not.
+					Name: "deps[0] postgres db:5432 SELECT (presence)",
+					Type: "postgres",
+					Meta: missingMeta(),
+				},
+			},
+			wantConsumed: 0,
+			wantChecked:  true,
+		},
+		{
+			name: "row indices skip the FILTERED entries, not the consumed ones",
+			expected: []models.MockEntry{
+				{Name: "dns-1", Kind: "DNS"},
+				{Name: "mock-1", Kind: "Http"},
+				{Name: "session-1", Kind: "Http"},
+				{Name: "mock-2", Kind: "Http"},
+			},
+			consumedMocks: nil,
+			valid:         true,
+			reusable:      map[string]bool{"session-1": true},
+			want: []models.DepResult{
+				{Name: "deps[0] http (presence)", Type: "http", Meta: missingMeta()},
+				{Name: "deps[1] http (presence)", Type: "http", Meta: missingMeta()},
+			},
+			wantConsumed: 0,
+			wantChecked:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildDepResults(tt.expected, tt.consumedMocks, tt.valid, tt.reusable, tt.kindByName, tt.lookup)
+			assert.Equal(t, tt.want, got.Rows, "MISSING rows")
+			assert.Equal(t, tt.wantConsumed, got.Consumed,
+				"Consumed count — this is the ONLY persisted trace of the dependencies the test did exercise")
+			assert.Equal(t, tt.wantChecked, got.Checked,
+				"Checked is the one bit that tells `dep_result: []` meaning 'nothing missing' apart from "+
+					"'the assertion never ran'; a consumer applying any(matched == false) reads the second as green")
+		})
+	}
+}
+
+// THE DEFECT, spelled out end to end on the shape a real recording produces.
+//
+// Reproduced against the http-pokeapi sample: its recorded outgoing HTTP calls
+// carry no per-test tier tag, so models.Mock.DeriveLifetime's legacy kind
+// fallback classifies them session-tier, isReusableTierMock is true for every
+// one of them, and the per-entry filter in buildDepResults removes the lot.
+// The function nonetheless returned Checked=true, and the persisted report read
+//
+//	deps_checked: true
+//	deps_consumed: 0
+//	dep_result: []
+//
+// which models.Result.DepsChecked, models.Result.DependenciesChecked and the
+// NDJSON `dependencies_checked` all document as "the assertion ran and found
+// nothing missing". Nothing had ever been eligible to be checked. An agent
+// applying the documented rule (`checked && any(matched == false)`) reads that
+// as a clean dependency verdict — the exact false green this slice exists to
+// close, re-created inside the surface built to close it.
+func TestBuildDepResults_NothingEligibleIsNotAGreenAssertion(t *testing.T) {
+	// Two ordinary recorded outgoing HTTP calls, both session-tier.
+	expected := []models.MockEntry{{Name: "mock-2", Kind: "Http"}, {Name: "mock-3", Kind: "Http"}}
+	reusable := map[string]bool{"mock-2": true, "mock-3": true}
+
+	dep := buildDepResults(expected, nil, true, reusable, nil, nil)
+
+	res := models.Result{DepResult: dep.Rows, DepsChecked: dep.Checked, DepsConsumed: dep.Consumed}
+	if res.DependenciesChecked() {
+		t.Fatalf("the report claims the dependency assertion RAN (deps_checked=%v, deps_consumed=%d, dep_result=%v) "+
+			"for a test whose every mapped dependency was filtered out before the assertion could look at it. "+
+			"A consumer reading `checked && no failed rows` reports 'no dependency regressions' for a question "+
+			"that was never asked.", dep.Checked, dep.Consumed, dep.Rows)
+	}
+	// Consistency: an unchecked verdict must not carry half an answer.
+	assert.Equal(t, 0, dep.Consumed, "an unchecked verdict must not report a consumed count")
+	assert.Nil(t, dep.Rows, "an unchecked verdict must not report rows")
+	assert.False(t, res.HasMissingDeps(), "nothing was asserted, so nothing can be missing")
+}
+
+// The exclusion itself is NOT the bug and must not be 'fixed' by asserting
+// reusable-tier mocks: they are recorded once at app boot and shared across
+// every test, so a per-test presence assertion over them goes missing at random
+// and turns healthy tests RED.
+//
+// So the mixed mapping is the case that pins both halves at once: the per-test
+// entry is asserted, and the reusable one is neither counted as consumed (even
+// though the agent did serve it) nor reported as missing (even though this
+// test's window never consumed it).
+func TestBuildDepResults_MixedMappingAssertsOnlyThePerTestEntry(t *testing.T) {
+	expected := []models.MockEntry{
+		{Name: "session-1", Kind: "Http"},
+		{Name: "per-test-1", Kind: "Http"},
+	}
+	consumedMocks := []models.MockState{
+		// The agent really did serve the session mock during this test...
+		{Name: "session-1", Kind: models.HTTP, Lifetime: models.LifetimeSession},
+		consumed("per-test-1", models.HTTP),
+	}
+	dep := buildDepResults(expected, consumedMocks, true, map[string]bool{"session-1": true}, nil, nil)
+
+	assert.True(t, dep.Checked, "one eligible dependency is a real assertion")
+	assert.Equal(t, 1, dep.Consumed,
+		"...and it must NOT be counted: the consumed count is per-test dependencies only, "+
+			"or 'consumed 2 of 2' would be reported for a test that exercised one")
+	assert.Nil(t, dep.Rows, "the per-test dependency was consumed, so nothing is missing")
+
+	// Now drop the reusable mock from the consumed side: it still must not
+	// produce a row, or every test that ran before the session mock was
+	// (re)served would report a phantom missing dependency.
+	dep = buildDepResults(expected, []models.MockState{consumed("per-test-1", models.HTTP)}, true,
+		map[string]bool{"session-1": true}, nil, nil)
+	assert.True(t, dep.Checked)
+	assert.Equal(t, 1, dep.Consumed)
+	assert.Nil(t, dep.Rows,
+		"a reusable-tier mock that this test's window did not consume must never be reported missing: "+
+			"it is not attributable to one test, so the row would be a false RED")
+}
+
+// BACKWARD COMPAT. The eligibility guard changes what a report says ONLY for
+// the tests it turns from a false "checked" into an honest "not checked"; a
+// test with no dependency bookkeeping at all must serialize exactly as it did
+// before this field had a writer.
+//
+// The baseline is a models.Result carrying no dependency data whatsoever —
+// which is byte-for-byte what every report already on disk holds — so this
+// compares the real struct tags rather than a hand-copied literal that could
+// drift from them.
+func TestBuildDepResults_UncheckedReportIsByteIdenticalToPreSliceReports(t *testing.T) {
+	preSlice, err := yaml.Marshal(models.Result{})
+	if err != nil {
+		t.Fatalf("marshal baseline: %v", err)
+	}
+
+	cases := map[string]depAssertion{
+		"no mapping for this test":         buildDepResults(nil, nil, true, nil, nil, nil),
+		"assertion context not armed":      buildDepResults([]models.MockEntry{{Name: "m1", Kind: "Http"}}, nil, false, nil, nil, nil),
+		"every mapped dependency filtered": buildDepResults([]models.MockEntry{{Name: "s1", Kind: "Http"}}, nil, true, map[string]bool{"s1": true}, nil, nil),
+		"every mapped dependency is DNS":   buildDepResults([]models.MockEntry{{Name: "d1", Kind: "DNS"}}, nil, true, nil, nil, nil),
+	}
+	for name, dep := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := yaml.Marshal(models.Result{
+				DepResult:    dep.Rows,
+				DepsChecked:  dep.Checked,
+				DepsConsumed: dep.Consumed,
+			})
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if string(got) != string(preSlice) {
+				t.Fatalf("an unchecked dependency verdict serialises to:\n%s\nwant the pre-slice-4 shape:\n%s\n"+
+					"WHY THIS MATTERS: every report already on disk carries `dep_result: []` and no deps_* keys. "+
+					"An unchecked test must stay byte-identical to those, or every consumer diffing reports across "+
+					"the upgrade sees a change on tests where nothing happened.", got, preSlice)
+			}
+		})
+	}
+}
+
+// models.DepRowName is documented as a stable identifier an agent correlates
+// across runs, and models.DepResult calls its shape a one-way door. Indexing
+// by the position in the EMITTED slice broke that: with expectations [a b c],
+// the run that lost only `a` and the run that lost only `c` both emitted
+// "deps[0]" — the same name for two different dependencies.
+func TestBuildDepResults_RowNameIsStableAcrossRuns(t *testing.T) {
+	expected := []models.MockEntry{
+		{Name: "a", Kind: "Postgres"},
+		{Name: "b", Kind: "Postgres"},
+		{Name: "c", Kind: "Postgres"},
+	}
+	lookup := map[string]mockDisplayInfo{
+		"a": {target: "db:5432 SELECT"},
+		"b": {target: "db:5432 INSERT"},
+		"c": {target: "db:5432 UPDATE"},
+	}
+
+	// nameOf runs one replay in which exactly `lost` went unobserved and
+	// returns the single MISSING row's name.
+	nameOf := func(t *testing.T, lost string) string {
+		t.Helper()
+		var consumedMocks []models.MockState
+		for _, m := range expected {
+			if m.Name == lost {
+				continue
+			}
+			consumedMocks = append(consumedMocks, consumed(m.Name, models.Kind("Postgres")))
+		}
+		names := models.MissingDepNames(buildDepResults(expected, consumedMocks, true, nil, nil, lookup).Rows)
+		if len(names) != 1 {
+			t.Fatalf("expected exactly one missing row for %q, got %v", lost, names)
+		}
+		return names[0]
+	}
+
+	want := map[string]string{
+		"a": "deps[0] postgres db:5432 SELECT (presence)",
+		"b": "deps[1] postgres db:5432 INSERT (presence)",
+		"c": "deps[2] postgres db:5432 UPDATE (presence)",
+	}
+	for _, lost := range []string{"a", "b", "c"} {
+		if got := nameOf(t, lost); got != want[lost] {
+			t.Errorf("run that lost %q named the row %q, want %q — the index must number the RECORDING, not the emitted rows",
+				lost, got, want[lost])
+		}
+	}
+
+	// And the name must not move when EVERY dependency goes missing either.
+	got := models.MissingDepNames(buildDepResults(expected, nil, true, nil, nil, lookup).Rows)
+	if len(got) != 3 || got[2] != want["c"] {
+		t.Fatalf("all-missing run renamed the rows: %v", got)
+	}
+}
+
+// The report must not grow with the number of dependencies a test consumes,
+// IN ANY MODE: it is written per test-set to disk, re-read by `keploy report`
+// and uploaded to the fleet report store, and --assert-dependencies is sold
+// as a CI gate — precisely where reports are written and uploaded most.
+// Persistence is decoupled from the verdict knob for exactly that reason.
+func TestBuildDepResults_ConsumedRowsDoNotScaleTheReport(t *testing.T) {
+	const n = 200
+	expected := make([]models.MockEntry, 0, n)
+	consumedMocks := make([]models.MockState, 0, n)
+	for i := range n {
+		name := "mock-" + string(rune('a'+i%26)) + string(rune('a'+i/26))
+		expected = append(expected, models.MockEntry{Name: name, Kind: "Postgres"})
+		consumedMocks = append(consumedMocks, consumed(name, models.Kind("Postgres")))
+	}
+
+	dep := buildDepResults(expected, consumedMocks, true, nil, nil, nil)
+	if len(dep.Rows) != 0 {
+		t.Fatalf("%d consumed dependencies produced %d persisted rows; the consumed side must be a "+
+			"COUNT, not rows — at ~190 bytes of YAML each this is 3-11 MB per test-set report on a "+
+			"Postgres-chatty suite, uploaded to the fleet report store, that no consumer reads:\n%+v",
+			n, len(dep.Rows), dep.Rows)
+	}
+	if dep.Consumed != n {
+		t.Errorf("Consumed = %d, want %d", dep.Consumed, n)
+	}
+	if !dep.Checked {
+		t.Error("a run with 200 consumed dependencies and nothing missing must still be provably CHECKED")
+	}
+}
+
+// The one hard-constraint case: instrument+mapping mode, nothing missing, knob
+// off. The persisted result must be byte-identical to a pre-slice-4 one apart
+// from the two scalars — no `dep_result` entries at all. An earlier revision
+// wrote an aggregate row here, which cost a measured +224 bytes per test on
+// EVERY report ever written, forever, to encode one bit and one small int.
+func TestBuildDepResults_CleanTestPersistsNoRows(t *testing.T) {
+	expected := []models.MockEntry{{Name: "m1", Kind: "Postgres"}, {Name: "m2", Kind: "Postgres"}}
+	consumedMocks := []models.MockState{
+		consumed("m1", models.Kind("Postgres")), consumed("m2", models.Kind("Postgres")),
+	}
+
+	tcResult := &models.TestResult{Status: models.TestStatusPassed}
+	dep := buildDepResults(expected, consumedMocks, true, nil, nil, nil)
+	missing, level := attachDepResults(tcResult, models.TestStatusPassed, dep, false)
+
+	if len(missing) != 0 || level != depLogNone {
+		t.Fatalf("a clean test logged something: missing=%v level=%v", missing, level)
+	}
+	if len(tcResult.Result.DepResult) != 0 {
+		t.Fatalf("a clean test persisted %d dependency rows, want 0:\n%+v",
+			len(tcResult.Result.DepResult), tcResult.Result.DepResult)
+	}
+	if !tcResult.Result.DependenciesChecked() {
+		t.Error("a clean test must still be provably CHECKED, or `dep_result: []` is ambiguous")
+	}
+	if tcResult.Result.DepsConsumed != 2 {
+		t.Errorf("DepsConsumed = %d, want 2", tcResult.Result.DepsConsumed)
+	}
+
+	// The YAML the report actually carries.
+	out, err := yaml.Marshal(tcResult.Result)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(out), "deps[") {
+		t.Errorf("a clean test persisted a dependency row:\n%s", out)
+	}
+	if !strings.Contains(string(out), "dep_result: []") {
+		t.Errorf("a clean test must keep the pre-slice-4 `dep_result: []`:\n%s", out)
+	}
+}
+
+// THE OTHER BLOAT AXIS. The flagship scenario for this slice — a downstream
+// service removed, a worker that stopped producing, a mock pool whose names
+// drifted wholesale — makes EVERY mapped dependency of EVERY test unconsumed
+// at once. Uncapped, that wrote a 5.4 MB test-set report at 100 tests x 200
+// dependencies where the pre-slice build wrote 115 KB. The cap bounds it while
+// keeping the failure visible.
+func TestBuildDepResults_MissingRowsAreCapped(t *testing.T) {
+	const n = 200
+	expected := make([]models.MockEntry, 0, n)
+	for i := range n {
+		expected = append(expected, models.MockEntry{
+			Name: fmt.Sprintf("mock-%03d", i), Kind: "Postgres",
+		})
+	}
+
+	// Nothing consumed: every one of the 200 is missing.
+	rows := buildDepResults(expected, nil, true, nil, nil, nil).Rows
+
+	// depMissingRowCap individual rows + the overflow row.
+	if len(rows) != depMissingRowCap+1 {
+		t.Fatalf("%d missing dependencies produced %d rows, want %d", n, len(rows), depMissingRowCap+1)
+	}
+	// The individual rows are the FIRST ones in RECORDED order, so which
+	// dependencies get named is a property of the mapping and does not shuffle
+	// between two runs over the same data.
+	for i := range depMissingRowCap {
+		want := models.DepRowName(i, models.DepTypePostgres, "")
+		if rows[i].Name != want {
+			t.Fatalf("row %d is %q, want %q (missing rows must follow the recorded order)", i, rows[i].Name, want)
+		}
+	}
+	overflow := rows[depMissingRowCap]
+	if !models.IsDepMissingOverflow(overflow) {
+		t.Fatalf("expected the overflow row at index %d, got %+v", depMissingRowCap, overflow)
+	}
+	if want := models.DepMissingOverflowRow(n - depMissingRowCap); overflow.Name != want.Name {
+		t.Errorf("overflow row = %q, want %q", overflow.Name, want.Name)
+	}
+	// Capping must not hide the failure: every downstream reader keys off
+	// these two.
+	res := models.Result{DepResult: rows}
+	if !res.HasMissingDeps() {
+		t.Fatal("capping the missing rows made the lost dependencies invisible to HasMissingDeps")
+	}
+	if got := len(models.MissingDepNames(rows)); got != depMissingRowCap+1 {
+		t.Errorf("MissingDepNames returned %d names, want %d", got, depMissingRowCap+1)
+	}
+}
+
+// Exactly at the cap there is nothing to overflow: an "and 0 more" row would
+// be a lie.
+func TestBuildDepResults_NoOverflowRowAtOrBelowTheCap(t *testing.T) {
+	for _, n := range []int{1, depMissingRowCap - 1, depMissingRowCap} {
+		expected := make([]models.MockEntry, 0, n)
+		for i := range n {
+			expected = append(expected, models.MockEntry{Name: fmt.Sprintf("mock-%03d", i), Kind: "Postgres"})
+		}
+		rows := buildDepResults(expected, nil, true, nil, nil, nil).Rows
+		if len(rows) != n {
+			t.Fatalf("n=%d produced %d rows, want %d (n missing, no overflow)", n, len(rows), n)
+		}
+		for _, row := range rows {
+			if models.IsDepMissingOverflow(row) {
+				t.Fatalf("n=%d emitted an overflow row for nothing: %+v", n, row)
+			}
+		}
+	}
+}
+
+// The persisted shape must not depend on the verdict knob at all. buildDepResults
+// no longer takes it; this pins that it never grows one again.
+func TestBuildDepResults_IsIndependentOfTheVerdictKnob(t *testing.T) {
+	fn := reflect.TypeOf(buildDepResults)
+	for i := range fn.NumIn() {
+		if fn.In(i).Kind() != reflect.Bool {
+			continue
+		}
+		if i != 2 {
+			t.Fatalf("buildDepResults grew a second bool parameter at index %d. "+
+				"If that is --assert-dependencies again, see buildDepResults' sizing note: "+
+				"a verdict knob must not change what is persisted.", i)
+		}
+	}
+}
+
+// The DepResult rows and the mockSetMismatch verdict signal must be computed
+// from the same filters, otherwise --assert-dependencies can fail a test with
+// nothing rendered to explain it.
+func TestBuildDepResults_MissingRowsAgreeWithMockSubset(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected []models.MockEntry
+		consumed []models.MockState
+		reusable map[string]bool
+	}{
+		{
+			name:     "all consumed",
+			expected: []models.MockEntry{{Name: "m1", Kind: "Http"}, {Name: "m2", Kind: "Http"}},
+			consumed: []models.MockState{consumed("m1", models.HTTP), consumed("m2", models.HTTP)},
+		},
+		{
+			name:     "one missing",
+			expected: []models.MockEntry{{Name: "m1", Kind: "Http"}, {Name: "m2", Kind: "Http"}},
+			consumed: []models.MockState{consumed("m1", models.HTTP)},
+		},
+		{
+			name:     "missing one is reusable so it is not asserted",
+			expected: []models.MockEntry{{Name: "m1", Kind: "Http"}, {Name: "m2", Kind: "Http"}},
+			consumed: []models.MockState{consumed("m1", models.HTTP)},
+			reusable: map[string]bool{"m2": true},
+		},
+		{
+			name:     "DNS never counts as missing",
+			expected: []models.MockEntry{{Name: "m1", Kind: "Http"}, {Name: "dns", Kind: "DNS"}},
+			consumed: []models.MockState{consumed("m1", models.HTTP)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reproduce the call site's filtered name slices verbatim.
+			var filteredExpected []string
+			for _, m := range tt.expected {
+				if isDNSMockEntry(m, nil) || tt.reusable[m.Name] {
+					continue
+				}
+				filteredExpected = append(filteredExpected, m.Name)
+			}
+			var filteredConsumed []string
+			for _, m := range tt.consumed {
+				if m.Kind == models.DNS || isReusableTierState(m) {
+					continue
+				}
+				filteredConsumed = append(filteredConsumed, m.Name)
+			}
+			mockSetMismatch := !isMockSubset(filteredConsumed, filteredExpected)
+
+			dep := buildDepResults(tt.expected, tt.consumed, true, tt.reusable, nil, nil)
+			result := models.Result{DepResult: dep.Rows, DepsChecked: dep.Checked, DepsConsumed: dep.Consumed}
+			assert.Equal(t, mockSetMismatch, result.HasMissingDeps(),
+				"missing dependency rows must agree with the mockSetMismatch verdict signal")
+			assert.True(t, result.DependenciesChecked(),
+				"a valid assertion must always leave persisted evidence that it ran")
+		})
+	}
+}
+
+func TestMockTargetFromSpec(t *testing.T) {
+	tests := []struct {
+		name string
+		mock *models.Mock
+		want string
+	}{
+		{name: "nil mock", mock: nil, want: ""},
+		{
+			name: "http carries method and path, not just the host",
+			mock: &models.Mock{Kind: models.HTTP, Spec: models.MockSpec{
+				HTTPReq: &models.HTTPReq{Method: "GET", URL: "http://api.internal:8080/orders"},
+			}},
+			want: "GET api.internal:8080/orders",
+		},
+		{
+			name: "two calls to one host are distinguishable",
+			mock: &models.Mock{Kind: models.HTTP, Spec: models.MockSpec{
+				HTTPReq: &models.HTTPReq{Method: "POST", URL: "http://api.internal:8080/payments"},
+			}},
+			want: "POST api.internal:8080/payments",
+		},
+		{
+			name: "http wins over destAddr, which would collapse the path away",
+			mock: &models.Mock{Kind: models.HTTP, Spec: models.MockSpec{
+				Metadata: map[string]string{"destAddr": "api.internal:8080"},
+				HTTPReq:  &models.HTTPReq{Method: "GET", URL: "http://api.internal:8080/orders"},
+			}},
+			want: "GET api.internal:8080/orders",
+		},
+		{
+			name: "destAddr is used for protocols with no request URL",
+			mock: &models.Mock{Kind: models.MySQL, Spec: models.MockSpec{
+				Metadata: map[string]string{"destAddr": "mysql:3306"},
+			}},
+			want: "mysql:3306",
+		},
+		{
+			// The MySQL v2 recorder writes requestOperation, not operation, so
+			// MockSummaryFromSpec returns a bare "MySQL" and is rejected as a
+			// target. Without folding it into destAddr, EVERY MySQL row of a
+			// test reads "mysql:3306" and the index is the only discriminator.
+			name: "the MySQL v2 operation is folded into the address",
+			mock: &models.Mock{Kind: models.MySQL, Spec: models.MockSpec{
+				Metadata: map[string]string{
+					"destAddr":          "mysql:3306",
+					"requestOperation":  "COM_QUERY",
+					"responseOperation": "OK",
+				},
+			}},
+			want: "mysql:3306 COM_QUERY",
+		},
+		{
+			// The response side names the server's reply status, not the call,
+			// so it must never become the target on its own.
+			name: "responseOperation alone is not an identity",
+			mock: &models.Mock{Kind: models.MySQL, Spec: models.MockSpec{
+				Metadata: map[string]string{"destAddr": "mysql:3306", "responseOperation": "OK"},
+			}},
+			want: "mysql:3306",
+		},
+		{
+			name: "a v1 operation still wins over the request-side alias",
+			mock: &models.Mock{Kind: models.Kind("PostgresV2"), Spec: models.MockSpec{
+				Metadata: map[string]string{
+					"destAddr":         "db:5432",
+					"operation":        "INSERT",
+					"requestOperation": "P",
+				},
+			}},
+			want: "db:5432 INSERT",
+		},
+		{
+			name: "the protocol-generic summary beats a bare operation token",
+			mock: &models.Mock{Kind: models.Mongo, Spec: models.MockSpec{
+				Metadata:      map[string]string{"operation": "find"},
+				MongoRequests: []models.MongoRequest{{}},
+			}},
+			want: "MongoDB find",
+		},
+		{
+			name: "operation is the last resort",
+			mock: &models.Mock{Kind: models.Kind("Redis"), Spec: models.MockSpec{
+				Metadata: map[string]string{"operation": "GET user:1"},
+			}},
+			want: "Redis GET user:1",
+		},
+		{
+			// No destAddr, no summary (requestOperation is invisible to
+			// MockSummaryFromSpec) — the bare verb is all that is left.
+			name: "the request-side operation is the last resort too",
+			mock: &models.Mock{Kind: models.MySQL, Spec: models.MockSpec{
+				Metadata: map[string]string{"requestOperation": "COM_STMT_PREPARE"},
+			}},
+			want: "COM_STMT_PREPARE",
+		},
+		{
+			name: "nothing identifying yields an empty target, not the bare kind",
+			mock: &models.Mock{Kind: models.Kind("Redis"), Spec: models.MockSpec{}},
+			want: "",
+		},
+		{
+			name: "unparseable http url still names the method and the raw url",
+			mock: &models.Mock{Kind: models.HTTP, Spec: models.MockSpec{
+				HTTPReq: &models.HTTPReq{Method: "GET", URL: "://nope"},
+			}},
+			want: "GET ://nope",
+		},
+		{
+			name: "a relative http url keeps the path",
+			mock: &models.Mock{Kind: models.HTTP, Spec: models.MockSpec{
+				HTTPReq: &models.HTTPReq{Method: "GET", URL: "/orders/1"},
+			}},
+			want: "GET /orders/1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, mockTargetFromSpec(tt.mock))
+		})
+	}
+}
+
+func TestDependencyAssertionKnob(t *testing.T) {
+	tests := []struct {
+		name               string
+		mockSetMismatch    bool
+		assertDependencies bool
+		strictMockReject   bool
+		strictFailure      bool
+		wantDepAssertFail  bool
+		wantDemote         bool
+	}{
+		{
+			name:            "knob off: a diverged mock set still demotes to OBSOLETE (historical default)",
+			mockSetMismatch: true,
+			wantDemote:      true,
+		},
+		{
+			name:               "knob on: a diverged mock set becomes a real failure",
+			mockSetMismatch:    true,
+			assertDependencies: true,
+			wantDepAssertFail:  true,
+			wantDemote:         false,
+		},
+		{
+			name:               "knob on with no divergence changes nothing",
+			mockSetMismatch:    false,
+			assertDependencies: true,
+			wantDepAssertFail:  false,
+			wantDemote:         false,
+		},
+		{
+			name:             "schema-noise-strict rejection also vetoes the demotion",
+			mockSetMismatch:  true,
+			strictMockReject: true,
+			wantDemote:       false,
+		},
+		{
+			name:            "strict-failure keeps vetoing the demotion on its own",
+			mockSetMismatch: true,
+			strictFailure:   true,
+			wantDemote:      false,
+		},
+		{
+			name:            "no divergence never demotes",
+			mockSetMismatch: false,
+			wantDemote:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			depAssertFail := dependencyAssertionRejects(tt.mockSetMismatch, tt.assertDependencies)
+			assert.Equal(t, tt.wantDepAssertFail, depAssertFail)
+			assert.Equal(t, tt.wantDemote,
+				demoteToObsolete(tt.mockSetMismatch, tt.strictMockReject, depAssertFail, tt.strictFailure))
+		})
+	}
+}
+
+// resolveTestStatus is the demotion ALGEBRA, downstream of the promotions:
+// `responseMatched` here already accounts for a veto having flipped it. The
+// entry point RunTestSet calls is resolveTestOutcome (below), which is where
+// the --assert-dependencies promotion itself lives.
+func TestResolveTestStatus(t *testing.T) {
+	tests := []struct {
+		name             string
+		testPass         bool
+		mockSetMismatch  bool
+		strictMockReject bool
+		depAssertFail    bool
+		strictFailure    bool
+		wantStatus       models.TestStatus
+		wantFailsSet     bool
+	}{
+		{
+			name: "a clean pass", testPass: true,
+			wantStatus: models.TestStatusPassed, wantFailsSet: false,
+		},
+		{
+			name:     "the silent-green case: response matched, dependency vanished, knob OFF",
+			testPass: true, mockSetMismatch: true,
+			wantStatus: models.TestStatusPassed, wantFailsSet: false,
+		},
+		{
+			// UNREACHABLE FROM PRODUCTION, and written down so it stays that
+			// way: resolveTestOutcome flips responseMatched to false before
+			// calling this when the knob promotes, so this input combination
+			// never occurs. If it ever did, PASSED would be the wrong answer —
+			// which is exactly why the promotion cannot live here. See
+			// TestResolveTestOutcome for the reachable knob-ON case.
+			name:     "post-flip contract: a still-matching response is PASSED even with depAssertFail set",
+			testPass: true, mockSetMismatch: true, depAssertFail: true,
+			wantStatus: models.TestStatusPassed, wantFailsSet: false,
+		},
+		{
+			name:       "a plain response failure is FAILED and reddens the set",
+			testPass:   false,
+			wantStatus: models.TestStatusFailed, wantFailsSet: true,
+		},
+		{
+			name:     "knob OFF: a diverged mock set is demoted to OBSOLETE and does NOT redden the set",
+			testPass: false, mockSetMismatch: true,
+			wantStatus: models.TestStatusObsolete, wantFailsSet: false,
+		},
+		{
+			name:     "knob ON: the same case is FAILED and reddens the set",
+			testPass: false, mockSetMismatch: true, depAssertFail: true,
+			wantStatus: models.TestStatusFailed, wantFailsSet: true,
+		},
+		{
+			name:     "--strict-failure vetoes the demotion on its own",
+			testPass: false, mockSetMismatch: true, strictFailure: true,
+			wantStatus: models.TestStatusFailed, wantFailsSet: true,
+		},
+		{
+			name:     "--schema-noise-strict vetoes the demotion on its own",
+			testPass: false, mockSetMismatch: true, strictMockReject: true,
+			wantStatus: models.TestStatusFailed, wantFailsSet: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status, failsSet := resolveTestStatus(tt.testPass, tt.mockSetMismatch, tt.strictMockReject, tt.depAssertFail, tt.strictFailure)
+			assert.Equal(t, tt.wantStatus, status)
+			assert.Equal(t, tt.wantFailsSet, failsSet)
+		})
+	}
+}
+
+// resolveTestOutcome is THE verdict seam RunTestSet calls, and the only place
+// the --assert-dependencies promotion exists. It takes the PRE-promotion
+// response result, which is what makes the flagship case assertable at all:
+// "the response matched but a recorded outgoing call was not observed" becomes
+// a failure by flipping that input, so a function that only saw the flipped
+// value could never be tested for it.
+func TestResolveTestOutcome(t *testing.T) {
+	tests := []struct {
+		name               string
+		responseMatched    bool
+		mockSetMismatch    bool
+		schemaNoiseStrict  bool
+		assertDependencies bool
+		strictFailure      bool
+		want               testOutcome
+	}{
+		{
+			name:            "a clean pass",
+			responseMatched: true,
+			want: testOutcome{
+				Status: models.TestStatusPassed, Log: mismatchLogNone,
+			},
+		},
+		{
+			name: "a plain response failure, no mock-set divergence",
+			want: testOutcome{
+				Status: models.TestStatusFailed, FailsTestSet: true, Log: mismatchLogNone,
+			},
+		},
+		{
+			name:               "the knob on a clean run changes nothing",
+			responseMatched:    true,
+			assertDependencies: true,
+			want: testOutcome{
+				Status: models.TestStatusPassed, Log: mismatchLogNone,
+			},
+		},
+		{
+			// THE SILENT-GREEN CASE, default behaviour: the response matched,
+			// a recorded outgoing call was not observed, and the run stays
+			// green. Visibility comes from the DepResult rows, not the verdict.
+			name:            "response matched, dependency not observed, knob OFF: still PASSED and still green",
+			responseMatched: true, mockSetMismatch: true,
+			want: testOutcome{
+				Status: models.TestStatusPassed, Log: mismatchLogIgnoredResponseMatched,
+			},
+		},
+		{
+			// THE FLAGSHIP PROMOTION. This is the whole reason
+			// --assert-dependencies exists and is distinct from
+			// --strict-failure, which cannot reach a test whose response
+			// matched.
+			name:            "response matched, dependency not observed, knob ON: FAILED and the set goes red",
+			responseMatched: true, mockSetMismatch: true, assertDependencies: true,
+			want: testOutcome{
+				Status: models.TestStatusFailed, FailsTestSet: true,
+				RecordMismatch: true, Log: mismatchLogDependencyReject,
+				DepAssertFail: true,
+			},
+		},
+		{
+			name:            "--strict-failure alone cannot reach a response that matched",
+			responseMatched: true, mockSetMismatch: true, strictFailure: true,
+			want: testOutcome{
+				Status: models.TestStatusPassed, Log: mismatchLogIgnoredResponseMatched,
+			},
+		},
+		{
+			name:            "--schema-noise-strict promotes a matching response too, and says so",
+			responseMatched: true, mockSetMismatch: true, schemaNoiseStrict: true,
+			want: testOutcome{
+				Status: models.TestStatusFailed, FailsTestSet: true,
+				RecordMismatch: true, Log: mismatchLogSchemaNoiseReject,
+			},
+		},
+		{
+			// Both promotions armed: schema-noise wins the LOG (it names the
+			// more specific cause), the verdict is the same either way.
+			name:            "schema-noise-strict wins the explanation when both knobs are on",
+			responseMatched: true, mockSetMismatch: true, schemaNoiseStrict: true, assertDependencies: true,
+			want: testOutcome{
+				Status: models.TestStatusFailed, FailsTestSet: true,
+				RecordMismatch: true, Log: mismatchLogSchemaNoiseReject,
+				DepAssertFail: true,
+			},
+		},
+		{
+			name:            "response failed AND the mock set diverged, knob OFF: the historical OBSOLETE demotion",
+			mockSetMismatch: true,
+			want: testOutcome{
+				Status: models.TestStatusObsolete, RecordMismatch: true, Log: mismatchLogObsolete,
+			},
+		},
+		{
+			// The wording matters: telling a user to re-record a test keploy
+			// is about to mark FAILED points them at the wrong fix.
+			name:            "response failed, knob ON: FAILED, and the log names the flag instead of saying re-record",
+			mockSetMismatch: true, assertDependencies: true,
+			want: testOutcome{
+				Status: models.TestStatusFailed, FailsTestSet: true,
+				RecordMismatch: true, Log: mismatchLogVetoedFailure,
+				VetoFlags: "--assert-dependencies", DepAssertFail: true,
+			},
+		},
+		{
+			name:            "response failed, --strict-failure: FAILED, and the log names that flag",
+			mockSetMismatch: true, strictFailure: true,
+			want: testOutcome{
+				Status: models.TestStatusFailed, FailsTestSet: true,
+				RecordMismatch: true, Log: mismatchLogVetoedFailure,
+				VetoFlags: "--strict-failure",
+			},
+		},
+		{
+			name:            "both vetoes are named",
+			mockSetMismatch: true, assertDependencies: true, strictFailure: true,
+			want: testOutcome{
+				Status: models.TestStatusFailed, FailsTestSet: true,
+				RecordMismatch: true, Log: mismatchLogVetoedFailure,
+				VetoFlags: "--assert-dependencies, --strict-failure", DepAssertFail: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveTestOutcome(tt.responseMatched, tt.mockSetMismatch, tt.schemaNoiseStrict, tt.assertDependencies, tt.strictFailure)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// Whatever else changes, a green default run must stay green: with every knob
+// off, no input can produce a FAILED test set that the pre-slice-4 code would
+// not also have produced (i.e. FailsTestSet implies the response failed and
+// the mock set agreed).
+func TestResolveTestOutcome_DefaultsAreBackwardCompatible(t *testing.T) {
+	for _, responseMatched := range []bool{false, true} {
+		for _, mismatch := range []bool{false, true} {
+			got := resolveTestOutcome(responseMatched, mismatch, false, false, false)
+			want, wantFails := resolveTestStatus(responseMatched, mismatch, false, false, false)
+			assert.Equal(t, want, got.Status,
+				"responseMatched=%v mismatch=%v", responseMatched, mismatch)
+			assert.Equal(t, wantFails, got.FailsTestSet,
+				"responseMatched=%v mismatch=%v", responseMatched, mismatch)
+			assert.False(t, got.DepAssertFail)
+		}
+	}
+}
+
+// A diverged mock set normally suppresses the response diff as "re-record
+// noise". Under --assert-dependencies the same test is about to be marked
+// FAILED, so suppressing its diff hands the user a red test with nothing to
+// look at.
+func TestShouldEmitFailureLogs(t *testing.T) {
+	tests := []struct {
+		name               string
+		mockSetMismatch    bool
+		assertDependencies bool
+		want               bool
+	}{
+		{name: "no divergence: diffs as always", want: true},
+		{name: "no divergence, knob on", assertDependencies: true, want: true},
+		{name: "divergence, knob off: historical suppression", mockSetMismatch: true, want: false},
+		{
+			name:            "divergence, knob on: the test is going red, so show the diff",
+			mockSetMismatch: true, assertDependencies: true, want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, shouldEmitFailureLogs(tt.mockSetMismatch, tt.assertDependencies))
+		})
+	}
+}
+
+// recordUnexercised is the single writer of the set warnUnexercisedDependencies
+// reports on. Emptying that set is otherwise an invisible mutation: the wiring
+// test pins the CALL to the summary, but a summary over an empty map is a
+// silent no-op.
+func TestRecordUnexercised(t *testing.T) {
+	tests := []struct {
+		name   string
+		level  depLogLevel
+		status models.TestStatus
+		want   map[string]models.TestStatus
+	}{
+		{
+			name:  "reported-only: collected, with its status",
+			level: depLogDebug, status: models.TestStatusPassed,
+			want: map[string]models.TestStatus{"tc": models.TestStatusPassed},
+		},
+		{
+			name:  "a demoted test is collected too, as OBSOLETE",
+			level: depLogDebug, status: models.TestStatusObsolete,
+			want: map[string]models.TestStatus{"tc": models.TestStatusObsolete},
+		},
+		{
+			name:  "nothing missing: nothing collected",
+			level: depLogNone, status: models.TestStatusPassed,
+			want: map[string]models.TestStatus{},
+		},
+		{
+			// Under the knob the per-test Error already fired and the run is
+			// red; a summary Warn on top would be noise.
+			name:  "knob on: the per-test Error already covered it",
+			level: depLogError, status: models.TestStatusFailed,
+			want: map[string]models.TestStatus{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := map[string]models.TestStatus{}
+			recordUnexercised(got, "tc", tt.status, tt.level)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	// A nil set must not panic.
+	recordUnexercised(nil, "tc", models.TestStatusPassed, depLogDebug)
+}
+
+// --retry-passing re-runs the passing tests up to five times and the LAST
+// cycle's rows are the ones persisted (finalTestCaseResults is overwritten each
+// cycle). A cumulative set would keep a test that lost a dependency in cycle 1
+// and consumed it in cycle 2, so the end-of-test-set Warn would name a test
+// whose own report carries no missing row — a WARN contradicting the report it
+// points the user at, in exactly the flake scenario --retry-passing exists to
+// smooth over.
+func TestRecordUnexercised_LastCycleWins(t *testing.T) {
+	tests := []struct {
+		name   string
+		cycles []depLogLevel
+		want   map[string]models.TestStatus
+	}{
+		{
+			name:   "lost it, then recovered on retry: dropped",
+			cycles: []depLogLevel{depLogDebug, depLogNone},
+			want:   map[string]models.TestStatus{},
+		},
+		{
+			name:   "recovered, then lost it again: kept",
+			cycles: []depLogLevel{depLogDebug, depLogNone, depLogDebug},
+			want:   map[string]models.TestStatus{"tc": models.TestStatusPassed},
+		},
+		{
+			name:   "still missing on every cycle: kept exactly once",
+			cycles: []depLogLevel{depLogDebug, depLogDebug, depLogDebug},
+			want:   map[string]models.TestStatus{"tc": models.TestStatusPassed},
+		},
+		{
+			// The knob turns the per-test line into an Error and the run is
+			// already red, so the summary drops the test as well.
+			name:   "escalated to the knob's Error on a later cycle: dropped",
+			cycles: []depLogLevel{depLogDebug, depLogError},
+			want:   map[string]models.TestStatus{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := map[string]models.TestStatus{}
+			for _, level := range tt.cycles {
+				recordUnexercised(got, "tc", models.TestStatusPassed, level)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// The per-test-set summary must not claim "the response still matched" over a
+// population that includes demoted tests, whose response did NOT match — that
+// is exactly the subset a user is most likely to go and investigate.
+func TestUnexercisedSummary(t *testing.T) {
+	tests := []struct {
+		name       string
+		in         map[string]models.TestStatus
+		wantNames  []string
+		wantSample []string
+		wantPassed int
+	}{
+		{
+			name: "mixed population: only the PASSED ones are counted as still-matching",
+			in: map[string]models.TestStatus{
+				"tc-b": models.TestStatusPassed,
+				"tc-a": models.TestStatusObsolete,
+				"tc-c": models.TestStatusPassed,
+			},
+			wantNames:  []string{"tc-a", "tc-b", "tc-c"},
+			wantSample: []string{"tc-a", "tc-b", "tc-c"},
+			wantPassed: 2,
+		},
+		{
+			name:       "all demoted: zero still matched",
+			in:         map[string]models.TestStatus{"tc-a": models.TestStatusObsolete},
+			wantNames:  []string{"tc-a"},
+			wantSample: []string{"tc-a"},
+			wantPassed: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			names, sample, passed := unexercisedSummary(tt.in)
+			assert.Equal(t, tt.wantNames, names)
+			assert.Equal(t, tt.wantSample, sample)
+			assert.Equal(t, tt.wantPassed, passed)
+		})
+	}
+}
+
+// A fully drifted suite must not emit a thousand-name log line.
+func TestUnexercisedSummary_SampleIsCapped(t *testing.T) {
+	in := map[string]models.TestStatus{}
+	for i := range 50 {
+		in[string(rune('a'+i%26))+string(rune('a'+i/26))] = models.TestStatusPassed
+	}
+	names, sample, passed := unexercisedSummary(in)
+	assert.Len(t, names, 50)
+	assert.Len(t, sample, depWarnSampleSize)
+	assert.Equal(t, 50, passed)
+	assert.Equal(t, names[:depWarnSampleSize], sample)
+}
+
+// attachDepResults is the writer seam RunTestSet calls. Neutering it (dropping
+// the assignment, or dropping the category, or flattening the log level) has to
+// fail here.
+func TestAttachDepResults(t *testing.T) {
+	missingRow := models.DepResult{
+		Name: "deps[0] postgres db:5432 (presence)", Type: "postgres", Meta: missingMeta(),
+	}
+	tests := []struct {
+		name               string
+		status             models.TestStatus
+		dep                depAssertion
+		assertDependencies bool
+		existingCategories []models.FailureCategory
+		wantMissing        []string
+		wantLevel          depLogLevel
+		wantCategories     []models.FailureCategory
+	}{
+		{
+			name:           "the assertion never ran: nothing is written, nothing is logged",
+			status:         models.TestStatusPassed,
+			wantLevel:      depLogNone,
+			wantCategories: nil,
+		},
+		{
+			name:           "everything consumed: the scalars persist, no rows, no category, no log",
+			status:         models.TestStatusPassed,
+			dep:            depAssertion{Checked: true, Consumed: 3},
+			wantLevel:      depLogNone,
+			wantCategories: nil,
+		},
+		{
+			name:        "PASSED with a missing dependency keeps the rows but NEVER gets a failure category",
+			status:      models.TestStatusPassed,
+			dep:         depAssertion{Checked: true, Consumed: 3, Rows: []models.DepResult{missingRow}},
+			wantMissing: []string{missingRow.Name},
+			wantLevel:   depLogDebug,
+			// The silent-green case: visible via the rows, not via a label.
+			wantCategories: nil,
+		},
+		{
+			name:           "OBSOLETE with a missing dependency is labelled",
+			status:         models.TestStatusObsolete,
+			dep:            depAssertion{Checked: true, Rows: []models.DepResult{missingRow}},
+			wantMissing:    []string{missingRow.Name},
+			wantLevel:      depLogDebug,
+			wantCategories: []models.FailureCategory{models.DependencyMissing},
+		},
+		{
+			name:               "FAILED under the knob is labelled and logged at Error",
+			status:             models.TestStatusFailed,
+			dep:                depAssertion{Checked: true, Rows: []models.DepResult{missingRow}},
+			assertDependencies: true,
+			wantMissing:        []string{missingRow.Name},
+			wantLevel:          depLogError,
+			wantCategories:     []models.FailureCategory{models.DependencyMissing},
+		},
+		{
+			name:               "the category is appended to what the matcher already set, without duplicating",
+			status:             models.TestStatusFailed,
+			dep:                depAssertion{Checked: true, Rows: []models.DepResult{missingRow}},
+			existingCategories: []models.FailureCategory{models.AppConnectionError, models.DependencyMissing},
+			wantMissing:        []string{missingRow.Name},
+			wantLevel:          depLogDebug,
+			wantCategories:     []models.FailureCategory{models.AppConnectionError, models.DependencyMissing},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tcResult := &models.TestResult{Status: tt.status}
+			tcResult.FailureInfo.Category = tt.existingCategories
+
+			missing, level := attachDepResults(tcResult, tt.status, tt.dep, tt.assertDependencies)
+
+			assert.Equal(t, tt.dep.Rows, tcResult.Result.DepResult, "the rows must land on the persisted result")
+			assert.Equal(t, tt.dep.Checked, tcResult.Result.DepsChecked,
+				"DepsChecked is the one bit that disambiguates `dep_result: []`; dropping it makes "+
+					"'checked and clean' indistinguishable from 'never checked' on disk")
+			assert.Equal(t, tt.dep.Consumed, tcResult.Result.DepsConsumed,
+				"DepsConsumed is the only persisted trace of the dependencies the test DID exercise")
+			assert.Equal(t, tt.wantMissing, missing)
+			assert.Equal(t, tt.wantLevel, level)
+			assert.Equal(t, tt.wantCategories, tcResult.FailureInfo.Category)
+		})
+	}
+}
+
+// The matcher owns FailureInfo.Category and the persisted Result shares its
+// backing array. Appending in place would mutate data the writer does not own.
+func TestAttachDepResults_DoesNotMutateTheCallersCategorySlice(t *testing.T) {
+	shared := make([]models.FailureCategory, 1, 4) // spare capacity: a plain append writes in place
+	shared[0] = models.AppConnectionError
+	alias := shared[:1:4]
+
+	tcResult := &models.TestResult{Status: models.TestStatusFailed}
+	tcResult.FailureInfo.Category = alias
+
+	attachDepResults(tcResult, models.TestStatusFailed, depAssertion{
+		Checked: true,
+		Rows:    []models.DepResult{{Name: "deps[0] postgres x (presence)", Meta: missingMeta()}},
+	}, false)
+
+	if len(shared) != 1 || shared[0] != models.AppConnectionError {
+		t.Fatalf("caller's slice header changed: %v", shared)
+	}
+	if got := shared[:2]; got[1] == models.DependencyMissing {
+		t.Fatalf("the category was appended into the caller's backing array: %v", got)
+	}
+	assert.Equal(t,
+		[]models.FailureCategory{models.AppConnectionError, models.DependencyMissing},
+		tcResult.FailureInfo.Category)
+}
+
+func TestAttachDepResults_NilResultIsSafe(t *testing.T) {
+	missing, level := attachDepResults(nil, models.TestStatusFailed, depAssertion{
+		Checked: true,
+		Rows:    []models.DepResult{{Name: "deps[0] x (presence)", Meta: missingMeta()}},
+	}, true)
+	assert.Nil(t, missing)
+	assert.Equal(t, depLogNone, level)
+}
+
+func TestDependencyAssertionInertReason(t *testing.T) {
+	tests := []struct {
+		name                string
+		instrument          bool
+		useMappingBased     bool
+		isMappingEnabled    bool
+		consumedFetchFailed bool
+		deferredStreaming   bool
+		noEligibleDeps      bool
+		wantSubstring       string
+		// wantAbsent pins a string the reason must NOT contain. Precedence
+		// between two simultaneously-true reasons is only half-tested by
+		// asserting the winner's wording: a message that concatenated both
+		// would pass that and still mis-direct the reader.
+		wantAbsent string
+	}{
+		{
+			name:       "everything armed: the assertion can run",
+			instrument: true, useMappingBased: true, isMappingEnabled: true,
+			wantSubstring: "",
+		},
+		{
+			name:       "base-path / remote agent: the per-test mapping is never armed",
+			instrument: false, useMappingBased: true, isMappingEnabled: true,
+			wantSubstring: "not instrument mode",
+		},
+		{
+			name:       "mapping disabled",
+			instrument: true, useMappingBased: true, isMappingEnabled: false,
+			wantSubstring: "test.disableMapping",
+		},
+		{
+			name:       "a legacy test set with no usable mappings.yaml",
+			instrument: true, useMappingBased: false, isMappingEnabled: true,
+			wantSubstring: "--update-test-mapping",
+		},
+		{
+			// THE SIXTH REASON. Every set-wide precondition holds, so
+			// nothing else in this function fires — but RunTestSet's Phase-2
+			// pass writes no DepResult and never resolves an outcome, so the
+			// flag is inert for those test cases anyway. Without this case
+			// --assert-dependencies over an SSE suite exits 0 in silence.
+			name:       "a healthy test set that defers streaming test cases",
+			instrument: true, useMappingBased: true, isMappingEnabled: true,
+			deferredStreaming: true,
+			wantSubstring:     "streaming",
+		},
+		{
+			// PRECEDENCE. A set-wide precondition disables the assertion for
+			// the streaming tests too, so naming the precondition (which the
+			// user can fix) beats naming the deferral (which they cannot).
+			name:       "a set-wide precondition outranks the streaming deferral",
+			instrument: false, useMappingBased: true, isMappingEnabled: true,
+			deferredStreaming: true,
+			wantSubstring:     "not instrument mode",
+		},
+		{
+			// THE FIFTH REASON, and the one an ordinary recording hits. Every
+			// precondition holds and the mapping is full of entries — they are
+			// all session/connection-tier, so the per-test assertion has
+			// nothing eligible to run over and reports NOT CHECKED. Without a
+			// named reason the user sees `dependencies_checked: false` on every
+			// test and has no way to tell it from a --base-path run.
+			name:       "an armed test set whose every mapped dependency is reusable-tier",
+			instrument: true, useMappingBased: true, isMappingEnabled: true,
+			noEligibleDeps: true,
+			wantSubstring:  "session/connection-tier",
+		},
+		{
+			// The reason has to say what the REPORT will show, because the
+			// honest report for this state is indistinguishable on the wire
+			// from every other not-run mode.
+			name:       "the no-eligible-dependency reason names the verdict the report carries",
+			instrument: true, useMappingBased: true, isMappingEnabled: true,
+			noEligibleDeps: true,
+			wantSubstring:  "dependencies_checked=false",
+		},
+		{
+			// PRECEDENCE, second axis. The tier classification comes from the
+			// RECORDING, so it applies to the deferred streaming test cases
+			// too; the deferral says nothing about the tests the main loop
+			// already asserted.
+			name:       "no eligible dependency outranks the streaming deferral",
+			instrument: true, useMappingBased: true, isMappingEnabled: true,
+			deferredStreaming: true, noEligibleDeps: true,
+			wantSubstring: "session/connection-tier",
+		},
+		{
+			// ...and a set-wide precondition still outranks BOTH: it is the
+			// one the user can actually fix.
+			name:       "a set-wide precondition outranks the no-eligible-dependency reason",
+			instrument: true, useMappingBased: false, isMappingEnabled: true,
+			noEligibleDeps: true,
+			wantSubstring:  "--update-test-mapping",
+		},
+		{
+			// THE FOURTH REASON. Every set-wide precondition holds and the
+			// mapping has eligible entries — the run still could not ask the
+			// question, because fetching the mocks the test consumed failed.
+			// Before this arm the function returned "" for this state, so
+			// --assert-dependencies reported dependencies_checked=false for
+			// those tests and said NOTHING about why. That is the same silent
+			// class as the other five.
+			name:       "an armed test set whose per-test consumed-mock fetch failed",
+			instrument: true, useMappingBased: true, isMappingEnabled: true,
+			consumedFetchFailed: true,
+			wantSubstring:       "consumed-mock fetch failed",
+		},
+		{
+			// THE MIS-ATTRIBUTION THIS ARM EXISTS TO STOP. Both states are
+			// true at once: the fetch failed AND the mapping happens to be
+			// all-reusable. Only the fetch is the operator's to fix, so the
+			// fetch must win. With the arms in the other order the run tells
+			// them to go re-tag a recording that was never the problem.
+			name:       "a failed consumed fetch outranks the tier reason",
+			instrument: true, useMappingBased: true, isMappingEnabled: true,
+			consumedFetchFailed: true, noEligibleDeps: true,
+			wantSubstring: "consumed-mock fetch failed",
+		},
+		{
+			// ...and it must NOT name the tier, which is the whole point of
+			// the previous case. Asserted as an absence because
+			// wantSubstring alone cannot see a message that says both.
+			name:       "the failed-fetch reason does not blame the recording's tier",
+			instrument: true, useMappingBased: true, isMappingEnabled: true,
+			consumedFetchFailed: true, noEligibleDeps: true,
+			wantAbsent: "session/connection-tier",
+		},
+		{
+			// PRECEDENCE, upper bound. A set-wide precondition is still more
+			// informative than a per-test transport error: it disables the
+			// assertion for every test in the set, including this one.
+			name:       "a set-wide precondition outranks the failed consumed fetch",
+			instrument: false, useMappingBased: true, isMappingEnabled: true,
+			consumedFetchFailed: true,
+			wantSubstring:       "not instrument mode",
+		},
+		{
+			// PRECEDENCE, lower bound: the fetch error is about the tests the
+			// main loop just ran, so it beats the streaming deferral too.
+			name:       "a failed consumed fetch outranks the streaming deferral",
+			instrument: true, useMappingBased: true, isMappingEnabled: true,
+			consumedFetchFailed: true, deferredStreaming: true,
+			wantSubstring: "consumed-mock fetch failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dependencyAssertionInertReason(tt.instrument, tt.useMappingBased, tt.isMappingEnabled, tt.consumedFetchFailed, tt.deferredStreaming, tt.noEligibleDeps)
+			if tt.wantAbsent != "" {
+				assert.NotContains(t, got, tt.wantAbsent,
+					"the reason names a state that did not win precedence: %q", got)
+			}
+			if tt.wantSubstring == "" {
+				if tt.wantAbsent != "" {
+					return
+				}
+				assert.Empty(t, got)
+				return
+			}
+			assert.Contains(t, got, tt.wantSubstring)
+		})
+	}
+}
+
+// THE BODY of warnDependencyAssertionInert, which the AST wiring test cannot
+// reach: that one pins the CALL and its arguments, so every one of the three
+// guards inside could be deleted with the whole suite still green.
+//
+// Each row below is the failure a deleted guard produces:
+//   - "the knob was never asked for" dies when the AssertDependencies gate
+//     goes, and every user on --base-path / --disable-mapping / a legacy test
+//     set gets a brand-new warning per test set on upgrade.
+//   - "called once per test, warns once per test set" dies when the *warned
+//     latch goes, turning one line per test set into one per test.
+//   - "a healthy test set says nothing" dies when the `reason == ""` early
+//     return goes, warning on every well-formed suite.
+func TestWarnDependencyAssertionInert(t *testing.T) {
+	tests := []struct {
+		name                string
+		assertDeps          bool
+		instrument          bool
+		useMappingBased     bool
+		isMappingEnabled    bool
+		consumedFetchFailed bool
+		deferredStreaming   bool
+		noEligibleDeps      bool
+		calls               int
+		wantLogs            int
+		wantMsg             string
+		wantReason          string
+	}{
+		{
+			name:       "the knob was never asked for: an inert test set is not the user's problem",
+			assertDeps: false,
+			instrument: false, useMappingBased: true, isMappingEnabled: true,
+			calls: 1, wantLogs: 0,
+		},
+		{
+			name:       "knob on, precondition missing: one warning naming it",
+			assertDeps: true,
+			instrument: false, useMappingBased: true, isMappingEnabled: true,
+			calls: 1, wantLogs: 1,
+			wantMsg:    "is inert for this test set",
+			wantReason: "not instrument mode",
+		},
+		{
+			name:       "called once per test, warns once per test set",
+			assertDeps: true,
+			instrument: true, useMappingBased: false, isMappingEnabled: true,
+			calls: 2, wantLogs: 1,
+			wantMsg:    "is inert for this test set",
+			wantReason: "--update-test-mapping",
+		},
+		{
+			name:       "a healthy test set says nothing",
+			assertDeps: true,
+			instrument: true, useMappingBased: true, isMappingEnabled: true,
+			calls: 1, wantLogs: 0,
+		},
+		{
+			// M-1: the streaming half. The set is healthy, so the only thing
+			// that can produce this warning is the deferral itself.
+			name:       "knob on and streaming tests deferred: the scope-accurate warning",
+			assertDeps: true,
+			instrument: true, useMappingBased: true, isMappingEnabled: true,
+			deferredStreaming: true,
+			calls:             1, wantLogs: 1,
+			// NOT "no dependency can fail a test here": in a mixed test set
+			// the assertion ran normally for every non-streaming test, and
+			// the set-wide sentence would be a false alarm about those.
+			wantMsg:    "does not run for this test set's streaming test cases",
+			wantReason: "streaming (SSE/chunked) test cases",
+		},
+		{
+			name:       "knob OFF and streaming tests deferred: silence",
+			assertDeps: false,
+			instrument: true, useMappingBased: true, isMappingEnabled: true,
+			deferredStreaming: true,
+			calls:             1, wantLogs: 0,
+		},
+		{
+			// The Phase-2 latch is Phase-1's latch: a mixed test set that
+			// already warned must not warn again when the streaming pass
+			// starts.
+			name:       "the streaming pass shares the test set's latch",
+			assertDeps: true,
+			instrument: true, useMappingBased: true, isMappingEnabled: true,
+			deferredStreaming: true,
+			calls:             3, wantLogs: 1,
+			wantMsg: "does not run for this test set's streaming test cases",
+		},
+		{
+			// THE NEW REASON, through the warner. The scope sentence is its
+			// own: this is decided per test case from that test's mapped
+			// entries, so the blanket "inert for this test set" would overclaim
+			// on a mixed set — and the line must say NOT CHECKED, because the
+			// whole point is that an empty dep_result here is not a clean
+			// dependency verdict.
+			name:       "knob on and nothing eligible: the scope-accurate NOT-CHECKED warning",
+			assertDeps: true,
+			instrument: true, useMappingBased: true, isMappingEnabled: true,
+			noEligibleDeps: true,
+			calls:          1, wantLogs: 1,
+			wantMsg:    "no eligible dependency to assert",
+			wantReason: "session/connection-tier",
+		},
+		{
+			// Same latch discipline as every other reason: one line per test
+			// set, however many of its test cases have nothing eligible.
+			name:       "nothing eligible warns once per test set, not once per test",
+			assertDeps: true,
+			instrument: true, useMappingBased: true, isMappingEnabled: true,
+			noEligibleDeps: true,
+			calls:          4, wantLogs: 1,
+			wantMsg: "no eligible dependency to assert",
+		},
+		{
+			name:       "knob OFF and nothing eligible: silence",
+			assertDeps: false,
+			instrument: true, useMappingBased: true, isMappingEnabled: true,
+			noEligibleDeps: true,
+			calls:          1, wantLogs: 0,
+		},
+		{
+			// ONLY WHEN IT APPLIES: a test whose mapping has an eligible
+			// dependency must not drag the whole test set into a warning.
+			name:       "an armed test set with an eligible dependency says nothing",
+			assertDeps: true,
+			instrument: true, useMappingBased: true, isMappingEnabled: true,
+			noEligibleDeps: false,
+			calls:          3, wantLogs: 0,
+		},
+		{
+			// THE FETCH-FAILURE REASON, through the warner. Everything is
+			// armed and the mapping HAS eligible entries, so no other arm can
+			// fire — before this reason existed this row produced zero logs
+			// while the report carried dependencies_checked=false.
+			name:       "knob on and the consumed-mock fetch failed: the transport reason, not silence",
+			assertDeps: true,
+			instrument: true, useMappingBased: true, isMappingEnabled: true,
+			consumedFetchFailed: true,
+			calls:               1, wantLogs: 1,
+			wantMsg:    "could not read the consumed mocks",
+			wantReason: "consumed-mock fetch failed",
+		},
+		{
+			// Latch discipline, same as every other reason.
+			name:       "a failed consumed fetch warns once per test set",
+			assertDeps: true,
+			instrument: true, useMappingBased: true, isMappingEnabled: true,
+			consumedFetchFailed: true,
+			calls:               4, wantLogs: 1,
+			wantMsg: "could not read the consumed mocks",
+		},
+		{
+			name:       "knob OFF and the consumed fetch failed: silence",
+			assertDeps: false,
+			instrument: true, useMappingBased: true, isMappingEnabled: true,
+			consumedFetchFailed: true,
+			calls:               1, wantLogs: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			core, logs := observer.New(zapcore.WarnLevel)
+			r := &Replayer{
+				logger:     zap.New(core),
+				instrument: tt.instrument,
+				config:     &config.Config{Test: config.Test{AssertDependencies: tt.assertDeps}},
+			}
+			warned := false
+			for range tt.calls {
+				r.warnDependencyAssertionInert("test-set-0", tt.useMappingBased, tt.isMappingEnabled, tt.consumedFetchFailed, tt.deferredStreaming, tt.noEligibleDeps, &warned)
+			}
+
+			entries := logs.All()
+			if len(entries) != tt.wantLogs {
+				t.Fatalf("got %d warning(s) over %d call(s), want %d: %v", len(entries), tt.calls, tt.wantLogs, entries)
+			}
+			if tt.wantLogs == 0 {
+				if warned {
+					t.Errorf("the latch was set even though nothing was emitted")
+				}
+				return
+			}
+			if !strings.Contains(entries[0].Message, tt.wantMsg) {
+				t.Errorf("message = %q, want it to contain %q", entries[0].Message, tt.wantMsg)
+			}
+			fields := entries[0].ContextMap()
+			if fields["testset"] != "test-set-0" {
+				t.Errorf("testset = %v, want test-set-0", fields["testset"])
+			}
+			reason, _ := fields["reason"].(string)
+			if tt.wantReason != "" && !strings.Contains(reason, tt.wantReason) {
+				t.Errorf("reason = %q, want it to contain %q", reason, tt.wantReason)
+			}
+			if reason == "" {
+				t.Errorf("the warning names no reason, so it tells the user nothing to fix: %v", entries[0])
+			}
+		})
+	}
+}
+
+// A nil latch is a programming error, not a reason to panic mid-run.
+func TestWarnDependencyAssertionInert_NilLatchIsSafe(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	r := &Replayer{
+		logger:     zap.New(core),
+		instrument: false,
+		config:     &config.Config{Test: config.Test{AssertDependencies: true}},
+	}
+	r.warnDependencyAssertionInert("test-set-0", true, true, false, false, false, nil)
+	if logs.Len() != 0 {
+		t.Fatalf("expected no output for a nil latch, got %v", logs.All())
+	}
+}
+
+func TestVetoFlagName(t *testing.T) {
+	tests := []struct {
+		depAssertFail bool
+		strictFailure bool
+		want          string
+	}{
+		{want: ""},
+		{depAssertFail: true, want: "--assert-dependencies"},
+		{strictFailure: true, want: "--strict-failure"},
+		{depAssertFail: true, strictFailure: true, want: "--assert-dependencies, --strict-failure"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, vetoFlagName(tt.depAssertFail, tt.strictFailure))
+	}
+}
+
+// A healthy test set where individual tests simply make no outgoing calls must
+// NOT produce the inert warning: hasExpectedMocks is a per-TEST condition, and
+// warning on it would fire on every well-formed suite and train users to
+// ignore the level.
+func TestDependencyAssertionInertReason_IsTestSetScoped(t *testing.T) {
+	assert.Empty(t, dependencyAssertionInertReason(true, true, true, false, false, false),
+		"a test case with no mapped dependencies is normal, not a misconfiguration")
+}
+
+// The per-test-set summary is the only WARN-level surface for the default
+// (knob off) mode, so what it CLAIMS matters.
+//
+// It used to say "the response still matched, so they were not failed" over a
+// population that includes OBSOLETE tests, whose response did not match — that
+// is why they were demoted. And "never made" overstates the evidence: consumed
+// mocks are drained when the response comes back, so a call the app makes
+// after writing its response is attributed to the next test.
+func TestWarnUnexercisedDependencies_ClaimsOnlyWhatTheDataSupports(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	r := &Replayer{logger: zap.New(core)}
+
+	r.warnUnexercisedDependencies("test-set-0", map[string]models.TestStatus{
+		"tc-passed":   models.TestStatusPassed,
+		"tc-obsolete": models.TestStatusObsolete,
+	})
+
+	entries := logs.All()
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly one summary WARN, got %d: %v", len(entries), entries)
+	}
+	msg := entries[0].Message
+	for _, banned := range []string{"never made", "the response still matched, so"} {
+		if strings.Contains(msg, banned) {
+			t.Errorf("the summary claims %q, which the drained per-test window cannot support:\n%s", banned, msg)
+		}
+	}
+	if !strings.Contains(msg, "--assert-dependencies") {
+		t.Errorf("the summary must name the knob that turns this into a verdict:\n%s", msg)
+	}
+
+	fields := entries[0].ContextMap()
+	if fields["tests"] != int64(2) {
+		t.Errorf("tests = %v, want 2", fields["tests"])
+	}
+	// The PASSED subset is reported separately instead of the message
+	// asserting it over everything.
+	if fields["responseStillMatched"] != int64(1) {
+		t.Errorf("responseStillMatched = %v, want 1 (tc-obsolete's response did NOT match)", fields["responseStillMatched"])
+	}
+}
+
+// Nothing collected, nothing said.
+func TestWarnUnexercisedDependencies_SilentWhenEmpty(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	r := &Replayer{logger: zap.New(core)}
+	r.warnUnexercisedDependencies("test-set-0", nil)
+	if logs.Len() != 0 {
+		t.Fatalf("expected no output, got %v", logs.All())
+	}
+}
+
+// THE SIZE ASSERTION, measured over the REAL writer output rather than a
+// hand-built row set. Mirrors report.TestDependencyRowsDoNotBloatThe
+// PersistedReport for the other axis: that one pins the consumed side, this
+// one pins the missing side.
+//
+// Reports are written per test-set, re-read by `keploy report` and uploaded to
+// the fleet report store. Uncapped, 100 tests x 200 mapped dependencies all
+// unconsumed serialised to 5.4 MB against 115 KB for the same run before this
+// slice — 47x, with the verdict knob OFF and no opt-in — for a shape that is
+// not pathological but is the slice's own flagship scenario.
+func TestBuildDepResults_AllMissingStaysBounded(t *testing.T) {
+	const deps = 200
+	expected := make([]models.MockEntry, 0, deps)
+	for i := range deps {
+		expected = append(expected, models.MockEntry{Name: fmt.Sprintf("mock-%03d", i), Kind: "Postgres"})
+	}
+
+	capped, err := yaml.Marshal(buildDepResults(expected, nil, true, nil, nil, nil).Rows)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// What the same input serialises to with no cap at all, computed here so
+	// the assertion states a RATIO rather than a machine-dependent constant.
+	uncapped := make([]models.DepResult, 0, deps)
+	for i := range deps {
+		uncapped = append(uncapped, models.DepResult{
+			Name: models.DepRowName(i, models.DepTypePostgres, ""),
+			Type: models.DepTypePostgres,
+			Meta: missingMeta(),
+		})
+	}
+	full, err := yaml.Marshal(uncapped)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if len(capped) >= len(full)/3 {
+		t.Fatalf("the all-missing shape serialised to %d bytes against %d uncapped; "+
+			"the per-test cap (%d rows) is not bounding it",
+			len(capped), len(full), depMissingRowCap)
+	}
+	t.Logf("all-missing per test: %d bytes capped vs %d bytes uncapped (%d dependencies)",
+		len(capped), len(full), deps)
+}
+
+// THE TWO HALVES OF THE ELIGIBILITY QUESTION AGREE, FOR EVERY SHAPE.
+//
+// `dependencies_checked: false` is written by buildDepResults; the line telling
+// the user WHY is chosen from noEligibleDeps, which RunTestSet computes as
+// `len(expectedMocks) > 0 && len(filteredExpectedNames) == 0`. Two computations
+// of one question. If they disagree the user gets one of two silent regressions:
+// an unexplained not-checked report, or a warning about test sets whose
+// assertion actually ran.
+//
+// TestEligibilityFilterHasExactlyOneDefinition pins that they share a function.
+// This pins the property that sharing it BUYS — that the answers match — over
+// the shapes that actually occur, so the invariant survives someone deciding to
+// inline the filter again for performance.
+//
+// The direction that matters is the biconditional: `not checked` must mean
+// `nothing eligible` and vice versa, whenever `valid` holds.
+func TestNoEligibleDepsAndCheckedAreTheSameQuestion(t *testing.T) {
+	httpEntry := models.MockEntry{Name: "mock-2", Kind: "Http"}
+	pgEntry := models.MockEntry{Name: "mock-9", Kind: "Postgres"}
+	dnsEntry := models.MockEntry{Name: "mock-dns", Kind: "DNS"}
+
+	tests := []struct {
+		name     string
+		expected []models.MockEntry
+		consumed []models.MockState
+		reusable map[string]bool
+		kinds    map[string]models.Kind
+	}{
+		{
+			name:     "the ordinary recording: every entry session-tier",
+			expected: []models.MockEntry{httpEntry, pgEntry},
+			reusable: map[string]bool{"mock-2": true, "mock-9": true},
+		},
+		{
+			name:     "one eligible entry, unconsumed",
+			expected: []models.MockEntry{httpEntry, pgEntry},
+			reusable: map[string]bool{"mock-2": true},
+		},
+		{
+			name:     "one eligible entry, consumed",
+			expected: []models.MockEntry{httpEntry, pgEntry},
+			consumed: []models.MockState{consumed("mock-9", models.Kind("Postgres"))},
+			reusable: map[string]bool{"mock-2": true},
+		},
+		{
+			name:     "every entry eligible",
+			expected: []models.MockEntry{httpEntry, pgEntry},
+		},
+		{
+			name:     "only DNS is mapped",
+			expected: []models.MockEntry{dnsEntry},
+		},
+		{
+			name:     "DNS and a reusable entry together",
+			expected: []models.MockEntry{dnsEntry, httpEntry},
+			reusable: map[string]bool{"mock-2": true},
+		},
+		{
+			name:     "DNS resolved through the kind lookup rather than the entry",
+			expected: []models.MockEntry{{Name: "mock-dns2"}},
+			kinds:    map[string]models.Kind{"mock-dns2": models.DNS},
+		},
+		{
+			name:     "the recording maps nothing at all",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Exactly how RunTestSet derives its two values.
+			eligible := eligibleExpectedEntries(tt.expected, tt.kinds, tt.reusable)
+			filteredExpectedNames := make([]string, 0, len(eligible))
+			for _, m := range eligible {
+				filteredExpectedNames = append(filteredExpectedNames, m.Name)
+			}
+			noEligibleDeps := len(tt.expected) > 0 && len(filteredExpectedNames) == 0
+
+			dep := buildDepResults(tt.expected, tt.consumed, true, tt.reusable, tt.kinds, nil)
+
+			// The biconditional, stated over the state a user can observe.
+			// `valid` is true throughout, so the ONLY thing that can make the
+			// writer report not-checked is the eligibility filter — which is
+			// the same filter the warning is keyed off.
+			if noEligibleDeps && dep.Checked {
+				t.Fatalf("the warner says nothing was eligible but the writer persisted deps_checked=true "+
+					"(consumed=%d, rows=%v). The report then claims the assertion ran and found nothing "+
+					"missing, while the run separately warns that it had nothing to assert.",
+					dep.Consumed, dep.Rows)
+			}
+			if len(tt.expected) > 0 && !noEligibleDeps && !dep.Checked {
+				t.Fatalf("the writer reports NOT CHECKED for a test with %d eligible dependency/ies, but "+
+					"noEligibleDeps is false so no warning explains it. The user gets "+
+					"`dependencies_checked: false` with no reason given.", len(filteredExpectedNames))
+			}
+
+			// ...and the scalars stay consistent with the bit either way: a
+			// not-checked verdict must carry no rows and no count, or a
+			// consumer reading dep_result/deps_consumed without first reading
+			// the bit sees data that the bit says does not exist.
+			if !dep.Checked && (dep.Consumed != 0 || len(dep.Rows) != 0) {
+				t.Fatalf("a NOT-CHECKED verdict carries data: consumed=%d rows=%v", dep.Consumed, dep.Rows)
+			}
+		})
+	}
+}

--- a/pkg/service/replay/depresult_wiring_test.go
+++ b/pkg/service/replay/depresult_wiring_test.go
@@ -1,0 +1,992 @@
+package replay
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// RunTestSet is ~2000 lines long and no test executes it: standing up its
+// eight collaborator interfaces (TestDB, MockDB, MappingDB, ReportDB,
+// TestSetConfig, Telemetry, Instrumentation, TestHooks) plus the simulate loop
+// is a harness this slice does not justify. The consequence measured by a
+// reviewer is that the DepResult writer could be replaced with a discard and
+// the whole suite stayed green.
+//
+// The BEHAVIOUR of every extracted seam is table-tested above
+// (resolveTestOutcome, resolveTestStatus, attachDepResults, buildDepResults,
+// shouldEmitFailureLogs, recordUnexercised). What is still unpinned is the
+// WIRING: that RunTestSet actually calls them, with the arguments that make
+// them mean what the tests say they mean.
+//
+// So this pins the wiring by reading the source, at TWO levels of strictness,
+// because neither alone is right for every site:
+//
+//   - IDENTIFIER SETS (TestRunTestSetWiring below) for argument lists. An
+//     earlier version compared the printed expression everywhere and produced a
+//     false failure during review when a behaviour-preserving argument rewrite
+//     changed the text. Comparing identifier sets lets a semantically neutral
+//     refactor through, while dropping an argument, hardcoding one to a
+//     literal, or swapping in a different variable still fails.
+//   - VERBATIM PRINTED EXPRESSIONS (TestSafetyPredicatesArePinnedVerbatim,
+//     TestDepWriterGateIsPinnedVerbatim, TestOutcomeDrivesTheRunVerdict,
+//     TestMockLookupCarriesATarget) for the handful of sites where the
+//     STRUCTURE is the safety property. An identifier set cannot see an
+//     operator flip: rewriting the five-conjunct `depAssertionValid` as
+//     `... && hasExpectedMocks || instrumentConsumedFetchErr == nil` keeps every
+//     identifier, makes the predicate unconditionally true in --base-path runs,
+//     and left the whole package green.
+//
+// WHAT THIS APPROACH STILL CANNOT CATCH, stated so the next reviewer does not
+// have to re-derive it: a semantic wiring bug that keeps the same identifiers
+// and the same structure — passing a testCaseResult that is not the object
+// InsertTestCaseResult persists, or the rows not surviving into the report
+// file. The runtime proof for those is the e2e script in
+// .github/workflows/test_workflow_scripts/golang/mock_mismatch, which asserts
+// on the persisted report YAML, the process exit code and a per-test NDJSON
+// delta rather than on log greps. That split — behaviour of every extracted
+// seam in unit tests here, wiring by AST, end-to-end truth in the e2e — is the
+// deliberate coverage story for this slice.
+func runTestSetSource(t *testing.T) (*token.FileSet, *ast.FuncDecl) {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "replay.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse replay.go: %v", err)
+	}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "RunTestSet" || fn.Recv == nil {
+			continue
+		}
+		return fset, fn
+	}
+	t.Fatal("RunTestSet not found in replay.go")
+	return nil, nil
+}
+
+// calleeName renders a call's callee as `foo` or `recv.foo`.
+func calleeName(call *ast.CallExpr) string {
+	switch fun := call.Fun.(type) {
+	case *ast.Ident:
+		return fun.Name
+	case *ast.SelectorExpr:
+		if recv, ok := fun.X.(*ast.Ident); ok {
+			return recv.Name + "." + fun.Sel.Name
+		}
+		return fun.Sel.Name
+	}
+	return ""
+}
+
+// exprIdents collects every identifier appearing anywhere in the expressions,
+// including the field names of selector chains (`r.config.Test.StrictFailure`
+// contributes r, config, Test and StrictFailure). A literal contributes
+// nothing, which is what makes `depAssertFail -> false` a failure.
+func exprIdents(exprs []ast.Expr) map[string]bool {
+	out := map[string]bool{}
+	for _, e := range exprs {
+		ast.Inspect(e, func(n ast.Node) bool {
+			if ident, ok := n.(*ast.Ident); ok {
+				out[ident.Name] = true
+			}
+			return true
+		})
+	}
+	return out
+}
+
+// callArgIdents returns, for every call to `name` in fn, the identifier set of
+// its arguments.
+func callArgIdents(fn *ast.FuncDecl, name string) []map[string]bool {
+	var out []map[string]bool
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || calleeName(call) != name {
+			return true
+		}
+		out = append(out, exprIdents(call.Args))
+		return true
+	})
+	return out
+}
+
+// assignRHSIdents returns, for every `name := rhs` / `name = rhs` in fn, the
+// identifier set of the right-hand side.
+func assignRHSIdents(fn *ast.FuncDecl, name string) []map[string]bool {
+	var out []map[string]bool
+	ast.Inspect(fn, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok || len(assign.Lhs) == 0 {
+			return true
+		}
+		ident, ok := assign.Lhs[0].(*ast.Ident)
+		if !ok || ident.Name != name {
+			return true
+		}
+		out = append(out, exprIdents(assign.Rhs))
+		return true
+	})
+	return out
+}
+
+// printNode renders a node back to source on one line, so a test can pin the
+// STRUCTURE of an expression and not just the identifiers in it.
+func printNode(t *testing.T, fset *token.FileSet, n ast.Node) string {
+	t.Helper()
+	var sb strings.Builder
+	if err := printer.Fprint(&sb, fset, n); err != nil {
+		t.Fatalf("print node: %v", err)
+	}
+	return strings.Join(strings.Fields(sb.String()), " ")
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestRunTestSetWiring(t *testing.T) {
+	_, fn := runTestSetSource(t)
+
+	tests := []struct {
+		name string
+		// Exactly one of these two is used.
+		call       string
+		assignment string
+		want       []string
+		why        string
+	}{
+		{
+			name:       "the dependency-assertion predicate still requires instrument mode",
+			assignment: "depAssertionValid",
+			want:       []string{"instrument", "useMappingBased", "isMappingEnabled", "hasExpectedMocks", "instrumentConsumedFetchErr"},
+			why: "Dropping r.instrument would emit dependency rows in --base-path / remote-agent runs, " +
+				"where the per-test mock mapping is never armed on the agent and 'which mock this request " +
+				"consumed' is decided across all tests. Every row would be a false MISSING.",
+		},
+		{
+			name:       "mockSetMismatch is computed under that same predicate",
+			assignment: "mockSetMismatch",
+			want:       []string{"isMockSubset", "filteredMockNames", "filteredExpectedNames"},
+			why:        "The verdict signal and the rows that explain it must come from identical inputs.",
+		},
+		{
+			name:       "the response diff is un-suppressed through the tested predicate",
+			assignment: "emitFailureLogs",
+			want:       []string{"shouldEmitFailureLogs", "mockSetMismatch", "AssertDependencies"},
+			why: "Reverting this to `!mockSetMismatch` hands the user a test that --assert-dependencies " +
+				"just marked FAILED with its response diff suppressed as 're-record noise'.",
+		},
+		{
+			name:       "the verdict goes through the single seam, carrying the raw response result and all three knobs",
+			assignment: "outcome",
+			want: []string{"resolveTestOutcome", "testPass", "mockSetMismatch",
+				"SchemaNoiseStrict", "AssertDependencies", "StrictFailure"},
+			why: "resolveTestOutcome is where --assert-dependencies turns a PASSED-and-green test into a " +
+				"FAILED-and-red one. Passing anything other than the raw testPass and the three knobs " +
+				"silently removes a promotion.",
+		},
+		{
+			name:       "the resolved status is what gets persisted",
+			assignment: "testStatus",
+			want:       []string{"outcome", "Status"},
+			why:        "Recomputing the status inline would let it drift from the verdict the seam decided.",
+		},
+		{
+			name:       "the rows are built from the mapped expectation and the per-test consumed set",
+			assignment: "depAssert",
+			want: []string{"buildDepResults", "expectedMocks", "perTestConsumed", "depAssertionValid",
+				"perTestConsumedKnown", "reusableMockNames", "mockKindByName", "mockLookup"},
+			why: "This is the FIRST WRITER of models.Result.DepResult (design v2 §2, §7 slice 4). " +
+				"Deleting it makes the whole slice a no-op.",
+		},
+		{
+			name: "the rows are attached to the persisted result",
+			call: "attachDepResults",
+			want: []string{"testCaseResult", "testStatus", "depAssert", "AssertDependencies"},
+			why: "Without this call the rows are computed and thrown away: nothing reaches the report, " +
+				"JUnit, --format json, or the DEPENDENCY_MISSING category.",
+		},
+		{
+			name: "the per-test-set set the summary reads is actually filled",
+			call: "recordUnexercised",
+			want: []string{"depMissingTests", "testCase", "Name", "testStatus", "depLevel"},
+			why: "The summary Warn is the only WARN-level surface for the knob-off case. Never inserting " +
+				"into the map it reads makes that summary a silent no-op even though the call to it survives.",
+		},
+		{
+			name: "the inert-knob warning is still emitted, and is told whether anything was eligible",
+			call: "r.warnDependencyAssertionInert",
+			want: []string{"testSetID", "useMappingBased", "isMappingEnabled", "instrumentConsumedFetchErr", "noEligibleDeps", "depAssertionInertWarned"},
+			why: "Without it, --assert-dependencies against an unmapped or mapping-disabled test set is a " +
+				"green run for an assertion that never executed. noEligibleDeps is the fifth reason and the " +
+				"one an ordinary recording hits: every mapped dependency filtered out as session/connection " +
+				"tier, so the assertion reports NOT CHECKED and the user is told why. Dropping the argument " +
+				"leaves those runs with a report full of `dependencies_checked: false` and no explanation. " +
+				"instrumentConsumedFetchErr is the fourth reason: when the per-test consumed fetch fails the " +
+				"assertion cannot run either, and dropping it makes the run either say nothing at all or " +
+				"blame the recording's tier for a transport error.",
+		},
+		{
+			name: "the per-test-set summary of unexercised dependencies is still emitted",
+			call: "r.warnUnexercisedDependencies",
+			want: []string{"testSetID", "depMissingTests"},
+			why:  "It is the only WARN-level surface for the knob-off case; the per-test line is Debug.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []map[string]bool
+			if tt.assignment != "" {
+				got = assignRHSIdents(fn, tt.assignment)
+			} else {
+				got = callArgIdents(fn, tt.call)
+			}
+
+			var seen []string
+			for _, idents := range got {
+				missing := make([]string, 0, len(tt.want))
+				for _, w := range tt.want {
+					if !idents[w] {
+						missing = append(missing, w)
+					}
+				}
+				if len(missing) == 0 {
+					return
+				}
+				seen = append(seen, strings.Join(sortedKeys(idents), " "))
+			}
+			target := tt.call
+			if tt.assignment != "" {
+				target = tt.assignment + " := ..."
+			}
+			t.Fatalf("RunTestSet's %s no longer passes all of %v.\nfound these identifier sets instead:\n\t%s\n\nWHY THIS MATTERS: %s",
+				target, tt.want, strings.Join(seen, "\n\t"), tt.why)
+		})
+	}
+}
+
+// The deferred streaming path must NOT write DepResult: its expected-mock list
+// is an un-tier-filtered slice built before the run, so reusable/startup mocks
+// would show up as per-test dependencies and go "missing" at random.
+func TestStreamingPathDoesNotWriteDepResults(t *testing.T) {
+	_, fn := runTestSetSource(t)
+	if calls := callArgIdents(fn, "buildDepResults"); len(calls) != 1 {
+		t.Fatalf("expected exactly one buildDepResults call in RunTestSet, found %d", len(calls))
+	}
+	if calls := callArgIdents(fn, "attachDepResults"); len(calls) != 1 {
+		t.Fatalf("expected exactly one attachDepResults call in RunTestSet, found %d", len(calls))
+	}
+}
+
+// ancestorsOf returns the node chain from fn down to the innermost node whose
+// position range contains pos, outermost first.
+func ancestorsOf(fn *ast.FuncDecl, pos token.Pos) []ast.Node {
+	var chain []ast.Node
+	ast.Inspect(fn, func(n ast.Node) bool {
+		if n == nil {
+			return false
+		}
+		if pos < n.Pos() || pos >= n.End() {
+			return false
+		}
+		chain = append(chain, n)
+		return true
+	})
+	return chain
+}
+
+// posOfCall returns the position of the single call to name inside fn.
+func posOfCall(t *testing.T, fn *ast.FuncDecl, name string) token.Pos {
+	t.Helper()
+	var found []token.Pos
+	ast.Inspect(fn, func(n ast.Node) bool {
+		if call, ok := n.(*ast.CallExpr); ok && calleeName(call) == name {
+			found = append(found, call.Pos())
+		}
+		return true
+	})
+	if len(found) != 1 {
+		t.Fatalf("expected exactly one call to %s in RunTestSet, found %d", name, len(found))
+	}
+	return found[0]
+}
+
+// posOfAssign returns the position of the single `name = rhs` / `name := rhs`
+// statement inside fn whose right-hand side mentions rhsIdent. rhsIdent
+// disambiguates variables the 3000-line function assigns from more than one
+// code path — testStatus is also set by the deferred streaming path, which
+// deliberately writes no DepResult at all.
+func posOfAssign(t *testing.T, fn *ast.FuncDecl, name, rhsIdent string) token.Pos {
+	t.Helper()
+	var found []token.Pos
+	ast.Inspect(fn, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok || len(assign.Lhs) == 0 {
+			return true
+		}
+		ident, ok := assign.Lhs[0].(*ast.Ident)
+		if !ok || ident.Name != name {
+			return true
+		}
+		if rhsIdent != "" && !exprIdents(assign.Rhs)[rhsIdent] {
+			return true
+		}
+		found = append(found, assign.Pos())
+		return true
+	})
+	if len(found) != 1 {
+		t.Fatalf("expected exactly one assignment to %s (rhs mentioning %q) in RunTestSet, found %d",
+			name, rhsIdent, len(found))
+	}
+	return found[0]
+}
+
+// TestRunTestSetWiring above pins WHAT each call is passed. It does not pin
+// that the calls RUN: a reviewer wrapped the whole writer block in
+// `if depAssertionValid && false { ... }`, keeping every call and every
+// argument byte-identical, and the package stayed green. Nothing in the repo
+// executes RunTestSet, so reachability has to be read out of the source too.
+//
+// This pins the ENCLOSING CONDITIONS as an exact list. Adding any guard around
+// the writer — a `&& false`, a new flag, a duplicate of an existing check —
+// changes the list and fails here with the reason attached. Removing one of
+// the two nil guards fails too, which is deliberate: they are what keep the
+// writer from dereferencing a nil result.
+func TestDepWriterIsReachable(t *testing.T) {
+	_, fn := runTestSetSource(t)
+	pos := posOfAssign(t, fn, "depAssert", "buildDepResults")
+
+	var conds []string
+	for _, n := range ancestorsOf(fn, pos) {
+		ifStmt, ok := n.(*ast.IfStmt)
+		if !ok {
+			continue
+		}
+		// An ancestor if whose ELSE branch contains the writer is a different
+		// (and much stranger) shape; record it distinctly rather than
+		// pretending the condition guards the writer.
+		if ifStmt.Else != nil && pos >= ifStmt.Else.Pos() && pos < ifStmt.Else.End() {
+			conds = append(conds, "else:"+strings.Join(sortedKeys(exprIdents([]ast.Expr{ifStmt.Cond})), " "))
+			continue
+		}
+		conds = append(conds, strings.Join(sortedKeys(exprIdents([]ast.Expr{ifStmt.Cond})), " "))
+	}
+
+	want := []string{"nil testResult", "nil testCaseResult"}
+	if strings.Join(conds, " | ") != strings.Join(want, " | ") {
+		t.Fatalf("the DepResult writer's enclosing conditions are %v, want %v.\n\n"+
+			"WHY THIS MATTERS: the wiring test above compares the arguments each call is passed, "+
+			"not whether the block runs. Wrapping the block in `if depAssertionValid && false` "+
+			"kept every call and argument identical and left the whole package green. The only "+
+			"conditions allowed to guard the writer are the two nil checks that protect the "+
+			"result pointers; gating it on anything else (including the assertion predicate, "+
+			"which buildDepResults already takes as an argument) makes the rows conditional on "+
+			"something no test can see.", conds, want)
+	}
+}
+
+// The DEPENDENCY_MISSING label attachDepResults applies is keyed off the
+// PERSISTED status, so the writer has to run after the verdict is folded into
+// testStatus. Reordering the block above `testStatus = outcome.Status` would
+// label the test from a stale status — an OBSOLETE test that the knob just
+// promoted to FAILED would be labelled from the pre-promotion value — while
+// leaving every argument and every enclosing condition untouched.
+func TestDepWriterRunsAfterTheStatusIsResolved(t *testing.T) {
+	_, fn := runTestSetSource(t)
+	statusAt := posOfAssign(t, fn, "testStatus", "outcome")
+
+	// Every reader of the resolved status has to come after the assignment.
+	// Checking only attachDepResults is not enough: moving the assignment DOWN
+	// to just above the writer keeps that one ordering intact while feeding
+	// the per-status counters (currentSuccess / currentObsolete /
+	// currentFailures) and the persisted testStatus a stale value.
+	readers := map[string]token.Pos{
+		"attachDepResults(...)":   posOfCall(t, fn, "attachDepResults"),
+		"switch testStatus {...}": posOfStatusSwitch(t, fn),
+	}
+	for what, at := range readers {
+		if statusAt >= at {
+			t.Fatalf("`testStatus = outcome.Status` (pos %d) does not precede %s (pos %d).\n\n"+
+				"WHY THIS MATTERS: attachDepResults applies the DEPENDENCY_MISSING label from the "+
+				"PERSISTED status, and the switch below drives the per-status counters. A test the "+
+				"--assert-dependencies promotion just moved from OBSOLETE to FAILED would be "+
+				"labelled and counted from its pre-promotion value, with every call argument and "+
+				"every enclosing condition left untouched.", statusAt, what, at)
+		}
+	}
+}
+
+// posOfStatusSwitch returns the position of `switch testStatus { ... }`.
+func posOfStatusSwitch(t *testing.T, fn *ast.FuncDecl) token.Pos {
+	t.Helper()
+	var found []token.Pos
+	ast.Inspect(fn, func(n ast.Node) bool {
+		sw, ok := n.(*ast.SwitchStmt)
+		if !ok {
+			return true
+		}
+		if ident, ok := sw.Tag.(*ast.Ident); ok && ident.Name == "testStatus" {
+			found = append(found, sw.Pos())
+		}
+		return true
+	})
+	if len(found) != 1 {
+		t.Fatalf("expected exactly one `switch testStatus` in RunTestSet, found %d", len(found))
+	}
+	return found[0]
+}
+
+// The third invisible mutation: an unconditional `continue` / `return` /
+// `break` inserted above the writer in its own block leaves the arguments, the
+// enclosing conditions and the ordering all intact.
+func TestNothingUnconditionallySkipsTheDepWriter(t *testing.T) {
+	_, fn := runTestSetSource(t)
+	pos := posOfAssign(t, fn, "depAssert", "buildDepResults")
+
+	chain := ancestorsOf(fn, pos)
+	var block *ast.BlockStmt
+	for _, n := range chain {
+		if b, ok := n.(*ast.BlockStmt); ok {
+			block = b
+		}
+	}
+	if block == nil {
+		t.Fatal("could not find the block statement holding the DepResult writer")
+	}
+	for _, stmt := range block.List {
+		if stmt.Pos() >= pos {
+			break
+		}
+		switch s := stmt.(type) {
+		case *ast.BranchStmt:
+			t.Fatalf("an unconditional %s at position %d precedes the DepResult writer in its own block; "+
+				"the writer is unreachable", s.Tok, s.Pos())
+		case *ast.ReturnStmt:
+			t.Fatalf("an unconditional return at position %d precedes the DepResult writer in its own block; "+
+				"the writer is unreachable", s.Pos())
+		}
+	}
+}
+
+// TestRunTestSetWiring compares identifier SETS, which is deliberately tolerant
+// of a neutral argument rewrite — and therefore blind to a rewrite of the
+// BOOLEAN ALGEBRA. Two mutations proved it:
+//
+//	depAssertionValid := ... && hasExpectedMocks || instrumentConsumedFetchErr == nil
+//	buildDepResults(..., depAssertionValid || perTestConsumedKnown, ...)
+//
+// Both kept every identifier and left the whole package green. The first is the
+// worse one: && binds tighter than ||, so the predicate reads
+// (A && B && C && D) || (err == nil), and in --base-path / remote-agent runs
+// instrumentConsumedFetchErr is always nil — the predicate becomes
+// unconditionally TRUE, mockSetMismatch is computed against a mapping that was
+// never armed, healthy tests are demoted to OBSOLETE and every dependency is
+// reported MISSING.
+//
+// A five-conjunct safety predicate is worth pinning verbatim.
+func TestSafetyPredicatesArePinnedVerbatim(t *testing.T) {
+	fset, fn := runTestSetSource(t)
+
+	tests := []struct {
+		name       string
+		assignment string
+		want       string
+		why        string
+	}{
+		{
+			name:       "the dependency-assertion predicate is a pure conjunction",
+			assignment: "depAssertionValid",
+			want: "r.instrument && useMappingBased && isMappingEnabled && hasExpectedMocks && " +
+				"instrumentConsumedFetchErr == nil",
+			why: "Every conjunct removes a mode in which 'which mock this request consumed' is not " +
+				"attributable to one test. Turning any && into || makes the predicate true in modes " +
+				"where the per-test mapping was never armed: healthy tests get demoted to OBSOLETE " +
+				"and every dependency is reported MISSING.",
+		},
+		{
+			name:       "the resolved verdict is folded back into testPass, not recomputed",
+			assignment: "testPass",
+			want:       "outcome.Status == models.TestStatusPassed",
+			why: "This is how the --assert-dependencies promotion reaches the 'result' log line and " +
+				"every later reader. Recomputing it from the raw response result silently drops the " +
+				"promotion.",
+		},
+		{
+			name:       "the no-eligible-dependency signal means EVERY mapped entry was filtered out",
+			assignment: "noEligibleDeps",
+			want:       "len(expectedMocks) > 0 && len(filteredExpectedNames) == 0",
+			why: "It must be computed from the same two lists the assertion uses, or the warning claims " +
+				"something buildDepResults disagrees with. Turning the && into || fires it on every test " +
+				"that maps a dependency (training users to ignore the line); dropping the len(expectedMocks) " +
+				"conjunct fires it on every test that makes no outgoing calls at all, which is normal.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []string
+			ast.Inspect(fn, func(n ast.Node) bool {
+				assign, ok := n.(*ast.AssignStmt)
+				if !ok || len(assign.Lhs) != 1 || len(assign.Rhs) != 1 {
+					return true
+				}
+				ident, ok := assign.Lhs[0].(*ast.Ident)
+				if !ok || ident.Name != tt.assignment {
+					return true
+				}
+				got = append(got, printNode(t, fset, assign.Rhs[0]))
+				return true
+			})
+			for _, g := range got {
+				if g == tt.want {
+					return
+				}
+			}
+			t.Fatalf("no assignment to %s has the pinned right-hand side.\nfound: %v\nwant:  %q\n\n"+
+				"WHY THIS MATTERS: %s\n\nIf the rewrite is deliberate, update this literal — that is "+
+				"the review step an identifier-set comparison cannot force.",
+				tt.assignment, got, tt.want, tt.why)
+		})
+	}
+}
+
+// The `valid` argument buildDepResults takes is the same class of predicate and
+// is pinned the same way: `depAssertionValid || perTestConsumedKnown` keeps
+// both identifiers and inverts the meaning.
+func TestDepWriterGateIsPinnedVerbatim(t *testing.T) {
+	fset, fn := runTestSetSource(t)
+
+	const want = "depAssertionValid && perTestConsumedKnown"
+	var got []string
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || calleeName(call) != "buildDepResults" {
+			return true
+		}
+		// buildDepResults(expected, consumed, valid, reusable, kinds, lookup)
+		if len(call.Args) < 3 {
+			t.Fatalf("buildDepResults is called with %d arguments", len(call.Args))
+		}
+		got = append(got, printNode(t, fset, call.Args[2]))
+		return true
+	})
+
+	for _, g := range got {
+		if g == want {
+			return
+		}
+	}
+	t.Fatalf("buildDepResults' `valid` argument is %v, want %q.\n\n"+
+		"WHY THIS MATTERS: this gate must be a CONJUNCTION. Turning it into `||` makes the writer "+
+		"emit rows in modes where the per-test mock mapping was never armed on the agent, so every "+
+		"dependency reads as MISSING for a healthy run.", got, want)
+}
+
+// posOfIf returns the single *ast.IfStmt inside fn whose condition prints
+// exactly cond.
+func posOfIf(t *testing.T, fset *token.FileSet, fn *ast.FuncDecl, cond string) *ast.IfStmt {
+	t.Helper()
+	var found []*ast.IfStmt
+	ast.Inspect(fn, func(n ast.Node) bool {
+		ifStmt, ok := n.(*ast.IfStmt)
+		if !ok {
+			return true
+		}
+		if printNode(t, fset, ifStmt.Cond) == cond {
+			found = append(found, ifStmt)
+		}
+		return true
+	})
+	if len(found) != 1 {
+		t.Fatalf("expected exactly one `if %s` in RunTestSet, found %d", cond, len(found))
+	}
+	return found[0]
+}
+
+// THE LAST MUTATION-VACUOUS LINE IN THE CHAIN. Replacing
+// `if outcome.FailsTestSet {` with `if false && outcome.FailsTestSet {` left the
+// whole package green: --assert-dependencies still wrote FAILED into the report
+// but the run exited 0 — precisely the false-green the slice exists to close.
+//
+// That single line is the entire path from the slice's headline promotion to
+// the user-visible outcome: RunTestSet returns testSetStatus -> testRunResult ->
+// `utils.ErrCode = 1` -> the process exit code. TestRunTestSetWiring pins ten
+// other seams and omitted this one.
+//
+// The second row is the same class with a smaller blast radius: neutering the
+// RecordMismatch guard silently empties the end-of-run mock-mismatch report.
+func TestOutcomeDrivesTheRunVerdict(t *testing.T) {
+	fset, fn := runTestSetSource(t)
+
+	tests := []struct {
+		name string
+		cond string
+		want string
+		why  string
+	}{
+		{
+			name: "FailsTestSet is what makes the run red and the exit code non-zero",
+			cond: "outcome.FailsTestSet",
+			want: "{ testSetStatus = models.TestSetStatusFailed }",
+			why: "RunTestSet returns testSetStatus, testRunResult turns it into utils.ErrCode = 1, " +
+				"and that is the process exit code. Without this assignment --assert-dependencies " +
+				"writes FAILED into the report and the run still exits 0 — the exact false-green " +
+				"this slice exists to close.",
+		},
+		{
+			name: "RecordMismatch is what fills the end-of-run mock-mismatch report",
+			cond: "outcome.RecordMismatch",
+			want: "{ r.mockMismatchFailures.AddFailure(testSetID, testCase.Name, filteredExpectedNames, filteredMockNames) }",
+			why: "It is the only per-test-set record of which expected mocks diverged; an empty " +
+				"store renders an end-of-run report that says nothing diverged.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ifStmt := posOfIf(t, fset, fn, tt.cond)
+			if ifStmt.Else != nil {
+				t.Fatalf("`if %s` grew an else branch; this guard is meant to be a plain one-way gate", tt.cond)
+			}
+			if got := printNode(t, fset, ifStmt.Body); got != tt.want {
+				t.Fatalf("`if %s` now does %s, want %s.\n\nWHY THIS MATTERS: %s",
+					tt.cond, got, tt.want, tt.why)
+			}
+		})
+	}
+}
+
+// The mock display lookup is what gives a dependency row a human-meaningful
+// target. mockTargetFromSpec is thoroughly table-tested, but its SINGLE
+// production call site was not pinned: replacing `target: mockTargetFromSpec(mock)`
+// with `target: ""` left the package green, and every dependency row would
+// degrade to `deps[0] postgres (presence)` — five calls to one service
+// distinguishable only by an unstable index, which is the finding this lookup
+// field exists to fix.
+func TestMockLookupCarriesATarget(t *testing.T) {
+	fset, fn := runTestSetSource(t)
+
+	var found []string
+	ast.Inspect(fn, func(n ast.Node) bool {
+		lit, ok := n.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		ident, ok := lit.Type.(*ast.Ident)
+		if !ok || ident.Name != "mockDisplayInfo" {
+			return true
+		}
+		found = append(found, printNode(t, fset, lit))
+		return true
+	})
+
+	if len(found) != 1 {
+		t.Fatalf("expected exactly one mockDisplayInfo literal in RunTestSet, found %d: %v", len(found), found)
+	}
+	const want = "mockDisplayInfo{ summary: models.MockSummaryFromSpec(mock), protocol: string(mock.Kind), target: mockTargetFromSpec(mock), }"
+	if found[0] != want {
+		t.Fatalf("the mock display lookup is now %s, want %s.\n\n"+
+			"WHY THIS MATTERS: `target` is the only human-meaningful destination a dependency row "+
+			"can carry — neither models.MockEntry (the mapping side) nor models.MockState (the "+
+			"consumed side) records one. Dropping it collapses five outgoing calls to the same "+
+			"service into rows that differ only by index.", found[0], want)
+	}
+}
+
+// THE ELIGIBILITY HALF OF THE INERT-KNOB WARNING.
+//
+// buildDepResults now reports NOT-CHECKED when the recording maps dependencies
+// to a test and every one of them is filtered out (DNS, or reusable
+// session/connection tier — which is what models.Mock.DeriveLifetime makes of
+// untagged HTTP/Postgres/MySQL egress, so it is the ORDINARY case). That is the
+// honest answer, but on its own it is an unexplained `dependencies_checked:
+// false` on every test of the run, indistinguishable from a --base-path run.
+//
+// The explanation is the fifth inert reason, and it can only be produced if the
+// main replay loop tells the warner what it observed. TestRunTestSetWiring pins
+// that the argument is passed; this pins that the MAIN LOOP is the caller that
+// passes a computed value and that the streaming pass — which has no filtered
+// expectation list — passes a literal false rather than something that would
+// make it claim a tier problem it never measured.
+func TestMainLoopReportsEligibilityToTheWarner(t *testing.T) {
+	fset, fn := runTestSetSource(t)
+
+	const warner = "r.warnDependencyAssertionInert"
+	// (testSetID, useMappingBased, isMappingEnabled, consumedFetchFailed,
+	//  deferredStreaming, noEligibleDeps, warned)
+	const eligibilityArg = 5
+
+	var args []string
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || calleeName(call) != warner {
+			return true
+		}
+		if len(call.Args) <= eligibilityArg {
+			t.Fatalf("%s takes %d argument(s); noEligibleDeps is argument %d", warner, len(call.Args), eligibilityArg+1)
+		}
+		args = append(args, printNode(t, fset, call.Args[eligibilityArg]))
+		return true
+	})
+
+	sort.Strings(args)
+	want := []string{"false", "noEligibleDeps"}
+	if strings.Join(args, " | ") != strings.Join(want, " | ") {
+		t.Fatalf("%s is passed noEligibleDeps=%v across its call sites, want %v.\n\n"+
+			"WHY THIS MATTERS: exactly one call site (the main replay loop) can observe that every mapped "+
+			"dependency of a test was filtered out; passing a literal false there deletes the only "+
+			"explanation the user gets for a run where every test reports dependencies_checked=false. "+
+			"The Phase-2 streaming pass has no filtered expectation list, so passing anything but false "+
+			"there makes it claim a tier problem it never measured.", warner, args, want)
+	}
+}
+
+// M-1: THE STREAMING HALF OF THE INERT-KNOB WARNING.
+//
+// RunTestSet splits SSE/chunked test cases out of the main replay loop and
+// replays them in a Phase-2 pass that deliberately writes no DepResult and
+// never calls resolveTestOutcome, so --assert-dependencies cannot promote
+// anything there. The warning that says so lives in that pass and nowhere
+// else: TestRunTestSetWiring's "the inert-knob warning is still emitted" row
+// is satisfied by the Phase-1 call alone, so deleting the Phase-2 one restores
+// exactly the silent green this slice exists to close — a CI run that points
+// --assert-dependencies at a set of streaming tests, gets no dependency
+// assertion at all, and exits 0.
+//
+// The BEHAVIOUR of the warner (scope-accurate message, one line per test set,
+// silence when the knob is off) is table-tested in
+// TestWarnDependencyAssertionInert. This pins that the streaming pass reaches
+// it, and reaches it with deferredStreaming set — passing a bare `false` there
+// would type-check, keep every identifier, and warn about nothing.
+func TestStreamingPassWarnsTheAssertionDidNotRun(t *testing.T) {
+	fset, fn := runTestSetSource(t)
+
+	const warner = "r.warnDependencyAssertionInert"
+	// deferredStreaming is the 5th parameter: (testSetID, useMappingBased,
+	// isMappingEnabled, consumedFetchFailed, deferredStreaming, noEligibleDeps,
+	// warned).
+	const streamingArg = 4
+
+	calls := callArgIdents(fn, warner)
+	if len(calls) != 2 {
+		t.Fatalf("RunTestSet calls %s %d time(s), want 2 (the main replay loop and the deferred streaming pass).\n\n"+
+			"WHY THIS MATTERS: the streaming pass runs no dependency assertion at all. Without its own "+
+			"call, --assert-dependencies over a set of SSE/chunked tests is silently inert and exits 0.",
+			warner, len(calls))
+	}
+
+	// The Phase-2 block: `if ... len(streamingTests) > 0 { for ... range streamingTests { ... } }`.
+	var inStreamingBlock []*ast.CallExpr
+	ast.Inspect(fn, func(n ast.Node) bool {
+		ifStmt, ok := n.(*ast.IfStmt)
+		if !ok || ifStmt.Cond == nil || !exprIdents([]ast.Expr{ifStmt.Cond})["streamingTests"] {
+			return true
+		}
+		rangesOverStreamingTests := false
+		ast.Inspect(ifStmt.Body, func(m ast.Node) bool {
+			rng, ok := m.(*ast.RangeStmt)
+			if ok && exprIdents([]ast.Expr{rng.X})["streamingTests"] {
+				rangesOverStreamingTests = true
+			}
+			return true
+		})
+		if !rangesOverStreamingTests {
+			return true
+		}
+		ast.Inspect(ifStmt.Body, func(m ast.Node) bool {
+			if call, ok := m.(*ast.CallExpr); ok && calleeName(call) == warner {
+				inStreamingBlock = append(inStreamingBlock, call)
+			}
+			return true
+		})
+		return true
+	})
+
+	if len(inStreamingBlock) != 1 {
+		t.Fatalf("the deferred-streaming block contains %d call(s) to %s, want exactly 1.\n\n"+
+			"WHY THIS MATTERS: cli/provider/cmd.go's --assert-dependencies help promises one warning per "+
+			"test set whenever the assertion cannot run. A streaming test set with no warning makes that "+
+			"promise false and hands CI a green run for an assertion that never executed.",
+			len(inStreamingBlock), warner)
+	}
+
+	call := inStreamingBlock[0]
+	if len(call.Args) <= streamingArg {
+		t.Fatalf("%s in the streaming block takes %d argument(s); deferredStreaming is argument %d",
+			warner, len(call.Args), streamingArg+1)
+	}
+	if got := printNode(t, fset, call.Args[streamingArg]); got != "true" {
+		t.Fatalf("the streaming pass passes deferredStreaming=%s, want true.\n\n"+
+			"WHY THIS MATTERS: reaching that block means len(streamingTests) > 0. Anything but a "+
+			"literal true makes the call reachable but inert — dependencyAssertionInertReason returns "+
+			"\"\" for a healthy test set, so the warning silently never fires.", got)
+	}
+
+	// The other half: the main replay loop only ever sees the non-streaming
+	// bucket, so IT must not claim a deferral. Passing len(streamingTests) > 0
+	// there would fire the streaming warning before a streaming test was even
+	// reached and, via the shared latch, suppress a real precondition failure.
+	var mainLoopArg string
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || calleeName(call) != warner || call == inStreamingBlock[0] || len(call.Args) <= streamingArg {
+			return true
+		}
+		mainLoopArg = printNode(t, fset, call.Args[streamingArg])
+		return true
+	})
+	if mainLoopArg != "false" {
+		t.Fatalf("the main replay loop passes deferredStreaming=%s, want false.\n\n"+
+			"WHY THIS MATTERS: that loop only ever sees the non-streaming bucket. Claiming a deferral "+
+			"there warns about streaming before any streaming test runs and, because both call sites "+
+			"share one latch, swallows the set-wide precondition warning that should have been emitted.",
+			mainLoopArg)
+	}
+}
+
+// THE FETCH-FAILURE HALF OF THE INERT-KNOB WARNING.
+//
+// dependencyAssertionInertReason's fourth arm reports that the per-test
+// consumed-mock fetch failed. Only the main replay loop knows that — it is the
+// function that performs the fetch and stores instrumentConsumedFetchErr — so
+// the reason can only ever fire if the loop passes what it observed.
+//
+// Passing a literal false there type-checks, keeps the call, keeps every other
+// identifier, and restores two separate silences: a test set whose fetch failed
+// and whose mapping HAS eligible dependencies goes back to reporting
+// `dependencies_checked: false` with no warning at all, and one whose mapping
+// is also all-reusable goes back to being told the recording's tier is at
+// fault when the actionable cause was a transport error. Both keep the suite
+// green, which is why this is pinned by shape rather than by behaviour.
+func TestMainLoopReportsTheConsumedFetchOutcomeToTheWarner(t *testing.T) {
+	fset, fn := runTestSetSource(t)
+
+	const warner = "r.warnDependencyAssertionInert"
+	// (testSetID, useMappingBased, isMappingEnabled, consumedFetchFailed,
+	//  deferredStreaming, noEligibleDeps, warned)
+	const fetchArg = 3
+
+	var args []string
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || calleeName(call) != warner {
+			return true
+		}
+		if len(call.Args) <= fetchArg {
+			t.Fatalf("%s takes %d argument(s); consumedFetchFailed is argument %d", warner, len(call.Args), fetchArg+1)
+		}
+		args = append(args, printNode(t, fset, call.Args[fetchArg]))
+		return true
+	})
+
+	sort.Strings(args)
+	want := []string{"false", "instrumentConsumedFetchErr != nil"}
+	if strings.Join(args, " | ") != strings.Join(want, " | ") {
+		t.Fatalf("%s is passed consumedFetchFailed=%v across its call sites, want %v.\n\n"+
+			"WHY THIS MATTERS: only the main replay loop performs the per-test consumed fetch, so only it "+
+			"can report that the fetch failed. A literal false there silences the fourth reason entirely: "+
+			"a run whose fetch failed reports dependencies_checked=false with no warning, or — when the "+
+			"mapping is also all-reusable — blames the recording's tier for a transport error the operator "+
+			"could have fixed. The Phase-2 streaming pass fetches no consumed set, so it must pass false.",
+			warner, args, want)
+	}
+}
+
+// THE ELIGIBILITY FILTER IS ONE FUNCTION, NOT TWO COPIES.
+//
+// `isDNSMockEntry(m, kinds) || reusable[m.Name]` decides two things that must
+// agree: the persisted deps_checked bit (buildDepResults iterates the survivors)
+// and the user-facing "why nothing was asserted" warning (RunTestSet measures
+// them for noEligibleDeps, via filteredExpectedNames). It used to be written
+// out at both sites.
+//
+// Nothing pinned that the copies agreed — each half is pinned separately and
+// each half is individually correct — so widening one alone stayed green while
+// producing a silent-honesty regression: widen the writer's copy and the report
+// says NOT-CHECKED with no explanation; widen the call site's and the warning
+// fires for test sets that WERE asserted. This test makes the shared call the
+// pinned property, so the drift is not expressible.
+func TestEligibilityFilterHasExactlyOneDefinition(t *testing.T) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi os.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		t.Fatalf("parse package: %v", err)
+	}
+
+	type site struct {
+		fn  string
+		pos string
+	}
+	var sites []site
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			ast.Inspect(file, func(n ast.Node) bool {
+				fn, ok := n.(*ast.FuncDecl)
+				if !ok {
+					return true
+				}
+				ast.Inspect(fn.Body, func(m ast.Node) bool {
+					bin, ok := m.(*ast.BinaryExpr)
+					if !ok || bin.Op != token.LOR {
+						return true
+					}
+					// The composite predicate: a call to isDNSMockEntry on one
+					// side, an index into the reusable map on the other.
+					idents := exprIdents([]ast.Expr{bin})
+					if idents["isDNSMockEntry"] && idents["reusableMockNames"] {
+						sites = append(sites, site{fn: fn.Name.Name, pos: fset.Position(bin.Pos()).String()})
+					}
+					return true
+				})
+				return false
+			})
+		}
+	}
+
+	if len(sites) != 1 || sites[0].fn != "eligibleExpectedEntries" {
+		t.Fatalf("the eligibility predicate is written at %d site(s): %+v; want exactly 1, inside eligibleExpectedEntries.\n\n"+
+			"WHY THIS MATTERS: this predicate decides BOTH the persisted deps_checked bit and the warning "+
+			"that explains it. Two copies can be widened one at a time, and each outcome is a silent "+
+			"regression that keeps the suite green: the report reporting NOT-CHECKED with no reason given, "+
+			"or the reason being given for test sets whose assertion actually ran. Call "+
+			"eligibleExpectedEntries instead of re-writing the filter.", len(sites), sites)
+	}
+}
+
+// ...and RunTestSet actually routes through it, rather than keeping its own
+// list that merely happens to match today.
+func TestRunTestSetDerivesItsExpectationListFromTheSharedFilter(t *testing.T) {
+	_, fn := runTestSetSource(t)
+
+	calls := callArgIdents(fn, "eligibleExpectedEntries")
+	if len(calls) != 1 {
+		t.Fatalf("RunTestSet calls eligibleExpectedEntries %d time(s), want exactly 1.\n\n"+
+			"WHY THIS MATTERS: filteredExpectedNames (the mockSetMismatch verdict) and noEligibleDeps (the "+
+			"warning) must both be derived from the same filtered list buildDepResults iterates, or the "+
+			"verdict, the persisted deps_checked bit and the reason shown to the user are three "+
+			"computations of one question with nothing holding them together.", len(calls))
+	}
+	want := []string{"expectedMocks", "mockKindByName", "reusableMockNames"}
+	for _, w := range want {
+		if !calls[0][w] {
+			t.Fatalf("eligibleExpectedEntries is called without %q (got %v).\n\n"+
+				"WHY THIS MATTERS: dropping mockKindByName stops DNS entries being excluded and dropping "+
+				"reusableMockNames stops session/connection-tier ones being excluded, so healthy tests are "+
+				"reported with MISSING dependencies and --assert-dependencies fails them.", w, calls[0])
+		}
+	}
+}

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1664,18 +1664,39 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 	for k, v := range totalConsumedMocks {
 		allConsumedAcrossCycles[k] = v
 	}
-	// Build a lookup of mock name -> summary and protocol from the mock registry (once per test set).
-	type mockInfo struct {
-		summary  string
-		protocol string
-	}
-	mockLookup := map[string]mockInfo{}
+	// Build a lookup of mock name -> summary, protocol and target from the mock
+	// registry (once per test set). `target` is added for the DepResult writer:
+	// neither models.MockEntry (the mapping side) nor models.MockState (the
+	// consumed side) carries a destination, so the only place a human-meaningful
+	// target exists is the loaded *models.Mock. Can legitimately stay empty —
+	// r.mockDB may be nil and GetUnFilteredMocks errors are swallowed here — so
+	// every consumer must degrade gracefully rather than assume a hit.
+	mockLookup := map[string]mockDisplayInfo{}
+
+	// Test-set-scoped dependency-assertion bookkeeping.
+	//
+	// depMissingTests collects the tests that lost a recorded outgoing call so
+	// ONE Warn can be emitted per test set at the end, instead of one per test
+	// on every run. Keyed by name, and recordUnexercised DELETES on a clean
+	// cycle as well as inserting on a dirty one, so a RetryPassing cycle can
+	// neither double-count a test nor leave a stale entry for one that
+	// recovered — the summary always describes the same cycle the persisted
+	// report does. The value is the test's status, so the summary can separate
+	// the tests whose response still matched (the silent-green population)
+	// from the ones that were demoted.
+	//
+	// depAssertionInertWarned makes the "you asked for --assert-dependencies
+	// but it cannot run here" warning fire once per test set rather than once
+	// per test.
+	depMissingTests := map[string]models.TestStatus{}
+	depAssertionInertWarned := false
 	if r.mockDB != nil {
 		if allMocks, err := r.mockDB.GetUnFilteredMocks(runTestSetCtx, testSetID, models.BaseTime, time.Now(), nil, nil); err == nil {
 			for _, mock := range allMocks {
-				mockLookup[mock.Name] = mockInfo{
+				mockLookup[mock.Name] = mockDisplayInfo{
 					summary:  models.MockSummaryFromSpec(mock),
 					protocol: string(mock.Kind),
+					target:   mockTargetFromSpec(mock),
 				}
 			}
 		}
@@ -1985,17 +2006,18 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			// mapping but are excluded here: they are not deterministically
 			// attributed to a single test's window, so including them would
 			// falsely demote tests to OBSOLETE.
-			filteredExpectedNames := make([]string, 0, len(expectedMocks))
-			for _, m := range expectedMocks {
-				isDNS := strings.EqualFold(m.Kind, string(models.DNS))
-				if !isDNS {
-					if kind, ok := mockKindByName[m.Name]; ok && kind == models.DNS {
-						isDNS = true
-					}
-				}
-				if isDNS || reusableMockNames[m.Name] {
-					continue
-				}
+			//
+			// eligibleExpectedEntries is the SHARED filter — literally the
+			// same call buildDepResults makes. Both the verdict signal
+			// (mockSetMismatch, via filteredExpectedNames) and the honesty
+			// signal (noEligibleDeps, below) are derived from its result, so
+			// they cannot drift from the rows the writer emits. It used to be
+			// written out inline here and again in the writer; see the
+			// function's doc comment for what a one-sided widening of those
+			// two copies did to the report.
+			eligibleExpected := eligibleExpectedEntries(expectedMocks, mockKindByName, reusableMockNames)
+			filteredExpectedNames := make([]string, 0, len(eligibleExpected))
+			for _, m := range eligibleExpected {
 				filteredExpectedNames = append(filteredExpectedNames, m.Name)
 			}
 
@@ -2007,21 +2029,81 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 				filteredMockNames = append(filteredMockNames, m.Name)
 			}
 
+			// depAssertionValid: the ONE predicate under which an
+			// expected-vs-consumed comparison is a valid per-test assertion.
+			// It gates the verdict signal (mockSetMismatch) AND the DepResult
+			// rows that explain it, so the two cannot diverge.
+			//
+			// Every conjunct is load-bearing:
+			//   - r.instrument: SendMockFilterParamsToAgent returns early when
+			//     it is false, so the per-test mapping is NEVER ARMED and the
+			//     agent serves from the whole pool. "Which mock got consumed
+			//     for this request" is then decided across all tests, so the
+			//     comparison is not attributable to one test at all.
+			//   - useMappingBased && isMappingEnabled: without them
+			//     determineMockingStrategy hands back defaultMappings and there
+			//     is no per-test expectation to compare against.
+			//   - hasExpectedMocks: nothing recorded for this test.
+			//   - instrumentConsumedFetchErr == nil: the fetch failed and
+			//     consumedMocks was cleared to nil above, which would
+			//     deterministically compute mockSetMismatch=true (empty subset
+			//     of any non-empty expected set) and falsely mark the test
+			//     OBSOLETE — and, on the rows side, report every dependency as
+			//     missing — because of an unrelated transport error.
+			depAssertionValid := r.instrument && useMappingBased && isMappingEnabled && hasExpectedMocks && instrumentConsumedFetchErr == nil
+
 			mockSetMismatch := false
-			if r.instrument && useMappingBased && isMappingEnabled && hasExpectedMocks && instrumentConsumedFetchErr == nil {
+			if depAssertionValid {
 				// Compare only per-test mocks (DNS + reusable/startup tiers
 				// excluded above) since those are the only mocks
-				// deterministically tied to a single test. Also gate on a
-				// successful per-test GetConsumedMocks — when the fetch failed,
-				// consumedMocks was cleared to nil above, which would
-				// deterministically compute mockSetMismatch=true (empty subset
-				// of any non-empty expected set) and falsely mark the test
-				// OBSOLETE due to an unrelated transport error rather than a
-				// real mock-pool divergence.
+				// deterministically tied to a single test.
 				mockSetMismatch = !isMockSubset(filteredMockNames, filteredExpectedNames)
 			}
+			// noEligibleDeps: the recording DOES map dependencies to this
+			// test and the filter above removed every one of them, so
+			// buildDepResults has nothing to assert and reports NOT-CHECKED
+			// (see its eligibility guard). That is the ordinary outcome for a
+			// recording whose mocks carry no per-test tier tag — untagged
+			// HTTP/Postgres/MySQL egress is classified session-tier by
+			// models.Mock.DeriveLifetime — so without a warning the user gets
+			// a report full of `dependencies_checked: false` and no statement
+			// of why.
+			//
+			// Computed from the SAME two lists the assertion itself uses
+			// (expectedMocks, filteredExpectedNames), so the warning cannot
+			// claim something buildDepResults disagrees with.
+			noEligibleDeps := len(expectedMocks) > 0 && len(filteredExpectedNames) == 0
 
-			emitFailureLogs := !mockSetMismatch
+			// One WARN per test set when the knob was asked for but cannot be
+			// honoured. Without it --assert-dependencies in CI against a
+			// legacy (unmapped) test set, with test.disableMapping set, or
+			// against a recording with no per-test-tier dependency at all,
+			// produces a green run and no indication the assertion never ran
+			// — the same silent-green class the slice exists to close.
+			//
+			// Called per TEST CASE (the latch keeps it one line per test set)
+			// because noEligibleDeps is a property of this test's own mapped
+			// entries, not of the test set.
+			//
+			// deferredStreaming is false here: this loop only ever sees the
+			// non-streaming bucket. The streaming tests were split out above
+			// and get their own latched call in Phase 2.
+			//
+			// instrumentConsumedFetchErr != nil is passed as its OWN reason
+			// rather than being left to fall through to noEligibleDeps. A
+			// failed fetch nils consumedMocks, which is a transport error the
+			// operator can act on; blaming the recording's tier for it sent
+			// them to re-tag a recording that was never the problem, and a
+			// fetch failure on a test set WITH eligible dependencies used to
+			// produce no warning at all.
+			r.warnDependencyAssertionInert(testSetID, useMappingBased, isMappingEnabled, instrumentConsumedFetchErr != nil, false, noEligibleDeps, &depAssertionInertWarned)
+
+			// A mock-set mismatch normally means "re-record", so the response
+			// diff is suppressed as noise. With --assert-dependencies the test
+			// is about to be marked FAILED instead of demoted to OBSOLETE, so
+			// suppressing its diffs would hand the user a red test with no
+			// explanation. Knob off (the default) is byte-identical to before.
+			emitFailureLogs := shouldEmitFailureLogs(mockSetMismatch, r.config.Test.AssertDependencies)
 
 			switch testCase.Kind {
 			case models.HTTP:
@@ -2105,57 +2187,101 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 				zap.Strings("mockNames", mockNames),
 				zap.Any("mocks", consumedMocks))
 
-			// strictMockReject: under SchemaNoiseStrict, an expected mock that
-			// went unconsumed means strict req-body matching REJECTED it — a
-			// non-noise request field drifted. The app's response can still
-			// match (e.g. a deterministic dependency), so the response check
-			// alone won't catch it; treat it as a real test failure.
-			strictMockReject := false
-			if mockSetMismatch {
-				switch {
-				case testPass && r.config.Test.SchemaNoiseStrict:
-					r.logger.Error("strict schema-noise: expected mock was rejected (non-noise request-body drift); failing testcase even though the response matched",
-						zap.String("testcase", testCase.Name),
-						zap.String("testset", testSetID),
-						zap.Strings("expectedMocks", filteredExpectedNames),
-						zap.Strings("actualMocks", filteredMockNames))
-					testPass = false
-					strictMockReject = true
-					r.mockMismatchFailures.AddFailure(testSetID, testCase.Name, filteredExpectedNames, filteredMockNames)
-				case testPass:
-					r.logger.Debug("mock mapping mismatch ignored because testcase passed",
-						zap.String("testcase", testCase.Name),
-						zap.String("testset", testSetID),
-						zap.Strings("expectedMocks", filteredExpectedNames),
-						zap.Strings("actualMocks", filteredMockNames))
-				default:
-					r.logger.Error("mock mapping mismatch detected; marking testcase as obsolete. Re-record the test case or run with --update-test-mapping to regenerate mappings",
-						zap.String("testcase", testCase.Name),
-						zap.String("testset", testSetID),
-						zap.Strings("expectedMocks", filteredExpectedNames),
-						zap.Strings("actualMocks", filteredMockNames))
-					r.mockMismatchFailures.AddFailure(testSetID, testCase.Name, filteredExpectedNames, filteredMockNames)
-				}
+			// THE PER-TEST VERDICT, in one call.
+			//
+			// resolveTestOutcome takes the PRE-PROMOTION response result and
+			// returns everything that follows from it: the persisted status,
+			// whether the test set goes red, whether the mismatch is recorded
+			// for the end-of-run report, and which log line explains it.
+			//
+			// It is a seam on purpose. The promotions used to be inline
+			// `case testPass && <knob>:` arms of a switch inside this
+			// 3000-line function, and a reviewer demonstrated that replacing
+			// the --assert-dependencies arm with `testPass && false` left the
+			// entire five-package suite green — i.e. the knob's only reason to
+			// exist was unguarded. Every arm is now a table row in
+			// TestResolveTestOutcome.
+			//
+			// The three knobs it weighs:
+			//   - SchemaNoiseStrict: an expected mock was REJECTED because a
+			//     non-noise request-body field drifted.
+			//   - AssertDependencies: an expected per-test mock was not
+			//     observed during this test's window, i.e. the app stopped
+			//     making an outgoing call the recording says it makes. The
+			//     response can still match — a deterministic dependency, a
+			//     cached value, a swallowed error — so the response check
+			//     alone cannot catch it, and today the test is silently
+			//     demoted to OBSOLETE with the run still exiting 0
+			//     (keploy-consumer-design-v2.md §5, false-pass row 0).
+			//     DEFAULT OFF: every existing suite with a drifting mock pool
+			//     would flip red on upgrade otherwise. The DepResult rows are
+			//     written and rendered either way, so with the knob off the
+			//     missing dependency is still visible in the report / JUnit /
+			//     --format json — only the verdict differs.
+			//   - StrictFailure: the pre-existing veto of the OBSOLETE
+			//     demotion for a response-failing test.
+			outcome := resolveTestOutcome(testPass, mockSetMismatch, r.config.Test.SchemaNoiseStrict, r.config.Test.AssertDependencies, r.config.Test.StrictFailure)
+			switch outcome.Log {
+			case mismatchLogSchemaNoiseReject:
+				r.logger.Error("strict schema-noise: expected mock was rejected (non-noise request-body drift); failing testcase even though the response matched",
+					zap.String("testcase", testCase.Name),
+					zap.String("testset", testSetID),
+					zap.Strings("expectedMocks", filteredExpectedNames),
+					zap.Strings("actualMocks", filteredMockNames))
+			case mismatchLogDependencyReject:
+				r.logger.Error("assert-dependencies: an expected per-test dependency was not observed during this test's window; failing testcase even though the response matched",
+					zap.String("testcase", testCase.Name),
+					zap.String("testset", testSetID),
+					zap.Strings("expectedMocks", filteredExpectedNames),
+					zap.Strings("actualMocks", filteredMockNames))
+			case mismatchLogIgnoredResponseMatched:
+				r.logger.Debug("mock mapping mismatch ignored because testcase passed",
+					zap.String("testcase", testCase.Name),
+					zap.String("testset", testSetID),
+					zap.Strings("expectedMocks", filteredExpectedNames),
+					zap.Strings("actualMocks", filteredMockNames))
+			case mismatchLogVetoedFailure:
+				r.logger.Error("mock mapping mismatch detected; marking testcase as FAILED",
+					zap.String("testcase", testCase.Name),
+					zap.String("testset", testSetID),
+					zap.String("reason", outcome.VetoFlags),
+					zap.Strings("expectedMocks", filteredExpectedNames),
+					zap.Strings("actualMocks", filteredMockNames))
+			case mismatchLogObsolete:
+				r.logger.Error("mock mapping mismatch detected; marking testcase as obsolete. Re-record the test case or run with --update-test-mapping to regenerate mappings",
+					zap.String("testcase", testCase.Name),
+					zap.String("testset", testSetID),
+					zap.Strings("expectedMocks", filteredExpectedNames),
+					zap.Strings("actualMocks", filteredMockNames))
+			case mismatchLogNone:
 			}
+			if outcome.RecordMismatch {
+				r.mockMismatchFailures.AddFailure(testSetID, testCase.Name, filteredExpectedNames, filteredMockNames)
+			}
+			// Fold the promotions back into testPass so the "result" line and
+			// every later reader see the resolved verdict, exactly as they did
+			// when the flips were inline.
+			testPass = outcome.Status == models.TestStatusPassed
 
 			if !testPass {
 				r.logger.Info("result", zap.String("testcase id", models.HighlightFailingString(testCase.Name)), zap.String("testset id", models.HighlightFailingString(testSetID)), zap.String("passed", models.HighlightFailingString(testPass)))
 			} else {
 				r.logger.Info("result", zap.String("testcase id", models.HighlightPassingString(testCase.Name)), zap.String("testset id", models.HighlightPassingString(testSetID)), zap.String("passed", models.HighlightPassingString(testPass)))
 			}
-			if testPass {
-				testStatus = models.TestStatusPassed
+			testStatus = outcome.Status
+			switch testStatus {
+			case models.TestStatusPassed:
 				currentSuccess++
 				nextTestsToRun = append(nextTestsToRun, testCase)
 				for _, m := range consumedMocks {
 					passingTotalConsumedMocks[m.Name] = m
 				}
-			} else if mockSetMismatch && !strictMockReject && !r.config.Test.StrictFailure {
-				testStatus = models.TestStatusObsolete
+			case models.TestStatusObsolete:
 				currentObsolete++
-			} else {
-				testStatus = models.TestStatusFailed
+			default:
 				currentFailures++
+			}
+			if outcome.FailsTestSet {
 				testSetStatus = models.TestSetStatusFailed
 			}
 
@@ -2313,6 +2439,62 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 					expectedMockInfos := buildExpectedMockInfos(expectedMocks, mockKindByName)
 					actualMockInfos := buildActualMockInfos(perTestConsumed, perTestConsumedKnown)
 
+					// FIRST WRITER of models.Result.DepResult
+					// (keploy-consumer-design-v2.md §2, §7 slice 4). Written
+					// for EVERY test that reaches here — passed, failed or
+					// obsolete — so a missing dependency is visible in the
+					// report, JUnit and --format json regardless of the
+					// verdict.
+					//
+					// Gated on the SAME depAssertionValid predicate as
+					// mockSetMismatch: the rows are only a valid per-test
+					// assertion when the per-test mock mapping was actually
+					// ARMED on the agent, which is instrument mode only. Under
+					// that predicate perTestConsumed == consumedMocks and
+					// perTestConsumedKnown is implied, so the rows and the
+					// verdict signal are computed from identical inputs.
+					//
+					// The dependencies that WERE observed collapse into a
+					// plain count (Result.DepsConsumed) in every mode:
+					// persistence is decoupled from the verdict knob on
+					// purpose, so turning the CI gate on cannot multiply the
+					// size of every report it writes. Result.DepsChecked is
+					// written unconditionally under the predicate, which is
+					// what makes "the assertion ran and found nothing"
+					// expressible on disk and distinguishable from "the
+					// assertion never ran" — for two short keys instead of the
+					// ~224-byte aggregate row an earlier revision persisted per
+					// test, on every report, to encode the same one bit.
+					//
+					// Rebuilt on every RetryPassing cycle: the last cycle's
+					// rows land in finalTestCaseResults, overwriting earlier
+					// ones, so no stale row survives a mock rewind.
+					//
+					// This is a read-only projection of bookkeeping the replay
+					// loop already computes — no new capture path, and mock
+					// matching / serving is untouched.
+					depAssert := buildDepResults(expectedMocks, perTestConsumed, depAssertionValid && perTestConsumedKnown, reusableMockNames, mockKindByName, mockLookup)
+					missingDepNames, depLevel := attachDepResults(testCaseResult, testStatus, depAssert, r.config.Test.AssertDependencies)
+					recordUnexercised(depMissingTests, testCase.Name, testStatus, depLevel)
+					switch depLevel {
+					case depLogError:
+						r.logger.Error("dependency assertion failed: an expected dependency was not observed during this test's window",
+							zap.String("testcase", testCase.Name),
+							zap.String("testset", testSetID),
+							zap.Strings("missingDependencies", missingDepNames))
+					case depLogDebug:
+						// Per-test Debug only: an expected-but-unobserved mock
+						// is the routine condition the OBSOLETE demotion exists
+						// to tolerate, so a Warn here would add hundreds of new
+						// lines per run to any suite with a drifting mock pool.
+						// The test-set summary below carries the signal instead.
+						r.logger.Debug("expected dependencies were not observed during this test's window (reported only; set test.assertDependencies / --assert-dependencies to fail on this)",
+							zap.String("testcase", testCase.Name),
+							zap.String("testset", testSetID),
+							zap.Strings("missingDependencies", missingDepNames))
+					case depLogNone:
+					}
+
 					// TestResult.MockMismatches: populated for tests going
 					// through this (non-streaming) replay path — regardless of
 					// pass/fail or obsolescence. Mirrors the sandbox integration
@@ -2414,6 +2596,24 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		r.logger.Info("Now executing streaming tests",
 			zap.String("testset", testSetID),
 			zap.Int("count", len(streamingTests)))
+
+		// The streaming half of the inert-knob warning, sharing Phase 1's
+		// latch so a test set still emits at most ONE of these however many
+		// streaming tests it deferred.
+		//
+		// This pass writes no DepResult and never calls resolveTestOutcome (see
+		// the NOTE further down), so --assert-dependencies cannot promote
+		// anything here. Without this call a CI run that points the flag at a
+		// set of SSE/chunked tests exits 0 for an assertion that never
+		// executed — the flag would be silently inert, which is exactly the
+		// failure mode the flag exists to remove. deferredStreaming is true
+		// unconditionally: reaching this block means len(streamingTests) > 0.
+		// noEligibleDeps is false here and must stay false: this pass has no
+		// per-test filtered expectation list to compute it from, and the
+		// deferral is the accurate thing to say about these test cases.
+		// consumedFetchFailed is false for the same reason — this pass fetches
+		// no per-test consumed set, so it has no fetch outcome to report.
+		r.warnDependencyAssertionInert(testSetID, useMappingBased, isMappingEnabled, false, true, false, &depAssertionInertWarned)
 
 		for i, deferred := range streamingTests {
 			tc := deferred.testCase
@@ -2531,6 +2731,14 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			if r.instrument && useMappingBased && isMappingEnabled && hasExpectedMocks {
 				mockSetMismatch = !isMockSubsetWithConfig(consumedMocks, expectedMocks)
 			}
+			// NOTE: models.Result.DepResult is deliberately NOT populated on
+			// the deferred streaming path, for the same reason MockMismatches
+			// is not (see models.TestResult.MockMismatches). deferred.expected
+			// Mocks is an un-tier-filtered name slice built before the run, so
+			// reusable/startup-tier mocks would show up as per-test
+			// dependencies and go "missing" at random. Consumers must treat an
+			// absent DepResult as "not available for this run mode", never as
+			// "this test had no dependencies".
 			emitFailureLogs := !mockSetMismatch
 
 			if !ok {
@@ -2797,6 +3005,14 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 	for k, v := range totalConsumedMocks {
 		allConsumedAcrossCycles[k] = v
 	}
+
+	// ONE summary line per test set for dependencies that were recorded but
+	// not observed, in the default (knob off) mode. Per-test this is logged
+	// at Debug: it is the routine condition the OBSOLETE demotion tolerates,
+	// and a Warn per test would add hundreds of lines per run to any suite
+	// with a drifting mock pool — a CLI-output regression for users who never
+	// opted into the assertion. The count and a sample still surface here.
+	r.warnUnexercisedDependencies(testSetID, depMissingTests)
 
 	timeTaken := time.Since(startTime)
 

--- a/pkg/service/report/depnotice.go
+++ b/pkg/service/report/depnotice.go
@@ -1,0 +1,185 @@
+package report
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// The COMPACT, BOUNDED, DEDUPLICATED dependency block for `keploy report`.
+//
+// WHY IT IS GROUPED BY DEPENDENCY AND NOT BY TEST. The population this block
+// describes is dominated by one shape: a single outgoing call the app stopped
+// making (or, per the caveat below, makes after flushing its response) shows
+// up as the SAME missing dependency on every test that used it. Rendering one
+// four-line block per test turned a 16-line all-green `keploy report` into
+// 1,217 lines on a 300-test suite, every block repeating one identical
+// sentence, and put a <system-out> on all 300 JUnit cases. Grouping collapses
+// that to a single line naming the dependency and how many tests it affected,
+// which is the sentence a human or an agent actually acts on.
+//
+// WHY IT IS CAPPED TWICE. Grouping alone is not a bound: a suite where every
+// test loses a DIFFERENT dependency has as many groups as tests. So the number
+// of groups named is capped (depNoticeGroupCap) and the tests listed under
+// each group are capped (depNoticeTestSampleSize), with the remainder carried
+// as counts. Nothing is silently dropped — the totals are always exact, and
+// the full per-test rows stay in the report file and in `--format json`, which
+// is where an exhaustive consumer should be reading them from anyway.
+//
+// WHAT IT DELIBERATELY DOES NOT DO: offer a name/glob suppression list. The
+// documented false-positive class (a call made after the response is written)
+// is a TIMING artifact, not a dependency a user wants permanently unwatched;
+// globbing it away restores exactly the silent green this slice exists to
+// close, and would do so for the real regression on the same dependency too.
+// One summary line per dependency is the tuning-down.
+const (
+	// depNoticeGroupCap bounds how many DISTINCT dependency rows are named.
+	depNoticeGroupCap = 10
+	// depNoticeTestSampleSize bounds how many test IDs are listed per
+	// dependency here, and how many dependency lines depNonFailureBody puts
+	// in a JUnit <system-out> / <skipped> body. Mirrors depWarnSampleSize on
+	// the replayer's own end-of-test-set Warn, so every sampled surface uses
+	// one number: whatever a reader is willing to skim in a summary is the
+	// same whether it is test ids or dependency names.
+	depNoticeTestSampleSize = 5
+)
+
+// depNoticeGroup is one missing dependency and the tests that lost it.
+type depNoticeGroup struct {
+	Name  string
+	Tests []string
+}
+
+// depNoticeTestLabel is the identity a test is listed under. TestCaseID is the
+// id every other `keploy report` surface prints; Name is the fallback for
+// results persisted without one.
+func depNoticeTestLabel(t models.TestResult) string {
+	if t.TestCaseID != "" {
+		return t.TestCaseID
+	}
+	return t.Name
+}
+
+// groupDepNotices inverts test -> missing dependencies into dependency ->
+// tests, ordered by blast radius (most tests first) and then by name, so the
+// dependency a user should look at first is printed first and two runs over
+// the same data produce identical output.
+func groupDepNotices(tests []models.TestResult) []depNoticeGroup {
+	byDep := map[string][]string{}
+	for _, t := range tests {
+		label := depNoticeTestLabel(t)
+		for _, name := range models.MissingDepNames(t.Result.DepResult) {
+			byDep[name] = append(byDep[name], label)
+		}
+	}
+
+	groups := make([]depNoticeGroup, 0, len(byDep))
+	for name, labels := range byDep {
+		sort.Strings(labels)
+		groups = append(groups, depNoticeGroup{Name: name, Tests: labels})
+	}
+	sort.Slice(groups, func(i, j int) bool {
+		if len(groups[i].Tests) != len(groups[j].Tests) {
+			return len(groups[i].Tests) > len(groups[j].Tests)
+		}
+		return groups[i].Name < groups[j].Name
+	})
+	return groups
+}
+
+// renderDepNoticeSummary renders the block.
+//
+// notices is the folded-in population (every admitted result that is NOT
+// getting a full diff); admitted is the whole set the run admitted, FAILED
+// tests included. BOTH counts are stated because the run has two different
+// true answers to "how many tests lost a dependency" and they must not read as
+// a contradiction: `keploy report --summary` counts every status
+// (report.depNoticeCounts), while this block only folds in the tests that were
+// not failed for it. A run with 3 PASSED and 2 FAILED tests all losing the same
+// dependency otherwise printed "3" here and "5" under --summary, and an agent
+// diffing the two invocations got two numbers for one question.
+//
+// Returns "" when no folded-in test lost a dependency, which is what keeps
+// `keploy report` byte-identical to pre-slice-4 for every report that carries
+// no missing row.
+func renderDepNoticeSummary(notices, admitted []models.TestResult) string {
+	groups := groupDepNotices(notices)
+	if len(groups) == 0 {
+		return ""
+	}
+
+	// Counted, not len(): the caller hands over every result in each
+	// population, and a clean test among them must not be reported as having
+	// lost something.
+	//
+	// total >= affected holds by construction and is NOT re-checked here:
+	// notices is the second return of partitionDepNotices over admitted, so it
+	// is a subset of it, and countWithMissingDeps is monotonic over subsets. A
+	// defensive `if total < affected { total = affected }` clamp was
+	// unreachable from the only call site — it could not be tested and would
+	// have quietly papered over a caller that had genuinely paired the wrong
+	// two populations. If a future caller can pass a narrower admitted set,
+	// fix the pairing there.
+	affected := countWithMissingDeps(notices)
+	total := countWithMissingDeps(admitted)
+
+	var sb strings.Builder
+	sb.WriteString("\n=== DEPENDENCIES NOT EXERCISED ===\n")
+	if total == affected {
+		fmt.Fprintf(&sb, "%d test(s) did not exercise a recorded outgoing call and were NOT failed for it.\n", affected)
+	} else {
+		fmt.Fprintf(&sb, "%d test(s) did not exercise a recorded outgoing call; %d of them were NOT failed for it and are summarised below.\n",
+			total, affected)
+	}
+	fmt.Fprintf(&sb, "(%s)\n", models.DepNoticeHint)
+	// The caveat belongs on the surface a human reads, not only in the flag
+	// help: consumed mocks are drained the moment the response comes back, so
+	// a call made after that point is attributed to the next test. Without
+	// this sentence the block reads as a regression report for a benign
+	// fire-and-forget write.
+	sb.WriteString("A call your app makes AFTER writing its response is attributed to the NEXT test, not this one.\n")
+
+	shown := groups
+	if len(shown) > depNoticeGroupCap {
+		shown = shown[:depNoticeGroupCap]
+	}
+	for _, g := range shown {
+		fmt.Fprintf(&sb, "  %s %s\n", models.DepNoticePrefix, g.Name)
+		fmt.Fprintf(&sb, "      %d test(s): %s\n", len(g.Tests), sampleList(g.Tests, depNoticeTestSampleSize))
+	}
+	if rest := len(groups) - len(shown); rest > 0 {
+		fmt.Fprintf(&sb, "  ...and %d more dependenc%s not exercised - see the report file or `keploy report --format json`\n",
+			rest, plural(rest, "y", "ies"))
+	}
+	sb.WriteString("--------------------------------------------------------------------\n")
+	return sb.String()
+}
+
+// countWithMissingDeps counts the results carrying at least one failed
+// dependency assertion.
+func countWithMissingDeps(tests []models.TestResult) int {
+	n := 0
+	for _, t := range tests {
+		if t.Result.HasMissingDeps() {
+			n++
+		}
+	}
+	return n
+}
+
+// sampleList joins at most n entries and reports how many were elided.
+func sampleList(items []string, n int) string {
+	if len(items) <= n {
+		return strings.Join(items, ", ")
+	}
+	return fmt.Sprintf("%s ...and %d more", strings.Join(items[:n], ", "), len(items)-n)
+}
+
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
+}

--- a/pkg/service/report/depnotice_test.go
+++ b/pkg/service/report/depnotice_test.go
@@ -1,0 +1,414 @@
+package report
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"go.keploy.io/server/v3/config"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// namedMissingRow builds a MISSING row with an arbitrary name, so a test can
+// control how many DISTINCT dependencies a population carries.
+func namedMissingRow(name string) models.DepResult {
+	return models.DepResult{
+		Name: name,
+		Type: "http",
+		Meta: []models.DepMetaResult{{
+			Normal:   false,
+			Key:      models.DepKeyPresence,
+			Expected: models.DepPresenceConsumed,
+			Actual:   models.DepPresenceMissing,
+		}},
+	}
+}
+
+func passedWithDeps(id string, rows ...models.DepResult) models.TestResult {
+	return models.TestResult{
+		TestCaseID: id, Name: "test-set-0", Status: models.TestStatusPassed,
+		Result: models.Result{DepResult: rows, DepsChecked: true},
+	}
+}
+
+// passedChecked is a test whose dependency assertion RAN and found nothing
+// missing: no rows at all, just the two scalars. That is the shape every
+// healthy test in an instrument+mapping run persists.
+func passedChecked(id string, consumed int) models.TestResult {
+	return models.TestResult{
+		TestCaseID: id, Name: "test-set-0", Status: models.TestStatusPassed,
+		Result: models.Result{DepsChecked: true, DepsConsumed: consumed},
+	}
+}
+
+func TestGroupDepNotices(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []models.TestResult
+		want  []depNoticeGroup
+	}{
+		{
+			name: "nothing missing groups to nothing",
+			input: []models.TestResult{
+				passedWithDeps("t1"),
+				passedChecked("t2", 4),
+			},
+			want: nil,
+		},
+		{
+			name: "one dependency lost by three tests is ONE group",
+			input: []models.TestResult{
+				passedWithDeps("t1", namedMissingRow("deps[4] http POST analytics/events (presence)")),
+				passedWithDeps("t2", namedMissingRow("deps[4] http POST analytics/events (presence)")),
+				passedWithDeps("t3", namedMissingRow("deps[4] http POST analytics/events (presence)")),
+			},
+			want: []depNoticeGroup{{
+				Name:  "deps[4] http POST analytics/events (presence)",
+				Tests: []string{"t1", "t2", "t3"},
+			}},
+		},
+		{
+			name: "groups are ordered by blast radius, then by name",
+			input: []models.TestResult{
+				passedWithDeps("t1", namedMissingRow("deps[0] a")),
+				passedWithDeps("t2", namedMissingRow("deps[1] b")),
+				passedWithDeps("t3", namedMissingRow("deps[1] b")),
+				passedWithDeps("t4", namedMissingRow("deps[2] c")),
+			},
+			want: []depNoticeGroup{
+				{Name: "deps[1] b", Tests: []string{"t2", "t3"}},
+				{Name: "deps[0] a", Tests: []string{"t1"}},
+				{Name: "deps[2] c", Tests: []string{"t4"}},
+			},
+		},
+		{
+			name: "a test that lost two dependencies appears in both groups",
+			input: []models.TestResult{
+				passedWithDeps("t1", namedMissingRow("deps[0] a"), namedMissingRow("deps[1] b")),
+			},
+			want: []depNoticeGroup{
+				{Name: "deps[0] a", Tests: []string{"t1"}},
+				{Name: "deps[1] b", Tests: []string{"t1"}},
+			},
+		},
+		{
+			name:  "a result with no TestCaseID falls back to its name",
+			input: []models.TestResult{{Name: "only-a-name", Status: models.TestStatusPassed, Result: models.Result{DepResult: []models.DepResult{namedMissingRow("deps[0] a")}}}},
+			want:  []depNoticeGroup{{Name: "deps[0] a", Tests: []string{"only-a-name"}}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := groupDepNotices(tt.input)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d groups %v, want %d %v", len(got), got, len(tt.want), tt.want)
+			}
+			for i := range got {
+				if got[i].Name != tt.want[i].Name {
+					t.Fatalf("group %d: got name %q, want %q (full: %v)", i, got[i].Name, tt.want[i].Name, got)
+				}
+				if strings.Join(got[i].Tests, ",") != strings.Join(tt.want[i].Tests, ",") {
+					t.Fatalf("group %q: got tests %v, want %v", got[i].Name, got[i].Tests, tt.want[i].Tests)
+				}
+			}
+		})
+	}
+}
+
+// THE MEASURED REGRESSION. A 300-test all-PASSED run in which every test lost
+// the SAME dependency (the shape an app that writes an audit/analytics call
+// after flushing its response produces) rendered 1,217 lines of `keploy
+// report` where the pre-slice build rendered 16, every block repeating one
+// identical sentence.
+func TestRenderDepNoticeSummary_IsBoundedAndDeduplicated(t *testing.T) {
+	const shared = "deps[4] http POST analytics.internal:9000/events (presence)"
+	population := make([]models.TestResult, 0, 300)
+	for i := range 300 {
+		population = append(population, passedWithDeps(fmt.Sprintf("tc-%03d", i), namedMissingRow(shared)))
+	}
+
+	out := renderDepNoticeSummary(population, population)
+	lines := strings.Count(out, "\n")
+
+	// One block, not 300. The exact budget: header rule, the count sentence,
+	// the hint, the caveat, one group line, one sample line, the trailing
+	// rule, plus the leading blank line.
+	if lines > 12 {
+		t.Fatalf("300 tests sharing one dependency rendered %d lines; the block must stay bounded:\n%s", lines, out)
+	}
+	if strings.Count(out, models.DepNoticePrefix) != 1 {
+		t.Fatalf("the notice is repeated per test instead of once per dependency:\n%s", out)
+	}
+	for _, want := range []string{
+		"300 test(s) did not exercise a recorded outgoing call",
+		models.DepNoticePrefix + " " + shared,
+		"300 test(s): tc-000, tc-001, tc-002, tc-003, tc-004 ...and 295 more",
+		models.DepNoticeHint,
+		"attributed to the NEXT test",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("block missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// The other unbounded axis: one distinct dependency per test.
+func TestRenderDepNoticeSummary_GroupCountIsCapped(t *testing.T) {
+	var population []models.TestResult
+	for i := range 40 {
+		population = append(population, passedWithDeps(fmt.Sprintf("tc-%02d", i),
+			namedMissingRow(fmt.Sprintf("deps[%d] http GET svc-%02d/x (presence)", i, i))))
+	}
+
+	out := renderDepNoticeSummary(population, population)
+	if got := strings.Count(out, models.DepNoticePrefix); got != depNoticeGroupCap {
+		t.Fatalf("named %d dependencies, want the cap of %d:\n%s", got, depNoticeGroupCap, out)
+	}
+	if !strings.Contains(out, "...and 30 more dependencies not exercised") {
+		t.Errorf("the elided dependencies are not accounted for:\n%s", out)
+	}
+	// Totals stay exact even though the listing is capped.
+	if !strings.Contains(out, "40 test(s) did not exercise a recorded outgoing call") {
+		t.Errorf("the total is wrong or missing:\n%s", out)
+	}
+}
+
+// The caller hands over every non-FAILED admitted result, so the count has to
+// come from the rows, not from the slice length.
+func TestRenderDepNoticeSummary_CountsOnlyTheAffectedTests(t *testing.T) {
+	population := []models.TestResult{
+		passedWithDeps("lost", namedMissingRow("deps[0] a")),
+		passedChecked("clean", 2),
+		passedWithDeps("no-rows-at-all"),
+	}
+	out := renderDepNoticeSummary(population, population)
+	if !strings.Contains(out, "1 test(s) did not exercise a recorded outgoing call") {
+		t.Fatalf("the count includes tests that lost nothing:\n%s", out)
+	}
+}
+
+func TestRenderDepNoticeSummary_EmptyForACleanPopulation(t *testing.T) {
+	if got := renderDepNoticeSummary(nil, nil); got != "" {
+		t.Fatalf("a nil population rendered %q", got)
+	}
+	clean := []models.TestResult{passedChecked("t1", 3)}
+	if got := renderDepNoticeSummary(clean, clean); got != "" {
+		t.Fatalf("a population that lost nothing rendered %q", got)
+	}
+}
+
+// Only a genuinely FAILED test gets the diff apparatus. OBSOLETE reaching the
+// full renderer meant 100% of obsolete tests grew a failure block on upgrade,
+// where before this slice they rendered nothing at all in `keploy report`.
+func TestPartitionDepNotices(t *testing.T) {
+	withDep := func(id string, status models.TestStatus) models.TestResult {
+		return models.TestResult{TestCaseID: id, Status: status,
+			Result: models.Result{DepResult: []models.DepResult{missingDepRow()}}}
+	}
+	diffs, notices := partitionDepNotices([]models.TestResult{
+		withDep("failed", models.TestStatusFailed),
+		withDep("obsolete", models.TestStatusObsolete),
+		withDep("passed", models.TestStatusPassed),
+		withDep("ignored", models.TestStatusIgnored),
+	})
+
+	ids := func(in []models.TestResult) []string {
+		var out []string
+		for _, t := range in {
+			out = append(out, t.TestCaseID)
+		}
+		return out
+	}
+	if got := strings.Join(ids(diffs), ","); got != "failed" {
+		t.Fatalf("diff apparatus went to %q, want only the FAILED test", got)
+	}
+	if got := strings.Join(ids(notices), ","); got != "obsolete,passed,ignored" {
+		t.Fatalf("notice population was %q, want every non-FAILED status", got)
+	}
+
+	// THE SUBSET INVARIANT renderDepNoticeSummary relies on instead of a
+	// runtime clamp. It pairs (notices, admitted) and prints "N of them" over
+	// the two counts; because notices is a partition half of admitted,
+	// countWithMissingDeps(notices) <= countWithMissingDeps(admitted) always
+	// holds and the block can never claim a subset larger than its own total.
+	// A defensive `if total < affected { total = affected }` there was
+	// unreachable and untestable, so the invariant is asserted at the place
+	// that actually establishes it.
+	if len(diffs)+len(notices) != 4 {
+		t.Fatalf("partition lost or duplicated results: %d diffs + %d notices, want 4 in total",
+			len(diffs), len(notices))
+	}
+	admitted := map[string]bool{"failed": true, "obsolete": true, "passed": true, "ignored": true}
+	for _, id := range ids(notices) {
+		if !admitted[id] {
+			t.Fatalf("notice %q is not in the admitted set; renderDepNoticeSummary's counts stop being "+
+				"a subset of its own total", id)
+		}
+	}
+}
+
+// End to end through the real `keploy report` renderer: the FAILED test keeps
+// its full block, and 300 notice-only tests collapse into one bounded block.
+//
+// Run in BOTH modes. The compact path's writeDepNoticeSummary call was pinned;
+// the identical call in the --full branch was not, so `keploy report --full`
+// could silently lose the "=== DEPENDENCIES NOT EXERCISED ===" block — the only
+// text surface for the flagship silent-green case — with the package green.
+func TestPrintFailedTestReports_NoticesCollapseIntoOneBlock(t *testing.T) {
+	for _, full := range []bool{false, true} {
+		t.Run(fmt.Sprintf("full=%v", full), func(t *testing.T) {
+			r := New(zap.NewNop(), &config.Config{
+				DisableANSI: true,
+				Report:      config.Report{ShowFullBody: full},
+			}, nil, nil)
+			var buf bytes.Buffer
+			r.out = bufio.NewWriter(&buf)
+
+			admitted := []models.TestResult{{
+				Kind: models.HTTP, Name: "test-set-0", TestCaseID: "really-failed",
+				Status: models.TestStatusFailed,
+				Result: models.Result{
+					StatusCode: models.IntResult{Normal: false, Expected: 200, Actual: 500},
+					DepResult:  []models.DepResult{missingDepRow()},
+				},
+			}}
+			for i := range 300 {
+				admitted = append(admitted, passedWithDeps(fmt.Sprintf("tc-%03d", i), missingDepRow()))
+			}
+
+			if err := r.printFailedTestReports(context.Background(), admitted); err != nil {
+				t.Fatalf("printFailedTestReports: %v", err)
+			}
+			out := buf.String()
+
+			if strings.Count(out, "Testrun failed for") != 1 {
+				t.Fatalf("expected exactly one failure block, got %d:\n%s", strings.Count(out, "Testrun failed for"), out)
+			}
+			if got := strings.Count(out, "=== DEPENDENCY ASSERTIONS ==="); got != 1 {
+				t.Fatalf("the full dependency block was rendered %d times; only the FAILED test gets it", got)
+			}
+			if got := strings.Count(out, models.DepNoticePrefix); got != 1 {
+				t.Fatalf("the compact notice appeared %d times; 300 tests sharing one dependency must collapse to one line", got)
+			}
+			if !strings.Contains(out, "=== DEPENDENCIES NOT EXERCISED ===") {
+				t.Fatalf("the run-level dependency block is missing — it is the only text surface for "+
+					"a test that PASSED while losing a recorded outgoing call:\n%s", out)
+			}
+			// The counts must reconcile with `--summary`, which counts every
+			// status: 301 tests lost the dependency, 300 of them were not
+			// failed for it and are what this block folds in.
+			if !strings.Contains(out, "301 test(s) did not exercise a recorded outgoing call") ||
+				!strings.Contains(out, "300 of them were NOT failed for it") {
+				t.Errorf("the notice-only population is not accounted for:\n%s", out)
+			}
+		})
+	}
+}
+
+// The same --full gap for the ONE-test case, where the block is the only line
+// that mentions the dependency at all.
+func TestPrintFailedTestReports_FullBodyKeepsTheRunLevelBlock(t *testing.T) {
+	r := New(zap.NewNop(), &config.Config{
+		DisableANSI: true,
+		Report:      config.Report{ShowFullBody: true},
+	}, nil, nil)
+	var buf bytes.Buffer
+	r.out = bufio.NewWriter(&buf)
+
+	err := r.printFailedTestReports(context.Background(), []models.TestResult{
+		passedWithDeps("tc-passed", missingDepRow()),
+	})
+	if err != nil {
+		t.Fatalf("printFailedTestReports: %v", err)
+	}
+	out := buf.String()
+
+	if !strings.Contains(out, "=== DEPENDENCIES NOT EXERCISED ===") {
+		t.Fatalf("`keploy report --full` lost the dependency block for a PASSED test that stopped "+
+			"making a recorded outgoing call:\n%s", out)
+	}
+	if !strings.Contains(out, models.DepNoticePrefix+" deps[0] postgres PostgreSQL INSERT (presence)") {
+		t.Errorf("the dependency is not named:\n%s", out)
+	}
+}
+
+// An OBSOLETE test must NOT gain the failure apparatus it never had before
+// this slice.
+func TestPrintFailedTestReports_ObsoleteGetsTheCompactNotice(t *testing.T) {
+	r := New(zap.NewNop(), &config.Config{DisableANSI: true}, nil, nil)
+	var buf bytes.Buffer
+	r.out = bufio.NewWriter(&buf)
+
+	err := r.printFailedTestReports(context.Background(), []models.TestResult{{
+		Kind: models.HTTP, Name: "test-set-0", TestCaseID: "tc-obsolete",
+		Status: models.TestStatusObsolete,
+		Result: models.Result{DepResult: []models.DepResult{missingDepRow()}},
+	}})
+	if err != nil {
+		t.Fatalf("printFailedTestReports: %v", err)
+	}
+	out := buf.String()
+
+	for _, bad := range []string{
+		"Testrun failed for", "Testrun obsolete for",
+		"=== CHANGES IN STATUS AND HEADERS ===",
+		"=== CHANGES WITHIN THE RESPONSE BODY ===",
+		"=== DEPENDENCY ASSERTIONS ===",
+	} {
+		if strings.Contains(out, bad) {
+			t.Errorf("an OBSOLETE test rendered the failure apparatus (%q):\n%s", bad, out)
+		}
+	}
+	if !strings.Contains(out, models.DepNoticePrefix+" "+missingDepRow().Name) {
+		t.Errorf("the obsolete test's lost dependency is invisible:\n%s", out)
+	}
+}
+
+// THE TWO-NUMBERS-FOR-ONE-QUESTION BUG. `keploy report --summary` counts every
+// status (report.depNoticeCounts) while this block only folds in the tests that
+// were not failed for it, so a run with 3 PASSED and 2 FAILED tests all losing
+// the same dependency printed "3" here and "5" under --summary. Both are true;
+// neither said which population it was describing.
+func TestRenderDepNoticeSummary_StatesWhichPopulationItDescribes(t *testing.T) {
+	const shared = "deps[4] http POST analytics.internal:9000/events (presence)"
+	failed := func(id string) models.TestResult {
+		return models.TestResult{
+			TestCaseID: id, Name: "test-set-0", Status: models.TestStatusFailed,
+			Result: models.Result{DepResult: []models.DepResult{namedMissingRow(shared)}, DepsChecked: true},
+		}
+	}
+
+	notices := []models.TestResult{
+		passedWithDeps("p1", namedMissingRow(shared)),
+		passedWithDeps("p2", namedMissingRow(shared)),
+		passedWithDeps("p3", namedMissingRow(shared)),
+	}
+	admitted := append(append([]models.TestResult{}, notices...), failed("f1"), failed("f2"))
+
+	out := renderDepNoticeSummary(notices, admitted)
+
+	// The total agrees with what --summary prints for the same run...
+	total, _ := depNoticeCounts(map[string]*models.TestReport{"test-set-0": {Tests: admitted}})
+	if total != 5 {
+		t.Fatalf("fixture is wrong: depNoticeCounts says %d", total)
+	}
+	if !strings.Contains(out, "5 test(s) did not exercise a recorded outgoing call") {
+		t.Errorf("the block does not reconcile with `--summary`'s count of %d:\n%s", total, out)
+	}
+	// ...and the subset this block actually folds in is named.
+	if !strings.Contains(out, "3 of them were NOT failed for it and are summarised below") {
+		t.Errorf("the block does not say which subset it is describing:\n%s", out)
+	}
+
+	// When the two populations agree, the sentence stays the short historical
+	// one rather than restating the same number twice.
+	if got := renderDepNoticeSummary(notices, notices); !strings.Contains(got,
+		"3 test(s) did not exercise a recorded outgoing call and were NOT failed for it.") {
+		t.Errorf("an all-notices run should keep the single-number sentence:\n%s", got)
+	}
+}

--- a/pkg/service/report/depresult_render_test.go
+++ b/pkg/service/report/depresult_render_test.go
@@ -1,0 +1,698 @@
+package report
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"go.keploy.io/server/v3/config"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+func missingDepRow() models.DepResult {
+	return models.DepResult{
+		Name: "deps[0] postgres PostgreSQL INSERT (presence)",
+		Type: "postgres",
+		Meta: []models.DepMetaResult{{
+			Normal:   false,
+			Key:      models.DepKeyPresence,
+			Expected: models.DepPresenceConsumed,
+			Actual:   models.DepPresenceMissing,
+		}},
+	}
+}
+
+func consumedDepRow() models.DepResult {
+	return models.DepResult{
+		Name: "deps[1] http GET api.internal:80/orders (presence)",
+		Type: "http",
+		Meta: []models.DepMetaResult{{
+			Normal:   true,
+			Key:      models.DepKeyPresence,
+			Expected: models.DepPresenceConsumed,
+			Actual:   models.DepPresenceConsumed,
+		}},
+	}
+}
+
+func TestRenderDepResults(t *testing.T) {
+	tests := []struct {
+		name     string
+		deps     []models.DepResult
+		wantZero bool
+		contains []string
+	}{
+		{
+			name:     "no dependency rows writes zero bytes",
+			deps:     nil,
+			wantZero: true,
+		},
+		{
+			name: "missing dependency renders expected vs actual",
+			deps: []models.DepResult{missingDepRow()},
+			contains: []string{
+				"=== DEPENDENCY ASSERTIONS ===",
+				"MISSING deps[0] postgres PostgreSQL INSERT (presence)",
+				`presence: expected "consumed", actual "not consumed"`,
+			},
+		},
+		{
+			// Same rule: a matched row on its own is not worth a block.
+			name:     "a matched row alone renders nothing",
+			deps:     []models.DepResult{consumedDepRow()},
+			wantZero: true,
+		},
+		{
+			// The overflow row stands in for the dependencies past the per-test
+			// cap; it must render as a MISSING line without restating its own
+			// count.
+			name: "the missing overflow renders alongside the named rows",
+			deps: []models.DepResult{missingDepRow(), models.DepMissingOverflowRow(150)},
+			contains: []string{
+				"MISSING deps[0] postgres PostgreSQL INSERT (presence)",
+				"MISSING deps[*] 150 more not consumed (presence)",
+			},
+		},
+		{
+			name: "mixed rows render both shapes",
+			deps: []models.DepResult{missingDepRow(), consumedDepRow()},
+			contains: []string{
+				"MISSING deps[0] postgres PostgreSQL INSERT (presence)",
+				"OK      deps[1] http GET api.internal:80/orders (presence) - consumed (presence only)",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sb strings.Builder
+			renderDepResults(&sb, models.TestResult{Result: models.Result{DepResult: tt.deps}})
+			out := sb.String()
+			if tt.wantZero {
+				if sb.Len() != 0 {
+					t.Fatalf("expected no output, got %q", out)
+				}
+				return
+			}
+			for _, want := range tt.contains {
+				if !strings.Contains(out, want) {
+					t.Errorf("rendered output missing %q:\n%s", want, out)
+				}
+			}
+		})
+	}
+}
+
+func TestRenderSingleFailedTest_IncludesDependencyBlock(t *testing.T) {
+	r := New(zap.NewNop(), &config.Config{DisableANSI: true}, nil, nil)
+
+	tests := []struct {
+		name       string
+		test       models.TestResult
+		wantHeader string
+		contains   []string
+		absent     []string
+	}{
+		{
+			name: "failed test with a missing dependency",
+			test: models.TestResult{
+				Kind:       models.HTTP,
+				Name:       "test-set-0",
+				TestCaseID: "test-1",
+				Status:     models.TestStatusFailed,
+				Result:     models.Result{DepResult: []models.DepResult{missingDepRow()}},
+			},
+			wantHeader: "Testrun failed for test-set-0/test-1",
+			contains:   []string{"=== DEPENDENCY ASSERTIONS ===", "MISSING deps[0] postgres PostgreSQL INSERT (presence)"},
+		},
+		{
+			name: "failed test with no dependencies is unchanged",
+			test: models.TestResult{
+				Kind:       models.HTTP,
+				Name:       "test-set-0",
+				TestCaseID: "test-3",
+				Status:     models.TestStatusFailed,
+			},
+			wantHeader: "Testrun failed for test-set-0/test-3",
+			absent:     []string{"DEPENDENCY ASSERTIONS"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sb strings.Builder
+			if err := r.renderSingleFailedTest(context.Background(), &sb, tt.test); err != nil {
+				t.Fatalf("renderSingleFailedTest: %v", err)
+			}
+			out := sb.String()
+			if !strings.Contains(out, tt.wantHeader) {
+				t.Errorf("output missing header %q:\n%s", tt.wantHeader, out)
+			}
+			for _, want := range tt.contains {
+				if !strings.Contains(out, want) {
+					t.Errorf("output missing %q:\n%s", want, out)
+				}
+			}
+			for _, bad := range tt.absent {
+				if strings.Contains(out, bad) {
+					t.Errorf("output unexpectedly contains %q:\n%s", bad, out)
+				}
+			}
+		})
+	}
+}
+
+// A test that lost a recorded dependency must reach the renderer WHATEVER its
+// status. The flagship silent-green case (response matched, outgoing call
+// vanished) lands on PASSED, so a FAILED-or-OBSOLETE-only admission rule left
+// it invisible in text and JUnit unless the user opted into a verdict knob.
+func TestExtractFailedTestsFromResults_AdmissionIsStatusIndependentForDependencies(t *testing.T) {
+	r := New(zap.NewNop(), &config.Config{}, nil, nil)
+
+	withMissing := func(id string, status models.TestStatus) models.TestResult {
+		return models.TestResult{TestCaseID: id, Status: status,
+			Result: models.Result{DepResult: []models.DepResult{missingDepRow()}}}
+	}
+
+	tests := []struct {
+		name  string
+		input []models.TestResult
+		want  []string
+	}{
+		{
+			name: "failed only (historical behaviour for reports with no dependency rows)",
+			input: []models.TestResult{
+				{TestCaseID: "t1", Status: models.TestStatusFailed},
+				{TestCaseID: "t2", Status: models.TestStatusPassed},
+				{TestCaseID: "t3", Status: models.TestStatusObsolete},
+				{TestCaseID: "t4", Status: models.TestStatusIgnored},
+			},
+			want: []string{"t1"},
+		},
+		{
+			name:  "obsolete with a missing dependency is admitted",
+			input: []models.TestResult{withMissing("t1", models.TestStatusObsolete)},
+			want:  []string{"t1"},
+		},
+		{
+			name: "PASSED with a missing dependency is admitted — this is the silent-green case",
+			input: []models.TestResult{
+				withMissing("t1", models.TestStatusPassed),
+				{TestCaseID: "t2", Status: models.TestStatusPassed},
+			},
+			want: []string{"t1"},
+		},
+		{
+			name:  "IGNORED with a missing dependency is admitted too",
+			input: []models.TestResult{withMissing("t1", models.TestStatusIgnored)},
+			want:  []string{"t1"},
+		},
+		{
+			name: "a test whose dependencies all held stays out, whatever its status",
+			input: []models.TestResult{
+				{TestCaseID: "t1", Status: models.TestStatusObsolete,
+					Result: models.Result{DepResult: []models.DepResult{consumedDepRow()}}},
+				{TestCaseID: "t2", Status: models.TestStatusPassed,
+					Result: models.Result{DepsChecked: true, DepsConsumed: 9}},
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := r.extractFailedTestsFromResults(tt.input)
+			var ids []string
+			for _, g := range got {
+				ids = append(ids, g.TestCaseID)
+			}
+			if len(ids) != len(tt.want) {
+				t.Fatalf("got %v, want %v", ids, tt.want)
+			}
+			for i := range ids {
+				if ids[i] != tt.want[i] {
+					t.Fatalf("got %v, want %v", ids, tt.want)
+				}
+			}
+		})
+	}
+}
+
+// --full uses a different renderer (matcher.DiffsPrinter buffered into the
+// same builder); the dependency block has to reach it too, in the SAME
+// position relative to the response diffs as the compact renderer puts it.
+func TestRenderSingleFullBodyFailedTest_IncludesDependencyBlock(t *testing.T) {
+	r := New(zap.NewNop(), &config.Config{DisableANSI: true}, nil, nil)
+
+	tests := []struct {
+		name     string
+		test     models.TestResult
+		contains []string
+		absent   []string
+	}{
+		{
+			name: "missing dependency is rendered",
+			test: models.TestResult{
+				Kind: models.HTTP, Name: "test-set-0", TestCaseID: "test-1",
+				Status: models.TestStatusFailed,
+				Result: models.Result{
+					StatusCode: models.IntResult{Normal: true},
+					DepResult:  []models.DepResult{missingDepRow()},
+				},
+			},
+			contains: []string{"Testrun failed for test-set-0/test-1", "MISSING deps[0] postgres PostgreSQL INSERT (presence)"},
+		},
+		{
+			name: "no dependencies leaves the output untouched",
+			test: models.TestResult{
+				Kind: models.HTTP, Name: "test-set-0", TestCaseID: "test-2",
+				Status: models.TestStatusFailed,
+				Result: models.Result{StatusCode: models.IntResult{Normal: true}},
+			},
+			absent: []string{"DEPENDENCY ASSERTIONS"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sb strings.Builder
+			if err := r.renderSingleFullBodyFailedTest(context.Background(), &sb, tt.test); err != nil {
+				t.Fatalf("renderSingleFullBodyFailedTest: %v", err)
+			}
+			out := sb.String()
+			for _, want := range tt.contains {
+				if !strings.Contains(out, want) {
+					t.Errorf("output missing %q:\n%s", want, out)
+				}
+			}
+			for _, bad := range tt.absent {
+				if strings.Contains(out, bad) {
+					t.Errorf("output unexpectedly contains %q:\n%s", bad, out)
+				}
+			}
+		})
+	}
+}
+
+// The dependency block must sit AFTER the response diffs in both modes. It
+// used to land before them in --full (the diff printer buffers and only
+// flushes on Render) and after them in compact mode — same data, two positions
+// depending on a flag.
+func TestDependencyBlockPositionIsTheSameInBothModes(t *testing.T) {
+	r := New(zap.NewNop(), &config.Config{DisableANSI: true}, nil, nil)
+	test := models.TestResult{
+		Kind: models.HTTP, Name: "test-set-0", TestCaseID: "test-1",
+		Status: models.TestStatusFailed,
+		Result: models.Result{
+			StatusCode: models.IntResult{Normal: false, Expected: 200, Actual: 500},
+			DepResult:  []models.DepResult{missingDepRow()},
+		},
+	}
+
+	render := func(t *testing.T, full bool) string {
+		t.Helper()
+		var sb strings.Builder
+		var err error
+		if full {
+			err = r.renderSingleFullBodyFailedTest(context.Background(), &sb, test)
+		} else {
+			err = r.renderSingleFailedTest(context.Background(), &sb, test)
+		}
+		if err != nil {
+			t.Fatalf("render(full=%v): %v", full, err)
+		}
+		return sb.String()
+	}
+
+	for _, full := range []bool{false, true} {
+		out := render(t, full)
+		depAt := strings.Index(out, "=== DEPENDENCY ASSERTIONS ===")
+		diffAt := strings.Index(out, "500")
+		if depAt < 0 {
+			t.Fatalf("full=%v: no dependency block:\n%s", full, out)
+		}
+		if diffAt < 0 {
+			t.Fatalf("full=%v: no response diff to order against:\n%s", full, out)
+		}
+		if depAt < diffAt {
+			t.Errorf("full=%v: the dependency block came BEFORE the response diffs (dep@%d, diff@%d):\n%s",
+				full, depAt, diffAt, out)
+		}
+	}
+}
+
+// printTests is the `--test-case` path. A passing test keeps its one-line
+// notice and gains exactly one line when it lost a dependency.
+func TestPrintTests_PassedTestCarriesTheDependencyNotice(t *testing.T) {
+	r := New(zap.NewNop(), &config.Config{DisableANSI: true}, nil, nil)
+	var buf bytes.Buffer
+	r.out = bufio.NewWriter(&buf)
+
+	err := r.printTests(context.Background(), []models.TestResult{
+		{TestCaseID: "clean", Name: "test-set-0", Status: models.TestStatusPassed, TimeTaken: "1ms"},
+		{TestCaseID: "lost-dep", Name: "test-set-0", Status: models.TestStatusPassed, TimeTaken: "2ms",
+			Result: models.Result{DepResult: []models.DepResult{missingDepRow()}}},
+	})
+	if err != nil {
+		t.Fatalf("printTests: %v", err)
+	}
+	out := buf.String()
+
+	if !strings.Contains(out, `Testcase "clean" (test-set-0) PASSED ✅ (1ms)`) {
+		t.Errorf("the historical pass line changed:\n%s", out)
+	}
+	if !strings.Contains(out, `Testcase "lost-dep" (test-set-0) PASSED ✅ (2ms)`) {
+		t.Errorf("a test that lost a dependency must still be reported as PASSED:\n%s", out)
+	}
+	if !strings.Contains(out, models.DepNoticePrefix+" deps[0] postgres PostgreSQL INSERT (presence)") {
+		t.Errorf("the dependency notice is missing:\n%s", out)
+	}
+	// The clean test must not have grown anything.
+	cleanBlock := out[:strings.Index(out, "lost-dep")]
+	if strings.Contains(cleanBlock, models.DepNoticePrefix) {
+		t.Errorf("a clean pass grew a notice:\n%s", cleanBlock)
+	}
+}
+
+// The same one-line path takes EVERY non-FAILED status, and it used to
+// hardcode "PASSED ✅" for all of them. `keploy report --test-case <obsolete>`
+// therefore announced a pass for a demoted test — and once this slice started
+// printing the dependency notice underneath, the two adjacent lines
+// contradicted each other on the one surface a user reached deliberately.
+func TestPrintTests_PrintsTheActualStatusNotAHardcodedPass(t *testing.T) {
+	r := New(zap.NewNop(), &config.Config{DisableANSI: true}, nil, nil)
+	var buf bytes.Buffer
+	r.out = bufio.NewWriter(&buf)
+
+	err := r.printTests(context.Background(), []models.TestResult{
+		{TestCaseID: "passed", Name: "test-set-0", Status: models.TestStatusPassed, TimeTaken: "1ms"},
+		{TestCaseID: "obsolete", Name: "test-set-0", Status: models.TestStatusObsolete, TimeTaken: "5ms"},
+		{TestCaseID: "ignored", Name: "test-set-0", Status: models.TestStatusIgnored, TimeTaken: "0ms"},
+		{TestCaseID: "obsolete-lost-dep", Name: "test-set-0", Status: models.TestStatusObsolete, TimeTaken: "6ms",
+			Result: models.Result{DepResult: []models.DepResult{missingDepRow()}, DepsChecked: true}},
+	})
+	if err != nil {
+		t.Fatalf("printTests: %v", err)
+	}
+	out := buf.String()
+
+	for _, want := range []string{
+		// Byte-identical to pre-slice-4 for the status that actually passed.
+		`Testcase "passed" (test-set-0) PASSED ✅ (1ms)`,
+		`Testcase "obsolete" (test-set-0) OBSOLETE ⚠️ (5ms)`,
+		`Testcase "ignored" (test-set-0) IGNORED ⏭️ (0ms)`,
+		`Testcase "obsolete-lost-dep" (test-set-0) OBSOLETE ⚠️ (6ms)`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q:\n%s", want, out)
+		}
+	}
+
+	// The contradiction itself: the notice must never sit under a line
+	// claiming the test passed.
+	noticeAt := strings.Index(out, models.DepNoticePrefix)
+	if noticeAt < 0 {
+		t.Fatalf("the obsolete test lost its dependency notice:\n%s", out)
+	}
+	head := out[:noticeAt]
+	lastLineStart := strings.LastIndex(strings.TrimRight(head, "\n"), "\n")
+	statusLine := strings.TrimSpace(head[lastLineStart+1:])
+	if strings.Contains(statusLine, "PASSED") {
+		t.Errorf("the dependency notice is printed directly under a line asserting the test passed: %q", statusLine)
+	}
+}
+
+func TestTestStatusLabel(t *testing.T) {
+	for status, want := range map[models.TestStatus]string{
+		models.TestStatusPassed:   "PASSED ✅",
+		models.TestStatusFailed:   "FAILED ❌",
+		models.TestStatusObsolete: "OBSOLETE ⚠️",
+		models.TestStatusIgnored:  "IGNORED ⏭️",
+		models.TestStatus("WAT"):  "WAT",
+	} {
+		if got := testStatusLabel(status); got != want {
+			t.Errorf("testStatusLabel(%s) = %q, want %q", status, got, want)
+		}
+	}
+}
+
+// The summary is the only surface a CI operator reads on a green run.
+func TestPrintSummary_CountsDependenciesAndCategories(t *testing.T) {
+	tests := []struct {
+		name     string
+		reports  map[string]*models.TestReport
+		contains []string
+		absent   []string
+	}{
+		{
+			name: "a green run that lost a dependency says so",
+			reports: map[string]*models.TestReport{
+				"test-set-0": {Total: 2, Success: 2, Tests: []models.TestResult{
+					{TestCaseID: "t1", Status: models.TestStatusPassed,
+						Result: models.Result{DepResult: []models.DepResult{missingDepRow()}}},
+					{TestCaseID: "t2", Status: models.TestStatusPassed},
+				}},
+			},
+			contains: []string{
+				"Dependencies not exercised: 1 test(s)",
+				"1 of them PASSED",
+				// The claim has to match what the data can support. Consumed
+				// mocks are drained when the response comes back, so a call
+				// the app makes AFTER writing its response lands in the next
+				// test's window: keploy can say it did not observe the call
+				// here, not that the app never made it.
+				"not observed during the test's own window",
+				"--assert-dependencies",
+			},
+			absent: []string{"FAILURE RISK DISTRIBUTION", "was never made"},
+		},
+		{
+			name: "DEPENDENCY_MISSING reaches the category block even with no risk and no failure",
+			reports: map[string]*models.TestReport{
+				"test-set-0": {Total: 1, Obsolete: 1, Tests: []models.TestResult{
+					{TestCaseID: "t1", Status: models.TestStatusObsolete,
+						FailureInfo: models.FailureInfo{
+							Category: []models.FailureCategory{models.DependencyMissing},
+						},
+						Result: models.Result{DepResult: []models.DepResult{missingDepRow()}}},
+				}},
+			},
+			contains: []string{"FAILURE CATEGORIES:", "DEPENDENCY_MISSING: 1"},
+		},
+		{
+			name: "a run with nothing missing is untouched",
+			reports: map[string]*models.TestReport{
+				"test-set-0": {Total: 1, Success: 1, Tests: []models.TestResult{
+					{TestCaseID: "t1", Status: models.TestStatusPassed},
+				}},
+			},
+			absent: []string{"Dependencies not exercised", "FAILURE CATEGORIES", "FAILURE RISK DISTRIBUTION"},
+		},
+		{
+			// DELIBERATE, PRE-EXISTING-REPORT BEHAVIOUR CHANGE, pinned so it
+			// stays deliberate. Categories used to be counted only inside
+			// `if Status == FAILED && Risk != ""`. A legacy report whose
+			// failure carries APP_CONNECTION_ERROR with no risk level — the
+			// shape replay.go's app-connection path produces — printed "No
+			// specific categories identified"; it now prints the category. The
+			// per-test header already showed it, so the summary was the odd
+			// one out, but a scraped block did change.
+			name: "a FAILED test with a category and NO risk level is now counted",
+			reports: map[string]*models.TestReport{
+				"test-set-0": {Total: 1, Failure: 1, Tests: []models.TestResult{
+					{TestCaseID: "t1", Status: models.TestStatusFailed,
+						FailureInfo: models.FailureInfo{
+							Category: []models.FailureCategory{models.AppConnectionError},
+						}},
+				}},
+			},
+			contains: []string{"FAILURE CATEGORIES:", "APP_CONNECTION_ERROR: 1"},
+			absent:   []string{"No specific categories identified", "Dependencies not exercised"},
+		},
+		{
+			// The risk block is still risk-gated: a category with no risk must
+			// not invent a High/Medium/Low distribution.
+			name: "counting a risk-less category does not fabricate a risk distribution",
+			reports: map[string]*models.TestReport{
+				"test-set-0": {Total: 1, Failure: 1, Tests: []models.TestResult{
+					{TestCaseID: "t1", Status: models.TestStatusFailed,
+						FailureInfo: models.FailureInfo{
+							Category: []models.FailureCategory{models.AppConnectionError},
+						}},
+				}},
+			},
+			contains: []string{"High Risk: 0", "Medium Risk: 0", "Low Risk: 0"},
+		},
+		{
+			// A PASSED test never grows a failure category (attachDepResults
+			// refuses to label one), so nothing it carries can reach the
+			// failure taxonomy even though its dependency notice is counted.
+			name: "a PASSED test's dependency loss is counted but never becomes a failure category",
+			reports: map[string]*models.TestReport{
+				"test-set-0": {Total: 1, Success: 1, Tests: []models.TestResult{
+					{TestCaseID: "t1", Status: models.TestStatusPassed,
+						Result: models.Result{DepResult: []models.DepResult{missingDepRow()}}},
+				}},
+			},
+			contains: []string{"Dependencies not exercised: 1 test(s)"},
+			absent:   []string{"FAILURE CATEGORIES"},
+		},
+		{
+			// BACKWARD COMPATIBILITY, on data this slice never touched. An
+			// OBSOLETE test's OTHER categories have never been counted, and
+			// counting them would change the numbers under a heading called
+			// FAILURE CATEGORIES for reports written long before slice 4:
+			// SCHEMA_BROKEN would read 2 next to "Total test failed: 1".
+			name: "an OBSOLETE test's non-dependency category does not inflate the count",
+			reports: map[string]*models.TestReport{
+				"test-set-0": {Total: 2, Failure: 1, Obsolete: 1, Tests: []models.TestResult{
+					{TestCaseID: "t1", Status: models.TestStatusFailed,
+						FailureInfo: models.FailureInfo{
+							Category: []models.FailureCategory{models.SchemaBroken},
+						}},
+					{TestCaseID: "t2", Status: models.TestStatusObsolete,
+						FailureInfo: models.FailureInfo{
+							Category: []models.FailureCategory{models.SchemaBroken},
+						}},
+				}},
+			},
+			contains: []string{"Total test failed: 1", "SCHEMA_BROKEN: 1"},
+			absent:   []string{"SCHEMA_BROKEN: 2"},
+		},
+		{
+			// The other half: a report with NO failures must not grow a
+			// FAILURE CATEGORIES block at all just because an obsolete test
+			// carries an unrelated category. `keploy report --summary` on an
+			// unchanged pre-slice-4 report has to stay byte-identical.
+			name: "a zero-failure report grows no category block from an obsolete test",
+			reports: map[string]*models.TestReport{
+				"test-set-0": {Total: 2, Success: 1, Obsolete: 1, Tests: []models.TestResult{
+					{TestCaseID: "t1", Status: models.TestStatusPassed},
+					{TestCaseID: "t2", Status: models.TestStatusObsolete,
+						FailureInfo: models.FailureInfo{
+							Category: []models.FailureCategory{models.SchemaBroken},
+						}},
+				}},
+			},
+			contains: []string{"Total test failed: 0"},
+			absent:   []string{"FAILURE CATEGORIES", "SCHEMA_BROKEN"},
+		},
+		{
+			// The gate reads the report's own `failure` counter, which can
+			// disagree with the statuses in a partially written report. Even
+			// then the ONLY thing that may summon the block on a zero-failure
+			// run is a dependency finding: `len(categoryCounts) > 0` would
+			// print a brand-new three-line section here, on data this slice
+			// never touched.
+			name: "a report whose failure counter is zero prints no block for a non-dependency category",
+			reports: map[string]*models.TestReport{
+				"test-set-0": {Total: 1, Tests: []models.TestResult{
+					{TestCaseID: "t1", Status: models.TestStatusFailed,
+						FailureInfo: models.FailureInfo{
+							Category: []models.FailureCategory{models.SchemaBroken},
+						}},
+				}},
+			},
+			contains: []string{"Total test failed: 0"},
+			absent:   []string{"FAILURE CATEGORIES", "SCHEMA_BROKEN"},
+		},
+		{
+			// THE NUMBER ITSELF, over a population where total != passed.
+			//
+			// Every other row here loses a dependency on PASSED tests only, so
+			// widening `if t.Status == models.TestStatusPassed` in
+			// depNoticeCounts to count every status left the printed numbers
+			// unchanged and the suite green. The claim that mutation breaks is
+			// the load-bearing one: "N of them PASSED — the response matched"
+			// is false for an OBSOLETE or FAILED test, whose response did NOT
+			// match. That is precisely the distinction
+			// replay.unexercisedSummary's doc comment says the wording is
+			// careful about, and this run has one test of each.
+			name: "the PASSED count is the passed subset, not the whole affected population",
+			reports: map[string]*models.TestReport{
+				"test-set-0": {Total: 3, Success: 1, Failure: 1, Obsolete: 1, Tests: []models.TestResult{
+					{TestCaseID: "t-passed", Status: models.TestStatusPassed,
+						Result: models.Result{DepResult: []models.DepResult{missingDepRow()}, DepsChecked: true}},
+					{TestCaseID: "t-obsolete", Status: models.TestStatusObsolete,
+						Result: models.Result{DepResult: []models.DepResult{missingDepRow()}, DepsChecked: true}},
+					{TestCaseID: "t-failed", Status: models.TestStatusFailed,
+						Result: models.Result{DepResult: []models.DepResult{missingDepRow()}, DepsChecked: true}},
+					// A clean PASSED test is in neither number.
+					{TestCaseID: "t-clean", Status: models.TestStatusPassed},
+				}},
+			},
+			contains: []string{
+				"Dependencies not exercised: 3 test(s)",
+				"1 of them PASSED",
+			},
+			absent: []string{
+				// The mutation's output: every affected test counted as passed.
+				"3 of them PASSED",
+				"2 of them PASSED",
+				"4 test(s)",
+			},
+		},
+		{
+			// The other direction: when NONE of the affected tests passed, the
+			// "N of them PASSED" line must not appear at all. Widening the
+			// count would print "2 of them PASSED — the response matched" for
+			// two tests whose response did not match.
+			name: "no passed test among the affected population prints no PASSED line",
+			reports: map[string]*models.TestReport{
+				"test-set-0": {Total: 2, Failure: 1, Obsolete: 1, Tests: []models.TestResult{
+					{TestCaseID: "t-obsolete", Status: models.TestStatusObsolete,
+						Result: models.Result{DepResult: []models.DepResult{missingDepRow()}, DepsChecked: true}},
+					{TestCaseID: "t-failed", Status: models.TestStatusFailed,
+						Result: models.Result{DepResult: []models.DepResult{missingDepRow()}, DepsChecked: true}},
+				}},
+			},
+			contains: []string{"Dependencies not exercised: 2 test(s)"},
+			absent:   []string{"of them PASSED", "the response matched"},
+		},
+		{
+			// ...but a dependency finding on a zero-failure run DOES earn the
+			// block. That is the one new trigger, and the reason the print gate
+			// is not simply `failed > 0`.
+			name: "a zero-failure report with a DEPENDENCY_MISSING obsolete test does print the block",
+			reports: map[string]*models.TestReport{
+				"test-set-0": {Total: 1, Obsolete: 1, Tests: []models.TestResult{
+					{TestCaseID: "t1", Status: models.TestStatusObsolete,
+						FailureInfo: models.FailureInfo{
+							Category: []models.FailureCategory{models.SchemaBroken, models.DependencyMissing},
+						},
+						Result: models.Result{DepResult: []models.DepResult{missingDepRow()}, DepsChecked: true}},
+				}},
+			},
+			contains: []string{"FAILURE CATEGORIES:", "DEPENDENCY_MISSING: 1"},
+			// The obsolete test's OTHER category still does not get counted,
+			// even once the block is on screen.
+			absent: []string{"SCHEMA_BROKEN"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := New(zap.NewNop(), &config.Config{DisableANSI: true}, nil, nil)
+			var buf bytes.Buffer
+			r.out = bufio.NewWriter(&buf)
+			if err := r.printSummary(tt.reports); err != nil {
+				t.Fatalf("printSummary: %v", err)
+			}
+			_ = r.out.Flush()
+			out := buf.String()
+			for _, want := range tt.contains {
+				if !strings.Contains(out, want) {
+					t.Errorf("summary missing %q:\n%s", want, out)
+				}
+			}
+			for _, bad := range tt.absent {
+				if strings.Contains(out, bad) {
+					t.Errorf("summary unexpectedly contains %q:\n%s", bad, out)
+				}
+			}
+		})
+	}
+}

--- a/pkg/service/report/junit.go
+++ b/pkg/service/report/junit.go
@@ -33,6 +33,13 @@ type junitTestCase struct {
 	Time      string        `xml:"time,attr"`
 	Failure   *junitFailure `xml:"failure,omitempty"`
 	Skipped   *junitSkipped `xml:"skipped,omitempty"`
+	// SystemOut carries information that must reach a CI consumer WITHOUT
+	// changing the case's verdict — today, the dependencies a PASSED test
+	// stopped exercising. <system-out> is the JUnit element every consumer
+	// already renders as free text; a <failure> would flip the build red,
+	// which is exactly what --assert-dependencies is for and must not happen
+	// by default.
+	SystemOut string `xml:"system-out,omitempty"`
 }
 
 type junitFailure struct {
@@ -43,6 +50,13 @@ type junitFailure struct {
 
 type junitSkipped struct {
 	Message string `xml:"message,attr,omitempty"`
+	// Text is the element body. Detail belongs HERE, not appended to the
+	// message attribute: the attribute is what Jenkins/GitLab/Buildkite group
+	// and display skipped cases by, so varying it per test would explode a
+	// single "obsolete test case" bucket into one bucket per dependency
+	// combination, and an unbounded attribute (one clause per unconsumed mock)
+	// would put kilobytes on one XML line.
+	Text string `xml:",chardata"`
 }
 
 // generateJUnit writes JUnit XML output for the collected test reports.
@@ -66,6 +80,43 @@ func (r *Report) generateJUnit(reports map[string]*models.TestReport) error {
 }
 
 // buildJUnitSuites converts Keploy TestReports into JUnit XML structs.
+//
+// WHAT JUNIT DELIBERATELY DOES NOT CARRY: the dependency-assertion COVERAGE
+// bit (models.Result.DepsChecked / the NDJSON `dependencies_checked`).
+//
+// A PASSED test whose dependency assertion ran and found nothing missing, and a
+// PASSED test whose assertion never ran at all, both render as
+// `<testcase ...></testcase>` with no <system-out>. They are byte-identical.
+// That is not an oversight to be fixed by adding a property here, and a
+// reviewer should not "fix" it without reading this:
+//
+//   - JUnit never makes a FALSE CLAIM either way. It says nothing about
+//     dependencies for a green test, so a consumer cannot read a coverage
+//     answer out of it and cannot be misled into treating "not checked" as
+//     "checked and clean". The false-green this slice closes lives in the
+//     surfaces that DO make a claim — the report YAML and the NDJSON — and it
+//     is closed there.
+//   - The obvious form (a suite-level
+//     `<property name="keploy.dependencies_checked" value="0/3"/>` emitted
+//     whenever some test in the suite is unchecked) CANNOT be added without
+//     changing the XML of every pre-slice-4 report. A legacy report and a
+//     modern all-unchecked run are indistinguishable on disk — both carry
+//     DepsChecked=false on every test, because the legacy report has no such
+//     field at all — so any rule that fires on "some test is unchecked" fires
+//     on every legacy suite too, and the backward-compatibility contract for
+//     this slice is that a report with no dependency data stays byte-identical.
+//
+// SO: dependency COVERAGE is not expressible in JUnit, and a CI system that
+// consumes only the JUnit artifact cannot learn whether the run's dependency
+// verdict was UNKNOWN — which, for an ordinary recording whose mocks carry no
+// per-test tier tag, is the state EVERY test lands in. Consumers that need the
+// bit must read `keploy report --format json` (`dependencies_checked` per
+// verdict) or the persisted `deps_checked` in the test-set report YAML. The
+// runtime WARN names the reason once per test set.
+//
+// What JUnit DOES carry is the dependency DETAIL when there is any: missing
+// rows reach <failure> on a FAILED case, the <skipped> body on an OBSOLETE one
+// and <system-out> on a green one (see depNonFailureBody).
 func buildJUnitSuites(reports map[string]*models.TestReport) junitTestSuites {
 	var totalTests, totalFailures int
 	var totalDuration time.Duration
@@ -116,10 +167,21 @@ func buildJUnitSuite(name string, rep *models.TestReport) junitTestSuite {
 			tc.Failure = buildFailure(t)
 		case models.TestStatusObsolete:
 			skipped++
-			tc.Skipped = &junitSkipped{Message: "obsolete test case"}
+			tc.Skipped = &junitSkipped{
+				Message: obsoleteSkipMessage,
+				Text:    depNonFailureBody(t.Result.DepResult),
+			}
 		case models.TestStatusIgnored:
 			skipped++
 			tc.Skipped = &junitSkipped{Message: "ignored test case"}
+		default:
+			// PASSED (and anything else that is neither failed nor skipped).
+			// A test whose response still matched while a recorded outgoing
+			// call vanished lands HERE, not on the failed or obsolete arms —
+			// it is the silent-green case the slice exists to expose. It gets
+			// <system-out> so CI shows it without the status flipping;
+			// --assert-dependencies is what turns it into a <failure>.
+			tc.SystemOut = depNonFailureBody(t.Result.DepResult)
 		}
 
 		cases = append(cases, tc)
@@ -163,6 +225,13 @@ func buildFailure(t models.TestResult) *junitFailure {
 		}
 	}
 
+	// Dependency assertions (models.Result.DepResult). Emitted alongside the
+	// body rows so a CI system consuming JUnit sees a vanished outgoing call,
+	// not just a response diff. Additive: DepResult had no writer before
+	// keploy-consumer-design-v2.md §7 slice 4, so this loop is a no-op for
+	// every report produced before it.
+	parts = append(parts, depFailureLines(t.Result.DepResult)...)
+
 	msg := "test assertion failed"
 	if t.FailureInfo.Risk != "" && t.FailureInfo.Risk != models.None {
 		msg = fmt.Sprintf("test assertion failed [%s-RISK]", t.FailureInfo.Risk)
@@ -174,6 +243,66 @@ func buildFailure(t models.TestResult) *junitFailure {
 		Text:    strings.Join(parts, "\n"),
 	}
 }
+
+// depNonFailureBody renders the dependency detail that hangs off a testcase
+// which is NOT red — a <system-out> on a passing case, or the body of an
+// OBSOLETE case's <skipped> element.
+//
+// SAMPLED, unlike buildFailure's list. A FAILED test's <failure> body is where
+// a human goes to read the whole story, so it stays complete; these two are
+// attached to cases a CI system reports as green, and the flagship shape this
+// slice exists to expose makes EVERY recorded dependency of EVERY test missing
+// at once. Measured on 300 PASSED tests that each lost 50 dependencies (a
+// downstream service removed), the uncapped body rendered 2,160,091 bytes of
+// JUnit XML against roughly 25 KB for the same run before this slice — an 85x
+// artifact for a run the CI system reports as passing — while the same report's
+// text block was 3,120 bytes and its summary 1,439, both bounded on purpose.
+//
+// Nothing is lost: the count is exact, and the full per-test rows stay in the
+// report file and in `keploy report --format json`, which is where an
+// exhaustive consumer should read them from anyway.
+//
+// Returns "" when nothing is missing, which keeps every pre-slice-4 report's
+// XML byte-identical.
+func depNonFailureBody(deps []models.DepResult) string {
+	lines := depFailureLines(deps)
+	if len(lines) == 0 {
+		return ""
+	}
+	if len(lines) <= depNoticeTestSampleSize {
+		return strings.Join(lines, "\n")
+	}
+	rest := len(lines) - depNoticeTestSampleSize
+	return strings.Join(lines[:depNoticeTestSampleSize], "\n") +
+		fmt.Sprintf("\n...and %d more dependenc%s not exercised - see the report file or `keploy report --format json`",
+			rest, plural(rest, "y", "ies"))
+}
+
+// depFailureLines renders the failed dependency assertions of a result as one
+// JUnit failure line per failed DepMetaResult.
+func depFailureLines(deps []models.DepResult) []string {
+	var parts []string
+	for _, d := range deps {
+		for _, m := range d.Meta {
+			if m.Normal {
+				continue
+			}
+			key := m.Key
+			if key == "" {
+				key = models.DepKeyPresence
+			}
+			parts = append(parts, fmt.Sprintf("dependency %s [%s] %s: expected %q, got %q",
+				d.Name, d.Type, key, m.Expected, m.Actual))
+		}
+	}
+	return parts
+}
+
+// obsoleteSkipMessage is the historical, FIXED <skipped message> literal for
+// an OBSOLETE test. It is a consumer-visible string contract — CI dashboards
+// group skipped cases by this attribute — so the dependency detail goes in the
+// element body (junitSkipped.Text) instead of being appended here.
+const obsoleteSkipMessage = "obsolete test case"
 
 // fmtSeconds formats a duration as seconds with 3 decimal places (JUnit convention).
 func fmtSeconds(d time.Duration) string {

--- a/pkg/service/report/junit_dep_test.go
+++ b/pkg/service/report/junit_dep_test.go
@@ -1,0 +1,322 @@
+package report
+
+import (
+	"encoding/xml"
+	"strings"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+func TestBuildFailure_IncludesDependencyRows(t *testing.T) {
+	tests := []struct {
+		name     string
+		result   models.TestResult
+		contains []string
+		absent   []string
+	}{
+		{
+			name: "dependency rows appear next to body rows",
+			result: models.TestResult{
+				Kind:   models.HTTP,
+				Status: models.TestStatusFailed,
+				Result: models.Result{
+					StatusCode: models.IntResult{Normal: true},
+					BodyResult: []models.BodyResult{{Normal: false, Type: models.JSON}},
+					DepResult:  []models.DepResult{missingDepRow(), consumedDepRow()},
+				},
+			},
+			contains: []string{
+				"body mismatch (JSON)",
+				`dependency deps[0] postgres PostgreSQL INSERT (presence) [postgres] presence: expected "consumed", got "not consumed"`,
+			},
+			// A row that held is not a failure line.
+			absent: []string{"deps[1] http"},
+		},
+		{
+			name: "no dependency rows leaves the failure text untouched",
+			result: models.TestResult{
+				Kind:   models.HTTP,
+				Status: models.TestStatusFailed,
+				Result: models.Result{
+					StatusCode: models.IntResult{Normal: false, Expected: 200, Actual: 500},
+				},
+			},
+			contains: []string{"status: expected 200, got 500"},
+			absent:   []string{"dependency"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := buildFailure(tt.result)
+			if f == nil {
+				t.Fatal("buildFailure returned nil")
+			}
+			for _, want := range tt.contains {
+				if !strings.Contains(f.Text, want) {
+					t.Errorf("failure text missing %q:\n%s", want, f.Text)
+				}
+			}
+			for _, bad := range tt.absent {
+				if strings.Contains(f.Text, bad) {
+					t.Errorf("failure text unexpectedly contains %q:\n%s", bad, f.Text)
+				}
+			}
+		})
+	}
+}
+
+// The <skipped message> attribute is what CI dashboards group and display
+// skipped cases by, so it must stay the historical literal no matter what the
+// test's dependencies did; the detail belongs in the element body.
+func TestObsoleteSkipMessageIsAFixedLiteral(t *testing.T) {
+	cases := []struct {
+		name     string
+		result   models.TestResult
+		wantBody string
+	}{
+		{
+			name:   "nothing missing: empty body",
+			result: models.TestResult{Status: models.TestStatusObsolete},
+		},
+		{
+			name: "every dependency held: empty body",
+			result: models.TestResult{Status: models.TestStatusObsolete,
+				Result: models.Result{DepResult: []models.DepResult{consumedDepRow()}}},
+		},
+		{
+			name: "missing dependency lands in the body, not the attribute",
+			result: models.TestResult{Status: models.TestStatusObsolete,
+				Result: models.Result{DepResult: []models.DepResult{missingDepRow()}}},
+			wantBody: `dependency deps[0] postgres PostgreSQL INSERT (presence) [postgres] presence: expected "consumed", got "not consumed"`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			suite := buildJUnitSuite("test-set-0", &models.TestReport{
+				Total: 1, Tests: []models.TestResult{tc.result},
+			})
+			if len(suite.Cases) != 1 || suite.Cases[0].Skipped == nil {
+				t.Fatalf("expected one skipped case, got %+v", suite.Cases)
+			}
+			skipped := suite.Cases[0].Skipped
+			if skipped.Message != "obsolete test case" {
+				t.Errorf("skip message attribute changed to %q; it is a consumer-visible grouping key", skipped.Message)
+			}
+			if skipped.Text != tc.wantBody {
+				t.Errorf("skip body = %q, want %q", skipped.Text, tc.wantBody)
+			}
+		})
+	}
+}
+
+// The flagship silent-green case: the response still matched, so the test is
+// PASSED, but a recorded outgoing call vanished. It must reach a CI consumer
+// WITHOUT the status flipping — that flip is what --assert-dependencies is for.
+func TestBuildJUnitSuite_PassedWithMissingDependencyGetsSystemOut(t *testing.T) {
+	suite := buildJUnitSuite("test-set-0", &models.TestReport{
+		Total: 2,
+		Tests: []models.TestResult{
+			{
+				Kind: models.HTTP, TestCaseID: "tc-passed", Status: models.TestStatusPassed,
+				Result: models.Result{DepResult: []models.DepResult{missingDepRow()}, DepsChecked: true, DepsConsumed: 3},
+			},
+			{
+				Kind: models.HTTP, TestCaseID: "tc-clean", Status: models.TestStatusPassed,
+				Result: models.Result{DepsChecked: true, DepsConsumed: 3},
+			},
+		},
+	})
+
+	if suite.Failures != 0 {
+		t.Fatalf("a reported-only dependency must not create a failure: %d", suite.Failures)
+	}
+	if suite.Skipped != 0 {
+		t.Fatalf("a reported-only dependency must not skip the case: %d", suite.Skipped)
+	}
+
+	byName := map[string]junitTestCase{}
+	for _, c := range suite.Cases {
+		byName[c.Name] = c
+	}
+
+	lost := byName["tc-passed"]
+	if lost.Failure != nil || lost.Skipped != nil {
+		t.Errorf("tc-passed must stay a clean pass: %+v", lost)
+	}
+	if !strings.Contains(lost.SystemOut, "deps[0] postgres PostgreSQL INSERT (presence)") {
+		t.Errorf("tc-passed lost its dependency notice; system-out = %q", lost.SystemOut)
+	}
+
+	if clean := byName["tc-clean"]; clean.SystemOut != "" {
+		t.Errorf("a test whose dependencies all held must stay byte-identical: system-out = %q", clean.SystemOut)
+	}
+
+	data, err := xml.MarshalIndent(suite, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	out := string(data)
+	if !strings.Contains(out, "<system-out>") {
+		t.Errorf("system-out did not survive marshalling:\n%s", out)
+	}
+	if strings.Contains(out, "<failure") {
+		t.Errorf("a reported-only dependency emitted a <failure>:\n%s", out)
+	}
+}
+
+func TestBuildJUnitSuites_DependencyRowsSurviveMarshalling(t *testing.T) {
+	reports := map[string]*models.TestReport{
+		"test-set-0": {
+			TestSet: "test-set-0",
+			Total:   3,
+			Tests: []models.TestResult{
+				{
+					Kind: models.HTTP, TestCaseID: "test-1", Status: models.TestStatusFailed,
+					Result: models.Result{
+						StatusCode: models.IntResult{Normal: true},
+						DepResult:  []models.DepResult{missingDepRow()},
+					},
+				},
+				{
+					Kind: models.HTTP, TestCaseID: "test-2", Status: models.TestStatusObsolete,
+					Result: models.Result{DepResult: []models.DepResult{missingDepRow()}},
+				},
+				{
+					Kind: models.HTTP, TestCaseID: "test-3", Status: models.TestStatusPassed,
+					Result: models.Result{DepResult: []models.DepResult{missingDepRow()}},
+				},
+			},
+		},
+	}
+
+	data, err := xml.MarshalIndent(buildJUnitSuites(reports), "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	out := string(data)
+
+	for _, want := range []string{
+		"deps[0] postgres PostgreSQL INSERT (presence)",
+		`<skipped message="obsolete test case">`,
+		`<failure message="test assertion failed"`,
+		"<system-out>",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("junit xml missing %q:\n%s", want, out)
+		}
+	}
+	// The message attribute must not have grown the dependency detail.
+	if strings.Contains(out, `message="obsolete test case: `) {
+		t.Errorf("the skipped message attribute grew per-test detail:\n%s", out)
+	}
+}
+
+// THE ASYMMETRY THE BOUNDING PASS MISSED. The text block is grouped by
+// dependency and double-capped, and the persisted YAML is capped at 50 rows per
+// test, but the JUnit body hanging off GREEN testcases was one line per failed
+// assertion with no cap of its own.
+//
+// Measured on the slice's own flagship shape — 300 PASSED tests that each lost
+// 50 recorded dependencies, i.e. a downstream service removed — the same report
+// rendered 3,120 B of text and 1,439 B of summary but 2,160,091 B of JUnit XML,
+// all of it on testcases the CI system reports as passing.
+func TestBuildJUnitSuite_NonFailureBodyIsCapped(t *testing.T) {
+	rows := make([]models.DepResult, 0, 50)
+	for i := range 50 {
+		rows = append(rows, models.DepResult{
+			Name: models.DepRowName(i, models.DepTypePostgres, "db:5432 SELECT"),
+			Type: models.DepTypePostgres,
+			Meta: []models.DepMetaResult{{
+				Normal: false, Key: models.DepKeyPresence,
+				Expected: models.DepPresenceConsumed, Actual: models.DepPresenceMissing,
+			}},
+		})
+	}
+
+	suite := buildJUnitSuite("test-set-0", &models.TestReport{
+		Total: 2,
+		Tests: []models.TestResult{
+			{
+				Kind: models.HTTP, TestCaseID: "tc-passed", Status: models.TestStatusPassed,
+				Result: models.Result{DepResult: rows, DepsChecked: true},
+			},
+			{
+				Kind: models.HTTP, TestCaseID: "tc-obsolete", Status: models.TestStatusObsolete,
+				Result: models.Result{DepResult: rows, DepsChecked: true},
+			},
+		},
+	})
+
+	byName := map[string]junitTestCase{}
+	for _, c := range suite.Cases {
+		byName[c.Name] = c
+	}
+
+	bodies := map[string]string{
+		"<system-out> on a green case": byName["tc-passed"].SystemOut,
+		"<skipped> body on an obsolete case": func() string {
+			if s := byName["tc-obsolete"].Skipped; s != nil {
+				return s.Text
+			}
+			return ""
+		}(),
+	}
+	for what, body := range bodies {
+		lines := strings.Split(body, "\n")
+		// depNoticeTestSampleSize named rows + the "...and N more" line.
+		if len(lines) != depNoticeTestSampleSize+1 {
+			t.Errorf("%s rendered %d lines for 50 missing dependencies, want %d — an uncapped body "+
+				"turns a green 300-test run into a 2 MB JUnit artifact:\n%s",
+				what, len(lines), depNoticeTestSampleSize+1, body)
+		}
+		// The count stays EXACT even though the listing is sampled.
+		if !strings.Contains(body, "...and 45 more dependencies not exercised") {
+			t.Errorf("%s lost the exact remainder:\n%s", what, body)
+		}
+		if !strings.Contains(body, "deps[0] postgres db:5432 SELECT (presence)") {
+			t.Errorf("%s dropped the first offender:\n%s", what, body)
+		}
+	}
+
+	// A FAILED test's <failure> body is where a human reads the whole story,
+	// so it is deliberately NOT sampled.
+	full := buildFailure(models.TestResult{
+		Kind: models.HTTP, TestCaseID: "tc-failed", Status: models.TestStatusFailed,
+		Result: models.Result{
+			StatusCode: models.IntResult{Normal: true, Expected: 200, Actual: 200},
+			DepResult:  rows, DepsChecked: true,
+		},
+	})
+	if got := len(strings.Split(full.Text, "\n")); got != 50 {
+		t.Errorf("a FAILED test's <failure> body carries %d lines, want all 50", got)
+	}
+}
+
+// A report with nothing missing must render byte-identical XML: no
+// <system-out> element at all, and an OBSOLETE case's <skipped> stays
+// self-closing rather than growing an empty body.
+func TestBuildJUnitSuite_NonFailureBodyIsEmptyWhenNothingIsMissing(t *testing.T) {
+	suites := buildJUnitSuites(map[string]*models.TestReport{"test-set-0": {
+		Total: 2,
+		Tests: []models.TestResult{
+			{Kind: models.HTTP, TestCaseID: "tc-passed", Status: models.TestStatusPassed,
+				Result: models.Result{DepsChecked: true, DepsConsumed: 12}},
+			{Kind: models.HTTP, TestCaseID: "tc-obsolete", Status: models.TestStatusObsolete,
+				Result: models.Result{DepsChecked: true, DepsConsumed: 12}},
+		},
+	}})
+	data, err := xml.MarshalIndent(suites, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "system-out") {
+		t.Errorf("a nothing-missing report grew a <system-out>:\n%s", data)
+	}
+	if !strings.Contains(string(data), `<skipped message="obsolete test case">`) &&
+		!strings.Contains(string(data), `<skipped message="obsolete test case"></skipped>`) {
+		t.Errorf("the obsolete skip element changed:\n%s", data)
+	}
+}

--- a/pkg/service/report/legacy_report_golden_test.go
+++ b/pkg/service/report/legacy_report_golden_test.go
@@ -1,0 +1,529 @@
+package report
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"flag"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/config"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+)
+
+const legacyReportPath = "testdata/legacy-report.yaml"
+
+// cleanDepsReportPath is the same report as written by a POST-slice-4 keploy
+// in instrument+mapping mode where every test lost nothing. It is checked in
+// for one reason: the nothing-missing case is the exact case the backward-
+// compatibility constraint singled out, and it is the one case whose bytes DO
+// change — by exactly the two scalars `deps_checked` / `deps_consumed`, with
+// `dep_result: []` unchanged. Pinning it makes that deliberate rather than
+// incidental, and shows exactly what the change is.
+const cleanDepsReportPath = "testdata/clean-deps-report.yaml"
+
+// updateGolden regenerates testdata/legacy-report.yaml FROM THE REAL STRUCTS:
+//
+//	go test ./pkg/service/report/... -run TestLegacyReport -update-golden
+//
+// The fixture is checked in and compared byte-for-byte by the tests below, so
+// it still pins the on-disk shape; generating it removes the class of bug a
+// hand-authored fixture invites (the previous version declared total: 2 while
+// carrying three tests, and could not have been produced by any keploy run).
+var updateGolden = flag.Bool("update-golden", false, "rewrite testdata/legacy-report.yaml from legacyReportFixture()")
+
+// legacyReportFixture is a report as a PRE-SLICE-4 keploy would have written
+// it: three tests (passed, failed, obsolete) and `dep_result: []` on every one,
+// because models.Result.DepResult had a declaration and no writer.
+//
+// Counters are derived from the tests rather than typed in, so the fixture
+// cannot be internally inconsistent.
+func legacyReportFixture() *models.TestReport {
+	req := func(method models.Method, url string, body string, header map[string]string) models.HTTPReq {
+		return models.HTTPReq{
+			Method: method, ProtoMajor: 1, ProtoMinor: 1, URL: url,
+			Header: header, Body: body, Timestamp: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
+		}
+	}
+	resp := func(code int, body string, header map[string]string) models.HTTPResp {
+		return models.HTTPResp{
+			StatusCode: code, Header: header, Body: body,
+			Timestamp: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
+		}
+	}
+
+	tests := []models.TestResult{
+		{
+			Kind: models.HTTP, Name: "test-set-0", Status: models.TestStatusPassed,
+			Started: 1755861852, Completed: 1755861853,
+			TestCasePath: "/keploy/test-set-0", MockPath: "/keploy/test-set-0/mocks.yaml",
+			TestCaseID: "test-1",
+			Req:        req("GET", "http://localhost:8080/orders/1", "", map[string]string{"Accept": "application/json"}),
+			Res:        resp(200, `{"id":1,"status":"CONFIRMED"}`, map[string]string{"Content-Type": "application/json"}),
+			Result: models.Result{
+				StatusCode: models.IntResult{Normal: true, Expected: 200, Actual: 200},
+				BodyResult: []models.BodyResult{{
+					Normal: true, Type: models.JSON,
+					Expected: `{"id":1,"status":"CONFIRMED"}`, Actual: `{"id":1,"status":"CONFIRMED"}`,
+				}},
+			},
+			TimeTaken: "12.3ms",
+		},
+		{
+			Kind: models.HTTP, Name: "test-set-0", Status: models.TestStatusFailed,
+			Started: 1755861854, Completed: 1755861855,
+			TestCasePath: "/keploy/test-set-0", MockPath: "/keploy/test-set-0/mocks.yaml",
+			TestCaseID: "test-2",
+			Req:        req("POST", "http://localhost:8080/orders", `{"sku":"SKU-9","qty":3}`, map[string]string{"Content-Type": "application/json"}),
+			Res:        resp(500, `{"error":"boom"}`, map[string]string{"Content-Type": "application/json"}),
+			Result: models.Result{
+				StatusCode: models.IntResult{Normal: false, Expected: 201, Actual: 500},
+				BodyResult: []models.BodyResult{{
+					Normal: false, Type: models.JSON,
+					Expected: `{"id":2,"status":"CONFIRMED"}`, Actual: `{"error":"boom"}`,
+				}},
+			},
+			TimeTaken: "8.1ms",
+		},
+		{
+			Kind: models.HTTP, Name: "test-set-0", Status: models.TestStatusObsolete,
+			Started: 1755861856, Completed: 1755861857,
+			TestCasePath: "/keploy/test-set-0", MockPath: "/keploy/test-set-0/mocks.yaml",
+			TestCaseID: "test-3",
+			Req:        req("GET", "http://localhost:8080/orders/9", "", map[string]string{}),
+			Res:        resp(404, `{"error":"not found"}`, map[string]string{}),
+			Result: models.Result{
+				StatusCode: models.IntResult{Normal: false, Expected: 200, Actual: 404},
+			},
+			TimeTaken: "5.0ms",
+		},
+	}
+
+	rep := &models.TestReport{
+		Version:   "api.keploy.io/v1beta1",
+		Name:      "test-set-0-report",
+		Status:    string(models.TestSetStatusFailed),
+		Total:     len(tests),
+		TestSet:   "test-set-0",
+		CreatedAt: 1755861860,
+		TimeTaken: "25.4ms",
+		Tests:     tests,
+	}
+	for _, t := range tests {
+		switch t.Status {
+		case models.TestStatusPassed:
+			rep.Success++
+		case models.TestStatusFailed:
+			rep.Failure++
+		case models.TestStatusIgnored:
+			rep.Ignored++
+		case models.TestStatusObsolete:
+			rep.Obsolete++
+		}
+	}
+	return rep
+}
+
+// cleanDepsReportFixture is legacyReportFixture() as the current replayer
+// writes it when the dependency assertion RAN and every test lost nothing: two
+// scalars per test, NO rows at all, no categories, no status change.
+func cleanDepsReportFixture() *models.TestReport {
+	rep := legacyReportFixture()
+	for i := range rep.Tests {
+		rep.Tests[i].Result.DepsChecked = true
+		rep.Tests[i].Result.DepsConsumed = 3 + i
+	}
+	return rep
+}
+
+func loadLegacyReport(t *testing.T) ([]byte, *models.TestReport) {
+	t.Helper()
+	raw, err := os.ReadFile(legacyReportPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", legacyReportPath, err)
+	}
+	var rep models.TestReport
+	if err := yaml.Unmarshal(raw, &rep); err != nil {
+		t.Fatalf("unmarshal %s: %v", legacyReportPath, err)
+	}
+	return raw, &rep
+}
+
+// A report written before models.Result.DepResult had any writer must
+// round-trip byte-for-byte. This is the on-disk backward-compatibility pin for
+// keploy-consumer-design-v2.md §7 slice 4: DepResult carries NO omitempty, so
+// every existing report already serializes `dep_result: []`, and the schema
+// does not change at all. Adding omitempty — or renaming/reordering any field
+// on TestReport / TestResult / Result — breaks this test, which is the point.
+func TestLegacyReportRoundTripsByteIdentically(t *testing.T) {
+	if *updateGolden {
+		out, err := yaml.Marshal(legacyReportFixture())
+		if err != nil {
+			t.Fatalf("marshal fixture: %v", err)
+		}
+		if err := os.WriteFile(legacyReportPath, out, 0o644); err != nil {
+			t.Fatalf("write %s: %v", legacyReportPath, err)
+		}
+		t.Logf("regenerated %s (%d bytes)", legacyReportPath, len(out))
+	}
+
+	raw, rep := loadLegacyReport(t)
+
+	out, err := yaml.Marshal(rep)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(out) != string(raw) {
+		t.Fatalf("legacy report did not round-trip byte-identically.\n--- on disk ---\n%s\n--- re-marshalled ---\n%s", raw, out)
+	}
+}
+
+// The checked-in bytes must be exactly what the struct fixture produces, so
+// the file cannot drift into a state no keploy run could emit (the previous
+// hand-authored version declared total: 2 while carrying three tests).
+func TestLegacyReportFixtureMatchesTheStructs(t *testing.T) {
+	raw, _ := loadLegacyReport(t)
+	want, err := yaml.Marshal(legacyReportFixture())
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	if string(raw) != string(want) {
+		t.Fatalf("testdata/legacy-report.yaml is stale. Regenerate it:\n"+
+			"  go test ./pkg/service/report/... -run TestLegacyReport -update-golden\n"+
+			"--- on disk ---\n%s\n--- from structs ---\n%s", raw, want)
+	}
+}
+
+// The fixture's own counters must agree with its tests.
+func TestLegacyReportFixtureIsInternallyConsistent(t *testing.T) {
+	_, rep := loadLegacyReport(t)
+	if rep.Total != len(rep.Tests) {
+		t.Errorf("total = %d but the report carries %d tests", rep.Total, len(rep.Tests))
+	}
+	var pass, fail, obsolete int
+	for _, test := range rep.Tests {
+		switch test.Status {
+		case models.TestStatusPassed:
+			pass++
+		case models.TestStatusFailed:
+			fail++
+		case models.TestStatusObsolete:
+			obsolete++
+		}
+	}
+	if rep.Success != pass || rep.Failure != fail || rep.Obsolete != obsolete {
+		t.Errorf("counters (success=%d failure=%d obsolete=%d) disagree with the tests (%d/%d/%d)",
+			rep.Success, rep.Failure, rep.Obsolete, pass, fail, obsolete)
+	}
+}
+
+// dep_result must stay present-and-empty rather than disappearing: k8s-proxy's
+// report-download handler reads the key, and an absent key is a schema change
+// for every consumer of every report ever written.
+func TestLegacyReportKeepsEmptyDepResultKey(t *testing.T) {
+	raw, rep := loadLegacyReport(t)
+
+	if !strings.Contains(string(raw), "dep_result: []") {
+		t.Fatal("fixture is not a pre-slice-4 report: it has no empty dep_result key")
+	}
+	for _, test := range rep.Tests {
+		if len(test.Result.DepResult) != 0 {
+			t.Fatalf("fixture test %q unexpectedly carries dependency rows", test.TestCaseID)
+		}
+		data, err := json.Marshal(test.Result)
+		if err != nil {
+			t.Fatalf("marshal result for %q: %v", test.TestCaseID, err)
+		}
+		if !strings.Contains(string(data), `"dep_result"`) {
+			t.Errorf("dep_result key vanished from the JSON projection of %q: %s", test.TestCaseID, data)
+		}
+	}
+}
+
+// Every renderer must produce exactly what it produced before this slice for a
+// report with no dependency rows.
+func TestLegacyReportRenderersAreUnchanged(t *testing.T) {
+	_, rep := loadLegacyReport(t)
+	r := New(zap.NewNop(), &config.Config{DisableANSI: true}, nil, nil)
+
+	t.Run("cli renderer emits no dependency block", func(t *testing.T) {
+		for _, test := range rep.Tests {
+			var sb strings.Builder
+			if err := r.renderSingleFailedTest(context.Background(), &sb, test); err != nil {
+				t.Fatalf("renderSingleFailedTest(%s): %v", test.TestCaseID, err)
+			}
+			out := sb.String()
+			if strings.Contains(out, "DEPENDENCY ASSERTIONS") || strings.Contains(out, models.DepNoticePrefix) {
+				t.Errorf("test %q grew a dependency block:\n%s", test.TestCaseID, out)
+			}
+			// The historical header is FAILED-only wording; obsolete tests were
+			// never rendered before, so only FAILED wording is pinned here.
+			if test.Status == models.TestStatusFailed &&
+				!strings.Contains(out, "Testrun failed for "+test.Name+"/"+test.TestCaseID) {
+				t.Errorf("failed test %q lost its historical header:\n%s", test.TestCaseID, out)
+			}
+		}
+	})
+
+	t.Run("failed-test collector still admits only FAILED", func(t *testing.T) {
+		got := r.extractFailedTestsFromResults(rep.Tests)
+		if len(got) != 1 || got[0].TestCaseID != "test-2" {
+			ids := make([]string, 0, len(got))
+			for _, g := range got {
+				ids = append(ids, g.TestCaseID)
+			}
+			t.Fatalf("collector returned %v, want [test-2] (the only FAILED test)", ids)
+		}
+	})
+
+	t.Run("junit output carries no dependency text and keeps the skip literal", func(t *testing.T) {
+		data, err := xml.MarshalIndent(buildJUnitSuites(map[string]*models.TestReport{"test-set-0": rep}), "", "  ")
+		if err != nil {
+			t.Fatalf("marshal junit: %v", err)
+		}
+		out := string(data)
+		if strings.Contains(out, "dependency ") {
+			t.Errorf("junit output grew dependency lines:\n%s", out)
+		}
+		if strings.Contains(out, "<system-out>") {
+			t.Errorf("junit output grew a system-out element for a legacy report:\n%s", out)
+		}
+		if !strings.Contains(out, `<skipped message="obsolete test case">`) {
+			t.Errorf("obsolete skip message changed:\n%s", out)
+		}
+	})
+
+	t.Run("ndjson projection reports empty effects", func(t *testing.T) {
+		verdicts := buildTestVerdicts("test-run-0", map[string]*models.TestReport{"test-set-0": rep})
+		if len(verdicts) != len(rep.Tests) {
+			t.Fatalf("got %d verdicts, want %d", len(verdicts), len(rep.Tests))
+		}
+		for _, v := range verdicts {
+			if len(v.Effects) != 0 {
+				t.Errorf("test %q has effects for a legacy report: %+v", v.TestCaseID, v.Effects)
+			}
+			if v.FailureCategories != nil {
+				t.Errorf("test %q grew failure categories: %v", v.TestCaseID, v.FailureCategories)
+			}
+		}
+	})
+}
+
+// A per-test-set report is written to disk, re-read by `keploy report` and
+// uploaded to the fleet report store, so the per-dependency cost of the
+// default mode is a shipping constraint, not a detail. One dependency row is
+// ~190 bytes of YAML; the aggregate is one row no matter how many
+// dependencies a test consumed.
+func TestDependencyRowsDoNotBloatThePersistedReport(t *testing.T) {
+	base := legacyReportFixture()
+	baseline, err := yaml.Marshal(base)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	withDeps := legacyReportFixture()
+	// 200 consumed dependencies + 1 missing, the shape a Postgres-chatty test
+	// produces, in the DEFAULT (knob off) mode.
+	withDeps.Tests[0].Result.DepsChecked = true
+	withDeps.Tests[0].Result.DepsConsumed = 200
+	withDeps.Tests[0].Result.DepResult = []models.DepResult{
+		{
+			Name: "deps[0] postgres PostgreSQL INSERT (presence)", Type: "postgres",
+			Meta: []models.DepMetaResult{{
+				Normal: false, Key: models.DepKeyPresence,
+				Expected: models.DepPresenceConsumed, Actual: models.DepPresenceMissing,
+			}},
+		},
+	}
+	grown, err := yaml.Marshal(withDeps)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	const maxGrowth = 320 // one missing row + two scalars, with slack for indentation
+	if delta := len(grown) - len(baseline); delta > maxGrowth {
+		t.Fatalf("a test consuming 200 dependencies grew the report by %d bytes (max %d). "+
+			"Per-dependency matched rows must not be persisted, in any mode — see "+
+			"models.Result.DepResult for the 3-11 MB/report measurement.",
+			delta, maxGrowth)
+	}
+}
+
+// The nothing-missing report: the one case where this slice changes the bytes
+// of a report that would otherwise be identical.
+//
+// Regenerate with:
+//
+//	go test ./pkg/service/report/... -run TestCleanDeps -update-golden
+func TestCleanDepsReportRoundTripsByteIdentically(t *testing.T) {
+	if *updateGolden {
+		out, err := yaml.Marshal(cleanDepsReportFixture())
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if err := os.WriteFile(cleanDepsReportPath, out, 0o644); err != nil {
+			t.Fatalf("write %s: %v", cleanDepsReportPath, err)
+		}
+		t.Logf("regenerated %s (%d bytes)", cleanDepsReportPath, len(out))
+		return
+	}
+
+	raw, err := os.ReadFile(cleanDepsReportPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", cleanDepsReportPath, err)
+	}
+	var rep models.TestReport
+	if err := yaml.Unmarshal(raw, &rep); err != nil {
+		t.Fatalf("unmarshal %s: %v", cleanDepsReportPath, err)
+	}
+	out, err := yaml.Marshal(&rep)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(out) != string(raw) {
+		t.Fatalf("the nothing-missing report no longer round-trips byte-identically.\n"+
+			"Regenerate with -update-golden if the change is deliberate.\n--- got ---\n%s\n--- want ---\n%s",
+			out, raw)
+	}
+
+	want, err := yaml.Marshal(cleanDepsReportFixture())
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	if string(want) != string(raw) {
+		t.Fatalf("%s has drifted from the structs; regenerate it with -update-golden", cleanDepsReportPath)
+	}
+}
+
+// What "nothing is missing" must look like, and must keep looking like: ZERO
+// dependency rows, the checked bit set, nothing failed, no category, and STATUS
+// UNCHANGED from the legacy report.
+func TestCleanDepsReportShape(t *testing.T) {
+	rep := cleanDepsReportFixture()
+	legacy := legacyReportFixture()
+
+	for i, tr := range rep.Tests {
+		if got := len(tr.Result.DepResult); got != 0 {
+			t.Fatalf("test %q carries %d dependency rows; a nothing-missing test must carry NONE — "+
+				"rows are for missing dependencies only:\n%+v",
+				tr.TestCaseID, got, tr.Result.DepResult)
+		}
+		if tr.Result.HasMissingDeps() {
+			t.Errorf("test %q reports a missing dependency in the nothing-missing fixture", tr.TestCaseID)
+		}
+		if !tr.Result.DependenciesChecked() {
+			t.Errorf("test %q must read as CHECKED; that is what deps_checked is for", tr.TestCaseID)
+		}
+		if tr.Result.DepsConsumed == 0 {
+			t.Errorf("test %q lost its consumed count", tr.TestCaseID)
+		}
+		if tr.Status != legacy.Tests[i].Status {
+			t.Errorf("test %q status changed from %s to %s — nothing-missing must not touch the verdict",
+				tr.TestCaseID, legacy.Tests[i].Status, tr.Status)
+		}
+		if len(tr.FailureInfo.Category) != len(legacy.Tests[i].FailureInfo.Category) {
+			t.Errorf("test %q grew a failure category with nothing missing: %v",
+				tr.TestCaseID, tr.FailureInfo.Category)
+		}
+	}
+	if rep.Status != legacy.Status || rep.Success != legacy.Success ||
+		rep.Failure != legacy.Failure || rep.Obsolete != legacy.Obsolete {
+		t.Errorf("the test-set counters changed: %+v vs %+v", rep, legacy)
+	}
+}
+
+// The measured price of making "checked and clean" distinguishable from "never
+// checked" on disk.
+//
+// This is the ONE surface the hard backward-compatibility constraint touches:
+// statuses, exit codes, stdout, JUnit XML and --json are byte-identical for a
+// nothing-missing run, and the report file grows by exactly two short scalar
+// keys. An earlier revision of this slice encoded the same one bit as an
+// unconditionally-persisted aggregate DepResult row, measured at +224 bytes per
+// test on EVERY report, forever, uploaded to the fleet report store. The bound
+// below is what keeps it from creeping back.
+func TestCleanDepsReportGrowthIsOneAggregateRowPerTest(t *testing.T) {
+	baseline, err := yaml.Marshal(legacyReportFixture())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	grown, err := yaml.Marshal(cleanDepsReportFixture())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// `dep_result: []` must survive verbatim: k8s-proxy's report-download
+	// handler reads the key, and a nothing-missing test must not start
+	// carrying rows again.
+	if strings.Contains(string(grown), "deps[") {
+		t.Fatalf("a nothing-missing report persisted a dependency row:\n%s", grown)
+	}
+	if !strings.Contains(string(grown), "dep_result: []") {
+		t.Fatalf("a nothing-missing report lost the pre-slice-4 `dep_result: []`:\n%s", grown)
+	}
+
+	n := len(legacyReportFixture().Tests)
+	delta := len(grown) - len(baseline)
+	perTest := delta / n
+	// Two scalar keys at report indentation. The deleted aggregate row cost
+	// 224; anything approaching that is the row coming back in disguise.
+	const maxPerTest = 64
+	if perTest > maxPerTest {
+		t.Fatalf("a nothing-missing report grew by %d bytes per test (max %d): %d bytes over %d tests. "+
+			"Encoding 'checked, N consumed' costs one bit and one small int; a nested row is 224.",
+			perTest, maxPerTest, delta, n)
+	}
+	t.Logf("nothing-missing growth: %d bytes total, %d bytes/test over %d tests", delta, perTest, n)
+}
+
+// The renderers must stay silent for a nothing-missing report: no dependency
+// block, no notice, no summary counter. Everything a user sees is unchanged.
+func TestCleanDepsReportRendersNothingNew(t *testing.T) {
+	rep := cleanDepsReportFixture()
+
+	for _, tr := range rep.Tests {
+		var sb strings.Builder
+		renderDepResults(&sb, tr)
+		if sb.Len() != 0 {
+			t.Errorf("test %q rendered a dependency block with nothing missing:\n%s", tr.TestCaseID, sb.String())
+		}
+		if got := models.FormatDepNotice(tr.Result.DepResult); got != "" {
+			t.Errorf("test %q produced a notice with nothing missing: %q", tr.TestCaseID, got)
+		}
+		if tr.Status != models.TestStatusFailed && shouldRenderDiff(tr) {
+			t.Errorf("test %q was admitted to the per-test renderer with nothing missing", tr.TestCaseID)
+		}
+	}
+
+	total, passed := depNoticeCounts(map[string]*models.TestReport{"test-set-0": rep})
+	if total != 0 || passed != 0 {
+		t.Errorf("the summary counted %d/%d dependency notices with nothing missing", passed, total)
+	}
+
+	// JUnit: no <system-out>, no dependency lines in the failure body.
+	suites := buildJUnitSuites(map[string]*models.TestReport{"test-set-0": rep})
+	out, err := xml.MarshalIndent(suites, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal junit: %v", err)
+	}
+	if strings.Contains(string(out), "system-out") || strings.Contains(string(out), "dependency ") {
+		t.Errorf("JUnit grew dependency output for a nothing-missing report:\n%s", out)
+	}
+
+	// NDJSON: checked, and no failed effect.
+	for _, v := range buildTestVerdicts("run-1", map[string]*models.TestReport{"test-set-0": rep}) {
+		if !v.DependenciesChecked {
+			t.Errorf("%s: dependencies_checked must be true", v.TestCaseID)
+		}
+		for _, e := range v.Effects {
+			if !e.Matched {
+				t.Errorf("%s: unexpected failed effect %+v", v.TestCaseID, e)
+			}
+		}
+	}
+}

--- a/pkg/service/report/ndjson.go
+++ b/pkg/service/report/ndjson.go
@@ -1,0 +1,267 @@
+package report
+
+import (
+	"fmt"
+	"io"
+	"sort"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.keploy.io/server/v3/utils"
+)
+
+// EffectsSchemaVersion is the version of the `keploy report --format json`
+// projection defined below. It is part of the agent contract: bump it only for
+// a BREAKING change (a field removed, renamed, or given a different meaning).
+// Adding a new optional field is not breaking and must not bump it.
+const EffectsSchemaVersion = "1"
+
+// `keploy report --format json` emits NDJSON: one self-contained JSON object
+// per test result, newline-delimited, test-sets in sorted order and tests in
+// report order so two runs over the same data produce byte-identical output.
+//
+// Schema (schema_version "1"):
+//
+//	{
+//	  "schema_version": "1",
+//	  "test_run_id":    "test-run-3",
+//	  "test_set_id":    "test-set-0",
+//	  "test_case_id":   "test-1",
+//	  "kind":           "Http",              // models.Kind
+//	  "status":         "FAILED",            // models.TestStatus
+//	  "failure_categories": ["DEPENDENCY_MISSING"],   // omitted when empty
+//	  "dependencies_checked":  true,
+//	  "dependencies_consumed": 7,
+//	  "effects": [
+//	    {
+//	      "name":     "deps[0] postgres PostgreSQL INSERT (presence)",
+//	      "type":     "postgres",
+//	      "key":      "presence",
+//	      "expected": "consumed",
+//	      "actual":   "not consumed",
+//	      "matched":  false
+//	    }
+//	  ]
+//	}
+//
+// One `effects` entry per models.DepMetaResult, flattened with its parent row's
+// name and type so a consumer never has to walk a nested structure. `effects`
+// is always present, and every entry in it is a FAILED assertion: the
+// dependencies a test DID exercise are the `dependencies_consumed` count, not
+// entries.
+//
+// READ `dependencies_checked` FIRST. It is false when the per-test dependency
+// assertion did not RUN for this test — a --base-path / remote-agent run,
+// --disable-mapping, a test set with no usable mappings.yaml, a failed
+// per-test consumed-mock fetch, the deferred streaming path, a test the
+// mapping records no dependency for, or a test whose every mapped dependency
+// is INELIGIBLE. `effects` is then `[]`, which is NOT the same statement as
+// "this test lost nothing": the question was never asked. A consumer that
+// skips this check reports "no dependency regressions" for a run in which
+// nothing was checked, which is the false-green this whole projection exists
+// to close.
+//
+// ELIGIBILITY IS THE ONE THAT SURPRISES PEOPLE, so it is stated plainly here
+// rather than left to be discovered: the assertion covers only mocks recorded
+// as PER-TEST tier. Session/connection-tier mocks are excluded (recorded once
+// at app boot and shared across every test, so a per-test presence assertion
+// over them goes missing at random and reds healthy tests) and so is DNS.
+// models.Mock.DeriveLifetime classifies an UNTAGGED HTTP / HTTP2 / Postgres /
+// MySQL / Generic mock as session-tier, so for a recording whose mocks carry no
+// per-test tier tag NOTHING is eligible and every verdict in this document
+// carries `dependencies_checked: false`. That is the honest answer, not a bug
+// in the run — but it does mean an ordinary recorded outgoing HTTP call is NOT
+// automatically covered by this assertion. The replayer logs one warning per
+// test set naming that reason when --assert-dependencies is on.
+//
+//	lost_a_dependency := v.dependencies_checked && any(e.matched == false)
+//	unknown           := !v.dependencies_checked
+//
+// `dependencies_consumed` is how many recorded dependencies WERE exercised.
+// Meaningful only when `dependencies_checked` is true, where 0 is a real
+// answer ("checked, exercised nothing") and not a missing one. It is a count,
+// not a list, because one persisted row per consumed dependency costs ~190
+// bytes of YAML in a report written per test-set and uploaded to the fleet
+// report store — 3-11 MB per report on a Postgres-chatty suite, of
+// `consumed/consumed` boilerplate no consumer reads. The identities are
+// carried by the report's own MatchedCalls.
+//
+// WHAT `effects` CONTAINS:
+//
+//   - `"key": "presence"`, `"matched": false` — one entry per dependency the
+//     recording says the test exercised that was NOT observed during the
+//     test's window. These are the failed assertions and they are ALWAYS
+//     individually present. `type` is a stable protocol FAMILY
+//     (models.DepTypeForKind), never a parser version: a Postgres dependency
+//     is `"postgres"` whether the mock was recorded by the v1, v2 or v3
+//     parser. `name` is stable across runs — its index numbers the RECORDED
+//     dependency list, not the emitted rows.
+//   - `"key": "missing_count"`, `"matched": false` — at most ONE overflow
+//     entry, present only when a test lost more dependencies than the
+//     per-test cap (replay.depMissingRowCap, 50). `expected` is "0" and
+//     `actual` is how many further dependencies went unobserved beyond the
+//     ones named individually above. It exists because the flagship scenario
+//     — a downstream service removed, a worker that stopped producing, a mock
+//     pool whose names drifted wholesale — makes EVERY mapped dependency of
+//     EVERY test missing at once, which uncapped serialised to a 5.4 MB
+//     test-set report against 115 KB before this slice. It carries
+//     `matched: false` so the documented "did this test lose a dependency"
+//     rule below still fires; what it does not carry is the identity of those
+//     dependencies, which stays in the test set's mappings.yaml.
+//
+// A consumer that keys on `matched == false` alone needs no special handling
+// for the overflow entry. One that assumes every failed entry has
+// `key == "presence"` does: check the key, or count only presence entries when
+// you want individually named dependencies. The overflow entry uses the
+// `deps[*]` index token in its `name` and is identified by `key`, never by
+// parsing the name.
+//
+// WHY THE CONTAINER IS `effects` WHILE ITS ROW NAMES SAY `deps[i]`, decided
+// before schema_version "1" ships and the key becomes unbumpable. `effects` is
+// the UNION container for both producers of dependency-shaped assertions: this
+// slice's sync-path presence rows (`deps[i]`, presence-only, covering outgoing
+// reads as well as writes) and slice 5's consumer projector rows
+// (`effects[i]`, carrying field-level diffs decoded from a protocol payload —
+// keploy-consumer-design-v2.md §2). Renaming the container to `dependencies`
+// would be wrong the moment slice 5 lands, because a consumer effect is not a
+// dependency; keeping the two ROW-NAME prefixes disjoint is what lets a
+// consumer tell the producers apart without a schema-version bump. The row
+// prefixes are a documented one-way door (models/depresult.go); so is this key.
+//
+// `keploy test --assert-dependencies` changes only the `status` a lost
+// dependency produces (PASSED/OBSOLETE -> FAILED). It does not change the
+// shape of this document, so a consumer's parsing is mode-independent.
+//
+// NOTE ON WHAT `matched: false` CLAIMS. Consumed mocks are drained when the
+// response comes back, so a call the app makes AFTER writing its response (an
+// audit write, an analytics POST, a cache set) is attributed to the next test.
+// The claim is "not observed during this test's window", not "never made".
+//
+// This is a READ-ONLY projection over the persisted report data
+// (models.TestReport). It must never reach into replay internals — that
+// decoupling is what lets an agent loop parse a verdict without Keploy's
+// replay loop being in the picture at all
+// (keploy-consumer-design-v2.md §7 slice 4).
+
+// effectRow is one flattened dependency assertion.
+type effectRow struct {
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	Key      string `json:"key"`
+	Expected string `json:"expected"`
+	Actual   string `json:"actual"`
+	Matched  bool   `json:"matched"`
+}
+
+// testVerdict is one NDJSON line.
+type testVerdict struct {
+	SchemaVersion     string   `json:"schema_version"`
+	TestRunID         string   `json:"test_run_id"`
+	TestSetID         string   `json:"test_set_id"`
+	TestCaseID        string   `json:"test_case_id"`
+	Kind              string   `json:"kind"`
+	Status            string   `json:"status"`
+	FailureCategories []string `json:"failure_categories,omitempty"`
+	// DependenciesChecked says whether the per-test dependency assertion RAN
+	// for this test. Without it `effects: []` is ambiguous — see the contract
+	// note above.
+	DependenciesChecked bool `json:"dependencies_checked"`
+	// DependenciesConsumed is how many recorded dependencies this test DID
+	// exercise. Always emitted (no omitempty): 0 is a real answer for a
+	// checked test, and a consumer must not have to distinguish "absent" from
+	// "zero" on a field whose whole job is to be a magnitude.
+	DependenciesConsumed int         `json:"dependencies_consumed"`
+	Effects              []effectRow `json:"effects"`
+}
+
+// buildEffectRows flattens a test's dependency rows into the wire shape. Pure
+// so it can be table-tested without a Report, a config or a filesystem.
+// Always returns a non-nil slice so `effects` marshals as [] rather than null.
+func buildEffectRows(t models.TestResult) []effectRow {
+	rows := make([]effectRow, 0, len(t.Result.DepResult))
+	for _, d := range t.Result.DepResult {
+		for _, m := range d.Meta {
+			key := m.Key
+			if key == "" {
+				key = models.DepKeyPresence
+			}
+			rows = append(rows, effectRow{
+				Name:     d.Name,
+				Type:     d.Type,
+				Key:      key,
+				Expected: m.Expected,
+				Actual:   m.Actual,
+				Matched:  m.Normal,
+			})
+		}
+	}
+	return rows
+}
+
+// buildTestVerdict projects one persisted test result onto the NDJSON schema.
+func buildTestVerdict(runID, testSetID string, t models.TestResult) testVerdict {
+	var categories []string
+	for _, c := range t.FailureInfo.Category {
+		categories = append(categories, string(c))
+	}
+	return testVerdict{
+		SchemaVersion:        EffectsSchemaVersion,
+		TestRunID:            runID,
+		TestSetID:            testSetID,
+		TestCaseID:           t.TestCaseID,
+		Kind:                 string(t.Kind),
+		Status:               string(t.Status),
+		FailureCategories:    categories,
+		DependenciesChecked:  t.Result.DependenciesChecked(),
+		DependenciesConsumed: t.Result.DepsConsumed,
+		Effects:              buildEffectRows(t),
+	}
+}
+
+// buildTestVerdicts projects a whole run. Test-set names are sorted so the
+// output is deterministic across runs; within a set, report order is kept.
+// testSetID falls back to the map key when the persisted report has no
+// TestSet field (older reports).
+func buildTestVerdicts(runID string, reports map[string]*models.TestReport) []testVerdict {
+	names := make([]string, 0, len(reports))
+	for name := range reports {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var out []testVerdict
+	for _, name := range names {
+		rep := reports[name]
+		if rep == nil {
+			continue
+		}
+		testSetID := rep.TestSet
+		if testSetID == "" {
+			testSetID = name
+		}
+		for _, t := range rep.Tests {
+			out = append(out, buildTestVerdict(runID, testSetID, t))
+		}
+	}
+	return out
+}
+
+// writeNDJSON emits one JSON object per line.
+func writeNDJSON(w io.Writer, verdicts []testVerdict) error {
+	jw := utils.NewJSONWriterOut(w, true)
+	for i := range verdicts {
+		if err := jw.Write(verdicts[i]); err != nil {
+			return fmt.Errorf("failed to write ndjson verdict for %s/%s: %w",
+				verdicts[i].TestSetID, verdicts[i].TestCaseID, err)
+		}
+	}
+	return nil
+}
+
+// generateNDJSON writes the `--format json` projection through the report's
+// own buffered writer.
+func (r *Report) generateNDJSON(runID string, reports map[string]*models.TestReport) error {
+	if err := writeNDJSON(r.out, buildTestVerdicts(runID, reports)); err != nil {
+		return err
+	}
+	return r.out.Flush()
+}

--- a/pkg/service/report/ndjson_generate_test.go
+++ b/pkg/service/report/ndjson_generate_test.go
@@ -1,0 +1,212 @@
+package report
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"go.keploy.io/server/v3/config"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+type fakeReportDB struct {
+	runIDs  []string
+	reports map[string]*models.TestReport
+}
+
+func (f *fakeReportDB) GetAllTestRunIDs(context.Context) ([]string, error) { return f.runIDs, nil }
+func (f *fakeReportDB) GetReport(_ context.Context, _ string, testSetID string) (*models.TestReport, error) {
+	return f.reports[testSetID], nil
+}
+
+type fakeTestDB struct{ testSets []string }
+
+func (f *fakeTestDB) GetReportTestSets(context.Context, string) ([]string, error) {
+	return f.testSets, nil
+}
+
+func newFakeReportFixture() (*fakeReportDB, *fakeTestDB) {
+	return &fakeReportDB{
+		runIDs: []string{"test-run-0", "test-run-1"},
+		reports: map[string]*models.TestReport{
+			"test-set-0": {
+				TestSet: "test-set-0",
+				Total:   2,
+				Tests: []models.TestResult{
+					{
+						Kind: models.HTTP, TestCaseID: "test-1", Status: models.TestStatusFailed,
+						FailureInfo: models.FailureInfo{
+							Category: []models.FailureCategory{models.DependencyMissing},
+						},
+						Result: models.Result{
+							DepResult: []models.DepResult{missingDepRow()}, DepsChecked: true, DepsConsumed: 5,
+						},
+					},
+					{Kind: models.HTTP, TestCaseID: "test-2", Status: models.TestStatusPassed},
+				},
+			},
+		},
+	}, &fakeTestDB{testSets: []string{"test-set-0"}}
+}
+
+func runGenerateReport(t *testing.T, cfg *config.Config) string {
+	t.Helper()
+	rdb, tdb := newFakeReportFixture()
+	r := New(zap.NewNop(), cfg, rdb, tdb)
+	var buf bytes.Buffer
+	r.out = bufio.NewWriter(&buf)
+	if err := r.GenerateReport(context.Background()); err != nil {
+		t.Fatalf("GenerateReport: %v", err)
+	}
+	return buf.String()
+}
+
+// --format json emits NDJSON over the persisted report, and does so even when
+// the global --json flag is also set: the explicit format wins over the
+// whole-map blob.
+func TestGenerateReport_FormatJSONEmitsNDJSON(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  *config.Config
+	}{
+		{name: "format json alone", cfg: &config.Config{Report: config.Report{Format: "json"}}},
+		{name: "format json beats the global --json blob", cfg: &config.Config{
+			JSONOutput: true, Report: config.Report{Format: "json"},
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := runGenerateReport(t, tc.cfg)
+			lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+			if len(lines) != 2 {
+				t.Fatalf("expected 2 NDJSON lines, got %d:\n%s", len(lines), out)
+			}
+
+			var first testVerdict
+			if err := json.Unmarshal([]byte(lines[0]), &first); err != nil {
+				t.Fatalf("line 0 is not JSON: %v (%q)", err, lines[0])
+			}
+			if first.SchemaVersion != EffectsSchemaVersion {
+				t.Errorf("schema_version = %q, want %q", first.SchemaVersion, EffectsSchemaVersion)
+			}
+			// getLatestTestRunID picks the highest-numbered run.
+			if first.TestRunID != "test-run-1" {
+				t.Errorf("test_run_id = %q, want test-run-1", first.TestRunID)
+			}
+			if first.TestSetID != "test-set-0" || first.TestCaseID != "test-1" {
+				t.Errorf("unexpected identity: %+v", first)
+			}
+			if len(first.Effects) != 1 || first.Effects[0].Matched {
+				t.Errorf("expected one failed effect, got %+v", first.Effects)
+			}
+			if len(first.FailureCategories) != 1 || first.FailureCategories[0] != string(models.DependencyMissing) {
+				t.Errorf("failure_categories = %v", first.FailureCategories)
+			}
+
+			var second testVerdict
+			if err := json.Unmarshal([]byte(lines[1]), &second); err != nil {
+				t.Fatalf("line 1 is not JSON: %v (%q)", err, lines[1])
+			}
+			if second.TestCaseID != "test-2" || len(second.Effects) != 0 {
+				t.Errorf("unexpected second verdict: %+v", second)
+			}
+			if !strings.Contains(lines[1], `"effects":[]`) {
+				t.Errorf("effects must serialize as [] for a test with no dependencies: %s", lines[1])
+			}
+		})
+	}
+}
+
+// --format json filters to the selected test cases, like the other formats.
+func TestGenerateReport_FormatJSONHonoursTestCaseFilter(t *testing.T) {
+	out := runGenerateReport(t, &config.Config{Report: config.Report{
+		Format:      "json",
+		TestCaseIDs: []string{"test-2"},
+	}})
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d:\n%s", len(lines), out)
+	}
+	if !strings.Contains(lines[0], `"test_case_id":"test-2"`) {
+		t.Errorf("wrong test emitted: %s", lines[0])
+	}
+}
+
+// The machine formats project a whole run; --report-path addresses a single
+// test-set file with no run identity, so the combination is refused.
+func TestGenerateReport_MachineFormatsRejectReportPath(t *testing.T) {
+	for _, format := range []string{"junit", "json"} {
+		t.Run(format, func(t *testing.T) {
+			rdb, tdb := newFakeReportFixture()
+			r := New(zap.NewNop(), &config.Config{Report: config.Report{
+				Format:     format,
+				ReportPath: "/tmp/does-not-matter.yaml",
+			}}, rdb, tdb)
+			err := r.GenerateReport(context.Background())
+			if err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if !strings.Contains(err.Error(), "--format "+format) ||
+				!strings.Contains(err.Error(), "--report-path") {
+				t.Errorf("unhelpful error: %v", err)
+			}
+		})
+	}
+}
+
+// The default text format must not be perturbed by any of this: with the
+// global --json flag it still emits the whole-report BLOB, not NDJSON.
+//
+// The blob now goes through r.out like every other branch. It used to be
+// written straight to os.Stdout, which meant this assertion was vacuous (it
+// checked a buffer that branch never touched) and every `go test` run of this
+// package dumped multiple KB of JSON into the test log.
+func TestGenerateReport_TextFormatStillUsesTheGlobalJSONBlob(t *testing.T) {
+	out := runGenerateReport(t, &config.Config{JSONOutput: true, Report: config.Report{Format: "text"}})
+	if out == "" {
+		t.Fatal("the global --json branch wrote nothing to r.out")
+	}
+	if strings.Contains(out, `"schema_version"`) {
+		t.Errorf("text format took the NDJSON branch:\n%s", out)
+	}
+	// One JSON document keyed by test-set name, not one object per test.
+	var blob map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(out), &blob); err != nil {
+		t.Fatalf("the --json blob is not a single JSON document: %v\n%s", err, out)
+	}
+	if _, ok := blob["test-set-0"]; !ok {
+		t.Errorf("the blob is not keyed by test set: %v", out)
+	}
+}
+
+// dependencies_checked has to survive the whole GenerateReport path, not just
+// the projection unit test: it is the field an agent reads before trusting an
+// empty `effects`.
+func TestGenerateReport_FormatJSONCarriesDependenciesChecked(t *testing.T) {
+	out := runGenerateReport(t, &config.Config{Report: config.Report{Format: "json"}})
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 NDJSON lines, got %d:\n%s", len(lines), out)
+	}
+	want := map[string]bool{"test-1": true, "test-2": false}
+	for i, line := range lines {
+		var v testVerdict
+		if err := json.Unmarshal([]byte(line), &v); err != nil {
+			t.Fatalf("line %d: %v", i, err)
+		}
+		if v.DependenciesChecked != want[v.TestCaseID] {
+			t.Errorf("%s: dependencies_checked = %v, want %v — an agent cannot tell "+
+				"'checked and clean' from 'never checked' without it",
+				v.TestCaseID, v.DependenciesChecked, want[v.TestCaseID])
+		}
+		if v.TestCaseID == "test-1" && v.DependenciesConsumed != 5 {
+			t.Errorf("test-1: dependencies_consumed = %d, want 5 — the count is the only "+
+				"trace of the dependencies the test DID exercise", v.DependenciesConsumed)
+		}
+	}
+}

--- a/pkg/service/report/ndjson_test.go
+++ b/pkg/service/report/ndjson_test.go
@@ -1,0 +1,439 @@
+package report
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+func TestBuildEffectRows(t *testing.T) {
+	tests := []struct {
+		name string
+		test models.TestResult
+		want []effectRow
+	}{
+		{
+			name: "no dependency rows yields a non-nil empty slice",
+			test: models.TestResult{},
+			want: []effectRow{},
+		},
+		{
+			name: "one row per meta, flattened with the parent name and type",
+			test: models.TestResult{Result: models.Result{DepResult: []models.DepResult{
+				missingDepRow(), consumedDepRow(),
+			}}},
+			want: []effectRow{
+				{
+					Name: "deps[0] postgres PostgreSQL INSERT (presence)", Type: "postgres",
+					Key: "presence", Expected: "consumed", Actual: "not consumed", Matched: false,
+				},
+				{
+					Name: "deps[1] http GET api.internal:80/orders (presence)", Type: "http",
+					Key: "presence", Expected: "consumed", Actual: "consumed", Matched: true,
+				},
+			},
+		},
+		{
+			name: "an empty meta key falls back to the presence key",
+			test: models.TestResult{Result: models.Result{DepResult: []models.DepResult{{
+				Name: "deps[0] kafka orders (presence)", Type: "kafka",
+				Meta: []models.DepMetaResult{{Normal: false, Expected: "1", Actual: "0"}},
+			}}}},
+			want: []effectRow{{
+				Name: "deps[0] kafka orders (presence)", Type: "kafka",
+				Key: "presence", Expected: "1", Actual: "0", Matched: false,
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildEffectRows(tt.test)
+			if got == nil {
+				t.Fatal("buildEffectRows must never return nil so effects marshals as []")
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d rows, want %d: %+v", len(got), len(tt.want), got)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("row %d = %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestBuildTestVerdict_Schema(t *testing.T) {
+	v := buildTestVerdict("test-run-3", "test-set-0", models.TestResult{
+		Kind:       models.HTTP,
+		TestCaseID: "test-1",
+		Status:     models.TestStatusFailed,
+		FailureInfo: models.FailureInfo{
+			Category: []models.FailureCategory{models.DependencyMissing},
+		},
+		Result: models.Result{
+			DepResult: []models.DepResult{missingDepRow()}, DepsChecked: true, DepsConsumed: 7,
+		},
+	})
+
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	want := map[string]any{
+		"schema_version":        EffectsSchemaVersion,
+		"test_run_id":           "test-run-3",
+		"test_set_id":           "test-set-0",
+		"test_case_id":          "test-1",
+		"kind":                  string(models.HTTP),
+		"status":                string(models.TestStatusFailed),
+		"failure_categories":    []any{"DEPENDENCY_MISSING"},
+		"dependencies_checked":  true,
+		"dependencies_consumed": float64(7),
+	}
+	for k, expected := range want {
+		got, ok := decoded[k]
+		if !ok {
+			t.Fatalf("schema field %q missing from %s", k, data)
+		}
+		if gotSlice, isSlice := got.([]any); isSlice {
+			expectedSlice := expected.([]any)
+			if len(gotSlice) != len(expectedSlice) || gotSlice[0] != expectedSlice[0] {
+				t.Errorf("field %q = %v, want %v", k, got, expected)
+			}
+			continue
+		}
+		if got != expected {
+			t.Errorf("field %q = %v, want %v", k, got, expected)
+		}
+	}
+
+	effects, ok := decoded["effects"].([]any)
+	if !ok {
+		t.Fatalf("effects missing or not an array in %s", data)
+	}
+	if len(effects) != 1 {
+		t.Fatalf("expected 1 effect, got %d", len(effects))
+	}
+	effect := effects[0].(map[string]any)
+	for _, key := range []string{"name", "type", "key", "expected", "actual", "matched"} {
+		if _, ok := effect[key]; !ok {
+			t.Errorf("effect missing field %q: %v", key, effect)
+		}
+	}
+	if effect["matched"] != false {
+		t.Errorf("matched = %v, want false", effect["matched"])
+	}
+}
+
+func TestBuildTestVerdict_EmptyCategoriesAreOmittedAndEffectsAlwaysPresent(t *testing.T) {
+	data, err := json.Marshal(buildTestVerdict("run", "set", models.TestResult{
+		Kind: models.HTTP, TestCaseID: "t", Status: models.TestStatusPassed,
+	}))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	out := string(data)
+	if strings.Contains(out, "failure_categories") {
+		t.Errorf("empty failure_categories must be omitted: %s", out)
+	}
+	if !strings.Contains(out, `"effects":[]`) {
+		t.Errorf(`effects must always be present as []: %s`, out)
+	}
+}
+
+func TestBuildTestVerdicts_DeterministicOrderingAndTestSetFallback(t *testing.T) {
+	reports := map[string]*models.TestReport{
+		"test-set-2": {TestSet: "test-set-2", Tests: []models.TestResult{
+			{TestCaseID: "c", Status: models.TestStatusPassed},
+		}},
+		"test-set-0": {TestSet: "test-set-0", Tests: []models.TestResult{
+			{TestCaseID: "a", Status: models.TestStatusPassed},
+			{TestCaseID: "b", Status: models.TestStatusFailed},
+		}},
+		// TestSet unset: the map key is the fallback.
+		"test-set-1": {Tests: []models.TestResult{{TestCaseID: "d", Status: models.TestStatusPassed}}},
+		"test-set-3": nil,
+	}
+
+	for range 5 {
+		got := buildTestVerdicts("run-9", reports)
+		var ids, sets []string
+		for _, v := range got {
+			ids = append(ids, v.TestCaseID)
+			sets = append(sets, v.TestSetID)
+		}
+		if strings.Join(ids, ",") != "a,b,d,c" {
+			t.Fatalf("non-deterministic or wrong ordering: %v", ids)
+		}
+		if strings.Join(sets, ",") != "test-set-0,test-set-0,test-set-1,test-set-2" {
+			t.Fatalf("test_set_id wrong (fallback broken?): %v", sets)
+		}
+	}
+}
+
+func TestWriteNDJSON_OneObjectPerLine(t *testing.T) {
+	var sb strings.Builder
+	verdicts := buildTestVerdicts("run-1", map[string]*models.TestReport{
+		"test-set-0": {TestSet: "test-set-0", Tests: []models.TestResult{
+			{Kind: models.HTTP, TestCaseID: "t1", Status: models.TestStatusFailed,
+				Result: models.Result{DepResult: []models.DepResult{missingDepRow()}}},
+			{Kind: models.HTTP, TestCaseID: "t2", Status: models.TestStatusPassed},
+		}},
+	})
+	if err := writeNDJSON(&sb, verdicts); err != nil {
+		t.Fatalf("writeNDJSON: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimRight(sb.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 NDJSON lines, got %d: %q", len(lines), sb.String())
+	}
+	for i, line := range lines {
+		var v testVerdict
+		if err := json.Unmarshal([]byte(line), &v); err != nil {
+			t.Fatalf("line %d is not standalone JSON: %v (%q)", i, err, line)
+		}
+		if v.SchemaVersion != EffectsSchemaVersion {
+			t.Errorf("line %d schema_version = %q, want %q", i, v.SchemaVersion, EffectsSchemaVersion)
+		}
+		if v.TestRunID != "run-1" {
+			t.Errorf("line %d test_run_id = %q", i, v.TestRunID)
+		}
+	}
+}
+
+func TestWriteNDJSON_NoVerdictsWritesNothing(t *testing.T) {
+	var sb strings.Builder
+	if err := writeNDJSON(&sb, nil); err != nil {
+		t.Fatalf("writeNDJSON: %v", err)
+	}
+	if sb.Len() != 0 {
+		t.Errorf("expected no output, got %q", sb.String())
+	}
+}
+
+// --- schema contract pin ---
+//
+// The other assertions in this file compare the emitted schema_version to
+// EffectsSchemaVersion, i.e. the constant to itself: changing "1" to "2" — the
+// exact act ndjson.go says must be deliberate and breaking — leaves them all
+// green. This one pins the literal BYTES of one line: the version, every field
+// name, and the field ORDER a consumer's line-oriented parser sees.
+//
+// If this fails you are changing the agent contract. That is allowed, but it
+// is a decision: update the literal here AND bump EffectsSchemaVersion if the
+// change removes, renames, or redefines a field.
+const goldenNDJSONLine = `{"schema_version":"1","test_run_id":"test-run-3","test_set_id":"test-set-0","test_case_id":"test-1","kind":"Http","status":"FAILED","failure_categories":["DEPENDENCY_MISSING"],"dependencies_checked":true,"dependencies_consumed":3,"effects":[{"name":"deps[0] postgres PostgreSQL INSERT (presence)","type":"postgres","key":"presence","expected":"consumed","actual":"not consumed","matched":false}]}`
+
+// The other half of the contract, and the one an agent gets wrong: a test the
+// assertion never ran for. It must be distinguishable from a clean one by a
+// field, not by an empty array.
+const goldenNDJSONUncheckedLine = `{"schema_version":"1","test_run_id":"test-run-3","test_set_id":"test-set-0","test_case_id":"test-2","kind":"Http","status":"PASSED","dependencies_checked":false,"dependencies_consumed":0,"effects":[]}`
+
+func TestNDJSONLineIsByteStable(t *testing.T) {
+	var sb strings.Builder
+	verdicts := buildTestVerdicts("test-run-3", map[string]*models.TestReport{
+		"test-set-0": {TestSet: "test-set-0", Tests: []models.TestResult{{
+			Kind:       models.HTTP,
+			TestCaseID: "test-1",
+			Status:     models.TestStatusFailed,
+			FailureInfo: models.FailureInfo{
+				Category: []models.FailureCategory{models.DependencyMissing},
+			},
+			Result: models.Result{
+				DepResult: []models.DepResult{missingDepRow()}, DepsChecked: true, DepsConsumed: 3,
+			},
+		}, {
+			Kind:       models.HTTP,
+			TestCaseID: "test-2",
+			Status:     models.TestStatusPassed,
+		}}},
+	})
+	if err := writeNDJSON(&sb, verdicts); err != nil {
+		t.Fatalf("writeNDJSON: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimRight(sb.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %q", len(lines), sb.String())
+	}
+	for i, want := range []string{goldenNDJSONLine, goldenNDJSONUncheckedLine} {
+		if lines[i] != want {
+			t.Fatalf("the NDJSON contract changed.\n got: %s\nwant: %s\n\n"+
+				"If this is deliberate, update the golden line — and bump EffectsSchemaVersion "+
+				"if a field was removed, renamed, or given a different meaning.", lines[i], want)
+		}
+	}
+
+	// And the version inside the golden line must be the constant, so the two
+	// cannot be updated independently.
+	if !strings.Contains(goldenNDJSONLine, `"schema_version":"`+EffectsSchemaVersion+`"`) {
+		t.Fatalf("EffectsSchemaVersion is %q but the golden line pins a different version: %s",
+			EffectsSchemaVersion, goldenNDJSONLine)
+	}
+}
+
+// The false-green the agent contract itself could re-create: a test whose
+// dependency assertion never ran emits `effects: []`, byte-identical to a fully
+// checked test that lost nothing. `dependencies_checked` is the only thing
+// separating them, so it has to be present and it has to differ.
+func TestNDJSON_UncheckedIsDistinguishableFromCleanlyChecked(t *testing.T) {
+	// Everything consumed: the assertion RAN and found nothing missing. The
+	// replayer sets the DepsChecked bit to say so — and writes NO rows, which
+	// is exactly why the bit has to exist.
+	//
+	// DepsConsumed is non-zero because a WRITER cannot produce checked-with-
+	// zero-consumed-and-no-rows: the bit is set only when at least one
+	// dependency was eligible, and an eligible dependency that was not consumed
+	// is a missing row. Using the impossible shape here would enshrine the
+	// false green as the example of a healthy test.
+	checked := buildTestVerdict("run", "set", models.TestResult{
+		Kind: models.HTTP, TestCaseID: "checked", Status: models.TestStatusPassed,
+		Result: models.Result{DepsChecked: true, DepsConsumed: 2},
+	})
+	// A --base-path run, --disable-mapping, an unmapped test set, a failed
+	// consumed-mock fetch, or the deferred streaming path.
+	unchecked := buildTestVerdict("run", "set", models.TestResult{
+		Kind: models.HTTP, TestCaseID: "unchecked", Status: models.TestStatusPassed,
+	})
+
+	if !checked.DependenciesChecked {
+		t.Error("a test whose assertion ran and found nothing must report dependencies_checked=true")
+	}
+	if unchecked.DependenciesChecked {
+		t.Error("a test whose assertion never ran must report dependencies_checked=false")
+	}
+
+	// Neither has a failed effect, so `any(matched == false)` cannot tell them
+	// apart — which is exactly why the boolean exists.
+	for _, v := range []testVerdict{checked, unchecked} {
+		for _, e := range v.Effects {
+			if !e.Matched {
+				t.Fatalf("%s unexpectedly has a failed effect: %+v", v.TestCaseID, e)
+			}
+		}
+	}
+
+	a, err := json.Marshal(checked)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	b, err := json.Marshal(unchecked)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(a), `"dependencies_checked":true`) {
+		t.Errorf("checked line lost the field: %s", a)
+	}
+	if !strings.Contains(string(b), `"dependencies_checked":false`) {
+		t.Errorf("unchecked line lost the field: %s", b)
+	}
+}
+
+// A test that PASSED while losing a dependency must be readable as such from
+// one NDJSON line alone — that is the agent-loop contract.
+func TestNDJSON_PassedWithMissingDependencyIsMachineDetectable(t *testing.T) {
+	v := buildTestVerdict("run", "set", models.TestResult{
+		Kind: models.HTTP, TestCaseID: "t", Status: models.TestStatusPassed,
+		Result: models.Result{
+			DepResult: []models.DepResult{missingDepRow()}, DepsChecked: true, DepsConsumed: 4,
+		},
+	})
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded struct {
+		Status               string `json:"status"`
+		DependenciesChecked  bool   `json:"dependencies_checked"`
+		DependenciesConsumed int    `json:"dependencies_consumed"`
+		Effects              []struct {
+			Key      string `json:"key"`
+			Matched  bool   `json:"matched"`
+			Expected string `json:"expected"`
+		} `json:"effects"`
+	}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.Status != string(models.TestStatusPassed) {
+		t.Errorf("status = %q, want PASSED (the knob is what flips it, not the report)", decoded.Status)
+	}
+	if !decoded.DependenciesChecked {
+		t.Error("dependencies_checked must be true, or the documented rule never fires")
+	}
+	if decoded.DependenciesConsumed != 4 {
+		t.Errorf("dependencies_consumed = %d, want 4", decoded.DependenciesConsumed)
+	}
+	var lost int
+	for _, e := range decoded.Effects {
+		if !e.Matched {
+			lost++
+		}
+	}
+	if lost != 1 {
+		t.Errorf("expected exactly one failed effect, got %d", lost)
+	}
+	// The dependencies the test DID exercise must not be effect entries: at
+	// ~190 bytes of persisted YAML each they are the report-bloat axis this
+	// slice explicitly rejected.
+	if len(decoded.Effects) != 1 {
+		t.Errorf("expected exactly one effect entry (the failed one), got %d: %s", len(decoded.Effects), data)
+	}
+}
+
+// The capped shape on the wire. An agent following the documented rule
+// (`dependencies_checked && any(e.matched == false)`) must still see the
+// failure when the per-test cap collapsed most of the missing dependencies
+// into the overflow entry, and must be able to tell an overflow entry from a
+// named one WITHOUT parsing the row name.
+func TestBuildEffectRows_MissingOverflowIsOnTheWire(t *testing.T) {
+	rows := buildEffectRows(models.TestResult{Result: models.Result{
+		DepResult:   []models.DepResult{missingDepRow(), models.DepMissingOverflowRow(150)},
+		DepsChecked: true,
+	}})
+
+	if len(rows) != 2 {
+		t.Fatalf("got %d effect rows, want 2: %+v", len(rows), rows)
+	}
+	overflow := rows[1]
+	want := effectRow{
+		Name:     "deps[*] 150 more not consumed (presence)",
+		Type:     "",
+		Key:      models.DepKeyMissingCount,
+		Expected: "0",
+		Actual:   "150",
+		Matched:  false,
+	}
+	if overflow != want {
+		t.Fatalf("overflow entry = %+v, want %+v", overflow, want)
+	}
+
+	// The documented rule fires.
+	lost := false
+	named := 0
+	for _, r := range rows {
+		if !r.Matched {
+			lost = true
+		}
+		if r.Key == models.DepKeyPresence && !r.Matched {
+			named++
+		}
+	}
+	if !lost {
+		t.Fatal("a capped, mostly-overflowed test reads as having lost nothing")
+	}
+	if named != 1 {
+		t.Fatalf("counted %d individually named missing dependencies, want 1", named)
+	}
+}

--- a/pkg/service/report/report.go
+++ b/pkg/service/report/report.go
@@ -138,14 +138,26 @@ func (r *Report) printSpecificTestCases(ctx context.Context, runID string, testS
 // helper used by both file and DB paths
 func (r *Report) printTests(ctx context.Context, tests []models.TestResult) error {
 	for _, t := range tests {
-		if t.Status == models.TestStatusFailed {
+		// FAILED/OBSOLETE keep the full diff. A test that merely lost a
+		// dependency keeps its one-line status notice below and gains one
+		// extra line, rather than being dressed up as a failure.
+		if shouldRenderDiff(t) && !rendersDepNoticeOnly(t) {
 			if err := r.printSingleTestReport(ctx, t); err != nil {
 				return fmt.Errorf("failed to print single test report in printTests: %w", err)
 			}
 			continue
 		}
-		// Passed — minimize output and avoid pretty printer
-		fmt.Fprintf(r.out, "Testcase %q (%s) PASSED ✅ (%s)\n", t.TestCaseID, t.Name, t.TimeTaken)
+		// Not rendering a diff — minimize output and avoid pretty printer.
+		// The status is PRINTED, not assumed: this branch takes every
+		// non-FAILED status, so hardcoding "PASSED ✅" made
+		// `keploy report --test-case <obsolete>` announce a pass for a test
+		// that was demoted, and the dependency notice below then printed
+		// directly under a line asserting it passed.
+		fmt.Fprintf(r.out, "Testcase %q (%s) %s (%s)\n", t.TestCaseID, t.Name, testStatusLabel(t.Status), t.TimeTaken)
+		// ... but a PASSED test can still have stopped making a recorded
+		// outgoing call. That is the silent-green case; it gets one line here
+		// whether or not --assert-dependencies was passed.
+		fmt.Fprint(r.out, models.FormatDepNotice(t.Result.DepResult))
 		fmt.Fprintln(r.out, "\n--------------------------------------------------------------------")
 	}
 	err := r.out.Flush()
@@ -153,6 +165,27 @@ func (r *Report) printTests(ctx context.Context, tests []models.TestResult) erro
 		return fmt.Errorf("failed while flushing in printTests: %w", err)
 	}
 	return nil
+}
+
+// testStatusLabel renders a status for the one-line, no-diff form of
+// `keploy report`.
+//
+// PASSED keeps its exact historical bytes ("PASSED ✅"), which is what makes
+// this change invisible for every report whose tests all passed; the other
+// statuses stop borrowing it.
+func testStatusLabel(status models.TestStatus) string {
+	switch status {
+	case models.TestStatusPassed:
+		return "PASSED ✅"
+	case models.TestStatusFailed:
+		return "FAILED ❌"
+	case models.TestStatusObsolete:
+		return "OBSOLETE ⚠️"
+	case models.TestStatusIgnored:
+		return "IGNORED ⏭️"
+	}
+	// An unknown status is still better named than mislabelled as a pass.
+	return string(status)
 }
 
 // printSummary prints the grand summary + per test-set table.
@@ -174,7 +207,7 @@ func (r *Report) printSummary(reports map[string]*models.TestReport) error {
 		failed += rep.Failure
 		obsolete += rep.Obsolete
 
-		// Count risk levels and categories for failed tests
+		// Count risk levels for failed tests that carry one.
 		for _, test := range rep.Tests {
 			if test.Status == models.TestStatusFailed && test.FailureInfo.Risk != "" {
 				switch test.FailureInfo.Risk {
@@ -185,9 +218,36 @@ func (r *Report) printSummary(reports map[string]*models.TestReport) error {
 				case models.Low:
 					lowRisk++
 				}
+			}
 
+			// Category counting, widened by exactly as much as this slice
+			// needs and no more.
+			//
+			// FAILED is counted INDEPENDENTLY of the risk level. Risk is set
+			// by the response matcher; a test promoted to FAILED by
+			// --assert-dependencies has a matching response and therefore no
+			// risk at all, so the historical `Risk != ""` gate meant
+			// DEPENDENCY_MISSING — the one category this slice adds — could
+			// never reach the summary block that advertises it.
+			//
+			// OBSOLETE contributes ONLY DependencyMissing. An OBSOLETE test
+			// has never been counted here, and counting its other categories
+			// would silently change the numbers under a heading called FAILURE
+			// CATEGORIES for reports written long before this slice: a report
+			// with one FAILED and one OBSOLETE test both carrying
+			// SCHEMA_BROKEN would print "SCHEMA_BROKEN: 2" next to "Total test
+			// failed: 1". That is unreviewed breadth on a surface CI users
+			// scrape, and none of it is needed to surface a lost dependency.
+			switch test.Status {
+			case models.TestStatusFailed:
 				for _, category := range test.FailureInfo.Category {
 					categoryCounts[category]++
+				}
+			case models.TestStatusObsolete:
+				for _, category := range test.FailureInfo.Category {
+					if category == models.DependencyMissing {
+						categoryCounts[category]++
+					}
 				}
 			}
 		}
@@ -223,14 +283,53 @@ func (r *Report) printSummary(reports map[string]*models.TestReport) error {
 		fmt.Fprintf(r.out, "\tTotal test obsolete: %d\n", obsolete)
 	}
 
+	// Dependencies that the recording says a test exercises but that the test
+	// never made during replay. Reported for EVERY status, because the case
+	// worth surfacing is the one where the response still matched and the test
+	// is green — CI is otherwise silent about it.
+	if depTotal, depPassed := depNoticeCounts(reports); depTotal > 0 {
+		fmt.Fprintf(r.out, "\tDependencies not exercised: %d test(s)\n", depTotal)
+		if depPassed > 0 {
+			// "not observed during the test's own window" rather than "never
+			// made": consumed mocks are drained when the response comes back,
+			// so an outgoing call the app makes AFTER writing its response is
+			// attributed to the next test. The data supports the weaker claim.
+			fmt.Fprintf(r.out, "\t\t%d of them PASSED — the response matched, but a recorded outgoing call was not observed during the test's own window.\n", depPassed)
+			fmt.Fprintln(r.out, "\t\tRun `keploy test --assert-dependencies` to fail on this.")
+		}
+	}
+
 	// Add risk level statistics
 	if failed > 0 {
 		fmt.Fprintln(r.out, "\n\tFAILURE RISK DISTRIBUTION:")
 		fmt.Fprintf(r.out, "\t\tHigh Risk: %d\n", highRisk)
 		fmt.Fprintf(r.out, "\t\tMedium Risk: %d\n", mediumRisk)
 		fmt.Fprintf(r.out, "\t\tLow Risk: %d\n", lowRisk)
+	}
 
-		// Add failure category statistics
+	// The block still appears whenever a test FAILED, exactly as it always
+	// has. The ONE new trigger is a dependency finding on a run with no
+	// failures at all — an OBSOLETE test labelled DEPENDENCY_MISSING, which
+	// carries a real category with no failure and no risk behind it and would
+	// otherwise be invisible in `--summary`.
+	//
+	// Deliberately NOT `len(categoryCounts) > 0`: that also printed a
+	// brand-new three-line block on zero-failure runs of UNCHANGED pre-slice-4
+	// reports, which is collateral this slice does not need.
+	//
+	// The counting loop above is not byte-identical for every pre-slice-4
+	// report, and that part is deliberate. It used to be nested inside
+	// `if Risk != ""`, and CreateFailedTestResult produces exactly the shape
+	// that trips over: replay.go copies Category only when Risk != models.None,
+	// then appends AppConnectionError unconditionally, leaving Risk empty. So a
+	// report from a run where the app never answered rendered "No specific
+	// categories identified" while carrying APP_CONNECTION_ERROR, and now
+	// renders "APP_CONNECTION_ERROR: 1". That is a pre-existing bug this slice
+	// fixes on the way past, not a side effect of the DEPENDENCY_MISSING
+	// plumbing — it is pinned by
+	// TestPrintSummary_CountsDependenciesAndCategories's "a FAILED test with a
+	// category and NO risk level is now counted" row so it stays deliberate.
+	if failed > 0 || categoryCounts[models.DependencyMissing] > 0 {
 		fmt.Fprintln(r.out, "\n\tFAILURE CATEGORIES:")
 		if len(categoryCounts) == 0 {
 			fmt.Fprintln(r.out, "\t\tNo specific categories identified")
@@ -352,8 +451,12 @@ func (r *Report) GenerateReport(ctx context.Context) error {
 	}
 
 	if r.config.Report.ReportPath != "" {
-		if r.config.Report.Format == "junit" {
-			return fmt.Errorf("--format junit is not supported with --report-path; use the database-backed report path instead")
+		// Both machine formats project a whole RUN (they carry test_run_id /
+		// per-suite aggregates); --report-path addresses a single test-set
+		// file with no run identity, so the combination is rejected rather
+		// than silently emitting a run-shaped document about one file.
+		if config.IsMachineReportFormat(r.config.Report.Format) {
+			return fmt.Errorf("--format %s is not supported with --report-path; use the database-backed report path instead", r.config.Report.Format)
 		}
 		// File mode (single test-set file)
 		return r.generateReportFromFile(ctx, r.config.Report.ReportPath)
@@ -383,7 +486,7 @@ func (r *Report) GenerateReport(ctx context.Context) error {
 		}
 	}
 
-	if r.config.Report.Format == "junit" {
+	if r.config.Report.Format == config.ReportFormatJUnit {
 		reports, err := r.collectReports(ctx, latestRunID, testSetIDs)
 		if err != nil {
 			return fmt.Errorf("failed to collect reports for JUnit output: %w", err)
@@ -396,6 +499,25 @@ func (r *Report) GenerateReport(ctx context.Context) error {
 			}
 		}
 		return r.generateJUnit(reports)
+	}
+
+	// --format json (NDJSON, one object per test result). Deliberately placed
+	// BEFORE the global --json branch below: --json dumps the whole report map
+	// as one blob, which is a different (and much less agent-friendly)
+	// document. When both are given, the explicit --format wins.
+	if r.config.Report.Format == config.ReportFormatJSON {
+		reports, err := r.collectReports(ctx, latestRunID, testSetIDs)
+		if err != nil {
+			return fmt.Errorf("failed to collect reports for ndjson output: %w", err)
+		}
+		if len(r.config.Report.TestCaseIDs) > 0 {
+			for name, rep := range reports {
+				rep.Tests = r.filterTestsByIDs(rep.Tests, r.config.Report.TestCaseIDs)
+				rep.Total = len(rep.Tests)
+				reports[name] = rep
+			}
+		}
+		return r.generateNDJSON(latestRunID, reports)
 	}
 
 	if r.config.JSONOutput {
@@ -427,7 +549,13 @@ func (r *Report) GenerateReport(ctx context.Context) error {
 				reports[name] = rep
 			}
 		}
-		return utils.NewJSONWriter(true).Write(reports)
+		// Through r.out, like every other branch: writing straight to
+		// os.Stdout races the buffered writer the rest of this service uses
+		// and makes the output unassertable in a test.
+		if err := utils.NewJSONWriterOut(r.out, true).Write(reports); err != nil {
+			return err
+		}
+		return r.out.Flush()
 	}
 
 	if r.config.Report.Summary {
@@ -674,18 +802,79 @@ func (r *Report) collectFailedTests(ctx context.Context, runID string, testSetID
 	return failedTests, nil
 }
 
-// extractFailedTestsFromResults filters out only the failed tests from results
+// extractFailedTestsFromResults filters out the tests worth rendering per-test
+// detail for: FAILED tests (historical behaviour, unchanged) plus ANY test —
+// whatever its status — carrying a MISSING dependency assertion.
+//
+// The dependency arm is deliberately STATUS-INDEPENDENT. The flagship
+// silent-green case this slice exists to expose is a test whose response still
+// matches while a recorded outgoing call vanished, and the replayer leaves
+// exactly that test PASSED (replay.go's `case testPass:` arm ignores the mock
+// mismatch when the response matched). Admitting only FAILED, or only
+// OBSOLETE, left that regression invisible in text and in JUnit unless the
+// user opted into --assert-dependencies — which would make VISIBILITY depend
+// on a verdict knob. It does not: the knob decides whether it becomes a
+// failure, never whether it is shown.
+//
+// Backward compatible by construction: DepResult had zero writers before this
+// slice, so no report written before it can contain a Normal==false dependency
+// row, and every such report is admitted exactly as before.
 func (r *Report) extractFailedTestsFromResults(tests []models.TestResult) []models.TestResult {
 	var failedTests []models.TestResult
 	for _, result := range tests {
-		if result.Status == models.TestStatusFailed {
+		if shouldRenderDiff(result) {
 			failedTests = append(failedTests, result)
 		}
 	}
 	return failedTests
 }
 
-func (r *Report) printFailedTestReports(ctx context.Context, failedTests []models.TestResult) error {
+// shouldRenderDiff reports whether a test result is admitted to the per-test
+// detail renderer at all.
+func shouldRenderDiff(result models.TestResult) bool {
+	return result.Status == models.TestStatusFailed || result.Result.HasMissingDeps()
+}
+
+// rendersDepNoticeOnly reports whether an admitted result is summarised in the
+// compact dependency block instead of getting the full diff apparatus.
+//
+// ONLY A GENUINELY FAILED TEST GETS THE APPARATUS. A test that did not fail
+// has no response diff to show: printing the header, "CHANGES IN STATUS AND
+// HEADERS" and "CHANGES WITHIN THE RESPONSE BODY" around a PASSED test would
+// be actively misleading, and an OBSOLETE test is in the same position —
+// OBSOLETE is only reachable when the mock set diverged, which under this
+// build guarantees a MISSING row, so admitting OBSOLETE to the full renderer
+// meant 100% of obsolete tests grew a failure block where before this slice
+// they rendered nothing at all in `keploy report`. The brief asked for a
+// compact notice; this is that, for every non-FAILED status.
+func rendersDepNoticeOnly(result models.TestResult) bool {
+	return result.Status != models.TestStatusFailed
+}
+
+// partitionDepNotices splits the admitted results into the ones that get the
+// full diff apparatus and the ones that are folded into the compact
+// dependency block.
+func partitionDepNotices(tests []models.TestResult) (diffs, notices []models.TestResult) {
+	for _, t := range tests {
+		if rendersDepNoticeOnly(t) {
+			notices = append(notices, t)
+			continue
+		}
+		diffs = append(diffs, t)
+	}
+	return diffs, notices
+}
+
+// printFailedTestReports renders the per-test detail for the admitted results.
+//
+// The admitted set is split first: only genuinely FAILED tests get the diff
+// apparatus, and every other status folds into ONE bounded, deduplicated
+// dependency block at the end (renderDepNoticeSummary). Rendering a block per
+// notice-only test instead turned a 16-line all-green report into 1,217 lines
+// on a 300-test suite that had lost one shared dependency.
+func (r *Report) printFailedTestReports(ctx context.Context, admitted []models.TestResult) error {
+	failedTests, notices := partitionDepNotices(admitted)
+
 	if r.config.Report.ShowFullBody {
 
 		workers := max(runtime.GOMAXPROCS(0), 2)
@@ -725,6 +914,9 @@ func (r *Report) printFailedTestReports(ctx context.Context, failedTests []model
 				return fmt.Errorf("failed to write test report to output: %w", err)
 			}
 		}
+		if err := r.writeDepNoticeSummary(notices, admitted); err != nil {
+			return err
+		}
 		err := r.out.Flush()
 		if err != nil {
 			return fmt.Errorf("failed while flushing in printFailedTestReports (full body mode): %w", err)
@@ -761,6 +953,9 @@ func (r *Report) printFailedTestReports(ctx context.Context, failedTests []model
 			return fmt.Errorf("failed to write test report to output: %w", err)
 		}
 	}
+	if err := r.writeDepNoticeSummary(notices, admitted); err != nil {
+		return err
+	}
 	err := r.out.Flush()
 	if err != nil {
 		return fmt.Errorf("failed while flushing in printFailedTestReports: %w", err)
@@ -768,9 +963,22 @@ func (r *Report) printFailedTestReports(ctx context.Context, failedTests []model
 	return nil
 }
 
+// writeDepNoticeSummary appends the compact dependency block, if any.
+func (r *Report) writeDepNoticeSummary(notices, admitted []models.TestResult) error {
+	block := renderDepNoticeSummary(notices, admitted)
+	if block == "" {
+		return nil
+	}
+	if _, err := r.out.WriteString(block); err != nil {
+		return fmt.Errorf("failed to write dependency notice summary: %w", err)
+	}
+	return nil
+}
+
 // renderSingleFailedTest writes the failed test report into sb (non-full-body mode).
 func (r *Report) renderSingleFailedTest(_ context.Context, sb *strings.Builder, test models.TestResult) error {
-	// Header with risk level and categories
+	// Header with risk level and categories. Unconditionally "failed":
+	// partitionDepNotices keeps every non-FAILED status out of this renderer.
 	header := fmt.Sprintf("Testrun failed for %s/%s", test.Name, test.TestCaseID)
 
 	// Add risk level if available and not NONE
@@ -854,6 +1062,12 @@ func (r *Report) renderSingleFailedTest(_ context.Context, sb *strings.Builder, 
 		sb.WriteString("\n\n")
 
 	}
+	// Dependency assertions, AFTER the response diffs. --full puts them here
+	// too (the diff printer buffers and only flushes on Render), so the block
+	// sits in the same place in both modes instead of moving depending on
+	// whether --full was passed.
+	renderDepResults(sb, test)
+
 	sb.WriteString("\n--------------------------------------------------------------------\n")
 	return nil
 }
@@ -937,6 +1151,52 @@ func renderUnmatchedCalls(sb *strings.Builder, test models.TestResult) {
 	sb.WriteString("\n")
 }
 
+// renderDepResults writes the per-test dependency-assertion block
+// (models.Result.DepResult) next to the response diffs, in the same
+// expected-vs-actual language: one line per failed DepMetaResult, and a
+// compact "consumed (presence only)" line for rows that held.
+//
+// GATED ON SOMETHING ACTUALLY BEING MISSING, not merely on the rows existing.
+// The writer emits rows only for dependencies that went missing, so the two
+// conditions coincide today — but a row set from any other producer must not
+// summon an "all dependencies consumed" section under every FAILED test, which
+// tells a human nothing they can act on. The proof that the assertion ran
+// stays where a machine reads it (Result.DepsChecked / the NDJSON
+// `dependencies_checked`); the human sees a block only when a dependency is
+// missing, which is the case worth their attention.
+//
+// So text output is byte-identical to pre-slice-4 for every test that lost
+// nothing. The formatter itself lives in pkg/models so the compact renderer
+// and --full cannot drift apart.
+func renderDepResults(sb *strings.Builder, test models.TestResult) {
+	if !test.Result.HasMissingDeps() {
+		return
+	}
+	sb.WriteString(models.FormatDepResults(test.Result.DepResult))
+}
+
+// depNoticeCounts counts, across a whole run, the tests that lost a recorded
+// dependency and how many of those still PASSED. The passed count is the one
+// that matters: those are the tests a green CI run currently says nothing
+// about.
+func depNoticeCounts(reports map[string]*models.TestReport) (total, passed int) {
+	for _, rep := range reports {
+		if rep == nil {
+			continue
+		}
+		for _, t := range rep.Tests {
+			if !t.Result.HasMissingDeps() {
+				continue
+			}
+			total++
+			if t.Status == models.TestStatusPassed {
+				passed++
+			}
+		}
+	}
+	return total, passed
+}
+
 // writerAdapter lets us reuse a bufio.Writer on top of strings.Builder.
 type writerAdapter struct{ sb *strings.Builder }
 
@@ -994,10 +1254,19 @@ func (r *Report) renderSingleFullBodyFailedTest(ctx context.Context, sb *strings
 		return fmt.Errorf("failed to add body diffs: %w", err)
 	}
 
+	// Render() is what actually flushes the buffered status/header/body diffs
+	// into sb, so the dependency block has to be written AFTER it. Writing it
+	// before put the block above every response diff in --full mode while the
+	// compact renderer put it below them — same data, two positions.
 	if err := logDiffs.Render(); err != nil {
 		r.logger.Error("failed to render the diffs", zap.Error(err))
 		return fmt.Errorf("failed to render diffs: %w", err)
 	}
+
+	// Dependency assertions sit after the body diffs, using the same
+	// expected/actual vocabulary. No-op when the test carries no rows.
+	renderDepResults(sb, test)
+
 	sb.WriteString("\n--------------------------------------------------------------------\n")
 	return nil
 }

--- a/pkg/service/report/testdata/clean-deps-report.yaml
+++ b/pkg/service/report/testdata/clean-deps-report.yaml
@@ -1,0 +1,129 @@
+version: api.keploy.io/v1beta1
+name: test-set-0-report
+status: FAILED
+success: 1
+failure: 1
+obsolete: 1
+ignored: 0
+total: 3
+tests:
+    - kind: Http
+      name: test-set-0
+      status: PASSED
+      started: 1755861852
+      completed: 1755861853
+      test_case_path: /keploy/test-set-0
+      mock_path: /keploy/test-set-0/mocks.yaml
+      test_case_id: test-1
+      req:
+        method: GET
+        proto_major: 1
+        proto_minor: 1
+        url: http://localhost:8080/orders/1
+        header:
+            Accept: application/json
+        body: ""
+        timestamp: 2000-01-01T00:00:00Z
+      resp:
+        status_code: 200
+        header:
+            Content-Type: application/json
+        body: '{"id":1,"status":"CONFIRMED"}'
+        status_message: ""
+        proto_major: 0
+        proto_minor: 0
+        timestamp: 2000-01-01T00:00:00Z
+      result:
+        status_code:
+            normal: true
+            expected: 200
+            actual: 200
+        headers_result: []
+        body_result:
+            - normal: true
+              type: JSON
+              expected: '{"id":1,"status":"CONFIRMED"}'
+              actual: '{"id":1,"status":"CONFIRMED"}'
+        dep_result: []
+        deps_checked: true
+        deps_consumed: 3
+      time_taken: 12.3ms
+    - kind: Http
+      name: test-set-0
+      status: FAILED
+      started: 1755861854
+      completed: 1755861855
+      test_case_path: /keploy/test-set-0
+      mock_path: /keploy/test-set-0/mocks.yaml
+      test_case_id: test-2
+      req:
+        method: POST
+        proto_major: 1
+        proto_minor: 1
+        url: http://localhost:8080/orders
+        header:
+            Content-Type: application/json
+        body: '{"sku":"SKU-9","qty":3}'
+        timestamp: 2000-01-01T00:00:00Z
+      resp:
+        status_code: 500
+        header:
+            Content-Type: application/json
+        body: '{"error":"boom"}'
+        status_message: ""
+        proto_major: 0
+        proto_minor: 0
+        timestamp: 2000-01-01T00:00:00Z
+      result:
+        status_code:
+            normal: false
+            expected: 201
+            actual: 500
+        headers_result: []
+        body_result:
+            - normal: false
+              type: JSON
+              expected: '{"id":2,"status":"CONFIRMED"}'
+              actual: '{"error":"boom"}'
+        dep_result: []
+        deps_checked: true
+        deps_consumed: 4
+      time_taken: 8.1ms
+    - kind: Http
+      name: test-set-0
+      status: OBSOLETE
+      started: 1755861856
+      completed: 1755861857
+      test_case_path: /keploy/test-set-0
+      mock_path: /keploy/test-set-0/mocks.yaml
+      test_case_id: test-3
+      req:
+        method: GET
+        proto_major: 1
+        proto_minor: 1
+        url: http://localhost:8080/orders/9
+        header: {}
+        body: ""
+        timestamp: 2000-01-01T00:00:00Z
+      resp:
+        status_code: 404
+        header: {}
+        body: '{"error":"not found"}'
+        status_message: ""
+        proto_major: 0
+        proto_minor: 0
+        timestamp: 2000-01-01T00:00:00Z
+      result:
+        status_code:
+            normal: false
+            expected: 200
+            actual: 404
+        headers_result: []
+        body_result: []
+        dep_result: []
+        deps_checked: true
+        deps_consumed: 5
+      time_taken: 5.0ms
+test_set: test-set-0
+created_at: 1755861860
+time_taken: 25.4ms

--- a/pkg/service/report/testdata/legacy-report.yaml
+++ b/pkg/service/report/testdata/legacy-report.yaml
@@ -1,0 +1,123 @@
+version: api.keploy.io/v1beta1
+name: test-set-0-report
+status: FAILED
+success: 1
+failure: 1
+obsolete: 1
+ignored: 0
+total: 3
+tests:
+    - kind: Http
+      name: test-set-0
+      status: PASSED
+      started: 1755861852
+      completed: 1755861853
+      test_case_path: /keploy/test-set-0
+      mock_path: /keploy/test-set-0/mocks.yaml
+      test_case_id: test-1
+      req:
+        method: GET
+        proto_major: 1
+        proto_minor: 1
+        url: http://localhost:8080/orders/1
+        header:
+            Accept: application/json
+        body: ""
+        timestamp: 2000-01-01T00:00:00Z
+      resp:
+        status_code: 200
+        header:
+            Content-Type: application/json
+        body: '{"id":1,"status":"CONFIRMED"}'
+        status_message: ""
+        proto_major: 0
+        proto_minor: 0
+        timestamp: 2000-01-01T00:00:00Z
+      result:
+        status_code:
+            normal: true
+            expected: 200
+            actual: 200
+        headers_result: []
+        body_result:
+            - normal: true
+              type: JSON
+              expected: '{"id":1,"status":"CONFIRMED"}'
+              actual: '{"id":1,"status":"CONFIRMED"}'
+        dep_result: []
+      time_taken: 12.3ms
+    - kind: Http
+      name: test-set-0
+      status: FAILED
+      started: 1755861854
+      completed: 1755861855
+      test_case_path: /keploy/test-set-0
+      mock_path: /keploy/test-set-0/mocks.yaml
+      test_case_id: test-2
+      req:
+        method: POST
+        proto_major: 1
+        proto_minor: 1
+        url: http://localhost:8080/orders
+        header:
+            Content-Type: application/json
+        body: '{"sku":"SKU-9","qty":3}'
+        timestamp: 2000-01-01T00:00:00Z
+      resp:
+        status_code: 500
+        header:
+            Content-Type: application/json
+        body: '{"error":"boom"}'
+        status_message: ""
+        proto_major: 0
+        proto_minor: 0
+        timestamp: 2000-01-01T00:00:00Z
+      result:
+        status_code:
+            normal: false
+            expected: 201
+            actual: 500
+        headers_result: []
+        body_result:
+            - normal: false
+              type: JSON
+              expected: '{"id":2,"status":"CONFIRMED"}'
+              actual: '{"error":"boom"}'
+        dep_result: []
+      time_taken: 8.1ms
+    - kind: Http
+      name: test-set-0
+      status: OBSOLETE
+      started: 1755861856
+      completed: 1755861857
+      test_case_path: /keploy/test-set-0
+      mock_path: /keploy/test-set-0/mocks.yaml
+      test_case_id: test-3
+      req:
+        method: GET
+        proto_major: 1
+        proto_minor: 1
+        url: http://localhost:8080/orders/9
+        header: {}
+        body: ""
+        timestamp: 2000-01-01T00:00:00Z
+      resp:
+        status_code: 404
+        header: {}
+        body: '{"error":"not found"}'
+        status_message: ""
+        proto_major: 0
+        proto_minor: 0
+        timestamp: 2000-01-01T00:00:00Z
+      result:
+        status_code:
+            normal: false
+            expected: 200
+            actual: 404
+        headers_result: []
+        body_result: []
+        dep_result: []
+      time_taken: 5.0ms
+test_set: test-set-0
+created_at: 1755861860
+time_taken: 25.4ms

--- a/utils/log/logger.go
+++ b/utils/log/logger.go
@@ -19,6 +19,95 @@ import (
 
 var Emoji = "\U0001F430" + " Keploy:"
 
+// primarySink is the console destination every logger-rebuilding helper
+// attaches its core to. nil means "os.Stdout, resolved at write time" — the
+// historical default — and RedirectToStderr moves it to os.Stderr.
+//
+// nil rather than a captured os.Stdout on purpose: os.Stdout is a variable,
+// and a test that swaps it for a pipe (which is how the CLI's stdout
+// cleanliness is asserted end to end) must see its replacement, not the
+// descriptor this package happened to observe at init. Same reason
+// utils.JSONWriter resolves its default sink at Write time.
+//
+// It exists because the helpers below REBUILD the core from scratch. Before
+// this, ChangeColorEncoding / ChangeLogLevel / AddMode each hardcoded
+// os.Stdout, so any of them running AFTER RedirectToStderr silently undid the
+// redirect and put log lines back on stdout — which corrupts every
+// machine-readable stdout document keploy emits (`--json`, `keploy report
+// --format junit|json`). Verified: `keploy report --format junit --json
+// --disable-ansi` printed two INFO lines above the XML because --disable-ansi
+// runs ChangeColorEncoding after the redirect.
+//
+// Guarded by a mutex rather than left as a plain var: the helpers run during
+// single-threaded CLI startup, but the race detector runs over the whole
+// binary and a package-level var written here and read from a logger rebuild
+// elsewhere is exactly the kind of thing that goes unnoticed until it does not.
+var (
+	primarySinkMu sync.Mutex
+	primarySink   *os.File
+)
+
+// setPrimarySink records the console destination for subsequent logger
+// rebuilds. Not exported: the sink must only ever move as a side effect of a
+// helper in this package that also rebuilds the logger.
+func setPrimarySink(f *os.File) {
+	primarySinkMu.Lock()
+	defer primarySinkMu.Unlock()
+	primarySink = f
+}
+
+// PrimarySink reports the console destination the logger currently writes to.
+//
+// Callers that print non-log output — the logo and the version line — write
+// through it so they stay on the same side of the stdout/stderr split as the
+// logger. Without that the mechanism is only half a mechanism: `keploy report
+// --format json` suppresses the logo outright, but any other future
+// stdout-is-a-document mode would have to remember to suppress every banner
+// individually instead of the split just holding.
+func PrimarySink() *os.File {
+	primarySinkMu.Lock()
+	defer primarySinkMu.Unlock()
+	if primarySink == nil {
+		return os.Stdout
+	}
+	return primarySink
+}
+
+// TestOnlyResetSink restores the package-level console sink and the shared
+// LogCfg to their process-start values.
+//
+// RedirectToStderr and ChangeColorEncoding mutate package state that outlives
+// a single test, so a test that drives the real CLI flag validation leaves the
+// next test in that binary running against a logger pointing at stderr with a
+// plain-console encoder. It exists so those tests can t.Cleanup themselves
+// instead of being order-dependent, and it is exported only because the
+// tests that need it (cli/provider) live in another package — an
+// export_test.go cannot reach across that boundary.
+//
+// NOT FOR PRODUCTION USE, and named so it cannot be reached for by accident.
+// Calling it from a running CLI does not rebuild the logger: the live *zap.
+// Logger keeps whatever core it was built with (including the debug file
+// sink), while the next helper that DOES rebuild — ChangeLogLevel, AddMode,
+// ChangeColorEncoding — silently reverts to stdout and to the default
+// encoder, undoing any --json / --format json redirect. Nothing in the
+// non-test tree calls it; TestNoProductionCallerResetsTheSink pins that.
+//
+// LogCfg is written under primarySinkMu here because this is the one helper
+// that can run from a *_test.go goroutine rather than from single-threaded CLI
+// startup, which is where every other writer of LogCfg (New, ChangeLogLevel,
+// ChangeColorEncoding) runs.
+func TestOnlyResetSink() {
+	primarySinkMu.Lock()
+	defer primarySinkMu.Unlock()
+	primarySink = nil
+	LogCfg = defaultLogCfg()
+}
+
+// primarySyncer is the WriteSyncer form of PrimarySink, for the core builders.
+func primarySyncer() zapcore.WriteSyncer {
+	return zapcore.AddSync(PrimarySink())
+}
+
 var LogCfg zap.Config
 
 // Redactor rewrites log entries/fields in place to strip secrets before the
@@ -200,6 +289,37 @@ func (e ansiConsoleEncoder) Clone() zapcore.Encoder {
 	}
 }
 
+// defaultLogCfg is the package's baseline zap.Config, factored out of New so
+// the rebuild helpers can fall back to it.
+func defaultLogCfg() zap.Config {
+	cfg := zap.NewDevelopmentConfig()
+	cfg.Encoding = "ansiConsole" // Use our custom encoder
+
+	// Customize the encoder config
+	cfg.EncoderConfig.EncodeTime = customTimeEncoder
+	cfg.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
+	cfg.EncoderConfig.EncodeDuration = zapcore.StringDurationEncoder
+
+	cfg.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
+	cfg.DisableStacktrace = true
+	cfg.EncoderConfig.EncodeCaller = nil
+	return cfg
+}
+
+// ensureLogCfg makes the rebuild helpers safe to call before New() has run.
+//
+// They all build their core from LogCfg.Level, and the zero zap.AtomicLevel
+// holds a nil *atomic.Int32 — so a logger built from an untouched LogCfg
+// panics on its first Debug/Info call, at the call site rather than here. In
+// the real binary New() always runs first, but the helpers are reachable from
+// any entry point that has not (and from tests), and a nil-pointer panic
+// inside the logger is a spectacularly bad failure mode for a CLI.
+func ensureLogCfg() {
+	if LogCfg.Level == (zap.AtomicLevel{}) {
+		LogCfg = defaultLogCfg()
+	}
+}
+
 func New() (*zap.Logger, *os.File, error) {
 	// Register the ANSI-friendly encoder
 	_ = zap.RegisterEncoder("ansiConsole", func(config zapcore.EncoderConfig) (zapcore.Encoder, error) {
@@ -216,20 +336,9 @@ func New() (*zap.Logger, *os.File, error) {
 		return nil, nil, fmt.Errorf("failed to set the log file permission to 777: %v", err)
 	}
 
-	writer := wrapWriter(zapcore.NewMultiWriteSyncer(zapcore.AddSync(os.Stdout), zapcore.AddSync(logFile)))
+	writer := wrapWriter(zapcore.NewMultiWriteSyncer(primarySyncer(), zapcore.AddSync(logFile)))
 
-	LogCfg = zap.NewDevelopmentConfig()
-	LogCfg.Encoding = "ansiConsole" // Use our custom encoder
-
-	// Customize the encoder config
-	LogCfg.EncoderConfig.EncodeTime = customTimeEncoder
-	LogCfg.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
-	LogCfg.EncoderConfig.EncodeDuration = zapcore.StringDurationEncoder
-	LogCfg.EncoderConfig.EncodeCaller = zapcore.ShortCallerEncoder
-
-	LogCfg.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
-	LogCfg.DisableStacktrace = true
-	LogCfg.EncoderConfig.EncodeCaller = nil
+	LogCfg = defaultLogCfg()
 
 	// Build the core with our custom encoder
 	encoder := NewANSIConsoleEncoder(LogCfg.EncoderConfig)
@@ -274,6 +383,7 @@ func reattachDebugFileSink(logger *zap.Logger) *zap.Logger {
 }
 
 func ChangeLogLevel(level zapcore.Level) (*zap.Logger, error) {
+	ensureLogCfg()
 	LogCfg.Level = zap.NewAtomicLevelAt(level)
 	if level == zap.DebugLevel {
 		LogCfg.DisableStacktrace = false
@@ -284,7 +394,7 @@ func ChangeLogLevel(level zapcore.Level) (*zap.Logger, error) {
 	encoder := NewANSIConsoleEncoder(LogCfg.EncoderConfig)
 	core := zapcore.NewCore(
 		encoder,
-		wrapWriter(zapcore.AddSync(os.Stdout)),
+		wrapWriter(primarySyncer()),
 		LogCfg.Level,
 	)
 
@@ -292,14 +402,23 @@ func ChangeLogLevel(level zapcore.Level) (*zap.Logger, error) {
 	return reattachDebugFileSink(logger), nil
 }
 
-// RedirectToStderr re-creates the logger writing to stderr instead of stdout.
-// Use this when --json mode is active to prevent log lines from contaminating
-// structured JSON on stdout.
+// RedirectToStderr re-creates the logger writing to stderr instead of stdout,
+// and moves the package's shared console sink there so every subsequent
+// logger rebuild follows.
+//
+// Call this for every mode whose STDOUT is a machine-readable document: the
+// global --json flag, and `keploy report --format json|junit`. A log line on
+// stdout makes that document unparseable.
 func RedirectToStderr() (*zap.Logger, error) {
+	ensureLogCfg()
+	// Move the shared sink FIRST so every later rebuild
+	// (ChangeLogLevel / AddMode / ChangeColorEncoding) inherits stderr
+	// instead of resetting the logger back onto stdout.
+	setPrimarySink(os.Stderr)
 	encoder := NewANSIConsoleEncoder(LogCfg.EncoderConfig)
 	core := zapcore.NewCore(
 		encoder,
-		wrapWriter(zapcore.AddSync(os.Stderr)),
+		wrapWriter(primarySyncer()),
 		LogCfg.Level,
 	)
 
@@ -308,6 +427,7 @@ func RedirectToStderr() (*zap.Logger, error) {
 }
 
 func AddMode(mode string) (*zap.Logger, error) {
+	ensureLogCfg()
 	cfg := LogCfg
 	cfg.EncoderConfig.EncodeTime = func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
 		emoji := "\U0001F430"
@@ -318,7 +438,7 @@ func AddMode(mode string) (*zap.Logger, error) {
 	encoder := NewANSIConsoleEncoder(cfg.EncoderConfig)
 	core := zapcore.NewCore(
 		encoder,
-		wrapWriter(zapcore.AddSync(os.Stdout)),
+		wrapWriter(primarySyncer()),
 		cfg.Level,
 	)
 
@@ -327,6 +447,7 @@ func AddMode(mode string) (*zap.Logger, error) {
 }
 
 func ChangeColorEncoding() (*zap.Logger, error) {
+	ensureLogCfg()
 	// For non-color mode, use the standard console encoder.
 	LogCfg.Encoding = "console"
 	LogCfg.EncoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
@@ -340,7 +461,7 @@ func ChangeColorEncoding() (*zap.Logger, error) {
 	encoder := zapcore.NewConsoleEncoder(LogCfg.EncoderConfig)
 	core := zapcore.NewCore(
 		encoder,
-		wrapWriter(zapcore.AddSync(os.Stdout)),
+		wrapWriter(primarySyncer()),
 		LogCfg.Level,
 	)
 	return reattachDebugFileSink(zap.New(newRedactingCore(core))), nil

--- a/utils/log/sink_test.go
+++ b/utils/log/sink_test.go
@@ -1,0 +1,189 @@
+package log
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// Every logger-rebuilding helper builds its core from the package's shared
+// console sink. RedirectToStderr moves that sink, so a rebuild that happens
+// afterwards — --disable-ansi (ChangeColorEncoding), --debug (ChangeLogLevel),
+// agent mode (AddMode) — must stay on stderr.
+//
+// The regression: each helper used to hardcode os.Stdout, so
+// `keploy report --format junit --json --disable-ansi` printed INFO lines
+// above the XML because --disable-ansi ran after the redirect.
+func TestRedirectToStderrSurvivesEveryLoggerRebuild(t *testing.T) {
+	orig := PrimarySink()
+	t.Cleanup(func() { setPrimarySink(orig) })
+
+	setPrimarySink(os.Stdout)
+	LogCfg = zap.Config{}
+
+	if got := PrimarySink(); got != os.Stdout {
+		t.Fatalf("precondition: sink is %v, want stdout", got)
+	}
+	if _, err := RedirectToStderr(); err != nil {
+		t.Fatalf("RedirectToStderr: %v", err)
+	}
+	if got := PrimarySink(); got != os.Stderr {
+		t.Fatalf("RedirectToStderr did not move the sink: %v", got)
+	}
+
+	rebuilds := []struct {
+		name string
+		fn   func() (*zap.Logger, error)
+	}{
+		{name: "ChangeColorEncoding (--disable-ansi)", fn: ChangeColorEncoding},
+		{name: "ChangeLogLevel (--debug)", fn: func() (*zap.Logger, error) { return ChangeLogLevel(zapcore.DebugLevel) }},
+		{name: "AddMode (agent)", fn: func() (*zap.Logger, error) { return AddMode("agent") }},
+	}
+	for _, rb := range rebuilds {
+		t.Run(rb.name, func(t *testing.T) {
+			logger, err := rb.fn()
+			if err != nil {
+				t.Fatalf("%s: %v", rb.name, err)
+			}
+			if logger == nil {
+				t.Fatalf("%s returned a nil logger", rb.name)
+			}
+			if got := PrimarySink(); got != os.Stderr {
+				t.Errorf("%s put the logger back on %v; machine-readable stdout is now corrupted", rb.name, got)
+			}
+		})
+	}
+}
+
+// The rebuild helpers must be safe before New() has run: they build their core
+// from LogCfg.Level, and the zero zap.AtomicLevel carries a nil *atomic.Int32
+// that panics on the logger's first write — at the caller, not here.
+func TestLoggerRebuildsAreSafeWithAnUninitialisedConfig(t *testing.T) {
+	orig := PrimarySink()
+	origCfg := LogCfg
+	t.Cleanup(func() { setPrimarySink(orig); LogCfg = origCfg })
+
+	rebuilds := map[string]func() (*zap.Logger, error){
+		"RedirectToStderr":    RedirectToStderr,
+		"ChangeColorEncoding": ChangeColorEncoding,
+		"ChangeLogLevel":      func() (*zap.Logger, error) { return ChangeLogLevel(zapcore.InfoLevel) },
+		"AddMode":             func() (*zap.Logger, error) { return AddMode("agent") },
+	}
+	for name, fn := range rebuilds {
+		t.Run(name, func(t *testing.T) {
+			LogCfg = zap.Config{}
+			setPrimarySink(os.Stderr)
+
+			logger, err := fn()
+			if err != nil {
+				t.Fatalf("%s: %v", name, err)
+			}
+			// The panic was on the first write, not on construction.
+			logger.Debug("probe")
+			logger.Info("probe")
+		})
+	}
+}
+
+// The sink defaults to os.Stdout resolved AT CALL TIME, not to the descriptor
+// this package saw at init. A test (and the CLI's own stdout-cleanliness test)
+// swaps os.Stdout for a pipe; capturing it at init would send the logo and the
+// version line to the real terminal and make the capture assert on nothing.
+func TestPrimarySinkResolvesStdoutLazily(t *testing.T) {
+	// TestOnlyResetSink, not a captured sink: restoring an EXPLICIT os.Stdout would
+	// quietly undo the lazy default this test exists to pin.
+	t.Cleanup(TestOnlyResetSink)
+
+	setPrimarySink(nil)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close(); _ = w.Close() })
+
+	realStdout := os.Stdout
+	os.Stdout = w
+	got := PrimarySink()
+	os.Stdout = realStdout
+
+	if got != w {
+		t.Fatalf("PrimarySink() returned %v, want the swapped os.Stdout (%v)", got, w)
+	}
+
+	// And an explicit sink still wins over os.Stdout.
+	setPrimarySink(os.Stderr)
+	if got := PrimarySink(); got != os.Stderr {
+		t.Fatalf("an explicit sink was ignored: %v", got)
+	}
+
+	// TestOnlyResetSink puts it back to the lazy default.
+	TestOnlyResetSink()
+	if got := PrimarySink(); got != os.Stdout {
+		t.Fatalf("TestOnlyResetSink did not restore the stdout default: %v", got)
+	}
+}
+
+// TestOnlyResetSink is an exported symbol on a package every keploy binary
+// imports, and its whole contract is "undo global state a test dirtied". It
+// cannot live in an export_test.go because cli/provider's tests need it across
+// the package boundary, so the guard is this: nothing outside a _test.go file
+// may call it. A production caller would detach the debug file sink from the
+// next logger rebuild and silently undo any --json / --format json redirect.
+func TestNoProductionCallerResetsTheSink(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve module root: %v", err)
+	}
+
+	var offenders []string
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "vendor", "node_modules":
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		body, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		// A CALL is `TestOnlyResetSink(`; the one declaration is
+		// `func TestOnlyResetSink(`. Matching on the call syntax rather than
+		// on the bare name means a caller inside logger.go itself is caught
+		// too, and prose mentions in doc comments are not.
+		for _, line := range strings.Split(string(body), "\n") {
+			idx := strings.Index(line, "TestOnlyResetSink(")
+			if idx < 0 {
+				continue
+			}
+			if strings.HasSuffix(line[:idx], "func ") {
+				continue // the declaration itself
+			}
+			rel, _ := filepath.Rel(root, path)
+			offenders = append(offenders, rel+": "+strings.TrimSpace(line))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	if len(offenders) > 0 {
+		t.Fatalf("log.TestOnlyResetSink is referenced from non-test files %v. "+
+			"It resets package-global logger state and is for tests only: a production caller "+
+			"detaches the debug file sink from the next logger rebuild and undoes the "+
+			"machine-output stderr redirect.", offenders)
+	}
+}

--- a/utils/output.go
+++ b/utils/output.go
@@ -3,17 +3,35 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 )
 
 type JSONWriter struct {
 	enabled bool
+	out     io.Writer
 }
 
+// NewJSONWriter writes to os.Stdout. Kept as-is for every existing caller.
+//
+// The sink is left nil rather than captured here on purpose: Write resolves
+// os.Stdout at call time, so a caller (or a test) that swaps os.Stdout AFTER
+// constructing the writer still gets its output redirected — the behaviour
+// this type had before it grew an explicit sink.
 func NewJSONWriter(enabled bool) *JSONWriter {
 	return &JSONWriter{enabled: enabled}
 }
 
+// NewJSONWriterOut writes to an explicit sink. Needed so callers that already
+// own a buffered writer can emit through it instead of racing os.Stdout, and
+// so the output is assertable in a test. Mirrors matcher.NewDiffsPrinterOut.
+// A nil sink means "os.Stdout, resolved at Write time".
+func NewJSONWriterOut(out io.Writer, enabled bool) *JSONWriter {
+	return &JSONWriter{enabled: enabled, out: out}
+}
+
+// Write marshals v and appends a trailing newline. Called in a loop this
+// produces NDJSON — one self-contained JSON object per line.
 func (w *JSONWriter) Write(v interface{}) error {
 	if !w.enabled {
 		return nil
@@ -24,7 +42,11 @@ func (w *JSONWriter) Write(v interface{}) error {
 		return fmt.Errorf("failed to marshal json output: %w", err)
 	}
 
-	if _, err := fmt.Fprintln(os.Stdout, string(data)); err != nil {
+	out := w.out
+	if out == nil {
+		out = os.Stdout
+	}
+	if _, err := fmt.Fprintln(out, string(data)); err != nil {
 		return fmt.Errorf("failed to write json output: %w", err)
 	}
 	return nil

--- a/utils/output_test.go
+++ b/utils/output_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"os"
 	"strings"
@@ -86,5 +87,71 @@ func TestJSONWriterIsEnabled(t *testing.T) {
 	}
 	if NewJSONWriter(false).IsEnabled() {
 		t.Fatal("expected writer to be disabled")
+	}
+}
+
+// --- NDJSON support (keploy-consumer-design-v2.md §7 slice 4) ---
+
+func TestJSONWriterOut(t *testing.T) {
+	type payload struct {
+		A string `json:"a"`
+	}
+
+	tests := []struct {
+		name    string
+		enabled bool
+		values  []any
+		want    []string
+	}{
+		{name: "disabled writes nothing", enabled: false, values: []any{payload{A: "x"}}, want: nil},
+		{name: "one value, one line", enabled: true, values: []any{payload{A: "x"}}, want: []string{`{"a":"x"}`}},
+		{
+			name:    "a loop produces NDJSON",
+			enabled: true,
+			values:  []any{payload{A: "x"}, payload{A: "y"}},
+			want:    []string{`{"a":"x"}`, `{"a":"y"}`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			w := NewJSONWriterOut(&buf, tt.enabled)
+			for _, v := range tt.values {
+				if err := w.Write(v); err != nil {
+					t.Fatalf("Write: %v", err)
+				}
+			}
+			if len(tt.want) == 0 {
+				if buf.Len() != 0 {
+					t.Fatalf("expected no output, got %q", buf.String())
+				}
+				return
+			}
+			lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+			if len(lines) != len(tt.want) {
+				t.Fatalf("got %d lines, want %d: %q", len(lines), len(tt.want), buf.String())
+			}
+			for i, want := range tt.want {
+				if lines[i] != want {
+					t.Errorf("line %d = %q, want %q", i, lines[i], want)
+				}
+				var decoded map[string]any
+				if err := json.Unmarshal([]byte(lines[i]), &decoded); err != nil {
+					t.Errorf("line %d is not standalone JSON: %v", i, err)
+				}
+			}
+		})
+	}
+}
+
+// A nil sink must not panic; it falls back to stdout like the original writer.
+func TestJSONWriterOutNilSinkFallsBack(t *testing.T) {
+	w := NewJSONWriterOut(nil, false)
+	if w == nil || w.IsEnabled() {
+		t.Fatal("expected a disabled writer")
+	}
+	if err := w.Write(struct{}{}); err != nil {
+		t.Fatalf("Write on a disabled writer: %v", err)
 	}
 }


### PR DESCRIPTION
## Describe the changes that are made

`models.Result.DepResult` has existed since the report schema was written and has **never had a writer**: one declaration, one reader in k8s-proxy, and nothing in between. So keploy could tell you a response changed, but never that a recorded outgoing call **stopped happening**.

It now does, on the ordinary synchronous path. For every test whose per-test mock mapping was actually armed, the run records which mapped dependencies were consumed and which went missing.

### The point is the visibility rule

A missing dependency is reported **whatever the test's status**. When a service still returns the right response but no longer writes its row or calls its downstream, the test **PASSES** — the mock-set mismatch is ignored on the passing branch — so until now nothing surfaced it anywhere. A PASSED test that lost a recorded call now gets a one-line notice, a JUnit `<system-out>`, a summary counter, and says so in NDJSON:

```
=== DEPENDENCIES NOT EXERCISED ===
1 test(s) did not exercise a recorded outgoing call and were NOT failed for it.
(reported only — run with --assert-dependencies to fail on this)
  DEPENDENCY NOT EXERCISED: deps[0] postgres INSERT orders (presence)
```

**Visibility is not the verdict.** `--assert-dependencies` (default **off**) is what turns a missing dependency into a FAILED test, a failed test set and a non-zero exit. Without it, nothing about an existing run's green/red changes. The assertion needs instrument mode, mapping-based filtering and a `mappings.yaml`, and it does not run for deferred streaming test cases — when any of those is missing, keploy logs **one warning per test set naming the reason**, so the flag can never be silently inert.

### A machine-readable verdict, for the first time

`keploy report --format json` emits NDJSON, one object per test result, with a versioned schema. Both `json` and `junit` now write their document to stdout with every log line on stderr, so `keploy report --format json | jq` parses. It did not before — the ANSI logo and community banner went to stdout ahead of the document, which also left `--format junit` emitting XML **no parser would accept**. `report.format` in `keploy.yml` is honoured too; it was silently dead.

### Size

Only missing rows are persisted. Two `omitempty` scalars (`deps_checked`, `deps_consumed`) carry "the check ran, and this many were consumed", which keeps a clean test's `dep_result` **byte-identical** to a pre-change report and costs ~52 bytes/test instead of the ~224 an aggregate row would. Named missing rows are capped per test with an overflow row, and JUnit bodies are bounded — a 300-test suite that loses a whole mock pool produced **2.2 MB** of XML uncapped, now 279 KB.

## Backward compatibility

Verified by building `main` and this branch and diffing stdout byte-for-byte on a pre-change report: `keploy report`, `--summary`, `--full`, `--json`, `--disable-ansi` and `--test-case` are all identical, as are exit codes. The verdict algebra was hand-derived against the old inline switch for all 8 (response × mock-mismatch × knob) combinations.

## Release notes

- `report.format` in `keploy.yml` now works.
- `keploy report --test-case <obsolete>` prints `OBSOLETE ⚠️` instead of `PASSED ✅`.
- The `FAILURE CATEGORIES` block counts failed tests carrying a category but no risk level.
- `--format junit` no longer prints the logo to stdout; `--json --debug` keeps logs on stderr.

## What this does NOT cover

- Nothing async or consumer-shaped.
- A dependency row asserts **that** a call happened, never **what it contained**.
- Streaming tests, `--base-path` runs, `disableMapping` and pre-`mappings.yaml` recordings all report `dependencies_checked: false` — which is also what a test with no dependencies reports.
- "Missing" means "not observed during this test's window": a call made after the response is attributed to the next test.
- The fleet report (k8s-proxy) still shows a PASSED-with-missing-dependency test as clean; its diff block is gated on FAILED/OBSOLETE. Follow-up.

## What type of PR is this?
- [x] 🍕 Feature

## Added e2e test pipeline?
- [x] 👍 yes — extended the existing mock-mismatch workflow
