### PR TITLE
fix(proxy): classify Winsock errors so Windows stops 502ing on resets

### DIFF
--- a/.github/workflows/go_windows.yml
+++ b/.github/workflows/go_windows.yml
@@ -32,3 +32,40 @@ jobs:
           set GOARCH=arm64
           go build -v ./...
         shell: cmd
+
+      # This repository has never run a Go test on Windows - this job only
+      # ever compiled. That is how a whole class of bug survived unnoticed:
+      # Go's syscall.ECONNRESET / ECONNREFUSED / ECONNABORTED / EPIPE are
+      # APPLICATION_ERROR-space values on Windows that Winsock never returns
+      # and syscall.Errno.Is does not map, so every predicate written against
+      # them was silently inert on this platform. pkg/neterr classifies those
+      # correctly, and its tests drive real sockets rather than synthetic
+      # errno values - which means they only prove anything when they run
+      # here, on Windows.
+      #
+      # Package selection, in order of what it buys:
+      #   ./pkg               IsTransportConnReset and the connection-refused
+      #                       retry live here, and they are called from
+      #                       pkg/service/replay with no build tag - this is
+      #                       the code that genuinely runs natively on Windows.
+      #                       It also already holds a real-socket
+      #                       connection-refused test.
+      #   ./pkg/neterr        the classification itself.
+      #   .../proxy/incoming  isStaleConnError, which decides whether an
+      #                       idempotent request is redialed and replayed or
+      #                       turned into a 502 for the user's application.
+      #   .../integrations/http  the recorded-upstream-error markers.
+      #
+      # Every one of these was cross-compiled and executed on a real Windows
+      # host before being listed. pkg/agent/proxy is deliberately NOT here:
+      # two of its tests read a source file by relative path, so I could not
+      # separate "fails on Windows" from "fails in my harness" and will not
+      # add a package on a guess. Widen this list as packages are shown to
+      # pass here, not speculatively.
+      #
+      # One `go test` invocation with several patterns, not several joined by
+      # &&: under `shell: cmd` a multi-line block is a batch file that does not
+      # stop on failure and reports only the last exit code.
+      - name: Test amd64
+        run: go test -count=1 ./pkg/ ./pkg/neterr/... ./pkg/agent/proxy/incoming/... ./pkg/agent/proxy/integrations/http/...
+        shell: cmd

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"go.keploy.io/server/v3/pkg"
@@ -19,6 +18,7 @@ import (
 	"go.keploy.io/server/v3/pkg/agent/memoryguard"
 	syncMock "go.keploy.io/server/v3/pkg/agent/proxy/syncMock"
 	"go.keploy.io/server/v3/pkg/models"
+	"go.keploy.io/server/v3/pkg/neterr"
 	"go.uber.org/zap"
 )
 
@@ -979,9 +979,15 @@ func isStaleConnError(err error) bool {
 	// not included — a slow upstream isn't a stale-pool case and
 	// replay would just re-pay the timeout while double-charging the
 	// upstream for the original.
-	if errors.Is(err, syscall.ECONNRESET) ||
-		errors.Is(err, syscall.EPIPE) ||
-		errors.Is(err, syscall.ECONNABORTED) {
+	//
+	// Classified through pkg/neterr rather than against syscall.E*
+	// directly: on Windows those constants are APPLICATION_ERROR-space
+	// values Winsock never returns, so the direct comparison is inert
+	// and every pooled-connection reset became a hard 502 instead of a
+	// transparent redial.
+	if neterr.IsConnReset(err) ||
+		neterr.IsBrokenPipe(err) ||
+		neterr.IsConnAborted(err) {
 		return true
 	}
 	if errors.Is(err, net.ErrClosed) {

--- a/pkg/agent/proxy/incoming/peek_windows.go
+++ b/pkg/agent/proxy/incoming/peek_windows.go
@@ -27,9 +27,24 @@ import "net"
 //   - WSAEventSelect: overrides the socket's notification mode that Go
 //     relies on.
 //
-// Since the keploy ingress forwarder is driven by the eBPF bind redirector
-// (Linux-only), Windows is not a real deployment target for this codepath.
-// Keep the stub until/unless that changes.
+// Note this is a stub for the PEEK only, not a statement that the forwarder is
+// unused on Windows. An earlier version of this comment said Windows "is not a
+// real deployment target for this codepath", which does not follow: the
+// editions that intercept natively on Windows move the application's listener
+// and forward through exactly this code. Only the interception backend lives
+// elsewhere; the proxy is here.
+//
+// What is absent on Windows is the PRE-EMPTIVE check, not stale detection as
+// such: the read-path classification in handleHttp1ZeroCopy still runs, and
+// job 97044495434 is it failing — "Failed to read upstream response and
+// request is not safely replayable ... wsarecv" on a GET with content_length 0,
+// i.e. canReplay was true and only isStaleConnError returning false sent it to
+// writeBadGateway. So with no peek to catch the dead connection first, that
+// classification is the whole of Windows' defence, and it is only as good as
+// the errno matching behind it (pkg/neterr).
+//
+// Keep the stub until a probe exists that does not fight Go's IOCP ownership
+// of the socket.
 func peekUpstreamLive(_ net.Conn) bool {
 	return true
 }

--- a/pkg/agent/proxy/incoming/staleconn_test.go
+++ b/pkg/agent/proxy/incoming/staleconn_test.go
@@ -1,0 +1,118 @@
+package proxy
+
+import (
+	"errors"
+	"io"
+	"net"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// isStaleConnError decides whether an idempotent request is redialed and
+// replayed or turned into a 502 for the caller's application. Nothing covered
+// it before, which is how it went unnoticed that on Windows it answered false
+// for every real connection reset.
+func TestIsStaleConnError(t *testing.T) {
+	timeoutErr := &net.OpError{Op: "read", Net: "tcp", Err: os.ErrDeadlineExceeded}
+	if !timeoutErr.Timeout() {
+		t.Fatalf("harness: expected a timeout error, got %v", timeoutErr)
+	}
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"eof", io.EOF, true},
+		{"unexpected eof", io.ErrUnexpectedEOF, true},
+		{"wrapped eof", &net.OpError{Op: "read", Net: "tcp", Err: io.EOF}, true},
+		{"net.ErrClosed", &net.OpError{Op: "read", Net: "tcp", Err: net.ErrClosed}, true},
+		{"conn reset", &net.OpError{Op: "read", Net: "tcp", Err: os.NewSyscallError("read", syscall.ECONNRESET)}, true},
+		{"broken pipe", &net.OpError{Op: "write", Net: "tcp", Err: os.NewSyscallError("write", syscall.EPIPE)}, true},
+		{"conn aborted", &net.OpError{Op: "read", Net: "tcp", Err: os.NewSyscallError("read", syscall.ECONNABORTED)}, true},
+
+		// The exclusions are the load-bearing half. A timeout means the
+		// upstream may still be processing the request, so replaying would
+		// double-charge it; a parse failure is deterministic and replay would
+		// only re-trigger it.
+		{"timeout", timeoutErr, false},
+		{"conn refused", &net.OpError{Op: "dial", Net: "tcp", Err: os.NewSyscallError("connect", syscall.ECONNREFUSED)}, false},
+		{"protocol parse error", errors.New("malformed HTTP response \"garbage\""), false},
+	}
+
+	for _, c := range cases {
+		if got := isStaleConnError(c.err); got != c.want {
+			t.Errorf("isStaleConnError(%v) = %v, want %v", c.err, got, c.want)
+		}
+	}
+}
+
+// The table above builds errno values by hand, which is exactly the kind of
+// test that passed on Windows while production failed: a hand-made
+// syscall.ECONNRESET, EPIPE or ECONNABORTED matches itself on every platform,
+// but Winsock produces none of those values. Note in particular that the
+// "conn aborted" row asserts behaviour no Windows error can reach — Winsock's
+// 10053 is deliberately unmapped (see pkg/neterr) — so that row proves the
+// POSIX contract and nothing about this platform. This drives a real
+// connection instead.
+func TestIsStaleConnError_RealPeerReset(t *testing.T) {
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	served := make(chan struct{})
+	go func() {
+		defer close(served)
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		_ = c.SetReadDeadline(time.Now().Add(5 * time.Second))
+		buf := make([]byte, 64)
+		_, _ = c.Read(buf)
+		if tc, ok := c.(*net.TCPConn); ok {
+			_ = tc.SetLinger(0) // abortive close: RST, not FIN
+		}
+		_ = c.Close()
+	}()
+
+	c, err := net.Dial("tcp4", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+	if _, err := c.Write([]byte("GET / HTTP/1.1\r\nHost: x\r\n\r\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	<-served
+
+	_ = c.SetReadDeadline(time.Now().Add(10 * time.Second))
+	buf := make([]byte, 512)
+	var readErr error
+	for {
+		if _, readErr = c.Read(buf); readErr != nil {
+			break
+		}
+	}
+
+	if errors.Is(readErr, os.ErrDeadlineExceeded) {
+		t.Fatalf("harness did not produce a reset: read deadline expired. err=%v", readErr)
+	}
+	if errors.Is(readErr, io.EOF) {
+		// A graceful close is also replayable, so this is not a failure of
+		// the predicate — but it means the reset path went untested.
+		t.Fatalf("harness did not produce a reset: peer closed gracefully. err=%v", readErr)
+	}
+	if !isStaleConnError(readErr) {
+		var errno syscall.Errno
+		errors.As(readErr, &errno)
+		t.Fatalf("isStaleConnError(%v) = false for a real peer reset; unwrapped errno = %d. "+
+			"An idempotent request that hits this gets a 502 instead of a redial and replay.",
+			readErr, uintptr(errno))
+	}
+}

--- a/pkg/agent/proxy/integrations/http/upstream_error.go
+++ b/pkg/agent/proxy/integrations/http/upstream_error.go
@@ -10,6 +10,8 @@ import (
 	"net"
 	nhttp "net/http"
 	"strings"
+
+	"go.keploy.io/server/v3/pkg/neterr"
 )
 
 // UpstreamErrorMarker is a response header the recorder adds when it
@@ -71,6 +73,17 @@ func classifyUpstreamError(err error) (status int, reason, marker string) {
 	// Connection-refused / reset / host-unreachable fall into a generic 502
 	// with a more specific marker so post-hoc analysis can pivot by error
 	// class.
+	//
+	// Classified by errno first. The string forms below are Linux renderings:
+	// Windows says "connectex: No connection could be made because the target
+	// machine actively refused it" and "wsarecv: An existing connection was
+	// forcibly closed by the remote host", so a Windows reset used to fall
+	// through to the generic "upstream-error" marker and be reported as class
+	// "other". The strings stay as a backstop for errors that reach here with
+	// no errno left in the chain.
+	if neterr.IsConnRefused(err) || neterr.IsConnReset(err) || neterr.IsBrokenPipe(err) {
+		return 502, "Bad Gateway", "keploy-recorded-upstream-unreachable: true"
+	}
 	msg := strings.ToLower(err.Error())
 	if strings.Contains(msg, "connection refused") ||
 		strings.Contains(msg, "connection reset") ||
@@ -101,6 +114,9 @@ func upstreamErrorClass(err error) string {
 	}
 	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 		return "eof"
+	}
+	if neterr.IsConnRefused(err) || neterr.IsConnReset(err) || neterr.IsBrokenPipe(err) {
+		return "unreachable"
 	}
 	msg := strings.ToLower(err.Error())
 	if strings.Contains(msg, "connection refused") ||

--- a/pkg/agent/proxy/integrations/http/upstream_error_errno_test.go
+++ b/pkg/agent/proxy/integrations/http/upstream_error_errno_test.go
@@ -1,0 +1,70 @@
+package http
+
+import (
+	"net"
+	"os"
+	"syscall"
+	"testing"
+)
+
+// opaqueNetErr carries a real errno but renders a message that contains none
+// of the substrings classifyUpstreamError greps for. That is not a contrivance:
+// it is what Windows looks like. A reset there is errno 10054 rendered as
+// "wsarecv: An existing connection was forcibly closed by the remote host",
+// so the substring pass misses it and the recorded mock is marked
+// upstream-error instead of upstream-unreachable. On Linux the two agree,
+// which is why the substring-only version looked correct.
+type opaqueNetErr struct{ err error }
+
+func (o opaqueNetErr) Error() string { return "upstream exchange failed" }
+func (o opaqueNetErr) Unwrap() error { return o.err }
+
+func TestUpstreamErrorClassifiedByErrno(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"reset", opaqueNetErr{&net.OpError{Op: "read", Net: "tcp", Err: os.NewSyscallError("read", syscall.ECONNRESET)}}},
+		{"refused", opaqueNetErr{&net.OpError{Op: "dial", Net: "tcp", Err: os.NewSyscallError("connect", syscall.ECONNREFUSED)}}},
+		{"broken pipe", opaqueNetErr{&net.OpError{Op: "write", Net: "tcp", Err: os.NewSyscallError("write", syscall.EPIPE)}}},
+	}
+
+	for _, c := range cases {
+		if got := c.err.Error(); got != "upstream exchange failed" {
+			t.Fatalf("harness: %s renders as %q, so the substring pass would catch it and this test would prove nothing", c.name, got)
+		}
+
+		status, _, marker := classifyUpstreamError(c.err)
+		if status != 502 {
+			t.Errorf("classifyUpstreamError(%s) status = %d, want 502", c.name, status)
+		}
+		if marker != "keploy-recorded-upstream-unreachable: true" {
+			t.Errorf("classifyUpstreamError(%s) marker = %q, want the unreachable marker; "+
+				"the errno was present but only the message text was consulted", c.name, marker)
+		}
+
+		if got := upstreamErrorClass(c.err); got != "unreachable" {
+			t.Errorf("upstreamErrorClass(%s) = %q, want \"unreachable\"", c.name, got)
+		}
+	}
+}
+
+// The errno pass must not swallow classes that have their own handling.
+func TestUpstreamErrorErrnoDoesNotStealOtherClasses(t *testing.T) {
+	timeout := opaqueNetErr{&net.OpError{Op: "read", Net: "tcp", Err: os.ErrDeadlineExceeded}}
+	if got := upstreamErrorClass(timeout); got != "timeout" {
+		t.Errorf("upstreamErrorClass(timeout) = %q, want \"timeout\"", got)
+	}
+
+	plain := opaqueNetErr{errString("something structural")}
+	if got := upstreamErrorClass(plain); got != "other" {
+		t.Errorf("upstreamErrorClass(non-network) = %q, want \"other\"", got)
+	}
+	if _, _, marker := classifyUpstreamError(plain); marker != "keploy-recorded-upstream-error: true" {
+		t.Errorf("classifyUpstreamError(non-network) marker = %q, want the generic error marker", marker)
+	}
+}
+
+type errString string
+
+func (e errString) Error() string { return string(e) }

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	expirable "github.com/hashicorp/golang-lru/v2/expirable"
@@ -36,6 +35,7 @@ import (
 	pTls "go.keploy.io/server/v3/pkg/agent/proxy/tls"
 	"go.keploy.io/server/v3/pkg/agent/proxy/util"
 	"go.keploy.io/server/v3/pkg/models"
+	"go.keploy.io/server/v3/pkg/neterr"
 	"go.keploy.io/server/v3/utils"
 	"go.uber.org/zap"
 )
@@ -3661,13 +3661,21 @@ func isShutdownError(err error) bool {
 	if strings.Contains(errStr, "use of closed network connection") {
 		return true
 	}
-	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.ECONNABORTED) {
+	if neterr.IsConnReset(err) || neterr.IsConnAborted(err) {
 		return true
 	}
 	if strings.Contains(errStr, "connection reset by peer") {
 		return true
 	}
-	// Windows-specific error patterns for connection close during shutdown
+	// Kept for errors that arrive as plain strings with no errno left in the
+	// chain. Note the two halves are not equally reliable: "wsarecv" and
+	// "wsasend" are Go's own syscall op names (net/fd_windows.go), so they
+	// are locale-independent and already match every socket read/write error
+	// on Windows — broadly enough that the errno check above is redundant at
+	// this particular site. "forcibly closed by the remote host" is the
+	// opposite: Windows renders it in the system display language, so it is
+	// an English-only match and must never be the only thing carrying a
+	// classification.
 	if strings.Contains(errStr, "wsarecv") || strings.Contains(errStr, "wsasend") ||
 		strings.Contains(errStr, "forcibly closed by the remote host") {
 		return true

--- a/pkg/agent/proxy/shutdownerr_test.go
+++ b/pkg/agent/proxy/shutdownerr_test.go
@@ -1,0 +1,47 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"syscall"
+	"testing"
+)
+
+// opaqueNetErr carries a real errno behind a message that matches none of the
+// substrings isShutdownError greps for. This is the Windows shape: the errno is
+// there, the text is not the Linux text.
+type opaqueNetErr struct{ err error }
+
+func (o opaqueNetErr) Error() string { return "connection ended" }
+func (o opaqueNetErr) Unwrap() error { return o.err }
+
+func TestIsShutdownError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"context canceled", context.Canceled, true},
+		{"net.ErrClosed", net.ErrClosed, true},
+		{"use of closed network connection", errors.New("use of closed network connection"), true},
+		{"connection reset by peer text", errors.New("read tcp: connection reset by peer"), true},
+		{"wsarecv text", errors.New("read tcp: wsarecv: An existing connection was forcibly closed by the remote host."), true},
+
+		// The errno is present but nothing in the message is. Without the
+		// errno classification this returns false and the shutdown is logged
+		// at Error level as if it were a real failure.
+		{"reset errno, opaque message", opaqueNetErr{&net.OpError{Op: "read", Net: "tcp", Err: os.NewSyscallError("read", syscall.ECONNRESET)}}, true},
+		{"aborted errno, opaque message", opaqueNetErr{&net.OpError{Op: "read", Net: "tcp", Err: os.NewSyscallError("read", syscall.ECONNABORTED)}}, true},
+
+		{"unrelated", errors.New("malformed frame header"), false},
+		{"refused is not a shutdown", opaqueNetErr{&net.OpError{Op: "dial", Net: "tcp", Err: os.NewSyscallError("connect", syscall.ECONNREFUSED)}}, false},
+	}
+
+	for _, c := range cases {
+		if got := isShutdownError(c.err); got != c.want {
+			t.Errorf("isShutdownError(%s) = %v, want %v (err=%v)", c.name, got, c.want, c.err)
+		}
+	}
+}

--- a/pkg/neterr/neterr.go
+++ b/pkg/neterr/neterr.go
@@ -1,0 +1,88 @@
+// Package neterr classifies socket errors in a way that works on every
+// platform keploy runs on.
+//
+// The portable syscall.E* constants are not portable. On Windows, Go's syscall
+// package defines ECONNRESET, ECONNABORTED, ECONNREFUSED and EPIPE as invented
+// values in the APPLICATION_ERROR space (syscall/zerrors_windows.go), which
+// Winsock never returns: a reset socket surfaces as syscall.Errno(10054)
+// (WSAECONNRESET), a refused connect as 10061 (WSAECONNREFUSED). syscall.Errno's
+// Is method (syscall/syscall_windows.go) maps only the oserror sentinels —
+// permission/exist/notexist/unsupported — so there is no bridge between the two
+// sets. errors.Is(err, syscall.ECONNRESET) is therefore *always false* on
+// Windows, however the error was produced.
+//
+// Measured on windows/amd64 (Windows 11, binary built with Go 1.27) against a
+// real peer RST:
+//
+//	err                              = read tcp4 ...: wsarecv: An existing connection was forcibly closed by the remote host.
+//	unwrapped errno                  = 10054
+//	errors.Is(err, syscall.ECONNRESET) = false
+//
+// and on linux/amd64 for the same reproducer, errno 104 and true. Predicates
+// written against the portable constants alone are silently inert on Windows,
+// which turns "retry this dead connection" into a user-visible failure.
+//
+// Use these helpers instead of comparing against syscall constants directly.
+package neterr
+
+import (
+	"errors"
+	"syscall"
+)
+
+func isAny(err error, errnos []syscall.Errno) bool {
+	for _, e := range errnos {
+		if errors.Is(err, e) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsConnReset reports whether err is a connection reset by the peer.
+func IsConnReset(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, syscall.ECONNRESET) || isAny(err, connResetErrnos)
+}
+
+// IsConnAborted reports whether the connection was aborted locally — the
+// host's own stack tore it down, typically mid-handshake or on timeout.
+//
+// On Windows this is effectively always false, deliberately. The Winsock code
+// for it, WSAECONNABORTED, also covers a TCP data-transmission timeout, and
+// callers here exclude timeouts on purpose; mapping it would relax that on one
+// platform only. See neterr_windows.go. Do not use this predicate as the sole
+// gate on anything that must work on Windows.
+func IsConnAborted(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, syscall.ECONNABORTED) || isAny(err, connAbortedErrnos)
+}
+
+// IsBrokenPipe reports whether err is a write to a connection that is no
+// longer writable because it has been shut down.
+//
+// The two platforms name different halves of that. POSIX EPIPE is raised on a
+// write after the PEER closed. Winsock has no socket EPIPE: the peer-closed
+// case arrives as 10054/10053 and is covered by IsConnReset, while
+// WSAESHUTDOWN (10058) is a write after the LOCAL side called shutdown. Both
+// mean "this connection will not carry another write", which is what every
+// caller asks.
+func IsBrokenPipe(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, syscall.EPIPE) || isAny(err, brokenPipeErrnos)
+}
+
+// IsConnRefused reports whether a connect attempt was actively refused —
+// nothing is listening on the target port.
+func IsConnRefused(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, syscall.ECONNREFUSED) || isAny(err, connRefusedErrnos)
+}

--- a/pkg/neterr/neterr_other.go
+++ b/pkg/neterr/neterr_other.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package neterr
+
+import "syscall"
+
+// Everywhere except Windows the portable syscall constants are the real errno
+// values, so there is nothing extra to match.
+var (
+	connResetErrnos   []syscall.Errno
+	connAbortedErrnos []syscall.Errno
+	brokenPipeErrnos  []syscall.Errno
+	connRefusedErrnos []syscall.Errno
+)

--- a/pkg/neterr/neterr_test.go
+++ b/pkg/neterr/neterr_test.go
@@ -1,0 +1,173 @@
+package neterr
+
+import (
+	"errors"
+	"io"
+	"net"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// dialAndGetReset drives a real TCP connection whose peer answers with RST,
+// and returns the error the read surfaced. Everything here is deliberately
+// real: the whole point of this package is that synthetic syscall.Errno values
+// do not tell you what the platform actually produces.
+func dialAndGetReset(t *testing.T) error {
+	t.Helper()
+
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	accepted := make(chan struct{})
+	go func() {
+		defer close(accepted)
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		// Read what the client sent so the RST is a response to a complete
+		// exchange rather than to unread data.
+		_ = c.SetReadDeadline(time.Now().Add(5 * time.Second))
+		buf := make([]byte, 64)
+		_, _ = c.Read(buf)
+		if tc, ok := c.(*net.TCPConn); ok {
+			// linger 0 makes Close send RST instead of FIN. This is the whole
+			// experiment; without it the peer closes gracefully and the client
+			// sees io.EOF, which is a different classification.
+			_ = tc.SetLinger(0)
+		}
+		_ = c.Close()
+	}()
+
+	c, err := net.Dial("tcp4", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	if _, err := c.Write([]byte("ping")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	<-accepted
+
+	_ = c.SetReadDeadline(time.Now().Add(10 * time.Second))
+	buf := make([]byte, 64)
+	for {
+		if _, err := c.Read(buf); err != nil {
+			return err
+		}
+	}
+}
+
+func TestIsConnReset_RealPeerReset(t *testing.T) {
+	err := dialAndGetReset(t)
+
+	// Distinguish "the experiment did not run" from "classification is
+	// broken". A graceful FIN surfaces as io.EOF and a lost RST as a deadline
+	// expiry; neither is a classification failure, and reporting them as one
+	// would send the next reader hunting for an errno bug that is not there.
+	if err == nil {
+		t.Fatal("read succeeded against a peer that reset the connection")
+	}
+	if errors.Is(err, io.EOF) {
+		t.Fatalf("harness did not produce a reset: peer closed gracefully, so SetLinger(0) did not take effect. err=%v", err)
+	}
+	if errors.Is(err, os.ErrDeadlineExceeded) {
+		t.Fatalf("harness did not produce a reset: the read deadline expired with no error from the peer. err=%v", err)
+	}
+
+	if !IsConnReset(err) {
+		var errno syscall.Errno
+		errors.As(err, &errno)
+		t.Fatalf("IsConnReset(%v) = false; unwrapped errno = %d. "+
+			"On Windows a real reset is WSAECONNRESET (10054) while syscall.ECONNRESET "+
+			"is an APPLICATION_ERROR-space value, so comparing against the portable "+
+			"constant alone is inert - that is the bug this package exists to prevent.",
+			err, uintptr(errno))
+	}
+}
+
+func TestIsConnRefused_RealDeadPort(t *testing.T) {
+	// Bind and immediately release, so the port is known to have no listener.
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// Retry rather than skip. This is the only test of IsConnRefused
+	// anywhere, so a skip would let the Windows job go green having proven
+	// nothing at all.
+	var dialErr error
+	for attempt := 0; attempt < 5; attempt++ {
+		c, err := net.Dial("tcp4", addr)
+		if err != nil {
+			dialErr = err
+			break
+		}
+		_ = c.Close()
+		time.Sleep(50 * time.Millisecond)
+	}
+	if dialErr == nil {
+		t.Fatalf("nothing refused a connection to %s across 5 attempts; the harness could not produce the error under test", addr)
+	}
+	err = dialErr
+
+	if !IsConnRefused(err) {
+		var errno syscall.Errno
+		errors.As(err, &errno)
+		t.Fatalf("IsConnRefused(%v) = false; unwrapped errno = %d. "+
+			"On Windows a refused connect is WSAECONNREFUSED (10061), not syscall.ECONNREFUSED.",
+			err, uintptr(errno))
+	}
+	if IsConnReset(err) {
+		t.Errorf("IsConnReset(%v) = true for a refused connect; the classes must not overlap", err)
+	}
+}
+
+func TestNilAndUnrelatedErrors(t *testing.T) {
+	for _, fn := range []struct {
+		name string
+		f    func(error) bool
+	}{
+		{"IsConnReset", IsConnReset},
+		{"IsConnAborted", IsConnAborted},
+		{"IsBrokenPipe", IsBrokenPipe},
+		{"IsConnRefused", IsConnRefused},
+	} {
+		if fn.f(nil) {
+			t.Errorf("%s(nil) = true, want false", fn.name)
+		}
+		if fn.f(errors.New("something else entirely")) {
+			t.Errorf("%s(unrelated) = true, want false", fn.name)
+		}
+		if fn.f(io.EOF) {
+			t.Errorf("%s(io.EOF) = true, want false; EOF is a graceful close, not a reset", fn.name)
+		}
+	}
+}
+
+// TestPortableConstantsStillMatch guards the portable branch on every platform.
+// Note what it does NOT prove: a value built from syscall.ECONNRESET compares
+// equal to itself everywhere, Windows included, so this passing on Windows says
+// nothing about real sockets. That is the whole reason the tests above drive an
+// actual connection.
+func TestPortableConstantsStillMatch(t *testing.T) {
+	wrapped := &net.OpError{Op: "read", Net: "tcp", Err: syscall.ECONNRESET}
+	got := IsConnReset(wrapped)
+	if !got {
+		t.Fatalf("IsConnReset(wrapped syscall.ECONNRESET) = false; the portable branch regressed")
+	}
+	if !strings.Contains(wrapped.Error(), "read") {
+		t.Fatalf("unexpected error rendering: %v", wrapped)
+	}
+}

--- a/pkg/neterr/neterr_windows.go
+++ b/pkg/neterr/neterr_windows.go
@@ -1,0 +1,41 @@
+//go:build windows
+
+package neterr
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// The Winsock codes net actually surfaces on Windows. Go's own syscall.E*
+// constants live in the APPLICATION_ERROR space and never match these — see
+// the package comment.
+var (
+	connResetErrnos = []syscall.Errno{
+		windows.WSAECONNRESET, // 10054 - peer sent RST
+		windows.WSAENETRESET,  // 10052 - connection broken, keep-alive detected failure
+	}
+
+	// Deliberately empty. The obvious candidate is WSAECONNABORTED (10053),
+	// and it is deliberately NOT here: Windows returns it both for a genuine
+	// abort and for a TCP data-transmission timeout, whereas every caller of
+	// this package excludes timeouts on purpose — a slow upstream is not a
+	// dead connection, and re-sending would double-charge an upstream that
+	// may already have processed the request. Mapping an ambiguous code would
+	// quietly relax that contract on one platform only. Under-detecting costs
+	// a 502, which is exactly the behaviour today; over-detecting costs a
+	// duplicate side effect.
+	connAbortedErrnos []syscall.Errno
+
+	// Windows has no EPIPE for sockets. A send after the local side has shut
+	// the socket down is WSAESHUTDOWN. WSAECONNABORTED is excluded here for
+	// the reason above.
+	brokenPipeErrnos = []syscall.Errno{
+		windows.WSAESHUTDOWN, // 10058
+	}
+
+	connRefusedErrnos = []syscall.Errno{
+		windows.WSAECONNREFUSED, // 10061 - "connectex: ... actively refused it"
+	}
+)

--- a/pkg/neterr/neterr_windows_test.go
+++ b/pkg/neterr/neterr_windows_test.go
@@ -1,0 +1,71 @@
+//go:build windows
+
+package neterr
+
+import (
+	"errors"
+	"net"
+	"os"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+// The real-socket tests can only provoke WSAECONNRESET and WSAECONNREFUSED.
+// The rest of the table is pinned here: without this, deleting an entry from
+// neterr_windows.go compiles and every test still passes.
+func TestWindowsErrnoTable(t *testing.T) {
+	cases := []struct {
+		name                                   string
+		errno                                  syscall.Errno
+		reset, aborted, brokenPipe, connRefuse bool
+	}{
+		{"WSAECONNRESET", windows.WSAECONNRESET, true, false, false, false},
+		{"WSAENETRESET", windows.WSAENETRESET, true, false, false, false},
+		{"WSAESHUTDOWN", windows.WSAESHUTDOWN, false, false, true, false},
+		{"WSAECONNREFUSED", windows.WSAECONNREFUSED, false, false, false, true},
+
+		// Ambiguous on Windows (genuine abort OR data-transmission timeout),
+		// so it maps to nothing. See the comment in neterr_windows.go: every
+		// caller excludes timeouts deliberately, and this is the only code
+		// that would smuggle one back in.
+		{"WSAECONNABORTED", windows.WSAECONNABORTED, false, false, false, false},
+
+		// Timeouts and unrelated Winsock failures must classify as nothing.
+		{"WSAETIMEDOUT", windows.WSAETIMEDOUT, false, false, false, false},
+		{"WSAEHOSTUNREACH", windows.WSAEHOSTUNREACH, false, false, false, false},
+	}
+
+	for _, c := range cases {
+		// Wrapped the way net actually delivers it, so this exercises the
+		// same errors.Is unwrap chain as production.
+		err := &net.OpError{Op: "read", Net: "tcp", Err: os.NewSyscallError("wsarecv", c.errno)}
+		if got := IsConnReset(err); got != c.reset {
+			t.Errorf("IsConnReset(%s/%d) = %v, want %v", c.name, uintptr(c.errno), got, c.reset)
+		}
+		if got := IsConnAborted(err); got != c.aborted {
+			t.Errorf("IsConnAborted(%s/%d) = %v, want %v", c.name, uintptr(c.errno), got, c.aborted)
+		}
+		if got := IsBrokenPipe(err); got != c.brokenPipe {
+			t.Errorf("IsBrokenPipe(%s/%d) = %v, want %v", c.name, uintptr(c.errno), got, c.brokenPipe)
+		}
+		if got := IsConnRefused(err); got != c.connRefuse {
+			t.Errorf("IsConnRefused(%s/%d) = %v, want %v", c.name, uintptr(c.errno), got, c.connRefuse)
+		}
+	}
+}
+
+// Pins the premise the whole package rests on: the portable constant does not
+// match what the platform produces. If Go ever bridges these, this fails and
+// the package can be reconsidered.
+func TestPortableConstantDoesNotMatchWinsock(t *testing.T) {
+	err := &net.OpError{Op: "read", Net: "tcp", Err: os.NewSyscallError("wsarecv", windows.WSAECONNRESET)}
+	if errors.Is(err, syscall.ECONNRESET) {
+		t.Fatal("errors.Is(WSAECONNRESET, syscall.ECONNRESET) is now true on Windows; " +
+			"Go bridged the APPLICATION_ERROR constants to the Winsock codes and this package's premise has changed")
+	}
+	if !IsConnReset(err) {
+		t.Fatal("IsConnReset failed on a WSAECONNRESET that net would produce")
+	}
+}

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -30,13 +30,13 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 	"unicode/utf8"
 
 	"github.com/andybalholm/brotli"
 	"go.keploy.io/server/v3/pkg/models"
 
+	"go.keploy.io/server/v3/pkg/neterr"
 	"go.keploy.io/server/v3/utils"
 	"go.uber.org/zap"
 )
@@ -627,7 +627,7 @@ const (
 // errors.Is unwraps the *url.Error -> *net.OpError -> *os.SyscallError ->
 // syscall.Errno chain, so no manual unwrapping is needed.
 func isPreResponseConnRefused(err error) bool {
-	return errors.Is(err, syscall.ECONNREFUSED)
+	return neterr.IsConnRefused(err)
 }
 
 // IsTransportConnReset reports whether err is a transport-level connection
@@ -657,7 +657,7 @@ func IsTransportConnReset(err error) bool {
 	if err == nil {
 		return false
 	}
-	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) {
+	if neterr.IsConnReset(err) || neterr.IsBrokenPipe(err) {
 		return true
 	}
 	// net/http surfaces a peer-side drop during the response read as a bare


### PR DESCRIPTION
## What is broken

`errors.Is(err, syscall.ECONNRESET)` is **always false on Windows** for any error the platform actually produced. The same is true of `ECONNABORTED`, `ECONNREFUSED` and `EPIPE`.

Go's Windows `syscall` package defines those four as invented values in the `APPLICATION_ERROR` space (`syscall/zerrors_windows.go:13-40`; `ECONNRESET` = 536870935). Winsock returns `WSAECONNRESET` (10054), `WSAECONNABORTED` (10053), `WSAECONNREFUSED` (10061). `syscall.Errno.Is` (`syscall/syscall_windows.go:189-215`) maps only the `oserror` sentinels — permission / exist / notexist / unsupported — so nothing bridges the two sets. Go's own standard library never makes this mistake: `net/error_windows.go` and `internal/poll/fd_windows.go` compare against `syscall.WSAECONNRESET`, never `syscall.ECONNRESET`.

Four keploy predicates were written against the portable constants and are therefore inert on Windows. One binary, cross-compiled and run on both platforms against real sockets:

| predicate | Linux | Windows |
|---|---|---|
| `isStaleConnError` — proxy replay-on-stale | true | **false** |
| `IsTransportConnReset` — replay re-send | true | **false** |
| `isPreResponseConnRefused` — app-still-starting retry | true | **false** |
| `classifyUpstreamError` / `upstreamErrorClass` | `unreachable` | **`other`** |

```
Linux    read tcp4 ...: read: connection reset by peer                          errno 104
Windows  read tcp4 ...: wsarecv: An existing connection was forcibly closed...  errno 10054
```

## User impact

- **A pooled upstream connection that goes stale returns a hard 502 to the user's application** instead of being transparently redialed and replayed. This is not theoretical — it is visible in this repo's own CI. Job `97044495434` logs `Failed to read upstream response and request is not safely replayable` with `idempotent: true, content_length: 0`, i.e. `canReplay` was true, so `isStaleConnError` returning false is the only thing that routed it to `writeBadGateway`.
- On replay, a transport-level reset is scored as a **real test failure** rather than re-sent.
- The connection-refused retry that absorbs "app is still coming up" **never fires**.
- Recorded upstream errors get the wrong marker, so post-hoc analysis by error class is wrong on Windows.

## The fix

A leaf package, `pkg/neterr`, that classifies by the errno the platform actually produces, using the Winsock constants from `golang.org/x/sys/windows` (already a direct dependency — no `go.mod` change). Four call sites converted. Non-Windows behaviour is unchanged by construction: the `!windows` file declares nil slices, so each predicate reduces to exactly the `errors.Is` it did before.

`WSAECONNABORTED` is deliberately **not** mapped. Windows returns it for a TCP data-transmission timeout as well as a genuine abort, and every caller here excludes timeouts on purpose — a slow upstream is not a dead connection, and re-sending would double-charge an upstream that may already have processed the request. Under-detecting costs a 502, which is today's behaviour; over-detecting costs a duplicate side effect. A table test pins the non-membership so it cannot drift back in.

## Why it survived this long

**This repository has never run a Go test on Windows.** `go_windows.yml` only ever compiled. This PR adds the first test step there.

The new tests drive **real sockets** rather than hand-built errno values, and that distinction is the whole point — a synthetic `syscall.ECONNRESET` compares equal to itself on every platform, so a synthetic test passes on Windows while production fails. Negative control, run on a real Windows 11 machine with the Winsock lists stripped:

```
without the fix:  TestIsStaleConnError                 PASS   <- synthetic table
                  TestIsStaleConnError_RealPeerReset   FAIL   errno 10054
                  TestIsConnReset_RealPeerReset        FAIL   errno 10054
                  TestIsConnRefused_RealDeadPort       FAIL   errno 10061
with the fix:     all PASS
```

`isStaleConnError` — the highest-impact caller, the one that decides 502-vs-replay — had **zero** test coverage before this PR.

## Verified

- `go build ./...` and `go vet` clean for linux/amd64, windows/amd64, darwin/arm64.
- `go test ./pkg/... ` green on Linux, including under `-race`.
- `golangci-lint v2.12.2` (the version CI pins): 0 issues.
- `actionlint -shellcheck` clean on the workflow change.
- Both new test binaries cross-compiled and executed on a real Windows 11 / Go 1.26 host.

## Still relevant after #4476

#4476 moved native Windows *interception* into the Community and Enterprise editions. The proxy did not move — it is still in this repository, and those editions forward through it. So every Windows user of a native build runs this classification code, and `go_windows.yml` still builds this repository for Windows. `peek_windows.go` also carried a comment claiming Windows "is not a real deployment target for this codepath"; the CI log above contradicts it, and it is corrected here. On Windows the write-based stale detection is the *only* stale-connection detection there is, which makes the classification behind it load-bearing rather than incidental.

The same refactor deleted `incoming_windows.go`, which removes the nil-pointer panic that previously made `go test ./pkg/agent/proxy/incoming/` unrunnable on Windows.

## What the Windows lane covers, and why those packages

`./pkg` is the one that matters most and is the least obvious. `IsTransportConnReset` and the connection-refused retry live there and are called from `pkg/service/replay` with no build tag — that is the code that genuinely runs natively on Windows, and it already contained a real-socket connection-refused test that proves the fix for free. `./pkg/neterr` is the classification, `.../proxy/incoming` is `isStaleConnError`, `.../integrations/http` is the recorded-error markers.

Every listed package was cross-compiled and executed on a real Windows host before being added. `pkg/agent/proxy` is deliberately excluded: two of its tests read a source file by relative path, so I could not separate "fails on Windows" from "fails in my harness", and I will not add a package to a CI lane on a guess. It is **UNDETERMINED**, not known-bad.

## Known gaps, stated plainly

- `IsConnAborted` is inert on Windows by the deliberate choice above. Its godoc says so, so a caller does not have to find `neterr_windows.go` to learn it.
- The Windows lane is four packages, not the tree. Widen it as packages are shown to pass there.