### PR TITLE
fix(ci): stop the deprecated-dependency check failing PRs on proxy hiccups

### DIFF
--- a/.github/workflows/test_workflow_scripts/check-deprecated-deps.sh
+++ b/.github/workflows/test_workflow_scripts/check-deprecated-deps.sh
@@ -17,7 +17,20 @@ direct_deps=$(go mod edit -json | jq -r '.Require[] | select(.Indirect == null) 
 # so a stream error here kills the lint job the same way it kills a sample
 # lane — but GO_RETRY_DIRECT_FROM is pushed past max attempts because going
 # direct would git ls-remote hundreds of upstream repositories.
-output=$(GO_RETRY_DIRECT_FROM=99 go_retry list -m -u all)
+#
+# If every attempt still fails, do NOT fail the job. A network error is not
+# evidence of a deprecated dependency, and reporting it as one is how this
+# check came to fail pull requests whose go.mod was byte-identical to main —
+# a different module flaking each run, so re-running looked like a fix and was
+# luck. This check's subject is the dependency list, and it has no opinion to
+# offer when it could not read one. It never prints its success line in that
+# case either, so a real deprecation is postponed to the next run, not hidden.
+if ! output=$(GO_RETRY_DIRECT_FROM=99 go_retry list -m -u all 2>/tmp/deprecated-deps-err.txt); then
+    echo "::warning::Could not read the module list, so the deprecated-dependency check DID NOT RUN."
+    echo "The failure was in reaching the module proxy, not in the dependency graph:"
+    sed -n '1,10p' /tmp/deprecated-deps-err.txt || true
+    exit 0
+fi
 
 found_deprecated=false
 


### PR DESCRIPTION
## Describe the changes that are made

The `lint` job's **Check for Deprecated Dependencies** step fails pull requests for reasons that have nothing to do with their dependencies.

`go list -m -u all` contacts the module proxy for **every** module in the graph to learn about updates and retractions, so it fails whenever any single one of those reads does — a proxy stream error, a sumdb verification read, a slow mirror. Under `set -euo pipefail` that failure ends the script and fails the job.

Because a *different* module flakes each time, it reads as random. Two consecutive runs on the same branch:

```
go: loading module retractions for github.com/DataDog/datadog-agent/pkg/proto@v0.70.2:
    read "https://proxy.golang.org/.../@v/list": stream error
go: loading module retractions for k8s.io/apiserver@v0.33.1: ...
```
```
go: loading module retractions for github.com/ulikunitz/xz@v0.5.12:
    verifying go.mod: github.com/ulikunitz/xz@v0.5.16/go.mod: reading ...
```

That branch's `go.mod` and `go.sum` are **byte-identical to `main`**, and a sibling branch with the same dependency graph passed the same step minutes apart. So re-running looked like a fix and was luck.

## The change

A network error is not evidence of a deprecated dependency and must not be reported as one.

- The listing is retried **3 times with backoff** for the genuinely transient case.
- If it still cannot be produced, the script emits a `::warning::` saying the check **DID NOT RUN**, prints the underlying proxy error, and exits 0.

It never prints its success line in that case, so "no deprecated dependencies" is never claimed on a run that could not read the list — a real deprecation is postponed to the next run rather than hidden. A deprecated or retracted direct dependency still fails the job exactly as before.

## Verified

- Real run, network available: `✅ No disallowed deprecated direct dependencies found.` (exit 0)
- `go list` failing every attempt (stubbed): retries 3×, warns that the check did not run, **exit 0**
- A genuinely deprecated direct dependency (stubbed): `Deprecated/retracted direct dependency found: … (deprecated)` → **exit 1**

## What type of PR is this?
- [x] 🔁 CI
- [x] 🐞 Bug Fix

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed — this is a CI script; the three behaviours above were verified directly, including both failure modes.
