### PR TITLE
[DO NOT MERGE] test(ci): pin integrations to #267 (mongo topologyVersion strip) for verification

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,7 +24,7 @@ env:
   # when set (so operators can override without editing this file),
   # falling back to `main`. Pin to a specific SHA via the repo var if
   # a feat branch needs to carry a cross-repo change.
-  INTEGRATION_REF: ${{ vars.INTEGRATION_REF || 'main' }}
+  INTEGRATION_REF: d7ed82e78b27ecb7012101e5b71087a97b22fdea
 
 jobs:
   golangci:

--- a/.github/workflows/prepare_and_run.yml
+++ b/.github/workflows/prepare_and_run.yml
@@ -33,7 +33,7 @@ env:
   # three workflows track the same integrations ref. Pin to a specific
   # SHA via the repo var if a feat branch needs to carry a cross-repo
   # change.
-  INTEGRATION_REF: ${{ vars.INTEGRATION_REF || 'main' }}
+  INTEGRATION_REF: d7ed82e78b27ecb7012101e5b71087a97b22fdea
 
 jobs:
   # -------------------------------------------------------------------


### PR DESCRIPTION
## Purpose — verification only, never to merge

Runs the **full OSS pipeline matrix** against keploy/integrations#267 (strip `topologyVersion` from replayed mongo hello responses) before that PR merges.

The integrations repo's own CI already builds keploy with the PR code and runs its sample lanes, but this repo's matrix is broader (more protocols, apps, and record/replay configurations). Since integrations code ships inside the keploy binary, a mongo parser change is exercised by every lane here that records or replays mongo — this PR is the cheap way to run all of them against the fix at once.

Pins `INTEGRATION_REF` to `d7ed82e` (head of integrations#267) in `prepare_and_run.yml` and `golangci-lint.yml`, same pattern as the earlier #253 verification.

**DO NOT MERGE** — close after the checks report; the pin must never land on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)