### PR TITLE
ci: run the real pipeline for #4451 (agent control-plane loopback binding)

### DIFF
--- a/cli/agent.go
+++ b/cli/agent.go
@@ -118,7 +118,7 @@ func Agent(ctx context.Context, logger *zap.Logger, conf *config.Config, service
 						logger.Info("running as a Kubernetes DaemonSet agent; not starting the control-plane HTTP server (push architecture has no inbound HTTP consumers)")
 						return
 					}
-					routes.StartAgentServer(ctx, logger, p, router)
+					routes.StartAgentServer(ctx, logger, p, isDocker, router)
 				}
 			}()
 

--- a/pkg/agent/routes/server.go
+++ b/pkg/agent/routes/server.go
@@ -45,9 +45,8 @@ const bindRetryInterval = 500 * time.Millisecond
 // (see GenerateKeployAgentService, which now publishes only to the host's
 // loopback).
 func StartAgentServer(ctx context.Context, logger *zap.Logger, port int, isDocker bool, router http.Handler) {
-	logger.Info("Starting Agent's HTTP server on :", zap.Int("port", port))
-
 	addr := agentBindAddr(port, isDocker)
+	logger.Info("Starting Agent's HTTP server", zap.String("addr", addr))
 	srv := &http.Server{
 		Handler: router,
 	}
@@ -75,12 +74,12 @@ func StartAgentServer(ctx context.Context, logger *zap.Logger, port int, isDocke
 	// this agent's startup; then serve on the acquired listener.
 	listener, err := listenWithRetry(srvCtx, logger, addr, bindRetryBudget, bindRetryInterval)
 	if err != nil {
-		logger.Error("failed to start HTTP server; verify port availability and network configuration", zap.Error(err))
+		logger.Error("failed to start HTTP server; verify port availability and network configuration", zap.String("addr", addr), zap.Error(err))
 		return
 	}
 
 	if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
-		logger.Error("failed to start HTTP server; verify port availability and network configuration", zap.Error(err))
+		logger.Error("failed to start HTTP server; verify port availability and network configuration", zap.String("addr", addr), zap.Error(err))
 		return
 	}
 	logger.Info("HTTP server stopped")

--- a/pkg/agent/routes/server.go
+++ b/pkg/agent/routes/server.go
@@ -31,10 +31,23 @@ const bindRetryBudget = 90 * time.Second
 // busy-spinning.
 const bindRetryInterval = 500 * time.Millisecond
 
-func StartAgentServer(ctx context.Context, logger *zap.Logger, port int, router http.Handler) {
+// StartAgentServer binds the agent's control-plane HTTP server. It is
+// unauthenticated (see /agent/pcap/keylog, /agent/stop, /agent/storemocks),
+// so the bind address must never be reachable by anything other than the
+// local keploy CLI that owns this agent.
+//
+// In native mode the agent and CLI share a network namespace, so loopback is
+// both sufficient and necessary: binding 0.0.0.0 would let any other local
+// process reach it. In docker mode the CLI runs on the host and reaches the
+// agent through its published port, so the server must stay reachable on the
+// container's non-loopback interface for the docker proxy to forward into —
+// exposure to the host network is instead closed off at the publish step
+// (see GenerateKeployAgentService, which now publishes only to the host's
+// loopback).
+func StartAgentServer(ctx context.Context, logger *zap.Logger, port int, isDocker bool, router http.Handler) {
 	logger.Info("Starting Agent's HTTP server on :", zap.Int("port", port))
 
-	addr := fmt.Sprintf(":%d", port)
+	addr := agentBindAddr(port, isDocker)
 	srv := &http.Server{
 		Handler: router,
 	}
@@ -71,6 +84,19 @@ func StartAgentServer(ctx context.Context, logger *zap.Logger, port int, router 
 		return
 	}
 	logger.Info("HTTP server stopped")
+}
+
+// agentBindAddr picks the agent control-plane server's bind address. Native
+// mode binds loopback-only since the endpoints (notably /agent/pcap/keylog,
+// which streams live TLS session keys) carry no authentication. Docker mode
+// must still bind every interface inside the container so the docker proxy
+// can forward the published port in; that publish is restricted to the
+// host's own loopback in GenerateKeployAgentService instead.
+func agentBindAddr(port int, isDocker bool) string {
+	if isDocker {
+		return fmt.Sprintf(":%d", port)
+	}
+	return fmt.Sprintf("127.0.0.1:%d", port)
 }
 
 // listenWithRetry binds a TCP listener on addr, retrying only the transient

--- a/pkg/agent/routes/server_test.go
+++ b/pkg/agent/routes/server_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -101,6 +102,30 @@ func TestListenWithRetry_ReturnsImmediatelyOnNonAddrInUse(t *testing.T) {
 	}
 }
 
+// TestAgentBindAddr_NativeModeIsLoopbackOnly guards the fix for the
+// unauthenticated-agent-exposure report: native mode must never bind every
+// interface, since /agent/pcap/keylog, /agent/stop, and /agent/storemocks
+// have no auth and would otherwise be reachable by any local or
+// network-adjacent process.
+func TestAgentBindAddr_NativeModeIsLoopbackOnly(t *testing.T) {
+	addr := agentBindAddr(12345, false)
+	if !strings.HasPrefix(addr, "127.0.0.1:") {
+		t.Fatalf("native mode must bind loopback only, got addr %q", addr)
+	}
+}
+
+// TestAgentBindAddr_DockerModeBindsAllInterfaces documents the accepted
+// trade-off in docker mode: the container's internal listener must stay on
+// every interface for the docker proxy to forward the published port in.
+// Host-network exposure is closed at the publish step instead (see
+// GenerateKeployAgentService), not here.
+func TestAgentBindAddr_DockerModeBindsAllInterfaces(t *testing.T) {
+	addr := agentBindAddr(12345, true)
+	if strings.HasPrefix(addr, "127.0.0.1:") {
+		t.Fatalf("docker mode must stay reachable on the container's non-loopback interface, got addr %q", addr)
+	}
+}
+
 // TestStartAgentServer_ServesAfterTransientPortConflict is the end-to-end proof:
 // the agent HTTP server starts while the port is still held, and begins serving
 // once it frees — exactly the previous-session-teardown race from CI.
@@ -120,7 +145,7 @@ func TestStartAgentServer_ServesAfterTransientPortConflict(t *testing.T) {
 		_ = holder.Close()
 	}()
 
-	go StartAgentServer(ctx, zap.NewNop(), port, handler)
+	go StartAgentServer(ctx, zap.NewNop(), port, false, handler)
 
 	url := fmt.Sprintf("http://127.0.0.1:%d/", port)
 	client := &http.Client{Timeout: 500 * time.Millisecond}

--- a/pkg/agent/routes/server_test.go
+++ b/pkg/agent/routes/server_test.go
@@ -118,11 +118,30 @@ func TestAgentBindAddr_NativeModeIsLoopbackOnly(t *testing.T) {
 // trade-off in docker mode: the container's internal listener must stay on
 // every interface for the docker proxy to forward the published port in.
 // Host-network exposure is closed at the publish step instead (see
-// GenerateKeployAgentService), not here.
+// GenerateKeployAgentService and agentPortPublish), not here.
+//
+// Asserted by splitting the address rather than by "is not 127.0.0.1:". A
+// negative prefix check passes for every other string, and several of those
+// are wrong in ways that matter: "localhost:%d" binds loopback and would break
+// docker mode under a test named BindsAllInterfaces, and "" binds every
+// interface on a RANDOM port — a silent misbind, which is worse than an error.
+// Splitting also avoids failing on "0.0.0.0:%d", which is byte-identical in
+// effect to ":%d".
 func TestAgentBindAddr_DockerModeBindsAllInterfaces(t *testing.T) {
 	addr := agentBindAddr(12345, true)
-	if strings.HasPrefix(addr, "127.0.0.1:") {
-		t.Fatalf("docker mode must stay reachable on the container's non-loopback interface, got addr %q", addr)
+
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("agentBindAddr(12345, true) = %q, which is not a valid listen address: %v", addr, err)
+	}
+	if port != "12345" {
+		t.Errorf("agentBindAddr(12345, true) = %q, want port 12345", addr)
+	}
+	// The unspecified address, however it is spelled.
+	switch host {
+	case "", "0.0.0.0", "::":
+	default:
+		t.Errorf("docker mode must bind every interface inside the container so docker can forward the published port in; got host %q from %q", host, addr)
 	}
 }
 

--- a/pkg/platform/docker/agent_port_publish_alias_test.go
+++ b/pkg/platform/docker/agent_port_publish_alias_test.go
@@ -1,0 +1,221 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"runtime"
+	"strings"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// TestAgentPortPublish is the behavioural half: one function, one exact string.
+// Everything else in this file exists only to prove that every platform arm
+// routes through it.
+func TestAgentPortPublish(t *testing.T) {
+	t.Parallel()
+
+	if got, want := agentPortPublish(16789), " -p 127.0.0.1:16789:16789"; got != want {
+		t.Fatalf("agentPortPublish(16789) = %q, want %q — the agent control plane is unauthenticated (/agent/pcap/keylog streams live TLS session keys), so this publish must reach the host's loopback only", got, want)
+	}
+}
+
+// TestGetAlias_LinuxPublishesAgentPortToHostLoopbackOnly runs the real linux
+// arm end to end. Skipped elsewhere: on darwin/windows getAlias takes a
+// different arm that shells out to `docker context ls`, so this would assert
+// against a command it was not written for — or fail outright where docker is
+// not installed.
+func TestGetAlias_LinuxPublishesAgentPortToHostLoopbackOnly(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "linux" {
+		t.Skip("getAlias switches on runtime.GOOS; the linux arm only executes here")
+	}
+
+	opts := models.SetupOptions{
+		KeployContainer: "keploy-test",
+		AgentPort:       16789,
+		ProxyPort:       16790,
+		DnsPort:         16791,
+		ClientNSPID:     4242,
+		Mode:            models.MODE_RECORD,
+	}
+
+	alias, err := getAlias(context.Background(), zap.NewNop(), opts, false)
+	if err != nil {
+		t.Fatalf("getAlias: %v", err)
+	}
+
+	want := fmt.Sprintf("-p 127.0.0.1:%d:%d", opts.AgentPort, opts.AgentPort)
+	if !strings.Contains(alias, want) {
+		t.Errorf("linux getAlias must publish the agent control port to the host's loopback only (want %q).\ngot: %s", want, alias)
+	}
+
+	// Presence alone is not the invariant: an alias carrying BOTH forms
+	// satisfies the check above while still exposing the control plane.
+	unrestricted := fmt.Sprintf("-p %d:%d", opts.AgentPort, opts.AgentPort)
+	if strings.Contains(alias, unrestricted) {
+		t.Errorf("linux getAlias also published the agent control port on all host interfaces (%q).\ngot: %s", unrestricted, alias)
+	}
+}
+
+// TestGetAlias_EveryPlatformBranchPublishesAgentPortViaHelper covers the four
+// arms that cannot execute here. getAlias switches on runtime.GOOS and each arm
+// rebuilds the alias from scratch; on linux the windows/colima, windows/default,
+// darwin/colima and darwin/default arms are dead code at runtime, and the
+// darwin/windows arms shell out to `docker context ls` before they get
+// anywhere. Nothing behavioural reaches them.
+//
+// Two assertions per branch, and the second is the one that took a review to
+// get right. Requiring the branch to CALL agentPortPublish catches an arm that
+// forgets to publish; it does not catch an arm that calls it and then appends a
+// second, unrestricted "-p <port>:<port>" — which re-exposes the control plane
+// while leaving a presence check green. So also require that no arm builds a
+// "-p" fragment of its own. That is exact here: the only other publishes in
+// getAlias (proxy and app ports) are assembled before the switch.
+func TestGetAlias_EveryPlatformBranchPublishesAgentPortViaHelper(t *testing.T) {
+	t.Parallel()
+
+	forEachAliasReturningBranch(t, func(t *testing.T, pos token.Position, list []ast.Stmt) {
+		t.Helper()
+
+		calls := false
+		for _, stmt := range list {
+			if stmtCallsFunc(stmt, "agentPortPublish") {
+				calls = true
+			}
+		}
+		if !calls {
+			t.Errorf("%s: this getAlias platform branch returns an alias without calling agentPortPublish — on that platform the unauthenticated agent control plane (/agent/pcap/keylog streams live TLS session keys) would not be scoped to the host's loopback", pos)
+		}
+
+		for _, stmt := range list {
+			if lit, ok := stmtAssignsAliasFromLiteralContaining(stmt, "-p "); ok {
+				t.Errorf("%s: this getAlias platform branch builds its own %q publish fragment instead of using agentPortPublish. Proxy and app ports are assembled before the switch, so an arm has no reason to; a second publish here would re-expose the agent control plane on every host interface while agentPortPublish is still called", pos, lit)
+			}
+		}
+	})
+}
+
+// forEachAliasReturningBranch walks getAlias in util.go and invokes fn once per
+// statement list that returns an alias, i.e. once per platform arm. Shared with
+// TestGetAlias_EveryPlatformBranchForwardsUpstreamTLSFlags so a future getAlias
+// restructure needs one edit rather than two that can drift apart.
+func forEachAliasReturningBranch(t *testing.T, fn func(*testing.T, token.Position, []ast.Stmt)) {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "util.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse util.go: %v", err)
+	}
+
+	var decl *ast.FuncDecl
+	for _, d := range file.Decls {
+		fd, ok := d.(*ast.FuncDecl)
+		if ok && fd.Recv == nil && fd.Name.Name == "getAlias" {
+			decl = fd
+			break
+		}
+	}
+	if decl == nil {
+		t.Fatal("getAlias not found in util.go; this test needs updating alongside the move")
+	}
+
+	// A platform arm is either a switch case body ([]ast.Stmt) or the body of
+	// the colima `if` (*ast.BlockStmt), so both shapes have to be walked.
+	var lists [][]ast.Stmt
+	ast.Inspect(decl.Body, func(n ast.Node) bool {
+		switch s := n.(type) {
+		case *ast.BlockStmt:
+			lists = append(lists, s.List)
+		case *ast.CaseClause:
+			lists = append(lists, s.Body)
+		}
+		return true
+	})
+
+	returns := 0
+	for _, list := range lists {
+		for _, stmt := range list {
+			if !isReturnAliasNil(stmt) {
+				continue
+			}
+			returns++
+			fn(t, fset.Position(stmt.Pos()), list)
+		}
+	}
+
+	// linux, windows/colima, windows/default, darwin/colima, darwin/default.
+	if returns < 5 {
+		t.Fatalf("found only %d alias-returning branches in getAlias, expected at least 5 (linux, windows x2, darwin x2) — the walk is not seeing the switch and would pass vacuously", returns)
+	}
+}
+
+// stmtCallsFunc reports whether stmt contains a call to the named function.
+// Unlike the literal checks below this deliberately descends into nested
+// blocks: a call is unambiguous, and a nested arm is walked as its own list
+// anyway.
+func stmtCallsFunc(stmt ast.Stmt, name string) bool {
+	found := false
+	ast.Inspect(stmt, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if ident, ok := call.Fun.(*ast.Ident); ok && ident.Name == name {
+			found = true
+		}
+		return true
+	})
+	return found
+}
+
+// stmtAssignsAliasFromLiteralContaining reports whether stmt assigns to `alias`
+// from a string literal containing sub, returning that literal.
+//
+// Restricted to assignments, and deliberately NOT descending into nested
+// blocks: a plain walk would let the colima `if` body's literals answer for the
+// enclosing case body, so an arm could lose its scoping undetected. That was a
+// real bug in an earlier version of this file, caught by mutating util.go:340
+// and :480. Nested blocks are walked as their own lists, so nothing is missed.
+func stmtAssignsAliasFromLiteralContaining(stmt ast.Stmt, sub string) (string, bool) {
+	assign, ok := stmt.(*ast.AssignStmt)
+	if !ok {
+		return "", false
+	}
+	isAlias := false
+	for _, lhs := range assign.Lhs {
+		if ident, ok := lhs.(*ast.Ident); ok && ident.Name == "alias" {
+			isAlias = true
+		}
+	}
+	if !isAlias {
+		return "", false
+	}
+	for _, rhs := range assign.Rhs {
+		var hit string
+		ast.Inspect(rhs, func(n ast.Node) bool {
+			if hit != "" {
+				return false
+			}
+			lit, ok := n.(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			if strings.Contains(lit.Value, sub) {
+				hit = lit.Value
+			}
+			return true
+		})
+		if hit != "" {
+			return hit, true
+		}
+	}
+	return "", false
+}

--- a/pkg/platform/docker/agent_port_publish_test.go
+++ b/pkg/platform/docker/agent_port_publish_test.go
@@ -1,0 +1,50 @@
+package docker
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/config"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// TestGenerateKeployAgentService_PublishesAgentPortLoopbackOnly guards the
+// fix for the unauthenticated-agent-exposure report: the agent control-plane
+// HTTP server carries no authentication (it streams live TLS session keys on
+// /agent/pcap/keylog and accepts unauthenticated /agent/stop and
+// /agent/storemocks), so its published port must reach only the host's own
+// loopback, never every host-network interface.
+func TestGenerateKeployAgentService_PublishesAgentPortLoopbackOnly(t *testing.T) {
+	t.Parallel()
+
+	serviceNode, err := (&Impl{
+		logger: zap.NewNop(),
+		conf:   &config.Config{},
+	}).GenerateKeployAgentService(models.SetupOptions{
+		KeployContainer: "keploy-agent",
+		AgentPort:       16789,
+		ProxyPort:       16790,
+		DnsPort:         16791,
+		Mode:            models.MODE_TEST,
+	})
+	if err != nil {
+		t.Fatalf("GenerateKeployAgentService: %v", err)
+	}
+
+	ports := mappingValue(serviceNode, "ports")
+	if ports == nil {
+		t.Fatalf("expected ports block")
+	}
+	wantAgentPublish := "127.0.0.1:16789:16789"
+	if !sequenceContains(ports, wantAgentPublish) {
+		t.Fatalf("expected agent port published loopback-only as %q, got %s", wantAgentPublish, formatSequence(ports))
+	}
+
+	// The proxy port has no auth concern (it's the traffic-interception
+	// listener app containers are meant to reach) and must stay published on
+	// every interface.
+	wantProxyPublish := "16790:16790"
+	if !sequenceContains(ports, wantProxyPublish) {
+		t.Fatalf("expected proxy port published on all interfaces as %q, got %s", wantProxyPublish, formatSequence(ports))
+	}
+}

--- a/pkg/platform/docker/agent_port_publish_test.go
+++ b/pkg/platform/docker/agent_port_publish_test.go
@@ -39,6 +39,13 @@ func TestGenerateKeployAgentService_PublishesAgentPortLoopbackOnly(t *testing.T)
 	if !sequenceContains(ports, wantAgentPublish) {
 		t.Fatalf("expected agent port published loopback-only as %q, got %s", wantAgentPublish, formatSequence(ports))
 	}
+	// Presence alone is not the invariant. A ports block carrying BOTH the
+	// loopback-scoped mapping and a bare one would satisfy the check above
+	// while leaving the control plane on every host interface, which is the
+	// exposure this test exists to prevent.
+	if unrestricted := "16789:16789"; sequenceContains(ports, unrestricted) {
+		t.Fatalf("agent port is also published unrestricted as %q, which re-exposes the unauthenticated control plane on every host interface; got %s", unrestricted, formatSequence(ports))
+	}
 
 	// The proxy port has no auth concern (it's the traffic-interception
 	// listener app containers are meant to reach) and must stay published on

--- a/pkg/platform/docker/docker.go
+++ b/pkg/platform/docker/docker.go
@@ -567,7 +567,12 @@ func (idc *Impl) GenerateKeployAgentService(opts models.SetupOptions) (*yaml.Nod
 	// Generate ports
 	var ports []string
 	if opts.AgentPort != 0 {
-		ports = append(ports, fmt.Sprintf("%d:%d", opts.AgentPort, opts.AgentPort))
+		// The agent control-plane HTTP server is unauthenticated (it streams
+		// live TLS session keys on /agent/pcap/keylog and accepts
+		// unauthenticated /agent/stop and /agent/storemocks). Only the local
+		// keploy CLI needs to reach it, so publish it to the host's own
+		// loopback rather than every host-network interface.
+		ports = append(ports, fmt.Sprintf("127.0.0.1:%d:%d", opts.AgentPort, opts.AgentPort))
 	}
 	if opts.ProxyPort != 0 {
 		ports = append(ports, fmt.Sprintf("%d:%d", opts.ProxyPort, opts.ProxyPort))

--- a/pkg/platform/docker/upstream_tls_flags_test.go
+++ b/pkg/platform/docker/upstream_tls_flags_test.go
@@ -3,7 +3,6 @@ package docker
 import (
 	"context"
 	"go/ast"
-	"go/parser"
 	"go/token"
 	"runtime"
 	"strings"
@@ -334,60 +333,16 @@ func TestGetAlias_LinuxForwardsUpstreamTLS(t *testing.T) {
 func TestGetAlias_EveryPlatformBranchForwardsUpstreamTLSFlags(t *testing.T) {
 	t.Parallel()
 
-	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, "util.go", nil, 0)
-	if err != nil {
-		t.Fatalf("parse util.go: %v", err)
-	}
+	forEachAliasReturningBranch(t, func(t *testing.T, pos token.Position, list []ast.Stmt) {
+		t.Helper()
 
-	var fn *ast.FuncDecl
-	for _, decl := range file.Decls {
-		d, ok := decl.(*ast.FuncDecl)
-		if ok && d.Recv == nil && d.Name.Name == "getAlias" {
-			fn = d
-			break
-		}
-	}
-	if fn == nil {
-		t.Fatal("getAlias not found in util.go; this test needs updating alongside the move")
-	}
-
-	// Every statement list inside getAlias. A platform arm is either a
-	// switch case body ([]ast.Stmt) or the body of the colima `if`
-	// (*ast.BlockStmt), so both shapes have to be walked.
-	var lists [][]ast.Stmt
-	ast.Inspect(fn.Body, func(n ast.Node) bool {
-		switch s := n.(type) {
-		case *ast.BlockStmt:
-			lists = append(lists, s.List)
-		case *ast.CaseClause:
-			lists = append(lists, s.Body)
-		}
-		return true
-	})
-
-	returns := 0
-	for _, list := range lists {
-		appended := false
 		for _, stmt := range list {
 			if isAliasAppendOf(stmt, "upstreamTLSFlags") {
-				appended = true
-			}
-			if !isReturnAliasNil(stmt) {
-				continue
-			}
-			returns++
-			if !appended {
-				t.Errorf("%s: this getAlias platform branch returns the alias without ever appending upstreamTLSFlags — the agent container on that platform would never receive --upstream-tls-verify/--upstream-tls-ca-cert and would silently fall back to its own defaults",
-					fset.Position(stmt.Pos()))
+				return
 			}
 		}
-	}
-
-	// linux, windows/colima, windows/default, darwin/colima, darwin/default.
-	if returns < 5 {
-		t.Fatalf("found only %d alias-returning branches in getAlias, expected at least 5 (linux, windows×2, darwin×2) — the walk is not seeing the switch and would pass vacuously", returns)
-	}
+		t.Errorf("%s: this getAlias platform branch returns the alias without ever appending upstreamTLSFlags — the agent container on that platform would never receive --upstream-tls-verify/--upstream-tls-ca-cert and would silently fall back to its own defaults", pos)
+	})
 }
 
 // isAliasAppendOf reports whether stmt is `alias += <ident>`.

--- a/pkg/platform/docker/util.go
+++ b/pkg/platform/docker/util.go
@@ -120,6 +120,27 @@ func GetKeployDockerAlias(ctx context.Context, logger *zap.Logger, conf *config.
 // Note: The container runs with --cap-add=NET_ADMIN to configure its own private network namespace.
 // Due to Docker's network isolation (namespaces), this capability is strictly confined to the container
 // and CANNOT access or modify the Host System's network interfaces or configuration.
+// agentPortPublish is the ONE place the agent's control-plane port is published
+// to the host. Every getAlias platform arm must call it rather than building
+// its own "-p" fragment.
+//
+// The scoping is load-bearing, not cosmetic. The control-plane server is
+// unauthenticated: /agent/pcap/keylog streams live TLS session keys,
+// /agent/stop kills the session and /agent/storemocks injects mock data. In
+// docker mode the in-container listener deliberately stays on every interface
+// (see agentBindAddr) so docker can forward the published port in, which makes
+// this host-IP scoping the only thing keeping that control plane off every
+// host interface.
+//
+// It is also untestable by behaviour: "-p <port>:<port>" binds 0.0.0.0, a
+// strict superset of 127.0.0.1, so the agent stays reachable over loopback
+// either way and every lane passes identically whether the scoping is here or
+// not. Five hand-written copies of this fragment were therefore five silent
+// single points of failure - hence one function, asserted directly.
+func agentPortPublish(agentPort uint32) string {
+	return fmt.Sprintf(" -p 127.0.0.1:%d:%d", agentPort, agentPort)
+}
+
 func getAlias(ctx context.Context, logger *zap.Logger, opts models.SetupOptions, debug bool) (string, error) {
 	// Get the name of the operating system.
 	osName := runtime.GOOS
@@ -198,8 +219,8 @@ func getAlias(ctx context.Context, logger *zap.Logger, opts models.SetupOptions,
 	switch osName {
 	case "linux":
 
-		alias := "sudo docker container run --name " + opts.KeployContainer + appNetworkStr + " " + envs + "-e BINARY_TO_DOCKER=true -p 127.0.0.1:" +
-			fmt.Sprintf("%d", opts.AgentPort) + ":" + fmt.Sprintf("%d", opts.AgentPort) +
+		alias := "sudo docker container run --name " + opts.KeployContainer + appNetworkStr + " " + envs + "-e BINARY_TO_DOCKER=true" +
+			agentPortPublish(opts.AgentPort) +
 			proxyPortStr + appPortsStr +
 			" --cap-add=BPF --cap-add=PERFMON --cap-add=NET_ADMIN --cap-add=SYS_RESOURCE --cap-add=SYS_PTRACE " + Volumes +
 			" -v /sys/fs/cgroup:/sys/fs/cgroup -v /sys/kernel/debug:/sys/kernel/debug -v /sys/fs/bpf:/sys/fs/bpf " +
@@ -274,8 +295,8 @@ func getAlias(ctx context.Context, logger *zap.Logger, opts models.SetupOptions,
 			// alias := "docker container run --name keploy-v2 " + envs + "-e BINARY_TO_DOCKER=true -p 36789:36789 -p 8096:8096 --privileged --pid=host" + "-v " + pwd + ":" + dpwd + " -w " + dpwd + " -v /sys/fs/cgroup:/sys/fs/cgroup -v /sys/kernel/debug:/sys/kernel/debug -v /sys/fs/bpf:/sys/fs/bpf -v /var/run/docker.sock:/var/run/docker.sock -v " + os.Getenv("USERPROFILE") + "\\.keploy-config:/root/.keploy-config -v " + os.Getenv("USERPROFILE") + "\\.keploy:/root/.keploy --rm " + img
 			// return alias, nil
 
-			alias := "docker container run --name " + opts.KeployContainer + appNetworkStr + " " + envs + "-e BINARY_TO_DOCKER=true -p 127.0.0.1:" +
-				fmt.Sprintf("%d", opts.AgentPort) + ":" + fmt.Sprintf("%d", opts.AgentPort) +
+			alias := "docker container run --name " + opts.KeployContainer + appNetworkStr + " " + envs + "-e BINARY_TO_DOCKER=true" +
+				agentPortPublish(opts.AgentPort) +
 				proxyPortStr + appPortsStr +
 				" --cap-add=BPF --cap-add=PERFMON --cap-add=NET_ADMIN --cap-add=SYS_RESOURCE --cap-add=SYS_PTRACE " + Volumes +
 				" -v /sys/fs/cgroup:/sys/fs/cgroup -v /sys/kernel/debug:/sys/kernel/debug -v /sys/fs/bpf:/sys/fs/bpf " +
@@ -337,8 +358,8 @@ func getAlias(ctx context.Context, logger *zap.Logger, opts models.SetupOptions,
 		// if default docker context is used
 		logger.Info("Starting keploy in docker with default context, as that is the current context.")
 		// alias := "docker container run --name keploy-v2 " + envs + "-e BINARY_TO_DOCKER=true -p 36789:36789 -p 8096:8096 --privileged --pid=host" + "-v " + pwd + ":" + dpwd + " -w " + dpwd + " -v /sys/fs/cgroup:/sys/fs/cgroup -v debugfs:/sys/kernel/debug:rw -v /sys/fs/bpf:/sys/fs/bpf -v /var/run/docker.sock:/var/run/docker.sock -v " + os.Getenv("USERPROFILE") + "\\.keploy-config:/root/.keploy-config -v " + os.Getenv("USERPROFILE") + "\\.keploy:/root/.keploy --rm " + img
-		alias := "docker container run --name " + opts.KeployContainer + appNetworkStr + " " + envs + "-e BINARY_TO_DOCKER=true -p 127.0.0.1:" +
-			fmt.Sprintf("%d", opts.AgentPort) + ":" + fmt.Sprintf("%d", opts.AgentPort) +
+		alias := "docker container run --name " + opts.KeployContainer + appNetworkStr + " " + envs + "-e BINARY_TO_DOCKER=true" +
+			agentPortPublish(opts.AgentPort) +
 			proxyPortStr + appPortsStr +
 			" --cap-add=BPF --cap-add=PERFMON --cap-add=NET_ADMIN --cap-add=SYS_RESOURCE --cap-add=SYS_PTRACE " + Volumes +
 			" -v /sys/fs/cgroup:/sys/fs/cgroup -v debugfs:/sys/kernel/debug:rw -v /sys/fs/bpf:/sys/fs/bpf " +
@@ -415,8 +436,8 @@ func getAlias(ctx context.Context, logger *zap.Logger, opts models.SetupOptions,
 			// alias := "docker container run --name keploy-v2 " + envs + "-e BINARY_TO_DOCKER=true -p 36789:36789 -p 8096:8096 --privileged --pid=host" + "-v " + os.Getenv("PWD") + ":" + os.Getenv("PWD") + " -w " + os.Getenv("PWD") + " -v /sys/fs/cgroup:/sys/fs/cgroup -v /sys/kernel/debug:/sys/kernel/debug -v /sys/fs/bpf:/sys/fs/bpf -v /var/run/docker.sock:/var/run/docker.sock -v " + os.Getenv("HOME") + "/.keploy-config:/root/.keploy-config -v " + os.Getenv("HOME") + "/.keploy:/root/.keploy --rm " + img
 			// return alias, nil
 			logger.Info("Starting keploy in docker with colima context, as that is the current context.")
-			alias := "docker container run --name " + opts.KeployContainer + appNetworkStr + " " + envs + "-e BINARY_TO_DOCKER=true -p 127.0.0.1:" +
-				fmt.Sprintf("%d", opts.AgentPort) + ":" + fmt.Sprintf("%d", opts.AgentPort) +
+			alias := "docker container run --name " + opts.KeployContainer + appNetworkStr + " " + envs + "-e BINARY_TO_DOCKER=true" +
+				agentPortPublish(opts.AgentPort) +
 				proxyPortStr + appPortsStr +
 				" --cap-add=BPF --cap-add=PERFMON --cap-add=NET_ADMIN --cap-add=SYS_RESOURCE --cap-add=SYS_PTRACE " + Volumes +
 				" -v /sys/fs/cgroup:/sys/fs/cgroup -v /sys/kernel/debug:/sys/kernel/debug -v /sys/fs/bpf:/sys/fs/bpf " +
@@ -477,8 +498,8 @@ func getAlias(ctx context.Context, logger *zap.Logger, opts models.SetupOptions,
 		}
 		// if default docker context is used
 		logger.Info("Starting keploy in docker with default context, as that is the current context.")
-		alias := "docker container run --name " + opts.KeployContainer + appNetworkStr + " " + envs + "-e BINARY_TO_DOCKER=true -p 127.0.0.1:" +
-			fmt.Sprintf("%d", opts.AgentPort) + ":" + fmt.Sprintf("%d", opts.AgentPort) +
+		alias := "docker container run --name " + opts.KeployContainer + appNetworkStr + " " + envs + "-e BINARY_TO_DOCKER=true" +
+			agentPortPublish(opts.AgentPort) +
 			proxyPortStr + appPortsStr +
 			" --cap-add=BPF --cap-add=PERFMON --cap-add=NET_ADMIN --cap-add=SYS_RESOURCE --cap-add=SYS_PTRACE " + Volumes +
 			" -v /sys/fs/cgroup:/sys/fs/cgroup -v debugfs:/sys/kernel/debug:rw -v /sys/fs/bpf:/sys/fs/bpf " +

--- a/pkg/platform/docker/util.go
+++ b/pkg/platform/docker/util.go
@@ -198,7 +198,7 @@ func getAlias(ctx context.Context, logger *zap.Logger, opts models.SetupOptions,
 	switch osName {
 	case "linux":
 
-		alias := "sudo docker container run --name " + opts.KeployContainer + appNetworkStr + " " + envs + "-e BINARY_TO_DOCKER=true -p " +
+		alias := "sudo docker container run --name " + opts.KeployContainer + appNetworkStr + " " + envs + "-e BINARY_TO_DOCKER=true -p 127.0.0.1:" +
 			fmt.Sprintf("%d", opts.AgentPort) + ":" + fmt.Sprintf("%d", opts.AgentPort) +
 			proxyPortStr + appPortsStr +
 			" --cap-add=BPF --cap-add=PERFMON --cap-add=NET_ADMIN --cap-add=SYS_RESOURCE --cap-add=SYS_PTRACE " + Volumes +
@@ -274,7 +274,7 @@ func getAlias(ctx context.Context, logger *zap.Logger, opts models.SetupOptions,
 			// alias := "docker container run --name keploy-v2 " + envs + "-e BINARY_TO_DOCKER=true -p 36789:36789 -p 8096:8096 --privileged --pid=host" + "-v " + pwd + ":" + dpwd + " -w " + dpwd + " -v /sys/fs/cgroup:/sys/fs/cgroup -v /sys/kernel/debug:/sys/kernel/debug -v /sys/fs/bpf:/sys/fs/bpf -v /var/run/docker.sock:/var/run/docker.sock -v " + os.Getenv("USERPROFILE") + "\\.keploy-config:/root/.keploy-config -v " + os.Getenv("USERPROFILE") + "\\.keploy:/root/.keploy --rm " + img
 			// return alias, nil
 
-			alias := "docker container run --name " + opts.KeployContainer + appNetworkStr + " " + envs + "-e BINARY_TO_DOCKER=true -p " +
+			alias := "docker container run --name " + opts.KeployContainer + appNetworkStr + " " + envs + "-e BINARY_TO_DOCKER=true -p 127.0.0.1:" +
 				fmt.Sprintf("%d", opts.AgentPort) + ":" + fmt.Sprintf("%d", opts.AgentPort) +
 				proxyPortStr + appPortsStr +
 				" --cap-add=BPF --cap-add=PERFMON --cap-add=NET_ADMIN --cap-add=SYS_RESOURCE --cap-add=SYS_PTRACE " + Volumes +
@@ -337,7 +337,7 @@ func getAlias(ctx context.Context, logger *zap.Logger, opts models.SetupOptions,
 		// if default docker context is used
 		logger.Info("Starting keploy in docker with default context, as that is the current context.")
 		// alias := "docker container run --name keploy-v2 " + envs + "-e BINARY_TO_DOCKER=true -p 36789:36789 -p 8096:8096 --privileged --pid=host" + "-v " + pwd + ":" + dpwd + " -w " + dpwd + " -v /sys/fs/cgroup:/sys/fs/cgroup -v debugfs:/sys/kernel/debug:rw -v /sys/fs/bpf:/sys/fs/bpf -v /var/run/docker.sock:/var/run/docker.sock -v " + os.Getenv("USERPROFILE") + "\\.keploy-config:/root/.keploy-config -v " + os.Getenv("USERPROFILE") + "\\.keploy:/root/.keploy --rm " + img
-		alias := "docker container run --name " + opts.KeployContainer + appNetworkStr + " " + envs + "-e BINARY_TO_DOCKER=true -p " +
+		alias := "docker container run --name " + opts.KeployContainer + appNetworkStr + " " + envs + "-e BINARY_TO_DOCKER=true -p 127.0.0.1:" +
 			fmt.Sprintf("%d", opts.AgentPort) + ":" + fmt.Sprintf("%d", opts.AgentPort) +
 			proxyPortStr + appPortsStr +
 			" --cap-add=BPF --cap-add=PERFMON --cap-add=NET_ADMIN --cap-add=SYS_RESOURCE --cap-add=SYS_PTRACE " + Volumes +
@@ -415,7 +415,7 @@ func getAlias(ctx context.Context, logger *zap.Logger, opts models.SetupOptions,
 			// alias := "docker container run --name keploy-v2 " + envs + "-e BINARY_TO_DOCKER=true -p 36789:36789 -p 8096:8096 --privileged --pid=host" + "-v " + os.Getenv("PWD") + ":" + os.Getenv("PWD") + " -w " + os.Getenv("PWD") + " -v /sys/fs/cgroup:/sys/fs/cgroup -v /sys/kernel/debug:/sys/kernel/debug -v /sys/fs/bpf:/sys/fs/bpf -v /var/run/docker.sock:/var/run/docker.sock -v " + os.Getenv("HOME") + "/.keploy-config:/root/.keploy-config -v " + os.Getenv("HOME") + "/.keploy:/root/.keploy --rm " + img
 			// return alias, nil
 			logger.Info("Starting keploy in docker with colima context, as that is the current context.")
-			alias := "docker container run --name " + opts.KeployContainer + appNetworkStr + " " + envs + "-e BINARY_TO_DOCKER=true -p " +
+			alias := "docker container run --name " + opts.KeployContainer + appNetworkStr + " " + envs + "-e BINARY_TO_DOCKER=true -p 127.0.0.1:" +
 				fmt.Sprintf("%d", opts.AgentPort) + ":" + fmt.Sprintf("%d", opts.AgentPort) +
 				proxyPortStr + appPortsStr +
 				" --cap-add=BPF --cap-add=PERFMON --cap-add=NET_ADMIN --cap-add=SYS_RESOURCE --cap-add=SYS_PTRACE " + Volumes +
@@ -477,7 +477,7 @@ func getAlias(ctx context.Context, logger *zap.Logger, opts models.SetupOptions,
 		}
 		// if default docker context is used
 		logger.Info("Starting keploy in docker with default context, as that is the current context.")
-		alias := "docker container run --name " + opts.KeployContainer + appNetworkStr + " " + envs + "-e BINARY_TO_DOCKER=true -p " +
+		alias := "docker container run --name " + opts.KeployContainer + appNetworkStr + " " + envs + "-e BINARY_TO_DOCKER=true -p 127.0.0.1:" +
 			fmt.Sprintf("%d", opts.AgentPort) + ":" + fmt.Sprintf("%d", opts.AgentPort) +
 			proxyPortStr + appPortsStr +
 			" --cap-add=BPF --cap-add=PERFMON --cap-add=NET_ADMIN --cap-add=SYS_RESOURCE --cap-add=SYS_PTRACE " + Volumes +


### PR DESCRIPTION
CI-only mirror of #4451 — **do not merge this**; merge #4451.

#4451 comes from a fork, so it shows three checks (`cla-assistant`, `greeting`, `DCO`) and none of the lanes that exercise the change have ever run: ten workflow runs have sat in `action_required` since 19 Aug, and `prepare_and_run.yml` gates the docker/macOS/Windows legs on `!head.repo.fork` even after approval.

This branch is that PR's head pushed same-repo so the pipeline actually runs. Identical tree; authorship and signoff on the original commit are unchanged.

Findings and rationale are on #4451.