### PR TITLE
fix(mock): clear mappings on mock re-record

### DIFF
--- a/pkg/platform/yaml/mapdb/db.go
+++ b/pkg/platform/yaml/mapdb/db.go
@@ -2,6 +2,7 @@ package mapdb
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -9,6 +10,7 @@ import (
 	"go.keploy.io/server/v3/pkg/models"
 	"go.keploy.io/server/v3/pkg/platform/yaml"
 	"go.keploy.io/server/v3/utils"
+	"go.keploy.io/server/v3/utils/pathsafe"
 	"go.uber.org/zap"
 )
 
@@ -238,6 +240,37 @@ func (db *MappingDb) UpsertBatch(ctx context.Context, testSetID string, byTest m
 	db.logger.Debug("Successfully upserted test-mock mappings",
 		zap.String("testSetID", testSetID),
 		zap.Int("tests", len(byTest)))
+
+	return nil
+}
+
+// DeleteMappingsForSet removes the mapping artifact for a re-recorded mock set.
+// Missing files are fine; permission, ownership, or path-safety errors surface
+// so callers do not silently keep stale per-test mappings.
+func (db *MappingDb) DeleteMappingsForSet(ctx context.Context, testSetID string) error {
+	_ = ctx
+	if err := pathsafe.ValidateSingleSegment(testSetID, false); err != nil {
+		return fmt.Errorf("rejecting DeleteMappingsForSet: testSetID %q must be a non-empty single-segment name (no separators, no drive/volume prefix, not '.' or '..') under the mappings output directory: %w", testSetID, err)
+	}
+
+	mappingPath := filepath.Join(db.path, testSetID)
+	fileName := db.MapFileName
+	if fileName == "" {
+		fileName = "mappings"
+	}
+
+	for _, format := range []yaml.Format{yaml.FormatYAML, yaml.FormatJSON} {
+		candidate := filepath.Join(mappingPath, fileName+"."+format.FileExtension())
+		validated, err := yaml.ValidatePath(candidate)
+		if err != nil {
+			utils.LogError(db.logger, err, "failed to validate mapping path for delete", zap.String("at_path", candidate))
+			return err
+		}
+		if err := os.Remove(validated); err != nil && !os.IsNotExist(err) {
+			utils.LogError(db.logger, err, "failed to delete stale mapping file during refresh", zap.String("path", validated))
+			return err
+		}
+	}
 
 	return nil
 }

--- a/pkg/platform/yaml/mapdb/db_test.go
+++ b/pkg/platform/yaml/mapdb/db_test.go
@@ -1,0 +1,43 @@
+package mapdb
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.keploy.io/server/v3/pkg/platform/yaml"
+	"go.uber.org/zap"
+)
+
+func TestDeleteMappingsForSetRemovesYamlAndJSON(t *testing.T) {
+	dir := t.TempDir()
+	setDir := filepath.Join(dir, "stale-map-demo")
+	require.NoError(t, os.MkdirAll(setDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(setDir, "mappings.yaml"), []byte("stale-yaml"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(setDir, "mappings.json"), []byte("stale-json"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(setDir, "mocks.yaml"), []byte("keep mocks"), 0644))
+
+	db := NewWithFormat(zap.NewNop(), dir, "mappings", yaml.FormatYAML)
+	require.NoError(t, db.DeleteMappingsForSet(context.Background(), "stale-map-demo"))
+
+	require.NoFileExists(t, filepath.Join(setDir, "mappings.yaml"))
+	require.NoFileExists(t, filepath.Join(setDir, "mappings.json"))
+	require.FileExists(t, filepath.Join(setDir, "mocks.yaml"), "mapping deletion must not remove mock artifacts")
+}
+
+func TestDeleteMappingsForSetMissingFilesIsNoop(t *testing.T) {
+	db := New(zap.NewNop(), t.TempDir(), "mappings")
+	require.NoError(t, db.DeleteMappingsForSet(context.Background(), "missing-set"))
+}
+
+func TestDeleteMappingsForSetRejectsUnsafeTestSetID(t *testing.T) {
+	dir := t.TempDir()
+	outside := filepath.Join(dir, "victim.yaml")
+	require.NoError(t, os.WriteFile(outside, []byte("do not delete"), 0644))
+
+	db := New(zap.NewNop(), filepath.Join(dir, "mappings"), "mappings")
+	require.Error(t, db.DeleteMappingsForSet(context.Background(), "../victim"))
+	require.FileExists(t, outside)
+}

--- a/pkg/service/mock/record.go
+++ b/pkg/service/mock/record.go
@@ -70,10 +70,19 @@ func (m *mockService) Record(ctx context.Context) error {
 		return fmt.Errorf("%s", stopReason)
 	}
 
-	// 2. Overwrite the named set in place: drop the previous mocks so the
-	//    re-record is a clean rewrite, not an append.
+	// 2. Overwrite the named set in place: drop the previous mocks and
+	//    mappings so the re-record is a clean rewrite, not an append.
 	if err := m.mockDB.DeleteMocksForSet(persistCtx, name); err != nil {
-		m.logger.Debug("no existing mock set to overwrite (or delete failed)", zap.String("mock-set", name), zap.Error(err))
+		stopReason = "failed to overwrite existing mock set"
+		utils.LogError(m.logger, err, stopReason, zap.String("mock-set", name))
+		return fmt.Errorf("%s: %w", stopReason, err)
+	}
+	if m.mappingDB != nil {
+		if err := m.mappingDB.DeleteMappingsForSet(persistCtx, name); err != nil {
+			stopReason = "failed to overwrite existing mock mappings"
+			utils.LogError(m.logger, err, stopReason, zap.String("mock-set", name))
+			return fmt.Errorf("%s: %w", stopReason, err)
+		}
 	}
 	m.mockDB.ResetCounterID()
 

--- a/pkg/service/mock/record_test.go
+++ b/pkg/service/mock/record_test.go
@@ -1,0 +1,127 @@
+package mock
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.keploy.io/server/v3/config"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+func TestRecordOverwriteDeletesMappingsBeforeRunnerStarts(t *testing.T) {
+	var order []string
+	mappingDB := &recordMappingDB{order: &order}
+	instr := &recordInstrumentation{order: &order}
+	mockDB := &recordMockDB{order: &order}
+	store := &recordStore{order: &order}
+	cfg := config.New()
+	cfg.Command = "go test ./..."
+	cfg.Mock.Name = "stale-map-demo"
+
+	svc := &mockService{
+		logger:          zap.NewNop(),
+		instrumentation: instr,
+		mockDB:          mockDB,
+		mappingDB:       mappingDB,
+		store:           store,
+		config:          cfg,
+	}
+
+	require.NoError(t, svc.Record(context.Background()))
+	require.True(t, mockDB.deleted)
+	require.True(t, mappingDB.deleted)
+	require.Equal(t, []string{"setup", "delete-mocks", "delete-mappings", "reset-counter", "get-outgoing", "run", "push", "notify-shutdown"}, order)
+}
+
+type recordInstrumentation struct {
+	order *[]string
+}
+
+func (i *recordInstrumentation) Setup(context.Context, string, models.SetupOptions) error {
+	*i.order = append(*i.order, "setup")
+	return nil
+}
+
+func (i *recordInstrumentation) GetOutgoing(context.Context, models.OutgoingOptions) (<-chan *models.Mock, error) {
+	*i.order = append(*i.order, "get-outgoing")
+	ch := make(chan *models.Mock)
+	close(ch)
+	return ch, nil
+}
+
+func (i *recordInstrumentation) MockOutgoing(context.Context, models.OutgoingOptions) error {
+	return nil
+}
+func (i *recordInstrumentation) StoreMocks(context.Context, []*models.Mock, []*models.Mock) error {
+	return nil
+}
+func (i *recordInstrumentation) UpdateMockParams(context.Context, models.MockFilterParams) error {
+	return nil
+}
+func (i *recordInstrumentation) GetConsumedMocks(context.Context) ([]models.MockState, error) {
+	return nil, nil
+}
+func (i *recordInstrumentation) GetMockErrors(context.Context) ([]models.UnmatchedCall, error) {
+	return nil, nil
+}
+
+func (i *recordInstrumentation) Run(context.Context, models.RunOptions) models.AppError {
+	*i.order = append(*i.order, "run")
+	return models.AppError{AppErrorType: models.ErrAppStopped}
+}
+
+func (i *recordInstrumentation) MakeAgentReadyForDockerCompose(context.Context) error { return nil }
+func (i *recordInstrumentation) NotifyGracefulShutdown(context.Context) error {
+	*i.order = append(*i.order, "notify-shutdown")
+	return nil
+}
+
+type recordMockDB struct {
+	order   *[]string
+	deleted bool
+}
+
+func (db *recordMockDB) InsertMock(context.Context, *models.Mock, string) error { return nil }
+func (db *recordMockDB) DeleteMocksForSet(context.Context, string) error {
+	db.deleted = true
+	*db.order = append(*db.order, "delete-mocks")
+	return nil
+}
+func (db *recordMockDB) GetFilteredMocks(context.Context, string, time.Time, time.Time, map[string]bool, map[string]bool) ([]*models.Mock, error) {
+	return nil, nil
+}
+func (db *recordMockDB) GetUnFilteredMocks(context.Context, string, time.Time, time.Time, map[string]bool, map[string]bool) ([]*models.Mock, error) {
+	return nil, nil
+}
+func (db *recordMockDB) ResetCounterID()    { *db.order = append(*db.order, "reset-counter") }
+func (db *recordMockDB) SetCounterID(int64) {}
+
+type recordMappingDB struct {
+	order   *[]string
+	deleted bool
+}
+
+func (db *recordMappingDB) DeleteMappingsForSet(context.Context, string) error {
+	db.deleted = true
+	*db.order = append(*db.order, "delete-mappings")
+	return nil
+}
+func (db *recordMappingDB) UpsertBatch(context.Context, string, map[string][]models.MockEntry) error {
+	return nil
+}
+func (db *recordMappingDB) Get(context.Context, string) (map[string][]models.MockEntry, bool, error) {
+	return nil, false, nil
+}
+
+type recordStore struct {
+	order *[]string
+}
+
+func (recordStore) Pull(context.Context, string) error { return nil }
+func (s recordStore) Push(context.Context, string) error {
+	*s.order = append(*s.order, "push")
+	return nil
+}

--- a/pkg/service/mock/service.go
+++ b/pkg/service/mock/service.go
@@ -106,6 +106,7 @@ type MockDB interface {
 // MappingDB persists and reads the per-test mock mapping for a set. Optional:
 // nil disables per-test scoping (suite-level record/replay).
 type MappingDB interface {
+	DeleteMappingsForSet(ctx context.Context, testSetID string) error
 	UpsertBatch(ctx context.Context, testSetID string, byTest map[string][]models.MockEntry) error
 	Get(ctx context.Context, testSetID string) (map[string][]models.MockEntry, bool, error)
 }


### PR DESCRIPTION
Fixes #4488

## Describe the changes that are made

- Clear stale mock mappings when `keploy mock record` overwrites an existing named mock set.
- Add `DeleteMappingsForSet` to the YAML mapping DB so both `mappings.yaml` and `mappings.json` are removed safely during re-record.
- Keep existing `UpsertBatch` merge behavior unchanged for normal mapping updates.
- Return an error if stale mocks or mappings cannot be deleted, instead of silently continuing with a partial overwrite.
- Add unit tests for mapping deletion and mock re-record overwrite behavior.

## Links & References

**Closes:** #4488

### 🔗 Related PRs

- NA

### 🐞 Related Issues

- #4488

### 📄 Related Documents

- NA

## What type of PR is this? (check all applicable)

- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?

- [x] 🙅 no, because they aren't needed

## Added comments for hard-to-understand areas?

- [x] 👍 yes

## Added to documentation?

- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?

- [x] 👍 yes, mentioned below

Tested with:

`go test ./pkg/service/mock ./pkg/platform/yaml/mapdb`

## Self Review done?

- [x] ✅ yes

## Any relevant screenshots, recordings or logs?

`go test ./pkg/service/mock ./pkg/platform/yaml/mapdb`

Result:

`ok   go.keploy.io/server/v3/pkg/service/mock`

`ok   go.keploy.io/server/v3/pkg/platform/yaml/mapdb`
