### PR TITLE
fix(mock): clear stale mappings.yaml on named-set re-record

### DIFF
--- a/pkg/platform/yaml/mapdb/db.go
+++ b/pkg/platform/yaml/mapdb/db.go
@@ -2,6 +2,7 @@ package mapdb
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -9,6 +10,7 @@ import (
 	"go.keploy.io/server/v3/pkg/models"
 	"go.keploy.io/server/v3/pkg/platform/yaml"
 	"go.keploy.io/server/v3/utils"
+	"go.keploy.io/server/v3/utils/pathsafe"
 	"go.uber.org/zap"
 )
 
@@ -239,6 +241,44 @@ func (db *MappingDb) UpsertBatch(ctx context.Context, testSetID string, byTest m
 		zap.String("testSetID", testSetID),
 		zap.Int("tests", len(byTest)))
 
+	return nil
+}
+
+// DeleteForSet removes the mappings file for a named set in every supported
+// format (mappings.yaml / mappings.json). It is the mapping-side counterpart
+// of mockdb's DeleteMocksForSet: a re-record must replace mocks.yaml AND
+// mappings.yaml together, otherwise the fresh mocks.yaml ships with stale
+// test-to-mock entries left over from the previous recording (keploy#4488).
+//
+// Missing files are tolerated; only permission/ownership errors surface. The
+// same pathsafe single-segment guard as the mock delete applies, because the
+// test-set ID reaches the filesystem here too.
+func (db *MappingDb) DeleteForSet(ctx context.Context, testSetID string) error {
+	_ = ctx
+	if err := pathsafe.ValidateSingleSegment(testSetID, false); err != nil {
+		return fmt.Errorf("rejecting MappingDb.DeleteForSet: testSetID %q must be a non-empty single-segment name under the mocks output directory: %w", testSetID, err)
+	}
+	mappingPath := filepath.Join(db.path, testSetID)
+	fileName := db.MapFileName
+	if fileName == "" {
+		fileName = "mappings"
+	}
+	candidates := []string{
+		filepath.Join(mappingPath, fileName+"."+yaml.FormatYAML.FileExtension()),
+		filepath.Join(mappingPath, fileName+"."+yaml.FormatJSON.FileExtension()),
+	}
+	for _, candidate := range candidates {
+		validated, err := yaml.ValidatePath(candidate)
+		if err != nil {
+			utils.LogError(db.logger, err, "failed to validate mapping path for delete", zap.String("at_path", candidate))
+			return err
+		}
+		if err := os.Remove(validated); err != nil && !os.IsNotExist(err) {
+			utils.LogError(db.logger, err, "failed to delete stale mapping file during refresh; missing files are tolerated, only permission/ownership errors surface here", zap.String("path", validated))
+			return err
+		}
+	}
+	db.logger.Info("Successfully cleared old test-mock mappings for refresh.", zap.String("testSetID", testSetID))
 	return nil
 }
 

--- a/pkg/platform/yaml/mapdb/delete_test.go
+++ b/pkg/platform/yaml/mapdb/delete_test.go
@@ -1,0 +1,121 @@
+package mapdb
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.keploy.io/server/v3/pkg/platform/yaml"
+	"go.uber.org/zap"
+)
+
+// Regression test for keploy#4488: a re-record deletes mocks.yaml for the set
+// but previously left mappings.yaml in place, so UpsertBatch merged the fresh
+// per-test entries into stale ones from the previous recording and tests could
+// map to mocks that no longer exist. DeleteForSet must remove every mapping
+// file variant so the next UpsertBatch starts from an empty slate.
+func TestDeleteForSetClearsStaleMappings(t *testing.T) {
+	logger := zap.NewNop()
+	dir := t.TempDir()
+	setID := "myset"
+
+	db := New(logger, dir, "")
+
+	ctx := context.Background()
+
+	// First recording: two tests mapped to their mocks.
+	first := map[string][]models.MockEntry{
+		"test-1": {{Name: "mock-1"}, {Name: "mock-2"}},
+		"test-2": {{Name: "mock-3"}},
+	}
+	if err := db.UpsertBatch(ctx, setID, first); err != nil {
+		t.Fatalf("first upsert failed: %v", err)
+	}
+
+	got, present, err := db.Get(ctx, setID)
+	if err != nil || !present {
+		t.Fatalf("mappings should exist after first record: got=%v present=%v err=%v", got, present, err)
+	}
+	if len(got["test-1"]) != 2 {
+		t.Fatalf("expected 2 mocks for test-1 after first record, got %d", len(got["test-1"]))
+	}
+
+	// Re-record: clear mappings exactly as the mock-record flow now does.
+	if err := db.DeleteForSet(ctx, setID); err != nil {
+		t.Fatalf("delete for set failed: %v", err)
+	}
+
+	if _, present, _ := db.Get(ctx, setID); present {
+		t.Fatal("mappings must not survive DeleteForSet")
+	}
+
+	// Second recording: only one test with one mock. The stale test-2 entry
+	// (and test-1's second mock) must NOT reappear via merge.
+	second := map[string][]models.MockEntry{
+		"test-1": {{Name: "mock-1"}},
+	}
+	if err := db.UpsertBatch(ctx, setID, second); err != nil {
+		t.Fatalf("second upsert failed: %v", err)
+	}
+
+	got, _, err = db.Get(ctx, setID)
+	if err != nil {
+		t.Fatalf("get after second record failed: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("stale tests survived re-record: got %d tests (%v), want 1", len(got), got)
+	}
+	if len(got["test-1"]) != 1 || got["test-1"][0].Name != "mock-1" {
+		t.Fatalf("stale mocks survived re-record for test-1: %v", got["test-1"])
+	}
+}
+
+// DeleteForSet must tolerate a missing mappings file (first-ever record calls
+// it before anything exists).
+func TestDeleteForSetMissingFileIsNoOp(t *testing.T) {
+	db := New(zap.NewNop(), t.TempDir(), "")
+	if err := db.DeleteForSet(context.Background(), "fresh"); err != nil {
+		t.Fatalf("delete on missing file should be a no-op, got: %v", err)
+	}
+}
+
+// The test-set ID reaches os.Remove here, so the pathsafe guard must reject
+// traversal attempts exactly like the mock-side delete does.
+func TestDeleteForSetRejectsUnsafeSetIDs(t *testing.T) {
+	db := New(zap.NewNop(), t.TempDir(), "")
+	for _, bad := range []string{"../escape", "a/b", "..", "."} {
+		if err := db.DeleteForSet(context.Background(), bad); err == nil {
+			t.Fatalf("expected rejection for %q", bad)
+		}
+	}
+}
+
+// JSON-format mappings must be cleared too — a yaml refresh must not leave a
+// stale json mapping file behind that FileExistsAny would then prefer.
+func TestDeleteForSetClearsJSONVariant(t *testing.T) {
+	logger := zap.NewNop()
+	dir := t.TempDir()
+	setID := "jsonset"
+
+	db := NewWithFormat(logger, dir, "", yaml.FormatJSON)
+	ctx := context.Background()
+	if err := db.UpsertBatch(ctx, setID, map[string][]models.MockEntry{
+		"test-1": {{Name: "mock-1"}},
+	}); err != nil {
+		t.Fatalf("json upsert failed: %v", err)
+	}
+	jsonPath := filepath.Join(dir, setID, "mappings.json")
+	if _, err := os.Stat(jsonPath); err != nil {
+		t.Fatalf("expected json mappings at %s: %v", jsonPath, err)
+	}
+
+	ydb := New(logger, dir, "")
+	if err := ydb.DeleteForSet(ctx, setID); err != nil {
+		t.Fatalf("delete failed: %v", err)
+	}
+	if _, err := os.Stat(jsonPath); !os.IsNotExist(err) {
+		t.Fatalf("json mappings survived delete: %v", err)
+	}
+}

--- a/pkg/service/mock/record.go
+++ b/pkg/service/mock/record.go
@@ -70,12 +70,20 @@ func (m *mockService) Record(ctx context.Context) error {
 		return fmt.Errorf("%s", stopReason)
 	}
 
-	// 2. Overwrite the named set in place: drop the previous mocks so the
-	//    re-record is a clean rewrite, not an append.
+	// 2. Overwrite the named set in place: drop the previous mocks AND their
+	//    per-test mappings so the re-record is a clean rewrite, not an append.
+	//    mappings.yaml must be cleared alongside mocks.yaml: UpsertBatch merges
+	//    (unions) with what is on disk, so surviving entries from the previous
+	//    recording would point tests at mocks that no longer exist (keploy#4488).
 	if err := m.mockDB.DeleteMocksForSet(persistCtx, name); err != nil {
 		m.logger.Debug("no existing mock set to overwrite (or delete failed)", zap.String("mock-set", name), zap.Error(err))
 	}
 	m.mockDB.ResetCounterID()
+	if m.mappingDB != nil {
+		if err := m.mappingDB.DeleteForSet(persistCtx, name); err != nil {
+			m.logger.Warn("failed to clear stale per-test mappings; replay may map tests to deleted mocks", zap.String("mock-set", name), zap.Error(err))
+		}
+	}
 
 	// 3. Arm the record proxy and stream captured mocks.
 	captureCtx, stopCapture := context.WithCancel(context.WithoutCancel(ctx))

--- a/pkg/service/mock/service.go
+++ b/pkg/service/mock/service.go
@@ -104,10 +104,14 @@ type MockDB interface {
 }
 
 // MappingDB persists and reads the per-test mock mapping for a set. Optional:
-// nil disables per-test scoping (suite-level record/replay).
+// nil disables per-test scoping (suite-level record/replay). DeleteForSet is
+// the re-record counterpart of MockDB.DeleteMocksForSet — a named-set refresh
+// must clear mappings.yaml alongside mocks.yaml so stale test-to-mock entries
+// from the previous recording cannot survive into the fresh set (keploy#4488).
 type MappingDB interface {
 	UpsertBatch(ctx context.Context, testSetID string, byTest map[string][]models.MockEntry) error
 	Get(ctx context.Context, testSetID string) (map[string][]models.MockEntry, bool, error)
+	DeleteForSet(ctx context.Context, testSetID string) error
 }
 
 // Store is the mock-set persistence backend. OSS uses FileStore (mocks live on


### PR DESCRIPTION
Fixes #4488

## What

`keploy mock record` on an existing named set deletes `mocks.yaml` but leaves `mappings.yaml` in place. Since `UpsertBatch` **unions** new per-test entries with what is on disk (by design, for mid-recording deltas), a re-record produced a fresh mocks set paired with stale test-to-mock mappings from the previous recording — tests could map to mocks that no longer exist.

## The fix

- **`MappingDb.DeleteForSet(ctx, testSetID)`** (`pkg/platform/yaml/mapdb/db.go`): removes `mappings.yaml` and `mappings.json` for the named set. Same pathsafe single-segment guard as `DeleteMocksForSet` (the testSetID reaches `os.Remove` here too), missing files tolerated, permission errors surfaced.
- **`record.go`**: calls `mappingDB.DeleteForSet` right after `DeleteMocksForSet`, so the mock delete + mapping delete are one logical overwrite unit. Warns (not fails) if the mapping clear doesn't land — recording still works, replay just can't scope per-test against stale data.
- **`MappingDB` interface** gains `DeleteForSet`.

## Why delete instead of replace-on-write

The union behavior in `UpsertBatch`/`mergeMockEntries` is load-bearing: the agent emits a test's mappings as multiple deltas and replacing would silently drop earlier ones (the comment block documents a real no_mocks failure from exactly that). Deleting at the start of a re-record is the one moment replacement is semantically correct, because there is nothing worth keeping — everything in the file describes the previous recording.

## Tests

New `pkg/platform/yaml/mapdb/delete_test.go`:

- `TestDeleteForSetClearsStaleMappings` — full record → re-record cycle; asserts stale tests AND stale mock entries don't resurface via merge
- `TestDeleteForSetMissingFileIsNoOp` — first-ever record tolerance
- `TestDeleteForSetRejectsUnsafeSetIDs` — traversal guards (`../`, `a/b`, `..`, ".")
- `TestDeleteForSetClearsJSONVariant` — json-format mappings cleared too, so a yaml refresh isn't shadowed

All 4 pass; full `mapdb` + `service/mock` suites green; build with `viper_bind_struct` clean.

## Checklist

- [x] Conventional commit + signoff
- [x] No customer data / traces / keys in tests or fixtures
- [x] Regression test proves the exact reported failure mode