### PR TITLE
feat(models): add unit test validation for PostgresV3Response mutual

### DIFF
--- a/pkg/models/mock_test.go
+++ b/pkg/models/mock_test.go
@@ -272,8 +272,17 @@ func TestPostgresV3Response_CopyIn_RoundTrip(t *testing.T) {
 	if decoded.CopyOut != nil {
 		t.Fatalf("CopyOut: omitempty should have kept this nil on the CopyIn-only fixture, got %+v", decoded.CopyOut)
 	}
-	// TODO(validation): once a Validate() method or a custom
-	// UnmarshalYAML lands on PostgresV3Response, add a separate test
-	// that feeds a malformed fixture carrying BOTH Rows and CopyIn
-	// and asserts the validator rejects it.
+
+	// Valid shape passes Validate()
+	if err := decoded.Validate(); err != nil {
+		t.Fatalf("Validate(): valid CopyIn response failed validation: %v", err)
+	}
+
+	// Malformed shape carrying both Rows and CopyIn must be rejected by Validate()
+	malformed := decoded
+	malformed.Rows = []PostgresV3Cells{{{Value: int64(42)}}}
+	if err := malformed.Validate(); err == nil {
+		t.Fatalf("Validate(): want non-nil error on malformed response with both Rows and CopyIn, got nil")
+	}
 }
+


### PR DESCRIPTION
## Describe the changes that are made
- Updated `TestPostgresV3Response_CopyIn_RoundTrip` in `pkg/models/mock_test.go` to explicitly test `PostgresV3Response.Validate()`.
- Verified that valid `CopyIn` responses pass validation while malformed shapes carrying both `Rows` and `CopyIn` are rejected by `Validate()`.
- Cleaned up the stale TODO in `pkg/models/mock_test.go`.

## Links & References

Closes #4492

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- #4492
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [x] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed

## Added comments for hard-to-understand areas?
- [x] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

Run Postgres model tests:
```bash
go test -v -tags=viper_bind_struct ./pkg/models -run "TestPostgresV3Response.*"
```

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?
