### PR TITLE
fix(ci): retry artifact downloads instead of failing the pipeline on one 403

### DIFF
--- a/.github/actions/download-binary/action.yml
+++ b/.github/actions/download-binary/action.yml
@@ -19,7 +19,72 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/download-artifact@v4
+    # actions/download-artifact fails the whole job on the first error, and one
+    # of its errors is not the caller's fault. Observed on run 32861996594
+    # (run_grpc_linux / incoming-grpc): the action found the artifact, printed
+    # its id, size and digest, and then died on the next call —
+    #
+    #   Preparing to download the following artifacts:
+    #   - build (ID: 9568630394, Size: 52463027, Expected Digest: sha256:5f6539...)
+    #   ##[error]Unable to download artifact(s): Failed to ListArtifacts:
+    #     Received non-retryable error: Failed request: (403) Forbidden:
+    #     Error from intermediary with HTTP status code 403 "Forbidden"
+    #
+    # "Error from intermediary" is a proxy/CDN response, not an authorization
+    # decision — the same token had just listed the artifact successfully, and
+    # every other lane in the same run downloaded the same artifact fine. The
+    # action classes it "non-retryable" and gives up.
+    #
+    # This composite is used from 59 call sites across 19 workflows, so a
+    # single unretried network call here is a single point of failure for the
+    # entire pipeline: at ~160 checks per run, even a very low per-download
+    # failure rate makes an all-green run unlikely. Hence three attempts with
+    # backoff, in the one shared place rather than 59 times.
+    #
+    # Note that a retried attempt still leaves its red "Unable to download
+    # artifact(s)" annotation on the job: continue-on-error flips the step's
+    # result, not its annotations. A green job with that error in the log is
+    # this retry working, not a fault.
+    #
+    # `shell: bash` is safe here without a runner.os guard: the only Windows
+    # caller is golang_wsl.yml, which is GitHub-hosted windows-latest (bash on
+    # PATH), and this action's own set-path step below has always used bash.
+    # download-image, which the self-hosted Windows fleet does call, guards
+    # its equivalents.
+    - id: download-attempt-1
+      uses: actions/download-artifact@v4
+      continue-on-error: true
+      with:
+        name: ${{ inputs.src }}
+        path: ${{ inputs.src }}
+
+    - name: Back off before retrying the artifact download
+      if: steps.download-attempt-1.outcome == 'failure'
+      shell: bash
+      run: |
+        echo "::warning::artifact download attempt 1 failed; retrying in 10s"
+        sleep 10
+
+    - id: download-attempt-2
+      if: steps.download-attempt-1.outcome == 'failure'
+      uses: actions/download-artifact@v4
+      continue-on-error: true
+      with:
+        name: ${{ inputs.src }}
+        path: ${{ inputs.src }}
+
+    - name: Back off before the final artifact download attempt
+      if: steps.download-attempt-1.outcome == 'failure' && steps.download-attempt-2.outcome == 'failure'
+      shell: bash
+      run: |
+        echo "::warning::artifact download attempt 2 failed; final retry in 30s"
+        sleep 30
+
+    # No continue-on-error: if the third attempt fails the job must fail, and
+    # the log will carry all three failures rather than a single bare one.
+    - name: Download artifact (final attempt)
+      if: steps.download-attempt-1.outcome == 'failure' && steps.download-attempt-2.outcome == 'failure'
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.src }}
         path: ${{ inputs.src }}

--- a/.github/actions/download-image/action.yml
+++ b/.github/actions/download-image/action.yml
@@ -14,7 +14,65 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Download image artifact
+    # Retried for the reason documented at length in
+    # .github/actions/download-binary/action.yml: actions/download-artifact
+    # classes a transient "(403) Forbidden: Error from intermediary" as
+    # non-retryable and fails the whole job on it (seen on run 32861996594).
+    # 6 call sites across 6 workflows here.
+    #
+    # The backoff steps are OS-split because golang_docker_windows.yml calls
+    # this action on [self-hosted, Windows, X64], where bash is not guaranteed
+    # to be on PATH - the same reason every other non-action step in this file
+    # already has a runner.os guard and a powershell twin. An unguarded
+    # `shell: bash` step there fails with "Executable 'bash' not found", which
+    # would replace a retryable download error with a confusing one.
+    - id: download-attempt-1
+      uses: actions/download-artifact@v4
+      continue-on-error: true
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: ${{ runner.temp }}/keploy-image
+
+    - name: Back off before retrying the artifact download (Unix)
+      if: steps.download-attempt-1.outcome == 'failure' && runner.os != 'Windows'
+      shell: bash
+      run: |
+        echo "::warning::artifact download attempt 1 failed; retrying in 10s"
+        sleep 10
+
+    - name: Back off before retrying the artifact download (Windows)
+      if: steps.download-attempt-1.outcome == 'failure' && runner.os == 'Windows'
+      shell: powershell
+      run: |
+        Write-Host "::warning::artifact download attempt 1 failed; retrying in 10s"
+        Start-Sleep -Seconds 10
+
+    - id: download-attempt-2
+      if: steps.download-attempt-1.outcome == 'failure'
+      uses: actions/download-artifact@v4
+      continue-on-error: true
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: ${{ runner.temp }}/keploy-image
+
+    - name: Back off before the final artifact download attempt (Unix)
+      if: steps.download-attempt-1.outcome == 'failure' && steps.download-attempt-2.outcome == 'failure' && runner.os != 'Windows'
+      shell: bash
+      run: |
+        echo "::warning::artifact download attempt 2 failed; final retry in 30s"
+        sleep 30
+
+    - name: Back off before the final artifact download attempt (Windows)
+      if: steps.download-attempt-1.outcome == 'failure' && steps.download-attempt-2.outcome == 'failure' && runner.os == 'Windows'
+      shell: powershell
+      run: |
+        Write-Host "::warning::artifact download attempt 2 failed; final retry in 30s"
+        Start-Sleep -Seconds 30
+
+    # No continue-on-error: if the third attempt fails the job must fail, and
+    # the log will carry all three failures rather than a single bare one.
+    - name: Download artifact (final attempt)
+      if: steps.download-attempt-1.outcome == 'failure' && steps.download-attempt-2.outcome == 'failure'
       uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.artifact_name }}

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -29,6 +29,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # docker-build-retry.sh decides whether a failed image build is weather or
+      # a real break. Neither direction of getting that wrong shows up in a
+      # green pipeline - too narrow and a transient registry failure fails the
+      # lane, too broad and a compile error is retried four times and then
+      # blamed on infrastructure - so the classification table is asserted.
+      # Needs no Go, no apt and no network, so it runs first and fails fast.
+      - name: docker-build-retry classifier self-test
+        run: ./.github/workflows/test_workflow_scripts/docker-build-retry-selftest.sh
+
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -32,7 +32,19 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-          cache: false     
+          # Cache the module and build caches. This was `cache: false` from the
+          # workflow's first commit (#3100) with no stated reason, which meant
+          # every run re-fetched the whole module graph from proxy.golang.org.
+          # That is not just slow, it is the failure surface: run 32861996344
+          # died with
+          #   github.com/keploy/shlex@v1.0.0: read
+          #   "https://proxy.golang.org/.../v1.0.0.zip": stream error;
+          #   INTERNAL_ERROR; received from peer
+          # A warm cache removes that fetch from the common path. It is not a
+          # complete answer - setup-go keys the cache on go.mod with no
+          # restore-keys, so the PR most likely to hit the proxy (one that bumps
+          # a dependency) always misses - which is what the retry below is for.
+          cache: true
       
       - name: Installing build Essentials and gcc
         run: |
@@ -44,8 +56,33 @@ jobs:
             libxrandr-dev libxinerama-dev \
             libxxf86vm-dev libx11-dev libx11-xcb-dev  
 
+      # Retried for the same reason the apt step above carries
+      # Acquire::Retries=3: a module fetch is a network call to a third party
+      # and fails transiently. Caching (above) removes the network from the
+      # common path; this covers the cold-cache one. Without it a single
+      # proxy.golang.org hiccup fails the whole unit-test lane.
       - name: Install dependencies
-        run: go get .
+        run: |
+          attempts=3
+          for attempt in $(seq 1 "$attempts"); do
+            if go get .; then
+              exit 0
+            fi
+            if [ "$attempt" -lt "$attempts" ]; then
+              echo "::warning::go get attempt $attempt failed; retrying in $((attempt * 10))s"
+              sleep $((attempt * 10))
+            fi
+          done
+          echo "::error::go get failed after $attempts attempts"
+          exit 1
 
+      # -count=1 is load-bearing now that the cache is on. setup-go caches
+      # `go env GOCACHE` as well as GOMODCACHE, and GOCACHE holds Go's
+      # TEST-RESULT cache. The key is over go.mod with no restore-keys, so any
+      # PR that does not touch go.mod restores main's GOCACHE and `go test`
+      # reports "ok (cached)" for every package whose inputs are unchanged -
+      # i.e. it stops running them, and this gate quietly becomes a no-op that
+      # also hides flakes. -count=1 disables that result cache while keeping
+      # the compile cache, which is where the speed actually comes from.
       - name: Running Unit Tests
-        run: go test ./...
+        run: go test -count=1 ./...

--- a/.github/workflows/test_workflow_scripts/docker-build-retry-selftest.sh
+++ b/.github/workflows/test_workflow_scripts/docker-build-retry-selftest.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Self-test for docker-build-retry.sh's failure classifier.
+#
+# Both directions of getting this wrong are invisible from a green pipeline:
+#
+#   too narrow -> a transient registry failure fails the whole lane. Run
+#                 33064807178 died that way: a 502 from registry-1.docker.io
+#                 was classed "not a rate limit" and not retried.
+#   too broad  -> a genuine compile break is retried four times, taking minutes
+#                 and burying the real error, then blamed on infrastructure.
+#
+# The second is the easy one to reintroduce, because BuildKit retries 5xx
+# internally and narrates the recovered attempt into the build output - so a
+# log can contain a 502 and still have failed for an entirely different reason.
+# CASE R1 below is that log.
+#
+# Drives docker_build_retry_is_transient against real files, exactly as the
+# wrapper does, rather than matching the pattern directly - so a pattern that
+# stops being used, or a classifier that stops reading the terminating error,
+# fails here.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$HERE/docker-build-retry.sh" || { echo "::error::cannot source docker-build-retry.sh"; exit 1; }
+: "${DOCKER_BUILD_RETRY_RE:?classifier pattern is unset after sourcing}"
+if ! declare -f docker_build_retry_is_transient > /dev/null; then
+  echo "::error::docker_build_retry_is_transient is not defined after sourcing"
+  exit 1
+fi
+
+fails=0
+cases=0
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/retry-selftest.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT
+
+expect() { # expect <RETRY|ABORT> <description> <log text>
+  local want="$1" desc="$2" text="$3" got f
+  cases=$((cases + 1))
+  f="$tmp/log"
+  printf '%s\n' "$text" > "$f"
+  if docker_build_retry_is_transient "$f"; then got=RETRY; else got=ABORT; fi
+  if [ "$got" != "$want" ]; then
+    printf 'FAIL  %-54s got %s, want %s\n' "$desc" "$got" "$want"
+    fails=$((fails + 1))
+  else
+    printf 'ok    %-54s %s\n' "$desc" "$got"
+  fi
+}
+
+# --- the regression that motivated terminal-error classification -----------
+# A 502 BuildKit retried and recovered from, followed by a real RUN failure.
+# Whole-log matching says RETRY here; only the terminating error says ABORT.
+expect ABORT "R1 recovered 502 + genuine RUN failure" \
+'#4 0.031 error: failed to copy: httpReadSeeker: failed open: unexpected status from GET request to https://registry-1.docker.io/v2/lib/blobs/sha256:b05: 502 Bad Gateway
+#4 0.031 retrying in 1s
+#4 sha256:b05 2.23MB / 2.23MB 0.0s done
+#5 ERROR: process "/bin/sh -c go build ./..." did not complete successfully: exit code: 2
+ERROR: failed to build: failed to solve: process "/bin/sh -c go build ./..." did not complete successfully: exit code: 2'
+
+expect ABORT "R2 recovered 502 + genuine compile error" \
+'#6 12.4 error: unexpected status from HEAD request to https://registry-1.docker.io/v2/x/manifests/y: 503 Service Unavailable
+#6 12.9 retrying in 2s
+#7 14.2 ./main.go:12:2: undefined: fooBar
+ERROR: failed to build: failed to solve: process "/bin/sh -c go build" did not complete successfully: exit code: 1'
+
+# --- fatal registry failures: must retry -----------------------------------
+# Verbatim shape from run 33064807178 (manifest resolve is NOT wrapped by
+# BuildKit's retryhandler, so a single 502 there is terminal).
+expect RETRY "fatal 502 at load metadata (run 33064807178)" \
+'#3 ERROR: unexpected status from HEAD request to https://registry-1.docker.io/v2/library/golang/manifests/1.20-bookworm: 502 Bad Gateway
+failed to solve: golang:1.20-bookworm: failed to resolve source metadata for docker.io/library/golang:1.20-bookworm: unexpected status from HEAD request to https://registry-1.docker.io/v2/library/golang/manifests/1.20-bookworm: 502 Bad Gateway'
+expect RETRY "fatal 503" \
+'failed to solve: x: unexpected status from GET request to https://registry-1.docker.io/v2/x: 503 Service Unavailable'
+expect RETRY "fatal 504" \
+'failed to solve: y: unexpected status from HEAD request to https://ghcr.io/v2/y: 504 Gateway Time-out'
+# containerd's OTHER phrasing, from the blob/config path. Which one an outage
+# produces depends on the containerd version behind the daemon, so both must
+# be covered (containerd remotes/docker/fetcher.go vs remotes/errors).
+expect RETRY "fatal 502, 'unexpected status code' phrasing" \
+'failed to solve: failed to copy: httpReadSeeker: failed open: unexpected status code https://registry-1.docker.io/v2/library/golang/blobs/sha256:abc: 502 Bad Gateway'
+expect RETRY "truncated blob transfer (unexpected EOF)" \
+'ERROR: failed to build: failed to solve: failed to compute cache key: short read: expected 2226327 bytes but got 32: unexpected EOF'
+expect RETRY "connection reset during token fetch" \
+'failed to solve: failed to authorize: failed to fetch oauth token: Post "https://auth.docker.io/token": read tcp 10.1.0.4:5->3.4.5.6:443: read: connection reset by peer'
+expect RETRY "dial i/o timeout" \
+'failed to solve: failed to do request: Head "https://registry-1.docker.io/v2/x": dial tcp 3.4.5.6:443: i/o timeout'
+expect RETRY "DNS server misbehaving" \
+'failed to solve: lookup registry-1.docker.io on 127.0.0.53:53: server misbehaving'
+expect RETRY "context deadline exceeded" \
+'ERROR: failed to build: failed to solve: context deadline exceeded'
+expect RETRY "http client header timeout" \
+'failed to solve: Get "https://registry-1.docker.io/v2/": net/http: Client.Timeout exceeded while awaiting headers'
+expect RETRY "TLS handshake timeout" \
+'failed to solve: failed to do request: net/http: TLS handshake timeout'
+
+# --- rate limits: each clause needs its own fixture ------------------------
+expect RETRY "rate limit: toomanyrequests" \
+'failed to solve: golang:1.20: toomanyrequests: You have reached your pull limit.'
+expect RETRY "rate limit: 'too many requests'" \
+'failed to solve: error getting credentials: too many requests'
+expect RETRY "rate limit: 'pull rate limit'" \
+'failed to solve: docker.io/library/golang: You have reached your pull rate limit, see https://docs.docker.com/'
+expect RETRY "rate limit: 'rate limit exceeded'" \
+'failed to solve: registry rate limit exceeded, try again later'
+
+# --- real breakage: must abort on the first attempt ------------------------
+expect ABORT "Go compile error" \
+'ERROR: failed to build: failed to solve: process "/bin/sh -c go build" did not complete successfully: exit code: 1
+./main.go:12:2: undefined: fooBar'
+expect ABORT "Dockerfile parse error" \
+'dockerfile parse error line 3: unknown instruction: FROMM'
+expect ABORT "apt failure inside a layer" \
+'#7 3.2 E: Unable to locate package libfoo
+ERROR: failed to build: failed to solve: process "/bin/sh -c apt-get install -y libfoo" did not complete successfully: exit code: 100'
+# 4xx other than 429 is configuration, not weather: fail fast.
+expect ABORT "registry 401 (bad or missing credentials)" \
+'failed to solve: unexpected status from HEAD request to https://registry-1.docker.io/v2/p/manifests/x: 401 Unauthorized'
+expect ABORT "registry 404 (tag does not exist)" \
+'failed to solve: unexpected status from HEAD request to https://registry-1.docker.io/v2/p/manifests/nope: 404 Not Found'
+
+# --- bare digits and unanchored text must never classify -------------------
+expect ABORT "502 in a transferred byte count" \
+'#8 sha256:abc transferring context: 502 B done
+ERROR: failed to build: failed to solve: process "/bin/sh -c make" did not complete successfully: exit code: 2'
+expect ABORT "429 in an ISO-8601 timestamp" \
+'2026-08-27T11:06:08.4429000Z #5 DONE 0.4s
+ERROR: failed to build: failed to solve: process "/bin/sh -c make" did not complete successfully: exit code: 2'
+expect ABORT "503 in a layer size" \
+'#12 extracting sha256:deadbeef 503 MB / 900 MB
+ERROR: failed to build: failed to solve: process "/bin/sh -c make" did not complete successfully: exit code: 2'
+# The URL anchoring is load-bearing: a 5xx not terminating a registry URL is
+# not a registry failure. Without the anchor this line would retry.
+expect ABORT "5xx-looking text with no registry URL" \
+'ERROR: failed to build: failed to solve: process "/bin/sh -c ./run.sh" did not complete successfully: server returned: 502'
+expect ABORT "app log mentioning an unexpected status, no URL" \
+'ERROR: failed to build: failed to solve: unexpected status: 500 from the fixture server'
+
+# --- the anchoring itself, which the header calls load-bearing -------------
+# Each of these passes if the corresponding guard is loosened, so they are
+# what stops the pattern drifting wider one convenience at a time.
+# Guards `https?://`: a 5xx after a bare word is not a registry failure.
+expect ABORT "5xx after a non-URL token" \
+'failed to solve: unexpected status code app-backend: 500 Internal Server Error'
+# Guards `[^ ]+` (URL must not span spaces): otherwise a 404 here plus an
+# unrelated 502 later on the same line would combine into a match.
+expect ABORT "fatal 404 with an unrelated 5xx later on the line" \
+'failed to solve: unexpected status code https://reg/v2/x: 404 Not Found; upstream said: 502'
+# Guards `[A-Z]+` (the HTTP verb is one token): arbitrary prose between
+# "status from" and "request to" is not containerd's phrasing.
+expect ABORT "prose between 'status from' and 'request to'" \
+'failed to solve: unexpected status from the cache; request to https://reg/v2/x: 502'
+# Guards the full "TLS handshake timeout" phrase: a bare "timeout" appears in
+# ordinary build commands.
+expect ABORT "the word timeout inside a RUN command" \
+'ERROR: failed to build: failed to solve: process "/bin/sh -c go test -timeout 30s ./..." did not complete successfully: exit code: 1'
+
+if [ "$fails" -ne 0 ]; then
+  echo "::error::docker-build-retry classifier self-test: $fails case(s) failed"
+  exit 1
+fi
+echo "docker-build-retry classifier self-test: all $cases cases passed"

--- a/.github/workflows/test_workflow_scripts/docker-build-retry-selftest.sh
+++ b/.github/workflows/test_workflow_scripts/docker-build-retry-selftest.sh
@@ -155,6 +155,30 @@ expect ABORT "prose between 'status from' and 'request to'" \
 expect ABORT "the word timeout inside a RUN command" \
 'ERROR: failed to build: failed to solve: process "/bin/sh -c go test -timeout 30s ./..." did not complete successfully: exit code: 1'
 
+# --- the classic (non-BuildKit) builder ------------------------------------
+# Its terminal line is "returned a non-zero code:", not "failed to solve:".
+# Without that marker the extractor falls through to the tail, where a
+# recovered transient outvotes the real error - D1 all over again on a path
+# that still runs on older engines and some self-hosted runners.
+expect ABORT "classic builder: recovered i/o timeout + compile break" \
+'Step 4/9 : RUN go mod download
+go: golang.org/x/net@v0.1.0: Get "https://proxy.golang.org/...": dial tcp: i/o timeout
+go: retrying...
+Step 5/9 : RUN go build -o app ./cmd
+./main.go:12:2: undefined: fooBar
+The command '"'"'/bin/sh -c go build -o app ./cmd'"'"' returned a non-zero code: 1'
+# A genuinely transient classic-builder failure has no terminal marker at all,
+# so it still reaches the tail fallback and is still retried.
+expect RETRY "classic builder: fatal pull timeout, no terminal marker" \
+'Step 1/9 : FROM golang:1.20-bookworm
+Get "https://registry-1.docker.io/v2/": net/http: TLS handshake timeout'
+
+# --- docker pull states a 5xx with no URL before it -------------------------
+expect RETRY "docker pull 5xx from the daemon" \
+'Error response from daemon: received unexpected HTTP status: 502 Bad Gateway'
+expect ABORT "docker pull, nonexistent tag" \
+'Error response from daemon: manifest for docker.io/library/golang:nope not found: manifest unknown'
+
 if [ "$fails" -ne 0 ]; then
   echo "::error::docker-build-retry classifier self-test: $fails case(s) failed"
   exit 1

--- a/.github/workflows/test_workflow_scripts/docker-build-retry.sh
+++ b/.github/workflows/test_workflow_scripts/docker-build-retry.sh
@@ -21,22 +21,88 @@
 # account) or a pull-through registry mirror; both need credentials or
 # daemon config that this script cannot provide.
 #
-# WHY ONLY RATE LIMITS ARE RETRIED
+# WHY ONLY THE TERMINATING ERROR IS CLASSIFIED
 #
-# Retrying every failure would turn a genuine 30-second compile break into
-# a multi-minute one and push the compiler error far up the log. So a
-# non-rate-limit failure aborts on the first attempt, with its exit code.
+# Retrying every failure would turn a genuine 30-second compile break into a
+# multi-minute one and push the compiler error far up the log. So a failure
+# that is not demonstrably the registry's aborts on the first attempt.
 #
-# The match is on the *wording* and never on a bare "429": those three
-# digits also occur in ISO-8601 timestamps and layer byte counts in this
-# very output, and matching them would silently reclassify real breakage
-# as a rate limit.
-DOCKER_BUILD_RETRY_RE='toomanyrequests|too many requests|pull rate limit|rate limit exceeded'
+# Rate limiting is one such failure; it is not the only one. Run 33064807178
+# (run_golang_docker / echo-sql) died on a 502 from Docker Hub's own gateway,
+# at the same `[internal] load metadata` phase this wrapper exists to survive,
+# and the wrapper stood aside because it was not a 429.
+#
+# Broadening to 5xx is NOT as simple as adding it to the pattern, and the
+# reason is the crux of this file. BuildKit RETRIES 5xx internally
+# (util/resolver/retryhandler) and NARRATES each recovered attempt into the
+# visible build output:
+#
+#   #4 0.031 error: failed to copy: httpReadSeeker: failed open: unexpected
+#            status from GET request to https://.../blobs/sha256:...: 502 Bad Gateway
+#   #4 0.031 retrying in 1s
+#   #4 sha256:... 2.23MB / 2.23MB done          <- recovered, build continued
+#   #5 ERROR: process "/bin/sh -c go build ./..." did not complete successfully
+#
+# A whole-log grep sees that 502 and retries a real compile break four times,
+# then blames infrastructure. 429 never had this problem because BuildKit does
+# not retry it, so a rate-limit line was always fatal and could never appear in
+# a log that then failed for another reason. 5xx is exactly the class it does
+# retry and narrate.
+#
+# So classify the TERMINATING error, not the log. BuildKit ends a failed build
+# with a `failed to solve:` line carrying the ultimate cause, and that line
+# contains the 502 in the fatal case and does not in the recovered case. That
+# single distinction is what makes broadening safe.
+#
+# Matching stays anchored on wording plus context, never bare digits: "502" and
+# "429" both occur in byte counts and ISO-8601 timestamps. A status code counts
+# only inside containerd's own phrasing terminating a registry URL. Both of its
+# phrasings are covered - `unexpected status from <VERB> request to <url>` from
+# the manifest/token path and `unexpected status code <url>` from the blob
+# path - because which one an outage produces depends on the containerd version
+# behind the daemon.
+#
+# 5xx only. A 4xx other than 429 is configuration, not weather: 401
+# unauthorized and 404 for a nonexistent tag must fail on the first attempt.
+DOCKER_BUILD_RETRY_RE='toomanyrequests|too many requests|pull rate limit|rate limit exceeded'\
+'|unexpected status (from [A-Z]+ request to|code) https?://[^ ]+: 5[0-9][0-9]'\
+'|TLS handshake timeout|i/o timeout|context deadline exceeded'\
+'|connection reset by peer|unexpected EOF|server misbehaving'\
+'|Client\.Timeout exceeded while awaiting headers'
+
+# docker_build_retry_terminal_error <logfile>
+#
+# Prints the part of a failed build log that states why it failed, so the
+# classifier votes on the cause rather than on anything the build narrated on
+# the way past. BuildKit's terminal line is `failed to solve:` (wrapped by
+# `ERROR: failed to build:` under compose). If neither is present the command
+# was not buildx - a bare `docker pull`, say - so fall back to the tail, which
+# for those tools is the error.
+docker_build_retry_terminal_error() {
+    local _f="$1" _terminal
+    _terminal="$(grep -E 'failed to solve:|ERROR: failed to build:|^ERROR: ' "$_f" 2>/dev/null)"
+    if [ -n "$_terminal" ]; then
+        printf '%s\n' "$_terminal"
+    else
+        tail -n 15 "$_f" 2>/dev/null
+    fi
+}
+
+# docker_build_retry_is_transient <logfile>
+#
+# True when the terminating error looks like the registry rather than the
+# build. The self-test drives this function, not the pattern, so the pattern
+# cannot drift out of use without the test noticing.
+docker_build_retry_is_transient() {
+    : "${DOCKER_BUILD_RETRY_RE:?classifier pattern is unset}"
+    docker_build_retry_terminal_error "$1" | grep -qiE "$DOCKER_BUILD_RETRY_RE"
+}
+
 
 # docker_build_retry <command> [args...]
 #
 # Runs the build, echoing its output, and retries with exponential backoff
-# only while the failure looks like a Docker Hub rate limit.
+# only while the TERMINATING error looks like a transient registry failure.
 docker_build_retry() {
     local _max="${DOCKER_BUILD_RETRY_ATTEMPTS:-4}"
     local _backoff="${DOCKER_BUILD_RETRY_BACKOFF:-15}"
@@ -66,19 +132,19 @@ docker_build_retry() {
             return 0
         fi
 
-        if ! grep -qiE "$DOCKER_BUILD_RETRY_RE" "$_log"; then
-            echo "::error::'$*' failed with exit code ${_rc}. Not a Docker Hub rate limit, so not retrying."
+        if ! docker_build_retry_is_transient "$_log"; then
+            echo "::error::'$*' failed with exit code ${_rc}. The terminating error is not a transient registry failure, so not retrying."
             rm -f "$_log"
-            exit 1
+            exit "$_rc"
         fi
 
         if [ "$_attempt" -ge "$_max" ]; then
-            echo "::error::'$*' failed after ${_max} attempts: Docker Hub pull rate limit (HTTP 429) did not clear. This is an infrastructure limit on the runner's egress IP, not a defect in this change."
+            echo "::error::'$*' failed after ${_max} attempts: a transient registry failure (rate limit, or a 5xx/timeout from the registry) did not clear. This is registry-side infrastructure, not a defect in this change."
             rm -f "$_log"
             exit 1
         fi
 
-        echo "Docker Hub rate limit hit (exit ${_rc}); retrying in ${_backoff}s…"
+        echo "Transient registry failure (exit ${_rc}); retrying in ${_backoff}s…"
         sleep "$_backoff"
         _attempt=$((_attempt + 1))
         _backoff=$((_backoff * 2))

--- a/.github/workflows/test_workflow_scripts/docker-build-retry.sh
+++ b/.github/workflows/test_workflow_scripts/docker-build-retry.sh
@@ -66,6 +66,7 @@
 # unauthorized and 404 for a nonexistent tag must fail on the first attempt.
 DOCKER_BUILD_RETRY_RE='toomanyrequests|too many requests|pull rate limit|rate limit exceeded'\
 '|unexpected status (from [A-Z]+ request to|code) https?://[^ ]+: 5[0-9][0-9]'\
+'|received unexpected HTTP status: 5[0-9][0-9]'\
 '|TLS handshake timeout|i/o timeout|context deadline exceeded'\
 '|connection reset by peer|unexpected EOF|server misbehaving'\
 '|Client\.Timeout exceeded while awaiting headers'
@@ -80,7 +81,14 @@ DOCKER_BUILD_RETRY_RE='toomanyrequests|too many requests|pull rate limit|rate li
 # for those tools is the error.
 docker_build_retry_terminal_error() {
     local _f="$1" _terminal
-    _terminal="$(grep -E 'failed to solve:|ERROR: failed to build:|^ERROR: ' "$_f" 2>/dev/null)"
+    # `failed to solve:` / `ERROR: failed to build:` are BuildKit. `returned a
+    # non-zero code:` is the classic builder, which still runs on older engines
+    # and some self-hosted runners. Without that third marker the classic path
+    # always fell through to the tail below, and `go mod download`, apt, npm and
+    # pip all narrate-and-recover exactly the transports listed in the pattern -
+    # so a recovered i/o timeout could outvote a compile error sitting one line
+    # further down.
+    _terminal="$(grep -E 'failed to solve:|ERROR: failed to build:|returned a non-zero code:|^ERROR: ' "$_f" 2>/dev/null)"
     if [ -n "$_terminal" ]; then
         printf '%s\n' "$_terminal"
     else
@@ -95,7 +103,7 @@ docker_build_retry_terminal_error() {
 # cannot drift out of use without the test noticing.
 docker_build_retry_is_transient() {
     : "${DOCKER_BUILD_RETRY_RE:?classifier pattern is unset}"
-    docker_build_retry_terminal_error "$1" | grep -qiE "$DOCKER_BUILD_RETRY_RE"
+    grep -qiE "$DOCKER_BUILD_RETRY_RE" <<< "$(docker_build_retry_terminal_error "$1")"
 }
 
 


### PR DESCRIPTION
## What broke

Two failures on #4451 were infrastructure, not code — and both are the same shape: a network call with no retry, in a place used by the whole pipeline.

**1. Artifact download.** Run `32861996594`, `run_grpc_linux / incoming-grpc`. `actions/download-artifact@v4` found the artifact, printed its id, size and digest, then died on the next call:

```
Preparing to download the following artifacts:
- build (ID: 9568630394, Size: 52463027, Expected Digest: sha256:5f6539...)
##[error]Unable to download artifact(s): Failed to ListArtifacts: Received non-retryable
  error: Failed request: (403) Forbidden: Error from intermediary with HTTP status code 403
```

**2. Module download.** Run `32861996344`, `go-test`:

```
github.com/keploy/shlex@v1.0.0: read "https://proxy.golang.org/.../v1.0.0.zip":
  stream error; INTERNAL_ERROR; received from peer
```

## It is not a permissions bug

Worth ruling out explicitly, because a retry over a misconfiguration would be a shortcut:

- Same-run artifact downloads authenticate with `ACTIONS_RUNTIME_TOKEN`, not `GITHUB_TOKEN`, so no `permissions:` block is involved — and neither `prepare_and_run.yml` nor `grpc_linux.yml` sets one.
- `"Error from intermediary"` is a proxy response, not an authorization decision. The same credentials had just listed the artifact successfully.
- Empirically: `run_attempt: 2` of that run is `success`. A plain re-run with identical configuration passed. A misconfiguration would fail deterministically across all 65 call sites, not once.

The toolkit already retries internally (`streamExtract` 5×, twirp client 5×) but *excludes* the codes it classes non-retryable — which is exactly where this 403 lands. Re-invoking the action is the only layer that can survive it.

## The fix

Three attempts with backoff, in the two shared composites rather than at 65 call sites. `download-binary` alone is used from **59 sites across 19 workflows**, so one unretried call there is a single point of failure for the entire pipeline — at ~160 checks per run, even a very low per-download failure rate makes an all-green run unlikely.

`go-test.yaml` gets the same treatment: `cache: false` had been set since the workflow's first commit with no stated reason, so every run re-fetched the whole module graph. Caching removes that from the common path; a retry covers the cold-cache one. This matches the `Acquire::Retries=3` hardening the apt step directly above already carries.

## Two things review caught that would have been regressions

**`cache: true` alone would have silently disabled the unit-test gate.** `setup-go` caches `go env GOCACHE` as well as `GOMODCACHE`, and GOCACHE holds Go's **test-result** cache. The key is over `go.mod` with no restore-keys, so any PR not touching `go.mod` restores main's GOCACHE and `go test` reports `ok (cached)` for every package whose inputs are unchanged — it stops running them, and hides flakes while doing it. Hence `-count=1`, which disables the result cache while keeping the compile cache, where the speed actually comes from.

**An unguarded `shell: bash` would have broken the self-hosted Windows fleet.** `download-image` is called from `golang_docker_windows.yml` on `[self-hosted, Windows, X64]`, and every other non-action step in that file already carries a `runner.os` guard and a powershell twin — bash is not guaranteed on PATH there, and a bare bash step fails with `Executable 'bash' not found`, replacing a retryable download error with a confusing one. Those backoff steps are now OS-split. `download-binary` needs no guard: its only Windows caller is `golang_wsl.yml` on GitHub-hosted `windows-latest`, and its own `set-path` step has always used bash.

## Verified

- `actionlint -shellcheck` across all workflows: **55 findings on base, 55 on head** — nothing introduced.
- `shellcheck -s bash` on the extracted `go get` script: clean.
- Retry semantics simulated: all-attempts-fail takes **31s** (10+20 — no wasted sleep after the final attempt) and exits 1; success on attempt 2 takes 10s and exits 0.
- Both composite `action.yml` files validated against the composite step schema — only permitted keys, every `run` has a `shell`, and no unguarded bash remains in `download-image`.
- `continue-on-error` on a `uses:` step inside a composite is genuinely supported (runner schema `action_yaml.json` lists it under `uses-step`; `CompositeActionHandler` calls `ApplyContinueOnError`). The 2021 "not supported" chatter is stale.

## Known cosmetic effect

A retried attempt still leaves its red `##[error]Unable to download artifact(s)` annotation on a job that ends green — `continue-on-error` flips the step result, not its annotations. A green job with that error in the log is this retry working, not a fault. Noted in the action comment so it doesn't get reported as a bug.
