### PR TITLE
[DO NOT MERGE] ci: verify integrations#266 across all lanes

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,7 +24,7 @@ env:
   # when set (so operators can override without editing this file),
   # falling back to `main`. Pin to a specific SHA via the repo var if
   # a feat branch needs to carry a cross-repo change.
-  INTEGRATION_REF: ${{ vars.INTEGRATION_REF || 'main' }}
+  INTEGRATION_REF: b201325bee0a525915af37c9cd063eff08e6920f
 
 jobs:
   golangci:

--- a/.github/workflows/prepare_and_run.yml
+++ b/.github/workflows/prepare_and_run.yml
@@ -33,7 +33,7 @@ env:
   # three workflows track the same integrations ref. Pin to a specific
   # SHA via the repo var if a feat branch needs to carry a cross-repo
   # change.
-  INTEGRATION_REF: ${{ vars.INTEGRATION_REF || 'main' }}
+  INTEGRATION_REF: b201325bee0a525915af37c9cd063eff08e6920f
 
 jobs:
   # -------------------------------------------------------------------


### PR DESCRIPTION
Verification-only PR. Pins `INTEGRATION_REF` to the head of keploy/integrations#266 (`b201325`) so every keploy pipeline builds the agent with that change and runs the full lane matrix against it.

integrations#266 = mongo/v2: a mock miss answers with a command error instead of a connection reset (getMore misses get `CursorNotFound`), plus a process-wide synthesized change-stream cursor registry — fixes keploy/integrations#271, the `ReplicaSetNoPrimary` cascade that failed 32/42 tests in the keploy-cloud-replay lane and thousands of auto-replay verdicts daily.

Close without merging once the matrix is green (same procedure as the #267 verification PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)