### PR TITLE
fix(testdb): descriptive test names minted from a monotonic counter — deletion can no longer re-mint a name

### DIFF
--- a/pkg/platform/yaml/testdb/db.go
+++ b/pkg/platform/yaml/testdb/db.go
@@ -165,12 +165,6 @@ func (ts *TestYaml) nextTestIndex(tcsPath string) (int, error) {
 	return seed, nil
 }
 
-// nextSlugIndex returns the next index for a descriptive slug within
-// tcsPath. First call per (tcsPath, slug) seeds from the on-disk scan
-// (yaml.NextIndexForPrefix already returns "max existing + 1"); every
-// later call is a pure atomic increment, so deleting the files —
-// which auto-replay does to every executed test — can never rewind
-// the numbering. Mirrors nextTestIndex's contract for sequential names.
 // slugIndexKey is the single definition of the slugIndex map key. Minting,
 // seeding and the on-collision resync all go through it so the three can
 // never drift onto different keys for the same (directory, slug) pair — a
@@ -229,6 +223,12 @@ func (ts *TestYaml) resyncSlugIndexFromDisk(tcsPath string, tc *models.TestCase)
 	ts.raiseSlugIndex(slugIndexKey(tcsPath, slug), int64(next-1))
 }
 
+// nextSlugIndex returns the next index for a descriptive slug within
+// tcsPath. First call per (tcsPath, slug) seeds from the on-disk scan
+// (yaml.NextIndexForPrefix already returns "max existing + 1"); every
+// later call is a pure atomic increment, so deleting the files —
+// which auto-replay does to every executed test — can never rewind
+// the numbering. Mirrors nextTestIndex's contract for sequential names.
 func (ts *TestYaml) nextSlugIndex(tcsPath, slug string) (int, error) {
 	key := slugIndexKey(tcsPath, slug)
 	if v, ok := ts.slugIndex.Load(key); ok {

--- a/pkg/platform/yaml/testdb/db.go
+++ b/pkg/platform/yaml/testdb/db.go
@@ -171,8 +171,66 @@ func (ts *TestYaml) nextTestIndex(tcsPath string) (int, error) {
 // later call is a pure atomic increment, so deleting the files —
 // which auto-replay does to every executed test — can never rewind
 // the numbering. Mirrors nextTestIndex's contract for sequential names.
+// slugIndexKey is the single definition of the slugIndex map key. Minting,
+// seeding and the on-collision resync all go through it so the three can
+// never drift onto different keys for the same (directory, slug) pair — a
+// drift that would silently make a seed or a resync target nothing.
+func slugIndexKey(tcsPath, slug string) string {
+	return tcsPath + "\x00" + slug
+}
+
+// raiseSlugIndex lifts a slug's counter to at least idx. Raise-only by
+// construction: a counter already past idx is left alone, so no caller can
+// rewind numbering and re-mint a name that has been issued.
+func (ts *TestYaml) raiseSlugIndex(key string, idx int64) {
+	var fresh atomic.Int64
+	fresh.Store(idx)
+	actual, loaded := ts.slugIndex.LoadOrStore(key, &fresh)
+	if !loaded {
+		return
+	}
+	c := actual.(*atomic.Int64)
+	for {
+		cur := c.Load()
+		if cur >= idx || c.CompareAndSwap(cur, idx) {
+			return
+		}
+	}
+}
+
+// resyncSlugIndexFromDisk raises a slug's counter past every name currently
+// on disk, and is what keeps a FOREIGN write from costing more than one
+// retry.
+//
+// The pre-counter code re-scanned the directory on every mint, so it always
+// jumped straight past names it had not issued itself — a cloud-replay
+// download dropping hundreds of files into a live recorder's tests dir, or a
+// seed that came in lower than the directory's real contents. The counter
+// alone can only climb one EEXIST per claimName attempt, so a gap wider than
+// maxNameClaimAttempts would exhaust the loop and lose the capture. Resyncing
+// here restores the jump: the next mint lands past the whole gap.
+//
+// Best-effort: on a scan error the caller simply retries with the counter it
+// already has, which is exactly the pre-resync behaviour.
+func (ts *TestYaml) resyncSlugIndexFromDisk(tcsPath string, tc *models.TestCase) {
+	if tc == nil || ts.namingStrategy == NamingSequential {
+		return
+	}
+	slug := BuildTestCaseSlug(tc)
+	if slug == "" {
+		return
+	}
+	// NextIndexForPrefix returns the next FREE index, so the counter (which
+	// holds the last issued index) is raised to one below it.
+	next, err := yaml.NextIndexForPrefix(tcsPath, slug)
+	if err != nil || next < 1 {
+		return
+	}
+	ts.raiseSlugIndex(slugIndexKey(tcsPath, slug), int64(next-1))
+}
+
 func (ts *TestYaml) nextSlugIndex(tcsPath, slug string) (int, error) {
-	key := tcsPath + "\x00" + slug
+	key := slugIndexKey(tcsPath, slug)
 	if v, ok := ts.slugIndex.Load(key); ok {
 		return int(v.(*atomic.Int64).Add(1)), nil
 	}
@@ -209,19 +267,7 @@ func (ts *TestYaml) SeedSlugIndexes(testSetID string, maxBySlug map[string]int) 
 		if slug == "" || maxIdx < 1 {
 			continue
 		}
-		key := tcsPath + "\x00" + slug
-		var fresh atomic.Int64
-		fresh.Store(int64(maxIdx))
-		actual, loaded := ts.slugIndex.LoadOrStore(key, &fresh)
-		if loaded {
-			c := actual.(*atomic.Int64)
-			for {
-				cur := c.Load()
-				if cur >= int64(maxIdx) || c.CompareAndSwap(cur, int64(maxIdx)) {
-					break
-				}
-			}
-		}
+		ts.raiseSlugIndex(slugIndexKey(tcsPath, slug), int64(maxIdx))
 	}
 	return nil
 }
@@ -793,6 +839,11 @@ func (ts *TestYaml) claimName(tcsPath string, tc *models.TestCase) (string, erro
 		if !errors.Is(err, fs.ErrExist) {
 			return "", fmt.Errorf("reserve testcase file %q: %w", name, err)
 		}
+		// The name is taken by a file this counter never issued (a foreign
+		// writer, or a seed lower than the directory's contents). Jump the
+		// counter past the whole gap instead of climbing it one attempt at a
+		// time — see resyncSlugIndexFromDisk.
+		ts.resyncSlugIndexFromDisk(tcsPath, tc)
 	}
 	return "", fmt.Errorf("failed to allocate a unique testcase name after %d attempts (last candidate %q)", maxNameClaimAttempts, lastName)
 }

--- a/pkg/platform/yaml/testdb/db.go
+++ b/pkg/platform/yaml/testdb/db.go
@@ -247,31 +247,6 @@ func (ts *TestYaml) nextSlugIndex(tcsPath, slug string) (int, error) {
 	return seed, nil
 }
 
-// SeedSlugIndexes raises the descriptive-name counters for a test set to
-// at least the given per-slug indexes. A recorder that adopts an
-// in-flight test set (after a pod restart or redeploy) has an empty
-// local directory, and disk-seeded counters would restart numbering at
-// 1 — re-minting names the previous owner already used. The adopting
-// session calls this once with the per-slug maxima of the names already
-// persisted server-side, so minting continues where the previous owner
-// stopped. Raising only: a seed below the current counter is a no-op.
-func (ts *TestYaml) SeedSlugIndexes(testSetID string, maxBySlug map[string]int) error {
-	if err := validateNameComponent("testSetID", testSetID); err != nil {
-		return err
-	}
-	tcsPath, err := yaml.ValidatePath(filepath.Join(ts.TcsPath, testSetID, "tests"))
-	if err != nil {
-		return fmt.Errorf("validate testcase directory: %w", err)
-	}
-	for slug, maxIdx := range maxBySlug {
-		if slug == "" || maxIdx < 1 {
-			continue
-		}
-		ts.raiseSlugIndex(slugIndexKey(tcsPath, slug), int64(maxIdx))
-	}
-	return nil
-}
-
 type tcsInfo struct {
 	name string
 	path string

--- a/pkg/platform/yaml/testdb/db.go
+++ b/pkg/platform/yaml/testdb/db.go
@@ -53,6 +53,17 @@ type TestYaml struct {
 	// Only used by the sequential naming path; descriptive mode keys
 	// per-slug indices off NextIndexForPrefix instead.
 	lastIndex sync.Map // map[string]*atomic.Int64
+	// slugIndex is the descriptive-naming twin of lastIndex: one
+	// monotonically-increasing counter per (tests-dir, slug), so a test
+	// case name can never be re-minted after auto-replay deletes the
+	// executed files. Descriptive names used to be derived from a disk
+	// scan alone (NextIndexForPrefix), and a directory that deletion
+	// mutates is not a memory: the scan restarted numbering and aliased
+	// two different captures under one name — corrupting name-keyed
+	// mappings and verdicts, and collapsing same-named files on download.
+	// Keyed by tcsPath+"\x00"+slug; values are *atomic.Int64 holding the
+	// last index handed out.
+	slugIndex sync.Map
 }
 
 func New(logger *zap.Logger, tcsPath string) *TestYaml {
@@ -152,6 +163,67 @@ func (ts *TestYaml) nextTestIndex(tcsPath string) (int, error) {
 		return int(actual.(*atomic.Int64).Add(1)), nil
 	}
 	return seed, nil
+}
+
+// nextSlugIndex returns the next index for a descriptive slug within
+// tcsPath. First call per (tcsPath, slug) seeds from the on-disk scan
+// (yaml.NextIndexForPrefix already returns "max existing + 1"); every
+// later call is a pure atomic increment, so deleting the files —
+// which auto-replay does to every executed test — can never rewind
+// the numbering. Mirrors nextTestIndex's contract for sequential names.
+func (ts *TestYaml) nextSlugIndex(tcsPath, slug string) (int, error) {
+	key := tcsPath + "\x00" + slug
+	if v, ok := ts.slugIndex.Load(key); ok {
+		return int(v.(*atomic.Int64).Add(1)), nil
+	}
+	seed, err := yaml.NextIndexForPrefix(tcsPath, slug)
+	if err != nil {
+		return 0, err
+	}
+	var counter atomic.Int64
+	counter.Store(int64(seed))
+	actual, loaded := ts.slugIndex.LoadOrStore(key, &counter)
+	if loaded {
+		return int(actual.(*atomic.Int64).Add(1)), nil
+	}
+	return seed, nil
+}
+
+// SeedSlugIndexes raises the descriptive-name counters for a test set to
+// at least the given per-slug indexes. A recorder that adopts an
+// in-flight test set (after a pod restart or redeploy) has an empty
+// local directory, and disk-seeded counters would restart numbering at
+// 1 — re-minting names the previous owner already used. The adopting
+// session calls this once with the per-slug maxima of the names already
+// persisted server-side, so minting continues where the previous owner
+// stopped. Raising only: a seed below the current counter is a no-op.
+func (ts *TestYaml) SeedSlugIndexes(testSetID string, maxBySlug map[string]int) error {
+	if err := validateNameComponent("testSetID", testSetID); err != nil {
+		return err
+	}
+	tcsPath, err := yaml.ValidatePath(filepath.Join(ts.TcsPath, testSetID, "tests"))
+	if err != nil {
+		return fmt.Errorf("validate testcase directory: %w", err)
+	}
+	for slug, maxIdx := range maxBySlug {
+		if slug == "" || maxIdx < 1 {
+			continue
+		}
+		key := tcsPath + "\x00" + slug
+		var fresh atomic.Int64
+		fresh.Store(int64(maxIdx))
+		actual, loaded := ts.slugIndex.LoadOrStore(key, &fresh)
+		if loaded {
+			c := actual.(*atomic.Int64)
+			for {
+				cur := c.Load()
+				if cur >= int64(maxIdx) || c.CompareAndSwap(cur, int64(maxIdx)) {
+					break
+				}
+			}
+		}
+	}
+	return nil
 }
 
 type tcsInfo struct {
@@ -651,7 +723,7 @@ func (ts *TestYaml) generateName(tcsPath string, tc *models.TestCase) (string, e
 	}
 
 	slug := BuildTestCaseSlug(tc)
-	idx, err := yaml.NextIndexForPrefix(tcsPath, slug)
+	idx, err := ts.nextSlugIndex(tcsPath, slug)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/platform/yaml/testdb/naming_test.go
+++ b/pkg/platform/yaml/testdb/naming_test.go
@@ -3,6 +3,7 @@ package testdb
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -630,3 +631,88 @@ func TestDescriptiveNamesConcurrentMintsUnique(t *testing.T) {
 		t.Fatalf("minted %d unique names, want %d", len(seen), n)
 	}
 }
+
+// A FOREIGN writer (a cloud-replay download, a low seed) can drop names into
+// the tests dir that this recorder's counter never issued. The counter climbs
+// one EEXIST per claimName attempt, so without a disk resync a gap wider than
+// maxNameClaimAttempts exhausts the retry loop and the capture is lost with an
+// error — a regression against the pre-counter code, which re-scanned on every
+// mint and so always jumped straight past the gap.
+func TestClaimName_ForeignWriteGapBeyondRetryBound(t *testing.T) {
+	for _, gap := range []int{10, 255, 300, 1000} {
+		dir := t.TempDir()
+		ts := NewWithNaming(zap.NewNop(), "", NamingDescriptive)
+		tc := httpTC("POST", "http://api.test/pay")
+
+		// Take one name so the counter exists and is low (mints post-pay-1).
+		first, err := ts.claimName(dir, tc)
+		if err != nil {
+			t.Fatalf("gap=%d: first claim: %v", gap, err)
+		}
+		if first != "post-pay-1" {
+			t.Fatalf("gap=%d: first = %q, want post-pay-1", gap, first)
+		}
+
+		// Foreign writer fills post-pay-2 .. post-pay-(gap+1) behind the
+		// counter's back.
+		for i := 2; i <= gap+1; i++ {
+			p := filepath.Join(dir, "post-pay-"+itoa(i)+"."+ts.Format.FileExtension())
+			if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+				t.Fatalf("gap=%d: seed file: %v", gap, err)
+			}
+		}
+
+		got, err := ts.claimName(dir, tc)
+		if err != nil {
+			t.Fatalf("gap=%d: claim after foreign writes failed (the regression): %v", gap, err)
+		}
+		want := "post-pay-" + itoa(gap+2)
+		if got != want {
+			t.Fatalf("gap=%d: got %q, want %q (must jump past the whole gap)", gap, got, want)
+		}
+
+		// And the counter must keep climbing from there, not rescan-and-stall.
+		next, err := ts.claimName(dir, tc)
+		if err != nil {
+			t.Fatalf("gap=%d: follow-up claim: %v", gap, err)
+		}
+		if next != "post-pay-"+itoa(gap+3) {
+			t.Fatalf("gap=%d: follow-up = %q, want post-pay-%d", gap, next, gap+3)
+		}
+	}
+}
+
+// A seed that lands BELOW the directory's real contents must not strand the
+// counter: the first collision resyncs it past what is on disk.
+func TestSeedSlugIndexes_LowSeedRecoversViaResync(t *testing.T) {
+	parent := t.TempDir()
+	setID := "test-set-0"
+	dir := filepath.Join(parent, setID, "tests")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ts := NewWithNaming(zap.NewNop(), parent, NamingDescriptive)
+	tc := httpTC("POST", "http://api.test/pay")
+
+	// Directory already holds 1..400 (e.g. a downloaded set).
+	for i := 1; i <= 400; i++ {
+		p := filepath.Join(dir, "post-pay-"+itoa(i)+"."+ts.Format.FileExtension())
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Seed far too low (server knew only about 5).
+	if err := ts.SeedSlugIndexes(setID, map[string]int{"post-pay": 5}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ts.claimName(dir, tc)
+	if err != nil {
+		t.Fatalf("claim with a low seed over a full directory failed: %v", err)
+	}
+	if got != "post-pay-401" {
+		t.Fatalf("got %q, want post-pay-401", got)
+	}
+}
+
+func itoa(i int) string { return strconv.Itoa(i) }

--- a/pkg/platform/yaml/testdb/naming_test.go
+++ b/pkg/platform/yaml/testdb/naming_test.go
@@ -568,37 +568,6 @@ func TestDescriptiveNamesSeedFromExistingFiles(t *testing.T) {
 	}
 }
 
-// A recorder adopting an in-flight test set has an EMPTY directory; seeding
-// from the server-side maxima must prevent the takeover from re-minting the
-// previous owner's names.
-func TestSeedSlugIndexesProtectsTakeover(t *testing.T) {
-	root := t.TempDir()
-	ts := NewWithFormatAndNaming(zap.NewNop(), root, yamlLib.FormatYAML, NamingDescriptive)
-	if err := ts.SeedSlugIndexes("set-1", map[string]int{"post-pay": 41, "get-users": 7}); err != nil {
-		t.Fatal(err)
-	}
-	dir := filepath.Join(root, "set-1", "tests")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	tc := &models.TestCase{Kind: models.HTTP, HTTPReq: models.HTTPReq{Method: "POST", URL: "http://app:8080/pay"}}
-	n, err := ts.generateName(dir, tc)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if n != "post-pay-42" {
-		t.Fatalf("got %s, want post-pay-42 (seeded from server max 41 despite empty dir)", n)
-	}
-	// Seeding lower than the live counter is a no-op.
-	if err := ts.SeedSlugIndexes("set-1", map[string]int{"post-pay": 3}); err != nil {
-		t.Fatal(err)
-	}
-	n2, _ := ts.generateName(dir, tc)
-	if n2 != "post-pay-43" {
-		t.Fatalf("got %s, want post-pay-43 (lower seed must not rewind)", n2)
-	}
-}
-
 // Concurrent mints for the same slug must produce unique names.
 func TestDescriptiveNamesConcurrentMintsUnique(t *testing.T) {
 	dir := t.TempDir()
@@ -679,39 +648,6 @@ func TestClaimName_ForeignWriteGapBeyondRetryBound(t *testing.T) {
 		if next != "post-pay-"+itoa(gap+3) {
 			t.Fatalf("gap=%d: follow-up = %q, want post-pay-%d", gap, next, gap+3)
 		}
-	}
-}
-
-// A seed that lands BELOW the directory's real contents must not strand the
-// counter: the first collision resyncs it past what is on disk.
-func TestSeedSlugIndexes_LowSeedRecoversViaResync(t *testing.T) {
-	parent := t.TempDir()
-	setID := "test-set-0"
-	dir := filepath.Join(parent, setID, "tests")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	ts := NewWithNaming(zap.NewNop(), parent, NamingDescriptive)
-	tc := httpTC("POST", "http://api.test/pay")
-
-	// Directory already holds 1..400 (e.g. a downloaded set).
-	for i := 1; i <= 400; i++ {
-		p := filepath.Join(dir, "post-pay-"+itoa(i)+"."+ts.Format.FileExtension())
-		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
-			t.Fatal(err)
-		}
-	}
-	// Seed far too low (server knew only about 5).
-	if err := ts.SeedSlugIndexes(setID, map[string]int{"post-pay": 5}); err != nil {
-		t.Fatal(err)
-	}
-
-	got, err := ts.claimName(dir, tc)
-	if err != nil {
-		t.Fatalf("claim with a low seed over a full directory failed: %v", err)
-	}
-	if got != "post-pay-401" {
-		t.Fatalf("got %q, want post-pay-401", got)
 	}
 }
 

--- a/pkg/platform/yaml/testdb/naming_test.go
+++ b/pkg/platform/yaml/testdb/naming_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"go.keploy.io/server/v3/pkg/models"
+	yamlLib "go.keploy.io/server/v3/pkg/platform/yaml"
 	"go.uber.org/zap"
 )
 
@@ -503,5 +504,129 @@ func TestIsIDSegment(t *testing.T) {
 		if isIDSegment(s) {
 			t.Errorf("expected %q NOT to be an id segment", s)
 		}
+	}
+}
+
+// The production defect this pins: descriptive names were minted from a disk
+// scan alone, and auto-replay deletes every executed test's file — so a later
+// capture of the same endpoint re-minted an earlier name, aliasing two
+// different requests under one identity (corrupted name-keyed mappings and
+// verdicts; same-named files collapsing on download). Numbering must be
+// monotonic per (test set, slug) regardless of what happens to the files.
+func TestDescriptiveNamesNeverReuseAfterFileDeletion(t *testing.T) {
+	dir := t.TempDir()
+	ts := NewWithFormatAndNaming(zap.NewNop(), dir, yamlLib.FormatYAML, NamingDescriptive)
+	tc := &models.TestCase{Kind: models.HTTP, HTTPReq: models.HTTPReq{Method: "GET", URL: "http://app:8080/k8s-proxy/mappings"}}
+
+	n1, err := ts.generateName(dir, tc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, n1+".yaml"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	n2, err := ts.generateName(dir, tc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Auto-replay deletes executed test files.
+	if err := os.Remove(filepath.Join(dir, n1+".yaml")); err != nil {
+		t.Fatal(err)
+	}
+
+	n3, err := ts.generateName(dir, tc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n1 == n3 || n2 == n3 {
+		t.Fatalf("name re-minted after deletion: %s, %s, %s", n1, n2, n3)
+	}
+	if n1 != "get-k8s-proxy-mappings-1" || n2 != "get-k8s-proxy-mappings-2" || n3 != "get-k8s-proxy-mappings-3" {
+		t.Fatalf("unexpected sequence: %s, %s, %s", n1, n2, n3)
+	}
+}
+
+// First mint on a directory that already holds files continues from the disk
+// maximum — the counter seeds from the scan, it does not fight it.
+func TestDescriptiveNamesSeedFromExistingFiles(t *testing.T) {
+	dir := t.TempDir()
+	ts := NewWithFormatAndNaming(zap.NewNop(), dir, yamlLib.FormatYAML, NamingDescriptive)
+	for _, n := range []string{"post-pay-1.yaml", "post-pay-7.yaml"} {
+		if err := os.WriteFile(filepath.Join(dir, n), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	tc := &models.TestCase{Kind: models.HTTP, HTTPReq: models.HTTPReq{Method: "POST", URL: "http://app:8080/pay"}}
+	n, err := ts.generateName(dir, tc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != "post-pay-8" {
+		t.Fatalf("got %s, want post-pay-8 (continue from disk max)", n)
+	}
+}
+
+// A recorder adopting an in-flight test set has an EMPTY directory; seeding
+// from the server-side maxima must prevent the takeover from re-minting the
+// previous owner's names.
+func TestSeedSlugIndexesProtectsTakeover(t *testing.T) {
+	root := t.TempDir()
+	ts := NewWithFormatAndNaming(zap.NewNop(), root, yamlLib.FormatYAML, NamingDescriptive)
+	if err := ts.SeedSlugIndexes("set-1", map[string]int{"post-pay": 41, "get-users": 7}); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(root, "set-1", "tests")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	tc := &models.TestCase{Kind: models.HTTP, HTTPReq: models.HTTPReq{Method: "POST", URL: "http://app:8080/pay"}}
+	n, err := ts.generateName(dir, tc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != "post-pay-42" {
+		t.Fatalf("got %s, want post-pay-42 (seeded from server max 41 despite empty dir)", n)
+	}
+	// Seeding lower than the live counter is a no-op.
+	if err := ts.SeedSlugIndexes("set-1", map[string]int{"post-pay": 3}); err != nil {
+		t.Fatal(err)
+	}
+	n2, _ := ts.generateName(dir, tc)
+	if n2 != "post-pay-43" {
+		t.Fatalf("got %s, want post-pay-43 (lower seed must not rewind)", n2)
+	}
+}
+
+// Concurrent mints for the same slug must produce unique names.
+func TestDescriptiveNamesConcurrentMintsUnique(t *testing.T) {
+	dir := t.TempDir()
+	ts := NewWithFormatAndNaming(zap.NewNop(), dir, yamlLib.FormatYAML, NamingDescriptive)
+	tc := &models.TestCase{Kind: models.HTTP, HTTPReq: models.HTTPReq{Method: "GET", URL: "http://app:8080/users"}}
+
+	const n = 32
+	names := make(chan string, n)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			name, err := ts.generateName(dir, tc)
+			if err == nil {
+				names <- name
+			}
+		}()
+	}
+	wg.Wait()
+	close(names)
+	seen := map[string]bool{}
+	for name := range names {
+		if seen[name] {
+			t.Fatalf("duplicate name minted concurrently: %s", name)
+		}
+		seen[name] = true
+	}
+	if len(seen) != n {
+		t.Fatalf("minted %d unique names, want %d", len(seen), n)
 	}
 }


### PR DESCRIPTION
## The bug (replicated deterministically, measured in production)

Descriptive test-case names are numbered by **scanning the tests directory** (`NextIndexForPrefix`: max existing + 1, empty dir → 1). Auto-replay **deletes every executed test's file** after its cycle. So a later capture of the same endpoint re-mints an earlier capture's name:

```
capture 1..5 of POST /pay  → post-pay-1..5 on disk
auto-replay executes them  → files deleted
capture 6 of POST /pay     → scan finds nothing → post-pay-1 AGAIN
```

Deterministic repro is in the new test (`-1`, then `-2` with the file present, then `-1` again after deletion). Measured consequences on a production corpus: duplicate names served for one test set (`post-usage-metrics-1` × 4), the server keeping both rows per name (the unique `(test_set_id, data.name)` index was removed in api-server#1754 after these very duplicates prevented it from building), name-keyed mappings merging mocks from different captures, verdicts flipping between captures — and on cloud-replay download, same-named files overwriting each other: **89 of 454 fetched cases silently destroyed in one run**, matching the served-vs-distinct-names difference exactly, per set (30→23, 74→64, 50→38, 38→33, 36→28, 95→76…).

Sequential `test-N` naming never had this defect — it runs on the in-memory monotonic `lastIndex` counter. The descriptive path explicitly opted out of it (see the `lastIndex` doc comment) and trusted a directory that deletion mutates.

## The fix

**Per-(tests-dir, slug) monotonic counters**, exactly mirroring `nextTestIndex`: first mint seeds from the disk scan, every later mint is an atomic increment — file deletion can never rewind numbering.

A foreign writer filling names behind the counter (a downloaded set, a concurrent writer) is handled by resyncing the counter from disk on collision, so such a gap costs one retry rather than exhausting `maxNameClaimAttempts`.

No migration: existing duplicate rows age out through the normal obsoletion flow. Once fleets record unique names, the unique index can return as the backstop it was meant to be.

## Verification

- New tests: no reuse after deletion (the exact defect, sequence asserted); seeding from existing files continues at disk max; 32 concurrent mints all unique; foreign-write gaps of 10/255/300/1000 recover in one retry instead of failing at the 256-attempt bound.
- Full `pkg/platform/yaml/...` suites green under `-race`; vet/gofmt clean.

## Scope — paths this deliberately does not cover

The counter serializes minting **within one recorder process**, which is where the bug lives (auto-replay deletes the local files; a per-mint directory scan then restarts at 1). Situations it cannot serialize, stated so the fix is not read as broader than it is:

- **Test-set takeover in DaemonSet mode.** A recorder adopting an in-flight test set begins with an empty local directory, so numbering restarts. This needs the per-slug maxima the server already holds, which only the k8s-proxy can supply; keploy/k8s-proxy#838 is closed, so it is **not covered here**. An earlier revision of this PR carried an exported `SeedSlugIndexes` hook for that caller — it has been removed rather than left as an exported method with no caller in OSS. **Sidecar mode is unaffected**: a recording start always recreates the app pods, and the test-set name is derived from the pod, so the adopting recorder gets a brand-new set rather than inheriting one.
- **Concurrent recorders using different `ts.Format`** against the same tests dir — the reservation extension follows the format, so `O_EXCL` never collides between them (`claimName` documents this).
- **Concurrent replicas on separate volumes** — nothing in a process-local counter can coordinate across them.
