### PR TITLE
fix(agent): mapping-selected mocks are authoritative — window containment must not re-drop them

### DIFF
--- a/pkg/agent/proxy/mockmanager.go
+++ b/pkg/agent/proxy/mockmanager.go
@@ -93,6 +93,18 @@ type MockManager struct {
 	windowMu    sync.RWMutex
 	windowStart time.Time
 	windowEnd   time.Time
+	// mappingAuthoritative marks the current per-test pool as selected by a
+	// recorded test→mock MAPPING rather than by timestamps. A mapping is the
+	// authoritative record of which mocks THIS test consumed, so window
+	// containment must not re-drop its mocks: test req/res stamps come from
+	// the ingress path while mock stamps come from the egress proxy path
+	// (ordering is not guaranteed at millisecond scale), and post-replay
+	// write-backs can re-stamp test timestamps entirely — either way a
+	// timestamp disagreement on a mapped mock is noise, not bleed. Set by
+	// SetMappedMocksWithWindow, cleared by SetMocksWithWindow /
+	// SetCurrentTestWindow; guarded by windowMu alongside the window it
+	// qualifies.
+	mappingAuthoritative bool
 
 	// firstWindowStart caches the earliest windowStart observed across
 	// all SetMocksWithWindow calls for this manager's lifetime. It's
@@ -494,6 +506,7 @@ func (m *MockManager) SetCurrentTestWindow(start, end time.Time) {
 	m.windowMu.Lock()
 	m.windowStart = start
 	m.windowEnd = end
+	m.mappingAuthoritative = false
 	m.windowMu.Unlock()
 	atomic.StoreUint64(&m.droppedOutOfWindow, 0)
 }
@@ -560,6 +573,7 @@ func (m *MockManager) GetFilteredMocksInWindow() ([]*models.Mock, error) {
 	m.treesMu.RUnlock()
 	m.windowMu.RLock()
 	start, end := m.windowStart, m.windowEnd
+	mappingAuthoritative := m.mappingAuthoritative
 	m.windowMu.RUnlock()
 	m.swapMu.RUnlock()
 
@@ -572,6 +586,13 @@ func (m *MockManager) GetFilteredMocksInWindow() ([]*models.Mock, error) {
 	})
 
 	if start.IsZero() || end.IsZero() {
+		return all, nil
+	}
+	// A mapping-authoritative pool was selected by the recorded test→mock
+	// mapping, not by timestamps; the set-time pre-filter already kept its
+	// out-of-window mocks, so re-enforcing containment here would drop them
+	// at match time. Serve the tree as-is.
+	if mappingAuthoritative {
 		return all, nil
 	}
 	out := make([]*models.Mock, 0, len(all))
@@ -659,6 +680,21 @@ func (m *MockManager) DroppedOutOfWindow() uint64 {
 //
 // Also resets the per-test droppedOutOfWindow counter.
 func (m *MockManager) SetMocksWithWindow(filtered, unfiltered []*models.Mock, start, end time.Time) {
+	m.setMocksWithWindow(filtered, unfiltered, start, end, false)
+}
+
+// SetMappedMocksWithWindow is SetMocksWithWindow for a per-test pool selected
+// by a recorded test→mock mapping. The mapping already IS the per-test
+// selection, so window containment keeps every mapped mock instead of
+// dropping the ones whose request timestamp strays outside [start, end]
+// (ingress/egress stamp skew, or test timestamps re-stamped by post-replay
+// write-backs). Everything else — window publication, startup routing for
+// pre-first-test mocks, invalid-order sanity drop — behaves identically.
+func (m *MockManager) SetMappedMocksWithWindow(filtered, unfiltered []*models.Mock, start, end time.Time) {
+	m.setMocksWithWindow(filtered, unfiltered, start, end, true)
+}
+
+func (m *MockManager) setMocksWithWindow(filtered, unfiltered []*models.Mock, start, end time.Time, mappingAuthoritative bool) {
 	m.swapMu.Lock()
 	defer m.swapMu.Unlock()
 
@@ -792,6 +828,13 @@ func (m *MockManager) SetMocksWithWindow(filtered, unfiltered []*models.Mock, st
 			// may legitimately straggle past `end` (async downstream
 			// completion is normal).
 			if !req.Before(start) && !req.After(end) {
+				out = append(out, mock)
+				continue
+			}
+			// Mapping-authoritative pools keep out-of-window mocks in the
+			// per-test tree: the mapping recorded that THIS test consumed
+			// them, which outranks a timestamp disagreement.
+			if mappingAuthoritative {
 				out = append(out, mock)
 				continue
 			}
@@ -932,6 +975,7 @@ func (m *MockManager) SetMocksWithWindow(filtered, unfiltered []*models.Mock, st
 		m.windowMu.Lock()
 		m.windowStart = start
 		m.windowEnd = end
+		m.mappingAuthoritative = mappingAuthoritative
 		m.windowMu.Unlock()
 	}
 	// Counter reflects pre-filtering drops for THIS test; legacy

--- a/pkg/agent/proxy/mockmanager_mapped_window_test.go
+++ b/pkg/agent/proxy/mockmanager_mapped_window_test.go
@@ -1,0 +1,142 @@
+// Package proxy — mapping-authoritative window tests.
+//
+// A per-test pool selected via the recorded test→mock MAPPING must not be
+// re-dropped by window containment: test req/res stamps come from the
+// ingress path while mock stamps come from the egress proxy path (ordering
+// is not guaranteed at millisecond scale), and post-replay write-backs can
+// re-stamp test timestamps entirely. The mapping is the authoritative record
+// of what THIS test consumed.
+package proxy
+
+import (
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// TestMockManager_MappedWindow_KeepsOutOfWindowMocks: with
+// SetMappedMocksWithWindow, mocks whose request timestamps fall entirely
+// outside [start, end] (the re-stamped-test shape: window hours away from
+// the mocks) stay servable at match time. The plain SetMocksWithWindow on
+// the same input drops them — the red/green pair for the bug this guards.
+func TestMockManager_MappedWindow_KeepsOutOfWindowMocks(t *testing.T) {
+	recorded := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	windowStart := recorded.Add(2 * time.Hour)
+	windowEnd := windowStart.Add(10 * time.Second)
+
+	mocks := []*models.Mock{
+		newMockForTest("mapped-1", recorded, models.LifetimePerTest),
+		newMockForTest("mapped-2", recorded.Add(time.Millisecond), models.LifetimePerTest),
+	}
+
+	red := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+	defer red.Close()
+	red.SetMocksWithWindow(mocks, nil, windowStart, windowEnd)
+	got, err := red.GetFilteredMocksInWindow()
+	if err != nil {
+		t.Fatalf("red GetFilteredMocksInWindow: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("plain window path kept %d out-of-window mocks; expected 0 (drop)", len(got))
+	}
+
+	green := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+	defer green.Close()
+	green.SetMappedMocksWithWindow(mocks, nil, windowStart, windowEnd)
+	got, err = green.GetFilteredMocksInWindow()
+	if err != nil {
+		t.Fatalf("green GetFilteredMocksInWindow: %v", err)
+	}
+	if len(got) != 2 || !containsMockNamed(got, "mapped-1") || !containsMockNamed(got, "mapped-2") {
+		t.Fatalf("mapped window path served %d mocks (%v); expected both mapped mocks", len(got), mockNamesOf(got))
+	}
+	if !green.IsTestWindowActive() {
+		t.Fatal("mapped set must still publish the test window (tier routing depends on it)")
+	}
+}
+
+// TestMockManager_MappedWindow_BoundarySkewKept: the ±1ms ingress/egress
+// skew shape — a mapped mock 1ms before windowStart is kept.
+func TestMockManager_MappedWindow_BoundarySkewKept(t *testing.T) {
+	windowStart := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	windowEnd := windowStart.Add(10 * time.Second)
+
+	mm := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+	defer mm.Close()
+	mm.SetMappedMocksWithWindow([]*models.Mock{
+		newMockForTest("skewed", windowStart.Add(-time.Millisecond), models.LifetimePerTest),
+		newMockForTest("inside", windowStart.Add(time.Second), models.LifetimePerTest),
+	}, nil, windowStart, windowEnd)
+
+	got, err := mm.GetFilteredMocksInWindow()
+	if err != nil {
+		t.Fatalf("GetFilteredMocksInWindow: %v", err)
+	}
+	if len(got) != 2 || !containsMockNamed(got, "skewed") {
+		t.Fatalf("boundary-skewed mapped mock dropped; served %v", mockNamesOf(got))
+	}
+}
+
+// TestMockManager_MappedWindow_InvalidOrderStillDropped: the res<req sanity
+// drop is about corrupt recordings, not window semantics — it stays.
+func TestMockManager_MappedWindow_InvalidOrderStillDropped(t *testing.T) {
+	windowStart := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	windowEnd := windowStart.Add(10 * time.Second)
+
+	bad := newMockForTest("invalid-order", windowStart.Add(time.Second), models.LifetimePerTest)
+	bad.Spec.ResTimestampMock = bad.Spec.ReqTimestampMock.Add(-time.Second)
+
+	mm := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+	defer mm.Close()
+	mm.SetMappedMocksWithWindow([]*models.Mock{bad}, nil, windowStart, windowEnd)
+
+	got, err := mm.GetFilteredMocksInWindow()
+	if err != nil {
+		t.Fatalf("GetFilteredMocksInWindow: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("invalid-order mock must still be dropped on the mapped path; served %v", mockNamesOf(got))
+	}
+}
+
+// TestMockManager_MappedWindow_ClearedByPlainSet: a later timestamp-selected
+// test on the same manager gets strict containment back.
+func TestMockManager_MappedWindow_ClearedByPlainSet(t *testing.T) {
+	recorded := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	windowStart := recorded.Add(2 * time.Hour)
+	windowEnd := windowStart.Add(10 * time.Second)
+
+	mm := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+	defer mm.Close()
+
+	mm.SetMappedMocksWithWindow([]*models.Mock{newMockForTest("mapped", recorded, models.LifetimePerTest)}, nil, windowStart, windowEnd)
+	if got, _ := mm.GetFilteredMocksInWindow(); len(got) != 1 {
+		t.Fatalf("mapped set: expected 1 servable mock, got %d", len(got))
+	}
+
+	// Next test: plain (timestamp-selected) set on the same manager. Note
+	// the same window start feeds firstWindowStart, so use a start AFTER
+	// the recorded stamp to make the out-of-window mock a genuine
+	// stale-bleed candidate rather than startup-init.
+	mm.SetMocksWithWindow([]*models.Mock{newMockForTest("stale", windowStart.Add(-time.Hour), models.LifetimePerTest)}, nil, windowStart, windowEnd)
+	if got, _ := mm.GetFilteredMocksInWindow(); len(got) != 0 {
+		t.Fatalf("plain set after mapped set must restore strict containment; served %d", len(got))
+	}
+
+	mm.SetCurrentTestWindow(windowStart, windowEnd)
+	if got, _ := mm.GetFilteredMocksInWindow(); len(got) != 0 {
+		t.Fatalf("SetCurrentTestWindow must clear mapping-authoritative mode; served %d", len(got))
+	}
+}
+
+func mockNamesOf(list []*models.Mock) []string {
+	out := make([]string, 0, len(list))
+	for _, m := range list {
+		if m != nil {
+			out = append(out, m.Name)
+		}
+	}
+	return out
+}

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -3299,6 +3299,23 @@ func (p *Proxy) SetMocksWithWindow(_ context.Context, filtered, unFiltered []*mo
 	return nil
 }
 
+// SetMappedMocksWithWindow is SetMocksWithWindow for a per-test pool the
+// agent selected via the recorded test→mock mapping: the window is still
+// published (tier routing, startup classification), but window containment
+// never drops a mapped mock — the mapping outranks timestamp skew. Satisfies
+// the agent's optional MappedWindowedProxy extension interface.
+func (p *Proxy) SetMappedMocksWithWindow(_ context.Context, filtered, unFiltered []*models.Mock, start, end time.Time) error {
+	p.deriveMysqlPorts(filtered, unFiltered)
+	if m := p.getMockManager(); m != nil {
+		m.SetMappedMocksWithWindow(filtered, unFiltered, start, end)
+		p.dnsCache.Purge()
+	}
+	if p.asyncEngine != nil {
+		p.asyncEngine.AdvanceWindow()
+	}
+	return nil
+}
+
 // FirstTestWindowStart returns the earliest test window start observed
 // by the underlying MockManager, or zero before any non-BaseTime
 // SetMocksWithWindow has landed. Satisfies the agent's optional

--- a/pkg/agent/service.go
+++ b/pkg/agent/service.go
@@ -116,6 +116,20 @@ type WindowedProxy interface {
 	SetMocksWithWindow(ctx context.Context, filtered, unFiltered []*models.Mock, start, end time.Time) error
 }
 
+// MappedWindowedProxy is the optional extension for per-test pools selected
+// via a recorded test→mock MAPPING. The mapping is the authoritative record
+// of which mocks the test consumed, so the proxy publishes the window as
+// usual (tier routing, startup classification) but window containment never
+// drops a mapped mock: test req/res stamps come from the ingress path while
+// mock stamps come from the egress path (ordering is not guaranteed at
+// millisecond scale), and post-replay write-backs can re-stamp test
+// timestamps — a timestamp disagreement on a mapped mock is noise, not
+// cross-test bleed. Callers MUST type-assert from Proxy and fall back to
+// WindowedProxy (then SetMocks) when the assertion fails.
+type MappedWindowedProxy interface {
+	SetMappedMocksWithWindow(ctx context.Context, filtered, unFiltered []*models.Mock, start, end time.Time) error
+}
+
 // AsyncMockLoader is an optional Proxy capability. The agent hands the proxy
 // the COMPLETE async-mock corpus exactly once (at mock-store time) so the
 // async engine can build its per-lane ordered streams. Proxies without async

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -1142,7 +1142,19 @@ func (a *Agent) UpdateMockParams(ctx context.Context, params models.MockFilterPa
 	// supports the WindowedProxy extension. Otherwise fall back to the
 	// stable SetMocks contract — third-party proxies without window
 	// support keep working in legacy lax mode.
-	if wp, ok := a.Proxy.(coreAgent.WindowedProxy); ok {
+	//
+	// Mapping-based selection prefers the MappedWindowedProxy extension:
+	// the mapping already IS this test's mock selection, so the proxy must
+	// not re-drop mapped mocks on window containment (ingress vs egress
+	// timestamp skew, or re-stamped test timestamps would otherwise empty
+	// the pool a passing recording proved complete).
+	mappingBased := params.UseMappingBased && len(params.MockMapping) > 0
+	if mwp, ok := a.Proxy.(coreAgent.MappedWindowedProxy); ok && mappingBased {
+		if err := mwp.SetMappedMocksWithWindow(ctx, filteredMocks, unfilteredMocks, params.AfterTime, params.BeforeTime); err != nil {
+			utils.LogError(a.logger, err, "failed to set mapped mocks and test window on proxy; verify the proxy implements MappedWindowedProxy and the agent/proxy versions are in sync, or retry via the plain SetMocks fallback path")
+			return err
+		}
+	} else if wp, ok := a.Proxy.(coreAgent.WindowedProxy); ok {
 		if err := wp.SetMocksWithWindow(ctx, filteredMocks, unfilteredMocks, params.AfterTime, params.BeforeTime); err != nil {
 			utils.LogError(a.logger, err, "failed to set mocks and test window on proxy; verify the proxy implements WindowedProxy and the agent/proxy versions are in sync, or retry via the plain SetMocks fallback path")
 			return err


### PR DESCRIPTION
## The bug

When a test's mocks are selected via the recorded **test→mock mapping** (`UseMappingBased` + `MockMapping`), the agent still hands them to `SetMocksWithWindow`, and both the set-time pre-filter and the match-time filter in `GetFilteredMocksInWindow` re-drop any mock whose request timestamp falls outside the outer test's `[req, res]` window. Mapped mocks lose that comparison two independent ways:

1. **Ingress/egress stamp skew**: the test's req/res are stamped on the ingress path, the mock's on the egress proxy path — ordering is not guaranteed at millisecond scale, so a mapped mock can sit ±1ms outside its own test's window.
2. **Re-stamped test timestamps**: post-replay write-backs rewrite a test's timestamps to the current simulation's time, after which the window is hours away from the recorded mocks and contains ZERO of the test's own mapped mocks (observed in cloud replay: `window filter summary … dropped_out_of_window: 3, kept_total: 0` on tests whose mapping listed exactly those three mocks) — every dependency call then misses and the test fails with `no_mocks` forever.

The mapping is the authoritative record of which mocks THIS test consumed. Timestamps are how mappings get **formed**; they must not decide how mapped mocks get **served**.

## The fix

New optional proxy extension `MappedWindowedProxy.SetMappedMocksWithWindow` (same additive pattern as `WindowedProxy` itself — third-party proxies fall back unchanged). The agent uses it for mapping-based selection. Semantics:

- The window is still **published** (tier routing via `IsTestWindowActive`, startup-init classification, `firstWindowStart` tracking — all unchanged).
- Window containment keeps every mapped mock — at set time (pre-filter) and at match time.
- The `res < req` invalid-order sanity drop stays (corrupt-recording guard, not window semantics).
- Plain `SetMocksWithWindow` / `SetCurrentTestWindow` clear the mode, so timestamp-selected tests on the same manager keep strict containment.

## Validation

**Live red→green in a kind cluster** (k8s-proxy full-set replay of a recorded set, real app + real mongo, patched enterprise agent built from this branch):
- Recorded a set, let auto-replay form mappings, then re-stamped one test's server-side timestamps 3h away from its mocks (the exact write-back corruption shape).
- **Red** (stock agent v3.7.24): that test **fails**; every sibling passes.
- **Green** (agent with this fix): same data, same replay — that test **passes**; all siblings' results unchanged.

**Unit** (`mockmanager_mapped_window_test.go`): out-of-window mapped mocks kept and servable (plain path drops them — the red/green pair), ±1ms boundary skew kept, invalid-order still dropped, mode cleared by the next plain set / `SetCurrentTestWindow`.

Full `pkg/agent/proxy` + `pkg/service/agent` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)