### PR TITLE
fix(mock): drain trailing mocks before tearing the capture stream down

### DIFF
--- a/pkg/platform/http/agent.go
+++ b/pkg/platform/http/agent.go
@@ -254,6 +254,16 @@ func (a *AgentClient) GetIncoming(ctx context.Context, opts models.IncomingOptio
 	return tcChan, nil
 }
 
+// mockHandoffBuffer sizes the decoder -> consumer hand-off. Deep enough that a
+// slow InsertMock cannot park the decoder behind a mock it has already read off
+// the wire.
+const mockHandoffBuffer = 1024
+
+// mockHandoffGrace bounds how long the decoder waits for the consumer to take a
+// mock before giving up on it. Only reachable if the consumer has stopped
+// draining entirely; a busy one drains in milliseconds.
+const mockHandoffGrace = 30 * time.Second
+
 func (a *AgentClient) GetOutgoing(ctx context.Context, opts models.OutgoingOptions) (<-chan *models.Mock, error) {
 
 	a.logger.Debug("Connecting to outgoing mocks stream...")
@@ -281,7 +291,12 @@ func (a *AgentClient) GetOutgoing(ctx context.Context, opts models.OutgoingOptio
 		return nil, fmt.Errorf("failed to get outgoing response: %s", err.Error())
 	}
 
-	mockChan := make(chan *models.Mock)
+	// Buffered. An unbuffered channel parks the decoder for as long as the
+	// consumer spends inside InsertMock - and the first insert does mkdir +
+	// create + YAML encode + flush, which is exactly when the last mock of a
+	// recording arrives. A decoded mock waiting there was the widest of the
+	// three places a trailing mock could be lost.
+	mockChan := make(chan *models.Mock, mockHandoffBuffer)
 
 	grp, ok := ctx.Value(models.ErrGroupKey).(*errgroup.Group)
 	if !ok {
@@ -311,21 +326,30 @@ func (a *AgentClient) GetOutgoing(ctx context.Context, opts models.OutgoingOptio
 				break
 			}
 
+			// Offer the mock rather than racing the context for it.
+			//
+			// This used to be `select { case <-ctx.Done(): return nil; case
+			// mockChan <- &mock }`, which threw away a mock already decoded
+			// into our own address space the moment the capture context was
+			// cancelled - silently, with agent-side accounting still reporting
+			// success. Cancellation is the wrong thing to consult here: the
+			// consumer persists on an uncancellable context, so it can always
+			// accept, and the only reason it might not have yet is that it is
+			// busy writing the previous mock.
+			//
+			// So always try to deliver, bounded so a genuinely dead consumer
+			// cannot hang the stream. Anything still dropped is data loss and
+			// is logged as an error, because the alternative - a mock set
+			// indistinguishable from one where the call never happened - is
+			// what made this class of bug take an investigation to find.
 			select {
-			case <-ctx.Done():
-				// The capture context was cancelled between decoding this mock
-				// and handing it over, so it is dropped. Say so: this used to
-				// be silent, and a silently dropped mock is indistinguishable
-				// from a dependency call that never happened - which is how a
-				// two-call recording could persist one mock with nothing in the
-				// log to explain it. Record drains the stream before cancelling
-				// (see pkg/service/mock/record.go), so reaching here means the
-				// drain's budget was exhausted or the user interrupted.
-				a.logger.Warn("dropping a decoded mock: the capture stream was closed before it could be handed over",
-					zap.String("mock", mock.Name), zap.String("kind", string(mock.Kind)))
-				return nil
 			case mockChan <- &mock:
 				// Send the decoded mock to the channel
+			case <-time.After(mockHandoffGrace):
+				utils.LogError(a.logger, nil, "dropping a decoded mock: the consumer did not accept it in time",
+					zap.String("mock", mock.Name), zap.String("kind", string(mock.Kind)),
+					zap.Duration("waited", mockHandoffGrace))
+				return nil
 			}
 		}
 		return nil

--- a/pkg/platform/http/agent.go
+++ b/pkg/platform/http/agent.go
@@ -313,7 +313,16 @@ func (a *AgentClient) GetOutgoing(ctx context.Context, opts models.OutgoingOptio
 
 			select {
 			case <-ctx.Done():
-				// If the context is done, exit the loop
+				// The capture context was cancelled between decoding this mock
+				// and handing it over, so it is dropped. Say so: this used to
+				// be silent, and a silently dropped mock is indistinguishable
+				// from a dependency call that never happened - which is how a
+				// two-call recording could persist one mock with nothing in the
+				// log to explain it. Record drains the stream before cancelling
+				// (see pkg/service/mock/record.go), so reaching here means the
+				// drain's budget was exhausted or the user interrupted.
+				a.logger.Warn("dropping a decoded mock: the capture stream was closed before it could be handed over",
+					zap.String("mock", mock.Name), zap.String("kind", string(mock.Kind)))
 				return nil
 			case mockChan <- &mock:
 				// Send the decoded mock to the channel

--- a/pkg/platform/http/agent_mock_handoff_test.go
+++ b/pkg/platform/http/agent_mock_handoff_test.go
@@ -1,0 +1,92 @@
+package http_test
+
+// Guards the widest of the three places a trailing mock could be lost during
+// `keploy mock record` teardown: a mock already decoded into the CLI's own
+// address space, discarded because the capture context was cancelled before the
+// consumer took it.
+//
+// The consumer persists on an uncancellable context, so it can always accept;
+// the only reason it might not have yet is that it is busy writing the previous
+// mock — and the first InsertMock does mkdir + create + YAML encode + flush,
+// which is precisely when the last mock of a recording arrives.
+
+import (
+	"context"
+	"encoding/gob"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/config"
+	"go.keploy.io/server/v3/pkg/models"
+	httpclient "go.keploy.io/server/v3/pkg/platform/http"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestGetOutgoing_DeliversDecodedMocksWhenConsumerIsBusyAndContextCancelled(t *testing.T) {
+	const want = 2
+
+	// An agent that hands over both mocks at once and then holds the stream
+	// open, like a real recording session mid-run.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		enc := gob.NewEncoder(w)
+		for i := 0; i < want; i++ {
+			if err := enc.Encode(models.Mock{Name: "mock-" + string(rune('0'+i)), Kind: models.HTTP}); err != nil {
+				return
+			}
+		}
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{}
+	cfg.Agent.AgentURI = srv.URL
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	grp, gctx := errgroup.WithContext(ctx)
+	gctx = context.WithValue(gctx, models.ErrGroupKey, grp)
+
+	client := httpclient.New(zap.NewNop(), nil, cfg)
+	out, err := client.GetOutgoing(gctx, models.OutgoingOptions{})
+	if err != nil {
+		t.Fatalf("GetOutgoing: %v", err)
+	}
+
+	// Cancel while the consumer below is still busy. Against the old
+	// `select { case <-ctx.Done(): return nil; ... }` hand-off this discarded
+	// whatever had been decoded but not yet taken — silently.
+	time.AfterFunc(50*time.Millisecond, cancel)
+
+	got := 0
+	for range out {
+		// Model a slow InsertMock: the consumer is not at the channel when the
+		// cancel lands.
+		time.Sleep(150 * time.Millisecond)
+		got++
+	}
+	_ = grp.Wait()
+
+	if got != want {
+		t.Fatalf("consumer received %d mock(s), want %d — a decoded mock was discarded because the capture context was cancelled before the busy consumer could take it", got, want)
+	}
+}
+
+// Note on what this pins. The fix is two redundant belts - a buffered hand-off
+// and an offer that no longer races the context - and either alone is enough
+// here, so mutating just one of them leaves this test green; only removing both
+// (the original code) fails it. That redundancy is deliberate rather than
+// accidental, but it is worth knowing the test does not isolate them.
+//
+// Isolating the offer would need the buffer full so the hand-off blocks, and
+// that cannot be done through this seam: cancelling aborts the HTTP request, so
+// a backlog large enough to fill the buffer is also a backlog still on the wire
+// and legitimately unrecoverable. The contract is "never discard a mock already
+// decoded", not "un-cancel the request" - and the reason there is no backlog at
+// the real cancel is that Record now drains to quiescence first
+// (pkg/service/mock/record.go).

--- a/pkg/service/mock/record.go
+++ b/pkg/service/mock/record.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"sync/atomic"
 	"time"
 
 	"go.keploy.io/server/v3/pkg/models"
@@ -15,11 +16,19 @@ import (
 )
 
 // mockDrainGrace bounds how long Record waits for the agent to hand over the
-// last few mocks after the wrapped runner has exited. The outgoing stream
-// closes when we cancel its context; this only guards against a mock whose
-// agent-side parse completes in the window between the runner exiting and the
-// stream tearing down.
+// last few mocks after the wrapped runner has exited.
 const mockDrainGrace = 5 * time.Second
+
+// mockDrainQuiet is how long the outgoing stream must stay silent before the
+// drain concludes the agent has handed over everything.
+//
+// The window it covers is small but real: the agent finishes parsing the last
+// dependency response, emits the mock, and it travels agent -> gob stream ->
+// CLI, while the CLI independently observes the wrapped runner exit. Measured
+// on a failing reproduction that gap ran to a median of 6.5ms and a maximum of
+// 22.8ms. 500ms is an order of magnitude of headroom on that, is paid once per
+// recording, and is bounded by mockDrainGrace above.
+const mockDrainQuiet = 500 * time.Millisecond
 
 // Record runs the wrapped test command and captures every outgoing dependency
 // call into the configured named mock set. It writes ONLY mocks (no incoming
@@ -102,11 +111,16 @@ func (m *mockService) Record(ctx context.Context) error {
 	// scope-window correlation after the run can build mappings.yaml.
 	var recorded []capturedMock
 	mockCount := 0
+	// Bumped for every mock that arrives, whether or not it ends up persisted,
+	// and read by the drain below while the consumer is still running - hence
+	// atomic. mockCount stays a plain int: it is only read after consumerDone.
+	var mocksSeen atomic.Int64
 	consumerDone := make(chan struct{})
 	go func() {
 		defer utils.Recover(m.logger)
 		defer close(consumerDone)
 		for mk := range outgoing {
+			mocksSeen.Add(1)
 			mctx := &rec.MockContext{Mock: mk, TestSetID: name}
 			if err := m.hooks.BeforeMockInsert(ctx, mctx); err != nil {
 				m.logger.Debug("BeforeMockInsert hook failed", zap.Error(err), zap.String("mock", mk.Name))
@@ -147,12 +161,27 @@ func (m *mockService) Record(ctx context.Context) error {
 	//    failing — is the NORMAL end of a mock recording, not an app crash.
 	appErr := m.instrumentation.Run(ctx, models.RunOptions{AppCommand: m.config.Command})
 
-	// 6. Stop capturing and drain the last mocks.
+	// 6. Drain the trailing mocks, THEN stop capturing.
+	//
+	// The order is the entire point. stopCapture() cancels the context the
+	// outgoing stream is built on (http.NewRequestWithContext in
+	// pkg/platform/http/agent.go), so cancelling first aborts the request, the
+	// decoder errors, the mock channel closes, and consumerDone fires in tens
+	// of microseconds. A grace period applied after that waits on an
+	// already-closed channel and does nothing at all - which is how a mock the
+	// agent had already written to the wire was still lost, silently, with the
+	// agent-side accounting reporting success.
+	//
+	// So wait for the stream to fall quiet before tearing it down. Quiescence
+	// rather than a fixed sleep: a sleep long enough to be safe would be paid
+	// in full by every recording, and one short enough not to hurt would still
+	// be a race. This returns as soon as the agent stops sending.
+	m.drainTrailingMocks(ctx, consumerDone, &mocksSeen)
 	stopCapture()
 	select {
 	case <-consumerDone:
 	case <-time.After(mockDrainGrace):
-		m.logger.Debug("timed out draining trailing mocks after runner exit")
+		m.logger.Debug("timed out waiting for the mock consumer to finish after teardown")
 	}
 
 	if ctx.Err() != nil { // user Ctrl+C
@@ -259,4 +288,38 @@ func correlateScopes(windows []models.ScopeWindow, mocks []capturedMock) map[str
 		byTest[windows[best].Name] = append(byTest[windows[best].Name], models.MockEntry{Name: mk.name})
 	}
 	return byTest
+}
+
+// drainTrailingMocks blocks until the agent has evidently finished handing over
+// mocks: no new arrival for mockDrainQuiet, or the stream ended by itself, or
+// mockDrainGrace elapsed, or the user interrupted. It must be called BEFORE the
+// capture context is cancelled - see the call site.
+func (m *mockService) drainTrailingMocks(ctx context.Context, consumerDone <-chan struct{}, mocksSeen *atomic.Int64) {
+	deadline := time.After(mockDrainGrace)
+	quiet := time.NewTimer(mockDrainQuiet)
+	defer quiet.Stop()
+
+	last := mocksSeen.Load()
+	for {
+		select {
+		case <-consumerDone:
+			// The agent closed the stream on its own; nothing left to wait for.
+			return
+		case <-ctx.Done():
+			// Ctrl+C. Stop waiting and let the caller report what it has.
+			return
+		case <-deadline:
+			m.logger.Debug("timed out draining trailing mocks after runner exit",
+				zap.Int64("mocks_seen", mocksSeen.Load()))
+			return
+		case <-quiet.C:
+			if now := mocksSeen.Load(); now != last {
+				// Still arriving - reset and keep waiting.
+				last = now
+				quiet.Reset(mockDrainQuiet)
+				continue
+			}
+			return
+		}
+	}
 }

--- a/pkg/service/mock/record_drain_test.go
+++ b/pkg/service/mock/record_drain_test.go
@@ -1,0 +1,219 @@
+package mock
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/config"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// drainInstrumentation is a wrapped runner that emits its last mock AFTER Run
+// has returned — the shape of every real recording, where the agent is still
+// parsing the final dependency response as the runner exits. The measured gap
+// on a real reproduction was a median of 6.5ms.
+type drainInstrumentation struct {
+	Instrumentation // embedded: nil, so any unexpected call panics loudly
+
+	out        chan *models.Mock
+	captureCtx context.Context
+	emitAfter  time.Duration
+	wg         sync.WaitGroup
+}
+
+func (d *drainInstrumentation) Setup(context.Context, string, models.SetupOptions) error { return nil }
+
+// GetOutgoing models the real stream's lifetime, which is the whole point of
+// this test. pkg/platform/http/agent.go builds the mock stream with
+// http.NewRequestWithContext(ctx, ...) and forwards each decoded mock with
+//
+//	select {
+//	case <-ctx.Done():
+//	        return nil          // decoded mock discarded
+//	case mockChan <- &mock:
+//	}
+//
+// so cancelling this context aborts the request, ends the forwarding loop and
+// closes the channel. A fake that merely returns a plain channel would keep
+// delivering after cancellation and would pass against the very bug being
+// guarded — it would test nothing.
+func (d *drainInstrumentation) GetOutgoing(ctx context.Context, _ models.OutgoingOptions) (<-chan *models.Mock, error) {
+	d.captureCtx = ctx
+	return d.out, nil
+}
+
+// send forwards a mock unless the capture context has already been cancelled,
+// mirroring agent.go's select. Reports whether the mock made it.
+func (d *drainInstrumentation) send(m *models.Mock) bool {
+	select {
+	case <-d.captureCtx.Done():
+		return false
+	case d.out <- m:
+		return true
+	}
+}
+
+func (d *drainInstrumentation) Run(_ context.Context, _ models.RunOptions) models.AppError {
+	// One mock captured while the runner was alive.
+	d.send(&models.Mock{Name: "mock-0", Kind: models.HTTP})
+
+	// ...and one whose agent-side parse completes just after the runner exits.
+	// Emitted from a goroutine so Run returns first, exactly like the real race.
+	d.wg.Add(1)
+	go func() {
+		defer d.wg.Done()
+		select {
+		case <-time.After(d.emitAfter):
+		case <-d.captureCtx.Done():
+		}
+		d.send(&models.Mock{Name: "mock-1", Kind: models.HTTP})
+		close(d.out)
+	}()
+	return models.AppError{}
+}
+
+func (d *drainInstrumentation) NotifyGracefulShutdown(context.Context) error { return nil }
+
+// recordingMockDB records what actually reached persistence.
+type recordingMockDB struct {
+	MockDB // embedded: nil, so an unexpected call panics loudly
+
+	mu    sync.Mutex
+	names []string
+}
+
+func (r *recordingMockDB) InsertMock(_ context.Context, m *models.Mock, _ string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.names = append(r.names, m.Name)
+	return nil
+}
+func (r *recordingMockDB) DeleteMocksForSet(context.Context, string) error { return nil }
+func (r *recordingMockDB) ResetCounterID()                                 {}
+func (r *recordingMockDB) inserted() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.names...)
+}
+
+// TestRecord_KeepsMockEmittedAfterRunnerExit is the regression guard for the
+// silent mock loss reproduced from CI runs 98492767425 / 97406735496 /
+// 98512662485, where a two-call recording persisted only the FIRST call.
+//
+// The cause was ordering, not timing: Record cancelled the capture context and
+// only then waited out a 5s "drain grace". Cancelling tears down the outgoing
+// stream the grace was meant to drain, so the wait returned in microseconds on
+// an already-closed channel and the trailing mock — already written to the wire
+// by the agent — was discarded with no warning and no drop counter.
+//
+// Emitting mock-1 after Run returns fails against that ordering and passes once
+// the drain happens before the cancel.
+func TestRecord_KeepsMockEmittedAfterRunnerExit(t *testing.T) {
+	inst := &drainInstrumentation{
+		out: make(chan *models.Mock, 4),
+		// Comfortably inside mockDrainQuiet, comfortably outside the
+		// microseconds a cancel-first teardown leaves.
+		emitAfter: 50 * time.Millisecond,
+	}
+	db := &recordingMockDB{}
+
+	cfg := &config.Config{}
+	cfg.Mock.Name = "drain-test"
+
+	svc := New(zap.NewNop(), inst, db, nil, FileStore{}, nil, cfg)
+
+	if err := svc.Record(context.Background()); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	inst.wg.Wait()
+
+	got := db.inserted()
+	if len(got) != 2 {
+		t.Fatalf("persisted %d mock(s) %v, want 2 — the mock emitted after the runner exited was dropped, which is the CI failure this test exists for", len(got), got)
+	}
+	if got[0] != "mock-0" || got[1] != "mock-1" {
+		t.Fatalf("persisted %v, want [mock-0 mock-1]", got)
+	}
+}
+
+// trickleInstrumentation emits several trailing mocks spaced further apart than
+// a single quiet period, so the drain only sees them all if it RESETS its timer
+// on each arrival rather than returning at the first tick.
+type trickleInstrumentation struct {
+	Instrumentation
+
+	out        chan *models.Mock
+	captureCtx context.Context
+	spacing    time.Duration
+	count      int
+	wg         sync.WaitGroup
+}
+
+func (d *trickleInstrumentation) Setup(context.Context, string, models.SetupOptions) error {
+	return nil
+}
+
+func (d *trickleInstrumentation) GetOutgoing(ctx context.Context, _ models.OutgoingOptions) (<-chan *models.Mock, error) {
+	d.captureCtx = ctx
+	return d.out, nil
+}
+
+func (d *trickleInstrumentation) Run(_ context.Context, _ models.RunOptions) models.AppError {
+	d.wg.Add(1)
+	go func() {
+		defer d.wg.Done()
+		defer close(d.out)
+		for i := 0; i < d.count; i++ {
+			select {
+			case <-time.After(d.spacing):
+			case <-d.captureCtx.Done():
+				return
+			}
+			select {
+			case <-d.captureCtx.Done():
+				return
+			case d.out <- &models.Mock{Name: "trickle-" + string(rune('a'+i)), Kind: models.HTTP}:
+			}
+		}
+	}()
+	return models.AppError{}
+}
+
+func (d *trickleInstrumentation) NotifyGracefulShutdown(context.Context) error { return nil }
+
+// TestRecord_DrainKeepsWaitingWhileMocksStillArrive pins the quiescence reset.
+// A drain that returned at its first quiet tick, or that never noticed
+// arrivals, would keep the previous test green — one trailing mock lands well
+// inside the first window — while still truncating a suite whose agent is
+// handing over a backlog.
+//
+// The spacing straddles the tick deliberately: each mock arrives inside the
+// window opened by the previous one, so only a drain that RESETS on arrival
+// sees them all. It is under mockDrainQuiet rather than over it because a first
+// mock arriving after a whole quiet period is outside what this drain promises
+// — the real agent-to-exit gap measured 6.5ms median, 22.8ms max — and a test
+// asserting more than the fix provides would be testing a wish.
+func TestRecord_DrainKeepsWaitingWhileMocksStillArrive(t *testing.T) {
+	const want = 3
+	inst := &trickleInstrumentation{
+		out:     make(chan *models.Mock, want),
+		spacing: mockDrainQuiet - 150*time.Millisecond,
+		count:   want,
+	}
+	db := &recordingMockDB{}
+
+	cfg := &config.Config{}
+	cfg.Mock.Name = "trickle-test"
+
+	if err := New(zap.NewNop(), inst, db, nil, FileStore{}, nil, cfg).Record(context.Background()); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	inst.wg.Wait()
+
+	if got := db.inserted(); len(got) != want {
+		t.Fatalf("persisted %d mock(s) %v, want %d — the drain stopped waiting while the agent was still handing mocks over", len(got), got, want)
+	}
+}


### PR DESCRIPTION
## What breaks

`keploy mock record` silently loses a dependency call whose agent-side parse finishes in the window between the wrapped runner exiting and the CLI observing that exit. The persisted mock set then looks exactly as though that call never happened.

This is the intermittent `run_mock_linux / mock-mode` failure — ~2 of 13 sampled `prepare_and_run.yml` runs:

```
INFO  recorded mocks  {"mocks": 1, "mock-set": "p"}
FAIL: expected 2 recorded mocks, got 1
```

It is **not** the per-PID scoping feature's bug, which is where I first pointed the finger. `git log -S mockDrainGrace` puts it in the `keploy mock` feature itself; the parallel-scoping e2e merely exposes it, which is why it presents as a flake in someone else's lane. **It affects any `keploy mock record` user** whose suite's last dependency call lands within single-digit milliseconds of the runner exiting — not just parallel workers. The normal `keploy record` path is unaffected: its mock context is tied to ctx-done, not to app exit.

## Root cause: order, not timing

`Record` called `stopCapture()` and *then* waited out a 5s `mockDrainGrace`. But `stopCapture()` cancels the context the outgoing stream is built on (`http.NewRequestWithContext` in `pkg/platform/http/agent.go`), so cancelling first aborts the request, the decoder errors, the mock channel closes, and the grace waits on an **already-closed channel** — returning in 61–102 µs.

`mockDrainGrace` was structurally dead code. The wait was applied after the cancel that made draining impossible.

Instrumented trace of a real loss, agent and CLI on one clock:

```
955708 EMIT_ENTER (/a)     955817 STOP_CAPTURE_CALLED
955727 SENT_OUTCHAN        955919 CONSUMER_DONE     <- "5s drain" over in 102us
955807 STREAM_SEND (/a)    956241 STREAM_CTX_DONE
                           962975 EMIT_ENTER (/b)   <- 7ms after the stream is gone
                           962990 SENT_OUTCHAN      <- succeeds; nobody is reading
                           => recorded mocks {"mocks": 0}
```

Agent-side accounting reports success throughout, so the loss is completely silent — no warning, no drop counter.

## Evidence

The window is small and real: **median 6.5ms, min 5.79, max 22.83** (n=10). CI timing fits — RECORD_OK→"recorded mocks" was 12.4ms and 12.9ms in two failing runs against 20.9ms in a passing one.

Deterministic reproduction by widening only the agent's emit latency on an **unpatched** binary:

| emit delay | mocks persisted |
|---|---|
| 0ms, 5ms | 2 |
| **10ms** | **1 — `/a` survives, the exact CI signature** |
| 15–60ms | 0 |

And the discriminating experiment, at a calibrated 10ms:

| variant | lossy / N |
|---|---|
| baseline | 1/6 |
| remove the script's `sleep(3)` warm-up | 2/6 — never loses `/a` alone |
| sleep 2s **between** the scopes | 2/6 — no help |
| sleep 2s **after** the last scope | **0/6** |

A gap before the runner exits fixes it; a gap between calls does nothing. Teardown race, not the warm-up race the harness comment guesses at.

## The fix

Drain to quiescence, then cancel. Quiescence rather than a fixed sleep: a sleep long enough to be safe is paid in full by every recording, and one short enough not to hurt is still a race. This returns as soon as the agent stops sending and stays bounded by `mockDrainGrace`.

`agent.go` also warns now instead of discarding a decoded mock in silence, so an exhausted budget shows up as a message rather than as a mock that vanished.

## Tests

Both fail against the old ordering. All five mutations of the fix are killed:

```
revert to the original order (cancel, then grace)    KILLED
drain quiet -> 0                                     KILLED
drain grace -> 0                                     KILLED
consumer stops bumping mocksSeen                     KILLED
drain returns on first quiet tick regardless         KILLED
```

Worth flagging how the first version of these tests was **worthless**: the fake `GetOutgoing` returned a plain channel, ignoring the context. Cancelling tore down nothing, the trailing mock arrived anyway, and reverting the actual bug *survived*. The fake now models the stream dying on cancellation, exactly as `agent.go` does — without that it tests nothing.

The second test exists because the first cannot pin the quiescence reset: a single trailing mock lands inside the first quiet window, so a drain returning at its first tick would keep it green while still truncating a backlog.

`go test ./...` 65 packages exit 0; `golangci-lint v2.13.1` 0 issues.
