### PR TITLE
fix: support MySQL COM_STMT_FETCH on V2 path

### DIFF
--- a/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
@@ -904,6 +904,8 @@ func buildClientTLSConfigV2(_ *supervisor.Session) *tls.Config {
 //
 // Exits cleanly on io.EOF / fakeconn.ErrClosed from either stream.
 func handleCommandsV2(ctx context.Context, logger *zap.Logger, sess *supervisor.Session, decodeCtx *wire.DecodeContext, clientKey net.Conn, firstCmd []byte) error {
+	cursorColumns := make(map[uint32][]*mysql.ColumnDefinition41)
+
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -938,6 +940,11 @@ func handleCommandsV2(ctx context.Context, logger *zap.Logger, sess *supervisor.
 		// matching the legacy recorder shape. Response timestamp is
 		// the command arrival time since no server response exists.
 		if wire.IsNoResponseCommand(cmdPkt.Header.Type) {
+			if closePkt, ok := cmdPkt.Message.(*mysql.StmtClosePacket); ok {
+				delete(cursorColumns, closePkt.StatementID)
+				delete(decodeCtx.PreparedStatements, closePkt.StatementID)
+				delete(decodeCtx.LongDataParams, closePkt.StatementID)
+			}
 			emitMockV2(ctx, sess, []mysql.Request{{PacketBundle: *cmdPkt}}, nil, "mocks",
 				cmdPkt.Header.Type, "NO Response Packet", reqTs, reqTs)
 			continue
@@ -952,13 +959,43 @@ func handleCommandsV2(ctx context.Context, logger *zap.Logger, sess *supervisor.
 		// Load lastOp for response shape.
 		lastOp, _ := decodeCtx.LastOp.Load(clientKey)
 
-		respBundle, resTs, err := collectResponseV2(ctx, logger, sess, decodeCtx, clientKey, lastOp)
+		var respBundle *mysql.PacketBundle
+		var resTs time.Time
+		if fetchPkt, ok := cmdPkt.Message.(*mysql.StmtFetchPacket); ok {
+			columns := cursorColumns[fetchPkt.StatementID]
+			if len(columns) == 0 {
+				if prepared := decodeCtx.PreparedStatements[fetchPkt.StatementID]; prepared != nil {
+					columns = prepared.ColumnDefs
+				}
+			}
+			respBundle, resTs, err = collectStmtFetchResponseV2(ctx, logger, sess, decodeCtx, clientKey, fetchPkt.StatementID, columns)
+		} else {
+			respBundle, resTs, err = collectResponseV2(ctx, logger, sess, decodeCtx, clientKey, lastOp)
+		}
 		if err != nil {
 			return err
 		}
 		if respBundle == nil {
 			// Desync or benign decode failure — drop this exchange.
 			continue
+		}
+
+		switch cmd := cmdPkt.Message.(type) {
+		case *mysql.StmtExecutePacket:
+			if stmtUsesCursor(cmd.Flags) {
+				columns := cursorColumns[cmd.StatementID]
+				if prepared := decodeCtx.PreparedStatements[cmd.StatementID]; prepared != nil && len(prepared.ColumnDefs) > 0 {
+					columns = prepared.ColumnDefs
+				}
+				if resultSet, ok := respBundle.Message.(*mysql.BinaryProtocolResultSet); ok && len(resultSet.Columns) > 0 {
+					columns = resultSet.Columns
+				}
+				if len(columns) > 0 {
+					cursorColumns[cmd.StatementID] = append([]*mysql.ColumnDefinition41(nil), columns...)
+				}
+			}
+		case *mysql.StmtResetPacket:
+			delete(cursorColumns, cmd.StatementID)
 		}
 
 		mockType := "mocks"
@@ -973,6 +1010,70 @@ func handleCommandsV2(ctx context.Context, logger *zap.Logger, sess *supervisor.
 			cmdPkt.Header.Type,
 			respBundle.Header.Type,
 			reqTs, resTs)
+	}
+}
+
+func stmtUsesCursor(flags byte) bool {
+	const cursorMask = mysql.CURSOR_TYPE_READ_ONLY | mysql.CURSOR_TYPE_FOR_UPDATE | mysql.CURSOR_TYPE_SCROLLABLE
+	return flags&cursorMask != 0
+}
+
+func collectStmtFetchResponseV2(ctx context.Context, logger *zap.Logger, sess *supervisor.Session, decodeCtx *wire.DecodeContext, clientKey net.Conn, statementID uint32, columns []*mysql.ColumnDefinition41) (*mysql.PacketBundle, time.Time, error) {
+	response := &mysql.StmtFetchResponse{}
+	var responseHeader *mysql.Header
+	var ts time.Time
+
+	for {
+		buf, err := mysqlUtils.ReadPacketBuffer(ctx, logger, sess.DestStream)
+		if err != nil {
+			return nil, ts, err
+		}
+		ts = sess.DestStream.LastReadTime()
+
+		packet, err := mysqlUtils.BytesToMySQLPacket(buf)
+		if err != nil {
+			return nil, ts, fmt.Errorf("parse COM_STMT_FETCH response packet: %w", err)
+		}
+		if len(packet.Payload) == 0 {
+			return nil, ts, fmt.Errorf("parse COM_STMT_FETCH response packet: payload is empty")
+		}
+		if responseHeader == nil {
+			header := packet.Header
+			responseHeader = &header
+		}
+
+		if packet.Payload[0] == mysql.ERR {
+			if len(response.Rows) != 0 {
+				return nil, ts, fmt.Errorf("COM_STMT_FETCH statement %d returned ERR after %d row packets", statementID, len(response.Rows))
+			}
+			errPkt, err := wire.DecodePayload(ctx, logger, buf, clientKey, decodeCtx)
+			if err != nil {
+				return nil, ts, fmt.Errorf("decode COM_STMT_FETCH ERR response: %w", err)
+			}
+			return errPkt, ts, nil
+		}
+
+		if mysqlUtils.IsResultSetTerminator(buf, decodeCtx.DeprecateEOF()) {
+			responseType := mysql.StatusToString(mysql.EOF)
+			if decodeCtx.DeprecateEOF() && mysqlUtils.IsOKReplacingEOF(buf) {
+				responseType = mysql.StatusToString(mysql.OK)
+			}
+			response.FinalResponse = &mysql.GenericResponse{Data: buf, Type: responseType}
+			decodeCtx.LastOp.Store(clientKey, wire.RESET)
+			return &mysql.PacketBundle{
+				Header:  &mysql.PacketInfo{Header: responseHeader, Type: mysql.COM_STMT_FETCH_RESPONSE},
+				Message: response,
+			}, ts, nil
+		}
+
+		if len(columns) == 0 {
+			return nil, ts, fmt.Errorf("decode COM_STMT_FETCH response for statement %d: column metadata is unavailable; record the COM_STMT_PREPARE and cursor COM_STMT_EXECUTE on the same connection", statementID)
+		}
+		row, _, err := rowscols.DecodeBinaryRow(ctx, logger, buf, columns)
+		if err != nil {
+			return nil, ts, fmt.Errorf("decode COM_STMT_FETCH row %d for statement %d: %w", len(response.Rows), statementID, err)
+		}
+		response.Rows = append(response.Rows, row)
 	}
 }
 

--- a/pkg/agent/proxy/integrations/mysql/recorder/v2_test.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/v2_test.go
@@ -9,8 +9,10 @@ import (
 
 	"go.keploy.io/server/v3/pkg/agent/proxy/directive"
 	"go.keploy.io/server/v3/pkg/agent/proxy/fakeconn"
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/wire"
 	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/wire/phase"
 	connphase "go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/wire/phase/conn"
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/wire/phase/query/rowscols"
 	"go.keploy.io/server/v3/pkg/agent/proxy/supervisor"
 	"go.keploy.io/server/v3/pkg/models"
 	"go.keploy.io/server/v3/pkg/models/mysql"
@@ -35,11 +37,16 @@ func wrapPacket(payload []byte, seq byte) []byte {
 // mysql_native_password auth. Using Native avoids the additional auth-
 // more-data round trip needed by caching_sha2 in the happy test.
 func cannedHandshakeV10(t *testing.T) []byte {
+	return cannedHandshakeV10WithCaps(t, 0)
+}
+
+func cannedHandshakeV10WithCaps(t *testing.T, additionalCaps uint32) []byte {
 	t.Helper()
 	caps := uint32(mysql.CLIENT_PROTOCOL_41 |
 		mysql.CLIENT_PLUGIN_AUTH |
 		mysql.CLIENT_SSL |
 		mysql.CLIENT_SECURE_CONNECTION)
+	caps |= additionalCaps
 	hs := &mysql.HandshakeV10Packet{
 		ProtocolVersion: 0x0a,
 		ServerVersion:   "8.0.test-keploy",
@@ -63,11 +70,16 @@ func cannedHandshakeV10(t *testing.T) []byte {
 // cannedHandshakeResponse41 returns a full HandshakeResponse41 packet
 // (Native auth). sslBit toggles whether CLIENT_SSL is advertised.
 func cannedHandshakeResponse41(t *testing.T, seq byte, sslBit bool) []byte {
+	return cannedHandshakeResponse41WithCaps(t, seq, sslBit, 0)
+}
+
+func cannedHandshakeResponse41WithCaps(t *testing.T, seq byte, sslBit bool, additionalCaps uint32) []byte {
 	t.Helper()
 	caps := uint32(mysql.CLIENT_PROTOCOL_41 | mysql.CLIENT_PLUGIN_AUTH | mysql.CLIENT_SECURE_CONNECTION)
 	if sslBit {
 		caps |= mysql.CLIENT_SSL
 	}
+	caps |= additionalCaps
 	hr := &mysql.HandshakeResponse41Packet{
 		CapabilityFlags: caps,
 		MaxPacketSize:   1 << 24,
@@ -114,6 +126,97 @@ func cannedCOMQuery(_ *testing.T, seq byte, query string) []byte {
 	body[0] = mysql.COM_QUERY
 	copy(body[1:], query)
 	return wrapPacket(body, seq)
+}
+
+func cannedStmtPrepare(seq byte, query string) []byte {
+	payload := append([]byte{mysql.COM_STMT_PREPARE}, []byte(query)...)
+	return wrapPacket(payload, seq)
+}
+
+func cannedStmtPrepareOK(seq byte, statementID uint32, numColumns uint16) []byte {
+	payload := make([]byte, 12)
+	payload[0] = mysql.OK
+	binary.LittleEndian.PutUint32(payload[1:5], statementID)
+	binary.LittleEndian.PutUint16(payload[5:7], numColumns)
+	return wrapPacket(payload, seq)
+}
+
+func cannedLongColumn(t *testing.T, seq byte, name string) []byte {
+	t.Helper()
+	column := &mysql.ColumnDefinition41{
+		Header:       mysql.Header{SequenceID: seq},
+		Catalog:      "def",
+		Schema:       "test",
+		Table:        "cursor_rows",
+		OrgTable:     "cursor_rows",
+		Name:         name,
+		OrgName:      name,
+		FixedLength:  0x0c,
+		CharacterSet: 0x21,
+		ColumnLength: 11,
+		Type:         byte(mysql.FieldTypeLong),
+		Filler:       []byte{0x00, 0x00},
+	}
+	buf, err := rowscols.EncodeColumn(context.Background(), zap.NewNop(), column)
+	if err != nil {
+		t.Fatalf("encode column: %v", err)
+	}
+	return buf
+}
+
+func cannedEOF(seq byte, statusFlags uint16) []byte {
+	payload := []byte{mysql.EOF, 0x00, 0x00, 0x00, 0x00}
+	binary.LittleEndian.PutUint16(payload[3:5], statusFlags)
+	return wrapPacket(payload, seq)
+}
+
+func cannedOKReplacingEOF(seq byte, statusFlags uint16) []byte {
+	payload := []byte{mysql.EOF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+	binary.LittleEndian.PutUint16(payload[3:5], statusFlags)
+	return wrapPacket(payload, seq)
+}
+
+func cannedStmtExecute(seq byte, statementID uint32, flags byte) []byte {
+	payload := make([]byte, 10)
+	payload[0] = mysql.COM_STMT_EXECUTE
+	binary.LittleEndian.PutUint32(payload[1:5], statementID)
+	payload[5] = flags
+	binary.LittleEndian.PutUint32(payload[6:10], 1)
+	return wrapPacket(payload, seq)
+}
+
+func cannedStmtFetch(seq byte, statementID, numRows uint32) []byte {
+	payload := make([]byte, 9)
+	payload[0] = mysql.COM_STMT_FETCH
+	binary.LittleEndian.PutUint32(payload[1:5], statementID)
+	binary.LittleEndian.PutUint32(payload[5:9], numRows)
+	return wrapPacket(payload, seq)
+}
+
+func cannedStmtClose(seq byte, statementID uint32) []byte {
+	payload := make([]byte, 5)
+	payload[0] = mysql.COM_STMT_CLOSE
+	binary.LittleEndian.PutUint32(payload[1:5], statementID)
+	return wrapPacket(payload, seq)
+}
+
+func cannedBinaryLongRow(t *testing.T, seq byte, value int32) []byte {
+	t.Helper()
+	row := &mysql.BinaryRow{
+		Header:        mysql.Header{SequenceID: seq},
+		RowNullBuffer: []byte{0x00},
+		Values: []mysql.ColumnEntry{{
+			Type:  mysql.FieldTypeLong,
+			Name:  "id",
+			Value: value,
+		}},
+	}
+	column := &mysql.ColumnDefinition41{Name: "id", Type: byte(mysql.FieldTypeLong)}
+	buf, err := rowscols.EncodeBinaryRow(context.Background(), zap.NewNop(), row, []*mysql.ColumnDefinition41{column})
+	if err != nil {
+		t.Fatalf("encode binary row: %v", err)
+	}
+	return buf
 }
 
 // v2Harness stitches together a fake supervisor.Session driven by
@@ -289,6 +392,138 @@ collect:
 	}
 	if !qm.Spec.ResTimestampMock.Equal(queryRespTs) {
 		t.Errorf("query mock ResTimestampMock = %v, want %v", qm.Spec.ResTimestampMock, queryRespTs)
+	}
+}
+
+func TestRecordV2_StmtFetchRecordsEveryCursorChunk(t *testing.T) {
+	t.Parallel()
+	h := newV2Harness(t)
+
+	const (
+		statementID       = uint32(4)
+		serverAutocommit  = uint16(0x0002)
+		serverCursorOpen  = uint16(0x0040)
+		serverLastRowSent = uint16(0x0080)
+	)
+	base := time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC)
+
+	handshakeBuf := cannedHandshakeV10WithCaps(t, wire.CLIENT_DEPRECATE_EOF)
+	greeting, err := connphase.DecodeHandshakeV10(context.Background(), zap.NewNop(), handshakeBuf[4:])
+	if err != nil {
+		t.Fatalf("decode handshake v10: %v", err)
+	}
+
+	// Handshake.
+	h.pushDest(handshakeBuf, base)
+	h.pushClient(cannedHandshakeResponse41WithCaps(t, 1, false, wire.CLIENT_DEPRECATE_EOF), base.Add(time.Millisecond))
+	h.pushDest(cannedOK(t, 2, greeting.CapabilityFlags), base.Add(2*time.Millisecond))
+
+	// PREPARE supplies the result-column metadata later needed to decode the
+	// row-only FETCH responses.
+	h.pushClient(cannedStmtPrepare(0, "SELECT id FROM cursor_rows ORDER BY id"), base.Add(10*time.Millisecond))
+	h.pushDest(cannedStmtPrepareOK(1, statementID, 1), base.Add(11*time.Millisecond))
+	h.pushDest(cannedLongColumn(t, 2, "id"), base.Add(12*time.Millisecond))
+
+	// EXECUTE opens a read-only cursor. It returns metadata and a cursor-open
+	// terminator, but no rows; rows arrive only after COM_STMT_FETCH.
+	h.pushClient(cannedStmtExecute(0, statementID, mysql.CURSOR_TYPE_READ_ONLY), base.Add(20*time.Millisecond))
+	h.pushDest(wrapPacket([]byte{0x01}, 1), base.Add(21*time.Millisecond))
+	h.pushDest(cannedLongColumn(t, 2, "id"), base.Add(22*time.Millisecond))
+	h.pushDest(cannedOKReplacingEOF(3, serverAutocommit|serverCursorOpen), base.Add(23*time.Millisecond))
+
+	// Two fetches prove repeated identical commands remain separate FIFO mocks.
+	h.pushClient(cannedStmtFetch(0, statementID, 2), base.Add(30*time.Millisecond))
+	h.pushDest(cannedBinaryLongRow(t, 1, 11), base.Add(31*time.Millisecond))
+	h.pushDest(cannedBinaryLongRow(t, 2, 12), base.Add(32*time.Millisecond))
+	h.pushDest(cannedOKReplacingEOF(3, serverAutocommit|serverCursorOpen), base.Add(33*time.Millisecond))
+
+	h.pushClient(cannedStmtFetch(0, statementID, 2), base.Add(40*time.Millisecond))
+	h.pushDest(cannedBinaryLongRow(t, 1, 13), base.Add(41*time.Millisecond))
+	h.pushDest(cannedOKReplacingEOF(2, serverAutocommit|serverLastRowSent), base.Add(42*time.Millisecond))
+
+	// CLOSE is a no-response command and must still be recorded separately.
+	h.pushClient(cannedStmtClose(0, statementID), base.Add(50*time.Millisecond))
+
+	done := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		done <- RecordV2(ctx, h.logger, h.sess)
+	}()
+
+	got := make([]*models.Mock, 0, 6)
+	for len(got) < 6 {
+		select {
+		case mock := <-h.mocks:
+			got = append(got, mock)
+			if len(got) == 6 {
+				h.closeStreams()
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for cursor mocks (got %d)", len(got))
+		}
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("RecordV2 returned error: %v", err)
+	}
+
+	wantOps := []string{
+		mysql.AuthStatusToString(mysql.HandshakeV10),
+		mysql.CommandStatusToString(mysql.COM_STMT_PREPARE),
+		mysql.CommandStatusToString(mysql.COM_STMT_EXECUTE),
+		mysql.CommandStatusToString(mysql.COM_STMT_FETCH),
+		mysql.CommandStatusToString(mysql.COM_STMT_FETCH),
+		mysql.CommandStatusToString(mysql.COM_STMT_CLOSE),
+	}
+	for i, want := range wantOps {
+		if gotOp := got[i].Spec.Metadata["requestOperation"]; gotOp != want {
+			t.Errorf("mock %d requestOperation = %q, want %q", i, gotOp, want)
+		}
+	}
+
+	assertFetch := func(mock *models.Mock, wantValues []int32, wantStatus uint16) {
+		t.Helper()
+		if len(mock.Spec.MySQLRequests) != 1 {
+			t.Fatalf("fetch requests = %d, want 1", len(mock.Spec.MySQLRequests))
+		}
+		request, ok := mock.Spec.MySQLRequests[0].Message.(*mysql.StmtFetchPacket)
+		if !ok {
+			t.Fatalf("fetch request message = %T", mock.Spec.MySQLRequests[0].Message)
+		}
+		if request.StatementID != statementID || request.NumRows != 2 {
+			t.Errorf("fetch request = %+v, want stmt=%d rows=2", request, statementID)
+		}
+
+		if len(mock.Spec.MySQLResponses) != 1 {
+			t.Fatalf("fetch responses = %d, want 1", len(mock.Spec.MySQLResponses))
+		}
+		response, ok := mock.Spec.MySQLResponses[0].Message.(*mysql.StmtFetchResponse)
+		if !ok {
+			t.Fatalf("fetch response message = %T", mock.Spec.MySQLResponses[0].Message)
+		}
+		if len(response.Rows) != len(wantValues) {
+			t.Fatalf("fetch rows = %d, want %d", len(response.Rows), len(wantValues))
+		}
+		for i, want := range wantValues {
+			if gotValue, ok := response.Rows[i].Values[0].Value.(int32); !ok || gotValue != want {
+				t.Errorf("fetch row %d value = %v (%T), want int32(%d)", i, response.Rows[i].Values[0].Value, response.Rows[i].Values[0].Value, want)
+			}
+		}
+		if response.FinalResponse == nil || len(response.FinalResponse.Data) < 9 {
+			t.Fatalf("fetch final response = %+v", response.FinalResponse)
+		}
+		if response.FinalResponse.Type != mysql.StatusToString(mysql.OK) {
+			t.Errorf("fetch final response type = %q, want OK", response.FinalResponse.Type)
+		}
+		if gotStatus := binary.LittleEndian.Uint16(response.FinalResponse.Data[7:9]); gotStatus != wantStatus {
+			t.Errorf("fetch final status = %#x, want %#x", gotStatus, wantStatus)
+		}
+	}
+
+	assertFetch(got[3], []int32{11, 12}, serverAutocommit|serverCursorOpen)
+	assertFetch(got[4], []int32{13}, serverAutocommit|serverLastRowSent)
+	if len(got[5].Spec.MySQLResponses) != 0 {
+		t.Errorf("COM_STMT_CLOSE responses = %d, want 0", len(got[5].Spec.MySQLResponses))
 	}
 }
 

--- a/pkg/agent/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match.go
@@ -282,6 +282,7 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 		sCOM_QUERY      = mysql.CommandStatusToString(mysql.COM_QUERY)
 		sCOM_STMT_PREP  = mysql.CommandStatusToString(mysql.COM_STMT_PREPARE)
 		sCOM_STMT_EXEC  = mysql.CommandStatusToString(mysql.COM_STMT_EXECUTE)
+		sCOM_STMT_FETCH = mysql.CommandStatusToString(mysql.COM_STMT_FETCH)
 		sCOM_STMT_CLOSE = mysql.CommandStatusToString(mysql.COM_STMT_CLOSE)
 		sCOM_INIT_DB    = mysql.CommandStatusToString(mysql.COM_INIT_DB)
 		sCOM_STATS      = mysql.CommandStatusToString(mysql.COM_STATISTICS)
@@ -347,7 +348,7 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 			// and the later "no matching mock" would mask the real
 			// root cause. Other command types tolerate the failure
 			// (connection pool is advisory for them) — log + continue.
-			if req.Header.Type == sCOM_STMT_PREP || req.Header.Type == sCOM_STMT_EXEC {
+			if req.Header.Type == sCOM_STMT_PREP || req.Header.Type == sCOM_STMT_EXEC || req.Header.Type == sCOM_STMT_FETCH {
 				utils.LogError(logger, cerr, "failed to get mysql connection mocks", zap.String("connID", connID))
 				return nil, false, nil, fmt.Errorf("failed to get mysql connection mocks for connID %q: %w", connID, cerr)
 			}
@@ -426,7 +427,7 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 	// Build recordedPrepByConn once (map[connID][]prepEntry) from recorded mocks
 	recordedPrepByConn := buildRecordedPrepIndex(pool)
 
-	if req.Header.Type == sCOM_STMT_PREP || req.Header.Type == sCOM_STMT_EXEC {
+	if req.Header.Type == sCOM_STMT_PREP || req.Header.Type == sCOM_STMT_EXEC || req.Header.Type == sCOM_STMT_FETCH {
 		var allEntries []string
 		for connID, prepEntries := range recordedPrepByConn {
 			for _, entry := range prepEntries {
@@ -464,6 +465,7 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 		matchedMock      *models.Mock
 		queryMatched     bool
 		stmtMatched      bool
+		fetchMatched     bool
 		bestPartialMock  *models.Mock // closest non-exact match for diff reporting
 		bestPartialQuery string       // query of the closest partial match
 
@@ -521,6 +523,14 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 		// genuinely reusable single-recording query.
 		queryExactResp *mysql.Response
 		queryExactMock *models.Mock
+
+		// COM_STMT_FETCH carries only a runtime statement ID and row limit.
+		// Resolve both recorded and live IDs through their PREPARE mappings,
+		// then retain the first out-of-window exact candidate as a fallback.
+		// In-window candidates win so identical fetch commands from different
+		// tests cannot cross-serve row chunks.
+		fetchExactResp *mysql.Response
+		fetchExactMock *models.Mock
 	)
 
 	// liveStatement is the incoming statement stripped of its inert leading
@@ -804,6 +814,32 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 					}
 				}
 
+			case sCOM_STMT_FETCH:
+				expected, expectedOK := mockReq.PacketBundle.Message.(*mysql.StmtFetchPacket)
+				actual, actualOK := req.PacketBundle.Message.(*mysql.StmtFetchPacket)
+				if !expectedOK || !actualOK || expected == nil || actual == nil {
+					continue
+				}
+
+				expectedQuery := lookupRecordedQuery(recordedPrepByConn, mock.Spec.Metadata["connID"], expected.StatementID)
+				actualQuery := ""
+				if decodeCtx != nil && decodeCtx.StmtIDToQuery != nil {
+					actualQuery = decodeCtx.StmtIDToQuery[actual.StatementID]
+				}
+				if !matchStmtFetchPacketQueryAware(mockReq.PacketBundle, req.PacketBundle, expectedQuery, actualQuery) {
+					continue
+				}
+				if !gate.allows(mock) {
+					continue
+				}
+				if windowActive && !mockInCurrentWindow(mock) {
+					if fetchExactMock == nil {
+						fetchExactResp, fetchExactMock = &mock.Spec.MySQLResponses[0], mock
+					}
+				} else {
+					matchedResp, matchedMock, fetchMatched = &mock.Spec.MySQLResponses[0], mock, true
+				}
+
 			case sCOM_INIT_DB:
 				if c := matchInitDbPacket(ctx, logger, mockReq.PacketBundle, req.PacketBundle); c > maxMatchedCount {
 					maxMatchedCount, matchedResp, matchedMock = c, &mock.Spec.MySQLResponses[0], mock
@@ -826,7 +862,7 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 				}
 			}
 		}
-		if queryMatched || stmtMatched {
+		if queryMatched || stmtMatched || fetchMatched {
 			break
 		}
 	}
@@ -839,6 +875,10 @@ func matchCommand(ctx context.Context, logger *zap.Logger, req mysql.Request, mo
 	// candidate rather than dropping to the score-based partial pick.
 	if req.Header.Type == sCOM_QUERY && !queryMatched && queryExactMock != nil {
 		matchedResp, matchedMock, queryMatched = queryExactResp, queryExactMock, true
+	}
+
+	if req.Header.Type == sCOM_STMT_FETCH && !fetchMatched && fetchExactMock != nil {
+		matchedResp, matchedMock, fetchMatched = fetchExactResp, fetchExactMock, true
 	}
 
 	// COM_STMT_EXECUTE FIFO fallback. If the scan found no definitive
@@ -1666,6 +1706,24 @@ func matchStmtExecutePacketQueryAware(logger *zap.Logger, expected, actual mysql
 
 	// Both queryMatched and allParamsMatched must be true for a definitive match. Otherwise, return the best-effort score.
 	return (queryMatched && allParamsMatched), matchCount, queryExactMatched
+}
+
+func matchStmtFetchPacketQueryAware(expected, actual mysql.PacketBundle, expectedQuery, actualQuery string) bool {
+	if expected.Header == nil || actual.Header == nil || expected.Header.Type != actual.Header.Type {
+		return false
+	}
+	expectedMessage, expectedOK := expected.Message.(*mysql.StmtFetchPacket)
+	actualMessage, actualOK := actual.Message.(*mysql.StmtFetchPacket)
+	if !expectedOK || !actualOK || expectedMessage == nil || actualMessage == nil {
+		return false
+	}
+	if expectedMessage.Status != actualMessage.Status || expectedMessage.NumRows != actualMessage.NumRows {
+		return false
+	}
+
+	expectedStatement := sqlStatementIdentity(expectedQuery)
+	actualStatement := sqlStatementIdentity(actualQuery)
+	return expectedStatement != "" && actualStatement != "" && strings.EqualFold(expectedStatement, actualStatement)
 }
 
 func paramValueEqual(a, b interface{}, nc *util.NoiseChecker) bool {

--- a/pkg/agent/proxy/integrations/mysql/replayer/query.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/query.go
@@ -170,6 +170,13 @@ func simulateCommandPhase(ctx context.Context, logger *zap.Logger, clientConn ne
 						}
 						actualQuery = strings.TrimSpace(actualQuery + " " + formatExecParams(msg.Parameters))
 					}
+				case *mysql.StmtFetchPacket:
+					if msg != nil {
+						if decodeCtx != nil && decodeCtx.StmtIDToQuery != nil {
+							actualQuery = sqlStatementIdentity(decodeCtx.StmtIDToQuery[msg.StatementID])
+						}
+						actualQuery = strings.TrimSpace(fmt.Sprintf("%s (fetch %d rows)", actualQuery, msg.NumRows))
+					}
 				case *mysql.StmtSendLongDataPacket:
 					if msg != nil {
 						actualQuery = fmt.Sprintf("(param %d, %d streamed bytes)", msg.ParameterID, len(msg.Data))

--- a/pkg/agent/proxy/integrations/mysql/replayer/stmt_fetch_test.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/stmt_fetch_test.go
@@ -1,0 +1,138 @@
+package replayer
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/wire"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.keploy.io/server/v3/pkg/models/mysql"
+	"go.uber.org/zap"
+)
+
+func TestSimulateCommandPhaseReplaysStmtFetchRowsWithoutMetadata(t *testing.T) {
+	const (
+		query          = "SELECT id FROM cursor_rows ORDER BY id"
+		otherQuery     = "SELECT id FROM other_rows ORDER BY id"
+		recordedStmtID = uint32(7)
+		otherStmtID    = uint32(8)
+		runtimeStmtID  = uint32(99)
+	)
+
+	otherPrepare := stmtFetchPrepareMock("prepare-other", "conn-1", otherQuery, otherStmtID)
+	otherFetch := stmtFetchMock("fetch-other", "conn-1", otherStmtID, 2, int32(99), 0x0082)
+	prepare := stmtFetchPrepareMock("prepare", "conn-1", query, recordedStmtID)
+	firstFetch := stmtFetchMock("fetch-1", "conn-1", recordedStmtID, 2, int32(7), 0x0042)
+	secondFetch := stmtFetchMock("fetch-2", "conn-1", recordedStmtID, 2, int32(8), 0x0082)
+	db := &fakeMockDb{perTest: []*models.Mock{otherPrepare, otherFetch, prepare, firstFetch, secondFetch}}
+
+	serverConn, clientConn := net.Pipe()
+	t.Cleanup(func() {
+		_ = serverConn.Close()
+		_ = clientConn.Close()
+	})
+
+	decodeCtx := &wire.DecodeContext{
+		Mode:               models.MODE_TEST,
+		LastOp:             wire.NewLastOpMap(),
+		PreparedStatements: map[uint32]*mysql.StmtPrepareOkPacket{runtimeStmtID: {StatementID: runtimeStmtID}},
+		ServerGreetings:    wire.NewGreetings(),
+		StmtIDToQuery:      map[uint32]string{runtimeStmtID: query},
+	}
+	decodeCtx.LastOp.Store(serverConn, wire.RESET)
+	decodeCtx.ServerGreetings.Store(serverConn, &mysql.HandshakeV10Packet{
+		CapabilityFlags: mysql.CLIENT_PROTOCOL_41,
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- simulateCommandPhase(context.Background(), zap.NewNop(), serverConn, db, decodeCtx, models.OutgoingOptions{})
+	}()
+
+	require.NoError(t, clientConn.SetDeadline(time.Now().Add(2*time.Second)))
+	writeFetchAndRequireResponse(t, clientConn, runtimeStmtID, 2, []byte{
+		0x06, 0x00, 0x00, 0x01, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00,
+		0x05, 0x00, 0x00, 0x02, 0xfe, 0x00, 0x00, 0x42, 0x00,
+	})
+	writeFetchAndRequireResponse(t, clientConn, runtimeStmtID, 2, []byte{
+		0x06, 0x00, 0x00, 0x01, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00,
+		0x05, 0x00, 0x00, 0x02, 0xfe, 0x00, 0x00, 0x82, 0x00,
+	})
+	require.Equal(t, []string{"fetch-1", "fetch-2"}, db.deletedFil)
+
+	require.NoError(t, clientConn.Close())
+	commandErr := <-done
+	require.True(t, errors.Is(commandErr, io.EOF) || errors.Is(commandErr, io.ErrClosedPipe), "command phase error = %v", commandErr)
+}
+
+func writeFetchAndRequireResponse(t *testing.T, conn net.Conn, statementID, numRows uint32, want []byte) {
+	t.Helper()
+	command := make([]byte, 13)
+	command[0] = 0x09
+	command[4] = mysql.COM_STMT_FETCH
+	binary.LittleEndian.PutUint32(command[5:9], statementID)
+	binary.LittleEndian.PutUint32(command[9:13], numRows)
+	_, err := conn.Write(command)
+	require.NoError(t, err)
+
+	got := make([]byte, len(want))
+	_, err = io.ReadFull(conn, got)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func stmtFetchPrepareMock(name, connID, query string, stmtID uint32) *models.Mock {
+	mock := &models.Mock{Name: name, Kind: models.MySQL}
+	mock.TestModeInfo.Lifetime = models.LifetimeConnection
+	mock.Spec.Metadata = map[string]string{"type": "connection", "connID": connID}
+	mock.Spec.MySQLRequests = []mysql.Request{{PacketBundle: mysql.PacketBundle{
+		Header:  &mysql.PacketInfo{Header: &mysql.Header{PayloadLength: uint32(len(query) + 1)}, Type: mysql.CommandStatusToString(mysql.COM_STMT_PREPARE)},
+		Message: &mysql.StmtPreparePacket{Command: mysql.COM_STMT_PREPARE, Query: query},
+	}}}
+	mock.Spec.MySQLResponses = []mysql.Response{{PacketBundle: mysql.PacketBundle{
+		Header:  &mysql.PacketInfo{Header: &mysql.Header{PayloadLength: 12, SequenceID: 1}, Type: mysql.COM_STMT_PREPARE_OK},
+		Message: &mysql.StmtPrepareOkPacket{StatementID: stmtID},
+	}}}
+	return mock
+}
+
+func stmtFetchMock(name, connID string, stmtID, numRows uint32, value int32, finalStatus uint16) *models.Mock {
+	mock := &models.Mock{Name: name, Kind: models.MySQL}
+	mock.TestModeInfo.Lifetime = models.LifetimePerTest
+	mock.Spec.Metadata = map[string]string{"type": "mocks", "connID": connID}
+	mock.Spec.MySQLRequests = []mysql.Request{{PacketBundle: mysql.PacketBundle{
+		Header: &mysql.PacketInfo{
+			Header: &mysql.Header{PayloadLength: 9},
+			Type:   mysql.CommandStatusToString(mysql.COM_STMT_FETCH),
+		},
+		Message: &mysql.StmtFetchPacket{Status: mysql.COM_STMT_FETCH, StatementID: stmtID, NumRows: numRows},
+	}}}
+	mock.Spec.MySQLResponses = []mysql.Response{{PacketBundle: mysql.PacketBundle{
+		Header: &mysql.PacketInfo{
+			Header: &mysql.Header{PayloadLength: 6, SequenceID: 1},
+			Type:   mysql.COM_STMT_FETCH_RESPONSE,
+		},
+		Message: &mysql.StmtFetchResponse{
+			Rows: []*mysql.BinaryRow{{
+				Header:        mysql.Header{PayloadLength: 6, SequenceID: 1},
+				RowNullBuffer: []byte{0x00},
+				Values: []mysql.ColumnEntry{{
+					Type:  mysql.FieldTypeLong,
+					Name:  "id",
+					Value: value,
+				}},
+			}},
+			FinalResponse: &mysql.GenericResponse{
+				Type: mysql.StatusToString(mysql.EOF),
+				Data: []byte{0x05, 0x00, 0x00, 0x02, 0xfe, 0x00, 0x00, byte(finalStatus), byte(finalStatus >> 8)},
+			},
+		},
+	}}}
+	return mock
+}

--- a/pkg/agent/proxy/integrations/mysql/wire/decode.go
+++ b/pkg/agent/proxy/integrations/mysql/wire/decode.go
@@ -405,7 +405,16 @@ func decodePacket(ctx context.Context, logger *zap.Logger, packet mysql.Packet, 
 		setPacketInfo(ctx, parsedPacket, pkt, mysql.CommandStatusToString(mysql.COM_STMT_EXECUTE), clientConn, mysql.COM_STMT_EXECUTE, decodeCtx)
 		logger.Debug("COM_STMT_EXECUTE decoded", zap.Any("parsed packet", parsedPacket))
 
-	// case payloadType == mysql.COM_STMT_FETCH:
+	case payloadType == mysql.COM_STMT_FETCH:
+		logger.Debug("COM_STMT_FETCH packet", zap.Any("Type", payloadType))
+		pkt, err := preparedstmt.DecodeStmtFetch(ctx, logger, payload)
+		if err != nil {
+			return parsedPacket, fmt.Errorf("failed to decode COM_STMT_FETCH packet: %w", err)
+		}
+
+		setPacketInfo(ctx, parsedPacket, pkt, mysql.CommandStatusToString(mysql.COM_STMT_FETCH), clientConn, mysql.COM_STMT_FETCH, decodeCtx)
+		logger.Debug("COM_STMT_FETCH decoded", zap.Any("parsed packet", parsedPacket))
+
 	case payloadType == mysql.COM_STMT_CLOSE:
 		logger.Debug("COM_STMT_CLOSE packet", zap.Any("Type", payloadType))
 		pkt, err := preparedstmt.DecoderStmtClose(ctx, payload)

--- a/pkg/agent/proxy/integrations/mysql/wire/encode.go
+++ b/pkg/agent/proxy/integrations/mysql/wire/encode.go
@@ -19,6 +19,9 @@ func EncodeToBinary(ctx context.Context, logger *zap.Logger, packet *mysql.Packe
 	if packet == nil {
 		return nil, fmt.Errorf("packet is nil")
 	}
+	if packet.Header == nil {
+		return nil, fmt.Errorf("packet header is nil for message type %T", packet.Message)
+	}
 
 	var data []byte
 	var err error
@@ -145,12 +148,21 @@ func EncodeToBinary(ctx context.Context, logger *zap.Logger, packet *mysql.Packe
 		if err != nil {
 			return nil, fmt.Errorf("error encoding BinaryProtocolResultSet: %v", err)
 		}
+
+	case *mysql.StmtFetchResponse:
+		pkt, ok := packet.Message.(*mysql.StmtFetchResponse)
+		if !ok {
+			return nil, fmt.Errorf("expected StmtFetchResponse, got %T", packet.Message)
+		}
+
+		data, err = query.EncodeStmtFetchResponse(ctx, logger, pkt)
+		if err != nil {
+			return nil, fmt.Errorf("error encoding StmtFetchResponse: %w", err)
+		}
+		logger.Debug("Encoded Packet", zap.String("packet", packet.Header.Type), zap.ByteString("data", data))
+		return data, nil
 	default:
 		return nil, fmt.Errorf("unhandled mysql message type %T for encoding", packet.Message)
-	}
-
-	if packet.Header == nil {
-		return nil, fmt.Errorf("packet header is nil for message type %T", packet.Message)
 	}
 
 	// Encode the header for the packet

--- a/pkg/agent/proxy/integrations/mysql/wire/phase/query/preparedstmt/stmtFetchPacket_test.go
+++ b/pkg/agent/proxy/integrations/mysql/wire/phase/query/preparedstmt/stmtFetchPacket_test.go
@@ -1,0 +1,52 @@
+package preparedstmt
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.keploy.io/server/v3/pkg/models/mysql"
+	"go.uber.org/zap"
+)
+
+func TestDecodeStmtFetch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		data    []byte
+		want    *mysql.StmtFetchPacket
+		wantErr string
+	}{
+		{
+			name: "valid packet",
+			data: []byte{0x1c, 0x78, 0x56, 0x34, 0x12, 0x20, 0x00, 0x00, 0x00},
+			want: &mysql.StmtFetchPacket{
+				Status:      0x1c,
+				StatementID: 0x12345678,
+				NumRows:     32,
+			},
+		},
+		{
+			name:    "truncated packet",
+			data:    []byte{0x1c, 0x01, 0x00, 0x00, 0x00},
+			wantErr: "data too short for COM_STMT_FETCH",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := DecodeStmtFetch(context.Background(), zap.NewNop(), tt.data)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/agent/proxy/integrations/mysql/wire/phase/query/stmtFetchResponse.go
+++ b/pkg/agent/proxy/integrations/mysql/wire/phase/query/stmtFetchResponse.go
@@ -1,0 +1,59 @@
+package query
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/wire/phase/query/rowscols"
+	"go.keploy.io/server/v3/pkg/models/mysql"
+	"go.uber.org/zap"
+)
+
+// EncodeStmtFetchResponse encodes the row-only response to COM_STMT_FETCH.
+func EncodeStmtFetchResponse(ctx context.Context, logger *zap.Logger, response *mysql.StmtFetchResponse) ([]byte, error) {
+	if response == nil {
+		return nil, fmt.Errorf("encode COM_STMT_FETCH response: response is nil")
+	}
+	if response.FinalResponse == nil || len(response.FinalResponse.Data) == 0 {
+		return nil, fmt.Errorf("encode COM_STMT_FETCH response: final response is missing")
+	}
+
+	var out bytes.Buffer
+	for i, row := range response.Rows {
+		columns, err := columnsFromBinaryRow(row)
+		if err != nil {
+			return nil, fmt.Errorf("encode COM_STMT_FETCH row %d: %w", i, err)
+		}
+		packet, err := rowscols.EncodeBinaryRow(ctx, logger, row, columns)
+		if err != nil {
+			return nil, fmt.Errorf("encode COM_STMT_FETCH row %d: %w", i, err)
+		}
+		if _, err := out.Write(packet); err != nil {
+			return nil, fmt.Errorf("write COM_STMT_FETCH row %d: %w", i, err)
+		}
+	}
+	if _, err := out.Write(response.FinalResponse.Data); err != nil {
+		return nil, fmt.Errorf("write COM_STMT_FETCH final response: %w", err)
+	}
+	return out.Bytes(), nil
+}
+
+func columnsFromBinaryRow(row *mysql.BinaryRow) ([]*mysql.ColumnDefinition41, error) {
+	if row == nil {
+		return nil, fmt.Errorf("row is nil")
+	}
+	columns := make([]*mysql.ColumnDefinition41, len(row.Values))
+	for i, value := range row.Values {
+		flags := uint16(0)
+		if value.Unsigned {
+			flags = mysql.UNSIGNED_FLAG
+		}
+		columns[i] = &mysql.ColumnDefinition41{
+			Name:  value.Name,
+			Type:  byte(value.Type),
+			Flags: flags,
+		}
+	}
+	return columns, nil
+}

--- a/pkg/agent/proxy/integrations/mysql/wire/phase/query/stmtFetchResponse_test.go
+++ b/pkg/agent/proxy/integrations/mysql/wire/phase/query/stmtFetchResponse_test.go
@@ -1,0 +1,60 @@
+package query
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.keploy.io/server/v3/pkg/models/mysql"
+	"go.uber.org/zap"
+)
+
+func TestEncodeStmtFetchResponsePreservesRowOnlyFraming(t *testing.T) {
+	t.Parallel()
+
+	response := &mysql.StmtFetchResponse{
+		Rows: []*mysql.BinaryRow{
+			{
+				Header:        mysql.Header{SequenceID: 1},
+				RowNullBuffer: []byte{0x00},
+				Values: []mysql.ColumnEntry{{
+					Type:  mysql.FieldTypeVarString,
+					Name:  "name",
+					Value: "seven",
+				}},
+			},
+			{
+				Header:        mysql.Header{SequenceID: 2},
+				RowNullBuffer: []byte{0x00},
+				Values: []mysql.ColumnEntry{{
+					Type:  mysql.FieldTypeVarString,
+					Name:  "name",
+					Value: "eight",
+				}},
+			},
+		},
+		FinalResponse: &mysql.GenericResponse{
+			Type: mysql.StatusToString(mysql.EOF),
+			Data: []byte{0x05, 0x00, 0x00, 0x03, 0xfe, 0x00, 0x00, 0x82, 0x00},
+		},
+	}
+
+	got, err := EncodeStmtFetchResponse(context.Background(), zap.NewNop(), response)
+	require.NoError(t, err)
+
+	// COM_STMT_FETCH returns binary rows directly. There is no column-count or
+	// column-definition prefix because those were sent by COM_STMT_EXECUTE.
+	want := []byte{
+		0x08, 0x00, 0x00, 0x01, 0x00, 0x00, 0x05, 's', 'e', 'v', 'e', 'n',
+		0x08, 0x00, 0x00, 0x02, 0x00, 0x00, 0x05, 'e', 'i', 'g', 'h', 't',
+		0x05, 0x00, 0x00, 0x03, 0xfe, 0x00, 0x00, 0x82, 0x00,
+	}
+	require.Equal(t, want, got)
+}
+
+func TestEncodeStmtFetchResponseRequiresTerminator(t *testing.T) {
+	t.Parallel()
+
+	_, err := EncodeStmtFetchResponse(context.Background(), zap.NewNop(), &mysql.StmtFetchResponse{})
+	require.EqualError(t, err, "encode COM_STMT_FETCH response: final response is missing")
+}

--- a/pkg/models/mysql/comm.go
+++ b/pkg/models/mysql/comm.go
@@ -45,6 +45,14 @@ type BinaryProtocolResultSet struct {
 	FinalResponse   *GenericResponse      `yaml:"FinalResponse" json:"FinalResponse"`
 }
 
+// StmtFetchResponse contains the binary rows returned by COM_STMT_FETCH.
+// Column metadata is omitted because COM_STMT_EXECUTE sends it when opening
+// the cursor; every row retains the field types needed for replay encoding.
+type StmtFetchResponse struct {
+	Rows          []*BinaryRow     `yaml:"rows" json:"rows"`
+	FinalResponse *GenericResponse `yaml:"FinalResponse" json:"FinalResponse"`
+}
+
 type GenericResponse struct {
 	Data []byte `yaml:"data" json:"data"`
 	Type string `yaml:"type" json:"type"`
@@ -142,8 +150,7 @@ type Parameter struct {
 	Value    any    `yaml:"value" json:"value"`
 }
 
-// COM_STMT_FETCH packet is not currently supported because its response involves multi-resultset
-
+// StmtFetchPacket requests the next row batch from a prepared-statement cursor.
 type StmtFetchPacket struct {
 	Status      byte   `yaml:"status" json:"status"`
 	StatementID uint32 `yaml:"statement_id" json:"statement_id"`

--- a/pkg/models/mysql/const.go
+++ b/pkg/models/mysql/const.go
@@ -20,9 +20,10 @@ const (
 
 // Some constants for MySQL
 const (
-	HandshakeResponse41 = "HandshakeResponse41"
-	SSLRequest          = "SSLRequest"
-	COM_STMT_PREPARE_OK = "COM_STMT_PREPARE_OK"
+	HandshakeResponse41     = "HandshakeResponse41"
+	SSLRequest              = "SSLRequest"
+	COM_STMT_PREPARE_OK     = "COM_STMT_PREPARE_OK"
+	COM_STMT_FETCH_RESPONSE = "COM_STMT_FETCH_RESPONSE"
 )
 
 type CachingSha2Password byte
@@ -171,10 +172,10 @@ const (
 
 // Command Packet Status
 const (
-	COM_QUERY        byte = 0x03
-	COM_STMT_PREPARE byte = 0x16
-	COM_STMT_EXECUTE byte = 0x17
-	// COM_STMT_FETCH          byte = 0x19
+	COM_QUERY               byte = 0x03
+	COM_STMT_PREPARE        byte = 0x16
+	COM_STMT_EXECUTE        byte = 0x17
+	COM_STMT_FETCH          byte = 0x1c
 	COM_STMT_CLOSE          byte = 0x19
 	COM_STMT_RESET          byte = 0x1a
 	COM_STMT_SEND_LONG_DATA byte = 0x18
@@ -219,10 +220,10 @@ var commandStatusToString = map[byte]string{
 	COM_RESET_CONNECTION: "COM_RESET_CONNECTION",
 	// COM_SET_OPTION:       "COM_SET_OPTION",
 	// command
-	COM_QUERY:        "COM_QUERY",
-	COM_STMT_PREPARE: "COM_STMT_PREPARE",
-	COM_STMT_EXECUTE: "COM_STMT_EXECUTE",
-	// COM_STMT_FETCH:          "COM_STMT_FETCH",
+	COM_QUERY:               "COM_QUERY",
+	COM_STMT_PREPARE:        "COM_STMT_PREPARE",
+	COM_STMT_EXECUTE:        "COM_STMT_EXECUTE",
+	COM_STMT_FETCH:          "COM_STMT_FETCH",
 	COM_STMT_CLOSE:          "COM_STMT_CLOSE",
 	COM_STMT_RESET:          "COM_STMT_RESET",
 	COM_STMT_SEND_LONG_DATA: "COM_STMT_SEND_LONG_DATA",

--- a/pkg/models/mysql/mysql.go
+++ b/pkg/models/mysql/mysql.go
@@ -78,6 +78,7 @@ func init() {
 	gob.Register(&LocalInFileRequestPacket{})
 	gob.Register(&TextResultSet{})
 	gob.Register(&BinaryProtocolResultSet{})
+	gob.Register(&StmtFetchResponse{})
 	gob.Register(&GenericResponse{})
 	gob.Register(&ColumnCount{})
 	gob.Register(&ColumnDefinition41{})

--- a/pkg/platform/yaml/mockdb/mysql_stmt_fetch_test.go
+++ b/pkg/platform/yaml/mockdb/mysql_stmt_fetch_test.go
@@ -1,0 +1,77 @@
+package mockdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.keploy.io/server/v3/pkg/models/mysql"
+	"go.keploy.io/server/v3/pkg/platform/yaml"
+	"go.uber.org/zap"
+)
+
+func TestMySQLStmtFetchRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	mock := &models.Mock{Name: "stmt-fetch", Kind: models.MySQL}
+	mock.Spec.Metadata = map[string]string{"type": "mocks"}
+	mock.Spec.MySQLRequests = []mysql.Request{{PacketBundle: mysql.PacketBundle{
+		Header: &mysql.PacketInfo{
+			Header: &mysql.Header{PayloadLength: 9},
+			Type:   mysql.CommandStatusToString(mysql.COM_STMT_FETCH),
+		},
+		Message: &mysql.StmtFetchPacket{Status: mysql.COM_STMT_FETCH, StatementID: 4, NumRows: 2},
+	}}}
+	mock.Spec.MySQLResponses = []mysql.Response{{PacketBundle: mysql.PacketBundle{
+		Header: &mysql.PacketInfo{
+			Header: &mysql.Header{PayloadLength: 6, SequenceID: 1},
+			Type:   mysql.COM_STMT_FETCH_RESPONSE,
+		},
+		Message: &mysql.StmtFetchResponse{
+			Rows: []*mysql.BinaryRow{{
+				Header:        mysql.Header{PayloadLength: 6, SequenceID: 1},
+				RowNullBuffer: []byte{0},
+				Values:        []mysql.ColumnEntry{{Type: mysql.FieldTypeLong, Name: "id", Value: int32(7)}},
+			}},
+			FinalResponse: &mysql.GenericResponse{
+				Type: mysql.StatusToString(mysql.EOF),
+				Data: []byte{0x05, 0x00, 0x00, 0x02, 0xfe, 0x00, 0x00, 0x82, 0x00},
+			},
+		},
+	}}}
+
+	t.Run("yaml", func(t *testing.T) {
+		doc, err := EncodeMock(mock, zap.NewNop())
+		require.NoError(t, err)
+		got, err := DecodeMocks([]*yaml.NetworkTrafficDoc{doc}, zap.NewNop())
+		require.NoError(t, err)
+		assertStmtFetchRoundTrip(t, got)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		doc, ok, err := EncodeMockJSON(mock, zap.NewNop())
+		require.NoError(t, err)
+		require.True(t, ok)
+		got, err := DecodeMocksJSON([]*yaml.NetworkTrafficDocJSON{doc}, zap.NewNop())
+		require.NoError(t, err)
+		assertStmtFetchRoundTrip(t, got)
+	})
+}
+
+func assertStmtFetchRoundTrip(t *testing.T, mocks []*models.Mock) {
+	t.Helper()
+	require.Len(t, mocks, 1)
+	require.Len(t, mocks[0].Spec.MySQLRequests, 1)
+	require.Len(t, mocks[0].Spec.MySQLResponses, 1)
+
+	req, ok := mocks[0].Spec.MySQLRequests[0].Message.(*mysql.StmtFetchPacket)
+	require.Truef(t, ok, "request type = %T", mocks[0].Spec.MySQLRequests[0].Message)
+	require.Equal(t, uint32(4), req.StatementID)
+	require.Equal(t, uint32(2), req.NumRows)
+
+	resp, ok := mocks[0].Spec.MySQLResponses[0].Message.(*mysql.StmtFetchResponse)
+	require.Truef(t, ok, "response type = %T", mocks[0].Spec.MySQLResponses[0].Message)
+	require.Len(t, resp.Rows, 1)
+	require.EqualValues(t, 7, resp.Rows[0].Values[0].Value)
+	require.Equal(t, []byte{0x05, 0x00, 0x00, 0x02, 0xfe, 0x00, 0x00, 0x82, 0x00}, resp.FinalResponse.Data)
+}

--- a/pkg/platform/yaml/mockdb/util.go
+++ b/pkg/platform/yaml/mockdb/util.go
@@ -1052,7 +1052,14 @@ func decodeMySQLMessage(_ context.Context, logger *zap.Logger, yamlSpec *mysql.S
 			}
 			req.Message = msg
 
-		// case mysql.CommandStatusToString(mysql.COM_FETCH): // not supported yet
+		case mysql.CommandStatusToString(mysql.COM_STMT_FETCH):
+			msg := &mysql.StmtFetchPacket{}
+			err := v.Message.Decode(msg)
+			if err != nil {
+				utils.LogError(logger, err, "failed to unmarshal yaml document into mysql StmtFetchPacket")
+				return nil, err
+			}
+			req.Message = msg
 
 		case mysql.CommandStatusToString(mysql.COM_STMT_CLOSE):
 			msg := &mysql.StmtClosePacket{}
@@ -1188,6 +1195,15 @@ func decodeMySQLMessage(_ context.Context, logger *zap.Logger, yamlSpec *mysql.S
 			err := v.Message.Decode(msg)
 			if err != nil {
 				utils.LogError(logger, err, "failed to unmarshal yml document into mysql BinaryProtocolResultSet")
+				return nil, err
+			}
+			resp.Message = msg
+
+		case mysql.COM_STMT_FETCH_RESPONSE:
+			msg := &mysql.StmtFetchResponse{}
+			err := v.Message.Decode(msg)
+			if err != nil {
+				utils.LogError(logger, err, "failed to unmarshal yml document into mysql StmtFetchResponse")
 				return nil, err
 			}
 			resp.Message = msg
@@ -1696,6 +1712,8 @@ func retypeMySQLRequest(header *mysql.PacketInfo, raw interface{}) (interface{},
 		target = &mysql.StmtPreparePacket{}
 	case mysql.CommandStatusToString(mysql.COM_STMT_EXECUTE):
 		target = &mysql.StmtExecutePacket{}
+	case mysql.CommandStatusToString(mysql.COM_STMT_FETCH):
+		target = &mysql.StmtFetchPacket{}
 	case mysql.CommandStatusToString(mysql.COM_STMT_CLOSE):
 		target = &mysql.StmtClosePacket{}
 	case mysql.CommandStatusToString(mysql.COM_STMT_RESET):
@@ -1741,6 +1759,8 @@ func retypeMySQLResponse(header *mysql.PacketInfo, raw interface{}) (interface{}
 		target = &mysql.TextResultSet{}
 	case string(mysql.Binary):
 		target = &mysql.BinaryProtocolResultSet{}
+	case mysql.COM_STMT_FETCH_RESPONSE:
+		target = &mysql.StmtFetchResponse{}
 	default:
 		return raw, nil
 	}


### PR DESCRIPTION
## Describe the changes that are made

- Decode `COM_STMT_FETCH` requests on the MySQL V2 path and record each row-only cursor response as a semantic batch.
- Retain prepared-statement column metadata for binary-row decoding, then clear cursor state on statement reset/close.
- Replay cursor batches without re-sending result-set metadata and match runtime statement IDs through their prepared SQL in FIFO order.
- Preserve the new request/response types through YAML, JSON, and gob serialization.

## Links & References

**Closes:** #4261

### Related PRs

- NA

### Related Issues

- #4261

### Related Documents

- [MySQL COM_STMT_FETCH protocol](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_stmt_fetch.html)
- [MySQL cursor execution protocol](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_stmt_execute.html)

## What type of PR is this? (check all applicable)

- [ ] Chore
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [x] Test
- [ ] CI
- [ ] Revert

## Added e2e test pipeline?

- [ ] yes
- [x] no, because the requested scope is the V2 parser; regression coverage uses the V2 supervisor harness and a live V2 validation run
- [ ] no, because I need help

## Added comments for hard-to-understand areas?

- [x] yes
- [ ] no, because the code is self-explanatory

## Added to documentation?

- [ ] README.md
- [ ] Wiki
- [x] no documentation needed

## Are there any sample code or steps to test the changes?

- [x] yes, mentioned below
- [ ] no, because it is not needed

Automated checks:

```bash
go test ./pkg/agent/proxy/integrations/mysql/... -count=1
go test ./pkg/platform/yaml/mockdb -run TestMySQLStmtFetchRoundTrip -count=1
go test ./pkg/models/mysql -count=1
go build -tags=viper_bind_struct .
golangci-lint run
```

Linux/amd64 race validation with Go 1.27.0:

```bash
go test -race ./pkg/agent/proxy/integrations/mysql/... -count=1
CGO_ENABLED=1 go build -race -tags=viper_bind_struct .
```

Live validation used Spring Boot 3.2.5, Connector/J with `useServerPrepStmts=true&useCursorFetch=true`, fetch size 2, and TiDB v8.5.6. Recording produced three fetch batches containing `[1,2]`, `[3,4]`, and `[5]`; their terminators retained `SERVER_STATUS_CURSOR_EXISTS` and `SERVER_STATUS_LAST_ROW_SENT`. TiDB was then stopped before replay. The same endpoint returned `{"fetchSize":2,"rows":[1,2,3,4,5]}` and the Keploy report passed.

The existing MySQL session was routed through the V2 supervisor only in the local validation build; that routing change is intentionally excluded from this V2-scoped patch.

## Self Review done?

- [x] yes
- [ ] no, because I need help

## Any relevant screenshots, recordings or logs?

- NA

## Additional checklist

- [x] Have you read the Contributing Guidelines on issues?
- [x] Have you followed the PR Semantics guide for naming this PR?
- [x] Have you followed the Branch Semantics guide for naming your branch?
