### PR TITLE
Test-Postgres

### DIFF
--- a/pkg/models/mock.go
+++ b/pkg/models/mock.go
@@ -544,6 +544,11 @@ func (q PostgresV3QuerySpec) MarshalYAML() (any, error) {
 	}, nil
 }
 
+// PostgresV3Response is one backend response bundle for a Query
+// invocation. Its payload axes (Rows, CopyOut, CopyIn, FunctionCall)
+// are mutually exclusive per the PG wire protocol; the struct tags
+// cannot express that, so the invariant is enforced by
+// Validate() in postgres_v3_response_validate.go.
 type PostgresV3Response struct {
 	RowDescription []PostgresV3ColumnDescriptor `json:"rowDescription,omitempty" yaml:"rowDescription,omitempty" bson:"row_description,omitempty"`
 	// Rows stores each row as a []PostgresV3Cell via PostgresV3Cells.

--- a/pkg/models/mock_test.go
+++ b/pkg/models/mock_test.go
@@ -2,7 +2,9 @@ package models
 
 import (
 	"bytes"
+	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	yamlLib "gopkg.in/yaml.v3"
@@ -258,22 +260,79 @@ func TestPostgresV3Response_CopyIn_RoundTrip(t *testing.T) {
 	// Serialization-stability check. The fixture set only CopyIn, so
 	// omitempty on Rows and CopyOut should keep both out of the
 	// emitted YAML and the re-decoded struct zero on those paths.
-	// This is NOT a schema-level mutual-exclusion guard — nothing in
-	// the struct today stops a caller from populating Rows + CopyIn
-	// simultaneously and marshaling that malformed shape. Enforcing
-	// the wire-level invariant (CopyIn and row-producing traffic
-	// never coexist on the same Query response) is the recorder's
-	// job in integrations; a misbehaving recorder would emit an
-	// invalid mock and this test would still pass. See the
-	// TODO(validation) below if we ever add struct-level validation.
+	// This is a serialization assertion, not the mutual-exclusion
+	// guard: the wire-level invariant (CopyIn and row-producing
+	// traffic never coexist on the same Query response) is enforced
+	// by PostgresV3Response.Validate(), exercised below in
+	// TestPostgresV3Response_RowsAndCopyIn_ValidateRejects.
 	if decoded.Rows != nil {
 		t.Fatalf("Rows: omitempty should have kept this nil on the CopyIn-only fixture, got %v", decoded.Rows)
 	}
 	if decoded.CopyOut != nil {
 		t.Fatalf("CopyOut: omitempty should have kept this nil on the CopyIn-only fixture, got %+v", decoded.CopyOut)
 	}
-	// TODO(validation): once a Validate() method or a custom
-	// UnmarshalYAML lands on PostgresV3Response, add a separate test
-	// that feeds a malformed fixture carrying BOTH Rows and CopyIn
-	// and asserts the validator rejects it.
+}
+
+// TestPostgresV3Response_RowsAndCopyIn_ValidateRejects feeds a
+// malformed on-disk fixture that carries BOTH `rows:` and `copyIn:`
+// on the same Query response and asserts PostgresV3Response.Validate()
+// rejects it.
+//
+// The shape is malformed per the PG wire protocol: a backend either
+// streams DataRow traffic ('D' rows terminated by CommandComplete) or
+// hands the conversation over to the client with CopyInResponse ('G')
+// — never both on one response. Nothing in the YAML layer stops such
+// a fixture from parsing (there is no custom UnmarshalYAML on
+// PostgresV3Response), so a hand-edited mock or a buggy recorder can
+// produce it; Validate() is the load-time guard that catches it before
+// the replay emitter silently picks one axis and drops the other.
+func TestPostgresV3Response_RowsAndCopyIn_ValidateRejects(t *testing.T) {
+	// Hand-written rather than Go-marshalled so the test exercises the
+	// real loader path a malformed mocks.yaml would arrive through.
+	const malformed = `
+rows:
+  - - "1"
+  - - "2"
+commandComplete: "SELECT 2"
+copyIn:
+  overallFormat: 0
+  columnFormatCodes: [0]
+`
+
+	var resp PostgresV3Response
+	if err := yamlLib.Unmarshal([]byte(malformed), &resp); err != nil {
+		t.Fatalf("yaml.Unmarshal of malformed fixture returned error: %v — "+
+			"the fixture must parse cleanly for Validate() to be the "+
+			"layer under test", err)
+	}
+	// Sanity-check the premise: both axes really are populated after
+	// the parse, otherwise the assertion below proves nothing.
+	if len(resp.Rows) != 2 {
+		t.Fatalf("Rows: want 2 rows from the malformed fixture, got %d", len(resp.Rows))
+	}
+	if resp.CopyIn == nil {
+		t.Fatalf("CopyIn: want non-nil from the malformed fixture, got nil")
+	}
+
+	err := resp.Validate()
+	if err == nil {
+		t.Fatalf("Validate(): want non-nil error on a response carrying " +
+			"both Rows and CopyIn, got nil")
+	}
+	if !errors.Is(err, ErrPostgresV3ResponseInvalid) {
+		t.Fatalf("Validate() error should wrap ErrPostgresV3ResponseInvalid, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Rows") || !strings.Contains(err.Error(), "CopyIn") {
+		t.Fatalf("Validate() error should name both colliding axes, got: %v", err)
+	}
+
+	// The CopyIn-only counterpart of the same fixture must still pass —
+	// Validate() rejects the collision, not the CopyIn axis itself.
+	valid := PostgresV3Response{
+		CommandComplete: "COPY 10",
+		CopyIn:          resp.CopyIn,
+	}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("Validate() returned %v on a CopyIn-only response — false positive", err)
+	}
 }


### PR DESCRIPTION
## Describe the changes that are made

- Added `TestPostgresV3Response_RowsAndCopyIn_ValidateRejects` in `pkg/models/mock_test.go`. It unmarshals a hand-written malformed YAML fixture that carries **both** `rows:` and `copyIn:` on the same Query response (hand-written rather than Go-marshalled, so the test exercises the real loader path a bad `mocks.yaml` would arrive through), sanity-checks that both axes survived the parse, and asserts `PostgresV3Response.Validate()` rejects it — returning an error that wraps `ErrPostgresV3ResponseInvalid` and names both colliding axes. The test closes with the CopyIn-only counterpart of the same fixture to prove `Validate()` rejects the *collision*, not the CopyIn axis itself (no false positives).
- Replaced the now-stale comment block in `TestPostgresV3Response_CopyIn_RoundTrip` that claimed "nothing in the struct today stops a caller from populating Rows + CopyIn", along with the open `TODO(validation)` it pointed at. Both are obsolete: `PostgresV3Response.Validate()` exists in `pkg/models/postgres_v3_response_validate.go` and enforces the invariant. The comment now points at the validator and at the new test.
- Added a doc comment on the `PostgresV3Response` type in `pkg/models/mock.go` recording that its payload axes (`Rows`, `CopyOut`, `CopyIn`, `FunctionCall`) are mutually exclusive per the PG wire protocol, that struct tags cannot express that, and where the enforcement lives — so a reader of `mock.go` finds `Validate()` without grepping.

**Note on scope:** `PostgresV3Response.Validate()` was already present and committed in this repo before this PR, in `pkg/models/postgres_v3_response_validate.go`. It already enforces the full documented mutual-exclusion set (Rows / CopyOut / CopyIn / FunctionCall), reports every colliding pair in one error, and treats `Error`, `Notices` and `Notifications` as orthogonal. The gap this PR closes is the second half of the issue: the `mock_test.go` test asserting the Rows + CopyIn case, and the stale comments claiming no guard exists.

**Known gap, not addressed here:** `Validate()` has no production caller — only tests invoke it. A malformed mock still loads silently on the replay path. The intended wiring site is named in `postgres_v3_response_validate_test.go` (`index_loader.go::convertQuery`, integrations side). Happy to follow up in a separate PR.

## Links & References

**Closes:** #4492

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [ ] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed — this is a pure unit-level schema assertion in `pkg/models`; it touches no record/replay runtime path.
- [ ] 🙋 no, because I need help

## Added comments for hard-to-understand areas?
- [x] 👍 yes — the new test carries a doc comment explaining *why* the shape is malformed per the PG wire protocol ('D' DataRow traffic vs. 'G' CopyInResponse never coexist), and why `Validate()` rather than the YAML layer is the guard.
- [ ] 🙅 no, because the code is self-explanatory

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

```bash
# Full package suite
go test ./pkg/models/...

# Just the new test
go test ./pkg/models/ -run 'TestPostgresV3Response_RowsAndCopyIn_ValidateRejects' -v