### PR TITLE
feat(record): carry static-dedup schema key and cross-pod duplicate mark on test cases

### DIFF
--- a/pkg/agent/hooks/conn/util.go
+++ b/pkg/agent/hooks/conn/util.go
@@ -58,9 +58,14 @@ type CaptureFunc func(ctx context.Context, logger *zap.Logger, t chan *models.Te
 var CaptureHook CaptureFunc = Capture
 
 // GRPCCaptureHook is called in CaptureGRPC before a test case is built.
-// Returns true if the request is a duplicate and should be dropped.
-// Enterprise sets this when --static-dedup is enabled; nil means no dedup.
-var GRPCCaptureHook func(req *models.GrpcReq, resp *models.GrpcResp) bool
+// isDuplicate reports whether the pair repeats an already-captured schema and
+// should be dropped; schemaKey is the canonical static-dedup fingerprint of
+// the pair, stamped onto the kept test case (TestCase.SchemaKey) so the
+// control plane can additionally mark duplicates across pods of a recording.
+// An empty schemaKey means "no fingerprint" and disables cross-pod judgement
+// for this test case. Enterprise sets this when --static-dedup is enabled;
+// nil means no dedup.
+var GRPCCaptureHook func(req *models.GrpcReq, resp *models.GrpcResp) (isDuplicate bool, schemaKey string)
 
 // MaxTestCaseSize is the maximum combined size of HTTP/gRPC request and response (5MB)
 const MaxTestCaseSize = 5 * 1024 * 1024 // 5 MB
@@ -451,8 +456,9 @@ func ExtractFormData(logger *zap.Logger, body []byte, contentType string) []mode
 
 // CaptureGRPC captures a gRPC request/response pair and sends it to the test case channel.
 // Mirrors NewCapture (HTTP) exactly:
-//   - GRPCCaptureHook is evaluated as a boolean so ResolveRange always runs,
-//     even for duplicates (with keep=false to flush their mocks cleanly).
+//   - GRPCCaptureHook is invoked unconditionally before ResolveRange, so
+//     ResolveRange always runs — even for duplicates (with keep=false to flush
+//     their mocks cleanly).
 //   - Counter is always incremented so concurrent duplicate streams each get a
 //     unique window name; keep=false discards their mocks without saving the TC.
 //   - Duplicate streams return after ResolveRange, before the test case is sent.
@@ -472,7 +478,11 @@ func CaptureGRPC(ctx context.Context, logger *zap.Logger, t chan *models.TestCas
 	}
 
 	testName := http2Stream.GRPCReq.Headers.OrdinaryHeaders["Keploy-Test-Name"]
-	isDuplicate := GRPCCaptureHook != nil && GRPCCaptureHook(http2Stream.GRPCReq, http2Stream.GRPCResp)
+	var isDuplicate bool
+	var schemaKey string
+	if GRPCCaptureHook != nil {
+		isDuplicate, schemaKey = GRPCCaptureHook(http2Stream.GRPCReq, http2Stream.GRPCResp)
+	}
 
 	// Bin buffered outgoing mocks into this stream's window before any early
 	// return. For non-duplicates keep=true attributes the mocks; for duplicates
@@ -516,6 +526,7 @@ func CaptureGRPC(ctx context.Context, logger *zap.Logger, t chan *models.TestCas
 		Kind:      models.GRPC_EXPORT,
 		Created:   time.Now().Unix(),
 		SourcePod: SourcePodFromContext(ctx),
+		SchemaKey: schemaKey,
 		GrpcReq:   *http2Stream.GRPCReq,
 		GrpcResp:  *http2Stream.GRPCResp,
 		Noise:     map[string][]string{},

--- a/pkg/agent/hooks/conn/util_test.go
+++ b/pkg/agent/hooks/conn/util_test.go
@@ -231,3 +231,61 @@ func TestIsFiltered_FilterPolicy(t *testing.T) {
 		})
 	}
 }
+
+// TestCaptureGRPC_SchemaKeyStamping pins the GRPCCaptureHook contract: the
+// hook's schemaKey return is stamped onto the kept test case (so the control
+// plane can mark cross-pod duplicates), a duplicate verdict still drops the
+// capture, and with no hook installed the schema key stays empty.
+func TestCaptureGRPC_SchemaKeyStamping(t *testing.T) {
+	origHook := GRPCCaptureHook
+	defer func() { GRPCCaptureHook = origHook }()
+
+	newStream := func() *pkg.HTTP2Stream {
+		return &pkg.HTTP2Stream{
+			GRPCReq:  &models.GrpcReq{},
+			GRPCResp: &models.GrpcResp{},
+		}
+	}
+	const key = "GRPC|/svc.Users/Get|0|11|22"
+
+	t.Run("hook stamps schema key on kept test case", func(t *testing.T) {
+		GRPCCaptureHook = func(_ *models.GrpcReq, _ *models.GrpcResp) (bool, string) {
+			return false, key
+		}
+		tChan := make(chan *models.TestCase, 1)
+		CaptureGRPC(context.Background(), zap.NewNop(), tChan, newStream(), 9090, false, false)
+		select {
+		case tc := <-tChan:
+			if tc.SchemaKey != key {
+				t.Fatalf("SchemaKey = %q, want %q", tc.SchemaKey, key)
+			}
+		default:
+			t.Fatal("expected a captured test case")
+		}
+	})
+
+	t.Run("duplicate verdict drops the capture", func(t *testing.T) {
+		GRPCCaptureHook = func(_ *models.GrpcReq, _ *models.GrpcResp) (bool, string) {
+			return true, key
+		}
+		tChan := make(chan *models.TestCase, 1)
+		CaptureGRPC(context.Background(), zap.NewNop(), tChan, newStream(), 9090, false, false)
+		if len(tChan) != 0 {
+			t.Fatal("duplicate must not emit a test case")
+		}
+	})
+
+	t.Run("nil hook leaves schema key empty", func(t *testing.T) {
+		GRPCCaptureHook = nil
+		tChan := make(chan *models.TestCase, 1)
+		CaptureGRPC(context.Background(), zap.NewNop(), tChan, newStream(), 9090, false, false)
+		select {
+		case tc := <-tChan:
+			if tc.SchemaKey != "" {
+				t.Fatalf("SchemaKey = %q, want empty with no hook", tc.SchemaKey)
+			}
+		default:
+			t.Fatal("expected a captured test case")
+		}
+	})
+}

--- a/pkg/models/testcase.go
+++ b/pkg/models/testcase.go
@@ -69,6 +69,21 @@ type TestCase struct {
 	// control plane. json/yaml/bson "-" so it never lands in stored test-case
 	// files or the upload body.
 	SourcePod string `json:"-" yaml:"-" bson:"-"`
+	// SchemaKey is the canonical static-dedup fingerprint of this test case,
+	// stamped by the enterprise capture hook when cross-pod dedup is on. It
+	// rides only the agent→control-plane upload (JSON) so the recording owner
+	// can detect duplicates across pods; yaml/bson "-" keeps it out of stored
+	// test-case files and backend rows. Empty when static dedup is off or the
+	// fingerprint could not be computed — consumers must treat empty as
+	// "cannot judge", never as "unique".
+	SchemaKey string `json:"schema_key,omitempty" yaml:"-" bson:"-"`
+	// DuplicateOf marks this test case as a cross-pod duplicate within its
+	// recording: "<test-set>/<test-name>@<pod>" of the first-stored copy
+	// (pod-only ref while the winner's name is still being assigned). Set by
+	// the recording owner, never by agents. Persisted — JSON/BSON here, YAML
+	// via the spec Metadata map — so the mark survives to storage and the UI.
+	// Empty means not a known duplicate.
+	DuplicateOf string `json:"duplicate_of,omitempty" bson:"duplicate_of,omitempty"`
 }
 
 func (tc *TestCase) GetKind() string {

--- a/pkg/models/testcase.go
+++ b/pkg/models/testcase.go
@@ -77,12 +77,21 @@ type TestCase struct {
 	// fingerprint could not be computed — consumers must treat empty as
 	// "cannot judge", never as "unique".
 	SchemaKey string `json:"schema_key,omitempty" yaml:"-" bson:"-"`
+	// SourceNode is a transient, never-persisted dedup-scope tag mirroring
+	// SourcePod: the node whose (node-scoped) DaemonSet deduper first counted
+	// this capture. The k8s-proxy control plane stamps it from the capture
+	// frame at ingest so its cross-pod dedup funnel can tell "this scope's
+	// own first copy" from "another scope's duplicate" — the scope must ride
+	// each capture, not be inferred from mutable registries. Never set by
+	// agents or on the wire ("-" everywhere).
+	SourceNode string `json:"-" yaml:"-" bson:"-"`
 	// DuplicateOf marks this test case as a cross-pod duplicate within its
-	// recording: "<test-set>/<test-name>@<pod>" of the first-stored copy
-	// (pod-only ref while the winner's name is still being assigned). Set by
-	// the recording owner, never by agents. Persisted — JSON/BSON here, YAML
-	// via the spec Metadata map — so the mark survives to storage and the UI.
-	// Empty means not a known duplicate.
+	// recording: "<test-set>/<test-name>" of the first-stored copy, or a
+	// scope-only ref ("pod:<p>" / "node:<n>") when the winner's identity was
+	// recovered from dedup-stat snapshots rather than a stored test case. Set
+	// by the recording owner, never by agents. Persisted — JSON/BSON here,
+	// YAML via the spec Metadata map — so the mark survives to storage and
+	// the UI. Empty means not a known duplicate.
 	DuplicateOf string `json:"duplicate_of,omitempty" bson:"duplicate_of,omitempty"`
 }
 

--- a/pkg/platform/yaml/testdb/util.go
+++ b/pkg/platform/yaml/testdb/util.go
@@ -57,16 +57,35 @@ func buildHTTPSchema(tc models.TestCase, logger *zap.Logger) models.HTTPSchema {
 			return a
 		}(),
 	}
-	if tc.Description != "" {
-		httpSchema.Metadata = map[string]string{"description": tc.Description}
-	}
+	httpSchema.Metadata = specMetadata(tc.Description, tc.DuplicateOf)
 	return httpSchema
+}
+
+// specMetadata builds the spec-level Metadata map carrying the fields that
+// persist through the spec rather than the doc: the user-facing description
+// and the cross-pod duplicate mark. Returns nil when there is nothing to
+// carry, so specs without metadata keep encoding byte-identically to before.
+// The gRPC encoders pass description="" — gRPC specs have never persisted a
+// description and that stays unchanged.
+func specMetadata(description, duplicateOf string) map[string]string {
+	if description == "" && duplicateOf == "" {
+		return nil
+	}
+	md := make(map[string]string, 2)
+	if description != "" {
+		md["description"] = description
+	}
+	if duplicateOf != "" {
+		md["duplicate_of"] = duplicateOf
+	}
+	return md
 }
 
 // buildGrpcSpec is the JSON-path counterpart of the gRPC branch in EncodeTestcase.
 func buildGrpcSpec(tc models.TestCase) models.GrpcSpec {
 	noise := tc.Noise
 	return models.GrpcSpec{
+		Metadata: specMetadata("", tc.DuplicateOf),
 		GrpcReq:  tc.GrpcReq,
 		GrpcResp: tc.GrpcResp,
 		Created:  tc.Created,
@@ -135,92 +154,21 @@ func EncodeTestcase(tc models.TestCase, logger *zap.Logger) (*yaml.NetworkTraffi
 		LastUpdated: tc.LastUpdated,
 	}
 
-	var noise map[string][]string
 	switch tc.Kind {
 	case models.HTTP:
 		logger.Debug("Encoding HTTP test case")
 		doc.Curl = tc.Curl
 
-		// find noisy fields only for HTTP responses
-		m, err := FlattenHTTPResponse(pkg.ToHTTPHeader(tc.HTTPResp.Header), tc.HTTPResp.Body)
-		if err != nil {
-			msg := "error in flattening http response"
-			utils.LogError(logger, err, msg)
-		}
-		noise = tc.Noise
-
-		noiseFieldsFound := FindNoisyFields(m, func(_ string, vals []string) bool {
-			// check if k is date
-			for _, v := range vals {
-				if pkg.IsTime(v) {
-					return true
-				}
-			}
-			// maybe we need to concatenate the values
-			return pkg.IsTime(strings.Join(vals, ", "))
-		})
-
-		for _, v := range noiseFieldsFound {
-			noise[v] = []string{}
-		}
-
-		httpSchema := models.HTTPSchema{
-			Request:  tc.HTTPReq,
-			Response: tc.HTTPResp,
-			Created:  tc.Created,
-			AppPort:  tc.AppPort,
-			// need to check here for type here as well as push in other custom assertions
-			Assertions: func() map[models.AssertionType]interface{} {
-				a := map[models.AssertionType]interface{}{}
-				for k, v := range tc.Assertions {
-					a[k] = v
-				}
-
-				if len(noise) > 0 {
-					a[models.NoiseAssertion] = noise
-				}
-
-				// Optionally add other custom assertions if needed here
-				// Example:
-				// a[models.StatusCode] = tc.HTTPResp.StatusCode
-
-				return a
-			}(),
-		}
-		if tc.Description != "" {
-			httpSchema.Metadata = map[string]string{
-				"description": tc.Description,
-			}
-		}
-		err = doc.Spec.Encode(httpSchema)
+		httpSchema := buildHTTPSchema(tc, logger)
+		err := doc.Spec.Encode(httpSchema)
 		if err != nil {
 			utils.LogError(logger, err, "failed to encode testcase into a yaml doc")
 			return nil, err
 		}
 	case models.GRPC_EXPORT:
 		logger.Debug("Encoding gRPC test case")
-		// For gRPC, use the noise directly from the test case
-		noise = tc.Noise
 
-		// Create a YAML node for the gRPC schema
-		grpcSpec := models.GrpcSpec{
-			GrpcReq:  tc.GrpcReq,
-			GrpcResp: tc.GrpcResp,
-			Created:  tc.Created,
-			AppPort:  tc.AppPort,
-			// need to check here for type here as well as push in other custom assertions
-			Assertions: func() map[models.AssertionType]interface{} {
-				a := map[models.AssertionType]interface{}{}
-				if len(noise) > 0 {
-					a[models.NoiseAssertion] = noise
-				}
-				// Optionally add other custom assertions if needed here
-				// Example:
-				// a[models.StatusCode] = tc.HTTPResp.StatusCode
-
-				return a
-			}(),
-		}
+		grpcSpec := buildGrpcSpec(tc)
 
 		logger.Debug("gRPC schema created",
 			zap.Any("request_headers", grpcSpec.GrpcReq.Headers),
@@ -420,6 +368,7 @@ func Decode(yamlTestcase *yaml.NetworkTrafficDoc, logger *zap.Logger) (*models.T
 		tc.HTTPReq = httpSpec.Request
 		tc.HTTPResp = httpSpec.Response
 		tc.Description = httpSpec.Metadata["description"]
+		tc.DuplicateOf = httpSpec.Metadata["duplicate_of"]
 		tc.AppPort = httpSpec.AppPort
 
 		// single map-based loop for all assertions
@@ -457,6 +406,7 @@ func Decode(yamlTestcase *yaml.NetworkTrafficDoc, logger *zap.Logger) (*models.T
 		tc.Created = grpcSpec.Created
 		tc.GrpcReq = grpcSpec.GrpcReq
 		tc.GrpcResp = grpcSpec.GrpcResp
+		tc.DuplicateOf = grpcSpec.Metadata["duplicate_of"]
 		tc.AppPort = grpcSpec.AppPort
 
 		for key, raw := range grpcSpec.Assertions {
@@ -519,6 +469,7 @@ func DecodeJSON(doc *yaml.NetworkTrafficDocJSON, logger *zap.Logger) (*models.Te
 		tc.HTTPReq = httpSpec.Request
 		tc.HTTPResp = httpSpec.Response
 		tc.Description = httpSpec.Metadata["description"]
+		tc.DuplicateOf = httpSpec.Metadata["duplicate_of"]
 		tc.AppPort = httpSpec.AppPort
 		expandAssertionsJSON(tc, httpSpec.Assertions)
 
@@ -531,6 +482,7 @@ func DecodeJSON(doc *yaml.NetworkTrafficDocJSON, logger *zap.Logger) (*models.Te
 		tc.Created = grpcSpec.Created
 		tc.GrpcReq = grpcSpec.GrpcReq
 		tc.GrpcResp = grpcSpec.GrpcResp
+		tc.DuplicateOf = grpcSpec.Metadata["duplicate_of"]
 		tc.AppPort = grpcSpec.AppPort
 		expandAssertionsJSON(tc, grpcSpec.Assertions)
 

--- a/pkg/platform/yaml/testdb/util_test.go
+++ b/pkg/platform/yaml/testdb/util_test.go
@@ -1,0 +1,165 @@
+package testdb
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+	yamlLib "gopkg.in/yaml.v3"
+)
+
+func httpTestCase() models.TestCase {
+	return models.TestCase{
+		Version: models.GetVersion(),
+		Kind:    models.HTTP,
+		Name:    "test-1",
+		HTTPReq: models.HTTPReq{Method: models.Method("GET"), URL: "http://example.com/users"},
+		HTTPResp: models.HTTPResp{
+			StatusCode: 200,
+			Body:       `{"ok":true}`,
+		},
+		Noise: map[string][]string{},
+	}
+}
+
+func grpcTestCase() models.TestCase {
+	return models.TestCase{
+		Version: models.GetVersion(),
+		Kind:    models.GRPC_EXPORT,
+		Name:    "test-1",
+		Noise:   map[string][]string{},
+	}
+}
+
+// TestDuplicateOfRoundTripYAML pins the cross-pod duplicate mark's persistence
+// through the YAML encode/decode pair for both testcase kinds. The mark rides
+// the spec Metadata map, so old readers (which only look up "description")
+// ignore it and old files (no metadata) decode to an empty mark.
+func TestDuplicateOfRoundTripYAML(t *testing.T) {
+	logger := zap.NewNop()
+
+	t.Run("http", func(t *testing.T) {
+		tc := httpTestCase()
+		tc.Description = "a described case"
+		tc.DuplicateOf = "test-set-0/test-3@pod-a"
+
+		doc, err := EncodeTestcase(tc, logger)
+		if err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+		got, err := Decode(doc, logger)
+		if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if got.DuplicateOf != tc.DuplicateOf {
+			t.Fatalf("DuplicateOf lost in yaml round-trip: got %q want %q", got.DuplicateOf, tc.DuplicateOf)
+		}
+		if got.Description != tc.Description {
+			t.Fatalf("Description must survive alongside the mark: got %q want %q", got.Description, tc.Description)
+		}
+	})
+
+	t.Run("grpc", func(t *testing.T) {
+		tc := grpcTestCase()
+		tc.DuplicateOf = "test-set-0/test-7@pod-b"
+
+		doc, err := EncodeTestcase(tc, logger)
+		if err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+		got, err := Decode(doc, logger)
+		if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if got.DuplicateOf != tc.DuplicateOf {
+			t.Fatalf("DuplicateOf lost in grpc yaml round-trip: got %q want %q", got.DuplicateOf, tc.DuplicateOf)
+		}
+	})
+}
+
+// TestDuplicateOfRoundTripJSON covers the JSON-native encoder/decoder pair
+// (the storage fast path) for both kinds.
+func TestDuplicateOfRoundTripJSON(t *testing.T) {
+	logger := zap.NewNop()
+
+	t.Run("http", func(t *testing.T) {
+		tc := httpTestCase()
+		tc.DuplicateOf = "test-set-0/test-3@pod-a"
+
+		doc, err := EncodeTestcaseJSON(tc, logger)
+		if err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+		got, err := DecodeJSON(doc, logger)
+		if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if got.DuplicateOf != tc.DuplicateOf {
+			t.Fatalf("DuplicateOf lost in json round-trip: got %q want %q", got.DuplicateOf, tc.DuplicateOf)
+		}
+	})
+
+	t.Run("grpc", func(t *testing.T) {
+		tc := grpcTestCase()
+		tc.DuplicateOf = "test-set-0/test-7@pod-b"
+
+		doc, err := EncodeTestcaseJSON(tc, logger)
+		if err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+		got, err := DecodeJSON(doc, logger)
+		if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if got.DuplicateOf != tc.DuplicateOf {
+			t.Fatalf("DuplicateOf lost in grpc json round-trip: got %q want %q", got.DuplicateOf, tc.DuplicateOf)
+		}
+	})
+}
+
+// TestSpecMetadataStaysAbsentWhenUnset pins byte-compatibility with existing
+// files: a testcase with neither description nor duplicate mark must encode a
+// nil Metadata map, exactly as before the mark existed.
+func TestSpecMetadataStaysAbsentWhenUnset(t *testing.T) {
+	if md := specMetadata("", ""); md != nil {
+		t.Fatalf("expected nil metadata for unset fields, got %v", md)
+	}
+	if schema := buildHTTPSchema(httpTestCase(), zap.NewNop()); schema.Metadata != nil {
+		t.Fatalf("unmarked http testcase must not grow a metadata map, got %v", schema.Metadata)
+	}
+	if spec := buildGrpcSpec(grpcTestCase()); spec.Metadata != nil {
+		t.Fatalf("unmarked grpc testcase must not grow a metadata map, got %v", spec.Metadata)
+	}
+}
+
+// TestDecodeIgnoresUnknownMetadataKeys pins the forward-compat contract: a
+// reader at this version decodes files whose metadata carries keys it does not
+// know without error, and an absent metadata map yields empty fields.
+func TestDecodeIgnoresUnknownMetadataKeys(t *testing.T) {
+	logger := zap.NewNop()
+
+	doc, err := EncodeTestcase(httpTestCase(), logger)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	// Splice a metadata map with only unknown keys into the spec node, the way
+	// a newer writer would.
+	var raw map[string]interface{}
+	if err := doc.Spec.Decode(&raw); err != nil {
+		t.Fatalf("spec to map: %v", err)
+	}
+	raw["metadata"] = map[string]string{"some_future_key": "x"}
+	var node yamlLib.Node
+	if err := node.Encode(raw); err != nil {
+		t.Fatalf("map to node: %v", err)
+	}
+	doc.Spec = node
+
+	got, err := Decode(doc, logger)
+	if err != nil {
+		t.Fatalf("decode with unknown metadata keys must not fail: %v", err)
+	}
+	if got.DuplicateOf != "" || got.Description != "" {
+		t.Fatalf("unknown keys must not bleed into fields: %+v", got)
+	}
+}


### PR DESCRIPTION
## Describe the changes that are made
- Groundwork for **cross-pod static dedup**: a recording spans many pods, but each agent's `SchemaDeduplicator` only sees its own pod (or node), so replicas each keep the first copy of the same schema. The control plane can mark those cross-pod duplicates at its ingest funnel — the one process every kept test case already flows through — if agents ship the schema fingerprint alongside each test case.
- `TestCase.SchemaKey` (json-only, `yaml/bson:"-"`): the canonical static-dedup fingerprint, stamped by the enterprise capture hook; rides the agent→control-plane upload, never persisted.
- `TestCase.DuplicateOf` (json+bson; YAML via the spec `Metadata` map): the control-plane-written mark naming the first-stored copy. Round-trips through all four encode/decode paths (YAML+JSON × HTTP+gRPC); old readers ignore the metadata key; old files decode to an empty mark.
- `GRPCCaptureHook` now returns `(isDuplicate, schemaKey)` so `CaptureGRPC` stamps gRPC test cases too. The only setter is the version-pinned enterprise repo, updated in lockstep.
- Refactor: `EncodeTestcase`'s HTTP/gRPC branches now delegate to `buildHTTPSchema`/`buildGrpcSpec` instead of duplicating them line-for-line. Output verified **byte-identical** against the pre-change encoder (rich unmarked HTTP+gRPC cases, diffed against a HEAD worktree).

## Links & References
**Closes:** NA (cross-repo feature; enterprise/k8s-proxy/api-server PRs pin this commit and follow)
### 🔗 Related PRs
- keploy/enterprise (agent stamping + config), keploy/k8s-proxy (ingest-funnel marking), keploy/api-server (manifest field) — opened alongside this PR
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [x] 🍕 Feature
- [x] ✅ Test

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed here — the model/serialization layer is pinned by round-trip unit tests; the e2e for the feature lands with the k8s-proxy/enterprise PRs that exercise the full path

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed (no user-visible OSS behavior change; fields are inert until the enterprise/k8s-proxy sides use them)

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
  - `go test ./pkg/platform/yaml/testdb/ ./pkg/agent/hooks/conn/ ./pkg/models/ -race -count=1`

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA
