### PR TITLE
fix(agent): report a slow BPF load at WARN, and reserve ERROR for a wedged one

### DIFF
--- a/pkg/agent/hooks/linux/hooks.go
+++ b/pkg/agent/hooks/linux/hooks.go
@@ -162,7 +162,7 @@ func (h *Hooks) load(ctx context.Context, opts agent.HookCfg, setupOpts config.A
 	// running across that would blame BPF_PROG_LOAD for whatever else was slow.
 	// The defer inside the closure keeps it from leaking if LoadAndAssign panics.
 	err = func() error {
-		stopStallWatch := watchStall(h.logger, "bpf(BPF_PROG_LOAD) via ebpf.CollectionSpec.LoadAndAssign", stallFirstReport, stallRepeatReport)
+		stopStallWatch := watchStall(h.logger, "bpf(BPF_PROG_LOAD) via ebpf.CollectionSpec.LoadAndAssign", stallFirstReport, stallRepeatReport, stallErrorAfter)
 		defer stopStallWatch()
 		return spec.LoadAndAssign(&objs, bpfopts)
 	}()

--- a/pkg/agent/hooks/linux/stallwatch.go
+++ b/pkg/agent/hooks/linux/stallwatch.go
@@ -3,11 +3,50 @@
 package linux
 
 import (
+	"strings"
 	"sync"
 	"time"
 
 	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
 )
+
+// isWSLRelease reports whether a kernel release string is a WSL one. Both
+// generations advertise themselves there — WSL2 as "...-microsoft-standard-WSL2"
+// and WSL1 as "4.4.0-19041-Microsoft" — so the lowercased substring covers both.
+//
+// Split out as a pure function so the parsing is testable on its own: stubbing a
+// runningUnderWSL var instead would have left the one thing that can actually be
+// wrong (this match) uncovered, and a var read from the watchdog goroutine while
+// a test writes it is a data race waiting for the first t.Parallel().
+func isWSLRelease(release string) bool {
+	return strings.Contains(strings.ToLower(release), "microsoft")
+}
+
+// runningUnderWSL reports whether this kernel is a WSL one. It reads the release
+// via uname(2) rather than /proc so it keeps working under a masked or
+// unmounted /proc (procMount, hardened seccomp/AppArmor profiles).
+func runningUnderWSL() bool {
+	var uts unix.Utsname
+	if err := unix.Uname(&uts); err != nil {
+		return false
+	}
+	return isWSLRelease(unix.ByteSliceToString(uts.Release[:]))
+}
+
+// stallRemediation returns advice that matches the kernel actually running.
+//
+// The WSL fix ("wsl --shutdown") is real but WSL-only, and emitting it
+// unconditionally sent operators on Linux hosts — every CI runner and every
+// production node — chasing a command that does not exist there, on a log line
+// that already reads as an emergency. Advice that cannot apply is worse than no
+// advice, so each platform gets the step that actually clears its own stall.
+func stallRemediation() string {
+	if runningUnderWSL() {
+		return "on WSL2/Docker Desktop run 'wsl --shutdown', which reboots the shared kernel; terminating only the docker-desktop distro leaves the same kernel running and does not clear it"
+	}
+	return "the stall is in the HOST kernel, so it outlives this container: check the host kernel log (dmesg) for 'tasks_rcu_exit_srcu_stall' and drain/reboot that node — restarting the agent or the pod cannot clear it"
+}
 
 // Default thresholds for watchStall. Loading the whole eBPF collection is
 // normally well under a second, so 15s already means something is wrong, and
@@ -16,6 +55,30 @@ import (
 const (
 	stallFirstReport  = 15 * time.Second
 	stallRepeatReport = 30 * time.Second
+	// stallErrorAfter is when a slow call stops being slow and starts being
+	// wedged, and therefore when the report escalates from WARN to ERROR.
+	//
+	// The distinction is the whole point of the severity. ERROR means "this
+	// degraded and you need to know" — a terminal outcome — and consumers act on
+	// it: the DaemonSet e2e fails a run on any agent ERROR, and the sample-app CI
+	// lanes gate on `grep ERROR` over the agent log. Reporting the FIRST 15s tick at ERROR
+	// made every load that was merely slow-then-successful indistinguishable
+	// from a permanently wedged one, so a completely healthy run (BPF load
+	// returned at ~16s, every test passed) was failed by its own logging. It
+	// also contradicted this file's own contract: stop() is synchronous
+	// specifically "so a successful load can never emit a scary ERROR", which
+	// only held when the load beat the first tick.
+	//
+	// A load blocked this long is not slow. The condition this watchdog exists
+	// for — a stalled RCU-tasks grace period — blocks bpf(BPF_PROG_LOAD) at 0%
+	// CPU for as long as the grace period is stuck (the kernel does not even
+	// REPORT one until rcu_task_stall_timeout, 600s by default), whereas a
+	// contended-but-progressing load clears this bar in seconds. It shrinks the
+	// false-ERROR window to near zero rather than proving it shut: a stall that
+	// resolves because the blocking task exits can still cross it. 2 minutes sits far
+	// above the slowest observed real load (~16s) and far below the point where
+	// an operator would have given up anyway.
+	stallErrorAfter = 2 * time.Minute
 )
 
 // watchStall reports that a kernel call has not returned yet, and keeps
@@ -37,7 +100,11 @@ const (
 // The syscall cannot be aborted, so this does not try to. It makes the failure
 // legible instead: what is blocked, for how long, and the kernel condition that
 // usually explains it.
-func watchStall(logger *zap.Logger, operation string, first, repeat time.Duration) (stop func()) {
+//
+// Reports start at WARN and escalate to ERROR once the call has been blocked for
+// errorAfter, so the severity distinguishes "slow" from "never coming back" — see
+// stallErrorAfter. A zero errorAfter reports at ERROR from the first tick.
+func watchStall(logger *zap.Logger, operation string, first, repeat, errorAfter time.Duration) (stop func()) {
 	if logger == nil {
 		return func() {}
 	}
@@ -53,12 +120,23 @@ func watchStall(logger *zap.Logger, operation string, first, repeat time.Duratio
 			case <-done:
 				return
 			case <-timer.C:
-				logger.Error("kernel call has not returned; the agent cannot become ready until it does",
+				// Round once and branch on the SAME value that gets logged, so a
+				// line can never read "blockedFor=2m0s" while being emitted at WARN
+				// because the raw duration was a few ms short of the threshold.
+				blocked := time.Since(start).Round(time.Second)
+				fields := []zap.Field{
 					zap.String("operation", operation),
-					zap.Duration("blockedFor", time.Since(start).Round(time.Second)),
+					zap.Duration("blockedFor", blocked),
 					zap.String("likelyCause", "a stalled RCU-tasks grace period makes bpf(BPF_PROG_LOAD) block indefinitely at 0% CPU; check the host kernel log for 'tasks_rcu_exit_srcu_stall'"),
-					zap.String("remediation", "on WSL2/Docker Desktop run 'wsl --shutdown', which reboots the shared kernel; terminating only the docker-desktop distro leaves the same kernel running and does not clear it"),
-				)
+					zap.String("remediation", stallRemediation()),
+				}
+				// WARN while the call may still return, ERROR once it has been
+				// blocked long enough that it never will. See stallErrorAfter.
+				if blocked >= errorAfter {
+					logger.Error("kernel call has not returned; the agent cannot become ready until it does", fields...)
+				} else {
+					logger.Warn("kernel call is taking unusually long; the agent cannot become ready until it returns", fields...)
+				}
 				timer.Reset(repeat)
 			}
 		}

--- a/pkg/agent/hooks/linux/stallwatch_test.go
+++ b/pkg/agent/hooks/linux/stallwatch_test.go
@@ -10,6 +10,8 @@ import (
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
+
+	"go.keploy.io/server/v3/pkg"
 )
 
 func newObservedLogger() (*zap.Logger, *observer.ObservedLogs) {
@@ -22,7 +24,7 @@ func newObservedLogger() (*zap.Logger, *observer.ObservedLogs) {
 // pure noise and would train readers to ignore it.
 func TestWatchStallSilentWhenCallReturnsQuickly(t *testing.T) {
 	logger, logs := newObservedLogger()
-	stop := watchStall(logger, "bpf(BPF_PROG_LOAD)", time.Hour, time.Hour)
+	stop := watchStall(logger, "bpf(BPF_PROG_LOAD)", time.Hour, time.Hour, stallErrorAfter)
 	// Give a watchdog that reports too eagerly real time to do so before
 	// stopping it. Stopping immediately would let a broken implementation win
 	// the race against its own first report and pass this test.
@@ -39,7 +41,9 @@ func TestWatchStallSilentWhenCallReturnsQuickly(t *testing.T) {
 // "not ready" for five minutes.
 func TestWatchStallReportsBlockedCall(t *testing.T) {
 	logger, logs := newObservedLogger()
-	stop := watchStall(logger, "bpf(BPF_PROG_LOAD) via ebpf.CollectionSpec.LoadAndAssign", 10*time.Millisecond, time.Hour)
+	// errorAfter=0 makes the very first tick terminal, which is the state this
+	// test is about: a call that is never coming back.
+	stop := watchStall(logger, "bpf(BPF_PROG_LOAD) via ebpf.CollectionSpec.LoadAndAssign", 10*time.Millisecond, time.Hour, 0)
 	defer stop()
 
 	deadline := time.Now().Add(2 * time.Second)
@@ -64,11 +68,139 @@ func TestWatchStallReportsBlockedCall(t *testing.T) {
 	if cause, _ := fields["likelyCause"].(string); !strings.Contains(cause, "tasks_rcu_exit_srcu_stall") {
 		t.Errorf("report must name the kernel symptom to grep for; got %q", cause)
 	}
-	if rem, _ := fields["remediation"].(string); !strings.Contains(rem, "wsl --shutdown") {
-		t.Errorf("report must name the remediation; got %q", rem)
+	if rem, _ := fields["remediation"].(string); rem == "" {
+		t.Error("report must name a remediation")
 	}
 	if _, ok := fields["blockedFor"]; !ok {
 		t.Error("report must say how long the call has been blocked")
+	}
+}
+
+// A call that is merely SLOW must not be reported at ERROR. ERROR is a terminal
+// signal here: the DaemonSet e2e fails a run on any agent ERROR and the sample-app
+// CI lanes gate on `grep ERROR` over the agent log, so a load that blocks past the first
+// tick and then succeeds would fail an otherwise perfectly healthy run — which
+// is exactly what happened before this split (BPF load returned at ~16s, all 34
+// tests passed, the lane still exited 1).
+func TestWatchStallReportsSlowCallAtWarnNotError(t *testing.T) {
+	logger, logs := newObservedLogger()
+	// The call has been blocked for ~10ms, far below errorAfter, so it may still
+	// return: WARN, not ERROR.
+	stop := watchStall(logger, "bpf(BPF_PROG_LOAD)", 10*time.Millisecond, time.Hour, time.Hour)
+	defer stop()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for logs.Len() == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if logs.Len() == 0 {
+		t.Fatal("watchdog stayed silent while the call was still blocked")
+	}
+
+	e := logs.All()[0]
+	if e.Level != zap.WarnLevel {
+		t.Errorf("a still-running call must report at WARN, not %v — ERROR is reserved for a call that is never coming back", e.Level)
+	}
+	// The diagnostic value must survive the severity change.
+	fields := e.ContextMap()
+	if op, _ := fields["operation"].(string); !strings.Contains(op, "BPF_PROG_LOAD") {
+		t.Errorf("the WARN report must still name the blocked operation; got %q", op)
+	}
+	if _, ok := fields["blockedFor"]; !ok {
+		t.Error("the WARN report must still say how long the call has been blocked")
+	}
+}
+
+// The escalation itself — a report that starts at WARN and becomes ERROR once the
+// call has been blocked past errorAfter. Testing only the two endpoints
+// (errorAfter=0 and errorAfter=huge) would pass against an implementation that
+// derived the severity from "errorAfter == 0" and never crossed anything.
+func TestWatchStallEscalatesFromWarnToError(t *testing.T) {
+	logger, logs := newObservedLogger()
+	// blockedFor is rounded to whole seconds before the comparison, so a 1s
+	// threshold crosses once ~500ms has elapsed. Ticking every 10ms gives plenty
+	// of reports on both sides of that line.
+	stop := watchStall(logger, "bpf(BPF_PROG_LOAD)", 10*time.Millisecond, 10*time.Millisecond, time.Second)
+	defer stop()
+
+	deadline := time.Now().Add(5 * time.Second)
+	sawWarn, sawError := false, false
+	for time.Now().Before(deadline) && !sawError {
+		for _, e := range logs.All() {
+			switch e.Level {
+			case zap.WarnLevel:
+				sawWarn = true
+			case zap.ErrorLevel:
+				sawError = true
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if !sawWarn {
+		t.Error("the early reports, while the call could still return, must be WARN")
+	}
+	if !sawError {
+		t.Error("a call still blocked past errorAfter must escalate to ERROR")
+	}
+	// Order matters: WARN must come first, or the escalation is not an escalation.
+	all := logs.All()
+	if len(all) > 0 && all[0].Level != zap.WarnLevel {
+		t.Errorf("the FIRST report must be WARN; got %v", all[0].Level)
+	}
+}
+
+// A genuinely wedged agent must still produce an ERROR before keploy gives up
+// waiting for it, or the escalation is unreachable in practice and the ERROR
+// signal is lost. Reports tick at first, then every repeat, so the first tick at
+// or past stallErrorAfter is what has to land inside the ready budget.
+func TestStallErrorLandsBeforeTheAgentReadyBudget(t *testing.T) {
+	firstErrorAt := stallFirstReport
+	for firstErrorAt < stallErrorAfter {
+		firstErrorAt += stallRepeatReport
+	}
+	if firstErrorAt >= pkg.DefaultAgentReadyTimeout {
+		t.Fatalf("the first ERROR lands at %v, at or past the %v agent-ready budget: a wedged agent would be given up on before it ever reported ERROR",
+			firstErrorAt, pkg.DefaultAgentReadyTimeout)
+	}
+}
+
+// The WSL match is the one thing in the remediation split that can actually be
+// wrong, so it is tested directly rather than stubbed away.
+func TestIsWSLRelease(t *testing.T) {
+	cases := []struct {
+		release string
+		want    bool
+	}{
+		{"5.15.153.1-microsoft-standard-WSL2", true},
+		{"4.4.0-19041-Microsoft", true}, // WSL1 capitalises it
+		{"6.12.63+deb13-amd64", false},
+		{"5.10.0-28-cloud-amd64", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isWSLRelease(tc.release); got != tc.want {
+			t.Errorf("isWSLRelease(%q) = %v, want %v", tc.release, got, tc.want)
+		}
+	}
+}
+
+// The remediation must match the kernel actually running: "wsl --shutdown" does
+// not exist on a Linux CI runner or a production node, and advice that cannot
+// apply is worse than none on a line that already reads as an emergency.
+func TestStallRemediationMatchesPlatform(t *testing.T) {
+	rem := stallRemediation()
+	if runningUnderWSL() {
+		if !strings.Contains(rem, "wsl --shutdown") {
+			t.Errorf("under WSL the remediation must name the WSL fix; got %q", rem)
+		}
+		return
+	}
+	if strings.Contains(rem, "wsl --shutdown") {
+		t.Errorf("off WSL the remediation must not send the operator to a command that does not exist; got %q", rem)
+	}
+	if !strings.Contains(rem, "tasks_rcu_exit_srcu_stall") {
+		t.Errorf("the non-WSL remediation must still name what to grep the host kernel log for; got %q", rem)
 	}
 }
 
@@ -76,7 +208,7 @@ func TestWatchStallReportsBlockedCall(t *testing.T) {
 // looks at a wedged container ten minutes later needs to see it is still stuck.
 func TestWatchStallRepeatsWhileBlocked(t *testing.T) {
 	logger, logs := newObservedLogger()
-	stop := watchStall(logger, "bpf(BPF_PROG_LOAD)", 10*time.Millisecond, 10*time.Millisecond)
+	stop := watchStall(logger, "bpf(BPF_PROG_LOAD)", 10*time.Millisecond, 10*time.Millisecond, 0)
 	defer stop()
 
 	deadline := time.Now().Add(3 * time.Second)
@@ -93,7 +225,7 @@ func TestWatchStallRepeatsWhileBlocked(t *testing.T) {
 func TestWatchStallStopIsRaceFree(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		logger, logs := newObservedLogger()
-		stop := watchStall(logger, "op", time.Microsecond, time.Microsecond)
+		stop := watchStall(logger, "op", time.Microsecond, time.Microsecond, 0)
 		time.Sleep(time.Duration(i%5) * time.Millisecond)
 		stop()
 		before := logs.Len()
@@ -110,7 +242,7 @@ func TestWatchStallStopIsRaceFree(t *testing.T) {
 // that panics the process with "close of closed channel".
 func TestWatchStallStopIsIdempotent(t *testing.T) {
 	logger, _ := newObservedLogger()
-	stop := watchStall(logger, "bpf(BPF_PROG_LOAD)", time.Hour, time.Hour)
+	stop := watchStall(logger, "bpf(BPF_PROG_LOAD)", time.Hour, time.Hour, stallErrorAfter)
 	stop()
 	stop() // would panic on a second close(done)
 	stop()
@@ -120,7 +252,7 @@ func TestWatchStallStopIsIdempotent(t *testing.T) {
 // watchdog actually stopped rather than returning early.
 func TestWatchStallStopIsConcurrencySafe(t *testing.T) {
 	logger, _ := newObservedLogger()
-	stop := watchStall(logger, "bpf(BPF_PROG_LOAD)", time.Hour, time.Hour)
+	stop := watchStall(logger, "bpf(BPF_PROG_LOAD)", time.Hour, time.Hour, stallErrorAfter)
 	var wg sync.WaitGroup
 	for i := 0; i < 8; i++ {
 		wg.Add(1)


### PR DESCRIPTION
## What

`watchStall` reported at **ERROR** on its first tick — 15s into a `bpf(BPF_PROG_LOAD)` that hadn't returned yet. This splits the severity: **WARN** while the call may still return, **ERROR** once it has been blocked past `stallErrorAfter` (2 min).

## Why

The call frequently *does* return after 15s. A load that blocks ~15s and then succeeds is **slow, not wedged** — and the ERROR asserted something untrue (*"the agent cannot become ready until it does"*) about an agent that went on to become ready and pass every test.

That mislabelling has teeth, because ERROR is a terminal signal and consumers act on it. Two CI lanes failed on completely healthy runs:

- **DaemonSet TLS e2e** — `PASS(C): 18 test(s) across 2 test set(s) replayed with no failures`, then `FAIL(G)` when its agent-ERROR scan matched this line.
- **couchbase-node-linux** — both replays passed **34/34**, step still exited 1 when `check_for_errors` matched it.

It also contradicted this file's own contract — `stop()` is synchronous *"so a successful load can never emit a scary ERROR"* — which only held while the load beat the first tick.

This is user-facing too: anyone tailing agent logs saw a red ERROR on a healthy run.

## Not a weakened assertion

Nothing diagnostic moves. The 15s line still fires with the same `operation`, `blockedFor` and `likelyCause` fields — only the level changes. A genuinely wedged agent still reports **ERROR**, at the 135s tick (ticks: 15s, 45s, 75s, 105s, 135s), comfortably inside the 330s `pkg.DefaultAgentReadyTimeout` — and a test now pins that invariant so the two constants can't drift apart.

## Also: stop sending every operator to `wsl --shutdown`

That remediation is real but **WSL-only**, and it was emitted unconditionally — on a Linux CI runner or a production node it points at a command that doesn't exist, on a line that already reads as an emergency. Now detected via `uname(2)` (no `/proc` dependency, so it survives a masked `/proc`), with each platform getting the step that actually clears its own stall.

## Tests

- `TestWatchStallEscalatesFromWarnToError` — the **crossing**, not just the two endpoints (testing only `errorAfter=0` / `errorAfter=huge` would pass against an implementation that never escalates)
- `TestWatchStallReportsSlowCallAtWarnNotError` — WARN path keeps its diagnostic fields
- `TestStallErrorLandsBeforeTheAgentReadyBudget` — the ERROR must land inside the ready budget
- `TestIsWSLRelease` — real WSL2 / WSL1 / Linux release strings

`go build`, `go vet`, and `go test -race` all clean (11/11).
