### PR TITLE
fix(mysql): stop dropping COM_QUERY on a late or lost post-TLS handshake stitch

### DIFF
--- a/pkg/agent/proxy/integrations/mysql/recorder/conn.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/conn.go
@@ -1210,6 +1210,17 @@ func fetchServerGreeting(ctx context.Context, opts models.OutgoingOptions) ([]by
 	if addr == "" {
 		return nil, fmt.Errorf("no destination address available to fetch server greeting")
 	}
+	// Never dial an address the capture layer fabricated. When the proxyless
+	// SSL-uprobe path cannot resolve a decrypted stream's real destination it
+	// substitutes a loopback stand-in (and content matching later forces the
+	// well-known port), yielding e.g. "127.0.0.1:3306" — an address this
+	// connection never talked to. Dialing it either fails instantly
+	// (ECONNREFUSED, aborting the capture) or, worse, fetches a greeting from
+	// an unrelated local server. Fail here so callers fall through to their
+	// stash/cache fallbacks or abort cleanly.
+	if opts.DstCfg != nil && opts.DstCfg.AddrFabricated {
+		return nil, fmt.Errorf("destination address %s is a capture-layer stand-in (real destination unresolved), refusing to dial it to fetch the server greeting", addr)
+	}
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}

--- a/pkg/agent/proxy/integrations/mysql/recorder/conn_test.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/conn_test.go
@@ -1,0 +1,88 @@
+package recorder
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// TestFetchServerGreeting_RefusesFabricatedAddr pins the dial guard: when the
+// capture layer marked the destination as a stand-in (AddrFabricated — the
+// proxyless SSL-uprobe path's loopback substitution + content-matched port),
+// fetchServerGreeting must fail WITHOUT dialing. A live listener on the
+// address proves no connection is attempted — dialing a fabricated loopback
+// address can reach an unrelated co-resident server and stitch a foreign
+// greeting into the mock.
+func TestFetchServerGreeting_RefusesFabricatedAddr(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	accepted := make(chan struct{}, 1)
+	go func() {
+		conn, aerr := ln.Accept()
+		if aerr != nil {
+			return
+		}
+		accepted <- struct{}{}
+		_ = conn.Close()
+	}()
+
+	opts := models.OutgoingOptions{
+		DstCfg: &models.ConditionalDstCfg{Addr: ln.Addr().String(), Port: 3306, AddrFabricated: true},
+	}
+	buf, err := fetchServerGreeting(context.Background(), opts)
+	if err == nil {
+		t.Fatal("fetchServerGreeting must refuse a fabricated destination")
+	}
+	if !strings.Contains(err.Error(), "refusing to dial") {
+		t.Errorf("error = %v, want the explicit dial refusal", err)
+	}
+	if buf != nil {
+		t.Errorf("buf = %v, want nil on refusal", buf)
+	}
+	select {
+	case <-accepted:
+		t.Fatal("fetchServerGreeting dialed a fabricated address")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// TestFetchServerGreeting_ReadsRealGreeting proves the guard does not break
+// the legitimate fallback (pre-warmed connections whose handshake predates
+// interception): a non-fabricated destination is dialed and the greeting
+// packet is returned verbatim.
+func TestFetchServerGreeting_ReadsRealGreeting(t *testing.T) {
+	greeting := cannedHandshakeV10(t)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		conn, aerr := ln.Accept()
+		if aerr != nil {
+			return
+		}
+		_, _ = conn.Write(greeting)
+		_ = conn.Close()
+	}()
+
+	opts := models.OutgoingOptions{
+		DstCfg: &models.ConditionalDstCfg{Addr: ln.Addr().String(), Port: 3306},
+	}
+	buf, err := fetchServerGreeting(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("fetchServerGreeting: %v", err)
+	}
+	if !bytes.Equal(buf, greeting) {
+		t.Fatalf("greeting bytes mismatch: got %d bytes, want %d", len(buf), len(greeting))
+	}
+}

--- a/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -389,30 +391,61 @@ func handlePostTLSHandshakeV2(ctx context.Context, logger *zap.Logger, sess *sup
 	if hsStore == nil {
 		return res, fmt.Errorf("post-TLS V2: PostTLSModeKey is set but TLSHandshakeStore is missing from the context — the SSL/GoTLS reader callback must set models.TLSHandshakeStoreKey (same store the pre-TLS raw stream pushes the greeting into) before dispatching the decrypted tls-* stream")
 	}
-	entry, ok := hsStore.PopWait(models.HandshakeStoreKey(sess.Opts.ConnKey, dstPort), 5*time.Second)
-	// Port-only fallback only when the first key was conn-specific — otherwise it
-	// is the same port-only key and we'd waste another 2s on a guaranteed miss
-	// (matches the legacy handlePostTLSRecord guard).
-	if !ok && sess.Opts.ConnKey != "" {
-		entry, ok = hsStore.PopWait(models.HandshakeStoreKey("", dstPort), 2*time.Second)
-	}
+	// The raw leg's push rides the SAME capture as this decrypted stream, so
+	// under CPU pressure it can land arbitrarily late — a short fixed timeout
+	// here converted that lateness into total capture loss (the CI "served but
+	// NOT recorded" shortfall). resolvePreTLSGreeting waits (bounded by ctx and
+	// by the store TTL) for this connection's own greeting, but falls back FAST
+	// to the port's last-greeting cache when the raw leg was genuinely dropped —
+	// so a dropped leg does not stall the whole overall window and push the
+	// COM_QUERY decode past the CI (2a) gate. Waiting is free: the client's
+	// post-TLS bytes are buffered on ClientStream and read only after this
+	// returns.
+	entry, source := resolvePreTLSGreeting(ctx, hsStore, sess.Opts.ConnKey, dstPort)
+	staleEntry := source == greetingCached
 	var greetingBuf []byte
-	if ok && len(entry.RespPackets) > 0 {
+	if source != greetingNone && len(entry.RespPackets) > 0 {
 		greetingBuf = entry.RespPackets[0]
+		if staleEntry {
+			// The raw leg was genuinely lost (its capture event dropped by a
+			// full ringbuf, or delayed past the store TTL). Greetings for the
+			// same destination are reusable for stitching: capabilities,
+			// protocol version and auth plugin are per-server, and the
+			// per-connection salt is never verified on the record or replay
+			// path (the replayer skips AuthResponse comparison — see
+			// replayer/match.go). Reuse the most recent greeting (+SSLRequest)
+			// another connection pushed for this port instead of losing the
+			// whole command phase.
+			logger.Debug("post-TLS V2: raw-leg greeting lost; falling back to the last cached greeting for this port",
+				zap.Uint16("dstPort", dstPort))
+		}
 	} else {
 		// The pre-TLS handshake was never captured (connection opened before
-		// interception started). Fetch the greeting directly, matching legacy.
+		// interception started) and no greeting is cached for the port. Fetch
+		// the greeting directly, matching legacy. fetchServerGreeting refuses
+		// fabricated destinations (see models.ConditionalDstCfg.AddrFabricated),
+		// so this cannot dial an address the capture layer merely invented.
 		var gErr error
 		greetingBuf, gErr = fetchServerGreeting(ctx, sess.Opts)
 		if gErr != nil {
 			return res, fmt.Errorf("post-TLS V2: no greeting in store (key port %d) and direct fetch failed: %w", dstPort, gErr)
 		}
+		// A directly-fetched greeting carries no stashed SSLRequest or
+		// timestamp; make downstream treat it as such.
+		entry = models.TLSHandshakeEntry{}
+		staleEntry = false
+		source = greetingNone
 	}
 
 	// Config-mock request timestamp = when the greeting arrived (stashed on the
 	// raw stream). Zero when we fell back to a direct fetch; sampled from the
 	// first client read below in that case.
 	res.reqTimestamp = entry.ReqTimestamp
+	if staleEntry {
+		// The cached entry belongs to an EARLIER connection; its timestamp
+		// would backdate this mock. Sample from the first client read below.
+		res.reqTimestamp = time.Time{}
+	}
 
 	// 2. Decode the greeting and seed the decode context (mirrors legacy).
 	greetingPkt, err := wire.DecodePayload(ctx, logger, greetingBuf, clientKey, decodeCtx)
@@ -440,7 +473,7 @@ func handlePostTLSHandshakeV2(ctx context.Context, logger *zap.Logger, sess *sup
 	//    before the HandshakeResponse41 below, while LastOp is still
 	//    HandshakeV10 — same ordering constraint as legacy handlePostTLSRecord.
 	var sslReqPkt *mysql.PacketBundle
-	if ok && len(entry.ReqPackets) > 0 {
+	if source != greetingNone && len(entry.ReqPackets) > 0 {
 		if pkt, sErr := wire.DecodePayload(ctx, logger, entry.ReqPackets[0], clientKey, decodeCtx); sErr == nil {
 			sslReqPkt = pkt
 			res.req = append(res.req, mysql.Request{PacketBundle: *pkt})
@@ -761,6 +794,185 @@ func handlePlainPasswordV2(ctx context.Context, logger *zap.Logger, sess *superv
 	res.resp = append(res.resp, mysql.Response{PacketBundle: *finalPkt})
 	res.responseOperation = finalPkt.Header.Type
 	return res, nil
+}
+
+// mysqlPostTLSStashWaitDefault is the OVERALL upper bound on how long
+// resolvePreTLSGreeting waits for a pre-TLS greeting when it has NO cached
+// greeting to fall back on (the first connection to a destination port, or one
+// where every sibling connection's raw leg was also dropped). 30s deliberately
+// matches the store's own unconsumed-entry TTL: an entry older than that is
+// pruned anyway, so waiting longer can only be serviced by entries pushed
+// DURING the wait — which the loop already catches. It still bounds teardown
+// when the raw leg was genuinely dropped. Override with
+// KEPLOY_MYSQL_POSTTLS_STASH_WAIT_MS (0 = single immediate check, no blocking).
+const mysqlPostTLSStashWaitDefault = 30 * time.Second
+
+// mysqlPostTLSStashPrimaryDefault is the SHORT primary bound: how long
+// resolvePreTLSGreeting waits for THIS connection's own raw leg before, if a
+// reusable greeting is already cached for the port, falling back to it rather
+// than blocking out the full overall window.
+//
+// CI (2a) observed the raw leg landing >5s late under CPU pressure, so 8s
+// comfortably absorbs that observed lateness — a merely-late own leg is still
+// preferred and stitched with its real per-connection salt+timestamp — while
+// leaving ~22s of the 30s "served but NOT recorded" decode gate as headroom for
+// the COM_QUERY to decode AFTER the greeting is resolved. The load-bearing
+// property: a genuinely-DROPPED raw leg whose port already has a cached greeting
+// reaches that cache at ~8s, NOT ~30s, so the command phase records well inside
+// the gate under the exact CPU pressure this fix targets. It is capped at the
+// overall bound, so a small KEPLOY_MYSQL_POSTTLS_STASH_WAIT_MS (tests, or 0)
+// collapses both bounds to a single short phase. Override the primary bound
+// itself with KEPLOY_MYSQL_POSTTLS_STASH_PRIMARY_MS.
+const mysqlPostTLSStashPrimaryDefault = 8 * time.Second
+
+// mysqlPostTLSStashPollSlice is the per-blocking-PopWait slice inside
+// resolvePreTLSGreeting's loop. The loop re-checks ctx (and the primary/overall
+// deadlines) between slices, so this is the worst-case reaction time to context
+// cancellation. A push wakes the blocked PopWait immediately, so it does NOT
+// delay the success path.
+const mysqlPostTLSStashPollSlice = 500 * time.Millisecond
+
+func mysqlPostTLSStashWait() time.Duration {
+	if v := os.Getenv("KEPLOY_MYSQL_POSTTLS_STASH_WAIT_MS"); v != "" {
+		if ms, err := strconv.Atoi(v); err == nil && ms >= 0 {
+			return time.Duration(ms) * time.Millisecond
+		}
+	}
+	return mysqlPostTLSStashWaitDefault
+}
+
+// mysqlPostTLSStashPrimary returns the primary (fast-fallback) bound, never
+// longer than the overall bound.
+func mysqlPostTLSStashPrimary(overall time.Duration) time.Duration {
+	primary := mysqlPostTLSStashPrimaryDefault
+	if v := os.Getenv("KEPLOY_MYSQL_POSTTLS_STASH_PRIMARY_MS"); v != "" {
+		if ms, err := strconv.Atoi(v); err == nil && ms >= 0 {
+			primary = time.Duration(ms) * time.Millisecond
+		}
+	}
+	if primary > overall {
+		return overall
+	}
+	return primary
+}
+
+// preTLSGreetingSource records where resolvePreTLSGreeting obtained the greeting.
+type preTLSGreetingSource int
+
+const (
+	// greetingNone: nothing available within the bounds — the caller must fetch
+	// the greeting directly or abort cleanly.
+	greetingNone preTLSGreetingSource = iota
+	// greetingOwn: this connection's own raw-leg stash (or, in the empty-connKey
+	// proxyless case, the port FIFO entry that bridges the two legs). Carries the
+	// real per-connection salt + request timestamp.
+	greetingOwn
+	// greetingCached: another connection's most-recent greeting for the port,
+	// from the non-consuming last-greeting cache. Reusable for stitching
+	// (capabilities/plugin are per-server; the salt is never verified — see
+	// replayer/match.go), but its per-connection metadata (the timestamp) must
+	// NOT leak into this mock.
+	greetingCached
+)
+
+// resolvePreTLSGreeting obtains the pre-TLS greeting (+SSLRequest) for a
+// decrypted tls-* stream. It prefers THIS connection's own raw-leg stash, but a
+// genuinely-dropped raw leg must NOT block the full overall window before using
+// a reusable cached greeting — that stall could push the COM_QUERY decode past
+// the CI (2a) 30s "served but NOT recorded" gate. So the wait is two-phase:
+//
+//   - up to `primary` (short): wait for this connection's own entry, waking the
+//     instant a Push arrives (the store broadcasts its cond). A merely-late own
+//     leg is absorbed here and stitched with its real salt+timestamp.
+//   - once `primary` elapses AND a greeting is cached for the port: use the
+//     cache immediately (the dropped-leg fast path).
+//   - only when NO greeting is cached yet (the first connection to the port, or
+//     every sibling leg also dropped) keep waiting for the own entry up to
+//     `overall`, since nothing better can serve this connection.
+//
+// ctx cancellation (stream/session teardown) cuts any wait short within one
+// poll slice. On a final miss it returns greetingNone so the caller can
+// fetchServerGreeting / abort cleanly.
+//
+// It checks the conn-specific key and the port-only key on every pass: in
+// proxyless the raw and decrypted legs are different TCP connections, so only
+// the port-only key (e.g. "port:3306") reliably bridges them — the raw leg
+// pushes under both (storePreTLSHandshakeV2).
+func resolvePreTLSGreeting(ctx context.Context, hsStore *models.TLSHandshakeStore, connKey string, dstPort uint16) (models.TLSHandshakeEntry, preTLSGreetingSource) {
+	connSpecificKey := models.HandshakeStoreKey(connKey, dstPort)
+	portKey := models.HandshakeStoreKey("", dstPort)
+
+	overall := mysqlPostTLSStashWait()
+	primary := mysqlPostTLSStashPrimary(overall)
+	start := time.Now()
+	overallDeadline := start.Add(overall)
+	primaryDeadline := start.Add(primary)
+
+	// popOwn returns this connection's own stashed entry (either key), if
+	// present, without blocking.
+	popOwn := func() (models.TLSHandshakeEntry, bool) {
+		if entry, ok := hsStore.PopWait(connSpecificKey, 0); ok {
+			return entry, true
+		}
+		if portKey != connSpecificKey {
+			if entry, ok := hsStore.PopWait(portKey, 0); ok {
+				return entry, true
+			}
+		}
+		return models.TLSHandshakeEntry{}, false
+	}
+	// cachedGreeting returns the port's last-greeting cache entry, if usable.
+	cachedGreeting := func() (models.TLSHandshakeEntry, bool) {
+		if c, ok := hsStore.Last(portKey); ok && len(c.RespPackets) > 0 {
+			return c, true
+		}
+		return models.TLSHandshakeEntry{}, false
+	}
+
+	for {
+		// 1. This connection's own entry is always preferred.
+		if entry, ok := popOwn(); ok {
+			return entry, greetingOwn
+		}
+		now := time.Now()
+		// 2. Past the primary bound, a cached greeting is good enough — take it
+		//    rather than blocking out the full overall window (the dropped-leg
+		//    fast path that keeps the decode inside the CI gate).
+		if !now.Before(primaryDeadline) {
+			if entry, ok := cachedGreeting(); ok {
+				return entry, greetingCached
+			}
+		}
+		// 3. Overall bound / teardown.
+		if !now.Before(overallDeadline) || ctx.Err() != nil {
+			break
+		}
+		// 4. Block on the port-only key (the one the raw leg reliably lands
+		//    under), waking the moment a Push broadcasts the cond. Bound the
+		//    slice by the next deadline so the cache is re-checked promptly at
+		//    the primary boundary.
+		nextEval := overallDeadline
+		if now.Before(primaryDeadline) && primaryDeadline.Before(nextEval) {
+			nextEval = primaryDeadline
+		}
+		slice := mysqlPostTLSStashPollSlice
+		if d := time.Until(nextEval); d < slice {
+			slice = d
+		}
+		if slice <= 0 {
+			continue
+		}
+		if entry, ok := hsStore.PopWait(portKey, slice); ok {
+			return entry, greetingOwn
+		}
+	}
+
+	// Final miss on the own entry: the cache is the last resort before a direct
+	// fetch (it may have been populated by a sibling during the overall wait).
+	if entry, ok := cachedGreeting(); ok {
+		return entry, greetingCached
+	}
+	return models.TLSHandshakeEntry{}, greetingNone
 }
 
 // storePreTLSHandshakeV2 pushes the pre-TLS MySQL server greeting and the

--- a/pkg/agent/proxy/integrations/mysql/recorder/record_v2_test.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record_v2_test.go
@@ -1,0 +1,357 @@
+package recorder
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	connphase "go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/wire/phase/conn"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// These tests pin the post-TLS stitch resilience added for the
+// e2e-mysql-tls-lowlatency-cycle "(2a) capture shortfall — served but NOT
+// recorded" failure: the raw (pre-TLS) leg's greeting push shares the capture
+// ringbuf with bulk traffic and, under CPU pressure, lands seconds late or is
+// dropped outright. The old code popped the stash with a fixed 5s timeout and,
+// on a miss, dialed opts.DstCfg.Addr — which on the degraded proxyless path is
+// a fabricated 127.0.0.1:3306 — so a merely-late stash became a total capture
+// loss for the connection (COM_QUERY never decoded although the app was
+// served).
+
+// postTLSCtxWithStore wires the context the way the SSL/GoTLS reader callback
+// does for a decrypted tls-* stream, but with a caller-owned store so tests
+// control exactly what (and when) the raw leg stashed.
+func postTLSCtxWithStore(store *models.TLSHandshakeStore) context.Context {
+	ctx := context.WithValue(context.Background(), models.PostTLSModeKey, true)
+	return context.WithValue(ctx, models.TLSHandshakeStoreKey, store)
+}
+
+// collectPostTLSMocks drives RecordV2 under ctx and collects want mocks, with
+// caller-controlled patience (the late-stash test needs >6s).
+func collectPostTLSMocks(t *testing.T, h *v2Harness, ctx context.Context, want int, patience time.Duration) []*models.Mock {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() {
+		cctx, cancel := context.WithTimeout(ctx, patience)
+		defer cancel()
+		done <- RecordV2(cctx, h.logger, h.sess)
+	}()
+	var got []*models.Mock
+	for len(got) < want {
+		select {
+		case m, ok := <-h.mocks:
+			if !ok {
+				t.Fatalf("mocks channel closed early (got %d, want %d)", len(got), want)
+			}
+			got = append(got, m)
+			if len(got) == want {
+				h.closeStreams()
+			}
+		case <-time.After(patience):
+			t.Fatalf("timed out waiting for mocks (got %d, want %d)", len(got), want)
+		}
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("RecordV2 (post-TLS) returned error: %v", err)
+	}
+	return got
+}
+
+// TestRecordV2_PostTLS_LateStash_StillRecords is the permanent regression test
+// for the 5s cliff: the raw leg's greeting+SSLRequest push lands 6s after the
+// decrypted stream started — past the old PopWait(5s)+fallback(2s) budget that
+// aborted the connection ("no greeting in store" → ECONNREFUSED on the
+// fabricated dial → command phase never reached). With the ctx/TTL-bounded
+// wait, lateness within the store TTL must yield a complete recording.
+//
+// Deliberately not parallel: it must observe the DEFAULT stash-wait bound
+// (other tests in this file shorten it via t.Setenv).
+func TestRecordV2_PostTLS_LateStash_StillRecords(t *testing.T) {
+	h := newV2Harness(t)
+	base := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+
+	handshakeBuf := cannedHandshakeV10(t)
+	greeting, err := connphase.DecodeHandshakeV10(context.Background(), zap.NewNop(), handshakeBuf[4:])
+	if err != nil {
+		t.Fatalf("decode handshake v10: %v", err)
+	}
+	sslReq := cannedSSLRequest(t, 1)
+
+	// Decrypted stream: HandshakeResponse41 (seq>=1), auth OK, one query.
+	h.pushClient(cannedHandshakeResponse41(t, 2, false), base.Add(5*time.Millisecond))
+	h.pushDest(cannedOK(t, 3, greeting.CapabilityFlags), base.Add(10*time.Millisecond))
+	h.pushClient(cannedCOMQuery(t, 0, "SELECT 1"), base.Add(20*time.Millisecond))
+	h.pushDest(cannedOK(t, 1, greeting.CapabilityFlags), base.Add(25*time.Millisecond))
+
+	// Raw leg: the stash arrives 6 seconds late — after the old cliff.
+	store := models.NewTLSHandshakeStore()
+	const lateBy = 6 * time.Second
+	go func() {
+		time.Sleep(lateBy)
+		store.Push(models.HandshakeStoreKey("", 3306), models.TLSHandshakeEntry{
+			RespPackets:  [][]byte{handshakeBuf},
+			ReqPackets:   [][]byte{sslReq},
+			ReqTimestamp: base,
+		})
+	}()
+
+	start := time.Now()
+	got := collectPostTLSMocks(t, h, postTLSCtxWithStore(store), 2, 25*time.Second)
+	if elapsed := time.Since(start); elapsed < lateBy {
+		t.Fatalf("mocks arrived after %v — before the stash was even pushed at %v; the test is not exercising the late path", elapsed, lateBy)
+	}
+
+	cfg := got[0]
+	if cfg.Name != "config" {
+		t.Fatalf("first mock = %q, want config", cfg.Name)
+	}
+	if len(cfg.Spec.MySQLResponses) < 1 {
+		t.Fatal("config mock has no responses — greeting was not seeded from the late stash")
+	}
+	if len(cfg.Spec.MySQLRequests) < 2 {
+		t.Errorf("config mock requests = %d, want >=2 (SSLRequest + HandshakeResponse41)", len(cfg.Spec.MySQLRequests))
+	}
+	// The entry is THIS connection's own raw leg, so its stamped ReqTimestamp
+	// must be preserved (no stale-cache zeroing on this path).
+	if !cfg.Spec.ReqTimestampMock.Equal(base) {
+		t.Errorf("config ReqTimestampMock = %v, want %v (the raw-leg stash timestamp)", cfg.Spec.ReqTimestampMock, base)
+	}
+	// The command phase must have been recorded — this is exactly what the old
+	// cliff lost.
+	assertQueryMock(t, got[1])
+}
+
+// TestRecordV2_PostTLS_LostStash_GreetingCacheFallback covers the raw leg
+// being genuinely LOST (its capture event dropped by a full ringbuf): the
+// consumable queue never gets this connection's entry, but an earlier
+// connection to the same port populated the store's last-greeting cache. The
+// stitch must reuse that greeting — greetings are per-server except the salt,
+// which nothing on the record/replay path verifies — instead of dialing the
+// (fabricated) destination or aborting.
+func TestRecordV2_PostTLS_LostStash_GreetingCacheFallback(t *testing.T) {
+	// Shorten the bounded wait so the test exercises the post-wait fallback
+	// quickly. t.Setenv also forbids t.Parallel, which keeps the env change
+	// isolated from the default-bound test above.
+	t.Setenv("KEPLOY_MYSQL_POSTTLS_STASH_WAIT_MS", "150")
+
+	h := newV2Harness(t)
+	base := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+
+	handshakeBuf := cannedHandshakeV10(t)
+	greeting, err := connphase.DecodeHandshakeV10(context.Background(), zap.NewNop(), handshakeBuf[4:])
+	if err != nil {
+		t.Fatalf("decode handshake v10: %v", err)
+	}
+	sslReq := cannedSSLRequest(t, 1)
+
+	// An EARLIER connection pushed and consumed its entry; only the
+	// last-greeting cache retains it. Its (stale) timestamp must NOT leak
+	// into this connection's mock.
+	store := models.NewTLSHandshakeStore()
+	staleTs := base.Add(-time.Hour)
+	store.Push(models.HandshakeStoreKey("", 3306), models.TLSHandshakeEntry{
+		RespPackets:  [][]byte{handshakeBuf},
+		ReqPackets:   [][]byte{sslReq},
+		ReqTimestamp: staleTs,
+	})
+	if _, ok := store.PopWait(models.HandshakeStoreKey("", 3306), 0); !ok {
+		t.Fatal("setup: expected to consume the earlier connection's entry")
+	}
+
+	// The degraded proxyless dest is fabricated — the fallback must succeed
+	// WITHOUT dialing it (a dial would fail: nothing listens on this port).
+	h.sess.Opts.DstCfg = &models.ConditionalDstCfg{Addr: "127.0.0.1:1", Port: 3306, AddrFabricated: true}
+
+	clientTs := base.Add(5 * time.Millisecond)
+	h.pushClient(cannedHandshakeResponse41(t, 2, false), clientTs)
+	h.pushDest(cannedOK(t, 3, greeting.CapabilityFlags), base.Add(10*time.Millisecond))
+	h.pushClient(cannedCOMQuery(t, 0, "SELECT 1"), base.Add(20*time.Millisecond))
+	h.pushDest(cannedOK(t, 1, greeting.CapabilityFlags), base.Add(25*time.Millisecond))
+
+	got := collectPostTLSMocks(t, h, postTLSCtxWithStore(store), 2, 10*time.Second)
+
+	cfg := got[0]
+	if cfg.Name != "config" {
+		t.Fatalf("first mock = %q, want config", cfg.Name)
+	}
+	if len(cfg.Spec.MySQLResponses) < 1 {
+		t.Fatal("config mock has no responses — cached greeting was not used")
+	}
+	if len(cfg.Spec.MySQLRequests) < 2 {
+		t.Errorf("config mock requests = %d, want >=2 (cached SSLRequest + HandshakeResponse41)", len(cfg.Spec.MySQLRequests))
+	}
+	if cfg.Spec.ReqTimestampMock.Equal(staleTs) {
+		t.Errorf("config ReqTimestampMock = %v — the stale cached timestamp leaked; it must be re-sampled from this connection's first client read", cfg.Spec.ReqTimestampMock)
+	}
+	if !cfg.Spec.ReqTimestampMock.Equal(clientTs) {
+		t.Errorf("config ReqTimestampMock = %v, want %v (sampled from the first client read)", cfg.Spec.ReqTimestampMock, clientTs)
+	}
+	assertQueryMock(t, got[1])
+}
+
+// TestRecordV2_PostTLS_LostStash_FabricatedDest_NoDialCleanAbort covers the
+// worst case: the stash never arrives AND nothing has populated the greeting
+// cache. With a fabricated destination the recorder must abort cleanly —
+// bounded time, an explicit error, no mock — and it must NEVER dial the
+// fabricated address (a live listener stands in for the "unrelated
+// co-resident server" a real dial could reach).
+func TestRecordV2_PostTLS_LostStash_FabricatedDest_NoDialCleanAbort(t *testing.T) {
+	t.Setenv("KEPLOY_MYSQL_POSTTLS_STASH_WAIT_MS", "150")
+
+	h := newV2Harness(t)
+
+	// A real listener on the fabricated address: if the recorder dials it, the
+	// accept below proves the regression.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	accepted := make(chan struct{}, 1)
+	go func() {
+		conn, aerr := ln.Accept()
+		if aerr != nil {
+			return
+		}
+		accepted <- struct{}{}
+		_ = conn.Close()
+	}()
+	h.sess.Opts.DstCfg = &models.ConditionalDstCfg{Addr: ln.Addr().String(), Port: 3306, AddrFabricated: true}
+
+	store := models.NewTLSHandshakeStore() // stays empty: raw leg lost, no cache
+
+	done := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(postTLSCtxWithStore(store), 10*time.Second)
+		defer cancel()
+		done <- RecordV2(ctx, h.logger, h.sess)
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("RecordV2 must return an error when the stash is lost, the cache is empty, and the dest is fabricated")
+		}
+		if !strings.Contains(err.Error(), "no greeting in store") {
+			t.Errorf("error = %v, want it to name the missing greeting", err)
+		}
+		if !strings.Contains(err.Error(), "refusing to dial") {
+			t.Errorf("error = %v, want the fabricated-address dial refusal as the cause", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("RecordV2 hung — the lost-stash abort must be bounded")
+	}
+
+	select {
+	case <-accepted:
+		t.Fatal("the recorder dialed the fabricated address — it must never dial a capture-layer stand-in")
+	case <-time.After(100 * time.Millisecond):
+	}
+	select {
+	case m := <-h.mocks:
+		t.Fatalf("unexpected mock emitted on the clean-abort path: %+v", m)
+	default:
+	}
+}
+
+// TestResolvePreTLSGreeting_CtxCancelUnblocks pins one half of the wait bound:
+// teardown (ctx cancellation) must unblock the wait promptly even though the
+// overall budget is 30s and no greeting is cached (so the loop is in its
+// extended no-cache wait).
+func TestResolvePreTLSGreeting_CtxCancelUnblocks(t *testing.T) {
+	store := models.NewTLSHandshakeStore()
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, source := resolvePreTLSGreeting(ctx, store, "", 3306)
+	elapsed := time.Since(start)
+	if source != greetingNone {
+		t.Fatalf("resolvePreTLSGreeting must return greetingNone on an empty store, got %v", source)
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("returned after %v — ctx cancellation must cut the 30s bound short (poll slice is %v)", elapsed, mysqlPostTLSStashPollSlice)
+	}
+}
+
+// TestResolvePreTLSGreeting_DroppedLegHitsCacheAtPrimaryBound is the regression
+// test for finding C: a genuinely-DROPPED raw leg whose port already has a
+// cached greeting must fall back to that cache at the SHORT primary bound, NOT
+// after the full (large) overall bound — otherwise the stall pushes the
+// COM_QUERY decode past the CI (2a) 30s gate. Here the overall bound stays at
+// its 30s default while the primary bound is shortened to 200ms; the cache hit
+// must land near 200ms, far below both the overall bound and any plausible
+// gate.
+func TestResolvePreTLSGreeting_DroppedLegHitsCacheAtPrimaryBound(t *testing.T) {
+	// Shorten only the PRIMARY bound; leave the overall (30s default) alone so
+	// the test proves the fast path returns at primary, not overall. t.Setenv
+	// also forbids t.Parallel.
+	t.Setenv("KEPLOY_MYSQL_POSTTLS_STASH_PRIMARY_MS", "200")
+
+	store := models.NewTLSHandshakeStore()
+	// A sibling connection populated the port's last-greeting cache; THIS
+	// connection's own raw leg was dropped (never pushed).
+	store.Push(models.HandshakeStoreKey("", 3306), models.TLSHandshakeEntry{
+		RespPackets:  [][]byte{[]byte("greeting")},
+		ReqPackets:   [][]byte{[]byte("sslreq")},
+		ReqTimestamp: time.Now(),
+	})
+	if _, ok := store.PopWait(models.HandshakeStoreKey("", 3306), 0); !ok {
+		t.Fatal("setup: expected to consume the sibling's queued entry, leaving only the cache")
+	}
+
+	start := time.Now()
+	entry, source := resolvePreTLSGreeting(context.Background(), store, "", 3306)
+	elapsed := time.Since(start)
+	if source != greetingCached {
+		t.Fatalf("source = %v, want greetingCached (the dropped-leg cache fallback)", source)
+	}
+	if len(entry.RespPackets) != 1 {
+		t.Fatalf("cached entry not returned: %+v", entry)
+	}
+	// Must land at ~the 200ms primary bound, decisively below the 30s overall
+	// bound. 5s is a generous ceiling that still proves it did not wait overall.
+	if elapsed > 5*time.Second {
+		t.Fatalf("cache fallback took %v — it must fire at the primary bound (200ms), not the 30s overall bound", elapsed)
+	}
+}
+
+// TestResolvePreTLSGreeting_OwnLatePreferredOverCache pins that a merely-late
+// own leg arriving within the primary bound is preferred over the cache (it
+// carries this connection's real salt+timestamp): with the cache populated but
+// the own entry pushed shortly after start, resolve must return greetingOwn.
+func TestResolvePreTLSGreeting_OwnLatePreferredOverCache(t *testing.T) {
+	t.Setenv("KEPLOY_MYSQL_POSTTLS_STASH_PRIMARY_MS", "3000")
+
+	store := models.NewTLSHandshakeStore()
+	// Cache is populated (a sibling), but the own leg is merely late.
+	store.Push(models.HandshakeStoreKey("", 3306), models.TLSHandshakeEntry{
+		RespPackets: [][]byte{[]byte("sibling-greeting")},
+	})
+	if _, ok := store.PopWait(models.HandshakeStoreKey("", 3306), 0); !ok {
+		t.Fatal("setup: expected to consume the sibling's queued entry")
+	}
+	ownTs := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		store.Push(models.HandshakeStoreKey("", 3306), models.TLSHandshakeEntry{
+			RespPackets:  [][]byte{[]byte("own-greeting")},
+			ReqTimestamp: ownTs,
+		})
+	}()
+
+	entry, source := resolvePreTLSGreeting(context.Background(), store, "", 3306)
+	if source != greetingOwn {
+		t.Fatalf("source = %v, want greetingOwn (a late own leg within the primary bound beats the cache)", source)
+	}
+	if !entry.ReqTimestamp.Equal(ownTs) {
+		t.Errorf("ReqTimestamp = %v, want the own leg's %v", entry.ReqTimestamp, ownTs)
+	}
+}

--- a/pkg/models/instrument.go
+++ b/pkg/models/instrument.go
@@ -227,6 +227,18 @@ type ConditionalDstCfg struct {
 	Addr   string // Destination Addr (ip:port)
 	Port   uint
 	TLSCfg *tls.Config
+	// AddrFabricated marks Addr/Port as a stand-in the capture layer
+	// synthesized because it could not resolve the connection's REAL
+	// destination (e.g. the proxyless SSL-uprobe path substitutes
+	// 127.0.0.1:0 when the pid→dest cache is ambiguous, and content
+	// matching later forces the well-known port, yielding
+	// "127.0.0.1:3306"). Such an address is good enough for parser
+	// selection and mock metadata (grouping), but it does NOT point at
+	// the server this connection actually talked to — consumers MUST
+	// NOT dial it (the MySQL recorder's fetchServerGreeting fallback
+	// would otherwise connect to an unrelated local server, or fail
+	// instantly with ECONNREFUSED and abort the capture).
+	AddrFabricated bool
 }
 
 type IncomingOptions struct {

--- a/pkg/models/tls_handshake_store.go
+++ b/pkg/models/tls_handshake_store.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 )
@@ -31,6 +32,21 @@ type TLSHandshakeStore struct {
 	mu   sync.Mutex
 	cond *sync.Cond
 	m    map[string][]timedTLSHandshakeEntry
+	// last remembers, per PORT-scoped key, the most recent entry ever pushed —
+	// independently of the consumable queue in m. Only port keys are cached
+	// here (Push skips conn-scoped keys) because it is never TTL/size-pruned and
+	// the only reader queries it by port. Unlike m it is never
+	// consumed by Pop and never TTL-pruned: it is the last-resort
+	// fallback for a consumer whose OWN raw-leg entry was genuinely
+	// lost (e.g. the plaintext MySQL greeting+SSLRequest capture event
+	// dropped by a full ringbuf under load). A MySQL server's greeting
+	// is reusable across connections for stitching purposes: the
+	// capability flags, protocol version and auth plugin are per-server
+	// (stable), and the only per-connection field — the auth-plugin-data
+	// salt — is not verified anywhere on the record or replay path (the
+	// replayer explicitly skips AuthResponse comparison because it is
+	// salt-dependent; see mysql/replayer/match.go matchHanshakeResponse41).
+	last map[string]TLSHandshakeEntry
 }
 
 type timedTLSHandshakeEntry struct {
@@ -40,7 +56,10 @@ type timedTLSHandshakeEntry struct {
 
 // NewTLSHandshakeStore creates a new store.
 func NewTLSHandshakeStore() *TLSHandshakeStore {
-	s := &TLSHandshakeStore{m: make(map[string][]timedTLSHandshakeEntry)}
+	s := &TLSHandshakeStore{
+		m:    make(map[string][]timedTLSHandshakeEntry),
+		last: make(map[string]TLSHandshakeEntry),
+	}
 	s.cond = sync.NewCond(&s.mu)
 	return s
 }
@@ -56,7 +75,8 @@ func HandshakeStoreKey(connKey string, dstPort uint16) string {
 	return fmt.Sprintf("port:%d", dstPort)
 }
 
-// Push adds a handshake entry for the given key.
+// Push adds a handshake entry for the given key. It also refreshes the
+// key's last-greeting cache (see Last).
 func (s *TLSHandshakeStore) Push(key string, entry TLSHandshakeEntry) {
 	s.mu.Lock()
 	s.pruneExpiredLocked(time.Now())
@@ -68,8 +88,38 @@ func (s *TLSHandshakeStore) Push(key string, entry TLSHandshakeEntry) {
 		entry:    entry,
 		pushedAt: time.Now(),
 	})
+	// Only PORT-scoped keys ("port:<n>", from HandshakeStoreKey with an empty
+	// connKey) feed the last-greeting cache. The post-TLS stitch's fallback
+	// reads Last() by the port-only key exclusively (see recorder/record_v2.go
+	// resolvePreTLSGreeting), so a conn-scoped ("conn:<connKey>") entry here
+	// would never be read — and, because `last` is deliberately never
+	// TTL/size-pruned (unlike m), a per-connection key would accumulate without
+	// bound over a long record session. Restrict the cache to the reusable,
+	// low-cardinality port keys.
+	if strings.HasPrefix(key, "port:") {
+		if s.last == nil {
+			s.last = make(map[string]TLSHandshakeEntry)
+		}
+		s.last[key] = entry
+	}
 	s.cond.Broadcast()
 	s.mu.Unlock()
+}
+
+// Last returns the most recent entry ever pushed for key, without
+// consuming anything. Unlike PopWait it survives consumption by other
+// connections and the TTL prune, so it stays available as a stitching
+// fallback when a connection's own raw-leg entry was lost (dropped
+// capture event / >TTL delay). Callers must treat the result as
+// belonging to ANOTHER connection to the same destination: reuse the
+// server-stable parts (greeting capabilities / plugin, client
+// SSLRequest shape) but not per-connection metadata such as the
+// request timestamp.
+func (s *TLSHandshakeStore) Last(key string) (TLSHandshakeEntry, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, ok := s.last[key]
+	return entry, ok
 }
 
 // PopWait pops the oldest handshake entry for the given key, waiting up

--- a/pkg/models/tls_handshake_store_test.go
+++ b/pkg/models/tls_handshake_store_test.go
@@ -1,0 +1,116 @@
+package models
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestTLSHandshakeStore_LastSurvivesConsumption pins the last-greeting cache
+// contract that the MySQL post-TLS stitch relies on when a connection's own
+// raw-leg entry is lost (dropped capture event): Last must keep returning the
+// most recent pushed entry for a key even after the consumable queue was
+// drained by other connections, and a newer Push must overwrite it.
+func TestTLSHandshakeStore_LastSurvivesConsumption(t *testing.T) {
+	s := NewTLSHandshakeStore()
+	key := HandshakeStoreKey("", 3306)
+
+	if _, ok := s.Last(key); ok {
+		t.Fatal("Last on an empty store must miss")
+	}
+
+	entry1 := TLSHandshakeEntry{
+		RespPackets:  [][]byte{[]byte("greeting-1")},
+		ReqPackets:   [][]byte{[]byte("sslreq-1")},
+		ReqTimestamp: time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC),
+	}
+	s.Push(key, entry1)
+
+	// Consume the queue the way another connection's PopWait would.
+	if _, ok := s.PopWait(key, 0); !ok {
+		t.Fatal("PopWait must return the pushed entry")
+	}
+	if _, ok := s.PopWait(key, 0); ok {
+		t.Fatal("queue must be empty after the pop")
+	}
+
+	// The last-greeting cache must still serve entry1.
+	got, ok := s.Last(key)
+	if !ok {
+		t.Fatal("Last must survive queue consumption — it is the lost-raw-leg fallback")
+	}
+	if len(got.RespPackets) != 1 || !bytes.Equal(got.RespPackets[0], []byte("greeting-1")) {
+		t.Fatalf("Last returned wrong entry: %+v", got)
+	}
+
+	// A newer push overwrites the cache.
+	entry2 := TLSHandshakeEntry{RespPackets: [][]byte{[]byte("greeting-2")}}
+	s.Push(key, entry2)
+	got, ok = s.Last(key)
+	if !ok || !bytes.Equal(got.RespPackets[0], []byte("greeting-2")) {
+		t.Fatalf("Last must return the most recent push, got %+v ok=%v", got, ok)
+	}
+
+	// Keys are independent.
+	if _, ok := s.Last(HandshakeStoreKey("", 5432)); ok {
+		t.Fatal("Last must be keyed — a different port must miss")
+	}
+}
+
+// TestTLSHandshakeStore_LastOnlyCachesPortKeys pins the leak guard (finding A):
+// `last` is never TTL/size-pruned, so it must only cache low-cardinality
+// PORT-scoped keys. A conn-scoped key must NOT populate `last` (it would
+// accumulate one unremovable entry per connection over a long session) — while
+// still flowing normally through the consumable queue m.
+func TestTLSHandshakeStore_LastOnlyCachesPortKeys(t *testing.T) {
+	s := NewTLSHandshakeStore()
+	connKey := HandshakeStoreKey("srcport:55123", 3306) // -> "conn:srcport:55123"
+	if !strings.HasPrefix(connKey, "conn:") {
+		t.Fatalf("precondition: expected a conn-scoped key, got %q", connKey)
+	}
+
+	entry := TLSHandshakeEntry{RespPackets: [][]byte{[]byte("greeting")}}
+	s.Push(connKey, entry)
+
+	// The conn-scoped push must be popable from the queue (unchanged behavior).
+	if _, ok := s.PopWait(connKey, 0); !ok {
+		t.Fatal("conn-scoped entry must still be queued/popable in m")
+	}
+	// ...but it must NOT have been cached in `last` (the unpruned map).
+	if _, ok := s.Last(connKey); ok {
+		t.Fatal("conn-scoped key must NOT populate the last-greeting cache — it would leak unbounded")
+	}
+
+	// A port-scoped push is cached as before.
+	portKey := HandshakeStoreKey("", 3306)
+	s.Push(portKey, entry)
+	if _, ok := s.Last(portKey); !ok {
+		t.Fatal("port-scoped key must populate the last-greeting cache")
+	}
+}
+
+// TestTLSHandshakeStore_PopWaitWakesOnPush pins that a blocked PopWait is
+// woken by a Push well before its timeout — the property that makes the
+// recorder's long bounded wait free on the success path.
+func TestTLSHandshakeStore_PopWaitWakesOnPush(t *testing.T) {
+	s := NewTLSHandshakeStore()
+	key := HandshakeStoreKey("", 3306)
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		s.Push(key, TLSHandshakeEntry{RespPackets: [][]byte{[]byte("g")}})
+	}()
+
+	start := time.Now()
+	entry, ok := s.PopWait(key, 5*time.Second)
+	if !ok {
+		t.Fatal("PopWait must return the entry pushed during the wait")
+	}
+	if len(entry.RespPackets) != 1 {
+		t.Fatalf("wrong entry: %+v", entry)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("PopWait took %v — it must wake on Push, not sleep out the timeout", elapsed)
+	}
+}


### PR DESCRIPTION
## Describe the changes that are made
- **Fixes the intermittent MySQL-over-TLS capture shortfall** (`e2e-mysql-tls-lowlatency-cycle` "(2a) served but NOT recorded"), a pre-existing flake on main that worsens under CPU pressure.
- Root cause: for a MySQL-over-TLS connection, the plaintext leg (server greeting + client SSLRequest) is captured separately and stitched onto the decrypted leg to decode the command phase. The old post-TLS path waited only **5s** for the stashed greeting and, on miss, **dialed the destination** to fetch one — but under degraded SSL-dest resolution that destination is a fabricated `127.0.0.1:3306`, so the dial hits ECONNREFUSED and the whole connection was **aborted before the COM_QUERY was decoded**. Under load the plaintext leg lands >5s late or is dropped, so a random subset of connections are served but never recorded.
- **Fix**:
  - `resolvePreTLSGreeting` — two-phase wait. Up to a short **primary bound (8s**, `KEPLOY_MYSQL_POSTTLS_STASH_PRIMARY_MS`) it waits for *this* connection's own greeting (woken instantly on push), so a merely-late leg is still stitched with its real per-connection salt+timestamp. Once primary elapses **and** a greeting is cached for the port, it uses the cache immediately (the dropped-leg fast path) instead of blocking the full 30s overall bound; only with no cache does it keep waiting. ctx-cancellation cuts any wait within a 500ms slice. This is the load-bearing property: a dropped-leg connection records at ~8s, comfortably inside the e2e's own 30s (2a) settle window.
  - `TLSHandshakeStore.Last` — a non-consuming last-greeting cache. A reused sibling greeting carries a different salt, which is **harmless**: replay's `matchHanshakeResponse41` never compares `AuthResponse`, and record-side decode reads capability flags + plugin name (per-server-stable), never the salt. `Push` caches only port-scoped keys so the never-pruned cache can't leak on conn-scoped keys.
  - `fetchServerGreeting` refuses a `DstCfg.AddrFabricated` address instead of dialing a fabricated loopback.
- Replicated first (the RCA reproduced the abort against the real recorder at exactly 5.001s with zero mocks emitted); every mechanism is pinned by a permanent regression test, including one that proves the dropped-leg fallback lands at the *primary* bound, not the 30s overall.

## Links & References
**Closes:** NA (pre-existing flake; RCA in the k8s-proxy CI investigation)
### 🔗 Related PRs
- **Enterprise companion (required pair): `fix/mysql-ssl-dest-remember`** — sets `DstCfg.AddrFabricated` on the fabricated dests (the *producer* of the flag this PR's `fetchServerGreeting` guard consumes) and seeds the true dest on SSLRequest detect so `resolveSSLDest` stops degrading MySQL. The guard is **dormant in OSS-standalone builds** (which don't fabricate dests) and engages when paired with the enterprise agent. These two land together.
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [x] 🐞 Bug Fix
- [x] ✅ Test

## Added e2e test pipeline?
- [x] 🙋 no, because I need help — the failing e2e lives in `keploy/mysql-tls-sample` + `k8s-proxy`; this OSS PR is the recorder-layer fix, pinned by unit/integration regression tests. A follow-up should add `"no greeting in store"` / `"failed to handle initial mysql handshake"` to that harness's (2a) evidence-dump grep so a recurrence is one-read confirmable.

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
  - `go test ./pkg/agent/proxy/integrations/mysql/... ./pkg/models/ -race -count=1`

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- Pre-fix: recorder aborts at 5.001s — `post-TLS V2: no greeting in store (key port 3306) and direct fetch failed: dial ... connection refused`, zero mocks emitted.

## Known limitation
- The legacy V1 relay path (`KEPLOY_NEW_RELAY=off`, the debug escape hatch) keeps the old 5s cliff; V2 is the default and carries the fix.
