### PR TITLE
fix(mock): allow native commands where a backend exists, and stop exiting 0 on failure

### DIFF
--- a/.github/workflows/golang_linux.yml
+++ b/.github/workflows/golang_linux.yml
@@ -73,9 +73,18 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Install yq
+      - name: Ensure yq
         run: |
-          # -f so an HTTP error is not silently written into the yq binary
+          # yq ships preinstalled on the ubuntu-24.04 runner image, so the
+          # unconditional download here was a redundant network hop that took the
+          # whole job down whenever github.com hiccuped — it failed with six
+          # consecutive 504s despite --retry 5. Use what is already there, and
+          # only reach out if a future image drops it.
+          if command -v yq >/dev/null 2>&1; then
+            echo "using preinstalled $(yq --version)"
+            exit 0
+          fi
+          echo "yq not present on this image; installing"
           curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused \
             https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o yq
           chmod +x yq
@@ -251,9 +260,18 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Install yq
+      - name: Ensure yq
         run: |
-          # -f so an HTTP error is not silently written into the yq binary
+          # yq ships preinstalled on the ubuntu-24.04 runner image, so the
+          # unconditional download here was a redundant network hop that took the
+          # whole job down whenever github.com hiccuped — it failed with six
+          # consecutive 504s despite --retry 5. Use what is already there, and
+          # only reach out if a future image drops it.
+          if command -v yq >/dev/null 2>&1; then
+            echo "using preinstalled $(yq --version)"
+            exit 0
+          fi
+          echo "yq not present on this image; installing"
           curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused \
             https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o yq
           chmod +x yq

--- a/cli/mock.go
+++ b/cli/mock.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 	"go.keploy.io/server/v3/config"
@@ -63,16 +64,25 @@ func MockRecord(ctx context.Context, logger *zap.Logger, serviceFactory ServiceF
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return cmdConfigurator.Validate(ctx, cmd)
 		},
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			svc, err := serviceFactory.GetService(ctx, "mock-record")
 			if err != nil {
 				utils.LogError(logger, err, "failed to get service")
-				return nil
+				// Return the error, don't swallow it: main's exitCodeForCmdErr
+				// turns a non-nil error into exit 1. Returning nil here reported
+				// SUCCESS to the shell and to CI after a hard setup failure — so
+				// `keploy mock record ... --name nope` printed four ERROR lines and
+				// still exited 0. The wrapped runner's own exit code is a
+				// separate channel (utils.ErrCode via propagateExit) and is
+				// untouched by this.
+				return err
 			}
 			m, ok := svc.(mockSvc.Service)
 			if !ok {
-				utils.LogError(logger, nil, "service doesn't satisfy mock service interface")
-				return nil
+				err := fmt.Errorf("service doesn't satisfy mock service interface")
+				utils.LogError(logger, nil, err.Error())
+				return err
 			}
 			// Ensure background goroutines (agent monitor, proxy streams) are
 			// torn down when Record returns, unless the user already interrupted.
@@ -84,9 +94,16 @@ func MockRecord(ctx context.Context, logger *zap.Logger, serviceFactory ServiceF
 				}
 			}()
 			if err := m.Record(ctx); err != nil {
-				if ctx.Err() != context.Canceled {
-					utils.LogError(logger, err, "failed to record mocks")
+				// A user interrupt is not a failure.
+				if ctx.Err() == context.Canceled {
+					return nil
 				}
+				utils.LogError(logger, err, "failed to record mocks")
+				// Record() returns nil after a merely-failing test command (it calls
+				// propagateExit and lets utils.ErrCode mirror the runner), so a
+				// non-nil error here is always a real Keploy failure and must not
+				// exit 0.
+				return err
 			}
 			return nil
 		},
@@ -103,16 +120,25 @@ func MockReplay(ctx context.Context, logger *zap.Logger, serviceFactory ServiceF
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return cmdConfigurator.Validate(ctx, cmd)
 		},
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			svc, err := serviceFactory.GetService(ctx, "mock-replay")
 			if err != nil {
 				utils.LogError(logger, err, "failed to get service")
-				return nil
+				// Return the error, don't swallow it: main's exitCodeForCmdErr
+				// turns a non-nil error into exit 1. Returning nil here reported
+				// SUCCESS to the shell and to CI after a hard setup failure — so
+				// `keploy mock replay ... --name nope` printed four ERROR lines and
+				// still exited 0. The wrapped runner's own exit code is a
+				// separate channel (utils.ErrCode via propagateExit) and is
+				// untouched by this.
+				return err
 			}
 			m, ok := svc.(mockSvc.Service)
 			if !ok {
-				utils.LogError(logger, nil, "service doesn't satisfy mock service interface")
-				return nil
+				err := fmt.Errorf("service doesn't satisfy mock service interface")
+				utils.LogError(logger, nil, err.Error())
+				return err
 			}
 			defer func() {
 				select {
@@ -122,9 +148,16 @@ func MockReplay(ctx context.Context, logger *zap.Logger, serviceFactory ServiceF
 				}
 			}()
 			if err := m.Replay(ctx); err != nil {
-				if ctx.Err() != context.Canceled {
-					utils.LogError(logger, err, "failed to replay mocks")
+				// A user interrupt is not a failure.
+				if ctx.Err() == context.Canceled {
+					return nil
 				}
+				utils.LogError(logger, err, "failed to replay mocks")
+				// Replay() returns nil after a merely-failing test command (it calls
+				// propagateExit and lets utils.ErrCode mirror the runner), so a
+				// non-nil error here is always a real Keploy failure and must not
+				// exit 0.
+				return err
 			}
 			return nil
 		},

--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -121,7 +121,7 @@ Usage:{{if .Runnable}}
   {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
 
 Aliases:
-  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+  {{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}
 
 Available Commands:{{range .Commands}}{{if .IsAvailableCommand}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableFlags}}
@@ -2008,9 +2008,17 @@ func (c *CmdConfigurator) validateMockFlags(ctx context.Context, cmd *cobra.Comm
 		return err
 	}
 	c.cfg.CommandType = commandType
-	if (c.cfg.CommandType == string(utils.Native) || c.cfg.CommandType == string(utils.Empty)) &&
-		!(runtime.GOOS == "linux" || (runtime.GOOS == "windows" && runtime.GOARCH == "amd64")) {
-		return fmt.Errorf("a native command is not supported on OS %s/%s for `keploy mock`; on macOS run your tests through a docker command (e.g. -c \"docker compose run tests\")", runtime.GOOS, runtime.GOARCH)
+	// Ask the same extension point `record`/`test` use (see the identical check
+	// above in validateFlags). This literal was copied here from the record path
+	// as it stood BEFORE that check became nativeCommandSupportedHere(), so it
+	// never learned about the native backends a wrapping build registers —
+	// macOS (DYLD shim) and Windows. The result was that `keploy record` ran
+	// natively on darwin while `keploy mock` refused, on the same binary.
+	if (c.cfg.CommandType == string(utils.Native) || c.cfg.CommandType == string(utils.Empty)) && !nativeCommandSupportedHere() {
+		// Retrying cannot help — the command shape has to change — so give the
+		// caller a code that says so rather than a generic 1.
+		utils.SetExitCodeOnce(utils.ExitUnsupportedPlatform)
+		return fmt.Errorf("a native command is not supported on OS %s/%s for `keploy mock`; run your tests through a docker command instead (e.g. -c \"docker compose run tests\")", runtime.GOOS, runtime.GOARCH)
 	}
 
 	// Resolve the keploy folder path.

--- a/pkg/platform/http/agent.go
+++ b/pkg/platform/http/agent.go
@@ -973,6 +973,10 @@ func (a *AgentClient) startAgent(ctx context.Context, isDockerCmd bool, opts mod
 		// Helper check to ensure the binary running inside docker has the required capabilities
 		if err := utils.CheckRequiredPermissions(); err != nil {
 			a.logger.Error("Failed to start Keploy Agent", zap.Error(err))
+			// Distinct exit code: a caller must be able to tell "Keploy needs
+			// kernel privileges" from "your tests failed", both of which used to
+			// be a bare 1. See utils/exitcodes.go.
+			utils.SetExitCodeOnce(utils.ExitPrivilegeRequired)
 			return err
 		}
 		// Start the agent in Docker container using errgroup

--- a/pkg/service/mock/replay.go
+++ b/pkg/service/mock/replay.go
@@ -252,6 +252,26 @@ func (m *mockService) pushScopeTable(ctx context.Context, name string) {
 	m.logger.Info("per-test scoping enabled", zap.Int("tests", len(table)), zap.String("mock-set", name))
 }
 
+// ReplayOutcome is what a replay produced, for a wrapping build that meters or
+// reports usage. Counts only; no payloads, no destinations.
+type ReplayOutcome struct {
+	SetName  string
+	Loaded   int
+	Consumed int
+	Missed   int
+}
+
+// replayOutcomeReporter is installed by a wrapping build (enterprise) from
+// init(). Mirrors the RegisterNativeCommandSupport extension point in
+// cli/provider/hooks.go: OSS stays free of any billing/api-server dependency,
+// and a build that has one opts in.
+var replayOutcomeReporter func(context.Context, ReplayOutcome)
+
+// RegisterReplayOutcomeReporter installs the reporter. A nil fn disables it.
+func RegisterReplayOutcomeReporter(fn func(context.Context, ReplayOutcome)) {
+	replayOutcomeReporter = fn
+}
+
 // reportOutcome logs which mocks were consumed and which outgoing calls matched
 // nothing, and returns the number of distinct missed calls.
 func (m *mockService) reportOutcome(ctx context.Context, loaded int) int {
@@ -267,12 +287,25 @@ func (m *mockService) reportOutcome(ctx context.Context, loaded int) int {
 		zap.Int("loaded", loaded),
 		zap.Int("consumed", len(consumed)),
 		zap.Int("missed", len(misses)))
+
 	for _, miss := range misses {
 		m.logger.Warn("no recorded mock matched an outgoing call",
 			zap.String("protocol", miss.Protocol),
 			zap.String("call", miss.ActualSummary),
 			zap.String("destination", miss.Destination),
 			zap.String("next_step", "record this call with --on-miss record, or re-record the set"))
+	}
+
+	// Metering LAST: it may do network I/O, and the miss warnings above are what
+	// the user actually needs to see first. Never for --local — that is the free
+	// offline loop and is deliberately unmetered and untracked.
+	if replayOutcomeReporter != nil && !m.config.Mock.Local {
+		replayOutcomeReporter(ctx, ReplayOutcome{
+			SetName:  m.config.Mock.Name,
+			Loaded:   loaded,
+			Consumed: len(consumed),
+			Missed:   len(misses),
+		})
 	}
 	return len(misses)
 }

--- a/utils/exitcodes.go
+++ b/utils/exitcodes.go
@@ -1,0 +1,46 @@
+package utils
+
+// Keploy's own exit codes.
+//
+// THE CONTRACT, and the reason it is narrow:
+//
+//	0        the wrapped test command succeeded (or there was none)
+//	<runner> the wrapped test command's OWN exit code, propagated verbatim.
+//	         Every CI job depends on this, so Keploy must never overwrite it —
+//	         see mock.propagateExit.
+//	1        a generic Keploy-side failure
+//	3,4      a SPECIFIC Keploy-side failure, listed below
+//
+// The specific codes exist so a caller can react correctly instead of pattern
+// matching log text or guessing from a bare 1. The VS Code extension, for
+// example, used to show an eBPF/setcap tutorial on ANY non-zero exit while
+// unelevated on Linux — which meant a plainly failing `pytest` (exit 1, the most
+// common non-zero code there is) told the user they had a permissions problem.
+//
+// These are only ever set for failures that ALREADY exited 1, so nothing that
+// previously succeeded starts failing. Deliberately kept clear of the shell's
+// reserved range (126, 127) and of 128+N signal codes.
+const (
+	// ExitKeployError is the generic Keploy-side failure.
+	ExitKeployError = 1
+
+	// ExitPrivilegeRequired means Keploy could not obtain the kernel privileges
+	// it needs (eBPF: CAP_SYS_ADMIN / CAP_BPF / CAP_NET_ADMIN / CAP_PERFMON).
+	// The remedy is `setcap` on the binary once, or running elevated — NOT
+	// retrying, and not anything to do with the user's tests.
+	ExitPrivilegeRequired = 3
+
+	// ExitUnsupportedPlatform means the requested mode cannot work on this
+	// OS/arch at all — e.g. a native command where only a container command is
+	// supported. Retrying is pointless; the command shape must change.
+	ExitUnsupportedPlatform = 4
+)
+
+// SetExitCodeOnce records a specific Keploy-side exit code, but never clobbers
+// a code already set — in particular the wrapped runner's own code, which
+// propagateExit may have installed first and which outranks ours.
+func SetExitCodeOnce(code int) {
+	if ErrCode == 0 {
+		ErrCode = code
+	}
+}


### PR DESCRIPTION
## What

`keploy mock` refused a native command on macOS while `keploy record` accepted one **on the same binary**.

The gate in `validateMockFlags` (`cli/provider/cmd.go`) was a copy of the record gate as it stood *before* #4467 replaced that literal with the `nativeCommandSupportedHere()` extension point. The mock command landed one day later in #4469 and reproduced the stale copy, so it never learned about the native backends a wrapping build registers. It now asks the extension point, like `record`/`test` do.

The literal was wrong in the other direction too: it still allowed `windows/amd64` after native Windows interception moved out of OSS, so a pure-OSS Windows build passed the gate and then failed with a confusing eBPF error much later.

## Also in this PR

- **`mock record|replay` no longer exits 0 on hard failures.** They returned `nil` after a failed `GetService` or a real `Record()`/`Replay()` error, reporting SUCCESS to the shell and to CI. `SilenceUsage` is set so a genuine failure does not print 4KB of usage. **The wrapped runner's exit code is untouched** — that is a separate channel (`utils.ErrCode` via `propagateExit`) and `Record()` returns `nil` on every path that reaches it.
- **A documented exit-code contract** (`utils/exitcodes.go`): distinct codes for *"Keploy needs kernel privileges"* (3) and *"unsupported on this platform"* (4). Both previously exited 1 — which is also what a failing `pytest` exits, so callers could not tell them apart. The VS Code extension was showing a setcap tutorial to people whose tests had simply failed. Only failures that already exited 1 get a new code, so nothing that previously succeeded starts failing.
- **`keploy mock --help` lists its subcommands.** "Available Commands" was gated behind `{{if .HasExample}}`.
- **A replay-outcome extension point** so a wrapping build can meter registry usage. It is never invoked for `--local`, which stays the free offline loop.

## Verification

`go build ./...`, `go test ./cli/... ./pkg/service/mock/... ./utils/...` all pass. The macOS behaviour was verified by building the enterprise CLI against this branch and running record → replay natively: `--on-miss fail` served the identical recorded response with `consumed:1 missed:0`, no Docker and no sudo.

## Note

The enterprise change that completes the macOS fix depends on the `ReplayOutcome` extension point added here, so this needs to be released and `go.mod` bumped there.