### PR TITLE
Fix/4349 header list order

### DIFF
--- a/pkg/matcher/header_listorder_test.go
+++ b/pkg/matcher/header_listorder_test.go
@@ -1,0 +1,94 @@
+package matcher
+
+import (
+	"net/http"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg"
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// The exact shape reported in keploy/keploy#4349: a server that builds Allow
+// from an unordered collection emits the same set of methods in a different
+// order on the replay, and the test failed on it.
+func TestCompareHeaders_UnorderedListHeaderReorder(t *testing.T) {
+	cases := []struct {
+		name     string
+		exp, act map[string]string
+		want     bool
+	}{
+		{"issue 4349: Allow reordered", map[string]string{"Allow": "POST, OPTIONS"}, map[string]string{"Allow": "OPTIONS, POST"}, true},
+		{"Allow identical", map[string]string{"Allow": "POST, OPTIONS"}, map[string]string{"Allow": "POST, OPTIONS"}, true},
+		{"Allow gained a method", map[string]string{"Allow": "POST, OPTIONS"}, map[string]string{"Allow": "OPTIONS, POST, GET"}, false},
+		{"Allow lost a method", map[string]string{"Allow": "POST, OPTIONS, GET"}, map[string]string{"Allow": "OPTIONS, POST"}, false},
+		{"Allow swapped a method", map[string]string{"Allow": "POST, OPTIONS"}, map[string]string{"Allow": "PUT, OPTIONS"}, false},
+		{"Vary reordered", map[string]string{"Vary": "Accept-Encoding, Origin"}, map[string]string{"Vary": "Origin, Accept-Encoding"}, true},
+		{"Cache-Control reordered", map[string]string{"Cache-Control": "no-cache, max-age=0"}, map[string]string{"Cache-Control": "max-age=0, no-cache"}, true},
+		{"CORS methods reordered", map[string]string{"Access-Control-Allow-Methods": "GET, POST"}, map[string]string{"Access-Control-Allow-Methods": "POST, GET"}, true},
+		{"lowercase header name still matched", map[string]string{"allow": "POST, OPTIONS"}, map[string]string{"allow": "OPTIONS, POST"}, true},
+		{"whitespace-only encoding change", map[string]string{"Allow": "POST,OPTIONS"}, map[string]string{"Allow": "POST, OPTIONS"}, true},
+
+		// Order IS semantic for these: reordering must stay a failure.
+		{"Content-Encoding reordered stays a failure", map[string]string{"Content-Encoding": "gzip, br"}, map[string]string{"Content-Encoding": "br, gzip"}, false},
+		{"Via reordered stays a failure", map[string]string{"Via": "1.1 a, 1.1 b"}, map[string]string{"Via": "1.1 b, 1.1 a"}, false},
+		{"Set-Cookie reordered stays a failure", map[string]string{"Set-Cookie": "a=1, b=2"}, map[string]string{"Set-Cookie": "b=2, a=1"}, false},
+		{"unlisted header reordered stays a failure", map[string]string{"X-Thing": "a, b"}, map[string]string{"X-Thing": "b, a"}, false},
+
+		// Unrelated regressions guarded.
+		{"plain header value change stays a failure", map[string]string{"Content-Type": "application/json"}, map[string]string{"Content-Type": "text/plain"}, false},
+		{"missing header stays a failure", map[string]string{"Allow": "POST"}, map[string]string{}, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			res := &[]models.HeaderResult{}
+			got := CompareHeaders(pkg.ToHTTPHeader(c.exp), pkg.ToHTTPHeader(c.act), res, map[string][]string{})
+			if got != c.want {
+				t.Errorf("CompareHeaders() = %v, want %v (results: %+v)", got, c.want, *res)
+			}
+		})
+	}
+}
+
+// A comma-folded header and repeated same-name headers are the same header
+// (RFC 9110 §5.3), so the fix must see through the encoding difference too.
+func TestCompareHeaders_FoldedVsRepeated(t *testing.T) {
+	exp := http.Header{"Allow": []string{"POST, OPTIONS"}}
+	act := http.Header{"Allow": []string{"OPTIONS", "POST"}}
+	res := &[]models.HeaderResult{}
+	if !CompareHeaders(exp, act, res, map[string][]string{}) {
+		t.Errorf("folded and repeated encodings of the same list should match, got mismatch: %+v", *res)
+	}
+
+	// but not when the elements actually differ
+	act2 := http.Header{"Allow": []string{"OPTIONS", "GET"}}
+	res2 := &[]models.HeaderResult{}
+	if CompareHeaders(exp, act2, res2, map[string][]string{}) {
+		t.Error("differing elements must not match")
+	}
+}
+
+func TestSplitHTTPListValues(t *testing.T) {
+	cases := []struct {
+		in   []string
+		want []string
+	}{
+		{[]string{"POST, OPTIONS"}, []string{"POST", "OPTIONS"}},
+		{[]string{"POST,OPTIONS"}, []string{"POST", "OPTIONS"}},
+		{[]string{"gzip,,deflate"}, []string{"gzip", "deflate"}},
+		{[]string{"POST", "OPTIONS"}, []string{"POST", "OPTIONS"}},
+		{[]string{`no-cache="X-Foo, X-Bar", max-age=0`}, []string{`no-cache="X-Foo, X-Bar"`, "max-age=0"}},
+		{[]string{""}, nil},
+	}
+	for _, c := range cases {
+		got := splitHTTPListValues(c.in)
+		if len(got) != len(c.want) {
+			t.Fatalf("splitHTTPListValues(%q) = %q, want %q", c.in, got, c.want)
+		}
+		for i := range got {
+			if got[i] != c.want[i] {
+				t.Fatalf("splitHTTPListValues(%q) = %q, want %q", c.in, got, c.want)
+			}
+		}
+	}
+}

--- a/pkg/matcher/utils.go
+++ b/pkg/matcher/utils.go
@@ -1857,7 +1857,12 @@ func CompareHeaders(h1 http.Header, h2 http.Header, res *[]models.HeaderResult, 
 				match = false
 				continue
 			}
-			if len(v) != len(val) {
+			// A recorded and a replayed header value are compared for
+			// EQUIVALENCE, not byte-for-byte identity of the recorded
+			// encoding: for a list-valued header whose elements are a set,
+			// "POST, OPTIONS" and "OPTIONS, POST" are the same header and
+			// must not fail the test (keploy/keploy#4349).
+			if !HeaderValuesMatch(k, v, val) {
 				if checkKey(res, k) {
 					*res = append(*res, models.HeaderResult{
 						Normal: false,
@@ -1873,25 +1878,6 @@ func CompareHeaders(h1 http.Header, h2 http.Header, res *[]models.HeaderResult, 
 				}
 				match = false
 				continue
-			}
-			for i, e := range v {
-				if val[i] != e {
-					if checkKey(res, k) {
-						*res = append(*res, models.HeaderResult{
-							Normal: false,
-							Expected: models.Header{
-								Key:   k,
-								Value: v,
-							},
-							Actual: models.Header{
-								Key:   k,
-								Value: val,
-							},
-						})
-					}
-					match = false
-					continue
-				}
 			}
 		}
 		if checkKey(res, k) {
@@ -2172,6 +2158,73 @@ func ParseContentType(raw string) (typ string, params map[string]string, okStric
 		return "", nil, false, e
 	}
 	return token, map[string]string{}, false, e
+}
+
+// HeaderValuesMatch reports whether the recorded and the replayed values of the
+// header called name assert the same thing.
+//
+// The default is the strict one: the value slices must be identical, element
+// for element. It is relaxed only for the headers models.IsUnorderedListHeader
+// names — those whose grammar makes the comma-separated elements a set rather
+// than a sequence. For those, both sides are flattened into their list elements
+// and compared as multisets, so a server that emits "POST, OPTIONS" on one run
+// and "OPTIONS, POST" on the next no longer fails the test, and so does a
+// server that switches between one comma-folded header and repeated same-name
+// headers — RFC 9110 §5.3 says those two encodings are equivalent.
+//
+// Element comparison stays case- and whitespace-exact within an element: only
+// the ORDER of the elements and the choice of encoding are forgiven, never a
+// changed element.
+func HeaderValuesMatch(name string, expected, actual []string) bool {
+	if slices.Equal(expected, actual) {
+		return true
+	}
+	if !models.IsUnorderedListHeader(name) {
+		return false
+	}
+	return CompareSlicesIgnoreOrder(splitHTTPListValues(expected), splitHTTPListValues(actual))
+}
+
+// splitHTTPListValues flattens a header's values into the list elements of
+// RFC 9110 §5.6.1: each value is split on the commas that sit outside a quoted
+// string, and each element is trimmed of the optional whitespace the grammar
+// allows around it.
+//
+// Commas inside a quoted-string are NOT separators — Cache-Control's
+// no-cache="X-Foo, X-Bar" is one directive, not two — so the scan tracks
+// quoting and the backslash escapes that may appear inside it.
+//
+// Empty elements are dropped rather than compared: the "#rule" grammar
+// explicitly tolerates them for compatibility with legacy senders, so
+// "gzip,,deflate" and "gzip, deflate" are the same list.
+func splitHTTPListValues(values []string) []string {
+	var out []string
+	for _, v := range values {
+		start := 0
+		inQuotes := false
+		escaped := false
+		flush := func(end int) {
+			if elem := strings.TrimSpace(v[start:end]); elem != "" {
+				out = append(out, elem)
+			}
+		}
+		for i := 0; i < len(v); i++ {
+			c := v[i]
+			switch {
+			case escaped:
+				escaped = false
+			case inQuotes && c == '\\':
+				escaped = true
+			case c == '"':
+				inQuotes = !inQuotes
+			case c == ',' && !inQuotes:
+				flush(i)
+				start = i + 1
+			}
+		}
+		flush(len(v))
+	}
+	return out
 }
 
 // compareSlicesIgnoreOrder checks if two string slices contain the same elements,

--- a/pkg/models/list_headers.go
+++ b/pkg/models/list_headers.go
@@ -1,0 +1,52 @@
+package models
+
+import "strings"
+
+// unorderedListHeaders lists HTTP headers (lowercased) whose value is a
+// comma-separated list (RFC 9110 §5.6.1 "#rule") in which the ORDER of the
+// elements carries no meaning. Two such headers that hold the same elements in
+// a different order are the same header, so comparing them positionally
+// reports a difference where the protocol says there is none.
+//
+// This is the shape that made keploy/keploy#4349 fail: a server that builds
+// `Allow` from an unordered collection — Django/DRF, Flask, Spring and Go's own
+// http.ServeMux all do — emits "POST, OPTIONS" on one run and "OPTIONS, POST"
+// on the next, and the replayed test failed on a header the application never
+// actually changed.
+//
+// Membership is deliberately narrow. A header belongs here only when its
+// grammar makes order meaningless, NOT merely when it happens to be a list:
+//
+//   - Via, Content-Encoding and Transfer-Encoding are ordered lists — the
+//     sequence is the proxy chain, or the order the codings were applied — so
+//     reordering them is a real difference and they stay out.
+//   - Accept, Accept-Encoding and Accept-Language rank equal-q values by
+//     position, so order is significant there too.
+//   - Set-Cookie, WWW-Authenticate and Link may carry commas inside a single
+//     element; they are not safely splittable and are excluded regardless of
+//     whether order matters.
+var unorderedListHeaders = map[string]struct{}{
+	"allow":                          {}, // RFC 9110 §10.2.1 — set of methods
+	"vary":                           {}, // RFC 9110 §12.5.5 — set of field names
+	"trailer":                        {}, // RFC 9110 §6.6.2 — set of field names
+	"connection":                     {}, // RFC 9110 §7.6.1 — set of connection options
+	"accept-ranges":                  {}, // RFC 9110 §14.3 — set of range units
+	"cache-control":                  {}, // RFC 9111 §5.2 — set of directives
+	"access-control-allow-methods":   {}, // Fetch — set of methods
+	"access-control-allow-headers":   {}, // Fetch — set of field names
+	"access-control-expose-headers":  {}, // Fetch — set of field names
+	"access-control-request-headers": {}, // Fetch — set of field names
+}
+
+// IsUnorderedListHeader reports whether name is EXACTLY one of the headers
+// whose comma-separated elements may be reordered without changing meaning,
+// compared case-insensitively.
+//
+// Exactness matters for the same reason it does in IsVolatileResponseHeader:
+// matcher.SubstringKeyMatch resolves noise keys with strings.Contains, so
+// routing this through a noise map would also catch unrelated headers that
+// merely contain one of these names.
+func IsUnorderedListHeader(name string) bool {
+	_, ok := unorderedListHeaders[strings.ToLower(name)]
+	return ok
+}

--- a/pkg/models/mock.go
+++ b/pkg/models/mock.go
@@ -544,6 +544,11 @@ func (q PostgresV3QuerySpec) MarshalYAML() (any, error) {
 	}, nil
 }
 
+// PostgresV3Response is one backend response bundle for a Query
+// invocation. Its payload axes (Rows, CopyOut, CopyIn, FunctionCall)
+// are mutually exclusive per the PG wire protocol; the struct tags
+// cannot express that, so the invariant is enforced by
+// Validate() in postgres_v3_response_validate.go.
 type PostgresV3Response struct {
 	RowDescription []PostgresV3ColumnDescriptor `json:"rowDescription,omitempty" yaml:"rowDescription,omitempty" bson:"row_description,omitempty"`
 	// Rows stores each row as a []PostgresV3Cell via PostgresV3Cells.

--- a/pkg/models/mock_test.go
+++ b/pkg/models/mock_test.go
@@ -2,7 +2,9 @@ package models
 
 import (
 	"bytes"
+	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	yamlLib "gopkg.in/yaml.v3"
@@ -258,22 +260,79 @@ func TestPostgresV3Response_CopyIn_RoundTrip(t *testing.T) {
 	// Serialization-stability check. The fixture set only CopyIn, so
 	// omitempty on Rows and CopyOut should keep both out of the
 	// emitted YAML and the re-decoded struct zero on those paths.
-	// This is NOT a schema-level mutual-exclusion guard — nothing in
-	// the struct today stops a caller from populating Rows + CopyIn
-	// simultaneously and marshaling that malformed shape. Enforcing
-	// the wire-level invariant (CopyIn and row-producing traffic
-	// never coexist on the same Query response) is the recorder's
-	// job in integrations; a misbehaving recorder would emit an
-	// invalid mock and this test would still pass. See the
-	// TODO(validation) below if we ever add struct-level validation.
+	// This is a serialization assertion, not the mutual-exclusion
+	// guard: the wire-level invariant (CopyIn and row-producing
+	// traffic never coexist on the same Query response) is enforced
+	// by PostgresV3Response.Validate(), exercised below in
+	// TestPostgresV3Response_RowsAndCopyIn_ValidateRejects.
 	if decoded.Rows != nil {
 		t.Fatalf("Rows: omitempty should have kept this nil on the CopyIn-only fixture, got %v", decoded.Rows)
 	}
 	if decoded.CopyOut != nil {
 		t.Fatalf("CopyOut: omitempty should have kept this nil on the CopyIn-only fixture, got %+v", decoded.CopyOut)
 	}
-	// TODO(validation): once a Validate() method or a custom
-	// UnmarshalYAML lands on PostgresV3Response, add a separate test
-	// that feeds a malformed fixture carrying BOTH Rows and CopyIn
-	// and asserts the validator rejects it.
+}
+
+// TestPostgresV3Response_RowsAndCopyIn_ValidateRejects feeds a
+// malformed on-disk fixture that carries BOTH `rows:` and `copyIn:`
+// on the same Query response and asserts PostgresV3Response.Validate()
+// rejects it.
+//
+// The shape is malformed per the PG wire protocol: a backend either
+// streams DataRow traffic ('D' rows terminated by CommandComplete) or
+// hands the conversation over to the client with CopyInResponse ('G')
+// — never both on one response. Nothing in the YAML layer stops such
+// a fixture from parsing (there is no custom UnmarshalYAML on
+// PostgresV3Response), so a hand-edited mock or a buggy recorder can
+// produce it; Validate() is the load-time guard that catches it before
+// the replay emitter silently picks one axis and drops the other.
+func TestPostgresV3Response_RowsAndCopyIn_ValidateRejects(t *testing.T) {
+	// Hand-written rather than Go-marshalled so the test exercises the
+	// real loader path a malformed mocks.yaml would arrive through.
+	const malformed = `
+rows:
+  - - "1"
+  - - "2"
+commandComplete: "SELECT 2"
+copyIn:
+  overallFormat: 0
+  columnFormatCodes: [0]
+`
+
+	var resp PostgresV3Response
+	if err := yamlLib.Unmarshal([]byte(malformed), &resp); err != nil {
+		t.Fatalf("yaml.Unmarshal of malformed fixture returned error: %v — "+
+			"the fixture must parse cleanly for Validate() to be the "+
+			"layer under test", err)
+	}
+	// Sanity-check the premise: both axes really are populated after
+	// the parse, otherwise the assertion below proves nothing.
+	if len(resp.Rows) != 2 {
+		t.Fatalf("Rows: want 2 rows from the malformed fixture, got %d", len(resp.Rows))
+	}
+	if resp.CopyIn == nil {
+		t.Fatalf("CopyIn: want non-nil from the malformed fixture, got nil")
+	}
+
+	err := resp.Validate()
+	if err == nil {
+		t.Fatalf("Validate(): want non-nil error on a response carrying " +
+			"both Rows and CopyIn, got nil")
+	}
+	if !errors.Is(err, ErrPostgresV3ResponseInvalid) {
+		t.Fatalf("Validate() error should wrap ErrPostgresV3ResponseInvalid, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Rows") || !strings.Contains(err.Error(), "CopyIn") {
+		t.Fatalf("Validate() error should name both colliding axes, got: %v", err)
+	}
+
+	// The CopyIn-only counterpart of the same fixture must still pass —
+	// Validate() rejects the collision, not the CopyIn axis itself.
+	valid := PostgresV3Response{
+		CommandComplete: "COPY 10",
+		CopyIn:          resp.CopyIn,
+	}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("Validate() returned %v on a CopyIn-only response — false positive", err)
+	}
 }


### PR DESCRIPTION
## Describe the changes that are made
`CompareHeaders` compared header values byte-for-byte, element by element. That
made a reordered list-valued header a test failure even when the header is
semantically unchanged — the case reported in #4349, where a server emits
`Allow: POST, OPTIONS` on record and `Allow: OPTIONS, POST` on replay. Servers
that build `Allow` from an unordered collection (Django/DRF, Flask, Spring, Go's
own `http.ServeMux`) flip that order between runs, so the test failed on a header
the application never actually changed.

Header values are now compared for **equivalence** rather than for byte-identity
of the recorded encoding:

- **`pkg/models/list_headers.go`** (new) — `IsUnorderedListHeader`, a deliberately
  narrow set of headers whose grammar makes the comma-separated elements a *set*
  rather than a sequence: `allow`, `vary`, `trailer`, `connection`,
  `accept-ranges`, `cache-control`, and the four CORS list headers.
- **`pkg/matcher/utils.go`** — `HeaderValuesMatch` replaces the positional
  comparison loop. The default remains strict `slices.Equal`; only listed headers
  fall back to a multiset comparison of their list elements. `splitHTTPListValues`
  splits on commas *outside* quoted strings, so `Cache-Control:
  no-cache="X-Foo, X-Bar"` stays a single directive.

Deliberately **excluded** from the set, because order is semantic there:
`Via` (proxy chain order), `Content-Encoding` / `Transfer-Encoding` (the order
codings were applied), `Accept*` (position breaks equal-q ties). Also excluded:
`Set-Cookie`, `WWW-Authenticate` and `Link`, which may carry commas inside a
single element and so aren't safely splittable.

Elements themselves are still compared exactly. Only element **order** and the
folded-vs-repeated encoding are forgiven — never a changed, added or dropped
element. The JSON body matcher is untouched: I verified `ignoreOrdering` (default
`true`) already handles reordered scalar arrays, object arrays, top-level arrays
and nested arrays correctly, so the bug was never in the body path despite the
issue title.

## Links & References

**Closes:** #4349

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

The change is confined to a pure comparison function with no I/O, no protocol
handling and no config surface. `pkg/matcher/header_listorder_test.go` covers it
directly, including the negative cases that must keep failing. I also ran an
end-to-end check through `httpMatcher.Match` while developing (passes on reorder,
still fails when the method set genuinely changes) and dropped it afterwards since
it duplicated the unit coverage.

## Added comments for hard-to-understand areas?
- [x] 👍 yes
- [ ] 🙅 no, because the code is self-explanatory

Both `unorderedListHeaders` and `splitHTTPListValues` carry comments explaining
*why* each header is in or out of the set, with RFC references, since the
membership rule is the part a future reader is most likely to get wrong.

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

No new flag, config field or CLI surface — this corrects the semantics of an
existing comparison. Happy to add a docs note if maintainers want the behaviour
called out.

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
- [ ] 🙅 no, because it is not needed

```bash
go test ./pkg/matcher/... ./pkg/models/...
```

To see the original failure, record a test case whose response carries
`Allow: POST, OPTIONS`, then replay it against a response carrying
`Allow: OPTIONS, POST`. Before this change the test fails with the header diff
from the issue; after it, the test passes. Changing one of the methods
(`Allow: OPTIONS, GET`) still fails, as it should.

## Self Review done?
- [x] ✅ yes
- [ ] ❌ no, because I need help

## Any relevant screenshots, recordings or logs?
The header diff from #4349 is the exact case now covered by
`TestCompareHeaders_UnorderedListHeaderReorder/issue_4349:_Allow_reordered`.

---

## Additional checklist:
- [x] Have you read the [Contributing Guidelines on issues](https://keploy.io/docs/keploy-explained/contribution-guide/)?
- [x] Have you followed the [PR Semantics guide](https://github.com/keploy/keploy/wiki/PR-Semantics) for naming this PR?
- [x] Have you followed the [Branch Semantics guide](https://github.com/keploy/keploy/wiki/Branch-Semantics) for naming your branch?
