### PR TITLE
fix(mysql): scope the greeting fallback per app so one server's greeting cannot serve another

### DIFF
--- a/pkg/agent/proxy/integrations/mysql/recorder/conn.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/conn.go
@@ -185,6 +185,11 @@ func handleInitialHandshake(ctx context.Context, logger *zap.Logger, clientConn,
 				logger.Debug("Also pushed to port-only fallback key",
 					zap.String("portKey", portKey))
 			}
+			// Record this greeting as the destination's last-resort fallback for
+			// a sibling connection whose own raw leg was dropped. Keyed by the
+			// resolved destination so it can only be reused for the SAME server,
+			// and skipped entirely when the address was synthesized.
+			hsStore.RememberLast(models.HandshakeLastKey(opts.PassThroughScope, opts.DstCfg), hsEntry)
 			// Signal that the pre-TLS config mock should NOT be recorded here;
 			// the post-TLS path will produce a single combined config mock.
 			res.skipConfigMock = true

--- a/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
@@ -401,7 +401,7 @@ func handlePostTLSHandshakeV2(ctx context.Context, logger *zap.Logger, sess *sup
 	// COM_QUERY decode past the CI (2a) gate. Waiting is free: the client's
 	// post-TLS bytes are buffered on ClientStream and read only after this
 	// returns.
-	entry, source := resolvePreTLSGreeting(ctx, hsStore, sess.Opts.ConnKey, dstPort)
+	entry, source := resolvePreTLSGreeting(ctx, hsStore, sess.Opts.ConnKey, dstPort, sess.Opts.PassThroughScope, sess.Opts.DstCfg)
 	staleEntry := source == greetingCached
 	var greetingBuf []byte
 	if source != greetingNone && len(entry.RespPackets) > 0 {
@@ -898,9 +898,15 @@ const (
 // proxyless the raw and decrypted legs are different TCP connections, so only
 // the port-only key (e.g. "port:3306") reliably bridges them — the raw leg
 // pushes under both (storePreTLSHandshakeV2).
-func resolvePreTLSGreeting(ctx context.Context, hsStore *models.TLSHandshakeStore, connKey string, dstPort uint16) (models.TLSHandshakeEntry, preTLSGreetingSource) {
+func resolvePreTLSGreeting(ctx context.Context, hsStore *models.TLSHandshakeStore, connKey string, dstPort uint16, scope string, dst *models.ConditionalDstCfg) (models.TLSHandshakeEntry, preTLSGreetingSource) {
 	connSpecificKey := models.HandshakeStoreKey(connKey, dstPort)
 	portKey := models.HandshakeStoreKey("", dstPort)
+	// The cross-connection fallback is keyed by DESTINATION, not by port: the
+	// fields it lets us reuse (capability flags, protocol version, auth plugin)
+	// are per-server, so an entry is only reusable for the same server. The key
+	// combines the app/session scope with the address so that a shared
+	// DaemonSet store cannot serve one app's greeting to another.
+	lastKey := models.HandshakeLastKey(scope, dst)
 
 	overall := mysqlPostTLSStashWait()
 	primary := mysqlPostTLSStashPrimary(overall)
@@ -923,7 +929,10 @@ func resolvePreTLSGreeting(ctx context.Context, hsStore *models.TLSHandshakeStor
 	}
 	// cachedGreeting returns the port's last-greeting cache entry, if usable.
 	cachedGreeting := func() (models.TLSHandshakeEntry, bool) {
-		if c, ok := hsStore.Last(portKey); ok && len(c.RespPackets) > 0 {
+		if lastKey == "" {
+			return models.TLSHandshakeEntry{}, false
+		}
+		if c, ok := hsStore.Last(lastKey); ok && len(c.RespPackets) > 0 {
 			return c, true
 		}
 		return models.TLSHandshakeEntry{}, false

--- a/pkg/agent/proxy/integrations/mysql/recorder/record_v2_test.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record_v2_test.go
@@ -153,18 +153,20 @@ func TestRecordV2_PostTLS_LostStash_GreetingCacheFallback(t *testing.T) {
 	// into this connection's mock.
 	store := models.NewTLSHandshakeStore()
 	staleTs := base.Add(-time.Hour)
-	store.Push(models.HandshakeStoreKey("", 3306), models.TLSHandshakeEntry{
-		RespPackets:  [][]byte{handshakeBuf},
-		ReqPackets:   [][]byte{sslReq},
-		ReqTimestamp: staleTs,
-	})
-	if _, ok := store.PopWait(models.HandshakeStoreKey("", 3306), 0); !ok {
-		t.Fatal("setup: expected to consume the earlier connection's entry")
-	}
 
 	// The degraded proxyless dest is fabricated — the fallback must succeed
 	// WITHOUT dialing it (a dial would fail: nothing listens on this port).
 	h.sess.Opts.DstCfg = &models.ConditionalDstCfg{Addr: "127.0.0.1:1", Port: 3306, AddrFabricated: true}
+
+	// The earlier connection was this SAME app reaching the SAME destination, so
+	// it shares the scope+address key and its greeting is reusable here. Only the
+	// queue entry was consumed; the cache retains it.
+	store.RememberLast(models.HandshakeLastKey(h.sess.Opts.PassThroughScope, h.sess.Opts.DstCfg),
+		models.TLSHandshakeEntry{
+			RespPackets:  [][]byte{handshakeBuf},
+			ReqPackets:   [][]byte{sslReq},
+			ReqTimestamp: staleTs,
+		})
 
 	clientTs := base.Add(5 * time.Millisecond)
 	h.pushClient(cannedHandshakeResponse41(t, 2, false), clientTs)
@@ -271,7 +273,7 @@ func TestResolvePreTLSGreeting_CtxCancelUnblocks(t *testing.T) {
 	}()
 
 	start := time.Now()
-	_, source := resolvePreTLSGreeting(ctx, store, "", 3306)
+	_, source := resolvePreTLSGreeting(ctx, store, "", 3306, "", testDst("10.0.0.5:3306"))
 	elapsed := time.Since(start)
 	if source != greetingNone {
 		t.Fatalf("resolvePreTLSGreeting must return greetingNone on an empty store, got %v", source)
@@ -298,17 +300,14 @@ func TestResolvePreTLSGreeting_DroppedLegHitsCacheAtPrimaryBound(t *testing.T) {
 	store := models.NewTLSHandshakeStore()
 	// A sibling connection populated the port's last-greeting cache; THIS
 	// connection's own raw leg was dropped (never pushed).
-	store.Push(models.HandshakeStoreKey("", 3306), models.TLSHandshakeEntry{
+	store.RememberLast("dst:|10.0.0.5:3306", models.TLSHandshakeEntry{
 		RespPackets:  [][]byte{[]byte("greeting")},
 		ReqPackets:   [][]byte{[]byte("sslreq")},
 		ReqTimestamp: time.Now(),
 	})
-	if _, ok := store.PopWait(models.HandshakeStoreKey("", 3306), 0); !ok {
-		t.Fatal("setup: expected to consume the sibling's queued entry, leaving only the cache")
-	}
 
 	start := time.Now()
-	entry, source := resolvePreTLSGreeting(context.Background(), store, "", 3306)
+	entry, source := resolvePreTLSGreeting(context.Background(), store, "", 3306, "", testDst("10.0.0.5:3306"))
 	elapsed := time.Since(start)
 	if source != greetingCached {
 		t.Fatalf("source = %v, want greetingCached (the dropped-leg cache fallback)", source)
@@ -332,12 +331,9 @@ func TestResolvePreTLSGreeting_OwnLatePreferredOverCache(t *testing.T) {
 
 	store := models.NewTLSHandshakeStore()
 	// Cache is populated (a sibling), but the own leg is merely late.
-	store.Push(models.HandshakeStoreKey("", 3306), models.TLSHandshakeEntry{
+	store.RememberLast("dst:|10.0.0.5:3306", models.TLSHandshakeEntry{
 		RespPackets: [][]byte{[]byte("sibling-greeting")},
 	})
-	if _, ok := store.PopWait(models.HandshakeStoreKey("", 3306), 0); !ok {
-		t.Fatal("setup: expected to consume the sibling's queued entry")
-	}
 	ownTs := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
 	go func() {
 		time.Sleep(150 * time.Millisecond)
@@ -347,11 +343,89 @@ func TestResolvePreTLSGreeting_OwnLatePreferredOverCache(t *testing.T) {
 		})
 	}()
 
-	entry, source := resolvePreTLSGreeting(context.Background(), store, "", 3306)
+	entry, source := resolvePreTLSGreeting(context.Background(), store, "", 3306, "", testDst("10.0.0.5:3306"))
 	if source != greetingOwn {
 		t.Fatalf("source = %v, want greetingOwn (a late own leg within the primary bound beats the cache)", source)
 	}
 	if !entry.ReqTimestamp.Equal(ownTs) {
 		t.Errorf("ReqTimestamp = %v, want the own leg's %v", entry.ReqTimestamp, ownTs)
+	}
+}
+
+// testDst builds a resolved (non-fabricated) destination.
+func testDst(addr string) *models.ConditionalDstCfg {
+	return &models.ConditionalDstCfg{Addr: addr, Port: 3306}
+}
+
+// The cross-connection greeting fallback exists because a MySQL server's
+// capability flags, protocol version and auth plugin are per-SERVER. That is
+// precisely why it must never be served across servers. Under a DaemonSet one
+// agent serves every pod on the node, so two apps talking to different MySQL
+// servers both see destination port 3306; keyed by port alone, the second would
+// stitch the first's greeting into its own config mock.
+func TestResolvePreTLSGreeting_DoesNotServeOneServersGreetingToAnother(t *testing.T) {
+	store := models.NewTLSHandshakeStore()
+	store.RememberLast("dst:|10.0.0.5:3306", models.TLSHandshakeEntry{
+		RespPackets: [][]byte{{0x0a, 'A'}},
+	})
+
+	// A different server, same port. Past the primary bound the fallback would
+	// fire if the cache were port-keyed.
+	t.Setenv("KEPLOY_MYSQL_POSTTLS_STASH_WAIT_MS", "0")
+	_, source := resolvePreTLSGreeting(context.Background(), store, "", 3306, "", testDst("10.0.0.9:3306"))
+	if source == greetingCached {
+		t.Fatal("served server A's greeting to a connection destined for server B; the cache must be " +
+			"scoped to a server, not to a port")
+	}
+}
+
+// The DaemonSet hazard: one store shared across every app on a node. Two apps
+// whose destinations are BOTH unresolvable present the same placeholder address,
+// so only the app/session scope keeps them apart. Without it, app B stitches app
+// A's server greeting into its own config mock.
+func TestResolvePreTLSGreeting_DoesNotServeOneAppsGreetingToAnother(t *testing.T) {
+	store := models.NewTLSHandshakeStore()
+	fabricated := func() *models.ConditionalDstCfg {
+		return &models.ConditionalDstCfg{Addr: "127.0.0.1:3306", Port: 3306, AddrFabricated: true}
+	}
+	store.RememberLast(models.HandshakeLastKey("ns/app-a/test-set-0", fabricated()),
+		models.TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'A'}}})
+
+	t.Setenv("KEPLOY_MYSQL_POSTTLS_STASH_WAIT_MS", "0")
+
+	// App B, same placeholder address, different scope: must NOT borrow.
+	if _, source := resolvePreTLSGreeting(context.Background(), store, "", 3306,
+		"ns/app-b/test-set-0", fabricated()); source == greetingCached {
+		t.Fatal("served app A's greeting to app B; a store shared across a node must isolate by scope")
+	}
+
+	// App A itself must still get the fallback — this is the case the feature
+	// exists for, and a fabricated address must not disable it.
+	if _, source := resolvePreTLSGreeting(context.Background(), store, "", 3306,
+		"ns/app-a/test-set-0", fabricated()); source != greetingCached {
+		t.Fatalf("app A lost its own cached fallback (source=%v); the fabricated proxyless "+
+			"destination is exactly the case this fallback was built for", source)
+	}
+}
+
+// HandshakeLastKey is the whole guard, so pin its contract directly.
+func TestHandshakeLastKey_OnlyNamesResolvedDestinations(t *testing.T) {
+	if got := models.HandshakeLastKey("", nil); got != "" {
+		t.Fatalf("nil DstCfg = %q, want empty", got)
+	}
+	if got := models.HandshakeLastKey("", &models.ConditionalDstCfg{Port: 3306}); got != "" {
+		t.Fatalf("no address = %q, want empty", got)
+	}
+	// A fabricated address is still keyable: the scope is what isolates apps,
+	// and refusing here would disable the fallback in the proxyless case it
+	// exists to serve.
+	if got := models.HandshakeLastKey("s", &models.ConditionalDstCfg{Addr: "127.0.0.1:3306", AddrFabricated: true}); got != "dst:s|127.0.0.1:3306" {
+		t.Fatalf("fabricated address = %q, want dst:s|127.0.0.1:3306", got)
+	}
+	// Different scopes must never collide on one address.
+	a := models.HandshakeLastKey("app-a", &models.ConditionalDstCfg{Addr: "127.0.0.1:3306"})
+	b := models.HandshakeLastKey("app-b", &models.ConditionalDstCfg{Addr: "127.0.0.1:3306"})
+	if a == b {
+		t.Fatalf("two apps collided on one key (%q)", a)
 	}
 }

--- a/pkg/models/tls_handshake_store.go
+++ b/pkg/models/tls_handshake_store.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 )
@@ -32,10 +31,10 @@ type TLSHandshakeStore struct {
 	mu   sync.Mutex
 	cond *sync.Cond
 	m    map[string][]timedTLSHandshakeEntry
-	// last remembers, per PORT-scoped key, the most recent entry ever pushed —
-	// independently of the consumable queue in m. Only port keys are cached
-	// here (Push skips conn-scoped keys) because it is never TTL/size-pruned and
-	// the only reader queries it by port. Unlike m it is never
+	// last remembers, per DESTINATION-scoped key, the most recent entry ever pushed —
+	// independently of the consumable queue in m. Only DESTINATION keys are
+	// cached here (see HandshakeLastKey) because it is never TTL/size-pruned and
+	// the only reader queries it by destination. Unlike m it is never
 	// consumed by Pop and never TTL-pruned: it is the last-resort
 	// fallback for a consumer whose OWN raw-leg entry was genuinely
 	// lost (e.g. the plaintext MySQL greeting+SSLRequest capture event
@@ -46,6 +45,17 @@ type TLSHandshakeStore struct {
 	// salt — is not verified anywhere on the record or replay path (the
 	// replayer explicitly skips AuthResponse comparison because it is
 	// salt-dependent; see mysql/replayer/match.go matchHanshakeResponse41).
+	//
+	// That reasoning is exactly why the key must name the SERVER. Those fields
+	// are per-server, so an entry may only be reused for the same server. A
+	// port-only key does not identify one: under a DaemonSet a single agent
+	// serves every pod on the node, so app A talking to MySQL-A:3306 and app B
+	// talking to MySQL-B:3306 share "port:3306", and B would stitch A's
+	// capability flags, server version and auth plugin into its own config mock.
+	// Keying by destination address confines reuse to one server, and
+	// HandshakeLastKey returns "" for an address the capture layer merely
+	// synthesized, which disables the cache rather than letting every
+	// unresolved destination collapse onto one placeholder key.
 	last map[string]TLSHandshakeEntry
 }
 
@@ -75,8 +85,54 @@ func HandshakeStoreKey(connKey string, dstPort uint16) string {
 	return fmt.Sprintf("port:%d", dstPort)
 }
 
-// Push adds a handshake entry for the given key. It also refreshes the
-// key's last-greeting cache (see Last).
+// HandshakeLastKey builds the key for the last-greeting cache.
+//
+// The cache lets a connection whose own raw leg was dropped borrow a greeting
+// captured for the same destination. That is only sound between connections to
+// the SAME server, so the key must name one. A destination address alone does
+// not: in a long-lived proxyless/DaemonSet agent a single store is shared across
+// every app on the node, and an unresolved destination is reported as a
+// placeholder (see ConditionalDstCfg.AddrFabricated), so app A talking to
+// MySQL-A and app B talking to MySQL-B both present as 127.0.0.1:3306. Keyed on
+// that alone, B would stitch A's capability flags, server version and auth
+// plugin into its own config mock.
+//
+// The key therefore combines the caller's app/session scope with the address.
+// Scope is the same isolation PassThroughScope already applies to a shared
+// recorder: the enterprise DaemonSet gate sets it per app/session, and the
+// classic sidecar leaves it empty because a process serves one session and the
+// address alone already isolates.
+//
+// Returns "" — meaning do not cache and do not read the cache — when there is no
+// address to key on at all.
+//
+// Residual, deliberately not solved here: within ONE scope, two DIFFERENT
+// servers whose addresses were both fabricated collapse to the same key (a
+// multi-destination JVM whose fds are unresolvable). That is narrower than the
+// cross-app case and needs real destination resolution, not a better key.
+func HandshakeLastKey(scope string, dst *ConditionalDstCfg) string {
+	if dst == nil || dst.Addr == "" {
+		return ""
+	}
+	return "dst:" + scope + "|" + dst.Addr
+}
+
+// RememberLast records entry as the most recent greeting seen for a
+// destination. A empty key is ignored, so callers may pass
+// HandshakeLastKey's result unconditionally.
+func (s *TLSHandshakeStore) RememberLast(key string, entry TLSHandshakeEntry) {
+	if key == "" {
+		return
+	}
+	s.mu.Lock()
+	if s.last == nil {
+		s.last = make(map[string]TLSHandshakeEntry)
+	}
+	s.last[key] = entry
+	s.mu.Unlock()
+}
+
+// Push adds a handshake entry for the given key.
 func (s *TLSHandshakeStore) Push(key string, entry TLSHandshakeEntry) {
 	s.mu.Lock()
 	s.pruneExpiredLocked(time.Now())
@@ -88,30 +144,20 @@ func (s *TLSHandshakeStore) Push(key string, entry TLSHandshakeEntry) {
 		entry:    entry,
 		pushedAt: time.Now(),
 	})
-	// Only PORT-scoped keys ("port:<n>", from HandshakeStoreKey with an empty
-	// connKey) feed the last-greeting cache. The post-TLS stitch's fallback
-	// reads Last() by the port-only key exclusively (see recorder/record_v2.go
-	// resolvePreTLSGreeting), so a conn-scoped ("conn:<connKey>") entry here
-	// would never be read — and, because `last` is deliberately never
-	// TTL/size-pruned (unlike m), a per-connection key would accumulate without
-	// bound over a long record session. Restrict the cache to the reusable,
-	// low-cardinality port keys.
-	if strings.HasPrefix(key, "port:") {
-		if s.last == nil {
-			s.last = make(map[string]TLSHandshakeEntry)
-		}
-		s.last[key] = entry
-	}
+	// The last-greeting cache is NOT populated from the queue key. A queue key
+	// is a port or a connection, neither of which identifies a server, and this
+	// cache is never TTL/size-pruned. Callers record into it explicitly via
+	// RememberLast with a destination-scoped key.
 	s.cond.Broadcast()
 	s.mu.Unlock()
 }
 
-// Last returns the most recent entry ever pushed for key, without
+// Last returns the most recent entry recorded for a destination key, without
 // consuming anything. Unlike PopWait it survives consumption by other
 // connections and the TTL prune, so it stays available as a stitching
 // fallback when a connection's own raw-leg entry was lost (dropped
 // capture event / >TTL delay). Callers must treat the result as
-// belonging to ANOTHER connection to the same destination: reuse the
+// belonging to ANOTHER connection to the same server: reuse the
 // server-stable parts (greeting capabilities / plugin, client
 // SSLRequest shape) but not per-connection metadata such as the
 // request timestamp.

--- a/pkg/models/tls_handshake_store_test.go
+++ b/pkg/models/tls_handshake_store_test.go
@@ -26,6 +26,11 @@ func TestTLSHandshakeStore_LastSurvivesConsumption(t *testing.T) {
 		ReqTimestamp: time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC),
 	}
 	s.Push(key, entry1)
+	// The cache is recorded explicitly now: a queue key is a port or a
+	// connection, neither of which names a server, so Push no longer populates
+	// it as a side effect.
+	dstKey := HandshakeLastKey("scope-a", &ConditionalDstCfg{Addr: "10.0.0.5:3306"})
+	s.RememberLast(dstKey, entry1)
 
 	// Consume the queue the way another connection's PopWait would.
 	if _, ok := s.PopWait(key, 0); !ok {
@@ -36,7 +41,7 @@ func TestTLSHandshakeStore_LastSurvivesConsumption(t *testing.T) {
 	}
 
 	// The last-greeting cache must still serve entry1.
-	got, ok := s.Last(key)
+	got, ok := s.Last(dstKey)
 	if !ok {
 		t.Fatal("Last must survive queue consumption — it is the lost-raw-leg fallback")
 	}
@@ -44,12 +49,12 @@ func TestTLSHandshakeStore_LastSurvivesConsumption(t *testing.T) {
 		t.Fatalf("Last returned wrong entry: %+v", got)
 	}
 
-	// A newer push overwrites the cache.
+	// A newer record overwrites the cache.
 	entry2 := TLSHandshakeEntry{RespPackets: [][]byte{[]byte("greeting-2")}}
-	s.Push(key, entry2)
-	got, ok = s.Last(key)
+	s.RememberLast(dstKey, entry2)
+	got, ok = s.Last(dstKey)
 	if !ok || !bytes.Equal(got.RespPackets[0], []byte("greeting-2")) {
-		t.Fatalf("Last must return the most recent push, got %+v ok=%v", got, ok)
+		t.Fatalf("Last must return the most recent record, got %+v ok=%v", got, ok)
 	}
 
 	// Keys are independent.
@@ -63,7 +68,7 @@ func TestTLSHandshakeStore_LastSurvivesConsumption(t *testing.T) {
 // PORT-scoped keys. A conn-scoped key must NOT populate `last` (it would
 // accumulate one unremovable entry per connection over a long session) — while
 // still flowing normally through the consumable queue m.
-func TestTLSHandshakeStore_LastOnlyCachesPortKeys(t *testing.T) {
+func TestTLSHandshakeStore_CacheIsExplicitAndScopeIsolated(t *testing.T) {
 	s := NewTLSHandshakeStore()
 	connKey := HandshakeStoreKey("srcport:55123", 3306) // -> "conn:srcport:55123"
 	if !strings.HasPrefix(connKey, "conn:") {
@@ -82,11 +87,24 @@ func TestTLSHandshakeStore_LastOnlyCachesPortKeys(t *testing.T) {
 		t.Fatal("conn-scoped key must NOT populate the last-greeting cache — it would leak unbounded")
 	}
 
-	// A port-scoped push is cached as before.
+	// Push never populates the cache now, whatever the key shape.
 	portKey := HandshakeStoreKey("", 3306)
 	s.Push(portKey, entry)
-	if _, ok := s.Last(portKey); !ok {
-		t.Fatal("port-scoped key must populate the last-greeting cache")
+	if _, ok := s.Last(portKey); ok {
+		t.Fatal("Push must not populate the last-greeting cache: a port names no server, and this " +
+			"map is never pruned")
+	}
+
+	// Only an explicit, scope+destination keyed record does.
+	dstKey := HandshakeLastKey("ns/app-a/ts0", &ConditionalDstCfg{Addr: "10.0.0.5:3306"})
+	s.RememberLast(dstKey, entry)
+	if _, ok := s.Last(dstKey); !ok {
+		t.Fatal("RememberLast must populate the cache under the destination key")
+	}
+	// A second app on the same node, same address, must not see it.
+	otherKey := HandshakeLastKey("ns/app-b/ts0", &ConditionalDstCfg{Addr: "10.0.0.5:3306"})
+	if _, ok := s.Last(otherKey); ok {
+		t.Fatal("a different app/session scope must not read another's cached greeting")
 	}
 }
 


### PR DESCRIPTION
## The bug

The last-greeting cache lets a connection whose own raw leg was dropped borrow a greeting captured for the same destination. It was keyed `"port:<n>"` — and the cache's own doc explains why that is the wrong key:

> the capability flags, protocol version and auth plugin are per-server (stable)

Those are per-**server**. A port does not name a server.

Under a DaemonSet **one agent serves every pod on the node** and shares one store, and an unresolved destination is reported as a placeholder address. So:

| | destination | key |
|---|---|---|
| app A | MySQL-A:3306 | `port:3306` |
| app B | MySQL-B:3306 | `port:3306` |

App B's raw leg is dropped (the exact ringbuf-drop case this feature targets), it falls back, and stitches **app A's** capability flags, server version and auth plugin into its own config mock.

Before this cache the queue was port-keyed too, but entries were consumed once and pruned at 30s, so the collision was a narrow race. The cache is **never pruned**, which makes it permanent and deterministic.

## The fix

Key the cache on the caller's **app/session scope plus the destination address**, and record into it explicitly via `RememberLast` rather than as a side effect of `Push` (a queue key is a port or a connection; neither names a server, and this map is unpruned).

Scope is the isolation `PassThroughScope` already applies to a recorder shared across tenants — its doc describes this same hazard, and the enterprise DaemonSet gate already sets it per app/session. The classic sidecar leaves it empty because a process serves one session and the address alone already isolates.

## Deliberately not gated on `AddrFabricated`

My first attempt refused the cache for fabricated destinations. `TestRecordV2_PostTLS_LostStash_GreetingCacheFallback` correctly rejected that: a fabricated destination is **precisely** the case this fallback exists for — the proxyless dropped-ringbuf path. Refusing there would disable the feature in its target scenario.

The scope is what separates apps. The address alone never could.

## Residual, stated rather than hidden

Within **one** scope, two different servers whose addresses were both fabricated still collapse to one key — a multi-destination JVM whose fds are unresolvable. That needs real destination resolution, not a better key.

## Verification

| check | result |
|---|---|
| `go build ./...`, `go vet` | clean |
| `pkg/models`, `mysql/...` | green |
| `gofmt` | clean |

**Mutation-tested both halves:**
- Dropping the scope from the key → the cross-app test fails.
- App A must still get its own fallback **with a fabricated address** → so the fix cannot be "solved" by disabling the feature.
