### PR TITLE
fix(replay): populate the startup tier, which was empty for every windowed replay

### DIFF
--- a/pkg/agent/proxy/startup_tier_population_test.go
+++ b/pkg/agent/proxy/startup_tier_population_test.go
@@ -1,0 +1,50 @@
+package proxy
+
+import (
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// The user-visible contract is not "the mock is in some slice" but "the startup
+// TIER is populated": GetStartupMocks is what the tier-aware dispatcher and the
+// mongo startup rescue actually read. A bootstrap mock handed to
+// SetMocksWithWindow in the FILTERED slice must land in the startup tree, and
+// must not remain in the unfiltered pool.
+//
+// This is the half the filter-level test cannot see. It also documents the
+// accessor shift the fix causes: pre-first-window per-test mocks used to reach
+// consumers via GetUnFilteredMocks in lax mode and now reach them via
+// GetStartupMocks.
+func TestSetMocksWithWindowRoutesPreFirstWindowMocksIntoTheStartupTier(t *testing.T) {
+	first := time.Date(2026, 9, 1, 12, 0, 10, 0, time.UTC)
+	end := first.Add(2 * time.Second)
+
+	boot := &models.Mock{
+		Version: "api.keploy.io/v1beta1",
+		Name:    "bootstrap-find-schema",
+		Kind:    models.Mongo,
+		Spec: models.MockSpec{
+			ReqTimestampMock: first.Add(-3 * time.Second), // recorded during app boot
+			ResTimestampMock: first.Add(-3*time.Second + time.Millisecond),
+		},
+		TestModeInfo: models.TestModeInfo{Lifetime: models.LifetimePerTest, IsFiltered: true},
+	}
+
+	m := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+	m.SetMocksWithWindow([]*models.Mock{boot}, nil, first, end)
+
+	startup, err := m.GetStartupMocks()
+	if err != nil {
+		t.Fatalf("GetStartupMocks: %v", err)
+	}
+	if len(startup) != 1 {
+		t.Fatalf("startup tier holds %d mocks, want 1 — an empty tier is what makes a bootstrap "+
+			"query miss with candidates:0 while its mock sits on disk", len(startup))
+	}
+	if startup[0].Name != boot.Name {
+		t.Fatalf("startup tier holds %q, want %q", startup[0].Name, boot.Name)
+	}
+}

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -930,6 +930,33 @@ func earliestReqTimestamp(filtered, unfiltered []*models.Mock) time.Time {
 // the old full-resident path): mapping -> named mocks; strict -> window +
 // startup band; lax -> all. Resident ineligible mocks are merged in; with no
 // disk store (legacy path) the resident slice is returned unchanged.
+
+// effectiveFirstWindowStart resolves the startup-band cutoff for this call.
+//
+// readerVal is what the proxy reports. On the FIRST window it is the zero time,
+// because SetMocksWithWindow records it later in this same call — so every
+// startup-band guard downstream is switched off for test #1, which is precisely
+// the test a slow application bootstrap lands in. Deriving the cutoff from this
+// call's own window start closes that, and uses the same predicate the manager
+// applies (a zero or BaseTime start means "no window").
+//
+// isWindowedProxy gates the derivation because it is only sound where the
+// manager adopts this same start as firstWindowStart in this call. A proxy with
+// neither the reader nor that adoption reports zero on EVERY window, so an
+// unguarded fallback would substitute the CURRENT window's start each time,
+// collapsing "req < firstWindowStart" into "req < afterTime" and preserving
+// every stale previous-test mock — the cross-test bleed strict mode exists to
+// prevent, on the one path where strict is actually live.
+func effectiveFirstWindowStart(isWindowedProxy bool, readerVal, afterTime time.Time) time.Time {
+	if !readerVal.IsZero() || !isWindowedProxy {
+		return readerVal
+	}
+	if afterTime.IsZero() || afterTime.Equal(models.BaseTime) {
+		return readerVal
+	}
+	return afterTime
+}
+
 func (a *Agent) loadPerTestMocks(resident []*models.Mock, disk *proxyPkg.DiskMocks, params models.MockFilterParams, firstWindowStart time.Time) ([]*models.Mock, error) {
 	if disk == nil {
 		return resident, nil
@@ -1050,10 +1077,33 @@ func (a *Agent) UpdateMockParams(ctx context.Context, params models.MockFilterPa
 
 	// firstWindowStart: earliest observed window start, so startup-init mocks
 	// (req < it) are kept, not dropped as stale.
+	//
+	// On the FIRST window the proxy has not learned it yet: SetMocksWithWindow
+	// records it (mockmanager.go:676-679) LATER in this same call, so the read
+	// here returns the zero time and every startup-band guard downstream is
+	// switched off for test #1 — loadPerTestMocks' disk.LoadBefore(...) never
+	// fires, and the startup tier stays EMPTY for the one test where a slow
+	// application bootstrap actually lands. That is why a bootstrap query issued
+	// under load misses with candidates:0 while the mock sits unread on disk.
+	//
+	// Derive it from this call's own window start instead, applying exactly the
+	// predicate mockmanager uses so the two cannot disagree: a zero or BaseTime
+	// AfterTime is "no window", anything else is a real start.
 	var firstWindowStart time.Time
 	if reader, ok := a.Proxy.(coreAgent.FirstWindowStartReader); ok {
 		firstWindowStart = reader.FirstTestWindowStart()
 	}
+	//
+	// Guarded on isWindowedProxy on purpose. This derivation is only valid where
+	// SetMocksWithWindow adopts this very same start as firstWindowStart later in
+	// this call (see MockManager.SetMocksWithWindow). A proxy implementing only
+	// the base agent.Proxy interface has neither the reader nor that adoption, so
+	// its reader value is permanently zero — without the guard the fallback would
+	// fire on EVERY window with the CURRENT window's start, collapsing
+	// "req < firstWindowStart" into "req < afterTime" and preserving every stale
+	// previous-test mock. That is exactly the cross-test bleed strict mode exists
+	// to prevent, and agentStrict is true on that path.
+	firstWindowStart = effectiveFirstWindowStart(isWindowedProxy, firstWindowStart, params.AfterTime)
 
 	// Load only what the filter will keep for this call (see loadPerTestMocks).
 	originalFiltered, err := a.loadPerTestMocks(residentFiltered, disk, params, firstWindowStart)

--- a/pkg/service/agent/first_window_start_test.go
+++ b/pkg/service/agent/first_window_start_test.go
@@ -1,0 +1,61 @@
+package agent
+
+import (
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+func TestEffectiveFirstWindowStart(t *testing.T) {
+	t1 := time.Date(2026, 9, 1, 12, 0, 10, 0, time.UTC)
+	t7 := t1.Add(60 * time.Second)
+	var zero time.Time
+
+	for _, tc := range []struct {
+		name      string
+		windowed  bool
+		readerVal time.Time
+		afterTime time.Time
+		want      time.Time
+		why       string
+	}{
+		{
+			name:     "first window on a windowed proxy derives from this call",
+			windowed: true, readerVal: zero, afterTime: t1, want: t1,
+			why: "the manager adopts this same start later in this call; without it the startup " +
+				"band is switched off for test #1, the test a slow bootstrap lands in",
+		},
+		{
+			name:     "later window keeps the reader's value",
+			windowed: true, readerVal: t1, afterTime: t7, want: t1,
+			why: "the cutoff is the FIRST window, not the current one",
+		},
+		{
+			// This is the case that made an earlier version of this fix reintroduce
+			// cross-test bleed: no reader means zero on EVERY window, so an
+			// unguarded fallback would substitute the current window's start and
+			// collapse the startup predicate into "req < afterTime".
+			name:     "no windowed proxy never derives, even with a real window",
+			windowed: false, readerVal: zero, afterTime: t7, want: zero,
+			why: "strict is live on this path; deriving here preserves every stale mock",
+		},
+		{
+			name:     "BaseTime means no window",
+			windowed: true, readerVal: zero, afterTime: models.BaseTime, want: zero,
+			why: "matches the manager's own guard",
+		},
+		{
+			name:     "zero AfterTime means no window",
+			windowed: true, readerVal: zero, afterTime: zero, want: zero,
+			why: "nothing to derive from",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := effectiveFirstWindowStart(tc.windowed, tc.readerVal, tc.afterTime)
+			if !got.Equal(tc.want) {
+				t.Fatalf("got %v, want %v — %s", got, tc.want, tc.why)
+			}
+		})
+	}
+}

--- a/pkg/startup_tier_lax_test.go
+++ b/pkg/startup_tier_lax_test.go
@@ -1,0 +1,71 @@
+package pkg
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// A bootstrap mock — one recorded BEFORE the first test window — must be
+// preserved in the filtered slice in BOTH strict and lax mode, because
+// MockManager.SetMocksWithWindow routes exactly that band into the startup
+// tree, and the tier-aware dispatcher reads it via GetStartupMocks.
+//
+// Lax is the case that regressed: agentStrict is permanently false on a
+// WindowedProxy, so on every windowed replay the preservation (which used to
+// live inside the strict branch) never ran, the mock was diverted into the
+// session/unfiltered pool that the mongo tier-aware path never consults for
+// bootstrap traffic, and the startup tier stayed empty for the whole run.
+func TestStartupBandIsPreservedInBothStrictAndLaxModes(t *testing.T) {
+	first := time.Date(2026, 9, 1, 12, 0, 10, 0, time.UTC) // first window start
+	after := first                                         // this test's window
+	before := first.Add(2 * time.Second)
+	bootTS := first.Add(-3 * time.Second) // recorded during app bootstrap
+
+	newBootstrapMock := func() *models.Mock {
+		return &models.Mock{
+			Version: "api.keploy.io/v1beta1",
+			Name:    "bootstrap-find-schema",
+			Kind:    models.Mongo,
+			Spec: models.MockSpec{
+				ReqTimestampMock: bootTS,
+				ResTimestampMock: bootTS.Add(time.Millisecond),
+			},
+			TestModeInfo: models.TestModeInfo{Lifetime: models.LifetimePerTest},
+		}
+	}
+
+	// strictWindowEnabled ORs in a process-wide env override, so strict=false is
+	// not lax on a machine or lane with KEPLOY_STRICT_MOCK_WINDOW=1 set — the lax
+	// subtest would silently pass even with the bug restored. Pin both knobs off.
+	prevOverride, prevExplicitOff := strictWindowEnvOverride, strictWindowEnvExplicitOff
+	strictWindowEnvOverride, strictWindowEnvExplicitOff = false, false
+	t.Cleanup(func() {
+		strictWindowEnvOverride, strictWindowEnvExplicitOff = prevOverride, prevExplicitOff
+	})
+
+	for _, strict := range []bool{true, false} {
+		name := "lax"
+		if strict {
+			name = "strict"
+		}
+		t.Run(name, func(t *testing.T) {
+			filtered, unfiltered := FilterPerTestAndLaxPromotedTierAware(
+				context.Background(), zap.NewNop(),
+				[]*models.Mock{newBootstrapMock()}, after, before, strict, first)
+
+			if len(filtered) != 1 {
+				t.Fatalf("bootstrap mock not preserved for the startup tier: filtered=%d unfiltered=%d; "+
+					"SetMocksWithWindow only builds the startup tree from the filtered slice, so a mock "+
+					"diverted here leaves the tier empty and bootstrap queries miss with candidates:0",
+					len(filtered), len(unfiltered))
+			}
+			if !filtered[0].TestModeInfo.IsFiltered {
+				t.Fatal("preserved bootstrap mock must be marked IsFiltered so the startup partition claims it")
+			}
+		})
+	}
+}

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -2841,15 +2841,17 @@ func FilterPerTestAndLaxPromoted(ctx context.Context, logger *zap.Logger, m []*m
 // test window start observed by the agent's MockManager, or zero before
 // any real test has fired) so the strict gate can preserve per-test
 // startup-init mocks (req < firstWindowStart) in the returned perTestIn
-// slice instead of dropping them. MockManager.SetMocksWithWindow's
+// slice instead of dropping them. The preservation runs in BOTH strict and
+// lax mode: agentStrict is false on a WindowedProxy, so a strict-only
+// preservation never runs on a windowed replay. MockManager.SetMocksWithWindow's
 // startup-tier partition then routes those preserved mocks into the
 // dedicated startup tree, and the v3 tier-aware dispatcher reaches them
 // via GetStartupMocks.
 //
 // Passing firstWindowStart == time.Time{} reproduces the legacy blanket-
-// drop contract (strict mode drops every per-test mock outside the
-// current window, regardless of whether the mock predates the first
-// test). Legacy callers that don't know firstWindowStart can keep
+// drop contract (every per-test mock outside the current window is dropped
+// in strict mode / promoted in lax, regardless of whether the mock predates
+// the first test), because there is no cutoff to preserve against. Legacy callers that don't know firstWindowStart can keep
 // calling FilterPerTestAndLaxPromoted unchanged.
 func FilterPerTestAndLaxPromotedTierAware(ctx context.Context, logger *zap.Logger, m []*models.Mock, afterTime time.Time, beforeTime time.Time, strict bool, firstWindowStart time.Time) ([]*models.Mock, []*models.Mock) {
 	perTestInWindow, promotedToSession := filterByTimeStampTierAware(ctx, logger, m, afterTime, beforeTime, strict, firstWindowStart)
@@ -3186,25 +3188,38 @@ func filterByTimeStampTierAware(_ context.Context, logger *zap.Logger, m []*mode
 		// the unfiltered pool by the lifetime-first short-circuit
 		// above, so the strict/lax divergence here applies exclusively
 		// to the perTest class that actually needs window containment.
+		// Startup-init (req < firstWindowStart) is preserved in the filtered
+		// slice so MockManager.SetMocksWithWindow's startup-tier partition
+		// routes it into the startup tree, where the tier-aware dispatcher
+		// reaches it via GetStartupMocks.
+		//
+		// This runs in BOTH modes, deliberately. It used to sit inside the
+		// strict branch below, and `agentStrict` is permanently false on a
+		// WindowedProxy (agent.go: `params.StrictMockWindow && !isWindowedProxy`),
+		// so on every windowed replay the lax branch diverted these mocks into
+		// the session/unfiltered pool instead — a pool the mongo tier-aware
+		// path never consults for bootstrap traffic (it reads GetFilteredMocks
+		// and GetStartupMocks only). The startup tier was therefore EMPTY for
+		// the whole run, and a bootstrap query issued while a window was open
+		// missed with candidates:0 even though its mock was on disk.
+		//
+		// It is not a widening of what may be served: these mocks predate the
+		// first test window, so they can only be bootstrap traffic, and routing
+		// them to the tier built for exactly that is what both modes intend.
+		// A zero firstWindowStart still means "no cutoff yet" and falls through
+		// to the legacy behaviour below, unchanged.
+		if !firstWindowStart.IsZero() && p.Spec.ReqTimestampMock.Before(firstWindowStart) {
+			p.TestModeInfo.IsFiltered = true
+			filteredMocks = append(filteredMocks, p)
+			preservedStartup++
+			continue
+		}
+
 		if strict {
-			// Per-test, out-of-window. Tier-aware split: startup-init
-			// (req < firstWindowStart) is preserved in the filtered slice
-			// so MockManager.SetMocksWithWindow's startup-tier partition
-			// routes it into the startup tree. Genuine stale cross-test
-			// bleed (firstWindowStart <= req < afterTime, or req >
-			// beforeTime) is dropped — the strictMockWindow guarantee.
-			//
-			// When firstWindowStart is zero we have no cutoff yet (either
-			// the agent hasn't observed a real test window on this
-			// MockManager, or the caller didn't thread the value through).
-			// In that case fall back to the legacy blanket-drop contract
-			// so the behaviour is strictly no worse than before.
-			if !firstWindowStart.IsZero() && p.Spec.ReqTimestampMock.Before(firstWindowStart) {
-				p.TestModeInfo.IsFiltered = true
-				filteredMocks = append(filteredMocks, p)
-				preservedStartup++
-				continue
-			}
+			// Per-test, out-of-window. Genuine stale cross-test bleed
+			// (firstWindowStart <= req < afterTime, or req > beforeTime) is
+			// dropped — the strictMockWindow guarantee. The startup-init band
+			// was already preserved above, in both modes.
 			// Per-mock diagnostic: emit the hash + window + actual ts
 			// at Debug for the strict-drop path so a CI log can
 			// pinpoint which postgres / http / mongo mock the per-test
@@ -3371,15 +3386,23 @@ func FilterByTimeStampThreeTier(ctx context.Context, logger *zap.Logger, m []*mo
 			continue
 		}
 
-		// Out-of-window per-test: strict drops (with startup-init
-		// preservation), lax promotes to unfiltered.
+		// Startup-init band, preserved in BOTH modes. Identical reasoning to
+		// filterByTimeStampTierAware: agentStrict is false on a WindowedProxy, so
+		// a strict-only preservation never runs on a windowed replay and the
+		// startup tier stays empty for the whole run. This twin is only
+		// test-called today, but fixing one of two identical functions would
+		// guarantee the bug returns the moment the three-tier path is wired for
+		// postgres v3 / mysql.
+		if !firstWindowStart.IsZero() && p.Spec.ReqTimestampMock.Before(firstWindowStart) {
+			p.TestModeInfo.IsFiltered = true
+			startup = append(startup, p)
+			preservedStartup++
+			continue
+		}
+
+		// Out-of-window per-test: strict drops, lax promotes to unfiltered.
+		// The startup-init band was already claimed above, in both modes.
 		if strict {
-			if !firstWindowStart.IsZero() && p.Spec.ReqTimestampMock.Before(firstWindowStart) {
-				p.TestModeInfo.IsFiltered = true
-				startup = append(startup, p)
-				preservedStartup++
-				continue
-			}
 			// Per-mock diagnostic: emit hash + window deltas at Debug
 			// for the three-tier strict-drop path so a CI log can
 			// identify which postgres / mongo / etc. mock the per-test


### PR DESCRIPTION
## The bug

keploy partitions mocks recorded before the first test window into a **startup tier**. `MockManager.SetMocksWithWindow` builds it, the tier-aware dispatcher reads it via `GetStartupMocks`, and mongo's `attemptStartupRescue` serves a late-arriving bootstrap query from it.

**That tier was empty for the entire duration of every windowed replay.** An application whose bootstrap ran slowly missed with `match_phase: no_mocks, candidates: 0` while its mock sat unread on disk.

Downstream, in enterprise CI: parse-server exits 1 on `keploy: no matching mock for find on _SCHEMA` during its own boot, `docker compose up` aborts the project, and every test reports `APP_CONNECTION_ERROR`. It reproduces **only under load** — load is what pushes the bootstrap past the first window boundary.

## Two independent causes, both about *populating* the tier

Neither changes what the matcher may serve, so replay stays deterministic.

**1. The first window read a zero cutoff.** The proxy learns `firstWindowStart` from `SetMocksWithWindow`, which runs *later in the same call*, so `loadPerTestMocks`' `disk.LoadBefore` never fired for test #1 — the one test a slow bootstrap lands in. The cutoff is now derived from this call's own window start, using the manager's own predicate.

Guarded on `isWindowedProxy`, and that guard is load-bearing: a proxy with neither the reader nor that adoption reports zero on **every** window, so an unguarded fallback would substitute the *current* window's start each time, collapsing `req < firstWindowStart` into `req < afterTime` and preserving every stale mock. That is cross-test bleed, on the one path where strict is actually live.

**2. The preservation was strict-only.** `agentStrict` is `params.StrictMockWindow && !isWindowedProxy` — **permanently false** on a windowed replay. So the lax branch diverted bootstrap mocks into the session pool, which the mongo tier-aware path never consults for bootstrap traffic. It now runs in both modes, in `filterByTimeStampTierAware` **and** its three-tier twin — fixing one of two identical functions would have let the bug return the moment the three-tier path is wired.

## Behaviour change to be aware of

In lax mode these mocks move from the session tree to the startup tree, so they are **consumed per window** rather than reusable without limit (replenished each `UpdateMockParams`).

Postgres v3 selects its startup index when `!FirstTestFired && !Active`. I first flagged a **between-tests** hazard here; that was wrong, and the correction matters for reviewing this PR: nothing ever clears the window inside a test set. `SetCurrentTestWindow` — the only API that can zero it — has no non-test callers anywhere in keploy or enterprise, and `SetMocksWithWindow` writes real timestamps on every non-staging call. So once the first test fires `Active` stays true, and the `FirstTestFired && !Active` session route is unreachable in production. The routing difference is confined to the bootstrap phase before the first test — the tier this PR repairs. **listmonk** and **pgtype-tour** remain the suites to watch.

## Verification

Every fix is pinned by a mutation that makes the test fail:

| mutation | result |
|---|---|
| preservation back inside `if strict` | lax subtest **fails** |
| drop the `isWindowedProxy` guard | no-reader subtest **fails** |
| same, with `KEPLOY_STRICT_MOCK_WINDOW=1` set | still **fails** |

That last one matters: `strictWindowEnabled` ORs in the env override, so an earlier version of this test silently passed on any lane setting it. Both knobs are now forced off.

A `MockManager` test asserts the **end contract** — `GetStartupMocks` actually returns the mock — since slice membership alone would not have caught an empty tier.

`go build`, `go vet`, `gofmt` clean; `./pkg`, `./pkg/service/agent`, `./pkg/agent/proxy` green; all repo suites matching `Window|Filter|Mock|Startup|Tier` green.
