### PR TITLE
fix(replay): reset per-test-set tier state at the test-set boundary

### DIFF
--- a/pkg/agent/proxy/integrations/integrations.go
+++ b/pkg/agent/proxy/integrations/integrations.go
@@ -344,7 +344,11 @@ type WindowAware interface {
 	// HasFirstTestFired reports whether at least one real test window
 	// has been set on the underlying MockManager via SetMocksWithWindow
 	// (non-zero start that is not the BaseTime staging sentinel).
-	// Sticky — once true, stays true.
+	// Sticky within a test-set; ResetForReplaySession clears it at each
+	// set boundary, so a set being staged reads false again. This is the
+	// same underlying value FirstTestWindowStart below exposes as a
+	// timestamp — "has this set's first test fired" and "when did it fire"
+	// are one field, so they share that per-set lifetime.
 	//
 	// Parsers use this alongside IsTestWindowActive to distinguish
 	// "app bootstrap" (before first test) from "between tests" (after
@@ -365,9 +369,11 @@ type WindowAware interface {
 	HasFirstTestFired() bool
 
 	// FirstTestWindowStart returns the earliest test window start observed
-	// by the MockManager, or zero if no real test has fired yet (i.e. every
-	// SetMocksWithWindow call so far was either absent or fired with the
-	// models.BaseTime staging sentinel). Used by filter / strict-gate
+	// by the MockManager FOR THE TEST SET BEING REPLAYED, or zero if no real
+	// test has fired in it yet (i.e. every SetMocksWithWindow call so far was
+	// either absent or fired with the models.BaseTime staging sentinel).
+	// ResetForReplaySession clears it at each set boundary, so each set
+	// classifies against its own first test. Used by filter / strict-gate
 	// callers to distinguish startup-init mocks (req_ts < firstWindowStart)
 	// from stale previous-test mocks (firstWindowStart <= req_ts <
 	// currentStart): the former are legitimate app-bootstrap traffic that

--- a/pkg/agent/proxy/mockmanager.go
+++ b/pkg/agent/proxy/mockmanager.go
@@ -108,8 +108,8 @@ type MockManager struct {
 	//
 	// Zero until the first SetMocksWithWindow call with a non-zero
 	// start arrives; after that it's sticky (only goes earlier, never
-	// later — see updateFirstWindowStart). HasFirstTestFired reads
-	// this field under swapMu.RLock.
+	// later within a set; cleared at each set boundary by
+	// ResetForReplaySession). Read under swapMu.RLock.
 	firstWindowStart time.Time
 
 	// swapMu guards the {filtered, unfiltered, window} swap performed by
@@ -316,15 +316,18 @@ func (m *MockManager) IsClosed() bool {
 //   - droppedOutOfWindow: per-test diagnostic counter that should
 //     reset at the test-set boundary so "dropped for this test-set"
 //     stays meaningful in metrics.
+//   - windowStart/windowEnd: the tier-routing window.
+//     Both describe the set currently being replayed, so both have to be
+//     back at "nothing has fired" before the next set is staged. Leaving
+//     them set is what made every test-set after the first route its
+//     bootstrap traffic to the per-test engine while staging had put those
+//     mocks in the startup tree.
+//   - firstWindowStart: the startup-init vs. stale-bleed cutoff, which is
+//     also per-set — each set must classify against its OWN first test.
+//     See the reset itself for why preserving it (as this used to) silently
+//     emptied the startup tier for every set but the earliest-recorded one.
 //
 // What it preserves:
-//   - firstWindowStart: deliberately sticky across the whole replay
-//     run so the startup-init vs. stale-bleed classification in
-//     SetMocksWithWindow keeps the same "before any test fired"
-//     cutoff for every test-set. Resetting it would let later
-//     test-sets' pre-firstTest mocks accidentally be classified as
-//     startup-init when they're really stale bleed from the previous
-//     test-set's tail.
 //   - filtered / unfiltered / startup trees: SetMocksWithWindow swaps
 //     these atomically on the next call from the orchestrator, so
 //     clearing them here would just briefly serve an empty pool to
@@ -354,6 +357,64 @@ func (m *MockManager) ResetForReplaySession() {
 		return true
 	})
 	atomic.StoreUint64(&m.droppedOutOfWindow, 0)
+
+	// Everything that describes "where are we in the current test set" goes
+	// back to "nothing has fired yet". Both of these are per-set questions,
+	// and between them they are the whole (Active, FirstTestFired) pair the
+	// tier dispatcher routes on:
+	//
+	//   windowStart/windowEnd — the active-window half of tier routing.
+	//   Left set, the next set's isInitialStaging call stages every mock
+	//   into the startup tree while the dispatcher, still seeing the
+	//   previous set's window, routes that set's bootstrap traffic to the
+	//   per-test engine and misses all of it.
+	//
+	//   firstWindowStart — the startup-init vs. stale-bleed cutoff. It used
+	//   to be preserved here, justified as keeping "the same before-any-test
+	//   cutoff for every test-set" so a later set's leading mocks could not
+	//   be misread as startup-init. That rationale does not hold: the mock
+	//   pool is REPLACED per set (Agent.StoreMocks allocates fresh slices and
+	//   finalizeClientMocks does clientMocks.Store(0, storage)), so a set's
+	//   SetMocksWithWindow only ever sees its own mocks and there is no
+	//   previous-set tail to bleed. Within a set the value never moves (the
+	//   test cases arrive sorted by request timestamp — platform/yaml/testdb
+	//   db.go), so per-set and global classify the same mocks WITHIN a set;
+	//   they differ only across sets, which is the bug.
+	//
+	//   What preserving it actually did: the cutoff is a running MINIMUM
+	//   (start.Before(m.firstWindowStart)), so it stuck at whichever set
+	//   recorded earliest. Every other set's own bootstrap mocks sit AFTER
+	//   that cutoff, get classified as stale bleed, and are dropped from
+	//   every tier the moment that set's first test fires. Resetting makes
+	//   each set classify against its own first test, which is what "before
+	//   any test fired" was always supposed to mean.
+	//
+	//   Scope note: this repairs the CLASSIFICATION. It does not by itself
+	//   guarantee the startup band is POPULATED, because the agent reads
+	//   FirstTestWindowStart() before calling SetMocksWithWindow, so on a
+	//   set's first test the read is still zero and the disk LoadBefore that
+	//   fetches the band is skipped. Deriving the cutoff from the window
+	//   being applied is a separate agent-side fix, and it has to stay gated
+	//   on the proxy actually adopting that start — an unguarded derivation
+	//   collapses "req < firstWindowStart" into "req < afterTime" and
+	//   preserves every stale previous-test mock.
+	//
+	// Lock order is swapMu then windowMu, matching WindowSnapshot, so a
+	// WindowSnapshot reader sees either the whole previous set or the whole
+	// cleared state. That guarantee does NOT extend to the legacy
+	// sequential pair (IsTestWindowActive then HasFirstTestFired): those
+	// take different locks, so a caller straddling this reset can still
+	// observe the forbidden Active=true && FirstTestFired=false. Reordering
+	// the writes cannot fix that — the straddle spans both calls — which is
+	// why the pair-coherent readers (the v3 dispatcher's routeTransactional,
+	// TierIndex.orderForCurrentState) are required to use WindowSnapshot.
+	m.swapMu.Lock()
+	m.firstWindowStart = time.Time{}
+	m.windowMu.Lock()
+	m.windowStart = time.Time{}
+	m.windowEnd = time.Time{}
+	m.windowMu.Unlock()
+	m.swapMu.Unlock()
 }
 
 // runIdleSweeper is the background loop that calls SweepIdleConnections
@@ -1166,8 +1227,9 @@ func (m *MockManager) GetSessionScopedMocks() ([]*models.Mock, error) {
 // HasFirstTestFired reports whether at least one real test window has
 // been set on this manager — i.e. some SetMocksWithWindow call arrived
 // with a non-zero start that was NOT the models.BaseTime sentinel used
-// for pre-test staging. Sticky: once true, stays true for the manager's
-// lifetime.
+// for pre-test staging. Sticky within a test set; ResetForReplaySession
+// clears it at each set boundary, so the next set reads false until its
+// own first test fires.
 //
 // Parsers use this to distinguish "app bootstrap" from "between tests"
 // when IsTestWindowActive() returns false. Before the first test fires
@@ -1175,10 +1237,11 @@ func (m *MockManager) GetSessionScopedMocks() ([]*models.Mock, error) {
 // the runner is in the idle gap between tests (or post-last-test
 // teardown).
 //
-// Concurrency: firstWindowStart is updated only under swapMu.Lock()
-// inside SetMocksWithWindow. A reader here uses swapMu.RLock to avoid
-// a torn read on the time.Time. An inherently-racy pre-check is
-// tolerable — a caller that needs strict window/pool atomicity
+// Concurrency: firstWindowStart is written only under swapMu.Lock() — in
+// SetMocksWithWindow when a real window arrives, and in
+// ResetForReplaySession at the set boundary. A reader here takes
+// swapMu.RLock so it cannot observe a torn time.Time or a half-applied
+// reset. An inherently-racy pre-check is tolerable — a caller that needs strict window/pool atomicity
 // consults GetPerTestMocksInWindow, which snapshots both under swapMu.
 //
 // Non-atomic-pair warning: a caller that reads IsTestWindowActive and

--- a/pkg/agent/proxy/mockmanager_wave2_test.go
+++ b/pkg/agent/proxy/mockmanager_wave2_test.go
@@ -7,7 +7,8 @@
 //   - GetPerTestMocksInWindow()→ per-test mocks inside [start, end]
 //
 // Plus the legacy GetSessionMocks() union shim (startup + session) and
-// the HasFirstTestFired() sticky signal.
+// the HasFirstTestFired() signal, which is sticky WITHIN a test-set and
+// clears at each set boundary (ResetForReplaySession).
 package proxy
 
 import (
@@ -938,5 +939,115 @@ func TestSetMocksWithWindow_StartupRebuild_DoesNotClobberUnfilteredID(t *testing
 	}
 	if !containsMockNamed(session, "sess") {
 		t.Fatalf("GetSessionScopedMocks: want 'sess' in session tier, got %v", mockNames(session))
+	}
+}
+
+// proxy.go reuses ONE MockManager for the whole replay — deliberately, to keep
+// revision tracking continuous for parsers that captured it at MockOutgoing
+// time — and marks each test-set boundary with ResetForReplaySession.
+//
+// Tier routing is a per-test-set question, so it has to be back at "nothing
+// has fired" when the next set is staged. It was not: the routing bit was read
+// off the process-global firstWindowStart, so from the first test of the FIRST
+// set onward it stayed true forever, and SetMocksWithWindow's isInitialStaging
+// branch kept the previous set's window besides. A parser staging set 2 saw
+// Active=true, routed that set's bootstrap traffic to the per-test engine, and
+// missed all of it — staging had just copied those mocks into the startup tree
+// precisely because it expected routing to land on the startup engine.
+func TestResetForReplaySession_PutsTierRoutingBackToPreTestState(t *testing.T) {
+	mm := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+	defer mm.Close()
+
+	// Test set 1: one real test fires.
+	start := time.Now().Add(-time.Minute)
+	mm.SetMocksWithWindow(nil, nil, start, start.Add(time.Second))
+	if snap := mm.WindowSnapshot(); !snap.Active || !snap.FirstTestFired {
+		t.Fatalf("precondition: a real test must publish an active window, got %+v", snap)
+	}
+
+	// Set 1 ends, set 2 begins and is staged with the "no test yet" sentinel.
+	mm.ResetForReplaySession()
+	mm.SetMocksWithWindow(nil, nil, models.BaseTime, time.Now())
+
+	snap := mm.WindowSnapshot()
+	if snap.Active {
+		t.Errorf("window still Active while staging test set 2 — bootstrap traffic routes to the per-test engine, whose tree staging just left empty")
+	}
+	if snap.FirstTestFired {
+		t.Errorf("FirstTestFired still set while staging test set 2 — routing skips the startup engine that holds the staged mocks")
+	}
+
+	// And it must come back for set 2's own first test, or every query in
+	// that set would route to startup.
+	s2 := time.Now()
+	mm.SetMocksWithWindow(nil, nil, s2, s2.Add(time.Second))
+	if snap := mm.WindowSnapshot(); !snap.Active || !snap.FirstTestFired {
+		t.Errorf("test set 2's first real test did not re-arm routing: %+v", snap)
+	}
+}
+
+// The other half of the same boundary, and the reason routing alone is not
+// enough: the startup-init vs. stale-bleed cutoff is per-set too.
+//
+// It is a running MINIMUM over every real window the manager has seen, so
+// preserving it across sets pinned it to whichever set recorded earliest.
+// Every other set's own bootstrap mocks fall AFTER that cutoff, so they are
+// classified as stale previous-test bleed and dropped from every tier the
+// instant that set's first test fires — the startup tier is empty for the
+// rest of the run even though staging had just populated it.
+//
+// Real mocks, not nil slices: the flags being right is worth nothing if the
+// mock is not actually in the tier the flags route to.
+func TestResetForReplaySession_SecondTestSetKeepsItsOwnBootstrapMocks(t *testing.T) {
+	mm := NewMockManager(nil, nil, zap.NewNop())
+	defer mm.Close()
+
+	// Test set 1, recorded earlier than set 2 (the normal ordering).
+	s1 := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	mm.SetMocksWithWindow(
+		[]*models.Mock{newMockForTest("s1test", s1.Add(time.Second), models.LifetimePerTest)},
+		nil, s1, s1.Add(10*time.Second))
+
+	// Boundary, then set 2 stages with the "no test yet" sentinel.
+	mm.ResetForReplaySession()
+
+	s2 := s1.Add(time.Hour)
+	boot := newMockForTest("s2boot", s2.Add(-5*time.Second), models.LifetimePerTest)
+	test := newMockForTest("s2test", s2.Add(time.Second), models.LifetimePerTest)
+	mm.SetMocksWithWindow([]*models.Mock{boot, test}, nil, models.BaseTime, time.Now())
+
+	startup, err := mm.GetStartupMocks()
+	if err != nil {
+		t.Fatalf("GetStartupMocks during staging: %v", err)
+	}
+	if !containsMockNamed(startup, "s2boot") {
+		t.Fatalf("staging did not put set 2's bootstrap mock in the startup tier: %v", startup)
+	}
+
+	// Set 2's first real test fires. Its bootstrap mock must STAY in the
+	// startup tier — it was recorded before this set's first test, which is
+	// the definition of startup-init.
+	mm.SetMocksWithWindow([]*models.Mock{boot, test}, nil, s2, s2.Add(10*time.Second))
+
+	startup, err = mm.GetStartupMocks()
+	if err != nil {
+		t.Fatalf("GetStartupMocks after set 2's first test: %v", err)
+	}
+	if !containsMockNamed(startup, "s2boot") {
+		perTest, _ := mm.GetPerTestMocksInWindow()
+		session, _ := mm.GetSessionScopedMocks()
+		t.Fatalf("set 2's own bootstrap mock was dropped from every tier once its first test fired "+
+			"(cutoff stuck at set 1's start): startup=%v perTest=%v session=%v",
+			startup, perTest, session)
+	}
+
+	// And the mock that IS in this set's window still routes per-test, so the
+	// cutoff reset did not simply reclassify everything as startup.
+	perTest, err := mm.GetPerTestMocksInWindow()
+	if err != nil {
+		t.Fatalf("GetPerTestMocksInWindow: %v", err)
+	}
+	if !containsMockNamed(perTest, "s2test") {
+		t.Fatalf("set 2's in-window test mock is missing from the per-test tier: %v", perTest)
 	}
 }

--- a/pkg/models/const.go
+++ b/pkg/models/const.go
@@ -73,7 +73,10 @@ var BaseTime = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
 //     non-zero start+end; BaseTime staging does NOT
 //     activate — see mockmanager.go isInitialStaging).
 //   - FirstTestFired: at least one real (non-BaseTime) test window has
-//     ever been set; sticky once true.
+//     been set for the test set currently being replayed.
+//     Sticky within a set; MockManager.ResetForReplaySession
+//     clears it at each set boundary, so a set being staged
+//     reads false again.
 //
 // The principal-engineer review flagged a torn-read hazard: the legacy
 // IsTestWindowActive / HasFirstTestFired accessors read under different


### PR DESCRIPTION
## The bug

`proxy.go` reuses **one** `MockManager` for an entire replay — deliberately, so parsers that captured it at `MockOutgoing` time keep observing revision bumps — and marks each test-set boundary with `ResetForReplaySession`.

That reset cleared connection-scoped state but left the tier-routing state latched, so both halves of the `(Active, FirstTestFired)` pair the dispatcher routes on still described the **previous** test set. Two consequences, both hitting every set after the first:

**1. Bootstrap traffic routed to an empty tier.** `SetMocksWithWindow`'s `isInitialStaging` branch copies every staged mock into the startup tree *precisely because* it expects `!Active && !FirstTestFired` to route to the startup engine, and deliberately does not publish the window — commented as keeping *"their current (zero for a fresh manager) values"*. That parenthetical only holds for set 1. From set 2 the window is the previous set's, so the dispatcher sent that set's bootstrap traffic to the per-test engine, whose tree staging had just left empty → `candidates=0` / KP001.

**2. The set's own bootstrap mocks were then dropped entirely.** `firstWindowStart` — the startup-init vs. stale-bleed cutoff — is a running **minimum** that never reset, so it stuck at whichever set recorded earliest. Every other set's bootstrap mocks sit *after* that cutoff, get classified as stale bleed, and vanish from every tier the moment that set's first test fires.

Replicated on clean `main` before any change:

```
set2 staging:  active=true  fired=true    <- routes to per-test, tree empty
set2 test1:    startup=[] perTest=[s2test] session=[]   <- s2boot gone from every tier
```

## The fix

Clear all three fields at the boundary. Two lines of behaviour.

The old comment justified **preserving** the cutoff as protection against *"stale bleed from the previous test-set's tail"*. That tail cannot exist: the pool is replaced per set — `Agent.StoreMocks` allocates fresh slices and `finalizeClientMocks` does `clientMocks.Store(0, storage)` — so a set only ever sees its own mocks. Within a set the value never moves (test cases arrive sorted by request timestamp, `platform/yaml/testdb`), so per-set and global classify identically *inside* a set and differ only *across* sets, which is the bug.

## Verification

Every part is pinned by a mutation that makes a test fail:

| mutation | tests failing |
|---|---|
| don't reset `firstWindowStart` | **2** |
| don't clear `windowStart`/`windowEnd` | **1** |
| remove the whole block | **2** |

The tests use real mocks and assert the tier contents, not the flags — the flags being right is worth nothing if the mock isn't in the tier they route to. `ResetForReplaySession` had **zero** test callers before this, which is how a method whose whole job is resetting per-set state shipped without resetting it.

`go build`, `go vet`, `gofmt` clean; `./pkg/agent/proxy/...` and `./pkg/service/agent/...` green; `-race` green.

## Scope notes

- This repairs the **classification**. It does not by itself guarantee the startup band is **populated**: the agent reads `FirstTestWindowStart()` *before* calling `SetMocksWithWindow`, so on a set's first test that read is still zero and the disk `LoadBefore` is skipped. #4513 is the agent-side half, and its derivation is gated on the proxy actually adopting that start — an unguarded version collapses `req < firstWindowStart` into `req < afterTime` and preserves every stale previous-test mock.
- `HasFirstTestFired`/`WindowSnapshot` have no production readers in this repo — only test fakes. The real consumers are in `keploy/integrations` (`routeTransactional`, `tier_index.go`, `mongo/v2/match.go`), so this lands for agents only once that pin bumps. It repairs mongo v2's set-≥2 bootstrap matching as well as postgres v3's.
- The same latch class is still live and untouched in `async.Engine` (`loaded`, `windowSeen`, `completed` — never reset, gated on `opts.Async.Lanes`). Worth its own change.
