### PR TITLE
fix(ci): retry transient registry failures when fetching lane images

### DIFF
--- a/.github/workflows/test_workflow_scripts/docker-build-retry.sh
+++ b/.github/workflows/test_workflow_scripts/docker-build-retry.sh
@@ -84,3 +84,118 @@ docker_build_retry() {
         _backoff=$((_backoff * 2))
     done
 }
+
+# WHAT ELSE IS WORTH RETRYING WHEN FETCHING AN IMAGE
+#
+# A build fails at "load metadata" when Docker Hub meters it. Fetching an
+# image fails the same way, but also on plain network faults that say nothing
+# about the image — the daemon could not reach the registry at all:
+#
+#   docker: Error response from daemon: Get "https://registry-1.docker.io/v2/":
+#     net/http: request canceled while waiting for connection
+#     (Client.Timeout exceeded while awaiting headers)
+#
+# That is what this covers. Via `docker run` it surfaces as exit 125 — the
+# daemon refusing to create the container — so the lane goes red having
+# executed no test and asserted nothing.
+#
+# The same "only retry what is transient" rule applies, and matters more here
+# because the permanent failures are ordinary mistakes: an unknown manifest
+# (bad tag), denied access (private image), or no matching platform (an arm64
+# runner, an amd64-only image). Retrying those wastes minutes and then blames
+# a network fault that never happened, sending the next reader after the wrong
+# cause. They abort on the first attempt, showing docker's own message.
+DOCKER_PULL_RETRY_RE="${DOCKER_BUILD_RETRY_RE}|client\.timeout|context deadline exceeded|i/o timeout|connection reset|connection refused|temporary failure|no such host|tls handshake timeout|unexpected eof|request canceled"
+
+# _docker_fetch_retry <what> <command> [args...]
+#
+# Shared body of docker_pull_retry / docker_compose_pull_retry: run the fetch,
+# retry only while the failure looks transient, abort otherwise. <what> names
+# the target in the messages.
+_docker_fetch_retry() {
+    local _what="$1"; shift
+    local _max="${DOCKER_PULL_RETRY_ATTEMPTS:-4}"
+    local _backoff="${DOCKER_PULL_RETRY_BACKOFF:-5}"
+    local _attempt=1
+    local _rc=0
+    local _log
+    local _restore_errexit=0
+
+    case "$-" in *e*) _restore_errexit=1 ;; esac
+    _log="$(mktemp "${TMPDIR:-/tmp}/docker-pull-retry.XXXXXX")"
+
+    while : ; do
+        echo "fetching ${_what}: $* (attempt ${_attempt}/${_max})"
+
+        set +e
+        "$@" 2>&1 | tee "$_log"
+        _rc=${PIPESTATUS[0]}
+        if [ "$_restore_errexit" -eq 1 ]; then set -e; fi
+
+        if [ "$_rc" -eq 0 ]; then
+            rm -f "$_log"
+            return 0
+        fi
+
+        if ! grep -qiE "$DOCKER_PULL_RETRY_RE" "$_log"; then
+            echo "::error::fetching ${_what} failed with exit code ${_rc} for a reason retrying will not clear. Docker's own message is above and carries the diagnosis. If it points at the daemon rather than the image, check 'docker info' and free disk on the runner."
+            rm -f "$_log"
+            exit 1
+        fi
+
+        if [ "$_attempt" -ge "$_max" ]; then
+            echo "::error::fetching ${_what} did not succeed in ${_max} attempts; the last failure is above. The lane never ran its test."
+            rm -f "$_log"
+            exit 1
+        fi
+
+        echo "Transient registry failure fetching ${_what} (exit ${_rc}); retrying in ${_backoff}s…"
+        sleep "$_backoff"
+        _attempt=$((_attempt + 1))
+        _backoff=$((_backoff * 2))
+    done
+}
+
+# docker_pull_retry <image>
+#
+# Fetch an image before the `docker run` that would otherwise pull it
+# implicitly.
+#
+# This does NOT retry a test. It runs before the application starts and
+# short-circuits the moment the image is local, so once it returns the lane
+# executes exactly once and any later failure stands on its own.
+docker_pull_retry() {
+    local _image="${1:-}"
+
+    if [ -z "$_image" ]; then
+        echo "::error::docker_pull_retry: called with no image"
+        exit 1
+    fi
+
+    # Already resident from an earlier step or a warm runner cache. Returning
+    # here also spends no manifest request, which is the budget the rate limit
+    # above meters.
+    if docker image inspect "$_image" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    _docker_fetch_retry "$_image" docker pull "$_image"
+}
+
+# docker_compose_pull_retry [compose args...]
+#
+# The compose equivalent: `docker compose up -d` pulls implicitly too, so a
+# compose-started dependency is exposed to exactly the same registry failure
+# as a `docker run` one. Pull first so the failure is attributed and retried.
+# Unlike the single-image form this cannot short-circuit on one `docker image
+# inspect`, so it defers to compose's own per-service resident check via
+# --policy missing (see below).
+docker_compose_pull_retry() {
+    # --policy missing matters: `docker compose pull` defaults to "always" and
+    # re-contacts the registry even when every image is already local, so an
+    # unconditional pull SPENDS the same metered budget the rate-limit handling
+    # above exists to protect. `docker compose up` itself defaults to "missing",
+    # so without this flag guarding a lane would cost it more requests than
+    # leaving it unguarded. Needs compose >= v2.22.
+    _docker_fetch_retry "the compose services" docker compose pull --policy missing "$@"
+}

--- a/.github/workflows/test_workflow_scripts/docker-build-retry.sh
+++ b/.github/workflows/test_workflow_scripts/docker-build-retry.sh
@@ -31,12 +31,54 @@
 # digits also occur in ISO-8601 timestamps and layer byte counts in this
 # very output, and matching them would silently reclassify real breakage
 # as a rate limit.
-DOCKER_BUILD_RETRY_RE='toomanyrequests|too many requests|pull rate limit|rate limit exceeded'
+#
+# THE MODULE PROXY IS THE OTHER TRANSIENT DEPENDENCY FETCH
+#
+# A build inside these images downloads Go modules, and proxy.golang.org
+# fails the same way a registry does. Observed on the echo-sql lane, after
+# the build had sat for two minutes:
+#
+#   github.com/valyala/fasttemplate@v1.2.1:
+#     read "https://proxy.golang.org/@v/v1.2.1.zip":
+#     stream error: stream ID 43; INTERNAL_ERROR; received from peer
+#
+# Only the HTTP/2 TRANSPORT wording is matched, and the reason is narrow: a
+# fetch that dies in transport says so, whereas a compiler failure never does.
+# Note the failure above is still emitted from a compiler line (it surfaces
+# while type-checking an import 120s in), so "the compile had not started" is
+# NOT the discriminator — the transport phrasing is.
+#
+# Two patterns were tried and removed after they collided:
+#
+#   unexpected eof   — cmd/compile prints "syntax error: unexpected EOF,
+#                      expected }" for ANY unterminated brace, and bash prints
+#                      it for an unbalanced quote in a RUN line. Matching it
+#                      retried a syntax error four times and pushed the
+#                      compiler line four builds up the log — exactly what the
+#                      paragraph above exists to prevent.
+#   proxy.golang.org — a hostname, not an error. Under the default
+#                      GOPROXY=...,direct a permanent dependency error (bad
+#                      checksum, unknown revision, missing module) falls through
+#                      to git and never prints it, so it buys nothing; but one
+#                      `go mod download -x` or an echoed ENV line would put it
+#                      in the log and make that lane retry everything.
+#
+# Like the rate-limit handling above, this is a MITIGATION, not a cure. The cure
+# is that the sample Dockerfiles run `go build` with no
+# --mount=type=cache,target=/go/pkg/mod, so every lane re-fetches the whole
+# module graph over the network on every build; a cache mount or vendoring in
+# the samples repos would remove the exposure instead of retrying it.
+#
+# Scope caveat: the grep is over the whole build log, and the compose call sites
+# build several services at once, so one service's transient blip retries the
+# others too — including a sibling's genuine compile break.
+DOCKER_BUILD_RETRY_RE='toomanyrequests|too many requests|pull rate limit|rate limit exceeded|stream error: stream id|INTERNAL_ERROR; received from peer|tls handshake timeout|i/o timeout|connection reset by peer'
 
 # docker_build_retry <command> [args...]
 #
 # Runs the build, echoing its output, and retries with exponential backoff
-# only while the failure looks like a Docker Hub rate limit.
+# only while the failure looks transient — a Docker Hub rate limit, or a
+# module/registry fetch that failed in transport rather than in the compiler.
 docker_build_retry() {
     local _max="${DOCKER_BUILD_RETRY_ATTEMPTS:-4}"
     local _backoff="${DOCKER_BUILD_RETRY_BACKOFF:-15}"
@@ -67,18 +109,18 @@ docker_build_retry() {
         fi
 
         if ! grep -qiE "$DOCKER_BUILD_RETRY_RE" "$_log"; then
-            echo "::error::'$*' failed with exit code ${_rc}. Not a Docker Hub rate limit, so not retrying."
+            echo "::error::'$*' failed with exit code ${_rc}. The failure above is not a transient fetch (rate limit or transport), so retrying would only bury it. Not retrying."
             rm -f "$_log"
             exit 1
         fi
 
         if [ "$_attempt" -ge "$_max" ]; then
-            echo "::error::'$*' failed after ${_max} attempts: Docker Hub pull rate limit (HTTP 429) did not clear. This is an infrastructure limit on the runner's egress IP, not a defect in this change."
+            echo "::error::'$*' failed after ${_max} attempts: the last failure is above. A fetch that never clears is usually an egress-IP rate limit or an upstream outage rather than a defect in this change — but read the message rather than assuming."
             rm -f "$_log"
             exit 1
         fi
 
-        echo "Docker Hub rate limit hit (exit ${_rc}); retrying in ${_backoff}s…"
+        echo "Transient fetch failure (exit ${_rc}); retrying in ${_backoff}s…"
         sleep "$_backoff"
         _attempt=$((_attempt + 1))
         _backoff=$((_backoff * 2))
@@ -105,7 +147,7 @@ docker_build_retry() {
 # runner, an amd64-only image). Retrying those wastes minutes and then blames
 # a network fault that never happened, sending the next reader after the wrong
 # cause. They abort on the first attempt, showing docker's own message.
-DOCKER_PULL_RETRY_RE="${DOCKER_BUILD_RETRY_RE}|client\.timeout|context deadline exceeded|i/o timeout|connection reset|connection refused|temporary failure|no such host|tls handshake timeout|unexpected eof|request canceled"
+DOCKER_PULL_RETRY_RE="${DOCKER_BUILD_RETRY_RE}|client\.timeout|context deadline exceeded|connection refused|temporary failure|no such host|unexpected eof|request canceled"
 
 # _docker_fetch_retry <what> <command> [args...]
 #

--- a/.github/workflows/test_workflow_scripts/fuzzer/mysql/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/fuzzer/mysql/golang-linux.sh
@@ -10,6 +10,8 @@ set -Eeuo pipefail
 # --- Helper Functions for Logging and Error Handling ---
 
 # Creates a collapsible group in the GitHub Actions log
+source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
+
 section() { echo "::group::$*"; }
 endsec()  { echo "::endgroup::"; }
 
@@ -179,6 +181,7 @@ sudo chmod +x $MYSQL_FUZZER_BIN
 sudo chown -R $(whoami):$(whoami) golden
 
 # Start a MySQL instance for the recording session
+docker_pull_retry mysql:8.0
 docker run --name mysql-container \
   -e MYSQL_ROOT_PASSWORD=password \
   -p 3306:3306 --rm -d mysql:8.0
@@ -234,6 +237,7 @@ if json_pass_supported; then
     # the same blank starting state.
     section "Reset MySQL before json record pass"
     docker rm -f mysql-container || true
+    docker_pull_retry mysql:8.0
     docker run --name mysql-container \
       -e MYSQL_ROOT_PASSWORD=password \
       -p 3306:3306 --rm -d mysql:8.0

--- a/.github/workflows/test_workflow_scripts/fuzzer/postgres/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/fuzzer/postgres/golang-linux.sh
@@ -7,6 +7,7 @@
 # --- Script Configuration and Safety ---
 set -Eeuo pipefail
 
+source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
 echo "root ALL=(ALL:ALL) ALL" | sudo tee -a /etc/sudoers
 
 # --- Helper Functions for Logging and Error Handling ---
@@ -205,6 +206,7 @@ sudo chmod +x $POSTGRES_FUZZER_BIN
 sudo chown -R $(whoami):$(whoami) golden
 
 # Start a Postgres instance for the recording session
+docker_pull_retry postgres:latest
 docker run --name postgres-container \
   -e POSTGRES_PASSWORD=password \
   -e POSTGRES_USER=postgres \

--- a/.github/workflows/test_workflow_scripts/golang/echo_mysql/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/echo_mysql/golang-linux.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # safer bash, but we’ll locally disable -e around commands we want to inspectset -Eeuo pipefail
 
+source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
 git fetch origin
 git checkout origin/add-ssl-mysql
 
@@ -162,12 +163,14 @@ section "Start MySQL"
 if ! docker ps --format '{{.Names}}' | grep -q '^mysql-container$'; then
   if [[ "${ENABLE_SSL:-false}" == "true" ]]; then
     echo "Starting MySQL with SSL/TLS via Docker Compose"
+    docker_compose_pull_retry
     docker compose up -d
     wait_for_mysql
   else
     echo "Starting MySQL with standard Docker run (no SSL)"
     sed -i 's/MYSQL_SSL_MODE=production/MYSQL_SSL_MODE=false/' .env
     cat .env
+    docker_pull_retry mysql:latest
     docker run --name mysql-container -e MYSQL_ROOT_PASSWORD=password -e MYSQL_DATABASE=uss \
       -p 3306:3306 --rm -d mysql:latest
     wait_for_mysql
@@ -193,9 +196,11 @@ if json_pass_supported; then
   section "Reset MySQL before json record pass"
   docker rm -f mysql-container || true
   if [[ "${ENABLE_SSL:-false}" == "true" ]]; then
+    docker_compose_pull_retry
     docker compose up -d
     wait_for_mysql
   else
+    docker_pull_retry mysql:latest
     docker run --name mysql-container -e MYSQL_ROOT_PASSWORD=password -e MYSQL_DATABASE=uss \
       -p 3306:3306 --rm -d mysql:latest
     wait_for_mysql

--- a/.github/workflows/test_workflow_scripts/golang/echo_sql/golang-docker-macos.sh
+++ b/.github/workflows/test_workflow_scripts/golang/echo_sql/golang-docker-macos.sh
@@ -175,6 +175,7 @@ dump_diag() {
 # either path.
 wait_for_postgres_ready() {
     echo "Pre-starting postgres and waiting for it to accept TCP connections..."
+    docker_compose_pull_retry postgres
     docker compose up -d postgres
     local ready=false
     for _ in $(seq 1 90); do

--- a/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-docker-macos.sh
+++ b/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-docker-macos.sh
@@ -78,6 +78,7 @@ docker network create "$NETWORK_NAME"
 
 # Start MongoDB with a unique container name but a network alias of "mongoDb"
 # so the gin-mongo app (which hardcodes "mongoDb:27017") resolves correctly.
+docker_pull_retry mongo
 docker run --name "$MONGO_CONTAINER" --rm \
   --net "$NETWORK_NAME" --network-alias mongoDb \
   -p "${DB_PORT}:27017" -d mongo

--- a/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-docker.sh
+++ b/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-docker.sh
@@ -5,6 +5,7 @@ source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_s
 
 # Start mongo before starting keploy.
 docker network create keploy-network
+docker_pull_retry mongo
 docker run --name mongoDb --rm --net keploy-network -p 27017:27017 -d mongo
 
 # Generate the keploy-config file.

--- a/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-linux.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
 echo "root ALL=(ALL:ALL) ALL" | sudo tee -a /etc/sudoers
 
 dump_gin_mongo_ci_diagnostics() {
@@ -23,6 +24,7 @@ dump_gin_mongo_ci_diagnostics() {
 
 # Start mongo before starting keploy.
 docker rm -f mongoDb >/dev/null 2>&1 || true
+docker_pull_retry mongo
 docker run --rm -d -p27017:27017 --name mongoDb mongo
 trap 'docker rm -f mongoDb >/dev/null 2>&1 || true' EXIT
 

--- a/.github/workflows/test_workflow_scripts/golang/mock_mismatch_streaming/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/mock_mismatch_streaming/golang-linux.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
+
 # E2E for STREAMING mock-mismatch reporting. Uses the sse-redis sample, whose
 # streaming endpoints (SSE / NDJSON / multipart / plain-text) are served from
 # Redis. We record it, then MUTATE the recorded LRANGE read mock — the outgoing
@@ -38,6 +40,7 @@ rm -rf keploy/
 rm -f record_logs.txt test_logs.txt
 
 # Redis backing store for the sample's streaming endpoints.
+docker_compose_pull_retry
 docker compose up -d
 echo "waiting for redis..."
 for i in $(seq 1 30); do

--- a/.github/workflows/test_workflow_scripts/java/async_config_poll/java-linux.sh
+++ b/.github/workflows/test_workflow_scripts/java/async_config_poll/java-linux.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
+
 # E2E test for the async-egress engine (keploy#4368) via the async-config-poll
 # sample (keploy/samples-java).
 #
@@ -154,6 +156,7 @@ sudo rm -rf keploy
 section "Start dependencies (MySQL + config-service stub)"
 # MySQL init runs in the background and overlaps the Maven build below; it is
 # only awaited (wait_for_mysql) just before the app boots under keploy.
+docker_compose_pull_retry
 docker compose up -d
 ( cd config-stub && go build -o /tmp/acp-config-stub . )
 env ${STUB_ENV} /tmp/acp-config-stub > config-stub.log 2>&1 &

--- a/.github/workflows/test_workflow_scripts/java/mysql_auto_port/java-linux.sh
+++ b/.github/workflows/test_workflow_scripts/java/mysql_auto_port/java-linux.sh
@@ -44,6 +44,8 @@
 
 set -Eeuo pipefail
 
+source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
+
 MYSQL_PORT=3307
 # The port the application is pointed at for the SECOND replay, to simulate an
 # environment whose database endpoint differs from the one that was recorded.
@@ -245,6 +247,7 @@ sudo rm -rf keploy/ keploy.yml
 relocate_mysql_port
 
 section "Start MySQL"
+docker_compose_pull_retry
 docker compose up -d
 wait_for_mysql
 endsec

--- a/.github/workflows/test_workflow_scripts/java/mysql_dual_conn/java-linux.sh
+++ b/.github/workflows/test_workflow_scripts/java/mysql_dual_conn/java-linux.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
+
 # E2E test for MySQL dual-connection handshake matching.
 #
 # Validates that Keploy correctly matches HandshakeResponse41 packets when
@@ -130,6 +132,7 @@ source "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/test-iid.sh"
 sudo rm -rf keploy/ keploy.yml
 
 section "Start MySQL"
+docker_compose_pull_retry
 docker compose up -d
 wait_for_mysql
 endsec

--- a/.github/workflows/test_workflow_scripts/java/spring_petclinic/java-linux.sh
+++ b/.github/workflows/test_workflow_scripts/java/spring_petclinic/java-linux.sh
@@ -3,6 +3,7 @@
 
 set -Eeuo pipefail
 
+source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
 section() { echo "::group::$*"; }
 endsec()  { echo "::endgroup::"; }
 
@@ -679,6 +680,7 @@ git checkout petclinic-script
 endsec
 
 section "Start Postgres"
+docker_pull_retry postgres:latest
 docker run -d --name mypostgres -e POSTGRES_USER=petclinic -e POSTGRES_PASSWORD=petclinic \
   -e POSTGRES_DB=petclinic -p 5432:5432 postgres:latest
 wait_for_postgres
@@ -752,6 +754,7 @@ if json_pass_supported; then
   # the same testcases, just in a different on-disk encoding.
   section "Reset Postgres before json record pass"
   docker rm -f mypostgres
+  docker_pull_retry postgres:latest
   docker run -d --name mypostgres -e POSTGRES_USER=petclinic -e POSTGRES_PASSWORD=petclinic \
     -e POSTGRES_DB=petclinic -p 5432:5432 postgres:latest
   wait_for_postgres

--- a/.github/workflows/test_workflow_scripts/java/tidb_stmt_cache/java-linux.sh
+++ b/.github/workflows/test_workflow_scripts/java/tidb_stmt_cache/java-linux.sh
@@ -20,6 +20,8 @@
 
 set -Eeuo pipefail
 
+source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
+
 section() { echo "::group::$*"; }
 endsec()  { echo "::endgroup::"; }
 
@@ -188,6 +190,7 @@ source "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/test-iid.sh"
 sudo rm -rf keploy/ keploy.yml
 
 section "Start TiDB"
+docker_compose_pull_retry
 docker compose up -d
 wait_for_tidb
 endsec

--- a/.github/workflows/test_workflow_scripts/node/express_mongoose/node-docker.sh
+++ b/.github/workflows/test_workflow_scripts/node/express_mongoose/node-docker.sh
@@ -5,6 +5,7 @@ source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_s
 
 # Start the docker container.
 docker network create keploy-network
+docker_pull_retry mongo
 docker run --name mongoDb --rm --net keploy-network -p 27017:27017 -d mongo
 
 # Remove any preexisting keploy tests.

--- a/.github/workflows/test_workflow_scripts/node/express_mongoose/node-linux.sh
+++ b/.github/workflows/test_workflow_scripts/node/express_mongoose/node-linux.sh
@@ -4,6 +4,7 @@
 set -Eeuo pipefail
 set -o errtrace
 
+source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
 section() { echo "::group::$*"; }
 endsec()  { echo "::endgroup::"; }
 
@@ -83,6 +84,7 @@ send_request() {
 source ./../../.github/workflows/test_workflow_scripts/test-iid.sh
 
 section "Start Mongo"
+docker_pull_retry mongo
 docker run --name mongoDb --rm -p 27017:27017 -d mongo
 wait_for_mongo
 endsec

--- a/.github/workflows/test_workflow_scripts/python-docker-macos.sh
+++ b/.github/workflows/test_workflow_scripts/python-docker-macos.sh
@@ -70,6 +70,7 @@ docker network create "$NETWORK_NAME"
 
 # --- Start fresh Mongo (force remove any stale one first) ---
 docker rm -f "$DB_CONTAINER" >/dev/null 2>&1 || true
+docker_pull_retry mongo
 docker run --name "$DB_CONTAINER" --rm \
   --net "$NETWORK_NAME" --network-alias mongo \
   -p "${DB_PORT}:27017" -d mongo

--- a/.github/workflows/test_workflow_scripts/python-docker.sh
+++ b/.github/workflows/test_workflow_scripts/python-docker.sh
@@ -5,6 +5,7 @@ source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_s
 
 # Start mongo before starting keploy.
 docker network create keploy-network
+docker_pull_retry mongo
 docker run --name mongo --rm --net keploy-network -p 27017:27017 -d mongo
 
 # Set up environment

--- a/.github/workflows/test_workflow_scripts/python/django_postgres/python-linux.sh
+++ b/.github/workflows/test_workflow_scripts/python/django_postgres/python-linux.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
+source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
+
 source ./../../../.github/workflows/test_workflow_scripts/test-iid.sh
 
 echo "root ALL=(ALL:ALL) ALL" | sudo tee -a /etc/sudoers
 
 # Start the postgres database
+docker_compose_pull_retry
 docker compose up -d
 
 # Install dependencies


### PR DESCRIPTION
## The failure

A lane went red with exit 125 having executed no test and asserted nothing:

```
Unable to find image 'mysql:latest' locally
docker: Error response from daemon: Get "https://registry-1.docker.io/v2/":
  net/http: request canceled while waiting for connection
  (Client.Timeout exceeded while awaiting headers)
Dumping logs and artifacts (exit code: 125)
```

Exit 125 is the daemon refusing to create the container. The lane scripts start their dependencies with `docker run <image>` and `docker compose up`, both of which pull implicitly — and that implicit pull is the only fetch, with exactly one attempt. **25 such sites** across the tree share the single point of failure. Docker Hub also meters anonymous pulls per egress IP, which shared CI networking makes considerably more likely, so this is not a one-off.

## What this adds

`docker_pull_retry <image>` and `docker_compose_pull_retry [services…]`, next to the existing `docker_build_retry` and sharing one core.

That file already had the right rule and I kept it: **only transient failures retry.** An unknown tag, denied access, or an unavailable platform aborts on the first attempt showing docker's own message — retrying those would waste minutes and then report a network fault that never happened, sending the next reader after the wrong cause.

**This does not retry a test.** It runs before the application starts and short-circuits when the image is already local, so the lane still executes exactly once and any failure after that point stands on its own. A pull that never succeeds still fails the lane, just naming the image instead of an opaque 125.

`--policy missing` on the compose form is load-bearing: `docker compose pull` defaults to `always` and re-contacts the registry even when every image is resident, while `docker compose up` defaults to `missing`. Without the flag, guarding a lane would spend *more* of the metered budget than leaving it unguarded.

## Verification

Behaviour was measured, not assumed:

| case | result |
|---|---|
| warm cache | returns immediately, no registry request |
| unreachable registry | retries with backoff, then fails naming the image |
| unknown tag | aborts after **1** attempt, no backoff |
| no argument under `set -u` | clean error, not `unbound variable` |
| `compose pull --policy missing`, resident image | `Skipped - Image is already present locally` |

A script-wide check confirms the `source` line precedes the first call and is top-level in all 18 lane scripts.

**One thing static analysis could not see.** An earlier revision of this diff spliced a call into a line continuation, so `docker_pull_retry` became the *image argument* to `docker run`. `bash -n` and `shellcheck -S error` were both clean on it. I caught it by extracting the MySQL start block and running it with `docker` stubbed:

```
broken:  DOCKER ARGV: run --name mysql-container … uss docker_pull_retry mysql:latest
         line 16: -p: command not found
fixed:   PULL ARGV:   mysql:latest
         DOCKER ARGV: run --name mysql-container … -p 3306:3306 --rm -d mysql:latest
```

`shellcheck -S warning` does catch it (SC2215), and that is the gate this kind of edit needs. **There is no shell linting in CI today** — adding one is worth a separate PR; it would likely surface pre-existing findings across the tree.

## Not covered

Stated rather than implied: the `keploy record -c "docker compose up"` / `keploy test -c "docker compose up"` sites (`echo_sql`, `go_memory_load*`, `proxy_stress_test`) are still exposed. There the pull happens *inside* keploy's app-run, so a registry blip surfaces as "keploy record failed" — a false product-bug signal, and strictly worse than an exit 125. Guarding those means inserting a pull before each keploy invocation, which changes timing in the memory-load lanes; it deserves its own change.

## Unrelated pre-existing bug found while editing

`golang/echo_mysql/golang-linux.sh:2` — `set -Eeuo pipefail` is swallowed into the preceding comment (`…we want to inspectset -Eeuo pipefail`), so that script runs with no `-u` and no `pipefail`. Consequently at `:227`:

```sh
"$REPLAY_BIN" test … | tee test_logs.txt || true
REPLAY_RC=$?      # status of `|| true` — always 0
```

so the `[ "$REPLAY_RC" -ne 0 ]` gates below it can never fire. Deliberately **not** fixed here: enabling `-Eeuo pipefail` on a script that has been tolerating non-zero exits needs its own change and CI cycle.


---

## Second commit: the module proxy is the other transient fetch

CI on this very PR then failed a *different* lane the same way — `echo-sql`, after its build sat for two minutes:

```
github.com/valyala/fasttemplate@v1.2.1: read "https://proxy.golang.org/@v/v1.2.1.zip":
  stream error: stream ID 43; INTERNAL_ERROR; received from peer
```

`docker_build_retry` already wrapped that build and **correctly declined** to retry it — its match set was Docker Hub rate limits only. But the module proxy is the other transient dependency fetch in these images and fails the same way a registry does, so the HTTP/2 transport wording joins the set.

The discriminator stays the *wording*, never the exit code. Worth stating plainly: this failure **is** printed from a compiler line (it surfaces while type-checking an import), so "the compile hadn't started" would have been the wrong rule.

Two candidate patterns were tried and **dropped** after they collided with real breakage:

| pattern | why it was removed |
|---|---|
| `unexpected eof` | what `cmd/compile` prints for *any* unterminated brace (`syntax error: unexpected EOF, expected }`), and what bash prints for an unbalanced quote in a `RUN`. Matching it retried a syntax error 4× and pushed the compiler line four builds up the log — the exact outcome this helper exists to prevent. |
| `proxy.golang.org` | a hostname, not an error. Under the default `GOPROXY=…,direct` a permanent failure (bad checksum, unknown revision, missing module) falls through to git and never prints it — so it buys nothing, while one `go mod download -x` would make that lane retry everything. |

The three operator-facing messages no longer claim "Docker Hub rate limit" for a set broader than one, and the exhausted message states what is known rather than asserting an HTTP 429 that may not have happened.

Verified by classification and end-to-end: syntax error, bash quote error, undefined symbol, checksum mismatch, proxy 404 and missing repository all **abort on attempt 1**; the observed stream error, a 429, a TLS handshake timeout and a connection reset all **retry**. Pull-side classification unchanged.

**Mitigation, not a cure** — and the comment now says so. The samples' Dockerfiles run `go build` with no `--mount=type=cache,target=/go/pkg/mod`, so every lane re-fetches the whole module graph over the network on every build. A cache mount or vendoring in the samples repos would remove the exposure instead of retrying it.
