### PR TITLE
fix(replay): honour AfterGetMocks reusable retagging by re-partitioning mocks

### DIFF
--- a/pkg/service/replay/rebalance_reusable_test.go
+++ b/pkg/service/replay/rebalance_reusable_test.go
@@ -1,0 +1,94 @@
+package replay
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+func perTest(name string) *models.Mock {
+	m := &models.Mock{Name: name, Kind: models.Mongo}
+	m.TestModeInfo.Lifetime = models.LifetimePerTest
+	return m
+}
+
+func configTagged(name string) *models.Mock {
+	m := &models.Mock{Name: name, Kind: models.Mongo}
+	m.TestModeInfo.Lifetime = models.LifetimeSession
+	m.Spec.Metadata = map[string]string{"type": "config"}
+	return m
+}
+
+func names(ms []*models.Mock) []string {
+	out := make([]string, 0, len(ms))
+	for _, m := range ms {
+		out = append(out, m.Name)
+	}
+	return out
+}
+
+func eq(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// A mock retagged reusable (config) but still sitting in the per-test pool must
+// be moved into the reusable pool so SetMocksWithWindow does not window-filter
+// it. Non-reusable mocks stay put; order is preserved in both pools.
+func TestRebalanceReusableMocks_MovesRetaggedOnly(t *testing.T) {
+	filtered := []*models.Mock{perTest("pt-1"), configTagged("promoted"), perTest("pt-2")}
+	unfiltered := []*models.Mock{configTagged("cfg-existing")}
+
+	f, u := rebalanceReusableMocks(filtered, unfiltered)
+
+	if got := names(f); !eq(got, []string{"pt-1", "pt-2"}) {
+		t.Fatalf("filtered pool = %v, want [pt-1 pt-2]", got)
+	}
+	if got := names(u); !eq(got, []string{"cfg-existing", "promoted"}) {
+		t.Fatalf("unfiltered pool = %v, want [cfg-existing promoted]", got)
+	}
+}
+
+// Nothing to move: an all-per-test filtered pool is returned unchanged.
+func TestRebalanceReusableMocks_NoReusableIsNoop(t *testing.T) {
+	filtered := []*models.Mock{perTest("a"), perTest("b")}
+	unfiltered := []*models.Mock{}
+	f, u := rebalanceReusableMocks(filtered, unfiltered)
+	if got := names(f); !eq(got, []string{"a", "b"}) {
+		t.Fatalf("filtered pool changed unexpectedly: %v", got)
+	}
+	if len(u) != 0 {
+		t.Fatalf("unfiltered pool must stay empty, got %v", names(u))
+	}
+}
+
+// Empty/nil filtered input is safe and a no-op.
+func TestRebalanceReusableMocks_EmptyInput(t *testing.T) {
+	f, u := rebalanceReusableMocks(nil, []*models.Mock{configTagged("c")})
+	if len(f) != 0 {
+		t.Fatalf("filtered must stay empty, got %v", names(f))
+	}
+	if got := names(u); !eq(got, []string{"c"}) {
+		t.Fatalf("unfiltered must be unchanged, got %v", got)
+	}
+}
+
+// A nil entry in the filtered pool is dropped from the per-test pool (it can
+// never match) and never treated as reusable.
+func TestRebalanceReusableMocks_NilEntrySafe(t *testing.T) {
+	filtered := []*models.Mock{perTest("a"), nil, configTagged("p")}
+	f, u := rebalanceReusableMocks(filtered, nil)
+	if got := names(f); !eq(got, []string{"a"}) {
+		t.Fatalf("filtered pool = %v, want [a]", got)
+	}
+	if got := names(u); !eq(got, []string{"p"}) {
+		t.Fatalf("unfiltered pool = %v, want [p]", got)
+	}
+}

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1312,6 +1312,10 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			if err := mutator.AfterGetMocks(ctx, filteredMocks, unfilteredMocks); err != nil {
 				return models.TestSetStatusFailed, err
 			}
+			// Honour any reusable retagging the mutator applied (e.g. the mongo/v2
+			// stable-metadata promotion): move retagged mocks from the per-test pool
+			// into the reusable pool so SetMocksWithWindow does not window-filter them.
+			filteredMocks, unfilteredMocks = rebalanceReusableMocks(filteredMocks, unfilteredMocks)
 		}
 
 		err = r.instrumentation.StoreMocks(ctx, filteredMocks, unfilteredMocks)
@@ -1409,6 +1413,9 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			if err := mutator.AfterGetMocks(ctx, filteredMocks, unfilteredMocks); err != nil {
 				return models.TestSetStatusFailed, err
 			}
+			// Honour any reusable retagging the mutator applied (see the
+			// non-DockerCompose branch above for the rationale).
+			filteredMocks, unfilteredMocks = rebalanceReusableMocks(filteredMocks, unfilteredMocks)
 		}
 		err = r.instrumentation.StoreMocks(ctx, filteredMocks, unfilteredMocks)
 		if err != nil {
@@ -4409,6 +4416,44 @@ func isReusableTierMock(m *models.Mock) bool {
 		}
 	}
 	return false
+}
+
+// rebalanceReusableMocks moves any mock that a MockMutator.AfterGetMocks
+// re-tagged as reusable (isReusableTierMock — Lifetime Session/Connection or
+// metadata type config/connection) out of the per-test `filtered` pool and into
+// the reusable `unfiltered` pool, and returns the adjusted slices.
+//
+// It exists because AfterGetMocks receives the two pools BY VALUE: a mutator can
+// retag a mock's Lifetime/metadata in place, but it cannot move a mock between
+// the slices (a shrink of `filtered` or a grow of `unfiltered` does not
+// propagate to the caller). Since the agent's SetMocksWithWindow window-filters
+// every mock in `filtered` regardless of its per-mock tag, a mock retagged
+// reusable but left in `filtered` would still be dropped when it fires outside
+// its record-time window — defeating the retag. Running this immediately after
+// AfterGetMocks honours the retag by physically re-partitioning.
+//
+// Memory: `filtered` is compacted in place (its backing array is reused via the
+// [:0] read/write cursor); `unfiltered` grows only by the promoted count. No
+// second copy of the corpus is allocated. Relative order within each pool is
+// preserved. Safe on nil/empty inputs.
+func rebalanceReusableMocks(filtered, unfiltered []*models.Mock) ([]*models.Mock, []*models.Mock) {
+	if len(filtered) == 0 {
+		return filtered, unfiltered
+	}
+	keep := filtered[:0]
+	for _, m := range filtered {
+		if m == nil {
+			// A nil entry can never match; drop it from the per-test pool rather
+			// than carrying it forward (SetMocksWithWindow skips nils anyway).
+			continue
+		}
+		if isReusableTierMock(m) {
+			unfiltered = append(unfiltered, m)
+			continue
+		}
+		keep = append(keep, m)
+	}
+	return keep, unfiltered
 }
 
 // isReusableTierState is the MockState (consumed-mock) equivalent of


### PR DESCRIPTION
## What

Adds `rebalanceReusableMocks`, run immediately after each `MockMutator.AfterGetMocks` call, to move any mock the mutator retagged reusable from the per-test `filtered` pool into the reusable `unfiltered` pool.

## Why

`AfterGetMocks` gets the two pools **by value** — a mutator can retag a mock's `Lifetime`/metadata in place but cannot move it between the slices. `SetMocksWithWindow` window-filters every mock left in `filtered` regardless of its per-mock tag, so a mock retagged reusable but left in `filtered` is still dropped when it fires **outside its record-time window** — silently defeating the retag.

The motivating consumer: a mongo v2 mutator that promotes a **provably stable** background metadata poll (byte-identical response across ≥2 distinct test windows) to `LifetimeSession`, so an async poll that re-fires in a different window than it recorded is no longer a per-test-window miss. Without this rebalance, that promotion is a no-op.

## Notes

- Memory-safe: `filtered` compacted in place (backing array reused via a `[:0]` cursor); `unfiltered` grows only by the promoted count — no second copy of the corpus. Order preserved; nil/empty safe.
- Reuses the existing `isReusableTierMock`. No interface change.
- Regression test `rebalance_reusable_test.go`. `go build`/`go vet`/`go test ./pkg/service/replay/` green.