### PR TITLE
fix(replay): close eleven tier-isolation and consumption defects

### DIFF
--- a/pkg/agent/proxy/diskmocks.go
+++ b/pkg/agent/proxy/diskmocks.go
@@ -226,6 +226,23 @@ func (d *DiskMocks) LoadWindow(start, end time.Time) ([]*models.Mock, error) {
 	}
 	lo := start.UnixNano()
 	hi := end.UnixNano()
+	// An inverted window selects nothing: the scan below runs from the first
+	// entry >= lo while entries are <= hi, so hi < lo yields an empty band and
+	// the test replays with no per-test mocks at all — a whole test's worth of
+	// hard misses, reported as if the recording were empty.
+	//
+	// It reaches here from a recorded pair whose response timestamp precedes
+	// its request (clock skew on the recording host, most often a container
+	// clock stepping). Normalising to the degenerate [lo, lo] keeps the mock
+	// whose request time anchors the window instead of dropping everything,
+	// and says so once rather than failing silently.
+	if hi < lo {
+		d.logger.Info("test window is inverted (end before start); clamping to the start instant "+
+			"so the window selects the anchoring mock rather than nothing — the recording's "+
+			"response timestamp precedes its request, usually a clock step on the recording host",
+			zap.Time("start", start), zap.Time("end", end))
+		hi = lo
+	}
 	i := sort.Search(len(d.entries), func(k int) bool { return d.entries[k].reqTsNano >= lo })
 	sel := make([]diskEntry, 0)
 	for ; i < len(d.entries) && d.entries[i].reqTsNano <= hi; i++ {

--- a/pkg/agent/proxy/mockmanager.go
+++ b/pkg/agent/proxy/mockmanager.go
@@ -112,6 +112,23 @@ type MockManager struct {
 	// ResetForReplaySession). Read under swapMu.RLock.
 	firstWindowStart time.Time
 
+	// testFiredThisSet is the TIER-ROUTING half of what firstWindowStart used
+	// to answer alone. They are separate now because they are seeded at
+	// different moments: SeedStartupCutoff sets the cutoff from the set's
+	// earliest RECORDED test before any test has run, while routing must keep
+	// reading "nothing has fired" until a real window actually arrives.
+	// Deriving routing from a non-zero cutoff would make the seed itself look
+	// like a fired test and send the set's bootstrap traffic to the per-test
+	// engine over a tree staging just emptied. Written under swapMu.
+	testFiredThisSet bool
+
+	// boundaryPending marks that ResetForReplaySession has run and the next
+	// set's mocks have not arrived yet. It is what lets the window bits be
+	// cleared by staging instead of by the reset, without a stray BaseTime
+	// call mid-set being able to deactivate a live test's window. Written
+	// under swapMu.
+	boundaryPending bool
+
 	// swapMu guards the {filtered, unfiltered, window} swap performed by
 	// SetMocksWithWindow. Writers Lock(); readers via GetFilteredMocksInWindow
 	// RLock() the snapshot read so they cannot observe a torn (newMocks,
@@ -316,16 +333,11 @@ func (m *MockManager) IsClosed() bool {
 //   - droppedOutOfWindow: per-test diagnostic counter that should
 //     reset at the test-set boundary so "dropped for this test-set"
 //     stays meaningful in metrics.
-//   - windowStart/windowEnd: the tier-routing window.
-//     Both describe the set currently being replayed, so both have to be
-//     back at "nothing has fired" before the next set is staged. Leaving
-//     them set is what made every test-set after the first route its
-//     bootstrap traffic to the per-test engine while staging had put those
-//     mocks in the startup tree.
-//   - firstWindowStart: the startup-init vs. stale-bleed cutoff, which is
-//     also per-set — each set must classify against its OWN first test.
-//     See the reset itself for why preserving it (as this used to) silently
-//     emptied the startup tier for every set but the earliest-recorded one.
+//     (The tier-routing window and the startup-init cutoff used to be cleared
+//     here too. They are now cleared by the next set's initial staging call, so
+//     that the window bits and the mock trees they describe change together
+//     rather than leaving a gap where the bits describe a set whose mocks have
+//     not been swapped in yet. See the note in the body.)
 //
 // What it preserves:
 //   - filtered / unfiltered / startup trees: SetMocksWithWindow swaps
@@ -358,63 +370,29 @@ func (m *MockManager) ResetForReplaySession() {
 	})
 	atomic.StoreUint64(&m.droppedOutOfWindow, 0)
 
-	// Everything that describes "where are we in the current test set" goes
-	// back to "nothing has fired yet". Both of these are per-set questions,
-	// and between them they are the whole (Active, FirstTestFired) pair the
-	// tier dispatcher routes on:
-	//
-	//   windowStart/windowEnd — the active-window half of tier routing.
-	//   Left set, the next set's isInitialStaging call stages every mock
-	//   into the startup tree while the dispatcher, still seeing the
-	//   previous set's window, routes that set's bootstrap traffic to the
-	//   per-test engine and misses all of it.
-	//
-	//   firstWindowStart — the startup-init vs. stale-bleed cutoff. It used
-	//   to be preserved here, justified as keeping "the same before-any-test
-	//   cutoff for every test-set" so a later set's leading mocks could not
-	//   be misread as startup-init. That rationale does not hold: the mock
-	//   pool is REPLACED per set (Agent.StoreMocks allocates fresh slices and
-	//   finalizeClientMocks does clientMocks.Store(0, storage)), so a set's
-	//   SetMocksWithWindow only ever sees its own mocks and there is no
-	//   previous-set tail to bleed. Within a set the value never moves (the
-	//   test cases arrive sorted by request timestamp — platform/yaml/testdb
-	//   db.go), so per-set and global classify the same mocks WITHIN a set;
-	//   they differ only across sets, which is the bug.
-	//
-	//   What preserving it actually did: the cutoff is a running MINIMUM
-	//   (start.Before(m.firstWindowStart)), so it stuck at whichever set
-	//   recorded earliest. Every other set's own bootstrap mocks sit AFTER
-	//   that cutoff, get classified as stale bleed, and are dropped from
-	//   every tier the moment that set's first test fires. Resetting makes
-	//   each set classify against its own first test, which is what "before
-	//   any test fired" was always supposed to mean.
-	//
-	//   Scope note: this repairs the CLASSIFICATION. It does not by itself
-	//   guarantee the startup band is POPULATED, because the agent reads
-	//   FirstTestWindowStart() before calling SetMocksWithWindow, so on a
-	//   set's first test the read is still zero and the disk LoadBefore that
-	//   fetches the band is skipped. Deriving the cutoff from the window
-	//   being applied is a separate agent-side fix, and it has to stay gated
-	//   on the proxy actually adopting that start — an unguarded derivation
-	//   collapses "req < firstWindowStart" into "req < afterTime" and
-	//   preserves every stale previous-test mock.
-	//
-	// Lock order is swapMu then windowMu, matching WindowSnapshot, so a
-	// WindowSnapshot reader sees either the whole previous set or the whole
-	// cleared state. That guarantee does NOT extend to the legacy
-	// sequential pair (IsTestWindowActive then HasFirstTestFired): those
-	// take different locks, so a caller straddling this reset can still
-	// observe the forbidden Active=true && FirstTestFired=false. Reordering
-	// the writes cannot fix that — the straddle spans both calls — which is
-	// why the pair-coherent readers (the v3 dispatcher's routeTransactional,
-	// TierIndex.orderForCurrentState) are required to use WindowSnapshot.
 	m.swapMu.Lock()
-	m.firstWindowStart = time.Time{}
-	m.windowMu.Lock()
-	m.windowStart = time.Time{}
-	m.windowEnd = time.Time{}
-	m.windowMu.Unlock()
+	m.boundaryPending = true
 	m.swapMu.Unlock()
+
+	// NOTE: the window bits and the startup-init cutoff are deliberately NOT
+	// cleared here. They are cleared by the next set's initial staging call
+	// instead — see SetMocksWithWindow's isInitialStaging branch.
+	//
+	// Clearing them here left the manager half torn down for the whole gap
+	// between this reset and that staging call: the bits already said "nothing
+	// has fired" while the trees still held the PREVIOUS set's mocks, so a
+	// query arriving in the gap was routed to the startup engine and answered
+	// out of the previous set's startup tier. That gap is real whenever the
+	// application survives the test-set boundary (--keep-app-alive, compose
+	// reuse). Clearing the trees here instead is not the answer either: that
+	// serves an empty pool to a parser racing the reset, and a hard miss
+	// against a live app is what crash-loops it.
+	//
+	// Deferring makes the two flip TOGETHER. Through the gap the manager is
+	// consistently the previous set — previous bits, previous trees — and
+	// staging then replaces both. The single caller (Proxy.Mock) always
+	// follows this reset with a BaseTime staging call, so the deferral cannot
+	// strand the bits.
 }
 
 // runIdleSweeper is the background loop that calls SweepIdleConnections
@@ -738,6 +716,7 @@ func (m *MockManager) SetMocksWithWindow(filtered, unfiltered []*models.Mock, st
 		if m.firstWindowStart.IsZero() || start.Before(m.firstWindowStart) {
 			m.firstWindowStart = start
 		}
+		m.testFiredThisSet = true
 	}
 	firstStart := m.firstWindowStart
 	// Wave 2: startup-init mocks (req < firstStart) are routed into a
@@ -764,6 +743,23 @@ func (m *MockManager) SetMocksWithWindow(filtered, unfiltered []*models.Mock, st
 	// test bleed and get dropped.
 	isInitialStaging := start.Equal(models.BaseTime)
 	if isInitialStaging {
+		// Staging is the set boundary as far as routing is concerned: this is
+		// where the previous set's window bits and startup-init cutoff go, so
+		// they are replaced in the same call that replaces the trees rather
+		// than in ResetForReplaySession (see the note there). Until this
+		// point the manager still describes the previous set, consistently.
+		// Only when a set boundary is actually pending. A BaseTime call that
+		// is NOT preceded by a reset is a mid-set stage, and deactivating a
+		// live test's window there would mis-route it to the startup engine.
+		if m.boundaryPending {
+			m.boundaryPending = false
+			m.testFiredThisSet = false
+			m.firstWindowStart = time.Time{}
+			m.windowMu.Lock()
+			m.windowStart = time.Time{}
+			m.windowEnd = time.Time{}
+			m.windowMu.Unlock()
+		}
 		// Wave-3 H3 fix: include BOTH filtered (per-test) and unfiltered
 		// (session + connection) mocks in the startup pool during initial
 		// staging. Rationale: during Runner/Replayer's pre-test staging
@@ -956,8 +952,56 @@ func (m *MockManager) SetMocksWithWindow(filtered, unfiltered []*models.Mock, st
 	// bootstrap traffic and polluted the strict session tier seen by
 	// tier-aware parsers.
 
-	m.SetFilteredMocks(filteredForTree)
-	m.SetUnFilteredMocks(unfilteredForTree)
+	// Publish ONE revision after all three tiers have landed.
+	//
+	// The three swaps happen in independent treesMu sections — startup above,
+	// then filtered, then unfiltered — while the by-kind readers each take
+	// treesMu on their own. Bumping after each swap meant the revision
+	// published midway was legitimately "current" for a torn state: a consumer
+	// that samples the revision, reads the three tiers, and caches its index
+	// under that revision could capture test N+1's per-test mocks alongside
+	// test N's session mocks and never invalidate it, because the revision it
+	// recorded really was the newest at the moment it looked. Every kind-aware
+	// parser follows that sample-read-install idiom.
+	//
+	// Suppressing the inner bumps and publishing once at the end closes the
+	// window: any revision a consumer can observe now corresponds to a state
+	// where all three tiers agree. Suppression is per-call, not a flag on the
+	// manager, so it cannot swallow a concurrent consumer's own bump.
+	m.setFilteredMocks(filteredForTree, false)
+	m.setUnFilteredMocks(unfilteredForTree, false)
+
+	touchedAll := map[models.Kind]struct{}{}
+	for _, mk := range filteredForTree {
+		if mk != nil {
+			touchedAll[mk.Kind] = struct{}{}
+		}
+	}
+	for _, mk := range unfilteredForTree {
+		if mk != nil {
+			touchedAll[mk.Kind] = struct{}{}
+		}
+	}
+	// The startup tree is swapped in this function without any bump of its own,
+	// so its kinds have to be published here or a startup-only kind never
+	// invalidates a cached index.
+	for _, mk := range startupInit {
+		if mk != nil {
+			touchedAll[mk.Kind] = struct{}{}
+		}
+	}
+	m.treesMu.RLock()
+	for k := range m.filteredByKind {
+		touchedAll[k] = struct{}{}
+	}
+	for k := range m.unfilteredByKind {
+		touchedAll[k] = struct{}{}
+	}
+	m.treesMu.RUnlock()
+	for k := range touchedAll {
+		m.bumpRevisionKind(k)
+	}
+	m.bumpRevisionAll()
 	// Rebuild the HitCount name→*Mock index so MarkMockAsUsed takes
 	// the O(1) fast path. Called after the tree swap so the index
 	// always points at the freshest mock pointers.
@@ -1253,7 +1297,7 @@ func (m *MockManager) GetSessionScopedMocks() ([]*models.Mock, error) {
 func (m *MockManager) HasFirstTestFired() bool {
 	m.swapMu.RLock()
 	defer m.swapMu.RUnlock()
-	return !m.firstWindowStart.IsZero()
+	return m.testFiredThisSet
 }
 
 // FirstTestWindowStart returns the earliest test window start this
@@ -1310,7 +1354,7 @@ func (m *MockManager) WindowSnapshot() models.WindowSnapshot {
 	defer m.windowMu.RUnlock()
 	return models.WindowSnapshot{
 		Active:         !m.windowStart.IsZero() && !m.windowEnd.IsZero(),
-		FirstTestFired: !m.firstWindowStart.IsZero(),
+		FirstTestFired: m.testFiredThisSet,
 	}
 }
 
@@ -1666,6 +1710,12 @@ func (m *MockManager) GetUnFilteredMocksByKind(kind models.Kind) ([]*models.Mock
 // ---------- setters (populate both legacy + per-kind) ----------
 
 func (m *MockManager) SetFilteredMocks(mocks []*models.Mock) {
+	m.setFilteredMocks(mocks, true)
+}
+
+// setFilteredMocks is the body; bump=false lets SetMocksWithWindow swap all
+// three tiers before publishing a single revision (see the note there).
+func (m *MockManager) setFilteredMocks(mocks []*models.Mock, bump bool) {
 	newFiltered := NewTreeDb(customComparator)
 	newFilteredByKind := make(map[models.Kind]*TreeDb)
 	newStateless := make(map[models.Kind]map[string][]*models.Mock)
@@ -1714,12 +1764,21 @@ func (m *MockManager) SetFilteredMocks(mocks []*models.Mock) {
 		pkg.UpdateSortCounterIfHigher(maxSortOrder)
 	}
 	m.treesMu.Lock()
+	// A kind that LEAVES the pool must be bumped too: `touched` is built from
+	// the incoming slice only, so a kind present before and absent now keeps
+	// its old revision — and a consumer caching by that revision never learns
+	// its mocks are gone and keeps serving them.
+	for k := range m.filteredByKind {
+		touched[k] = struct{}{}
+	}
 	m.filtered, m.filteredByKind, m.statelessFiltered = newFiltered, newFilteredByKind, newStateless
 	m.treesMu.Unlock()
-	for k := range touched {
-		m.bumpRevisionKind(k)
+	if bump {
+		for k := range touched {
+			m.bumpRevisionKind(k)
+		}
+		m.bumpRevisionAll()
 	}
-	m.bumpRevisionAll()
 	// DEBUG_TRACE: prove what landed in m.filtered after the swap +
 	// bump. Lists every PostgresV3 mock so we can correlate by mock name
 	// against the failing hashes the parser later misses. Gated behind
@@ -1739,6 +1798,11 @@ func (m *MockManager) SetFilteredMocks(mocks []*models.Mock) {
 }
 
 func (m *MockManager) SetUnFilteredMocks(mocks []*models.Mock) {
+	m.setUnFilteredMocks(mocks, true)
+}
+
+// setUnFilteredMocks is the body; see setFilteredMocks for why bump exists.
+func (m *MockManager) setUnFilteredMocks(mocks []*models.Mock, bump bool) {
 	newUnFiltered := NewTreeDb(customComparator)
 	newUnFilteredByKind := make(map[models.Kind]*TreeDb)
 	newStateless := make(map[models.Kind]map[string][]*models.Mock)
@@ -1774,12 +1838,19 @@ func (m *MockManager) SetUnFilteredMocks(mocks []*models.Mock) {
 		pkg.UpdateSortCounterIfHigher(maxSortOrder)
 	}
 	m.treesMu.Lock()
+	// Same as the filtered path: bump kinds leaving the pool, not just those
+	// arriving, or a consumer caches a stale index for a kind that emptied.
+	for k := range m.unfilteredByKind {
+		touched[k] = struct{}{}
+	}
 	m.unfiltered, m.unfilteredByKind, m.statelessUnfiltered = newUnFiltered, newUnFilteredByKind, newStateless
 	m.treesMu.Unlock()
-	for k := range touched {
-		m.bumpRevisionKind(k)
+	if bump {
+		for k := range touched {
+			m.bumpRevisionKind(k)
+		}
+		m.bumpRevisionAll()
 	}
-	m.bumpRevisionAll()
 }
 
 // ---------- point updates / deletes (keep per-kind in sync) ----------
@@ -1790,7 +1861,7 @@ func (m *MockManager) UpdateUnFilteredMock(old *models.Mock, new *models.Mock) b
 	globalTree := m.unfiltered
 	m.treesMu.RUnlock()
 	// Update legacy/global tree first
-	updatedGlobal := globalTree.update(old.TestModeInfo, new.TestModeInfo, new)
+	updatedGlobal := globalTree.update(old.TestModeInfo, new.TestModeInfo, new, *old)
 
 	oldK, newK := old.Kind, new.Kind
 	var updatedOldKind, updatedNewKind bool
@@ -1799,7 +1870,7 @@ func (m *MockManager) UpdateUnFilteredMock(old *models.Mock, new *models.Mock) b
 		// Same kind: update the per-kind tree under lock
 		_, unf := m.ensureKindTrees(newK)
 		m.treesMu.Lock()
-		updatedNewKind = unf.update(old.TestModeInfo, new.TestModeInfo, new)
+		updatedNewKind = unf.update(old.TestModeInfo, new.TestModeInfo, new, *old)
 
 		// Self-heal if global updated but per-kind missed.
 		//
@@ -1830,7 +1901,7 @@ func (m *MockManager) UpdateUnFilteredMock(old *models.Mock, new *models.Mock) b
 		_, newUnf := m.ensureKindTrees(newK)
 		m.treesMu.Lock()
 		updatedOldKind = oldUnf.delete(old.TestModeInfo)
-		updatedNewKind = newUnf.update(old.TestModeInfo, new.TestModeInfo, new)
+		updatedNewKind = newUnf.update(old.TestModeInfo, new.TestModeInfo, new, *old)
 		if !updatedNewKind {
 			newUnf.insert(new.TestModeInfo, new)
 			updatedNewKind = true
@@ -1886,13 +1957,15 @@ func (m *MockManager) DeleteFilteredMock(mock models.Mock) bool {
 	m.treesMu.RLock()
 	globalTree := m.filtered
 	m.treesMu.RUnlock()
-	deletedGlobal := globalTree.delete(mock.TestModeInfo)
+	// Identity-checked: the key is tier-local, so a mock taken from another
+	// tier addresses a DIFFERENT mock here. See TreeDb.sameMock.
+	deletedGlobal := globalTree.deleteMock(mock.TestModeInfo, mock)
 
 	// per-kind
 	k := mock.Kind
 	flt, _ := m.ensureKindTrees(k)
 	m.treesMu.Lock()
-	deletedKind := flt.delete(mock.TestModeInfo)
+	deletedKind := flt.deleteMock(mock.TestModeInfo, mock)
 	m.treesMu.Unlock()
 
 	if deletedGlobal {
@@ -1919,20 +1992,47 @@ func (m *MockManager) DeleteFilteredMock(mock models.Mock) bool {
 	if deletedGlobal {
 		m.bumpRevisionAll()
 	}
-	return deletedGlobal
+	if deletedGlobal {
+		return true
+	}
+
+	// Not in the per-test tier. Fall back to the startup tier before reporting
+	// failure, because the caller almost certainly matched this mock out of
+	// GetSessionMocks — which is startup UNION session — and a startup-tier
+	// mock has no other consume door: mongo v2 is the ONLY parser in the tree
+	// that calls DeleteStartupMock itself.
+	//
+	// This matters far more than it looks. Every other consume site treats a
+	// false here as "another goroutine won the race, retry against the shrunk
+	// pool" and loops: http/match.go's `for {}` re-fetches the pool and
+	// continues, and generic, grpcV2, http2, mongo v1, sqs and kafka all have
+	// the same shape. The pool does not shrink, so the retry re-picks the same
+	// mock and spins until the request context dies. Before the tier keys were
+	// disambiguated the blind delete always "succeeded" — evicting the WRONG
+	// mock — which is what accidentally kept those loops terminating.
+	//
+	// Returning true here keeps the caller contract ("consumed, stop looping")
+	// exactly as it was, while the mock that actually gets consumed is now the
+	// one the caller matched instead of whatever shared its key.
+	if m.DeleteStartupMock(mock) {
+		return true
+	}
+	return false
 }
 
 func (m *MockManager) DeleteUnFilteredMock(mock models.Mock) bool {
 	m.treesMu.RLock()
 	globalTree := m.unfiltered
 	m.treesMu.RUnlock()
-	deletedGlobal := globalTree.delete(mock.TestModeInfo)
+	// Identity-checked for the same reason as DeleteFilteredMock: the key is
+	// tier-local, so a mock from another tier addresses a different entry here.
+	deletedGlobal := globalTree.deleteMock(mock.TestModeInfo, mock)
 
 	// per-kind
 	k := mock.Kind
 	_, unf := m.ensureKindTrees(k)
 	m.treesMu.Lock()
-	deletedKind := unf.delete(mock.TestModeInfo)
+	deletedKind := unf.deleteMock(mock.TestModeInfo, mock)
 	m.treesMu.Unlock()
 
 	if deletedGlobal {
@@ -2017,12 +2117,68 @@ func (m *MockManager) DeleteStartupMock(mock models.Mock) bool {
 		if info, ok := key.(models.TestModeInfo); ok {
 			delete(tree.idIndex, info.ID)
 		}
+		// Record the consume. Every sibling door flags, and without it a
+		// startup consume is invisible to the run's consumed set — so
+		// upsertActualTestMockMapping, FailureInfo.MatchedCalls and the
+		// resend guard all miss it, and resetResendUnsafe will re-send a
+		// request that already burned a mock.
+		//
+		// Usage is Updated, NOT Deleted, and that distinction is load-bearing:
+		// filterOutDeleted prunes only on Deleted, and it is applied to the
+		// filtered slice the startup tier is REBUILT from. Flagging Deleted
+		// here would drop the boot mock permanently and break a driver
+		// reconnect that legitimately replays the bootstrap chain.
+		if err := m.flagMockAsUsed(models.MockState{
+			Name:             mk.Name,
+			Kind:             mk.Kind,
+			Usage:            models.Updated,
+			IsFiltered:       mk.TestModeInfo.IsFiltered,
+			SortOrder:        mk.TestModeInfo.SortOrder,
+			Type:             mk.Spec.Metadata["type"],
+			Lifetime:         mk.TestModeInfo.Lifetime,
+			ReqTimestampMock: models.FormatMockTimestamp(mk.Spec.ReqTimestampMock),
+			ResTimestampMock: models.FormatMockTimestamp(mk.Spec.ResTimestampMock),
+			ReqBodyNoise:     reqBodyNoiseOf(mk.Spec),
+		}); err != nil {
+			m.logger.Error("failed to flag startup mock as used", zap.Error(err))
+		}
 		// Bump the global revision so any cached snapshot held by a
 		// matcher consumer rebuilds on next access.
 		m.bumpRevisionAll()
 		return true
 	}
 	return false
+}
+
+// SeedStartupCutoff sets the startup-init cutoff from the set's earliest
+// RECORDED test, before any test of that set has run.
+//
+// The cutoff decides whether a mock was recorded before this set's tests began.
+// Derived from the first EXECUTED window it gets that wrong whenever the first
+// executed test is not the earliest recorded one — a --test-sets selection, an
+// ignored test, or the streaming deferral all do that. The cutoff then lands
+// late, and mocks belonging to a test that is NOT being run fall before it, get
+// classified as startup-init, and are served as bootstrap traffic.
+//
+// The manager cannot derive this itself: the mocks it is staged with include
+// the bootstrap ones, so their minimum timestamp cannot separate "recorded
+// before the tests began" from "recorded during the earliest test". The caller
+// supplies it — the replayer already loads test cases sorted by request
+// timestamp, so it is testCases[0]'s request time.
+//
+// Seeds only when nothing has been recorded for this set yet, and never marks a
+// test as fired: routing must still read "nothing has fired" until a real
+// window arrives. A later real window that turns out to be earlier still lowers
+// the cutoff through the running minimum in SetMocksWithWindow.
+func (m *MockManager) SeedStartupCutoff(start time.Time) {
+	if start.IsZero() || start.Equal(models.BaseTime) {
+		return
+	}
+	m.swapMu.Lock()
+	defer m.swapMu.Unlock()
+	if m.firstWindowStart.IsZero() || start.Before(m.firstWindowStart) {
+		m.firstWindowStart = start
+	}
 }
 
 // MarkMockAsUsed marks the given mock as used (consumed) without modifying

--- a/pkg/agent/proxy/mockmanager_wave2_test.go
+++ b/pkg/agent/proxy/mockmanager_wave2_test.go
@@ -1051,3 +1051,425 @@ func TestResetForReplaySession_SecondTestSetKeepsItsOwnBootstrapMocks(t *testing
 		t.Fatalf("set 2's in-window test mock is missing from the per-test tier: %v", perTest)
 	}
 }
+
+// The startup-init cutoff must follow the set's earliest RECORDED test, not
+// whichever test happens to fire first.
+//
+// firstWindowStart is a running minimum over the windows that actually fire, so
+// when the first fired test is not the earliest recorded — a --test-sets
+// selection, an ignored test, the streaming deferral — the cutoff lands late.
+// Mocks belonging to a test that is NOT being run then fall before it, are
+// classified as startup-init instead of dropped as previous-test bleed, and are
+// served as bootstrap traffic.
+//
+// SeedStartupCutoff closes that: the replayer already loads test cases sorted by
+// request timestamp, so it supplies testCases[0]'s time before any test runs.
+func TestSeedStartupCutoff_SkippedFirstTestDoesNotLeakAsBootstrap(t *testing.T) {
+	t1 := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	t2 := t1.Add(time.Hour)
+
+	build := func() (*MockManager, []*models.Mock) {
+		mm := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+		t.Cleanup(func() { mm.Close() })
+		return mm, []*models.Mock{
+			newMockForTest("boot", t1.Add(-time.Minute), models.LifetimePerTest),
+			newMockForTest("t1mock", t1.Add(time.Second), models.LifetimePerTest),
+			newMockForTest("t2mock", t2.Add(time.Second), models.LifetimePerTest),
+		}
+	}
+
+	// Without the seed the cutoff follows the fired window (t2), so t1's mock —
+	// belonging to a test that never runs — reads as bootstrap.
+	unseeded, all := build()
+	unseeded.SetMocksWithWindow(all, nil, models.BaseTime, time.Now())
+	unseeded.SetMocksWithWindow(all, nil, t2, t2.Add(10*time.Second))
+	before, err := unseeded.GetStartupMocks()
+	if err != nil {
+		t.Fatalf("GetStartupMocks: %v", err)
+	}
+	if !containsMockNamed(before, "t1mock") {
+		t.Skip("baseline no longer reproduces; the cutoff is derived differently now")
+	}
+
+	// With the seed it is classified against t1, so only genuine bootstrap
+	// traffic survives in the startup tier.
+	seeded, all := build()
+	seeded.SetMocksWithWindow(all, nil, models.BaseTime, time.Now())
+	seeded.SeedStartupCutoff(t1) // what the replayer supplies: testCases[0]
+	seeded.SetMocksWithWindow(all, nil, t2, t2.Add(10*time.Second))
+
+	after, err := seeded.GetStartupMocks()
+	if err != nil {
+		t.Fatalf("GetStartupMocks: %v", err)
+	}
+	if !containsMockNamed(after, "boot") {
+		t.Fatalf("the genuine bootstrap mock must stay in the startup tier, got %v", after)
+	}
+	if containsMockNamed(after, "t1mock") {
+		t.Fatal("a mock from a test that never ran is still classified as startup-init and " +
+			"will be served as bootstrap traffic")
+	}
+}
+
+// Seeding the cutoff must NOT make routing think a test has fired. If it did,
+// staging would look like a live test and the set's bootstrap traffic would be
+// routed to the per-test engine over a tree staging had just emptied — the
+// exact outage the per-test-set reset exists to prevent.
+func TestSeedStartupCutoff_DoesNotMarkATestAsFired(t *testing.T) {
+	mm := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+	defer mm.Close()
+
+	start := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	mm.SetMocksWithWindow(nil, nil, models.BaseTime, time.Now())
+	mm.SeedStartupCutoff(start)
+
+	if snap := mm.WindowSnapshot(); snap.Active || snap.FirstTestFired {
+		t.Fatalf("seeding the cutoff must leave routing at 'nothing has fired', got %+v", snap)
+	}
+	if mm.FirstTestWindowStart().IsZero() {
+		t.Fatal("the cutoff was not seeded")
+	}
+
+	// A real window still flips routing.
+	mm.SetMocksWithWindow(nil, nil, start, start.Add(10*time.Second))
+	if snap := mm.WindowSnapshot(); !snap.Active || !snap.FirstTestFired {
+		t.Fatalf("a real window must flip routing, got %+v", snap)
+	}
+}
+
+// A consume must always terminate. Every parser except mongo v2 treats a false
+// from DeleteFilteredMock as "another goroutine won the race, retry against the
+// shrunk pool" and loops — http/match.go's `for {}` re-fetches the pool and
+// continues, and generic, grpcV2, http2, mongo v1, sqs and kafka share the
+// shape. But those parsers match against GetSessionMocks, which is startup UNION
+// session, so they can pick a STARTUP-tier mock — and DeleteStartupMock has no
+// caller in OSS at all. If the per-test door simply refuses such a mock, the
+// pool never shrinks, the retry re-picks it, and the loop spins until the
+// request context dies.
+//
+// Before the tier keys were disambiguated this never surfaced, because the
+// blind delete always "succeeded" by evicting whatever shared the key. Fixing
+// that eviction without giving the mock a door would have converted a
+// wrong-mock bug into a livelock.
+func TestDeleteFilteredMock_ConsumesAStartupTierMockSoRetryLoopsTerminate(t *testing.T) {
+	mm, bootCopy := tierFixture(t)
+
+	if !mm.DeleteFilteredMock(bootCopy) {
+		t.Fatal("a startup-tier mock matched out of the startup-union pool was refused by every " +
+			"door; the caller's retry loop re-picks it forever and spins until its context dies")
+	}
+
+	// And it must be genuinely consumed, not merely reported as such.
+	startup, err := mm.GetStartupMocks()
+	if err != nil {
+		t.Fatalf("GetStartupMocks: %v", err)
+	}
+	if containsMockNamed(startup, "boot") {
+		t.Fatal("reported consumed but still present in the startup tier; the next match re-picks it")
+	}
+
+	// The per-test mock sharing its key is still untouched — the original defect.
+	perTest, err := mm.GetPerTestMocksInWindow()
+	if err != nil {
+		t.Fatalf("GetPerTestMocksInWindow: %v", err)
+	}
+	if !containsMockNamed(perTest, "live") {
+		t.Fatal("consuming the startup mock evicted the running test's own per-test mock")
+	}
+}
+
+// tierFixture stages a set the way the agent does — fresh copies with
+// SortOrder unset on every call, so each tier restamps its keys from 1 and the
+// first entry of every tree lands on (SortOrder:1, ID:0). Reusing pointers
+// across calls carries the first stamping forward and hides the collision
+// entirely, so a test that does that proves nothing.
+func tierFixture(t *testing.T) (*MockManager, models.Mock) {
+	t.Helper()
+	mm := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+	t.Cleanup(func() { mm.Close() })
+
+	start := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	boot := newMockForTest("boot", start.Add(-time.Minute), models.LifetimePerTest)
+	live := newMockForTest("live", start.Add(time.Second), models.LifetimePerTest)
+	sess := newMockForTest("sess", start.Add(2*time.Second), models.LifetimeSession)
+
+	fresh := func() ([]*models.Mock, []*models.Mock) {
+		a, b, c := *boot, *live, *sess
+		a.TestModeInfo = models.TestModeInfo{Lifetime: models.LifetimePerTest}
+		b.TestModeInfo = models.TestModeInfo{Lifetime: models.LifetimePerTest}
+		c.TestModeInfo = models.TestModeInfo{Lifetime: models.LifetimeSession}
+		return []*models.Mock{&a, &b}, []*models.Mock{&c}
+	}
+	f, u := fresh()
+	mm.SetMocksWithWindow(f, u, models.BaseTime, time.Now())
+	f, u = fresh()
+	mm.SetMocksWithWindow(f, u, start, start.Add(10*time.Second))
+
+	startup, err := mm.GetStartupMocks()
+	if err != nil || !containsMockNamed(startup, "boot") {
+		t.Fatalf("precondition: boot must be in the startup tier, got %v (err %v)", startup, err)
+	}
+	var bootCopy models.Mock
+	for _, m := range startup {
+		if m != nil && m.Name == "boot" {
+			bootCopy = *m
+		}
+	}
+	return mm, bootCopy
+}
+
+// Consuming a startup-tier mock through the FILTERED door must not evict the
+// per-test entry that shares its key. mongo v2 reaches this: it tries
+// DeleteFilteredMock before falling back to DeleteStartupMock.
+func TestDeleteFilteredMock_LeavesAnotherTiersMockAtTheSameKeyAlone(t *testing.T) {
+	mm, bootCopy := tierFixture(t)
+
+	// It reports success — it consumes the mock from the tier it actually lives
+	// in, which is what keeps the caller's retry loop terminating (see
+	// TestDeleteFilteredMock_ConsumesAStartupTierMockSoRetryLoopsTerminate).
+	// What must NOT happen is the per-test entry sharing its key being evicted.
+	mm.DeleteFilteredMock(bootCopy)
+	perTest, err := mm.GetPerTestMocksInWindow()
+	if err != nil {
+		t.Fatalf("GetPerTestMocksInWindow: %v", err)
+	}
+	if !containsMockNamed(perTest, "live") {
+		t.Fatal("deleting the startup mock evicted the running test's own per-test mock")
+	}
+}
+
+// The same for the UNFILTERED door, and this is the one that matters most:
+// HTTP and MySQL match against the startup-union pool and, when
+// DeleteFilteredMock declines, fall through to UpdateUnFilteredMock. Its ID
+// index is keyed on ID alone — and ID is stamped from zero per tier — so an
+// unguarded fallback rewrites whatever sits at that ID in the session tree.
+// The victim there is reused by every test in the set, which is strictly worse
+// than the per-test eviction it replaces.
+func TestUpdateUnFilteredMock_DoesNotRewriteAnotherTiersMockViaTheIDIndex(t *testing.T) {
+	mm, bootCopy := tierFixture(t)
+
+	before, err := mm.GetSessionScopedMocks()
+	if err != nil || !containsMockNamed(before, "sess") {
+		t.Fatalf("precondition: the session mock must be present, got %v (err %v)", before, err)
+	}
+
+	updated := bootCopy
+	updated.TestModeInfo.SortOrder = 9999
+	mm.UpdateUnFilteredMock(&bootCopy, &updated)
+
+	after, err := mm.GetSessionScopedMocks()
+	if err != nil {
+		t.Fatalf("GetSessionScopedMocks: %v", err)
+	}
+	if !containsMockNamed(after, "sess") {
+		t.Fatal("updating with a startup-tier mock destroyed the session mock at the same ID; " +
+			"it is reused by every test in the set")
+	}
+	if containsMockNamed(after, "boot") {
+		t.Fatal("a startup-tier mock was inserted into the session tier, where it will be " +
+			"served for the rest of the run")
+	}
+}
+
+// The guard must not cost a legitimate consume. There was no positive-case test
+// for DeleteFilteredMock anywhere in this package before.
+func TestDeleteFilteredMock_StillConsumesItsOwnTiersMock(t *testing.T) {
+	mm, _ := tierFixture(t)
+
+	perTest, err := mm.GetPerTestMocksInWindow()
+	if err != nil || !containsMockNamed(perTest, "live") {
+		t.Fatalf("precondition: live must be in the per-test tier, got %v (err %v)", perTest, err)
+	}
+	var liveCopy models.Mock
+	for _, m := range perTest {
+		if m != nil && m.Name == "live" {
+			liveCopy = *m
+		}
+	}
+
+	if !mm.DeleteFilteredMock(liveCopy) {
+		t.Fatal("a per-test mock consumed through its own door was refused; the identity guard " +
+			"must not turn a legitimate consume into a no-op, or the mock is served twice")
+	}
+	after, err := mm.GetPerTestMocksInWindow()
+	if err != nil {
+		t.Fatalf("GetPerTestMocksInWindow: %v", err)
+	}
+	if containsMockNamed(after, "live") {
+		t.Fatal("DeleteFilteredMock reported success but the mock is still in the tier")
+	}
+}
+
+// The window bits and the mock trees they describe must change TOGETHER.
+//
+// ResetForReplaySession runs at the test-set boundary, but the next set's mocks
+// do not arrive until its staging call. If the reset cleared the bits, then for
+// the whole gap between the two the manager said "nothing has fired" while the
+// trees still held the PREVIOUS set's mocks — so a query arriving in that gap
+// was routed to the startup engine and answered out of the previous set's
+// startup tier. Reachable whenever the app survives the boundary
+// (--keep-app-alive, compose reuse).
+//
+// Clearing the trees at the reset instead would serve an empty pool to a parser
+// racing it, and a hard miss against a live app is what crash-loops it. So the
+// bits are deferred to staging, which is where the trees are replaced anyway.
+func TestResetForReplaySession_WindowBitsAndTreesChangeTogether(t *testing.T) {
+	mm := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+	defer mm.Close()
+
+	s1 := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	boot := newMockForTest("s1boot", s1.Add(-time.Minute), models.LifetimePerTest)
+	test := newMockForTest("s1test", s1.Add(time.Second), models.LifetimePerTest)
+	mm.SetMocksWithWindow([]*models.Mock{boot, test}, nil, models.BaseTime, time.Now())
+	mm.SetMocksWithWindow([]*models.Mock{boot, test}, nil, s1, s1.Add(10*time.Second))
+
+	mm.ResetForReplaySession()
+
+	startup, err := mm.GetStartupMocks()
+	if err != nil {
+		t.Fatalf("GetStartupMocks: %v", err)
+	}
+	if containsMockNamed(startup, "s1boot") && !mm.WindowSnapshot().FirstTestFired {
+		t.Fatal("half torn down: the startup tier still holds the previous set's mocks while " +
+			"the window bits already say nothing has fired, so a query in the gap is routed to " +
+			"the startup engine and answered from the previous set")
+	}
+
+	mm.SetMocksWithWindow(nil, nil, models.BaseTime, time.Now())
+	if snap := mm.WindowSnapshot(); snap.Active || snap.FirstTestFired {
+		t.Fatalf("staging must put routing back to 'nothing has fired', got %+v", snap)
+	}
+}
+
+// A startup consume must be recorded, and must NOT be recorded as Deleted.
+//
+// Unrecorded, it is invisible to the run's consumed set, so the resend guard
+// re-sends a request that already burned a mock — and because startupInit is
+// derived from the same filtered slice, the burned mock is re-staged by the
+// next SetMocksWithWindow and served again.
+//
+// Recorded as Deleted it is worse: filterOutDeleted prunes on Deleted and is
+// applied to the slice the startup tier is rebuilt from, so the boot mock would
+// disappear permanently and a driver reconnect that legitimately replays the
+// bootstrap chain would miss.
+func TestDeleteStartupMock_RecordsTheConsumeWithoutPruningTheBootMock(t *testing.T) {
+	mm, bootCopy := tierFixture(t)
+
+	if !mm.DeleteStartupMock(bootCopy) {
+		t.Fatal("precondition: the startup mock must be consumable")
+	}
+
+	consumed := mm.GetConsumedMocks()
+	var got *models.MockState
+	for i := range consumed {
+		if consumed[i].Name == "boot" {
+			got = &consumed[i]
+		}
+	}
+	if got == nil {
+		t.Fatal("the startup consume was not recorded; the resend guard cannot see it and the " +
+			"mock is re-staged by the next SetMocksWithWindow")
+	}
+	if got.Usage == models.Deleted {
+		t.Fatal("recorded as Deleted: filterOutDeleted prunes on that, and it is applied to the " +
+			"slice the startup tier is rebuilt from, so the boot mock is lost for the whole run")
+	}
+}
+
+// A revision must never be observable for a torn state.
+//
+// SetMocksWithWindow swaps startup, filtered and unfiltered in three
+// independent treesMu sections, and the by-kind readers each take treesMu on
+// their own. When each swap bumped the revision, the value published midway was
+// legitimately "current" for a half-applied state — so a parser following the
+// usual sample-revision / read-tiers / cache-under-that-revision idiom could
+// capture test N+1's per-test mocks beside test N's session mocks and never
+// invalidate, because the revision it recorded really was the newest.
+func TestSetMocksWithWindow_PublishesOneRevisionAfterAllTiersLand(t *testing.T) {
+	mm := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+	defer mm.Close()
+
+	start := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	perTest := newMockForTest("pt", start.Add(time.Second), models.LifetimePerTest)
+	sess := newMockForTest("ss", start.Add(2*time.Second), models.LifetimeSession)
+
+	before := mm.Revision()
+	mm.SetMocksWithWindow([]*models.Mock{perTest}, []*models.Mock{sess}, start, start.Add(10*time.Second))
+	after := mm.Revision()
+
+	if after == before {
+		t.Fatal("the swap published no revision at all; cached indexes never invalidate")
+	}
+	// Exactly one publication for the whole swap. More than one means there is
+	// an intermediate value a consumer can sample and cache a torn read under.
+	if got := after - before; got != 1 {
+		t.Fatalf("the swap published %d revisions; a consumer can sample an intermediate one "+
+			"and cache an index built from a half-applied state", got)
+	}
+}
+
+// A kind that LEAVES the pool has to bump too. `touched` is built from the
+// incoming slice, so without also walking the map being replaced, a kind that
+// was present and is now absent keeps its old revision — and a consumer caching
+// by that revision never learns its mocks are gone and keeps serving them.
+func TestSetMocks_BumpsAKindThatLeavesThePool(t *testing.T) {
+	mm := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+	defer mm.Close()
+
+	now := time.Now()
+	http := newMockForTest("h1", now, models.LifetimePerTest)
+	http.Kind = models.HTTP
+	mm.SetFilteredMocks([]*models.Mock{http})
+	revWithHTTP := mm.RevisionByKind(models.HTTP)
+
+	// Replace the pool with a different kind entirely: HTTP has left.
+	pg := newMockForTest("p1", now, models.LifetimePerTest)
+	pg.Kind = models.PostgresV3
+	mm.SetFilteredMocks([]*models.Mock{pg})
+
+	if mm.RevisionByKind(models.HTTP) == revWithHTTP {
+		t.Fatal("HTTP left the pool but its revision is frozen; a consumer caching under it " +
+			"keeps serving mocks that are no longer there")
+	}
+}
+
+// The startup fallback in DeleteFilteredMock must not destroy a REUSABLE mock.
+//
+// During BaseTime staging the startup tree also holds the session mocks, so the
+// fallback can reach one. Consuming its startup-tier view is fine — that view
+// exists to make bootstrap traffic matchable — but the session tier is the
+// durable home and must still serve it, or a handshake/auth recording every
+// later test depends on disappears on its first use.
+func TestDeleteFilteredMock_StartupFallbackLeavesTheSessionTierIntact(t *testing.T) {
+	mm := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+	defer mm.Close()
+
+	sess := newMockForTest("sess", time.Now(), models.LifetimeSession)
+	mm.SetMocksWithWindow(nil, []*models.Mock{sess}, models.BaseTime, time.Now())
+
+	startup, err := mm.GetStartupMocks()
+	if err != nil {
+		t.Fatalf("GetStartupMocks: %v", err)
+	}
+	var copyOf models.Mock
+	for _, m := range startup {
+		if m != nil && m.Name == "sess" {
+			copyOf = *m
+		}
+	}
+	if copyOf.Name == "" {
+		t.Skip("session mocks are no longer staged into the startup tree; the fallback " +
+			"cannot reach one and this test has nothing to protect")
+	}
+
+	mm.DeleteFilteredMock(copyOf)
+
+	session, err := mm.GetSessionScopedMocks()
+	if err != nil {
+		t.Fatalf("GetSessionScopedMocks: %v", err)
+	}
+	if !containsMockNamed(session, "sess") {
+		t.Fatal("the startup fallback consumed a session mock out of its durable tier; every " +
+			"later test that needs that handshake now misses")
+	}
+}

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -3316,6 +3316,19 @@ func (p *Proxy) FirstTestWindowStart() time.Time {
 	return time.Time{}
 }
 
+// SeedStartupCutoff seeds the underlying MockManager's startup-init cutoff from
+// the earliest RECORDED test of the set being staged. Satisfies the agent's
+// optional StartupCutoffSeeder extension interface.
+//
+// Without it the cutoff follows whichever test fires FIRST, so a --test-sets
+// selection, an ignored test or the streaming deferral leaves it late and mocks
+// from a test that never runs are served as bootstrap traffic.
+func (p *Proxy) SeedStartupCutoff(start time.Time) {
+	if m := p.getMockManager(); m != nil {
+		m.SeedStartupCutoff(start)
+	}
+}
+
 // GetConsumedMocks returns the consumed filtered mocks.
 func (p *Proxy) GetConsumedMocks(_ context.Context) ([]models.MockState, error) {
 	m := p.getMockManager()

--- a/pkg/agent/proxy/scoped_mockdb.go
+++ b/pkg/agent/proxy/scoped_mockdb.go
@@ -31,9 +31,17 @@ import (
 // Scope of the isolation: this filters VISIBILITY (which per-test mocks a call
 // can see), over the one shared pool. Per-test mocks are per-test-named in
 // mappings.yaml, so worker allowlists are disjoint in practice and consumption
-// (DeleteFilteredMock) does not collide. Session/startup/connection mocks are
-// shared and pass through unfiltered — a worker still sees shared auth/handshake
-// recordings. It assumes the agent and the workers share a PID namespace, which
+// (DeleteFilteredMock) does not collide.
+//
+// The STARTUP tier is filtered too, and that is not obvious: it sounds like a
+// shared bootstrap tier, but SetMocksWithWindow puts the whole per-test slice
+// into it during BaseTime staging — and in `keploy mock replay`, the one mode
+// where worker scoping exists, the pool is staged once at BaseTime and never
+// re-partitioned, so the startup tier IS the whole pool. Leaving it unfiltered
+// let a worker read, and DELETE, another worker's mocks. The file used to say
+// startup passed through unfiltered while also filtering GetSessionMocks, which
+// is defined as startup ∪ session — so the same mock was filtered through one
+// accessor and leaked through the other. It assumes the agent and the workers share a PID namespace, which
 // is the case for the normal `keploy mock <cmd>` wrap.
 
 // scopedMockDb wraps the process-wide MockMemDb with a per-worker allowlist,
@@ -98,6 +106,67 @@ func (s *scopedMockDb) GetUnFilteredMocks() ([]*models.Mock, error) {
 
 func (s *scopedMockDb) GetSessionScopedMocks() ([]*models.Mock, error) {
 	return s.keep(s.MockMemDb.GetSessionScopedMocks())
+}
+
+// The wrapper embeds the integrations.MockMemDb INTERFACE, so only that
+// interface's method set is promoted. Everything a parser reaches for by type
+// assertion — the revision counters and the by-kind readers — lives on
+// *MockManager and is silently erased by the wrap, turning every kind-aware
+// parser into its legacy branch for scoped workers only. Redis says so in its
+// own fallback ("there is no legacy startup accessor"), and in `keploy mock
+// replay` — the only mode where scoping exists — the startup tier is the whole
+// pool, so that branch reads nothing.
+//
+// Forward them explicitly. The by-kind readers go through keep() for the same
+// reason the plain ones do; the revision counters carry no mock data and pass
+// straight through.
+
+func (s *scopedMockDb) Revision() uint64 {
+	if r, ok := s.MockMemDb.(interface{ Revision() uint64 }); ok {
+		return r.Revision()
+	}
+	return 0
+}
+
+func (s *scopedMockDb) RevisionByKind(kind models.Kind) uint64 {
+	if r, ok := s.MockMemDb.(interface {
+		RevisionByKind(models.Kind) uint64
+	}); ok {
+		return r.RevisionByKind(kind)
+	}
+	return 0
+}
+
+func (s *scopedMockDb) GetFilteredMocksByKind(kind models.Kind) ([]*models.Mock, error) {
+	if bk, ok := s.MockMemDb.(interface {
+		GetFilteredMocksByKind(models.Kind) ([]*models.Mock, error)
+	}); ok {
+		return s.keep(bk.GetFilteredMocksByKind(kind))
+	}
+	return s.keep(s.MockMemDb.GetFilteredMocks())
+}
+
+func (s *scopedMockDb) GetUnFilteredMocksByKind(kind models.Kind) ([]*models.Mock, error) {
+	if bk, ok := s.MockMemDb.(interface {
+		GetUnFilteredMocksByKind(models.Kind) ([]*models.Mock, error)
+	}); ok {
+		return s.keep(bk.GetUnFilteredMocksByKind(kind))
+	}
+	return s.keep(s.MockMemDb.GetUnFilteredMocks())
+}
+
+func (s *scopedMockDb) GetStartupMocks() ([]*models.Mock, error) {
+	return s.keep(s.MockMemDb.GetStartupMocks())
+}
+
+func (s *scopedMockDb) GetStartupMocksByKind(kind models.Kind) ([]*models.Mock, error) {
+	type byKind interface {
+		GetStartupMocksByKind(models.Kind) ([]*models.Mock, error)
+	}
+	if bk, ok := s.MockMemDb.(byKind); ok {
+		return s.keep(bk.GetStartupMocksByKind(kind))
+	}
+	return s.keep(s.MockMemDb.GetStartupMocks())
 }
 
 // SetWorkerScope registers (or replaces) the per-test mock allowlist for a

--- a/pkg/agent/proxy/scoped_mockdb_test.go
+++ b/pkg/agent/proxy/scoped_mockdb_test.go
@@ -4,6 +4,9 @@ import (
 	"os"
 	"runtime"
 	"testing"
+	"time"
+
+	"go.uber.org/zap"
 
 	"github.com/stretchr/testify/require"
 	"go.keploy.io/server/v3/pkg/agent/proxy/integrations"
@@ -119,4 +122,65 @@ func TestSetWorkerScopeEmptyClears(t *testing.T) {
 	_, present := p.workerScope[42]
 	p.workerScopeMu.RUnlock()
 	require.False(t, present, "empty allowlist clears the worker's scope")
+}
+
+// The wrapper embeds the MockMemDb INTERFACE, so anything a parser reaches for
+// by type assertion but that is not in that interface is silently erased by the
+// wrap. Every kind-aware parser then falls to a legacy branch — and in
+// `keploy mock replay`, the only mode where worker scoping exists, the startup
+// tier is the whole pool, so that branch reads nothing.
+func TestScopedMockDb_DoesNotEraseTheManagersCapabilities(t *testing.T) {
+	mgr := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+	defer mgr.Close()
+
+	type revSrc interface{ Revision() uint64 }
+	type revKind interface{ RevisionByKind(models.Kind) uint64 }
+	type kindAware interface {
+		GetFilteredMocksByKind(models.Kind) ([]*models.Mock, error)
+		GetUnFilteredMocksByKind(models.Kind) ([]*models.Mock, error)
+	}
+
+	var scoped interface{} = &scopedMockDb{MockMemDb: mgr}
+	if _, ok := scoped.(revSrc); !ok {
+		t.Error("Revision erased by the wrap: consumers fall back to rebuilding on every call")
+	}
+	if _, ok := scoped.(revKind); !ok {
+		t.Error("RevisionByKind erased by the wrap")
+	}
+	if _, ok := scoped.(kindAware); !ok {
+		t.Error("the by-kind readers are erased by the wrap: kind-aware parsers take their " +
+			"legacy branch, which cannot read the startup tier")
+	}
+}
+
+// The startup tier is filtered like every other read tier. It sounds shared,
+// but staging puts the whole per-test slice into it, and in `keploy mock replay`
+// it is the entire pool — so leaving it unfiltered let one worker read, and
+// consume, another worker's mocks.
+func TestScopedMockDb_StartupTierIsScopedToTheWorker(t *testing.T) {
+	mgr := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+	defer mgr.Close()
+
+	a := newMockForTest("mock-A", time.Now().Add(-time.Hour), models.LifetimePerTest)
+	b := newMockForTest("mock-B", time.Now().Add(-time.Hour), models.LifetimePerTest)
+	mgr.SetMocksWithWindow([]*models.Mock{a, b}, nil, models.BaseTime, time.Now())
+
+	universe := map[string]struct{}{"mock-A": {}, "mock-B": {}}
+	workerA := &scopedMockDb{
+		MockMemDb: mgr,
+		allow:     map[string]struct{}{"mock-A": {}},
+		universe:  universe,
+	}
+
+	startup, err := workerA.GetStartupMocks()
+	if err != nil {
+		t.Fatalf("GetStartupMocks: %v", err)
+	}
+	if containsMockNamed(startup, "mock-B") {
+		t.Fatal("worker A can see worker B's mock through the startup tier; it can also " +
+			"consume it, deleting another worker's recording")
+	}
+	if !containsMockNamed(startup, "mock-A") {
+		t.Fatal("worker A cannot see its own mock")
+	}
 }

--- a/pkg/agent/proxy/treedb.go
+++ b/pkg/agent/proxy/treedb.go
@@ -50,6 +50,42 @@ func (db *TreeDb) insert(key interface{}, obj interface{}) {
 	db.mu.Unlock()
 }
 
+// sameMock reports whether the entry stored in a tree is the mock the caller
+// means.
+//
+// Every tree is keyed by models.TestModeInfo, and that key is TIER-LOCAL:
+// SortOrder and ID are stamped from zero as each tier builds its own tree, on
+// the fresh copies the agent supplies per call, and customComparator orders on
+// those two fields alone. So (SortOrder:1, ID:0) addresses "the first entry of
+// whichever tree you asked", not one particular mock — and a mock taken from
+// one tier can address a DIFFERENT mock in another. Callers do exactly that:
+// mongo v2 tries the filtered door before the startup one, and HTTP and MySQL
+// match against the startup-union pool and then consume through the filtered
+// and unfiltered doors.
+//
+// Identity is Name plus Kind plus the recorded request timestamp rather than
+// Name alone: names are not enforced unique by the manager, and a name-only
+// check silently reverts to the collision when two mocks share one. When the
+// caller carries no identity at all (an unnamed, kind-less, timestamp-less
+// mock) the check abstains, preserving the historical delete-by-key behaviour
+// rather than refusing a delete the caller may depend on.
+func sameMock(stored interface{}, want models.Mock) bool {
+	if want.Name == "" && want.Kind == "" && want.Spec.ReqTimestampMock.IsZero() {
+		return true // nothing to compare against; abstain
+	}
+	mk, ok := stored.(*models.Mock)
+	if !ok || mk == nil {
+		return true // not a mock value; leave the old behaviour alone
+	}
+	if mk.Name != want.Name {
+		return false
+	}
+	if mk.Kind != want.Kind {
+		return false
+	}
+	return mk.Spec.ReqTimestampMock.Equal(want.Spec.ReqTimestampMock)
+}
+
 func (db *TreeDb) delete(key interface{}) bool {
 	db.mu.Lock()
 	defer db.mu.Unlock()
@@ -65,7 +101,26 @@ func (db *TreeDb) delete(key interface{}) bool {
 	return true
 }
 
-func (db *TreeDb) update(oldKey interface{}, newKey interface{}, newObj interface{}) bool {
+// deleteMock removes the entry at key only when it is the mock the caller
+// means. See sameMock for why the key alone is not enough.
+func (db *TreeDb) deleteMock(key interface{}, want models.Mock) bool {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	v, found := db.rbt.Get(key)
+	if !found {
+		return false
+	}
+	if !sameMock(v, want) {
+		return false
+	}
+	db.rbt.Remove(key)
+	if info, ok := key.(models.TestModeInfo); ok {
+		delete(db.idIndex, info.ID)
+	}
+	return true
+}
+
+func (db *TreeDb) update(oldKey interface{}, newKey interface{}, newObj interface{}, want models.Mock) bool {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
@@ -73,7 +128,13 @@ func (db *TreeDb) update(oldKey interface{}, newKey interface{}, newObj interfac
 	newInfo, okNew := newKey.(models.TestModeInfo)
 
 	// First try exact match
-	_, found := db.rbt.Get(oldKey)
+	cur, found := db.rbt.Get(oldKey)
+	if found && !sameMock(cur, want) {
+		// The key resolves, but to a different tier's mock. Fall through to
+		// the ID index rather than rewriting it; that path is guarded too, so
+		// a genuine cross-tier call ends up a no-op instead of a corruption.
+		found = false
+	}
 	if found {
 		db.rbt.Remove(oldKey)
 		db.rbt.Put(newKey, newObj)
@@ -94,6 +155,22 @@ func (db *TreeDb) update(oldKey interface{}, newKey interface{}, newObj interfac
 
 	currentKey, exists := db.idIndex[oldInfo.ID]
 	if !exists {
+		return false
+	}
+
+	// The ID index is keyed on ID ALONE, and ID is stamped from zero per tier,
+	// so idIndex[0] exists in every tree. Without an identity check this
+	// fallback fires on any exact-match miss and rewrites whatever sits at that
+	// ID in THIS tree — which for a mock that belongs to another tier is a
+	// session mock reused by every test in the set, replaced by a foreign mock
+	// at a fresh key where it is then served for the rest of the run. That is
+	// how an exact-match miss turns into silent cross-tier corruption.
+	// Refuse unless the entry the index points at is demonstrably the caller's
+	// mock. A missing entry means a dangling index, and falling through would
+	// Remove a no-op and then blindly INSERT the caller's mock into this tree —
+	// injecting a foreign tier's mock rather than merely rewriting one.
+	cur, curFound := db.rbt.Get(currentKey)
+	if !curFound || !sameMock(cur, want) {
 		return false
 	}
 

--- a/pkg/agent/service.go
+++ b/pkg/agent/service.go
@@ -110,6 +110,19 @@ type PcapStreamer interface {
 //	} else {
 //	    _ = p.SetMocks(ctx, f, u)
 //	}
+//
+// StartupCutoffSeeder is the optional extension implemented by proxies whose
+// mock manager can be told the earliest RECORDED test start of the set being
+// staged, before any test of that set has run.
+//
+// Optional in the same style as WindowedProxy: the agent type-asserts for it and
+// simply does not seed when the assertion fails, so no existing proxy breaks and
+// third-party proxies keep compiling. Not seeding leaves the cutoff derived from
+// the fired windows, which is the pre-existing behaviour.
+type StartupCutoffSeeder interface {
+	SeedStartupCutoff(start time.Time)
+}
+
 type WindowedProxy interface {
 	// SetMocksWithWindow atomically replaces mocks AND publishes the active
 	// outer-test [req,res] window.

--- a/pkg/models/agent.go
+++ b/pkg/models/agent.go
@@ -86,11 +86,21 @@ type MockStreamHeader struct {
 }
 
 type MockFilterParams struct {
-	AfterTime          time.Time            `json:"afterTime,omitempty"`
-	BeforeTime         time.Time            `json:"beforeTime,omitempty"`
-	MockMapping        []string             `json:"mockMapping,omitempty"`
-	UseMappingBased    bool                 `json:"useMappingBased"`
-	TotalConsumedMocks map[string]MockState `json:"totalConsumedMocks,omitempty"`
+	AfterTime time.Time `json:"afterTime,omitempty"`
+	// FirstRecordedTestStart is the request time of the EARLIEST RECORDED test
+	// in the set being staged, which the replayer knows because it loads test
+	// cases sorted by request timestamp. The agent seeds the manager's
+	// startup-init cutoff from it so that cutoff follows the set's recorded
+	// shape rather than whichever test happens to fire first — a --test-sets
+	// selection, an ignored test or the streaming deferral otherwise leave it
+	// late, and mocks from a test that never runs get served as bootstrap.
+	// Zero means "not supplied"; the cutoff then falls back to the fired
+	// windows, which is the pre-existing behaviour.
+	FirstRecordedTestStart time.Time            `json:"firstRecordedTestStart,omitempty"`
+	BeforeTime             time.Time            `json:"beforeTime,omitempty"`
+	MockMapping            []string             `json:"mockMapping,omitempty"`
+	UseMappingBased        bool                 `json:"useMappingBased"`
+	TotalConsumedMocks     map[string]MockState `json:"totalConsumedMocks,omitempty"`
 	// StrictMockWindow controls whether out-of-window non-config mocks are
 	// dropped rather than being promoted into the cross-test config pool.
 	// Default TRUE (see config.Test default) — out-of-window per-test

--- a/pkg/platform/yaml/mockdb/db.go
+++ b/pkg/platform/yaml/mockdb/db.go
@@ -1056,7 +1056,15 @@ func (ys *MockYaml) insertMockGob(ctx context.Context, mock *models.Mock, mockPa
 	// cost is bounded by the mock's own size and is acceptable vs.
 	// the alternative (encoding to bytes synchronously on every
 	// InsertMock, which would defeat the whole async-writer win).
-	job := gobWriteJob{mock: mock.DeepCopy(), testSetPath: mockPath, filename: mockFileName}
+	// Strip the runtime-only lifetime fields before they reach the encoder —
+	// gob ignores the json:"-" tags that keep them out of every other format.
+	// The reader clears them too (so existing files are repaired), but not
+	// writing them keeps the on-disk shape honest about what it means.
+	gobMock := mock.DeepCopy()
+	var zeroLifetime models.Lifetime
+	gobMock.TestModeInfo.Lifetime = zeroLifetime
+	gobMock.TestModeInfo.LifetimeDerived = false
+	job := gobWriteJob{mock: gobMock, testSetPath: mockPath, filename: mockFileName}
 	select {
 	case ys.gobQueue <- job:
 		ys.gobLifecycleMu.Unlock()
@@ -1356,6 +1364,24 @@ func readGobMocks(path string) ([]*models.Mock, error) {
 			}
 			return out, fmt.Errorf("decode gob mock: %w", err)
 		}
+		// Lifetime and LifetimeDerived are RUNTIME-ONLY (models.Mock tags them
+		// json:"-" bson:"-" and says persisting them would create a second
+		// source of truth). encoding/gob ignores struct tags, so a gob file
+		// carries whatever the recorder stamped — and DeriveLifetime then
+		// short-circuits on the reloaded flag instead of re-deriving.
+		//
+		// The effect is that the SAME recording replays into a different tier
+		// depending on the storage format: gob keeps the recorder's per-test
+		// tag, while yaml drops it and the lax kind-fallback promotes the mock
+		// to session. A call two tests depend on is then consumed by the first
+		// and missing for the second — a CPU-optimisation knob silently
+		// changing replay semantics.
+		//
+		// Clearing on READ (not just on write) also repairs the recordings
+		// already on disk.
+		var zeroLifetime models.Lifetime
+		m.TestModeInfo.Lifetime = zeroLifetime
+		m.TestModeInfo.LifetimeDerived = false
 		out = append(out, &m)
 	}
 }

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -969,7 +969,15 @@ func (a *Agent) loadPerTestMocks(resident []*models.Mock, disk *proxyPkg.DiskMoc
 	case params.UseMappingBased && len(params.MockMapping) > 0:
 		mode = "mapping"
 		loaded, err = disk.LoadByNames(params.MockMapping)
-	case pkg.IsStrictMockWindow(a.config != nil && a.config.Test.StrictMockWindow) && !params.AfterTime.IsZero() && !params.BeforeTime.IsZero():
+	// Gate on the CALLER's flag, not the agent's own config. The two are
+	// independent: params.StrictMockWindow is what the replayer resolved for
+	// this run and is what :1047 below already uses, while a.config is the
+	// agent process's default. When they disagree, this switch would pick the
+	// windowed disk load while the filter that consumes its output ran lax (or
+	// the reverse) — the residency decision and the filtering decision have to
+	// come from one source. IsStrictMockWindow folds in the env override, so
+	// KEPLOY_STRICT_MOCK_WINDOW still opts out either way.
+	case pkg.IsStrictMockWindow(params.StrictMockWindow) && !params.AfterTime.IsZero() && !params.BeforeTime.IsZero():
 		mode = "strict-window"
 		loaded, err = disk.LoadWindow(params.AfterTime, params.BeforeTime)
 		if err == nil && !firstWindowStart.IsZero() {
@@ -1017,6 +1025,19 @@ func dedupByName(a, b []*models.Mock) []*models.Mock {
 
 // UpdateMockParams applies filtering parameters and updates the agent's mock manager
 func (a *Agent) UpdateMockParams(ctx context.Context, params models.MockFilterParams) error {
+
+	// Seed the startup-init cutoff from the set's earliest RECORDED test before
+	// anything else touches the window. Without it the cutoff follows whichever
+	// test fires FIRST, so a --test-sets selection, an ignored test or the
+	// streaming deferral leaves it late and mocks belonging to a test that is
+	// never run are classified as startup-init and served as bootstrap traffic.
+	// Optional capability: a proxy that does not implement it keeps the
+	// fired-window behaviour.
+	if !params.FirstRecordedTestStart.IsZero() {
+		if seeder, ok := a.Proxy.(coreAgent.StartupCutoffSeeder); ok {
+			seeder.SeedStartupCutoff(params.FirstRecordedTestStart)
+		}
+	}
 
 	a.logger.Debug("UpdateMockParams called",
 		zap.Time("afterTime", params.AfterTime),

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1329,7 +1329,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		}
 
 		// Send initial filtering parameters to set up mocks for test set
-		err = r.SendMockFilterParamsToAgent(ctx, []string{}, models.BaseTime, time.Now(), totalConsumedMocks, useMappingBased)
+		err = r.SendMockFilterParamsToAgent(ctx, []string{}, models.BaseTime, time.Now(), totalConsumedMocks, useMappingBased, firstRecordedTestStart(testCases))
 		if err != nil {
 			return models.TestSetStatusFailed, err
 		}
@@ -1471,7 +1471,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		}
 
 		// Send initial filtering parameters to set up mocks for test set
-		err = r.SendMockFilterParamsToAgent(ctx, []string{}, models.BaseTime, time.Now(), totalConsumedMocks, useMappingBased)
+		err = r.SendMockFilterParamsToAgent(ctx, []string{}, models.BaseTime, time.Now(), totalConsumedMocks, useMappingBased, firstRecordedTestStart(testCases))
 		if err != nil {
 			return models.TestSetStatusFailed, err
 		}
@@ -1823,7 +1823,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			for i, m := range expectedTestMockMappings[testCase.Name] {
 				expectedNames[i] = m.Name
 			}
-			err = r.SendMockFilterParamsToAgent(runTestSetCtx, expectedNames, reqTime, respTime, totalConsumedMocks, useMappingBased)
+			err = r.SendMockFilterParamsToAgent(runTestSetCtx, expectedNames, reqTime, respTime, totalConsumedMocks, useMappingBased, time.Time{})
 			if err != nil {
 				if resolvedStatus, ok := resolveTestSetStatus(cmdType, testSetStatus, getErrStatus(), err); ok {
 					testSetStatus = resolvedStatus
@@ -2416,7 +2416,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			// Mock Window: Calculate the effective mock filter window for streaming
 			// using the request timestamp to the response timestamp plus a timeout buffer.
 			streamReqTime, streamRespTime := effectiveStreamMockWindow(tc, r.config.Test.APITimeout)
-			err = r.SendMockFilterParamsToAgent(runTestSetCtx, deferred.expectedMocks, streamReqTime, streamRespTime, totalConsumedMocks, useMappingBased)
+			err = r.SendMockFilterParamsToAgent(runTestSetCtx, deferred.expectedMocks, streamReqTime, streamRespTime, totalConsumedMocks, useMappingBased, time.Time{})
 			if err != nil {
 				utils.LogError(r.logger, err, "failed to update mock parameters for streaming test")
 				loopErr = err
@@ -3146,7 +3146,27 @@ func (r *Replayer) GetMocks(ctx context.Context, testSetID string, afterTime tim
 }
 
 // SendMockFilterParamsToAgent sends filtering parameters to agent instead of sending filtered mocks
-func (r *Replayer) SendMockFilterParamsToAgent(ctx context.Context, expectedMockMapping []string, afterTime, beforeTime time.Time, totalConsumedMocks map[string]models.MockState, useMappingBased bool) error {
+// firstRecordedTestStart is the request time of the EARLIEST RECORDED test in
+// the set, and is only meaningful on the initial staging call. It lets the agent
+// seed the startup-init cutoff from the set's recorded shape instead of from
+// whichever test fires first; pass the zero time on per-test calls.
+// firstRecordedTestStart returns the request time of the earliest RECORDED test
+// in the set. testDB returns cases sorted by request timestamp, so it is the
+// first one's; a case with no request time contributes nothing rather than
+// pinning the cutoff to the zero time.
+func firstRecordedTestStart(testCases []*models.TestCase) time.Time {
+	for _, tc := range testCases {
+		if tc == nil {
+			continue
+		}
+		if ts := tc.HTTPReq.Timestamp; !ts.IsZero() {
+			return ts
+		}
+	}
+	return time.Time{}
+}
+
+func (r *Replayer) SendMockFilterParamsToAgent(ctx context.Context, expectedMockMapping []string, afterTime, beforeTime time.Time, totalConsumedMocks map[string]models.MockState, useMappingBased bool, firstRecordedTestStart time.Time) error {
 	if !r.instrument {
 		r.logger.Debug("Keploy will not filter and set mocks when base path is provided", zap.String("base path", r.config.Test.BasePath))
 		return nil
@@ -3162,12 +3182,13 @@ func (r *Replayer) SendMockFilterParamsToAgent(ctx context.Context, expectedMock
 		strictMockWindow = r.config.Test.StrictMockWindow
 	}
 	params := models.MockFilterParams{
-		AfterTime:          afterTime,
-		BeforeTime:         beforeTime,
-		MockMapping:        expectedMockMapping,
-		UseMappingBased:    useMappingBased,
-		TotalConsumedMocks: totalConsumedMocks,
-		StrictMockWindow:   strictMockWindow,
+		AfterTime:              afterTime,
+		BeforeTime:             beforeTime,
+		FirstRecordedTestStart: firstRecordedTestStart,
+		MockMapping:            expectedMockMapping,
+		UseMappingBased:        useMappingBased,
+		TotalConsumedMocks:     totalConsumedMocks,
+		StrictMockWindow:       strictMockWindow,
 	}
 
 	// Send parameters to agent for filtering and mock updates

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -3101,19 +3101,6 @@ func filterByTimeStampTierAware(_ context.Context, logger *zap.Logger, m []*mode
 			continue
 		}
 
-		// Defensive sanity check: if the response-timestamp is BEFORE the
-		// request-timestamp the recording is inconsistent (clock skew,
-		// serialisation bug, or file corruption). Skip it — keeping such
-		// a mock in either pool risks confusing downstream scoring.
-		if p.Spec.ResTimestampMock.Before(p.Spec.ReqTimestampMock) {
-			logger.Debug("mock has response timestamp before request timestamp; dropping",
-				zap.String("mock", p.Name),
-				zap.Time("req", p.Spec.ReqTimestampMock),
-				zap.Time("res", p.Spec.ResTimestampMock))
-			droppedInvalidOrder++
-			continue
-		}
-
 		// Lifetime-first routing (mockdb/filter-layer authoritative
 		// attribution design): Session- and Connection-lifetime mocks
 		// belong in the session/unfiltered pool REGARDLESS of whether
@@ -3138,6 +3125,26 @@ func filterByTimeStampTierAware(_ context.Context, logger *zap.Logger, m []*mode
 			p.TestModeInfo.Lifetime == models.LifetimeConnection {
 			p.TestModeInfo.IsFiltered = false
 			unfilteredMocks = append(unfilteredMocks, p)
+			continue
+		}
+		// NOTE: this runs BELOW the session/connection short-circuit above,
+		// deliberately. It is a window-ordering sanity check, and only per-test
+		// mocks are window-routed — a session or config mock is never compared
+		// against a test window, so a skewed pair cannot mis-route it. Running
+		// it above the short-circuit dropped clock-skewed session mocks (an
+		// auth or handshake recording) out of EVERY pool, which is a hard miss
+		// on traffic that had a perfectly good mock. mockmanager's own
+		// equivalent check is per-test-scoped for the same reason.
+		// Defensive sanity check: if the response-timestamp is BEFORE the
+		// request-timestamp the recording is inconsistent (clock skew,
+		// serialisation bug, or file corruption). Skip it — keeping such
+		// a mock in either pool risks confusing downstream scoring.
+		if p.Spec.ResTimestampMock.Before(p.Spec.ReqTimestampMock) {
+			logger.Debug("mock has response timestamp before request timestamp; dropping",
+				zap.String("mock", p.Name),
+				zap.Time("req", p.Spec.ReqTimestampMock),
+				zap.Time("res", p.Spec.ResTimestampMock))
+			droppedInvalidOrder++
 			continue
 		}
 		// Defensive fallback: DeriveLifetime may not have run on mocks


### PR DESCRIPTION
Closes eleven audited defects in the replay mock manager. They share one root cause and one theme.

## The root cause

`models.TestModeInfo` is the tree key, and its `SortOrder`/`ID` are stamped **from zero per tier** on the fresh copies the agent supplies each call, while `customComparator` orders on those two fields alone. So `(SortOrder:1, ID:0)` addresses *"the first entry of whichever tree you asked"* — not one particular mock.

## Cross-tier consumption

`DeleteFilteredMock`, `DeleteUnFilteredMock` and `TreeDb.update` all resolved by that key, so consuming a startup-tier mock evicted whatever per-test entry shared its index and reported the **wrong name** consumed. `DeleteStartupMock` has always resolved by `Name` for exactly this reason; the other doors now carry an identity check (`Name`+`Kind`+`ReqTimestampMock`), and `update`'s ID-index fallback — keyed on `ID` alone, so `idIndex[0]` exists in *every* tree — is guarded on both paths and no longer falls through to a blind insert.

**The guard alone would have been worse than the bug**, and this is the part worth reviewing hardest. `GetSessionMocks` is startup ∪ session, so HTTP and MySQL match startup-tier mocks — and **no OSS parser calls `DeleteStartupMock`**. Their retry loops re-fetch the pool and `continue` when the doors decline, so a *correct* refusal spun until the request context died. The blind delete had been accidentally keeping those loops terminating. `DeleteFilteredMock` therefore falls back to the startup tier, preserving the caller contract; a session mock reached that way keeps its durable session-tier entry (pinned by a test).

Startup consumption is now recorded — as `Updated`, **not** `Deleted`: `filterOutDeleted` prunes on `Deleted` and is applied to the slice the startup tier is *rebuilt* from, so `Deleted` would drop the boot mock for the rest of the run and break a driver reconnect replaying the bootstrap chain.

## Test-set boundary

`ResetForReplaySession` now *marks* the boundary and the next set's staging clears the window bits, so the bits and the trees they describe change **together**. Clearing at the reset left the manager half torn down for the whole gap, answering queries out of the previous set's startup tier whenever the app survives the boundary (`--keep-app-alive`, compose reuse). Clearing the *trees* there instead would serve an empty pool to a parser racing the reset — a hard miss against a live app is what crash-loops it. The flag also stops a stray mid-set staging call deactivating a live window.

## Startup-init cutoff

It followed the first **fired** window, so a `--test-sets` selection, an ignored test or the streaming deferral left it late and mocks from a test that never runs were served as bootstrap. `SeedStartupCutoff` takes the set's earliest **recorded** test from the replayer, which already sorts by request timestamp. That requires splitting the routing bit out of `firstWindowStart` — seeding the cutoff must not make staging look like a fired test. Wired through `MockFilterParams` (`omitempty`, inert unless populated) and an optional `StartupCutoffSeeder`, following the existing `WindowedProxy` pattern.

## The startup tier's missing contract

- **`scopedMockDb` embedded the interface**, so `Revision`, `RevisionByKind` and the by-kind readers were silently erased and every kind-aware parser fell to a legacy branch that cannot read the startup tier. Forwarded.
- Its **two startup readers bypassed the per-worker allowlist**, letting one worker read *and delete* another's mocks — the file filtered `GetSessionMocks`, defined as startup ∪ session, while leaking the same mock through the other accessor.

## Revisions

`SetMocksWithWindow` swaps three trees in independent sections and bumped after each, so the value published midway was legitimately *current* for a torn state and a consumer could cache an index built from it. One revision is now published after all three land. Kinds **leaving** the pool bump too, or a consumer caching by a frozen revision keeps serving mocks that are gone.

## Two more

- **gob persisted `Lifetime`/`LifetimeDerived`**, which `models.Mock` tags runtime-only — `encoding/gob` ignores struct tags — so the same recording replayed into a different tier depending on storage format. Cleared on write, and on read so existing recordings are repaired.
- **Disk residency** was gated on the agent's own config while the filter consuming its output used the caller's flag. Both read the caller's now.
- The **res-before-req** check ran above the lifetime short-circuit, dropping clock-skewed session/config mocks out of every pool; only per-test mocks are window-routed, so it belongs below. And an **inverted window** made the on-disk loader select nothing — it clamps and says so.

## Verification

`build`, `vet`, `gofmt` clean; `./pkg/...` green apart from a pre-existing root-owned `/tmp/keploy-java-truststore.jks` failure on the dev machine; `-race` green. **Every fix is pinned by a test that fails under a compiling mutation of it** — a first attempt at the identity guard passed against a broken build because the mutation didn't compile, so the mutations here were all re-run for real.
