### PR TITLE
fix(replay): complete the consume ladder and stop two replay hangs

### DIFF
--- a/pkg/agent/proxy/mockmanager.go
+++ b/pkg/agent/proxy/mockmanager.go
@@ -129,6 +129,13 @@ type MockManager struct {
 	// under swapMu.
 	boundaryPending bool
 
+	// cutoffSeeded records that SeedStartupCutoff supplied the startup-init
+	// cutoff for the set now being staged. Production order is
+	// ResetForReplaySession (raises boundaryPending) -> SeedStartupCutoff ->
+	// SetMocksWithWindow(BaseTime); without this the staging branch clears the
+	// cutoff it was just given, in the same call, and the seed does nothing.
+	cutoffSeeded bool
+
 	// swapMu guards the {filtered, unfiltered, window} swap performed by
 	// SetMocksWithWindow. Writers Lock(); readers via GetFilteredMocksInWindow
 	// RLock() the snapshot read so they cannot observe a torn (newMocks,
@@ -372,6 +379,7 @@ func (m *MockManager) ResetForReplaySession() {
 
 	m.swapMu.Lock()
 	m.boundaryPending = true
+	m.cutoffSeeded = false
 	m.swapMu.Unlock()
 
 	// NOTE: the window bits and the startup-init cutoff are deliberately NOT
@@ -754,7 +762,12 @@ func (m *MockManager) SetMocksWithWindow(filtered, unfiltered []*models.Mock, st
 		if m.boundaryPending {
 			m.boundaryPending = false
 			m.testFiredThisSet = false
-			m.firstWindowStart = time.Time{}
+			// Leave a cutoff that was seeded for THIS set. The caller seeds
+			// between the reset and this call, so clearing unconditionally
+			// erased it in the same breath it was given.
+			if !m.cutoffSeeded {
+				m.firstWindowStart = time.Time{}
+			}
 			m.windowMu.Lock()
 			m.windowStart = time.Time{}
 			m.windowEnd = time.Time{}
@@ -968,10 +981,28 @@ func (m *MockManager) SetMocksWithWindow(filtered, unfiltered []*models.Mock, st
 	// window: any revision a consumer can observe now corresponds to a state
 	// where all three tiers agree. Suppression is per-call, not a flag on the
 	// manager, so it cannot swallow a concurrent consumer's own bump.
+	// Collect the kinds LEAVING the pool BEFORE the swaps replace the maps.
+	// Reading them afterwards re-reads the new maps, so a kind that was present
+	// and is now absent never bumps — and a consumer caching under that frozen
+	// per-kind revision keeps serving mocks that are gone. Test set A uses
+	// redis, set B does not: set B was served set A's cached redis index.
+	departing := map[models.Kind]struct{}{}
+	m.treesMu.RLock()
+	for k := range m.filteredByKind {
+		departing[k] = struct{}{}
+	}
+	for k := range m.unfilteredByKind {
+		departing[k] = struct{}{}
+	}
+	m.treesMu.RUnlock()
+
 	m.setFilteredMocks(filteredForTree, false)
 	m.setUnFilteredMocks(unfilteredForTree, false)
 
 	touchedAll := map[models.Kind]struct{}{}
+	for k := range departing {
+		touchedAll[k] = struct{}{}
+	}
 	for _, mk := range filteredForTree {
 		if mk != nil {
 			touchedAll[mk.Kind] = struct{}{}
@@ -990,14 +1021,7 @@ func (m *MockManager) SetMocksWithWindow(filtered, unfiltered []*models.Mock, st
 			touchedAll[mk.Kind] = struct{}{}
 		}
 	}
-	m.treesMu.RLock()
-	for k := range m.filteredByKind {
-		touchedAll[k] = struct{}{}
-	}
-	for k := range m.unfilteredByKind {
-		touchedAll[k] = struct{}{}
-	}
-	m.treesMu.RUnlock()
+
 	for k := range touchedAll {
 		m.bumpRevisionKind(k)
 	}
@@ -1900,7 +1924,7 @@ func (m *MockManager) UpdateUnFilteredMock(old *models.Mock, new *models.Mock) b
 		_, oldUnf := m.ensureKindTrees(oldK)
 		_, newUnf := m.ensureKindTrees(newK)
 		m.treesMu.Lock()
-		updatedOldKind = oldUnf.delete(old.TestModeInfo)
+		updatedOldKind = oldUnf.deleteMock(old.TestModeInfo, *old)
 		updatedNewKind = newUnf.update(old.TestModeInfo, new.TestModeInfo, new, *old)
 		if !updatedNewKind {
 			newUnf.insert(new.TestModeInfo, new)
@@ -1950,7 +1974,28 @@ func (m *MockManager) UpdateUnFilteredMock(old *models.Mock, new *models.Mock) b
 	if updatedGlobal {
 		m.bumpRevisionAll()
 	}
-	return updatedGlobal
+	if updatedGlobal {
+		return true
+	}
+
+	// Ladder step: the unfiltered doors missed, so try the startup tier.
+	//
+	// Every consume door has to be able to resolve a mock the caller legitimately
+	// matched, because a false is not a terminal answer to any caller — it means
+	// "someone else won the race, retry against the shrunk pool", and the pool
+	// does not shrink. http2's matcher takes its candidates from GetSessionMocks
+	// (startup UNION session) and this is its ONLY consume door, so a
+	// bootstrap-recorded per-test mock — which lands in the startup tier — made
+	// it spin until the request context died. Generic and mongo v1 have the same
+	// shape.
+	//
+	// Consuming from startup is the right analogue here: the identity-checked
+	// rewrite above could not find it in the unfiltered trees because it does not
+	// live there.
+	if m.DeleteStartupMock(*old) {
+		return true
+	}
+	return false
 }
 
 func (m *MockManager) DeleteFilteredMock(mock models.Mock) bool {
@@ -2016,6 +2061,20 @@ func (m *MockManager) DeleteFilteredMock(mock models.Mock) bool {
 	// one the caller matched instead of whatever shared its key.
 	if m.DeleteStartupMock(mock) {
 		return true
+	}
+
+	// Final ladder step: a per-test mock that the lax filter promoted into the
+	// SESSION tier. agentStrict is permanently false on the stock proxy, so
+	// pkg/util.go appends out-of-window per-test mocks to the unfiltered slice
+	// with their Lifetime left at per-test. grpcV2 dispatches on Lifetime and
+	// sends those here; kafka reaches here for the same shape. Neither has a
+	// second door, so refusing made them spin.
+	//
+	// Gated on per-test lifetime: a genuine session or connection mock is
+	// REUSABLE and must never be consumed out of the unfiltered tier by this
+	// door, or one match destroys a recording every later test depends on.
+	if mock.TestModeInfo.Lifetime == models.LifetimePerTest {
+		return m.DeleteUnFilteredMock(mock)
 	}
 	return false
 }
@@ -2109,7 +2168,17 @@ func (m *MockManager) DeleteStartupMock(mock models.Mock) bool {
 	it := tree.rbt.Iterator()
 	for it.Next() {
 		mk, ok := it.Value().(*models.Mock)
-		if !ok || mk == nil || mk.Name != mock.Name {
+		if !ok || mk == nil {
+			continue
+		}
+		// Name alone is not enough, and this door is now reached far more often
+		// because the consume ladder falls through to it. Names are not unique:
+		// pulsar emits "pulsar-<commandType>" and says so in its own comment,
+		// kafka emits "kafka-<api>-<corrID>" with correlation ids restarting per
+		// connection. Two callers reach here with mocks they never matched
+		// (pulsar's consumeServerPush, zookeeper's notification flush), so a
+		// name-only match can consume an unrelated recording.
+		if !sameMock(mk, mock) {
 			continue
 		}
 		key := it.Key()
@@ -2179,6 +2248,7 @@ func (m *MockManager) SeedStartupCutoff(start time.Time) {
 	if m.firstWindowStart.IsZero() || start.Before(m.firstWindowStart) {
 		m.firstWindowStart = start
 	}
+	m.cutoffSeeded = true
 }
 
 // MarkMockAsUsed marks the given mock as used (consumed) without modifying

--- a/pkg/agent/proxy/mockmanager_wave2_test.go
+++ b/pkg/agent/proxy/mockmanager_wave2_test.go
@@ -1473,3 +1473,89 @@ func TestDeleteFilteredMock_StartupFallbackLeavesTheSessionTierIntact(t *testing
 			"later test that needs that handshake now misses")
 	}
 }
+
+// The cutoff must survive being seeded in the gap between the boundary and
+// staging — which is the order production actually uses.
+//
+// MockOutgoing calls ResetForReplaySession (raising boundaryPending), then
+// UpdateMockParams seeds the cutoff and only THEN calls SetMocksWithWindow with
+// the BaseTime sentinel. The boundary branch cleared the cutoff unconditionally,
+// so the seed was erased in the same call that set it and the whole
+// earliest-recorded-test fix was inert. The original test for this passed only
+// because it staged first and seeded second.
+func TestSeedStartupCutoff_SurvivesTheBoundaryClearInProductionOrder(t *testing.T) {
+	mm := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+	defer mm.Close()
+
+	t1 := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	// Production order.
+	mm.ResetForReplaySession()
+	mm.SeedStartupCutoff(t1)
+	mm.SetMocksWithWindow(nil, nil, models.BaseTime, time.Now())
+
+	if got := mm.FirstTestWindowStart(); !got.Equal(t1) {
+		t.Fatalf("the seeded cutoff was wiped by the boundary clear: got %v, want %v", got, t1)
+	}
+	// Routing must still read "nothing has fired" — seeding is not a test firing.
+	if snap := mm.WindowSnapshot(); snap.Active || snap.FirstTestFired {
+		t.Fatalf("seeding must not look like a fired test, got %+v", snap)
+	}
+}
+
+// Every consume door has to resolve a mock the caller legitimately matched.
+// A false is not terminal to any caller — it means "someone else won the race,
+// retry against the shrunk pool" — and the pool does not shrink, so a door that
+// refuses makes the caller spin until its context dies.
+func TestConsumeLadder_EveryDoorResolvesAMockFromAnotherTier(t *testing.T) {
+	newMgr := func() *MockManager {
+		m := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+		t.Cleanup(func() { m.Close() })
+		return m
+	}
+	start := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	t.Run("UpdateUnFilteredMock resolves a startup-tier mock", func(t *testing.T) {
+		mm := newMgr()
+		boot := newMockForTest("boot", start.Add(-time.Minute), models.LifetimePerTest)
+		mm.SetMocksWithWindow([]*models.Mock{boot}, nil, models.BaseTime, time.Now())
+
+		startup, _ := mm.GetStartupMocks()
+		var c models.Mock
+		for _, m := range startup {
+			if m != nil && m.Name == "boot" {
+				c = *m
+			}
+		}
+		if c.Name == "" {
+			t.Skip("boot is not in the startup tier")
+		}
+		updated := c
+		if !mm.UpdateUnFilteredMock(&c, &updated) {
+			t.Fatal("http2's only consume door refused a startup-tier mock it matched out of " +
+				"GetSessionMocks; its retry loop re-matches the same mock until the context dies")
+		}
+	})
+
+	t.Run("DeleteFilteredMock resolves a per-test mock promoted into the session tier", func(t *testing.T) {
+		mm := newMgr()
+		// what the lax filter produces: per-test lifetime, unfiltered slice
+		promoted := newMockForTest("promoted", start.Add(-time.Hour), models.LifetimePerTest)
+		mm.SetMocksWithWindow(nil, []*models.Mock{promoted}, start, start.Add(10*time.Second))
+
+		sess, _ := mm.GetSessionScopedMocks()
+		var c models.Mock
+		for _, m := range sess {
+			if m != nil && m.Name == "promoted" {
+				c = *m
+			}
+		}
+		if c.Name == "" {
+			t.Skip("the promoted mock is not in the session tier")
+		}
+		if !mm.DeleteFilteredMock(c) {
+			t.Fatal("grpcV2 and kafka dispatch a per-test-lifetime mock here; refusing it makes " +
+				"them re-pick the same mock forever")
+		}
+	})
+}

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -3162,6 +3162,11 @@ func firstRecordedTestStart(testCases []*models.TestCase) time.Time {
 		if ts := tc.HTTPReq.Timestamp; !ts.IsZero() {
 			return ts
 		}
+		// A gRPC-only test set has no HTTPReq, so reading that field alone
+		// returned zero and the cutoff was never seeded for it at all.
+		if ts := tc.GrpcReq.Timestamp; !ts.IsZero() {
+			return ts
+		}
 	}
 	return time.Time{}
 }


### PR DESCRIPTION
> [!WARNING]
> Fixes **two live replay hangs** introduced by #4518 (released as v3.6.34). http2, gRPC and Kafka replays can spin until the request context dies.

## What went wrong in #4518

It gave `DeleteFilteredMock` a startup-tier fallback for a specific reason: **a refused consume is not a terminal answer to any caller.** It reads as *"someone else won the race, retry against the shrunk pool"* — and the pool does not shrink, so the caller re-picks the same mock forever.

It then applied the same identity guard to `TreeDb.update` and `DeleteUnFilteredMock` **without giving those doors a fallback**. Both previously returned `true` via the blind rewrite. They now return `false` with the mock still in the pool. Same livelock, two more paths.

**Path 1 — `UpdateUnFilteredMock` on a startup-tier mock.** `http2` matches from `GetSessionMocks` (startup ∪ session) and `UpdateUnFilteredMock` is its **only** consume door, with four `continue` sites. Its mocks are stamped `type: HTTP2Client`, so `DeriveLifetime` leaves them per-test and bootstrap-recorded ones land in the startup tier, where the rewrite can't find them. Worse: the caller re-stamps `SortOrder` on the *pooled pointer* before each attempt, so every spin moves the key further from any tree and burns the global sort counter. Generic and mongo v1 share the shape.

**Path 2 — `DeleteFilteredMock` on a lax-promoted per-test mock.** `agentStrict` is permanently false on the stock proxy, so `pkg/util.go` routinely appends out-of-window per-test mocks to the unfiltered slice with their lifetime unchanged. `grpcV2` dispatches on `Lifetime` and sends them here; `kafka` picks from the filtered ∪ unfiltered union. Neither has a second door.

Both are pinned by tests that fail without the fix.

## The rest of the ladder

Every consume door now resolves a mock the caller legitimately matched. The unfiltered step is **gated on per-test lifetime** — a session or connection mock is reusable and must never be consumed out of that tier by this door.

## Four more from the same review

- **`DeleteStartupMock` is identity-checked.** The ladder makes it the common destination and it matched on `Name` alone. Pulsar emits `pulsar-<commandType>` and documents that those aren't unique; kafka emits `kafka-<api>-<corrID>` with correlation ids restarting per connection. Two callers reach it with mocks they never matched.
- **The departing-kinds walk moved above the swaps.** It read `filteredByKind`/`unfilteredByKind` *after* the setters had replaced them, so it saw the new maps and never the kinds that left — leaving that per-kind revision frozen. Set A uses redis, set B doesn't, set B was served set A's cached redis index.
- **`SeedStartupCutoff` was wiped by the call meant to use it.** Production order is reset → seed → `SetMocksWithWindow(BaseTime)`, whose boundary branch cleared the cutoff unconditionally. The seed lived for one call and #4518's earliest-recorded-test fix did nothing. The shipped test passed only because it staged first and seeded second, which production never does — the new test uses production order.
- **`firstRecordedTestStart`** read only `HTTPReq.Timestamp`, so a gRPC-only test set never seeded at all.
- One **blind delete** in `UpdateUnFilteredMock`'s cross-kind branch was missed when its siblings were converted.

## Verification

`gofmt`, `vet` clean; `./pkg/...` green apart from a pre-existing root-owned `/tmp` truststore failure; `-race` green. Both hangs reproduce on `main` and pass here.
