### PR TITLE
fix(replay): load each test-set's async corpus instead of replaying the first

### DIFF
--- a/pkg/agent/proxy/integrations/async/engine.go
+++ b/pkg/agent/proxy/integrations/async/engine.go
@@ -57,7 +57,6 @@ type Engine struct {
 
 	mu         sync.Mutex
 	cond       *sync.Cond             // signaled whenever completed/windowSeen changes; wakes held POLL Decide calls
-	loaded     bool                   // true once Load has partitioned+sorted streams; makes Load idempotent
 	streams    map[string]*laneStream // by lane name
 	completed  int                    // number of testcases completed
 	windowSeen bool                   // AdvanceWindow: first window doesn't count as a completed test
@@ -141,14 +140,34 @@ func (e *Engine) laneByName(name string) (models.AsyncLane, bool) {
 }
 
 // Load partitions async-tagged mocks into per-lane epoch timelines, sorted by
-// (effectiveFromPos, seq). It is run-once: the first call partitions and
-// sorts; subsequent calls are no-ops.
+// (effectiveFromPos, seq). Each call REPLACES the previous corpus and rewinds
+// the epoch cursor.
+//
+// It used to be run-once, which was wrong: one Engine serves a whole replay run
+// (proxy.go builds it in InitIntegrations), while StoreMocks — the only thing
+// that feeds it — runs once per TEST-SET. So sets 2..N had their corpus dropped
+// and set 1's replayed in their place, and `completed`, which counts windows for
+// the whole run while AnchorPos restarts at 0 in every set, made currentEpoch
+// open mid-timeline so a set's boot value was never served.
+//
+// Replacing inside Load rather than on a separate reset seam is deliberate: the
+// two replay branches call StoreMocks and MockOutgoing in OPPOSITE orders —
+// compose is MockOutgoing then StoreMocks (replay.go:1239/1321), native is
+// StoreMocks then MockOutgoing (replay.go:1420/1450) — so any seam in
+// Proxy.Mock is correct for one path and wipes the just-loaded corpus on the
+// other. Doing it here is ordering-independent.
+//
+// The report tallies (pass/flag/flags) are deliberately left alone; they are
+// not per-set state.
 func (e *Engine) Load(mocks []*models.Mock) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	if e.loaded {
-		return
-	}
+	e.streams = make(map[string]*laneStream)
+	e.completed = 0
+	e.windowSeen = false
+	// A poll Decide parked on cond is waiting for a counter that just moved
+	// backwards; wake it rather than let it block until its context expires.
+	e.cond.Broadcast()
 	for _, m := range mocks {
 		if m == nil || !m.IsAsync() {
 			continue
@@ -177,7 +196,6 @@ func (e *Engine) Load(mocks []*models.Mock) {
 			return s.epochs[i].seq < s.epochs[j].seq
 		})
 	}
-	e.loaded = true
 }
 
 // OnTestComplete increments the completed-testcase counter directly. Used by
@@ -265,6 +283,15 @@ func (e *Engine) Decide(ctx context.Context, lane models.AsyncLane, live *models
 	}
 	if lane.IsPoll() {
 		e.holdThrottle(ctx, lane.ThrottleDuration()) // pace + wake-early; holds e.mu
+	}
+	// Re-read the stream: holdThrottle released e.mu, and a Load for the next
+	// test-set may have replaced e.streams while this poll was parked. The
+	// captured pointer would serve the PREVIOUS set's timeline against the
+	// rewound counter — i.e. its boot value — instead of keep-aliving.
+	s = e.streams[lane.Name]
+	if s == nil || len(s.epochs) == 0 {
+		e.mu.Unlock()
+		return e.keepAlive(p, lane)
 	}
 	cur := s.currentEpoch(e.completed)
 	e.mu.Unlock()

--- a/pkg/agent/proxy/integrations/async/engine_test.go
+++ b/pkg/agent/proxy/integrations/async/engine_test.go
@@ -3,6 +3,7 @@ package async
 import (
 	"context"
 	"testing"
+	"time"
 
 	"go.keploy.io/server/v3/pkg/models"
 	"go.uber.org/zap"
@@ -196,5 +197,116 @@ func TestNonPollServesReselectableCurrentEpoch(t *testing.T) {
 		if rec == nil || rec.Spec.HTTPResp.Body != "B" {
 			t.Fatalf("req %d @completed=1: want re-selectable B, got %v", i, rec)
 		}
+	}
+}
+
+// One Engine serves a whole replay run, but StoreMocks — the only thing that
+// feeds it — runs once per TEST-SET. Load therefore has to REPLACE.
+//
+// The corpus must be replaced, not merged: a surviving set-A epoch stays in the
+// same lane timeline and, because currentEpoch takes the last entry effective
+// at the cursor, can silently answer for set B. Set B here deliberately has NO
+// epoch effective at boot, so an inherited set-A epoch is observable.
+func TestLoadReplacesThePreviousTestSetsCorpus(t *testing.T) {
+	e := newTestEngine(&fakeParser{matches: true, shapeOK: true, empty: []byte("KA")})
+	lane := models.AsyncLane{Name: "L", Type: "fake", ThrottleMs: 10}
+
+	e.Load([]*models.Mock{asyncMock("L", 1, 0, "SET-A")})
+	if rec, _, _ := e.Decide(context.Background(), lane, &models.Mock{}); rec == nil || rec.Spec.HTTPResp.Body != "SET-A" {
+		t.Fatalf("precondition: set A must serve SET-A, got %v", rec)
+	}
+
+	// Set B's timeline starts at position 2 — nothing is effective at boot.
+	e.Load([]*models.Mock{asyncMock("L", 2, 2, "SET-B")})
+
+	rec, keepAlive, err := e.Decide(context.Background(), lane, &models.Mock{})
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if rec != nil {
+		t.Fatalf("set B boot served %q, want a keep-alive: set A's corpus survived "+
+			"the new set's Load and is answering for it", rec.Spec.HTTPResp.Body)
+	}
+	if string(keepAlive) != "KA" {
+		t.Fatalf("want the parser's keep-alive, got %q", keepAlive)
+	}
+}
+
+// AnchorPos is recorded per test-set and always starts at 0, but `completed`
+// counts test windows for the WHOLE RUN. Entering set B with a carried count
+// makes currentEpoch open mid-timeline, so set B's boot value is never served.
+func TestLoadRewindsTheEpochCursor(t *testing.T) {
+	e := newTestEngine(&fakeParser{matches: true, shapeOK: true, empty: []byte("KA")})
+	lane := models.AsyncLane{Name: "L", Type: "fake", ThrottleMs: 10}
+
+	e.Load([]*models.Mock{asyncMock("L", 1, 0, "A0")})
+	e.AdvanceWindow() // first window: windowSeen, completed stays 0
+	e.AdvanceWindow() // completed=1
+	e.AdvanceWindow() // completed=2
+
+	e.Load([]*models.Mock{
+		asyncMock("L", 1, 0, "B0"),
+		asyncMock("L", 2, 1, "B1"),
+	})
+	e.AdvanceWindow() // set B's FIRST window must not count as a completed test
+
+	rec, _, _ := e.Decide(context.Background(), lane, &models.Mock{})
+	if rec == nil {
+		t.Fatal("set B: nothing served at boot")
+	}
+	if got := rec.Spec.HTTPResp.Body; got != "B0" {
+		// B1 sits at pos 1, so an off-by-one is observable here: carrying
+		// windowSeen makes set B's first window count as a completed test and
+		// every epoch in the set fires one test early.
+		t.Fatalf("set B boot served %q, want B0: the completed counter carried %d "+
+			"tests over from the previous set, so the cursor started mid-timeline",
+			got, e.CompletedForTest())
+	}
+}
+
+// A poll parked in holdThrottle captured its *laneStream before releasing e.mu.
+// The next test-set's Load replaces e.streams and broadcasts, waking it — and
+// the captured pointer would serve the PREVIOUS set's boot value against the
+// rewound cursor. Decide must re-read the stream after the hold.
+func TestPollParkedAcrossLoadDoesNotServeThePreviousCorpus(t *testing.T) {
+	e := newTestEngine(&fakeParser{matches: true, shapeOK: true, empty: []byte("KA")})
+	// A long throttle so the poll is genuinely parked when Load lands.
+	lane := models.AsyncLane{Name: "L", Type: "fakePoll", ThrottleMs: 5000}
+
+	e.Load([]*models.Mock{asyncMock("L", 1, 0, "SET-A-BOOT")})
+
+	type res struct {
+		rec *models.Mock
+		ka  []byte
+	}
+	done := make(chan res, 1)
+	go func() {
+		rec, ka, _ := e.Decide(context.Background(), lane, &models.Mock{})
+		done <- res{rec, ka}
+	}()
+
+	// Let the poll reach the hold, then swap in a set with nothing at boot.
+	time.Sleep(50 * time.Millisecond)
+	swapped := time.Now()
+	e.Load([]*models.Mock{asyncMock("L", 2, 2, "SET-B")})
+
+	select {
+	case r := <-done:
+		// The poll must be woken BY the Load, not merely outlive the 5s
+		// throttle — otherwise this test passes even with Load's Broadcast
+		// removed, and equally if the goroutine parked after the swap.
+		if waited := time.Since(swapped); waited > time.Second {
+			t.Fatalf("poll took %v to return: it timed out on the throttle rather than "+
+				"being woken by Load's broadcast, so this test proved nothing", waited)
+		}
+		if r.rec != nil {
+			t.Fatalf("parked poll served %q from the previous test-set's stream after "+
+				"Load replaced it; want a keep-alive", r.rec.Spec.HTTPResp.Body)
+		}
+		if string(r.ka) != "KA" {
+			t.Fatalf("want the parser's keep-alive, got %q", r.ka)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("parked poll never returned; the Load broadcast did not wake it")
 	}
 }

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -3254,7 +3254,8 @@ func (p *Proxy) Mock(_ context.Context, opts models.OutgoingOptions) error {
 var _ agent.AsyncMockLoader = (*Proxy)(nil)
 
 // LoadAsyncMocks forwards the complete async-mock corpus to the async engine
-// (run-once inside Engine.Load). No-op when async is not configured.
+// (which REPLACES the previous test-set's corpus). No-op when async is not
+// configured.
 func (p *Proxy) LoadAsyncMocks(mocks []*models.Mock) {
 	if p.asyncEngine != nil {
 		p.asyncEngine.Load(mocks)

--- a/pkg/agent/proxy/proxy_async_test.go
+++ b/pkg/agent/proxy/proxy_async_test.go
@@ -45,7 +45,7 @@ func asyncMock(lane string, seq int, body string) *models.Mock {
 }
 
 // TestLoadAsyncMocksForwardsToEngine proves Proxy.LoadAsyncMocks hands the
-// complete corpus to the async engine's run-once Load (the engine's Load
+// complete corpus to the async engine's Load (the engine's Load
 // filter ignores the interleaved non-async mock), and that under the
 // value-epoch model two epochs recorded at the same AnchorPos resolve to the
 // newest one: both "a" (seq 1) and "b" (seq 2) are effective at completed=0,

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -669,12 +669,11 @@ func (a *Agent) wantsAsyncMocks() bool {
 }
 
 // loadAsyncIntoProxy hands the async corpus to the proxy if it supports it.
-// Engine.Load is run-once, so callers pass the COMPLETE async corpus in a
-// single call per store path — never per window.
+// Engine.Load REPLACES the corpus, so callers pass the COMPLETE async corpus
+// for the test-set in a single call per store path — never per window.
 func (a *Agent) loadAsyncIntoProxy(asyncMocks []*models.Mock) {
-	if len(asyncMocks) == 0 {
-		return
-	}
+	// No early return on an empty corpus: Load REPLACES, so a test-set holding
+	// no async mocks has to clear the previous set's rather than inherit them.
 	if loader, ok := a.Proxy.(coreAgent.AsyncMockLoader); ok {
 		loader.LoadAsyncMocks(asyncMocks)
 	}

--- a/pkg/service/agent/agent_async_test.go
+++ b/pkg/service/agent/agent_async_test.go
@@ -3,12 +3,13 @@ package agent
 import (
 	"testing"
 
+	coreAgent "go.keploy.io/server/v3/pkg/agent"
 	"go.keploy.io/server/v3/pkg/models"
 )
 
 // TestCollectAsyncMocksFiltersByMetadata proves collectAsyncMocks keeps only
 // the async mocks (Spec.Async != nil), preserves their input order, and
-// tolerates nil entries. This is the exact subset the agent hands the run-once
+// tolerates nil entries. This is the exact subset the agent hands
 // Engine.Load, so a false negative here silently drops async mocks at replay.
 func TestCollectAsyncMocksFiltersByMetadata(t *testing.T) {
 	a := &models.Mock{Spec: models.MockSpec{Async: &models.AsyncMeta{Lane: "L"}}}
@@ -17,5 +18,42 @@ func TestCollectAsyncMocksFiltersByMetadata(t *testing.T) {
 	got := collectAsyncMocks([]*models.Mock{a, b, c, nil})
 	if len(got) != 2 || got[0] != a || got[1] != c {
 		t.Fatalf("collectAsyncMocks = %v, want [a c]", got)
+	}
+}
+
+// asyncLoaderStub records what the proxy layer is handed. It implements only
+// the optional AsyncMockLoader capability, which is what loadAsyncIntoProxy
+// type-asserts for.
+type asyncLoaderStub struct {
+	coreAgent.Proxy
+	calls [][]*models.Mock
+}
+
+func (s *asyncLoaderStub) LoadAsyncMocks(mocks []*models.Mock) {
+	s.calls = append(s.calls, mocks)
+}
+
+// A test-set holding NO async mocks has to clear the previous set's corpus.
+//
+// Engine.Load replaces rather than latches, so the clear is expressed by
+// calling it with an empty slice. The early return that used to skip that call
+// meant a set with no async mocks silently inherited the previous set's
+// recordings and replayed them as its own.
+func TestLoadAsyncIntoProxy_EmptyCorpusStillClearsThePreviousSet(t *testing.T) {
+	stub := &asyncLoaderStub{}
+	a := &Agent{Proxy: stub}
+
+	a.loadAsyncIntoProxy([]*models.Mock{
+		{Spec: models.MockSpec{Async: &models.AsyncMeta{Lane: "L"}}},
+	})
+	a.loadAsyncIntoProxy(nil) // next test-set has no async mocks
+
+	if len(stub.calls) != 2 {
+		t.Fatalf("LoadAsyncMocks called %d times, want 2: a set with no async mocks "+
+			"never reached the engine, so it inherited the previous set's corpus",
+			len(stub.calls))
+	}
+	if len(stub.calls[1]) != 0 {
+		t.Fatalf("second call carried %d mocks, want 0", len(stub.calls[1]))
 	}
 }


### PR DESCRIPTION
## Problem

One async `Engine` serves a whole replay run — `proxy.go` builds it once in `InitIntegrations` — but `StoreMocks`, the only thing that feeds it, runs **once per test-set**. `Engine.Load` was run-once (`if e.loaded { return }`), so test-sets 2..N had their async corpus silently dropped and **set 1's was replayed in their place** for the rest of the run.

`completed` compounded it. It counts test windows for the whole run, while `Spec.Async.AnchorPos` is recorded per set and always starts at 0. Entering a later set with a carried count made `currentEpoch` open mid-timeline, so that set's boot value was never served.

Both were reproduced against unmodified `main` before any fix.

## Why the fix is inside `Load`, not on a reset seam

The obvious fix — reset the engine on the same seam that calls `mm.ResetForReplaySession()` — is wrong, and the first version of this PR had it. The two replay branches call `StoreMocks` and `MockOutgoing` in **opposite orders**:

| branch | order |
|---|---|
| native (`replay.go:1368`) | `StoreMocks` **1420** → `MockOutgoing` **1450** |
| compose (`replay.go:1149`) | `MockOutgoing` **1239** → `StoreMocks` **1321** |

A seam in `Proxy.Mock` is therefore correct for compose and **fatal** on the default native path: it would empty `e.streams` immediately after the corpus was loaded, so every async request — in every set, including the first — would get a keep-alive instead of its recorded value.

`Load` is the one call that carries the corpus, so acting there is ordering-independent. Verified against both branches plus `service/runner` and `service/mock`.

## Changes

- **`Engine.Load` replaces** rather than latches: fresh `streams` map, `completed`/`windowSeen` rewound, one broadcast to wake any parked poll. `loaded` is deleted — nothing reads it.
- **`loadAsyncIntoProxy` no longer skips an empty corpus.** A set with no async mocks must *clear* the previous set's, not inherit it.
- **`Decide` re-reads its `laneStream` after `holdThrottle`.** It captured the pointer before releasing the mutex, so a poll parked across a set boundary served the previous set's timeline against the rewound cursor — its boot value — instead of keep-aliving.

## Testing

Six new/updated tests, every one mutation-verified:

| mutation | caught by |
|---|---|
| drop `e.streams = make(...)` | `TestLoadReplacesThePreviousTestSetsCorpus` |
| drop `e.completed = 0` | `TestLoadRewindsTheEpochCursor` |
| drop `e.windowSeen = false` | `TestLoadRewindsTheEpochCursor` |
| drop `Load`'s `cond.Broadcast()` | `TestPollParkedAcrossLoadDoesNotServeThePreviousCorpus` |
| drop `Decide`'s post-hold re-read | same |
| restore the empty-corpus early return | `TestLoadAsyncIntoProxy_EmptyCorpusStillClearsThePreviousSet` |

The poll test asserts the poll returns **within 1s** of the swap, so it fails rather than silently passing 100× slower if the broadcast is removed or the goroutine loses the scheduling race.

`go build ./...`, `go vet`, and `-race` on `async` / `agent/proxy` / `service/agent` all clean.

## Out of scope, found while reviewing

`Engine.LogReport` is `logOnce`-guarded while `NotifyGracefulShutdown` runs in `RunTestSet`'s deferred teardown for **every** set (`replay.go:981`), so the run-level async tally is printed at the end of test-set 1 and the accumulation for sets 2..N is never emitted. Pre-existing; not touched here.
