### PR TITLE
fix(replay): honour the seeded startup cutoff and bump departing kinds

### DIFF
--- a/pkg/agent/proxy/mockmanager.go
+++ b/pkg/agent/proxy/mockmanager.go
@@ -106,10 +106,14 @@ type MockManager struct {
 	// Previous-test mocks continue to be dropped to prevent cross-test
 	// bleed.
 	//
-	// Zero until the first SetMocksWithWindow call with a non-zero
-	// start arrives; after that it's sticky (only goes earlier, never
-	// later within a set; cleared at each set boundary by
-	// ResetForReplaySession). Read under swapMu.RLock.
+	// Zero until either the replayer seeds this set's cutoff (see
+	// cutoffSeeded, installed by the boundary staging call) or the first
+	// SetMocksWithWindow call with a non-zero start arrives — whichever comes
+	// first, which in production is the seed. After that it is sticky within
+	// the set (only goes earlier, never later), and the set boundary REPLACES
+	// it with the next set's seeded value rather than clearing it: the clear
+	// used to happen in ResetForReplaySession, then moved to staging, and
+	// staging is also where the seed lands. Read under swapMu.RLock.
 	firstWindowStart time.Time
 
 	// testFiredThisSet is the TIER-ROUTING half of what firstWindowStart used
@@ -128,6 +132,20 @@ type MockManager struct {
 	// call mid-set being able to deactivate a live test's window. Written
 	// under swapMu.
 	boundaryPending bool
+
+	// cutoffSeeded parks the startup-init cutoff the replayer supplies for the
+	// NEXT set, until that set's staging call installs it.
+	//
+	// The seed cannot be written straight into firstWindowStart: staging clears
+	// firstWindowStart at the boundary, and the replayer seeds BEFORE staging in
+	// the same UpdateMockParams call (SeedStartupCutoff then
+	// SetMocksWithWindow), so a directly-written seed was wiped microseconds
+	// later — for every set. Parking it separately lets staging INSTALL the
+	// value instead of clearing to zero, which is also what stops set N+1 from
+	// inheriting set N's cutoff: sets are recorded in chronological order, so
+	// the next set's cutoff is always LATER and a running-minimum guard against
+	// the live value would refuse it. Written under swapMu.
+	cutoffSeeded time.Time
 
 	// swapMu guards the {filtered, unfiltered, window} swap performed by
 	// SetMocksWithWindow. Writers Lock(); readers via GetFilteredMocksInWindow
@@ -372,6 +390,14 @@ func (m *MockManager) ResetForReplaySession() {
 
 	m.swapMu.Lock()
 	m.boundaryPending = true
+	// A parked cutoff belongs to the set that seeded it and must never outlive
+	// it. UpdateMockParams can abort between SeedStartupCutoff and
+	// SetMocksWithWindow (the "no mocks stored for client ID" bail and the
+	// loadPerTestMocks error path), leaving a park with no staging call to
+	// consume it — and since sets are recorded chronologically the stale value
+	// is always the EARLIER one, so it would win any running-minimum guard and
+	// the next set would run on the aborted set's cutoff.
+	m.cutoffSeeded = time.Time{}
 	m.swapMu.Unlock()
 
 	// NOTE: the window bits and the startup-init cutoff are deliberately NOT
@@ -754,7 +780,10 @@ func (m *MockManager) SetMocksWithWindow(filtered, unfiltered []*models.Mock, st
 		if m.boundaryPending {
 			m.boundaryPending = false
 			m.testFiredThisSet = false
-			m.firstWindowStart = time.Time{}
+			// Install this set's seeded cutoff. Zero when nothing was seeded,
+			// which is exactly the historical clear.
+			m.firstWindowStart = m.cutoffSeeded
+			m.cutoffSeeded = time.Time{}
 			m.windowMu.Lock()
 			m.windowStart = time.Time{}
 			m.windowEnd = time.Time{}
@@ -931,6 +960,38 @@ func (m *MockManager) SetMocksWithWindow(filtered, unfiltered []*models.Mock, st
 		startupKey.ID = idx
 		newStartup.insert(startupKey, mk)
 	}
+	// Harvest the kinds present BEFORE any tier is swapped.
+	//
+	// A kind that LEAVES the pool has to bump its own per-kind revision, or a
+	// consumer caching an index under RevisionByKind never learns its mocks are
+	// gone and keeps serving the previous set's index. Reading the by-kind maps
+	// after the swaps — as this used to — reads the NEW maps, so it is exactly
+	// redundant with walking the new input slices and departing kinds are
+	// published nowhere.
+	//
+	// The old startup tree is walked too: during BaseTime staging
+	// filteredForTree is nil, so a kind whose mocks all live in the startup tier
+	// never appears in filteredByKind either, and reading only the two by-kind
+	// maps misses it in both directions.
+	outgoingKinds := map[models.Kind]struct{}{}
+	m.treesMu.RLock()
+	for k := range m.filteredByKind {
+		outgoingKinds[k] = struct{}{}
+	}
+	for k := range m.unfilteredByKind {
+		outgoingKinds[k] = struct{}{}
+	}
+	oldStartup := m.startup
+	m.treesMu.RUnlock()
+	if oldStartup != nil {
+		oldStartup.rangeValues(func(v interface{}) bool {
+			if mk, ok := v.(*models.Mock); ok && mk != nil {
+				outgoingKinds[mk.Kind] = struct{}{}
+			}
+			return true
+		})
+	}
+
 	m.treesMu.Lock()
 	m.startup = newStartup
 	m.treesMu.Unlock()
@@ -990,14 +1051,11 @@ func (m *MockManager) SetMocksWithWindow(filtered, unfiltered []*models.Mock, st
 			touchedAll[mk.Kind] = struct{}{}
 		}
 	}
-	m.treesMu.RLock()
-	for k := range m.filteredByKind {
+	// Kinds that were present before this call but are absent from every input
+	// slice above. Collected pre-swap; see outgoingKinds.
+	for k := range outgoingKinds {
 		touchedAll[k] = struct{}{}
 	}
-	for k := range m.unfilteredByKind {
-		touchedAll[k] = struct{}{}
-	}
-	m.treesMu.RUnlock()
 	for k := range touchedAll {
 		m.bumpRevisionKind(k)
 	}
@@ -1300,9 +1358,14 @@ func (m *MockManager) HasFirstTestFired() bool {
 	return m.testFiredThisSet
 }
 
-// FirstTestWindowStart returns the earliest test window start this
-// MockManager has observed, or the zero time if no non-BaseTime
-// SetMocksWithWindow call has landed yet.
+// FirstTestWindowStart returns this set's startup-init cutoff: the earliest
+// test window start observed, or — from the boundary staging call onward — the
+// value the replayer seeded via SeedStartupCutoff.
+//
+// It is NOT "zero until a non-BaseTime SetMocksWithWindow lands". In production
+// the seed arrives first, so this returns a non-zero cutoff throughout the
+// staging window. A non-zero value here does not mean a test has fired; use
+// HasFirstTestFired for that.
 //
 // Exposed so the agent's tier-aware strictMockWindow filter can
 // distinguish:
@@ -2176,6 +2239,21 @@ func (m *MockManager) SeedStartupCutoff(start time.Time) {
 	}
 	m.swapMu.Lock()
 	defer m.swapMu.Unlock()
+	if m.boundaryPending {
+		// This set has not been staged yet, so firstWindowStart still describes
+		// the PREVIOUS set and comparing against it is meaningless. Park the
+		// value; staging installs it.
+		//
+		// Unconditionally, NOT as a running minimum: the reset clears the park,
+		// so anything already here belongs to this same set, and a minimum
+		// would be backwards anyway — later sets always seed later, so an
+		// earlier value would win every comparison.
+		m.cutoffSeeded = start
+		return
+	}
+	// Already staged: apply directly, keeping the running-minimum semantics.
+	// Parking it here instead would strand the value until the NEXT boundary,
+	// where it would install a cutoff belonging to the wrong set.
 	if m.firstWindowStart.IsZero() || start.Before(m.firstWindowStart) {
 		m.firstWindowStart = start
 	}

--- a/pkg/agent/proxy/mockmanager_wave2_test.go
+++ b/pkg/agent/proxy/mockmanager_wave2_test.go
@@ -1473,3 +1473,170 @@ func TestDeleteFilteredMock_StartupFallbackLeavesTheSessionTierIntact(t *testing
 			"later test that needs that handshake now misses")
 	}
 }
+
+// The replayer seeds the set's startup-init cutoff and then stages its mocks in
+// ONE UpdateMockParams call — SeedStartupCutoff (agent.go) followed by
+// SetMocksWithWindow. Staging is also where the set boundary clears the window
+// bits, so a seed written straight into firstWindowStart was wiped microseconds
+// after it was written, for EVERY set: the feature was inert in production
+// while its unit tests passed, because they used a fresh manager where the
+// clear had nothing to remove.
+func TestSeedStartupCutoff_SurvivesTheStagingThatFollowsIt(t *testing.T) {
+	mm := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+	t.Cleanup(func() { mm.Close() })
+
+	first := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	// Exactly the production order for one test set.
+	mm.ResetForReplaySession()
+	mm.SeedStartupCutoff(first)
+	mm.SetMocksWithWindow(nil, nil, models.BaseTime, time.Now())
+
+	if got := mm.FirstTestWindowStart(); !got.Equal(first) {
+		t.Fatalf("cutoff after staging = %v, want %v: the boundary clear wiped the "+
+			"seed the replayer had just supplied, so every mock recorded before the "+
+			"set's first test is dropped instead of routed to the startup tier", got, first)
+	}
+
+	// Installing a cutoff must not look like a fired test. If it did, tier-aware
+	// parsers would route the set's bootstrap traffic to the per-test engine
+	// over a tree that staging just emptied.
+	if mm.HasFirstTestFired() {
+		t.Fatal("the installed cutoff marked a test as fired")
+	}
+	if snap := mm.WindowSnapshot(); snap.Active || snap.FirstTestFired {
+		t.Fatalf("window snapshot after staging = %+v, want inactive with no test fired", snap)
+	}
+}
+
+// Test sets are recorded in chronological order, so set N+1's cutoff is always
+// LATER than set N's. A running-minimum guard against the live value therefore
+// REFUSES it, and set N+1 runs the whole set on set N's cutoff — every mock
+// recorded between the two sets reads as previous-test bleed and is dropped
+// rather than served as that set's bootstrap traffic.
+func TestSeedStartupCutoff_SecondSetDoesNotInheritTheFirstsCutoff(t *testing.T) {
+	mm := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+	t.Cleanup(func() { mm.Close() })
+
+	setA := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	setB := setA.Add(time.Hour)
+
+	mm.ResetForReplaySession()
+	mm.SeedStartupCutoff(setA)
+	mm.SetMocksWithWindow(nil, nil, models.BaseTime, time.Now())
+	mm.SetMocksWithWindow(nil, nil, setA, setA.Add(time.Second)) // a test fires in set A
+
+	mm.ResetForReplaySession()
+	mm.SeedStartupCutoff(setB)
+	mm.SetMocksWithWindow(nil, nil, models.BaseTime, time.Now())
+
+	if got := mm.FirstTestWindowStart(); !got.Equal(setB) {
+		t.Fatalf("set B cutoff = %v, want %v: set B is running on set A's cutoff", got, setB)
+	}
+
+	// The user-visible consequence: set B's own bootstrap mock, recorded after
+	// set A ended, must reach the startup tier.
+	boot := newMockForTest("setB-bootstrap", setB.Add(-5*time.Minute), models.LifetimePerTest)
+	mm.SetMocksWithWindow([]*models.Mock{boot}, nil, setB, setB.Add(time.Second))
+
+	startup, err := mm.GetStartupMocks()
+	if err != nil {
+		t.Fatalf("GetStartupMocks: %v", err)
+	}
+	if !containsMockNamed(startup, "setB-bootstrap") {
+		t.Fatalf("set B's bootstrap mock was dropped instead of routed to startup "+
+			"(startup=%d dropped=%d cutoff=%v)", len(startup), mm.DroppedOutOfWindow(),
+			mm.FirstTestWindowStart())
+	}
+}
+
+// A kind that LEAVES the pool must bump its own per-kind revision, or a
+// consumer caching an index under RevisionByKind never learns its mocks are
+// gone and keeps serving the previous set's index.
+//
+// The walk used to read filteredByKind/unfilteredByKind AFTER the tier swap, so
+// it read the NEW maps — exactly redundant with walking the new input slices,
+// and departing kinds were published nowhere. A kind living only in the startup
+// tier was missed in both directions, because during BaseTime staging
+// filteredForTree is nil and such a kind never enters filteredByKind at all.
+func TestSetMocksWithWindow_BumpsRevisionForDepartingKinds(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		startup bool // seed via the startup tier (BaseTime staging) instead of a live window
+	}{
+		{name: "per-test tier"},
+		{name: "startup tier", startup: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mm := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+			t.Cleanup(func() { mm.Close() })
+
+			at := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+			redis := newMockForTest("redis-1", at, models.LifetimePerTest)
+			redis.Kind = models.REDIS
+
+			if tc.startup {
+				mm.SetMocksWithWindow([]*models.Mock{redis}, nil, models.BaseTime, time.Now())
+			} else {
+				mm.SetMocksWithWindow([]*models.Mock{redis}, nil, at, at.Add(time.Second))
+			}
+			before := mm.RevisionByKind(models.REDIS)
+			if before == 0 {
+				t.Fatal("precondition: staging redis mocks must move the redis revision")
+			}
+
+			// Next set holds no redis mocks at all.
+			mm.SetMocksWithWindow(nil, nil, at.Add(time.Hour), at.Add(time.Hour+time.Second))
+
+			if got := mm.RevisionByKind(models.REDIS); got == before {
+				t.Fatalf("redis per-kind revision stayed %d after its mocks left the pool; "+
+					"a revision-gated consumer keeps serving the previous set's redis index", got)
+			}
+		})
+	}
+}
+
+// A parked cutoff must not outlive the set that seeded it.
+//
+// UpdateMockParams can abort between SeedStartupCutoff and SetMocksWithWindow
+// — the "no mocks stored for client ID" bail and the loadPerTestMocks error
+// path both return in that gap — leaving a park with no staging call to consume
+// it. Sets are recorded chronologically, so the orphan is always the EARLIER
+// value: it would win any running-minimum guard and the next set would replay
+// on the aborted set's cutoff, dropping its bootstrap traffic as bleed.
+func TestSeedStartupCutoff_AbortedSetDoesNotLeakItsCutoffToTheNext(t *testing.T) {
+	mm := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+	t.Cleanup(func() { mm.Close() })
+
+	setA := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	setB := setA.Add(time.Hour)
+
+	// Set A seeds and then aborts before staging.
+	mm.ResetForReplaySession()
+	mm.SeedStartupCutoff(setA)
+
+	// Set B runs normally.
+	mm.ResetForReplaySession()
+	mm.SeedStartupCutoff(setB)
+	mm.SetMocksWithWindow(nil, nil, models.BaseTime, time.Now())
+
+	if got := mm.FirstTestWindowStart(); !got.Equal(setB) {
+		t.Fatalf("set B cutoff = %v, want %v: the aborted set's parked cutoff survived "+
+			"its own set and was installed here", got, setB)
+	}
+
+	// The set after an abort need not seed at all — the replayer supplies a
+	// cutoff only when it knows the set's first recorded test. Then nothing
+	// overwrites the orphan, so the reset is the only thing that can clear it.
+	mm.ResetForReplaySession()
+	mm.SeedStartupCutoff(setB.Add(time.Hour))
+	mm.ResetForReplaySession() // that set aborts before staging
+
+	mm.ResetForReplaySession()
+	mm.SetMocksWithWindow(nil, nil, models.BaseTime, time.Now()) // no seed for this one
+
+	if got := mm.FirstTestWindowStart(); !got.IsZero() {
+		t.Fatalf("cutoff = %v, want zero: an unseeded set inherited a parked cutoff "+
+			"from an aborted earlier set", got)
+	}
+}


### PR DESCRIPTION
Two independent defects in `SetMocksWithWindow`'s set-boundary handling. Both were reproduced against unmodified `main` before any fix, and every production line below is mutation-verified.

## 1. `SeedStartupCutoff` was inert for **every** test set

The replayer seeds the set's startup-init cutoff and stages its mocks in **one** `UpdateMockParams` call — `SeedStartupCutoff` at `agent.go:1038`, `SetMocksWithWindow` at `:1217` — and staging is also where the set boundary cleared `firstWindowStart`. The seed was wiped microseconds after it was written, every time.

It looked covered because the existing tests use a fresh manager, where the clear has nothing to remove, and they seed *after* staging — the inverse of production order. That inversion is exactly why this shipped.

Writing the seed straight into `firstWindowStart` cannot work for a second reason: test sets are recorded chronologically, so set N+1's cutoff is always **later** than set N's, and the "only ever lower" guard refuses it. Set N+1 would run its whole replay on set N's cutoff.

**Fix.** The seed is parked in a `cutoffSeeded` field and **installed** by staging instead of cleared — zero when nothing was seeded, which is exactly the historical behaviour. `ResetForReplaySession` clears the park, so a set that aborts between seeding and staging (the `"no mocks stored for client ID"` bail at `agent.go:1080`, the `loadPerTestMocks` error at `:1133`) cannot hand its cutoff to the next set.

**Impact.** Without the seed the cutoff follows whichever test *fires* first rather than the set's earliest *recorded* test. With a `--test-sets` selection, an ignored test, or the streaming deferral, mocks belonging to a test that never runs fall before it, are classified startup-init rather than dropped as previous-test bleed, and are served as bootstrap traffic.

## 2. Departing and startup-only kinds never bumped their per-kind revision

The walk built `touchedAll` from the new input slices and then re-read `filteredByKind`/`unfilteredByKind` **after** `setFilteredMocks`/`setUnFilteredMocks` had already swapped those maps — so it read the *new* maps and was exactly redundant with the loops above it. A kind leaving the pool published nothing, so a consumer caching an index under `RevisionByKind` never learns its mocks are gone and keeps serving the previous set's index.

A kind living only in the startup tier was missed in **both** directions: during BaseTime staging `filteredForTree` is nil, so it never enters `filteredByKind` either.

**Fix.** Harvest the outgoing kinds *before* any tier is swapped, including a walk of the old startup tree.

**Cost.** Measured on a real `MockManager`, per `SetMocksWithWindow` call: 100 startup mocks 19.8µs → 20.8µs; 1 000: 252µs → 297µs; 10 000: 2.33ms → 2.60ms. That is 5–18% on top of an O(n) startup-tree rebuild the function already performs, i.e. the same asymptotic class. `oldStartup` is snapshotted under `treesMu.RLock` and walked under the tree's own `RLock`, so a concurrent insert can only be missed (benign — no bump for a kind that is arriving), never observed torn.

## Testing

Four new tests plus a `HasFirstTestFired`/`WindowSnapshot` assertion on the new install path. Mutation matrix:

| mutation | caught by |
|---|---|
| install → clear-to-zero at the boundary | both `SeedStartupCutoff` staging tests |
| remove the `boundaryPending` park branch | both |
| revert `outgoingKinds` to the post-swap read | **both** `BumpsRevisionForDepartingKinds` subtests |
| remove **only** the startup-tree walk | the `startup tier` subtest alone |
| drop the reset's park clear | `AbortedSetDoesNotLeakItsCutoffToTheNext` |

The startup subtest is genuinely on the startup path: BaseTime staging sets `filteredForTree = nil`, so the mock lands only in the startup tree and the bump can only come from the walk.

`gofmt`, `go vet`, and the full `./pkg/agent/proxy/...` suite pass under `-race`. The one failure is `TestSetupJavaTrustStoreEnv_SetsMergedStore`, a root-owned `/tmp/keploy-java-truststore.jks` on this machine — it fails identically on unmodified `main`.

## Note for downstream

`FirstTestWindowStart` now returns the seeded cutoff during a set's staging window rather than the zero time. A non-zero value there still does **not** mean a test has fired — `HasFirstTestFired` and `WindowSnapshot` read `testFiredThisSet`, which staging explicitly clears in the same block. The stale doc comments that said otherwise are corrected.

Blocks keploy/integrations#279, which gates its postgres index rebuild on `RevisionByKind` and needs defect 2 fixed to be safe.
