### PR TITLE
fix(replay): index startup-tier mocks so their hit counts are recorded

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -49,3 +49,11 @@ jobs:
 
       - name: Running Unit Tests
         run: go test ./...
+
+      # The mock-manager's concurrency guards — the tier-key/HitCount race and
+      # the hitMu/treesMu lock order — are only meaningful under -race: without
+      # it their tests pass on a build that races, so they read as coverage
+      # while proving nothing. Scoped to this package rather than the whole
+      # tree to keep the lane fast.
+      - name: Running Race Detector (agent proxy)
+        run: go test -race -count=1 ./pkg/agent/proxy/

--- a/pkg/agent/proxy/mockmanager.go
+++ b/pkg/agent/proxy/mockmanager.go
@@ -1225,9 +1225,9 @@ func (m *MockManager) SetMocksWithWindowThreeTier(filtered, unfiltered, startup 
 func (m *MockManager) addToHitIndexIfAbsent(mocks []*models.Mock) {
 	m.hitMu.Lock()
 	defer m.hitMu.Unlock()
-	if m.hitIdx == nil {
-		m.hitIdx = make(map[string]*models.Mock, len(mocks))
-	}
+	// No nil check: NewMockManager allocates hitIdx and rebuildHitIndex only
+	// ever assigns a non-nil map, so a nil here would be a construction bug
+	// that a silent re-allocation would hide.
 	for _, mk := range mocks {
 		if mk == nil || mk.Name == "" {
 			continue

--- a/pkg/agent/proxy/mockmanager.go
+++ b/pkg/agent/proxy/mockmanager.go
@@ -22,6 +22,11 @@ import (
 //	                          bump revisions; revMu is a leaf lock —
 //	                          never re-acquire swapMu/treesMu from under it)
 //	swapMu  →  consumedMu    (independent; never hold consumedMu then swapMu)
+//	hitMu   →  treesMu  →  connMu  →  TreeDb.mu
+//	                         (bumpHitCount's slow path; rebuildHitIndex and
+//	                          addToHitIndexIfAbsent take hitMu as a LEAF —
+//	                          never acquire treesMu from under either, and
+//	                          never take hitMu while holding treesMu)
 //
 // Any new code path that acquires more than one of these MUST take them
 // in the declared order. Readers of {mock pool, test window} as an
@@ -365,8 +370,10 @@ func (m *MockManager) IsClosed() bool {
 //   - sweeperStop / closed: the idle sweeper goroutine keeps running
 //     across the reset; closing it would stop the per-connection
 //     idle reaping for the rest of the replay.
-//   - hitIdx: rebuilt by SetFilteredMocks/SetUnFilteredMocks on the
-//     next mock load, so an explicit clear here is redundant.
+//   - hitIdx: rebuilt by the next SetMocksWithWindow (NOT by a bare
+//     SetFilteredMocks/SetUnFilteredMocks), so an explicit clear here
+//     is redundant only because Proxy.Mock always follows this reset
+//     with a staging SetMocksWithWindow.
 //
 // Safe to call concurrently with active matchers — connMu guards
 // the maps and noConnMocks is a sync.Map. Matchers holding stale
@@ -956,9 +963,7 @@ func (m *MockManager) SetMocksWithWindow(filtered, unfiltered []*models.Mock, st
 		// ID on the copy. mk.TestModeInfo.ID is left untouched so a
 		// later SetUnFilteredMocks re-stamp does not corrupt the
 		// startup tree's idIndex.
-		startupKey := mk.TestModeInfo
-		startupKey.ID = idx
-		newStartup.insert(startupKey, mk)
+		newStartup.insert(tierKey(mk, idx), mk)
 	}
 	// Harvest the kinds present BEFORE any tier is swapped.
 	//
@@ -1063,7 +1068,20 @@ func (m *MockManager) SetMocksWithWindow(filtered, unfiltered []*models.Mock, st
 	// Rebuild the HitCount name→*Mock index so MarkMockAsUsed takes
 	// the O(1) fast path. Called after the tree swap so the index
 	// always points at the freshest mock pointers.
-	m.rebuildHitIndex(filteredForTree, unfilteredForTree)
+	// The startup tier is included: without it a startup-only mock never enters
+	// hitIdx, so MarkMockAsUsed on one takes the exclusive-lock slow path,
+	// walks the filtered tree, the unfiltered tree and every connection tree,
+	// finds nothing and seeds nothing — repeating that walk on every call for a
+	// mock whose HitCount never moves. Session and connection mocks copied into
+	// startup during BaseTime staging are already covered via unfilteredForTree;
+	// the ones that miss are those the startup tier alone holds.
+	//
+	// startupInit goes FIRST because the index resolves duplicate names to the
+	// LAST writer. Passing it last would silently make a startup mock outrank a
+	// session or per-test mock of the same name, inverting the precedence this
+	// call has always had (session over per-test). Names are not enforced
+	// unique by the manager — see sameMock — so the order has to be deliberate.
+	m.rebuildHitIndex(startupInit, filteredForTree, unfilteredForTree)
 
 	// Seed per-connID trees for connection-scoped mocks so
 	// GetConnectionMocks takes the O(1) path from the first lookup.
@@ -1164,26 +1182,59 @@ func (m *MockManager) SetMocksWithWindowThreeTier(filtered, unfiltered, startup 
 	// contribute connection-scoped mocks that the heuristic can't
 	// derive on its own.
 	m.SetMocksWithWindow(filtered, unfiltered, start, end)
-	m.swapMu.Lock()
-	defer m.swapMu.Unlock()
-	m.treesMu.Lock()
-	defer m.treesMu.Unlock()
-	if m.startup == nil {
-		m.startup = NewTreeDb(customComparator)
+	// Scoped so swapMu and treesMu are RELEASED before hitIdx is seeded below.
+	// bumpHitCount's slow path takes hitMu and then treesMu; seeding from in
+	// here would take them in the opposite order and the two paths would
+	// deadlock on each other.
+	func() {
+		m.swapMu.Lock()
+		defer m.swapMu.Unlock()
+		m.treesMu.Lock()
+		defer m.treesMu.Unlock()
+		if m.startup == nil {
+			m.startup = NewTreeDb(customComparator)
+		}
+		for idx, mk := range startup {
+			if mk == nil {
+				continue
+			}
+			if mk.TestModeInfo.SortOrder == 0 {
+				mk.TestModeInfo.SortOrder = int64(idx) + 1
+			}
+			// Tier-local key with an ID offset by a large constant so it cannot
+			// collide with the legacy SetMocksWithWindow's startup IDs (0..N).
+			m.startup.insert(tierKey(mk, 1_000_000+idx), mk)
+		}
+	}()
+	// The inserts above happen AFTER the SetMocksWithWindow already rebuilt
+	// hitIdx, so without this they could never reach the index and
+	// MarkMockAsUsed on one would take the exclusive-lock slow path — which
+	// does not search the startup tree — find nothing, and seed nothing.
+	// Additive, so a name already claimed by the per-test or session tier keeps
+	// its entry rather than being outranked by an explicit startup mock.
+	m.addToHitIndexIfAbsent(startup)
+}
+
+// addToHitIndexIfAbsent seeds hitIdx for mocks inserted into a tier outside
+// SetMocksWithWindow's rebuild. It never displaces an existing entry: the
+// rebuild's precedence (session over per-test over startup) is authoritative.
+//
+// Takes hitMu as a LEAF — callers must not hold treesMu, because
+// bumpHitCount's slow path acquires hitMu then treesMu and the reverse order
+// deadlocks.
+func (m *MockManager) addToHitIndexIfAbsent(mocks []*models.Mock) {
+	m.hitMu.Lock()
+	defer m.hitMu.Unlock()
+	if m.hitIdx == nil {
+		m.hitIdx = make(map[string]*models.Mock, len(mocks))
 	}
-	for idx, mk := range startup {
-		if mk == nil {
+	for _, mk := range mocks {
+		if mk == nil || mk.Name == "" {
 			continue
 		}
-		if mk.TestModeInfo.SortOrder == 0 {
-			mk.TestModeInfo.SortOrder = int64(idx) + 1
+		if _, ok := m.hitIdx[mk.Name]; !ok {
+			m.hitIdx[mk.Name] = mk
 		}
-		// Tier-local key: copy TestModeInfo and stamp an ID offset.
-		// Offset by a large constant so it cannot collide with the
-		// legacy SetMocksWithWindow's startup IDs (idx 0..N).
-		startupKey := mk.TestModeInfo
-		startupKey.ID = 1_000_000 + idx
-		m.startup.insert(startupKey, mk)
 	}
 }
 
@@ -2381,11 +2432,36 @@ func (m *MockManager) bumpHitCount(name string, kind models.Kind) {
 }
 
 // rebuildHitIndex walks the given mock slices and replaces m.hitIdx
-// with a fresh name → *Mock map. Called from SetFilteredMocks +
-// SetUnFilteredMocks after their tree swap so the fast-path bump
-// sees the new pool. Collisions (duplicate names across pools)
-// resolve to the last inserted pointer — acceptable for a telemetry
-// counter; the reuse metric aggregates by name anyway.
+// Its sole caller is SetMocksWithWindow, after all three tier swaps, so the
+// fast-path bump sees the new pool. A tier populated outside that call — the
+// explicit startup slice in SetMocksWithWindowThreeTier — must seed itself via
+// addToHitIndexIfAbsent, or its mocks never reach the index at all.
+//
+// NOTE: a bare SetFilteredMocks / SetUnFilteredMocks swaps its tree WITHOUT
+// rebuilding here, leaving hitIdx pointing at the previous pool.
+// tierKey builds a mock's tier-local tree key with an explicit ID.
+//
+// It copies field by field rather than taking a struct copy of TestModeInfo,
+// because HitCount lives in that struct and is written with atomic.AddUint64 by
+// bumpHitCount. A wholesale copy reads it non-atomically and races every
+// concurrent bump — benign in effect (customComparator orders on SortOrder and
+// ID alone, so HitCount cannot affect placement) but undefined behaviour under
+// the Go memory model, and it trips -race. The key genuinely does not need the
+// counter, so the cleanest fix is not to read it.
+func tierKey(mk *models.Mock, id int) models.TestModeInfo {
+	return models.TestModeInfo{
+		ID:              id,
+		IsFiltered:      mk.TestModeInfo.IsFiltered,
+		SortOrder:       mk.TestModeInfo.SortOrder,
+		Lifetime:        mk.TestModeInfo.Lifetime,
+		LifetimeDerived: mk.TestModeInfo.LifetimeDerived,
+		IsStartup:       mk.TestModeInfo.IsStartup,
+	}
+}
+
+// rebuildHitIndex REPLACES hitIdx with a fresh name → *Mock map built from the
+// given slices, in order: a duplicate name resolves to the LAST slice that
+// carries it, so callers pass tiers lowest-precedence first.
 func (m *MockManager) rebuildHitIndex(slices ...[]*models.Mock) {
 	total := 0
 	for _, s := range slices {

--- a/pkg/agent/proxy/mockmanager_race_test.go
+++ b/pkg/agent/proxy/mockmanager_race_test.go
@@ -1,0 +1,142 @@
+package proxy
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// Building a tier-local tree key must not read HitCount.
+//
+// The key used to be a wholesale copy of TestModeInfo, and HitCount lives in
+// that struct and is written with atomic.AddUint64 by bumpHitCount — so every
+// key build raced every concurrent bump. It was latent for the startup tier
+// only because startup mocks were never bumped; indexing them makes it live.
+//
+// Benign in effect (customComparator orders on SortOrder and ID alone, so
+// HitCount cannot affect placement) but undefined behaviour, and it trips
+// -race. Run this package with -race or the test proves nothing.
+func TestTierKeyDoesNotRaceWithHitCountBumps(t *testing.T) {
+	mm := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+	defer mm.Close()
+	at := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	pool := make([]*models.Mock, 0, 20)
+	for i := 0; i < 20; i++ {
+		pool = append(pool, newMockForTest("m"+string(rune('a'+i)), at.Add(-time.Minute), models.LifetimePerTest))
+	}
+	mm.SetMocksWithWindow(pool, nil, models.BaseTime, time.Now())
+	mm.SetMocksWithWindow(pool, nil, at, at.Add(time.Second))
+	// Real callers pass a mock they matched out of a pool snapshot, not a live
+	// dereference of the tree pointer — MarkMockAsUsed takes models.Mock BY
+	// VALUE, so `*livePointer` would copy HitCount non-atomically in the
+	// CALLER. Snapshot once, like a matcher does.
+	snaps := make([]models.Mock, 0, len(pool))
+	for _, mk := range pool {
+		snaps = append(snaps, *mk)
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					for i := range snaps {
+						mm.MarkMockAsUsed(snaps[i])
+					}
+				}
+			}
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				mm.SetMocksWithWindow(pool, nil, at, at.Add(time.Second))
+			}
+		}
+	}()
+	time.Sleep(2 * time.Second)
+	close(stop)
+	wg.Wait()
+}
+
+// SetMocksWithWindowThreeTier must not hold treesMu while seeding hitIdx.
+//
+// bumpHitCount's slow path takes hitMu and THEN treesMu. Seeding from inside
+// the tree-swap block takes them in the opposite order, so a ThreeTier call
+// racing a MarkMockAsUsed miss deadlocks: one goroutine holds treesMu waiting
+// for hitMu, the other holds hitMu waiting for treesMu. An ordinary run never
+// shows it — the window is the few instructions between the two acquisitions.
+func TestThreeTierSeedingDoesNotInvertTheHitMuLockOrder(t *testing.T) {
+	mm := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+	defer mm.Close()
+
+	at := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	startup := make([]*models.Mock, 0, 16)
+	for i := 0; i < 16; i++ {
+		startup = append(startup, newMockForTest("tt"+string(rune('a'+i)), at.Add(-time.Minute), models.LifetimePerTest))
+	}
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Writers: repeatedly take swapMu -> treesMu, then seed hitIdx.
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					mm.SetMocksWithWindowThreeTier(nil, nil, startup, at, at.Add(time.Second))
+				}
+			}
+		}()
+	}
+	// Readers: force the slow path (a name in no tree) so it takes
+	// hitMu -> treesMu, the opposite order.
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					mm.MarkMockAsUsed(models.Mock{Name: "absent-everywhere", Kind: models.HTTP})
+				}
+			}
+		}()
+	}
+
+	finished := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(finished)
+	}()
+
+	time.Sleep(2 * time.Second)
+	close(done)
+	select {
+	case <-finished:
+	case <-time.After(30 * time.Second):
+		t.Fatal("deadlock: ThreeTier seeded hitIdx while holding treesMu, inverting the " +
+			"hitMu -> treesMu order that bumpHitCount's slow path takes")
+	}
+}

--- a/pkg/agent/proxy/mockmanager_race_test.go
+++ b/pkg/agent/proxy/mockmanager_race_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -29,10 +30,15 @@ func TestTierKeyDoesNotRaceWithHitCountBumps(t *testing.T) {
 	}
 	mm.SetMocksWithWindow(pool, nil, models.BaseTime, time.Now())
 	mm.SetMocksWithWindow(pool, nil, at, at.Add(time.Second))
-	// Real callers pass a mock they matched out of a pool snapshot, not a live
-	// dereference of the tree pointer — MarkMockAsUsed takes models.Mock BY
-	// VALUE, so `*livePointer` would copy HitCount non-atomically in the
-	// CALLER. Snapshot once, like a matcher does.
+	// Snapshot once so this test isolates the MANAGER's half of the race.
+	//
+	// It is not what every caller does: the consume doors take models.Mock BY
+	// VALUE and real callers dereference a live tree pointer into them —
+	// http/match.go:1209 `deleteMock := *matchedMock`, mysql/replayer/conn.go:764
+	// `DeleteUnFilteredMock(*initialHandshakeMock)`. That copy reads HitCount
+	// non-atomically in the CALLER and still races after this fix. tierKey
+	// closes the manager's half only; closing the caller's half means changing
+	// the by-value API, which is a separate change.
 	snaps := make([]models.Mock, 0, len(pool))
 	for _, mk := range pool {
 		snaps = append(snaps, *mk)
@@ -138,5 +144,63 @@ func TestThreeTierSeedingDoesNotInvertTheHitMuLockOrder(t *testing.T) {
 	case <-time.After(30 * time.Second):
 		t.Fatal("deadlock: ThreeTier seeded hitIdx while holding treesMu, inverting the " +
 			"hitMu -> treesMu order that bumpHitCount's slow path takes")
+	}
+}
+
+// tierKey hand-copies TestModeInfo field by field (to avoid reading HitCount),
+// so the field list is a maintenance hazard: drop one and the key silently
+// loses it. SortOrder is the dangerous one — customComparator orders on it, and
+// DeleteStartupMock's contract depends on the startup tier staying in recorded
+// order — but nothing else in the package asserts startup ordering, so the
+// omission compiles and the whole suite stays green.
+func TestTierKeyPreservesEveryFieldButHitCount(t *testing.T) {
+	src := &models.Mock{
+		Name: "m",
+		Kind: models.HTTP,
+		TestModeInfo: models.TestModeInfo{
+			ID:              7,
+			IsFiltered:      true,
+			SortOrder:       42,
+			Lifetime:        models.LifetimeSession,
+			LifetimeDerived: true,
+			HitCount:        99,
+			IsStartup:       true,
+		},
+	}
+
+	got := tierKey(src, 123)
+
+	if got.ID != 123 {
+		t.Fatalf("ID = %d, want the explicit 123", got.ID)
+	}
+	if got.SortOrder != 42 {
+		t.Fatal("SortOrder was dropped: customComparator orders on it, so the startup " +
+			"tier would lose its recorded order and DeleteStartupMock's chronological " +
+			"contract with it")
+	}
+	if !got.IsFiltered {
+		t.Fatal("IsFiltered was dropped")
+	}
+	if got.Lifetime != models.LifetimeSession {
+		t.Fatal("Lifetime was dropped: tier routing reads it directly")
+	}
+	if !got.LifetimeDerived {
+		t.Fatal("LifetimeDerived was dropped: DeriveLifetime would re-run and could " +
+			"reclassify the mock")
+	}
+	if !got.IsStartup {
+		t.Fatal("IsStartup was dropped")
+	}
+	if got.HitCount != 0 {
+		t.Fatalf("HitCount = %d, want 0: reading it is exactly the race tierKey exists "+
+			"to avoid", got.HitCount)
+	}
+
+	// Guard the hand-maintained list itself: if a field is ADDED to
+	// TestModeInfo, tierKey must be updated to carry it (or deliberately not).
+	if n := reflect.TypeOf(models.TestModeInfo{}).NumField(); n != 7 {
+		t.Fatalf("TestModeInfo now has %d fields, not 7: tierKey copies them by hand, "+
+			"so decide explicitly whether the new field belongs in a tree key and "+
+			"update this count", n)
 	}
 }

--- a/pkg/agent/proxy/mockmanager_wave2_test.go
+++ b/pkg/agent/proxy/mockmanager_wave2_test.go
@@ -12,6 +12,7 @@
 package proxy
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1638,5 +1639,127 @@ func TestSeedStartupCutoff_AbortedSetDoesNotLeakItsCutoffToTheNext(t *testing.T)
 	if got := mm.FirstTestWindowStart(); !got.IsZero() {
 		t.Fatalf("cutoff = %v, want zero: an unseeded set inherited a parked cutoff "+
 			"from an aborted earlier set", got)
+	}
+}
+
+// MarkMockAsUsed must move a startup-tier mock's HitCount.
+//
+// rebuildHitIndex was handed only the per-test and session slices, and
+// bumpHitCount's slow path walked filteredByKind, unfilteredByKind and the
+// connection trees — never the startup tree. A startup-only mock therefore
+// missed the index forever: every call took the process-wide exclusive hitMu,
+// walked all of those trees, found nothing, and seeded nothing, so the next
+// call repeated the whole walk — and the mock's HitCount never moved.
+func TestMarkMockAsUsed_CountsStartupTierMocks(t *testing.T) {
+	mm := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+	t.Cleanup(func() { mm.Close() })
+
+	first := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	boot := newMockForTest("boot-mock", first.Add(-time.Minute), models.LifetimePerTest)
+
+	// Stage, then open a window so the boot mock is classified startup-init.
+	mm.SetMocksWithWindow([]*models.Mock{boot}, nil, models.BaseTime, time.Now())
+	mm.SetMocksWithWindow([]*models.Mock{boot}, nil, first, first.Add(time.Second))
+
+	startup, err := mm.GetStartupMocks()
+	if err != nil {
+		t.Fatalf("GetStartupMocks: %v", err)
+	}
+	if !containsMockNamed(startup, "boot-mock") {
+		t.Fatal("precondition: the mock must be in the startup tier")
+	}
+
+	if !mm.MarkMockAsUsed(*boot) {
+		t.Fatal("MarkMockAsUsed reported failure")
+	}
+
+	live, err := mm.GetStartupMocks()
+	if err != nil {
+		t.Fatalf("GetStartupMocks: %v", err)
+	}
+	for _, mk := range live {
+		if mk != nil && mk.Name == "boot-mock" {
+			if got := atomic.LoadUint64(&mk.TestModeInfo.HitCount); got == 0 {
+				t.Fatal("the startup-tier mock's HitCount is still 0: it is absent from " +
+					"hitIdx and from the slow path's search, so every MarkMockAsUsed " +
+					"takes the exclusive lock, walks every other tree and seeds nothing")
+			}
+			return
+		}
+	}
+	t.Fatal("the startup mock disappeared from the tier")
+}
+
+// SetMocksWithWindowThreeTier inserts its explicit startup slice AFTER the
+// SetMocksWithWindow it delegates to has already rebuilt hitIdx, so those mocks
+// could never reach the index — and the slow path does not search the startup
+// tree. Their HitCount could never move at all.
+func TestSetMocksWithWindowThreeTier_IndexesItsExplicitStartupSlice(t *testing.T) {
+	mm := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+	t.Cleanup(func() { mm.Close() })
+
+	at := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	boot := newMockForTest("threetier-boot", at.Add(-time.Minute), models.LifetimePerTest)
+
+	mm.SetMocksWithWindowThreeTier(nil, nil, []*models.Mock{boot}, at, at.Add(time.Second))
+
+	mm.hitMu.RLock()
+	_, indexed := mm.hitIdx["threetier-boot"]
+	mm.hitMu.RUnlock()
+	if !indexed {
+		t.Fatal("the explicit startup mock never reached hitIdx: it is inserted after " +
+			"SetMocksWithWindow's rebuild, and the slow path does not search the startup tree")
+	}
+
+	if !mm.MarkMockAsUsed(*boot) {
+		t.Fatal("MarkMockAsUsed reported failure")
+	}
+	if got := atomic.LoadUint64(&boot.TestModeInfo.HitCount); got == 0 {
+		t.Fatal("HitCount did not move for a mock in the explicit startup slice")
+	}
+
+	// The seeding is additive, never displacing: an explicit startup mock must
+	// not steal the index entry of a session mock with the same name, or the
+	// rebuild's precedence is inverted by the back door.
+	mm2 := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+	t.Cleanup(func() { mm2.Close() })
+	sessionCopy := newMockForTest("dup-name", at.Add(time.Second), models.LifetimeSession)
+	startupCopy := newMockForTest("dup-name", at.Add(-time.Minute), models.LifetimePerTest)
+
+	mm2.SetMocksWithWindowThreeTier(nil, []*models.Mock{sessionCopy},
+		[]*models.Mock{startupCopy}, at, at.Add(time.Minute))
+
+	mm2.hitMu.RLock()
+	claimed := mm2.hitIdx["dup-name"]
+	mm2.hitMu.RUnlock()
+	if claimed != sessionCopy {
+		t.Fatal("the explicit startup mock displaced the session mock's index entry; " +
+			"addToHitIndexIfAbsent must not overwrite what the rebuild established")
+	}
+}
+
+// A duplicate name must not let a startup mock outrank a session or per-test
+// one. rebuildHitIndex resolves duplicates to the LAST slice that carries the
+// name, so the tier order it is called with is load-bearing: passing startup
+// last would silently invert the precedence this call has always had.
+func TestRebuildHitIndex_StartupDoesNotOutrankTheOtherTiers(t *testing.T) {
+	mm := NewMockManager(NewTreeDb(customComparator), NewTreeDb(customComparator), zap.NewNop())
+	t.Cleanup(func() { mm.Close() })
+
+	at := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	// Same name, distinct pointers: one lands in the startup tier (recorded
+	// before the window), one in the session tier.
+	bootCopy := newMockForTest("shared-name", at.Add(-time.Minute), models.LifetimePerTest)
+	sessionCopy := newMockForTest("shared-name", at.Add(time.Second), models.LifetimeSession)
+
+	mm.SetMocksWithWindow([]*models.Mock{bootCopy}, []*models.Mock{sessionCopy}, at, at.Add(time.Minute))
+
+	mm.hitMu.RLock()
+	got := mm.hitIdx["shared-name"]
+	mm.hitMu.RUnlock()
+	if got != sessionCopy {
+		t.Fatal("a startup-tier mock claimed the index entry over the session-tier mock " +
+			"of the same name; rebuildHitIndex must be called with startup FIRST so it " +
+			"loses the duplicate-name tie")
 	}
 }


### PR DESCRIPTION
## Scope: a latent defect, not a live cost

`MarkMockAsUsed` is an exported `MockMemDb` method with **no in-tree caller** — the integrations interface declares it, and out-of-tree parsers consume through it. `SessionMockHitCounts`, which reads what it writes, is likewise declared and never invoked in this repo. So this fixes a defect in that API's contract; it is not a cost any current keploy request path pays. (An earlier revision of this PR claimed a live per-request lock cost. That was wrong.)

## The defect

`rebuildHitIndex` was called with only the per-test and session slices, and `bumpHitCount`'s slow path walks `filteredByKind`, `unfilteredByKind` and the connection trees — **never the startup tree**. A mock the startup tier alone holds therefore missed `hitIdx` entirely:

1. `MarkMockAsUsed` → `bumpHitCount` misses the fast path;
2. takes `m.hitMu` **exclusively** — a process-wide lock;
3. walks the filtered tree, the unfiltered tree, and every connection tree;
4. finds nothing, seeds nothing (the seed is guarded on `target != nil`);
5. the next call repeats the walk. `HitCount` never moves.

Session and connection mocks copied into the startup tree during BaseTime staging were **already covered** — they live in `unfilteredForTree` too. What missed is what the startup tier alone holds.

## Two independent gaps, each fixed where it is

**1. `SetMocksWithWindow`** now passes `startupInit` to `rebuildHitIndex` — **first**. The index resolves a duplicate name to the *last* slice carrying it, so passing startup last would silently make a startup mock outrank a session or per-test mock of the same name, inverting the precedence this call has always had. `sameMock`'s own doc notes names are not enforced unique, so the order is deliberate rather than incidental.

**2. `SetMocksWithWindowThreeTier`** inserts its explicit startup slice *after* the `SetMocksWithWindow` it delegates to has already rebuilt the index — so those mocks could never reach it **by any route**. It now seeds them itself via `addToHitIndexIfAbsent`, which is additive: a name already claimed by another tier keeps its entry, so the rebuild's precedence cannot be inverted through the back door.

The seeding runs **outside** ThreeTier's tree-swap block, and that is load-bearing rather than stylistic: `bumpHitCount`'s slow path takes `hitMu` then `treesMu`, so seeding from inside the block takes them in the opposite order and the two paths deadlock on each other. Reproduced — with the seeding moved inside, `TestThreeTierSeedingDoesNotInvertTheHitMuLockOrder` hangs past its 30s bound; outside, it finishes in 3s.

### Why gap 2 is fixed at source, not by extending the slow path

Adding the startup tree to `bumpHitCount`'s walk would work, and an earlier revision did that. It is the wrong trade:

- **the walk is paid on every miss**, including a name present in no tree at all — the one case that still misses forever, since there is no negative cache — and during BaseTime staging the startup tree is the *entire staged pool*;
- it makes the exclusive `hitMu` wait on `DeleteStartupMock`, which holds the startup tree's **write** lock across a full O(N) scan plus `flagMockAsUsed`. A boot consume could then stall every `MarkMockAsUsed` in the process.

Fixing each gap where it originates costs nothing on the hot path.

## Data race the indexing would otherwise make live

The tier-local tree key was a wholesale copy of `TestModeInfo`, and `HitCount` lives in that struct and is written with `atomic.AddUint64`. Every key build therefore raced every concurrent bump — latent for the startup tier only because startup mocks were never bumped. Indexing them makes it live.

`tierKey` builds the key field by field and never reads the counter, which the key does not need: `customComparator` orders on `SortOrder` and `ID` alone. Measured with the new stress test: **1 race** with the struct copy, **0** with `tierKey`.

(The same shape exists on `main` for the per-test tier in `setFilteredMocks`, which *writes* `SortOrder`/`ID` on the live mock. Pre-existing and not touched here.)

## Testing

Four mutations, each verified to compile before concluding anything — a non-compiling mutation produces zero `--- FAIL` lines and reads as a coverage gap:

| mutation | caught by |
|---|---|
| drop `startupInit` from the rebuild | `TestMarkMockAsUsed_CountsStartupTierMocks` |
| pass `startupInit` **last** (precedence inverted) | `TestRebuildHitIndex_StartupDoesNotOutrankTheOtherTiers` |
| drop ThreeTier's self-indexing | `TestSetMocksWithWindowThreeTier_IndexesItsExplicitStartupSlice` |
| make ThreeTier's seeding displace an existing entry | same |

Plus two concurrency tests: `TestTierKeyDoesNotRaceWithHitCountBumps` (needs `-race` to mean anything, and says so) and `TestThreeTierSeedingDoesNotInvertTheHitMuLockOrder`, which is mutation-verified — moving the seeding back inside the locked block makes it hang and fail.

`gofmt`, `go vet`, and `./pkg/agent/proxy/...` green under `-race`. The one failure is `TestSetupJavaTrustStoreEnv_SetsMergedStore` — root-owned `/tmp/keploy-java-truststore.jks` on this machine; it fails identically on unmodified `main`.

## Comments corrected

Three said the opposite of the code: `rebuildHitIndex` is called from *neither* `SetFilteredMocks` nor `SetUnFilteredMocks` (its sole caller is `SetMocksWithWindow`); `ResetForReplaySession` repeated that claim; and the lock-ordering block never mentioned `hitMu` despite two `hitMu → treesMu` nestings. A bare `SetFilteredMocks`/`SetUnFilteredMocks` still swaps its tree without rebuilding the index — now documented rather than silently assumed away.

## Where it was found

Surfaced while reviewing keploy/enterprise#2491, which routes hbase region discovery and boot reads through the startup tier. Not hbase-specific — redis, couchbase, memcached, zookeeper and pulsar all serve from the startup pool through the same door.