### PR TITLE
fix(agent): allocate the agent port outside the kernel's local port range

### DIFF
--- a/pkg/platform/http/agent.go
+++ b/pkg/platform/http/agent.go
@@ -1346,13 +1346,15 @@ func (a *AgentClient) Setup(ctx context.Context, cmd string, opts models.SetupOp
 	}
 
 	// Check and allocate available ports for proxy and DNS
-	proxyPort, err := utils.EnsureAvailablePorts(a.conf.ProxyPort) // check if the proxy port provided by user is unused
+	// Exclude the ports already handed out in this setup: none of them is bound
+	// yet, so a later draw could otherwise legitimately return one of them.
+	proxyPort, err := utils.EnsureAvailablePorts(a.conf.ProxyPort, agentPort) // check if the proxy port provided by user is unused
 	if err != nil {
 		utils.LogError(a.logger, err, "failed to ensure available ports for proxy")
 		return err
 	}
 
-	dnsPort, err := utils.EnsureAvailablePorts(a.conf.DNSPort) // check if the dns port provided by user is unused
+	dnsPort, err := utils.EnsureAvailablePorts(a.conf.DNSPort, agentPort, proxyPort) // check if the dns port provided by user is unused
 	if err != nil {
 		utils.LogError(a.logger, err, "failed to ensure available ports for DNS")
 		return err

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"debug/elf"
 	"encoding/binary"
@@ -12,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"net"
 	"net/http"
 	"net/url"
@@ -1178,16 +1180,115 @@ func findChildPIDs(parentPID int) ([]int, error) {
 	return childPIDs, nil
 }
 
-// GetAvailablePort finds and returns an available port on the system
+// ephemeralPortRange reports the kernel's local port range and whether it could
+// actually be determined.
+//
+// known=false means "this platform's range is unknown to us", NOT "assume
+// Linux". Guessing is worse than not acting: macOS and Windows both default to
+// 49152-65535, so assuming the Linux 32768-60999 would make GetAvailablePort
+// allocate from 61000-65534 — entirely INSIDE the real ephemeral range on those
+// platforms — while shrinking the pool from 16384 to 4535 and making collisions
+// materially more likely than plain :0.
+func ephemeralPortRange() (lo, hi uint32, known bool) {
+	return ephemeralPortRangeFrom(os.ReadFile)
+}
+
+// ephemeralPortRangeFrom takes the file reader as a parameter so the
+// unknown-platform path is testable. On Linux the read always succeeds, which
+// would otherwise leave that branch dead code no test can reach — and it is the
+// branch that decides whether the allocator acts at all.
+func ephemeralPortRangeFrom(readFile func(string) ([]byte, error)) (lo, hi uint32, known bool) {
+	b, err := readFile("/proc/sys/net/ipv4/ip_local_port_range")
+	if err != nil {
+		return 0, 0, false
+	}
+	return parseEphemeralPortRange(string(b))
+}
+
+// Linux's documented default, used when ip_local_port_range exists but its
+// contents are malformed.
+const (
+	defaultEphemeralLo uint32 = 32768
+	defaultEphemeralHi uint32 = 60999
+)
+
+// parseEphemeralPortRange parses the two-field content of ip_local_port_range.
+// Split out from the file read so its fallbacks are testable: on a normal Linux
+// box the read always succeeds, which would leave every fallback branch dead
+// code no test could reach.
+func parseEphemeralPortRange(content string) (lo, hi uint32, ok bool) {
+	f := strings.Fields(content)
+	if len(f) != 2 {
+		return defaultEphemeralLo, defaultEphemeralHi, true
+	}
+	l, err1 := strconv.ParseUint(f[0], 10, 32)
+	h, err2 := strconv.ParseUint(f[1], 10, 32)
+	if err1 != nil || err2 != nil || l == 0 || h < l || h > 65535 {
+		return defaultEphemeralLo, defaultEphemeralHi, true
+	}
+	return uint32(l), uint32(h), true
+}
+
+// GetAvailablePort finds and returns an available port on the system.
+//
+// It deliberately avoids the kernel's local port range, because that range is
+// where EVERY bind(0) allocator on the machine draws from — including a second
+// keploy process doing exactly this, and Docker's dynamic host-port publisher.
+// The probe listener must be CLOSED before the number can be handed to whoever
+// will actually bind it, so anything drawing from the same range can take it in
+// between, and the eventual holder is a LIVE process that never releases it —
+// which is why the agent's bind retry cannot recover and the run dies with
+// "keploy-agent did not become ready in time".
+//
+// Measured on Linux 6.12 with the default range 32768-60999: 3000/3000
+// bind(":0") allocations landed inside it, none above. (Outbound connections
+// are NOT the thief — the kernel partitions the two, handing bind(0) odd ports
+// and connect() even ones: 1500/1500 vs 1000/1000 in the same measurement. The
+// port that failed in CI, 34467, is odd, i.e. it came from a bind(0)-class
+// allocator, not from an outbound socket.)
+//
+// So candidates come from ABOVE the range's high-water mark. This NARROWS the
+// window rather than closing it — nothing short of passing the listener itself
+// closes it — but the port no longer competes with every other bind(0) on the
+// host.
 func GetAvailablePort() (uint32, error) {
-	// Use port 0 to let the OS assign an available port
+	if _, ephemeralHi, known := ephemeralPortRange(); known && ephemeralHi < 65535 {
+		lo := ephemeralHi + 1
+		span := 65536 - lo // inclusive of 65535
+		// A random start, not a scan from the bottom. Scanning upward returns
+		// the LOWEST free port every time, so two keploy processes started
+		// moments apart — the ordinary CI pattern — are handed an identical
+		// number, each having verified it free; whichever binds second loses.
+		start := lo
+		if n, err := rand.Int(rand.Reader, big.NewInt(int64(span))); err == nil {
+			start = lo + uint32(n.Int64())
+		}
+		for i := uint32(0); i < span; i++ {
+			port := lo + ((start - lo + i) % span)
+			ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+			if err != nil {
+				continue
+			}
+			// A failed Close leaves this process holding the port for its
+			// lifetime, so the candidate is unusable AND leaked — return the
+			// error rather than continuing and leaking one fd per candidate.
+			if err := ln.Close(); err != nil {
+				return 0, fmt.Errorf("failed to release probe listener on port %d: %w", port, err)
+			}
+			return port, nil
+		}
+	}
+
+	// Either the platform's ephemeral range is unknown, or every port above it
+	// is taken, or the range reaches 65535 leaving no space. Fall back to the
+	// OS assignment rather than failing: a port that may race is strictly
+	// better than no port at all, and this is the historical behaviour.
 	listener, err := net.Listen("tcp", ":0")
 	if err != nil {
 		return 0, fmt.Errorf("failed to find available port: %w", err)
 	}
 	defer listener.Close()
 
-	// Extract the port from the listener's address
 	addr := listener.Addr().(*net.TCPAddr)
 	return uint32(addr.Port), nil
 }
@@ -1205,17 +1306,39 @@ func isPortAvailable(port uint32) bool {
 // EnsureAvailablePorts checks if the proxy and DNS ports are available.
 // If they are available, it returns them unchanged.
 // If not, it allocates new available ports for them.
-func EnsureAvailablePorts(port uint32) (uint32, error) {
-	var newPort uint32
-	var err error
-	if isPortAvailable(port) {
+//
+// exclude lists ports already handed out in this same setup. Nothing binds
+// them yet — the agent, proxy and DNS ports are all allocated before any of
+// them is used — so without this the second and third draws can legitimately
+// return a port the first already claimed, and two subsystems then race for
+// it. Narrowing allocation to above the ephemeral range makes the pool smaller
+// and that coincidence correspondingly more likely, so the exclusion is not
+// optional bookkeeping.
+func EnsureAvailablePorts(port uint32, exclude ...uint32) (uint32, error) {
+	taken := make(map[uint32]struct{}, len(exclude))
+	for _, p := range exclude {
+		taken[p] = struct{}{}
+	}
+	if _, clash := taken[port]; !clash && isPortAvailable(port) {
 		return port, nil
 	}
-	newPort, err = GetAvailablePort()
-	if err != nil {
-		return 0, fmt.Errorf("failed to allocate new proxy port: %w", err)
+	var newPort uint32
+	var err error
+	// Bounded: a handful of draws is plenty to miss a set this small, and a
+	// bound means an exhausted pool surfaces as an error rather than a hang.
+	for i := 0; i < 16; i++ {
+		newPort, err = GetAvailablePort()
+		if err != nil {
+			break
+		}
+		if _, clash := taken[newPort]; !clash {
+			return newPort, nil
+		}
 	}
-	return newPort, nil
+	if err == nil {
+		return 0, fmt.Errorf("failed to allocate a port distinct from %v", exclude)
+	}
+	return 0, fmt.Errorf("failed to allocate new port: %w", err)
 }
 
 func EnsureRmBeforeName(cmd string) string {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,6 +1,13 @@
 package utils
 
-import "testing"
+import (
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
 
 func TestContainerNameFromDockerRun(t *testing.T) {
 	cases := []struct {
@@ -20,5 +27,247 @@ func TestContainerNameFromDockerRun(t *testing.T) {
 				t.Fatalf("ContainerNameFromDockerRun(%q) = %q, want %q", tc.cmd, got, tc.want)
 			}
 		})
+	}
+}
+
+// GetAvailablePort must not hand back a port from the kernel's local port
+// range.
+//
+// The oracle is read straight from /proc, NOT from ephemeralPortRange: using
+// the production helper as its own oracle makes the test self-referential, and
+// a helper that mis-reports the range (say 32768-40000) would then pass while
+// handing out 40001-65534 — most of it inside the real range, i.e. exactly the
+// bug this test exists to catch.
+func TestGetAvailablePortAvoidsTheEphemeralRange(t *testing.T) {
+	raw, err := os.ReadFile("/proc/sys/net/ipv4/ip_local_port_range")
+	if err != nil {
+		t.Skipf("no ip_local_port_range on this platform (%v); GetAvailablePort "+
+			"correctly falls back to :0 there and there is nothing to assert", err)
+	}
+	f := strings.Fields(string(raw))
+	if len(f) != 2 {
+		t.Fatalf("unexpected ip_local_port_range content %q", raw)
+	}
+	lo64, err1 := strconv.ParseUint(f[0], 10, 32)
+	hi64, err2 := strconv.ParseUint(f[1], 10, 32)
+	if err1 != nil || err2 != nil {
+		t.Fatalf("unparseable ip_local_port_range %q", raw)
+	}
+	lo, hi := uint32(lo64), uint32(hi64)
+	if hi >= 65535 {
+		t.Skipf("kernel range reaches %d, leaving no space above it; the fallback is "+
+			"correct here and there is nothing to assert", hi)
+	}
+
+	for i := 0; i < 50; i++ {
+		port, err := GetAvailablePort()
+		if err != nil {
+			t.Fatalf("GetAvailablePort: %v", err)
+		}
+		if port == 0 {
+			t.Fatal("GetAvailablePort returned port 0")
+		}
+		if port >= lo && port <= hi {
+			t.Fatalf("GetAvailablePort returned %d, inside the kernel's local port range "+
+				"%d-%d read from /proc: every other bind(0) allocator on the machine — a "+
+				"second keploy process, Docker's host-port publisher — draws from there "+
+				"and can take it before the agent binds", port, lo, hi)
+		}
+	}
+}
+
+// The returned port must be one the function VERIFIED, not merely a number in
+// the right band.
+//
+// Asserting "the returned port is bindable" is not enough: on an idle box
+// almost any port above the ephemeral range binds, so that assertion holds by
+// luck even if the bindability probe is deleted entirely. Instead, hold a block
+// of candidates and require the function to return something outside it.
+func TestGetAvailablePortSkipsPortsAlreadyHeld(t *testing.T) {
+	if _, _, known := ephemeralPortRange(); !known {
+		t.Skip("platform range unknown; GetAvailablePort falls back to :0 here")
+	}
+	_, hi, _ := ephemeralPortRange()
+	if hi >= 65535 {
+		t.Skip("no space above the ephemeral range on this host")
+	}
+
+	// Occupy a contiguous block so a probe-less implementation, which returns
+	// whatever candidate it lands on, has a high chance of returning a held one.
+	held := map[uint32]bool{}
+	var lns []net.Listener
+	for p := hi + 1; p <= 65535 && len(lns) < 2000; p++ {
+		ln, err := net.Listen("tcp", fmt.Sprintf(":%d", p))
+		if err != nil {
+			continue
+		}
+		lns = append(lns, ln)
+		held[p] = true
+	}
+	defer func() {
+		for _, ln := range lns {
+			_ = ln.Close()
+		}
+	}()
+	if len(held) < 100 {
+		t.Skipf("could only hold %d ports; too few to discriminate", len(held))
+	}
+
+	for i := 0; i < 200; i++ {
+		port, err := GetAvailablePort()
+		if err != nil {
+			t.Fatalf("GetAvailablePort: %v", err)
+		}
+		if held[port] {
+			t.Fatalf("GetAvailablePort returned %d, a port THIS TEST is holding: the "+
+				"candidate was never verified bindable, so callers are handed ports "+
+				"that are already in use", port)
+		}
+	}
+}
+
+// Successive callers must not all be handed the SAME port.
+//
+// Scanning upward from a fixed floor returns the lowest free port every time,
+// so two keploy processes started moments apart — the ordinary CI pattern —
+// are handed an identical number, each having verified it free. Whichever
+// binds second loses, and the agent's bind retry cannot recover because the
+// winner is a live holder, not a departing one.
+//
+// Sequential rather than concurrent: concurrent callers are separated anyway
+// by the brief hold of the verification listener, so a concurrent test passes
+// even with a fixed floor and proves nothing.
+func TestGetAvailablePortDoesNotHandEveryCallerTheSamePort(t *testing.T) {
+	const n = 12
+	seen := map[uint32]int{}
+	for i := 0; i < n; i++ {
+		p, err := GetAvailablePort()
+		if err != nil {
+			t.Fatalf("GetAvailablePort: %v", err)
+		}
+		seen[p]++
+	}
+	if len(seen) < 2 {
+		t.Fatalf("%d successive calls returned %d distinct port(s): candidates are not "+
+			"randomised, so keploy processes started moments apart are handed the same "+
+			"port and one of them fails to bind", n, len(seen))
+	}
+}
+
+func TestEphemeralPortRangeIsSane(t *testing.T) {
+	lo, hi, known := ephemeralPortRange()
+	if !known {
+		// Correct on any platform without ip_local_port_range. It MUST report
+		// unknown rather than guessing: macOS and Windows both default to
+		// 49152-65535, so assuming the Linux range would allocate entirely
+		// inside the real ephemeral range there.
+		if lo != 0 || hi != 0 {
+			t.Fatalf("unknown range still reported %d-%d; callers must not act on it", lo, hi)
+		}
+		return
+	}
+	if lo == 0 || hi == 0 || hi < lo || hi > 65535 {
+		t.Fatalf("ephemeralPortRange returned %d-%d, want a sane range", lo, hi)
+	}
+}
+
+// The fallback branches are unreachable on a normal Linux box — the /proc read
+// always succeeds — so they are tested through the pure parser instead. Without
+// this, a broken default would be dead code that no test can reach.
+func TestParseEphemeralPortRange(t *testing.T) {
+	cases := []struct {
+		name   string
+		in     string
+		lo, hi uint32
+	}{
+		{"normal", "32768\t60999\n", 32768, 60999},
+		{"widened", "1024 65000\n", 1024, 65000},
+		{"one field", "32768\n", defaultEphemeralLo, defaultEphemeralHi},
+		{"three fields", "1 2 3\n", defaultEphemeralLo, defaultEphemeralHi},
+		{"empty", "", defaultEphemeralLo, defaultEphemeralHi},
+		{"non-numeric", "lo hi\n", defaultEphemeralLo, defaultEphemeralHi},
+		{"inverted", "60999 32768\n", defaultEphemeralLo, defaultEphemeralHi},
+		{"zero low", "0 60999\n", defaultEphemeralLo, defaultEphemeralHi},
+		{"out of range high", "32768 70000\n", defaultEphemeralLo, defaultEphemeralHi},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lo, hi, ok := parseEphemeralPortRange(tc.in)
+			if !ok {
+				t.Fatal("parseEphemeralPortRange reported unknown; it is only called " +
+					"when the file was read, so it must always resolve to a range")
+			}
+			if lo != tc.lo || hi != tc.hi {
+				t.Fatalf("parseEphemeralPortRange(%q) = %d-%d, want %d-%d", tc.in, lo, hi, tc.lo, tc.hi)
+			}
+		})
+	}
+
+	// The Linux default must leave usable space above it, or GetAvailablePort
+	// has nowhere to draw from on a host whose file is malformed and silently
+	// falls back to the racy :0 path. This constrains the LINUX default only —
+	// unknown platforms report known=false and fall back deliberately.
+	if defaultEphemeralHi >= 65535 {
+		t.Fatalf("Linux default high-water mark %d leaves no room above it",
+			defaultEphemeralHi)
+	}
+}
+
+// The agent, proxy and DNS ports are all allocated before ANY of them is bound,
+// so a later draw can legitimately return a port an earlier one already
+// claimed — isPortAvailable says yes, because nothing is listening on it yet.
+// Narrowing allocation to above the ephemeral range shrinks the pool and makes
+// that coincidence correspondingly more likely.
+func TestEnsureAvailablePortsHonoursTheExclusionSet(t *testing.T) {
+	// A port that IS free: without the exclusion set it is returned unchanged.
+	free, err := GetAvailablePort()
+	if err != nil {
+		t.Fatalf("GetAvailablePort: %v", err)
+	}
+
+	if got, err := EnsureAvailablePorts(free); err != nil || got != free {
+		t.Fatalf("precondition: a free port must be returned unchanged, got %d (%v)", got, err)
+	}
+
+	got, err := EnsureAvailablePorts(free, free)
+	if err != nil {
+		t.Fatalf("EnsureAvailablePorts: %v", err)
+	}
+	if got == free {
+		t.Fatalf("EnsureAvailablePorts returned %d, which the caller had already claimed: "+
+			"nothing is bound to it yet, so isPortAvailable says free and two subsystems "+
+			"end up racing for the same port", got)
+	}
+}
+
+// A platform without ip_local_port_range must report UNKNOWN, not guess.
+//
+// This is the branch that decides whether the allocator acts at all, and on
+// Linux the read always succeeds so it is dead code no ordinary test reaches.
+// Guessing the Linux range there is actively harmful: macOS and Windows both
+// default to 49152-65535, so 61000-65534 would be entirely INSIDE their real
+// ephemeral range while shrinking the pool from 16384 to 4535 — strictly worse
+// than the plain :0 the fallback gives them.
+func TestEphemeralPortRangeReportsUnknownWhenUnreadable(t *testing.T) {
+	lo, hi, known := ephemeralPortRangeFrom(func(string) ([]byte, error) {
+		return nil, os.ErrNotExist
+	})
+	if known {
+		t.Fatalf("reported a known range %d-%d on a platform with no "+
+			"ip_local_port_range; GetAvailablePort would then allocate from a band that "+
+			"is inside the real ephemeral range on macOS and Windows", lo, hi)
+	}
+	if lo != 0 || hi != 0 {
+		t.Fatalf("unknown range still returned %d-%d; callers must not act on it", lo, hi)
+	}
+
+	// A readable-but-malformed file is a different case: the platform IS Linux,
+	// so the documented default is the right answer.
+	lo, hi, known = ephemeralPortRangeFrom(func(string) ([]byte, error) {
+		return []byte("garbage\n"), nil
+	})
+	if !known || lo != defaultEphemeralLo || hi != defaultEphemeralHi {
+		t.Fatalf("malformed content gave %d-%d known=%v, want the Linux default %d-%d known=true",
+			lo, hi, known, defaultEphemeralLo, defaultEphemeralHi)
 	}
 }


### PR DESCRIPTION
## Problem

`GetAvailablePort` binds `:0`, reads the port the OS assigns, and **closes the listener** before handing the number to whoever will actually bind it.

The OS answers from `ip_local_port_range` — which is where **every `bind(0)` allocator on the machine** draws from, including a second keploy process doing exactly this, and Docker's dynamic host-port publisher. Any of them can take the port in that window, and the eventual holder is a **live** process that never releases it. That is why the agent's retry cannot recover: `listenWithRetry` exists for a port a *departing* owner is still releasing.

Observed in CI as the agent being allocated `34467`, failing to bind, and the run dying with `keploy-agent did not become ready in time`.

### The same port recurs across runs

Two independent CI runs, days apart, both failed on **`:34467`** — 363 bind attempts in the second. A genuinely random collision would not repeat the number. `bind(":0")` is repeatable enough on a given host that successive keploy jobs are handed the *same* port, and one of them collides with an agent from a previous job that is still holding it.

That is the "second keploy process" case exactly, and it is what the randomised scan start addresses independently of the range change: even within the same band, two jobs must not be handed the same number.

## Measured, not assumed

An earlier revision of this PR claimed the thief was an **outbound connection** reusing the port. That is wrong, and measuring it is what showed the real mechanism. On Linux 6.12 with the default range `32768-60999`:

```
bind(":0")         -> 3000/3000 inside the range, 0 above
bind(":0")         -> 1500/1500 ODD  ports
outbound connect() -> 1000/1000 EVEN ports
```

The kernel partitions the two allocators by parity, so an outbound socket could only reach an odd port after the ~14k even ones are exhausted. **`34467` is odd** — it came from a `bind(0)`-class allocator, not an outbound connection.

## Fix

Candidates come from **above** the range's high-water mark — space no `bind(0)` draws from. This **narrows** the window rather than closing it; nothing short of passing the listener itself closes it.

**Random scan start.** Scanning upward returns the lowest free port every time, so two keploy processes started moments apart are handed an identical number, each having verified it free, and whichever binds second loses.

**Unknown platforms fall back to `:0` instead of guessing.** macOS and Windows both default to `49152-65535`, so assuming the Linux range would allocate `61000-65534` — *entirely inside* their real ephemeral range — while shrinking the pool from 16384 to 4535. That is strictly worse than the `:0` it replaced, so `ephemeralPortRange` reports `known=false` there and the allocator declines to act.

**Exclusion set.** `EnsureAvailablePorts` now takes ports already handed out, and `Setup` threads them through. The agent, proxy and DNS ports are all allocated *before any of them is bound*, so `isPortAvailable` reports free a port an earlier draw already claimed — and the narrower band makes that coincidence likelier.

Also fixes an off-by-one that made 65535 unreachable, and a probe listener whose failed `Close` leaked the fd while leaving this process holding the port.

## Testing

The read is split behind a reader parameter and the parse behind a pure function, so the unknown-platform and malformed-content branches are reachable: on Linux the `/proc` read always succeeds, which would leave *the branch that decides whether to act at all* as dead code no test could reach.

Every mutation build-checked first — a non-compiling mutation emits zero `--- FAIL` lines and reads as a coverage gap:

| mutation | caught by |
|---|---|
| delete the bindability probe entirely | `TestGetAvailablePortSkipsPortsAlreadyHeld` |
| `ephemeralPortRange` mis-reports the high-water mark | `TestGetAvailablePortAvoidsTheEphemeralRange` |
| guess the Linux range on an unknown platform | `TestEphemeralPortRangeReportsUnknownWhenUnreadable` |
| ignore the exclusion set | `TestEnsureAvailablePortsHonoursTheExclusionSet` |
| fixed scan start instead of randomised | `TestGetAvailablePortDoesNotHandEveryCallerTheSamePort` |

Two of these — the probe deletion and the mis-reported range — killed nothing in the first revision. "The returned port is bindable" held by luck on an idle box even with the probe deleted, and the range test used the production helper as its own oracle. Both now discriminate: the first holds a block of 2000 ports and requires the result to be outside it; the second reads `/proc` directly.

`gofmt`, `go vet`, `./utils/` and `./pkg/platform/http/` green.

## Scope

Only the allocation. `listenWithRetry` is unchanged — it remains correct for the case it was written for, and is now much less likely to be the last line of defence. The structural fix is a feedback path letting the agent ask the CLI for a *different* port on bind failure; that is a larger change and this does not claim to replace it.