### PR TITLE
fix(mysql): seed the last-greeting cache on the V2 path so pooled connections keep their mocks

### DIFF
--- a/.github/workflows/mysql-tls-greeting-stitch-linux.yml
+++ b/.github/workflows/mysql-tls-greeting-stitch-linux.yml
@@ -1,0 +1,146 @@
+name: MySQL TLS Greeting-Stitch Regression (Linux)
+# Regression guard for the proxyless MySQL-over-TLS "served but NOT recorded"
+# capture shortfall.
+#
+# The bug: recording MySQL over TLS splits into two legs — a raw plaintext leg
+# carrying the server greeting + SSLRequest, and a decrypted TLS-uprobe leg
+# carrying the command phase. The greeting is stashed in TLSHandshakeStore under
+# conn:<connKey> and port:<dstPort>, and PopWait CONSUMES it. A pooled MySQL
+# connection reused across cycles yields a decrypted leg with no handshake of its
+# own, so both keys miss. resolvePreTLSGreeting has a documented last-resort
+# fallback (cachedGreeting, backed by RememberLast/Last) for exactly that case —
+# but the only caller of RememberLast was the LEGACY handleInitialHandshake,
+# which the V2 path never runs. The fallback was dead code, so such a connection
+# fell through to fetchServerGreeting, dialled a destination the capture layer
+# had only synthesized, got ECONNREFUSED, and the record was SILENTLY DISCARDED.
+# Downstream that surfaces as a dirty replay verdict with no visible error.
+#
+# These tests are also run by the normal `go test ./...` lane. This lane exists
+# because that is not enough: the defect was a DEAD FALLBACK, and the way such a
+# bug returns is for the guarding test to quietly stop exercising it. So the
+# second job mutates the fix back out and asserts the tests actually FAIL —
+# a vacuous regression test is treated as a red build, not a green one.
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: 'The type of runner to use for this job'
+        type: string
+        required: false
+        default: 'ubuntu-latest'
+      jobs_to_run:
+        description: 'Controls which jobs to run. "all" runs everything.'
+        type: string
+        required: false
+        default: 'all'
+
+jobs:
+  mysql_tls_greeting_stitch_linux:
+    if: ${{ inputs.jobs_to_run == 'all' }}
+    runs-on: ${{ inputs.runner }}
+    name: greeting-stitch regression
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      # -race because the store is touched from both legs concurrently, and
+      # -count=3 because the end-to-end case drives the recorder through a
+      # bounded wait — a fix that only sometimes populates the cache would
+      # otherwise pass intermittently and be read as green.
+      - name: Greeting-stitch regression tests
+        run: |
+          go test ./pkg/models/ ./pkg/agent/proxy/integrations/mysql/recorder/ \
+            -run 'TestStorePreTLSHandshakeV2|TestHandshakeLastPortKey|TestRecordV2_PostTLS_PooledConn|TestRecordV2_PostTLS_LostStash|TestTLSHandshakeStore|TestResolvePreTLSGreeting|TestRememberLast|TestAmbiguityLatch|TestTombstone|TestLastGreeting|TestGreetingServerIdentity|TestRecordV2_RawLeg|TestRawLegIdentity|TestHandshakeLastKey' \
+            -race -count=3 -v
+
+      - name: Full MySQL + models suites
+        run: go test ./pkg/models/ ./pkg/agent/proxy/integrations/mysql/... -race -count=1
+
+  # Asserts the guard above is load-bearing. Removing the writer's cache seeding
+  # must break it; if it does not, the regression test has gone vacuous and is no
+  # longer protecting anything.
+  mysql_tls_greeting_stitch_mutation_guard:
+    if: ${{ inputs.jobs_to_run == 'all' }}
+    runs-on: ${{ inputs.runner }}
+    name: greeting-stitch mutation guard
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Remove the fix, expect the regression tests to FAIL
+        run: |
+          set -uo pipefail
+          f=pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
+          before=$(grep -cE 'hsStore\.RememberLast(ForPort)?\(' "$f")
+          forport=$(grep -c 'hsStore.RememberLastForPort(' "$f")
+          if [ "$before" -lt 2 ] || [ "$forport" -lt 1 ]; then
+            echo "::error::expected >=2 RememberLast calls in $f, found $before —" \
+                 "the fix or this guard has drifted; update both together"
+            exit 1
+          fi
+          # Neutralise only the writer half of the fix.
+          sed -i -E 's/^([[:space:]]*)hsStore\.RememberLast(ForPort)?\(/\1_ = \&hsStore; \/\/ MUTATED: /' "$f"
+          go build ./pkg/agent/proxy/integrations/mysql/... 2>/dev/null || {
+            # A non-compiling mutant proves nothing; fall back to deleting the lines.
+            git checkout -- "$f"
+            sed -i -E '/hsStore\.RememberLast(ForPort)?\(/d' "$f"
+            go build ./pkg/agent/proxy/integrations/mysql/... || {
+              echo "::error::neither mutant compiles; the guard cannot score a kill"
+              git checkout -- "$f"; exit 1
+            }
+          }
+          if go test ./pkg/agent/proxy/integrations/mysql/recorder/ \
+               -run 'TestStorePreTLSHandshakeV2_SeedsLastGreetingCache|TestRecordV2_PostTLS_PooledConn_BridgesRealWriterToFabricatedReader' \
+               -count=1 >/tmp/mutant.log 2>&1; then
+            echo "::error::VACUOUS TEST: the greeting-stitch regression tests still PASS with the" \
+                 "last-greeting cache seeding removed. They are not guarding the fix."
+            tail -40 /tmp/mutant.log
+            git checkout -- "$f"
+            exit 1
+          fi
+          echo "OK: removing the cache seeding fails the regression tests, as it must."
+          git checkout -- "$f"
+
+          # Second mutant: the seeding calls survive, but the SERVER IDENTITY
+          # feeding them is blanked. RememberLastForPort drops an empty identity,
+          # so the port key is never written and the fix is inert on the exact
+          # path it targets — with both call sites still present, so the grep
+          # above cannot see it. Only an end-to-end raw-leg test catches this.
+          if ! grep -q 'serverID = greetingServerIdentity(greeting)' "$f"; then
+            echo "::error::the greetingServerIdentity wiring moved; update this guard with it"
+            exit 1
+          fi
+          sed -i 's/serverID = greetingServerIdentity(greeting)/serverID = ""/' "$f"
+          # A test failure only counts as a kill if the mutant actually COMPILES.
+          # Without this gate a behaviour-preserving refactor that leaves
+          # `greeting` unused after the sed turns "build failed" into a false
+          # kill — the exact vacuity this job exists to catch, occurring inside
+          # the job. Mutant 1 has the same gate.
+          go build ./pkg/agent/proxy/integrations/mysql/... || {
+            echo "::error::the blank-identity mutant does not compile, so a test failure would" \
+                 "score a FALSE kill; rework the guard alongside the code it mutates"
+            git checkout -- "$f"; exit 1
+          }
+          if go test ./pkg/agent/proxy/integrations/mysql/recorder/ \
+               -run 'TestRecordV2_RawLegSeedsPortKeyFromGreeting' \
+               -count=1 >/tmp/mutant2.log 2>&1; then
+            echo "::error::VACUOUS TEST: blanking the server identity still passes. The port key" \
+                 "would never be seeded and the fallback would be inert."
+            tail -30 /tmp/mutant2.log
+            git checkout -- "$f"
+            exit 1
+          fi
+          echo "OK: blanking the server identity fails the raw-leg test, as it must."
+          git checkout -- "$f"

--- a/.github/workflows/prepare_and_run.yml
+++ b/.github/workflows/prepare_and_run.yml
@@ -723,6 +723,14 @@ jobs:
   run_mock_linux:
     needs: [build-and-upload, upload-latest]
     uses: ./.github/workflows/mock_linux.yml
+  run_mysql_tls_greeting_stitch_linux:
+    # Regression guard for the proxyless MySQL-over-TLS capture shortfall: the
+    # last-greeting fallback (resolvePreTLSGreeting -> cachedGreeting) was dead
+    # code on the V2 path because only the legacy handleInitialHandshake ever
+    # seeded it, so a pooled connection whose own greeting had been consumed
+    # lost its whole command phase. Includes a mutation guard that fails the
+    # build if the regression tests stop actually exercising the fix.
+    uses: ./.github/workflows/mysql-tls-greeting-stitch-linux.yml
   run_http_stale_pool_race_linux:
     # Regression guard for issue #4165 (upstream-pool half-close race
     # in handleHttp1ZeroCopy). Bursty client + gunicorn --keep-alive 2

--- a/pkg/agent/proxy/integrations/mysql/recorder/conn.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/conn.go
@@ -870,6 +870,27 @@ func handlePostTLSRecord(ctx context.Context, logger *zap.Logger, clientConn, de
 			zap.String("portKey", portKey))
 		entry, ok = hsStore.PopWait(portKey, 2*time.Second)
 	}
+	// Both consumable keys missed. Before dialling the server, consult the
+	// last-greeting cache — the same fallback the V2 path uses, and the reason
+	// handleInitialHandshake seeds it above. Without this read that seeding is a
+	// write with no reader, and a POOLED connection (reused long after its
+	// handshake, so its own entry was already consumed) loses its whole command
+	// phase here exactly as it did on V2.
+	//
+	// Address-keyed only. The V2 path additionally bridges legs that disagree
+	// about the address via a port key, but that key names no server and is only
+	// safe with the identity latch that RememberLastForPort applies; this path
+	// writes no port key, so there is nothing here that could answer unsafely.
+	if !ok || len(entry.RespPackets) == 0 {
+		if lastKey := models.HandshakeLastKey(opts.PassThroughScope, opts.DstCfg); lastKey != "" {
+			if c, found := hsStore.Last(lastKey); found && len(c.RespPackets) > 0 {
+				logger.Debug("Post-TLS MySQL: own handshake entry gone; reusing the last greeting recorded for this destination",
+					zap.String("lastKey", lastKey))
+				entry, ok = c, true
+			}
+		}
+	}
+
 	var serverGreetingBuf []byte
 	if ok && len(entry.RespPackets) > 0 {
 		serverGreetingBuf = entry.RespPackets[0]

--- a/pkg/agent/proxy/integrations/mysql/recorder/conn.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/conn.go
@@ -187,8 +187,10 @@ func handleInitialHandshake(ctx context.Context, logger *zap.Logger, clientConn,
 			}
 			// Record this greeting as the destination's last-resort fallback for
 			// a sibling connection whose own raw leg was dropped. Keyed by the
-			// resolved destination so it can only be reused for the SAME server,
-			// and skipped entirely when the address was synthesized.
+			// resolved destination so it can only be reused for the SAME server.
+			// Note it is NOT skipped for a synthesized address: HandshakeLastKey
+			// combines the address with the app/session scope, so a placeholder
+			// bucket is still per-scope (see its doc).
 			hsStore.RememberLast(models.HandshakeLastKey(opts.PassThroughScope, opts.DstCfg), hsEntry)
 			// Signal that the pre-TLS config mock should NOT be recorded here;
 			// the post-TLS path will produce a single combined config mock.

--- a/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
@@ -208,9 +208,11 @@ func handleInitialHandshakeV2(ctx context.Context, logger *zap.Logger, sess *sup
 		return res, fmt.Errorf("decode server greeting: %w", err)
 	}
 	res.requestOperation = handshakePkt.Header.Type
+	var serverID string
 	if greeting, ok := handshakePkt.Message.(*mysql.HandshakeV10Packet); ok {
 		decodeCtx.ServerCaps = greeting.CapabilityFlags
 		decodeCtx.ServerGreetings.Store(clientKey, greeting)
+		serverID = greetingServerIdentity(greeting)
 	}
 	pluginName, err := wire.GetPluginName(handshakePkt.Message)
 	if err != nil {
@@ -258,7 +260,7 @@ func handleInitialHandshakeV2(ctx context.Context, logger *zap.Logger, sess *sup
 		// is false) control falls through to the directive-based upgrade
 		// below instead.
 		if sess.Opts.SkipTLSMITM {
-			if err := storePreTLSHandshakeV2(ctx, logger, sess, handshake, clientFirst, res.reqTimestamp); err != nil {
+			if err := storePreTLSHandshakeV2(ctx, logger, sess, handshake, clientFirst, res.reqTimestamp, serverID); err != nil {
 				return res, err
 			}
 			res.skipConfigMock = true
@@ -901,12 +903,38 @@ const (
 func resolvePreTLSGreeting(ctx context.Context, hsStore *models.TLSHandshakeStore, connKey string, dstPort uint16, scope string, dst *models.ConditionalDstCfg) (models.TLSHandshakeEntry, preTLSGreetingSource) {
 	connSpecificKey := models.HandshakeStoreKey(connKey, dstPort)
 	portKey := models.HandshakeStoreKey("", dstPort)
-	// The cross-connection fallback is keyed by DESTINATION, not by port: the
+	// The cross-connection fallback has TWO keys. One names the destination: the
 	// fields it lets us reuse (capability flags, protocol version, auth plugin)
 	// are per-server, so an entry is only reusable for the same server. The key
 	// combines the app/session scope with the address so that a shared
 	// DaemonSet store cannot serve one app's greeting to another.
 	lastKey := models.HandshakeLastKey(scope, dst)
+	// The decrypted leg's address is frequently a capture-layer stand-in, which
+	// can never match what the raw leg wrote. The port is agreed between the two
+	// legs, so it is the key that actually bridges them here.
+	lastPortKey := models.HandshakeLastPortKey(scope, dstPort)
+	// The port key exists ONLY for a leg that cannot identify its own server. If
+	// this leg's destination was genuinely resolved, a key that names no server
+	// must never be allowed to answer for it: the latch cannot save us here,
+	// because it only trips once the OTHER server's raw leg writes the key, and
+	// by construction that has not happened — that is precisely why the fallback
+	// was reached. Without this gate a fully-resolved connection is stitched with
+	// another server's capability flags and auth plugin, turning a missing mock
+	// into a WRONG one, which is strictly worse.
+	// NOTE ON REACHABILITY: AddrFabricated has NO producer in this repository —
+	// every assignment is in a _test.go. It is set by the out-of-tree proxyless
+	// capture layer (enterprise pkg/agent/proxy, routeEgressToParser, which
+	// propagates its destInfoResult.Fabricated into DstCfg.AddrFabricated) when
+	// it could not resolve a decrypted TLS leg's destination and had to
+	// substitute a stand-in. So in a plain OSS/sidecar deployment this gate is
+	// always false and the port key never answers; the path below is exercised
+	// only under that capture layer, and OSS tests must set the flag by hand.
+	// This is stated because "a mechanism with no in-tree caller" is exactly the
+	// defect being fixed here — RememberLast had one, in a legacy path the
+	// proxyless flow never runs — and it should not be rediscovered by accident.
+	if dst != nil && dst.Addr != "" && !dst.AddrFabricated {
+		lastPortKey = ""
+	}
 
 	overall := mysqlPostTLSStashWait()
 	primary := mysqlPostTLSStashPrimary(overall)
@@ -929,11 +957,31 @@ func resolvePreTLSGreeting(ctx context.Context, hsStore *models.TLSHandshakeStor
 	}
 	// cachedGreeting returns the port's last-greeting cache entry, if usable.
 	cachedGreeting := func() (models.TLSHandshakeEntry, bool) {
-		if lastKey == "" {
+		// A latched port key is POSITIVE proof that this scope+port serves more
+		// than one server. Falling through to the address key would then quietly
+		// answer from the shared placeholder bucket — which carries no identity
+		// at all — after the guarded key just told us reuse is unsafe. Decline
+		// outright instead; a missing mock beats one stitched from a server we
+		// have already proven is not necessarily this connection's.
+		if lastPortKey != "" && hsStore.IsAmbiguous(lastPortKey) {
 			return models.TLSHandshakeEntry{}, false
 		}
-		if c, ok := hsStore.Last(lastKey); ok && len(c.RespPackets) > 0 {
-			return c, true
+		// Port key FIRST. It is the only one of the two with a runtime guard:
+		// RememberLastForPort tags every entry with the destination that produced
+		// it and latches the key unusable once a second server appears. The
+		// address key has no such guard, and on this path the reader's address is
+		// usually a capture-layer stand-in, so "dst:<scope>|127.0.0.1:3306" is a
+		// shared bucket that any unresolved connection in the scope can land in —
+		// consulting it first would let it shadow the guarded answer.
+		if lastPortKey != "" {
+			if c, ok := hsStore.Last(lastPortKey); ok && len(c.RespPackets) > 0 {
+				return c, true
+			}
+		}
+		if lastKey != "" {
+			if c, ok := hsStore.Last(lastKey); ok && len(c.RespPackets) > 0 {
+				return c, true
+			}
 		}
 		return models.TLSHandshakeEntry{}, false
 	}
@@ -984,6 +1032,27 @@ func resolvePreTLSGreeting(ctx context.Context, hsStore *models.TLSHandshakeStor
 	return models.TLSHandshakeEntry{}, greetingNone
 }
 
+// greetingServerIdentity fingerprints the SERVER-STABLE parts of a HandshakeV10
+// greeting: protocol version, server version, capability flags, default charset
+// and auth plugin. These are exactly the fields a borrowed greeting contributes
+// to a config mock (ServerCaps drives DeprecateEOF and result-set parsing;
+// PluginName drives auth-flow selection), so two greetings with the same
+// fingerprint are interchangeable for stitching no matter which address or
+// connection they arrived on.
+//
+// The per-connection fields — connection id, auth-plugin-data salt, status flags
+// — are deliberately excluded: they differ on every connection to the SAME
+// server, and none of them is verified on the record or replay path (the
+// replayer skips AuthResponse comparison precisely because it is salt-derived).
+// Including them would make every connection look like a different server.
+func greetingServerIdentity(g *mysql.HandshakeV10Packet) string {
+	if g == nil {
+		return ""
+	}
+	return fmt.Sprintf("v%d|%s|caps=%d|cs=%d|%s",
+		g.ProtocolVersion, g.ServerVersion, g.CapabilityFlags, g.CharacterSet, g.AuthPluginName)
+}
+
 // storePreTLSHandshakeV2 pushes the pre-TLS MySQL server greeting and the
 // client SSLRequest into the shared TLSHandshakeStore so the decrypted
 // (uprobe) tls-* stream's handlePostTLSRecord can recover them. It mirrors
@@ -992,7 +1061,7 @@ func resolvePreTLSGreeting(ctx context.Context, hsStore *models.TLSHandshakeStor
 // observe-only stream and the decrypted uprobe stream are different TCP
 // connections with different connIDs — only the port-only key (port:3306)
 // reliably bridges the two.
-func storePreTLSHandshakeV2(ctx context.Context, logger *zap.Logger, sess *supervisor.Session, greeting, sslRequest []byte, reqTimestamp time.Time) error {
+func storePreTLSHandshakeV2(ctx context.Context, logger *zap.Logger, sess *supervisor.Session, greeting, sslRequest []byte, reqTimestamp time.Time, serverID string) error {
 	hsStore, ok := ctx.Value(models.TLSHandshakeStoreKey).(*models.TLSHandshakeStore)
 	if !ok || hsStore == nil {
 		return fmt.Errorf("SkipTLSMITM requires TLSHandshakeStore in context for MySQL handshake reconstruction")
@@ -1014,10 +1083,38 @@ func storePreTLSHandshakeV2(ctx context.Context, logger *zap.Logger, sess *super
 	if portKey != storeKey {
 		hsStore.Push(portKey, hsEntry)
 	}
+	// Seed the last-greeting cache too. Push/PopWait entries are CONSUMED, so a
+	// connection whose own raw leg never produced one — a pooled connection
+	// reused long after its handshake, or a leg the ringbuf dropped under load —
+	// finds both keys above empty and has nothing left to stitch with. That is
+	// what resolvePreTLSGreeting's cachedGreeting fallback exists for, but until
+	// now nothing on this path ever wrote it: the only RememberLast caller was
+	// the legacy handleInitialHandshake, which the proxyless V2 flow never runs.
+	// The fallback was therefore dead code on every proxyless MySQL-over-TLS
+	// recording, and the command phase of such a connection was dropped outright
+	// (the "served but NOT recorded" capture shortfall).
+	//
+	// Both keys are written because the two legs disagree about the address: the
+	// decrypted leg's destination is often unresolvable, so it presents a
+	// synthesized stand-in and could never match an address-keyed entry. See
+	// models.HandshakeLastPortKey.
+	scope := sess.Opts.PassThroughScope
+	hsStore.RememberLast(models.HandshakeLastKey(scope, sess.Opts.DstCfg), hsEntry)
+	// The port-scoped copy is tagged with the SERVER's identity, taken from the
+	// greeting itself rather than from the address it arrived from. Address is
+	// the wrong identity here: in Kubernetes the same logical MySQL gets a new
+	// pod IP on every rollout, and a Service with several endpoints hands out a
+	// different IP per connection, so an address-tagged latch would fire on two
+	// connections to the SAME server and permanently disable the fallback in the
+	// environment it exists for. The greeting fingerprint is stable across those
+	// and captures exactly the fields a borrower reuses, so it latches only when
+	// reuse would genuinely be unsafe.
+	hsStore.RememberLastForPort(models.HandshakeLastPortKey(scope, dstPort), serverID, hsEntry)
 	logger.Debug("V2: pushed pre-TLS MySQL greeting + SSLRequest to TLSHandshakeStore for post-TLS stitch",
 		zap.String("key", storeKey),
 		zap.String("portKey", portKey),
 		zap.String("connKey", sess.Opts.ConnKey),
+		zap.String("scope", scope),
 		zap.Uint16("dstPort", dstPort))
 	return nil
 }

--- a/pkg/agent/proxy/integrations/mysql/recorder/record_v2_test.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record_v2_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"go.keploy.io/server/v3/pkg/models/mysql"
 	"net"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -932,5 +933,43 @@ func TestResolvePreTLSGreeting_GateHandlesNilAndEmptyAddr(t *testing.T) {
 	noAddr := &models.ConditionalDstCfg{Port: 3306}
 	if _, source := resolvePreTLSGreeting(context.Background(), seed(), "", 3306, scope, noAddr); source != greetingCached {
 		t.Errorf("empty Addr: source = %v, want the port key to answer", source)
+	}
+}
+
+// TestLegacyPostTLSReadsLastGreetingCache pins that the LEGACY path
+// (KEPLOY_NEW_RELAY=off) also consults the last-greeting cache.
+//
+// That path is the documented escape hatch our own error messages tell users to
+// pull when a V2 parser misbehaves — proxy_v2.go, util.go and directive_proc.go
+// all name it — so it cannot simply be deleted. But handleInitialHandshake
+// SEEDS the cache there while the post-TLS reader only ever did PopWait, so the
+// seeding was a write with no reader and a pooled connection lost its command
+// phase exactly as it did on V2. A write with no reader is the defect class
+// this whole change exists to fix; leaving a second instance of it in place
+// would be careless.
+func TestLegacyPostTLSReadsLastGreetingCache(t *testing.T) {
+	src, err := os.ReadFile("conn.go")
+	if err != nil {
+		t.Fatalf("read conn.go: %v", err)
+	}
+	s := string(src)
+
+	// The seeding must still be there...
+	if !strings.Contains(s, "hsStore.RememberLast(models.HandshakeLastKey(opts.PassThroughScope, opts.DstCfg)") {
+		t.Error("conn.go no longer seeds the last-greeting cache")
+	}
+	// ...and the post-TLS reader must actually consult it.
+	i := strings.Index(s, "PopWait(portKey")
+	if i < 0 {
+		t.Fatal("the legacy post-TLS port-key PopWait moved; update this guard with it")
+	}
+	rest := s[i:]
+	if j := strings.Index(rest, "serverGreetingBuf = entry.RespPackets[0]"); j > 0 {
+		rest = rest[:j]
+	}
+	if !strings.Contains(rest, "hsStore.Last(lastKey)") {
+		t.Error("the legacy post-TLS reader does not consult the last-greeting cache between its " +
+			"PopWait misses and the direct dial; the seeding above is a write with no reader and " +
+			"a pooled connection still loses its command phase on this path")
 	}
 }

--- a/pkg/agent/proxy/integrations/mysql/recorder/record_v2_test.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record_v2_test.go
@@ -1,7 +1,9 @@
 package recorder
 
 import (
+	"bytes"
 	"context"
+	"go.keploy.io/server/v3/pkg/models/mysql"
 	"net"
 	"strings"
 	"testing"
@@ -427,5 +429,508 @@ func TestHandshakeLastKey_OnlyNamesResolvedDestinations(t *testing.T) {
 	b := models.HandshakeLastKey("app-b", &models.ConditionalDstCfg{Addr: "127.0.0.1:3306"})
 	if a == b {
 		t.Fatalf("two apps collided on one key (%q)", a)
+	}
+}
+
+// TestStorePreTLSHandshakeV2_SeedsLastGreetingCache pins that the V2 writer
+// populates the last-greeting cache, under BOTH the address key and the
+// port-scoped key.
+//
+// Regression: it previously seeded only the two CONSUMABLE keys. The only
+// RememberLast caller in the package was the legacy handleInitialHandshake,
+// which the proxyless V2 flow never runs — so resolvePreTLSGreeting's
+// cachedGreeting fallback was dead code on every proxyless MySQL-over-TLS
+// recording, and a connection whose own entry had been consumed lost its whole
+// command phase.
+func TestStorePreTLSHandshakeV2_SeedsLastGreetingCache(t *testing.T) {
+	store := models.NewTLSHandshakeStore()
+	h := newV2Harness(t)
+	const scope = "ns/app/test-set-0"
+	h.sess.Opts.PassThroughScope = scope
+	h.sess.Opts.ConnKey = "conn-abc"
+	h.sess.Opts.DstCfg = &models.ConditionalDstCfg{Addr: "10.244.0.24:3306", Port: 3306}
+
+	greeting := cannedHandshakeV10(t)
+	sslReq := cannedSSLRequest(t, 1)
+	ts := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+
+	if err := storePreTLSHandshakeV2(postTLSCtxWithStore(store), zap.NewNop(), h.sess, greeting, sslReq, ts, "server-A"); err != nil {
+		t.Fatalf("storePreTLSHandshakeV2: %v", err)
+	}
+
+	if _, ok := store.Last(models.HandshakeLastKey(scope, h.sess.Opts.DstCfg)); !ok {
+		t.Error("address-keyed last-greeting cache not seeded by the V2 writer")
+	}
+	if _, ok := store.Last(models.HandshakeLastPortKey(scope, 3306)); !ok {
+		t.Error("port-keyed last-greeting cache not seeded by the V2 writer — " +
+			"a decrypted leg with an unresolved destination can never find the greeting")
+	}
+}
+
+// TestHandshakeLastPortKey_ScopeIsolatedAndPortNamed pins the key contract: it
+// isolates by scope (so a shared DaemonSet store cannot serve app A's greeting
+// to app B) and returns "" when there is no port to key on.
+func TestHandshakeLastPortKey_ScopeIsolatedAndPortNamed(t *testing.T) {
+	if got := models.HandshakeLastPortKey("s", 0); got != "" {
+		t.Errorf("HandshakeLastPortKey(_, 0) = %q, want \"\" (no port to key on)", got)
+	}
+	a := models.HandshakeLastPortKey("ns/app-a/ts0", 3306)
+	b := models.HandshakeLastPortKey("ns/app-b/ts0", 3306)
+	if a == b {
+		t.Errorf("two apps on the same port share key %q — cross-app greeting contamination", a)
+	}
+	if a == "" {
+		t.Error("HandshakeLastPortKey returned empty for a valid scope+port")
+	}
+	if same := models.HandshakeLastPortKey("ns/app-a/ts0", 3306); same != a {
+		t.Errorf("key is not stable: %q vs %q", same, a)
+	}
+}
+
+// TestRecordV2_PostTLS_PooledConn_BridgesRealWriterToFabricatedReader is the
+// end-to-end regression for the proxyless "served but NOT recorded" capture
+// shortfall.
+//
+// Shape, exactly as it occurs in production: an earlier connection's raw
+// plaintext leg recorded the greeting against the REAL destination and its
+// consumable entries were then popped (PopWait consumes). A pooled connection
+// is now reused; its decrypted leg is fd-less, so the capture layer could not
+// resolve a destination and presents a synthesized stand-in. The greeting must
+// still be found — via the port, the one thing both legs agree on.
+//
+// Before the fix this produced no mock at all: nothing had seeded the cache,
+// and the address keys could not have matched even if it had.
+func TestRecordV2_PostTLS_PooledConn_BridgesRealWriterToFabricatedReader(t *testing.T) {
+	t.Setenv("KEPLOY_MYSQL_POSTTLS_STASH_WAIT_MS", "150")
+
+	store := models.NewTLSHandshakeStore()
+	const scope = "ns/app/test-set-0"
+	base := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+
+	handshakeBuf := cannedHandshakeV10(t)
+	greeting, err := connphase.DecodeHandshakeV10(context.Background(), zap.NewNop(), handshakeBuf[4:])
+	if err != nil {
+		t.Fatalf("decode handshake v10: %v", err)
+	}
+	sslReq := cannedSSLRequest(t, 1)
+
+	// The EARLIER connection: raw leg seen against the real server address.
+	writer := newV2Harness(t)
+	writer.sess.Opts.PassThroughScope = scope
+	writer.sess.Opts.ConnKey = "earlier-conn"
+	writer.sess.Opts.DstCfg = &models.ConditionalDstCfg{Addr: "10.244.0.24:3306", Port: 3306}
+	if err := storePreTLSHandshakeV2(postTLSCtxWithStore(store), zap.NewNop(), writer.sess,
+		handshakeBuf, sslReq, base.Add(-time.Hour), "server-A"); err != nil {
+		t.Fatalf("seed via storePreTLSHandshakeV2: %v", err)
+	}
+	// ...and that connection consumed both of its queue entries, leaving only
+	// the last-greeting cache behind.
+	for _, k := range []string{
+		models.HandshakeStoreKey("earlier-conn", 3306),
+		models.HandshakeStoreKey("", 3306),
+	} {
+		for {
+			if _, ok := store.PopWait(k, 0); !ok {
+				break
+			}
+		}
+	}
+
+	// The pooled connection's decrypted leg: destination unresolved, so the
+	// address is a stand-in that matches nothing the writer stored.
+	h := newV2Harness(t)
+	h.sess.Opts.PassThroughScope = scope
+	h.sess.Opts.ConnKey = "pooled-conn"
+	// The realistic proxyless stand-in, not a contrived one: an unresolved
+	// destination is reported as loopback on the content-matched well-known
+	// port. It differs from the writer's REAL address, which is the whole
+	// reason an address-keyed cache cannot bridge the two legs.
+	h.sess.Opts.DstCfg = &models.ConditionalDstCfg{Addr: "127.0.0.1:3306", Port: 3306, AddrFabricated: true}
+
+	// A pooled connection joins MID-STREAM: it handshook cycles ago, so there is
+	// no HandshakeResponse41 on this leg — the first client packet is a command
+	// at seq==0. (The earlier version of this test pushed an HR41 at seq 2 and
+	// so exercised the fresh-auth branch, not the pooled shape it claims.)
+	h.pushClient(cannedCOMQuery(t, 0, "SELECT 1"), base.Add(20*time.Millisecond))
+	h.pushDest(cannedOK(t, 1, greeting.CapabilityFlags), base.Add(25*time.Millisecond))
+
+	got := collectPostTLSMocks(t, h, postTLSCtxWithStore(store), 2, 10*time.Second)
+
+	cfg := got[0]
+	if cfg.Name != "config" {
+		t.Fatalf("first mock = %q, want config", cfg.Name)
+	}
+	if len(cfg.Spec.MySQLResponses) < 1 {
+		t.Fatal("config mock has no responses — the greeting was not recovered across the address mismatch")
+	}
+	// A seq==0 config mock must carry a synthesized HandshakeResponse41 or the
+	// replayer cannot match the connection — recovering the greeting is only
+	// useful if the mock it produces is actually replayable.
+	if !configMockHasHR41(cfg) {
+		t.Errorf("seq==0 config mock has no HandshakeResponse41; it would fail replay handshake matching (reqs=%d)",
+			len(cfg.Spec.MySQLRequests))
+	}
+	assertQueryMock(t, got[1])
+}
+
+// TestResolvePreTLSGreeting_PortKeyRefusesCrossServer covers the cross-server
+// case AT THE RESOLVER, with a scope set. The existing sibling test passes
+// scope="" and so never exercised the port key at all — which is how a
+// cross-server hole reached review. Two servers on 3306 in one scope must latch
+// the port key unusable rather than let the second borrow the first's greeting.
+func TestResolvePreTLSGreeting_PortKeyRefusesCrossServer(t *testing.T) {
+	t.Setenv("KEPLOY_MYSQL_POSTTLS_STASH_WAIT_MS", "0")
+	const scope = "ns/app/ts0"
+	store := models.NewTLSHandshakeStore()
+	portKey := models.HandshakeLastPortKey(scope, 3306)
+
+	store.RememberLastForPort(portKey, "v10|8.4.0|caps=1|cs=255|caching_sha2_password",
+		models.TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'A'}}})
+	// A genuinely DIFFERENT server on the same port — different version, caps
+	// and auth plugin. (Note an identical-version replica would legitimately
+	// share a fingerprint and must NOT latch: the reused fields are exactly the
+	// fingerprinted ones, so reuse between them is safe.)
+	store.RememberLastForPort(portKey, "v10|5.7.44|caps=2|cs=33|mysql_native_password",
+		models.TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'B'}}})
+
+	fabricated := &models.ConditionalDstCfg{Addr: "127.0.0.1:3306", Port: 3306, AddrFabricated: true}
+	if _, source := resolvePreTLSGreeting(context.Background(), store, "", 3306, scope, fabricated); source == greetingCached {
+		t.Error("resolver served a greeting from a port key that has seen two servers — " +
+			"the borrower would stitch the wrong capability flags into its config mock")
+	}
+}
+
+// TestResolvePreTLSGreeting_UnscopedSidecarStillRecovers pins that the fallback
+// works for a caller that was never given a scope — the classic sidecar, and
+// every OSS deployment, since nothing in this repo sets PassThroughScope. An
+// earlier revision disabled the port key on an empty scope, which silently made
+// the whole fix enterprise-only while its tests still passed by hand-setting the
+// field.
+func TestResolvePreTLSGreeting_UnscopedSidecarStillRecovers(t *testing.T) {
+	t.Setenv("KEPLOY_MYSQL_POSTTLS_STASH_WAIT_MS", "0")
+	store := models.NewTLSHandshakeStore()
+	// Writer: the raw leg, real resolved destination, no scope.
+	store.RememberLastForPort(models.HandshakeLastPortKey("", 3306), "10.244.0.24:3306",
+		models.TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'A'}}})
+
+	// Reader: the decrypted leg, destination unresolved, so its address is a
+	// stand-in that cannot match the writer's address key.
+	fabricated := &models.ConditionalDstCfg{Addr: "127.0.0.1:3306", Port: 3306, AddrFabricated: true}
+	entry, source := resolvePreTLSGreeting(context.Background(), store, "", 3306, "", fabricated)
+	if source != greetingCached {
+		t.Fatalf("unscoped caller did not recover the greeting (source=%v); the fix would be inert "+
+			"in every OSS deployment", source)
+	}
+	if len(entry.RespPackets) == 0 || entry.RespPackets[0][1] != 'A' {
+		t.Errorf("recovered the wrong entry: %q", entry.RespPackets)
+	}
+}
+
+// TestResolvePreTLSGreeting_ResolvedReaderIgnoresPortKey pins that a connection
+// which KNOWS its own destination never accepts an answer from a key that names
+// no server.
+//
+// Regression: the port key was consulted first, unconditionally. A resolved leg
+// talking to server B, whose own entry had been consumed, was handed server A's
+// greeting — and the ambiguity latch could not help, because it only trips once
+// B's own raw leg writes the key, which by construction had not happened (that
+// is why the fallback was reached at all). The result was a config mock carrying
+// another server's capability flags and auth plugin: a WRONG mock in place of a
+// missing one. Before the port key existed this case correctly fell through and
+// the recorder fetched B's real greeting.
+func TestResolvePreTLSGreeting_ResolvedReaderIgnoresPortKey(t *testing.T) {
+	t.Setenv("KEPLOY_MYSQL_POSTTLS_STASH_WAIT_MS", "0")
+	for _, scope := range []string{"", "ns/app/ts0"} {
+		t.Run("scope="+scope, func(t *testing.T) {
+			store := models.NewTLSHandshakeStore()
+			// Server A's raw leg populated the port key.
+			store.RememberLastForPort(models.HandshakeLastPortKey(scope, 3306), "10.0.0.5:3306",
+				models.TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'A'}}})
+
+			// A different server, whose destination this leg resolved perfectly.
+			resolved := &models.ConditionalDstCfg{Addr: "10.0.0.9:3306", Port: 3306}
+			if _, source := resolvePreTLSGreeting(context.Background(), store, "", 3306, scope, resolved); source == greetingCached {
+				t.Error("a leg that knows its own destination was served another server's greeting " +
+					"from the port key; it must fall through and fetch its own")
+			}
+		})
+	}
+}
+
+// TestGreetingServerIdentity pins the fingerprint that the whole cross-server
+// guard rests on. It had no direct test: setting it to "" left every test green
+// while making the fix INERT (RememberLastForPort drops an empty identity, so
+// the port key is never written), and adding a per-connection field left every
+// test green while making the fallback PERMANENTLY DEAD (every connection to one
+// server looks like a new server, latching the key forever).
+func TestGreetingServerIdentity(t *testing.T) {
+	base := func() *mysql.HandshakeV10Packet {
+		return &mysql.HandshakeV10Packet{
+			ProtocolVersion: 10,
+			ServerVersion:   "8.4.0",
+			ConnectionID:    1234,
+			AuthPluginData:  []byte("per-connection-salt-aaaaaaaa"),
+			CapabilityFlags: 0xC00FFFFF,
+			CharacterSet:    255,
+			StatusFlags:     0x0002,
+			AuthPluginName:  "caching_sha2_password",
+		}
+	}
+	if got := greetingServerIdentity(base()); got == "" {
+		t.Fatal("empty identity for a valid greeting — RememberLastForPort drops it and the fix is inert")
+	}
+	if got := greetingServerIdentity(nil); got != "" {
+		t.Errorf("nil greeting = %q, want empty", got)
+	}
+
+	// PER-CONNECTION fields must NOT appear: the same server answers every
+	// connection with a fresh connection id, salt and status flags.
+	t.Run("stable across connections to one server", func(t *testing.T) {
+		a := base()
+		b := base()
+		b.ConnectionID = 99999
+		b.AuthPluginData = []byte("a-completely-different-salt-b")
+		b.StatusFlags = 0x0022
+		if greetingServerIdentity(a) != greetingServerIdentity(b) {
+			t.Errorf("identity changed across two connections to the SAME server:\n a=%s\n b=%s\n"+
+				"every connection would latch the key and the fallback dies permanently",
+				greetingServerIdentity(a), greetingServerIdentity(b))
+		}
+	})
+
+	// SERVER-STABLE fields MUST appear: these are exactly what a borrowed
+	// greeting contributes to a config mock.
+	for _, tc := range []struct {
+		name string
+		mut  func(*mysql.HandshakeV10Packet)
+	}{
+		{"server version", func(p *mysql.HandshakeV10Packet) { p.ServerVersion = "5.7.44" }},
+		{"capability flags", func(p *mysql.HandshakeV10Packet) { p.CapabilityFlags = 0x000FFFFF }},
+		{"auth plugin", func(p *mysql.HandshakeV10Packet) { p.AuthPluginName = "mysql_native_password" }},
+		{"protocol version", func(p *mysql.HandshakeV10Packet) { p.ProtocolVersion = 9 }},
+		{"charset", func(p *mysql.HandshakeV10Packet) { p.CharacterSet = 33 }},
+	} {
+		t.Run("distinguishes "+tc.name, func(t *testing.T) {
+			a := base()
+			b := base()
+			tc.mut(b)
+			if greetingServerIdentity(a) == greetingServerIdentity(b) {
+				t.Errorf("%s does not affect the identity; two genuinely different servers would "+
+					"share a port key and cross-serve greetings", tc.name)
+			}
+		})
+	}
+}
+
+// TestResolvePreTLSGreeting_LatchedPortKeyDeclinesAddressBucket covers the case
+// the sibling cross-server test does not: a latched port key AND a populated
+// shared address bucket. Without the IsAmbiguous decline the resolver falls
+// through to that bucket — which carries no server identity at all — moments
+// after the guarded key established that reuse here is unsafe.
+func TestResolvePreTLSGreeting_LatchedPortKeyDeclinesAddressBucket(t *testing.T) {
+	t.Setenv("KEPLOY_MYSQL_POSTTLS_STASH_WAIT_MS", "0")
+	const scope = "ns/app/ts0"
+	store := models.NewTLSHandshakeStore()
+	fab := &models.ConditionalDstCfg{Addr: "127.0.0.1:3306", Port: 3306, AddrFabricated: true}
+
+	// Two servers seen on this scope+port -> latched.
+	pk := models.HandshakeLastPortKey(scope, 3306)
+	store.RememberLastForPort(pk, "v10|8.4.0|caps=1|cs=255|caching_sha2_password",
+		models.TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'A'}}})
+	store.RememberLastForPort(pk, "v10|5.7.44|caps=2|cs=33|mysql_native_password",
+		models.TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'B'}}})
+	if !store.IsAmbiguous(pk) {
+		t.Fatal("precondition: the port key should be latched")
+	}
+	// ...and the shared fabricated-address bucket is populated, exactly as
+	// storePreTLSHandshakeV2 does for a fabricated destination.
+	store.RememberLast(models.HandshakeLastKey(scope, fab),
+		models.TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'C'}}})
+
+	if _, source := resolvePreTLSGreeting(context.Background(), store, "", 3306, scope, fab); source == greetingCached {
+		t.Error("served from the identity-less address bucket after the port key was latched; " +
+			"a latch is proof that this scope+port has more than one server")
+	}
+}
+
+// TestRecordV2_RawLegSeedsPortKeyFromGreeting drives the REAL raw plaintext leg
+// end to end and asserts the port key gets seeded.
+//
+// This is the gap a unit test of greetingServerIdentity cannot close: replacing
+// the call site with `serverID = ""` leaves the fingerprint function perfect and
+// every other test green, while RememberLastForPort silently drops the empty
+// identity — so the port key is never written and the whole fix is inert on the
+// exact path it targets. That is the failure mode of three previous rounds,
+// reachable by deleting one line.
+func TestRecordV2_RawLegSeedsPortKeyFromGreeting(t *testing.T) {
+	const scope = "ns/app/test-set-0"
+	store := models.NewTLSHandshakeStore()
+
+	h := newV2Harness(t)
+	h.sess.Opts.SkipTLSMITM = true // observe-only: stash the handshake and stop
+	h.sess.Opts.PassThroughScope = scope
+	h.sess.Opts.ConnKey = "raw-leg-conn"
+	h.sess.Opts.DstCfg = &models.ConditionalDstCfg{Addr: "10.244.0.24:3306", Port: 3306}
+
+	base := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+	h.pushDest(cannedHandshakeV10(t), base)
+	h.pushClient(cannedSSLRequest(t, 1), base.Add(2*time.Millisecond))
+
+	// The RAW leg, so the store must be in ctx WITHOUT PostTLSModeKey — that key
+	// selects the decrypted-leg path instead.
+	rawCtx := context.WithValue(context.Background(), models.TLSHandshakeStoreKey, store)
+	ctx, cancel := context.WithTimeout(rawCtx, 10*time.Second)
+	defer cancel()
+	// The raw leg stops after stashing; RecordV2 returning is the success path.
+	done := make(chan error, 1)
+	go func() { done <- RecordV2(ctx, h.logger, h.sess) }()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("RecordV2 did not return on the raw leg")
+	}
+
+	if _, ok := store.Last(models.HandshakeLastPortKey(scope, 3306)); !ok {
+		t.Error("the raw leg did not seed the PORT key — greetingServerIdentity produced no " +
+			"identity, so RememberLastForPort dropped it and the fallback is inert")
+	}
+	if _, ok := store.Last(models.HandshakeLastKey(scope, h.sess.Opts.DstCfg)); !ok {
+		t.Error("the raw leg did not seed the address key")
+	}
+}
+
+// greetingWithVersion builds a HandshakeV10 packet identical to cannedHandshakeV10
+// except for the server version, so a test can present two genuinely DIFFERENT
+// servers (or the same one twice) to the raw leg.
+func greetingWithVersion(t *testing.T, version string) []byte {
+	t.Helper()
+	caps := uint32(mysql.CLIENT_PROTOCOL_41 | mysql.CLIENT_PLUGIN_AUTH |
+		mysql.CLIENT_SSL | mysql.CLIENT_SECURE_CONNECTION)
+	hs := &mysql.HandshakeV10Packet{
+		ProtocolVersion: 0x0a,
+		ServerVersion:   version,
+		ConnectionID:    42,
+		AuthPluginData:  bytes.Repeat([]byte{0x11}, 20),
+		CapabilityFlags: caps,
+		CharacterSet:    255,
+		StatusFlags:     2,
+		AuthPluginName:  "caching_sha2_password",
+	}
+	buf, err := connphase.EncodeHandshakeV10(context.Background(), zap.NewNop(), hs)
+	if err != nil {
+		t.Fatalf("encode handshake: %v", err)
+	}
+	return wrapPacket(buf, 0)
+}
+
+// rawLeg drives one raw plaintext leg through RecordV2 with the given greeting.
+func rawLeg(t *testing.T, store *models.TLSHandshakeStore, scope, connKey, addr, greeting string) {
+	t.Helper()
+	h := newV2Harness(t)
+	h.sess.Opts.SkipTLSMITM = true
+	h.sess.Opts.PassThroughScope = scope
+	h.sess.Opts.ConnKey = connKey
+	h.sess.Opts.DstCfg = &models.ConditionalDstCfg{Addr: addr, Port: 3306}
+	base := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+	h.pushDest(greetingWithVersion(t, greeting), base)
+	h.pushClient(cannedSSLRequest(t, 1), base.Add(2*time.Millisecond))
+	ctx, cancel := context.WithTimeout(
+		context.WithValue(context.Background(), models.TLSHandshakeStoreKey, store), 10*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- RecordV2(ctx, h.logger, h.sess) }()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("RecordV2 did not return on the raw leg")
+	}
+}
+
+// TestRawLegIdentityDrivesTheLatch pins the whole chain end to end: call site ->
+// fingerprint -> latch. Testing greetingServerIdentity in isolation is not
+// enough — replacing the call site with a CONSTANT identity leaves that unit
+// test perfect and the suite green, while the latch can then never fire and two
+// different servers cross-serve greetings, which is the corruption the latch
+// exists to prevent.
+func TestRawLegIdentityDrivesTheLatch(t *testing.T) {
+	const scope = "ns/app/test-set-0"
+	pk := models.HandshakeLastPortKey(scope, 3306)
+
+	t.Run("two different servers latch the port key", func(t *testing.T) {
+		store := models.NewTLSHandshakeStore()
+		rawLeg(t, store, scope, "conn-a", "10.0.0.5:3306", "8.4.0")
+		rawLeg(t, store, scope, "conn-b", "10.0.0.9:3306", "5.7.44")
+		if !store.IsAmbiguous(pk) {
+			t.Error("two servers with different versions did not latch the port key; the identity " +
+				"reaching the store is not derived from the greeting")
+		}
+	})
+
+	t.Run("the same server twice does NOT latch", func(t *testing.T) {
+		store := models.NewTLSHandshakeStore()
+		// Same server, two connections — in k8s these routinely arrive from
+		// different pod IPs after a rollout.
+		rawLeg(t, store, scope, "conn-a", "10.244.0.24:3306", "8.4.0")
+		rawLeg(t, store, scope, "conn-b", "10.244.0.31:3306", "8.4.0")
+		if store.IsAmbiguous(pk) {
+			t.Error("the same server on two addresses latched the key — the identity is " +
+				"address-derived, which kills the fallback after any rollout")
+		}
+		if _, ok := store.Last(pk); !ok {
+			t.Error("the port key holds nothing after two writes from one server")
+		}
+	})
+}
+
+// TestResolvePreTLSGreeting_PortKeyWinsOverSharedAddressBucket pins the LOOKUP
+// ORDER. The address key for a fabricated reader is the shared
+// dst:<scope>|127.0.0.1:3306 placeholder, which RememberLast writes UNTAGGED, so
+// it can never latch and can hold any server's greeting. Consulting it first
+// bypasses the identity latch entirely.
+func TestResolvePreTLSGreeting_PortKeyWinsOverSharedAddressBucket(t *testing.T) {
+	t.Setenv("KEPLOY_MYSQL_POSTTLS_STASH_WAIT_MS", "0")
+	const scope = "ns/app/ts0"
+	store := models.NewTLSHandshakeStore()
+	fab := &models.ConditionalDstCfg{Addr: "127.0.0.1:3306", Port: 3306, AddrFabricated: true}
+
+	// Port key: server A, tagged and unlatched (the guarded answer).
+	store.RememberLastForPort(models.HandshakeLastPortKey(scope, 3306),
+		"v10|8.4.0|caps=1|cs=255|caching_sha2_password",
+		models.TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'A'}}})
+	// Shared placeholder bucket: a DIFFERENT server, untagged.
+	store.RememberLast(models.HandshakeLastKey(scope, fab),
+		models.TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'B'}}})
+
+	entry, source := resolvePreTLSGreeting(context.Background(), store, "", 3306, scope, fab)
+	if source != greetingCached {
+		t.Fatalf("no cached greeting served (source=%v)", source)
+	}
+	if len(entry.RespPackets) == 0 || entry.RespPackets[0][1] != 'A' {
+		t.Errorf("served %q from the untagged shared bucket; the identity-guarded port key must "+
+			"be consulted first or the latch is bypassed", entry.RespPackets)
+	}
+}
+
+// TestResolvePreTLSGreeting_GateHandlesNilAndEmptyAddr pins the two conjuncts of
+// the resolved-reader gate that no test covered. dst==nil is reachable:
+// handlePostTLSHandshakeV2 guards DstCfg != nil separately and then passes the
+// possibly-nil pointer down, so removing the check turns a reorder into a panic.
+func TestResolvePreTLSGreeting_GateHandlesNilAndEmptyAddr(t *testing.T) {
+	t.Setenv("KEPLOY_MYSQL_POSTTLS_STASH_WAIT_MS", "0")
+	const scope = "ns/app/ts0"
+	seed := func() *models.TLSHandshakeStore {
+		s := models.NewTLSHandshakeStore()
+		s.RememberLastForPort(models.HandshakeLastPortKey(scope, 3306), "srv-A",
+			models.TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'A'}}})
+		return s
+	}
+	// A nil DstCfg must not panic, and cannot be a "resolved" reader.
+	if _, source := resolvePreTLSGreeting(context.Background(), seed(), "", 3306, scope, nil); source != greetingCached {
+		t.Errorf("nil DstCfg: source = %v, want the port key to answer", source)
+	}
+	// A DstCfg with no address is likewise unresolved.
+	noAddr := &models.ConditionalDstCfg{Port: 3306}
+	if _, source := resolvePreTLSGreeting(context.Background(), seed(), "", 3306, scope, noAddr); source != greetingCached {
+		t.Errorf("empty Addr: source = %v, want the port key to answer", source)
 	}
 }

--- a/pkg/models/tls_handshake_store.go
+++ b/pkg/models/tls_handshake_store.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 )
@@ -31,11 +32,12 @@ type TLSHandshakeStore struct {
 	mu   sync.Mutex
 	cond *sync.Cond
 	m    map[string][]timedTLSHandshakeEntry
-	// last remembers, per DESTINATION-scoped key, the most recent entry ever pushed —
-	// independently of the consumable queue in m. Only DESTINATION keys are
-	// cached here (see HandshakeLastKey) because it is never TTL/size-pruned and
-	// the only reader queries it by destination. Unlike m it is never
-	// consumed by Pop and never TTL-pruned: it is the last-resort
+	// last remembers, per scoped key, the most recent entry ever pushed —
+	// independently of the consumable queue in m. Unlike m it is never consumed
+	// by Pop, and it is pruned on its OWN, much longer schedule
+	// (lastGreetingTTL) and capped at maxLastGreetings, so a long-lived
+	// DaemonSet agent cannot accumulate entries without bound. It is the
+	// last-resort
 	// fallback for a consumer whose OWN raw-leg entry was genuinely
 	// lost (e.g. the plaintext MySQL greeting+SSLRequest capture event
 	// dropped by a full ringbuf under load). A MySQL server's greeting
@@ -46,18 +48,93 @@ type TLSHandshakeStore struct {
 	// replayer explicitly skips AuthResponse comparison because it is
 	// salt-dependent; see mysql/replayer/match.go matchHanshakeResponse41).
 	//
-	// That reasoning is exactly why the key must name the SERVER. Those fields
-	// are per-server, so an entry may only be reused for the same server. A
-	// port-only key does not identify one: under a DaemonSet a single agent
-	// serves every pod on the node, so app A talking to MySQL-A:3306 and app B
-	// talking to MySQL-B:3306 share "port:3306", and B would stitch A's
-	// capability flags, server version and auth plugin into its own config mock.
-	// Keying by destination address confines reuse to one server, and
-	// HandshakeLastKey returns "" for an address the capture layer merely
-	// synthesized, which disables the cache rather than letting every
-	// unresolved destination collapse onto one placeholder key.
-	last map[string]TLSHandshakeEntry
+	// That reasoning is exactly why an entry may only ever be reused for the
+	// SAME server: those fields are per-server, and stitching one server's
+	// capability flags, version and auth plugin into another's config mock is
+	// silent corruption — strictly worse than the missing mock it would replace.
+	//
+	// Two kinds of key are cached here, and they earn that guarantee differently:
+	//
+	//   - DESTINATION keys (HandshakeLastKey) name the server directly, in the
+	//     address. Note they do NOT drop a synthesized address: the key also
+	//     carries the app/session scope, so one app's "127.0.0.1:3306"
+	//     placeholder bucket is already distinct from another's, and the
+	//     degraded proxyless destination is precisely the case this fallback
+	//     exists to rescue.
+	//
+	//   - PORT keys (HandshakeLastPortKey) do NOT name a server, and exist only
+	//     because the two legs of a proxyless TLS connection disagree about the
+	//     address (the decrypted leg's is often unresolvable). They earn the
+	//     guarantee at RUNTIME instead: RememberLastForPort tags each entry with
+	//     the SERVER that produced it — a caller-supplied identity, NOT an
+	//     address — and latches the key ambiguous the moment a second, different
+	//     server appears under it, after which
+	//     Last refuses to serve it. This is BEST-EFFORT, not a guarantee: a
+	//     server that never writes the key — because its own raw leg was the one
+	//     that went missing, which is precisely when a borrower needs the
+	//     fallback — cannot trip the latch, so it can still read another
+	//     server's greeting. The reused fields are per-server-stable and the
+	//     replayer already serves one recorded greeting to every connection, so
+	//     the trade is deliberate; it is not a proof of isolation.
+	//
+	// Residual, shared by both and deliberately accepted: within ONE scope, two
+	// different servers whose addresses BOTH had to be synthesized are
+	// indistinguishable to the capture layer, so they can collapse onto one
+	// destination key. Resolving that needs real destination resolution, not a
+	// better key.
+	//
+	// A second residual, for completeness: a cached entry also carries the
+	// borrowed connection's SSLRequest, and on the seq==0 path the synthetic
+	// HandshakeResponse41 built from it copies CLIENT-side fields (max packet
+	// size, charset, filler) that the replayer compares exactly. The identity
+	// above names the SERVER; nothing names the client. Within one app and
+	// driver that is a no-op, but two different clients sharing one unscoped
+	// store can produce a mock that fails to match at replay. Pre-existing —
+	// the shared placeholder-address bucket already had this — but the identity
+	// does not remove it, so do not read it as doing so.
+	last map[string]lastGreeting
+	// lastPruned is when the last-greeting cache was last swept, so the sweep is
+	// not repeated on every write while the map is under budget.
+	lastPruned time.Time
 }
+
+// lastGreeting is a cached greeting plus the identity of the server that
+// produced it, so a key that does NOT name a server (a port-scoped key) can
+// still refuse to serve one server's greeting to another.
+type lastGreeting struct {
+	entry TLSHandshakeEntry
+	// serverID identifies the SERVER whose raw leg produced this entry, as
+	// supplied by the caller. It is deliberately opaque to this package: the
+	// MySQL recorder passes a fingerprint of the greeting's server-stable fields
+	// rather than an address, because in Kubernetes the same server answers on a
+	// different pod IP after any rollout. Empty for address-keyed entries, where
+	// the key already names the server.
+	serverID string
+	// ambiguous latches once two DIFFERENT server identities have been recorded
+	// under the same key. Once latched it is never unlatched by a write, and it
+	// is exempt from the TTL sweep, because a key shown not to identify a single
+	// server cannot become trustworthy again — serving across servers stitches
+	// the wrong capability flags / auth plugin into a connection's config mock.
+	// (Tombstones are still subject to their own eviction budget, so an agent
+	// that accumulates more than maxLastGreetings of them will drop the oldest.)
+	ambiguous bool
+	seen      time.Time
+}
+
+const (
+	// lastPortKeyPrefix marks keys built by HandshakeLastPortKey, which must
+	// only ever be written through RememberLastForPort.
+	lastPortKeyPrefix = "dstport:"
+	// lastGreetingTTL bounds how long a cached greeting stays usable. It is far
+	// longer than tlsHandshakeEntryTTL because this cache exists to survive a
+	// connection's own entry being consumed, but it is not unbounded: a server
+	// restarted hours ago may advertise different capabilities.
+	lastGreetingTTL = 30 * time.Minute
+	// maxLastGreetings caps the cache. Cardinality is distinct (scope,
+	// destination) pairs, and a long-lived DaemonSet agent accumulates one per
+	// app x session x destination, so without a cap this map only ever grows.
+	maxLastGreetings = 512
+)
 
 type timedTLSHandshakeEntry struct {
 	entry    TLSHandshakeEntry
@@ -68,7 +145,7 @@ type timedTLSHandshakeEntry struct {
 func NewTLSHandshakeStore() *TLSHandshakeStore {
 	s := &TLSHandshakeStore{
 		m:    make(map[string][]timedTLSHandshakeEntry),
-		last: make(map[string]TLSHandshakeEntry),
+		last: make(map[string]lastGreeting),
 	}
 	s.cond = sync.NewCond(&s.mu)
 	return s
@@ -117,6 +194,45 @@ func HandshakeLastKey(scope string, dst *ConditionalDstCfg) string {
 	return "dst:" + scope + "|" + dst.Addr
 }
 
+// HandshakeLastPortKey builds the port-scoped key for the last-greeting cache.
+//
+// It exists because the two legs of a proxyless TLS connection do not agree on
+// an address. The raw plaintext leg is captured with the connection's real
+// destination, but the DECRYPTED leg arrives from an fd-less uprobe whose
+// destination the capture layer could not resolve, so it carries a synthesized
+// stand-in (ConditionalDstCfg.AddrFabricated). Keyed on the address alone the
+// writer and the reader therefore never meet, and the last-greeting fallback —
+// the whole point of which is to rescue a connection whose own raw leg was
+// lost — can never fire on that path.
+//
+// The port IS agreed: it is the same value both legs key their consumable
+// entries under (HandshakeStoreKey's "port:%d"), recovered on the decrypted leg
+// from content matching. Combining it with the caller's app/session scope keeps
+// the isolation that matters: scope is what stops a shared DaemonSet agent from
+// serving app A's greeting to app B, which is the cross-app contamination a
+// bare "port:3306" would allow.
+//
+// Residual, and the same one HandshakeLastKey already documents: within ONE
+// scope, two different servers on the same port collapse to this key. That is
+// narrower than the cross-app case, is already indistinguishable to the
+// decrypted leg (it cannot resolve its own destination), and only ever applies
+// after the connection's own greeting has gone missing.
+//
+// Returns "" — meaning do not cache and do not read the cache — when there is
+// no port to key on.
+func HandshakeLastPortKey(scope string, dstPort uint16) string {
+	if dstPort == 0 {
+		return ""
+	}
+	// An empty scope is permitted, matching HandshakeLastKey: a process that was
+	// never told a scope is a classic sidecar serving ONE session, so there is no
+	// second app to contaminate. Scope is the CROSS-APP guard and is set by the
+	// multi-app DaemonSet path; cross-SERVER safety comes from the ambiguity
+	// latch instead (see RememberLastForPort), which is what makes a key that
+	// does not name a server usable at all.
+	return fmt.Sprintf("%s%s|%d", lastPortKeyPrefix, scope, dstPort)
+}
+
 // RememberLast records entry as the most recent greeting seen for a
 // destination. A empty key is ignored, so callers may pass
 // HandshakeLastKey's result unconditionally.
@@ -124,12 +240,136 @@ func (s *TLSHandshakeStore) RememberLast(key string, entry TLSHandshakeEntry) {
 	if key == "" {
 		return
 	}
-	s.mu.Lock()
-	if s.last == nil {
-		s.last = make(map[string]TLSHandshakeEntry)
+	// A port key carries no server identity of its own, so it is safe only while
+	// every write tags the destination it came from (RememberLastForPort). An
+	// untagged write here would blank that tag and permanently disable the
+	// ambiguity latch for that key, so refuse it rather than silently weaken it.
+	if strings.HasPrefix(key, lastPortKeyPrefix) {
+		return
 	}
-	s.last[key] = entry
-	s.mu.Unlock()
+	s.rememberLast(key, "", entry)
+}
+
+// IsAmbiguous reports whether a key has been latched: two different servers were
+// seen under it, so nothing recorded there may be reused. Callers use this as
+// POSITIVE evidence that this scope+port serves more than one server, and should
+// then decline any other identity-less fallback for the same connection rather
+// than quietly reaching for one.
+func (s *TLSHandshakeStore) IsAmbiguous(key string) bool {
+	if key == "" {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.last[key].ambiguous
+}
+
+// RememberLastForPort records entry under a key that does NOT name a server
+// (see HandshakeLastPortKey), tagging it with the caller's opaque identity for
+// the SERVER that produced it. Callers must NOT pass an address: the MySQL
+// recorder passes a fingerprint of the greeting's server-stable fields, because
+// in Kubernetes one server answers on a new pod IP after every rollout and an
+// address-tagged latch would fire on two connections to the same server. If a
+// DIFFERENT identity is later recorded under the same key
+// the entry is latched ambiguous and Last stops serving it — the key has been
+// proven not to identify one server, and a cross-server greeting would corrupt
+// the borrower's config mock rather than merely fail to fill it.
+func (s *TLSHandshakeStore) RememberLastForPort(key string, serverID string, entry TLSHandshakeEntry) {
+	if key == "" || serverID == "" {
+		return
+	}
+	s.rememberLast(key, serverID, entry)
+}
+
+func (s *TLSHandshakeStore) rememberLast(key string, serverID string, entry TLSHandshakeEntry) {
+	if key == "" {
+		return
+	}
+	now := time.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.last == nil {
+		s.last = make(map[string]lastGreeting)
+	}
+	cur, ok := s.last[key]
+	if ok && cur.ambiguous {
+		// Latched: never serve this key again. Refresh seen so the tombstone ages
+		// with USE, not with time-since-latching. It is already exempt from the
+		// TTL sweep, so this is about EVICTION ORDER: the tombstone budget evicts
+		// the oldest, and a frozen timestamp would make a busy key's tombstone
+		// the first one dropped — after which the next single-server write
+		// recreates a clean, SERVING entry for a key we proved unsafe.
+		cur.seen = now
+		s.last[key] = cur
+		return
+	}
+	if ok && serverID != "" && cur.serverID != "" && cur.serverID != serverID {
+		s.last[key] = lastGreeting{ambiguous: true, seen: now}
+		return
+	}
+	s.last[key] = lastGreeting{entry: entry, serverID: serverID, seen: now}
+	// Prune AFTER inserting, so a write cannot leave the map over its budget;
+	// pruning first leaves it one over every time. Live entries and tombstones
+	// are budgeted separately, so the map holds about 2*maxLastGreetings — a
+	// latching write returns before pruning, so the tombstone class can sit one
+	// over its budget until the next write.
+	s.pruneLastLocked(now)
+}
+
+// pruneLastLocked drops expired entries and, if still over the cap, the oldest
+// ones. Live entries and tombstones have SEPARATE budgets: tombstones must not
+// be able to crowd out live entries (that would disable the fallback store-wide,
+// recreating the capture loss this cache prevents), and live entries must not be
+// able to evict tombstones early (that would let a proven-unsafe key serve
+// again).
+func (s *TLSHandshakeStore) pruneLastLocked(now time.Time) {
+	// Fast path. This runs under s.mu, which also serialises Push/PopWait for
+	// every MySQL connection, and the sweeps below are full map scans. While the
+	// map is comfortably under budget there is nothing for them to find, so only
+	// pay for them once it is worth checking.
+	if len(s.last) <= maxLastGreetings && now.Sub(s.lastPruned) < lastGreetingTTL {
+		return
+	}
+	s.lastPruned = now
+	for k, v := range s.last {
+		// Tombstones are exempt: expiring one lets a key already proven not to
+		// identify a single server start serving again. They are bounded by
+		// their own budget in the cap step below instead.
+		if v.ambiguous {
+			continue
+		}
+		if now.Sub(v.seen) > lastGreetingTTL {
+			delete(s.last, k)
+		}
+	}
+	// Tombstones and live entries are capped SEPARATELY. Sharing one budget makes
+	// them compete: tombstones are refreshed on every suppressed write, so on a
+	// key that keeps taking traffic they stay the NEWEST entries in the map while
+	// genuinely useful live greetings age past them and get evicted first. The
+	// cache then fills with keys that can only ever refuse, and the fallback goes
+	// dead for destinations that were never ambiguous at all.
+	evictOldest := func(ambiguous bool, budget int) {
+		for {
+			n := 0
+			var oldestKey string
+			var oldest time.Time
+			for k, v := range s.last {
+				if v.ambiguous != ambiguous {
+					continue
+				}
+				n++
+				if oldestKey == "" || v.seen.Before(oldest) {
+					oldestKey, oldest = k, v.seen
+				}
+			}
+			if n <= budget || oldestKey == "" {
+				return
+			}
+			delete(s.last, oldestKey)
+		}
+	}
+	evictOldest(false, maxLastGreetings)
+	evictOldest(true, maxLastGreetings)
 }
 
 // Push adds a handshake entry for the given key.
@@ -146,17 +386,19 @@ func (s *TLSHandshakeStore) Push(key string, entry TLSHandshakeEntry) {
 	})
 	// The last-greeting cache is NOT populated from the queue key. A queue key
 	// is a port or a connection, neither of which identifies a server, and this
-	// cache is never TTL/size-pruned. Callers record into it explicitly via
-	// RememberLast with a destination-scoped key.
+	// cache is pruned on its own, much longer schedule (lastGreetingTTL) and
+	// capped. Callers record into it explicitly via RememberLast (destination
+	// keys) or RememberLastForPort (port keys).
 	s.cond.Broadcast()
 	s.mu.Unlock()
 }
 
 // Last returns the most recent entry recorded for a destination key, without
 // consuming anything. Unlike PopWait it survives consumption by other
-// connections and the TTL prune, so it stays available as a stitching
-// fallback when a connection's own raw-leg entry was lost (dropped
-// capture event / >TTL delay). Callers must treat the result as
+// connections and the consumable queue's TTL prune, so it stays available as a
+// stitching fallback when a connection's own raw-leg entry was lost (dropped
+// capture event / >TTL delay). It has its own, longer expiry (lastGreetingTTL)
+// and refuses any key latched ambiguous by RememberLastForPort. Callers must treat the result as
 // belonging to ANOTHER connection to the same server: reuse the
 // server-stable parts (greeting capabilities / plugin, client
 // SSLRequest shape) but not per-connection metadata such as the
@@ -164,8 +406,14 @@ func (s *TLSHandshakeStore) Push(key string, entry TLSHandshakeEntry) {
 func (s *TLSHandshakeStore) Last(key string) (TLSHandshakeEntry, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	entry, ok := s.last[key]
-	return entry, ok
+	v, ok := s.last[key]
+	if !ok || v.ambiguous {
+		return TLSHandshakeEntry{}, false
+	}
+	if time.Since(v.seen) > lastGreetingTTL {
+		return TLSHandshakeEntry{}, false
+	}
+	return v.entry, true
 }
 
 // PopWait pops the oldest handshake entry for the given key, waiting up

--- a/pkg/models/tls_handshake_store_test.go
+++ b/pkg/models/tls_handshake_store_test.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -63,10 +64,11 @@ func TestTLSHandshakeStore_LastSurvivesConsumption(t *testing.T) {
 	}
 }
 
-// TestTLSHandshakeStore_LastOnlyCachesPortKeys pins the leak guard (finding A):
-// `last` is never TTL/size-pruned, so it must only cache low-cardinality
-// PORT-scoped keys. A conn-scoped key must NOT populate `last` (it would
-// accumulate one unremovable entry per connection over a long session) — while
+// TestTLSHandshakeStore_CacheIsExplicitAndScopeIsolated pins that `last` is
+// populated ONLY by an explicit RememberLast/RememberLastForPort call, never as
+// a side effect of Push. A conn-scoped key must not reach it: that would add one
+// entry per connection, which even with the TTL and size cap would churn the
+// cache and evict the low-cardinality entries the fallback depends on — while
 // still flowing normally through the consumable queue m.
 func TestTLSHandshakeStore_CacheIsExplicitAndScopeIsolated(t *testing.T) {
 	s := NewTLSHandshakeStore()
@@ -84,15 +86,15 @@ func TestTLSHandshakeStore_CacheIsExplicitAndScopeIsolated(t *testing.T) {
 	}
 	// ...but it must NOT have been cached in `last` (the unpruned map).
 	if _, ok := s.Last(connKey); ok {
-		t.Fatal("conn-scoped key must NOT populate the last-greeting cache — it would leak unbounded")
+		t.Fatal("conn-scoped key must NOT populate the last-greeting cache — one entry per connection would churn it")
 	}
 
 	// Push never populates the cache now, whatever the key shape.
 	portKey := HandshakeStoreKey("", 3306)
 	s.Push(portKey, entry)
 	if _, ok := s.Last(portKey); ok {
-		t.Fatal("Push must not populate the last-greeting cache: a port names no server, and this " +
-			"map is never pruned")
+		t.Fatal("Push must not populate the last-greeting cache: a port names no server, so an " +
+			"entry there is only safe when tagged via RememberLastForPort")
 	}
 
 	// Only an explicit, scope+destination keyed record does.
@@ -130,5 +132,300 @@ func TestTLSHandshakeStore_PopWaitWakesOnPush(t *testing.T) {
 	}
 	if elapsed := time.Since(start); elapsed > 2*time.Second {
 		t.Fatalf("PopWait took %v — it must wake on Push, not sleep out the timeout", elapsed)
+	}
+}
+
+// TestRememberLastForPort_LatchesAmbiguousAcrossServers pins the guard that
+// makes a port-scoped greeting cache safe. A port key does not name a server,
+// so the moment two DIFFERENT destinations are seen under one it must stop
+// serving: handing server B's greeting to a connection talking to server A
+// would stitch A's capability flags and auth plugin into B's config mock —
+// silently wrong data, which is worse than the missing mock it replaces.
+func TestRememberLastForPort_LatchesAmbiguousAcrossServers(t *testing.T) {
+	s := NewTLSHandshakeStore()
+	key := HandshakeLastPortKey("ns/app/ts0", 3306)
+	if key == "" {
+		t.Fatal("expected a non-empty port key for a scoped caller")
+	}
+
+	s.RememberLastForPort(key, "v10|8.4.0|caps=1|cs=255|caching_sha2_password", TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'A'}}})
+	if got, ok := s.Last(key); !ok || string(got.RespPackets[0]) != "\x0aA" {
+		t.Fatalf("single server should be served from the port key; ok=%v", ok)
+	}
+
+	// A second, different server appears on the same port.
+	s.RememberLastForPort(key, "v10|5.7.44|caps=2|cs=33|mysql_native_password", TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'B'}}})
+	if _, ok := s.Last(key); ok {
+		t.Error("port key kept serving after two distinct servers were seen — cross-server contamination")
+	}
+
+	// The latch is permanent: a later write from the original server must not
+	// resurrect a key already proven not to identify one server.
+	s.RememberLastForPort(key, "v10|8.4.0|caps=1|cs=255|caching_sha2_password", TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'A'}}})
+	if _, ok := s.Last(key); ok {
+		t.Error("ambiguity latch was cleared by a later write; it must never unlatch")
+	}
+}
+
+// TestHandshakeLastPortKey_AllowsEmptyScopeRejectsZeroPort pins the key's
+// contract.
+func TestHandshakeLastPortKey_AllowsEmptyScopeRejectsZeroPort(t *testing.T) {
+	// An unscoped caller is a classic sidecar serving one session, so it still
+	// gets a key — matching HandshakeLastKey, which accepts an empty scope for
+	// the same reason. Cross-server safety comes from the ambiguity latch, not
+	// from scope; scope is the CROSS-APP guard the DaemonSet path sets.
+	if got := HandshakeLastPortKey("", 3306); got == "" {
+		t.Error("an unscoped caller got no port key; the sidecar path would lose the fallback entirely")
+	}
+	// A port is the one thing the key must have.
+	if got := HandshakeLastPortKey("ns/app/ts0", 0); got != "" {
+		t.Errorf("HandshakeLastPortKey(_, 0) = %q, want \"\"", got)
+	}
+	// Scope must still separate apps when it IS set.
+	if HandshakeLastPortKey("ns/app-a/ts0", 3306) == HandshakeLastPortKey("ns/app-b/ts0", 3306) {
+		t.Error("two scoped apps share a port key — cross-app greeting contamination")
+	}
+}
+
+// TestLastGreetingCacheIsBounded pins that the never-consumed cache cannot grow
+// without limit in a long-lived DaemonSet agent, which accumulates one entry
+// per app x session x destination.
+func TestLastGreetingCacheIsBounded(t *testing.T) {
+	s := NewTLSHandshakeStore()
+	for i := 0; i < maxLastGreetings*2; i++ {
+		s.RememberLast(HandshakeLastKey("scope", &ConditionalDstCfg{Addr: fmt.Sprintf("10.0.%d.%d:3306", i/256, i%256)}),
+			TLSHandshakeEntry{RespPackets: [][]byte{{0x0a}}})
+	}
+	s.mu.Lock()
+	n := len(s.last)
+	s.mu.Unlock()
+	if n > maxLastGreetings {
+		t.Errorf("last-greeting cache holds %d entries, want <= %d — unbounded growth", n, maxLastGreetings)
+	}
+}
+
+// TestLastGreetingExpires pins the TTL: a greeting cached long ago may describe
+// a server that has since restarted with different capabilities.
+func TestLastGreetingExpires(t *testing.T) {
+	s := NewTLSHandshakeStore()
+	key := HandshakeLastKey("scope", &ConditionalDstCfg{Addr: "10.0.0.5:3306"})
+	s.RememberLast(key, TLSHandshakeEntry{RespPackets: [][]byte{{0x0a}}})
+	s.mu.Lock()
+	v := s.last[key]
+	v.seen = time.Now().Add(-2 * lastGreetingTTL)
+	s.last[key] = v
+	s.mu.Unlock()
+	if _, ok := s.Last(key); ok {
+		t.Error("Last served an entry older than lastGreetingTTL")
+	}
+}
+
+// TestAmbiguityLatchSurvivesTTL pins that a proven-unsafe key stays unsafe. The
+// tombstone's timestamp must be refreshed by suppressed writes and exempt from
+// the TTL sweep — otherwise the latch simply expires and the next single-server
+// write recreates a clean, serving entry, reopening cross-server contamination
+// on a repeating 30-minute cycle.
+func TestAmbiguityLatchSurvivesTTL(t *testing.T) {
+	s := NewTLSHandshakeStore()
+	key := HandshakeLastPortKey("ns/app/ts0", 3306)
+	s.RememberLastForPort(key, "v10|8.4.0|caps=1|cs=255|caching_sha2_password", TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'A'}}})
+	s.RememberLastForPort(key, "v10|5.7.44|caps=2|cs=33|mysql_native_password", TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'B'}}})
+	if _, ok := s.Last(key); ok {
+		t.Fatal("precondition: key should be latched ambiguous")
+	}
+
+	// Age the tombstone well past the TTL, then drive a sweep with an unrelated
+	// write, exactly as a busy agent would.
+	s.mu.Lock()
+	v := s.last[key]
+	v.seen = time.Now().Add(-4 * lastGreetingTTL)
+	s.last[key] = v
+	// Also backdate lastPruned: pruneLastLocked has a fast path that skips the
+	// sweep entirely while the map is under budget and was swept recently, so
+	// without this the "unrelated write" below returns before sweeping and the
+	// test asserts nothing. (That fast path silently disarmed this guard once.)
+	s.lastPruned = time.Now().Add(-4 * lastGreetingTTL)
+	s.mu.Unlock()
+	s.RememberLast(HandshakeLastKey("ns/app/ts0", &ConditionalDstCfg{Addr: "10.0.0.7:5432"}),
+		TLSHandshakeEntry{RespPackets: [][]byte{{0x0a}}})
+
+	s.mu.Lock()
+	_, stillThere := s.last[key]
+	s.mu.Unlock()
+	if !stillThere {
+		t.Error("ambiguity tombstone was collected by the TTL sweep; it must age with use, not with time")
+	}
+	// And a later single-server write must not resurrect it.
+	s.RememberLastForPort(key, "v10|8.4.0|caps=1|cs=255|caching_sha2_password", TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'A'}}})
+	if _, ok := s.Last(key); ok {
+		t.Error("port key serves again after the TTL window — cross-server contamination reopened")
+	}
+}
+
+// TestTombstonesDoNotStarveTheCache pins that ambiguous keys cannot disable the
+// whole fallback. Sharing one budget with live entries lets tombstones fill the
+// map, after which the only evictable entry is whichever was just inserted — so
+// every write is undone and the cache goes dead store-wide, silently recreating
+// the capture-loss bug it exists to prevent.
+func TestTombstonesDoNotStarveTheCache(t *testing.T) {
+	s := NewTLSHandshakeStore()
+	// Live greetings recorded first, so they are the OLDEST entries in the map.
+	// Half the budget, so the result is unambiguous: with SEPARATE budgets every
+	// one of these survives; with a shared budget the refreshed tombstones push
+	// the total past the cap and evict these, the oldest, first.
+	nLive := maxLastGreetings / 2
+	var live []string
+	for i := 0; i < nLive; i++ {
+		k := HandshakeLastKey(fmt.Sprintf("ns/live-%d/ts0", i), &ConditionalDstCfg{Addr: "10.0.0.5:3306"})
+		s.RememberLast(k, TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'L'}}})
+		live = append(live, k)
+	}
+	// Then a busy set of latched keys. Every suppressed write refreshes their
+	// timestamps, so on a SHARED budget they stay newest and the live entries
+	// above become the eviction victims.
+	for i := 0; i < maxLastGreetings; i++ {
+		k := HandshakeLastPortKey(fmt.Sprintf("ns/amb-%d/ts0", i), 3306)
+		s.RememberLastForPort(k, "server-A", TLSHandshakeEntry{RespPackets: [][]byte{{0x0a}}})
+		s.RememberLastForPort(k, "server-B", TLSHandshakeEntry{RespPackets: [][]byte{{0x0a}}})
+		s.RememberLastForPort(k, "server-A", TLSHandshakeEntry{RespPackets: [][]byte{{0x0a}}}) // refresh
+	}
+
+	surviving := 0
+	for _, k := range live {
+		if _, ok := s.Last(k); ok {
+			surviving++
+		}
+	}
+	if surviving == 0 {
+		t.Fatalf("all %d live greetings were evicted by refreshed tombstones — the fallback is dead "+
+			"for destinations that were never ambiguous", len(live))
+	}
+	if surviving != nLive {
+		t.Errorf("live greetings surviving = %d, want %d: tombstones must not compete with them "+
+			"for the same budget", surviving, nLive)
+	}
+}
+
+// TestRememberLastRefusesPortKeys pins that the untagged setter cannot be used on
+// a port key. A port key is only safe while every write carries a server
+// identity; an untagged write would blank that tag and permanently disable the
+// ambiguity latch, turning the guarded key into an unguarded one.
+func TestRememberLastRefusesPortKeys(t *testing.T) {
+	s := NewTLSHandshakeStore()
+	key := HandshakeLastPortKey("ns/app/ts0", 3306)
+	s.RememberLast(key, TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'X'}}})
+	if _, ok := s.Last(key); ok {
+		t.Error("RememberLast populated a port key; an untagged entry there disables the latch")
+	}
+	// And it must not be able to clear an existing latch either.
+	s.RememberLastForPort(key, "server-A", TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'A'}}})
+	s.RememberLastForPort(key, "server-B", TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'B'}}})
+	s.RememberLast(key, TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'X'}}})
+	if _, ok := s.Last(key); ok {
+		t.Error("an untagged RememberLast cleared a latched port key")
+	}
+}
+
+// TestRememberLastForPort_SameServerNewAddressDoesNotLatch is the Kubernetes
+// case that decides whether this fallback survives in production at all.
+//
+// The latch identifies a server by the caller-supplied serverID, NOT by address,
+// precisely because addresses are unstable in k8s: a StatefulSet rollout gives
+// the same logical MySQL a new pod IP, and a Service with several endpoints
+// hands out a different IP per connection. An address-tagged latch fires on two
+// connections to the SAME server, and because tombstones are TTL-exempt it would
+// then disable the fallback permanently for that scope+port — the fix would go
+// dead after the first rollout, silently, while every test stayed green.
+func TestRememberLastForPort_SameServerNewAddressDoesNotLatch(t *testing.T) {
+	s := NewTLSHandshakeStore()
+	key := HandshakeLastPortKey("ns/app/ts0", 3306)
+	const sameServer = "v10|8.4.0|caps=123|cs=255|caching_sha2_password"
+
+	// Pod 10.244.0.24 before the rollout, 10.244.0.31 after — one server.
+	s.RememberLastForPort(key, sameServer, TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'A'}}})
+	s.RememberLastForPort(key, sameServer, TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'A'}}})
+
+	got, ok := s.Last(key)
+	if !ok {
+		t.Fatal("the same server on a new pod IP latched the key ambiguous; the fallback is now " +
+			"permanently dead for this scope+port, which is the environment it exists for")
+	}
+	if len(got.RespPackets) == 0 || got.RespPackets[0][1] != 'A' {
+		t.Errorf("wrong entry returned: %q", got.RespPackets)
+	}
+	if s.IsAmbiguous(key) {
+		t.Error("IsAmbiguous reports a latch for a single server")
+	}
+
+	// A genuinely different server — different capability flags — must still latch.
+	s.RememberLastForPort(key, "v10|5.7.44|caps=999|cs=33|mysql_native_password",
+		TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'B'}}})
+	if _, ok := s.Last(key); ok {
+		t.Error("two genuinely different servers did not latch the key")
+	}
+	if !s.IsAmbiguous(key) {
+		t.Error("IsAmbiguous did not report the latch")
+	}
+}
+
+// TestTombstoneRefreshSurvivesEvictionPressure pins the `cur.seen = now` refresh
+// on a suppressed write.
+//
+// Tombstones are exempt from the TTL sweep but NOT from their own eviction
+// budget. Without the refresh a tombstone's timestamp is frozen at the moment of
+// latching, so a key that keeps taking traffic becomes the OLDEST entry and is
+// evicted first — after which the next single-server write recreates a clean,
+// SERVING entry for a key already proven to have two servers behind it. The
+// refresh makes a tombstone age with USE rather than with time-since-latching.
+func TestTombstoneRefreshSurvivesEvictionPressure(t *testing.T) {
+	s := NewTLSHandshakeStore()
+	victim := HandshakeLastPortKey("ns/victim/ts0", 3306)
+
+	// Latch the victim FIRST, so without a refresh it is the oldest tombstone.
+	s.RememberLastForPort(victim, "srv-A", TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'A'}}})
+	s.RememberLastForPort(victim, "srv-B", TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'B'}}})
+	if !s.IsAmbiguous(victim) {
+		t.Fatal("precondition: victim should be latched")
+	}
+
+	// Fill the tombstone budget with other latched keys, refreshing the victim
+	// along the way exactly as continuing traffic on that destination would.
+	for i := 0; i < maxLastGreetings+16; i++ {
+		k := HandshakeLastPortKey(fmt.Sprintf("ns/filler-%d/ts0", i), 3306)
+		s.RememberLastForPort(k, "srv-X", TLSHandshakeEntry{RespPackets: [][]byte{{0x0a}}})
+		s.RememberLastForPort(k, "srv-Y", TLSHandshakeEntry{RespPackets: [][]byte{{0x0a}}})
+		// Traffic keeps arriving on the victim's destination.
+		s.RememberLastForPort(victim, "srv-A", TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'A'}}})
+	}
+
+	if !s.IsAmbiguous(victim) {
+		t.Error("a still-busy latched key was evicted under tombstone pressure; the next " +
+			"single-server write would recreate it CLEAN and cross-server reuse reopens")
+	}
+	if _, ok := s.Last(victim); ok {
+		t.Error("the victim key is serving again after eviction pressure")
+	}
+}
+
+// TestRememberLastForPortRefusesEmptyIdentity pins the guard the CI mutation
+// job's own reasoning depends on: mutant 2 blanks the server identity and
+// expects the port key to go unwritten. If an untagged entry could reach a port
+// key, the latch would be permanently disabled for it — a port key carries no
+// server identity of its own, so an entry with no identity can never be shown
+// to be unsafe.
+func TestRememberLastForPortRefusesEmptyIdentity(t *testing.T) {
+	s := NewTLSHandshakeStore()
+	key := HandshakeLastPortKey("ns/app/ts0", 3306)
+	s.RememberLastForPort(key, "", TLSHandshakeEntry{RespPackets: [][]byte{{0x0a}}})
+	if _, ok := s.Last(key); ok {
+		t.Error("an untagged entry reached a port key; the ambiguity latch is permanently " +
+			"disabled for it, and the CI guard's blank-identity mutant would stop being a kill")
+	}
+	// And it must not be able to clear an existing latch.
+	s.RememberLastForPort(key, "srv-A", TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'A'}}})
+	s.RememberLastForPort(key, "srv-B", TLSHandshakeEntry{RespPackets: [][]byte{{0x0a, 'B'}}})
+	s.RememberLastForPort(key, "", TLSHandshakeEntry{RespPackets: [][]byte{{0x0a}}})
+	if !s.IsAmbiguous(key) {
+		t.Error("an untagged write cleared a latched port key")
 	}
 }


### PR DESCRIPTION
## The bug

Proxyless MySQL-over-TLS recording splits into two legs: a raw plaintext leg carrying the server greeting + SSLRequest, and a decrypted TLS-uprobe leg carrying the command phase. The greeting is stashed under `conn:<connKey>` and `port:<dstPort>` — and `PopWait` **consumes** it.

A pooled connection reused across cycles has no handshake of its own, so both keys miss. `resolvePreTLSGreeting` documents a last-resort `cachedGreeting` fallback for exactly this — but **nothing on the V2 path ever wrote the cache**. The only non-test `RememberLast` caller was the legacy `handleInitialHandshake`, which proxyless never runs.

So the fallback was dead code. Such a connection fell through to `fetchServerGreeting` and its record was **silently discarded** — no error the user sees, surfacing much later as an unexplained dirty replay verdict.

Measured on the failing CI cycle: the count of `V2: failed to handle initial mysql handshake` equals the capture shortfall exactly, and 11 MySQL connections opened against 11 greetings captured — nothing was lost in the ring buffer; the greeting was captured and then consumed.

## The fix

`storePreTLSHandshakeV2` now seeds the cache under the existing address key **and** a new scope-qualified **port key**. The two legs disagree about the address — the decrypted leg's destination is frequently unresolvable, so it presents a capture-layer stand-in that can never match what the raw leg wrote. The port is the one thing both legs agree on.

A key that doesn't name a server is only safe with a runtime guard, so each port-keyed entry is tagged with a **server identity** and the key latches unusable once a second, different identity appears.

The identity is a **fingerprint of the greeting** (protocol version, server version, capability flags, charset, auth plugin) — deliberately *not* the address. In Kubernetes the same server answers on a new pod IP after every rollout, so an address-tagged latch fires on two connections to the *same* server and disables the fallback permanently. The excluded fields (connection id, salt, status flags) differ per connection and are not verified on record or replay.

Also:
- a leg whose own destination **is** resolved never accepts an answer from the port key;
- a latched port key makes the resolver decline outright rather than fall through to the unguarded shared address bucket;
- the cache is bounded (30m TTL, 512-entry cap) with **separate** eviction budgets so tombstones cannot starve live entries.

## Scope and known limits

- **V2 only.** The legacy path (`KEPLOY_NEW_RELAY=off`) never reads the last-greeting cache, so the pooled-connection loss persists there.
- The port key is activated by `ConditionalDstCfg.AddrFabricated`, which **has no producer in this repository** — it is set by the out-of-tree proxyless capture layer. This is stated at the gate, because "a mechanism with no in-tree caller" is precisely the defect being fixed.
- The latch is **best-effort**: a server that never writes the key cannot trip it. Documented in code.

## Testing

- New unit + resolver tests, plus an end-to-end raw-leg test that drives `RecordV2` and asserts the port key is seeded.
- A CI lane runs the guards under `-race -count=3`, plus a **mutation-guard job** that strips the fix and fails if the tests still pass — the original defect was a mechanism with no caller, and a regression test that quietly stops exercising it would hide the same thing.
- Adversarial review swept 63 mutants with **zero load-bearing survivors**.