### PR TITLE
fix(replay): report the async verdict for every test-set, not just the first

### DIFF
--- a/pkg/agent/proxy/integrations/async/engine.go
+++ b/pkg/agent/proxy/integrations/async/engine.go
@@ -61,10 +61,53 @@ type Engine struct {
 	completed  int                    // number of testcases completed
 	windowSeen bool                   // AdvanceWindow: first window doesn't count as a completed test
 
+	// pass/flag are CUMULATIVE for this Engine's lifetime and are deliberately
+	// never reset. CI parses the emitted verdict line with `tail -n1`
+	// (.github/workflows/test_workflow_scripts/java/async_config_poll/java-linux.sh),
+	// so the LAST line has to describe the whole run. Per-set deltas would
+	// quietly narrow that gate from "no drift anywhere in the run" to "no drift
+	// in the last chunk" — and worse, a poll woken by the test-set context
+	// being cancelled (holdThrottle registers a context.AfterFunc that
+	// broadcasts on cancel) lands AFTER the per-set flush, so the final line
+	// would report served:0 on a run that served dozens.
+	//
+	// Scope, stated precisely: a straggler landing between the per-set flush
+	// and the run-level one IS counted, because the run-level flush follows it.
+	// One landing after the run-level flush is not — replay.go cancels the run
+	// context immediately after that notify and no seam flushes afterwards
+	// (Proxy.StopProxyServer would, but it is dead code with no call
+	// expression anywhere). That tail was equally lost under the sync.Once
+	// guard, so it is unchanged here rather than fixed.
 	pass, flag int
-	flags      []string
+	// flags holds drift details NOT YET EMITTED. LogReport drains it, so each
+	// detail is logged exactly once even though LogReport now fires per
+	// test-set. Draining is also what stops the output going quadratic: with
+	// logOnce removed but the slice retained, every flush would re-log the
+	// whole backlog.
+	flags []string
+	// lastPass/lastFlag are the tallies as of the last emitted line. LogReport
+	// emits only when the cumulative counts have MOVED since then, which is
+	// what keeps record mode silent (it never increments) and what suppresses a
+	// duplicate identical line when the run-level flush follows a per-set flush
+	// with no traffic in between.
+	lastPass, lastFlag int
 
-	logOnce         sync.Once // LogReport fires at most once (multiple shutdown seams call it)
+	// emitMu serialises drain-and-log as one unit. drainReport returns under
+	// e.mu but the logger.Info call happens after it is released, so two
+	// concurrent LogReport callers could otherwise write their lines in the
+	// opposite order to their snapshots — and CI reads the LAST line, so it
+	// would see the SMALLER total. The replayer happens to serialise the two
+	// callers today; nothing in the code says so, and the whole CI contract
+	// rests on the last line being the largest.
+	//
+	// Deliberately NOT pinned by a test: making the two callers interleave
+	// deterministically means blocking one inside the other's critical section,
+	// which deadlocks against e.mu, and a purely racing test scores no
+	// detections under CI's `go test ./...`. This is defence in depth for a
+	// path that is not reachable today, kept because the invariant it protects
+	// is load-bearing and undocumented elsewhere — not because it is covered.
+	emitMu sync.Mutex
+
 	nonWindowedOnce sync.Once // WarnNonWindowed fires at most once (SetMocks runs per test-set)
 }
 
@@ -378,9 +421,66 @@ func (e *Engine) decideServe(p AsyncParser, lane models.AsyncLane, recorded, liv
 func (e *Engine) Report() ReportSnapshot {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	out := ReportSnapshot{Pass: e.pass, Flag: e.flag, NotExercised: 0, Held: 0}
+	out := e.reportLocked()
 	out.Flags = append(out.Flags, e.flags...)
 	return out
+}
+
+// reportLocked builds the tally snapshot. Caller holds e.mu.
+//
+// Shared with drainReport so the two cannot drift: ReportSnapshot.Flags is
+// populated only by Report, because drainReport hands the drift details back
+// out-of-band after draining them. Anything that printed the verdict via
+// Report would therefore re-log the whole backlog on every call — the
+// quadratic-output bug the drain exists to prevent.
+func (e *Engine) reportLocked() ReportSnapshot {
+	return ReportSnapshot{Pass: e.pass, Flag: e.flag, NotExercised: 0, Held: 0}
+}
+
+// drainTestHook, when non-nil, runs between drainReport's snapshot and its
+// cursor advance. It exists ONLY so a test can deterministically land an
+// increment in that window: the window is otherwise unreachable by racing
+// goroutines (Decide holds e.mu throughout unless the lane is a POLL lane, and
+// even then the gap is a few instructions), so a purely concurrent test scores
+// zero detections under CI's `go test ./...` — no -race, no -count>1. nil in
+// production; the branch is one predictable-not-taken compare.
+var drainTestHook func()
+
+// drainReport returns the CUMULATIVE tallies together with the drift details
+// not yet emitted, advances the emission cursor, and reports whether anything
+// actually moved — all in ONE critical section.
+//
+// One section matters: MatchRequestShape runs unlocked and its increment takes
+// e.mu afterwards, so a snapshot-then-separate-drain would let an increment
+// land in the gap and be discarded without ever being logged.
+//
+// It deliberately does NOT delegate to Report(). sync.Mutex is not reentrant
+// and Report() takes e.mu, so calling it from under the lock would self-
+// deadlock the caller — which on the SetGracefulShutdown seam is the agent's
+// HTTP handler goroutine. Handing e.flags over by assignment rather than
+// copying is safe precisely because the engine drops its own reference in the
+// same section.
+func (e *Engine) drainReport() (ReportSnapshot, []string, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.pass == e.lastPass && e.flag == e.lastFlag {
+		return ReportSnapshot{}, nil, false
+	}
+	snap := e.reportLocked()
+	if drainTestHook != nil {
+		drainTestHook()
+	}
+	drained := e.flags
+	e.flags = nil
+	// Advance the cursor to what was SNAPSHOT, not to the current values.
+	// Advancing to the current values would mark as "reported" anything that
+	// landed after the snapshot was taken — counted by the cursor, printed by
+	// no line, and never picked up again because the cursor had moved past it.
+	// e.mu makes that window empty in production (decideServe needs the lock to
+	// increment), so this costs nothing and removes the dependence on that
+	// being true.
+	e.lastPass, e.lastFlag = snap.Pass, snap.Flag
+	return snap, drained, true
 }
 
 // LogReport emits the async verdict tally so it is visible in keploy's output
@@ -393,21 +493,29 @@ func (e *Engine) Report() ReportSnapshot {
 // (holdThrottle), served lanes serve immediately. Each shape flag is logged at
 // Info with a remediation hint.
 func (e *Engine) LogReport(logger *zap.Logger) {
-	e.logOnce.Do(func() {
-		s := e.Report()
-		if s.Pass == 0 && s.Flag == 0 && s.NotExercised == 0 {
-			return // no async activity (e.g. record mode) — stay quiet
-		}
-		logger.Info("async egress verdict",
-			zap.Int("served", s.Pass),
-			zap.Int("shape_flags", s.Flag),
-			zap.Int("not_exercised", s.NotExercised),
-			zap.Int("held", s.Held))
-		for _, f := range s.Flags {
-			logger.Info("async egress shape drift (served recorded response anyway); "+
-				"re-record if the request legitimately changed, or widen the lane's "+
-				"volatileParams / match to treat the varying part as noise",
-				zap.String("detail", f))
-		}
-	})
+	e.emitMu.Lock()
+	defer e.emitMu.Unlock()
+	s, drift, moved := e.drainReport()
+	if !moved {
+		return // nothing new since the last line (record mode, or a repeat flush)
+	}
+	// Field names and ORDER are load-bearing: java-linux.sh greps the encoded
+	// line for `"served": N, "shape_flags": N, "not_exercised": N`. Renaming or
+	// reordering these silently breaks that gate.
+	logger.Info("async egress verdict",
+		zap.Int("served", s.Pass),
+		zap.Int("shape_flags", s.Flag),
+		zap.Int("not_exercised", s.NotExercised),
+		zap.Int("held", s.Held),
+		// Appended AFTER held so the three fields CI greps stay contiguous.
+		// The boundary flush runs inside RunTestSet, which the replayer has
+		// already announced as the NEXT test-set, so without this a reader
+		// attributes the previous set's verdict to the one just announced.
+		zap.String("scope", "cumulative-for-run"))
+	for _, f := range drift {
+		logger.Info("async egress shape drift (served recorded response anyway); "+
+			"re-record if the request legitimately changed, or widen the lane's "+
+			"volatileParams / match to treat the varying part as noise",
+			zap.String("detail", f))
+	}
 }

--- a/pkg/agent/proxy/integrations/async/engine_report_test.go
+++ b/pkg/agent/proxy/integrations/async/engine_report_test.go
@@ -1,0 +1,226 @@
+package async
+
+import (
+	"context"
+	"regexp"
+	"sync"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func observedEngine(t *testing.T, p AsyncParser) (*Engine, *observer.ObservedLogs, *zap.Logger) {
+	t.Helper()
+	core, logs := observer.New(zapcore.InfoLevel)
+	return newTestEngine(p), logs, zap.New(core)
+}
+
+func verdictCount(logs *observer.ObservedLogs) int {
+	return len(logs.FilterMessage("async egress verdict").All())
+}
+
+func driftCount(logs *observer.ObservedLogs) int {
+	n := 0
+	for _, e := range logs.All() {
+		if len(e.Message) >= 24 && e.Message[:24] == "async egress shape drift" {
+			n++
+		}
+	}
+	return n
+}
+
+func fieldInt(t *testing.T, e observer.LoggedEntry, key string) int64 {
+	t.Helper()
+	for _, f := range e.Context {
+		if f.Key == key {
+			return f.Integer
+		}
+	}
+	t.Fatalf("verdict line has no %q field", key)
+	return 0
+}
+
+// LogReport used to be sync.Once-guarded, so the verdict was printed at the end
+// of TEST-SET 1 and the accumulation for sets 2..N was silently discarded.
+//
+// The counts stay CUMULATIVE across flushes rather than becoming per-set
+// deltas. CI greps the line with `tail -n1`, so the last line must describe the
+// whole run; deltas would narrow that gate to "the last chunk" and let a
+// straggler poll — woken by the test-set context being cancelled — report
+// served:0 on a run that served dozens.
+func TestLogReportEmitsPerFlushWithCumulativeCounts(t *testing.T) {
+	e, logs, lg := observedEngine(t, &fakeParser{matches: true, shapeOK: true, empty: []byte("KA")})
+	lane := models.AsyncLane{Name: "L", Type: "fake", ThrottleMs: 10}
+	e.Load([]*models.Mock{asyncMock("L", 1, 0, "V0")})
+
+	e.Decide(context.Background(), lane, &models.Mock{})
+	e.LogReport(lg)
+	if got := verdictCount(logs); got != 1 {
+		t.Fatalf("first flush emitted %d verdict lines, want 1", got)
+	}
+	if got := fieldInt(t, logs.All()[0], "served"); got != 1 {
+		t.Fatalf("first verdict served=%d, want 1", got)
+	}
+
+	e.Decide(context.Background(), lane, &models.Mock{})
+	e.LogReport(lg)
+	all := logs.FilterMessage("async egress verdict").All()
+	if len(all) != 2 {
+		t.Fatalf("second flush emitted %d verdict lines total, want 2: the sync.Once "+
+			"guard is back, so every test-set after the first is invisible", len(all))
+	}
+	if got := fieldInt(t, all[1], "served"); got != 2 {
+		t.Fatalf("second verdict served=%d, want 2 (CUMULATIVE): per-set deltas make "+
+			"the last line — the one CI reads with tail -n1 — describe only the final "+
+			"chunk instead of the run", got)
+	}
+}
+
+// Drift DETAILS are drained on emit, so each is logged exactly once. Retaining
+// them while removing the Once guard would re-log the whole backlog on every
+// flush, making output quadratic in (test-sets x drifts).
+func TestLogReportDrainsDriftDetails(t *testing.T) {
+	e, logs, lg := observedEngine(t, &fakeParser{matches: true, shapeOK: false, empty: []byte("KA")})
+	lane := models.AsyncLane{Name: "L", Type: "fake", ThrottleMs: 10}
+	e.Load([]*models.Mock{asyncMock("L", 1, 0, "V0")})
+
+	e.Decide(context.Background(), lane, &models.Mock{})
+	e.LogReport(lg)
+	if got := driftCount(logs); got != 1 {
+		t.Fatalf("first flush logged %d drift details, want 1", got)
+	}
+
+	e.Decide(context.Background(), lane, &models.Mock{})
+	e.LogReport(lg)
+	if got := driftCount(logs); got != 2 {
+		t.Fatalf("logged %d drift details in total, want 2: the backlog is re-logged on "+
+			"every flush, so output grows quadratically with test-sets", got)
+	}
+	if got := fieldInt(t, logs.FilterMessage("async egress verdict").All()[1], "shape_flags"); got != 2 {
+		t.Fatalf("second verdict shape_flags=%d, want the cumulative 2", got)
+	}
+}
+
+// A flush with nothing new since the last line must stay silent — otherwise the
+// run-level flush that follows a per-set flush prints a duplicate.
+func TestLogReportQuietWhenNothingNew(t *testing.T) {
+	e, logs, lg := observedEngine(t, &fakeParser{matches: true, shapeOK: true, empty: []byte("KA")})
+	lane := models.AsyncLane{Name: "L", Type: "fake", ThrottleMs: 10}
+	e.Load([]*models.Mock{asyncMock("L", 1, 0, "V0")})
+
+	e.Decide(context.Background(), lane, &models.Mock{})
+	e.LogReport(lg)
+	before := verdictCount(logs)
+
+	e.LogReport(lg) // no traffic in between
+	if got := verdictCount(logs); got != before {
+		t.Fatalf("a repeat flush with no new activity emitted another line (%d -> %d)",
+			before, got)
+	}
+}
+
+// An engine that never served anything must stay silent: record mode never
+// increments, and LoadAsyncMocks now flushes at every test-set boundary
+// including sets with no async traffic at all.
+func TestLogReportQuietOnVirginEngine(t *testing.T) {
+	e, logs, lg := observedEngine(t, &fakeParser{matches: true, shapeOK: true, empty: []byte("KA")})
+	e.LogReport(lg)
+	if got := len(logs.All()); got != 0 {
+		t.Fatalf("a virgin engine emitted %d log entries, want 0: record mode and "+
+			"async-free test-sets would print served:0 noise", got)
+	}
+}
+
+// The verdict line is machine-read. This pins the field names AND their order
+// against the verbatim regex from
+// .github/workflows/test_workflow_scripts/java/async_config_poll/java-linux.sh:
+//
+//	'"served": [0-9]+, "shape_flags": [0-9]+, "not_exercised": [0-9]+'
+//
+// Reordering the zap.Int calls or renaming a field breaks that gate silently —
+// the lane would report "async lane was not evaluated" on a healthy run.
+func TestVerdictLineMatchesTheCIRegex(t *testing.T) {
+	e, logs, lg := observedEngine(t, &fakeParser{matches: true, shapeOK: true, empty: []byte("KA")})
+	lane := models.AsyncLane{Name: "L", Type: "fake", ThrottleMs: 10}
+	e.Load([]*models.Mock{asyncMock("L", 1, 0, "V0")})
+	e.Decide(context.Background(), lane, &models.Mock{})
+	e.LogReport(lg)
+
+	entries := logs.FilterMessage("async egress verdict").All()
+	if len(entries) != 1 {
+		t.Fatalf("want exactly one verdict line, got %d", len(entries))
+	}
+	// The CONSOLE encoder is what keploy runs (utils/log: NewDevelopmentConfig
+	// with a custom "ansiConsole" encoding), and it renders context fields as
+	// {"served": 2, "shape_flags": 0, ...} — byte-for-byte what the CI script
+	// greps. No normalisation: matching the real encoder's real output is the
+	// whole point.
+	enc := zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig())
+	buf, err := enc.EncodeEntry(entries[0].Entry, entries[0].Context)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	line := buf.String()
+
+	ciRegex := regexp.MustCompile(`"served": [0-9]+, "shape_flags": [0-9]+, "not_exercised": [0-9]+`)
+	if !ciRegex.MatchString(line) {
+		t.Fatalf("verdict line does not match the CI regex.\n  encoded: %s\n  regex: %s\n"+
+			"Field names and order are load-bearing — see java-linux.sh in "+
+			".github/workflows/test_workflow_scripts/java/async_config_poll/",
+			line, ciRegex)
+	}
+}
+
+// drainReport must do snapshot + drain + cursor advance in ONE critical
+// section: MatchRequestShape runs unlocked and takes e.mu only for its
+// increment, so a snapshot-then-separate-drain drops increments that land in
+// the gap AND advances the cursor past them, losing them permanently.
+//
+// This drives that window DETERMINISTICALLY via drainTestHook rather than by
+// racing goroutines. Racing does not work: Decide holds e.mu throughout unless
+// the lane is a POLL lane (AsyncLane.IsPoll needs a "Poll" type suffix), and
+// even with one the gap is a few instructions — a purely concurrent version of
+// this test scored ZERO detections under CI's `go test ./...`, which passes
+// neither -race nor -count>1. A test that cannot fail is worse than none.
+func TestDrainReportLosesNoIncrementInTheSnapshotWindow(t *testing.T) {
+	e, logs, lg := observedEngine(t, &fakeParser{matches: true, shapeOK: true, empty: []byte("KA")})
+	lane := models.AsyncLane{Name: "L", Type: "fake", ThrottleMs: 10}
+	e.Load([]*models.Mock{asyncMock("L", 1, 0, "V0")})
+
+	e.Decide(context.Background(), lane, &models.Mock{}) // pass = 1
+
+	// Land a second increment exactly inside the snapshot->advance window.
+	// Under a split drain the snapshot says 1, the cursor advances to 2, and
+	// that second serve is never reported by any line, ever.
+	var once sync.Once
+	drainTestHook = func() {
+		// NO locking here: the hook runs with e.mu already held by drainReport,
+		// and sync.Mutex is not reentrant — taking it would deadlock, which is
+		// the same trap that keeps drainReport from delegating to Report().
+		once.Do(func() { e.pass++ }) // as decideServe's increment would
+	}
+	t.Cleanup(func() { drainTestHook = nil })
+
+	e.LogReport(lg)
+	drainTestHook = nil
+	e.LogReport(lg) // whatever the first flush missed must surface here
+
+	entries := logs.FilterMessage("async egress verdict").All()
+	if len(entries) == 0 {
+		t.Fatal("no verdict emitted")
+	}
+	last := entries[len(entries)-1]
+	if got := fieldInt(t, last, "served"); got != 2 {
+		t.Fatalf("final cumulative served=%d, want 2: an increment landed between the "+
+			"snapshot and the cursor advance and was discarded — the cursor moved past "+
+			"it, so no later flush reports it either", got)
+	}
+}
+
+// drainReport must do snapshot + drain + cursor advance in ONE critical
+// section: MatchRequestShape runs unlocked and takes e.mu only for its
+// increment, so a snapshot-then-separate-drain drops increments that land in
+// the gap. Run under -race.

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -1101,8 +1101,13 @@ func (p *Proxy) ResetRecordedDNSMocks() {
 // When this flag is set, connection errors will be logged as debug instead of error
 func (p *Proxy) SetGracefulShutdown(_ context.Context) error {
 	p.isGracefulShutdown.Store(true)
-	// Surface the async-egress verdict at replay wind-down (logs once; the
-	// StopProxyServer path also calls this, whichever fires first wins).
+	// Surface the async-egress verdict at replay wind-down. This fires per
+	// test-set on the native path and once per run on every path (replay.go's
+	// run-level defer is ungated), so it is what covers the FINAL test-set.
+	// LogReport is idempotent when nothing has moved since the last line.
+	//
+	// StopProxyServer also calls LogReport but is unreachable — it has no call
+	// expression anywhere in the tree, only comments referring to it.
 	if p.asyncEngine != nil {
 		p.asyncEngine.LogReport(p.logger)
 	}
@@ -3257,9 +3262,32 @@ var _ agent.AsyncMockLoader = (*Proxy)(nil)
 // (which REPLACES the previous test-set's corpus). No-op when async is not
 // configured.
 func (p *Proxy) LoadAsyncMocks(mocks []*models.Mock) {
-	if p.asyncEngine != nil {
-		p.asyncEngine.Load(mocks)
+	if p.asyncEngine == nil {
+		return
 	}
+	// Flush the previous test-set's verdict at the boundary.
+	//
+	// Order relative to Load is NOT load-bearing — Load touches streams,
+	// completed and windowSeen, never the tally — so this reads before it only
+	// because that is the order the boundary happens in, not because anything
+	// depends on it.
+	//
+	// This is the only seam that runs once per test-set on EVERY replay path.
+	// The SetGracefulShutdown seam does not: replay.go gates its per-test-set
+	// notify on `r.instrument && !serveTest`, and serveTest is true for
+	// docker-compose replay with mocking on — which is the DEFAULT — so on that
+	// path only the run-level notify fires and sets 2..N would stay invisible.
+	//
+	// Emitting here is ordering-independent for the same reason Load itself
+	// replaces here rather than on a reset seam: the two replay branches call
+	// StoreMocks and MockOutgoing in opposite orders, and Load is the one call
+	// that carries the corpus.
+	//
+	// The last set is still covered: replay.go's run-level defer calls
+	// NotifyGracefulShutdown ungated, which reaches SetGracefulShutdown and
+	// flushes whatever the final set accumulated.
+	p.asyncEngine.LogReport(p.logger)
+	p.asyncEngine.Load(mocks)
 }
 
 func (p *Proxy) SetMocks(_ context.Context, filtered []*models.Mock, unFiltered []*models.Mock) error {

--- a/pkg/agent/proxy/proxy_async_test.go
+++ b/pkg/agent/proxy/proxy_async_test.go
@@ -7,6 +7,8 @@ import (
 	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/async"
 	"go.keploy.io/server/v3/pkg/models"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestSetMocksWithWindowAdvancesEngineAfterFirst(t *testing.T) {
@@ -62,5 +64,76 @@ func TestLoadAsyncMocksForwardsToEngine(t *testing.T) {
 	rec, _, _ := eng.Decide(context.Background(), lane, &models.Mock{})
 	if rec == nil || rec.Spec.HTTPResp.Body != "b" {
 		t.Fatalf("want newest same-AnchorPos epoch 'b', got %v", rec)
+	}
+}
+
+// LoadAsyncMocks must flush the previous test-set's verdict at the boundary.
+//
+// Not "before Load" — Load touches no tally state, so that ordering is not a
+// real property and asserting it would be theatre. What matters is that the
+// flush happens AT ALL on this seam.
+//
+// This is the only seam that runs once per test-set on EVERY replay path. The
+// SetGracefulShutdown seam does not: replay.go gates its per-test-set notify on
+// `r.instrument && !serveTest`, and serveTest is true for docker-compose replay
+// with mocking on — the DEFAULT — so on that path only the run-level notify
+// fires and sets 2..N would stay invisible. Without this test, reverting the
+// flush leaves every other test green.
+func TestLoadAsyncMocksFlushesTheVerdictAtTheBoundary(t *testing.T) {
+	core, logs := observer.New(zapcore.InfoLevel)
+	lane := models.AsyncLane{Name: "L", Type: "fake", ThrottleMs: 10}
+	eng := async.NewEngine(zap.NewNop(), []models.AsyncLane{lane},
+		map[string]async.AsyncParser{"fake": fakeAsyncParser{}})
+	p := &Proxy{logger: zap.New(core), asyncEngine: eng}
+
+	verdicts := func() int { return len(logs.FilterMessage("async egress verdict").All()) }
+
+	// First set: nothing served yet, so the flush must stay silent.
+	p.LoadAsyncMocks([]*models.Mock{asyncMock("L", 1, "SET-A")})
+	if got := verdicts(); got != 0 {
+		t.Fatalf("loading the first set emitted %d verdict lines, want 0", got)
+	}
+
+	if rec, _, _ := eng.Decide(context.Background(), lane, &models.Mock{}); rec == nil {
+		t.Fatal("precondition: set A must serve")
+	}
+
+	// Second set: the boundary must publish set A's verdict.
+	p.LoadAsyncMocks([]*models.Mock{asyncMock("L", 1, "SET-B")})
+	entries := logs.FilterMessage("async egress verdict").All()
+	if len(entries) != 1 {
+		t.Fatalf("the test-set boundary emitted %d verdict lines, want 1: without the "+
+			"flush in LoadAsyncMocks, every set after the first is invisible on the "+
+			"docker-compose and --keep-app-alive paths", len(entries))
+	}
+	var served int64 = -1
+	for _, f := range entries[0].Context {
+		if f.Key == "served" {
+			served = f.Integer
+		}
+	}
+	if served != 1 {
+		t.Fatalf("boundary verdict served=%d, want 1 (set A's tally)", served)
+	}
+
+	// The flush must not have skipped or reordered the Load itself.
+	rec, _, _ := eng.Decide(context.Background(), lane, &models.Mock{})
+	if rec == nil || rec.Spec.HTTPResp.Body != "SET-B" {
+		t.Fatalf("after the boundary the engine served %v, want SET-B: the flush "+
+			"displaced the corpus replacement", rec)
+	}
+
+	// The verdict is a running total, and it prints inside RunTestSet — which
+	// the replayer has already announced as the NEXT set — so it must say so.
+	var scope string
+	for _, f := range entries[0].Context {
+		if f.Key == "scope" {
+			scope = f.String
+		}
+	}
+	if scope != "cumulative-for-run" {
+		t.Fatalf("boundary verdict scope=%q, want cumulative-for-run: without it a "+
+			"reader attributes the previous set's numbers to the set just announced",
+			scope)
 	}
 }


### PR DESCRIPTION
## Problem

`Engine.LogReport` was guarded by `e.logOnce sync.Once`, so the async egress verdict was printed at the end of **test-set 1** and the accumulation for sets 2..N was silently discarded. The tallies were never reset, so the numbers existed — nothing ever emitted them.

## Why counts stay cumulative rather than becoming per-set deltas

Per-set deltas are the obvious design and they are **wrong here**, for a reason worth stating.

CI parses the line with `tail -n1` (`.github/workflows/test_workflow_scripts/java/async_config_poll/java-linux.sh:240`) and gates `served >= 1` and `flags == 0` on that one line. Deltas would narrow the gate from *"no drift anywhere in the run"* to *"no drift in the last chunk"*.

Worse: `holdThrottle` registers a `context.AfterFunc` that broadcasts on cancel, so cancelling the test-set context **wakes** parked polls, which then reach `decideServe` and increment **after** the per-set flush. Under deltas the final line — the one CI reads — would report `served: 0` on a run that served dozens.

Cumulative counts make sets 2..N visible because the number *grows* across lines, while leaving that gate exactly as strong as it is today.

## Changes

- **`flags` (drift details) are drained on emit**, so each logs once. Retaining them while removing the `Once` guard would re-log the whole backlog on every flush — output quadratic in (test-sets × drifts).
- **A `lastPass`/`lastFlag` cursor** emits only when the counts have moved. Keeps record mode silent and suppresses a duplicate line when the run-level flush follows a per-set flush with no traffic between.
- **The cursor advances to the *snapshot* values, not the live ones.** Advancing to the live values marks as reported anything that landed after the snapshot — counted by the cursor, printed by no line, never picked up again. A test drove that window deterministically and caught it.
- **`drainReport` does snapshot + drain + cursor advance in ONE critical section**, and deliberately does **not** delegate to `Report()`: `sync.Mutex` is not reentrant and `Report()` takes `e.mu`, so that would self-deadlock the agent's HTTP handler goroutine. `Report` and `drainReport` now share `reportLocked` so they cannot drift apart.
- **The flush moves to `Proxy.LoadAsyncMocks`** — the only seam that runs once per test-set on *every* replay path. `SetGracefulShutdown` is not: `replay.go` gates its per-test-set notify on `r.instrument && !serveTest`, and `serveTest` is true for docker-compose replay with mocking (**the default**), so on that path only the run-level notify fires.
- **A `scope` field** on the line. The boundary flush runs inside `RunTestSet`, which the replayer has *already announced as the next test-set*, so the previous set's verdict prints under the next set's banner. Appended after `held` so the three fields CI greps stay contiguous.

## Testing

Seven mutations, every one build-checked first — a non-compiling mutation emits zero `--- FAIL` lines and reads as a coverage gap:

| mutation | caught by |
|---|---|
| restore the `logOnce` guard (the bug) | 4 tests |
| per-set deltas instead of cumulative | 3 tests |
| stop draining drift details | `TestLogReportDrainsDriftDetails` |
| drop the `lastPass`/`lastFlag` cursor | 3 tests |
| reorder the verdict fields | `TestVerdictLineMatchesTheCIRegex` |
| remove the `LoadAsyncMocks` flush | `TestLoadAsyncMocksFlushesTheVerdictAtTheBoundary` |
| advance the cursor past the snapshot window | `TestDrainReportLosesNoIncrementInTheSnapshotWindow` |

`TestVerdictLineMatchesTheCIRegex` encodes the entry with the **console encoder keploy actually uses** and matches the verbatim CI regex, so a field rename or reorder fails locally instead of silently in CI.

`TestDrainReportLosesNoIncrementInTheSnapshotWindow` drives the window through a test-only hook rather than by racing goroutines — deliberately. A purely concurrent version scored **zero** detections under CI's `go test ./...`, which passes neither `-race` nor `-count>1`; the lane it was meant to guard also never reached `holdThrottle`, because `AsyncLane.IsPoll` requires a `"Poll"` type suffix. A test that cannot fail is worse than no test.

`-race` green on `pkg/agent/proxy/...`.

## Stated plainly, not papered over

- **`emitMu` is not pinned by a test.** It serialises drain-and-log so the last line written is the largest — the invariant CI's `tail -n1` depends on. Making the two callers interleave deterministically means blocking one inside the other's critical section, which deadlocks against `e.mu`. It is defence in depth for a path the replayer serialises today, kept because the invariant is load-bearing and undocumented elsewhere.
- **A straggler landing after the RUN-level flush is still not emitted.** `replay.go` cancels immediately after that notify and no seam flushes afterwards — `Proxy.StopProxyServer` would, but it is dead code with no call expression anywhere in the tree. That tail was equally lost under the `Once` guard, so it is unchanged rather than fixed.
- **The `flags == 0` gate gets strictly stronger.** Late drift that `logOnce` hid now lands in the last line. That is the correct behaviour, but it is a new exposure on the one lane guarding this feature.
