### PR TITLE
fix(proxy): route the generic catch-all through the supervisor

### DIFF
--- a/pkg/agent/proxy/generic_v2_dispatch_test.go
+++ b/pkg/agent/proxy/generic_v2_dispatch_test.go
@@ -1,0 +1,93 @@
+package proxy
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations"
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/generic"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// fakeParser implements Integrations, and IntegrationsV2 only when v2Declared.
+type fakeParser struct{ v2 bool }
+
+func (fakeParser) MatchType(context.Context, []byte) bool { return false }
+func (fakeParser) RecordOutgoing(context.Context, *integrations.RecordSession) error {
+	return nil
+}
+func (fakeParser) MockOutgoing(context.Context, net.Conn, *models.ConditionalDstCfg, integrations.MockMemDb, models.OutgoingOptions) error {
+	return nil
+}
+func (f fakeParser) IsV2() bool { return f.v2 }
+
+// legacyOnlyParser does NOT implement IntegrationsV2 at all.
+type legacyOnlyParser struct{}
+
+func (legacyOnlyParser) MatchType(context.Context, []byte) bool { return false }
+func (legacyOnlyParser) RecordOutgoing(context.Context, *integrations.RecordSession) error {
+	return nil
+}
+func (legacyOnlyParser) MockOutgoing(context.Context, net.Conn, *models.ConditionalDstCfg, integrations.MockMemDb, models.OutgoingOptions) error {
+	return nil
+}
+
+// TestShouldRecordViaSupervisor pins the dispatch decision behaviourally.
+//
+// This replaces two source-grep assertions that could not fail for any
+// behavioural reason. They asserted that the substrings "recordViaSupervisor("
+// and "IsV2()" appeared in a text window — so INVERTING the gate
+// (ok && !v2.IsV2()) kept every asserted substring and left the entire proxy
+// test tree green, which is the exact bug plus its inverse. One of them also
+// bounded its window on a string that does not exist in proxy.go, so the
+// "window" was the remaining 890 lines of the file and any match anywhere
+// satisfied it.
+func TestShouldRecordViaSupervisor(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		parser     integrations.Integrations
+		relayOff   string
+		wantV2Path bool
+		why        string
+	}{
+		{
+			name: "V2 parser, relay enabled", parser: fakeParser{v2: true},
+			wantV2Path: true,
+			why:        "a migrated parser must reach the supervisor, or its V2 recorder never runs",
+		},
+		{
+			name: "V2 parser, relay disabled", parser: fakeParser{v2: true}, relayOff: "off",
+			wantV2Path: false,
+			why:        "KEPLOY_NEW_RELAY=off is the documented escape hatch and must still force legacy",
+		},
+		{
+			name: "parser declares IsV2() false", parser: fakeParser{v2: false},
+			wantV2Path: false,
+			why:        "a parser that opts out must not be handed FakeConns it cannot use",
+		},
+		{
+			name: "parser does not implement IntegrationsV2", parser: legacyOnlyParser{},
+			wantV2Path: false,
+			why:        "an unmigrated parser has no V2 entrypoint at all",
+		},
+		{
+			name: "the real generic parser", parser: generic.New(zap.NewNop()),
+			wantV2Path: true,
+			why: "generic is the catch-all for every unmatched protocol; if it does not reach " +
+				"the supervisor, the widest path in the proxy records legacy on the default config",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.relayOff != "" {
+				t.Setenv("KEPLOY_NEW_RELAY", tc.relayOff)
+			} else {
+				t.Setenv("KEPLOY_NEW_RELAY", "")
+			}
+			if got := shouldRecordViaSupervisor(tc.parser); got != tc.wantV2Path {
+				t.Errorf("shouldRecordViaSupervisor = %v, want %v — %s", got, tc.wantV2Path, tc.why)
+			}
+		})
+	}
+}

--- a/pkg/agent/proxy/integrations/generic/generic.go
+++ b/pkg/agent/proxy/integrations/generic/generic.go
@@ -38,6 +38,34 @@ func (g *Generic) MatchType(_ context.Context, _ []byte) bool {
 // to run under supervisor.Run. The generic parser is protocol-agnostic
 // and needs no TLS upgrade or mid-stream directives; it simply observes
 // chunks in each direction and pairs them into mocks.
+// Generic deliberately does NOT implement integrations.GapResyncCapable, and
+// should not be "fixed" to.
+//
+// The tempting argument is that the conservative default exists for
+// length-prefix framers — a hole makes them read the next header from the middle
+// of a body, so every later frame is garbage and one Postgres framer once tried
+// to allocate gigabytes from misread row data. Generic has no framer at all; it
+// pairs chunks by direction transitions. So the framer rationale does not apply,
+// and it looks like generic is being penalised for someone else's failure mode.
+//
+// But the capability asserts something generic cannot honour. Returning true
+// means the parser DETECTS the hole — the relay stamps a monotonic
+// fakeconn.Chunk.SeqNo per direction and a dropped chunk still consumes its
+// ordinal, so a gap is visible as a discontinuity — and re-anchors on a real
+// message boundary. This recorder reads no SeqNo and has no notion of a
+// boundary to re-anchor on.
+//
+// Its failure mode after a hole is not garbage frames; it is worse in the way
+// that matters. It would pair a request with the WRONG response and emit a mock
+// that looks perfectly well-formed, which replays incorrectly and silently. The
+// conservative default instead marks the capture desynced and suppresses the
+// affected test cases — loud, and safe. Losing a test case beats shipping a
+// confidently wrong one.
+//
+// Implementing real gap detection here (compare SeqNo, drop the in-flight
+// exchange, resume cleanly on the next request) would justify flipping this. A
+// bare `return true` would not.
+
 func (g *Generic) IsV2() bool { return true }
 
 func (g *Generic) RecordOutgoing(ctx context.Context, session *integrations.RecordSession) error {

--- a/pkg/agent/proxy/integrations/mysql/recorder/record_v2_test.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record_v2_test.go
@@ -3,12 +3,13 @@ package recorder
 import (
 	"bytes"
 	"context"
-	"go.keploy.io/server/v3/pkg/models/mysql"
 	"net"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"go.keploy.io/server/v3/pkg/models/mysql"
 
 	connphase "go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/wire/phase/conn"
 	"go.keploy.io/server/v3/pkg/models"

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -991,6 +991,19 @@ func New(logger *zap.Logger, info agent.DestInfo, opts *config.Config) *Proxy {
 // It wraps src/dst in SafeConn. The caller (handleConnection) is responsible
 // for creating the TLSUpgrader using pointers to its own srcConn/dstConn
 // variables, so the upgrader updates the correct references on TLS upgrade.
+// shouldRecordViaSupervisor is the single decision for "does this parser record
+// through the supervisor + relay, or through the legacy path".
+//
+// Extracted so the rule is testable. It was previously written inline at three
+// dispatch sites, and two of them simply omitted it — the generic catch-all and
+// the MySQL probe branch both recorded legacy on the default configuration with
+// no flag set. Source-grep fences over those call sites proved nothing: an
+// inverted condition keeps every asserted substring and stays green.
+func shouldRecordViaSupervisor(parser integrations.Integrations) bool {
+	v2, ok := parser.(integrations.IntegrationsV2)
+	return ok && v2.IsV2() && !newRelayDisabled()
+}
+
 func (p *Proxy) buildRecordSession(
 	srcConn, dstConn net.Conn,
 	mocks chan<- *models.Mock,
@@ -2794,7 +2807,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 			// isolates parser panics/hangs and falls through to passthrough
 			// on failure. The legacy path below is preserved for parsers
 			// that have not yet migrated.
-			if v2, ok := matchedParser.(integrations.IntegrationsV2); ok && v2.IsV2() && !newRelayDisabled() {
+			if shouldRecordViaSupervisor(matchedParser) {
 				if err := p.recordViaSupervisor(parserCtx, srcConn, dstConn, matchedParser, parserType, rule.MC, parserErrGrp, logger, clientConnID, destConnID, outgoingOpts); err != nil {
 					if isNetworkClosedErr(err) {
 						logger.Debug("V2 record path: connection closed", zap.Error(err))
@@ -2857,11 +2870,33 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 	if generic {
 		logger.Debug("The external dependency is not supported. Hence using generic parser")
 		if rule.Mode == models.MODE_RECORD {
-			genericSession := p.buildRecordSession(srcConn, dstConn, rule.MC, parserErrGrp, logger, clientConnID, destConnID, outgoingOpts, nil)
-			err := p.Integrations[integrations.GENERIC].RecordOutgoing(parserCtx, genericSession)
-			if err != nil && err != io.EOF && !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), "tls: user canceled") {
-				utils.LogError(logger, err, "failed to record the outgoing message")
-				return err
+			genericParser := p.Integrations[integrations.GENERIC]
+			// Route through the supervisor exactly like the matched-parser path
+			// above. This branch previously called RecordOutgoing directly with
+			// NO IsV2 gate, so every connection that matched no parser recorded
+			// through generic's LEGACY path — on the default configuration, with
+			// no flag set. Generic has declared IsV2() == true all along; nothing
+			// consulted it here, so the migration silently skipped the widest
+			// code path in the proxy.
+			if shouldRecordViaSupervisor(genericParser) {
+				if err := p.recordViaSupervisor(parserCtx, srcConn, dstConn, genericParser, integrations.GENERIC, rule.MC, parserErrGrp, logger, clientConnID, destConnID, outgoingOpts); err != nil {
+					if isNetworkClosedErr(err) {
+						logger.Debug("V2 generic record path: connection closed", zap.Error(err))
+					} else {
+						utils.LogError(logger, err, "V2 generic record path failed",
+							zap.String("next_step", "set KEPLOY_NEW_RELAY=off to force the legacy record path while investigating, or KEPLOY_DISABLE_PARSING=1 / SIGUSR1 to disable parser dispatch entirely (raw passthrough); the supervisor has already fallen through to passthrough for this connection so user traffic continues"),
+						)
+					}
+					return err
+				}
+				logger.Debug("V2 generic record path returned")
+			} else {
+				genericSession := p.buildRecordSession(srcConn, dstConn, rule.MC, parserErrGrp, logger, clientConnID, destConnID, outgoingOpts, nil)
+				err := genericParser.RecordOutgoing(parserCtx, genericSession)
+				if err != nil && err != io.EOF && !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), "tls: user canceled") {
+					utils.LogError(logger, err, "failed to record the outgoing message")
+					return err
+				}
 			}
 		} else {
 			err := p.Integrations[integrations.GENERIC].MockOutgoing(parserCtx, srcConn, dstCfg, p.scopedFor(outgoingOpts.SrcPid, m), outgoingOpts)

--- a/pkg/agent/proxy/tls/ca.go
+++ b/pkg/agent/proxy/tls/ca.go
@@ -327,7 +327,21 @@ func setupJavaTrustStoreEnv(logger *zap.Logger) error {
 	// accumulate a new JKS in the temp dir every time (there is no teardown hook
 	// to remove a random-named one). The contents are the same public bundle
 	// each run, so a concurrent overwrite is harmless.
-	jksPath := filepath.Join(os.TempDir(), "keploy-java-truststore.jks")
+	//
+	// The uid in the NAME is what makes "per-user" true. It used to be a single
+	// shared filename, which is not per-user at all: os.TempDir() is shared and
+	// world-writable with the sticky bit, so the first run to create it owns it
+	// forever. One `sudo keploy` — or any rootful-docker run — left a root-owned
+	// file that every later run as the normal user failed to rewrite:
+	//
+	//	failed to build the Java truststore: failed to create jks file:
+	//	open /tmp/keploy-java-truststore.jks: permission denied
+	//
+	// and Java interception stayed broken on that machine until someone removed
+	// it by hand. Keying the name by uid means two users, or the same user with
+	// and without sudo, never contend for one inode. The store holds only public
+	// certificates, so a per-uid copy costs nothing.
+	jksPath := filepath.Join(os.TempDir(), fmt.Sprintf("keploy-java-truststore-%d.jks", os.Geteuid()))
 	if err := generateTrustStore(mergedPath, jksPath); err != nil {
 		return fmt.Errorf("failed to build the Java truststore: %w", err)
 	}

--- a/pkg/agent/proxy/tls/ca_java_truststore_test.go
+++ b/pkg/agent/proxy/tls/ca_java_truststore_test.go
@@ -2,11 +2,13 @@ package tls
 
 import (
 	"encoding/pem"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -159,5 +161,66 @@ func TestGenerateTrustStore_SkipsNonCertSequence(t *testing.T) {
 	}
 	if !strings.Contains(string(out), "keploy-root") {
 		t.Fatalf("real cert missing from store:\n%s", out)
+	}
+}
+
+// TestJavaTrustStorePathIsPerUser pins the property that makes this survivable
+// on a shared machine.
+//
+// The path used to be a single shared filename in os.TempDir(). That directory
+// is world-writable with the sticky bit, so the first run to create the file
+// owns it permanently: one `sudo keploy`, or any rootful-docker run, left a
+// root-owned JKS and every later run as the normal user died with
+//
+//	failed to build the Java truststore: ... permission denied
+//
+// with Java interception silently broken until someone removed it by hand. This
+// test fails on a machine that still has such a leftover ONLY if the code has
+// regressed to the shared name — which is the point: it must pass regardless of
+// what is already sitting in /tmp.
+func TestJavaTrustStorePathIsPerUser(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("TMPDIR", dir)
+	// setupJavaTrustStoreEnv ends in os.Setenv, which outlives this test and
+	// leaks a JAVA_TOOL_OPTIONS pointing at a truststore inside t.TempDir() —
+	// a path that no longer exists once the test finishes. Every later test in
+	// the binary, and every subprocess they spawn, would inherit it. t.Setenv
+	// registers the restore.
+	t.Setenv(EnvJavaToolOptions, "")
+
+	// os.TempDir honours TMPDIR only on unix; on Windows it reads TMP/TEMP, so
+	// the redirect above would not take effect and this test would assert
+	// against the real temp dir.
+	if runtime.GOOS == "windows" {
+		t.Skip("os.TempDir does not honour TMPDIR on Windows; the per-user property is " +
+			"already provided there by a per-user temp dir")
+	}
+
+	logger := zap.NewNop()
+	if err := setupJavaTrustStoreEnv(logger); err != nil {
+		t.Fatalf("setupJavaTrustStoreEnv: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var jks []string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".jks") {
+			jks = append(jks, e.Name())
+		}
+	}
+	if len(jks) == 0 {
+		t.Fatal("no truststore was written")
+	}
+	want := fmt.Sprintf("-%d.jks", os.Geteuid())
+	for _, name := range jks {
+		if !strings.HasSuffix(name, want) {
+			t.Errorf("truststore %q is not keyed by uid (want a name ending %q).\n\n"+
+				"A shared name in a world-writable sticky temp dir is owned forever by "+
+				"whoever creates it first, so a single run under sudo permanently breaks "+
+				"Java interception for that machine's normal user.", name, want)
+		}
 	}
 }


### PR DESCRIPTION
## The bug

Every connection that matched **no parser** recorded through generic's **legacy**
path — on the default configuration, with no flag set.

The catch-all called `buildRecordSession` + `RecordOutgoing` directly with **no `IsV2`
gate**, while the matched-parser branch a few lines above consults one.
`generic.RecordOutgoing` then sees `session.V2 == nil` and falls to `recordLegacy`.
`generic.IsV2()` has returned `true` since it was migrated — nothing here ever asked.

It wasn't a wrong condition; it was **no condition**. Nothing observable differed unless
you looked at which recorder ran, which is how it survived the migration that moved
every other parser.

## The fix

The decision is now one tested function, `shouldRecordViaSupervisor`, shared by every
dispatch site.

That matters more than it sounds. My first attempt fenced the call site with a source
grep, and **inverting the gate** kept every asserted substring and left the entire proxy
test tree green — the exact bug plus its inverse. The same grep also bounded its window
on a string that does not exist in `proxy.go`, so the "window" was the remaining 890
lines of the file. Both are replaced by a table test over the decision itself.

Mutations killed: gate inverted, always-true, always-false, `KEPLOY_NEW_RELAY` check
dropped, type assertion dropped.

## Behaviour changes — not cosmetic

Generic connections now come under the supervisor's containment:

- A relay drop (per-conn cap or memory pressure) marks the capture desynced, opens an
  orphan window, and `record.go` then **suppresses every test case whose window
  overlaps**. Legacy generic just stopped capturing: mocks were lost, test cases were
  not dropped.
- Generic inherits the **60s hang watchdog** and the **8 MiB per-connection cap**, so a
  fire-and-forget or long-poll protocol silent for 60s can have its parser retired and
  its test cases suppressed.
- Recorded mocks gain a top-level `connectionId`. Its consumers are logging and
  round-trip only, never matching.

Suppression is the safer end of that trade. Generic cannot detect a capture hole — it
reads no `Chunk.SeqNo` — so it would otherwise pair a request with the **wrong response**
and emit a well-formed mock that replays incorrectly and silently. `generic.go` now
documents why it must **not** declare `GapResyncCapable`, and what would actually justify
flipping that (real gap detection, not a bare `return true`).

## Also here

The Java truststore path is keyed by uid. It was a shared name in a world-writable
sticky `/tmp`, so one `sudo keploy` left a root-owned file and every later run as the
normal user died with `permission denied`, silently disabling Java interception. It also
fails `TestSetupJavaTrustStoreEnv_SetsMergedStore` on any host that ever ran keploy under
sudo — reproduced on `origin/main`, green again here with the leftover still present.

Scope stated honestly: that fixes **contention**, not the symlink class. `os.Create`
still follows symlinks; closing that needs a `0700` per-uid directory or
`O_NOFOLLOW|O_EXCL`.

## Not here, and currently BLOCKED

The **MySQL probe branch** has the same missing gate — stock MySQL on 3306/4000 records
legacy on every connection. It is deliberately not in this PR, and to be clear about
status: **it is not merely unopened, it is blocked on a reproduced regression.**

Routing that branch through the supervisor breaks MySQL's `CLIENT_SSL` upgrade. There is
no server round-trip between the client's 36-byte SSLRequest and its TLS ClientHello — the
client writes both back to back — so the relay forwards the app's ClientHello upstream **in
cleartext** before the parser has even decoded the SSLRequest, and `performTLSUpgradeV2`
then injects a *second* ClientHello from `tls.Client` into a stream the server is already
handshaking on. Reproduced 5/5; the upstream socket receives, in order: the SSLRequest, the
app's ClientHello, then keploy's own ClientHello with Go's cipher-suite list.

The legacy recorder is correct by construction — `recorder/conn.go` owns both sockets, so
nothing races it. `sslMode=PREFERRED` is connector/J's default and `mysql:8` advertises
`CLIENT_SSL`, so this is not an exotic path.

It also needs the `mysql_dual_conn` / `mysql_auto_port` e2e lanes to gate it rather than
unit tests, since it activates a recorder with no reachable caller in this repository, by
default, on the busiest port. Those lanes have been green while MySQL recorded *legacy*, so
a green run there would not by itself prove the TLS path.

## Verification

`go build ./...`, `go vet`, `gofmt`, `goimports` clean; 22 packages green; darwin and
windows cross-builds OK.
