### PR TITLE
fix(ci): debounce the perf memory monitor to stop single-sample-spike flakes

### DIFF
--- a/.github/workflows/test_workflow_scripts/golang/go_memory_load/golang-docker.sh
+++ b/.github/workflows/test_workflow_scripts/golang/go_memory_load/golang-docker.sh
@@ -16,6 +16,12 @@ LARGE_PAYLOAD_MAX_VUS="${LARGE_PAYLOAD_MAX_VUS:-60}"
 LARGE_PAYLOAD_STAGE_TARGETS="${LARGE_PAYLOAD_STAGE_TARGETS:-1,2,1}"
 LARGE_PAYLOAD_SIZES_MB="${LARGE_PAYLOAD_SIZES_MB:-1}"
 MEMORY_MONITOR_INTERVAL_SECONDS="${MEMORY_MONITOR_INTERVAL_SECONDS:-0.5}"
+# Debounce: require K CONSECUTIVE over-threshold samples before killing keploy.
+# A single 0.5s sample crossing the line is almost always a transient GC/page-
+# cache spike, not a leak; killing on it severs every in-flight connection and
+# manufactures an HTTP-failure storm (the main flakiness source). K back-to-back
+# ticks (~1.5s sustained) still catches real runaway growth. Set 1 for old behaviour.
+MEMORY_VIOLATION_MIN_TICKS="${MEMORY_VIOLATION_MIN_TICKS:-3}"
 
 # CI-tuned k6 thresholds — intentionally very relaxed because:
 #   - Keploy proxy buffers request/response bodies for capture, adding latency
@@ -294,6 +300,7 @@ start_memory_monitor() {
         usage_bytes=""
         oom_killed=""
         running=""
+        consecutive_over=0
 
         while kill -0 "$phase_pid" 2>/dev/null; do
             if ! docker inspect "$keploy_container" >/dev/null 2>&1; then
@@ -316,10 +323,16 @@ start_memory_monitor() {
             fi
 
             if [ "$usage_bytes" -ge 0 ] && [ "$usage_bytes" -ge "$threshold_bytes" ]; then
-                echo "Keploy container ${keploy_container} exceeded ${threshold_mib} MiB during ${phase_name}. Observed usage: ${usage_raw}." > "$MEMORY_VIOLATION_FILE"
-                docker kill "$keploy_container" >/dev/null 2>&1 || true
-                kill -TERM "$phase_pid" 2>/dev/null || true
-                exit 0
+                consecutive_over=$((consecutive_over + 1))
+                if [ "$consecutive_over" -ge "$MEMORY_VIOLATION_MIN_TICKS" ]; then
+                    sustained_s="$(awk -v n="$consecutive_over" -v i="$MEMORY_MONITOR_INTERVAL_SECONDS" 'BEGIN { printf "%.1f", n * i }')"
+                    echo "Keploy container ${keploy_container} exceeded ${threshold_mib} MiB during ${phase_name} for ${consecutive_over} consecutive samples (~${sustained_s}s sustained). Observed usage: ${usage_raw}." > "$MEMORY_VIOLATION_FILE"
+                    docker kill "$keploy_container" >/dev/null 2>&1 || true
+                    kill -TERM "$phase_pid" 2>/dev/null || true
+                    exit 0
+                fi
+            else
+                consecutive_over=0
             fi
 
             sleep "$MEMORY_MONITOR_INTERVAL_SECONDS"

--- a/.github/workflows/test_workflow_scripts/golang/go_memory_load_grpc/golang-docker.sh
+++ b/.github/workflows/test_workflow_scripts/golang/go_memory_load_grpc/golang-docker.sh
@@ -16,6 +16,12 @@ LARGE_PAYLOAD_MAX_VUS="${LARGE_PAYLOAD_MAX_VUS:-60}"
 LARGE_PAYLOAD_STAGE_TARGETS="${LARGE_PAYLOAD_STAGE_TARGETS:-1,2,1}"
 LARGE_PAYLOAD_SIZES_MB="${LARGE_PAYLOAD_SIZES_MB:-1}"
 MEMORY_MONITOR_INTERVAL_SECONDS="${MEMORY_MONITOR_INTERVAL_SECONDS:-0.5}"
+# Debounce: require K CONSECUTIVE over-threshold samples before killing keploy.
+# A single 0.5s sample crossing the line is almost always a transient GC/page-
+# cache spike, not a leak; killing on it severs every in-flight connection and
+# manufactures an HTTP-failure storm (the main flakiness source). K back-to-back
+# ticks (~1.5s sustained) still catches real runaway growth. Set 1 for old behaviour.
+MEMORY_VIOLATION_MIN_TICKS="${MEMORY_VIOLATION_MIN_TICKS:-3}"
 
 # CI-tuned k6 thresholds — intentionally very relaxed because:
 #   - Keploy proxy buffers request/response bodies for capture, adding latency
@@ -330,6 +336,7 @@ start_memory_monitor() {
         usage_bytes=""
         oom_killed=""
         running=""
+        consecutive_over=0
 
         while kill -0 "$phase_pid" 2>/dev/null; do
             if ! docker inspect "$keploy_container" >/dev/null 2>&1; then
@@ -352,10 +359,16 @@ start_memory_monitor() {
             fi
 
             if [ "$usage_bytes" -ge 0 ] && [ "$usage_bytes" -ge "$threshold_bytes" ]; then
-                echo "Keploy container ${keploy_container} exceeded ${threshold_mib} MiB during ${phase_name}. Observed usage: ${usage_raw}." > "$MEMORY_VIOLATION_FILE"
-                docker kill "$keploy_container" >/dev/null 2>&1 || true
-                kill -TERM "$phase_pid" 2>/dev/null || true
-                exit 0
+                consecutive_over=$((consecutive_over + 1))
+                if [ "$consecutive_over" -ge "$MEMORY_VIOLATION_MIN_TICKS" ]; then
+                    sustained_s="$(awk -v n="$consecutive_over" -v i="$MEMORY_MONITOR_INTERVAL_SECONDS" 'BEGIN { printf "%.1f", n * i }')"
+                    echo "Keploy container ${keploy_container} exceeded ${threshold_mib} MiB during ${phase_name} for ${consecutive_over} consecutive samples (~${sustained_s}s sustained). Observed usage: ${usage_raw}." > "$MEMORY_VIOLATION_FILE"
+                    docker kill "$keploy_container" >/dev/null 2>&1 || true
+                    kill -TERM "$phase_pid" 2>/dev/null || true
+                    exit 0
+                fi
+            else
+                consecutive_over=0
             fi
 
             sleep "$MEMORY_MONITOR_INTERVAL_SECONDS"

--- a/.github/workflows/test_workflow_scripts/golang/go_memory_load_mongo/golang-docker.sh
+++ b/.github/workflows/test_workflow_scripts/golang/go_memory_load_mongo/golang-docker.sh
@@ -16,11 +16,22 @@ LARGE_PAYLOAD_MAX_VUS="${LARGE_PAYLOAD_MAX_VUS:-60}"
 LARGE_PAYLOAD_STAGE_TARGETS="${LARGE_PAYLOAD_STAGE_TARGETS:-1,2,1}"
 LARGE_PAYLOAD_SIZES_MB="${LARGE_PAYLOAD_SIZES_MB:-1}"
 MEMORY_MONITOR_INTERVAL_SECONDS="${MEMORY_MONITOR_INTERVAL_SECONDS:-0.5}"
+# Debounce: how many CONSECUTIVE over-threshold samples before we declare a
+# violation and kill keploy. A single 0.5s sample crossing the line is almost
+# always a transient GC/page-cache spike, not a leak; killing on it severs every
+# in-flight connection and manufactures an HTTP-failure storm, which is the main
+# source of this lane's flakiness. Requiring K back-to-back over-threshold ticks
+# (~1.5s of sustained excess) keeps real runaway growth caught while ignoring
+# blips. Set to 1 to restore the old single-sample behaviour.
+MEMORY_VIOLATION_MIN_TICKS="${MEMORY_VIOLATION_MIN_TICKS:-3}"
 
 # CI-tuned k6 thresholds — intentionally very relaxed because:
 #   - Keploy proxy buffers request/response bodies for capture, adding latency
 #   - GOMEMLIMIT at 90% of memory-limit causes aggressive GC under pressure
-#   - memoryguard pause/resume cycling disrupts connections (Connection: close)
+#   - under memory pressure the guard pauses CAPTURE (captureEnabled=false); on
+#     the default ASYNC record path the client connection is kept alive (NO
+#     Connection: close — that is sync/sampling-mode only), so extra latency is
+#     GC + the capture pause, not severed connections
 #   - ubuntu-latest has 2 shared vCPUs compounding all of the above
 # k6 threshold failures are NOT fatal — the script checks HTTP failure rate
 # separately (see check_k6_failure_rate). Only >40% HTTP failures are fatal.
@@ -386,6 +397,7 @@ start_memory_monitor() {
         usage_bytes=""
         oom_killed=""
         running=""
+        consecutive_over=0
 
         while kill -0 "$phase_pid" 2>/dev/null; do
             if ! docker inspect "$keploy_container" >/dev/null 2>&1; then
@@ -409,10 +421,18 @@ start_memory_monitor() {
             fi
 
             if [ "$usage_bytes" -ge "$threshold_bytes" ]; then
-                echo "Keploy container ${keploy_container} exceeded ${threshold_mib} MiB working-set during ${phase_name}. Observed: ${usage_mib} MiB." > "$MEMORY_VIOLATION_FILE"
-                docker kill "$keploy_container" >/dev/null 2>&1 || true
-                kill -TERM "$phase_pid" 2>/dev/null || true
-                exit 0
+                consecutive_over=$((consecutive_over + 1))
+                if [ "$consecutive_over" -ge "$MEMORY_VIOLATION_MIN_TICKS" ]; then
+                    sustained_s="$(awk -v n="$consecutive_over" -v i="$MEMORY_MONITOR_INTERVAL_SECONDS" 'BEGIN { printf "%.1f", n * i }')"
+                    echo "Keploy container ${keploy_container} exceeded ${threshold_mib} MiB working-set during ${phase_name} for ${consecutive_over} consecutive samples (~${sustained_s}s sustained). Observed: ${usage_mib} MiB." > "$MEMORY_VIOLATION_FILE"
+                    docker kill "$keploy_container" >/dev/null 2>&1 || true
+                    kill -TERM "$phase_pid" 2>/dev/null || true
+                    exit 0
+                fi
+            else
+                # Dropped back under the line — the excess was a transient spike,
+                # not sustained growth. Reset so only BACK-TO-BACK breaches count.
+                consecutive_over=0
             fi
 
             sleep "$MEMORY_MONITOR_INTERVAL_SECONDS"

--- a/.github/workflows/test_workflow_scripts/golang/go_memory_load_mysql/golang-docker.sh
+++ b/.github/workflows/test_workflow_scripts/golang/go_memory_load_mysql/golang-docker.sh
@@ -16,11 +16,23 @@ LARGE_PAYLOAD_MAX_VUS="${LARGE_PAYLOAD_MAX_VUS:-60}"
 LARGE_PAYLOAD_STAGE_TARGETS="${LARGE_PAYLOAD_STAGE_TARGETS:-1,2,1}"
 LARGE_PAYLOAD_SIZES_MB="${LARGE_PAYLOAD_SIZES_MB:-1}"
 MEMORY_MONITOR_INTERVAL_SECONDS="${MEMORY_MONITOR_INTERVAL_SECONDS:-0.5}"
+# Debounce: how many CONSECUTIVE over-threshold samples before we declare a
+# violation and kill keploy. A single 0.5s sample crossing the line is almost
+# always a transient GC/page-cache spike, not a leak; killing on it severs every
+# in-flight connection and manufactures an HTTP-failure storm, which is the main
+# source of this lane's flakiness. Requiring K back-to-back over-threshold ticks
+# (~1.5s of sustained excess) keeps real runaway growth caught while ignoring
+# blips. Set to 1 to restore the old single-sample behaviour.
+MEMORY_VIOLATION_MIN_TICKS="${MEMORY_VIOLATION_MIN_TICKS:-3}"
 
 # CI-tuned k6 thresholds — intentionally very relaxed because:
 #   - Keploy proxy buffers request/response bodies for capture, adding latency
 #   - GOMEMLIMIT at 90% of memory-limit causes aggressive GC under pressure
-#   - memoryguard pause/resume cycling disrupts connections (Connection: close)
+#   - under memory pressure the guard pauses CAPTURE (captureEnabled=false); on
+#     this lane's default ASYNC record path the client connection is kept alive
+#     (NO Connection: close — that is injected only in sync/sampling mode, see
+#     pkg/agent/proxy/incoming/http.go), so the extra latency is GC + the capture
+#     pause, not severed connections
 #   - ubuntu-latest has 2 shared vCPUs compounding all of the above
 # k6 threshold failures are NOT fatal — the script checks HTTP failure rate
 # separately (see check_k6_failure_rate). Only >40% HTTP failures are fatal.
@@ -386,6 +398,7 @@ start_memory_monitor() {
         usage_bytes=""
         oom_killed=""
         running=""
+        consecutive_over=0
 
         while kill -0 "$phase_pid" 2>/dev/null; do
             if ! docker inspect "$keploy_container" >/dev/null 2>&1; then
@@ -409,10 +422,18 @@ start_memory_monitor() {
             fi
 
             if [ "$usage_bytes" -ge "$threshold_bytes" ]; then
-                echo "Keploy container ${keploy_container} exceeded ${threshold_mib} MiB working-set during ${phase_name}. Observed: ${usage_mib} MiB." > "$MEMORY_VIOLATION_FILE"
-                docker kill "$keploy_container" >/dev/null 2>&1 || true
-                kill -TERM "$phase_pid" 2>/dev/null || true
-                exit 0
+                consecutive_over=$((consecutive_over + 1))
+                if [ "$consecutive_over" -ge "$MEMORY_VIOLATION_MIN_TICKS" ]; then
+                    sustained_s="$(awk -v n="$consecutive_over" -v i="$MEMORY_MONITOR_INTERVAL_SECONDS" 'BEGIN { printf "%.1f", n * i }')"
+                    echo "Keploy container ${keploy_container} exceeded ${threshold_mib} MiB working-set during ${phase_name} for ${consecutive_over} consecutive samples (~${sustained_s}s sustained). Observed: ${usage_mib} MiB." > "$MEMORY_VIOLATION_FILE"
+                    docker kill "$keploy_container" >/dev/null 2>&1 || true
+                    kill -TERM "$phase_pid" 2>/dev/null || true
+                    exit 0
+                fi
+            else
+                # Dropped back under the line — the excess was a transient spike,
+                # not sustained growth. Reset so only BACK-TO-BACK breaches count.
+                consecutive_over=0
             fi
 
             sleep "$MEMORY_MONITOR_INTERVAL_SECONDS"


### PR DESCRIPTION
## What & why

The four `go-memory-load*` performance lanes are flaky. Root cause (verified against the code, not just symptoms): the memory monitor kills keploy the instant **one** 0.5s working-set sample crosses the threshold — a single-sample `docker kill`. On shared CI runners a transient GC/page-cache spike routinely crosses the line for a single tick, and that kill severs every in-flight connection at once, manufacturing an HTTP-failure storm that then trips the lane's failure gate. It's a **monitor artifact, not a real leak** — the dominant source of these lanes' non-deterministic reds.

## Fix

**Debounce the monitor:** require `MEMORY_VIOLATION_MIN_TICKS=3` (default) consecutive over-threshold samples (~1.5s sustained) before declaring a violation, resetting the counter whenever usage drops back under the line.

- Real runaway growth is still caught (it sits over the line for many ticks).
- One-off blips no longer kill the run.
- The violation message now records how long the excess was sustained (debuggability).
- `MEMORY_VIOLATION_MIN_TICKS=1` restores the old single-sample behaviour.

Applied to all four lanes: `go_memory_load{,_mysql,_mongo,_grpc}`.

Also **corrects a misleading comment** in the mysql/mongo lanes: on the default *async* record path the guard pauses **capture** (`captureEnabled=false`) and keeps the client connection alive — `Connection: close` is injected only in sync/sampling mode (`pkg/agent/proxy/incoming/http.go`), so it doesn't apply here. That comment had misdirected past threshold tuning.

## Scope

This is the first, lowest-risk step. Follow-ups (separate PRs): baseline-vs-PR **relative** regression detection (replace frozen absolute thresholds with same-runner delta + band/floor), making the record-side memory gate informational in `record_latest_replay_build`, k6 JSON-summary parsing, and the one real product bug surfaced (the memory guard derives `GOMEMLIMIT`/pause thresholds from the `--memory-limit` flag but never reads the cgroup `memory.max`).

## Type
- [x] 🐞 Bug Fix
- [x] 🔁 CI

Validated: `bash -n` + `shellcheck -S error` clean on all four scripts.