### PR TITLE
fix(mysql): keep the greeting latch armed, and read it atomically

### DIFF
--- a/.github/workflows/mysql-tls-greeting-stitch-linux.yml
+++ b/.github/workflows/mysql-tls-greeting-stitch-linux.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Greeting-stitch regression tests
         run: |
           go test ./pkg/models/ ./pkg/agent/proxy/integrations/mysql/recorder/ \
-            -run 'TestStorePreTLSHandshakeV2|TestHandshakeLastPortKey|TestRecordV2_PostTLS_PooledConn|TestRecordV2_PostTLS_LostStash|TestTLSHandshakeStore|TestResolvePreTLSGreeting|TestRememberLast|TestAmbiguityLatch|TestTombstone|TestLastGreeting|TestGreetingServerIdentity|TestRecordV2_RawLeg|TestRawLegIdentity|TestHandshakeLastKey' \
+            -run 'TestStorePreTLSHandshakeV2|TestHandshakeLastPortKey|TestRecordV2_PostTLS_PooledConn|TestRecordV2_PostTLS_LostStash|TestTLSHandshakeStore|TestResolvePreTLSGreeting|TestRememberLast|TestAmbiguityLatch|TestTombstone|TestLastGreeting|TestGreetingServerIdentity|TestRecordV2_RawLeg|TestRawLegIdentity|TestHandshakeLastKey|TestLatchSurvives|TestIdentityRecords|TestPayloadlessEntriesAreBounded|TestLastForPortIsAtomic|TestLegacyPostTLSUsesTheLastGreetingCache' \
             -race -count=3 -v
 
       - name: Full MySQL + models suites
@@ -144,3 +144,157 @@ jobs:
           fi
           echo "OK: blanking the server identity fails the raw-leg test, as it must."
           git checkout -- "$f"
+
+          # Mutant 3: the LEGACY post-TLS reader (conn.go). The previous guard for
+          # this path asserted on SOURCE TEXT -- it grepped conn.go for
+          # "hsStore.Last(lastKey)" -- so flipping the surrounding condition to
+          # `if false` left the string in place, killed the whole fallback, and the
+          # suite stayed green. That is the same write-with-no-reader defect this
+          # workflow exists to catch, one file over. conn.go was never mutated by
+          # this job at all, which is exactly how it slipped through.
+          c=pkg/agent/proxy/integrations/mysql/recorder/conn.go
+          if ! grep -q 'if !ok || len(entry.RespPackets) == 0 {' "$c"; then
+            echo "::error::the legacy post-TLS cache-read guard moved in $c; update this mutant with it"
+            exit 1
+          fi
+          perl -0pi -e 's/\tif !ok \|\| len\(entry\.RespPackets\) == 0 \{\n\t\tif lastKey :=/\tif false {\n\t\tif lastKey :=/' "$c"
+          if ! grep -q 'if false {' "$c"; then
+            echo "::error::mutant 3 did not apply; rework it alongside the code it mutates"
+            git checkout -- "$c"; exit 1
+          fi
+          go build ./pkg/agent/proxy/integrations/mysql/... || {
+            echo "::error::the disabled-legacy-read mutant does not compile, so a test failure would" \
+                 "score a FALSE kill; rework the guard"
+            git checkout -- "$c"; exit 1
+          }
+          if go test ./pkg/agent/proxy/integrations/mysql/recorder/ \
+               -run 'TestLegacyPostTLSUsesTheLastGreetingCacheInsteadOfDialling' \
+               -count=1 >/tmp/mutant3.log 2>&1; then
+            echo "::error::VACUOUS TEST: disabling the legacy post-TLS cache read still passes." \
+                 "The seeding in handleInitialHandshake is a write with no reader and a pooled" \
+                 "connection loses its command phase on that path."
+            tail -30 /tmp/mutant3.log
+            git checkout -- "$c"; exit 1
+          fi
+          echo "OK: disabling the legacy cache read fails its behavioural test, as it must."
+          git checkout -- "$c"
+
+          # Mutant 4: the ambiguity latch's DURABILITY. The latch is the only thing
+          # stopping a port key from serving one server's greeting to a connection
+          # that talked to another, but only the tombstone was TTL-exempt: the live
+          # entry carrying serverID was swept like any other, so server A could age
+          # out and server B's next write would recreate the key CLEAN and SERVING.
+          m=pkg/models/tls_handshake_store.go
+          if ! grep -q 'lastGreeting{serverID: v.serverID, seen: v.seen}' "$m"; then
+            echo "::error::the identity-preserving demotion moved in $m; update this mutant with it"
+            exit 1
+          fi
+          perl -0pi -e 's/\t\t\tif v\.serverID != "" \{\n\t\t\t\ts\.last\[k\] = lastGreeting\{serverID: v\.serverID, seen: v\.seen\}\n\t\t\t\tcontinue\n\t\t\t\}\n//' "$m"
+          go build ./pkg/models/ || {
+            echo "::error::the lost-identity mutant does not compile; rework the guard"
+            git checkout -- "$m"; exit 1
+          }
+          if go test ./pkg/models/ -run 'TestLatchSurvivesTheLiveEntryExpiring' -count=1 >/tmp/mutant4.log 2>&1; then
+            echo "::error::VACUOUS TEST: dropping the server identity when a live entry expires still" \
+                 "passes. The latch would silently disarm and a later write from a DIFFERENT server" \
+                 "would recreate the key clean and serving."
+            tail -30 /tmp/mutant4.log
+            git checkout -- "$m"; exit 1
+          fi
+          echo "OK: forgetting the identity on expiry fails the latch-durability test, as it must."
+          git checkout -- "$m"
+
+          # Mutant 5: the latch check and the read must be ONE lock acquisition.
+          # Composing IsAmbiguous with Last lets another connection's raw leg latch
+          # the key between the two calls; Last then reports a plain miss, the
+          # caller reads that as "nothing cached", and answers from the UNGUARDED
+          # shared address bucket -- after the guard just proved reuse unsafe. It is
+          # a logic race, so -race cannot see it and only a contended test catches it.
+          if ! grep -q 'e, found := s.lastLocked(key, time.Now())' "$m"; then
+            echo "::error::LastForPort's single-acquisition body moved in $m; update this mutant with it"
+            exit 1
+          fi
+          perl -0pi -e 's/\ts\.mu\.Lock\(\)\n\tdefer s\.mu\.Unlock\(\)\n\tif s\.last\[key\]\.ambiguous \{\n\t\treturn TLSHandshakeEntry\{\}, false, true\n\t\}\n\te, found := s\.lastLocked\(key, time\.Now\(\)\)/\tif s.IsAmbiguous(key) {\n\t\treturn TLSHandshakeEntry{}, false, true\n\t}\n\te, found := s.Last(key)/' "$m"
+          go build ./pkg/models/ || {
+            echo "::error::the composed-accessor mutant does not compile; rework the guard"
+            git checkout -- "$m"; exit 1
+          }
+          if go test ./pkg/models/ -run 'TestLastForPortIsAtomicAgainstLatching' -count=1 >/tmp/mutant5.log 2>&1; then
+            echo "::error::VACUOUS TEST: composing IsAmbiguous with Last still passes. A latch landing" \
+                 "between the two calls would fall through to the unguarded address bucket."
+            tail -30 /tmp/mutant5.log
+            git checkout -- "$m"; exit 1
+          fi
+          echo "OK: the composed accessor fails the atomicity test, as it must."
+          git checkout -- "$m"
+
+          # Mutant 6: an identity record must never be SERVED. It exists only to
+          # keep the ambiguity latch armed after a payload expires or is evicted;
+          # handing one to a caller returns ok=true with an empty greeting.
+          # Deleting this guard previously left the whole pkg/models suite green.
+          if ! grep -q 'if !v.hasPayload() {' "$m"; then
+            echo "::error::the identity-record payload guard moved in $m; update this mutant with it"
+            exit 1
+          fi
+          perl -0pi -e 's/\tif !v\.hasPayload\(\) \{\n\t\treturn TLSHandshakeEntry\{\}, false\n\t\}\n//' "$m"
+          go build ./pkg/models/ || { echo "::error::mutant 6 does not compile"; git checkout -- "$m"; exit 1; }
+          if go test ./pkg/models/ -run 'TestIdentityRecordsAreNeverServed' -count=1 >/tmp/mutant6.log 2>&1; then
+            echo "::error::VACUOUS TEST: serving identity records still passes. Last would return ok=true" \
+                 "with an empty greeting."
+            tail -30 /tmp/mutant6.log; git checkout -- "$m"; exit 1
+          fi
+          echo "OK: serving an identity record fails its test, as it must."
+          git checkout -- "$m"
+
+          # Mutant 7: the three eviction classes must be EXHAUSTIVE. Defining live
+          # as "!ambiguous && hasPayload()" drops payload-less, identity-less
+          # entries into no class at all, so nothing ever evicts them and the map
+          # grows without bound -- measured at 2048 against a 512 budget, with
+          # every write past the budget scanning the whole map for nothing.
+          if ! grep -q 'isLive := func(g lastGreeting) bool { return !g.ambiguous && !g.isIdentityOnly() }' "$m"; then
+            echo "::error::the isLive class predicate moved in $m; update this mutant with it"
+            exit 1
+          fi
+          sed -i 's/isLive := func(g lastGreeting) bool { return !g.ambiguous \&\& !g.isIdentityOnly() }/isLive := func(g lastGreeting) bool { return !g.ambiguous \&\& g.hasPayload() }/' "$m"
+          go build ./pkg/models/ || { echo "::error::mutant 7 does not compile"; git checkout -- "$m"; exit 1; }
+          if go test ./pkg/models/ -run 'TestPayloadlessEntriesAreBounded' -count=1 >/tmp/mutant7.log 2>&1; then
+            echo "::error::VACUOUS TEST: a non-exhaustive class split still passes. Entries in no class" \
+                 "are never evicted and the cache grows without bound."
+            tail -30 /tmp/mutant7.log; git checkout -- "$m"; exit 1
+          fi
+          echo "OK: a non-exhaustive class split fails the boundedness test, as it must."
+          git checkout -- "$m"
+
+          # Mutant 8: the EVICTION half of the latch durability fix. The commit
+          # treats expiry and eviction as one change, but only the expiry half had
+          # a mutant -- so the eviction test could go vacuous without CI noticing,
+          # which is the precise failure mode this job exists to prevent.
+          if ! grep -q 'demote && v.serverID != ""' "$m"; then
+            echo "::error::the eviction-demotion guard moved in $m; update this mutant with it"
+            exit 1
+          fi
+          perl -0pi -e 's/\t\t\tif v := s\.last\[oldestKey\]; demote && v\.serverID != "" \{\n\t\t\t\ts\.last\[oldestKey\] = lastGreeting\{serverID: v\.serverID, seen: v\.seen\}\n\t\t\t\tcontinue\n\t\t\t\}\n//' "$m"
+          go build ./pkg/models/ || { echo "::error::mutant 8 does not compile"; git checkout -- "$m"; exit 1; }
+          if go test ./pkg/models/ -run 'TestLatchSurvivesTheLiveEntryBeingEvicted' -count=1 >/tmp/mutant8.log 2>&1; then
+            echo "::error::VACUOUS TEST: forgetting the identity on EVICTION still passes. Unrelated" \
+                 "address keys overflowing the live budget would disarm the latch with no clock involved."
+            tail -30 /tmp/mutant8.log; git checkout -- "$m"; exit 1
+          fi
+          echo "OK: forgetting the identity on eviction fails its test, as it must."
+          git checkout -- "$m"
+
+          # Mutant 9: the identity TTL bound. Without it a key latched by an
+          # in-place server version bump never serves again for the agent's life.
+          if ! grep -q 'now.Sub(v.seen) > identityTTL' "$m"; then
+            echo "::error::the identityTTL bound moved in $m; update this mutant with it"
+            exit 1
+          fi
+          perl -0pi -e 's/\t\t\tif now\.Sub\(v\.seen\) > identityTTL \{\n\t\t\t\tdelete\(s\.last, k\)\n\t\t\t\}\n//' "$m"
+          go build ./pkg/models/ || { echo "::error::mutant 9 does not compile"; git checkout -- "$m"; exit 1; }
+          if go test ./pkg/models/ -run 'TestIdentityRecordsExpireEventually' -count=1 >/tmp/mutant9.log 2>&1; then
+            echo "::error::VACUOUS TEST: an unbounded identity record still passes. A key latched by an" \
+                 "in-place version bump would stay dead for the agent's lifetime."
+            tail -30 /tmp/mutant9.log; git checkout -- "$m"; exit 1
+          fi
+          echo "OK: an unbounded identity record fails its test, as it must."
+          git checkout -- "$m"

--- a/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
@@ -963,18 +963,30 @@ func resolvePreTLSGreeting(ctx context.Context, hsStore *models.TLSHandshakeStor
 		// at all — after the guarded key just told us reuse is unsafe. Decline
 		// outright instead; a missing mock beats one stitched from a server we
 		// have already proven is not necessarily this connection's.
-		if lastPortKey != "" && hsStore.IsAmbiguous(lastPortKey) {
-			return models.TLSHandshakeEntry{}, false
-		}
-		// Port key FIRST. It is the only one of the two with a runtime guard:
-		// RememberLastForPort tags every entry with the destination that produced
-		// it and latches the key unusable once a second server appears. The
-		// address key has no such guard, and on this path the reader's address is
-		// usually a capture-layer stand-in, so "dst:<scope>|127.0.0.1:3306" is a
-		// shared bucket that any unresolved connection in the scope can land in —
-		// consulting it first would let it shadow the guarded answer.
+		// Port key FIRST, and the latch check and the read must be ONE
+		// acquisition of the store lock. It is the only one of the two with a
+		// runtime guard: RememberLastForPort tags every entry with the
+		// destination that produced it and latches the key unusable once a
+		// second server appears. The address key has no such guard, and on this
+		// path the reader's address is usually a capture-layer stand-in, so
+		// "dst:<scope>|127.0.0.1:3306" is a shared bucket that any unresolved
+		// connection in the scope can land in — consulting it first would let it
+		// shadow the guarded answer.
+		//
+		// Composing IsAmbiguous with Last is NOT equivalent: another connection's
+		// raw leg can latch the key between the two calls, Last then reports a
+		// plain miss, and control falls through to that unguarded address bucket
+		// after the guard just proved reuse unsafe. LastForPort answers both
+		// under one lock.
 		if lastPortKey != "" {
-			if c, ok := hsStore.Last(lastPortKey); ok && len(c.RespPackets) > 0 {
+			c, ok, ambiguous := hsStore.LastForPort(lastPortKey)
+			if ambiguous {
+				// POSITIVE proof this scope+port serves more than one server.
+				// A missing mock beats one stitched from a server we have already
+				// proven is not necessarily this connection's.
+				return models.TLSHandshakeEntry{}, false
+			}
+			if ok && len(c.RespPackets) > 0 {
 				return c, true
 			}
 		}

--- a/pkg/agent/proxy/integrations/mysql/recorder/record_v2_test.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record_v2_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"net"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -937,40 +936,61 @@ func TestResolvePreTLSGreeting_GateHandlesNilAndEmptyAddr(t *testing.T) {
 	}
 }
 
-// TestLegacyPostTLSReadsLastGreetingCache pins that the LEGACY path
-// (KEPLOY_NEW_RELAY=off) also consults the last-greeting cache.
+// TestLegacyPostTLSUsesTheLastGreetingCacheInsteadOfDialling drives the LEGACY
+// post-TLS reader and asserts its BEHAVIOUR.
 //
-// That path is the documented escape hatch our own error messages tell users to
-// pull when a V2 parser misbehaves — proxy_v2.go, util.go and directive_proc.go
-// all name it — so it cannot simply be deleted. But handleInitialHandshake
-// SEEDS the cache there while the post-TLS reader only ever did PopWait, so the
-// seeding was a write with no reader and a pooled connection lost its command
-// phase exactly as it did on V2. A write with no reader is the defect class
-// this whole change exists to fix; leaving a second instance of it in place
-// would be careless.
-func TestLegacyPostTLSReadsLastGreetingCache(t *testing.T) {
-	src, err := os.ReadFile("conn.go")
-	if err != nil {
-		t.Fatalf("read conn.go: %v", err)
-	}
-	s := string(src)
+// It replaces a test that asserted on the SOURCE TEXT of conn.go: it read the
+// file and grepped for "hsStore.Last(lastKey)". That guard could only detect
+// textual deletion. Changing the surrounding condition to `if false` leaves the
+// string present, kills the entire fallback, and the whole suite stayed green --
+// verified. A write with no reader is the exact defect this fallback exists to
+// fix, so the guard for it must exercise the reader rather than look at it.
+//
+// The destination is a fabricated (capture-layer stand-in) address, which
+// separates the two paths cleanly: with the cache consulted the greeting comes
+// from the store and the flow reaches the client read; without it,
+// fetchServerGreeting REFUSES the address (it does not dial a stand-in) and the
+// call fails with "direct fetch failed".
+//
+// It asserts the success error POSITIVELY as well as the failure negatively. A
+// one-sided check would pass the moment some future change returned a different
+// error before the store lookup ever happened — the same vacuity that let the
+// predecessor of this test rot.
+func TestLegacyPostTLSUsesTheLastGreetingCacheInsteadOfDialling(t *testing.T) {
+	store := models.NewTLSHandshakeStore()
+	ctx := postTLSCtxWithStore(store)
 
-	// The seeding must still be there...
-	if !strings.Contains(s, "hsStore.RememberLast(models.HandshakeLastKey(opts.PassThroughScope, opts.DstCfg)") {
-		t.Error("conn.go no longer seeds the last-greeting cache")
+	scope := "ns/app/ts0"
+	// Port 1 is closed, so the direct-dial fallback cannot succeed.
+	dst := &models.ConditionalDstCfg{Addr: "127.0.0.1:1", Port: 1, AddrFabricated: true}
+	store.RememberLast(models.HandshakeLastKey(scope, dst), models.TLSHandshakeEntry{
+		RespPackets: [][]byte{cannedHandshakeV10(t)},
+	})
+
+	clientConn, peer := net.Pipe()
+	defer func() { _ = clientConn.Close() }()
+	// The command phase ends immediately; this test is about WHICH SOURCE the
+	// greeting came from, not about decoding traffic.
+	_ = peer.Close()
+
+	opts := models.OutgoingOptions{
+		DstCfg:           dst,
+		PassThroughScope: scope,
+		ConnKey:          "pooled-conn-whose-own-entry-was-consumed",
 	}
-	// ...and the post-TLS reader must actually consult it.
-	i := strings.Index(s, "PopWait(portKey")
-	if i < 0 {
-		t.Fatal("the legacy post-TLS port-key PopWait moved; update this guard with it")
+	mocks := make(chan *models.Mock, 16)
+
+	err := handlePostTLSRecord(ctx, zap.NewNop(), clientConn, nil, mocks,
+		buildPostHandshakeDecodeCtx(clientConn), opts)
+
+	if err != nil && strings.Contains(err.Error(), "direct fetch failed") {
+		t.Fatalf("the legacy post-TLS reader ignored the last-greeting cache and fell through to "+
+			"fetchServerGreeting for %s — the seeding in handleInitialHandshake is then a write with "+
+			"no reader, and a pooled connection loses its whole command phase here: %v", dst.Addr, err)
 	}
-	rest := s[i:]
-	if j := strings.Index(rest, "serverGreetingBuf = entry.RespPackets[0]"); j > 0 {
-		rest = rest[:j]
-	}
-	if !strings.Contains(rest, "hsStore.Last(lastKey)") {
-		t.Error("the legacy post-TLS reader does not consult the last-greeting cache between its " +
-			"PopWait misses and the direct dial; the seeding above is a write with no reader and " +
-			"a pooled connection still loses its command phase on this path")
+	// Positive assertion: having taken the greeting from the cache, the flow must
+	// reach the first client read and end there, because the peer is closed.
+	if err == nil || !strings.Contains(err.Error(), "first post-TLS client packet") {
+		t.Fatalf("expected the flow to consume the cached greeting and stop at the first client read, got: %v", err)
 	}
 }

--- a/pkg/models/tls_handshake_store.go
+++ b/pkg/models/tls_handshake_store.go
@@ -121,6 +121,18 @@ type lastGreeting struct {
 	seen      time.Time
 }
 
+// hasPayload reports whether this record can actually be served. A record with a
+// serverID but no response packets is an IDENTITY record: the payload aged out or
+// was evicted, but the key must keep remembering which server owned it so a later
+// write from a DIFFERENT server still latches. Without that the identity dies
+// with the payload and the next write recreates the key clean and serving.
+func (g lastGreeting) hasPayload() bool { return len(g.entry.RespPackets) > 0 }
+
+// isIdentityOnly reports whether this record is an identity placeholder.
+func (g lastGreeting) isIdentityOnly() bool {
+	return !g.ambiguous && !g.hasPayload() && g.serverID != ""
+}
+
 const (
 	// lastPortKeyPrefix marks keys built by HandshakeLastPortKey, which must
 	// only ever be written through RememberLastForPort.
@@ -130,6 +142,13 @@ const (
 	// connection's own entry being consumed, but it is not unbounded: a server
 	// restarted hours ago may advertise different capabilities.
 	lastGreetingTTL = 30 * time.Minute
+	// identityTTL is how long a key remembers WHICH server owned it after its
+	// payload is gone. It must outlast any rollout drain by a wide margin --
+	// surviving the payload is the whole point -- but not forever, or a key
+	// latched by an in-place version bump stays dead for the agent's lifetime.
+	// 4x the payload TTL: a key that has seen no traffic from ANY server for two
+	// hours has no live producer left to protect.
+	identityTTL = 4 * lastGreetingTTL
 	// maxLastGreetings caps the cache. Cardinality is distinct (scope,
 	// destination) pairs, and a long-lived DaemonSet agent accumulates one per
 	// app x session x destination, so without a cap this map only ever grows.
@@ -255,6 +274,10 @@ func (s *TLSHandshakeStore) RememberLast(key string, entry TLSHandshakeEntry) {
 // POSITIVE evidence that this scope+port serves more than one server, and should
 // then decline any other identity-less fallback for the same connection rather
 // than quietly reaching for one.
+// Do NOT compose this with Last to decide whether a cached greeting is usable:
+// a latch landing between the two calls makes Last report a plain miss, and the
+// caller then falls through to an unguarded fallback right after the guard
+// proved reuse unsafe. Use LastForPort, which answers both under one lock.
 func (s *TLSHandshakeStore) IsAmbiguous(key string) bool {
 	if key == "" {
 		return false
@@ -310,23 +333,42 @@ func (s *TLSHandshakeStore) rememberLast(key string, serverID string, entry TLSH
 	s.last[key] = lastGreeting{entry: entry, serverID: serverID, seen: now}
 	// Prune AFTER inserting, so a write cannot leave the map over its budget;
 	// pruning first leaves it one over every time. Live entries and tombstones
-	// are budgeted separately, so the map holds about 2*maxLastGreetings — a
+	// are budgeted separately, so the map holds about 3*maxLastGreetings — a
 	// latching write returns before pruning, so the tombstone class can sit one
 	// over its budget until the next write.
 	s.pruneLastLocked(now)
 }
 
 // pruneLastLocked drops expired entries and, if still over the cap, the oldest
-// ones. Live entries and tombstones have SEPARATE budgets: tombstones must not
-// be able to crowd out live entries (that would disable the fallback store-wide,
-// recreating the capture loss this cache prevents), and live entries must not be
-// able to evict tombstones early (that would let a proven-unsafe key serve
-// again).
+// ones.
+//
+// THREE classes have SEPARATE budgets, so the map's designed steady state is up
+// to 3*maxLastGreetings (measured: 1536):
+//
+//   - live      — a servable greeting.
+//   - identity  — remembers WHICH server owned a key after the payload expired
+//     or was evicted, so the ambiguity latch stays armed. Never servable.
+//   - tombstone — a latched key, permanently refusing.
+//
+// The budgets are separate because the classes must not crowd each other out.
+// Tombstones evicting live entries would disable the fallback store-wide,
+// recreating the capture loss this cache prevents; live entries evicting
+// tombstones early would let a proven-unsafe key serve again; and either
+// evicting identity records would disarm the latch, which is the guard itself.
 func (s *TLSHandshakeStore) pruneLastLocked(now time.Time) {
 	// Fast path. This runs under s.mu, which also serialises Push/PopWait for
 	// every MySQL connection, and the sweeps below are full map scans. While the
 	// map is comfortably under budget there is nothing for them to find, so only
 	// pay for them once it is worth checking.
+	// The threshold is the SMALLEST single class budget, deliberately, even
+	// though the three classes below are budgeted separately and the map's
+	// designed steady state is therefore up to 3*maxLastGreetings. Raising it to
+	// the sum looks like an obvious win -- the scans are skipped more often --
+	// but it lets ONE class run far past its own budget while the total stays
+	// under the combined threshold, which is unbounded growth of that class.
+	// Measured: with the sum as the threshold, 1024 address-keyed live entries
+	// all survived against a 512 live budget. Under the smallest budget no class
+	// can be over while the total is under, so the early return is always safe.
 	if len(s.last) <= maxLastGreetings && now.Sub(s.lastPruned) < lastGreetingTTL {
 		return
 	}
@@ -338,7 +380,47 @@ func (s *TLSHandshakeStore) pruneLastLocked(now time.Time) {
 		if v.ambiguous {
 			continue
 		}
+		// Identity records are exempt for the same reason, one step earlier: they
+		// ARE the memory that makes the latch fire. Expiring one returns the key
+		// to "never seen", and the next write from a different server recreates
+		// it clean and serving.
+		if v.isIdentityOnly() {
+			// Exempt from the PAYLOAD TTL, but not immortal: unbounded, a key
+			// latched by an in-place server upgrade never serves again for the
+			// agent's lifetime, because the only other escape is the identity
+			// class's own eviction budget, which a low-cardinality node never
+			// reaches.
+			if now.Sub(v.seen) > identityTTL {
+				delete(s.last, k)
+			}
+			continue
+		}
 		if now.Sub(v.seen) > lastGreetingTTL {
+			// Demote rather than delete when the key knows which server owned
+			// it. Deleting outright is what let server A's entry age out and
+			// server B's next write recreate the key with no latch, serving B's
+			// capability flags and auth plugin to a reader that expected A.
+			//
+			// KNOWN TRADE, deliberate: the identity now outlives the TTL, so an
+			// IN-PLACE server upgrade latches this key permanently. greetingServerIdentity
+			// fingerprints ServerVersion and CapabilityFlags, so a minor-version
+			// bump on the same logical server reads as a second server. Before
+			// this change the key recovered after lastGreetingTTL -- but only if
+			// no old-version write landed inside that window, which a real
+			// rolling upgrade usually violates, so main latched permanently too
+			// in the common case. identityTTL now bounds it either way; the
+			// remaining exposure is a >2h gap between the two versions
+			// (scale-to-zero, then redeploy). The outcome is a MISSING mock
+			// (the fallback goes dead for that scope+port) rather than a WRONG
+			// one, which is the direction we want to fail in -- but it does mean
+			// the capture shortfall can return for a destination after a rolling
+			// upgrade, so it is a latency-to-recovery regression, not a no-op.
+			// The TTL rationale above is about payload staleness and still holds
+			// for the payload; it does not apply to the identity.
+			if v.serverID != "" {
+				s.last[k] = lastGreeting{serverID: v.serverID, seen: v.seen}
+				continue
+			}
 			delete(s.last, k)
 		}
 	}
@@ -348,13 +430,17 @@ func (s *TLSHandshakeStore) pruneLastLocked(now time.Time) {
 	// genuinely useful live greetings age past them and get evicted first. The
 	// cache then fills with keys that can only ever refuse, and the fallback goes
 	// dead for destinations that were never ambiguous at all.
-	evictOldest := func(ambiguous bool, budget int) {
+	//
+	// Identity records get a third budget for the same reason: they must outlive
+	// their payloads (that is their whole purpose) but must not be able to crowd
+	// out live entries.
+	evictOldest := func(class func(lastGreeting) bool, budget int, demote bool) {
 		for {
 			n := 0
 			var oldestKey string
 			var oldest time.Time
 			for k, v := range s.last {
-				if v.ambiguous != ambiguous {
+				if !class(v) {
 					continue
 				}
 				n++
@@ -365,11 +451,28 @@ func (s *TLSHandshakeStore) pruneLastLocked(now time.Time) {
 			if n <= budget || oldestKey == "" {
 				return
 			}
+			// Evicting a live entry must not forget which server owned the key:
+			// 512 unrelated address keys could otherwise evict a port key's live
+			// entry and disarm its latch without any clock involved.
+			if v := s.last[oldestKey]; demote && v.serverID != "" {
+				s.last[oldestKey] = lastGreeting{serverID: v.serverID, seen: v.seen}
+				continue
+			}
 			delete(s.last, oldestKey)
 		}
 	}
-	evictOldest(false, maxLastGreetings)
-	evictOldest(true, maxLastGreetings)
+	// NOT "!ambiguous && hasPayload()": that leaves an entry which is neither
+	// ambiguous, nor carrying a payload, nor carrying an identity in NO class at
+	// all, so no eviction pass ever counts or removes it and the map grows
+	// without bound. Measured: 2048 payload-less entries survived a 512 budget,
+	// with every write past the budget doing a full scan that removes nothing.
+	// Defining live as "not a tombstone and not an identity record" keeps the
+	// three classes exhaustive, which is what the fast path's argument requires.
+	isLive := func(g lastGreeting) bool { return !g.ambiguous && !g.isIdentityOnly() }
+	isTomb := func(g lastGreeting) bool { return g.ambiguous }
+	evictOldest(isLive, maxLastGreetings, true)
+	evictOldest(lastGreeting.isIdentityOnly, maxLastGreetings, false)
+	evictOldest(isTomb, maxLastGreetings, false)
 }
 
 // Push adds a handshake entry for the given key.
@@ -406,14 +509,47 @@ func (s *TLSHandshakeStore) Push(key string, entry TLSHandshakeEntry) {
 func (s *TLSHandshakeStore) Last(key string) (TLSHandshakeEntry, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	return s.lastLocked(key, time.Now())
+}
+
+// lastLocked is the shared body of Last and LastForPort. Callers hold s.mu.
+func (s *TLSHandshakeStore) lastLocked(key string, now time.Time) (TLSHandshakeEntry, bool) {
 	v, ok := s.last[key]
 	if !ok || v.ambiguous {
 		return TLSHandshakeEntry{}, false
 	}
-	if time.Since(v.seen) > lastGreetingTTL {
+	// An identity record remembers WHICH server owned this key after its payload
+	// expired or was evicted. It exists to keep the ambiguity latch armed; it is
+	// never servable.
+	if !v.hasPayload() {
+		return TLSHandshakeEntry{}, false
+	}
+	if now.Sub(v.seen) > lastGreetingTTL {
 		return TLSHandshakeEntry{}, false
 	}
 	return v.entry, true
+}
+
+// LastForPort answers "is this key latched, and if not what does it hold?" in a
+// SINGLE acquisition of s.mu.
+//
+// Callers must not compose IsAmbiguous with Last to get this. Between the two
+// calls another connection's raw leg can latch the key; Last then reports a miss
+// (it re-checks ambiguous), the caller reads that as "nothing cached", and falls
+// through to the unguarded shared address bucket — which is the exact outcome
+// the ambiguity check exists to prevent. That interleaving is a logic race, so
+// -race cannot see it; it was reproduced on iteration 127 of 20000.
+func (s *TLSHandshakeStore) LastForPort(key string) (entry TLSHandshakeEntry, ok bool, ambiguous bool) {
+	if key == "" {
+		return TLSHandshakeEntry{}, false, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.last[key].ambiguous {
+		return TLSHandshakeEntry{}, false, true
+	}
+	e, found := s.lastLocked(key, time.Now())
+	return e, found, false
 }
 
 // PopWait pops the oldest handshake entry for the given key, waiting up

--- a/pkg/models/tls_handshake_store_test.go
+++ b/pkg/models/tls_handshake_store_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -427,5 +429,270 @@ func TestRememberLastForPortRefusesEmptyIdentity(t *testing.T) {
 	s.RememberLastForPort(key, "", TLSHandshakeEntry{RespPackets: [][]byte{{0x0a}}})
 	if !s.IsAmbiguous(key) {
 		t.Error("an untagged write cleared a latched port key")
+	}
+}
+
+// TestLatchSurvivesTheLiveEntryExpiring is the regression fence for a latch that
+// was defeated by its own TTL sweep.
+//
+// The ambiguity latch is the ONLY thing stopping a port key from serving one
+// server's greeting to a connection that talked to another. Only the TOMBSTONE
+// was TTL-exempt; the live entry carrying serverID was swept like any other. So:
+// server A writes at T, A goes quiet, and at T+31min server B's write finds no
+// serverID to disagree with and recreates the key CLEAN and SERVING. A reader
+// then gets B's capability flags and auth plugin while decoding A's connection.
+func TestLatchSurvivesTheLiveEntryExpiring(t *testing.T) {
+	s := NewTLSHandshakeStore()
+	key := HandshakeLastPortKey("ns/app/ts", 3306)
+	s.RememberLastForPort(key, "server-A", TLSHandshakeEntry{RespPackets: [][]byte{{0xAA}}})
+
+	// Age A's entry past the TTL and force the sweep to run.
+	s.mu.Lock()
+	v := s.last[key]
+	v.seen = time.Now().Add(-2 * lastGreetingTTL)
+	s.last[key] = v
+	s.lastPruned = time.Time{}
+	s.pruneLastLocked(time.Now())
+	s.mu.Unlock()
+
+	// A DIFFERENT server now writes the same scope+port.
+	s.RememberLastForPort(key, "server-B", TLSHandshakeEntry{RespPackets: [][]byte{{0xBB}}})
+
+	entry, ok, ambiguous := s.LastForPort(key)
+	if !ambiguous {
+		t.Fatalf("port key not latched after two different servers; LastForPort -> ok=%v entry=%v — "+
+			"server A's identity died with its payload, so B recreated the key clean and serving", ok, entry.RespPackets)
+	}
+	if ok {
+		t.Fatalf("latched key still served an entry: %v", entry.RespPackets)
+	}
+}
+
+// TestLatchSurvivesTheLiveEntryBeingEvicted is the same defect reached without a
+// clock: unrelated address keys overflow the live budget and evict the port
+// key's entry, taking its identity with it.
+func TestLatchSurvivesTheLiveEntryBeingEvicted(t *testing.T) {
+	s := NewTLSHandshakeStore()
+	key := HandshakeLastPortKey("ns/app/ts", 3306)
+	s.RememberLastForPort(key, "server-A", TLSHandshakeEntry{RespPackets: [][]byte{{0xAA}}})
+
+	// Overflow the live budget with unrelated address keys so the port key, being
+	// the oldest, is the eviction victim.
+	for i := 0; i < maxLastGreetings+16; i++ {
+		s.RememberLast(HandshakeLastKey("ns/app/ts", &ConditionalDstCfg{
+			Addr: fmt.Sprintf("10.9.%d.%d:3306", i/256, i%256)}),
+			TLSHandshakeEntry{RespPackets: [][]byte{{0x01}}})
+	}
+
+	s.RememberLastForPort(key, "server-B", TLSHandshakeEntry{RespPackets: [][]byte{{0xBB}}})
+
+	entry, ok, ambiguous := s.LastForPort(key)
+	if !ambiguous {
+		t.Fatalf("port key not latched after eviction forgot server A; ok=%v entry=%v", ok, entry.RespPackets)
+	}
+	if ok {
+		t.Fatalf("latched key still served an entry: %v", entry.RespPackets)
+	}
+}
+
+// TestIdentityRecordsAreBounded proves the durability above did not trade a
+// corruption bug for an unbounded-growth one. Identity records outlive their
+// payloads deliberately, so they need their own budget.
+func TestIdentityRecordsAreBounded(t *testing.T) {
+	s := NewTLSHandshakeStore()
+	for i := 0; i < maxLastGreetings*3; i++ {
+		k := HandshakeLastPortKey(fmt.Sprintf("ns/app/ts-%d", i), 3306)
+		s.RememberLastForPort(k, fmt.Sprintf("server-%d", i), TLSHandshakeEntry{RespPackets: [][]byte{{0x0a}}})
+		s.mu.Lock()
+		v := s.last[k]
+		v.seen = time.Now().Add(-2 * lastGreetingTTL)
+		s.last[k] = v
+		s.lastPruned = time.Time{}
+		s.mu.Unlock()
+	}
+	s.mu.Lock()
+	s.lastPruned = time.Time{}
+	s.pruneLastLocked(time.Now())
+	var identity int
+	for _, v := range s.last {
+		if v.isIdentityOnly() {
+			identity++
+		}
+	}
+	total := len(s.last)
+	s.mu.Unlock()
+	if identity > maxLastGreetings {
+		t.Fatalf("identity records = %d, want <= %d — they outlive their payloads, so an unbudgeted class grows without bound", identity, maxLastGreetings)
+	}
+	if total > 3*maxLastGreetings {
+		t.Fatalf("cache holds %d entries across all classes, want <= %d", total, 3*maxLastGreetings)
+	}
+}
+
+// TestLastForPortIsAtomicAgainstLatching fences the check-then-act race that
+// composing IsAmbiguous with Last reintroduces.
+//
+// A latch landing between the two calls made Last report a plain miss, which the
+// caller read as "nothing cached" and answered from the UNGUARDED shared address
+// bucket — the one outcome the ambiguity check exists to prevent. It is a logic
+// race, so -race cannot see it: both calls are correctly locked, the composition
+// is not. LastForPort must never report (ok=false, ambiguous=false) for a key
+// that holds an entry or is latched.
+//
+// The reader spins against a concurrent latcher so the window between the two
+// lock acquisitions is actually entered; a single read per experiment almost
+// never lands in it and lets the composed version pass.
+//
+// Do NOT add runtime.Gosched() to the reader loop. It looks like an obvious
+// courtesy — the loop is a busy spin and costs ~80x under -race at
+// GOMAXPROCS=1 — but yielding hands the writer the lock at a predictable point
+// and the window stops being entered: MEASURED 0/5 kills with the yield versus
+// 5/5 without. A cheap test that cannot detect the defect is worth less than an
+// expensive one that can.
+func TestLastForPortIsAtomicAgainstLatching(t *testing.T) {
+	const experiments = 300
+	for iter := 0; iter < experiments; iter++ {
+		s := NewTLSHandshakeStore()
+		key := HandshakeLastPortKey("ns/app/ts", 3306)
+		s.RememberLastForPort(key, "server-A", TLSHandshakeEntry{RespPackets: [][]byte{{0xAA}}})
+
+		var violation atomic.Bool
+		var servedB atomic.Bool
+		stop := make(chan struct{})
+		ready := make(chan struct{})
+		var once sync.Once
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				entry, ok, ambiguous := s.LastForPort(key)
+				// Signal only after a read has completed, so the latch below
+				// lands while this loop is genuinely in flight. Writing before
+				// the reader spins leaves the window unentered and lets the
+				// composed implementation pass.
+				once.Do(func() { close(ready) })
+				if !ok && !ambiguous {
+					violation.Store(true)
+					return
+				}
+				if ok && len(entry.RespPackets) > 0 && entry.RespPackets[0][0] == 0xBB {
+					servedB.Store(true)
+					return
+				}
+				select {
+				case <-stop:
+					return
+				default:
+				}
+			}
+		}()
+
+		// A second server's raw leg latches the key while the reader is spinning.
+		<-ready
+		s.RememberLastForPort(key, "server-B", TLSHandshakeEntry{RespPackets: [][]byte{{0xBB}}})
+		close(stop)
+		wg.Wait()
+
+		if violation.Load() {
+			t.Fatalf("iter %d: LastForPort reported neither an entry nor the latch — "+
+				"the caller falls through to the unguarded address bucket after the guard proved reuse unsafe", iter)
+		}
+		if servedB.Load() {
+			t.Fatalf("iter %d: served server B's greeting under a key server A owned", iter)
+		}
+	}
+}
+
+// TestPayloadlessEntriesAreBounded fences the class-exhaustiveness invariant the
+// prune fast path depends on.
+//
+// The three eviction classes must cover EVERY entry. Defining live as
+// "!ambiguous && hasPayload()" left an entry that is not ambiguous, carries no
+// payload and carries no identity in no class at all: no pass counted it, none
+// evicted it, and the map grew without bound while every write past the budget
+// did a full scan that removed nothing. Measured at 2048 against a 512 budget.
+func TestPayloadlessEntriesAreBounded(t *testing.T) {
+	s := NewTLSHandshakeStore()
+	for i := 0; i < maxLastGreetings*4; i++ {
+		s.RememberLast(HandshakeLastKey("scope", &ConditionalDstCfg{
+			Addr: fmt.Sprintf("10.4.%d.%d:3306", i/256, i%256)}),
+			TLSHandshakeEntry{ReqPackets: [][]byte{{0x01}}})
+	}
+	s.mu.Lock()
+	n := len(s.last)
+	s.mu.Unlock()
+	if n > maxLastGreetings {
+		t.Fatalf("payload-less entries grew to %d against a %d budget — they fall into no eviction "+
+			"class, so nothing ever removes them and every write past the budget scans the whole map for nothing", n, maxLastGreetings)
+	}
+}
+
+// TestIdentityRecordsAreNeverServed pins the single most safety-critical property
+// of the identity class: it remembers WHICH server owned a key so the ambiguity
+// latch stays armed, and it must never be handed to a caller as a greeting.
+//
+// Without this, deleting the payload guard in lastLocked leaves the whole suite
+// green while Last returns ok=true with an empty entry.
+func TestIdentityRecordsAreNeverServed(t *testing.T) {
+	s := NewTLSHandshakeStore()
+	key := HandshakeLastPortKey("ns/app/ts", 3306)
+
+	// A record demoted by EVICTION keeps a fresh timestamp, so the TTL check
+	// cannot be what refuses it — the payload guard has to.
+	s.mu.Lock()
+	if s.last == nil {
+		s.last = make(map[string]lastGreeting)
+	}
+	s.last[key] = lastGreeting{serverID: "server-A", seen: time.Now()}
+	s.mu.Unlock()
+
+	if entry, ok := s.Last(key); ok {
+		t.Fatalf("Last served an identity record: ok=true entry=%v — it carries no greeting and must never be served", entry.RespPackets)
+	}
+	if entry, ok, ambiguous := s.LastForPort(key); ok || ambiguous {
+		t.Fatalf("LastForPort served or latched on an identity record: ok=%v ambiguous=%v entry=%v", ok, ambiguous, entry.RespPackets)
+	}
+}
+
+// TestIdentityRecordsExpireEventually pins the bound on the ambiguity latch.
+//
+// Identity records deliberately outlive the payload TTL so a rolling upgrade
+// cannot disarm the latch mid-drain. Unbounded, though, a key latched by an
+// in-place server version bump never serves again for the agent's lifetime:
+// greetingServerIdentity fingerprints ServerVersion, so a minor bump reads as a
+// second server, and the only other escape is the identity eviction budget,
+// which a low-cardinality node never reaches. identityTTL bounds that.
+func TestIdentityRecordsExpireEventually(t *testing.T) {
+	s := NewTLSHandshakeStore()
+	key := HandshakeLastPortKey("ns/app/ts", 3306)
+	s.RememberLastForPort(key, "server-A", TLSHandshakeEntry{RespPackets: [][]byte{{0xAA}}})
+
+	// Age past the PAYLOAD ttl and sweep: the payload goes, the identity stays.
+	s.mu.Lock()
+	v := s.last[key]
+	v.seen = time.Now().Add(-2 * lastGreetingTTL)
+	s.last[key] = v
+	s.lastPruned = time.Time{}
+	s.pruneLastLocked(time.Now())
+	held, ok := s.last[key]
+	s.mu.Unlock()
+	if !ok || !held.isIdentityOnly() {
+		t.Fatalf("after the payload TTL the key should hold an identity record, got ok=%v %+v", ok, held)
+	}
+
+	// Age past the IDENTITY ttl and sweep again: now it is forgotten, so the key
+	// is reusable rather than latched for the process lifetime.
+	s.mu.Lock()
+	v = s.last[key]
+	v.seen = time.Now().Add(-2 * identityTTL)
+	s.last[key] = v
+	s.lastPruned = time.Time{}
+	s.pruneLastLocked(time.Now())
+	_, stillThere := s.last[key]
+	s.mu.Unlock()
+	if stillThere {
+		t.Fatalf("identity record outlived identityTTL — a key latched by an in-place version bump " +
+			"would stay dead for the agent's lifetime")
 	}
 }


### PR DESCRIPTION
Follow-up to #4524. Three defects found by an adversarial review of the merged code, each reproduced before being fixed.

### 1. The ambiguity latch was defeated by its own TTL sweep and eviction budget

The latch is the only thing stopping a port key from serving one server's greeting to a connection that talked to another. Only the **tombstone** was TTL-exempt; the live entry carrying `serverID` was swept like any other. So server A writes at T, A goes quiet, and at T+31min server B's write finds no identity to disagree with and recreates the key **clean and serving** — a reader then decodes A's connection with B's capability flags and auth plugin.

The same happens with no clock at all when 512 unrelated address keys overflow the live budget and evict the port key.

An expiring or evicted entry that knows which server owned it is now **demoted to an identity record**: no payload, so it can never be served, but the identity survives and the latch still fires. Identity records get their own eviction budget so outliving their payloads cannot starve live entries.

### 2. `cachedGreeting` composed `IsAmbiguous` with `Last` — check-then-act

A latch landing between the two calls made `Last` report a plain miss, the caller read that as "nothing cached", and answered from the **unguarded shared address bucket** — right after the guard proved reuse unsafe. Both calls are correctly locked, so `-race` is blind to it; it reproduces in a contended loop. `LastForPort` answers both questions under one acquisition.

### 3. The legacy post-TLS reader's only guard asserted on source text

It read `conn.go` off disk and grepped for `hsStore.Last(lastKey)`. Flipping the enclosing condition to `if false` leaves the string in place, kills the entire fallback, and the whole suite stays green — verified. Replaced by a test that drives `handlePostTLSRecord` against a fabricated address, where consulting the cache and falling through to `fetchServerGreeting` are cleanly separable.

### Bounded, not unbounded

Identity records outlive the payload TTL deliberately, so a rolling upgrade cannot disarm the latch mid-drain. Unbounded, though, an **in-place** server version bump latches a key permanently: `greetingServerIdentity` fingerprints `ServerVersion`, so a minor bump reads as a second server. `identityTTL` (4× the payload TTL) bounds that — a key that has seen no traffic from any server for two hours has no live producer left to protect.

The prune fast path deliberately keeps comparing against the **smallest** single-class budget, not the sum. Raising it to the sum looks free and is not: it lets one class run far past its own budget while the total stays under the combined threshold. Measured — 1024 address-keyed live entries survived a 512 budget.

### CI

The mutation guard never mutated `conn.go` at all, which is exactly how (3) slipped through. It now carries **nine** mutants, each verified to apply, compile and kill — a mutant that cannot apply scores a false pass:

| mutant | guards |
|---|---|
| remove the cache seeding | the original fix |
| blank the server identity | the port key is never seeded |
| disable the legacy cache read | (3) |
| forget the identity on expiry | (1), TTL sweep |
| forget the identity on eviction | (1), eviction budget |
| composed accessor | (2) |
| serve an identity record | identity records are never servable |
| non-exhaustive class split | unbounded growth |
| unbounded identity record | permanent latch |

### Verification

`gofmt`, `go vet`, and `go test -race` green across `./pkg/models/` and `./pkg/agent/proxy/integrations/mysql/...`. Full mutation block exits 0 with the tree restored.

**Not claimed:** none of the cross-server scenarios are proven in a running system — the e2e harness has exactly one MySQL server and cannot exercise them. The store-level behaviour is proven by executable tests; the rest is code reading. The address bucket remains unguarded and the pre-existing `port:%d` queue has no identity guard at all; both are left alone here and neither is overclaimed in the code comments.