### PR TITLE
refactor(record): remove the cross-pod TestCase.DuplicateOf mark

### DIFF
--- a/pkg/models/testcase.go
+++ b/pkg/models/testcase.go
@@ -85,14 +85,6 @@ type TestCase struct {
 	// each capture, not be inferred from mutable registries. Never set by
 	// agents or on the wire ("-" everywhere).
 	SourceNode string `json:"-" yaml:"-" bson:"-"`
-	// DuplicateOf marks this test case as a cross-pod duplicate within its
-	// recording: "<test-set>/<test-name>" of the first-stored copy, or a
-	// scope-only ref ("pod:<p>" / "node:<n>") when the winner's identity was
-	// recovered from dedup-stat snapshots rather than a stored test case. Set
-	// by the recording owner, never by agents. Persisted — JSON/BSON here,
-	// YAML via the spec Metadata map — so the mark survives to storage and
-	// the UI. Empty means not a known duplicate.
-	DuplicateOf string `json:"duplicate_of,omitempty" bson:"duplicate_of,omitempty"`
 }
 
 func (tc *TestCase) GetKind() string {

--- a/pkg/platform/yaml/testdb/util.go
+++ b/pkg/platform/yaml/testdb/util.go
@@ -57,35 +57,27 @@ func buildHTTPSchema(tc models.TestCase, logger *zap.Logger) models.HTTPSchema {
 			return a
 		}(),
 	}
-	httpSchema.Metadata = specMetadata(tc.Description, tc.DuplicateOf)
+	httpSchema.Metadata = specMetadata(tc.Description)
 	return httpSchema
 }
 
 // specMetadata builds the spec-level Metadata map carrying the fields that
-// persist through the spec rather than the doc: the user-facing description
-// and the cross-pod duplicate mark. Returns nil when there is nothing to
-// carry, so specs without metadata keep encoding byte-identically to before.
-// The gRPC encoders pass description="" — gRPC specs have never persisted a
-// description and that stays unchanged.
-func specMetadata(description, duplicateOf string) map[string]string {
-	if description == "" && duplicateOf == "" {
+// persist through the spec rather than the doc: the user-facing description.
+// Returns nil when there is nothing to carry, so specs without metadata keep
+// encoding byte-identically to before. The gRPC encoders pass description="" —
+// gRPC specs have never persisted a description and that stays unchanged.
+func specMetadata(description string) map[string]string {
+	if description == "" {
 		return nil
 	}
-	md := make(map[string]string, 2)
-	if description != "" {
-		md["description"] = description
-	}
-	if duplicateOf != "" {
-		md["duplicate_of"] = duplicateOf
-	}
-	return md
+	return map[string]string{"description": description}
 }
 
 // buildGrpcSpec is the JSON-path counterpart of the gRPC branch in EncodeTestcase.
 func buildGrpcSpec(tc models.TestCase) models.GrpcSpec {
 	noise := tc.Noise
 	return models.GrpcSpec{
-		Metadata: specMetadata("", tc.DuplicateOf),
+		Metadata: specMetadata(""),
 		GrpcReq:  tc.GrpcReq,
 		GrpcResp: tc.GrpcResp,
 		Created:  tc.Created,
@@ -368,7 +360,6 @@ func Decode(yamlTestcase *yaml.NetworkTrafficDoc, logger *zap.Logger) (*models.T
 		tc.HTTPReq = httpSpec.Request
 		tc.HTTPResp = httpSpec.Response
 		tc.Description = httpSpec.Metadata["description"]
-		tc.DuplicateOf = httpSpec.Metadata["duplicate_of"]
 		tc.AppPort = httpSpec.AppPort
 
 		// single map-based loop for all assertions
@@ -406,7 +397,6 @@ func Decode(yamlTestcase *yaml.NetworkTrafficDoc, logger *zap.Logger) (*models.T
 		tc.Created = grpcSpec.Created
 		tc.GrpcReq = grpcSpec.GrpcReq
 		tc.GrpcResp = grpcSpec.GrpcResp
-		tc.DuplicateOf = grpcSpec.Metadata["duplicate_of"]
 		tc.AppPort = grpcSpec.AppPort
 
 		for key, raw := range grpcSpec.Assertions {
@@ -469,7 +459,6 @@ func DecodeJSON(doc *yaml.NetworkTrafficDocJSON, logger *zap.Logger) (*models.Te
 		tc.HTTPReq = httpSpec.Request
 		tc.HTTPResp = httpSpec.Response
 		tc.Description = httpSpec.Metadata["description"]
-		tc.DuplicateOf = httpSpec.Metadata["duplicate_of"]
 		tc.AppPort = httpSpec.AppPort
 		expandAssertionsJSON(tc, httpSpec.Assertions)
 
@@ -482,7 +471,6 @@ func DecodeJSON(doc *yaml.NetworkTrafficDocJSON, logger *zap.Logger) (*models.Te
 		tc.Created = grpcSpec.Created
 		tc.GrpcReq = grpcSpec.GrpcReq
 		tc.GrpcResp = grpcSpec.GrpcResp
-		tc.DuplicateOf = grpcSpec.Metadata["duplicate_of"]
 		tc.AppPort = grpcSpec.AppPort
 		expandAssertionsJSON(tc, grpcSpec.Assertions)
 

--- a/pkg/platform/yaml/testdb/util_test.go
+++ b/pkg/platform/yaml/testdb/util_test.go
@@ -31,97 +31,11 @@ func grpcTestCase() models.TestCase {
 	}
 }
 
-// TestDuplicateOfRoundTripYAML pins the cross-pod duplicate mark's persistence
-// through the YAML encode/decode pair for both testcase kinds. The mark rides
-// the spec Metadata map, so old readers (which only look up "description")
-// ignore it and old files (no metadata) decode to an empty mark.
-func TestDuplicateOfRoundTripYAML(t *testing.T) {
-	logger := zap.NewNop()
-
-	t.Run("http", func(t *testing.T) {
-		tc := httpTestCase()
-		tc.Description = "a described case"
-		tc.DuplicateOf = "test-set-0/test-3@pod-a"
-
-		doc, err := EncodeTestcase(tc, logger)
-		if err != nil {
-			t.Fatalf("encode: %v", err)
-		}
-		got, err := Decode(doc, logger)
-		if err != nil {
-			t.Fatalf("decode: %v", err)
-		}
-		if got.DuplicateOf != tc.DuplicateOf {
-			t.Fatalf("DuplicateOf lost in yaml round-trip: got %q want %q", got.DuplicateOf, tc.DuplicateOf)
-		}
-		if got.Description != tc.Description {
-			t.Fatalf("Description must survive alongside the mark: got %q want %q", got.Description, tc.Description)
-		}
-	})
-
-	t.Run("grpc", func(t *testing.T) {
-		tc := grpcTestCase()
-		tc.DuplicateOf = "test-set-0/test-7@pod-b"
-
-		doc, err := EncodeTestcase(tc, logger)
-		if err != nil {
-			t.Fatalf("encode: %v", err)
-		}
-		got, err := Decode(doc, logger)
-		if err != nil {
-			t.Fatalf("decode: %v", err)
-		}
-		if got.DuplicateOf != tc.DuplicateOf {
-			t.Fatalf("DuplicateOf lost in grpc yaml round-trip: got %q want %q", got.DuplicateOf, tc.DuplicateOf)
-		}
-	})
-}
-
-// TestDuplicateOfRoundTripJSON covers the JSON-native encoder/decoder pair
-// (the storage fast path) for both kinds.
-func TestDuplicateOfRoundTripJSON(t *testing.T) {
-	logger := zap.NewNop()
-
-	t.Run("http", func(t *testing.T) {
-		tc := httpTestCase()
-		tc.DuplicateOf = "test-set-0/test-3@pod-a"
-
-		doc, err := EncodeTestcaseJSON(tc, logger)
-		if err != nil {
-			t.Fatalf("encode: %v", err)
-		}
-		got, err := DecodeJSON(doc, logger)
-		if err != nil {
-			t.Fatalf("decode: %v", err)
-		}
-		if got.DuplicateOf != tc.DuplicateOf {
-			t.Fatalf("DuplicateOf lost in json round-trip: got %q want %q", got.DuplicateOf, tc.DuplicateOf)
-		}
-	})
-
-	t.Run("grpc", func(t *testing.T) {
-		tc := grpcTestCase()
-		tc.DuplicateOf = "test-set-0/test-7@pod-b"
-
-		doc, err := EncodeTestcaseJSON(tc, logger)
-		if err != nil {
-			t.Fatalf("encode: %v", err)
-		}
-		got, err := DecodeJSON(doc, logger)
-		if err != nil {
-			t.Fatalf("decode: %v", err)
-		}
-		if got.DuplicateOf != tc.DuplicateOf {
-			t.Fatalf("DuplicateOf lost in grpc json round-trip: got %q want %q", got.DuplicateOf, tc.DuplicateOf)
-		}
-	})
-}
-
 // TestSpecMetadataStaysAbsentWhenUnset pins byte-compatibility with existing
-// files: a testcase with neither description nor duplicate mark must encode a
-// nil Metadata map, exactly as before the mark existed.
+// files: a testcase with no description must encode a nil Metadata map,
+// exactly as before the metadata map existed.
 func TestSpecMetadataStaysAbsentWhenUnset(t *testing.T) {
-	if md := specMetadata("", ""); md != nil {
+	if md := specMetadata(""); md != nil {
 		t.Fatalf("expected nil metadata for unset fields, got %v", md)
 	}
 	if schema := buildHTTPSchema(httpTestCase(), zap.NewNop()); schema.Metadata != nil {
@@ -159,7 +73,7 @@ func TestDecodeIgnoresUnknownMetadataKeys(t *testing.T) {
 	if err != nil {
 		t.Fatalf("decode with unknown metadata keys must not fail: %v", err)
 	}
-	if got.DuplicateOf != "" || got.Description != "" {
+	if got.Description != "" {
 		t.Fatalf("unknown keys must not bleed into fields: %+v", got)
 	}
 }


### PR DESCRIPTION
## What

Cross-pod static dedup is moving from **store-but-mark** to **drop**: the k8s-proxy recording owner now discards a later cross-pod copy of an already-stored schema at its ingest funnel (see keploy/k8s-proxy#849) instead of persisting it with a `DuplicateOf` annotation.

That makes `TestCase.DuplicateOf` and its persistence dead code. This PR removes it:

- Drop `TestCase.DuplicateOf` (`pkg/models/testcase.go`).
- Drop the `duplicate_of` spec-metadata read/write in the YAML test DB; `specMetadata` now carries only `description` (`pkg/platform/yaml/testdb/util.go`).
- Remove the now-obsolete `DuplicateOf` round-trip tests.

## Compatibility

- `SchemaKey` and `SourceNode` (the transient, wire-only fields cross-pod dedup actually uses) are untouched.
- Unmarked testcases still encode a `nil` spec metadata map, so existing test-case YAML stays byte-identical; older files carrying a `duplicate_of` metadata key decode fine (the key is simply ignored).

## Testing

`go build ./...`, `go vet`, and `go test ./pkg/platform/yaml/testdb/... ./pkg/models/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)