### PR TITLE
perf(mysql/replay): agent-owned consumed set (flag) + IsDML-once — cut the per-testcase client↔agent cost

### DIFF
--- a/pkg/agent/proxy/integrations/mysql/replayer/match.go
+++ b/pkg/agent/proxy/integrations/mysql/replayer/match.go
@@ -1450,20 +1450,28 @@ func matchQuery(_ context.Context, log *zap.Logger, expected, actual mysql.Packe
 		return false, 0
 	}
 
+	// sqlparser.IsDML parses the statement, so it is the most expensive check in
+	// this function and it is deterministic for a given query. On the per-command
+	// O(pool) match path the old code parsed each side 3-4x per candidate; compute
+	// each side ONCE and reuse. (Profiled: IsDML re-parsing is a measurable slice
+	// of replay agent CPU when the candidate pool is large.)
+	expectedIsDML := sqlparser.IsDML(expectedQuery)
+	actualIsDML := sqlparser.IsDML(actualQuery)
+
 	// check if any of them the query is dml and other is not, then there is no match.
-	if sqlparser.IsDML(expectedQuery) && !sqlparser.IsDML(actualQuery) {
+	if expectedIsDML && !actualIsDML {
 		log.Debug("expected query is dml but actual is not",
 			zap.String("expected query", expectedQuery),
 			zap.String("actual query", actualQuery))
 		return false, 0
-	} else if !sqlparser.IsDML(expectedQuery) && sqlparser.IsDML(actualQuery) {
+	} else if !expectedIsDML && actualIsDML {
 		log.Debug("actual query is dml but expected is not",
 			zap.String("expected query", expectedQuery),
 			zap.String("actual query", actualQuery))
 		return false, 0
 	}
 
-	if !(sqlparser.IsDML(expectedQuery) && sqlparser.IsDML(actualQuery)) {
+	if !(expectedIsDML && actualIsDML) {
 		// Non-DML. sqlparser.IsDML covers only INSERT/UPDATE/DELETE, so this is
 		// where every SELECT and SHOW lands, and the parse-tree tier below never
 		// sees them. Last resort: the same statement with a drifted inline

--- a/pkg/agent/proxy/mockmanager.go
+++ b/pkg/agent/proxy/mockmanager.go
@@ -80,6 +80,12 @@ type MockManager struct {
 	consumedMu    sync.Mutex
 	consumedList  []models.MockState
 	consumedIndex map[string]int
+	// consumedPersistent accumulates the LATEST MockState per mock name across
+	// the whole session and is NEVER drained (unlike consumedList, which
+	// GetConsumedMocks empties). It lets the agent apply filterOutDeleted from
+	// its OWN consumption history instead of a copy the client re-sends every
+	// testcase. Read only when MockFilterParams.AgentOwnsConsumed is set.
+	consumedPersistent map[string]models.MockState
 
 	// Optimized lookup maps
 	statelessFiltered   map[models.Kind]map[string][]*models.Mock
@@ -288,6 +294,7 @@ func NewMockManager(filtered, unfiltered *TreeDb, logger *zap.Logger) *MockManag
 		statelessUnfiltered: make(map[models.Kind]map[string][]*models.Mock),
 		revByKind:           make(map[models.Kind]*uint64),
 		consumedIndex:       make(map[string]int),
+		consumedPersistent:  make(map[string]models.MockState),
 		connectionTrees:     make(map[string]*TreeDb),
 		connectionLastTs:    make(map[string]time.Time),
 		sweeperStop:         make(chan struct{}),
@@ -2506,6 +2513,12 @@ func (m *MockManager) flagMockAsUsed(mock models.MockState) error {
 		m.consumedIndex[mock.Name] = len(m.consumedList)
 		m.consumedList = append(m.consumedList, mock)
 	}
+	// Never-drained accumulation (latest state per name) mirroring exactly what
+	// the client builds from successive GetConsumedMocks drains — so the agent
+	// can self-apply filterOutDeleted with no client round-trip.
+	if m.consumedPersistent != nil {
+		m.consumedPersistent[mock.Name] = mock
+	}
 	m.consumedMu.Unlock()
 	return nil
 }
@@ -2519,6 +2532,21 @@ func (m *MockManager) GetConsumedMocks() []models.MockState {
 	m.consumedList = m.consumedList[:0]
 	m.consumedIndex = make(map[string]int)
 	m.consumedMu.Unlock()
+	return out
+}
+
+// GetPersistentConsumed returns a COPY of the never-drained per-name
+// consumption map (latest MockState per mock name for the whole session).
+// Unlike GetConsumedMocks it does NOT drain. It is the agent-side equivalent of
+// the client's accumulated totalConsumedMocks, used to apply filterOutDeleted
+// from the agent's own history when MockFilterParams.AgentOwnsConsumed is set.
+func (m *MockManager) GetPersistentConsumed() map[string]models.MockState {
+	m.consumedMu.Lock()
+	defer m.consumedMu.Unlock()
+	out := make(map[string]models.MockState, len(m.consumedPersistent))
+	for k, v := range m.consumedPersistent {
+		out[k] = v
+	}
 	return out
 }
 

--- a/pkg/agent/proxy/mockmanager_persistent_consumed_test.go
+++ b/pkg/agent/proxy/mockmanager_persistent_consumed_test.go
@@ -1,0 +1,97 @@
+// Package proxy — equivalence proof for the agent-owned consumption map.
+//
+// The AgentOwnsConsumed re-architecture (models.MockFilterParams.AgentOwnsConsumed)
+// stops the client from re-sending its accumulated TotalConsumedMocks every
+// testcase and has the agent apply filterOutDeleted from its OWN persistent map
+// instead. That is only correct if the agent's persistent map is IDENTICAL to
+// what the client would have accumulated from the per-call GetConsumedMocks
+// drains. This test pins that equivalence on the real MockManager so the
+// re-architecture can never silently diverge (which would re-serve or wrongly
+// drop mocks under load — the exact regression the flag guards against).
+package proxy
+
+import (
+	"reflect"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// TestGetPersistentConsumed_EqualsClientAccumulation drives several "testcases"
+// of consumption (including a mock whose state CHANGES to Deleted on a later
+// testcase, and per-call drains in between, exactly as replay drives it) and
+// asserts the agent's never-drained GetPersistentConsumed equals the map the
+// client builds by merging successive GetConsumedMocks drains by name.
+func TestGetPersistentConsumed_EqualsClientAccumulation(t *testing.T) {
+	mm := NewMockManager(nil, nil, zap.NewNop())
+	defer mm.Close()
+
+	// The client's accumulation: after each testcase it drains and merges by
+	// name (latest state wins) — exactly pkg/service/replay/replay.go's
+	// `totalConsumedMocks[m.Name] = m`.
+	client := map[string]models.MockState{}
+	accumulate := func() {
+		for _, ms := range mm.GetConsumedMocks() {
+			client[ms.Name] = ms
+		}
+	}
+
+	// Testcase 1: consume A (updated) and B (deleted).
+	if err := mm.flagMockAsUsed(models.MockState{Name: "A", Kind: models.MySQL, Usage: models.Updated, IsFiltered: true, SortOrder: 1}); err != nil {
+		t.Fatalf("flagMockAsUsed A: %v", err)
+	}
+	if err := mm.flagMockAsUsed(models.MockState{Name: "B", Kind: models.MySQL, Usage: models.Deleted, IsFiltered: false, SortOrder: 2}); err != nil {
+		t.Fatalf("flagMockAsUsed B: %v", err)
+	}
+	accumulate()
+
+	// Testcase 2: A's state CHANGES to deleted; consume C (updated). The latest
+	// state per name is what filterOutDeleted reads, so this transition is the
+	// load-bearing case.
+	if err := mm.flagMockAsUsed(models.MockState{Name: "A", Kind: models.MySQL, Usage: models.Deleted, IsFiltered: true, SortOrder: 3}); err != nil {
+		t.Fatalf("flagMockAsUsed A2: %v", err)
+	}
+	if err := mm.flagMockAsUsed(models.MockState{Name: "C", Kind: models.MySQL, Usage: models.Updated, IsFiltered: true, SortOrder: 4}); err != nil {
+		t.Fatalf("flagMockAsUsed C: %v", err)
+	}
+	accumulate()
+
+	persistent := mm.GetPersistentConsumed()
+
+	// Core equivalence: the two maps MUST be identical (same keys, same latest
+	// MockState per name). If they ever diverge, AgentOwnsConsumed is unsafe.
+	if !reflect.DeepEqual(persistent, client) {
+		t.Fatalf("agent persistent map != client accumulation\n persistent=%#v\n client=%#v", persistent, client)
+	}
+
+	// Spot-check the exact fields filterOutDeleted keys on (Usage, IsFiltered,
+	// SortOrder) reflect the LATEST state, not the first.
+	if got := persistent["A"]; got.Usage != models.Deleted || got.SortOrder != 3 {
+		t.Fatalf("A must reflect its latest (deleted, sortOrder=3) state, got %+v", got)
+	}
+	if got := persistent["C"]; got.Usage != models.Updated {
+		t.Fatalf("C must be updated, got %+v", got)
+	}
+	if _, ok := persistent["B"]; !ok {
+		t.Fatal("B (deleted on testcase 1) must remain in the persistent map for filterOutDeleted")
+	}
+}
+
+// TestGetPersistentConsumed_NotDrained proves the persistent map is NOT drained
+// by GetConsumedMocks (the whole point — the drain is why the client had to
+// re-feed state; the persistent map must survive it).
+func TestGetPersistentConsumed_NotDrained(t *testing.T) {
+	mm := NewMockManager(nil, nil, zap.NewNop())
+	defer mm.Close()
+
+	if err := mm.flagMockAsUsed(models.MockState{Name: "X", Kind: models.MySQL, Usage: models.Deleted}); err != nil {
+		t.Fatalf("flagMockAsUsed: %v", err)
+	}
+	_ = mm.GetConsumedMocks() // drains consumedList
+	_ = mm.GetConsumedMocks() // still drained
+
+	if p := mm.GetPersistentConsumed(); len(p) != 1 || p["X"].Usage != models.Deleted {
+		t.Fatalf("persistent map must survive GetConsumedMocks drains; got %#v", p)
+	}
+}

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -3402,6 +3402,17 @@ func (p *Proxy) GetConsumedMocks(_ context.Context) ([]models.MockState, error) 
 	return m.GetConsumedMocks(), nil
 }
 
+// GetPersistentConsumed forwards the mock manager's never-drained per-name
+// consumption map (implements coreAgent.ConsumedStateReader; see
+// models.MockFilterParams.AgentOwnsConsumed). Returns nil when no manager.
+func (p *Proxy) GetPersistentConsumed() map[string]models.MockState {
+	m := p.getMockManager()
+	if m == nil {
+		return nil
+	}
+	return m.GetPersistentConsumed()
+}
+
 // testErrorAccumulator collects errors during an active test case.
 // It is goroutine-safe via an internal mutex.
 type testErrorAccumulator struct {

--- a/pkg/agent/service.go
+++ b/pkg/agent/service.go
@@ -153,6 +153,14 @@ type FirstWindowStartReader interface {
 	FirstTestWindowStart() time.Time
 }
 
+// ConsumedStateReader is implemented by proxies whose mock manager keeps a
+// persistent (never-drained) per-name consumption map. It lets the agent apply
+// filterOutDeleted from its OWN history instead of a copy the client re-sends
+// every testcase — see models.MockFilterParams.AgentOwnsConsumed.
+type ConsumedStateReader interface {
+	GetPersistentConsumed() map[string]models.MockState
+}
+
 type IncomingProxy interface {
 	Start(ctx context.Context, opts models.IncomingOptions) chan *models.TestCase
 }

--- a/pkg/models/agent.go
+++ b/pkg/models/agent.go
@@ -100,6 +100,11 @@ type MockFilterParams struct {
 	BeforeTime             time.Time            `json:"beforeTime,omitempty"`
 	MockMapping            []string             `json:"mockMapping,omitempty"`
 	UseMappingBased        bool                 `json:"useMappingBased"`
+	// AgentOwnsConsumed, when true, tells the agent to apply filterOutDeleted
+	// from its OWN persistent consumption history instead of the
+	// TotalConsumedMocks map the client would otherwise re-send every testcase
+	// (which is O(testcases^2) marshaling). Default false = legacy behaviour.
+	AgentOwnsConsumed      bool                 `json:"agentOwnsConsumed,omitempty"`
 	TotalConsumedMocks     map[string]MockState `json:"totalConsumedMocks,omitempty"`
 	// StrictMockWindow controls whether out-of-window non-config mocks are
 	// dropped rather than being promoted into the cross-test config pool.

--- a/pkg/models/agent.go
+++ b/pkg/models/agent.go
@@ -96,16 +96,16 @@ type MockFilterParams struct {
 	// late, and mocks from a test that never runs get served as bootstrap.
 	// Zero means "not supplied"; the cutoff then falls back to the fired
 	// windows, which is the pre-existing behaviour.
-	FirstRecordedTestStart time.Time            `json:"firstRecordedTestStart,omitempty"`
-	BeforeTime             time.Time            `json:"beforeTime,omitempty"`
-	MockMapping            []string             `json:"mockMapping,omitempty"`
-	UseMappingBased        bool                 `json:"useMappingBased"`
+	FirstRecordedTestStart time.Time `json:"firstRecordedTestStart,omitempty"`
+	BeforeTime             time.Time `json:"beforeTime,omitempty"`
+	MockMapping            []string  `json:"mockMapping,omitempty"`
+	UseMappingBased        bool      `json:"useMappingBased"`
 	// AgentOwnsConsumed, when true, tells the agent to apply filterOutDeleted
 	// from its OWN persistent consumption history instead of the
 	// TotalConsumedMocks map the client would otherwise re-send every testcase
 	// (which is O(testcases^2) marshaling). Default false = legacy behaviour.
-	AgentOwnsConsumed      bool                 `json:"agentOwnsConsumed,omitempty"`
-	TotalConsumedMocks     map[string]MockState `json:"totalConsumedMocks,omitempty"`
+	AgentOwnsConsumed  bool                 `json:"agentOwnsConsumed,omitempty"`
+	TotalConsumedMocks map[string]MockState `json:"totalConsumedMocks,omitempty"`
 	// StrictMockWindow controls whether out-of-window non-config mocks are
 	// dropped rather than being promoted into the cross-test config pool.
 	// Default TRUE (see config.Test default) — out-of-window per-test

--- a/pkg/service/agent/agent.go
+++ b/pkg/service/agent/agent.go
@@ -1204,7 +1204,20 @@ func (a *Agent) UpdateMockParams(ctx context.Context, params models.MockFilterPa
 		zap.Int("unfilteredWithIsFilteredFalse", unfilteredCount))
 
 	// Filter out deleted mocks if totalConsumedMocks is provided
-	if params.TotalConsumedMocks != nil {
+	if params.AgentOwnsConsumed {
+		// Agent applies filterOutDeleted from its OWN persistent consumption
+		// history — the client no longer re-sends the growing TotalConsumedMocks
+		// map. Equivalent by construction: that persistent map is the exact
+		// accumulation of the flagMockAsUsed states the client used to relay.
+		if reader, ok := a.Proxy.(coreAgent.ConsumedStateReader); ok {
+			filteredMocks = a.filterOutDeleted(filteredMocks, reader.GetPersistentConsumed())
+		} else if params.TotalConsumedMocks != nil {
+			// Proxy can't expose its persistent map — never silently skip the
+			// filter; fall back to any client-sent map.
+			a.logger.Warn("AgentOwnsConsumed set but proxy has no ConsumedStateReader; falling back to client-sent TotalConsumedMocks")
+			filteredMocks = a.filterOutDeleted(filteredMocks, params.TotalConsumedMocks)
+		}
+	} else if params.TotalConsumedMocks != nil {
 		filteredMocks = a.filterOutDeleted(filteredMocks, params.TotalConsumedMocks)
 	}
 

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -3181,13 +3181,26 @@ func (r *Replayer) SendMockFilterParamsToAgent(ctx context.Context, expectedMock
 	if r.config != nil {
 		strictMockWindow = r.config.Test.StrictMockWindow
 	}
+	// EXPERIMENTAL, default OFF: when KEPLOY_AGENT_OWNS_CONSUMED is set, the
+	// agent applies filterOutDeleted from its own persistent consumption history
+	// instead of us re-sending the ever-growing TotalConsumedMocks map every
+	// testcase (O(testcases^2) marshaling). We then send a nil map to eliminate
+	// that cost. Off by default so behaviour is byte-identical until proven
+	// equivalent by the golden-reference harness.
+	agentOwnsConsumed := os.Getenv("KEPLOY_AGENT_OWNS_CONSUMED") == "1" ||
+		strings.EqualFold(os.Getenv("KEPLOY_AGENT_OWNS_CONSUMED"), "true")
+	consumedForAgent := totalConsumedMocks
+	if agentOwnsConsumed {
+		consumedForAgent = nil
+	}
 	params := models.MockFilterParams{
 		AfterTime:              afterTime,
 		BeforeTime:             beforeTime,
 		FirstRecordedTestStart: firstRecordedTestStart,
 		MockMapping:            expectedMockMapping,
 		UseMappingBased:        useMappingBased,
-		TotalConsumedMocks:     totalConsumedMocks,
+		AgentOwnsConsumed:      agentOwnsConsumed,
+		TotalConsumedMocks:     consumedForAgent,
 		StrictMockWindow:       strictMockWindow,
 	}
 


### PR DESCRIPTION
## Why
Profiling MySQL replay (VM, 250 tests / 796 mocks) showed the keploy **agent is 94.6% idle** — replay is **latency-bound**, dominated by **per-testcase client↔agent orchestration**. Before every testcase the client does a synchronous `POST /updatemockparams` whose payload carries `TotalConsumedMocks` — the agent's *own* consumption state, accumulated by the client and re-sent every testcase → **O(testcases²) marshaling** + a per-testcase tree rebuild. (The measurement pipeline #4529 reports the current baseline **RATIO=2.03×**; target 10×.)

## What
Two changes on the replay hot path:

1. **`IsDML`-once** in `matchQuery` — `sqlparser.IsDML` was parsed 3–4× per candidate on the O(pool) match path; compute each side once. Pure CPU, no behaviour change (matcher tests green).

2. **Agent-owned consumed set, behind a flag (default OFF).** The agent keeps a **persistent, never-drained** per-name consumption map (`consumedPersistent`, updated in `flagMockAsUsed`). With `MockFilterParams.AgentOwnsConsumed` (env `KEPLOY_AGENT_OWNS_CONSUMED`), the agent applies `filterOutDeleted` from its **own** map (via new `coreAgent.ConsumedStateReader`) and the client sends a **nil** `TotalConsumedMocks` — eliminating the O(n²) marshaling. This is P1 of a phased re-architecture (P2: push the plan once + advance signal; P3: pre-built trees + O(1) swap).

## Regression safety
- **Default OFF** takes the **byte-identical legacy branch** — this cannot change behaviour until the flag is enabled.
- The agent's persistent map is the **exact accumulation** of the `flagMockAsUsed` states the client used to relay (latest-state-per-name). Proven by `TestGetPersistentConsumed_EqualsClientAccumulation` (incl. the state-changes-to-`Deleted` case) and `TestGetPersistentConsumed_NotDrained`.
- **The flag will default ON only after** a golden-reference harness proves identical per-testcase verdicts + consumed-mock sets on a real record→replay, and the #4529 ratio pipeline confirms the win. Until then it ships off.

## Type
- [x] 🔥 Performance Improvements
- [x] ✅ Test

`go build` + `go vet` + the proxy/matcher tests green.