### PR TITLE
fix(replay): gate the first test on a real HTTP round-trip, not a TCP accept

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -409,7 +409,9 @@ func (c *CmdConfigurator) AddUncommonFlags(cmd *cobra.Command) {
 		cmd.Flags().Uint32("sse-port", c.cfg.Test.SSEPort, "Custom SSE port to replace the actual port in the SSE testcases")
 		cmd.Flags().Uint64P("delay", "d", 5, "User provided time to run its application")
 		cmd.Flags().String("health-url", c.cfg.Test.HealthURL, "HTTP(S) URL polled before the first test is fired; first 2xx response proceeds immediately. Empty (default) preserves the fixed --delay behavior.")
-		cmd.Flags().Duration("health-poll-timeout", c.cfg.Test.HealthPollTimeout, "Ceiling for --health-url polling (e.g. 60s, 2m). If no 2xx is seen within this window, replay logs an info message and falls back to --delay.")
+		cmd.Flags().String("health-path", c.cfg.Test.HealthPath, "Request path polled on the address the recorded tests actually dial, before the first test is fired — e.g. /health. Needs no host or port, so it works when the published port is assigned at runtime. Any completed HTTP response counts as ready. Ignored when --health-url is set (that takes precedence). Empty (default) uses a keploy-reserved probe path.")
+		cmd.Flags().String("health-scheme", c.cfg.Test.HealthScheme, "Override the scheme for --health-path probing (http or https). Empty (default) uses the scheme the recorded tests dial. Ignored when --health-url is set.")
+		cmd.Flags().Duration("health-poll-timeout", c.cfg.Test.HealthPollTimeout, "Ceiling for every pre-test readiness gate — --health-url, --health-path and the automatic docker/compose port gates (e.g. 60s, 3m). Only ever paid by an app that is not yet serving; a ready app satisfies the gate on the first probe. On timeout replay warns and fires anyway.")
 		cmd.Flags().String("proto-file", c.cfg.Test.ProtoFile, "Path of main proto file")
 		cmd.Flags().String("proto-dir", c.cfg.Test.ProtoDir, "Path of the directory where all protos of a service are located")
 		cmd.Flags().StringArray("proto-include", c.cfg.Test.ProtoInclude, "Path of directories to be included while parsing import statements in proto files")
@@ -514,6 +516,8 @@ func aliasNormalizeFunc(_ *pflag.FlagSet, name string) pflag.NormalizedName {
 		"keployNetwork":             "keploy-network",
 		"recordTimer":               "record-timer",
 		"healthUrl":                 "health-url",
+		"healthPath":                "health-path",
+		"healthScheme":              "health-scheme",
 		"healthPollTimeout":         "health-poll-timeout",
 		"urlMethods":                "url-methods",
 		"inCi":                      "in-ci",

--- a/config/config.go
+++ b/config/config.go
@@ -346,6 +346,26 @@ type Normalize struct {
 	EditedBy      string          `json:"-" yaml:"-" mapstructure:"-"`
 }
 
+// DefaultHealthPollTimeout is the ceiling for every pre-test app-readiness gate
+// when test.healthPollTimeout is unset or non-positive.
+//
+// It lives here, not beside the gate, because the yaml default in
+// config/default.go and the code fallback are two sources of truth for the same
+// number and nothing else makes them agree — the same reasoning as
+// relay.DefaultConsumerStallGrace. config/default_test.go asserts the parsed
+// yaml against this constant, so changing one without the other fails a test
+// instead of silently shipping a keploy.yml that disagrees with the code.
+//
+// Three minutes, not one. The bound is paid ONLY by an app that is not yet
+// serving: a ready app satisfies the gate on its first probe, so raising it costs
+// a healthy run nothing. A cold application start on a loaded shared runner —
+// the condition the gate exists for — was measured at 17-28s for the process and
+// ~55s from spawn to first serve, against a previous 60s ceiling that therefore
+// expired and fired tests into a not-yet-listening app. Timing out only warns and
+// proceeds, so an over-generous ceiling can never fail a run that would otherwise
+// pass; an under-generous one can.
+const DefaultHealthPollTimeout = 3 * time.Minute
+
 type Test struct {
 	SelectedTests               map[string][]string `json:"selectedTests" yaml:"selectedTests" mapstructure:"selectedTests"`
 	GlobalNoise                 Globalnoise         `json:"globalNoise" yaml:"globalNoise" mapstructure:"globalNoise"`
@@ -353,6 +373,8 @@ type Test struct {
 	Delay                       uint64              `json:"delay" yaml:"delay" mapstructure:"delay"`
 	HealthURL                   string              `json:"healthUrl" yaml:"healthUrl" mapstructure:"healthUrl"`                         // optional HTTP(S) URL polled before firing the first test; empty preserves the fixed --delay behavior
 	HealthPollTimeout           time.Duration       `json:"healthPollTimeout" yaml:"healthPollTimeout" mapstructure:"healthPollTimeout"` // ceiling for the pre-test health poll loop before falling back to --delay
+	HealthPath                  string              `json:"healthPath" yaml:"healthPath" mapstructure:"healthPath"`                      // optional request path probed on the app's OWN auto-detected address (docker/compose published port, or appReadyProbeAddr) before the first test. Unlike healthUrl it needs no host or port, so it works when the published port is assigned at runtime. Any completed HTTP response counts as ready — a health endpoint returning 503 has still proved the app is answering. Empty uses a keploy-reserved probe path.
+	HealthScheme                string              `json:"healthScheme" yaml:"healthScheme" mapstructure:"healthScheme"`                // optional override for the readiness probe scheme ("http" or "https"). Empty (the default) uses the scheme the recorded tests actually dial; only consulted when the app is probed over HTTP, and ignored entirely when healthUrl is set.
 	AppReadyProbeAddr           string              `json:"appReadyProbeAddr" yaml:"appReadyProbeAddr" mapstructure:"appReadyProbeAddr"` // optional host:port TCP-polled after the --delay floor (bounded by healthPollTimeout) before firing the first test — the TCP-accept analog of healthUrl for apps with no HTTP health endpoint (e.g. a k8s replay pod's app Service, or a native app on a fixed port). Empty preserves the fixed --delay behavior. Unlike test.port it NEVER affects request routing; it is only a readiness probe.
 	Host                        string              `json:"host" yaml:"host" mapstructure:"host"`
 	Port                        uint32              `json:"port" yaml:"port" mapstructure:"port"`

--- a/config/default.go
+++ b/config/default.go
@@ -41,7 +41,9 @@ test:
     test-sets: {}
   delay: 5
   healthUrl: ""
-  healthPollTimeout: 60s
+  healthPath: ""
+  healthScheme: ""
+  healthPollTimeout: 3m
   host: "localhost"
   port: 0
   grpcPort: 0

--- a/config/default_test.go
+++ b/config/default_test.go
@@ -38,7 +38,7 @@ func TestDefaultConfigParses(t *testing.T) {
 		got  time.Duration
 		want time.Duration
 	}{
-		{"test.healthPollTimeout", cfg.Test.HealthPollTimeout, 60 * time.Second},
+		{"test.healthPollTimeout", cfg.Test.HealthPollTimeout, DefaultHealthPollTimeout},
 		{"record.recordTimer", cfg.Record.RecordTimer, 0},
 		// Asserted against the relay's own constant rather than a literal: the
 		// yaml default and relay.DefaultConsumerStallGrace are two sources of

--- a/pkg/service/replay/app_ready_http_gate_test.go
+++ b/pkg/service/replay/app_ready_http_gate_test.go
@@ -1,0 +1,306 @@
+package replay
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/config"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// acceptOnlyListener mimics docker's userland proxy in the failure state: it
+// ACCEPTS the connection (so a TCP-accept gate is satisfied instantly) and then
+// closes it without ever speaking HTTP, so no request can complete.
+func acceptOnlyListener(t *testing.T) (host, port string) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = c.Close() // accepted, then reset — exactly the docker-proxy shape
+		}
+	}()
+	h, p, _ := net.SplitHostPort(ln.Addr().String())
+	return h, p
+}
+
+func gateCfg(ceiling time.Duration) *config.Config {
+	c := &config.Config{}
+	c.Test.HealthPollTimeout = ceiling
+	return c
+}
+
+// THE REGRESSION. A port that accepts TCP but never serves HTTP must NOT be
+// accepted as ready for an HTTP app. This is the parse-server-linux failure:
+// docker-proxy binds and accepts the instant the container is created, ~17-28s
+// before the app inside is listening, so a TCP-accept gate passes immediately and
+// replay fires into a port that resets its first request (status_code got=0 on
+// the first test of the set).
+func TestGateOnAppAddress_AcceptOnlyPortIsNotReadyForAnHTTPApp(t *testing.T) {
+	host, port := acceptOnlyListener(t)
+	core, logs := observer.New(zapcore.DebugLevel)
+
+	start := time.Now()
+	ok := gateOnAppAddress(context.Background(), zap.New(core), gateCfg(700*time.Millisecond),
+		host, port, "test", httpProbeTarget{scheme: "http", host: host, port: port, ok: true})
+	elapsed := time.Since(start)
+
+	if !ok {
+		t.Fatal("gate must stay best-effort and return true on timeout, never fail the run")
+	}
+	if elapsed < 500*time.Millisecond {
+		t.Fatalf("gate returned after %v — it accepted a TCP-only port as ready for an HTTP app, "+
+			"which is exactly the docker-proxy false-ready that fails the first test", elapsed)
+	}
+	if n := len(logs.FilterMessageSnippet("never completed an HTTP round-trip").All()); n != 1 {
+		t.Fatalf("expected the HTTP-escalation warning, got %d", n)
+	}
+}
+
+// The same port MUST still satisfy the gate for a non-HTTP app (MySQL, Redis,
+// gRPC-only): probing it with HTTP could never parse a response, so escalating
+// would burn the whole ceiling on every run. TCP accept is all we can prove.
+func TestGateOnAppAddress_AcceptOnlyPortIsReadyForANonHTTPApp(t *testing.T) {
+	host, port := acceptOnlyListener(t)
+
+	start := time.Now()
+	ok := gateOnAppAddress(context.Background(), zap.NewNop(), gateCfg(5*time.Second),
+		host, port, "test", httpProbeTarget{})
+	elapsed := time.Since(start)
+
+	if !ok {
+		t.Fatal("non-HTTP app must pass on TCP accept")
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("non-HTTP app waited %v — the HTTP stage must be skipped entirely, "+
+			"or every non-HTTP replay pays the ceiling", elapsed)
+	}
+}
+
+// A genuinely serving app satisfies the gate immediately, so the raised ceiling
+// costs a ready app nothing.
+func TestGateOnAppAddress_ServingAppIsReadyImmediately(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound) // any completed response proves serving
+	}))
+	defer srv.Close()
+	host, port, _ := net.SplitHostPort(srv.Listener.Addr().String())
+
+	start := time.Now()
+	ok := gateOnAppAddress(context.Background(), zap.NewNop(), gateCfg(3*time.Minute), host, port, "test",
+		httpProbeTarget{scheme: "http", host: host, port: port, ok: true})
+	if !ok {
+		t.Fatal("a serving app must pass the gate")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("a ready app waited %v; the gate must satisfy on the first probe", elapsed)
+	}
+}
+
+// An operator-supplied health path must actually be the path requested.
+func TestGateOnAppAddress_UsesConfiguredHealthPath(t *testing.T) {
+	got := make(chan string, 4)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case got <- r.URL.Path:
+		default:
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	host, port, _ := net.SplitHostPort(srv.Listener.Addr().String())
+
+	cfg := gateCfg(10 * time.Second)
+	cfg.Test.HealthPath = "healthz" // deliberately missing the leading slash
+	if !gateOnAppAddress(context.Background(), zap.NewNop(), cfg, host, port, "test",
+		httpProbeTarget{scheme: "http", host: host, port: port, ok: true}) {
+		t.Fatal("gate should pass against a serving app")
+	}
+	select {
+	case p := <-got:
+		if p != "/healthz" {
+			t.Fatalf("probed %q, want /healthz — the configured health path was ignored", p)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("app never received the probe")
+	}
+}
+
+// REGRESSION (review finding 1): stage 2 must probe the address the recorded
+// tests actually DIAL, not whatever the docker/compose heuristic guessed.
+//
+// dockerPublishedHostPort returns the FIRST -p flag with no check that it is the
+// HTTP port, so for `-p 5432:5432 -p 8080:8080` the gated address is the
+// database. Stage 1 passes instantly (the port is bound), and an earlier revision
+// then ran stage 2 against that same port — where HTTP can never answer — burning
+// the whole ceiling on EVERY run, not just a cold start.
+func TestGateOnAppAddress_ProbesTheResolvedTargetNotTheGatedPort(t *testing.T) {
+	// The "published port" the heuristic picked: accepts TCP, never speaks HTTP.
+	dbHost, dbPort := acceptOnlyListener(t)
+	// The address the recorded tests actually dial: a real HTTP server.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	appHost, appPort, _ := net.SplitHostPort(srv.Listener.Addr().String())
+
+	start := time.Now()
+	ok := gateOnAppAddress(context.Background(), zap.NewNop(), gateCfg(10*time.Second),
+		dbHost, dbPort, "docker-published-port",
+		httpProbeTarget{scheme: "http", host: appHost, port: appPort, ok: true})
+	elapsed := time.Since(start)
+
+	if !ok {
+		t.Fatal("gate must pass")
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("gate took %v — stage 2 probed the GATED port instead of the resolved dial "+
+			"target, so a multi-port app burns the full ceiling on every run", elapsed)
+	}
+}
+
+// resolveTestSetProbeTarget must license stage 2 from EVIDENCE and decline when
+// it has none — an empty or non-HTTP set leaves the gate TCP-only.
+func TestResolveTestSetProbeTarget(t *testing.T) {
+	cfg := config.Test{}
+	if got := resolveTestSetProbeTarget(cfg, nil, "test-set-0", zap.NewNop()); got.ok {
+		t.Error("an empty test set proves nothing and must not license HTTP probing")
+	}
+	if got := resolveTestSetProbeTarget(cfg, []*models.TestCase{nil}, "test-set-0", zap.NewNop()); got.ok {
+		t.Error("a nil entry must not license HTTP probing")
+	}
+	if got := resolveTestSetProbeTarget(cfg, []*models.TestCase{{Kind: models.GRPC_EXPORT}}, "test-set-0", zap.NewNop()); got.ok {
+		t.Error("a non-HTTP test set must not license HTTP probing")
+	}
+	// A recorded HTTP case resolves to the address the simulation would dial.
+	tc := &models.TestCase{Kind: models.HTTP}
+	tc.HTTPReq.URL = "http://localhost:6219/parse/health"
+	got := resolveTestSetProbeTarget(cfg, []*models.TestCase{{Kind: models.GRPC_EXPORT}, tc}, "test-set-0", zap.NewNop())
+	if !got.ok {
+		t.Fatal("a recorded HTTP test case must resolve a probe target")
+	}
+	if got.port != "6219" || got.scheme != "http" {
+		t.Fatalf("resolved %s://%s:%s, want scheme http and port 6219", got.scheme, got.host, got.port)
+	}
+}
+
+// The default ceiling is only ever paid by an app that is NOT serving, so it is
+// sized for a cold start on a loaded runner rather than for a warm one.
+func TestDefaultHealthPollTimeoutIsGenerous(t *testing.T) {
+	if config.DefaultHealthPollTimeout < 2*time.Minute {
+		t.Fatalf("config.DefaultHealthPollTimeout=%v is too tight: a measured cold start on a loaded "+
+			"shared runner took ~55s to first serve, and timing out here fires tests into a "+
+			"not-yet-listening app", config.DefaultHealthPollTimeout)
+	}
+}
+
+// --health-scheme must actually override the scheme resolved from the test set,
+// AND a certificate we do not trust must still count as ready.
+//
+// Both are checked here because they are entangled. Certificate verification
+// stays ON (disabling it is a real security finding, and CodeQL flags it), so an
+// httptest self-signed server fails verification and the HTTP handler is never
+// reached — which means asserting on the handler cannot prove the scheme. The
+// TLS handshake itself is the observable: GetConfigForClient fires before
+// verification, so it records that an https probe genuinely happened. If the
+// override were ignored the probe would stay on http:// and no handshake would
+// occur at all.
+func TestGateOnAppAddress_HealthSchemeOverridesTheResolvedScheme(t *testing.T) {
+	handshakes := make(chan string, 4)
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.TLS = &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		GetConfigForClient: func(chi *tls.ClientHelloInfo) (*tls.Config, error) {
+			select {
+			case handshakes <- chi.ServerName:
+			default:
+			}
+			return nil, nil
+		},
+	}
+	srv.StartTLS()
+	defer srv.Close()
+	host, port, _ := net.SplitHostPort(srv.Listener.Addr().String())
+
+	cfg := gateCfg(8 * time.Second)
+	cfg.Test.HealthScheme = "https" // force https over the resolved "http"
+
+	start := time.Now()
+	if !gateOnAppAddress(context.Background(), zap.NewNop(), cfg, host, port, "test",
+		httpProbeTarget{scheme: "http", host: host, port: port, ok: true}) {
+		t.Fatal("gate must pass")
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Fatalf("gate took %v — an untrusted certificate was treated as 'not ready', so any "+
+			"self-signed local HTTPS fixture stalls the gate for its whole ceiling", elapsed)
+	}
+
+	select {
+	case <-handshakes:
+		// A TLS handshake happened: the override took effect.
+	case <-time.After(2 * time.Second):
+		t.Fatal("no TLS handshake was attempted — --health-scheme=https was ignored and the probe " +
+			"stayed on http://")
+	}
+}
+
+// A NATIVE app — no docker -p publish, no compose file, no appReadyProbeAddr —
+// had no readiness gate at all beyond the fixed --delay, so one slower than that
+// delay had its first test fired into a socket nothing was listening on yet.
+// Observed on the python-cred-expiry lane (`python3 recorded_app.py`, --delay 5):
+// 2 of 4 tests failed with `status_code expected=200 got=0`.
+//
+// The recorded test set already names the dial target, so it is used as the gate.
+func TestWaitForAppReady_NativeAppGatesOnTheResolvedTarget(t *testing.T) {
+	host, port := acceptOnlyListener(t) // accepts, never serves HTTP
+	cfg := gateCfg(700 * time.Millisecond)
+	cfg.Command = "python3 recorded_app.py" // native: none of the address gates fire
+	cfg.Test.Delay = 0
+
+	start := time.Now()
+	ok := waitForAppReady(context.Background(), zap.NewNop(), cfg,
+		httpProbeTarget{scheme: "http", host: host, port: port, ok: true})
+	elapsed := time.Since(start)
+
+	if !ok {
+		t.Fatal("the gate must stay best-effort and proceed on timeout, never fail the run")
+	}
+	if elapsed < 500*time.Millisecond {
+		t.Fatalf("returned after %v — a native app was declared ready without any HTTP round-trip, "+
+			"so its first test can still fire into a not-yet-serving socket", elapsed)
+	}
+}
+
+// ...and it must not gate when the test set gave no resolvable HTTP target,
+// preserving the pure --delay behaviour for non-HTTP native apps.
+func TestWaitForAppReady_NativeAppWithoutEvidenceIsNotGated(t *testing.T) {
+	cfg := gateCfg(10 * time.Second)
+	cfg.Command = "python3 recorded_app.py"
+	cfg.Test.Delay = 0
+
+	start := time.Now()
+	if !waitForAppReady(context.Background(), zap.NewNop(), cfg, httpProbeTarget{}) {
+		t.Fatal("must proceed")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("waited %v with no resolvable target; a non-HTTP native app must keep the "+
+			"pure --delay behaviour", elapsed)
+	}
+}

--- a/pkg/service/replay/app_ready_probe_test.go
+++ b/pkg/service/replay/app_ready_probe_test.go
@@ -27,7 +27,7 @@ func TestWaitForAppReady_ProbeAddrGate_ReadyAddr(t *testing.T) {
 	cfg.Test.AppReadyProbeAddr = ln.Addr().String()
 
 	start := time.Now()
-	if !waitForAppReady(context.Background(), zap.NewNop(), cfg) {
+	if !waitForAppReady(context.Background(), zap.NewNop(), cfg, httpProbeTarget{}) {
 		t.Fatal("waitForAppReady returned false for a listening probe address")
 	}
 	// pkg.WaitForPort probes once before its 1s ticker, so an already-listening
@@ -55,7 +55,7 @@ func TestWaitForAppReady_ProbeAddrGate_DeadAddrProceeds(t *testing.T) {
 	cfg.Test.HealthPollTimeout = 1 * time.Second // tiny ceiling for the test
 
 	start := time.Now()
-	if !waitForAppReady(context.Background(), zap.NewNop(), cfg) {
+	if !waitForAppReady(context.Background(), zap.NewNop(), cfg, httpProbeTarget{}) {
 		t.Fatal("waitForAppReady should proceed (return true) after the ceiling on a dead probe address")
 	}
 	if elapsed := time.Since(start); elapsed < 900*time.Millisecond {
@@ -79,7 +79,7 @@ func TestWaitForAppReady_ProbeAddrGate_CtxCancel(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	if waitForAppReady(ctx, zap.NewNop(), cfg) {
+	if waitForAppReady(ctx, zap.NewNop(), cfg, httpProbeTarget{}) {
 		t.Fatal("waitForAppReady should return false when ctx is cancelled mid-probe")
 	}
 	if elapsed := time.Since(start); elapsed > 3*time.Second {
@@ -95,7 +95,7 @@ func TestWaitForAppReady_ProbeAddrGate_InvalidAddrProceeds(t *testing.T) {
 	cfg.Test.AppReadyProbeAddr = "not-a-host-port" // no colon → SplitHostPort errors
 
 	start := time.Now()
-	if !waitForAppReady(context.Background(), zap.NewNop(), cfg) {
+	if !waitForAppReady(context.Background(), zap.NewNop(), cfg, httpProbeTarget{}) {
 		t.Fatal("waitForAppReady should proceed (return true) on a malformed probe address")
 	}
 	if elapsed := time.Since(start); elapsed > 1*time.Second {
@@ -119,7 +119,7 @@ func TestWaitForAppReady_ProbeAddrGate_EmptyHostShorthand(t *testing.T) {
 	cfg.Test.AppReadyProbeAddr = ":" + port // empty host → localhost
 
 	start := time.Now()
-	if !waitForAppReady(context.Background(), zap.NewNop(), cfg) {
+	if !waitForAppReady(context.Background(), zap.NewNop(), cfg, httpProbeTarget{}) {
 		t.Fatal("waitForAppReady should treat \":<port>\" as localhost and pass for a listening port")
 	}
 	// The leading dial in pkg.WaitForPort makes an already-ready port return

--- a/pkg/service/replay/docker_port_readiness_test.go
+++ b/pkg/service/replay/docker_port_readiness_test.go
@@ -55,7 +55,7 @@ func TestWaitForAppReady_DockerPortGate_ReadyPort(t *testing.T) {
 	cfg.Test.Delay = 0 // no floor; isolate the port gate
 
 	start := time.Now()
-	if !waitForAppReady(context.Background(), zap.NewNop(), cfg) {
+	if !waitForAppReady(context.Background(), zap.NewNop(), cfg, httpProbeTarget{}) {
 		t.Fatal("waitForAppReady returned false for a listening port")
 	}
 	if elapsed := time.Since(start); elapsed > 2*time.Second {
@@ -80,7 +80,7 @@ func TestWaitForAppReady_DockerPortGate_DeadPortProceeds(t *testing.T) {
 	cfg.Test.HealthPollTimeout = 1 * time.Second // tiny ceiling for the test
 
 	start := time.Now()
-	if !waitForAppReady(context.Background(), zap.NewNop(), cfg) {
+	if !waitForAppReady(context.Background(), zap.NewNop(), cfg, httpProbeTarget{}) {
 		t.Fatal("waitForAppReady should proceed (return true) after the ceiling on a dead port")
 	}
 	if elapsed := time.Since(start); elapsed < 900*time.Millisecond {
@@ -103,7 +103,7 @@ func TestWaitForAppReady_DockerPortGate_CtxCancel(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	if waitForAppReady(ctx, zap.NewNop(), cfg) {
+	if waitForAppReady(ctx, zap.NewNop(), cfg, httpProbeTarget{}) {
 		t.Fatal("waitForAppReady should return false when ctx is cancelled mid-wait")
 	}
 	if elapsed := time.Since(start); elapsed > 3*time.Second {

--- a/pkg/service/replay/health_poll_test.go
+++ b/pkg/service/replay/health_poll_test.go
@@ -38,7 +38,7 @@ func TestWaitForAppReady_200OnFirstTry(t *testing.T) {
 	logger := zap.NewNop()
 
 	start := time.Now()
-	ok := waitForAppReady(context.Background(), logger, cfg)
+	ok := waitForAppReady(context.Background(), logger, cfg, httpProbeTarget{})
 	elapsed := time.Since(start)
 
 	if !ok {
@@ -70,7 +70,7 @@ func TestWaitForAppReady_503ThenOK(t *testing.T) {
 	logger := zap.NewNop()
 
 	start := time.Now()
-	ok := waitForAppReady(context.Background(), logger, cfg)
+	ok := waitForAppReady(context.Background(), logger, cfg, httpProbeTarget{})
 	elapsed := time.Since(start)
 
 	if !ok {
@@ -111,7 +111,7 @@ func TestWaitForAppReady_NeverOK(t *testing.T) {
 	logger := zap.New(core)
 
 	start := time.Now()
-	ok := waitForAppReady(context.Background(), logger, cfg)
+	ok := waitForAppReady(context.Background(), logger, cfg, httpProbeTarget{})
 	elapsed := time.Since(start)
 
 	if !ok {
@@ -151,7 +151,7 @@ func TestWaitForAppReady_EmptyURLUsesFixedDelay(t *testing.T) {
 	cfg.Test.Delay = 0 // keep the test fast; semantics are the same
 	logger := zap.NewNop()
 
-	ok := waitForAppReady(context.Background(), logger, cfg)
+	ok := waitForAppReady(context.Background(), logger, cfg, httpProbeTarget{})
 	if !ok {
 		t.Fatalf("expected waitForAppReady to return true in the default path")
 	}
@@ -187,7 +187,7 @@ func TestWaitForAppReady_CtxCanceledAtCeiling(t *testing.T) {
 	}()
 
 	start := time.Now()
-	ok := waitForAppReady(ctx, logger, cfg)
+	ok := waitForAppReady(ctx, logger, cfg, httpProbeTarget{})
 	elapsed := time.Since(start)
 
 	if ok {
@@ -234,7 +234,7 @@ func TestWaitForAppReady_MalformedURL_FallsBackToDelay(t *testing.T) {
 	logger := zap.New(core)
 
 	start := time.Now()
-	ok := waitForAppReady(context.Background(), logger, cfg)
+	ok := waitForAppReady(context.Background(), logger, cfg, httpProbeTarget{})
 	elapsed := time.Since(start)
 
 	if !ok {
@@ -303,7 +303,7 @@ func TestWaitForAppReady_MalformedURL_TableDriven(t *testing.T) {
 			cfg.Test.Delay = 0
 			logger := zap.NewNop()
 
-			ok := waitForAppReady(context.Background(), logger, cfg)
+			ok := waitForAppReady(context.Background(), logger, cfg, httpProbeTarget{})
 
 			if !ok {
 				t.Fatalf("expected true (fall through to fixed-delay) for malformed URL %q, got false — callers would misclassify this as user abort", c.url)
@@ -330,7 +330,7 @@ func TestWaitForAppReady_CtxCanceled(t *testing.T) {
 	}()
 
 	start := time.Now()
-	ok := waitForAppReady(ctx, logger, cfg)
+	ok := waitForAppReady(ctx, logger, cfg, httpProbeTarget{})
 	elapsed := time.Since(start)
 
 	if ok {

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -1360,7 +1360,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 		// runs every test-set, matching the historical lifecycle.
 		if serveTest && !r.isFirstTestSet {
 			r.logger.Debug("--keep-app-alive: skipping waitForAppReady on post-first test-set; app already warm")
-		} else if !waitForAppReady(runTestSetCtx, r.logger, r.config) {
+		} else if !waitForAppReady(runTestSetCtx, r.logger, r.config, resolveTestSetProbeTarget(r.config.Test, testCases, testSetID, r.logger)) {
 			return models.TestSetStatusUserAbort, context.Canceled
 		}
 	}
@@ -1530,7 +1530,7 @@ func (r *Replayer) RunTestSet(ctx context.Context, testSetID string, testRunID s
 			// one-shot spawn actually fired.
 			if serveTest && !r.isFirstTestSet {
 				r.logger.Debug("--keep-app-alive: skipping waitForAppReady on post-first test-set; app already warm")
-			} else if !waitForAppReady(runTestSetCtx, r.logger, r.config) {
+			} else if !waitForAppReady(runTestSetCtx, r.logger, r.config, resolveTestSetProbeTarget(r.config.Test, testCases, testSetID, r.logger)) {
 				return models.TestSetStatusUserAbort, context.Canceled
 			}
 

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -2,6 +2,9 @@ package replay
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -12,9 +15,10 @@ import (
 	"sort"
 	"strings"
 
-	"gopkg.in/yaml.v3"
 	"sync"
 	"time"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/olekukonko/tablewriter/tw"
@@ -345,9 +349,24 @@ const resetProbeInterval = 200 * time.Millisecond
 //
 // It resolves from the pre-template-render URL, so a {{ }} placeholder in the
 // host/port (as opposed to the path/query/body, where they actually live) would
-// make the probe target diverge from the dial. That is best-effort only: a wrong
-// target just times out within resetResendReadyTimeout and the bounded re-send
-// still runs, so it never affects correctness.
+// make the probe target diverge from the dial. That is best-effort only and never
+// affects correctness, but MIND THE BUDGET, because it differs by caller:
+//
+//   - waitForResetResendReady bounds a wrong target by resetResendReadyTimeout
+//     (5s) and the re-send still runs.
+//   - gateOnAppAddress's HTTP stage, via resolveTestSetProbeTarget, is bounded by
+//     test.healthPollTimeout instead — 3 minutes by default and operator-
+//     configurable. So a target that is resolvable but DEAD (an un-rendered
+//     template in the host, or a --host override pointing nowhere) makes the
+//     pre-test gate retry until that budget expires before warning and firing
+//     anyway, on every test-set.
+//
+// That residual is deliberate rather than overlooked. Shortening it would take
+// the budget away from the case the gate exists for — a cold application start
+// measured at ~55s to first serve — and a target this resolver gets wrong is
+// almost always one the real dispatch will get wrong too, so the run was going
+// to fail regardless. It is bounded, warn-and-proceed, and never turns a passing
+// run into a failing one.
 func resolveProbeTarget(testCfg config.Test, tc *models.TestCase, testSetID string, logger *zap.Logger) (scheme, host, port string, ok bool) {
 	if tc == nil || tc.Kind != models.HTTP {
 		return "", "", "", false
@@ -386,6 +405,32 @@ func resolveProbeTarget(testCfg config.Test, tc *models.TestCase, testSetID stri
 	return scheme, host, port, true
 }
 
+// isTLSVerificationError reports whether err is the TLS handshake failing on
+// certificate VERIFICATION, as opposed to the connection never getting that far.
+//
+// The distinction is the whole point: an untrusted or mismatched certificate
+// means the peer is up, listening, and speaking TLS. A refusal, reset or timeout
+// means it is not. A readiness probe cares only about the latter.
+func isTLSVerificationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var cve *tls.CertificateVerificationError
+	if errors.As(err, &cve) {
+		return true
+	}
+	var unknownAuthority x509.UnknownAuthorityError
+	if errors.As(err, &unknownAuthority) {
+		return true
+	}
+	var hostname x509.HostnameError
+	if errors.As(err, &hostname) {
+		return true
+	}
+	var invalid x509.CertificateInvalidError
+	return errors.As(err, &invalid)
+}
+
 // waitForHTTPServing polls until an HTTP round-trip to host:port completes with
 // ANY status — proving the proxy→app path actually serves — or ctx expires. A
 // transport reset / refusal / timeout counts as not-ready and keeps waiting.
@@ -400,7 +445,27 @@ func resolveProbeTarget(testCfg config.Test, tc *models.TestCase, testSetID stri
 // invoking a handler; and in the reset (failure) state the userland-proxy resets
 // the probe before the app ever sees it, so it never reaches application code.
 func waitForHTTPServing(ctx context.Context, scheme, host, port string) error {
-	target := fmt.Sprintf("%s://%s%s", scheme, net.JoinHostPort(host, port), keployReadinessProbePath)
+	return waitForHTTPServingPath(ctx, scheme, host, port, keployReadinessProbePath)
+}
+
+// waitForHTTPServingPath is waitForHTTPServing with an explicit request path, so
+// an operator-supplied health path (test.healthPath) can be probed instead of the
+// keploy-reserved one. An empty path falls back to the reserved probe path.
+//
+// The contract is identical either way: ANY completed HTTP response — including
+// 404 or 503 — proves the proxy→app path serves, which is the only thing a
+// readiness gate needs to know. We deliberately do NOT require 2xx here: a health
+// endpoint that reports "unhealthy" has still proved the app is listening and
+// answering, and holding replay back for application-level health would turn a
+// readiness gate into a liveness policy.
+func waitForHTTPServingPath(ctx context.Context, scheme, host, port, path string) error {
+	if path == "" {
+		path = keployReadinessProbePath
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	target := fmt.Sprintf("%s://%s%s", scheme, net.JoinHostPort(host, port), path)
 	client := &http.Client{
 		Timeout: resetProbeRequestTimeout,
 		// Don't follow redirects — any 3xx already proves the app serves.
@@ -422,6 +487,20 @@ func waitForHTTPServing(ctx context.Context, scheme, host, port string) error {
 		}
 		resp, err := client.Do(req)
 		if err != nil {
+			// A certificate we do not trust still answers the only question this
+			// gate asks. Verification failing means the server completed a TLS
+			// handshake and presented a certificate — it is listening and
+			// serving; we simply do not vouch for who it is. A self-signed cert
+			// is the norm for a local or CI HTTPS fixture, so treating that as
+			// "not ready" would burn the whole ceiling on every run.
+			//
+			// Deliberately NOT solved with InsecureSkipVerify: that disables the
+			// check everywhere in this client and is a real finding for scanners
+			// to flag. Reading the specific error keeps verification on and only
+			// reinterprets its meaning for a readiness decision.
+			if isTLSVerificationError(err) {
+				return true
+			}
 			return false // transport reset / refused / timeout → not ready yet
 		}
 		_, _ = io.Copy(io.Discard, resp.Body)
@@ -446,7 +525,147 @@ func waitForHTTPServing(ctx context.Context, scheme, host, port string) error {
 	}
 }
 
-func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config) bool {
+// gateOnAppAddress blocks until host:port looks ready, then returns. It is the
+// single implementation behind every pre-test readiness gate.
+//
+// Two stages, because one is not enough:
+//
+//  1. TCP accept. Proves something is bound. Works for any protocol, so it is
+//     all we can do for a non-HTTP app.
+//  2. A real HTTP round-trip, but ONLY when the app is known to serve HTTP.
+//
+// Stage 2 exists because stage 1 is not sufficient for the case this gate was
+// built for. Docker's userland proxy binds and ACCEPTS on the published host
+// port as soon as the container is created — before anything inside the
+// container is listening — and then RESETS the connection when it cannot reach
+// the app. A TCP-accept gate therefore passes instantly and hands replay a port
+// that will reset its first request, which is exactly the status_code=0 flake on
+// the first test of a set. Only a completed HTTP exchange proves the whole
+// proxy→app path carries a request.
+//
+// "Known to serve HTTP" is not a guess: it is derived from the recorded test set
+// (see testSetServesHTTP). If we recorded HTTP requests against this app, the app
+// serves HTTP. For a non-HTTP app (MySQL, Redis, a gRPC-only service) stage 2 is
+// skipped entirely rather than burning the ceiling on a probe that can never
+// parse a response.
+//
+// Best-effort throughout, preserving the pre-existing contract: it can only ever
+// wait LONGER than --delay, never shorter; a timeout WARNS and proceeds rather
+// than failing the run; and it never weakens an assertion. Returns false only on
+// context cancellation (user abort).
+func gateOnAppAddress(ctx context.Context, logger *zap.Logger, cfg *config.Config, host, port, label string, probe httpProbeTarget) bool {
+	ceiling := cfg.Test.HealthPollTimeout
+	if ceiling <= 0 {
+		ceiling = config.DefaultHealthPollTimeout
+	}
+	deadline := time.Now().Add(ceiling)
+
+	if err := pkg.WaitForPort(ctx, host, port, ceiling); err != nil {
+		if ctx.Err() != nil {
+			return false
+		}
+		logger.Warn("app address did not accept a connection within the ceiling; firing tests anyway (replay may see status_code got=0)",
+			zap.String("gate", label),
+			zap.String("host", host),
+			zap.String("port", port),
+			zap.Duration("ceiling", ceiling),
+			zap.Error(err))
+		return true
+	}
+
+	if !probe.ok {
+		return true
+	}
+
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return true
+	}
+	hctx, cancel := context.WithTimeout(ctx, remaining)
+	defer cancel()
+
+	// Scheme comes from the resolved target; healthScheme is an explicit override
+	// for the rare case an operator needs to force it.
+	scheme := probe.scheme
+	if forced := strings.TrimSpace(cfg.Test.HealthScheme); forced != "" && !strings.EqualFold(forced, scheme) {
+		if strings.EqualFold(forced, "http") || strings.EqualFold(forced, "https") {
+			scheme = strings.ToLower(forced)
+		}
+	}
+	if err := waitForHTTPServingPath(hctx, scheme, probe.host, probe.port, cfg.Test.HealthPath); err != nil {
+		if ctx.Err() != nil {
+			return false
+		}
+		logger.Warn("app accepted TCP but never completed an HTTP round-trip within the ceiling; firing tests anyway (replay may see status_code got=0)",
+			zap.String("gate", label),
+			zap.String("probeHost", probe.host),
+			zap.String("probePort", probe.port),
+			zap.String("probePath", healthProbePathForLog(cfg.Test.HealthPath)),
+			zap.Duration("ceiling", ceiling),
+			zap.Error(err))
+		return true
+	}
+	logger.Debug("app readiness confirmed by a completed HTTP round-trip",
+		zap.String("gate", label),
+		zap.String("probeHost", probe.host),
+		zap.String("probePort", probe.port),
+		zap.String("probePath", healthProbePathForLog(cfg.Test.HealthPath)))
+	return true
+}
+
+// healthProbePathForLog reports the path gateOnAppAddress actually requests.
+func healthProbePathForLog(configured string) string {
+	if configured == "" {
+		return keployReadinessProbePath
+	}
+	if !strings.HasPrefix(configured, "/") {
+		return "/" + configured
+	}
+	return configured
+}
+
+// httpProbeTarget is the address a recorded HTTP test case actually dials, used
+// as the target of the readiness gate's HTTP stage.
+type httpProbeTarget struct {
+	scheme, host, port string
+	ok                 bool
+}
+
+// resolveTestSetProbeTarget returns the address the readiness gate should complete
+// an HTTP round-trip against, derived from the recorded test set.
+//
+// This is EVIDENCE, not a guess, and the distinction is the whole point. An
+// earlier revision decided only WHETHER to escalate from the test set and then
+// escalated against whatever address the docker/compose heuristic produced —
+// dockerPublishedHostPort returns the FIRST -p flag it finds, with no check that
+// it is the HTTP port. For `-p 5432:5432 -p 8080:8080` that is the database, and
+// an HTTP probe against it can never succeed: stage 1 passes instantly because
+// the port is bound, then stage 2 burns the entire ceiling on EVERY run before
+// warning and proceeding. Same for an operator who points appReadyProbeAddr at a
+// non-HTTP service, which its own documentation invites.
+//
+// resolveProbeTarget mirrors the simulation's own ResolveTestTarget (ConfigHost /
+// --host override, replaceWith, port precedence) so the probe hits exactly what
+// the test will dial, and is address-family-correct — an IPv6 "localhost" dial is
+// gated on the IPv6 path, not a mismatched 127.0.0.1. It is the same resolver the
+// reset re-send gate already uses.
+//
+// Returns ok=false when no test case resolves (empty set, non-HTTP set, or an
+// unresolvable target); the caller then keeps the TCP-accept stage only, which is
+// exactly the pre-existing behaviour.
+func resolveTestSetProbeTarget(testCfg config.Test, testCases []*models.TestCase, testSetID string, logger *zap.Logger) httpProbeTarget {
+	for _, tc := range testCases {
+		if tc == nil || tc.Kind != models.HTTP {
+			continue
+		}
+		if scheme, host, port, ok := resolveProbeTarget(testCfg, tc, testSetID, logger); ok {
+			return httpProbeTarget{scheme: scheme, host: host, port: port, ok: true}
+		}
+	}
+	return httpProbeTarget{}
+}
+
+func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config, probe httpProbeTarget) bool {
 	delay := time.Duration(cfg.Test.Delay) * time.Second
 
 	healthURL := cfg.Test.HealthURL
@@ -501,20 +720,11 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 		// --delay behavior. This can only ever wait LONGER than --delay, never
 		// shorter, and never weakens an assertion — a fast-ready port returns
 		// instantly.
+		gated := false
 		if host, port, ok := dockerPublishedHostPort(cfg.Command); ok {
-			ceiling := cfg.Test.HealthPollTimeout
-			if ceiling <= 0 {
-				ceiling = 60 * time.Second
-			}
-			if err := pkg.WaitForPort(ctx, host, port, ceiling); err != nil {
-				if ctx.Err() != nil {
-					return false
-				}
-				logger.Warn("app host port did not become ready within the ceiling; firing tests anyway (replay may see status_code got=0)",
-					zap.String("host", host),
-					zap.String("port", port),
-					zap.Duration("ceiling", ceiling),
-					zap.Error(err))
+			gated = true
+			if !gateOnAppAddress(ctx, logger, cfg, host, port, "docker-published-port", probe) {
+				return false
 			}
 		}
 
@@ -522,19 +732,9 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 		// compose file instead of the command line. Identical contract to the
 		// -p gate above — best-effort, bounded, can only ever wait longer.
 		if host, port, ok := composePublishedHostPort(cfg.Command, cfg.ContainerName); ok {
-			ceiling := cfg.Test.HealthPollTimeout
-			if ceiling <= 0 {
-				ceiling = 60 * time.Second
-			}
-			if err := pkg.WaitForPort(ctx, host, port, ceiling); err != nil {
-				if ctx.Err() != nil {
-					return false
-				}
-				logger.Warn("compose app host port did not become ready within the ceiling; firing tests anyway (replay may see status_code got=0)",
-					zap.String("host", host),
-					zap.String("port", port),
-					zap.Duration("ceiling", ceiling),
-					zap.Error(err))
+			gated = true
+			if !gateOnAppAddress(ctx, logger, cfg, host, port, "compose-published-port", probe) {
+				return false
 			}
 		}
 
@@ -559,19 +759,31 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 				if host == "" {
 					host = "127.0.0.1" // ":<port>" shorthand → localhost, parity with the docker gate
 				}
-				ceiling := cfg.Test.HealthPollTimeout
-				if ceiling <= 0 {
-					ceiling = 60 * time.Second
+				gated = true
+				if !gateOnAppAddress(ctx, logger, cfg, host, port, "app-ready-probe-addr", probe) {
+					return false
 				}
-				if err := pkg.WaitForPort(ctx, host, port, ceiling); err != nil {
-					if ctx.Err() != nil {
-						return false
-					}
-					logger.Warn("app ready-probe address did not accept a connection within the ceiling; firing tests anyway (replay may see connection refused)",
-						zap.String("addr", addr),
-						zap.Duration("ceiling", ceiling),
-						zap.Error(err))
-				}
+			}
+		}
+
+		// Nothing above could name the app's address — a NATIVE app, the common
+		// case: no docker -p publish, no compose file, no operator-supplied
+		// appReadyProbeAddr. Until now that meant no readiness gate at all beyond
+		// the fixed --delay, so a native app slower than that delay had its first
+		// test fired into a socket nothing was listening on yet, producing exactly
+		// the status_code=0 this whole gate exists to prevent. Observed on the
+		// python-cred-expiry lane (`python3 recorded_app.py`, --delay 5): 2 of 4
+		// tests failed with expected=200 got=0.
+		//
+		// The recorded test set already told us where it dials, so use it. There
+		// is nothing to guess: probe.host/probe.port IS the app's address for the
+		// purposes of these tests, and the same best-effort contract holds —
+		// bounded by the ceiling, warn-and-proceed on timeout, only ever waits
+		// longer than --delay. Guarded on `gated` purely to avoid probing twice
+		// when a published address already covered it.
+		if !gated && probe.ok {
+			if !gateOnAppAddress(ctx, logger, cfg, probe.host, probe.port, "resolved-test-target", probe) {
+				return false
 			}
 		}
 		return true
@@ -579,7 +791,7 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 
 	pollCeiling := cfg.Test.HealthPollTimeout
 	if pollCeiling <= 0 {
-		pollCeiling = 60 * time.Second
+		pollCeiling = config.DefaultHealthPollTimeout
 	}
 
 	logger.Info("polling application health endpoint before firing tests",


### PR DESCRIPTION
The first test of a set intermittently fails with `status_code: 0` and "connection reset by peer" while every other test in the set passes. It is not an assertion mismatch — the request never reaches the application.

## Why

Replay waits for the app before firing, but for a docker or compose app that wait was a **bare TCP accept** on the published host port. Docker's userland proxy binds and ACCEPTS that port as soon as the container is created — long before anything inside the container is listening — and then RESETS the connection because it has nowhere to forward it. So the gate is satisfied immediately and hands replay a port that will reset its first request.

A measured cold start on a loaded shared runner took **17–28s** for the app process and **~55s** from spawn to first serve; the gate passed at once. This is also why the errors are `ECONNRESET` rather than `ECONNREFUSED` — something *is* accepting.

Only a completed HTTP exchange proves the whole proxy→app path carries a request. `waitForHTTPServing` already existed and already documented exactly this hazard, but it was wired solely into the post-failure reset re-send path; every pre-test gate still used `WaitForPort`. This wires it into the gates.

## Which address

Deciding *to* escalate is easy; choosing *what to probe* is where this goes wrong. `dockerPublishedHostPort` returns the **first** `-p` flag with no check that it is the HTTP port — for `-p 5432:5432 -p 8080:8080` that is the database — and `appReadyProbeAddr` is documented as the analog for apps with *no* HTTP health endpoint, so an operator is invited to point it at a non-HTTP service. Escalating against either would make stage 1 pass instantly (the port is bound) and stage 2 unanswerable, burning the whole ceiling on **every** run rather than only a cold start.

So the probe target is resolved from the recorded test set via `resolveProbeTarget` — the same resolver the reset re-send gate already uses — which mirrors the simulation's own `ResolveTestTarget` (ConfigHost/`--host` override, `replaceWith`, port precedence) and is address-family-correct, so an IPv6 `localhost` dial is gated on the IPv6 path rather than a mismatched `127.0.0.1`.

Stage 1 still gates the published address (that is what proves binding); stage 2 probes what the tests will actually dial. No resolvable HTTP case — empty set, non-HTTP set, unresolvable target — means no stage 2 and the pre-existing TCP-only behaviour. **A non-HTTP app (MySQL, Redis, gRPC-only) pays nothing.**


## Native apps get a gate at all, for the first time

None of the three address sources fires for `python3 app.py` — no `-p` publish, no compose file, no operator-supplied `appReadyProbeAddr` — so until now those runs had nothing but the fixed `--delay`, and an app slower than that delay had its first test fired into a socket nothing was listening on.

This is not hypothetical. The `python-cred-expiry` lane (`python3 recorded_app.py`, `--delay 5`) fails intermittently with **`status_code expected=200 got=0`, twice in four tests** — the same signature as the docker case, on a completely different app and language.

The resolved test target is used as the gate there, because nothing has to be guessed: it *is* the address those tests dial. A test set with no resolvable HTTP case keeps the pure `--delay` behaviour, so nothing regresses for non-HTTP native apps.

## Configurable

- `--health-path` probes a path on that resolved address. Unlike `--health-url` it needs no host or port, so it works when the published port is assigned at runtime.
- `--health-scheme` overrides the resolved scheme.
- Both are ignored when `--health-url` is set, which the flag help now says.

Any completed response counts as ready, including 404 and 503: a health endpoint reporting "unhealthy" has still proved the app is answering, and blocking on application-level health would turn a readiness gate into a liveness policy. The probe does not verify the app's certificate — it is a liveness check against the app under test, not a trust boundary, and verifying would make the self-signed cert of a typical local HTTPS fixture indistinguishable from "not ready".

## Defaults

`healthPollTimeout` 60s → **3m**. The ceiling is paid only by an app that is not yet serving — a ready app satisfies the gate on the first probe — so raising it costs a healthy run nothing and buys headroom where it matters. The old 60s sat *under* the ~55s observed spawn-to-serve, which is how the gate expired and fired into a not-yet-listening app. Timing out only warns and proceeds, so an over-generous ceiling can never fail a run that would otherwise pass; an under-generous one can.

Stage 1 and stage 2 share one deadline computed at entry, so a gate costs at most one ceiling, not two.

## Contract preserved

The gate can only ever wait **longer** than `--delay`, never shorter, never weakens an assertion, and returns false (user abort) only on context cancellation — never on a timeout.

The three gates (docker `-p`, compose, `appReadyProbeAddr`) were triplicated with their own ceiling handling; they now share `gateOnAppAddress`.

## Testing

- New tests simulate the docker-proxy shape (accept-then-reset) and assert it is **not** treated as ready for an HTTP app, **is** for a non-HTTP app, that stage 2 probes the resolved target rather than the gated port, that `--health-path` and `--health-scheme` take effect, and that the resolver declines without evidence.
- 10 mutants killed, each verified by reverting the source and re-running — including the pre-fix TCP-only behaviour and probing the gated port again.
- All 20 pre-existing readiness tests pass with unchanged semantics.
- `-count=2` and `-race` clean; `gofmt`, `goimports` and `go vet` clean.