### PR TITLE
fix(replay): say when a mock miss went to an out-of-scope destination

### DIFF
--- a/pkg/agent/proxy/integrations/http/destination_scope_test.go
+++ b/pkg/agent/proxy/integrations/http/destination_scope_test.go
@@ -1,0 +1,447 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// httpMockOnHost builds a recorded HTTP mock the way the recorder writes one:
+// a path-only URL with the upstream authority in the Host header.
+func httpMockOnHost(name, method, rawURL, host string) *models.Mock {
+	header := map[string]string{"Accept": "application/json"}
+	if host != "" {
+		header["Host"] = host
+	}
+	return &models.Mock{
+		Name: name,
+		Kind: models.Kind(models.HTTP),
+		Spec: models.MockSpec{
+			HTTPReq: &models.HTTPReq{
+				Method: models.Method(method),
+				URL:    rawURL,
+				Header: header,
+			},
+		},
+	}
+}
+
+func reqToHost(method, path, host string) *http.Request {
+	return &http.Request{
+		Method: method,
+		URL:    &url.URL{Path: path},
+		Host:   host,
+		Header: http.Header{},
+	}
+}
+
+// End-to-end over the real report builder, in the shape of the reported
+// bundle: a sidecar container's call to 192.0.2.20 that none of the compared
+// mocks target, against a pool recorded from the one container the user named.
+// Until this check existed the report claimed the request structure had
+// changed and led with a diff against a mock on a different host.
+func TestBuildHTTPMismatchReport_DestinationScope(t *testing.T) {
+	recorded := []*models.Mock{
+		httpMockOnHost("mock-1", "GET", "/api/orders?id=90", "192.0.2.10"),
+		httpMockOnHost("mock-2", "GET", "/api/clients?code=demo", "192.0.2.10"),
+		httpMockOnHost("mock-3", "POST", "/oauth/token?grant_type=client_credentials", "192.0.2.30:9090"),
+		httpMockOnHost("mock-4", "GET", "/api/vendors?name=vendor-a", "192.0.2.40"),
+	}
+	// One mock whose upstream cannot be read: a path-only URL with no Host
+	// header. It could be the mock that targeted the live call, so it has to
+	// veto the whole verdict.
+	unreadable := append(append([]*models.Mock{}, recorded...),
+		httpMockOnHost("mock-5", "GET", "/internal/health", ""))
+
+	tests := []struct {
+		name        string
+		mocks       []*models.Mock
+		request     *http.Request
+		diag        *matchDiag
+		wantScope   string
+		wantPhase   string
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			name:      "sidecar destination absent from the compared set",
+			mocks:     recorded,
+			request:   reqToHost("GET", "/v1/metrics", "192.0.2.20"),
+			diag:      &matchDiag{phase: models.MatchPhaseSchema, candidates: len(recorded)},
+			wantScope: models.DestinationScopeNotInComparedSet,
+			wantPhase: models.MatchPhaseSchema,
+			wantContain: []string{
+				"No recorded HTTP mock in the compared set targets 192.0.2.20",
+			},
+			// The shared causes are rendered once per test from
+			// models.OutOfScopeDestinationCauses, never per call.
+			wantAbsent: []string{"Request structure changed", "sidecar", "ONE container per session"},
+		},
+		{
+			name:        "destination in the compared set, drifted request keeps today's message",
+			mocks:       recorded,
+			request:     reqToHost("GET", "/api/orders/renamed", "192.0.2.10"),
+			diag:        &matchDiag{phase: models.MatchPhaseSchema, candidates: len(recorded)},
+			wantScope:   models.DestinationScopeInComparedSet,
+			wantPhase:   models.MatchPhaseSchema,
+			wantContain: []string{"Request structure changed since recording"},
+			wantAbsent:  []string{"compared set"},
+		},
+		{
+			// One mock in the pool has no readable upstream, so the pool
+			// proves nothing about any destination.
+			name:        "one unreadable mock in the pool falls back",
+			mocks:       unreadable,
+			request:     reqToHost("GET", "/v1/metrics", "192.0.2.20"),
+			diag:        &matchDiag{phase: models.MatchPhaseSchema, candidates: len(unreadable)},
+			wantScope:   models.DestinationScopeUnknown,
+			wantPhase:   models.MatchPhaseSchema,
+			wantContain: []string{"Request structure changed since recording"},
+			wantAbsent:  []string{"compared set"},
+		},
+		{
+			// No Host header and no URL authority: the live destination is
+			// unknown, so nothing can be said about it.
+			name:        "unknown live destination falls back",
+			mocks:       recorded,
+			request:     makeReqWithQuery("GET", "/v1/metrics", ""),
+			diag:        &matchDiag{phase: models.MatchPhaseSchema, candidates: len(recorded)},
+			wantScope:   models.DestinationScopeUnknown,
+			wantPhase:   models.MatchPhaseSchema,
+			wantContain: []string{"Request structure changed since recording"},
+			wantAbsent:  []string{"compared set"},
+		},
+		{
+			// An empty pool is MatchPhaseNoMocks' case, and it keeps it.
+			name:        "empty mock set keeps no_mocks",
+			mocks:       nil,
+			request:     reqToHost("GET", "/v1/metrics", "192.0.2.20"),
+			diag:        nil,
+			wantScope:   models.DestinationScopeUnknown,
+			wantPhase:   models.MatchPhaseNoMocks,
+			wantContain: []string{"No recorded mocks were available"},
+			wantAbsent:  []string{"compared set", "sidecar"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newHTTP()
+			db := &mockMemDb{mocks: tt.mocks}
+			report := h.buildHTTPMismatchReport(tt.request, nil, db, nil, nil, nil, tt.diag)
+
+			if report.DestinationScope != tt.wantScope {
+				t.Errorf("DestinationScope = %q, want %q", report.DestinationScope, tt.wantScope)
+			}
+			if report.MatchPhase != tt.wantPhase {
+				t.Errorf("MatchPhase = %q, want %q", report.MatchPhase, tt.wantPhase)
+			}
+			for _, want := range tt.wantContain {
+				if !strings.Contains(report.NextSteps, want) {
+					t.Errorf("NextSteps missing %q:\n%s", want, report.NextSteps)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(report.NextSteps, absent) {
+					t.Errorf("NextSteps must not contain %q:\n%s", absent, report.NextSteps)
+				}
+			}
+		})
+	}
+}
+
+// THE reason the claim is local. Every mock for 192.0.2.10 has been served and
+// permanently stripped from the pool (updateMock -> DeleteFilteredMock, then
+// the agent's filterOutDeleted for every later test), so the pool the matcher
+// just failed against mentions the host nowhere — even though it is the
+// application's own upstream and was recorded all along.
+//
+// The verdict may say what it can see: nothing here targets that host. It may
+// NOT dress that up as "never recorded", which is what four earlier cuts of
+// this diagnostic did and what put a false claim in front of a user.
+func TestBuildHTTPMismatchReport_ConsumedHostMakesNoGlobalClaim(t *testing.T) {
+	h := newHTTP()
+	// What survives: one mock, on a different host entirely.
+	survivors := []*models.Mock{httpMockOnHost("mock-4", "GET", "/api/vendors?name=vendor-a", "192.0.2.40")}
+	db := &mockMemDb{mocks: survivors}
+
+	report := h.buildHTTPMismatchReport(
+		reqToHost("GET", "/api/orders?id=91", "192.0.2.10"), nil, db, survivors, nil, nil,
+		&matchDiag{phase: models.MatchPhaseSchema, candidates: len(survivors)})
+
+	if report.DestinationScope != models.DestinationScopeNotInComparedSet {
+		t.Fatalf("DestinationScope = %q, want %q", report.DestinationScope, models.DestinationScopeNotInComparedSet)
+	}
+	for _, forbidden := range []string{"never recorded", "was not recorded", "outside the recorded scope"} {
+		if strings.Contains(strings.ToLower(report.NextSteps), forbidden) {
+			t.Errorf("a consumed host must not be claimed unrecorded (%q):\n%s", forbidden, report.NextSteps)
+		}
+	}
+	// And the guidance the user actually reads says out loud why they should
+	// not read it as one. The caveat lives in the once-per-test block, and it
+	// has to cover BOTH ways a recorded mock leaves the compared set:
+	// consumption earlier in the run, and a per-test window that excluded it.
+	if !strings.Contains(models.OutOfScopeDestinationCauses,
+		"Mocks already served earlier in this run, or recorded outside this test's mock window, are no") {
+		t.Errorf("the consumption/windowing caveat must be stated, got:\n%s", models.OutOfScopeDestinationCauses)
+	}
+}
+
+// THE coverage gap this diagnostic used to have. On the schema-survivor path
+// buildHTTPMismatchReport deliberately does not reload the pool — it diffs
+// against the survivors — so it held only a SUBSET of the compared set and had
+// to stay silent. That silence landed on exactly the worst case: an
+// out-of-scope call whose method+path schema-matches an application mock
+// (shared paths like /health, /metrics, /oauth/token on a different host), left
+// with the old "Request structure changed" message and a closest-mock diff
+// against another upstream.
+//
+// matchDiag.pool carries the set match() actually walked, so the verdict is
+// reachable there too. The evidence for the DIFF is unchanged: the closest mock
+// still comes from the survivors, exactly as before.
+func TestBuildHTTPMismatchReport_SchemaSurvivorPathIsStillScored(t *testing.T) {
+	h := newHTTP()
+	// /health recorded for the app's own upstream; the live /health goes to a
+	// sidecar's. Same method, same path — a schema match, on a different host.
+	appHealth := httpMockOnHost("mock-1", "GET", "/health", "192.0.2.10")
+	pool := []*models.Mock{
+		appHealth,
+		httpMockOnHost("mock-2", "GET", "/api/orders?id=90", "192.0.2.10"),
+	}
+	survivors := []*models.Mock{appHealth}
+	db := &mockMemDb{mocks: pool}
+
+	report := h.buildHTTPMismatchReport(
+		reqToHost("GET", "/health", "192.0.2.20"), nil, db, nil, nil, nil,
+		&matchDiag{
+			phase:         models.MatchPhaseBody,
+			candidates:    len(pool),
+			schemaMatched: survivors,
+			pool:          pool,
+		})
+
+	if report.DestinationScope != models.DestinationScopeNotInComparedSet {
+		t.Fatalf("DestinationScope = %q, want %q on the schema-survivor path",
+			report.DestinationScope, models.DestinationScopeNotInComparedSet)
+	}
+	if !strings.Contains(report.NextSteps, "in the compared set targets 192.0.2.20") {
+		t.Errorf("expected the out-of-scope guidance, got:\n%s", report.NextSteps)
+	}
+	// Diagnostic-only: the candidate the matcher was diffing against is
+	// untouched, and so is the cascade stop.
+	if report.ClosestMock != "mock-1" {
+		t.Errorf("ClosestMock = %q, want the schema survivor mock-1", report.ClosestMock)
+	}
+	if report.MatchPhase != models.MatchPhaseBody || report.CandidateCount != len(pool) {
+		t.Errorf("phase/candidates disturbed: %q / %d", report.MatchPhase, report.CandidateCount)
+	}
+}
+
+// The diag pool is the compared set, so it also decides IN-set correctly on the
+// survivor path — the check must not have become a one-way "always out of
+// scope" stamp for schema survivors.
+func TestBuildHTTPMismatchReport_SchemaSurvivorPathInScope(t *testing.T) {
+	h := newHTTP()
+	appHealth := httpMockOnHost("mock-1", "GET", "/health", "192.0.2.10")
+	pool := []*models.Mock{appHealth, httpMockOnHost("mock-2", "GET", "/api/orders?id=90", "192.0.2.10")}
+	db := &mockMemDb{mocks: pool}
+
+	report := h.buildHTTPMismatchReport(
+		reqToHost("GET", "/health", "192.0.2.10"), nil, db, nil, nil, nil,
+		&matchDiag{
+			phase:         models.MatchPhaseBody,
+			candidates:    len(pool),
+			schemaMatched: []*models.Mock{appHealth},
+			pool:          pool,
+		})
+
+	if report.DestinationScope != models.DestinationScopeInComparedSet {
+		t.Fatalf("DestinationScope = %q, want %q", report.DestinationScope, models.DestinationScopeInComparedSet)
+	}
+	if strings.Contains(report.NextSteps, "in the compared set targets") {
+		t.Errorf("an in-scope miss must keep its ordinary guidance:\n%s", report.NextSteps)
+	}
+}
+
+// When a caller hands over fewer mocks than the matcher reported comparing and
+// supplies no diag.pool, what is in hand is a SUBSET of the compared set, and
+// "none of them targets it" would overreach on the reader's behalf (the report
+// says "candidates: 19" right next to it).
+//
+// This is a guard for callers, not a live production branch: the production
+// caller (decode.go) always passes httpMocks == nil, and match() always
+// attaches diag.pool, whose length equals diag.candidates by construction. It
+// still fires for a hand-built diag like this one, for a future parser reusing
+// the builder, and for the pool-reload path if a concurrent consumption on
+// another connection shrank the pool between the match and the report.
+func TestBuildHTTPMismatchReport_SubsetOfComparedPoolMakesNoClaim(t *testing.T) {
+	h := newHTTP()
+	survivors := []*models.Mock{httpMockOnHost("mock-4", "GET", "/api/vendors?name=vendor-a", "192.0.2.40")}
+	db := &mockMemDb{mocks: survivors}
+
+	report := h.buildHTTPMismatchReport(
+		reqToHost("GET", "/v1/metrics", "192.0.2.20"), nil, db, survivors, nil, nil,
+		&matchDiag{phase: models.MatchPhaseSchema, candidates: 19, schemaMatched: survivors})
+
+	if report.DestinationScope != models.DestinationScopeUnknown {
+		t.Errorf("DestinationScope = %q, want unset when only a subset of the compared pool is in hand", report.DestinationScope)
+	}
+	if !strings.Contains(report.NextSteps, "Request structure changed since recording") {
+		t.Errorf("expected the unchanged fallback message, got %q", report.NextSteps)
+	}
+}
+
+// The live destination is read from the Host header first and the URL
+// authority second, mirroring how recorded mocks store it — so the same
+// upstream is recognised whichever way the live request carries it.
+func TestBuildHTTPMismatchReport_LiveDestinationFromURL(t *testing.T) {
+	h := newHTTP()
+	mocks := []*models.Mock{httpMockOnHost("mock-1", "GET", "/api/orders?id=90", "192.0.2.10")}
+	db := &mockMemDb{mocks: mocks}
+
+	// No Host field; the authority sits on the URL, as it does for a request
+	// captured through a forward proxy.
+	request := &http.Request{
+		Method: "GET",
+		URL:    &url.URL{Host: "192.0.2.20", Path: "/v1/metrics"},
+		Header: http.Header{},
+	}
+	report := h.buildHTTPMismatchReport(request, nil, db, mocks, nil, nil,
+		&matchDiag{phase: models.MatchPhaseSchema, candidates: 1})
+
+	if report.Destination != "192.0.2.20" {
+		t.Fatalf("Destination = %q, want the URL authority", report.Destination)
+	}
+	if report.DestinationScope != models.DestinationScopeNotInComparedSet {
+		t.Errorf("DestinationScope = %q, want %q", report.DestinationScope, models.DestinationScopeNotInComparedSet)
+	}
+}
+
+// comparedDestinations is the whole evidence source; its undecidable arms are
+// the safety property, so they are pinned directly.
+func TestComparedDestinations(t *testing.T) {
+	readable := []*models.Mock{
+		httpMockOnHost("a", "GET", "/x", "192.0.2.10"),
+		httpMockOnHost("b", "GET", "/y", "192.0.2.10"), // duplicate host collapses
+		httpMockOnHost("c", "GET", "/z", "192.0.2.40"),
+	}
+
+	if got := comparedDestinations(nil, 0); got != nil {
+		t.Errorf("empty pool must be undecidable, got %v", got)
+	}
+	if got := comparedDestinations(readable, 19); got != nil {
+		t.Errorf("subset of the compared pool must be undecidable, got %v", got)
+	}
+	withUnreadable := append(append([]*models.Mock{}, readable...), httpMockOnHost("d", "GET", "/w", ""))
+	if got := comparedDestinations(withUnreadable, len(withUnreadable)); got != nil {
+		t.Errorf("one unreadable mock must veto the set, got %v", got)
+	}
+	got := comparedDestinations(readable, len(readable))
+	if len(got) != 2 {
+		t.Fatalf("comparedDestinations = %v, want the 2 distinct hosts", got)
+	}
+	want := map[string]bool{"192.0.2.10": true, "192.0.2.40": true}
+	for _, d := range got {
+		if !want[d] {
+			t.Errorf("unexpected destination %q in %v", d, got)
+		}
+	}
+}
+
+// The plumbing that makes the schema-survivor path decidable at all: match()
+// must hand the compared set out on EVERY miss return, and len(pool) must equal
+// the candidate count it reports — comparedDestinations refuses to judge a pool
+// smaller than that count, so a diag that reports 19 candidates and carries 3
+// mocks would silently disable the diagnostic again.
+func TestMatchDiagCarriesTheComparedPool(t *testing.T) {
+	h := newHTTP()
+	ctx := context.Background()
+	postMock := httpMockOnHost("mock-2", "POST", "http://192.0.2.10/api/orders", "192.0.2.10")
+	postMock.Spec.HTTPReq.Body = `{"id":"recorded"}`
+	pool := []*models.Mock{
+		httpMockOnHost("mock-1", "GET", "http://192.0.2.10/api/orders?id=90", "192.0.2.10"),
+		postMock,
+	}
+	db := &mockMemDb{mocks: pool}
+
+	// Both miss shapes: the no-schema-candidate return, and the
+	// schema-SURVIVOR return, which is the one the builder does not reload a
+	// pool for and where the diagnostic used to be blind.
+	cases := []struct {
+		name      string
+		live      *req
+		wantPhase string
+		wantSurv  bool
+	}{
+		{
+			name: "no schema candidate",
+			live: &req{
+				method: "GET",
+				url:    &url.URL{Scheme: "http", Host: "192.0.2.20", Path: "/v1/metrics"},
+				header: http.Header{},
+				raw:    []byte("GET /v1/metrics HTTP/1.1\r\nHost: 192.0.2.20\r\n\r\n"),
+			},
+			wantPhase: models.MatchPhaseSchema,
+		},
+		{
+			// Same method+path as a recorded mock on ANOTHER host: schema
+			// matches, the body rules it out, and the survivor comes back on
+			// the diag. This is the shape the gap hid in.
+			name: "schema survivor, body mismatch",
+			live: &req{
+				method: "POST",
+				url:    &url.URL{Scheme: "http", Host: "192.0.2.20", Path: "/api/orders"},
+				header: http.Header{
+					"Content-Type": []string{"application/json"},
+					"Accept":       []string{"application/json"},
+					"Host":         []string{"192.0.2.20"},
+				},
+				// A DIFFERENT top-level key, not just a different value: the
+				// body schema match is key-based, so a same-key body would
+				// MATCH here and be served instead of missing.
+				body: []byte(`{"unrelated":"live"}`),
+				raw:  []byte("POST /api/orders HTTP/1.1\r\nHost: 192.0.2.20\r\n\r\n{\"unrelated\":\"live\"}"),
+			},
+			wantPhase: models.MatchPhaseBody,
+			wantSurv:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			matched, _, diag, err := h.match(ctx, tc.live, db, nil, nil, nil, true, false, false)
+			if err != nil || matched {
+				t.Fatalf("match() = (%v, %v), want a clean miss", matched, err)
+			}
+			if diag == nil {
+				t.Fatal("miss returned no diag")
+			}
+			if diag.phase != tc.wantPhase {
+				t.Fatalf("phase = %q, want %q (the fixture no longer exercises this return)", diag.phase, tc.wantPhase)
+			}
+			if tc.wantSurv != (len(diag.schemaMatched) > 0) {
+				t.Fatalf("schemaMatched = %d, want survivors: %v", len(diag.schemaMatched), tc.wantSurv)
+			}
+			if len(diag.pool) != diag.candidates {
+				t.Fatalf("diag.pool has %d mocks but reports %d candidates — comparedDestinations would refuse to judge it",
+					len(diag.pool), diag.candidates)
+			}
+			if len(diag.pool) != len(pool) {
+				t.Fatalf("diag.pool = %d mocks, want the whole compared set (%d)", len(diag.pool), len(pool))
+			}
+
+			// And end to end: the report the builder makes from that diag
+			// reaches a verdict instead of falling back.
+			report := h.buildHTTPMismatchReport(
+				reqToHost(tc.live.method, tc.live.url.Path, "192.0.2.20"),
+				tc.live.body, db, nil, nil, nil, diag)
+			if report.DestinationScope != models.DestinationScopeNotInComparedSet {
+				t.Errorf("DestinationScope = %q, want %q", report.DestinationScope, models.DestinationScopeNotInComparedSet)
+			}
+		})
+	}
+}

--- a/pkg/agent/proxy/integrations/http/match.go
+++ b/pkg/agent/proxy/integrations/http/match.go
@@ -45,6 +45,25 @@ type matchDiag struct {
 	phase         string         // models.MatchPhase* constant
 	candidates    int            // HTTP mocks considered
 	schemaMatched []*models.Mock // candidates alive after schema match (nil if none)
+	// pool is the FULL set match() walked for this attempt (per-test mocks in
+	// window + session mocks, filtered to HTTP) — the literal "compared set".
+	// len(pool) == candidates by construction.
+	//
+	// It exists so the destination-scope diagnostic can answer "did anything
+	// we compared even target this upstream?" on EVERY miss, including the
+	// schema-survivor paths where buildHTTPMismatchReport deliberately does
+	// not reload the pool (it diffs against the survivors instead). Without
+	// it, an out-of-scope call whose method+path happens to schema-match an
+	// application mock — the shared paths, /health, /metrics, /oauth/token,
+	// on a different host — was the ONE case the diagnostic could not see,
+	// and precisely the case where a closest-mock diff against another
+	// upstream is most confusing.
+	//
+	// Carrying the slice out costs one pointer copy on the miss path and
+	// changes nothing about matching: it is a reference to a set match() has
+	// already finished with, attached to a struct only ever built on the
+	// no-match return.
+	pool []*models.Mock
 }
 
 // match returns (matched, mock, diag, err). diag is non-nil only when
@@ -138,7 +157,7 @@ func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMe
 		}
 
 		if len(schemaMatched) == 0 {
-			return false, nil, &matchDiag{phase: models.MatchPhaseSchema, candidates: len(unfilteredMocks)}, nil
+			return false, nil, &matchDiag{phase: models.MatchPhaseSchema, candidates: len(unfilteredMocks), pool: unfilteredMocks}, nil
 		}
 
 		h.Logger.Debug("http mock schema match results",
@@ -182,7 +201,7 @@ func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMe
 				if beforeStrict > 0 {
 					phase = models.MatchPhaseStrict
 				}
-				return false, nil, &matchDiag{phase: phase, candidates: len(unfilteredMocks), schemaMatched: schemaMatched}, nil
+				return false, nil, &matchDiag{phase: phase, candidates: len(unfilteredMocks), schemaMatched: schemaMatched, pool: unfilteredMocks}, nil
 			}
 
 			if len(bodyMatched) == 1 {
@@ -209,7 +228,7 @@ func (h *HTTP) match(ctx context.Context, input *req, mockDb integrations.MockMe
 			}
 			return true, bestMatch, nil, nil
 		}
-		return false, nil, &matchDiag{phase: models.MatchPhaseExhausted, candidates: len(unfilteredMocks), schemaMatched: shortListed}, nil
+		return false, nil, &matchDiag{phase: models.MatchPhaseExhausted, candidates: len(unfilteredMocks), schemaMatched: shortListed, pool: unfilteredMocks}, nil
 	}
 }
 
@@ -1434,6 +1453,24 @@ func (h *HTTP) buildHTTPMismatchReport(request *http.Request, liveBody []byte, m
 			WithPhase(models.MatchPhaseNoMocks, 0).Build()
 	}
 
+	// Does anything the matcher just compared against even target this
+	// upstream? Answered from the compared set and nothing else — see
+	// comparedDestinations for why the wider "was it ever recorded?" question
+	// is not asked.
+	//
+	// diag.pool is the set match() literally walked, so it is preferred over
+	// httpMocks: on the schema-survivor path httpMocks is nil (the pool is
+	// deliberately not reloaded, the diff comes from the survivors), and on
+	// the other path httpMocks is a fresh re-read that a concurrent
+	// consumption on another connection can have shrunk since the match. Only
+	// the caller-supplied / re-read pool is used when the diag carries none —
+	// a hand-built diag in a test, or diag == nil.
+	comparedPool := httpMocks
+	if diag != nil && diag.pool != nil {
+		comparedPool = diag.pool
+	}
+	comparedDests := comparedDestinations(comparedPool, candidateCount)
+
 	// Pick the candidate to diff against. Preference order:
 	//  1. a schema-match survivor (method+path+keys already matched — the
 	//     interesting drift is in query values, headers, or the body)
@@ -1442,6 +1479,7 @@ func (h *HTTP) buildHTTPMismatchReport(request *http.Request, liveBody []byte, m
 	if closestMock == nil || closestMock.Spec.HTTPReq == nil {
 		return mismatch.NewReport(mismatch.ProtocolHTTP, actualKey).
 			WithDestination(dest).
+			WithComparedDestinations(comparedDests).
 			WithPhase(phase, candidateCount).Build()
 	}
 
@@ -1495,6 +1533,7 @@ func (h *HTTP) buildHTTPMismatchReport(request *http.Request, liveBody []byte, m
 
 	b := mismatch.NewReport(mismatch.ProtocolHTTP, actualKey).
 		WithDestination(dest).
+		WithComparedDestinations(comparedDests).
 		WithPhase(phase, candidateCount).
 		WithClosest(closestMock.Name, fieldDiffs).
 		// Whole-request renders for the CLI side-by-side diff. Mock.Noise is
@@ -1510,6 +1549,67 @@ func (h *HTTP) buildHTTPMismatchReport(request *http.Request, liveBody []byte, m
 		b = b.WithDiff(fmt.Sprintf("closest mock %q has no field-level differences; match stopped at phase %q", closestMock.Name, phase))
 	}
 	return b.Build()
+}
+
+// comparedDestinations returns the upstream authority of every mock in the
+// pool this report was built against, or nil when the "does anything here
+// target the live upstream?" question cannot be answered from it — nil means
+// undecidable, and an undecidable check leaves today's message exactly as it
+// was (mismatch.WithComparedDestinations carries the full WHY).
+//
+// The claim it feeds is strictly LOCAL: "no mock in the compared set targets
+// this host". It is deliberately NOT the stronger "this host was never
+// recorded". That stronger claim needs global, consumption-immune knowledge
+// of the whole test set, and keploy does not have it here: HTTP per-test
+// mocks are consumed on match (updateMock -> DeleteFilteredMock) and the
+// agent then strips every consumed mock from the pool it sends for all later
+// tests (pkg/service/agent/agent.go filterOutDeleted over TotalConsumedMocks).
+// Once a host's last mock has been served it is gone from every pool while
+// having been recorded all along — so an absence read off any pool, however
+// carefully assembled, eventually accuses the application's own upstream. The
+// weaker claim costs a sentence of precision and is always true.
+//
+// nil (undecidable) when:
+//   - the pool is empty — there is nothing to have compared against. In
+//     production this is the diag-less path (a caller that supplied no
+//     matchDiag) and the mockDb-read-failed path; on the schema-survivor path
+//     the builder does NOT reload the pool, but matchDiag.pool carries the
+//     compared set out of match() so that path is decidable too;
+//   - the pool holds fewer mocks than the matcher reported comparing, so what
+//     is in hand is a subset of the compared set and "none of them" would
+//     overreach. matchDiag.pool never trips this (len(pool) == candidates by
+//     construction); it fires for a caller that hands over a partial pool —
+//     a test, or a future parser reusing this builder — and for the re-read
+//     path if a concurrent consumption shrank the pool between the match and
+//     the report. Kept as the defence for those callers, not as a live
+//     production branch.
+//   - any mock in it carries no readable destination — that mock could be the
+//     one that targeted the live call, so the set proves nothing.
+//
+// This runs only on the miss path, where a report is already being rendered,
+// so the walk never touches the matching hot path.
+func comparedDestinations(pool []*models.Mock, candidateCount int) []string {
+	if len(pool) == 0 || len(pool) < candidateCount {
+		return nil
+	}
+	// Sized for distinct UPSTREAMS, not for mocks: a recorded test set has
+	// single-digit distinct hosts behind hundreds of mocks, so len(pool)
+	// would over-allocate by two orders of magnitude on every miss.
+	const typicalDistinctHosts = 8
+	seen := make(map[string]struct{}, typicalDistinctHosts)
+	dests := make([]string, 0, typicalDistinctHosts)
+	for _, mock := range pool {
+		dest, ok := mock.RecordedDestination()
+		if !ok {
+			return nil
+		}
+		if _, dup := seen[dest]; dup {
+			continue
+		}
+		seen[dest] = struct{}{}
+		dests = append(dests, dest)
+	}
+	return dests
 }
 
 // pickClosestCandidate prefers a schema-match survivor (already same

--- a/pkg/agent/proxy/integrations/http/mismatch_report_test.go
+++ b/pkg/agent/proxy/integrations/http/mismatch_report_test.go
@@ -84,15 +84,15 @@ func TestBuildHTTPMismatchReport_RecordsDestination(t *testing.T) {
 
 	// Host header wins.
 	req := makeReqWithQuery("GET", "/api/orders", "")
-	req.Host = "api.payments.svc:8443"
-	if got := h.buildHTTPMismatchReport(req, nil, db, nil, nil, nil, diag).Destination; got != "api.payments.svc:8443" {
+	req.Host = "api.example.com:8443"
+	if got := h.buildHTTPMismatchReport(req, nil, db, nil, nil, nil, diag).Destination; got != "api.example.com:8443" {
 		t.Fatalf("expected destination from Host header, got %q", got)
 	}
 
 	// Falls back to the URL authority when Host is unset.
 	req = makeReqWithQuery("GET", "/api/orders", "")
-	req.URL.Host = "inventory.internal:9000"
-	if got := h.buildHTTPMismatchReport(req, nil, db, nil, nil, nil, diag).Destination; got != "inventory.internal:9000" {
+	req.URL.Host = "inventory.example.com:9000"
+	if got := h.buildHTTPMismatchReport(req, nil, db, nil, nil, nil, diag).Destination; got != "inventory.example.com:9000" {
 		t.Fatalf("expected destination from URL authority fallback, got %q", got)
 	}
 

--- a/pkg/agent/proxy/integrations/mismatch/destination_scope_test.go
+++ b/pkg/agent/proxy/integrations/mismatch/destination_scope_test.go
@@ -1,0 +1,595 @@
+package mismatch
+
+import (
+	"strings"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// destinationScope is the safety gate for the whole feature: it may only
+// answer "not in the compared set" when the compared destinations say so
+// unambiguously. Every row here is a rule that, if broken, produces a false
+// claim — the same class of misdirection the feature exists to remove.
+//
+// The three states are distinct on purpose. "in_compared_set" and "unknown"
+// both leave today's message alone, but only the first means the question was
+// actually answered, and downstream surfaces (the agent log's
+// destination_scope field) render the two differently.
+func TestDestinationScope(t *testing.T) {
+	tests := []struct {
+		name     string
+		dest     string
+		compared []string
+		want     string
+	}{
+		{
+			name:     "absent from a non-empty set",
+			dest:     "192.0.2.20",
+			compared: []string{"192.0.2.10", "192.0.2.30:9090", "192.0.2.40"},
+			want:     models.DestinationScopeNotInComparedSet,
+		},
+		{
+			name:     "present in the set",
+			dest:     "192.0.2.10",
+			compared: []string{"192.0.2.10", "192.0.2.40"},
+			want:     models.DestinationScopeInComparedSet,
+		},
+		{
+			name:     "live carries a port the recording elided",
+			dest:     "192.0.2.10:80",
+			compared: []string{"192.0.2.10"},
+			want:     models.DestinationScopeInComparedSet,
+		},
+		{
+			name:     "recording carries a port the live call elided",
+			dest:     "192.0.2.30",
+			compared: []string{"192.0.2.30:9090"},
+			want:     models.DestinationScopeInComparedSet,
+		},
+		{
+			name:     "same host, different port, is NOT a new destination",
+			dest:     "192.0.2.30:9999",
+			compared: []string{"192.0.2.30:9090"},
+			want:     models.DestinationScopeInComparedSet,
+		},
+		{
+			name:     "host case is not a difference",
+			dest:     "API.Example.COM:8443",
+			compared: []string{"api.example.com:8443"},
+			want:     models.DestinationScopeInComparedSet,
+		},
+		{
+			name:     "surrounding whitespace is not a difference",
+			dest:     "  192.0.2.10  ",
+			compared: []string{"192.0.2.10"},
+			want:     models.DestinationScopeInComparedSet,
+		},
+		{
+			name:     "blank live destination is undecidable",
+			dest:     "",
+			compared: []string{"192.0.2.10"},
+			want:     models.DestinationScopeUnknown,
+		},
+		{
+			name:     "whitespace-only live destination is undecidable",
+			dest:     "   ",
+			compared: []string{"192.0.2.10"},
+			want:     models.DestinationScopeUnknown,
+		},
+		{
+			name:     "bare port carries no host, undecidable",
+			dest:     ":8080",
+			compared: []string{"192.0.2.10"},
+			want:     models.DestinationScopeUnknown,
+		},
+		{
+			name:     "nil compared set is undecidable, not absence",
+			dest:     "192.0.2.20",
+			compared: nil,
+			want:     models.DestinationScopeUnknown,
+		},
+		{
+			name:     "empty compared set is undecidable, not absence",
+			dest:     "192.0.2.20",
+			compared: []string{},
+			want:     models.DestinationScopeUnknown,
+		},
+		{
+			name:     "one unreadable compared entry vetoes the claim",
+			dest:     "192.0.2.20",
+			compared: []string{"192.0.2.10", ""},
+			want:     models.DestinationScopeUnknown,
+		},
+		{
+			name:     "IPv6 literal with a port matches its bracketless form",
+			dest:     "[fd00::1]:8080",
+			compared: []string{"fd00::1"},
+			want:     models.DestinationScopeInComparedSet,
+		},
+		{
+			name:     "IPv6 literal absent from the set",
+			dest:     "[fd00::2]:8080",
+			compared: []string{"fd00::1", "192.0.2.10"},
+			want:     models.DestinationScopeNotInComparedSet,
+		},
+		{
+			name:     "hostname absent from a set of IPs",
+			dest:     "payments.example.com:8443",
+			compared: []string{"192.0.2.10", "192.0.2.30:9090"},
+			want:     models.DestinationScopeNotInComparedSet,
+		},
+		{
+			// net.SplitHostPort("http://example.com") SUCCEEDS with host
+			// "http". Parsed as an authority, every scheme-carrying value
+			// collapses to its scheme and compares equal to every other —
+			// so a live "http://a.example.com" against a compared
+			// "https://a.example.com" would read as a different upstream,
+			// and two genuinely different hosts on the same scheme would
+			// read as the same one. Refuse to judge instead.
+			name:     "scheme-prefixed live destination is undecidable",
+			dest:     "http://192.0.2.20",
+			compared: []string{"192.0.2.10"},
+			want:     models.DestinationScopeUnknown,
+		},
+		{
+			name:     "scheme-prefixed compared entry vetoes the claim",
+			dest:     "192.0.2.20",
+			compared: []string{"http://192.0.2.10"},
+			want:     models.DestinationScopeUnknown,
+		},
+		{
+			// The trap in full: without the guard both sides normalise to
+			// "http" and the verdict is a confident, wrong "in_compared_set".
+			name:     "two different scheme-prefixed hosts never read as the same upstream",
+			dest:     "http://192.0.2.20",
+			compared: []string{"http://192.0.2.10"},
+			want:     models.DestinationScopeUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := destinationScope(tt.dest, tt.compared); got != tt.want {
+				t.Errorf("destinationScope(%q, %v) = %q, want %q", tt.dest, tt.compared, got, tt.want)
+			}
+		})
+	}
+}
+
+// The guidance a miss carries must follow the evidence: a destination absent
+// from the compared set gets the scope message, everything else keeps the
+// message it had before this feature existed. The cascade phase is never
+// rewritten — it is a separate fact from the scope verdict, and the only one
+// that says how far matching got.
+func TestBuilder_OutOfScopeDestinationGuidance(t *testing.T) {
+	valueDrift := []models.MockFieldDiff{
+		{Path: "body.order_id", Kind: models.DiffKindValueChanged, Expected: "o-1", Actual: "o-2"},
+	}
+	structuralDrift := []models.MockFieldDiff{
+		{Path: "body.new_field", Kind: models.DiffKindMissingInMock, Actual: "1"},
+	}
+
+	tests := []struct {
+		name        string
+		dest        string
+		compared    []string
+		phase       string
+		candidates  int
+		diffs       []models.MockFieldDiff
+		wantScope   string
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			// The reported case: a sidecar's call to a host that none of
+			// the compared mocks target, reported until now as "Request
+			// structure changed since recording".
+			name:       "destination absent from a non-empty compared set",
+			dest:       "192.0.2.20",
+			compared:   []string{"192.0.2.10", "192.0.2.30:9090"},
+			phase:      models.MatchPhaseSchema,
+			candidates: 19,
+			diffs:      structuralDrift,
+			wantScope:  models.DestinationScopeNotInComparedSet,
+			wantContain: []string{
+				"No recorded HTTP mock in the compared set targets 192.0.2.20",
+			},
+			// The causes live in models.OutOfScopeDestinationCauses and are
+			// rendered once per test; per-call guidance must not carry them.
+			wantAbsent: []string{"Request structure changed", "sidecar", "ONE container per session"},
+		},
+		{
+			name:        "destination in the compared set, request drifted structurally",
+			dest:        "192.0.2.10",
+			compared:    []string{"192.0.2.10", "192.0.2.30:9090"},
+			phase:       models.MatchPhaseSchema,
+			candidates:  19,
+			diffs:       structuralDrift,
+			wantScope:   models.DestinationScopeInComparedSet,
+			wantContain: []string{"Request structure changed since recording"},
+			wantAbsent:  []string{"compared set", "sidecar"},
+		},
+		{
+			// Value drift still wins where it should: the destination IS in
+			// the compared set, so the noise hint remains the right advice.
+			name:        "destination in the compared set, only values drifted",
+			dest:        "192.0.2.10",
+			compared:    []string{"192.0.2.10"},
+			phase:       models.MatchPhaseBody,
+			candidates:  4,
+			diffs:       valueDrift,
+			wantScope:   models.DestinationScopeInComparedSet,
+			wantContain: []string{"Only values drifted", "requestbody"},
+			wantAbsent:  []string{"compared set"},
+		},
+		{
+			// ...and loses where it should: diffs against a mock on a
+			// DIFFERENT upstream describe a comparison that never meant
+			// anything, so noising those fields would be a second wrong turn.
+			name:        "out-of-scope destination beats value drift",
+			dest:        "192.0.2.20",
+			compared:    []string{"192.0.2.10"},
+			phase:       models.MatchPhaseBody,
+			candidates:  4,
+			diffs:       valueDrift,
+			wantScope:   models.DestinationScopeNotInComparedSet,
+			wantContain: []string{"in the compared set targets 192.0.2.20"},
+			wantAbsent:  []string{"Only values drifted"},
+		},
+		{
+			name:        "empty compared set keeps the no_mocks message",
+			dest:        "192.0.2.20",
+			compared:    nil,
+			phase:       models.MatchPhaseNoMocks,
+			candidates:  0,
+			wantScope:   models.DestinationScopeUnknown,
+			wantContain: []string{"No recorded mocks were available", "keploy record"},
+			wantAbsent:  []string{"compared set", "sidecar"},
+		},
+		{
+			// Defence in depth: even if a caller contradicts itself by
+			// declaring no_mocks while handing over destinations, the
+			// accurate no_mocks message is not stolen and no verdict is
+			// invented.
+			name:        "no_mocks phase is never scored",
+			dest:        "192.0.2.20",
+			compared:    []string{"192.0.2.10"},
+			phase:       models.MatchPhaseNoMocks,
+			candidates:  0,
+			wantScope:   models.DestinationScopeUnknown,
+			wantContain: []string{"No recorded mocks were available"},
+			wantAbsent:  []string{"compared set"},
+		},
+		{
+			name:        "unknown live destination falls back unchanged",
+			dest:        "",
+			compared:    []string{"192.0.2.10"},
+			phase:       models.MatchPhaseSchema,
+			candidates:  19,
+			diffs:       structuralDrift,
+			wantScope:   models.DestinationScopeUnknown,
+			wantContain: []string{"Request structure changed since recording"},
+			wantAbsent:  []string{"compared set"},
+		},
+		{
+			name:        "unreadable mock destinations fall back unchanged",
+			dest:        "192.0.2.20",
+			compared:    nil, // the HTTP side passes nil when the evidence is not conclusive
+			phase:       models.MatchPhaseSchema,
+			candidates:  19,
+			diffs:       structuralDrift,
+			wantScope:   models.DestinationScopeUnknown,
+			wantContain: []string{"Request structure changed since recording"},
+			wantAbsent:  []string{"compared set"},
+		},
+		{
+			name:        "host:port equivalence keeps today's message",
+			dest:        "192.0.2.30",
+			compared:    []string{"192.0.2.30:9090"},
+			phase:       models.MatchPhaseSchema,
+			candidates:  19,
+			diffs:       structuralDrift,
+			wantScope:   models.DestinationScopeInComparedSet,
+			wantContain: []string{"Request structure changed since recording"},
+			wantAbsent:  []string{"compared set"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := NewReport(ProtocolHTTP, "GET /v1/metrics").
+				WithDestination(tt.dest).
+				WithComparedDestinations(tt.compared).
+				WithPhase(tt.phase, tt.candidates).
+				WithClosest("mock-1", tt.diffs).
+				Build()
+
+			if report.DestinationScope != tt.wantScope {
+				t.Errorf("DestinationScope = %q, want %q", report.DestinationScope, tt.wantScope)
+			}
+			// The scope verdict never overwrites the cascade's stopping
+			// point: both facts have to survive to the report.
+			if report.MatchPhase != tt.phase {
+				t.Errorf("MatchPhase = %q, want the real cascade stop %q", report.MatchPhase, tt.phase)
+			}
+			for _, want := range tt.wantContain {
+				if !strings.Contains(report.NextSteps, want) {
+					t.Errorf("NextSteps missing %q:\n%s", want, report.NextSteps)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(report.NextSteps, absent) {
+					t.Errorf("NextSteps must not contain %q:\n%s", absent, report.NextSteps)
+				}
+			}
+			// THE rule this simplification exists to enforce: local evidence
+			// can never support a claim about the whole recording, so the
+			// words must never appear — in any branch, in any phrasing.
+			for _, forbidden := range []string{"never recorded", "was not recorded", "outside the recorded scope"} {
+				if strings.Contains(strings.ToLower(report.NextSteps), forbidden) {
+					t.Errorf("guidance claims global knowledge (%q):\n%s", forbidden, report.NextSteps)
+				}
+			}
+		})
+	}
+}
+
+// The no-candidate branch of the HTTP builder produces a report with no
+// closest mock at all. The guidance must not then point at "the closest mock",
+// which is not rendered anywhere.
+func TestBuilder_OutOfScopeWithoutAClosestMock(t *testing.T) {
+	report := NewReport(ProtocolHTTP, "GET /v1/metrics").
+		WithDestination("192.0.2.20").
+		WithComparedDestinations([]string{"192.0.2.10"}).
+		WithPhase(models.MatchPhaseSchema, 19).
+		Build()
+
+	if !strings.Contains(report.NextSteps, "in the compared set targets 192.0.2.20") {
+		t.Errorf("out-of-scope verdict lost its lead sentence:\n%s", report.NextSteps)
+	}
+	if strings.Contains(report.NextSteps, "The closest mock is on a different upstream") {
+		t.Errorf("guidance refers to a closest mock that was never picked:\n%s", report.NextSteps)
+	}
+}
+
+// The per-call hint must stay ONE sentence about THIS call. An out-of-scope
+// container produces one miss per outgoing call it makes; the shared causes
+// paragraph used to be inlined here, so a single test could carry the same
+// ~1 KB of prose dozens of times over — in the report, and in the agent's
+// per-miss next_step log field.
+func TestBuilder_OutOfScopeHintIsShortAndPerCall(t *testing.T) {
+	report := NewReport(ProtocolHTTP, "GET /v1/metrics").
+		WithDestination("192.0.2.20").
+		WithComparedDestinations([]string{"192.0.2.10"}).
+		WithPhase(models.MatchPhaseSchema, 19).
+		WithClosest("mock-1", nil).
+		Build()
+
+	// Comfortably under the ~1079 chars the inlined paragraph cost, and in
+	// the same size class as every other hint in the switch.
+	if len(report.NextSteps) > 260 {
+		t.Errorf("per-call hint is %d chars, must stay a short lead sentence:\n%s",
+			len(report.NextSteps), report.NextSteps)
+	}
+	// The one call-specific fact stays.
+	if !strings.Contains(report.NextSteps, "192.0.2.20") {
+		t.Errorf("hint lost the upstream it is about:\n%s", report.NextSteps)
+	}
+	// Everything shared must have moved to the once-per-test block.
+	for _, moved := range []string{"(1)", "(2)", "(3)", "(4)", "sidecar", "per-test mock window"} {
+		if strings.Contains(report.NextSteps, moved) {
+			t.Errorf("shared guidance %q must not be repeated per call:\n%s", moved, report.NextSteps)
+		}
+	}
+}
+
+// The shared block is the whole user-facing explanation, so every cause it has
+// to offer is pinned here.
+//
+//   - Endpoint/config drift is a real, test-affecting problem that is neither
+//     a container-scope mistake nor ignorable; an "app-under-test → re-record,
+//     otherwise → ignore" binary buries it in the ignore bucket.
+//   - Per-test-window misrouting is keploy's OWN failure mode: the compared set
+//     is GetPerTestMocksInWindow() + GetSessionMocks(), so a mock recorded for
+//     this very dependency but timestamped outside the current test's window is
+//     absent from it. Without this cause the message sends the user to
+//     re-record something that is already recorded.
+//   - The container/pod claim must be scoped to Kubernetes. keploy also runs
+//     natively ("keploy record -c 'go run .'") and under docker, where there is
+//     no pod for replay to intercept, and unconditional pod guidance is
+//     literally inapplicable there.
+func TestOutOfScopeDestinationCauses(t *testing.T) {
+	causes := models.OutOfScopeDestinationCauses
+
+	for _, want := range []string{
+		"ONE container per session",
+		"different endpoint than the recording",
+		"align the replay configuration",
+		"outside this test's per-test mock window",
+		"timestamps and windowing before re-recording",
+		"sidecar",
+	} {
+		if !strings.Contains(causes, want) {
+			t.Errorf("shared causes missing %q:\n%s", want, causes)
+		}
+	}
+
+	// The pod model is a Kubernetes fact, stated as one.
+	podIdx := strings.Index(causes, "whole pod")
+	k8sIdx := strings.Index(causes, "In Kubernetes")
+	if k8sIdx < 0 || podIdx < 0 || k8sIdx > podIdx {
+		t.Errorf("the pod/container claim must be qualified as Kubernetes-specific:\n%s", causes)
+	}
+
+	// Ordering: the two causes that are real problems come before the one
+	// that says "ignore it", or a genuine drift lands in the ignore bucket.
+	ignoreIdx := strings.Index(causes, "can be ignored")
+	driftIdx := strings.Index(causes, "different endpoint")
+	windowIdx := strings.Index(causes, "per-test mock window")
+	if driftIdx < 0 || windowIdx < 0 || ignoreIdx < 0 || driftIdx > ignoreIdx || windowIdx > ignoreIdx {
+		t.Errorf("actionable causes must precede the ignore-it clause:\n%s", causes)
+	}
+
+	// Framed as possibilities, never as findings, and never as a claim about
+	// the whole recording.
+	if !strings.Contains(causes, "Likely causes") {
+		t.Errorf("causes must be framed as likely, not asserted:\n%s", causes)
+	}
+	for _, forbidden := range []string{"never recorded", "was not recorded", "outside the recorded scope"} {
+		if strings.Contains(strings.ToLower(causes), forbidden) {
+			t.Errorf("shared causes claim global knowledge (%q):\n%s", forbidden, causes)
+		}
+	}
+	// The caveat has to cover BOTH ways a recorded mock can be missing from
+	// the compared set, or cause (3) contradicts it.
+	if !strings.Contains(causes, "already served earlier in this run, or recorded outside this test's mock window") {
+		t.Errorf("caveat must cover consumption AND windowing:\n%s", causes)
+	}
+	// Every line fits a 100-column terminal unwrapped.
+	for _, line := range strings.Split(causes, "\n") {
+		if len(line) > 100 {
+			t.Errorf("line exceeds 100 columns (%d): %q", len(line), line)
+		}
+	}
+}
+
+// RenderOutOfScopeDestinationCauses indents every line, including blank-ish
+// ones, so a renderer can nest the block without re-wrapping it.
+func TestRenderOutOfScopeDestinationCauses(t *testing.T) {
+	rendered := models.RenderOutOfScopeDestinationCauses("  ")
+	for _, line := range strings.Split(rendered, "\n") {
+		if !strings.HasPrefix(line, "  ") {
+			t.Fatalf("line not indented: %q", line)
+		}
+	}
+	if strings.Count(rendered, "\n") != strings.Count(models.OutOfScopeDestinationCauses, "\n") {
+		t.Errorf("indenting must not add or drop lines")
+	}
+}
+
+// The scope check is diagnostic only. It may set its own verdict and pick the
+// guidance; it must never touch the evidence a user reads to judge the miss
+// (candidate count, closest mock, field diffs, the cascade phase) or override
+// a hint the parser set explicitly.
+func TestBuilder_OutOfScopeDestinationPreservesEvidence(t *testing.T) {
+	diffs := []models.MockFieldDiff{
+		{Path: "path", Kind: models.DiffKindValueChanged, Expected: "/api/orders", Actual: "/v1/metrics"},
+	}
+	report := NewReport(ProtocolHTTP, "GET /v1/metrics").
+		WithDestination("192.0.2.20").
+		WithComparedDestinations([]string{"192.0.2.10"}).
+		WithPhase(models.MatchPhaseSchema, 19).
+		WithClosest("mock-1", diffs).
+		Build()
+
+	if report.CandidateCount != 19 || report.ClosestMock != "mock-1" || len(report.FieldDiffs) != 1 {
+		t.Errorf("scope check must not disturb the evidence: %+v", report)
+	}
+	if !strings.Contains(report.Diff, "/v1/metrics") {
+		t.Errorf("rendered diff lost: %q", report.Diff)
+	}
+	// Triage information: "the cascade stopped for want of schema candidates"
+	// is what a reader needs next, and an earlier cut of this code destroyed
+	// it by writing the verdict over the phase.
+	if report.MatchPhase != models.MatchPhaseSchema {
+		t.Errorf("MatchPhase = %q, want the real cascade stop %q", report.MatchPhase, models.MatchPhaseSchema)
+	}
+
+	explicit := NewReport(ProtocolHTTP, "GET /v1/metrics").
+		WithDestination("192.0.2.20").
+		WithComparedDestinations([]string{"192.0.2.10"}).
+		WithPhase(models.MatchPhaseSchema, 19).
+		WithNextSteps("parser-supplied hint").
+		Build()
+	if explicit.NextSteps != "parser-supplied hint" {
+		t.Errorf("explicit NextSteps overridden: %q", explicit.NextSteps)
+	}
+	if explicit.DestinationScope != models.DestinationScopeNotInComparedSet {
+		t.Errorf("verdict should still record the out-of-scope destination, got %q", explicit.DestinationScope)
+	}
+	if explicit.MatchPhase != models.MatchPhaseSchema {
+		t.Errorf("MatchPhase = %q, want %q", explicit.MatchPhase, models.MatchPhaseSchema)
+	}
+}
+
+// WORDING ONLY. The guidance names the protocol so a mixed-protocol report
+// reads correctly, and stays grammatical when the parser did not set one.
+//
+// The configurations fed in here are NOT reachable in production: HTTP is the
+// only protocol whose recorded mocks carry an upstream authority
+// (models.Mock.RecordedDestination returns ok=false for every non-HTTP kind),
+// so nothing but HTTP can supply a compared set, and no Mongo miss will ever
+// reach this branch. The point of the test is the sentence the branch builds,
+// not the reachability of the inputs — the mechanism is protocol-agnostic by
+// design and this pins the wording for the day a second protocol records a
+// destination.
+func TestBuilder_OutOfScopeDestinationProtocolWording(t *testing.T) {
+	withProto := NewReport(ProtocolMongo, "find users").
+		WithDestination("192.0.2.20:27017").
+		WithComparedDestinations([]string{"mongo.example.com:27017"}).
+		WithPhase(models.MatchPhaseExhausted, 3).Build()
+	if !strings.Contains(withProto.NextSteps, "No recorded MongoDB mock in the compared set targets") {
+		t.Errorf("expected protocol-named scope, got %q", withProto.NextSteps)
+	}
+
+	noProto := NewReport("", "opaque exchange").
+		WithDestination("192.0.2.20:9000").
+		WithComparedDestinations([]string{"192.0.2.10:9000"}).
+		WithPhase(models.MatchPhaseExhausted, 3).Build()
+	if !strings.Contains(noProto.NextSteps, "No recorded mock in the compared set targets") {
+		t.Errorf("expected protocol-less wording, got %q", noProto.NextSteps)
+	}
+}
+
+// A protocol that supplies no destination evidence — every protocol but HTTP
+// today — must leave the verdict empty rather than "in_compared_set". An empty
+// verdict is what stops the agent log from asserting a scope check nobody ran
+// on a Mongo miss.
+func TestBuilder_NoEvidenceLeavesVerdictUnset(t *testing.T) {
+	report := NewReport(ProtocolMongo, "find users").
+		WithDestination("mongo.example.com:27017").
+		WithPhase(models.MatchPhaseExhausted, 7).Build()
+
+	if report.DestinationScope != models.DestinationScopeUnknown {
+		t.Errorf("DestinationScope = %q, want unset for a protocol that supplied no evidence", report.DestinationScope)
+	}
+}
+
+// TestNormalizeDestinationRootedFQDN pins the rooted-FQDN equivalence. A Go
+// client resolving through a search domain presents the name rooted; the
+// recorded mock's Host header carries it unrooted. They are the same upstream,
+// and without the trailing-dot strip the diagnostic reports "no compared mock
+// targets this destination" about a host sitting in the compared set — a false
+// statement, in exactly the in-cluster shape this diagnostic exists to explain.
+func TestNormalizeDestinationRootedFQDN(t *testing.T) {
+	for _, tc := range []struct {
+		name, dest, wantHost string
+		wantOK               bool
+	}{
+		{"rooted fqdn", "svc.ns.svc.cluster.local.", "svc.ns.svc.cluster.local", true},
+		{"unrooted fqdn", "svc.ns.svc.cluster.local", "svc.ns.svc.cluster.local", true},
+		{"rooted with port", "svc.ns.svc.cluster.local.:8443", "svc.ns.svc.cluster.local", true},
+		{"bare dns root", ".", "", false},
+		{"ipv6 literal is untouched", "[fd00::1]:8080", "fd00::1", true},
+		{"scheme-carrying value is refused, not parsed as host \"http\"", "http://example.com", "", false},
+		{"scheme with a port is refused too", "https://example.com:8443", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			host, ok := normalizeDestination(tc.dest)
+			if ok != tc.wantOK || host != tc.wantHost {
+				t.Fatalf("normalizeDestination(%q) = (%q, %v), want (%q, %v)",
+					tc.dest, host, ok, tc.wantHost, tc.wantOK)
+			}
+		})
+	}
+}
+
+// TestRootedAndUnrootedAreTheSameUpstream is the end-to-end form: the verdict
+// must NOT claim absence when the compared set holds the same name unrooted.
+func TestRootedAndUnrootedAreTheSameUpstream(t *testing.T) {
+	if got := destinationScope("svc.ns.svc.cluster.local.",
+		[]string{"svc.ns.svc.cluster.local"}); got == models.DestinationScopeNotInComparedSet {
+		t.Fatal("a rooted FQDN was reported as absent from a compared set that holds it unrooted")
+	}
+}

--- a/pkg/agent/proxy/integrations/mismatch/mismatch.go
+++ b/pkg/agent/proxy/integrations/mismatch/mismatch.go
@@ -22,6 +22,7 @@ package mismatch
 
 import (
 	"fmt"
+	"net"
 	"sort"
 	"strings"
 
@@ -53,6 +54,11 @@ const maxFieldDiffs = 25
 // Builder assembles a models.MockMismatchReport with consistent rendering.
 type Builder struct {
 	report models.MockMismatchReport
+	// comparedDests is the set of upstreams the mocks this miss was actually
+	// compared against were recorded for — evidence for the destination-scope
+	// check in Build(). nil means "the question is undecidable" — see
+	// WithComparedDestinations.
+	comparedDests []string
 }
 
 // NewReport starts a report for one missed call. actualSummary should be the
@@ -71,6 +77,76 @@ func NewReport(protocol, actualSummary string) *Builder {
 // calls several services.
 func (b *Builder) WithDestination(dest string) *Builder {
 	b.report.Destination = dest
+	return b
+}
+
+// WithComparedDestinations supplies the upstream authority of every mock this
+// miss was actually compared against, so Build() can tell a call whose
+// upstream is absent from that set apart from a drifted request.
+//
+// WHY THIS EXISTS — the sibling-container scope asymmetry (KUBERNETES; the
+// check itself is mode-neutral, and so is the guidance it selects — see
+// models.OutOfScopeDestinationCauses, which names the pod model as a
+// Kubernetes specific because native and docker runs have no pod):
+//
+// keploy's RECORD path arms exactly ONE container: the one the user named in
+// the record request (RecordRequest.Container). The DS agent honours it
+// precisely — sibling containers in the same pod log "matchedSession": false
+// and nothing they send is ever captured. The REPLAY path has no such
+// narrowing: the sandbox pod's keploy-agent intercepts the WHOLE pod network
+// namespace, so a sibling container's egress IS intercepted, finds no mock
+// (there was never one to find), and gets reported to the user as a mock
+// mismatch.
+//
+// That is the shape the check was built from, not the limit of what it
+// catches: a destination absent from the compared set is equally the
+// signature of endpoint/config drift between the recording and replay
+// environments, and of a per-test mock window that excluded the very mock
+// this call needed — both of which happen in every execution mode.
+//
+// Before this check, such a miss fell through to the generic "Request
+// structure changed since recording. Re-record the test set..." hint, which
+// is false twice over: nothing changed, and the closest mock it pointed at
+// was on a different upstream entirely. In one reported recording that was 23 of
+// 28 unmatched calls, each diffed against a mock for another host — noise
+// that buried the 5 misses that were genuinely the application's and cost two
+// engineers real debugging time.
+//
+// WHAT THE VERDICT MAY AND MAY NOT SAY. It speaks for the compared set and
+// nothing wider. It must never be rendered as "this destination was never
+// recorded": that is a claim about the whole recording, and local state
+// cannot support it — protocols that consume mocks on match (HTTP deletes
+// per-test mocks via DeleteFilteredMock, and the agent then strips them from
+// every later pool) lose a host from their pools the moment its last mock is
+// served, so "absent from what survives" and "never recorded" are different
+// facts. Every attempt to assert the stronger one produced a false claim
+// about a real upstream. The weaker claim is always true, and it still
+// removes both things that misled the reader: the "re-record, the request
+// structure changed" advice, and leading with a diff against another host.
+//
+// The interception itself is deliberately NOT changed here: narrowing it
+// needs cgroup-scoped BPF (the excluded_pids map is keyed by ROOT-namespace
+// TGIDs, which the replay agent — living in the pod's PID namespace — cannot
+// enumerate from /proc), and it is harmless anyway, because k8s-proxy
+// attaches a deny-all-egress NetworkPolicy to every replay pod, so the
+// sibling's call cannot reach its upstream either way. Only the REPORT was
+// harmful, so only the REPORT is fixed. This is diagnostic-only by
+// construction: it can change what a miss SAYS, never whether a call matches.
+//
+// Callers must pass nil whenever they cannot read a destination off EVERY
+// mock they compared — nil means undecidable, and an undecidable check leaves
+// today's message exactly as it was. One unreadable mock is enough: it could
+// be the very mock that targeted the live call.
+//
+// Protocol reach: the mechanism is protocol-agnostic — any parser that can
+// name the upstreams of its compared mocks may feed it — but HTTP is the only
+// caller today, because it is the only protocol whose recorded mocks carry a
+// destination at all (Mongo/MySQL/Postgres/Generic store wire payloads with
+// no authority in them). Every other protocol therefore leaves the verdict at
+// models.DestinationScopeUnknown, and their reports read exactly as they did
+// before this check existed.
+func (b *Builder) WithComparedDestinations(dests []string) *Builder {
+	b.comparedDests = dests
 	return b
 }
 
@@ -122,6 +198,22 @@ func (b *Builder) WithRenderedRequests(mockReq, receivedReq string) *Builder {
 // and returns the finished report.
 func (b *Builder) Build() *models.MockMismatchReport {
 	r := b.report
+	// Destination scope is decided BEFORE the next-steps default so the
+	// verdict and the guidance can never disagree.
+	//
+	// It is written to its OWN field, never over MatchPhase. The phase is the
+	// cascade's stopping point (no_schema_candidates / body_mismatch /
+	// strict_noise_reject), which is what tells a reader how far matching got
+	// — triage information that an earlier cut of this code destroyed by
+	// overwriting it, leaving the CLI printing "[match stopped at:
+	// destination_not_recorded]", a phase that never ran.
+	//
+	// MatchPhaseNoMocks is left unscored: "there were no mocks at all" has
+	// its own accurate message, and there is no compared set to speak about,
+	// so the question is not even asked.
+	if r.MatchPhase != models.MatchPhaseNoMocks {
+		r.DestinationScope = destinationScope(r.Destination, b.comparedDests)
+	}
 	if r.Diff == "" {
 		r.Diff = RenderFieldDiffs(r.FieldDiffs)
 	}
@@ -168,6 +260,32 @@ func defaultNextSteps(r *models.MockMismatchReport) string {
 	switch {
 	case r.MatchPhase == models.MatchPhaseNoMocks:
 		return "No recorded mocks were available to match against for this protocol in the selected test set. Re-record the test set with 'keploy record'."
+	case r.DestinationScope == models.DestinationScopeNotInComparedSet:
+		// Ahead of the value-drift branch on purpose: when nothing in the
+		// compared set targets this upstream, the closest mock belongs to a
+		// DIFFERENT one, so its field diffs describe a comparison that was
+		// never meaningful. Telling the user to noise those fields would be a
+		// second misdirection stacked on the first.
+		scope := "recorded mock"
+		if r.Protocol != "" {
+			scope = "recorded " + r.Protocol + " mock"
+		}
+		// ONE sentence — the only part of this guidance that differs between
+		// two out-of-scope misses is WHICH upstream they went to. The likely
+		// causes and the caveat are identical for every one of them and live
+		// in models.OutOfScopeDestinationCauses, which renderers emit once
+		// per test. An out-of-scope container produces one miss per outgoing
+		// call it makes (23 of 28 unmatched calls in the recording this was
+		// built from); the paragraph that used to be inlined here was ~1 KB,
+		// repeated per miss, in the report AND in the agent's per-miss
+		// next_step log field.
+		lead := fmt.Sprintf("No %s in the compared set targets %s.", scope, r.Destination)
+		if r.ClosestMock != "" {
+			// Only claimed when a closest mock was actually picked; the
+			// no-candidate branch of the HTTP builder renders no diff at all.
+			lead += " The closest mock is on a different upstream, so its differences are not evidence about this call."
+		}
+		return lead
 	case onlyValueDrift:
 		paths := make([]string, 0, len(r.FieldDiffs))
 		// Body diffs are reported "body."-prefixed for readability, but HTTP
@@ -293,4 +411,112 @@ func QueryParamDiffs(recorded, live map[string][]string) []models.MockFieldDiff 
 
 func sortDiffs(d []models.MockFieldDiff) {
 	sort.Slice(d, func(i, j int) bool { return d[i].Path < d[j].Path })
+}
+
+// destinationScope decides whether `dest` is absent from, present in, or
+// simply unjudgeable against the destinations of the mocks this miss was
+// compared against. It returns one of the models.DestinationScope* constants.
+//
+// A wrong verdict would be exactly the same class of misdirection this check
+// exists to remove, so it is deliberately biased toward silence:
+// models.DestinationScopeNotInComparedSet is returned only when all three
+// hold:
+//
+//   - the live destination is known. Parsers pass "" when they cannot tell
+//     which upstream a call targeted; "" is undecidable, never "absent".
+//   - the compared set is non-empty. An empty set means either no mocks at
+//     all (models.MatchPhaseNoMocks owns that case) or mocks whose
+//     destination could not be read — neither is evidence of anything.
+//   - no compared entry matches on the bare host (port stripped, case and
+//     trailing DNS root normalised).
+//
+// Anything else that leaves the question open returns
+// models.DestinationScopeUnknown, which is distinct from
+// models.DestinationScopeInComparedSet on purpose: "we checked and the host
+// was among the compared mocks" and "we could not check" are different facts,
+// and reporting the second as the first is an unchecked negative asserted as
+// evidence.
+//
+// Host vs host:port: recorded HTTP mocks store the authority exactly as the
+// app put it in the Host header, which is inconsistent by construction — mock
+// sets in the field carry both "192.0.2.10" (default port elided) and
+// "192.0.2.30:9090" (explicit) — and the live Host header for that same
+// upstream may or may not carry the port. So a port-only difference must never
+// produce the claim, and comparison is on the BARE HOST alone: a call to a
+// compared host on a new port is reported as in-set rather than out. (An
+// authority-equality arm would be dead code next to it — normalizeDestination
+// derives the host from the authority by stripping the port, so two equal
+// authorities always have equal hosts.) The asymmetry is intentional; the cost
+// of staying quiet is a slightly vaguer message, the cost of over-claiming is
+// sending an operator after an upstream difference that is not there.
+func destinationScope(dest string, compared []string) string {
+	liveHost, ok := normalizeDestination(dest)
+	if !ok || len(compared) == 0 {
+		return models.DestinationScopeUnknown
+	}
+	for _, c := range compared {
+		cHost, ok := normalizeDestination(c)
+		if !ok {
+			// An unreadable compared entry could be the live destination, so
+			// nothing can be concluded. Callers are expected to pass nil
+			// rather than a partial set; this is the belt-and-braces.
+			return models.DestinationScopeUnknown
+		}
+		if cHost == liveHost {
+			return models.DestinationScopeInComparedSet
+		}
+	}
+	return models.DestinationScopeNotInComparedSet
+}
+
+// normalizeDestination reduces a destination to the one comparable form the
+// verdict is decided on: the bare host, lowercased, with any port stripped.
+// ok is false for anything that carries no usable host identity — blank,
+// whitespace, a bare port like ":8080", or a scheme-carrying string — which
+// the caller must treat as undecidable.
+func normalizeDestination(dest string) (host string, ok bool) {
+	authority := strings.ToLower(strings.TrimSpace(dest))
+	if authority == "" {
+		return "", false
+	}
+	// A scheme-prefixed value is not an authority and must not be parsed as
+	// one: net.SplitHostPort("http://example.com") SUCCEEDS, yielding host
+	// "http", which would make every scheme-carrying destination compare
+	// equal to every other and produce a confident, wrong verdict. No
+	// in-tree producer emits one today — models.RecordedDestination returns
+	// url.Parse's Host, and the live side reads request.Host /
+	// request.URL.Host, all scheme-free — but this is the exact failure
+	// class the feature exists to prevent, so it is refused rather than
+	// guessed at.
+	if strings.Contains(authority, "://") {
+		return "", false
+	}
+	// net.SplitHostPort is used rather than a LastIndex(":") so bracketed IPv6
+	// literals ("[::1]:8080") split correctly and unbracketed ones
+	// ("fd00::1", which has many colons and no port) fall through unsplit.
+	host = authority
+	if h, _, err := net.SplitHostPort(authority); err == nil {
+		// A successful split with an empty host means the caller handed us a
+		// bare port (":8080") — there is no upstream identity in that, so it
+		// falls through to the "not ok" check below rather than comparing as
+		// the literal ":8080".
+		host = h
+	}
+	host = strings.Trim(host, "[]")
+	// Strip the root label of a rooted FQDN. A Go client that resolves through a
+	// search-domain-qualified name can present "svc.ns.svc.cluster.local." while
+	// the recorded mock's Host header carries the same name unrooted — they are
+	// the SAME upstream, and DNS says so, but a byte comparison does not. Without
+	// this the verdict is FALSE for exactly the in-cluster names this diagnostic
+	// exists to explain: it would report "no compared mock targets this
+	// destination" about an upstream sitting in the compared set. A lone "." is
+	// the DNS root and carries no upstream identity, so it falls through to the
+	// empty check below.
+	if len(host) > 1 {
+		host = strings.TrimSuffix(host, ".")
+	}
+	if host == "" || host == "." {
+		return "", false
+	}
+	return host, true
 }

--- a/pkg/agent/proxy/mock_mismatch_log_test.go
+++ b/pkg/agent/proxy/mock_mismatch_log_test.go
@@ -1,0 +1,76 @@
+// Package proxy — the one agent-wide mock-mismatch log line must not assert a
+// negative it never checked.
+//
+// destination_scope is only meaningful for a report whose parser supplied
+// destination evidence. HTTP is the only protocol that does today (nothing
+// else records an upstream authority in its mocks), so an unconditional field
+// printed a negative verdict on every mongo/mysql/generic/pulsar miss — which
+// reads as "we checked, and it was fine" for a check that never ran.
+package proxy
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func mismatchLogFields(t *testing.T, report *models.MockMismatchReport) map[string]any {
+	t.Helper()
+	core, logs := observer.New(zap.WarnLevel)
+	p := &Proxy{logger: zap.New(core), errChannel: make(chan error, 4)}
+
+	p.sendMockNotFoundError(models.NewMockMismatchError(models.ErrNoMockMatched, report))
+
+	entries := logs.All()
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly one mismatch log entry, got %d", len(entries))
+	}
+	return entries[0].ContextMap()
+}
+
+func TestSendMockNotFoundError_ScopeFieldOmittedWithoutEvidence(t *testing.T) {
+	// A Mongo miss: no destination evidence was ever gathered.
+	fields := mismatchLogFields(t, &models.MockMismatchReport{
+		Protocol:      "MongoDB",
+		Destination:   "mongo.example.com:27017",
+		ActualSummary: "find users",
+		MatchPhase:    models.MatchPhaseExhausted,
+	})
+
+	if _, present := fields["destination_scope"]; present {
+		t.Errorf("unchecked destination scope must be absent from the log, got %v", fields["destination_scope"])
+	}
+	if fields["match_phase"] != models.MatchPhaseExhausted {
+		t.Errorf("match_phase = %v, want %q", fields["match_phase"], models.MatchPhaseExhausted)
+	}
+}
+
+func TestSendMockNotFoundError_ScopeFieldReflectsTheVerdict(t *testing.T) {
+	for _, scope := range []string{
+		models.DestinationScopeNotInComparedSet,
+		models.DestinationScopeInComparedSet,
+	} {
+		t.Run(scope, func(t *testing.T) {
+			fields := mismatchLogFields(t, &models.MockMismatchReport{
+				Protocol:         "HTTP",
+				Destination:      "192.0.2.20",
+				ActualSummary:    "GET /v1/metrics",
+				MatchPhase:       models.MatchPhaseSchema,
+				DestinationScope: scope,
+			})
+			got, present := fields["destination_scope"]
+			if !present {
+				t.Fatalf("an answered scope check must be logged; fields: %v", fields)
+			}
+			if got != scope {
+				t.Errorf("destination_scope = %v, want %v", got, scope)
+			}
+			// The cascade's stopping point survives alongside the verdict.
+			if fields["match_phase"] != models.MatchPhaseSchema {
+				t.Errorf("match_phase = %v, want %q", fields["match_phase"], models.MatchPhaseSchema)
+			}
+		})
+	}
+}

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -3638,17 +3638,25 @@ func (p *Proxy) GetMockErrors(_ context.Context) ([]models.UnmatchedCall, error)
 		if parserErr, ok := err.(models.ParserError); ok && parserErr.ParserErrorType == models.ErrMockNotFound {
 			if parserErr.MismatchReport != nil {
 				errs = append(errs, models.UnmatchedCall{
-					Protocol:       parserErr.MismatchReport.Protocol,
-					ActualSummary:  parserErr.MismatchReport.ActualSummary,
-					Destination:    parserErr.MismatchReport.Destination,
-					ClosestMock:    parserErr.MismatchReport.ClosestMock,
-					Diff:           parserErr.MismatchReport.Diff,
-					NextSteps:      parserErr.MismatchReport.NextSteps,
-					MatchPhase:     parserErr.MismatchReport.MatchPhase,
-					CandidateCount: parserErr.MismatchReport.CandidateCount,
-					FieldDiffs:     parserErr.MismatchReport.FieldDiffs,
-					ClosestMockReq: parserErr.MismatchReport.ClosestMockReq,
-					ReceivedReq:    parserErr.MismatchReport.ReceivedReq,
+					Protocol:      parserErr.MismatchReport.Protocol,
+					ActualSummary: parserErr.MismatchReport.ActualSummary,
+					Destination:   parserErr.MismatchReport.Destination,
+					ClosestMock:   parserErr.MismatchReport.ClosestMock,
+					Diff:          parserErr.MismatchReport.Diff,
+					NextSteps:     parserErr.MismatchReport.NextSteps,
+					MatchPhase:    parserErr.MismatchReport.MatchPhase,
+					// Separate axis from MatchPhase: the phase still reports
+					// where the cascade stopped, the scope says whether any
+					// mock this miss was compared against targeted that
+					// upstream. Deliberately a statement about the COMPARED
+					// SET, not about the whole recording — mocks served
+					// earlier in the run are no longer in that set, so a
+					// wider claim would be false.
+					DestinationScope: parserErr.MismatchReport.DestinationScope,
+					CandidateCount:   parserErr.MismatchReport.CandidateCount,
+					FieldDiffs:       parserErr.MismatchReport.FieldDiffs,
+					ClosestMockReq:   parserErr.MismatchReport.ClosestMockReq,
+					ReceivedReq:      parserErr.MismatchReport.ReceivedReq,
 				})
 			} else if errors.Is(parserErr.Err, models.ErrNoMockMatched) {
 				// A genuine miss without a structured report must still reach
@@ -3701,14 +3709,35 @@ func (p *Proxy) sendMockNotFoundError(err error) {
 	// got, instead of each parser logging it differently (or not at all). The
 	// per-parser decode loggers stay at Debug to avoid double-logging.
 	if r := proxyErr.MismatchReport; r != nil {
-		p.logger.Warn("mock mismatch: no matching mock for outgoing call",
+		fields := []zap.Field{
 			zap.String("protocol", r.Protocol),
 			zap.String("destination", r.Destination),
 			zap.String("actual", r.ActualSummary),
 			zap.String("match_phase", r.MatchPhase),
 			zap.Int("candidates", r.CandidateCount),
 			zap.String("closest", r.ClosestMock),
-			zap.String("next_step", r.NextSteps))
+			zap.String("next_step", r.NextSteps),
+		}
+		// destination_scope is greppable in a node-wide agent log:
+		// "not_in_compared_set" is the one value that says "nothing this miss
+		// was compared against even targets that upstream" — in Kubernetes
+		// most often a sibling container's egress (replay intercepts the whole
+		// pod while record armed only the container the user named), and in
+		// any mode endpoint drift or a per-test mock window that excluded the
+		// mock. models.OutOfScopeDestinationCauses carries the user-facing
+		// wording; the log field is the machine-greppable half.
+		//
+		// A string, and emitted ONLY when the question was actually answered.
+		// The mechanism is protocol-agnostic, but HTTP is the only protocol
+		// that supplies destination evidence today (nothing else records an
+		// upstream authority in its mocks), so an unconditional boolean
+		// printed a negative on every mongo/mysql/generic miss — an unchecked
+		// negative that reads as "we checked, and it was fine". Absent means
+		// "not established", which is the truth.
+		if r.DestinationScope != models.DestinationScopeUnknown {
+			fields = append(fields, zap.String("destination_scope", r.DestinationScope))
+		}
+		p.logger.Warn("mock mismatch: no matching mock for outgoing call", fields...)
 	} else {
 		p.logger.Warn("mock mismatch: no matching mock for outgoing call (no structured report)", zap.Error(err))
 	}

--- a/pkg/models/errors.go
+++ b/pkg/models/errors.go
@@ -3,6 +3,7 @@ package models
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 type AppError struct {
@@ -73,21 +74,126 @@ const (
 	MatchPhaseProtoError = "protocol_error"       // matching aborted on a protocol/decode error
 )
 
+// Destination-scope verdicts recorded on MockMismatchReport.DestinationScope.
+// They answer a question the match cascade cannot: did any of the mocks this
+// miss was actually compared against target the same upstream as the live
+// call? A "no" is the signature of a call that was never in scope for the
+// compared set — in Kubernetes typically a sibling container's egress, which
+// replay intercepts pod-wide while record arms only the one container the
+// user named, but equally endpoint/config drift between the recording and
+// replay environments, or a per-test mock window that excluded the mock this
+// call needed. See OutOfScopeDestinationCauses for the user-facing wording.
+//
+// The claim is deliberately LOCAL. Keploy cannot say from here that a
+// destination was "never recorded": per-test mocks are consumed on match and
+// stripped from every later pool, so a host whose mocks have all been served
+// is missing from the pool while having been recorded all along. The verdict
+// therefore speaks only for the compared set, which is evidence the report
+// builder holds in its hand.
+//
+// Deliberately a three-state field, not a bool. "We checked and the
+// destination was in the compared set" and "we could not check" are different
+// facts, and collapsing them would make every protocol that never supplies
+// destination evidence (Mongo, MySQL, Generic, ...) read as "checked, and it
+// WAS there" — an unchecked negative asserted as a fact. The scope verdict
+// travels ALONGSIDE MatchPhase, never on top of it: MatchPhase keeps
+// reporting where the cascade actually stopped, which is the triage
+// information a report reader needs next.
+const (
+	// DestinationScopeUnknown — no verdict. Either the protocol supplied no
+	// destination evidence, or the evidence was not conclusive. Rendered as
+	// an absent field everywhere; never as a negative.
+	DestinationScopeUnknown = ""
+	// DestinationScopeInComparedSet — at least one mock the matcher compared
+	// against targets this destination, so the miss is a genuine
+	// drift/candidate problem.
+	DestinationScopeInComparedSet = "in_compared_set"
+	// DestinationScopeNotInComparedSet — no mock in the compared set targets
+	// this destination. It is NOT a claim that the destination was never
+	// recorded; it is the strongest statement local evidence supports.
+	DestinationScopeNotInComparedSet = "not_in_compared_set"
+)
+
+// OutOfScopeDestinationCauses explains a DestinationScopeNotInComparedSet
+// miss: why nothing the matcher compared against targeted that upstream, and
+// what to do about it.
+//
+// It is STATIC text and renderers MUST emit it ONCE PER TEST, never once per
+// missed call. A single out-of-scope container produces one such miss per
+// outgoing call it makes — 23 of 28 unmatched calls in the recording this
+// diagnostic was built from — and repeating a paragraph per call buries the
+// per-call facts (which upstream, which cascade stop) under kilobytes of
+// identical prose. The per-call NextSteps therefore carries only the sentence
+// that is specific to that call; everything shared lives here.
+//
+// Deliberately MODE-NEUTRAL. Keploy runs natively ("keploy record -c 'go run
+// .'"), under docker, and in Kubernetes; only the Kubernetes mode has a pod
+// whose sibling containers replay intercepts while record armed just one. The
+// pod model is named as a Kubernetes specific rather than asserted at every
+// user, so a native or docker user is not handed guidance that cannot apply
+// to them.
+//
+// Cause (3) is keploy's own failure mode and has to be listed: the compared
+// set is GetPerTestMocksInWindow() + GetSessionMocks(), so a per-test mock
+// recorded for this very dependency but timestamped outside the current
+// test's window is not in it and never was — a miss that is neither a
+// container-scope mistake, nor endpoint drift, nor ignorable, and that the
+// other three causes would send the user off to re-record for nothing.
+//
+// Wrapped at 100 columns; renderers indent it, they do not re-wrap it.
+const OutOfScopeDestinationCauses = `Out-of-scope destinations: no mock in the compared set targeted the upstream these calls went to.
+Likely causes:
+  (1) The call came from a process or container Keploy was not recording. In Kubernetes, Keploy
+      records ONE container per session — the one named when recording started — while replay
+      intercepts the whole pod, so a sibling container's egress arrives with no mock behind it.
+      Re-record with that container selected.
+  (2) The replay environment points the application at a different endpoint than the recording
+      environment did (config/env drift: another service address or port). Compare this host with
+      the one recorded for the same dependency and align the replay configuration, or re-record
+      against the new endpoint.
+  (3) The mock for this dependency was recorded but fell outside this test's per-test mock window,
+      so it was never in the set this call was compared against. Check the test set's mock
+      timestamps and windowing before re-recording.
+  (4) The call belongs to a sidecar or agent that is not part of the application under test. That
+      miss is expected and can be ignored.
+Mocks already served earlier in this run, or recorded outside this test's mock window, are no
+longer in the compared set — this describes what was compared for these calls, not the whole
+recording.`
+
+// RenderOutOfScopeDestinationCauses returns OutOfScopeDestinationCauses with
+// prefix prepended to every line, so the CLI and the file report can each
+// indent the block to their own surrounding style without either of them
+// re-wrapping (and re-drifting) the text.
+func RenderOutOfScopeDestinationCauses(prefix string) string {
+	lines := strings.Split(OutOfScopeDestinationCauses, "\n")
+	for i, line := range lines {
+		lines[i] = prefix + line
+	}
+	return strings.Join(lines, "\n")
+}
+
 // MockMismatchReport describes what didn't match when a mock lookup fails.
 // It is populated by protocol-specific matching logic and surfaced to the user
 // in the CLI mismatch table, the test-report yaml (FailureInfo.UnmatchedCalls)
 // and the platform/UI APIs. Protocol parsers should build it via
 // pkg/agent/proxy/integrations/mismatch so vocabulary stays uniform.
 type MockMismatchReport struct {
-	Protocol       string          // "HTTP", "MySQL", "PostgreSQL", "MongoDB", "gRPC", "HTTP/2", "Generic", "DNS"
-	ActualSummary  string          // Brief description of the actual request
-	Destination    string          // outgoing call's destination/domain (HTTP Host, or host:port) — identifies WHICH upstream missed
-	ClosestMock    string          // Name of the closest mock (empty if none)
-	Diff           string          // Human-readable diff (protocol-specific)
-	NextSteps      string          // Actionable suggestion for the user
-	MatchPhase     string          // how far the match cascade got (MatchPhase* constants)
-	CandidateCount int             // protocol mocks considered before giving up
-	FieldDiffs     []MockFieldDiff // field-level diffs vs the closest mock, noise-vocabulary paths
+	Protocol      string // "HTTP", "MySQL", "PostgreSQL", "MongoDB", "gRPC", "HTTP/2", "Generic", "DNS"
+	ActualSummary string // Brief description of the actual request
+	Destination   string // outgoing call's destination/domain (HTTP Host, or host:port) — identifies WHICH upstream missed
+	ClosestMock   string // Name of the closest mock (empty if none)
+	Diff          string // Human-readable diff (protocol-specific)
+	NextSteps     string // Actionable suggestion for the user
+	MatchPhase    string // how far the match cascade got (MatchPhase* constants)
+	// DestinationScope is the verdict on whether any mock the matcher
+	// compared against targeted this call's upstream (DestinationScope*
+	// constants; empty means the question was never answered). It is a
+	// SEPARATE axis from MatchPhase on purpose — a call whose upstream is
+	// absent from the compared set still has a real cascade stop, and
+	// overwriting the phase with the verdict destroys that triage fact.
+	DestinationScope string
+	CandidateCount   int             // protocol mocks considered before giving up
+	FieldDiffs       []MockFieldDiff // field-level diffs vs the closest mock, noise-vocabulary paths
 	// ClosestMockReq / ReceivedReq are the FULL rendered requests for the CLI
 	// side-by-side diff (left = recorded mock, right = live request). They are
 	// the human-facing complement to FieldDiffs (machine-readable): the

--- a/pkg/models/mock.go
+++ b/pkg/models/mock.go
@@ -2,6 +2,8 @@ package models
 
 import (
 	"encoding/gob"
+	"net/url"
+	"strings"
 	"time"
 
 	"go.keploy.io/server/v3/pkg/models/mysql"
@@ -221,6 +223,54 @@ type TestModeInfo struct {
 
 func (m *Mock) GetKind() string {
 	return string(m.Kind)
+}
+
+// RecordedDestination reads the upstream authority a recorded mock was
+// captured against — "which host did this mock's call go to?" — for the
+// destination-scope diagnostic (see pkg/agent/proxy/integrations/mismatch).
+//
+// ok is false when the answer is UNKNOWN, and the caller must treat that as
+// "undecidable", never as "no destination": one mock whose host cannot be
+// read could be the very mock that targeted the live call, so it has to veto
+// the verdict rather than count as evidence. Today only HTTP mocks carry a
+// readable destination — the other protocols' recorded specs keep no
+// authority at all (Mongo/MySQL/Postgres store wire payloads, Generic stores
+// opaque buffers) — so every non-HTTP kind answers "unknown".
+//
+// Header Host first, URL authority second: the recorder stores an HTTP
+// request path-only ("/api/orders?id=90") with the authority in the
+// Host header, but a mock captured through a forward proxy carries an
+// absolute URL instead.
+func (m *Mock) RecordedDestination() (string, bool) {
+	if m == nil || m.Kind != Kind(HTTP) || m.Spec.HTTPReq == nil {
+		return "", false
+	}
+	// Case-insensitive lookup: recorded mock headers are a plain map (no
+	// textproto canonicalisation), so the key's case depends on whichever
+	// recorder wrote it.
+	//
+	// The two conventional spellings are probed directly first: the fallback
+	// scan below is O(headers) with a strings.EqualFold per key, and a real
+	// recorded request carries far more headers than a test fixture does, so
+	// the scan's cost grows with them while these two lookups do not. The
+	// scan still runs for anything else ("HOST", "hOst"), so no recording
+	// stops being readable.
+	h := m.Spec.HTTPReq.Header
+	if v := h["Host"]; v != "" {
+		return v, true
+	}
+	if v := h["host"]; v != "" {
+		return v, true
+	}
+	for k, v := range h {
+		if strings.EqualFold(k, "Host") && v != "" {
+			return v, true
+		}
+	}
+	if u, err := url.Parse(m.Spec.HTTPReq.URL); err == nil && u.Host != "" {
+		return u.Host, true
+	}
+	return "", false
 }
 
 type MockSpec struct {

--- a/pkg/models/mock_destination_test.go
+++ b/pkg/models/mock_destination_test.go
@@ -1,0 +1,92 @@
+package models
+
+import "testing"
+
+// RecordedDestination is the evidence source for the destination-scope
+// diagnostic, so its ok=false cases matter as much as its values: each one
+// means "undecidable", and a caller that read them as "no destination" would
+// manufacture a false absence claim out of a mock it simply could not read.
+func TestMockRecordedDestination(t *testing.T) {
+	httpMock := func(rawURL string, header map[string]string) *Mock {
+		return &Mock{
+			Kind: Kind(HTTP),
+			Spec: MockSpec{HTTPReq: &HTTPReq{Method: "GET", URL: rawURL, Header: header}},
+		}
+	}
+
+	tests := []struct {
+		name   string
+		mock   *Mock
+		want   string
+		wantOK bool
+	}{
+		{
+			name:   "host header on a path-only URL (how the recorder writes one)",
+			mock:   httpMock("/api/orders?id=90", map[string]string{"Host": "192.0.2.10", "Accept": "*/*"}),
+			want:   "192.0.2.10",
+			wantOK: true,
+		},
+		{
+			name:   "lowercase host key is still a Host header",
+			mock:   httpMock("/a", map[string]string{"host": "192.0.2.30:9090"}),
+			want:   "192.0.2.30:9090",
+			wantOK: true,
+		},
+		{
+			// The direct "Host"/"host" probes are a fast path, not the whole
+			// lookup: an unconventional spelling must still resolve, or a
+			// recording quietly stops being readable and vetoes the verdict
+			// for its whole test set.
+			name:   "unconventional header casing still resolves via the scan",
+			mock:   httpMock("/a", map[string]string{"Accept": "*/*", "HOST": "billing.svc.cluster.local"}),
+			want:   "billing.svc.cluster.local",
+			wantOK: true,
+		},
+		{
+			name:   "an empty conventional key does not shadow a populated one",
+			mock:   httpMock("/a", map[string]string{"Host": "", "host": "192.0.2.40"}),
+			want:   "192.0.2.40",
+			wantOK: true,
+		},
+		{
+			name:   "absolute URL supplies the authority when no header does",
+			mock:   httpMock("http://192.0.2.20:8080/v1/metrics", nil),
+			want:   "192.0.2.20:8080",
+			wantOK: true,
+		},
+		{
+			name:   "empty Host header falls through to the URL",
+			mock:   httpMock("http://192.0.2.20:8080/v1/metrics", map[string]string{"Host": ""}),
+			want:   "192.0.2.20:8080",
+			wantOK: true,
+		},
+		{
+			name: "path-only URL with no Host header is undecidable",
+			mock: httpMock("/internal/health", map[string]string{"Accept": "*/*"}),
+		},
+		{
+			name: "HTTP mock with no request spec is undecidable",
+			mock: &Mock{Kind: Kind(HTTP)},
+		},
+		{
+			// Mongo/MySQL/Postgres/Generic record wire payloads with no
+			// authority in them; claiming "no destination" for them would be
+			// asserting an unchecked negative.
+			name: "non-HTTP kinds are undecidable",
+			mock: &Mock{Kind: Mongo, Spec: MockSpec{}},
+		},
+		{
+			name: "nil mock is undecidable",
+			mock: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := tt.mock.RecordedDestination()
+			if got != tt.want || ok != tt.wantOK {
+				t.Errorf("RecordedDestination() = (%q, %v), want (%q, %v)", got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}

--- a/pkg/models/testrun.go
+++ b/pkg/models/testrun.go
@@ -138,9 +138,17 @@ type UnmatchedCall struct {
 	// render structured field-level drift instead of an opaque string. Paths
 	// in FieldDiffs use the noise-config vocabulary and can be copied
 	// verbatim into test.globalNoise / spec.assertions.noise.
-	MatchPhase     string          `json:"match_phase,omitempty" yaml:"match_phase,omitempty"`
-	CandidateCount int             `json:"candidate_count,omitempty" yaml:"candidate_count,omitempty"`
-	FieldDiffs     []MockFieldDiff `json:"field_diffs,omitempty" yaml:"field_diffs,omitempty"`
+	MatchPhase string `json:"match_phase,omitempty" yaml:"match_phase,omitempty"`
+	// DestinationScope mirrors MockMismatchReport.DestinationScope
+	// (DestinationScope* constants). It is a separate axis from MatchPhase:
+	// "not_in_compared_set" says no mock this miss was compared against
+	// targeted the call's upstream, while MatchPhase still reports where the
+	// cascade stopped. Omitted when empty — the protocol supplied no
+	// destination evidence, and an absent field is the only honest rendering
+	// of "we did not check".
+	DestinationScope string          `json:"destination_scope,omitempty" yaml:"destination_scope,omitempty"`
+	CandidateCount   int             `json:"candidate_count,omitempty" yaml:"candidate_count,omitempty"`
+	FieldDiffs       []MockFieldDiff `json:"field_diffs,omitempty" yaml:"field_diffs,omitempty"`
 	// ClosestMockReq / ReceivedReq carry the FULL rendered requests for the CLI
 	// side-by-side whole-mock diff (left = mock, right = live request).
 	ClosestMockReq string `json:"closest_mock_req,omitempty" yaml:"closest_mock_req,omitempty"`

--- a/pkg/service/replay/mismatch_render_test.go
+++ b/pkg/service/replay/mismatch_render_test.go
@@ -1,0 +1,160 @@
+package replay
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// captureStdout runs fn with os.Stdout redirected and returns what it printed.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+	fn()
+	_ = w.Close()
+	os.Stdout = orig
+	out := <-done
+	_ = r.Close()
+	return out
+}
+
+// outOfScopeReport is the reported shape: the matcher's least-distant mock
+// is on a DIFFERENT upstream, so every field of it differs for reasons that
+// have nothing to do with the miss.
+func outOfScopeReport() *models.MockMismatchReport {
+	return &models.MockMismatchReport{
+		Protocol:         "HTTP",
+		ActualSummary:    "GET /v1/metrics",
+		Destination:      "192.0.2.20",
+		ClosestMock:      "mock-1",
+		MatchPhase:       models.MatchPhaseSchema,
+		DestinationScope: models.DestinationScopeNotInComparedSet,
+		CandidateCount:   19,
+		FieldDiffs: []models.MockFieldDiff{
+			{Path: "path", Kind: models.DiffKindValueChanged, Expected: "/api/orders", Actual: "/v1/metrics"},
+		},
+		ClosestMockReq: "GET /api/orders\nHost: 192.0.2.10\n\n",
+		ReceivedReq:    "GET /v1/metrics\nHost: 192.0.2.20\n\n",
+		NextSteps:      "No recorded HTTP mock in the compared set targets 192.0.2.20. ...",
+	}
+}
+
+// A diff against a mock on another upstream is not evidence, it is an
+// invitation to reconcile two unrelated requests. The CLI must not lead with
+// it — and must say why it is missing, so its absence reads as an answer.
+func TestPrintMismatchReport_SuppressesClosestMockWhenOutOfScope(t *testing.T) {
+	out := captureStdout(t, func() { printMismatchReport(outOfScopeReport()) })
+
+	if strings.Contains(out, "mock-1") {
+		t.Errorf("closest mock on a different upstream must not be rendered:\n%s", out)
+	}
+	if strings.Contains(out, "/api/orders") {
+		t.Errorf("diff against a different upstream must not be rendered:\n%s", out)
+	}
+	if !strings.Contains(out, "closest-mock diff omitted") {
+		t.Errorf("suppression must be explained, not silent:\n%s", out)
+	}
+	// ...in six words. The hint printed immediately below already opens with
+	// "No recorded HTTP mock in the compared set targets 192.0.2.20."; a full
+	// second copy of that sentence, once per missed call, was duplication.
+	if strings.Count(out, "in the compared set targets") != 1 {
+		t.Errorf("the suppression line must not restate the hint's first sentence:\n%s", out)
+	}
+	// The facts that ARE about this miss stay: which upstream, how far the
+	// cascade got, and the guidance.
+	for _, want := range []string{"192.0.2.20", "match stopped at: no_schema_candidates", "in the compared set targets"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output lost %q:\n%s", want, out)
+		}
+	}
+}
+
+// The suppression is keyed to the verdict alone: an ordinary miss keeps the
+// full side-by-side diff it has always had.
+func TestPrintMismatchReport_KeepsDiffForInScopeMiss(t *testing.T) {
+	r := outOfScopeReport()
+	r.DestinationScope = models.DestinationScopeInComparedSet
+	r.Destination = "192.0.2.10"
+	r.NextSteps = "Request structure changed since recording."
+
+	out := captureStdout(t, func() { printMismatchReport(r) })
+
+	if !strings.Contains(out, "mock-1") {
+		t.Errorf("in-scope miss must still name its closest mock:\n%s", out)
+	}
+	if strings.Contains(out, "closest-mock diff omitted") {
+		t.Errorf("in-scope miss must not suppress its diff:\n%s", out)
+	}
+}
+
+// The likely-causes paragraph is identical for every out-of-scope miss and an
+// out-of-scope container produces one miss per outgoing call it makes. It is
+// printed ONCE for the test, after that test's calls — not once per call, which
+// is what put the same ~1 KB of prose on screen dozens of times.
+func TestPrintFailuresTable_CausesRenderedOncePerTest(t *testing.T) {
+	tfs := NewTestFailureStore()
+	for _, host := range []string{"192.0.2.20", "192.0.2.21", "192.0.2.22"} {
+		r := outOfScopeReport()
+		r.Destination = host
+		r.NextSteps = "No recorded HTTP mock in the compared set targets " + host + "."
+		tfs.failures = append(tfs.failures, TestFailure{
+			TestSetID:      "test-set-0",
+			TestID:         "test-1",
+			FailureReason:  models.ErrMockNotFound,
+			MismatchReport: r,
+		})
+	}
+
+	out := captureStdout(t, tfs.PrintFailuresTable)
+
+	// Every call keeps its own one-line, call-specific hint.
+	for _, host := range []string{"192.0.2.20", "192.0.2.21", "192.0.2.22"} {
+		if !strings.Contains(out, "compared set targets "+host) {
+			t.Errorf("per-call hint for %s missing:\n%s", host, out)
+		}
+	}
+	// The shared block appears exactly once for the three of them.
+	if got := strings.Count(out, "Likely causes:"); got != 1 {
+		t.Errorf("shared causes rendered %d times for 3 calls in one test, want 1:\n%s", got, out)
+	}
+	if got := strings.Count(out, "ONE container per session"); got != 1 {
+		t.Errorf("cause (1) rendered %d times, want 1:\n%s", got, out)
+	}
+	if !strings.Contains(out, "per-test mock window") {
+		t.Errorf("the window-misrouting cause must reach the CLI:\n%s", out)
+	}
+}
+
+// ...and it is not printed at all for a test with no out-of-scope miss.
+func TestPrintFailuresTable_NoCausesWithoutAnOutOfScopeMiss(t *testing.T) {
+	r := outOfScopeReport()
+	r.DestinationScope = models.DestinationScopeInComparedSet
+	r.NextSteps = "Request structure changed since recording."
+	tfs := NewTestFailureStore()
+	tfs.failures = append(tfs.failures, TestFailure{
+		TestSetID:      "test-set-0",
+		TestID:         "test-1",
+		FailureReason:  models.ErrMockNotFound,
+		MismatchReport: r,
+	})
+
+	out := captureStdout(t, tfs.PrintFailuresTable)
+	if strings.Contains(out, "Likely causes:") {
+		t.Errorf("shared causes must not appear without an out-of-scope miss:\n%s", out)
+	}
+}

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -1116,17 +1116,21 @@ func (tfs *TestFailureStore) AddUnmatchedCallForTest(testSetID string, testCaseI
 		ActualMocks:   []string{},
 		FailureReason: models.ErrMockNotFound,
 		MismatchReport: &models.MockMismatchReport{
-			Protocol:       call.Protocol,
-			ActualSummary:  call.ActualSummary,
-			Destination:    call.Destination,
-			ClosestMock:    call.ClosestMock,
-			Diff:           call.Diff,
-			NextSteps:      call.NextSteps,
-			MatchPhase:     call.MatchPhase,
-			CandidateCount: call.CandidateCount,
-			FieldDiffs:     call.FieldDiffs,
-			ClosestMockReq: call.ClosestMockReq,
-			ReceivedReq:    call.ReceivedReq,
+			Protocol:      call.Protocol,
+			ActualSummary: call.ActualSummary,
+			Destination:   call.Destination,
+			ClosestMock:   call.ClosestMock,
+			Diff:          call.Diff,
+			NextSteps:     call.NextSteps,
+			MatchPhase:    call.MatchPhase,
+			// Carried across so the CLI rendering can tell an out-of-scope
+			// destination from a drifted request; the two need different
+			// artifacts, not just different hints.
+			DestinationScope: call.DestinationScope,
+			CandidateCount:   call.CandidateCount,
+			FieldDiffs:       call.FieldDiffs,
+			ClosestMockReq:   call.ClosestMockReq,
+			ReceivedReq:      call.ReceivedReq,
 		},
 	}
 	tfs.failures = append(tfs.failures, failure)
@@ -1243,9 +1247,14 @@ func (tfs *TestFailureStore) PrintFailuresTable() {
 			fmt.Printf("\nTest: %s / %s\n", testSetID, testID)
 
 			var mappingNotes []string
+			var anyOutOfScope bool
 			for _, failure := range testIDGroups[testID] {
 				if failure.FailureReason == models.ErrMockNotFound {
 					printMismatchReport(failure.MismatchReport)
+					if failure.MismatchReport != nil &&
+						failure.MismatchReport.DestinationScope == models.DestinationScopeNotInComparedSet {
+						anyOutOfScope = true
+					}
 				}
 				if len(failure.ExpectedMocks) > 0 || len(failure.ActualMocks) > 0 {
 					differences := CompareMockSlices(failure.ExpectedMocks, failure.ActualMocks)
@@ -1269,6 +1278,14 @@ func (tfs *TestFailureStore) PrintFailuresTable() {
 			for _, note := range mappingNotes {
 				fmt.Printf("  %s\n", note)
 			}
+			// ONCE PER TEST, not once per missed call. The likely causes are
+			// static text that is identical for every out-of-scope miss, and
+			// one out-of-scope container produces one miss per outgoing call
+			// it makes — inlining them in each call's hint put the same ~1 KB
+			// paragraph on screen dozens of times per test.
+			if anyOutOfScope {
+				fmt.Println(models.RenderOutOfScopeDestinationCauses("  "))
+			}
 		}
 	}
 	fmt.Println()
@@ -1283,11 +1300,22 @@ func printMismatchReport(r *models.MockMismatchReport) {
 		fmt.Println("  Outgoing call mock was not matched")
 		return
 	}
+	// When nothing in the compared set targets this destination there is no
+	// meaningful "closest mock": the matcher picked the least-distant mock in
+	// the pool, which belongs to a DIFFERENT upstream. Naming it in the
+	// heading and rendering a side-by-side diff against it invites the reader
+	// to reconcile two requests that were never related — the first cut of
+	// this diagnostic fixed only the hint and left that diff leading the
+	// output. The structured evidence (ClosestMock, FieldDiffs, both rendered
+	// requests) stays on the report object for the yaml/platform consumers;
+	// only this human rendering suppresses it.
+	outOfScope := r.DestinationScope == models.DestinationScopeNotInComparedSet
+
 	heading := fmt.Sprintf("  Mock mismatch: [%s] %s", r.Protocol, r.ActualSummary)
 	if r.Destination != "" {
 		heading += fmt.Sprintf("  →  %s", r.Destination)
 	}
-	if r.ClosestMock != "" {
+	if r.ClosestMock != "" && !outOfScope {
 		heading += fmt.Sprintf("   (closest mock: %s)", r.ClosestMock)
 	}
 	if r.MatchPhase != "" {
@@ -1300,6 +1328,14 @@ func printMismatchReport(r *models.MockMismatchReport) {
 	fmt.Println(heading)
 
 	switch {
+	case outOfScope:
+		// Say why the diff is missing, so its absence reads as a deliberate
+		// answer rather than a renderer that gave up — but say it in six
+		// words: the hint printed immediately below already opens with "No
+		// recorded <protocol> mock in the compared set targets <host>." and a
+		// full second copy of that sentence, once per missed call, was pure
+		// duplication.
+		fmt.Println("  (closest-mock diff omitted — see hint)")
 	case r.ClosestMockReq != "" && r.ReceivedReq != "":
 		printRequestDiff(r.ClosestMock, r.ClosestMockReq, r.ReceivedReq)
 	case len(r.FieldDiffs) > 0:

--- a/pkg/service/report/report.go
+++ b/pkg/service/report/report.go
@@ -867,6 +867,10 @@ func renderUnmatchedCalls(sb *strings.Builder, test models.TestResult) {
 		return
 	}
 	sb.WriteString("=== OUTGOING CALLS WITH NO MATCHING MOCK (likely root cause) ===\n")
+	// Set by any out-of-scope call below; the shared explanation is written
+	// ONCE for the whole test after the loop, never once per call — see
+	// models.OutOfScopeDestinationCauses.
+	var outOfScope bool
 	for _, uc := range test.FailureInfo.UnmatchedCalls {
 		sb.WriteString(fmt.Sprintf("  [%s] %s", uc.Protocol, uc.ActualSummary))
 		if uc.MatchPhase != "" {
@@ -877,6 +881,31 @@ func renderUnmatchedCalls(sb *strings.Builder, test models.TestResult) {
 			sb.WriteString(")")
 		}
 		sb.WriteString("\n")
+		// An upstream that nothing in the compared set targets has no
+		// comparable "closest mock": the matcher picked the least-distant
+		// mock in the pool, which belongs to a DIFFERENT host. Its field
+		// diffs are worse than useless here — the paths in this block are
+		// advertised as copy-pasteable noise configuration, so rendering them
+		// invites the reader to noise a `path` difference between two
+		// unrelated calls. The values stay on the UnmatchedCall for machine
+		// consumers; only this human rendering drops them, and says so.
+		if uc.DestinationScope == models.DestinationScopeNotInComparedSet {
+			outOfScope = true
+			// Name the destination. "this destination" only ever resolved
+			// because the default NextSteps happens to spell the host out
+			// two lines down, and a parser that supplies its own hint (via
+			// WithNextSteps) removes that accident — leaving a line that
+			// refers to a host it never prints.
+			dest := uc.Destination
+			if dest == "" {
+				dest = "an unidentified upstream"
+			}
+			sb.WriteString(fmt.Sprintf("    no recorded mock in the compared set targets %s; closest-mock diff omitted (it would compare against a different upstream)\n", dest))
+			if uc.NextSteps != "" {
+				sb.WriteString(fmt.Sprintf("    next steps: %s\n", uc.NextSteps))
+			}
+			continue
+		}
 		if uc.ClosestMock != "" {
 			sb.WriteString(fmt.Sprintf("    closest mock: %s\n", uc.ClosestMock))
 		}
@@ -900,6 +929,10 @@ func renderUnmatchedCalls(sb *strings.Builder, test models.TestResult) {
 		if uc.NextSteps != "" {
 			sb.WriteString(fmt.Sprintf("    next steps: %s\n", uc.NextSteps))
 		}
+	}
+	if outOfScope {
+		sb.WriteString(models.RenderOutOfScopeDestinationCauses("  "))
+		sb.WriteString("\n")
 	}
 	sb.WriteString("\n")
 }

--- a/pkg/service/report/unmatched_calls_test.go
+++ b/pkg/service/report/unmatched_calls_test.go
@@ -54,3 +54,141 @@ func TestRenderUnmatchedCalls_EmptyIsSilent(t *testing.T) {
 		t.Errorf("expected no output for tests without unmatched calls, got %q", sb.String())
 	}
 }
+
+// When nothing in the compared set targets the upstream, the "closest mock" is
+// on a DIFFERENT host and its field differences describe a comparison that
+// never meant anything. This block advertises its paths as copy-pasteable noise
+// configuration, so rendering them here would invite a user to noise away a
+// path difference between two unrelated calls. The values stay on the
+// UnmatchedCall for machine consumers; only this rendering drops them.
+func TestRenderUnmatchedCalls_SuppressesClosestMockWhenOutOfScope(t *testing.T) {
+	test := models.TestResult{
+		FailureInfo: models.FailureInfo{
+			UnmatchedCalls: []models.UnmatchedCall{
+				{
+					Protocol:         "HTTP",
+					ActualSummary:    "GET /v1/metrics",
+					Destination:      "192.0.2.20",
+					ClosestMock:      "mock-1",
+					MatchPhase:       models.MatchPhaseSchema,
+					DestinationScope: models.DestinationScopeNotInComparedSet,
+					CandidateCount:   19,
+					NextSteps:        "No recorded HTTP mock in the compared set targets 192.0.2.20. ...",
+					FieldDiffs: []models.MockFieldDiff{
+						{Path: "path", Kind: models.DiffKindValueChanged, Expected: "/api/orders", Actual: "/v1/metrics"},
+					},
+				},
+			},
+		},
+	}
+
+	var sb strings.Builder
+	renderUnmatchedCalls(&sb, test)
+	out := sb.String()
+
+	for _, absent := range []string{"closest mock: mock-1", "/api/orders", "noise-config compatible"} {
+		if strings.Contains(out, absent) {
+			t.Errorf("out-of-scope miss must not render %q:\n%s", absent, out)
+		}
+	}
+	// The cascade stop and the guidance are still this miss's own facts, and
+	// the suppression line NAMES the destination it is about. It used to say
+	// "this destination" and resolve only because the default NextSteps
+	// happens to spell the host out on the next line — an accident a parser
+	// supplying its own hint (WithNextSteps) removes.
+	for _, want := range []string{
+		"no recorded mock in the compared set targets 192.0.2.20; closest-mock diff omitted",
+		models.MatchPhaseSchema,
+		"next steps: No recorded HTTP mock in the compared set targets 192.0.2.20",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// The suppression line must name the upstream even when the parser supplied
+// its own hint, which is exactly when nothing else on the line does.
+func TestRenderUnmatchedCalls_SuppressionLineNamesTheDestination(t *testing.T) {
+	test := models.TestResult{
+		FailureInfo: models.FailureInfo{
+			UnmatchedCalls: []models.UnmatchedCall{{
+				Protocol:         "HTTP",
+				ActualSummary:    "GET /v1/metrics",
+				Destination:      "192.0.2.20",
+				ClosestMock:      "mock-1",
+				MatchPhase:       models.MatchPhaseSchema,
+				DestinationScope: models.DestinationScopeNotInComparedSet,
+				NextSteps:        "parser-supplied hint",
+			}},
+		},
+	}
+
+	var sb strings.Builder
+	renderUnmatchedCalls(&sb, test)
+	out := sb.String()
+
+	if !strings.Contains(out, "targets 192.0.2.20;") {
+		t.Errorf("suppression line must name the destination:\n%s", out)
+	}
+	if strings.Contains(out, "this destination") {
+		t.Errorf("suppression line must not defer to a host it never prints:\n%s", out)
+	}
+}
+
+// The likely-causes paragraph is identical for every out-of-scope miss and one
+// out-of-scope container produces one miss per outgoing call it makes (23 of 28
+// unmatched calls in the recording this was built from). It is written ONCE per
+// test, not once per call.
+func TestRenderUnmatchedCalls_CausesRenderedOncePerTest(t *testing.T) {
+	var calls []models.UnmatchedCall
+	for _, host := range []string{"192.0.2.20", "192.0.2.21", "192.0.2.22"} {
+		calls = append(calls, models.UnmatchedCall{
+			Protocol:         "HTTP",
+			ActualSummary:    "GET /v1/metrics",
+			Destination:      host,
+			ClosestMock:      "mock-1",
+			MatchPhase:       models.MatchPhaseSchema,
+			DestinationScope: models.DestinationScopeNotInComparedSet,
+			NextSteps:        "No recorded HTTP mock in the compared set targets " + host + ".",
+		})
+	}
+	var sb strings.Builder
+	renderUnmatchedCalls(&sb, models.TestResult{FailureInfo: models.FailureInfo{UnmatchedCalls: calls}})
+	out := sb.String()
+
+	if got := strings.Count(out, "Likely causes:"); got != 1 {
+		t.Errorf("shared causes written %d times for 3 calls in one test, want 1:\n%s", got, out)
+	}
+	if got := strings.Count(out, "ONE container per session"); got != 1 {
+		t.Errorf("cause (1) written %d times, want 1:\n%s", got, out)
+	}
+	if !strings.Contains(out, "per-test mock window") {
+		t.Errorf("the window-misrouting cause must reach the file report:\n%s", out)
+	}
+	// Each call still carries its own upstream.
+	for _, host := range []string{"192.0.2.20", "192.0.2.21", "192.0.2.22"} {
+		if !strings.Contains(out, "targets "+host+";") {
+			t.Errorf("per-call destination %s missing:\n%s", host, out)
+		}
+	}
+}
+
+// ...and not written at all when no call was out of scope.
+func TestRenderUnmatchedCalls_NoCausesWithoutAnOutOfScopeMiss(t *testing.T) {
+	var sb strings.Builder
+	renderUnmatchedCalls(&sb, models.TestResult{FailureInfo: models.FailureInfo{
+		UnmatchedCalls: []models.UnmatchedCall{{
+			Protocol:         "HTTP",
+			ActualSummary:    "GET /api/orders",
+			Destination:      "192.0.2.10",
+			ClosestMock:      "mock-1",
+			MatchPhase:       models.MatchPhaseSchema,
+			DestinationScope: models.DestinationScopeInComparedSet,
+			NextSteps:        "Request structure changed since recording.",
+		}},
+	}})
+	if strings.Contains(sb.String(), "Likely causes:") {
+		t.Errorf("shared causes must not appear without an out-of-scope miss:\n%s", sb.String())
+	}
+}


### PR DESCRIPTION
## Describe the changes that are made

A replay-time mock miss for a destination that **no compared mock targets** was reported as if the request had drifted:

```
match_phase: "no_schema_candidates", candidates: 19, closest: "mock-329"
next_step:   "Request structure changed since recording. Re-record the test set with 'keploy record',
              or refresh mappings with --update-test-mapping if mocks were edited."
```

Nothing had changed since recording. The call went to an upstream nothing in the compared set targets, and the "closest" mock was on a **different host entirely** — so the side-by-side diff printed against it compared two unrelated requests field by field.

That is not cosmetic. Keploy records **one container per session** while replay intercepts the whole pod, so every call a sibling container makes lands here. In the recording this was built from, **23 of 28** unmatched calls came from one such container, each carrying the same wrong advice and burying the five misses that actually mattered.

### After

```
[HTTP] GET /v1/buckets/...  →  192.0.2.20   (match stopped at: no_schema_candidates, 19 candidate mock(s))
  No recorded HTTP mock in the compared set targets 192.0.2.20.
  (closest-mock diff omitted — the closest mock is on a different upstream)
```

with the likely causes printed **once per test** rather than once per call: a process or container that was not being recorded, endpoint drift between the record and replay environments, a mock that fell outside the per-test window, or a sidecar whose traffic is not part of the application under test.

### The verdict is deliberately LOCAL

Keploy **cannot** say a destination was "never recorded" from here — per-test mocks are consumed on match and stripped from later pools, so a host whose mocks have all been served is missing from the pool while having been recorded all along. An earlier draft did claim that, and it told users their own application's upstream was an ignorable sidecar. The verdict now speaks only for the compared set, which is evidence the report builder holds in hand.

Two more deliberate choices:
- **Alongside `MatchPhase`, never on top of it** — the cascade stopping point is still reported, because that is the triage information a reader needs next.
- **Three-state, not a bool** — "we checked and it was there" and "we could not check" are different facts. Protocols that supply no destination evidence (Mongo, MySQL, Generic) render no verdict at all, rather than an unchecked negative that reads as "checked, and it WAS there".

**Diagnostic only:** nothing here changes matching, mock serving, or control flow.

## Links & References

**Closes:** NA

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- NA
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [ ] 📦 Chore
- [ ] 🍕 Feature
- [x] 🐞 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Added e2e test pipeline?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

The change only alters report text and one report field. It is covered by unit tests at every layer that
produces or renders the verdict; an e2e lane would assert on log prose without exercising any new code path.

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Wiki
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below

```
go test ./pkg/agent/proxy/integrations/mismatch/... \
        ./pkg/agent/proxy/integrations/http/... \
        ./pkg/models/... ./pkg/service/report/... ./pkg/service/replay/... -count=1
```

New tests cover: a destination absent from a non-empty compared set gets the new guidance; a destination
present gets today's drift message unchanged; `MatchPhaseNoMocks` is not stolen; the value-drift branch still
wins where it applies; an unknown or unreadable destination falls through silently; and host vs `host:port`,
IPv6 (bracketed and bare), rooted FQDNs (`svc.ns.svc.cluster.local.`) and scheme-prefixed authorities all
compare correctly — each of those was a way to make the verdict false.

## Self Review done?
- [x] ✅ yes

Reviewed independently before commit. That review caught, and this PR fixes: a k8s-specific hint being shown
to native CLI users who have no pod; a missing cause (a mock recorded but outside the per-test window) that
would have sent users to re-record for nothing; a 1079-character hint repeated per call rather than once per
test; and a rooted-FQDN comparison bug that made the verdict false for in-cluster names.

## Any relevant screenshots, recordings or logs?
- NA
