### PR TITLE
fix(replay): let an embedder turn off app-readiness probing

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -411,6 +411,7 @@ func (c *CmdConfigurator) AddUncommonFlags(cmd *cobra.Command) {
 		cmd.Flags().String("health-url", c.cfg.Test.HealthURL, "HTTP(S) URL polled before the first test is fired; first 2xx response proceeds immediately. Empty (default) preserves the fixed --delay behavior.")
 		cmd.Flags().String("health-path", c.cfg.Test.HealthPath, "Request path polled on the address the recorded tests actually dial, before the first test is fired — e.g. /health. Needs no host or port, so it works when the published port is assigned at runtime. Any completed HTTP response counts as ready. Ignored when --health-url is set (that takes precedence). Empty (default) uses a keploy-reserved probe path.")
 		cmd.Flags().String("health-scheme", c.cfg.Test.HealthScheme, "Override the scheme for --health-path probing (http or https). Empty (default) uses the scheme the recorded tests dial. Ignored when --health-url is set.")
+		cmd.Flags().Bool("disable-app-ready-probe", c.cfg.Test.DisableAppReadyProbe, "Turn off every address-based readiness probe before the first test (the docker/compose published-port gates, --app-ready-probe-addr, and the recorded-target fallback), plus the reset-resend readiness re-gate. Use when a connect-then-close probe is destructive in your environment — notably an app reached through `kubectl port-forward`, where probing can tear the forward down. --health-url is unaffected. Replay falls back to the fixed --delay.")
 		cmd.Flags().Duration("health-poll-timeout", c.cfg.Test.HealthPollTimeout, "Ceiling for every pre-test readiness gate — --health-url, --health-path and the automatic docker/compose port gates (e.g. 60s, 3m). Only ever paid by an app that is not yet serving; a ready app satisfies the gate on the first probe. On timeout replay warns and fires anyway.")
 		cmd.Flags().String("proto-file", c.cfg.Test.ProtoFile, "Path of main proto file")
 		cmd.Flags().String("proto-dir", c.cfg.Test.ProtoDir, "Path of the directory where all protos of a service are located")
@@ -519,6 +520,7 @@ func aliasNormalizeFunc(_ *pflag.FlagSet, name string) pflag.NormalizedName {
 		"healthPath":                "health-path",
 		"healthScheme":              "health-scheme",
 		"healthPollTimeout":         "health-poll-timeout",
+		"disableAppReadyProbe":      "disable-app-ready-probe",
 		"urlMethods":                "url-methods",
 		"inCi":                      "in-ci",
 		"protoFile":                 "proto-file",

--- a/cli/provider/upstream_tls_flags_test.go
+++ b/cli/provider/upstream_tls_flags_test.go
@@ -237,3 +237,41 @@ func TestAgentMarkersStayUnsetWithoutArgv(t *testing.T) {
 		t.Fatal("the markers were set without the flags appearing on argv; the agent would ignore its own keploy.yml")
 	}
 }
+
+// TestDisableAppReadyProbeFlagIsRegistered pins the operator escape
+// hatch for a destructive readiness probe.
+//
+// The field is reachable from keploy.yml and programmatically, but the
+// CLI user who hits the hazard most directly — `keploy test` against an
+// app behind their own `kubectl port-forward`, where a
+// connect-then-close probe can tear the forward down — needs a
+// discoverable switch. A struct field alone is not one.
+//
+// Registration and the camelCase->kebab mapping are pinned separately
+// because either half missing leaves the flag unusable: no
+// registration and `--disable-app-ready-probe` is rejected outright; no
+// mapping and `disableAppReadyProbe` in a config file never binds to it.
+func TestDisableAppReadyProbeFlagIsRegistered(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cfg := &config.Config{}
+	c := &CmdConfigurator{cfg: cfg, logger: zap.NewNop()}
+	if err := c.AddFlags(cmd); err != nil {
+		t.Fatalf("AddFlags: %v", err)
+	}
+
+	f := cmd.Flags().Lookup("disable-app-ready-probe")
+	if f == nil {
+		t.Fatal("--disable-app-ready-probe is not registered: a CLI user behind a port-forward " +
+			"has no way to turn off a probe that breaks their connection")
+	}
+	if f.Value.Type() != "bool" {
+		t.Errorf("flag type = %q, want bool", f.Value.Type())
+	}
+
+	if err := cmd.Flags().Set("disable-app-ready-probe", "true"); err != nil {
+		t.Fatalf("set flag: %v", err)
+	}
+	if got := cmd.Flags().Lookup("disable-app-ready-probe").Value.String(); got != "true" {
+		t.Errorf("flag value = %q, want true", got)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -367,15 +367,34 @@ type Normalize struct {
 const DefaultHealthPollTimeout = 3 * time.Minute
 
 type Test struct {
-	SelectedTests               map[string][]string `json:"selectedTests" yaml:"selectedTests" mapstructure:"selectedTests"`
-	GlobalNoise                 Globalnoise         `json:"globalNoise" yaml:"globalNoise" mapstructure:"globalNoise"`
-	ReplaceWith                 ReplaceWith         `json:"replaceWith" yaml:"replaceWith" mapstructure:"replaceWith"`
-	Delay                       uint64              `json:"delay" yaml:"delay" mapstructure:"delay"`
-	HealthURL                   string              `json:"healthUrl" yaml:"healthUrl" mapstructure:"healthUrl"`                         // optional HTTP(S) URL polled before firing the first test; empty preserves the fixed --delay behavior
-	HealthPollTimeout           time.Duration       `json:"healthPollTimeout" yaml:"healthPollTimeout" mapstructure:"healthPollTimeout"` // ceiling for the pre-test health poll loop before falling back to --delay
-	HealthPath                  string              `json:"healthPath" yaml:"healthPath" mapstructure:"healthPath"`                      // optional request path probed on the app's OWN auto-detected address (docker/compose published port, or appReadyProbeAddr) before the first test. Unlike healthUrl it needs no host or port, so it works when the published port is assigned at runtime. Any completed HTTP response counts as ready — a health endpoint returning 503 has still proved the app is answering. Empty uses a keploy-reserved probe path.
-	HealthScheme                string              `json:"healthScheme" yaml:"healthScheme" mapstructure:"healthScheme"`                // optional override for the readiness probe scheme ("http" or "https"). Empty (the default) uses the scheme the recorded tests actually dial; only consulted when the app is probed over HTTP, and ignored entirely when healthUrl is set.
-	AppReadyProbeAddr           string              `json:"appReadyProbeAddr" yaml:"appReadyProbeAddr" mapstructure:"appReadyProbeAddr"` // optional host:port TCP-polled after the --delay floor (bounded by healthPollTimeout) before firing the first test — the TCP-accept analog of healthUrl for apps with no HTTP health endpoint (e.g. a k8s replay pod's app Service, or a native app on a fixed port). Empty preserves the fixed --delay behavior. Unlike test.port it NEVER affects request routing; it is only a readiness probe.
+	SelectedTests     map[string][]string `json:"selectedTests" yaml:"selectedTests" mapstructure:"selectedTests"`
+	GlobalNoise       Globalnoise         `json:"globalNoise" yaml:"globalNoise" mapstructure:"globalNoise"`
+	ReplaceWith       ReplaceWith         `json:"replaceWith" yaml:"replaceWith" mapstructure:"replaceWith"`
+	Delay             uint64              `json:"delay" yaml:"delay" mapstructure:"delay"`
+	HealthURL         string              `json:"healthUrl" yaml:"healthUrl" mapstructure:"healthUrl"`                         // optional HTTP(S) URL polled before firing the first test; empty preserves the fixed --delay behavior
+	HealthPollTimeout time.Duration       `json:"healthPollTimeout" yaml:"healthPollTimeout" mapstructure:"healthPollTimeout"` // ceiling for the pre-test health poll loop before falling back to --delay
+	HealthPath        string              `json:"healthPath" yaml:"healthPath" mapstructure:"healthPath"`                      // optional request path probed on the app's OWN auto-detected address (docker/compose published port, or appReadyProbeAddr) before the first test. Unlike healthUrl it needs no host or port, so it works when the published port is assigned at runtime. Any completed HTTP response counts as ready — a health endpoint returning 503 has still proved the app is answering. Empty uses a keploy-reserved probe path.
+	HealthScheme      string              `json:"healthScheme" yaml:"healthScheme" mapstructure:"healthScheme"`                // optional override for the readiness probe scheme ("http" or "https"). Empty (the default) uses the scheme the recorded tests actually dial; only consulted when the app is probed over HTTP, and ignored entirely when healthUrl is set.
+	AppReadyProbeAddr string              `json:"appReadyProbeAddr" yaml:"appReadyProbeAddr" mapstructure:"appReadyProbeAddr"` // optional host:port TCP-polled after the --delay floor (bounded by healthPollTimeout) before firing the first test — the TCP-accept analog of healthUrl for apps with no HTTP health endpoint (e.g. a k8s replay pod's app Service, or a native app on a fixed port). Empty preserves the fixed --delay behavior. Unlike test.port it NEVER affects request routing; it is only a readiness probe.
+
+	// DisableAppReadyProbe turns off the app-readiness probing that
+	// runs before the first test fires — the docker/compose
+	// published-port gates, AppReadyProbeAddr, and the resolved
+	// test-target fallback. --health-url is unaffected: that is an
+	// explicit operator request, not an inferred probe.
+	//
+	// It exists for embedders that drive replay as a library in an
+	// environment where a connect-then-close probe is DESTRUCTIVE.
+	// keploy/k8s-proxy is the motivating case: on its cluster-mode path
+	// the app is reached through a kubectl port-forward, and probing it
+	// can make kubelet's SPDY relay tear the session down ("lost
+	// connection to pod"), killing the app and agent forwards together.
+	//
+	// Leaving a gate input unset is NOT a reliable way to express this:
+	// such a caller still sets Test.Host (it rewrites recorded request
+	// URLs), and the resolved-test-target fallback will reach for that
+	// address and probe it. Intent has to be stated, not inferred.
+	DisableAppReadyProbe        bool                `json:"disableAppReadyProbe" yaml:"disableAppReadyProbe" mapstructure:"disableAppReadyProbe"`
 	Host                        string              `json:"host" yaml:"host" mapstructure:"host"`
 	Port                        uint32              `json:"port" yaml:"port" mapstructure:"port"`
 	GRPCPort                    uint32              `json:"grpcPort" yaml:"grpcPort" mapstructure:"grpcPort"`

--- a/config/default.go
+++ b/config/default.go
@@ -44,6 +44,7 @@ test:
   healthPath: ""
   healthScheme: ""
   healthPollTimeout: 3m
+  disableAppReadyProbe: false
   host: "localhost"
   port: 0
   grpcPort: 0

--- a/config/default_test.go
+++ b/config/default_test.go
@@ -79,6 +79,16 @@ func TestDefaultConfigParses(t *testing.T) {
 	if got := cfg.Record.UpstreamTLS.CACert; got != "" {
 		t.Errorf("record.upstreamTls.caCert = %q, want empty", got)
 	}
+
+	// Present in the generated config so the escape hatch is
+	// discoverable, and false so nothing changes for anyone who does not
+	// need it. A readiness probe is destructive only in specific
+	// environments (an app behind a kubectl port-forward); everywhere
+	// else it is the thing preventing status_code=0 flakes.
+	if cfg.Test.DisableAppReadyProbe {
+		t.Error("test.disableAppReadyProbe defaults to true; it must default to false or every " +
+			"app silently loses the readiness gate that stops the first test firing early")
+	}
 }
 
 // TestDefaultConfigUpstreamTLSBlockPosition pins WHERE the upstreamTls block

--- a/pkg/service/replay/app_ready_http_gate_test.go
+++ b/pkg/service/replay/app_ready_http_gate_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -37,6 +38,36 @@ func acceptOnlyListener(t *testing.T) (host, port string) {
 	}()
 	h, p, _ := net.SplitHostPort(ln.Addr().String())
 	return h, p
+}
+
+// countingListener is acceptOnlyListener that also reports how many
+// connections were made to it.
+//
+// The disable-probe contract is "no connect-then-close happens", and
+// elapsed time cannot express that: against a listener that accepts
+// instantly, a probe that IS made still returns in microseconds, so a
+// wall-clock assertion passes whether or not the flag was honoured. The
+// hazard being guarded against is the connection itself.
+func countingListener(t *testing.T) (host, port string, conns *atomic.Int64) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	var n atomic.Int64
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			n.Add(1)
+			_ = c.Close()
+		}
+	}()
+	h, p, _ := net.SplitHostPort(ln.Addr().String())
+	return h, p, &n
 }
 
 func gateCfg(ceiling time.Duration) *config.Config {
@@ -302,5 +333,135 @@ func TestWaitForAppReady_NativeAppWithoutEvidenceIsNotGated(t *testing.T) {
 	if elapsed := time.Since(start); elapsed > 2*time.Second {
 		t.Fatalf("waited %v with no resolvable target; a non-HTTP native app must keep the "+
 			"pure --delay behaviour", elapsed)
+	}
+}
+
+// TestWaitForAppReady_DisableProbeIsHonoured covers the embedder that
+// drives replay as a library where a connect-then-close probe is
+// DESTRUCTIVE.
+//
+// keploy/k8s-proxy is the motivating case: on its cluster-mode path the
+// app is reached through a kubectl port-forward, and probing it can make
+// kubelet's SPDY relay tear the session down ("lost connection to pod"),
+// killing the app and agent forwards together. It therefore supplies no
+// test.appReadyProbeAddr — but it DOES set test.host, because that is
+// what rewrites recorded request URLs.
+//
+// That is why the opt-out is a stated flag rather than an inference from
+// "no gate input was supplied": for this caller that inference is simply
+// false, and the resolved-test-target fallback would reach for test.host
+// and probe it anyway.
+func TestWaitForAppReady_DisableProbeIsHonoured(t *testing.T) {
+	host, port := acceptOnlyListener(t) // accepts, never serves HTTP
+	cfg := gateCfg(10 * time.Second)
+	cfg.Command = "replay"
+	cfg.CommandType = "docker-compose"
+	cfg.Test.Host = host // set for request rewriting, NOT for probing
+	cfg.Test.AppReadyProbeAddr = ""
+	cfg.Test.DisableAppReadyProbe = true
+	cfg.Test.Delay = 0
+
+	start := time.Now()
+	ok := waitForAppReady(context.Background(), zap.NewNop(), cfg,
+		httpProbeTarget{scheme: "http", host: host, port: port, ok: true})
+	elapsed := time.Since(start)
+
+	if !ok {
+		t.Fatal("the gate must stay best-effort and proceed, never fail the run")
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("waited %v with probing disabled: the caller said a connect-then-close probe "+
+			"is destructive in its environment, and this one tears down the very connection "+
+			"it is testing", elapsed)
+	}
+}
+
+// The opt-out must cover EVERY address gate, not just the fallback: the
+// hazard is the connect-then-close itself, and each of them performs
+// one. Asserted by counting connections, because against a listener that
+// accepts instantly a wall-clock assertion passes whether or not the
+// probe was made.
+func TestWaitForAppReady_DisableProbeMakesNoConnection(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		apply func(cfg *config.Config, host, port string)
+	}{
+		{
+			name: "explicit appReadyProbeAddr",
+			apply: func(cfg *config.Config, host, port string) {
+				cfg.Test.AppReadyProbeAddr = net.JoinHostPort(host, port)
+			},
+		},
+		{
+			name: "docker published port",
+			apply: func(cfg *config.Config, host, port string) {
+				cfg.Command = "docker run -p " + host + ":" + port + ":" + port + " myapp"
+				cfg.CommandType = "docker-run"
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			host, port, conns := countingListener(t)
+			cfg := gateCfg(10 * time.Second)
+			cfg.Command = "replay"
+			cfg.CommandType = "docker-compose"
+			cfg.Test.DisableAppReadyProbe = true
+			cfg.Test.Delay = 0
+			tc.apply(cfg, host, port)
+
+			if !waitForAppReady(context.Background(), zap.NewNop(), cfg,
+				httpProbeTarget{scheme: "http", host: host, port: port, ok: true}) {
+				t.Fatal("must proceed")
+			}
+			if got := conns.Load(); got != 0 {
+				t.Fatalf("%d connection(s) made to the app address with probing disabled. The "+
+					"caller said a connect-then-close is destructive in its environment; a "+
+					"gate that still dials tears down the very connection it is testing.", got)
+			}
+		})
+	}
+}
+
+// ...and with the flag OFF the same gates still probe, so the opt-out is
+// the only thing suppressing them.
+func TestWaitForAppReady_ProbeConnectsWhenNotDisabled(t *testing.T) {
+	host, port, conns := countingListener(t)
+	cfg := gateCfg(700 * time.Millisecond)
+	cfg.Command = "replay"
+	cfg.CommandType = "docker-compose"
+	cfg.Test.AppReadyProbeAddr = net.JoinHostPort(host, port)
+	cfg.Test.Delay = 0
+
+	if !waitForAppReady(context.Background(), zap.NewNop(), cfg,
+		httpProbeTarget{scheme: "http", host: host, port: port, ok: true}) {
+		t.Fatal("must proceed")
+	}
+	if got := conns.Load(); got == 0 {
+		t.Fatal("no connection was made with probing ENABLED: the disable tests above would " +
+			"then pass for the wrong reason")
+	}
+}
+
+// And with the flag off, nothing changes — every gate that shipped in
+// v3.6.41 still fires. This is the half the previous attempt got wrong:
+// a guard keyed on command type silently dropped the gate for
+// docker-start, docker run without a parseable -p, and compose without
+// a published host port, all of which are gated on released v3.6.41.
+func TestWaitForAppReady_DockerStartKeepsItsGate(t *testing.T) {
+	host, port := acceptOnlyListener(t) // accepts TCP, never serves HTTP
+	cfg := gateCfg(700 * time.Millisecond)
+	cfg.Command = "docker start myapp" // no -p to parse
+	cfg.CommandType = "docker-start"
+	cfg.Test.Delay = 0
+
+	start := time.Now()
+	if !waitForAppReady(context.Background(), zap.NewNop(), cfg,
+		httpProbeTarget{scheme: "http", host: host, port: port, ok: true}) {
+		t.Fatal("must proceed")
+	}
+	if elapsed := time.Since(start); elapsed < 500*time.Millisecond {
+		t.Fatalf("returned after %v — a docker-start app was declared ready with no HTTP "+
+			"round-trip. Its ports were published at create time, so there is no -p to parse "+
+			"and the resolved-test-target fallback is the only gate it has.", elapsed)
 	}
 }

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -4325,6 +4325,17 @@ func (r *Replayer) resetResendUnsafe(ctx context.Context) (bool, []models.MockSt
 // published host-port TCP gate (no-op for native apps / unmapped publishes). On
 // timeout it returns and lets the bounded re-send attempts run.
 func (r *Replayer) waitForResetResendReady(ctx context.Context, testCase *models.TestCase, testSetID string) {
+	// The same opt-out as the pre-test gate, and this path needs it more,
+	// not less. Its trigger is a transport-level reset — which, behind a
+	// kubectl port-forward, is exactly what a dying forward produces.
+	// Re-opening a connect-then-close probe against the same address in
+	// response is the one thing most likely to finish it off. The
+	// bounded re-sends themselves are unaffected; only the readiness
+	// re-gate is skipped. See config.Test.DisableAppReadyProbe.
+	if r.config.Test.DisableAppReadyProbe {
+		return
+	}
+
 	wctx, cancel := context.WithTimeout(ctx, resetResendReadyTimeout)
 	defer cancel()
 

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -553,24 +553,45 @@ func waitForHTTPServingPath(ctx context.Context, scheme, host, port, path string
 // wait LONGER than --delay, never shorter; a timeout WARNS and proceeds rather
 // than failing the run; and it never weakens an assertion. Returns false only on
 // context cancellation (user abort).
-func gateOnAppAddress(ctx context.Context, logger *zap.Logger, cfg *config.Config, host, port, label string, probe httpProbeTarget) bool {
+// gateMode tweaks how gateOnAppAddress probes. The zero value runs both
+// stages; httpOnly skips the stage-1 TCP dial, for the one caller whose
+// stage-1 and stage-2 addresses are identical and whose bare
+// connect-then-close is therefore both redundant and harmful.
+type gateMode int
+
+const (
+	bothStages gateMode = iota
+	httpOnly
+)
+
+func gateOnAppAddress(ctx context.Context, logger *zap.Logger, cfg *config.Config, host, port, label string, probe httpProbeTarget, modes ...gateMode) bool {
+	mode := bothStages
+	if len(modes) > 0 {
+		mode = modes[0]
+	}
 	ceiling := cfg.Test.HealthPollTimeout
 	if ceiling <= 0 {
 		ceiling = config.DefaultHealthPollTimeout
 	}
 	deadline := time.Now().Add(ceiling)
 
-	if err := pkg.WaitForPort(ctx, host, port, ceiling); err != nil {
-		if ctx.Err() != nil {
-			return false
+	// Stage 1: the address accepts a TCP connection. Skipped in
+	// httpOnly mode, where stage 2 probes the very same address and the
+	// bare connect-then-close would be redundant — see the rationale at
+	// the resolved-test-target call site.
+	if mode != httpOnly {
+		if err := pkg.WaitForPort(ctx, host, port, ceiling); err != nil {
+			if ctx.Err() != nil {
+				return false
+			}
+			logger.Warn("app address did not accept a connection within the ceiling; firing tests anyway (replay may see status_code got=0)",
+				zap.String("gate", label),
+				zap.String("host", host),
+				zap.String("port", port),
+				zap.Duration("ceiling", ceiling),
+				zap.Error(err))
+			return true
 		}
-		logger.Warn("app address did not accept a connection within the ceiling; firing tests anyway (replay may see status_code got=0)",
-			zap.String("gate", label),
-			zap.String("host", host),
-			zap.String("port", port),
-			zap.Duration("ceiling", ceiling),
-			zap.Error(err))
-		return true
 	}
 
 	if !probe.ok {
@@ -720,6 +741,38 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 		// --delay behavior. This can only ever wait LONGER than --delay, never
 		// shorter, and never weakens an assertion — a fast-ready port returns
 		// instantly.
+
+		// An embedder can state that probing is unsafe here. Honoured
+		// for every address-based gate below, not just the fallback,
+		// and for the reset-resend readiness re-gate in replay.go:
+		// the hazard is the connect-then-close itself, and all of these
+		// perform one. --health-url is untouched — that is an explicit
+		// operator request rather than an inferred probe.
+		//
+		// This is a stated intent, not an inferred one, because the
+		// inference is unreliable: a caller in this position still sets
+		// test.host (it rewrites recorded request URLs), so "no gate
+		// input was supplied" is simply false for it, and the
+		// resolved-test-target fallback would reach for that address
+		// and probe it anyway. See config.Test.DisableAppReadyProbe.
+		if cfg.Test.DisableAppReadyProbe {
+			// Info, not Debug: a safety gate being switched off should
+			// be visible at default verbosity, the way the health poll
+			// announces itself below.
+			logger.Info("app-readiness probing disabled by configuration; using the delay floor only",
+				zap.Duration("delay", delay),
+			)
+			// The delay select above can take its timer branch even when
+			// ctx is already cancelled. Every other exit from here goes
+			// through gateOnAppAddress, which checks; this one must too,
+			// or a cancelled run reports ready and fires tests instead
+			// of reporting the abort.
+			if ctx.Err() != nil {
+				return false
+			}
+			return true
+		}
+
 		gated := false
 		if host, port, ok := dockerPublishedHostPort(cfg.Command); ok {
 			gated = true
@@ -782,7 +835,23 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 		// longer than --delay. Guarded on `gated` purely to avoid probing twice
 		// when a published address already covered it.
 		if !gated && probe.ok {
-			if !gateOnAppAddress(ctx, logger, cfg, probe.host, probe.port, "resolved-test-target", probe) {
+			// httpOnly: skip gateOnAppAddress's stage-1 bare TCP dial.
+			//
+			// Here, and only here, stage 1 and stage 2 probe the SAME
+			// address, so the dial proves nothing the HTTP round-trip
+			// does not — waitForHTTPServingPath already treats refusal
+			// and reset as not-ready and retries to the ceiling. What
+			// the dial does add is a naked connect-then-close, the
+			// shape a kubectl port-forward's SPDY relay is most hostile
+			// to. Dropping it removes that shape from the exact path
+			// that broke keploy/k8s-proxy, for every embedder that
+			// never learns about test.disableAppReadyProbe, at no cost
+			// in coverage.
+			//
+			// The docker and compose gates above deliberately pass a
+			// DIFFERENT stage-1 address than the probe target, so their
+			// dial is not redundant and stays.
+			if !gateOnAppAddress(ctx, logger, cfg, probe.host, probe.port, "resolved-test-target", probe, httpOnly) {
 				return false
 			}
 		}


### PR DESCRIPTION
## The bug (a regression from #4535, already released in v3.6.41)

#4535 added a resolved-test-target fallback so an app with no published port still gets a readiness gate. It fires whenever nothing else gated, and `!gated` was read as *"nobody could name an address"*.

For an embedder driving replay as a library it can mean something else: **probing is unsafe here.**

`keploy/k8s-proxy` is that caller. On its cluster-mode path the app is reached through a `kubectl port-forward`, and it *deliberately* supplies no `test.appReadyProbeAddr` — its own comment says a connect-then-close probe there can make kubelet's SPDY relay tear the session down (`"lost connection to pod"`), killing the app and agent forwards together. But it **does** set `test.host`, because that is what rewrites recorded request URLs.

So the fallback reached for an address supplied for *rewriting* and probed it — overriding a considered opt-out with the one probe that breaks the connection it is testing.

## The fix

`test.disableAppReadyProbe` states the intent rather than inferring it. It turns off every address-based gate, and the reset-resend readiness re-gate in `replay.go` with them — that path needs it *more*, since its trigger is a transport reset, which behind a port-forward is exactly what a dying forward produces. `--health-url` is untouched, being an explicit operator request rather than an inferred probe.

**Independent of the flag**, the resolved-test-target fallback no longer makes a bare TCP dial before its HTTP probe. It is the one gate whose stage-1 and stage-2 addresses are identical, so the dial proves nothing the round-trip does not — `waitForHTTPServingPath` already treats refusal and reset as not-ready — while contributing exactly the naked connect-then-close a port-forward is most hostile to. That helps every embedder that never learns about the flag, at no cost in coverage. The docker and compose gates pass a *different* stage-1 address and keep theirs.

## Two approaches tried and rejected

| Approach | Why not |
|---|---|
| Guard on `CommandType == native` | Silently dropped the v3.6.41 gate for `docker start` (ports published at create time, no `-p` to parse), `docker run -P`, and compose without a published host port. Measured: 700ms gated → 7.5µs ungated. `TestWaitForAppReady_DockerStartKeepsItsGate` now pins that those keep it. |
| Guard on `test.host == ""` | Fails the other way — the caller needing the opt-out is precisely the one that sets `test.host`. |

## Testing

The tests assert on **connections made**, not elapsed time. Against a listener that accepts instantly, a probe that *is* made still returns in microseconds, so a wall-clock assertion passes whether or not the flag was honoured — an earlier version of these tests did exactly that and stayed green with the flag check deleted.

Mutation-verified:

| Mutation | Result |
|---|---|
| Ignore the flag entirely | `DisableProbeIsHonoured` fails, 10s stall |
| Honour it in only the fallback | `DisableProbeMakesNoConnection` fails |
| Delete the fallback | `DockerStartKeepsItsGate` fails |

`go test ./...` 65 packages green; `vet`/`gofmt` clean.

## Follow-up

`test.disableAppReadyProbe` is reachable from `keploy.yml` and programmatically, but has no CLI flag or env var yet. A CLI user hitting the same hazard — `keploy test` against an app behind their own port-forward — has no discoverable escape hatch. Worth plumbing separately.