### PR TITLE
fix(cli): resolve --half-close-grace, which was a dead flag

### DIFF
--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -1344,6 +1344,9 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 			if err := c.resolveRecordBufferDuration(cmd, "consumer-stall-grace", "KEPLOY_RECORD_CONSUMER_STALL_GRACE", &c.cfg.Record.RecordBuffer.ConsumerStallGrace); err != nil {
 				return err
 			}
+			if err := c.resolveRecordBufferDuration(cmd, "half-close-grace", "KEPLOY_RECORD_HALF_CLOSE_GRACE", &c.cfg.Record.RecordBuffer.HalfCloseGrace); err != nil {
+				return err
+			}
 
 			// Cross-check: a single connection's recording buffer must
 			// not exceed the docker container's memory limit. Otherwise
@@ -1802,6 +1805,9 @@ func (c *CmdConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command)
 			return err
 		}
 		if err := c.resolveRecordBufferDuration(cmd, "consumer-stall-grace", "KEPLOY_RECORD_CONSUMER_STALL_GRACE", &c.cfg.Record.RecordBuffer.ConsumerStallGrace); err != nil {
+			return err
+		}
+		if err := c.resolveRecordBufferDuration(cmd, "half-close-grace", "KEPLOY_RECORD_HALF_CLOSE_GRACE", &c.cfg.Record.RecordBuffer.HalfCloseGrace); err != nil {
 			return err
 		}
 

--- a/cli/provider/record_buffer_wiring_test.go
+++ b/cli/provider/record_buffer_wiring_test.go
@@ -1,0 +1,105 @@
+package provider
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strconv"
+	"testing"
+)
+
+// Every record-buffer flag that is REGISTERED must also be RESOLVED.
+//
+// --half-close-grace shipped registered, aliased in flagNameMapping, and
+// forwarded to the agent's argv — and read by nobody, because no
+// resolveRecordBuffer* call was ever added for it. Every test passed:
+// registration tests only prove the flag parses.
+//
+// In docker record mode that gap is total. pkg/platform/docker/util.go
+// says it outright — the host's keploy.yml is not bind-mounted into the
+// agent container, so argv is the only propagation channel. The
+// orchestrator appended `--half-close-grace -1s`, the containerised
+// agent parsed it and threw it away, and ran the 10s default. An
+// operator who disabled half-close got it enabled, with no way to tell
+// from outside.
+//
+// There is no runtime seam to assert this through: the resolve calls
+// live inside ValidateFlags, behind validation that a bare harness
+// cannot satisfy. So the pin is on the source, in the same spirit as
+// relay_config_test.go's pin on the relay.Config literal. It proves the
+// wiring, not the behaviour.
+func TestEveryRecordBufferFlagIsResolved(t *testing.T) {
+	t.Parallel()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "cmd.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse cmd.go: %v", err)
+	}
+
+	// Flags registered against Record.RecordBuffer.*, and flags passed to
+	// a resolveRecordBuffer* helper.
+	registered := map[string]bool{}
+	resolved := map[string]bool{}
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || len(call.Args) == 0 {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		name := func(i int) (string, bool) {
+			lit, ok := call.Args[i].(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return "", false
+			}
+			v, err := strconv.Unquote(lit.Value)
+			return v, err == nil
+		}
+
+		switch {
+		// cmd.Flags().Duration("x", c.cfg.Record.RecordBuffer.Y, ...)
+		case len(call.Args) >= 2 && isRecordBufferSelector(call.Args[1]):
+			if f, ok := name(0); ok {
+				registered[f] = true
+			}
+		// c.resolveRecordBufferXxx(cmd, "x", "ENV", &c.cfg.Record.RecordBuffer.Y)
+		case len(sel.Sel.Name) > len("resolveRecordBuffer") &&
+			sel.Sel.Name[:len("resolveRecordBuffer")] == "resolveRecordBuffer":
+			if f, ok := name(1); ok {
+				resolved[f] = true
+			}
+		}
+		return true
+	})
+
+	if len(registered) == 0 {
+		t.Fatal("found no record-buffer flag registrations in cmd.go; this pin has stopped " +
+			"looking at anything and would pass no matter what")
+	}
+
+	for flag := range registered {
+		if !resolved[flag] {
+			t.Errorf("--%s is registered against config.Record.RecordBuffer but never passed to "+
+				"a resolveRecordBuffer* helper. It parses, it is forwarded to the agent's argv, "+
+				"and nothing reads it into config — a knob that silently does nothing. In docker "+
+				"record mode argv is the ONLY propagation channel, so the operator's value is "+
+				"lost entirely.", flag)
+		}
+	}
+}
+
+// isRecordBufferSelector reports whether an expression is a selector
+// rooted at ...Record.RecordBuffer, e.g.
+// c.cfg.Record.RecordBuffer.HalfCloseGrace.
+func isRecordBufferSelector(e ast.Expr) bool {
+	sel, ok := e.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	inner, ok := sel.X.(*ast.SelectorExpr)
+	return ok && inner.Sel.Name == "RecordBuffer"
+}

--- a/config/config.go
+++ b/config/config.go
@@ -260,7 +260,8 @@ type UpstreamTLS struct {
 // giving up on the chunks still queued for it.
 //
 // Env vars KEPLOY_RECORD_MAX_MEMORY_PER_CONN, KEPLOY_RECORD_QUEUE_SIZE and
-// KEPLOY_RECORD_CONSUMER_STALL_GRACE override the yaml/flag values when set.
+// KEPLOY_RECORD_CONSUMER_STALL_GRACE and KEPLOY_RECORD_HALF_CLOSE_GRACE
+// override the yaml/flag values when set.
 type RecordBuffer struct {
 	// MaxMemoryPerConnection caps the bytes the recorder may hold
 	// in the per-connection queue while the parser catches up.

--- a/config/default.go
+++ b/config/default.go
@@ -117,7 +117,8 @@ record:
   # recordBuffer tunes the per-connection recording queue. Touch only
   # if you see "mock incomplete" warnings (reason: per_conn_cap) in
   # the agent logs. Env vars KEPLOY_RECORD_MAX_MEMORY_PER_CONN,
-  # KEPLOY_RECORD_QUEUE_SIZE and KEPLOY_RECORD_CONSUMER_STALL_GRACE
+  # KEPLOY_RECORD_QUEUE_SIZE, KEPLOY_RECORD_CONSUMER_STALL_GRACE and
+  # KEPLOY_RECORD_HALF_CLOSE_GRACE
   # override these values.
   recordBuffer:
     # Bytes. 67108864 = 64 MiB. Zero falls through to the built-in


### PR DESCRIPTION
## The bug

#4538 registered `--half-close-grace`, aliased it in `flagNameMapping`, and forwarded it to the agent's argv — and **nothing ever read it**. No `resolveRecordBuffer*` call was added, so the value never reached `config.Record.RecordBuffer.HalfCloseGrace`.

In **docker record mode the gap is total**. `pkg/platform/docker/util.go` says it outright: the host's `keploy.yml` is not bind-mounted into the agent container, so argv is the only propagation channel. The orchestrator appended `--half-close-grace -1s`, the containerised agent parsed it and discarded it, and ran the 10s default.

So an operator who set a negative value to **disable** half-close got it **enabled** — the opposite of what they configured, and invisible from outside. The native agent survived only by accident, because `--config-path` is forwarded and the agent re-reads the same `keploy.yml`.

Measured before the fix:

```
--consumer-stall-grace 7s   -> cfg = 7s     (sibling works)
--half-close-grace   -1s    -> cfg = 10s    (dead)
```

## The fix

The resolve call, in both blocks (`record`/`test` and `agent`). That also activates `KEPLOY_RECORD_HALF_CLOSE_GRACE`, now documented alongside its three siblings.

## The test is an AST pin, deliberately

A runtime harness cannot reach these: the resolve calls sit inside `ValidateFlags` behind validation a bare harness cannot satisfy — which is precisely why a registration test passed the whole time while the knob did nothing. Same technique, and the same reason, as `relay_config_test.go`'s pin on the `relay.Config` literal.

It is also **generalised rather than specific**: *every* flag registered against `config.Record.RecordBuffer` must be passed to a `resolveRecordBuffer*` helper. The next knob added fails the same way, and this catches it.

Mutation-verified — removing the new resolve calls fails it by name:

```
--half-close-grace is registered against config.Record.RecordBuffer but never
passed to a resolveRecordBuffer* helper. It parses, it is forwarded to the
agent's argv, and nothing reads it into config — a knob that silently does
nothing.
```

`go test ./...` 65 packages green; `vet`/`gofmt` clean.