### PR TITLE
revert(replay): restore the readiness gate's stage-1 TCP dial

### DIFF
--- a/pkg/service/replay/app_ready_http_gate_test.go
+++ b/pkg/service/replay/app_ready_http_gate_test.go
@@ -6,6 +6,8 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -464,4 +466,121 @@ func TestWaitForAppReady_DockerStartKeepsItsGate(t *testing.T) {
 			"round-trip. Its ports were published at create time, so there is no -p to parse "+
 			"and the resolved-test-target fallback is the only gate it has.", elapsed)
 	}
+}
+
+// TestWaitForAppReady_UnreachableTargetReportsWhatWasObserved pins the
+// reason stage 1 exists at all, which is not what an earlier version of
+// this file assumed.
+//
+// That version skipped the fallback's stage-1 TCP dial, reasoning that
+// it was a redundant connect-then-close on a path where a port-forward
+// is hostile to exactly that shape. The reasoning was wrong and is worth
+// recording: waitForHTTPServingPath sets DisableKeepAlives, so EVERY one
+// of its 200ms polls is itself a fresh connect-then-close. Over the 3m
+// default ceiling that is ~900 of them, and dropping the single stage-1
+// dial removed roughly 1 in 900 — measured at 16 vs 15 against a 3s
+// ceiling. It bought nothing.
+//
+// What it cost is this: with stage 1 skipped, an app that never accepts
+// TCP at all is reported as "accepted TCP but never completed an HTTP
+// round-trip", and WaitForPort's specific error is flattened to a bare
+// context deadline. That is a false statement about the failure the
+// operator is staring at, on the very case this gate was added for
+// (status_code=0 because nothing was listening yet).
+func TestWaitForAppReady_UnreachableTargetReportsWhatWasObserved(t *testing.T) {
+	// A port nothing listens on: TCP never accepts.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	host, port, _ := net.SplitHostPort(ln.Addr().String())
+	_ = ln.Close() // free it so connects are refused
+
+	core, logs := observer.New(zapcore.WarnLevel)
+	logger := zap.New(core)
+
+	cfg := gateCfg(700 * time.Millisecond)
+	cfg.Command = "python3 recorded_app.py"
+	cfg.CommandType = "native"
+	cfg.Test.Delay = 0
+
+	if !waitForAppReady(context.Background(), logger, cfg,
+		httpProbeTarget{scheme: "http", host: host, port: port, ok: true}) {
+		t.Fatal("the gate must stay best-effort and proceed, never fail the run")
+	}
+
+	var got string
+	for _, e := range logs.All() {
+		if strings.Contains(e.Message, "app address did not accept a connection") {
+			got = e.Message
+		}
+		if strings.Contains(e.Message, "app accepted TCP but never completed") {
+			t.Fatalf("the gate reported %q for an address that never accepted TCP. Stage 1 is "+
+				"what tells those two apart; skipping it makes the warning describe an "+
+				"app-level HTTP problem when the truth is that nothing is listening.", e.Message)
+		}
+	}
+	if got == "" {
+		t.Fatal("no readiness warning was emitted for an address that never accepts; the " +
+			"operator gets no signal at all about why the first test fired early")
+	}
+}
+
+// The opt-out covers the reset-resend readiness re-gate too — that path
+// needs it MORE, since its trigger is a transport reset, which behind a
+// port-forward is what a dying forward produces. Asserted by counting
+// connections, because the probe returns in microseconds against a
+// listener that accepts.
+func TestWaitForResetResendReady_HonoursTheDisableFlag(t *testing.T) {
+	host, port, conns := countingListener(t)
+
+	for _, tc := range []struct {
+		name     string
+		disabled bool
+		wantMin  int64
+	}{
+		{"probing enabled", false, 1},
+		{"probing disabled", true, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			before := conns.Load()
+			cfg := gateCfg(500 * time.Millisecond)
+			cfg.Test.Host = host
+			cfg.Test.Port = uint32(mustAtoi(t, port))
+			cfg.Test.DisableAppReadyProbe = tc.disabled
+
+			r := &Replayer{config: cfg, logger: zap.NewNop()}
+			r.waitForResetResendReady(context.Background(),
+				&models.TestCase{
+					// Kind is load-bearing: resolveProbeTarget returns
+					// ok=false for anything that is not HTTP, so without
+					// it the probe never runs and BOTH cases would show
+					// zero connections — the disabled assertion would
+					// pass for the wrong reason.
+					Kind:    models.HTTP,
+					HTTPReq: models.HTTPReq{URL: "http://" + host + ":" + port + "/x"},
+				},
+				"test-set-0")
+
+			made := conns.Load() - before
+			if tc.disabled && made != 0 {
+				t.Fatalf("%d connection(s) made with probing disabled; the reset-resend re-gate "+
+					"re-opens the destructive probe in response to the very reset a dying "+
+					"port-forward produces", made)
+			}
+			if !tc.disabled && made < tc.wantMin {
+				t.Fatalf("no connection made with probing ENABLED: the disabled case above " +
+					"would then pass for the wrong reason")
+			}
+		})
+	}
+}
+
+func mustAtoi(t *testing.T, s string) int {
+	t.Helper()
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		t.Fatalf("atoi %q: %v", s, err)
+	}
+	return n
 }

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -553,45 +553,24 @@ func waitForHTTPServingPath(ctx context.Context, scheme, host, port, path string
 // wait LONGER than --delay, never shorter; a timeout WARNS and proceeds rather
 // than failing the run; and it never weakens an assertion. Returns false only on
 // context cancellation (user abort).
-// gateMode tweaks how gateOnAppAddress probes. The zero value runs both
-// stages; httpOnly skips the stage-1 TCP dial, for the one caller whose
-// stage-1 and stage-2 addresses are identical and whose bare
-// connect-then-close is therefore both redundant and harmful.
-type gateMode int
-
-const (
-	bothStages gateMode = iota
-	httpOnly
-)
-
-func gateOnAppAddress(ctx context.Context, logger *zap.Logger, cfg *config.Config, host, port, label string, probe httpProbeTarget, modes ...gateMode) bool {
-	mode := bothStages
-	if len(modes) > 0 {
-		mode = modes[0]
-	}
+func gateOnAppAddress(ctx context.Context, logger *zap.Logger, cfg *config.Config, host, port, label string, probe httpProbeTarget) bool {
 	ceiling := cfg.Test.HealthPollTimeout
 	if ceiling <= 0 {
 		ceiling = config.DefaultHealthPollTimeout
 	}
 	deadline := time.Now().Add(ceiling)
 
-	// Stage 1: the address accepts a TCP connection. Skipped in
-	// httpOnly mode, where stage 2 probes the very same address and the
-	// bare connect-then-close would be redundant — see the rationale at
-	// the resolved-test-target call site.
-	if mode != httpOnly {
-		if err := pkg.WaitForPort(ctx, host, port, ceiling); err != nil {
-			if ctx.Err() != nil {
-				return false
-			}
-			logger.Warn("app address did not accept a connection within the ceiling; firing tests anyway (replay may see status_code got=0)",
-				zap.String("gate", label),
-				zap.String("host", host),
-				zap.String("port", port),
-				zap.Duration("ceiling", ceiling),
-				zap.Error(err))
-			return true
+	if err := pkg.WaitForPort(ctx, host, port, ceiling); err != nil {
+		if ctx.Err() != nil {
+			return false
 		}
+		logger.Warn("app address did not accept a connection within the ceiling; firing tests anyway (replay may see status_code got=0)",
+			zap.String("gate", label),
+			zap.String("host", host),
+			zap.String("port", port),
+			zap.Duration("ceiling", ceiling),
+			zap.Error(err))
+		return true
 	}
 
 	if !probe.ok {
@@ -835,23 +814,7 @@ func waitForAppReady(ctx context.Context, logger *zap.Logger, cfg *config.Config
 		// longer than --delay. Guarded on `gated` purely to avoid probing twice
 		// when a published address already covered it.
 		if !gated && probe.ok {
-			// httpOnly: skip gateOnAppAddress's stage-1 bare TCP dial.
-			//
-			// Here, and only here, stage 1 and stage 2 probe the SAME
-			// address, so the dial proves nothing the HTTP round-trip
-			// does not — waitForHTTPServingPath already treats refusal
-			// and reset as not-ready and retries to the ceiling. What
-			// the dial does add is a naked connect-then-close, the
-			// shape a kubectl port-forward's SPDY relay is most hostile
-			// to. Dropping it removes that shape from the exact path
-			// that broke keploy/k8s-proxy, for every embedder that
-			// never learns about test.disableAppReadyProbe, at no cost
-			// in coverage.
-			//
-			// The docker and compose gates above deliberately pass a
-			// DIFFERENT stage-1 address than the probe target, so their
-			// dial is not redundant and stays.
-			if !gateOnAppAddress(ctx, logger, cfg, probe.host, probe.port, "resolved-test-target", probe, httpOnly) {
+			if !gateOnAppAddress(ctx, logger, cfg, probe.host, probe.port, "resolved-test-target", probe) {
 				return false
 			}
 		}


### PR DESCRIPTION
Follow-up to #4539, correcting one half of it. The flag it added is sound and stays; the stage-1 skip does not.

## The reasoning was wrong, and measurably so

#4539 made the resolved-test-target fallback skip `gateOnAppAddress`'s stage-1 dial, arguing it was a redundant connect-then-close on the path where a `kubectl port-forward` is hostile to exactly that shape.

But `waitForHTTPServingPath` sets `DisableKeepAlives`, so **every one of its 200ms polls is itself a fresh connect-then-close**. Over the 3m default ceiling that's ~900 of them. Dropping the single stage-1 dial removed roughly **1 in 900** — measured at 16 vs 15 against a 3s ceiling.

It bought nothing. The `test.disableAppReadyProbe` flag added in the same PR is what actually protects k8s-proxy.

## What it cost

A truthful diagnostic. With stage 1 skipped, an app that never accepts TCP is reported as:

> app accepted TCP but never completed an HTTP round-trip

…which is false, and `WaitForPort`'s specific error — naming the port, suggesting a larger `--delay` — is flattened to a bare `context deadline exceeded`. That lands on precisely the case this gate exists to catch: `status_code=0` because nothing was listening yet.

It was also unrequested scope in a bugfix PR, and nothing pinned it — reverting the argument left every test passing.

## Two tests, closing two gaps

Both gaps were the same shape: a comment asserting coverage the tests didn't provide.

1. **The warning must describe what was observed.** An address that never accepts TCP has to produce the accept failure, not the HTTP one.
2. **The reset-resend re-gate honours the flag.** That path needs the opt-out *more* than the pre-test gate: its trigger is a transport reset, which behind a port-forward is what a dying forward produces, so re-opening the probe in response is the thing most likely to finish it off. Deleting the early return previously kept every test green; now it fails in 10s.

Both assert on **connections made**, not elapsed time — against a listener that accepts instantly, a probe that *is* made still returns in microseconds, so a wall-clock assertion can't tell the two apart. That was the exact defect a reviewer found in #4539's first test round.

`go test ./...` 65 packages green; `vet`/`gofmt` clean.