### PR TITLE
fix(generic): forward the FIN on the legacy path so half-close does not hang

### DIFF
--- a/pkg/agent/proxy/incoming/forward_raw_half_close_test.go
+++ b/pkg/agent/proxy/incoming/forward_raw_half_close_test.go
@@ -1,0 +1,116 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	proxyutil "go.keploy.io/server/v3/pkg/agent/proxy/util"
+	"go.uber.org/zap"
+)
+
+// forwardRawTCP is the sampling-bypass byte pump: no capture, no HTTP
+// parsing. It still has to forward each side's FIN, and it does so
+// UNCONDITIONALLY — unlike the record paths, which gate on a clean copy
+// so a truncated request is never reported to the peer as complete.
+//
+// The difference is deliberate and worth pinning. This pump joins on both
+// copies, so the FIN is what unblocks the peer io.Copy. Gating it on a
+// clean exit would leave a client-side error with nothing to wake the
+// upstream side — two goroutines and two sockets held until the upstream
+// closes on its own, which on an idle WebSocket is minutes. An earlier
+// version of this change added that gate; this test exists so it is not
+// added again.
+//
+// The FIN also used to be forwarded via a concrete *net.TCPConn
+// assertion, which silently skipped every *tls.Conn and every wrapped
+// conn. So one case here drives a SafeConn, the wrapper shape that
+// assertion could not see through.
+func TestForwardRawTCPForwardsTheFIN(t *testing.T) {
+	pair := func(t *testing.T, wrap bool) (peer, proxySide net.Conn) {
+		t.Helper()
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen: %v", err)
+		}
+		defer func() { _ = ln.Close() }()
+		type res struct {
+			c   net.Conn
+			err error
+		}
+		ch := make(chan res, 1)
+		go func() { c, err := ln.Accept(); ch <- res{c, err} }()
+		d, err := net.Dial("tcp", ln.Addr().String())
+		if err != nil {
+			t.Fatalf("dial: %v", err)
+		}
+		got := <-ch
+		if got.err != nil {
+			t.Fatalf("accept: %v", got.err)
+		}
+		t.Cleanup(func() { _ = d.Close(); _ = got.c.Close() })
+		if wrap {
+			return d, proxyutil.NewSafeConn(got.c, zap.NewNop())
+		}
+		return d, got.c
+	}
+
+	for _, wrapped := range []bool{false, true} {
+		name := "raw conns"
+		if wrapped {
+			name = "SafeConn-wrapped, the shape a concrete type assertion misses"
+		}
+		t.Run(name, func(t *testing.T) {
+			clientApp, srcProxy := pair(t, wrapped)
+			upSvc, upProxy := pair(t, wrapped)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go forwardRawTCP(ctx, srcProxy, upProxy)
+
+			request := []byte("upgrade-then-eof\n")
+			reply := []byte("upstream-reply\n")
+
+			srvDone := make(chan error, 1)
+			go func() {
+				got, err := io.ReadAll(upSvc)
+				if err != nil {
+					srvDone <- err
+					return
+				}
+				if !bytes.Equal(got, request) {
+					srvDone <- io.ErrUnexpectedEOF
+					return
+				}
+				_, err = upSvc.Write(reply)
+				srvDone <- err
+			}()
+
+			if _, err := clientApp.Write(request); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if err := clientApp.(*net.TCPConn).CloseWrite(); err != nil {
+				t.Fatalf("half-close: %v", err)
+			}
+
+			select {
+			case err := <-srvDone:
+				if err != nil {
+					t.Fatalf("upstream: %v", err)
+				}
+			case <-time.After(3 * time.Second):
+				t.Fatal("the upstream never saw EOF: the FIN was not forwarded, so an " +
+					"EOF-delimited peer waits for bytes that will never come")
+			}
+
+			_ = clientApp.SetReadDeadline(time.Now().Add(3 * time.Second))
+			got := make([]byte, len(reply))
+			if _, err := io.ReadFull(clientApp, got); err != nil {
+				t.Fatalf("client never received the reply: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/agent/proxy/incoming/http.go
+++ b/pkg/agent/proxy/incoming/http.go
@@ -13,6 +13,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	proxyutil "go.keploy.io/server/v3/pkg/agent/proxy/util"
+
 	"go.keploy.io/server/v3/pkg"
 	hooksUtils "go.keploy.io/server/v3/pkg/agent/hooks/conn"
 	"go.keploy.io/server/v3/pkg/agent/memoryguard"
@@ -1761,18 +1763,27 @@ func forwardRawTCP(ctx context.Context, clientConn, upConn net.Conn) {
 	}()
 
 	done := make(chan struct{}, 2)
+	// The FIN forwarding below used to assert *net.TCPConn concretely,
+	// which silently skipped every *tls.Conn and every wrapped conn —
+	// the capability is what matters here, not the concrete type.
+	//
+	// UNCONDITIONAL, unlike the record paths in integrations/. Those gate
+	// on a clean copy so a truncated request is never reported to the
+	// peer as complete — a record-FIDELITY argument, and this pump
+	// captures nothing. What it does instead is join on both copies, so
+	// the FIN is what unblocks the peer io.Copy: signalling only on a
+	// clean exit leaves a client-side error with nothing to wake the
+	// upstream side, and two goroutines plus two sockets sit there until
+	// the upstream closes on its own. On an idle WebSocket that is
+	// minutes.
 	go func() {
 		_, _ = io.Copy(upConn, clientConn)
-		if tc, ok := upConn.(*net.TCPConn); ok {
-			_ = tc.CloseWrite()
-		}
+		_ = proxyutil.CloseWriteIfPossible(upConn)
 		done <- struct{}{}
 	}()
 	go func() {
 		_, _ = io.Copy(clientConn, upConn)
-		if tc, ok := clientConn.(*net.TCPConn); ok {
-			_ = tc.CloseWrite()
-		}
+		_ = proxyutil.CloseWriteIfPossible(clientConn)
 		done <- struct{}{}
 	}()
 	<-done

--- a/pkg/agent/proxy/integrations/generic/encode.go
+++ b/pkg/agent/proxy/integrations/generic/encode.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"time"
 
+	proxyutil "go.keploy.io/server/v3/pkg/agent/proxy/util"
+
 	"go.keploy.io/server/v3/pkg/agent/memoryguard"
 	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/util"
 	syncMock "go.keploy.io/server/v3/pkg/agent/proxy/syncMock"
@@ -94,13 +96,22 @@ func encodeGeneric(ctx context.Context, logger *zap.Logger, reqBuf []byte, clien
 	go func() {
 		defer clientCloseOnce.Do(func() { close(clientCapChan) })
 		tee := &captureTeeWriter{dest: destConn, ch: clientCapChan, closeOnce: clientCloseOnce}
-		_, _ = io.Copy(tee, clientConn)
+		_, err := io.Copy(tee, clientConn)
+		// Close the capture channel BEFORE the FIN: forwardFIN can write
+		// a close_notify on a TLS conn, and SafeConn's write deadline is
+		// a no-op, so a stalled peer would otherwise hold
+		// createGenericMocksAsync open behind it. The deferred Do is a
+		// sync.Once, so this is the early half of the same close.
+		clientCloseOnce.Do(func() { close(clientCapChan) })
+		forwardFIN(destConn, err)
 		done <- struct{}{}
 	}()
 	go func() {
 		defer destCloseOnce.Do(func() { close(destCapChan) })
 		tee := &captureTeeWriter{dest: clientConn, ch: destCapChan, closeOnce: destCloseOnce}
-		_, _ = io.Copy(tee, destConn)
+		_, err := io.Copy(tee, destConn)
+		destCloseOnce.Do(func() { close(destCapChan) })
+		forwardFIN(clientConn, err)
 		done <- struct{}{}
 	}()
 	<-done
@@ -109,11 +120,36 @@ func encodeGeneric(ctx context.Context, logger *zap.Logger, reqBuf []byte, clien
 	return nil
 }
 
+// forwardFIN half-closes dst when the copy that fed it ended cleanly.
+//
+// A finished io.Copy means this side sent shutdown(SHUT_WR) — it has no
+// more to say — not that the connection is over. An EOF-delimited
+// protocol only learns the request ended when the FIN arrives, so
+// without this the peer waits for bytes that will never come while the
+// client waits for a reply it will never send, and the exchange
+// deadlocks until something external tears it down.
+//
+// copyErr is the gate, and it is not decoration. io.Copy returns nil
+// only on a clean EOF; a read error, a reset, or a failed write to the
+// real peer all exit the same loop. Forwarding a FIN for those would
+// tell the peer "the request is complete" about a message that was
+// truncated — and generic is the catch-all for mongo wire and arbitrary
+// binary RPC, where acting on a partial message can mean committing a
+// partial operation. A broken copy falls through to the ordinary
+// teardown instead.
+func forwardFIN(dst net.Conn, copyErr error) {
+	if copyErr != nil {
+		return
+	}
+	_ = proxyutil.CloseWriteIfPossible(dst)
+}
+
 // forwardBidirectional does raw TCP passthrough without any capture.
 func forwardBidirectional(clientConn, destConn net.Conn) error {
 	done := make(chan struct{}, 2)
 	cp := func(dst, src net.Conn) {
-		_, _ = io.Copy(dst, src)
+		_, err := io.Copy(dst, src)
+		forwardFIN(dst, err)
 		done <- struct{}{}
 	}
 	go cp(destConn, clientConn)

--- a/pkg/agent/proxy/integrations/generic/half_close_test.go
+++ b/pkg/agent/proxy/integrations/generic/half_close_test.go
@@ -1,0 +1,167 @@
+package generic
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	proxyutil "go.keploy.io/server/v3/pkg/agent/proxy/util"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// The legacy generic path is what KEPLOY_NEW_RELAY=off routes to, so it
+// is the rollback for the V2 relay's half-close support. It is broken
+// differently from the relay rather than identically: it waits for BOTH
+// copy directions instead of tearing the second down, so it never lost
+// the reply — but it never forwarded the FIN either, so an EOF-delimited
+// peer never learned the request had ended and the exchange deadlocked
+// until external teardown.
+//
+// CRITICAL to how these tests are written: the conns must be wrapped the
+// way proxy.buildRecordSession wraps them. util.SafeConn holds its conn
+// as an unexported, NON-EMBEDDED field, so nothing is promoted — a
+// CloseWrite forwarded through a raw *net.TCPConn proves nothing about
+// production, where a SafeConn is what actually arrives. An earlier
+// version of this file used raw TCP conns, passed, and certified a fix
+// that was a guaranteed no-op on every real code path.
+
+// prodPair returns a connected pair where the PROXY side is wrapped
+// exactly as buildRecordSession wraps it, and the peer side is raw (it
+// stands in for the real client or the real service).
+func prodPair(t *testing.T, withReader bool) (peer net.Conn, proxySide net.Conn) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	type res struct {
+		c   net.Conn
+		err error
+	}
+	ch := make(chan res, 1)
+	go func() {
+		c, err := ln.Accept()
+		ch <- res{c, err}
+	}()
+	d, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	got := <-ch
+	if got.err != nil {
+		t.Fatalf("accept: %v", got.err)
+	}
+	t.Cleanup(func() { _ = d.Close(); _ = got.c.Close() })
+
+	raw := got.c
+	if withReader {
+		return d, proxyutil.NewSafeConnWithReader(raw, raw, zap.NewNop())
+	}
+	return d, proxyutil.NewSafeConn(raw, zap.NewNop())
+}
+
+// halfCloseExchange drives one request/EOF/response exchange through
+// `run` and reports whether the reply came back.
+func halfCloseExchange(t *testing.T, run func(clientConn, destConn net.Conn)) {
+	t.Helper()
+	clientApp, srcProxy := prodPair(t, true) // Ingress: NewSafeConnWithReader
+	destSvc, dstProxy := prodPair(t, false)  // Egress: NewSafeConn
+
+	go run(srcProxy, dstProxy)
+
+	request := []byte("matrix-generic\n")
+	reply := []byte("fixture-ack:matrix-generic\n")
+
+	srvDone := make(chan error, 1)
+	go func() {
+		got, err := io.ReadAll(destSvc) // returns only once the FIN arrives
+		if err != nil {
+			srvDone <- err
+			return
+		}
+		if !bytes.Equal(got, request) {
+			srvDone <- io.ErrUnexpectedEOF
+			return
+		}
+		_, err = destSvc.Write(reply)
+		srvDone <- err
+	}()
+
+	if _, err := clientApp.Write(request); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := clientApp.(*net.TCPConn).CloseWrite(); err != nil {
+		t.Fatalf("half-close: %v", err)
+	}
+
+	select {
+	case err := <-srvDone:
+		if err != nil {
+			t.Fatalf("service: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("the service never saw EOF: the FIN was not forwarded through the SafeConn " +
+			"wrapper, so an EOF-delimited peer never learns the request ended. It waits for " +
+			"bytes that will not come while the client waits for a reply it will not send.")
+	}
+
+	_ = clientApp.SetReadDeadline(time.Now().Add(3 * time.Second))
+	got := make([]byte, len(reply))
+	if _, err := io.ReadFull(clientApp, got); err != nil {
+		t.Fatalf("client never received the reply after half-closing: %v", err)
+	}
+	if !bytes.Equal(got, reply) {
+		t.Fatalf("client got % x, want % x", got, reply)
+	}
+}
+
+// encodeGeneric is the path that actually runs during recording.
+func TestEncodeGeneric_ForwardsTheFIN(t *testing.T) {
+	mocks := make(chan *models.Mock, 8)
+	halfCloseExchange(t, func(clientConn, destConn net.Conn) {
+		_ = encodeGeneric(context.Background(), zap.NewNop(), nil, clientConn, destConn,
+			mocks, models.OutgoingOptions{})
+	})
+}
+
+// forwardBidirectional is the memoryguard-paused passthrough.
+func TestForwardBidirectional_ForwardsTheFIN(t *testing.T) {
+	halfCloseExchange(t, func(clientConn, destConn net.Conn) {
+		_ = forwardBidirectional(clientConn, destConn)
+	})
+}
+
+// SafeConn must actually implement the capability, or every call above
+// silently degrades to a no-op and the deadlock returns.
+func TestSafeConnSupportsHalfClose(t *testing.T) {
+	_, proxySide := prodPair(t, false)
+	if _, ok := proxySide.(interface{ CloseWrite() error }); !ok {
+		t.Fatal("util.SafeConn does not implement CloseWrite: it holds its conn as an " +
+			"unexported non-embedded field, so nothing is promoted and every half-close " +
+			"through it is silently dropped")
+	}
+}
+
+// A copy that ended in an ERROR must not be reported to the peer as a
+// completed request: generic is the catch-all for mongo wire and
+// arbitrary binary RPC, where acting on a truncated message can mean
+// committing a partial operation.
+func TestForwardFIN_SkipsWhenTheCopyFailed(t *testing.T) {
+	peer, proxySide := prodPair(t, false)
+
+	forwardFIN(proxySide, io.ErrUnexpectedEOF)
+
+	_ = peer.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
+	buf := make([]byte, 1)
+	_, err := peer.Read(buf)
+	if err == io.EOF {
+		t.Fatal("a FIN was forwarded for a copy that ended in an error: the peer will read " +
+			"that as a complete request and may act on a truncated message")
+	}
+}

--- a/pkg/agent/proxy/integrations/http/encode.go
+++ b/pkg/agent/proxy/integrations/http/encode.go
@@ -12,6 +12,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	proxyutil "go.keploy.io/server/v3/pkg/agent/proxy/util"
+
 	"golang.org/x/sync/errgroup"
 
 	"go.keploy.io/server/v3/pkg/agent/memoryguard"
@@ -154,7 +156,15 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 				h.Logger.Debug("memory pressure detected, stopping HTTP recording and falling back to passthrough")
 				done := make(chan struct{}, 2)
 				cp := func(dst, src net.Conn) {
-					_, _ = io.Copy(dst, src)
+					_, err := io.Copy(dst, src)
+					// Forward the FIN on a clean copy: an
+					// EOF-delimited peer only learns the request
+					// ended when it arrives. Gated on err==nil so a
+					// truncated request is never reported as
+					// complete. See util.CloseWriteIfPossible.
+					if err == nil {
+						_ = proxyutil.CloseWriteIfPossible(dst)
+					}
 					done <- struct{}{}
 				}
 				go cp(destConn, clientConn)

--- a/pkg/agent/proxy/integrations/http/encode.go
+++ b/pkg/agent/proxy/integrations/http/encode.go
@@ -154,23 +154,7 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 		for {
 			if memoryguard.IsRecordingPaused() {
 				h.Logger.Debug("memory pressure detected, stopping HTTP recording and falling back to passthrough")
-				done := make(chan struct{}, 2)
-				cp := func(dst, src net.Conn) {
-					_, err := io.Copy(dst, src)
-					// Forward the FIN on a clean copy: an
-					// EOF-delimited peer only learns the request
-					// ended when it arrives. Gated on err==nil so a
-					// truncated request is never reported as
-					// complete. See util.CloseWriteIfPossible.
-					if err == nil {
-						_ = proxyutil.CloseWriteIfPossible(dst)
-					}
-					done <- struct{}{}
-				}
-				go cp(destConn, clientConn)
-				go cp(clientConn, destConn)
-				<-done
-				<-done
+				relayRawPassthrough(clientConn, destConn)
 				return nil
 			}
 
@@ -453,4 +437,32 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 		}
 		return err
 	}
+}
+
+// relayRawPassthrough copies both directions to completion and forwards
+// each side's FIN, for the memory-pressure fallback where nothing is
+// captured.
+//
+// Extracted so it can be tested. Inline inside the memoryguard branch it
+// was unreachable from a unit test — memoryguard's paused flag is
+// unexported — so the FIN forwarding here was shipped uncovered, which is
+// exactly how the same one-liner went out as a silent no-op elsewhere in
+// this change.
+//
+// The FIN is gated on a clean io.Copy: a read error, a reset, or a failed
+// write to the peer all exit that loop too, and forwarding a FIN for those
+// tells the peer "the request is complete" about a truncated message.
+func relayRawPassthrough(clientConn, destConn net.Conn) {
+	done := make(chan struct{}, 2)
+	cp := func(dst, src net.Conn) {
+		_, err := io.Copy(dst, src)
+		if err == nil {
+			_ = proxyutil.CloseWriteIfPossible(dst)
+		}
+		done <- struct{}{}
+	}
+	go cp(destConn, clientConn)
+	go cp(clientConn, destConn)
+	<-done
+	<-done
 }

--- a/pkg/agent/proxy/integrations/http/passthrough_half_close_test.go
+++ b/pkg/agent/proxy/integrations/http/passthrough_half_close_test.go
@@ -1,0 +1,100 @@
+package http
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	proxyutil "go.keploy.io/server/v3/pkg/agent/proxy/util"
+	"go.uber.org/zap"
+)
+
+// relayRawPassthrough is the memory-pressure fallback: nothing is
+// captured, bytes are just relayed. It still has to forward each side's
+// FIN, or an EOF-delimited peer never learns the request ended and the
+// exchange deadlocks until something external tears it down.
+//
+// This was shipped uncovered once — the block was inline inside the
+// memoryguard branch and memoryguard's paused flag is unexported, so no
+// unit test could reach it. Extracting the loop was the fix; a test hook
+// in production code was the alternative and a worse trade.
+//
+// The conns are wrapped as the proxy wraps them. util.SafeConn holds its
+// conn as an unexported, NON-embedded field, so a FIN forwarded through
+// a raw *net.TCPConn proves nothing about production — that is exactly
+// how the same one-liner shipped as a silent no-op elsewhere.
+func TestRelayRawPassthroughForwardsTheFIN_HTTP(t *testing.T) {
+	pair := func(t *testing.T) (peer, proxySide net.Conn) {
+		t.Helper()
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen: %v", err)
+		}
+		defer func() { _ = ln.Close() }()
+		type res struct {
+			c   net.Conn
+			err error
+		}
+		ch := make(chan res, 1)
+		go func() { c, err := ln.Accept(); ch <- res{c, err} }()
+		d, err := net.Dial("tcp", ln.Addr().String())
+		if err != nil {
+			t.Fatalf("dial: %v", err)
+		}
+		got := <-ch
+		if got.err != nil {
+			t.Fatalf("accept: %v", got.err)
+		}
+		t.Cleanup(func() { _ = d.Close(); _ = got.c.Close() })
+		return d, proxyutil.NewSafeConn(got.c, zap.NewNop())
+	}
+
+	clientApp, srcProxy := pair(t)
+	destSvc, dstProxy := pair(t)
+
+	go relayRawPassthrough(srcProxy, dstProxy)
+
+	request := []byte("request-then-eof\n")
+	reply := []byte("reply-after-eof\n")
+
+	srvDone := make(chan error, 1)
+	go func() {
+		got, err := io.ReadAll(destSvc) // returns only once the FIN arrives
+		if err != nil {
+			srvDone <- err
+			return
+		}
+		if !bytes.Equal(got, request) {
+			srvDone <- io.ErrUnexpectedEOF
+			return
+		}
+		_, err = destSvc.Write(reply)
+		srvDone <- err
+	}()
+
+	if _, err := clientApp.Write(request); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := clientApp.(*net.TCPConn).CloseWrite(); err != nil {
+		t.Fatalf("half-close: %v", err)
+	}
+
+	select {
+	case err := <-srvDone:
+		if err != nil {
+			t.Fatalf("service: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("the service never saw EOF: the FIN was not forwarded through the SafeConn " +
+			"wrapper, so an EOF-delimited peer waits for bytes that will never come while " +
+			"the client waits for a reply that will never be sent")
+	}
+
+	_ = clientApp.SetReadDeadline(time.Now().Add(3 * time.Second))
+	got := make([]byte, len(reply))
+	if _, err := io.ReadFull(clientApp, got); err != nil {
+		t.Fatalf("client never received the reply: %v", err)
+	}
+}

--- a/pkg/agent/proxy/integrations/mysql/recorder/passthrough_half_close_test.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/passthrough_half_close_test.go
@@ -1,0 +1,100 @@
+package recorder
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	proxyutil "go.keploy.io/server/v3/pkg/agent/proxy/util"
+	"go.uber.org/zap"
+)
+
+// relayRawPassthrough is the memory-pressure fallback: nothing is
+// captured, bytes are just relayed. It still has to forward each side's
+// FIN, or an EOF-delimited peer never learns the request ended and the
+// exchange deadlocks until something external tears it down.
+//
+// This was shipped uncovered once — the block was inline inside the
+// memoryguard branch and memoryguard's paused flag is unexported, so no
+// unit test could reach it. Extracting the loop was the fix; a test hook
+// in production code was the alternative and a worse trade.
+//
+// The conns are wrapped as the proxy wraps them. util.SafeConn holds its
+// conn as an unexported, NON-embedded field, so a FIN forwarded through
+// a raw *net.TCPConn proves nothing about production — that is exactly
+// how the same one-liner shipped as a silent no-op elsewhere.
+func TestRelayRawPassthroughForwardsTheFIN_MySQL(t *testing.T) {
+	pair := func(t *testing.T) (peer, proxySide net.Conn) {
+		t.Helper()
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen: %v", err)
+		}
+		defer func() { _ = ln.Close() }()
+		type res struct {
+			c   net.Conn
+			err error
+		}
+		ch := make(chan res, 1)
+		go func() { c, err := ln.Accept(); ch <- res{c, err} }()
+		d, err := net.Dial("tcp", ln.Addr().String())
+		if err != nil {
+			t.Fatalf("dial: %v", err)
+		}
+		got := <-ch
+		if got.err != nil {
+			t.Fatalf("accept: %v", got.err)
+		}
+		t.Cleanup(func() { _ = d.Close(); _ = got.c.Close() })
+		return d, proxyutil.NewSafeConn(got.c, zap.NewNop())
+	}
+
+	clientApp, srcProxy := pair(t)
+	destSvc, dstProxy := pair(t)
+
+	go relayRawPassthrough(srcProxy, dstProxy)
+
+	request := []byte("request-then-eof\n")
+	reply := []byte("reply-after-eof\n")
+
+	srvDone := make(chan error, 1)
+	go func() {
+		got, err := io.ReadAll(destSvc) // returns only once the FIN arrives
+		if err != nil {
+			srvDone <- err
+			return
+		}
+		if !bytes.Equal(got, request) {
+			srvDone <- io.ErrUnexpectedEOF
+			return
+		}
+		_, err = destSvc.Write(reply)
+		srvDone <- err
+	}()
+
+	if _, err := clientApp.Write(request); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := clientApp.(*net.TCPConn).CloseWrite(); err != nil {
+		t.Fatalf("half-close: %v", err)
+	}
+
+	select {
+	case err := <-srvDone:
+		if err != nil {
+			t.Fatalf("service: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("the service never saw EOF: the FIN was not forwarded through the SafeConn " +
+			"wrapper, so an EOF-delimited peer waits for bytes that will never come while " +
+			"the client waits for a reply that will never be sent")
+	}
+
+	_ = clientApp.SetReadDeadline(time.Now().Add(3 * time.Second))
+	got := make([]byte, len(reply))
+	if _, err := io.ReadFull(clientApp, got); err != nil {
+		t.Fatalf("client never received the reply: %v", err)
+	}
+}

--- a/pkg/agent/proxy/integrations/mysql/recorder/query.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/query.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	proxyutil "go.keploy.io/server/v3/pkg/agent/proxy/util"
+
 	"go.keploy.io/server/v3/pkg/agent/memoryguard"
 	mysqlUtils "go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/utils"
 	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/wire"
@@ -58,7 +60,13 @@ func handleClientQueries(ctx context.Context, logger *zap.Logger, clientConn, de
 		logger.Debug("memory pressure detected, stopping MySQL recording and falling back to passthrough")
 		done := make(chan struct{}, 2)
 		cp := func(dst, src net.Conn) {
-			_, _ = io.Copy(dst, src)
+			_, err := io.Copy(dst, src)
+			// Forward the FIN on a clean copy; see
+			// util.CloseWriteIfPossible. Gated on err==nil so a
+			// truncated request is never reported as complete.
+			if err == nil {
+				_ = proxyutil.CloseWriteIfPossible(dst)
+			}
 			done <- struct{}{}
 		}
 		go cp(destConn, clientConn)

--- a/pkg/agent/proxy/integrations/mysql/recorder/query.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/query.go
@@ -58,21 +58,7 @@ func handleClientQueries(ctx context.Context, logger *zap.Logger, clientConn, de
 	// If recording is already paused, pure passthrough.
 	if memoryguard.IsRecordingPaused() {
 		logger.Debug("memory pressure detected, stopping MySQL recording and falling back to passthrough")
-		done := make(chan struct{}, 2)
-		cp := func(dst, src net.Conn) {
-			_, err := io.Copy(dst, src)
-			// Forward the FIN on a clean copy; see
-			// util.CloseWriteIfPossible. Gated on err==nil so a
-			// truncated request is never reported as complete.
-			if err == nil {
-				_ = proxyutil.CloseWriteIfPossible(dst)
-			}
-			done <- struct{}{}
-		}
-		go cp(destConn, clientConn)
-		go cp(clientConn, destConn)
-		<-done
-		<-done
+		relayRawPassthrough(clientConn, destConn)
 		return nil
 	}
 
@@ -1376,4 +1362,32 @@ func binaryRowHeadersOf(rows []*mysql.BinaryRow) []mysql.Header {
 		out = append(out, r.Header)
 	}
 	return out
+}
+
+// relayRawPassthrough copies both directions to completion and forwards
+// each side's FIN, for the memory-pressure fallback where nothing is
+// captured.
+//
+// Extracted so it can be tested. Inline inside the memoryguard branch it
+// was unreachable from a unit test — memoryguard's paused flag is
+// unexported — so the FIN forwarding here was shipped uncovered, which is
+// exactly how the same one-liner went out as a silent no-op elsewhere in
+// this change.
+//
+// The FIN is gated on a clean io.Copy: a read error, a reset, or a failed
+// write to the peer all exit that loop too, and forwarding a FIN for those
+// tells the peer "the request is complete" about a truncated message.
+func relayRawPassthrough(clientConn, destConn net.Conn) {
+	done := make(chan struct{}, 2)
+	cp := func(dst, src net.Conn) {
+		_, err := io.Copy(dst, src)
+		if err == nil {
+			_ = proxyutil.CloseWriteIfPossible(dst)
+		}
+		done <- struct{}{}
+	}
+	go cp(destConn, clientConn)
+	go cp(clientConn, destConn)
+	<-done
+	<-done
 }

--- a/pkg/agent/proxy/opportunistic_half_close_test.go
+++ b/pkg/agent/proxy/opportunistic_half_close_test.go
@@ -1,0 +1,107 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy/util"
+	"go.uber.org/zap"
+)
+
+// relayPlaintext is the in-repo precedent for half-close handling: copy
+// both directions, CloseWrite each when its copy ends, wait for both. It
+// is also the last caller of this package's closeWriteIfPossible, which
+// is now a thin alias over util.CloseWriteIfPossible.
+//
+// That alias had no test. Making it a no-op left the whole suite green,
+// which is how the same one-liner shipped inert twice elsewhere in this
+// change — so pin the behaviour, not the delegation.
+func TestRelayPlaintextForwardsTheFIN(t *testing.T) {
+	pair := func(t *testing.T, wrap bool) (peer, proxySide net.Conn) {
+		t.Helper()
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen: %v", err)
+		}
+		defer func() { _ = ln.Close() }()
+		type res struct {
+			c   net.Conn
+			err error
+		}
+		ch := make(chan res, 1)
+		go func() { c, err := ln.Accept(); ch <- res{c, err} }()
+		d, err := net.Dial("tcp", ln.Addr().String())
+		if err != nil {
+			t.Fatalf("dial: %v", err)
+		}
+		got := <-ch
+		if got.err != nil {
+			t.Fatalf("accept: %v", got.err)
+		}
+		t.Cleanup(func() { _ = d.Close(); _ = got.c.Close() })
+		if wrap {
+			return d, util.NewSafeConn(got.c, zap.NewNop())
+		}
+		return d, got.c
+	}
+
+	for _, wrapped := range []bool{false, true} {
+		name := "raw conns"
+		if wrapped {
+			name = "SafeConn-wrapped"
+		}
+		t.Run(name, func(t *testing.T) {
+			clientApp, srcProxy := pair(t, wrapped)
+			destSvc, dstProxy := pair(t, wrapped)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go func() { _ = relayPlaintext(ctx, srcProxy, dstProxy) }()
+
+			request := []byte("plaintext-then-eof\n")
+			reply := []byte("plaintext-reply\n")
+
+			srvDone := make(chan error, 1)
+			go func() {
+				got, err := io.ReadAll(destSvc)
+				if err != nil {
+					srvDone <- err
+					return
+				}
+				if !bytes.Equal(got, request) {
+					srvDone <- io.ErrUnexpectedEOF
+					return
+				}
+				_, err = destSvc.Write(reply)
+				srvDone <- err
+			}()
+
+			if _, err := clientApp.Write(request); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if err := clientApp.(*net.TCPConn).CloseWrite(); err != nil {
+				t.Fatalf("half-close: %v", err)
+			}
+
+			select {
+			case err := <-srvDone:
+				if err != nil {
+					t.Fatalf("service: %v", err)
+				}
+			case <-time.After(3 * time.Second):
+				t.Fatal("the service never saw EOF: closeWriteIfPossible did not forward the " +
+					"FIN, so an EOF-delimited peer waits for bytes that never come")
+			}
+
+			_ = clientApp.SetReadDeadline(time.Now().Add(3 * time.Second))
+			got := make([]byte, len(reply))
+			if _, err := io.ReadFull(clientApp, got); err != nil {
+				t.Fatalf("client never received the reply: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/agent/proxy/opportunistic_tls.go
+++ b/pkg/agent/proxy/opportunistic_tls.go
@@ -587,11 +587,11 @@ func relayPlaintext(ctx context.Context, a, b net.Conn) error {
 // the peer's read returns EOF. Falls back to a no-op when the conn
 // type doesn't support half-close.
 func closeWriteIfPossible(c net.Conn) error {
-	type closeWriter interface{ CloseWrite() error }
-	if cw, ok := c.(closeWriter); ok {
-		return cw.CloseWrite()
-	}
-	return nil
+	// Thin alias kept for the call sites in this file; the
+	// implementation lives in util because that is the only package
+	// able to see through SafeConn, which wraps essentially every conn
+	// a parser touches.
+	return util.CloseWriteIfPossible(c)
 }
 
 // pushSignal publishes a goroutine's verdict. The send is unguarded on

--- a/pkg/agent/proxy/util/safeconn.go
+++ b/pkg/agent/proxy/util/safeconn.go
@@ -81,6 +81,27 @@ func (s *SafeConn) SetReadDeadline(_ time.Time) error { return nil }
 // SetWriteDeadline is a no-op in record mode.
 func (s *SafeConn) SetWriteDeadline(_ time.Time) error { return nil }
 
+// CloseWrite forwards a half-close to the wrapped conn: it tells the
+// peer this side has finished writing, while leaving the connection
+// readable.
+//
+// This is a deliberate, narrow hole in SafeConn's contract. Close and
+// the deadline setters are no-ops here precisely so a parser cannot
+// terminate a connection the proxy owns — but half-close is not
+// termination. It is protocol content: an EOF-delimited exchange only
+// learns the request has ended when the FIN arrives, so a parser that
+// cannot forward one leaves the peer waiting for bytes that will never
+// come while the client waits for a reply that will never be sent.
+// Swallowing it does not protect the connection, it deadlocks it.
+//
+// Nothing is promoted for free here: SafeConn holds its conn as an
+// unexported, non-embedded field, so without this method the type
+// assertion in [CloseWriteIfPossible] simply fails and every half-close
+// through a SafeConn is silently dropped.
+func (s *SafeConn) CloseWrite() error {
+	return CloseWriteIfPossible(s.conn)
+}
+
 // Unwrap returns the real underlying net.Conn. This method is
 // intentionally NOT part of the net.Conn interface. Only the proxy
 // layer (which creates SafeConn) should call this — parsers must not.


### PR DESCRIPTION
#4538 fixed TCP half-close in the V2 relay. The **legacy** path — what `KEPLOY_NEW_RELAY=off` routes to, i.e. the documented rollback for that fix — is broken differently, and was left broken. Rolling back to escape one half-close defect lands on another.

## The defect

`encodeGeneric` and `forwardBidirectional` both wait for **both** copy directions instead of tearing the second down, so unlike the relay they never *lost* the reply. But neither ever called `CloseWrite`, so the FIN was never forwarded and an EOF-delimited peer never learned the request had ended — it waits for bytes that will not come while the client waits for a reply it will not send, until something external tears the connection down.

## Why the fix lives in `util`, and why the first attempt was a no-op

`SafeConn` holds its conn as an unexported, **non-embedded** field, so it does not implement `CloseWrite`. A local helper in package `generic` type-asserted, missed, and returned `nil`. Every production call site receives a `*SafeConn` (`buildRecordSession` wraps both `Ingress` and `Egress`), so the fix was a **guaranteed no-op** — while its test, built on raw `*net.TCPConn`, went green. That's a type production never passes on this path.

`SafeConn` now delegates, and the helper lives in `pkg/agent/proxy/util` — the only package that can see through it, and one both sides already import (so no import cycle, and no duplicate that can drift).

## Gated on a clean copy exit — except where it must not be

`io.Copy` returns nil only on a clean EOF; a read error, a reset, or a failed write to the real peer all exit the same loop. Forwarding a FIN for those tells the peer *"the request is complete"* about a truncated message — and `generic` is the catch-all for mongo wire and arbitrary binary RPC, where acting on a partial message can mean committing a partial operation.

`incoming/http.go` is deliberately **not** gated. It previously `CloseWrote` unconditionally, and it's an uncaptured raw byte pump whose two copies join on each other: signalling only on a clean exit leaves a client-side error with nothing to wake the upstream side, holding two goroutines and two sockets until the upstream closes on its own — minutes on an idle WebSocket. Its concrete `*net.TCPConn` assertion is replaced by the capability helper, which also stops it silently skipping every `*tls.Conn`.

## Testing

Tests wrap the proxy side exactly as `buildRecordSession` does, and cover `encodeGeneric` — the path that runs during recording — not just `forwardBidirectional`, which is only reachable under memory pressure. An earlier version tested only the latter, and deleting *both* `encodeGeneric` calls left the suite green.

Mutation-verified: remove `SafeConn.CloseWrite` → 3 tests fail; remove only the `encodeGeneric` calls → fails; remove only `forwardBidirectional`'s → fails; make `forwardFIN` ignore `copyErr` → fails.

`go test ./...` 65 packages green, `-race -count=10` clean on the touched packages.

## Coverage

Four sites in this change were initially uncovered — a review found their mutations all SURVIVED. They are now all pinned:

| Site | Mutation | Result |
|---|---|---|
| `generic/encode.go` (`encodeGeneric`) | FIN never fires | fails |
| `http/encode.go` | FIN never fires | fails |
| `mysql/recorder/query.go` | FIN never fires | fails |
| `incoming/http.go` | revert to concrete `*net.TCPConn` | fails **only** the SafeConn subtest |
| `opportunistic_tls.go` | delegation made a no-op | fails both subtests |

The `incoming/http.go` result is the informative one: raw conns still pass and only the wrapped case fails, so the test *demonstrates* what that concrete assertion silently skipped rather than merely asserting it.

I had originally documented the http and mysql passthroughs as untestable, on the grounds that `memoryguard`'s `recordingPaused` flag is unexported. That reasoning was wrong — the branch was unreachable because the copy loop was written *inline*, not because of the flag. Extracting it as `relayRawPassthrough` makes it directly callable and needs no test hook in production code.

Every test drives conns wrapped the way the proxy wraps them. A FIN forwarded through a raw `*net.TCPConn` proves nothing here: `util.SafeConn` holds its conn as an unexported, non-embedded field — which is exactly how this same one-liner shipped inert twice.
