### PR TITLE
feat(relay): hold client writes so MySQL's CLIENT_SSL upgrade stops leaking

### DIFF
--- a/pkg/agent/proxy/client_brakes_test.go
+++ b/pkg/agent/proxy/client_brakes_test.go
@@ -1,0 +1,126 @@
+package proxy
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations"
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql"
+	"go.keploy.io/server/v3/pkg/agent/proxy/relay"
+	"go.keploy.io/server/v3/pkg/agent/proxy/supervisor"
+	"go.uber.org/zap"
+)
+
+// These tests exist because the client write hold shipped switched off.
+// The relay implemented it, MySQL declared WantsClientWriteHold, the
+// session carried ClientWritesHeld — and nothing connected them, because
+// every other test built relay.Config by hand. A feature whose only
+// wiring is one line in a 400-line dispatcher needs a test that fails
+// when that line goes away.
+
+// brakeParser is a stand-in parser that answers whichever capability
+// probes the test wants it to. Embedding the interface keeps it
+// compiling as an integrations.Integrations without implementing a
+// parser; none of these tests call the parsing methods.
+type brakeParser struct {
+	integrations.Integrations
+	hold        bool
+	preDispatch bool
+	sayHold     bool
+	sayPre      bool
+}
+
+func (b *brakeParser) WantsClientWriteHold() bool  { return b.hold }
+func (b *brakeParser) WantsPreDispatchPause() bool { return b.preDispatch }
+
+// bareParser answers no capability probe at all — the third-party
+// parser that never heard of either brake.
+type bareParser struct{ integrations.Integrations }
+
+func TestApplyClientBrakes_SetsRelayAndSessionTogether(t *testing.T) {
+	cfg := relay.Config{}
+	sess := &supervisor.Session{}
+
+	applyClientBrakes(&cfg, sess, &brakeParser{hold: true}, zap.NewNop(), integrations.MYSQL)
+
+	if !cfg.HoldClientWrites {
+		t.Error("relay.Config.HoldClientWrites is false: the relay will forward the client's " +
+			"ClientHello upstream in cleartext, which is the bug the hold exists to prevent")
+	}
+	if !sess.ClientWritesHeld {
+		t.Error("supervisor.Session.ClientWritesHeld is false: the parser will not release the " +
+			"hold on the plaintext path, and the connection wedges waiting for a reply to a " +
+			"request the server never received")
+	}
+}
+
+func TestApplyClientBrakes_NoHoldWhenParserDoesNotAsk(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		parser integrations.Integrations
+	}{
+		{"declines explicitly", &brakeParser{hold: false}},
+		{"does not implement the probe", &bareParser{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := relay.Config{}
+			sess := &supervisor.Session{}
+			applyClientBrakes(&cfg, sess, tc.parser, zap.NewNop(), integrations.HTTP)
+			if cfg.HoldClientWrites || sess.ClientWritesHeld {
+				t.Errorf("a parser that did not ask got a hold: cfg=%v sess=%v",
+					cfg.HoldClientWrites, sess.ClientWritesHeld)
+			}
+		})
+	}
+}
+
+// The two brakes are alternatives, not layers. Pre-dispatch routes the
+// client's first chunk through the pause stash, which bypasses the
+// hold's byte accounting, and its resume handler acks OK while leaving
+// the hold armed.
+func TestApplyClientBrakes_HoldWinsOverPreDispatch(t *testing.T) {
+	cfg := relay.Config{}
+	sess := &supervisor.Session{}
+
+	applyClientBrakes(&cfg, sess, &brakeParser{hold: true, preDispatch: true}, zap.NewNop(), integrations.MYSQL)
+
+	if !cfg.HoldClientWrites {
+		t.Error("HoldClientWrites was dropped; the hold is the stronger brake and must win")
+	}
+	if cfg.PreDispatchPause {
+		t.Error("PreDispatchPause survived alongside a hold: the combination silently disables " +
+			"ClientHoldCap and lets resume-pre-dispatch ack OK on a still-held connection")
+	}
+}
+
+func TestApplyClientBrakes_PreDispatchStillWorksAlone(t *testing.T) {
+	cfg := relay.Config{}
+	sess := &supervisor.Session{}
+
+	applyClientBrakes(&cfg, sess, &brakeParser{preDispatch: true}, zap.NewNop(), integrations.POSTGRES_V2)
+
+	if !cfg.PreDispatchPause {
+		t.Error("PreDispatchPause was lost; postgres depends on it and the hold must not disturb it")
+	}
+	if cfg.HoldClientWrites || sess.ClientWritesHeld {
+		t.Error("a pre-dispatch parser was given a client write hold it never asked for")
+	}
+}
+
+// MySQL is the parser the hold was built for. If this ever returns
+// false the e2e MySQL-over-TLS lanes go back to recording a
+// desynchronised upstream, so pin it here rather than relying on the
+// dispatcher tests above to notice.
+func TestMySQLAsksForTheClientWriteHold(t *testing.T) {
+	var parser integrations.Integrations = mysql.New(zap.NewNop())
+
+	hp, ok := parser.(interface{ WantsClientWriteHold() bool })
+	if !ok {
+		t.Fatal("MySQL no longer implements WantsClientWriteHold; the dispatcher probe is " +
+			"duck-typed, so dropping the method silently disables the hold rather than " +
+			"failing to compile")
+	}
+	if !hp.WantsClientWriteHold() {
+		t.Error("MySQL declines the client write hold; its CLIENT_SSL upgrade leaks the " +
+			"ClientHello upstream without it")
+	}
+}

--- a/pkg/agent/proxy/client_hold_wiring_test.go
+++ b/pkg/agent/proxy/client_hold_wiring_test.go
@@ -1,0 +1,121 @@
+package proxy
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations"
+	"go.keploy.io/server/v3/pkg/agent/proxy/util"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+)
+
+// TestRecordViaSupervisorArmsTheClientWriteHold pins the ONE line that
+// turns the hold on.
+//
+// client_brakes_test.go tests applyClientBrakes itself, and an earlier
+// review found the feature had shipped entirely inert because nothing
+// called it. That review's fix is still undefended by that file:
+// replacing the applyClientBrakes(...) call in recordViaSupervisor with
+// `_ = applyClientBrakes` leaves every test in the package green. A
+// feature whose only wiring is one line in a 400-line dispatcher needs a
+// test that fails when the line goes away — this is it.
+//
+// It asserts the OBSERVABLE effect rather than the config value: with a
+// hold armed, bytes the client writes must not reach the destination
+// until a directive ends it. Real sockets, because net.Pipe would let
+// the forwarder's write block and mask the difference.
+type holdWantingParser struct{ feedProbe }
+
+func (h *holdWantingParser) WantsClientWriteHold() bool { return true }
+
+func TestRecordViaSupervisorArmsTheClientWriteHold(t *testing.T) {
+	t.Parallel()
+
+	tcpPair := func(t *testing.T) (dialed, accepted net.Conn) {
+		t.Helper()
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen: %v", err)
+		}
+		defer func() { _ = ln.Close() }()
+		type res struct {
+			c   net.Conn
+			err error
+		}
+		ch := make(chan res, 1)
+		go func() {
+			c, err := ln.Accept()
+			ch <- res{c, err}
+		}()
+		d, err := net.Dial("tcp", ln.Addr().String())
+		if err != nil {
+			t.Fatalf("dial: %v", err)
+		}
+		got := <-ch
+		if got.err != nil {
+			t.Fatalf("accept: %v", got.err)
+		}
+		t.Cleanup(func() { _ = d.Close(); _ = got.c.Close() })
+		return d, got.c
+	}
+
+	run := func(t *testing.T, parser integrations.Integrations) (clientApp, destSvc net.Conn) {
+		t.Helper()
+		clientApp, rawSrc := tcpPair(t)
+		dstConn, destSvc := tcpPair(t)
+		srcConn := &util.Conn{Conn: rawSrc, Reader: rawSrc, Logger: zap.NewNop()}
+
+		p := &Proxy{
+			recordBufferCap:        64 * 1024,
+			recordBufferQueueSize:  64,
+			recordBufferStallGrace: 2 * time.Second,
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		go func() {
+			_ = p.recordViaSupervisor(ctx, srcConn, dstConn, parser, "test",
+				make(chan *models.Mock, 8), &errgroup.Group{}, zap.NewNop(), 1, 2,
+				models.OutgoingOptions{})
+		}()
+		return clientApp, destSvc
+	}
+
+	reached := func(t *testing.T, destSvc net.Conn, within time.Duration) bool {
+		t.Helper()
+		_ = destSvc.SetReadDeadline(time.Now().Add(within))
+		buf := make([]byte, 32)
+		n, _ := destSvc.Read(buf)
+		return n > 0
+	}
+
+	t.Run("a parser that asks for the hold gets it", func(t *testing.T) {
+		clientApp, destSvc := run(t, &holdWantingParser{*newFeedProbe()})
+		if _, err := clientApp.Write([]byte("held-bytes")); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if reached(t, destSvc, 750*time.Millisecond) {
+			t.Fatal("the client's bytes reached the destination although the parser asked for " +
+				"a client write hold. recordViaSupervisor is not putting that answer on " +
+				"relay.Config.HoldClientWrites, so MySQL's ClientHello still leaks upstream " +
+				"in cleartext — the exact defect this feature exists to prevent, and the " +
+				"exact way it shipped inert the first time.")
+		}
+	})
+
+	// Positive control: without it, the assertion above could pass
+	// because nothing forwards at all.
+	t.Run("a parser that does not ask is forwarded normally", func(t *testing.T) {
+		clientApp, destSvc := run(t, newFeedProbe())
+		if _, err := clientApp.Write([]byte("plain-bytes")); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if !reached(t, destSvc, 3*time.Second) {
+			t.Fatal("nothing reached the destination for a parser with no hold; the negative " +
+				"case above would then pass for the wrong reason")
+		}
+	})
+}

--- a/pkg/agent/proxy/directive/directive.go
+++ b/pkg/agent/proxy/directive/directive.go
@@ -60,6 +60,22 @@ const (
 	// can either continue (via the surviving peer if any) or be torn
 	// down by the supervisor's fallthrough-to-passthrough path.
 	KindResumePreDispatch
+
+	// KindReleaseClient ends a client→destination write hold set up by
+	// [relay.Config.HoldClientWrites]. The relay writes every byte it
+	// held, in read order, to the real destination and then resumes
+	// normal forwarding on that direction.
+	//
+	// It is the "no TLS after all" counterpart to [KindUpgradeTLS] for
+	// held connections, and a parser that arms the hold MUST send one
+	// of the two: while the hold is up, nothing the client writes
+	// reaches the server, so a parser that decides "this session stays
+	// cleartext" and then stays silent wedges the connection.
+	//
+	// The bytes have already been teed to the parser's FakeConn — the
+	// hold defers the destination Write, not the parser's view — so
+	// releasing does not re-deliver them to the parser.
+	KindReleaseClient
 )
 
 // String returns a short label for logging.
@@ -77,6 +93,8 @@ func (k Kind) String() string {
 		return "finalize-mock"
 	case KindResumePreDispatch:
 		return "resume-pre-dispatch"
+	case KindReleaseClient:
+		return "release-client"
 	default:
 		return "unknown"
 	}
@@ -152,6 +170,31 @@ type UpgradeTLSParams struct {
 	// letting the C2D forwarder pick up the client's reply (TLS
 	// ClientHello after 'S') as cleartext.
 	PreambleForwardToSrc bool
+
+	// ClientFlushBytes is how many bytes from the head of a held
+	// client→destination stash the relay writes to the real
+	// destination before any handshake begins. It is consulted ONLY
+	// when [relay.Config.HoldClientWrites] armed a hold on this
+	// connection; without a hold the client's bytes were forwarded in
+	// real time and there is nothing to flush.
+	//
+	// MySQL is the motivating case and shows why a count is needed
+	// rather than a flush-all. Its CLIENT_SSL choreography is
+	// server-greets, client sends a 36-byte SSLRequest, and then —
+	// with no further server turn — the client begins its TLS
+	// handshake on the same connection. The server must receive the
+	// SSLRequest, or it will not switch to TLS; it must NOT receive
+	// the ClientHello that follows, because keploy is the one that
+	// terminates that handshake. Both can already be sitting in the
+	// same stash (they frequently arrive coalesced in a single read),
+	// so the split is by byte count: ClientFlushBytes=36 forwards the
+	// SSLRequest and leaves the ClientHello for the client-side
+	// handshake to consume via the prepending conn.
+	//
+	// Zero flushes nothing, which is the safe default for a hold: a
+	// parser that does not say what the server needs does not get to
+	// leak the rest of the client's cleartext upstream by accident.
+	ClientFlushBytes int
 
 	// ProceedOnPreamble, when non-empty, gates the TLS handshakes on
 	// an exact byte-for-byte match against the read preamble. A
@@ -256,6 +299,12 @@ func Pause(d fakeconn.Direction, reason string) Directive {
 // Resume returns a [KindResumeDir] directive for the given direction.
 func Resume(d fakeconn.Direction, reason string) Directive {
 	return Directive{Kind: KindResumeDir, Dir: d, Reason: reason}
+}
+
+// ReleaseClient returns a [KindReleaseClient] directive. See the
+// kind's docstring for the hold lifecycle it completes.
+func ReleaseClient(reason string) Directive {
+	return Directive{Kind: KindReleaseClient, Reason: reason}
 }
 
 // ResumePreDispatch returns a [KindResumePreDispatch] directive. See

--- a/pkg/agent/proxy/fakeconn/fakeconn.go
+++ b/pkg/agent/proxy/fakeconn/fakeconn.go
@@ -37,8 +37,11 @@ var ErrDeadlineExceeded net.Error = deadlineError{}
 // not touch any real socket — the relay owns those.
 //
 // FakeConn is safe for a single reader goroutine concurrent with
-// calls to Close and SetReadDeadline. Concurrent Read callers are
-// not supported; parsers are single-consumer by construction.
+// calls to Close, SetReadDeadline and DiscardBefore. Concurrent Read
+// callers are not supported; parsers are single-consumer by
+// construction. DiscardBefore carries one extra rule that the mutex
+// cannot enforce — it must not be called while the parser is inside a
+// read; see its doc.
 //
 // Satisfies [net.Conn] so that parsers coded against net.Conn can
 // consume it unchanged. Note that [FakeConn.Write] always returns
@@ -49,11 +52,23 @@ type FakeConn struct {
 	ch     <-chan Chunk
 	logger logger
 
-	mu              sync.Mutex
-	buf             bytes.Buffer
-	bufReadAt       time.Time // source ReadAt of bytes currently in buf
-	bufWrittenAt    time.Time // source WrittenAt of bytes currently in buf
-	bufDir          Direction // source direction of bytes currently in buf
+	mu           sync.Mutex
+	buf          bytes.Buffer
+	bufReadAt    time.Time // source ReadAt of bytes currently in buf
+	bufWrittenAt time.Time // source WrittenAt of bytes currently in buf
+	bufDir       Direction // source direction of bytes currently in buf
+	// pos is the absolute offset, in bytes of this stream, of the next
+	// byte the parser will be handed. Equivalently: how many bytes have
+	// already left this FakeConn, counting both bytes delivered to the
+	// parser and bytes swallowed on its behalf by [FakeConn.DiscardBefore].
+	//
+	// buf therefore holds the bytes at offsets [pos, pos+buf.Len()), and
+	// pos+buf.Len() is the number of bytes pulled off ch so far — the
+	// quantity the producer counts on its side.
+	pos int64
+	// discardTo is the discard watermark set by [FakeConn.DiscardBefore]:
+	// every byte below it is swallowed rather than delivered. Monotonic.
+	discardTo       int64
 	lastReadNano    atomic.Int64
 	lastWrittenNano atomic.Int64
 	closed          atomic.Bool
@@ -121,6 +136,21 @@ func newWithLogger(ch <-chan Chunk, localAddr, remoteAddr net.Addr, log logger) 
 // left over from a previous Chunk, then blocks for the next Chunk
 // (subject to read deadline and Close).
 func (f *FakeConn) Read(p []byte) (int, error) {
+	// A zero-length Read consumes nothing and must not block, so it is
+	// answered before the discard below can park on the channel. Kept
+	// above the closed check too, matching io.Reader's "Read(p) with
+	// len(p)==0 returns 0, nil" convention for a stream that has not
+	// otherwise failed.
+	if len(p) == 0 {
+		return 0, nil
+	}
+	// Honour any discard watermark BEFORE looking at the buffer: the
+	// bytes it wants gone may be sitting in buf, in ch, or still
+	// upstream in the relay's tee, and all three are reached by
+	// pulling forward from here. See [FakeConn.DiscardBefore].
+	if err := f.applyDiscard(); err != nil {
+		return 0, err
+	}
 	if f.closed.Load() {
 		// Close means "no more blocking", NOT "discard bytes already
 		// delivered to me". The relay tee drains its buffered chunks
@@ -134,25 +164,24 @@ func (f *FakeConn) Read(p []byte) (int, error) {
 		// once nothing buffered remains.
 		if c, ok := f.drainBufferedLocked(); ok {
 			n := copy(p, c.Bytes)
+			f.mu.Lock()
+			f.pos += int64(n)
 			if n < len(c.Bytes) {
-				f.mu.Lock()
 				f.buf.Write(c.Bytes[n:])
 				f.bufReadAt = c.ReadAt
 				f.bufWrittenAt = c.WrittenAt
 				f.bufDir = c.Dir
-				f.mu.Unlock()
 			}
+			f.mu.Unlock()
 			return n, nil
 		}
 		return 0, ErrClosed
-	}
-	if len(p) == 0 {
-		return 0, nil
 	}
 
 	f.mu.Lock()
 	if f.buf.Len() > 0 {
 		n, err := f.buf.Read(p)
+		f.pos += int64(n)
 		f.mu.Unlock()
 		// bytes.Buffer.Read returns io.EOF whenever it drains the
 		// buffer to empty, even when we got bytes back on this call
@@ -178,14 +207,15 @@ func (f *FakeConn) Read(p []byte) (int, error) {
 	// a later ReadChunk call that drains the stash returns them
 	// intact (documented contract on ReadChunk).
 	n := copy(p, chunk.Bytes)
+	f.mu.Lock()
+	f.pos += int64(n)
 	if n < len(chunk.Bytes) {
-		f.mu.Lock()
 		f.buf.Write(chunk.Bytes[n:])
 		f.bufReadAt = chunk.ReadAt
 		f.bufWrittenAt = chunk.WrittenAt
 		f.bufDir = chunk.Dir
-		f.mu.Unlock()
 	}
+	f.mu.Unlock()
 	return n, nil
 }
 
@@ -206,16 +236,31 @@ func (f *FakeConn) Read(p []byte) (int, error) {
 // were drained from; callers should typically use Read XOR ReadChunk
 // on a single FakeConn to avoid mixing the two.
 func (f *FakeConn) ReadChunk() (Chunk, error) {
+	// See Read: the watermark is honoured before anything is handed
+	// back, and it reaches bytes wherever they currently sit.
+	if err := f.applyDiscard(); err != nil {
+		return Chunk{}, err
+	}
 	if f.closed.Load() {
 		// See Read: a chunk already delivered to f.ch (or stashed) is a
 		// recorded wire event and must survive Close. Drain what is
 		// buffered before reporting ErrClosed.
 		if c, ok := f.drainBufferedLocked(); ok {
+			f.mu.Lock()
+			f.pos += int64(len(c.Bytes))
+			f.mu.Unlock()
 			return c, nil
 		}
 		return Chunk{}, ErrClosed
 	}
-	return f.readChunkLocked()
+	c, err := f.readChunkLocked()
+	if err != nil {
+		return c, err
+	}
+	f.mu.Lock()
+	f.pos += int64(len(c.Bytes))
+	f.mu.Unlock()
+	return c, nil
 }
 
 // drainBufferedLocked returns the next chunk that is ALREADY available
@@ -297,6 +342,15 @@ func (f *FakeConn) readChunkLocked() (Chunk, error) {
 	}
 	f.mu.Unlock()
 
+	return f.recvChunk()
+}
+
+// recvChunk blocks for the next Chunk on f.ch, ignoring anything
+// residual in buf. Split out of readChunkLocked because
+// [FakeConn.applyDiscard] must pull the pipeline forward WITHOUT
+// draining buf into a synthetic chunk — it consumes buf itself, and
+// only as far as the watermark, so a discard can stop mid-chunk.
+func (f *FakeConn) recvChunk() (Chunk, error) {
 	// Re-fetch the deadline channel on each iteration so concurrent
 	// SetReadDeadline calls take effect on this in-flight read. The
 	// changed-notification channel (closed by SetReadDeadline) wakes
@@ -320,6 +374,130 @@ func (f *FakeConn) readChunkLocked() (Chunk, error) {
 		case <-changedCh:
 			// deadline changed; loop and re-fetch.
 		}
+	}
+}
+
+// DiscardBefore declares that the parser must never be handed a stream
+// byte whose absolute offset is below `offset`, and that its next read
+// resumes at `offset`. Returns how many bytes are still to be swallowed
+// at the moment of the call (0 when the watermark is already behind the
+// reader). The watermark is monotonic: a lower offset is ignored.
+//
+// # Why the consumer side, and why an absolute offset
+//
+// The relay sometimes CONSUMES bytes it has already teed here. The
+// canonical case is MySQL's CLIENT_SSL upgrade: the client sends a
+// 36-byte SSLRequest and, with no further server turn, immediately
+// starts a TLS handshake on the same socket. The relay's forwarder is
+// parked in Read, so it has both messages in hand long before the
+// parser has decoded the SSLRequest and asked for the upgrade — and
+// both get teed. The parser reads its 36 bytes; the ClientHello behind
+// them is then consumed by keploy's own client-side handshake, but a
+// copy of it is still sitting in this FakeConn, where the parser's next
+// read finds `16 03 01 ...` in place of the post-TLS message it
+// expects, mis-frames it as a packet header and hangs.
+//
+// Retracting those bytes on the PRODUCER side does not work: the tee is
+// a pipeline (staging queue -> drain goroutine -> channel -> this
+// buffer), so bytes to be dropped can simultaneously be in the queue,
+// in the drain goroutine's hand, in the channel, and in buf. Draining
+// that from outside means racing the drain goroutine. Here there is no
+// race at all: this FakeConn is single-consumer by construction, and
+// every one of those places is reached by pulling FORWARD from the
+// reader, which is what applyDiscard does.
+//
+// The offset is absolute rather than a count of "whatever is pending
+// now" for the same reason: the producer states a stream position, so
+// bytes that have not been teed yet when the watermark is set are still
+// covered, and bytes teed AFTER it (the post-upgrade plaintext) are
+// above the watermark and pass through untouched. No quiescing of the
+// pipeline is required, and arming the watermark before or after the
+// forwarders resume gives the same result.
+//
+// Caller contract: call it while the parser is not reading. The relay
+// does this under its directive pause, where the parser is blocked on
+// the directive ack by construction. A watermark armed against a reader
+// already blocked inside a channel receive cannot retract the chunk
+// that receive is about to return.
+//
+// The guarantee is exact while the FakeConn is open. After Close it
+// degrades to best effort: nothing more is coming, so applyDiscard stops
+// pulling rather than blocking, and a chunk that lands on the channel in
+// the window between that decision and the post-Close drain can still be
+// handed back. That window only exists on a connection whose parser is
+// already being retired.
+func (f *FakeConn) DiscardBefore(offset int64) int64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if offset > f.discardTo {
+		f.discardTo = offset
+	}
+	if n := f.discardTo - f.pos; n > 0 {
+		return n
+	}
+	return 0
+}
+
+// applyDiscard swallows bytes until the reader has reached the discard
+// watermark. It consumes buf first and then pulls chunks, so a
+// watermark that falls in the middle of a chunk splits it exactly.
+//
+// Blocking is correct while the FakeConn is open: the bytes below the
+// watermark were teed before it was set, so they are already on their
+// way and the parser's next read must not overtake them. Once closed,
+// nothing more is coming, so the pull is best-effort and non-blocking —
+// otherwise a discard armed just before teardown would turn every
+// subsequent read into an ErrClosed instead of letting the post-Close
+// drain paths hand back what did arrive.
+func (f *FakeConn) applyDiscard() error {
+	for {
+		f.mu.Lock()
+		need := f.discardTo - f.pos
+		if need <= 0 {
+			f.mu.Unlock()
+			return nil
+		}
+		if have := int64(f.buf.Len()); have > 0 {
+			n := have
+			if n > need {
+				n = need
+			}
+			f.buf.Next(int(n))
+			f.pos += n
+			if f.buf.Len() == 0 {
+				f.bufReadAt = time.Time{}
+				f.bufWrittenAt = time.Time{}
+				f.bufDir = 0
+			}
+			f.mu.Unlock()
+			continue
+		}
+		f.mu.Unlock()
+
+		var c Chunk
+		if f.closed.Load() {
+			var ok bool
+			select {
+			case c, ok = <-f.ch:
+				if !ok {
+					return nil
+				}
+			default:
+				return nil
+			}
+		} else {
+			var err error
+			c, err = f.recvChunk()
+			if err != nil {
+				return err
+			}
+		}
+		f.mu.Lock()
+		f.buf.Write(c.Bytes)
+		f.bufReadAt = c.ReadAt
+		f.bufWrittenAt = c.WrittenAt
+		f.bufDir = c.Dir
+		f.mu.Unlock()
 	}
 }
 

--- a/pkg/agent/proxy/fakeconn/fakeconn_test.go
+++ b/pkg/agent/proxy/fakeconn/fakeconn_test.go
@@ -356,3 +356,157 @@ func TestWriteLoggerInvoked(t *testing.T) {
 		t.Errorf("logger.Debug called %d times, want 2", log.warns)
 	}
 }
+
+// The DiscardBefore tests below pin the three properties the relay
+// depends on when it consumes bytes it has already teed (MySQL's
+// CLIENT_SSL ClientHello): the watermark reaches bytes wherever they
+// currently sit, it can split a chunk mid-way, and it never touches
+// anything above it.
+
+// TestDiscardBeforeSplitsAChunk: the parser consumed the head of a
+// chunk and the relay consumed its tail. This is the coalesced
+// SSLRequest+ClientHello case, and the reason the watermark counts
+// bytes rather than chunks.
+func TestDiscardBeforeSplitsAChunk(t *testing.T) {
+	t.Parallel()
+	ch := make(chan Chunk, 2)
+	ch <- Chunk{Dir: FromClient, Bytes: []byte("HEADTAILTAIL"), ReadAt: time.Unix(1, 0)}
+	f := New(ch, nil, nil)
+
+	head := make([]byte, 4)
+	if _, err := io.ReadFull(f, head); err != nil {
+		t.Fatalf("read head: %v", err)
+	}
+	if string(head) != "HEAD" {
+		t.Fatalf("head = %q, want HEAD", head)
+	}
+
+	// Everything the producer had accepted at this point (12 bytes) is
+	// off limits from here on.
+	if pending := f.DiscardBefore(12); pending != 8 {
+		t.Fatalf("DiscardBefore reported %d bytes pending, want the 8 unread tail bytes", pending)
+	}
+
+	ch <- Chunk{Dir: FromClient, Bytes: []byte("NEXT"), ReadAt: time.Unix(2, 0)}
+	got := make([]byte, 4)
+	if _, err := io.ReadFull(f, got); err != nil {
+		t.Fatalf("read after discard: %v", err)
+	}
+	if string(got) != "NEXT" {
+		t.Fatalf("after the discard the reader got %q, want NEXT — the watermark must split "+
+			"the chunk it lands inside, not round to a chunk boundary", got)
+	}
+}
+
+// TestDiscardBeforeReachesUndeliveredChunks: the bytes to drop had not
+// reached this FakeConn yet when the watermark was set. Naming an
+// absolute offset is what makes that work without quiescing the
+// producer.
+func TestDiscardBeforeReachesUndeliveredChunks(t *testing.T) {
+	t.Parallel()
+	ch := make(chan Chunk, 3)
+	ch <- Chunk{Dir: FromClient, Bytes: []byte("SSLREQ"), ReadAt: time.Unix(1, 0)}
+	f := New(ch, nil, nil)
+
+	first := make([]byte, 6)
+	if _, err := io.ReadFull(f, first); err != nil {
+		t.Fatalf("read first: %v", err)
+	}
+
+	// The producer has accepted 6+5 bytes; only the first 6 were ever
+	// the parser's. The 5 are still in the channel, unseen here.
+	f.DiscardBefore(11)
+	ch <- Chunk{Dir: FromClient, Bytes: []byte("HELLO"), ReadAt: time.Unix(2, 0)}
+	ch <- Chunk{Dir: FromClient, Bytes: []byte("AFTER"), ReadAt: time.Unix(3, 0)}
+
+	got := make([]byte, 5)
+	if _, err := io.ReadFull(f, got); err != nil {
+		t.Fatalf("read after discard: %v", err)
+	}
+	if string(got) != "AFTER" {
+		t.Fatalf("after the discard the reader got %q, want AFTER — a watermark set before the "+
+			"bytes arrived must still swallow them", got)
+	}
+}
+
+// TestDiscardBeforeIsMonotonicAndNeverOverruns: a lower offset is
+// ignored, and an offset already behind the reader is a no-op rather
+// than a rewind that would eat live traffic.
+func TestDiscardBeforeIsMonotonicAndNeverOverruns(t *testing.T) {
+	t.Parallel()
+	ch := make(chan Chunk, 2)
+	ch <- Chunk{Dir: FromClient, Bytes: []byte("ABCDEF"), ReadAt: time.Unix(1, 0)}
+	f := New(ch, nil, nil)
+
+	f.DiscardBefore(3)
+	if pending := f.DiscardBefore(1); pending != 3 {
+		t.Fatalf("a lower offset moved the watermark: pending = %d, want 3", pending)
+	}
+	got := make([]byte, 3)
+	if _, err := io.ReadFull(f, got); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "DEF" {
+		t.Fatalf("got %q, want DEF", got)
+	}
+	if pending := f.DiscardBefore(2); pending != 0 {
+		t.Fatalf("an offset behind the reader reported %d bytes to discard, want 0", pending)
+	}
+	ch <- Chunk{Dir: FromClient, Bytes: []byte("GHI"), ReadAt: time.Unix(2, 0)}
+	got = make([]byte, 3)
+	if _, err := io.ReadFull(f, got); err != nil {
+		t.Fatalf("read after stale watermark: %v", err)
+	}
+	if string(got) != "GHI" {
+		t.Fatalf("got %q, want GHI — a stale watermark must not consume live bytes", got)
+	}
+}
+
+// TestDiscardBeforeAfterCloseDoesNotBlock: a watermark armed against
+// bytes that will now never arrive must not turn every later read into
+// a block. Post-Close the discard is best effort.
+func TestDiscardBeforeAfterCloseDoesNotBlock(t *testing.T) {
+	t.Parallel()
+	ch := make(chan Chunk, 1)
+	ch <- Chunk{Dir: FromClient, Bytes: []byte("XY"), ReadAt: time.Unix(1, 0)}
+	f := New(ch, nil, nil)
+	f.DiscardBefore(1000)
+	_ = f.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, 4)
+		_, _ = f.Read(buf)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Read blocked forever on a discard that can never complete after Close")
+	}
+}
+
+// TestDiscardBeforeZeroLengthReadDoesNotBlock: a zero-length Read
+// consumes nothing, so it must not be made to wait on a discard that is
+// still waiting on the producer. The watermark check sits after the
+// len(p)==0 early return for exactly this reason.
+func TestDiscardBeforeZeroLengthReadDoesNotBlock(t *testing.T) {
+	t.Parallel()
+	ch := make(chan Chunk) // nothing queued, nothing coming
+	f := New(ch, nil, nil)
+	f.DiscardBefore(64)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		n, err := f.Read(nil)
+		if n != 0 || err != nil {
+			t.Errorf("Read(nil) = (%d, %v), want (0, nil)", n, err)
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Read with a zero-length buffer blocked on a pending discard")
+	}
+}

--- a/pkg/agent/proxy/integrations/mysql/mysql.go
+++ b/pkg/agent/proxy/integrations/mysql/mysql.go
@@ -119,6 +119,28 @@ func (m *MySQL) MatchType(_ context.Context, buf []byte) bool {
 // directive channel rather than touching the real sockets directly.
 func (m *MySQL) IsV2() bool { return true }
 
+// WantsClientWriteHold opts this parser into relay.Config.HoldClientWrites.
+//
+// MySQL needs it because its CLIENT_SSL upgrade gives the client no
+// reason to wait. The server greets, the client answers with a 36-byte
+// SSLRequest, and then — with no further server turn — it starts a TLS
+// handshake on the same socket. Without a hold the relay's forwarder,
+// which is always parked in Read on the client socket, has the
+// ClientHello in hand and on its way upstream before this parser has
+// even been scheduled to look at the SSLRequest. The real server then
+// reads TLS handshake bytes as MySQL protocol, and keploy's own
+// destination handshake runs against a socket that is already
+// desynchronised.
+//
+// Holding costs nothing on connections that never upgrade: the
+// plaintext path releases the hold as soon as it has decoded the
+// client's HandshakeResponse41, which is the same point at which it
+// would otherwise have had nothing left to decide.
+//
+// Duck-typed, matching WantsPreDispatchPause — see the probe in
+// proxy_v2.go.
+func (m *MySQL) WantsClientWriteHold() bool { return true }
+
 func (m *MySQL) RecordOutgoing(ctx context.Context, session *integrations.RecordSession) error {
 	if session != nil && session.V2 != nil {
 		return m.recordV2(ctx, session)

--- a/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
@@ -268,7 +268,22 @@ func handleInitialHandshakeV2(ctx context.Context, logger *zap.Logger, sess *sup
 			return res, nil
 		}
 
-		if err := performTLSUpgradeV2(ctx, logger, sess); err != nil {
+		// len(clientFirst) is the exact width of the SSLRequest packet
+		// we just consumed, and it is what the relay forwards upstream
+		// before handshaking. It has to be a measured count rather than
+		// a constant: the relay is holding the client's writes, and the
+		// SSLRequest and the ClientHello behind it frequently arrive in
+		// one read, so "forward the SSLRequest and nothing else" can
+		// only be expressed as a byte count. See
+		// relay.Config.HoldClientWrites.
+		// Zero when nothing is held: the relay ignores the count in
+		// that case, but passing the real width would misreport what
+		// the directive actually did.
+		clientFlush := 0
+		if sess.ClientWritesHeld {
+			clientFlush = len(clientFirst)
+		}
+		if err := performTLSUpgradeV2(ctx, logger, sess, clientFlush); err != nil {
 			sess.MarkMockIncomplete("tls upgrade failed")
 			return res, err
 		}
@@ -301,6 +316,22 @@ func handleInitialHandshakeV2(ctx context.Context, logger *zap.Logger, sess *sup
 		}
 		decodeCtx.ClientCaps = decodeCtx.ClientCapabilities
 		res.req = append(res.req, mysql.Request{PacketBundle: *hr41Pkt})
+	} else if sess.ClientWritesHeld {
+		// No TLS: the client authenticated in cleartext, so the hold
+		// the relay armed for this connection has to come off before
+		// anything else can happen. Nothing we have read so far has
+		// reached the server — that is the point of the hold — so the
+		// auth decider read below would block forever on a reply to a
+		// request the server never received.
+		//
+		// Gated on ClientWritesHeld rather than sent unconditionally:
+		// the release costs an ack round-trip, and on every path with
+		// no relay behind it (observe-only proxyless capture, unit
+		// harnesses) there is no one to answer it.
+		if err := releaseClientHoldV2(ctx, logger, sess); err != nil {
+			sess.MarkMockIncomplete("client hold release failed")
+			return res, err
+		}
 	}
 
 	// Auth decider: AuthSwitchRequest / AuthMoreData / OK / ERR.
@@ -1131,22 +1162,59 @@ func storePreTLSHandshakeV2(ctx context.Context, logger *zap.Logger, sess *super
 	return nil
 }
 
+// releaseClientHoldV2 ends the relay's client write hold for a
+// connection that turned out not to use TLS, delivering the client's
+// HandshakeResponse41 to the real server.
+//
+// Sending it unconditionally is safe and deliberate. When no hold was
+// armed — a proxyless observe-only capture, or a relay built before
+// this capability existed — the relay refuses the directive and we
+// carry on: there is nothing held, so there is nothing to deliver, and
+// the connection was never blocked in the first place. Treating that
+// refusal as fatal would make the parser's correctness depend on how
+// the relay beneath it was configured.
+func releaseClientHoldV2(ctx context.Context, logger *zap.Logger, sess *supervisor.Session) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case sess.Directives <- directive.ReleaseClient("mysql plaintext handshake"):
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case ack, ok := <-sess.Acks:
+		if !ok {
+			return errors.New("directive channel closed before client-hold release ack")
+		}
+		if !ack.OK {
+			logger.Debug("V2: relay declined the client-hold release; assuming no hold was armed",
+				zap.Error(ack.Err))
+		}
+		return nil
+	}
+}
+
 // performTLSUpgradeV2 builds TLS configs from the session options and
 // sends a KindUpgradeTLS directive on sess.Directives, blocking on the
 // ack. Returns nil on OK, an error on failure. Failure cases MUST call
 // sess.MarkMockIncomplete at the call site.
-func performTLSUpgradeV2(ctx context.Context, logger *zap.Logger, sess *supervisor.Session) error {
+func performTLSUpgradeV2(ctx context.Context, logger *zap.Logger, sess *supervisor.Session, clientFlushBytes int) error {
 	destCfg := buildDestTLSConfigV2(sess)
 	clientCfg := buildClientTLSConfigV2(sess)
 
 	logger.Debug("V2: sending mysql client_ssl upgrade directive",
 		zap.Bool("destCfg", destCfg != nil),
-		zap.Bool("clientCfg", clientCfg != nil))
+		zap.Bool("clientCfg", clientCfg != nil),
+		zap.Int("clientFlushBytes", clientFlushBytes))
+
+	d := directive.UpgradeTLS(destCfg, clientCfg, "mysql client_ssl")
+	d.TLS.ClientFlushBytes = clientFlushBytes
 
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case sess.Directives <- directive.UpgradeTLS(destCfg, clientCfg, "mysql client_ssl"):
+	case sess.Directives <- d:
 	}
 
 	select {

--- a/pkg/agent/proxy/integrations/mysql/recorder/v2_test.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/v2_test.go
@@ -667,3 +667,122 @@ func TestEmitMockV2ReportsAWindowInvertedByMonotonicClamping(t *testing.T) {
 		}
 	})
 }
+
+// tlsClientHelloBytes is a stand-in for the record the client's TLS
+// stack writes immediately after its SSLRequest. Only the leading
+// `16 03 01` matters: read as a MySQL header it declares a payload
+// length of 66326, which is what makes the failure a hang rather than a
+// decode error.
+func tlsClientHelloBytes() []byte {
+	p := make([]byte, 120)
+	p[0], p[1], p[2] = 0x16, 0x03, 0x01
+	p[3], p[4] = 0x00, 0x73
+	return p
+}
+
+// TestRecordV2_TLSUpgrade_ClientHelloDiscardedFromParserStream is the
+// MySQL end of the client write hold's contract, and the reason the
+// hold is not finished when the ClientHello stops reaching the wire.
+//
+// The relay's forwarder is parked in Read on the client socket, so it
+// holds the SSLRequest and the ClientHello — here in ONE chunk, which is
+// what a coalesced client write produces — before this parser has been
+// scheduled to look at either. Both are teed. The parser reads exactly
+// the 36-byte SSLRequest and asks for the upgrade; the relay then
+// consumes the ClientHello for its own client-side handshake and, at the
+// pause barrier, tells the parser's stream to discard everything below
+// the position it consumed to.
+//
+// Without that last step the parser's next read returns `16 03 01 00`
+// where the post-TLS HandshakeResponse41 should be, ReadRequiredBytes
+// blocks on a 66326-byte payload, the hang watchdog retires the parser
+// and the connection falls through to passthrough with zero mocks. The
+// wire leak would be fixed and every MySQL TLS recording lost.
+func TestRecordV2_TLSUpgrade_ClientHelloDiscardedFromParserStream(t *testing.T) {
+	t.Parallel()
+	h := newV2Harness(t)
+	h.sess.ClientWritesHeld = true
+
+	base := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+
+	handshakeBuf := cannedHandshakeV10(t)
+	greeting, err := connphase.DecodeHandshakeV10(context.Background(), zap.NewNop(), handshakeBuf[4:])
+	if err != nil {
+		t.Fatalf("decode handshake: %v", err)
+	}
+	h.pushDest(handshakeBuf, base)
+
+	sslReq := cannedSSLRequest(t, 1)
+	clientHello := tlsClientHelloBytes()
+	// One chunk, both messages: the forwarder read them together and
+	// teed what it read.
+	h.pushClient(append(append([]byte(nil), sslReq...), clientHello...), base.Add(1*time.Millisecond))
+
+	// Post-TLS traffic, exactly as the relay would deliver it once the
+	// handshake is up.
+	h.pushClient(cannedHandshakeResponse41(t, 2, true), base.Add(20*time.Millisecond))
+	h.pushDest(cannedOK(t, 3, greeting.CapabilityFlags), base.Add(25*time.Millisecond))
+
+	dirSeen := make(chan directive.Directive, 1)
+	go func() {
+		select {
+		case d := <-h.dirs:
+			dirSeen <- d
+			// The relay's half of the contract, at the point it performs
+			// it: the barrier is up, the parser is blocked on this ack,
+			// and everything teed so far that the parser did not read is
+			// handshake material.
+			h.sess.ClientStream.DiscardBefore(int64(len(sslReq) + len(clientHello)))
+			h.acks <- directive.Ack{
+				Kind:              d.Kind,
+				OK:                true,
+				BoundaryReadAt:    base.Add(10 * time.Millisecond),
+				BoundaryWrittenAt: base.Add(15 * time.Millisecond),
+			}
+		case <-time.After(2 * time.Second):
+			t.Errorf("parser never sent a directive")
+		}
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		done <- RecordV2(ctx, h.logger, h.sess)
+	}()
+
+	select {
+	case m := <-h.mocks:
+		if m.Name != "config" {
+			t.Errorf("mock name = %q, want config", m.Name)
+		}
+		if len(m.Spec.MySQLRequests) < 2 {
+			t.Errorf("TLS config mock has %d requests, want >=2 (SSLRequest + post-TLS "+
+				"HandshakeResponse41). A short count means the parser never got past the "+
+				"ClientHello left in its stream.", len(m.Spec.MySQLRequests))
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the TLS config mock: the parser is blocked reading a " +
+			"packet whose header it took from the TLS ClientHello")
+	}
+
+	select {
+	case d := <-dirSeen:
+		if d.TLS == nil {
+			t.Fatalf("directive carried no TLS params: %+v", d)
+		}
+		if d.TLS.ClientFlushBytes != len(sslReq) {
+			t.Errorf("ClientFlushBytes = %d, want %d — the relay forwards exactly the "+
+				"SSLRequest upstream and keeps the ClientHello, so the count has to be the "+
+				"measured width of the packet this parser consumed",
+				d.TLS.ClientFlushBytes, len(sslReq))
+		}
+	default:
+		t.Fatal("directive never observed")
+	}
+
+	h.closeStreams()
+	if err := <-done; err != nil {
+		t.Errorf("RecordV2 returned error: %v", err)
+	}
+}

--- a/pkg/agent/proxy/proxy_v2.go
+++ b/pkg/agent/proxy/proxy_v2.go
@@ -222,10 +222,6 @@ func (p *Proxy) recordViaSupervisor(
 	// each parser stays free to add the method independently and we
 	// don't have to touch every IntegrationsV2 implementation in this
 	// change.
-	var preDispatchPause bool
-	if pp, ok := parser.(interface{ WantsPreDispatchPause() bool }); ok {
-		preDispatchPause = pp.WantsPreDispatchPause()
-	}
 
 	// Opt-in gap resync. See [parserCanResyncAfterGap].
 	canResyncAfterGap := parserCanResyncAfterGap(parser)
@@ -273,7 +269,7 @@ func (p *Proxy) recordViaSupervisor(
 	// the connection.
 	defer close(trackerStop)
 
-	r := relay.New(relay.Config{
+	relayCfg := relay.Config{
 		Logger: logger,
 		// verify / rootCAs / srcConn come from record.upstreamTls.* and are
 		// captured once per connection: the relay calls the returned fn with
@@ -314,12 +310,25 @@ func (p *Proxy) recordViaSupervisor(
 		TeeChanBuf:         p.recordBufferQueueSize,
 		ConsumerStallGrace: p.recordBufferStallGrace,
 		HalfCloseGrace:     p.recordBufferHalfCloseGrace,
-		PreDispatchPause:   preDispatchPause,
+		// PreDispatchPause and HoldClientWrites are set by
+		// applyClientBrakes below, together with the session's
+		// ClientWritesHeld — they are one decision and must not drift.
+
 		// Default false — see relay.Config.ParserCanResyncAfterGap for why
 		// "cannot resync" is the safe default for everything that has not
 		// explicitly claimed otherwise.
 		ParserCanResyncAfterGap: canResyncAfterGap,
-	}, srcConn, dstConn)
+	}
+
+	// One call sets the relay's client-direction brake AND the parser's
+	// view of it. They are set together because they cannot be allowed
+	// to drift: the relay holding bytes the parser does not know are
+	// held wedges the connection, and the parser trying to release a
+	// hold the relay never armed blocks on an ack nobody sends. Wiring
+	// them at two sites is what let the hold ship switched off.
+	applyClientBrakes(&relayCfg, svSess, parser, logger, parserType)
+
+	r := relay.New(relayCfg, srcConn, dstConn)
 
 	svSess.ClientStream = r.ClientStream()
 	svSess.DestStream = r.DestStream()
@@ -335,6 +344,18 @@ func (p *Proxy) recordViaSupervisor(
 	go func() { relayDone <- r.Run(relayCtx) }()
 
 	sv.SessionOnAbort = func() {
+		// PauseTees also ends any client write hold, flushing what it
+		// held. That matters here more than the tee pausing does: this
+		// runs when the parser has been retired — hung, panicked, over
+		// its memory cap, cancelled — and the dispatcher's answer to
+		// all of those is to leave the relay forwarding raw bytes so
+		// user traffic survives (invariant I1 below, and the Warn the
+		// caller emits promising exactly that). A hold that outlives
+		// its parser blackholes the client direction for the rest of
+		// the connection, and no cap rescues it, because a client
+		// blocked waiting for a reply to the request we are sitting on
+		// never sends the bytes a cap would count.
+		//
 		// Pause the tees FIRST so every subsequent chunk drops
 		// cheaply via the pause fast-path (atomic-bool check) instead
 		// of falling through to the channel-full DropChannelFull
@@ -726,6 +747,79 @@ func (p *Proxy) waitForConnDrain(ctx context.Context) {
 // Asserted against the named [integrations.GapResyncCapable] rather than an
 // anonymous interface so the contract has one documented home; the assertion
 // still keeps non-implementers compiling.
+// applyClientBrakes resolves the client-direction brakes for a parser
+// and writes BOTH consequences: the relay's config, which decides
+// whether bytes are actually held, and the supervisor session's
+// ClientWritesHeld, which is how the parser learns a hold is in force.
+//
+// The two live in one function because splitting them is precisely how
+// this feature shipped inert. "I asked for a hold" and "a hold is in
+// force" are different claims and the parser needs the second: ending a
+// hold costs an ack round-trip, and on a path with no relay to answer
+// it — an observe-only proxyless capture — a parser that assumed one
+// would block forever. Setting one without the other is a wedge in
+// whichever direction it drifts, so neither is reachable alone.
+func applyClientBrakes(
+	cfg *relay.Config,
+	sess *supervisor.Session,
+	parser integrations.Integrations,
+	logger *zap.Logger,
+	parserType integrations.IntegrationType,
+) {
+	hold, preDispatch := parserClientBrakes(parser, logger, parserType)
+	if cfg != nil {
+		cfg.HoldClientWrites = hold
+		cfg.PreDispatchPause = preDispatch
+	}
+	if sess != nil {
+		sess.ClientWritesHeld = hold
+	}
+}
+
+// parserClientBrakes resolves the two client-direction brakes a parser
+// may ask the relay for: a client write hold
+// ([relay.Config.HoldClientWrites]) and a pre-dispatch pause
+// ([relay.Config.PreDispatchPause]).
+//
+// Extracted for the same reason shouldRecordViaSupervisor was: written
+// inline, the rule is untestable, and an inline probe that is simply
+// never called compiles, passes every test, and silently leaves the
+// feature switched off. That is not hypothetical — this is the second
+// brake to be wired here, and the first review of the hold caught
+// exactly that: the parser declared WantsClientWriteHold, the session
+// field existed, the relay implemented the hold, and the one line
+// connecting them was missing. Every test still passed, because they
+// all built relay.Config themselves.
+//
+// Both probes are duck-typed rather than added to IntegrationsV2 so a
+// parser can opt in without every other implementation being touched.
+//
+// The two are mutually exclusive, and the hold wins. Pre-dispatch
+// routes the client's first chunk through the pause stash, which
+// bypasses the hold's byte accounting entirely, and its resume handler
+// acks OK while leaving the hold armed — the parser would believe the
+// connection resumed while every client byte was still being swallowed.
+// relay.Run refuses the combination too; this is the earlier, louder
+// half, where the parser can still be named.
+func parserClientBrakes(parser integrations.Integrations, logger *zap.Logger, parserType integrations.IntegrationType) (holdClientWrites, preDispatchPause bool) {
+	if hp, ok := parser.(interface{ WantsClientWriteHold() bool }); ok {
+		holdClientWrites = hp.WantsClientWriteHold()
+	}
+	if pp, ok := parser.(interface{ WantsPreDispatchPause() bool }); ok {
+		preDispatchPause = pp.WantsPreDispatchPause()
+	}
+	if holdClientWrites && preDispatchPause {
+		if logger != nil {
+			logger.Error("parser asked for both a client write hold and a pre-dispatch pause; using the hold",
+				zap.String("parser", string(parserType)),
+				zap.String("next_step", "implement WantsClientWriteHold or WantsPreDispatchPause, not both — the hold subsumes pre-dispatch for the client direction"),
+			)
+		}
+		preDispatchPause = false
+	}
+	return holdClientWrites, preDispatchPause
+}
+
 func parserCanResyncAfterGap(parser integrations.Integrations) bool {
 	gr, ok := parser.(integrations.GapResyncCapable)
 	return ok && gr.CanResyncAfterGap()

--- a/pkg/agent/proxy/relay/client_hold_test.go
+++ b/pkg/agent/proxy/relay/client_hold_test.go
@@ -1,0 +1,913 @@
+package relay
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy/directive"
+	"go.uber.org/zap"
+)
+
+// These tests cover Config.HoldClientWrites against the choreography it
+// was built for: MySQL's CLIENT_SSL upgrade.
+//
+// MySQL is server-speaks-first. The upgrade is: server greets, client
+// replies with a 36-byte SSLRequest, and then — with no further server
+// turn — the client starts its TLS handshake on the SAME connection. So
+// exactly the SSLRequest, and nothing after it, may reach the upstream
+// in cleartext. The ClientHello that follows must not be forwarded,
+// because by the time it is written keploy is the one terminating that
+// handshake.
+//
+// TestClientWriteHold_NoHoldLeaksClientHello is the negative control and
+// is the most important test in this file: it asserts that WITHOUT the
+// hold the ClientHello does leak. Two earlier drafts of these tests
+// passed against unfixed code — once because net.Pipe's unbuffered
+// Write serialises the application behind the relay and makes the race
+// impossible to stage, and once because the byte counter stopped at the
+// TLS upgrade while the leak actually lands just after it. A positive
+// test alone cannot tell "the hold works" from "the harness never
+// reproduced the race"; the control is what separates them.
+
+const (
+	// sslRequestLen is the fixed width of MySQL's SSLRequest packet:
+	// a 4-byte header plus the 32-byte truncated HandshakeResponse41.
+	sslRequestLen = 36
+	// clientHelloLen is a plausible TLS ClientHello size. The exact
+	// value only has to be distinguishable from sslRequestLen.
+	clientHelloLen = 120
+)
+
+func mysqlSSLRequest() []byte {
+	p := make([]byte, sslRequestLen)
+	p[0] = byte(sslRequestLen - 4) // payload length, 3-byte LE
+	p[3] = 1                       // sequence id
+	for i := 4; i < sslRequestLen; i++ {
+		p[i] = byte(i)
+	}
+	return p
+}
+
+func tlsClientHello() []byte {
+	p := make([]byte, clientHelloLen)
+	// Record type 0x16 (handshake), TLS 1.0 record version.
+	p[0], p[1], p[2] = 0x16, 0x03, 0x01
+	return p
+}
+
+// tcpHarness is newHarness over REAL TCP sockets instead of net.Pipe.
+//
+// The distinction is load-bearing. net.Pipe is synchronous and
+// unbuffered: a client Write blocks until the relay reads it, which
+// accidentally serialises the application behind the relay and hides the
+// race entirely. A real socket has kernel buffers, so the application's
+// ClientHello lands in the buffer the instant it is written and the
+// forwarder picks it up on its next read — exactly as in production.
+type tcpHarness struct {
+	clientApp net.Conn
+	destSvc   net.Conn
+	r         *Relay
+	cancel    context.CancelFunc
+	done      chan struct{}
+
+	upMu     sync.Mutex
+	upstream []byte
+}
+
+func newTCPHarness(t *testing.T, cfg Config) *tcpHarness {
+	t.Helper()
+	if cfg.Logger == nil {
+		cfg.Logger = zap.NewNop()
+	}
+
+	pair := func() (a, b net.Conn) {
+		t.Helper()
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen: %v", err)
+		}
+		defer func() { _ = ln.Close() }()
+		type res struct {
+			c   net.Conn
+			err error
+		}
+		ch := make(chan res, 1)
+		go func() {
+			c, err := ln.Accept()
+			ch <- res{c, err}
+		}()
+		dial, err := net.Dial("tcp", ln.Addr().String())
+		if err != nil {
+			t.Fatalf("dial: %v", err)
+		}
+		got := <-ch
+		if got.err != nil {
+			t.Fatalf("accept: %v", got.err)
+		}
+		return dial, got.c
+	}
+
+	clientApp, srcProxy := pair()
+	dstProxy, destSvc := pair()
+
+	r := New(cfg, srcProxy, dstProxy)
+	ctx, cancel := context.WithCancel(context.Background())
+	h := &tcpHarness{clientApp: clientApp, destSvc: destSvc, r: r, cancel: cancel, done: make(chan struct{})}
+	go func() {
+		defer close(h.done)
+		_ = r.Run(ctx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		_ = clientApp.Close()
+		_ = destSvc.Close()
+		select {
+		case <-h.done:
+		case <-time.After(2 * time.Second):
+		}
+	})
+	return h
+}
+
+// drainUpstream records every byte the real destination service
+// receives. It counts them ALL, not just the ones before the TLS
+// upgrade: the leak this file is about lands just AFTER the upgrade
+// completes, because the forwarder is still running and flushes what the
+// application already wrote.
+func (h *tcpHarness) drainUpstream(t *testing.T) {
+	t.Helper()
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			_ = h.destSvc.SetReadDeadline(time.Now().Add(3 * time.Second))
+			n, err := h.destSvc.Read(buf)
+			if n > 0 {
+				h.upMu.Lock()
+				h.upstream = append(h.upstream, buf[:n]...)
+				h.upMu.Unlock()
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+}
+
+// upstreamBytes returns a copy of everything the destination has seen.
+// Callers settle first so a leak in flight is not mistaken for absence.
+func (h *tcpHarness) upstreamBytes() []byte {
+	h.upMu.Lock()
+	defer h.upMu.Unlock()
+	return append([]byte(nil), h.upstream...)
+}
+
+func awaitTCPAck(t *testing.T, h *tcpHarness) directive.Ack {
+	t.Helper()
+	select {
+	case ack := <-h.r.Acks():
+		return ack
+	case <-time.After(3 * time.Second):
+		t.Fatal("no ack from the directive")
+		return directive.Ack{}
+	}
+}
+
+// greetAndAwait plays the server's MySQL greeting and waits for the real
+// client to receive it, establishing that D2C forwarding is unaffected
+// by a client-side hold.
+func (h *tcpHarness) greetAndAwait(t *testing.T) {
+	t.Helper()
+	greeting := []byte{0x0a, 'm', 'y', 's', 'q', 'l', 0x00}
+	if _, err := h.destSvc.Write(greeting); err != nil {
+		t.Fatalf("write greeting: %v", err)
+	}
+	got := make([]byte, len(greeting))
+	_ = h.clientApp.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, err := io.ReadFull(h.clientApp, got); err != nil {
+		t.Fatalf("client never saw the greeting (a client hold must not stall dest->client): %v", err)
+	}
+}
+
+// awaitParserSees consumes exactly n bytes off the parser's client
+// stream and returns once it has them, mirroring a parser that reads a
+// fixed-width packet before deciding what to do about it.
+func (h *tcpHarness) awaitParserSees(t *testing.T, n int) []byte {
+	t.Helper()
+	type res struct {
+		b   []byte
+		err error
+	}
+	ch := make(chan res, 1)
+	go func() {
+		buf := make([]byte, n)
+		_, err := io.ReadFull(h.r.ClientStream(), buf)
+		ch <- res{buf, err}
+	}()
+	select {
+	case got := <-ch:
+		if got.err != nil {
+			t.Fatalf("parser never saw %d bytes on the teed client stream: %v", n, got.err)
+		}
+		return got.b
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for the parser to see %d bytes on the teed client stream", n)
+		return nil
+	}
+}
+
+// awaitForwarderTeed blocks until the C2D forwarder has read and teed at
+// least n client bytes. It CONSUMES NOTHING — it observes the tee's
+// accepted-byte counter, which is the same stream position the relay
+// itself names when it discards handshake bytes.
+//
+// It exists because the two jobs the old single awaitParserSees call was
+// doing are in direct conflict.
+//
+// Job one is staging the production ordering: the forwarder is parked in
+// Read on the client socket, so it holds the ClientHello long before the
+// parser — which has to be scheduled, decode a packet and decide — can
+// say anything about it. The forwarder being AHEAD of the parser is
+// precisely why the leak exists, and a test that leaves it to a race
+// stops reproducing it silently (an earlier draft did exactly that).
+//
+// Job two was reading the ClientHello off the parser's stream, and that
+// is not staging at all — it is the assertion's own subject being
+// quietly cleaned up. A real MySQL parser reads the 36-byte SSLRequest
+// and stops; the ClientHello behind it stays in its FakeConn, which is
+// the entire defect. Draining it in the shared helper made every test in
+// this file blind to it.
+//
+// So the ordering is established here, without touching the stream, and
+// the parser's read is spelled out separately as the fixed-width packet
+// read it models.
+func (h *tcpHarness) awaitForwarderTeed(t *testing.T, n int64) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if h.r.teeC2D.acceptedBytes() >= n {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for the forwarder to tee %d client bytes; it teed %d. Without "+
+		"the forwarder demonstrably ahead of the parser these tests are not staging the race "+
+		"they exist to reproduce.", n, h.r.teeC2D.acceptedBytes())
+}
+
+// runSSLRequestUpgrade drives the MySQL CLIENT_SSL exchange and returns
+// what the upstream received in cleartext. coalesced controls whether
+// the client writes the SSLRequest and the ClientHello as one write —
+// which real clients do intermittently, and which is why the flush has
+// to split by byte count rather than by chunk.
+func runSSLRequestUpgrade(t *testing.T, cfg Config, flushBytes int, coalesced bool) (*tcpHarness, []byte, directive.Ack, []byte) {
+	t.Helper()
+
+	sslRequest := mysqlSSLRequest()
+	clientHello := tlsClientHello()
+
+	// The client-side upgrade reads the ClientHello off whatever conn
+	// the relay hands it. That is the real proof the held remainder is
+	// not lost: it arrives either prepended from the stash or straight
+	// off the socket, and either way the handshake must be able to read
+	// it. Captured so the assertions can check it is the ClientHello and
+	// not, say, the SSLRequest replayed by mistake.
+	var helloMu sync.Mutex
+	var helloSeen []byte
+	fn := func(_ context.Context, conn net.Conn, isClient bool, _ *tls.Config) (net.Conn, error) {
+		if !isClient {
+			seen := make([]byte, clientHelloLen)
+			// Short deadline on purpose: in the no-hold control the
+			// ClientHello has already gone upstream, so this read is
+			// meant to come up empty rather than stall the test.
+			_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+			if _, err := io.ReadFull(conn, seen); err == nil {
+				helloMu.Lock()
+				helloSeen = seen
+				helloMu.Unlock()
+			}
+			_ = conn.SetReadDeadline(time.Time{})
+		}
+		return &closeTrackingConn{Conn: conn}, nil
+	}
+	cfg.TLSUpgradeFn = fn
+
+	h := newTCPHarness(t, cfg)
+	h.drainUpstream(t)
+	h.greetAndAwait(t)
+
+	// Ordering is staged as a fact rather than left to a race — see
+	// awaitForwarderTeed for why, and for why the wait must not consume
+	// anything off the parser's stream.
+	if coalesced {
+		// One write, both messages. The forwarder sees them as a single
+		// read, so nothing chunk-shaped can separate them.
+		if _, err := h.clientApp.Write(append(append([]byte(nil), sslRequest...), clientHello...)); err != nil {
+			t.Fatalf("write coalesced SSLRequest+ClientHello: %v", err)
+		}
+	} else {
+		if _, err := h.clientApp.Write(sslRequest); err != nil {
+			t.Fatalf("write SSLRequest: %v", err)
+		}
+		h.awaitForwarderTeed(t, sslRequestLen)
+		// The application's TLS stack now writes its ClientHello
+		// immediately. Nothing asks it to wait, because on a real
+		// connection nothing can.
+		if _, err := h.clientApp.Write(clientHello); err != nil {
+			t.Fatalf("write ClientHello: %v", err)
+		}
+	}
+	// Both messages are now through the forwarder. In the no-hold case
+	// this is the moment the leak has already happened; in the hold case
+	// it is the moment both are sitting in the stash awaiting the split.
+	h.awaitForwarderTeed(t, sslRequestLen+clientHelloLen)
+
+	// Now the parser does what a MySQL parser does: read exactly the
+	// SSLRequest packet, decide on it, and dispatch. It does NOT read
+	// the ClientHello — nothing in the protocol would make it, and the
+	// bytes are not its to consume.
+	h.awaitParserSees(t, sslRequestLen)
+
+	h.r.Directives() <- directive.Directive{
+		Kind: directive.KindUpgradeTLS,
+		TLS: &directive.UpgradeTLSParams{
+			DestTLSConfig:    &tls.Config{},
+			ClientTLSConfig:  &tls.Config{},
+			ClientFlushBytes: flushBytes,
+		},
+		Reason: "mysql client_ssl",
+	}
+
+	ack := awaitTCPAck(t, h)
+	// Let anything still in flight land, so a leak a moment behind the
+	// ack is not mistaken for no leak at all.
+	time.Sleep(300 * time.Millisecond)
+
+	helloMu.Lock()
+	hello := helloSeen
+	helloMu.Unlock()
+	return h, h.upstreamBytes(), ack, hello
+}
+
+// TestClientWriteHold_NoHoldLeaksClientHello is the negative control:
+// with no hold, the ClientHello reaches the real server in cleartext.
+// If this test ever passes-by-not-leaking, the harness has stopped
+// reproducing the race and every other test in this file is vacuous.
+func TestClientWriteHold_NoHoldLeaksClientHello(t *testing.T) {
+	_, upstream, ack, _ := runSSLRequestUpgrade(t, Config{}, 0, false)
+	if !ack.OK {
+		t.Fatalf("TLS upgrade failed: %+v", ack)
+	}
+	if len(upstream) <= sslRequestLen {
+		t.Fatalf("negative control did not reproduce the leak: upstream saw %d cleartext bytes, "+
+			"expected more than the %d-byte SSLRequest. Without a demonstrated leak here, the "+
+			"hold tests below cannot distinguish a working hold from a harness that never staged "+
+			"the race.", len(upstream), sslRequestLen)
+	}
+}
+
+// TestClientWriteHold_SSLRequestPrefixOnly is the fix: the hold keeps
+// the ClientHello off the wire while still delivering the SSLRequest the
+// server needs in order to switch to TLS.
+func TestClientWriteHold_SSLRequestPrefixOnly(t *testing.T) {
+	cfg := Config{HoldClientWrites: true}
+	_, upstream, ack, hello := runSSLRequestUpgrade(t, cfg, sslRequestLen, false)
+
+	if !ack.OK {
+		t.Fatalf("TLS upgrade failed: %+v", ack)
+	}
+	if len(upstream) != sslRequestLen {
+		t.Fatalf("upstream received %d cleartext bytes, want exactly %d (the SSLRequest and "+
+			"nothing else). The surplus is the application's ClientHello: the real MySQL server "+
+			"reads it as protocol, and keploy's own destination handshake then runs against a "+
+			"desynchronised connection.", len(upstream), sslRequestLen)
+	}
+	if !bytes.Equal(upstream, mysqlSSLRequest()) {
+		t.Fatalf("upstream received %d bytes but not the SSLRequest: % x", len(upstream), upstream)
+	}
+	if len(hello) == 0 || hello[0] != 0x16 {
+		t.Fatalf("the client-side handshake never read the ClientHello (got % x); holding it back "+
+			"from the destination must not lose it — it belongs to keploy's own handshake", hello)
+	}
+}
+
+// TestClientWriteHold_CoalescedSSLRequestAndClientHello is the same
+// exchange with both messages in a single client write. Real clients do
+// this intermittently, and it is why the flush splits by byte count: no
+// chunk boundary separates the two here.
+func TestClientWriteHold_CoalescedSSLRequestAndClientHello(t *testing.T) {
+	cfg := Config{HoldClientWrites: true}
+	_, upstream, ack, hello := runSSLRequestUpgrade(t, cfg, sslRequestLen, true)
+
+	if !ack.OK {
+		t.Fatalf("TLS upgrade failed: %+v", ack)
+	}
+	if len(upstream) != sslRequestLen {
+		t.Fatalf("coalesced write: upstream received %d cleartext bytes, want exactly %d. A "+
+			"chunk-shaped flush forwards the whole read and leaks the ClientHello with it; the "+
+			"split has to be by byte count.", len(upstream), sslRequestLen)
+	}
+	if !bytes.Equal(upstream, mysqlSSLRequest()) {
+		t.Fatalf("coalesced write: upstream got %d bytes but not the SSLRequest: % x", len(upstream), upstream)
+	}
+	if len(hello) == 0 || hello[0] != 0x16 {
+		t.Fatalf("coalesced write: the client-side handshake never read the ClientHello (got % x)", hello)
+	}
+}
+
+// postTLSHandshakeResponse is a stand-in for the HandshakeResponse41 a
+// MySQL client sends once TLS is up. Only two things matter: it is not
+// the ClientHello, and its first byte is not 0x16, so a parser that got
+// handed the ClientHello instead fails on content rather than on length.
+func postTLSHandshakeResponse() []byte {
+	p := []byte{0x20, 0x00, 0x00, 0x01}
+	return append(p, []byte("post-tls-handshake-response")...)
+}
+
+// assertParserResumesAfterUpgrade writes a post-TLS message from the
+// client and asserts the parser's next bytes are exactly that message.
+//
+// In production the relay hands the parser plaintext lifted out of the
+// upgraded tls.Conn; here the harness's TLSUpgradeFn is a passthrough,
+// so a plain socket write after the ack is the same event.
+func assertParserResumesAfterUpgrade(t *testing.T, h *tcpHarness) {
+	t.Helper()
+	post := postTLSHandshakeResponse()
+	if _, err := h.clientApp.Write(post); err != nil {
+		t.Fatalf("write post-TLS message: %v", err)
+	}
+	got := h.awaitParserSees(t, len(post))
+	if !bytes.Equal(got, post) {
+		t.Fatalf("after the TLS upgrade the parser read % x, want % x.\n"+
+			"The relay consumed the held ClientHello for its own client-side handshake but a "+
+			"copy of it was still teed into the parser's stream, so the parser reads TLS "+
+			"handshake bytes where the post-TLS HandshakeResponse41 should be. A MySQL header "+
+			"of 16 03 01 00 declares payloadLength=66326, so ReadRequiredBytes blocks until the "+
+			"hang watchdog retires the parser and the connection falls through to passthrough — "+
+			"zero mocks on every MySQL TLS connection.", got, post)
+	}
+}
+
+// TestClientWriteHold_ParserDoesNotSeeClientHello is the other half of
+// the hold's contract, and the one the wire-level tests above cannot
+// see: bytes the relay CONSUMES for the handshake must not also reach
+// the parser as stream content.
+//
+// Keeping the ClientHello off the wire and leaving a copy of it in the
+// parser's stream trades a leak for a hang, which is strictly worse —
+// the leak corrupted one upstream connection, the hang costs every mock
+// on every MySQL TLS connection.
+func TestClientWriteHold_ParserDoesNotSeeClientHello(t *testing.T) {
+	h, upstream, ack, hello := runSSLRequestUpgrade(t, Config{HoldClientWrites: true}, sslRequestLen, false)
+	if !ack.OK {
+		t.Fatalf("TLS upgrade failed: %+v", ack)
+	}
+	if len(upstream) != sslRequestLen {
+		t.Fatalf("upstream received %d cleartext bytes, want exactly %d", len(upstream), sslRequestLen)
+	}
+	if len(hello) == 0 || hello[0] != 0x16 {
+		t.Fatalf("the client-side handshake never read the ClientHello (got % x); this test is "+
+			"only meaningful if the handshake really did consume it", hello)
+	}
+	assertParserResumesAfterUpgrade(t, h)
+}
+
+// TestClientWriteHold_ParserDoesNotSeeCoalescedClientHello is the same
+// assertion when both messages arrive in one read — the case where the
+// ClientHello is not a chunk of its own but the tail of the chunk whose
+// head the parser legitimately consumed. Any fix that works by dropping
+// whole pending chunks passes the test above and fails this one.
+func TestClientWriteHold_ParserDoesNotSeeCoalescedClientHello(t *testing.T) {
+	h, upstream, ack, hello := runSSLRequestUpgrade(t, Config{HoldClientWrites: true}, sslRequestLen, true)
+	if !ack.OK {
+		t.Fatalf("TLS upgrade failed: %+v", ack)
+	}
+	if len(upstream) != sslRequestLen {
+		t.Fatalf("coalesced: upstream received %d cleartext bytes, want exactly %d", len(upstream), sslRequestLen)
+	}
+	if len(hello) == 0 || hello[0] != 0x16 {
+		t.Fatalf("coalesced: the client-side handshake never read the ClientHello (got % x)", hello)
+	}
+	assertParserResumesAfterUpgrade(t, h)
+}
+
+// TestClientWriteHold_ReleaseFlushesEverything covers the no-TLS branch:
+// a MySQL client that sends a plaintext HandshakeResponse. The parser
+// releases the hold and every held byte is delivered, in order, followed
+// by normal forwarding.
+func TestClientWriteHold_ReleaseFlushesEverything(t *testing.T) {
+	h := newTCPHarness(t, Config{HoldClientWrites: true})
+	h.drainUpstream(t)
+	h.greetAndAwait(t)
+
+	plainAuth := bytes.Repeat([]byte{0xAB}, 64)
+	if _, err := h.clientApp.Write(plainAuth); err != nil {
+		t.Fatalf("write HandshakeResponse: %v", err)
+	}
+	h.awaitParserSees(t, len(plainAuth))
+
+	// Nothing has reached the server yet: that is the hold doing its job.
+	if got := h.upstreamBytes(); len(got) != 0 {
+		t.Fatalf("upstream saw %d bytes while the hold was up, want 0", len(got))
+	}
+
+	h.r.Directives() <- directive.ReleaseClient("mysql plaintext auth")
+	if ack := awaitTCPAck(t, h); !ack.OK {
+		t.Fatalf("release-client failed: %+v", ack)
+	}
+
+	// The held bytes are delivered...
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && len(h.upstreamBytes()) < len(plainAuth) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := h.upstreamBytes(); !bytes.Equal(got, plainAuth) {
+		t.Fatalf("release flushed %d bytes, want the %d held bytes verbatim", len(got), len(plainAuth))
+	}
+
+	// ...and forwarding resumes for everything after.
+	query := []byte("SELECT 1")
+	if _, err := h.clientApp.Write(query); err != nil {
+		t.Fatalf("write post-release query: %v", err)
+	}
+	want := append(append([]byte(nil), plainAuth...), query...)
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && len(h.upstreamBytes()) < len(want) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := h.upstreamBytes(); !bytes.Equal(got, want) {
+		t.Fatalf("after release the forwarder delivered %d bytes, want %d — the hold must come "+
+			"off for good, not just for the flush", len(got), len(want))
+	}
+}
+
+// TestClientWriteHold_CapBreachReleases covers a parser that arms a hold
+// and then never answers. The relay must choose the application over the
+// recording: flush, resume, and report the mock incomplete.
+func TestClientWriteHold_CapBreachReleases(t *testing.T) {
+	var incMu sync.Mutex
+	var reasons []string
+	cfg := Config{
+		HoldClientWrites: true,
+		ClientHoldCap:    1024,
+		OnMarkMockIncomplete: func(reason string) {
+			incMu.Lock()
+			reasons = append(reasons, reason)
+			incMu.Unlock()
+		},
+	}
+	h := newTCPHarness(t, cfg)
+	h.drainUpstream(t)
+	h.greetAndAwait(t)
+
+	// Overrun the cap without the parser ever issuing a directive.
+	payload := bytes.Repeat([]byte{0xCD}, 4096)
+	if _, err := h.clientApp.Write(payload); err != nil {
+		t.Fatalf("write oversized payload: %v", err)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) && len(h.upstreamBytes()) < len(payload) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := h.upstreamBytes(); len(got) != len(payload) {
+		t.Fatalf("cap breach delivered %d of %d bytes; the relay must not strand the client's "+
+			"request when it gives up on the hold", len(got), len(payload))
+	}
+
+	incMu.Lock()
+	got := append([]string(nil), reasons...)
+	incMu.Unlock()
+	var found bool
+	for _, reason := range got {
+		if reason == "client_hold_cap" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("cap breach reported %v, want a client_hold_cap mark — a silently degraded "+
+			"recording is worse than a loud one", got)
+	}
+}
+
+// TestClientWriteHold_ShortFlushIsRejected: a parser asking to forward
+// more than it ever saw is a bug in the parser. Forwarding the short
+// prefix would leave the server blocked on the rest of a message that is
+// never coming, so the directive fails instead.
+func TestClientWriteHold_ShortFlushIsRejected(t *testing.T) {
+	cfg := Config{HoldClientWrites: true}
+	_, upstream, ack, _ := runSSLRequestUpgrade(t, cfg, sslRequestLen+clientHelloLen+1, false)
+
+	if ack.OK {
+		t.Fatal("upgrade acked OK with a flush request larger than the stash; a byte-exact " +
+			"split that cannot be performed must be refused, not approximated")
+	}
+	// The refusal is loud, and nothing is silently destroyed: no TLS
+	// came up, so every held byte is delivered.
+	//
+	// The alternative — dropping them with the pause — was worse in
+	// both directions. takeStashedPrefix mutates, so validating after
+	// claiming ate the prefix and abandoned it; the server was then
+	// left waiting for a message whose head the relay had swallowed,
+	// while passthrough resumed and fed it the continuation. Two hangs
+	// and a desynchronised stream, from a parser bug.
+	//
+	// Delivering does mean that on a CLIENT_SSL connection the
+	// ClientHello reaches the server in cleartext — the very thing the
+	// hold prevents. That is accepted here and only here: reaching this
+	// path means the parser asked for a split that its own view of the
+	// stream cannot justify, so the connection is already unsalvageable
+	// (the client is committed to a TLS handshake nobody will answer).
+	// Given a choice between two broken outcomes, the server sees a
+	// protocol error and closes promptly, instead of both peers
+	// blocking until their own timeouts.
+	if len(upstream) != sslRequestLen+clientHelloLen {
+		t.Fatalf("a refused flush delivered %d of %d held bytes; a refusal must not silently "+
+			"destroy what the client already sent", len(upstream), sslRequestLen+clientHelloLen)
+	}
+}
+
+// TestReleaseClient_WithoutHoldIsRejected: the directive installs a
+// pause and nudges read deadlines into the past. Acting on it with no
+// hold up would leave those deadlines stuck there, spinning both
+// forwarders on EAGAIN for the rest of the connection.
+func TestReleaseClient_WithoutHoldIsRejected(t *testing.T) {
+	h := newTCPHarness(t, Config{})
+	h.drainUpstream(t)
+
+	h.r.Directives() <- directive.ReleaseClient("no hold armed")
+	ack := awaitTCPAck(t, h)
+	if ack.OK {
+		t.Fatal("release-client acked OK with no hold active; it must be refused")
+	}
+	if ack.Err == nil {
+		t.Fatal("release-client refusal carried no error")
+	}
+
+	// The connection must still work.
+	msg := []byte("still alive")
+	if _, err := h.clientApp.Write(msg); err != nil {
+		t.Fatalf("write after refused release: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && len(h.upstreamBytes()) < len(msg) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := h.upstreamBytes(); !bytes.Equal(got, msg) {
+		t.Fatalf("forwarding broke after a refused release: upstream got % x, want % x", got, msg)
+	}
+}
+
+// awaitUpstream waits until the destination has received at least n
+// bytes, then returns everything it has.
+func (h *tcpHarness) awaitUpstream(t *testing.T, n int) []byte {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if got := h.upstreamBytes(); len(got) >= n {
+			return got
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return h.upstreamBytes()
+}
+
+// TestClientWriteHold_ReleasedOnParserAbort covers the supervisor's
+// abort path: hang, panic, memory cap and cancellation all retire a
+// parser without a releasing directive, and the dispatcher's answer to
+// every one of them is to leave the relay forwarding raw bytes so user
+// traffic survives.
+//
+// A hold that outlives its parser falsifies that promise outright — the
+// client direction stays blackholed for the rest of the connection, and
+// ClientHoldCap cannot rescue it, because a client blocked waiting for
+// a reply to the request we are sitting on never sends the further
+// bytes a cap would count.
+func TestClientWriteHold_ReleasedOnParserAbort(t *testing.T) {
+	h := newTCPHarness(t, Config{HoldClientWrites: true})
+	h.drainUpstream(t)
+	h.greetAndAwait(t)
+
+	held := bytes.Repeat([]byte{0x5A}, 48)
+	if _, err := h.clientApp.Write(held); err != nil {
+		t.Fatalf("write held payload: %v", err)
+	}
+	h.awaitParserSees(t, len(held))
+	if got := h.upstreamBytes(); len(got) != 0 {
+		t.Fatalf("upstream saw %d bytes while the hold was up, want 0", len(got))
+	}
+
+	// Exactly what proxy_v2.go's SessionOnAbort does — and nothing
+	// more. The release is deliberately NOT called here: PauseTees owns
+	// it, so that forgetting it at a call site is impossible rather
+	// than merely discouraged. If someone decouples them, this test
+	// fails instead of a customer's connection hanging.
+	h.r.PauseTees()
+	_ = h.r.ClientStream().Close()
+	_ = h.r.DestStream().Close()
+
+	if got := h.awaitUpstream(t, len(held)); !bytes.Equal(got, held) {
+		t.Fatalf("abort delivered %d of %d held bytes; the relay promises user traffic is "+
+			"unaffected when a parser is retired", len(got), len(held))
+	}
+
+	// And the connection keeps working with no parser attached.
+	after := []byte("post-abort")
+	if _, err := h.clientApp.Write(after); err != nil {
+		t.Fatalf("write after abort: %v", err)
+	}
+	want := append(append([]byte(nil), held...), after...)
+	if got := h.awaitUpstream(t, len(want)); !bytes.Equal(got, want) {
+		t.Fatalf("forwarding did not resume after abort: got %d bytes, want %d", len(got), len(want))
+	}
+}
+
+// TestClientWriteHold_NoUpgraderStillDelivers: a relay with no
+// TLSUpgradeFn refuses the directive. That refusal used to return above
+// every hold-clearing path, leaving the connection blackholed for good.
+func TestClientWriteHold_NoUpgraderStillDelivers(t *testing.T) {
+	h := newTCPHarness(t, Config{HoldClientWrites: true})
+	h.drainUpstream(t)
+	h.greetAndAwait(t)
+
+	held := mysqlSSLRequest()
+	if _, err := h.clientApp.Write(held); err != nil {
+		t.Fatalf("write SSLRequest: %v", err)
+	}
+	h.awaitParserSees(t, len(held))
+
+	h.r.Directives() <- directive.Directive{
+		Kind:   directive.KindUpgradeTLS,
+		TLS:    &directive.UpgradeTLSParams{ClientFlushBytes: len(held)},
+		Reason: "no upgrader configured",
+	}
+	ack := awaitTCPAck(t, h)
+	if ack.OK {
+		t.Fatal("upgrade acked OK with no TLSUpgradeFn configured")
+	}
+	if got := h.awaitUpstream(t, len(held)); !bytes.Equal(got, held) {
+		t.Fatalf("a refused upgrade stranded %d of %d held bytes; the hold must not outlive "+
+			"the directive that failed to end it", len(got), len(held))
+	}
+}
+
+// TestClientWriteHold_FlushWithoutHoldIsRefused: ClientFlushBytes only
+// means something under a hold. Honouring it without one would tell the
+// parser its byte-exact split had been performed on a stream that was
+// forwarded in real time — the leak, with a green light on it.
+func TestClientWriteHold_FlushWithoutHoldIsRefused(t *testing.T) {
+	fn := func(_ context.Context, conn net.Conn, _ bool, _ *tls.Config) (net.Conn, error) {
+		return &closeTrackingConn{Conn: conn}, nil
+	}
+	h := newTCPHarness(t, Config{TLSUpgradeFn: fn}) // no hold
+	h.drainUpstream(t)
+
+	h.r.Directives() <- directive.Directive{
+		Kind:   directive.KindUpgradeTLS,
+		TLS:    &directive.UpgradeTLSParams{ClientFlushBytes: 36},
+		Reason: "flush without a hold",
+	}
+	ack := awaitTCPAck(t, h)
+	if ack.OK {
+		t.Fatal("upgrade acked OK for a byte-exact flush with no hold to split")
+	}
+	if ack.Err == nil {
+		t.Fatal("refusal carried no error")
+	}
+}
+
+// TestClientWriteHold_PreambleMismatchDeliversHeldBytes: the documented
+// "server declined TLS, record the cleartext path" outcome acks OK=true
+// with TLSUpgraded=false. No handshake ran, so the held remainder is
+// ordinary cleartext the server is still waiting for — and endPause
+// discards stashes unconditionally, so it used to vanish under a
+// success ack.
+func TestClientWriteHold_PreambleMismatchDeliversHeldBytes(t *testing.T) {
+	fn := func(_ context.Context, conn net.Conn, _ bool, _ *tls.Config) (net.Conn, error) {
+		return &closeTrackingConn{Conn: conn}, nil
+	}
+	h := newTCPHarness(t, Config{HoldClientWrites: true, TLSUpgradeFn: fn})
+	h.drainUpstream(t)
+
+	head := bytes.Repeat([]byte{0x11}, 20)
+	tail := bytes.Repeat([]byte{0x22}, 30)
+	if _, err := h.clientApp.Write(append(append([]byte(nil), head...), tail...)); err != nil {
+		t.Fatalf("write client payload: %v", err)
+	}
+	h.awaitParserSees(t, len(head)+len(tail))
+
+	// The server answers 'N' where the parser required 'S' — written
+	// AFTER the directive, so the pause barrier is up and the handler
+	// owns the socket. Writing it earlier lets the D2C forwarder
+	// consume it and forward it to the client, and the handler's
+	// preamble read then blocks on a byte that has already gone.
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		_, _ = h.destSvc.Write([]byte{'N'})
+	}()
+
+	h.r.Directives() <- directive.Directive{
+		Kind: directive.KindUpgradeTLS,
+		TLS: &directive.UpgradeTLSParams{
+			DestTLSConfig:        &tls.Config{},
+			ClientTLSConfig:      &tls.Config{},
+			ClientFlushBytes:     len(head),
+			PreambleReadFromDest: 1,
+			ProceedOnPreamble:    []byte{'S'},
+		},
+		Reason: "preamble gate",
+	}
+	ack := awaitTCPAck(t, h)
+	if !ack.OK || ack.TLSUpgraded {
+		t.Fatalf("want OK=true TLSUpgraded=false on a preamble mismatch, got %+v", ack)
+	}
+
+	want := append(append([]byte(nil), head...), tail...)
+	if got := h.awaitUpstream(t, len(want)); !bytes.Equal(got, want) {
+		t.Fatalf("preamble mismatch delivered %d of %d held bytes. No TLS came up, so the "+
+			"remainder is plain client data — dropping it truncates the client's message "+
+			"mid-stream while acking success.", len(got), len(want))
+	}
+}
+
+// TestClientWriteHold_CapAccumulatesAcrossReads exercises the cap the
+// way it actually trips in production — many small client writes rather
+// than one oversized one.
+func TestClientWriteHold_CapAccumulatesAcrossReads(t *testing.T) {
+	var incMu sync.Mutex
+	var reasons []string
+	h := newTCPHarness(t, Config{
+		HoldClientWrites: true,
+		ClientHoldCap:    512,
+		OnMarkMockIncomplete: func(reason string) {
+			incMu.Lock()
+			reasons = append(reasons, reason)
+			incMu.Unlock()
+		},
+	})
+	h.drainUpstream(t)
+	h.greetAndAwait(t)
+
+	chunk := bytes.Repeat([]byte{0x33}, 64)
+	total := 0
+	for i := 0; i < 12; i++ {
+		if _, err := h.clientApp.Write(chunk); err != nil {
+			t.Fatalf("write chunk %d: %v", i, err)
+		}
+		total += len(chunk)
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if got := h.awaitUpstream(t, total); len(got) != total {
+		t.Fatalf("cap breach across many reads delivered %d of %d bytes", len(got), total)
+	}
+
+	incMu.Lock()
+	got := append([]string(nil), reasons...)
+	incMu.Unlock()
+	var found bool
+	for _, reason := range got {
+		if reason == "client_hold_cap" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("cap breach reported %v, want client_hold_cap", got)
+	}
+}
+
+// TestClientWriteHold_MutuallyExclusiveWithPreDispatch: arming both
+// silently disables the hold's byte accounting and lets
+// resume-pre-dispatch ack OK on a still-held connection. Run refuses
+// the combination and keeps the hold.
+func TestClientWriteHold_MutuallyExclusiveWithPreDispatch(t *testing.T) {
+	h := newTCPHarness(t, Config{HoldClientWrites: true, PreDispatchPause: true})
+	h.drainUpstream(t)
+	h.greetAndAwait(t)
+
+	held := bytes.Repeat([]byte{0x44}, 24)
+	if _, err := h.clientApp.Write(held); err != nil {
+		t.Fatalf("write held payload: %v", err)
+	}
+	h.awaitParserSees(t, len(held))
+
+	// The hold is in force, not pre-dispatch: nothing reached the server
+	// and the bytes are counted against the cap rather than parked in
+	// the pause stash.
+	if got := h.upstreamBytes(); len(got) != 0 {
+		t.Fatalf("upstream saw %d bytes; the hold should be the active brake", len(got))
+	}
+
+	h.r.Directives() <- directive.ReleaseClient("release under both flags")
+	if ack := awaitTCPAck(t, h); !ack.OK {
+		t.Fatalf("release-client failed: %+v", ack)
+	}
+	if got := h.awaitUpstream(t, len(held)); !bytes.Equal(got, held) {
+		t.Fatalf("release delivered %d of %d held bytes", len(got), len(held))
+	}
+}

--- a/pkg/agent/proxy/relay/client_hold_test.go
+++ b/pkg/agent/proxy/relay/client_hold_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"go.keploy.io/server/v3/pkg/agent/proxy/fakeconn"
 	"io"
 	"net"
 	"sync"
@@ -956,4 +957,47 @@ func TestClientWriteHold_WholeHoldFlushedIsNotDiscarded(t *testing.T) {
 	}
 	// ...and normal stream continuity resumes after them.
 	assertParserResumesAfterUpgrade(t, h)
+}
+
+// TestClientWriteHold_ReleaseDeliversTheDestStash covers what endPause
+// would otherwise throw away.
+//
+// endPause discards both stashes unconditionally. After a TLS upgrade
+// that is right — the socket underneath has been replaced, and cleartext
+// bytes read before it have nowhere sensible to go. On a PLAIN release
+// it is wrong: nothing about the connection changes, so server bytes
+// read at the pause boundary are ordinary response data the client is
+// still waiting for. Dropping them is silent user-traffic loss on a
+// directive whose entire contract is "our brake comes off, nothing else
+// changes".
+//
+// The stash is populated directly rather than raced for. The real window
+// is nanoseconds wide — a reviewer failed to stage it in 60 attempts —
+// so a timing-based test would pass whether or not the delivery exists.
+// What matters is the handler's behaviour when the stash is non-empty.
+func TestClientWriteHold_ReleaseDeliversTheDestStash(t *testing.T) {
+	h := newTCPHarness(t, Config{HoldClientWrites: true})
+	h.drainUpstream(t)
+	h.greetAndAwait(t)
+
+	// A server response caught at the pause boundary.
+	stranded := []byte("server-bytes-read-at-the-boundary\n")
+	h.r.stashInflightFromPause(fakeconn.FromDest, stranded, time.Now())
+
+	h.r.Directives() <- directive.ReleaseClient("plaintext auth")
+	if ack := awaitTCPAck(t, h); !ack.OK {
+		t.Fatalf("release-client failed: %+v", ack)
+	}
+
+	_ = h.clientApp.SetReadDeadline(time.Now().Add(3 * time.Second))
+	got := make([]byte, len(stranded))
+	if _, err := io.ReadFull(h.clientApp, got); err != nil {
+		t.Fatalf("the client never received the bytes stashed at the pause boundary: %v.\n"+
+			"A plain release changes nothing about the connection, so those are ordinary "+
+			"response bytes the client is waiting for — endPause dropping them is silent "+
+			"user-traffic loss.", err)
+	}
+	if !bytes.Equal(got, stranded) {
+		t.Fatalf("client received % x, want % x", got, stranded)
+	}
 }

--- a/pkg/agent/proxy/relay/client_hold_test.go
+++ b/pkg/agent/proxy/relay/client_hold_test.go
@@ -911,3 +911,49 @@ func TestClientWriteHold_MutuallyExclusiveWithPreDispatch(t *testing.T) {
 		t.Fatalf("release delivered %d of %d held bytes", len(got), len(held))
 	}
 }
+
+// TestClientWriteHold_WholeHoldFlushedIsNotDiscarded is the case that
+// separates heldConsumedByHandshake from `upgradedSrc != nil`, and the
+// reason the flag exists at all.
+//
+// A parser that flushes the WHOLE hold — ClientFlushBytes covering
+// everything held, so nothing is left to prepend — and then upgrades
+// successfully has `upgradedSrc != nil` true, but NO held byte was
+// consumed by the handshake: every one of them went to the real server.
+// Discarding them from the parser's stream on the strength of
+// `upgradedSrc != nil` would hide bytes the server actually received,
+// and the recording would be missing the request it answered.
+//
+// The predicate was originally justified by a ClientTLSFirst ordering
+// argument that does not hold — upgradedSrc is assigned at the end of
+// upgradeClient and a later dest failure only Closes it, so the two
+// agree there. This is the case that actually discriminates.
+func TestClientWriteHold_WholeHoldFlushedIsNotDiscarded(t *testing.T) {
+	// Flush everything the client sent: SSLRequest AND the bytes behind
+	// it. Nothing is left for the handshake to prepend.
+	whole := sslRequestLen + clientHelloLen
+	h, upstream, ack, _ := runSSLRequestUpgrade(t, Config{HoldClientWrites: true}, whole, false)
+	if !ack.OK {
+		t.Fatalf("TLS upgrade failed: %+v", ack)
+	}
+	if len(upstream) != whole {
+		t.Fatalf("upstream received %d bytes, want all %d held bytes flushed", len(upstream), whole)
+	}
+
+	// The parser must still see every byte the server received — and it
+	// sees them BEFORE the post-TLS traffic, because they legitimately
+	// preceded it on the wire. That ordering is the assertion: if the
+	// discard keyed on "the client side upgraded" rather than on "the
+	// handshake consumed the remainder", these 120 bytes vanish and the
+	// parser's stream jumps straight to the post-TLS message, silently
+	// missing the request the server actually answered.
+	tail := h.awaitParserSees(t, clientHelloLen)
+	if len(tail) != clientHelloLen || tail[0] != 0x16 {
+		t.Fatalf("parser read % x after the upgrade, want the %d bytes that were flushed "+
+			"upstream. The whole hold went to the server, so nothing was consumed by the "+
+			"handshake and nothing should have been discarded from the parser's stream.",
+			tail, clientHelloLen)
+	}
+	// ...and normal stream continuity resumes after them.
+	assertParserResumesAfterUpgrade(t, h)
+}

--- a/pkg/agent/proxy/relay/config.go
+++ b/pkg/agent/proxy/relay/config.go
@@ -71,6 +71,20 @@ const (
 	// closes — short enough that a busy proxy is not holding file
 	// descriptors and tee buffers for half a minute per connection.
 	DefaultHalfCloseGrace = 10 * time.Second
+
+	// DefaultClientHoldCap bounds how many client bytes a
+	// [Config.HoldClientWrites] hold may accumulate before the relay
+	// gives up on the hold and releases it — see [Config.ClientHoldCap]
+	// for why the breach is handled by releasing rather than by
+	// dropping the connection.
+	//
+	// The window a hold covers is one client message: the parser is
+	// deciding, off the first chunk, whether this connection upgrades
+	// to TLS. MySQL's SSLRequest is 36 bytes and its plaintext
+	// HandshakeResponse is a few hundred, so 256 KiB is roughly three
+	// orders of magnitude of headroom over the real traffic while
+	// still bounding what one connection can pin in memory.
+	DefaultClientHoldCap int64 = 256 * 1024 // 256 KiB
 )
 
 // TLSUpgradeFn performs a TLS handshake on a real net.Conn and returns
@@ -307,6 +321,69 @@ type Config struct {
 	// keploy.yml or the hidden --half-close-grace flag.
 	HalfCloseGrace time.Duration
 
+	// HoldClientWrites, when true, stops the client→destination
+	// forwarder from writing to the real destination. Bytes are still
+	// read and still teed to the parser's FakeConn; only the
+	// destination Write is deferred. The hold stays up until the
+	// parser ends it with [directive.ReleaseClient] (which flushes
+	// everything held, in read order) or [directive.UpgradeTLS] (which
+	// flushes [directive.UpgradeTLSParams.ClientFlushBytes] and leaves
+	// the rest to the client-side handshake).
+	//
+	// This exists because [PreDispatchPause] cannot express MySQL's
+	// CLIENT_SSL upgrade, for two reasons:
+	//
+	//  1. It is all-or-nothing in TIME. The pre-dispatch pause parks
+	//     the forwarders at the first chunk and ends at dispatch; the
+	//     MySQL decision point is later, after the server's greeting
+	//     has already round-tripped through both directions.
+	//
+	//  2. It is all-or-nothing in BYTES. Its TLS flush is takeStashed,
+	//     the whole stash. MySQL needs a split: the 36-byte SSLRequest
+	//     must reach the server (or it never switches to TLS) and the
+	//     ClientHello immediately behind it must not (keploy terminates
+	//     that handshake itself). Those two routinely arrive in a
+	//     single read, so the split has to be by byte count.
+	//
+	// Without a hold, the C2D forwarder keeps running while the parser
+	// decides and forwards whatever the client wrote next. That is not
+	// a lost recording, it is a corrupted connection: the real server
+	// parses the ClientHello as MySQL protocol, and keploy's own
+	// destination handshake then runs against a desynchronised socket.
+	//
+	// The hold is directional. Destination→client forwarding is
+	// untouched, which is what lets a server-speaks-first protocol
+	// deliver its greeting while the client's reply is held.
+	//
+	// Default false. A parser that does not arm this sees today's
+	// behaviour exactly; a parser that arms it and then never sends a
+	// releasing directive wedges the connection until teardown, so the
+	// dispatcher only sets it for parsers that opt in via a capability
+	// method.
+	HoldClientWrites bool
+
+	// ClientHoldCap bounds the bytes a [HoldClientWrites] hold may
+	// accumulate. Zero resolves to [DefaultClientHoldCap]; negative
+	// disables the bound.
+	//
+	// On breach the relay releases the hold — flushing what it held
+	// and resuming normal forwarding — rather than dropping the
+	// connection, and reports "client_hold_cap" through
+	// [OnMarkMockIncomplete].
+	//
+	// Releasing is the right failure mode because of what a breach
+	// actually means. The hold covers one decision by the parser, over
+	// a message measured in hundreds of bytes; reaching 256 KiB means
+	// the parser is not going to answer. The client is by then blocked
+	// waiting for a server reply that cannot come, because its request
+	// is sitting in our stash. Flushing unwedges it: in the common
+	// no-TLS case the session simply proceeds, and the only casualty
+	// is the recording. Dropping the connection would take the user's
+	// application down to protect a mock, which inverts the priority
+	// the relay holds everywhere else — the forward path is not
+	// allowed to lose to the capture path.
+	ClientHoldCap int64
+
 	// ParserCanResyncAfterGap tells the tees whether the parser on the other
 	// end can re-anchor its framer after a HOLE in capture. Set by the
 	// dispatcher from the parser's optional
@@ -366,9 +443,32 @@ func (c Config) withDefaults() Config {
 	// opt out of half-close, so it must survive default resolution.
 	if out.HalfCloseGrace == 0 {
 		out.HalfCloseGrace = DefaultHalfCloseGrace
+
+	// == 0, not <= 0: a negative ClientHoldCap is the documented way to
+	// disable the bound, so it must survive default resolution.
+	if out.ClientHoldCap == 0 {
+		out.ClientHoldCap = DefaultClientHoldCap
 	}
 	if out.ConsumerStallGrace <= 0 {
 		out.ConsumerStallGrace = DefaultConsumerStallGrace
+	}
+	// The two client-direction brakes are alternatives, not layers, and
+	// the conflict is resolved HERE rather than in run() because run()
+	// installs the pre-dispatch pause barrier before it could act on
+	// the flag — clearing preDispatchActive afterwards leaves that
+	// barrier up with nothing to release it, and both forwarders park
+	// forever on a connection whose greeting never reaches the client.
+	//
+	// The hold wins. Pre-dispatch routes the client's first chunk
+	// through the pause stash, which bypasses the hold's byte
+	// accounting entirely (ClientHoldCap silently stops being
+	// enforced), and its resume handler acks OK while leaving the hold
+	// armed. See [HoldClientWrites].
+	if out.HoldClientWrites && out.PreDispatchPause {
+		out.PreDispatchPause = false
+		out.Logger.Error("relay: HoldClientWrites and PreDispatchPause are mutually exclusive; ignoring PreDispatchPause",
+			zap.String("next_step", "a parser should implement WantsClientWriteHold or WantsPreDispatchPause, never both — the hold subsumes pre-dispatch for the client direction"),
+		)
 	}
 	if out.MemoryGuardCheck == nil {
 		out.MemoryGuardCheck = memoryguard.IsRecordingPaused

--- a/pkg/agent/proxy/relay/config.go
+++ b/pkg/agent/proxy/relay/config.go
@@ -443,7 +443,7 @@ func (c Config) withDefaults() Config {
 	// opt out of half-close, so it must survive default resolution.
 	if out.HalfCloseGrace == 0 {
 		out.HalfCloseGrace = DefaultHalfCloseGrace
-
+	}
 	// == 0, not <= 0: a negative ClientHoldCap is the documented way to
 	// disable the bound, so it must survive default resolution.
 	if out.ClientHoldCap == 0 {

--- a/pkg/agent/proxy/relay/directive_proc.go
+++ b/pkg/agent/proxy/relay/directive_proc.go
@@ -892,6 +892,28 @@ func (r *Relay) handleReleaseClient(ctx context.Context, stopping <-chan struct{
 		r.cfg.OnMarkMockIncomplete("write_error")
 	}
 
+	// Deliver anything the D2C forwarder stashed at the pause boundary
+	// before endPause drops it.
+	//
+	// endPause discards both stashes unconditionally, which is right
+	// after a TLS upgrade — the socket underneath has been replaced and
+	// cleartext bytes read before it have nowhere sensible to go. It is
+	// wrong here: a plain release changes nothing about the connection,
+	// so server bytes read at the boundary are still ordinary response
+	// data the client is waiting for, and dropping them is silent
+	// user-traffic loss on a directive whose whole contract is "our
+	// brake comes off, nothing else changes".
+	if held := r.takeStashed(fakeconn.FromDest); held.len() > 0 {
+		if srcPtr := r.src.Load(); srcPtr != nil {
+			if _, werr := (*srcPtr).Write(held.bytes); werr != nil && log != nil {
+				log.Debug("relay: delivering the D2C pause stash on release failed",
+					zap.Error(werr),
+					zap.Int("bytes", held.len()),
+				)
+			}
+		}
+	}
+
 	r.endPause()
 
 	if err != nil {

--- a/pkg/agent/proxy/relay/directive_proc.go
+++ b/pkg/agent/proxy/relay/directive_proc.go
@@ -518,10 +518,19 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, stopping <-chan struct{}, 
 		// unspent would have endUpgradePause try to deliver bytes that are
 		// already gone.
 		//
-		// Distinct from `upgradedSrc != nil` only under ClientTLSFirst,
-		// where the client handshake runs first and a later dest-side
-		// failure would otherwise claim the client never upgraded. See
-		// endUpgradePause.
+		// Distinct from `upgradedSrc != nil`, and NOT for the reason it
+		// is tempting to write down. It is not about ClientTLSFirst
+		// ordering: upgradedSrc is assigned at the end of upgradeClient
+		// and upgradeDest's failure path only Closes it, so
+		// `upgradedSrc != nil` is true there too.
+		//
+		// The case that separates them is a parser that flushes the
+		// WHOLE hold — ClientFlushBytes covering everything held, so
+		// nothing is left to prepend — and then upgrades successfully.
+		// `upgradedSrc != nil` is true, but no held byte was consumed by
+		// the handshake: every one of them went to the real server.
+		// Discarding them from the parser's stream on that basis would
+		// hide bytes the server actually received. See endUpgradePause.
 		heldConsumedByHandshake bool
 	)
 

--- a/pkg/agent/proxy/relay/directive_proc.go
+++ b/pkg/agent/proxy/relay/directive_proc.go
@@ -71,6 +71,8 @@ func (r *Relay) handleDirective(ctx context.Context, stopping <-chan struct{}, d
 		return directive.Ack{Kind: d.Kind, OK: true}
 	case directive.KindResumePreDispatch:
 		return r.handleResumePreDispatch(ctx, stopping, d)
+	case directive.KindReleaseClient:
+		return r.handleReleaseClient(ctx, stopping, d)
 	default:
 		return directive.Ack{
 			Kind: d.Kind,
@@ -125,12 +127,46 @@ func (r *Relay) handleDirective(ctx context.Context, stopping <-chan struct{}, d
 // parser can detect from already-forwarded bytes alone.
 func (r *Relay) handleUpgradeTLS(ctx context.Context, stopping <-chan struct{}, d directive.Directive) directive.Ack {
 	log := r.cfg.Logger
+
+	// Whether a client write hold was in force when this directive
+	// arrived. Every exit below routes through endUpgradePause, which
+	// uses this to decide what happens to bytes still held: if the
+	// client side did not end up behind TLS, they are ordinary
+	// cleartext that the server is still waiting for, and dropping them
+	// would truncate the connection mid-message.
+	//
+	// Computed FIRST, above every early return. An exit that skips it
+	// leaves the hold armed with no one left to release it, and the
+	// client direction is blackholed for the rest of the connection —
+	// the no-upgrader return below was exactly that bug.
+	heldAtEntry := r.holdClient.Load()
+
 	if r.cfg.TLSUpgradeFn == nil {
+		// No pause was installed, so endUpgradePause only does the
+		// flush half here — which is the half that matters: the parser
+		// asked for an upgrade this relay cannot perform, and the bytes
+		// it held for that upgrade still belong to the server.
+		r.endUpgradePause(heldAtEntry, false, 0)
 		return directive.Ack{Kind: d.Kind, OK: false, Err: ErrNoTLSUpgrader}
 	}
 	params := d.TLS
 	if params == nil {
 		params = &directive.UpgradeTLSParams{}
+	}
+
+	// A flush count is only meaningful under a hold. Asking for one
+	// without a hold means the parser believes bytes are being held
+	// back that were in fact forwarded in real time — exactly the leak
+	// the hold exists to prevent, and acking OK would tell the parser
+	// its byte-exact split had been honoured when nothing was split at
+	// all. Refuse before the barrier goes up.
+	if params.ClientFlushBytes > 0 && !heldAtEntry {
+		return directive.Ack{
+			Kind: d.Kind,
+			OK:   false,
+			Err: fmt.Errorf("TLS upgrade: ClientFlushBytes=%d but no client write hold is active",
+				params.ClientFlushBytes),
+		}
 	}
 
 	// Barrier up. Forwarders will park on their next loop iteration.
@@ -151,6 +187,26 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, stopping <-chan struct{}, 
 	// has already been consumed by the forwarder Read that just woke
 	// up.
 	r.waitForwardersParked(ctx, stopping)
+
+	// The parser's client stream is now exactly this long, and it
+	// cannot grow while the forwarders are parked. Under a client
+	// write hold this number is the boundary between "bytes the parser
+	// was meant to read" and "bytes keploy's own client-side handshake
+	// is about to consume": the parser has read the SSLRequest it based
+	// this directive on, and everything the tee accepted after that is
+	// the ClientHello behind it. Captured here rather than derived
+	// later so it names a position the forwarders could not have moved.
+	// See the use in endUpgradePause.
+	//
+	// Both ways of being wrong here are safe in the same direction.
+	// waitForwardersParked gives up if the relay is stopping, so C2D can
+	// in principle still be live and tee past this point — those bytes
+	// are ABOVE the offset and are simply left alone, never swallowed.
+	// And a parser that had over-read past its own flush prefix has
+	// already seen bytes we cannot take back, but the offset still
+	// bounds the discard to what was teed before the barrier, so live
+	// post-upgrade traffic is untouchable either way.
+	barrierTeeOffset := r.teeC2D.acceptedBytes()
 
 	boundaryReadAt := time.Now()
 
@@ -204,7 +260,88 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, stopping <-chan struct{}, 
 	// path — where the forwarder forwarded the SSLRequest in real time
 	// and only the post-pause-boundary 'S' byte ended up stashed on
 	// the D2C side — keeps the existing semantics.
-	if r.preDispatchActive.Load() {
+	//
+	// A client write hold (Config.HoldClientWrites) needs the same
+	// flush for the same reason, but a byte-exact one. Under
+	// pre-dispatch the stash is the client's first message and all of
+	// it belongs upstream. Under a hold the stash can hold the
+	// SSLRequest AND the ClientHello behind it — often from a single
+	// read — and only the first belongs upstream; the remainder is
+	// claimed further down as the prepend for the client-side
+	// handshake. So the hold branch flushes exactly
+	// params.ClientFlushBytes and leaves the rest in place.
+	if r.holdClient.Load() {
+		// Clear the hold before the flush, not after. The forwarders
+		// are parked behind the pause barrier and cannot observe the
+		// flag until endPause below, but leaving it set through an
+		// early return (a short stash, a failed Write) would strand
+		// the connection in a hold that nothing will ever release.
+		r.holdClient.Store(false)
+		r.heldClientBytes.Store(0)
+
+		if params.ClientFlushBytes > 0 {
+			// Check the length BEFORE claiming anything.
+			// takeStashedPrefix mutates the stash, so taking first and
+			// validating second would consume the prefix and then
+			// abandon it on the error return — the server would be left
+			// waiting for a message whose head we had silently eaten.
+			if avail := r.stashedLen(fakeconn.FromClient); avail < params.ClientFlushBytes {
+				// The parser asked us to forward more than it ever saw.
+				// Fail the directive; endUpgradePause below still
+				// delivers everything held, so the connection stays
+				// consistent even though the split did not happen.
+				if log != nil {
+					log.Debug("relay: TLS upgrade client-hold flush short",
+						zap.Int("requested", params.ClientFlushBytes),
+						zap.Int("available", avail),
+						zap.String("directive_reason", d.Reason),
+					)
+				}
+				r.endUpgradePause(heldAtEntry, false, barrierTeeOffset)
+				return directive.Ack{
+					Kind: d.Kind,
+					OK:   false,
+					Err: fmt.Errorf("TLS upgrade client-hold flush: asked for %d bytes, stash held %d",
+						params.ClientFlushBytes, avail),
+				}
+			}
+			c2dForward := r.takeStashedPrefix(fakeconn.FromClient, params.ClientFlushBytes)
+			dstPtr := r.dst.Load()
+			if dstPtr == nil || *dstPtr == nil {
+				r.endUpgradePause(heldAtEntry, false, barrierTeeOffset)
+				return directive.Ack{
+					Kind: d.Kind,
+					OK:   false,
+					Err:  errors.New("TLS upgrade client-hold C2D flush: no destination conn"),
+				}
+			}
+			wn, werr := (*dstPtr).Write(c2dForward.bytes)
+			if werr == nil && wn != c2dForward.len() {
+				werr = fmt.Errorf("short write %d of %d bytes", wn, c2dForward.len())
+			}
+			if werr != nil {
+				if log != nil {
+					log.Debug("relay: TLS upgrade client-hold C2D flush failed",
+						zap.Error(werr),
+						zap.Int("bytes", c2dForward.len()),
+						zap.String("directive_reason", d.Reason),
+					)
+				}
+				// The server did not get the client's message, so
+				// whatever this connection records next is missing its
+				// head. Say so rather than scoring the mock clean.
+				if r.cfg.OnMarkMockIncomplete != nil {
+					r.cfg.OnMarkMockIncomplete("write_error")
+				}
+				r.endUpgradePause(heldAtEntry, false, barrierTeeOffset)
+				return directive.Ack{
+					Kind: d.Kind,
+					OK:   false,
+					Err:  fmt.Errorf("TLS upgrade client-hold C2D flush: %w", werr),
+				}
+			}
+		}
+	} else if r.preDispatchActive.Load() {
 		c2dForward := r.takeStashed(fakeconn.FromClient)
 		if c2dForward.len() > 0 {
 			dst := *r.dst.Load()
@@ -216,7 +353,7 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, stopping <-chan struct{}, 
 						zap.String("directive_reason", d.Reason),
 					)
 				}
-				r.endPause()
+				r.endUpgradePause(heldAtEntry, false, barrierTeeOffset)
 				return directive.Ack{
 					Kind: d.Kind,
 					OK:   false,
@@ -254,7 +391,7 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, stopping <-chan struct{}, 
 							zap.String("next_step", "the upstream closed mid-preamble; verify the destination is the protocol the parser was matched to and consider KEPLOY_DISABLE_PARSING=1 to bypass parsing"),
 						)
 					}
-					r.endPause()
+					r.endUpgradePause(heldAtEntry, false, barrierTeeOffset)
 					return directive.Ack{
 						Kind:            d.Kind,
 						OK:              false,
@@ -292,7 +429,7 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, stopping <-chan struct{}, 
 						zap.String("next_step", "the upstream closed the connection or returned fewer bytes than the parser expected for its preamble; verify the destination is the protocol the parser was matched to (Postgres on a non-Postgres port, etc.) and consider KEPLOY_DISABLE_PARSING=1 to bypass parsing"),
 					)
 				}
-				r.endPause()
+				r.endUpgradePause(heldAtEntry, false, barrierTeeOffset)
 				return directive.Ack{
 					Kind:            d.Kind,
 					OK:              false,
@@ -317,7 +454,7 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, stopping <-chan struct{}, 
 						zap.String("directive_reason", d.Reason),
 					)
 				}
-				r.endPause()
+				r.endUpgradePause(heldAtEntry, false, barrierTeeOffset)
 				return directive.Ack{
 					Kind:            d.Kind,
 					OK:              false,
@@ -334,7 +471,7 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, stopping <-chan struct{}, 
 		// marking it incomplete.
 		if len(params.ProceedOnPreamble) > 0 && !bytesEqual(params.ProceedOnPreamble, preamblePayload) {
 			boundaryWrittenAt := time.Now()
-			r.endPause()
+			r.endUpgradePause(heldAtEntry, false, barrierTeeOffset)
 			return directive.Ack{
 				Kind:              d.Kind,
 				OK:                true,
@@ -372,6 +509,20 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, stopping <-chan struct{}, 
 	var (
 		upgradedDst net.Conn
 		upgradedSrc net.Conn
+		// heldConsumedByHandshake records that the client write hold's
+		// remainder was handed to the client-side handshake as a prepend,
+		// and is therefore no longer the relay's to deliver — while a copy
+		// of it is still stranded in the parser's stream. Set at the
+		// hand-over rather than after a successful handshake: the bytes are
+		// spent either way, and a failed handshake that reported them
+		// unspent would have endUpgradePause try to deliver bytes that are
+		// already gone.
+		//
+		// Distinct from `upgradedSrc != nil` only under ClientTLSFirst,
+		// where the client handshake runs first and a later dest-side
+		// failure would otherwise claim the client never upgraded. See
+		// endUpgradePause.
+		heldConsumedByHandshake bool
 	)
 
 	upgradeDest := func() *directive.Ack {
@@ -420,7 +571,7 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, stopping <-chan struct{}, 
 			if upgradedSrc != nil {
 				_ = upgradedSrc.Close()
 			}
-			r.endPause()
+			r.endUpgradePause(heldAtEntry, heldConsumedByHandshake, barrierTeeOffset)
 			return &directive.Ack{
 				Kind:            d.Kind,
 				OK:              false,
@@ -484,6 +635,7 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, stopping <-chan struct{}, 
 				)
 			}
 			src = newPrependingConnWithReadAt(src, stashed.bytes, stashed.readAt)
+			heldConsumedByHandshake = true
 		}
 		trackedSrc := newReadTrackingConn(src)
 		var err error
@@ -506,7 +658,7 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, stopping <-chan struct{}, 
 			if upgradedDst != nil {
 				_ = upgradedDst.Close()
 			}
-			r.endPause()
+			r.endUpgradePause(heldAtEntry, heldConsumedByHandshake, barrierTeeOffset)
 			return &directive.Ack{
 				Kind:            d.Kind,
 				OK:              false,
@@ -540,7 +692,11 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, stopping <-chan struct{}, 
 	}
 
 	boundaryWrittenAt := time.Now()
-	r.endPause()
+	// The CLIENT-side handshake is what consumes the held remainder (it
+	// is that side's ClientHello). A dest-only upgrade never claims it,
+	// so it stays plain client bytes the server is still owed — and the
+	// parser's copy of them stays legitimate stream content.
+	r.endUpgradePause(heldAtEntry, heldConsumedByHandshake, barrierTeeOffset)
 
 	return directive.Ack{
 		Kind:              d.Kind,
@@ -674,6 +830,71 @@ func (r *Relay) handleAbortMock(d directive.Directive) directive.Ack {
 //
 //  5. Calls endPause to close the pause channel — forwarders parked on
 //     it wake up and resume normal Read→Write→Tee operation.
+//
+// handleReleaseClient ends a [Config.HoldClientWrites] hold without a
+// TLS upgrade: every byte held for the real destination is written to
+// it in read order and the C2D forwarder goes back to forwarding.
+//
+// This is the path a parser takes when it has inspected the client's
+// opening message and concluded the session stays cleartext — MySQL
+// sending a plain HandshakeResponse rather than an SSLRequest. Nothing
+// about the connection changes except that our brake comes off, so
+// unlike the TLS path there is no handshake, no socket swap, and the
+// bytes are delivered rather than consumed.
+//
+// It runs under the pause barrier for the same reason the TLS path
+// does: the forwarder appends to the same stash we are draining, and
+// the parked-wait is what makes "take the stash" mean "take all of it".
+func (r *Relay) handleReleaseClient(ctx context.Context, stopping <-chan struct{}, d directive.Directive) directive.Ack {
+	log := r.cfg.Logger
+
+	// Reject a release for a hold that is not up. As with
+	// resume-pre-dispatch, the alternative is worse than an error: the
+	// pause below nudges read deadlines into the past, and endPause
+	// only restores them while a pause is actually installed, so a
+	// stray directive could leave the forwarders spinning on EAGAIN
+	// for the rest of the connection.
+	if !r.holdClient.Load() {
+		return directive.Ack{
+			Kind: d.Kind,
+			OK:   false,
+			Err:  errors.New("release-client: no active client write hold to release"),
+		}
+	}
+
+	r.beginPause()
+	r.waitForwardersParked(ctx, stopping)
+
+	// beginPause put a past read deadline on both sockets to wake the
+	// forwarders. Clear it before writing: a *tls.Conn Write can need
+	// to read (renegotiation, or simply the handshake it defers to the
+	// first I/O), and it would fail on the stale deadline.
+	clearDeadline(r.dst.Load())
+	clearDeadline(r.src.Load())
+
+	err := r.releaseClientHold()
+	if err != nil && log != nil {
+		log.Debug("relay: client hold release flush failed",
+			zap.Error(err),
+			zap.String("directive_reason", d.Reason),
+		)
+	}
+	if err != nil && r.cfg.OnMarkMockIncomplete != nil {
+		r.cfg.OnMarkMockIncomplete("write_error")
+	}
+
+	r.endPause()
+
+	if err != nil {
+		return directive.Ack{
+			Kind: d.Kind,
+			OK:   false,
+			Err:  fmt.Errorf("release-client flush: %w", err),
+		}
+	}
+	return directive.Ack{Kind: d.Kind, OK: true}
+}
+
 func (r *Relay) handleResumePreDispatch(ctx context.Context, stopping <-chan struct{}, d directive.Directive) directive.Ack {
 	log := r.cfg.Logger
 
@@ -719,6 +940,18 @@ func (r *Relay) handleResumePreDispatch(ctx context.Context, stopping <-chan str
 	// behind pauseCh until endPause below — the flag clear here is
 	// belt-and-braces) sees the standard pause semantics.
 	r.preDispatchActive.Store(false)
+
+	// A client write hold means "resume" cannot be honoured by lifting
+	// the pause alone: the forward loop would come back up and keep
+	// swallowing client bytes, and this handler would have acked OK
+	// while doing it. Run() refuses to arm both brakes at once, so this
+	// is unreachable today and stays as a guard: if a hold is up, a
+	// resume ends it. The stash claimed above is drained below, so
+	// clear the flag and the counter rather than calling
+	// releaseClientHold, which would try to drain it a second time.
+	if r.holdClient.Swap(false) {
+		r.heldClientBytes.Store(0)
+	}
 
 	var drainErr error
 	if len(c2dStash) > 0 {

--- a/pkg/agent/proxy/relay/relay.go
+++ b/pkg/agent/proxy/relay/relay.go
@@ -1254,23 +1254,6 @@ func (r *Relay) noteHeldClientBytes(n int64) bool {
 	return true
 }
 
-// ReleaseClientHold ends a [Config.HoldClientWrites] hold from outside
-// the directive path, delivering everything held to the real
-// destination. No-op when no hold is up, and safe to call repeatedly.
-//
-// This is the safety valve the supervisor's abort path needs. A hold is
-// normally ended by the parser, but hang, panic, memory-cap and context
-// cancellation all retire a parser without one — and the dispatcher's
-// response to those is to leave the relay running and let raw bytes
-// flow ("user traffic is unaffected"). A hold that survives the parser
-// falsifies exactly that promise: the client direction is blackholed
-// for the rest of the connection, and no cap rescues it because a
-// client blocked on a reply it cannot get sends nothing more. The
-// caller invokes this before it stops caring about the parser.
-func (r *Relay) ReleaseClientHold() error {
-	return r.releaseClientHold()
-}
-
 // releaseClientHold ends a client write hold: everything the C2D
 // forwarder held is written to the real destination in read order and
 // normal forwarding resumes. No-op when no hold is up.

--- a/pkg/agent/proxy/relay/relay.go
+++ b/pkg/agent/proxy/relay/relay.go
@@ -674,7 +674,16 @@ func (r *Relay) forward(
 				// (the client's first chunk) and nothing it didn't
 				// (the server's preamble reply belongs to the
 				// directive handler, not the parser).
-				if r.preDispatchActive.Load() && dir == fakeconn.FromClient {
+				// A hold gets the same treatment as pre-dispatch, and
+				// for the same reason. Under a hold every client byte is
+				// the parser's to see — that is the hold's contract, and
+				// what the upgrade's watermark later retracts is only
+				// the part the handshake consumed. Without this, bytes
+				// the forwarder happened to read inside the pause window
+				// are flushed upstream by the release but never teed, so
+				// the parser's stream has a hole covering bytes the real
+				// server received.
+				if (r.preDispatchActive.Load() || r.holdClient.Load()) && dir == fakeconn.FromClient {
 					chunk := fakeconn.Chunk{
 						Dir:    dir,
 						Bytes:  stash,

--- a/pkg/agent/proxy/relay/relay.go
+++ b/pkg/agent/proxy/relay/relay.go
@@ -3,6 +3,7 @@ package relay
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"strings"
@@ -107,6 +108,38 @@ type Relay struct {
 	// single-shot; subsequent Run calls return this cached error via
 	// ErrRelayAlreadyRun.
 	runErr atomic.Pointer[error]
+
+	// holdClient is true while a [Config.HoldClientWrites] hold is up:
+	// the C2D forwarder reads and tees but does not write to the real
+	// destination, parking the client's bytes in stashedC2D instead.
+	// Armed by [Relay.Run] when the config asks for it, cleared by the
+	// KindReleaseClient or KindUpgradeTLS handler (or by the cap
+	// breach in noteHeldClientBytes).
+	//
+	// Separate from preDispatchActive because the two answer different
+	// questions: preDispatchActive is a property of a PAUSE WINDOW and
+	// dies with it, while a hold spans the parser's whole decision —
+	// across the server greeting's round trip, which for a
+	// server-speaks-first protocol happens before the client has said
+	// anything worth deciding on.
+	holdClient atomic.Bool
+
+	// heldClientBytes counts the bytes currently held by holdClient, so
+	// the forwarder can enforce [Config.ClientHoldCap] without taking
+	// stashMu on its hot path.
+	heldClientBytes atomic.Int64
+
+	// holdMu serialises hold releases so a claim-then-write pair is
+	// atomic with respect to any other releaser.
+	//
+	// It is NOT redundant with the pause barrier. waitForwardersParked
+	// gives up when `stopping` closes, and `stopping` closes as soon as
+	// the FIRST forwarder exits — so from the moment D2C sees EOF, a
+	// directive handler proceeds while C2D is still live inside the hold
+	// block. Without this lock the handler's take+write and the
+	// forwarder's cap-breach take+write can interleave and reach the
+	// upstream socket out of order.
+	holdMu sync.Mutex
 
 	// preDispatchActive is true between [Relay.Run]'s pre-spawn
 	// [installPreDispatchPause] call (gated on
@@ -246,9 +279,24 @@ func (r *Relay) DropCounts() (c2d, d2c uint64) {
 //
 // Idempotent; calling after Run has returned is a no-op because the
 // tees are already closed.
+//
+// This also ENDS any client write hold, flushing what it held. The
+// coupling is not a convenience: this function's own contract is that
+// every incoming byte still reaches its peer, and a hold that outlives
+// its parser falsifies exactly that — the client direction stays
+// blackholed for the rest of the connection. "The parser is dead" and
+// "the parser can still decide what to do with the bytes we are holding
+// for it" cannot both be true, so the release belongs here rather than
+// at the call site, where forgetting it is a silent user-traffic
+// outage rather than a compile error.
 func (r *Relay) PauseTees() {
 	r.teeC2D.setPaused(true)
 	r.teeD2C.setPaused(true)
+	if err := r.releaseClientHold(); err != nil && r.cfg.Logger != nil {
+		r.cfg.Logger.Debug("relay: flushing the client hold while pausing tees failed",
+			zap.Error(err),
+		)
+	}
 }
 
 // Run starts the forwarder, drain, and directive-processor goroutines
@@ -348,6 +396,21 @@ func (r *Relay) run(ctx context.Context) error {
 		r.preDispatchActive.Store(true)
 	}
 
+	// Client write hold: armed before the forwarders start so it covers
+	// the connection from its first byte. Unlike the pre-dispatch pause
+	// this installs no pause barrier — the forwarders must keep reading
+	// (the parser needs to SEE the client's bytes to decide what to do
+	// about them) and the destination→client direction must keep
+	// flowing (a server-speaks-first protocol greets before the client
+	// says anything). Only the C2D Write is deferred. See
+	// [Config.HoldClientWrites].
+	// withDefaults has already refused any HoldClientWrites +
+	// PreDispatchPause combination, so the block above cannot have
+	// installed a pause barrier that this hold would strand.
+	if r.cfg.HoldClientWrites {
+		r.holdClient.Store(true)
+	}
+
 	// When one forwarder exits, signal the other to exit too via the
 	// existing stopping/nudgeDeadline machinery. Without this signalling,
 	// if e.g. the upstream sends FIN → FromDest reads EOF and exits, the
@@ -438,6 +501,18 @@ func (r *Relay) run(ctx context.Context) error {
 	wgForward.Wait()
 	close(bothDone)
 	graceWG.Wait()
+
+	// Both forwarders are gone, so nothing can add to the hold stash
+	// any more. Anything still in it was read from the client and never
+	// delivered; flush it so "the relay forwards every byte it read"
+	// holds even when the parser never ended the hold. Errors are
+	// expected here (the peer is usually already gone) and are logged
+	// rather than surfaced — the connection is ending either way.
+	if err := r.releaseClientHold(); err != nil && r.cfg.Logger != nil {
+		r.cfg.Logger.Debug("relay: flushing the client hold at teardown failed",
+			zap.Error(err),
+		)
+	}
 
 	// Now it is safe to stop the tees: no more push() calls will
 	// fire. Close staging channels and wait for drain goroutines to
@@ -620,6 +695,81 @@ func (r *Relay) forward(
 			// Pause has lifted. err is preserved so a closed-conn
 			// condition still tears the forwarder down on the next
 			// loop trip.
+		}
+
+		// Client write hold. The bytes go to the parser but not to the
+		// real destination: they are teed and stashed, and the
+		// destination Write waits for the parser to say what should
+		// happen to them (KindReleaseClient flushes all of it,
+		// KindUpgradeTLS flushes a byte-exact prefix).
+		//
+		// This sits AFTER the pause recheck on purpose. Once a pause is
+		// up the directive handler owns the sockets and the stash, and
+		// the block above has already routed the bytes there; holding
+		// them a second time here would double-stash them.
+		if n > 0 && dir == fakeconn.FromClient && r.holdClient.Load() {
+			payload := make([]byte, n)
+			copy(payload, buf[:n])
+
+			// Stash BEFORE teeing, and the order is load-bearing.
+			//
+			// The parser's decision is what ends the hold, so everything
+			// downstream synchronises on having SEEN a chunk — a test
+			// waits for it on the FakeConn, and in production the parser
+			// issues its directive the moment it has decoded enough.
+			// Teeing first makes "the parser saw it" true while "it is in
+			// the stash" is not yet, so a release can run against an
+			// empty stash and strand the very bytes it was meant to
+			// deliver. Stashing first makes the visible event the LATER
+			// of the two, so anyone who observed the chunk is guaranteed
+			// the stash already holds it.
+			//
+			// The reverse hazard does not exist: if a release claims the
+			// stash between these two statements, the bytes go upstream
+			// and are teed immediately after, so the parser still sees
+			// every byte the connection carried.
+			r.stashInflightFromPause(dir, payload, readAt)
+			chunk := fakeconn.Chunk{
+				Dir:    dir,
+				Bytes:  payload,
+				ReadAt: readAt,
+				SeqNo:  seq.Add(1),
+			}
+			teed := t.push(chunk)
+			if teed && r.cfg.OnClientChunkTeed != nil {
+				r.cfg.OnClientChunkTeed()
+			}
+			// The connection IS carrying traffic even though nothing
+			// reaches the peer yet. Without this the only bump on this
+			// path is the one OnClientChunkTeed makes, so a held
+			// connection whose tee is dropping chunks (per-conn cap,
+			// memory pressure) stops bumping altogether and reads as
+			// idle to the hang watchdog while it is anything but.
+			if r.cfg.BumpActivity != nil {
+				r.cfg.BumpActivity()
+			}
+			if log != nil {
+				log.Debug("relay: holding client bytes from the destination",
+					zap.Int("held_bytes", n),
+					zap.Bool("teed", teed),
+				)
+			}
+			// A hold that outgrows its cap is a parser that is not
+			// coming back. Release rather than keep buffering: the
+			// client is blocked on a reply it cannot get while we sit
+			// on its request. See [Config.ClientHoldCap].
+			if r.noteHeldClientBytes(int64(n)) {
+				if werr := r.releaseClientHold(); werr != nil {
+					if log != nil {
+						log.Debug("relay: client hold cap release failed",
+							zap.Error(werr),
+						)
+					}
+					return werr
+				}
+			}
+			// Suppress the forward below; the bytes are accounted for.
+			n = 0
 		}
 
 		if n > 0 {
@@ -1044,6 +1194,241 @@ func (r *Relay) stashInflightFromPause(dir fakeconn.Direction, payload []byte, r
 	case fakeconn.FromDest:
 		r.stashedD2C = append(r.stashedD2C, stashed)
 	}
+}
+
+// noteHeldClientBytes adds n to the held-byte count and reports
+// whether the hold has now exceeded [Config.ClientHoldCap]. A
+// non-positive cap disables the bound. Reports true at most once per
+// hold: the caller releases on true, and releaseClientHold zeroes the
+// counter, so a hold cannot trip the cap twice.
+func (r *Relay) noteHeldClientBytes(n int64) bool {
+	total := r.heldClientBytes.Add(n)
+	limit := r.cfg.ClientHoldCap
+	if limit <= 0 || total <= limit {
+		return false
+	}
+	if r.cfg.Logger != nil {
+		r.cfg.Logger.Warn("relay: client write hold exceeded its cap; releasing",
+			zap.Int64("held_bytes", total),
+			zap.Int64("cap_bytes", limit),
+		)
+	}
+	if r.cfg.OnMarkMockIncomplete != nil {
+		r.cfg.OnMarkMockIncomplete("client_hold_cap")
+	}
+	return true
+}
+
+// ReleaseClientHold ends a [Config.HoldClientWrites] hold from outside
+// the directive path, delivering everything held to the real
+// destination. No-op when no hold is up, and safe to call repeatedly.
+//
+// This is the safety valve the supervisor's abort path needs. A hold is
+// normally ended by the parser, but hang, panic, memory-cap and context
+// cancellation all retire a parser without one — and the dispatcher's
+// response to those is to leave the relay running and let raw bytes
+// flow ("user traffic is unaffected"). A hold that survives the parser
+// falsifies exactly that promise: the client direction is blackholed
+// for the rest of the connection, and no cap rescues it because a
+// client blocked on a reply it cannot get sends nothing more. The
+// caller invokes this before it stops caring about the parser.
+func (r *Relay) ReleaseClientHold() error {
+	return r.releaseClientHold()
+}
+
+// releaseClientHold ends a client write hold: everything the C2D
+// forwarder held is written to the real destination in read order and
+// normal forwarding resumes. No-op when no hold is up.
+//
+// holdMu is held across the whole claim-then-write so two releasers
+// cannot interleave their writes onto the upstream socket. The hold
+// flag is cleared first so that anything the forwarder reads after this
+// point it forwards itself rather than adding to a stash nobody will
+// drain again.
+func (r *Relay) releaseClientHold() error {
+	r.holdMu.Lock()
+	defer r.holdMu.Unlock()
+
+	if !r.holdClient.Swap(false) {
+		return nil
+	}
+	r.heldClientBytes.Store(0)
+	held := r.takeStashed(fakeconn.FromClient)
+	if held.len() == 0 {
+		return nil
+	}
+	dstPtr := r.dst.Load()
+	if dstPtr == nil {
+		return fmt.Errorf("relay: client hold release: no destination to flush %d held bytes to", held.len())
+	}
+	if err := writeHeldBytes(*dstPtr, held.bytes); err != nil {
+		return err
+	}
+	return nil
+}
+
+// heldFlushWriteTimeout bounds a hold flush's Write.
+//
+// Without it the flush is an unbounded blocking Write on the abort path.
+// [Relay.PauseTees] is called from the supervisor's SessionOnAbort, whose
+// contract is explicitly that callbacks are NON-BLOCKING — they run where
+// further errors have nowhere to propagate to, and a blocked one wedges
+// the very teardown that was supposed to recover the connection. A held
+// payload is a MySQL handshake message, hundreds of bytes against a
+// socket buffer measured in tens of kilobytes, so this can only fire when
+// the peer has genuinely stopped reading — a connection already lost.
+const heldFlushWriteTimeout = 5 * time.Second
+
+// writeHeldBytes writes a claimed hold payload to dst under a bounded
+// deadline, clearing the deadline afterwards so the forwarders' own
+// writes are not left capped.
+//
+// SetWriteDeadline, never SetReadDeadline: the forwarders' Reads drive
+// the pause machinery and must not be disturbed by a flush.
+func writeHeldBytes(dst net.Conn, payload []byte) error {
+	if dst == nil {
+		return errors.New("relay: no destination to flush held bytes to")
+	}
+	_ = dst.SetWriteDeadline(time.Now().Add(heldFlushWriteTimeout))
+	defer func() { _ = dst.SetWriteDeadline(time.Time{}) }()
+
+	wn, err := dst.Write(payload)
+	if err != nil {
+		return err
+	}
+	if wn != len(payload) {
+		// A short write on a blocking Write is a net.Conn contract
+		// violation, and here it means the server holds half a message.
+		// Surface it rather than reporting a clean flush.
+		return fmt.Errorf("relay: short write %d of %d held bytes", wn, len(payload))
+	}
+	return nil
+}
+
+// stashedLen reports how many bytes the given direction's stash holds,
+// without claiming any of them. Callers that must validate a request
+// before consuming it use this; takeStashedPrefix mutates.
+func (r *Relay) stashedLen(dir fakeconn.Direction) int {
+	r.stashMu.Lock()
+	defer r.stashMu.Unlock()
+	var parts []stashedPayload
+	switch dir {
+	case fakeconn.FromClient:
+		parts = r.stashedC2D
+	case fakeconn.FromDest:
+		parts = r.stashedD2C
+	}
+	total := 0
+	for _, p := range parts {
+		total += p.len()
+	}
+	return total
+}
+
+// endUpgradePause ends the TLS-upgrade pause, first delivering any
+// client bytes still held if the client-side handshake did NOT take
+// them.
+//
+// heldConsumedByHandshake, not "the client side ended up behind TLS":
+// the two differ on exactly one path. Under [Config.ClientTLSFirst] the
+// client handshake runs FIRST and claims the held remainder, and a
+// dest-side handshake that then fails would report "not upgraded" for a
+// connection whose held bytes are already spent. Both halves of this
+// function want the same question answered — "is the remainder still
+// ours to deliver, and is a copy of it still stranded in the parser's
+// stream" — so the parameter asks that one.
+//
+// This is the whole reason handleUpgradeTLS does not call endPause
+// directly. endPause discards both stashes unconditionally, which is
+// right when the handshake consumed them — the held remainder IS the
+// client's ClientHello, and the client-side handshake reads it through
+// a prepending conn. It is wrong on every other exit. A preamble
+// mismatch (the documented "server declined TLS, record the cleartext
+// path" outcome, which acks OK=true), a failed handshake, a refused
+// flush: in all of those the connection stays cleartext, the server has
+// already received whatever prefix we flushed, and the bytes behind it
+// are the rest of a message it is still waiting for. Dropping them
+// truncates the client's request on the wire and then lets passthrough
+// feed the server the continuation of a message whose head is missing.
+//
+// So: flush first, end the pause second.
+//
+// The other half of the job is the parser's view of the stream, and it
+// is the mirror image. When the client side DID end up behind TLS, the
+// held remainder was consumed by keploy's own handshake — but a copy of
+// it was teed to the parser on the way in, because the forwarder had it
+// long before the parser had decoded enough to ask for the upgrade.
+// Left there, the parser's next read after the upgrade returns
+// `16 03 01 ...` where a post-TLS message should be, mis-frames it as a
+// packet header (a MySQL header reads that as payloadLength=66326) and
+// blocks until the hang watchdog retires it — a connection that records
+// zero mocks. barrierTeeOffset is the length of the parser's stream at
+// the pause barrier, so discarding below it removes everything teed
+// before the barrier that the parser had not yet read. That equals "the
+// bytes the handshake took" for a parser that read exactly its own flush
+// prefix — which is what ClientFlushBytes requires it to have measured —
+// rather than being a property of the mechanism on its own.
+//
+// Only under a hold. The pre-dispatch path reaches this function too,
+// but there the C2D stash is FLUSHED UPSTREAM whole before the
+// handshakes run, so its prepend is normally empty and what the parser
+// saw is what the server got — consistent, and not ours to change here.
+func (r *Relay) endUpgradePause(heldAtEntry, heldConsumedByHandshake bool, barrierTeeOffset int64) {
+	if heldAtEntry && heldConsumedByHandshake {
+		if pending := r.clientStream.DiscardBefore(barrierTeeOffset); pending > 0 && r.cfg.Logger != nil {
+			r.cfg.Logger.Debug("relay: dropping handshake bytes from the parser's client stream",
+				zap.Int64("discard_bytes", pending),
+				zap.Int64("stream_offset", barrierTeeOffset),
+			)
+		}
+	}
+	if heldAtEntry && !heldConsumedByHandshake {
+		// releaseClientHold, not flushHeldRemainder: the hold must be
+		// CLEARED here, not merely drained once. handleUpgradeTLS clears
+		// the flag itself only inside its hold branch, and the exits
+		// above that branch — no TLSUpgradeFn, a rejected flush request
+		// — never reach it. Draining without clearing leaves the
+		// forwarder holding every byte that arrives next, on a
+		// connection whose parser has just been told the upgrade
+		// failed. releaseClientHold is a no-op when the flag is already
+		// down, so the normal path is unaffected.
+		if err := r.releaseClientHold(); err != nil && r.cfg.Logger != nil {
+			r.cfg.Logger.Debug("relay: flushing the held remainder after a non-upgrade exit failed",
+				zap.Error(err),
+			)
+		}
+		// The hold branch clears the flag before flushing its prefix, so
+		// by the time we get here on THAT path releaseClientHold above
+		// found the flag down and did nothing. Drain what its prefix
+		// flush left behind.
+		if err := r.flushHeldRemainder(); err != nil && r.cfg.Logger != nil {
+			r.cfg.Logger.Debug("relay: flushing the held remainder after a non-upgrade exit failed",
+				zap.Error(err),
+			)
+		}
+	}
+	r.endPause()
+}
+
+// flushHeldRemainder writes whatever is left of the client hold stash
+// to the real destination. Unlike releaseClientHold it does not require
+// the hold flag to still be set: handleUpgradeTLS clears the flag early
+// so no failure path can strand the connection, and the bytes still
+// need delivering afterwards.
+func (r *Relay) flushHeldRemainder() error {
+	r.holdMu.Lock()
+	defer r.holdMu.Unlock()
+
+	r.heldClientBytes.Store(0)
+	held := r.takeStashed(fakeconn.FromClient)
+	if held.len() == 0 {
+		return nil
+	}
+	dstPtr := r.dst.Load()
+	if dstPtr == nil {
+		return fmt.Errorf("relay: no destination to flush %d held bytes to", held.len())
+	}
+	return writeHeldBytes(*dstPtr, held.bytes)
 }
 
 // takeStashed returns and clears the stash for the given direction.

--- a/pkg/agent/proxy/relay/relay.go
+++ b/pkg/agent/proxy/relay/relay.go
@@ -192,6 +192,13 @@ func New(cfg Config, src, dst net.Conn) *Relay {
 	r.src.Store(&src)
 	r.dst.Store(&dst)
 
+	// Armed here rather than in run(): the caller registers its abort
+	// hook between New and Run, and an abort in that window must find a
+	// hold it can actually release. See the note in run().
+	if cfg.HoldClientWrites {
+		r.holdClient.Store(true)
+	}
+
 	r.teeC2D = newTee(
 		fakeconn.FromClient,
 		cfg.PerConnCap,
@@ -404,12 +411,19 @@ func (r *Relay) run(ctx context.Context) error {
 	// flowing (a server-speaks-first protocol greets before the client
 	// says anything). Only the C2D Write is deferred. See
 	// [Config.HoldClientWrites].
+	// The hold itself is armed in New(), NOT here. Arming inside this
+	// goroutine loses a race with the caller: proxy_v2.go does
+	// relay.New, then `go r.Run(...)`, then registers SessionOnAbort. An
+	// abort firing before this goroutine got scheduled found holdClient
+	// still false, so PauseTees released nothing — and then Run armed a
+	// hold with no releaser left. On the FallthroughToPassthrough path
+	// the relay deliberately keeps running, so the client direction
+	// stayed blackholed until peer close: exactly the silent
+	// user-traffic outage PauseTees exists to prevent.
+	//
 	// withDefaults has already refused any HoldClientWrites +
 	// PreDispatchPause combination, so the block above cannot have
 	// installed a pause barrier that this hold would strand.
-	if r.cfg.HoldClientWrites {
-		r.holdClient.Store(true)
-	}
 
 	// When one forwarder exits, signal the other to exit too via the
 	// existing stopping/nudgeDeadline machinery. Without this signalling,
@@ -708,68 +722,89 @@ func (r *Relay) forward(
 		// the block above has already routed the bytes there; holding
 		// them a second time here would double-stash them.
 		if n > 0 && dir == fakeconn.FromClient && r.holdClient.Load() {
-			payload := make([]byte, n)
-			copy(payload, buf[:n])
+			// holdMu, and re-check under it. Without the lock a
+			// releaser can clear the flag and start writing the stash
+			// to the upstream socket while this goroutine is deciding
+			// to stash-or-write, and the two writes reach the server
+			// out of order — observed 25/25 with a slow flush, which is
+			// exactly the case an abort correlates with (a full
+			// upstream socket buffer). Held chunks only occur during
+			// the pre-handshake window, so this is not a hot path.
+			r.holdMu.Lock()
+			if !r.holdClient.Load() {
+				// A release won the race; fall through and forward
+				// normally, after the flush it just completed.
+				r.holdMu.Unlock()
+			} else {
+				payload := make([]byte, n)
+				copy(payload, buf[:n])
 
-			// Stash BEFORE teeing, and the order is load-bearing.
-			//
-			// The parser's decision is what ends the hold, so everything
-			// downstream synchronises on having SEEN a chunk — a test
-			// waits for it on the FakeConn, and in production the parser
-			// issues its directive the moment it has decoded enough.
-			// Teeing first makes "the parser saw it" true while "it is in
-			// the stash" is not yet, so a release can run against an
-			// empty stash and strand the very bytes it was meant to
-			// deliver. Stashing first makes the visible event the LATER
-			// of the two, so anyone who observed the chunk is guaranteed
-			// the stash already holds it.
-			//
-			// The reverse hazard does not exist: if a release claims the
-			// stash between these two statements, the bytes go upstream
-			// and are teed immediately after, so the parser still sees
-			// every byte the connection carried.
-			r.stashInflightFromPause(dir, payload, readAt)
-			chunk := fakeconn.Chunk{
-				Dir:    dir,
-				Bytes:  payload,
-				ReadAt: readAt,
-				SeqNo:  seq.Add(1),
-			}
-			teed := t.push(chunk)
-			if teed && r.cfg.OnClientChunkTeed != nil {
-				r.cfg.OnClientChunkTeed()
-			}
-			// The connection IS carrying traffic even though nothing
-			// reaches the peer yet. Without this the only bump on this
-			// path is the one OnClientChunkTeed makes, so a held
-			// connection whose tee is dropping chunks (per-conn cap,
-			// memory pressure) stops bumping altogether and reads as
-			// idle to the hang watchdog while it is anything but.
-			if r.cfg.BumpActivity != nil {
-				r.cfg.BumpActivity()
-			}
-			if log != nil {
-				log.Debug("relay: holding client bytes from the destination",
-					zap.Int("held_bytes", n),
-					zap.Bool("teed", teed),
-				)
-			}
-			// A hold that outgrows its cap is a parser that is not
-			// coming back. Release rather than keep buffering: the
-			// client is blocked on a reply it cannot get while we sit
-			// on its request. See [Config.ClientHoldCap].
-			if r.noteHeldClientBytes(int64(n)) {
-				if werr := r.releaseClientHold(); werr != nil {
-					if log != nil {
-						log.Debug("relay: client hold cap release failed",
-							zap.Error(werr),
-						)
-					}
-					return werr
+				// Stash BEFORE teeing, and the order is load-bearing.
+				//
+				// The parser's decision is what ends the hold, so everything
+				// downstream synchronises on having SEEN a chunk — a test
+				// waits for it on the FakeConn, and in production the parser
+				// issues its directive the moment it has decoded enough.
+				// Teeing first makes "the parser saw it" true while "it is in
+				// the stash" is not yet, so a release can run against an
+				// empty stash and strand the very bytes it was meant to
+				// deliver. Stashing first makes the visible event the LATER
+				// of the two, so anyone who observed the chunk is guaranteed
+				// the stash already holds it.
+				//
+				// The reverse hazard does not exist: if a release claims the
+				// stash between these two statements, the bytes go upstream
+				// and are teed immediately after, so the parser still sees
+				// every byte the connection carried.
+				r.stashInflightFromPause(dir, payload, readAt)
+				chunk := fakeconn.Chunk{
+					Dir:    dir,
+					Bytes:  payload,
+					ReadAt: readAt,
+					SeqNo:  seq.Add(1),
 				}
+				teed := t.push(chunk)
+				if teed && r.cfg.OnClientChunkTeed != nil {
+					r.cfg.OnClientChunkTeed()
+				}
+				// The connection IS carrying traffic even though nothing
+				// reaches the peer yet. Without this the only bump on this
+				// path is the one OnClientChunkTeed makes, so a held
+				// connection whose tee is dropping chunks (per-conn cap,
+				// memory pressure) stops bumping altogether and reads as
+				// idle to the hang watchdog while it is anything but.
+				if r.cfg.BumpActivity != nil {
+					r.cfg.BumpActivity()
+				}
+				if log != nil {
+					log.Debug("relay: holding client bytes from the destination",
+						zap.Int("held_bytes", n),
+						zap.Bool("teed", teed),
+					)
+				}
+				capBreached := r.noteHeldClientBytes(int64(n))
+				// Drop the lock BEFORE releasing: releaseClientHold
+				// takes holdMu itself, so calling it here would
+				// self-deadlock.
+				r.holdMu.Unlock()
+
+				// A hold that outgrows its cap is a parser that is not
+				// coming back. Release rather than keep buffering: the
+				// client is blocked on a reply it cannot get while we
+				// sit on its request. See [Config.ClientHoldCap].
+				if capBreached {
+					if werr := r.releaseClientHold(); werr != nil {
+						if log != nil {
+							log.Debug("relay: client hold cap release failed",
+								zap.Error(werr),
+							)
+						}
+						return werr
+					}
+				}
+				// Suppress the forward below; the bytes are accounted for.
+				n = 0
 			}
-			// Suppress the forward below; the bytes are accounted for.
-			n = 0
 		}
 
 		if n > 0 {

--- a/pkg/agent/proxy/relay/tee.go
+++ b/pkg/agent/proxy/relay/tee.go
@@ -204,6 +204,29 @@ type tee struct {
 	// [tee.dropCount] for diagnostics and tests.
 	drops atomic.Uint64
 
+	// accepted is the running total of PAYLOAD BYTES this tee has
+	// accepted, i.e. the absolute length of the byte stream the
+	// consuming FakeConn will see. Incremented only on a successful
+	// push, so a dropped chunk does not advance it.
+	//
+	// [tee.abandon] does skew it: chunks counted here are thrown away
+	// undelivered, so accepted can end up permanently ahead of what the
+	// FakeConn received. That is safe in the only way that matters —
+	// abandon returns from drain, whose deferred close of out closes the
+	// FakeConn's channel, so a discard watermark left stranded above the
+	// delivered total ends in io.EOF rather than a stall, and no byte
+	// ABOVE the watermark can be lost to it (everything delivered is
+	// below it by construction).
+	//
+	// It exists so the relay can name a position in the parser's stream
+	// — "the parser must not see anything below offset N" — when it
+	// consumes bytes it has already teed (see
+	// fakeconn.FakeConn.DiscardBefore). A count of "chunks pending
+	// somewhere in the pipeline" could not express that: the pipeline
+	// spans a queue, a goroutine, a channel and a buffer, and the
+	// answer has to hold across all four without quiescing any of them.
+	accepted atomic.Int64
+
 	// closedFlag mirrors closed for a lock-free fast path in push.
 	closedFlag atomic.Bool
 	// closeOnce guards the single shutdown.
@@ -255,6 +278,12 @@ func (t *tee) readCh() <-chan fakeconn.Chunk { return t.out }
 // dropCount returns the number of chunks dropped since construction.
 // Safe to call concurrently.
 func (t *tee) dropCount() uint64 { return t.drops.Load() }
+
+// acceptedBytes returns how many payload bytes this tee has accepted —
+// the absolute length of the stream its FakeConn will deliver. See the
+// [tee.accepted] field comment for why the relay needs a stream
+// position rather than a pending-chunk count.
+func (t *tee) acceptedBytes() int64 { return t.accepted.Load() }
 
 // setPaused toggles delivery. When paused, push immediately drops with
 // reason [DropPaused] without consuming capacity.
@@ -327,6 +356,11 @@ func (t *tee) push(c fakeconn.Chunk) bool {
 	}
 	t.q = append(t.q, c)
 	t.qBytes += n
+	// Counted under mu, with the append that makes the chunk visible.
+	// Outside the lock there is a window where a chunk is queued but
+	// uncounted, and a reader of acceptedBytes that lands in it would
+	// name a stream position short of what the FakeConn will deliver.
+	t.accepted.Add(n)
 	t.mu.Unlock()
 
 	// Doorbell. Non-blocking: a pending token already tells drain there is

--- a/pkg/agent/proxy/supervisor/session.go
+++ b/pkg/agent/proxy/supervisor/session.go
@@ -91,6 +91,21 @@ type Session struct {
 	// TLS keys, noise config, etc.).
 	Opts models.OutgoingOptions
 
+	// ClientWritesHeld reports that the relay behind this session armed
+	// a client write hold (relay.Config.HoldClientWrites), so nothing
+	// the client sends reaches the real destination until the parser
+	// ends the hold — with directive.ReleaseClient, or with a
+	// directive.UpgradeTLS carrying a ClientFlushBytes count.
+	//
+	// The dispatcher sets it from the same capability probe that arms
+	// the hold, so a parser can tell "I asked for a hold" from "a hold
+	// is actually in place". Those differ: an observe-only proxyless
+	// capture has no relay to hold anything, and a parser that assumed
+	// otherwise would send a release that nobody answers and block on
+	// the ack forever. False on every path that does not hold, which
+	// is every path today except MySQL under the V2 relay.
+	ClientWritesHeld bool
+
 	// --- Backward-compatibility (populated by the migration shim) ---
 
 	// Ingress is the legacy client-side net.Conn handle. nil on the


### PR DESCRIPTION
MySQL's TLS upgrade leaked the client's ClientHello upstream in cleartext. **Measured: 156 bytes where 36 was correct.**

MySQL is server-speaks-first and its upgrade gives the client no reason to wait — the server greets, the client answers with a 36-byte SSLRequest, and then, with no further server turn, it begins a TLS handshake on the same socket. The relay's C2D forwarder is permanently parked in `Read`, so it has the ClientHello before the parser has even been scheduled to look at the SSLRequest. The real server then read TLS handshake bytes as MySQL protocol, and keploy's own destination handshake ran against a desynchronised connection.

## Reproduced before building on it

Two earlier attempts at the repro **passed against unfixed code**, and both are called out in the test file:

- `net.Pipe` is unbuffered, so a client `Write` blocks until the relay reads it — that accidentally serialises the application behind the relay and the race cannot be staged at all.
- The first byte counter stopped at the TLS upgrade, and the leak lands just *after* it.

A false-passing harness here is worse than no harness.

## The hard part was un-teeing, not holding

The hold itself is straightforward: under `Config.HoldClientWrites` the C2D forwarder tees and stashes but does not write, until `directive.ReleaseClient` (flush all) or `directive.UpgradeTLS` with `ClientFlushBytes` (flush a byte-exact prefix). The split is by **byte count**, not by chunk, because the SSLRequest and ClientHello frequently arrive in one read.

The problem is that the parser must **see** the SSLRequest to decide, so the bytes are already on their way to it before anyone knows where the split is — and at the upgrade barrier a chunk can be in the staging queue, in `tee.drain`'s hand, in the out channel, and half-consumed in the FakeConn buffer simultaneously. A producer-side drop misses it; draining from outside races `drain`'s own goroutine.

So the retraction is a **stream position on the consumer side**: `tee.acceptedBytes()` counts payload advanced by a successful push, and `FakeConn.DiscardBefore(offset)` is a monotonic watermark that swallows by pulling forward from the reader. Because it is an absolute offset rather than "whatever is pending now", bytes not yet teed when it is armed are still covered, post-upgrade plaintext sits above it, and arming before or after the forwarders resume gives the same answer. Nothing is quiesced.

Lazy teeing was considered and cannot work: the parser cannot supply `ClientFlushBytes` until it has read the SSLRequest *off the tee*, and the only exit from that circularity changes `FakeConn`'s read contract for every parser to fix one path.

## Mutation evidence

| Mutation | Result |
|---|---|
| watermark unarmed (pre-fix behaviour) | 2 tests fail with the literal `16 03 01 00`; **all 13 pre-existing hold tests pass** |
| buf-only discard | non-coalesced fails, coalesced passes |
| chunk-granular discard | both fail |
| discard keyed on `upgradedSrc != nil` | whole-hold-flushed test fails |
| dispatcher stops arming the hold | wiring test fails |
| `util.Conn` loses `CloseWrite` | server-half-close test fails |

That first row is the point: the pre-existing tests could not see this defect, which is how it survived two review rounds.

## Review history

Three rounds, ten defects. Worth knowing what they were, because they were all lifecycle rather than mechanism:

- the feature was **entirely inert** — the dispatcher never armed it, and every test built `relay.Config` by hand
- a hold could **outlive its parser**, blackholing the client direction for the whole connection
- a refused flush **destroyed the bytes it had already consumed**
- the hold was armed inside the relay goroutine, racing its own releaser
- the abort flush could **reorder against the forwarder** (25/25 runs)
- a plain release **dropped** the D2C pause stash and left a hole in the C2D tee

## Not proven

**No real MySQL server is involved anywhere.** The relay tests use a passthrough `TLSUpgradeFn` and never run a TLS handshake; the MySQL recorder tests have no relay under them. The two halves are verified against each other's contract, not end to end.

**This PR is dormant.** MySQL still records legacy via the probe branch in `proxy.go`, which does not consult `shouldRecordViaSupervisor`. Flipping that gate is a separate change and wants an e2e soak, precisely because it is the one that changes what production does.

`go test ./...` 65 packages green; `-race -count=3` clean on relay/proxy/fakeconn.