### PR TITLE
fix(mysql): route the probe dispatch branch through the supervisor

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -21,10 +21,41 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: "1" # Enable CGO for this job
+      # This lane PROVIDES the MySQL below, so it is the one lane entitled to
+      # fail when the server is missing. The real-server tests key their hard
+      # failure on this var rather than on the generic CI var: CI is set by
+      # every GitHub Actions run, including forks and lanes that promise no
+      # database, so keying on it would turn an unrelated contributor's PR red
+      # over a service they were never offered. Unset, the tests skip.
+      KEPLOY_TEST_MYSQL_REQUIRED: "1"
+      KEPLOY_TEST_MYSQL_ADDR: "127.0.0.1:3306"
+      KEPLOY_TEST_MYSQL_USER: root
+      KEPLOY_TEST_MYSQL_PASS: rootpass
+      KEPLOY_TEST_MYSQL_DB: sampledb
     permissions:
       contents: read
       packages: write
       id-token: write
+
+    # The MySQL V2 record path is the one place keploy terminates TLS on
+    # BOTH sides of a connection it is also parsing, and its client-write
+    # hold is only observable against a server that actually speaks the
+    # protocol: a scripted peer accepts a leaked ClientHello that a real
+    # mysqld rejects. mysql:8.0 generates its own certs at init, so
+    # have_ssl is YES with no extra configuration.
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: rootpass
+          MYSQL_DATABASE: sampledb
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -prootpass"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
 
     steps:
       - uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/getsentry/sentry-go v0.28.1
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/go-chi/render v1.0.3
+	github.com/go-sql-driver/mysql v1.8.1
 	github.com/google/uuid v1.6.0
 	github.com/gopacket/gopacket v1.4.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
@@ -59,6 +60,7 @@ require (
 require (
 	charm.land/lipgloss/v2 v2.0.0 // indirect
 	dario.cat/mergo v1.0.1 // indirect
+	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/BobuSumisu/aho-corasick v1.0.3 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,7 @@ dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 facette.io/natsort v0.0.0-20181210072756-2cd4dd1e2dcb h1:1pSweJFeR3Pqx7uoelppkzeegfUBXL6I2FFAbfXw570=
 facette.io/natsort v0.0.0-20181210072756-2cd4dd1e2dcb/go.mod h1:npRYmtaITVom7rcSo+pRURltHSG2r4TQM1cdqJ2dUB0=
+filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/7sDream/geko v0.1.1 h1:Ms9RVcUJDPsUuRlk3T3sGmSGAMuttqh2/3okZ4yWUpU=
 github.com/7sDream/geko v0.1.1/go.mod h1:NcSQXSUpcoqNP8BkOLP2TsinxRVjnMkDYCKl9L1Czxk=
@@ -178,6 +179,7 @@ github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+Gr
 github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
 github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6 h1:teYtXy9B7y5lHTp8V9KPxpYRAVA7dozigQcMiBust1s=
 github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6/go.mod h1:p4lGIVX+8Wa6ZPNDvqcxq36XpUDLh42FLetFU7odllI=
+github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
 github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=

--- a/pkg/agent/proxy/dispatch_gate_test.go
+++ b/pkg/agent/proxy/dispatch_gate_test.go
@@ -1,0 +1,141 @@
+package proxy
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+	"testing"
+)
+
+// Every function that can start a LEGACY recording must also consult
+// shouldRecordViaSupervisor.
+//
+// This has silently gone wrong twice, the same way both times. A dispatch
+// site calls RecordOutgoing directly with a hand-built RecordSession; the
+// parser's RecordOutgoing sees V2 == nil and falls to recordLegacy; and the
+// parser records legacy on the default configuration even though IsV2()
+// returns true. keploy#4526 found it on the generic catch-all — "the V2
+// migration silently skipped the widest code path in the proxy" — and
+// deliberately left the MySQL probe branch for later. Nothing failed in
+// between.
+//
+// WHAT THIS CATCHES: a NEW dispatch site added in a new function with no
+// gate at all — the shape both regressions actually took.
+//
+// WHAT IT DOES NOT CATCH, and must not be trusted for: whether an existing
+// gate still WORKS. An earlier version of this pin counted call sites and
+// was green against `if false && shouldRecordViaSupervisor(...)` and
+// against inserting a `!` — it never looked for the predicate at all,
+// because shouldRecordViaSupervisor(x) is an *ast.Ident call, not a
+// SelectorExpr, and was invisible to its walker by construction. What
+// still defeats it is a decoy: an ungated dispatch in a function that
+// mentions shouldRecordViaSupervisor for some other reason satisfies the
+// count. Those live behaviours belong to the table test over
+// shouldRecordViaSupervisor and to
+// TestMySQLProbeBranchRoutesByShouldRecordViaSupervisor, which hand a
+// parser to the real dispatcher and assert which surface it receives.
+// exemptFn is the V2 adapter itself; see the scan loop.
+const exemptFn = "recordViaSupervisor"
+
+// callCounts returns how many times each interesting function is called
+// anywhere inside n, counting BOTH pkg.Fn()/x.Fn() selector calls and
+// bare Fn() identifier calls. The identifier case is the one an earlier
+// version of this pin missed entirely.
+func callCounts(n ast.Node) (legacy, gate int) {
+	ast.Inspect(n, func(inner ast.Node) bool {
+		call, ok := inner.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		var name string
+		switch fn := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			name = fn.Sel.Name
+		case *ast.Ident:
+			name = fn.Name
+		}
+		switch name {
+		case "RecordOutgoing":
+			legacy++
+		case "shouldRecordViaSupervisor":
+			gate++
+		}
+		return true
+	})
+	return legacy, gate
+}
+
+func TestEveryLegacyDispatchFunctionConsultsTheGate(t *testing.T) {
+	t.Parallel()
+
+	fset := token.NewFileSet()
+
+	// Scan EVERY non-test file in the package, not just proxy.go. Both
+	// prior regressions happened to live in proxy.go; the next one need
+	// not, and a pin that names one file silently stops covering the
+	// package the moment a dispatch moves.
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+	var scanned []string
+	var totalLegacy, totalGate int
+	exemptSeen := false
+
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		scanned = append(scanned, name)
+
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			// recordViaSupervisor is the V2 adapter itself: its
+			// RecordOutgoing call IS the supervised dispatch, so it has
+			// legacy=1 gate=0 by construction. Exempt by name, and assert
+			// below that the name still resolves so the allowlist cannot
+			// rot into a hole.
+			if fn.Name.Name == exemptFn {
+				exemptSeen = true
+				continue
+			}
+			legacy, gate := callCounts(fn.Body)
+			totalLegacy += legacy
+			totalGate += gate
+			if legacy > 0 && gate < legacy {
+				t.Errorf("%s has %d legacy RecordOutgoing dispatch site(s) but consults "+
+					"shouldRecordViaSupervisor only %d time(s) (%s). Every legacy dispatch needs "+
+					"the gate in front of it, or that parser records legacy on the default "+
+					"configuration even though IsV2() is true — silently, because an ungated site "+
+					"is indistinguishable from a gated one whose parser is not V2, and every "+
+					"runtime test keeps passing. This is the defect keploy#4526 found on the "+
+					"generic catch-all and the one the MySQL probe branch carried after it.",
+					fn.Name.Name, legacy, gate, fset.Position(fn.Pos()))
+			}
+		}
+	}
+
+	if !exemptSeen {
+		t.Errorf("the %q exemption matched no function in %v — either it was renamed (update "+
+			"exemptFn) or removed (drop the exemption). An allowlist entry that resolves to "+
+			"nothing is a hole in this pin.", exemptFn, scanned)
+	}
+
+	// Guard against the pin quietly matching nothing — the failure mode that
+	// makes a source-scanning test worthless.
+	if totalLegacy == 0 || totalGate == 0 {
+		t.Fatalf("found %d RecordOutgoing and %d shouldRecordViaSupervisor call sites across "+
+			"%v; this pin has stopped looking at anything and would pass no matter what",
+			totalLegacy, totalGate, scanned)
+	}
+}

--- a/pkg/agent/proxy/mysql_dispatch_test.go
+++ b/pkg/agent/proxy/mysql_dispatch_test.go
@@ -1,0 +1,326 @@
+package proxy
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations"
+	"go.keploy.io/server/v3/pkg/agent/proxy/util"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+)
+
+// recordingMySQLParser captures which SURFACE the dispatcher handed it.
+// The V2 path sets RecordSession.V2 and leaves Ingress/Egress nil; the
+// legacy path does the opposite. That difference is the only observable
+// the dispatch decision produces, so it is what the test asserts on.
+type recordingMySQLParser struct {
+	v2Declared bool
+
+	mu       sync.Mutex
+	called   bool
+	sawV2    bool
+	sawSocks bool
+}
+
+func (f *recordingMySQLParser) MatchType(context.Context, []byte) bool { return false }
+func (f *recordingMySQLParser) RecordOutgoing(_ context.Context, s *integrations.RecordSession) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.called = true
+	f.sawV2 = s.V2 != nil
+	f.sawSocks = s.Ingress != nil || s.Egress != nil
+	return nil
+}
+func (f *recordingMySQLParser) MockOutgoing(context.Context, net.Conn, *models.ConditionalDstCfg, integrations.MockMemDb, models.OutgoingOptions) error {
+	return nil
+}
+func (f *recordingMySQLParser) IsV2() bool { return f.v2Declared }
+
+func (f *recordingMySQLParser) snapshot() (called, v2, socks bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.called, f.sawV2, f.sawSocks
+}
+
+// TestMySQLProbeBranchRoutesByShouldRecordViaSupervisor pins the dispatch
+// decision of the MySQL PROBE branch behaviourally.
+//
+// This is the only test that covers the gate itself. The full-stack test
+// calls recordViaSupervisor directly, so it stays green with the gate
+// reverted, negated, or short-circuited; and a source-scanning pin is
+// defeated by `if false &&` or by inserting a `!`. Here the parser reports
+// which surface it was handed, so any of those mutations flips the
+// observable and fails.
+func TestMySQLProbeBranchRoutesByShouldRecordViaSupervisor(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		v2       bool
+		relayOff string
+		wantV2   bool
+		why      string
+	}{
+		{
+			name: "V2 parser goes to the supervisor", v2: true, wantV2: true,
+			why: "the probe branch recorded legacy on the default config while the matched-parser branch recorded V2 — one parser, two answers",
+		},
+		{
+			name: "non-V2 parser stays legacy", v2: false, wantV2: false,
+			why: "a parser that opts out must not be handed FakeConns it cannot use",
+		},
+		{
+			name: "KEPLOY_NEW_RELAY=off forces legacy", v2: true, relayOff: "off", wantV2: false,
+			why: "the documented escape hatch must reach this dispatch site too",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.relayOff != "" {
+				t.Setenv("KEPLOY_NEW_RELAY", tc.relayOff)
+			}
+
+			parser := &recordingMySQLParser{v2Declared: tc.v2}
+			p := &Proxy{
+				logger:                     zap.NewNop(),
+				Integrations:               map[integrations.IntegrationType]integrations.Integrations{integrations.MYSQL: parser},
+				recordBufferCap:            8 << 20,
+				recordBufferQueueSize:      64,
+				recordBufferStallGrace:     5 * time.Second,
+				recordBufferHalfCloseGrace: 5 * time.Second,
+			}
+
+			srcRaw, destRaw, cleanup := tcpConnPair(t)
+			defer cleanup()
+			// Mirror handleConnection: the upgrader holds pointers to the
+			// caller's own conn variables, never to a callee's copies.
+			srcConn, destConn := srcRaw, destRaw
+			upgrader := util.NewConnTLSUpgrader(&srcConn, &destConn, zap.NewNop(), nil)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			errGrp, gctx := errgroup.WithContext(ctx)
+			mocks := make(chan *models.Mock, 8)
+
+			if err := p.recordMySQLOutgoing(gctx, srcConn, destConn, mocks, errGrp,
+				zap.NewNop(), 1, 2, models.OutgoingOptions{
+					DstCfg: &models.ConditionalDstCfg{Addr: destConn.RemoteAddr().String()},
+				}, upgrader); err != nil {
+				t.Fatalf("recordMySQLOutgoing: %v", err)
+			}
+
+			called, sawV2, sawSocks := parser.snapshot()
+			if !called {
+				t.Fatal("the parser was never invoked at all")
+			}
+			if sawV2 != tc.wantV2 {
+				t.Fatalf("parser was handed V2=%v, want V2=%v.\n%s", sawV2, tc.wantV2, tc.why)
+			}
+			// The two surfaces are mutually exclusive by construction; assert
+			// it so a session that carries both never passes silently.
+			if tc.wantV2 && sawSocks {
+				t.Error("V2 session also carried Ingress/Egress sockets the relay owns")
+			}
+			if !tc.wantV2 && !sawSocks {
+				t.Error("legacy session carried no sockets")
+			}
+		})
+	}
+}
+
+// tcpConnPair returns a connected pair of real TCP conns. Real sockets,
+// not net.Pipe: the relay needs CloseWrite and deadline support.
+func tcpConnPair(t *testing.T) (client, server net.Conn, cleanup func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	type res struct {
+		c   net.Conn
+		err error
+	}
+	ch := make(chan res, 1)
+	go func() {
+		c, err := ln.Accept()
+		ch <- res{c, err}
+	}()
+
+	dialed, err := net.DialTimeout("tcp", ln.Addr().String(), 5*time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	got := <-ch
+	if got.err != nil {
+		t.Fatalf("accept: %v", got.err)
+	}
+	return dialed, got.c, func() {
+		_ = dialed.Close()
+		_ = got.c.Close()
+	}
+}
+
+// TestRecordMySQLOutgoing_UnregisteredParser covers the guard that stops
+// an unregistered build nil-panicking. The probe's configured-port and
+// known-port verdicts return IsMySQL without checking registration, so
+// this is reachable on a build that omits the parser.
+func TestRecordMySQLOutgoing_UnregisteredParser(t *testing.T) {
+	p := &Proxy{
+		logger:                     zap.NewNop(),
+		Integrations:               map[integrations.IntegrationType]integrations.Integrations{},
+		recordBufferCap:            8 << 20,
+		recordBufferQueueSize:      64,
+		recordBufferStallGrace:     5 * time.Second,
+		recordBufferHalfCloseGrace: 5 * time.Second,
+	}
+	srcRaw, dstRaw, cleanup := tcpConnPair(t)
+	defer cleanup()
+	src, dst := srcRaw, dstRaw
+	upgrader := util.NewConnTLSUpgrader(&src, &dst, zap.NewNop(), nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	errGrp, gctx := errgroup.WithContext(ctx)
+
+	err := p.recordMySQLOutgoing(gctx, srcRaw, dstRaw, make(chan *models.Mock, 1), errGrp,
+		zap.NewNop(), 1, 2, models.OutgoingOptions{}, upgrader)
+	if err == nil {
+		t.Fatal("an unregistered MySQL parser returned no error; the legacy path would have " +
+			"nil-panicked on p.Integrations[MYSQL].RecordOutgoing")
+	}
+}
+
+// upgradingParser drives the legacy TLSUpgrader the way the MySQL
+// recorder's STARTTLS path does (recorder/conn.go UpgradeDestTLS).
+type upgradingParser struct {
+	recordingMySQLParser
+	upgradeErr error
+}
+
+func (u *upgradingParser) RecordOutgoing(_ context.Context, s *integrations.RecordSession) error {
+	u.mu.Lock()
+	u.called = true
+	u.sawV2 = s.V2 != nil
+	u.mu.Unlock()
+	if s.TLSUpgrader == nil {
+		u.upgradeErr = fmt.Errorf("legacy session carried no TLSUpgrader")
+		return nil
+	}
+	if _, err := s.TLSUpgrader.UpgradeDestTLS(&tls.Config{InsecureSkipVerify: true}); err != nil { //nolint:gosec // test dial
+		u.upgradeErr = err
+	}
+	return nil
+}
+
+// TestRecordMySQLOutgoing_TLSUpgradeRebindsTheCallersConn pins the
+// pointer contract that makes deferred close correct after a STARTTLS.
+//
+// ConnTLSUpgrader exists to write the upgraded *tls.Conn back through
+// the &srcConn/&dstConn pointers it was given, so handleConnection's
+// deferred close acts on the TLS conn and sends close_notify. Build the
+// upgrader inside the dispatch helper instead of at the call site and
+// those pointers alias the helper's PARAMETER COPIES: the upgrade still
+// succeeds, the parser still works, every other test stays green — and
+// the caller closes the raw socket, so the peer sees a reset instead of
+// a clean shutdown. That is precisely the regression this test exists to
+// catch, because it has no other symptom.
+func TestRecordMySQLOutgoing_TLSUpgradeRebindsTheCallersConn(t *testing.T) {
+	// A real TLS server for the dest side to hand-shake against.
+	cert := selfSignedForDispatch(t)
+	tlsLn, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{Certificates: []tls.Certificate{cert}})
+	if err != nil {
+		t.Fatalf("tls listen: %v", err)
+	}
+	defer func() { _ = tlsLn.Close() }()
+	go func() {
+		for {
+			c, err := tlsLn.Accept()
+			if err != nil {
+				return
+			}
+			go func() { _, _ = io.Copy(io.Discard, c) }()
+		}
+	}()
+
+	parser := &upgradingParser{recordingMySQLParser: recordingMySQLParser{v2Declared: false}}
+	p := &Proxy{
+		logger:                     zap.NewNop(),
+		Integrations:               map[integrations.IntegrationType]integrations.Integrations{integrations.MYSQL: parser},
+		recordBufferCap:            8 << 20,
+		recordBufferQueueSize:      64,
+		recordBufferStallGrace:     5 * time.Second,
+		recordBufferHalfCloseGrace: 5 * time.Second,
+	}
+
+	srcRaw, _, cleanup := tcpConnPair(t)
+	defer cleanup()
+	dstRaw, err := net.DialTimeout("tcp", tlsLn.Addr().String(), 5*time.Second)
+	if err != nil {
+		t.Fatalf("dial tls listener: %v", err)
+	}
+	defer func() { _ = dstRaw.Close() }()
+
+	// These stand in for handleConnection's own variables — the ones its
+	// deferred close operates on.
+	var srcConn net.Conn = srcRaw
+	var dstConn net.Conn = dstRaw
+	before := dstConn
+
+	upgrader := util.NewConnTLSUpgrader(&srcConn, &dstConn, p.logger, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	errGrp, gctx := errgroup.WithContext(ctx)
+
+	if err := p.recordMySQLOutgoing(gctx, srcConn, dstConn, make(chan *models.Mock, 8), errGrp,
+		zap.NewNop(), 1, 2, models.OutgoingOptions{}, upgrader); err != nil {
+		t.Fatalf("recordMySQLOutgoing: %v", err)
+	}
+	if parser.upgradeErr != nil {
+		t.Fatalf("the parser's dest TLS upgrade failed: %v", parser.upgradeErr)
+	}
+
+	if dstConn == before {
+		t.Fatal("after the parser upgraded the destination, the CALLER's dstConn still points " +
+			"at the raw socket. handleConnection's deferred close will shut down the TCP " +
+			"connection instead of the tls.Conn, so no close_notify is sent and the peer sees " +
+			"a reset. The TLSUpgrader must be built where the real conn variables live, not " +
+			"over a callee's parameter copies.")
+	}
+	if _, ok := dstConn.(*tls.Conn); !ok {
+		t.Fatalf("caller's dstConn is %T after the upgrade, want *tls.Conn", dstConn)
+	}
+}
+
+func selfSignedForDispatch(t *testing.T) tls.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "keploy-dispatch-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("createcert: %v", err)
+	}
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+}

--- a/pkg/agent/proxy/mysql_fullstack_test.go
+++ b/pkg/agent/proxy/mysql_fullstack_test.go
@@ -1,0 +1,323 @@
+package proxy
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations"
+	mysqlparser "go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql"
+	syncMock "go.keploy.io/server/v3/pkg/agent/proxy/syncMock"
+	pTls "go.keploy.io/server/v3/pkg/agent/proxy/tls"
+	"go.keploy.io/server/v3/pkg/agent/proxy/util"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+)
+
+// TestMySQLV2_FullStackAgainstARealServer drives the COMPLETE production
+// record path against a real TLS-enabled mysqld: the real MySQL V2
+// parser, the real supervisor, the real relay, the real proxy TLS upgrade
+// (keploy's own MITM cert chain), and the real client driver.
+//
+// It closes the gap the relay-package tests cannot. There the parser is a
+// scripted stand-in and TLSUpgradeFn is a passthrough; in the
+// mysql/recorder tests there is no relay underneath at all. Both halves
+// were only ever checked against each other's contract.
+//
+// Asserts, in order of what has actually regressed before:
+//  0. It goes through recordMySQLOutgoing — the real dispatcher — so the
+//     gate is actually evaluated rather than bypassed.
+//  1. The query succeeds — mysqld's connection state was never corrupted.
+//  2. Mocks reach the SyncMockManager, and one carries the query — the
+//     parser was not left blocked on a bogus MySQL header of 16 03 01 00
+//     (payloadLength=66326), and the command phase was not lost while the
+//     handshake alone was captured.
+//  3. Nothing was delivered down the raw Mocks channel, which production
+//     does not use for V2 parsers (RouteMocksViaSyncMock is true).
+func TestMySQLV2_FullStackAgainstARealServer(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		// wrapDest mirrors how handleConnection hands the destination to
+		// the dispatcher.
+		wrapDest func(net.Conn, *zap.Logger) (net.Conn, error)
+		// relayOff sets KEPLOY_NEW_RELAY, the documented escape hatch.
+		relayOff string
+	}{
+		{
+			name:     "bare socket",
+			wrapDest: func(c net.Conn, _ *zap.Logger) (net.Conn, error) { return c, nil },
+		},
+		{
+			// The PROBE path — the primary MySQL path, since probeMysql runs
+			// before parser matching — dials the server itself to read the
+			// greeting, then hands the relay a replayConn that serves those
+			// consumed bytes back before falling through to the socket. That
+			// wrapper had never been fed to the relay: every other test uses
+			// a bare net.Dial, so the shape production actually uses was the
+			// one shape nothing exercised.
+			name: "prefix-replay dstConn (the probe's real shape)",
+			wrapDest: func(c net.Conn, lg *zap.Logger) (net.Conn, error) {
+				greeting, err := readOneMySQLPacket(c)
+				if err != nil {
+					return nil, fmt.Errorf("read greeting for replay wrap: %w", err)
+				}
+				return replayConn(c, greeting, lg), nil
+			},
+		},
+		{
+			// The escape hatch this PR's own error message tells operators to
+			// reach for. Flipping the primary MySQL path to V2 is only safe if
+			// the documented way back still records — and nothing proved that
+			// against a real server. The dispatch test shows the parser is
+			// handed the legacy surface; this shows the legacy surface still
+			// produces mocks.
+			name:     "KEPLOY_NEW_RELAY=off still records via the legacy path",
+			wrapDest: func(c net.Conn, _ *zap.Logger) (net.Conn, error) { return c, nil },
+			relayOff: "off",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.relayOff != "" {
+				t.Setenv("KEPLOY_NEW_RELAY", tc.relayOff)
+			}
+			runFullStackMySQL(t, tc.wrapDest, tc.relayOff != "")
+		})
+	}
+}
+
+func runFullStackMySQL(t *testing.T, wrapDest func(net.Conn, *zap.Logger) (net.Conn, error), legacy bool) {
+	addr, user, pass, dbName := mysqlTestTarget(t)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	logger := zap.NewNop()
+	parser := mysqlparser.New(logger)
+	p := &Proxy{
+		logger: logger,
+		// Registered so the dispatcher resolves the parser itself, rather
+		// than the test handing it in — the dispatch decision is the thing
+		// under test.
+		Integrations:               map[integrations.IntegrationType]integrations.Integrations{integrations.MYSQL: parser},
+		recordBufferCap:            8 << 20,
+		recordBufferQueueSize:      64,
+		recordBufferStallGrace:     10 * time.Second,
+		recordBufferHalfCloseGrace: 10 * time.Second,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	// Production routes EmitMock through the SyncMockManager
+	// (RouteMocksViaSyncMock: true), NOT down the raw Mocks channel. Bind
+	// a SEPARATE channel to each so the two are distinguishable: an
+	// earlier version passed one channel to both and stayed green with
+	// RouteMocksViaSyncMock flipped to false.
+	managerMocks := make(chan *models.Mock, 128)
+	rawMocks := make(chan *models.Mock, 128)
+
+	mgr := syncMock.New(logger)
+	mgr.SetOutputChannel(managerMocks)
+	ctx = syncMock.NewContext(ctx, mgr)
+
+	svErr := make(chan error, 1)
+	go func() {
+		clientConn, err := ln.Accept()
+		// One connection is all this test serves. Closing the listener now
+		// makes the driver's ErrBadConn retry fail immediately instead of
+		// dialling a listener nobody drains — which cost ~40s per failure.
+		_ = ln.Close()
+		if err != nil {
+			svErr <- fmt.Errorf("accept: %w", err)
+			return
+		}
+		defer func() { _ = clientConn.Close() }()
+
+		rawDest, err := net.DialTimeout("tcp", addr, 5*time.Second)
+		if err != nil {
+			svErr <- fmt.Errorf("dial mysql: %w", err)
+			return
+		}
+		defer func() { _ = rawDest.Close() }()
+		destConn, err := wrapDest(rawDest, logger)
+		if err != nil {
+			svErr <- err
+			return
+		}
+
+		errGrp, gctx := errgroup.WithContext(ctx)
+		// handleConnection seeds these three before dispatching (proxy.go
+		// ~2010). Without them the LEGACY half of this dispatcher is
+		// unrunnable — recordLegacy fails with "failed to get the error group
+		// from the context", and recorder/record.go does an unchecked
+		// ctx.Value(ClientConnectionIDKey).(string) — so a gate mutation
+		// failed here after 80s blaming cleartext leakage when the real cause
+		// was a missing context value.
+		gctx = context.WithValue(gctx, models.ErrGroupKey, errGrp)
+		gctx = context.WithValue(gctx, models.ClientConnectionIDKey, "1")
+		gctx = context.WithValue(gctx, models.DestConnectionIDKey, "2")
+		// Through the DISPATCHER, not straight to recordViaSupervisor. Calling
+		// the V2 entry point directly leaves the gate unevaluated, so the whole
+		// production change could be reverted with this test still green.
+		src, dst := clientConn, destConn
+		upgrader := util.NewConnTLSUpgrader(&src, &dst, logger, pTls.HandleTLSConnection)
+		svErr <- p.recordMySQLOutgoing(gctx, clientConn, destConn, rawMocks, errGrp, logger,
+			1, 2, models.OutgoingOptions{
+				DstCfg: &models.ConditionalDstCfg{Addr: addr},
+			}, upgrader)
+	}()
+
+	dsn := fmt.Sprintf("%s:%s@tcp(%s)/%s?tls=skip-verify&timeout=20s&readTimeout=20s",
+		user, pass, ln.Addr().String(), dbName)
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(1)
+
+	var got int
+	if err := db.QueryRow("SELECT 42").Scan(&got); err != nil {
+		t.Fatalf("query through the full production path failed: %v.\n"+
+			"The direct connection in the preflight succeeded, so this is keploy: the most "+
+			"likely cause is client bytes past the 36-byte SSLRequest reaching mysqld in "+
+			"cleartext and corrupting its view of the connection.", err)
+	}
+	if got != 42 {
+		t.Fatalf("SELECT 42 returned %d", got)
+	}
+	_ = db.Close()
+
+	// Wait for the production path itself rather than guessing a drain
+	// window; the connection lives only a few milliseconds. AddMock
+	// forwards synchronously on the bound && !firstReqSeen branch, so once
+	// recordViaSupervisor has returned every mock is already in the
+	// channel and no sleep is needed.
+	var svFinal error
+	select {
+	case svFinal = <-svErr:
+	case <-time.After(30 * time.Second):
+		t.Fatal("recordViaSupervisor never returned")
+	}
+
+	var captured []*models.Mock
+drain:
+	for {
+		select {
+		case m := <-managerMocks:
+			if m != nil {
+				captured = append(captured, m)
+			}
+		default:
+			break drain
+		}
+	}
+
+	if len(captured) == 0 {
+		t.Fatalf("the query succeeded but ZERO mocks reached the manager bound to this "+
+			"session. Traffic flows, the app is happy, and keploy records nothing. Candidates: "+
+			"the parser never got usable plaintext; EmitMock routed somewhere else; or the "+
+			"session was marked incomplete and its mocks dropped. (supervisor: %v)", svFinal)
+	}
+
+	// A count alone is too weak: the handshake mock alone would satisfy it
+	// while every command-phase mock was lost.
+	var sawQuery bool
+	for i, m := range captured {
+		t.Logf("mock[%d] kind=%s name=%s", i, m.Kind, m.Name)
+		if b, err := json.Marshal(m); err == nil && strings.Contains(string(b), "SELECT 42") {
+			sawQuery = true
+		}
+	}
+	if !sawQuery {
+		t.Fatalf("recorded %d mock(s) but none contains the query 'SELECT 42' — the handshake "+
+			"was captured while the command phase was lost", len(captured))
+	}
+
+	// Production does not deliver V2 parser mocks down the raw channel.
+	// If this ever fills, RouteMocksViaSyncMock has been turned off and
+	// the session-window buffering that replay depends on is bypassed.
+	if n := len(rawMocks); n != 0 && !legacy {
+		t.Errorf("%d mock(s) went down the raw Mocks channel; production routes V2 parser "+
+			"mocks through the SyncMockManager (RouteMocksViaSyncMock), and bypassing it loses "+
+			"the firstReqSeen session window at replay", n)
+	}
+	t.Logf("recorded %d mock(s) through the full production path (supervisor err: %v)",
+		len(captured), svFinal)
+}
+
+// mysqlTestTarget resolves the server and PROVES it usable with a
+// direct, unproxied query first. Without that preflight an unrelated
+// MySQL on 3306 (wrong password, missing database) fails through keploy
+// and gets diagnosed as upstream corruption — a confident, wrong answer.
+//
+// A missing server is a hard failure only where the lane PROMISED one,
+// signalled by KEPLOY_TEST_MYSQL_REQUIRED (set by go-test.yaml, which
+// provides the service). Keying this on the generic CI var instead would
+// redden every fork and every unrelated lane over a database they were
+// never offered, while still not making the test run anywhere.
+func mysqlTestTarget(t *testing.T) (addr, user, pass, dbName string) {
+	t.Helper()
+	addr = envOr("KEPLOY_TEST_MYSQL_ADDR", "127.0.0.1:3306")
+	user = envOr("KEPLOY_TEST_MYSQL_USER", "root")
+	pass = envOr("KEPLOY_TEST_MYSQL_PASS", "rootpass")
+	dbName = envOr("KEPLOY_TEST_MYSQL_DB", "sampledb")
+
+	dsn := fmt.Sprintf("%s:%s@tcp(%s)/%s?tls=skip-verify&timeout=5s&readTimeout=5s",
+		user, pass, addr, dbName)
+	db, err := sql.Open("mysql", dsn)
+	if err == nil {
+		defer func() { _ = db.Close() }()
+		var probe int
+		err = db.QueryRow("SELECT 1").Scan(&probe)
+	}
+	if err != nil {
+		msg := fmt.Sprintf("no usable TLS-capable MySQL at %s (%v); set "+
+			"KEPLOY_TEST_MYSQL_ADDR/USER/PASS/DB", addr, err)
+		if os.Getenv("KEPLOY_TEST_MYSQL_REQUIRED") != "" {
+			t.Fatalf("%s. KEPLOY_TEST_MYSQL_REQUIRED is set, so this lane promised a server. This is the only coverage of the real "+
+				"MySQL TLS handshake through the full record path, and a skip would let it rot "+
+				"unnoticed.", msg)
+		}
+		t.Skip(msg)
+	}
+	return addr, user, pass, dbName
+}
+
+func envOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+// readOneMySQLPacket reads a single length-prefixed MySQL packet
+// (4-byte header, 3-byte LE payload length) so the test can consume the
+// server greeting the way probeMysql does before wrapping the conn.
+func readOneMySQLPacket(c net.Conn) ([]byte, error) {
+	hdr := make([]byte, 4)
+	if _, err := io.ReadFull(c, hdr); err != nil {
+		return nil, err
+	}
+	n := int(uint32(hdr[0]) | uint32(hdr[1])<<8 | uint32(hdr[2])<<16)
+	buf := make([]byte, 4+n)
+	copy(buf, hdr)
+	if n > 0 {
+		if _, err := io.ReadFull(c, buf[4:]); err != nil {
+			return nil, err
+		}
+	}
+	return buf, nil
+}

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -1014,6 +1014,88 @@ func shouldRecordViaSupervisor(parser integrations.Integrations) bool {
 	return ok && v2.IsV2() && !newRelayDisabled()
 }
 
+// recordMySQLOutgoing dispatches a record-mode MySQL connection that
+// arrived through the PROBE branch, to either the V2 supervisor path or
+// the legacy one.
+//
+// It is a method rather than an inlined block so the dispatch decision is
+// reachable from a test. Inlined, it sat ~250 lines into handleConnection
+// behind an eBPF-resolved destination and a live greeting probe, so no
+// test could assert which surface the parser was handed — reverting the
+// gate entirely left the whole suite green, and a source-scanning pin was
+// defeated by `if false &&` or by negating the condition.
+//
+// tlsUpgrader is a PARAMETER rather than built here, and that is
+// load-bearing. util.NewConnTLSUpgrader keeps the &srcConn/&dstConn
+// pointers it is given and writes the upgraded *tls.Conn back through
+// them, so that handleConnection's deferred close acts on the TLS conn
+// and sends close_notify. Constructing it here would alias this
+// function's PARAMETER COPIES: the legacy MySQL STARTTLS path
+// (recorder/conn.go UpgradeClientTLS/UpgradeDestTLS) would still
+// upgrade, but the caller's variables would keep pointing at the raw
+// sockets and the deferred close would tear them down without
+// close_notify. proxy.go's matched-parser site carries the same warning.
+//
+// The error handling deliberately mirrors the two sibling supervisor
+// dispatch sites: a network-closed error is logged at Debug rather than
+// as a failure, but is still returned, so all three sites answer the same
+// way for the same condition.
+func (p *Proxy) recordMySQLOutgoing(
+	parserCtx context.Context,
+	srcConn, dstConn net.Conn,
+	mocks chan<- *models.Mock,
+	parserErrGrp *errgroup.Group,
+	mysqlLogger *zap.Logger,
+	clientConnID, destConnID int64,
+	outgoingOpts models.OutgoingOptions,
+	tlsUpgrader models.TLSUpgrader,
+) error {
+	mysqlParser := p.Integrations[integrations.MYSQL]
+	if shouldRecordViaSupervisor(mysqlParser) {
+		if err := p.recordViaSupervisor(parserCtx, srcConn, dstConn, mysqlParser,
+			integrations.MYSQL, mocks, parserErrGrp, mysqlLogger,
+			clientConnID, destConnID, outgoingOpts); err != nil {
+			if isNetworkClosedErr(err) {
+				mysqlLogger.Debug("V2 record path: connection closed", zap.Error(err))
+			} else {
+				utils.LogError(mysqlLogger, err, "V2 record path failed for the MySQL probe branch",
+					zap.String("next_step", "set KEPLOY_NEW_RELAY=off to force the legacy record path for MySQL while investigating, or KEPLOY_DISABLE_PARSING=1 / SIGUSR1 to disable parser dispatch entirely (raw passthrough)"),
+				)
+			}
+			return err
+		}
+		mysqlLogger.Debug("V2 record path returned", zap.String("ParserType", string(integrations.MYSQL)))
+		return nil
+	}
+
+	// A probe verdict of IsMySQL does not imply the parser is registered
+	// (the configured-port and known-port verdicts never check), so the
+	// legacy path would nil-panic on an unregistered build.
+	if mysqlParser == nil {
+		utils.LogError(mysqlLogger, nil, "no MySQL parser is registered",
+			zap.String("next_step", "the MySQL probe matched but integrations.MYSQL is absent from p.Integrations; this is a build/registration bug"))
+		return errors.New("mysql parser not registered")
+	}
+
+	mysqlSession := &integrations.RecordSession{
+		Ingress:      util.NewSafeConn(srcConn, mysqlLogger),
+		Egress:       util.NewSafeConn(dstConn, mysqlLogger),
+		Mocks:        mocks,
+		ErrGroup:     parserErrGrp,
+		TLSUpgrader:  tlsUpgrader,
+		Logger:       mysqlLogger,
+		ClientConnID: fmt.Sprint(clientConnID),
+		DestConnID:   fmt.Sprint(destConnID),
+		Opts:         outgoingOpts,
+	}
+
+	if err := mysqlParser.RecordOutgoing(parserCtx, mysqlSession); err != nil {
+		utils.LogError(p.logger, err, "failed to record the outgoing message")
+		return err
+	}
+	return nil
+}
+
 func (p *Proxy) buildRecordSession(
 	srcConn, dstConn net.Conn,
 	mocks chan<- *models.Mock,
@@ -2070,25 +2152,27 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 				zap.String("Destination ConnectionID", fmt.Sprint(destConnID)),
 				zap.String("Destination Address", dstAddr),
 			)
-			mysqlSession := &integrations.RecordSession{
-				Ingress:      util.NewSafeConn(srcConn, mysqlLogger),
-				Egress:       util.NewSafeConn(dstConn, mysqlLogger),
-				Mocks:        rule.MC,
-				ErrGroup:     parserErrGrp,
-				TLSUpgrader:  util.NewConnTLSUpgrader(&srcConn, &dstConn, p.logger, pTls.HandleTLSConnection),
-				Logger:       mysqlLogger,
-				ClientConnID: fmt.Sprint(clientConnID),
-				DestConnID:   fmt.Sprint(destConnID),
-				Opts:         outgoingOpts,
-			}
-
-			// Record the outgoing message into a mock
-			err := p.Integrations[integrations.MYSQL].RecordOutgoing(parserCtx, mysqlSession)
-			if err != nil {
-				utils.LogError(p.logger, err, "failed to record the outgoing message")
-				return err
-			}
-			return nil
+			// This branch used to build a legacy RecordSession and call
+			// RecordOutgoing directly, with no IsV2 gate — so a MySQL
+			// connection reaching keploy through the PROBE recorded
+			// legacy on the default configuration, while the very same
+			// parser recorded via the supervisor when it arrived through
+			// the matched-parser branch a few hundred lines below. Two
+			// dispatch sites, two different answers, for one parser.
+			//
+			// keploy#4526 fixed the identical omission on the generic
+			// catch-all and deliberately left this one alone, because
+			// MySQL's V2 path leaked the client's ClientHello upstream
+			// in cleartext and needed its own soak. That leak is fixed
+			// (the client write hold), so the gate goes on here too and
+			// shouldRecordViaSupervisor becomes the single answer for
+			// every dispatch site.
+			// Built HERE, in handleConnection scope, so it holds pointers to
+			// the real srcConn/dstConn variables the deferred close uses —
+			// not to copies. See recordMySQLOutgoing's doc comment.
+			mysqlUpgrader := util.NewConnTLSUpgrader(&srcConn, &dstConn, p.logger, pTls.HandleTLSConnection)
+			return p.recordMySQLOutgoing(parserCtx, srcConn, dstConn, rule.MC,
+				parserErrGrp, mysqlLogger, clientConnID, destConnID, outgoingOpts, mysqlUpgrader)
 		}
 
 		m := p.getMockManager()
@@ -2097,8 +2181,19 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 			return err
 		}
 
+		// Same registration hazard as the record path above: a probe verdict
+		// of IsMySQL does not imply the parser is registered (the
+		// configured-port and known-port verdicts never check), so an
+		// unregistered build nil-panics here instead of failing cleanly.
+		mysqlMocker := p.Integrations[integrations.MYSQL]
+		if mysqlMocker == nil {
+			utils.LogError(p.logger, nil, "no MySQL parser is registered",
+				zap.String("next_step", "the MySQL probe matched but integrations.MYSQL is absent from p.Integrations; this is a build/registration bug"))
+			return errors.New("mysql parser not registered")
+		}
+
 		//mock the outgoing message
-		err := p.Integrations[integrations.MYSQL].MockOutgoing(parserCtx, srcConn, &models.ConditionalDstCfg{Addr: dstAddr}, p.scopedFor(outgoingOpts.SrcPid, m), outgoingOpts)
+		err := mysqlMocker.MockOutgoing(parserCtx, srcConn, &models.ConditionalDstCfg{Addr: dstAddr}, p.scopedFor(outgoingOpts.SrcPid, m), outgoingOpts)
 		if err != nil && err != io.EOF && !errors.Is(err, context.Canceled) && !isNetworkClosedErr(err) {
 			p.logger.Debug("mysql mock outgoing finished with error", zap.Error(err))
 			p.sendMockNotFoundError(err)

--- a/pkg/agent/proxy/relay/mysql_real_server_test.go
+++ b/pkg/agent/proxy/relay/mysql_real_server_test.go
@@ -1,0 +1,292 @@
+package relay
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"database/sql"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"go.keploy.io/server/v3/pkg/agent/proxy/directive"
+	"go.uber.org/zap"
+)
+
+// byteCountingConn counts bytes written to the wire. The relay writes the
+// flushed client hold through this before the TLS upgrade wraps it, so a
+// snapshot taken at upgrade time is exactly the number of CLEARTEXT bytes
+// that reached mysqld.
+type byteCountingConn struct {
+	net.Conn
+	written atomic.Int64
+}
+
+func (c *byteCountingConn) Write(p []byte) (int, error) {
+	n, err := c.Conn.Write(p)
+	c.written.Add(int64(n))
+	return n, err
+}
+
+// TestClientWriteHold_AgainstARealMySQLServer drives a REAL TLS-enabled
+// mysqld through the REAL relay with a REAL TLS upgrade on both sides.
+//
+// The assertion that earns this test its place is upstreamCleartext: the
+// relay must forward the 36-byte SSLRequest to the server and NOTHING
+// after it. Everything past that byte belongs to the client's ClientHello,
+// which the hold must keep back for keploy's own handshake — if it leaks,
+// mysqld reads TLS bytes as protocol and the connection is corrupted.
+//
+// That number is measured on the destination socket, not on the tee. An
+// earlier version read it off ClientStream, where it was always 36
+// regardless of the hold (the tee delivers client bytes either way) — it
+// asserted a property of go-sql-driver, not of keploy, and stayed green
+// with the flush written nowhere at all.
+//
+// Skips unless a TLS-capable MySQL is reachable; where the lane promised
+// one (KEPLOY_TEST_MYSQL_REQUIRED) a missing server is a hard failure so
+// the coverage cannot rot unnoticed.
+func TestClientWriteHold_AgainstARealMySQLServer(t *testing.T) {
+	addr, user, pass, dbName := mysqlTestTarget(t)
+
+	mitm := selfSignedCert(t)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	type result struct {
+		upstreamCleartext  int64
+		parserAfterUpgrade []byte
+		err                error
+	}
+	resCh := make(chan result, 1)
+
+	// The relay must outlive the report: the query runs AFTER the upgrade,
+	// so tearing the context down at report time kills the connection
+	// mid-query and the driver returns "invalid connection".
+	release := make(chan struct{})
+	defer close(release)
+
+	go func() {
+		clientConn, err := ln.Accept()
+		if err != nil {
+			resCh <- result{err: fmt.Errorf("accept: %w", err)}
+			return
+		}
+		defer func() { _ = clientConn.Close() }()
+
+		rawDest, err := net.DialTimeout("tcp", addr, 5*time.Second)
+		if err != nil {
+			resCh <- result{err: fmt.Errorf("dial mysql: %w", err)}
+			return
+		}
+		defer func() { _ = rawDest.Close() }()
+		destConn := &byteCountingConn{Conn: rawDest}
+
+		// Snapshot the upstream byte count at the instant of the upgrade,
+		// before the TLS handshake writes anything of its own.
+		var cleartextAtUpgrade atomic.Int64
+		upgrade := func(_ context.Context, c net.Conn, isClient bool, _ *tls.Config) (net.Conn, error) {
+			if isClient {
+				cleartextAtUpgrade.Store(destConn.written.Load())
+				tc := tls.Client(c, &tls.Config{InsecureSkipVerify: true}) //nolint:gosec // MITM dial to a test server
+				if err := tc.Handshake(); err != nil {
+					return nil, fmt.Errorf("dest handshake: %w", err)
+				}
+				return tc, nil
+			}
+			ts := tls.Server(c, &tls.Config{Certificates: []tls.Certificate{mitm}})
+			if err := ts.Handshake(); err != nil {
+				return nil, fmt.Errorf("client handshake: %w", err)
+			}
+			return ts, nil
+		}
+
+		r := New(Config{
+			Logger:           zap.NewNop(),
+			HoldClientWrites: true,
+			TLSUpgradeFn:     upgrade,
+		}, clientConn, destConn)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		go func() { _ = r.Run(ctx) }()
+		defer func() { <-release }()
+
+		if _, err := readMySQLPacket(r.DestStream()); err != nil {
+			resCh <- result{err: fmt.Errorf("read greeting: %w", err)}
+			return
+		}
+		sslReq, err := readMySQLPacket(r.ClientStream())
+		if err != nil {
+			resCh <- result{err: fmt.Errorf("read SSLRequest: %w", err)}
+			return
+		}
+
+		// A real parser does not answer instantly: it decodes the packet,
+		// consults session state and only then emits the directive. That
+		// gap is the whole race. With a scripted parser on loopback the
+		// directive lands before the client's ClientHello has even
+		// arrived, which hides the defect completely — the unfixed path
+		// passes 5/5 with this sleep at 0 and fails 5/5 with it set.
+		time.Sleep(parserThinkTime)
+
+		d := directive.UpgradeTLS(&tls.Config{}, &tls.Config{}, "mysql client_ssl")
+		d.TLS.ClientFlushBytes = len(sslReq)
+		r.Directives() <- d
+		ack := <-r.Acks()
+		if !ack.OK {
+			resCh <- result{err: fmt.Errorf("upgrade ack: %+v", ack)}
+			return
+		}
+
+		next, err := readMySQLPacket(r.ClientStream())
+		if err != nil {
+			resCh <- result{err: fmt.Errorf("read post-TLS packet: %w", err)}
+			return
+		}
+		resCh <- result{upstreamCleartext: cleartextAtUpgrade.Load(), parserAfterUpgrade: next}
+	}()
+
+	dsn := fmt.Sprintf("%s:%s@tcp(%s)/%s?tls=skip-verify&timeout=15s&readTimeout=15s",
+		user, pass, ln.Addr().String(), dbName)
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var got int
+	qErr := db.QueryRow("SELECT 42").Scan(&got)
+
+	select {
+	case res := <-resCh:
+		if res.err != nil {
+			t.Fatalf("relay side: %v", res.err)
+		}
+		if res.upstreamCleartext != 36 {
+			t.Errorf("%d cleartext bytes reached mysqld before the upgrade, want exactly the "+
+				"36-byte SSLRequest. Anything beyond it is the client's ClientHello leaking "+
+				"upstream, which corrupts the server's view of the connection.",
+				res.upstreamCleartext)
+		}
+		if len(res.parserAfterUpgrade) > 0 && res.parserAfterUpgrade[0] == 0x16 {
+			t.Fatalf("after the upgrade the parser read TLS handshake bytes (% x...). Against a "+
+				"REAL server this is the hang: a MySQL header of 16 03 01 00 declares "+
+				"payloadLength=66326, so the parser blocks until the watchdog retires it and "+
+				"the connection records zero mocks.", res.parserAfterUpgrade[:4])
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("relay side never reported")
+	}
+
+	if qErr != nil {
+		t.Fatalf("the query failed through the relay: %v", qErr)
+	}
+	if got != 42 {
+		t.Fatalf("SELECT 42 returned %d", got)
+	}
+}
+
+// parserThinkTime models the real parser's decode latency, which is what
+// opens the window for the client's ClientHello to reach mysqld.
+const parserThinkTime = 100 * time.Millisecond
+
+// readMySQLPacket reads one length-prefixed MySQL packet (4-byte header,
+// 3-byte LE payload length) and returns header+payload.
+func readMySQLPacket(c net.Conn) ([]byte, error) {
+	hdr := make([]byte, 4)
+	if _, err := io.ReadFull(c, hdr); err != nil {
+		return nil, err
+	}
+	n := int(uint32(hdr[0]) | uint32(hdr[1])<<8 | uint32(hdr[2])<<16)
+	buf := make([]byte, 4+n)
+	copy(buf, hdr)
+	if n > 0 {
+		if _, err := io.ReadFull(c, buf[4:]); err != nil {
+			return nil, err
+		}
+	}
+	return buf, nil
+}
+
+func selfSignedCert(t *testing.T) tls.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "keploy-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("createcert: %v", err)
+	}
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+}
+
+// mysqlTestTarget resolves the server to test against and PROVES it is
+// usable with a direct, unproxied query first.
+//
+// Without that preflight, an unrelated MySQL on 3306 (wrong password,
+// missing database) fails the test through keploy and gets diagnosed as
+// "client bytes reached the server in cleartext" — a confident, wrong
+// answer. Only a failure that the direct connection did NOT hit belongs to
+// keploy.
+//
+// A missing server is a hard failure only where the lane PROMISED one,
+// signalled by KEPLOY_TEST_MYSQL_REQUIRED (set by go-test.yaml, which
+// provides the service). Keying this on the generic CI var instead would
+// redden every fork and every unrelated lane over a database they were
+// never offered, while still not making the test run anywhere.
+func mysqlTestTarget(t *testing.T) (addr, user, pass, dbName string) {
+	t.Helper()
+	addr = envOr("KEPLOY_TEST_MYSQL_ADDR", "127.0.0.1:3306")
+	user = envOr("KEPLOY_TEST_MYSQL_USER", "root")
+	pass = envOr("KEPLOY_TEST_MYSQL_PASS", "rootpass")
+	dbName = envOr("KEPLOY_TEST_MYSQL_DB", "sampledb")
+
+	dsn := fmt.Sprintf("%s:%s@tcp(%s)/%s?tls=skip-verify&timeout=5s&readTimeout=5s",
+		user, pass, addr, dbName)
+	db, err := sql.Open("mysql", dsn)
+	if err == nil {
+		defer func() { _ = db.Close() }()
+		var probe int
+		err = db.QueryRow("SELECT 1").Scan(&probe)
+	}
+	if err != nil {
+		msg := fmt.Sprintf("no usable TLS-capable MySQL at %s (%v); set KEPLOY_TEST_MYSQL_ADDR/"+
+			"USER/PASS/DB", addr, err)
+		if os.Getenv("KEPLOY_TEST_MYSQL_REQUIRED") != "" {
+			t.Fatalf("%s. KEPLOY_TEST_MYSQL_REQUIRED is set, so this lane promised a MySQL: "+
+				"the real MySQL TLS handshake, and a skip would let them rot unnoticed.", msg)
+		}
+		t.Skip(msg)
+	}
+	return addr, user, pass, dbName
+}
+
+func envOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}


### PR DESCRIPTION
`probeMysql` runs **before** parser matching, so the probe branch — not the matched-parser branch — is the primary path for MySQL. It called `RecordOutgoing` directly with a hand-built `RecordSession` and no `IsV2` gate, so MySQL recorded **legacy on the default configuration** even though `IsV2()` returns true, while the same parser recorded via the supervisor when it arrived through the matched-parser branch. Two dispatch sites, two answers, one parser.

keploy#4526 fixed the identical omission on the generic catch-all and deliberately left this one, because MySQL's V2 path leaked the client's ClientHello upstream in cleartext. #4543 fixed that leak, so the gate goes on here too and `shouldRecordViaSupervisor` becomes the single answer for every dispatch site.

## Why the dispatch moved into a function

Inlined, the decision sat ~250 lines into `handleConnection` behind an eBPF-resolved destination and a live greeting probe. Nothing could assert which surface the parser was handed — **reverting the gate entirely left the whole suite green**, and a source-scanning pin was defeated by `if false &&` or by inserting a `!`. `recordMySQLOutgoing` makes it reachable.

`TLSUpgrader` is deliberately a **parameter** built at the call site. `util.NewConnTLSUpgrader` keeps the `&srcConn`/`&dstConn` pointers it is given and writes the upgraded `*tls.Conn` back through them so the deferred close sends `close_notify`. Building it inside the callee aliases the parameter copies: a legacy STARTTLS still upgrades, every test stays green, and the caller closes the raw socket so the peer sees a reset. The matched-parser site carries the same warning.

## Nil-parser guards

A probe verdict of `IsMySQL` does not imply the parser is registered — the configured-port and known-port verdicts never check, only the content path does. Both the record and replay branches nil-panicked on an unregistered build; both now fail cleanly.

## Tests

Each was verified by re-introducing the defect it covers:

| test | catches |
|---|---|
| `TestMySQLProbeBranchRoutesByShouldRecordViaSupervisor` | asserts which **surface** the parser receives, so `if false &&`, a negated gate and `if true` all fail |
| `TestRecordMySQLOutgoing_TLSUpgradeRebindsTheCallersConn` | the pointer contract above — its only detector |
| `TestMySQLV2_FullStackAgainstARealServer` | the full production path against a real TLS mysqld: bare socket, the probe's real prefix-replay `dstConn`, and `KEPLOY_NEW_RELAY=off` |
| `TestEveryLegacyDispatchFunctionConsultsTheGate` | a new ungated dispatch site anywhere in the package, with a guard that errors if its exemption stops resolving |
| `TestRecordMySQLOutgoing_UnregisteredParser` | the nil guard |

The full-stack test seeds the three context values `handleConnection` sets (`ErrGroupKey`, `ClientConnectionIDKey`, `DestConnectionIDKey`). Without them the legacy half is unrunnable and the test misdiagnoses its own failure — a gate mutation failed after 80s blaming cleartext leakage when the cause was a missing context value.

## CI

`go-test.yaml` gains a `mysql:8.0` service so the real-server tests actually run — they have never executed in CI. They key their hard failure on `KEPLOY_TEST_MYSQL_REQUIRED`, which only that lane sets, so a fork or an unrelated lane **skips** rather than failing over a server it was never offered. Keying on the generic `CI` var would redden every PR in the repo.

## Scope

This flips **all** MySQL recording to V2 by default. `MySQL.IsV2()` already returns true and the matched-parser site already routed that way; this aligns the path that actually carries MySQL traffic.

## Follow-ups, not bundled

- The replay-side nil guard is untested — the AST pin only looks at `RecordOutgoing`, not `MockOutgoing`.
- Both guards return an error, which unwinds to `handleConnection`'s deferred close. `globalPassThrough` is the house answer for "we cannot parse this" and better matches invariant I1. Unreachable in the shipped binary since MySQL is always registered, and strictly better than the panic it replaces.
