### PR TITLE
fix(mysql): stop the legacy post-TLS path shipping another connection's timestamp

### DIFF
--- a/pkg/agent/proxy/integrations/mysql/recorder/conn.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/conn.go
@@ -886,9 +886,40 @@ func handlePostTLSRecord(ctx context.Context, logger *zap.Logger, clientConn, de
 			if c, found := hsStore.Last(lastKey); found && len(c.RespPackets) > 0 {
 				logger.Debug("Post-TLS MySQL: own handshake entry gone; reusing the last greeting recorded for this destination",
 					zap.String("lastKey", lastKey))
+				// Reuse the PACKETS, not the timing. The store's own contract
+				// says so (TLSHandshakeStore.Last: "reuse the server-stable
+				// parts ... but not per-connection metadata such as the request
+				// timestamp"), and this was the only in-tree violator: both
+				// config-mock emitters below pass entry.ReqTimestamp straight to
+				// recordMock, so adopting a borrowed one backdates this mock by
+				// up to lastGreetingTTL (30 min).
+				//
+				// That matters twice over. recordMock stamps a "config" mock as
+				// LifetimeSession, so it skips the per-test window entirely —
+				// but pkg/util.go still sorts the session pool by
+				// ReqTimestampMock, and treedb.sameMock IDENTIFIES a mock by
+				// Name+Kind+ReqTimestampMock. Every pooled connection borrowing
+				// the same cached entry would emit mutually indistinguishable
+				// config mocks, and the guard that stops UpdateUnFilteredMock
+				// touching the wrong entry silently abstains.
+				//
+				// The V2 path draws the same line (record_v2.go, staleEntry).
+				c.ReqTimestamp = models.CapturedReqTime(ctx)
 				entry, ok = c, true
 			}
 		}
+	}
+
+	// A zero ReqTimestamp is worse than a stale one: pkg/util.go routes any
+	// mock with a zero request OR response timestamp into filteredMocks with
+	// IsFiltered=true and stops there — ABOVE the lifetime-first routing — so
+	// a LifetimeSession config mock lands in the per-test pool. That happens
+	// whenever both PopWaits and the cache miss and the greeting comes from
+	// the direct fetch below, which never sets a timestamp. V2 handles the
+	// same case by re-sampling; normalise here so neither emitter can ship a
+	// zero.
+	if entry.ReqTimestamp.IsZero() {
+		entry.ReqTimestamp = models.CapturedReqTime(ctx)
 	}
 
 	var serverGreetingBuf []byte

--- a/pkg/agent/proxy/integrations/mysql/recorder/legacy_borrowed_timestamp_test.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/legacy_borrowed_timestamp_test.go
@@ -1,0 +1,124 @@
+package recorder
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	syncMock "go.keploy.io/server/v3/pkg/agent/proxy/syncMock"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// TestLegacyPostTLS_BorrowedGreetingDoesNotBackdateTheConfigMock pins the
+// timing half of the last-greeting fallback.
+//
+// When this connection's own handshake entry is gone (its capture event
+// dropped, or it is a pooled connection whose entry was already consumed),
+// the legacy post-TLS reader borrows the last greeting another connection
+// recorded for the same destination. Only the PACKETS are reusable that
+// way — capabilities, protocol version and auth plugin are per-server. The
+// TIMING is not: the borrowed entry's ReqTimestamp belongs to a different
+// connection and can be anything up to the store's TTL old.
+//
+// Adopting it wholesale backdates this connection's config mock. A config
+// mock is LifetimeSession so it skips the per-test window, but the
+// timestamp is still load-bearing: pkg/util.go sorts the session pool by
+// ReqTimestampMock, and treedb.sameMock IDENTIFIES a mock by
+// Name+Kind+ReqTimestampMock — so every pooled connection borrowing the
+// same cached entry emits mutually indistinguishable config mocks. The V2
+// path draws this line explicitly; this test holds the legacy path to it.
+func TestLegacyPostTLS_BorrowedGreetingDoesNotBackdateTheConfigMock(t *testing.T) {
+	// This test takes ~7s by construction: reaching the cache fallback means
+	// missing BOTH PopWait calls in handlePostTLSRecord first (5s on the
+	// conn-specific key, then 2s on the port-only key). Those timeouts are
+	// hardcoded, so there is no knob to shorten them — and waiting them out
+	// is the point, since the fallback is only reachable after they expire.
+	store := models.NewTLSHandshakeStore()
+	// recordMock reads ClientConnectionIDKey as a string, so the emit path
+	// needs it present.
+	ctx := context.WithValue(postTLSCtxWithStore(store),
+		models.ClientConnectionIDKey, "borrowed-greeting-conn")
+
+	// recordMock delivers through syncMock.FromContextOrGlobal and returns,
+	// so a bare mocks channel never sees anything — the mock would go to the
+	// package-global manager. Bind a manager of our own with its output
+	// channel wired, which is what production does.
+	mocks := make(chan *models.Mock, 16)
+	mgr := syncMock.New(zap.NewNop())
+	mgr.SetOutputChannel(mocks)
+	ctx = syncMock.NewContext(ctx, mgr)
+
+	scope := "ns/app/ts0"
+	// Fabricated, closed port: the direct-dial fallback cannot succeed, so
+	// the greeting can only come from the cache.
+	dst := &models.ConditionalDstCfg{Addr: "127.0.0.1:1", Port: 3306, AddrFabricated: true}
+
+	// An EARLIER connection's entry, an hour old.
+	staleTs := time.Now().Add(-time.Hour)
+	store.RememberLast(models.HandshakeLastKey(scope, dst), models.TLSHandshakeEntry{
+		RespPackets:  [][]byte{cannedHandshakeV10(t)},
+		ReqPackets:   [][]byte{cannedSSLRequest(t, 1)},
+		ReqTimestamp: staleTs,
+	})
+
+	clientConn, peer := net.Pipe()
+	defer func() { _ = clientConn.Close() }()
+	// A real (immediately closed) destination: the command phase cannot
+	// complete, which is fine — the config mock is emitted before that
+	// matters — but a nil conn panics rather than failing.
+	destConn, destPeer := net.Pipe()
+	defer func() { _ = destConn.Close() }()
+	_ = destPeer.Close()
+
+	// A seq=0 packet takes the "already authenticated" branch, which emits
+	// the synthetic config mock built from the borrowed entry — the shortest
+	// route to the timestamp under test.
+	go func() {
+		_, _ = peer.Write(cannedCOMQuery(t, 0, "SELECT 1"))
+		_ = peer.Close()
+	}()
+
+	opts := models.OutgoingOptions{
+		DstCfg:           dst,
+		PassThroughScope: scope,
+		ConnKey:          "pooled-conn-whose-own-entry-was-consumed",
+	}
+	t0 := time.Now()
+
+	// The command phase cannot complete (no destination), but the config
+	// mock is emitted before that matters.
+	_ = handlePostTLSRecord(ctx, zap.NewNop(), clientConn, destConn, mocks,
+		buildPostHandshakeDecodeCtx(clientConn), opts)
+
+	close(mocks)
+	var cfg *models.Mock
+	for m := range mocks {
+		if m != nil && m.Name == "config" {
+			cfg = m
+			break
+		}
+	}
+	if cfg == nil {
+		t.Fatal("no config mock was emitted — the borrowed greeting was not used at all, so " +
+			"this test is not exercising the path it claims to")
+	}
+
+	if cfg.Spec.ReqTimestampMock.Equal(staleTs) {
+		t.Fatalf("the config mock carries the BORROWED connection's request timestamp (%s, %s "+
+			"old). Only the greeting PACKETS are reusable across connections; the timing is "+
+			"not. It backdates this mock in the session pool's sort order, and because "+
+			"treedb.sameMock identifies a mock by Name+Kind+ReqTimestampMock, every pooled "+
+			"connection borrowing this same cached entry emits an indistinguishable config mock.",
+			staleTs.Format(time.RFC3339), time.Since(staleTs).Truncate(time.Minute))
+	}
+
+	// And it must be this connection's own time, not merely "not stale" —
+	// bracketed exactly, so a "zero it like V2 does" implementation (which
+	// would satisfy the check above) fails here too.
+	if got := cfg.Spec.ReqTimestampMock; got.Before(t0) || got.After(time.Now()) {
+		t.Errorf("config mock ReqTimestampMock = %s, want a time this connection produced "+
+			"(between %s and now)", got.Format(time.RFC3339Nano), t0.Format(time.RFC3339Nano))
+	}
+}


### PR DESCRIPTION
`handlePostTLSRecord` borrows the last greeting recorded for the same destination when this connection's own handshake entry is gone (its capture event dropped, or a pooled connection whose entry was already consumed). It adopted that entry **wholesale** — including its `ReqTimestamp`, which belongs to a *different* connection and can be up to `lastGreetingTTL` (30 min) old. Both config-mock emitters pass it straight to `recordMock`.

The store's own contract already forbids this — `TLSHandshakeStore.Last`:

> Callers must treat the result as belonging to ANOTHER connection to the same server: reuse the server-stable parts … but not per-connection metadata such as the request timestamp.

This was the only in-tree violator. The V2 path draws the same line via `staleEntry`.

## Why it matters

A `config` mock is stamped `LifetimeSession`, so it skips the per-test window and is not reaped — the timestamp is not inert, though:

- **Sort order** — `pkg/util.go` sorts the session/unfiltered pool by `ReqTimestampMock`.
- **Mock identity** — `treedb.sameMock` identifies a mock by `Name + Kind + ReqTimestampMock`. Every pooled connection borrowing the *same* cached entry inherits the *same* timestamp, so they emit mutually indistinguishable `config`/MySQL mocks and the guard that stops `UpdateUnFilteredMock` consuming the wrong entry silently abstains.
- **Memory-pressure attribution** — `syncMock` decides drop/keep via `pressureActiveAtLocked(ReqTimestampMock)`, i.e. against pressure state from half an hour ago.

## Also fixed: the zero case, which is worse

When both `PopWait`s **and** the cache miss, the greeting comes from the direct fetch, which never sets a timestamp — so the emitters shipped a **zero**. `pkg/util.go` routes any mock with a zero request or response timestamp into `filteredMocks` with `IsFiltered=true` and `continue`s, *above* the lifetime-first routing — putting a `LifetimeSession` config mock into the per-test pool. Normalised at a single point so neither emitter can ship a zero.

## Test

`TestLegacyPostTLS_BorrowedGreetingDoesNotBackdateTheConfigMock` drives the real borrow path and fails without the fix, reporting the hour-old borrowed timestamp. The second assertion brackets the stamp between a `t0` taken before the call and `time.Now()` after, so a "zero it like V2 does" implementation — which would satisfy the first assertion — fails too.

It costs ~7s by construction: reaching the cache fallback means missing both `PopWait`s first (5s + 2s), and those timeouts are hardcoded, so waiting them out *is* the path under test.

## Verified

`go build ./...`, `go vet ./...`, `gofmt -l` clean; `go test -race -count=1 ./pkg/agent/proxy/integrations/mysql/...` green.

`hsStore.Last` returns the entry **by value** from a value map, so writing `ReqTimestamp` on the copy cannot corrupt the cached entry other connections borrow — confirmed by mutating the copy and observing the store unchanged. `RespPackets` do alias the caller's backing array; the fix never writes them.
