### PR TITLE
fix(proxy): relay a connection the parser declined instead of dropping it

### DIFF
--- a/pkg/agent/proxy/declined_passthrough_test.go
+++ b/pkg/agent/proxy/declined_passthrough_test.go
@@ -1,0 +1,490 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations"
+	"go.keploy.io/server/v3/pkg/agent/proxy/util"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+)
+
+const h2Preface = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+
+// TestRelayDeclinedConn_RelaysTheWholeStreamIncludingConsumedBytes pins
+// the fix for a live user-facing break, and the subtlety that makes a
+// naive version of it useless.
+//
+// A parser that MATCHED and then declined — gRPC claims any HTTP/2
+// connection at priority 100, then bails when the destination port is
+// outside its allowlist (default "50051,443") — signalled that by
+// returning nil. The dispatcher read nil as "handled", logged
+// "successfully recorded outgoing message", and handleConnection's
+// deferred close tore the socket down. So gRPC on any non-default port had
+// its connections DROPPED in record mode.
+//
+// The subtlety: deciding whether it wants the connection requires the
+// parser to READ, and gRPC reads the HTTP/2 preface. It restores those
+// bytes by wrapping session.Ingress. Relaying handleConnection's own
+// srcConn instead would forward a preface-less stream, and a real server
+// answers GOAWAY(PROTOCOL_ERROR) — moving the user's break rather than
+// fixing it. This asserts the FULL stream, preface included, reaches
+// upstream.
+func TestRelayDeclinedConn_RelaysTheWholeStreamIncludingConsumedBytes(t *testing.T) {
+	upstream, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = upstream.Close() }()
+
+	received := make(chan []byte, 1)
+	go func() {
+		c, err := upstream.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = c.Close() }()
+		buf := make([]byte, len(h2Preface)+4)
+		n, _ := io.ReadFull(c, buf)
+		received <- buf[:n]
+	}()
+
+	appSide, proxySide, cleanupPair := tcpConnPair(t)
+	defer cleanupPair()
+	defer func() { _ = appSide.Close() }()
+	dstConn, err := net.DialTimeout("tcp", upstream.Addr().String(), 5*time.Second)
+	if err != nil {
+		t.Fatalf("dial upstream: %v", err)
+	}
+	defer func() { _ = dstConn.Close() }()
+
+	// The app speaks first, exactly as an h2 client does.
+	go func() {
+		_, _ = appSide.Write([]byte(h2Preface))
+		_, _ = appSide.Write([]byte("POST"))
+	}()
+
+	// Reproduce what a declining parser leaves behind: it DRAINED the
+	// preface off Ingress, then restored it by wrapping. handleConnection's
+	// own srcConn is left positioned past those bytes.
+	drained := make([]byte, len(h2Preface))
+	if _, err := io.ReadFull(proxySide, drained); err != nil {
+		t.Fatalf("simulating the parser's read: %v", err)
+	}
+	if string(drained) != h2Preface {
+		t.Fatalf("drained %q, want the h2 preface", drained)
+	}
+	// The SAME wrapper production uses (buildRecordSession) — not util.Conn.
+	// util.Conn embeds a real net.Conn with real Close and deadlines;
+	// SafeConn no-ops both and exposes Unwrap(). A future "unwrap to get at
+	// the real socket" edit passes against util.Conn and loses the preface
+	// against SafeConn.
+	session := &integrations.RecordSession{
+		Ingress: util.NewSafeConnWithReader(proxySide, util.NewPrefixReader(drained, proxySide), zap.NewNop()),
+		Egress:  util.NewSafeConn(dstConn, zap.NewNop()),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	errGrp, gctx := errgroup.WithContext(ctx)
+	ctx = context.WithValue(gctx, models.ErrGroupKey, errGrp)
+	ctx = context.WithValue(ctx, models.ClientConnectionIDKey, "1")
+	ctx = context.WithValue(ctx, models.DestConnectionIDKey, "2")
+
+	declined := fmt.Errorf("destination port 8080 not in KEPLOY_GRPC_V2_PORTS allowlist: %w",
+		integrations.ErrParserDeclined)
+
+	go func() {
+		_ = p0().relayDeclinedConn(ctx, declined, zap.NewNop(), integrations.GRPC, session)
+	}()
+
+	select {
+	case got := <-received:
+		if !bytes.Equal(got, []byte(h2Preface+"POST")) {
+			t.Fatalf("upstream received %q, want the full stream %q.\nThe parser consumed the "+
+				"preface to make its decision and restored it on session.Ingress; relaying "+
+				"anything else forwards a truncated stream and the server resets it.",
+				got, h2Preface+"POST")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("upstream received nothing within the deadline. Either the declined connection " +
+			"was not relayed at all, or it was relayed from a conn positioned PAST the bytes " +
+			"the parser consumed — the preface is gone, so the reader below never fills.")
+	}
+
+}
+
+// TestDeclineClassification: only a wrapped ErrParserDeclined diverts.
+// Classification is deliberately a pure errors.Is at each call site rather
+// than folded into relayDeclinedConn — fusing the check with a blocking
+// relay meant `false &&` could delete a call site's effect while traffic
+// still flowed, so no test could tell an honoured result from an ignored
+// one.
+func TestDeclineClassification(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"wrapped sentinel is a decline", fmt.Errorf("port: %w", integrations.ErrParserDeclined), true},
+		{"nil means the parser handled it", nil, false},
+		{"a real error keeps its own handling", errors.New("decode failed"), false},
+		{"a wrapped unrelated error is not a decline", fmt.Errorf("ctx: %w", context.Canceled), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := errors.Is(tc.err, integrations.ErrParserDeclined); got != tc.want {
+				t.Fatalf("errors.Is(%v, ErrParserDeclined) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEveryLegacyRecordDispatchHandlesDeclines pins EVERY call site, not
+// just the one the behavioural test drives.
+//
+// The behavioural test only exercises recordMySQLOutgoing, so deleting the
+// check at the matched-parser site — the path a gRPC parser actually takes,
+// and the one carrying the reported bug — left the whole package green. A
+// per-function comparison catches it, which is the shape
+// dispatch_gate_test.go already converged on for the same class of gap.
+func TestEveryLegacyRecordDispatchHandlesDeclines(t *testing.T) {
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+
+	// recordViaSupervisor is exempt: the supervisor turns a parser error
+	// into FallthroughToPassthrough itself, with a correctly scoped window.
+	const exempt = "recordViaSupervisor"
+	exemptSeen := false
+	var totalLegacy int
+
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			if fn.Name.Name == exempt {
+				exemptSeen = true
+				continue
+			}
+			var legacy, handled int
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				if call, ok := n.(*ast.CallExpr); ok {
+					if f, ok := call.Fun.(*ast.SelectorExpr); ok && f.Sel.Name == "RecordOutgoing" {
+						legacy++
+					}
+					return true
+				}
+				ifStmt, ok := n.(*ast.IfStmt)
+				if !ok || !bodyCalls(ifStmt.Body, "relayDeclinedConn") {
+					return true
+				}
+				// The call existing is not enough. Counting call
+				// EXPRESSIONS is what let `if false && errors.Is(...)`
+				// delete the entire fix and stay green — the expression is
+				// still there, it just never runs. So require the guard's
+				// condition to be EXACTLY errors.Is(x, ErrParserDeclined):
+				// a `false &&` or a `!` makes the condition a Binary/Unary
+				// expression rather than that call, and stops counting.
+				if isDeclineCheck(ifStmt.Cond) {
+					handled++
+				}
+				return true
+			})
+			// recordMySQLOutgoing also relays a SYNTHESIZED decline (an
+			// unregistered parser), guarded by `mysqlParser == nil` rather
+			// than by errors.Is. It is a real handled site, so credit it —
+			// but only for that one named shape, so the credit cannot
+			// silently absorb a deleted errors.Is guard.
+			handled += countNilParserDeclines(fn.Body)
+
+			totalLegacy += legacy
+			if legacy > 0 && handled < legacy {
+				t.Errorf("%s (%s) has %d legacy RecordOutgoing dispatch site(s) but handles a "+
+					"decline only %d time(s). A parser that matches and then declines returns "+
+					"the sentinel; an unhandled site falls through to the deferred close and "+
+					"drops the user's connection. Note a site only counts when its guard is "+
+					"exactly errors.Is(err, integrations.ErrParserDeclined) — a `false &&` or a "+
+					"negation leaves the call in place but never reaches it.",
+					fn.Name.Name, name, legacy, handled)
+			}
+		}
+	}
+	if totalLegacy == 0 {
+		t.Fatal("found no RecordOutgoing dispatch sites; this pin has stopped looking at anything")
+	}
+	if !exemptSeen {
+		t.Errorf("the %q exemption matched no function — update or drop it", exempt)
+	}
+}
+
+func p0() *Proxy { return &Proxy{logger: zap.NewNop()} }
+
+// decliningParser matches, then declines — the shape gRPC takes when the
+// destination port is outside its allowlist.
+type decliningParser struct{ recordingMySQLParser }
+
+func (d *decliningParser) RecordOutgoing(_ context.Context, _ *integrations.RecordSession) error {
+	return fmt.Errorf("destination port 8080 not in allowlist: %w", integrations.ErrParserDeclined)
+}
+
+// TestRecordMySQLOutgoing_DeclineRelaysRatherThanDropping is the
+// BEHAVIOURAL dispatcher pin.
+//
+// The AST pin below only sees that the call exists — `if false && declined`
+// deletes the entire fix and leaves it green, which is the same decoy
+// defeat dispatch_gate_test.go already documents. This drives a real
+// dispatch function with a parser that declines and asserts the client
+// connection is still alive and relaying afterwards, which no source scan
+// can express.
+func TestRecordMySQLOutgoing_DeclineRelaysRatherThanDropping(t *testing.T) {
+	upstream, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = upstream.Close() }()
+	go func() {
+		c, err := upstream.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = c.Close() }()
+		_, _ = io.Copy(c, c) // echo
+	}()
+
+	parser := &decliningParser{}
+	p := &Proxy{
+		logger:                     zap.NewNop(),
+		Integrations:               map[integrations.IntegrationType]integrations.Integrations{integrations.MYSQL: parser},
+		recordBufferCap:            8 << 20,
+		recordBufferQueueSize:      64,
+		recordBufferStallGrace:     5 * time.Second,
+		recordBufferHalfCloseGrace: 5 * time.Second,
+	}
+
+	appSide, proxySide, cleanupPair := tcpConnPair(t)
+	defer cleanupPair()
+	defer func() { _ = appSide.Close() }()
+	dstConn, err := net.DialTimeout("tcp", upstream.Addr().String(), 5*time.Second)
+	if err != nil {
+		t.Fatalf("dial upstream: %v", err)
+	}
+	defer func() { _ = dstConn.Close() }()
+
+	src, dst := proxySide, dstConn
+	upgrader := util.NewConnTLSUpgrader(&src, &dst, zap.NewNop(), nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	errGrp, gctx := errgroup.WithContext(ctx)
+	ctx = context.WithValue(gctx, models.ErrGroupKey, errGrp)
+	ctx = context.WithValue(ctx, models.ClientConnectionIDKey, "1")
+	ctx = context.WithValue(ctx, models.DestConnectionIDKey, "2")
+
+	go func() {
+		_ = p.recordMySQLOutgoing(ctx, proxySide, dstConn, make(chan *models.Mock, 8), errGrp,
+			zap.NewNop(), 1, 2, models.OutgoingOptions{}, upgrader)
+	}()
+
+	// If the decline relayed, the echo comes back. If the dispatcher treated
+	// the decline as "handled", the caller's deferred close drops this.
+	if _, err := appSide.Write([]byte("ping")); err != nil {
+		t.Fatalf("app write: %v", err)
+	}
+	_ = appSide.SetReadDeadline(time.Now().Add(10 * time.Second))
+	buf := make([]byte, 4)
+	if _, err := io.ReadFull(appSide, buf); err != nil {
+		t.Fatalf("the declined connection did not relay: %v.\nA parser that declines must leave "+
+			"user traffic flowing; dropping the connection is keploy ending one it merely chose "+
+			"not to parse.", err)
+	}
+	if string(buf) != "ping" {
+		t.Fatalf("relayed %q, want %q", buf, "ping")
+	}
+}
+
+// bodyCalls reports whether blk contains a call to the named function.
+func bodyCalls(blk *ast.BlockStmt, name string) bool {
+	found := false
+	ast.Inspect(blk, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if f, ok := call.Fun.(*ast.SelectorExpr); ok && f.Sel.Name == name {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+// isDeclineCheck reports whether cond is literally
+// errors.Is(<anything>, integrations.ErrParserDeclined).
+//
+// Anything else — a negation, a && with a constant, a different sentinel,
+// swapped arguments — is not a decline check, however much it looks like
+// one at a glance.
+func isDeclineCheck(cond ast.Expr) bool {
+	call, ok := cond.(*ast.CallExpr)
+	if !ok || len(call.Args) != 2 {
+		return false
+	}
+	fn, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || fn.Sel.Name != "Is" {
+		return false
+	}
+	pkg, ok := fn.X.(*ast.Ident)
+	if !ok || pkg.Name != "errors" {
+		return false
+	}
+	sentinel, ok := call.Args[1].(*ast.SelectorExpr)
+	return ok && sentinel.Sel.Name == "ErrParserDeclined"
+}
+
+// countNilParserDeclines counts `if <parser> == nil { ... relayDeclinedConn ... }`
+// blocks — the synthesized decline for a build with no parser registered.
+func countNilParserDeclines(blk *ast.BlockStmt) int {
+	n := 0
+	ast.Inspect(blk, func(node ast.Node) bool {
+		ifStmt, ok := node.(*ast.IfStmt)
+		if !ok || !bodyCalls(ifStmt.Body, "relayDeclinedConn") {
+			return true
+		}
+		bin, ok := ifStmt.Cond.(*ast.BinaryExpr)
+		if !ok || bin.Op != token.EQL {
+			return true
+		}
+		if rhs, ok := bin.Y.(*ast.Ident); ok && rhs.Name == "nil" {
+			n++
+		}
+		return true
+	})
+	return n
+}
+
+// TestRelayDeclinedConn_ForwardsTheHalfClose is why the declined relay does
+// NOT go through globalPassThrough.
+//
+// globalPassThrough never calls CloseWrite on either side and returns on
+// io.EOF, so a client doing shutdown(SHUT_WR) — the end-of-request signal
+// for every EOF-delimited exchange — makes the relay return, and
+// handleConnection's deferred close then tears down BOTH sockets. The
+// upstream never learns the request ended, never replies, and the user's
+// connection dies one round trip later than before. That is the same bug
+// this whole change exists to remove, so relaying through a passthrough
+// that cannot carry a FIN would have shipped it again.
+func TestRelayDeclinedConn_ForwardsTheHalfClose(t *testing.T) {
+	upstream, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = upstream.Close() }()
+
+	replied := make(chan error, 1)
+	go func() {
+		c, err := upstream.Accept()
+		if err != nil {
+			replied <- err
+			return
+		}
+		defer func() { _ = c.Close() }()
+		// Reads until EOF: it only ever returns if the client's FIN is
+		// forwarded through the relay.
+		body, err := io.ReadAll(c)
+		if err != nil {
+			replied <- err
+			return
+		}
+		if string(body) != "request" {
+			replied <- fmt.Errorf("upstream got %q, want %q", body, "request")
+			return
+		}
+		_, err = c.Write([]byte("reply"))
+		replied <- err
+	}()
+
+	appSide, proxySide, cleanupPair := tcpConnPair(t)
+	defer cleanupPair()
+	defer func() { _ = appSide.Close() }()
+	dstConn, err := net.DialTimeout("tcp", upstream.Addr().String(), 5*time.Second)
+	if err != nil {
+		t.Fatalf("dial upstream: %v", err)
+	}
+	defer func() { _ = dstConn.Close() }()
+
+	session := &integrations.RecordSession{
+		Ingress: util.NewSafeConn(proxySide, zap.NewNop()),
+		Egress:  util.NewSafeConn(dstConn, zap.NewNop()),
+	}
+
+	// A fully populated ctx on purpose. The point of this test is the FIN,
+	// so it must not be able to "pass" because some other passthrough
+	// implementation panicked on a missing context value before it ever got
+	// to the half-close — globalPassThrough does unchecked .(string)
+	// assertions on all three of these.
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	errGrp, gctx := errgroup.WithContext(ctx)
+	ctx = context.WithValue(gctx, models.ErrGroupKey, errGrp)
+	ctx = context.WithValue(ctx, models.ClientConnectionIDKey, "1")
+	ctx = context.WithValue(ctx, models.DestConnectionIDKey, "2")
+
+	declined := fmt.Errorf("port not in allowlist: %w", integrations.ErrParserDeclined)
+	go func() {
+		_ = p0().relayDeclinedConn(ctx, declined, zap.NewNop(), integrations.GRPC, session)
+	}()
+
+	if _, err := appSide.Write([]byte("request")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if tc, ok := appSide.(*net.TCPConn); ok {
+		if err := tc.CloseWrite(); err != nil {
+			t.Fatalf("half-close: %v", err)
+		}
+	}
+
+	select {
+	case err := <-replied:
+		if err != nil {
+			t.Fatalf("upstream: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the upstream never saw the client's FIN, so it never replied. A declined " +
+			"connection relayed through a passthrough that drops half-close ends the user's " +
+			"request instead of forwarding it — the same failure this change exists to fix.")
+	}
+
+	_ = appSide.SetReadDeadline(time.Now().Add(5 * time.Second))
+	got := make([]byte, len("reply"))
+	if _, err := io.ReadFull(appSide, got); err != nil {
+		t.Fatalf("client never received the reply after half-closing: %v", err)
+	}
+	if string(got) != "reply" {
+		t.Fatalf("client got %q, want %q", got, "reply")
+	}
+}

--- a/pkg/agent/proxy/integrations/generic/drain_test.go
+++ b/pkg/agent/proxy/integrations/generic/drain_test.go
@@ -1,0 +1,293 @@
+package generic
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	proxyutil "go.keploy.io/server/v3/pkg/agent/proxy/util"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// testDrainIdle keeps these quick; the drain's logic does not depend on
+// the size of the window, only on whether the survivor moved bytes during
+// one. The production value is pinned separately, in the util package.
+const testDrainIdle = 400 * time.Millisecond
+
+// splitReadConn fails on Read while Write keeps working — what Go's
+// tls.Conn does, since it keeps c.in.err and c.out.err separate. Recording
+// reaches encodeGeneric with SafeConns over *tls.Conn on every
+// TLS-intercepted path, so one direction failing while the other stays
+// healthy is the real case, not a contrivance.
+type splitReadConn struct {
+	net.Conn
+	readErr error
+}
+
+func (c *splitReadConn) Read(p []byte) (int, error) {
+	if c.readErr != nil {
+		return 0, c.readErr
+	}
+	return c.Conn.Read(p)
+}
+
+// Delegated because embedding net.Conn as an INTERFACE promotes only
+// net.Conn's method set — a fake that silently swallows CloseWrite
+// certifies nothing about a path whose whole subject is the FIN.
+func (c *splitReadConn) CloseWrite() error { return proxyutil.CloseWriteIfPossible(c.Conn) }
+
+// TestEncodeGeneric_DrainsTheSurvivorInBothDirections is the generic-path
+// twin of the relay's drain test. What it loses when it goes wrong is
+// worse than the relay's: the user's bytes AND the mocks the tee captured
+// from them.
+//
+// Scope it honestly, though. encodeGeneric is reached only via
+// Generic.recordLegacy, which needs session.V2 == nil, and
+// shouldRecordViaSupervisor routes to the supervisor unless
+// newRelayDisabled(). Every in-tree parser reports IsV2() == true, so this
+// path — like http's and mysql's siblings — runs only under
+// KEPLOY_NEW_RELAY=off. It is the rollback, not the default.
+//
+// Both orientations are driven on purpose. The survivor is whichever
+// direction did NOT report, so the drain has to poll that direction's byte
+// counter; code that assumes the first result came from the first copy
+// goroutine watches the counter of the direction that just died, which
+// never advances again — the first tick reads "stalled" and the drain
+// collapses into the fixed wall clock it replaced. That is invisible in
+// one orientation and total data loss in the other.
+func TestEncodeGeneric_DrainsTheSurvivorInBothDirections(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		breakDest bool
+	}{
+		{"client read half fails, response survives", false},
+		{"upstream read half fails, request survives", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clientApp, srcProxy := prodPair(t, true)
+			destSvc, dstProxy := prodPair(t, false)
+
+			clientConn, destConn := srcProxy, dstProxy
+			var sender, receiver net.Conn
+			if tc.breakDest {
+				destConn = &splitReadConn{Conn: dstProxy, readErr: io.ErrUnexpectedEOF}
+				sender, receiver = clientApp, destSvc
+			} else {
+				clientConn = &splitReadConn{Conn: srcProxy, readErr: io.ErrUnexpectedEOF}
+				sender, receiver = destSvc, clientApp
+			}
+
+			// Paced so the transfer is still ARRIVING when the other
+			// direction breaks, and so it outlasts a whole idle window —
+			// a wall clock truncates this, an idle timer does not.
+			const chunks, chunkSize = 12, 16 * 1024
+			gap := testDrainIdle / 3
+			payload := bytes.Repeat([]byte("G"), chunks*chunkSize)
+			go func() {
+				for i := 0; i < chunks; i++ {
+					if _, err := sender.Write(payload[i*chunkSize : (i+1)*chunkSize]); err != nil {
+						return
+					}
+					time.Sleep(gap)
+				}
+			}()
+
+			got := make(chan int, 1)
+			go func() {
+				buf := make([]byte, len(payload))
+				n, _ := io.ReadFull(receiver, buf)
+				got <- n
+			}()
+
+			mocks := make(chan *models.Mock, 64)
+			returned := make(chan struct{})
+			go func() {
+				_ = encodeGenericWithDrain(context.Background(), zap.NewNop(), nil,
+					clientConn, destConn, mocks, models.OutgoingOptions{}, testDrainIdle)
+				close(returned)
+			}()
+
+			select {
+			case <-returned:
+			case <-time.After(30 * time.Second):
+				t.Fatal("encodeGeneric never returned")
+			}
+			// Model the caller: handleConnection closes the real sockets the
+			// moment this returns. Without that close the test proves nothing,
+			// because the copy goroutines would keep delivering on their own.
+			//
+			// It must be the REAL socket. SafeConn.Close is a no-op — that is
+			// the whole reason keploy cannot wake a stranded io.Copy — so
+			// closing the wrapper here would model nothing and quietly turn
+			// this into a test that passes against a truncating build.
+			closeUnderlying(t, srcProxy)
+			closeUnderlying(t, dstProxy)
+
+			select {
+			case n := <-got:
+				if n < len(payload) {
+					t.Fatalf("the surviving direction delivered %d of %d bytes over %v. On this "+
+						"path an early return or a fixed grace costs the user's bytes AND the "+
+						"mocks the tee captured from them.",
+						n, len(payload), time.Duration(chunks)*gap)
+				}
+			case <-time.After(10 * time.Second):
+				t.Fatal("reader never completed")
+			}
+		})
+	}
+}
+
+// TestCaptureTeeWriterCountsWhatItDelivered is the positive control for
+// the counter the drain polls. A tee that always reported zero would make
+// every survivor look stalled from the first tick, silently restoring the
+// wall clock — and no forwarding test would notice, because forwarding
+// still works.
+func TestCaptureTeeWriterCountsWhatItDelivered(t *testing.T) {
+	var sink bytes.Buffer
+	ch := make(chan []byte, 8)
+	tee := &captureTeeWriter{dest: &sink, ch: ch, closeOnce: &sync.Once{}}
+
+	if got := tee.delivered(); got != 0 {
+		t.Fatalf("a fresh tee reports %d bytes delivered, want 0", got)
+	}
+	if _, err := tee.Write([]byte("hello")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := tee.Write([]byte(" world")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got, want := tee.delivered(), int64(len("hello world")); got != want {
+		t.Fatalf("tee reports %d bytes delivered, want %d. The drain treats an unmoving "+
+			"count as a stalled survivor, so a counter that does not advance abandons a "+
+			"direction that is still delivering.", got, want)
+	}
+	if sink.String() != "hello world" {
+		t.Fatalf("destination got %q", sink.String())
+	}
+}
+
+// closeUnderlying closes the real socket inside a SafeConn, which is what
+// handleConnection's deferred close reaches. SafeConn's own Close is a
+// no-op, so calling it here would assert nothing.
+func closeUnderlying(t *testing.T, c net.Conn) {
+	t.Helper()
+	sc, ok := c.(*proxyutil.SafeConn)
+	if !ok {
+		t.Fatalf("expected a *proxyutil.SafeConn, got %T — production wraps both conns, and a "+
+			"raw conn here would make this test pass for the wrong reason", c)
+	}
+	_ = sc.Unwrap().Close()
+}
+
+// TestEncodeGeneric_ProductionEntryPointDrainsTheSurvivor drives
+// encodeGeneric itself, on the production window, through the survivor
+// path.
+//
+// The tests above call encodeGenericWithDrain so they can run at 400ms,
+// which means the one line that wires proxyutil.RelayDrainIdle into the
+// drain is executed but never checked. Passing a window too small to cover
+// a real transfer abandons the survivor immediately — the original bug —
+// and nothing else here would notice.
+func TestEncodeGeneric_ProductionEntryPointDrainsTheSurvivor(t *testing.T) {
+	clientApp, srcProxy := prodPair(t, true)
+	destSvc, dstProxy := prodPair(t, false)
+
+	broken := &splitReadConn{Conn: srcProxy, readErr: io.ErrUnexpectedEOF}
+
+	const chunks, chunkSize = 10, 16 * 1024
+	payload := bytes.Repeat([]byte("E"), chunks*chunkSize)
+	go func() {
+		for i := 0; i < chunks; i++ {
+			if _, err := destSvc.Write(payload[i*chunkSize : (i+1)*chunkSize]); err != nil {
+				return
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		// Ends the survivor's copy so this returns without sitting out the
+		// production idle window.
+		if tc, ok := destSvc.(*net.TCPConn); ok {
+			_ = tc.CloseWrite()
+		}
+	}()
+
+	got := make(chan int, 1)
+	go func() {
+		buf := make([]byte, len(payload))
+		n, _ := io.ReadFull(clientApp, buf)
+		got <- n
+	}()
+
+	mocks := make(chan *models.Mock, 64)
+	returned := make(chan struct{})
+	go func() {
+		_ = encodeGeneric(context.Background(), zap.NewNop(), nil, broken, dstProxy,
+			mocks, models.OutgoingOptions{})
+		close(returned)
+	}()
+	select {
+	case <-returned:
+	case <-time.After(60 * time.Second):
+		t.Fatal("encodeGeneric never returned")
+	}
+	closeUnderlying(t, srcProxy)
+	closeUnderlying(t, dstProxy)
+
+	select {
+	case n := <-got:
+		if n < len(payload) {
+			t.Fatalf("the surviving direction delivered %d of %d bytes through encodeGeneric "+
+				"on the production window. The drain is only as good as the window wired in "+
+				"at that call site.", n, len(payload))
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("reader never completed")
+	}
+}
+
+// TestEncodeGeneric_CleanThenResetReturnsPromptly guards generic's copy of
+// the early return: when both copy results are already in hand there is
+// nothing to drain, and waiting anyway costs a full idle window — 30s in
+// production — on the case the code itself calls "very common".
+func TestEncodeGeneric_CleanThenResetReturnsPromptly(t *testing.T) {
+	clientApp, srcProxy := prodPair(t, true)
+	destSvc, dstProxy := prodPair(t, false)
+
+	go func() {
+		_, _ = clientApp.Write([]byte("hello"))
+		if tc, ok := clientApp.(*net.TCPConn); ok {
+			_ = tc.CloseWrite()
+		}
+	}()
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		if tc, ok := destSvc.(*net.TCPConn); ok {
+			_ = tc.SetLinger(0)
+		}
+		_ = destSvc.Close()
+	}()
+
+	mocks := make(chan *models.Mock, 64)
+	start := time.Now()
+	returned := make(chan struct{})
+	go func() {
+		_ = encodeGenericWithDrain(context.Background(), zap.NewNop(), nil, srcProxy, dstProxy,
+			mocks, models.OutgoingOptions{}, testDrainIdle)
+		close(returned)
+	}()
+	select {
+	case <-returned:
+	case <-time.After(10 * time.Second):
+		t.Fatal("encodeGenericWithDrain never returned")
+	}
+	if elapsed := time.Since(start); elapsed > testDrainIdle*3/4 {
+		t.Fatalf("returned after %v, most of one %v window, with both copy results already "+
+			"available. In production that dead time is %v per clean-then-reset connection.",
+			elapsed, testDrainIdle, proxyutil.RelayDrainIdle)
+	}
+}

--- a/pkg/agent/proxy/integrations/generic/encode.go
+++ b/pkg/agent/proxy/integrations/generic/encode.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	proxyutil "go.keploy.io/server/v3/pkg/agent/proxy/util"
@@ -26,7 +27,16 @@ type captureTeeWriter struct {
 	ch        chan []byte
 	stopped   bool
 	closeOnce *sync.Once // shared with the forwarding goroutine's defer close
+
+	// n counts bytes that actually reached dest. The drain polls it from
+	// the caller's goroutine while this tee is still being written by its
+	// own copy goroutine, so it has to be atomic; stopped stays a plain
+	// bool because only the copy goroutine ever touches it.
+	n atomic.Int64
 }
+
+// delivered reports how many bytes this direction has handed on.
+func (w *captureTeeWriter) delivered() int64 { return w.n.Load() }
 
 func (w *captureTeeWriter) stop() {
 	w.stopped = true
@@ -38,6 +48,7 @@ func (w *captureTeeWriter) stop() {
 func (w *captureTeeWriter) Write(p []byte) (int, error) {
 	// Forward to destination first — this is the critical path.
 	n, err := w.dest.Write(p)
+	w.n.Add(int64(n))
 	if err != nil {
 		return n, err
 	}
@@ -59,6 +70,14 @@ func (w *captureTeeWriter) Write(p []byte) (int, error) {
 }
 
 func encodeGeneric(ctx context.Context, logger *zap.Logger, reqBuf []byte, clientConn, destConn net.Conn, mocks chan<- *models.Mock, opts models.OutgoingOptions) error {
+	return encodeGenericWithDrain(ctx, logger, reqBuf, clientConn, destConn, mocks, opts, proxyutil.RelayDrainIdle)
+}
+
+// encodeGenericWithDrain is encodeGeneric with the survivor drain's idle
+// window as a parameter, so tests can drive the drain without waiting out
+// the production window. Production has exactly one caller, above, and it
+// always passes proxyutil.RelayDrainIdle.
+func encodeGenericWithDrain(ctx context.Context, logger *zap.Logger, reqBuf []byte, clientConn, destConn net.Conn, mocks chan<- *models.Mock, opts models.OutgoingOptions, drainIdle time.Duration) error {
 
 	// Forward initial request buffer to destination immediately.
 	_, err := destConn.Write(reqBuf)
@@ -92,11 +111,28 @@ func encodeGeneric(ctx context.Context, logger *zap.Logger, reqBuf []byte, clien
 	clientCloseOnce := &sync.Once{}
 	destCloseOnce := &sync.Once{}
 
-	done := make(chan struct{}, 2)
+	// Buffered and error-carrying: a broken direction must not strand the
+	// other. The two directions do NOT necessarily fail together — these are
+	// SafeConns over *tls.Conn on TLS-intercepted paths, and tls.Conn keeps
+	// its read and write halves' errors separate — so the survivor may still
+	// have decrypted bytes to deliver. Give it an idle window rather than
+	// waiting forever or cutting it off at once.
+	//
+	// The result carries the direction's index, not just its error. The
+	// survivor to drain is whichever direction did NOT report, and a bare
+	// error cannot say which that is — guessing watches the byte counter
+	// of the direction that just died, which never moves again, and
+	// collapses the idle drain back into a single fixed wait.
+	done := make(chan copyOutcome, 2)
+	// Built before either goroutine starts: the drain reads whichever tee
+	// belongs to the survivor.
+	tees := [2]*captureTeeWriter{
+		{dest: destConn, ch: clientCapChan, closeOnce: clientCloseOnce},
+		{dest: clientConn, ch: destCapChan, closeOnce: destCloseOnce},
+	}
 	go func() {
 		defer clientCloseOnce.Do(func() { close(clientCapChan) })
-		tee := &captureTeeWriter{dest: destConn, ch: clientCapChan, closeOnce: clientCloseOnce}
-		_, err := io.Copy(tee, clientConn)
+		_, err := io.Copy(tees[0], clientConn)
 		// Close the capture channel BEFORE the FIN: forwardFIN can write
 		// a close_notify on a TLS conn, and SafeConn's write deadline is
 		// a no-op, so a stalled peer would otherwise hold
@@ -104,20 +140,48 @@ func encodeGeneric(ctx context.Context, logger *zap.Logger, reqBuf []byte, clien
 		// sync.Once, so this is the early half of the same close.
 		clientCloseOnce.Do(func() { close(clientCapChan) })
 		forwardFIN(destConn, err)
-		done <- struct{}{}
+		done <- copyOutcome{idx: 0, err: err}
 	}()
 	go func() {
 		defer destCloseOnce.Do(func() { close(destCapChan) })
-		tee := &captureTeeWriter{dest: clientConn, ch: destCapChan, closeOnce: destCloseOnce}
-		_, err := io.Copy(tee, destConn)
+		_, err := io.Copy(tees[1], destConn)
 		destCloseOnce.Do(func() { close(destCapChan) })
 		forwardFIN(clientConn, err)
-		done <- struct{}{}
+		done <- copyOutcome{idx: 1, err: err}
 	}()
-	<-done
-	<-done
+
+	for i := 0; i < 2; i++ {
+		res := <-done
+		if res.err == nil {
+			continue
+		}
+		// Both results are already in hand on the second iteration — there
+		// is nothing left to drain, and waiting would hold the caller for a
+		// full idle window on the very common "one side ends cleanly, the
+		// other resets".
+		if i == 1 {
+			return nil
+		}
+		// Give the surviving direction a chance to finish. Returning at once
+		// would let the caller's deferred close truncate it, and on this
+		// path that costs the user's bytes AND the mocks the tee captured.
+		// Waiting a fixed grace instead is the same bug wearing a longer
+		// coat: it cuts off a response that is still arriving, just later.
+		// Wait while it is delivering, and stop when it stalls.
+		//
+		// A copy error is a peer/socket condition, not a parser fault, so
+		// the dispatcher still sees nil.
+		proxyutil.WaitForSurvivor(done, tees[1-res.idx].delivered, drainIdle)
+		return nil
+	}
 
 	return nil
+}
+
+// copyOutcome reports which forwarding direction ended, and how.
+type copyOutcome struct {
+	idx int
+	err error
 }
 
 // forwardFIN half-closes dst when the copy that fed it ended cleanly.
@@ -146,16 +210,11 @@ func forwardFIN(dst net.Conn, copyErr error) {
 
 // forwardBidirectional does raw TCP passthrough without any capture.
 func forwardBidirectional(clientConn, destConn net.Conn) error {
-	done := make(chan struct{}, 2)
-	cp := func(dst, src net.Conn) {
-		_, err := io.Copy(dst, src)
-		forwardFIN(dst, err)
-		done <- struct{}{}
-	}
-	go cp(destConn, clientConn)
-	go cp(clientConn, destConn)
-	<-done
-	<-done
+	// This is generic's memory-pressure fallback and was a verbatim copy of
+	// http's and mysql's. It gets the shared implementation — including the
+	// bounded drain, without which a broken direction either wedges the
+	// caller or truncates the surviving one.
+	proxyutil.RelayRawPassthrough(clientConn, destConn)
 	return nil
 }
 

--- a/pkg/agent/proxy/integrations/http/encode.go
+++ b/pkg/agent/proxy/integrations/http/encode.go
@@ -439,30 +439,16 @@ func (h *HTTP) encodeHTTP(ctx context.Context, reqBuf []byte, clientConn, destCo
 	}
 }
 
-// relayRawPassthrough copies both directions to completion and forwards
-// each side's FIN, for the memory-pressure fallback where nothing is
-// captured.
+// relayRawPassthrough is the memory-pressure fallback: nothing is
+// captured, bytes are just relayed.
 //
-// Extracted so it can be tested. Inline inside the memoryguard branch it
-// was unreachable from a unit test — memoryguard's paused flag is
-// unexported — so the FIN forwarding here was shipped uncovered, which is
-// exactly how the same one-liner went out as a silent no-op elsewhere in
-// this change.
-//
-// The FIN is gated on a clean io.Copy: a read error, a reset, or a failed
-// write to the peer all exit that loop too, and forwarding a FIN for those
-// tells the peer "the request is complete" about a truncated message.
+// It delegates to proxyutil.RelayRawPassthrough. http and mysql shared
+// this verbatim; generic had the same logic with the FIN factored into a
+// forwardFIN helper. See that function for the two rules
+// it enforces — forward the FIN only on a clean EOF, and give a surviving
+// direction a bounded drain when the other breaks rather than waiting for
+// it forever or abandoning it at once.
+
 func relayRawPassthrough(clientConn, destConn net.Conn) {
-	done := make(chan struct{}, 2)
-	cp := func(dst, src net.Conn) {
-		_, err := io.Copy(dst, src)
-		if err == nil {
-			_ = proxyutil.CloseWriteIfPossible(dst)
-		}
-		done <- struct{}{}
-	}
-	go cp(destConn, clientConn)
-	go cp(clientConn, destConn)
-	<-done
-	<-done
+	proxyutil.RelayRawPassthrough(clientConn, destConn)
 }

--- a/pkg/agent/proxy/integrations/integrations.go
+++ b/pkg/agent/proxy/integrations/integrations.go
@@ -3,12 +3,62 @@ package integrations
 
 import (
 	"context"
+	"errors"
 	"net"
 	"time"
 
 	"go.keploy.io/server/v3/pkg/models"
 	"go.uber.org/zap"
 )
+
+// ErrParserDeclined is returned by a parser that MATCHED a connection but
+// then decided not to handle it — a port outside its allowlist, a kill
+// switch, an unsupported sub-protocol.
+//
+// It exists because "return nil" cannot express that. The dispatcher reads
+// a nil error as "the parser handled this connection", logs success, and
+// falls through to handleConnection's deferred close — so a parser that
+// bailed politely had the user's connection torn down under it, which is
+// an I1 violation (keploy must never be what ends a connection). Parsers
+// documented that returning nil would "pass through"; it did not.
+//
+// Wrap it (fmt.Errorf("...: %w", integrations.ErrParserDeclined)) to carry
+// the reason.
+//
+// CONTRACT, and both clauses are load-bearing:
+//
+//  1. If the parser READ from a connection to make its decision, it must
+//     restore those bytes on the RecordSession conn it read from —
+//     RecordSession.Ingress and/or RecordSession.Egress. The dispatcher
+//     relays the SESSION's conns, not handleConnection's own, precisely so
+//     a consumed protocol preamble is not lost. Relaying a drained stream
+//     makes the peer reset the connection, which moves the user's break
+//     rather than removing it.
+//
+//     Note this is integrations.RecordSession, NOT supervisor.Session.
+//     supervisor.Session also has an Ingress field, but it is nil on the
+//     V2 path and ignored — bytes restored there vanish silently.
+//
+//     A parser that upgraded the connection to TLS before declining must
+//     not rely on this: util.ConnTLSUpgrader writes the upgraded conn back
+//     through handleConnection's pointers, not into RecordSession, so the
+//     session's Egress is the pre-upgrade socket.
+//
+//  2. The parser must not leave goroutines reading those conns. The relay
+//     becomes the sole reader; a surviving parser reader races it for
+//     bytes on the same socket.
+//
+// SCOPE: honoured on every legacy RECORD dispatch site — the
+// matched-parser branch, the generic catch-all, and the MySQL probe
+// branch. On the V2/supervisor path the sentinel is not consulted, but a
+// parser error there already becomes FallthroughToPassthrough with a
+// correctly activity-scoped orphan window, which is the better shape.
+//
+// On replay there is no upstream connection to relay to — every
+// destination dial in handleConnection is mode-gated — so a parser that
+// needs to decline during replay is not yet supported and must not rely
+// on this.
+var ErrParserDeclined = errors.New("parser declined to handle this connection")
 
 type Initializer func(logger *zap.Logger) Integrations
 

--- a/pkg/agent/proxy/integrations/mysql/recorder/query.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/query.go
@@ -1364,30 +1364,16 @@ func binaryRowHeadersOf(rows []*mysql.BinaryRow) []mysql.Header {
 	return out
 }
 
-// relayRawPassthrough copies both directions to completion and forwards
-// each side's FIN, for the memory-pressure fallback where nothing is
-// captured.
+// relayRawPassthrough is the memory-pressure fallback: nothing is
+// captured, bytes are just relayed.
 //
-// Extracted so it can be tested. Inline inside the memoryguard branch it
-// was unreachable from a unit test — memoryguard's paused flag is
-// unexported — so the FIN forwarding here was shipped uncovered, which is
-// exactly how the same one-liner went out as a silent no-op elsewhere in
-// this change.
-//
-// The FIN is gated on a clean io.Copy: a read error, a reset, or a failed
-// write to the peer all exit that loop too, and forwarding a FIN for those
-// tells the peer "the request is complete" about a truncated message.
+// It delegates to proxyutil.RelayRawPassthrough. http and mysql shared
+// this verbatim; generic had the same logic with the FIN factored into a
+// forwardFIN helper. See that function for the two rules
+// it enforces — forward the FIN only on a clean EOF, and give a surviving
+// direction a bounded drain when the other breaks rather than waiting for
+// it forever or abandoning it at once.
+
 func relayRawPassthrough(clientConn, destConn net.Conn) {
-	done := make(chan struct{}, 2)
-	cp := func(dst, src net.Conn) {
-		_, err := io.Copy(dst, src)
-		if err == nil {
-			_ = proxyutil.CloseWriteIfPossible(dst)
-		}
-		done <- struct{}{}
-	}
-	go cp(destConn, clientConn)
-	go cp(clientConn, destConn)
-	<-done
-	<-done
+	proxyutil.RelayRawPassthrough(clientConn, destConn)
 }

--- a/pkg/agent/proxy/mysql_dispatch_test.go
+++ b/pkg/agent/proxy/mysql_dispatch_test.go
@@ -173,11 +173,30 @@ func tcpConnPair(t *testing.T) (client, server net.Conn, cleanup func()) {
 	}
 }
 
-// TestRecordMySQLOutgoing_UnregisteredParser covers the guard that stops
-// an unregistered build nil-panicking. The probe's configured-port and
-// known-port verdicts return IsMySQL without checking registration, so
-// this is reachable on a build that omits the parser.
+// TestRecordMySQLOutgoing_UnregisteredParser covers the case where the
+// probe says IsMySQL but no parser is registered — reachable on a build
+// that omits it, because the configured-port and known-port verdicts never
+// check registration.
+//
+// It used to nil-panic; then it returned an error, which unwound to
+// handleConnection's deferred close and dropped the user's connection.
+// Neither is right: not having a parser is a reason to stop PARSING, not a
+// reason to end someone's connection. It now relays.
 func TestRecordMySQLOutgoing_UnregisteredParser(t *testing.T) {
+	upstream, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = upstream.Close() }()
+	go func() {
+		c, err := upstream.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = c.Close() }()
+		_, _ = io.Copy(c, c)
+	}()
+
 	p := &Proxy{
 		logger:                     zap.NewNop(),
 		Integrations:               map[integrations.IntegrationType]integrations.Integrations{},
@@ -186,20 +205,37 @@ func TestRecordMySQLOutgoing_UnregisteredParser(t *testing.T) {
 		recordBufferStallGrace:     5 * time.Second,
 		recordBufferHalfCloseGrace: 5 * time.Second,
 	}
-	srcRaw, dstRaw, cleanup := tcpConnPair(t)
+
+	appSide, proxySide, cleanup := tcpConnPair(t)
 	defer cleanup()
-	src, dst := srcRaw, dstRaw
+	dstConn, err := net.DialTimeout("tcp", upstream.Addr().String(), 5*time.Second)
+	if err != nil {
+		t.Fatalf("dial upstream: %v", err)
+	}
+	defer func() { _ = dstConn.Close() }()
+
+	src, dst := proxySide, dstConn
 	upgrader := util.NewConnTLSUpgrader(&src, &dst, zap.NewNop(), nil)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 	errGrp, gctx := errgroup.WithContext(ctx)
+	ctx = context.WithValue(gctx, models.ErrGroupKey, errGrp)
+	ctx = context.WithValue(ctx, models.ClientConnectionIDKey, "1")
+	ctx = context.WithValue(ctx, models.DestConnectionIDKey, "2")
 
-	err := p.recordMySQLOutgoing(gctx, srcRaw, dstRaw, make(chan *models.Mock, 1), errGrp,
-		zap.NewNop(), 1, 2, models.OutgoingOptions{}, upgrader)
-	if err == nil {
-		t.Fatal("an unregistered MySQL parser returned no error; the legacy path would have " +
-			"nil-panicked on p.Integrations[MYSQL].RecordOutgoing")
+	go func() {
+		_ = p.recordMySQLOutgoing(ctx, proxySide, dstConn, make(chan *models.Mock, 1), errGrp,
+			zap.NewNop(), 1, 2, models.OutgoingOptions{}, upgrader)
+	}()
+
+	if _, err := appSide.Write([]byte("ping")); err != nil {
+		t.Fatalf("app write: %v", err)
+	}
+	_ = appSide.SetReadDeadline(time.Now().Add(10 * time.Second))
+	buf := make([]byte, 4)
+	if _, err := io.ReadFull(appSide, buf); err != nil {
+		t.Fatalf("an unregistered parser dropped the connection instead of relaying it: %v", err)
 	}
 }
 

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -1072,9 +1072,11 @@ func (p *Proxy) recordMySQLOutgoing(
 	// (the configured-port and known-port verdicts never check), so the
 	// legacy path would nil-panic on an unregistered build.
 	if mysqlParser == nil {
-		utils.LogError(mysqlLogger, nil, "no MySQL parser is registered",
-			zap.String("next_step", "the MySQL probe matched but integrations.MYSQL is absent from p.Integrations; this is a build/registration bug"))
-		return errors.New("mysql parser not registered")
+		// This is a decline, not a failure: relay rather than letting the
+		// caller's deferred close drop the connection.
+		declined := fmt.Errorf("no MySQL parser is registered: %w", integrations.ErrParserDeclined)
+		return p.relayDeclinedConn(parserCtx, declined, mysqlLogger, integrations.MYSQL,
+			mysqlSessionForRelay(srcConn, dstConn, mysqlLogger))
 	}
 
 	mysqlSession := &integrations.RecordSession{
@@ -1090,10 +1092,126 @@ func (p *Proxy) recordMySQLOutgoing(
 	}
 
 	if err := mysqlParser.RecordOutgoing(parserCtx, mysqlSession); err != nil {
+		// A decline is not a failure: relay rather than letting the caller's
+		// deferred close drop a connection keploy merely chose not to parse.
+		if errors.Is(err, integrations.ErrParserDeclined) {
+			return p.relayDeclinedConn(parserCtx, err, mysqlLogger, integrations.MYSQL, mysqlSession)
+		}
 		utils.LogError(p.logger, err, "failed to record the outgoing message")
 		return err
 	}
 	return nil
+}
+
+// mysqlSessionForRelay builds the minimal RecordSession the decline relay
+// needs when there is no parser to build a full one for.
+func mysqlSessionForRelay(srcConn, dstConn net.Conn, logger *zap.Logger) *integrations.RecordSession {
+	return &integrations.RecordSession{
+		Ingress: util.NewSafeConn(srcConn, logger),
+		Egress:  util.NewSafeConn(dstConn, logger),
+	}
+}
+
+// relayDeclinedConn relays a connection whose parser MATCHED it and then
+// declined it (port allowlist, kill switch, unsupported sub-protocol),
+// signalled by wrapping integrations.ErrParserDeclined.
+//
+// Without this the connection is left to handleConnection's deferred
+// close. That close is the bug: a declining parser returned nil, the
+// dispatcher logged "successfully recorded outgoing message", and the
+// user's connection was torn down — while the parser's own docs promised
+// the proxy would "treat the connection as a pass-through".
+//
+// The caller decides what a decline is; this function is only reached
+// once errors.Is(err, integrations.ErrParserDeclined) has already said
+// yes. It returns error to match the dispatch sites it returns through,
+// and that error is always nil: a relay ending is not a record failure.
+//
+// It relays the SESSION's conns, not handleConnection's srcConn/dstConn
+// locals, and that is load-bearing. A parser must read bytes to decide
+// whether it wants the connection — gRPC reads the HTTP/2 preface — and
+// it restores them by wrapping session.Ingress. handleConnection's local
+// still points at the drained socket, so relaying that sends a
+// preface-less stream and a real server answers GOAWAY(PROTOCOL_ERROR).
+// The user's break would move rather than disappear.
+//
+// RECORD ONLY. dstConn is nil at every dispatch site in MODE_TEST, so
+// there is no upstream to relay to; a parser that needs to decline during
+// replay should fall through to the generic mock path, which is a
+// separate change. (Note this is a property of the DISPATCH SITES, not of
+// the whole file: proxy.go also dials in MODE_TEST when !rule.Mocking,
+// and in any mode under GlobalPassthrough — both return before dispatch.)
+//
+// WHY util.RelayRawPassthrough AND NOT globalPassThrough. globalPassThrough
+// never calls CloseWrite on either side and returns on io.EOF, so a
+// client that does shutdown(SHUT_WR) — the end-of-request signal for
+// every EOF-delimited exchange — ends the connection instead of getting
+// its reply. Relaying through it would re-break, one round trip later,
+// the exact thing this function exists to stop breaking. That is also why
+// recordViaSupervisor refuses it (proxy_v2.go: "Critically we do NOT call
+// globalPassThrough here"). RelayRawPassthrough forwards the FIN on a
+// clean EOF and lets a surviving direction finish, which is what a
+// pass-through has to mean.
+//
+// WHY NO ORPHAN WINDOW. Nothing is captured on this connection from here
+// on, so the test cases recorded over the same window will fail at replay
+// with match_phase=no_mocks. Suppressing them was tried and removed: the
+// orphan window is a TIME range read by the GLOBAL syncMock manager, so it
+// suppresses every test case that overlaps it, including ones on
+// unrelated, fully captured connections. Activity-scoping only narrows the
+// range, never the blast radius — a busy connection never goes idle long
+// enough to close the window at all. And a decline is not a transient
+// incident like the V2 fallthrough's panic or memcap trip; it is a
+// persistent configuration state that holds for every connection, every
+// run. Suppression would turn "keploy drops my gRPC connections" into
+// "keploy hands back a recording with the passing cases stripped out",
+// which is not the better failure. The honest signal is the Warn below,
+// one per connection, which is also what the other two pass-through paths
+// (the record-mode kill switch and GlobalPassthrough) do.
+func (p *Proxy) relayDeclinedConn(ctx context.Context, err error, logger *zap.Logger, parserType integrations.IntegrationType, session *integrations.RecordSession) error {
+	if session == nil || !relayableConn(session.Ingress) || !relayableConn(session.Egress) {
+		utils.LogError(logger, err, "parser declined but the session carried no conns to relay",
+			zap.String("parser", string(parserType)))
+		return nil
+	}
+
+	// Suppressed on a clean stop, for the same reason the V2 fallthrough
+	// suppresses its own: on `keploy record` shutdown every in-flight
+	// connection unwinds at once, and telling the user their recording is
+	// incomplete at the moment they are reading the logs is noise about
+	// something that did not go wrong.
+	if ctx.Err() == nil {
+		// Warn, not Debug: this is permanent capture loss for the rest of
+		// the connection, and the user's recording is quietly smaller than
+		// they think.
+		logger.Warn("parser declined this connection; relaying raw and recording nothing for it",
+			zap.String("parser", string(parserType)),
+			zap.Error(err),
+			zap.String("next_step", "user traffic is unaffected, but nothing on this connection is captured, so its test cases will report no mocks at replay. If this is traffic keploy should record, the parser declined it deliberately — check its port allowlist or sub-protocol support"),
+		)
+	}
+
+	util.RelayRawPassthrough(session.Ingress, session.Egress)
+	return nil
+}
+
+// relayableConn reports whether c can actually be relayed.
+//
+// A nil check on the session field is not enough, and the difference is
+// not academic: buildRecordSession and mysqlSessionForRelay both wrap in
+// util.NewSafeConn, which returns a non-nil *SafeConn even around a nil
+// conn. `session.Egress == nil` is therefore false for every real caller,
+// and a nil upstream would sail straight past it into a nil dereference
+// inside the copy — recovered and swallowed, leaving the relay blocked
+// with no error anywhere.
+func relayableConn(c net.Conn) bool {
+	if c == nil {
+		return false
+	}
+	if sc, ok := c.(*util.SafeConn); ok {
+		return sc.Unwrap() != nil
+	}
+	return true
 }
 
 func (p *Proxy) buildRecordSession(
@@ -2187,6 +2305,9 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 		// unregistered build nil-panics here instead of failing cleanly.
 		mysqlMocker := p.Integrations[integrations.MYSQL]
 		if mysqlMocker == nil {
+			// Replay has no upstream to relay to, so a decline cannot be
+			// rescued here the way it is on the record path; fail cleanly
+			// rather than nil-panicking.
 			utils.LogError(p.logger, nil, "no MySQL parser is registered",
 				zap.String("next_step", "the MySQL probe matched but integrations.MYSQL is absent from p.Integrations; this is a build/registration bug"))
 			return errors.New("mysql parser not registered")
@@ -2944,6 +3065,9 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 			}
 			session := p.buildRecordSession(srcConn, dstConn, rule.MC, parserErrGrp, logger, clientConnID, destConnID, outgoingOpts, upgrader)
 			err := matchedParser.RecordOutgoing(parserCtx, session)
+			if errors.Is(err, integrations.ErrParserDeclined) {
+				return p.relayDeclinedConn(parserCtx, err, logger, parserType, session)
+			}
 			if err != nil {
 				if isNetworkClosedErr(err) {
 					logger.Debug("failed to record the outgoing message (connection closed)", zap.Error(err))
@@ -2998,6 +3122,9 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 			} else {
 				genericSession := p.buildRecordSession(srcConn, dstConn, rule.MC, parserErrGrp, logger, clientConnID, destConnID, outgoingOpts, nil)
 				err := genericParser.RecordOutgoing(parserCtx, genericSession)
+				if errors.Is(err, integrations.ErrParserDeclined) {
+					return p.relayDeclinedConn(parserCtx, err, logger, integrations.GENERIC, genericSession)
+				}
 				if err != nil && err != io.EOF && !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), "tls: user canceled") {
 					utils.LogError(logger, err, "failed to record the outgoing message")
 					return err

--- a/pkg/agent/proxy/util/relay_passthrough_test.go
+++ b/pkg/agent/proxy/util/relay_passthrough_test.go
@@ -1,0 +1,755 @@
+package util
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// testDrainIdle keeps the timing tests quick. The drain's logic does not
+// depend on the size of the window — only on whether the survivor moved
+// bytes during one — so exercising it at 400ms proves the same mechanism
+// the production window runs. What the short window cannot check is that
+// the production value is big enough to be useful; that is pinned
+// separately by TestRelayDrainIdleLeavesRoomForARealUpstream.
+const testDrainIdle = 400 * time.Millisecond
+
+func tcpPair(t *testing.T, ln net.Listener) (dialed, accepted net.Conn) {
+	t.Helper()
+	type res struct {
+		c   net.Conn
+		err error
+	}
+	ch := make(chan res, 1)
+	go func() { c, err := ln.Accept(); ch <- res{c, err} }()
+	d, err := net.DialTimeout("tcp", ln.Addr().String(), 5*time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	got := <-ch
+	if got.err != nil {
+		t.Fatalf("accept: %v", got.err)
+	}
+	return d, got.c
+}
+
+// splitHalfConn models the property that makes the drain necessary: a
+// connection whose READ half has failed while its WRITE half still works.
+//
+// That is not a plain-TCP shape — resetting a socket kills both halves —
+// but it is exactly what Go's tls.Conn does, keeping c.in.err and
+// c.out.err separate. Production reaches these functions with SafeConns
+// over *tls.Conn on every TLS-intercepted path, so this is the real case,
+// not a contrivance. Writes still go to the real socket, so the assertions
+// below are about bytes that genuinely crossed the wire.
+type splitHalfConn struct {
+	net.Conn
+	readErr error
+}
+
+func (c *splitHalfConn) Read(p []byte) (int, error) {
+	if c.readErr != nil {
+		return 0, c.readErr
+	}
+	return c.Conn.Read(p)
+}
+
+// Delegated for the same reason as deadWriteConn.CloseWrite — interface
+// embedding does not promote it. Not load-bearing for these tests (the
+// broken direction never forwards a FIN), but a fake that silently
+// swallows CloseWrite is a trap for the next person to reuse it.
+func (c *splitHalfConn) CloseWrite() error { return CloseWriteIfPossible(c.Conn) }
+
+// relayFixture wires up two real TCP pairs with one side's READ half
+// broken, and runs the relay over them.
+//
+// breakDest selects WHICH direction fails, and running every drain test
+// both ways is the point. The drain has to watch the byte counter of the
+// direction that did NOT report, and code that assumes the first result
+// came from the first goroutine is right in one orientation and silently
+// wrong in the other — it watches the dead direction's counter, which
+// never moves again, so the very first tick reads "stalled" and the drain
+// collapses back into a single fixed wait. Tests that only ever break the
+// app side certify half a function.
+type relayFixture struct {
+	appSide, appPeer   net.Conn
+	destSide, destPeer net.Conn
+	// sender writes into the relay; receiver reads what the surviving
+	// direction delivered.
+	sender, receiver net.Conn
+	relayDone        chan struct{}
+}
+
+func newRelayFixture(t *testing.T, breakDest bool, idle time.Duration) *relayFixture {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	f := &relayFixture{relayDone: make(chan struct{})}
+	f.appSide, f.appPeer = tcpPair(t, ln)
+	f.destSide, f.destPeer = tcpPair(t, ln)
+	t.Cleanup(func() {
+		_ = f.appSide.Close()
+		_ = f.appPeer.Close()
+		_ = f.destSide.Close()
+		_ = f.destPeer.Close()
+	})
+
+	clientConn, destConn := net.Conn(f.appSide), net.Conn(f.destSide)
+	if breakDest {
+		// The upstream read fails: the surviving direction is the REQUEST
+		// still being uploaded to that upstream. This is the orientation
+		// that shows up first in production — a reset or a TLS alert from
+		// the server surfaces on the dest read while the client is still
+		// mid-body.
+		destConn = &splitHalfConn{Conn: f.destSide, readErr: io.ErrUnexpectedEOF}
+		f.sender, f.receiver = f.appPeer, f.destPeer
+	} else {
+		// The client read fails: the surviving direction is the RESPONSE
+		// still being delivered to the app.
+		clientConn = &splitHalfConn{Conn: f.appSide, readErr: io.ErrUnexpectedEOF}
+		f.sender, f.receiver = f.destPeer, f.appPeer
+	}
+
+	go func() {
+		relayRawPassthrough(NewSafeConn(clientConn, zap.NewNop()), NewSafeConn(destConn, zap.NewNop()), idle)
+		close(f.relayDone)
+	}()
+	return f
+}
+
+// awaitReturnAndClose waits for the relay to return, then models
+// handleConnection: it closes the REAL sockets the moment the relay hands
+// control back. Without that close these tests prove nothing — returning
+// early is harmless on its own, since the copier goroutines keep
+// delivering; it is the caller's close that truncates them.
+func (f *relayFixture) awaitReturnAndClose(t *testing.T) {
+	t.Helper()
+	select {
+	case <-f.relayDone:
+	case <-time.After(30 * time.Second):
+		t.Fatal("relayRawPassthrough never returned; a reintroduced unconditional wait shows " +
+			"up here rather than as an opaque package timeout")
+	}
+	_ = f.appSide.Close()
+	_ = f.destSide.Close()
+}
+
+// pacedSend writes payload in chunks with a gap between them, so the
+// transfer is still ARRIVING when the other direction breaks. Blasting it
+// in one write finishes over loopback before the break lands, leaving
+// nothing in flight to truncate — which is how the first version of these
+// tests passed against a build that truncated.
+func pacedSend(c net.Conn, payload []byte, chunkSize int, gap time.Duration) {
+	go func() {
+		for off := 0; off < len(payload); off += chunkSize {
+			end := off + chunkSize
+			if end > len(payload) {
+				end = len(payload)
+			}
+			if _, err := c.Write(payload[off:end]); err != nil {
+				return
+			}
+			time.Sleep(gap)
+		}
+	}()
+}
+
+func readAllInto(c net.Conn, n int) <-chan int {
+	got := make(chan int, 1)
+	go func() {
+		buf := make([]byte, n)
+		read, _ := io.ReadFull(c, buf)
+		got <- read
+	}()
+	return got
+}
+
+// TestRelayRawPassthrough_LetsTheSurvivorFinishAfterABreak is the pin that
+// makes the early exit safe, and the one whose absence made the first
+// version of this function a data-loss regression.
+//
+// The two directions do NOT necessarily fail together. Production passes
+// SafeConns over *tls.Conn, and Go's tls.Conn keeps its read and write
+// halves' errors separate — so a read-side break leaves a healthy write
+// half with already-decrypted bytes still to deliver. Returning the
+// instant either direction errors lets the caller's deferred close land on
+// that healthy direction and truncate it.
+func TestRelayRawPassthrough_LetsTheSurvivorFinishAfterABreak(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		breakDest bool
+	}{
+		{"client read half fails, response survives", false},
+		{"upstream read half fails, request survives", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			const chunks, chunkSize = 20, 32 * 1024
+			payload := bytes.Repeat([]byte("R"), chunks*chunkSize)
+
+			f := newRelayFixture(t, tc.breakDest, testDrainIdle)
+			pacedSend(f.sender, payload, chunkSize, 5*time.Millisecond)
+			got := readAllInto(f.receiver, len(payload))
+
+			f.awaitReturnAndClose(t)
+
+			select {
+			case n := <-got:
+				if n < len(payload) {
+					t.Fatalf("the surviving direction delivered %d of %d bytes. Returning the "+
+						"moment either direction errors lets the caller's deferred close "+
+						"truncate a healthy direction — the two halves of a tls.Conn fail "+
+						"independently.", n, len(payload))
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("reader never completed")
+			}
+		})
+	}
+}
+
+// TestRelayRawPassthrough_DrainIsIdleNotAWallClock pins the difference
+// between "stop a stalled survivor" and "cut every survivor off after a
+// fixed interval".
+//
+// A fixed grace is only a slower way of abandoning the survivor: a
+// response that legitimately takes longer than the grace gets truncated,
+// and this proxy sits in front of real upstreams where that is entirely
+// ordinary. Measured on the wall-clock version: 33% of a 960 KiB response
+// delivered before the cut.
+//
+// Here the survivor keeps delivering, slowly, for well beyond one idle
+// window — every byte must still arrive, in BOTH orientations. Watching
+// the wrong direction's counter reproduces the wall clock exactly, and
+// only in one of them.
+func TestRelayRawPassthrough_DrainIsIdleNotAWallClock(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		breakDest bool
+	}{
+		{"client read half fails, response survives", false},
+		{"upstream read half fails, request survives", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Total transfer time well over one window, but never idle for a
+			// whole window: a wall clock truncates this, an idle timer does not.
+			const chunks, chunkSize = 12, 16 * 1024
+			gap := testDrainIdle / 3
+			payload := bytes.Repeat([]byte("S"), chunks*chunkSize)
+
+			f := newRelayFixture(t, tc.breakDest, testDrainIdle)
+			pacedSend(f.sender, payload, chunkSize, gap)
+			got := readAllInto(f.receiver, len(payload))
+
+			f.awaitReturnAndClose(t)
+
+			select {
+			case n := <-got:
+				if n < len(payload) {
+					t.Fatalf("the surviving direction delivered %d of %d bytes over %v. A fixed "+
+						"grace is a deadline on the whole transfer, not a flush — it truncates "+
+						"any response slower than the grace, which for a real upstream is normal.",
+						n, len(payload), time.Duration(chunks)*gap)
+				}
+			case <-time.After(10 * time.Second):
+				t.Fatal("reader never completed")
+			}
+		})
+	}
+}
+
+// TestRelayRawPassthrough_WaitsThroughUpstreamThinkTime covers the window
+// BEFORE the survivor's first byte.
+//
+// The idle clock starts at the break, so a survivor that has not begun
+// delivering yet is indistinguishable from one that has stalled — it has
+// moved zero bytes either way. An upstream that is still computing when
+// the other direction fails therefore loses its entire response if the
+// window is shorter than its think time, which is why the window is sized
+// for a real upstream rather than for a loopback test.
+func TestRelayRawPassthrough_WaitsThroughUpstreamThinkTime(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		breakDest bool
+	}{
+		{"client read half fails, response survives", false},
+		{"upstream read half fails, request survives", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := []byte("the answer, eventually")
+			think := testDrainIdle * 3 / 4 // silent for most of a window, then answers
+
+			f := newRelayFixture(t, tc.breakDest, testDrainIdle)
+			go func() {
+				time.Sleep(think)
+				_, _ = f.sender.Write(payload)
+			}()
+			got := readAllInto(f.receiver, len(payload))
+
+			f.awaitReturnAndClose(t)
+
+			select {
+			case n := <-got:
+				if n < len(payload) {
+					t.Fatalf("delivered %d of %d bytes after a %v think time. The drain treats "+
+						"'has not started yet' as 'stalled', so a window shorter than the "+
+						"upstream's first-byte latency drops the whole response.",
+						n, len(payload), think)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("reader never completed")
+			}
+		})
+	}
+}
+
+// TestRelayDrainIdleLeavesRoomForARealUpstream is the one assertion the
+// short-window tests cannot make.
+//
+// Everything above runs the drain at testDrainIdle, which proves the
+// mechanism but says nothing about whether the production window is long
+// enough to be worth having. It is not an arbitrary number: the window is
+// the maximum time a survivor may be SILENT before keploy decides it is
+// dead, and ordinary upstreams are silent for hundreds of milliseconds
+// before their first byte and between streamed chunks. A previous 500ms
+// window lost entire responses to an upstream that thought for 800ms.
+func TestRelayDrainIdleLeavesRoomForARealUpstream(t *testing.T) {
+	if RelayDrainIdle < 5*time.Second {
+		t.Fatalf("RelayDrainIdle is %v. This is how long a survivor may go quiet before its "+
+			"bytes are abandoned, and sub-second silence is normal for a database mid-query, "+
+			"an upstream computing its first byte, or an event stream between heartbeats. "+
+			"Shrinking it back turns the idle drain into the fixed wall clock it replaced.",
+			RelayDrainIdle)
+	}
+}
+
+// TestRelayRawPassthrough_ReturnsWhenOneDirectionBreaks is the liveness
+// half: a broken pair must not wedge the caller indefinitely.
+//
+// The bound is real but not "forever" — the surviving peer's own close or
+// timeout releases it. What it costs meanwhile is the CALLER: the
+// abandoned copier itself exits as soon as handleConnection's defer closes
+// the real sockets, so nothing lingers past the return.
+func TestRelayRawPassthrough_ReturnsWhenOneDirectionBreaks(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	appSide, appPeer := tcpPair(t, ln)
+	destSide, destPeer := tcpPair(t, ln)
+	defer func() { _ = appSide.Close(); _ = appPeer.Close(); _ = destSide.Close() }()
+
+	// The app peer stays open and silent, so app->dest can only end by a FIN.
+	go func() { _, _ = appPeer.Write([]byte("hello")) }()
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		if tc, ok := destPeer.(*net.TCPConn); ok {
+			_ = tc.SetLinger(0)
+		}
+		_ = destPeer.Close()
+	}()
+
+	returned := make(chan struct{})
+	go func() {
+		relayRawPassthrough(NewSafeConn(appSide, zap.NewNop()), NewSafeConn(destSide, zap.NewNop()), testDrainIdle)
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("relayRawPassthrough did not return after one direction was reset. keploy " +
+			"cannot wake the surviving io.Copy before session teardown — SafeConn's Close and " +
+			"deadline setters are no-ops — so this holds a goroutine and both fds until the " +
+			"surviving peer gives up, on the one path that runs only under memory pressure.")
+	}
+}
+
+// TestRelayRawPassthrough_ForwardsFINOnCleanEOF: a clean end of stream must
+// still propagate, or an EOF-delimited peer waits forever for a reply that
+// was already complete.
+//
+// This one calls the exported entry point, so the wiring from
+// RelayRawPassthrough down to the copy loop is covered by a test too, not
+// only the parameterised form the timing tests use.
+func TestRelayRawPassthrough_ForwardsFINOnCleanEOF(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	appSide, appPeer := tcpPair(t, ln)
+	destSide, destPeer := tcpPair(t, ln)
+	defer func() { _ = appSide.Close(); _ = appPeer.Close(); _ = destSide.Close(); _ = destPeer.Close() }()
+
+	gotAll := make(chan []byte, 1)
+	go func() {
+		b, _ := io.ReadAll(destPeer) // returns only once the FIN arrives
+		gotAll <- b
+	}()
+
+	go RelayRawPassthrough(NewSafeConn(appSide, zap.NewNop()), NewSafeConn(destSide, zap.NewNop()))
+
+	if _, err := appPeer.Write([]byte("request")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if tc, ok := appPeer.(*net.TCPConn); ok {
+		if err := tc.CloseWrite(); err != nil {
+			t.Fatalf("half-close: %v", err)
+		}
+	}
+
+	select {
+	case b := <-gotAll:
+		if string(b) != "request" {
+			t.Fatalf("destination got %q, want %q", b, "request")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the destination never saw EOF: the client's FIN was not forwarded, so an " +
+			"EOF-delimited peer would wait forever for a request that was already complete")
+	}
+}
+
+// deadWriteConn fails on Write while Read keeps working — the other half
+// of tls.Conn's split error state, and the case where forwarding a FIN is
+// most wrong: dst may be alive after a short write, so claiming the
+// message is complete is a lie about data that never arrived.
+type deadWriteConn struct {
+	net.Conn
+	writeErr error
+}
+
+func (c *deadWriteConn) Write(p []byte) (int, error) {
+	if c.writeErr != nil {
+		return 0, c.writeErr
+	}
+	return c.Conn.Write(p)
+}
+
+// CloseWrite must be delegated explicitly. Embedding net.Conn as an
+// INTERFACE promotes only net.Conn's method set, so CloseWrite is NOT
+// inherited — a fake without this silently swallows every FIN and any test
+// built on it certifies nothing. That exact omission has shipped four
+// times in this tree — readTimeReportingConn, readTrackingConn, SafeConn
+// and util.Conn each shipped without it and each had to be fixed, so they
+// all carry an explicit CloseWrite today — and it made the first version
+// of the write-error test below pass against a build that forwarded the
+// FIN unconditionally.
+func (c *deadWriteConn) CloseWrite() error { return CloseWriteIfPossible(c.Conn) }
+
+// TestRelayRawPassthrough_NoFINAfterAWriteError covers the direction the
+// other tests miss: io.Copy also exits when the WRITE to dst fails, and a
+// FIN there tells the peer a truncated exchange finished cleanly.
+func TestRelayRawPassthrough_NoFINAfterAWriteError(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	appSide, appPeer := tcpPair(t, ln)
+	destSide, destPeer := tcpPair(t, ln)
+	defer func() { _ = appSide.Close(); _ = appPeer.Close(); _ = destSide.Close(); _ = destPeer.Close() }()
+
+	sawEOF := make(chan struct{})
+	go func() {
+		_, _ = io.ReadAll(destPeer) // returns when destSide's write half closes
+		close(sawEOF)
+	}()
+
+	go func() { _, _ = appPeer.Write([]byte("request")); _ = appPeer.Close() }()
+
+	// Writing to the destination fails, so the app->dest copy exits with an
+	// error even though the app side ended cleanly.
+	dead := &deadWriteConn{Conn: destSide, writeErr: io.ErrClosedPipe}
+	returned := make(chan struct{})
+	go func() {
+		relayRawPassthrough(NewSafeConn(appSide, zap.NewNop()), NewSafeConn(dead, zap.NewNop()), testDrainIdle)
+		close(returned)
+	}()
+	select {
+	case <-returned:
+	case <-time.After(30 * time.Second):
+		// Run it in a goroutine so a liveness regression fails HERE with a
+		// name, instead of hanging until the package-level timeout kills
+		// every test in the package with a stack dump.
+		t.Fatal("relayRawPassthrough never returned after a write error")
+	}
+
+	select {
+	case <-sawEOF:
+		t.Fatal("a FIN was forwarded to the destination after the write to it FAILED. That " +
+			"tells the peer the request is complete when its bytes never arrived.")
+	case <-time.After(300 * time.Millisecond):
+		// No FIN — correct.
+	}
+}
+
+// TestDeadWriteConnActuallyForwardsCloseWrite is the positive control for
+// the fake above.
+//
+// TestRelayRawPassthrough_NoFINAfterAWriteError passes when NO FIN
+// arrives, so it also passes when the fake silently swallows every FIN —
+// at which point it asserts nothing at all. Interface embedding does not
+// promote CloseWrite, and that omission has shipped four times in this
+// tree, so the fake's delegation needs its own proof. Here the write half
+// is healthy and the copy ends cleanly, so a FIN MUST come through.
+func TestDeadWriteConnActuallyForwardsCloseWrite(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	appSide, appPeer := tcpPair(t, ln)
+	destSide, destPeer := tcpPair(t, ln)
+	defer func() { _ = appSide.Close(); _ = appPeer.Close(); _ = destSide.Close(); _ = destPeer.Close() }()
+
+	gotAll := make(chan []byte, 1)
+	go func() {
+		b, _ := io.ReadAll(destPeer) // returns only once the FIN arrives
+		gotAll <- b
+	}()
+
+	// Same fake, healthy write half: whatever the FIN test proves about the
+	// error case, this proves the fake can carry a FIN at all.
+	healthy := &deadWriteConn{Conn: destSide}
+	go relayRawPassthrough(NewSafeConn(appSide, zap.NewNop()), NewSafeConn(healthy, zap.NewNop()), testDrainIdle)
+
+	if _, err := appPeer.Write([]byte("request")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if tc, ok := appPeer.(*net.TCPConn); ok {
+		if err := tc.CloseWrite(); err != nil {
+			t.Fatalf("half-close: %v", err)
+		}
+	}
+
+	select {
+	case b := <-gotAll:
+		if string(b) != "request" {
+			t.Fatalf("destination got %q, want %q", b, "request")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("deadWriteConn swallowed CloseWrite, so TestRelayRawPassthrough_NoFINAfterAWriteError " +
+			"is a tautology: it would pass against a build that forwards the FIN unconditionally")
+	}
+}
+
+// TestRelayRawPassthrough_ProductionEntryPointDrainsTheSurvivor closes the
+// gap the parameterised window opens.
+//
+// Every other drain test calls relayRawPassthrough with testDrainIdle, so
+// the line that actually wires the production constant into the mechanism
+// is executed but never CHECKED. Severing it — passing 0, or any value too
+// small to cover a real transfer — abandons the survivor immediately,
+// which is this function's original data-loss bug, and the rest of the
+// suite stays green because none of it goes through this door.
+//
+// So drive the exported entry point, on the production constant, through
+// the survivor path. It does not cost 30s: a survivor is only ever waited
+// ON the window when its source goes silent while still open. Here the
+// source closes when it is done, io.Copy returns, and the relay returns
+// with it.
+func TestRelayRawPassthrough_ProductionEntryPointDrainsTheSurvivor(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	appSide, appPeer := tcpPair(t, ln)
+	destSide, destPeer := tcpPair(t, ln)
+	defer func() { _ = appSide.Close(); _ = appPeer.Close(); _ = destSide.Close(); _ = destPeer.Close() }()
+
+	const chunks, chunkSize = 10, 16 * 1024
+	payload := bytes.Repeat([]byte("P"), chunks*chunkSize)
+	go func() {
+		for i := 0; i < chunks; i++ {
+			if _, err := destPeer.Write(payload[i*chunkSize : (i+1)*chunkSize]); err != nil {
+				return
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		// Closing ends the survivor's copy, so the relay returns on its own
+		// rather than sitting out the production idle window.
+		if tc, ok := destPeer.(*net.TCPConn); ok {
+			_ = tc.CloseWrite()
+		}
+	}()
+
+	got := readAllInto(appPeer, len(payload))
+
+	broken := &splitHalfConn{Conn: appSide, readErr: io.ErrUnexpectedEOF}
+	relayDone := make(chan struct{})
+	go func() {
+		// The EXPORTED function, on RelayDrainIdle. That is the whole point.
+		RelayRawPassthrough(NewSafeConn(broken, zap.NewNop()), NewSafeConn(destSide, zap.NewNop()))
+		close(relayDone)
+	}()
+	select {
+	case <-relayDone:
+	case <-time.After(60 * time.Second):
+		t.Fatal("RelayRawPassthrough never returned")
+	}
+	_ = appSide.Close()
+	_ = destSide.Close()
+
+	select {
+	case n := <-got:
+		if n < len(payload) {
+			t.Fatalf("the surviving direction delivered %d of %d bytes through the EXPORTED "+
+				"entry point. The drain is only as good as the window wired into it here; a "+
+				"window too small to cover a real transfer abandons the survivor and the "+
+				"caller's close truncates it.", n, len(payload))
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("reader never completed")
+	}
+}
+
+// TestRelayRawPassthrough_ReplySurvivesTheClientFIN is the shape an
+// EOF-delimited exchange actually takes, and nothing else in this tree
+// pins it.
+//
+// The client sends a request and half-closes. That is a CLEAN end of one
+// direction, so the copy loop must treat it as "one direction finished"
+// and keep waiting for the other. Returning there instead — the natural
+// mistake, since a nil error looks like completion — hands control back to
+// handleConnection, whose deferred close then destroys the reply the
+// upstream was in the middle of sending.
+//
+// Modelling the caller's close is what gives this test teeth: returning
+// early is harmless on its own, because the copier goroutines keep
+// running. It is the close that turns it into lost data.
+func TestRelayRawPassthrough_ReplySurvivesTheClientFIN(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	appSide, appPeer := tcpPair(t, ln)
+	destSide, destPeer := tcpPair(t, ln)
+	defer func() { _ = appSide.Close(); _ = appPeer.Close(); _ = destSide.Close(); _ = destPeer.Close() }()
+
+	reply := bytes.Repeat([]byte("A"), 64*1024)
+
+	// A realistic upstream: read the request to EOF, think, then answer.
+	go func() {
+		if _, err := io.ReadAll(destPeer); err != nil {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+		_, _ = destPeer.Write(reply)
+		if tc, ok := destPeer.(*net.TCPConn); ok {
+			_ = tc.CloseWrite()
+		}
+	}()
+
+	got := readAllInto(appPeer, len(reply))
+
+	relayDone := make(chan struct{})
+	go func() {
+		RelayRawPassthrough(NewSafeConn(appSide, zap.NewNop()), NewSafeConn(destSide, zap.NewNop()))
+		close(relayDone)
+	}()
+
+	if _, err := appPeer.Write([]byte("request")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if tc, ok := appPeer.(*net.TCPConn); ok {
+		if err := tc.CloseWrite(); err != nil {
+			t.Fatalf("half-close: %v", err)
+		}
+	}
+
+	select {
+	case <-relayDone:
+	case <-time.After(60 * time.Second):
+		t.Fatal("RelayRawPassthrough never returned")
+	}
+	// handleConnection closes the real sockets the instant this returns.
+	_ = appSide.Close()
+	_ = destSide.Close()
+
+	select {
+	case n := <-got:
+		if n < len(reply) {
+			t.Fatalf("the client got %d of %d reply bytes after half-closing. A clean EOF on "+
+				"one direction means that direction finished, NOT that the exchange did — "+
+				"returning there lets the caller's close destroy a reply that was still "+
+				"arriving.", n, len(reply))
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("client never received the reply")
+	}
+}
+
+// TestRelayRawPassthrough_CleanThenResetReturnsPromptly guards the early
+// return for the case the code calls "very common": one side ends
+// cleanly, the other resets.
+//
+// Both results are already in hand there, so there is nothing left to
+// drain and no reason to wait. Dropping that check costs a full idle
+// window of dead time per connection — 30s in production — and no other
+// test notices, because they all run on a short window where the
+// difference is invisible.
+func TestRelayRawPassthrough_CleanThenResetReturnsPromptly(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	appSide, appPeer := tcpPair(t, ln)
+	destSide, destPeer := tcpPair(t, ln)
+	defer func() { _ = appSide.Close(); _ = appPeer.Close(); _ = destSide.Close() }()
+
+	// app->dest ends cleanly; dest->app resets. Both land quickly, so the
+	// loop reaches its second iteration with both results in hand.
+	go func() {
+		_, _ = appPeer.Write([]byte("hello"))
+		if tc, ok := appPeer.(*net.TCPConn); ok {
+			_ = tc.CloseWrite()
+		}
+	}()
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		if tc, ok := destPeer.(*net.TCPConn); ok {
+			_ = tc.SetLinger(0)
+		}
+		_ = destPeer.Close()
+	}()
+
+	start := time.Now()
+	returned := make(chan struct{})
+	go func() {
+		relayRawPassthrough(NewSafeConn(appSide, zap.NewNop()), NewSafeConn(destSide, zap.NewNop()), testDrainIdle)
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(10 * time.Second):
+		t.Fatal("relayRawPassthrough never returned")
+	}
+	// Comfortably under a window, but not so tight that a loaded runner
+	// trips it: the bug this catches costs a WHOLE window, not a slice.
+	if elapsed := time.Since(start); elapsed > testDrainIdle*3/4 {
+		t.Fatalf("returned after %v, which is most of one %v idle window. Both copy results "+
+			"were already available, so there was nothing to drain — waiting anyway burns a "+
+			"full window of dead time on every clean-then-reset connection, and in production "+
+			"that window is %v.", elapsed, testDrainIdle, RelayDrainIdle)
+	}
+}

--- a/pkg/agent/proxy/util/util.go
+++ b/pkg/agent/proxy/util/util.go
@@ -1009,3 +1009,184 @@ func Recover(logger *zap.Logger, client, dest net.Conn) {
 		sentry.Flush(time.Second * 2)
 	}
 }
+
+// RelayDrainIdle is how long a surviving copy direction may go with NO
+// progress before it is abandoned. It is an IDLE timeout, not a deadline
+// on the transfer: a survivor that is still moving bytes keeps going for
+// as long as it keeps moving them.
+//
+// That distinction is the whole point. A fixed wall clock is just a
+// slower version of abandoning the survivor — measured at 33% of a
+// 960 KiB response delivered before the cut — and this proxy sits in
+// front of real upstreams, where a response taking longer than a fixed
+// grace is entirely ordinary.
+//
+// The window is deliberately generous, and the asymmetry is why. A clean
+// EOF, a reset, or a failed write all end io.Copy on their own and are
+// noticed the instant they happen, so what this timer actually bounds is
+// only two things: a source socket that is open and SILENT, and a write
+// to the destination that has not returned yet. Both of those are
+// ordinary traffic — an upstream still computing its first byte, a
+// database mid-query, an event stream between heartbeats, a peer whose
+// receive window is momentarily full. Cutting them off costs the user
+// bytes that were about to arrive.
+//
+// Waiting costs two goroutines and two fds per held connection (~48 KiB,
+// dominated by io.Copy's two 32 KiB buffers), bounded by this window.
+// Measured at 300 concurrently draining connections that is ~14 MiB, and
+// memoryguard's pause headroom is 128 MiB, so it does not meaningfully
+// worsen the condition the fallback runs under. That trade is not close,
+// which is why an earlier 500ms window is gone: it dropped entire
+// responses to nothing more exotic than an upstream that thought for
+// 800ms before its first byte.
+//
+// The tempting alternative — a long budget for the FIRST byte and a short
+// idle tick afterwards — was considered and rejected. It fixes the
+// upstream that has not answered yet and leaves a guillotine on every gap
+// AFTER the first byte, so a response that streams with pauses longer
+// than the short tick is still truncated: server-sent events between
+// heartbeats, a long-poll, a cursor that pages a large result set. Those
+// gaps are not a degraded state, they are how the protocols work.
+//
+// Be precise about what one window buys, though: it does not REMOVE the
+// truncation case, it moves the edge from sub-second to 30s. A stream
+// whose gaps exceed 30s is still cut. The claim is only that no ordinary
+// gap is sub-second, so a single generous window has no edge anywhere
+// real traffic lives, where two windows keep one.
+const RelayDrainIdle = 30 * time.Second
+
+// countingWriter records how many bytes have reached the destination, so
+// the drain can tell "still delivering" from "stalled".
+type countingWriter struct {
+	w io.Writer
+	n atomic.Int64
+}
+
+func (c *countingWriter) Write(p []byte) (int, error) {
+	n, err := c.w.Write(p)
+	c.n.Add(int64(n))
+	return n, err
+}
+
+// copyOutcome reports WHICH copy direction ended, and how.
+//
+// The index is not bookkeeping, it is the correctness of the drain. A
+// bare error says that a direction broke but not which one, and the
+// survivor to watch is always the other one. Assuming the first result
+// must have come from the first goroutine is wrong half the time, and
+// wrong in a way that looks like it works: it watches the counter of the
+// direction that just died, which never advances again, so the drain
+// sees "stalled" on its very first tick and returns after a single idle
+// window. That is precisely the fixed wall clock this mechanism exists
+// to avoid, reintroduced for half the failure orientations — and it is
+// the more common half, because the upstream read is where a reset or a
+// TLS alert surfaces first.
+type copyOutcome struct {
+	idx int
+	err error
+}
+
+// WaitForSurvivor blocks until the surviving copy direction finishes or
+// stalls, whichever comes first.
+//
+// Receiving anything on finished means that direction's copy is over, so
+// there is nothing left to wait for. delivered reports how many bytes it
+// has handed on so far; it is polled once per window, and any change at
+// all counts as progress and buys another full window. Only a window
+// that passes with the count unmoved ends the wait.
+func WaitForSurvivor[T any](finished <-chan T, delivered func() int64, idle time.Duration) {
+	last := delivered()
+	t := time.NewTimer(idle)
+	defer t.Stop()
+	for {
+		select {
+		case <-finished:
+			return
+		case <-t.C:
+			n := delivered()
+			if n == last {
+				return // stalled
+			}
+			last = n
+			t.Reset(idle)
+		}
+	}
+}
+
+// RelayRawPassthrough relays bytes both ways between two connections and
+// returns once the exchange is over. Nothing is captured — it is the
+// memory-pressure fallback, used when a parser stops recording but the
+// user's traffic must keep flowing.
+//
+// Two rules, and the second is the one that is easy to get wrong.
+//
+// FORWARD THE FIN ONLY ON A CLEAN EOF. A FIN means "I have sent
+// everything I am going to send", so forwarding it after a truncated
+// read, a reset, or a failed write tells the peer a partial message is
+// complete — and an EOF-delimited protocol acts on it. io.Copy exits the
+// same way for all of these, so err is the only thing that separates
+// them.
+//
+// WHEN ONE DIRECTION BREAKS, LET THE OTHER KEEP GOING WHILE IT IS STILL
+// MAKING PROGRESS, and abandon it only once it stalls.
+//
+// Waiting unconditionally wedges the CALLER, and that is the cost worth
+// naming. The survivor is blocked reading a socket whose peer will never
+// be told the stream ended, and keploy cannot wake it before session
+// teardown (SafeConn's Close and all three deadline setters are no-ops).
+// It is not literally forever — the surviving peer's own close or timeout
+// releases it — but handleConnection cannot proceed until this returns.
+//
+// Note what it is NOT: the goroutines do not linger past the return.
+// handleConnection's defer closes the real srcConn/dstConn directly and
+// connCloser fires on parserCtx cancellation, so the abandoned copier
+// exits as soon as this function hands control back — measured at +0
+// goroutines immediately after return and close.
+//
+// Abandoning it at once is worse, and was this function's first bug. The
+// two directions do NOT necessarily fail together: these conns are
+// SafeConns over *tls.Conn on every TLS-intercepted path, and Go's
+// tls.Conn keeps its read and write halves' errors separate, so a
+// read-side failure leaves a fully usable write half with
+// already-decrypted bytes still to deliver. Returning at once lets the
+// caller's deferred close land on that healthy direction and shred it.
+func RelayRawPassthrough(clientConn, destConn net.Conn) {
+	relayRawPassthrough(clientConn, destConn, RelayDrainIdle)
+}
+
+// relayRawPassthrough is RelayRawPassthrough with the idle window as a
+// parameter, so tests can drive the drain without waiting out the
+// production window. Production has exactly one caller, above, and it
+// always passes RelayDrainIdle.
+func relayRawPassthrough(clientConn, destConn net.Conn, idle time.Duration) {
+	done := make(chan copyOutcome, 2)
+	// counters[i] counts what direction i has delivered to its destination.
+	// Both are built before either goroutine starts.
+	counters := [2]*countingWriter{{w: destConn}, {w: clientConn}}
+	cp := func(idx int, dst, src net.Conn) {
+		_, err := io.Copy(counters[idx], src)
+		if err == nil {
+			_ = CloseWriteIfPossible(dst)
+		}
+		done <- copyOutcome{idx: idx, err: err}
+	}
+	go cp(0, destConn, clientConn)
+	go cp(1, clientConn, destConn)
+
+	for i := 0; i < 2; i++ {
+		res := <-done
+		if res.err == nil {
+			continue
+		}
+		// Both results are already in hand — nothing is left to drain, and
+		// waiting would just hold the caller for the full idle window on
+		// the very common "one side ends cleanly, the other resets".
+		if i == 1 {
+			return
+		}
+		// Let the survivor run while it is still delivering. The survivor
+		// is the direction that did NOT just report.
+		WaitForSurvivor(done, counters[1-res.idx].n.Load, idle)
+		return
+	}
+}


### PR DESCRIPTION
> **Stacked on #4546.** Base is `fix/passthrough-fallback-liveness`, because this relies on `util.RelayRawPassthrough` behaving correctly. Retarget to `main` once that merges.

### The bug

A parser can **match** a connection and then decline it. gRPC claims any HTTP/2 connection at priority 100, then bails when the destination port is outside its allowlist (default `50051,443`). It signalled that by returning `nil` — so the dispatcher read nil as "handled", logged *"successfully recorded outgoing message"*, and `handleConnection`'s deferred close tore the socket down.

**gRPC on any non-default port had its connections dropped in record mode**, while the parser's own docs promised the proxy would "treat the connection as a pass-through".

`integrations.ErrParserDeclined` makes that sayable, and the four legacy record dispatch sites relay instead of dropping.

### Why it relays the session's conns

Deciding whether it wants the connection requires the parser to **read** — gRPC reads the HTTP/2 preface — and it restores those bytes by wrapping `session.Ingress`. `handleConnection`'s own `srcConn` is left positioned past them, so relaying *that* forwards a preface-less stream and a real server answers `GOAWAY(PROTOCOL_ERROR)`. The user's break would move, not disappear.

### Two things review changed

**Not `globalPassThrough`.** It never calls `CloseWrite` on either side and returns on `io.EOF`, so a client doing `shutdown(SHUT_WR)` — the end-of-request signal for every EOF-delimited exchange — ends the connection instead of getting its reply. Relaying through it would have re-broken, one round trip later, the exact thing this change exists to stop breaking. That is also why `recordViaSupervisor` refuses it (*"Critically we do NOT call globalPassThrough here"*). There's now a test that fails on its own assertion when the relay is reverted.

**No orphan window.** The first version suppressed test cases recorded over the same interval, so a recording couldn't silently lose mocks. Measured, it did the opposite of its intent **in both directions**:

- it opened asynchronously and covered *neither end* of the interval it was for
- on a busy connection it never went idle long enough to close, suppressing **unrelated, fully captured** test cases across the whole session — the reader is the global manager, so activity scoping narrows the time range and never the blast radius

A decline also isn't a transient incident like the V2 fallthrough's panic or memcap trip — it's a persistent configuration state that holds every run. That turns *"keploy drops my gRPC connections"* into *"keploy hands back a recording with the passing cases stripped out"*, which is not the better failure. One `Warn` per connection is the honest signal, and it matches what the record-mode kill switch and `GlobalPassthrough` already do.

### Smaller, but wrong before

The nil guard now checks the conn **inside** the `SafeConn`. `NewSafeConn` returns a non-nil `*SafeConn` around a nil conn, so `session.Egress == nil` was false for every real caller — a nil upstream would have sailed past it into a nil deref inside the copy, recovered and swallowed, leaving the relay blocked with no error anywhere.

The AST pin checks the guard's **shape**, not just that the call exists. Counting call expressions let `if false && errors.Is(…)` delete the entire fix and stay green; a site now only counts when its condition is exactly `errors.Is(err, integrations.ErrParserDeclined)`.

### Scope

No in-tree parser produces the sentinel yet — every OSS parser is V2, so the patched legacy sites are reachable under `KEPLOY_NEW_RELAY=off`, and a V2 gRPC parser is already covered by the supervisor's `FallthroughToPassthrough`. This lands the contract the out-of-tree parser needs. `go test -race ./pkg/agent/proxy/...` green.
