### PR TITLE
fix(matcher/grpc): a grpc-status flip was reported as a passing test

### DIFF
--- a/pkg/matcher/grpc/match.go
+++ b/pkg/matcher/grpc/match.go
@@ -308,7 +308,39 @@ func Match(tc *models.TestCase, actualResp *models.GrpcResp, noiseConfig map[str
 		}
 	}
 
-	// Calculate final match status based on remaining differences
+	// Compare grpc-status trailer — this is the canonical gRPC status code.
+	// HTTP/2 :status (always 200 for gRPC) is transport framing and must not
+	// be used as the gRPC status; grpc-status: 0 = OK, non-zero = error.
+	expectedGrpcStatus := parseGrpcStatus(expectedResp.Trailers.OrdinaryHeaders["grpc-status"])
+	actualGrpcStatus := parseGrpcStatus(actualResp.Trailers.OrdinaryHeaders["grpc-status"])
+	result.StatusCode = models.IntResult{
+		Normal:   expectedGrpcStatus == actualGrpcStatus,
+		Expected: expectedGrpcStatus,
+		Actual:   actualGrpcStatus,
+	}
+	if !result.StatusCode.Normal {
+		differences["trailers.grpc-status"] = struct {
+			Expected string
+			Actual   string
+			Message  string
+		}{
+			Expected: strconv.Itoa(expectedGrpcStatus),
+			Actual:   strconv.Itoa(actualGrpcStatus),
+			Message:  "grpc-status mismatch",
+		}
+		currentRisk = models.High
+		currentCategories = append(currentCategories, models.StatusCodeChanged)
+	}
+
+	// Calculate final match status based on remaining differences.
+	//
+	// The grpc-status comparison above MUST stay above this line. It was
+	// below it, so its difference was written after `matched` had already
+	// been decided: a response with a byte-identical body whose grpc-status
+	// flipped 0 -> 13 set result.StatusCode.Normal=false and still returned
+	// matched=true, printing "Testrun passed" for a failed RPC. Moving it up
+	// also gets the mismatch into the diff the user is shown, which it was
+	// previously excluded from.
 	matched := len(differences) == 0
 
 	if !matched {
@@ -396,30 +428,6 @@ func Match(tc *models.TestCase, actualResp *models.GrpcResp, noiseConfig map[str
 			currentRisk = models.High
 			currentCategories = append(currentCategories, models.SchemaBroken)
 		}
-	}
-
-	// Compare grpc-status trailer — this is the canonical gRPC status code.
-	// HTTP/2 :status (always 200 for gRPC) is transport framing and must not
-	// be used as the gRPC status; grpc-status: 0 = OK, non-zero = error.
-	expectedGrpcStatus := parseGrpcStatus(expectedResp.Trailers.OrdinaryHeaders["grpc-status"])
-	actualGrpcStatus := parseGrpcStatus(actualResp.Trailers.OrdinaryHeaders["grpc-status"])
-	result.StatusCode = models.IntResult{
-		Normal:   expectedGrpcStatus == actualGrpcStatus,
-		Expected: expectedGrpcStatus,
-		Actual:   actualGrpcStatus,
-	}
-	if !result.StatusCode.Normal {
-		differences["trailers.grpc-status"] = struct {
-			Expected string
-			Actual   string
-			Message  string
-		}{
-			Expected: strconv.Itoa(expectedGrpcStatus),
-			Actual:   strconv.Itoa(actualGrpcStatus),
-			Message:  "grpc-status mismatch",
-		}
-		currentRisk = models.High
-		currentCategories = append(currentCategories, models.StatusCodeChanged)
 	}
 
 	// remove duplicates

--- a/pkg/matcher/grpc/status_ordering_test.go
+++ b/pkg/matcher/grpc/status_ordering_test.go
@@ -1,0 +1,56 @@
+package grpc
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// TestMatch_GrpcStatusFlipMustFail is a latent bug that this streaming work
+// turns load-bearing.
+//
+// `matched := len(differences) == 0` is evaluated BEFORE the grpc-status
+// trailer comparison writes differences["trailers.grpc-status"]. So a
+// response whose body is byte-identical but whose grpc-status flipped from 0
+// (OK) to 13 (INTERNAL) is reported as a PASS — result.StatusCode.Normal is
+// correctly false, and the returned bool says the test passed anyway.
+//
+// It matters more once streams replay: today SimulateGRPC reads trailers
+// before io.EOF, so they come back empty and grpc-status is fabricated as "0"
+// — the actual status is almost always 0 and the bug rarely shows. Draining a
+// stream properly makes real trailers arrive, at which point a stream that
+// dies partway carries a real non-zero status and would be reported green.
+func TestMatch_GrpcStatusFlipMustFail(t *testing.T) {
+	body := models.GrpcLengthPrefixedMessage{MessageLength: 7, DecodedData: `1: {"alpha"}`}
+	hdrs := func(status string) models.GrpcHeaders {
+		return models.GrpcHeaders{
+			PseudoHeaders:   map[string]string{},
+			OrdinaryHeaders: map[string]string{"grpc-status": status},
+		}
+	}
+
+	tc := &models.TestCase{
+		Name: "grpc-status-flip",
+		GrpcResp: models.GrpcResp{
+			Headers:  models.GrpcHeaders{PseudoHeaders: map[string]string{}, OrdinaryHeaders: map[string]string{}},
+			Body:     body,
+			Trailers: hdrs("0"), // recorded OK
+		},
+	}
+	actual := &models.GrpcResp{
+		Headers:  models.GrpcHeaders{PseudoHeaders: map[string]string{}, OrdinaryHeaders: map[string]string{}},
+		Body:     body,       // identical body
+		Trailers: hdrs("13"), // INTERNAL
+	}
+
+	pass, result := Match(tc, actual, nil, false, zap.NewNop(), false)
+	if result != nil && result.StatusCode.Normal {
+		t.Fatalf("StatusCode.Normal = true for 0 vs 13; the comparison itself is broken")
+	}
+	if pass {
+		t.Fatal("Match reported PASS for a response whose grpc-status flipped 0 -> 13. " +
+			"`matched` is computed before the grpc-status comparison contributes its " +
+			"difference, so a failed RPC with an identical body prints \"Testrun passed\".")
+	}
+}


### PR DESCRIPTION
`matched := len(differences) == 0` was evaluated **before** the grpc-status trailer comparison contributed its difference.

So a response with a **byte-identical body** whose grpc-status flipped `0` (OK) → `13` (INTERNAL) set `result.StatusCode.Normal = false`, wrote `differences["trailers.grpc-status"]`, and **still returned `matched = true`**. keploy printed *"Testrun passed"* for an RPC that failed.

Replicated before fixing:

```
--- FAIL: TestMatch_GrpcStatusFlipMustFail
    Match reported PASS for a response whose grpc-status flipped 0 -> 13.
```

### The fix

The comparison moves **above** the decision, rather than the decision moving below it — that also gets the mismatch into the diff the user sees. It was excluded from that too: the diff printer runs inside `if !matched`, which never fired for a status-only failure.

Noise handling is unchanged. The status comparison already sat after the noise-application loop and still does, so `trailers.grpc-status` is no more or less noise-filterable than before.

### Why it has been survivable, and why that is about to change

`SimulateGRPC` reads `stream.Trailer()` immediately after a single `RecvMsg`, **before** `io.EOF`, so trailers come back empty and grpc-status is fabricated as `"0"` a few lines later. The actual status is therefore almost always 0 and the two sides rarely disagree.

That stops being true the moment replay drains a stream properly and real trailers arrive — a streaming RPC that dies on message 3 would replay as a clean pass. Hence fixing it standalone rather than burying it in the streaming work.

### Heads-up on impact

This is a behaviour change users will see: a suite that was green *because* of this bug will now correctly go red. That is the point, but it is worth a release note — the failure is real and was always real.

`go test ./pkg/matcher/...` green.
