### PR TITLE
feat(models/grpc): make a gRPC stream representable, without touching what unary writes

### DIFF
--- a/pkg/grpc_framing_test.go
+++ b/pkg/grpc_framing_test.go
@@ -1,0 +1,236 @@
+package pkg
+
+import (
+	"encoding/binary"
+	"errors"
+	"testing"
+
+	"github.com/protocolbuffers/protoscope"
+)
+
+func protoscopeWrite(b []byte) string {
+	return protoscope.Write(b, protoscope.WriterOptions{})
+}
+
+// wire builds a length-prefixed gRPC message from a raw protobuf payload.
+func wire(payload []byte) []byte {
+	out := make([]byte, 5)
+	binary.BigEndian.PutUint32(out[1:5], uint32(len(payload)))
+	return append(out, payload...)
+}
+
+// pb builds a trivial protobuf message: field 1, length-delimited string.
+func pb(s string) []byte { return append([]byte{0x0a, byte(len(s))}, s...) }
+
+// TestSplitLengthPrefixedMessages_FindsBoundariesByPrefix is the core of the
+// streaming work: message boundaries come from the 5-byte prefix, never from
+// how the bytes were chunked on the way in.
+func TestSplitLengthPrefixedMessages_FindsBoundariesByPrefix(t *testing.T) {
+	a, b, c := pb("alpha"), pb("beta"), pb("gamma")
+	stream := append(append(wire(a), wire(b)...), wire(c)...)
+
+	msgs, err := SplitLengthPrefixedMessages(stream)
+	if err != nil {
+		t.Fatalf("splitting a well-formed 3-message stream: %v", err)
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("got %d messages, want 3", len(msgs))
+	}
+	for i, want := range []int{len(a), len(b), len(c)} {
+		if int(msgs[i].MessageLength) != want {
+			t.Fatalf("message %d declares %d bytes, want %d", i, msgs[i].MessageLength, want)
+		}
+	}
+	if msgs[0].DecodedData == msgs[1].DecodedData {
+		t.Fatal("distinct messages decoded identically; boundaries were not honoured")
+	}
+}
+
+// TestSplitLengthPrefixedMessages_IsIndependentOfChunking pins the property
+// that makes the mock deterministic: the same stream split into different
+// DATA-frame-sized pieces must yield the same messages. Frame boundaries are
+// set by MTU, flow control and write batching, so anything that recorded them
+// would produce a different mock on every run.
+func TestSplitLengthPrefixedMessages_IsIndependentOfChunking(t *testing.T) {
+	stream := append(wire(pb("alpha")), wire(pb("beta"))...)
+
+	whole, err := SplitLengthPrefixedMessages(stream)
+	if err != nil {
+		t.Fatalf("whole: %v", err)
+	}
+	// Re-assemble from arbitrary chunk sizes, as the recorder does from DATA
+	// frames, and split again. Every split point is exercised, including ones
+	// that land mid-prefix and mid-payload.
+	for cut := 1; cut < len(stream); cut++ {
+		reassembled := append(append([]byte{}, stream[:cut]...), stream[cut:]...)
+		got, err := SplitLengthPrefixedMessages(reassembled)
+		if err != nil {
+			t.Fatalf("cut at %d: %v", cut, err)
+		}
+		if len(got) != len(whole) {
+			t.Fatalf("cut at %d produced %d messages, want %d. Message count must not depend "+
+				"on how the bytes were chunked in transit.", cut, len(got), len(whole))
+		}
+		for i := range got {
+			if got[i] != whole[i] {
+				t.Fatalf("cut at %d changed message %d", cut, i)
+			}
+		}
+	}
+}
+
+// TestSplitLengthPrefixedMessages_RejectsPartialTail: a chain that does not
+// consume its buffer exactly means the capture was cut off. Inventing a
+// message from the remainder would record a body that cannot reproduce.
+func TestSplitLengthPrefixedMessages_RejectsPartialTail(t *testing.T) {
+	full := append(wire(pb("alpha")), wire(pb("beta"))...)
+
+	for _, tc := range []struct {
+		name string
+		data []byte
+	}{
+		{"truncated mid-payload", full[:len(full)-3]},
+		{"truncated mid-prefix", full[:len(wire(pb("alpha")))+2]},
+		{"declared length runs past the end", wire(pb("alpha"))[:5+2]},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			msgs, err := SplitLengthPrefixedMessages(tc.data)
+			if !errors.Is(err, ErrTrailingGrpcBytes) {
+				t.Fatalf("got err=%v, want ErrTrailingGrpcBytes. A partial capture must be "+
+					"reported, not silently turned into a message.", err)
+			}
+			// Whatever decoded cleanly before the break is still returned so
+			// the caller can decide.
+			_ = msgs
+		})
+	}
+}
+
+func TestSplitLengthPrefixedMessages_EmptyIsNotAnError(t *testing.T) {
+	msgs, err := SplitLengthPrefixedMessages(nil)
+	if err != nil || len(msgs) != 0 {
+		t.Fatalf("empty buffer gave (%v, %d messages), want (nil, 0). A direction carrying only "+
+			"trailers is legitimate.", err, len(msgs))
+	}
+}
+
+// TestCreateLengthPrefixedMessageFromPayload_HonoursDeclaredLength is the
+// regression for the decode bug.
+//
+// The old implementation protoscoped EVERYTHING after byte 5, ignoring the
+// declared length. On a stream that swallows the next message's 5-byte header
+// as if it were protobuf payload, producing a DecodedData that disagrees with
+// the MessageLength sitting beside it.
+func TestCreateLengthPrefixedMessageFromPayload_HonoursDeclaredLength(t *testing.T) {
+	a := pb("alpha")
+	stream := append(wire(a), wire(pb("beta"))...)
+
+	got := CreateLengthPrefixedMessageFromPayload(stream)
+	if int(got.MessageLength) != len(a) {
+		t.Fatalf("MessageLength = %d, want %d", got.MessageLength, len(a))
+	}
+	// The decoded body must be message 0 alone — identical to decoding it in
+	// isolation.
+	alone := CreateLengthPrefixedMessageFromPayload(wire(a))
+	if got.DecodedData != alone.DecodedData {
+		t.Fatalf("decoding the first message of a stream gave:\n  %q\nbut decoding it alone gave:\n  %q\n"+
+			"Decoding past the declared length swallows the next message's header as payload.",
+			got.DecodedData, alone.DecodedData)
+	}
+}
+
+// TestLengthPrefixedRoundTrip: split then re-encode must reproduce the wire
+// bytes exactly, or replay sends something different from what was recorded.
+func TestLengthPrefixedRoundTrip(t *testing.T) {
+	stream := append(append(wire(pb("alpha")), wire(pb("beta"))...), wire(pb("gamma"))...)
+
+	msgs, err := SplitLengthPrefixedMessages(stream)
+	if err != nil {
+		t.Fatalf("split: %v", err)
+	}
+	back, err := CreatePayloadFromLengthPrefixedMessages(msgs)
+	if err != nil {
+		t.Fatalf("re-encode: %v", err)
+	}
+	if string(back) != string(stream) {
+		t.Fatalf("round trip changed the wire bytes:\n got % x\nwant % x", back, stream)
+	}
+}
+
+// oldCreateLengthPrefixedMessageFromPayload is origin/main's implementation,
+// verbatim. It is the reference this package must not diverge from for any
+// input that exists in a recording today.
+func oldCreateLengthPrefixedMessageFromPayload(data []byte) (flag uint, length uint32, decoded string) {
+	if len(data) < 5 {
+		return 0, 0, ""
+	}
+	flag = uint(data[0])
+	length = binary.BigEndian.Uint32(data[1:5])
+	if len(data) > 5 {
+		decoded = protoscopeWrite(data[5:])
+	}
+	return flag, length, decoded
+}
+
+// TestCreateLengthPrefixedMessageFromPayload_MatchesOldOnEverySingleMessage
+// is the no-regression proof for the decode change.
+//
+// Honouring the declared length is a behaviour change, so the question is not
+// "is the new behaviour better" but "can it alter anything already recorded".
+// It cannot: for a well-formed single message 5+length == len(data), so the
+// old slice data[5:] and the new data[5:5+length] are the SAME slice. This
+// sweeps payload lengths, compression flags and payload shapes and requires
+// byte-equality with the old implementation on every one.
+//
+// The divergence is confined to inputs the old code decoded WRONGLY — a
+// multi-message stream, where it swallowed the next message's 5-byte header
+// as payload — and to truncated captures, where both clamp to the bytes
+// present.
+func TestCreateLengthPrefixedMessageFromPayload_MatchesOldOnEverySingleMessage(t *testing.T) {
+	payloads := [][]byte{
+		nil,
+		{},
+		pb(""),
+		pb("a"),
+		pb("alpha"),
+		pb("a longer field value that spans more bytes"),
+		{0x08, 0x96, 0x01},       // varint field
+		{0x12, 0x02, 0xff, 0xfe}, // bytes field with non-UTF8
+		{0x0a, 0x00},             // empty length-delimited
+	}
+	flags := []byte{0, 1}
+
+	for _, flag := range flags {
+		for i, p := range payloads {
+			w := wire(p)
+			w[0] = flag
+
+			oldFlag, oldLen, oldDecoded := oldCreateLengthPrefixedMessageFromPayload(w)
+			got := CreateLengthPrefixedMessageFromPayload(w)
+
+			if got.CompressionFlag != oldFlag || got.MessageLength != oldLen || got.DecodedData != oldDecoded {
+				t.Fatalf("payload %d (flag %d) decoded differently from origin/main:\n"+
+					" old: flag=%d len=%d data=%q\n new: flag=%d len=%d data=%q\n"+
+					"Every mock on disk today is a single message; this path must be byte-identical for them.",
+					i, flag, oldFlag, oldLen, oldDecoded,
+					got.CompressionFlag, got.MessageLength, got.DecodedData)
+			}
+		}
+	}
+}
+
+// TestCreateLengthPrefixedMessageFromPayload_TruncatedMatchesOld: a capture
+// cut off mid-payload must decode the same as before — both take the bytes
+// present and invent nothing.
+func TestCreateLengthPrefixedMessageFromPayload_TruncatedMatchesOld(t *testing.T) {
+	full := wire(pb("alpha"))
+	for cut := 5; cut < len(full); cut++ {
+		trunc := full[:cut]
+		oldFlag, oldLen, oldDecoded := oldCreateLengthPrefixedMessageFromPayload(trunc)
+		got := CreateLengthPrefixedMessageFromPayload(trunc)
+		if got.CompressionFlag != oldFlag || got.MessageLength != oldLen || got.DecodedData != oldDecoded {
+			t.Fatalf("truncated at %d decoded differently from origin/main:\n old: len=%d data=%q\n new: len=%d data=%q",
+				cut, oldLen, oldDecoded, got.MessageLength, got.DecodedData)
+		}
+	}
+}

--- a/pkg/http2.go
+++ b/pkg/http2.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -765,7 +766,21 @@ func SimulateGRPC(ctx context.Context, tc *models.TestCase, testSetID string, lo
 	return grpcResp, nil
 }
 
-// CreateLengthPrefixedMessageFromPayload creates a GrpcLengthPrefixedMessage from raw payload data
+// CreateLengthPrefixedMessageFromPayload creates a GrpcLengthPrefixedMessage
+// from the FIRST length-prefixed message in data.
+//
+// It honours the declared length rather than protoscoping everything after
+// byte 5. Those are the same thing for a well-formed single message, where
+// 5+length == len(data), and different for a stream: decoding past the
+// declared end swallows the NEXT message's 5-byte header as if it were
+// protobuf payload, producing a DecodedData that disagrees with the
+// MessageLength beside it. Prefer SplitLengthPrefixedMessages when the input
+// may carry more than one message.
+//
+// A declared length longer than the data available means the capture was
+// truncated. The bytes present are still decoded — callers that must not
+// serve a partial body detect it by comparing MessageLength against the
+// re-encoded length — but nothing is invented to fill the gap.
 func CreateLengthPrefixedMessageFromPayload(data []byte) models.GrpcLengthPrefixedMessage {
 	msg := models.GrpcLengthPrefixedMessage{}
 
@@ -780,13 +795,84 @@ func CreateLengthPrefixedMessageFromPayload(data []byte) models.GrpcLengthPrefix
 	// The next 4 bytes are message length.
 	msg.MessageLength = binary.BigEndian.Uint32(data[1:5])
 
+	end := 5 + int(msg.MessageLength)
+	if end > len(data) || end < 5 {
+		// Truncated capture, or a length so large it overflowed the add.
+		end = len(data)
+	}
+
 	// The payload could be empty. We only parse it if it is present.
-	if len(data) > 5 {
+	if end > 5 {
 		// Use protoscope to decode the message.
-		msg.DecodedData = protoscope.Write(data[5:], protoscope.WriterOptions{})
+		msg.DecodedData = protoscope.Write(data[5:end], protoscope.WriterOptions{})
 	}
 
 	return msg
+}
+
+// ErrTrailingGrpcBytes reports that a length-prefixed chain did not consume
+// its input exactly — the last message's declared length ran past the end of
+// the buffer, or stopped short of it with fewer than 5 bytes left over.
+var ErrTrailingGrpcBytes = errors.New("grpc: length-prefixed chain does not consume its buffer exactly")
+
+// SplitLengthPrefixedMessages walks a contiguous stream of length-prefixed
+// gRPC messages and returns them in wire order.
+//
+// THIS IS THE ONLY CORRECT WAY TO FIND MESSAGE BOUNDARIES, and the reason is
+// worth stating because the obvious alternative is wrong. HTTP/2 DATA frame
+// boundaries are NOT message boundaries: one message may span several frames,
+// several messages may share one frame, and where the splits fall depends on
+// MTU, flow-control windows and write batching. Recording one entry per frame
+// would make the same RPC produce a different mock on every run and would
+// replay a message split across two frames as two corrupt ones. Boundaries
+// come from the 5-byte prefix and nowhere else.
+//
+// The walk is STRICT: the chain must consume the buffer exactly. A partial
+// trailing message means the capture was cut off, and inventing a message
+// from the remainder would record a body that cannot reproduce. Callers get
+// ErrTrailingGrpcBytes and the messages decoded so far, so they can decide
+// whether to skip the mock or record the prefix.
+//
+// An empty buffer yields no messages and no error — that is a legitimate
+// direction (a client-streaming call whose response carries only trailers).
+func SplitLengthPrefixedMessages(data []byte) ([]models.GrpcLengthPrefixedMessage, error) {
+	var msgs []models.GrpcLengthPrefixedMessage
+	for off := 0; off < len(data); {
+		if len(data)-off < 5 {
+			return msgs, fmt.Errorf("%w: %d trailing byte(s) after %d message(s), too few for a 5-byte prefix",
+				ErrTrailingGrpcBytes, len(data)-off, len(msgs))
+		}
+		length := binary.BigEndian.Uint32(data[off+1 : off+5])
+		end := off + 5 + int(length)
+		if end < off+5 || end > len(data) {
+			return msgs, fmt.Errorf("%w: message %d declares %d bytes but only %d remain",
+				ErrTrailingGrpcBytes, len(msgs), length, len(data)-off-5)
+		}
+		msg := models.GrpcLengthPrefixedMessage{
+			CompressionFlag: uint(data[off]),
+			MessageLength:   length,
+		}
+		if length > 0 {
+			msg.DecodedData = protoscope.Write(data[off+5:end], protoscope.WriterOptions{})
+		}
+		msgs = append(msgs, msg)
+		off = end
+	}
+	return msgs, nil
+}
+
+// CreatePayloadFromLengthPrefixedMessages re-encodes a whole direction back
+// into the contiguous wire form SplitLengthPrefixedMessages accepts.
+func CreatePayloadFromLengthPrefixedMessages(msgs []models.GrpcLengthPrefixedMessage) ([]byte, error) {
+	var out []byte
+	for i, m := range msgs {
+		b, err := CreatePayloadFromLengthPrefixedMessage(m)
+		if err != nil {
+			return nil, fmt.Errorf("message %d of %d: %w", i, len(msgs), err)
+		}
+		out = append(out, b...)
+	}
+	return out, nil
 }
 
 // CreatePayloadFromLengthPrefixedMessage converts a GrpcLengthPrefixedMessage to raw payload bytes

--- a/pkg/models/grpc.go
+++ b/pkg/models/grpc.go
@@ -26,18 +26,103 @@ type GrpcLengthPrefixedMessage struct {
 	DecodedData     string `json:"decoded_data" yaml:"decoded_data"`
 }
 
+// A gRPC direction carries a SEQUENCE of length-prefixed messages, not one.
+// Unary sends exactly one each way; client-, server- and bidi-streaming send
+// many, and server reflection is bidi-streaming, so this is not an exotic
+// case.
+//
+// Body is message 0. AdditionalMessages is the TAIL — messages 1..N — and is
+// empty for every unary call, which is why a unary mock is byte-identical on
+// disk to one written before streams were representable.
+//
+// WHY A TAIL AND NOT A LIST. The obvious shape, retyping Body to a slice, is
+// undeliverable: mocks travel from agent to CLI over gob with no version
+// handshake (agent/routes/record.go -> platform/http/agent.go), and gob sends
+// a type's whole transitive graph before the first value. Changing Body's type
+// breaks decoding of EVERY mock in the stream, including HTTP mocks whose
+// GrpcReq is nil, on any agent/CLI version skew. Adding a field does not.
+//
+// The tail also makes an illegal state unrepresentable. A full list alongside
+// Body would be two sources of truth for message 0, and every existing
+// in-place `Body.DecodedData = ...` write in the replay path would silently
+// stop taking effect. With a tail there is exactly one place message 0 lives.
+//
+// Read through AllMessages(); write through SetMessages(). Do not append to
+// AdditionalMessages directly.
 type GrpcReq struct {
-	Headers   GrpcHeaders               `json:"headers" yaml:"headers"`
-	Body      GrpcLengthPrefixedMessage `json:"body" yaml:"body"`
-	Timestamp time.Time                 `json:"timestamp" yaml:"timestamp"`
+	Headers GrpcHeaders               `json:"headers" yaml:"headers"`
+	Body    GrpcLengthPrefixedMessage `json:"body" yaml:"body"`
+	// AdditionalMessages carries messages 1..N of a streaming request.
+	// omitempty keeps it off disk entirely for unary.
+	AdditionalMessages []GrpcLengthPrefixedMessage `json:"additional_messages,omitempty" yaml:"additional_messages,omitempty"`
+	Timestamp          time.Time                   `json:"timestamp" yaml:"timestamp"`
 }
 
 type GrpcResp struct {
-	Headers   GrpcHeaders               `json:"headers" yaml:"headers"`
-	Body      GrpcLengthPrefixedMessage `json:"body" yaml:"body"`
-	Trailers  GrpcHeaders               `json:"trailers" yaml:"trailers"`
-	Timestamp time.Time                 `json:"timestamp" yaml:"timestamp"`
+	Headers GrpcHeaders               `json:"headers" yaml:"headers"`
+	Body    GrpcLengthPrefixedMessage `json:"body" yaml:"body"`
+	// AdditionalMessages carries messages 1..N of a streaming response.
+	AdditionalMessages []GrpcLengthPrefixedMessage `json:"additional_messages,omitempty" yaml:"additional_messages,omitempty"`
+	Trailers           GrpcHeaders                 `json:"trailers" yaml:"trailers"`
+	Timestamp          time.Time                   `json:"timestamp" yaml:"timestamp"`
 }
+
+// AllMessages returns the direction's messages in wire order.
+//
+// It ALWAYS returns at least one element, and that is load-bearing rather
+// than defensive. A zero-value Body is a real recorded shape — the Health
+// check test case stores message_length: 0 with an empty decoded_data, and
+// replay sends exactly one message with a nil payload for it. Returning an
+// empty slice for that would make `for range AllMessages()` send nothing and
+// hang the RPC, turning a passing unary test into a timeout.
+func (r GrpcReq) AllMessages() []GrpcLengthPrefixedMessage {
+	return allMessages(r.Body, r.AdditionalMessages)
+}
+
+// AllMessages returns the response's messages in wire order. See GrpcReq.AllMessages.
+func (r GrpcResp) AllMessages() []GrpcLengthPrefixedMessage {
+	return allMessages(r.Body, r.AdditionalMessages)
+}
+
+func allMessages(head GrpcLengthPrefixedMessage, tail []GrpcLengthPrefixedMessage) []GrpcLengthPrefixedMessage {
+	out := make([]GrpcLengthPrefixedMessage, 0, 1+len(tail))
+	out = append(out, head)
+	return append(out, tail...)
+}
+
+// SetMessages stores msgs in wire order, splitting head from tail.
+//
+// An empty msgs zeroes the direction rather than leaving a stale body, so
+// callers cannot half-write a direction by passing nothing.
+func (r *GrpcReq) SetMessages(msgs []GrpcLengthPrefixedMessage) {
+	r.Body, r.AdditionalMessages = splitMessages(msgs)
+}
+
+// SetMessages stores msgs in wire order. See GrpcReq.SetMessages.
+func (r *GrpcResp) SetMessages(msgs []GrpcLengthPrefixedMessage) {
+	r.Body, r.AdditionalMessages = splitMessages(msgs)
+}
+
+func splitMessages(msgs []GrpcLengthPrefixedMessage) (GrpcLengthPrefixedMessage, []GrpcLengthPrefixedMessage) {
+	if len(msgs) == 0 {
+		return GrpcLengthPrefixedMessage{}, nil
+	}
+	if len(msgs) == 1 {
+		// nil, not an empty slice: omitempty must keep it off disk so a
+		// unary mock stays byte-identical to one written before streaming
+		// was representable.
+		return msgs[0], nil
+	}
+	tail := make([]GrpcLengthPrefixedMessage, len(msgs)-1)
+	copy(tail, msgs[1:])
+	return msgs[0], tail
+}
+
+// IsStream reports whether this direction carries more than one message.
+func (r GrpcReq) IsStream() bool { return len(r.AdditionalMessages) > 0 }
+
+// IsStream reports whether this direction carries more than one message.
+func (r GrpcResp) IsStream() bool { return len(r.AdditionalMessages) > 0 }
 
 // GrpcStream is a helper function to combine the request-response model in a single struct
 type GrpcStream struct {

--- a/pkg/models/grpc_stream_test.go
+++ b/pkg/models/grpc_stream_test.go
@@ -1,0 +1,161 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	yamlLib "gopkg.in/yaml.v3"
+)
+
+// TestAllMessages_ZeroBodyStillYieldsOneMessage is the guard that keeps a
+// currently-passing unary test from turning into a hang.
+//
+// A zero-value Body is a REAL recorded shape, not an empty one: the gRPC
+// health-check test case stores `message_length: 0` with an empty
+// `decoded_data`, and replay sends exactly one message with a nil payload for
+// it. If AllMessages returned an empty slice for that, `for range
+// AllMessages()` would send nothing and the RPC would hang waiting for a
+// response that is never written.
+func TestAllMessages_ZeroBodyStillYieldsOneMessage(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		got  []GrpcLengthPrefixedMessage
+	}{
+		{"request", GrpcReq{}.AllMessages()},
+		{"response", GrpcResp{}.AllMessages()},
+	} {
+		if len(tc.got) != 1 {
+			t.Fatalf("%s: a zero-value body yielded %d messages, want exactly 1. The health-check "+
+				"test case records message_length:0 with empty decoded_data and replay sends one "+
+				"empty message for it; returning none makes that RPC hang.", tc.name, len(tc.got))
+		}
+	}
+}
+
+func TestSetMessages_RoundTripsAndKeepsUnaryTailNil(t *testing.T) {
+	msgs := []GrpcLengthPrefixedMessage{
+		{MessageLength: 5, DecodedData: `1: {"alpha"}`},
+		{MessageLength: 4, DecodedData: `1: {"beta"}`},
+		{MessageLength: 5, DecodedData: `1: {"gamma"}`},
+	}
+
+	var req GrpcReq
+	req.SetMessages(msgs)
+	if got := req.AllMessages(); len(got) != 3 || got[0].DecodedData != msgs[0].DecodedData ||
+		got[2].DecodedData != msgs[2].DecodedData {
+		t.Fatalf("round trip lost order or content: %+v", got)
+	}
+	if !req.IsStream() {
+		t.Fatal("three messages should report IsStream")
+	}
+
+	// One message must leave the tail NIL, not an empty slice: omitempty is
+	// what keeps a unary mock byte-identical on disk, and an empty non-nil
+	// slice still marshals in some encoders.
+	var unary GrpcResp
+	unary.SetMessages(msgs[:1])
+	if unary.AdditionalMessages != nil {
+		t.Fatalf("a single message left AdditionalMessages = %#v, want nil", unary.AdditionalMessages)
+	}
+	if unary.IsStream() {
+		t.Fatal("one message must not report IsStream")
+	}
+
+	// Empty input zeroes the direction rather than leaving a stale body.
+	var stale GrpcResp
+	stale.SetMessages(msgs)
+	stale.SetMessages(nil)
+	if stale.Body != (GrpcLengthPrefixedMessage{}) || stale.AdditionalMessages != nil {
+		t.Fatalf("SetMessages(nil) left %+v, want a zeroed direction", stale)
+	}
+}
+
+// TestUnaryEncodingIsUnchanged is the compatibility guard that matters most.
+//
+// Every mock already on a user's disk is unary-shaped. If adding the tail
+// field changed what a unary mock serialises to, then normalise, templatize,
+// dedup or a re-record would silently rewrite those files into a shape older
+// keploy cannot read — and a decode error is fatal for the WHOLE file, not
+// just the offending document. Nothing new may appear on disk until there is
+// actually a second message.
+func TestUnaryEncodingIsUnchanged(t *testing.T) {
+	body := GrpcLengthPrefixedMessage{CompressionFlag: 0, MessageLength: 7, DecodedData: `1: {"alpha"}`}
+
+	resp := GrpcResp{Body: body}
+	y, err := yamlLib.Marshal(resp)
+	if err != nil {
+		t.Fatalf("yaml: %v", err)
+	}
+	j, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	for _, out := range []string{string(y), string(j)} {
+		if containsKey(out, "additional_messages") {
+			t.Fatalf("a unary response emitted additional_messages:\n%s\nA unary mock must stay "+
+				"byte-identical to one written before streaming was representable, or every "+
+				"rewrite is a one-way upgrade the user did not ask for.", out)
+		}
+	}
+}
+
+// TestLegacyMockDecodesWithNoTail pins the read direction: a mock written
+// before this field existed must load with exactly one message.
+func TestLegacyMockDecodesWithNoTail(t *testing.T) {
+	const legacy = `
+headers:
+    pseudo_headers: {}
+    ordinary_headers: {}
+body:
+    compression_flag: 0
+    message_length: 7
+    decoded_data: '1: {"alpha"}'
+trailers:
+    pseudo_headers: {}
+    ordinary_headers: {}
+timestamp: 0001-01-01T00:00:00Z
+`
+	var resp GrpcResp
+	if err := yamlLib.Unmarshal([]byte(legacy), &resp); err != nil {
+		t.Fatalf("a pre-streaming mock failed to decode: %v", err)
+	}
+	if got := resp.AllMessages(); len(got) != 1 || got[0].MessageLength != 7 {
+		t.Fatalf("legacy mock decoded to %+v, want exactly one 7-byte message", got)
+	}
+	if resp.IsStream() {
+		t.Fatal("a legacy mock must not look like a stream")
+	}
+}
+
+// TestStreamingMockRoundTripsThroughYAML covers the new shape end to end.
+func TestStreamingMockRoundTripsThroughYAML(t *testing.T) {
+	var resp GrpcResp
+	resp.SetMessages([]GrpcLengthPrefixedMessage{
+		{MessageLength: 7, DecodedData: `1: {"alpha"}`},
+		{MessageLength: 6, DecodedData: `1: {"beta"}`},
+	})
+	out, err := yamlLib.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !containsKey(string(out), "additional_messages") {
+		t.Fatalf("a two-message response did not emit additional_messages:\n%s", out)
+	}
+	var back GrpcResp
+	if err := yamlLib.Unmarshal(out, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got := back.AllMessages()
+	if len(got) != 2 || got[0].DecodedData != `1: {"alpha"}` || got[1].DecodedData != `1: {"beta"}` {
+		t.Fatalf("round trip changed the stream: %+v", got)
+	}
+}
+
+func containsKey(s, key string) bool {
+	for i := 0; i+len(key) <= len(s); i++ {
+		if s[i:i+len(key)] == key {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/platform/yaml/testdb/grpc_ondisk_golden_test.go
+++ b/pkg/platform/yaml/testdb/grpc_ondisk_golden_test.go
@@ -1,0 +1,204 @@
+package testdb
+
+import (
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+	yamlLib "gopkg.in/yaml.v3"
+)
+
+// unaryGrpcGolden is the EXACT on-disk spec a unary gRPC test case encodes to.
+//
+// It was captured from origin/main before streaming support existed and is
+// byte-for-byte what that build produces. Every gRPC mock and test case
+// already on a user's disk is unary-shaped, so this string is the contract
+// with all of them.
+//
+// If this test fails, a unary recording no longer round-trips through the
+// build that wrote it. That is not a cosmetic diff: normalise, templatize,
+// dedup and re-record all rewrite these files, and a decode error is fatal
+// for the WHOLE file — mockdb and testdb both return the first decode error
+// up rather than skipping the offending document. So a change here silently
+// converts every existing recording into a shape the previous keploy cannot
+// read, on the next unrelated operation, without the user asking for it.
+//
+// Adding a field to GrpcReq/GrpcResp is safe ONLY while it stays omitempty
+// and stays empty for one message. Do not "fix" this test by re-capturing
+// the golden; fix the encoder.
+const unaryGrpcGolden = `metadata: {}
+grpcReq:
+    headers:
+        pseudo_headers:
+            :method: POST
+            :path: /pkg.Svc/Method
+        ordinary_headers:
+            content-type: application/grpc
+    body:
+        compression_flag: 0
+        message_length: 7
+        decoded_data: '1: {"alpha"}'
+    timestamp: 2023-11-14T22:13:20Z
+grpcResp:
+    headers:
+        pseudo_headers:
+            :method: POST
+            :path: /pkg.Svc/Method
+        ordinary_headers:
+            content-type: application/grpc
+    body:
+        compression_flag: 0
+        message_length: 7
+        decoded_data: '1: {"alpha"}'
+    trailers:
+        pseudo_headers: {}
+        ordinary_headers:
+            grpc-status: "0"
+    timestamp: 2023-11-14T22:13:20Z
+created: 1700000000
+assertions: {}
+`
+
+func unaryGrpcTestCase() models.TestCase {
+	hdr := models.GrpcHeaders{
+		PseudoHeaders:   map[string]string{":method": "POST", ":path": "/pkg.Svc/Method"},
+		OrdinaryHeaders: map[string]string{"content-type": "application/grpc"},
+	}
+	body := models.GrpcLengthPrefixedMessage{CompressionFlag: 0, MessageLength: 7, DecodedData: `1: {"alpha"}`}
+	ts := time.Unix(1700000000, 0).UTC()
+	return models.TestCase{
+		Version: models.V1Beta1, Kind: models.GRPC_EXPORT, Name: "grpc-unary-golden",
+		GrpcReq: models.GrpcReq{Headers: hdr, Body: body, Timestamp: ts},
+		GrpcResp: models.GrpcResp{
+			Headers: hdr, Body: body,
+			Trailers:  models.GrpcHeaders{PseudoHeaders: map[string]string{}, OrdinaryHeaders: map[string]string{"grpc-status": "0"}},
+			Timestamp: ts,
+		},
+		Created: 1700000000,
+	}
+}
+
+// TestEncodeTestcase_UnaryGrpcOnDiskShapeIsUnchanged pins the on-disk bytes
+// through the REAL encoder, not a struct-level yaml.Marshal. The encoder is
+// what actually writes user files, and it is where a regression would land.
+func TestEncodeTestcase_UnaryGrpcOnDiskShapeIsUnchanged(t *testing.T) {
+	doc, err := EncodeTestcase(unaryGrpcTestCase(), zap.NewNop())
+	if err != nil {
+		t.Fatalf("EncodeTestcase: %v", err)
+	}
+	out, err := yamlLib.Marshal(&doc.Spec)
+	if err != nil {
+		t.Fatalf("marshal spec: %v", err)
+	}
+	if string(out) != unaryGrpcGolden {
+		t.Fatalf("a unary gRPC test case no longer encodes to the bytes origin/main wrote.\n"+
+			"--- got ---\n%s\n--- want ---\n%s\n"+
+			"Every existing recording is unary-shaped. A change here means the next normalise, "+
+			"templatize, dedup or re-record rewrites those files into a shape the previous "+
+			"keploy cannot read, and a decode error there is fatal for the whole file.",
+			out, unaryGrpcGolden)
+	}
+}
+
+// TestEncodeTestcase_StreamingGrpcAddsOnlyTheTail proves the new field is
+// strictly additive: the streaming document is the golden one plus the tail,
+// with nothing else moved or changed.
+func TestEncodeTestcase_StreamingGrpcAddsOnlyTheTail(t *testing.T) {
+	tc := unaryGrpcTestCase()
+	tc.GrpcResp.SetMessages([]models.GrpcLengthPrefixedMessage{
+		tc.GrpcResp.Body,
+		{CompressionFlag: 0, MessageLength: 6, DecodedData: `1: {"beta"}`},
+	})
+
+	doc, err := EncodeTestcase(tc, zap.NewNop())
+	if err != nil {
+		t.Fatalf("EncodeTestcase: %v", err)
+	}
+	out, err := yamlLib.Marshal(&doc.Spec)
+	if err != nil {
+		t.Fatalf("marshal spec: %v", err)
+	}
+	got := string(out)
+
+	// The tail must appear...
+	if !contains(got, "additional_messages") {
+		t.Fatalf("a two-message response did not emit additional_messages:\n%s", got)
+	}
+	// ...and message 0 must still be exactly where it was.
+	if !contains(got, "        decoded_data: '1: {\"alpha\"}'") {
+		t.Fatalf("message 0 moved or changed shape:\n%s", got)
+	}
+	// ...and the request, which is still unary, must be untouched.
+	reqStart := indexOf(got, "grpcReq:")
+	reqEnd := indexOf(got, "grpcResp:")
+	if reqStart < 0 || reqEnd < 0 || contains(got[reqStart:reqEnd], "additional_messages") {
+		t.Fatalf("a unary REQUEST gained a tail because the response had one:\n%s", got[maxInt(reqStart, 0):maxInt(reqEnd, 0)])
+	}
+
+	// And it must read back as the same two messages, through the REAL
+	// reader (testdb.Decode), not a hand-rolled unmarshal — that is the
+	// function which loads a user's recorded file.
+	doc.Kind = models.GRPC_EXPORT
+	doc.Name = tc.Name
+	doc.Version = models.V1Beta1
+	back, err := Decode(doc, zap.NewNop())
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if msgs := back.GrpcResp.AllMessages(); len(msgs) != 2 ||
+		msgs[0].DecodedData != `1: {"alpha"}` || msgs[1].DecodedData != `1: {"beta"}` {
+		t.Fatalf("round trip through the real reader changed the stream: %+v", msgs)
+	}
+	if back.GrpcReq.IsStream() {
+		t.Fatal("the unary request read back as a stream")
+	}
+}
+
+func contains(s, sub string) bool { return indexOf(s, sub) >= 0 }
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// TestEncodeTestcase_UnaryViaSetMessagesMatchesGolden covers the path a
+// RECORDER actually takes.
+//
+// The golden test above builds the fixture by assigning Body directly, which
+// is how a hand-written test case looks. A recorder does not do that — it
+// calls SetMessages with whatever it decoded, which for a unary call is a
+// one-element slice. If SetMessages left an empty-but-non-nil tail there,
+// omitempty would not suppress it in every encoder and unary recordings would
+// start carrying an `additional_messages: []` key that older keploy has never
+// seen. Same golden, reached the way production reaches it.
+func TestEncodeTestcase_UnaryViaSetMessagesMatchesGolden(t *testing.T) {
+	tc := unaryGrpcTestCase()
+	body := tc.GrpcResp.Body
+	tc.GrpcReq.SetMessages([]models.GrpcLengthPrefixedMessage{body})
+	tc.GrpcResp.SetMessages([]models.GrpcLengthPrefixedMessage{body})
+
+	doc, err := EncodeTestcase(tc, zap.NewNop())
+	if err != nil {
+		t.Fatalf("EncodeTestcase: %v", err)
+	}
+	out, err := yamlLib.Marshal(&doc.Spec)
+	if err != nil {
+		t.Fatalf("marshal spec: %v", err)
+	}
+	if string(out) != unaryGrpcGolden {
+		t.Fatalf("a unary gRPC test case built through SetMessages does not match the golden "+
+			"on-disk bytes.\n--- got ---\n%s\n--- want ---\n%s\nA recorder reaches this path for "+
+			"every unary call, so a difference here changes every new recording.",
+			out, unaryGrpcGolden)
+	}
+}


### PR DESCRIPTION
A gRPC direction carries a **sequence** of length-prefixed messages. The model held one, so client-, server- and bidi-streaming could not be represented at all — and **server reflection is bidi-streaming**, so this is not an exotic corner.

This lands the schema and the framing. Recorders and the replay drain follow in separate PRs.

### Why a tail, not a slice

Retyping `Body` to `[]GrpcLengthPrefixedMessage` is undeliverable. Mocks travel agent→CLI over **gob with no version handshake**, and gob sends a type's whole transitive graph before the first value. I ran it rather than trusting the reasoning:

| stream | result |
|---|---|
| old encoder → retyped decoder | ❌ **both mocks fail**, incl. an HTTP-only mock whose `*GrpcReq` is nil — `gob: wrong type ([]Msg) for received field OldReq.Body` |
| old encoder → tail decoder | ✅ both decode, body intact |
| tail encoder → old decoder | ✅ both decode, tail silently ignored |

The tail also makes an illegal state unrepresentable: a full list beside `Body` would be two sources of truth for message 0, and every in-place `Body.DecodedData = ...` write in the replay path would silently stop taking effect.

`AllMessages()` always returns **at least one** element — load-bearing, not defensive. The health-check test case records `message_length: 0` with empty `decoded_data`, and replay sends exactly one empty message for it; returning nothing would hang a currently-passing unary test.

### Framing comes from the length prefix, never from DATA frames

HTTP/2 frame boundaries are **not** message boundaries: one message may span several frames, several may share one, and where the splits land depends on MTU, flow-control windows and write batching. Recording per frame would make the same RPC produce a different mock every run.

`TestSplitLengthPrefixedMessages_IsIndependentOfChunking` re-splits the same stream at **every byte offset** and requires identical output.

`CreateLengthPrefixedMessageFromPayload` now honours the declared length instead of protoscoping everything after byte 5 — which on a stream swallowed the next message's header as payload, producing a `DecodedData` that disagreed with the `MessageLength` beside it.

### Nothing existing changes — proved, not asserted

- **On-disk golden captured from `origin/main`**, asserted through the **real encoder** (`testdb.EncodeTestcase`), not a struct-level marshal. Byte-for-byte identical — both via a literal `Body` and via `SetMessages`, which is the path a recorder actually takes.
- **Differential test** pins the new decode against origin/main's implementation across payload shapes, compression flags and *every* truncation offset. They agree everywhere. The only divergence is multi-message input, which the old code decoded wrongly.
- gRPC types carry **no bson tags** and OSS never bson-marshals them, so that boundary is additive-only.

Mutations caught: restoring the decode-past-length bug; a lenient splitter; `AllMessages()` empty for a zero body; losing `omitempty` (fails both goldens).

`go build ./... && go test ./...` green.
