### PR TITLE
feat(matcher/grpc): compare streams positionally, and fail when the count differs

### DIFF
--- a/pkg/http2.go
+++ b/pkg/http2.go
@@ -12,6 +12,7 @@ import (
 	"maps"
 	"net"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -25,6 +26,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -657,6 +659,23 @@ func SimulateGRPC(ctx context.Context, tc *models.TestCase, testSetID string, lo
 		md[k] = []string{v}
 	}
 
+	// Bound the whole call, because the drain below is now a loop.
+	//
+	// A single RecvMsg was self-limiting. Draining to io.EOF is not: a bidi
+	// stream the server holds open — server reflection is exactly that shape
+	// — never reaches EOF, so without a deadline one bad test case blocks
+	// until the entire test-run context dies, taking the rest of the test set
+	// with it and attributing the hang to nothing in particular.
+	//
+	// APITimeout is the same knob the HTTP replay path uses. Zero means the
+	// caller did not set one, so fall back rather than leaving it unbounded.
+	timeout := time.Duration(cfg.APITimeout) * time.Second
+	if timeout <= 0 {
+		timeout = defaultGrpcCallTimeout
+	}
+	ctx, cancelCall := context.WithTimeout(ctx, timeout)
+	defer cancelCall()
+
 	// Create context with metadata
 	callCtx := metadata.NewOutgoingContext(ctx, md)
 
@@ -670,24 +689,31 @@ func SimulateGRPC(ctx context.Context, tc *models.TestCase, testSetID string, lo
 		return nil, fmt.Errorf("failed to create stream: %w", err)
 	}
 
-	// Convert the request body to raw message format
-	// For gRPC client with passthrough codec, we only need the protobuf bytes, not the full gRPC frame
-	var requestPayload []byte
-	if grpcReq.Body.DecodedData != "" {
-		// Parse the protoscope format back to bytes
-		scanner := protoscope.NewScanner(grpcReq.Body.DecodedData)
-		var err error
-		requestPayload, err = scanner.Exec()
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse request payload: %w", err)
+	// Send every recorded request message, in order.
+	//
+	// A client-streaming or bidi call records N messages; sending only the
+	// first replays a different request from the one that was captured, and
+	// the server's response to it is not the response that was recorded.
+	//
+	// AllMessages() always yields at least one element, including for a
+	// zero-value body — the health check records message_length 0 with empty
+	// decoded_data and expects exactly one empty message. An empty payload
+	// here is a real message, not the absence of one.
+	reqMsgs := grpcReq.AllMessages()
+	for i, m := range reqMsgs {
+		var requestPayload []byte
+		if m.DecodedData != "" {
+			// Parse the protoscope format back to bytes
+			scanner := protoscope.NewScanner(m.DecodedData)
+			var err error
+			requestPayload, err = scanner.Exec()
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse request payload (message %d of %d): %w", i, len(reqMsgs), err)
+			}
 		}
-	}
-
-	requestMsg := &rawMessage{data: requestPayload}
-
-	// Send the request
-	if err := stream.SendMsg(requestMsg); err != nil {
-		return nil, fmt.Errorf("failed to send request: %w", err)
+		if err := stream.SendMsg(&rawMessage{data: requestPayload}); err != nil {
+			return nil, fmt.Errorf("failed to send request (message %d of %d): %w", i, len(reqMsgs), err)
+		}
 	}
 
 	// Close the send side of the stream
@@ -701,13 +727,45 @@ func SimulateGRPC(ctx context.Context, tc *models.TestCase, testSetID string, lo
 		return nil, fmt.Errorf("failed to get response headers: %w", err)
 	}
 
-	// Read the response message
-	responseMsg := &rawMessage{}
-	if err := stream.RecvMsg(responseMsg); err != nil && err != io.EOF {
-		return nil, fmt.Errorf("failed to receive response: %w", err)
+	// Drain the response stream to io.EOF.
+	//
+	// A single RecvMsg captures the first message of a server-streaming or
+	// bidi response and abandons the rest, which also tears the connection
+	// down early — so the app handler aborts and any dependency calls behind
+	// messages 2..N never run.
+	//
+	// TRAILERS MUST BE READ AFTER THE DRAIN, NOT AFTER THE FIRST MESSAGE.
+	// grpc-go only populates Trailer() once RecvMsg has returned a non-nil
+	// error. Reading it earlier returns an empty map, the grpc-status fixup
+	// below then fabricates "0", and a stream that died partway replays as a
+	// clean success — the worst possible outcome, because it looks correct.
+	var respMsgs []models.GrpcLengthPrefixedMessage
+	var drainErr error
+	for {
+		responseMsg := &rawMessage{}
+		err := stream.RecvMsg(responseMsg)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			// Not fatal: this error IS the RPC's outcome and belongs in the
+			// mock. Stop draining and record it below, rather than discarding
+			// a partial stream and the reason it ended.
+			drainErr = err
+			logger.Debug("gRPC response stream ended with an error; recording what arrived",
+				zap.String("method", path), zap.Int("messages", len(respMsgs)), zap.Error(err))
+			break
+		}
+		respMsgs = append(respMsgs, createLengthPrefixedMessage(responseMsg.data))
+	}
+	if len(respMsgs) == 0 {
+		// A response carrying only trailers is legitimate (an error status, or
+		// a client-streaming call the server rejects). Keep one empty message
+		// so the recorded shape matches what a single RecvMsg used to produce.
+		respMsgs = append(respMsgs, createLengthPrefixedMessage(nil))
 	}
 
-	// Get trailers
+	// Now that the stream is finished, the trailers are real.
 	trailers := stream.Trailer()
 
 	// Construct the response
@@ -716,7 +774,6 @@ func SimulateGRPC(ctx context.Context, tc *models.TestCase, testSetID string, lo
 			PseudoHeaders:   make(map[string]string),
 			OrdinaryHeaders: make(map[string]string),
 		},
-		Body: createLengthPrefixedMessage(responseMsg.data),
 		Trailers: models.GrpcHeaders{
 			PseudoHeaders:   make(map[string]string),
 			OrdinaryHeaders: make(map[string]string),
@@ -754,6 +811,24 @@ func SimulateGRPC(ctx context.Context, tc *models.TestCase, testSetID string, lo
 		}
 	}
 
+	// The real status comes from the terminal RecvMsg error, NOT from the
+	// trailer map.
+	//
+	// grpc-go consumes grpc-status and grpc-message off the wire and turns
+	// them into the error RecvMsg returns; Trailer() carries only the
+	// application's own custom trailers. So a stream that ended INTERNAL has
+	// no grpc-status key at all, and the default below would fabricate "0" —
+	// replaying a failed RPC as a clean pass. Reading the status off the
+	// error is what makes a mid-stream failure visible.
+	if drainErr != nil {
+		if st, ok := status.FromError(drainErr); ok {
+			grpcResp.Trailers.OrdinaryHeaders["grpc-status"] = strconv.Itoa(int(st.Code()))
+			if msg := st.Message(); msg != "" {
+				grpcResp.Trailers.OrdinaryHeaders["grpc-message"] = msg
+			}
+		}
+	}
+
 	// Ensure mandatory gRPC status is present
 	if _, ok := grpcResp.Trailers.OrdinaryHeaders["grpc-status"]; !ok {
 		grpcResp.Trailers.OrdinaryHeaders["grpc-status"] = "0"
@@ -762,9 +837,17 @@ func SimulateGRPC(ctx context.Context, tc *models.TestCase, testSetID string, lo
 		grpcResp.Trailers.OrdinaryHeaders["grpc-message"] = ""
 	}
 
-	logger.Info("successfully completed gRPC simulation", zap.String("method", path))
+	grpcResp.SetMessages(respMsgs)
+
+	logger.Info("successfully completed gRPC simulation",
+		zap.String("method", path), zap.Int("response_messages", len(respMsgs)))
 	return grpcResp, nil
 }
+
+// defaultGrpcCallTimeout bounds a replayed gRPC call when the caller supplies
+// no APITimeout. It exists so the response drain can never hang a test set on
+// a stream the server holds open; it is not a latency target.
+const defaultGrpcCallTimeout = 30 * time.Second
 
 // CreateLengthPrefixedMessageFromPayload creates a GrpcLengthPrefixedMessage
 // from the FIRST length-prefixed message in data.

--- a/pkg/http2_grpc_stream_replay_test.go
+++ b/pkg/http2_grpc_stream_replay_test.go
@@ -1,0 +1,213 @@
+package pkg
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// rawSrvCodec passes bytes through untouched, so the fake server can speak
+// gRPC without any .proto — the same trick the real parser uses.
+type rawSrvCodec struct{}
+
+func (rawSrvCodec) Name() string { return "proto" }
+func (rawSrvCodec) Marshal(v interface{}) ([]byte, error) {
+	if m, ok := v.(*rawMessage); ok {
+		return m.data, nil
+	}
+	return nil, fmt.Errorf("unexpected type %T", v)
+}
+func (rawSrvCodec) Unmarshal(data []byte, v interface{}) error {
+	if m, ok := v.(*rawMessage); ok {
+		m.data = append([]byte(nil), data...)
+		return nil
+	}
+	return fmt.Errorf("unexpected type %T", v)
+}
+
+// streamingServer answers every method by echoing back `respond` messages and
+// finishing with `st`. It records how many request messages it received.
+type streamingServer struct {
+	respond  [][]byte
+	st       error
+	gotReqs  chan int
+	holdOpen chan struct{} // when non-nil, never returns: models a bidi stream the server holds open
+}
+
+func (s *streamingServer) handle(_ interface{}, stream grpc.ServerStream) error {
+	n := 0
+	for {
+		var m rawMessage
+		if err := stream.RecvMsg(&m); err != nil {
+			break
+		}
+		n++
+	}
+	if s.gotReqs != nil {
+		s.gotReqs <- n
+	}
+	for _, r := range s.respond {
+		if err := stream.SendMsg(&rawMessage{data: r}); err != nil {
+			return err
+		}
+	}
+	if s.holdOpen != nil {
+		<-s.holdOpen // never completes within the test's patience
+	}
+	return s.st
+}
+
+func startStreamingServer(t *testing.T, srv *streamingServer) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	g := grpc.NewServer(
+		grpc.ForceServerCodec(rawSrvCodec{}),
+		grpc.UnknownServiceHandler(srv.handle),
+	)
+	go func() { _ = g.Serve(ln) }()
+	t.Cleanup(func() { g.Stop(); _ = ln.Close() })
+	return ln.Addr().String()
+}
+
+// pbMsg builds a trivial protobuf payload: field 1, length-delimited string.
+func pbMsg(s string) []byte { return append([]byte{0x0a, byte(len(s))}, s...) }
+
+func grpcTestCase(addr string, reqMsgs []models.GrpcLengthPrefixedMessage) *models.TestCase {
+	req := models.GrpcReq{
+		Headers: models.GrpcHeaders{
+			PseudoHeaders: map[string]string{
+				":authority": addr,
+				":path":      "/pkg.Svc/Method",
+				":method":    "POST",
+			},
+			OrdinaryHeaders: map[string]string{"content-type": "application/grpc"},
+		},
+	}
+	req.SetMessages(reqMsgs)
+	return &models.TestCase{Name: "stream-replay", Kind: models.GRPC_EXPORT, GrpcReq: req}
+}
+
+// TestSimulateGRPC_DrainsEveryResponseMessage is the core of streaming replay.
+//
+// A single RecvMsg captured the first message of a server-streaming response
+// and abandoned the rest — and by tearing the stream down early it also meant
+// the app handler aborted, so dependency calls behind messages 2..N never ran.
+func TestSimulateGRPC_DrainsEveryResponseMessage(t *testing.T) {
+	want := [][]byte{pbMsg("one"), pbMsg("two"), pbMsg("three")}
+	addr := startStreamingServer(t, &streamingServer{respond: want})
+
+	tc := grpcTestCase(addr, []models.GrpcLengthPrefixedMessage{{}})
+	resp, err := SimulateGRPC(context.Background(), tc, "set", zap.NewNop(), SimulationConfig{APITimeout: 10})
+	if err != nil {
+		t.Fatalf("SimulateGRPC: %v", err)
+	}
+	got := resp.AllMessages()
+	if len(got) != len(want) {
+		t.Fatalf("captured %d response messages, want %d. A single RecvMsg takes the first and "+
+			"abandons the rest of the stream.", len(got), len(want))
+	}
+	for i := range want {
+		if int(got[i].MessageLength) != len(want[i]) {
+			t.Fatalf("message %d has length %d, want %d", i, got[i].MessageLength, len(want[i]))
+		}
+	}
+}
+
+// TestSimulateGRPC_SendsEveryRequestMessage: a client-streaming call records N
+// request messages; sending only the first replays a different request than
+// the one captured.
+func TestSimulateGRPC_SendsEveryRequestMessage(t *testing.T) {
+	gotReqs := make(chan int, 1)
+	addr := startStreamingServer(t, &streamingServer{respond: [][]byte{pbMsg("ack")}, gotReqs: gotReqs})
+
+	reqs := []models.GrpcLengthPrefixedMessage{
+		{MessageLength: 5, DecodedData: `1: {"one"}`},
+		{MessageLength: 5, DecodedData: `1: {"two"}`},
+		{MessageLength: 7, DecodedData: `1: {"three"}`},
+	}
+	tc := grpcTestCase(addr, reqs)
+	if _, err := SimulateGRPC(context.Background(), tc, "set", zap.NewNop(), SimulationConfig{APITimeout: 10}); err != nil {
+		t.Fatalf("SimulateGRPC: %v", err)
+	}
+	select {
+	case n := <-gotReqs:
+		if n != len(reqs) {
+			t.Fatalf("the server received %d request messages, want %d", n, len(reqs))
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("server never reported")
+	}
+}
+
+// TestSimulateGRPC_TrailersAreRealNotFabricated is the ordering bug.
+//
+// grpc-go only populates Trailer() once RecvMsg has returned a non-nil error.
+// Reading it right after the first message returns an EMPTY map, and the
+// fixup below then fabricates grpc-status "0" — so a stream that failed
+// replays as a clean success, which is the worst possible outcome because it
+// looks correct.
+func TestSimulateGRPC_TrailersAreRealNotFabricated(t *testing.T) {
+	addr := startStreamingServer(t, &streamingServer{
+		respond: [][]byte{pbMsg("partial")},
+		st:      status.Error(codes.Internal, "boom"),
+	})
+
+	tc := grpcTestCase(addr, []models.GrpcLengthPrefixedMessage{{}})
+	resp, err := SimulateGRPC(context.Background(), tc, "set", zap.NewNop(), SimulationConfig{APITimeout: 10})
+	if err != nil {
+		t.Fatalf("SimulateGRPC: %v", err)
+	}
+	gotStatus := resp.Trailers.OrdinaryHeaders["grpc-status"]
+	wantStatus := fmt.Sprintf("%d", codes.Internal)
+	if gotStatus != wantStatus {
+		t.Fatalf("grpc-status = %q, want %q. Trailers must be read AFTER the drain reaches "+
+			"io.EOF; reading them earlier yields an empty map and the fixup fabricates \"0\", "+
+			"so a failed RPC replays as a pass.", gotStatus, wantStatus)
+	}
+}
+
+// TestSimulateGRPC_HeldOpenStreamIsBounded: draining to io.EOF is not
+// self-limiting the way one RecvMsg was. A bidi stream the server holds open
+// — server reflection is exactly that shape — must fail this ONE test case
+// rather than block until the whole test-run context dies.
+func TestSimulateGRPC_HeldOpenStreamIsBounded(t *testing.T) {
+	hold := make(chan struct{})
+	t.Cleanup(func() { close(hold) })
+	addr := startStreamingServer(t, &streamingServer{respond: [][]byte{pbMsg("first")}, holdOpen: hold})
+
+	tc := grpcTestCase(addr, []models.GrpcLengthPrefixedMessage{{}})
+	done := make(chan struct{})
+	start := time.Now()
+	go func() {
+		defer close(done)
+		_, _ = SimulateGRPC(context.Background(), tc, "set", zap.NewNop(), SimulationConfig{APITimeout: 2})
+	}()
+	select {
+	case <-done:
+		if elapsed := time.Since(start); elapsed > 10*time.Second {
+			t.Fatalf("returned after %v, far beyond the 2s APITimeout", elapsed)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("SimulateGRPC never returned against a stream the server holds open. The drain " +
+			"loop must be bounded by APITimeout, or one bad test case hangs the entire test set.")
+	}
+}
+
+// keep the framing helpers honest about their assumptions
+var _ = binary.BigEndian
+var _ = io.EOF
+var _ = metadata.MD{}

--- a/pkg/matcher/grpc/match.go
+++ b/pkg/matcher/grpc/match.go
@@ -27,11 +27,7 @@ func Match(tc *models.TestCase, actualResp *models.GrpcResp, noiseConfig map[str
 	var currentCategories []models.FailureCategory
 
 	// Local variables to track overall match status
-	differences := make(map[string]struct {
-		Expected string
-		Actual   string
-		Message  string
-	})
+	differences := make(map[string]grpcDiff)
 
 	// Only compare :status in pseudo headers
 	if expectedStatus, ok := expectedResp.Headers.PseudoHeaders[":status"]; ok {
@@ -146,47 +142,6 @@ func Match(tc *models.TestCase, actualResp *models.GrpcResp, noiseConfig map[str
 		result.HeadersResult = append(result.HeadersResult, headerResult)
 	}
 
-	// Compare Body - using specialized body types for gRPC
-	// Compare compression flag
-	compressionFlagNormal := expectedResp.Body.CompressionFlag == actualResp.Body.CompressionFlag
-	if !compressionFlagNormal {
-		differences["body.compression_flag"] = struct {
-			Expected string
-			Actual   string
-			Message  string
-		}{
-			Expected: fmt.Sprintf("%d", expectedResp.Body.CompressionFlag),
-			Actual:   fmt.Sprintf("%d", actualResp.Body.CompressionFlag),
-			Message:  "compression flag mismatch",
-		}
-	}
-	result.BodyResult = append(result.BodyResult, models.BodyResult{
-		Normal:   compressionFlagNormal,
-		Type:     models.GrpcCompression,
-		Expected: fmt.Sprintf("%d", expectedResp.Body.CompressionFlag),
-		Actual:   fmt.Sprintf("%d", actualResp.Body.CompressionFlag),
-	})
-
-	// Compare message length
-	messageLengthNormal := expectedResp.Body.MessageLength == actualResp.Body.MessageLength
-	if !messageLengthNormal {
-		differences["body.message_length"] = struct {
-			Expected string
-			Actual   string
-			Message  string
-		}{
-			Expected: fmt.Sprintf("%d", expectedResp.Body.MessageLength),
-			Actual:   fmt.Sprintf("%d", actualResp.Body.MessageLength),
-			Message:  "message length mismatch",
-		}
-	}
-	result.BodyResult = append(result.BodyResult, models.BodyResult{
-		Normal:   messageLengthNormal,
-		Type:     models.GrpcLength,
-		Expected: fmt.Sprintf("%d", expectedResp.Body.MessageLength),
-		Actual:   fmt.Sprintf("%d", actualResp.Body.MessageLength),
-	})
-
 	// Handle noise configuration first - needed for JSON comparison
 	noise := tc.Noise
 
@@ -207,89 +162,70 @@ func Match(tc *models.TestCase, actualResp *models.GrpcResp, noiseConfig map[str
 		headerNoise[field] = regexArr
 	}
 
-	// Compare decoded data - use JSON comparison if both are valid JSON, otherwise use canonicalization
-	decodedDataNormal := true
-	expectedDecodedData := expectedResp.Body.DecodedData
-	actualDecodedData := actualResp.Body.DecodedData
+	// Compare the body POSITIONALLY, one length-prefixed message at a time.
+	//
+	// Order is the entire semantic content of a stream, so comparison has to
+	// be by position. Concatenating messages into one string and diffing that
+	// would let a stream replayed in reverse order match, and so would routing
+	// a multi-message body through CanonicalizeTopLevelBlocks, which sorts
+	// sibling blocks.
+	expMsgs := expectedResp.AllMessages()
+	actMsgs := actualResp.AllMessages()
 
+	// The COUNT gets its own verdict. Comparing only min(len(exp), len(act))
+	// and calling that a match means a server returning 3 of 5 recorded
+	// messages passes — strictly worse than not supporting streams, because
+	// the user now believes streams are covered.
+	if len(expMsgs) != len(actMsgs) {
+		differences["body.message_count"] = grpcDiff{
+			Expected: fmt.Sprintf("%d", len(expMsgs)),
+			Actual:   fmt.Sprintf("%d", len(actMsgs)),
+			Message:  "gRPC message count mismatch",
+		}
+		result.BodyResult = append(result.BodyResult, models.BodyResult{
+			Normal:   false,
+			Type:     models.GrpcLength,
+			Expected: fmt.Sprintf("%d message(s)", len(expMsgs)),
+			Actual:   fmt.Sprintf("%d message(s)", len(actMsgs)),
+		})
+		currentRisk = models.High
+		currentCategories = append(currentCategories, models.SchemaBroken)
+	}
+
+	// Keys stay UNPREFIXED while both sides carry a single message, which is
+	// every recording made before streams were representable. A user's
+	// assertions.noise holds the bare string `body.decoded_data`, and the
+	// report reader keys off these too, so unary comparison must emit exactly
+	// the keys it always did.
+	indexed := useIndexedKeys(expMsgs, actMsgs)
+
+	compareCount := len(expMsgs)
+	if len(actMsgs) < compareCount {
+		compareCount = len(actMsgs)
+	}
+
+	// Carried out for the failure assessment below: the FIRST message that
+	// differs, which is the one the user needs to look at.
+	decodedDataNormal := true
+	expectedDecodedData := ""
+	actualDecodedData := ""
 	var jsonComparisonResult matcher.JSONComparisonResult
 
-	// Check if both decoded data are valid JSON
-	if json.Valid([]byte(expectedDecodedData)) && json.Valid([]byte(actualDecodedData)) {
-		// Both are JSON - use proper JSON comparison like HTTP matcher
-		logger.Debug("Both gRPC decoded data are valid JSON, using JSON comparison",
-			zap.String("expectedDecodedData", expectedDecodedData),
-			zap.String("actualDecodedData", actualDecodedData))
-
-		expectedDecodedData = matcher.NormalizeNestedJSONForNoise(expectedDecodedData, bodyNoise, logger)
-		actualDecodedData = matcher.NormalizeNestedJSONForNoise(actualDecodedData, bodyNoise, logger)
-
-		validatedJSON, err := matcher.ValidateAndMarshalJSON(logger, &expectedDecodedData, &actualDecodedData)
-		if err != nil {
-			logger.Error("Failed to validate and marshal JSON for gRPC decoded data", zap.Error(err))
+	for msgIdx := 0; msgIdx < compareCount; msgIdx++ {
+		cmp := compareGrpcMessage(msgIdx, indexed, expMsgs[msgIdx], actMsgs[msgIdx],
+			differences, result, bodyNoise, ignoreOrdering, logger)
+		if !cmp.decodedNormal && decodedDataNormal {
+			// first mismatch wins
 			decodedDataNormal = false
-		} else if validatedJSON.IsIdentical() {
-			jsonComparisonResult, err = matcher.JSONDiffWithNoiseControl(validatedJSON, bodyNoise, ignoreOrdering, logger)
-			decodedDataNormal = jsonComparisonResult.IsExact()
-			if err != nil {
-				logger.Error("Failed to perform JSON diff with noise control", zap.Error(err))
-				decodedDataNormal = false
-			}
-			if !decodedDataNormal {
-				logger.Debug("JSON comparison found differences",
-					zap.Bool("isExact", jsonComparisonResult.IsExact()),
-					zap.Bool("matches", jsonComparisonResult.Matches()))
-			}
-		} else {
-			logger.Debug("JSON structures are not identical, marking as mismatch")
-			decodedDataNormal = false
-		}
-	} else {
-		// At least one is not JSON - fall back to canonicalization approach
-		logger.Debug("At least one gRPC decoded data is not valid JSON, using canonicalization",
-			zap.Bool("expectedIsJSON", json.Valid([]byte(expectedDecodedData))),
-			zap.Bool("actualIsJSON", json.Valid([]byte(actualDecodedData))))
-
-		expCanon := CanonicalizeTopLevelBlocks(expectedDecodedData)
-		actCanon := CanonicalizeTopLevelBlocks(actualDecodedData)
-		decodedDataNormal = expCanon == actCanon
-		// Update the data for result reporting
-		expectedDecodedData = expCanon
-		actualDecodedData = actCanon
-	}
-
-	if !decodedDataNormal {
-		differences["body.decoded_data"] = struct {
-			Expected string
-			Actual   string
-			Message  string
-		}{
-			Expected: expectedDecodedData,
-			Actual:   actualDecodedData,
-			Message:  "decoded data mismatch",
+			expectedDecodedData = cmp.expected
+			actualDecodedData = cmp.actual
+			jsonComparisonResult = cmp.json
 		}
 	}
-	result.BodyResult = append(result.BodyResult, models.BodyResult{
-		Normal:   decodedDataNormal,
-		Type:     models.GrpcData,
-		Expected: expectedDecodedData,
-		Actual:   actualDecodedData,
-	})
-
-	// If decoded data matches but message length differs, ignore the length difference
-	if decodedDataNormal && !messageLengthNormal {
-		logger.Debug("Ignoring message length mismatch since decoded data is identical",
-			zap.Uint32("expected", expectedResp.Body.MessageLength),
-			zap.Uint32("actual", actualResp.Body.MessageLength))
-		// Update the message length result to Normal=true
-		for i := range result.BodyResult {
-			if result.BodyResult[i].Type == models.GrpcLength {
-				result.BodyResult[i].Normal = true
-				break
-			}
-		}
-		// Remove the message_length difference from differences map
-		delete(differences, "body.message_length")
+	if decodedDataNormal && compareCount > 0 {
+		// Nothing differed; surface message 0 for the report's benefit.
+		expectedDecodedData = expMsgs[0].DecodedData
+		actualDecodedData = actMsgs[0].DecodedData
 	}
 
 	// Apply noise configuration to ignore specified differences
@@ -297,7 +233,19 @@ func Match(tc *models.TestCase, actualResp *models.GrpcResp, noiseConfig map[str
 		pathParts := strings.Split(path, ".")
 		if len(pathParts) > 1 {
 			if pathParts[0] == "body" && len(bodyNoise) > 0 {
-				if _, found := bodyNoise[strings.Join(pathParts[1:], ".")]; found {
+				// Strip a per-message index before the lookup. A user's
+				// assertions.noise holds bare `decoded_data` /
+				// `message_length` / `compression_flag`; joining a streaming
+				// key's parts would ask for `1.decoded_data`, match nothing,
+				// and silently render every recorded gRPC noise entry inert —
+				// so previously-suppressed flakiness would reappear as
+				// failures with no diagnostic, since this matcher never calls
+				// WarnUnmatchableBodyNoise.
+				fields := pathParts[1:]
+				if len(fields) > 1 && isAllDigits(fields[0]) {
+					fields = fields[1:]
+				}
+				if _, found := bodyNoise[strings.Join(fields, ".")]; found {
 					delete(differences, path)
 				}
 			} else if pathParts[0] == "headers" && len(headerNoise) > 0 {
@@ -319,11 +267,7 @@ func Match(tc *models.TestCase, actualResp *models.GrpcResp, noiseConfig map[str
 		Actual:   actualGrpcStatus,
 	}
 	if !result.StatusCode.Normal {
-		differences["trailers.grpc-status"] = struct {
-			Expected string
-			Actual   string
-			Message  string
-		}{
+		differences["trailers.grpc-status"] = grpcDiff{
 			Expected: strconv.Itoa(expectedGrpcStatus),
 			Actual:   strconv.Itoa(actualGrpcStatus),
 			Message:  "grpc-status mismatch",
@@ -462,4 +406,193 @@ func parseGrpcStatus(s string) int {
 		return -1
 	}
 	return n
+}
+
+// grpcDiff is one entry in the differences map. It was an anonymous struct
+// literal repeated at every site; naming it is what lets the per-message
+// comparison live in its own function.
+type grpcDiff struct {
+	Expected string
+	Actual   string
+	Message  string
+}
+
+// msgComparison reports how one length-prefixed message compared.
+type msgComparison struct {
+	decodedNormal bool
+	expected      string
+	actual        string
+	json          matcher.JSONComparisonResult
+}
+
+// isAllDigits reports whether s is a non-empty run of ASCII digits, i.e. a
+// message index in a difference key like `body.1.decoded_data`.
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// compareGrpcMessage compares ONE length-prefixed message and records its
+// differences and BodyResult entries.
+//
+// This is the body-comparison logic that used to be inline against
+// GrpcResp.Body, unchanged in substance — the same compression-flag, length
+// and decoded-data checks, the same JSON-versus-canonicalization split, and
+// the same rule that a length difference is forgiven when the decoded data is
+// identical. What is new is that it runs once per message and that its
+// difference keys can carry the message index.
+//
+// The key shape is deliberate. With a single message on both sides the keys
+// are exactly what they have always been (`body.decoded_data`), so existing
+// noise entries, reports and UI keep working untouched. Only a real stream
+// produces `body.<n>.decoded_data`.
+func compareGrpcMessage(
+	msgIdx int,
+	indexed bool,
+	expMsg, actMsg models.GrpcLengthPrefixedMessage,
+	differences map[string]grpcDiff,
+	result *models.Result,
+	bodyNoise map[string][]string,
+	ignoreOrdering bool,
+	logger *zap.Logger,
+) msgComparison {
+	key := func(field string) string {
+		if !indexed {
+			return "body." + field
+		}
+		return fmt.Sprintf("body.%d.%s", msgIdx, field)
+	}
+
+	// Compare compression flag
+	compressionFlagNormal := expMsg.CompressionFlag == actMsg.CompressionFlag
+	if !compressionFlagNormal {
+		differences[key("compression_flag")] = grpcDiff{
+			Expected: fmt.Sprintf("%d", expMsg.CompressionFlag),
+			Actual:   fmt.Sprintf("%d", actMsg.CompressionFlag),
+			Message:  "compression flag mismatch",
+		}
+	}
+	result.BodyResult = append(result.BodyResult, models.BodyResult{
+		Normal:   compressionFlagNormal,
+		Type:     models.GrpcCompression,
+		Expected: fmt.Sprintf("%d", expMsg.CompressionFlag),
+		Actual:   fmt.Sprintf("%d", actMsg.CompressionFlag),
+	})
+
+	// Compare message length
+	messageLengthNormal := expMsg.MessageLength == actMsg.MessageLength
+	if !messageLengthNormal {
+		differences[key("message_length")] = grpcDiff{
+			Expected: fmt.Sprintf("%d", expMsg.MessageLength),
+			Actual:   fmt.Sprintf("%d", actMsg.MessageLength),
+			Message:  "message length mismatch",
+		}
+	}
+	lengthResultIdx := len(result.BodyResult)
+	result.BodyResult = append(result.BodyResult, models.BodyResult{
+		Normal:   messageLengthNormal,
+		Type:     models.GrpcLength,
+		Expected: fmt.Sprintf("%d", expMsg.MessageLength),
+		Actual:   fmt.Sprintf("%d", actMsg.MessageLength),
+	})
+
+	// Compare decoded data — JSON comparison when both sides are valid JSON,
+	// canonicalization otherwise.
+	decodedDataNormal := true
+	expectedDecodedData := expMsg.DecodedData
+	actualDecodedData := actMsg.DecodedData
+	var jsonComparisonResult matcher.JSONComparisonResult
+
+	if json.Valid([]byte(expectedDecodedData)) && json.Valid([]byte(actualDecodedData)) {
+		logger.Debug("Both gRPC decoded data are valid JSON, using JSON comparison",
+			zap.Int("message_index", msgIdx),
+			zap.String("expectedDecodedData", expectedDecodedData),
+			zap.String("actualDecodedData", actualDecodedData))
+
+		expectedDecodedData = matcher.NormalizeNestedJSONForNoise(expectedDecodedData, bodyNoise, logger)
+		actualDecodedData = matcher.NormalizeNestedJSONForNoise(actualDecodedData, bodyNoise, logger)
+
+		validatedJSON, err := matcher.ValidateAndMarshalJSON(logger, &expectedDecodedData, &actualDecodedData)
+		if err != nil {
+			logger.Error("Failed to validate and marshal JSON for gRPC decoded data", zap.Error(err))
+			decodedDataNormal = false
+		} else if validatedJSON.IsIdentical() {
+			jsonComparisonResult, err = matcher.JSONDiffWithNoiseControl(validatedJSON, bodyNoise, ignoreOrdering, logger)
+			decodedDataNormal = jsonComparisonResult.IsExact()
+			if err != nil {
+				logger.Error("Failed to perform JSON diff with noise control", zap.Error(err))
+				decodedDataNormal = false
+			}
+		} else {
+			logger.Debug("JSON structures are not identical, marking as mismatch")
+			decodedDataNormal = false
+		}
+	} else {
+		logger.Debug("At least one gRPC decoded data is not valid JSON, using canonicalization",
+			zap.Int("message_index", msgIdx),
+			zap.Bool("expectedIsJSON", json.Valid([]byte(expectedDecodedData))),
+			zap.Bool("actualIsJSON", json.Valid([]byte(actualDecodedData))))
+
+		// Per-message only. Canonicalizing a whole stream would sort across
+		// message boundaries and let a reordered stream match.
+		expCanon := CanonicalizeTopLevelBlocks(expectedDecodedData)
+		actCanon := CanonicalizeTopLevelBlocks(actualDecodedData)
+		decodedDataNormal = expCanon == actCanon
+		expectedDecodedData = expCanon
+		actualDecodedData = actCanon
+	}
+
+	if !decodedDataNormal {
+		differences[key("decoded_data")] = grpcDiff{
+			Expected: expectedDecodedData,
+			Actual:   actualDecodedData,
+			Message:  "decoded data mismatch",
+		}
+	}
+	result.BodyResult = append(result.BodyResult, models.BodyResult{
+		Normal:   decodedDataNormal,
+		Type:     models.GrpcData,
+		Expected: expectedDecodedData,
+		Actual:   actualDecodedData,
+	})
+
+	// A length difference is forgiven when the decoded data is identical —
+	// mocks can be hand-edited, and CreatePayloadFromLengthPrefixedMessage
+	// deliberately re-derives the length from the re-encoded payload. Scoped
+	// to THIS message's length result, not the first one in the slice.
+	if decodedDataNormal && !messageLengthNormal {
+		logger.Debug("Ignoring message length mismatch since decoded data is identical",
+			zap.Int("message_index", msgIdx),
+			zap.Uint32("expected", expMsg.MessageLength),
+			zap.Uint32("actual", actMsg.MessageLength))
+		result.BodyResult[lengthResultIdx].Normal = true
+		delete(differences, key("message_length"))
+	}
+
+	return msgComparison{
+		decodedNormal: decodedDataNormal,
+		expected:      expectedDecodedData,
+		actual:        actualDecodedData,
+		json:          jsonComparisonResult,
+	}
+}
+
+// useIndexedKeys reports whether difference keys should carry a message
+// index.
+//
+// They must NOT while both sides carry a single message. Every recording made
+// before streams were representable is unary, users' assertions.noise holds
+// the bare string `body.decoded_data`, and the report reader and UI key off
+// these names. Indexing unconditionally would rename every unary failure —
+// invisibly, because the noise lookup strips the index and would keep
+// suppressing correctly either way.
+func useIndexedKeys(expMsgs, actMsgs []models.GrpcLengthPrefixedMessage) bool {
+	return len(expMsgs) > 1 || len(actMsgs) > 1
 }

--- a/pkg/matcher/grpc/stream_match_test.go
+++ b/pkg/matcher/grpc/stream_match_test.go
@@ -1,0 +1,237 @@
+package grpc
+
+import (
+	"strings"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+func msg(data string) models.GrpcLengthPrefixedMessage {
+	return models.GrpcLengthPrefixedMessage{MessageLength: uint32(len(data)), DecodedData: data}
+}
+
+func emptyHdrs() models.GrpcHeaders {
+	return models.GrpcHeaders{PseudoHeaders: map[string]string{}, OrdinaryHeaders: map[string]string{}}
+}
+
+func okTrailers() models.GrpcHeaders {
+	return models.GrpcHeaders{PseudoHeaders: map[string]string{}, OrdinaryHeaders: map[string]string{"grpc-status": "0"}}
+}
+
+func streamCase(t *testing.T, recorded, actual []models.GrpcLengthPrefixedMessage) (bool, *models.Result) {
+	t.Helper()
+	var exp models.GrpcResp
+	exp.Headers, exp.Trailers = emptyHdrs(), okTrailers()
+	exp.SetMessages(recorded)
+
+	var act models.GrpcResp
+	act.Headers, act.Trailers = emptyHdrs(), okTrailers()
+	act.SetMessages(actual)
+
+	tc := &models.TestCase{Name: "stream", GrpcResp: exp}
+	return Match(tc, &act, nil, false, zap.NewNop(), false)
+}
+
+// TestMatch_ShortStreamMustFail: a server that returns fewer messages than
+// were recorded must NOT pass.
+//
+// Comparing only min(len(expected), len(actual)) and calling that a match is
+// strictly worse than not supporting streams at all — every message compared
+// would be identical, the test would go green, and the user would believe
+// streams are covered while the RPC silently truncated.
+func TestMatch_ShortStreamMustFail(t *testing.T) {
+	recorded := []models.GrpcLengthPrefixedMessage{msg("one"), msg("two"), msg("three"), msg("four"), msg("five")}
+	actual := recorded[:3] // 3 of 5, each byte-identical
+
+	pass, result := streamCase(t, recorded, actual)
+	if pass {
+		t.Fatal("a response returning 3 of 5 recorded messages PASSED. Every compared message " +
+			"was identical, so only an explicit count verdict can catch this.")
+	}
+	found := false
+	for _, br := range result.BodyResult {
+		if !br.Normal && strings.Contains(br.Expected, "message(s)") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no message-count entry in BodyResult; the user cannot see WHY it failed: %+v", result.BodyResult)
+	}
+}
+
+// TestMatch_ReorderedStreamMustFail: order is the semantic content of a
+// stream. Concatenating messages before comparing, or canonicalizing across
+// message boundaries (CanonicalizeTopLevelBlocks sorts sibling blocks), would
+// both let this pass.
+func TestMatch_ReorderedStreamMustFail(t *testing.T) {
+	recorded := []models.GrpcLengthPrefixedMessage{msg("alpha"), msg("beta"), msg("gamma")}
+	reversed := []models.GrpcLengthPrefixedMessage{msg("gamma"), msg("beta"), msg("alpha")}
+
+	if pass, _ := streamCase(t, recorded, reversed); pass {
+		t.Fatal("a stream replayed in REVERSE order passed. Comparison must be positional; " +
+			"the same messages in a different order is a different stream.")
+	}
+}
+
+// TestMatch_IdenticalStreamPasses is the positive control — without it the
+// two tests above could pass because everything fails.
+func TestMatch_IdenticalStreamPasses(t *testing.T) {
+	msgs := []models.GrpcLengthPrefixedMessage{msg("alpha"), msg("beta"), msg("gamma")}
+	same := []models.GrpcLengthPrefixedMessage{msg("alpha"), msg("beta"), msg("gamma")}
+
+	pass, result := streamCase(t, msgs, same)
+	if !pass {
+		t.Fatalf("an identical 3-message stream FAILED: %+v", result.BodyResult)
+	}
+}
+
+// TestMatch_MiddleMessageMismatchIsReportedByPosition: the user has to be
+// told WHICH message differs, not just that the body did.
+func TestMatch_MiddleMessageMismatchIsReportedByPosition(t *testing.T) {
+	recorded := []models.GrpcLengthPrefixedMessage{msg("alpha"), msg("beta"), msg("gamma")}
+	actual := []models.GrpcLengthPrefixedMessage{msg("alpha"), msg("CHANGED"), msg("gamma")}
+
+	pass, result := streamCase(t, recorded, actual)
+	if pass {
+		t.Fatal("a stream whose middle message differs passed")
+	}
+	// message 0 and 2 must still be reported normal; only 1 abnormal.
+	var abnormalData int
+	for _, br := range result.BodyResult {
+		if br.Type == models.GrpcData && !br.Normal {
+			abnormalData++
+			if br.Expected != "beta" {
+				t.Fatalf("the reported mismatch is %q, want the middle message %q", br.Expected, "beta")
+			}
+		}
+	}
+	if abnormalData != 1 {
+		t.Fatalf("%d decoded-data mismatches reported, want exactly 1 (only message 1 differs)", abnormalData)
+	}
+}
+
+// TestMatch_UnaryDifferenceKeysAreUnchanged pins the compatibility promise
+// for every recording that exists today.
+//
+// A user's assertions.noise holds the bare string `body.decoded_data`. If a
+// unary comparison started emitting `body.0.decoded_data`, every recorded
+// noise entry would go inert and previously-suppressed flakiness would
+// reappear as failures — with no diagnostic, because this matcher never calls
+// WarnUnmatchableBodyNoise.
+func TestMatch_UnaryDifferenceKeysAreUnchanged(t *testing.T) {
+	var exp models.GrpcResp
+	exp.Headers, exp.Trailers = emptyHdrs(), okTrailers()
+	exp.Body = msg("alpha")
+
+	var act models.GrpcResp
+	act.Headers, act.Trailers = emptyHdrs(), okTrailers()
+	act.Body = msg("brave") // same length as "alpha": only decoded_data differs
+
+	tc := &models.TestCase{Name: "unary", GrpcResp: exp}
+
+	// With the bare noise key, a unary mismatch must be suppressed entirely.
+	noiseCfg := map[string]map[string][]string{"body": {"decoded_data": {}}}
+	pass, _ := Match(tc, &act, noiseCfg, false, zap.NewNop(), false)
+	if !pass {
+		t.Fatal("a unary body mismatch was NOT suppressed by the bare `decoded_data` noise key. " +
+			"Unary difference keys must stay exactly what they were before streams existed.")
+	}
+}
+
+// TestMatch_StreamNoiseKeysStripTheMessageIndex: the same bare noise entry
+// must keep working when the body is a stream. Joining the key's parts
+// verbatim would look up `1.decoded_data` and match nothing.
+func TestMatch_StreamNoiseKeysStripTheMessageIndex(t *testing.T) {
+	recorded := []models.GrpcLengthPrefixedMessage{msg("alpha"), msg("beta")}
+	// same length as "beta": only decoded_data differs, so the noise key is
+	// the only thing that can suppress it
+	actual := []models.GrpcLengthPrefixedMessage{msg("alpha"), msg("brav")}
+
+	var exp models.GrpcResp
+	exp.Headers, exp.Trailers = emptyHdrs(), okTrailers()
+	exp.SetMessages(recorded)
+	var act models.GrpcResp
+	act.Headers, act.Trailers = emptyHdrs(), okTrailers()
+	act.SetMessages(actual)
+
+	tc := &models.TestCase{Name: "stream-noise", GrpcResp: exp}
+	noiseCfg := map[string]map[string][]string{"body": {"decoded_data": {}}}
+
+	pass, _ := Match(tc, &act, noiseCfg, false, zap.NewNop(), false)
+	if !pass {
+		t.Fatal("a bare `decoded_data` noise key did not suppress a STREAM body mismatch. " +
+			"The per-message index has to be stripped before the bodyNoise lookup, or every " +
+			"gRPC noise entry a user already has goes inert the moment a stream is recorded.")
+	}
+}
+
+// TestCompareGrpcMessage_KeyShape pins the exact difference keys, because
+// noise suppression is not the only thing that reads them.
+//
+// The keys land in the differences map, which drives the diff shown to the
+// user and is the vocabulary the report reader and UI key off. Suppression
+// alone cannot catch a change here: the index-stripping in the noise lookup
+// deliberately makes `body.0.decoded_data` and `body.decoded_data` behave the
+// same for noise, so an accidental switch to always-indexed keys would leave
+// every noise test green while changing what every unary failure is called.
+func TestCompareGrpcMessage_KeyShape(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		indexed bool
+		idx     int
+		want    []string
+	}{
+		{
+			name: "unary keeps the pre-streaming keys", indexed: false, idx: 0,
+			want: []string{"body.compression_flag", "body.decoded_data"},
+		},
+		{
+			name: "streaming carries the message index", indexed: true, idx: 2,
+			want: []string{"body.2.compression_flag", "body.2.decoded_data"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			differences := make(map[string]grpcDiff)
+			result := &models.Result{BodyResult: make([]models.BodyResult, 0)}
+
+			// Differ in compression flag and content, same length so the
+			// length difference is not the one under test.
+			expMsg := models.GrpcLengthPrefixedMessage{CompressionFlag: 0, MessageLength: 5, DecodedData: "alpha"}
+			actMsg := models.GrpcLengthPrefixedMessage{CompressionFlag: 1, MessageLength: 5, DecodedData: "brave"}
+
+			compareGrpcMessage(tc.idx, tc.indexed, expMsg, actMsg, differences, result, nil, false, zap.NewNop())
+
+			for _, want := range tc.want {
+				if _, ok := differences[want]; !ok {
+					got := make([]string, 0, len(differences))
+					for k := range differences {
+						got = append(got, k)
+					}
+					t.Fatalf("missing difference key %q; got %v.\nThese strings are the vocabulary "+
+						"the report reader, the UI and users' assertions.noise all key off — a "+
+						"unary failure must keep the name it has always had.", want, got)
+				}
+			}
+		})
+	}
+}
+
+// TestUseIndexedKeys pins when a message index appears in a difference key.
+// Unary must never be indexed — see useIndexedKeys' own comment for why the
+// noise tests cannot catch a regression here.
+func TestUseIndexedKeys(t *testing.T) {
+	one := []models.GrpcLengthPrefixedMessage{msg("a")}
+	two := []models.GrpcLengthPrefixedMessage{msg("a"), msg("b")}
+
+	if useIndexedKeys(one, one) {
+		t.Fatal("a unary comparison would use indexed difference keys. That renames every " +
+			"existing failure (body.decoded_data -> body.0.decoded_data), which the report " +
+			"reader, the UI and users' recorded noise entries all key off.")
+	}
+	if !useIndexedKeys(two, one) || !useIndexedKeys(one, two) || !useIndexedKeys(two, two) {
+		t.Fatal("a stream on either side must produce indexed keys, or two messages' " +
+			"differences collide under the same key and one silently overwrites the other")
+	}
+}

--- a/pkg/service/replay/hooks.go
+++ b/pkg/service/replay/hooks.go
@@ -108,6 +108,9 @@ func (h *Hooks) SimulateRequest(ctx context.Context, tc *models.TestCase, testSe
 		}
 
 		resp, err := pkg.SimulateGRPC(ctx, tc, testSetID, h.logger, pkg.SimulationConfig{
+			// Bounds the response drain. Without it a bidi stream the server
+			// holds open hangs the whole test set instead of failing one case.
+			APITimeout:      h.cfg.Test.APITimeout,
 			ConfigPort:      configPort,
 			ConfigHost:      hostToUse,
 			URLReplacements: urlReplacements,


### PR DESCRIPTION
> **Stacked on #4549** (`feat/grpc-streaming-messages`), which makes a stream representable. Retarget to `main` once that merges.

The body comparison ran against `GrpcResp.Body` — one message. It now runs per message, and two things about *how* are load-bearing.

### Positional, not set-wise

Order is the entire semantic content of a stream. Concatenating messages into one string and diffing that would let a stream **replayed in reverse** match — and so would routing a multi-message body through `CanonicalizeTopLevelBlocks`, which sorts sibling blocks. Each message is compared at the same index, and canonicalization stays scoped to one message.

### The count needs its own verdict

Looping over `min(len(expected), len(actual))` and calling that a match means **a server returning 3 of 5 recorded messages passes** — every compared message is byte-identical, so nothing else can catch it. That is strictly worse than not supporting streams at all, because the user now believes streams are covered.

### What does not change

Difference keys stay **unprefixed** while both sides carry a single message — which is every recording that exists today. Users' `assertions.noise` holds the bare string `body.decoded_data`, and the report reader and UI key off the same names. Only a real stream produces `body.<n>.decoded_data`.

The noise lookup strips a leading message index before consulting `bodyNoise`. Without it a streaming key would ask for `1.decoded_data`, match nothing, and render **every gRPC noise entry a user already has inert** — silently, because this matcher never calls `WarnUnmatchableBodyNoise`, so previously-suppressed flakiness would return as bare failures with no diagnostic.

`compareGrpcMessage` is the old inline block moved out unchanged in substance. The one real behaviour change: the "length mismatch forgiven when decoded data is identical" fixup now targets *this* message's length result rather than the first in the slice — which only mattered once there could be more than one.

### Mutations pinned

| mutation | caught by |
|---|---|
| drop the count verdict | `TestMatch_ShortStreamMustFail` |
| compare as a sorted set | `TestMatch_ReorderedStreamMustFail` + position test |
| skip the index strip | `TestMatch_StreamNoiseKeysStripTheMessageIndex` |
| index unary keys too | `TestUseIndexedKeys` |

That last one is why `useIndexedKeys` is a named function with its own test: the noise tests **cannot** catch it, because index-stripping makes suppression behave identically either way. It would rename every unary failure invisibly.

`go build ./... && go test ./...` green.
