### PR TITLE
feat(replay/grpc): drain the response stream, and report the status it really ended with

### DIFF
--- a/pkg/http2.go
+++ b/pkg/http2.go
@@ -12,6 +12,7 @@ import (
 	"maps"
 	"net"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -25,6 +26,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -657,6 +659,23 @@ func SimulateGRPC(ctx context.Context, tc *models.TestCase, testSetID string, lo
 		md[k] = []string{v}
 	}
 
+	// Bound the whole call, because the drain below is now a loop.
+	//
+	// A single RecvMsg was self-limiting. Draining to io.EOF is not: a bidi
+	// stream the server holds open — server reflection is exactly that shape
+	// — never reaches EOF, so without a deadline one bad test case blocks
+	// until the entire test-run context dies, taking the rest of the test set
+	// with it and attributing the hang to nothing in particular.
+	//
+	// APITimeout is the same knob the HTTP replay path uses. Zero means the
+	// caller did not set one, so fall back rather than leaving it unbounded.
+	timeout := time.Duration(cfg.APITimeout) * time.Second
+	if timeout <= 0 {
+		timeout = defaultGrpcCallTimeout
+	}
+	ctx, cancelCall := context.WithTimeout(ctx, timeout)
+	defer cancelCall()
+
 	// Create context with metadata
 	callCtx := metadata.NewOutgoingContext(ctx, md)
 
@@ -670,24 +689,31 @@ func SimulateGRPC(ctx context.Context, tc *models.TestCase, testSetID string, lo
 		return nil, fmt.Errorf("failed to create stream: %w", err)
 	}
 
-	// Convert the request body to raw message format
-	// For gRPC client with passthrough codec, we only need the protobuf bytes, not the full gRPC frame
-	var requestPayload []byte
-	if grpcReq.Body.DecodedData != "" {
-		// Parse the protoscope format back to bytes
-		scanner := protoscope.NewScanner(grpcReq.Body.DecodedData)
-		var err error
-		requestPayload, err = scanner.Exec()
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse request payload: %w", err)
+	// Send every recorded request message, in order.
+	//
+	// A client-streaming or bidi call records N messages; sending only the
+	// first replays a different request from the one that was captured, and
+	// the server's response to it is not the response that was recorded.
+	//
+	// AllMessages() always yields at least one element, including for a
+	// zero-value body — the health check records message_length 0 with empty
+	// decoded_data and expects exactly one empty message. An empty payload
+	// here is a real message, not the absence of one.
+	reqMsgs := grpcReq.AllMessages()
+	for i, m := range reqMsgs {
+		var requestPayload []byte
+		if m.DecodedData != "" {
+			// Parse the protoscope format back to bytes
+			scanner := protoscope.NewScanner(m.DecodedData)
+			var err error
+			requestPayload, err = scanner.Exec()
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse request payload (message %d of %d): %w", i, len(reqMsgs), err)
+			}
 		}
-	}
-
-	requestMsg := &rawMessage{data: requestPayload}
-
-	// Send the request
-	if err := stream.SendMsg(requestMsg); err != nil {
-		return nil, fmt.Errorf("failed to send request: %w", err)
+		if err := stream.SendMsg(&rawMessage{data: requestPayload}); err != nil {
+			return nil, fmt.Errorf("failed to send request (message %d of %d): %w", i, len(reqMsgs), err)
+		}
 	}
 
 	// Close the send side of the stream
@@ -701,13 +727,45 @@ func SimulateGRPC(ctx context.Context, tc *models.TestCase, testSetID string, lo
 		return nil, fmt.Errorf("failed to get response headers: %w", err)
 	}
 
-	// Read the response message
-	responseMsg := &rawMessage{}
-	if err := stream.RecvMsg(responseMsg); err != nil && err != io.EOF {
-		return nil, fmt.Errorf("failed to receive response: %w", err)
+	// Drain the response stream to io.EOF.
+	//
+	// A single RecvMsg captures the first message of a server-streaming or
+	// bidi response and abandons the rest, which also tears the connection
+	// down early — so the app handler aborts and any dependency calls behind
+	// messages 2..N never run.
+	//
+	// TRAILERS MUST BE READ AFTER THE DRAIN, NOT AFTER THE FIRST MESSAGE.
+	// grpc-go only populates Trailer() once RecvMsg has returned a non-nil
+	// error. Reading it earlier returns an empty map, the grpc-status fixup
+	// below then fabricates "0", and a stream that died partway replays as a
+	// clean success — the worst possible outcome, because it looks correct.
+	var respMsgs []models.GrpcLengthPrefixedMessage
+	var drainErr error
+	for {
+		responseMsg := &rawMessage{}
+		err := stream.RecvMsg(responseMsg)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			// Not fatal: this error IS the RPC's outcome and belongs in the
+			// mock. Stop draining and record it below, rather than discarding
+			// a partial stream and the reason it ended.
+			drainErr = err
+			logger.Debug("gRPC response stream ended with an error; recording what arrived",
+				zap.String("method", path), zap.Int("messages", len(respMsgs)), zap.Error(err))
+			break
+		}
+		respMsgs = append(respMsgs, createLengthPrefixedMessage(responseMsg.data))
+	}
+	if len(respMsgs) == 0 {
+		// A response carrying only trailers is legitimate (an error status, or
+		// a client-streaming call the server rejects). Keep one empty message
+		// so the recorded shape matches what a single RecvMsg used to produce.
+		respMsgs = append(respMsgs, createLengthPrefixedMessage(nil))
 	}
 
-	// Get trailers
+	// Now that the stream is finished, the trailers are real.
 	trailers := stream.Trailer()
 
 	// Construct the response
@@ -716,7 +774,6 @@ func SimulateGRPC(ctx context.Context, tc *models.TestCase, testSetID string, lo
 			PseudoHeaders:   make(map[string]string),
 			OrdinaryHeaders: make(map[string]string),
 		},
-		Body: createLengthPrefixedMessage(responseMsg.data),
 		Trailers: models.GrpcHeaders{
 			PseudoHeaders:   make(map[string]string),
 			OrdinaryHeaders: make(map[string]string),
@@ -754,6 +811,24 @@ func SimulateGRPC(ctx context.Context, tc *models.TestCase, testSetID string, lo
 		}
 	}
 
+	// The real status comes from the terminal RecvMsg error, NOT from the
+	// trailer map.
+	//
+	// grpc-go consumes grpc-status and grpc-message off the wire and turns
+	// them into the error RecvMsg returns; Trailer() carries only the
+	// application's own custom trailers. So a stream that ended INTERNAL has
+	// no grpc-status key at all, and the default below would fabricate "0" —
+	// replaying a failed RPC as a clean pass. Reading the status off the
+	// error is what makes a mid-stream failure visible.
+	if drainErr != nil {
+		if st, ok := status.FromError(drainErr); ok {
+			grpcResp.Trailers.OrdinaryHeaders["grpc-status"] = strconv.Itoa(int(st.Code()))
+			if msg := st.Message(); msg != "" {
+				grpcResp.Trailers.OrdinaryHeaders["grpc-message"] = msg
+			}
+		}
+	}
+
 	// Ensure mandatory gRPC status is present
 	if _, ok := grpcResp.Trailers.OrdinaryHeaders["grpc-status"]; !ok {
 		grpcResp.Trailers.OrdinaryHeaders["grpc-status"] = "0"
@@ -762,9 +837,17 @@ func SimulateGRPC(ctx context.Context, tc *models.TestCase, testSetID string, lo
 		grpcResp.Trailers.OrdinaryHeaders["grpc-message"] = ""
 	}
 
-	logger.Info("successfully completed gRPC simulation", zap.String("method", path))
+	grpcResp.SetMessages(respMsgs)
+
+	logger.Info("successfully completed gRPC simulation",
+		zap.String("method", path), zap.Int("response_messages", len(respMsgs)))
 	return grpcResp, nil
 }
+
+// defaultGrpcCallTimeout bounds a replayed gRPC call when the caller supplies
+// no APITimeout. It exists so the response drain can never hang a test set on
+// a stream the server holds open; it is not a latency target.
+const defaultGrpcCallTimeout = 30 * time.Second
 
 // CreateLengthPrefixedMessageFromPayload creates a GrpcLengthPrefixedMessage
 // from the FIRST length-prefixed message in data.

--- a/pkg/http2_grpc_stream_replay_test.go
+++ b/pkg/http2_grpc_stream_replay_test.go
@@ -1,0 +1,213 @@
+package pkg
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// rawSrvCodec passes bytes through untouched, so the fake server can speak
+// gRPC without any .proto — the same trick the real parser uses.
+type rawSrvCodec struct{}
+
+func (rawSrvCodec) Name() string { return "proto" }
+func (rawSrvCodec) Marshal(v interface{}) ([]byte, error) {
+	if m, ok := v.(*rawMessage); ok {
+		return m.data, nil
+	}
+	return nil, fmt.Errorf("unexpected type %T", v)
+}
+func (rawSrvCodec) Unmarshal(data []byte, v interface{}) error {
+	if m, ok := v.(*rawMessage); ok {
+		m.data = append([]byte(nil), data...)
+		return nil
+	}
+	return fmt.Errorf("unexpected type %T", v)
+}
+
+// streamingServer answers every method by echoing back `respond` messages and
+// finishing with `st`. It records how many request messages it received.
+type streamingServer struct {
+	respond  [][]byte
+	st       error
+	gotReqs  chan int
+	holdOpen chan struct{} // when non-nil, never returns: models a bidi stream the server holds open
+}
+
+func (s *streamingServer) handle(_ interface{}, stream grpc.ServerStream) error {
+	n := 0
+	for {
+		var m rawMessage
+		if err := stream.RecvMsg(&m); err != nil {
+			break
+		}
+		n++
+	}
+	if s.gotReqs != nil {
+		s.gotReqs <- n
+	}
+	for _, r := range s.respond {
+		if err := stream.SendMsg(&rawMessage{data: r}); err != nil {
+			return err
+		}
+	}
+	if s.holdOpen != nil {
+		<-s.holdOpen // never completes within the test's patience
+	}
+	return s.st
+}
+
+func startStreamingServer(t *testing.T, srv *streamingServer) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	g := grpc.NewServer(
+		grpc.ForceServerCodec(rawSrvCodec{}),
+		grpc.UnknownServiceHandler(srv.handle),
+	)
+	go func() { _ = g.Serve(ln) }()
+	t.Cleanup(func() { g.Stop(); _ = ln.Close() })
+	return ln.Addr().String()
+}
+
+// pbMsg builds a trivial protobuf payload: field 1, length-delimited string.
+func pbMsg(s string) []byte { return append([]byte{0x0a, byte(len(s))}, s...) }
+
+func grpcTestCase(addr string, reqMsgs []models.GrpcLengthPrefixedMessage) *models.TestCase {
+	req := models.GrpcReq{
+		Headers: models.GrpcHeaders{
+			PseudoHeaders: map[string]string{
+				":authority": addr,
+				":path":      "/pkg.Svc/Method",
+				":method":    "POST",
+			},
+			OrdinaryHeaders: map[string]string{"content-type": "application/grpc"},
+		},
+	}
+	req.SetMessages(reqMsgs)
+	return &models.TestCase{Name: "stream-replay", Kind: models.GRPC_EXPORT, GrpcReq: req}
+}
+
+// TestSimulateGRPC_DrainsEveryResponseMessage is the core of streaming replay.
+//
+// A single RecvMsg captured the first message of a server-streaming response
+// and abandoned the rest — and by tearing the stream down early it also meant
+// the app handler aborted, so dependency calls behind messages 2..N never ran.
+func TestSimulateGRPC_DrainsEveryResponseMessage(t *testing.T) {
+	want := [][]byte{pbMsg("one"), pbMsg("two"), pbMsg("three")}
+	addr := startStreamingServer(t, &streamingServer{respond: want})
+
+	tc := grpcTestCase(addr, []models.GrpcLengthPrefixedMessage{{}})
+	resp, err := SimulateGRPC(context.Background(), tc, "set", zap.NewNop(), SimulationConfig{APITimeout: 10})
+	if err != nil {
+		t.Fatalf("SimulateGRPC: %v", err)
+	}
+	got := resp.AllMessages()
+	if len(got) != len(want) {
+		t.Fatalf("captured %d response messages, want %d. A single RecvMsg takes the first and "+
+			"abandons the rest of the stream.", len(got), len(want))
+	}
+	for i := range want {
+		if int(got[i].MessageLength) != len(want[i]) {
+			t.Fatalf("message %d has length %d, want %d", i, got[i].MessageLength, len(want[i]))
+		}
+	}
+}
+
+// TestSimulateGRPC_SendsEveryRequestMessage: a client-streaming call records N
+// request messages; sending only the first replays a different request than
+// the one captured.
+func TestSimulateGRPC_SendsEveryRequestMessage(t *testing.T) {
+	gotReqs := make(chan int, 1)
+	addr := startStreamingServer(t, &streamingServer{respond: [][]byte{pbMsg("ack")}, gotReqs: gotReqs})
+
+	reqs := []models.GrpcLengthPrefixedMessage{
+		{MessageLength: 5, DecodedData: `1: {"one"}`},
+		{MessageLength: 5, DecodedData: `1: {"two"}`},
+		{MessageLength: 7, DecodedData: `1: {"three"}`},
+	}
+	tc := grpcTestCase(addr, reqs)
+	if _, err := SimulateGRPC(context.Background(), tc, "set", zap.NewNop(), SimulationConfig{APITimeout: 10}); err != nil {
+		t.Fatalf("SimulateGRPC: %v", err)
+	}
+	select {
+	case n := <-gotReqs:
+		if n != len(reqs) {
+			t.Fatalf("the server received %d request messages, want %d", n, len(reqs))
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("server never reported")
+	}
+}
+
+// TestSimulateGRPC_TrailersAreRealNotFabricated is the ordering bug.
+//
+// grpc-go only populates Trailer() once RecvMsg has returned a non-nil error.
+// Reading it right after the first message returns an EMPTY map, and the
+// fixup below then fabricates grpc-status "0" — so a stream that failed
+// replays as a clean success, which is the worst possible outcome because it
+// looks correct.
+func TestSimulateGRPC_TrailersAreRealNotFabricated(t *testing.T) {
+	addr := startStreamingServer(t, &streamingServer{
+		respond: [][]byte{pbMsg("partial")},
+		st:      status.Error(codes.Internal, "boom"),
+	})
+
+	tc := grpcTestCase(addr, []models.GrpcLengthPrefixedMessage{{}})
+	resp, err := SimulateGRPC(context.Background(), tc, "set", zap.NewNop(), SimulationConfig{APITimeout: 10})
+	if err != nil {
+		t.Fatalf("SimulateGRPC: %v", err)
+	}
+	gotStatus := resp.Trailers.OrdinaryHeaders["grpc-status"]
+	wantStatus := fmt.Sprintf("%d", codes.Internal)
+	if gotStatus != wantStatus {
+		t.Fatalf("grpc-status = %q, want %q. Trailers must be read AFTER the drain reaches "+
+			"io.EOF; reading them earlier yields an empty map and the fixup fabricates \"0\", "+
+			"so a failed RPC replays as a pass.", gotStatus, wantStatus)
+	}
+}
+
+// TestSimulateGRPC_HeldOpenStreamIsBounded: draining to io.EOF is not
+// self-limiting the way one RecvMsg was. A bidi stream the server holds open
+// — server reflection is exactly that shape — must fail this ONE test case
+// rather than block until the whole test-run context dies.
+func TestSimulateGRPC_HeldOpenStreamIsBounded(t *testing.T) {
+	hold := make(chan struct{})
+	t.Cleanup(func() { close(hold) })
+	addr := startStreamingServer(t, &streamingServer{respond: [][]byte{pbMsg("first")}, holdOpen: hold})
+
+	tc := grpcTestCase(addr, []models.GrpcLengthPrefixedMessage{{}})
+	done := make(chan struct{})
+	start := time.Now()
+	go func() {
+		defer close(done)
+		_, _ = SimulateGRPC(context.Background(), tc, "set", zap.NewNop(), SimulationConfig{APITimeout: 2})
+	}()
+	select {
+	case <-done:
+		if elapsed := time.Since(start); elapsed > 10*time.Second {
+			t.Fatalf("returned after %v, far beyond the 2s APITimeout", elapsed)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("SimulateGRPC never returned against a stream the server holds open. The drain " +
+			"loop must be bounded by APITimeout, or one bad test case hangs the entire test set.")
+	}
+}
+
+// keep the framing helpers honest about their assumptions
+var _ = binary.BigEndian
+var _ = io.EOF
+var _ = metadata.MD{}

--- a/pkg/service/replay/hooks.go
+++ b/pkg/service/replay/hooks.go
@@ -108,6 +108,9 @@ func (h *Hooks) SimulateRequest(ctx context.Context, tc *models.TestCase, testSe
 		}
 
 		resp, err := pkg.SimulateGRPC(ctx, tc, testSetID, h.logger, pkg.SimulationConfig{
+			// Bounds the response drain. Without it a bidi stream the server
+			// holds open hangs the whole test set instead of failing one case.
+			APITimeout:      h.cfg.Test.APITimeout,
 			ConfigPort:      configPort,
 			ConfigHost:      hostToUse,
 			URLReplacements: urlReplacements,


### PR DESCRIPTION
> **Stacked on #4550** → #4549. Retarget as those merge.

Replay sent one request message and received one response message, so a streaming RPC replayed as its first message and nothing else. Three problems — and the third is what made the other two dangerous.

### Send every recorded request message

A client-streaming or bidi call records N. Sending only the first replays a *different request* from the one captured, so the response it draws is not the response that was recorded.

### Drain the response to `io.EOF`

A single `RecvMsg` took the first message and abandoned the rest — and by tearing the stream down early it also **aborted the app handler**, so dependency calls behind messages 2..N never ran at all.

### Read trailers after the drain — and take the status from the terminal error

grpc-go only populates `Trailer()` once `RecvMsg` has returned a non-nil error. Reading it after the first message returned an **empty map**, and the fixup below then fabricated `grpc-status: "0"`. A stream that died partway replayed as a **clean success**.

Moving the read is necessary but **not sufficient**, and a test caught that: grpc-go consumes `grpc-status`/`grpc-message` off the wire and turns them into the *error*, so `Trailer()` carries only the application's own custom trailers. A stream ending `INTERNAL` has no `grpc-status` key at all and would still have defaulted to `"0"`. The status now comes from `status.FromError` on the terminal error, which is the only place it exists.

### Bound the call

One `RecvMsg` was self-limiting; a drain loop is not. A bidi stream the server holds open — **server reflection is exactly that shape** — never reaches EOF, so without a deadline one bad test case blocks until the whole test-run context dies and takes the rest of the test set with it.

`APITimeout` is the knob the HTTP replay path already uses; `hooks.go` wasn't passing it, so it's plumbed through, with a bounded fallback when unset.

### Unary is unchanged

`AllMessages()` yields exactly one message for a unary mock — including the zero-value body the health check records — and a response carrying only trailers still produces the single empty message a lone `RecvMsg` used to produce.

### Mutations, against a real gRPC server

| mutation | caught by |
|---|---|
| restore the single `RecvMsg` | drains-every-message, trailers |
| send only the first request message | sends-every-request-message |
| don't derive status from the terminal error | trailers-are-real |
| remove the timeout | held-open-stream-is-bounded (hangs to its 20s guard) |

`go build ./... && go test ./...` green.
