### PR TITLE
fix(replay): exit non-zero when the app never starts under --keep-app-alive

### DIFF
--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -499,6 +500,13 @@ func (r *Replayer) Start(ctx context.Context) error {
 	// keeps working unchanged (OR can only widen).
 	composeReuse := cmdType == utils.DockerCompose && r.config.Test.Mocking
 	effectiveKeepAlive := (r.config.Test.KeepAppAlive || composeReuse) && r.instrument && cmdType != utils.Empty
+
+	// Records a --keep-app-alive app failure so the run can exit non-zero on
+	// it. The errgroup alone cannot do that: nothing ever calls g.Wait(), so
+	// the error this goroutine returns is collected by no one, and the exit
+	// code is carried by utils.ErrCode rather than by Start's return value.
+	var keepAliveAppErr atomic.Pointer[models.AppError]
+
 	if effectiveKeepAlive {
 		g.Go(func() error {
 			defer utils.Recover(r.logger)
@@ -534,6 +542,7 @@ func (r *Replayer) Start(ctx context.Context) error {
 						"Common causes: image build failure, port already in use, missing env var, dependency container crash-looped. "+
 						"If the app is expected to manage its own lifecycle across test-sets, drop --keep-app-alive and let keploy "+
 						"restart it per test-set instead."))
+			keepAliveAppErr.Store(&appErr)
 			return appErr
 		})
 	}
@@ -918,10 +927,36 @@ func (r *Replayer) Start(ctx context.Context) error {
 
 	// return non-zero error code so that pipeline processes
 	// know that there is a failure in tests
-	if !testRunResult {
-		utils.ErrCode = 1
+	errCode, runErr := replayRunOutcome(testRunResult, keepAliveAppErr.Load())
+	utils.ErrCode = errCode
+	return runErr
+}
+
+// replayRunOutcome decides how a replay run reports itself: the process exit
+// code, and the error Start returns.
+//
+// Two things make this worth naming rather than inlining.
+//
+// The exit code does NOT travel through Start's return value — it is carried
+// by utils.ErrCode, so returning an error alone would still exit 0.
+//
+// And an app that died under --keep-app-alive is a failed run even when no
+// test reported a failure, which is exactly the case that used to escape.
+// testRunResult starts true and is only ever set false by a test-set that
+// actually RAN, so an app failing to start leaves it true: zero tests
+// execute, the summary reports nothing failed, and keploy exits 0 while
+// logging "replay completed successfully". Every CI pipeline downstream reads
+// that as a pass. The errgroup was supposed to carry the failure — the
+// goroutine's own comment says g.Wait() surfaces it — but nothing in this
+// package ever calls g.Wait(), so the error had nowhere to go.
+func replayRunOutcome(testRunResult bool, keepAliveAppErr *models.AppError) (int, error) {
+	if keepAliveAppErr != nil {
+		return 1, fmt.Errorf("user application failed under --keep-app-alive: %v", *keepAliveAppErr)
 	}
-	return nil
+	if !testRunResult {
+		return 1, nil
+	}
+	return 0, nil
 }
 
 func (r *Replayer) Instrument(ctx context.Context) (*InstrumentState, error) {

--- a/pkg/service/replay/replay_exit_code_test.go
+++ b/pkg/service/replay/replay_exit_code_test.go
@@ -1,0 +1,125 @@
+package replay
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// TestReplayRunOutcome_AppFailureExitsNonZero is the bug this pins.
+//
+// A user runs `keploy test` with --keep-app-alive, their app fails to start
+// (image build failure, port in use, missing env var, a crash-looping
+// dependency), ZERO tests run — and keploy exits 0 while logging "replay
+// completed successfully". Every CI pipeline downstream reads that as a pass.
+//
+// It escaped because testRunResult starts true and is only ever set false by
+// a test-set that actually ran. With no tests, nothing sets it false. The app
+// error was returned into an errgroup whose Wait() is never called anywhere
+// in this package, so it went nowhere.
+func TestReplayRunOutcome_AppFailureExitsNonZero(t *testing.T) {
+	appErr := models.AppError{AppErrorType: models.ErrUnExpected}
+
+	// The exact shape of the escape: app died, but no test reported failure.
+	code, err := replayRunOutcome(true, &appErr)
+	if code == 0 {
+		t.Fatal("exit code 0 for a run whose app failed under --keep-app-alive with zero tests " +
+			"run. testRunResult stays true when nothing ran, so this is precisely the case " +
+			"that reported success while the app was dead.")
+	}
+	if err == nil {
+		t.Fatal("no error returned for a failed app; the reason must reach the caller, not " +
+			"just the exit code")
+	}
+}
+
+// TestReplayRunOutcome_Table covers the remaining combinations, including the
+// two that must stay a pass.
+func TestReplayRunOutcome_Table(t *testing.T) {
+	appErr := models.AppError{AppErrorType: models.ErrUnExpected}
+
+	for _, tc := range []struct {
+		name          string
+		testRunResult bool
+		appErr        *models.AppError
+		wantCode      int
+		wantErr       bool
+	}{
+		{"everything passed", true, nil, 0, false},
+		{"a test failed", false, nil, 1, false},
+		{"app died, tests passed", true, &appErr, 1, true},
+		{"app died and tests failed", false, &appErr, 1, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			code, err := replayRunOutcome(tc.testRunResult, tc.appErr)
+			if code != tc.wantCode {
+				t.Fatalf("exit code = %d, want %d", code, tc.wantCode)
+			}
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, want error: %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestKeepAliveAppErrIsWiredToTheOutcome pins the WIRING, which the tests
+// above deliberately cannot reach.
+//
+// replayRunOutcome is a pure function, so testing it proves the rule and
+// nothing about whether the rule is ever consulted. Deleting the
+// keepAliveAppErr.Store in the --keep-app-alive goroutine, or the
+// .Load() feeding the outcome, restores the original bug — an app that dies
+// with zero tests run exits 0 — while every behavioural test above stays
+// green. Driving Start() end to end would need a full instrumented replay, so
+// this asserts the two connections directly in the source.
+func TestKeepAliveAppErrIsWiredToTheOutcome(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "replay.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse replay.go: %v", err)
+	}
+
+	var stored, loadedIntoOutcome bool
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		// keepAliveAppErr.Store(...)
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "Store" {
+			if ident, ok := sel.X.(*ast.Ident); ok && ident.Name == "keepAliveAppErr" {
+				stored = true
+			}
+		}
+		// replayRunOutcome(_, keepAliveAppErr.Load())
+		if ident, ok := call.Fun.(*ast.Ident); ok && ident.Name == "replayRunOutcome" {
+			for _, arg := range call.Args {
+				inner, ok := arg.(*ast.CallExpr)
+				if !ok {
+					continue
+				}
+				sel, ok := inner.Fun.(*ast.SelectorExpr)
+				if !ok || sel.Sel.Name != "Load" {
+					continue
+				}
+				if x, ok := sel.X.(*ast.Ident); ok && x.Name == "keepAliveAppErr" {
+					loadedIntoOutcome = true
+				}
+			}
+		}
+		return true
+	})
+
+	if !stored {
+		t.Error("nothing stores into keepAliveAppErr. The --keep-app-alive goroutine must record " +
+			"the app failure, or it is lost: it returns the error into an errgroup whose Wait() " +
+			"is never called anywhere in this package.")
+	}
+	if !loadedIntoOutcome {
+		t.Error("replayRunOutcome is not called with keepAliveAppErr.Load(). The rule can be " +
+			"correct and still never consulted, which is exactly how a dead app exited 0.")
+	}
+}


### PR DESCRIPTION
A user runs `keploy test` with `--keep-app-alive`, their app fails to start, **zero tests run** — and keploy **exits 0** while logging *"replay completed successfully"*. Every CI pipeline downstream reads that as a pass.

Observed on a real pipeline: zero tests executed, exit code 0, and the only clue was an `ERROR` line buried mid-log.

### Two things had to line up

**`testRunResult` starts `true`** and is only ever set false by a test-set that actually *ran*. An app that fails to start means nothing runs, so nothing sets it false — the run reports success **by default rather than by evidence**.

**The app error had nowhere to go.** The `--keep-app-alive` goroutine returns it into the errgroup, and its own comment says:

> propagate it back through the errgroup so `g.Wait()` at the bottom of `Start()` surfaces the cause

But `g.Wait()` appears **exactly once in this entire package — inside that comment**. Nothing ever calls it. And the exit code doesn't travel through `Start`'s return value either; it's carried by `utils.ErrCode`, so returning an error alone would still have exited 0.

### The fix

The goroutine records the failure, and `replayRunOutcome` decides both the exit code and the returned error from it. Extracted and named rather than inlined, because it's a rule worth stating: **an app that died is a failed run even when no test reported a failure — and especially then.**

| testRunResult | app died | exit | error |
|---|---|---|---|
| pass | no | 0 | nil |
| fail | no | 1 | nil |
| **pass** | **yes** | **1** | **reason** |
| fail | yes | 1 | reason |

Row 3 is the escape.

### Mutations

Two behavioural — ignoring the app error, and reporting the exit code while swallowing the reason.

The third is the **wiring**, which the behavioural tests deliberately cannot reach: `replayRunOutcome` is pure, so testing it proves the rule and nothing about whether the rule is ever *consulted*. Deleting the `Store` in the goroutine restores the original bug with every other test green — so that connection is asserted directly in the source.

Found while root-causing an unrelated CI lane, where the harness had grown a workaround for exactly this.

`go build ./... && go test ./...` green.
