### PR TITLE
test(models): assert Validate() on CopyIn round-trip fixture

### DIFF
--- a/pkg/models/mock_test.go
+++ b/pkg/models/mock_test.go
@@ -272,8 +272,9 @@ func TestPostgresV3Response_CopyIn_RoundTrip(t *testing.T) {
 	if decoded.CopyOut != nil {
 		t.Fatalf("CopyOut: omitempty should have kept this nil on the CopyIn-only fixture, got %+v", decoded.CopyOut)
 	}
-	// TODO(validation): once a Validate() method or a custom
-	// UnmarshalYAML lands on PostgresV3Response, add a separate test
-	// that feeds a malformed fixture carrying BOTH Rows and CopyIn
-	// and asserts the validator rejects it.
+	// PostgresV3Response.Validate() enforces mutual exclusion between
+	// Rows, CopyIn, CopyOut, and FunctionCall (see postgres_v3_response_validate_test.go).
+	if err := decoded.Validate(); err != nil {
+		t.Fatalf("Validate(): unexpected error on valid CopyIn fixture: %v", err)
+	}
 }


### PR DESCRIPTION
## Describe the changes that are made
- Assert `Validate()` on the valid `CopyIn` round-trip test fixture and clean up the resolved TODO in [mock_test.go](file:///Users/abhipra/Developer/Github/keploy/pkg/models/mock_test.go).
- The mutual exclusion validation method `(*PostgresV3Response).Validate()` and its exhaustive unit tests across pairwise collisions (`Rows`, `CopyIn`, `CopyOut`, `FunctionCall`) are implemented and tested in [postgres_v3_response_validate.go](file:///Users/abhipra/Developer/Github/keploy/pkg/models/postgres_v3_response_validate.go) and [postgres_v3_response_validate_test.go](file:///Users/abhipra/Developer/Github/keploy/pkg/models/postgres_v3_response_validate_test.go).

## Links & References

**Closes:** #4492

### 🔗 Related PRs
- NA
### 🐞 Related Issues
- #4492
### 📄 Related Documents
- NA

## What type of PR is this? (check all applicable)
- [x] ✅ Test
- [x] 🧑‍💻 Code Refactor

## Added e2e test pipeline?
- [x] 🙅 no, because they aren't needed

## Added comments for hard-to-understand areas?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed

## Are there any sample code or steps to test the changes?
- [x] 👍 yes, mentioned below
Run `go test -v ./pkg/models/...`

## Self Review done?
- [x] ✅ yes

## Any relevant screenshots, recordings or logs?
- NA
