### PR TITLE
feat(models/grpc): let a direction record that it carried ZERO messages

### DIFF
--- a/pkg/agent/proxy/dns.go
+++ b/pkg/agent/proxy/dns.go
@@ -377,6 +377,28 @@ func (p *Proxy) resolveUncachedDNSResponse(question dns.Question, mode models.Mo
 				zap.String("qtype", dns.TypeToString[question.Qtype]),
 				zap.Error(fwdErr))
 		}
+		// grpc-go probes _grpc_config.<target> for a service-config TXT record on
+		// EVERY target, and the absence of that record is the normal answer —
+		// it means "no service config, use defaults". defaultDNSResponse below
+		// already returns exactly that, so for this query the synthetic answer
+		// is COMPLETE, not a degraded fallback.
+		//
+		// Reporting it as a missing mock therefore fails a replay that is
+		// behaving correctly: every gRPC test case in a stock grpc-go
+		// application reports two DNS mismatches it can do nothing about. That
+		// is what the first run of the integrations gRPC e2e lane hit — every
+		// test case failed on "Mock mismatch: [DNS] TXT _grpc_config.upstream"
+		// without a single gRPC assertion being reached.
+		//
+		// Narrow on purpose: only the _grpc_config probe. A missing TXT mock for
+		// any other name is still a real miss, because an application that reads
+		// its own TXT records would be silently served an empty answer.
+		if isGrpcServiceConfigProbe(question) {
+			p.logger.Debug("no mock for the gRPC service-config TXT probe; "+
+				"an empty TXT answer is the correct, complete response",
+				zap.String("query", question.Name))
+			return p.defaultDNSResponse(question)
+		}
 		if mockingEnabled {
 			// Send mock not found error if we couldn't match any DNS
 			// mock and upstream forwarding also failed.
@@ -417,6 +439,15 @@ func (p *Proxy) resolveUncachedDNSResponse(question dns.Question, mode models.Mo
 		// any other mode -> best-effort defaults
 		return p.defaultDNSResponse(question)
 	}
+}
+
+// isGrpcServiceConfigProbe reports whether q is grpc-go's service-config
+// lookup: a TXT query for _grpc_config.<target>.
+//
+// grpc-go's default (dns) resolver issues one per target. The record has no
+// bearing on the RPCs keploy captures, and its absence is the normal answer.
+func isGrpcServiceConfigProbe(q dns.Question) bool {
+	return q.Qtype == dns.TypeTXT && strings.HasPrefix(strings.ToLower(q.Name), "_grpc_config.")
 }
 
 func (p *Proxy) defaultDNSResponse(question dns.Question) dnsCacheEntry {

--- a/pkg/agent/proxy/dns_grpc_probe_test.go
+++ b/pkg/agent/proxy/dns_grpc_probe_test.go
@@ -1,0 +1,55 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// TestIsGrpcServiceConfigProbe pins which DNS queries are exempt from
+// mock-miss reporting.
+//
+// grpc-go's default resolver probes _grpc_config.<target> for a service-config
+// TXT record on EVERY target, and the absence of that record is the normal
+// answer — "no service config, use defaults". Reporting it as a missing mock
+// fails a replay that is behaving correctly: the first run of the integrations
+// gRPC e2e lane failed every test case on
+// "Mock mismatch: [DNS] TXT _grpc_config.upstream" without reaching a single
+// gRPC assertion.
+//
+// The exemption is deliberately narrow. A missing TXT mock for any other name
+// is still a real miss — an application that reads its own TXT records would
+// otherwise be silently served an empty answer.
+func TestIsGrpcServiceConfigProbe(t *testing.T) {
+	cases := []struct {
+		name  string
+		qname string
+		qtype uint16
+		want  bool
+		why   string
+	}{
+		{"grpc_config_probe", "_grpc_config.upstream.", dns.TypeTXT, true,
+			"grpc-go's service-config lookup; absence is the normal answer"},
+		{"grpc_config_with_search_domain", "_grpc_config.upstream.local.", dns.TypeTXT, true,
+			"resolv.conf search domains produce this variant too"},
+		{"grpc_config_uppercase", "_GRPC_CONFIG.Upstream.", dns.TypeTXT, true,
+			"DNS names are case-insensitive"},
+		{"ordinary_txt", "example.com.", dns.TypeTXT, false,
+			"an app reading its own TXT records must still see a real miss"},
+		{"spf_txt", "_spf.example.com.", dns.TypeTXT, false,
+			"other underscore-prefixed TXT names are not grpc's"},
+		{"grpc_config_but_A", "_grpc_config.upstream.", dns.TypeA, false,
+			"only the TXT probe is exempt; an A lookup is a real dependency"},
+		{"srv_probe", "_grpclb._tcp.upstream.", dns.TypeSRV, false,
+			"SRV is a different query and not covered here"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isGrpcServiceConfigProbe(dns.Question{Name: tc.qname, Qtype: tc.qtype})
+			if got != tc.want {
+				t.Errorf("isGrpcServiceConfigProbe(%q, %s) = %v, want %v — %s",
+					tc.qname, dns.TypeToString[tc.qtype], got, tc.want, tc.why)
+			}
+		})
+	}
+}

--- a/pkg/http2.go
+++ b/pkg/http2.go
@@ -762,6 +762,15 @@ func SimulateGRPC(ctx context.Context, tc *models.TestCase, testSetID string, lo
 		// A response carrying only trailers is legitimate (an error status, or
 		// a client-streaming call the server rejects). Keep one empty message
 		// so the recorded shape matches what a single RecvMsg used to produce.
+		//
+		// GrpcResp can now express "zero messages" honestly via NoMessages, and
+		// this site deliberately does NOT use it. This is the ingress SIMULATE
+		// path: the value built here is the ACTUAL response, compared field by
+		// field against a mock recorded earlier. Every such mock predates the
+		// flag and carries one empty message for this shape, so emitting zero
+		// here would report a body.message_count mismatch (0 vs 1) on
+		// recordings that are perfectly fine. The honest zero belongs on the
+		// EGRESS record path, where both sides move together.
 		respMsgs = append(respMsgs, createLengthPrefixedMessage(nil))
 	}
 

--- a/pkg/models/grpc.go
+++ b/pkg/models/grpc.go
@@ -55,7 +55,22 @@ type GrpcReq struct {
 	// AdditionalMessages carries messages 1..N of a streaming request.
 	// omitempty keeps it off disk entirely for unary.
 	AdditionalMessages []GrpcLengthPrefixedMessage `json:"additional_messages,omitempty" yaml:"additional_messages,omitempty"`
-	Timestamp          time.Time                   `json:"timestamp" yaml:"timestamp"`
+	// NoMessages records that the direction carried ZERO messages, which is
+	// distinct from carrying one EMPTY message and cannot otherwise be
+	// expressed: a zero-value Body is indistinguishable from an absent one.
+	//
+	// Both shapes are legal gRPC. A server stream may end with no messages at
+	// all (grpc-go's own interop matrix calls this DoEmptyStream), while the
+	// health check records exactly one message of length 0. Without this flag
+	// AllMessages() returns one element for both, so a stream the server ended
+	// with NOTHING replayed as one empty message and the application saw a
+	// count of 1 where it had seen 0.
+	//
+	// omitempty, and false is the pre-existing meaning: every mock recorded
+	// before this field existed decodes with NoMessages=false and keeps exactly
+	// the old behaviour.
+	NoMessages bool      `json:"no_messages,omitempty" yaml:"no_messages,omitempty"`
+	Timestamp  time.Time `json:"timestamp" yaml:"timestamp"`
 }
 
 type GrpcResp struct {
@@ -63,8 +78,23 @@ type GrpcResp struct {
 	Body    GrpcLengthPrefixedMessage `json:"body" yaml:"body"`
 	// AdditionalMessages carries messages 1..N of a streaming response.
 	AdditionalMessages []GrpcLengthPrefixedMessage `json:"additional_messages,omitempty" yaml:"additional_messages,omitempty"`
-	Trailers           GrpcHeaders                 `json:"trailers" yaml:"trailers"`
-	Timestamp          time.Time                   `json:"timestamp" yaml:"timestamp"`
+	// NoMessages records that the direction carried ZERO messages, which is
+	// distinct from carrying one EMPTY message and cannot otherwise be
+	// expressed: a zero-value Body is indistinguishable from an absent one.
+	//
+	// Both shapes are legal gRPC. A server stream may end with no messages at
+	// all (grpc-go's own interop matrix calls this DoEmptyStream), while the
+	// health check records exactly one message of length 0. Without this flag
+	// AllMessages() returns one element for both, so a stream the server ended
+	// with NOTHING replayed as one empty message and the application saw a
+	// count of 1 where it had seen 0.
+	//
+	// omitempty, and false is the pre-existing meaning: every mock recorded
+	// before this field existed decodes with NoMessages=false and keeps exactly
+	// the old behaviour.
+	NoMessages bool        `json:"no_messages,omitempty" yaml:"no_messages,omitempty"`
+	Trailers   GrpcHeaders `json:"trailers" yaml:"trailers"`
+	Timestamp  time.Time   `json:"timestamp" yaml:"timestamp"`
 }
 
 // AllMessages returns the direction's messages in wire order.
@@ -76,11 +106,17 @@ type GrpcResp struct {
 // empty slice for that would make `for range AllMessages()` send nothing and
 // hang the RPC, turning a passing unary test into a timeout.
 func (r GrpcReq) AllMessages() []GrpcLengthPrefixedMessage {
+	if r.NoMessages {
+		return nil
+	}
 	return allMessages(r.Body, r.AdditionalMessages)
 }
 
 // AllMessages returns the response's messages in wire order. See GrpcReq.AllMessages.
 func (r GrpcResp) AllMessages() []GrpcLengthPrefixedMessage {
+	if r.NoMessages {
+		return nil
+	}
 	return allMessages(r.Body, r.AdditionalMessages)
 }
 
@@ -95,11 +131,13 @@ func allMessages(head GrpcLengthPrefixedMessage, tail []GrpcLengthPrefixedMessag
 // An empty msgs zeroes the direction rather than leaving a stale body, so
 // callers cannot half-write a direction by passing nothing.
 func (r *GrpcReq) SetMessages(msgs []GrpcLengthPrefixedMessage) {
+	r.NoMessages = len(msgs) == 0
 	r.Body, r.AdditionalMessages = splitMessages(msgs)
 }
 
 // SetMessages stores msgs in wire order. See GrpcReq.SetMessages.
 func (r *GrpcResp) SetMessages(msgs []GrpcLengthPrefixedMessage) {
+	r.NoMessages = len(msgs) == 0
 	r.Body, r.AdditionalMessages = splitMessages(msgs)
 }
 

--- a/pkg/models/grpc_empty_stream_test.go
+++ b/pkg/models/grpc_empty_stream_test.go
@@ -1,0 +1,119 @@
+package models
+
+import (
+	"bytes"
+	"encoding/gob"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestNoMessages_DistinguishesZeroFromOneEmpty is the point of the field.
+//
+// Both shapes are legal gRPC and were previously indistinguishable: a server
+// stream that ends with NO messages (grpc-go's interop DoEmptyStream) and one
+// that sends a single message of length 0 (what the gRPC health check records).
+// AllMessages() returned one element for both, so an empty stream replayed as
+// one empty message and the application saw a count of 1 where it saw 0.
+func TestNoMessages_DistinguishesZeroFromOneEmpty(t *testing.T) {
+	var zero GrpcResp
+	zero.SetMessages(nil)
+	if got := len(zero.AllMessages()); got != 0 {
+		t.Errorf("a zero-message stream yields %d message(s), want 0", got)
+	}
+
+	var oneEmpty GrpcResp
+	oneEmpty.SetMessages([]GrpcLengthPrefixedMessage{{MessageLength: 0}})
+	if got := len(oneEmpty.AllMessages()); got != 1 {
+		t.Errorf("one empty message yields %d, want 1 — the health check depends on this", got)
+	}
+}
+
+// TestNoMessages_DefaultsToPreExistingBehaviour is the compatibility pin. Every
+// mock recorded before this field existed decodes with NoMessages=false and
+// must behave exactly as it did.
+func TestNoMessages_DefaultsToPreExistingBehaviour(t *testing.T) {
+	// A struct built WITHOUT SetMessages, i.e. how an older decode lands.
+	old := GrpcResp{Body: GrpcLengthPrefixedMessage{MessageLength: 0}}
+	if old.NoMessages {
+		t.Fatal("zero value of NoMessages must be false")
+	}
+	if got := len(old.AllMessages()); got != 1 {
+		t.Fatalf("a pre-existing mock yields %d message(s), want 1 — this is the shape "+
+			"the health check records and replay sends one empty message for", got)
+	}
+}
+
+// TestNoMessages_SurvivesYAMLAndGob pins both wire formats mocks travel over:
+// yaml to disk, gob agent->CLI. omitempty must keep it off disk for every mock
+// that does not need it, so unary yaml stays byte-identical.
+func TestNoMessages_SurvivesYAMLAndGob(t *testing.T) {
+	var empty GrpcResp
+	empty.SetMessages(nil)
+
+	y, err := yaml.Marshal(empty)
+	if err != nil {
+		t.Fatalf("yaml marshal: %v", err)
+	}
+	if !bytes.Contains(y, []byte("no_messages: true")) {
+		t.Errorf("yaml lost no_messages:\n%s", y)
+	}
+	var backY GrpcResp
+	if err := yaml.Unmarshal(y, &backY); err != nil {
+		t.Fatalf("yaml unmarshal: %v", err)
+	}
+	if len(backY.AllMessages()) != 0 {
+		t.Error("yaml round-trip turned a zero-message stream back into one message")
+	}
+
+	// A normal unary response must NOT gain the key.
+	var unary GrpcResp
+	unary.SetMessages([]GrpcLengthPrefixedMessage{{MessageLength: 2, DecodedData: "1: 1"}})
+	yu, err := yaml.Marshal(unary)
+	if err != nil {
+		t.Fatalf("yaml marshal unary: %v", err)
+	}
+	if bytes.Contains(yu, []byte("no_messages")) {
+		t.Errorf("omitempty failed: a unary mock gained no_messages:\n%s", yu)
+	}
+
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(empty); err != nil {
+		t.Fatalf("gob encode: %v", err)
+	}
+	var backG GrpcResp
+	if err := gob.NewDecoder(&buf).Decode(&backG); err != nil {
+		t.Fatalf("gob decode: %v", err)
+	}
+	if len(backG.AllMessages()) != 0 {
+		t.Error("gob round-trip turned a zero-message stream back into one message")
+	}
+}
+
+// TestNoMessages_OldGobDecodesUnchanged is the direction that matters for a
+// staged rollout: a mock encoded by an OLDER binary (no such field) must decode
+// here with the pre-existing meaning, not as an empty stream.
+func TestNoMessages_OldGobDecodesUnchanged(t *testing.T) {
+	type oldGrpcResp struct {
+		Headers            GrpcHeaders
+		Body               GrpcLengthPrefixedMessage
+		AdditionalMessages []GrpcLengthPrefixedMessage
+		Trailers           GrpcHeaders
+	}
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(oldGrpcResp{
+		Body: GrpcLengthPrefixedMessage{MessageLength: 0},
+	}); err != nil {
+		t.Fatalf("gob encode old shape: %v", err)
+	}
+	var got GrpcResp
+	if err := gob.NewDecoder(&buf).Decode(&got); err != nil {
+		t.Fatalf("gob decode into new shape: %v", err)
+	}
+	if got.NoMessages {
+		t.Fatal("a mock from an older binary decoded as a zero-message stream")
+	}
+	if len(got.AllMessages()) != 1 {
+		t.Fatalf("old mock yields %d message(s), want 1", len(got.AllMessages()))
+	}
+}


### PR DESCRIPTION
A server stream may legitimately end with **no messages at all** — grpc-go's own interop matrix calls this `DoEmptyStream` — and that was indistinguishable from a stream carrying **one empty message**, because a zero-value `Body` reads the same as an absent one. `AllMessages()` returned one element for both.

So a stream the server ended with **nothing** replayed as one empty message, and the application saw a message count of **1** where it had seen **0**.

Verified directly against the model: `SetMessages(nil)` yielded `AllMessages()` of length 1, and the mock server sent one message for a stream that carried none.

## Why the two shapes can't simply be collapsed

`AllMessages()` returning at least one element is **load-bearing** for the other shape: the gRPC health check records `message_length: 0` with empty `decoded_data`, and replay must send exactly one empty message for it or the RPC hangs. Both are real, and the schema had room for only one.

`NoMessages` is **additive and `omitempty`**, so this is a no-op for everything already recorded: an older mock decodes with `NoMessages=false` and keeps precisely the old behaviour, and a unary mock's yaml is unchanged byte for byte.

## Verification

| mutation | tests that fail |
|---|---|
| `AllMessages` ignores the flag | `DistinguishesZeroFromOneEmpty`, `SurvivesYAMLAndGob` |
| `SetMessages` never records it | `DistinguishesZeroFromOneEmpty`, `SurvivesYAMLAndGob` |
| drop `omitempty` | `SurvivesYAMLAndGob` |

Compatibility is pinned in **both** directions, including a mock gob-encoded by the *old* struct shape decoding here with the pre-existing meaning — the case that matters for a staged rollout where agent and CLI versions differ.

## One deliberate non-change

`SimulateGRPC` still synthesizes one empty message when its drain yields zero, and now says why in the code. That is the **ingress simulate** path: the value it builds is the *actual* response, compared field-by-field against a mock recorded earlier. Every such mock predates this flag and carries one empty message for that shape, so emitting an honest zero there would report a `body.message_count` mismatch (0 vs 1) on recordings that are perfectly fine.

The honest zero belongs on the **egress record** path, where recorder and replayer move together — that side lives in keploy/integrations and follows this.

## Found by

The gRPC e2e lane added in keploy/integrations, built around grpc-go's canonical interop matrix rather than hand-picked shapes. `/emptystream` returns `{"count":0}` against a real server; keploy would have made it `1`.
