### PR TITLE
refactor(proxy): remove the legacy relay mode so every parser records via V2

### DIFF
--- a/docs/contributing/parser-migration-guide.md
+++ b/docs/contributing/parser-migration-guide.md
@@ -284,10 +284,12 @@ Three parsers are migrated on PR #4113 — use them as templates:
 
 ## Rollout knobs
 
-- `KEPLOY_NEW_RELAY=off` forces every parser (including yours) back
-  to the legacy path. Use during incidents.
-- `KEPLOY_DISABLE_PARSING=1` disables parser dispatch entirely; every
-  connection goes to raw passthrough.
+- `KEPLOY_NEW_RELAY` — **REMOVED.** It used to force every parser back
+  to the legacy path. A value left in the environment is ignored (and
+  logged once at startup), so it is no longer an incident lever.
+- `KEPLOY_DISABLE_PARSING=1` / `SIGUSR1` disables parser dispatch
+  entirely; every connection goes to raw passthrough. This is the
+  incident lever.
 
 ## When in doubt
 

--- a/pkg/agent/proxy/README.md
+++ b/pkg/agent/proxy/README.md
@@ -121,8 +121,10 @@ Numbered to match `PLAN.md` at the repo root.
    - Emit mocks via `sess.EmitMock`. The gate and post-record hook
      chain run automatically.
 
-4. Legacy path stays untouched. During rollout, `KEPLOY_NEW_RELAY=off`
-   forces every parser to the legacy path.
+4. The legacy branch still exists in the dispatcher for a parser that
+   does not implement `IntegrationsV2`, but nothing in tree is in that
+   state on the record path. There is no env knob that forces it: the
+   `KEPLOY_NEW_RELAY` rollback switch has been removed.
 
 Reference implementations: `integrations/http/recordv2.go`,
 `integrations/mysql/recorder/record_v2.go`,
@@ -144,8 +146,12 @@ All unit tests pass under `-race`.
 
 ## Rollout knobs
 
-- `KEPLOY_NEW_RELAY=off` / `KEPLOY_NEW_RELAY=0` — force every parser,
-  including V2-capable ones, onto the legacy path. Global V2 rollback.
+- `KEPLOY_NEW_RELAY` — **REMOVED.** It forced V2-capable parsers onto
+  the legacy path as a global rollback. Every parser on the record path
+  is now V2, and the legacy path it selected hangs EOF-delimited peers
+  (it waits for both copy directions instead of tearing the second
+  down), so the rollback traded one half-close defect for another. A
+  value left in the environment is ignored and logged once at startup.
 - `KEPLOY_DISABLE_PARSING=1` / `SIGUSR1` / admin endpoint — disable
   parsing entirely for new connections; existing connections drain.
   Routes everything to raw `globalPassThrough`. Kill switch for

--- a/pkg/agent/proxy/generic_v2_dispatch_test.go
+++ b/pkg/agent/proxy/generic_v2_dispatch_test.go
@@ -3,12 +3,18 @@ package proxy
 import (
 	"context"
 	"net"
+	"os"
+	"strings"
 	"testing"
+	"time"
 
+	"go.keploy.io/server/v3/config"
 	"go.keploy.io/server/v3/pkg/agent/proxy/integrations"
 	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/generic"
 	"go.keploy.io/server/v3/pkg/models"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+	"golang.org/x/sync/errgroup"
 )
 
 // fakeParser implements Integrations, and IntegrationsV2 only when v2Declared.
@@ -53,14 +59,20 @@ func TestShouldRecordViaSupervisor(t *testing.T) {
 		why        string
 	}{
 		{
-			name: "V2 parser, relay enabled", parser: fakeParser{v2: true},
+			name: "V2 parser", parser: fakeParser{v2: true},
 			wantV2Path: true,
 			why:        "a migrated parser must reach the supervisor, or its V2 recorder never runs",
 		},
 		{
-			name: "V2 parser, relay disabled", parser: fakeParser{v2: true}, relayOff: "off",
-			wantV2Path: false,
-			why:        "KEPLOY_NEW_RELAY=off is the documented escape hatch and must still force legacy",
+			// The KEPLOY_NEW_RELAY rollback knob was REMOVED: every parser the
+			// dispatcher can route to record is V2, and the switch only served
+			// to force them onto a legacy path whose half-close handling hangs
+			// EOF-delimited peers. Setting it must now be inert. Kept as a case
+			// rather than deleted so re-introducing the knob fails here.
+			name:   "the removed rollback knob no longer forces legacy",
+			parser: fakeParser{v2: true}, relayOff: "off",
+			wantV2Path: true,
+			why:        "KEPLOY_NEW_RELAY is gone; a stale value in the environment must not divert a V2 parser",
 		},
 		{
 			name: "parser declares IsV2() false", parser: fakeParser{v2: false},
@@ -89,5 +101,181 @@ func TestShouldRecordViaSupervisor(t *testing.T) {
 				t.Errorf("shouldRecordViaSupervisor = %v, want %v — %s", got, tc.wantV2Path, tc.why)
 			}
 		})
+	}
+}
+
+// TestWarnIfRemovedRelayKnobSet pins the startup notice for the removed
+// KEPLOY_NEW_RELAY variable.
+//
+// Silence is the dangerous outcome: the variable was a documented incident
+// rollback, so an operator can reasonably set it, restart, see no error, and
+// believe they have rolled back — while every parser still records through the
+// supervisor. The warning has to fire whenever the variable is PRESENT, not
+// only when it holds a formerly-truthy value: "off" and "on" are now equally
+// ignored, and someone who left `KEPLOY_NEW_RELAY=on` set is just as misled.
+func TestWarnIfRemovedRelayKnobSet(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		set      bool
+		value    string
+		wantWarn bool
+	}{
+		{name: "unset", set: false, wantWarn: false},
+		{name: "off (the documented rollback)", set: true, value: "off", wantWarn: true},
+		{name: "0", set: true, value: "0", wantWarn: true},
+		{name: "on", set: true, value: "on", wantWarn: true},
+		{name: "empty but present", set: true, value: "", wantWarn: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv("KEPLOY_NEW_RELAY", tc.value)
+			} else {
+				os.Unsetenv("KEPLOY_NEW_RELAY")
+			}
+			core, logs := observer.New(zap.WarnLevel)
+			warnIfRemovedRelayKnobSet(zap.New(core))
+
+			got := logs.FilterMessageSnippet("KEPLOY_NEW_RELAY").Len() > 0
+			if got != tc.wantWarn {
+				t.Fatalf("warned=%v, want %v — an operator who set a removed rollback knob "+
+					"must be told it is ignored, or they believe a rollback is in effect", got, tc.wantWarn)
+			}
+			if !tc.wantWarn {
+				return
+			}
+			// The message must name the lever that still works, or it tells the
+			// operator their escape hatch is gone without offering another.
+			if logs.FilterMessageSnippet("KEPLOY_NEW_RELAY").Len() > 0 {
+				fields := logs.All()[0].ContextMap()
+				next, _ := fields["next_step"].(string)
+				if !strings.Contains(next, "KEPLOY_DISABLE_PARSING") {
+					t.Errorf("next_step %q does not point at KEPLOY_DISABLE_PARSING, the "+
+						"remaining way to disable parsing during an incident", next)
+				}
+			}
+		})
+	}
+}
+
+// TestNilLoggerDoesNotPanicOnRemovedKnob covers the guard: New is called with a
+// logger in production, but the helper must not become a nil-panic source.
+func TestNilLoggerDoesNotPanicOnRemovedKnob(t *testing.T) {
+	t.Setenv("KEPLOY_NEW_RELAY", "off")
+	warnIfRemovedRelayKnobSet(nil)
+}
+
+// TestNewWarnsAboutTheRemovedRelayKnob pins the WIRING, not just the helper.
+//
+// TestWarnIfRemovedRelayKnobSet calls warnIfRemovedRelayKnobSet directly, so it
+// stays green if the call is deleted from New — the operator then gets silence,
+// which is the exact failure the warning exists to prevent. This drives the
+// real constructor.
+func TestNewWarnsAboutTheRemovedRelayKnob(t *testing.T) {
+	t.Setenv("KEPLOY_NEW_RELAY", "off")
+	core, logs := observer.New(zap.WarnLevel)
+	_ = New(zap.New(core), nil, &config.Config{})
+	if logs.FilterMessageSnippet("KEPLOY_NEW_RELAY").Len() == 0 {
+		t.Fatal("New() did not warn about the removed KEPLOY_NEW_RELAY knob — the helper " +
+			"exists but nothing calls it, so an operator relying on the old rollback " +
+			"gets no signal that it is ignored")
+	}
+}
+
+// TestNewIsQuietWithoutTheRemovedKnob is the negative control: the warning must
+// not fire on a normal start, or it becomes noise everyone learns to ignore.
+func TestNewIsQuietWithoutTheRemovedKnob(t *testing.T) {
+	os.Unsetenv("KEPLOY_NEW_RELAY")
+	core, logs := observer.New(zap.WarnLevel)
+	_ = New(zap.New(core), nil, &config.Config{})
+	if n := logs.FilterMessageSnippet("KEPLOY_NEW_RELAY").Len(); n != 0 {
+		t.Fatalf("New() warned about KEPLOY_NEW_RELAY %d time(s) with the variable unset", n)
+	}
+}
+
+// TestRecordGenericOutgoing_UnregisteredParserDeclinesInsteadOfPanicking covers
+// the guard that had no coverage at all: deleting it left the entire proxy
+// suite green.
+//
+// Generic.IsV2() is unconditionally true, so with the KEPLOY_NEW_RELAY rollback
+// removed the only way past the supervisor branch is an unregistered GENERIC —
+// where the legacy call nil-derefs the interface. The connection must be
+// relayed as a decline, not dropped and not panicked on.
+func TestRecordGenericOutgoing_UnregisteredParserDeclinesInsteadOfPanicking(t *testing.T) {
+	p := &Proxy{
+		logger:                     zap.NewNop(),
+		Integrations:               map[integrations.IntegrationType]integrations.Integrations{}, // GENERIC absent
+		recordBufferCap:            8 << 20,
+		recordBufferQueueSize:      64,
+		recordBufferStallGrace:     5 * time.Second,
+		recordBufferHalfCloseGrace: 5 * time.Second,
+	}
+
+	srcRaw, destRaw, cleanup := tcpConnPair(t)
+	defer cleanup()
+	// Close both so relayDeclinedConn's copy loops finish rather than blocking.
+	_ = srcRaw.Close()
+	_ = destRaw.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	ctx = context.WithValue(ctx, models.ClientConnectionIDKey, "1")
+	ctx = context.WithValue(ctx, models.DestConnectionIDKey, "2")
+	errGrp, gctx := errgroup.WithContext(ctx)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("recordGenericOutgoing panicked on an unregistered GENERIC parser: %v — "+
+				"the legacy branch dereferences a nil integrations.Integrations", r)
+		}
+	}()
+
+	err := p.recordGenericOutgoing(gctx, srcRaw, destRaw, make(chan *models.Mock, 8), errGrp,
+		zap.NewNop(), 1, 2, models.OutgoingOptions{})
+	if err != nil {
+		t.Fatalf("recordGenericOutgoing returned %v, want nil — an unregistered parser is a "+
+			"decline to be relayed, not a connection failure", err)
+	}
+}
+
+// TestRecordGenericOutgoing_RoutesRegisteredParserToSupervisor pins the other
+// half of the dispatch decision, so the nil guard cannot be "fixed" by making
+// every generic connection take it.
+func TestRecordGenericOutgoing_RoutesRegisteredParserToSupervisor(t *testing.T) {
+	if !shouldRecordViaSupervisor(generic.New(zap.NewNop())) {
+		t.Fatal("the real generic parser no longer routes to the supervisor — the widest " +
+			"path in the proxy would record through the legacy surface")
+	}
+}
+
+// TestMockGenericOutgoing_UnregisteredParserReportsInsteadOfPanicking is the
+// replay-side twin of the record guard. The record half got a nil check while
+// this one kept dereferencing the map lookup, so the same unregistered build
+// that was fixed for recording still crashed on replay.
+//
+// Replay cannot relay — every destination dial in handleConnection is
+// mode-gated, so there is no upstream conn — hence this reports the miss rather
+// than passing the connection through.
+func TestMockGenericOutgoing_UnregisteredParserReportsInsteadOfPanicking(t *testing.T) {
+	p := &Proxy{
+		logger:       zap.NewNop(),
+		Integrations: map[integrations.IntegrationType]integrations.Integrations{}, // GENERIC absent
+	}
+
+	srcRaw, destRaw, cleanup := tcpConnPair(t)
+	defer cleanup()
+	_ = destRaw.Close()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("mockGenericOutgoing panicked on an unregistered GENERIC parser: %v", r)
+		}
+	}()
+
+	err := p.mockGenericOutgoing(context.Background(), srcRaw,
+		&models.ConditionalDstCfg{Addr: "127.0.0.1:1"}, nil, models.OutgoingOptions{}, zap.NewNop())
+	if err == nil {
+		t.Fatal("mockGenericOutgoing returned nil with no GENERIC parser registered — replay " +
+			"cannot serve the connection, so this must surface as a mock miss rather than " +
+			"reporting success")
 	}
 }

--- a/pkg/agent/proxy/integrations/generic/drain_test.go
+++ b/pkg/agent/proxy/integrations/generic/drain_test.go
@@ -48,10 +48,11 @@ func (c *splitReadConn) CloseWrite() error { return proxyutil.CloseWriteIfPossib
 //
 // Scope it honestly, though. encodeGeneric is reached only via
 // Generic.recordLegacy, which needs session.V2 == nil, and
-// shouldRecordViaSupervisor routes to the supervisor unless
-// newRelayDisabled(). Every in-tree parser reports IsV2() == true, so this
-// path — like http's and mysql's siblings — runs only under
-// KEPLOY_NEW_RELAY=off. It is the rollback, not the default.
+// shouldRecordViaSupervisor routes every parser implementing
+// IntegrationsV2 to the supervisor, and every in-tree parser reports
+// IsV2() == true. With the KEPLOY_NEW_RELAY rollback knob removed there is
+// no way to reach this legacy path from the dispatcher at all; it is kept
+// covered because the code is still reachable by direct construction.
 //
 // Both orientations are driven on purpose. The survivor is whichever
 // direction did NOT report, so the drain has to poll that direction's byte

--- a/pkg/agent/proxy/integrations/generic/half_close_test.go
+++ b/pkg/agent/proxy/integrations/generic/half_close_test.go
@@ -13,8 +13,9 @@ import (
 	"go.uber.org/zap"
 )
 
-// The legacy generic path is what KEPLOY_NEW_RELAY=off routes to, so it
-// is the rollback for the V2 relay's half-close support. It is broken
+// The legacy generic path is no longer reachable from the dispatcher —
+// the KEPLOY_NEW_RELAY rollback knob that routed to it has been removed.
+// It is still covered here because the code exists and is broken
 // differently from the relay rather than identically: it waits for BOTH
 // copy directions instead of tearing the second down, so it never lost
 // the reply — but it never forwarded the FIN either, so an EOF-delimited

--- a/pkg/agent/proxy/integrations/http/http.go
+++ b/pkg/agent/proxy/integrations/http/http.go
@@ -118,14 +118,15 @@ func (h *HTTP) MatchType(_ context.Context, buf []byte) bool {
 // routes to recordViaSupervisor only when IsV2() returns true.
 //
 // Returning true is unconditional — the HTTP parser has no per-instance
-// configuration that could force it back to the legacy path. The rollback
-// knob is the env KEPLOY_NEW_RELAY=off handled in proxy_v2.go.
+// configuration that could force it back to the legacy path, and there is no
+// longer an env knob that can: the KEPLOY_NEW_RELAY rollback switch is gone.
 func (h *HTTP) IsV2() bool { return true }
 
 // RecordOutgoing dispatches to the V2 path when the supervisor has
 // attached a session via RecordSession.V2, and to the legacy path
-// otherwise. Keeping both paths live lets the dispatcher / rollback
-// knob (KEPLOY_NEW_RELAY) swap between them without code changes.
+// otherwise. In practice the dispatcher always attaches V2 for this parser
+// now that the KEPLOY_NEW_RELAY rollback knob is gone; the legacy branch
+// remains only for callers that construct a session without one.
 func (h *HTTP) RecordOutgoing(ctx context.Context, session *integrations.RecordSession) error {
 	if session != nil && session.V2 != nil {
 		return h.recordV2(ctx, session.V2)

--- a/pkg/agent/proxy/integrations/integrations.go
+++ b/pkg/agent/proxy/integrations/integrations.go
@@ -54,6 +54,17 @@ import (
 // parser error there already becomes FallthroughToPassthrough with a
 // correctly activity-scoped orphan window, which is the better shape.
 //
+// Be aware that those legacy sites are no longer reachable for any parser
+// in tree. Every parser the dispatcher can route to record implements
+// IntegrationsV2, and the KEPLOY_NEW_RELAY knob that could force them onto
+// the legacy path has been removed — so in practice a decline is only
+// honoured for an out-of-tree parser that does not implement
+// IntegrationsV2, or for the not-registered guards at the MySQL and
+// generic sites. A V2 parser that returns this sentinel does NOT get the
+// relay-and-restore treatment above; it degrades to
+// FallthroughToPassthrough, which keeps user traffic alive but logs the
+// connection as a retired parser rather than a decline.
+//
 // On replay there is no upstream connection to relay to — every
 // destination dial in handleConnection is mode-gated — so a parser that
 // needs to decline during replay is not yet supported and must not rely

--- a/pkg/agent/proxy/integrations/mysql/mysql.go
+++ b/pkg/agent/proxy/integrations/mysql/mysql.go
@@ -172,7 +172,7 @@ func (m *MySQL) recordV2(ctx context.Context, session *integrations.RecordSessio
 	err := recorder.RecordV2(ctx, logger, session.V2)
 	if err != nil {
 		utils.LogError(logger, err, "failed to encode the mysql message into the yaml",
-			zap.String("next_step", "set KEPLOY_NEW_RELAY=off to route MySQL through the legacy record path while investigating, or KEPLOY_DISABLE_PARSING=1 / SIGUSR1 to disable parser dispatch entirely (raw passthrough); the supervisor will have already fallen through to passthrough on the affected connection so user traffic continues"),
+			zap.String("next_step", "set KEPLOY_DISABLE_PARSING=1 / SIGUSR1 to disable parser dispatch entirely (raw passthrough) while investigating; the supervisor will have already fallen through to passthrough on the affected connection so user traffic continues"),
 		)
 		return err
 	}

--- a/pkg/agent/proxy/mysql_dispatch_test.go
+++ b/pkg/agent/proxy/mysql_dispatch_test.go
@@ -82,8 +82,10 @@ func TestMySQLProbeBranchRoutesByShouldRecordViaSupervisor(t *testing.T) {
 			why: "a parser that opts out must not be handed FakeConns it cannot use",
 		},
 		{
-			name: "KEPLOY_NEW_RELAY=off forces legacy", v2: true, relayOff: "off", wantV2: false,
-			why: "the documented escape hatch must reach this dispatch site too",
+			// The rollback knob was removed. A stale KEPLOY_NEW_RELAY in the
+			// environment must not divert the probe branch back to legacy.
+			name: "the removed rollback knob no longer forces legacy", v2: true, relayOff: "off", wantV2: true,
+			why: "KEPLOY_NEW_RELAY is gone; leaving it set must be inert at this dispatch site too",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -359,4 +361,183 @@ func selfSignedForDispatch(t *testing.T) tls.Certificate {
 		t.Fatalf("createcert: %v", err)
 	}
 	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+}
+
+// TestMySQLProbeBranchHonoursTheKillSwitch pins that the record-mode parsing
+// kill switch actually disables parsing on the MySQL probe branch.
+//
+// It did not. The only gate on util.DefaultKillSwitch lives in
+// handleConnection's matched-parser section; the probe branch dispatches and
+// returns several hundred lines earlier, so KEPLOY_DISABLE_PARSING / SIGUSR1 /
+// the admin endpoint were silently inert for MySQL on its normal route —
+// probeMysql's zero-cost fast path is the port check against MysqlPorts (3306
+// and 4000 by default), so the probe branch IS the common MySQL path. An
+// operator disabled parsing, restarted, and every MySQL connection was still
+// handed to the parser.
+//
+// The observable is the parser being invoked at all: with the switch tripped it
+// must never be called, whichever surface it would otherwise have been handed.
+func TestMySQLProbeBranchHonoursTheKillSwitch(t *testing.T) {
+	for _, v2 := range []bool{true, false} {
+		name := "V2 parser"
+		if !v2 {
+			name = "legacy parser"
+		}
+		t.Run(name, func(t *testing.T) {
+			util.DefaultKillSwitch.Trip()
+			defer util.DefaultKillSwitch.Reset()
+
+			parser := &recordingMySQLParser{v2Declared: v2}
+			p := &Proxy{
+				logger:                     zap.NewNop(),
+				Integrations:               map[integrations.IntegrationType]integrations.Integrations{integrations.MYSQL: parser},
+				recordBufferCap:            8 << 20,
+				recordBufferQueueSize:      64,
+				recordBufferStallGrace:     5 * time.Second,
+				recordBufferHalfCloseGrace: 5 * time.Second,
+			}
+
+			srcRaw, destRaw, cleanup := tcpConnPair(t)
+			defer cleanup()
+			srcConn, destConn := srcRaw, destRaw
+			upgrader := util.NewConnTLSUpgrader(&srcConn, &destConn, zap.NewNop(), nil)
+
+			// globalPassThrough reads these two off the context and type-asserts
+			// them as strings, so the passthrough route panics without them.
+			// handleConnection sets both well before it reaches the probe
+			// branch, so production is safe; the test has to mirror that.
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			ctx = context.WithValue(ctx, models.ClientConnectionIDKey, "1")
+			ctx = context.WithValue(ctx, models.DestConnectionIDKey, "2")
+			errGrp, gctx := errgroup.WithContext(ctx)
+
+			// globalPassThrough copies until both sides close; closing them
+			// immediately lets it return rather than blocking the test.
+			_ = srcRaw.Close()
+			_ = destRaw.Close()
+
+			_ = p.recordMySQLOutgoing(gctx, srcConn, destConn, make(chan *models.Mock, 8), errGrp,
+				zap.NewNop(), 1, 2, models.OutgoingOptions{
+					DstCfg: &models.ConditionalDstCfg{Addr: destConn.RemoteAddr().String()},
+				}, upgrader)
+
+			if called, _, _ := parser.snapshot(); called {
+				t.Fatal("the parser was invoked with the record-mode kill switch tripped — " +
+					"KEPLOY_DISABLE_PARSING / SIGUSR1 is documented as routing to raw " +
+					"passthrough, and every next_step message now points operators at it")
+			}
+		})
+	}
+}
+
+// TestMySQLProbeKillSwitchRelaysAndHonoursHalfClose is the other half of the
+// kill-switch contract: not just "the parser was not invoked", but "the
+// connection still works".
+//
+// TestMySQLProbeBranchHonoursTheKillSwitch closes both sockets before
+// dispatching and only inspects the parser, so it cannot tell a working
+// passthrough from a dropped connection — replacing the relay with a bare
+// `return nil` keeps it green. That gap hid a real defect: the gate first
+// routed through globalPassThrough, which never calls CloseWrite and returns
+// on io.EOF, so a client doing shutdown(SHUT_WR) — the end-of-request signal
+// for every EOF-delimited exchange — had its connection torn down instead of
+// receiving the reply. relayDeclinedConn documents exactly this and uses
+// util.RelayRawPassthrough; the gate now does too.
+//
+// This matters here specifically because probeMysql's fast path admits by PORT
+// alone (MysqlPorts, 3306/4000 by default, zero content inspection), so any
+// protocol on those ports reaches this dispatch site, half-closing ones
+// included.
+func TestMySQLProbeKillSwitchRelaysAndHonoursHalfClose(t *testing.T) {
+	util.DefaultKillSwitch.Trip()
+	defer util.DefaultKillSwitch.Reset()
+
+	// An upstream that replies only AFTER it observes end-of-request. If the
+	// FIN is never forwarded, it never speaks; if the reply is not relayed
+	// back, the client never hears it. Either failure mode shows up as an
+	// empty read below.
+	up, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen upstream: %v", err)
+	}
+	defer func() { _ = up.Close() }()
+	go func() {
+		c, err := up.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = c.Close() }()
+		buf := make([]byte, 512)
+		for {
+			if _, err := c.Read(buf); err != nil {
+				break
+			}
+		}
+		_, _ = c.Write([]byte("SERVER-REPLY"))
+	}()
+
+	appLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen app: %v", err)
+	}
+	defer func() { _ = appLn.Close() }()
+	appConn, err := net.Dial("tcp", appLn.Addr().String())
+	if err != nil {
+		t.Fatalf("dial app side: %v", err)
+	}
+	defer func() { _ = appConn.Close() }()
+	srcConn, err := appLn.Accept()
+	if err != nil {
+		t.Fatalf("accept: %v", err)
+	}
+	dstConn, err := net.Dial("tcp", up.Addr().String())
+	if err != nil {
+		t.Fatalf("dial upstream: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	ctx = context.WithValue(ctx, models.ClientConnectionIDKey, "1")
+	ctx = context.WithValue(ctx, models.DestConnectionIDKey, "2")
+	errGrp, gctx := errgroup.WithContext(ctx)
+
+	parser := &recordingMySQLParser{v2Declared: true}
+	p := &Proxy{
+		logger:                     zap.NewNop(),
+		Integrations:               map[integrations.IntegrationType]integrations.Integrations{integrations.MYSQL: parser},
+		recordBufferCap:            8 << 20,
+		recordBufferQueueSize:      64,
+		recordBufferStallGrace:     5 * time.Second,
+		recordBufferHalfCloseGrace: 5 * time.Second,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = p.recordMySQLOutgoing(gctx, srcConn, dstConn, make(chan *models.Mock, 8), errGrp,
+			zap.NewNop(), 1, 2, models.OutgoingOptions{
+				DstCfg: &models.ConditionalDstCfg{Addr: dstConn.RemoteAddr().String()},
+			}, nil)
+	}()
+
+	if _, err := appConn.Write([]byte("REQUEST")); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	if err := appConn.(*net.TCPConn).CloseWrite(); err != nil {
+		t.Fatalf("half-close: %v", err)
+	}
+
+	_ = appConn.SetReadDeadline(time.Now().Add(10 * time.Second))
+	buf := make([]byte, 64)
+	n, _ := appConn.Read(buf)
+	if got := string(buf[:n]); got != "SERVER-REPLY" {
+		t.Fatalf("app half-closed its write side and read back %q, want %q — the kill "+
+			"switch must relay the connection, not end it. globalPassThrough returns on "+
+			"io.EOF without forwarding the FIN or the reply; use util.RelayRawPassthrough", got, "SERVER-REPLY")
+	}
+	if called, _, _ := parser.snapshot(); called {
+		t.Error("the parser was invoked with the kill switch tripped")
+	}
+	<-done
 }

--- a/pkg/agent/proxy/mysql_fullstack_test.go
+++ b/pkg/agent/proxy/mysql_fullstack_test.go
@@ -49,7 +49,8 @@ func TestMySQLV2_FullStackAgainstARealServer(t *testing.T) {
 		// wrapDest mirrors how handleConnection hands the destination to
 		// the dispatcher.
 		wrapDest func(net.Conn, *zap.Logger) (net.Conn, error)
-		// relayOff sets KEPLOY_NEW_RELAY, the documented escape hatch.
+		// relayOff sets the REMOVED KEPLOY_NEW_RELAY variable, to prove a
+		// stale value left in an operator's environment is inert.
 		relayOff string
 	}{
 		{
@@ -74,13 +75,13 @@ func TestMySQLV2_FullStackAgainstARealServer(t *testing.T) {
 			},
 		},
 		{
-			// The escape hatch this PR's own error message tells operators to
-			// reach for. Flipping the primary MySQL path to V2 is only safe if
-			// the documented way back still records — and nothing proved that
-			// against a real server. The dispatch test shows the parser is
-			// handed the legacy surface; this shows the legacy surface still
-			// produces mocks.
-			name:     "KEPLOY_NEW_RELAY=off still records via the legacy path",
+			// KEPLOY_NEW_RELAY was the rollback knob, and it is gone. Operators
+			// who set it once will still have it in their environment, so prove
+			// end-to-end against a real server that it no longer diverts
+			// anything: this case must record through the SAME V2 path as
+			// "bare socket", including the strict no-raw-mocks assertion that
+			// the legacy surface used to be exempt from.
+			name:     "a stale KEPLOY_NEW_RELAY=off is inert",
 			wrapDest: func(c net.Conn, _ *zap.Logger) (net.Conn, error) { return c, nil },
 			relayOff: "off",
 		},
@@ -88,13 +89,23 @@ func TestMySQLV2_FullStackAgainstARealServer(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.relayOff != "" {
 				t.Setenv("KEPLOY_NEW_RELAY", tc.relayOff)
+				// Assert the DISPATCH DECISION, not just that mocks appear.
+				// MySQL's legacy path also routes its mocks through the
+				// SyncMockManager, so every downstream assertion in
+				// runFullStackMySQL is satisfied on either surface — this case
+				// stayed green with the kill switch restored until this check
+				// was added.
+				if !shouldRecordViaSupervisor(mysqlparser.New(zap.NewNop())) {
+					t.Fatal("a stale KEPLOY_NEW_RELAY in the environment diverted MySQL off " +
+						"the supervisor path; the rollback knob was removed and must be inert")
+				}
 			}
-			runFullStackMySQL(t, tc.wrapDest, tc.relayOff != "")
+			runFullStackMySQL(t, tc.wrapDest)
 		})
 	}
 }
 
-func runFullStackMySQL(t *testing.T, wrapDest func(net.Conn, *zap.Logger) (net.Conn, error), legacy bool) {
+func runFullStackMySQL(t *testing.T, wrapDest func(net.Conn, *zap.Logger) (net.Conn, error)) {
 	addr, user, pass, dbName := mysqlTestTarget(t)
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -249,7 +260,7 @@ drain:
 	// Production does not deliver V2 parser mocks down the raw channel.
 	// If this ever fills, RouteMocksViaSyncMock has been turned off and
 	// the session-window buffering that replay depends on is bypassed.
-	if n := len(rawMocks); n != 0 && !legacy {
+	if n := len(rawMocks); n != 0 {
 		t.Errorf("%d mock(s) went down the raw Mocks channel; production routes V2 parser "+
 			"mocks through the SyncMockManager (RouteMocksViaSyncMock), and bypassing it loses "+
 			"the firstReqSeen session window at replay", n)

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -882,6 +882,7 @@ func resolveUpstreamTLSConfig(opts *config.Config) (verify bool, caCert string) 
 }
 
 func New(logger *zap.Logger, info agent.DestInfo, opts *config.Config) *Proxy {
+	warnIfRemovedRelayKnobSet(logger)
 	proxy := &Proxy{
 		logger:                    logger,
 		Port:                      opts.ProxyPort,
@@ -997,10 +998,34 @@ func New(logger *zap.Logger, info agent.DestInfo, opts *config.Config) *Proxy {
 	return proxy
 }
 
-// buildRecordSession constructs a RecordSession for a parser in record mode.
-// It wraps src/dst in SafeConn. The caller (handleConnection) is responsible
-// for creating the TLSUpgrader using pointers to its own srcConn/dstConn
-// variables, so the upgrader updates the correct references on TLS upgrade.
+// warnIfRemovedRelayKnobSet tells an operator that KEPLOY_NEW_RELAY no longer
+// does anything.
+//
+// It was the global V2 rollback: set it to off/0/false/no and every V2-capable
+// parser was forced onto the legacy record path. That knob is gone — every
+// parser the dispatcher can route to record implements IntegrationsV2, and the
+// legacy path it selected hangs EOF-delimited peers because it waits for both
+// copy directions instead of tearing the second down.
+//
+// Silence would be the dangerous outcome: someone reaches for a documented
+// rollback during an incident, sets it, restarts, sees no error, and believes
+// they have rolled back. Say so once, at startup, and name the lever that does
+// still work.
+func warnIfRemovedRelayKnobSet(logger *zap.Logger) {
+	if logger == nil {
+		return
+	}
+	v, ok := os.LookupEnv("KEPLOY_NEW_RELAY")
+	if !ok {
+		return
+	}
+	logger.Warn("KEPLOY_NEW_RELAY is set but has been REMOVED; it is ignored",
+		zap.String("value", v),
+		zap.String("impact", "no rollback is in effect — every parser records through the supervisor + relay path, which is what it would have done without this variable"),
+		zap.String("next_step", "unset KEPLOY_NEW_RELAY. To disable parsing during an incident use KEPLOY_DISABLE_PARSING=1 (or SIGUSR1 on Unix, or the admin endpoint), which routes new connections to raw passthrough"),
+	)
+}
+
 // shouldRecordViaSupervisor is the single decision for "does this parser record
 // through the supervisor + relay, or through the legacy path".
 //
@@ -1011,7 +1036,7 @@ func New(logger *zap.Logger, info agent.DestInfo, opts *config.Config) *Proxy {
 // inverted condition keeps every asserted substring and stays green.
 func shouldRecordViaSupervisor(parser integrations.Integrations) bool {
 	v2, ok := parser.(integrations.IntegrationsV2)
-	return ok && v2.IsV2() && !newRelayDisabled()
+	return ok && v2.IsV2()
 }
 
 // recordMySQLOutgoing dispatches a record-mode MySQL connection that
@@ -1050,6 +1075,37 @@ func (p *Proxy) recordMySQLOutgoing(
 	outgoingOpts models.OutgoingOptions,
 	tlsUpgrader models.TLSUpgrader,
 ) error {
+	// The record-mode parsing kill switch. The matched-parser path has its own
+	// gate far below in handleConnection, but the MySQL PROBE branch returns
+	// before ever reaching it — so without this check KEPLOY_DISABLE_PARSING /
+	// SIGUSR1 / the admin endpoint silently did NOTHING for MySQL on its normal
+	// route. probeMysql's zero-cost fast path is the port check against
+	// MysqlPorts (3306 and 4000 by default), so the probe branch IS the common
+	// MySQL path: an operator set the switch, restarted, and every MySQL
+	// connection was still parsed.
+	//
+	// Gated here rather than at the call site so it covers every caller of this
+	// dispatch function and is reachable from a test. The probe's connections
+	// are adopted unconditionally by the caller, so they already carry any
+	// bytes it consumed.
+	//
+	// util.RelayRawPassthrough, NOT globalPassThrough, for the reason
+	// relayDeclinedConn spells out below: globalPassThrough never calls
+	// CloseWrite and returns on io.EOF, so a client that does shutdown(SHUT_WR)
+	// — the end-of-request signal for every EOF-delimited exchange — has its
+	// connection torn down instead of receiving the reply. Reproduced on this
+	// exact path before the switch: the app half-closed and read back nothing.
+	// The probe's fast path admits by PORT alone (MysqlPorts, 3306/4000 by
+	// default, no content inspection), so any protocol on those ports reaches
+	// here, including half-closing ones.
+	if util.DefaultKillSwitch.Enabled() {
+		mysqlLogger.Debug("record-mode parsing kill switch tripped; relaying raw",
+			zap.String("parser", string(integrations.MYSQL)),
+			zap.String("dispatch_site", "mysql-probe"))
+		util.RelayRawPassthrough(srcConn, dstConn)
+		return nil
+	}
+
 	mysqlParser := p.Integrations[integrations.MYSQL]
 	if shouldRecordViaSupervisor(mysqlParser) {
 		if err := p.recordViaSupervisor(parserCtx, srcConn, dstConn, mysqlParser,
@@ -1059,7 +1115,7 @@ func (p *Proxy) recordMySQLOutgoing(
 				mysqlLogger.Debug("V2 record path: connection closed", zap.Error(err))
 			} else {
 				utils.LogError(mysqlLogger, err, "V2 record path failed for the MySQL probe branch",
-					zap.String("next_step", "set KEPLOY_NEW_RELAY=off to force the legacy record path for MySQL while investigating, or KEPLOY_DISABLE_PARSING=1 / SIGUSR1 to disable parser dispatch entirely (raw passthrough)"),
+					zap.String("next_step", "set KEPLOY_DISABLE_PARSING=1 / SIGUSR1 to disable parser dispatch entirely (raw passthrough) while investigating"),
 				)
 			}
 			return err
@@ -1214,6 +1270,10 @@ func relayableConn(c net.Conn) bool {
 	return true
 }
 
+// buildRecordSession constructs a RecordSession for a parser in record mode.
+// It wraps src/dst in SafeConn. The caller (handleConnection) is responsible
+// for creating the TLSUpgrader using pointers to its own srcConn/dstConn
+// variables, so the upgrader updates the correct references on TLS upgrade.
 func (p *Proxy) buildRecordSession(
 	srcConn, dstConn net.Conn,
 	mocks chan<- *models.Mock,
@@ -3040,7 +3100,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 					} else {
 						utils.LogError(logger, err, "V2 record path failed",
 							zap.String("parser", string(parserType)),
-							zap.String("next_step", "set KEPLOY_NEW_RELAY=off to force the legacy record path for this parser while investigating, or KEPLOY_DISABLE_PARSING=1 / SIGUSR1 to disable parser dispatch entirely (raw passthrough); the supervisor has already fallen through to passthrough for this connection so user traffic continues"),
+							zap.String("next_step", "set KEPLOY_DISABLE_PARSING=1 / SIGUSR1 to disable parser dispatch entirely (raw passthrough) while investigating; the supervisor has already fallen through to passthrough for this connection so user traffic continues"),
 						)
 					}
 					return err
@@ -3099,46 +3159,112 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 	if generic {
 		logger.Debug("The external dependency is not supported. Hence using generic parser")
 		if rule.Mode == models.MODE_RECORD {
-			genericParser := p.Integrations[integrations.GENERIC]
-			// Route through the supervisor exactly like the matched-parser path
-			// above. This branch previously called RecordOutgoing directly with
-			// NO IsV2 gate, so every connection that matched no parser recorded
-			// through generic's LEGACY path — on the default configuration, with
-			// no flag set. Generic has declared IsV2() == true all along; nothing
-			// consulted it here, so the migration silently skipped the widest
-			// code path in the proxy.
-			if shouldRecordViaSupervisor(genericParser) {
-				if err := p.recordViaSupervisor(parserCtx, srcConn, dstConn, genericParser, integrations.GENERIC, rule.MC, parserErrGrp, logger, clientConnID, destConnID, outgoingOpts); err != nil {
-					if isNetworkClosedErr(err) {
-						logger.Debug("V2 generic record path: connection closed", zap.Error(err))
-					} else {
-						utils.LogError(logger, err, "V2 generic record path failed",
-							zap.String("next_step", "set KEPLOY_NEW_RELAY=off to force the legacy record path while investigating, or KEPLOY_DISABLE_PARSING=1 / SIGUSR1 to disable parser dispatch entirely (raw passthrough); the supervisor has already fallen through to passthrough for this connection so user traffic continues"),
-						)
-					}
-					return err
-				}
-				logger.Debug("V2 generic record path returned")
-			} else {
-				genericSession := p.buildRecordSession(srcConn, dstConn, rule.MC, parserErrGrp, logger, clientConnID, destConnID, outgoingOpts, nil)
-				err := genericParser.RecordOutgoing(parserCtx, genericSession)
-				if errors.Is(err, integrations.ErrParserDeclined) {
-					return p.relayDeclinedConn(parserCtx, err, logger, integrations.GENERIC, genericSession)
-				}
-				if err != nil && err != io.EOF && !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), "tls: user canceled") {
-					utils.LogError(logger, err, "failed to record the outgoing message")
-					return err
-				}
-			}
-		} else {
-			err := p.Integrations[integrations.GENERIC].MockOutgoing(parserCtx, srcConn, dstCfg, p.scopedFor(outgoingOpts.SrcPid, m), outgoingOpts)
-			if err != nil && err != io.EOF && !errors.Is(err, context.Canceled) && !isNetworkClosedErr(err) {
-				utils.LogError(logger, err, "failed to mock the outgoing message")
-				// Send specific error type to error channel for external monitoring
-				p.sendMockNotFoundError(err)
-				return err
-			}
+			return p.recordGenericOutgoing(parserCtx, srcConn, dstConn, rule.MC,
+				parserErrGrp, logger, clientConnID, destConnID, outgoingOpts)
 		}
+		return p.mockGenericOutgoing(parserCtx, srcConn, dstCfg, m, outgoingOpts, logger)
+	}
+	return nil
+}
+
+// recordGenericOutgoing dispatches a record-mode connection that matched no
+// specific parser to the GENERIC catch-all.
+//
+// It is a function rather than an inlined block for the same reason
+// recordMySQLOutgoing is: inlined, the dispatch decision sat deep inside
+// handleConnection behind an eBPF-resolved destination, so no test could reach
+// it — deleting the unregistered-parser guard below left the whole proxy suite
+// green.
+func (p *Proxy) recordGenericOutgoing(
+	parserCtx context.Context,
+	srcConn, dstConn net.Conn,
+	mocks chan<- *models.Mock,
+	parserErrGrp *errgroup.Group,
+	logger *zap.Logger,
+	clientConnID, destConnID int64,
+	outgoingOpts models.OutgoingOptions,
+) error {
+	genericParser := p.Integrations[integrations.GENERIC]
+	// Route through the supervisor exactly like the matched-parser path. This
+	// branch previously called RecordOutgoing directly with NO IsV2 gate, so
+	// every connection that matched no parser recorded through generic's LEGACY
+	// path — on the default configuration, with no flag set. Generic has
+	// declared IsV2() == true all along; nothing consulted it here, so the
+	// migration silently skipped the widest code path in the proxy.
+	if shouldRecordViaSupervisor(genericParser) {
+		if err := p.recordViaSupervisor(parserCtx, srcConn, dstConn, genericParser, integrations.GENERIC, mocks, parserErrGrp, logger, clientConnID, destConnID, outgoingOpts); err != nil {
+			if isNetworkClosedErr(err) {
+				logger.Debug("V2 generic record path: connection closed", zap.Error(err))
+			} else {
+				utils.LogError(logger, err, "V2 generic record path failed",
+					zap.String("next_step", "set KEPLOY_DISABLE_PARSING=1 / SIGUSR1 to disable parser dispatch entirely (raw passthrough) while investigating; the supervisor has already fallen through to passthrough for this connection so user traffic continues"),
+				)
+			}
+			return err
+		}
+		logger.Debug("V2 generic record path returned")
+		return nil
+	}
+
+	// Generic.IsV2() is unconditionally true, so reaching here means the GENERIC
+	// parser is not registered at all — and the legacy call below would nil-panic
+	// on the interface. The MySQL dispatch site guards the same case; this one
+	// did not, and with the KEPLOY_NEW_RELAY rollback removed an unregistered
+	// build is the ONLY way to get here, so the branch's sole remaining
+	// reachable state was a crash.
+	//
+	// Treat it as a decline, not a failure: relay the connection rather than
+	// letting the caller's deferred close drop it.
+	if genericParser == nil {
+		declined := fmt.Errorf("no generic parser is registered: %w", integrations.ErrParserDeclined)
+		return p.relayDeclinedConn(parserCtx, declined, logger, integrations.GENERIC,
+			p.buildRecordSession(srcConn, dstConn, mocks, parserErrGrp, logger, clientConnID, destConnID, outgoingOpts, nil))
+	}
+
+	genericSession := p.buildRecordSession(srcConn, dstConn, mocks, parserErrGrp, logger, clientConnID, destConnID, outgoingOpts, nil)
+	err := genericParser.RecordOutgoing(parserCtx, genericSession)
+	if errors.Is(err, integrations.ErrParserDeclined) {
+		return p.relayDeclinedConn(parserCtx, err, logger, integrations.GENERIC, genericSession)
+	}
+	if err != nil && err != io.EOF && !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), "tls: user canceled") {
+		utils.LogError(logger, err, "failed to record the outgoing message")
+		return err
+	}
+	return nil
+}
+
+// mockGenericOutgoing serves a replay-mode connection that matched no specific
+// parser from the GENERIC catch-all.
+//
+// Extracted for the same reason as recordGenericOutgoing: inlined in
+// handleConnection, the unregistered-parser guard below was unreachable from a
+// test and deleting it left the whole suite green.
+func (p *Proxy) mockGenericOutgoing(
+	parserCtx context.Context,
+	srcConn net.Conn,
+	dstCfg *models.ConditionalDstCfg,
+	m integrations.MockMemDb,
+	outgoingOpts models.OutgoingOptions,
+	logger *zap.Logger,
+) error {
+	genericParser := p.Integrations[integrations.GENERIC]
+	if genericParser == nil {
+		// Same unregistered-build case the record half guards; without it the
+		// map lookup nil-derefs. There is no upstream connection to relay to on
+		// the replay path (every destination dial in handleConnection is
+		// mode-gated), so report rather than relay — which is what the MySQL
+		// replay site does too.
+		err := errors.New("no generic parser is registered to mock this connection")
+		utils.LogError(logger, err, "failed to mock the outgoing message")
+		p.sendMockNotFoundError(err)
+		return err
+	}
+	err := genericParser.MockOutgoing(parserCtx, srcConn, dstCfg, p.scopedFor(outgoingOpts.SrcPid, m), outgoingOpts)
+	if err != nil && err != io.EOF && !errors.Is(err, context.Canceled) && !isNetworkClosedErr(err) {
+		utils.LogError(logger, err, "failed to mock the outgoing message")
+		// Send specific error type to error channel for external monitoring
+		p.sendMockNotFoundError(err)
+		return err
 	}
 	return nil
 }

--- a/pkg/agent/proxy/proxy_v2.go
+++ b/pkg/agent/proxy/proxy_v2.go
@@ -7,8 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"os"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -97,15 +95,6 @@ func trackOrphanWhileActive(stop <-chan struct{}, sess orphanWindowOpener, lastF
 			}
 		}
 	}
-}
-
-// newRelayDisabled reports whether the new supervisor+relay architecture
-// is disabled via environment. Set KEPLOY_NEW_RELAY to 0/false/off/no to
-// force the legacy path even for parsers that implement IntegrationsV2.
-// Any other value (or unset) enables the new path.
-func newRelayDisabled() bool {
-	v := strings.ToLower(strings.TrimSpace(os.Getenv("KEPLOY_NEW_RELAY")))
-	return v == "0" || v == "false" || v == "off" || v == "no"
 }
 
 // recordViaSupervisor runs a V2-capable parser's RecordOutgoing inside
@@ -438,7 +427,7 @@ func (p *Proxy) recordViaSupervisor(
 				zap.String("parser", string(parserType)),
 				zap.String("status", result.Status.String()),
 				zap.String("clientConnID", svSess.ClientConnID),
-				zap.String("next_step", "user traffic is unaffected — the relay keeps forwarding raw bytes — but no further mock can be captured on this connection, so tests recorded against it are dropped rather than shipped unreplayable. Re-run with --debug for the underlying error. If this repeats, set KEPLOY_NEW_RELAY=off to force the legacy path for this parser, or KEPLOY_DISABLE_PARSING=1 to disable record parsing entirely"),
+				zap.String("next_step", "user traffic is unaffected — the relay keeps forwarding raw bytes — but no further mock can be captured on this connection, so tests recorded against it are dropped rather than shipped unreplayable. Re-run with --debug for the underlying error. If this repeats, set KEPLOY_DISABLE_PARSING=1 to disable record parsing entirely (raw passthrough)"),
 			)
 		}
 		logger.Debug("parser supervisor triggered passthrough fallback; relay continues raw forwarding until peer close",

--- a/pkg/agent/proxy/relay/directive_proc.go
+++ b/pkg/agent/proxy/relay/directive_proc.go
@@ -571,7 +571,7 @@ func (r *Relay) handleUpgradeTLS(ctx context.Context, stopping <-chan struct{}, 
 				log.Debug("relay: dest-side TLS upgrade failed",
 					zap.Error(err),
 					zap.String("directive_reason", d.Reason),
-					zap.String("next_step", "if the upstream uses a self-signed or private-CA cert, either turn on record.upstreamTls.verify with record.upstreamTls.caCert pointing at its CA PEM (resolved on the agent's filesystem), or leave verification off — the default — and run with KEPLOY_NEW_RELAY=off to fall back to the legacy parser path"),
+					zap.String("next_step", "if the upstream uses a self-signed or private-CA cert, either turn on record.upstreamTls.verify with record.upstreamTls.caCert pointing at its CA PEM (resolved on the agent's filesystem), or leave verification off — the default"),
 				)
 			}
 			// If the client side was upgraded first (Config.ClientTLSFirst),

--- a/pkg/agent/proxy/relay/doc.go
+++ b/pkg/agent/proxy/relay/doc.go
@@ -36,14 +36,16 @@
 // This package is wired into the record path via the V2 dispatcher
 // (see ../proxy_v2.go::recordViaSupervisor). V2-capable parsers
 // (those implementing integrations.IntegrationsV2 with IsV2()==true)
-// run inside a supervisor attached to a Relay; legacy parsers
-// continue on the pre-V2 path unchanged. The KEPLOY_NEW_RELAY=off
-// env var forces legacy routing for all parsers as a rollback knob.
+// run inside a supervisor attached to a Relay. Every parser that the
+// dispatcher can route to record is V2, so this is the only record path
+// in practice; the pre-V2 branch survives solely for a parser that does
+// not implement IntegrationsV2 (today: none on the record path).
 //
-// Note that the legacy path handles half-close differently rather than
-// identically: it waits for both directions instead of tearing the
-// second down, so it does not LOSE the reply — but it never forwards
-// the FIN either, so an EOF-delimited peer never learns the request
-// ended and the connection hangs until external teardown. Rolling back
-// to it trades one half-close defect for another.
+// There is no longer an env knob that forces legacy routing — the
+// KEPLOY_NEW_RELAY rollback switch has been removed. That matters because
+// rolling back was never a clean escape: the legacy path waits for both
+// directions instead of tearing the second down, so it does not LOSE the
+// reply, but it never forwards the FIN either, so an EOF-delimited peer
+// never learns the request ended and the connection hangs until external
+// teardown. It traded one half-close defect for another.
 package relay

--- a/pkg/agent/proxy/relay/half_close_test.go
+++ b/pkg/agent/proxy/relay/half_close_test.go
@@ -186,9 +186,9 @@ func TestHalfClose_GraceBoundsASilentPeer(t *testing.T) {
 //
 // Operators reach it as record.recordBuffer.halfCloseGrace in keploy.yml
 // or the hidden --half-close-grace flag, so turning it off in the field
-// needs no new build — and specifically does not need
-// KEPLOY_NEW_RELAY=off, which routes to the legacy path where a
-// half-closing client hangs instead.
+// needs no new build. There is no longer an env knob that would route to
+// the legacy path instead (KEPLOY_NEW_RELAY has been removed), and that
+// path hung a half-closing client anyway.
 func TestHalfClose_NegativeGraceOptsOut(t *testing.T) {
 	h := newHalfCloseHarness(t, Config{HalfCloseGrace: -1})
 

--- a/pkg/agent/proxy/supervisor/supervisor.go
+++ b/pkg/agent/proxy/supervisor/supervisor.go
@@ -275,7 +275,7 @@ func (s *Supervisor) Run(ctx context.Context, fn ParserFunc, sess *Session) Resu
 		// to tune behaviour have explicit knobs (see next_step).
 		s.cfg.Logger.Debug("parser hang detected; aborting",
 			zap.Duration("hang_budget", s.cfg.HangBudget),
-			zap.String("next_step", "raise supervisor.Config.HangBudget for slow-but-legitimate workloads (long LLM replies, pg_sleep), or set KEPLOY_NEW_RELAY=off to force the legacy parser path"),
+			zap.String("next_step", "raise supervisor.Config.HangBudget for slow-but-legitimate workloads (long LLM replies, pg_sleep), or set KEPLOY_DISABLE_PARSING=1 / SIGUSR1 to disable parser dispatch entirely (raw passthrough)"),
 		)
 		s.fireOnAbort()
 		runCancel()
@@ -339,7 +339,7 @@ func (s *Supervisor) classifyReturn(outerCtx context.Context, panicked bool, pan
 		s.cfg.Logger.Error("parser panicked",
 			zap.Any("panic", panicVal),
 			zap.ByteString("stack", stack),
-			zap.String("next_step", "the supervisor is falling through to raw passthrough so user traffic continues unaffected; file the panic with the parser owner using the captured stack, and set KEPLOY_NEW_RELAY=off to force the legacy path for this parser, or KEPLOY_DISABLE_PARSING=1 / SIGUSR1 to disable parser dispatch entirely until the root cause is fixed"),
+			zap.String("next_step", "the supervisor is falling through to raw passthrough so user traffic continues unaffected; file the panic with the parser owner using the captured stack, and set KEPLOY_DISABLE_PARSING=1 / SIGUSR1 to disable parser dispatch entirely until the root cause is fixed"),
 		)
 		s.reportPanic(panicVal, stack)
 		s.fireOnAbort()

--- a/pkg/agent/proxy/util/util.go
+++ b/pkg/agent/proxy/util/util.go
@@ -964,7 +964,7 @@ func RecoverWithoutClose(logger *zap.Logger) {
 	if r := recover(); r != nil {
 		logger.Error("Recovered from panic in parser",
 			zap.Any("panic", r),
-			zap.String("next_step", "the supervisor (if wrapping this call) will fall through to raw passthrough so user traffic continues; file the panic with the parser owner using the Sentry issue that was just captured, or set KEPLOY_NEW_RELAY=off to force the legacy path for this parser until the root cause is fixed"),
+			zap.String("next_step", "the supervisor (if wrapping this call) will fall through to raw passthrough so user traffic continues; file the panic with the parser owner using the Sentry issue that was just captured, or set KEPLOY_DISABLE_PARSING=1 / SIGUSR1 to disable parser dispatch entirely until the root cause is fixed"),
 		)
 		utils.HandleRecovery(logger, r, "Recovered from panic")
 		// Flush only on the panic path so the happy path (defer


### PR DESCRIPTION
`KEPLOY_NEW_RELAY` forced V2-capable parsers back onto the legacy record path as a global rollback. Every parser the dispatcher can route to record now implements `IntegrationsV2` — OSS http/mysql/generic, keploy/integrations mongo-v2 + http2 + postgres-v3, and enterprise's ten — so the switch only selected a path whose half-close handling **hangs EOF-delimited peers**: it waits for both copy directions instead of tearing the second down, so it never forwards the FIN and the peer never learns the request ended. Rolling back traded one half-close defect for another.

`newRelayDisabled` is deleted; `shouldRecordViaSupervisor` is now `ok && v2.IsV2()`.

The legacy dispatch **branch** stays. It is the only home of `ErrParserDeclined` handling, whose sole producer (grpcV2) is non-V2 and replay-only, and an out-of-tree parser may still not implement `IntegrationsV2`. Its doc now states the in-tree sites are unreachable instead of implying otherwise.

Removing a documented incident lever *silently* is the real hazard, so `New()` warns once when `KEPLOY_NEW_RELAY` is present and names the switch that still works. `pkg/agent/proxy/README.md` and `docs/contributing/parser-migration-guide.md` both listed it under **Rollout knobs**; they now record it as removed. Twelve `next_step` strings pointing operators at it were rewritten.

## Three defects this surfaced, fixed here

**1. `KEPLOY_DISABLE_PARSING` never applied to MySQL.** `util.DefaultKillSwitch` was consulted at exactly one site, and the MySQL probe branch returns several hundred lines earlier. `probeMysql`'s fast path admits by **port alone** (`MysqlPorts`, 3306/4000 by default, zero content inspection), so the probe branch is MySQL's *common* route — an operator disabled parsing, restarted, and every MySQL connection was still parsed. Now gated inside `recordMySQLOutgoing`, where a test can reach it.

**2. That gate must not use `globalPassThrough`.** It never calls `CloseWrite` and returns on `io.EOF`, so a client doing `shutdown(SHUT_WR)` — the end-of-request signal for every EOF-delimited exchange — has its connection torn down instead of receiving the reply. Reproduced on this path: the app half-closed and read back nothing; with `util.RelayRawPassthrough` it reads `SERVER-REPLY`. `relayDeclinedConn` documents this exact rule 95 lines below and already uses the safe primitive.

**3. The generic catch-all could only crash.** `Generic.IsV2()` is unconditionally true, so with the rollback gone an unregistered `GENERIC` was the *sole* way into its legacy branch — where the call nil-derefs. Guarded on both modes (record relays a decline, replay reports a miss, matching the MySQL sites), and both halves extracted to `recordGenericOutgoing` / `mockGenericOutgoing` so the guards are reachable from a test — exactly the reasoning that produced `recordMySQLOutgoing`.

## Verification

Six mutants, each killed by a named test:

| mutation | caught by |
|---|---|
| restore the `KEPLOY_NEW_RELAY` kill switch | `ShouldRecordViaSupervisor`, `MySQLProbeBranchRoutesByShouldRecordViaSupervisor` |
| swap the MySQL gate back to `globalPassThrough` | `MySQLProbeKillSwitchRelaysAndHonoursHalfClose` |
| delete the MySQL kill-switch gate | `MySQLProbeBranchHonoursTheKillSwitch`, `…RelaysAndHonoursHalfClose` |
| delete the generic record nil guard | `RecordGenericOutgoing_UnregisteredParserDeclinesInsteadOfPanicking` |
| delete the generic replay nil guard | `MockGenericOutgoing_UnregisteredParserReportsInsteadOfPanicking` |
| delete the startup warning wiring | `NewWarnsAboutTheRemovedRelayKnob` |

Three existing tests were **inverted** rather than deleted — they now assert a stale `KEPLOY_NEW_RELAY` is inert instead of that it forces legacy, including the full-stack MySQL run against a real server (which now also runs the stricter no-raw-mocks assertion the legacy surface was exempt from).

`go build ./...`, `go vet ./...`, `go test ./...` — 65 packages ok, 0 failures.