### PR TITLE
fix(cli): propagate errors from utility commands to exit non-zero on failure

### DIFF
--- a/cli/diff.go
+++ b/cli/diff.go
@@ -49,18 +49,18 @@ func Diff(ctx context.Context, logger *zap.Logger, _ *config.Config, serviceFact
 			svc, err := serviceFactory.GetService(ctx, cmd.Name())
 			if err != nil {
 				utils.LogError(logger, err, "failed to get service", zap.String("command", cmd.Name()))
-				return nil
+				return err
 			}
 			var diffService diffSvc.Service
 			var ok bool
 			if diffService, ok = svc.(diffSvc.Service); !ok {
 				utils.LogError(logger, nil, "service doesn't satisfy diff service interface")
-				return nil
+				return fmt.Errorf("service doesn't satisfy diff service interface")
 			}
 
 			if err := diffService.Compare(ctx, run1, run2, testSets); err != nil {
 				utils.LogError(logger, err, "failed to compare test runs")
-				return nil
+				return err
 			}
 			return nil
 		},

--- a/cli/export.go
+++ b/cli/export.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -38,17 +39,18 @@ func Export(ctx context.Context, logger *zap.Logger, _ *config.Config, serviceFa
 			svc, err := serviceFactory.GetService(ctx, "export")
 			if err != nil {
 				utils.LogError(logger, err, "failed to get service", zap.String("command", cmd.Name()))
-				return nil
+				return err
 			}
 			var tools toolsSvc.Service
 			var ok bool
 			if tools, ok = svc.(toolsSvc.Service); !ok {
 				utils.LogError(logger, nil, "service doesn't satisfy tools service interface")
-				return nil
+				return fmt.Errorf("service doesn't satisfy tools service interface")
 			}
 			err = tools.Export(ctx) // Assuming ExportPostmanCollection is a method in tools service
 			if err != nil {
 				utils.LogError(logger, err, "failed to export Postman collection")
+				return err
 			}
 			return nil
 		},

--- a/cli/import.go
+++ b/cli/import.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -44,17 +45,18 @@ func Import(ctx context.Context, logger *zap.Logger, _ *config.Config, serviceFa
 			svc, err := serviceFactory.GetService(ctx, "import")
 			if err != nil {
 				utils.LogError(logger, err, "failed to get service", zap.String("command", cmd.Name()))
-				return nil
+				return err
 			}
 			var tools toolsSvc.Service
 			var ok bool
 			if tools, ok = svc.(toolsSvc.Service); !ok {
 				utils.LogError(logger, nil, "service doesn't satisfy tools service interface")
-				return nil
+				return fmt.Errorf("service doesn't satisfy tools service interface")
 			}
 			err = tools.Import(ctx, path, basePath)
 			if err != nil {
 				utils.LogError(logger, err, "failed to import Postman collection")
+				return err
 			}
 			return nil
 		},

--- a/cli/normalise.go
+++ b/cli/normalise.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 	"go.keploy.io/server/v3/config"
@@ -27,17 +28,17 @@ func Normalize(ctx context.Context, logger *zap.Logger, _ *config.Config, servic
 			svc, err := serviceFactory.GetService(ctx, cmd.Name())
 			if err != nil {
 				utils.LogError(logger, err, "failed to get service", zap.String("command", cmd.Name()))
-				return nil
+				return err
 			}
 			var tools toolsSvc.Service
 			var ok bool
 			if tools, ok = svc.(toolsSvc.Service); !ok {
 				utils.LogError(logger, nil, "service doesn't satisfy tools service interface")
-				return nil
+				return fmt.Errorf("service doesn't satisfy tools service interface")
 			}
 			if err := tools.Normalize(ctx); err != nil {
 				utils.LogError(logger, err, "failed to normalize test cases")
-				return nil
+				return err
 			}
 			return nil
 		},

--- a/cli/sanitize.go
+++ b/cli/sanitize.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 	"go.keploy.io/server/v3/config"
@@ -26,19 +27,19 @@ func Sanitize(ctx context.Context, logger *zap.Logger, _ *config.Config, service
 			svc, err := serviceFactory.GetService(ctx, cmd.Name())
 			if err != nil {
 				utils.LogError(logger, err, "failed to get service", zap.String("command", cmd.Name()))
-				return nil
+				return err
 			}
 			var sanitizeService toolsSvc.Service
 			var ok bool
 			if sanitizeService, ok = svc.(toolsSvc.Service); !ok {
 				utils.LogError(logger, nil, "service doesn't satisfy tools service interface")
-				return nil
+				return fmt.Errorf("service doesn't satisfy tools service interface")
 			}
 
 			err = sanitizeService.Sanitize(ctx)
 			if err != nil {
 				utils.LogError(logger, err, "failed to sanitize test cases")
-				return nil
+				return err
 			}
 
 			return nil

--- a/cli/templatize.go
+++ b/cli/templatize.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 	"go.keploy.io/server/v3/config"
@@ -27,17 +28,17 @@ func Templatize(ctx context.Context, logger *zap.Logger, _ *config.Config, servi
 			svc, err := serviceFactory.GetService(ctx, cmd.Name())
 			if err != nil {
 				utils.LogError(logger, err, "failed to get service", zap.String("command", cmd.Name()))
-				return nil
+				return err
 			}
 			var tools toolsSvc.Service
 			var ok bool
 			if tools, ok = svc.(toolsSvc.Service); !ok {
 				utils.LogError(logger, nil, "service doesn't satisfy tools service interface")
-				return nil
+				return fmt.Errorf("service doesn't satisfy tools service interface")
 			}
 			if err := tools.Templatize(ctx); err != nil {
 				utils.LogError(logger, err, "failed to templatize test cases")
-				return nil
+				return err
 			}
 			return nil
 		},

--- a/cli/tools_commands_test.go
+++ b/cli/tools_commands_test.go
@@ -1,0 +1,102 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"go.keploy.io/server/v3/config"
+	"go.uber.org/zap"
+)
+
+type mockFaultyServiceFactory struct {
+	err error
+}
+
+func (m *mockFaultyServiceFactory) GetService(ctx context.Context, name string) (interface{}, error) {
+	return nil, m.err
+}
+
+type dummyConfigurator struct{}
+
+func (d *dummyConfigurator) Validate(ctx context.Context, cmd *cobra.Command) error {
+	return nil
+}
+
+func (d *dummyConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Command) error {
+	return nil
+}
+
+func (d *dummyConfigurator) AddFlags(cmd *cobra.Command) error {
+	return nil
+}
+
+func TestToolsCommandsReturnErrorOnFailure(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+	conf := &config.Config{}
+	expectedErr := errors.New("service initialization failed")
+	factory := &mockFaultyServiceFactory{err: expectedErr}
+	configurator := &dummyConfigurator{}
+
+	t.Run("sanitize command error propagation", func(t *testing.T) {
+		cmd := Sanitize(ctx, logger, conf, factory, configurator)
+		err := cmd.RunE(cmd, []string{})
+		if err == nil {
+			t.Fatal("expected error from sanitize command RunE, got nil")
+		}
+	})
+
+	t.Run("normalize command error propagation", func(t *testing.T) {
+		cmd := Normalize(ctx, logger, conf, factory, configurator)
+		err := cmd.RunE(cmd, []string{})
+		if err == nil {
+			t.Fatal("expected error from normalize command RunE, got nil")
+		}
+	})
+
+	t.Run("templatize command error propagation", func(t *testing.T) {
+		cmd := Templatize(ctx, logger, conf, factory, configurator)
+		err := cmd.RunE(cmd, []string{})
+		if err == nil {
+			t.Fatal("expected error from templatize command RunE, got nil")
+		}
+	})
+
+	t.Run("export postman command error propagation", func(t *testing.T) {
+		cmd := Export(ctx, logger, conf, factory, configurator)
+		var postmanSubCmd *cobra.Command
+		for _, c := range cmd.Commands() {
+			if c.Name() == "postman" {
+				postmanSubCmd = c
+				break
+			}
+		}
+		if postmanSubCmd == nil {
+			t.Fatal("postman subcommand not found on export")
+		}
+		err := postmanSubCmd.RunE(postmanSubCmd, []string{})
+		if err == nil {
+			t.Fatal("expected error from export postman command RunE, got nil")
+		}
+	})
+
+	t.Run("import postman command error propagation", func(t *testing.T) {
+		cmd := Import(ctx, logger, conf, factory, configurator)
+		var postmanSubCmd *cobra.Command
+		for _, c := range cmd.Commands() {
+			if c.Name() == "postman" {
+				postmanSubCmd = c
+				break
+			}
+		}
+		if postmanSubCmd == nil {
+			t.Fatal("postman subcommand not found on import")
+		}
+		err := postmanSubCmd.RunE(postmanSubCmd, []string{})
+		if err == nil {
+			t.Fatal("expected error from import postman command RunE, got nil")
+		}
+	})
+}

--- a/cli/tools_commands_test.go
+++ b/cli/tools_commands_test.go
@@ -29,6 +29,7 @@ func (d *dummyConfigurator) ValidateFlags(ctx context.Context, cmd *cobra.Comman
 }
 
 func (d *dummyConfigurator) AddFlags(cmd *cobra.Command) error {
+	cmd.Flags().StringSlice("test-sets", nil, "")
 	return nil
 }
 
@@ -43,24 +44,24 @@ func TestToolsCommandsReturnErrorOnFailure(t *testing.T) {
 	t.Run("sanitize command error propagation", func(t *testing.T) {
 		cmd := Sanitize(ctx, logger, conf, factory, configurator)
 		err := cmd.RunE(cmd, []string{})
-		if err == nil {
-			t.Fatal("expected error from sanitize command RunE, got nil")
+		if !errors.Is(err, expectedErr) {
+			t.Fatalf("expected %q from sanitize command RunE, got %v", expectedErr, err)
 		}
 	})
 
 	t.Run("normalize command error propagation", func(t *testing.T) {
 		cmd := Normalize(ctx, logger, conf, factory, configurator)
 		err := cmd.RunE(cmd, []string{})
-		if err == nil {
-			t.Fatal("expected error from normalize command RunE, got nil")
+		if !errors.Is(err, expectedErr) {
+			t.Fatalf("expected %q from normalize command RunE, got %v", expectedErr, err)
 		}
 	})
 
 	t.Run("templatize command error propagation", func(t *testing.T) {
 		cmd := Templatize(ctx, logger, conf, factory, configurator)
 		err := cmd.RunE(cmd, []string{})
-		if err == nil {
-			t.Fatal("expected error from templatize command RunE, got nil")
+		if !errors.Is(err, expectedErr) {
+			t.Fatalf("expected %q from templatize command RunE, got %v", expectedErr, err)
 		}
 	})
 
@@ -77,8 +78,8 @@ func TestToolsCommandsReturnErrorOnFailure(t *testing.T) {
 			t.Fatal("postman subcommand not found on export")
 		}
 		err := postmanSubCmd.RunE(postmanSubCmd, []string{})
-		if err == nil {
-			t.Fatal("expected error from export postman command RunE, got nil")
+		if !errors.Is(err, expectedErr) {
+			t.Fatalf("expected %q from export postman command RunE, got %v", expectedErr, err)
 		}
 	})
 
@@ -95,17 +96,16 @@ func TestToolsCommandsReturnErrorOnFailure(t *testing.T) {
 			t.Fatal("postman subcommand not found on import")
 		}
 		err := postmanSubCmd.RunE(postmanSubCmd, []string{})
-		if err == nil {
-			t.Fatal("expected error from import postman command RunE, got nil")
+		if !errors.Is(err, expectedErr) {
+			t.Fatalf("expected %q from import postman command RunE, got %v", expectedErr, err)
 		}
 	})
 
 	t.Run("diff command error propagation", func(t *testing.T) {
 		cmd := Diff(ctx, logger, conf, factory, configurator)
 		err := cmd.RunE(cmd, []string{"run1", "run2"})
-		if err == nil {
-			t.Fatal("expected error from diff command RunE, got nil")
+		if !errors.Is(err, expectedErr) {
+			t.Fatalf("expected %q from diff command RunE, got %v", expectedErr, err)
 		}
 	})
 }
-

--- a/cli/tools_commands_test.go
+++ b/cli/tools_commands_test.go
@@ -99,4 +99,13 @@ func TestToolsCommandsReturnErrorOnFailure(t *testing.T) {
 			t.Fatal("expected error from import postman command RunE, got nil")
 		}
 	})
+
+	t.Run("diff command error propagation", func(t *testing.T) {
+		cmd := Diff(ctx, logger, conf, factory, configurator)
+		err := cmd.RunE(cmd, []string{"run1", "run2"})
+		if err == nil {
+			t.Fatal("expected error from diff command RunE, got nil")
+		}
+	})
 }
+


### PR DESCRIPTION
### Summary
This PR fixes error propagation across Keploy CLI utility commands (Fixes #4531).

Previously, commands such as `sanitize`, `normalize`, `templatize`, `export` (and `export postman`), `import` (and `import postman`), and `diff` logged execution errors using `utils.LogError()` but always returned `nil` from Cobra's `RunE`. Because `RunE` returned `nil`, Cobra reported a successful execution and `main()` exited with exit code 0 (`utils.ErrCode` remained 0). This caused CI/CD pipelines and automated scripts to silently treat failed command runs as successes.

With this change:
- All CLI utility commands propagate returned errors directly from `RunE` if service resolution, interface casting, or command execution fails.
- Cobra captures the non-nil error and propagates it to `main()`, causing `keploy` to exit with a non-zero exit code on failure.

### Changes
- **`cli/sanitize.go`**: Propagate error on service resolution failure, interface mismatch, or sanitize execution error.
- **`cli/normalise.go`**: Propagate error on service resolution failure, interface mismatch, or normalize execution error.
- **`cli/templatize.go`**: Propagate error on service resolution failure, interface mismatch, or templatize execution error.
- **`cli/export.go`**: Propagate error on export service retrieval and execution failure.
- **`cli/import.go`**: Propagate error on import service retrieval and execution failure.
- **`cli/diff.go`**: Propagate error on diff service retrieval and execution failure.
- **`cli/tools_commands_test.go`**: Added comprehensive unit test suite `TestToolsCommandsReturnErrorOnFailure` covering error propagation across all utility commands.

### Verification
- Added table-driven unit tests verifying that all utility commands return non-nil errors when service execution fails.
