### PR TITLE
fix(agent): recover from a stalled agent bring-up instead of failing the run

### DIFF
--- a/pkg/models/instrument.go
+++ b/pkg/models/instrument.go
@@ -346,6 +346,12 @@ type SetupOptions struct {
 	// environment variables to disk. When non-nil, SetupCompose uses this content
 	// directly instead of reading from a file path extracted from the command.
 	InMemoryCompose []byte
+	// AgentReadyTimeout, when > 0, overrides pkg.AgentReadyTimeout() for this
+	// bring-up. A retry after a stalled agent sets a shorter window than the
+	// generous first-attempt slow-start budget: a fresh agent reports healthy in
+	// a second or two, so a wedged retry should be cut short rather than re-wait
+	// minutes.
+	AgentReadyTimeout time.Duration
 }
 
 type RunOptions struct {

--- a/pkg/platform/http/agent.go
+++ b/pkg/platform/http/agent.go
@@ -1323,6 +1323,28 @@ func (a *AgentClient) stopAgent() {
 	}
 }
 
+// logAgentContainerDiagnostics dumps the agent container's own logs and state
+// when it never became ready. Without it a readiness timeout is a black box:
+// the CLI prints the whole wait window of silence and then a generic error,
+// with no way to tell a docker-run/container-start stall from an in-agent hang
+// (eBPF load, OOM, panic). Best-effort and bounded — never blocks teardown.
+func (a *AgentClient) logAgentContainerDiagnostics(container string) {
+	if strings.TrimSpace(container) == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	logs, _ := exec.CommandContext(ctx, "docker", "logs", "--tail", "200", container).CombinedOutput()
+	state, _ := exec.CommandContext(ctx, "docker", "inspect", "-f",
+		"status={{.State.Status}} exitCode={{.State.ExitCode}} oomKilled={{.State.OOMKilled}} error={{.State.Error}}",
+		container).CombinedOutput()
+	a.logger.Warn("keploy-agent did not become ready; captured agent container diagnostics",
+		zap.String("container", container),
+		zap.String("state", strings.TrimSpace(string(state))),
+		zap.String("agent_logs", strings.TrimSpace(string(logs))))
+}
+
 // monitorAgent monitors the agent process and handles cleanup
 func (a *AgentClient) monitorAgent(clientCtx context.Context, agentCtx context.Context) {
 	select {
@@ -1434,7 +1456,11 @@ func (a *AgentClient) Setup(ctx context.Context, cmd string, opts models.SetupOp
 		// well over a minute just to start (observed: a local-image `docker run`
 		// taking 126s), so a 60s wait gave up prematurely and tore down a
 		// bring-up that would have succeeded. Overridable via KEPLOY_AGENT_READY_TIMEOUT.
-		agentCtx, cancel := context.WithTimeout(ctx, pkg.AgentReadyTimeout())
+		readyTimeout := pkg.AgentReadyTimeout()
+		if opts.AgentReadyTimeout > 0 {
+			readyTimeout = opts.AgentReadyTimeout
+		}
+		agentCtx, cancel := context.WithTimeout(ctx, readyTimeout)
 		defer cancel()
 
 		agentReadyCh := make(chan bool, 1)
@@ -1445,7 +1471,18 @@ func (a *AgentClient) Setup(ctx context.Context, cmd string, opts models.SetupOp
 			// Parent context cancelled (user pressed Ctrl+C)
 			return ctx.Err()
 		case <-agentCtx.Done():
-			return fmt.Errorf("keploy-agent did not become ready in time")
+			// The agent never reported healthy. The cleanup defer below is not in
+			// scope yet, so without this the wedged agent container and its
+			// goroutine leak — and any retry inherits the mess. Dump the container's
+			// own logs first: the CLI otherwise shows the full readiness window of
+			// silence followed by a bare error, with nothing to root-cause from.
+			if isDockerCmd {
+				a.logAgentContainerDiagnostics(opts.KeployContainer)
+			}
+			a.stopAgent()
+			// Sentinel so the caller can retry a fresh bring-up on this specific,
+			// nondeterministic stall without retrying deterministic failures.
+			return fmt.Errorf("%w", pkg.ErrAgentNotReady)
 		case <-agentReadyCh:
 		}
 	}

--- a/pkg/retry_agent_setup_test.go
+++ b/pkg/retry_agent_setup_test.go
@@ -1,0 +1,79 @@
+package pkg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+func TestRetryAgentSetup(t *testing.T) {
+	// speed: the helper sleeps 3s between attempts; shrink the test's patience by
+	// cancelling only where a case needs it. Cases that succeed within the first
+	// two attempts still incur real backoff, so keep failing-attempt counts low.
+	t.Run("succeeds first try, no retry", func(t *testing.T) {
+		calls := 0
+		err := RetryAgentSetup(context.Background(), zap.NewNop(), func(_ context.Context, _ int) error {
+			calls++
+			return nil
+		})
+		if err != nil || calls != 1 {
+			t.Fatalf("calls=%d err=%v, want 1 call and nil", calls, err)
+		}
+	})
+
+	t.Run("retries only ErrAgentNotReady, then succeeds", func(t *testing.T) {
+		calls := 0
+		err := RetryAgentSetup(context.Background(), zap.NewNop(), func(_ context.Context, _ int) error {
+			calls++
+			if calls == 1 {
+				return fmt.Errorf("wrap: %w", ErrAgentNotReady)
+			}
+			return nil
+		})
+		if err != nil || calls != 2 {
+			t.Fatalf("calls=%d err=%v, want 2 calls and nil", calls, err)
+		}
+	})
+
+	t.Run("does NOT retry a deterministic error", func(t *testing.T) {
+		deterministic := errors.New("missing kernel privileges")
+		calls := 0
+		err := RetryAgentSetup(context.Background(), zap.NewNop(), func(_ context.Context, _ int) error {
+			calls++
+			return deterministic
+		})
+		if calls != 1 || !errors.Is(err, deterministic) {
+			t.Fatalf("calls=%d err=%v, want 1 call and the original error", calls, err)
+		}
+	})
+
+	t.Run("gives up after all attempts, returns the sentinel", func(t *testing.T) {
+		calls := 0
+		err := RetryAgentSetup(context.Background(), zap.NewNop(), func(_ context.Context, _ int) error {
+			calls++
+			return ErrAgentNotReady
+		})
+		if calls != agentSetupAttempts || !errors.Is(err, ErrAgentNotReady) {
+			t.Fatalf("calls=%d err=%v, want %d calls and the sentinel", calls, err, agentSetupAttempts)
+		}
+	})
+
+	t.Run("stops immediately on context cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		calls := 0
+		go func() { time.Sleep(50 * time.Millisecond); cancel() }()
+		err := RetryAgentSetup(ctx, zap.NewNop(), func(_ context.Context, _ int) error {
+			calls++
+			return ErrAgentNotReady
+		})
+		// first attempt returns the sentinel, then the loop hits the backoff select
+		// and observes cancellation -> returns ctx.Err(); at most 1 call.
+		if calls != 1 || !errors.Is(err, context.Canceled) {
+			t.Fatalf("calls=%d err=%v, want 1 call and context.Canceled", calls, err)
+		}
+	})
+}

--- a/pkg/service/record/record.go
+++ b/pkg/service/record/record.go
@@ -941,7 +941,15 @@ func (r *Recorder) Start(ctx context.Context) error {
 	}
 
 	// Instrument will setup the environment and start the hooks and proxy
-	err = r.instrumentation.Setup(setupCtx, r.config.Command, models.SetupOptions{Container: r.config.ContainerName, DockerDelay: r.config.BuildDelay, Mode: models.MODE_RECORD, CommandType: r.config.CommandType, EnableTesting: false, GlobalPassthrough: r.config.Record.GlobalPassthrough, CapturePackets: r.config.Record.CapturePackets, OpportunisticTLSIntercept: r.config.Record.OpportunisticTLSIntercept, ChannelBindingShim: r.config.Record.ChannelBindingShim, UpstreamTLSVerify: r.config.Record.UpstreamTLS.Verify, UpstreamTLSCACert: r.config.Record.UpstreamTLS.CACert, BuildDelay: r.config.BuildDelay, PassThroughPorts: passPortsUint, MemoryLimit: memoryLimit, ConfigPath: r.config.ConfigPath, EnableSampling: r.config.Record.EnableSampling, RecordBufferMaxMemoryPerConn: r.config.Record.RecordBuffer.MaxMemoryPerConnection, RecordBufferQueueSize: r.config.Record.RecordBuffer.QueueSize, RecordBufferConsumerStallGrace: r.config.Record.RecordBuffer.ConsumerStallGrace, RecordBufferHalfCloseGrace: r.config.Record.RecordBuffer.HalfCloseGrace})
+	setupOpts := models.SetupOptions{Container: r.config.ContainerName, DockerDelay: r.config.BuildDelay, Mode: models.MODE_RECORD, CommandType: r.config.CommandType, EnableTesting: false, GlobalPassthrough: r.config.Record.GlobalPassthrough, CapturePackets: r.config.Record.CapturePackets, OpportunisticTLSIntercept: r.config.Record.OpportunisticTLSIntercept, ChannelBindingShim: r.config.Record.ChannelBindingShim, UpstreamTLSVerify: r.config.Record.UpstreamTLS.Verify, UpstreamTLSCACert: r.config.Record.UpstreamTLS.CACert, BuildDelay: r.config.BuildDelay, PassThroughPorts: passPortsUint, MemoryLimit: memoryLimit, ConfigPath: r.config.ConfigPath, EnableSampling: r.config.Record.EnableSampling, RecordBufferMaxMemoryPerConn: r.config.Record.RecordBuffer.MaxMemoryPerConnection, RecordBufferQueueSize: r.config.Record.RecordBuffer.QueueSize, RecordBufferConsumerStallGrace: r.config.Record.RecordBuffer.ConsumerStallGrace, RecordBufferHalfCloseGrace: r.config.Record.RecordBuffer.HalfCloseGrace}
+	// Retry only a stalled agent bring-up (pkg.ErrAgentNotReady) with a fresh agent.
+	err = pkg.RetryAgentSetup(setupCtx, r.logger, func(c context.Context, attempt int) error {
+		o := setupOpts
+		if attempt > 1 {
+			o.AgentReadyTimeout = 120 * time.Second
+		}
+		return r.instrumentation.Setup(c, r.config.Command, o)
+	})
 
 	if err != nil {
 		// If context was cancelled (user pressed Ctrl+C), return gracefully without error

--- a/pkg/service/replay/replay.go
+++ b/pkg/service/replay/replay.go
@@ -970,7 +970,18 @@ func (r *Replayer) Instrument(ctx context.Context) (*InstrumentState, error) {
 		passPortsUint32[i] = uint32(port)
 	}
 
-	err := r.instrumentation.Setup(ctx, r.config.Command, models.SetupOptions{Container: r.config.ContainerName, CommandType: r.config.CommandType, DockerDelay: r.config.BuildDelay, Mode: models.MODE_TEST, BuildDelay: r.config.BuildDelay, EnableTesting: true, GlobalPassthrough: r.config.Record.GlobalPassthrough, ChannelBindingShim: r.config.Record.ChannelBindingShim, ConfigPath: r.config.ConfigPath, PassThroughPorts: passPortsUint, InMemoryCompose: r.config.InMemoryCompose})
+	setupOpts := models.SetupOptions{Container: r.config.ContainerName, CommandType: r.config.CommandType, DockerDelay: r.config.BuildDelay, Mode: models.MODE_TEST, BuildDelay: r.config.BuildDelay, EnableTesting: true, GlobalPassthrough: r.config.Record.GlobalPassthrough, ChannelBindingShim: r.config.Record.ChannelBindingShim, ConfigPath: r.config.ConfigPath, PassThroughPorts: passPortsUint, InMemoryCompose: r.config.InMemoryCompose}
+	// Retry only a stalled agent bring-up (pkg.ErrAgentNotReady) with a fresh
+	// agent; a healthy agent is set up once and the test set runs against it.
+	err := pkg.RetryAgentSetup(ctx, r.logger, func(c context.Context, attempt int) error {
+		o := setupOpts
+		if attempt > 1 {
+			// The first attempt keeps the full slow-start budget; a retry's fresh
+			// agent is ready in a second or two, so cut a wedged retry short.
+			o.AgentReadyTimeout = 120 * time.Second
+		}
+		return r.instrumentation.Setup(c, r.config.Command, o)
+	})
 	if err != nil {
 		stopReason := "failed setting up the environment"
 		utils.LogError(r.logger, err, stopReason)

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -2707,6 +2707,13 @@ func WaitForPort(ctx context.Context, host string, port string, timeout time.Dur
 // `docker run` of an already-local image taking 126s before the agent process
 // ran. A shorter CLI wait gives up while the agent's own healthcheck still
 // considers it starting, tearing down a bring-up that would have succeeded.
+// ErrAgentNotReady is returned by an agent Setup whose agent never reported
+// healthy within AgentReadyTimeout. It is a distinct sentinel so callers can
+// retry a fresh bring-up on this — a nondeterministic container-runtime stall,
+// observed intermittently on macOS Docker Desktop — WITHOUT retrying
+// deterministic failures like missing kernel privileges or a bad config.
+var ErrAgentNotReady = errors.New("keploy-agent did not become ready in time")
+
 const DefaultAgentReadyTimeout = 330 * time.Second
 
 // AgentReadyTimeout returns how long to wait for the keploy-agent to become
@@ -2721,6 +2728,40 @@ func AgentReadyTimeout() time.Duration {
 		}
 	}
 	return DefaultAgentReadyTimeout
+}
+
+// agentSetupAttempts bounds how many times a stalled agent bring-up is retried
+// with a fresh agent before giving up. Three attempts takes a ~37%-per-attempt
+// intermittent stall (observed on macOS Docker Desktop) to ~5% while adding no
+// delay to the overwhelmingly common first-try success.
+const agentSetupAttempts = 3
+
+// RetryAgentSetup runs an agent Setup and retries it, up to agentSetupAttempts,
+// ONLY when it fails with ErrAgentNotReady. Each retry is a full fresh bring-up
+// (Setup re-draws ports and regenerates the agent container), which is what
+// clears a nondeterministic container-runtime stall. Deterministic failures
+// (missing privileges, bad config) do not match the sentinel and return at
+// once, and a cancelled context stops the loop immediately. The test assertions
+// downstream still run exactly once, against a healthy agent — this retries the
+// agent infrastructure, never a test.
+func RetryAgentSetup(ctx context.Context, logger *zap.Logger, setup func(ctx context.Context, attempt int) error) error {
+	var err error
+	for attempt := 1; attempt <= agentSetupAttempts; attempt++ {
+		err = setup(ctx, attempt)
+		if err == nil || ctx.Err() != nil || !errors.Is(err, ErrAgentNotReady) {
+			return err
+		}
+		if attempt < agentSetupAttempts {
+			logger.Warn("keploy-agent bring-up stalled; retrying with a fresh agent",
+				zap.Int("attempt", attempt), zap.Int("of", agentSetupAttempts), zap.Error(err))
+			select {
+			case <-time.After(3 * time.Second):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	}
+	return err
 }
 
 // AgentHealthTicker continuously monitors the agent health endpoint at specified intervals


### PR DESCRIPTION
## Problem

On docker/macOS CI runners the keploy-agent container intermittently **stalls at startup** — it produces no logs and never reports healthy — so `AgentClient.Setup` waits the full agent-ready timeout (330s) and gives up. It's nondeterministic (~37% on the macOS python-docker lanes, and it **recurs on `main`** with unchanged code), so one wedged container turns an otherwise-green run red.

Two defects made this both unrecoverable and undiagnosable:

- **Leak:** the readiness-timeout branch returned *before* the `if err != nil { stopAgent() }` cleanup defer was in scope, so the wedged agent container **and** `startAgent`'s goroutine leaked (the leaked context is `a.agentCancel`, which the readiness poll's own context never touches).
- **Black box:** nothing captured the agent container's own logs, so a failure was 330s of silence then a generic error — no way to tell a `docker run`/container-start stall from an in-agent hang.

## Fix

1. On the readiness timeout: dump the agent container's `docker logs` + state (`logAgentContainerDiagnostics`, best-effort, 15s-bounded), call `stopAgent()` to tear the wedged container down (fixes the leak), and return a new `pkg.ErrAgentNotReady` sentinel.
2. `pkg.RetryAgentSetup` retries the bring-up up to 3× **only** on `ErrAgentNotReady`. A fresh `Setup` re-draws ports and regenerates the agent container, which is what clears a nondeterministic runtime stall. The readiness poll happens **before** any app/proxy is started, so a retry only re-brings-up the agent — **the test set still runs once, against a healthy agent**. Deterministic failures (missing privileges, bad config) don't match the sentinel and return immediately; a cancelled context stops the loop.
3. Retries pass a shorter `SetupOptions.AgentReadyTimeout` (120s): attempt 1 keeps the full slow-start budget (for the legitimately-slow ~126s cold start that 330s exists for), but a fresh agent is ready in ~1–2s, so a wedged retry is cut short. Worst case is bounded at 330+120+120s instead of 3×330s.

This retries the agent **infrastructure**, never a test assertion — a genuine test failure still fails on the first attempt.

## Scope (deliberate)

- The **leak fix + diagnostics** live inside `Setup`, so they apply to every caller (record, replay, `keploy mock`, runner).
- The **retry** wraps the record/replay `Instrument` bring-up — the path that hits this stall. `keploy mock` and `runner` remain single-attempt (they still get the leak fix + diagnostics).
- The **docker-compose** per-test-set readiness path is out of scope: `Setup` skips the readiness poll for compose, so it never returns the sentinel. The observed failure is the plain-`docker run` poll inside `Setup`, which this covers. If the stall ever reproduces on a compose lane, those bare-error waits (`record.go`/`replay.go`/`runner.go`) would need the same treatment.

## Tests

`pkg/retry_agent_setup_test.go` verifies: single call on success; retry only on the wrapped sentinel; **no** retry on a deterministic error; bounded attempts; and immediate stop on context cancellation. `go build ./pkg/...`, `go vet`, and the touched-package suites are clean.