### PR TITLE
fix(cli): propagate errors from utility commands and skip empty Postman request URLs

### DIFF
--- a/cli/export.go
+++ b/cli/export.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -38,17 +39,19 @@ func Export(ctx context.Context, logger *zap.Logger, _ *config.Config, serviceFa
 			svc, err := serviceFactory.GetService(ctx, "export")
 			if err != nil {
 				utils.LogError(logger, err, "failed to get service", zap.String("command", cmd.Name()))
-				return nil
+				return err
 			}
 			var tools toolsSvc.Service
 			var ok bool
 			if tools, ok = svc.(toolsSvc.Service); !ok {
-				utils.LogError(logger, nil, "service doesn't satisfy tools service interface")
-				return nil
+				err := errors.New("service doesn't satisfy tools service interface")
+				utils.LogError(logger, err, err.Error())
+				return err
 			}
 			err = tools.Export(ctx) // Assuming ExportPostmanCollection is a method in tools service
 			if err != nil {
 				utils.LogError(logger, err, "failed to export Postman collection")
+				return err
 			}
 			return nil
 		},

--- a/cli/import.go
+++ b/cli/import.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -44,17 +45,19 @@ func Import(ctx context.Context, logger *zap.Logger, _ *config.Config, serviceFa
 			svc, err := serviceFactory.GetService(ctx, "import")
 			if err != nil {
 				utils.LogError(logger, err, "failed to get service", zap.String("command", cmd.Name()))
-				return nil
+				return err
 			}
 			var tools toolsSvc.Service
 			var ok bool
 			if tools, ok = svc.(toolsSvc.Service); !ok {
-				utils.LogError(logger, nil, "service doesn't satisfy tools service interface")
-				return nil
+				err := errors.New("service doesn't satisfy tools service interface")
+				utils.LogError(logger, err, err.Error())
+				return err
 			}
 			err = tools.Import(ctx, path, basePath)
 			if err != nil {
 				utils.LogError(logger, err, "failed to import Postman collection")
+				return err
 			}
 			return nil
 		},

--- a/cli/normalise.go
+++ b/cli/normalise.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 
 	"github.com/spf13/cobra"
 	"go.keploy.io/server/v3/config"
@@ -27,17 +28,18 @@ func Normalize(ctx context.Context, logger *zap.Logger, _ *config.Config, servic
 			svc, err := serviceFactory.GetService(ctx, cmd.Name())
 			if err != nil {
 				utils.LogError(logger, err, "failed to get service", zap.String("command", cmd.Name()))
-				return nil
+				return err
 			}
 			var tools toolsSvc.Service
 			var ok bool
 			if tools, ok = svc.(toolsSvc.Service); !ok {
-				utils.LogError(logger, nil, "service doesn't satisfy tools service interface")
-				return nil
+				err := errors.New("service doesn't satisfy tools service interface")
+				utils.LogError(logger, err, err.Error())
+				return err
 			}
 			if err := tools.Normalize(ctx); err != nil {
 				utils.LogError(logger, err, "failed to normalize test cases")
-				return nil
+				return err
 			}
 			return nil
 		},

--- a/cli/sanitize.go
+++ b/cli/sanitize.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 
 	"github.com/spf13/cobra"
 	"go.keploy.io/server/v3/config"
@@ -26,19 +27,20 @@ func Sanitize(ctx context.Context, logger *zap.Logger, _ *config.Config, service
 			svc, err := serviceFactory.GetService(ctx, cmd.Name())
 			if err != nil {
 				utils.LogError(logger, err, "failed to get service", zap.String("command", cmd.Name()))
-				return nil
+				return err
 			}
 			var sanitizeService toolsSvc.Service
 			var ok bool
 			if sanitizeService, ok = svc.(toolsSvc.Service); !ok {
-				utils.LogError(logger, nil, "service doesn't satisfy tools service interface")
-				return nil
+				err := errors.New("service doesn't satisfy tools service interface")
+				utils.LogError(logger, err, err.Error())
+				return err
 			}
 
 			err = sanitizeService.Sanitize(ctx)
 			if err != nil {
 				utils.LogError(logger, err, "failed to sanitize test cases")
-				return nil
+				return err
 			}
 
 			return nil

--- a/cli/templatize.go
+++ b/cli/templatize.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 
 	"github.com/spf13/cobra"
 	"go.keploy.io/server/v3/config"
@@ -27,17 +28,18 @@ func Templatize(ctx context.Context, logger *zap.Logger, _ *config.Config, servi
 			svc, err := serviceFactory.GetService(ctx, cmd.Name())
 			if err != nil {
 				utils.LogError(logger, err, "failed to get service", zap.String("command", cmd.Name()))
-				return nil
+				return err
 			}
 			var tools toolsSvc.Service
 			var ok bool
 			if tools, ok = svc.(toolsSvc.Service); !ok {
-				utils.LogError(logger, nil, "service doesn't satisfy tools service interface")
-				return nil
+				err := errors.New("service doesn't satisfy tools service interface")
+				utils.LogError(logger, err, err.Error())
+				return err
 			}
 			if err := tools.Templatize(ctx); err != nil {
 				utils.LogError(logger, err, "failed to templatize test cases")
-				return nil
+				return err
 			}
 			return nil
 		},

--- a/pkg/service/import/import.go
+++ b/pkg/service/import/import.go
@@ -354,11 +354,14 @@ func (pi *PostmanImporter) processEmptyResponse(testItem *TestData, globalVariab
 		testItem.Response = append(testItem.Response, response)
 		return nil
 	}
-	pi.logger.Error("URL is empty", zap.String("testItem", testItem.Name))
-	return fmt.Errorf("URL is empty")
+	pi.logger.Warn("Skipping test item because URL is empty", zap.String("testItem", testItem.Name))
+	return nil
 }
 
 func (pi *PostmanImporter) writeTestData(testItem TestData, testsPath string, globalVariables map[string]string, testCounter *int) error {
+	if len(testItem.Response) == 0 {
+		return nil
+	}
 	for _, response := range testItem.Response {
 		testName := fmt.Sprintf("test-%d", *testCounter+1)
 


### PR DESCRIPTION
## Problem

1. When running CLI utility commands (`sanitize`, `normalize`, `templatize`, `export`, `import`), if the service fails (e.g. invalid test set or unparseable file), `utils.LogError` was called but `RunE` returned `nil`. Because `RunE` returned `nil` and `utils.ErrCode` was not updated, `main()` exited with code 0 (Success) instead of non-zero failure, misleading CI/CD pipelines.
2. During Postman collection imports, collections containing folders without request URLs caused `processEmptyResponse` to abort the entire import with `URL is empty`.

## Root Cause

- In `cli/sanitize.go`, `cli/normalise.go`, `cli/templatize.go`, `cli/export.go`, and `cli/import.go`, `RunE` swallowed errors by returning `nil` after logging.
- In `pkg/service/import/import.go`, empty request URLs in Postman items triggered a fatal error return rather than warning and skipping non-request folder items.

## Fix

- Return `err` from `RunE` across `sanitize`, `normalize`, `templatize`, `export`, and `import` commands so cobra command execution reports non-zero exit code to the caller.
- Warn and skip empty request URLs during Postman collection processing.

## Verification

- Ran `go test ./cli/...` and `go test ./pkg/service/import/...` cleanly.

Fixes #4531, Fixes #4434