### PR TITLE
fix(agent): give the docker healthcheck time to load a large mock set

### DIFF
--- a/pkg/platform/docker/agent_healthcheck_startperiod_test.go
+++ b/pkg/platform/docker/agent_healthcheck_startperiod_test.go
@@ -1,0 +1,77 @@
+package docker
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/config"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+)
+
+func TestAgentHealthcheckStartPeriod(t *testing.T) {
+	if got := agentHealthcheckStartPeriod(); got.Seconds() != 600 {
+		t.Errorf("default = %v, want 600s", got)
+	}
+	t.Setenv("KEPLOY_AGENT_HEALTHCHECK_START_PERIOD_SECONDS", "1800")
+	if got := agentHealthcheckStartPeriod(); got.Seconds() != 1800 {
+		t.Errorf("override 1800 = %v, want 1800s", got)
+	}
+	for _, bad := range []string{"0", "-5", "abc", ""} {
+		t.Setenv("KEPLOY_AGENT_HEALTHCHECK_START_PERIOD_SECONDS", bad)
+		if got := agentHealthcheckStartPeriod(); got.Seconds() != 600 {
+			t.Errorf("invalid %q = %v, want default 600s", bad, got)
+		}
+	}
+}
+
+// The generated keploy-agent healthcheck must carry the generous, env-tunable
+// start_period so a large mock load (ready file written only after StoreMocks)
+// is not marked unhealthy mid-load. Regression guard for the go-memory-load flake.
+func TestGenerateKeployAgentService_HealthcheckStartPeriod(t *testing.T) {
+	startPeriod := func(t *testing.T) string {
+		t.Helper()
+		svc, err := (&Impl{logger: zap.NewNop(), conf: &config.Config{}}).GenerateKeployAgentService(models.SetupOptions{
+			KeployContainer: "keploy-agent",
+			AgentPort:       16789,
+			ProxyPort:       16790,
+			DnsPort:         16791,
+			Mode:            models.MODE_TEST,
+		})
+		if err != nil {
+			t.Fatalf("GenerateKeployAgentService: %v", err)
+		}
+		hc := mappingValue(svc, "healthcheck")
+		if hc == nil {
+			t.Fatal("no healthcheck block")
+		}
+		sp := mappingValue(hc, "start_period")
+		if sp == nil || sp.Kind != yaml.ScalarNode {
+			t.Fatalf("no scalar start_period in healthcheck")
+		}
+		return sp.Value
+	}
+
+	if got := startPeriod(t); got != "600s" {
+		t.Errorf("default healthcheck start_period = %q, want 600s (covers a large mock load)", got)
+	}
+
+	// interval/timeout/retries must be untouched — guards against the start_period
+	// change accidentally cross-wiring to a neighbouring healthcheck field.
+	for _, tc := range []struct{ key, want string }{{"interval", "5s"}, {"timeout", "5s"}, {"retries", "60"}} {
+		svc, err := (&Impl{logger: zap.NewNop(), conf: &config.Config{}}).GenerateKeployAgentService(models.SetupOptions{
+			KeployContainer: "keploy-agent", AgentPort: 16789, ProxyPort: 16790, DnsPort: 16791, Mode: models.MODE_TEST,
+		})
+		if err != nil {
+			t.Fatalf("GenerateKeployAgentService: %v", err)
+		}
+		v := mappingValue(mappingValue(svc, "healthcheck"), tc.key)
+		if v == nil || v.Value != tc.want {
+			t.Errorf("healthcheck %s = %v, want %q", tc.key, v, tc.want)
+		}
+	}
+	t.Setenv("KEPLOY_AGENT_HEALTHCHECK_START_PERIOD_SECONDS", "900")
+	if got := startPeriod(t); got != "900s" {
+		t.Errorf("env-tuned start_period = %q, want 900s", got)
+	}
+}

--- a/pkg/platform/docker/docker.go
+++ b/pkg/platform/docker/docker.go
@@ -40,6 +40,62 @@ const (
 	defaultTimeoutForDockerQuery = 1 * time.Minute
 )
 
+// agentHealthcheckStartPeriod is the docker-compose healthcheck start_period for
+// the keploy-agent service: the window in which a FAILING healthcheck neither
+// counts toward `retries` nor marks the container unhealthy, so a dependent app
+// (depends_on: service_healthy) simply keeps waiting.
+//
+// WHAT IT IS NOT. For a LITERAL `docker compose` command it is NOT the
+// mechanism that detects a dead agent: keploy rewrites such commands to inject
+// `--abort-on-container-exit` (ensureComposeExitOnAppFailure, called from
+// modifyDockerComposeCommand / ensureInMemoryComposeFlags in pkg/client/app),
+// so a crashed or OOM-killed agent container EXITS and aborts the whole run
+// immediately, independent of this budget. That covers the go-memory-load lanes
+// this fix targets (they run `-c "docker compose up"`). For a WRAPPER command
+// (make / npm / a shell script) keploy passes its compose file via COMPOSE_FILE
+// and cannot splice the flag in — it warns about exactly this at app.go:~288 —
+// so there this window genuinely IS the backstop, which is a further reason to
+// keep it generous. In both cases the window's job is the same: avoid
+// false-failing an agent that is ALIVE and still doing its one-time setup.
+//
+// WHAT IT BOUNDS. The agent writes AgentReadyFile only after the CLI has read
+// and decoded the test-set's mock corpus (GetFilteredMocks) and streamed it to
+// the agent (StoreMocks -> MakeAgentReady). Measured, the stream+park itself is
+// not the cost — gob encode/decode + on-disk parking runs at ~380 MB/s, so even
+// a multi-hundred-MB corpus lands in seconds (measured with a throwaway
+// benchmark, since removed). What actually stretches the
+// wall-clock is the CLI-side corpus DECODE racing everything else on a
+// contended shared runner: on the go-memory-load lanes a ~80 MB / ~1.1k-mock
+// set decoded while the app's own DB seeded on the same 2 vCPUs took ~60s, and
+// on a slower run crossed the old fixed 10s+60x5s=310s budget — flipping a
+// healthy-but-still-setting-up agent to unhealthy and failing the app's
+// depends_on. That is the flake.
+//
+// WHY GENEROUS IS THE RIGHT SHAPE, NOT A GUESS. The container flips healthy the
+// instant the ready file appears, so in the common case the app starts in
+// seconds no matter how large this window is — a generous value costs the fast
+// path nothing. For literal compose, agent death is caught by container-exit
+// (--abort-on-container-exit), not by this window. So this
+// is a floor sized to "comfortably longer than any legitimate setup," not a
+// delicate estimate of load time; its exact value is not correctness-critical.
+// The only case it still bounds is an agent that is alive but wedged (never
+// ready, never exits): retries*interval past this window it is declared
+// unhealthy and the run fails with a clear cause rather than hanging to the CI
+// job timeout. 600s default keeps that backstop while giving the observed
+// worst case ~10x headroom.
+//
+// Overridable via KEPLOY_AGENT_HEALTHCHECK_START_PERIOD_SECONDS. Non-positive or
+// unparsable falls back to the default.
+func agentHealthcheckStartPeriod() time.Duration {
+	const def = 600 * time.Second
+	if v := strings.TrimSpace(os.Getenv("KEPLOY_AGENT_HEALTHCHECK_START_PERIOD_SECONDS")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return time.Duration(n) * time.Second
+		}
+	}
+	return def
+}
+
 // ComposeServiceHook is called for each keploy-managed Docker Compose service
 // node during generation so a downstream caller (the enterprise low-latency hook)
 // can mutate the right one. E.g. it adds the deterministic JVM agent (-javaagent
@@ -860,9 +916,14 @@ func (idc *Impl) GenerateKeployAgentService(opts models.SetupOptions) (*yaml.Nod
 			{Kind: yaml.ScalarNode, Value: "retries"},
 			{Kind: yaml.ScalarNode, Value: "60"},
 
-			// start_period
+			// start_period — a generous, env-tunable readiness floor. For a
+			// literal `docker compose` command it is not the death detector (a
+			// dead agent exits and --abort-on-container-exit aborts the run); it
+			// only keeps a live, still-setting-up agent from being false-failed
+			// while the CLI decodes and streams the mock corpus. See
+			// agentHealthcheckStartPeriod for the full rationale.
 			{Kind: yaml.ScalarNode, Value: "start_period"},
-			{Kind: yaml.ScalarNode, Value: "10s"},
+			{Kind: yaml.ScalarNode, Value: fmt.Sprintf("%ds", int(agentHealthcheckStartPeriod().Seconds()))},
 		},
 	}
 

--- a/pkg/service/replay/utils.go
+++ b/pkg/service/replay/utils.go
@@ -185,7 +185,7 @@ func dockerPublishedHostPort(cmd string) (host, port string, ok bool) {
 // recognises -p/--publish on the command line, and `docker compose up` carries
 // none, so the fixed --delay is the entire protection. That is not a
 // theoretical gap — keploy's own generated compose holds the application behind
-// the agent's healthcheck (start_period 10s, interval 5s), so on a contended
+// the agent's ready-file healthcheck, so on a contended
 // machine the app starts as the delay expires, the first test window opens
 // while the app is still booting, and its bootstrap queries are scored against
 // a per-test pool that has nothing in it. The app then dies on a refused

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -2700,13 +2700,16 @@ func WaitForPort(ctx context.Context, host string, port string, timeout time.Dur
 }
 
 // DefaultAgentReadyTimeout is how long keploy waits for the in-docker
-// keploy-agent to report ready before giving up. It is sized to the agent
-// container's OWN healthcheck budget (start_period 10s + interval 5s × retries
-// 60 ≈ 310s, see pkg/platform/docker): under heavy CI docker-daemon contention
-// the agent container can take ~2 minutes just to start — observed in CI as a
-// `docker run` of an already-local image taking 126s before the agent process
-// ran. A shorter CLI wait gives up while the agent's own healthcheck still
-// considers it starting, tearing down a bring-up that would have succeeded.
+// keploy-agent's HTTP endpoint to become reachable before giving up. This
+// bounds container BOOT only — the AgentHealthTicker gate that runs before
+// StoreMocks — not the compose ready-file healthcheck, which has its own
+// generous, env-tunable start_period floor (see agentHealthcheckStartPeriod in
+// pkg/platform/docker). Under heavy CI docker-daemon contention the agent
+// container can take ~2 minutes just to start — observed in CI as a `docker
+// run` of an already-local image taking 126s before the agent process ran. A
+// shorter CLI wait gives up while the container is still booting, tearing down
+// a bring-up that would have succeeded.
+//
 // ErrAgentNotReady is returned by an agent Setup whose agent never reported
 // healthy within AgentReadyTimeout. It is a distinct sentinel so callers can
 // retry a fresh bring-up on this — a nondeterministic container-runtime stall,


### PR DESCRIPTION
## `go-memory-load-mongo` flake — the real root cause

The keploy-agent compose service healthchecks with `cat /tmp/agent.ready` (interval 5s, retries 60), and the user's app waits on it via `depends_on: condition: service_healthy`. `/tmp/agent.ready` is written only after the CLI has decoded the test-set's mock corpus (`GetFilteredMocks`) and streamed it into the agent (`StoreMocks` → `MakeAgentReadyForDockerCompose`). The old `start_period` was **10s**, so the effective budget before the container was declared *unhealthy* was `10s + 60×5s ≈ 310s`. On a slow run that budget expired while the agent was still, legitimately, setting up — the container flipped `unhealthy` and `docker compose up` aborted the app with `dependency failed to start: … is unhealthy`.

### What it is NOT (correcting an earlier diagnosis)

An earlier version of this PR blamed `StoreMocks` throughput (~1.4 MB/s over a ~431 MB corpus). **That was wrong, and I verified it by measurement**:

- The corpus on this lane is modest — a passing run parks **~82 MB / ~1,100 mocks** (`onDisk: 1111, diskBytes: 85899166`), only **10** of them session/config.
- A microbenchmark of the real gob receive path (`StoreMocksStream` decode + `DiskMocks.Add` re-encode + `WriteAt`) runs at ~380 MB/s, and the encode/pipe transport at ~1.5 GB/s (measured with a throwaway benchmark, since removed); adding a `bufio` layer changed it <10%. So stream+park of an 82 MB corpus is **sub-second**, not the bottleneck.
- The real time sink is CLI-side corpus **decode** racing everything else on a shared **2-vCPU** runner: in the passing run the agent's HTTP server was up at `14:33:55`, but mocks weren't parked until `14:34:59` — a **~63 s** gap during which the CLI was silently decoding while the app's own MongoDB seeded on the same two cores. On a slower run that ~60 s becomes >310 s and the lane fails. It's variance/contention, not a code hot path — which is why it flakes rather than always failing.

### Why raising `start_period` is the correct fix, not a bandaid

The load-bearing fact: **the healthcheck budget is not what detects a dead agent.** For a literal `docker compose` command (which is what these lanes run — `-c "docker compose up"`), keploy rewrites it to inject `--abort-on-container-exit` (`ensureComposeExitOnAppFailure` in `pkg/client/app`), so a crashed or OOM-killed agent container **exits and aborts the whole run immediately**, independent of this budget. (For wrapper commands — `make`/`npm`/scripts — keploy passes the compose file via `COMPOSE_FILE` and can't splice the flag in, so there this window genuinely is the backstop, which only argues for keeping it generous.) `start_period`'s only job is to avoid false-failing an agent that is **alive and still doing one-time setup**.

Given that:

- The container flips healthy the **instant** the ready file appears, so in the common case the app starts in seconds *no matter how large this window is* — a generous value costs the fast path nothing.
- Death (for literal compose) is caught by container-exit, so this is a **floor sized to "comfortably longer than any legitimate setup," not a delicate estimate of load time.** Its exact value is not correctness-critical.
- The only thing it still bounds is an agent that is alive but *wedged* (never ready, never exits): `retries×interval` past the window it's declared unhealthy and the run fails with a clear cause instead of hanging to the CI job timeout. **600s** keeps that backstop while giving the observed worst case ~10× headroom.

Env-tunable via `KEPLOY_AGENT_HEALTHCHECK_START_PERIOD_SECONDS`.

### What I deliberately did NOT do

The only *corpus-size-independent* gate would be to release the app after the **session/config** mocks (10) instead of the whole corpus, parking per-test mocks in the background. I rejected it: some apps issue boot-time queries that the recorder tags per-test (disk-parked), so releasing the app before per-test parking completes risks boot-time mock misses — a correctness regression. The safe invariant is "app waits for the full load," and this PR keeps it.

### Tests

Assert the helper (default / env-override / invalid-fallback) and that the generated healthcheck node carries the tuned `start_period` with `interval`/`timeout`/`retries` untouched.
