### PR TITLE
fix(dns): an NXDOMAIN name is not a missing mock

### DIFF
--- a/pkg/agent/proxy/dns.go
+++ b/pkg/agent/proxy/dns.go
@@ -290,6 +290,11 @@ func (p *Proxy) resolveUncachedDNSResponse(question dns.Question, mode models.Mo
 		// "mock not found" path: same error, same log line, same
 		// NXDOMAIN / synthetic fallback. Forwarding is strictly
 		// additive.
+		// Set when upstream answers authoritatively that the name does not
+		// exist. Such a name has no mock and never could: the record side
+		// deliberately skips non-Success rcodes, so its absence is correct
+		// rather than a recording gap. See the mock-miss report below.
+		upstreamSaysNameDoesNotExist := false
 		if fwdResp, fwdErr := p.forwardDNSUpstream(question); fwdErr == nil && fwdResp != nil {
 			// A RcodeSuccess response splits into two cases by answer count:
 			// resolved (>=1 RR) vs NODATA (0 RRs). Both are relayed as-is; only
@@ -367,6 +372,13 @@ func (p *Proxy) resolveUncachedDNSResponse(question dns.Question, mode models.Mo
 					zap.Int("rcode", fwdResp.Rcode))
 				return dnsCacheEntry{Msg: fwdResp, FromUpstream: true}
 			}
+			// ONLY NXDOMAIN. This branch also covers SERVFAIL, REFUSED,
+			// NOTIMP and FORMERR, which mean the resolver could not or would
+			// not answer -- they say nothing about whether the name exists,
+			// so they stay reportable like an unreachable upstream.
+			if fwdResp.Rcode == dns.RcodeNameError {
+				upstreamSaysNameDoesNotExist = true
+			}
 			p.logger.Debug("DNS mock miss: upstream returned negative answer; falling back to synthetic DNS response",
 				zap.String("query", question.Name),
 				zap.String("qtype", dns.TypeToString[question.Qtype]),
@@ -399,7 +411,25 @@ func (p *Proxy) resolveUncachedDNSResponse(question dns.Question, mode models.Mo
 				zap.String("query", question.Name))
 			return p.defaultDNSResponse(question)
 		}
-		if mockingEnabled {
+		// Skipped when upstream said NXDOMAIN: there is no mock to be missing.
+		// The record side deliberately does not store non-Success rcodes, so a
+		// name that does not resolve was never recordable, and the report's
+		// own advice -- "re-record to capture DNS queries" -- can never
+		// succeed for it. Kubernetes resolvers reach here routinely: with
+		// ndots:5 a name like appdb.ns.svc.cluster.local is first tried as
+		// appdb.ns.svc.cluster.local.ns.svc.cluster.local, which NXDOMAINs by
+		// design.
+		//
+		// Everything else that reaches this point is still reported: upstream
+		// unreachable, no upstream configured, a non-forwardable qtype, and
+		// SERVFAIL/REFUSED/NOTIMP/FORMERR -- none of which tell us the name is
+		// absent. (A name that DOES resolve never gets here; it returns
+		// upstream's answer above. So after this change DNS-miss reporting
+		// fires only when the forwarder itself could not reach a verdict.)
+		//
+		// The app is unaffected either way -- it still receives the synthetic
+		// NOERROR steer below (issue #2006). Only the spurious verdict goes.
+		if mockingEnabled && !upstreamSaysNameDoesNotExist {
 			// Send mock not found error if we couldn't match any DNS
 			// mock and upstream forwarding also failed.
 			p.logger.Debug("mock miss",

--- a/pkg/agent/proxy/dns_negative_answer_test.go
+++ b/pkg/agent/proxy/dns_negative_answer_test.go
@@ -1,0 +1,173 @@
+package proxy
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// nxdomainUpstream starts a local DNS server that answers NXDOMAIN for every
+// query, standing in for a cluster resolver being asked about a name that does
+// not exist. Returns its address parts and a stop func.
+func rcodeUpstream(t *testing.T, rcode int) (host, port string, stop func()) {
+	t.Helper()
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := &dns.Server{PacketConn: pc, Handler: dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetRcode(r, rcode)
+		_ = w.WriteMsg(m)
+	})}
+	go func() { _ = srv.ActivateAndServe() }()
+	h, p, err := net.SplitHostPort(pc.LocalAddr().String())
+	if err != nil {
+		t.Fatalf("split: %v", err)
+	}
+	return h, p, func() { _ = srv.Shutdown() }
+}
+
+// A Kubernetes resolver walks its search list (ndots:5 by default), so a name
+// like appdb.ns.svc.cluster.local is first tried as
+// appdb.ns.svc.cluster.local.ns.svc.cluster.local. Those probes NXDOMAIN by
+// design, and the record side deliberately does not store non-Success rcodes,
+// so there is no mock for them and never can be.
+//
+// Reporting that absence as a mock miss fails the test case over a name that
+// legitimately does not exist, and tells the user to "re-record to capture DNS
+// queries" — advice that can never work. Observed in enterprise pipelines 8649
+// (main) and 8653 as:
+//
+//	Mock mismatch: [DNS] AAAA appdb.java-mysql.svc.cluster.local.java-mysql.svc.cluster.local.
+func TestDNSMockMiss_UpstreamNXDOMAIN_IsNotReportedAsAMockMiss(t *testing.T) {
+	host, port, stop := rcodeUpstream(t, dns.RcodeNameError)
+	defer stop()
+
+	p := &Proxy{
+		logger:             zap.NewNop(),
+		errChannel:         make(chan error, 4),
+		dnsUpstreamServers: []string{host},
+		dnsUpstreamPort:    port,
+		dnsForwardTimeout:  2 * time.Second,
+		// Without this the synthesised A record carries a nil address, and an
+		// assertion on Rcode alone would pass on a response no app could use.
+		IP4: "127.0.0.1",
+	}
+
+	q := dns.Question{
+		Name:   "appdb.java-mysql.svc.cluster.local.java-mysql.svc.cluster.local.",
+		Qtype:  dns.TypeA,
+		Qclass: dns.ClassINET,
+	}
+
+	got := p.resolveUncachedDNSResponse(q, models.MODE_TEST, true, time.Now(), nil)
+
+	// The app must still get a USABLE answer — steering it at the proxy rather
+	// than relaying NXDOMAIN is deliberate (issue #2006).
+	if got.Msg == nil || got.Msg.Rcode != dns.RcodeSuccess {
+		t.Fatalf("expected a synthetic NOERROR response so the app proceeds, got %+v", got.Msg)
+	}
+	if len(got.Msg.Answer) == 0 {
+		t.Fatalf("synthetic response carried no answer; the app would have nothing to dial")
+	}
+	a, ok := got.Msg.Answer[0].(*dns.A)
+	if !ok || a.A == nil || a.A.String() != "127.0.0.1" {
+		t.Fatalf("expected the proxy steer 127.0.0.1 in the A record, got %v", got.Msg.Answer[0])
+	}
+
+	select {
+	case err := <-p.errChannel:
+		t.Fatalf("upstream authoritatively said this name does not exist, so there is no "+
+			"mock to be missing; it must not be reported as a mock miss. got: %v", err)
+	default:
+	}
+}
+
+// The narrowing above must not swallow REAL gaps. When upstream cannot be
+// reached we have no evidence either way about the name, so an unmatched query
+// is still a mock miss worth failing on — otherwise a cluster with a broken
+// resolver would silently "pass" every replay.
+func TestDNSMockMiss_UpstreamUnreachable_IsStillReported(t *testing.T) {
+	// Port 1 on loopback: nothing listens, so the forward fails rather than
+	// returning an authoritative negative answer.
+	p := &Proxy{
+		logger:             zap.NewNop(),
+		errChannel:         make(chan error, 4),
+		dnsUpstreamServers: []string{"127.0.0.1"},
+		dnsUpstreamPort:    "1",
+		dnsForwardTimeout:  200 * time.Millisecond,
+	}
+
+	q := dns.Question{Name: "some-service.default.svc.cluster.local.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	_ = p.resolveUncachedDNSResponse(q, models.MODE_TEST, true, time.Now(), nil)
+
+	select {
+	case <-p.errChannel:
+		// expected: we could not confirm the name is absent, so report it.
+	default:
+		t.Fatal("upstream was unreachable, so the miss is unexplained and MUST still be reported")
+	}
+}
+
+// With no upstream configured at all there is likewise no evidence, so a miss
+// stays a miss.
+func TestDNSMockMiss_NoUpstreamConfigured_IsStillReported(t *testing.T) {
+	p := &Proxy{
+		logger:            zap.NewNop(),
+		errChannel:        make(chan error, 4),
+		dnsForwardTimeout: 200 * time.Millisecond,
+	}
+
+	q := dns.Question{Name: "some-service.default.svc.cluster.local.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	_ = p.resolveUncachedDNSResponse(q, models.MODE_TEST, true, time.Now(), nil)
+
+	select {
+	case <-p.errChannel:
+		// expected
+	default:
+		t.Fatal("no upstream to consult, so the miss is unexplained and MUST still be reported")
+	}
+}
+
+// SERVFAIL/REFUSED are NOT "this name does not exist" — they are "the resolver
+// could not or would not answer". That is the same no-evidence state as an
+// unreachable upstream, so the miss must still be reported. Suppressing them
+// would let an overloaded CoreDNS, a DNSSEC validation failure, or a resolver
+// refusing our queries turn every replay silently green.
+func TestDNSMockMiss_UpstreamSERVFAILOrREFUSED_IsStillReported(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		rcode int
+	}{
+		{"SERVFAIL", dns.RcodeServerFailure},
+		{"REFUSED", dns.RcodeRefused},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			host, port, stop := rcodeUpstream(t, tc.rcode)
+			defer stop()
+
+			p := &Proxy{
+				logger:             zap.NewNop(),
+				errChannel:         make(chan error, 4),
+				dnsUpstreamServers: []string{host},
+				dnsUpstreamPort:    port,
+				dnsForwardTimeout:  2 * time.Second,
+			}
+			q := dns.Question{Name: "some-service.default.svc.cluster.local.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+			_ = p.resolveUncachedDNSResponse(q, models.MODE_TEST, true, time.Now(), nil)
+
+			select {
+			case <-p.errChannel:
+				// expected: the resolver failed, so we learned nothing about the name.
+			default:
+				t.Fatalf("%s means the resolver failed, not that the name is absent; "+
+					"the miss MUST still be reported", tc.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The bug

On a DNS mock miss in `MODE_TEST` the proxy forwards upstream. When upstream answers that the name **does not exist**, it correctly synthesises a NOERROR steer so the app proceeds (issue #2006) — and then *also* raises `ErrMockNotFound` with a `MockMismatchReport`, failing the test case.

There is no mock to be missing. The record side deliberately skips non-Success rcodes, so a name that does not resolve was never recordable — and the report's own next step, *"re-record to capture DNS queries"*, can never succeed for it.

## Why it shows up constantly on Kubernetes

With the default `ndots:5`, a resolver walks its search list first. So `appdb.ns.svc.cluster.local` (4 dots) is tried as:

```
appdb.java-mysql.svc.cluster.local.java-mysql.svc.cluster.local.    <- NXDOMAIN by design
```

That is verbatim what enterprise pipelines 8649 (main) and 8653 report as the only mismatch kind. Any JVM app in a default cluster meets this.

## Scope — deliberately narrow

Only `dns.RcodeNameError` suppresses the report.

An earlier draft of this change keyed off the whole non-Success branch, which also caught **SERVFAIL, REFUSED, NOTIMP and FORMERR**. Those mean the resolver *could not or would not answer* — they say nothing about whether the name exists. Suppressing them would let an overloaded CoreDNS or a DNSSEC validation failure turn every replay silently green. `TestDNSMockMiss_UpstreamSERVFAILOrREFUSED_IsStillReported` pins that, and fails against the wider draft.

| path | reported before | after |
|---|---|---|
| upstream NXDOMAIN | yes | **no** |
| upstream SERVFAIL / REFUSED / NOTIMP / FORMERR | yes | yes |
| upstream unreachable / timeout | yes | yes |
| no upstream configured | yes | yes |
| non-forwardable qtype | yes | yes |
| name resolves upstream | no (returns earlier) | no |
| NODATA (empty NOERROR) | no (relayed) | no |

After this change, DNS-miss reporting fires only when the forwarder could not reach a verdict.

## App behaviour is unchanged

Same synthetic steer, same return value, same caching — `FromUpstream` stays false so this path was never cached. Only the spurious verdict goes away.

## Tests

Hermetic: a local DNS server answering a chosen rcode, no network dependency. The NXDOMAIN test fails on unfixed code with the exact production error string. Full `pkg/agent/proxy` suite passes; `gofmt`/`go vet` clean.

## What this does *not* do

It does **not** by itself green `selfhosted-cloud-replay-e2e`. In 8649 the mismatch block attributes DNS to 1 of 9 failing cases, and in 8653 to 1 of 2 — the remaining leading-prefix failures have another cause still to find. This removes a systematic misreport, not the whole lane failure.
