### PR TITLE
chore: Rename pkg/agent/hooks/linux/comm.go to a more descriptive name

### DIFF
--- a/pkg/agent/hooks/linux/network.go
+++ b/pkg/agent/hooks/linux/network.go
@@ -17,8 +17,6 @@ import (
 	"go.uber.org/zap"
 )
 
-//TODO: rename this file.
-
 // Get Used by proxy
 func (h *Hooks) Get(_ context.Context, srcPort uint16) (*agent.NetworkAddress, error) {
 	d, err := h.GetDestinationInfo(srcPort)


### PR DESCRIPTION
Rename comm.go to network.go to better reflect that it handles network addresses and TLS information for eBPF hooks.

Also removes the open TODO comment.

Resolves #4566

## Describe the changes that are made
- Renamed `pkg/agent/hooks/linux/comm.go` to `pkg/agent/hooks/linux/network.go` to better reflect its network/TLS purpose.
- Removed the `//TODO: rename this file.` comment.


## What type of PR is this? (check all applicable)
-  📦 Chore


## Self Review done?
-  ✅ yes

