### PR TITLE
fix(mysql): return an unused post-TLS greeting to the shared port FIFO

### DIFF
--- a/pkg/agent/proxy/integrations/mysql/recorder/conn.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/conn.go
@@ -979,6 +979,12 @@ func handlePostTLSRecord(ctx context.Context, logger *zap.Logger, clientConn, de
 	}
 	pluginName, err := wire.GetPluginName(greetingPkt.Message)
 	if err != nil {
+		// Decodable but not a handshake (GetPluginName accepts only HandshakeV10
+		// / AuthSwitchRequest). This runs BEFORE the HandshakeV10 assertion
+		// below, so without clearing the flag here such an entry would be
+		// recycled — and Push re-stamps its expiry, making it immortal and
+		// tripping every later stream to this port.
+		restoreShared = false
 		return fmt.Errorf("failed to get plugin name from stored server greeting: %w", err)
 	}
 	decodeCtx.PluginName = pluginName
@@ -1044,6 +1050,12 @@ func handlePostTLSRecord(ctx context.Context, logger *zap.Logger, clientConn, de
 		// Produce a synthetic config mock from pre-TLS data so test mode
 		// can match the SSLRequest + HandshakeResponse41 during replay.
 		if ok && len(entry.ReqPackets) > 0 {
+			// Spent: a mock is about to be built from this greeting. Past this
+			// point the entry must NOT go back — handleClientQueries below
+			// returns non-nil at ordinary teardown (ctx.Done), so the error
+			// alone cannot distinguish "never used" from "used and then the
+			// connection ended".
+			restoreShared = false
 			if err := recordSyntheticConfigMock(ctx, logger, clientConn, mocks, decodeCtx, greetingPkt, entry, opts); err != nil {
 				logger.Debug("best-effort synthetic config mock generation failed for seq=0 path; continuing with command-phase capture", zap.Error(err))
 			}
@@ -1156,6 +1168,8 @@ func handlePostTLSRecord(ctx context.Context, logger *zap.Logger, clientConn, de
 	if len(requests) > 0 && requests[0].Header != nil {
 		reqOp = requests[0].Header.Type // Use SSLRequest type if present
 	}
+	// Spent, for the same reason as the synthetic-config path above.
+	restoreShared = false
 	recordMock(ctx, requests, responses, "config",
 		reqOp, authRes.responseOperation,
 		mocks, entry.ReqTimestamp, models.CapturedRespTime(ctx), opts)

--- a/pkg/agent/proxy/integrations/mysql/recorder/conn.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/conn.go
@@ -845,7 +845,7 @@ func handlePlainPassword(ctx context.Context, logger *zap.Logger, clientConn, de
 // In this mode, the SSL/GoTLS uprobes provide decrypted plaintext starting
 // from HandshakeResponse41 (the full auth after TLS handshake). The server
 // greeting was captured by the ringbuf path and stored in TLSHandshakeStore.
-func handlePostTLSRecord(ctx context.Context, logger *zap.Logger, clientConn, destConn net.Conn, mocks chan<- *models.Mock, decodeCtx *wire.DecodeContext, opts models.OutgoingOptions) error {
+func handlePostTLSRecord(ctx context.Context, logger *zap.Logger, clientConn, destConn net.Conn, mocks chan<- *models.Mock, decodeCtx *wire.DecodeContext, opts models.OutgoingOptions) (err error) {
 	// 1. Pop the server greeting from TLSHandshakeStore.
 	dstPort := uint16(0)
 	if opts.DstCfg != nil {
@@ -860,15 +860,44 @@ func handlePostTLSRecord(ctx context.Context, logger *zap.Logger, clientConn, de
 		zap.String("key", storeKey),
 		zap.String("connKey", opts.ConnKey),
 		zap.Uint16("dstPort", dstPort))
+	portOnlyKey := models.HandshakeStoreKey("", dstPort)
+	// fromShared: the entry came off the port-only FIFO, which is shared by every
+	// post-TLS stream to this port. An empty ConnKey collapses storeKey onto that
+	// same key, so the FIRST pop can read the shared queue too — classify by the
+	// key, not by which pop succeeded.
 	entry, ok := hsStore.PopWait(storeKey, 5*time.Second)
+	fromShared := ok && storeKey == portOnlyKey
 	// If conn-specific key missed, try the port-only fallback key.
 	// The proxy and uprobe see different TCP connections with different
 	// ephemeral ports, so conn-specific keys may not match.
 	if !ok && opts.ConnKey != "" {
-		portKey := models.HandshakeStoreKey("", dstPort)
 		logger.Debug("Conn-specific key missed, trying port-only fallback",
-			zap.String("portKey", portKey))
-		entry, ok = hsStore.PopWait(portKey, 2*time.Second)
+			zap.String("portKey", portOnlyKey))
+		entry, ok = hsStore.PopWait(portOnlyKey, 2*time.Second)
+		fromShared = ok
+	}
+	// Popping the shared FIFO is destructive: if this stream fails before
+	// recording anything, the greeting it consumed is gone and the connection
+	// that pushed it is starved, losing its whole command phase silently. Put an
+	// unused entry back. ReqTimestamp is stripped for the same reason the cached
+	// fallback below strips it — to the next consumer this is a BORROWED entry
+	// from another connection, and config mocks are identified and ordered by
+	// ReqTimestampMock. Mirrors handlePostTLSHandshakeV2 on the V2 path.
+	// Cleared at the greeting-decode failures below: an undecodable entry is
+	// garbage, and Push re-stamps its expiry, so recycling it would make it
+	// immortal and trip every later stream to this port.
+	restoreShared := true
+	if fromShared {
+		sharedEntry := entry
+		sharedEntry.ReqTimestamp = time.Time{}
+		defer func() {
+			if !restoreShared || err == nil {
+				return
+			}
+			hsStore.Push(portOnlyKey, sharedEntry)
+			logger.Debug("post-TLS MySQL: returned an unused shared greeting to the port FIFO",
+				zap.Uint16("dstPort", dstPort), zap.Error(err))
+		}()
 	}
 	// Both consumable keys missed. Before dialling the server, consult the
 	// last-greeting cache — the same fallback the V2 path uses, and the reason
@@ -945,6 +974,7 @@ func handlePostTLSRecord(ctx context.Context, logger *zap.Logger, clientConn, de
 	// 2. Decode the server greeting to initialize decode context.
 	greetingPkt, err := wire.DecodePayload(ctx, logger, serverGreetingBuf, clientConn, decodeCtx)
 	if err != nil {
+		restoreShared = false
 		return fmt.Errorf("failed to decode stored server greeting for post-TLS: %w", err)
 	}
 	pluginName, err := wire.GetPluginName(greetingPkt.Message)
@@ -957,6 +987,7 @@ func handlePostTLSRecord(ctx context.Context, logger *zap.Logger, clientConn, de
 	// Store the server greeting for the clientConn (needed by DecodePayload for command phase).
 	sg, ok := greetingPkt.Message.(*mysql.HandshakeV10Packet)
 	if !ok {
+		restoreShared = false
 		return fmt.Errorf("stored server greeting is not HandshakeV10Packet")
 	}
 	decodeCtx.ServerGreetings.Store(clientConn, sg)

--- a/pkg/agent/proxy/integrations/mysql/recorder/legacy_borrowed_timestamp_test.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/legacy_borrowed_timestamp_test.go
@@ -122,3 +122,59 @@ func TestLegacyPostTLS_BorrowedGreetingDoesNotBackdateTheConfigMock(t *testing.T
 			"(between %s and now)", got.Format(time.RFC3339Nano), t0.Format(time.RFC3339Nano))
 	}
 }
+
+// The legacy post-TLS reader draws from the same port-only FIFO the V2 path
+// does, and an empty ConnKey collapses its conn-specific key onto that shared
+// key — so its FIRST PopWait consumes a queue every other post-TLS stream to
+// this port is competing for. Popping is destructive: a stream that takes a
+// greeting and then fails has starved the connection that pushed it, which
+// loses its whole command phase with nothing logged. The entry must go back,
+// and without its ReqTimestamp (to the next consumer it is a borrowed entry —
+// see TestLegacyPostTLS_BorrowedGreetingDoesNotBackdateTheConfigMock).
+func TestLegacyPostTLS_RestoresUnusedSharedGreeting(t *testing.T) {
+	store := models.NewTLSHandshakeStore()
+	ctx := context.WithValue(postTLSCtxWithStore(store),
+		models.ClientConnectionIDKey, "restore-shared-conn")
+	mocks := make(chan *models.Mock, 16)
+	mgr := syncMock.New(zap.NewNop())
+	mgr.SetOutputChannel(mocks)
+	ctx = syncMock.NewContext(ctx, mgr)
+
+	portKey := models.HandshakeStoreKey("", 3306)
+	origTs := time.Now().Add(-time.Minute)
+	store.Push(portKey, models.TLSHandshakeEntry{
+		RespPackets:  [][]byte{cannedHandshakeV10(t)},
+		ReqPackets:   [][]byte{cannedSSLRequest(t, 1)},
+		ReqTimestamp: origTs,
+	})
+
+	// Client closed before any post-TLS packet arrives: the greeting is popped
+	// and decoded, then the first-client-packet read fails. That is the measured
+	// production shape — a stream whose own bytes never arrive.
+	clientConn, peer := net.Pipe()
+	_ = peer.Close()
+	defer func() { _ = clientConn.Close() }()
+	destConn, destPeer := net.Pipe()
+	_ = destPeer.Close()
+	defer func() { _ = destConn.Close() }()
+
+	// ConnKey empty ⇒ storeKey == portKey ⇒ the pop reads the SHARED FIFO.
+	opts := models.OutgoingOptions{
+		DstCfg:  &models.ConditionalDstCfg{Addr: "127.0.0.1:1", Port: 3306, AddrFabricated: true},
+		ConnKey: "",
+	}
+	if err := handlePostTLSRecord(ctx, zap.NewNop(), clientConn, destConn, mocks,
+		buildPostHandshakeDecodeCtx(clientConn), opts); err == nil {
+		t.Fatal("expected the legacy post-TLS record to fail with no client packet")
+	}
+
+	restored, ok := store.PopWait(portKey, 0)
+	if !ok {
+		t.Fatal("a greeting consumed by a FAILED legacy post-TLS attempt was never returned to the " +
+			"shared port FIFO; the connection it belonged to is starved")
+	}
+	if !restored.ReqTimestamp.IsZero() {
+		t.Fatalf("restored entry kept ReqTimestamp %v; it would backdate the next connection's config mock",
+			restored.ReqTimestamp)
+	}
+}

--- a/pkg/agent/proxy/integrations/mysql/recorder/legacy_borrowed_timestamp_test.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/legacy_borrowed_timestamp_test.go
@@ -3,6 +3,7 @@ package recorder
 import (
 	"context"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -176,5 +177,102 @@ func TestLegacyPostTLS_RestoresUnusedSharedGreeting(t *testing.T) {
 	if !restored.ReqTimestamp.IsZero() {
 		t.Fatalf("restored entry kept ReqTimestamp %v; it would backdate the next connection's config mock",
 			restored.ReqTimestamp)
+	}
+}
+
+// A greeting this connection USED must never go back. handlePostTLSRecord emits
+// its own mocks and then returns handleClientQueries, which returns non-nil at
+// ordinary teardown (ctx cancellation) — so "err != nil" does NOT mean "no mock
+// was produced". Restoring on that basis republishes a spent greeting and lets
+// another stream stitch a duplicate config mock from it.
+func TestLegacyPostTLS_DoesNotRestoreAGreetingItAlreadyUsed(t *testing.T) {
+	store := models.NewTLSHandshakeStore()
+	ctx := context.WithValue(postTLSCtxWithStore(store),
+		models.ClientConnectionIDKey, "used-greeting-conn")
+	mocks := make(chan *models.Mock, 16)
+	mgr := syncMock.New(zap.NewNop())
+	mgr.SetOutputChannel(mocks)
+	ctx = syncMock.NewContext(ctx, mgr)
+	// Teardown while the command phase is live — the normal end of a recorded
+	// connection, and the case that makes err != nil despite a mock existing.
+	ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+
+	portKey := models.HandshakeStoreKey("", 3306)
+	store.Push(portKey, models.TLSHandshakeEntry{
+		RespPackets:  [][]byte{cannedHandshakeV10(t)},
+		ReqPackets:   [][]byte{cannedSSLRequest(t, 1)},
+		ReqTimestamp: time.Now(),
+	})
+
+	clientConn, peer := net.Pipe()
+	defer func() { _ = clientConn.Close() }()
+	destConn, destPeer := net.Pipe()
+	defer func() { _ = destConn.Close() }()
+	_ = destPeer.Close()
+
+	// seq==0 takes the already-authenticated branch, which records the synthetic
+	// config mock built FROM the popped greeting — i.e. the greeting is spent.
+	go func() {
+		_, _ = peer.Write(cannedCOMQuery(t, 0, "SELECT 1"))
+	}()
+
+	_ = handlePostTLSRecord(ctx, zap.NewNop(), clientConn, destConn, mocks,
+		buildPostHandshakeDecodeCtx(clientConn), models.OutgoingOptions{
+			DstCfg:  &models.ConditionalDstCfg{Addr: "127.0.0.1:1", Port: 3306, AddrFabricated: true},
+			ConnKey: "",
+		})
+
+	if _, ok := store.PopWait(portKey, 0); ok {
+		t.Fatal("a greeting that was already used to build a config mock was pushed back into the " +
+			"shared FIFO; another stream would stitch a duplicate config mock from it")
+	}
+}
+
+// A greeting that DECODES but is not a HandshakeV10 must not be recycled either.
+// GetPluginName rejects it before the HandshakeV10 assertion, so that error path
+// needs its own guard; Push re-stamps the expiry, so a recycled entry would
+// never age out and would trip every later stream to this port.
+func TestLegacyPostTLS_DoesNotRecycleDecodableNonHandshakeGreeting(t *testing.T) {
+	store := models.NewTLSHandshakeStore()
+	ctx := context.WithValue(postTLSCtxWithStore(store),
+		models.ClientConnectionIDKey, "non-handshake-conn")
+	mocks := make(chan *models.Mock, 16)
+	mgr := syncMock.New(zap.NewNop())
+	mgr.SetOutputChannel(mocks)
+	ctx = syncMock.NewContext(ctx, mgr)
+
+	portKey := models.HandshakeStoreKey("", 3306)
+	// Decodes cleanly, but it is an OK packet, not a handshake. The capability
+	// flags must be REAL: with 0 the packet is too short to decode and the test
+	// would stop at the decode guard instead of reaching GetPluginName, which is
+	// the path under test.
+	store.Push(portKey, models.TLSHandshakeEntry{
+		RespPackets: [][]byte{cannedOK(t, 1, 0x000FA68D)},
+	})
+
+	clientConn, peer := net.Pipe()
+	_ = peer.Close()
+	defer func() { _ = clientConn.Close() }()
+	destConn, destPeer := net.Pipe()
+	_ = destPeer.Close()
+	defer func() { _ = destConn.Close() }()
+
+	err := handlePostTLSRecord(ctx, zap.NewNop(), clientConn, destConn, mocks,
+		buildPostHandshakeDecodeCtx(clientConn), models.OutgoingOptions{
+			DstCfg:  &models.ConditionalDstCfg{Addr: "127.0.0.1:1", Port: 3306, AddrFabricated: true},
+			ConnKey: "",
+		})
+	if err == nil {
+		t.Fatal("expected a non-handshake greeting to fail the legacy post-TLS record")
+	}
+	// Pin the path: it must fail at GetPluginName, which runs BEFORE the
+	// HandshakeV10 assertion and therefore needs its own guard.
+	if !strings.Contains(err.Error(), "get plugin name") {
+		t.Fatalf("failed on a different path (%v); this test must exercise GetPluginName", err)
+	}
+	if _, ok := store.PopWait(portKey, 0); ok {
+		t.Fatal("a decodable non-handshake greeting was recycled into the shared FIFO; Push re-stamps " +
+			"its expiry so it would never age out and would trip every later stream to this port")
 	}
 }

--- a/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
@@ -405,8 +405,8 @@ func handleInitialHandshakeV2(ctx context.Context, logger *zap.Logger, sess *sup
 // the command phase to V2's structured per-direction reader (which reads the
 // client command then the server response in wire order, so it needs neither
 // the legacy path's ktime relay-merge nor its res>=req timestamp clamp).
-func handlePostTLSHandshakeV2(ctx context.Context, logger *zap.Logger, sess *supervisor.Session, decodeCtx *wire.DecodeContext, clientKeyPtr *net.Conn) (v2HandshakeResult, error) {
-	res := v2HandshakeResult{
+func handlePostTLSHandshakeV2(ctx context.Context, logger *zap.Logger, sess *supervisor.Session, decodeCtx *wire.DecodeContext, clientKeyPtr *net.Conn) (res v2HandshakeResult, err error) {
+	res = v2HandshakeResult{
 		req:  make([]mysql.Request, 0),
 		resp: make([]mysql.Response, 0),
 	}
@@ -435,10 +435,63 @@ func handlePostTLSHandshakeV2(ctx context.Context, logger *zap.Logger, sess *sup
 	// post-TLS bytes are buffered on ClientStream and read only after this
 	// returns.
 	entry, source := resolvePreTLSGreeting(ctx, hsStore, sess.Opts.ConnKey, dstPort, sess.Opts.PassThroughScope, sess.Opts.DstCfg)
+	// A greetingShared entry came off the port-only FIFO, which is shared by
+	// every decrypted stream to this port — in proxyless that FIFO is the ONLY
+	// key that bridges the raw and decrypted legs, so all of them draw from it.
+	// Popping is destructive. If this stream then fails before producing a mock
+	// (the common case being a decrypted stream whose own bytes never arrive, so
+	// the first-client-packet read returns EOF), the greeting it consumed is
+	// gone and a LIVE connection that needed it is starved — silent decode loss,
+	// which is what made this a "served but not recorded" shortfall rather than
+	// an error. Put an unused entry back so the rightful owner still gets it;
+	// Push broadcasts the store's cond, so a sibling already blocked in
+	// resolvePreTLSGreeting wakes immediately.
+	//
+	// Restore-if-UNUSED, not restore-if-error: the direct-fetch branch below
+	// discards a payload-less entry and can then SUCCEED, which must still give
+	// the entry back. sharedAdopted tracks that directly.
+	//
+	// The restored entry is stripped of ReqTimestamp. Push re-stamps pushedAt,
+	// so a restored entry is rejuvenated rather than expiring, and it comes back
+	// as greetingShared — for which staleEntry is false — so keeping the
+	// timestamp would stamp a DEAD connection's capture time onto a live
+	// connection's config mock. Config mocks are identified by Name+Kind+
+	// ReqTimestampMock (treedb.sameMock) and ordered by it, so that is a replay
+	// break, and it is the same hazard conn.go already documents for the legacy
+	// borrowed greeting. A zero ReqTimestamp makes the next consumer sample its
+	// own first client read, which is exactly what the direct-fetch path does.
+	sharedAdopted := false
+	sharedUndecodable := false
+	if source == greetingShared {
+		sharedKey := models.HandshakeStoreKey("", dstPort)
+		sharedEntry := entry
+		sharedEntry.ReqTimestamp = time.Time{}
+		defer func() {
+			// Kept only when this stream both adopted the entry AND produced a
+			// mock from it. Anything else — never adopted (direct-fetch branch),
+			// or adopted then failed — leaves a live connection starved.
+			if sharedAdopted && err == nil {
+				return
+			}
+			// An entry whose greeting does not decode is garbage, and Push
+			// re-stamps pushedAt, so putting it back would make it immortal and
+			// trip every later stream to this port. Drop it — the connection it
+			// belonged to could not have used it either.
+			if sharedUndecodable {
+				return
+			}
+			hsStore.Push(sharedKey, sharedEntry)
+			logger.Debug("post-TLS V2: returned an unused shared greeting to the port FIFO",
+				zap.Uint16("dstPort", dstPort), zap.Error(err))
+		}()
+	}
 	staleEntry := source == greetingCached
 	var greetingBuf []byte
 	if source != greetingNone && len(entry.RespPackets) > 0 {
 		greetingBuf = entry.RespPackets[0]
+		// Adopted: this stream owns the entry from here. It goes back only if
+		// the stream fails before producing a mock (the defer above).
+		sharedAdopted = true
 		if staleEntry {
 			// The raw leg was genuinely lost (its capture event dropped by a
 			// full ringbuf, or delayed past the store TTL). Greetings for the
@@ -483,10 +536,12 @@ func handlePostTLSHandshakeV2(ctx context.Context, logger *zap.Logger, sess *sup
 	// 2. Decode the greeting and seed the decode context (mirrors legacy).
 	greetingPkt, err := wire.DecodePayload(ctx, logger, greetingBuf, clientKey, decodeCtx)
 	if err != nil {
+		sharedUndecodable = true
 		return res, fmt.Errorf("post-TLS V2: decode stored greeting: %w", err)
 	}
 	sg, isHS := greetingPkt.Message.(*mysql.HandshakeV10Packet)
 	if !isHS {
+		sharedUndecodable = true
 		return res, fmt.Errorf("post-TLS V2: stored greeting is not HandshakeV10")
 	}
 	decodeCtx.ServerCaps = sg.CapabilityFlags
@@ -896,10 +951,20 @@ const (
 	// greetingNone: nothing available within the bounds — the caller must fetch
 	// the greeting directly or abort cleanly.
 	greetingNone preTLSGreetingSource = iota
-	// greetingOwn: this connection's own raw-leg stash (or, in the empty-connKey
-	// proxyless case, the port FIFO entry that bridges the two legs). Carries the
-	// real per-connection salt + request timestamp.
+	// greetingOwn: this connection's own raw-leg stash, found under the
+	// conn-specific key. Carries the real per-connection salt + request timestamp.
 	greetingOwn
+	// greetingShared: an entry taken from the port-only FIFO (e.g. "port:3306").
+	// That queue is CROSS-CONNECTION: in proxyless the raw and decrypted legs are
+	// different TCP connections, so this is the only key that bridges them, but
+	// the entry popped is not necessarily the one this connection's own raw leg
+	// pushed. Consuming it is destructive — every other decrypted stream waiting
+	// on that port is competing for the same FIFO — so a caller that fails before
+	// producing a mock MUST put it back (handlePostTLSHandshakeV2 does, via a
+	// defer on sharedAdopted). Otherwise a
+	// stream that pops one and then errors silently starves a live connection of
+	// the greeting it needed, which is decode loss with no diagnostic.
+	greetingShared
 	// greetingCached: another connection's most-recent greeting for the port,
 	// from the non-consuming last-greeting cache. Reusable for stitching
 	// (capabilities/plugin are per-server; the salt is never verified — see
@@ -975,16 +1040,24 @@ func resolvePreTLSGreeting(ctx context.Context, hsStore *models.TLSHandshakeStor
 
 	// popOwn returns this connection's own stashed entry (either key), if
 	// present, without blocking.
-	popOwn := func() (models.TLSHandshakeEntry, bool) {
+	popOwn := func() (models.TLSHandshakeEntry, preTLSGreetingSource) {
 		if entry, ok := hsStore.PopWait(connSpecificKey, 0); ok {
-			return entry, true
+			// An empty connKey (the proxyless decrypted stream, which cannot know
+			// the raw leg's connection identity) collapses the conn-specific key
+			// onto the port-only key. The entry then came off the SHARED FIFO
+			// even though this branch read it, so it must be classified — and
+			// restored on failure — as shared.
+			if connSpecificKey == portKey {
+				return entry, greetingShared
+			}
+			return entry, greetingOwn
 		}
 		if portKey != connSpecificKey {
 			if entry, ok := hsStore.PopWait(portKey, 0); ok {
-				return entry, true
+				return entry, greetingShared
 			}
 		}
-		return models.TLSHandshakeEntry{}, false
+		return models.TLSHandshakeEntry{}, greetingNone
 	}
 	// cachedGreeting returns the port's last-greeting cache entry, if usable.
 	cachedGreeting := func() (models.TLSHandshakeEntry, bool) {
@@ -1031,8 +1104,8 @@ func resolvePreTLSGreeting(ctx context.Context, hsStore *models.TLSHandshakeStor
 
 	for {
 		// 1. This connection's own entry is always preferred.
-		if entry, ok := popOwn(); ok {
-			return entry, greetingOwn
+		if entry, src := popOwn(); src != greetingNone {
+			return entry, src
 		}
 		now := time.Now()
 		// 2. Past the primary bound, a cached greeting is good enough — take it
@@ -1063,7 +1136,7 @@ func resolvePreTLSGreeting(ctx context.Context, hsStore *models.TLSHandshakeStor
 			continue
 		}
 		if entry, ok := hsStore.PopWait(portKey, slice); ok {
-			return entry, greetingOwn
+			return entry, greetingShared
 		}
 	}
 

--- a/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
@@ -477,7 +477,11 @@ func handlePostTLSHandshakeV2(ctx context.Context, logger *zap.Logger, sess *sup
 			// re-stamps pushedAt, so putting it back would make it immortal and
 			// trip every later stream to this port. Drop it — the connection it
 			// belonged to could not have used it either.
-			if sharedUndecodable {
+			// Only when the failure was THIS entry's own greeting. On the
+			// direct-fetch branch the buffer that failed to decode is the
+			// FETCHED greeting, not the shared entry, so dropping it on that
+			// basis would discard an untouched entry someone else needs.
+			if sharedAdopted && sharedUndecodable {
 				return
 			}
 			hsStore.Push(sharedKey, sharedEntry)

--- a/pkg/agent/proxy/integrations/mysql/recorder/record_v2_test.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record_v2_test.go
@@ -10,6 +10,7 @@ import (
 
 	"go.keploy.io/server/v3/pkg/models/mysql"
 
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/wire"
 	connphase "go.keploy.io/server/v3/pkg/agent/proxy/integrations/mysql/wire/phase/conn"
 	"go.keploy.io/server/v3/pkg/models"
 	"go.uber.org/zap"
@@ -328,7 +329,15 @@ func TestResolvePreTLSGreeting_DroppedLegHitsCacheAtPrimaryBound(t *testing.T) {
 // TestResolvePreTLSGreeting_OwnLatePreferredOverCache pins that a merely-late
 // own leg arriving within the primary bound is preferred over the cache (it
 // carries this connection's real salt+timestamp): with the cache populated but
-// the own entry pushed shortly after start, resolve must return greetingOwn.
+// the own entry pushed shortly after start, resolve must take the stashed entry
+// rather than the cache.
+//
+// The connKey here is "" — the proxyless decrypted stream, which cannot know the
+// raw leg's connection identity — so the conn-specific key collapses onto the
+// port-only key and the entry necessarily comes off the SHARED port FIFO.
+// greetingShared is therefore the correct classification; what this test pins is
+// that the stashed entry (with its real timestamp) beats the cache, not which of
+// the two stash keys it arrived under.
 func TestResolvePreTLSGreeting_OwnLatePreferredOverCache(t *testing.T) {
 	t.Setenv("KEPLOY_MYSQL_POSTTLS_STASH_PRIMARY_MS", "3000")
 
@@ -347,8 +356,8 @@ func TestResolvePreTLSGreeting_OwnLatePreferredOverCache(t *testing.T) {
 	}()
 
 	entry, source := resolvePreTLSGreeting(context.Background(), store, "", 3306, "", testDst("10.0.0.5:3306"))
-	if source != greetingOwn {
-		t.Fatalf("source = %v, want greetingOwn (a late own leg within the primary bound beats the cache)", source)
+	if source != greetingShared {
+		t.Fatalf("source = %v, want greetingShared (a late own leg within the primary bound beats the cache)", source)
 	}
 	if !entry.ReqTimestamp.Equal(ownTs) {
 		t.Errorf("ReqTimestamp = %v, want the own leg's %v", entry.ReqTimestamp, ownTs)
@@ -992,5 +1001,177 @@ func TestLegacyPostTLSUsesTheLastGreetingCacheInsteadOfDialling(t *testing.T) {
 	// reach the first client read and end there, because the peer is closed.
 	if err == nil || !strings.Contains(err.Error(), "first post-TLS client packet") {
 		t.Fatalf("expected the flow to consume the cached greeting and stop at the first client read, got: %v", err)
+	}
+}
+
+// The port-only FIFO ("port:3306") is CROSS-CONNECTION: in proxyless the raw and
+// decrypted legs are different TCP connections, so every decrypted stream to that
+// port draws from the same queue. Popping is destructive, so a stream that takes
+// a greeting and then fails has consumed a live connection's greeting and
+// produced nothing — silent decode loss, which is what made the
+// e2e-mysql-tls-lowlatency-cycle shortfall "served but NOT recorded" rather than
+// an error. An unused entry must go back.
+func TestPostTLSHandshakeV2_RestoresUnusedSharedGreeting(t *testing.T) {
+	h := newV2Harness(t)
+	base := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+
+	store := models.NewTLSHandshakeStore()
+	portKey := models.HandshakeStoreKey("", 3306)
+	store.Push(portKey, models.TLSHandshakeEntry{
+		RespPackets:  [][]byte{cannedHandshakeV10(t)},
+		ReqPackets:   [][]byte{cannedSSLRequest(t, 1)},
+		ReqTimestamp: base,
+	})
+
+	// This decrypted stream's own bytes never arrive — the connection completed
+	// and closed before its parser was wired. That is the measured failure: the
+	// first-client-packet read returns EOF after the greeting has been popped.
+	h.closeStreams()
+
+	decodeCtx := &wire.DecodeContext{
+		Mode:               models.MODE_RECORD,
+		LastOp:             wire.NewLastOpMap(),
+		ServerGreetings:    wire.NewGreetings(),
+		PreparedStatements: make(map[uint32]*mysql.StmtPrepareOkPacket),
+	}
+	var clientKey net.Conn = h.sess.ClientStream
+
+	if _, err := handlePostTLSHandshakeV2(postTLSCtxWithStore(store), h.logger, h.sess, decodeCtx, &clientKey); err == nil {
+		t.Fatal("expected the post-TLS handshake to fail when the client stream is already closed")
+	}
+
+	// The greeting must still be available to the connection that actually needs
+	// it. Without the restore it was consumed and gone, and a live MySQL
+	// connection lost its command phase with nothing logged.
+	if _, ok := store.PopWait(portKey, 0); !ok {
+		t.Fatal("a greeting consumed by a FAILED post-TLS attempt was never returned to the shared " +
+			"port FIFO; the connection it belonged to is starved and its queries go unrecorded")
+	}
+}
+
+// The mirror case: a greeting this connection legitimately consumed and USED
+// must NOT be pushed back, or a later stream would stitch a duplicate.
+func TestPostTLSHandshakeV2_KeepsSharedGreetingOnSuccess(t *testing.T) {
+	h := newV2Harness(t)
+	base := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+
+	handshakeBuf := cannedHandshakeV10(t)
+	greeting, err := connphase.DecodeHandshakeV10(context.Background(), zap.NewNop(), handshakeBuf[4:])
+	if err != nil {
+		t.Fatalf("decode handshake v10: %v", err)
+	}
+
+	store := models.NewTLSHandshakeStore()
+	portKey := models.HandshakeStoreKey("", 3306)
+	store.Push(portKey, models.TLSHandshakeEntry{
+		RespPackets:  [][]byte{handshakeBuf},
+		ReqPackets:   [][]byte{cannedSSLRequest(t, 1)},
+		ReqTimestamp: base,
+	})
+
+	h.pushClient(cannedHandshakeResponse41(t, 2, false), base.Add(5*time.Millisecond))
+	h.pushDest(cannedOK(t, 3, greeting.CapabilityFlags), base.Add(10*time.Millisecond))
+
+	decodeCtx := &wire.DecodeContext{
+		Mode:               models.MODE_RECORD,
+		LastOp:             wire.NewLastOpMap(),
+		ServerGreetings:    wire.NewGreetings(),
+		PreparedStatements: make(map[uint32]*mysql.StmtPrepareOkPacket),
+	}
+	var clientKey net.Conn = h.sess.ClientStream
+
+	if _, err := handlePostTLSHandshakeV2(postTLSCtxWithStore(store), h.logger, h.sess, decodeCtx, &clientKey); err != nil {
+		t.Fatalf("post-TLS handshake failed unexpectedly: %v", err)
+	}
+	if _, ok := store.PopWait(portKey, 0); ok {
+		t.Fatal("a greeting that WAS used got pushed back; a later stream would stitch it a second time")
+	}
+}
+
+// A conn-specific entry is this connection's OWN. It must classify as
+// greetingOwn and must never be recycled — restoring it would hand one
+// connection's greeting to another. Without this, every direct
+// resolvePreTLSGreeting test passes connKey=="" and the own-key branch is
+// entirely uncovered.
+func TestResolvePreTLSGreeting_ConnKeyedEntryIsOwnNotShared(t *testing.T) {
+	store := models.NewTLSHandshakeStore()
+	store.Push(models.HandshakeStoreKey("conn-A", 3306), models.TLSHandshakeEntry{
+		RespPackets: [][]byte{[]byte("greeting")},
+	})
+
+	entry, source := resolvePreTLSGreeting(context.Background(), store, "conn-A", 3306, "", testDst("10.0.0.5:3306"))
+	if source != greetingOwn {
+		t.Fatalf("source = %v, want greetingOwn for an entry under the conn-specific key", source)
+	}
+	if len(entry.RespPackets) != 1 {
+		t.Fatalf("own entry not returned: %+v", entry)
+	}
+}
+
+// A restored greeting is, for whatever connection picks it up next, a BORROWED
+// entry from a dead connection. Push re-stamps the store's own expiry, so the
+// entry does not age out; if it also carried its original ReqTimestamp it would
+// backdate the next connection's config mock. Config mocks are identified by
+// Name+Kind+ReqTimestampMock and ordered by it, so that is a replay break — the
+// same hazard the legacy path documents for borrowed greetings.
+func TestPostTLSHandshakeV2_RestoredGreetingCarriesNoTimestamp(t *testing.T) {
+	h := newV2Harness(t)
+	base := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+
+	store := models.NewTLSHandshakeStore()
+	portKey := models.HandshakeStoreKey("", 3306)
+	store.Push(portKey, models.TLSHandshakeEntry{
+		RespPackets:  [][]byte{cannedHandshakeV10(t)},
+		ReqPackets:   [][]byte{cannedSSLRequest(t, 1)},
+		ReqTimestamp: base,
+	})
+	h.closeStreams()
+
+	decodeCtx := &wire.DecodeContext{
+		Mode:               models.MODE_RECORD,
+		LastOp:             wire.NewLastOpMap(),
+		ServerGreetings:    wire.NewGreetings(),
+		PreparedStatements: make(map[uint32]*mysql.StmtPrepareOkPacket),
+	}
+	var clientKey net.Conn = h.sess.ClientStream
+	if _, err := handlePostTLSHandshakeV2(postTLSCtxWithStore(store), h.logger, h.sess, decodeCtx, &clientKey); err == nil {
+		t.Fatal("expected the post-TLS handshake to fail")
+	}
+
+	restored, ok := store.PopWait(portKey, 0)
+	if !ok {
+		t.Fatal("greeting was not restored")
+	}
+	if !restored.ReqTimestamp.IsZero() {
+		t.Fatalf("restored entry kept ReqTimestamp %v; it would backdate the next connection's config mock",
+			restored.ReqTimestamp)
+	}
+}
+
+// An entry whose greeting cannot decode is garbage. Restoring it would be worse
+// than dropping it: Push re-stamps the expiry, so it would never age out and
+// would trip every later decrypted stream to this port.
+func TestPostTLSHandshakeV2_DoesNotRecycleUndecodableGreeting(t *testing.T) {
+	h := newV2Harness(t)
+
+	store := models.NewTLSHandshakeStore()
+	portKey := models.HandshakeStoreKey("", 3306)
+	store.Push(portKey, models.TLSHandshakeEntry{
+		RespPackets: [][]byte{{0x01, 0x00, 0x00, 0x00, 0xff}}, // not a HandshakeV10
+	})
+
+	decodeCtx := &wire.DecodeContext{
+		Mode:               models.MODE_RECORD,
+		LastOp:             wire.NewLastOpMap(),
+		ServerGreetings:    wire.NewGreetings(),
+		PreparedStatements: make(map[uint32]*mysql.StmtPrepareOkPacket),
+	}
+	var clientKey net.Conn = h.sess.ClientStream
+	if _, err := handlePostTLSHandshakeV2(postTLSCtxWithStore(store), h.logger, h.sess, decodeCtx, &clientKey); err == nil {
+		t.Fatal("expected an undecodable greeting to fail the handshake")
+	}
+	if _, ok := store.PopWait(portKey, 0); ok {
+		t.Fatal("an undecodable greeting was put back into the shared FIFO; Push re-stamps its expiry so it " +
+			"would never age out and would trip every later stream to this port")
 	}
 }

--- a/pkg/agent/proxy/integrations/mysql/recorder/record_v2_test.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record_v2_test.go
@@ -1036,8 +1036,16 @@ func TestPostTLSHandshakeV2_RestoresUnusedSharedGreeting(t *testing.T) {
 	}
 	var clientKey net.Conn = h.sess.ClientStream
 
-	if _, err := handlePostTLSHandshakeV2(postTLSCtxWithStore(store), h.logger, h.sess, decodeCtx, &clientKey); err == nil {
+	_, err := handlePostTLSHandshakeV2(postTLSCtxWithStore(store), h.logger, h.sess, decodeCtx, &clientKey)
+	if err == nil {
 		t.Fatal("expected the post-TLS handshake to fail when the client stream is already closed")
+	}
+	// Pin WHICH failure: the greeting must have been popped and decoded, and the
+	// stream must have died on the first client packet. Any earlier error would
+	// leave the entry unconsumed and make the restore assertion vacuous.
+	if !strings.Contains(err.Error(), "read first client packet") {
+		t.Fatalf("failed before consuming the greeting (%v); this test must exercise the "+
+			"first-client-packet path or it proves nothing", err)
 	}
 
 	// The greeting must still be available to the connection that actually needs

--- a/pkg/models/tls_handshake_store.go
+++ b/pkg/models/tls_handshake_store.go
@@ -481,9 +481,13 @@ func (s *TLSHandshakeStore) Push(key string, entry TLSHandshakeEntry) {
 	s.pruneExpiredLocked(time.Now())
 	q := s.m[key]
 	if len(q) >= tlsHandshakeMaxQueuePerKey {
+		// Drop the oldest. This MUST append to the trimmed q, not to s.m[key]:
+		// appending to the untrimmed slice discarded the trim entirely and the
+		// cap never applied, so a key with a producer and no matching consumer
+		// grew without bound.
 		q = q[1:]
 	}
-	s.m[key] = append(s.m[key], timedTLSHandshakeEntry{
+	s.m[key] = append(q, timedTLSHandshakeEntry{
 		entry:    entry,
 		pushedAt: time.Now(),
 	})

--- a/pkg/models/tls_handshake_store_test.go
+++ b/pkg/models/tls_handshake_store_test.go
@@ -696,3 +696,31 @@ func TestIdentityRecordsExpireEventually(t *testing.T) {
 			"would stay dead for the agent's lifetime")
 	}
 }
+
+// tlsHandshakeMaxQueuePerKey must actually bound a key's queue. The trim used
+// to be computed into a local and then discarded by appending to the untrimmed
+// slice, so the cap never applied and a key with a producer but no matching
+// consumer grew without bound.
+func TestTLSHandshakeStore_PushBoundsQueuePerKey(t *testing.T) {
+	store := NewTLSHandshakeStore()
+	const key = "port:3306"
+
+	for i := 0; i < tlsHandshakeMaxQueuePerKey+50; i++ {
+		store.Push(key, TLSHandshakeEntry{RespPackets: [][]byte{{byte(i)}}})
+	}
+
+	drained := 0
+	for {
+		if _, ok := store.PopWait(key, 0); !ok {
+			break
+		}
+		drained++
+		if drained > tlsHandshakeMaxQueuePerKey*4 {
+			t.Fatalf("queue never drained; it is unbounded (drained %d)", drained)
+		}
+	}
+	if drained > tlsHandshakeMaxQueuePerKey {
+		t.Fatalf("queue held %d entries, want at most tlsHandshakeMaxQueuePerKey=%d",
+			drained, tlsHandshakeMaxQueuePerKey)
+	}
+}

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -2950,18 +2950,70 @@ func FilterTcsMocksMapping(ctx context.Context, logger *zap.Logger, m []*models.
 	return filteredMocks
 }
 
-func FilterConfigMocksMapping(ctx context.Context, logger *zap.Logger, m []*models.Mock, mocksPresentInMapping []string) []*models.Mock {
-	filteredMocks, unfilteredMocks := filterByMapping(ctx, logger, m, mocksPresentInMapping)
+// FilterConfigMocksMapping tags the reusable (config/session/connection) pool
+// with its mapping membership and returns it in RECORDED order.
+//
+// Mapping membership is not a chronological signal and must not reorder this
+// pool. Its members are reusable tier — none is owned by a single test — so
+// membership only records which tests happened to consume a mock, and says
+// nothing about when it was recorded. Partitioning on it and concatenating
+// (mapped first, then unmapped) puts every consumed entry ahead of every
+// unconsumed one, inverting chronology whenever the two interleave: a pool
+// recorded rev1,rev2,rev3,rev4 with rev3,rev4 consumed came back as
+// rev3,rev4,rev1,rev2.
+//
+// That matters because downstream reads this pool as a SEQUENCE, not a set. The
+// slice order becomes TestModeInfo.SortOrder in MockManager.setUnFilteredMocks,
+// which keys the RB-tree that GetUnFilteredMocksByKind walks in order — so a
+// replayer that walks a recorded revision sequence (a cluster-config poll, a
+// bootstrap handshake) is handed it backwards.
+//
+// The tagging is done IN PLACE over m rather than by partitioning, so entries
+// with equal ReqTimestampMock keep their recorded order under the stable sort.
+// Partition-then-sort left ties in mapped-first order — the very inversion this
+// removes — and ties are not rare: a protocol encoder that drains several frames
+// from one TCP read stamps them all with that chunk's timestamp (see
+// mysql/recorder/record_v2.go, where ReqTimestampMock is the ReadAt of the chunk
+// that delivered the command bytes), which is exactly what a coalesced bootstrap
+// burst looks like. In a legacy pool carrying no timestamps at all the whole
+// slice is one tie, so the sort does nothing and the partition alone decided the
+// order — that is where the inversion was total, not absent.
+//
+// This deliberately does NOT try to reproduce FilterConfigMocksTierAware's
+// output. That path additionally applies window semantics the mapping path has
+// no equivalent of — it hoists a mock with a missing timestamp into its filtered
+// pool and drops one whose response predates its request — so the two agree only
+// on a pool where neither rule fires. The property claimed here is narrower and
+// is the one that matters: mapping membership is not a chronological signal, so
+// it must not reorder this pool.
+func FilterConfigMocksMapping(_ context.Context, logger *zap.Logger, m []*models.Mock, mocksPresentInMapping []string) []*models.Mock {
+	mapping := make(map[string]bool, len(mocksPresentInMapping))
+	for _, name := range mocksPresentInMapping {
+		mapping[name] = true
+	}
 
-	sort.SliceStable(filteredMocks, func(i, j int) bool {
-		return filteredMocks[i].Spec.ReqTimestampMock.Before(filteredMocks[j].Spec.ReqTimestampMock)
+	isNonKeploy := false
+	pool := make([]*models.Mock, 0, len(m))
+	for _, mock := range m {
+		if mock == nil {
+			continue
+		}
+		p := mock.DeepCopy()
+		if p.Version != "api.keploy.io/v1beta1" && p.Version != "api.keploy.io/v1beta2" {
+			isNonKeploy = true
+		}
+		p.TestModeInfo.IsFiltered = mapping[p.Name]
+		pool = append(pool, p)
+	}
+	if isNonKeploy {
+		logger.Debug("Few mocks in the mock File are not recorded by keploy ignoring them")
+	}
+
+	sort.SliceStable(pool, func(i, j int) bool {
+		return pool[i].Spec.ReqTimestampMock.Before(pool[j].Spec.ReqTimestampMock)
 	})
 
-	sort.SliceStable(unfilteredMocks, func(i, j int) bool {
-		return unfilteredMocks[i].Spec.ReqTimestampMock.Before(unfilteredMocks[j].Spec.ReqTimestampMock)
-	})
-
-	return append(filteredMocks, unfilteredMocks...)
+	return pool
 }
 
 // strictWindowEnvOverride holds the result of one-time env-var parsing

--- a/pkg/util_config_mock_order_test.go
+++ b/pkg/util_config_mock_order_test.go
@@ -1,0 +1,299 @@
+package pkg
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// configMockAt builds a reusable config-tier mock with DISTINCT request and
+// response timestamps, so a sort keyed on the wrong one is detectable.
+func configMockAt(name string, base time.Time, reqOffset, resOffset int) *models.Mock {
+	return &models.Mock{
+		Name:    name,
+		Version: "api.keploy.io/v1beta1",
+		Kind:    "Couchbase",
+		Spec: models.MockSpec{
+			Metadata:         map[string]string{"type": "config"},
+			ReqTimestampMock: base.Add(time.Duration(reqOffset) * time.Second),
+			ResTimestampMock: base.Add(time.Duration(resOffset) * time.Second),
+		},
+	}
+}
+
+func configMock(name string, base time.Time, offsetSec int) *models.Mock {
+	// Response deliberately ordered OPPOSITE to request, so sorting by
+	// ResTimestampMock produces a different order and cannot pass silently.
+	return configMockAt(name, base, offsetSec, 1000-offsetSec)
+}
+
+// Mapping membership must not reorder the reusable pool: it records which tests
+// consumed a mock, not when it was recorded. Downstream reads this pool as a
+// sequence (slice order -> SortOrder -> RB-tree -> in-order walk), so inverting
+// it hands an order-sensitive replayer its recorded sequence backwards.
+func TestFilterConfigMocksMapping_PreservesRecordedOrder(t *testing.T) {
+	base := time.Unix(1700000000, 0).UTC()
+	pool := []*models.Mock{
+		configMock("cfg-rev1", base, 1),
+		configMock("cfg-rev2", base, 2),
+		configMock("cfg-rev3", base, 3),
+		configMock("cfg-rev4", base, 4),
+	}
+	mapping := []string{"cfg-rev3", "cfg-rev4"}
+
+	got := FilterConfigMocksMapping(context.Background(), zap.NewNop(), pool, mapping)
+
+	want := []string{"cfg-rev1", "cfg-rev2", "cfg-rev3", "cfg-rev4"}
+	if names := mockNames(got); len(names) != len(want) {
+		t.Fatalf("config pool = %v, want %v", names, want)
+	}
+	for i, w := range want {
+		if got[i].Name != w {
+			t.Fatalf("config pool = %v, want %v", mockNames(got), want)
+		}
+	}
+}
+
+// Ties are structural, not hypothetical: an encoder that drains several frames
+// from one TCP read stamps them all with that chunk's timestamp, so a coalesced
+// bootstrap burst arrives all-equal. Under equal timestamps the pool must keep
+// its RECORDED order — a partition-then-stable-sort leaves ties in mapped-first
+// order, which is the inversion this guards against.
+func TestFilterConfigMocksMapping_EqualTimestampsKeepRecordedOrder(t *testing.T) {
+	base := time.Unix(1700000000, 0).UTC()
+	pool := []*models.Mock{
+		configMockAt("hello", base, 5, 5),
+		configMockAt("sasl-auth", base, 5, 5),
+		configMockAt("select-bucket", base, 5, 5),
+		configMockAt("cluster-config", base, 5, 5),
+	}
+	// The LAST-recorded frame is the one a test consumed.
+	mapping := []string{"cluster-config"}
+
+	got := FilterConfigMocksMapping(context.Background(), zap.NewNop(), pool, mapping)
+
+	want := []string{"hello", "sasl-auth", "select-bucket", "cluster-config"}
+	for i, w := range want {
+		if got[i].Name != w {
+			t.Fatalf("equal-timestamp pool reordered: got %v, want %v", mockNames(got), want)
+		}
+	}
+}
+
+// Legacy recordings carry no timestamps at all, so the whole pool is one tie.
+func TestFilterConfigMocksMapping_ZeroTimestampsKeepRecordedOrder(t *testing.T) {
+	mk := func(name string) *models.Mock {
+		return &models.Mock{
+			Name:    name,
+			Version: "api.keploy.io/v1beta1",
+			Spec:    models.MockSpec{Metadata: map[string]string{"type": "config"}},
+		}
+	}
+	pool := []*models.Mock{mk("hello"), mk("sasl-auth"), mk("cfg")}
+
+	got := FilterConfigMocksMapping(context.Background(), zap.NewNop(), pool, []string{"cfg"})
+
+	want := []string{"hello", "sasl-auth", "cfg"}
+	for i, w := range want {
+		if got[i].Name != w {
+			t.Fatalf("zero-timestamp pool reordered: got %v, want %v", mockNames(got), want)
+		}
+	}
+}
+
+// Mapping membership decides the IsFiltered tag and nothing else — no mock is
+// dropped, because a reusable mock no single test owns must stay in the pool.
+func TestFilterConfigMocksMapping_TagsMembershipAndKeepsEveryMock(t *testing.T) {
+	base := time.Unix(1700000000, 0).UTC()
+	pool := []*models.Mock{
+		configMock("hello", base, 1),
+		configMock("sasl-auth", base, 2),
+		configMock("select-bucket", base, 3),
+	}
+
+	got := FilterConfigMocksMapping(context.Background(), zap.NewNop(), pool, []string{"sasl-auth"})
+
+	if len(got) != 3 {
+		t.Fatalf("config pool dropped mocks: %v", mockNames(got))
+	}
+	want := map[string]bool{"hello": false, "sasl-auth": true, "select-bucket": false}
+	for _, m := range got {
+		if m.TestModeInfo.IsFiltered != want[m.Name] {
+			t.Fatalf("%s: IsFiltered = %v, want %v", m.Name, m.TestModeInfo.IsFiltered, want[m.Name])
+		}
+	}
+}
+
+// The pool must be a deep copy: callers mutate TestModeInfo (SortOrder is
+// stamped downstream), and writing through to the shared mock set is a data
+// race against every other consumer of the same mocks.
+func TestFilterConfigMocksMapping_DeepCopiesSoCallersCannotMutateInput(t *testing.T) {
+	base := time.Unix(1700000000, 0).UTC()
+	in := []*models.Mock{configMock("hello", base, 1)}
+
+	got := FilterConfigMocksMapping(context.Background(), zap.NewNop(), in, []string{"hello"})
+
+	if got[0] == in[0] {
+		t.Fatal("config pool returned the input mock by pointer; callers would mutate shared state")
+	}
+	got[0].TestModeInfo.SortOrder = 99
+	got[0].Name = "mutated"
+	if in[0].TestModeInfo.SortOrder != 0 || in[0].Name != "hello" {
+		t.Fatalf("mutating the returned pool wrote through to the input: %+v", in[0].TestModeInfo)
+	}
+	// A shallow copy shares Spec's reference fields, which is the data race the
+	// DeepCopy exists to prevent — pointer inequality alone does not catch it.
+	got[0].Spec.Metadata["type"] = "mutated"
+	if in[0].Spec.Metadata["type"] != "config" {
+		t.Fatalf("the copy shares Spec state with the input: metadata = %v", in[0].Spec.Metadata)
+	}
+}
+
+// The pool as loaded is not guaranteed to be in recorded order, so the sort is
+// what establishes it. An input already in order cannot show that.
+func TestFilterConfigMocksMapping_SortsAnOutOfOrderPool(t *testing.T) {
+	base := time.Unix(1700000000, 0).UTC()
+	pool := []*models.Mock{
+		configMock("cfg-rev3", base, 3),
+		configMock("cfg-rev1", base, 1),
+		configMock("cfg-rev4", base, 4),
+		configMock("cfg-rev2", base, 2),
+	}
+
+	got := FilterConfigMocksMapping(context.Background(), zap.NewNop(), pool, []string{"cfg-rev1"})
+
+	want := []string{"cfg-rev1", "cfg-rev2", "cfg-rev3", "cfg-rev4"}
+	for i, w := range want {
+		if got[i].Name != w {
+			t.Fatalf("out-of-order pool was not sorted into recorded order: got %v, want %v", mockNames(got), want)
+		}
+	}
+}
+
+// A nil entry in the pool must be skipped, not dereferenced or propagated —
+// a nil reaching the RB-tree stamp downstream panics.
+func TestFilterConfigMocksMapping_SkipsNilMocks(t *testing.T) {
+	base := time.Unix(1700000000, 0).UTC()
+	pool := []*models.Mock{
+		configMock("hello", base, 1),
+		nil,
+		configMock("cfg", base, 2),
+	}
+
+	got := FilterConfigMocksMapping(context.Background(), zap.NewNop(), pool, nil)
+
+	if len(got) != 2 {
+		t.Fatalf("nil mock not skipped: got %d entries %v", len(got), mockNames(got))
+	}
+	for _, m := range got {
+		if m == nil {
+			t.Fatal("nil mock propagated into the config pool")
+		}
+	}
+}
+
+// Tie order must survive a pool whose chunks arrive INTERLEAVED, which is what
+// the loader actually hands over — mocks are not pre-grouped by timestamp. The
+// sort has to do two things at once: order the chunks, and keep each chunk's
+// frames in the order they were recorded. An unstable sort silently scrambles
+// the second (an already-grouped input would hide it, because pdqsort
+// short-circuits on sorted input).
+func TestFilterConfigMocksMapping_InterleavedChunkTiesKeepRecordedOrder(t *testing.T) {
+	base := time.Unix(1700000000, 0).UTC()
+	const chunks, perChunk = 8, 8
+
+	// Input round-robins across chunks: c0f0, c1f0, ... c7f0, c0f1, c1f1, ...
+	var pool []*models.Mock
+	var mapping []string
+	for f := 0; f < perChunk; f++ {
+		for c := 0; c < chunks; c++ {
+			name := fmt.Sprintf("chunk%d-frame%d", c, f)
+			pool = append(pool, configMockAt(name, base, c, c))
+			if f%2 == 0 {
+				mapping = append(mapping, name)
+			}
+		}
+	}
+
+	// Expected: chunks in timestamp order, frames within a chunk in recorded order.
+	var want []string
+	for c := 0; c < chunks; c++ {
+		for f := 0; f < perChunk; f++ {
+			want = append(want, fmt.Sprintf("chunk%d-frame%d", c, f))
+		}
+	}
+
+	got := FilterConfigMocksMapping(context.Background(), zap.NewNop(), pool, mapping)
+
+	if len(got) != len(want) {
+		t.Fatalf("pool size changed: got %d want %d", len(got), len(want))
+	}
+	for i, w := range want {
+		if got[i].Name != w {
+			t.Fatalf("interleaved chunk ties reordered at index %d: got %s, want %s\n got=%v", i, got[i].Name, w, mockNames(got))
+		}
+	}
+}
+
+// The pool must not be partitioned by ANY attribute — mapping membership was
+// the defect found, but partitioning on Lifetime or Kind would reorder a
+// recorded sequence exactly the same way. This pins the general rule: recorded
+// order in, recorded order out, whatever the mocks differ by.
+func TestFilterConfigMocksMapping_DoesNotPartitionByLifetimeOrKind(t *testing.T) {
+	base := time.Unix(1700000000, 0).UTC()
+	lifetimes := []models.Lifetime{models.LifetimePerTest, models.LifetimeConnection, models.LifetimeSession}
+	kinds := []string{"Couchbase", "MySQL", "Postgres"}
+
+	var pool []*models.Mock
+	var want []string
+	var mapping []string
+	for i := 0; i < 18; i++ {
+		name := fmt.Sprintf("mock-%02d", i)
+		// Interleave lifetime and kind so any partition on either reorders.
+		m := configMockAt(name, base, i/3, i/3)
+		m.TestModeInfo.Lifetime = lifetimes[i%3]
+		m.Kind = models.Kind(kinds[(i+1)%3])
+		pool = append(pool, m)
+		want = append(want, name)
+		if i%2 == 0 {
+			mapping = append(mapping, name)
+		}
+	}
+
+	got := FilterConfigMocksMapping(context.Background(), zap.NewNop(), pool, mapping)
+
+	if len(got) != len(want) {
+		t.Fatalf("pool size changed: got %d want %d", len(got), len(want))
+	}
+	for i, w := range want {
+		if got[i].Name != w {
+			t.Fatalf("pool was partitioned by lifetime or kind: index %d is %s, want %s\n got=%v",
+				i, got[i].Name, w, mockNames(got))
+		}
+	}
+}
+
+// A mock this keploy version does not recognise must still reach the pool, and
+// must be reported once at Debug — the pool is not the place to silently drop
+// something the user recorded.
+func TestFilterConfigMocksMapping_ReportsNonKeployMocks(t *testing.T) {
+	base := time.Unix(1700000000, 0).UTC()
+	foreign := configMock("foreign", base, 2)
+	foreign.Version = "not-keploy/v1"
+	pool := []*models.Mock{configMock("hello", base, 1), foreign}
+
+	core, logs := observer.New(zap.DebugLevel)
+	got := FilterConfigMocksMapping(context.Background(), zap.New(core), pool, nil)
+
+	if len(got) != 2 {
+		t.Fatalf("a non-keploy mock was dropped from the pool: %v", mockNames(got))
+	}
+	if n := logs.FilterMessageSnippet("not recorded by keploy").Len(); n != 1 {
+		t.Fatalf("non-keploy mocks reported %d times, want exactly 1", n)
+	}
+}


### PR DESCRIPTION
## The bug

In proxyless capture a MySQL-over-TLS connection has two legs: a plaintext one that captures the server greeting, and a decrypted one that is a **different TCP connection**. The decrypted leg's conn key can never match the key the plaintext leg pushed under, so it always draws from the port-only FIFO (`port:3306`) — a queue every decrypted stream to that port competes for.

`PopWait` is destructive. A stream that took a greeting and then failed simply **dropped** it, leaving the connection that pushed it with nothing. That connection lost its whole command phase with no error and no log — which is why `e2e-mysql-tls-lowlatency-cycle` reads *"served but NOT recorded"* rather than failing loudly.

## Evidence

Measured on a 3-node kind cluster, 50 concurrent MySQL-over-TLS requests per cycle. Counting decrypted streams routed to 3306 (`attr`) against EOFs and decode loss across 52 cycles in 6 independent runs: `attr == 0` never lost a query, and loss scaled with `attr`. The pre-existing last-greeting cache is a *partial* net — when it fires victims survive (`attr=32 EOF=20 cached=20` → 50/50), when it doesn't they don't (`attr=12 EOF=1 cached=0` → 49/50).

Paired validation, 8 cycles per arm, back to back:

| arm | cycles short | queries lost | EOFs |
|---|---|---|---|
| this branch | **0/8** | **0** | 13 |
| control | 2/8 | **7** | 7 |

In the control, EOFs convert to lost queries **1:1** (2→2, 5→5). With this change 13 EOFs cost nothing.

## The change

Both post-TLS readers now classify a greeting by the **key it came off** (`greetingShared` vs `greetingOwn`) rather than by which lookup succeeded — an empty `ConnKey` collapses the conn-specific key onto the port key, which is exactly the proxyless case — and restore it unless the stream both adopted it **and** produced a mock from it.

The V2 reader emits nothing itself, so an error there means no mock. The legacy reader emits its own and then returns `handleClientQueries`, which fails at ordinary teardown, so it marks the entry spent at each point it is used instead.

Two things are deliberately **not** restored:

- **`ReqTimestamp` is stripped.** `Push` re-stamps the store's expiry, so the entry does not age out, and to whoever picks it up next it is a borrowed entry from a dead connection. Config mocks are identified and ordered by `ReqTimestampMock` (`treedb.sameMock`), so carrying it would backdate a live connection's mock. Both readers already re-sample when it is zero.
- **An undecodable greeting is dropped**, not recycled — the expiry re-stamp would otherwise make it immortal and trip every later stream to that port.

Also fixes a dead per-key queue cap in `TLSHandshakeStore.Push` (it trimmed into a local and appended to the untrimmed slice, so `tlsHandshakeMaxQueuePerKey` never applied — 178 entries retained against a cap of 128). Separate commit.

## Scope

The spurious decrypted streams still fail — that is a separate defect, and this change does not pretend to fix it. What it fixes is the collateral damage: a failing stream no longer takes a live connection down with it.

## Tests

Every new behaviour has a test that fails before and passes after (each mutation-verified):
- V2 and legacy: an unused shared greeting is restored
- a *used* greeting is not restored (the legacy case where the connection later dies at teardown)
- a restored entry carries no `ReqTimestamp`
- an undecodable / decodable-but-non-handshake greeting is not recycled
- `greetingOwn` classification for a conn-keyed entry (previously uncovered)
- the queue cap actually bounds

---

# Second fix: mapping membership must not reorder the reusable mock pool

Folded in rather than opened separately, so this repo keeps one PR in flight.

## The bug

`FilterConfigMocksMapping` partitioned the reusable (config/session/connection) pool by mapping membership, sorted each half by `ReqTimestampMock`, and returned mapped-first. That places every *consumed* entry ahead of every *unconsumed* one, so the pool leaves in a different order than it was recorded in whenever the two interleave:

```
recorded [rev1 rev2 rev3 rev4] + mapping [rev3 rev4] -> [rev3 rev4 rev1 rev2]
recorded [hello sasl-auth select-bucket] + mapping [sasl-auth]
                                        -> [sasl-auth hello select-bucket]
```

The second is a protocol inversion — SASL hoisted ahead of HELLO.

Mapping membership is not a chronological signal. Every member of this pool is reusable tier, owned by no single test, so membership only records which tests happened to consume a mock. Order, though, is load-bearing: the slice order becomes `TestModeInfo.SortOrder` in `MockManager.setUnFilteredMocks`, which keys the RB-tree that `GetUnFilteredMocksByKind` walks in order. `mysql/replayer/conn.go` depends on exactly that — *"Order preserved (sorted by ReqTimestampMock ASC upstream), so the earliest recorded handshake wins"*.

## The change

Tag `IsFiltered` in place over the input and stable-sort once, instead of partitioning. Tagging in place also fixes **ties**, which the partition left inverted: an encoder that drains several frames from one TCP read stamps them all with that chunk's timestamp (`mysql/recorder/record_v2.go` documents `ReqTimestampMock` as the chunk's `ReadAt`), and a legacy pool carrying no timestamps at all is one big tie where the partition alone decided the order.

Mapped-half and unmapped-half orders are individually unchanged, so consumers that re-partition on `IsFiltered` (`generic/match.go` is the only one in-tree) are bit-identical.

## Scope

Customer-facing and not specific to one protocol: any replay with mappings enabled had its reusable config/handshake mocks reordered, for any protocol whose replay depends on recorded order.

## Tests

Nine tests covering out-of-order pools, equal timestamps, zero timestamps, interleaved chunk ties, mixed lifetime/kind (no partitioning by *anything*), membership tagging, deep-copy isolation, nil skipping, and the non-keploy-version report. Twelve mutants, all killed, via a standalone harness with an md5-verified file restore.

## What this is NOT

An earlier revision of this claimed to fix the `couchbase-java` CI stall. That was wrong and the claim is gone: `agent.go` gates the mapping branch on a non-empty mapping, and the pre-test staging call passes an empty one, so at app boot the agent is on the timestamp branch — the same one the passing replay used. This fix bites once per-test mappings are live, inside the test loop.
